### PR TITLE
[Merged by Bors] - refactor(data/real/ennreal): remove sub lemmas

### DIFF
--- a/src/analysis/analytic/basic.lean
+++ b/src/analysis/analytic/basic.lean
@@ -865,7 +865,7 @@ convergence.-/
 lemma change_origin_radius : p.radius - ∥x∥₊ ≤ (p.change_origin x).radius :=
 begin
   refine ennreal.le_of_forall_pos_nnreal_lt (λ r h0 hr, _),
-  rw [ennreal.lt_sub_iff_add_lt, add_comm] at hr,
+  rw [lt_tsub_iff_right, add_comm] at hr,
   have hr' : (∥x∥₊ : ℝ≥0∞) < p.radius, from (le_add_right le_rfl).trans_lt hr,
   apply le_radius_of_summable_nnnorm,
   have : ∀ k : ℕ, ∥p.change_origin x k∥₊ * r ^ k ≤
@@ -896,7 +896,7 @@ begin
     from mem_emetric_ball_zero_iff.2 ((le_add_right le_rfl).trans_lt h),
   have y_mem_ball : y ∈ emetric.ball (0 : E) (p.change_origin x).radius,
   { refine mem_emetric_ball_zero_iff.2 (lt_of_lt_of_le _ p.change_origin_radius),
-    rwa [ennreal.lt_sub_iff_add_lt, add_comm] },
+    rwa [lt_tsub_iff_right, add_comm] },
   have x_add_y_mem_ball : x + y ∈ emetric.ball (0 : E) p.radius,
   { refine mem_emetric_ball_zero_iff.2 (lt_of_le_of_lt _ h),
     exact_mod_cast nnnorm_add_le x y },
@@ -949,17 +949,17 @@ theorem has_fpower_series_on_ball.change_origin
   has_fpower_series_on_ball f (p.change_origin y) (x + y) (r - ∥y∥₊) :=
 { r_le := begin
     apply le_trans _ p.change_origin_radius,
-    exact ennreal.sub_le_sub hf.r_le (le_refl _)
+    exact tsub_le_tsub hf.r_le (le_refl _)
   end,
   r_pos := by simp [h],
   has_sum := λ z hz, begin
     convert (p.change_origin y).has_sum _,
-    { rw [mem_emetric_ball_zero_iff, ennreal.lt_sub_iff_add_lt, add_comm] at hz,
+    { rw [mem_emetric_ball_zero_iff, lt_tsub_iff_right, add_comm] at hz,
       rw [p.change_origin_eval (hz.trans_le hf.r_le), add_assoc, hf.sum],
       refine mem_emetric_ball_zero_iff.2 (lt_of_le_of_lt _ hz),
       exact_mod_cast nnnorm_add_le y z },
     { refine emetric.ball_subset_ball (le_trans _ p.change_origin_radius) hz,
-      exact ennreal.sub_le_sub hf.r_le le_rfl }
+      exact tsub_le_tsub hf.r_le le_rfl }
   end }
 
 /-- If a function admits a power series expansion `p` on an open ball `B (x, r)`, then

--- a/src/analysis/box_integral/integrability.lean
+++ b/src/analysis/box_integral/integrability.lean
@@ -73,7 +73,7 @@ begin
     simpa only [r, s.piecewise_eq_of_mem _ _ hJs] using hπ.1 J hJ (box.coe_subset_Icc hx) },
   refine abs_sub_le_iff.2 ⟨_, _⟩,
   { refine (ennreal.le_to_real_sub B).trans (ennreal.to_real_le_coe_of_le_coe _),
-    refine (ennreal.sub_le_sub (measure_mono htU) le_rfl).trans (le_measure_diff.trans _),
+    refine (tsub_le_tsub (measure_mono htU) le_rfl).trans (le_measure_diff.trans _),
     refine (measure_mono $ λ x hx, _).trans hμU.le,
     exact ⟨hx.1.1, λ hx', hx.2 ⟨hx'.1, hx.1.2⟩⟩ },
   { have hμt : μ t ≠ ∞ :=

--- a/src/data/real/ennreal.lean
+++ b/src/data/real/ennreal.lean
@@ -731,40 +731,13 @@ by simp
 lemma sub_top : a - ∞ = 0 :=
 by simp
 
-lemma le_sub_add_self : a ≤ (a - b) + b :=
-le_tsub_add
-
-protected lemma sub_le_iff_le_add : a - b ≤ c ↔ a ≤ c + b :=
-tsub_le_iff_right
-
 -- todo: make this a `@[simp]` lemma in general
 @[simp] lemma sub_eq_zero_of_le (h : a ≤ b) : a - b = 0 :=
 tsub_eq_zero_iff_le.mpr h
 
-lemma sub_self : a - a = 0 :=
-tsub_self a -- explicit arg
-
-lemma zero_sub : 0 - a = 0 :=
-zero_tsub a -- explicit arg
-
-protected lemma sub_add_cancel_of_le (h : b ≤ a) : (a - b) + b = a :=
-tsub_add_cancel_of_le h
-
-lemma sub_le_sub (h₁ : a ≤ b) (h₂ : d ≤ c) : a - c ≤ b - d :=
-tsub_le_tsub h₁ h₂
-
 -- todo: make `add_tsub_cancel_of_le` a `@[simp]` lemma
 @[simp] protected lemma add_sub_cancel_of_le (h : b ≤ a) : b + (a - b) = a :=
 add_tsub_cancel_of_le h
-
-lemma sub_add_self_eq_max : (a - b) + b = max a b :=
-tsub_add_eq_max
-
-protected lemma sub_le_iff_le_add' : a - b ≤ c ↔ a ≤ b + c :=
-tsub_le_iff_left
-
-protected lemma sub_le_of_sub_le (h : a - b ≤ c) : a - c ≤ b :=
-tsub_le_iff_tsub_le.mp h
 
 -- todo: make `tsub_eq_zero_iff_le` a `@[simp]` lemma
 @[simp] protected lemma sub_eq_zero_iff_le : a - b = 0 ↔ a ≤ b :=
@@ -774,27 +747,11 @@ tsub_eq_zero_iff_le
 @[simp] protected lemma sub_pos : 0 < a - b ↔ b < a :=
 tsub_pos_iff_lt
 
-lemma sub_le_self (a b : ℝ≥0∞) : a - b ≤ a :=
-tsub_le_self
-
-lemma sub_zero : a - 0 = a :=
-tsub_zero a -- explicit
-
 lemma sub_eq_top_iff : a - b = ∞ ↔ a = ∞ ∧ b ≠ ∞ :=
 by { cases a; cases b; simp [← with_top.coe_sub] }
 
 lemma sub_ne_top (ha : a ≠ ∞) : a - b ≠ ∞ :=
 mt sub_eq_top_iff.mp $ mt and.left ha
-
-/-- A version of triangle inequality for difference as a "distance". -/
-lemma sub_le_sub_add_sub : a - c ≤ a - b + (b - c) :=
-tsub_le_tsub_add_tsub
-
-lemma lt_sub_iff_add_lt : a < b - c ↔ a + c < b := lt_tsub_iff_right
-
-lemma lt_sub_comm : a < b - c ↔ c < b - a := lt_tsub_comm
-
-/-! The following lemmas cannot be directly replaced by the general lemmas. -/
 
 protected lemma sub_lt_of_lt_add (hac : c ≤ a) (h : a < b + c) : a - c < b :=
 ((cancel_of_lt' $ hac.trans_lt h).tsub_lt_iff_right hac).mpr h
@@ -843,8 +800,7 @@ begin
   exact (cancel_of_ne $ mul_ne_top hab.ne_top (h hb hab)).sub_mul
 end
 
-lemma mul_sub (h : 0 < c → c < b → a ≠ ∞) :
-  a * (b - c) = a * b - a * c :=
+lemma mul_sub (h : 0 < c → c < b → a ≠ ∞) : a * (b - c) = a * b - a * c :=
 by { simp only [mul_comm a], exact sub_mul h }
 
 end sub
@@ -1616,18 +1572,18 @@ variables {ι : Sort*} {f g : ι → ℝ≥0∞}
 lemma infi_add : infi f + a = ⨅i, f i + a :=
 le_antisymm
   (le_infi $ assume i, add_le_add (infi_le _ _) $ le_refl _)
-  (ennreal.sub_le_iff_le_add.1 $ le_infi $ assume i, ennreal.sub_le_iff_le_add.2 $ infi_le _ _)
+  (tsub_le_iff_right.1 $ le_infi $ assume i, tsub_le_iff_right.2 $ infi_le _ _)
 
 lemma supr_sub : (⨆i, f i) - a = (⨆i, f i - a) :=
 le_antisymm
-  (ennreal.sub_le_iff_le_add.2 $ supr_le $ assume i, ennreal.sub_le_iff_le_add.1 $ le_supr _ i)
-  (supr_le $ assume i, ennreal.sub_le_sub (le_supr _ _) (le_refl a))
+  (tsub_le_iff_right.2 $ supr_le $ assume i, tsub_le_iff_right.1 $ le_supr _ i)
+  (supr_le $ assume i, tsub_le_tsub (le_supr _ _) (le_refl a))
 
 lemma sub_infi : a - (⨅i, f i) = (⨆i, a - f i) :=
 begin
   refine (eq_of_forall_ge_iff $ λ c, _),
-  rw [ennreal.sub_le_iff_le_add, add_comm, infi_add],
-  simp [ennreal.sub_le_iff_le_add, sub_eq_add_neg, add_comm],
+  rw [tsub_le_iff_right, add_comm, infi_add],
+  simp [tsub_le_iff_right, sub_eq_add_neg, add_comm],
 end
 
 lemma Inf_add {s : set ℝ≥0∞} : Inf s + a = ⨅b∈s, b + a :=

--- a/src/measure_theory/integral/lebesgue.lean
+++ b/src/measure_theory/integral/lebesgue.lean
@@ -609,7 +609,7 @@ begin
         coe_sub, pi.sub_apply, ennreal.coe_to_nnreal,
         ennreal.add_sub_cancel_of_le (monotone_eapprox f (nat.le_succ _) _)],
     apply (lt_of_le_of_lt _ (eapprox_lt_top f (n+1) a)).ne,
-    rw ennreal.sub_le_iff_le_add,
+    rw tsub_le_iff_right,
     exact le_self_add },
 end
 
@@ -1590,10 +1590,10 @@ lemma lintegral_sub {f g : α → ℝ≥0∞} (hf : measurable f) (hg : measurab
   ∫⁻ a, f a - g a ∂μ = ∫⁻ a, f a ∂μ - ∫⁻ a, g a ∂μ :=
 begin
   rw [← ennreal.add_left_inj hg_fin,
-        ennreal.sub_add_cancel_of_le (lintegral_mono_ae h_le),
+        tsub_add_cancel_of_le (lintegral_mono_ae h_le),
       ← lintegral_add (hf.sub hg) hg],
   refine lintegral_congr_ae (h_le.mono $ λ x hx, _),
-  exact ennreal.sub_add_cancel_of_le hx
+  exact tsub_add_cancel_of_le hx
 end
 
 lemma lintegral_sub_le (f g : α → ℝ≥0∞)
@@ -1661,7 +1661,7 @@ calc
   ... = ⨆n, ∫⁻ a, f 0 a - f n a ∂μ :
     lintegral_supr_ae
       (assume n, (h_meas 0).sub (h_meas n))
-      (assume n, (h_mono n).mono $ assume a ha, ennreal.sub_le_sub (le_refl _) ha)
+      (assume n, (h_mono n).mono $ assume a ha, tsub_le_tsub (le_refl _) ha)
   ... = ⨆n, ∫⁻ a, f 0 a ∂μ - ∫⁻ a, f n a ∂μ :
     have h_mono : ∀ᵐ a ∂μ, ∀n:ℕ, f n.succ a ≤ f n a := ae_all_iff.2 h_mono,
     have h_mono : ∀n, ∀ᵐ a ∂μ, f n a ≤ f 0 a := assume n, h_mono.mono $ assume a h,

--- a/src/measure_theory/integral/set_integral.lean
+++ b/src/measure_theory/integral/set_integral.lean
@@ -170,7 +170,7 @@ begin
     ← coe_nnnorm, nnreal.coe_le_coe, ← ennreal.coe_le_coe],
   refine (ennnorm_integral_le_lintegral_ennnorm _).trans _,
   rw [← with_density_apply _ (hSm.diff (hsm _)), ← hν, measure_diff hsub hSm (hsm _)],
-  exacts [ennreal.sub_le_of_sub_le hi.1,
+  exacts [tsub_le_iff_tsub_le.mp hi.1,
     (hi.2.trans_lt $ ennreal.add_lt_top.2 ⟨hfi', ennreal.coe_lt_top⟩).ne]
 end
 

--- a/src/measure_theory/measure/content.lean
+++ b/src/measure_theory/measure/content.lean
@@ -144,7 +144,7 @@ begin
   have := ennreal.sub_lt_self hU h.ne_bot h'ε,
   conv at this {to_rhs, rw inner_content }, simp only [lt_supr_iff] at this,
   rcases this with ⟨U, h1U, h2U⟩, refine ⟨U, h1U, _⟩,
-  rw [← ennreal.sub_le_iff_le_add], exact le_of_lt h2U
+  rw [← tsub_le_iff_right], exact le_of_lt h2U
 end
 
 /-- The inner content of a supremum of opens is at most the sum of the individual inner

--- a/src/measure_theory/measure/haar_lebesgue.lean
+++ b/src/measure_theory/measure/haar_lebesgue.lean
@@ -294,7 +294,7 @@ begin
   { rw [← closed_ball_diff_ball,
         measure_diff ball_subset_closed_ball measurable_set_closed_ball measurable_set_ball
           ((add_haar_ball_lt_top μ x r).ne),
-        add_haar_ball_of_pos μ _ h, add_haar_closed_ball μ _ h.le, ennreal.sub_self] }
+        add_haar_ball_of_pos μ _ h, add_haar_closed_ball μ _ h.le, tsub_self] }
 end
 
 lemma add_haar_sphere [nontrivial E] (x : E) (r : ℝ) :

--- a/src/measure_theory/measure/hausdorff.lean
+++ b/src/measure_theory/measure/hausdorff.lean
@@ -230,7 +230,7 @@ begin
   apply ennreal.le_of_add_le_add_right hyz.ne_top,
   refine le_trans _ (edist_triangle _ _ _),
   refine (add_le_add le_rfl hyz.le).trans (eq.trans_le _ hxz),
-  rw [ennreal.sub_add_cancel_of_le A.le]
+  rw [tsub_add_cancel_of_le A.le]
 end
 
 lemma le_caratheodory [measurable_space X] [borel_space X] (hm : is_metric μ) :

--- a/src/measure_theory/measure/measure_space.lean
+++ b/src/measure_theory/measure/measure_space.lean
@@ -177,7 +177,7 @@ begin
 end
 
 lemma le_measure_diff : μ s₁ - μ s₂ ≤ μ (s₁ \ s₂) :=
-ennreal.sub_le_iff_le_add'.2 $
+tsub_le_iff_right'.2 $
 calc μ s₁ ≤ μ (s₂ ∪ s₁)        : measure_mono (subset_union_right _ _)
       ... = μ (s₂ ∪ s₁ \ s₂)   : congr_arg μ union_diff_self.symm
       ... ≤ μ s₂ + μ (s₁ \ s₂) : measure_union_le _ _
@@ -191,7 +191,7 @@ end
 
 lemma measure_diff_le_iff_le_add (hs : measurable_set s) (ht : measurable_set t) (hst : s ⊆ t)
   (hs' : μ s ≠ ∞) {ε : ℝ≥0∞} : μ (t \ s) ≤ ε ↔ μ t ≤ μ s + ε :=
-by rwa [measure_diff hst ht hs hs', ennreal.sub_le_iff_le_add']
+by rwa [measure_diff hst ht hs hs', tsub_le_iff_right']
 
 lemma measure_eq_measure_of_null_diff {s t : set α}
   (hst : s ⊆ t) (h_nulldiff : μ (t.diff s) = 0) : μ s = μ t :=
@@ -341,7 +341,7 @@ begin
       use j,
       rw [← measure_diff hjk (h _) (h _) (this _ hjk)],
       exact measure_mono (diff_subset_diff_right hji) },
-    { rw [ennreal.sub_le_iff_le_add, ← measure_union disjoint_diff.symm ((h k).diff (h i)) (h i),
+    { rw [tsub_le_iff_right, ← measure_union disjoint_diff.symm ((h k).diff (h i)) (h i),
         set.union_comm],
       exact measure_mono (diff_subset_iff.1 $ subset.refl _) } },
   { exact λ i, (h k).diff (h i) },
@@ -1629,9 +1629,9 @@ lemma measure_compl_le_add_of_le_add [is_finite_measure μ] (hs : measurable_set
   μ tᶜ ≤ μ sᶜ + ε :=
 begin
   rw [measure_compl ht (measure_ne_top μ _), measure_compl hs (measure_ne_top μ _),
-    ennreal.sub_le_iff_le_add],
+    tsub_le_iff_right],
   calc μ univ = μ univ - μ s + μ s :
-    (ennreal.sub_add_cancel_of_le $ measure_mono s.subset_univ).symm
+    (tsub_add_cancel_of_le $ measure_mono s.subset_univ).symm
   ... ≤ μ univ - μ s + (μ t + ε) : add_le_add_left h _
   ... = _ : by rw [add_right_comm, add_assoc]
 end
@@ -2270,7 +2270,7 @@ begin
     { ext t h_t_measurable_set,
       simp only [pi.add_apply, coe_add],
       rw [measure_theory.measure.of_measurable_apply _ h_t_measurable_set, add_comm,
-        ennreal.sub_add_cancel_of_le (h₂ t h_t_measurable_set)] },
+        tsub_add_cancel_of_le (h₂ t h_t_measurable_set)] },
     have h_measure_sub_eq : (μ - ν) = measure_sub,
     { rw measure_theory.measure.sub_def, apply le_antisymm,
       { apply @Inf_le (measure α) measure.complete_semilattice_Inf,
@@ -2286,7 +2286,7 @@ end
 lemma sub_add_cancel_of_le [is_finite_measure ν] (h₁ : ν ≤ μ) : μ - ν + ν = μ :=
 begin
   ext s h_s_meas,
-  rw [add_apply, sub_apply h_s_meas h₁, ennreal.sub_add_cancel_of_le (h₁ s h_s_meas)],
+  rw [add_apply, sub_apply h_s_meas h₁, tsub_add_cancel_of_le (h₁ s h_s_meas)],
 end
 
 lemma sub_le : μ - ν ≤ μ :=

--- a/src/measure_theory/measure/measure_space.lean
+++ b/src/measure_theory/measure/measure_space.lean
@@ -177,7 +177,7 @@ begin
 end
 
 lemma le_measure_diff : μ s₁ - μ s₂ ≤ μ (s₁ \ s₂) :=
-tsub_le_iff_right'.2 $
+tsub_le_iff_left.2 $
 calc μ s₁ ≤ μ (s₂ ∪ s₁)        : measure_mono (subset_union_right _ _)
       ... = μ (s₂ ∪ s₁ \ s₂)   : congr_arg μ union_diff_self.symm
       ... ≤ μ s₂ + μ (s₁ \ s₂) : measure_union_le _ _
@@ -191,7 +191,7 @@ end
 
 lemma measure_diff_le_iff_le_add (hs : measurable_set s) (ht : measurable_set t) (hst : s ⊆ t)
   (hs' : μ s ≠ ∞) {ε : ℝ≥0∞} : μ (t \ s) ≤ ε ↔ μ t ≤ μ s + ε :=
-by rwa [measure_diff hst ht hs hs', tsub_le_iff_right']
+by rwa [measure_diff hst ht hs hs', tsub_le_iff_left]
 
 lemma measure_eq_measure_of_null_diff {s t : set α}
   (hst : s ⊆ t) (h_nulldiff : μ (t.diff s) = 0) : μ s = μ t :=

--- a/src/measure_theory/measure/regular.lean
+++ b/src/measure_theory/measure/regular.lean
@@ -308,7 +308,7 @@ begin
       (disjoint_disjointed s.set).mono (λ k l hkl, hkl.mono inf_le_right inf_le_right), _⟩,
     rw [← inter_Union, Union_disjointed, s.spanning, inter_univ] },
   rcases ennreal.exists_pos_sum_of_encodable' (ennreal.sub_pos.2 hr).ne' ℕ with ⟨δ, δ0, hδε⟩,
-  rw [ennreal.lt_sub_iff_add_lt, add_comm] at hδε,
+  rw [lt_tsub_iff_right, add_comm] at hδε,
   have : ∀ n, ∃ U ⊇ A n, is_open U ∧ μ U < μ (A n) + δ n,
   { intro n,
     have H₁ : ∀ t, μ.restrict (s.set n) t = μ (t ∩ s.set n), from λ t, restrict_apply' (hm n),
@@ -347,7 +347,7 @@ begin
   calc μ s ≤ μ U                   : μ.mono hsU
        ... < μ K + ε               : hKr
        ... ≤ μ (K \ U') + μ U' + ε :
-    add_le_add_right (ennreal.sub_le_iff_le_add.1 le_measure_diff) _
+    add_le_add_right (tsub_le_iff_right.1 le_measure_diff) _
        ... ≤ μ (K \ U') + ε + ε    : by { mono*, exacts [hμU'.le, le_rfl] }
        ... = μ (K \ U') + (ε + ε)  : add_assoc _ _ _
 end

--- a/src/topology/instances/ennreal.lean
+++ b/src/topology/instances/ennreal.lean
@@ -701,7 +701,7 @@ begin
   have h₃: ∑' i, (f i - g i) = ∑' i, (f i - g i + g i) - ∑' i, g i,
   { rw [ennreal.tsum_add, add_sub_self h₁]},
   have h₄:(λ i, (f i - g i) + (g i)) = f,
-  { ext n, rw ennreal.sub_add_cancel_of_le (h₂ n)},
+  { ext n, rw tsub_add_cancel_of_le (h₂ n)},
   rw h₄ at h₃, apply h₃,
 end
 

--- a/src/topology/instances/ennreal.lean
+++ b/src/topology/instances/ennreal.lean
@@ -253,7 +253,7 @@ protected lemma tendsto_at_top_zero [hβ : nonempty β] [semilattice_sup β] {f 
   filter.at_top.tendsto f (𝓝 0) ↔ ∀ ε > 0, ∃ N, ∀ n ≥ N, f n ≤ ε :=
 begin
   rw ennreal.tendsto_at_top zero_ne_top,
-  { simp_rw [set.mem_Icc, zero_add, zero_sub, zero_le _, true_and], },
+  { simp_rw [set.mem_Icc, zero_add, zero_tsub, zero_le _, true_and], },
   { exact hβ, },
 end
 
@@ -495,10 +495,10 @@ lemma sub_supr {ι : Sort*} [nonempty ι] {b : ι → ℝ≥0∞} (hr : a < ⊤)
 let ⟨r, eq, _⟩ := lt_iff_exists_coe.mp hr in
 have Inf ((λb, ↑r - b) '' range b) = ↑r - (⨆i, b i),
   from is_glb.Inf_eq $ is_lub_supr.is_glb_of_tendsto
-    (assume x _ y _, sub_le_sub (le_refl _))
+    (assume x _ y _, tsub_le_tsub (le_refl (r : ℝ≥0∞)))
     (range_nonempty _)
     (ennreal.tendsto_coe_sub.comp (tendsto_id' inf_le_left)),
-by rw [eq, ←this]; simp [Inf_image, infi_range, -mem_range]; exact le_refl _
+by rw [eq, ←this]; simp [Inf_image, infi_range, -mem_range]; exact le_rfl
 
 end topological_space
 

--- a/src/topology/metric_space/contracting.lean
+++ b/src/topology/metric_space/contracting.lean
@@ -56,7 +56,7 @@ lemma edist_inequality (hf : contracting_with K f) {x y} (h : edist x y ≠ ∞)
   edist x y ≤ (edist x (f x) + edist y (f y)) / (1 - K) :=
 suffices edist x y ≤ edist x (f x) + edist y (f y) + K * edist x y,
   by rwa [ennreal.le_div_iff_mul_le (or.inl hf.one_sub_K_ne_zero) (or.inl one_sub_K_ne_top),
-    mul_comm, ennreal.sub_mul (λ _ _, h), one_mul, ennreal.sub_le_iff_le_add],
+    mul_comm, ennreal.sub_mul (λ _ _, h), one_mul, tsub_le_iff_right],
 calc edist x y ≤ edist x (f x) + edist (f x) (f y) + edist (f y) y : edist_triangle4 _ _ _ _
   ... = edist x (f x) + edist y (f y) + edist (f x) (f y) : by rw [edist_comm y, add_right_comm]
   ... ≤ edist x (f x) + edist y (f y) + K * edist x y : add_le_add (le_refl _) (hf.2 _ _)


### PR DESCRIPTION
* Remove all lemmas about subtraction on `ennreal` that are special cases of `has_ordered_sub` lemmas.
* [This](https://github.com/leanprover-community/mathlib/blob/fe5ddaf42c5d61ecc740e815d63ac38f5e94a2e8/src/data/real/ennreal.lean#L734-L795) gives a list of renamings.
* The lemmas that have a `@[simp]` attribute will be done in a separate PR

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
