### PR TITLE
[Merged by Bors] -  feat(ring_theory/ideal/over): algebra structure on R/p → S/P for `P` lying over `p`

### DIFF
--- a/src/ring_theory/ideal/over.lean
+++ b/src/ring_theory/ideal/over.lean
@@ -116,6 +116,50 @@ begin
   exact (submodule.eq_bot_iff _).mpr (λ x hx, hP x (mem_comap.mp hx)),
 end
 
+variables {p : ideal R} {P : ideal S}
+
+/-- If there is an injective map `R/p → S/P` such that following diagram commutes:
+```
+R   → S
+↓     ↓
+R/p → S/P
+```
+then `P` lies over `p`.
+-/
+lemma comap_eq_of_scalar_tower_quotient [algebra R S] [algebra p.quotient P.quotient]
+  [is_scalar_tower R p.quotient P.quotient]
+  (h : function.injective (algebra_map p.quotient P.quotient)) :
+  comap (algebra_map R S) P = p :=
+begin
+  ext x, split; rw [mem_comap, ← quotient.eq_zero_iff_mem, ← quotient.eq_zero_iff_mem,
+    quotient.mk_algebra_map, is_scalar_tower.algebra_map_apply _ p.quotient,
+    quotient.algebra_map_eq],
+  { intro hx,
+    exact (algebra_map p.quotient P.quotient).injective_iff.mp h _ hx },
+  { intro hx,
+    rw [hx, ring_hom.map_zero] },
+end
+
+/-- If `P` lies over `p`, then `R / p` has a canonical map to `S / P`. -/
+def quotient.algebra_quotient_of_over (h : p ≤ comap f P) :
+  algebra p.quotient P.quotient :=
+ring_hom.to_algebra $ quotient_map _ f h
+
+/-- `R / p` has a canonical map to `S / pS`. -/
+instance quotient.algebra_quotient_map_quotient :
+  algebra p.quotient (map f p).quotient :=
+quotient.algebra_quotient_of_over le_comap_map
+
+@[simp] lemma quotient.algebra_map_quotient_map_quotient (x : R) :
+  algebra_map p.quotient (map f p).quotient (quotient.mk p x) = quotient.mk _ (f x) :=
+rfl
+
+instance quotient.tower_quotient_map_quotient [algebra R S] :
+  is_scalar_tower R p.quotient (map (algebra_map R S) p).quotient :=
+is_scalar_tower.of_algebra_map_eq $ λ x,
+by rw [quotient.algebra_map_eq, quotient.algebra_map_quotient_map_quotient,
+       quotient.mk_algebra_map]
+
 end comm_ring
 
 section is_domain

--- a/src/ring_theory/ideal/over.lean
+++ b/src/ring_theory/ideal/over.lean
@@ -141,14 +141,14 @@ begin
 end
 
 /-- If `P` lies over `p`, then `R / p` has a canonical map to `S / P`. -/
-def quotient.algebra_quotient_of_over (h : p ≤ comap f P) :
+def quotient.algebra_quotient_of_le_comap (h : p ≤ comap f P) :
   algebra p.quotient P.quotient :=
 ring_hom.to_algebra $ quotient_map _ f h
 
 /-- `R / p` has a canonical map to `S / pS`. -/
 instance quotient.algebra_quotient_map_quotient :
   algebra p.quotient (map f p).quotient :=
-quotient.algebra_quotient_of_over le_comap_map
+quotient.algebra_quotient_of_le_comap le_comap_map
 
 @[simp] lemma quotient.algebra_map_quotient_map_quotient (x : R) :
   algebra_map p.quotient (map f p).quotient (quotient.mk p x) = quotient.mk _ (f x) :=

--- a/src/ring_theory/ideal/over.lean
+++ b/src/ring_theory/ideal/over.lean
@@ -154,6 +154,10 @@ quotient.algebra_quotient_of_le_comap le_comap_map
   algebra_map p.quotient (map f p).quotient (quotient.mk p x) = quotient.mk _ (f x) :=
 rfl
 
+@[simp] lemma quotient.mk_smul_mk_quotient_map_quotient (x : R) (y : S) :
+  quotient.mk p x • quotient.mk (map f p) y = quotient.mk _ (f x * y) :=
+rfl
+
 instance quotient.tower_quotient_map_quotient [algebra R S] :
   is_scalar_tower R p.quotient (map (algebra_map R S) p).quotient :=
 is_scalar_tower.of_algebra_map_eq $ λ x,


### PR DESCRIPTION
This PR shows `P` lies over `p` if there is an injective map completing the square `R/p ← R —f→ S → S/P`, and conversely that there is a (not necessarily injective, since `f` doesn't have to be) map completing the square if `P` lies over `p`. Then we specialize this to the case where `P = map f p` to provide an `algebra p.quotient (map f p).quotient` instance.

This algebra instance is useful if you want to study the extension `R → S` locally at `p`, e.g. to show `R/p : S/pS` has the same dimension as `Frac(R) : Frac(S)` if `p` is prime.

---
- [x] depends on: #9829

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
