### PR TITLE
[Merged by Bors] - feat(ring_theory/localization): generalize `exist_integer_multiples` to finite families

### DIFF
--- a/src/ring_theory/localization.lean
+++ b/src/ring_theory/localization.lean
@@ -209,20 +209,32 @@ by rw [mul_comm, sec_spec]
 
 open_locale big_operators
 
-/-- We can clear the denominators of a finite set of fractions. -/
-lemma exist_integer_multiples_of_finset (s : finset S) :
-  ∃ (b : M), ∀ a ∈ s, is_integer R ((b : R) • a) :=
+/-- We can clear the denominators of a `finset`-indexed family of fractions. -/
+lemma exist_integer_multiples {ι : Type*} (s : finset ι) (f : ι → S) :
+  ∃ (b : M), ∀ i ∈ s, is_localization.is_integer R ((b : R) • f i) :=
 begin
   haveI := classical.prop_decidable,
-  use ∏ a in s, (is_localization.sec M a).2,
-  intros a ha,
-  use (∏ x in s.erase a, (is_localization.sec M x).2) * (is_localization.sec M a).1,
+  refine ⟨∏ i in s, (sec M (f i)).2, λ i hi, ⟨_, _⟩⟩,
+  { exact (∏ j in s.erase i, (sec M (f j)).2) * (sec M (f i)).1 },
   rw [ring_hom.map_mul, sec_spec', ←mul_assoc, ←(algebra_map R S).map_mul, ← algebra.smul_def],
   congr' 2,
   refine trans _ ((submonoid.subtype M).map_prod _ _).symm,
-  rw [mul_comm, ←finset.prod_insert (s.not_mem_erase a), finset.insert_erase ha],
-  refl,
+  rw [mul_comm, ←finset.prod_insert (s.not_mem_erase i), finset.insert_erase hi],
+  refl
 end
+
+/-- We can clear the denominators of a `fintype`-indexed family of fractions. -/
+lemma exist_integer_multiples_of_fintype {ι : Type*} [fintype ι] (f : ι → S) :
+  ∃ (b : M), ∀ i, is_localization.is_integer R ((b : R) • f i) :=
+begin
+  obtain ⟨b, hb⟩ := exist_integer_multiples M finset.univ f,
+  exact ⟨b, λ i, hb i (finset.mem_univ _)⟩
+end
+
+/-- We can clear the denominators of a finite set of fractions. -/
+lemma exist_integer_multiples_of_finset (s : finset S) :
+  ∃ (b : M), ∀ a ∈ s, is_integer R ((b : R) • a) :=
+exist_integer_multiples M s id
 
 variables {R M}
 


### PR DESCRIPTION
This PR shows we can clear denominators of finitely-indexed collections of fractions (i.e. elements of `S` where `is_localization M S`), with the existing result about finite sets of fractions as a special case.



---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
