### PR TITLE
[Merged by Bors] - feat(linear_algebra): add notation for star-linear maps

### DIFF
--- a/src/algebra/module/linear_map.lean
+++ b/src/algebra/module/linear_map.lean
@@ -18,7 +18,7 @@ In this file we define
 * `linear_map σ M M₂`, `M →ₛₗ[σ] M₂` : a semilinear map between two `module`s. Here,
   `σ` is a `ring_hom` from `R` to `R₂` and an `f : M →ₛₗ[σ] M₂` satisfies
   `f (c • x) = (σ c) • (f x)`. We recover plain linear maps by choosing `σ` to be `ring_hom.id R`.
-  This is denoted by `M →ₗ[R] M₂`.
+  This is denoted by `M →ₗ[R] M₂`. We also add the notation `M →ₗ⋆[R] M₂` for star-linear maps.
 
 * `is_linear_map R f` : predicate saying that `f : M → M₂` is a linear map. (Note that this
   was not generalized to semilinear maps.)
@@ -94,7 +94,7 @@ add_decl_doc linear_map.to_add_hom
 
 notation M ` →ₛₗ[`:25 σ:25 `] `:0 M₂:0 := linear_map σ M M₂
 notation M ` →ₗ[`:25 R:25 `] `:0 M₂:0 := linear_map (ring_hom.id R) M M₂
-notation M ` →ₗ*[`:25 R:25 `] `:0 M₂:0 := linear_map (@star_ring_aut R _ _ : R →+* R) M M₂
+notation M ` →ₗ⋆[`:25 R:25 `] `:0 M₂:0 := linear_map (@star_ring_aut R _ _ : R →+* R) M M₂
 
 namespace linear_map
 

--- a/src/algebra/module/linear_map.lean
+++ b/src/algebra/module/linear_map.lean
@@ -94,6 +94,7 @@ add_decl_doc linear_map.to_add_hom
 
 notation M ` →ₛₗ[`:25 σ:25 `] `:0 M₂:0 := linear_map σ M M₂
 notation M ` →ₗ[`:25 R:25 `] `:0 M₂:0 := linear_map (ring_hom.id R) M M₂
+notation M ` →ₗ*[`:25 R:25 `] `:0 M₂:0 := linear_map (@star_ring_aut R _ _ : R →+* R) M M₂
 
 namespace linear_map
 

--- a/src/analysis/normed_space/linear_isometry.lean
+++ b/src/analysis/normed_space/linear_isometry.lean
@@ -45,6 +45,7 @@ structure linear_isometry (σ₁₂ : R →+* R₂) (E E₂ : Type*) [semi_norme
 
 notation E ` →ₛₗᵢ[`:25 σ₁₂:25 `] `:0 E₂:0 := linear_isometry σ₁₂ E E₂
 notation E ` →ₗᵢ[`:25 R:25 `] `:0 E₂:0 := linear_isometry (ring_hom.id R) E E₂
+notation E ` →ₗᵢ*[`:25 R:25 `] `:0 F:0 := linear_isometry (@star_ring_aut R _ _ : R →+* R) E F
 
 namespace linear_isometry
 
@@ -200,6 +201,8 @@ structure linear_isometry_equiv (σ₁₂ : R →+* R₂) {σ₂₁ : R₂ →+*
 
 notation E ` ≃ₛₗᵢ[`:25 σ₁₂:25 `] `:0 E₂:0 := linear_isometry_equiv σ₁₂ E E₂
 notation E ` ≃ₗᵢ[`:25 R:25 `] `:0 E₂:0 := linear_isometry_equiv (ring_hom.id R) E E₂
+notation E ` ≃ₗᵢ*[`:25 R:25 `] `:0 E₂:0 :=
+  linear_isometry_equiv (@star_ring_aut R _ _ : R →+* R) E E₂
 
 namespace linear_isometry_equiv
 

--- a/src/analysis/normed_space/linear_isometry.lean
+++ b/src/analysis/normed_space/linear_isometry.lean
@@ -11,7 +11,8 @@ import analysis.normed_space.basic
 In this file we define `linear_isometry σ₁₂ E E₂` (notation: `E →ₛₗᵢ[σ₁₂] E₂`) to be a semilinear
 isometric embedding of `E` into `E₂` and `linear_isometry_equiv` (notation: `E ≃ₛₗᵢ[σ₁₂] E₂`) to be
 a semilinear isometric equivalence between `E` and `E₂`.  The notation for the associated purely
-linear concepts is `E →ₗᵢ[R] E₂`, `E ≃ₗᵢ[R] E₂`.
+linear concepts is `E →ₗᵢ[R] E₂`, `E ≃ₗᵢ[R] E₂`, and `E →ₗᵢ⋆[R] E₂`, `E ≃ₗᵢ⋆[R] E₂` for
+the star-linear versions.
 
 We also prove some trivial lemmas and provide convenience constructors.
 
@@ -45,7 +46,7 @@ structure linear_isometry (σ₁₂ : R →+* R₂) (E E₂ : Type*) [semi_norme
 
 notation E ` →ₛₗᵢ[`:25 σ₁₂:25 `] `:0 E₂:0 := linear_isometry σ₁₂ E E₂
 notation E ` →ₗᵢ[`:25 R:25 `] `:0 E₂:0 := linear_isometry (ring_hom.id R) E E₂
-notation E ` →ₗᵢ*[`:25 R:25 `] `:0 E₂:0 := linear_isometry (@star_ring_aut R _ _ : R →+* R) E E₂
+notation E ` →ₗᵢ⋆[`:25 R:25 `] `:0 E₂:0 := linear_isometry (@star_ring_aut R _ _ : R →+* R) E E₂
 
 namespace linear_isometry
 
@@ -201,7 +202,7 @@ structure linear_isometry_equiv (σ₁₂ : R →+* R₂) {σ₂₁ : R₂ →+*
 
 notation E ` ≃ₛₗᵢ[`:25 σ₁₂:25 `] `:0 E₂:0 := linear_isometry_equiv σ₁₂ E E₂
 notation E ` ≃ₗᵢ[`:25 R:25 `] `:0 E₂:0 := linear_isometry_equiv (ring_hom.id R) E E₂
-notation E ` ≃ₗᵢ*[`:25 R:25 `] `:0 E₂:0 :=
+notation E ` ≃ₗᵢ⋆[`:25 R:25 `] `:0 E₂:0 :=
   linear_isometry_equiv (@star_ring_aut R _ _ : R →+* R) E E₂
 
 namespace linear_isometry_equiv

--- a/src/analysis/normed_space/linear_isometry.lean
+++ b/src/analysis/normed_space/linear_isometry.lean
@@ -45,7 +45,7 @@ structure linear_isometry (σ₁₂ : R →+* R₂) (E E₂ : Type*) [semi_norme
 
 notation E ` →ₛₗᵢ[`:25 σ₁₂:25 `] `:0 E₂:0 := linear_isometry σ₁₂ E E₂
 notation E ` →ₗᵢ[`:25 R:25 `] `:0 E₂:0 := linear_isometry (ring_hom.id R) E E₂
-notation E ` →ₗᵢ*[`:25 R:25 `] `:0 F:0 := linear_isometry (@star_ring_aut R _ _ : R →+* R) E F
+notation E ` →ₗᵢ*[`:25 R:25 `] `:0 E₂:0 := linear_isometry (@star_ring_aut R _ _ : R →+* R) E E₂
 
 namespace linear_isometry
 

--- a/src/data/equiv/module.lean
+++ b/src/data/equiv/module.lean
@@ -57,7 +57,7 @@ attribute [nolint doc_blame] linear_equiv.to_add_equiv
 
 notation M ` ≃ₛₗ[`:50 σ `] ` M₂ := linear_equiv σ M M₂
 notation M ` ≃ₗ[`:50 R `] ` M₂ := linear_equiv (ring_hom.id R) M M₂
-notation M ` ≃ₗ*[`:25 R:25 `] `:0 M₂:0 := linear_equiv (@star_ring_aut R _ _ : R →+* R) M M₂
+notation M ` ≃ₗ*[`:50 R `] ` M₂ := linear_equiv (@star_ring_aut R _ _ : R →+* R) M M₂
 
 namespace linear_equiv
 

--- a/src/data/equiv/module.lean
+++ b/src/data/equiv/module.lean
@@ -57,6 +57,7 @@ attribute [nolint doc_blame] linear_equiv.to_add_equiv
 
 notation M ` ≃ₛₗ[`:50 σ `] ` M₂ := linear_equiv σ M M₂
 notation M ` ≃ₗ[`:50 R `] ` M₂ := linear_equiv (ring_hom.id R) M M₂
+notation M ` ≃ₗ*[`:25 R:25 `] `:0 M₂:0 := linear_equiv (@star_ring_aut R _ _ : R →+* R) M M₂
 
 namespace linear_equiv
 

--- a/src/data/equiv/module.lean
+++ b/src/data/equiv/module.lean
@@ -13,7 +13,8 @@ In this file we define
 
 * `linear_equiv σ M M₂`, `M ≃ₛₗ[σ] M₂`: an invertible semilinear map. Here, `σ` is a `ring_hom`
   from `R` to `R₂` and an `e : M ≃ₛₗ[σ] M₂` satisfies `e (c • x) = (σ c) • (e x)`. The plain
-  linear version, with `σ` being `ring_hom.id R`, is denoted by `M ≃ₗ[R] M₂`.
+  linear version, with `σ` being `ring_hom.id R`, is denoted by `M ≃ₗ[R] M₂`, and the
+  star-linear version (with `σ` begin `star_ring_aut`) is denoted by `M ≃ₗ⋆[R] M₂`.
 
 ## Implementation notes
 
@@ -57,7 +58,7 @@ attribute [nolint doc_blame] linear_equiv.to_add_equiv
 
 notation M ` ≃ₛₗ[`:50 σ `] ` M₂ := linear_equiv σ M M₂
 notation M ` ≃ₗ[`:50 R `] ` M₂ := linear_equiv (ring_hom.id R) M M₂
-notation M ` ≃ₗ*[`:50 R `] ` M₂ := linear_equiv (@star_ring_aut R _ _ : R →+* R) M M₂
+notation M ` ≃ₗ⋆[`:50 R `] ` M₂ := linear_equiv (@star_ring_aut R _ _ : R →+* R) M M₂
 
 namespace linear_equiv
 

--- a/src/topology/algebra/module.lean
+++ b/src/topology/algebra/module.lean
@@ -210,6 +210,8 @@ structure continuous_linear_map
 
 notation M ` →SL[`:25 σ `] ` M₂ := continuous_linear_map σ M M₂
 notation M ` →L[`:25 R `] ` M₂ := continuous_linear_map (ring_hom.id R) M M₂
+notation M ` →L*[`:25 R:25 `] `:0 M₂:0 :=
+  continuous_linear_map (@star_ring_aut R _ _ : R →+* R) M M₂
 
 /-- Continuous linear equivalences between modules. We only put the type classes that are necessary
 for the definition, although in applications `M` and `M₂` will be topological modules over the
@@ -227,6 +229,8 @@ structure continuous_linear_equiv
 
 notation M ` ≃SL[`:50 σ `] ` M₂ := continuous_linear_equiv σ M M₂
 notation M ` ≃L[`:50 R `] ` M₂ := continuous_linear_equiv (ring_hom.id R) M M₂
+notation M ` ≃L*[`:25 R:25 `] `:0 M₂:0 :=
+  continuous_linear_equiv (@star_ring_aut R _ _ : R →+* R) M M₂
 
 namespace continuous_linear_map
 

--- a/src/topology/algebra/module.lean
+++ b/src/topology/algebra/module.lean
@@ -210,8 +210,7 @@ structure continuous_linear_map
 
 notation M ` →SL[`:25 σ `] ` M₂ := continuous_linear_map σ M M₂
 notation M ` →L[`:25 R `] ` M₂ := continuous_linear_map (ring_hom.id R) M M₂
-notation M ` →L*[`:25 R:25 `] `:0 M₂:0 :=
-  continuous_linear_map (@star_ring_aut R _ _ : R →+* R) M M₂
+notation M ` →L*[`:25 R `] ` M₂ := continuous_linear_map (@star_ring_aut R _ _ : R →+* R) M M₂
 
 /-- Continuous linear equivalences between modules. We only put the type classes that are necessary
 for the definition, although in applications `M` and `M₂` will be topological modules over the
@@ -229,8 +228,7 @@ structure continuous_linear_equiv
 
 notation M ` ≃SL[`:50 σ `] ` M₂ := continuous_linear_equiv σ M M₂
 notation M ` ≃L[`:50 R `] ` M₂ := continuous_linear_equiv (ring_hom.id R) M M₂
-notation M ` ≃L*[`:25 R:25 `] `:0 M₂:0 :=
-  continuous_linear_equiv (@star_ring_aut R _ _ : R →+* R) M M₂
+notation M ` ≃L*[`:50 R `] ` M₂ := continuous_linear_equiv (@star_ring_aut R _ _ : R →+* R) M M₂
 
 namespace continuous_linear_map
 

--- a/src/topology/algebra/module.lean
+++ b/src/topology/algebra/module.lean
@@ -16,12 +16,12 @@ import linear_algebra.pi
 
 We use the class `has_continuous_smul` for topological (semi) modules and topological vector spaces.
 
-In this file we define continuous linear maps, as linear maps between topological modules which are
-continuous. The set of continuous linear maps between the topological `R`-modules `M` and `M₂` is
-denoted by `M →L[R] M₂`.
+In this file we define continuous (semi-)linear maps, as semilinear maps between topological
+modules which are continuous. The set of continuous semilinear maps between the topological
+`R₁`-module `M` and `R₂`-module `M₂` with respect to the `ring_hom` `σ` is denoted by `M →SL[σ] M₂`.
+Plain linear maps are denoted by `M →L[R] M₂` and star-linear maps by `M →L⋆[R] M₂`.
 
-Continuous linear equivalences are denoted by `M ≃L[R] M₂`.
-
+The corresponding notation for equivalences is `M ≃SL[σ] M₂`, `M ≃L[R] M₂` and `M ≃L⋆[R] M₂`.
 -/
 
 open filter
@@ -210,7 +210,7 @@ structure continuous_linear_map
 
 notation M ` →SL[`:25 σ `] ` M₂ := continuous_linear_map σ M M₂
 notation M ` →L[`:25 R `] ` M₂ := continuous_linear_map (ring_hom.id R) M M₂
-notation M ` →L*[`:25 R `] ` M₂ := continuous_linear_map (@star_ring_aut R _ _ : R →+* R) M M₂
+notation M ` →L⋆[`:25 R `] ` M₂ := continuous_linear_map (@star_ring_aut R _ _ : R →+* R) M M₂
 
 /-- Continuous linear equivalences between modules. We only put the type classes that are necessary
 for the definition, although in applications `M` and `M₂` will be topological modules over the
@@ -228,7 +228,7 @@ structure continuous_linear_equiv
 
 notation M ` ≃SL[`:50 σ `] ` M₂ := continuous_linear_equiv σ M M₂
 notation M ` ≃L[`:50 R `] ` M₂ := continuous_linear_equiv (ring_hom.id R) M M₂
-notation M ` ≃L*[`:50 R `] ` M₂ := continuous_linear_equiv (@star_ring_aut R _ _ : R →+* R) M M₂
+notation M ` ≃L⋆[`:50 R `] ` M₂ := continuous_linear_equiv (@star_ring_aut R _ _ : R →+* R) M M₂
 
 namespace continuous_linear_map
 

--- a/test/semilinear.lean
+++ b/test/semilinear.lean
@@ -55,6 +55,3 @@ example (f : M →ₗ⋆[R] M₂) (g : M₂ →ₗ[R] M₃) : M →ₗ⋆[R] M�
 example (f : M ≃ₗ⋆[R] M₂) : M₂ ≃ₗ⋆[R] M := f.symm
 
 end star_ring
-
-⋆
-

--- a/test/semilinear.lean
+++ b/test/semilinear.lean
@@ -18,7 +18,7 @@ properties:
 2. The composition of two conjugate-linear maps is *definitionally* a plain linear map.
 
 3. The inverse of a conjugate-linear equivalence is *definitionally* a conjugate-linear
-equivalence.
+  equivalence.
 
 This file contains tests to make sure that future refactors do not lose these definitional
 properties.

--- a/test/semilinear.lean
+++ b/test/semilinear.lean
@@ -17,7 +17,9 @@ properties:
 
 2. The composition of two conjugate-linear maps is *definitionally* a plain linear map.
 
-3. The inverse of a conjugate-linear equivalence is *definitionally* a conjugate-linear
+3. The composition of a plain linear map and a conjugate-linear map is conjugate-linear.
+
+4. The inverse of a conjugate-linear equivalence is *definitionally* a conjugate-linear
   equivalence.
 
 This file contains tests to make sure that future refactors do not lose these definitional
@@ -44,8 +46,12 @@ variables {R : Type*} [comm_semiring R] [star_ring R]
 variables {M : Type*} [add_comm_monoid M] [module R M]
 variables {M₂ : Type*} [add_comm_monoid M₂] [module R M₂]
 variables {M₃ : Type*} [add_comm_monoid M₃] [module R M₃]
+variables {N : Type*} [add_comm_monoid N] [module ℝ N]
 
 example (f : M →ₗ*[R] M₂) (g : M₂ →ₗ*[R] M₃) : M →ₗ[R] M₃ := g.comp f
+
+example (f : M →ₗ[R] M₂) (g : M₂ →ₗ*[R] M₃) : M →ₗ*[R] M₃ := g.comp f
+example (f : M →ₗ*[R] M₂) (g : M₂ →ₗ[R] M₃) : M →ₗ*[R] M₃ := g.comp f
 
 example (f : M ≃ₗ*[R] M₂) : M₂ ≃ₗ*[R] M := f.symm
 

--- a/test/semilinear.lean
+++ b/test/semilinear.lean
@@ -35,9 +35,9 @@ section real
 variables {M : Type*} [add_comm_monoid M] [module ℝ M]
 variables {M₂ : Type*} [add_comm_monoid M₂] [module ℝ M₂]
 
-example (f : M →ₗ*[ℝ] M₂) : M →ₗ[ℝ] M₂ := f
+example (f : M →ₗ⋆[ℝ] M₂) : M →ₗ[ℝ] M₂ := f
 
-example (f : M →ₗ[ℝ] M₂) : M →ₗ*[ℝ] M₂ := f
+example (f : M →ₗ[ℝ] M₂) : M →ₗ⋆[ℝ] M₂ := f
 
 end real
 
@@ -47,11 +47,14 @@ variables {M : Type*} [add_comm_monoid M] [module R M]
 variables {M₂ : Type*} [add_comm_monoid M₂] [module R M₂]
 variables {M₃ : Type*} [add_comm_monoid M₃] [module R M₃]
 
-example (f : M →ₗ*[R] M₂) (g : M₂ →ₗ*[R] M₃) : M →ₗ[R] M₃ := g.comp f
+example (f : M →ₗ⋆[R] M₂) (g : M₂ →ₗ⋆[R] M₃) : M →ₗ[R] M₃ := g.comp f
 
-example (f : M →ₗ[R] M₂) (g : M₂ →ₗ*[R] M₃) : M →ₗ*[R] M₃ := g.comp f
-example (f : M →ₗ*[R] M₂) (g : M₂ →ₗ[R] M₃) : M →ₗ*[R] M₃ := g.comp f
+example (f : M →ₗ[R] M₂) (g : M₂ →ₗ⋆[R] M₃) : M →ₗ⋆[R] M₃ := g.comp f
+example (f : M →ₗ⋆[R] M₂) (g : M₂ →ₗ[R] M₃) : M →ₗ⋆[R] M₃ := g.comp f
 
-example (f : M ≃ₗ*[R] M₂) : M₂ ≃ₗ*[R] M := f.symm
+example (f : M ≃ₗ⋆[R] M₂) : M₂ ≃ₗ⋆[R] M := f.symm
 
 end star_ring
+
+⋆
+

--- a/test/semilinear.lean
+++ b/test/semilinear.lean
@@ -1,0 +1,52 @@
+/-
+Copyright (c) 2021 Frédéric Dupuis. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Frédéric Dupuis, Heather Macbeth
+-/
+import data.equiv.module
+import data.real.basic
+
+/-!
+# Test file for conjugate linear maps
+
+The implementation of conjugate-linear maps in mathlib is designed to have a few convenient
+properties:
+
+1. A conjugate-linear map with respect to the ring `ℝ` (or any other ring given the "trivial"
+  `star_ring` instance) is *definitionally* a plain linear map; that is, the type is the same.
+
+2. The composition of two conjugate-linear maps is *definitionally* a plain linear map.
+
+3. The inverse of a conjugate-linear equivalence is *definitionally* a conjugate-linear
+equivalence.
+
+This file contains tests to make sure that future refactors do not lose these definitional
+properties.
+
+## Tags
+
+Conjugate linear maps, semilinear maps
+
+-/
+
+section real
+variables {M : Type*} [add_comm_monoid M] [module ℝ M]
+variables {M₂ : Type*} [add_comm_monoid M₂] [module ℝ M₂]
+
+example (f : M →ₗ*[ℝ] M₂) : M →ₗ[ℝ] M₂ := f
+
+example (f : M →ₗ[ℝ] M₂) : M →ₗ*[ℝ] M₂ := f
+
+end real
+
+section star_ring
+variables {R : Type*} [comm_semiring R] [star_ring R]
+variables {M : Type*} [add_comm_monoid M] [module R M]
+variables {M₂ : Type*} [add_comm_monoid M₂] [module R M₂]
+variables {M₃ : Type*} [add_comm_monoid M₃] [module R M₃]
+
+example (f : M →ₗ*[R] M₂) (g : M₂ →ₗ*[R] M₃) : M →ₗ[R] M₃ := g.comp f
+
+example (f : M ≃ₗ*[R] M₂) : M₂ ≃ₗ*[R] M := f.symm
+
+end star_ring

--- a/test/semilinear.lean
+++ b/test/semilinear.lean
@@ -46,7 +46,6 @@ variables {R : Type*} [comm_semiring R] [star_ring R]
 variables {M : Type*} [add_comm_monoid M] [module R M]
 variables {M₂ : Type*} [add_comm_monoid M₂] [module R M₂]
 variables {M₃ : Type*} [add_comm_monoid M₃] [module R M₃]
-variables {N : Type*} [add_comm_monoid N] [module ℝ N]
 
 example (f : M →ₗ*[R] M₂) (g : M₂ →ₗ*[R] M₃) : M →ₗ[R] M₃ := g.comp f
 


### PR DESCRIPTION
This PR adds the notation `M →ₗ⋆[R] N`, `M ≃ₗ⋆[R] N`, etc, to denote star-linear maps/equivalences, i.e. semilinear maps where the ring hom is `star`. A special case of this are conjugate-linear maps when `R = ℂ`.

Co-authored-by: Heather Macbeth <hmacbeth1@fordham.edu>

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
