### PR TITLE
[Merged by Bors] - chore(linear_algebra/matrix): add fin expansions for trace and adjugate, and some trace lemmas

### DIFF
--- a/src/algebra/lie/classical.lean
+++ b/src/algebra/lie/classical.lean
@@ -77,7 +77,7 @@ variables [comm_ring R]
   matrix.trace n R R ⁅X, Y⁆ = 0 :=
 calc _ = matrix.trace n R R (X ⬝ Y) - matrix.trace n R R (Y ⬝ X) : linear_map.map_sub _ _ _
    ... = matrix.trace n R R (X ⬝ Y) - matrix.trace n R R (X ⬝ Y) :
-     congr_arg (λ x, _ - x) (matrix.trace_mul_comm X Y)
+     congr_arg (λ x, _ - x) (matrix.trace_mul_comm Y X)
    ... = 0 : sub_self _
 
 namespace special_linear

--- a/src/linear_algebra/matrix/nonsingular_inverse.lean
+++ b/src/linear_algebra/matrix/nonsingular_inverse.lean
@@ -309,6 +309,12 @@ begin
      ... = det A ^ (fintype.card n - 1) : by rw [ha, one_mul]
 end
 
+lemma adjugate_fin_zero (A : matrix (fin 0) (fin 0) α) : adjugate A = 0 :=
+@subsingleton.elim _ matrix.subsingleton_of_empty_left _ _
+
+lemma adjugate_fin_one (A : matrix (fin 1) (fin 1) α) : adjugate A = 1 :=
+adjugate_subsingleton A
+
 lemma adjugate_fin_two (A : matrix (fin 2) (fin 2) α) :
   adjugate A = ![![A 1 1, -A 0 1], ![-A 1 0, A 0 0]] :=
 begin

--- a/src/linear_algebra/matrix/nonsingular_inverse.lean
+++ b/src/linear_algebra/matrix/nonsingular_inverse.lean
@@ -309,10 +309,10 @@ begin
      ... = det A ^ (fintype.card n - 1) : by rw [ha, one_mul]
 end
 
-lemma adjugate_fin_zero (A : matrix (fin 0) (fin 0) α) : adjugate A = 0 :=
+@[simp] lemma adjugate_fin_zero (A : matrix (fin 0) (fin 0) α) : adjugate A = 0 :=
 @subsingleton.elim _ matrix.subsingleton_of_empty_left _ _
 
-lemma adjugate_fin_one (A : matrix (fin 1) (fin 1) α) : adjugate A = 1 :=
+@[simp] lemma adjugate_fin_one (A : matrix (fin 1) (fin 1) α) : adjugate A = 1 :=
 adjugate_subsingleton A
 
 lemma adjugate_fin_two (A : matrix (fin 2) (fin 2) α) :

--- a/src/linear_algebra/matrix/trace.lean
+++ b/src/linear_algebra/matrix/trace.lean
@@ -78,6 +78,24 @@ lemma trace_mul_comm {S : Type v} [comm_semiring S] (A : matrix m n S) (B : matr
   trace n S S (B ⬝ A) = trace m S S (A ⬝ B) :=
 by rw [←trace_transpose, ←trace_transpose_mul, transpose_mul]
 
+/-! ### Special cases for `fin n`
+
+While `simp [fin.sum_univ_succ]` can prove these, we include them for convenience and consistency
+with `matrix.det_fin_two` etc.
+-/
+
+lemma trace_fin_zero (A : matrix (fin 0) (fin 0) R) : trace _ R R A = 0 :=
+rfl
+
+lemma trace_fin_one (A : matrix (fin 1) (fin 1) R) : trace _ R R A = A 0 0 :=
+add_zero _
+
+lemma trace_fin_two (A : matrix (fin 2) (fin 2) R) : trace _ R R A = A 0 0 + A 1 1 :=
+congr_arg ((+) _) (add_zero (A 1 1))
+
+lemma trace_fin_three (A : matrix (fin 3) (fin 3) R) : trace _ R R A = A 0 0 + A 1 1 + A 2 2 :=
+by { rw [← add_zero (A 2 2), add_assoc], refl }
+
 end trace
 
 end matrix

--- a/src/linear_algebra/matrix/trace.lean
+++ b/src/linear_algebra/matrix/trace.lean
@@ -100,7 +100,7 @@ While `simp [fin.sum_univ_succ]` can prove these, we include them for convenienc
 with `matrix.det_fin_two` etc.
 -/
 
-lemma trace_fin_zero (A : matrix (fin 0) (fin 0) R) : trace _ R R A = 0 :=
+@[simp] lemma trace_fin_zero (A : matrix (fin 0) (fin 0) R) : trace _ R R A = 0 :=
 rfl
 
 lemma trace_fin_one (A : matrix (fin 1) (fin 1) R) : trace _ R R A = A 0 0 :=

--- a/src/linear_algebra/matrix/trace.lean
+++ b/src/linear_algebra/matrix/trace.lean
@@ -28,7 +28,7 @@ section trace
 
 universes u v w
 
-variables {m : Type*} (n : Type*)
+variables {m : Type*} (n : Type*) {p : Type*}
 variables (R : Type*) (M : Type*) [semiring R] [add_comm_monoid M] [module R M]
 
 /--
@@ -48,6 +48,9 @@ variables {n} {R} {M}
 
 @[simp] lemma diag_transpose (A : matrix n n M) : diag n R M Aᵀ = diag n R M A := rfl
 
+@[simp] lemma diag_col_mul_row (a b : n → R) : diag n R R (col a ⬝ row b) = a * b :=
+by { ext, simp [matrix.mul_apply] }
+
 variables (n) (R) (M)
 
 /--
@@ -58,7 +61,7 @@ def trace [fintype n] : (matrix n n M) →ₗ[R] M :=
   map_add'  := by { intros, apply finset.sum_add_distrib, },
   map_smul' := by { intros, simp [finset.smul_sum], } }
 
-variables {n} {R} {M} [fintype n] [fintype m]
+variables {n} {R} {M} [fintype n] [fintype m] [fintype p]
 
 @[simp] lemma trace_diag (A : matrix n n M) : trace n R M A = ∑ i, diag n R M A i := rfl
 
@@ -75,8 +78,21 @@ by simp_rw [h, diag_one, finset.sum_const, nsmul_one]; refl
   trace n R R (Aᵀ ⬝ Bᵀ) = trace m R R (A ⬝ B) := finset.sum_comm
 
 lemma trace_mul_comm {S : Type v} [comm_semiring S] (A : matrix m n S) (B : matrix n m S) :
-  trace n S S (B ⬝ A) = trace m S S (A ⬝ B) :=
+  trace m S S (A ⬝ B) = trace n S S (B ⬝ A) :=
 by rw [←trace_transpose, ←trace_transpose_mul, transpose_mul]
+
+lemma trace_mul_cycle {S : Type v} [comm_semiring S]
+  (A : matrix m n S) (B : matrix n p S) (C : matrix p m S) :
+  trace _ S S (A ⬝ B ⬝ C) = trace p S S (C ⬝ A ⬝ B) :=
+by rw [trace_mul_comm, matrix.mul_assoc]
+
+lemma trace_mul_cycle' {S : Type v} [comm_semiring S]
+  (A : matrix m n S) (B : matrix n p S) (C : matrix p m S) :
+  trace _ S S (A ⬝ (B ⬝ C)) = trace p S S (C ⬝ (A ⬝ B)) :=
+by rw [←matrix.mul_assoc, trace_mul_comm]
+
+@[simp] lemma trace_col_mul_row (a b : n → R) : trace n R R (col a ⬝ row b) = dot_product a b :=
+by simp [dot_product]
 
 /-! ### Special cases for `fin n`
 


### PR DESCRIPTION
We have these expansions for `det` already, I figured we may as well have them for these.

This adds some other trivial trace lemmas while I'm touching the same file.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)

This is in part motivated by my attempt to transcribe "The matrix cookbook" [here](https://github.com/eric-wieser/lean-matrix-cookbook/blob/eb31d52af680edeb4a0f98ea07fc54bd25ca3f1d/src/matrix_cookbook/1_basic.lean#L86), where eq30 wants a direct expression for `trace`, and eqs 26-27 can probably benefit from these expansions too.