### PR TITLE
[Merged by Bors] - feat(set_theory/cardinal): add `add_le_omega`

### DIFF
--- a/src/data/real/cardinality.lean
+++ b/src/data/real/cardinality.lean
@@ -164,7 +164,7 @@ by rw [mk_univ, mk_real]
 
 /-- **Non-Denumerability of the Continuum**: The reals are not countable. -/
 lemma not_countable_real : ¬ countable (set.univ : set ℝ) :=
-by { rw [countable_iff, not_le, mk_univ_real], apply cantor }
+by { rw [← mk_set_le_omega, not_le, mk_univ_real], apply cantor }
 
 /-- The cardinality of the interval (a, ∞). -/
 lemma mk_Ioi_real (a : ℝ) : #(Ioi a) = 𝔠 :=

--- a/src/data/set/countable.lean
+++ b/src/data/set/countable.lean
@@ -175,8 +175,14 @@ lemma countable.union
 by rw union_eq_Union; exact
 countable_Union (bool.forall_bool.2 ⟨h₂, h₁⟩)
 
+@[simp] lemma countable_union {s t : set α} : countable (s ∪ t) ↔ countable s ∧ countable t :=
+⟨λ h, ⟨h.mono (subset_union_left s t), h.mono (subset_union_right _ _)⟩, λ h, h.1.union h.2⟩
+
+@[simp] lemma countable_insert {s : set α} {a : α} : countable (insert a s) ↔ countable s :=
+by simp only [insert_eq, countable_union, countable_singleton, true_and]
+
 lemma countable.insert {s : set α} (a : α) (h : countable s) : countable (insert a s) :=
-by { rw [set.insert_eq], exact (countable_singleton _).union h }
+countable_insert.2 h
 
 lemma finite.countable {s : set α} : finite s → countable s
 | ⟨h⟩ := trunc.nonempty (by exactI trunc_encodable_of_fintype s)

--- a/src/set_theory/cardinal.lean
+++ b/src/set_theory/cardinal.lean
@@ -938,6 +938,8 @@ end
 
 @[simp] lemma omega_add_omega : ω + ω = ω := mk_denumerable _
 
+@[simp] lemma omega_mul_omega : ω * ω = ω := mk_denumerable _
+
 @[simp] lemma add_le_omega {c₁ c₂ : cardinal} : c₁ + c₂ ≤ ω ↔ c₁ ≤ ω ∧ c₂ ≤ ω :=
 ⟨λ h, ⟨le_self_add.trans h, le_add_self.trans h⟩, λ h, omega_add_omega ▸ add_le_add h.1 h.2⟩
 

--- a/src/set_theory/cardinal.lean
+++ b/src/set_theory/cardinal.lean
@@ -929,12 +929,17 @@ lemma denumerable_iff {α : Type u} : nonempty (denumerable α) ↔ #α = ω :=
 @[simp] lemma mk_denumerable (α : Type u) [denumerable α] : #α = ω :=
 denumerable_iff.1 ⟨‹_›⟩
 
-lemma countable_iff (s : set α) : countable s ↔ #s ≤ ω :=
+@[simp] lemma mk_set_le_omega (s : set α) : #s ≤ ω ↔ countable s :=
 begin
   rw [countable_iff_exists_injective], split,
-  rintro ⟨f, hf⟩, exact ⟨embedding.trans ⟨f, hf⟩ equiv.ulift.symm.to_embedding⟩,
-  rintro ⟨f'⟩, cases embedding.trans f' equiv.ulift.to_embedding with f hf, exact ⟨f, hf⟩
+  { rintro ⟨f'⟩, cases embedding.trans f' equiv.ulift.to_embedding with f hf, exact ⟨f, hf⟩ },
+  { rintro ⟨f, hf⟩, exact ⟨embedding.trans ⟨f, hf⟩ equiv.ulift.symm.to_embedding⟩ }
 end
+
+@[simp] lemma omega_add_omega : ω + ω = ω := mk_denumerable _
+
+@[simp] lemma add_le_omega {c₁ c₂ : cardinal} : c₁ + c₂ ≤ ω ↔ c₁ ≤ ω ∧ c₂ ≤ ω :=
+⟨λ h, ⟨le_self_add.trans h, le_add_self.trans h⟩, λ h, omega_add_omega ▸ add_le_add h.1 h.2⟩
 
 /-- This function sends finite cardinals to the corresponding natural, and infinite cardinals
   to 0. -/
@@ -1292,6 +1297,9 @@ lemma mk_subtype_mono {p q : α → Prop} (h : ∀x, p x → q x) : #{x // p x} 
 
 lemma mk_set_le (s : set α) : #s ≤ #α :=
 mk_subtype_le s
+
+lemma mk_union_le_omega {α} {P Q : set α} : #((P ∪ Q : set α)) ≤ ω ↔ #P ≤ ω ∧ #Q ≤ ω :=
+by simp
 
 lemma mk_image_eq_lift {α : Type u} {β : Type v} (f : α → β) (s : set α) (h : injective f) :
   lift.{u} (#(f '' s)) = lift.{v} (#s) :=

--- a/src/set_theory/cardinal_ordinal.lean
+++ b/src/set_theory/cardinal_ordinal.lean
@@ -223,11 +223,11 @@ theorem aleph'_is_normal : is_normal (ord ∘ aleph') :=
 theorem aleph_is_normal : is_normal (ord ∘ aleph) :=
 aleph'_is_normal.trans $ add_is_normal ordinal.omega
 
+theorem succ_omega : succ ω = aleph 1 :=
+by rw [← aleph_zero, ← aleph_succ, ordinal.succ_zero]
+
 lemma countable_iff_lt_aleph_one {α : Type*} (s : set α) : countable s ↔ #s < aleph 1 :=
-begin
-  have : aleph 1 = (aleph 0).succ, by simp only [← aleph_succ, ordinal.succ_zero],
-  rw [countable_iff, ← aleph_zero, this, lt_succ],
-end
+by rw [← succ_omega, lt_succ, mk_set_le_omega]
 
 /-! ### Properties of `mul` -/
 

--- a/src/set_theory/cofinality.lean
+++ b/src/set_theory/cofinality.lean
@@ -467,6 +467,12 @@ theorem is_strong_limit.is_limit {c} (H : is_strong_limit c) : is_limit c :=
 def is_regular (c : cardinal) : Prop :=
 ω ≤ c ∧ c.ord.cof = c
 
+lemma is_regular.pos {c : cardinal} (H : c.is_regular) : 0 < c :=
+omega_pos.trans_le H.left
+
+lemma is_regular.ord_pos {c : cardinal} (H : c.is_regular) : 0 < c.ord :=
+by { rw cardinal.lt_ord, exact H.pos }
+
 theorem cof_is_regular {o : ordinal} (h : o.is_limit) : is_regular o.cof :=
 ⟨omega_le_cof.2 h, cof_cof _⟩
 


### PR DESCRIPTION
* simplify `c₁ + c₂ ≤ ω` to `c₁ ≤ ω ∧ c₂ ≤ ω`;
* simplify `ω + ω` to `ω`;
* simplify `#s ≤ ω` to `s.countable`;
* simplify `(s ∪ t).countable` and `(insert a s).countable`.

Motivated by lemmas from flypitch.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
