### PR TITLE
[Merged by Bors] - feat(*): introduce classes for types of homomorphism

### DIFF
--- a/src/algebra/category/Module/basic.lean
+++ b/src/algebra/category/Module/basic.lean
@@ -88,6 +88,11 @@ instance has_forget_to_AddCommGroup : has_forget₂ (Module R) AddCommGroup :=
   { obj := λ M, AddCommGroup.of M,
     map := λ M₁ M₂ f, linear_map.to_add_monoid_hom f } }
 
+-- TODO: instantiate `linear_map_class` once that gets defined
+instance (M N : Module R) : add_monoid_hom_class (M ⟶ N) M N :=
+{ coe := λ f, f,
+  .. linear_map.add_monoid_hom_class }
+
 /-- The object in the category of R-modules associated to an R-module -/
 def of (X : Type v) [add_comm_group X] [module R X] : Module R := ⟨X⟩
 

--- a/src/algebra/category/Module/limits.lean
+++ b/src/algebra/category/Module/limits.lean
@@ -91,11 +91,14 @@ Witness that the limit cone in `Module R` is a limit cone.
 (Internal use only; use the limits API.)
 -/
 def limit_cone_is_limit (F : J ⥤ Module R) : is_limit (limit_cone F) :=
-begin
-  refine is_limit.of_faithful
-    (forget (Module R)) (types.limit_cone_is_limit _)
-    (λ s, ⟨_, _, _⟩) (λ s, rfl); tidy
-end
+by refine is_limit.of_faithful
+      (forget (Module R)) (types.limit_cone_is_limit _)
+      (λ s, ⟨_, _, _⟩) (λ s, rfl);
+    intros;
+    ext j;
+    simp only [subtype.coe_mk, functor.map_cone_π_app, forget_map_eq_coe,
+         linear_map.map_add, linear_map.map_smul];
+    refl
 
 end has_limits
 

--- a/src/algebra/group/hom.lean
+++ b/src/algebra/group/hom.lean
@@ -613,11 +613,13 @@ def one_hom.comp [has_one M] [has_one N] [has_one P]
 def mul_hom.comp [has_mul M] [has_mul N] [has_mul P]
   (hnp : mul_hom N P) (hmn : mul_hom M N) : mul_hom M P :=
 { to_fun := hnp ∘ hmn, map_mul' := by simp, }
+
 /-- Composition of monoid morphisms as a monoid morphism. -/
 @[to_additive]
 def monoid_hom.comp [mul_one_class M] [mul_one_class N] [mul_one_class P]
   (hnp : N →* P) (hmn : M →* N) : M →* P :=
 { to_fun := hnp ∘ hmn, map_one' := by simp, map_mul' := by simp, }
+
 /-- Composition of `monoid_with_zero_hom`s as a `monoid_with_zero_hom`. -/
 def monoid_with_zero_hom.comp [mul_zero_one_class M] [mul_zero_one_class N] [mul_zero_one_class P]
   (hnp : monoid_with_zero_hom N P) (hmn : monoid_with_zero_hom M N) : monoid_with_zero_hom M P :=

--- a/src/algebra/group/hom.lean
+++ b/src/algebra/group/hom.lean
@@ -81,7 +81,7 @@ structure zero_hom (M : Type*) (N : Type*) [has_zero M] [has_zero N] :=
 You should extend this typeclass when you extend `zero_hom`.
 -/
 class zero_hom_class (F : Type*) (M N : out_param $ Type*)
-  [has_zero M] [has_zero N] extends fun_like F M N :=
+  [has_zero M] [has_zero N] extends fun_like F M (λ _, N) :=
 (map_zero : ∀ (f : F), f 0 = 0)
 
 -- Instances and lemmas are defined below through `@[to_additive]`.
@@ -106,7 +106,7 @@ structure add_hom (M : Type*) (N : Type*) [has_add M] [has_add N] :=
 You should declare an instance of this typeclass when you extend `add_hom`.
 -/
 class add_hom_class (F : Type*) (M N : out_param $ Type*)
-  [has_add M] [has_add N] extends fun_like F M N :=
+  [has_add M] [has_add N] extends fun_like F M (λ _, N) :=
 (map_add : ∀ (f : F) (x y : M), f (x + y) = f x + f y)
 
 -- Instances and lemmas are defined below through `@[to_additive]`.
@@ -169,7 +169,7 @@ You should extend this typeclass when you extend `one_hom`.
 @[to_additive]
 class one_hom_class (F : Type*) (M N : out_param $ Type*)
   [has_one M] [has_one N]
-  extends fun_like F M N :=
+  extends fun_like F M (λ _, N) :=
 (map_one : ∀ (f : F), f 1 = 1)
 
 @[to_additive]
@@ -204,7 +204,7 @@ You should declare an instance of this typeclass when you extend `mul_hom`.
 -/
 @[to_additive]
 class mul_hom_class (F : Type*) (M N : out_param $ Type*)
-  [has_mul M] [has_mul N] extends fun_like F M N :=
+  [has_mul M] [has_mul N] extends fun_like F M (λ _, N) :=
 (map_mul : ∀ (f : F) (x y : M), f (x * y) = f x * f y)
 
 @[to_additive]

--- a/src/algebra/group/hom.lean
+++ b/src/algebra/group/hom.lean
@@ -6,6 +6,7 @@ Authors: Patrick Massot, Kevin Buzzard, Scott Morrison, Johan Commelin, Chris Hu
 -/
 import algebra.group.commute
 import algebra.group_with_zero.defs
+import data.fun_like
 
 /-!
 # monoid and group homomorphisms
@@ -56,22 +57,73 @@ monoid_hom, add_monoid_hom
 -/
 
 variables {M : Type*} {N : Type*} {P : Type*} -- monoids
-  {G : Type*} {H : Type*} -- groups
+variables {G : Type*} {H : Type*} -- groups
+variables {F : Type*} -- homs
 
 -- for easy multiple inheritance
 set_option old_structure_cmd true
 
-/-- Homomorphism that preserves zero -/
+section zero
+
+/-- `zero_hom M N` is the type of functions `M → N` that preserve zero.
+
+When possible, instead of parametrizing results over `(f : zero_hom M N)`,
+you should parametrize over `(F : Type*) [zero_hom_class F M N] (f : F)`.
+
+When you extend this structure, make sure to also extend `zero_hom_class`.
+-/
 structure zero_hom (M : Type*) (N : Type*) [has_zero M] [has_zero N] :=
 (to_fun : M → N)
 (map_zero' : to_fun 0 = 0)
 
-/-- Homomorphism that preserves addition -/
+/-- `zero_hom_class F M N` states that `F` is a type of zero-preserving homomorphisms.
+
+You should extend this typeclass when you extend `zero_hom`.
+-/
+class zero_hom_class (F : Type*) (M N : out_param $ Type*)
+  [has_zero M] [has_zero N] extends fun_like F M N :=
+(map_zero : ∀ (f : F), f 0 = 0)
+
+-- Instances and lemmas are defined below through `@[to_additive]`.
+
+end zero
+
+section add
+
+
+/-- `add_hom M N` is the type of functions `M → N` that preserve addition.
+
+When possible, instead of parametrizing results over `(f : add_hom M N)`,
+you should parametrize over `(F : Type*) [add_hom_class F M N] (f : F)`.
+
+When you extend this structure, make sure to extend `add_hom_class`.
+-/
 structure add_hom (M : Type*) (N : Type*) [has_add M] [has_add N] :=
 (to_fun : M → N)
 (map_add' : ∀ x y, to_fun (x + y) = to_fun x + to_fun y)
 
-/-- Bundled add_monoid homomorphisms; use this for bundled add_group homomorphisms too. -/
+/-- `add_hom_class F M N` states that `F` is a type of addition-preserving homomorphisms.
+You should declare an instance of this typeclass when you extend `add_hom`.
+-/
+class add_hom_class (F : Type*) (M N : out_param $ Type*)
+  [has_add M] [has_add N] extends fun_like F M N :=
+(map_add : ∀ (f : F) (x y : M), f (x + y) = f x + f y)
+
+-- Instances and lemmas are defined below through `@[to_additive]`.
+
+end add
+
+section add_zero
+
+/-- `M →+ N` is the type of functions `M → N` that preserve the `add_zero_class` structure.
+
+`add_monoid_hom` is also used for group homomorphisms.
+
+When possible, instead of parametrizing results over `(f : M →+ N)`,
+you should parametrize over `(F : Type*) [add_monoid_hom_class F M N] (f : F)`.
+
+When you extend this structure, make sure to extend `add_monoid_hom_class`.
+-/
 @[ancestor zero_hom add_hom]
 structure add_monoid_hom (M : Type*) (N : Type*) [add_zero_class M] [add_zero_class N]
   extends zero_hom M N, add_hom M N
@@ -81,35 +133,195 @@ attribute [nolint doc_blame] add_monoid_hom.to_zero_hom
 
 infixr ` →+ `:25 := add_monoid_hom
 
-/-- Homomorphism that preserves one -/
+/-- `add_monoid_hom_class F M N` states that `F` is a type of `add_zero_class`-preserving
+homomorphisms.
+
+You should also extend this typeclass when you extend `add_monoid_hom`.
+-/
+@[ancestor add_hom_class zero_hom_class]
+class add_monoid_hom_class (F : Type*) (M N : out_param $ Type*)
+  [add_zero_class M] [add_zero_class N]
+  extends add_hom_class F M N, zero_hom_class F M N
+
+-- Instances and lemmas are defined below through `@[to_additive]`.
+
+end add_zero
+
+section one
+
+variables [has_one M] [has_one N]
+
+/-- `one_hom M N` is the type of functions `M → N` that preserve one.
+
+When possible, instead of parametrizing results over `(f : one_hom M N)`,
+you should parametrize over `(F : Type*) [one_hom_class F M N] (f : F)`.
+
+When you extend this structure, make sure to also extend `one_hom_class`.
+-/
 @[to_additive]
 structure one_hom (M : Type*) (N : Type*) [has_one M] [has_one N] :=
 (to_fun : M → N)
 (map_one' : to_fun 1 = 1)
 
-/-- Homomorphism that preserves multiplication -/
+/-- `one_hom_class F M N` states that `F` is a type of one-preserving homomorphisms.
+You should extend this typeclass when you extend `one_hom`.
+-/
+@[to_additive]
+class one_hom_class (F : Type*) (M N : out_param $ Type*)
+  [has_one M] [has_one N]
+  extends fun_like F M N :=
+(map_one : ∀ (f : F), f 1 = 1)
+
+@[to_additive]
+instance one_hom.one_hom_class : one_hom_class (one_hom M N) M N :=
+{ coe := one_hom.to_fun,
+  coe_injective' := λ f g h, by cases f; cases g; congr',
+  map_one := one_hom.map_one' }
+
+@[simp, to_additive] lemma map_one [one_hom_class F M N] (f : F) : f 1 = 1 :=
+one_hom_class.map_one f
+
+end one
+
+section mul
+
+variables [has_mul M] [has_mul N]
+
+/-- `mul_hom M N` is the type of functions `M → N` that preserve multiplication.
+
+When possible, instead of parametrizing results over `(f : mul_hom M N)`,
+you should parametrize over `(F : Type*) [mul_hom_class F M N] (f : F)`.
+When you extend this structure, make sure to extend `mul_hom_class`.
+-/
 @[to_additive]
 structure mul_hom (M : Type*) (N : Type*) [has_mul M] [has_mul N] :=
 (to_fun : M → N)
 (map_mul' : ∀ x y, to_fun (x * y) = to_fun x * to_fun y)
 
-/-- Bundled monoid homomorphisms; use this for bundled group homomorphisms too. -/
+/-- `mul_hom_class F M N` states that `F` is a type of multiplication-preserving homomorphisms.
+
+You should declare an instance of this typeclass when you extend `mul_hom`.
+-/
+@[to_additive]
+class mul_hom_class (F : Type*) (M N : out_param $ Type*)
+  [has_mul M] [has_mul N] extends fun_like F M N :=
+(map_mul : ∀ (f : F) (x y : M), f (x * y) = f x * f y)
+
+@[to_additive]
+instance mul_hom.mul_hom_class : mul_hom_class (mul_hom M N) M N :=
+{ coe := mul_hom.to_fun,
+  coe_injective' := λ f g h, by cases f; cases g; congr',
+  map_mul := mul_hom.map_mul' }
+
+@[simp, to_additive] lemma map_mul [mul_hom_class F M N] (f : F) (x y : M) :
+  f (x * y) = f x * f y :=
+mul_hom_class.map_mul f x y
+
+end mul
+
+section mul_one
+
+variables [mul_one_class M] [mul_one_class N]
+
+/-- `M →* N` is the type of functions `M → N` that preserve the `monoid` structure.
+`monoid_hom` is also used for group homomorphisms.
+
+When possible, instead of parametrizing results over `(f : M →+ N)`,
+you should parametrize over `(F : Type*) [monoid_hom_class F M N] (f : F)`.
+
+When you extend this structure, make sure to extend `monoid_hom_class`.
+-/
 @[ancestor one_hom mul_hom, to_additive]
 structure monoid_hom (M : Type*) (N : Type*) [mul_one_class M] [mul_one_class N]
   extends one_hom M N, mul_hom M N
 
-/-- Bundled monoid with zero homomorphisms; use this for bundled group with zero homomorphisms
-too. -/
+attribute [nolint doc_blame] monoid_hom.to_mul_hom
+attribute [nolint doc_blame] monoid_hom.to_one_hom
+
+infixr ` →* `:25 := monoid_hom
+
+/-- `monoid_hom_class F M N` states that `F` is a type of `monoid`-preserving homomorphisms.
+You should also extend this typeclass when you extend `monoid_hom`.
+-/
+@[ancestor mul_hom_class one_hom_class, to_additive]
+class monoid_hom_class (F : Type*) (M N : out_param $ Type*)
+  [mul_one_class M] [mul_one_class N]
+  extends mul_hom_class F M N, one_hom_class F M N
+
+@[to_additive]
+instance monoid_hom.monoid_hom_class : monoid_hom_class (M →* N) M N :=
+{ coe := monoid_hom.to_fun,
+  coe_injective' := λ f g h, by cases f; cases g; congr',
+  map_mul := monoid_hom.map_mul',
+  map_one := monoid_hom.map_one' }
+
+@[to_additive]
+instance [monoid_hom_class F M N] : has_coe_t F (M →* N) :=
+⟨λ f, { to_fun := f, map_one' := map_one f, map_mul' := map_mul f }⟩
+
+@[to_additive]
+lemma map_mul_eq_one [monoid_hom_class F M N] (f : F) {a b : M} (h : a * b = 1) :
+  f a * f b = 1 :=
+by rw [← map_mul, h, map_one]
+
+/-- Group homomorphisms preserve inverse. -/
+@[simp, to_additive]
+theorem map_inv [group G] [group H] [monoid_hom_class F G H]
+  (f : F) (g : G) : f g⁻¹ = (f g)⁻¹ :=
+eq_inv_of_mul_eq_one $ map_mul_eq_one f $ inv_mul_self g
+
+/-- Group homomorphisms preserve division. -/
+@[simp, to_additive]
+theorem map_mul_inv [group G] [group H] [monoid_hom_class F G H]
+  (f : F) (g h : G) : f (g * h⁻¹) = f g * (f h)⁻¹ :=
+by rw [map_mul, map_inv]
+
+/-- Group homomorphisms preserve division. -/
+@[simp, to_additive] lemma map_div [group G] [group H] [monoid_hom_class F G H]
+  (f : F) (x y : G) : f (x / y) = f x / f y :=
+by rw [div_eq_mul_inv, div_eq_mul_inv, map_mul_inv]
+
+end mul_one
+
+section mul_zero_one
+
+variables [mul_zero_one_class M] [mul_zero_one_class N]
+
+/-- `monoid_with_zero_hom M N` is the type of functions `M → N` that preserve
+the `monoid_with_zero` structure.
+
+`monoid_with_zero_hom` is also used for group homomorphisms.
+
+When possible, instead of parametrizing results over `(f : M →+ N)`,
+you should parametrize over `(F : Type*) [monoid_with_zero_hom_class F M N] (f : F)`.
+
+When you extend this structure, make sure to extend `monoid_with_zero_hom_class`.
+-/
 @[ancestor zero_hom monoid_hom]
 structure monoid_with_zero_hom (M : Type*) (N : Type*) [mul_zero_one_class M] [mul_zero_one_class N]
   extends zero_hom M N, monoid_hom M N
 
-attribute [nolint doc_blame] monoid_hom.to_mul_hom
-attribute [nolint doc_blame] monoid_hom.to_one_hom
 attribute [nolint doc_blame] monoid_with_zero_hom.to_monoid_hom
 attribute [nolint doc_blame] monoid_with_zero_hom.to_zero_hom
 
-infixr ` →* `:25 := monoid_hom
+/-- `monoid_with_zero_hom_class F M N` states that `F` is a type of
+`monoid_with_zero`-preserving homomorphisms.
+
+You should also extend this typeclass when you extend `monoid_with_zero_hom`.
+-/
+class monoid_with_zero_hom_class (F : Type*) (M N : out_param $ Type*)
+  [mul_zero_one_class M] [mul_zero_one_class N]
+  extends monoid_hom_class F M N, zero_hom_class F M N
+
+instance monoid_with_zero_hom.monoid_with_zero_hom_class :
+  monoid_with_zero_hom_class (monoid_with_zero_hom M N) M N :=
+{ coe := monoid_with_zero_hom.to_fun,
+  coe_injective' := λ f g h, by cases f; cases g; congr',
+  map_mul := monoid_with_zero_hom.map_mul',
+  map_one := monoid_with_zero_hom.map_one',
+  map_zero := monoid_with_zero_hom.map_zero' }
+
+end mul_zero_one
 
 -- completely uninteresting lemmas about coercion to function, that all homs need
 section coes
@@ -146,6 +358,7 @@ lemma monoid_with_zero_hom.coe_eq_to_zero_hom
   {mM : mul_zero_one_class M} {mN : mul_zero_one_class N} (f : monoid_with_zero_hom M N) :
   (f : zero_hom M N) = f.to_zero_hom := rfl
 
+-- Fallback `has_coe_to_fun` instances to help the elaborator
 @[to_additive]
 instance {mM : has_one M} {mN : has_one N} : has_coe_to_fun (one_hom M N) (λ _, M → N) :=
 ⟨one_hom.to_fun⟩
@@ -182,16 +395,16 @@ lemma monoid_with_zero_hom.to_fun_eq_coe [mul_zero_one_class M] [mul_zero_one_cl
 
 @[simp, to_additive]
 lemma one_hom.coe_mk [has_one M] [has_one N]
-  (f : M → N) (h1) : ⇑(one_hom.mk f h1) = f := rfl
+  (f : M → N) (h1) : (one_hom.mk f h1 : M → N) = f := rfl
 @[simp, to_additive]
 lemma mul_hom.coe_mk [has_mul M] [has_mul N]
-  (f : M → N) (hmul) : ⇑(mul_hom.mk f hmul) = f := rfl
+  (f : M → N) (hmul) : (mul_hom.mk f hmul : M → N) = f := rfl
 @[simp, to_additive]
 lemma monoid_hom.coe_mk [mul_one_class M] [mul_one_class N]
-  (f : M → N) (h1 hmul) : ⇑(monoid_hom.mk f h1 hmul) = f := rfl
+  (f : M → N) (h1 hmul) : (monoid_hom.mk f h1 hmul : M → N) = f := rfl
 @[simp]
 lemma monoid_with_zero_hom.coe_mk [mul_zero_one_class M] [mul_zero_one_class N]
-  (f : M → N) (h0 h1 hmul) : ⇑(monoid_with_zero_hom.mk f h0 h1 hmul) = f := rfl
+  (f : M → N) (h0 h1 hmul) : (monoid_with_zero_hom.mk f h0 h1 hmul : M → N) = f := rfl
 
 @[simp, to_additive]
 lemma monoid_hom.to_one_hom_coe [mul_one_class M] [mul_one_class N] (f : M →* N) :
@@ -302,30 +515,28 @@ monoid_with_zero_hom.ext $ λ _, rfl
 
 end coes
 
-@[simp, to_additive]
-lemma one_hom.map_one [has_one M] [has_one N] (f : one_hom M N) : f 1 = 1 := f.map_one'
+@[to_additive]
+protected lemma one_hom.map_one [has_one M] [has_one N] (f : one_hom M N) : f 1 = 1 := f.map_one'
 /-- If `f` is a monoid homomorphism then `f 1 = 1`. -/
-@[simp, to_additive]
-lemma monoid_hom.map_one [mul_one_class M] [mul_one_class N] (f : M →* N) : f 1 = 1 := f.map_one'
-@[simp]
-lemma monoid_with_zero_hom.map_one [mul_zero_one_class M] [mul_zero_one_class N]
+@[to_additive]
+protected lemma monoid_hom.map_one [mul_one_class M] [mul_one_class N] (f : M →* N) :
+  f 1 = 1 := f.map_one'
+protected lemma monoid_with_zero_hom.map_one [mul_zero_one_class M] [mul_zero_one_class N]
   (f : monoid_with_zero_hom M N) : f 1 = 1 := f.map_one'
 
 /-- If `f` is an additive monoid homomorphism then `f 0 = 0`. -/
 add_decl_doc add_monoid_hom.map_zero
-@[simp]
-lemma monoid_with_zero_hom.map_zero [mul_zero_one_class M] [mul_zero_one_class N]
+protected lemma monoid_with_zero_hom.map_zero [mul_zero_one_class M] [mul_zero_one_class N]
   (f : monoid_with_zero_hom M N) : f 0 = 0 := f.map_zero'
 
-@[simp, to_additive]
-lemma mul_hom.map_mul [has_mul M] [has_mul N]
+@[to_additive]
+protected lemma mul_hom.map_mul [has_mul M] [has_mul N]
   (f : mul_hom M N) (a b : M) : f (a * b) = f a * f b := f.map_mul' a b
 /-- If `f` is a monoid homomorphism then `f (a * b) = f a * f b`. -/
-@[simp, to_additive]
-lemma monoid_hom.map_mul [mul_one_class M] [mul_one_class N]
+@[to_additive]
+protected lemma monoid_hom.map_mul [mul_one_class M] [mul_one_class N]
   (f : M →* N) (a b : M) : f (a * b) = f a * f b := f.map_mul' a b
-@[simp]
-lemma monoid_with_zero_hom.map_mul [mul_zero_one_class M] [mul_zero_one_class N]
+protected lemma monoid_with_zero_hom.map_mul [mul_zero_one_class M] [mul_zero_one_class N]
   (f :  monoid_with_zero_hom M N) (a b : M) : f (a * b) = f a * f b := f.map_mul' a b
 
 /-- If `f` is an additive monoid homomorphism then `f (a + b) = f a + f b`. -/
@@ -339,7 +550,7 @@ include mM mN
 
 @[to_additive]
 lemma map_mul_eq_one (f : M →* N) {a b : M} (h : a * b = 1) : f a * f b = 1 :=
-by rw [← f.map_mul, h, f.map_one]
+map_mul_eq_one f h
 
 /-- Given a monoid homomorphism `f : M →* N` and an element `x : M`, if `x` has a right inverse,
 then `f x` has a right inverse too. For elements invertible on both sides see `is_unit.map`. -/
@@ -704,13 +915,13 @@ by { ext, simp only [mul_apply, function.comp_app, map_mul, coe_comp] }
 then they are equal at `-x`." ]
 lemma eq_on_inv {G} [group G] [monoid M] {f g : G →* M} {x : G} (h : f x = g x) :
   f x⁻¹ = g x⁻¹ :=
-left_inv_eq_right_inv (f.map_mul_eq_one $ inv_mul_self x) $
+left_inv_eq_right_inv (map_mul_eq_one f $ inv_mul_self x) $
   h.symm ▸ g.map_mul_eq_one $ mul_inv_self x
 
 /-- Group homomorphisms preserve inverse. -/
-@[simp, to_additive]
-theorem map_inv {G H} [group G] [group H] (f : G →* H) (g : G) : f g⁻¹ = (f g)⁻¹ :=
-eq_inv_of_mul_eq_one $ f.map_mul_eq_one $ inv_mul_self g
+@[to_additive]
+protected theorem map_inv {G H} [group G] [group H] (f : G →* H) (g : G) : f g⁻¹ = (f g)⁻¹ :=
+map_inv f g
 
 /-- Group homomorphisms preserve integer power. -/
 @[simp, to_additive /-" Additive group homomorphisms preserve integer scaling. "-/]
@@ -718,14 +929,16 @@ theorem map_zpow {G H} [group G] [group H] (f : G →* H) (g : G) (n : ℤ) : f 
 f.map_zpow' f.map_inv g n
 
 /-- Group homomorphisms preserve division. -/
-@[simp, to_additive]
-theorem map_mul_inv {G H} [group G] [group H] (f : G →* H) (g h : G) :
-  f (g * h⁻¹) = (f g) * (f h)⁻¹ := by rw [f.map_mul, f.map_inv]
+@[to_additive /-" Additive group homomorphisms preserve subtraction. "-/]
+protected theorem map_div {G H} [group G] [group H] (f : G →* H) (g h : G) :
+  f (g / h) = f g / f h :=
+map_div f g h
 
 /-- Group homomorphisms preserve division. -/
-@[simp, to_additive /-" Additive group homomorphisms preserve subtraction. "-/]
-theorem map_div {G H} [group G] [group H] (f : G →* H) (g h : G) : f (g / h) = (f g) / (f h) :=
-f.map_div' f.map_inv g h
+@[to_additive]
+protected theorem map_mul_inv {G H} [group G] [group H] (f : G →* H) (g h : G) :
+f (g * h⁻¹) = (f g) * (f h)⁻¹ :=
+map_mul_inv f g h
 
 /-- A homomorphism from a group to a monoid is injective iff its kernel is trivial.
 For the iff statement on the triviality of the kernel, see `monoid_hom.injective_iff'`.  -/

--- a/src/algebra/group/hom.lean
+++ b/src/algebra/group/hom.lean
@@ -939,7 +939,7 @@ map_div f g h
 /-- Group homomorphisms preserve division. -/
 @[to_additive]
 protected theorem map_mul_inv {G H} [group G] [group H] (f : G →* H) (g h : G) :
-f (g * h⁻¹) = (f g) * (f h)⁻¹ :=
+  f (g * h⁻¹) = (f g) * (f h)⁻¹ :=
 map_mul_inv f g h
 
 /-- A homomorphism from a group to a monoid is injective iff its kernel is trivial.

--- a/src/algebra/module/linear_map.lean
+++ b/src/algebra/module/linear_map.lean
@@ -161,20 +161,16 @@ theorem is_linear : is_linear_map R fₗ := ⟨fₗ.map_add', fₗ.map_smul'⟩
 
 variables {fₗ gₗ f g σ}
 
--- TODO: can be replaced with `fun_like.coe_injective`
 theorem coe_injective : @injective (M →ₛₗ[σ] M₃) (M → M₃) coe_fn :=
 fun_like.coe_injective
 
--- TODO: can be replaced with `fun_like.congr_arg`
 protected lemma congr_arg {x x' : M} : x = x' → f x = f x' :=
 fun_like.congr_arg f
 
--- TODO: can be replaced with `fun_like.congr_fun`
 /-- If two linear maps are equal, they are equal at each point. -/
 protected lemma congr_fun (h : f = g) (x : M) : f x = g x :=
 fun_like.congr_fun h x
 
--- TODO: can be replaced with `fun_like.ext_iff`
 theorem ext_iff : f = g ↔ ∀ x, f x = g x :=
 fun_like.ext_iff
 

--- a/src/algebra/module/linear_map.lean
+++ b/src/algebra/module/linear_map.lean
@@ -106,12 +106,32 @@ section
 variables [add_comm_monoid M] [add_comm_monoid M₁] [add_comm_monoid M₂] [add_comm_monoid M₃]
 variables [add_comm_monoid N₁] [add_comm_monoid N₂] [add_comm_monoid N₃]
 variables [module R M] [module R M₂] [module S M₃]
+variables {σ : R →+* S}
+
+instance : add_monoid_hom_class (M →ₛₗ[σ] M₃) M M₃ :=
+{ coe := linear_map.to_fun,
+  coe_injective' := λ f g h, by cases f; cases g; congr',
+  map_add := linear_map.map_add',
+  map_zero := λ f, show f.to_fun 0 = 0, by { rw [← zero_smul R (0 : M), f.map_smul'], simp } }
 
 /-- The `distrib_mul_action_hom` underlying a `linear_map`. -/
 def to_distrib_mul_action_hom (f : M →ₗ[R] M₂) : distrib_mul_action_hom R M M₂ :=
-{ map_zero' := zero_smul R (0 : M) ▸ zero_smul R (f.to_fun 0) ▸ f.map_smul' 0 0, ..f }
+{ map_zero' := show f 0 = 0, from map_zero f, ..f }
 
-instance {σ : R →+* S} : has_coe_to_fun (M →ₛₗ[σ] M₃) (λ _, M → M₃) := ⟨linear_map.to_fun⟩
+/-- Helper instance for when there's too many metavariables to apply `to_fun.to_coe_fn` directly.
+-/
+instance : has_coe_to_fun (M →ₛₗ[σ] M₃) (λ _, M → M₃) := ⟨linear_map.to_fun⟩
+
+@[simp] lemma to_fun_eq_coe {f : M →ₛₗ[σ] M₃} : f.to_fun = (f : M → M₃) := rfl
+
+@[ext] theorem ext {f g : M →ₛₗ[σ] M₃} (h : ∀ x, f x = g x) : f = g := fun_like.ext f g h
+
+/-- Copy of a `linear_map` with a new `to_fun` equal to the old one. Useful to fix definitional
+equalities. -/
+protected def copy (f : M →ₛₗ[σ] M₃) (f' : M → M₃) (h : f' = ⇑f) : M →ₛₗ[σ] M₃ :=
+{ to_fun := f',
+  map_add' := h.symm ▸ f.map_add',
+  map_smul' := h.symm ▸ f.map_smul' }
 
 initialize_simps_projections linear_map (to_fun → apply)
 
@@ -137,33 +157,33 @@ variables [module R M] [module R M₂] [module S M₃]
 variables (σ : R →+* S)
 variables (fₗ gₗ : M →ₗ[R] M₂) (f g : M →ₛₗ[σ] M₃)
 
-@[simp] lemma to_fun_eq_coe : f.to_fun = ⇑f := rfl
-
 theorem is_linear : is_linear_map R fₗ := ⟨fₗ.map_add', fₗ.map_smul'⟩
 
 variables {fₗ gₗ f g σ}
 
+-- TODO: can be replaced with `fun_like.coe_injective`
 theorem coe_injective : @injective (M →ₛₗ[σ] M₃) (M → M₃) coe_fn :=
-by rintro ⟨f, _⟩ ⟨g, _⟩ ⟨h⟩; congr
+fun_like.coe_injective
 
-@[ext] theorem ext (H : ∀ x, f x = g x) : f = g :=
-coe_injective $ funext H
+-- TODO: can be replaced with `fun_like.congr_arg`
+protected lemma congr_arg {x x' : M} : x = x' → f x = f x' :=
+fun_like.congr_arg f
 
-protected lemma congr_arg : Π {x x' : M}, x = x' → f x = f x'
-| _ _ rfl := rfl
-
+-- TODO: can be replaced with `fun_like.congr_fun`
 /-- If two linear maps are equal, they are equal at each point. -/
-protected lemma congr_fun (h : f = g) (x : M) : f x = g x := h ▸ rfl
+protected lemma congr_fun (h : f = g) (x : M) : f x = g x :=
+fun_like.congr_fun h x
 
+-- TODO: can be replaced with `fun_like.ext_iff`
 theorem ext_iff : f = g ↔ ∀ x, f x = g x :=
-⟨by { rintro rfl x, refl }, ext⟩
+fun_like.ext_iff
 
 @[simp] lemma mk_coe (f : M →ₛₗ[σ] M₃) (h₁ h₂) :
   (linear_map.mk f h₁ h₂ : M →ₛₗ[σ] M₃) = f := ext $ λ _, rfl
 
 variables (fₗ gₗ f g)
 
-@[simp] lemma map_add (x y : M) : f (x + y) = f x + f y := f.map_add' x y
+protected lemma map_add (x y : M) : f (x + y) = f x + f y := map_add f x y
 
 @[simp] lemma map_smulₛₗ (c : R) (x : M) : f (c • x) = (σ c) • f x := f.map_smul' c x
 
@@ -173,9 +193,9 @@ lemma map_smul_inv {σ' : S →+* R} [ring_hom_inv_pair σ σ'] (c : S) (x : M) 
   c • f x = f (σ' c • x) :=
 by simp
 
-@[simp] lemma map_zero : f 0 = 0 :=
-by { rw [←zero_smul R (0 : M), map_smulₛₗ], simp }
+protected lemma map_zero : f 0 = 0 := map_zero f
 
+-- TODO: generalize to `zero_hom_class`
 @[simp] lemma map_eq_zero_iff (h : function.injective f) {x : M} : f x = 0 ↔ x = 0 :=
 ⟨λ w, by { apply h, simp [w], }, λ w, by { subst w, simp, }⟩
 
@@ -320,11 +340,9 @@ variables [semiring R] [semiring S] [add_comm_group M] [add_comm_group M₂]
 variables {module_M : module R M} {module_M₂ : module S M₂} {σ : R →+* S}
 variables (f : M →ₛₗ[σ] M₂)
 
-@[simp] lemma map_neg (x : M) : f (- x) = - f x :=
-f.to_add_monoid_hom.map_neg x
+protected lemma map_neg (x : M) : f (- x) = - f x := map_neg f x
 
-@[simp] lemma map_sub (x y : M) : f (x - y) = f x - f y :=
-f.to_add_monoid_hom.map_sub x y
+protected lemma map_sub (x y : M) : f (x - y) = f x - f y := map_sub f x y
 
 instance compatible_smul.int_module
   {S : Type*} [semiring S] [module S M] [module S M₂] : compatible_smul M M₂ ℤ S :=

--- a/src/algebra/ring/basic.lean
+++ b/src/algebra/ring/basic.lean
@@ -356,6 +356,20 @@ variables {rα : non_assoc_semiring α} {rβ : non_assoc_semiring β}
 
 include rα rβ
 
+instance : add_monoid_hom_class (α →+* β) α β :=
+{ coe := ring_hom.to_fun,
+  coe_injective' := λ f g h, by cases f; cases g; congr',
+  map_add := ring_hom.map_add',
+  map_zero := ring_hom.map_zero' }
+
+instance : monoid_hom_class (α →+* β) α β :=
+{ coe := ring_hom.to_fun,
+  coe_injective' := λ f g h, by cases f; cases g; congr',
+  map_mul := ring_hom.map_mul',
+  map_one := ring_hom.map_one' }
+
+/-- Helper instance for when there's too many metavariables to apply `to_fun.to_coe_fn` directly.
+-/
 instance : has_coe_to_fun (α →+* β) (λ _, α → β) := ⟨ring_hom.to_fun⟩
 
 initialize_simps_projections ring_hom (to_fun → apply)
@@ -420,16 +434,16 @@ theorem coe_monoid_hom_injective : function.injective (coe : (α →+* β) → (
 λ f g h, ext (λ x, monoid_hom.congr_fun h x)
 
 /-- Ring homomorphisms map zero to zero. -/
-@[simp] lemma map_zero (f : α →+* β) : f 0 = 0 := f.map_zero'
+protected lemma map_zero (f : α →+* β) : f 0 = 0 := map_zero f
 
 /-- Ring homomorphisms map one to one. -/
-@[simp] lemma map_one (f : α →+* β) : f 1 = 1 := f.map_one'
+protected lemma map_one (f : α →+* β) : f 1 = 1 := map_one f
 
 /-- Ring homomorphisms preserve addition. -/
-@[simp] lemma map_add (f : α →+* β) (a b : α) : f (a + b) = f a + f b := f.map_add' a b
+protected lemma map_add (f : α →+* β) (a b : α) : f (a + b) = f a + f b := map_add f a b
 
 /-- Ring homomorphisms preserve multiplication. -/
-@[simp] lemma map_mul (f : α →+* β) (a b : α) : f (a * b) = f a * f b := f.map_mul' a b
+protected lemma map_mul (f : α →+* β) (a b : α) : f (a * b) = f a * f b := map_mul f a b
 
 /-- Ring homomorphisms preserve `bit0`. -/
 @[simp] lemma map_bit0 (f : α →+* β) (a : α) : f (bit0 a) = bit0 (f a) := map_add _ _ _
@@ -740,12 +754,12 @@ lemma is_unit.neg_iff [ring α] (a : α) : is_unit (-a) ↔ is_unit a :=
 namespace ring_hom
 
 /-- Ring homomorphisms preserve additive inverse. -/
-@[simp] theorem map_neg {α β} [ring α] [ring β] (f : α →+* β) (x : α) : f (-x) = -(f x) :=
-(f : α →+ β).map_neg x
+protected theorem map_neg {α β} [ring α] [ring β] (f : α →+* β) (x : α) : f (-x) = -(f x) :=
+map_neg f x
 
 /-- Ring homomorphisms preserve subtraction. -/
-@[simp] theorem map_sub {α β} [ring α] [ring β] (f : α →+* β) (x y : α) :
-  f (x - y) = (f x) - (f y) := (f : α →+ β).map_sub x y
+protected theorem map_sub {α β} [ring α] [ring β] (f : α →+* β) (x y : α) :
+  f (x - y) = (f x) - (f y) := map_sub f x y
 
 /-- A ring homomorphism is injective iff its kernel is trivial. -/
 theorem injective_iff {α β} [ring α] [non_assoc_semiring β] (f : α →+* β) :

--- a/src/algebra/ring/basic.lean
+++ b/src/algebra/ring/basic.lean
@@ -344,6 +344,30 @@ add_decl_doc ring_hom.to_monoid_hom
 The `simp`-normal form is `(f : R →+ S)`. -/
 add_decl_doc ring_hom.to_add_monoid_hom
 
+section ring_hom_class
+
+/-- `ring_hom_class F R S` states that `F` is a type of (semi)ring homomorphisms.
+You should extend this class when you extend `ring_hom`.
+
+This extends from both `monoid_hom_class` and `monoid_with_zero_hom_class` in
+order to put the fields in a sensible order, even though
+`monoid_with_zero_hom_class` already extends `monoid_hom_class`. -/
+class ring_hom_class (F : Type*) (R S : out_param Type*)
+  [non_assoc_semiring R] [non_assoc_semiring S]
+  extends monoid_hom_class F R S, add_monoid_hom_class F R S, monoid_with_zero_hom_class F R S
+
+variables {F : Type*} [non_assoc_semiring α] [non_assoc_semiring β] [ring_hom_class F α β]
+
+/-- Ring homomorphisms preserve `bit0`. -/
+@[simp] lemma map_bit0 (f : F) (a : α) : (f (bit0 a) : β) = bit0 (f a) :=
+map_add _ _ _
+
+/-- Ring homomorphisms preserve `bit1`. -/
+@[simp] lemma map_bit1 (f : F) (a : α) : (f (bit1 a) : β) = bit1 (f a) :=
+by simp [bit1]
+
+end ring_hom_class
+
 namespace ring_hom
 
 section coe
@@ -356,15 +380,11 @@ variables {rα : non_assoc_semiring α} {rβ : non_assoc_semiring β}
 
 include rα rβ
 
-instance : add_monoid_hom_class (α →+* β) α β :=
+instance : ring_hom_class (α →+* β) α β :=
 { coe := ring_hom.to_fun,
   coe_injective' := λ f g h, by cases f; cases g; congr',
   map_add := ring_hom.map_add',
-  map_zero := ring_hom.map_zero' }
-
-instance : monoid_hom_class (α →+* β) α β :=
-{ coe := ring_hom.to_fun,
-  coe_injective' := λ f g h, by cases f; cases g; congr',
+  map_zero := ring_hom.map_zero',
   map_mul := ring_hom.map_mul',
   map_one := ring_hom.map_one' }
 
@@ -410,19 +430,19 @@ include rα rβ
 variables (f : α →+* β) {x y : α} {rα rβ}
 
 theorem congr_fun {f g : α →+* β} (h : f = g) (x : α) : f x = g x :=
-congr_arg (λ h : α →+* β, h x) h
+fun_like.congr_fun h x
 
 theorem congr_arg (f : α →+* β) {x y : α} (h : x = y) : f x = f y :=
-congr_arg (λ x : α, f x) h
+fun_like.congr_arg f h
 
 theorem coe_inj ⦃f g : α →+* β⦄ (h : (f : α → β) = g) : f = g :=
-by cases f; cases g; cases h; refl
+fun_like.coe_injective h
 
 @[ext] theorem ext ⦃f g : α →+* β⦄ (h : ∀ x, f x = g x) : f = g :=
-coe_inj (funext h)
+fun_like.ext _ _ h
 
 theorem ext_iff {f g : α →+* β} : f = g ↔ ∀ x, f x = g x :=
-⟨λ h x, h ▸ rfl, λ h, ext h⟩
+fun_like.ext_iff
 
 @[simp] lemma mk_coe (f : α →+* β) (h₁ h₂ h₃ h₄) : ring_hom.mk f h₁ h₂ h₃ h₄ = f :=
 ext $ λ _, rfl
@@ -446,10 +466,10 @@ protected lemma map_add (f : α →+* β) (a b : α) : f (a + b) = f a + f b := 
 protected lemma map_mul (f : α →+* β) (a b : α) : f (a * b) = f a * f b := map_mul f a b
 
 /-- Ring homomorphisms preserve `bit0`. -/
-@[simp] lemma map_bit0 (f : α →+* β) (a : α) : f (bit0 a) = bit0 (f a) := map_add _ _ _
+protected lemma map_bit0 (f : α →+* β) (a : α) : f (bit0 a) = bit0 (f a) := map_add _ _ _
 
 /-- Ring homomorphisms preserve `bit1`. -/
-@[simp] lemma map_bit1 (f : α →+* β) (a : α) : f (bit1 a) = bit1 (f a) :=
+protected lemma map_bit1 (f : α →+* β) (a : α) : f (bit1 a) = bit1 (f a) :=
 by simp [bit1]
 
 /-- `f : R →+* S` has a trivial codomain iff `f 1 = 0`. -/

--- a/src/analysis/complex/basic.lean
+++ b/src/analysis/complex/basic.lean
@@ -216,7 +216,9 @@ end
 lemma has_sum_iff {α} (f : α → ℂ) (c : ℂ) :
   has_sum f c ↔ has_sum (λ x, (f x).re) c.re ∧ has_sum (λ x, (f x).im) c.im :=
 begin
-  refine ⟨λ h, ⟨h.mapL re_clm, h.mapL im_clm⟩, _⟩,
+  -- For some reason, `continuous_linear_map.has_sum` is orders of magnitude faster than
+  -- `has_sum.mapL` here:
+  refine ⟨λ h, ⟨re_clm.has_sum h, im_clm.has_sum h⟩, _⟩,
   rintro ⟨h₁, h₂⟩,
   convert (h₁.prod_mk h₂).mapL equiv_real_prodₗ.symm.to_continuous_linear_map,
   { ext x; refl },

--- a/src/analysis/normed_space/bounded_linear_maps.lean
+++ b/src/analysis/normed_space/bounded_linear_maps.lean
@@ -88,7 +88,7 @@ def to_linear_map (f : E → F) (h : is_bounded_linear_map 𝕜 f) : E →ₗ[�
 
 /-- Construct a continuous linear map from is_bounded_linear_map -/
 def to_continuous_linear_map {f : E → F} (hf : is_bounded_linear_map 𝕜 f) : E →L[𝕜] F :=
-{ cont := let ⟨C, Cpos, hC⟩ := hf.bound in linear_map.continuous_of_bound _ C hC,
+{ cont := let ⟨C, Cpos, hC⟩ := hf.bound in (to_linear_map f hf).continuous_of_bound C hC,
   ..to_linear_map f hf}
 
 lemma zero : is_bounded_linear_map 𝕜 (λ (x:E), (0:F)) :=

--- a/src/analysis/normed_space/dual.lean
+++ b/src/analysis/normed_space/dual.lean
@@ -38,6 +38,8 @@ variables (F : Type*) [normed_group F] [normed_space 𝕜 F]
 /-- The topological dual of a seminormed space `E`. -/
 @[derive [inhabited, semi_normed_group, semi_normed_space 𝕜]] def dual := E →L[𝕜] 𝕜
 
+instance : add_monoid_hom_class (dual 𝕜 E) E 𝕜 := continuous_linear_map.add_monoid_hom_class
+
 instance : has_coe_to_fun (dual 𝕜 E) (λ _, E → 𝕜) := continuous_linear_map.to_fun
 
 instance : normed_group (dual 𝕜 F) := continuous_linear_map.to_normed_group

--- a/src/analysis/normed_space/finite_dimension.lean
+++ b/src/analysis/normed_space/finite_dimension.lean
@@ -153,7 +153,7 @@ lemma continuous_equiv_fun_basis {ι : Type v} [fintype ι] (ξ : basis ι 𝕜 
   continuous ξ.equiv_fun :=
 begin
   unfreezingI { induction hn : fintype.card ι with n IH generalizing ι E },
-  { apply linear_map.continuous_of_bound _ 0 (λx, _),
+  { apply ξ.equiv_fun.to_linear_map.continuous_of_bound 0 (λx, _),
     have : ξ.equiv_fun x = 0,
       by { ext i, exact (fintype.card_eq_zero_iff.1 hn).elim i },
     change ∥ξ.equiv_fun x∥ ≤ 0 * ∥x∥,
@@ -169,7 +169,8 @@ begin
       { have : fintype.card (basis.of_vector_space_index 𝕜 s) = n,
           by { rw ← s_dim, exact (finrank_eq_card_basis b).symm },
         have : continuous b.equiv_fun := IH b this,
-        exact b.equiv_fun.symm.uniform_embedding (linear_map.continuous_on_pi _) this },
+        exact b.equiv_fun.symm.uniform_embedding b.equiv_fun.symm.to_linear_map.continuous_on_pi
+          this },
       have : is_complete (s : set E),
         from complete_space_coe_iff_is_complete.1 ((complete_space_congr U).1 (by apply_instance)),
       exact this.is_closed },
@@ -209,7 +210,7 @@ begin
     have C_nonneg : 0 ≤ C := finset.sum_nonneg (λi hi, (hC0 i).1),
     have C0_le : ∀i, C0 i ≤ C :=
       λi, finset.single_le_sum (λj hj, (hC0 j).1) (finset.mem_univ _),
-    apply linear_map.continuous_of_bound _ C (λx, _),
+    apply ξ.equiv_fun.to_linear_map.continuous_of_bound C (λx, _),
     rw pi_semi_norm_le_iff,
     { exact λi, le_trans ((hC0 i).2 x) (mul_le_mul_of_nonneg_right (C0_le i) (norm_nonneg _)) },
     { exact mul_nonneg C_nonneg (norm_nonneg _) } }
@@ -355,11 +356,11 @@ functions from its basis indexing type to `𝕜`. -/
 def basis.equiv_funL (v : basis ι 𝕜 E) : E ≃L[𝕜] (ι → 𝕜) :=
 { continuous_to_fun := begin
     haveI : finite_dimensional 𝕜 E := finite_dimensional.of_fintype_basis v,
-    apply linear_map.continuous_of_finite_dimensional,
+    exact v.equiv_fun.to_linear_map.continuous_of_finite_dimensional,
   end,
   continuous_inv_fun := begin
     change continuous v.equiv_fun.symm.to_fun,
-    apply linear_map.continuous_of_finite_dimensional,
+    exact v.equiv_fun.symm.to_linear_map.continuous_of_finite_dimensional,
   end,
   ..v.equiv_fun }
 

--- a/src/category_theory/preadditive/default.lean
+++ b/src/category_theory/preadditive/default.lean
@@ -123,11 +123,11 @@ map_sub (right_comp P g) f f'
 map_sub (left_comp R f) g g'
 
 @[simp, reassoc] lemma neg_comp : (-f) ≫ g = -(f ≫ g) :=
-map_neg (right_comp _ _) _
+map_neg (right_comp P g) f
 
 /- The redundant simp lemma linter says that simp can prove the reassoc version of this lemma. -/
 @[reassoc, simp] lemma comp_neg : f ≫ (-g) = -(f ≫ g) :=
-map_neg (left_comp _ _) _
+map_neg (left_comp R f) g
 
 @[reassoc] lemma neg_comp_neg : (-f) ≫ (-g) = f ≫ g :=
 by simp
@@ -161,8 +161,8 @@ instance {P Q : C} {f : P ⟶ Q} [mono f] : mono (-f) :=
 @[priority 100]
 instance preadditive_has_zero_morphisms : has_zero_morphisms C :=
 { has_zero := infer_instance,
-  comp_zero' := λ P Q f R, map_zero $ left_comp R f,
-  zero_comp' := λ P Q R f, map_zero $ right_comp P f }
+  comp_zero' := λ P Q f R, show left_comp R f 0 = 0, from map_zero _,
+  zero_comp' := λ P Q R f, show right_comp P f 0 = 0, from map_zero _ }
 
 lemma mono_of_cancel_zero {Q R : C} (f : Q ⟶ R) (h : ∀ {P : C} (g : P ⟶ Q), g ≫ f = 0 → g = 0) :
   mono f :=

--- a/src/data/equiv/module.lean
+++ b/src/data/equiv/module.lean
@@ -101,9 +101,15 @@ lemma to_linear_map_injective :
   (e₁ : M →ₛₗ[σ] M₂) = e₂ ↔ e₁ = e₂ :=
 to_linear_map_injective.eq_iff
 
+instance : add_monoid_hom_class (M ≃ₛₗ[σ] M₂) M M₂ :=
+{ coe := linear_equiv.to_fun,
+  coe_injective' := λ f g h, to_linear_map_injective (fun_like.coe_injective h),
+  map_add := linear_equiv.map_add',
+  map_zero := λ f, f.to_linear_map.map_zero }
+
 lemma coe_injective :
   @injective (M ≃ₛₗ[σ] M₂) (M → M₂) coe_fn :=
-linear_map.coe_injective.comp to_linear_map_injective
+fun_like.coe_injective
 
 end
 
@@ -128,16 +134,13 @@ lemma to_linear_map_eq_coe : e.to_linear_map = (e : M →ₛₗ[σ] M₂) := rfl
 
 section
 variables {e e'}
-@[ext] lemma ext (h : ∀ x, e x = e' x) : e = e' :=
-coe_injective $ funext h
+@[ext] lemma ext (h : ∀ x, e x = e' x) : e = e' := fun_like.ext _ _ h
 
-protected lemma congr_arg : Π {x x' : M}, x = x' → e x = e x'
-| _ _ rfl := rfl
+lemma ext_iff : e = e' ↔ ∀ x, e x = e' x := fun_like.ext_iff
 
-protected lemma congr_fun (h : e = e') (x : M) : e x = e' x := h ▸ rfl
+protected lemma congr_arg {x x'} : x = x' → e x = e x' := fun_like.congr_arg e
 
-lemma ext_iff : e = e' ↔ ∀ x, e x = e' x :=
-⟨λ h x, h ▸ rfl, ext⟩
+protected lemma congr_fun (h : e = e') (x : M) : e x = e' x := fun_like.congr_fun h x
 
 end
 
@@ -257,8 +260,8 @@ rfl
 @[simp] lemma mk_coe (h₁ h₂ f h₃ h₄) :
   (linear_equiv.mk e h₁ h₂ f h₃ h₄ : M ≃ₛₗ[σ] M₂) = e := ext $ λ _, rfl
 
-@[simp] theorem map_add (a b : M) : e (a + b) = e a + e b := e.map_add' a b
-@[simp] theorem map_zero : e 0 = 0 := e.to_linear_map.map_zero
+protected theorem map_add (a b : M) : e (a + b) = e a + e b := map_add e a b
+protected theorem map_zero : e 0 = 0 := map_zero e
 @[simp] theorem map_smulₛₗ (c : R) (x : M) : e (c • x) = (σ c) • e x := e.map_smul' c x
 
 include module_N₁ module_N₂

--- a/src/linear_algebra/dual.lean
+++ b/src/linear_algebra/dual.lean
@@ -49,6 +49,9 @@ variables [comm_semiring R] [add_comm_monoid M] [module R M]
 instance {S : Type*} [comm_ring S] {N : Type*} [add_comm_group N] [module S N] :
   add_comm_group (dual S N) := by {unfold dual, apply_instance}
 
+instance : add_monoid_hom_class (dual R M) M R :=
+linear_map.add_monoid_hom_class
+
 namespace dual
 
 instance : inhabited (dual R M) := by dunfold dual; apply_instance

--- a/src/linear_algebra/multilinear/basic.lean
+++ b/src/linear_algebra/multilinear/basic.lean
@@ -114,7 +114,7 @@ theorem ext_iff {f g : multilinear_map R M₁ M₂} : f = g ↔ ∀ x, f x = g x
   (⟨f, h₁, h₂⟩ : multilinear_map R M₁ M₂) = f :=
 by { ext, refl, }
 
-@[simp] lemma map_add (m : Πi, M₁ i) (i : ι) (x y : M₁ i) :
+@[simp] protected lemma map_add (m : Πi, M₁ i) (i : ι) (x y : M₁ i) :
   f (update m i (x + y)) = f (update m i x) + f (update m i y) :=
 f.map_add' m i x y
 
@@ -796,7 +796,7 @@ instance : has_neg (multilinear_map R M₁ M₂) :=
 instance : has_sub (multilinear_map R M₁ M₂) :=
 ⟨λ f g,
   ⟨λ m, f m - g m,
-   λ m i x y, by { simp only [map_add, sub_eq_add_neg, neg_add], cc },
+   λ m i x y, by { simp only [multilinear_map.map_add, sub_eq_add_neg, neg_add], cc },
    λ m i c x, by { simp only [map_smul, smul_sub] }⟩⟩
 
 @[simp] lemma sub_apply (m : Πi, M₁ i) : (f - g) m = f m - g m := rfl
@@ -826,11 +826,12 @@ variables [semiring R] [∀i, add_comm_group (M₁ i)] [add_comm_group M₂]
 
 @[simp] lemma map_neg (m : Πi, M₁ i) (i : ι) (x : M₁ i) :
   f (update m i (-x)) = -f (update m i x) :=
-eq_neg_of_add_eq_zero $ by rw [←map_add, add_left_neg, f.map_coord_zero i (update_same i 0 m)]
+eq_neg_of_add_eq_zero $ by rw [←multilinear_map.map_add, add_left_neg,
+  f.map_coord_zero i (update_same i 0 m)]
 
 @[simp] lemma map_sub (m : Πi, M₁ i) (i : ι) (x y : M₁ i) :
   f (update m i (x - y)) = f (update m i x) - f (update m i y) :=
-by rw [sub_eq_add_neg, sub_eq_add_neg, map_add, map_neg]
+by rw [sub_eq_add_neg, sub_eq_add_neg, multilinear_map.map_add, map_neg]
 
 end add_comm_group
 
@@ -892,7 +893,7 @@ def linear_map.uncurry_left
       revert x y,
       rw ← succ_pred i h,
       assume x y,
-      rw [tail_update_succ, map_add, tail_update_succ, tail_update_succ] }
+      rw [tail_update_succ, multilinear_map.map_add, tail_update_succ, tail_update_succ] }
   end,
   map_smul' := λm i c x, begin
     by_cases h : i = 0,
@@ -976,8 +977,8 @@ def multilinear_map.uncurry_right
       revert x y,
       rw [(cast_succ_cast_lt i h).symm],
       assume x y,
-      rw [init_update_cast_succ, map_add, init_update_cast_succ, init_update_cast_succ,
-          linear_map.add_apply] },
+      rw [init_update_cast_succ, multilinear_map.map_add, init_update_cast_succ,
+        init_update_cast_succ, linear_map.add_apply] },
     { revert x y,
       rw eq_last_of_not_lt h,
       assume x y,
@@ -1088,7 +1089,7 @@ def uncurry_sum (f : multilinear_map R (λ x : ι, M') (multilinear_map R (λ x 
   multilinear_map R (λ x : ι ⊕ ι', M') M₂ :=
 { to_fun := λ u, f (u ∘ sum.inl) (u ∘ sum.inr),
   map_add' := λ u i x y, by cases i;
-    simp only [map_add, add_apply, sum.update_inl_comp_inl, sum.update_inl_comp_inr,
+    simp only [multilinear_map.map_add, add_apply, sum.update_inl_comp_inl, sum.update_inl_comp_inr,
       sum.update_inr_comp_inl, sum.update_inr_comp_inr],
   map_smul' := λ u i c x, by cases i;
     simp only [map_smul, smul_apply, sum.update_inl_comp_inl, sum.update_inl_comp_inr,

--- a/src/ring_theory/derivation.lean
+++ b/src/ring_theory/derivation.lean
@@ -49,7 +49,17 @@ variables {M : Type*} [add_cancel_comm_monoid M] [module A M] [module R M]
 variables [is_scalar_tower R A M]
 variables (D : derivation R A M) {D1 D2 : derivation R A M} (r : R) (a b : A)
 
+instance : add_monoid_hom_class (derivation R A M) A M :=
+{ coe := λ D, D.to_fun,
+  coe_injective' := λ D1 D2 h, by { cases D1, cases D2, congr, exact fun_like.coe_injective h },
+  map_add := λ D, D.to_linear_map.map_add',
+  map_zero := λ D, D.to_linear_map.map_zero }
+
+/-- Helper instance for when there's too many metavariables to apply `to_fun.to_coe_fn` directly. -/
 instance : has_coe_to_fun (derivation R A M) (λ _, A → M) := ⟨λ D, D.to_linear_map.to_fun⟩
+
+-- Not a simp lemma because it can be proved via `coe_fn_coe` + `to_linear_map_eq_coe`
+lemma to_fun_eq_coe : D.to_fun = ⇑D := rfl
 
 instance has_coe_to_linear_map : has_coe (derivation R A M) (A →ₗ[R] M) :=
 ⟨λ D, D.to_linear_map⟩
@@ -63,16 +73,16 @@ instance has_coe_to_linear_map : has_coe (derivation R A M) (A →ₗ[R] M) :=
 lemma coe_fn_coe (f : derivation R A M) : ⇑(f : A →ₗ[R] M) = f := rfl
 
 lemma coe_injective : @function.injective (derivation R A M) (A → M) coe_fn :=
-λ D1 D2 h, by { rcases D1 with ⟨⟨⟩⟩, rcases D2 with ⟨⟨⟩⟩, congr', }
+fun_like.coe_injective
 
 @[ext] theorem ext (H : ∀ a, D1 a = D2 a) : D1 = D2 :=
-coe_injective $ funext H
+fun_like.ext _ _ H
 
-lemma congr_fun (h : D1 = D2) (a : A) : D1 a = D2 a := congr_fun (congr_arg coe_fn h) a
+lemma congr_fun (h : D1 = D2) (a : A) : D1 a = D2 a := fun_like.congr_fun h a
 
-@[simp] lemma map_add : D (a + b) = D a + D b := linear_map.map_add D a b
-@[simp] lemma map_zero : D 0 = 0 := linear_map.map_zero D
-@[simp] lemma map_smul : D (r • a) = r • D a := linear_map.map_smul D r a
+protected lemma map_add : D (a + b) = D a + D b := map_add D a b
+protected lemma map_zero : D 0 = 0 := map_zero D
+@[simp] lemma map_smul : D (r • a) = r • D a := D.to_linear_map.map_smul r a
 @[simp] lemma leibniz : D (a * b) = a • D b + b • D a := D.leibniz' _ _
 
 @[simp] lemma map_one_eq_zero : D 1 = 0 :=
@@ -205,8 +215,8 @@ section
 variables {M : Type*} [add_comm_group M] [module A M] [module R M] [is_scalar_tower R A M]
 variables (D : derivation R A M) {D1 D2 : derivation R A M} (r : R) (a b : A)
 
-@[simp] lemma map_neg : D (-a) = -D a := linear_map.map_neg D a
-@[simp] lemma map_sub : D (a - b) = D a - D b := linear_map.map_sub D a b
+protected lemma map_neg : D (-a) = -D a := map_neg D a
+protected lemma map_sub : D (a - b) = D a - D b := map_sub D a b
 
 lemma leibniz_of_mul_eq_one {a b : A} (h : a * b = 1) : D a = -a^2 • D b :=
 begin

--- a/src/ring_theory/tensor_product.lean
+++ b/src/ring_theory/tensor_product.lean
@@ -166,9 +166,12 @@ linear_equiv.of_linear
   (lift $ tensor_product.uncurry A _ _ _ $ comp (lcurry R A _ _ _) $
     tensor_product.mk A M (P ⊗[R] N))
   (tensor_product.uncurry A _ _ _ $ comp (uncurry R A _ _ _) $
-    by apply tensor_product.curry; exact (mk R A _ _))
+    by { apply tensor_product.curry, exact (mk R A _ _) })
   (by { ext, refl, })
-  (by { ext, refl, })
+  (by { ext, simp only [curry_apply, tensor_product.curry_apply, mk_apply, tensor_product.mk_apply,
+              uncurry_apply, tensor_product.uncurry_apply, id_apply, lift_tmul, compr₂_apply,
+              restrict_scalars_apply, function.comp_app, to_fun_eq_coe, lcurry_apply,
+              linear_map.comp_apply] })
 
 end comm_semiring
 
@@ -564,27 +567,27 @@ def alg_equiv_of_linear_equiv_triple_tensor_product
   map_mul' := λ x y,
   begin
     apply tensor_product.induction_on x,
-    { simp, },
+    { simp only [map_zero, zero_mul] },
     { intros ab₁ c₁,
       apply tensor_product.induction_on y,
-      { simp, },
+      { simp only [map_zero, mul_zero] },
       { intros ab₂ c₂,
         apply tensor_product.induction_on ab₁,
-        { simp, },
+        { simp only [zero_tmul, map_zero, zero_mul] },
         { intros a₁ b₁,
           apply tensor_product.induction_on ab₂,
-          { simp, },
-          { simp [w₁], },
+          { simp only [zero_tmul, map_zero, mul_zero] },
+          { intros, simp only [tmul_mul_tmul, w₁] },
           { intros x₁ x₂ h₁ h₂,
-            simp at h₁ h₂,
-            simp [mul_add, add_tmul, h₁, h₂], }, },
+            simp only [tmul_mul_tmul] at h₁ h₂,
+            simp only [tmul_mul_tmul, mul_add, add_tmul, map_add, h₁, h₂] } },
         { intros x₁ x₂ h₁ h₂,
-          simp at h₁ h₂,
-          simp [add_mul, add_tmul, h₁, h₂], }, },
+          simp only [tmul_mul_tmul] at h₁ h₂,
+          simp only [tmul_mul_tmul, add_mul, add_tmul, map_add, h₁, h₂] } },
       { intros x₁ x₂ h₁ h₂,
-        simp [mul_add, add_mul, h₁, h₂], }, },
+        simp only [tmul_mul_tmul, map_add, mul_add, add_mul, h₁, h₂], }, },
     { intros x₁ x₂ h₁ h₂,
-      simp [mul_add, add_mul, h₁, h₂], }
+      simp only [tmul_mul_tmul, map_add, mul_add, add_mul, h₁, h₂], }
   end,
   commutes' := λ r, by simp [w₂],
   .. f }

--- a/src/tactic/elementwise.lean
+++ b/src/tactic/elementwise.lean
@@ -84,8 +84,6 @@ do
    CC_type ← instantiate_mvars CC_type,
    x_type ← to_expr ``(@coe_sort %%C _
      (@category_theory.concrete_category.has_coe_to_sort %%C %%S %%CC) %%X),
-    y_type ← to_expr ``(@coe_sort %%C _
-     (@category_theory.concrete_category.has_coe_to_sort %%C %%S %%CC) %%Y),
    x ← mk_local_def `x x_type,
    t' ← to_expr ``(@coe_fn (@quiver.hom %%C %%H %%X %%Y) _
      (@category_theory.concrete_category.has_coe_to_fun %%C %%S %%CC %%X %%Y) %%f %%x =

--- a/src/tactic/elementwise.lean
+++ b/src/tactic/elementwise.lean
@@ -84,6 +84,8 @@ do
    CC_type ← instantiate_mvars CC_type,
    x_type ← to_expr ``(@coe_sort %%C _
      (@category_theory.concrete_category.has_coe_to_sort %%C %%S %%CC) %%X),
+    y_type ← to_expr ``(@coe_sort %%C _
+     (@category_theory.concrete_category.has_coe_to_sort %%C %%S %%CC) %%Y),
    x ← mk_local_def `x x_type,
    t' ← to_expr ``(@coe_fn (@quiver.hom %%C %%H %%X %%Y) _
      (@category_theory.concrete_category.has_coe_to_fun %%C %%S %%CC %%X %%Y) %%f %%x =

--- a/src/topology/algebra/module.lean
+++ b/src/topology/algebra/module.lean
@@ -272,9 +272,18 @@ instance : has_coe (M₁ →SL[σ₁₂] M₂) (M₁ →ₛₗ[σ₁₂] M₂) :
 -- make the coercion the preferred form
 @[simp] lemma to_linear_map_eq_coe (f : M₁ →SL[σ₁₂] M₂) : f.to_linear_map = f := rfl
 
+theorem coe_injective : function.injective (coe : (M₁ →SL[σ₁₂] M₂) → (M₁ →ₛₗ[σ₁₂] M₂)) :=
+by { intros f g H, cases f, cases g, congr' }
+
+instance : add_monoid_hom_class (M₁ →SL[σ₁₂] M₂) M₁ M₂ :=
+{ coe := λ f, f.to_fun,
+  coe_injective' := λ f g h, coe_injective (fun_like.coe_injective h),
+  map_add := λ f, map_add f.to_linear_map,
+  map_zero := λ f, linear_map.map_zero f }
+
 /-- Coerce continuous linear maps to functions. -/
 -- see Note [function coercion]
-instance to_fun : has_coe_to_fun (M₁ →SL[σ₁₂] M₂) (λ _, M₁ → M₂) := ⟨λ f, f⟩
+instance to_fun : has_coe_to_fun (M₁ →SL[σ₁₂] M₂) (λ _, M₁ → M₂) := ⟨λ f, f.to_fun⟩
 
 @[simp] lemma coe_mk (f : M₁ →ₛₗ[σ₁₂] M₂) (h) : (mk f h : M₁ →ₛₗ[σ₁₂] M₂) = f := rfl
 @[simp] lemma coe_mk' (f : M₁ →ₛₗ[σ₁₂] M₂) (h) : (mk f h : M₁ → M₂) = f := rfl
@@ -282,15 +291,12 @@ instance to_fun : has_coe_to_fun (M₁ →SL[σ₁₂] M₂) (λ _, M₁ → M�
 @[continuity]
 protected lemma continuous (f : M₁ →SL[σ₁₂] M₂) : continuous f := f.2
 
-theorem coe_injective : function.injective (coe : (M₁ →SL[σ₁₂] M₂) → (M₁ →ₛₗ[σ₁₂] M₂)) :=
-by { intros f g H, cases f, cases g, congr' }
-
 @[simp, norm_cast] lemma coe_inj {f g : M₁ →SL[σ₁₂] M₂} :
   (f : M₁ →ₛₗ[σ₁₂] M₂) = g ↔ f = g :=
 coe_injective.eq_iff
 
 theorem coe_fn_injective : @function.injective (M₁ →SL[σ₁₂] M₂) (M₁ → M₂) coe_fn :=
-linear_map.coe_injective.comp coe_injective
+fun_like.coe_injective
 
 /-- See Note [custom simps projection]. We need to specify this projection explicitly in this case,
   because it is a composition of multiple projections. -/
@@ -303,16 +309,16 @@ initialize_simps_projections continuous_linear_map
   (to_linear_map_to_fun → apply, to_linear_map → coe)
 
 @[ext] theorem ext {f g : M₁ →SL[σ₁₂] M₂} (h : ∀ x, f x = g x) : f = g :=
-coe_fn_injective $ funext h
+fun_like.ext f g h
 
 theorem ext_iff {f g : M₁ →SL[σ₁₂] M₂} : f = g ↔ ∀ x, f x = g x :=
-⟨λ h x, by rw h, by ext⟩
+fun_like.ext_iff
 
 variables (f g : M₁ →SL[σ₁₂] M₂) (c : R₁) (h : M₂ →SL[σ₂₃] M₃) (x y z : M₁)
 
 -- make some straightforward lemmas available to `simp`.
-@[simp] lemma map_zero : f (0 : M₁) = 0 := (to_linear_map _).map_zero
-@[simp] lemma map_add  : f (x + y) = f x + f y := (to_linear_map _).map_add _ _
+protected lemma map_zero : f (0 : M₁) = 0 := map_zero f
+protected lemma map_add  : f (x + y) = f x + f y := map_add f x y
 @[simp] lemma map_smulₛₗ : f (c • x) = (σ₁₂ c) • f x := (to_linear_map _).map_smulₛₗ _ _
 
 @[simp] lemma map_smul [module R₁ M₂] (f : M₁ →L[R₁] M₂)(c : R₁) (x : M₁) : f (c • x) = c • f x :=
@@ -325,7 +331,7 @@ lemma map_smul_of_tower {R S : Type*} [semiring S] [has_scalar R M₁]
   f (c • x) = c • f x :=
 linear_map.compatible_smul.map_smul f c x
 
-lemma map_sum {ι : Type*} (s : finset ι) (g : ι → M₁) :
+protected lemma map_sum {ι : Type*} (s : finset ι) (g : ι → M₁) :
   f (∑ i in s, g i) = ∑ i in s, f (g i) := f.to_linear_map.map_sum
 
 @[simp, norm_cast] lemma coe_coe : ((f : M₁ →ₛₗ[σ₁₂] M₂) : (M₁ → M₂)) = (f : M₁ → M₂) := rfl
@@ -808,8 +814,8 @@ variables
 section
 variables (f g : M →SL[σ₁₂] M₂) (x y : M)
 
-@[simp] lemma map_neg  : f (-x) = - (f x) := (to_linear_map _).map_neg _
-@[simp] lemma map_sub  : f (x - y) = f x - f y := (to_linear_map _).map_sub _ _
+protected lemma map_neg : f (-x) = - (f x) := (to_linear_map _).map_neg _
+protected lemma map_sub : f (x - y) = f x - f y := (to_linear_map _).map_sub _ _
 @[simp] lemma sub_apply' (x : M) : ((f : M →ₛₗ[σ₁₂] M₂) - g) x = f x - g x := rfl
 end
 
@@ -889,7 +895,7 @@ instance [topological_add_group M] : ring (M →L[R] M) :=
   mul_one := λ _, ext $ λ _, rfl,
   one_mul := λ _, ext $ λ _, rfl,
   mul_assoc := λ _ _ _, ext $ λ _, rfl,
-  left_distrib := λ _ _ _, ext $ λ _, map_add _ _ _,
+  left_distrib := λ f g h, ext $ λ x, map_add f (g x) (h x),
   right_distrib := λ _ _ _, ext $ λ _, linear_map.add_apply _ _ _,
   ..continuous_linear_map.add_comm_group }
 


### PR DESCRIPTION
This PR is the main proof-of-concept in my plan to use typeclasses to reduce duplication surrounding `hom` classes. Essentially, I want to take each type of bundled homs, such as `monoid_hom`, and add a class `monoid_hom_class` which has an instance for each *type* extending `monoid_hom`. Declarations that now take a parameter of the specific type `monoid_hom M N` can instead take a more general `{F : Type*} [monoid_hom_class F M N] (f : F)`; this means we don't need to duplicate e.g. `monoid_hom.map_prod` to `ring_hom.map_prod`, `mul_equiv.map_prod`, `ring_equiv.map_prod`, or `monoid_hom.map_div` to `ring_hom.map_div`, `mul_equiv.map_div`, `ring_equiv.map_div`, ...

Basically, instead of having `O(n * k)` declarations for `n` types of homs and `k` lemmas, following the plan we only need `O(n + k)`.

## Overview

 * Change `has_coe_to_fun` to include the type of the function as a parameter (rather than a field of the structure) (**done** as part of #7033)
 * Define a class `fun_like`, analogous to `set_like`, for types of bundled function + proof (**done** in #10286)
 * Extend `fun_like` for each `foo_hom` to create a `foo_hom_class` (**done** in this PR for `ring_hom` and its ancestors, **todo** in follow-up for the rest)
 * Change parameters of type `foo_hom A B` to take `{F : Type*} [foo_hom_class F A B] (f : F)` instead (**done** in this PR for `map_{add,zero,mul,one,sub,div}`, **todo** in follow-up for remaining declarations)

## API changes

Lemmas matching `*_hom.map_{add,zero,mul,one,sub,div}` are deprecated. Use the new `simp` lemmas called simply `map_add`, `map_zero`, ...

Namespaced lemmas of the form `map_{add,zero,mul,one,sub,div}` are now protected. This includes e.g. `polynomial.map_add` and `multiset.map_add`, which involve `polynomial.map` and `multiset.map` respectively. In fact, it should be possible to turn those `map` definitions into bundled maps, so we don't even need to worry about the name change.

## New classes

 * `zero_hom_class`, `one_hom_class` defines `map_zero`, `map_one`
 * `add_hom_class`, `mul_hom_class` defines `map_add`, `map_mul`
 * `add_monoid_hom_class`, `monoid_hom_class` extends `{zero,one}_hom_class`, `{add,mul}_hom_class`
 * `monoid_with_zero_hom_class` extends `monoid_hom_class` and `zero_hom_class`
 * `ring_hom_class` extends `monoid_hom_class`, `add_monoid_hom_class` and `monoid_with_zero_hom_class`

## Classes still to be implemented

Some of the core algebraic homomorphisms are still missing their corresponding classes:

 * `mul_action_hom_class` defines `map_smul`
 * `distrib_mul_action_hom_class`, `mul_semiring_action_hom_class` extends the above
 * `linear_map_class` extends `add_hom_class` and defines `map_smulₛₗ`
 * `alg_hom_class` extends `ring_hom_class` and defines `commutes`

We could also add an `equiv_like` and its descendants `add_equiv_class`, `mul_equiv_class`, `ring_equiv_class`, `linear_equiv_class`, ...

## Other changes

`coe_fn_coe_base` now has an appropriately low priority, so it doesn't take precedence over `fun_like.has_coe_to_fun`.

## Why are you unbundling the morphisms again?

It's not quite the same thing as unbundling. When using unbundled morphisms, parameters have the form `(f : A → B) (hf : is_foo_hom f)`; bundled morphisms look like `(f : foo_hom A B)` (where `foo_hom A B` is equivalent to `{ f : A → B // is_foo_hom f }`; typically you would use a custom structure instead of `subtype`). This plan puts a predicate on the *type* `foo_hom` rather than the *elements* of the type as you would with unbundled morphisms. I believe this will preserve the advantages of the bundled approach (being able to talk about the identity map, making it work with `simp`), while addressing one of its disadvantages (needing to duplicate all the lemmas whenever extending the type of morphisms).

## Discussion

Main Zulip thread: https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/Typeclasses.20for.20morphisms

Some other threads referencing this plan:
 * https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/Morphism.20refactor
 * https://leanprover.zulipchat.com/#narrow/stream/263328-triage/topic/issue.20.231044.3A.20bundling.20morphisms
 * #1044
 * #4985

---

- [x] depends on: #10286
- [x] depends on: #10580 

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
