### PR TITLE
[Merged by Bors] - chore(data/real/sqrt): A couple of lemmas about sqrt

### DIFF
--- a/src/data/real/sqrt.lean
+++ b/src/data/real/sqrt.lean
@@ -266,6 +266,12 @@ begin
   { rw [div_eq_iff (sqrt_ne_zero'.mpr h), mul_self_sqrt h.le] },
 end
 
+theorem sqrt_div_self' : sqrt x / x = 1 / sqrt x :=
+by rw [←div_sqrt, one_div_div, div_sqrt]
+
+theorem sqrt_div_self : sqrt x / x = (sqrt x)⁻¹ :=
+by rw [sqrt_div_self', one_div]
+
 theorem lt_sqrt (hx : 0 ≤ x) (hy : 0 ≤ y) : x < sqrt y ↔ x ^ 2 < y :=
 by rw [mul_self_lt_mul_self_iff hx (sqrt_nonneg y), sq, mul_self_sqrt hy]
 


### PR DESCRIPTION
Add a couple of lemmas about `sqrt x / x`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

These lemmas are pulled out of the enormous Bertrand PR https://github.com/leanprover-community/mathlib/pull/8002/. I was a bit unsure about the naming, or indeed whether both lemmas should be here.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
