### PR TITLE
[Merged by Bors] - feat(topology): add some lemmas

### DIFF
--- a/src/topology/constructions.lean
+++ b/src/topology/constructions.lean
@@ -121,11 +121,25 @@ continuous_inf_dom_left continuous_induced_dom
 lemma continuous_at_fst {p : α × β} : continuous_at prod.fst p :=
 continuous_fst.continuous_at
 
+lemma continuous.fst {f : α → β × γ} (hf : continuous f) : continuous (λ a : α, (f a).1) :=
+continuous_fst.comp hf
+
+lemma continuous_at.fst {f : α → β × γ} {x : α} (hf : continuous_at f x) :
+  continuous_at (λ a : α, (f a).1) x :=
+continuous_at_fst.comp hf
+
 @[continuity] lemma continuous_snd : continuous (@prod.snd α β) :=
 continuous_inf_dom_right continuous_induced_dom
 
 lemma continuous_at_snd {p : α × β} : continuous_at prod.snd p :=
 continuous_snd.continuous_at
+
+lemma continuous.snd {f : α → β × γ} (hf : continuous f) : continuous (λ a : α, (f a).2) :=
+continuous_snd.comp hf
+
+lemma continuous_at.snd {f : α → β × γ} {x : α} (hf : continuous_at f x) :
+  continuous_at (λ a : α, (f a).2) x :=
+continuous_at_snd.comp hf
 
 @[continuity] lemma continuous.prod_mk {f : γ → α} {g : γ → β}
   (hf : continuous f) (hg : continuous g) : continuous (λx, (f x, g x)) :=
@@ -152,7 +166,7 @@ lemma filter.eventually.prod_mk_nhds {pa : α → Prop} {a} (ha : ∀ᶠ x in �
 (ha.prod_inl_nhds b).and (hb.prod_inr_nhds a)
 
 lemma continuous_swap : continuous (prod.swap : α × β → β × α) :=
-continuous.prod_mk continuous_snd continuous_fst
+continuous_snd.prod_mk continuous_fst
 
 lemma continuous_uncurry_left {f : α → β → γ} (a : α)
   (h : continuous (function.uncurry f)) : continuous (f a) :=

--- a/src/topology/continuous_on.lean
+++ b/src/topology/continuous_on.lean
@@ -1059,6 +1059,14 @@ lemma continuous_within_at_fst {s : set (α × β)} {p : α × β} :
   continuous_within_at prod.fst s p :=
 continuous_fst.continuous_within_at
 
+lemma continuous_on.fst {f : α → β × γ} {s : set α} (hf : continuous_on f s) :
+  continuous_on (λ x, (f x).1) s :=
+continuous_fst.comp_continuous_on hf
+
+lemma continuous_within_at.fst {f : α → β × γ} {s : set α} {a : α}
+  (h : continuous_within_at f s a) : continuous_within_at (λ x, (f x).fst) s a :=
+continuous_at_fst.comp_continuous_within_at h
+
 lemma continuous_on_snd {s : set (α × β)} : continuous_on prod.snd s :=
 continuous_snd.continuous_on
 
@@ -1066,9 +1074,9 @@ lemma continuous_within_at_snd {s : set (α × β)} {p : α × β} :
   continuous_within_at prod.snd s p :=
 continuous_snd.continuous_within_at
 
-lemma continuous_within_at.fst {f : α → β × γ} {s : set α} {a : α}
-  (h : continuous_within_at f s a) : continuous_within_at (λ x, (f x).fst) s a :=
-continuous_at_fst.comp_continuous_within_at h
+lemma continuous_on.snd {f : α → β × γ} {s : set α} (hf : continuous_on f s) :
+  continuous_on (λ x, (f x).2) s :=
+continuous_snd.comp_continuous_on hf
 
 lemma continuous_within_at.snd {f : α → β × γ} {s : set α} {a : α}
   (h : continuous_within_at f s a) : continuous_within_at (λ x, (f x).snd) s a :=

--- a/src/topology/continuous_on.lean
+++ b/src/topology/continuous_on.lean
@@ -875,12 +875,13 @@ lemma continuous_on.prod {f : α → β} {g : α → γ} {s : set α}
   (hf : continuous_on f s) (hg : continuous_on g s) : continuous_on (λx, (f x, g x)) s :=
 λx hx, continuous_within_at.prod (hf x hx) (hg x hx)
 
+lemma inducing.continuous_within_at_iff {f : α → β} {g : β → γ} (hg : inducing g) {s : set α}
+  {x : α} : continuous_within_at f s x ↔ continuous_within_at (g ∘ f) s x :=
+by simp_rw [continuous_within_at, inducing.tendsto_nhds_iff hg]
+
 lemma inducing.continuous_on_iff {f : α → β} {g : β → γ} (hg : inducing g) {s : set α} :
   continuous_on f s ↔ continuous_on (g ∘ f) s :=
-begin
-  simp only [continuous_on_iff_continuous_restrict, restrict_eq],
-  conv_rhs { rw [function.comp.assoc, ← (inducing.continuous_iff hg)] },
-end
+by simp_rw [continuous_on, hg.continuous_within_at_iff]
 
 lemma embedding.continuous_on_iff {f : α → β} {g : β → γ} (hg : embedding g) {s : set α} :
   continuous_on f s ↔ continuous_on (g ∘ f) s :=

--- a/src/topology/homeomorph.lean
+++ b/src/topology/homeomorph.lean
@@ -251,6 +251,14 @@ h.inducing.continuous_iff.symm
   continuous (f ∘ h) ↔ continuous f :=
 h.quotient_map.continuous_iff.symm
 
+lemma comp_continuous_at_iff (h : α ≃ₜ β) (f : γ → α) (x : γ) :
+  continuous_at (h ∘ f) x ↔ continuous_at f x :=
+h.inducing.continuous_at_iff.symm
+
+lemma comp_continuous_at_iff' (h : α ≃ₜ β) (f : β → γ) (x : α) :
+  continuous_at (f ∘ h) x ↔ continuous_at f (h x) :=
+h.inducing.continuous_at_iff' (by simp)
+
 @[simp] lemma comp_is_open_map_iff (h : α ≃ₜ β) {f : γ → α} :
   is_open_map (h ∘ f) ↔ is_open_map f :=
 begin

--- a/src/topology/homeomorph.lean
+++ b/src/topology/homeomorph.lean
@@ -259,6 +259,10 @@ lemma comp_continuous_at_iff' (h : α ≃ₜ β) (f : β → γ) (x : α) :
   continuous_at (f ∘ h) x ↔ continuous_at f (h x) :=
 h.inducing.continuous_at_iff' (by simp)
 
+lemma comp_continuous_within_at_iff (h : α ≃ₜ β) (f : γ → α) (s : set γ) (x : γ) :
+  continuous_within_at f s x ↔ continuous_within_at (h ∘ f) s x :=
+h.inducing.continuous_within_at_iff
+
 @[simp] lemma comp_is_open_map_iff (h : α ≃ₜ β) {f : γ → α} :
   is_open_map (h ∘ f) ↔ is_open_map f :=
 begin

--- a/src/topology/maps.lean
+++ b/src/topology/maps.lean
@@ -86,9 +86,17 @@ lemma inducing.tendsto_nhds_iff {ι : Type*}
   tendsto f a (𝓝 b) ↔ tendsto (g ∘ f) a (𝓝 (g b)) :=
 by rw [tendsto, tendsto, hg.induced, nhds_induced, ← map_le_iff_le_comap, filter.map_map]
 
+lemma inducing.continuous_at_iff {f : α → β} {g : β → γ} (hg : inducing g) {x : α} :
+  continuous_at f x ↔ continuous_at (g ∘ f) x :=
+by simp_rw [continuous_at, inducing.tendsto_nhds_iff hg]
+
 lemma inducing.continuous_iff {f : α → β} {g : β → γ} (hg : inducing g) :
   continuous f ↔ continuous (g ∘ f) :=
-by simp [continuous_iff_continuous_at, continuous_at, inducing.tendsto_nhds_iff hg]
+by simp_rw [continuous_iff_continuous_at, hg.continuous_at_iff]
+
+lemma inducing.continuous_at_iff' {f : α → β} {g : β → γ} (hf : inducing f) {x : α}
+  (h : range f ∈ 𝓝 (f x)) : continuous_at (g ∘ f) x ↔ continuous_at g (f x) :=
+by { simp_rw [continuous_at, filter.tendsto, ← hf.map_nhds_of_mem _ h, filter.map_map] }
 
 lemma inducing.continuous {f : α → β} (hf : inducing f) : continuous f :=
 hf.continuous_iff.mp continuous_id


### PR DESCRIPTION
* From the sphere eversion project
* Add compositional version `continuous.fst` of `continuous_fst`, compare `measurable.fst`.
* Add `comp_continuous_at_iff` and `comp_continuous_at_iff'` for `homeomorph` (and for `inducing`).
* Add some variants of these (requested by review).

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
