### PR TITLE
[Merged by Bors] - feat(group_theory/index): Second isomorphism theorem in terms of `relindex`

### DIFF
--- a/src/group_theory/index.lean
+++ b/src/group_theory/index.lean
@@ -101,6 +101,13 @@ end
 lemma inf_relindex_left : (H ⊓ K).relindex H = K.relindex H :=
 by rw [inf_comm, inf_relindex_right]
 
+lemma inf_relindex_eq_relindex_sup [K.normal] : (H ⊓ K).relindex H = K.relindex (H ⊔ K) :=
+cardinal.to_nat_congr (quotient_group.quotient_inf_equiv_prod_normal_quotient H K).to_equiv
+
+lemma relindex_eq_relindex_sup [K.normal] :
+  K.relindex H = K.relindex (H ⊔ K) :=
+by rw [←inf_relindex_left, inf_relindex_eq_relindex_sup]
+
 variables {H K}
 
 lemma relindex_dvd_of_le_left (hHK : H ≤ K) :

--- a/src/group_theory/index.lean
+++ b/src/group_theory/index.lean
@@ -104,8 +104,7 @@ by rw [inf_comm, inf_relindex_right]
 lemma inf_relindex_eq_relindex_sup [K.normal] : (H ⊓ K).relindex H = K.relindex (H ⊔ K) :=
 cardinal.to_nat_congr (quotient_group.quotient_inf_equiv_prod_normal_quotient H K).to_equiv
 
-lemma relindex_eq_relindex_sup [K.normal] :
-  K.relindex H = K.relindex (H ⊔ K) :=
+lemma relindex_eq_relindex_sup [K.normal] : K.relindex H = K.relindex (H ⊔ K) :=
 by rw [←inf_relindex_left, inf_relindex_eq_relindex_sup]
 
 variables {H K}


### PR DESCRIPTION
Restates the second isomorphism theorem in terms of `relindex`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
