### PR TITLE
[Merged by Bors] - feat(group_theory/subgroup/basic): Define characteristic subgroups

### DIFF
--- a/src/data/equiv/mul_add_aut.lean
+++ b/src/data/equiv/mul_add_aut.lean
@@ -167,7 +167,7 @@ homomorphism mapping addition in `G` into multiplication in the automorphism gro
 (written additively in order to define the map). -/
 def conj [add_group G] : G →+ additive (add_aut G) :=
 { to_fun := λ g, @additive.of_mul (add_aut G)
-  { to_fun := λ h, g + h + -g,
+  { to_fun := λ h, g + h + -g, -- this definition is chosen to match the definition of `mul_aut.conj`
     inv_fun := λ h, -g + h + g,
     left_inv := λ _, by simp [add_assoc],
     right_inv := λ _, by simp [add_assoc],

--- a/src/data/equiv/mul_add_aut.lean
+++ b/src/data/equiv/mul_add_aut.lean
@@ -167,15 +167,15 @@ homomorphism mapping addition in `G` into multiplication in the automorphism gro
 (written additively in order to define the map). -/
 def conj [add_group G] : G →+ additive (add_aut G) :=
 { to_fun := λ g, @additive.of_mul (add_aut G)
-  { to_fun := λ h, g + h - g,
+  { to_fun := λ h, g + h + -g,
     inv_fun := λ h, -g + h + g,
     left_inv := λ _, by simp [add_assoc],
     right_inv := λ _, by simp [add_assoc],
-    map_add' := by simp [add_assoc, sub_eq_add_neg] },
-  map_add' := λ _ _, by apply additive.to_mul.injective; ext; simp [add_assoc, sub_eq_add_neg],
+    map_add' := by simp [add_assoc] },
+  map_add' := λ _ _, by apply additive.to_mul.injective; ext; simp [add_assoc],
   map_zero' := by ext; simpa }
 
-@[simp] lemma conj_apply [add_group G] (g h : G) : conj g h = g + h - g := rfl
+@[simp] lemma conj_apply [add_group G] (g h : G) : conj g h = g + h + -g := rfl
 @[simp] lemma conj_symm_apply [add_group G] (g h : G) : (conj g).symm h = -g + h + g := rfl
 @[simp] lemma conj_inv_apply [add_group G] (g h : G) : (-(conj g)) h = -g + h + g := rfl
 

--- a/src/data/equiv/mul_add_aut.lean
+++ b/src/data/equiv/mul_add_aut.lean
@@ -167,7 +167,7 @@ homomorphism mapping addition in `G` into multiplication in the automorphism gro
 (written additively in order to define the map). -/
 def conj [add_group G] : G →+ additive (add_aut G) :=
 { to_fun := λ g, @additive.of_mul (add_aut G)
-  { to_fun := λ h, g + h + -g, -- this definition is chosen to match the definition of `mul_aut.conj`
+  { to_fun := λ h, g + h + -g, -- this definition is chosen to match `mul_aut.conj`
     inv_fun := λ h, -g + h + g,
     left_inv := λ _, by simp [add_assoc],
     right_inv := λ _, by simp [add_assoc],

--- a/src/group_theory/nilpotent.lean
+++ b/src/group_theory/nilpotent.lean
@@ -273,9 +273,8 @@ rfl
 instance (n : ℕ) : normal (lower_central_series G n) :=
 begin
   induction n with d hd,
-  { simp [subgroup.top_normal] },
-  { haveI := hd,
-    exact general_commutator_normal (lower_central_series G d) ⊤ },
+  { exact (⊤ : subgroup G).normal_of_characteristic },
+  { exactI general_commutator_normal (lower_central_series G d) ⊤ },
 end
 
 lemma lower_central_series_antitone :

--- a/src/group_theory/solvable.lean
+++ b/src/group_theory/solvable.lean
@@ -45,9 +45,8 @@ def derived_series : ℕ → subgroup G
 lemma derived_series_normal (n : ℕ) : (derived_series G n).normal :=
 begin
   induction n with n ih,
-  { exact subgroup.top_normal, },
-  { rw derived_series_succ,
-    exactI general_commutator_normal (derived_series G n) (derived_series G n), }
+  { exact (⊤ : subgroup G).normal_of_characteristic },
+  { exactI general_commutator_normal (derived_series G n) (derived_series G n) }
 end
 
 @[simp] lemma general_commutator_eq_commutator :

--- a/src/group_theory/subgroup/basic.lean
+++ b/src/group_theory/subgroup/basic.lean
@@ -1050,7 +1050,8 @@ end normal
 
 variables (H)
 
-/-- A subgroup is characteristic if it is fixed by all automorphisms -/
+/-- A subgroup is characteristic if it is fixed by all automorphisms.
+  Several equivalent conditions are provided by lemmas of the form `characteristic.iff...` -/
 structure characteristic : Prop :=
 (fixed : ∀ ϕ : G ≃* G, H.comap ϕ.to_monoid_hom = H)
 
@@ -1065,7 +1066,8 @@ namespace add_subgroup
 
 variables (H : add_subgroup A)
 
-/-- An add_subgroup is characteristic if it is fixed by all automorphisms -/
+/-- A add_subgroup is characteristic if it is fixed by all automorphisms.
+  Several equivalent conditions are provided by lemmas of the form `characteristic.iff...` -/
 structure characteristic  : Prop :=
 (fixed : ∀ ϕ : A ≃+ A, H.comap ϕ.to_add_monoid_hom = H)
 
@@ -1117,10 +1119,10 @@ begin
 end
 
 @[to_additive] instance bot_characteristic : characteristic (⊥ : subgroup G) :=
-characteristic_iff_map_eq.mpr (λ ϕ, map_bot ϕ.to_monoid_hom)
+characteristic_iff_le_map.mpr (λ ϕ, bot_le)
 
 @[to_additive] instance top_characteristic : characteristic (⊤ : subgroup G) :=
-characteristic_iff_comap_eq.mpr (λ ϕ, comap_top ϕ.to_monoid_hom)
+characteristic_iff_map_le.mpr (λ ϕ, le_top)
 
 variable (G)
 /-- The center of a group `G` is the set of elements that commute with everything in `G` -/
@@ -1144,7 +1146,7 @@ variable {G}
 instance decidable_mem_center [decidable_eq G] [fintype G] : decidable_pred (∈ center G) :=
 λ _, decidable_of_iff' _ mem_center_iff
 
-@[priority 100, to_additive] instance center_characteristic : (center G).characteristic :=
+@[to_additive] instance center_characteristic : (center G).characteristic :=
 begin
   refine characteristic_iff_comap_le.mpr (λ ϕ g hg h, _),
   rw [←ϕ.injective.eq_iff, ϕ.map_mul, ϕ.map_mul],

--- a/src/group_theory/subgroup/basic.lean
+++ b/src/group_theory/subgroup/basic.lean
@@ -1048,11 +1048,79 @@ have a⁻¹ * (a * b) * a⁻¹⁻¹ ∈ H, from nH.conj_mem (a * b) h a⁻¹, by
 
 end normal
 
-@[priority 100, to_additive]
-instance bot_normal : normal (⊥ : subgroup G) := ⟨by simp⟩
+variables (H)
 
-@[priority 100, to_additive]
-instance top_normal : normal (⊤ : subgroup G) := ⟨λ _ _, mem_top⟩
+/-- A subgroup is characteristic if it is fixed by all automorphisms -/
+structure characteristic : Prop :=
+(fixed : ∀ ϕ : G ≃* G, H.comap ϕ.to_monoid_hom = H)
+
+attribute [class] characteristic
+
+@[priority 100] instance normal_of_characteristic [h : H.characteristic] : H.normal :=
+⟨λ a ha b, (set_like.ext_iff.mp (h.fixed (mul_aut.conj b)) a).mpr ha⟩
+
+end subgroup
+
+namespace add_subgroup
+
+variables (H : add_subgroup A)
+
+/-- An add_subgroup is characteristic if it is fixed by all automorphisms -/
+structure characteristic  : Prop :=
+(fixed : ∀ ϕ : A ≃+ A, H.comap ϕ.to_add_monoid_hom = H)
+
+attribute [to_additive add_subgroup.characteristic] subgroup.characteristic
+attribute [class] characteristic
+
+@[priority 100] instance normal_of_characteristic [h : H.characteristic] : H.normal :=
+⟨λ a ha b, (set_like.ext_iff.mp (h.fixed (add_aut.conj b)) a).mpr ha⟩
+
+end add_subgroup
+
+namespace subgroup
+
+variables {H K : subgroup G}
+
+@[to_additive] lemma characteristic_iff_comap_eq :
+  H.characteristic ↔ ∀ ϕ : G ≃* G, H.comap ϕ.to_monoid_hom = H :=
+⟨characteristic.fixed, characteristic.mk⟩
+
+@[to_additive] lemma characteristic_iff_comap_le :
+  H.characteristic ↔ ∀ ϕ : G ≃* G, H.comap ϕ.to_monoid_hom ≤ H :=
+characteristic_iff_comap_eq.trans ⟨λ h ϕ, le_of_eq (h ϕ),
+  λ h ϕ, le_antisymm (h ϕ) (λ g hg, h ϕ.symm ((congr_arg (∈ H) (ϕ.symm_apply_apply g)).mpr hg))⟩
+
+@[to_additive] lemma characteristic_iff_le_comap :
+  H.characteristic ↔ ∀ ϕ : G ≃* G, H ≤ H.comap ϕ.to_monoid_hom :=
+characteristic_iff_comap_eq.trans ⟨λ h ϕ, ge_of_eq (h ϕ),
+  λ h ϕ, le_antisymm (λ g hg, (congr_arg (∈ H) (ϕ.symm_apply_apply g)).mp (h ϕ.symm hg)) (h ϕ)⟩
+
+@[to_additive] lemma characteristic_iff_map_eq :
+  H.characteristic ↔ ∀ ϕ : G ≃* G, H.map ϕ.to_monoid_hom = H :=
+begin
+  simp_rw map_equiv_eq_comap_symm,
+  exact characteristic_iff_comap_eq.trans ⟨λ h ϕ, h ϕ.symm, λ h ϕ, h ϕ.symm⟩,
+end
+
+@[to_additive] lemma characteristic_iff_map_le :
+  H.characteristic ↔ ∀ ϕ : G ≃* G, H.map ϕ.to_monoid_hom ≤ H :=
+begin
+  simp_rw map_equiv_eq_comap_symm,
+  exact characteristic_iff_comap_le.trans ⟨λ h ϕ, h ϕ.symm, λ h ϕ, h ϕ.symm⟩,
+end
+
+@[to_additive] lemma characteristic_iff_le_map :
+  H.characteristic ↔ ∀ ϕ : G ≃* G, H ≤ H.map ϕ.to_monoid_hom :=
+begin
+  simp_rw map_equiv_eq_comap_symm,
+  exact characteristic_iff_le_comap.trans ⟨λ h ϕ, h ϕ.symm, λ h ϕ, h ϕ.symm⟩,
+end
+
+@[to_additive] instance bot_characteristic : characteristic (⊥ : subgroup G) :=
+characteristic_iff_map_eq.mpr (λ ϕ, map_bot ϕ.to_monoid_hom)
+
+@[to_additive] instance top_characteristic : characteristic (⊤ : subgroup G) :=
+characteristic_iff_comap_eq.mpr (λ ϕ, comap_top ϕ.to_monoid_hom)
 
 variable (G)
 /-- The center of a group `G` is the set of elements that commute with everything in `G` -/
@@ -1076,13 +1144,12 @@ variable {G}
 instance decidable_mem_center [decidable_eq G] [fintype G] : decidable_pred (∈ center G) :=
 λ _, decidable_of_iff' _ mem_center_iff
 
-@[priority 100, to_additive]
-instance center_normal : (center G).normal :=
-⟨begin
-  assume n hn g h,
-  assoc_rw [hn (h * g), hn g],
-  simp
-end⟩
+@[priority 100, to_additive] instance center_characteristic : (center G).characteristic :=
+begin
+  refine characteristic_iff_comap_le.mpr (λ ϕ g hg h, _),
+  rw [←ϕ.injective.eq_iff, ϕ.map_mul, ϕ.map_mul],
+  exact hg (ϕ h),
+end
 
 variables {G} (H)
 /-- The `normalizer` of `H` is the largest subgroup of `G` inside which `H` is normal. -/


### PR DESCRIPTION
This PR defines characteristic subgroups and builds the basic API.

Getting `@[to_additive]` to work correctly was a bit tricky, so I mostly just copied the setup for `subgroup.normal`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
