### PR TITLE
[Merged by Bors] - feat(measure_theory/measure): better `measure.restrict_singleton`

### DIFF
--- a/src/measure_theory/integral/bochner.lean
+++ b/src/measure_theory/integral/bochner.lean
@@ -1308,14 +1308,14 @@ begin
     rwa ← ae_measurable_map_equiv_iff }
 end
 
-lemma integral_dirac' [measurable_space α] (f : α → E) (a : α) (hfm : measurable f) :
+@[simp] lemma integral_dirac' [measurable_space α] (f : α → E) (a : α) (hfm : measurable f) :
   ∫ x, f x ∂(measure.dirac a) = f a :=
 calc ∫ x, f x ∂(measure.dirac a) = ∫ x, f a ∂(measure.dirac a) :
   integral_congr_ae $ ae_eq_dirac' hfm
 ... = f a : by simp [measure.dirac_apply_of_mem]
 
-lemma integral_dirac [measurable_space α] [measurable_singleton_class α] (f : α → E) (a : α) :
-  ∫ x, f x ∂(measure.dirac a) = f a :=
+@[simp] lemma integral_dirac [measurable_space α] [measurable_singleton_class α]
+  (f : α → E) (a : α) : ∫ x, f x ∂(measure.dirac a) = f a :=
 calc ∫ x, f x ∂(measure.dirac a) = ∫ x, f a ∂(measure.dirac a) :
   integral_congr_ae $ ae_eq_dirac f
 ... = f a : by simp [measure.dirac_apply_of_mem]

--- a/src/measure_theory/measure/measure_space.lean
+++ b/src/measure_theory/measure/measure_space.lean
@@ -1117,6 +1117,16 @@ lemma map_dirac {f : α → β} (hf : measurable f) (a : α) :
   map f (dirac a) = dirac (f a) :=
 ext $ assume s hs, by simp [hs, map_apply hf hs, hf hs, indicator_apply]
 
+@[simp] lemma restrict_singleton (μ : measure α) (a : α) : μ.restrict {a} = μ {a} • dirac a :=
+begin
+  ext1 s hs,
+  by_cases ha : a ∈ s,
+  { have : s ∩ {a} = {a}, by simpa,
+    simp * },
+  { have : s ∩ {a} = ∅, from inter_singleton_eq_empty.2 ha,
+    simp * }
+end
+
 end dirac
 
 section sum
@@ -1761,7 +1771,7 @@ lemma _root_.set.subsingleton.measure_zero {α : Type*} {m : measurable_space α
   μ s = 0 :=
 hs.induction_on measure_empty measure_singleton
 
-@[simp] lemma measure.restrict_singleton' {a : α} :
+lemma measure.restrict_singleton' {a : α} :
   μ.restrict {a} = 0 :=
 by simp only [measure_singleton, measure.restrict_eq_zero]
 


### PR DESCRIPTION
With new `restrict_singleton`, `simp` can simplify `∫ x in {a}, f x ∂μ`
to `(μ {a}).to_real • f a`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)