### PR TITLE
[Merged by Bors] - chore(linear_algebra/matrix/nonsingular_inverse): use pi.single instead of ite

### DIFF
--- a/src/linear_algebra/matrix/nonsingular_inverse.lean
+++ b/src/linear_algebra/matrix/nonsingular_inverse.lean
@@ -166,13 +166,13 @@ while the `inv` section is specifically for invertible matrices.
   minor as replacing a column with a basis vector, since it allows us to use
   facts about the `cramer` map.
 -/
-def adjugate (A : matrix n n α) : matrix n n α := λ i, cramer Aᵀ (λ j, if i = j then 1 else 0)
+def adjugate (A : matrix n n α) : matrix n n α := λ i, cramer Aᵀ (pi.single i 1)
 
 lemma adjugate_def (A : matrix n n α) :
-  adjugate A = λ i, cramer Aᵀ (λ j, if i = j then 1 else 0) := rfl
+  adjugate A = λ i, cramer Aᵀ (pi.single i 1) := rfl
 
 lemma adjugate_apply (A : matrix n n α) (i j : n) :
-  adjugate A i j = (A.update_row j (λ j, if i = j then 1 else 0)).det :=
+  adjugate A i j = (A.update_row j (pi.single i 1)).det :=
 by { rw adjugate_def, simp only, rw [cramer_apply, update_column_transpose, det_transpose], }
 
 lemma adjugate_transpose (A : matrix n n α) : (adjugate A)ᵀ = adjugate (Aᵀ) :=
@@ -187,20 +187,23 @@ begin
   by_cases i = σ j,
   { -- Everything except `(i , j)` (= `(σ j , j)`) is given by A, and the rest is a single `1`.
     congr; ext j',
-    have := (@equiv.injective _ _ σ j j' : σ j = σ j' → j = j'),
+    subst h,
+    have : σ j' = σ j ↔ j' = j := σ.injective.eq_iff,
     rw [update_row_apply, update_column_apply],
-    finish },
+    simp_rw this,
+    rw [←dite_eq_ite, ←dite_eq_ite],
+    congr' 1 with rfl,
+    rw [pi.single_eq_same, pi.single_eq_same], },
   { -- Otherwise, we need to show that there is a `0` somewhere in the product.
-    have : (∏ j' : n, update_column A j (λ (i' : n), ite (i = i') 1 0) (σ j') j') = 0,
+    have : (∏ j' : n, update_column A j (pi.single i 1) (σ j') j') = 0,
     { apply prod_eq_zero (mem_univ j),
-      rw [update_column_self],
-      exact if_neg h },
+      rw [update_column_self, pi.single_eq_of_ne' h], },
     rw this,
     apply prod_eq_zero (mem_univ (σ⁻¹ i)),
     erw [apply_symm_apply σ i, update_row_self],
-    apply if_neg,
+    apply pi.single_eq_of_ne,
     intro h',
-    exact h ((symm_apply_eq σ).mp h'.symm) }
+    exact h ((symm_apply_eq σ).mp h') }
 end
 
 /-- Since the map `b ↦ cramer A b` is linear in `b`, it must be multiplication by some matrix. This
@@ -210,17 +213,16 @@ lemma cramer_eq_adjugate_mul_vec (A : matrix n n α) (b : n → α) :
 begin
   nth_rewrite 1 ← A.transpose_transpose,
   rw [← adjugate_transpose, adjugate_def],
-  have : b = ∑ i, (b i) • (λ j, if i = j then 1 else 0), { ext i, simp, },
-  rw this, ext k,
+  have : b = ∑ i, (b i) • (pi.single i 1),
+  { refine (pi_eq_sum_univ b).trans _, congr' with j, simp [pi.single_apply, eq_comm], congr, },
+  nth_rewrite 0 this, ext k,
   simp [mul_vec, dot_product, mul_comm],
 end
 
 lemma mul_adjugate_apply (A : matrix n n α) (i j k) :
-  A i k * adjugate A k j = cramer Aᵀ (λ j, if k = j then A i k else 0) j :=
+  A i k * adjugate A k j = cramer Aᵀ (pi.single k (A i k)) j :=
 begin
-  erw [←smul_eq_mul, ←pi.smul_apply, ←linear_map.map_smul],
-  congr' with l,
-  rw [pi.smul_apply, smul_eq_mul, mul_boole],
+  erw [←smul_eq_mul, ←pi.smul_apply, ←linear_map.map_smul, ←pi.single_smul', smul_eq_mul, mul_one],
 end
 
 lemma mul_adjugate (A : matrix n n α) : A ⬝ adjugate A = A.det • 1 :=
@@ -271,7 +273,7 @@ begin
 end
 
 @[simp] lemma adjugate_one : adjugate (1 : matrix n n α) = 1 :=
-by { ext, simp [adjugate_def, matrix.one_apply] }
+by { ext, simp [adjugate_def, matrix.one_apply, pi.single_apply, eq_comm] }
 
 lemma det_adjugate_eq_one {A : matrix n n α} (h : A.det = 1) : (adjugate A).det = 1 :=
 calc (adjugate A).det
@@ -315,9 +317,9 @@ begin
   ext i j,
   rw [adjugate_apply, det_fin_two],
   fin_cases i with [0, 1]; fin_cases j with [0, 1];
-  simp only [nat.one_ne_zero, one_mul, fin.one_eq_zero_iff, if_true, zero_mul, fin.zero_eq_one_iff,
-    eq_self_iff_true, sub_zero, if_false, ne.def, not_false_iff, update_row_self, update_row_ne,
-    cons_val_zero, mul_zero, mul_one, zero_sub, cons_val_one, head_cons],
+  simp only [nat.one_ne_zero, one_mul, fin.one_eq_zero_iff, pi.single_eq_same, zero_mul,
+    fin.zero_eq_one_iff, sub_zero, pi.single_eq_of_ne, ne.def, not_false_iff, update_row_self,
+    update_row_ne, cons_val_zero, mul_zero, mul_one, zero_sub, cons_val_one, head_cons],
 end
 
 @[simp] lemma adjugate_fin_two' (a b c d : α) :
@@ -608,9 +610,9 @@ lemma ring_hom.map_adjugate {R S : Type*} [comm_ring R] [comm_ring S] (f : R →
   (M : matrix n n R) : f.map_matrix M.adjugate = matrix.adjugate (f.map_matrix M) :=
 begin
   ext i k,
-  have : (λ (j : n), ite (i = j) (1 : S) 0) = f ∘ (λ (j : n), ite (i = j) 1 0),
-  { ext,
-    simp [apply_ite f] },
+  have : pi.single i (1 : S) = f ∘ pi.single i 1,
+  { rw ←f.map_one,
+    exact pi.single_op (λ i, f) (λ i, f.map_zero) i (1 : R) },
   rw [adjugate_apply, ring_hom.map_matrix_apply, map_apply, ring_hom.map_matrix_apply,
       this, ←map_update_row, ←ring_hom.map_matrix_apply, ←ring_hom.map_det, ←adjugate_apply]
 end


### PR DESCRIPTION

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
