### PR TITLE
[Merged by Bors] - chore(group_theory/submonoid): move a lemma to reduce imports

### DIFF
--- a/src/group_theory/subgroup/basic.lean
+++ b/src/group_theory/subgroup/basic.lean
@@ -4,10 +4,10 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Kexing Ying
 -/
 import group_theory.submonoid.pointwise
+import group_theory.submonoid.membership
 import group_theory.submonoid.center
 import algebra.group.conj
 import order.atoms
-import algebra.pointwise
 
 /-!
 # Subgroups

--- a/src/group_theory/subgroup/basic.lean
+++ b/src/group_theory/subgroup/basic.lean
@@ -3,10 +3,11 @@ Copyright (c) 2020 Kexing Ying. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Kexing Ying
 -/
-import group_theory.submonoid
+import group_theory.submonoid.pointwise
 import group_theory.submonoid.center
 import algebra.group.conj
 import order.atoms
+import algebra.pointwise
 
 /-!
 # Subgroups

--- a/src/group_theory/submonoid/membership.lean
+++ b/src/group_theory/submonoid/membership.lean
@@ -7,7 +7,6 @@ Amelia Livingston, Yury Kudryashov
 import group_theory.submonoid.operations
 import algebra.big_operators.basic
 import algebra.free_monoid
-import algebra.pointwise
 
 /-!
 # Submonoids: membership criteria
@@ -31,7 +30,7 @@ In this file we prove various facts about membership in a submonoid:
 submonoid, submonoids
 -/
 
-open_locale big_operators pointwise
+open_locale big_operators
 
 variables {M : Type*}
 variables {A : Type*}
@@ -330,24 +329,6 @@ submonoid `S` is contained in the additive closure of `S`. -/
 lemma mul_left_mem_add_closure (ha : a ∈ S) (hb : b ∈ add_submonoid.closure (S : set R)) :
   a * b ∈ add_submonoid.closure (S : set R) :=
 S.mul_mem_add_closure (add_submonoid.mem_closure.mpr (λ sT hT, hT ha)) hb
-
-@[to_additive]
-lemma mem_closure_inv {G : Type*} [group G] (S : set G) (x : G) :
-  x ∈ submonoid.closure S⁻¹ ↔ x⁻¹ ∈ submonoid.closure S :=
-begin
-  suffices : ∀ (S : set G) (x : G), x ∈ submonoid.closure S⁻¹ → x⁻¹ ∈ submonoid.closure S,
-  { refine ⟨this S x, _⟩,
-    have := this S⁻¹ x⁻¹,
-    rw [inv_inv, set.inv_inv] at this,
-    exact this, },
-  intros S x hx,
-  refine submonoid.closure_induction hx (λ x hx, _) _ (λ x y hx hy, _),
-  { exact submonoid.subset_closure (set.mem_inv.mp hx), },
-  { rw one_inv,
-    exact submonoid.one_mem _ },
-  { rw mul_inv_rev x y,
-    exact submonoid.mul_mem _ hy hx },
-end
 
 end submonoid
 

--- a/src/group_theory/submonoid/pointwise.lean
+++ b/src/group_theory/submonoid/pointwise.lean
@@ -194,4 +194,24 @@ subset_set_smul_iff₀ ha
 
 end group_with_zero
 
+open_locale pointwise
+
+@[to_additive]
+lemma mem_closure_inv {G : Type*} [group G] (S : set G) (x : G) :
+  x ∈ submonoid.closure S⁻¹ ↔ x⁻¹ ∈ submonoid.closure S :=
+begin
+  suffices : ∀ (S : set G) (x : G), x ∈ submonoid.closure S⁻¹ → x⁻¹ ∈ submonoid.closure S,
+  { refine ⟨this S x, _⟩,
+    have := this S⁻¹ x⁻¹,
+    rw [inv_inv, set.inv_inv] at this,
+    exact this, },
+  intros S x hx,
+  refine submonoid.closure_induction hx (λ x hx, _) _ (λ x y hx hy, _),
+  { exact submonoid.subset_closure (set.mem_inv.mp hx), },
+  { rw one_inv,
+    exact submonoid.one_mem _ },
+  { rw mul_inv_rev x y,
+    exact submonoid.mul_mem _ hy hx },
+end
+
 end add_submonoid

--- a/src/group_theory/submonoid/pointwise.lean
+++ b/src/group_theory/submonoid/pointwise.lean
@@ -109,6 +109,25 @@ subset_set_smul_iff₀ ha
 
 end group_with_zero
 
+open_locale pointwise
+
+@[to_additive]
+lemma mem_closure_inv {G : Type*} [group G] (S : set G) (x : G) :
+  x ∈ submonoid.closure S⁻¹ ↔ x⁻¹ ∈ submonoid.closure S :=
+begin
+  suffices : ∀ (S : set G) (x : G), x ∈ submonoid.closure S⁻¹ → x⁻¹ ∈ submonoid.closure S,
+  { refine ⟨this S x, _⟩,
+    have := this S⁻¹ x⁻¹,
+    rwa [inv_inv, set.inv_inv] at this },
+  intros S x hx,
+  refine submonoid.closure_induction hx (λ x hx, _) _ (λ x y hx hy, _),
+  { exact submonoid.subset_closure (set.mem_inv.mp hx), },
+  { rw one_inv,
+    exact submonoid.one_mem _ },
+  { rw mul_inv_rev x y,
+    exact submonoid.mul_mem _ hy hx },
+end
+
 end submonoid
 
 namespace add_submonoid
@@ -195,23 +214,5 @@ subset_set_smul_iff₀ ha
 end group_with_zero
 
 open_locale pointwise
-
-@[to_additive]
-lemma mem_closure_inv {G : Type*} [group G] (S : set G) (x : G) :
-  x ∈ submonoid.closure S⁻¹ ↔ x⁻¹ ∈ submonoid.closure S :=
-begin
-  suffices : ∀ (S : set G) (x : G), x ∈ submonoid.closure S⁻¹ → x⁻¹ ∈ submonoid.closure S,
-  { refine ⟨this S x, _⟩,
-    have := this S⁻¹ x⁻¹,
-    rw [inv_inv, set.inv_inv] at this,
-    exact this, },
-  intros S x hx,
-  refine submonoid.closure_induction hx (λ x hx, _) _ (λ x y hx hy, _),
-  { exact submonoid.subset_closure (set.mem_inv.mp hx), },
-  { rw one_inv,
-    exact submonoid.one_mem _ },
-  { rw mul_inv_rev x y,
-    exact submonoid.mul_mem _ hy hx },
-end
 
 end add_submonoid

--- a/src/ring_theory/subsemiring.lean
+++ b/src/ring_theory/subsemiring.lean
@@ -5,6 +5,7 @@ Authors: Yury Kudryashov
 -/
 
 import algebra.ring.prod
+import algebra.module.basic
 import group_theory.submonoid.membership
 import group_theory.submonoid.center
 import data.set.finite

--- a/src/ring_theory/subsemiring.lean
+++ b/src/ring_theory/subsemiring.lean
@@ -5,8 +5,9 @@ Authors: Yury Kudryashov
 -/
 
 import algebra.ring.prod
-import group_theory.submonoid
+import group_theory.submonoid.membership
 import group_theory.submonoid.center
+import data.set.finite
 import data.equiv.ring
 
 /-!


### PR DESCRIPTION
Currently, `algebra.pointwise` is a relatively "heavy" import (e.g., it depends on `data.set.finite`) and I want to use submonoid closures a bit earlier than that.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
