### PR TITLE
[Merged by Bors] - chore(linear_algebra/matrix/nonsingular_inverse): replace `1 < fintype.card n` with `nontrivial n`

### DIFF
--- a/src/linear_algebra/matrix/nonsingular_inverse.lean
+++ b/src/linear_algebra/matrix/nonsingular_inverse.lean
@@ -261,10 +261,10 @@ begin
   exact adjugate_subsingleton _
 end
 
-@[simp] lemma adjugate_zero (h : 1 < fintype.card n) : adjugate (0 : matrix n n α) = 0 :=
+@[simp] lemma adjugate_zero [nontrivial n] : adjugate (0 : matrix n n α) = 0 :=
 begin
   ext i j,
-  obtain ⟨j', hj'⟩ : ∃ j', j' ≠ j := fintype.exists_ne_of_one_lt_card h j,
+  obtain ⟨j', hj'⟩ : ∃ j', j' ≠ j := exists_ne j,
   apply det_eq_zero_of_column_eq_zero j',
   intro j'',
   simp [update_column_ne hj'],


### PR DESCRIPTION
This likely makes this a better simp lemma

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
