### PR TITLE
[Merged by Bors] - doc(topology) add a library note about continuity lemmas

### DIFF
--- a/src/topology/basic.lean
+++ b/src/topology/basic.lean
@@ -1468,3 +1468,82 @@ end
 end dense_range
 
 end continuous
+
+/--
+The library contains many lemmas that functions/operations are continuous. There are many ways
+to formulate the continuity of operations. Some are more convenient than others.
+Note: for the most part this note also applies to other properties
+(measurable, differentiable, continuous_on, ...).
+
+### The traditional way
+As an example, let's look at addition `(+) : M → M → M`. We can state that this is continuous
+in different definitionally equal ways (omitting some typing information)
+* `continuous (λ p, p.1 + p.2)`;
+* `continuous (function.uncurry (+))`;
+* `continuous ↿(+)`.
+
+However, lemmas with this conclusion are not nice to use in practice because
+(1) They confuse the elaborator. The following two examples fail, because of limitations in the
+elaboration process.
+```
+variables {M : Type*} [has_mul M] [topological_space M] [has_continuous_mul M]
+example : continuous (λ x : M, x + x) :=
+continuous_add.comp _
+
+example : continuous (λ x : M, x + x) :=
+continuous_add.comp (continuous_id.prod_mk continuous_id)
+```
+The second is a valid proof, which is accepted if you write it as
+`continuous_add.comp (continuous_id.prod_mk continuous_id : _)`
+
+(2) If the operation has more than 2 arguments, they are impractical to use, because in your
+application the arguments in the domain might be in a different order or associated differently.
+
+### The convenient way
+A much more convenient way to write continuity lemmas is like `continuous.add`:
+```
+continuous.add : {f g : X → M} (hf : continuous f) (hg : continuous g) : continuous (λ x, f x + g x)
+```
+This has the following advantages
+* It supports projection notation, so is shorter to write.
+* `continuous.add _ _` is recognized correctly by the elaborator and gives useful new goals.
+* It works for in any application, since the domain is the variable `X`.
+
+As an example for an unary operation, we have `continuous.neg`.
+```
+continuous.neg {f : α → G} (hf : continuous f) : continuous (λ x, -f x)
+```
+For unary functions, the elaborator is not confused when applying the traditional lemma
+(like `continuous_neg`), but it's still convenient to have the short version available (compare
+`hf.neg.neg.neg` with `continuous_neg.comp $ continuous_neg.comp $ continuous_neg.comp hf`).
+
+As an harder example, consider an operation of the following type:
+```
+def strans {x : F} (γ γ' : path x x) (t₀ : I) : path x x
+```
+The precise definition is not important, only its type.
+The correct continuity principle for this operation is:
+```
+{f : X → F} {γ γ' : ∀ x, path (f x) (f x)} {t₀ s : X → I}
+  (hγ : continuous ↿γ) (hγ' : continuous ↿γ')
+  (ht : continuous t₀) (hs : continuous s)
+  (some additional assumptions, if the definition might contain continuities) :
+  continuous (λ x, strans (γ x) (γ' x) (t x) (s x))
+```
+Note that *all* arguments of `strans` are indexed over `X`, even the basepoint `x`, and the last
+argument `s` that arises since `path x x` has a coercion to `I → F`. The paths `γ` and `γ'` (which
+are unary functions from `I`) become binary functions in the continuity lemma.
+
+### Notes
+* In summary, make sure that your continuity lemmas are stated in the most general way. That means
+  that:
+  - Wherever possible, all point arguments are replaced by functions
+  - All `n`-ary function arguments are replaced by `n+1`-ary functions
+  - The conclusion has as domain a variable (not something like `X × Y`), and neither does the
+    continuity happen in a `Π`-type.
+  - All (relevant) arguments have continuity assumptions, and perhaps there are additional
+    assumptions needed to make the operation continuous.
+* This library note is about the *conclusions* of continuity lemmas. In assumptions it's fine to
+  state that a function with more than 1 argument is continuous using `↿` or `function.uncurry`.
+-/
+library_note "continuity lemma statement"

--- a/src/topology/basic.lean
+++ b/src/topology/basic.lean
@@ -1517,7 +1517,7 @@ For unary functions, the elaborator is not confused when applying the traditiona
 (like `continuous_neg`), but it's still convenient to have the short version available (compare
 `hf.neg.neg.neg` with `continuous_neg.comp $ continuous_neg.comp $ continuous_neg.comp hf`).
 
-As an harder example, consider an operation of the following type:
+As a harder example, consider an operation of the following type:
 ```
 def strans {x : F} (γ γ' : path x x) (t₀ : I) : path x x
 ```
@@ -1534,16 +1534,17 @@ Note that *all* arguments of `strans` are indexed over `X`, even the basepoint `
 argument `s` that arises since `path x x` has a coercion to `I → F`. The paths `γ` and `γ'` (which
 are unary functions from `I`) become binary functions in the continuity lemma.
 
-### Notes
-* In summary, make sure that your continuity lemmas are stated in the most general way. That means
-  that:
-  - Wherever possible, all point arguments are replaced by functions
+### Summary
+* Make sure that your continuity lemmas are stated in the most general way, and in a convenient
+  form. That means that:
+  - The conclusion has a variable `X` as domain (not something like `Y × Z`);
+  - Wherever possible, all point arguments `c : Y` are replaced by functions `c : X → Y`;
   - All `n`-ary function arguments are replaced by `n+1`-ary functions
-  - The conclusion has a variable as domain (not something like `X × Y`), and neither does the
-    continuity happen in a `Π`-type.
+    (`f : Y → Z` becomes `f : X → Y → Z`);
   - All (relevant) arguments have continuity assumptions, and perhaps there are additional
-    assumptions needed to make the operation continuous.
-* This library note is mostly about the format of the *conclusion* of a continuity lemma.
+    assumptions needed to make the operation continuous;
+  - The function in the conclusion is fully applied.
+* These remarks are mostly about the format of the *conclusion* of a continuity lemma.
   In assumptions it's fine to state that a function with more than 1 argument is continuous using
   `↿` or `function.uncurry`.
 -/

--- a/src/topology/basic.lean
+++ b/src/topology/basic.lean
@@ -1539,11 +1539,12 @@ are unary functions from `I`) become binary functions in the continuity lemma.
   that:
   - Wherever possible, all point arguments are replaced by functions
   - All `n`-ary function arguments are replaced by `n+1`-ary functions
-  - The conclusion has as domain a variable (not something like `X × Y`), and neither does the
+  - The conclusion has a variable as domain (not something like `X × Y`), and neither does the
     continuity happen in a `Π`-type.
   - All (relevant) arguments have continuity assumptions, and perhaps there are additional
     assumptions needed to make the operation continuous.
-* This library note is about the *conclusions* of continuity lemmas. In assumptions it's fine to
-  state that a function with more than 1 argument is continuous using `↿` or `function.uncurry`.
+* This library note is mostly about the format of the *conclusion* of a continuity lemma.
+  In assumptions it's fine to state that a function with more than 1 argument is continuous using
+  `↿` or `function.uncurry`.
 -/
 library_note "continuity lemma statement"

--- a/src/topology/basic.lean
+++ b/src/topology/basic.lean
@@ -1559,5 +1559,7 @@ lemma continuous_on.comp_fract {X Y : Type*} [topological_space X] [topological_
   {f : X → ℝ → Y} {g : X → ℝ} (hf : continuous ↿f) (hg : continuous g) (h : ∀ s, f s 0 = f s 1) :
   continuous (λ x, f x (fract (g x)))
 ```
+With `continuous_at` you can be even more precise about what to prove in case of discontinuities,
+see e.g. `continuous_at.comp_div_cases`.
 -/
 library_note "continuity lemma statement"

--- a/src/topology/basic.lean
+++ b/src/topology/basic.lean
@@ -1470,8 +1470,8 @@ end dense_range
 end continuous
 
 /--
-The library contains many lemmas that functions/operations are continuous. There are many ways
-to formulate the continuity of operations. Some are more convenient than others.
+The library contains many lemmas stating that functions/operations are continuous. There are many
+ways to formulate the continuity of operations. Some are more convenient than others.
 Note: for the most part this note also applies to other properties
 (measurable, differentiable, continuous_on, ...).
 
@@ -1480,7 +1480,7 @@ As an example, let's look at addition `(+) : M → M → M`. We can state that t
 in different definitionally equal ways (omitting some typing information)
 * `continuous (λ p, p.1 + p.2)`;
 * `continuous (function.uncurry (+))`;
-* `continuous ↿(+)`.
+* `continuous ↿(+)`. (`↿` is notation for recursively uncurrying a function)
 
 However, lemmas with this conclusion are not nice to use in practice because
 (1) They confuse the elaborator. The following two examples fail, because of limitations in the
@@ -1507,7 +1507,7 @@ continuous.add : {f g : X → M} (hf : continuous f) (hg : continuous g) : conti
 This has the following advantages
 * It supports projection notation, so is shorter to write.
 * `continuous.add _ _` is recognized correctly by the elaborator and gives useful new goals.
-* It works for in any application, since the domain is the variable `X`.
+* It works generally, since the domain is a variable.
 
 As an example for an unary operation, we have `continuous.neg`.
 ```
@@ -1522,12 +1522,11 @@ As a harder example, consider an operation of the following type:
 def strans {x : F} (γ γ' : path x x) (t₀ : I) : path x x
 ```
 The precise definition is not important, only its type.
-The correct continuity principle for this operation is:
+The correct continuity principle for this operation is something like this:
 ```
 {f : X → F} {γ γ' : ∀ x, path (f x) (f x)} {t₀ s : X → I}
   (hγ : continuous ↿γ) (hγ' : continuous ↿γ')
-  (ht : continuous t₀) (hs : continuous s)
-  (some additional assumptions, if the definition might contain continuities) :
+  (ht : continuous t₀) (hs : continuous s) :
   continuous (λ x, strans (γ x) (γ' x) (t x) (s x))
 ```
 Note that *all* arguments of `strans` are indexed over `X`, even the basepoint `x`, and the last
@@ -1547,5 +1546,18 @@ are unary functions from `I`) become binary functions in the continuity lemma.
 * These remarks are mostly about the format of the *conclusion* of a continuity lemma.
   In assumptions it's fine to state that a function with more than 1 argument is continuous using
   `↿` or `function.uncurry`.
+
+### Functions with discontinuities
+
+In some cases, you want to work with discontinuous functions, and in certain expressions they are
+still continuous. For example, consider the fractional part of a number, `fract : ℝ → ℝ`.
+In this case, you want to add conditions to when a function involving `fract` is continuous, so you
+get something like this: (assumption `hf` could be weakened, but the important thing is the shape
+of the conclusion)
+```
+lemma continuous_on.comp_fract {X Y : Type*} [topological_space X] [topological_space Y]
+  {f : X → ℝ → Y} {g : X → ℝ} (hf : continuous ↿f) (hg : continuous g) (h : ∀ s, f s 0 = f s 1) :
+  continuous (λ x, f x (fract (g x)))
+```
 -/
 library_note "continuity lemma statement"

--- a/src/topology/basic.lean
+++ b/src/topology/basic.lean
@@ -1473,7 +1473,7 @@ end continuous
 The library contains many lemmas stating that functions/operations are continuous. There are many
 ways to formulate the continuity of operations. Some are more convenient than others.
 Note: for the most part this note also applies to other properties
-(measurable, differentiable, continuous_on, ...).
+(`measurable`, `differentiable`, `continuous_on`, ...).
 
 ### The traditional way
 As an example, let's look at addition `(+) : M → M → M`. We can state that this is continuous
@@ -1502,7 +1502,7 @@ application the arguments in the domain might be in a different order or associa
 ### The convenient way
 A much more convenient way to write continuity lemmas is like `continuous.add`:
 ```
-continuous.add : {f g : X → M} (hf : continuous f) (hg : continuous g) : continuous (λ x, f x + g x)
+continuous.add {f g : X → M} (hf : continuous f) (hg : continuous g) : continuous (λ x, f x + g x)
 ```
 This has the following advantages
 * It supports projection notation, so is shorter to write.

--- a/src/topology/basic.lean
+++ b/src/topology/basic.lean
@@ -1483,27 +1483,28 @@ in different definitionally equal ways (omitting some typing information)
 * `continuous ↿(+)`. (`↿` is notation for recursively uncurrying a function)
 
 However, lemmas with this conclusion are not nice to use in practice because
-(1) They confuse the elaborator. The following two examples fail, because of limitations in the
-elaboration process.
-```
-variables {M : Type*} [has_mul M] [topological_space M] [has_continuous_mul M]
-example : continuous (λ x : M, x + x) :=
-continuous_add.comp _
+1. They confuse the elaborator. The following two examples fail, because of limitations in the
+  elaboration process.
+  ```
+  variables {M : Type*} [has_mul M] [topological_space M] [has_continuous_mul M]
+  example : continuous (λ x : M, x + x) :=
+  continuous_add.comp _
 
-example : continuous (λ x : M, x + x) :=
-continuous_add.comp (continuous_id.prod_mk continuous_id)
-```
-The second is a valid proof, which is accepted if you write it as
-`continuous_add.comp (continuous_id.prod_mk continuous_id : _)`
+  example : continuous (λ x : M, x + x) :=
+  continuous_add.comp (continuous_id.prod_mk continuous_id)
+  ```
+  The second is a valid proof, which is accepted if you write it as
+  `continuous_add.comp (continuous_id.prod_mk continuous_id : _)`
 
-(2) If the operation has more than 2 arguments, they are impractical to use, because in your
-application the arguments in the domain might be in a different order or associated differently.
+2. If the operation has more than 2 arguments, they are impractical to use, because in your
+  application the arguments in the domain might be in a different order or associated differently.
 
 ### The convenient way
 A much more convenient way to write continuity lemmas is like `continuous.add`:
 ```
 continuous.add {f g : X → M} (hf : continuous f) (hg : continuous g) : continuous (λ x, f x + g x)
 ```
+The conclusion can be `continuous (f + g)`, which is definitionally equal.
 This has the following advantages
 * It supports projection notation, so is shorter to write.
 * `continuous.add _ _` is recognized correctly by the elaborator and gives useful new goals.


### PR DESCRIPTION
* This is a note with some tips how to formulate a continuity (or measurability, differentiability, ...) lemma.
* I wanted to write this up after formulating `continuous.strans` in many "wrong" ways before discovering the "right" way.
* I think many lemmas are not following this principle, and could be improved in generality and/or convenience by following this advice.
* Based on experience from the sphere eversion project.
* The note mentions a lemma that will be added in #9959, but I don't think we necessarily have to wait for that PR.

---

Comments to improve this library note are welcome!

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
