### PR TITLE
[Merged by Bors] - refactor(order/boolean_algebra): factor out pi.sdiff and pi.compl

### DIFF
--- a/src/order/boolean_algebra.lean
+++ b/src/order/boolean_algebra.lean
@@ -691,6 +691,9 @@ boolean_algebra.of_core
 instance pi.has_sdiff {ι : Type u} {α : ι → Type v} [∀ i, has_sdiff (α i)] : has_sdiff (Π i, α i) :=
 ⟨λ x y i, x i \ y i⟩
 
+lemma pi.sdiff_def {ι : Type u} {α : ι → Type v} [∀ i, has_sdiff (α i)] (x y : Π i, α i) :
+  (x \ y) = λ i, x i \ y i := rfl
+
 @[simp]
 lemma pi.sdiff_apply {ι : Type u} {α : ι → Type v} [∀ i, has_sdiff (α i)] (x y : Π i, α i) (i : ι) :
   (x \ y) i = x i \ y i := rfl
@@ -698,8 +701,11 @@ lemma pi.sdiff_apply {ι : Type u} {α : ι → Type v} [∀ i, has_sdiff (α i)
 instance pi.has_compl {ι : Type u} {α : ι → Type v} [∀ i, has_compl (α i)] : has_compl (Π i, α i) :=
 ⟨λ x i, (x i)ᶜ⟩
 
+lemma pi.compl_def {ι : Type u} {α : ι → Type v} [∀ i, has_compl (α i)] (x : Π i, α i) :
+  xᶜ = λ i, (x i)ᶜ := rfl
+
 @[simp]
-lemma pi.compl_apply {ι : Type u} {α : ι → Type v} [∀ i, has_compl (α i)] (x : Π i, α i) (i : ι)  :
+lemma pi.compl_apply {ι : Type u} {α : ι → Type v} [∀ i, has_compl (α i)] (x : Π i, α i) (i : ι) :
   xᶜ i = (x i)ᶜ := rfl
 
 instance pi.boolean_algebra {ι : Type u} {α : ι → Type v} [∀ i, boolean_algebra (α i)] :

--- a/src/order/boolean_algebra.lean
+++ b/src/order/boolean_algebra.lean
@@ -688,7 +688,28 @@ boolean_algebra.of_core
   top_le_sup_compl := λ p H, classical.em p,
   .. Prop.bounded_distrib_lattice }
 
+instance pi.has_sdiff {ι : Type u} {α : ι → Type v} [∀ i, has_sdiff (α i)] : has_sdiff (Π i, α i) :=
+⟨λ x y i, x i \ y i⟩
+
+@[simp]
+lemma pi.sdiff_apply {ι : Type u} {α : ι → Type v} [∀ i, has_sdiff (α i)] (x y : Π i, α i) (i : ι) :
+  (x \ y) i = x i \ y i := rfl
+
+instance pi.has_compl {ι : Type u} {α : ι → Type v} [∀ i, has_compl (α i)] : has_compl (Π i, α i) :=
+⟨λ x i, (x i)ᶜ⟩
+
+@[simp]
+lemma pi.compl_apply {ι : Type u} {α : ι → Type v} [∀ i, has_compl (α i)] (x : Π i, α i) (i : ι)  :
+  xᶜ i = (x i)ᶜ := rfl
+
 instance pi.boolean_algebra {ι : Type u} {α : ι → Type v} [∀ i, boolean_algebra (α i)] :
   boolean_algebra (Π i, α i) :=
-by refine_struct { sdiff := λ x y i, x i \ y i, compl := λ x i, (x i)ᶜ, .. pi.bounded_lattice };
-  tactic.pi_instance_derive_field
+{ sdiff_eq := λ x y, funext $ λ i, sdiff_eq,
+  sup_inf_sdiff := λ x y, funext $ λ i, sup_inf_sdiff (x i) (y i),
+  inf_inf_sdiff := λ x y, funext $ λ i, inf_inf_sdiff (x i) (y i),
+  inf_compl_le_bot := λ _ _, boolean_algebra.inf_compl_le_bot _,
+  top_le_sup_compl := λ _ _, boolean_algebra.top_le_sup_compl _,
+  .. pi.has_sdiff,
+  .. pi.has_compl,
+  .. pi.bounded_lattice,
+  .. pi.distrib_lattice }


### PR DESCRIPTION
Provide definitional lemmas about sdiff and compl on pi types.
This allows usage later on even without a whole `boolean_algebra` instance.



---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
