### PR TITLE
[Merged by Bors] - chore(topology,measure_theory): generalize a few instances

### DIFF
--- a/src/data/subtype.lean
+++ b/src/data/subtype.lean
@@ -111,6 +111,15 @@ lemma restrict_injective {α β} {f : α → β} (p : α → Prop) (h : injectiv
   injective (restrict f p) :=
 h.comp coe_injective
 
+lemma surjective_restrict {α} {β : α → Type*} [ne : Π a, nonempty (β a)] (p : α → Prop) :
+  surjective (λ f : Π x, β x, restrict f p) :=
+begin
+  letI := classical.dec_pred p,
+  refine λ f, ⟨λ x, if h : p x then f ⟨x, h⟩ else nonempty.some (ne x), funext $ _⟩,
+  rintro ⟨x, hx⟩,
+  exact dif_pos hx
+end
+
 /-- Defining a map into a subtype, this can be seen as an "coinduction principle" of `subtype`-/
 @[simps] def coind {α β} (f : α → β) {p : β → Prop} (h : ∀ a, p (f a)) : α → subtype p :=
 λ a, ⟨f a, h a⟩

--- a/src/measure_theory/constructions/borel_space.lean
+++ b/src/measure_theory/constructions/borel_space.lean
@@ -281,7 +281,7 @@ instance opens_measurable_space.to_measurable_singleton_class [t1_space α] :
   measurable_singleton_class α :=
 ⟨λ x, is_closed_singleton.measurable_set⟩
 
-instance pi.opens_measurable_space {ι : Type*} {π : ι → Type*} [fintype ι]
+instance pi.opens_measurable_space_encodable {ι : Type*} {π : ι → Type*} [encodable ι]
   [t' : Π i, topological_space (π i)]
   [Π i, measurable_space (π i)] [∀ i, second_countable_topology (π i)]
   [∀ i, opens_measurable_space (π i)] :
@@ -299,6 +299,13 @@ begin
   rw [eq_generate_from_countable_basis (π a)],
   exact generate_open.basic _ (hi a ha)
 end
+
+instance pi.opens_measurable_space_fintype {ι : Type*} {π : ι → Type*} [fintype ι]
+  [t' : Π i, topological_space (π i)]
+  [Π i, measurable_space (π i)] [∀ i, second_countable_topology (π i)]
+  [∀ i, opens_measurable_space (π i)] :
+  opens_measurable_space (Π i, π i) :=
+by { letI := fintype.encodable ι, apply_instance }
 
 instance prod.opens_measurable_space [second_countable_topology α] [second_countable_topology β] :
   opens_measurable_space (α × β) :=
@@ -595,7 +602,14 @@ begin
   { exact comap_le_iff_le_map.mpr continuous_snd.borel_measurable }
 end
 
-instance pi.borel_space {ι : Type*} {π : ι → Type*} [fintype ι]
+instance pi.borel_space_fintype_encodable {ι : Type*} {π : ι → Type*} [encodable ι]
+  [t' : Π i, topological_space (π i)]
+  [Π i, measurable_space (π i)] [∀ i, second_countable_topology (π i)]
+  [∀ i, borel_space (π i)] :
+  borel_space (Π i, π i) :=
+⟨le_antisymm pi_le_borel_pi opens_measurable_space.borel_le⟩
+
+instance pi.borel_space_fintype {ι : Type*} {π : ι → Type*} [fintype ι]
   [t' : Π i, topological_space (π i)]
   [Π i, measurable_space (π i)] [∀ i, second_countable_topology (π i)]
   [∀ i, borel_space (π i)] :

--- a/src/topology/bases.lean
+++ b/src/topology/bases.lean
@@ -533,21 +533,33 @@ instance {β : Type*} [topological_space β]
 ((is_basis_countable_basis α).prod (is_basis_countable_basis β)).second_countable_topology $
   (countable_countable_basis α).image2 (countable_countable_basis β) _
 
-instance second_countable_topology_fintype {ι : Type*} {π : ι → Type*}
-  [fintype ι] [t : ∀a, topological_space (π a)] [sc : ∀a, second_countable_topology (π a)] :
+instance second_countable_topology_encodable {ι : Type*} {π : ι → Type*}
+  [encodable ι] [t : ∀a, topological_space (π a)] [∀a, second_countable_topology (π a)] :
   second_countable_topology (∀a, π a) :=
 begin
   have : t = (λa, generate_from (countable_basis (π a))),
     from funext (assume a, (is_basis_countable_basis (π a)).eq_generate_from),
-  rw this,
-  constructor,
-  refine ⟨pi univ '' pi univ (λ a, countable_basis (π a)), countable.image _ _, _⟩,
-  { suffices : countable {f : Πa, set (π a) | ∀a, f a ∈ countable_basis (π a)}, { simpa [pi] },
-    exact countable_pi (assume i, (countable_countable_basis _)), },
-  rw [pi_generate_from_eq_fintype],
-  { congr' 1 with f, simp [pi, eq_comm] },
-  exact assume a, (is_basis_countable_basis (π a)).sUnion_eq
+  rw [this, pi_generate_from_eq],
+  constructor, refine ⟨_, _, rfl⟩,
+  have : countable {T : set (Π i, π i) | ∃ (I : finset ι) (s : Π i : I, set (π i)),
+    (∀ i, s i ∈ countable_basis (π i)) ∧ T = {f | ∀ i : I, f i ∈ s i}},
+  { simp only [set_of_exists, ← exists_prop],
+    refine countable_Union (λ I, countable.bUnion _ (λ _ _, countable_singleton _)),
+    change countable {s : Π i : I, set (π i) | ∀ i, s i ∈ countable_basis (π i)},
+    exact countable_pi (λ i, countable_countable_basis _) },
+  convert this using 1, ext1 T, split,
+  { rintro ⟨s, I, hs, rfl⟩,
+    refine ⟨I, λ i, s i, λ i, hs i i.2, _⟩,
+    simp only [set.pi, set_coe.forall'], refl },
+  { rintro ⟨I, s, hs, rfl⟩,
+    rcases @subtype.surjective_restrict ι (λ i, set (π i)) _ (λ i, i ∈ I) s with ⟨s, rfl⟩,
+    exact ⟨s, I, λ i hi, hs ⟨i, hi⟩, set.ext $ λ f, subtype.forall⟩ }
 end
+
+instance second_countable_topology_fintype {ι : Type*} {π : ι → Type*}
+  [fintype ι] [t : ∀a, topological_space (π a)] [∀a, second_countable_topology (π a)] :
+  second_countable_topology (∀a, π a) :=
+by { letI := fintype.encodable ι, exact topological_space.second_countable_topology_encodable }
 
 @[priority 100] -- see Note [lower instance priority]
 instance second_countable_topology.to_separable_space


### PR DESCRIPTION
* Prove that `Π i : ι, π i` has second countable topology if `ι` is encodable and each `π i` has second countable topology.
* Similarly for `borel_space`.
* Preserve old instances about `fintype` because we don't have (and can't have) an instance `fintype ι → encodable ι`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
