### PR TITLE
[Merged by Bors] - refactor(topology+algebraic_geometry): prove and make use of equalities to simplify definitions

### DIFF
--- a/src/algebraic_geometry/Scheme.lean
+++ b/src/algebraic_geometry/Scheme.lean
@@ -34,7 +34,7 @@ for some `R : CommRing`.
 -/
 structure Scheme extends X : LocallyRingedSpace :=
 (local_affine : ∀ x : X, ∃ (U : open_nhds x) (R : CommRing),
-  nonempty (X.restrict _ U.open_embedding ≅ Spec.to_LocallyRingedSpace.obj (op R)))
+  nonempty (X.restrict U.open_embedding ≅ Spec.to_LocallyRingedSpace.obj (op R)))
 
 namespace Scheme
 
@@ -109,10 +109,10 @@ lemma Γ_def : Γ = (induced_functor Scheme.to_LocallyRingedSpace).op ⋙ Locall
 lemma Γ_obj_op (X : Scheme) : Γ.obj (op X) = X.presheaf.obj (op ⊤) := rfl
 
 @[simp] lemma Γ_map {X Y : Schemeᵒᵖ} (f : X ⟶ Y) :
-  Γ.map f = f.unop.1.c.app (op ⊤) ≫ (unop Y).presheaf.map (opens.le_map_top _ _).op := rfl
+  Γ.map f = f.unop.1.c.app (op ⊤) := rfl
 
 lemma Γ_map_op {X Y : Scheme} (f : X ⟶ Y) :
-  Γ.map f.op = f.1.c.app (op ⊤) ≫ X.presheaf.map (opens.le_map_top _ _).op := rfl
+  Γ.map f.op = f.1.c.app (op ⊤) := rfl
 
 -- PROJECTS:
 -- 1. Construct `Spec ≫ Γ ≅ functor.id _`.

--- a/src/algebraic_geometry/Spec.lean
+++ b/src/algebraic_geometry/Spec.lean
@@ -109,12 +109,7 @@ end
 lemma Spec.SheafedSpace_map_comp {R S T : CommRing} (f : R ⟶ S) (g : S ⟶ T) :
   Spec.SheafedSpace_map (f ≫ g) = Spec.SheafedSpace_map g ≫ Spec.SheafedSpace_map f :=
 PresheafedSpace.ext _ _ (Spec.Top_map_comp f g) $ nat_trans.ext _ _ $ funext $ λ U,
-begin
-  dsimp,
-  rw [category.comp_id],
-    rw [(structure_sheaf T).1.map_id, category.comp_id, comap_comp],
-  refl,
-end
+by { dsimp, rw category.comp_id, erw comap_comp f g, refl }
 
 /--
 Spec, as a contravariant functor from commutative rings to sheafed spaces.

--- a/src/algebraic_geometry/Spec.lean
+++ b/src/algebraic_geometry/Spec.lean
@@ -103,8 +103,7 @@ begin
   dsimp,
   erw [PresheafedSpace.id_c_app, comap_id], swap,
     { rw [Spec.Top_map_id, topological_space.opens.map_id_obj_unop] },
-  rw [eq_to_hom_op, eq_to_hom_map, eq_to_hom_trans],
-  refl,
+  simpa,
 end
 
 lemma Spec.SheafedSpace_map_comp {R S T : CommRing} (f : R ⟶ S) (g : S ⟶ T) :
@@ -112,8 +111,8 @@ lemma Spec.SheafedSpace_map_comp {R S T : CommRing} (f : R ⟶ S) (g : S ⟶ T) 
 PresheafedSpace.ext _ _ (Spec.Top_map_comp f g) $ nat_trans.ext _ _ $ funext $ λ U,
 begin
   dsimp,
-  erw [Top.presheaf.pushforward.comp_inv_app, ← category.assoc, category.comp_id,
-    (structure_sheaf T).1.map_id, category.comp_id, comap_comp],
+  rw [category.comp_id],
+    rw [(structure_sheaf T).1.map_id, category.comp_id, comap_comp],
   refl,
 end
 

--- a/src/algebraic_geometry/locally_ringed_space.lean
+++ b/src/algebraic_geometry/locally_ringed_space.lean
@@ -32,7 +32,7 @@ namespace algebraic_geometry
 such that all the stalks are local rings.
 
 A morphism of locally ringed spaces is a morphism of ringed spaces
-such that the morphims induced on stalks are local ring homomorphisms. -/
+such that the morphisms induced on stalks are local ring homomorphisms. -/
 @[nolint has_inhabited_instance]
 structure LocallyRingedSpace extends SheafedSpace CommRing :=
 (local_ring : ∀ x, local_ring (presheaf.stalk x))

--- a/src/algebraic_geometry/locally_ringed_space.lean
+++ b/src/algebraic_geometry/locally_ringed_space.lean
@@ -166,7 +166,7 @@ instance : reflects_isomorphisms forget_to_SheafedSpace :=
 The restriction of a locally ringed space along an open embedding.
 -/
 @[simps]
-def restrict {U : Top} (X : LocallyRingedSpace) (f : U ⟶ X.to_Top)
+def restrict {U : Top} (X : LocallyRingedSpace) {f : U ⟶ X.to_Top}
   (h : open_embedding f) : LocallyRingedSpace :=
 { local_ring :=
   begin
@@ -174,16 +174,16 @@ def restrict {U : Top} (X : LocallyRingedSpace) (f : U ⟶ X.to_Top)
     dsimp at *,
     -- We show that the stalk of the restriction is isomorphic to the original stalk,
     apply @ring_equiv.local_ring _ _ _ (X.local_ring (f x)),
-    exact (X.to_PresheafedSpace.restrict_stalk_iso f h x).symm.CommRing_iso_to_ring_equiv,
+    exact (X.to_PresheafedSpace.restrict_stalk_iso h x).symm.CommRing_iso_to_ring_equiv,
   end,
-  .. X.to_SheafedSpace.restrict f h }
+  .. X.to_SheafedSpace.restrict h }
 
 /--
 The restriction of a locally ringed space `X` to the top subspace is isomorphic to `X` itself.
 -/
 def restrict_top_iso (X : LocallyRingedSpace) :
-  X.restrict (opens.inclusion ⊤) (opens.open_embedding ⊤) ≅ X :=
-@iso_of_SheafedSpace_iso (X.restrict (opens.inclusion ⊤) (opens.open_embedding ⊤)) X
+  X.restrict (opens.open_embedding ⊤) ≅ X :=
+@iso_of_SheafedSpace_iso (X.restrict (opens.open_embedding ⊤)) X
   X.to_SheafedSpace.restrict_top_iso
 
 /--
@@ -199,10 +199,10 @@ lemma Γ_def : Γ = forget_to_SheafedSpace.op ⋙ SheafedSpace.Γ := rfl
 lemma Γ_obj_op (X : LocallyRingedSpace) : Γ.obj (op X) = X.presheaf.obj (op ⊤) := rfl
 
 @[simp] lemma Γ_map {X Y : LocallyRingedSpaceᵒᵖ} (f : X ⟶ Y) :
-  Γ.map f = f.unop.1.c.app (op ⊤) ≫ (unop Y).presheaf.map (opens.le_map_top _ _).op := rfl
+  Γ.map f = f.unop.1.c.app (op ⊤) := rfl
 
 lemma Γ_map_op {X Y : LocallyRingedSpace} (f : X ⟶ Y) :
-  Γ.map f.op = f.1.c.app (op ⊤) ≫ X.presheaf.map (opens.le_map_top _ _).op := rfl
+  Γ.map f.op = f.1.c.app (op ⊤) := rfl
 
 end LocallyRingedSpace
 

--- a/src/algebraic_geometry/presheafed_space.lean
+++ b/src/algebraic_geometry/presheafed_space.lean
@@ -67,7 +67,7 @@ structure hom (X Y : PresheafedSpace C) :=
 
 @[ext] lemma ext {X Y : PresheafedSpace C} (α β : hom X Y)
   (w : α.base = β.base)
-  (h : α.c ≫ eq_to_hom (presheaf.pushforward_eq' w _) = β.c) :
+  (h : α.c ≫ eq_to_hom (by rw w) = β.c) :
   α = β :=
 begin
   cases α, cases β,
@@ -112,24 +112,13 @@ instance category_of_PresheafedSpaces : category (PresheafedSpace C) :=
 { hom := hom,
   id := id,
   comp := λ X Y Z f g, comp f g,
-  id_comp' := λ X Y f,
-  begin
-    ext1, { rw comp_c,
-      erw eq_to_hom_map, simp,
-      apply comp_id },
-    apply id_comp,
-  end,
-  comp_id' := λ X Y f,
-  begin
-    ext1, { rw comp_c,
-      erw congr_hom (presheaf.id_pushforward) f.c,
-      simp, erw eq_to_hom_trans_assoc, simp },
-    apply comp_id,
-  end,
-  assoc' := λ W X Y Z f g h,
-  begin
-    ext1, repeat {rw comp_c}, simpa, refl,
-  end }
+  id_comp' := λ X Y f, by { ext1,
+    { rw comp_c, erw eq_to_hom_map, simp, apply comp_id }, apply id_comp },
+  comp_id' := λ X Y f, by { ext1,
+    { rw comp_c, erw congr_hom (presheaf.id_pushforward) f.c,
+      simp, erw eq_to_hom_trans_assoc, simp }, apply comp_id },
+  assoc' := λ W X Y Z f g h, by { ext1,
+    repeat {rw comp_c}, simpa, refl } }
 
 end
 
@@ -183,7 +172,7 @@ def of_restrict {U : Top} (X : PresheafedSpace C)
   X.restrict h ⟶ X :=
 { base := f,
   c := { app := λ V, X.presheaf.map (h.is_open_map.adjunction.counit.app V.unop).op,
-    naturality':= λ U V f, show _ = _ ≫ X.presheaf.map _,
+    naturality' := λ U V f, show _ = _ ≫ X.presheaf.map _,
       by { rw [← map_comp, ← map_comp], refl } } }
 
 lemma restrict_top_presheaf (X : PresheafedSpace C) :

--- a/src/algebraic_geometry/presheafed_space.lean
+++ b/src/algebraic_geometry/presheafed_space.lean
@@ -67,26 +67,37 @@ structure hom (X Y : PresheafedSpace C) :=
 
 @[ext] lemma ext {X Y : PresheafedSpace C} (α β : hom X Y)
   (w : α.base = β.base)
-  (h : α.c ≫ (whisker_right (nat_trans.op (opens.map_iso _ _ w).inv) X.presheaf) = β.c) :
+  (h : α.c ≫ eq_to_hom (presheaf.pushforward_eq' w _) = β.c) :
   α = β :=
 begin
   cases α, cases β,
   dsimp [presheaf.pushforward_obj] at *,
   tidy, -- TODO including `injections` would make tidy work earlier.
 end
+
+lemma ext' {X Y : PresheafedSpace C} (α β : hom X Y)
+  (w : α.base = β.base)
+  (h : α.c == β.c) :
+  α = β :=
+by { cases α, cases β, congr, exacts [w,h] }
+
 .
 
 /-- The identity morphism of a `PresheafedSpace`. -/
 def id (X : PresheafedSpace C) : hom X X :=
 { base := 𝟙 (X : Top.{v}),
-  c := (functor.left_unitor _).inv ≫ whisker_right (nat_trans.op (opens.map_id X.carrier).hom) _ }
+  c := eq_to_hom (presheaf.pushforward.id_eq X.presheaf).symm }
 
 instance hom_inhabited (X : PresheafedSpace C) : inhabited (hom X X) := ⟨id X⟩
 
 /-- Composition of morphisms of `PresheafedSpace`s. -/
 def comp {X Y Z : PresheafedSpace C} (α : hom X Y) (β : hom Y Z) : hom X Z :=
 { base := α.base ≫ β.base,
-  c := β.c ≫ (whisker_left (opens.map β.base).op α.c) ≫ (Top.presheaf.pushforward.comp _ _ _).inv }
+  c := β.c ≫ (presheaf.pushforward β.base).map α.c }
+
+lemma comp_c {X Y Z : PresheafedSpace C} (α : hom X Y) (β : hom Y Z) :
+  (comp α β).c = β.c ≫ (presheaf.pushforward β.base).map α.c := rfl
+
 
 variables (C)
 
@@ -103,33 +114,21 @@ instance category_of_PresheafedSpaces : category (PresheafedSpace C) :=
   comp := λ X Y Z f g, comp f g,
   id_comp' := λ X Y f,
   begin
-    ext1, swap,
-    { dsimp, simp only [id_comp] },  -- See note [dsimp, simp].
-    { ext U, induction U using opposite.rec, cases U,
-      dsimp,
-      simp only [presheaf.pushforward.comp_inv_app, opens.map_iso_inv_app],
-      dsimp,
-      simp only [comp_id, comp_id, map_id], },
+    ext1, { rw comp_c,
+      erw eq_to_hom_map, simp,
+      apply comp_id },
+    apply id_comp,
   end,
   comp_id' := λ X Y f,
   begin
-    ext1, swap,
-    { dsimp, simp only [comp_id] },
-    { ext U, induction U using opposite.rec, cases U,
-      dsimp,
-      simp only [presheaf.pushforward.comp_inv_app, opens.map_iso_inv_app],
-      dsimp,
-      simp only [id_comp, comp_id, map_id], }
+    ext1, { rw comp_c,
+      erw congr_hom (presheaf.id_pushforward) f.c,
+      simp, erw eq_to_hom_trans_assoc, simp },
+    apply comp_id,
   end,
   assoc' := λ W X Y Z f g h,
   begin
-     ext1, swap,
-     refl,
-     { ext U, induction U using opposite.rec, cases U,
-       dsimp,
-       simp only [assoc, presheaf.pushforward.comp_inv_app, opens.map_iso_inv_app],
-       dsimp,
-       simp only [comp_id, id_comp, map_id], }
+    ext1, repeat {rw comp_c}, simpa, refl,
   end }
 
 end
@@ -137,11 +136,10 @@ end
 variables {C}
 
 @[simp] lemma id_base (X : PresheafedSpace C) :
-  ((𝟙 X) : X ⟶ X).base = (𝟙 (X : Top.{v})) := rfl
+  ((𝟙 X) : X ⟶ X).base = 𝟙 (X : Top.{v}) := rfl
 
 lemma id_c (X : PresheafedSpace C) :
-  ((𝟙 X) : X ⟶ X).c =
-  (functor.left_unitor _).inv ≫ whisker_right (nat_trans.op (opens.map_id X.carrier).hom) _ := rfl
+  ((𝟙 X) : X ⟶ X).c = eq_to_hom (presheaf.pushforward.id_eq X.presheaf).symm := rfl
 
 @[simp] lemma id_c_app (X : PresheafedSpace C) (U) :
   ((𝟙 X) : X ⟶ X).c.app U = eq_to_hom (by { induction U using opposite.rec, cases U, refl }) :=
@@ -151,8 +149,7 @@ by { induction U using opposite.rec, cases U, simp only [id_c], dsimp, simp, }
   (f ≫ g).base = f.base ≫ g.base := rfl
 
 @[simp] lemma comp_c_app {X Y Z : PresheafedSpace C} (α : X ⟶ Y) (β : Y ⟶ Z) (U) :
-  (α ≫ β).c.app U = (β.c).app U ≫ (α.c).app (op ((opens.map (β.base)).obj (unop U))) ≫
-    (Top.presheaf.pushforward.comp _ _ _).inv.app U := rfl
+  (α ≫ β).c.app U = (β.c).app U ≫ (α.c).app (op ((opens.map (β.base)).obj (unop U))) := rfl
 
 lemma congr_app {X Y : PresheafedSpace C} {α β : X ⟶ Y} (h : α = β) (U) :
   α.c.app U = β.c.app U ≫ X.presheaf.map (eq_to_hom (by subst h)) :=
@@ -174,7 +171,7 @@ The restriction of a presheafed space along an open embedding into the space.
 -/
 @[simps]
 def restrict {U : Top} (X : PresheafedSpace C)
-  (f : U ⟶ (X : Top.{v})) (h : open_embedding f) : PresheafedSpace C :=
+  {f : U ⟶ (X : Top.{v})} (h : open_embedding f) : PresheafedSpace C :=
 { carrier := U,
   presheaf := h.is_open_map.functor.op ⋙ X.presheaf }
 
@@ -182,13 +179,33 @@ def restrict {U : Top} (X : PresheafedSpace C)
 The map from the restriction of a presheafed space.
 -/
 def of_restrict {U : Top} (X : PresheafedSpace C)
-  (f : U ⟶ (X : Top.{v})) (h : open_embedding f) :
-  X.restrict f h ⟶ X :=
+  {f : U ⟶ (X : Top.{v})} (h : open_embedding f) :
+  X.restrict h ⟶ X :=
 { base := f,
-  c := { app := λ V, X.presheaf.map $
-      ((h.is_open_map.adjunction.hom_equiv _ _).symm (𝟙 $ (opens.map f).obj $ unop V)).op,
+  c := { app := λ V, X.presheaf.map (h.is_open_map.adjunction.counit.app V.unop).op,
     naturality':= λ U V f, show _ = _ ≫ X.presheaf.map _,
       by { rw [← map_comp, ← map_comp], refl } } }
+
+lemma restrict_top_presheaf (X : PresheafedSpace C) :
+  (X.restrict (opens.open_embedding ⊤)).presheaf =
+  (opens.inclusion_top_iso X.carrier).inv _* X.presheaf :=
+by { dsimp, rw opens.inclusion_top_functor X.carrier, refl }
+
+lemma of_restrict_top_c (X : PresheafedSpace C) :
+  ∃ h, (X.of_restrict (opens.open_embedding ⊤)).c = eq_to_hom h :=
+  /- another approach would be to prove the left hand side
+     is a natural isoomorphism, but I encountered a universe
+     issue when `apply nat_iso.is_iso_of_is_iso_app`. -/
+begin
+  fsplit, { rw [restrict_top_presheaf, ←presheaf.pushforward.comp_eq],
+    erw iso.inv_hom_id, rw presheaf.pushforward.id_eq },
+  ext U, change X.presheaf.map _ = _, convert eq_to_hom_map _ _ using 1,
+  congr, simpa,
+  { induction U using opposite.rec, dsimp, congr, ext,
+    exact ⟨ λ h, ⟨⟨x,trivial⟩,h,rfl⟩, λ ⟨⟨_,_⟩,h,rfl⟩, h ⟩ },
+    /- or `rw [opens.inclusion_top_functor, ←comp_obj, ←opens.map_comp_eq],
+           erw iso.inv_hom_id, cases U, refl` after `dsimp` -/
+end
 
 /--
 The map to the restriction of a presheafed space along the canonical inclusion from the top
@@ -196,37 +213,22 @@ subspace.
 -/
 @[simps]
 def to_restrict_top (X : PresheafedSpace C) :
-  X ⟶ X.restrict (opens.inclusion ⊤) (opens.open_embedding ⊤) :=
-{ base := ⟨λ x, ⟨x, trivial⟩, continuous_def.2 $ λ U ⟨S, hS, hSU⟩, hSU ▸ hS⟩,
-  c := { app := λ U, X.presheaf.map $ (hom_of_le $ λ x hxU, ⟨⟨x, trivial⟩, hxU, rfl⟩ :
-      (opens.map (⟨λ x, ⟨x, trivial⟩, continuous_def.2 $ λ U ⟨S, hS, hSU⟩, hSU ▸ hS⟩ :
-          X.1 ⟶ (opens.to_Top X.1).obj ⊤)).obj (unop U) ⟶
-        (opens.open_embedding ⊤).is_open_map.functor.obj (unop U)).op,
-    naturality':= λ U V f, show X.presheaf.map _ ≫ _ = _ ≫ X.presheaf.map _,
-      by { rw [← map_comp, ← map_comp], refl } } }
+  X ⟶ X.restrict (opens.open_embedding ⊤) :=
+{ base := (opens.inclusion_top_iso X.carrier).inv,
+  c := eq_to_hom (restrict_top_presheaf X) }
 
 /--
 The isomorphism from the restriction to the top subspace.
 -/
 @[simps]
 def restrict_top_iso (X : PresheafedSpace C) :
-  X.restrict (opens.inclusion ⊤) (opens.open_embedding ⊤) ≅ X :=
-{ hom := X.of_restrict _ _,
+  X.restrict (opens.open_embedding ⊤) ≅ X :=
+{ hom := X.of_restrict _,
   inv := X.to_restrict_top,
   hom_inv_id' := ext _ _ (concrete_category.hom_ext _ _ $ λ ⟨x, _⟩, rfl) $
-    nat_trans.ext _ _ $ funext $ λ U, by { induction U using opposite.rec,
-      dsimp only [nat_trans.comp_app, comp_c_app, to_restrict_top, of_restrict,
-          whisker_right_app, comp_base, nat_trans.op_app, opens.map_iso_inv_app],
-      erw [presheaf.pushforward.comp_inv_app, comp_id, ← X.presheaf.map_comp,
-          ← X.presheaf.map_comp, id_c_app],
-      exact X.presheaf.map_id _ },
-  inv_hom_id' := ext _ _ rfl $ nat_trans.ext _ _ $ funext $ λ U, by {
-    induction U using opposite.rec,
-    dsimp only [nat_trans.comp_app, comp_c_app, of_restrict, to_restrict_top,
-        whisker_right_app, comp_base, nat_trans.op_app, opens.map_iso_inv_app],
-    erw [← X.presheaf.map_comp, ← X.presheaf.map_comp, ← X.presheaf.map_comp, id_c_app],
-    convert eq_to_hom_map X.presheaf _,
-    erw [op_obj, id_base, opens.map_id_obj], refl } }
+    by { erw comp_c, rw X.of_restrict_top_c.some_spec, simpa },
+  inv_hom_id' := ext _ _ rfl $
+    by { erw comp_c, rw X.of_restrict_top_c.some_spec, simpa } }
 
 /--
 The global sections, notated Gamma.
@@ -234,24 +236,12 @@ The global sections, notated Gamma.
 @[simps]
 def Γ : (PresheafedSpace C)ᵒᵖ ⥤ C :=
 { obj := λ X, (unop X).presheaf.obj (op ⊤),
-  map := λ X Y f, f.unop.c.app (op ⊤) ≫ (unop Y).presheaf.map (opens.le_map_top _ _).op,
-  map_id' := λ X, begin
-    induction X using opposite.rec,
-    erw [unop_id_op, id_c_app, eq_to_hom_refl, id_comp],
-    exact X.presheaf.map_id _
-  end,
-  map_comp' := λ X Y Z f g, begin
-    rw [unop_comp, comp_c_app],
-    simp_rw category.assoc,
-    erw [nat_trans.naturality_assoc, presheaf.pushforward.comp_inv_app, id_comp,
-        category_theory.functor.comp_map, ← map_comp],
-    refl
-  end }
+  map := λ X Y f, f.unop.c.app (op ⊤) }
 
 lemma Γ_obj_op (X : PresheafedSpace C) : Γ.obj (op X) = X.presheaf.obj (op ⊤) := rfl
 
 lemma Γ_map_op {X Y : PresheafedSpace C} (f : X ⟶ Y) :
-  Γ.map f.op = f.c.app (op ⊤) ≫ X.presheaf.map (opens.le_map_top _ _).op := rfl
+  Γ.map f.op = f.c.app (op ⊤) := rfl
 
 end PresheafedSpace
 
@@ -294,8 +284,7 @@ A natural transformation induces a natural transformation between the `map_presh
 def on_presheaf {F G : C ⥤ D} (α : F ⟶ G) : G.map_presheaf ⟶ F.map_presheaf :=
 { app := λ X,
   { base := 𝟙 _,
-    c := whisker_left X.presheaf α ≫ (functor.left_unitor _).inv ≫
-           whisker_right (nat_trans.op (opens.map_id X.carrier).hom) _ }, }
+    c := whisker_left X.presheaf α ≫ eq_to_hom (presheaf.pushforward.id_eq _).symm } }
 
 -- TODO Assemble the last two constructions into a functor
 --   `(C ⥤ D) ⥤ (PresheafedSpace C ⥤ PresheafedSpace D)`

--- a/src/algebraic_geometry/presheafed_space.lean
+++ b/src/algebraic_geometry/presheafed_space.lean
@@ -75,7 +75,7 @@ begin
   tidy, -- TODO including `injections` would make tidy work earlier.
 end
 
-lemma ext' {X Y : PresheafedSpace C} (α β : hom X Y)
+lemma hext {X Y : PresheafedSpace C} (α β : hom X Y)
   (w : α.base = β.base)
   (h : α.c == β.c) :
   α = β :=
@@ -181,19 +181,19 @@ lemma restrict_top_presheaf (X : PresheafedSpace C) :
 by { dsimp, rw opens.inclusion_top_functor X.carrier, refl }
 
 lemma of_restrict_top_c (X : PresheafedSpace C) :
-  ∃ h, (X.of_restrict (opens.open_embedding ⊤)).c = eq_to_hom h :=
+  (X.of_restrict (opens.open_embedding ⊤)).c = eq_to_hom
+    (by { rw [restrict_top_presheaf, ←presheaf.pushforward.comp_eq],
+          erw iso.inv_hom_id, rw presheaf.pushforward.id_eq }) :=
   /- another approach would be to prove the left hand side
      is a natural isoomorphism, but I encountered a universe
      issue when `apply nat_iso.is_iso_of_is_iso_app`. -/
 begin
-  fsplit, { rw [restrict_top_presheaf, ←presheaf.pushforward.comp_eq],
-    erw iso.inv_hom_id, rw presheaf.pushforward.id_eq },
   ext U, change X.presheaf.map _ = _, convert eq_to_hom_map _ _ using 1,
   congr, simpa,
   { induction U using opposite.rec, dsimp, congr, ext,
     exact ⟨ λ h, ⟨⟨x,trivial⟩,h,rfl⟩, λ ⟨⟨_,_⟩,h,rfl⟩, h ⟩ },
-    /- or `rw [opens.inclusion_top_functor, ←comp_obj, ←opens.map_comp_eq],
-           erw iso.inv_hom_id, cases U, refl` after `dsimp` -/
+  /- or `rw [opens.inclusion_top_functor, ←comp_obj, ←opens.map_comp_eq],
+         erw iso.inv_hom_id, cases U, refl` after `dsimp` -/
 end
 
 /--
@@ -215,9 +215,9 @@ def restrict_top_iso (X : PresheafedSpace C) :
 { hom := X.of_restrict _,
   inv := X.to_restrict_top,
   hom_inv_id' := ext _ _ (concrete_category.hom_ext _ _ $ λ ⟨x, _⟩, rfl) $
-    by { erw comp_c, rw X.of_restrict_top_c.some_spec, simpa },
+    by { erw comp_c, rw X.of_restrict_top_c, simpa },
   inv_hom_id' := ext _ _ rfl $
-    by { erw comp_c, rw X.of_restrict_top_c.some_spec, simpa } }
+    by { erw comp_c, rw X.of_restrict_top_c, simpa } }
 
 /--
 The global sections, notated Gamma.

--- a/src/algebraic_geometry/presheafed_space/has_colimits.lean
+++ b/src/algebraic_geometry/presheafed_space/has_colimits.lean
@@ -164,8 +164,7 @@ def colimit_cocone (F : J ⥤ PresheafedSpace C) : cocone F :=
         congr,
         dsimp,
         simp only [id_comp],
-        rw ←is_iso.inv_comp_eq,
-        simp, refl, }
+        simpa, }
     end, }, }
 
 namespace colimit_cocone_is_colimit
@@ -196,7 +195,7 @@ begin
     replace w := congr_arg op w,
     have w' := nat_trans.congr (F.map f.unop).c w,
     rw w',
-    dsimp, simp, dsimp, simp, refl, },
+    dsimp, simp, dsimp, simp, },
 end
 
 lemma desc_c_naturality (F : J ⥤ PresheafedSpace C) (s : cocone F)

--- a/src/algebraic_geometry/presheafed_space/has_colimits.lean
+++ b/src/algebraic_geometry/presheafed_space/has_colimits.lean
@@ -264,7 +264,7 @@ def colimit_cocone_is_colimit (F : J ⥤ PresheafedSpace C) : is_colimit (colimi
       dsimp,
       have w := congr_arg op (functor.congr_obj (congr_arg opens.map t) (unop U)),
       rw nat_trans.congr (limit.π (pushforward_diagram_to_colimit F).left_op j) w,
-      simp, dsimp, simp, }
+      simpa }
   end, }
 
 /--

--- a/src/algebraic_geometry/sheafed_space.lean
+++ b/src/algebraic_geometry/sheafed_space.lean
@@ -78,9 +78,7 @@ local attribute [simp] id comp
   ((𝟙 X) : X ⟶ X).base = (𝟙 (X : Top.{v})) := rfl
 
 lemma id_c (X : SheafedSpace C) :
-  ((𝟙 X) : X ⟶ X).c =
-  (((functor.left_unitor _).inv) ≫
-  (whisker_right (nat_trans.op (opens.map_id (X.carrier)).hom) _)) := rfl
+  ((𝟙 X) : X ⟶ X).c = eq_to_hom (presheaf.pushforward.id_eq X.presheaf).symm := rfl
 
 @[simp] lemma id_c_app (X : SheafedSpace C) (U) :
   ((𝟙 X) : X ⟶ X).c.app U = eq_to_hom (by { induction U using opposite.rec, cases U, refl }) :=
@@ -90,8 +88,8 @@ by { induction U using opposite.rec, cases U, simp only [id_c], dsimp, simp, }
   (f ≫ g).base = f.base ≫ g.base := rfl
 
 @[simp] lemma comp_c_app {X Y Z : SheafedSpace C} (α : X ⟶ Y) (β : Y ⟶ Z) (U) :
-  (α ≫ β).c.app U = (β.c).app U ≫ (α.c).app (op ((opens.map (β.base)).obj (unop U))) ≫
-    (Top.presheaf.pushforward.comp _ _ _).inv.app U := rfl
+  (α ≫ β).c.app U = (β.c).app U ≫ (α.c).app (op ((opens.map (β.base)).obj (unop U)))
+:= rfl
 
 variables (C)
 
@@ -108,19 +106,19 @@ open Top.presheaf
 The restriction of a sheafed space along an open embedding into the space.
 -/
 def restrict {U : Top} (X : SheafedSpace C)
-  (f : U ⟶ (X : Top.{v})) (h : open_embedding f) : SheafedSpace C :=
+  {f : U ⟶ (X : Top.{v})} (h : open_embedding f) : SheafedSpace C :=
 { is_sheaf := λ ι 𝒰, ⟨is_limit.of_iso_limit
     ((is_limit.postcompose_inv_equiv _ _).inv_fun (X.is_sheaf _).some)
     (sheaf_condition_equalizer_products.fork.iso_of_open_embedding h 𝒰).symm⟩,
-  ..X.to_PresheafedSpace.restrict f h }
+  ..X.to_PresheafedSpace.restrict h }
 
 /--
 The restriction of a sheafed space `X` to the top subspace is isomorphic to `X` itself.
 -/
 def restrict_top_iso (X : SheafedSpace C) :
-  X.restrict (opens.inclusion ⊤) (opens.open_embedding ⊤) ≅ X :=
+  X.restrict (opens.open_embedding ⊤) ≅ X :=
 @preimage_iso _ _ _ _ forget_to_PresheafedSpace _ _
-  (X.restrict (opens.inclusion ⊤) (opens.open_embedding ⊤)) _
+  (X.restrict (opens.open_embedding ⊤)) _
   X.to_PresheafedSpace.restrict_top_iso
 
 /--
@@ -136,10 +134,10 @@ lemma Γ_def : (Γ : _ ⥤ C) = forget_to_PresheafedSpace.op ⋙ PresheafedSpace
 lemma Γ_obj_op (X : SheafedSpace C) : Γ.obj (op X) = X.presheaf.obj (op ⊤) := rfl
 
 @[simp] lemma Γ_map {X Y : (SheafedSpace C)ᵒᵖ} (f : X ⟶ Y) :
-  Γ.map f = f.unop.c.app (op ⊤) ≫ (unop Y).presheaf.map (opens.le_map_top _ _).op := rfl
+  Γ.map f = f.unop.c.app (op ⊤) := rfl
 
 lemma Γ_map_op {X Y : SheafedSpace C} (f : X ⟶ Y) :
-  Γ.map f.op = f.c.app (op ⊤) ≫ X.presheaf.map (opens.le_map_top _ _).op := rfl
+  Γ.map f.op = f.c.app (op ⊤) := rfl
 
 end SheafedSpace
 

--- a/src/algebraic_geometry/stalks.lean
+++ b/src/algebraic_geometry/stalks.lean
@@ -57,8 +57,8 @@ For an open embedding `f : U ⟶ X` and a point `x : U`, we get an isomorphism b
 of `X` at `f x` and the stalk of the restriction of `X` along `f` at t `x`.
 -/
 def restrict_stalk_iso {U : Top} (X : PresheafedSpace C)
-  (f : U ⟶ (X : Top.{v})) (h : open_embedding f) (x : U) :
-  (X.restrict f h).stalk x ≅ X.stalk (f x) :=
+  {f : U ⟶ (X : Top.{v})} (h : open_embedding f) (x : U) :
+  (X.restrict h).stalk x ≅ X.stalk (f x) :=
 begin
   -- As a left adjoint, the functor `h.is_open_map.functor_nhds x` is initial.
   haveI := initial_of_adjunction (h.is_open_map.adjunction_nhds x),
@@ -69,18 +69,18 @@ begin
 end
 
 @[simp, elementwise, reassoc]
-lemma restrict_stalk_iso_hom_eq_germ {U : Top} (X : PresheafedSpace C) (f : U ⟶ (X : Top.{v}))
+lemma restrict_stalk_iso_hom_eq_germ {U : Top} (X : PresheafedSpace C) {f : U ⟶ (X : Top.{v})}
   (h : open_embedding f) (V : opens U) (x : U) (hx : x ∈ V) :
-  (X.restrict f h).presheaf.germ ⟨x, hx⟩ ≫ (restrict_stalk_iso X f h x).hom =
+  (X.restrict h).presheaf.germ ⟨x, hx⟩ ≫ (restrict_stalk_iso X h x).hom =
   X.presheaf.germ ⟨f x, show f x ∈ h.is_open_map.functor.obj V, from ⟨x, hx, rfl⟩⟩ :=
 colimit.ι_pre ((open_nhds.inclusion (f x)).op ⋙ X.presheaf)
   (h.is_open_map.functor_nhds x).op (op ⟨V, hx⟩)
 
 @[simp, elementwise, reassoc]
-lemma restrict_stalk_iso_inv_eq_germ {U : Top} (X : PresheafedSpace C) (f : U ⟶ (X : Top.{v}))
+lemma restrict_stalk_iso_inv_eq_germ {U : Top} (X : PresheafedSpace C) {f : U ⟶ (X : Top.{v})}
   (h : open_embedding f) (V : opens U) (x : U) (hx : x ∈ V) :
   X.presheaf.germ ⟨f x, show f x ∈ h.is_open_map.functor.obj V, from ⟨x, hx, rfl⟩⟩ ≫
-  (restrict_stalk_iso X f h x).inv = (X.restrict f h).presheaf.germ ⟨x, hx⟩ :=
+  (restrict_stalk_iso X h x).inv = (X.restrict h).presheaf.germ ⟨x, hx⟩ :=
 by rw [← restrict_stalk_iso_hom_eq_germ, category.assoc, iso.hom_inv_id, category.comp_id]
 
 end restrict
@@ -114,7 +114,7 @@ begin
   -- FIXME Why doesn't simp do this:
   erw [category_theory.functor.map_id],
   erw [category_theory.functor.map_id],
-  erw [id_comp, id_comp, id_comp],
+  erw [id_comp, id_comp],
 end
 
 /--

--- a/src/algebraic_geometry/structure_sheaf.lean
+++ b/src/algebraic_geometry/structure_sheaf.lean
@@ -970,9 +970,10 @@ begin
   refl,
 end
 
-@[elementwise, reassoc] lemma to_open_comp_comap (f : R →+* S) :
-  to_open R ⊤ ≫ comap f ⊤ ⊤ (λ p hpV, trivial) =
-  @category_theory.category_struct.comp _ _ (CommRing.of R) (CommRing.of S) _ f (to_open S ⊤) :=
+@[elementwise, reassoc] lemma to_open_comp_comap (f : R →+* S)
+  (U : opens (prime_spectrum.Top R)):
+  to_open R U ≫ comap f U (opens.comap (comap_continuous f) U) (λ _, id) =
+  CommRing.of_hom f ≫ (to_open S _) :=
 ring_hom.ext $ λ s, subtype.eq $ funext $ λ p,
 begin
   simp_rw [comp_apply, comap_apply, subtype.val_eq_coe],

--- a/src/algebraic_geometry/structure_sheaf.lean
+++ b/src/algebraic_geometry/structure_sheaf.lean
@@ -971,7 +971,7 @@ begin
 end
 
 @[elementwise, reassoc] lemma to_open_comp_comap (f : R →+* S)
-  (U : opens (prime_spectrum.Top R)):
+  (U : opens (prime_spectrum.Top R)) :
   to_open R U ≫ comap f U (opens.comap (comap_continuous f) U) (λ _, id) =
   CommRing.of_hom f ≫ (to_open S _) :=
 ring_hom.ext $ λ s, subtype.eq $ funext $ λ p,

--- a/src/category_theory/whiskering.lean
+++ b/src/category_theory/whiskering.lean
@@ -13,8 +13,8 @@ we can construct a new natural transformation `F ⋙ G ⟶ F ⋙ H`,
 called `whisker_left F α`. This is the same as the horizontal composition of `𝟙 F` with `α`.
 
 This operation is functorial in `F`, and we package this as `whiskering_left`. Here
-`(whiskering_lift.obj F).obj G` is `F ⋙ G`, and
-`(whiskering_lift.obj F).map α` is `whisker_left F α`.
+`(whiskering_left.obj F).obj G` is `F ⋙ G`, and
+`(whiskering_left.obj F).map α` is `whisker_left F α`.
 (That is, we might have alternatively named this as the "left composition functor".)
 
 We also provide analogues for composition on the right, and for these operations on isomorphisms.
@@ -57,8 +57,8 @@ variables (C D E)
 /--
 Left-composition gives a functor `(C ⥤ D) ⥤ ((D ⥤ E) ⥤ (C ⥤ E))`.
 
-`(whiskering_lift.obj F).obj G` is `F ⋙ G`, and
-`(whiskering_lift.obj F).map α` is `whisker_left F α`.
+`(whiskering_left.obj F).obj G` is `F ⋙ G`, and
+`(whiskering_left.obj F).map α` is `whisker_left F α`.
 -/
 @[simps] def whiskering_left : (C ⥤ D) ⥤ ((D ⥤ E) ⥤ (C ⥤ E)) :=
 { obj := λ F,

--- a/src/topology/category/Top/opens.lean
+++ b/src/topology/category/Top/opens.lean
@@ -135,8 +135,6 @@ def map (f : X ⟶ Y) : opens Y ⥤ opens X :=
 
 @[simp] lemma map_id_obj (U : opens X) : (map (𝟙 X)).obj U = U :=
 let ⟨_,_⟩ := U in rfl
--- by { ext, refl } -- not quite `rfl`, since we don't have eta for records
--- or cases U, refl
 
 @[simp] lemma map_id_obj' (U) (p) : (map (𝟙 X)).obj ⟨U, p⟩ = ⟨U, p⟩ :=
 rfl

--- a/src/topology/category/Top/opens.lean
+++ b/src/topology/category/Top/opens.lean
@@ -117,23 +117,29 @@ def inclusion {X : Top.{u}} (U : opens X) : (to_Top X).obj U ⟶ X :=
 lemma open_embedding {X : Top.{u}} (U : opens X) : open_embedding (inclusion U) :=
 is_open.open_embedding_subtype_coe U.2
 
+def inclusion_top_iso (X : Top.{u}) : (to_Top X).obj ⊤ ≅ X :=
+{ hom := inclusion ⊤,
+  inv := ⟨λ x, ⟨x, trivial⟩, continuous_def.2 $ λ U ⟨S, hS, hSU⟩, hSU ▸ hS⟩ }
+
 /-- `opens.map f` gives the functor from open sets in Y to open set in X,
     given by taking preimages under f. -/
 def map (f : X ⟶ Y) : opens Y ⥤ opens X :=
 { obj := λ U, ⟨ f ⁻¹' U.val, U.property.preimage f.continuous ⟩,
-  map := λ U V i, ⟨ ⟨ λ a b, i.le b ⟩ ⟩ }.
+  map := λ U V i, ⟨ ⟨ λ x h, i.le h ⟩ ⟩ }.
 
 @[simp] lemma map_obj (f : X ⟶ Y) (U) (p) :
   (map f).obj ⟨U, p⟩ = ⟨f ⁻¹' U, p.preimage f.continuous⟩ := rfl
 
 @[simp] lemma map_id_obj (U : opens X) : (map (𝟙 X)).obj U = U :=
-by { ext, refl } -- not quite `rfl`, since we don't have eta for records
+let ⟨_,_⟩ := U in rfl
+-- by { ext, refl } -- not quite `rfl`, since we don't have eta for records
+-- or cases U, refl
 
 @[simp] lemma map_id_obj' (U) (p) : (map (𝟙 X)).obj ⟨U, p⟩ = ⟨U, p⟩ :=
 rfl
 
 @[simp] lemma map_id_obj_unop (U : (opens X)ᵒᵖ) : (map (𝟙 X)).obj (unop U) = unop U :=
-by simp
+let ⟨_,_⟩ := U.unop in rfl
 @[simp] lemma op_map_id_obj (U : (opens X)ᵒᵖ) : (map (𝟙 X)).op.obj U = U :=
 by simp
 
@@ -141,11 +147,11 @@ by simp
 The inclusion `U ⟶ (map f).obj ⊤` as a morphism in the category of open sets.
 -/
 def le_map_top (f : X ⟶ Y) (U : opens X) : U ⟶ (map f).obj ⊤ :=
-hom_of_le $ λ _ _, trivial
+le_top U
 
 @[simp] lemma map_comp_obj (f : X ⟶ Y) (g : Y ⟶ Z) (U) :
   (map (f ≫ g)).obj U = (map f).obj ((map g).obj U) :=
-by { ext, refl } -- not quite `rfl`, since we don't have eta for records
+rfl
 
 @[simp] lemma map_comp_obj' (f : X ⟶ Y) (g : Y ⟶ Z) (U) (p) :
   (map (f ≫ g)).obj ⟨U, p⟩ = (map f).obj ((map g).obj ⟨U, p⟩) :=
@@ -157,11 +163,18 @@ rfl
 
 @[simp] lemma map_comp_obj_unop (f : X ⟶ Y) (g : Y ⟶ Z) (U) :
   (map (f ≫ g)).obj (unop U) = (map f).obj ((map g).obj (unop U)) :=
-map_comp_obj f g (unop U)
+rfl
 
 @[simp] lemma op_map_comp_obj (f : X ⟶ Y) (g : Y ⟶ Z) (U) :
   (map (f ≫ g)).op.obj U = (map f).op.obj ((map g).op.obj U) :=
-by simp
+rfl
+
+lemma map_supr (f : X ⟶ Y) {ι : Type*} (U : ι → opens Y) :
+  (map f).obj (supr U) = supr ((map f).obj ∘ U) :=
+begin
+  apply subtype.eq, rw [supr_def, supr_def, map_obj],
+  dsimp, rw set.preimage_Union, refl,
+end
 
 section
 variable (X)
@@ -175,6 +188,9 @@ def map_id : map (𝟙 X) ≅ 𝟭 (opens X) :=
 { hom := { app := λ U, eq_to_hom (map_id_obj U) },
   inv := { app := λ U, eq_to_hom (map_id_obj U).symm } }
 
+lemma map_id_eq : map (𝟙 X) = 𝟭 (opens X) :=
+by { unfold map, congr, ext, refl, ext }
+
 end
 
 /--
@@ -186,6 +202,9 @@ def map_comp (f : X ⟶ Y) (g : Y ⟶ Z) : map (f ≫ g) ≅ map g ⋙ map f :=
 { hom := { app := λ U, eq_to_hom (map_comp_obj f g U) },
   inv := { app := λ U, eq_to_hom (map_comp_obj f g U).symm } }
 
+lemma map_comp_eq (f : X ⟶ Y) (g : Y ⟶ Z) : map (f ≫ g) = map g ⋙ map f :=
+rfl
+
 /--
 If two continuous maps `f g : X ⟶ Y` are equal,
 then the functors `opens Y ⥤ opens X` they induce are isomorphic.
@@ -195,6 +214,9 @@ then the functors `opens Y ⥤ opens X` they induce are isomorphic.
 def map_iso (f g : X ⟶ Y) (h : f = g) : map f ≅ map g :=
 nat_iso.of_components (λ U, eq_to_iso (congr_fun (congr_arg functor.obj (congr_arg map h)) U) )
   (by obviously)
+
+lemma map_eq (f g : X ⟶ Y) (h : f = g) : map f = map g :=
+by { unfold map, congr, ext, rw h, rw h, assumption' }
 
 @[simp] lemma map_iso_refl (f : X ⟶ Y) (h) : map_iso f f h = iso.refl (map _) := rfl
 
@@ -226,3 +248,18 @@ def is_open_map.adjunction {X Y : Top} {f : X ⟶ Y} (hf : is_open_map f) :
 adjunction.mk_of_unit_counit
 { unit := { app := λ U, hom_of_le $ λ x hxU, ⟨x, hxU, rfl⟩ },
   counit := { app := λ V, hom_of_le $ λ y ⟨x, hfxV, hxy⟩, hxy ▸ hfxV } }
+
+namespace topological_space.opens
+open topological_space
+
+lemma inclusion_top_functor (X : Top) :
+  (@opens.open_embedding X ⊤).is_open_map.functor =
+  map (inclusion_top_iso X).inv :=
+begin
+  apply functor.hext, intro, abstract obj_eq { ext,
+  exact ⟨ λ ⟨⟨_,_⟩,h,rfl⟩, h, λ h, ⟨⟨x,trivial⟩,h,rfl⟩ ⟩ },
+  intros, apply subsingleton.helim, congr' 1,
+  iterate 2 {apply inclusion_top_functor.obj_eq},
+end
+
+end topological_space.opens

--- a/src/topology/category/Top/opens.lean
+++ b/src/topology/category/Top/opens.lean
@@ -117,6 +117,9 @@ def inclusion {X : Top.{u}} (U : opens X) : (to_Top X).obj U ⟶ X :=
 lemma open_embedding {X : Top.{u}} (U : opens X) : open_embedding (inclusion U) :=
 is_open.open_embedding_subtype_coe U.2
 
+/--
+The inclusion of the top open subset (i.e. the whole space) is an isomorphism.
+-/
 def inclusion_top_iso (X : Top.{u}) : (to_Top X).obj ⊤ ≅ X :=
 { hom := inclusion ⊤,
   inv := ⟨λ x, ⟨x, trivial⟩, continuous_def.2 $ λ U ⟨S, hS, hSU⟩, hSU ▸ hS⟩ }

--- a/src/topology/sheaves/functors.lean
+++ b/src/topology/sheaves/functors.lean
@@ -1,0 +1,85 @@
+/-
+Copyright (c) 2021 Junyan Xu. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Junyan Xu
+-/
+
+import topology.sheaves.sheaf_condition.pairwise_intersections
+
+/-!
+# functors between categories of sheaves
+
+Show that the pushforward of a sheaf is a sheaf, and define
+the pushforward functor from the category of C-valued sheaves
+on X to that of sheaves on Y, given a continuous map between
+topological spaces X and Y.
+
+TODO: pullback for presheaves and sheaves
+-/
+
+noncomputable theory
+
+universes v u u₁
+
+open category_theory
+open category_theory.limits
+open topological_space
+
+variables {C : Type u₁} [category.{v} C]
+variables {X Y : Top.{v}} (f : X ⟶ Y)
+variables ⦃ι : Type v⦄ {U : ι → opens Y}
+
+namespace Top
+namespace presheaf.sheaf_condition_pairwise_intersections
+
+lemma map_diagram: pairwise.diagram U ⋙ opens.map f
+                 = pairwise.diagram ((opens.map f).obj ∘ U) :=
+begin
+  apply functor.hext,
+  abstract obj_eq {intro i, cases i; refl},
+  intros i j g, apply subsingleton.helim,
+  iterate 2 {rw map_diagram.obj_eq},
+end
+
+lemma map_cocone : (opens.map f).map_cocone (pairwise.cocone U)
+                     == pairwise.cocone ((opens.map f).obj ∘ U) :=
+begin
+  unfold functor.map_cocone cocones.functoriality, dsimp, congr,
+  iterate 2 {rw map_diagram, rw opens.map_supr},
+  apply subsingleton.helim, rw [map_diagram, opens.map_supr],
+  apply proof_irrel_heq,
+end
+
+theorem pushforward_sheaf_of_sheaf {F : presheaf C X}
+  (h : F.is_sheaf_pairwise_intersections) :
+  (f _* F).is_sheaf_pairwise_intersections :=
+λ ι U, begin
+  convert h ((opens.map f).obj ∘ U) using 2,
+  rw ← map_diagram, refl,
+  change F.map_cone ((opens.map f).map_cocone _).op == _,
+  congr, iterate 2 {rw map_diagram}, apply map_cocone,
+end
+
+end presheaf.sheaf_condition_pairwise_intersections
+
+namespace sheaf
+
+open presheaf
+
+variables [has_products C]
+
+/--
+The pushforward of a sheaf (by a continuous map) is a sheaf
+-/
+theorem pushforward_sheaf_of_sheaf
+  {F : presheaf C X} (h : F.is_sheaf) : (f _* F).is_sheaf :=
+by rw is_sheaf_iff_is_sheaf_pairwise_intersections at h ⊢;
+   exact sheaf_condition_pairwise_intersections.pushforward_sheaf_of_sheaf f h
+
+def pushforward (f : X ⟶ Y) : X.sheaf C ⥤ Y.sheaf C :=
+{ obj := λ ℱ, ⟨f _* ℱ.1, pushforward_sheaf_of_sheaf f ℱ.2⟩,
+  map := λ _ _, pushforward_map f }
+
+end sheaf
+
+end Top

--- a/src/topology/sheaves/functors.lean
+++ b/src/topology/sheaves/functors.lean
@@ -32,8 +32,8 @@ variables ⦃ι : Type v⦄ {U : ι → opens Y}
 namespace Top
 namespace presheaf.sheaf_condition_pairwise_intersections
 
-lemma map_diagram: pairwise.diagram U ⋙ opens.map f
-                 = pairwise.diagram ((opens.map f).obj ∘ U) :=
+lemma map_diagram :
+  pairwise.diagram U ⋙ opens.map f = pairwise.diagram ((opens.map f).obj ∘ U) :=
 begin
   apply functor.hext,
   abstract obj_eq {intro i, cases i; refl},

--- a/src/topology/sheaves/functors.lean
+++ b/src/topology/sheaves/functors.lean
@@ -69,13 +69,16 @@ open presheaf
 variables [has_products C]
 
 /--
-The pushforward of a sheaf (by a continuous map) is a sheaf
+The pushforward of a sheaf (by a continuous map) is a sheaf.
 -/
 theorem pushforward_sheaf_of_sheaf
   {F : presheaf C X} (h : F.is_sheaf) : (f _* F).is_sheaf :=
 by rw is_sheaf_iff_is_sheaf_pairwise_intersections at h ⊢;
    exact sheaf_condition_pairwise_intersections.pushforward_sheaf_of_sheaf f h
 
+/--
+The pushforward functor.
+-/
 def pushforward (f : X ⟶ Y) : X.sheaf C ⥤ Y.sheaf C :=
 { obj := λ ℱ, ⟨f _* ℱ.1, pushforward_sheaf_of_sheaf f ℱ.2⟩,
   map := λ _ _, pushforward_map f }

--- a/src/topology/sheaves/presheaf.lean
+++ b/src/topology/sheaves/presheaf.lean
@@ -60,7 +60,7 @@ def pushforward_eq {X Y : Top.{v}} {f g : X ⟶ Y} (h : f = g) (ℱ : X.presheaf
   f _* ℱ ≅ g _* ℱ :=
 iso_whisker_right (nat_iso.op (opens.map_iso f g h).symm) ℱ
 
-def pushforward_eq' {X Y : Top.{v}} {f g : X ⟶ Y} (h : f = g) (ℱ : X.presheaf C) :
+lemma pushforward_eq' {X Y : Top.{v}} {f g : X ⟶ Y} (h : f = g) (ℱ : X.presheaf C) :
   f _* ℱ = g _* ℱ :=
 by rw h
 
@@ -133,6 +133,9 @@ def pushforward_map {X Y : Top.{v}} (f : X ⟶ Y) {ℱ 𝒢 : X.presheaf C} (α 
 { app := λ U, α.app _,
   naturality' := λ U V i, by { erw α.naturality, refl, } }
 
+/--
+The pushforward functor.
+-/
 def pushforward {X Y : Top.{v}} (f : X ⟶ Y) : X.presheaf C ⥤ Y.presheaf C :=
 { obj := pushforward_obj f,
   map := @pushforward_map _ _ X Y f }

--- a/src/topology/sheaves/presheaf.lean
+++ b/src/topology/sheaves/presheaf.lean
@@ -60,6 +60,10 @@ def pushforward_eq {X Y : Top.{v}} {f g : X ⟶ Y} (h : f = g) (ℱ : X.presheaf
   f _* ℱ ≅ g _* ℱ :=
 iso_whisker_right (nat_iso.op (opens.map_iso f g h).symm) ℱ
 
+def pushforward_eq' {X Y : Top.{v}} {f g : X ⟶ Y} (h : f = g) (ℱ : X.presheaf C) :
+  f _* ℱ = g _* ℱ :=
+by rw h
+
 @[simp] lemma pushforward_eq_hom_app
   {X Y : Top.{v}} {f g : X ⟶ Y} (h : f = g) (ℱ : X.presheaf C) (U) :
   (pushforward_eq h ℱ).hom.app U =
@@ -86,6 +90,9 @@ and the original presheaf. -/
 def id : (𝟙 X) _* ℱ ≅ ℱ :=
 (iso_whisker_right (nat_iso.op (opens.map_id X).symm) ℱ) ≪≫ functor.left_unitor _
 
+lemma id_eq : (𝟙 X) _* ℱ = ℱ :=
+by { unfold pushforward_obj, rw opens.map_id_eq, erw functor.id_comp }
+
 @[simp] lemma id_hom_app' (U) (p) :
   (id ℱ).hom.app (op ⟨U, p⟩) = ℱ.map (𝟙 (op ⟨U, p⟩)) :=
 by { dsimp [id], simp, }
@@ -103,6 +110,9 @@ the pushforward of a presheaf along the composition of two continuous maps and
 the corresponding pushforward of a pushforward. -/
 def comp {Y Z : Top.{v}} (f : X ⟶ Y) (g : Y ⟶ Z) : (f ≫ g) _* ℱ ≅ g _* (f _* ℱ) :=
 iso_whisker_right (nat_iso.op (opens.map_comp f g).symm) ℱ
+
+lemma comp_eq {Y Z : Top.{v}} (f : X ⟶ Y) (g : Y ⟶ Z) : (f ≫ g) _* ℱ = g _* (f _* ℱ) :=
+rfl
 
 @[simp] lemma comp_hom_app {Y Z : Top.{v}} (f : X ⟶ Y) (g : Y ⟶ Z) (U) :
   (comp ℱ f g).hom.app U = 𝟙 _ :=
@@ -122,6 +132,18 @@ def pushforward_map {X Y : Top.{v}} (f : X ⟶ Y) {ℱ 𝒢 : X.presheaf C} (α 
   f _* ℱ ⟶ f _* 𝒢 :=
 { app := λ U, α.app _,
   naturality' := λ U V i, by { erw α.naturality, refl, } }
+
+def pushforward {X Y : Top.{v}} (f : X ⟶ Y) : X.presheaf C ⥤ Y.presheaf C :=
+{ obj := pushforward_obj f,
+  map := @pushforward_map _ _ X Y f }
+
+lemma id_pushforward {X : Top.{v}} : pushforward (𝟙 X) = 𝟭 (X.presheaf C) :=
+begin
+  apply category_theory.functor.ext,
+  { intros, ext U, have h := f.congr,
+    erw h (opens.op_map_id_obj U), simpa },
+  { intros, apply pushforward.id_eq },
+end
 
 end presheaf
 


### PR DESCRIPTION
Prove and make use of equalities whenever possible, even between functors (which is discouraged according to certain philosophy), to replace isomorphisms by equalities, to remove the need of transporting across isomorphisms in various definitions (using `eq_to_hom` directly), most notably: [simplified definition of identity morphism for PresheafedSpace](https://github.com/leanprover-community/mathlib/compare/use_equality?expand=1#diff-252fb30c3a3221e6472db5ba794344dfb423898696e70299653d95f635de06adR89), [simplified extensionality lemma for morphisms](https://github.com/leanprover-community/mathlib/compare/use_equality?expand=1#diff-252fb30c3a3221e6472db5ba794344dfb423898696e70299653d95f635de06adR68), [simplified definition of composition](https://github.com/leanprover-community/mathlib/compare/use_equality?expand=1#diff-252fb30c3a3221e6472db5ba794344dfb423898696e70299653d95f635de06adR96) and [the global section functor](https://github.com/leanprover-community/mathlib/compare/use_equality?expand=1#diff-252fb30c3a3221e6472db5ba794344dfb423898696e70299653d95f635de06adR228) (takes advantage of defeq and doesn't require proving any new equality).

Other small changes to mathlib:
- Define pushforward functor of presheaves in topology/sheaves/presheaf.lean
- Add new file functor.lean in topology/sheaves, proves the pushforward of a sheaf is a sheaf, and defines the pushforward functor of sheaves, with the expectation that pullbacks will be added later.
- Make one of the arguments in various `restrict`s implicit.
- Change statement of [`to_open_comp_comap`](https://github.com/leanprover-community/mathlib/compare/use_equality?expand=1#diff-54364470f443f847742b1c105e853afebc25da68faad63cc5a73db167bc85d06R973) in structure_sheaf.lean to be more general (the same proof works!)

The new definitions result in simplified proofs, but apart from the main files opens.lean, presheaf.lean and presheafed_space.lean where proofs are optimized, I did only the minimum changes required to fix the broken proofs, and I expect there to be large room of improvement with the new definitions especially in the files changed in this PR. I also didn't remove the old lemmas and mostly just add new ones, so subsequent cleanup may be desired.

Zulip discussion thread: https://leanprover.zulipchat.com/#narrow/stream/113489-new-members/topic/extensionality.20for.20functors

---

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
