### PR TITLE
[Merged by Bors] - chore(data/fintype/card): add `fin.prod_univ_{one,two}`

### DIFF
--- a/src/data/fintype/card.lean
+++ b/src/data/fintype/card.lean
@@ -154,6 +154,14 @@ theorem fin.prod_univ_cast_succ [comm_monoid β] {n : ℕ} (f : fin (n + 1) → 
   ∏ i, f i = (∏ i : fin n, f i.cast_succ) * f (fin.last n) :=
 by simpa [mul_comm] using fin.prod_univ_succ_above f (fin.last n)
 
+@[to_additive] theorem fin.prod_univ_one [comm_monoid β] (f : fin 1 → β) :
+  ∏ i, f i = f 0 :=
+by simp
+
+@[to_additive] theorem fin.prod_univ_two [comm_monoid β] (f : fin 2 → β) :
+  ∏ i, f i = f 0 * f 1 :=
+by simp [fin.prod_univ_succ]
+
 open finset
 
 @[simp] theorem fintype.card_sigma {α : Type*} (β : α → Type*)

--- a/src/data/fintype/card.lean
+++ b/src/data/fintype/card.lean
@@ -154,7 +154,7 @@ theorem fin.prod_univ_cast_succ [comm_monoid β] {n : ℕ} (f : fin (n + 1) → 
   ∏ i, f i = (∏ i : fin n, f i.cast_succ) * f (fin.last n) :=
 by simpa [mul_comm] using fin.prod_univ_succ_above f (fin.last n)
 
-@[to_additive] theorem fin.prod_univ_one [comm_monoid β] (f : fin 1 → β) :
+@[to_additive sum_univ_one] theorem fin.prod_univ_one [comm_monoid β] (f : fin 1 → β) :
   ∏ i, f i = f 0 :=
 by simp
 


### PR DESCRIPTION
Sometimes Lean fails to simplify `(default : fin 1)` to `0` and
`0.succ` to `1` in complex expressions. These lemmas explicitly use
`f 0` and `f 1` in the output.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
