### PR TITLE
[Merged by Bors] - feat(group_theory/group_action/conj_act): A characteristic subgroup of a normal subgroup is normal

### DIFF
--- a/src/group_theory/group_action/conj_act.lean
+++ b/src/group_theory/group_action/conj_act.lean
@@ -144,4 +144,11 @@ lemma _root_.mul_aut.conj_normal_coe {H : subgroup G} [H.normal] {h : H} :
   mul_aut.conj_normal ↑h = mul_aut.conj h :=
 mul_equiv.ext (λ x, rfl)
 
+instance normal_of_characteristic_of_normal {H : subgroup G} [hH : H.normal]
+  {K : subgroup H} [h : K.characteristic] : (K.map H.subtype).normal :=
+⟨λ a ha b, by
+{ obtain ⟨a, ha, rfl⟩ := ha,
+  exact K.apply_coe_mem_map H.subtype
+    ⟨_, ((set_like.ext_iff.mp (h.fixed (mul_aut.conj_normal b)) a).mpr ha)⟩ }⟩
+
 end conj_act


### PR DESCRIPTION
Uses `mul_aut.conj_normal` to prove an instance stating that a characteristic subgroup of a normal subgroup is normal.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
