### PR TITLE
[Merged by Bors] - chore(measure_theory): drop a few `measurable_set` assumptions

### DIFF
--- a/src/measure_theory/constructions/pi.lean
+++ b/src/measure_theory/constructions/pi.lean
@@ -283,7 +283,7 @@ begin
   intro t,
   simp_rw [pi_premeasure],
   refine finset.prod_add_prod_le' (finset.mem_univ i) _ _ _,
-  { simp [image_inter_preimage, image_diff_preimage, (μ i).caratheodory hs, le_refl] },
+  { simp [image_inter_preimage, image_diff_preimage, measure_inter_add_diff _ hs, le_refl] },
   { rintro j - hj, apply mono', apply image_subset, apply inter_subset_left },
   { rintro j - hj, apply mono', apply image_subset, apply diff_subset }
 end

--- a/src/measure_theory/decomposition/unsigned_hahn.lean
+++ b/src/measure_theory/decomposition/unsigned_hahn.lean
@@ -57,7 +57,7 @@ begin
     d s = d (s \ t) + d (s ∩ t),
   { assume s t hs ht,
     simp only [d],
-    rw [measure_eq_inter_diff hs ht, measure_eq_inter_diff hs ht,
+    rw [← measure_inter_add_diff s ht, ← measure_inter_add_diff s ht,
       ennreal.to_nnreal_add (hμ _) (hμ _), ennreal.to_nnreal_add (hν _) (hν _),
       nnreal.coe_add, nnreal.coe_add],
     simp only [sub_eq_add_neg, neg_add],

--- a/src/measure_theory/measure/measure_space.lean
+++ b/src/measure_theory/measure/measure_space.lean
@@ -457,6 +457,9 @@ lemma measure_union_add_inter (s : set α) (ht : measurable_set t) :
 by { rw [← measure_inter_add_diff (s ∪ t) ht, set.union_inter_cancel_right,
   union_diff_right, ← measure_inter_add_diff s ht], ac_refl }
 
+lemma measure_union_add_inter' (hs : measurable_set s) (t : set α) :
+  μ (s ∪ t) + μ (s ∩ t) = μ s + μ t :=
+by rw [union_comm, inter_comm, measure_union_add_inter t hs, add_comm]
 namespace measure
 
 /-! ### The `ℝ≥0∞`-module of measures -/

--- a/src/measure_theory/measure/measure_space.lean
+++ b/src/measure_theory/measure/measure_space.lean
@@ -578,7 +578,7 @@ begin
     refine infi_le_of_le (μ.to_outer_measure) (infi_le_of_le (mem_image_of_mem _ hμ) _),
     rw [to_outer_measure_apply],
     refine measure_mono hst },
-  rw [measure_eq_inter_diff hu hs],
+  rw [← measure_inter_add_diff u hs],
   refine add_le_add (hm $ inter_subset_inter_left _ htu) (hm $ diff_subset_diff_left htu)
 end
 
@@ -917,7 +917,7 @@ begin
     restrict_congr_mono (subset_union_right _ _) htm h⟩, _⟩,
   simp only [restrict_congr_meas, hsm, htm, hsm.union htm],
   rintros ⟨hs, ht⟩ u hu hum,
-  rw [measure_eq_inter_diff hum hsm, measure_eq_inter_diff hum hsm,
+  rw [← measure_inter_add_diff u hsm, ← measure_inter_add_diff u hsm,
     hs _ (inter_subset_right _ _) (hum.inter hsm),
     ht _ (diff_subset_iff.2 hu) (hum.diff hsm)]
 end
@@ -1036,7 +1036,7 @@ begin
   { intros v hv hvt,
     have := T_eq t ht,
     rw [set.inter_comm] at hvt ⊢,
-    rwa [measure_eq_inter_diff (hm _ ht) hv, measure_eq_inter_diff (hm _ ht) hv, ← hvt,
+    rwa [← measure_inter_add_diff t hv, ← measure_inter_add_diff t hv, ← hvt,
       ennreal.add_right_inj] at this,
     exact ne_top_of_le_ne_top (htop t ht) (measure_mono $ set.inter_subset_left _ _) },
   { intros f hfd hfm h_eq,
@@ -2324,7 +2324,7 @@ begin
         { intro t', rw set.inter_eq_self_of_subset_left, apply set.inter_subset_right t t' },
         have h_meas_t_inter_s : measurable_set (t ∩ s) :=
            h_meas_t.inter h_meas_s,
-        repeat {rw measure_eq_inter_diff h_meas_t h_meas_s, rw set.diff_eq},
+        repeat { rw ← measure_inter_add_diff t h_meas_s, rw set.diff_eq },
         refine add_le_add _ _,
         { rw add_apply,
           apply le_add_right _,

--- a/src/probability_theory/density.lean
+++ b/src/probability_theory/density.lean
@@ -271,12 +271,7 @@ end
 lemma quasi_measure_preserving_has_pdf' [is_finite_measure ℙ] [sigma_finite ν]
   {X : α → E} [has_pdf X ℙ μ] {g : E → F} (hg : quasi_measure_preserving g μ ν) :
   has_pdf (g ∘ X) ℙ ν :=
-begin
-  haveI : is_finite_measure (map g (map X ℙ)) :=
-    @is_finite_measure_map _ _ _ _ (map X ℙ)
-      (is_finite_measure_map ℙ (has_pdf.measurable X ℙ μ)) _ hg.measurable,
-  exact quasi_measure_preserving_has_pdf hg infer_instance,
-end
+quasi_measure_preserving_has_pdf hg infer_instance
 
 end
 
@@ -288,7 +283,6 @@ variables [is_finite_measure ℙ] {X : α → ℝ}
 only if the push-forward measure of `ℙ` along `X` is absolutely continuous with respect to `λ`. -/
 lemma real.has_pdf_iff_of_measurable (hX : measurable X) : has_pdf X ℙ ↔ map X ℙ ≪ volume :=
 begin
-  haveI : is_finite_measure (map X ℙ) := is_finite_measure_map ℙ hX,
   rw [has_pdf_iff_of_measurable hX, and_iff_right_iff_imp],
   exact λ h, infer_instance,
 end


### PR DESCRIPTION
We had an extra `measurable_set` assumption in (one of the copies of) Caratheodory. Also remove `measurable f` assumption in `is_finite_measure (map f μ)` and make it an instance.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)