### PR TITLE
[Merged by Bors] - feat(algebra/direct_sum/module) : coe and internal

### DIFF
--- a/src/algebra/direct_sum/basic.lean
+++ b/src/algebra/direct_sum/basic.lean
@@ -188,13 +188,18 @@ begin
   exact function.bijective.surjective h,
 end
 
+/-- The canonical embedding from `⨁ i, A i` to `M`-/
+def direct_sum.add_subgroup_coe {M : Type*} [decidable_eq ι] [add_comm_group M]
+  (A : ι → add_subgroup M) : (⨁ i, A i) →+ M :=
+direct_sum.to_add_monoid (λ i, (A i).subtype)
+
 /-- The `direct_sum` formed by a collection of `add_subgroup`s of `M` is said to be internal if the
 canonical map `(⨁ i, A i) →+ M` is bijective.
 
 See `direct_sum.submodule_is_internal` for the same statement about `submodules`s. -/
 def add_subgroup_is_internal {M : Type*} [decidable_eq ι] [add_comm_group M]
   (A : ι → add_subgroup M) : Prop :=
-function.bijective (direct_sum.to_add_monoid (λ i, (A i).subtype) : (⨁ i, A i) →+ M)
+function.bijective (direct_sum.add_subgroup_coe A)
 
 lemma add_subgroup_is_internal.to_add_submonoid
   {M : Type*} [decidable_eq ι] [add_comm_group M] (A : ι → add_subgroup M) :

--- a/src/algebra/direct_sum/basic.lean
+++ b/src/algebra/direct_sum/basic.lean
@@ -203,7 +203,7 @@ def add_subgroup_coe {M : Type*} [decidable_eq ι] [add_comm_group M]
   (A : ι → add_subgroup M) : (⨁ i, A i) →+ M :=
 direct_sum.to_add_monoid (λ i, (A i).subtype)
 
-@[simp] lemma add_group_coe_of {M : Type*} [decidable_eq ι] [add_comm_group M]
+@[simp] lemma add_subgroup_coe_of {M : Type*} [decidable_eq ι] [add_comm_group M]
   (A : ι → add_subgroup M) (i : ι) (x : A i) :
 direct_sum.add_subgroup_coe A (direct_sum.of (λ i, A i) i x) = x :=
 direct_sum.to_add_monoid_of _ _ _

--- a/src/algebra/direct_sum/basic.lean
+++ b/src/algebra/direct_sum/basic.lean
@@ -172,15 +172,16 @@ protected def id (M : Type v) (ι : Type* := punit) [add_comm_monoid M] [unique 
   right_inv := λ x, to_add_monoid_of _ _ _,
   ..direct_sum.to_add_monoid (λ _, add_monoid_hom.id M) }
 
-/-- The canonical embedding from `⨁ i, A i` to `M`-/
+/-- The canonical embedding from `⨁ i, A i` to `M` where `A` is a collection of `add_submonoid M`
+indexed by `ι`-/
 def add_submonoid_coe {M : Type*} [decidable_eq ι] [add_comm_monoid M]
   (A : ι → add_submonoid M) : (⨁ i, A i) →+ M :=
-direct_sum.to_add_monoid (λ i, (A i).subtype)
+to_add_monoid (λ i, (A i).subtype)
 
 @[simp] lemma add_submonoid_coe_of {M : Type*} [decidable_eq ι] [add_comm_monoid M]
   (A : ι → add_submonoid M) (i : ι) (x : A i) :
-  direct_sum.add_submonoid_coe A (direct_sum.of (λ i, A i) i x) = x :=
-direct_sum.to_add_monoid_of _ _ _
+  add_submonoid_coe A (of (λ i, A i) i x) = x :=
+to_add_monoid_of _ _ _
 
 /-- The `direct_sum` formed by a collection of `add_submonoid`s of `M` is said to be internal if the
 canonical map `(⨁ i, A i) →+ M` is bijective.
@@ -188,7 +189,7 @@ canonical map `(⨁ i, A i) →+ M` is bijective.
 See `direct_sum.add_subgroup_is_internal` for the same statement about `add_subgroup`s. -/
 def add_submonoid_is_internal {M : Type*} [decidable_eq ι] [add_comm_monoid M]
   (A : ι → add_submonoid M) : Prop :=
-function.bijective (direct_sum.add_submonoid_coe A)
+function.bijective (add_submonoid_coe A)
 
 lemma add_submonoid_is_internal.supr_eq_top {M : Type*} [decidable_eq ι] [add_comm_monoid M]
   (A : ι → add_submonoid M)
@@ -198,15 +199,16 @@ begin
   exact function.bijective.surjective h,
 end
 
-/-- The canonical embedding from `⨁ i, A i` to `M`-/
+/-- The canonical embedding from `⨁ i, A i` to `M`  where `A` is a collection of `add_subgroup M`
+indexed by `ι`-/
 def add_subgroup_coe {M : Type*} [decidable_eq ι] [add_comm_group M]
   (A : ι → add_subgroup M) : (⨁ i, A i) →+ M :=
-direct_sum.to_add_monoid (λ i, (A i).subtype)
+to_add_monoid (λ i, (A i).subtype)
 
 @[simp] lemma add_subgroup_coe_of {M : Type*} [decidable_eq ι] [add_comm_group M]
   (A : ι → add_subgroup M) (i : ι) (x : A i) :
-  direct_sum.add_subgroup_coe A (direct_sum.of (λ i, A i) i x) = x :=
-direct_sum.to_add_monoid_of _ _ _
+  add_subgroup_coe A (of (λ i, A i) i x) = x :=
+to_add_monoid_of _ _ _
 
 /-- The `direct_sum` formed by a collection of `add_subgroup`s of `M` is said to be internal if the
 canonical map `(⨁ i, A i) →+ M` is bijective.
@@ -214,7 +216,7 @@ canonical map `(⨁ i, A i) →+ M` is bijective.
 See `direct_sum.submodule_is_internal` for the same statement about `submodules`s. -/
 def add_subgroup_is_internal {M : Type*} [decidable_eq ι] [add_comm_group M]
   (A : ι → add_subgroup M) : Prop :=
-function.bijective (direct_sum.add_subgroup_coe A)
+function.bijective (add_subgroup_coe A)
 
 lemma add_subgroup_is_internal.to_add_submonoid
   {M : Type*} [decidable_eq ι] [add_comm_group M] (A : ι → add_subgroup M) :

--- a/src/algebra/direct_sum/basic.lean
+++ b/src/algebra/direct_sum/basic.lean
@@ -177,6 +177,11 @@ def add_submonoid_coe {M : Type*} [decidable_eq ι] [add_comm_monoid M]
   (A : ι → add_submonoid M) : (⨁ i, A i) →+ M :=
 direct_sum.to_add_monoid (λ i, (A i).subtype)
 
+@[simp] lemma add_submonoid_coe_of {M : Type*} [decidable_eq ι] [add_comm_monoid M]
+  (A : ι → add_submonoid M) (i : ι) (x : A i) :
+direct_sum.add_submonoid_coe A (direct_sum.of (λ i, A i) i x) = x :=
+direct_sum.to_add_monoid_of _ _ _
+
 /-- The `direct_sum` formed by a collection of `add_submonoid`s of `M` is said to be internal if the
 canonical map `(⨁ i, A i) →+ M` is bijective.
 
@@ -201,10 +206,7 @@ direct_sum.to_add_monoid (λ i, (A i).subtype)
 @[simp] lemma add_group_coe_of {M : Type*} [decidable_eq ι] [add_comm_group M]
   (A : ι → add_subgroup M) (i : ι) (x : A i) :
 direct_sum.add_subgroup_coe A (direct_sum.of (λ i, A i) i x) = x :=
-begin
-  rw [direct_sum.add_subgroup_coe, direct_sum.to_add_monoid_of],
-  simp only [add_subgroup.coe_subtype],
-end
+direct_sum.to_add_monoid_of _ _ _
 
 /-- The `direct_sum` formed by a collection of `add_subgroup`s of `M` is said to be internal if the
 canonical map `(⨁ i, A i) →+ M` is bijective.

--- a/src/algebra/direct_sum/basic.lean
+++ b/src/algebra/direct_sum/basic.lean
@@ -173,7 +173,7 @@ protected def id (M : Type v) (ι : Type* := punit) [add_comm_monoid M] [unique 
   ..direct_sum.to_add_monoid (λ _, add_monoid_hom.id M) }
 
 /-- The canonical embedding from `⨁ i, A i` to `M`-/
-def direct_sum.add_submonoid_coe {M : Type*} [decidable_eq ι] [add_comm_monoid M]
+def add_submonoid_coe {M : Type*} [decidable_eq ι] [add_comm_monoid M]
   (A : ι → add_submonoid M) : (⨁ i, A i) →+ M :=
 direct_sum.to_add_monoid (λ i, (A i).subtype)
 
@@ -194,7 +194,7 @@ begin
 end
 
 /-- The canonical embedding from `⨁ i, A i` to `M`-/
-def direct_sum.add_subgroup_coe {M : Type*} [decidable_eq ι] [add_comm_group M]
+def add_subgroup_coe {M : Type*} [decidable_eq ι] [add_comm_group M]
   (A : ι → add_subgroup M) : (⨁ i, A i) →+ M :=
 direct_sum.to_add_monoid (λ i, (A i).subtype)
 

--- a/src/algebra/direct_sum/basic.lean
+++ b/src/algebra/direct_sum/basic.lean
@@ -205,7 +205,7 @@ direct_sum.to_add_monoid (λ i, (A i).subtype)
 
 @[simp] lemma add_subgroup_coe_of {M : Type*} [decidable_eq ι] [add_comm_group M]
   (A : ι → add_subgroup M) (i : ι) (x : A i) :
-direct_sum.add_subgroup_coe A (direct_sum.of (λ i, A i) i x) = x :=
+  direct_sum.add_subgroup_coe A (direct_sum.of (λ i, A i) i x) = x :=
 direct_sum.to_add_monoid_of _ _ _
 
 /-- The `direct_sum` formed by a collection of `add_subgroup`s of `M` is said to be internal if the

--- a/src/algebra/direct_sum/basic.lean
+++ b/src/algebra/direct_sum/basic.lean
@@ -172,13 +172,18 @@ protected def id (M : Type v) (ι : Type* := punit) [add_comm_monoid M] [unique 
   right_inv := λ x, to_add_monoid_of _ _ _,
   ..direct_sum.to_add_monoid (λ _, add_monoid_hom.id M) }
 
+/-- The canonical embedding from `⨁ i, A i` to `M`-/
+def direct_sum.add_submonoid_coe {M : Type*} [decidable_eq ι] [add_comm_monoid M]
+  (A : ι → add_submonoid M) : (⨁ i, A i) →+ M :=
+direct_sum.to_add_monoid (λ i, (A i).subtype)
+
 /-- The `direct_sum` formed by a collection of `add_submonoid`s of `M` is said to be internal if the
 canonical map `(⨁ i, A i) →+ M` is bijective.
 
 See `direct_sum.add_subgroup_is_internal` for the same statement about `add_subgroup`s. -/
 def add_submonoid_is_internal {M : Type*} [decidable_eq ι] [add_comm_monoid M]
   (A : ι → add_submonoid M) : Prop :=
-function.bijective (direct_sum.to_add_monoid (λ i, (A i).subtype) : (⨁ i, A i) →+ M)
+function.bijective (direct_sum.add_submonoid_coe A)
 
 lemma add_submonoid_is_internal.supr_eq_top {M : Type*} [decidable_eq ι] [add_comm_monoid M]
   (A : ι → add_submonoid M)
@@ -192,6 +197,14 @@ end
 def direct_sum.add_subgroup_coe {M : Type*} [decidable_eq ι] [add_comm_group M]
   (A : ι → add_subgroup M) : (⨁ i, A i) →+ M :=
 direct_sum.to_add_monoid (λ i, (A i).subtype)
+
+@[simp] lemma add_group_coe_of {M : Type*} [decidable_eq ι] [add_comm_group M]
+  (A : ι → add_subgroup M) (i : ι) (x : A i) :
+direct_sum.add_subgroup_coe A (direct_sum.of (λ i, A i) i x) = x :=
+begin
+  rw [direct_sum.add_subgroup_coe, direct_sum.to_add_monoid_of],
+  simp only [add_subgroup.coe_subtype],
+end
 
 /-- The `direct_sum` formed by a collection of `add_subgroup`s of `M` is said to be internal if the
 canonical map `(⨁ i, A i) →+ M` is bijective.

--- a/src/algebra/direct_sum/basic.lean
+++ b/src/algebra/direct_sum/basic.lean
@@ -179,7 +179,7 @@ direct_sum.to_add_monoid (λ i, (A i).subtype)
 
 @[simp] lemma add_submonoid_coe_of {M : Type*} [decidable_eq ι] [add_comm_monoid M]
   (A : ι → add_submonoid M) (i : ι) (x : A i) :
-direct_sum.add_submonoid_coe A (direct_sum.of (λ i, A i) i x) = x :=
+  direct_sum.add_submonoid_coe A (direct_sum.of (λ i, A i) i x) = x :=
 direct_sum.to_add_monoid_of _ _ _
 
 /-- The `direct_sum` formed by a collection of `add_submonoid`s of `M` is said to be internal if the

--- a/src/algebra/direct_sum/module.lean
+++ b/src/algebra/direct_sum/module.lean
@@ -194,7 +194,7 @@ lemma component.of (i j : ι) (b : M j) :
   if h : j = i then eq.rec_on h b else 0 :=
 dfinsupp.single_apply
 
-def direct_sum.submodule_coe {R M : Type*} [semiring R] [add_comm_monoid M] [module R M]
+def submodule_coe {R M : Type*} [semiring R] [add_comm_monoid M] [module R M]
   (A : ι → submodule R M) : (⨁ i, A i) →ₗ[R] M :=
 direct_sum.to_module R ι M (λ i, (A i).subtype)
 

--- a/src/algebra/direct_sum/module.lean
+++ b/src/algebra/direct_sum/module.lean
@@ -194,6 +194,7 @@ lemma component.of (i j : ι) (b : M j) :
   if h : j = i then eq.rec_on h b else 0 :=
 dfinsupp.single_apply
 
+/-- The canonical embedding from `⨁ i, A i` to `M`-/
 def submodule_coe {R M : Type*} [semiring R] [add_comm_monoid M] [module R M]
   (A : ι → submodule R M) : (⨁ i, A i) →ₗ[R] M :=
 direct_sum.to_module R ι M (λ i, (A i).subtype)

--- a/src/algebra/direct_sum/module.lean
+++ b/src/algebra/direct_sum/module.lean
@@ -194,6 +194,10 @@ lemma component.of (i j : ι) (b : M j) :
   if h : j = i then eq.rec_on h b else 0 :=
 dfinsupp.single_apply
 
+def direct_sum.submodule_coe {R M : Type*} [semiring R] [add_comm_monoid M] [module R M]
+  (A : ι → submodule R M) : (⨁ i, A i) →ₗ[R] M :=
+direct_sum.to_module R ι M (λ i, (A i).subtype)
+
 /-- The `direct_sum` formed by a collection of `submodule`s of `M` is said to be internal if the
 canonical map `(⨁ i, A i) →ₗ[R] M` is bijective.
 
@@ -202,7 +206,7 @@ For the alternate statement in terms of independence and spanning, see
 def submodule_is_internal {R M : Type*}
   [semiring R] [add_comm_monoid M] [module R M]
   (A : ι → submodule R M) : Prop :=
-function.bijective (to_module R ι M (λ i, (A i).subtype))
+function.bijective (direct_sum.submodule_coe A)
 
 lemma submodule_is_internal.to_add_submonoid {R M : Type*}
   [semiring R] [add_comm_monoid M] [module R M] (A : ι → submodule R M) :

--- a/src/algebra/direct_sum/module.lean
+++ b/src/algebra/direct_sum/module.lean
@@ -198,12 +198,12 @@ dfinsupp.single_apply
 indexed by `ι`-/
 def submodule_coe {R M : Type*} [semiring R] [add_comm_monoid M] [module R M]
   (A : ι → submodule R M) : (⨁ i, A i) →ₗ[R] M :=
-direct_sum.to_module R ι M (λ i, (A i).subtype)
+to_module R ι M (λ i, (A i).subtype)
 
 @[simp] lemma submodule_coe_of {R M : Type*} [semiring R] [add_comm_monoid M] [module R M]
   (A : ι → submodule R M) (i : ι) (x : A i) :
-  direct_sum.submodule_coe A (direct_sum.of (λ i, A i) i x) = x :=
-direct_sum.to_add_monoid_of _ _ _
+  submodule_coe A (of (λ i, A i) i x) = x :=
+to_add_monoid_of _ _ _
 
 
 /-- The `direct_sum` formed by a collection of `submodule`s of `M` is said to be internal if the
@@ -214,7 +214,7 @@ For the alternate statement in terms of independence and spanning, see
 def submodule_is_internal {R M : Type*}
   [semiring R] [add_comm_monoid M] [module R M]
   (A : ι → submodule R M) : Prop :=
-function.bijective (direct_sum.submodule_coe A)
+function.bijective (submodule_coe A)
 
 lemma submodule_is_internal.to_add_submonoid {R M : Type*}
   [semiring R] [add_comm_monoid M] [module R M] (A : ι → submodule R M) :

--- a/src/algebra/direct_sum/module.lean
+++ b/src/algebra/direct_sum/module.lean
@@ -194,7 +194,8 @@ lemma component.of (i j : ι) (b : M j) :
   if h : j = i then eq.rec_on h b else 0 :=
 dfinsupp.single_apply
 
-/-- The canonical embedding from `⨁ i, A i` to `M`-/
+/-- The canonical embedding from `⨁ i, A i` to `M`  where `A` is a collection of `submodule R M`
+indexed by `ι`-/
 def submodule_coe {R M : Type*} [semiring R] [add_comm_monoid M] [module R M]
   (A : ι → submodule R M) : (⨁ i, A i) →ₗ[R] M :=
 direct_sum.to_module R ι M (λ i, (A i).subtype)

--- a/src/algebra/direct_sum/module.lean
+++ b/src/algebra/direct_sum/module.lean
@@ -198,6 +198,12 @@ def submodule_coe {R M : Type*} [semiring R] [add_comm_monoid M] [module R M]
   (A : ι → submodule R M) : (⨁ i, A i) →ₗ[R] M :=
 direct_sum.to_module R ι M (λ i, (A i).subtype)
 
+@[simp] lemma submodule_coe_of {R M : Type*} [semiring R] [add_comm_monoid M] [module R M]
+  (A : ι → submodule R M) (i : ι) (x : A i) :
+direct_sum.submodule_coe A (direct_sum.of (λ i, A i) i x) = x :=
+direct_sum.to_add_monoid_of _ _ _
+
+
 /-- The `direct_sum` formed by a collection of `submodule`s of `M` is said to be internal if the
 canonical map `(⨁ i, A i) →ₗ[R] M` is bijective.
 

--- a/src/algebra/direct_sum/module.lean
+++ b/src/algebra/direct_sum/module.lean
@@ -201,7 +201,7 @@ direct_sum.to_module R ι M (λ i, (A i).subtype)
 
 @[simp] lemma submodule_coe_of {R M : Type*} [semiring R] [add_comm_monoid M] [module R M]
   (A : ι → submodule R M) (i : ι) (x : A i) :
-direct_sum.submodule_coe A (direct_sum.of (λ i, A i) i x) = x :=
+  direct_sum.submodule_coe A (direct_sum.of (λ i, A i) i x) = x :=
 direct_sum.to_add_monoid_of _ _ _
 
 


### PR DESCRIPTION
This extracts the following `def`s from within the various `is_internal` properties:
* `direct_sum.add_submonoid_coe`
* `direct_sum.add_subgroup_coe`
* `direct_sum.submodule_coe`

Packing these into a def makes things more concise, and avoids some annoying elaboration issues.

Co-authored-by: Eric Wieser <wieser.eric@gmail.com>

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
