### PR TITLE
[Merged by Bors] - refactor(group_theory/complement): Introduce abbreviation for subgroups

### DIFF
--- a/src/group_theory/complement.lean
+++ b/src/group_theory/complement.lean
@@ -38,6 +38,8 @@ variables {G : Type*} [group G] (H K : subgroup G) (S T : set G)
 @[to_additive "`S` and `T` are complements if `(*) : S × T → G` is a bijection"]
 def is_complement : Prop := function.bijective (λ x : S × T, x.1.1 * x.2.1)
 
+@[to_additive] abbreviation is_complement' := is_complement (H : set G) (K : set G)
+
 /-- The set of left-complements of `T : set G` -/
 @[to_additive "The set of left-complements of `T : set G`"]
 def left_transversals : set (set G) := {S : set G | is_complement S T}
@@ -48,6 +50,9 @@ def right_transversals : set (set G) := {T : set G | is_complement S T}
 
 variables {H K S T}
 
+@[to_additive] lemma is_complement'_def :
+  is_complement' H K ↔ is_complement (H : set G) (K : set G) := iff.rfl
+
 @[to_additive] lemma is_complement_iff_exists_unique :
   is_complement S T ↔ ∀ g : G, ∃! x : S × T, x.1.1 * x.2.1 = g :=
 function.bijective_iff_exists_unique _
@@ -56,20 +61,18 @@ function.bijective_iff_exists_unique _
   ∃! x : S × T, x.1.1 * x.2.1 = g :=
 is_complement_iff_exists_unique.mp h g
 
-@[to_additive] lemma is_complement.symm (h : is_complement (H : set G) (K : set G)) :
-  is_complement (K : set G) (H : set G) :=
+@[to_additive] lemma is_complement'.symm (h : is_complement' H K) : is_complement' K H :=
 begin
   let ϕ : H × K ≃ K × H := equiv.mk (λ x, ⟨x.2⁻¹, x.1⁻¹⟩) (λ x, ⟨x.2⁻¹, x.1⁻¹⟩)
     (λ x, prod.ext (inv_inv _) (inv_inv _)) (λ x, prod.ext (inv_inv _) (inv_inv _)),
   let ψ : G ≃ G := equiv.mk (λ g : G, g⁻¹) (λ g : G, g⁻¹) inv_inv inv_inv,
   suffices : ψ ∘ (λ x : H × K, x.1.1 * x.2.1) = (λ x : K × H, x.1.1 * x.2.1) ∘ ϕ,
-  { rwa [is_complement, ←equiv.bijective_comp, ←this, equiv.comp_bijective] },
+  { rwa [is_complement'_def, is_complement, ←equiv.bijective_comp, ←this, equiv.comp_bijective] },
   exact funext (λ x, mul_inv_rev _ _),
 end
 
-@[to_additive] lemma is_complement_comm :
-  is_complement (H : set G) (K : set G) ↔ is_complement (K : set G) (H : set G) :=
-⟨is_complement.symm, is_complement.symm⟩
+@[to_additive] lemma is_complement'_comm : is_complement' H K ↔ is_complement' K H :=
+⟨is_complement'.symm, is_complement'.symm⟩
 
 @[to_additive] lemma is_complement_top_singleton {g : G} :
   is_complement (⊤ : set G) {g} :=
@@ -149,18 +152,17 @@ mem_right_transversals_iff_exists_unique_quotient_mk'_eq.trans
 { rintros ⟨_, q₁, rfl⟩ ⟨_, q₂, rfl⟩ hg,
   rw (q₁.out_eq'.symm.trans hg).trans q₂.out_eq' }, λ q, ⟨⟨q.out', q, rfl⟩, quotient.out_eq' q⟩⟩⟩⟩
 
-lemma is_complement.card_mul [fintype G] [fintype H] [fintype K]
-  (h : is_complement (H : set G) (K : set G)) :
+lemma is_complement'.card_mul [fintype G] [fintype H] [fintype K] (h : is_complement' H K) :
   fintype.card H * fintype.card K = fintype.card G :=
 (fintype.card_prod _ _).symm.trans (fintype.card_of_bijective h)
 
-lemma is_complement.disjoint (h : is_complement (H : set G) (K : set G)) : disjoint H K :=
+lemma is_complement'.disjoint (h : is_complement' H K) : disjoint H K :=
 λ g hg, let x : H × K := ⟨⟨g, hg.1⟩, 1⟩, y : H × K := ⟨1, ⟨g, hg.2⟩⟩ in subtype.ext_iff.mp
   (prod.ext_iff.mp (h.1 (show x.1.1 * _ = y.1.1 * _, from (mul_one g).trans (one_mul g).symm))).1
 
-lemma is_complement_of_card_mul_and_disjoint [fintype G] [fintype H] [fintype K]
+lemma is_complement'_of_card_mul_and_disjoint [fintype G] [fintype H] [fintype K]
   (h1 : fintype.card H * fintype.card K = fintype.card G) (h2 : disjoint H K) :
-  is_complement (H : set G) (K : set G) :=
+  is_complement' H K :=
 begin
   refine (fintype.bijective_iff_injective_and_card _).mpr
     ⟨λ x y h, _, (fintype.card_prod H K).trans h1⟩,
@@ -171,15 +173,15 @@ begin
   exact ⟨subtype.mem ((x.1)⁻¹ * (y.1)), (congr_arg (∈ K) h).mp (subtype.mem (x.2 * (y.2)⁻¹))⟩,
 end
 
-lemma is_complement_iff_card_mul_and_disjoint [fintype G] [fintype H] [fintype K] :
-  is_complement (H : set G) (K : set G) ↔
+lemma is_complement'_iff_card_mul_and_disjoint [fintype G] [fintype H] [fintype K] :
+  is_complement' H K ↔
     fintype.card H * fintype.card K = fintype.card G ∧ disjoint H K :=
-⟨λ h, ⟨h.card_mul, h.disjoint⟩, λ h, is_complement_of_card_mul_and_disjoint h.1 h.2⟩
+⟨λ h, ⟨h.card_mul, h.disjoint⟩, λ h, is_complement'_of_card_mul_and_disjoint h.1 h.2⟩
 
-lemma is_complement_of_coprime [fintype G] [fintype H] [fintype K]
+lemma is_complement'_of_coprime [fintype G] [fintype H] [fintype K]
   (h1 : fintype.card H * fintype.card K = fintype.card G)
   (h2 : nat.coprime (fintype.card H) (fintype.card K)) :
-  is_complement (H : set G) (K : set G) :=
-is_complement_of_card_mul_and_disjoint h1 (disjoint_iff.mpr (inf_eq_bot_of_coprime h2))
+  is_complement' H K :=
+is_complement'_of_card_mul_and_disjoint h1 (disjoint_iff.mpr (inf_eq_bot_of_coprime h2))
 
 end subgroup

--- a/src/group_theory/complement.lean
+++ b/src/group_theory/complement.lean
@@ -38,7 +38,9 @@ variables {G : Type*} [group G] (H K : subgroup G) (S T : set G)
 @[to_additive "`S` and `T` are complements if `(*) : S × T → G` is a bijection"]
 def is_complement : Prop := function.bijective (λ x : S × T, x.1.1 * x.2.1)
 
-@[to_additive] abbreviation is_complement' := is_complement (H : set G) (K : set G)
+/-- `H` and `K` are complements if `(*) : H × K → G` is a bijection -/
+@[to_additive "`H` and `K` are complements if `(*) : H × K → G` is a bijection"]
+abbreviation is_complement' := is_complement (H : set G) (K : set G)
 
 /-- The set of left-complements of `T : set G` -/
 @[to_additive "The set of left-complements of `T : set G`"]

--- a/src/group_theory/schur_zassenhaus.lean
+++ b/src/group_theory/schur_zassenhaus.lean
@@ -145,9 +145,9 @@ lemma smul_left_injective [H.normal] (α : H.quotient_diff)
   exact (pow_coprime hH).injective hα,
 end
 
-lemma is_complement_stabilizer_of_coprime [fintype G] [H.normal] {α : H.quotient_diff}
+lemma is_complement'_stabilizer_of_coprime [fintype G] [H.normal] {α : H.quotient_diff}
   (hH : nat.coprime (fintype.card H) H.index) :
-  is_complement (H : set G) (mul_action.stabilizer G α : set G) :=
+  is_complement' H (mul_action.stabilizer G α) :=
 begin
   classical,
   let ϕ : H ≃ mul_action.orbit G α := equiv.of_bijective (λ h, ⟨h • α, h, rfl⟩)
@@ -155,7 +155,7 @@ begin
       λ β, exists_imp_exists (λ h hh, subtype.ext hh) (exists_smul_eq α β hH)⟩,
   have key := card_eq_card_quotient_mul_card_subgroup (mul_action.stabilizer G α),
   rw ← fintype.card_congr (ϕ.trans (mul_action.orbit_equiv_quotient_stabilizer G α)) at key,
-  apply is_complement_of_coprime key.symm,
+  apply is_complement'_of_coprime key.symm,
   rw [card_eq_card_quotient_mul_card_subgroup H, mul_comm, mul_right_inj'] at key,
   { rwa [←key, ←index_eq_card] },
   { rw [←pos_iff_ne_zero, fintype.card_pos_iff],
@@ -165,18 +165,18 @@ end
 /-- **Schur-Zassenhaus** for abelian normal subgroups:
   If `H : subgroup G` is abelian, normal, and has order coprime to its index, then there exists
   a subgroup `K` which is a (right) complement of `H`. -/
-theorem exists_right_complement_of_coprime [fintype G] [H.normal]
+theorem exists_right_complement'_of_coprime [fintype G] [H.normal]
   (hH : nat.coprime (fintype.card H) H.index) :
-  ∃ K : subgroup G, is_complement (H : set G) (K : set G) :=
+  ∃ K : subgroup G, is_complement' H K :=
 nonempty_of_inhabited.elim
-  (λ α : H.quotient_diff, ⟨mul_action.stabilizer G α, is_complement_stabilizer_of_coprime hH⟩)
+  (λ α : H.quotient_diff, ⟨mul_action.stabilizer G α, is_complement'_stabilizer_of_coprime hH⟩)
 
 /-- **Schur-Zassenhaus** for abelian normal subgroups:
   If `H : subgroup G` is abelian, normal, and has order coprime to its index, then there exists
   a subgroup `K` which is a (left) complement of `H`. -/
-theorem exists_left_complement_of_coprime [fintype G] [H.normal]
+theorem exists_left_complement'_of_coprime [fintype G] [H.normal]
   (hH : nat.coprime (fintype.card H) H.index) :
-  ∃ K : subgroup G, is_complement (K : set G) (H : set G) :=
-Exists.imp (λ _, is_complement.symm) (exists_right_complement_of_coprime hH)
+  ∃ K : subgroup G, is_complement' K H :=
+Exists.imp (λ _, is_complement'.symm) (exists_right_complement'_of_coprime hH)
 
 end subgroup


### PR DESCRIPTION
Introduces abbreviation for `is_complement (H : set G) (K : set G)`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
