### PR TITLE
chore(measure_theory/measure/finite_measure_weak_convergence): make probability_measure a subtype of finite_measure

### DIFF
--- a/src/measure_theory/measure/finite_measure_weak_convergence.lean
+++ b/src/measure_theory/measure/finite_measure_weak_convergence.lean
@@ -165,6 +165,7 @@ probability measures (i.e., their total mass is one). -/
 def probability_measure (α : Type*) [measurable_space α] : Type* :=
 {μ : finite_measure α // μ univ = 1}
 
+/-- Get a `probability_measure` from a measure which has the property `is_probability_measure`. -/
 def measure.to_probability_measure {m : measurable_space α} (μ : measure α)
   [is_probability_measure μ] :
   probability_measure α :=
@@ -190,8 +191,6 @@ include m
 
 instance : has_coe_to_fun (probability_measure α) (λ _, set α → ℝ≥0) :=
 ⟨λ μ s, (μ : finite_measure α) s⟩
-
-lemma coe_fn_to_finite_measure (ν : probability_measure α) : ⇑(ν : finite_measure α) = ⇑ν := rfl
 
 lemma coe_fn_eq_to_nnreal_coe_fn_to_measure (ν : probability_measure α) :
   ⇑ν = λ s, ((ν : measure α) s).to_nnreal := rfl


### PR DESCRIPTION
Currently, both `finite_measure α` and `probability_measure α` are subtypes of `measure α`. This PR changes `probability_measure α` to be a subtype of `finite_measure α`. Hopefully it will avoid duplication of some notions for both types of measures.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)

Inspired by the duplication of `test_against_nn` in #9430 .
