### PR TITLE
[Merged by Bors] - chore(data/set/pairwise): rename `set.pairwise_on` to `set.pairwise` to match `list.pairwise` and `multiset.pairwise`

### DIFF
--- a/src/algebra/big_operators/finprod.lean
+++ b/src/algebra/big_operators/finprod.lean
@@ -682,7 +682,7 @@ sets `t i`, `i ∈ I`, are finite, if all `t i`, `i ∈ I`, are pairwise disjoin
 the product of `f a` over `a ∈ ⋃ i ∈ I, t i` is equal to the product over `i ∈ I`
 of the products of `f a` over `a ∈ t i`. -/
 @[to_additive] lemma finprod_mem_bUnion {I : set ι} {t : ι → set α}
-  (h : pairwise_on I (disjoint on t)) (hI : I.finite) (ht : ∀ i ∈ I, (t i).finite) :
+  (h : I.pairwise (disjoint on t)) (hI : I.finite) (ht : ∀ i ∈ I, (t i).finite) :
   ∏ᶠ a ∈ ⋃ x ∈ I, t x, f a = ∏ᶠ i ∈ I, ∏ᶠ j ∈ t i, f j :=
 begin
   haveI := hI.fintype,
@@ -692,7 +692,7 @@ end
 
 /-- If `t` is a finite set of pairwise disjoint finite sets, then the product of `f a`
 over `a ∈ ⋃₀ t` is the product over `s ∈ t` of the products of `f a` over `a ∈ s`. -/
-@[to_additive] lemma finprod_mem_sUnion {t : set (set α)} (h : pairwise_on t disjoint)
+@[to_additive] lemma finprod_mem_sUnion {t : set (set α)} (h : t.pairwise disjoint)
   (ht₀ : t.finite) (ht₁ : ∀ x ∈ t, set.finite x):
   ∏ᶠ a ∈ ⋃₀ t, f a = ∏ᶠ s ∈ t, ∏ᶠ a ∈ s, f a :=
 by rw [set.sUnion_eq_bUnion, finprod_mem_bUnion h ht₀ ht₁]

--- a/src/analysis/box_integral/partition/basic.lean
+++ b/src/analysis/box_integral/partition/basic.lean
@@ -47,7 +47,7 @@ variables {ι : Type*}
 structure prepartition (I : box ι) :=
 (boxes : finset (box ι))
 (le_of_mem' : ∀ J ∈ boxes, J ≤ I)
-(pairwise_disjoint : pairwise_on ↑boxes (disjoint on (coe : box ι → set (ι → ℝ))))
+(pairwise_disjoint : set.pairwise ↑boxes (disjoint on (coe : box ι → set (ι → ℝ))))
 
 namespace prepartition
 
@@ -308,7 +308,7 @@ end
 the empty one if it exists. -/
 def of_with_bot (boxes : finset (with_bot (box ι)))
   (le_of_mem : ∀ J ∈ boxes, (J : with_bot (box ι)) ≤ I)
-  (pairwise_disjoint : pairwise_on (boxes : set (with_bot (box ι))) disjoint) :
+  (pairwise_disjoint : set.pairwise (boxes : set (with_bot (box ι))) disjoint) :
   prepartition I :=
 { boxes := boxes.erase_none,
   le_of_mem' := λ J hJ,
@@ -328,7 +328,7 @@ mem_erase_none
 
 @[simp] lemma Union_of_with_bot (boxes : finset (with_bot (box ι)))
   (le_of_mem : ∀ J ∈ boxes, (J : with_bot (box ι)) ≤ I)
-  (pairwise_disjoint : pairwise_on (boxes : set (with_bot (box ι))) disjoint) :
+  (pairwise_disjoint : set.pairwise (boxes : set (with_bot (box ι))) disjoint) :
   (of_with_bot boxes le_of_mem pairwise_disjoint).Union = ⋃ J ∈ boxes, ↑J :=
 begin
   suffices : (⋃ (J : box ι) (hJ : ↑J ∈ boxes), ↑J) = ⋃ J ∈ boxes, ↑J,
@@ -339,7 +339,7 @@ end
 
 lemma of_with_bot_le {boxes : finset (with_bot (box ι))}
   {le_of_mem : ∀ J ∈ boxes, (J : with_bot (box ι)) ≤ I}
-  {pairwise_disjoint : pairwise_on (boxes : set (with_bot (box ι))) disjoint}
+  {pairwise_disjoint : set.pairwise (boxes : set (with_bot (box ι))) disjoint}
   (H : ∀ J ∈ boxes, J ≠ ⊥ → ∃ J' ∈ π, J ≤ ↑J') :
   of_with_bot boxes le_of_mem pairwise_disjoint ≤ π :=
 have ∀ (J : box ι), ↑J ∈ boxes → ∃ J' ∈ π, J ≤ J',
@@ -348,7 +348,7 @@ by simpa [of_with_bot, le_def]
 
 lemma le_of_with_bot {boxes : finset (with_bot (box ι))}
   {le_of_mem : ∀ J ∈ boxes, (J : with_bot (box ι)) ≤ I}
-  {pairwise_disjoint : pairwise_on (boxes : set (with_bot (box ι))) disjoint}
+  {pairwise_disjoint : set.pairwise (boxes : set (with_bot (box ι))) disjoint}
   (H : ∀ J ∈ π, ∃ J' ∈ boxes, ↑J ≤ J') :
   π ≤ of_with_bot boxes le_of_mem pairwise_disjoint :=
 begin
@@ -360,10 +360,10 @@ end
 
 lemma of_with_bot_mono {boxes₁ : finset (with_bot (box ι))}
   {le_of_mem₁ : ∀ J ∈ boxes₁, (J : with_bot (box ι)) ≤ I}
-  {pairwise_disjoint₁ : pairwise_on (boxes₁ : set (with_bot (box ι))) disjoint}
+  {pairwise_disjoint₁ : set.pairwise (boxes₁ : set (with_bot (box ι))) disjoint}
   {boxes₂ : finset (with_bot (box ι))}
   {le_of_mem₂ : ∀ J ∈ boxes₂, (J : with_bot (box ι)) ≤ I}
-  {pairwise_disjoint₂ : pairwise_on (boxes₂ : set (with_bot (box ι))) disjoint}
+  {pairwise_disjoint₂ : set.pairwise (boxes₂ : set (with_bot (box ι))) disjoint}
   (H : ∀ J ∈ boxes₁, J ≠ ⊥ → ∃ J' ∈ boxes₂, J ≤ J') :
   of_with_bot boxes₁ le_of_mem₁ pairwise_disjoint₁ ≤
     of_with_bot boxes₂ le_of_mem₂ pairwise_disjoint₂ :=
@@ -372,7 +372,7 @@ le_of_with_bot _ $ λ J hJ, H J (mem_of_with_bot.1 hJ) (with_bot.coe_ne_bot _)
 lemma sum_of_with_bot {M : Type*} [add_comm_monoid M]
   (boxes : finset (with_bot (box ι)))
   (le_of_mem : ∀ J ∈ boxes, (J : with_bot (box ι)) ≤ I)
-  (pairwise_disjoint : pairwise_on (boxes : set (with_bot (box ι))) disjoint)
+  (pairwise_disjoint : set.pairwise (boxes : set (with_bot (box ι))) disjoint)
   (f : box ι → M) :
   ∑ J in (of_with_bot boxes le_of_mem pairwise_disjoint).boxes, f J =
     ∑ J in boxes, option.elim J 0 f :=

--- a/src/analysis/box_integral/partition/basic.lean
+++ b/src/analysis/box_integral/partition/basic.lean
@@ -224,7 +224,7 @@ function. -/
     end,
   pairwise_disjoint :=
     begin
-      simp only [pairwise_on, finset.mem_coe, finset.mem_bUnion],
+      simp only [set.pairwise, finset.mem_coe, finset.mem_bUnion],
       rintro J₁' ⟨J₁, hJ₁, hJ₁'⟩ J₂' ⟨J₂, hJ₂, hJ₂'⟩ Hne x ⟨hx₁, hx₂⟩, apply Hne,
       obtain rfl : J₁ = J₂,
         from π.eq_of_mem_of_mem hJ₁ hJ₂ ((πi J₁).le_of_mem hJ₁' hx₁)
@@ -384,7 +384,7 @@ def restrict (π : prepartition I) (J : box ι) :
 of_with_bot (π.boxes.image (λ J', J ⊓ J'))
   (λ J' hJ', by { rcases finset.mem_image.1 hJ' with ⟨J', -, rfl⟩, exact inf_le_left })
   begin
-    simp only [pairwise_on, on_fun, finset.mem_coe, finset.mem_image],
+    simp only [set.pairwise, on_fun, finset.mem_coe, finset.mem_image],
     rintro _ ⟨J₁, h₁, rfl⟩ _ ⟨J₂, h₂, rfl⟩ Hne,
     have : J₁ ≠ J₂, by { rintro rfl, exact Hne rfl },
     exact ((box.disjoint_coe.2 $ π.disjoint_coe_of_mem h₁ h₂ this).inf_left' _).inf_right' _
@@ -523,7 +523,7 @@ by convert sum_fiberwise_of_maps_to (λ _, finset.mem_image_of_mem f) g
   le_of_mem' := λ J hJ, (finset.mem_union.1 hJ).elim π₁.le_of_mem π₂.le_of_mem,
   pairwise_disjoint :=
     suffices ∀ (J₁ ∈ π₁) (J₂ ∈ π₂), J₁ ≠ J₂ → disjoint (J₁ : set (ι → ℝ)) J₂,
-      by simpa [pairwise_on_union_of_symmetric (symmetric_disjoint.comap _), pairwise_disjoint],
+      by simpa [pairwise_union_of_symmetric (symmetric_disjoint.comap _), pairwise_disjoint],
     λ J₁ h₁ J₂ h₂ _, h.mono (π₁.subset_Union h₁) (π₂.subset_Union h₂) }
 
 @[simp] lemma mem_disj_union (H : disjoint π₁.Union π₂.Union) :

--- a/src/analysis/box_integral/partition/split.lean
+++ b/src/analysis/box_integral/partition/split.lean
@@ -147,7 +147,7 @@ of_with_bot {I.split_lower i x, I.split_upper i x}
   end
   begin
     simp only [finset.coe_insert, finset.coe_singleton, true_and, set.mem_singleton_iff,
-     pairwise_on_insert_of_symmetric symmetric_disjoint, pairwise_on_singleton],
+      pairwise_insert_of_symmetric symmetric_disjoint, pairwise_singleton],
     rintro J rfl -,
     exact I.disjoint_split_lower_split_upper i x
   end

--- a/src/analysis/convex/basic.lean
+++ b/src/analysis/convex/basic.lean
@@ -530,7 +530,7 @@ begin
 end
 
 lemma convex_iff_pairwise_on_pos :
-  convex 𝕜 s ↔ s.pairwise_on (λ x y, ∀ ⦃a b : 𝕜⦄, 0 < a → 0 < b → a + b = 1 → a • x + b • y ∈ s) :=
+  convex 𝕜 s ↔ s.pairwise (λ x y, ∀ ⦃a b : 𝕜⦄, 0 < a → 0 < b → a + b = 1 → a • x + b • y ∈ s) :=
 begin
   refine ⟨λ h x hx y hy _ a b ha hb hab, h hx hy ha.le hb.le hab, _⟩,
   intros h x y hx hy a b ha hb hab,

--- a/src/analysis/convex/basic.lean
+++ b/src/analysis/convex/basic.lean
@@ -529,7 +529,7 @@ begin
   exact h hx hy ha hb hab
 end
 
-lemma convex_iff_pairwise_on_pos :
+lemma convex_iff_pairwise_pos :
   convex 𝕜 s ↔ s.pairwise (λ x y, ∀ ⦃a b : 𝕜⦄, 0 < a → 0 < b → a + b = 1 → a • x + b • y ∈ s) :=
 begin
   refine ⟨λ h x hx y hy _ a b ha hb hab, h hx hy ha.le hb.le hab, _⟩,

--- a/src/analysis/convex/function.lean
+++ b/src/analysis/convex/function.lean
@@ -229,7 +229,7 @@ lemma concave_on_iff_forall_pos {s : set E} {f : E → β} :
     → a • f x + b • f y ≤ f (a • x + b • y) :=
 @convex_on_iff_forall_pos 𝕜 E (order_dual β) _ _ _ _ _ _ _
 
-lemma convex_on_iff_pairwise_on_pos {s : set E} {f : E → β} :
+lemma convex_on_iff_pairwise_pos {s : set E} {f : E → β} :
   convex_on 𝕜 s f ↔ convex 𝕜 s ∧
     s.pairwise (λ x y, ∀ ⦃a b : 𝕜⦄, 0 < a → 0 < b → a + b = 1
     → f (a • x + b • y) ≤ a • f x + b • f y) :=
@@ -242,11 +242,11 @@ begin
   exact h x hx y hy hxy ha hb hab,
 end
 
-lemma concave_on_iff_pairwise_on_pos {s : set E} {f : E → β} :
+lemma concave_on_iff_pairwise_pos {s : set E} {f : E → β} :
   concave_on 𝕜 s f ↔ convex 𝕜 s ∧
    s.pairwise (λ x y, ∀ ⦃a b : 𝕜⦄, 0 < a → 0 < b → a + b = 1
     → a • f x + b • f y ≤ f (a • x + b • y)) :=
-@convex_on_iff_pairwise_on_pos 𝕜 E (order_dual β) _ _ _ _ _ _ _
+@convex_on_iff_pairwise_pos 𝕜 E (order_dual β) _ _ _ _ _ _ _
 
 /-- A linear map is convex. -/
 lemma linear_map.convex_on (f : E →ₗ[𝕜] β) {s : set E} (hs : convex 𝕜 s) : convex_on 𝕜 s f :=
@@ -279,7 +279,7 @@ variables [ordered_smul 𝕜 β] {s : set E} {f : E → β}
 
 lemma strict_convex_on.convex_lt (hf : strict_convex_on 𝕜 s f) (r : β) :
   convex 𝕜 {x ∈ s | f x < r} :=
-convex_iff_pairwise_on_pos.2 $ λ x hx y hy hxy a b ha hb hab, ⟨hf.1 hx.1 hy.1 ha.le hb.le hab,
+convex_iff_pairwise_pos.2 $ λ x hx y hy hxy a b ha hb hab, ⟨hf.1 hx.1 hy.1 ha.le hb.le hab,
   calc
     f (a • x + b • y) < a • f x + b • f y : hf.2 hx.1 hy.1 hxy ha hb hab
                   ... ≤ a • r + b • r     : add_le_add (smul_lt_smul_of_pos hx.2 ha).le
@@ -304,7 +304,7 @@ lemma linear_order.convex_on_of_lt (hs : convex 𝕜 s)
   (hf : ∀ ⦃x y : E⦄, x ∈ s → y ∈ s → x < y → ∀ ⦃a b : 𝕜⦄, 0 < a → 0 < b → a + b = 1 →
     f (a • x + b • y) ≤ a • f x + b • f y) : convex_on 𝕜 s f :=
 begin
-  refine convex_on_iff_pairwise_on_pos.2 ⟨hs, λ x hx y hy hxy a b ha hb hab, _⟩,
+  refine convex_on_iff_pairwise_pos.2 ⟨hs, λ x hx y hy hxy a b ha hb hab, _⟩,
   wlog h : x ≤ y using [x y a b, y x b a],
   { exact le_total _ _ },
   exact hf hx hy (h.lt_of_ne hxy) ha hb hab,

--- a/src/analysis/convex/function.lean
+++ b/src/analysis/convex/function.lean
@@ -231,7 +231,7 @@ lemma concave_on_iff_forall_pos {s : set E} {f : E → β} :
 
 lemma convex_on_iff_pairwise_on_pos {s : set E} {f : E → β} :
   convex_on 𝕜 s f ↔ convex 𝕜 s ∧
-    s.pairwise_on (λ x y, ∀ ⦃a b : 𝕜⦄, 0 < a → 0 < b → a + b = 1
+    s.pairwise (λ x y, ∀ ⦃a b : 𝕜⦄, 0 < a → 0 < b → a + b = 1
     → f (a • x + b • y) ≤ a • f x + b • f y) :=
 begin
   rw convex_on_iff_forall_pos,
@@ -244,7 +244,7 @@ end
 
 lemma concave_on_iff_pairwise_on_pos {s : set E} {f : E → β} :
   concave_on 𝕜 s f ↔ convex 𝕜 s ∧
-   s.pairwise_on (λ x y, ∀ ⦃a b : 𝕜⦄, 0 < a → 0 < b → a + b = 1
+   s.pairwise (λ x y, ∀ ⦃a b : 𝕜⦄, 0 < a → 0 < b → a + b = 1
     → a • f x + b • f y ≤ f (a • x + b • y)) :=
 @convex_on_iff_pairwise_on_pos 𝕜 E (order_dual β) _ _ _ _ _ _ _
 

--- a/src/data/list/nodup.lean
+++ b/src/data/list/nodup.lean
@@ -338,8 +338,8 @@ begin
   exact absurd (hl x) hx.not_le
 end
 
-lemma nodup.pairwise_of_set_pairwise_on {l : list α} {r : α → α → Prop}
-  (hl : l.nodup) (h : {x | x ∈ l}.pairwise_on r) : l.pairwise r :=
+lemma nodup.pairwise_of_set_pairwise {l : list α} {r : α → α → Prop}
+  (hl : l.nodup) (h : {x | x ∈ l}.pairwise r) : l.pairwise r :=
 hl.pairwise_of_forall_ne h
 
 end list

--- a/src/data/list/pairwise.lean
+++ b/src/data/list/pairwise.lean
@@ -246,8 +246,8 @@ from λ R l, ⟨λ p, reverse_reverse l ▸ this p, this⟩,
     pairwise_cons, forall_prop_of_false (not_mem_nil _), forall_true_iff,
     pairwise.nil, mem_reverse, mem_singleton, forall_eq, true_and] using h]
 
-lemma pairwise.set_pairwise_on {l : list α} (h : pairwise R l) (hr : symmetric R) :
-  set.pairwise_on {x | x ∈ l} R :=
+lemma pairwise.set_pairwise {l : list α} (h : pairwise R l) (hr : symmetric R) :
+  set.pairwise {x | x ∈ l} R :=
 begin
   induction h with hd tl imp h IH,
   { simp },

--- a/src/data/polynomial/field_division.lean
+++ b/src/data/polynomial/field_division.lean
@@ -408,7 +408,7 @@ begin
     pairwise_coprime_X_sub function.injective_id,
   have H : pairwise (is_coprime on λ (a : R), (polynomial.X - C (id a)) ^ (root_multiplicity a p)),
   { intros a b hdiff, exact (hcoprime a b hdiff).pow },
-  apply finset.prod_dvd_of_coprime (pairwise.pairwise_on H (↑(multiset.to_finset p.roots) : set R)),
+  apply finset.prod_dvd_of_coprime (pairwise.set_pairwise H (↑(multiset.to_finset p.roots) : set R)),
   intros a h,
   rw multiset.mem_to_finset at h,
   exact pow_root_multiplicity_dvd p a

--- a/src/data/polynomial/field_division.lean
+++ b/src/data/polynomial/field_division.lean
@@ -408,7 +408,7 @@ begin
     pairwise_coprime_X_sub function.injective_id,
   have H : pairwise (is_coprime on λ (a : R), (polynomial.X - C (id a)) ^ (root_multiplicity a p)),
   { intros a b hdiff, exact (hcoprime a b hdiff).pow },
-  apply finset.prod_dvd_of_coprime (pairwise.set_pairwise H (↑(multiset.to_finset p.roots) : set R)),
+  apply finset.prod_dvd_of_coprime (H.set_pairwise (↑(multiset.to_finset p.roots) : set R)),
   intros a h,
   rw multiset.mem_to_finset at h,
   exact pow_root_multiplicity_dvd p a

--- a/src/data/set/pairwise.lean
+++ b/src/data/set/pairwise.lean
@@ -13,7 +13,7 @@ This file defines pairwise relations and pairwise disjoint sets.
 ## Main declarations
 
 * `pairwise`: `pairwise r` states that `r i j` for all `i ≠ j`.
-* `set.pairwise_on`: `s.pairwise_on p` states that `p i j` for all `i ≠ j` with `i, j ∈ s`.
+* `set.pairwise`: `s.pairwise p` states that `p i j` for all `i ≠ j` with `i, j ∈ s`.
 * `set.pairwise_disjoint`: `pairwise_disjoint s` states that all elements in `s` are either equal or
   `disjoint`.
 -/
@@ -51,37 +51,37 @@ symmetric.pairwise_on disjoint.symm f
 namespace set
 
 /-- The relation `r` holds pairwise on the set `s` if `r x y` for all *distinct* `x y ∈ s`. -/
-def pairwise_on (s : set α) (r : α → α → Prop) := ∀ x ∈ s, ∀ y ∈ s, x ≠ y → r x y
+protected def pairwise (s : set α) (r : α → α → Prop) := ∀ x ∈ s, ∀ y ∈ s, x ≠ y → r x y
 
-lemma pairwise_on_of_forall (s : set α) (r : α → α → Prop) (h : ∀ a b, r a b) : s.pairwise_on r :=
+lemma pairwise_of_forall (s : set α) (r : α → α → Prop) (h : ∀ a b, r a b) : s.pairwise r :=
 λ a _ b _ _, h a b
 
-lemma pairwise_on.imp_on (h : s.pairwise_on r) (hrp : s.pairwise_on (λ ⦃a b : α⦄, r a b → p a b)) :
-  s.pairwise_on p :=
+lemma pairwise.imp_on (h : s.pairwise r) (hrp : s.pairwise (λ ⦃a b : α⦄, r a b → p a b)) :
+  s.pairwise p :=
 λ a ha b hb hab, hrp a ha b hb hab (h a ha b hb hab)
 
-lemma pairwise_on.imp (h : s.pairwise_on r) (hpq : ∀ ⦃a b : α⦄, r a b → p a b) : s.pairwise_on p :=
-h.imp_on $ pairwise_on_of_forall s _ hpq
+lemma pairwise.imp (h : s.pairwise r) (hpq : ∀ ⦃a b : α⦄, r a b → p a b) : s.pairwise p :=
+h.imp_on $ pairwise_of_forall s _ hpq
 
-lemma pairwise_on.mono (h : t ⊆ s) (hs : s.pairwise_on r) : t.pairwise_on r :=
+lemma pairwise.mono (h : t ⊆ s) (hs : s.pairwise r) : t.pairwise r :=
 λ x xt y yt, hs x (h xt) y (h yt)
 
-lemma pairwise_on.mono' (H : r ≤ p) (hr : s.pairwise_on r) : s.pairwise_on p := hr.imp H
+lemma pairwise.mono' (H : r ≤ p) (hr : s.pairwise r) : s.pairwise p := hr.imp H
 
-lemma pairwise_on_top (s : set α) : s.pairwise_on ⊤ := pairwise_on_of_forall s _ (λ a b, trivial)
+lemma pairwise_top (s : set α) : s.pairwise ⊤ := pairwise_of_forall s _ (λ a b, trivial)
 
-protected lemma subsingleton.pairwise_on (h : s.subsingleton) (r : α → α → Prop) :
-  s.pairwise_on r :=
+protected lemma subsingleton.pairwise (h : s.subsingleton) (r : α → α → Prop) :
+  s.pairwise r :=
 λ x hx y hy hne, (hne (h hx hy)).elim
 
-@[simp] lemma pairwise_on_empty (r : α → α → Prop) : (∅ : set α).pairwise_on r :=
-subsingleton_empty.pairwise_on r
+@[simp] lemma pairwise_empty (r : α → α → Prop) : (∅ : set α).pairwise r :=
+subsingleton_empty.pairwise r
 
-@[simp] lemma pairwise_on_singleton (a : α) (r : α → α → Prop) : pairwise_on {a} r :=
-subsingleton_singleton.pairwise_on r
+@[simp] lemma pairwise_singleton (a : α) (r : α → α → Prop) : set.pairwise {a} r :=
+subsingleton_singleton.pairwise r
 
-lemma nonempty.pairwise_on_iff_exists_forall [is_equiv α r] {s : set ι} (hs : s.nonempty) :
-  (s.pairwise_on (r on f)) ↔ ∃ z, ∀ x ∈ s, r (f x) z :=
+lemma nonempty.pairwise_iff_exists_forall [is_equiv α r] {s : set ι} (hs : s.nonempty) :
+  (s.pairwise (r on f)) ↔ ∃ z, ∀ x ∈ s, r (f x) z :=
 begin
   fsplit,
   { rcases hs with ⟨y, hy⟩,
@@ -95,85 +95,85 @@ end
 
 /-- For a nonempty set `s`, a function `f` takes pairwise equal values on `s` if and only if
 for some `z` in the codomain, `f` takes value `z` on all `x ∈ s`. See also
-`set.pairwise_on_eq_iff_exists_eq` for a version that assumes `[nonempty ι]` instead of
+`set.pairwise_eq_iff_exists_eq` for a version that assumes `[nonempty ι]` instead of
 `set.nonempty s`. -/
-lemma nonempty.pairwise_on_eq_iff_exists_eq {s : set α} (hs : s.nonempty) {f : α → ι} :
-  (s.pairwise_on (λ x y, f x = f y)) ↔ ∃ z, ∀ x ∈ s, f x = z :=
-hs.pairwise_on_iff_exists_forall
+lemma nonempty.pairwise_eq_iff_exists_eq {s : set α} (hs : s.nonempty) {f : α → ι} :
+  (s.pairwise (λ x y, f x = f y)) ↔ ∃ z, ∀ x ∈ s, f x = z :=
+hs.pairwise_iff_exists_forall
 
-lemma pairwise_on_iff_exists_forall [nonempty ι] (s : set α) (f : α → ι) {r : ι → ι → Prop}
+lemma pairwise_iff_exists_forall [nonempty ι] (s : set α) (f : α → ι) {r : ι → ι → Prop}
   [is_equiv ι r] :
-  (s.pairwise_on (r on f)) ↔ ∃ z, ∀ x ∈ s, r (f x) z :=
+  (s.pairwise (r on f)) ↔ ∃ z, ∀ x ∈ s, r (f x) z :=
 begin
   rcases s.eq_empty_or_nonempty with rfl|hne,
   { simp },
-  { exact hne.pairwise_on_iff_exists_forall }
+  { exact hne.pairwise_iff_exists_forall }
 end
 
 /-- A function `f : α → ι` with nonempty codomain takes pairwise equal values on a set `s` if and
 only if for some `z` in the codomain, `f` takes value `z` on all `x ∈ s`. See also
-`set.nonempty.pairwise_on_eq_iff_exists_eq` for a version that assumes `set.nonempty s` instead of
+`set.nonempty.pairwise_eq_iff_exists_eq` for a version that assumes `set.nonempty s` instead of
 `[nonempty ι]`. -/
-lemma pairwise_on_eq_iff_exists_eq [nonempty ι] (s : set α) (f : α → ι) :
-  (s.pairwise_on (λ x y, f x = f y)) ↔ ∃ z, ∀ x ∈ s, f x = z :=
-pairwise_on_iff_exists_forall s f
+lemma pairwise_eq_iff_exists_eq [nonempty ι] (s : set α) (f : α → ι) :
+  (s.pairwise (λ x y, f x = f y)) ↔ ∃ z, ∀ x ∈ s, f x = z :=
+pairwise_iff_exists_forall s f
 
-lemma pairwise_on_union :
-  (s ∪ t).pairwise_on r ↔
-    s.pairwise_on r ∧ t.pairwise_on r ∧ ∀ (a ∈ s) (b ∈ t), a ≠ b → r a b ∧ r b a :=
+lemma pairwise_union :
+  (s ∪ t).pairwise r ↔
+    s.pairwise r ∧ t.pairwise r ∧ ∀ (a ∈ s) (b ∈ t), a ≠ b → r a b ∧ r b a :=
 begin
-  simp only [pairwise_on, mem_union_eq, or_imp_distrib, forall_and_distrib],
+  simp only [set.pairwise, mem_union_eq, or_imp_distrib, forall_and_distrib],
   exact ⟨λ H, ⟨H.1.1, H.2.2, H.2.1, λ x hx y hy hne, H.1.2 y hy x hx hne.symm⟩,
     λ H, ⟨⟨H.1, λ x hx y hy hne, H.2.2.2 y hy x hx hne.symm⟩, H.2.2.1, H.2.1⟩⟩
 end
 
-lemma pairwise_on_union_of_symmetric (hr : symmetric r) :
-  (s ∪ t).pairwise_on r ↔
-    s.pairwise_on r ∧ t.pairwise_on r ∧ ∀ (a ∈ s) (b ∈ t), a ≠ b → r a b :=
-pairwise_on_union.trans $ by simp only [hr.iff, and_self]
+lemma pairwise_union_of_symmetric (hr : symmetric r) :
+  (s ∪ t).pairwise r ↔
+    s.pairwise r ∧ t.pairwise r ∧ ∀ (a ∈ s) (b ∈ t), a ≠ b → r a b :=
+pairwise_union.trans $ by simp only [hr.iff, and_self]
 
-lemma pairwise_on_insert :
-  (insert a s).pairwise_on r ↔ s.pairwise_on r ∧ ∀ b ∈ s, a ≠ b → r a b ∧ r b a :=
-by simp only [insert_eq, pairwise_on_union, pairwise_on_singleton, true_and,
+lemma pairwise_insert :
+  (insert a s).pairwise r ↔ s.pairwise r ∧ ∀ b ∈ s, a ≠ b → r a b ∧ r b a :=
+by simp only [insert_eq, pairwise_union, pairwise_singleton, true_and,
   mem_singleton_iff, forall_eq]
 
-lemma pairwise_on_insert_of_symmetric (hr : symmetric r) :
-  (insert a s).pairwise_on r ↔ s.pairwise_on r ∧ ∀ b ∈ s, a ≠ b → r a b :=
-by simp only [pairwise_on_insert, hr.iff a, and_self]
+lemma pairwise_insert_of_symmetric (hr : symmetric r) :
+  (insert a s).pairwise r ↔ s.pairwise r ∧ ∀ b ∈ s, a ≠ b → r a b :=
+by simp only [pairwise_insert, hr.iff a, and_self]
 
-lemma pairwise_on_pair : pairwise_on {a, b} r ↔ (a ≠ b → r a b ∧ r b a) :=
-by simp [pairwise_on_insert]
+lemma pairwise_pair : set.pairwise {a, b} r ↔ (a ≠ b → r a b ∧ r b a) :=
+by simp [pairwise_insert]
 
-lemma pairwise_on_pair_of_symmetric (hr : symmetric r) : pairwise_on {a, b} r ↔ (a ≠ b → r a b) :=
-by simp [pairwise_on_insert_of_symmetric hr]
+lemma pairwise_pair_of_symmetric (hr : symmetric r) : set.pairwise {a, b} r ↔ (a ≠ b → r a b) :=
+by simp [pairwise_insert_of_symmetric hr]
 
-lemma pairwise_on_disjoint_on_mono {s : set ι} {f g : ι → set α} (h : s.pairwise_on (disjoint on f))
+lemma pairwise_disjoint_on_mono {s : set ι} {f g : ι → set α} (h : s.pairwise (disjoint on f))
   (h' : ∀ x ∈ s, g x ⊆ f x) :
-  s.pairwise_on (disjoint on g) :=
+  s.pairwise (disjoint on g) :=
 λ i hi j hj hij, disjoint.mono (h' i hi) (h' j hj) (h i hi j hj hij)
 
-lemma pairwise_on_univ : (univ : set α).pairwise_on r ↔ pairwise r :=
-by simp only [pairwise_on, pairwise, mem_univ, forall_const]
+lemma pairwise_univ : (univ : set α).pairwise r ↔ pairwise r :=
+by simp only [set.pairwise, pairwise, mem_univ, forall_const]
 
-lemma pairwise_on.on_injective (hs : s.pairwise_on r) (hf : function.injective f)
+lemma pairwise.on_injective (hs : s.pairwise r) (hf : function.injective f)
   (hfs : ∀ x, f x ∈ s) :
   pairwise (r on f) :=
 λ i j hij, hs _ (hfs i) _ (hfs j) (hf.ne hij)
 
-lemma inj_on.pairwise_on_image {s : set ι} (h : s.inj_on f) :
-  (f '' s).pairwise_on r ↔ s.pairwise_on (r on f) :=
-by simp [h.eq_iff, pairwise_on] {contextual := tt}
+lemma inj_on.pairwise_image {s : set ι} (h : s.inj_on f) :
+  (f '' s).pairwise r ↔ s.pairwise (r on f) :=
+by simp [h.eq_iff, set.pairwise] {contextual := tt}
 
-lemma pairwise_on_disjoint_fiber (f : ι → α) (s : set α) :
-  s.pairwise_on (disjoint on (λ a, f ⁻¹' {a})) :=
+lemma pairwise_disjoint_fiber (f : ι → α) (s : set α) :
+  s.pairwise (disjoint on (λ a, f ⁻¹' {a})) :=
 λ a _ b _ h i ⟨hia, hib⟩, h $ (eq.symm hia).trans hib
 
-lemma pairwise_on_Union {f : ι → set α} (h : directed (⊆) f) :
-  (⋃ n, f n).pairwise_on r ↔ ∀ n, (f n).pairwise_on r :=
+lemma pairwise_Union {f : ι → set α} (h : directed (⊆) f) :
+  (⋃ n, f n).pairwise r ↔ ∀ n, (f n).pairwise r :=
 begin
   split,
   { assume H n,
-    exact pairwise_on.mono (subset_Union _ _) H },
+    exact pairwise.mono (subset_Union _ _) H },
   { assume H i hi j hj hij,
     rcases mem_Union.1 hi with ⟨m, hm⟩,
     rcases mem_Union.1 hj with ⟨n, hn⟩,
@@ -181,16 +181,16 @@ begin
     exact H p i (mp hm) j (np hn) hij }
 end
 
-lemma pairwise_on_sUnion {r : α → α → Prop} {s : set (set α)} (h : directed_on (⊆) s) :
-  (⋃₀ s).pairwise_on r ↔ (∀ a ∈ s, set.pairwise_on a r) :=
-by { rw [sUnion_eq_Union, pairwise_on_Union (h.directed_coe), set_coe.forall], refl }
+lemma pairwise_sUnion {r : α → α → Prop} {s : set (set α)} (h : directed_on (⊆) s) :
+  (⋃₀ s).pairwise r ↔ (∀ a ∈ s, set.pairwise a r) :=
+by { rw [sUnion_eq_Union, pairwise_Union (h.directed_coe), set_coe.forall], refl }
 
 end set
 
-lemma pairwise.pairwise_on (h : pairwise r) (s : set α) : s.pairwise_on r := λ x hx y hy, h x y
+lemma pairwise.set_pairwise (h : pairwise r) (s : set α) : s.pairwise r := λ x hx y hy, h x y
 
 lemma pairwise_disjoint_fiber (f : ι → α) : pairwise (disjoint on (λ a : α, f ⁻¹' {a})) :=
-set.pairwise_on_univ.1 $ set.pairwise_on_disjoint_fiber f univ
+set.pairwise_univ.1 $ set.pairwise_disjoint_fiber f univ
 
 namespace set
 section semilattice_inf_bot
@@ -198,20 +198,20 @@ variables [semilattice_inf_bot α]
 
 /-- Elements of a set is `pairwise_disjoint`, if any distinct two are disjoint. -/
 def pairwise_disjoint (s : set α) : Prop :=
-s.pairwise_on disjoint
+s.pairwise disjoint
 
 lemma pairwise_disjoint.subset (ht : pairwise_disjoint t) (h : s ⊆ t) : pairwise_disjoint s :=
-pairwise_on.mono h ht
+pairwise.mono h ht
 
 lemma pairwise_disjoint_empty : (∅ : set α).pairwise_disjoint :=
-pairwise_on_empty _
+pairwise_empty _
 
 lemma pairwise_disjoint_singleton (a : α) : ({a} : set α).pairwise_disjoint :=
-pairwise_on_singleton a _
+pairwise_singleton a _
 
 lemma pairwise_disjoint_insert {a : α} :
   (insert a s).pairwise_disjoint ↔ s.pairwise_disjoint ∧ ∀ b ∈ s, a ≠ b → disjoint a b :=
-set.pairwise_on_insert_of_symmetric symmetric_disjoint
+set.pairwise_insert_of_symmetric symmetric_disjoint
 
 lemma pairwise_disjoint.insert (hs : s.pairwise_disjoint) {a : α}
   (hx : ∀ b ∈ s, a ≠ b → disjoint a b) :
@@ -260,7 +260,7 @@ lemma pairwise_disjoint.elim_set {s : set (set α)} (hs : pairwise_disjoint s) {
 hs.elim hx hy (not_disjoint_iff.2 ⟨z, hzx, hzy⟩)
 
 lemma bUnion_diff_bUnion_eq {s t : set ι} {f : ι → set α}
-  (h : (s ∪ t).pairwise_on (disjoint on f)) :
+  (h : (s ∪ t).pairwise (disjoint on f)) :
   (⋃ i ∈ s, f i) \ (⋃ i ∈ t, f i) = (⋃ i ∈ s \ t, f i) :=
 begin
   refine (bUnion_diff_bUnion_subset f s t).antisymm
@@ -271,7 +271,7 @@ end
 
 /-- Equivalence between a disjoint bounded union and a dependent sum. -/
 noncomputable def bUnion_eq_sigma_of_disjoint {s : set ι} {f : ι → set α}
-  (h : pairwise_on s (disjoint on f)) :
+  (h : s.pairwise (disjoint on f)) :
   (⋃ i ∈ s, f i) ≃ (Σ i : s, f i) :=
 (equiv.set_congr (bUnion_eq_Union _ _)).trans $ Union_eq_sigma_of_disjoint $
   λ ⟨i, hi⟩ ⟨j, hj⟩ ne, h _ hi _ hj $ λ eq, ne $ subtype.eq eq

--- a/src/geometry/euclidean/circumcenter.lean
+++ b/src/geometry/euclidean/circumcenter.lean
@@ -63,8 +63,8 @@ end
 `orthogonal_projection` is. -/
 lemma dist_set_eq_iff_dist_orthogonal_projection_eq {s : affine_subspace ℝ P} [nonempty s]
   [complete_space s.direction] {ps : set P} (hps : ps ⊆ s) (p : P) :
-  (set.pairwise_on ps (λ p1 p2, dist p1 p = dist p2 p) ↔
-    (set.pairwise_on ps (λ p1 p2, dist p1 (orthogonal_projection s p) =
+  (set.pairwise ps (λ p1 p2, dist p1 p = dist p2 p) ↔
+    (set.pairwise ps (λ p1 p2, dist p1 (orthogonal_projection s p) =
       dist p2 (orthogonal_projection s p)))) :=
 ⟨λ h p1 hp1 p2 hp2 hne,
   (dist_eq_iff_dist_orthogonal_projection_eq p (hps hp1) (hps hp2)).1 (h p1 hp1 p2 hp2 hne),
@@ -81,7 +81,7 @@ lemma exists_dist_eq_iff_exists_dist_orthogonal_projection_eq {s : affine_subspa
     ∃ r, ∀ p1 ∈ ps, dist p1 ↑(orthogonal_projection s p) = r :=
 begin
   have h := dist_set_eq_iff_dist_orthogonal_projection_eq hps p,
-  simp_rw set.pairwise_on_eq_iff_exists_eq at h,
+  simp_rw set.pairwise_eq_iff_exists_eq at h,
   exact h
 end
 
@@ -362,7 +362,7 @@ end
 lemma circumcenter_eq_centroid (s : simplex ℝ P 1) :
   s.circumcenter = finset.univ.centroid ℝ s.points :=
 begin
-  have hr : set.pairwise_on set.univ
+  have hr : set.pairwise set.univ
     (λ i j : fin 2, dist (s.points i) (finset.univ.centroid ℝ s.points) =
                     dist (s.points j) (finset.univ.centroid ℝ s.points)),
   { intros i hi j hj hij,
@@ -370,7 +370,7 @@ begin
         dist_eq_norm_vsub V (s.points j), vsub_vadd_eq_vsub_sub, vsub_vadd_eq_vsub_sub,
         ←one_smul ℝ (s.points i -ᵥ s.points 0), ←one_smul ℝ (s.points j -ᵥ s.points 0)],
     fin_cases i; fin_cases j; simp [-one_smul, ←sub_smul]; norm_num },
-  rw set.pairwise_on_eq_iff_exists_eq at hr,
+  rw set.pairwise_eq_iff_exists_eq at hr,
   cases hr with r hr,
   exact (s.eq_circumcenter_of_dist_eq
           (centroid_mem_affine_span_of_card_eq_add_one ℝ _ (finset.card_fin 2))

--- a/src/geometry/euclidean/circumcenter.lean
+++ b/src/geometry/euclidean/circumcenter.lean
@@ -362,7 +362,7 @@ end
 lemma circumcenter_eq_centroid (s : simplex ℝ P 1) :
   s.circumcenter = finset.univ.centroid ℝ s.points :=
 begin
-  have hr : set.pairwise set.univ
+  have hr : set.univ.pairwise
     (λ i j : fin 2, dist (s.points i) (finset.univ.centroid ℝ s.points) =
                     dist (s.points j) (finset.univ.centroid ℝ s.points)),
   { intros i hi j hj hij,

--- a/src/geometry/euclidean/circumcenter.lean
+++ b/src/geometry/euclidean/circumcenter.lean
@@ -362,7 +362,7 @@ end
 lemma circumcenter_eq_centroid (s : simplex ℝ P 1) :
   s.circumcenter = finset.univ.centroid ℝ s.points :=
 begin
-  have hr : set.univ.pairwise
+  have hr : set.pairwise set.univ
     (λ i j : fin 2, dist (s.points i) (finset.univ.centroid ℝ s.points) =
                     dist (s.points j) (finset.univ.centroid ℝ s.points)),
   { intros i hi j hj hij,

--- a/src/group_theory/perm/cycle_type.lean
+++ b/src/group_theory/perm/cycle_type.lean
@@ -50,7 +50,7 @@ lemma cycle_type_eq' {σ : perm α} (s : finset (perm α))
   (h1 : ∀ f : perm α, f ∈ s → f.is_cycle) (h2 : ∀ (a ∈ s) (b ∈ s), a ≠ b → disjoint a b)
   (h0 : s.noncomm_prod id
     (λ a ha b hb, (em (a = b)).by_cases (λ h, h ▸ commute.refl a)
-      (set.pairwise_on.mono' (λ _ _, disjoint.commute) h2 a ha b hb)) = σ) :
+      (set.pairwise.mono' (λ _ _, disjoint.commute) h2 a ha b hb)) = σ) :
   σ.cycle_type = s.1.map (finset.card ∘ support) :=
 begin
   rw cycle_type_def,

--- a/src/group_theory/perm/cycles.lean
+++ b/src/group_theory/perm/cycles.lean
@@ -890,7 +890,7 @@ lemma cycle_factors_finset_eq_finset {σ : perm α} {s : finset (perm α)} :
   σ.cycle_factors_finset = s ↔ (∀ f : perm α, f ∈ s → f.is_cycle) ∧
     (∃ h : (∀ (a ∈ s) (b ∈ s), a ≠ b → disjoint a b), s.noncomm_prod id
       (λ a ha b hb, (em (a = b)).by_cases (λ h, h ▸ commute.refl a)
-        (set.pairwise_on.mono' (λ _ _, disjoint.commute) h a ha b hb)) = σ) :=
+        (set.pairwise.mono' (λ _ _, disjoint.commute) h a ha b hb)) = σ) :=
 begin
   obtain ⟨l, hl, rfl⟩ := s.exists_list_nodup_eq,
   rw cycle_factors_finset_eq_list_to_finset hl,

--- a/src/measure_theory/covering/besicovitch.lean
+++ b/src/measure_theory/covering/besicovitch.lean
@@ -418,7 +418,7 @@ are no satellite configurations with `N+1` points. -/
 theorem exist_disjoint_covering_families {N : ℕ} {τ : ℝ}
   (hτ : 1 < τ) (hN : is_empty (satellite_config α N τ)) (q : ball_package β α) :
   ∃ s : fin N → set β,
-    (∀ (i : fin N), (s i).pairwise_on (disjoint on (λ j, closed_ball (q.c j) (q.r j)))) ∧
+    (∀ (i : fin N), (s i).pairwise (disjoint on (λ j, closed_ball (q.c j) (q.r j)))) ∧
       (range q.c ⊆ ⋃ (i : fin N), ⋃ (j ∈ s i), ball (q.c j) (q.r j)) :=
 begin
   -- first exclude the trivial case where `β` is empty (we need non-emptiness for the transfinite
@@ -493,7 +493,7 @@ lemma exist_finset_disjoint_balls_large_measure
   (hτ : 1 < τ) (hN : is_empty (satellite_config α N τ)) (s : set α)
   (r : α → ℝ) (rpos : ∀ x ∈ s, 0 < r x) (rle : ∀ x ∈ s, r x ≤ 1) :
   ∃ (t : finset α), (↑t ⊆ s) ∧ μ (s \ (⋃ (x ∈ t), closed_ball x (r x))) ≤ N/(N+1) * μ s
-    ∧ (t : set α).pairwise_on (disjoint on (λ x, closed_ball x (r x))) :=
+    ∧ (t : set α).pairwise (disjoint on (λ x, closed_ball x (r x))) :=
 begin
   -- exclude the trivial case where `μ s = 0`.
   rcases le_or_lt (μ s) 0 with hμs|hμs,
@@ -598,7 +598,7 @@ begin
       apply hw.le.trans (le_of_eq _),
       rw [← finset.set_bUnion_coe, inter_comm _ o, inter_bUnion, finset.set_bUnion_coe,
           measure_bUnion_finset],
-      { have : (w : set (u i)).pairwise_on
+      { have : (w : set (u i)).pairwise
             (disjoint on (λ (b : u i), closed_ball (b : α) (r (b : α)))),
           by { assume k hk l hl hkl, exact hu i k k.2 l l.2 (subtype.coe_injective.ne hkl) },
         exact pairwise_on_disjoint_on_mono this (λ k hk, inter_subset_right _ _) },
@@ -635,13 +635,13 @@ theorem exists_disjoint_closed_ball_covering_ae_of_finite_measure_aux
   ∃ (t : set (α × ℝ)), (countable t)
     ∧ (∀ (p : α × ℝ), p ∈ t → p.1 ∈ s) ∧ (∀ (p : α × ℝ), p ∈ t → p.2 ∈ f p.1)
     ∧ μ (s \ (⋃ (p : α × ℝ) (hp : p ∈ t), closed_ball p.1 p.2)) = 0
-    ∧ t.pairwise_on (disjoint on (λ p, closed_ball p.1 p.2)) :=
+    ∧ t.pairwise (disjoint on (λ p, closed_ball p.1 p.2)) :=
 begin
   rcases hb.no_satellite_config with ⟨N, τ, hτ, hN⟩,
   /- Introduce a property `P` on finsets saying that we have a nice disjoint covering of a
     subset of `s` by admissible balls. -/
   let P : finset (α × ℝ) → Prop := λ t,
-    (t : set (α × ℝ)).pairwise_on (disjoint on (λ p, closed_ball p.1 p.2)) ∧
+    (t : set (α × ℝ)).pairwise (disjoint on (λ p, closed_ball p.1 p.2)) ∧
     (∀ (p : α × ℝ), p ∈ t → p.1 ∈ s) ∧ (∀ (p : α × ℝ), p ∈ t → p.2 ∈ f p.1),
   /- Given a finite good covering of a subset `s`, one can find a larger finite good covering,
   covering additionally a proportion at least `1/(N+1)` of leftover points. This follows from
@@ -672,7 +672,7 @@ begin
     choose! r hr using this,
     obtain ⟨v, vs', hμv, hv⟩ : ∃ (v : finset α), ↑v ⊆ s'
       ∧ μ (s' \ ⋃ (x ∈ v), closed_ball x (r x)) ≤ N/(N+1) * μ s'
-      ∧ (v : set α).pairwise_on (disjoint on λ (x : α), closed_ball x (r x)),
+      ∧ (v : set α).pairwise (disjoint on λ (x : α), closed_ball x (r x)),
     { have rpos : ∀ x ∈ s', 0 < r x := λ x hx, hf' x ((mem_diff x).1 hx).1 (hr x hx).1,
       have rle : ∀ x ∈ s', r x ≤ 1 := λ x hx, (hr x hx).2.1,
       exact exist_finset_disjoint_balls_large_measure μ hτ hN s' r rpos rle },
@@ -779,7 +779,7 @@ theorem exists_disjoint_closed_ball_covering_ae_aux
   ∃ (t : set (α × ℝ)), (countable t)
     ∧ (∀ (p : α × ℝ), p ∈ t → p.1 ∈ s) ∧ (∀ (p : α × ℝ), p ∈ t → p.2 ∈ f p.1)
     ∧ μ (s \ (⋃ (p : α × ℝ) (hp : p ∈ t), closed_ball p.1 p.2)) = 0
-    ∧ t.pairwise_on (disjoint on (λ p, closed_ball p.1 p.2)) :=
+    ∧ t.pairwise (disjoint on (λ p, closed_ball p.1 p.2)) :=
 begin
   /- This is deduced from the finite measure case, by using a finite measure with respect to which
   the initial sigma-finite measure is absolutely continuous. -/
@@ -803,7 +803,7 @@ theorem exists_disjoint_closed_ball_covering_ae
   (hf : ∀ x ∈ s, (f x).nonempty) (hf' : ∀ x ∈ s, f x ⊆ Ioi 0) (hf'' : ∀ x ∈ s, Inf (f x) ≤ 0) :
   ∃ (t : set α) (r : α → ℝ), countable t ∧ t ⊆ s ∧ (∀ x ∈ t, r x ∈ f x)
     ∧ μ (s \ (⋃ (x ∈ t), closed_ball x (r x))) = 0
-    ∧ t.pairwise_on (disjoint on (λ x, closed_ball x (r x))) :=
+    ∧ t.pairwise (disjoint on (λ x, closed_ball x (r x))) :=
 begin
   rcases exists_disjoint_closed_ball_covering_ae_aux μ f s hf hf' hf''
     with ⟨v, v_count, vs, vf, μv, v_disj⟩,
@@ -848,7 +848,7 @@ begin
     exact μv },
   { have A : inj_on (λ x : α, (x, r x)) t,
       by simp only [inj_on, prod.mk.inj_iff, implies_true_iff, eq_self_iff_true] {contextual := tt},
-    rwa [← im_t, A.pairwise_on_image] at v_disj }
+    rwa [← im_t, A.pairwise_image] at v_disj }
 end
 
 end besicovitch

--- a/src/measure_theory/covering/besicovitch.lean
+++ b/src/measure_theory/covering/besicovitch.lean
@@ -500,7 +500,7 @@ begin
   { have : μ s = 0 := le_bot_iff.1 hμs,
     refine ⟨∅, by simp only [finset.coe_empty, empty_subset], _, _⟩,
     { simp only [this, diff_empty, Union_false, Union_empty, nonpos_iff_eq_zero, mul_zero] },
-    { simp only [finset.coe_empty, pairwise_on_empty], } },
+    { simp only [finset.coe_empty, pairwise_empty], } },
   casesI is_empty_or_nonempty α,
   { simp only [eq_empty_of_is_empty s, measure_empty] at hμs,
     exact (lt_irrefl _ hμs).elim },
@@ -560,7 +560,7 @@ begin
   { have : o ∩ v i = ⋃ (x : s) (hx : x ∈ u i), o ∩ closed_ball x (r x), by simp only [inter_Union],
     rw [this, measure_bUnion (u_count i)],
     { refl },
-    { exact pairwise_on_disjoint_on_mono (hu i) (λ k hk, inter_subset_right _ _) },
+    { exact pairwise_disjoint_on_mono (hu i) (λ k hk, inter_subset_right _ _) },
     { exact λ b hb, omeas.inter measurable_set_closed_ball } },
   -- A large enough finite subfamily of `u i` will also cover a proportion `> 1/(N+1)` of `s`.
   -- Since `s` might not be measurable, we express this in terms of the measurable superset `o`.
@@ -601,7 +601,7 @@ begin
       { have : (w : set (u i)).pairwise
             (disjoint on (λ (b : u i), closed_ball (b : α) (r (b : α)))),
           by { assume k hk l hl hkl, exact hu i k k.2 l l.2 (subtype.coe_injective.ne hkl) },
-        exact pairwise_on_disjoint_on_mono this (λ k hk, inter_subset_right _ _) },
+        exact pairwise_disjoint_on_mono this (λ k hk, inter_subset_right _ _) },
       { assume b hb,
         apply omeas.inter measurable_set_closed_ball }
     end },
@@ -677,7 +677,7 @@ begin
       have rle : ∀ x ∈ s', r x ≤ 1 := λ x hx, (hr x hx).2.1,
       exact exist_finset_disjoint_balls_large_measure μ hτ hN s' r rpos rle },
     refine ⟨t ∪ (finset.image (λ x, (x, r x)) v), finset.subset_union_left _ _, ⟨_, _, _⟩, _⟩,
-    { simp only [finset.coe_union, pairwise_on_union, ht.1, true_and, finset.coe_image],
+    { simp only [finset.coe_union, pairwise_union, ht.1, true_and, finset.coe_image],
       split,
       { assume p hp q hq hpq,
         rcases (mem_image _ _ _).1 hp with ⟨p', p'v, rfl⟩,
@@ -716,7 +716,7 @@ begin
     induction n with n IH,
     { simp only [u, P, prod.forall, id.def, function.iterate_zero],
       simp only [finset.not_mem_empty, forall_false_left, finset.coe_empty, forall_2_true_iff,
-        and_self, pairwise_on_empty] },
+        and_self, pairwise_empty] },
     { rw u_succ,
       exact (hF (u n) IH).2.1 } },
   refine ⟨⋃ n, u n, countable_Union (λ n, (u n).countable_to_set), _, _, _, _⟩,
@@ -755,7 +755,7 @@ begin
     rw zero_mul at C,
     apply le_bot_iff.1,
     exact le_of_tendsto_of_tendsto' tendsto_const_nhds C (λ n, (A n).trans (B n)) },
-  { refine (pairwise_on_Union _).2 (λ n, (Pu n).1),
+  { refine (pairwise_Union _).2 (λ n, (Pu n).1),
     apply (monotone_nat_of_le_succ (λ n, _)).directed_le,
     rw u_succ,
     exact (hF (u n) (Pu n)).1 }

--- a/src/measure_theory/covering/besicovitch_vector_space.lean
+++ b/src/measure_theory/covering/besicovitch_vector_space.lean
@@ -146,7 +146,7 @@ begin
   let ρ : ℝ := (5 : ℝ)/2,
   have ρpos : 0 < ρ := by norm_num [ρ],
   set A := ⋃ (c ∈ s), ball (c : E) δ with hA,
-  have D : set.pairwise_on (s : set E) (disjoint on (λ c, ball (c : E) δ)),
+  have D : set.pairwise (s : set E) (disjoint on (λ c, ball (c : E) δ)),
   { rintros c hc d hd hcd,
     apply ball_disjoint_ball,
     rw dist_eq_norm,

--- a/src/measure_theory/covering/vitali.lean
+++ b/src/measure_theory/covering/vitali.lean
@@ -72,7 +72,7 @@ begin
     simp only [set.sUnion_subset_iff, and_imp, exists_prop, forall_exists_index,
                 set.mem_set_of_eq],
     refine ⟨λ u hu, (UT hu).1, _, λ a hat b u uU hbu hab, _⟩,
-    { rw [pairwise_on_sUnion hU.directed_on],
+    { rw [pairwise_sUnion hU.directed_on],
       assume u hu,
       exact (UT hu).2.1 },
     { obtain ⟨c, cu, ac, hc⟩ : ∃ (c : set α) (H : c ∈ u), (a ∩ c).nonempty ∧ δ a ≤ τ * δ c :=
@@ -119,7 +119,7 @@ begin
     exact ⟨a'A.1, uT.1⟩ },
   -- check that `u ∪ {a'}` is a disjoint family. This follows from the fact that `a'` does not
   -- intersect `u`.
-  { rw pairwise_on_insert_of_symmetric, swap,
+  { rw pairwise_insert_of_symmetric, swap,
     { simp only [function.on_fun, symmetric, disjoint.comm, imp_self, forall_const] },
     exact ⟨uT.2.1, λ b bu ba', a'A.2 b bu⟩ },
   -- check that every element `c` of `t` intersecting `u ∪ {a'}` intersects an element of this
@@ -163,7 +163,7 @@ begin
   rcases eq_or_ne t {∅} with rfl|t_ne_empty,
   { refine ⟨{∅}, subset.refl _, _⟩,
     simp only [true_and, closed_ball_eq_empty, mem_singleton_iff, and_true, empty_subset, forall_eq,
-      pairwise_on_singleton, exists_const],
+      pairwise_singleton, exists_const],
     exact ⟨-1, by simp only [right.neg_neg_iff, zero_lt_one]⟩ },
   -- The real proof starts now. Since the center or the radius of a ball is not uniquely defined
   -- in a general metric space, we just choose one for definiteness.
@@ -255,7 +255,7 @@ begin
   the family is assumed to be fine at every point of `s`).
   -/
   rcases eq_empty_or_nonempty s with rfl|nonempty,
-  { refine ⟨∅, empty_subset _, countable_empty, by simp only [pairwise_on_empty],
+  { refine ⟨∅, empty_subset _, countable_empty, by simp only [pairwise_empty],
       by simp only [measure_empty, Union_false, Union_empty, diff_self]⟩ },
   haveI : inhabited α,
   { choose x hx using nonempty,

--- a/src/measure_theory/covering/vitali.lean
+++ b/src/measure_theory/covering/vitali.lean
@@ -47,7 +47,7 @@ element `b` of `u` of size larger than that of `a` up to `τ`, i.e., `δ b ≥ �
 theorem exists_disjoint_subfamily_covering_enlargment
   (t : set (set α)) (δ : set α → ℝ) (τ : ℝ) (hτ : 1 < τ) (δnonneg : ∀ a ∈ t, 0 ≤ δ a)
   (R : ℝ) (δle : ∀ a ∈ t, δ a ≤ R) (hne : ∀ a ∈ t, set.nonempty a) :
-  ∃ u ⊆ t, u.pairwise_on disjoint ∧
+  ∃ u ⊆ t, u.pairwise disjoint ∧
     ∀ a ∈ t, ∃ b ∈ u, set.nonempty (a ∩ b) ∧ δ a ≤ τ * δ b :=
 begin
   /- The proof could be formulated as a transfinite induction. First pick an element of `t` with `δ`
@@ -63,7 +63,7 @@ begin
   that `u ∪ {a'}` still has this property, contradicting the maximality. Therefore, `u`
   intersects all elements of `t`, and by definition it satisfies all the desired properties.
   -/
-  let T : set (set (set α)) := {u | u ⊆ t ∧ u.pairwise_on disjoint
+  let T : set (set (set α)) := {u | u ⊆ t ∧ u.pairwise disjoint
     ∧ ∀ a ∈ t, ∀ b ∈ u, set.nonempty (a ∩ b) → ∃ c ∈ u, (a ∩ c).nonempty ∧ δ a ≤ τ * δ c},
   -- By Zorn, choose a maximal family in the good set `T` of disjoint families.
   obtain ⟨u, uT, hu⟩ : ∃ u ∈ T, ∀ v ∈ T, u ⊆ v → v = u,
@@ -150,7 +150,7 @@ extract a disjoint subfamily `u ⊆ t` so that all balls in `t` are covered by t
 dilations of balls in `u`. -/
 theorem exists_disjoint_subfamily_covering_enlargment_closed_ball [metric_space α]
   (t : set (set α)) (R : ℝ) (ht : ∀ s ∈ t, ∃ x r, s = closed_ball x r ∧ r ≤ R) :
-  ∃ u ⊆ t, u.pairwise_on disjoint ∧
+  ∃ u ⊆ t, u.pairwise disjoint ∧
     ∀ a ∈ t, ∃ x r, closed_ball x r ∈ u ∧ a ⊆ closed_ball x (5 * r) :=
 begin
   rcases eq_empty_or_nonempty t with rfl|tnonempty,
@@ -177,7 +177,7 @@ begin
   -- to the subfamily `t'` made of nonempty sets, and we use `δ = r` there. This gives a disjointed
   -- subfamily `u'`.
   let t' := {a ∈ t | 0 ≤ r a},
-  obtain ⟨u', u't', u'_disj, hu'⟩ : ∃ u' ⊆ t', u'.pairwise_on disjoint ∧
+  obtain ⟨u', u't', u'_disj, hu'⟩ : ∃ u' ⊆ t', u'.pairwise disjoint ∧
     ∀ a ∈ t', ∃ b ∈ u', set.nonempty (a ∩ b) ∧ r a ≤ 2 * r b,
   { refine exists_disjoint_subfamily_covering_enlargment t' r 2 one_lt_two
       (λ a ha, ha.2) R (λ a ha, (hxr a ha.1).2) (λ a ha, _),
@@ -234,7 +234,7 @@ theorem exists_disjoint_covering_ae [metric_space α] [measurable_space α] [ope
   (t : set (set α)) (hf : ∀ x ∈ s, ∀ (ε > (0 : ℝ)), ∃ a ∈ t, x ∈ a ∧ a ⊆ closed_ball x ε)
   (ht : ∀ a ∈ t, (interior a).nonempty) (h't : ∀ a ∈ t, is_closed a)
   (C : ℝ≥0) (h : ∀ a ∈ t, ∃ x ∈ a, μ (closed_ball x (3 * diam a)) ≤ C * μ a) :
-  ∃ u ⊆ t, countable u ∧ u.pairwise_on disjoint ∧ μ (s \ ⋃ (a ∈ u), a) = 0 :=
+  ∃ u ⊆ t, countable u ∧ u.pairwise disjoint ∧ μ (s \ ⋃ (a ∈ u), a) = 0 :=
 begin
   /- The idea of the proof is the following. Assume for simplicity that `μ` is finite. Applying the
   abstract Vitali covering theorem with `δ = diam`, one obtains a disjoint subfamily `u`, such
@@ -278,7 +278,7 @@ begin
   -- they only see a finite part of the measure.
   let t' := {a ∈ t | ∃ x, a ⊆ closed_ball x (r x)},
   -- extract a disjoint subfamily `u` of `t'` thanks to the abstract Vitali covering theorem.
-  obtain ⟨u, ut', u_disj, hu⟩ : ∃ u ⊆ t', u.pairwise_on disjoint ∧
+  obtain ⟨u, ut', u_disj, hu⟩ : ∃ u ⊆ t', u.pairwise disjoint ∧
     ∀ a ∈ t', ∃ b ∈ u, set.nonempty (a ∩ b) ∧ diam a ≤ 2 * diam b,
   { have A : ∀ (a : set α), a ∈ t' → diam a ≤ 2,
     { rintros a ⟨hat, ⟨x, hax⟩⟩,

--- a/src/measure_theory/integral/set_integral.lean
+++ b/src/measure_theory/integral/set_integral.lean
@@ -118,7 +118,7 @@ lemma integral_fintype_Union {ι : Type*} [fintype ι] {s : ι → set α}
 begin
   convert integral_finset_bUnion finset.univ (λ i hi, hs i) _ (λ i _, hf i),
   { simp },
-  { simp [pairwise_on_univ, h's] }
+  { simp [pairwise_univ, h's] }
 end
 
 lemma integral_empty : ∫ x in ∅, f x ∂μ = 0 := by rw [measure.restrict_empty, integral_zero_measure]

--- a/src/measure_theory/integral/set_integral.lean
+++ b/src/measure_theory/integral/set_integral.lean
@@ -102,7 +102,7 @@ lemma integral_finset_bUnion {ι : Type*} (t : finset ι) {s : ι → set α}
 begin
   induction t using finset.induction_on with a t hat IH hs h's,
   { simp },
-  { simp only [finset.coe_insert, finset.forall_mem_insert, set.pairwise_on_insert,
+  { simp only [finset.coe_insert, finset.forall_mem_insert, set.pairwise_insert,
       finset.set_bUnion_insert] at hs hf h's ⊢,
     rw [integral_union _ hs.1 _ hf.1 (integrable_on_finset_Union.2 hf.2)],
     { rw [finset.sum_insert hat, IH hs.2 h's.1 hf.2] },
@@ -180,7 +180,7 @@ lemma has_sum_integral_Union {ι : Type*} [encodable ι] {s : ι → set α} {f 
   has_sum (λ n, ∫ a in s n, f a ∂ μ) (∫ a in ⋃ n, s n, f a ∂μ) :=
 begin
   have hfi' : ∀ i, integrable_on f (s i) μ, from λ i, hfi.mono_set (subset_Union _ _),
-  simp only [has_sum, ← integral_finset_bUnion _ (λ i _, hm i) (hd.pairwise_on _) (λ i _, hfi' i)],
+  simp only [has_sum, ← integral_finset_bUnion _ (λ i _, hm i) (hd.set_pairwise _) (λ i _, hfi' i)],
   rw Union_eq_Union_finset at hfi ⊢,
   exact tendsto_set_integral_of_monotone (λ t, t.measurable_set_bUnion (λ i _, hm i))
     (λ t₁ t₂ h, bUnion_subset_bUnion_left h) hfi

--- a/src/measure_theory/integral/set_integral.lean
+++ b/src/measure_theory/integral/set_integral.lean
@@ -96,7 +96,7 @@ begin
 end
 
 lemma integral_finset_bUnion {ι : Type*} (t : finset ι) {s : ι → set α}
-  (hs : ∀ i ∈ t, measurable_set (s i)) (h's : pairwise_on ↑t (disjoint on s))
+  (hs : ∀ i ∈ t, measurable_set (s i)) (h's : set.pairwise ↑t (disjoint on s))
   (hf : ∀ i ∈ t, integrable_on f (s i) μ) :
   ∫ x in (⋃ i ∈ t, s i), f x ∂ μ = ∑ i in t, ∫ x in s i, f x ∂ μ :=
 begin

--- a/src/measure_theory/measure/measure_space.lean
+++ b/src/measure_theory/measure/measure_space.lean
@@ -126,7 +126,7 @@ lemma measure_add_measure_compl (h : measurable_set s) :
 by { rw [← union_compl_self s, measure_union _ h h.compl], exact disjoint_compl_right }
 
 lemma measure_bUnion {s : set β} {f : β → set α} (hs : countable s)
-  (hd : pairwise_on s (disjoint on f)) (h : ∀ b ∈ s, measurable_set (f b)) :
+  (hd : s.pairwise (disjoint on f)) (h : ∀ b ∈ s, measurable_set (f b)) :
   μ (⋃ b ∈ s, f b) = ∑' p : s, μ (f p) :=
 begin
   haveI := hs.to_encodable,
@@ -135,11 +135,11 @@ begin
 end
 
 lemma measure_sUnion {S : set (set α)} (hs : countable S)
-  (hd : pairwise_on S disjoint) (h : ∀ s ∈ S, measurable_set s) :
+  (hd : S.pairwise disjoint) (h : ∀ s ∈ S, measurable_set s) :
   μ (⋃₀ S) = ∑' s : S, μ s :=
 by rw [sUnion_eq_bUnion, measure_bUnion hs hd h]
 
-lemma measure_bUnion_finset {s : finset ι} {f : ι → set α} (hd : pairwise_on ↑s (disjoint on f))
+lemma measure_bUnion_finset {s : finset ι} {f : ι → set α} (hd : set.pairwise ↑s (disjoint on f))
   (hm : ∀ b ∈ s, measurable_set (f b)) :
   μ (⋃ b ∈ s, f b) = ∑ p in s, μ (f p) :=
 begin
@@ -222,7 +222,7 @@ lemma measure_compl (h₁ : measurable_set s) (h_fin : μ s ≠ ∞) : μ (sᶜ)
 by { rw compl_eq_univ_diff, exact measure_diff (subset_univ s) measurable_set.univ h₁ h_fin }
 
 lemma sum_measure_le_measure_univ {s : finset ι} {t : ι → set α} (h : ∀ i ∈ s, measurable_set (t i))
-  (H : pairwise_on ↑s (disjoint on t)) :
+  (H : set.pairwise ↑s (disjoint on t)) :
   ∑ i in s, μ (t i) ≤ μ (univ : set α) :=
 by { rw ← measure_bUnion_finset H h, exact measure_mono (subset_univ _) }
 

--- a/src/measure_theory/measure/measure_space.lean
+++ b/src/measure_theory/measure/measure_space.lean
@@ -152,14 +152,14 @@ of the fibers `f ⁻¹' {y}`. -/
 lemma tsum_measure_preimage_singleton {s : set β} (hs : countable s) {f : α → β}
   (hf : ∀ y ∈ s, measurable_set (f ⁻¹' {y})) :
   ∑' b : s, μ (f ⁻¹' {↑b}) = μ (f ⁻¹' s) :=
-by rw [← set.bUnion_preimage_singleton, measure_bUnion hs (pairwise_on_disjoint_fiber _ _) hf]
+by rw [← set.bUnion_preimage_singleton, measure_bUnion hs (pairwise_disjoint_fiber _ _) hf]
 
 /-- If `s` is a `finset`, then the measure of its preimage can be found as the sum of measures
 of the fibers `f ⁻¹' {y}`. -/
 lemma sum_measure_preimage_singleton (s : finset β) {f : α → β}
   (hf : ∀ y ∈ s, measurable_set (f ⁻¹' {y})) :
   ∑ b in s, μ (f ⁻¹' {b}) = μ (f ⁻¹' ↑s) :=
-by simp only [← measure_bUnion_finset (pairwise_on_disjoint_fiber _ _) hf,
+by simp only [← measure_bUnion_finset (pairwise_disjoint_fiber _ _) hf,
   finset.set_bUnion_preimage_singleton]
 
 lemma measure_diff_null' (h : μ (s₁ ∩ s₂) = 0) : μ (s₁ \ s₂) = μ s₁ :=

--- a/src/measure_theory/measure/measure_space.lean
+++ b/src/measure_theory/measure/measure_space.lean
@@ -303,7 +303,7 @@ begin
     measurable_set.disjointed (measurable_set.bUnion_decode₂ h),
   rw [← encodable.Union_decode₂, ← Union_disjointed, measure_Union (disjoint_disjointed _) this,
     ennreal.tsum_eq_supr_nat],
-  simp only [← measure_bUnion_finset ((disjoint_disjointed _).pairwise_on _) (λ n _, this n)],
+  simp only [← measure_bUnion_finset ((disjoint_disjointed _).set_pairwise _) (λ n _, this n)],
   refine supr_le (λ n, _),
   refine le_trans (_ : _ ≤ μ (⋃ (k ∈ finset.range n) (i ∈ encodable.decode₂ ι k), s i)) _,
   exact measure_mono (bUnion_mono (λ k hk, disjointed_subset _ _)),

--- a/src/order/zorn.lean
+++ b/src/order/zorn.lean
@@ -80,7 +80,7 @@ parameters {α : Type u} (r : α → α → Prop)
 local infix ` ≺ `:50  := r
 
 /-- A chain is a subset `c` satisfying `x ≺ y ∨ x = y ∨ y ≺ x` for all `x y ∈ c`. -/
-def chain (c : set α) := pairwise_on c (λ x y, x ≺ y ∨ y ≺ x)
+def chain (c : set α) := c.pairwise (λ x y, x ≺ y ∨ y ≺ x)
 parameters {r}
 
 lemma chain.total_of_refl [is_refl α r]

--- a/src/order/zorn.lean
+++ b/src/order/zorn.lean
@@ -90,7 +90,7 @@ if e : x = y then or.inl (e ▸ refl _) else H _ hx _ hy e
 
 lemma chain.mono {c c'} :
   c' ⊆ c → chain c → chain c' :=
-pairwise_on.mono
+set.pairwise.mono
 
 lemma chain_of_trichotomous [is_trichotomous α r] (s : set α) :
   chain s :=

--- a/src/ring_theory/coprime/lemmas.lean
+++ b/src/ring_theory/coprime/lemmas.lean
@@ -70,7 +70,7 @@ end
 
 theorem fintype.prod_dvd_of_coprime [fintype I] (Hs : pairwise (is_coprime on s))
   (Hs1 : ∀ i, s i ∣ z) : ∏ x, s x ∣ z :=
-finset.prod_dvd_of_coprime (Hs.pairwise _) (λ i _, Hs1 i)
+finset.prod_dvd_of_coprime (Hs.set_pairwise _) (λ i _, Hs1 i)
 
 variables {m n : ℕ}
 

--- a/src/ring_theory/coprime/lemmas.lean
+++ b/src/ring_theory/coprime/lemmas.lean
@@ -55,7 +55,7 @@ theorem is_coprime.of_prod_right (H1 : is_coprime x (∏ i in t, s i)) (i : I) (
 is_coprime.prod_right_iff.1 H1 i hit
 
 theorem finset.prod_dvd_of_coprime :
-  ∀ (Hs : set.pairwise_on (↑t : set I) (is_coprime on s)) (Hs1 : ∀ i ∈ t, s i ∣ z),
+  ∀ (Hs : set.pairwise (↑t : set I) (is_coprime on s)) (Hs1 : ∀ i ∈ t, s i ∣ z),
   ∏ x in t, s x ∣ z :=
 finset.induction_on t (λ _ _, one_dvd z)
 begin
@@ -70,7 +70,7 @@ end
 
 theorem fintype.prod_dvd_of_coprime [fintype I] (Hs : pairwise (is_coprime on s))
   (Hs1 : ∀ i, s i ∣ z) : ∏ x, s x ∣ z :=
-finset.prod_dvd_of_coprime (Hs.pairwise_on _) (λ i _, Hs1 i)
+finset.prod_dvd_of_coprime (Hs.pairwise _) (λ i _, Hs1 i)
 
 variables {m n : ℕ}
 

--- a/src/topology/bases.lean
+++ b/src/topology/bases.lean
@@ -285,7 +285,7 @@ variable {α}
 /-- In a separable space, a family of nonempty disjoint open sets is countable. -/
 lemma countable_of_is_open_of_disjoint [separable_space α] {β : Type*}
   (s : β → set α) {a : set β} (ha : ∀ i ∈ a, is_open (s i)) (h'a : ∀ i ∈ a, (s i).nonempty)
-  (h : a.pairwise_on (disjoint on s)) :
+  (h : a.pairwise (disjoint on s)) :
   countable a :=
 begin
   rcases eq_empty_or_nonempty a with rfl|H, { exact countable_empty },
@@ -313,10 +313,10 @@ end
 
 /-- In a separable space, a family of disjoint sets with nonempty interiors is countable. -/
 lemma countable_of_nonempty_interior_of_disjoint [separable_space α] {β : Type*} (s : β → set α)
-  {a : set β} (ha : ∀ i ∈ a, (interior (s i)).nonempty) (h : a.pairwise_on (disjoint on s)) :
+  {a : set β} (ha : ∀ i ∈ a, (interior (s i)).nonempty) (h : a.pairwise (disjoint on s)) :
   countable a :=
 begin
-  have : a.pairwise_on (disjoint on (λ i, interior (s i))) :=
+  have : a.pairwise (disjoint on (λ i, interior (s i))) :=
     pairwise_on_disjoint_on_mono h (λ i hi, interior_subset),
   exact countable_of_is_open_of_disjoint (λ i, interior (s i)) (λ i hi, is_open_interior) ha this
 end

--- a/src/topology/bases.lean
+++ b/src/topology/bases.lean
@@ -317,7 +317,7 @@ lemma countable_of_nonempty_interior_of_disjoint [separable_space α] {β : Type
   countable a :=
 begin
   have : a.pairwise (disjoint on (λ i, interior (s i))) :=
-    pairwise_on_disjoint_on_mono h (λ i hi, interior_subset),
+    pairwise_disjoint_on_mono h (λ i hi, interior_subset),
   exact countable_of_is_open_of_disjoint (λ i, interior (s i)) (λ i hi, is_open_interior) ha this
 end
 

--- a/src/topology/metric_space/basic.lean
+++ b/src/topology/metric_space/basic.lean
@@ -2081,7 +2081,7 @@ instance metric_space.to_emetric_space : emetric_space γ :=
   ..pseudo_metric_space.to_pseudo_emetric_space, }
 
 lemma is_closed_of_pairwise_on_le_dist {s : set γ} {ε : ℝ} (hε : 0 < ε)
-  (hs : pairwise_on s (λ x y, ε ≤ dist x y)) : is_closed s :=
+  (hs : s.pairwise (λ x y, ε ≤ dist x y)) : is_closed s :=
 is_closed_of_spaced_out (dist_mem_uniformity hε) $ by simpa using hs
 
 lemma closed_embedding_of_pairwise_le_dist {α : Type*} [topological_space α] [discrete_topology α]

--- a/src/topology/metric_space/basic.lean
+++ b/src/topology/metric_space/basic.lean
@@ -2080,7 +2080,7 @@ instance metric_space.to_emetric_space : emetric_space γ :=
 { eq_of_edist_eq_zero := assume x y h, by simpa [edist_dist] using h,
   ..pseudo_metric_space.to_pseudo_emetric_space, }
 
-lemma is_closed_of_pairwise_on_le_dist {s : set γ} {ε : ℝ} (hε : 0 < ε)
+lemma is_closed_of_pairwise_le_dist {s : set γ} {ε : ℝ} (hε : 0 < ε)
   (hs : s.pairwise (λ x y, ε ≤ dist x y)) : is_closed s :=
 is_closed_of_spaced_out (dist_mem_uniformity hε) $ by simpa using hs
 

--- a/src/topology/uniform_space/separation.lean
+++ b/src/topology/uniform_space/separation.lean
@@ -208,7 +208,7 @@ instance separated_regular [separated_space α] : regular_space α :=
     ..@t2_space.t1_space _ _ (separated_iff_t2.mp ‹_›) }
 
 lemma is_closed_of_spaced_out [separated_space α] {V₀ : set (α × α)} (V₀_in : V₀ ∈ 𝓤 α)
-  {s : set α} (hs : pairwise_on s (λ x y, (x, y) ∉ V₀)) : is_closed s :=
+  {s : set α} (hs : s.pairwise (λ x y, (x, y) ∉ V₀)) : is_closed s :=
 begin
   rcases comp_symm_mem_uniformity_sets V₀_in with ⟨V₁, V₁_in, V₁_symm, h_comp⟩,
   apply is_closed_of_closure_subset,


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)

This might conflict a little with #9898, but probably with fairly straightforward conflicts.