### PR TITLE
[Merged by Bors] - feat(data/equiv/mul_add): add lemmas about multiplication and addition on a group being bijective and finite cancel_monoid_with_zeros

### DIFF
--- a/src/data/equiv/mul_add.lean
+++ b/src/data/equiv/mul_add.lean
@@ -561,7 +561,7 @@ protected def mul_left₀ (a : G) (ha : a ≠ 0) : perm G :=
   left_inv := λ x, by { dsimp, rw [← mul_assoc, inv_mul_cancel ha, one_mul] },
   right_inv := λ x, by { dsimp, rw [← mul_assoc, mul_inv_cancel ha, one_mul] } }
 
-lemma _root_.group_with_zero.mul_left_bijective₀ (a : G) (ha : a ≠ 0) :
+lemma _root_.mul_left_bijective₀ (a : G) (ha : a ≠ 0) :
   function.bijective ((*) a : G → G) :=
 (equiv.mul_left₀ a ha).bijective
 
@@ -574,7 +574,7 @@ protected def mul_right₀ (a : G) (ha : a ≠ 0) : perm G :=
   left_inv := λ x, by { dsimp, rw [mul_assoc, mul_inv_cancel ha, mul_one] },
   right_inv := λ x, by { dsimp, rw [mul_assoc, inv_mul_cancel ha, mul_one] } }
 
-lemma _root_.group_with_zero.mul_right_bijective₀ (a : G) (ha : a ≠ 0) :
+lemma _root_.mul_right_bijective₀ (a : G) (ha : a ≠ 0) :
   function.bijective ((* a) : G → G) :=
 (equiv.mul_right₀ a ha).bijective
 

--- a/src/data/equiv/mul_add.lean
+++ b/src/data/equiv/mul_add.lean
@@ -484,7 +484,8 @@ lemma mul_left_symm (a : G) : (equiv.mul_left a).symm = equiv.mul_left a⁻¹ :=
 ext $ λ x, rfl
 
 @[to_additive]
-lemma mul_left_bijective (a : G) : function.bijective ((*) a) := (equiv.mul_left a).bijective
+lemma _root_.group.mul_left_bijective (a : G) : function.bijective ((*) a) :=
+(equiv.mul_left a).bijective
 
 /-- Right multiplication in a `group` is a permutation of the underlying type. -/
 @[to_additive "Right addition in an `add_group` is a permutation of the underlying type."]
@@ -502,7 +503,8 @@ ext $ λ x, rfl
 lemma mul_right_symm_apply (a : G) : ((equiv.mul_right a).symm : G → G) = λ x, x * a⁻¹ := rfl
 
 @[to_additive]
-lemma mul_right_bijective (a : G) : function.bijective (* a) := (equiv.mul_right a).bijective
+lemma _root_.group.mul_right_bijective (a : G) : function.bijective (* a) :=
+(equiv.mul_right a).bijective
 
 variable (G)
 
@@ -559,7 +561,8 @@ protected def mul_left₀ (a : G) (ha : a ≠ 0) : perm G :=
   left_inv := λ x, by { dsimp, rw [← mul_assoc, inv_mul_cancel ha, one_mul] },
   right_inv := λ x, by { dsimp, rw [← mul_assoc, mul_inv_cancel ha, one_mul] } }
 
-lemma mul_left_bijective₀ (a : G) (ha : a ≠ 0) : function.bijective ((*) a : G → G) :=
+lemma _root_.group_with_zero.mul_left_bijective₀ (a : G) (ha : a ≠ 0) :
+  function.bijective ((*) a : G → G) :=
 (equiv.mul_left₀ a ha).bijective
 
 /-- Right multiplication by a nonzero element in a `group_with_zero` is a permutation of the
@@ -571,7 +574,8 @@ protected def mul_right₀ (a : G) (ha : a ≠ 0) : perm G :=
   left_inv := λ x, by { dsimp, rw [mul_assoc, mul_inv_cancel ha, mul_one] },
   right_inv := λ x, by { dsimp, rw [mul_assoc, inv_mul_cancel ha, mul_one] } }
 
-lemma mul_right_bijective₀ (a : G) (ha : a ≠ 0) : function.bijective ((* a) : G → G) :=
+lemma _root_.group_with_zero.mul_right_bijective₀ (a : G) (ha : a ≠ 0) :
+  function.bijective ((* a) : G → G) :=
 (equiv.mul_right₀ a ha).bijective
 
 end group_with_zero

--- a/src/data/equiv/mul_add.lean
+++ b/src/data/equiv/mul_add.lean
@@ -484,11 +484,7 @@ lemma mul_left_symm (a : G) : (equiv.mul_left a).symm = equiv.mul_left a⁻¹ :=
 ext $ λ x, rfl
 
 @[to_additive]
-lemma mul_left_bijective (a : G) : function.bijective ((*) a) :=
-begin
-  rw ← coe_mul_left,
-  exact (equiv.mul_left a).bijective,
-end
+lemma mul_left_bijective (a : G) : function.bijective ((*) a) := (equiv.mul_left a).bijective
 
 /-- Right multiplication in a `group` is a permutation of the underlying type. -/
 @[to_additive "Right addition in an `add_group` is a permutation of the underlying type."]
@@ -506,11 +502,7 @@ ext $ λ x, rfl
 lemma mul_right_symm_apply (a : G) : ((equiv.mul_right a).symm : G → G) = λ x, x * a⁻¹ := rfl
 
 @[to_additive]
-lemma mul_right_bijective (a : G) : function.bijective (* a) :=
-begin
-  rw ← coe_mul_right,
-  exact (equiv.mul_right a).bijective,
-end
+lemma mul_right_bijective (a : G) : function.bijective (* a) := (equiv.mul_right a).bijective
 
 variable (G)
 

--- a/src/data/equiv/mul_add.lean
+++ b/src/data/equiv/mul_add.lean
@@ -440,6 +440,10 @@ def mul_left (u : units M) : equiv.perm M :=
 lemma mul_left_symm (u : units M) : u.mul_left.symm = u⁻¹.mul_left :=
 equiv.ext $ λ x, rfl
 
+@[to_additive]
+lemma mul_left_bijective (a : units M) : function.bijective ((*) a : M → M) :=
+(mul_left a).bijective
+
 /-- Right multiplication by a unit of a monoid is a permutation of the underlying type. -/
 @[to_additive "Right addition of an additive unit is a permutation of the underlying type.",
   simps apply {fully_applied := ff}]
@@ -452,6 +456,10 @@ def mul_right (u : units M) : equiv.perm M :=
 @[simp, to_additive]
 lemma mul_right_symm (u : units M) : u.mul_right.symm = u⁻¹.mul_right :=
 equiv.ext $ λ x, rfl
+
+@[to_additive]
+lemma mul_right_bijective (a : units M) : function.bijective ((* a) : M → M) :=
+(mul_right a).bijective
 
 end units
 
@@ -475,6 +483,13 @@ lemma mul_left_symm_apply (a : G) : ((equiv.mul_left a).symm : G → G) = (*) a�
 lemma mul_left_symm (a : G) : (equiv.mul_left a).symm = equiv.mul_left a⁻¹ :=
 ext $ λ x, rfl
 
+@[to_additive]
+lemma mul_left_bijective (a : G) : function.bijective ((*) a) :=
+begin
+  rw ← coe_mul_left,
+  exact (equiv.mul_left a).bijective,
+end
+
 /-- Right multiplication in a `group` is a permutation of the underlying type. -/
 @[to_additive "Right addition in an `add_group` is a permutation of the underlying type."]
 protected def mul_right (a : G) : perm G := (to_units a).mul_right
@@ -489,6 +504,13 @@ ext $ λ x, rfl
 /-- extra simp lemma that `dsimp` can use. `simp` will never use this.  -/
 @[simp, nolint simp_nf, to_additive]
 lemma mul_right_symm_apply (a : G) : ((equiv.mul_right a).symm : G → G) = λ x, x * a⁻¹ := rfl
+
+@[to_additive]
+lemma mul_right_bijective (a : G) : function.bijective (* a) :=
+begin
+  rw ← coe_mul_right,
+  exact (equiv.mul_right a).bijective,
+end
 
 variable (G)
 
@@ -545,6 +567,9 @@ protected def mul_left₀ (a : G) (ha : a ≠ 0) : perm G :=
   left_inv := λ x, by { dsimp, rw [← mul_assoc, inv_mul_cancel ha, one_mul] },
   right_inv := λ x, by { dsimp, rw [← mul_assoc, mul_inv_cancel ha, one_mul] } }
 
+lemma mul_left_bijective₀ (a : G) (ha : a ≠ 0) : function.bijective ((*) a : G → G) :=
+(equiv.mul_left₀ a ha).bijective
+
 /-- Right multiplication by a nonzero element in a `group_with_zero` is a permutation of the
 underlying type. -/
 @[simps {fully_applied := ff}]
@@ -553,6 +578,9 @@ protected def mul_right₀ (a : G) (ha : a ≠ 0) : perm G :=
   inv_fun := λ x, x * a⁻¹,
   left_inv := λ x, by { dsimp, rw [mul_assoc, mul_inv_cancel ha, mul_one] },
   right_inv := λ x, by { dsimp, rw [mul_assoc, inv_mul_cancel ha, mul_one] } }
+
+lemma mul_right_bijective₀ (a : G) (ha : a ≠ 0) : function.bijective ((* a) : G → G) :=
+(equiv.mul_right₀ a ha).bijective
 
 end group_with_zero
 

--- a/src/ring_theory/integral_domain.lean
+++ b/src/ring_theory/integral_domain.lean
@@ -40,6 +40,7 @@ fintype.injective_iff_bijective.1 $ mul_right_injective₀ ha
 lemma mul_left_bijective_of_fintype₀ {a : M} (ha : a ≠ 0) : bijective (λ b, b * a) :=
 fintype.injective_iff_bijective.1 $ mul_left_injective₀ ha
 
+/-- Every finite nontrivial cancel_monoid_with_zero is a group_with_zero. -/
 def group_with_zero_of_fintype (M : Type*) [cancel_monoid_with_zero M] [decidable_eq M] [fintype M]
   [nontrivial M] : group_with_zero M :=
 { inv := λ a, if h : a = 0 then 0 else fintype.bij_inv (mul_right_bijective_of_fintype₀ h) 1,

--- a/src/ring_theory/integral_domain.lean
+++ b/src/ring_theory/integral_domain.lean
@@ -64,7 +64,6 @@ which shows a finite domain is in fact commutative, hence a field. -/
 def division_ring_of_is_domain (R : Type*) [ring R] [is_domain R] [decidable_eq R] [fintype R] :
   division_ring R :=
 { ..show group_with_zero R, from group_with_zero_of_fintype R,
-  ..show nontrivial R, by apply_instance,
   ..‹ring R› }
 
 end ring

--- a/src/ring_theory/integral_domain.lean
+++ b/src/ring_theory/integral_domain.lean
@@ -32,7 +32,7 @@ open_locale big_operators nat
 
 section cancel_monoid_with_zero
 -- There doesn't seem to be a better home for these right now
-variables {M : Type*} [cancel_monoid_with_zero M]
+variables {M : Type*} [cancel_monoid_with_zero M] [fintype M]
 
 lemma mul_right_bijective_of_fintype₀ (a : M) (ha : a ≠ 0) : bijective (λ b, a * b) :=
 fintype.injective_iff_bijective.1 $ mul_right_injective₀ ha

--- a/src/ring_theory/integral_domain.lean
+++ b/src/ring_theory/integral_domain.lean
@@ -32,7 +32,7 @@ open_locale big_operators nat
 
 section cancel_monoid_with_zero
 -- There doesn't seem to be a better home for these right now
-variable {M : Type*} [cancel_monoid_with_zero M]
+variables {M : Type*} [cancel_monoid_with_zero M]
 
 lemma mul_right_bijective_of_fintype₀ (a : M) (ha : a ≠ 0) : bijective (λ b, a * b) :=
 fintype.injective_iff_bijective.1 $ mul_right_injective₀ ha

--- a/src/ring_theory/integral_domain.lean
+++ b/src/ring_theory/integral_domain.lean
@@ -30,17 +30,23 @@ section
 open finset polynomial function
 open_locale big_operators nat
 
+section cancel_monoid_with_zero
+-- There doesn't seem to be a better home for these right now
+variable {M : Type*} [cancel_monoid_with_zero M]
+
+lemma mul_right_bijective_of_fintype₀ (a : M) (ha : a ≠ 0) : bijective (λ b, a * b) :=
+fintype.injective_iff_bijective.1 $ mul_right_injective₀ ha
+
+lemma mul_left_bijective_of_fintype₀ (a : M) (ha : a ≠ 0) : bijective (λ b, b * a) :=
+fintype.injective_iff_bijective.1 $ mul_left_injective₀ ha
+
+end cancel_monoid_with_zero
+
 variables {R : Type*} {G : Type*}
 
 section ring
 
 variables [ring R] [is_domain R] [fintype R]
-
-lemma mul_right_bijective₀ (a : R) (ha : a ≠ 0) : bijective (λ b, a * b) :=
-fintype.injective_iff_bijective.1 $ mul_right_injective₀ ha
-
-lemma mul_left_bijective₀ (a : R) (ha : a ≠ 0) : bijective (λ b, b * a) :=
-fintype.injective_iff_bijective.1 $ mul_left_injective₀ ha
 
 /-- Every finite domain is a division ring.
 
@@ -48,7 +54,7 @@ TODO: Prove Wedderburn's little theorem,
 which shows a finite domain is in fact commutative, hence a field. -/
 def division_ring_of_is_domain (R : Type*) [ring R] [is_domain R] [decidable_eq R] [fintype R] :
   division_ring R :=
-{ inv := λ a, if h : a = 0 then 0 else fintype.bij_inv (mul_right_bijective₀ a h) 1,
+{ inv := λ a, if h : a = 0 then 0 else fintype.bij_inv (mul_right_bijective_of_fintype₀ a h) 1,
   mul_inv_cancel := λ a ha, show a * dite _ _ _ = _,
     by { rw dif_neg ha, exact fintype.right_inverse_bij_inv _ _ },
   inv_zero := dif_pos rfl,

--- a/src/ring_theory/integral_domain.lean
+++ b/src/ring_theory/integral_domain.lean
@@ -34,11 +34,20 @@ section cancel_monoid_with_zero
 -- There doesn't seem to be a better home for these right now
 variables {M : Type*} [cancel_monoid_with_zero M] [fintype M]
 
-lemma mul_right_bijective_of_fintype₀ (a : M) (ha : a ≠ 0) : bijective (λ b, a * b) :=
+lemma mul_right_bijective_of_fintype₀ {a : M} (ha : a ≠ 0) : bijective (λ b, a * b) :=
 fintype.injective_iff_bijective.1 $ mul_right_injective₀ ha
 
-lemma mul_left_bijective_of_fintype₀ (a : M) (ha : a ≠ 0) : bijective (λ b, b * a) :=
+lemma mul_left_bijective_of_fintype₀ {a : M} (ha : a ≠ 0) : bijective (λ b, b * a) :=
 fintype.injective_iff_bijective.1 $ mul_left_injective₀ ha
+
+def group_with_zero_of_fintype (M : Type*) [cancel_monoid_with_zero M] [decidable_eq M] [fintype M]
+  [nontrivial M] : group_with_zero M :=
+{ inv := λ a, if h : a = 0 then 0 else fintype.bij_inv (mul_right_bijective_of_fintype₀ h) 1,
+  mul_inv_cancel := λ a ha,
+    by { simp [has_inv.inv, dif_neg ha], exact fintype.right_inverse_bij_inv _ _ },
+  inv_zero := by { simp [has_inv.inv, dif_pos rfl] },
+  ..‹nontrivial M›,
+  ..‹cancel_monoid_with_zero M› }
 
 end cancel_monoid_with_zero
 
@@ -54,10 +63,7 @@ TODO: Prove Wedderburn's little theorem,
 which shows a finite domain is in fact commutative, hence a field. -/
 def division_ring_of_is_domain (R : Type*) [ring R] [is_domain R] [decidable_eq R] [fintype R] :
   division_ring R :=
-{ inv := λ a, if h : a = 0 then 0 else fintype.bij_inv (mul_right_bijective_of_fintype₀ a h) 1,
-  mul_inv_cancel := λ a ha, show a * dite _ _ _ = _,
-    by { rw dif_neg ha, exact fintype.right_inverse_bij_inv _ _ },
-  inv_zero := dif_pos rfl,
+{ ..show group_with_zero R, from group_with_zero_of_fintype R,
   ..show nontrivial R, by apply_instance,
   ..‹ring R› }
 


### PR DESCRIPTION

---

We couldn't find these with library_search so they seemed like sensible additions, lets see what the linters think

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
