### PR TITLE
[Merged by Bors] - feat(algebra/module/submodule_lattice): add `add_subgroup.to_int_submodule`

### DIFF
--- a/src/algebra/module/submodule_lattice.lean
+++ b/src/algebra/module/submodule_lattice.lean
@@ -254,7 +254,25 @@ section int_module
 variables [add_comm_group M]
 
 /-- An additive subgroup is equivalent to a ℤ-submodule. -/
-def add_subgroup.to_int_submodule : add_subgroup M ≃o submodule ℤ M := add_comm_group.int_module M
+def add_subgroup.to_int_submodule : add_subgroup M ≃o submodule ℤ M :=
+{ to_fun := λ S,
+  { smul_mem' := λ r s hs, begin
+    by_cases 0 ≤ r,
+    lift r to ℕ using h,
+    have := S.nsmul_mem hs ↑r,
+    simp only [nat.cast_id, add_subgroup.mem_carrier, gsmul_coe_nat] at this ⊢, refine this,
+    simp only [add_subgroup.mem_carrier],
+    suffices : -(r • s) ∈ S,
+    have eq := (add_subgroup.neg_mem_iff _).mp this, exact eq,
+    rw ←neg_smul, lift -r to ℕ,
+    have := S.nsmul_mem hs ↑_x_1, simp only [nat.cast_id, gsmul_coe_nat] at this ⊢,  exact this,
+    linarith,
+  end, ..S},
+  inv_fun := submodule.to_add_subgroup,
+  left_inv := λ ⟨S, _, _, _⟩, rfl,
+  right_inv := λ ⟨S, _, _, _⟩, rfl,
+  map_rel_iff' := λ a b, iff.rfl }
+
 
 @[simp]
 lemma add_subgroup.to_int_submodule_symm :

--- a/src/algebra/module/submodule_lattice.lean
+++ b/src/algebra/module/submodule_lattice.lean
@@ -253,7 +253,6 @@ section int_module
 
 variables [add_comm_group M]
 
-instance M_int_module : module ℤ M := add_comm_group.int_module M
 /-- An additive subgroup is equivalent to a ℤ-submodule. -/
 def add_subgroup.to_int_submodule : add_subgroup M ≃o submodule ℤ M :=
 { to_fun := λ S,

--- a/src/algebra/module/submodule_lattice.lean
+++ b/src/algebra/module/submodule_lattice.lean
@@ -254,25 +254,7 @@ section int_module
 variables [add_comm_group M]
 
 /-- An additive subgroup is equivalent to a ℤ-submodule. -/
-def add_subgroup.to_int_submodule : add_subgroup M ≃o submodule ℤ M :=
-{ to_fun := λ S,
-  { smul_mem' := λ r s hs, begin
-    by_cases 0 ≤ r,
-    lift r to ℕ using h,
-    have := S.nsmul_mem hs ↑r,
-    simp only [nat.cast_id, add_subgroup.mem_carrier, gsmul_coe_nat] at this ⊢, refine this,
-    simp only [add_subgroup.mem_carrier],
-    suffices : -(r • s) ∈ S,
-    have eq := (add_subgroup.neg_mem_iff _).mp this, exact eq,
-    rw ←neg_smul, lift -r to ℕ,
-    have := S.nsmul_mem hs ↑_x_1, simp only [nat.cast_id, gsmul_coe_nat] at this ⊢,  exact this,
-    linarith,
-  end, ..S},
-  inv_fun := submodule.to_add_subgroup,
-  left_inv := λ ⟨S, _, _, _⟩, rfl,
-  right_inv := λ ⟨S, _, _, _⟩, rfl,
-  map_rel_iff' := λ a b, iff.rfl }
-
+def add_subgroup.to_int_submodule : add_subgroup M ≃o submodule ℤ M := add_comm_group.int_module M
 
 @[simp]
 lemma add_subgroup.to_int_submodule_symm :

--- a/src/algebra/module/submodule_lattice.lean
+++ b/src/algebra/module/submodule_lattice.lean
@@ -274,4 +274,24 @@ def add_subgroup.to_int_submodule : add_subgroup M ≃o submodule ℤ M :=
   right_inv := λ ⟨S, _, _, _⟩, rfl,
   map_rel_iff' := λ a b, iff.rfl }
 
+
+@[simp]
+lemma add_subgroup.to_int_submodule_symm :
+  ⇑(add_subgroup.to_int_submodule.symm : _ ≃o add_subgroup M) = submodule.to_add_subgroup := rfl
+
+@[simp]
+lemma add_subgroup.coe_to_int_submodule (S : add_subgroup M) :
+  (S.to_int_submodule : set M) = S := rfl
+
+@[simp]
+lemma add_subgroup.to_int_submodule_to_add_subgroup (S : add_subgroup M) :
+  S.to_int_submodule.to_add_subgroup = S :=
+add_subgroup.to_int_submodule.symm_apply_apply S
+
+@[simp]
+lemma submodule.to_add_subgroup_to_int_submodule (S : submodule ℤ M) :
+  S.to_add_subgroup.to_int_submodule = S :=
+add_subgroup.to_int_submodule.apply_symm_apply S
+
+
 end int_module

--- a/src/algebra/module/submodule_lattice.lean
+++ b/src/algebra/module/submodule_lattice.lean
@@ -248,8 +248,7 @@ end nat_submodule
 
 end add_comm_monoid
 
-
-section int_module
+section int_submodule
 
 variables [add_comm_group M]
 
@@ -261,7 +260,6 @@ def add_subgroup.to_int_submodule : add_subgroup M ≃o submodule ℤ M := add_c
   left_inv := λ ⟨S, _, _, _⟩, rfl,
   right_inv := λ ⟨S, _, _, _⟩, rfl,
   map_rel_iff' := λ a b, iff.rfl }
-
 
 @[simp]
 lemma add_subgroup.to_int_submodule_symm :
@@ -281,5 +279,4 @@ lemma submodule.to_add_subgroup_to_int_submodule (S : submodule ℤ M) :
   S.to_add_subgroup.to_int_submodule = S :=
 add_subgroup.to_int_submodule.apply_symm_apply S
 
-
-end int_module
+end int_submodule

--- a/src/algebra/module/submodule_lattice.lean
+++ b/src/algebra/module/submodule_lattice.lean
@@ -254,20 +254,9 @@ section int_module
 variables [add_comm_group M]
 
 /-- An additive subgroup is equivalent to a ℤ-submodule. -/
-def add_subgroup.to_int_submodule : add_subgroup M ≃o submodule ℤ M :=
+def add_subgroup.to_int_submodule : add_subgroup M ≃o submodule ℤ M := add_comm_group.int_module M
 { to_fun := λ S,
-  { smul_mem' := λ r s hs, begin
-    by_cases 0 ≤ r,
-    lift r to ℕ using h,
-    have := S.nsmul_mem hs ↑r,
-    simp only [nat.cast_id, add_subgroup.mem_carrier, gsmul_coe_nat] at this ⊢, refine this,
-    simp only [add_subgroup.mem_carrier],
-    suffices : -(r • s) ∈ S,
-    have eq := (add_subgroup.neg_mem_iff _).mp this, exact eq,
-    rw ←neg_smul, lift -r to ℕ,
-    have := S.nsmul_mem hs ↑_x_1, simp only [nat.cast_id, gsmul_coe_nat] at this ⊢,  exact this,
-    linarith,
-  end, ..S},
+  { smul_mem' := λ r s hs, S.zsmul_mem hs _, ..S},
   inv_fun := submodule.to_add_subgroup,
   left_inv := λ ⟨S, _, _, _⟩, rfl,
   right_inv := λ ⟨S, _, _, _⟩, rfl,

--- a/src/algebra/module/submodule_lattice.lean
+++ b/src/algebra/module/submodule_lattice.lean
@@ -247,3 +247,31 @@ add_submonoid.to_nat_submodule.apply_symm_apply S
 end nat_submodule
 
 end add_comm_monoid
+
+
+section int_module
+
+variables [add_comm_group M]
+
+instance M_int_module : module ℤ M := add_comm_group.int_module M
+/-- An additive subgroup is equivalent to a ℤ-submodule. -/
+def add_subgroup.to_int_submodule : add_subgroup M ≃o submodule ℤ M :=
+{ to_fun := λ S,
+  { smul_mem' := λ r s hs, begin
+    by_cases 0 ≤ r,
+    lift r to ℕ using h,
+    have := S.nsmul_mem hs ↑r,
+    simp only [nat.cast_id, add_subgroup.mem_carrier, gsmul_coe_nat] at this ⊢, refine this,
+    simp only [add_subgroup.mem_carrier],
+    suffices : -(r • s) ∈ S,
+    have eq := (add_subgroup.neg_mem_iff _).mp this, exact eq,
+    rw ←neg_smul, lift -r to ℕ,
+    have := S.nsmul_mem hs ↑_x_1, simp only [nat.cast_id, gsmul_coe_nat] at this ⊢,  exact this,
+    linarith,
+  end, ..S},
+  inv_fun := submodule.to_add_subgroup,
+  left_inv := λ ⟨S, _, _, _⟩, rfl,
+  right_inv := λ ⟨S, _, _, _⟩, rfl,
+  map_rel_iff' := λ a b, iff.rfl }
+
+end int_module

--- a/src/algebra/module/submodule_lattice.lean
+++ b/src/algebra/module/submodule_lattice.lean
@@ -254,7 +254,7 @@ section int_module
 variables [add_comm_group M]
 
 /-- An additive subgroup is equivalent to a ℤ-submodule. -/
-def add_subgroup.to_int_submodule : add_subgroup M ≃o submodule ℤ M := add_comm_group.int_module M
+def add_subgroup.to_int_submodule : add_subgroup M ≃o submodule ℤ M :=
 { to_fun := λ S,
   { smul_mem' := λ r s hs, S.zsmul_mem hs _, ..S},
   inv_fun := submodule.to_add_subgroup,


### PR DESCRIPTION
This converts an `add_subgroup M` to a `submodule ℤ M`. We already have the analogous construction for `add_submonoid M`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)

Basically copy and pasted from code #7221

