### PR TITLE
[Merged by Bors] - feat(data/int/basic): coercion subtraction inequality

### DIFF
--- a/src/data/int/basic.lean
+++ b/src/data/int/basic.lean
@@ -140,7 +140,7 @@ not_congr coe_nat_eq_zero
 
 @[simp] lemma coe_nat_nonneg (n : ℕ) : 0 ≤ (n : ℤ) := coe_nat_le.2 (nat.zero_le _)
 
-@[simp] lemma le_coe_nat_sub (m n : ℕ) :
+lemma le_coe_nat_sub (m n : ℕ) :
   (m - n : ℤ) ≤ ↑(m - n : ℕ) :=
 begin
   by_cases h: m ≥ n,

--- a/src/data/int/basic.lean
+++ b/src/data/int/basic.lean
@@ -140,6 +140,20 @@ not_congr coe_nat_eq_zero
 
 @[simp] lemma coe_nat_nonneg (n : ℕ) : 0 ≤ (n : ℤ) := coe_nat_le.2 (nat.zero_le _)
 
+@[simp] lemma coe_sub_ge (m n : ℕ):
+  (m : ℤ)-(n : ℤ) ≤ (((m-n) : ℕ):ℤ) :=
+begin
+  by_cases h: m ≥ n,
+  have coe_sub_eq := int.coe_nat_sub h,
+  exact (le_of_eq coe_sub_eq.symm),
+
+  push_neg at h,
+  have sub_zero_le := int.coe_nat_le.2 (nat.zero_le (m-n)),
+  have le_zero := int.sub_le_sub_right (le_of_lt (int.coe_nat_lt.2 h)) (n:ℤ),
+  rw sub_self at le_zero,
+  exact le_trans le_zero sub_zero_le,
+end
+
 lemma coe_nat_ne_zero_iff_pos {n : ℕ} : (n : ℤ) ≠ 0 ↔ 0 < n :=
 ⟨λ h, nat.pos_of_ne_zero (coe_nat_ne_zero.1 h),
 λ h, (ne_of_lt (coe_nat_lt.2 h)).symm⟩

--- a/src/data/int/basic.lean
+++ b/src/data/int/basic.lean
@@ -140,8 +140,8 @@ not_congr coe_nat_eq_zero
 
 @[simp] lemma coe_nat_nonneg (n : ℕ) : 0 ≤ (n : ℤ) := coe_nat_le.2 (nat.zero_le _)
 
-@[simp] lemma coe_sub_ge (m n : ℕ):
-  (m : ℤ)-(n : ℤ) ≤ (((m-n) : ℕ):ℤ) :=
+@[simp] lemma le_coe_nat_sub (m n : ℕ) :
+  (m - n : ℤ) ≤ ↑(m - n : ℕ) :=
 begin
   by_cases h: m ≥ n,
   have coe_sub_eq := int.coe_nat_sub h,

--- a/src/data/int/basic.lean
+++ b/src/data/int/basic.lean
@@ -144,14 +144,8 @@ not_congr coe_nat_eq_zero
   (m - n : ℤ) ≤ ↑(m - n : ℕ) :=
 begin
   by_cases h: m ≥ n,
-  have coe_sub_eq := int.coe_nat_sub h,
-  exact (le_of_eq coe_sub_eq.symm),
-
-  push_neg at h,
-  have sub_zero_le := int.coe_nat_le.2 (nat.zero_le (m-n)),
-  have le_zero := int.sub_le_sub_right (le_of_lt (int.coe_nat_lt.2 h)) (n:ℤ),
-  rw sub_self at le_zero,
-  exact le_trans le_zero sub_zero_le,
+  { exact le_of_eq (int.coe_nat_sub h).symm },
+  { simp [le_of_not_ge h] }
 end
 
 lemma coe_nat_ne_zero_iff_pos {n : ℕ} : (n : ℤ) ≠ 0 ↔ 0 < n :=


### PR DESCRIPTION
Adding to simp a subtraction inequality over coercion from int to nat

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
