### PR TITLE
[Merged by Bors] - feat(measure_theory/decomposition/lebesgue): more on Radon-Nikodym derivatives

### DIFF
--- a/src/measure_theory/decomposition/jordan.lean
+++ b/src/measure_theory/decomposition/jordan.lean
@@ -63,7 +63,7 @@ open measure vector_measure
 variable (j : jordan_decomposition α)
 
 instance : has_zero (jordan_decomposition α) :=
-{ zero := ⟨0, 0, mutually_singular.zero⟩ }
+{ zero := ⟨0, 0, mutually_singular.zero_right⟩ }
 
 instance : inhabited (jordan_decomposition α) :=
 { default := 0 }

--- a/src/measure_theory/decomposition/lebesgue.lean
+++ b/src/measure_theory/decomposition/lebesgue.lean
@@ -131,7 +131,7 @@ begin
   by_cases h : have_lebesgue_decomposition μ ν,
   { exactI (have_lebesgue_decomposition_spec μ ν).2.1 },
   { rw [singular_part, dif_neg h],
-    exact mutually_singular.zero.symm }
+    exact mutually_singular.zero_left }
 end
 
 lemma singular_part_le (μ ν : measure α) : μ.singular_part ν ≤ μ :=
@@ -275,7 +275,7 @@ end
 
 lemma singular_part_zero (ν : measure α) : (0 : measure α).singular_part ν = 0 :=
 begin
-  refine (eq_singular_part measurable_zero mutually_singular.zero.symm _).symm,
+  refine (eq_singular_part measurable_zero mutually_singular.zeroleft _).symm,
   rw [zero_add, with_density_zero],
 end
 
@@ -930,9 +930,9 @@ begin
   { rw not_have_lebesgue_decomposition_iff at hl,
     cases hl with hp hn,
     { rw [measure.singular_part, dif_neg hp],
-      exact mutually_singular.zero.symm },
+      exact mutually_singular.zero_left },
     { rw [measure.singular_part, measure.singular_part, dif_neg hn],
-      exact mutually_singular.zero } }
+      exact mutually_singular.zero_right } }
 end
 
 lemma singular_part_total_variation (s : signed_measure α) (μ : measure α) :

--- a/src/measure_theory/decomposition/lebesgue.lean
+++ b/src/measure_theory/decomposition/lebesgue.lean
@@ -75,14 +75,14 @@ class have_lebesgue_decomposition (μ ν : measure α) : Prop :=
 
 /-- If a pair of measures `have_lebesgue_decomposition`, then `singular_part` chooses the
 measure from `have_lebesgue_decomposition`, otherwise it returns the zero measure. For sigma-finite
-measures, `μ = μ.singular_part ν + ν.with_density (μ.rn_deriv μ)`. -/
+measures, `μ = μ.singular_part ν + ν.with_density (μ.rn_deriv ν)`. -/
 @[irreducible]
 def singular_part (μ ν : measure α) : measure α :=
 if h : have_lebesgue_decomposition μ ν then (classical.some h.lebesgue_decomposition).1 else 0
 
 /-- If a pair of measures `have_lebesgue_decomposition`, then `rn_deriv` chooses the
 measurable function from `have_lebesgue_decomposition`, otherwise it returns the zero function.
-For sigma-finite measures, `μ = μ.singular_part ν + ν.with_density (μ.rn_deriv μ)`.-/
+For sigma-finite measures, `μ = μ.singular_part ν + ν.with_density (μ.rn_deriv ν)`.-/
 @[irreducible]
 def rn_deriv (μ ν : measure α) : α → ℝ≥0∞ :=
 if h : have_lebesgue_decomposition μ ν then (classical.some h.lebesgue_decomposition).2 else 0

--- a/src/measure_theory/decomposition/lebesgue.lean
+++ b/src/measure_theory/decomposition/lebesgue.lean
@@ -275,7 +275,7 @@ end
 
 lemma singular_part_zero (ν : measure α) : (0 : measure α).singular_part ν = 0 :=
 begin
-  refine (eq_singular_part measurable_zero mutually_singular.zeroleft _).symm,
+  refine (eq_singular_part measurable_zero mutually_singular.zero_left _).symm,
   rw [zero_add, with_density_zero],
 end
 

--- a/src/measure_theory/decomposition/lebesgue.lean
+++ b/src/measure_theory/decomposition/lebesgue.lean
@@ -286,7 +286,7 @@ begin
   { rw [hr, zero_smul, zero_smul, singular_part_zero] },
   by_cases hl : have_lebesgue_decomposition μ ν,
   { haveI := hl,
-    refine (eq_singular_part ((measurable_μ.rn_deriv ν).const_smul (r : ℝ≥0∞))
+    refine (eq_singular_part ((measurable_rn_deriv μ ν).const_smul (r : ℝ≥0∞))
       (mutually_singular.smul r (have_lebesgue_decomposition_spec _ _).2.1) _).symm,
     rw with_density_smul _ (measurable_rn_deriv _ _),
     change _ = _ + r • _,
@@ -388,7 +388,8 @@ theorem eq_rn_deriv [sigma_finite ν] {s : measure α} {f : α → ℝ≥0∞} (
   (hs : s ⊥ₘ ν) (hadd : μ = s + ν.with_density f) :
   f =ᵐ[ν] μ.rn_deriv ν :=
 begin
-  refine ae_eq_of_forall_set_lintegral_eq_of_sigma_finite hf (measurable_μ.rn_deriv ν) (λ a ha, _),
+  refine ae_eq_of_forall_set_lintegral_eq_of_sigma_finite hf (measurable_rn_deriv μ ν) _,
+  assume a ha h'a,
   calc ∫⁻ (x : α) in a, f x ∂ν = ν.with_density f a : (with_density_apply f ha).symm
   ... = ν.with_density (μ.rn_deriv ν) a : by rw eq_with_density_rn_deriv hf hs hadd
   ... = ∫⁻ (x : α) in a, μ.rn_deriv ν x ∂ν : with_density_apply _ ha

--- a/src/measure_theory/decomposition/lebesgue.lean
+++ b/src/measure_theory/decomposition/lebesgue.lean
@@ -11,8 +11,8 @@ import measure_theory.function.ae_eq_of_integral
 # Lebesgue decomposition
 
 This file proves the Lebesgue decomposition theorem. The Lebesgue decomposition theorem states that,
-given two σ-finite measures `μ` and `ν`, there exists a finite measure `ξ` and a measurable function
-`f` such that `μ = ξ + fν` and `ξ` is mutually singular with respect to `ν`.
+given two σ-finite measures `μ` and `ν`, there exists a σ-finite measure `ξ` and a measurable
+function `f` such that `μ = ξ + fν` and `ξ` is mutually singular with respect to `ν`.
 
 The Lebesgue decomposition provides the Radon-Nikodym theorem readily.
 
@@ -44,10 +44,10 @@ The Lebesgue decomposition provides the Radon-Nikodym theorem readily.
   the Lebesgue decomposition theorem.
 * `measure_theory.measure.eq_singular_part` : Given measures `μ` and `ν`, if `s` is a measure
   mutually singular to `ν` and `f` is a measurable function such that `μ = s + fν`, then
-  `s = singular_part μ ν`.
+  `s = μ.singular_part ν`.
 * `measure_theory.measure.eq_rn_deriv` : Given measures `μ` and `ν`, if `s` is a
   measure mutually singular to `ν` and `f` is a measurable function such that `μ = s + fν`,
-  then `f = rn_deriv μ ν`.
+  then `f = μ.rn_deriv ν`.
 * `measure_theory.signed_measure.singular_part_add_with_density_rn_deriv_eq` :
   the Lebesgue decomposition theorem between a signed measure and a σ-finite positive measure.
 
@@ -75,22 +75,22 @@ class have_lebesgue_decomposition (μ ν : measure α) : Prop :=
 
 /-- If a pair of measures `have_lebesgue_decomposition`, then `singular_part` chooses the
 measure from `have_lebesgue_decomposition`, otherwise it returns the zero measure. For sigma-finite
-measures, `μ = (singular_part μ ν) + ν.with_density (rn_deriv μ ν)`. -/
+measures, `μ = μ.singular_part ν + ν.with_density (μ.rn_deriv μ)`. -/
 @[irreducible]
 def singular_part (μ ν : measure α) : measure α :=
 if h : have_lebesgue_decomposition μ ν then (classical.some h.lebesgue_decomposition).1 else 0
 
 /-- If a pair of measures `have_lebesgue_decomposition`, then `rn_deriv` chooses the
 measurable function from `have_lebesgue_decomposition`, otherwise it returns the zero function.
-For sigma-finite measures, `μ = (singular_part μ ν) + ν.with_density (rn_deriv μ ν)`.-/
+For sigma-finite measures, `μ = μ.singular_part ν + ν.with_density (μ.rn_deriv μ)`.-/
 @[irreducible]
 def rn_deriv (μ ν : measure α) : α → ℝ≥0∞ :=
 if h : have_lebesgue_decomposition μ ν then (classical.some h.lebesgue_decomposition).2 else 0
 
 lemma have_lebesgue_decomposition_spec (μ ν : measure α)
   [h : have_lebesgue_decomposition μ ν] :
-  measurable (rn_deriv μ ν) ∧ (singular_part μ ν) ⊥ₘ ν ∧
-  μ = (singular_part μ ν) + ν.with_density (rn_deriv μ ν) :=
+  measurable (μ.rn_deriv ν) ∧ (μ.singular_part ν) ⊥ₘ ν ∧
+  μ = (μ.singular_part ν) + ν.with_density (μ.rn_deriv ν) :=
 begin
   rw [singular_part, rn_deriv, dif_pos h, dif_pos h],
   exact classical.some_spec h.lebesgue_decomposition,
@@ -98,7 +98,7 @@ end
 
 lemma have_lebesgue_decomposition_add (μ ν : measure α)
   [have_lebesgue_decomposition μ ν] :
-  μ = (singular_part μ ν) + ν.with_density (rn_deriv μ ν) :=
+  μ = (μ.singular_part ν) + ν.with_density (μ.rn_deriv ν) :=
 (have_lebesgue_decomposition_spec μ ν).2.2
 
 instance have_lebesgue_decomposition_smul
@@ -117,7 +117,7 @@ instance have_lebesgue_decomposition_smul
 
 @[measurability]
 lemma measurable_rn_deriv (μ ν : measure α) :
-  measurable $ rn_deriv μ ν :=
+  measurable $ μ.rn_deriv ν :=
 begin
   by_cases h : have_lebesgue_decomposition μ ν,
   { exactI (have_lebesgue_decomposition_spec μ ν).1 },
@@ -126,7 +126,7 @@ begin
 end
 
 lemma mutually_singular_singular_part (μ ν : measure α) :
-  singular_part μ ν ⊥ₘ ν :=
+  μ.singular_part ν ⊥ₘ ν :=
 begin
   by_cases h : have_lebesgue_decomposition μ ν,
   { exactI (have_lebesgue_decomposition_spec μ ν).2.1 },
@@ -134,7 +134,7 @@ begin
     exact mutually_singular.zero.symm }
 end
 
-lemma singular_part_le (μ ν : measure α) : singular_part μ ν ≤ μ :=
+lemma singular_part_le (μ ν : measure α) : μ.singular_part ν ≤ μ :=
 begin
   by_cases hl : have_lebesgue_decomposition μ ν,
   { casesI (have_lebesgue_decomposition_spec μ ν).2 with _ h,
@@ -145,7 +145,7 @@ begin
 end
 
 lemma with_density_rn_deriv_le (μ ν : measure α) :
-  ν.with_density (rn_deriv μ ν) ≤ μ :=
+  ν.with_density (μ.rn_deriv ν) ≤ μ :=
 begin
   by_cases hl : have_lebesgue_decomposition μ ν,
   { casesI (have_lebesgue_decomposition_spec μ ν).2 with _ h,
@@ -155,24 +155,24 @@ begin
     exact measure.zero_le μ }
 end
 
-instance [is_finite_measure μ] : is_finite_measure (singular_part μ ν) :=
+instance [is_finite_measure μ] : is_finite_measure (μ.singular_part ν) :=
 is_finite_measure_of_le μ $ singular_part_le μ ν
 
-instance [sigma_finite μ] : sigma_finite (singular_part μ ν) :=
+instance [sigma_finite μ] : sigma_finite (μ.singular_part ν) :=
 sigma_finite_of_le μ $ singular_part_le μ ν
 
 instance [topological_space α] [is_locally_finite_measure μ] :
-  is_locally_finite_measure (singular_part μ ν) :=
+  is_locally_finite_measure (μ.singular_part ν) :=
 is_locally_finite_measure_of_le $ singular_part_le μ ν
 
-instance [is_finite_measure μ] : is_finite_measure (ν.with_density $ rn_deriv μ ν) :=
+instance [is_finite_measure μ] : is_finite_measure (ν.with_density $ μ.rn_deriv ν) :=
 is_finite_measure_of_le μ $ with_density_rn_deriv_le μ ν
 
-instance [sigma_finite μ] : sigma_finite (ν.with_density $ rn_deriv μ ν) :=
+instance [sigma_finite μ] : sigma_finite (ν.with_density $ μ.rn_deriv ν) :=
 sigma_finite_of_le μ $ with_density_rn_deriv_le μ ν
 
 instance [topological_space α] [is_locally_finite_measure μ] :
-  is_locally_finite_measure (ν.with_density $ rn_deriv μ ν) :=
+  is_locally_finite_measure (ν.with_density $ μ.rn_deriv ν) :=
 is_locally_finite_measure_of_le $ with_density_rn_deriv_le μ ν
 
 lemma lintegral_rn_deriv_lt_top_of_measure_ne_top
@@ -219,7 +219,7 @@ begin
 end
 
 /-- Given measures `μ` and `ν`, if `s` is a measure mutually singular to `ν` and `f` is a
-measurable function such that `μ = s + fν`, then `s = singular_part μ ν`.
+measurable function such that `μ = s + fν`, then `s = μ.singular_part μ`.
 
 This theorem provides the uniqueness of the `singular_part` in the Lebesgue decomposition theorem,
 while `measure_theory.measure.eq_rn_deriv` provides the uniqueness of the
@@ -286,7 +286,7 @@ begin
   { rw [hr, zero_smul, zero_smul, singular_part_zero] },
   by_cases hl : have_lebesgue_decomposition μ ν,
   { haveI := hl,
-    refine (eq_singular_part ((measurable_rn_deriv μ ν).const_smul (r : ℝ≥0∞))
+    refine (eq_singular_part ((measurable_μ.rn_deriv ν).const_smul (r : ℝ≥0∞))
       (mutually_singular.smul r (have_lebesgue_decomposition_spec _ _).2.1) _).symm,
     rw with_density_smul _ (measurable_rn_deriv _ _),
     change _ = _ + r • _,
@@ -320,7 +320,7 @@ begin
 end
 
 /-- Given measures `μ` and `ν`, if `s` is a measure mutually singular to `ν` and `f` is a
-measurable function such that `μ = s + fν`, then `f = rn_deriv μ ν`.
+measurable function such that `μ = s + fν`, then `f = μ.rn_deriv ν`.
 
 This theorem provides the uniqueness of the `rn_deriv` in the Lebesgue decomposition
 theorem, while `measure_theory.measure.eq_singular_part` provides the uniqueness of the
@@ -340,7 +340,7 @@ begin
     rw [hT₃, hS₃, add_zero],
     exact le_refl _ },
   have heq : (ν.with_density f).restrict (S ∩ T) =
-              (ν.with_density (rn_deriv μ ν)).restrict (S ∩ T),
+              (ν.with_density (μ.rn_deriv ν)).restrict (S ∩ T),
   { ext1 A hA,
     have hs : s (A ∩ (S ∩ T)) = 0,
     { rw ← nonpos_iff_eq_zero,
@@ -378,7 +378,7 @@ begin
 end
 
 /-- Given measures `μ` and `ν`, if `s` is a measure mutually singular to `ν` and `f` is a
-measurable function such that `μ = s + fν`, then `f = rn_deriv μ ν`.
+measurable function such that `μ = s + fν`, then `f = μ.rn_deriv ν`.
 
 This theorem provides the uniqueness of the `rn_deriv` in the Lebesgue decomposition
 theorem, while `measure_theory.measure.eq_singular_part` provides the uniqueness of the
@@ -388,7 +388,7 @@ theorem eq_rn_deriv [sigma_finite ν] {s : measure α} {f : α → ℝ≥0∞} (
   (hs : s ⊥ₘ ν) (hadd : μ = s + ν.with_density f) :
   f =ᵐ[ν] μ.rn_deriv ν :=
 begin
-  refine ae_eq_of_forall_set_lintegral_eq_of_sigma_finite hf (measurable_rn_deriv μ ν) (λ a ha, _),
+  refine ae_eq_of_forall_set_lintegral_eq_of_sigma_finite hf (measurable_μ.rn_deriv ν) (λ a ha, _),
   calc ∫⁻ (x : α) in a, f x ∂ν = ν.with_density f a : (with_density_apply f ha).symm
   ... = ν.with_density (μ.rn_deriv ν) a : by rw eq_with_density_rn_deriv hf hs hadd
   ... = ∫⁻ (x : α) in a, μ.rn_deriv ν x ∂ν : with_density_apply _ ha

--- a/src/measure_theory/function/ae_eq_of_integral.lean
+++ b/src/measure_theory/function/ae_eq_of_integral.lean
@@ -17,7 +17,7 @@ possible finiteness of the measure.
 
 ## Main statements
 
-All results listed below apply to two functions `f,g`, together with two main hypotheses,
+All results listed below apply to two functions `f, g`, together with two main hypotheses,
 * `f` and `g` are integrable on all measurable sets with finite measure,
 * for all measurable sets `s` with finite measure, `∫ x in s, f x ∂μ = ∫ x in s, g x ∂μ`.
 The conclusion is then `f =ᵐ[μ] g`. The main lemmas are:
@@ -287,26 +287,18 @@ begin
   exact hf_zero s hs,
 end
 
-lemma ae_nonneg_of_forall_set_integral_nonneg_of_sigma_finite [sigma_finite μ]
-  {f : α → ℝ}
+lemma ae_nonneg_of_forall_set_integral_nonneg_of_sigma_finite [sigma_finite μ] {f : α → ℝ}
   (hf_int_finite : ∀ s, measurable_set s → μ s < ∞ → integrable_on f s μ)
   (hf_zero : ∀ s, measurable_set s → μ s < ∞ → 0 ≤ ∫ x in s, f x ∂μ) :
   0 ≤ᵐ[μ] f :=
 begin
-  let S := spanning_sets μ,
-  rw [← @measure.restrict_univ _ _ μ, ← Union_spanning_sets μ, eventually_le, ae_iff,
-    measure.restrict_apply'],
-  swap,
-  { exact measurable_set.Union (measurable_spanning_sets μ), },
-  rw [set.inter_Union, measure_Union_null_iff],
-  intro n,
-  have h_meas_n : measurable_set (S n), from (measurable_spanning_sets μ n),
-  have hμn : μ (S n) < ∞, from measure_spanning_sets_lt_top μ n,
-  rw ← measure.restrict_apply' h_meas_n,
-  refine ae_nonneg_restrict_of_forall_set_integral_nonneg_inter hμn.ne
-    (hf_int_finite (S n) h_meas_n hμn) (λ s hs, _),
-  exact hf_zero (s ∩ S n) (hs.inter h_meas_n)
-    ((measure_mono (set.inter_subset_right _ _)).trans_lt hμn),
+  apply ae_of_forall_measure_lt_top_ae_restrict,
+  assume t t_meas t_lt_top,
+  apply ae_nonneg_restrict_of_forall_set_integral_nonneg_inter t_lt_top.ne
+    (hf_int_finite t t_meas t_lt_top),
+  assume s s_meas,
+  exact hf_zero _ (s_meas.inter t_meas)
+    (lt_of_le_of_lt (measure_mono (set.inter_subset_right _ _)) t_lt_top)
 end
 
 lemma ae_fin_strongly_measurable.ae_nonneg_of_forall_set_integral_nonneg {f : α → ℝ}

--- a/src/measure_theory/function/ae_eq_of_integral.lean
+++ b/src/measure_theory/function/ae_eq_of_integral.lean
@@ -159,7 +159,7 @@ open_locale topological_space
 
 lemma ae_le_of_forall_set_lintegral_le_of_sigma_finite [sigma_finite μ]
   {f g : α → ℝ≥0∞} (hf : measurable f) (hg : measurable g)
-  (h : ∀ s, measurable_set s → ∫⁻ x in s, f x ∂μ ≤ ∫⁻ x in s, g x ∂μ) :
+  (h : ∀ s, measurable_set s → μ s < ∞ → ∫⁻ x in s, f x ∂μ ≤ ∫⁻ x in s, g x ∂μ) :
   f ≤ᵐ[μ] g :=
 begin
   have A : ∀ (ε N : ℝ≥0) (p : ℕ), 0 < ε →
@@ -170,21 +170,21 @@ begin
     { have A : measurable_set {x | g x + ε ≤ f x} := measurable_set_le (hg.add measurable_const) hf,
       have B : measurable_set {x | g x ≤ N} := measurable_set_le hg measurable_const,
       exact (A.inter B).inter (measurable_spanning_sets μ p) },
+    have s_lt_top : μ s < ∞ :=
+      (measure_mono (set.inter_subset_right _ _)).trans_lt (measure_spanning_sets_lt_top μ p),
     have A : ∫⁻ x in s, g x ∂μ + ε * μ s ≤ ∫⁻ x in s, g x ∂μ + 0 := calc
       ∫⁻ x in s, g x ∂μ + ε * μ s = ∫⁻ x in s, g x ∂μ + ∫⁻ x in s, ε ∂μ :
         by simp only [lintegral_const, set.univ_inter, measurable_set.univ, measure.restrict_apply]
       ... = ∫⁻ x in s, (g x + ε) ∂μ : (lintegral_add hg measurable_const).symm
       ... ≤ ∫⁻ x in s, f x ∂μ : set_lintegral_mono (hg.add measurable_const) hf (λ x hx, hx.1.1)
-      ... ≤ ∫⁻ x in s, g x ∂μ + 0 : by { rw [add_zero], exact h s s_meas },
+      ... ≤ ∫⁻ x in s, g x ∂μ + 0 : by { rw [add_zero], exact h s s_meas s_lt_top },
     have B : ∫⁻ x in s, g x ∂μ ≠ ∞,
     { apply ne_of_lt,
       calc ∫⁻ x in s, g x ∂μ ≤ ∫⁻ x in s, N ∂μ :
         set_lintegral_mono hg measurable_const (λ x hx, hx.1.2)
       ... = N * μ s :
         by simp only [lintegral_const, set.univ_inter, measurable_set.univ, measure.restrict_apply]
-      ... ≤ N * μ (spanning_sets μ p) :
-        ennreal.mul_le_mul le_rfl (measure_mono (set.inter_subset_right _ _))
-      ... < ∞ : by simp only [lt_top_iff_ne_top, (measure_spanning_sets_lt_top μ p).ne, and_false,
+      ... < ∞ : by simp only [lt_top_iff_ne_top, s_lt_top.ne, and_false,
         ennreal.coe_ne_top, with_top.mul_eq_top_iff, ne.def, not_false_iff, false_and, or_self] },
     have : (ε : ℝ≥0∞) * μ s ≤ 0 := ennreal.le_of_add_le_add_left B A,
     simpa only [ennreal.coe_eq_zero, nonpos_iff_eq_zero, mul_eq_zero, εpos.ne', false_or] },
@@ -215,13 +215,13 @@ end
 
 lemma ae_eq_of_forall_set_lintegral_eq_of_sigma_finite [sigma_finite μ]
   {f g : α → ℝ≥0∞} (hf : measurable f) (hg : measurable g)
-  (h : ∀ s, measurable_set s → ∫⁻ x in s, f x ∂μ = ∫⁻ x in s, g x ∂μ) :
+  (h : ∀ s, measurable_set s → μ s < ∞ → ∫⁻ x in s, f x ∂μ = ∫⁻ x in s, g x ∂μ) :
   f =ᵐ[μ] g :=
 begin
   have A : f ≤ᵐ[μ] g :=
-    ae_le_of_forall_set_lintegral_le_of_sigma_finite hf hg (λ s hs, le_of_eq (h s hs)),
+    ae_le_of_forall_set_lintegral_le_of_sigma_finite hf hg (λ s hs h's, le_of_eq (h s hs h's)),
   have B : g ≤ᵐ[μ] f :=
-    ae_le_of_forall_set_lintegral_le_of_sigma_finite hg hf (λ s hs, ge_of_eq (h s hs)),
+    ae_le_of_forall_set_lintegral_le_of_sigma_finite hg hf (λ s hs h's, ge_of_eq (h s hs h's)),
   filter_upwards [A, B],
   exact λ x, le_antisymm
 end

--- a/src/measure_theory/function/ae_eq_of_integral.lean
+++ b/src/measure_theory/function/ae_eq_of_integral.lean
@@ -30,6 +30,9 @@ The conclusion is then `f =ᵐ[μ] g`. The main lemmas are:
 For each of these results, we also provide a lemma about the equality of one function and 0. For
 example, `Lp.ae_eq_zero_of_forall_set_integral_eq_zero`.
 
+We also register the corresponding lemma for integrals of `ℝ≥0∞`-valued functions, in
+`ae_eq_of_forall_set_lintegral_eq_of_sigma_finite`.
+
 Generally useful lemmas which are not related to integrals:
 * `ae_eq_zero_of_forall_inner`: if for all constants `c`, `λ x, inner c (f x) =ᵐ[μ] 0` then
   `f =ᵐ[μ] 0`.
@@ -149,6 +152,81 @@ begin
   assume n,
   exact hc _ (u_lt n),
 end
+
+section ennreal
+
+open_locale topological_space
+
+lemma ae_le_of_forall_set_lintegral_le_of_sigma_finite [sigma_finite μ]
+  {f g : α → ℝ≥0∞} (hf : measurable f) (hg : measurable g)
+  (h : ∀ s, measurable_set s → ∫⁻ x in s, f x ∂μ ≤ ∫⁻ x in s, g x ∂μ) :
+  f ≤ᵐ[μ] g :=
+begin
+  have A : ∀ (ε N : ℝ≥0) (p : ℕ), 0 < ε →
+    μ ({x | g x + ε ≤ f x ∧ g x ≤ N} ∩ spanning_sets μ p) = 0,
+  { assume ε N p εpos,
+    let s := {x | g x + ε ≤ f x ∧ g x ≤ N} ∩ spanning_sets μ p,
+    have s_meas : measurable_set s,
+    { have A : measurable_set {x | g x + ε ≤ f x} := measurable_set_le (hg.add measurable_const) hf,
+      have B : measurable_set {x | g x ≤ N} := measurable_set_le hg measurable_const,
+      exact (A.inter B).inter (measurable_spanning_sets μ p) },
+    have A : ∫⁻ x in s, g x ∂μ + ε * μ s ≤ ∫⁻ x in s, g x ∂μ + 0 := calc
+      ∫⁻ x in s, g x ∂μ + ε * μ s = ∫⁻ x in s, g x ∂μ + ∫⁻ x in s, ε ∂μ :
+        by simp only [lintegral_const, set.univ_inter, measurable_set.univ, measure.restrict_apply]
+      ... = ∫⁻ x in s, (g x + ε) ∂μ : (lintegral_add hg measurable_const).symm
+      ... ≤ ∫⁻ x in s, f x ∂μ : set_lintegral_mono (hg.add measurable_const) hf (λ x hx, hx.1.1)
+      ... ≤ ∫⁻ x in s, g x ∂μ + 0 : by { rw [add_zero], exact h s s_meas },
+    have B : ∫⁻ x in s, g x ∂μ ≠ ∞,
+    { apply ne_of_lt,
+      calc ∫⁻ x in s, g x ∂μ ≤ ∫⁻ x in s, N ∂μ :
+        set_lintegral_mono hg measurable_const (λ x hx, hx.1.2)
+      ... = N * μ s :
+        by simp only [lintegral_const, set.univ_inter, measurable_set.univ, measure.restrict_apply]
+      ... ≤ N * μ (spanning_sets μ p) :
+        ennreal.mul_le_mul le_rfl (measure_mono (set.inter_subset_right _ _))
+      ... < ∞ : by simp only [lt_top_iff_ne_top, (measure_spanning_sets_lt_top μ p).ne, and_false,
+        ennreal.coe_ne_top, with_top.mul_eq_top_iff, ne.def, not_false_iff, false_and, or_self] },
+    have : (ε : ℝ≥0∞) * μ s ≤ 0 := ennreal.le_of_add_le_add_left B A,
+    simpa only [ennreal.coe_eq_zero, nonpos_iff_eq_zero, mul_eq_zero, εpos.ne', false_or] },
+  obtain ⟨u, u_mono, u_pos, u_lim⟩ : ∃ (u : ℕ → ℝ≥0), strict_anti u ∧ (∀ n, 0 < u n) ∧
+    tendsto u at_top (nhds 0) := exists_seq_strict_anti_tendsto (0 : ℝ≥0),
+  let s := λ (n : ℕ), {x | g x + u n ≤ f x ∧ g x ≤ (n : ℝ≥0)} ∩ spanning_sets μ n,
+  have μs : ∀ n, μ (s n) = 0 := λ n, A _ _ _ (u_pos n),
+  have B : {x | f x ≤ g x}ᶜ ⊆ ⋃ n, s n,
+  { assume x hx,
+    simp at hx,
+    have L1 : ∀ᶠ n in at_top, g x + u n ≤ f x,
+    { have : tendsto (λ n, g x + u n) at_top (𝓝 (g x + (0 : ℝ≥0))) :=
+        tendsto_const_nhds.add (ennreal.tendsto_coe.2 u_lim),
+      simp at this,
+      exact eventually_le_of_tendsto_lt hx this },
+    have L2 : ∀ᶠ (n : ℕ) in (at_top : filter ℕ), g x ≤ (n : ℝ≥0),
+    { have : tendsto (λ (n : ℕ), ((n : ℝ≥0) : ℝ≥0∞)) at_top (𝓝 ∞),
+      { simp only [ennreal.coe_nat],
+        exact ennreal.tendsto_nat_nhds_top },
+      exact eventually_ge_of_tendsto_gt (hx.trans_le le_top) this },
+    apply set.mem_Union.2,
+    exact ((L1.and L2).and (eventually_mem_spanning_sets μ x)).exists },
+  refine le_antisymm _ bot_le,
+  calc μ {x : α | (λ (x : α), f x ≤ g x) x}ᶜ ≤ μ (⋃ n, s n) : measure_mono B
+  ... ≤ ∑' n, μ (s n) : measure_Union_le _
+  ... = 0 : by simp only [μs, tsum_zero]
+end
+
+lemma ae_eq_of_forall_set_lintegral_eq_of_sigma_finite [sigma_finite μ]
+  {f g : α → ℝ≥0∞} (hf : measurable f) (hg : measurable g)
+  (h : ∀ s, measurable_set s → ∫⁻ x in s, f x ∂μ = ∫⁻ x in s, g x ∂μ) :
+  f =ᵐ[μ] g :=
+begin
+  have A : f ≤ᵐ[μ] g :=
+    ae_le_of_forall_set_lintegral_le_of_sigma_finite hf hg (λ s hs, le_of_eq (h s hs)),
+  have B : g ≤ᵐ[μ] f :=
+    ae_le_of_forall_set_lintegral_le_of_sigma_finite hg hf (λ s hs, ge_of_eq (h s hs)),
+  filter_upwards [A, B],
+  exact λ x, le_antisymm
+end
+
+end ennreal
 
 section real
 

--- a/src/measure_theory/measure/measure_space.lean
+++ b/src/measure_theory/measure/measure_space.lean
@@ -1380,7 +1380,7 @@ localized "infix ` ⊥ₘ `:60 := measure_theory.measure.mutually_singular" in m
 
 namespace mutually_singular
 
-lemma zero : μ ⊥ₘ 0 :=
+lemma zero_right : μ ⊥ₘ 0 :=
 ⟨∅, measurable_set.empty, measure_empty, rfl⟩
 
 lemma symm (h : ν ⊥ₘ μ) : μ ⊥ₘ ν :=
@@ -1388,7 +1388,7 @@ let ⟨i, hi, his, hit⟩ := h in
   ⟨iᶜ, measurable_set.compl hi, hit, (compl_compl i).symm ▸ his⟩
 
 lemma zero_left : 0 ⊥ₘ μ :=
-zero.symm
+zero_right.symm
 
 lemma add (h₁ : ν₁ ⊥ₘ μ) (h₂ : ν₂ ⊥ₘ μ) : ν₁ + ν₂ ⊥ₘ μ :=
 begin
@@ -2262,8 +2262,8 @@ lemma finite_at_nhds_within [topological_space α] {m0 : measurable_space α} (�
 @[simp] lemma finite_at_principal : μ.finite_at_filter (𝓟 s) ↔ μ s < ∞ :=
 ⟨λ ⟨t, ht, hμ⟩, (measure_mono ht).trans_lt hμ, λ h, ⟨s, mem_principal_self s, h⟩⟩
 
-lemma is_locally_finite_measure_of_le [topological_space α] {m : measurable_space α} {μ ν : measure α}
-  [H : is_locally_finite_measure μ] (h : ν ≤ μ) :
+lemma is_locally_finite_measure_of_le [topological_space α] {m : measurable_space α}
+  {μ ν : measure α} [H : is_locally_finite_measure μ] (h : ν ≤ μ) :
   is_locally_finite_measure ν :=
 let F := H.finite_at_nhds in ⟨λ x, (F x).measure_mono h⟩
 

--- a/src/measure_theory/measure/measure_space.lean
+++ b/src/measure_theory/measure/measure_space.lean
@@ -2262,7 +2262,7 @@ lemma finite_at_nhds_within [topological_space α] {m0 : measurable_space α} (�
 @[simp] lemma finite_at_principal : μ.finite_at_filter (𝓟 s) ↔ μ s < ∞ :=
 ⟨λ ⟨t, ht, hμ⟩, (measure_mono ht).trans_lt hμ, λ h, ⟨s, mem_principal_self s, h⟩⟩
 
-lemma is_locally_finite_measure_of_le [topological_space α] [measurable_space α] {μ ν: measure α}
+lemma is_locally_finite_measure_of_le [topological_space α] {m : measurable_space α} {μ ν : measure α}
   [H : is_locally_finite_measure μ] (h : ν ≤ μ) :
   is_locally_finite_measure ν :=
 let F := H.finite_at_nhds in ⟨λ x, (F x).measure_mono h⟩

--- a/src/measure_theory/measure/measure_space.lean
+++ b/src/measure_theory/measure/measure_space.lean
@@ -1960,6 +1960,19 @@ lemma eventually_mem_spanning_sets (μ : measure α) [sigma_finite μ] (x : α) 
   ∀ᶠ n in at_top, x ∈ spanning_sets μ n :=
 eventually_at_top.2 ⟨spanning_sets_index μ x, λ b, mem_spanning_sets_of_index_le μ x⟩
 
+lemma ae_of_forall_measure_lt_top_ae_restrict {μ : measure α} [sigma_finite μ] (P : α → Prop)
+  (h : ∀ s, measurable_set s → μ s < ∞ → ∀ᵐ x ∂(μ.restrict s), P x) :
+  ∀ᵐ x ∂μ, P x :=
+begin
+  have : ∀ n, ∀ᵐ x ∂μ, x ∈ spanning_sets μ n → P x,
+  { assume n,
+    have := h (spanning_sets μ n) (measurable_spanning_sets _ _) (measure_spanning_sets_lt_top _ _),
+    rwa ae_restrict_iff' (measurable_spanning_sets _ _) at this },
+  filter_upwards [ae_all_iff.2 this],
+  assume x hx,
+  exact hx _ (mem_spanning_sets_index _ _),
+end
+
 omit m0
 
 namespace measure

--- a/src/measure_theory/measure/measure_space.lean
+++ b/src/measure_theory/measure/measure_space.lean
@@ -1277,6 +1277,12 @@ protected lemma rfl : μ ≪ μ := λ s hs, hs
 if hf : measurable f then absolutely_continuous.mk $ λ s hs, by simpa [hf, hs] using @h _
 else by simp only [map_of_not_measurable hf]
 
+protected lemma smul (h : μ ≪ ν) (c : ℝ≥0∞) : c • μ ≪ ν :=
+mk (λ s hs hνs, by simp only [h hνs, algebra.id.smul_eq_mul, coe_smul, pi.smul_apply, mul_zero])
+
+protected lemma coe_nnreal_smul (h : μ ≪ ν) (c : ℝ≥0) : c • μ ≪ ν :=
+h.smul c
+
 end absolutely_continuous
 
 lemma ae_le_iff_absolutely_continuous : μ.ae ≤ ν.ae ↔ μ ≪ ν :=
@@ -1380,6 +1386,9 @@ lemma zero : μ ⊥ₘ 0 :=
 lemma symm (h : ν ⊥ₘ μ) : μ ⊥ₘ ν :=
 let ⟨i, hi, his, hit⟩ := h in
   ⟨iᶜ, measurable_set.compl hi, hit, (compl_compl i).symm ▸ his⟩
+
+lemma zero_left : 0 ⊥ₘ μ :=
+zero.symm
 
 lemma add (h₁ : ν₁ ⊥ₘ μ) (h₂ : ν₂ ⊥ₘ μ) : ν₁ + ν₂ ⊥ₘ μ :=
 begin
@@ -1942,6 +1951,15 @@ lemma mem_spanning_sets_index (μ : measure α) [sigma_finite μ] (x : α) :
   x ∈ spanning_sets μ (spanning_sets_index μ x) :=
 disjointed_subset _ _ (mem_disjointed_spanning_sets_index μ x)
 
+lemma mem_spanning_sets_of_index_le (μ : measure α) [sigma_finite μ] (x : α)
+  {n : ℕ} (hn : spanning_sets_index μ x ≤ n) :
+  x ∈ spanning_sets μ n :=
+monotone_spanning_sets μ hn (mem_spanning_sets_index μ x)
+
+lemma eventually_mem_spanning_sets (μ : measure α) [sigma_finite μ] (x : α) :
+  ∀ᶠ n in at_top, x ∈ spanning_sets μ n :=
+eventually_at_top.2 ⟨spanning_sets_index μ x, λ b, mem_spanning_sets_of_index_le μ x⟩
+
 omit m0
 
 namespace measure
@@ -2078,6 +2096,16 @@ lemma measure.exists_is_open_measure_lt_top [topological_space α] (μ : measure
   ∃ s : set α, x ∈ s ∧ is_open s ∧ μ s < ∞ :=
 by simpa only [exists_prop, and.assoc]
   using (μ.finite_at_nhds x).exists_mem_basis (nhds_basis_opens x)
+
+instance is_locally_finite_measure_smul_nnreal [topological_space α] (μ : measure α)
+  [is_locally_finite_measure μ] (c : ℝ≥0) : is_locally_finite_measure (c • μ) :=
+begin
+  refine ⟨λ x, _⟩,
+  rcases μ.exists_is_open_measure_lt_top x with ⟨o, xo, o_open, μo⟩,
+  refine ⟨o, o_open.mem_nhds xo, _⟩,
+  apply ennreal.mul_lt_top _ μo.ne,
+  simp only [ennreal.coe_ne_top, ennreal.coe_of_nnreal_hom, ne.def, not_false_iff],
+end
 
 omit m0
 
@@ -2220,6 +2248,11 @@ lemma finite_at_nhds_within [topological_space α] {m0 : measurable_space α} (�
 
 @[simp] lemma finite_at_principal : μ.finite_at_filter (𝓟 s) ↔ μ s < ∞ :=
 ⟨λ ⟨t, ht, hμ⟩, (measure_mono ht).trans_lt hμ, λ h, ⟨s, mem_principal_self s, h⟩⟩
+
+lemma is_locally_finite_measure_of_le [topological_space α] [measurable_space α] {μ ν: measure α}
+  [H : is_locally_finite_measure μ] (h : ν ≤ μ) :
+  is_locally_finite_measure ν :=
+let F := H.finite_at_nhds in ⟨λ x, (F x).measure_mono h⟩
 
 /-! ### Subtraction of measures -/
 

--- a/src/probability_theory/density.lean
+++ b/src/probability_theory/density.lean
@@ -224,7 +224,7 @@ lemma to_quasi_measure_preserving {X : α → E} [has_pdf X ℙ μ] : quasi_meas
 lemma have_lebesgue_decomposition_of_has_pdf {X : α → E} [hX' : has_pdf X ℙ μ] :
   (map X ℙ).have_lebesgue_decomposition μ :=
 ⟨⟨⟨0, pdf X ℙ μ⟩,
-  by simp only [zero_add, measurable_pdf X ℙ μ, true_and, mutually_singular.zero.symm,
+  by simp only [zero_add, measurable_pdf X ℙ μ, true_and, mutually_singular.zero_right,
     map_eq_with_density_pdf X ℙ μ] ⟩⟩
 
 lemma has_pdf_iff {X : α → E} :

--- a/src/probability_theory/density.lean
+++ b/src/probability_theory/density.lean
@@ -224,7 +224,7 @@ lemma to_quasi_measure_preserving {X : α → E} [has_pdf X ℙ μ] : quasi_meas
 lemma have_lebesgue_decomposition_of_has_pdf {X : α → E} [hX' : has_pdf X ℙ μ] :
   (map X ℙ).have_lebesgue_decomposition μ :=
 ⟨⟨⟨0, pdf X ℙ μ⟩,
-  by simp only [zero_add, measurable_pdf X ℙ μ, true_and, mutually_singular.zero_right,
+  by simp only [zero_add, measurable_pdf X ℙ μ, true_and, mutually_singular.zero_left,
     map_eq_with_density_pdf X ℙ μ] ⟩⟩
 
 lemma has_pdf_iff {X : α → E} :


### PR DESCRIPTION
We show that the density in the Lebesgue decomposition theorem (aka the Radon-Nikodym derivative) is unique. Previously, uniqueness of the absolutely continuous part was known, but not of its density. We also show that the Radon-Nikodym derivative is almost everywhere finite. Plus some cleanup of the whole file. 

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
