### PR TITLE
[Merged by Bors] - chore(ring_theory/algebra_tower): relax typeclasses

### DIFF
--- a/src/ring_theory/algebra_tower.lean
+++ b/src/ring_theory/algebra_tower.lean
@@ -67,14 +67,14 @@ end is_scalar_tower
 namespace algebra
 
 theorem adjoin_algebra_map' {R : Type u} {S : Type v} {A : Type w}
-  [comm_ring R] [comm_ring S] [comm_ring A] [algebra R S] [algebra S A] (s : set S) :
+  [comm_semiring R] [comm_semiring S] [semiring A] [algebra R S] [algebra S A] (s : set S) :
   adjoin R (algebra_map S (restrict_scalars R S A) '' s) = (adjoin R s).map
   ((algebra.of_id S (restrict_scalars R S A)).restrict_scalars R) :=
 le_antisymm (adjoin_le $ set.image_subset_iff.2 $ λ y hy, ⟨y, subset_adjoin hy, rfl⟩)
   (subalgebra.map_le.2 $ adjoin_le $ λ y hy, subset_adjoin ⟨y, hy, rfl⟩)
 
 theorem adjoin_algebra_map (R : Type u) (S : Type v) (A : Type w)
-  [comm_ring R] [comm_ring S] [comm_ring A] [algebra R S] [algebra S A] [algebra R A]
+  [comm_semiring R] [comm_semiring S] [semiring A] [algebra R S] [algebra S A] [algebra R A]
   [is_scalar_tower R S A] (s : set S) :
   adjoin R (algebra_map S A '' s) =
     subalgebra.map (adjoin R s) (is_scalar_tower.to_alg_hom R S A) :=
@@ -113,7 +113,7 @@ end algebra
 
 section
 open_locale classical
-lemma algebra.fg_trans' {R S A : Type*} [comm_ring R] [comm_ring S] [comm_ring A]
+lemma algebra.fg_trans' {R S A : Type*} [comm_semiring R] [comm_semiring S] [comm_semiring A]
   [algebra R S] [algebra S A] [algebra R A] [is_scalar_tower R S A]
   (hRS : (⊤ : subalgebra R S).fg) (hSA : (⊤ : subalgebra S A).fg) :
   (⊤ : subalgebra R A).fg :=
@@ -143,14 +143,14 @@ b.coe_map_coeffs _ _
 
 end algebra_map_coeffs
 
-section ring
+section semiring
 
 open finsupp
 open_locale big_operators classical
 universes v₁ w₁
 
 variables {R S A}
-variables [comm_ring R] [ring S] [add_comm_group A]
+variables [comm_semiring R] [semiring S] [add_comm_monoid A]
 variables [algebra R S] [module S A] [module R A] [is_scalar_tower R S A]
 
 theorem linear_independent_smul {ι : Type v₁} {b : ι → S} {ι' : Type w₁} {c : ι' → A}
@@ -202,7 +202,14 @@ begin
   { simp [hi] },
 end
 
-lemma basis.algebra_map_injective {ι : Type v₁} [no_zero_divisors R] [nontrivial S]
+end semiring
+
+section ring
+
+variables {R S}
+variables [comm_ring R] [ring S] [algebra R S]
+
+lemma basis.algebra_map_injective {ι : Type*} [no_zero_divisors R] [nontrivial S]
   (b : basis ι R S) :
   function.injective (algebra_map R S) :=
 have no_zero_smul_divisors R S := b.no_zero_smul_divisors,
@@ -213,7 +220,10 @@ end ring
 section artin_tate
 
 variables (C : Type*)
-variables [comm_ring A] [comm_ring B] [comm_ring C]
+
+section semiring
+
+variables [comm_semiring A] [comm_semiring B] [semiring C]
 variables [algebra A B] [algebra B C] [algebra A C] [is_scalar_tower A B C]
 
 open finset submodule
@@ -257,6 +267,13 @@ begin
     (subset_span $ mem_insert_self _ _) (λ p q hp hq, hyy $ submodule.mul_mem_mul hp hq)
 end
 
+end semiring
+
+section ring
+
+variables [comm_ring A] [comm_ring B] [comm_ring C]
+variables [algebra A B] [algebra B C] [algebra A C] [is_scalar_tower A B C]
+
 /-- Artin--Tate lemma: if A ⊆ B ⊆ C is a chain of subrings of commutative rings, and
 A is noetherian, and C is algebra-finite over A, and C is module-finite over B,
 then B is algebra-finite over A.
@@ -271,6 +288,8 @@ algebra.fg_trans' (B₀.fg_top.2 hAB₀) $ subalgebra.fg_of_submodule_fg $
 have is_noetherian_ring B₀, from is_noetherian_ring_of_fg hAB₀,
 have is_noetherian B₀ C, by exactI is_noetherian_of_fg_of_noetherian' hB₀C,
 by exactI fg_of_injective (is_scalar_tower.to_alg_hom B₀ B C).to_linear_map hBCi
+
+end ring
 
 end artin_tate
 


### PR DESCRIPTION
This generalizes some `comm_ring`s to `comm_semiring`s.

Split from #10024

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
