### PR TITLE
[Merged by Bors] - chore(coinductive_predicates): remove private and use of import_private

### DIFF
--- a/src/algebra/lie/weights.lean
+++ b/src/algebra/lie/weights.lean
@@ -263,7 +263,7 @@ begin
     simp only [mem_weight_space, mem_pre_weight_space,
       lie_subalgebra.coe_incl', lie_submodule.mem_comap, this], },
   have hfg : ∀ (y : H), (f y).comp (H.incl : H →ₗ[R] L) = (H.incl : H →ₗ[R] L).comp (g y),
-  { rintros ⟨y, hz⟩, ext ⟨z, hz⟩,
+  { rintros ⟨y, hy⟩, ext ⟨z, hz⟩,
     simp only [submodule.coe_sub, to_endomorphism_apply_apply, lie_hom.coe_to_linear_map,
       linear_map.one_apply, lie_subalgebra.coe_incl, lie_subalgebra.coe_bracket_of_module,
       lie_subalgebra.coe_bracket, linear_map.smul_apply, function.comp_app,

--- a/src/meta/coinductive_predicates.lean
+++ b/src/meta/coinductive_predicates.lean
@@ -217,7 +217,7 @@ end add_coinductive_predicate
 
 open add_coinductive_predicate
 
-/- compact_relation bs as_ps: Product a relation of the form:
+/-- compact_relation bs as_ps: Product a relation of the form:
   R := λ as, ∃ bs, Λ_i a_i = p_i[bs]
 This relation is user visible, so we compact it by removing each `b_j` where a `p_i = b_j`, and
 hence `a_i = b_j`. We need to take care when there are `p_i` and `p_j` with `p_i = p_j = b_k`. -/

--- a/src/meta/coinductive_predicates.lean
+++ b/src/meta/coinductive_predicates.lean
@@ -221,7 +221,7 @@ open add_coinductive_predicate
   R := λ as, ∃ bs, Λ_i a_i = p_i[bs]
 This relation is user visible, so we compact it by removing each `b_j` where a `p_i = b_j`, and
 hence `a_i = b_j`. We need to take care when there are `p_i` and `p_j` with `p_i = p_j = b_k`. -/
-private meta def compact_relation :
+meta def compact_relation :
   list expr → list (expr × expr) → list expr × list (expr × expr)
 | [] ps      := ([], ps)
 | (list.cons b bs) ps :=

--- a/test/coinductive.lean
+++ b/test/coinductive.lean
@@ -105,17 +105,3 @@ end
 
 coinductive coind_foo : list ℕ → Prop
 | mk : ∀ xs, (∀ k l m, coind_foo (k::l::m::xs)) → coind_foo xs
-
-meta example : true :=
-begin
-   success_if_fail { let := compact_relation },
-   trivial
-end
-
-import_private compact_relation from tactic.coinduction
-
-meta example : true :=
-begin
-  let := compact_relation,
-  trivial
-end


### PR DESCRIPTION
Remove a `private` modifier (I think this had previously been ported from core by @bryangingechen).

Then remove the only use of `import_private` from the library. (Besides another use in `tests/`, which we're not porting.)

(In mathlib4 we have `OpenPrivate` as an alternative. Removing `import_private` is one less thing for mathport to care about.)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
