### PR TITLE
[Merged by Bors] - feat(algebra/big_operators/order): add unbundled is_absolute_value.sum_le and map_prod

### DIFF
--- a/src/algebra/big_operators/order.lean
+++ b/src/algebra/big_operators/order.lean
@@ -511,9 +511,19 @@ begin
   exact (abv.add_le _ _).trans (add_le_add (le_refl _) ih) },
 end
 
+lemma is_absolute_value.abv_sum [semiring R] [ordered_semiring S] (abv : R → S)
+  [is_absolute_value abv] (f : ι → R) (s : finset ι) :
+  abv (∑ i in s, f i) ≤ ∑ i in s, abv (f i) :=
+(is_absolute_value.to_absolute_value abv).sum_le _ _
+
 lemma absolute_value.map_prod [comm_semiring R] [nontrivial R] [linear_ordered_comm_ring S]
   (abv : absolute_value R S) (f : ι → R) (s : finset ι) :
   abv (∏ i in s, f i) = ∏ i in s, abv (f i) :=
 abv.to_monoid_hom.map_prod f s
+
+lemma is_absolute_value.map_prod [comm_semiring R] [nontrivial R] [linear_ordered_comm_ring S]
+  (abv : R → S) [is_absolute_value abv] (f : ι → R) (s : finset ι) :
+  abv (∏ i in s, f i) = ∏ i in s, abv (f i) :=
+(is_absolute_value.to_absolute_value abv).map_prod _ _
 
 end absolute_value

--- a/src/algebra/order/absolute_value.lean
+++ b/src/algebra/order/absolute_value.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro, Anne Baanen
 -/
 import algebra.order.field
-import algebra.big_operators.basic
 
 /-!
 # Absolute values
@@ -203,19 +202,6 @@ theorem abv_zero : abv 0 = 0 := (abv_eq_zero abv).2 rfl
 theorem abv_pos {a : R} : 0 < abv a ↔ a ≠ 0 :=
 by rw [lt_iff_le_and_ne, ne, eq_comm]; simp [abv_eq_zero abv, abv_nonneg abv]
 
-variables {ι : Type*} (f : ι → R) (s : finset ι)
-
-open_locale big_operators
-
-theorem abv_sum : abv (∑ i in s, f i) ≤ ∑ i in s, abv (f i) :=
-begin
-  classical,
-  induction s using finset.induction with i s hi ih,
-  { simp [is_absolute_value.abv_zero abv], },
-  { rw [finset.sum_insert hi, finset.sum_insert hi],
-    calc _ ≤ _ : is_absolute_value.abv_add abv _ _
-       ... ≤ _ : add_le_add_left ih _, }
-end
 
 end ordered_semiring
 
@@ -254,21 +240,6 @@ lemma abv_pow [nontrivial R] (abv : R → S) [is_absolute_value abv]
 
 end semiring
 
-section comm_semiring
-
-variables {R ι : Type*} [comm_semiring R] [nontrivial R] (abv : R → S) [is_absolute_value abv]
-variables (f : ι → R) (s : finset ι)
-open_locale big_operators
-
-theorem abv_prod : abv (∏ i in s, f i) = ∏ i in s, abv (f i) :=
-begin
-  classical,
-  induction s using finset.induction with i s hi ih,
-  { simp [is_absolute_value.abv_one abv], },
-  { rw [finset.prod_insert hi, finset.prod_insert hi],
-    simp [is_absolute_value.abv_mul abv, ih], },
-end
-end comm_semiring
 end linear_ordered_comm_ring
 
 section linear_ordered_field

--- a/src/algebra/order/absolute_value.lean
+++ b/src/algebra/order/absolute_value.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro, Anne Baanen
 -/
 import algebra.order.field
+import algebra.big_operators.basic
 
 /-!
 # Absolute values
@@ -145,7 +146,7 @@ section linear_ordered_field
 
 section field
 
-variables {R S : Type*} [field R] [linear_ordered_field S] (abv : absolute_value R S)
+variables {R S : Type*} [division_ring R] [linear_ordered_field S] (abv : absolute_value R S)
 
 @[simp] protected theorem map_inv (a : R) : abv a⁻¹ = (abv a)⁻¹ :=
 abv.to_monoid_with_zero_hom.map_inv a
@@ -202,6 +203,20 @@ theorem abv_zero : abv 0 = 0 := (abv_eq_zero abv).2 rfl
 theorem abv_pos {a : R} : 0 < abv a ↔ a ≠ 0 :=
 by rw [lt_iff_le_and_ne, ne, eq_comm]; simp [abv_eq_zero abv, abv_nonneg abv]
 
+variables {ι : Type*} (f : ι → R) (s : finset ι)
+
+open_locale big_operators
+
+theorem is_absolute_value.abv_sum : abv (∑ i in s, f i) ≤ ∑ i in s, abv (f i) :=
+begin
+  classical,
+  induction s using finset.induction with i s hi ih,
+  { simp [is_absolute_value.abv_zero abv], },
+  { rw [finset.sum_insert hi, finset.sum_insert hi],
+    calc _ ≤ _ : is_absolute_value.abv_add abv _ _
+       ... ≤ _ : add_le_add_left ih _, }
+end
+
 end ordered_semiring
 
 section linear_ordered_ring
@@ -218,9 +233,9 @@ instance abs_is_absolute_value {S} [linear_ordered_ring S] :
 
 end linear_ordered_ring
 
-section linear_ordered_field
+section linear_ordered_comm_ring
 
-variables {S : Type*} [linear_ordered_field S]
+variables {S : Type*} [linear_ordered_comm_ring S]
 
 section semiring
 variables {R : Type*} [semiring R] (abv : R → S) [is_absolute_value abv]
@@ -238,6 +253,26 @@ lemma abv_pow [nontrivial R] (abv : R → S) [is_absolute_value abv]
 (abv_hom abv).to_monoid_hom.map_pow a n
 
 end semiring
+
+section comm_semiring
+
+variables {R ι : Type*} [comm_semiring R] [nontrivial R] (abv : R → S) [is_absolute_value abv]
+variables (f : ι → R) (s : finset ι)
+open_locale big_operators
+
+theorem is_absolute_value.abv_prod : abv (∏ i in s, f i) = ∏ i in s, abv (f i) :=
+begin
+  classical,
+  induction s using finset.induction with i s hi ih,
+  { simp [is_absolute_value.abv_one abv], },
+  { rw [finset.prod_insert hi, finset.prod_insert hi],
+    simp [is_absolute_value.abv_mul abv, ih], },
+end
+end comm_semiring
+end linear_ordered_comm_ring
+
+section linear_ordered_field
+variables {S : Type*} [linear_ordered_field S]
 
 section ring
 variables {R : Type*} [ring R] (abv : R → S) [is_absolute_value abv]
@@ -262,7 +297,7 @@ abs_sub_le_iff.2 ⟨sub_abv_le_abv_sub abv _ _,
 end ring
 
 section field
-variables {R : Type*} [field R] (abv : R → S) [is_absolute_value abv]
+variables {R : Type*} [division_ring R] (abv : R → S) [is_absolute_value abv]
 
 theorem abv_inv (a : R) : abv a⁻¹ = (abv a)⁻¹ :=
 (abv_hom abv).map_inv a

--- a/src/algebra/order/absolute_value.lean
+++ b/src/algebra/order/absolute_value.lean
@@ -207,7 +207,7 @@ variables {ι : Type*} (f : ι → R) (s : finset ι)
 
 open_locale big_operators
 
-theorem is_absolute_value.abv_sum : abv (∑ i in s, f i) ≤ ∑ i in s, abv (f i) :=
+theorem abv_sum : abv (∑ i in s, f i) ≤ ∑ i in s, abv (f i) :=
 begin
   classical,
   induction s using finset.induction with i s hi ih,
@@ -260,7 +260,7 @@ variables {R ι : Type*} [comm_semiring R] [nontrivial R] (abv : R → S) [is_ab
 variables (f : ι → R) (s : finset ι)
 open_locale big_operators
 
-theorem is_absolute_value.abv_prod : abv (∏ i in s, f i) = ∏ i in s, abv (f i) :=
+theorem abv_prod : abv (∏ i in s, f i) = ∏ i in s, abv (f i) :=
 begin
   classical,
   induction s using finset.induction with i s hi ih,


### PR DESCRIPTION
Add unbundled versions of two existing lemmas.
Additionally generalize a few typeclass assumptions in an earlier file.

From the flt-regular project


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
