### PR TITLE
[Merged by Bors] - chore(combinatorics/choose/bounds): move to nat namespace

### DIFF
--- a/src/combinatorics/choose/bounds.lean
+++ b/src/combinatorics/choose/bounds.lean
@@ -16,13 +16,15 @@ bounds `n^r/r^r ≤ n.choose r ≤ e^r n^r/r^r` in the future.
 
 ## Main declarations
 
-* `choose_le_pow`: `n.choose r ≤ n^r / r!`
-* `pow_le_choose`: `(n + 1 - r)^r / r! ≤ n.choose r`. Beware of the fishy ℕ-subtraction.
+* `nat.choose_le_pow`: `n.choose r ≤ n^r / r!`
+* `nat.pow_le_choose`: `(n + 1 - r)^r / r! ≤ n.choose r`. Beware of the fishy ℕ-subtraction.
 -/
 
 open_locale nat
 
 variables {α : Type*} [linear_ordered_field α]
+
+namespace nat
 
 lemma choose_le_pow (r n : ℕ) : (n.choose r : α) ≤ n^r / r! :=
 begin
@@ -42,3 +44,5 @@ begin
     exact n.pow_sub_le_desc_factorial r },
   exact_mod_cast r.factorial_pos,
 end
+
+end nat


### PR DESCRIPTION
There are module docstrings elsewhere that expect this to be in the `nat` namespace with the other `choose` lemmas.



---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
