### PR TITLE
[Merged by Bors] - feat(ring_theory/trace): remove a useless assumption

### DIFF
--- a/src/ring_theory/trace.lean
+++ b/src/ring_theory/trace.lean
@@ -325,9 +325,9 @@ begin
 end
 
 lemma trace_eq_sum_embeddings [finite_dimensional K L] [is_separable K L]
-  {x : L} (hx : is_integral K x) :
-  algebra_map K E (algebra.trace K L x) = ∑ σ : L →ₐ[K] E, σ x :=
+  {x : L} : algebra_map K E (algebra.trace K L x) = ∑ σ : L →ₐ[K] E, σ x :=
 begin
+  have hx := is_separable.is_integral K x,
   rw [trace_eq_trace_adjoin K x, algebra.smul_def, ring_hom.map_mul, ← adjoin.power_basis_gen hx,
       trace_eq_sum_embeddings_gen E (adjoin.power_basis hx) (is_alg_closed.splits_codomain _),
       ← algebra.smul_def, algebra_map_smul],
@@ -364,8 +364,7 @@ begin
   { refine congr_arg det _, ext i j,
     rw [vandermonde_transpose_mul_vandermonde, ring_hom.map_matrix_apply, matrix.map_apply,
         bilin_form.to_matrix_apply, pb.basis_eq_pow, pb.basis_eq_pow, trace_form_apply,
-        ← pow_add, trace_eq_sum_embeddings (algebraic_closure L) (pb.is_integral_gen.pow _),
-        fintype.sum_equiv e],
+        ← pow_add, trace_eq_sum_embeddings (algebraic_closure L), fintype.sum_equiv e],
     intros σ,
     rw [e.symm_apply_apply, σ.map_pow] },
   { simp only [det_vandermonde, finset.prod_eq_zero_iff, not_exists, sub_eq_zero],


### PR DESCRIPTION
We remove an assumption that is always true.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
