### PR TITLE
[Merged by Bors] - feat(group_theory/complement): iff-lemmas for when bottom and top subgroups are complementary

### DIFF
--- a/src/data/set/basic.lean
+++ b/src/data/set/basic.lean
@@ -765,12 +765,22 @@ ne_empty_iff_nonempty
 instance unique_singleton (a : α) : unique ↥({a} : set α) :=
 ⟨⟨⟨a, mem_singleton a⟩⟩, λ ⟨x, h⟩, subtype.eq h⟩
 
-lemma eq_singleton_iff_unique_mem {s : set α} {a : α} : s = {a} ↔ a ∈ s ∧ ∀ x ∈ s, x = a :=
+lemma eq_singleton_iff_unique_mem : s = {a} ↔ a ∈ s ∧ ∀ x ∈ s, x = a :=
 subset.antisymm_iff.trans $ and.comm.trans $ and_congr_left' singleton_subset_iff
 
-lemma eq_singleton_iff_nonempty_unique_mem {s : set α} {a : α} :
+lemma eq_singleton_iff_nonempty_unique_mem :
   s = {a} ↔ s.nonempty ∧ ∀ x ∈ s, x = a :=
 eq_singleton_iff_unique_mem.trans $ and_congr_left $ λ H, ⟨λ h', ⟨_, h'⟩, λ ⟨x, h⟩, H x h ▸ h⟩
+
+lemma exists_eq_singleton_iff_nonempty_unique_mem :
+  (∃ a : α, s = {a}) ↔ (s.nonempty ∧ ∀ a b ∈ s, a = b) :=
+begin
+  refine ⟨_, λ h, _⟩,
+  { rintros ⟨a, rfl⟩,
+    refine ⟨set.singleton_nonempty a, λ b c hb hc, hb.trans hc.symm⟩ },
+  { obtain ⟨a, ha⟩ := h.1,
+    refine ⟨a, set.eq_singleton_iff_unique_mem.mpr ⟨ha, λ b hb, (h.2 b a hb ha)⟩⟩ },
+end
 
 -- while `simp` is capable of proving this, it is not capable of turning the LHS into the RHS.
 @[simp] lemma default_coe_singleton (x : α) :

--- a/src/data/set/basic.lean
+++ b/src/data/set/basic.lean
@@ -768,8 +768,7 @@ instance unique_singleton (a : α) : unique ↥({a} : set α) :=
 lemma eq_singleton_iff_unique_mem : s = {a} ↔ a ∈ s ∧ ∀ x ∈ s, x = a :=
 subset.antisymm_iff.trans $ and.comm.trans $ and_congr_left' singleton_subset_iff
 
-lemma eq_singleton_iff_nonempty_unique_mem :
-  s = {a} ↔ s.nonempty ∧ ∀ x ∈ s, x = a :=
+lemma eq_singleton_iff_nonempty_unique_mem : s = {a} ↔ s.nonempty ∧ ∀ x ∈ s, x = a :=
 eq_singleton_iff_unique_mem.trans $ and_congr_left $ λ H, ⟨λ h', ⟨_, h'⟩, λ ⟨x, h⟩, H x h ▸ h⟩
 
 lemma exists_eq_singleton_iff_nonempty_unique_mem :

--- a/src/group_theory/complement.lean
+++ b/src/group_theory/complement.lean
@@ -76,15 +76,74 @@ end
 @[to_additive] lemma is_complement'_comm : is_complement' H K ↔ is_complement' K H :=
 ⟨is_complement'.symm, is_complement'.symm⟩
 
-@[to_additive] lemma is_complement_top_singleton {g : G} :
-  is_complement (⊤ : set G) {g} :=
+@[to_additive] lemma is_complement_top_singleton {g : G} : is_complement (⊤ : set G) {g} :=
 ⟨λ ⟨x, _, rfl⟩ ⟨y, _, rfl⟩ h, prod.ext (subtype.ext (mul_right_cancel h)) rfl,
   λ x, ⟨⟨⟨x * g⁻¹, ⟨⟩⟩, g, rfl⟩, inv_mul_cancel_right x g⟩⟩
 
-@[to_additive] lemma is_complement_singleton_top {g : G} :
-  is_complement ({g} : set G) (⊤ : set G) :=
+@[to_additive] lemma is_complement_singleton_top {g : G} : is_complement ({g} : set G) ⊤ :=
 ⟨λ ⟨⟨_, rfl⟩, x⟩ ⟨⟨_, rfl⟩, y⟩ h, prod.ext rfl (subtype.ext (mul_left_cancel h)),
   λ x, ⟨⟨⟨g, rfl⟩, g⁻¹ * x, ⟨⟩⟩, mul_inv_cancel_left g x⟩⟩
+
+@[to_additive] lemma is_complement_singleton_left {g : G} : is_complement {g} S ↔ S = ⊤ :=
+begin
+  refine ⟨λ h, top_le_iff.mp (λ x hx, _), λ h, (congr_arg _ h).mpr is_complement_singleton_top⟩,
+  obtain ⟨y, hy⟩ := h.2 (g * x),
+  conv_rhs at hy { rw ← (show y.1.1 = g, from y.1.2) },
+  rw ← mul_left_cancel hy,
+  exact y.2.2,
+end
+
+@[to_additive] lemma is_complement_singleton_right {g : G} : is_complement S {g} ↔ S = ⊤ :=
+begin
+  refine ⟨λ h, top_le_iff.mp (λ x hx, _), λ h, (congr_arg _ h).mpr is_complement_top_singleton⟩,
+  obtain ⟨y, hy⟩ := h.2 (x * g),
+  conv_rhs at hy { rw ← (show y.2.1 = g, from y.2.2) },
+  rw ← mul_right_cancel hy,
+  exact y.1.2,
+end
+
+@[to_additive] lemma is_complement_top_left : is_complement ⊤ S ↔ ∃ g : G, S = {g} :=
+begin
+  refine ⟨λ h, set.exists_eq_singleton.mpr ⟨_, λ a b ha hb, _⟩, _⟩,
+  { obtain ⟨a, ha⟩ := h.2 1,
+    exact ⟨a.2.1, a.2.2⟩ },
+  { have : (⟨⟨_, mem_top a⁻¹⟩, ⟨a, ha⟩⟩ : (⊤ : set G) × S) = ⟨⟨_, mem_top b⁻¹⟩, ⟨b, hb⟩⟩ :=
+    h.1 ((inv_mul_self a).trans (inv_mul_self b).symm),
+    exact subtype.ext_iff.mp ((prod.ext_iff.mp this).2) },
+  { rintro ⟨g, rfl⟩,
+    exact is_complement_top_singleton },
+end
+
+@[to_additive] lemma is_complement_top_right :
+  is_complement S ⊤ ↔ ∃ g : G, S = {g} :=
+begin
+  refine ⟨λ h, set.exists_eq_singleton.mpr ⟨_, λ a b ha hb, _⟩, _⟩,
+  { obtain ⟨a, ha⟩ := h.2 1,
+    exact ⟨a.1.1, a.1.2⟩ },
+  { have : (⟨⟨a, ha⟩, ⟨_, mem_top a⁻¹⟩⟩ : S × (⊤ : set G)) = ⟨⟨b, hb⟩, ⟨_, mem_top b⁻¹⟩⟩ :=
+    h.1 ((mul_inv_self a).trans (mul_inv_self b).symm),
+    exact subtype.ext_iff.mp ((prod.ext_iff.mp this).1) },
+  { rintro ⟨g, rfl⟩,
+    exact is_complement_singleton_top },
+end
+
+@[to_additive] lemma is_complement'_top_bot : is_complement' (⊤ : subgroup G) ⊥ :=
+is_complement_top_singleton
+
+@[to_additive] lemma is_complement'_bot_top : is_complement' (⊥ : subgroup G) ⊤ :=
+is_complement_singleton_top
+
+@[to_additive] lemma is_complement'_bot_left : is_complement' ⊥ H ↔ H = ⊤ :=
+is_complement_singleton_left.trans coe_eq_top
+
+@[to_additive] lemma is_complement'_bot_right : is_complement' H ⊥ ↔ H = ⊤ :=
+is_complement_singleton_right.trans coe_eq_top
+
+@[to_additive] lemma is_complement'_top_left : is_complement' ⊤ H ↔ H = ⊥ :=
+is_complement_top_left.trans coe_eq_singleton
+
+@[to_additive] lemma is_complement'_top_right : is_complement' H ⊤ ↔ H = ⊥ :=
+is_complement_top_right.trans coe_eq_singleton
 
 @[to_additive] lemma mem_left_transversals_iff_exists_unique_inv_mul_mem :
   S ∈ left_transversals T ↔ ∀ g : G, ∃! s : S, (s : G)⁻¹ * g ∈ T :=

--- a/src/group_theory/complement.lean
+++ b/src/group_theory/complement.lean
@@ -87,10 +87,8 @@ end
 @[to_additive] lemma is_complement_singleton_left {g : G} : is_complement {g} S ↔ S = ⊤ :=
 begin
   refine ⟨λ h, top_le_iff.mp (λ x hx, _), λ h, (congr_arg _ h).mpr is_complement_singleton_top⟩,
-  obtain ⟨y, hy⟩ := h.2 (g * x),
-  conv_rhs at hy { rw ← (show y.1.1 = g, from y.1.2) },
-  rw ← mul_left_cancel hy,
-  exact y.2.2,
+  obtain ⟨⟨⟨z, rfl : z = g⟩, y, _⟩, hy⟩ := h.2 (g * x),
+  rwa ← mul_left_cancel hy,
 end
 
 @[to_additive] lemma is_complement_singleton_right {g : G} : is_complement S {g} ↔ S = ⊤ :=

--- a/src/group_theory/complement.lean
+++ b/src/group_theory/complement.lean
@@ -114,8 +114,7 @@ begin
     exact is_complement_top_singleton },
 end
 
-@[to_additive] lemma is_complement_top_right :
-  is_complement S ⊤ ↔ ∃ g : G, S = {g} :=
+@[to_additive] lemma is_complement_top_right : is_complement S ⊤ ↔ ∃ g : G, S = {g} :=
 begin
   refine ⟨λ h, set.exists_eq_singleton.mpr ⟨_, λ a b ha hb, _⟩, _⟩,
   { obtain ⟨a, ha⟩ := h.2 1,

--- a/src/group_theory/complement.lean
+++ b/src/group_theory/complement.lean
@@ -132,16 +132,16 @@ is_complement_top_singleton
 @[to_additive] lemma is_complement'_bot_top : is_complement' (⊥ : subgroup G) ⊤ :=
 is_complement_singleton_top
 
-@[to_additive] lemma is_complement'_bot_left : is_complement' ⊥ H ↔ H = ⊤ :=
-is_complement_singleton_left.trans coe_eq_top
+@[simp, to_additive] lemma is_complement'_bot_left : is_complement' ⊥ H ↔ H = ⊤ :=
+is_complement_singleton_left.trans coe_eq_univ
 
-@[to_additive] lemma is_complement'_bot_right : is_complement' H ⊥ ↔ H = ⊤ :=
-is_complement_singleton_right.trans coe_eq_top
+@[simp, to_additive] lemma is_complement'_bot_right : is_complement' H ⊥ ↔ H = ⊤ :=
+is_complement_singleton_right.trans coe_eq_univ
 
-@[to_additive] lemma is_complement'_top_left : is_complement' ⊤ H ↔ H = ⊥ :=
+@[simp, to_additive] lemma is_complement'_top_left : is_complement' ⊤ H ↔ H = ⊥ :=
 is_complement_top_left.trans coe_eq_singleton
 
-@[to_additive] lemma is_complement'_top_right : is_complement' H ⊤ ↔ H = ⊥ :=
+@[simp, to_additive] lemma is_complement'_top_right : is_complement' H ⊤ ↔ H = ⊥ :=
 is_complement_top_right.trans coe_eq_singleton
 
 @[to_additive] lemma mem_left_transversals_iff_exists_unique_inv_mul_mem :

--- a/src/group_theory/complement.lean
+++ b/src/group_theory/complement.lean
@@ -104,7 +104,7 @@ end
 
 @[to_additive] lemma is_complement_top_left : is_complement ⊤ S ↔ ∃ g : G, S = {g} :=
 begin
-  refine ⟨λ h, set.exists_eq_singleton.mpr ⟨_, λ a b ha hb, _⟩, _⟩,
+  refine ⟨λ h, set.exists_eq_singleton_iff_nonempty_unique_mem.mpr ⟨_, λ a b ha hb, _⟩, _⟩,
   { obtain ⟨a, ha⟩ := h.2 1,
     exact ⟨a.2.1, a.2.2⟩ },
   { have : (⟨⟨_, mem_top a⁻¹⟩, ⟨a, ha⟩⟩ : (⊤ : set G) × S) = ⟨⟨_, mem_top b⁻¹⟩, ⟨b, hb⟩⟩ :=
@@ -116,7 +116,7 @@ end
 
 @[to_additive] lemma is_complement_top_right : is_complement S ⊤ ↔ ∃ g : G, S = {g} :=
 begin
-  refine ⟨λ h, set.exists_eq_singleton.mpr ⟨_, λ a b ha hb, _⟩, _⟩,
+  refine ⟨λ h, set.exists_eq_singleton_iff_nonempty_unique_mem.mpr ⟨_, λ a b ha hb, _⟩, _⟩,
   { obtain ⟨a, ha⟩ := h.2 1,
     exact ⟨a.1.1, a.1.2⟩ },
   { have : (⟨⟨a, ha⟩, ⟨_, mem_top a⁻¹⟩⟩ : S × (⊤ : set G)) = ⟨⟨b, hb⟩, ⟨_, mem_top b⁻¹⟩⟩ :=

--- a/src/group_theory/subgroup/basic.lean
+++ b/src/group_theory/subgroup/basic.lean
@@ -425,7 +425,7 @@ begin
   rw [← subgroup.coe_mk H y hy, subsingleton.elim (⟨y, hy⟩ : H) 1, subgroup.coe_one],
 end
 
-@[to_additive] lemma coe_eq_top {H : subgroup G} : (H : set G) = ⊤ ↔ H = ⊤ :=
+@[to_additive] lemma coe_eq_univ {H : subgroup G} : (H : set G) = set.univ ↔ H = ⊤ :=
 (set_like.ext'_iff.trans (by refl)).symm
 
 @[to_additive] lemma coe_eq_singleton {H : subgroup G} : (∃ g : G, (H : set G) = {g}) ↔ H = ⊥ :=

--- a/src/group_theory/subgroup/basic.lean
+++ b/src/group_theory/subgroup/basic.lean
@@ -425,6 +425,13 @@ begin
   rw [← subgroup.coe_mk H y hy, subsingleton.elim (⟨y, hy⟩ : H) 1, subgroup.coe_one],
 end
 
+@[to_additive] lemma coe_eq_top {H : subgroup G} : (H : set G) = ⊤ ↔ H = ⊤ :=
+(set_like.ext'_iff.trans (by refl)).symm
+
+@[to_additive] lemma coe_eq_singleton {H : subgroup G} : (∃ g : G, (H : set G) = {g}) ↔ H = ⊥ :=
+⟨λ ⟨g, hg⟩, by { haveI : subsingleton (H : set G) := by { rw hg, apply_instance },
+  exact H.eq_bot_of_subsingleton }, λ h, ⟨1, set_like.ext'_iff.mp h⟩⟩
+
 @[to_additive] instance fintype_bot : fintype (⊥ : subgroup G) := ⟨{1},
 by {rintro ⟨x, ⟨hx⟩⟩, exact finset.mem_singleton_self _}⟩
 


### PR DESCRIPTION
Adds iff lemmas for when bottom and top subgroups are complementary.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
