### PR TITLE
[Merged by Bors] - feat(group_theory/sylow): Sylow subgroups are nontrivial!

### DIFF
--- a/src/group_theory/sylow.lean
+++ b/src/group_theory/sylow.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Chris Hughes, Thomas Browning
 -/
 
+import data.set_like.fintype
 import group_theory.group_action.conj_act
 import group_theory.p_group
 
@@ -399,5 +400,33 @@ theorem exists_subgroup_card_pow_prime [fintype G] (p : ℕ) {n : ℕ} [fact p.p
   (hdvd : p ^ n ∣ card G) : ∃ K : subgroup G, fintype.card K = p ^ n :=
 let ⟨K, hK⟩ := exists_subgroup_card_pow_prime_le p hdvd ⊥ (by simp) n.zero_le in
 ⟨K, hK.1⟩
+
+lemma pow_dvd_card_of_pow_dvd_card [fintype G] {p n : ℕ} [fact p.prime] (P : sylow p G)
+  (hdvd : p ^ n ∣ card G) : p ^ n ∣ card P :=
+begin
+  obtain ⟨Q, hQ⟩ := exists_subgroup_card_pow_prime p hdvd,
+  obtain ⟨R, hR⟩ := (is_p_group.of_card hQ).exists_le_sylow,
+  obtain ⟨g, hg⟩ := exists_smul_eq G R P,
+  calc p ^ n = card Q : hQ.symm
+  ... ∣ card R : card_dvd_of_le hR
+  ... = card (g • R) : card_congr (R.equiv_smul g).to_equiv
+  ... = card P : by rw hg,
+end
+
+lemma dvd_card_of_dvd_card [fintype G] {p : ℕ} [fact p.prime] (P : sylow p G)
+  (hdvd : p ∣ card G) : p ∣ card P :=
+begin
+  rw ← pow_one p at hdvd,
+  have key := P.pow_dvd_card_of_pow_dvd_card hdvd,
+  rwa pow_one at key,
+end
+
+lemma ne_bot_of_dvd_card [fintype G] {p : ℕ} [hp : fact p.prime] (P : sylow p G)
+  (hdvd : p ∣ card G) : (P : subgroup G) ≠ ⊥ :=
+begin
+  refine λ h, hp.out.not_dvd_one _,
+  have key : p ∣ card (P : subgroup G) := P.dvd_card_of_dvd_card hdvd,
+  rwa [h, card_bot] at key,
+end
 
 end sylow

--- a/src/group_theory/sylow.lean
+++ b/src/group_theory/sylow.lean
@@ -406,11 +406,10 @@ lemma pow_dvd_card_of_pow_dvd_card [fintype G] {p n : ℕ} [fact p.prime] (P : s
 begin
   obtain ⟨Q, hQ⟩ := exists_subgroup_card_pow_prime p hdvd,
   obtain ⟨R, hR⟩ := (is_p_group.of_card hQ).exists_le_sylow,
-  obtain ⟨g, hg⟩ := exists_smul_eq G R P,
+  obtain ⟨g, rfl⟩ := exists_smul_eq G R P,
   calc p ^ n = card Q : hQ.symm
   ... ∣ card R : card_dvd_of_le hR
   ... = card (g • R) : card_congr (R.equiv_smul g).to_equiv
-  ... = card P : by rw hg,
 end
 
 lemma dvd_card_of_dvd_card [fintype G] {p : ℕ} [fact p.prime] (P : sylow p G)


### PR DESCRIPTION
These lemmas (finally!) connect the work of @ChrisHughes24 with the recent definition of Sylow subgroups, to show that Sylow subgroups are actually nontrivial!

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
