### PR TITLE
[Merged by Bors] - chore(data/equiv/mul_add): DRY

### DIFF
--- a/src/data/equiv/mul_add.lean
+++ b/src/data/equiv/mul_add.lean
@@ -540,19 +540,13 @@ variables [group_with_zero G]
 underlying type. -/
 @[simps {fully_applied := ff}]
 protected def mul_left₀ (a : G) (ha : a ≠ 0) : perm G :=
-{ to_fun := λ x, a * x,
-  inv_fun := λ x, a⁻¹ * x,
-  left_inv := λ x, by { dsimp, rw [← mul_assoc, inv_mul_cancel ha, one_mul] },
-  right_inv := λ x, by { dsimp, rw [← mul_assoc, mul_inv_cancel ha, one_mul] } }
+(units.mk0 a ha).mul_left
 
 /-- Right multiplication by a nonzero element in a `group_with_zero` is a permutation of the
 underlying type. -/
 @[simps {fully_applied := ff}]
 protected def mul_right₀ (a : G) (ha : a ≠ 0) : perm G :=
-{ to_fun := λ x, x * a,
-  inv_fun := λ x, x * a⁻¹,
-  left_inv := λ x, by { dsimp, rw [mul_assoc, mul_inv_cancel ha, mul_one] },
-  right_inv := λ x, by { dsimp, rw [mul_assoc, inv_mul_cancel ha, mul_one] } }
+(units.mk0 a ha).mul_right
 
 end group_with_zero
 


### PR DESCRIPTION
use `units.mul_left`/`units.mul_right` to define
`equiv.mul_left₀`/`equiv.mul_right₀`.



---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
