### PR TITLE
[Merged by Bors] - chore(measure_theory/function/special_functions): import inner_product_space.basic instead of inner_product_space.calculus

### DIFF
--- a/src/measure_theory/function/special_functions.lean
+++ b/src/measure_theory/function/special_functions.lean
@@ -6,7 +6,7 @@ Authors: Yury Kudryashov
 
 import analysis.special_functions.pow
 import analysis.special_functions.trigonometric.arctan
-import analysis.inner_product_space.calculus
+import analysis.inner_product_space.basic
 import measure_theory.constructions.borel_space
 
 /-!


### PR DESCRIPTION
Right now this changes almost nothing because other imports like `analysis.special_functions.pow` depend on calculus, but I am changing that in other PRs. `measure_theory/function/special_functions` will soon not depend on calculus at all.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
