### PR TITLE
[Merged by Bors] - feat(analysis/calculus/times_cont_diff): `equiv.prod_assoc` is smooth.

### DIFF
--- a/src/analysis/calculus/times_cont_diff.lean
+++ b/src/analysis/calculus/times_cont_diff.lean
@@ -1628,18 +1628,20 @@ times_cont_diff_snd.times_cont_diff_within_at
 
 /--
 The natural equivalence `(E × F) × G ≃ E × (F × G)` is smooth.
+
+Warning: if you think you need this lemma, it is likely that you can simplify your proof by
+reformulating the lemma that you're applying next using the tips in
+Note [continuity lemma statement]
 -/
-lemma times_cont_diff_prod_assoc :
-  times_cont_diff 𝕜 ⊤ $ equiv.prod_assoc E F G :=
-(linear_isometry_equiv.coe_prod_assoc 𝕜 E F G) ▸
+lemma times_cont_diff_prod_assoc : times_cont_diff 𝕜 ⊤ $ equiv.prod_assoc E F G :=
 (linear_isometry_equiv.prod_assoc 𝕜 E F G).times_cont_diff
 
 /--
 The natural equivalence `E × (F × G) ≃ (E × F) × G` is smooth.
+
+Warning: see remarks attached to `times_cont_diff_prod_assoc`
 -/
-lemma times_cont_diff_prod_assoc_symm :
-  times_cont_diff 𝕜 ⊤ $ (equiv.prod_assoc E F G).symm :=
-(linear_isometry_equiv.coe_prod_assoc 𝕜 E F G).symm ▸
+lemma times_cont_diff_prod_assoc_symm : times_cont_diff 𝕜 ⊤ $ (equiv.prod_assoc E F G).symm :=
 (linear_isometry_equiv.prod_assoc 𝕜 E F G).symm.times_cont_diff
 
 /--

--- a/src/analysis/calculus/times_cont_diff.lean
+++ b/src/analysis/calculus/times_cont_diff.lean
@@ -1627,6 +1627,22 @@ lemma times_cont_diff_within_at_snd {s : set (E × F)} {p : E × F} {n : with_to
 times_cont_diff_snd.times_cont_diff_within_at
 
 /--
+The natural equivalence `(E × F) × G ≃ E × (F × G)` is smooth.
+-/
+lemma times_cont_diff_prod_assoc :
+  times_cont_diff 𝕜 ⊤ $ equiv.prod_assoc E F G :=
+(linear_isometry_equiv.coe_prod_assoc 𝕜 E F G) ▸
+(linear_isometry_equiv.prod_assoc 𝕜 E F G).times_cont_diff
+
+/--
+The natural equivalence `E × (F × G) ≃ (E × F) × G` is smooth.
+-/
+lemma times_cont_diff_prod_assoc_symm :
+  times_cont_diff 𝕜 ⊤ $ (equiv.prod_assoc E F G).symm :=
+(linear_isometry_equiv.coe_prod_assoc 𝕜 E F G).symm ▸
+(linear_isometry_equiv.prod_assoc 𝕜 E F G).symm.times_cont_diff
+
+/--
 The identity is `C^∞`.
 -/
 lemma times_cont_diff_id {n : with_top ℕ} : times_cont_diff 𝕜 n (id : E → E) :=

--- a/src/analysis/normed_space/linear_isometry.lean
+++ b/src/analysis/normed_space/linear_isometry.lean
@@ -415,4 +415,24 @@ variables {R}
 
 @[simp] lemma symm_neg : (neg R : E ≃ₗᵢ[R] E).symm = neg R := rfl
 
+variables (R E E₂ E₃)
+
+/-- The natural equivalence `(E × E₂) × E₃ ≃ E × (E₂ × E₃)` is a linear isometry. -/
+@[simps] noncomputable def prod_assoc [module R E₂] [module R E₃] :
+  (E × E₂) × E₃ ≃ₗᵢ[R] E × E₂ × E₃ :=
+{ to_fun    := equiv.prod_assoc E E₂ E₃,
+  inv_fun   := (equiv.prod_assoc E E₂ E₃).symm,
+  map_add'  := by simp,
+  map_smul' := by simp,
+  norm_map' :=
+    begin
+      rintros ⟨⟨e, f⟩, g⟩,
+      simp only [linear_equiv.coe_mk, equiv.prod_assoc_apply, prod.semi_norm_def, max_assoc],
+    end,
+  .. equiv.prod_assoc E E₂ E₃, }
+
+@[simp] lemma coe_prod_assoc [module R E₂] [module R E₃] :
+  (prod_assoc R E E₂ E₃ : (E × E₂) × E₃ → E × E₂ × E₃) = equiv.prod_assoc E E₂ E₃ :=
+rfl
+
 end linear_isometry_equiv

--- a/src/analysis/normed_space/linear_isometry.lean
+++ b/src/analysis/normed_space/linear_isometry.lean
@@ -418,8 +418,7 @@ variables {R}
 variables (R E E₂ E₃)
 
 /-- The natural equivalence `(E × E₂) × E₃ ≃ E × (E₂ × E₃)` is a linear isometry. -/
-@[simps] noncomputable def prod_assoc [module R E₂] [module R E₃] :
-  (E × E₂) × E₃ ≃ₗᵢ[R] E × E₂ × E₃ :=
+noncomputable def prod_assoc [module R E₂] [module R E₃] : (E × E₂) × E₃ ≃ₗᵢ[R] E × E₂ × E₃ :=
 { to_fun    := equiv.prod_assoc E E₂ E₃,
   inv_fun   := (equiv.prod_assoc E E₂ E₃).symm,
   map_add'  := by simp,
@@ -433,6 +432,10 @@ variables (R E E₂ E₃)
 
 @[simp] lemma coe_prod_assoc [module R E₂] [module R E₃] :
   (prod_assoc R E E₂ E₃ : (E × E₂) × E₃ → E × E₂ × E₃) = equiv.prod_assoc E E₂ E₃ :=
+rfl
+
+@[simp] lemma coe_prod_assoc_symm [module R E₂] [module R E₃] :
+  ((prod_assoc R E E₂ E₃).symm : E × E₂ × E₃ → (E × E₂) × E₃) = (equiv.prod_assoc E E₂ E₃).symm :=
 rfl
 
 end linear_isometry_equiv


### PR DESCRIPTION
Formalized as part of the Sphere Eversion project.



---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
