### PR TITLE
[Merged by Bors] - refactor(linear_algebra/matrix/nonsingular_inverse): clean up

### DIFF
--- a/src/algebra/invertible.lean
+++ b/src/algebra/invertible.lean
@@ -202,6 +202,15 @@ lemma commute_inv_of {M : Type*} [has_one M] [has_mul M] (m : M) [invertible m] 
 calc m * ⅟m = 1       : mul_inv_of_self m
         ... = ⅟ m * m : (inv_of_mul_self m).symm
 
+section monoid_with_zero
+variable [monoid_with_zero α]
+
+/-- A variant of `ring.inverse_unit`. -/
+@[simp] lemma ring.inverse_invertible (x : α) [invertible x] : ring.inverse x = ⅟x :=
+ring.inverse_unit (unit_of_invertible _)
+
+end monoid_with_zero
+
 section group_with_zero
 
 variable [group_with_zero α]

--- a/src/algebra/lie/classical.lean
+++ b/src/algebra/lie/classical.lean
@@ -172,11 +172,7 @@ begin
 end
 
 lemma is_unit_Pso {i : R} (hi : i*i = -1) : is_unit (Pso p q R i) :=
-⟨{ val     := Pso p q R i,
-   inv     := Pso p q R (-i),
-   val_inv := Pso_inv p q R hi,
-   inv_val := by { apply matrix.nonsing_inv_left_right, exact Pso_inv p q R hi, }, },
-rfl⟩
+@is_unit_of_invertible _ _ _ (invertible_of_right_inverse _ _ (Pso_inv p q R hi))
 
 lemma indefinite_diagonal_transform {i : R} (hi : i*i = -1) :
   (Pso p q R i)ᵀ ⬝ (indefinite_diagonal p q R) ⬝ (Pso p q R i) = 1 :=
@@ -258,11 +254,7 @@ begin
 end
 
 lemma is_unit_PD [fintype l] [invertible (2 : R)] : is_unit (PD l R) :=
-⟨{ val     := PD l R,
-   inv     := ⅟(2 : R) • (PD l R)ᵀ,
-   val_inv := PD_inv l R,
-   inv_val := by { apply matrix.nonsing_inv_left_right, exact PD_inv l R, }, },
-rfl⟩
+@is_unit_of_invertible _ _ _ (invertible_of_right_inverse _ _ (PD_inv l R))
 
 /-- An equivalence between two possible definitions of the classical Lie algebra of type D. -/
 noncomputable def type_D_equiv_so' [fintype l] [invertible (2 : R)] :
@@ -322,11 +314,7 @@ begin
 end
 
 lemma is_unit_PB [invertible (2 : R)] : is_unit (PB l R) :=
-⟨{ val     := PB l R,
-   inv     := matrix.from_blocks 1 0 0 (PD l R)⁻¹,
-   val_inv := PB_inv l R,
-   inv_val := by { apply matrix.nonsing_inv_left_right, exact PB_inv l R, }, },
-rfl⟩
+@is_unit_of_invertible _ _ _ (invertible_of_right_inverse _ _ (PB_inv l R))
 
 lemma JB_transform : (PB l R)ᵀ ⬝ (JB l R) ⬝ (PB l R) = (2 : R) • matrix.from_blocks 1 0 0 (S l R) :=
 by simp [PB, JB, JD_transform, matrix.from_blocks_transpose, matrix.from_blocks_multiply,

--- a/src/linear_algebra/general_linear_group.lean
+++ b/src/linear_algebra/general_linear_group.lean
@@ -83,7 +83,7 @@ variables (A B : GL n R)
 lemma coe_inv : ↑(A⁻¹) = (↑A : matrix n n R)⁻¹ :=
 begin
   letI := A.invertible,
-  exact inv_eq_nonsing_inv_of_invertible (↑A : matrix n n R),
+  exact inv_of_eq_nonsing_inv (↑A : matrix n n R),
 end
 
 end coe_lemmas

--- a/src/linear_algebra/matrix/nonsingular_inverse.lean
+++ b/src/linear_algebra/matrix/nonsingular_inverse.lean
@@ -76,11 +76,7 @@ def invertible_of_det_invertible [invertible A.det] : invertible A :=
     by rw [smul_mul_assoc, matrix.mul_eq_mul, adjugate_mul, smul_smul, inv_of_mul_self, one_smul] }
 
 lemma inv_of_eq [invertible A.det] [invertible A] : ⅟A = ⅟A.det • A.adjugate :=
-begin
-  letI := invertible_of_det_invertible A,
-  have : ⅟A = ⅟A.det • A.adjugate := rfl,
-  convert this,
-end
+by { letI := invertible_of_det_invertible A, convert (rfl : ⅟A = ⅟A.det • A.adjugate) }
 
 /-- `A.det` is invertible if `A` has a left inverse. -/
 def det_invertible_of_left_inverse (h : B ⬝ A = 1) : invertible A.det :=
@@ -99,11 +95,7 @@ def det_invertible_of_invertible [invertible A] : invertible A.det :=
 det_invertible_of_left_inverse A (⅟A) (inv_of_mul_self _)
 
 lemma det_inv_of [invertible A] [invertible A.det] : (⅟A).det = ⅟A.det :=
-begin
-  letI := det_invertible_of_invertible A,
-  have : (⅟A).det = ⅟A.det := rfl,
-  convert this,
-end
+by { letI := det_invertible_of_invertible A, convert (rfl : (⅟A).det = ⅟A.det) }
 
 variables {A B}
 

--- a/src/linear_algebra/matrix/nonsingular_inverse.lean
+++ b/src/linear_algebra/matrix/nonsingular_inverse.lean
@@ -76,7 +76,7 @@ def invertible_of_det_invertible [invertible A.det] : invertible A :=
     by rw [smul_mul_assoc, matrix.mul_eq_mul, adjugate_mul, smul_smul, inv_of_mul_self, one_smul] }
 
 lemma inv_of_eq [invertible A.det] [invertible A] : ⅟A = ⅟A.det • A.adjugate :=
-by { letI := invertible_of_det_invertible A, convert (rfl : ⅟A = ⅟A.det • A.adjugate) }
+by { letI := invertible_of_det_invertible A, convert (rfl : ⅟A = _) }
 
 /-- `A.det` is invertible if `A` has a left inverse. -/
 def det_invertible_of_left_inverse (h : B ⬝ A = 1) : invertible A.det :=
@@ -95,7 +95,7 @@ def det_invertible_of_invertible [invertible A] : invertible A.det :=
 det_invertible_of_left_inverse A (⅟A) (inv_of_mul_self _)
 
 lemma det_inv_of [invertible A] [invertible A.det] : (⅟A).det = ⅟A.det :=
-by { letI := det_invertible_of_invertible A, convert (rfl : (⅟A).det = ⅟A.det) }
+by { letI := det_invertible_of_invertible A, convert (rfl : _ = ⅟A.det) }
 
 variables {A B}
 

--- a/src/linear_algebra/matrix/nonsingular_inverse.lean
+++ b/src/linear_algebra/matrix/nonsingular_inverse.lean
@@ -62,10 +62,10 @@ variables (A : matrix n n α) (B : matrix n n α)
 section invertible
 
 /-- A copy of `inv_of_mul_self` using `⬝` not `*`. -/
-protected lemma inv_of_mul_self [invertible A] : ⅟A ⬝ A = 1 := inv_of_mul_self A
+@[simp] protected lemma inv_of_mul_self [invertible A] : ⅟A ⬝ A = 1 := inv_of_mul_self A
 
 /-- A copy of `mul_inv_of_self` using `⬝` not `*`. -/
-protected lemma mul_inv_of_self [invertible A] : A ⬝ ⅟A = 1 := mul_inv_of_self A
+@[simp] protected lemma mul_inv_of_self [invertible A] : A ⬝ ⅟A = 1 := mul_inv_of_self A
 
 /-- If `A.det` has a constructive inverse, produce one for `A`. -/
 def invertible_of_det_invertible [invertible A.det] : invertible A :=

--- a/src/linear_algebra/matrix/nonsingular_inverse.lean
+++ b/src/linear_algebra/matrix/nonsingular_inverse.lean
@@ -23,9 +23,10 @@ will result in a multiplicative inverse to `A`.
 Note that there are at least three different inverses in mathlib:
 
 * `A⁻¹` (`has_inv.inv`): alone, this satisfies no properties, although it is usually used in
-  conjunction with `group` or `group_with_zero`. On matrices, this is defined to be zero when no inverse exists.
-* `⅟A` (`inv_of`): this is only available in the presence of `[invertible A]`, which guarantees an inverse
-  exists.
+  conjunction with `group` or `group_with_zero`. On matrices, this is defined to be zero when no
+  inverse exists.
+* `⅟A` (`inv_of`): this is only available in the presence of `[invertible A]`, which guarantees an
+  inverse exists.
 * `ring.inverse A`: this is defined on any `monoid_with_zero`, and just like `⁻¹` on matrices, is
   defined to be zero when no inverse exists.
 

--- a/src/linear_algebra/matrix/nonsingular_inverse.lean
+++ b/src/linear_algebra/matrix/nonsingular_inverse.lean
@@ -62,10 +62,10 @@ variables (A : matrix n n α) (B : matrix n n α)
 section invertible
 
 /-- A copy of `inv_of_mul_self` using `⬝` not `*`. -/
-@[simp] protected lemma inv_of_mul_self [invertible A] : ⅟A ⬝ A = 1 := inv_of_mul_self A
+protected lemma inv_of_mul_self [invertible A] : ⅟A ⬝ A = 1 := inv_of_mul_self A
 
 /-- A copy of `mul_inv_of_self` using `⬝` not `*`. -/
-@[simp] protected lemma mul_inv_of_self [invertible A] : A ⬝ ⅟A = 1 := mul_inv_of_self A
+protected lemma mul_inv_of_self [invertible A] : A ⬝ ⅟A = 1 := mul_inv_of_self A
 
 /-- If `A.det` has a constructive inverse, produce one for `A`. -/
 def invertible_of_det_invertible [invertible A.det] : invertible A :=

--- a/src/linear_algebra/matrix/nonsingular_inverse.lean
+++ b/src/linear_algebra/matrix/nonsingular_inverse.lean
@@ -144,20 +144,22 @@ end
 
 /-! #### Variants of the statements above with `is_unit`-/
 
+lemma is_unit_det_of_invertible [invertible A] : is_unit A.det :=
+@is_unit_of_invertible _ _ _ (det_invertible_of_invertible A)
+
+variables {A B}
+
 lemma is_unit_det_of_left_inverse (h : B ⬝ A = 1) : is_unit A.det :=
 @is_unit_of_invertible _ _ _ (det_invertible_of_left_inverse _ _ h)
 
 lemma is_unit_det_of_right_inverse (h : A ⬝ B = 1) : is_unit A.det :=
 @is_unit_of_invertible _ _ _ (det_invertible_of_right_inverse _ _ h)
 
-lemma is_unit_det_of_invertible [invertible A] : is_unit A.det :=
-@is_unit_of_invertible _ _ _ (det_invertible_of_invertible A)
-
 lemma det_ne_zero_of_left_inverse [nontrivial α] (h : B ⬝ A = 1) : A.det ≠ 0 :=
-(is_unit_det_of_left_inverse A B h).ne_zero
+(is_unit_det_of_left_inverse h).ne_zero
 
 lemma det_ne_zero_of_right_inverse [nontrivial α] (h : A ⬝ B = 1) : A.det ≠ 0 :=
-(is_unit_det_of_right_inverse A B h).ne_zero
+(is_unit_det_of_right_inverse h).ne_zero
 
 end invertible
 

--- a/src/linear_algebra/matrix/nonsingular_inverse.lean
+++ b/src/linear_algebra/matrix/nonsingular_inverse.lean
@@ -11,13 +11,33 @@ import linear_algebra.matrix.adjugate
 /-!
 # Nonsingular inverses
 
-In this file, we define an inverse for square matrices of invertible
-determinant. For matrices that are not square or not of full rank, there is a
-more general notion of pseudoinverses which we do not consider here.
+In this file, we define an inverse for square matrices of invertible determinant.
+
+For matrices that are not square or not of full rank, there is a more general notion of
+pseudoinverses which we do not consider here.
 
 The definition of inverse used in this file is the adjugate divided by the determinant.
 We show that dividing the adjugate by `det A` (if possible), giving a matrix `A⁻¹` (`nonsing_inv`),
 will result in a multiplicative inverse to `A`.
+
+Note that there are at least three different inverses in mathlib:
+
+* `A⁻¹` (`has_inv.inv`): alone, this satisfies no properties, although it is usually used in
+  conjunction with `group` or `group_with_zero`. On matrices, this is defined to be zero when no inverse exists.
+* `⅟A` (`inv_of`): this is only available in the presence of `[invertible A]`, which guarantees an inverse
+  exists.
+* `ring.inverse A`: this is defined on any `monoid_with_zero`, and just like `⁻¹` on matrices, is
+  defined to be zero when no inverse exists.
+
+We start by working with `invertible`, and show the main results:
+
+* `matrix.invertible_of_det_invertible`
+* `matrix.det_invertible_of_invertible`
+* `matrix.is_unit_iff_is_unit_det`
+* `matrix.mul_eq_one_comm`
+
+After this we define `matrix.has_inv` and show it matches `⅟A` and `ring.inverse A`.
+The rest of the results in the file are then about `A⁻¹`
 
 ## References
 
@@ -36,86 +56,15 @@ open equiv equiv.perm finset
 
 variables (A : matrix n n α) (B : matrix n n α)
 
-open_locale classical
+/-! ### Matrices are `invertible` iff their determinants are -/
 
-lemma is_unit_det_transpose (h : is_unit A.det) : is_unit Aᵀ.det :=
-by { rw det_transpose, exact h, }
+section invertible
 
+/-- A copy of `inv_of_mul_self` using `⬝` not `*`. -/
+protected lemma inv_of_mul_self [invertible A] : ⅟A ⬝ A = 1 := inv_of_mul_self A
 
-/-- The inverse of a square matrix, when it is invertible (and zero otherwise).-/
-noncomputable instance : has_inv (matrix n n α) := ⟨λ A, ring.inverse A.det • A.adjugate⟩
-
-lemma inv_def (A : matrix n n α) : A⁻¹ = ring.inverse A.det • A.adjugate := rfl
-
-lemma nonsing_inv_apply_not_is_unit (h : ¬ is_unit A.det) :
-  A⁻¹ = 0 :=
-by rw [inv_def, ring.inverse_non_unit _ h, zero_smul]
-
-lemma nonsing_inv_apply (h : is_unit A.det) :
-  A⁻¹ = (↑h.unit⁻¹ : α) • A.adjugate :=
-begin
-  rw [inv_def, ←ring.inverse_unit h.unit],
-  refl,
-end
-
-lemma transpose_nonsing_inv : (A⁻¹)ᵀ = (Aᵀ)⁻¹ :=
-by rw [inv_def, inv_def, transpose_smul, det_transpose, adjugate_transpose]
-
-lemma conj_transpose_nonsing_inv [star_ring α] : (A⁻¹)ᴴ = (Aᴴ)⁻¹ :=
-by rw [inv_def, inv_def, conj_transpose_smul, det_conj_transpose, adjugate_conj_transpose,
-       ring.inverse_star]
-
-/-- The `nonsing_inv` of `A` is a right inverse. -/
-@[simp] lemma mul_nonsing_inv (h : is_unit A.det) : A ⬝ A⁻¹ = 1 :=
-by rw [A.nonsing_inv_apply h, mul_smul, mul_adjugate, smul_smul,
-       units.inv_mul_of_eq h.unit_spec, one_smul]
-
-/-- The `nonsing_inv` of `A` is a left inverse. -/
-@[simp] lemma nonsing_inv_mul (h : is_unit A.det) : A⁻¹ ⬝ A = 1 :=
-calc A⁻¹ ⬝ A = (Aᵀ ⬝ (Aᵀ)⁻¹)ᵀ : by { rw [transpose_mul,
-                                    Aᵀ.transpose_nonsing_inv,
-                                    transpose_transpose], }
-         ... = 1ᵀ             : by { rw Aᵀ.mul_nonsing_inv, exact A.is_unit_det_transpose h, }
-         ... = 1              : transpose_one
-
-lemma nonsing_inv_cancel_or_zero :
-  (A⁻¹ ⬝ A = 1 ∧ A ⬝ A⁻¹ = 1) ∨ A⁻¹ = 0 :=
-begin
-  by_cases h : is_unit A.det,
-  { exact or.inl ⟨nonsing_inv_mul _ h, mul_nonsing_inv _ h⟩ },
-  { exact or.inr (nonsing_inv_apply_not_is_unit _ h) }
-end
-
-lemma det_nonsing_inv_mul_det (h : is_unit A.det) : A⁻¹.det * A.det = 1 :=
-by rw [←det_mul, A.nonsing_inv_mul h, det_one]
-
-@[simp] lemma det_nonsing_inv : A⁻¹.det = ring.inverse A.det :=
-begin
-  rw [inv_def, det_smul, det_adjugate],
-  casesI is_empty_or_nonempty n,
-  { rw [fintype.card_eq_zero, zero_tsub, pow_zero, det_is_empty, pow_zero, ring.inverse_one,
-      one_mul] },
-  have hc_pos : 0 < fintype.card n := fintype.card_pos,
-  by_cases h : is_unit A.det,
-  { obtain ⟨u, hu⟩ := h,
-    rw [←hu, ring.inverse_unit, ←units.coe_pow, ←units.coe_pow, ←units.coe_mul,
-      inv_pow, ←inv_pow_sub _ tsub_le_self, tsub_tsub_cancel_of_le hc_pos.nat_succ_le, pow_one], },
-  { rw [ring.inverse_non_unit _ h, zero_pow hc_pos, zero_mul], },
-end
-
-lemma is_unit_nonsing_inv_det (h : is_unit A.det) : is_unit A⁻¹.det :=
-is_unit_of_mul_eq_one _ _ (A.det_nonsing_inv_mul_det h)
-
-@[simp] lemma nonsing_inv_nonsing_inv (h : is_unit A.det) : (A⁻¹)⁻¹ = A :=
-calc (A⁻¹)⁻¹ = 1 ⬝ (A⁻¹)⁻¹        : by rw matrix.one_mul
-         ... = A ⬝ A⁻¹ ⬝ (A⁻¹)⁻¹  : by rw A.mul_nonsing_inv h
-         ... = A                  : by { rw [matrix.mul_assoc,
-                                         (A⁻¹).mul_nonsing_inv (A.is_unit_nonsing_inv_det h),
-                                         matrix.mul_one], }
-
-lemma is_unit_nonsing_inv_det_iff {A : matrix n n α} :
-  is_unit A⁻¹.det ↔ is_unit A.det :=
-by rw [matrix.det_nonsing_inv, is_unit_ring_inverse]
+/-- A copy of `mul_inv_of_self` using `⬝` not `*`. -/
+protected lemma mul_inv_of_self [invertible A] : A ⬝ ⅟A = 1 := mul_inv_of_self A
 
 /-- If `A.det` has a constructive inverse, produce one for `A`. -/
 def invertible_of_det_invertible [invertible A.det] : invertible A :=
@@ -124,6 +73,13 @@ def invertible_of_det_invertible [invertible A.det] : invertible A :=
     by rw [mul_smul_comm, matrix.mul_eq_mul, mul_adjugate, smul_smul, inv_of_mul_self, one_smul],
   inv_of_mul_self :=
     by rw [smul_mul_assoc, matrix.mul_eq_mul, adjugate_mul, smul_smul, inv_of_mul_self, one_smul] }
+
+lemma inv_of_eq [invertible A.det] [invertible A] : ⅟A = ⅟A.det • A.adjugate :=
+begin
+  letI := invertible_of_det_invertible A,
+  have : ⅟A = ⅟A.det • A.adjugate := rfl,
+  convert this,
+end
 
 /-- `A.det` is invertible if `A` has a left inverse. -/
 def det_invertible_of_left_inverse (h : B ⬝ A = 1) : invertible A.det :=
@@ -141,21 +97,39 @@ def det_invertible_of_right_inverse (h : A ⬝ B = 1) : invertible A.det :=
 def det_invertible_of_invertible [invertible A] : invertible A.det :=
 det_invertible_of_left_inverse A (⅟A) (inv_of_mul_self _)
 
+lemma det_inv_of [invertible A] [invertible A.det] : (⅟A).det = ⅟A.det :=
+begin
+  letI := det_invertible_of_invertible A,
+  have : (⅟A).det = ⅟A.det := rfl,
+  convert this,
+end
+
+variables {A B}
+
+lemma mul_eq_one_comm : A ⬝ B = 1 ↔ B ⬝ A = 1 :=
+suffices ∀ A B, A ⬝ B = 1 → B ⬝ A = 1, from ⟨this A B, this B A⟩, assume A B h,
+begin
+  letI : invertible B.det := det_invertible_of_left_inverse _ _ h,
+  letI : invertible B := invertible_of_det_invertible B,
+  calc B ⬝ A = (B ⬝ A) ⬝ (B ⬝ ⅟B) : by rw [matrix.mul_inv_of_self, matrix.mul_one]
+        ... = B ⬝ ((A ⬝ B) ⬝ ⅟B) : by simp only [matrix.mul_assoc]
+        ... = B ⬝ ⅟B : by rw [h, matrix.one_mul]
+        ... = 1 : matrix.mul_inv_of_self B,
+end
+
+variables (A B)
+
+/-- We can construct an instance of invertible A if A has a left inverse. -/
+def invertible_of_left_inverse (h : B ⬝ A = 1) : invertible A :=
+⟨B, h, mul_eq_one_comm.mp h⟩
+
+/-- We can construct an instance of invertible A if A has a right inverse. -/
+def invertible_of_right_inverse (h : A ⬝ B = 1) : invertible A :=
+⟨B, mul_eq_one_comm.mp h, h⟩
+
 /-- Given a proof that `A.det` has a constructive inverse, lift `A` to `units (matrix n n α)`-/
 def unit_of_det_invertible [invertible A.det] : units (matrix n n α) :=
 @unit_of_invertible _ _ A (invertible_of_det_invertible A)
-
-/-- A matrix whose determinant is a unit is itself a unit. This is a noncomputable version of
-`matrix.units_of_det_invertible`, with the inverse defeq to `matrix.nonsing_inv`. -/
-noncomputable def nonsing_inv_unit (h : is_unit A.det) : units (matrix n n α) :=
-{ val     := A,
-  inv     := A⁻¹,
-  val_inv := by { rw matrix.mul_eq_mul, apply A.mul_nonsing_inv h, },
-  inv_val := by { rw matrix.mul_eq_mul, apply A.nonsing_inv_mul h, } }
-
-lemma unit_of_det_invertible_eq_nonsing_inv_unit [invertible A.det] :
-  unit_of_det_invertible A = nonsing_inv_unit A (is_unit_of_invertible _) :=
-by { ext, refl }
 
 /-- When lowered to a prop, `matrix.det_invertible_of_invertible` and
 `matrix.invertible_of_det_invertible` form an `iff`. -/
@@ -168,41 +142,7 @@ begin
     apply invertible_of_det_invertible, },
 end
 
-/-- The nonsingular inverse is the same as the general `ring.inverse`. -/
-lemma nonsing_inv_eq_ring_inverse : A⁻¹ = ring.inverse A :=
-begin
-  by_cases h_det : is_unit A.det,
-  { change ↑(nonsing_inv_unit A h_det)⁻¹ = _,
-    obtain ⟨u, rfl⟩ := (is_unit_iff_is_unit_det _).mpr h_det,
-    rw [ring.inverse_unit _, units.inv_unique],
-    refl },
-  { have h := mt (is_unit_iff_is_unit_det _).mp h_det,
-    rw [ring.inverse_non_unit _ h, nonsing_inv_apply_not_is_unit A h_det], },
-end
-
-/- `is_unit_of_invertible A`
-   converts the "stronger" condition `invertible A` to proposition `is_unit A`. -/
-
-/-- `matrix.is_unit_det_of_invertible` converts `invertible A` to `is_unit A.det`. -/
-lemma is_unit_det_of_invertible [invertible A] : is_unit A.det :=
-@is_unit_of_invertible _ _ _(det_invertible_of_invertible A)
-
-@[simp]
-lemma inv_eq_nonsing_inv_of_invertible [invertible A] : ⅟ A = A⁻¹ :=
-begin
-  suffices : is_unit A,
-  { rw [←this.mul_left_inj, inv_of_mul_self, matrix.mul_eq_mul, nonsing_inv_mul],
-    rwa ←is_unit_iff_is_unit_det },
-  exact is_unit_of_invertible _
-end
-
-variables {A} {B}
-
-/- `is_unit.invertible` lifts the proposition `is_unit A` to a constructive inverse of `A`. -/
-
-/-- "Lift" the proposition `is_unit A.det` to a constructive inverse of `A`. -/
-noncomputable def invertible_of_is_unit_det  (h : is_unit A.det) : invertible A :=
-⟨A⁻¹, nonsing_inv_mul A h, mul_nonsing_inv A h⟩
+/-! #### Variants of the statements above with `is_unit`-/
 
 lemma is_unit_det_of_left_inverse (h : B ⬝ A = 1) : is_unit A.det :=
 @is_unit_of_invertible _ _ _ (det_invertible_of_left_inverse _ _ h)
@@ -210,65 +150,160 @@ lemma is_unit_det_of_left_inverse (h : B ⬝ A = 1) : is_unit A.det :=
 lemma is_unit_det_of_right_inverse (h : A ⬝ B = 1) : is_unit A.det :=
 @is_unit_of_invertible _ _ _ (det_invertible_of_right_inverse _ _ h)
 
+lemma is_unit_det_of_invertible [invertible A] : is_unit A.det :=
+@is_unit_of_invertible _ _ _ (det_invertible_of_invertible A)
+
 lemma det_ne_zero_of_left_inverse [nontrivial α] (h : B ⬝ A = 1) : A.det ≠ 0 :=
-is_unit.ne_zero (matrix.is_unit_det_of_left_inverse h)
+(is_unit_det_of_left_inverse A B h).ne_zero
 
 lemma det_ne_zero_of_right_inverse [nontrivial α] (h : A ⬝ B = 1) : A.det ≠ 0 :=
-is_unit.ne_zero (matrix.is_unit_det_of_right_inverse h)
+(is_unit_det_of_right_inverse A B h).ne_zero
 
-lemma nonsing_inv_left_right (h : A ⬝ B = 1) : B ⬝ A = 1 :=
+end invertible
+
+open_locale classical
+
+lemma is_unit_det_transpose (h : is_unit A.det) : is_unit Aᵀ.det :=
+by { rw det_transpose, exact h, }
+
+/-! ### A noncomputable `has_inv` instance  -/
+
+/-- The inverse of a square matrix, when it is invertible (and zero otherwise).-/
+noncomputable instance : has_inv (matrix n n α) := ⟨λ A, ring.inverse A.det • A.adjugate⟩
+
+lemma inv_def (A : matrix n n α) : A⁻¹ = ring.inverse A.det • A.adjugate := rfl
+
+lemma nonsing_inv_apply_not_is_unit (h : ¬ is_unit A.det) :
+  A⁻¹ = 0 :=
+by rw [inv_def, ring.inverse_non_unit _ h, zero_smul]
+
+lemma nonsing_inv_apply (h : is_unit A.det) :
+  A⁻¹ = (↑h.unit⁻¹ : α) • A.adjugate :=
+by rw [inv_def, ←ring.inverse_unit h.unit, is_unit.unit_spec]
+
+/-- The nonsingular inverse is the same as `inv_of` when `A` is invertible. -/
+@[simp] lemma inv_of_eq_nonsing_inv [invertible A] : ⅟A = A⁻¹ :=
 begin
-  have h' : is_unit B.det := is_unit_det_of_left_inverse h,
-  calc B ⬝ A = (B ⬝ A) ⬝ (B ⬝ B⁻¹) : by simp only [h', matrix.mul_one, mul_nonsing_inv]
-        ... = B ⬝ ((A ⬝ B) ⬝ B⁻¹) : by simp only [matrix.mul_assoc]
-        ... = B ⬝ B⁻¹ : by simp only [h, matrix.one_mul]
-        ... = 1 : mul_nonsing_inv B h',
+  letI := det_invertible_of_invertible A,
+  rw [inv_def, ring.inverse_invertible, inv_of_eq],
 end
 
-lemma nonsing_inv_right_left (h : B ⬝ A = 1) : A ⬝ B = 1 :=
-nonsing_inv_left_right h
+/-- The nonsingular inverse is the same as the general `ring.inverse`. -/
+lemma nonsing_inv_eq_ring_inverse : A⁻¹ = ring.inverse A :=
+begin
+  by_cases h_det : is_unit A.det,
+  { casesI (A.is_unit_iff_is_unit_det.mpr h_det).nonempty_invertible,
+    rw [←inv_of_eq_nonsing_inv, ring.inverse_invertible], },
+  { have h := mt A.is_unit_iff_is_unit_det.mp h_det,
+    rw [ring.inverse_non_unit _ h, nonsing_inv_apply_not_is_unit A h_det], },
+end
+
+lemma transpose_nonsing_inv : (A⁻¹)ᵀ = (Aᵀ)⁻¹ :=
+by rw [inv_def, inv_def, transpose_smul, det_transpose, adjugate_transpose]
+
+lemma conj_transpose_nonsing_inv [star_ring α] : (A⁻¹)ᴴ = (Aᴴ)⁻¹ :=
+by rw [inv_def, inv_def, conj_transpose_smul, det_conj_transpose, adjugate_conj_transpose,
+       ring.inverse_star]
+
+/-- The `nonsing_inv` of `A` is a right inverse. -/
+@[simp] lemma mul_nonsing_inv (h : is_unit A.det) : A ⬝ A⁻¹ = 1 :=
+begin
+  casesI (A.is_unit_iff_is_unit_det.mpr h).nonempty_invertible,
+  rw [←inv_of_eq_nonsing_inv, matrix.mul_inv_of_self],
+end
+
+/-- The `nonsing_inv` of `A` is a left inverse. -/
+@[simp] lemma nonsing_inv_mul (h : is_unit A.det) : A⁻¹ ⬝ A = 1 :=
+begin
+  casesI (A.is_unit_iff_is_unit_det.mpr h).nonempty_invertible,
+  rw [←inv_of_eq_nonsing_inv, matrix.inv_of_mul_self],
+end
+
+@[simp] lemma mul_inv_of_invertible [invertible A] : A ⬝ A⁻¹ = 1 :=
+mul_nonsing_inv A (is_unit_det_of_invertible A)
+
+@[simp] lemma inv_mul_of_invertible [invertible A] : A⁻¹ ⬝ A = 1 :=
+nonsing_inv_mul A (is_unit_det_of_invertible A)
+
+lemma nonsing_inv_cancel_or_zero :
+  (A⁻¹ ⬝ A = 1 ∧ A ⬝ A⁻¹ = 1) ∨ A⁻¹ = 0 :=
+begin
+  by_cases h : is_unit A.det,
+  { exact or.inl ⟨nonsing_inv_mul _ h, mul_nonsing_inv _ h⟩ },
+  { exact or.inr (nonsing_inv_apply_not_is_unit _ h) }
+end
+
+lemma det_nonsing_inv_mul_det (h : is_unit A.det) : A⁻¹.det * A.det = 1 :=
+by rw [←det_mul, A.nonsing_inv_mul h, det_one]
+
+@[simp] lemma det_nonsing_inv : A⁻¹.det = ring.inverse A.det :=
+begin
+  by_cases h : is_unit A.det,
+  { casesI h.nonempty_invertible, letI := invertible_of_det_invertible A,
+    rw [ring.inverse_invertible, ←inv_of_eq_nonsing_inv, det_inv_of] },
+  casesI is_empty_or_nonempty n,
+  { rw [det_is_empty, det_is_empty, ring.inverse_one] },
+  { rw [ring.inverse_non_unit _ h, nonsing_inv_apply_not_is_unit _ h, det_zero ‹_›] },
+end
+
+lemma is_unit_nonsing_inv_det (h : is_unit A.det) : is_unit A⁻¹.det :=
+is_unit_of_mul_eq_one _ _ (A.det_nonsing_inv_mul_det h)
+
+@[simp] lemma nonsing_inv_nonsing_inv (h : is_unit A.det) : (A⁻¹)⁻¹ = A :=
+calc (A⁻¹)⁻¹ = 1 ⬝ (A⁻¹)⁻¹        : by rw matrix.one_mul
+         ... = A ⬝ A⁻¹ ⬝ (A⁻¹)⁻¹  : by rw A.mul_nonsing_inv h
+         ... = A                  : by { rw [matrix.mul_assoc,
+                                         (A⁻¹).mul_nonsing_inv (A.is_unit_nonsing_inv_det h),
+                                         matrix.mul_one], }
+
+lemma is_unit_nonsing_inv_det_iff {A : matrix n n α} :
+  is_unit A⁻¹.det ↔ is_unit A.det :=
+by rw [matrix.det_nonsing_inv, is_unit_ring_inverse]
+
+/- `is_unit.invertible` lifts the proposition `is_unit A` to a constructive inverse of `A`. -/
+
+/-- A version of `matrix.invertible_of_det_invertible` with the inverse defeq to `A⁻¹` that is
+therefore noncomputable. -/
+noncomputable def invertible_of_is_unit_det (h : is_unit A.det) : invertible A :=
+⟨A⁻¹, nonsing_inv_mul A h, mul_nonsing_inv A h⟩
+
+/-- A version of `matrix.units_of_det_invertible` with the inverse defeq to `A⁻¹` that is therefore
+noncomputable. -/
+noncomputable def nonsing_inv_unit (h : is_unit A.det) : units (matrix n n α) :=
+@unit_of_invertible _ _ _ (invertible_of_is_unit_det A h)
+
+lemma unit_of_det_invertible_eq_nonsing_inv_unit [invertible A.det] :
+  unit_of_det_invertible A = nonsing_inv_unit A (is_unit_of_invertible _) :=
+by { ext, refl }
+
+variables {A} {B}
 
 /-- If matrix A is left invertible, then its inverse equals its left inverse. -/
 lemma inv_eq_left_inv (h : B ⬝ A = 1) : A⁻¹ = B :=
 begin
-  have h1 :=  (is_unit_det_of_left_inverse h),
-  have h2 := matrix.invertible_of_is_unit_det h1,
-  have := @inv_of_eq_left_inv (matrix n n α) (infer_instance) A B h2 h,
-  simp* at *,
+  letI := invertible_of_left_inverse _ _ h,
+  exact inv_of_eq_nonsing_inv A ▸ inv_of_eq_left_inv h,
 end
 
 /-- If matrix A is right invertible, then its inverse equals its right inverse. -/
 lemma inv_eq_right_inv (h : A ⬝ B = 1) : A⁻¹ = B :=
-begin
-  have h1 :=  (is_unit_det_of_right_inverse h),
-  have h2 := matrix.invertible_of_is_unit_det h1,
-  have := @inv_of_eq_right_inv (matrix n n α) (infer_instance) A B h2 h,
-  simp* at *,
-end
-
-/-- We can construct an instance of invertible A if A has a left inverse. -/
-def invertible_of_left_inverse (h: B ⬝ A = 1) : invertible A :=
-⟨B, h, nonsing_inv_right_left h⟩
-
-/-- We can construct an instance of invertible A if A has a right inverse. -/
-def invertible_of_right_inverse (h: A ⬝ B = 1) : invertible A :=
-⟨B, nonsing_inv_left_right h, h⟩
+inv_eq_left_inv (mul_eq_one_comm.2 h)
 
 section inv_eq_inv
 
 variables {C : matrix n n α}
 
 /-- The left inverse of matrix A is unique when existing. -/
-lemma left_inv_eq_left_inv (h: B ⬝ A = 1) (g: C ⬝ A = 1) : B = C :=
-by rw [←(inv_eq_left_inv h), ←(inv_eq_left_inv g)]
+lemma left_inv_eq_left_inv (h : B ⬝ A = 1) (g : C ⬝ A = 1) : B = C :=
+by rw [←inv_eq_left_inv h, ←inv_eq_left_inv g]
 
 /-- The right inverse of matrix A is unique when existing. -/
-lemma right_inv_eq_right_inv (h: A ⬝ B = 1) (g: A ⬝ C = 1) : B = C :=
-by rw [←(inv_eq_right_inv h), ←(inv_eq_right_inv g)]
+lemma right_inv_eq_right_inv (h : A ⬝ B = 1) (g : A ⬝ C = 1) : B = C :=
+by rw [←inv_eq_right_inv h, ←inv_eq_right_inv g]
 
 /-- The right inverse of matrix A equals the left inverse of A when they exist. -/
-lemma right_inv_eq_left_inv (h: A ⬝ B = 1) (g: C ⬝ A = 1) : B = C :=
-by rw [←(inv_eq_right_inv h), ←(inv_eq_left_inv g)]
+lemma right_inv_eq_left_inv (h : A ⬝ B = 1) (g : C ⬝ A = 1) : B = C :=
+by rw [←inv_eq_right_inv h, ←inv_eq_left_inv g]
 
 lemma inv_inj (h : A⁻¹ = B⁻¹) (h' : is_unit A.det) : A = B :=
 begin
@@ -281,12 +316,6 @@ end
 end inv_eq_inv
 
 variable (A)
-
-@[simp] lemma mul_inv_of_invertible [invertible A] : A ⬝ A⁻¹ = 1 :=
-mul_nonsing_inv A (is_unit_det_of_invertible A)
-
-@[simp] lemma inv_mul_of_invertible [invertible A] : A⁻¹ ⬝ A = 1 :=
-nonsing_inv_mul A (is_unit_det_of_invertible A)
 
 @[simp] lemma inv_zero : (0 : matrix n n α)⁻¹ = 0 :=
 begin

--- a/src/linear_algebra/unitary_group.lean
+++ b/src/linear_algebra/unitary_group.lean
@@ -76,7 +76,7 @@ namespace unitary_submonoid
 
 lemma star_mem {A : matrix n n α} (h : A ∈ unitary_submonoid (matrix n n α)) :
   star A ∈ unitary_submonoid (matrix n n α) :=
-matrix.nonsing_inv_left_right $ (star_star A).symm ▸ h
+mul_eq_one_comm.mp $ (star_star A).symm ▸ h
 
 @[simp]
 lemma star_mem_iff {A : matrix n n α} :


### PR DESCRIPTION
This file is a mess, and switches back and forth between three different inverses, proving the same things over and over again.

This pulls all the `invertible` versions of these statements to the top, and uses them here and there to golf proofs.

The lemmas `nonsing_inv_left_right` and `nonsing_inv_right_left` are merged into a single lemma `mul_eq_one_comm`.
The lemma `inv_eq_nonsing_inv_of_invertible` has been renamed to `inv_of_eq_nonsing_inv`

This also adds two new lemmas `inv_of_eq` and `det_inv_of`, both of which have trivial proofs.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
