### PR TITLE
[Merged by Bors] - feat(data/list/basic): list products

### DIFF
--- a/src/data/list/basic.lean
+++ b/src/data/list/basic.lean
@@ -2724,36 +2724,26 @@ begin
     exact lt_of_add_lt_add_left (lt_of_le_of_lt h $ add_lt_add_right (lt_of_not_ge h') _) }
 end
 
--- Several lemmas about sum/head/tail for `list ℕ`.
--- These are hard to generalize well, as they rely on the fact that `default ℕ = 0`.
-
--- We'd like to state this as `L.head * L.tail.prod = L.prod`,
--- but because `L.head` relies on an inhabited instances and
--- returns a garbage value for the empty list, this is not possible.
--- Instead we write the statement in terms of `(L.nth 0).get_or_else 1`,
--- and below, restate the lemma just for `ℕ`.
+/--
+We'd like to state this as `L.head * L.tail.prod = L.prod`,
+but because `L.head` relies on an inhabited instances and
+returns a garbage value for the empty list, this is not possible.
+Instead we write the statement in terms of `(L.nth 0).get_or_else 1`,
+and below, restate the lemma just for `ℕ`.
+-/
 @[to_additive]
 lemma head_mul_tail_prod' [monoid α] (L : list α) :
   (L.nth 0).get_or_else 1 * L.tail.prod = L.prod :=
 by cases L; simp
 
--- In the case where L is not empty the above complication can be avoided
-@[to_additive head_add_tail_sum']
-lemma head_mul_tail_prod [monoid α] [inhabited α] (L : list α) (h: L ≠ []) :
+/-- In the case where thge list is not empty the above complication can be avoided. -/
+@[to_additive]
+lemma head_mul_tail_prod_of_ne_nil [monoid α] [inhabited α] (L : list α) (h: L ≠ []) :
   L.head * L.tail.prod = L.prod :=
 by {cases L, { contradiction }, { simp }}
 
-lemma head_add_tail_sum (L : list ℕ) : L.head + L.tail.sum = L.sum :=
-by { cases L, { simp, refl, }, { simp, }, }
-
-lemma head_le_sum (L : list ℕ) : L.head ≤ L.sum :=
-nat.le.intro (head_add_tail_sum L)
-
-lemma tail_sum (L : list ℕ) : L.tail.sum = L.sum - L.head :=
-by rw [← head_add_tail_sum L, add_comm, add_tsub_cancel_right]
-
--- The product of a list of positive natural numbers is positive,
--- and likewise for any nontrivial ordered semiring
+/-- The product of a list of positive natural numbers is positive,
+and likewise for any nontrivial ordered semiring. -/
 lemma prod_pos {S : Type} [ordered_semiring S] [nontrivial S] (L : list S)
 (h: ∀ n:S, n ∈ L → 0 < n) : 0 < L.prod :=
 begin
@@ -2763,7 +2753,24 @@ begin
     { exact L_ih (λ n hn, h n (mem_cons_of_mem L_hd hn)) }}
 end
 
+/-!
+Several lemmas about sum/head/tail for `list ℕ`.
+These are hard to generalize well, as they rely on the fact that `default ℕ = 0`.
+If desired, we could add a class stating that `default α = 0` at some point
+(extending `inhabited` and `has_zero`).
+-/
 
+/-- This relies on `default ℕ = 0`. -/
+lemma head_add_tail_sum (L : list ℕ) : L.head + L.tail.sum = L.sum :=
+by { cases L, { simp, refl, }, { simp, }, }
+
+/-- This relies on `default ℕ = 0`. -/
+lemma head_le_sum (L : list ℕ) : L.head ≤ L.sum :=
+nat.le.intro (head_add_tail_sum L)
+
+/-- This relies on `default ℕ = 0`. -/
+lemma tail_sum (L : list ℕ) : L.tail.sum = L.sum - L.head :=
+by rw [← head_add_tail_sum L, add_comm, add_tsub_cancel_right]
 
 section
 variables {G : Type*} [comm_group G]

--- a/src/data/list/basic.lean
+++ b/src/data/list/basic.lean
@@ -2732,11 +2732,11 @@ Instead we write the statement in terms of `(L.nth 0).get_or_else 1`,
 and below, restate the lemma just for `ℕ`.
 -/
 @[to_additive]
-lemma head_mul_tail_prod' [monoid α] (L : list α) :
+lemma nth_zero_mul_tail_prod [monoid α] (L : list α) :
   (L.nth 0).get_or_else 1 * L.tail.prod = L.prod :=
 by cases L; simp
 
-/-- In the case where thge list is not empty the above complication can be avoided. -/
+/-- In the case where the list is not empty the above complication can be avoided. -/
 @[to_additive]
 lemma head_mul_tail_prod_of_ne_nil [monoid α] [inhabited α] (L : list α) (h: L ≠ []) :
   L.head * L.tail.prod = L.prod :=

--- a/src/data/list/basic.lean
+++ b/src/data/list/basic.lean
@@ -2738,7 +2738,8 @@ lemma head_mul_tail_prod' [monoid α] (L : list α) :
 by cases L; simp
 
 -- In the case where L is not empty the above complication can be avoided
-lemma nonempty_head_mul_tail_prod [monoid α] [inhabited α] (L : list α) (h: L ≠ list.nil) :
+@[to_additive head_add_tail_sum']
+lemma head_mul_tail_prod [monoid α] [inhabited α] (L : list α) (h: L ≠ []) :
   L.head * L.tail.prod = L.prod :=
 by {cases L, { contradiction }, { simp }}
 

--- a/src/data/list/basic.lean
+++ b/src/data/list/basic.lean
@@ -2752,9 +2752,17 @@ nat.le.intro (head_add_tail_sum L)
 lemma tail_sum (L : list ℕ) : L.tail.sum = L.sum - L.head :=
 by rw [← head_add_tail_sum L, add_comm, add_tsub_cancel_right]
 
--- The product of a list of positive natural numbers is positive
-lemma pos_list_nat_prod_pos (L : list ℕ) (h: ∀ n ∈ L, 0 < n) : 0 < L.prod :=
-by {rw pos_iff_ne_zero, apply list.prod_ne_zero (λ H, lt_irrefl 0 (h 0 H))}
+-- The product of a list of positive natural numbers is positive,
+-- and likewise for any nontrivial ordered semiring
+lemma prod_pos {S : Type} [ordered_semiring S] [nontrivial S] (L : list S)
+(h: ∀ n:S, n ∈ L → 0 < n) : 0 < L.prod :=
+begin
+  induction L, {simp},
+  { simp, apply mul_pos,
+    { apply h, simp },
+    { exact L_ih (λ n hn, h n (mem_cons_of_mem L_hd hn)) }}
+end
+
 
 
 section

--- a/src/data/list/basic.lean
+++ b/src/data/list/basic.lean
@@ -2737,6 +2737,11 @@ lemma head_mul_tail_prod' [monoid α] (L : list α) :
   (L.nth 0).get_or_else 1 * L.tail.prod = L.prod :=
 by cases L; simp
 
+-- In the case where L is not empty the above complication can be avoided
+lemma nonempty_head_mul_tail_prod [monoid α] [inhabited α] (L : list α) (h: L ≠ list.nil) :
+  L.head * L.tail.prod = L.prod :=
+by {cases L, { contradiction }, { simp }}
+
 lemma head_add_tail_sum (L : list ℕ) : L.head + L.tail.sum = L.sum :=
 by { cases L, { simp, refl, }, { simp, }, }
 
@@ -2745,6 +2750,11 @@ nat.le.intro (head_add_tail_sum L)
 
 lemma tail_sum (L : list ℕ) : L.tail.sum = L.sum - L.head :=
 by rw [← head_add_tail_sum L, add_comm, add_tsub_cancel_right]
+
+-- The product of a list of positive natural numbers is positive
+lemma pos_list_nat_prod_pos (L : list ℕ) (h: ∀ n ∈ L, 0 < n) : 0 < L.prod :=
+by {rw pos_iff_ne_zero, apply list.prod_ne_zero (λ H, lt_irrefl 0 (h 0 H))}
+
 
 section
 variables {G : Type*} [comm_group G]


### PR DESCRIPTION
Adding a couple of lemmas about list products. The first is a simpler variant of `head_mul_tail_prod'` in the case where the list is not empty.  The other is a variant of `list.prod_ne_zero` for `list ℕ`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
