### PR TITLE
[Merged by Bors] - feat(algebra/group/with_one): cleanup algebraic instances

### DIFF
--- a/src/algebra/group/with_one.lean
+++ b/src/algebra/group/with_one.lean
@@ -227,12 +227,18 @@ instance [mul_one_class α] : mul_zero_one_class (with_zero α) :=
   ..with_zero.mul_zero_class,
   ..with_zero.has_one }
 
+instance [has_one α] [has_pow α ℕ] : has_pow (with_zero α) ℕ :=
+⟨λ x n, match x, n with
+  | none, 0 := 1
+  | none, n + 1 := 0
+  | some x, n := ↑(x ^ n)
+  end⟩
+
+@[simp, norm_cast] lemma coe_pow [has_one α] [has_pow α ℕ] {a : α} (n : ℕ) :
+  ↑(a ^ n : α) = (↑a ^ n : with_zero α) := rfl
+
 instance [monoid α] : monoid_with_zero (with_zero α) :=
-{ npow := λ n x, match x, n with
-    | none, 0 := 1
-    | none, n + 1 := 0
-    | some x, n := some (x ^ n)
-    end,
+{ npow := λ n x, x ^ n,
   npow_zero' := λ x, match x with
     | none   := rfl
     | some x := congr_arg some $ pow_zero _
@@ -243,9 +249,6 @@ instance [monoid α] : monoid_with_zero (with_zero α) :=
     end,
   .. with_zero.mul_zero_one_class,
   .. with_zero.semigroup_with_zero }
-
-@[simp, norm_cast] lemma coe_pow [monoid α] {a : α} (n : ℕ) :
-  ↑(a ^ n : α) = (↑a ^ n : with_zero α) := rfl
 
 instance [comm_monoid α] : comm_monoid_with_zero (with_zero α) :=
 { ..with_zero.monoid_with_zero, ..with_zero.comm_semigroup }
@@ -265,18 +268,24 @@ instance [has_div α] : has_div (with_zero α) :=
 
 @[norm_cast] lemma coe_div [has_div α] (a b : α) : ↑(a / b : α) = (a / b : with_zero α) := rfl
 
+instance [has_one α] [has_pow α ℤ] : has_pow (with_zero α) ℤ :=
+⟨λ x n, match x, n with
+  | none, int.of_nat 0            := 1
+  | none, int.of_nat (nat.succ n) := 0
+  | none, int.neg_succ_of_nat n   := 0
+  | some x, n                     := ↑(x ^ n)
+  end⟩
+
+@[simp, norm_cast] lemma coe_zpow [div_inv_monoid α] {a : α} (n : ℤ) :
+  ↑(a ^ n : α) = (↑a ^ n : with_zero α) := rfl
+
 instance [div_inv_monoid α] : div_inv_monoid (with_zero α) :=
 { div_eq_mul_inv := λ a b, match a, b with
-    | none, _   := rfl
+    | none,   _      := rfl
     | some a, none   := rfl
     | some a, some b := congr_arg some (div_eq_mul_inv _ _)
     end,
-  zpow := λ n x, match x, n with
-    | none, int.of_nat 0 := 1
-    | none, int.of_nat (nat.succ n) := 0
-    | none, int.neg_succ_of_nat n := 0
-    | some x, n := some (x ^ n)
-    end,
+  zpow := λ n x, x ^ n,
   zpow_zero' := λ x, match x with
     | none   := rfl
     | some x := congr_arg some $ zpow_zero _
@@ -293,8 +302,6 @@ instance [div_inv_monoid α] : div_inv_monoid (with_zero α) :=
   .. with_zero.has_inv,
   .. with_zero.monoid_with_zero, }
 
-@[simp, norm_cast] lemma coe_zpow [div_inv_monoid α] {a : α} (n : ℤ) :
-  ↑(a ^ n : α) = (↑a ^ n : with_zero α) := rfl
 
 section group
 variables [group α]

--- a/src/algebra/group/with_one.lean
+++ b/src/algebra/group/with_one.lean
@@ -228,8 +228,24 @@ instance [mul_one_class α] : mul_zero_one_class (with_zero α) :=
   ..with_zero.has_one }
 
 instance [monoid α] : monoid_with_zero (with_zero α) :=
-{ ..with_zero.mul_zero_one_class,
-  ..with_zero.semigroup_with_zero }
+{ npow := λ n x, match x, n with
+    | none, 0 := 1
+    | none, n + 1 := 0
+    | some x, n := some (x ^ n)
+    end,
+  npow_zero' := λ x, match x with
+    | none   := rfl
+    | some x := congr_arg some $ pow_zero _
+    end,
+  npow_succ' := λ n x, match x with
+    | none   := rfl
+    | some x := congr_arg some $ pow_succ _ _
+    end,
+  .. with_zero.mul_zero_one_class,
+  .. with_zero.semigroup_with_zero }
+
+@[simp, norm_cast] lemma coe_pow [monoid α] {a : α} (n : ℕ) :
+  ↑(a ^ n : α) = (↑a ^ n : with_zero α) := rfl
 
 instance [comm_monoid α] : comm_monoid_with_zero (with_zero α) :=
 { ..with_zero.monoid_with_zero, ..with_zero.comm_semigroup }
@@ -255,9 +271,30 @@ instance [div_inv_monoid α] : div_inv_monoid (with_zero α) :=
     | some a, none   := rfl
     | some a, some b := congr_arg some (div_eq_mul_inv _ _)
     end,
+  zpow := λ n x, match x, n with
+    | none, int.of_nat 0 := 1
+    | none, int.of_nat (nat.succ n) := 0
+    | none, int.neg_succ_of_nat n := 0
+    | some x, n := some (x ^ n)
+    end,
+  zpow_zero' := λ x, match x with
+    | none   := rfl
+    | some x := congr_arg some $ zpow_zero _
+    end,
+  zpow_succ' := λ n x, match x with
+    | none   := rfl
+    | some x := congr_arg some $ div_inv_monoid.zpow_succ' _ _
+    end,
+  zpow_neg' := λ n x, match x with
+    | none   := rfl
+    | some x := congr_arg some $ div_inv_monoid.zpow_neg' _ _
+    end,
   .. with_zero.has_div,
   .. with_zero.has_inv,
   .. with_zero.monoid_with_zero, }
+
+@[simp, norm_cast] lemma coe_zpow [div_inv_monoid α] {a : α} (n : ℤ) :
+  ↑(a ^ n : α) = (↑a ^ n : with_zero α) := rfl
 
 section group
 variables [group α]

--- a/src/algebra/group/with_one.lean
+++ b/src/algebra/group/with_one.lean
@@ -37,6 +37,9 @@ instance : has_one (with_one α) := ⟨none⟩
 instance [has_mul α] : has_mul (with_one α) := ⟨option.lift_or_get (*)⟩
 
 @[to_additive]
+instance [has_inv α] : has_inv (with_zero α) := ⟨λ a, option.map has_inv.inv a⟩
+
+@[to_additive]
 instance : inhabited (with_one α) := ⟨1⟩
 
 @[to_additive]

--- a/src/algebra/group/with_one.lean
+++ b/src/algebra/group/with_one.lean
@@ -37,7 +37,7 @@ instance : has_one (with_one α) := ⟨none⟩
 instance [has_mul α] : has_mul (with_one α) := ⟨option.lift_or_get (*)⟩
 
 @[to_additive]
-instance [has_inv α] : has_inv (with_zero α) := ⟨λ a, option.map has_inv.inv a⟩
+instance [has_inv α] : has_inv (with_one α) := ⟨λ a, option.map has_inv.inv a⟩
 
 @[to_additive]
 instance : inhabited (with_one α) := ⟨1⟩


### PR DESCRIPTION
This:

* adds a `has_neg (with_zero α)` instance which sends `0` to `0` and otherwise uses the underlying negation (and the same for `has_inv (with_one α)`).
* replaces the `has_div (with_zero α)`,  `has_pow (with_zero α) ℕ`, and `has_pow (with_zero α) ℤ` instances in order to produce better definitional properties than the previous default ones.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
