### PR TITLE
[Merged by Bors] - feat(analysis/normed_space/continuous_affine_map): isometry from space of continuous affine maps to product of codomain with space of continuous linear maps

### DIFF
--- a/src/analysis/normed_space/continuous_affine_map.lean
+++ b/src/analysis/normed_space/continuous_affine_map.lean
@@ -16,28 +16,6 @@ spaces.
 
 -/
 
-namespace continuous_linear_map
-
-variables {R V W : Type*} [normed_group V] [normed_group W]
-variables [normed_field R] [normed_space R V] [normed_space R W]
-
-/-- A continuous linear map can be regarded as a continuous affine map. -/
-def to_continuous_affine_map (f : V →L[R] W) : V →A[R] W :=
-{ to_fun    := f,
-  linear    := f,
-  map_vadd' := by simp,
-  cont      := f.cont, }
-
-@[simp] lemma coe_to_continuous_affine_map (f : V →L[R] W) :
-  ⇑f.to_continuous_affine_map = f :=
-rfl
-
-@[simp] lemma to_continuous_affine_map_map_zero (f : V →L[R] W) :
-  f.to_continuous_affine_map 0 = 0 :=
-by simp
-
-end continuous_linear_map
-
 namespace continuous_affine_map
 
 variables {𝕜 R V W P Q : Type*}

--- a/src/analysis/normed_space/continuous_affine_map.lean
+++ b/src/analysis/normed_space/continuous_affine_map.lean
@@ -14,6 +14,29 @@ import analysis.normed_space.operator_norm
 This file develops the theory of continuous affine maps between affine spaces modelled on normed
 spaces.
 
+In the particular case that the affine spaces are just normed vector spaces `V`, `W`, we define a
+norm on the space of continuous affine maps by defining the norm of `f : V →A[𝕜] W` to be
+`∥f∥ = max ∥f 0∥ ∥f.cont_linear∥`. This is chosen so that we have a linear isometry:
+`(V →A[𝕜] W) ≃ₗᵢ[𝕜] W × (V →L[𝕜] W)`.
+
+The abstract picture is that for an affine space `P` modelled on a vector space `V`, together with
+a vector space `W`, there is an exact sequence of `𝕜`-modules: `0 → C → A → L → 0` where `C`, `A`
+are the spaces of constant and affine maps `P → W` and `L` is the space of linear maps `V → W`.
+
+Any choice of a base point in `P` corresponds to a splitting of this sequence so in particular if we
+take `P = V`, using `0 : V` as the base point provides a splitting, and we prove this is an
+isometric decomposition.
+
+On the other hand, choosing a base point breaks the affine invariance so the norm fails to be
+submultiplicative: for a composition of maps, we have only `∥f.comp g∥ ≤ ∥f∥ * ∥g∥ + ∥f 0∥`.
+
+## Main definitions:
+
+ * `continuous_affine_map.cont_linear`
+ * `continuous_affine_map.has_norm`
+ * `continuous_affine_map.norm_comp_le`
+ * `continuous_affine_map.to_const_prod_continuous_linear_map`
+
 -/
 
 namespace continuous_affine_map
@@ -120,10 +143,10 @@ section normed_space_structure
 
 variables (f : V →A[𝕜] W)
 
-noncomputable instance : has_norm (V →A[𝕜] W) := ⟨λ f, max ∥f 0∥ ∥f.cont_linear∥⟩
-
 /-- Note that unlike the operator norm for linear maps, this norm is _not_ submultiplicative:
 we do _not_ necessarily have `∥f.comp g∥ ≤ ∥f∥ * ∥g∥`. See `norm_comp_le` for what we can say. -/
+noncomputable instance has_norm : has_norm (V →A[𝕜] W) := ⟨λ f, max ∥f 0∥ ∥f.cont_linear∥⟩
+
 lemma norm_def : ∥f∥ = (max ∥f 0∥ ∥f.cont_linear∥) := rfl
 
 lemma norm_cont_linear_le : ∥f.cont_linear∥ ≤ ∥f∥ := le_max_right _ _

--- a/src/analysis/normed_space/continuous_affine_map.lean
+++ b/src/analysis/normed_space/continuous_affine_map.lean
@@ -6,6 +6,7 @@ Authors: Oliver Nash
 import topology.algebra.continuous_affine_map
 import analysis.normed_space.add_torsor
 import analysis.normed_space.affine_isometry
+import analysis.normed_space.operator_norm
 
 /-!
 # Continuous affine maps between normed spaces.
@@ -15,12 +16,35 @@ spaces.
 
 -/
 
+namespace continuous_linear_map
+
+variables {R V W : Type*} [normed_group V] [normed_group W]
+variables [normed_field R] [normed_space R V] [normed_space R W]
+
+/-- A continuous linear map can be regarded as a continuous affine map. -/
+def to_continuous_affine_map (f : V →L[R] W) : V →A[R] W :=
+{ to_fun    := f,
+  linear    := f,
+  map_vadd' := by simp,
+  cont      := f.cont, }
+
+@[simp] lemma coe_to_continuous_affine_map (f : V →L[R] W) :
+  ⇑f.to_continuous_affine_map = f :=
+rfl
+
+@[simp] lemma to_continuous_affine_map_map_zero (f : V →L[R] W) :
+  f.to_continuous_affine_map 0 = 0 :=
+by simp
+
+end continuous_linear_map
+
 namespace continuous_affine_map
 
-variables {R V W P Q : Type*}
-variables [normed_field R]
-variables [normed_group V] [normed_space R V] [metric_space P] [normed_add_torsor V P]
-variables [normed_group W] [normed_space R W] [metric_space Q] [normed_add_torsor W Q]
+variables {𝕜 R V W P Q : Type*}
+variables [normed_group V] [metric_space P] [normed_add_torsor V P]
+variables [normed_group W] [metric_space Q] [normed_add_torsor W Q]
+variables [normed_field R] [normed_space R V] [normed_space R W]
+variables [nondiscrete_normed_field 𝕜] [normed_space 𝕜 V] [normed_space 𝕜 W]
 
 include V W
 
@@ -69,5 +93,108 @@ begin
   simp_rw [h₁, h₂],
   exact (f : P →ᵃ[R] Q).linear_eq_zero_iff_exists_const,
 end
+
+@[simp] lemma to_affine_map_cont_linear (f : V →L[R] W) :
+  f.to_continuous_affine_map.cont_linear = f :=
+by { ext, refl, }
+
+@[simp] lemma zero_cont_linear :
+  (0 : P →A[R] W).cont_linear = 0 :=
+rfl
+
+@[simp] lemma add_cont_linear (f g : P →A[R] W) :
+  (f + g).cont_linear = f.cont_linear + g.cont_linear :=
+rfl
+
+@[simp] lemma sub_cont_linear (f g : P →A[R] W) :
+  (f - g).cont_linear = f.cont_linear - g.cont_linear :=
+rfl
+
+@[simp] lemma neg_cont_linear (f : P →A[R] W) :
+  (-f).cont_linear = -f.cont_linear :=
+rfl
+
+@[simp] lemma smul_cont_linear (t : R) (f : P →A[R] W) :
+  (t • f).cont_linear = t • f.cont_linear :=
+rfl
+
+lemma decomp (f : V →A[R] W) :
+  (f : V → W) = f.cont_linear + function.const V (f 0) :=
+begin
+  rcases f with ⟨f, h⟩,
+  rw [coe_mk_const_linear_eq_linear, coe_mk, f.decomp, pi.add_apply, linear_map.map_zero, zero_add],
+end
+
+section normed_space_structure
+
+variables (f : V →A[𝕜] W)
+
+noncomputable instance : has_norm (V →A[𝕜] W) := ⟨λ f, max ∥f 0∥ ∥f.cont_linear∥⟩
+
+lemma norm_def : ∥f∥ = (max ∥f 0∥ ∥f.cont_linear∥) := rfl
+
+lemma norm_cont_linear_le : ∥f.cont_linear∥ ≤ ∥f∥ := le_max_right _ _
+
+lemma norm_image_zero_le : ∥f 0∥ ≤ ∥f∥ := le_max_left _ _
+
+@[simp] lemma norm_eq (h : f 0 = 0) : ∥f∥ = ∥f.cont_linear∥ :=
+calc ∥f∥ = (max ∥f 0∥ ∥f.cont_linear∥) : by rw norm_def
+    ... = (max 0 ∥f.cont_linear∥) : by rw [h, norm_zero]
+    ... = ∥f.cont_linear∥ : max_eq_right (norm_nonneg _)
+
+noncomputable instance : normed_group (V →A[𝕜] W) :=
+normed_group.of_core _
+{ norm_eq_zero_iff := λ f,
+    begin
+      rw norm_def,
+      refine ⟨λ h₀, _, by { rintros rfl, simp, }⟩,
+      rcases max_eq_iff.mp h₀ with ⟨h₁, h₂⟩ | ⟨h₁, h₂⟩;
+      rw h₁ at h₂,
+      { rw [norm_le_zero_iff, cont_linear_eq_zero_iff_exists_const] at h₂,
+        obtain ⟨q, rfl⟩ := h₂,
+        simp only [function.const_apply, coe_const, norm_eq_zero] at h₁,
+        rw h₁,
+        refl, },
+      { rw [norm_eq_zero_iff', cont_linear_eq_zero_iff_exists_const] at h₁,
+        obtain ⟨q, rfl⟩ := h₁,
+        simp only [function.const_apply, coe_const, norm_le_zero_iff] at h₂,
+        rw h₂,
+        refl, },
+    end,
+  triangle := λ f g,
+    begin
+      simp only [norm_def, pi.add_apply, add_cont_linear, coe_add, max_le_iff],
+      exact ⟨(norm_add_le _ _).trans (add_le_add (le_max_left _ _) (le_max_left _ _)),
+             (norm_add_le _ _).trans (add_le_add (le_max_right _ _) (le_max_right _ _))⟩,
+    end,
+  norm_neg := λ f, by simp [norm_def], }
+
+noncomputable instance : normed_space 𝕜 (V →A[𝕜] W) :=
+{ norm_smul_le := λ t f, by simp only [norm_def, smul_cont_linear, coe_smul, pi.smul_apply,
+    norm_smul, ← mul_max_of_nonneg _ _ (norm_nonneg t)], }
+
+variables (𝕜 V W)
+
+/-- The space of affine maps between two normed spaces is linearly isometric to the product of the
+codomain with the space of linear maps, by taking the value of the affine map at `(0 : V)` and the
+linear part. -/
+noncomputable def to_const_prod_continuous_linear_map : (V →A[𝕜] W) ≃ₗᵢ[𝕜] W × (V →L[𝕜] W) :=
+{ to_fun    := λ f, ⟨f 0, f.cont_linear⟩,
+  inv_fun   := λ p, p.2.to_continuous_affine_map + const 𝕜 V p.1,
+  left_inv  := λ f, by { ext, rw f.decomp, simp, },
+  right_inv := by { rintros ⟨v, f⟩, ext; simp, },
+  map_add'  := by simp,
+  map_smul' := by simp,
+  norm_map' := λ f, by simp [prod.norm_def, norm_def], }
+
+@[simp] lemma to_const_prod_continuous_linear_map_fst (f : V →A[𝕜] W) :
+  (to_const_prod_continuous_linear_map 𝕜 V W f).fst = f 0 :=
+rfl
+
+@[simp] lemma to_const_prod_continuous_linear_map_snd (f : V →A[𝕜] W) :
+  (to_const_prod_continuous_linear_map 𝕜 V W f).snd = f.cont_linear :=
+rfl
+
+end normed_space_structure
 
 end continuous_affine_map

--- a/src/topology/algebra/continuous_affine_map.lean
+++ b/src/topology/algebra/continuous_affine_map.lean
@@ -5,6 +5,7 @@ Authors: Oliver Nash
 -/
 import linear_algebra.affine_space.affine_map
 import topology.continuous_function.basic
+import topology.algebra.mul_action
 
 /-!
 # Continuous affine maps.
@@ -148,5 +149,61 @@ rfl
 lemma comp_apply (f : Q →A[R] Q₂) (g : P →A[R] Q) (x : P) :
   f.comp g x = f (g x) :=
 rfl
+
+omit W₂
+
+section module_valued_maps
+
+variables {S : Type*} [comm_ring S] [module S V] [module S W]
+variables [topological_space W] [topological_space S] [has_continuous_smul S W]
+
+instance : has_zero (P →A[R] W) := ⟨continuous_affine_map.const R P 0⟩
+
+@[norm_cast, simp] lemma coe_zero : ((0 : P →A[R] W) : P → W) = 0 := rfl
+
+lemma zero_apply (x : P) : (0 : P →A[R] W) x = 0 := rfl
+
+instance : has_scalar S (P →A[S] W) :=
+{ smul := λ t f, { cont := f.continuous.const_smul t, .. (t • (f : P →ᵃ[S] W)) } }
+
+@[norm_cast, simp] lemma coe_smul (t : S) (f : P →A[S] W) : ⇑(t • f) = t • f := rfl
+
+lemma smul_apply (t : S) (f : P →A[S] W) (x : P) : (t • f) x = t • (f x) := rfl
+
+variables [topological_add_group W]
+
+instance : has_add (P →A[R] W) :=
+{ add := λ f g, { cont := f.continuous.add g.continuous, .. ((f : P →ᵃ[R] W) + (g : P →ᵃ[R] W)) }, }
+
+@[norm_cast, simp] lemma coe_add (f g : P →A[R] W) : ⇑(f + g) = f + g := rfl
+
+lemma add_apply (f g : P →A[R] W) (x : P) : (f + g) x = f x + g x := rfl
+
+instance : has_sub (P →A[R] W) :=
+{ sub := λ f g, { cont := f.continuous.sub g.continuous, .. ((f : P →ᵃ[R] W) - (g : P →ᵃ[R] W)) }, }
+
+@[norm_cast, simp] lemma coe_sub (f g : P →A[R] W) : ⇑(f - g) = f - g := rfl
+
+lemma sub_apply (f g : P →A[R] W) (x : P) : (f - g) x = f x - g x := rfl
+
+instance : has_neg (P →A[R] W) :=
+{ neg := λ f, { cont := f.continuous.neg, .. (-(f : P →ᵃ[R] W)) }, }
+
+@[norm_cast, simp] lemma coe_neg (f : P →A[R] W) : ⇑(-f) = -f := rfl
+
+lemma neg_apply (f : P →A[R] W) (x : P) : (-f) x = -(f x) := rfl
+
+instance : add_comm_group (P →A[R] W) :=
+{ add := (+),
+  zero := 0,
+  neg := has_neg.neg,
+  sub := has_sub.sub,
+  .. (coe_injective.add_comm_group _ coe_zero coe_add coe_neg coe_sub :
+    add_comm_group (P →A[R] W)) }
+
+instance : module S (P →A[S] W) :=
+function.injective.module S ⟨λ f, f.to_affine_map.to_fun, rfl, coe_add⟩ coe_injective coe_smul
+
+end module_valued_maps
 
 end continuous_affine_map

--- a/src/topology/algebra/continuous_affine_map.lean
+++ b/src/topology/algebra/continuous_affine_map.lean
@@ -5,7 +5,7 @@ Authors: Oliver Nash
 -/
 import linear_algebra.affine_space.affine_map
 import topology.continuous_function.basic
-import topology.algebra.mul_action
+import topology.algebra.module
 
 /-!
 # Continuous affine maps.
@@ -207,3 +207,26 @@ function.injective.module S ⟨λ f, f.to_affine_map.to_fun, rfl, coe_add⟩ coe
 end module_valued_maps
 
 end continuous_affine_map
+
+namespace continuous_linear_map
+
+variables {R V W : Type*} [ring R]
+variables [add_comm_group V] [module R V] [topological_space V]
+variables [add_comm_group W] [module R W] [topological_space W]
+
+/-- A continuous linear map can be regarded as a continuous affine map. -/
+def to_continuous_affine_map (f : V →L[R] W) : V →A[R] W :=
+{ to_fun    := f,
+  linear    := f,
+  map_vadd' := by simp,
+  cont      := f.cont, }
+
+@[simp] lemma coe_to_continuous_affine_map (f : V →L[R] W) :
+  ⇑f.to_continuous_affine_map = f :=
+rfl
+
+@[simp] lemma to_continuous_affine_map_map_zero (f : V →L[R] W) :
+  f.to_continuous_affine_map 0 = 0 :=
+by simp
+
+end continuous_linear_map


### PR DESCRIPTION
Formalized as part of the Sphere Eversion project.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
