### PR TITLE
[Merged by Bors] - feat(analysis/{seminorm, convex/specific_functions}): A seminorm is convex

### DIFF
--- a/src/analysis/convex/function.lean
+++ b/src/analysis/convex/function.lean
@@ -178,10 +178,10 @@ lemma concave_on_iff_convex_hypograph :
 end ordered_smul
 
 section module
-variables [module 𝕜 E] [has_scalar 𝕜 β] {s : set E} {f : E → β} {c : E}
+variables [module 𝕜 E] [has_scalar 𝕜 β] {s : set E} {f : E → β}
 
 /-- Right translation preserves convexity. -/
-lemma convex_on.translate_right (hf : convex_on 𝕜 s f) :
+lemma convex_on.translate_right (hf : convex_on 𝕜 s f) (c : E) :
   convex_on 𝕜 ((λ z, c + z) ⁻¹' s) (f ∘ (λ z, c + z)) :=
 ⟨hf.1.translate_preimage_right _, λ x y hx hy a b ha hb hab,
   calc
@@ -190,19 +190,19 @@ lemma convex_on.translate_right (hf : convex_on 𝕜 s f) :
     ... ≤ a • f (c + x) + b • f (c + y) : hf.2 hx hy ha hb hab⟩
 
 /-- Right translation preserves concavity. -/
-lemma concave_on.translate_right (hf : concave_on 𝕜 s f) :
+lemma concave_on.translate_right (hf : concave_on 𝕜 s f) (c : E) :
   concave_on 𝕜 ((λ z, c + z) ⁻¹' s) (f ∘ (λ z, c + z)) :=
-hf.dual.translate_right
+hf.dual.translate_right _
 
 /-- Left translation preserves convexity. -/
-lemma convex_on.translate_left (hf : convex_on 𝕜 s f) :
+lemma convex_on.translate_left (hf : convex_on 𝕜 s f) (c : E) :
   convex_on 𝕜 ((λ z, c + z) ⁻¹' s) (f ∘ (λ z, z + c)) :=
-by simpa only [add_comm] using hf.translate_right
+by simpa only [add_comm] using hf.translate_right _
 
-/-- Left translation preserves strict concavity. -/
-lemma concave_on.translate_left (hf : concave_on 𝕜 s f) :
+/-- Left translation preserves concavity. -/
+lemma concave_on.translate_left (hf : concave_on 𝕜 s f) (c : E) :
   concave_on 𝕜 ((λ z, c + z) ⁻¹' s) (f ∘ (λ z, z + c)) :=
-hf.dual.translate_left
+hf.dual.translate_left _
 
 end module
 
@@ -710,10 +710,10 @@ end add_comm_monoid
 
 section add_cancel_comm_monoid
 variables [add_cancel_comm_monoid E] [ordered_add_comm_monoid β] [module 𝕜 E] [has_scalar 𝕜 β]
-  {s : set E} {f : E → β} {c : E}
+  {s : set E} {f : E → β}
 
 /-- Right translation preserves strict convexity. -/
-lemma strict_convex_on.translate_right (hf : strict_convex_on 𝕜 s f) :
+lemma strict_convex_on.translate_right (hf : strict_convex_on 𝕜 s f) (c : E) :
   strict_convex_on 𝕜 ((λ z, c + z) ⁻¹' s) (f ∘ (λ z, c + z)) :=
 ⟨hf.1.translate_preimage_right _, λ x y hx hy hxy a b ha hb hab,
   calc
@@ -722,19 +722,19 @@ lemma strict_convex_on.translate_right (hf : strict_convex_on 𝕜 s f) :
     ... < a • f (c + x) + b • f (c + y) : hf.2 hx hy ((add_right_injective c).ne hxy) ha hb hab⟩
 
 /-- Right translation preserves strict concavity. -/
-lemma strict_concave_on.translate_right (hf : strict_concave_on 𝕜 s f) :
+lemma strict_concave_on.translate_right (hf : strict_concave_on 𝕜 s f) (c : E) :
   strict_concave_on 𝕜 ((λ z, c + z) ⁻¹' s) (f ∘ (λ z, c + z)) :=
-hf.dual.translate_right
+hf.dual.translate_right _
 
 /-- Left translation preserves strict convexity. -/
-lemma strict_convex_on.translate_left (hf : strict_convex_on 𝕜 s f) :
+lemma strict_convex_on.translate_left (hf : strict_convex_on 𝕜 s f) (c : E) :
   strict_convex_on 𝕜 ((λ z, c + z) ⁻¹' s) (f ∘ (λ z, z + c)) :=
-by simpa only [add_comm] using hf.translate_right
+by simpa only [add_comm] using hf.translate_right _
 
 /-- Left translation preserves strict concavity. -/
-lemma strict_concave_on.translate_left (hf : strict_concave_on 𝕜 s f) :
+lemma strict_concave_on.translate_left (hf : strict_concave_on 𝕜 s f) (c : E) :
   strict_concave_on 𝕜 ((λ z, c + z) ⁻¹' s) (f ∘ (λ z, z + c)) :=
-by simpa only [add_comm] using hf.translate_right
+by simpa only [add_comm] using hf.translate_right _
 
 end add_cancel_comm_monoid
 end ordered_semiring

--- a/src/analysis/convex/specific_functions.lean
+++ b/src/analysis/convex/specific_functions.lean
@@ -23,7 +23,7 @@ In this file we prove that the following functions are convex:
 open real set
 open_locale big_operators
 
-/-- The norm of a real normed space is convex. -/
+/-- The norm of a real normed space is convex. Also see `seminorm.convex_on`. -/
 lemma convex_on_norm {E : Type*} [normed_group E] [normed_space ℝ E] :
   convex_on ℝ univ (norm : E → ℝ) :=
 ⟨convex_univ, λ x y hx hy a b ha hb hab,

--- a/src/analysis/convex/specific_functions.lean
+++ b/src/analysis/convex/specific_functions.lean
@@ -23,6 +23,14 @@ In this file we prove that the following functions are convex:
 open real set
 open_locale big_operators
 
+/-- The norm of a real normed space is convex. -/
+lemma convex_on_norm {E : Type*} [normed_group E] [normed_space ℝ E] :
+  convex_on ℝ univ (norm : E → ℝ) :=
+⟨convex_univ, λ x y hx hy a b ha hb hab,
+  calc ∥a • x + b • y∥ ≤ ∥a • x∥ + ∥b • y∥ : norm_add_le _ _
+    ... = a * ∥x∥ + b * ∥y∥
+        : by rw [norm_smul, norm_smul, real.norm_of_nonneg ha, real.norm_of_nonneg hb]⟩
+
 /-- `exp` is convex on the whole real line -/
 lemma convex_on_exp : convex_on ℝ univ exp :=
 convex_on_univ_of_deriv2_nonneg differentiable_exp (by simp)

--- a/src/analysis/seminorm.lean
+++ b/src/analysis/seminorm.lean
@@ -3,7 +3,7 @@ Copyright (c) 2019 Jean Lo. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jean Lo, Bhavik Mehta, Yaël Dillies
 -/
-import analysis.convex.basic
+import analysis.convex.function
 import analysis.normed_space.ordered
 import data.real.pointwise
 import data.set.intervals
@@ -338,30 +338,38 @@ balanced_ball_zero p r (-1) (by rw [norm_neg, norm_one]) ⟨x, hx, by rw [neg_sm
 end normed_field
 
 section normed_linear_ordered_field
-variables [normed_linear_ordered_field 𝕜] [add_comm_group E] [module ℝ E] [semi_normed_space ℝ 𝕜]
-  [module 𝕜 E] [is_scalar_tower ℝ 𝕜 E] (p : seminorm 𝕜 E) (c : 𝕜) (x y : E) (r : ℝ)
+variables [normed_linear_ordered_field 𝕜] [add_comm_group E] [semi_normed_space ℝ 𝕜] [module 𝕜 E]
+
+section has_scalar
+variables [has_scalar ℝ E] [is_scalar_tower ℝ 𝕜 E] (p : seminorm 𝕜 E)
+
+/-- A seminorm is convex. Also see `convex_on_norm`. -/
+protected lemma convex_on : convex_on ℝ univ p :=
+begin
+  refine ⟨convex_univ, λ x y _ _ a b ha hb hab, _⟩,
+  calc p (a • x + b • y) ≤ p (a • x) + p (b • y) : p.triangle _ _
+    ... = ∥a • (1 : 𝕜)∥ * p x + ∥b • (1 : 𝕜)∥ * p y
+        : by rw [←p.smul, ←p.smul, smul_one_smul, smul_one_smul]
+    ... = a * p x + b * p y
+        : by rw [norm_smul, norm_smul, norm_one, mul_one, mul_one, real.norm_of_nonneg ha,
+            real.norm_of_nonneg hb],
+end
+
+end has_scalar
+
+section module
+variables [module ℝ E] [is_scalar_tower ℝ 𝕜 E] (p : seminorm 𝕜 E) (c : 𝕜) (x : E) (r : ℝ)
 
 /-- Seminorm-balls are convex. -/
 lemma convex_ball : convex ℝ (ball p x r) :=
 begin
-  rw convex_iff_forall_pos,
-  rintro y z hy hz a b ha hb hab,
-  rw mem_ball at ⊢ hy hz,
-  calc p (a • y + b • z - x)
-        = p (a • (y - x) + b • (z - x))
-        : by rw [smul_sub, smul_sub, sub_add_comm, convex.combo_self hab x]
-    ... ≤ p (a • (y - x)) + p (b • (z - x)) : p.triangle _ _
-    ... = ∥a • (1 : 𝕜)∥ * p (y - x) + ∥b • (1 : 𝕜)∥ * p (z - x)
-        : by rw [←p.smul, ←p.smul, smul_one_smul, smul_one_smul]
-    ... = a * p (y - x) + b * p (z - x)
-        : by rw [norm_smul, norm_smul, norm_one, mul_one, mul_one, real.norm_eq_abs,
-            real.norm_eq_abs, abs_of_pos ha, abs_of_pos hb]
-    ... < a * r + b * r
-        : add_lt_add (mul_lt_mul_of_pos_left hy ha) (mul_lt_mul_of_pos_left hz hb)
-    ... = r
-        : by rw [←smul_eq_mul, ←smul_eq_mul, convex.combo_self hab _]
+  convert (p.convex_on.translate_left (-x)).convex_lt r,
+  ext y,
+  rw [preimage_univ, sep_univ, p.mem_ball x y r, sub_eq_add_neg],
+  refl,
 end
 
+end module
 end normed_linear_ordered_field
 
 -- TODO: convexity and absorbent/balanced sets in vector spaces over ℝ

--- a/src/analysis/seminorm.lean
+++ b/src/analysis/seminorm.lean
@@ -358,7 +358,7 @@ end
 end has_scalar
 
 section module
-variables [module ℝ E] [is_scalar_tower ℝ 𝕜 E] (p : seminorm 𝕜 E) (c : 𝕜) (x : E) (r : ℝ)
+variables [module ℝ E] [is_scalar_tower ℝ 𝕜 E] (p : seminorm 𝕜 E) (x : E) (r : ℝ)
 
 /-- Seminorm-balls are convex. -/
 lemma convex_ball : convex ℝ (ball p x r) :=


### PR DESCRIPTION
This proves `seminorm.convex_on`, `convex_on_norm` (which is morally a special case of the former) and leverages it to golf `seminorm.convex_ball`.

This also fixes the explicitness of arguments of `convex_on.translate_left` and friends.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
@hrmacbeth, this too partly comes from your branch `triangles`.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
