### PR TITLE
[Merged by Bors] - feat(data/finset/basic): add card_insert_eq_ite

### DIFF
--- a/src/data/finset/basic.lean
+++ b/src/data/finset/basic.lean
@@ -2293,6 +2293,14 @@ theorem card_insert_le [decidable_eq α] (a : α) (s : finset α) : card (insert
 by by_cases a ∈ s; [{rw [insert_eq_of_mem h], apply nat.le_add_right},
 rw [card_insert_of_not_mem h]]
 
+theorem card_insert_eq_ite [decidable_eq α] {a : α} {s : finset α} :
+  card (insert a s) = if a ∈ s then card s else card s + 1 :=
+begin
+  by_cases h : a ∈ s,
+  rw [card_insert_of_mem h, if_pos h],
+  rw [card_insert_of_not_mem h, if_neg h],
+end
+
 @[simp] theorem card_singleton (a : α) : card ({a} : finset α) = 1 := card_singleton _
 
 lemma card_singleton_inter [decidable_eq α] {x : α} {s : finset α} : ({x} ∩ s).card ≤ 1 :=

--- a/src/data/finset/basic.lean
+++ b/src/data/finset/basic.lean
@@ -2293,6 +2293,7 @@ theorem card_insert_le [decidable_eq α] (a : α) (s : finset α) : card (insert
 by by_cases a ∈ s; [{rw [insert_eq_of_mem h], apply nat.le_add_right},
 rw [card_insert_of_not_mem h]]
 
+/-- If `a ∈ s` is known, see also `finset.card_insert_of_mem` and `finset.card_insert_of_not_mem`. -/
 theorem card_insert_eq_ite [decidable_eq α] {a : α} {s : finset α} :
   card (insert a s) = if a ∈ s then card s else card s + 1 :=
 begin

--- a/src/data/finset/basic.lean
+++ b/src/data/finset/basic.lean
@@ -2293,7 +2293,8 @@ theorem card_insert_le [decidable_eq α] (a : α) (s : finset α) : card (insert
 by by_cases a ∈ s; [{rw [insert_eq_of_mem h], apply nat.le_add_right},
 rw [card_insert_of_not_mem h]]
 
-/-- If `a ∈ s` is known, see also `finset.card_insert_of_mem` and `finset.card_insert_of_not_mem`. -/
+/-- If `a ∈ s` is known, see also `finset.card_insert_of_mem` and
+`finset.card_insert_of_not_mem`. -/
 theorem card_insert_eq_ite [decidable_eq α] {a : α} {s : finset α} :
   card (insert a s) = if a ∈ s then card s else card s + 1 :=
 begin

--- a/src/data/finset/basic.lean
+++ b/src/data/finset/basic.lean
@@ -2299,8 +2299,8 @@ theorem card_insert_eq_ite [decidable_eq α] {a : α} {s : finset α} :
   card (insert a s) = if a ∈ s then card s else card s + 1 :=
 begin
   by_cases h : a ∈ s,
-  rw [card_insert_of_mem h, if_pos h],
-  rw [card_insert_of_not_mem h, if_neg h],
+  { rw [card_insert_of_mem h, if_pos h] },
+  { rw [card_insert_of_not_mem h, if_neg h] },
 end
 
 @[simp] theorem card_singleton (a : α) : card ({a} : finset α) = 1 := card_singleton _


### PR DESCRIPTION

Adds the lemma `card_insert_eq_ite` combining the functionality of `card_insert_of_not_mem` and `card_insert_of_mem`, analogous to how `card_erase_eq_ite`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
