### PR TITLE
[Merged by Bors] - doc(algebra/algebra/basic): expand the docstring

### DIFF
--- a/src/algebra/algebra/basic.lean
+++ b/src/algebra/algebra/basic.lean
@@ -90,6 +90,9 @@ all be relaxed independently; for instance, this allows us to:
   `R`-algebra `A`.
 While `alg_hom R A B` cannot be used in the second approach, `non_unital_alg_hom R A B` still can.
 
+You should always use the first approach when working with associative unital algebras, and mimic
+the second approach only when you need to weaken a condition on either `R` or `A`.
+
 -/
 
 universes u v w u₁ v₁

--- a/src/algebra/algebra/basic.lean
+++ b/src/algebra/algebra/basic.lean
@@ -41,14 +41,27 @@ set_option extends_priority 200 /- control priority of
 `instance [algebra R A] : has_scalar R A` -/
 
 /--
-Given a commutative (semi)ring `R`, an `R`-algebra is a (possibly noncommutative)
-(semi)ring `A` endowed with a morphism of rings `R →+* A` which lands in the
-center of `A`.
+Given a commutative (semi)ring `R`, an `R`-algebra is a (possibly noncommutative) (semi)ring `A`
+endowed with a morphism of rings `R →+* A` denoted `algebra_map R A` which lands in the center of
+`A`.
 
-For convenience, this typeclass extends `has_scalar R A` where the scalar action must
-agree with left multiplication by the image of the structure morphism.
+Alternatively, an `R`-algebra is an `R`-module over a semiring `A` such that the action associates
+with multiplication as `r • (a₁ * a₂) = (r • a₁) * a₂ = a₁ * (r • a₂)`.
 
-Given an `algebra R A` instance, the structure morphism `R →+* A` is denoted `algebra_map R A`.
+For convenience, we define `algebra R A` as the first case, but ensure compatibility with the second
+by having this typeclass extend `has_scalar R A` where the scalar action must agree with left
+multiplication by the image of the structure morphism (that is `r • x` = `algebra_map R A r * x`).
+
+For algebras in more general settings, such as when `A` has no `1` or is not associative, use:
+```lean
+[module R A] [smul_comm_class R A A] [is_scalar_tower R A A]
+```
+instead of
+```lean
+[algebra R A]
+```
+as the former places weaker contraints on the typeclasses that `R` and `A` must individually
+satisfy. The lemmas `mul_smul_comm` and `smul_mul_assoc` will work in both cases.
 -/
 @[nolint has_inhabited_instance]
 class algebra (R : Type u) (A : Type v) [comm_semiring R] [semiring A]

--- a/src/algebra/algebra/basic.lean
+++ b/src/algebra/algebra/basic.lean
@@ -41,27 +41,41 @@ set_option extends_priority 200 /- control priority of
 `instance [algebra R A] : has_scalar R A` -/
 
 /--
-Given a commutative (semi)ring `R`, an `R`-algebra is a (possibly noncommutative) (semi)ring `A`
-endowed with a morphism of rings `R →+* A` denoted `algebra_map R A` which lands in the center of
-`A`.
+Given a commutative (semi)ring `R`, there are two ways to define an `R`-algebra structure on a
+(possibly noncommutative) (semi)ring `A`:
+* By endowing `A` with a morphism of rings `R →+* A` denoted `algebra_map R A` which lands in the
+  center of `A`.
+* By requiring `A` be an `R`-module such that the action associates and commutes with multiplication
+  as `r • (a₁ * a₂) = (r • a₁) * a₂ = a₁ * (r • a₂)`.
 
-Alternatively, an `R`-algebra is an `R`-module over a semiring `A` such that the action associates
-with multiplication as `r • (a₁ * a₂) = (r • a₁) * a₂ = a₁ * (r • a₂)`.
+We define `algebra R A` as in a way that subsumes both definitions, by extending `has_scalar R A`
+and requiring that this scalar action `r • x` must agree with left multiplication by the image of
+the structure morphism `algebra_map R A r * x`.
 
-For convenience, we define `algebra R A` as the first case, but ensure compatibility with the second
-by having this typeclass extend `has_scalar R A` where the scalar action must agree with left
-multiplication by the image of the structure morphism (that is `r • x` = `algebra_map R A r * x`).
-
-For algebras in more general settings, such as when `A` has no `1` or is not associative, use:
+As a result, there are two ways to talk about an `R`-algebra `A` when `A` is a semiring:
+1. ```lean
+   variables [comm_semiring R] [semiring A]
+   variables [algebra R A]
+   ```
+2. ```lean
+   variables [comm_semiring R] [semiring A]
+   variables [module R A] [smul_comm_class R A A] [is_scalar_tower R A A]
+   ```
+The first approach implies the second via typeclass search; so any lemma stated with the second set
+of arguments will automatically apply to the first set. Typeclass search does not know that the
+second approach implies the first, but this can be shown with:
 ```lean
-[module R A] [smul_comm_class R A A] [is_scalar_tower R A A]
+example {R A : Type*} [comm_semiring R] [semiring A]
+  [module R A] [smul_comm_class R A A] [is_scalar_tower R A A] : algebra R A :=
+algebra.of_module smul_mul_assoc mul_smul_comm
 ```
-instead of
-```lean
-[algebra R A]
-```
-as the former places weaker contraints on the typeclasses that `R` and `A` must individually
-satisfy. The lemmas `mul_smul_comm` and `smul_mul_assoc` will work in both cases.
+
+The advantage of the second approach is that `comm_semiring R`, `semiring A`, and `module R A` can
+all be relaxed independently; for instance, this allows us to:
+* Replace `semiring A` with `non_unital_non_assoc_semiring A` in order to describe Lie algebras
+* Replace `comm_semiring R` and `module R A` with `comm_group R'` and `distrib_mul_action R' A`,
+  which when `R' = units R` lets us talk about the "algebra-like" action of `units R` on an
+  `R`-algebra `A`.
 -/
 @[nolint has_inhabited_instance]
 class algebra (R : Type u) (A : Type v) [comm_semiring R] [semiring A]
@@ -1449,3 +1463,7 @@ variables [algebra R A] [algebra R B]
   .. f.to_ring_hom.comp_left I }
 
 end alg_hom
+
+example {R A} [comm_semiring R] [semiring A]
+  [module R A] [smul_comm_class R A A] [is_scalar_tower R A A] : algebra R A :=
+algebra.of_module smul_mul_assoc mul_smul_comm

--- a/src/algebra/algebra/basic.lean
+++ b/src/algebra/algebra/basic.lean
@@ -48,9 +48,9 @@ Given a commutative (semi)ring `R`, there are two ways to define an `R`-algebra 
 * By requiring `A` be an `R`-module such that the action associates and commutes with multiplication
   as `r • (a₁ * a₂) = (r • a₁) * a₂ = a₁ * (r • a₂)`.
 
-We define `algebra R A` as in a way that subsumes both definitions, by extending `has_scalar R A`
-and requiring that this scalar action `r • x` must agree with left multiplication by the image of
-the structure morphism `algebra_map R A r * x`.
+We define `algebra R A` in a way that subsumes both definitions, by extending `has_scalar R A` and
+requiring that this scalar action `r • x` must agree with left multiplication by the image of the
+structure morphism `algebra_map R A r * x`.
 
 As a result, there are two ways to talk about an `R`-algebra `A` when `A` is a semiring:
 1. ```lean
@@ -70,12 +70,18 @@ example {R A : Type*} [comm_semiring R] [semiring A]
 algebra.of_module smul_mul_assoc mul_smul_comm
 ```
 
+The advantage of the first approach is that `algebra_map R A` is available, and `alg_hom R A B` and
+`subalgebra R A` can be used. For concrete `R` and `A`, `algebra_map R A` is often definitionally
+convenient.
+
 The advantage of the second approach is that `comm_semiring R`, `semiring A`, and `module R A` can
 all be relaxed independently; for instance, this allows us to:
-* Replace `semiring A` with `non_unital_non_assoc_semiring A` in order to describe Lie algebras
+* Replace `semiring A` with `non_unital_non_assoc_semiring A` in order to describe non-unital and/or
+  non-associative algebras.
 * Replace `comm_semiring R` and `module R A` with `comm_group R'` and `distrib_mul_action R' A`,
   which when `R' = units R` lets us talk about the "algebra-like" action of `units R` on an
   `R`-algebra `A`.
+While `alg_hom R A B` cannot be used in the second approach, `non_unital_alg_hom R A B` still can.
 -/
 @[nolint has_inhabited_instance]
 class algebra (R : Type u) (A : Type v) [comm_semiring R] [semiring A]

--- a/src/algebra/algebra/basic.lean
+++ b/src/algebra/algebra/basic.lean
@@ -12,35 +12,42 @@ import tactic.abel
 /-!
 # Algebras over commutative semirings
 
-In this file we define `algebra`s over commutative (semi)rings, algebra homomorphisms `alg_hom`,
-and algebra equivalences `alg_equiv`.
-We also define the usual operations on `alg_hom`s (`id`, `comp`).
+In this file we define associative unital `algebra`s over commutative (semi)rings, algebra
+homomorphisms `alg_hom`, and algebra equivalences `alg_equiv`.
 
 `subalgebra`s are defined in `algebra.algebra.subalgebra`.
 
-If `S` is an `R`-algebra and `A` is an `S`-algebra then `algebra.comap.algebra R S A` can be used
-to provide `A` with a structure of an `R`-algebra. Other than that, `algebra.comap` is now
-deprecated and replaced with `is_scalar_tower`.
-
 For the category of `R`-algebras, denoted `Algebra R`, see the file
 `algebra/category/Algebra/basic.lean`.
+
+See the implementation notes for remarks about non-associative and non-unital algebras.
+
+## Main definitions:
+
+* `algebra R A`: the algebra typeclass.
+* `alg_hom R A B`: the type of `R`-algebra morphisms from `A` to `B`.
+* `alg_equiv R A B`: the type of `R`-algebra isomorphisms between `A` to `B`.
+* `algebra_map R A : R →+* A`: the canonical map from `R` to `A`, as a `ring_hom`. This is the
+  preferred spelling of this map.
+* `algebra.linear_map R A : R →ₗ[R] A`: the canonical map from `R` to `A`, as a `linear_map`.
+* `algebra.of_id R A : R →ₐ[R] A`: the canonical map from `R` to `A`, as n `alg_hom`.
+* Instances of `algebra` in this file:
+  * `algebra.id`
+  * `pi.algebra`
+  * `prod.algebra`
+  * `algebra_nat`
+  * `algebra_int`
+  * `algebra_rat`
+  * `opposite.algebra`
+  * `module.End.algebra`
 
 ## Notations
 
 * `A →ₐ[R] B` : `R`-algebra homomorphism from `A` to `B`.
 * `A ≃ₐ[R] B` : `R`-algebra equivalence from `A` to `B`.
--/
 
-universes u v w u₁ v₁
+## Implementation notes
 
-open_locale big_operators
-
-section prio
--- We set this priority to 0 later in this file
-set_option extends_priority 200 /- control priority of
-`instance [algebra R A] : has_scalar R A` -/
-
-/--
 Given a commutative (semi)ring `R`, there are two ways to define an `R`-algebra structure on a
 (possibly noncommutative) (semi)ring `A`:
 * By endowing `A` with a morphism of rings `R →+* A` denoted `algebra_map R A` which lands in the
@@ -82,6 +89,22 @@ all be relaxed independently; for instance, this allows us to:
   which when `R' = units R` lets us talk about the "algebra-like" action of `units R` on an
   `R`-algebra `A`.
 While `alg_hom R A B` cannot be used in the second approach, `non_unital_alg_hom R A B` still can.
+
+-/
+
+universes u v w u₁ v₁
+
+open_locale big_operators
+
+section prio
+-- We set this priority to 0 later in this file
+set_option extends_priority 200 /- control priority of
+`instance [algebra R A] : has_scalar R A` -/
+
+/--
+An associative unital `R`-algebra is a semiring `A` equipped with a map into its center `R → A`.
+
+See the implementation notes in this file for discussion of the details of this definition.
 -/
 @[nolint has_inhabited_instance]
 class algebra (R : Type u) (A : Type v) [comm_semiring R] [semiring A]


### PR DESCRIPTION
This doesn't rule out having a better way to spell "non-unital non-associative algebra" in future, but let's document how it can be done today.

Much of this description is taken from [my talk at CICM's FMM](https://eric-wieser.github.io/fmm-2021/#/algebras).

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
