### PR TITLE
[Merged by Bors] - feat(algebra/order/sub): An `add_group` has ordered subtraction

### DIFF
--- a/src/algebra/order/group.lean
+++ b/src/algebra/order/group.lean
@@ -582,10 +582,10 @@ by rw [← mul_le_mul_iff_right c, div_eq_mul_inv, inv_mul_cancel_right]
 
 -- TODO: Should we get rid of `sub_le_iff_le_add` in favor of
 -- (a renamed version of) `tsub_le_iff_right`?
-instance add_group.to_has_ordered_sub [add_group α] [has_le α]
+@[priority 100] -- see Note [lower instance priority]
+instance add_group.to_has_ordered_sub {α : Type*} [add_group α] [has_le α]
   [covariant_class α α (swap (+)) (≤)] : has_ordered_sub α :=
 ⟨λ a b c, sub_le_iff_le_add⟩
-
 /-- `equiv.mul_right` as an `order_iso`. See also `order_embedding.mul_right`. -/
 @[to_additive "`equiv.add_right` as an `order_iso`. See also `order_embedding.add_right`.",
   simps to_equiv apply {simp_rhs := tt}]

--- a/src/algebra/order/group.lean
+++ b/src/algebra/order/group.lean
@@ -580,7 +580,8 @@ alias le_sub_iff_add_le ↔ add_le_of_le_sub_right le_sub_right_of_add_le
 lemma div_le_iff_le_mul : a / c ≤ b ↔ a ≤ b * c :=
 by rw [← mul_le_mul_iff_right c, div_eq_mul_inv, inv_mul_cancel_right]
 
---TODO: Should -/
+-- TODO: Should we get rid of `sub_le_iff_le_add` in favor of
+-- (a renamed version of) `tsub_le_iff_right`?
 instance add_group.to_has_ordered_sub [add_group α] [has_le α]
   [covariant_class α α (swap (+)) (≤)] : has_ordered_sub α :=
 ⟨λ a b c, sub_le_iff_le_add⟩

--- a/src/algebra/order/group.lean
+++ b/src/algebra/order/group.lean
@@ -3,9 +3,9 @@ Copyright (c) 2016 Jeremy Avigad. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jeremy Avigad, Leonardo de Moura, Mario Carneiro, Johannes Hölzl
 -/
-import algebra.order.monoid
-import order.order_dual
 import algebra.abs
+import algebra.order.sub
+import order.order_dual
 
 /-!
 # Ordered groups
@@ -579,6 +579,11 @@ alias le_sub_iff_add_le ↔ add_le_of_le_sub_right le_sub_right_of_add_le
 @[to_additive]
 lemma div_le_iff_le_mul : a / c ≤ b ↔ a ≤ b * c :=
 by rw [← mul_le_mul_iff_right c, div_eq_mul_inv, inv_mul_cancel_right]
+
+--TODO: Should -/
+instance add_group.to_has_ordered_sub [add_group α] [has_le α]
+  [covariant_class α α (swap (+)) (≤)] : has_ordered_sub α :=
+⟨λ a b c, sub_le_iff_le_add⟩
 
 /-- `equiv.mul_right` as an `order_iso`. See also `order_embedding.mul_right`. -/
 @[to_additive "`equiv.add_right` as an `order_iso`. See also `order_embedding.add_right`.",

--- a/src/algebra/order/sub.lean
+++ b/src/algebra/order/sub.lean
@@ -3,7 +3,7 @@ Copyright (c) 2021 Floris van Doorn. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Floris van Doorn
 -/
-import algebra.order.group
+import algebra.order.monoid
 /-!
 # Ordered Subtraction
 
@@ -49,10 +49,6 @@ in canonically ordered monoids on many specific types.
 -/
 class has_ordered_sub (α : Type*) [has_le α] [has_add α] [has_sub α] :=
 (tsub_le_iff_right : ∀ a b c : α, a - b ≤ c ↔ a ≤ c + b)
-
-instance add_group.to_has_ordered_sub [add_group α] [has_le α]
-  [covariant_class α α (swap (+)) (≤)] : has_ordered_sub α :=
-⟨λ a b c, sub_le_iff_le_add⟩
 
 section has_add
 

--- a/src/algebra/order/sub.lean
+++ b/src/algebra/order/sub.lean
@@ -3,7 +3,7 @@ Copyright (c) 2021 Floris van Doorn. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Floris van Doorn
 -/
-import algebra.order.monoid
+import algebra.order.group
 /-!
 # Ordered Subtraction
 
@@ -37,6 +37,8 @@ TODO: generalize `nat.le_of_le_of_sub_le_sub_right`, `nat.sub_le_sub_right_iff`,
   `nat.mul_self_sub_mul_self_eq`
 -/
 
+open function
+
 variables {α β : Type*}
 
 /-- `has_ordered_sub α` means that `α` has a subtraction characterized by `a - b ≤ c ↔ a ≤ c + b`.
@@ -47,6 +49,10 @@ in canonically ordered monoids on many specific types.
 -/
 class has_ordered_sub (α : Type*) [has_le α] [has_add α] [has_sub α] :=
 (tsub_le_iff_right : ∀ a b c : α, a - b ≤ c ↔ a ≤ c + b)
+
+instance add_group.to_has_ordered_sub [add_group α] [has_le α]
+  [covariant_class α α (swap (+)) (≤)] : has_ordered_sub α :=
+⟨λ a b c, sub_le_iff_le_add⟩
 
 section has_add
 

--- a/src/algebra/order/sub.lean
+++ b/src/algebra/order/sub.lean
@@ -37,8 +37,6 @@ TODO: generalize `nat.le_of_le_of_sub_le_sub_right`, `nat.sub_le_sub_right_iff`,
   `nat.mul_self_sub_mul_self_eq`
 -/
 
-open function
-
 variables {α β : Type*}
 
 /-- `has_ordered_sub α` means that `α` has a subtraction characterized by `a - b ≤ c ↔ a ≤ c + b`.

--- a/src/data/real/ennreal.lean
+++ b/src/data/real/ennreal.lean
@@ -1396,7 +1396,10 @@ end
 lemma le_to_real_sub {a b : ℝ≥0∞} (hb : b ≠ ∞) : a.to_real - b.to_real ≤ (a - b).to_real :=
 begin
   lift b to ℝ≥0 using hb,
-  cases a; simp [none_eq_top, some_eq_coe, ← coe_sub, nnreal.sub_def] at *
+  cases a,
+  { simp },
+  { simp only [some_eq_coe, ←coe_sub, nnreal.sub_def, real.coe_to_nnreal', coe_to_real],
+    exact le_max_left _ _ }
 end
 
 lemma to_real_add_le : (a+b).to_real ≤ a.to_real + b.to_real :=


### PR DESCRIPTION
This wraps up `sub_le_iff_le_add` in an `has_ordered_sub` instance.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
