### PR TITLE
[Merged by Bors] - chore(topology/algebra/mul_action): define `has_continuous_vadd` using `to_additive`

### DIFF
--- a/src/analysis/normed_space/add_torsor.lean
+++ b/src/analysis/normed_space/add_torsor.lean
@@ -183,16 +183,12 @@ lemma uniform_continuous_vadd : uniform_continuous (λ x : V × P, x.1 +ᵥ x.2)
 lemma uniform_continuous_vsub : uniform_continuous (λ x : P × P, x.1 -ᵥ x.2) :=
 (lipschitz_with.prod_fst.vsub lipschitz_with.prod_snd).uniform_continuous
 
-lemma continuous_vadd : continuous (λ x : V × P, x.1 +ᵥ x.2) :=
-uniform_continuous_vadd.continuous
+instance semi_normed_add_torsor.has_continuous_vadd :
+  has_continuous_vadd V P :=
+{ continuous_vadd := uniform_continuous_vadd.continuous }
 
 lemma continuous_vsub : continuous (λ x : P × P, x.1 -ᵥ x.2) :=
 uniform_continuous_vsub.continuous
-
-lemma filter.tendsto.vadd {l : filter α} {f : α → V} {g : α → P} {v : V} {p : P}
-  (hf : tendsto f l (𝓝 v)) (hg : tendsto g l (𝓝 p)) :
-  tendsto (f +ᵥ g) l (𝓝 (v +ᵥ p)) :=
-(continuous_vadd.tendsto (v, p)).comp (hf.prod_mk_nhds hg)
 
 lemma filter.tendsto.vsub {l : filter α} {f g : α → P} {x y : P}
   (hf : tendsto f l (𝓝 x)) (hg : tendsto g l (𝓝 y)) :
@@ -203,27 +199,13 @@ section
 
 variables [topological_space α]
 
-lemma continuous.vadd {f : α → V} {g : α → P} (hf : continuous f) (hg : continuous g) :
-  continuous (f +ᵥ g) :=
-continuous_vadd.comp (hf.prod_mk hg)
-
 lemma continuous.vsub {f g : α → P} (hf : continuous f) (hg : continuous g) :
   continuous (f -ᵥ g) :=
 continuous_vsub.comp (hf.prod_mk hg : _)
 
-lemma continuous_at.vadd {f : α → V} {g : α → P} {x : α} (hf : continuous_at f x)
-  (hg : continuous_at g x) :
-  continuous_at (f +ᵥ g) x :=
-hf.vadd hg
-
 lemma continuous_at.vsub {f g : α → P}  {x : α} (hf : continuous_at f x) (hg : continuous_at g x) :
   continuous_at (f -ᵥ g) x :=
 hf.vsub hg
-
-lemma continuous_within_at.vadd {f : α → V} {g : α → P} {x : α} {s : set α}
-  (hf : continuous_within_at f s x) (hg : continuous_within_at g s x) :
-  continuous_within_at (f +ᵥ g) s x :=
-hf.vadd hg
 
 lemma continuous_within_at.vsub {f g : α → P} {x : α} {s : set α}
   (hf : continuous_within_at f s x) (hg : continuous_within_at g s x) :

--- a/src/analysis/normed_space/add_torsor.lean
+++ b/src/analysis/normed_space/add_torsor.lean
@@ -183,7 +183,7 @@ lemma uniform_continuous_vadd : uniform_continuous (λ x : V × P, x.1 +ᵥ x.2)
 lemma uniform_continuous_vsub : uniform_continuous (λ x : P × P, x.1 -ᵥ x.2) :=
 (lipschitz_with.prod_fst.vsub lipschitz_with.prod_snd).uniform_continuous
 
-instance semi_normed_add_torsor.has_continuous_vadd :
+@[priority 100] instance semi_normed_add_torsor.has_continuous_vadd :
   has_continuous_vadd V P :=
 { continuous_vadd := uniform_continuous_vadd.continuous }
 

--- a/src/topology/algebra/mul_action.lean
+++ b/src/topology/algebra/mul_action.lean
@@ -175,8 +175,8 @@ protected def homeomorph.smul (c : G) : α ≃ₜ α :=
   continuous_to_fun  := continuous_id.const_smul _,
   continuous_inv_fun := continuous_id.const_smul _ }
 
-/-- Scalar multiplication by a unit of a monoid `M` acting on `α` is a homeomorphism from `α`
-to itself. -/
+/-- Scalar multiplication by an element of an additive group `G` acting on `α` is a homeomorphism
+from `α` to itself. -/
 protected def homeomorph.vadd {G : Type*} [topological_space G] [add_group G] [add_action G α]
   [has_continuous_vadd G α] (c : G) : α ≃ₜ α :=
 { to_equiv := add_action.to_perm_hom α G c,

--- a/src/topology/algebra/mul_action.lean
+++ b/src/topology/algebra/mul_action.lean
@@ -112,7 +112,7 @@ lemma continuous_on.const_smul (hg : continuous_on g s) (c : M) :
   continuous_on (λ x, c • g x) s :=
 λ x hx, (hg x hx).const_smul c
 
-@[to_additive, continuity]
+@[continuity, to_additive]
 lemma continuous.smul (hf : continuous f) (hg : continuous g) :
   continuous (λ x, f x • g x) :=
 continuous_smul.comp (hf.prod_mk hg)

--- a/src/topology/algebra/mul_action.lean
+++ b/src/topology/algebra/mul_action.lean
@@ -175,7 +175,7 @@ protected def homeomorph.smul (c : G) : α ≃ₜ α :=
   continuous_to_fun  := continuous_id.const_smul _,
   continuous_inv_fun := continuous_id.const_smul _ }
 
-/-- Scalar multiplication by an element of an additive group `G` acting on `α` is a homeomorphism
+/-- Affine-addition of an element of an additive group `G` acting on `α` is a homeomorphism
 from `α` to itself. -/
 protected def homeomorph.vadd {G : Type*} [topological_space G] [add_group G] [add_action G α]
   [has_continuous_vadd G α] (c : G) : α ≃ₜ α :=

--- a/src/topology/algebra/mul_action.lean
+++ b/src/topology/algebra/mul_action.lean
@@ -44,12 +44,22 @@ class has_continuous_smul (M α : Type*) [has_scalar M α]
 
 export has_continuous_smul (continuous_smul)
 
+/-- Class `has_continuous_vadd M α` says that the additive action `(+ᵥ) : M → α → α`
+is continuous in both arguments. We use the same class for all kinds of additive actions,
+including (semi)modules and algebras. -/
+class has_continuous_vadd (M α : Type*) [has_vadd M α]
+  [topological_space M] [topological_space α] : Prop :=
+(continuous_vadd : continuous (λp : M × α, p.1 +ᵥ p.2))
+
+export has_continuous_vadd (continuous_vadd)
+
 variables {M α β : Type*} [topological_space M] [topological_space α]
 
 section has_scalar
 
 variables [has_scalar M α] [has_continuous_smul M α]
 
+@[to_additive]
 lemma filter.tendsto.smul {f : β → M} {g : β → α} {l : filter β} {c : M} {a : α}
   (hf : tendsto f l (𝓝 c)) (hg : tendsto g l (𝓝 a)) :
   tendsto (λ x, f x • g x) l (𝓝 $ c • a) :=

--- a/src/topology/algebra/mul_action.lean
+++ b/src/topology/algebra/mul_action.lean
@@ -53,6 +53,8 @@ class has_continuous_vadd (M α : Type*) [has_vadd M α]
 
 export has_continuous_vadd (continuous_vadd)
 
+attribute [to_additive] has_continuous_smul
+
 variables {M α β : Type*} [topological_space M] [topological_space α]
 
 section has_scalar
@@ -65,11 +67,13 @@ lemma filter.tendsto.smul {f : β → M} {g : β → α} {l : filter β} {c : M}
   tendsto (λ x, f x • g x) l (𝓝 $ c • a) :=
 (continuous_smul.tendsto _).comp (hf.prod_mk_nhds hg)
 
+@[to_additive]
 lemma filter.tendsto.const_smul {f : β → α} {l : filter β} {a : α} (hf : tendsto f l (𝓝 a))
   (c : M) :
   tendsto (λ x, c • f x) l (𝓝 (c • a)) :=
 tendsto_const_nhds.smul hf
 
+@[to_additive]
 lemma filter.tendsto.smul_const {f : β → M} {l : filter β} {c : M}
   (hf : tendsto f l (𝓝 c)) (a : α) :
   tendsto (λ x, (f x) • a) l (𝓝 (c • a)) :=
@@ -77,36 +81,43 @@ hf.smul tendsto_const_nhds
 
 variables [topological_space β] {f : β → M} {g : β → α} {b : β} {s : set β}
 
+@[to_additive]
 lemma continuous_within_at.smul (hf : continuous_within_at f s b)
   (hg : continuous_within_at g s b) :
   continuous_within_at (λ x, f x • g x) s b :=
 hf.smul hg
 
+@[to_additive]
 lemma continuous_within_at.const_smul (hg : continuous_within_at g s b) (c : M) :
   continuous_within_at (λ x, c • g x) s b :=
 hg.const_smul c
 
+@[to_additive]
 lemma continuous_at.smul (hf : continuous_at f b) (hg : continuous_at g b) :
   continuous_at (λ x, f x • g x) b :=
 hf.smul hg
 
+@[to_additive]
 lemma continuous_at.const_smul (hg : continuous_at g b) (c : M) :
   continuous_at (λ x, c • g x) b :=
 hg.const_smul c
 
+@[to_additive]
 lemma continuous_on.smul (hf : continuous_on f s) (hg : continuous_on g s) :
   continuous_on (λ x, f x • g x) s :=
 λ x hx, (hf x hx).smul (hg x hx)
 
+@[to_additive]
 lemma continuous_on.const_smul (hg : continuous_on g s) (c : M) :
   continuous_on (λ x, c • g x) s :=
 λ x hx, (hg x hx).const_smul c
 
-@[continuity]
+@[to_additive, continuity]
 lemma continuous.smul (hf : continuous f) (hg : continuous g) :
   continuous (λ x, f x • g x) :=
 continuous_smul.comp (hf.prod_mk hg)
 
+@[to_additive]
 lemma continuous.const_smul (hg : continuous g) (c : M) :
   continuous (λ x, c • g x) :=
 continuous_smul.comp (continuous_const.prod_mk hg)
@@ -129,6 +140,7 @@ section group
 variables {G : Type*} [topological_space G] [group G] [mul_action G α]
   [has_continuous_smul G α]
 
+@[to_additive]
 lemma tendsto_const_smul_iff {f : β → α} {l : filter β} {a : α} (c : G) :
   tendsto (λ x, c • f x) l (𝓝 $ c • a) ↔ tendsto f l (𝓝 a) :=
 ⟨λ h, by simpa only [inv_smul_smul] using h.const_smul c⁻¹,
@@ -136,32 +148,48 @@ lemma tendsto_const_smul_iff {f : β → α} {l : filter β} {a : α} (c : G) :
 
 variables [topological_space β] {f : β → α} {b : β}  {s : set β}
 
+@[to_additive]
 lemma continuous_within_at_const_smul_iff (c : G) :
   continuous_within_at (λ x, c • f x) s b ↔ continuous_within_at f s b :=
 tendsto_const_smul_iff c
 
+@[to_additive]
 lemma continuous_on_const_smul_iff (c : G) :
   continuous_on (λ x, c • f x) s ↔ continuous_on f s :=
 forall_congr $ λ b, forall_congr $ λ hb, continuous_within_at_const_smul_iff c
 
+@[to_additive]
 lemma continuous_at_const_smul_iff (c : G) :
   continuous_at (λ x, c • f x) b ↔ continuous_at f b :=
 tendsto_const_smul_iff c
 
+@[to_additive]
 lemma continuous_const_smul_iff (c : G) :
   continuous (λ x, c • f x) ↔ continuous f :=
 by simp only [continuous_iff_continuous_at, continuous_at_const_smul_iff]
 
-/-- Scalar multiplication by a unit of a monoid `M` acting on `α` is a homeomorphism from `α`
+/-- Scalar multiplication by an element of a group `G` acting on `α` is a homeomorphism from `α`
 to itself. -/
 protected def homeomorph.smul (c : G) : α ≃ₜ α :=
 { to_equiv := mul_action.to_perm_hom G α c,
   continuous_to_fun  := continuous_id.const_smul _,
   continuous_inv_fun := continuous_id.const_smul _ }
 
+/-- Scalar multiplication by a unit of a monoid `M` acting on `α` is a homeomorphism from `α`
+to itself. -/
+protected def homeomorph.vadd {G : Type*} [topological_space G] [add_group G] [add_action G α]
+  [has_continuous_vadd G α] (c : G) : α ≃ₜ α :=
+{ to_equiv := add_action.to_perm_hom α G c,
+  continuous_to_fun  := continuous_id.const_vadd _,
+  continuous_inv_fun := continuous_id.const_vadd _ }
+
+attribute [to_additive] homeomorph.smul
+
+@[to_additive]
 lemma is_open_map_smul (c : G) : is_open_map (λ x : α, c • x) :=
 (homeomorph.smul c).is_open_map
 
+@[to_additive]
 lemma is_closed_map_smul (c : G) : is_closed_map (λ x : α, c • x) :=
 (homeomorph.smul c).is_closed_map
 
@@ -258,17 +286,20 @@ let ⟨u, hu⟩ := hc in hu ▸ is_closed_map_smul u
 
 end is_unit
 
+@[to_additive]
 instance has_continuous_mul.has_continuous_smul {M : Type*} [monoid M]
   [topological_space M] [has_continuous_mul M] :
   has_continuous_smul M M :=
 ⟨continuous_mul⟩
 
+@[to_additive]
 instance [topological_space β] [has_scalar M α] [has_scalar M β] [has_continuous_smul M α]
   [has_continuous_smul M β] :
   has_continuous_smul M (α × β) :=
 ⟨(continuous_fst.smul (continuous_fst.comp continuous_snd)).prod_mk
   (continuous_fst.smul (continuous_snd.comp continuous_snd))⟩
 
+@[to_additive]
 instance {ι : Type*} {γ : ι → Type}
   [∀ i, topological_space (γ i)] [Π i, has_scalar M (γ i)] [∀ i, has_continuous_smul M (γ i)] :
   has_continuous_smul M (Π i, γ i) :=


### PR DESCRIPTION
Make additive version of the theory of `has_continuous_smul`, i.e., `has_continuous_vadd`, using `to_additive`.  I've been fairly conservative in adding `to_additive` tags -- I left them off lemmas that didn't seem like they'd be relevant for typical additive actions, like those about `units` or `group_with_zero`.

Also make `normed_add_torsor` an instance of `has_continuous_vadd` and use this to establish some of its continuity API.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
