### PR TITLE
[Merged by Bors] - feat(category_theory/preadditive/additive_functor): map_zero' is a redundant field, remove it

### DIFF
--- a/src/algebra/category/Module/adjunctions.lean
+++ b/src/algebra/category/Module/adjunctions.lean
@@ -264,8 +264,7 @@ lemma lift_map_single (F : C ⥤ D) {X Y : C} (f : X ⟶ Y) (r : R) :
 by simp
 
 instance lift_additive (F : C ⥤ D) : (lift R F).additive :=
-{ map_zero' := by simp,
-  map_add' := λ X Y f g, begin
+{ map_add' := λ X Y f g, begin
     dsimp,
     rw finsupp.sum_add_index; simp [add_smul]
   end, }

--- a/src/algebra/homology/additive.lean
+++ b/src/algebra/homology/additive.lean
@@ -75,15 +75,7 @@ instance boundaries_additive : (boundaries_functor V c i).additive := {}
 variables [has_equalizers V] [has_cokernels V]
 
 instance homology_additive : (homology_functor V c i).additive :=
-{ map_zero' := λ C D, begin
-    dsimp [homology_functor],
-    ext,
-    simp only [limits.cokernel.π_desc, limits.comp_zero, homology.π_map],
-    convert zero_comp,
-    ext,
-    simp,
-  end,
-  map_add' := λ C D f g, begin
+{ map_add' := λ C D f g, begin
     dsimp [homology_functor],
     ext,
     simp only [homology.π_map, preadditive.comp_add, ←preadditive.add_comp],

--- a/src/analysis/normed/group/SemiNormedGroup/completion.lean
+++ b/src/analysis/normed/group/SemiNormedGroup/completion.lean
@@ -84,8 +84,7 @@ instance : preadditive SemiNormedGroup.{u} :=
     simp only [normed_group_hom.add_apply, category_theory.comp_apply, normed_group_hom.map_add] } }
 
 instance : functor.additive Completion :=
-{ map_zero' := Completion.map_zero,
-  map_add' := λ X Y, (Completion.map_hom _ _).map_add }
+{ map_add' := λ X Y, (Completion.map_hom _ _).map_add }
 
 /-- Given a normed group hom `f : V → W` with `W` complete, this provides a lift of `f` to
 the completion of `V`. The lemmas `lift_unique` and `lift_comp_incl` provide the api for the

--- a/src/category_theory/preadditive/additive_functor.lean
+++ b/src/category_theory/preadditive/additive_functor.lean
@@ -33,7 +33,6 @@ namespace category_theory
 /-- A functor `F` is additive provided `F.map` is an additive homomorphism. -/
 class functor.additive {C D : Type*} [category C] [category D]
   [preadditive C] [preadditive D] (F : C ⥤ D) : Prop :=
-(map_zero' : Π {X Y : C}, F.map (0 : X ⟶ Y) = 0 . obviously)
 (map_add' : Π {X Y : C} {f g : X ⟶ Y}, F.map (f + g) = F.map f + F.map g . obviously)
 
 section preadditive
@@ -45,12 +44,19 @@ variables {C D : Type*} [category C] [category D] [preadditive C]
   [preadditive D] (F : C ⥤ D) [functor.additive F]
 
 @[simp]
-lemma map_zero {X Y : C} : F.map (0 : X ⟶ Y) = 0 :=
-functor.additive.map_zero'
-
-@[simp]
 lemma map_add {X Y : C} {f g : X ⟶ Y} : F.map (f + g) = F.map f + F.map g :=
 functor.additive.map_add'
+
+/-- `F.map_add_hom` is an additive homomorphism whose underlying function is `F.map`. -/
+@[simps]
+def map_add_hom {X Y : C} : (X ⟶ Y) →+ (F.obj X ⟶ F.obj Y) :=
+add_monoid_hom.mk' (λ f, F.map f) (λ f g, F.map_add)
+
+lemma coe_map_add_hom {X Y : C} : ⇑(F.map_add_hom : (X ⟶ Y) →+ _) = @map C _ D _ F X Y := rfl
+
+@[simp]
+lemma map_zero {X Y : C} : F.map (0 : X ⟶ Y) = 0 :=
+F.map_add_hom.map_zero
 
 instance : additive (𝟭 C) :=
 {}
@@ -58,15 +64,6 @@ instance : additive (𝟭 C) :=
 instance {E : Type*} [category E] [preadditive E] (G : D ⥤ E) [functor.additive G] :
   additive (F ⋙ G) :=
 {}
-
-/-- `F.map_add_hom` is an additive homomorphism whose underlying function is `F.map`. -/
-@[simps]
-def map_add_hom {X Y : C} : (X ⟶ Y) →+ (F.obj X ⟶ F.obj Y) :=
-{ to_fun := λ f, F.map f,
-  map_zero' := F.map_zero,
-  map_add' := λ _ _, F.map_add }
-
-lemma coe_map_add_hom {X Y : C} : ⇑(F.map_add_hom : (X ⟶ Y) →+ _) = @map C _ D _ F X Y := rfl
 
 @[simp]
 lemma map_neg {X Y : C} {f : X ⟶ Y} : F.map (-f) = - F.map f :=
@@ -157,8 +154,7 @@ namespace equivalence
 variables {C D : Type*} [category C] [category D] [preadditive C] [preadditive D]
 
 instance inverse_additive (e : C ≌ D) [e.functor.additive] : e.inverse.additive :=
-{ map_zero' := λ X Y, by { apply e.functor.map_injective, simp, },
-  map_add' := λ X Y f g, by { apply e.functor.map_injective, simp, }, }
+{ map_add' := λ X Y f g, by { apply e.functor.map_injective, simp, }, }
 
 end equivalence
 

--- a/src/category_theory/preadditive/additive_functor.lean
+++ b/src/category_theory/preadditive/additive_functor.lean
@@ -48,7 +48,7 @@ lemma map_add {X Y : C} {f g : X ⟶ Y} : F.map (f + g) = F.map f + F.map g :=
 functor.additive.map_add'
 
 /-- `F.map_add_hom` is an additive homomorphism whose underlying function is `F.map`. -/
-@[simps]
+@[simps {fully_applied := ff}]
 def map_add_hom {X Y : C} : (X ⟶ Y) →+ (F.obj X ⟶ F.obj Y) :=
 add_monoid_hom.mk' (λ f, F.map f) (λ f g, F.map_add)
 


### PR DESCRIPTION
The map_zero' field in the definition of an additive functor can be deduced from the map_add' field. So we remove it.




---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)