### PR TITLE
[Merged by Bors] - feat(linear_algebra/determinant): alternating maps as multiples of determinant

### DIFF
--- a/src/linear_algebra/alternating.lean
+++ b/src/linear_algebra/alternating.lean
@@ -157,6 +157,14 @@ f.to_multilinear_map.map_update_zero m i
 @[simp] lemma map_zero [nonempty ι] : f 0 = 0 :=
 f.to_multilinear_map.map_zero
 
+lemma map_eq_zero_of_not_injective (v : ι → M) (hv : ¬function.injective v) : f v = 0 :=
+begin
+  rw function.injective at hv,
+  push_neg at hv,
+  rcases hv with ⟨i₁, i₂, heq, hne⟩,
+  exact f.map_eq_zero_of_eq v heq hne
+end
+
 /-!
 ### Algebraic structure inherited from `multilinear_map`
 

--- a/src/linear_algebra/alternating.lean
+++ b/src/linear_algebra/alternating.lean
@@ -780,18 +780,12 @@ are distinct basis vectors. -/
 lemma basis.ext_alternating {f g : alternating_map R' N₁ N₂ ι} (e : basis ι₁ R' N₁)
   (h : ∀ v : ι → ι₁, function.injective v → f (λ i, e (v i)) = g (λ i, e (v i))) : f = g :=
 begin
-  rw ←alternating_map.coe_multilinear_map_injective.eq_iff,
-  refine basis.ext_multilinear e _,
-  intro v,
+  refine alternating_map.coe_multilinear_map_injective (basis.ext_multilinear e $ λ v, _),
   by_cases hi : function.injective v,
   { exact h v hi },
-  { rw function.injective at hi,
-    push_neg at hi,
-    rcases hi with ⟨i₁, i₂, heq, hne⟩,
-    rw [coe_multilinear_map, coe_multilinear_map, f.map_eq_zero_of_eq _ _ hne],
-    { rw [map_eq_zero_of_eq _ _ _ hne],
-      rw heq },
-    { rw heq } }
+  { have : ¬function.injective (λ i, e (v i)) := hi.imp function.injective.of_comp,
+    rw [coe_multilinear_map, coe_multilinear_map,
+        f.map_eq_zero_of_not_injective _ this, g.map_eq_zero_of_not_injective _ this], }
 end
 
 end basis

--- a/src/linear_algebra/alternating.lean
+++ b/src/linear_algebra/alternating.lean
@@ -775,7 +775,8 @@ variables [module R' N₁] [module R' N₂]
 
 /-- Two alternating maps indexed by a `fintype` are equal if they are equal when all arguments
 are basis vectors. -/
-lemma basis.ext_alternating {f g : alternating_map R' N₁ N₂ ι} (e : basis ι₁ R' N₁) (h : ∀ v : ι → ι₁, f (λ i, e (v i)) = g (λ i, e (v i))) : f = g :=
+lemma basis.ext_alternating {f g : alternating_map R' N₁ N₂ ι} (e : basis ι₁ R' N₁)
+  (h : ∀ v : ι → ι₁, f (λ i, e (v i)) = g (λ i, e (v i))) : f = g :=
 begin
   rw ←alternating_map.coe_multilinear_map_injective.eq_iff,
   exact basis.ext_multilinear e h

--- a/src/linear_algebra/alternating.lean
+++ b/src/linear_algebra/alternating.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Eric Wieser, Zhangir Azerbayev
 -/
 
+import linear_algebra.multilinear.basis
 import linear_algebra.multilinear.tensor_product
 import linear_algebra.linear_independent
 import group_theory.perm.sign
@@ -765,3 +766,19 @@ begin
 end
 
 end coprod
+
+section basis
+
+variables {ι₁ : Type*} [fintype ι]
+variables {R' : Type*} {N₁ N₂ : Type*} [comm_semiring R'] [add_comm_monoid N₁] [add_comm_monoid N₂]
+variables [module R' N₁] [module R' N₂]
+
+/-- Two alternating maps indexed by a `fintype` are equal if they are equal when all arguments
+are basis vectors. -/
+lemma basis.ext_alternating {f g : alternating_map R' N₁ N₂ ι} (e : basis ι₁ R' N₁) (h : ∀ v : ι → ι₁, f (λ i, e (v i)) = g (λ i, e (v i))) : f = g :=
+begin
+  rw ←alternating_map.coe_multilinear_map_injective.eq_iff,
+  exact basis.ext_multilinear e h
+end
+
+end basis

--- a/src/linear_algebra/alternating.lean
+++ b/src/linear_algebra/alternating.lean
@@ -769,17 +769,29 @@ end coprod
 
 section basis
 
+open alternating_map
+
 variables {ι₁ : Type*} [fintype ι]
 variables {R' : Type*} {N₁ N₂ : Type*} [comm_semiring R'] [add_comm_monoid N₁] [add_comm_monoid N₂]
 variables [module R' N₁] [module R' N₂]
 
 /-- Two alternating maps indexed by a `fintype` are equal if they are equal when all arguments
-are basis vectors. -/
+are distinct basis vectors. -/
 lemma basis.ext_alternating {f g : alternating_map R' N₁ N₂ ι} (e : basis ι₁ R' N₁)
-  (h : ∀ v : ι → ι₁, f (λ i, e (v i)) = g (λ i, e (v i))) : f = g :=
+  (h : ∀ v : ι → ι₁, function.injective v → f (λ i, e (v i)) = g (λ i, e (v i))) : f = g :=
 begin
   rw ←alternating_map.coe_multilinear_map_injective.eq_iff,
-  exact basis.ext_multilinear e h
+  refine basis.ext_multilinear e _,
+  intro v,
+  by_cases hi : function.injective v,
+  { exact h v hi },
+  { rw function.injective at hi,
+    push_neg at hi,
+    rcases hi with ⟨i₁, i₂, heq, hne⟩,
+    rw [coe_multilinear_map, coe_multilinear_map, f.map_eq_zero_of_eq _ _ hne],
+    { rw [map_eq_zero_of_eq _ _ _ hne],
+      rw heq },
+    { rw heq } }
 end
 
 end basis

--- a/src/linear_algebra/determinant.lean
+++ b/src/linear_algebra/determinant.lean
@@ -372,19 +372,10 @@ lemma basis.is_unit_det (e' : basis ι R M) : is_unit (e.det e') :=
 map with respect to that basis, multiplied by the value of that alternating map on that basis. -/
 lemma alternating_map.eq_smul_det (f : alternating_map R M R ι) : f = f e • e.det :=
 begin
-  refine basis.ext_alternating e _,
-  intro i,
-  by_cases h : function.injective i,
-  { let σ : equiv.perm ι := equiv.of_bijective i (fintype.injective_iff_bijective.1 h),
-    change f (e ∘ σ) = (f e • e.det) (e ∘ σ),
-    simp [alternating_map.map_perm, basis.det_self] },
-  { rw function.injective at h,
-    push_neg at h,
-    rcases h with ⟨i₁, i₂, heq, hne⟩,
-    rw f.map_eq_zero_of_eq _ _ hne,
-    { rw (f e • e.det).map_eq_zero_of_eq _ _ hne,
-      rw heq },
-    { rw heq } }
+  refine basis.ext_alternating e (λ i h, _),
+  let σ : equiv.perm ι := equiv.of_bijective i (fintype.injective_iff_bijective.1 h),
+  change f (e ∘ σ) = (f e • e.det) (e ∘ σ),
+  simp [alternating_map.map_perm, basis.det_self]
 end
 
 variables {A : Type*} [comm_ring A] [is_domain A] [module A M]

--- a/src/linear_algebra/determinant.lean
+++ b/src/linear_algebra/determinant.lean
@@ -370,7 +370,7 @@ lemma basis.is_unit_det (e' : basis ι R M) : is_unit (e.det e') :=
 
 /-- Any alternating map to `R` where `ι` has the cardinality of a basis equals the determinant
 map with respect to that basis, multiplied by the value of that alternating map on that basis. -/
-lemma alternating_map.eq_smul_det (f : alternating_map R M R ι) : f = f e • e.det :=
+lemma alternating_map.eq_smul_basis_det (f : alternating_map R M R ι) : f = f e • e.det :=
 begin
   refine basis.ext_alternating e (λ i h, _),
   let σ : equiv.perm ι := equiv.of_bijective i (fintype.injective_iff_bijective.1 h),

--- a/src/linear_algebra/determinant.lean
+++ b/src/linear_algebra/determinant.lean
@@ -8,7 +8,7 @@ import linear_algebra.matrix.basis
 import linear_algebra.matrix.diagonal
 import linear_algebra.matrix.to_linear_equiv
 import linear_algebra.matrix.reindex
-import linear_algebra.multilinear.basic
+import linear_algebra.multilinear.basis
 import linear_algebra.dual
 import ring_theory.algebra_tower
 
@@ -367,6 +367,27 @@ end
 
 lemma basis.is_unit_det (e' : basis ι R M) : is_unit (e.det e') :=
 (is_basis_iff_det e).mp ⟨e'.linear_independent, e'.span_eq⟩
+
+/-- Any alternating map to `R` where `ι` has the cardinality of a basis equals the determinant
+map with respect to that basis, multiplied by the value of that alternating map on that basis. -/
+lemma alternating_map.eq_smul_det (f : alternating_map R M R ι) : f = f e • e.det :=
+begin
+  rw ←alternating_map.coe_multilinear_map_injective.eq_iff,
+  refine basis.ext_multilinear e _,
+  intro i,
+  rw [alternating_map.coe_multilinear_map, alternating_map.coe_multilinear_map],
+  by_cases h : function.injective i,
+  { let σ : equiv.perm ι := equiv.of_bijective i (fintype.injective_iff_bijective.1 h),
+    change f (e ∘ σ) = (f e • e.det) (e ∘ σ),
+    simp [alternating_map.map_perm, basis.det_self] },
+  { rw function.injective at h,
+    push_neg at h,
+    rcases h with ⟨i₁, i₂, heq, hne⟩,
+    rw f.map_eq_zero_of_eq _ _ hne,
+    { rw (f e • e.det).map_eq_zero_of_eq _ _ hne,
+      rw heq },
+    { rw heq } }
+end
 
 variables {A : Type*} [comm_ring A] [is_domain A] [module A M]
 

--- a/src/linear_algebra/determinant.lean
+++ b/src/linear_algebra/determinant.lean
@@ -372,10 +372,8 @@ lemma basis.is_unit_det (e' : basis ι R M) : is_unit (e.det e') :=
 map with respect to that basis, multiplied by the value of that alternating map on that basis. -/
 lemma alternating_map.eq_smul_det (f : alternating_map R M R ι) : f = f e • e.det :=
 begin
-  rw ←alternating_map.coe_multilinear_map_injective.eq_iff,
-  refine basis.ext_multilinear e _,
+  refine basis.ext_alternating e _,
   intro i,
-  rw [alternating_map.coe_multilinear_map, alternating_map.coe_multilinear_map],
   by_cases h : function.injective i,
   { let σ : equiv.perm ι := equiv.of_bijective i (fintype.injective_iff_bijective.1 h),
     change f (e ∘ σ) = (f e • e.det) (e ∘ σ),


### PR DESCRIPTION
Add the lemma that any alternating map with the same type as the
determinant map with respect to a basis is a multiple of the
determinant map (given by the value of the alternating map applied to
the basis vectors).



---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
