### PR TITLE
[Merged by Bors] - feat(algebra/module/linear_map,linear_algebra/alternating,linear_algebra/multilinear/basic): no_zero_smul_divisors instances

### DIFF
--- a/src/algebra/module/basic.lean
+++ b/src/algebra/module/basic.lean
@@ -478,6 +478,24 @@ class no_zero_smul_divisors (R M : Type*) [has_zero R] [has_zero M] [has_scalar 
 
 export no_zero_smul_divisors (eq_zero_or_eq_zero_of_smul_eq_zero)
 
+/-- A `no_zero_smul_divisors` instance on the codomain of a type coercing to functions induces
+one on that type, given appropriate properties of the types and scalar actions. -/
+lemma function.injective.no_zero_smul_divisors {R F M N : Type*} [has_zero R] [has_zero F]
+  [has_zero N] [has_scalar R F] [has_scalar R N] [no_zero_smul_divisors R N]
+  [has_coe_to_fun F (λ _, M → N)] (hi : function.injective (coe_fn : F → M → N))
+  (h0 : ((0 : F) : M → N) = 0) (hs : ∀ (c : R) (f : F) (x : M), (c • f) x = c • f x) :
+  no_zero_smul_divisors R F :=
+⟨λ c f h, begin
+  rw or_iff_not_imp_right,
+  intro hf,
+  simp_rw [←hi.eq_iff, function.funext_iff, h0, pi.zero_apply, not_forall] at hf,
+  rcases hf with ⟨x, hx⟩,
+  simp_rw [←hi.eq_iff, h0, function.funext_iff, pi.zero_apply] at h,
+  have h' := h x,
+  rw hs c f at h',
+  exact or.resolve_right (eq_zero_or_eq_zero_of_smul_eq_zero h') hx
+end⟩
+
 section module
 
 variables [semiring R] [add_comm_monoid M] [module R M]

--- a/src/algebra/module/basic.lean
+++ b/src/algebra/module/basic.lean
@@ -478,23 +478,13 @@ class no_zero_smul_divisors (R M : Type*) [has_zero R] [has_zero M] [has_scalar 
 
 export no_zero_smul_divisors (eq_zero_or_eq_zero_of_smul_eq_zero)
 
-/-- A `no_zero_smul_divisors` instance on the codomain of a type coercing to functions induces
-one on that type, given appropriate properties of the types and scalar actions. -/
-lemma function.injective.no_zero_smul_divisors {R F M N : Type*} [has_zero R] [has_zero F]
-  [has_zero N] [has_scalar R F] [has_scalar R N] [no_zero_smul_divisors R N]
-  [has_coe_to_fun F (λ _, M → N)] (hi : function.injective (coe_fn : F → M → N))
-  (h0 : ((0 : F) : M → N) = 0) (hs : ∀ (c : R) (f : F) (x : M), (c • f) x = c • f x) :
-  no_zero_smul_divisors R F :=
-⟨λ c f h, begin
-  rw or_iff_not_imp_right,
-  intro hf,
-  simp_rw [←hi.eq_iff, function.funext_iff, h0, pi.zero_apply, not_forall] at hf,
-  rcases hf with ⟨x, hx⟩,
-  simp_rw [←hi.eq_iff, h0, function.funext_iff, pi.zero_apply] at h,
-  have h' := h x,
-  rw hs c f at h',
-  exact or.resolve_right (eq_zero_or_eq_zero_of_smul_eq_zero h') hx
-end⟩
+/-- Pullback a `no_zero_smul_divisors` instance along an injective function. -/
+lemma function.injective.no_zero_smul_divisors {R M N : Type*} [has_zero R] [has_zero M]
+  [has_zero N] [has_scalar R M] [has_scalar R N] [no_zero_smul_divisors R N] (f : M → N)
+  (hf : function.injective f) (h0 : f 0 = 0) (hs : ∀ (c : R) (x : M), f (c • x) = c • f x) :
+  no_zero_smul_divisors R M :=
+⟨λ c m h,
+  or.imp_right (@hf _ _) $ h0.symm ▸ eq_zero_or_eq_zero_of_smul_eq_zero (by rw [←hs, h, h0])⟩
 
 section module
 

--- a/src/algebra/module/linear_map.lean
+++ b/src/algebra/module/linear_map.lean
@@ -487,8 +487,6 @@ variables {σ₁₂ : R₁ →+* R₂} {σ₂₃ : R₂ →+* R₃} {σ₁₃ : 
 instance : has_zero (M →ₛₗ[σ₁₂] M₂) :=
 ⟨{ to_fun := 0, map_add' := by simp, map_smul' := by simp }⟩
 
-lemma coe_zero : ⇑(0 : M →ₛₗ[σ₁₂] M₂) = 0 := rfl
-
 @[simp] lemma zero_apply (x : M) : (0 : M →ₛₗ[σ₁₂] M₂) x = 0 := rfl
 
 @[simp] theorem comp_zero (g : M₂ →ₛₗ[σ₂₃] M₃) : (g.comp (0 : M →ₛₗ[σ₁₂] M₂) : M →ₛₗ[σ₁₃] M₃) = 0 :=
@@ -505,8 +503,6 @@ instance : inhabited (M →ₛₗ[σ₁₂] M₂) := ⟨0⟩
 instance : has_add (M →ₛₗ[σ₁₂] M₂) :=
 ⟨λ f g, { to_fun := f + g,
           map_add' := by simp [add_comm, add_left_comm], map_smul' := by simp [smul_add] }⟩
-
-lemma coe_add (f g : M →ₛₗ[σ₁₂] M₂) : ⇑(f + g) = f + g := rfl
 
 @[simp] lemma add_apply (f g : M →ₛₗ[σ₁₂] M₂) (x : M) : (f + g) x = f x + g x := rfl
 
@@ -554,8 +550,6 @@ instance : has_sub (M →ₛₗ[σ₁₂] N₂) :=
 ⟨λ f g, { to_fun := f - g,
           map_add' := λ x y, by simp only [pi.sub_apply, map_add, add_sub_comm],
           map_smul' := λ r x, by simp [pi.sub_apply, map_smul, smul_sub] }⟩
-
-lemma coe_sub (f g : M →ₛₗ[σ₁₂] N₂) : ⇑(f - g) = f - g := rfl
 
 @[simp] lemma sub_apply (f g : M →ₛₗ[σ₁₂] N₂) (x : M) : (f - g) x = f x - g x := rfl
 

--- a/src/algebra/module/linear_map.lean
+++ b/src/algebra/module/linear_map.lean
@@ -633,14 +633,7 @@ instance : module S (M →ₗ[R] M₂) :=
   zero_smul := λ f, ext $ λ x, zero_smul _ _ }
 
 instance [no_zero_smul_divisors S M₂] : no_zero_smul_divisors S (M →ₗ[R] M₂) :=
-⟨λ c f h, begin
-  rw or_iff_not_imp_right,
-  intro hf,
-  simp_rw [ext_iff, not_forall, zero_apply] at hf,
-  rcases hf with ⟨x, hx⟩,
-  rw ext_iff at h,
-  simpa [hx] using h x
-end⟩
+coe_injective.no_zero_smul_divisors rfl (λ _ _ _, rfl)
 
 end module
 

--- a/src/algebra/module/linear_map.lean
+++ b/src/algebra/module/linear_map.lean
@@ -487,6 +487,8 @@ variables {σ₁₂ : R₁ →+* R₂} {σ₂₃ : R₂ →+* R₃} {σ₁₃ : 
 instance : has_zero (M →ₛₗ[σ₁₂] M₂) :=
 ⟨{ to_fun := 0, map_add' := by simp, map_smul' := by simp }⟩
 
+lemma coe_zero : ⇑(0 : M →ₛₗ[σ₁₂] M₂) = 0 := rfl
+
 @[simp] lemma zero_apply (x : M) : (0 : M →ₛₗ[σ₁₂] M₂) x = 0 := rfl
 
 @[simp] theorem comp_zero (g : M₂ →ₛₗ[σ₂₃] M₃) : (g.comp (0 : M →ₛₗ[σ₁₂] M₂) : M →ₛₗ[σ₁₃] M₃) = 0 :=
@@ -503,6 +505,8 @@ instance : inhabited (M →ₛₗ[σ₁₂] M₂) := ⟨0⟩
 instance : has_add (M →ₛₗ[σ₁₂] M₂) :=
 ⟨λ f g, { to_fun := f + g,
           map_add' := by simp [add_comm, add_left_comm], map_smul' := by simp [smul_add] }⟩
+
+lemma coe_add (f g : M →ₛₗ[σ₁₂] M₂) : ⇑(f + g) = f + g := rfl
 
 @[simp] lemma add_apply (f g : M →ₛₗ[σ₁₂] M₂) (x : M) : (f + g) x = f x + g x := rfl
 
@@ -550,6 +554,8 @@ instance : has_sub (M →ₛₗ[σ₁₂] N₂) :=
 ⟨λ f g, { to_fun := f - g,
           map_add' := λ x y, by simp only [pi.sub_apply, map_add, add_sub_comm],
           map_smul' := λ r x, by simp [pi.sub_apply, map_smul, smul_sub] }⟩
+
+lemma coe_sub (f g : M →ₛₗ[σ₁₂] N₂) : ⇑(f - g) = f - g := rfl
 
 @[simp] lemma sub_apply (f g : M →ₛₗ[σ₁₂] N₂) (x : M) : (f - g) x = f x - g x := rfl
 

--- a/src/algebra/module/linear_map.lean
+++ b/src/algebra/module/linear_map.lean
@@ -602,10 +602,10 @@ instance : has_scalar S (M →ₗ[R] M₂) :=
 
 @[simp] lemma smul_apply (a : S) (f : M →ₗ[R] M₂) (x : M) : (a • f) x = a • f x := rfl
 
+lemma coe_smul (a : S) (f : M →ₗ[R] M₂) : ⇑(a • f) = a • f := rfl
+
 instance [smul_comm_class S T M₂] : smul_comm_class S T (M →ₗ[R] M₂) :=
 ⟨λ a b f, ext $ λ x, smul_comm _ _ _⟩
-
-lemma coe_smul (a : S) (f : M →ₗ[R] M₂) : ⇑(a • f) = a • ⇑f := rfl
 
 -- example application of this instance: if S -> T -> R are homomorphisms of commutative rings and
 -- M and M₂ are R-modules then the S-module and T-module structures on Hom_R(M,M₂) are compatible.

--- a/src/algebra/module/linear_map.lean
+++ b/src/algebra/module/linear_map.lean
@@ -605,6 +605,8 @@ instance : has_scalar S (M →ₗ[R] M₂) :=
 instance [smul_comm_class S T M₂] : smul_comm_class S T (M →ₗ[R] M₂) :=
 ⟨λ a b f, ext $ λ x, smul_comm _ _ _⟩
 
+lemma coe_smul (a : S) (f : M →ₗ[R] M₂) : ⇑(a • f) = a • ⇑f := λ _ _, funext $ λ _, rfl
+
 -- example application of this instance: if S -> T -> R are homomorphisms of commutative rings and
 -- M and M₂ are R-modules then the S-module and T-module structures on Hom_R(M,M₂) are compatible.
 instance [has_scalar S T] [is_scalar_tower S T M₂] : is_scalar_tower S T (M →ₗ[R] M₂) :=
@@ -633,7 +635,7 @@ instance : module S (M →ₗ[R] M₂) :=
   zero_smul := λ f, ext $ λ x, zero_smul _ _ }
 
 instance [no_zero_smul_divisors S M₂] : no_zero_smul_divisors S (M →ₗ[R] M₂) :=
-coe_injective.no_zero_smul_divisors _ rfl (λ _ _, funext $ λ _, rfl)
+coe_injective.no_zero_smul_divisors _ rfl coe_smul
 
 end module
 

--- a/src/algebra/module/linear_map.lean
+++ b/src/algebra/module/linear_map.lean
@@ -633,7 +633,7 @@ instance : module S (M →ₗ[R] M₂) :=
   zero_smul := λ f, ext $ λ x, zero_smul _ _ }
 
 instance [no_zero_smul_divisors S M₂] : no_zero_smul_divisors S (M →ₗ[R] M₂) :=
-coe_injective.no_zero_smul_divisors rfl (λ _ _ _, rfl)
+coe_injective.no_zero_smul_divisors _ rfl (λ _ _, funext $ λ _, rfl)
 
 end module
 

--- a/src/algebra/module/linear_map.lean
+++ b/src/algebra/module/linear_map.lean
@@ -605,7 +605,7 @@ instance : has_scalar S (M →ₗ[R] M₂) :=
 instance [smul_comm_class S T M₂] : smul_comm_class S T (M →ₗ[R] M₂) :=
 ⟨λ a b f, ext $ λ x, smul_comm _ _ _⟩
 
-lemma coe_smul (a : S) (f : M →ₗ[R] M₂) : ⇑(a • f) = a • ⇑f := λ _ _, funext $ λ _, rfl
+lemma coe_smul (a : S) (f : M →ₗ[R] M₂) : ⇑(a • f) = a • ⇑f := rfl
 
 -- example application of this instance: if S -> T -> R are homomorphisms of commutative rings and
 -- M and M₂ are R-modules then the S-module and T-module structures on Hom_R(M,M₂) are compatible.

--- a/src/algebra/module/linear_map.lean
+++ b/src/algebra/module/linear_map.lean
@@ -632,6 +632,16 @@ instance : module S (M →ₗ[R] M₂) :=
 { add_smul := λ a b f, ext $ λ x, add_smul _ _ _,
   zero_smul := λ f, ext $ λ x, zero_smul _ _ }
 
+instance [no_zero_smul_divisors S M₂] : no_zero_smul_divisors S (M →ₗ[R] M₂) :=
+⟨λ c f h, begin
+  rw or_iff_not_imp_right,
+  intro hf,
+  simp_rw [ext_iff, not_forall, zero_apply] at hf,
+  rcases hf with ⟨x, hx⟩,
+  rw ext_iff at h,
+  simpa [hx] using h x
+end⟩
+
 end module
 
 end actions

--- a/src/linear_algebra/alternating.lean
+++ b/src/linear_algebra/alternating.lean
@@ -249,8 +249,8 @@ instance : has_scalar S (alternating_map R M N ι) :=
 @[norm_cast] lemma coe_smul (c : S):
   ((c • f : alternating_map R M N ι) : multilinear_map R (λ i : ι, M) N) = c • f := rfl
 
-lemma coe_fn_smul (c : S) (f : alternating_map R M N ι) : ⇑(c • f) = c • ⇑f :=
-funext $ λ _, rfl
+lemma coe_fn_smul (c : S) (f : alternating_map R M N ι) : ⇑(c • f) = c • f :=
+rfl
 
 instance : distrib_mul_action S (alternating_map R M N ι) :=
 { one_smul := λ f, ext $ λ x, one_smul _ _,

--- a/src/linear_algebra/alternating.lean
+++ b/src/linear_algebra/alternating.lean
@@ -249,6 +249,9 @@ instance : has_scalar S (alternating_map R M N ι) :=
 @[norm_cast] lemma coe_smul (c : S):
   ((c • f : alternating_map R M N ι) : multilinear_map R (λ i : ι, M) N) = c • f := rfl
 
+lemma coe_fn_smul (c : S) (f : alternating_map R M N ι) : ⇑(c • f) = c • ⇑f :=
+λ _ _, funext $ λ _, rfl
+
 instance : distrib_mul_action S (alternating_map R M N ι) :=
 { one_smul := λ f, ext $ λ x, one_smul _ _,
   mul_smul := λ c₁ c₂ f, ext $ λ x, mul_smul _ _ _,
@@ -268,7 +271,7 @@ instance : module S (alternating_map R M N ι) :=
   zero_smul := λ f, ext $ λ x, zero_smul _ _ }
 
 instance [no_zero_smul_divisors S N] : no_zero_smul_divisors S (alternating_map R M N ι) :=
-coe_injective.no_zero_smul_divisors _ rfl (λ _ _, funext $ λ _, rfl)
+coe_injective.no_zero_smul_divisors _ rfl coe_fn_smul
 
 end module
 

--- a/src/linear_algebra/alternating.lean
+++ b/src/linear_algebra/alternating.lean
@@ -250,7 +250,7 @@ instance : has_scalar S (alternating_map R M N ι) :=
   ((c • f : alternating_map R M N ι) : multilinear_map R (λ i : ι, M) N) = c • f := rfl
 
 lemma coe_fn_smul (c : S) (f : alternating_map R M N ι) : ⇑(c • f) = c • ⇑f :=
-λ _ _, funext $ λ _, rfl
+funext $ λ _, rfl
 
 instance : distrib_mul_action S (alternating_map R M N ι) :=
 { one_smul := λ f, ext $ λ x, one_smul _ _,

--- a/src/linear_algebra/alternating.lean
+++ b/src/linear_algebra/alternating.lean
@@ -267,6 +267,16 @@ instance : module S (alternating_map R M N ι) :=
 { add_smul := λ r₁ r₂ f, ext $ λ x, add_smul _ _ _,
   zero_smul := λ f, ext $ λ x, zero_smul _ _ }
 
+instance [no_zero_smul_divisors S N] : no_zero_smul_divisors S (alternating_map R M N ι) :=
+⟨λ c f h, begin
+  rw or_iff_not_imp_right,
+  intro hf,
+  simp_rw [ext_iff, not_forall, zero_apply] at hf,
+  rcases hf with ⟨x, hx⟩,
+  rw ext_iff at h,
+  simpa [hx] using h x
+end⟩
+
 end module
 
 section

--- a/src/linear_algebra/alternating.lean
+++ b/src/linear_algebra/alternating.lean
@@ -268,14 +268,7 @@ instance : module S (alternating_map R M N ι) :=
   zero_smul := λ f, ext $ λ x, zero_smul _ _ }
 
 instance [no_zero_smul_divisors S N] : no_zero_smul_divisors S (alternating_map R M N ι) :=
-⟨λ c f h, begin
-  rw or_iff_not_imp_right,
-  intro hf,
-  simp_rw [ext_iff, not_forall, zero_apply] at hf,
-  rcases hf with ⟨x, hx⟩,
-  rw ext_iff at h,
-  simpa [hx] using h x
-end⟩
+coe_injective.no_zero_smul_divisors rfl (λ _ _ _, rfl)
 
 end module
 

--- a/src/linear_algebra/alternating.lean
+++ b/src/linear_algebra/alternating.lean
@@ -268,7 +268,7 @@ instance : module S (alternating_map R M N ι) :=
   zero_smul := λ f, ext $ λ x, zero_smul _ _ }
 
 instance [no_zero_smul_divisors S N] : no_zero_smul_divisors S (alternating_map R M N ι) :=
-coe_injective.no_zero_smul_divisors rfl (λ _ _ _, rfl)
+coe_injective.no_zero_smul_divisors _ rfl (λ _ _, funext $ λ _, rfl)
 
 end module
 

--- a/src/linear_algebra/multilinear/basic.lean
+++ b/src/linear_algebra/multilinear/basic.lean
@@ -626,8 +626,8 @@ instance : has_scalar R' (multilinear_map A M₁ M₂) := ⟨λ c f,
 @[simp] lemma smul_apply (f : multilinear_map A M₁ M₂) (c : R') (m : Πi, M₁ i) :
   (c • f) m = c • f m := rfl
 
-lemma coe_smul (c : R') (f : multilinear_map A M₁ M₂) : ⇑(c • f) = c • ⇑f :=
-funext $ λ _, rfl
+lemma coe_smul (c : R') (f : multilinear_map A M₁ M₂) : ⇑(c • f) = c • f :=
+rfl
 
 instance : distrib_mul_action R' (multilinear_map A M₁ M₂) :=
 { one_smul := λ f, ext $ λ x, one_smul _ _,

--- a/src/linear_algebra/multilinear/basic.lean
+++ b/src/linear_algebra/multilinear/basic.lean
@@ -646,6 +646,16 @@ instance [module R' M₂] [smul_comm_class A R' M₂] : module R' (multilinear_m
 { add_smul := λ r₁ r₂ f, ext $ λ x, add_smul _ _ _,
   zero_smul := λ f, ext $ λ x, zero_smul _ _ }
 
+instance [no_zero_smul_divisors R' M₃] : no_zero_smul_divisors R' (multilinear_map A M₁ M₃) :=
+⟨λ c f h, begin
+  rw or_iff_not_imp_right,
+  intro hf,
+  simp_rw [ext_iff, not_forall, zero_apply] at hf,
+  rcases hf with ⟨x, hx⟩,
+  rw ext_iff at h,
+  simpa [hx] using h x
+end⟩
+
 variables (M₂ M₃ R' A)
 
 /-- `multilinear_map.dom_dom_congr` as a `linear_equiv`. -/

--- a/src/linear_algebra/multilinear/basic.lean
+++ b/src/linear_algebra/multilinear/basic.lean
@@ -647,14 +647,7 @@ instance [module R' M₂] [smul_comm_class A R' M₂] : module R' (multilinear_m
   zero_smul := λ f, ext $ λ x, zero_smul _ _ }
 
 instance [no_zero_smul_divisors R' M₃] : no_zero_smul_divisors R' (multilinear_map A M₁ M₃) :=
-⟨λ c f h, begin
-  rw or_iff_not_imp_right,
-  intro hf,
-  simp_rw [ext_iff, not_forall, zero_apply] at hf,
-  rcases hf with ⟨x, hx⟩,
-  rw ext_iff at h,
-  simpa [hx] using h x
-end⟩
+coe_injective.no_zero_smul_divisors rfl (λ _ _ _, rfl)
 
 variables (M₂ M₃ R' A)
 

--- a/src/linear_algebra/multilinear/basic.lean
+++ b/src/linear_algebra/multilinear/basic.lean
@@ -626,6 +626,9 @@ instance : has_scalar R' (multilinear_map A M₁ M₂) := ⟨λ c f,
 @[simp] lemma smul_apply (f : multilinear_map A M₁ M₂) (c : R') (m : Πi, M₁ i) :
   (c • f) m = c • f m := rfl
 
+lemma coe_smul (c : R') (f : multilinear_map A M₁ M₂) : ⇑(c • f) = c • ⇑f :=
+λ _ _, funext $ λ _, rfl
+
 instance : distrib_mul_action R' (multilinear_map A M₁ M₂) :=
 { one_smul := λ f, ext $ λ x, one_smul _ _,
   mul_smul := λ c₁ c₂ f, ext $ λ x, mul_smul _ _ _,
@@ -647,7 +650,7 @@ instance [module R' M₂] [smul_comm_class A R' M₂] : module R' (multilinear_m
   zero_smul := λ f, ext $ λ x, zero_smul _ _ }
 
 instance [no_zero_smul_divisors R' M₃] : no_zero_smul_divisors R' (multilinear_map A M₁ M₃) :=
-coe_injective.no_zero_smul_divisors _ rfl (λ _ _, funext $ λ _, rfl)
+coe_injective.no_zero_smul_divisors _ rfl coe_smul
 
 variables (M₂ M₃ R' A)
 

--- a/src/linear_algebra/multilinear/basic.lean
+++ b/src/linear_algebra/multilinear/basic.lean
@@ -647,7 +647,7 @@ instance [module R' M₂] [smul_comm_class A R' M₂] : module R' (multilinear_m
   zero_smul := λ f, ext $ λ x, zero_smul _ _ }
 
 instance [no_zero_smul_divisors R' M₃] : no_zero_smul_divisors R' (multilinear_map A M₁ M₃) :=
-coe_injective.no_zero_smul_divisors rfl (λ _ _ _, rfl)
+coe_injective.no_zero_smul_divisors _ rfl (λ _ _, funext $ λ _, rfl)
 
 variables (M₂ M₃ R' A)
 

--- a/src/linear_algebra/multilinear/basic.lean
+++ b/src/linear_algebra/multilinear/basic.lean
@@ -627,7 +627,7 @@ instance : has_scalar R' (multilinear_map A M₁ M₂) := ⟨λ c f,
   (c • f) m = c • f m := rfl
 
 lemma coe_smul (c : R') (f : multilinear_map A M₁ M₂) : ⇑(c • f) = c • ⇑f :=
-λ _ _, funext $ λ _, rfl
+funext $ λ _, rfl
 
 instance : distrib_mul_action R' (multilinear_map A M₁ M₂) :=
 { one_smul := λ f, ext $ λ x, one_smul _ _,


### PR DESCRIPTION
Add `no_zero_smul_divisors` instances for linear, multilinear and alternating maps, given such instances for the codomain of the maps.

This also adds some missing `coe_smul` lemmas on these types.

Co-authored-by: Eric Wieser <wieser.eric@gmail.com>

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
