### PR TITLE
[Merged by Bors] - feat(data/finset/pairwise): Interaction of `set.pairwise_disjoint` with `finset`

### DIFF
--- a/src/data/finset/pairwise.lean
+++ b/src/data/finset/pairwise.lean
@@ -1,0 +1,60 @@
+/-
+Copyright (c) 2021 Yaël Dillies. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Yaël Dillies
+-/
+import data.finset.lattice
+
+/-!
+# Relations holding pairwise on finite sets
+
+In this file we prove a few results about the interaction of `set.pairwise_disjoint` and `finset`.
+-/
+
+open finset
+
+variables {α ι ι' : Type*}
+
+lemma finset.pairwise_disjoint_range_singleton [decidable_eq α] :
+  (set.range (singleton : α → finset α)).pairwise_disjoint id :=
+begin
+  rintro _ ⟨a, rfl⟩ _ ⟨b, rfl⟩ h,
+  exact disjoint_singleton.2 (ne_of_apply_ne _ h),
+end
+
+namespace set
+
+lemma pairwise_disjoint.elim_finset [decidable_eq α] {s : set ι} {f : ι → finset α}
+  (hs : s.pairwise_disjoint f) {i j : ι} (hi : i ∈ s) (hj : j ∈ s) (a : α) (hai : a ∈ f i)
+  (haj : a ∈ f j) :
+  i = j :=
+hs.elim hi hj (finset.not_disjoint_iff.2 ⟨a, hai, haj⟩)
+
+lemma pairwise_disjoint.image_finset_of_le [decidable_eq ι] [semilattice_inf_bot α]
+  {s : finset ι} {f : ι → α} (hs : (s : set ι).pairwise_disjoint f) {g : ι → ι}
+  (hf : ∀ a, f (g a) ≤ f a) :
+  (s.image g :set ι).pairwise_disjoint f :=
+begin
+  rw coe_image,
+  exact hs.image_of_le hf,
+end
+
+variables [distrib_lattice_bot α] -- TODO: This could be `lattice_bot` if it existed
+
+/-- Bind operation for `set.pairwise_disjoint`. In a complete lattice, you can use
+`set.pairwise_disjoint.bUnion_finset`. -/
+lemma pairwise_disjoint.bUnion_finset {s : set ι'} {g : ι' → finset ι} {f : ι → α}
+  (hs : s.pairwise_disjoint (λ i' : ι', (g i').sup f))
+  (hg : ∀ i ∈ s, (g i : set ι).pairwise_disjoint f) :
+  (⋃ i ∈ s, ↑(g i)).pairwise_disjoint f :=
+begin
+  rintro a ha b hb hab,
+  simp_rw set.mem_Union at ha hb,
+  obtain ⟨c, hc, ha⟩ := ha,
+  obtain ⟨d, hd, hb⟩ := hb,
+  obtain hcd | hcd := eq_or_ne (g c) (g d),
+  { exact hg d hd a (hcd ▸ ha) b hb hab },
+  { exact (hs _ hc _ hd (ne_of_apply_ne _ hcd)).mono (finset.le_sup ha) (finset.le_sup hb) }
+end
+
+end set

--- a/src/data/finset/pairwise.lean
+++ b/src/data/finset/pairwise.lean
@@ -42,7 +42,7 @@ end
 variables [distrib_lattice_bot α] -- TODO: This could be `lattice_bot` if it existed
 
 /-- Bind operation for `set.pairwise_disjoint`. In a complete lattice, you can use
-`set.pairwise_disjoint.bUnion_finset`. -/
+`set.pairwise_disjoint.bUnion`. -/
 lemma pairwise_disjoint.bUnion_finset {s : set ι'} {g : ι' → finset ι} {f : ι → α}
   (hs : s.pairwise_disjoint (λ i' : ι', (g i').sup f))
   (hg : ∀ i ∈ s, (g i : set ι).pairwise_disjoint f) :

--- a/src/data/finset/pairwise.lean
+++ b/src/data/finset/pairwise.lean
@@ -33,7 +33,7 @@ hs.elim hi hj (finset.not_disjoint_iff.2 ⟨a, hai, haj⟩)
 lemma pairwise_disjoint.image_finset_of_le [decidable_eq ι] [semilattice_inf_bot α]
   {s : finset ι} {f : ι → α} (hs : (s : set ι).pairwise_disjoint f) {g : ι → ι}
   (hf : ∀ a, f (g a) ≤ f a) :
-  (s.image g :set ι).pairwise_disjoint f :=
+  (s.image g : set ι).pairwise_disjoint f :=
 begin
   rw coe_image,
   exact hs.image_of_le hf,

--- a/src/data/set/pairwise.lean
+++ b/src/data/set/pairwise.lean
@@ -281,6 +281,27 @@ hs.elim hi hj $ λ hij, h hij.eq_bot
 
 end semilattice_inf_bot
 
+section complete_lattice
+variables [complete_lattice α]
+
+/-- Bind operation for `set.pairwise_disjoint`. If you want to only consider finsets of indices, you
+can use `set.pairwise_disjoint.bUnion_finset`. -/
+lemma pairwise_disjoint.bUnion {s : set ι'} {g : ι' → set ι} {f : ι → α}
+  (hs : s.pairwise_disjoint (λ i' : ι', ⨆ i ∈ g i', f i))
+  (hg : ∀ i ∈ s, (g i).pairwise_disjoint f) :
+  (⋃ i ∈ s, g i).pairwise_disjoint f :=
+begin
+  rintro a ha b hb hab,
+  simp_rw set.mem_Union at ha hb,
+  obtain ⟨c, hc, ha⟩ := ha,
+  obtain ⟨d, hd, hb⟩ := hb,
+  obtain hcd | hcd := eq_or_ne (g c) (g d),
+  { exact hg d hd a (hcd ▸ ha) b hb hab },
+  { exact (hs _ hc _ hd (ne_of_apply_ne _ hcd)).mono (le_bsupr a ha) (le_bsupr b hb) }
+end
+
+end complete_lattice
+
 /-! ### Pairwise disjoint set of sets -/
 
 lemma pairwise_disjoint_range_singleton :


### PR DESCRIPTION
This proves a few results about `set.pairwise_disjoint` and `finset` that couldn't go `data.set.pairwise` because of cyclic imports.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
