### PR TITLE
[Merged by Bors] - feat(group_theory/exponent): Define the exponent of a group

### DIFF
--- a/src/algebra/gcd_monoid/finset.lean
+++ b/src/algebra/gcd_monoid/finset.lean
@@ -88,10 +88,8 @@ lemma lcm_mono (h : s₁ ⊆ s₂) : s₁.lcm f ∣ s₂.lcm f :=
 lcm_dvd $ assume b hb, dvd_lcm (h hb)
 
 theorem lcm_eq_zero_iff [nontrivial α] : s.lcm f = 0 ↔ 0 ∈ f '' s :=
-begin
-  simp only [multiset.mem_map, lcm_def, multiset.lcm_eq_zero_iff, set.mem_image, mem_coe],
-  refl
-end
+by simp only [multiset.mem_map, lcm_def, multiset.lcm_eq_zero_iff, set.mem_image, mem_coe,
+  ← finset.mem_def]
 
 end lcm
 

--- a/src/algebra/gcd_monoid/finset.lean
+++ b/src/algebra/gcd_monoid/finset.lean
@@ -87,6 +87,13 @@ lcm_dvd (λ b hb, (h b hb).trans (dvd_lcm hb))
 lemma lcm_mono (h : s₁ ⊆ s₂) : s₁.lcm f ∣ s₂.lcm f :=
 lcm_dvd $ assume b hb, dvd_lcm (h hb)
 
+theorem lcm_eq_zero_iff [nontrivial α] : s.lcm f = 0 ↔ ∃ (x : β), x ∈ s ∧ f x = 0 :=
+begin
+  rw [lcm_def, multiset.lcm_eq_zero_iff],
+  simp only [multiset.mem_map],
+  refl,
+end
+
 end lcm
 
 /-! ### gcd -/

--- a/src/algebra/gcd_monoid/finset.lean
+++ b/src/algebra/gcd_monoid/finset.lean
@@ -88,10 +88,7 @@ lemma lcm_mono (h : s₁ ⊆ s₂) : s₁.lcm f ∣ s₂.lcm f :=
 lcm_dvd $ assume b hb, dvd_lcm (h hb)
 
 theorem lcm_eq_zero_iff [nontrivial α] : s.lcm f = 0 ↔ 0 ∈ f '' s :=
-begin
-  simp only [multiset.mem_map, lcm_def, multiset.lcm_eq_zero_iff, set.mem_image, mem_coe],
-  refl
-end
+by simpa only [multiset.mem_map, lcm_def, multiset.lcm_eq_zero_iff, set.mem_image, mem_coe]
 
 end lcm
 

--- a/src/algebra/gcd_monoid/finset.lean
+++ b/src/algebra/gcd_monoid/finset.lean
@@ -87,12 +87,8 @@ lcm_dvd (λ b hb, (h b hb).trans (dvd_lcm hb))
 lemma lcm_mono (h : s₁ ⊆ s₂) : s₁.lcm f ∣ s₂.lcm f :=
 lcm_dvd $ assume b hb, dvd_lcm (h hb)
 
-theorem lcm_eq_zero_iff [nontrivial α] : s.lcm f = 0 ↔ ∃ (x : β), x ∈ s ∧ f x = 0 :=
-begin
-  rw [lcm_def, multiset.lcm_eq_zero_iff],
-  simp only [multiset.mem_map],
-  refl,
-end
+theorem lcm_eq_zero_iff [nontrivial α] : s.lcm f = 0 ↔ 0 ∈ f '' s :=
+by simpa only [multiset.mem_map, lcm_def, multiset.lcm_eq_zero_iff],
 
 end lcm
 

--- a/src/algebra/gcd_monoid/finset.lean
+++ b/src/algebra/gcd_monoid/finset.lean
@@ -88,7 +88,10 @@ lemma lcm_mono (h : s₁ ⊆ s₂) : s₁.lcm f ∣ s₂.lcm f :=
 lcm_dvd $ assume b hb, dvd_lcm (h hb)
 
 theorem lcm_eq_zero_iff [nontrivial α] : s.lcm f = 0 ↔ 0 ∈ f '' s :=
-by simpa only [multiset.mem_map, lcm_def, multiset.lcm_eq_zero_iff],
+begin
+  simp only [multiset.mem_map, lcm_def, multiset.lcm_eq_zero_iff, set.mem_image, mem_coe],
+  refl
+end
 
 end lcm
 

--- a/src/algebra/gcd_monoid/multiset.lean
+++ b/src/algebra/gcd_monoid/multiset.lean
@@ -58,6 +58,22 @@ lcm_dvd.2 $ assume b hb, dvd_lcm (h hb)
 @[simp] lemma normalize_lcm (s : multiset α) : normalize (s.lcm) = s.lcm :=
 multiset.induction_on s (by simp) $ λ a s IH, by simp
 
+theorem lcm_eq_zero_iff [nontrivial α] (s : multiset α) : s.lcm = 0 ↔ (0 : α) ∈ s :=
+begin
+  split,
+  { apply s.induction_on,
+    { simp },
+    { intros a s slcm h,
+      rw mem_cons,
+      rw [lcm_cons, lcm_eq_zero_iff] at h,
+      cases h,
+      { left,
+        exact h.symm },
+      { right,
+        exact slcm h } } },
+  { exact λ h, zero_dvd_iff.mp (dvd_lcm h) }
+end
+
 variables [decidable_eq α]
 
 @[simp] lemma lcm_erase_dup (s : multiset α) : (erase_dup s).lcm = s.lcm :=

--- a/src/algebra/gcd_monoid/multiset.lean
+++ b/src/algebra/gcd_monoid/multiset.lean
@@ -58,20 +58,11 @@ lcm_dvd.2 $ assume b hb, dvd_lcm (h hb)
 @[simp] lemma normalize_lcm (s : multiset α) : normalize (s.lcm) = s.lcm :=
 multiset.induction_on s (by simp) $ λ a s IH, by simp
 
-theorem lcm_eq_zero_iff [nontrivial α] (s : multiset α) : s.lcm = 0 ↔ (0 : α) ∈ s :=
+@[simp] theorem lcm_eq_zero_iff [nontrivial α] (s : multiset α) : s.lcm = 0 ↔ (0 : α) ∈ s :=
 begin
-  split,
-  { apply s.induction_on,
-    { simp },
-    { intros a s slcm h,
-      rw mem_cons,
-      rw [lcm_cons, lcm_eq_zero_iff] at h,
-      cases h,
-      { left,
-        exact h.symm },
-      { right,
-        exact slcm h } } },
-  { exact λ h, zero_dvd_iff.mp (dvd_lcm h) }
+  induction s using multiset.induction_on with a s ihs,
+  { simp only [lcm_zero, one_ne_zero, not_mem_zero] },
+  { simp only [mem_cons, lcm_cons, lcm_eq_zero_iff, ihs, @eq_comm _ a] },
 end
 
 variables [decidable_eq α]

--- a/src/group_theory/exponent.lean
+++ b/src/group_theory/exponent.lean
@@ -6,6 +6,7 @@ Authors: Julian Kuelshammer
 import group_theory.order_of_element
 import algebra.punit_instances
 import algebra.gcd_monoid.finset
+import ring_theory.int.basic
 
 /-!
 # Exponent of a group
@@ -78,4 +79,19 @@ begin
 end
 
 lemma order_dvd_exponent (g : G) : (order_of g) ∣ exponent G :=
-by exact order_of_dvd_of_pow_eq_one (pow_exponent_eq_one G g)
+begin
+  exact order_of_dvd_of_pow_eq_one (pow_exponent_eq_one G g)
+end
+
+variable [fintype G]
+
+lemma lcm_order_dvd_exponent : ((finset.univ : finset G).image order_of).lcm id ∣ exponent G :=
+begin
+  apply finset.lcm_dvd,
+  intros n hn,
+  simp only [finset.mem_univ, finset.mem_image, exists_true_left] at hn,
+  cases hn with g hg,
+  cases hg with hg1 hg2,
+  rw [id, ←hg2],
+  exact order_dvd_exponent G g,
+end

--- a/src/group_theory/exponent.lean
+++ b/src/group_theory/exponent.lean
@@ -1,0 +1,44 @@
+
+import group_theory.order_of_element
+import algebra.punit_instances
+
+universe u
+
+open_locale classical
+
+def exponent_exists (G : Type u) [monoid G] := ∃ n, 0 < n ∧ ∀ g : G, g ^ n = 1
+
+noncomputable def exponent (G : Type u) [monoid G] :=
+if h : exponent_exists G then nat.find h else 0
+
+lemma exponent_pos_of_exists (G : Type u) [monoid G] (n : ℕ) (hpos : 0 < n)
+(hG : ∀ g : G, g ^ n = 1) : 0 < exponent G :=
+begin
+  rw [exponent, dif_pos] ,
+  { have : ∃ n, 0 < n ∧ ∀ g : G, g ^ n = 1,
+      { exact ⟨n, hpos, hG⟩ },
+    exact (nat.find_spec this).1,
+  },
+  { exact ⟨n, hpos, hG⟩ },
+end
+
+lemma exponent_min' (G : Type u) [monoid G] (n : ℕ) (hpos : 0 < n) (hG : ∀ g : G, g ^ n = 1) :
+  exponent G ≤ n :=
+begin
+  rw [exponent, dif_pos],
+  { apply nat.find_min',
+    exact ⟨hpos, hG⟩,},
+  { exact ⟨n, hpos, hG⟩ },
+end
+
+lemma exp_punit_eq_one : exponent punit = 1 :=
+begin
+  apply le_antisymm,
+  { apply exponent_min' _ _ nat.one_pos,
+    intro g,
+    refl },
+  { apply nat.succ_le_of_lt,
+    apply exponent_pos_of_exists _ 1 (nat.one_pos),
+    intro g,
+    refl },
+end

--- a/src/group_theory/exponent.lean
+++ b/src/group_theory/exponent.lean
@@ -1,33 +1,67 @@
-
+/-
+Copyright (c) 2021 Julian Kuelshammer. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Julian Kuelshammer
+-/
 import group_theory.order_of_element
 import algebra.punit_instances
+import algebra.gcd_monoid.finset
+
+/-!
+# Exponent of a group
+
+This file defines the exponent of a group. For a group `G` it is defined to be the minimal `n≥1`
+such that `g ^ n = 1` for all `g ∈ G`. For a finite group `G` it is equal to the lowest common
+multiple of the order of all elements of the group `G`.
+
+## Main definitions
+
+* `exponent_exists` is a predicate on a monoid `G` saying that there is some positive `n` such that
+  `g ^ n = 1` for all `g ∈ G`.
+* `exponent` defines the exponent of a monoid `G` as the minimal positive `n` such that `g ^ n = 1`
+  for all `g ∈ G`, by convention it is `0` if no such `n` exists.
+
+## TODO
+* Show that for a finite group `G`, the exponent is equal to the lcm of the orders of its elements.
+* Provide additive versions of all notions.
+* Compute the exponent of cyclic groups.
+* Refactor the characteristic of a ring to be the exponent of its underlying additive group.
+-/
 
 universe u
 
+variables (G : Type u) [monoid G]
+
 open_locale classical
 
-def exponent_exists (G : Type u) [monoid G] := ∃ n, 0 < n ∧ ∀ g : G, g ^ n = 1
+def exponent_exists  := ∃ n, 0 < n ∧ ∀ g : G, g ^ n = 1
 
-noncomputable def exponent (G : Type u) [monoid G] :=
+noncomputable def exponent :=
 if h : exponent_exists G then nat.find h else 0
 
-lemma exponent_pos_of_exists (G : Type u) [monoid G] (n : ℕ) (hpos : 0 < n)
-(hG : ∀ g : G, g ^ n = 1) : 0 < exponent G :=
+lemma pow_exponent_eq_one (g : G) : g ^ exponent G = 1 :=
 begin
-  rw [exponent, dif_pos] ,
-  { have : ∃ n, 0 < n ∧ ∀ g : G, g ^ n = 1,
-      { exact ⟨n, hpos, hG⟩ },
-    exact (nat.find_spec this).1,
-  },
-  { exact ⟨n, hpos, hG⟩ },
+  by_cases exponent_exists G,
+  { simp_rw [exponent, dif_pos h],
+    exact (nat.find_spec h).2 g},
+  { simp_rw [exponent, dif_neg h, pow_zero] }
 end
 
-lemma exponent_min' (G : Type u) [monoid G] (n : ℕ) (hpos : 0 < n) (hG : ∀ g : G, g ^ n = 1) :
+lemma exponent_pos_of_exists (n : ℕ) (hpos : 0 < n)
+(hG : ∀ g : G, g ^ n = 1) : 0 < exponent G :=
+begin
+  have h : ∃ n, 0 < n ∧ ∀ g : G, g ^ n = 1,
+      { exact ⟨n, hpos, hG⟩ },
+  rw [exponent, dif_pos],
+  exact (nat.find_spec h).1,
+end
+
+lemma exponent_min' (n : ℕ) (hpos : 0 < n) (hG : ∀ g : G, g ^ n = 1) :
   exponent G ≤ n :=
 begin
   rw [exponent, dif_pos],
   { apply nat.find_min',
-    exact ⟨hpos, hG⟩,},
+    exact ⟨hpos, hG⟩ },
   { exact ⟨n, hpos, hG⟩ },
 end
 
@@ -42,3 +76,6 @@ begin
     intro g,
     refl },
 end
+
+lemma order_dvd_exponent (g : G) : (order_of g) ∣ exponent G :=
+by exact order_of_dvd_of_pow_eq_one (pow_exponent_eq_one G g)

--- a/src/group_theory/exponent.lean
+++ b/src/group_theory/exponent.lean
@@ -71,8 +71,7 @@ calc g ^ n = g ^ (n % exponent G + exponent G * (n / exponent G)) : by rw [nat.m
 lemma exponent_pos_of_exists (n : ℕ) (hpos : 0 < n)
 (hG : ∀ g : G, g ^ n = 1) : 0 < exponent G :=
 begin
-  have h : ∃ n, 0 < n ∧ ∀ g : G, g ^ n = 1,
-      { exact ⟨n, hpos, hG⟩ },
+  have h : ∃ n, 0 < n ∧ ∀ g : G, g ^ n = 1 := ⟨n, hpos, hG⟩,
   rw [exponent, dif_pos],
   exact (nat.find_spec h).1,
 end
@@ -110,9 +109,7 @@ end
 
 @[to_additive add_order_dvd_exponent]
 lemma order_dvd_exponent (g : G) : (order_of g) ∣ exponent G :=
-begin
-  exact order_of_dvd_of_pow_eq_one (pow_exponent_eq_one G g)
-end
+order_of_dvd_of_pow_eq_one (pow_exponent_eq_one G g)
 
 @[to_additive]
 lemma exponent_dvd_of_forall_pow_eq_one (n : ℕ) (hpos : 0 < n) (hG : ∀ g : G, g ^ n = 1) :

--- a/src/group_theory/exponent.lean
+++ b/src/group_theory/exponent.lean
@@ -70,8 +70,8 @@ calc g ^ n = g ^ (n % exponent G + exponent G * (n / exponent G)) : by rw [nat.m
   ... = g ^ (n % exponent G) : by simp [pow_add, pow_mul, pow_exponent_eq_one]
 
 @[to_additive]
-lemma exponent_pos_of_exists (n : ℕ) (hpos : 0 < n)
-(hG : ∀ g : G, g ^ n = 1) : 0 < exponent G :=
+lemma exponent_pos_of_exists (n : ℕ) (hpos : 0 < n) (hG : ∀ g : G, g ^ n = 1) :
+  0 < exponent G :=
 begin
   have h : ∃ n, 0 < n ∧ ∀ g : G, g ^ n = 1 := ⟨n, hpos, hG⟩,
   rw [exponent, dif_pos],

--- a/src/group_theory/exponent.lean
+++ b/src/group_theory/exponent.lean
@@ -48,8 +48,8 @@ namespace monoid
   that `n • g = 0` for all `g`."]
 def exponent_exists  := ∃ n, 0 < n ∧ ∀ g : G, g ^ n = 1
 
-/--The exponent of a group is the smallest positive integer `n` such that `g ^ n = 1` for all `g ∈ G`
-if it exists, otherwise it is zero by convention.-/
+/--The exponent of a group is the smallest positive integer `n` such that `g ^ n = 1` for all
+  `g ∈ G` if it exists, otherwise it is zero by convention.-/
 @[to_additive "The exponent of an additive group is the smallest positive integer `n` such that
   `n • g = 0` for all `g ∈ G` if it exists, otherwise it is zero by convention."]
 noncomputable def exponent :=

--- a/src/group_theory/exponent.lean
+++ b/src/group_theory/exponent.lean
@@ -101,12 +101,10 @@ lemma exp_punit_eq_one : exponent punit = 1 :=
 begin
   apply le_antisymm,
   { apply exponent_min' _ _ nat.one_pos,
-    intro g,
-    refl },
+    exact λ g, rfl },
   { apply nat.succ_le_of_lt,
     apply exponent_pos_of_exists _ 1 (nat.one_pos),
-    intro g,
-    refl },
+    exact λ g, rfl },
 end
 
 @[to_additive add_order_dvd_exponent]
@@ -136,9 +134,7 @@ begin
   apply finset.lcm_dvd,
   intros n hn,
   simp only [finset.mem_univ, finset.mem_image, exists_true_left] at hn,
-  cases hn with g hg,
-  cases hg with hg1 hg2,
-  rw [id, ←hg2],
+  rcases hn with ⟨g, hg1, rfl⟩,
   exact order_dvd_exponent G g,
 end
 

--- a/src/group_theory/exponent.lean
+++ b/src/group_theory/exponent.lean
@@ -129,33 +129,29 @@ end
 variable [fintype G]
 
 @[to_additive lcm_add_order_of_dvd_exponent]
-lemma lcm_order_of_dvd_exponent : ((finset.univ : finset G).image order_of).lcm id ∣ exponent G :=
+lemma lcm_order_of_dvd_exponent : (finset.univ : finset G).lcm order_of ∣ exponent G :=
 begin
   apply finset.lcm_dvd,
-  intros n hn,
-  simp only [finset.mem_univ, finset.mem_image, exists_true_left] at hn,
-  rcases hn with ⟨g, hg1, rfl⟩,
-  exact order_dvd_exponent G g,
+  intros g hg,
+  exact order_dvd_exponent G g
 end
 
 @[to_additive lcm_add_order_eq_exponent]
 lemma lcm_order_eq_exponent {H : Type u} [fintype H] [left_cancel_monoid H] :
-  ((finset.univ : finset H).image order_of).lcm id = exponent H :=
+  (finset.univ : finset H).lcm order_of = exponent H :=
 begin
-  apply nat.dvd_antisymm (lcm_order_of_dvd_exponent _),
+  apply nat.dvd_antisymm (lcm_order_of_dvd_exponent H),
   apply exponent_dvd_of_forall_pow_eq_one,
   { apply nat.pos_of_ne_zero,
     by_contradiction,
     rw finset.lcm_eq_zero_iff at h,
-    cases h with m hm,
-    simp at hm,
-    rcases hm with ⟨⟨g, hg⟩, rfl⟩,
+    cases h with g hg,
+    simp only [true_and, set.mem_univ, finset.coe_univ] at hg,
     exact ne_of_gt (order_of_pos g) hg },
   { intro g,
-    have h : (order_of g) ∣ (finset.image order_of finset.univ).lcm id,
+    have h : (order_of g) ∣ (finset.univ : finset H).lcm order_of,
     { apply finset.dvd_lcm,
-      rw finset.mem_image,
-      exact ⟨g, finset.mem_univ g, rfl⟩ },
+      exact finset.mem_univ g },
     cases h with m hm,
     rw [hm, pow_mul, pow_order_of_eq_one, one_pow] },
 end

--- a/src/group_theory/exponent.lean
+++ b/src/group_theory/exponent.lean
@@ -88,7 +88,7 @@ lemma exponent_min (m : ℕ) (hpos : 0 < m) (hm : m < exponent G) : ∃ g : G, g
 begin
   by_contradiction,
   push_neg at h,
-  have hcon : exponent G ≤ m, from exponent_min' G m hpos h,
+  have hcon : exponent G ≤ m := exponent_min' G m hpos h,
   linarith,
 end
 
@@ -110,10 +110,25 @@ begin
   exact order_of_dvd_of_pow_eq_one (pow_exponent_eq_one G g)
 end
 
+@[to_additive]
+lemma exponent_dvd_of_forall_pow_eq_one (n : ℕ) (hpos : 0 < n) (hG : ∀ g : G, g ^ n = 1) :
+  exponent G ∣ n :=
+begin
+  apply nat.dvd_of_mod_eq_zero,
+  by_contradiction h,
+  have h₁ := nat.pos_of_ne_zero h,
+  have h₂ : n % exponent G < exponent G := nat.mod_lt _ (exponent_pos_of_exists _ n hpos hG),
+  have h₃ : exponent G ≤ n % exponent G,
+  { apply exponent_min' _ _ h₁,
+    simp_rw ←pow_eq_mod_exponent,
+    exact hG },
+  linarith,
+end
+
 variable [fintype G]
 
-@[to_additive lcm_add_order_dvd_exponent]
-lemma lcm_order_dvd_exponent : ((finset.univ : finset G).image order_of).lcm id ∣ exponent G :=
+@[to_additive lcm_add_order_of_dvd_exponent]
+lemma lcm_order_of_dvd_exponent : ((finset.univ : finset G).image order_of).lcm id ∣ exponent G :=
 begin
   apply finset.lcm_dvd,
   intros n hn,
@@ -124,10 +139,18 @@ begin
   exact order_dvd_exponent G g,
 end
 
-lemma exponent_dvd_of_forall_pow_eq_one (n : ℕ) (hpos : 0 < n) (hG : ∀ g : G, g ^ n = 1) :
-  exponent G ∣ n :=
+lemma lcm_order_eq_exponent : ((finset.univ : finset G).image order_of).lcm id = exponent G :=
 begin
-  sorry
+  apply nat.dvd_antisymm (lcm_order_of_dvd_exponent _),
+  apply exponent_dvd_of_forall_pow_eq_one,
+  { sorry },
+  { intro g,
+    have h : (order_of g) ∣ (finset.image order_of finset.univ).lcm id,
+    { apply finset.dvd_lcm,
+      rw finset.mem_image,
+      exact ⟨g, finset.mem_univ g, rfl⟩ },
+    cases h with m hm,
+    rw [hm, pow_mul, pow_order_of_eq_one, one_pow] },
 end
 
 end monoid

--- a/src/group_theory/exponent.lean
+++ b/src/group_theory/exponent.lean
@@ -42,14 +42,16 @@ open_locale classical
 
 namespace monoid
 
-/-A predicate on a monoid saying that there is a positive integer `n` such that `g ^ n = 1`
+/--A predicate on a monoid saying that there is a positive integer `n` such that `g ^ n = 1`
   for all `g`.-/
-@[to_additive]
+@[to_additive "A predicate on an additive monoid saying that there is a positive integer `n` such
+  that `n • g = 0` for all `g`."]
 def exponent_exists  := ∃ n, 0 < n ∧ ∀ g : G, g ^ n = 1
 
-/-The exponent of a group is the smallest positive integer `n` such that `g ^ n = 1` for all `g ∈ G`
+/--The exponent of a group is the smallest positive integer `n` such that `g ^ n = 1` for all `g ∈ G`
 if it exists, otherwise it is zero by convention.-/
-@[to_additive]
+@[to_additive "The exponent of an additive group is the smallest positive integer `n` such that
+  `n • g = 0` for all `g ∈ G` if it exists, otherwise it is zero by convention."]
 noncomputable def exponent :=
 if h : exponent_exists G then nat.find h else 0
 
@@ -140,6 +142,7 @@ begin
   exact order_dvd_exponent G g,
 end
 
+@[to_additive lcm_add_order_eq_exponent]
 lemma lcm_order_eq_exponent {H : Type u} [fintype H] [left_cancel_monoid H] :
   ((finset.univ : finset H).image order_of).lcm id = exponent H :=
 begin

--- a/src/group_theory/exponent.lean
+++ b/src/group_theory/exponent.lean
@@ -24,8 +24,12 @@ the lowest common multiple of the order of all elements of the group `G`.
 * `add_monoid.exponent_exists` the additive version of `monoid.exponent_exists`.
 * `add_monoid.exponent` the additive version of `monoid.exponent`.
 
+## Main results
+
+* `lcm_order_eq_exponent`: For a finite group `G`, the exponent is equal to the `lcm` of the order
+  of its elements.
+
 ## TODO
-* Show that for a finite group `G`, the exponent is equal to the lcm of the orders of its elements.
 * Compute the exponent of cyclic groups.
 * Refactor the characteristic of a ring to be the exponent of its underlying additive group.
 -/
@@ -139,11 +143,18 @@ begin
   exact order_dvd_exponent G g,
 end
 
-lemma lcm_order_eq_exponent : ((finset.univ : finset G).image order_of).lcm id = exponent G :=
+lemma lcm_order_eq_exponent {H : Type u} [fintype H] [left_cancel_monoid H] :
+  ((finset.univ : finset H).image order_of).lcm id = exponent H :=
 begin
   apply nat.dvd_antisymm (lcm_order_of_dvd_exponent _),
   apply exponent_dvd_of_forall_pow_eq_one,
-  { sorry },
+  { apply nat.pos_of_ne_zero,
+    by_contradiction,
+    rw finset.lcm_eq_zero_iff at h,
+    cases h with m hm,
+    simp at hm,
+    rcases hm with ⟨⟨g, hg⟩, rfl⟩,
+    exact ne_of_gt (order_of_pos g) hg },
   { intro g,
     have h : (order_of g) ∣ (finset.image order_of finset.univ).lcm id,
     { apply finset.dvd_lcm,

--- a/src/group_theory/exponent.lean
+++ b/src/group_theory/exponent.lean
@@ -98,7 +98,7 @@ begin
 end
 
 @[simp, to_additive]
-lemma exp_punit_eq_one [subsingleton G] : exponent G = 1 :=
+lemma exp_eq_one_of_subsingleton [subsingleton G] : exponent G = 1 :=
 begin
   apply le_antisymm,
   { apply exponent_min' _ _ nat.one_pos,

--- a/src/group_theory/exponent.lean
+++ b/src/group_theory/exponent.lean
@@ -11,20 +11,21 @@ import ring_theory.int.basic
 /-!
 # Exponent of a group
 
-This file defines the exponent of a group. For a group `G` it is defined to be the minimal `n≥1`
-such that `g ^ n = 1` for all `g ∈ G`. For a finite group `G` it is equal to the lowest common
-multiple of the order of all elements of the group `G`.
+This file defines the exponent of a group, or more generally a monoid. For a group `G` it is defined
+to be the minimal `n≥1` such that `g ^ n = 1` for all `g ∈ G`. For a finite group `G` it is equal to
+the lowest common multiple of the order of all elements of the group `G`.
 
 ## Main definitions
 
-* `exponent_exists` is a predicate on a monoid `G` saying that there is some positive `n` such that
-  `g ^ n = 1` for all `g ∈ G`.
-* `exponent` defines the exponent of a monoid `G` as the minimal positive `n` such that `g ^ n = 1`
-  for all `g ∈ G`, by convention it is `0` if no such `n` exists.
+* `monoid.exponent_exists` is a predicate on a monoid `G` saying that there is some positive `n`
+  such that `g ^ n = 1` for all `g ∈ G`.
+* `monoid.exponent` defines the exponent of a monoid `G` as the minimal positive `n` such that
+  `g ^ n = 1` for all `g ∈ G`, by convention it is `0` if no such `n` exists.
+* `add_monoid.exponent_exists` the additive version of `monoid.exponent_exists`.
+* `add_monoid.exponent` the additive version of `monoid.exponent`.
 
 ## TODO
 * Show that for a finite group `G`, the exponent is equal to the lcm of the orders of its elements.
-* Provide additive versions of all notions.
 * Compute the exponent of cyclic groups.
 * Refactor the characteristic of a ring to be the exponent of its underlying additive group.
 -/
@@ -35,11 +36,20 @@ variables (G : Type u) [monoid G]
 
 open_locale classical
 
+namespace monoid
+
+/-A predicate on a monoid saying that there is a positive integer `n` such that `g ^ n = 1`
+  for all `g`.-/
+@[to_additive]
 def exponent_exists  := ∃ n, 0 < n ∧ ∀ g : G, g ^ n = 1
 
+/-The exponent of a group is the smallest positive integer `n` such that `g ^ n = 1` for all `g ∈ G`
+if it exists, otherwise it is zero by convention.-/
+@[to_additive]
 noncomputable def exponent :=
 if h : exponent_exists G then nat.find h else 0
 
+@[to_additive exponent_nsmul_eq_zero]
 lemma pow_exponent_eq_one (g : G) : g ^ exponent G = 1 :=
 begin
   by_cases exponent_exists G,
@@ -48,6 +58,12 @@ begin
   { simp_rw [exponent, dif_neg h, pow_zero] }
 end
 
+@[to_additive nsmul_eq_mod_exponent]
+lemma pow_eq_mod_exponent {n : ℕ} (g : G): g ^ n = g ^ (n % exponent G) :=
+calc g ^ n = g ^ (n % exponent G + exponent G * (n / exponent G)) : by rw [nat.mod_add_div]
+  ... = g ^ (n % exponent G) : by simp [pow_add, pow_mul, pow_exponent_eq_one]
+
+@[to_additive]
 lemma exponent_pos_of_exists (n : ℕ) (hpos : 0 < n)
 (hG : ∀ g : G, g ^ n = 1) : 0 < exponent G :=
 begin
@@ -57,6 +73,7 @@ begin
   exact (nat.find_spec h).1,
 end
 
+@[to_additive]
 lemma exponent_min' (n : ℕ) (hpos : 0 < n) (hG : ∀ g : G, g ^ n = 1) :
   exponent G ≤ n :=
 begin
@@ -78,6 +95,7 @@ begin
     refl },
 end
 
+@[to_additive add_order_dvd_exponent]
 lemma order_dvd_exponent (g : G) : (order_of g) ∣ exponent G :=
 begin
   exact order_of_dvd_of_pow_eq_one (pow_exponent_eq_one G g)
@@ -85,6 +103,7 @@ end
 
 variable [fintype G]
 
+@[to_additive lcm_add_order_dvd_exponent]
 lemma lcm_order_dvd_exponent : ((finset.univ : finset G).image order_of).lcm id ∣ exponent G :=
 begin
   apply finset.lcm_dvd,
@@ -95,3 +114,11 @@ begin
   rw [id, ←hg2],
   exact order_dvd_exponent G g,
 end
+
+lemma exponent_dvd_of_forall_pow_eq_one (n : ℕ) (hpos : 0 < n) (hG : ∀ g : G, g ^ n = 1) :
+  exponent G ∣ n :=
+begin
+  sorry
+end
+
+end monoid

--- a/src/group_theory/exponent.lean
+++ b/src/group_theory/exponent.lean
@@ -83,6 +83,15 @@ begin
   { exact ⟨n, hpos, hG⟩ },
 end
 
+@[to_additive]
+lemma exponent_min (m : ℕ) (hpos : 0 < m) (hm : m < exponent G) : ∃ g : G, g ^ m ≠ 1 :=
+begin
+  by_contradiction,
+  push_neg at h,
+  have hcon : exponent G ≤ m, from exponent_min' G m hpos h,
+  linarith,
+end
+
 lemma exp_punit_eq_one : exponent punit = 1 :=
 begin
   apply le_antisymm,

--- a/src/group_theory/exponent.lean
+++ b/src/group_theory/exponent.lean
@@ -97,14 +97,15 @@ begin
   linarith,
 end
 
-lemma exp_punit_eq_one : exponent punit = 1 :=
+@[simp, to_additive]
+lemma exp_punit_eq_one [subsingleton G] : exponent G = 1 :=
 begin
   apply le_antisymm,
   { apply exponent_min' _ _ nat.one_pos,
-    exact λ g, rfl },
+    simp },
   { apply nat.succ_le_of_lt,
     apply exponent_pos_of_exists _ 1 (nat.one_pos),
-    exact λ g, rfl },
+    simp },
 end
 
 @[to_additive add_order_dvd_exponent]


### PR DESCRIPTION
This PR provides the definition and some very basic API for the exponent of a group/monoid.  


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
