### PR TITLE
[Merged by Bors] - feat(linear_algebra/determinant): linear coordinates are ratio of determinants

### DIFF
--- a/src/linear_algebra/basis.lean
+++ b/src/linear_algebra/basis.lean
@@ -888,6 +888,32 @@ show finsupp.total _ _ _ v _ = v i, by simp
 @[simp] lemma coe_mk : ⇑(basis.mk hli hsp) = v :=
 funext (mk_apply _ _)
 
+variables {hli hsp}
+
+/-- Given a basis, the `i`th element of the dual basis evaluates to 1 on the `i`th element of the
+basis. -/
+lemma mk_coord_apply_eq (i : ι) :
+  (basis.mk hli hsp).coord i (v i) = 1 :=
+show hli.repr ⟨v i, submodule.subset_span (mem_range_self i)⟩ i = 1,
+by simp [hli.repr_eq_single i]
+
+/-- Given a basis, the `i`th element of the dual basis evaluates to 0 on the `j`th element of the
+basis if `j ≠ i`. -/
+lemma mk_coord_apply_neq {i j : ι} (h : j ≠ i) :
+  (basis.mk hli hsp).coord i (v j) = 0 :=
+show hli.repr ⟨v j, submodule.subset_span (mem_range_self j)⟩ i = 0,
+by simp [hli.repr_eq_single j, h]
+
+/-- Given a basis, the `i`th element of the dual basis evaluates to the Kronecker delta on the
+`j`th element of the basis. -/
+lemma mk_coord_apply {i j : ι} :
+  (basis.mk hli hsp).coord i (v j) = if j = i then 1 else 0 :=
+begin
+  cases eq_or_ne j i,
+  { simp only [h, if_true, eq_self_iff_true, mk_coord_apply_eq i], },
+  { simp only [h, if_false, mk_coord_apply_neq h], },
+end
+
 end mk
 
 section span

--- a/src/linear_algebra/basis.lean
+++ b/src/linear_algebra/basis.lean
@@ -899,7 +899,7 @@ by simp [hli.repr_eq_single i]
 
 /-- Given a basis, the `i`th element of the dual basis evaluates to 0 on the `j`th element of the
 basis if `j ≠ i`. -/
-lemma mk_coord_apply_neq {i j : ι} (h : j ≠ i) :
+lemma mk_coord_apply_ne {i j : ι} (h : j ≠ i) :
   (basis.mk hli hsp).coord i (v j) = 0 :=
 show hli.repr ⟨v j, submodule.subset_span (mem_range_self j)⟩ i = 0,
 by simp [hli.repr_eq_single j, h]
@@ -911,7 +911,7 @@ lemma mk_coord_apply {i j : ι} :
 begin
   cases eq_or_ne j i,
   { simp only [h, if_true, eq_self_iff_true, mk_coord_apply_eq i], },
-  { simp only [h, if_false, mk_coord_apply_neq h], },
+  { simp only [h, if_false, mk_coord_apply_ne h], },
 end
 
 end mk

--- a/src/linear_algebra/determinant.lean
+++ b/src/linear_algebra/determinant.lean
@@ -46,7 +46,7 @@ open submodule
 
 universes u v w
 
-open linear_map matrix
+open linear_map matrix set function
 
 variables {R : Type*} [comm_ring R]
 variables {M : Type*} [add_comm_group M] [module R M]
@@ -400,3 +400,19 @@ by rw [basis.det_reindex, function.comp.assoc, e.self_comp_symm, function.comp.r
 lemma basis.det_map (b : basis ι R M) (f : M ≃ₗ[R] M') (v : ι → M') :
   (b.map f).det v = b.det (f.symm ∘ v) :=
 by { rw [basis.det_apply, basis.to_matrix_map, basis.det_apply] }
+
+/-- If we fix a background basis `e`, then for any other basis `v`, we can characterise coordinates
+provided by `v` in terms of determinants relative to `b`. -/
+lemma basis.det_smul_mk_coord_eq_det_update {v : ι → M}
+  (hli : linear_independent R v) (hsp : span R (range v) = ⊤) (i : ι) :
+  (e.det v) • (basis.mk hli hsp).coord i =
+  ⟨λ m, e.det (update v i m), e.det.map_add v i, e.det.map_smul v i⟩ :=
+begin
+  apply (basis.mk hli hsp).ext,
+  intros k,
+  rcases eq_or_ne k i with rfl | hik;
+  simp only [algebra.id.smul_eq_mul, basis.coe_mk, linear_map.smul_apply, linear_map.coe_mk],
+  { rw [basis.mk_coord_apply_eq, mul_one, update_eq_self], },
+  { rw [basis.mk_coord_apply_neq hik, mul_zero, eq_comm],
+    exact e.det.map_eq_zero_of_eq _ (by simp [hik, function.update_apply]) hik, },
+end

--- a/src/linear_algebra/determinant.lean
+++ b/src/linear_algebra/determinant.lean
@@ -401,8 +401,8 @@ lemma basis.det_map (b : basis ι R M) (f : M ≃ₗ[R] M') (v : ι → M') :
   (b.map f).det v = b.det (f.symm ∘ v) :=
 by { rw [basis.det_apply, basis.to_matrix_map, basis.det_apply] }
 
-/-- If we fix a background basis `e`, then for any other basis `v`, we can characterise coordinates
-provided by `v` in terms of determinants relative to `b`. -/
+/-- If we fix a background basis `e`, then for any other basis `v`, we can characterise the
+coordinates provided by `v` in terms of determinants relative to `e`. -/
 lemma basis.det_smul_mk_coord_eq_det_update {v : ι → M}
   (hli : linear_independent R v) (hsp : span R (range v) = ⊤) (i : ι) :
   (e.det v) • (basis.mk hli hsp).coord i =
@@ -413,6 +413,6 @@ begin
   rcases eq_or_ne k i with rfl | hik;
   simp only [algebra.id.smul_eq_mul, basis.coe_mk, linear_map.smul_apply, linear_map.coe_mk],
   { rw [basis.mk_coord_apply_eq, mul_one, update_eq_self], },
-  { rw [basis.mk_coord_apply_neq hik, mul_zero, eq_comm],
+  { rw [basis.mk_coord_apply_ne hik, mul_zero, eq_comm],
     exact e.det.map_eq_zero_of_eq _ (by simp [hik, function.update_apply]) hik, },
 end

--- a/src/linear_algebra/determinant.lean
+++ b/src/linear_algebra/determinant.lean
@@ -405,14 +405,14 @@ by { rw [basis.det_apply, basis.to_matrix_map, basis.det_apply] }
 coordinates provided by `v` in terms of determinants relative to `e`. -/
 lemma basis.det_smul_mk_coord_eq_det_update {v : ι → M}
   (hli : linear_independent R v) (hsp : span R (range v) = ⊤) (i : ι) :
-  (e.det v) • (basis.mk hli hsp).coord i =
-  ⟨λ m, e.det (update v i m), e.det.map_add v i, e.det.map_smul v i⟩ :=
+  (e.det v) • (basis.mk hli hsp).coord i = e.det.to_multilinear_map.to_linear_map v i :=
 begin
   apply (basis.mk hli hsp).ext,
   intros k,
   rcases eq_or_ne k i with rfl | hik;
-  simp only [algebra.id.smul_eq_mul, basis.coe_mk, linear_map.smul_apply, linear_map.coe_mk],
-  { rw [basis.mk_coord_apply_eq, mul_one, update_eq_self], },
+  simp only [algebra.id.smul_eq_mul, basis.coe_mk, linear_map.smul_apply, linear_map.coe_mk,
+    multilinear_map.to_linear_map_apply],
+  { rw [basis.mk_coord_apply_eq, mul_one, update_eq_self], congr, },
   { rw [basis.mk_coord_apply_ne hik, mul_zero, eq_comm],
     exact e.det.map_eq_zero_of_eq _ (by simp [hik, function.update_apply]) hik, },
 end

--- a/src/linear_algebra/multilinear/basic.lean
+++ b/src/linear_algebra/multilinear/basic.lean
@@ -167,7 +167,7 @@ end
 
 /-- If `f` is a multilinear map, then `f.to_linear_map m i` is the linear map obtained by fixing all
 coordinates but `i` equal to those of `m`, and varying the `i`-th coordinate. -/
-def to_linear_map (m : Πi, M₁ i) (i : ι) : M₁ i →ₗ[R] M₂ :=
+@[simps] def to_linear_map (m : Πi, M₁ i) (i : ι) : M₁ i →ₗ[R] M₂ :=
 { to_fun    := λx, f (update m i x),
   map_add'  := λx y, by simp,
   map_smul' := λc x, by simp }


### PR DESCRIPTION
Formalized as part of the Sphere Eversion project.



---

I have reluctantly persuaded myself to prove the smoothness result I need via determinants instead of the exterior algebra.


[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
