### PR TITLE
[Merged by Bors] - refactor(group_theory/complement): Generalize `card_mul` to from subgroups to subsets

### DIFF
--- a/src/group_theory/complement.lean
+++ b/src/group_theory/complement.lean
@@ -210,9 +210,13 @@ mem_right_transversals_iff_exists_unique_quotient_mk'_eq.trans
 { rintros ⟨_, q₁, rfl⟩ ⟨_, q₂, rfl⟩ hg,
   rw (q₁.out_eq'.symm.trans hg).trans q₂.out_eq' }, λ q, ⟨⟨q.out', q, rfl⟩, quotient.out_eq' q⟩⟩⟩⟩
 
+lemma is_complement.card_mul [fintype G] [fintype S] [fintype T] (h : is_complement S T) :
+  fintype.card S * fintype.card T = fintype.card G :=
+(fintype.card_prod _ _).symm.trans (fintype.card_of_bijective h)
+
 lemma is_complement'.card_mul [fintype G] [fintype H] [fintype K] (h : is_complement' H K) :
   fintype.card H * fintype.card K = fintype.card G :=
-(fintype.card_prod _ _).symm.trans (fintype.card_of_bijective h)
+h.card_mul
 
 lemma is_complement'.disjoint (h : is_complement' H K) : disjoint H K :=
 λ g hg, let x : H × K := ⟨⟨g, hg.1⟩, 1⟩, y : H × K := ⟨1, ⟨g, hg.2⟩⟩ in subtype.ext_iff.mp


### PR DESCRIPTION
Adds `is_complement.card_mul`, which generalizes `is_complement'.card_mul`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
