### PR TITLE
[Merged by Bors] - chore(category_theory/isomorphisms): Adjust priority for is_iso.comp_is_iso

### DIFF
--- a/src/category_theory/isomorphism.lean
+++ b/src/category_theory/isomorphism.lean
@@ -236,6 +236,7 @@ variables {f g : X ⟶ Y} {h : Y ⟶ Z}
 instance inv_is_iso [is_iso f] : is_iso (inv f) :=
 is_iso.of_iso_inv (as_iso f)
 
+@[priority 900]
 instance comp_is_iso [is_iso f] [is_iso h] : is_iso (f ≫ h) :=
 is_iso.of_iso $ (as_iso f) ≪≫ (as_iso h)
 

--- a/src/category_theory/isomorphism.lean
+++ b/src/category_theory/isomorphism.lean
@@ -236,6 +236,8 @@ variables {f g : X ⟶ Y} {h : Y ⟶ Z}
 instance inv_is_iso [is_iso f] : is_iso (inv f) :=
 is_iso.of_iso_inv (as_iso f)
 
+/- The following instance has lower priority for the following reason:
+Given `f : X ≅ Y` with `X Y : Type u`, without this priority change, typeclass inference cannot deduce `is_iso f.hom` because `f.hom` is defeq to `(λ x, x) ≫ f.hom`, triggering a loop. -/
 @[priority 900]
 instance comp_is_iso [is_iso f] [is_iso h] : is_iso (f ≫ h) :=
 is_iso.of_iso $ (as_iso f) ≪≫ (as_iso h)

--- a/src/category_theory/isomorphism.lean
+++ b/src/category_theory/isomorphism.lean
@@ -237,7 +237,9 @@ instance inv_is_iso [is_iso f] : is_iso (inv f) :=
 is_iso.of_iso_inv (as_iso f)
 
 /- The following instance has lower priority for the following reason:
-Given `f : X ≅ Y` with `X Y : Type u`, without this priority change, typeclass inference cannot deduce `is_iso f.hom` because `f.hom` is defeq to `(λ x, x) ≫ f.hom`, triggering a loop. -/
+Suppose we are given `f : X ≅ Y` with `X Y : Type u`.
+Without the lower priority, typeclass inference cannot deduce `is_iso f.hom`
+because `f.hom` is defeq to `(λ x, x) ≫ f.hom`, triggering a loop. -/
 @[priority 900]
 instance comp_is_iso [is_iso f] [is_iso h] : is_iso (f ≫ h) :=
 is_iso.of_iso $ (as_iso f) ≪≫ (as_iso h)


### PR DESCRIPTION
[See Zulip](https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/iso.20to.20is_iso.20for.20types/near/261122457)

Given `f : X ≅ Y` with `X Y : Type u`, without this change, typeclass inference cannot deduce `is_iso f.hom` because `f.hom` is defeq to `(λ x, x) ≫ f.hom`, triggering a loop. 

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
