### PR TITLE
[Merged by Bors] - feat(data/list/big_operators): When `list.sum` is strictly positive

### DIFF
--- a/src/data/list/big_operators.lean
+++ b/src/data/list/big_operators.lean
@@ -215,20 +215,8 @@ begin
   exact one_le_mul (hl₁ hd (mem_cons_self hd tl)) (ih (λ x h, hl₁ x (mem_cons_of_mem hd h))),
 end
 
-lemma sum_pos [ordered_add_comm_monoid α] :
-  ∀ (l : list α) (hl : ∀ x ∈ l, (0 : α) < x) (hl₂ : l ≠ []), 0 < l.sum
-| [] _ h := (h rfl).elim
-| [b] h _ := by simpa using h
-| (a :: b :: l) hl₁ hl₂ :=
-begin
-  simp only [forall_eq_or_imp, list.mem_cons_iff _ a] at hl₁,
-  rw list.sum_cons,
-  apply add_pos_of_pos_of_nonneg hl₁.1,
-  apply le_of_lt ((b :: l).sum_pos hl₁.2 (l.cons_ne_nil b)),
-end
-
--- @[to_additive sum_pos]
-lemma one_lt_prod_of_one_lt [ordered_semiring α] :
+@[to_additive sum_pos]
+lemma one_lt_prod_of_one_lt [ordered_comm_monoid α] :
   ∀ (l : list α) (hl : ∀ x ∈ l, (1 : α) < x) (hl₂ : l ≠ []), 1 < l.prod
 | [] _ h := (h rfl).elim
 | [b] h _ := by simpa using h
@@ -236,9 +224,9 @@ lemma one_lt_prod_of_one_lt [ordered_semiring α] :
 begin
   simp only [forall_eq_or_imp, list.mem_cons_iff _ a] at hl₁,
   rw list.prod_cons,
-  exact one_lt_mul hl₁.1.le (one_lt_prod_of_one_lt _ hl₁.2 $ cons_ne_nil _ _),
+  apply one_lt_mul_of_lt_of_le' hl₁.1,
+  apply le_of_lt ((b :: l).one_lt_prod_of_one_lt hl₁.2 (l.cons_ne_nil b)),
 end
-
 @[to_additive]
 lemma single_le_prod [ordered_comm_monoid α] {l : list α} (hl₁ : ∀ x ∈ l, (1 : α) ≤ x) :
   ∀ x ∈ l, x ≤ l.prod :=

--- a/src/data/list/big_operators.lean
+++ b/src/data/list/big_operators.lean
@@ -215,6 +215,30 @@ begin
   exact one_le_mul (hl₁ hd (mem_cons_self hd tl)) (ih (λ x h, hl₁ x (mem_cons_of_mem hd h))),
 end
 
+lemma sum_pos [ordered_add_comm_monoid α] :
+  ∀ (l : list α) (hl : ∀ x ∈ l, (0 : α) < x) (hl₂ : l ≠ []), 0 < l.sum
+| [] _ h := (h rfl).elim
+| [b] h _ := by simpa using h
+| (a :: b :: l) hl₁ hl₂ :=
+begin
+  simp only [forall_eq_or_imp, list.mem_cons_iff _ a] at hl₁,
+  rw list.sum_cons,
+  apply add_pos_of_pos_of_nonneg hl₁.1,
+  apply le_of_lt ((b :: l).sum_pos hl₁.2 (l.cons_ne_nil b)),
+end
+
+-- @[to_additive sum_pos]
+lemma one_lt_prod_of_one_lt [ordered_semiring α] :
+  ∀ (l : list α) (hl : ∀ x ∈ l, (1 : α) < x) (hl₂ : l ≠ []), 1 < l.prod
+| [] _ h := (h rfl).elim
+| [b] h _ := by simpa using h
+| (a :: b :: l) hl₁ hl₂ :=
+begin
+  simp only [forall_eq_or_imp, list.mem_cons_iff _ a] at hl₁,
+  rw list.prod_cons,
+  exact one_lt_mul hl₁.1.le (one_lt_prod_of_one_lt _ hl₁.2 $ cons_ne_nil _ _),
+end
+
 @[to_additive]
 lemma single_le_prod [ordered_comm_monoid α] {l : list α} (hl₁ : ∀ x ∈ l, (1 : α) ≤ x) :
   ∀ x ∈ l, x ≤ l.prod :=


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
I don't know whether we want the `multiset` and `list` versions.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
