### PR TITLE
[Merged by Bors] - fix(logic/basic): remove `noncomputable lemma`

### DIFF
--- a/src/logic/basic.lean
+++ b/src/logic/basic.lean
@@ -1145,25 +1145,14 @@ theorem cases {p : Prop → Prop} (h1 : p true) (h2 : p false) : ∀a, p a :=
 assume a, cases_on a h1 h2
 
 /- use shortened names to avoid conflict when classical namespace is open. -/
-noncomputable lemma dec (p : Prop) : decidable p := -- see Note [classical lemma]
+noncomputable def dec (p : Prop) : decidable p :=
 by apply_instance
-noncomputable lemma dec_pred (p : α → Prop) : decidable_pred p := -- see Note [classical lemma]
+noncomputable def dec_pred (p : α → Prop) : decidable_pred p :=
 by apply_instance
-noncomputable lemma dec_rel (p : α → α → Prop) : decidable_rel p := -- see Note [classical lemma]
+noncomputable def dec_rel (p : α → α → Prop) : decidable_rel p :=
 by apply_instance
-noncomputable lemma dec_eq (α : Sort*) : decidable_eq α := -- see Note [classical lemma]
+noncomputable def dec_eq (α : Sort*) : decidable_eq α :=
 by apply_instance
-
-/--
-We make decidability results that depends on `classical.choice` noncomputable lemmas.
-* We have to mark them as noncomputable, because otherwise Lean will try to generate bytecode
-  for them, and fail because it depends on `classical.choice`.
-* We make them lemmas, and not definitions, because otherwise later definitions will raise
-  \"failed to generate bytecode\" errors when writing something like
-  `letI := classical.dec_eq _`.
-Cf. <https://leanprover-community.github.io/archive/stream/113488-general/topic/noncomputable.20theorem.html>
--/
-library_note "classical lemma"
 
 /-- Construct a function from a default value `H0`, and a function to use if there exists a value
 satisfying the predicate. -/

--- a/src/logic/basic.lean
+++ b/src/logic/basic.lean
@@ -1145,12 +1145,16 @@ theorem cases {p : Prop → Prop} (h1 : p true) (h2 : p false) : ∀a, p a :=
 assume a, cases_on a h1 h2
 
 /- use shortened names to avoid conflict when classical namespace is open. -/
+/-- Any prop `p` is decidable classically. A shorthand for `classical.prop_decidable`. -/
 noncomputable def dec (p : Prop) : decidable p :=
 by apply_instance
+/-- Any predicate `p` is decidable classically. -/
 noncomputable def dec_pred (p : α → Prop) : decidable_pred p :=
 by apply_instance
+/-- Any relation `p` is decidable classically. -/
 noncomputable def dec_rel (p : α → α → Prop) : decidable_rel p :=
 by apply_instance
+/-- Any type `α` has decidable equality classically. -/
 noncomputable def dec_eq (α : Sort*) : decidable_eq α :=
 by apply_instance
 

--- a/src/tactic/lint/misc.lean
+++ b/src/tactic/lint/misc.lean
@@ -251,8 +251,6 @@ has been used. -/
   no_errors_found := "All declarations correctly marked as def/lemma.",
   errors_found := "INCORRECT DEF/LEMMA:" }
 
-attribute [nolint def_lemma] classical.dec classical.dec_pred classical.dec_rel classical.dec_eq
-
 /-!
 ## Linter that checks whether declarations are well-typed
 -/


### PR DESCRIPTION
It's been three years since this was discussed according to the zulip archive link in the library note.

According to CI, the reason is no longer relevant. Leaving these as `noncomputable lemma` is harmful as it results in non-defeq instance diamonds sometimes as lean was not able to unfold the lemmas to get to the data underneath.

Since these are now `def`s, the linter requires them to have docstrings.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

This came up [on Zulip](https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/A.20possible.20diamond/near/261246251). 

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
