### PR TITLE
[Merged by Bors] - refactor(algebra/opposites): use mul_opposite for multiplicative opposite

### DIFF
--- a/src/algebra/algebra/basic.lean
+++ b/src/algebra/algebra/basic.lean
@@ -382,20 +382,20 @@ end field
 
 end no_zero_smul_divisors
 
-namespace opposite
+namespace mul_opposite
 
 variables {R A : Type*} [comm_semiring R] [semiring A] [algebra R A]
 
-instance : algebra R Aᵒᵖ :=
+instance : algebra R Aᵐᵒᵖ :=
 { to_ring_hom := (algebra_map R A).to_opposite $ λ x y, algebra.commutes _ _,
   smul_def' := λ c x, unop_injective $
     by { dsimp, simp only [op_mul, algebra.smul_def, algebra.commutes, op_unop] },
-  commutes' := λ r, opposite.rec $ λ x, by dsimp; simp only [← op_mul, algebra.commutes],
-  ..opposite.has_scalar A R }
+  commutes' := λ r, mul_opposite.rec $ λ x, by dsimp; simp only [← op_mul, algebra.commutes],
+  .. mul_opposite.has_scalar A R }
 
-@[simp] lemma algebra_map_apply (c : R) : algebra_map R Aᵒᵖ c = op (algebra_map R A c) := rfl
+@[simp] lemma algebra_map_apply (c : R) : algebra_map R Aᵐᵒᵖ c = op (algebra_map R A c) := rfl
 
-end opposite
+end mul_opposite
 
 namespace module
 variables (R : Type u) (M : Type v) [comm_semiring R] [add_comm_monoid M] [module R M]

--- a/src/algebra/big_operators/basic.lean
+++ b/src/algebra/big_operators/basic.lean
@@ -126,8 +126,8 @@ lemma ring_hom.map_list_sum [non_assoc_semiring β] [non_assoc_semiring γ]
 f.to_add_monoid_hom.map_list_sum l
 
 /-- A morphism into the opposite ring acts on the product by acting on the reversed elements -/
-lemma ring_hom.unop_map_list_prod [semiring β] [semiring γ] (f : β →+* γᵒᵖ) (l : list β) :
-  opposite.unop (f l.prod) = (l.map (opposite.unop ∘ f)).reverse.prod :=
+lemma ring_hom.unop_map_list_prod [semiring β] [semiring γ] (f : β →+* γᵐᵒᵖ) (l : list β) :
+  mul_opposite.unop (f l.prod) = (l.map (mul_opposite.unop ∘ f)).reverse.prod :=
 f.to_monoid_hom.unop_map_list_prod l
 
 lemma ring_hom.map_multiset_prod [comm_semiring β] [comm_semiring γ] (f : β →+* γ)
@@ -1216,16 +1216,16 @@ end
 
 section opposite
 
-open opposite
+open mul_opposite
 
 /-- Moving to the opposite additive commutative monoid commutes with summing. -/
 @[simp] lemma op_sum [add_comm_monoid β] {s : finset α} (f : α → β) :
   op (∑ x in s, f x) = ∑ x in s, op (f x) :=
-(op_add_equiv : β ≃+ βᵒᵖ).map_sum _ _
+(op_add_equiv : β ≃+ βᵐᵒᵖ).map_sum _ _
 
-@[simp] lemma unop_sum [add_comm_monoid β] {s : finset α} (f : α → βᵒᵖ) :
+@[simp] lemma unop_sum [add_comm_monoid β] {s : finset α} (f : α → βᵐᵒᵖ) :
   unop (∑ x in s, f x) = ∑ x in s, unop (f x) :=
-(op_add_equiv : β ≃+ βᵒᵖ).symm.map_sum _ _
+(op_add_equiv : β ≃+ βᵐᵒᵖ).symm.map_sum _ _
 
 end opposite
 

--- a/src/algebra/free_algebra.lean
+++ b/src/algebra/free_algebra.lean
@@ -414,7 +414,7 @@ end
 
 /-- The star ring formed by reversing the elements of products -/
 instance : star_ring (free_algebra R X) :=
-{ star := opposite.unop ∘ lift R (opposite.op ∘ ι R),
+{ star := mul_opposite.unop ∘ lift R (mul_opposite.op ∘ ι R),
   star_involutive := λ x, by
   { unfold has_star.star,
     simp only [function.comp_apply],
@@ -431,7 +431,7 @@ lemma star_algebra_map (r : R) : star (algebra_map R (free_algebra R X) r) = (al
 by simp [star, has_star.star]
 
 /-- `star` as an `alg_equiv` -/
-def star_hom : free_algebra R X ≃ₐ[R] (free_algebra R X)ᵒᵖ :=
+def star_hom : free_algebra R X ≃ₐ[R] (free_algebra R X)ᵐᵒᵖ :=
 { commutes' := λ r, by simp [star_algebra_map],
   ..star_ring_equiv }
 

--- a/src/algebra/geom_sum.lean
+++ b/src/algebra/geom_sum.lean
@@ -37,7 +37,7 @@ are recorded.
 universe u
 variable {α : Type u}
 
-open finset opposite
+open finset mul_opposite
 
 open_locale big_operators
 
@@ -152,7 +152,7 @@ end
 lemma commute.mul_neg_geom_sum₂ [ring α] {x y : α} (h : commute x y) (n : ℕ) :
   (y - x) * (geom_sum₂ x y n) = y ^ n - x ^ n :=
 begin
-  rw ← op_inj_iff,
+  apply op_injective,
   simp only [op_mul, op_sub, op_geom_sum₂, op_pow],
   exact (commute.op h.symm).geom_sum₂_mul n
 end
@@ -175,10 +175,7 @@ end
 
 lemma mul_geom_sum [ring α] (x : α) (n : ℕ) :
   (x - 1) * (geom_sum x n) = x ^ n - 1 :=
-begin
-  rw ← op_inj_iff,
-  simpa using geom_sum_mul (op x) n,
-end
+op_injective $ by simpa using geom_sum_mul (op x) n
 
 theorem geom_sum_mul_neg [ring α] (x : α) (n : ℕ) :
   (geom_sum x n) * (1 - x) = 1 - x ^ n :=
@@ -190,10 +187,7 @@ end
 
 lemma mul_neg_geom_sum [ring α] (x : α) (n : ℕ) :
   (1 - x) * (geom_sum x n) = 1 - x ^ n :=
-begin
-  rw ← op_inj_iff,
-  simpa using geom_sum_mul_neg (op x) n,
-end
+op_injective $ by simpa using geom_sum_mul_neg (op x) n
 
 protected theorem commute.geom_sum₂ [division_ring α] {x y : α} (h' : commute x y) (h : x ≠ y)
   (n : ℕ) : (geom_sum₂ x y n) = (x ^ n - y ^ n) / (x - y) :=
@@ -256,7 +250,7 @@ protected theorem commute.geom_sum₂_Ico_mul [ring α] {x y : α} (h : commute 
   (hmn : m ≤ n) :
   (∑ i in finset.Ico m n, x ^ i * y ^ (n - 1 - i)) * (x - y) = x ^ n -  y ^ (n - m) * x ^ m :=
 begin
-  rw ← op_inj_iff,
+  apply op_injective,
   simp only [op_sub, op_mul, op_pow, op_sum],
   have : ∑ k in Ico m n, op y ^ (n - 1 - k) * op x ^ k
     = ∑ k in Ico m n, op x ^ k * op y ^ (n - 1 - k),

--- a/src/algebra/group/prod.lean
+++ b/src/algebra/group/prod.lean
@@ -337,11 +337,11 @@ end mul_equiv
 
 section units
 
-open opposite
+open mul_opposite
 
-/-- Canonical homomorphism of monoids from `units α` into `α × αᵒᵖ`.
+/-- Canonical homomorphism of monoids from `units α` into `α × αᵐᵒᵖ`.
 Used mainly to define the natural topology of `units α`. -/
-def embed_product (α : Type*) [monoid α] : units α →* α × αᵒᵖ :=
+def embed_product (α : Type*) [monoid α] : units α →* α × αᵐᵒᵖ :=
 { to_fun := λ x, ⟨x, op ↑x⁻¹⟩,
   map_one' := by simp only [one_inv, eq_self_iff_true, units.coe_one, op_one, prod.mk_eq_one,
     and_self],

--- a/src/algebra/group_power/lemmas.lean
+++ b/src/algebra/group_power/lemmas.lean
@@ -915,14 +915,14 @@ lemma conj_pow' (u : units M) (x : M) (n : ℕ) : (↑(u⁻¹) * x * u)^n = ↑(
 
 end units
 
-namespace opposite
+namespace mul_opposite
 
 /-- Moving to the opposite monoid commutes with taking powers. -/
 @[simp] lemma op_pow [monoid M] (x : M) (n : ℕ) : op (x ^ n) = (op x) ^ n := rfl
-@[simp] lemma unop_pow [monoid M] (x : Mᵒᵖ) (n : ℕ) : unop (x ^ n) = (unop x) ^ n := rfl
+@[simp] lemma unop_pow [monoid M] (x : Mᵐᵒᵖ) (n : ℕ) : unop (x ^ n) = (unop x) ^ n := rfl
 
 /-- Moving to the opposite group or group_with_zero commutes with taking powers. -/
 @[simp] lemma op_zpow [div_inv_monoid M] (x : M) (z : ℤ) : op (x ^ z) = (op x) ^ z := rfl
-@[simp] lemma unop_zpow [div_inv_monoid M] (x : Mᵒᵖ) (z : ℤ) : unop (x ^ z) = (unop x) ^ z := rfl
+@[simp] lemma unop_zpow [div_inv_monoid M] (x : Mᵐᵒᵖ) (z : ℤ) : unop (x ^ z) = (unop x) ^ z := rfl
 
-end opposite
+end mul_opposite

--- a/src/algebra/hierarchy_design.lean
+++ b/src/algebra/hierarchy_design.lean
@@ -67,10 +67,10 @@ when applicable:
   ```
   instance pi.Z [∀ i, Z $ f i] : Z (Π i : I, f i) := ...
   ```
-* Instances transferred to `opposite M`, like `opposite.monoid`.
+* Instances transferred to `mul_opposite M`, like `mul_opposite.monoid`.
   See `algebra.opposites` for more examples.
   ```
-  instance opposite.Z [Z M] : Z (opposite M) := ...
+  instance mul_opposite.Z [Z M] : Z (mul_opposite M) := ...
   ```
 * Instances transferred to `ulift M`, like `ulift.monoid`.
   See `algebra.group.ulift` for more examples.

--- a/src/algebra/module/basic.lean
+++ b/src/algebra/module/basic.lean
@@ -251,7 +251,7 @@ instance semiring.to_module [semiring R] : module R R :=
 
 /-- Like `semiring.to_module`, but multiplies on the right. -/
 @[priority 910] -- see Note [lower instance priority]
-instance semiring.to_opposite_module [semiring R] : module Rᵒᵖ R :=
+instance semiring.to_opposite_module [semiring R] : module Rᵐᵒᵖ R :=
 { smul_add := λ r x y, add_mul _ _ _,
   add_smul := λ r x y, mul_add _ _ _,
   ..monoid_with_zero.to_opposite_mul_action_with_zero R}

--- a/src/algebra/module/opposites.lean
+++ b/src/algebra/module/opposites.lean
@@ -7,40 +7,40 @@ import algebra.opposites
 import data.equiv.module
 
 /-!
-# Module operations on `Mᵒᵖ`
+# Module operations on `Mᵐᵒᵖ`
 
 This file contains definitions that could not be placed into `algebra.opposites` due to import
 cycles.
 -/
 
-namespace opposite
+namespace mul_opposite
 universes u v
 
 variables (R : Type u) {M : Type v} [semiring R] [add_comm_monoid M] [module R M]
 
-/-- `opposite.distrib_mul_action` extends to a `module` -/
-instance : module R (opposite M) :=
+/-- `mul_opposite.distrib_mul_action` extends to a `module` -/
+instance : module R (mul_opposite M) :=
 { add_smul := λ r₁ r₂ x, unop_injective $ add_smul r₁ r₂ (unop x),
   zero_smul := λ x, unop_injective $ zero_smul _ (unop x),
-  ..opposite.distrib_mul_action M R }
+  ..mul_opposite.distrib_mul_action M R }
 
 /-- The function `op` is a linear equivalence. -/
-def op_linear_equiv : M ≃ₗ[R] Mᵒᵖ :=
-{ map_smul' := opposite.op_smul, .. op_add_equiv }
+def op_linear_equiv : M ≃ₗ[R] Mᵐᵒᵖ :=
+{ map_smul' := mul_opposite.op_smul, .. op_add_equiv }
 
 @[simp] lemma coe_op_linear_equiv :
-  (op_linear_equiv R : M → Mᵒᵖ) = op := rfl
+  (op_linear_equiv R : M → Mᵐᵒᵖ) = op := rfl
 @[simp] lemma coe_op_linear_equiv_symm :
-  ((op_linear_equiv R).symm : Mᵒᵖ → M) = unop := rfl
+  ((op_linear_equiv R).symm : Mᵐᵒᵖ → M) = unop := rfl
 
 @[simp] lemma coe_op_linear_equiv_to_linear_map :
-  ((op_linear_equiv R).to_linear_map : M → Mᵒᵖ) = op := rfl
+  ((op_linear_equiv R).to_linear_map : M → Mᵐᵒᵖ) = op := rfl
 @[simp] lemma coe_op_linear_equiv_symm_to_linear_map :
-  ((op_linear_equiv R).symm.to_linear_map : Mᵒᵖ → M) = unop := rfl
+  ((op_linear_equiv R).symm.to_linear_map : Mᵐᵒᵖ → M) = unop := rfl
 
 @[simp] lemma op_linear_equiv_to_add_equiv :
-  (op_linear_equiv R : M ≃ₗ[R] Mᵒᵖ).to_add_equiv = op_add_equiv := rfl
+  (op_linear_equiv R : M ≃ₗ[R] Mᵐᵒᵖ).to_add_equiv = op_add_equiv := rfl
 @[simp] lemma op_linear_equiv_symm_to_add_equiv :
-  (op_linear_equiv R : M ≃ₗ[R] Mᵒᵖ).symm.to_add_equiv = op_add_equiv.symm := rfl
+  (op_linear_equiv R : M ≃ₗ[R] Mᵐᵒᵖ).symm.to_add_equiv = op_add_equiv.symm := rfl
 
-end opposite
+end mul_opposite

--- a/src/algebra/monoid_algebra/basic.lean
+++ b/src/algebra/monoid_algebra/basic.lean
@@ -739,28 +739,28 @@ end span
 
 section opposite
 
-open finsupp opposite
+open finsupp mul_opposite
 
 variables [semiring k]
 
 /-- The opposite of an `monoid_algebra R I` equivalent as a ring to
-the `monoid_algebra Rᵒᵖ Iᵒᵖ` over the opposite ring, taking elements to their opposite. -/
+the `monoid_algebra Rᵐᵒᵖ Iᵐᵒᵖ` over the opposite ring, taking elements to their opposite. -/
 @[simps {simp_rhs := tt}] protected noncomputable def op_ring_equiv [monoid G] :
-  (monoid_algebra k G)ᵒᵖ ≃+* monoid_algebra kᵒᵖ Gᵒᵖ :=
+  (monoid_algebra k G)ᵐᵒᵖ ≃+* monoid_algebra kᵐᵒᵖ Gᵐᵒᵖ :=
 { map_mul' := begin
     dsimp only [add_equiv.to_fun_eq_coe, ←add_equiv.coe_to_add_monoid_hom],
     rw add_monoid_hom.map_mul_iff,
     ext i₁ r₁ i₂ r₂ : 6,
     simp
   end,
-  ..op_add_equiv.symm.trans $ (finsupp.map_range.add_equiv (op_add_equiv : k ≃+ kᵒᵖ)).trans $
-    finsupp.dom_congr equiv_to_opposite }
+  ..op_add_equiv.symm.trans $ (finsupp.map_range.add_equiv (op_add_equiv : k ≃+ kᵐᵒᵖ)).trans $
+    finsupp.dom_congr op_equiv }
 
 @[simp] lemma op_ring_equiv_single [monoid G] (r : k) (x : G) :
   monoid_algebra.op_ring_equiv (op (single x r)) = single (op x) (op r) :=
 by simp
 
-@[simp] lemma op_ring_equiv_symm_single [monoid G] (r : kᵒᵖ) (x : Gᵒᵖ) :
+@[simp] lemma op_ring_equiv_symm_single [monoid G] (r : kᵐᵒᵖ) (x : Gᵐᵒᵖ) :
   monoid_algebra.op_ring_equiv.symm (single x r) = op (single x.unop r.unop) :=
 by simp
 
@@ -1242,14 +1242,14 @@ ring_hom_ext (ring_hom.congr_fun h₁) (monoid_hom.congr_fun h_of)
 
 section opposite
 
-open finsupp opposite
+open finsupp mul_opposite
 
 variables [semiring k]
 
 /-- The opposite of an `add_monoid_algebra R I` is ring equivalent to
-the `add_monoid_algebra Rᵒᵖ I` over the opposite ring, taking elements to their opposite. -/
+the `add_monoid_algebra Rᵐᵒᵖ I` over the opposite ring, taking elements to their opposite. -/
 @[simps {simp_rhs := tt}] protected noncomputable def op_ring_equiv [add_comm_monoid G] :
-  (add_monoid_algebra k G)ᵒᵖ ≃+* add_monoid_algebra kᵒᵖ G :=
+  (add_monoid_algebra k G)ᵐᵒᵖ ≃+* add_monoid_algebra kᵐᵒᵖ G :=
 { map_mul' := begin
     dsimp only [add_equiv.to_fun_eq_coe, ←add_equiv.coe_to_add_monoid_hom],
     rw add_monoid_hom.map_mul_iff,
@@ -1257,14 +1257,14 @@ the `add_monoid_algebra Rᵒᵖ I` over the opposite ring, taking elements to th
     dsimp,
     simp only [map_range_single, single_mul_single, ←op_mul, add_comm]
   end,
-  ..opposite.op_add_equiv.symm.trans
-    (finsupp.map_range.add_equiv (opposite.op_add_equiv : k ≃+ kᵒᵖ))}
+  ..mul_opposite.op_add_equiv.symm.trans
+    (finsupp.map_range.add_equiv (mul_opposite.op_add_equiv : k ≃+ kᵐᵒᵖ))}
 
 @[simp] lemma op_ring_equiv_single [add_comm_monoid G] (r : k) (x : G) :
   add_monoid_algebra.op_ring_equiv (op (single x r)) = single x (op r) :=
 by simp
 
-@[simp] lemma op_ring_equiv_symm_single [add_comm_monoid G] (r : kᵒᵖ) (x : Gᵒᵖ) :
+@[simp] lemma op_ring_equiv_symm_single [add_comm_monoid G] (r : kᵐᵒᵖ) (x : Gᵐᵒᵖ) :
   add_monoid_algebra.op_ring_equiv.symm (single x r) = op (single x r.unop) :=
 by simp
 

--- a/src/algebra/opposites.lean
+++ b/src/algebra/opposites.lean
@@ -3,285 +3,332 @@ Copyright (c) 2018 Kenny Lau. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Kenny Lau
 -/
-import data.opposite
 import algebra.field
 import algebra.group.commute
 import group_theory.group_action.defs
 import data.equiv.mul_add
 
 /-!
-# Algebraic operations on `αᵒᵖ`
+# Multiplicative opposite and algebraic operations on it
 
-This file records several basic facts about the opposite of an algebraic structure, e.g. the
-opposite of a ring is a ring (with multiplication `x * y = yx`). Use is made of the identity
-functions `op : α → αᵒᵖ` and `unop : αᵒᵖ → α`.
+In this file we define `mul_oppposite α = αᵐᵒᵖ` to be the multiplicative opposite of `α`. It
+inherits all additive algebraic structures on `α`, and reverses the order of multipliers in
+multiplicative structures, i.e., `op (x * y) = op x * op y`, where `mul_opposite.op` is the
+canonical map from `α` to `αᵐᵒᵖ`.
+
+## Notation
+
+`αᵐᵒᵖ = mul_opposite α`
 -/
 
-namespace opposite
-universes u
+universes u v
+open function
 
-variables (α : Type u)
+/-- Multiplicative opposite of a type. This type inherits all additive structures on `α` and
+reverses left and right in multiplication.-/
+def mul_opposite (α : Type u) : Type u := α
 
-instance [has_zero α] : has_zero (opposite α) :=
-{ zero := op 0 }
+postfix `ᵐᵒᵖ`:std.prec.max_plus := mul_opposite
 
-instance [has_one α] : has_one (opposite α) :=
-{ one := op 1 }
+namespace mul_opposite
 
-instance [has_add α] : has_add (opposite α) :=
+variables {α : Type u}
+
+/-- The element of `mul_opposite α` that represents `x : α`. -/
+@[pp_nodot]
+def op : α → αᵐᵒᵖ := id
+
+/-- The element of `α` represented by `x : αᵐᵒᵖ`. -/
+@[pp_nodot]
+def unop : αᵐᵒᵖ → α := id
+
+@[simp] lemma unop_op (x : α) : unop (op x) = x := rfl
+@[simp] lemma op_unop (x : αᵐᵒᵖ) : op (unop x) = x := rfl
+@[simp] lemma op_comp_unop : (op : α → αᵐᵒᵖ) ∘ unop = id := rfl
+@[simp] lemma unop_comp_op : (unop : αᵐᵒᵖ → α) ∘ op = id := rfl
+
+attribute [irreducible] mul_opposite
+
+/-- A recursor for `opposite`. Use as `induction x using mul_opposite.rec`. -/
+@[simp]
+protected def rec {F : Π (X : αᵐᵒᵖ), Sort v} (h : Π X, F (op X)) : Π X, F X :=
+λ X, h (unop X)
+
+/-- The canonical bijection between `αᵐᵒᵖ` and `α`. -/
+@[simps apply symm_apply { fully_applied := ff }]
+def op_equiv : α ≃ αᵐᵒᵖ := ⟨op, unop, unop_op, op_unop⟩
+
+lemma op_bijective : bijective (op : α → αᵐᵒᵖ) := op_equiv.bijective
+lemma unop_bijective : bijective (unop : αᵐᵒᵖ → α) := op_equiv.symm.bijective
+lemma op_injective : injective (op : α → αᵐᵒᵖ) := op_bijective.injective
+lemma op_surjective : surjective (op : α → αᵐᵒᵖ) := op_bijective.surjective
+lemma unop_injective : injective (unop : αᵐᵒᵖ → α) := unop_bijective.injective
+lemma unop_surjective : surjective (unop : αᵐᵒᵖ → α) := unop_bijective.surjective
+
+@[simp] lemma op_inj {x y : α} : op x = op y ↔ x = y := op_injective.eq_iff
+@[simp] lemma unop_inj {x y : αᵐᵒᵖ} : unop x = unop y ↔ x = y := unop_injective.eq_iff
+
+variable (α)
+
+instance [nontrivial α] : nontrivial αᵐᵒᵖ := op_injective.nontrivial
+instance [inhabited α] : inhabited αᵐᵒᵖ := ⟨op (default α)⟩
+instance [subsingleton α] : subsingleton αᵐᵒᵖ := unop_injective.subsingleton
+instance [unique α] : unique αᵐᵒᵖ := unique.mk' _
+instance [is_empty α] : is_empty αᵐᵒᵖ := function.is_empty unop
+
+instance [has_zero α] : has_zero αᵐᵒᵖ := { zero := op 0 }
+
+instance [has_one α] : has_one αᵐᵒᵖ := { one := op 1 }
+
+instance [has_add α] : has_add αᵐᵒᵖ :=
 { add := λ x y, op (unop x + unop y) }
 
-instance [has_sub α] : has_sub (opposite α) :=
+instance [has_sub α] : has_sub αᵐᵒᵖ :=
 { sub := λ x y, op (unop x - unop y) }
 
-instance [has_neg α] : has_neg (opposite α) :=
+instance [has_neg α] : has_neg αᵐᵒᵖ :=
 { neg := λ x, op $ -(unop x) }
 
-instance [has_mul α] : has_mul (opposite α) :=
+instance [has_mul α] : has_mul αᵐᵒᵖ :=
 { mul := λ x y, op (unop y * unop x) }
 
-instance [has_inv α] : has_inv (opposite α) :=
+instance [has_inv α] : has_inv αᵐᵒᵖ :=
 { inv := λ x, op $ (unop x)⁻¹ }
 
-instance (R : Type*) [has_scalar R α] : has_scalar R (opposite α) :=
+instance (R : Type*) [has_scalar R α] : has_scalar R αᵐᵒᵖ :=
 { smul := λ c x, op (c • unop x) }
 
 section
 variables (α)
 
 @[simp] lemma op_zero [has_zero α] : op (0 : α) = 0 := rfl
-@[simp] lemma unop_zero [has_zero α] : unop (0 : αᵒᵖ) = 0 := rfl
+@[simp] lemma unop_zero [has_zero α] : unop (0 : αᵐᵒᵖ) = 0 := rfl
 
 @[simp] lemma op_one [has_one α] : op (1 : α) = 1 := rfl
-@[simp] lemma unop_one [has_one α] : unop (1 : αᵒᵖ) = 1 := rfl
+@[simp] lemma unop_one [has_one α] : unop (1 : αᵐᵒᵖ) = 1 := rfl
 
 variable {α}
 
 @[simp] lemma op_add [has_add α] (x y : α) : op (x + y) = op x + op y := rfl
-@[simp] lemma unop_add [has_add α] (x y : αᵒᵖ) : unop (x + y) = unop x + unop y := rfl
+@[simp] lemma unop_add [has_add α] (x y : αᵐᵒᵖ) : unop (x + y) = unop x + unop y := rfl
 
 @[simp] lemma op_neg [has_neg α] (x : α) : op (-x) = -op x := rfl
-@[simp] lemma unop_neg [has_neg α] (x : αᵒᵖ) : unop (-x) = -unop x := rfl
+@[simp] lemma unop_neg [has_neg α] (x : αᵐᵒᵖ) : unop (-x) = -unop x := rfl
 
 @[simp] lemma op_mul [has_mul α] (x y : α) : op (x * y) = op y * op x := rfl
-@[simp] lemma unop_mul [has_mul α] (x y : αᵒᵖ) : unop (x * y) = unop y * unop x := rfl
+@[simp] lemma unop_mul [has_mul α] (x y : αᵐᵒᵖ) : unop (x * y) = unop y * unop x := rfl
 
 @[simp] lemma op_inv [has_inv α] (x : α) : op (x⁻¹) = (op x)⁻¹ := rfl
-@[simp] lemma unop_inv [has_inv α] (x : αᵒᵖ) : unop (x⁻¹) = (unop x)⁻¹ := rfl
+@[simp] lemma unop_inv [has_inv α] (x : αᵐᵒᵖ) : unop (x⁻¹) = (unop x)⁻¹ := rfl
 
 @[simp] lemma op_sub [has_sub α] (x y : α) : op (x - y) = op x - op y := rfl
-@[simp] lemma unop_sub [has_sub α] (x y : αᵒᵖ) : unop (x - y) = unop x - unop y := rfl
+@[simp] lemma unop_sub [has_sub α] (x y : αᵐᵒᵖ) : unop (x - y) = unop x - unop y := rfl
 
 @[simp] lemma op_smul {R : Type*} [has_scalar R α] (c : R) (a : α) : op (c • a) = c • op a := rfl
-@[simp] lemma unop_smul {R : Type*} [has_scalar R α] (c : R) (a : αᵒᵖ) :
+@[simp] lemma unop_smul {R : Type*} [has_scalar R α] (c : R) (a : αᵐᵒᵖ) :
   unop (c • a) = c • unop a := rfl
 
 end
 
-instance [add_semigroup α] : add_semigroup (αᵒᵖ) :=
+instance [add_semigroup α] : add_semigroup (αᵐᵒᵖ) :=
 unop_injective.add_semigroup _ (λ x y, rfl)
 
-instance [add_left_cancel_semigroup α] : add_left_cancel_semigroup (opposite α) :=
+instance [add_left_cancel_semigroup α] : add_left_cancel_semigroup αᵐᵒᵖ :=
 unop_injective.add_left_cancel_semigroup _ (λ x y, rfl)
 
-instance [add_right_cancel_semigroup α] : add_right_cancel_semigroup (opposite α) :=
+instance [add_right_cancel_semigroup α] : add_right_cancel_semigroup αᵐᵒᵖ :=
 unop_injective.add_right_cancel_semigroup _ (λ x y, rfl)
 
-instance [add_comm_semigroup α] : add_comm_semigroup (opposite α) :=
+instance [add_comm_semigroup α] : add_comm_semigroup αᵐᵒᵖ :=
 { add_comm := λ x y, unop_injective $ add_comm (unop x) (unop y),
-  .. opposite.add_semigroup α }
+  .. mul_opposite.add_semigroup α }
 
-instance [nontrivial α] : nontrivial (opposite α) :=
-op_injective.nontrivial
-
-@[simp] lemma unop_eq_zero_iff {α} [has_zero α] (a : αᵒᵖ) : a.unop = (0 : α) ↔ a = (0 : αᵒᵖ) :=
+@[simp] lemma unop_eq_zero_iff {α} [has_zero α] (a : αᵐᵒᵖ) : a.unop = (0 : α) ↔ a = (0 : αᵐᵒᵖ) :=
 unop_injective.eq_iff' rfl
 
-@[simp] lemma op_eq_zero_iff {α} [has_zero α] (a : α) : op a = (0 : αᵒᵖ) ↔ a = (0 : α) :=
+@[simp] lemma op_eq_zero_iff {α} [has_zero α] (a : α) : op a = (0 : αᵐᵒᵖ) ↔ a = (0 : α) :=
 op_injective.eq_iff' rfl
 
-lemma unop_ne_zero_iff {α} [has_zero α] (a : αᵒᵖ) : a.unop ≠ (0 : α) ↔ a ≠ (0 : αᵒᵖ) :=
+lemma unop_ne_zero_iff {α} [has_zero α] (a : αᵐᵒᵖ) : a.unop ≠ (0 : α) ↔ a ≠ (0 : αᵐᵒᵖ) :=
 not_congr $ unop_eq_zero_iff a
 
-lemma op_ne_zero_iff {α} [has_zero α] (a : α) : op a ≠ (0 : αᵒᵖ) ↔ a ≠ (0 : α) :=
+lemma op_ne_zero_iff {α} [has_zero α] (a : α) : op a ≠ (0 : αᵐᵒᵖ) ↔ a ≠ (0 : α) :=
 not_congr $ op_eq_zero_iff a
 
-instance [add_zero_class α] : add_zero_class (opposite α) :=
+instance [add_zero_class α] : add_zero_class αᵐᵒᵖ :=
 unop_injective.add_zero_class _ rfl (λ x y, rfl)
 
-instance [add_monoid α] : add_monoid (opposite α) :=
+instance [add_monoid α] : add_monoid αᵐᵒᵖ :=
 unop_injective.add_monoid_smul _ rfl (λ _ _, rfl) (λ _ _, rfl)
 
-instance [add_comm_monoid α] : add_comm_monoid (opposite α) :=
-{ .. opposite.add_monoid α, .. opposite.add_comm_semigroup α }
+instance [add_comm_monoid α] : add_comm_monoid αᵐᵒᵖ :=
+{ .. mul_opposite.add_monoid α, .. mul_opposite.add_comm_semigroup α }
 
-instance [sub_neg_monoid α] : sub_neg_monoid (opposite α) :=
+instance [sub_neg_monoid α] : sub_neg_monoid αᵐᵒᵖ :=
 unop_injective.sub_neg_monoid_smul _ rfl (λ _ _, rfl) (λ _, rfl)
   (λ _ _, rfl) (λ _ _, rfl) (λ _ _, rfl)
 
-instance [add_group α] : add_group (opposite α) :=
+instance [add_group α] : add_group αᵐᵒᵖ :=
 unop_injective.add_group_smul _ rfl (λ _ _, rfl) (λ _, rfl)
   (λ _ _, rfl) (λ _ _, rfl) (λ _ _, rfl)
 
-instance [add_comm_group α] : add_comm_group (opposite α) :=
-{ .. opposite.add_group α, .. opposite.add_comm_monoid α }
+instance [add_comm_group α] : add_comm_group αᵐᵒᵖ :=
+{ .. mul_opposite.add_group α, .. mul_opposite.add_comm_monoid α }
 
-instance [semigroup α] : semigroup (opposite α) :=
+instance [semigroup α] : semigroup αᵐᵒᵖ :=
 { mul_assoc := λ x y z, unop_injective $ eq.symm $ mul_assoc (unop z) (unop y) (unop x),
-  .. opposite.has_mul α }
+  .. mul_opposite.has_mul α }
 
-instance [right_cancel_semigroup α] : left_cancel_semigroup (opposite α) :=
+instance [right_cancel_semigroup α] : left_cancel_semigroup αᵐᵒᵖ :=
 { mul_left_cancel := λ x y z H, unop_injective $ mul_right_cancel $ op_injective H,
-  .. opposite.semigroup α }
+  .. mul_opposite.semigroup α }
 
-instance [left_cancel_semigroup α] : right_cancel_semigroup (opposite α) :=
+instance [left_cancel_semigroup α] : right_cancel_semigroup αᵐᵒᵖ :=
 { mul_right_cancel := λ x y z H, unop_injective $ mul_left_cancel $ op_injective H,
-  .. opposite.semigroup α }
+  .. mul_opposite.semigroup α }
 
-instance [comm_semigroup α] : comm_semigroup (opposite α) :=
+instance [comm_semigroup α] : comm_semigroup αᵐᵒᵖ :=
 { mul_comm := λ x y, unop_injective $ mul_comm (unop y) (unop x),
-  .. opposite.semigroup α }
+  .. mul_opposite.semigroup α }
 
-section
-local attribute [semireducible] opposite
-@[simp] lemma unop_eq_one_iff {α} [has_one α] (a : αᵒᵖ) : a.unop = 1 ↔ a = 1 :=
-iff.refl _
+@[simp] lemma unop_eq_one_iff {α} [has_one α] (a : αᵐᵒᵖ) : a.unop = 1 ↔ a = 1 :=
+unop_injective.eq_iff' rfl
 
 @[simp] lemma op_eq_one_iff {α} [has_one α] (a : α) : op a = 1 ↔ a = 1 :=
-iff.refl _
-end
+op_injective.eq_iff' rfl
 
-instance [mul_one_class α] : mul_one_class (opposite α) :=
+instance [mul_one_class α] : mul_one_class αᵐᵒᵖ :=
 { one_mul := λ x, unop_injective $ mul_one $ unop x,
   mul_one := λ x, unop_injective $ one_mul $ unop x,
-  .. opposite.has_mul α, .. opposite.has_one α }
+  .. mul_opposite.has_mul α, .. mul_opposite.has_one α }
 
-instance [monoid α] : monoid (opposite α) :=
+instance [monoid α] : monoid αᵐᵒᵖ :=
 { npow := λ n x, op $ x.unop ^ n,
   npow_zero' := λ x, unop_injective $ monoid.npow_zero' x.unop,
   npow_succ' := λ n x, unop_injective $ pow_succ' x.unop n,
-  .. opposite.semigroup α, .. opposite.mul_one_class α }
+  .. mul_opposite.semigroup α, .. mul_opposite.mul_one_class α }
 
-instance [right_cancel_monoid α] : left_cancel_monoid (opposite α) :=
-{ .. opposite.left_cancel_semigroup α, ..opposite.monoid α }
+instance [right_cancel_monoid α] : left_cancel_monoid αᵐᵒᵖ :=
+{ .. mul_opposite.left_cancel_semigroup α, .. mul_opposite.monoid α }
 
-instance [left_cancel_monoid α] : right_cancel_monoid (opposite α) :=
-{ .. opposite.right_cancel_semigroup α, ..opposite.monoid α }
+instance [left_cancel_monoid α] : right_cancel_monoid αᵐᵒᵖ :=
+{ .. mul_opposite.right_cancel_semigroup α, .. mul_opposite.monoid α }
 
-instance [cancel_monoid α] : cancel_monoid (opposite α) :=
-{ .. opposite.right_cancel_monoid α, ..opposite.left_cancel_monoid α }
+instance [cancel_monoid α] : cancel_monoid αᵐᵒᵖ :=
+{ .. mul_opposite.right_cancel_monoid α, .. mul_opposite.left_cancel_monoid α }
 
-instance [comm_monoid α] : comm_monoid (opposite α) :=
-{ .. opposite.monoid α, .. opposite.comm_semigroup α }
+instance [comm_monoid α] : comm_monoid αᵐᵒᵖ :=
+{ .. mul_opposite.monoid α, .. mul_opposite.comm_semigroup α }
 
-instance [cancel_comm_monoid α] : cancel_comm_monoid (opposite α) :=
-{ .. opposite.cancel_monoid α, ..opposite.comm_monoid α }
+instance [cancel_comm_monoid α] : cancel_comm_monoid αᵐᵒᵖ :=
+{ .. mul_opposite.cancel_monoid α, .. mul_opposite.comm_monoid α }
 
-instance [div_inv_monoid α] : div_inv_monoid (opposite α) :=
+instance [div_inv_monoid α] : div_inv_monoid αᵐᵒᵖ :=
 { zpow := λ n x, op $ x.unop ^ n,
   zpow_zero' := λ x, unop_injective $ div_inv_monoid.zpow_zero' x.unop,
   zpow_succ' := λ n x, unop_injective $
     by rw [unop_op, zpow_of_nat, zpow_of_nat, pow_succ', unop_mul, unop_op],
   zpow_neg' := λ z x, unop_injective $ div_inv_monoid.zpow_neg' z x.unop,
-  .. opposite.monoid α, .. opposite.has_inv α }
+  .. mul_opposite.monoid α, .. mul_opposite.has_inv α }
 
-instance [group α] : group (opposite α) :=
+instance [group α] : group αᵐᵒᵖ :=
 { mul_left_inv := λ x, unop_injective $ mul_inv_self $ unop x,
-  .. opposite.div_inv_monoid α, }
+  .. mul_opposite.div_inv_monoid α, }
 
-instance [comm_group α] : comm_group (opposite α) :=
-{ .. opposite.group α, .. opposite.comm_monoid α }
+instance [comm_group α] : comm_group αᵐᵒᵖ :=
+{ .. mul_opposite.group α, .. mul_opposite.comm_monoid α }
 
-instance [distrib α] : distrib (opposite α) :=
+instance [distrib α] : distrib αᵐᵒᵖ :=
 { left_distrib := λ x y z, unop_injective $ add_mul (unop y) (unop z) (unop x),
   right_distrib := λ x y z, unop_injective $ mul_add (unop z) (unop x) (unop y),
-  .. opposite.has_add α, .. opposite.has_mul α }
+  .. mul_opposite.has_add α, .. mul_opposite.has_mul α }
 
-instance [mul_zero_class α] : mul_zero_class (opposite α) :=
+instance [mul_zero_class α] : mul_zero_class αᵐᵒᵖ :=
 { zero := 0,
   mul := (*),
   zero_mul := λ x, unop_injective $ mul_zero $ unop x,
   mul_zero := λ x, unop_injective $ zero_mul $ unop x }
 
-instance [mul_zero_one_class α] : mul_zero_one_class (opposite α) :=
-{ .. opposite.mul_zero_class α, .. opposite.mul_one_class α }
+instance [mul_zero_one_class α] : mul_zero_one_class αᵐᵒᵖ :=
+{ .. mul_opposite.mul_zero_class α, .. mul_opposite.mul_one_class α }
 
-instance [semigroup_with_zero α] : semigroup_with_zero (opposite α) :=
-{ .. opposite.semigroup α, .. opposite.mul_zero_class α }
+instance [semigroup_with_zero α] : semigroup_with_zero αᵐᵒᵖ :=
+{ .. mul_opposite.semigroup α, .. mul_opposite.mul_zero_class α }
 
-instance [monoid_with_zero α] : monoid_with_zero (opposite α) :=
-{ .. opposite.monoid α, .. opposite.mul_zero_one_class α }
+instance [monoid_with_zero α] : monoid_with_zero αᵐᵒᵖ :=
+{ .. mul_opposite.monoid α, .. mul_opposite.mul_zero_one_class α }
 
-instance [non_unital_non_assoc_semiring α] : non_unital_non_assoc_semiring (opposite α) :=
-{ .. opposite.add_comm_monoid α, .. opposite.mul_zero_class α, .. opposite.distrib α }
+instance [non_unital_non_assoc_semiring α] : non_unital_non_assoc_semiring αᵐᵒᵖ :=
+{ .. mul_opposite.add_comm_monoid α, .. mul_opposite.mul_zero_class α, .. mul_opposite.distrib α }
 
-instance [non_unital_semiring α] : non_unital_semiring (opposite α) :=
-{ .. opposite.semigroup_with_zero α, .. opposite.non_unital_non_assoc_semiring α }
+instance [non_unital_semiring α] : non_unital_semiring αᵐᵒᵖ :=
+{ .. mul_opposite.semigroup_with_zero α, .. mul_opposite.non_unital_non_assoc_semiring α }
 
-instance [non_assoc_semiring α] : non_assoc_semiring (opposite α) :=
-{ .. opposite.mul_zero_one_class α, .. opposite.non_unital_non_assoc_semiring α }
+instance [non_assoc_semiring α] : non_assoc_semiring αᵐᵒᵖ :=
+{ .. mul_opposite.mul_zero_one_class α, .. mul_opposite.non_unital_non_assoc_semiring α }
 
-instance [semiring α] : semiring (opposite α) :=
-{ .. opposite.non_unital_semiring α, .. opposite.non_assoc_semiring α,
-  .. opposite.monoid_with_zero α }
+instance [semiring α] : semiring αᵐᵒᵖ :=
+{ .. mul_opposite.non_unital_semiring α, .. mul_opposite.non_assoc_semiring α,
+  .. mul_opposite.monoid_with_zero α }
 
-instance [comm_semiring α] : comm_semiring (opposite α) :=
-{ .. opposite.semiring α, .. opposite.comm_semigroup α }
+instance [comm_semiring α] : comm_semiring αᵐᵒᵖ :=
+{ .. mul_opposite.semiring α, .. mul_opposite.comm_semigroup α }
 
-instance [ring α] : ring (opposite α) :=
-{ .. opposite.add_comm_group α, .. opposite.monoid α, .. opposite.semiring α }
+instance [ring α] : ring αᵐᵒᵖ :=
+{ .. mul_opposite.add_comm_group α, .. mul_opposite.monoid α, .. mul_opposite.semiring α }
 
-instance [comm_ring α] : comm_ring (opposite α) :=
-{ .. opposite.ring α, .. opposite.comm_semiring α }
+instance [comm_ring α] : comm_ring αᵐᵒᵖ :=
+{ .. mul_opposite.ring α, .. mul_opposite.comm_semiring α }
 
-instance [has_zero α] [has_mul α] [no_zero_divisors α] : no_zero_divisors (opposite α) :=
+instance [has_zero α] [has_mul α] [no_zero_divisors α] : no_zero_divisors αᵐᵒᵖ :=
 { eq_zero_or_eq_zero_of_mul_eq_zero := λ x y (H : op (_ * _) = op (0:α)),
     or.cases_on (eq_zero_or_eq_zero_of_mul_eq_zero $ op_injective H)
       (λ hy, or.inr $ unop_injective $ hy) (λ hx, or.inl $ unop_injective $ hx), }
 
-instance [ring α] [is_domain α] : is_domain (opposite α) :=
-{ .. opposite.no_zero_divisors α, .. opposite.ring α, .. opposite.nontrivial α }
+instance [ring α] [is_domain α] : is_domain αᵐᵒᵖ :=
+{ .. mul_opposite.no_zero_divisors α, .. mul_opposite.ring α, .. mul_opposite.nontrivial α }
 
-instance [group_with_zero α] : group_with_zero (opposite α) :=
+instance [group_with_zero α] : group_with_zero αᵐᵒᵖ :=
 { mul_inv_cancel := λ x hx, unop_injective $ inv_mul_cancel $ unop_injective.ne hx,
   inv_zero := unop_injective inv_zero,
-  .. opposite.monoid_with_zero α, .. opposite.div_inv_monoid α, .. opposite.nontrivial α }
+  .. mul_opposite.monoid_with_zero α, .. mul_opposite.div_inv_monoid α,
+  .. mul_opposite.nontrivial α }
 
-instance [division_ring α] : division_ring (opposite α) :=
-{ .. opposite.group_with_zero α, .. opposite.ring α }
+instance [division_ring α] : division_ring αᵐᵒᵖ :=
+{ .. mul_opposite.group_with_zero α, .. mul_opposite.ring α }
 
-instance [field α] : field (opposite α) :=
-{ .. opposite.division_ring α, .. opposite.comm_ring α }
+instance [field α] : field αᵐᵒᵖ :=
+{ .. mul_opposite.division_ring α, .. mul_opposite.comm_ring α }
 
-instance (R : Type*) [monoid R] [mul_action R α] : mul_action R (opposite α) :=
+instance (R : Type*) [monoid R] [mul_action R α] : mul_action R αᵐᵒᵖ :=
 { one_smul := λ x, unop_injective $ one_smul R (unop x),
   mul_smul := λ r₁ r₂ x, unop_injective $ mul_smul r₁ r₂ (unop x),
-  ..opposite.has_scalar α R }
+  .. mul_opposite.has_scalar α R }
 
 instance (R : Type*) [monoid R] [add_monoid α] [distrib_mul_action R α] :
-  distrib_mul_action R (opposite α) :=
+  distrib_mul_action R αᵐᵒᵖ :=
 { smul_add := λ r x₁ x₂, unop_injective $ smul_add r (unop x₁) (unop x₂),
   smul_zero := λ r, unop_injective $ smul_zero r,
-  ..opposite.mul_action α R }
+  .. mul_opposite.mul_action α R }
 
 instance (R : Type*) [monoid R] [monoid α] [mul_distrib_mul_action R α] :
-  mul_distrib_mul_action R (opposite α) :=
+  mul_distrib_mul_action R αᵐᵒᵖ :=
 { smul_mul := λ r x₁ x₂, unop_injective $ smul_mul' r (unop x₂) (unop x₁),
   smul_one := λ r, unop_injective $ smul_one r,
-  ..opposite.mul_action α R }
+  .. mul_opposite.mul_action α R }
 
 instance {M N} [has_scalar M N] [has_scalar M α] [has_scalar N α] [is_scalar_tower M N α] :
-  is_scalar_tower M N αᵒᵖ :=
+  is_scalar_tower M N αᵐᵒᵖ :=
 ⟨λ x y z, unop_injective $ smul_assoc _ _ _⟩
 
 instance {M N} [has_scalar M α] [has_scalar N α] [smul_comm_class M N α] :
-  smul_comm_class M N αᵒᵖ :=
+  smul_comm_class M N αᵐᵒᵖ :=
 ⟨λ x y z, unop_injective $ smul_comm _ _ _⟩
 
 /-- Like `has_mul.to_has_scalar`, but multiplies on the right.
 
 See also `monoid.to_opposite_mul_action` and `monoid_with_zero.to_opposite_mul_action`. -/
-instance _root_.has_mul.to_has_opposite_scalar [has_mul α] : has_scalar (opposite α) α :=
+instance _root_.has_mul.to_has_opposite_scalar [has_mul α] : has_scalar αᵐᵒᵖ α :=
 { smul := λ c x, x * c.unop }
 
 @[simp] lemma op_smul_eq_mul [has_mul α] {a a' : α} : op a • a' = a' * a := rfl
@@ -289,45 +336,45 @@ instance _root_.has_mul.to_has_opposite_scalar [has_mul α] : has_scalar (opposi
 -- TODO: add an additive version once we have additive opposites
 /-- The right regular action of a group on itself is transitive. -/
 instance _root_.mul_action.opposite_regular.is_pretransitive {G : Type*} [group G] :
-  mul_action.is_pretransitive Gᵒᵖ G :=
+  mul_action.is_pretransitive Gᵐᵒᵖ G :=
 ⟨λ x y, ⟨op (x⁻¹ * y), mul_inv_cancel_left _ _⟩⟩
 
 instance _root_.semigroup.opposite_smul_comm_class [semigroup α] :
-  smul_comm_class (opposite α) α α :=
+  smul_comm_class αᵐᵒᵖ α α :=
 { smul_comm := λ x y z, (mul_assoc _ _ _) }
 
 instance _root_.semigroup.opposite_smul_comm_class' [semigroup α] :
-  smul_comm_class α (opposite α) α :=
+  smul_comm_class α αᵐᵒᵖ α :=
 { smul_comm := λ x y z, (mul_assoc _ _ _).symm }
 
 /-- Like `monoid.to_mul_action`, but multiplies on the right. -/
-instance _root_.monoid.to_opposite_mul_action [monoid α] : mul_action (opposite α) α :=
+instance _root_.monoid.to_opposite_mul_action [monoid α] : mul_action αᵐᵒᵖ α :=
 { smul := (•),
   one_smul := mul_one,
   mul_smul := λ x y r, (mul_assoc _ _ _).symm }
 
 instance _root_.is_scalar_tower.opposite_mid {M N} [monoid N] [has_scalar M N]
   [smul_comm_class M N N] :
-  is_scalar_tower M Nᵒᵖ N :=
+  is_scalar_tower M Nᵐᵒᵖ N :=
 ⟨λ x y z, mul_smul_comm _ _ _⟩
 
 instance _root_.smul_comm_class.opposite_mid {M N} [monoid N] [has_scalar M N]
   [is_scalar_tower M N N] :
-  smul_comm_class M Nᵒᵖ N :=
-⟨λ x y z, by { induction y using opposite.rec, simp [smul_mul_assoc] }⟩
+  smul_comm_class M Nᵐᵒᵖ N :=
+⟨λ x y z, by { induction y using mul_opposite.rec, simp [smul_mul_assoc] }⟩
 
 -- The above instance does not create an unwanted diamond, the two paths to
--- `mul_action (opposite α) (opposite α)` are defeq.
-example [monoid α] : monoid.to_mul_action (opposite α) = opposite.mul_action α (opposite α) := rfl
+-- `mul_action αᵐᵒᵖ αᵐᵒᵖ` are defeq.
+example [monoid α] : monoid.to_mul_action αᵐᵒᵖ = mul_opposite.mul_action α αᵐᵒᵖ := rfl
 
 /-- `monoid.to_opposite_mul_action` is faithful on cancellative monoids. -/
 instance _root_.left_cancel_monoid.to_has_faithful_opposite_scalar [left_cancel_monoid α] :
-  has_faithful_scalar (opposite α) α :=
+  has_faithful_scalar αᵐᵒᵖ α :=
 ⟨λ x y h, unop_injective $ mul_left_cancel (h 1)⟩
 
 /-- `monoid.to_opposite_mul_action` is faithful on nontrivial cancellative monoids with zero. -/
 instance _root_.cancel_monoid_with_zero.to_has_faithful_opposite_scalar
-  [cancel_monoid_with_zero α] [nontrivial α] : has_faithful_scalar (opposite α) α :=
+  [cancel_monoid_with_zero α] [nontrivial α] : has_faithful_scalar αᵐᵒᵖ α :=
 ⟨λ x y h, unop_injective $ mul_left_cancel₀ one_ne_zero (h 1)⟩
 
 variable {α}
@@ -339,7 +386,7 @@ begin
   rw [← op_mul, ← op_mul, h.eq]
 end
 
-lemma semiconj_by.unop [has_mul α] {a x y : αᵒᵖ} (h : semiconj_by a x y) :
+lemma semiconj_by.unop [has_mul α] {a x y : αᵐᵒᵖ} (h : semiconj_by a x y) :
   semiconj_by (unop a) (unop y) (unop x) :=
 begin
   dunfold semiconj_by,
@@ -357,7 +404,7 @@ begin
     exact semiconj_by.op h }
 end
 
-@[simp] lemma semiconj_by_unop [has_mul α] {a x y : αᵒᵖ} :
+@[simp] lemma semiconj_by_unop [has_mul α] {a x y : αᵐᵒᵖ} :
   semiconj_by (unop a) (unop y) (unop x) ↔ semiconj_by a x y :=
 by conv_rhs { rw [← op_unop a, ← op_unop x, ← op_unop y, semiconj_by_op] }
 
@@ -367,7 +414,7 @@ begin
   exact semiconj_by.op h
 end
 
-lemma commute.unop [has_mul α] {x y : αᵒᵖ} (h : commute x y) : commute (unop x) (unop y) :=
+lemma commute.unop [has_mul α] {x y : αᵐᵒᵖ} (h : commute x y) : commute (unop x) (unop y) :=
 begin
   dunfold commute at h ⊢,
   exact semiconj_by.unop h
@@ -380,97 +427,92 @@ begin
   rw semiconj_by_op
 end
 
-@[simp] lemma commute_unop [has_mul α] {x y : αᵒᵖ} :
+@[simp] lemma commute_unop [has_mul α] {x y : αᵐᵒᵖ} :
   commute (unop x) (unop y) ↔ commute x y :=
 begin
   dunfold commute,
   rw semiconj_by_unop
 end
 
-/-- The function `op` is an additive equivalence. -/
-def op_add_equiv [has_add α] : α ≃+ αᵒᵖ :=
-{ map_add' := λ a b, rfl, .. equiv_to_opposite }
-
-@[simp] lemma coe_op_add_equiv [has_add α] : (op_add_equiv : α → αᵒᵖ) = op := rfl
-@[simp] lemma coe_op_add_equiv_symm [has_add α] :
-  (op_add_equiv.symm : αᵒᵖ → α) = unop := rfl
+/-- The function `unop` is an additive equivalence. -/
+@[simps { fully_applied := ff, simp_rhs := tt }]
+def op_add_equiv [has_add α] : α ≃+ αᵐᵒᵖ :=
+{ map_add' := λ a b, rfl, .. op_equiv }
 
 @[simp] lemma op_add_equiv_to_equiv [has_add α] :
-  (op_add_equiv : α ≃+ αᵒᵖ).to_equiv = equiv_to_opposite :=
+  (op_add_equiv : α ≃+ αᵐᵒᵖ).to_equiv = op_equiv :=
 rfl
 
-end opposite
+end mul_opposite
 
-open opposite
+open mul_opposite
 
 /-- Inversion on a group is a `mul_equiv` to the opposite group. When `G` is commutative, there is
 `mul_equiv.inv`. -/
-@[simps {fully_applied := ff}]
-def mul_equiv.inv' (G : Type*) [group G] : G ≃* Gᵒᵖ :=
-{ to_fun := opposite.op ∘ has_inv.inv,
-  inv_fun := has_inv.inv ∘ opposite.unop,
-  map_mul' := λ x y, unop_injective $ mul_inv_rev x y,
-  ..(equiv.inv G).trans equiv_to_opposite}
+@[simps { fully_applied := ff, simp_rhs := tt }]
+def mul_equiv.inv' (G : Type*) [group G] : G ≃* Gᵐᵒᵖ :=
+{ map_mul' := λ x y, unop_injective $ mul_inv_rev x y,
+  .. (equiv.inv G).trans op_equiv }
 
 /-- A monoid homomorphism `f : R →* S` such that `f x` commutes with `f y` for all `x, y` defines
-a monoid homomorphism to `Sᵒᵖ`. -/
+a monoid homomorphism to `Sᵐᵒᵖ`. -/
 @[simps {fully_applied := ff}]
 def monoid_hom.to_opposite {R S : Type*} [mul_one_class R] [mul_one_class S] (f : R →* S)
-  (hf : ∀ x y, commute (f x) (f y)) : R →* Sᵒᵖ :=
-{ to_fun := opposite.op ∘ f,
+  (hf : ∀ x y, commute (f x) (f y)) : R →* Sᵐᵒᵖ :=
+{ to_fun := mul_opposite.op ∘ f,
   map_one' := congr_arg op f.map_one,
   map_mul' := λ x y, by simp [(hf x y).eq] }
 
 /-- A ring homomorphism `f : R →+* S` such that `f x` commutes with `f y` for all `x, y` defines
-a ring homomorphism to `Sᵒᵖ`. -/
+a ring homomorphism to `Sᵐᵒᵖ`. -/
 @[simps {fully_applied := ff}]
 def ring_hom.to_opposite {R S : Type*} [semiring R] [semiring S] (f : R →+* S)
-  (hf : ∀ x y, commute (f x) (f y)) : R →+* Sᵒᵖ :=
-{ to_fun := opposite.op ∘ f,
-  .. ((opposite.op_add_equiv : S ≃+ Sᵒᵖ).to_add_monoid_hom.comp ↑f : R →+ Sᵒᵖ),
+  (hf : ∀ x y, commute (f x) (f y)) : R →+* Sᵐᵒᵖ :=
+{ to_fun := mul_opposite.op ∘ f,
+  .. ((op_add_equiv : S ≃+ Sᵐᵒᵖ).to_add_monoid_hom.comp ↑f : R →+ Sᵐᵒᵖ),
   .. f.to_monoid_hom.to_opposite hf }
 
 /-- The units of the opposites are equivalent to the opposites of the units. -/
-def units.op_equiv {R} [monoid R] : units Rᵒᵖ ≃* (units R)ᵒᵖ :=
+def units.op_equiv {R} [monoid R] : units Rᵐᵒᵖ ≃* (units R)ᵐᵒᵖ :=
 { to_fun := λ u, op ⟨unop u, unop ↑(u⁻¹), op_injective u.4, op_injective u.3⟩,
-  inv_fun := opposite.rec $ λ u, ⟨op ↑(u), op ↑(u⁻¹), unop_injective $ u.4, unop_injective u.3⟩,
+  inv_fun := mul_opposite.rec $ λ u, ⟨op ↑(u), op ↑(u⁻¹), unop_injective $ u.4, unop_injective u.3⟩,
   map_mul' := λ x y, unop_injective $ units.ext $ rfl,
-  left_inv := λ x, units.ext $ rfl,
+  left_inv := λ x, units.ext $ by simp,
   right_inv := λ x, unop_injective $ units.ext $ rfl }
 
 @[simp]
-lemma units.coe_unop_op_equiv {R} [monoid R] (u : units Rᵒᵖ) :
-  ((units.op_equiv u).unop : R) = unop (u : Rᵒᵖ) :=
+lemma units.coe_unop_op_equiv {R} [monoid R] (u : units Rᵐᵒᵖ) :
+  ((units.op_equiv u).unop : R) = unop (u : Rᵐᵒᵖ) :=
 rfl
 
 @[simp]
-lemma units.coe_op_equiv_symm {R} [monoid R] (u : (units R)ᵒᵖ) :
-  (units.op_equiv.symm u : Rᵒᵖ) = op (u.unop : R) :=
+lemma units.coe_op_equiv_symm {R} [monoid R] (u : (units R)ᵐᵒᵖ) :
+  (units.op_equiv.symm u : Rᵐᵒᵖ) = op (u.unop : R) :=
 rfl
 
-/-- A hom `α →* β` can equivalently be viewed as a hom `αᵒᵖ →* βᵒᵖ`. This is the action of the
-(fully faithful) `ᵒᵖ`-functor on morphisms. -/
+/-- A hom `α →* β` can equivalently be viewed as a hom `αᵐᵒᵖ →* βᵐᵒᵖ`. This is the action of the
+(fully faithful) `ᵐᵒᵖ`-functor on morphisms. -/
 @[simps]
 def monoid_hom.op {α β} [mul_one_class α] [mul_one_class β] :
-  (α →* β) ≃ (αᵒᵖ →* βᵒᵖ) :=
+  (α →* β) ≃ (αᵐᵒᵖ →* βᵐᵒᵖ) :=
 { to_fun    := λ f, { to_fun   := op ∘ f ∘ unop,
-                      map_one' := unop_injective f.map_one,
+                      map_one' := congr_arg op f.map_one,
                       map_mul' := λ x y, unop_injective (f.map_mul y.unop x.unop) },
   inv_fun   := λ f, { to_fun   := unop ∘ f ∘ op,
                       map_one' := congr_arg unop f.map_one,
                       map_mul' := λ x y, congr_arg unop (f.map_mul (op y) (op x)) },
   left_inv  := λ f, by { ext, refl },
-  right_inv := λ f, by { ext, refl } }
+  right_inv := λ f, by { ext x, simp } }
 
-/-- The 'unopposite' of a monoid hom `αᵒᵖ →* βᵒᵖ`. Inverse to `monoid_hom.op`. -/
+/-- The 'unopposite' of a monoid hom `αᵐᵒᵖ →* βᵐᵒᵖ`. Inverse to `monoid_hom.op`. -/
 @[simp] def monoid_hom.unop {α β} [mul_one_class α] [mul_one_class β] :
-  (αᵒᵖ →* βᵒᵖ) ≃ (α →* β) := monoid_hom.op.symm
+  (αᵐᵒᵖ →* βᵐᵒᵖ) ≃ (α →* β) := monoid_hom.op.symm
 
-/-- A hom `α →+ β` can equivalently be viewed as a hom `αᵒᵖ →+ βᵒᵖ`. This is the action of the
-(fully faithful) `ᵒᵖ`-functor on morphisms. -/
+/-- A hom `α →+ β` can equivalently be viewed as a hom `αᵐᵒᵖ →+ βᵐᵒᵖ`. This is the action of the
+(fully faithful) `ᵐᵒᵖ`-functor on morphisms. -/
 @[simps]
 def add_monoid_hom.op {α β} [add_zero_class α] [add_zero_class β] :
-  (α →+ β) ≃ (αᵒᵖ →+ βᵒᵖ) :=
+  (α →+ β) ≃ (αᵐᵒᵖ →+ βᵐᵒᵖ) :=
 { to_fun    := λ f, { to_fun    := op ∘ f ∘ unop,
                       map_zero' := unop_injective f.map_zero,
                       map_add'  := λ x y, unop_injective (f.map_add x.unop y.unop) },
@@ -478,43 +520,43 @@ def add_monoid_hom.op {α β} [add_zero_class α] [add_zero_class β] :
                       map_zero' := congr_arg unop f.map_zero,
                       map_add'  := λ x y, congr_arg unop (f.map_add (op x) (op y)) },
   left_inv  := λ f, by { ext, refl },
-  right_inv := λ f, by { ext, refl } }
+  right_inv := λ f, by { ext, simp } }
 
-/-- The 'unopposite' of an additive monoid hom `αᵒᵖ →+ βᵒᵖ`. Inverse to `add_monoid_hom.op`. -/
+/-- The 'unopposite' of an additive monoid hom `αᵐᵒᵖ →+ βᵐᵒᵖ`. Inverse to `add_monoid_hom.op`. -/
 @[simp] def add_monoid_hom.unop {α β} [add_zero_class α] [add_zero_class β] :
-  (αᵒᵖ →+ βᵒᵖ) ≃ (α →+ β) := add_monoid_hom.op.symm
+  (αᵐᵒᵖ →+ βᵐᵒᵖ) ≃ (α →+ β) := add_monoid_hom.op.symm
 
-/-- A ring hom `α →+* β` can equivalently be viewed as a ring hom `αᵒᵖ →+* βᵒᵖ`. This is the action
-of the (fully faithful) `ᵒᵖ`-functor on morphisms. -/
+/-- A ring hom `α →+* β` can equivalently be viewed as a ring hom `αᵐᵒᵖ →+* βᵐᵒᵖ`. This is the
+action of the (fully faithful) `ᵐᵒᵖ`-functor on morphisms. -/
 @[simps]
 def ring_hom.op {α β} [non_assoc_semiring α] [non_assoc_semiring β] :
-  (α →+* β) ≃ (αᵒᵖ →+* βᵒᵖ) :=
+  (α →+* β) ≃ (αᵐᵒᵖ →+* βᵐᵒᵖ) :=
 { to_fun    := λ f, { ..f.to_add_monoid_hom.op, ..f.to_monoid_hom.op },
   inv_fun   := λ f, { ..f.to_add_monoid_hom.unop, ..f.to_monoid_hom.unop },
   left_inv  := λ f, by { ext, refl },
-  right_inv := λ f, by { ext, refl } }
+  right_inv := λ f, by { ext, simp } }
 
-/-- The 'unopposite' of a ring hom `αᵒᵖ →+* βᵒᵖ`. Inverse to `ring_hom.op`. -/
+/-- The 'unopposite' of a ring hom `αᵐᵒᵖ →+* βᵐᵒᵖ`. Inverse to `ring_hom.op`. -/
 @[simp] def ring_hom.unop {α β} [non_assoc_semiring α] [non_assoc_semiring β] :
-  (αᵒᵖ →+* βᵒᵖ) ≃ (α →+* β) := ring_hom.op.symm
+  (αᵐᵒᵖ →+* βᵐᵒᵖ) ≃ (α →+* β) := ring_hom.op.symm
 
-/-- A iso `α ≃+ β` can equivalently be viewed as an iso `αᵒᵖ ≃+ βᵒᵖ`. -/
+/-- A iso `α ≃+ β` can equivalently be viewed as an iso `αᵐᵒᵖ ≃+ βᵐᵒᵖ`. -/
 @[simps]
 def add_equiv.op {α β} [has_add α] [has_add β] :
-  (α ≃+ β) ≃ (αᵒᵖ ≃+ βᵒᵖ) :=
+  (α ≃+ β) ≃ (αᵐᵒᵖ ≃+ βᵐᵒᵖ) :=
 { to_fun    := λ f, op_add_equiv.symm.trans (f.trans op_add_equiv),
   inv_fun   := λ f, op_add_equiv.trans (f.trans op_add_equiv.symm),
   left_inv  := λ f, by { ext, refl },
-  right_inv := λ f, by { ext, refl } }
+  right_inv := λ f, by { ext, simp } }
 
-/-- The 'unopposite' of an iso `αᵒᵖ ≃+ βᵒᵖ`. Inverse to `add_equiv.op`. -/
+/-- The 'unopposite' of an iso `αᵐᵒᵖ ≃+ βᵐᵒᵖ`. Inverse to `add_equiv.op`. -/
 @[simp] def add_equiv.unop {α β} [has_add α] [has_add β] :
-  (αᵒᵖ ≃+ βᵒᵖ) ≃ (α ≃+ β) := add_equiv.op.symm
+  (αᵐᵒᵖ ≃+ βᵐᵒᵖ) ≃ (α ≃+ β) := add_equiv.op.symm
 
-/-- A iso `α ≃* β` can equivalently be viewed as an iso `αᵒᵖ ≃+ βᵒᵖ`. -/
+/-- A iso `α ≃* β` can equivalently be viewed as an iso `αᵐᵒᵖ ≃+ βᵐᵒᵖ`. -/
 @[simps]
 def mul_equiv.op {α β} [has_mul α] [has_mul β] :
-  (α ≃* β) ≃ (αᵒᵖ ≃* βᵒᵖ) :=
+  (α ≃* β) ≃ (αᵐᵒᵖ ≃* βᵐᵒᵖ) :=
 { to_fun    := λ f, { to_fun   := op ∘ f ∘ unop,
                       inv_fun  := op ∘ f.symm ∘ unop,
                       left_inv := λ x, unop_injective (f.symm_apply_apply x.unop),
@@ -522,26 +564,26 @@ def mul_equiv.op {α β} [has_mul α] [has_mul β] :
                       map_mul' := λ x y, unop_injective (f.map_mul y.unop x.unop) },
   inv_fun   := λ f, { to_fun   := unop ∘ f ∘ op,
                       inv_fun  := unop ∘ f.symm ∘ op,
-                      left_inv := λ x, op_injective (f.symm_apply_apply (op x)),
-                      right_inv := λ x, op_injective (f.apply_symm_apply (op x)),
+                      left_inv := λ x, by simp,
+                      right_inv := λ x, by simp,
                       map_mul' := λ x y, congr_arg unop (f.map_mul (op y) (op x)) },
   left_inv  := λ f, by { ext, refl },
-  right_inv := λ f, by { ext, refl } }
+  right_inv := λ f, by { ext, simp } }
 
-/-- The 'unopposite' of an iso `αᵒᵖ ≃* βᵒᵖ`. Inverse to `mul_equiv.op`. -/
+/-- The 'unopposite' of an iso `αᵐᵒᵖ ≃* βᵐᵒᵖ`. Inverse to `mul_equiv.op`. -/
 @[simp] def mul_equiv.unop {α β} [has_mul α] [has_mul β] :
-  (αᵒᵖ ≃* βᵒᵖ) ≃ (α ≃* β) := mul_equiv.op.symm
+  (αᵐᵒᵖ ≃* βᵐᵒᵖ) ≃ (α ≃* β) := mul_equiv.op.symm
 
 section ext
 
-/-- This ext lemma change equalities on `αᵒᵖ →+ β` to equalities on `α →+ β`.
+/-- This ext lemma change equalities on `αᵐᵒᵖ →+ β` to equalities on `α →+ β`.
 This is useful because there are often ext lemmas for specific `α`s that will apply
 to an equality of `α →+ β` such as `finsupp.add_hom_ext'`. -/
 @[ext]
 lemma add_monoid_hom.op_ext {α β} [add_zero_class α] [add_zero_class β]
-  (f g : αᵒᵖ →+ β)
-  (h : f.comp (op_add_equiv : α ≃+ αᵒᵖ).to_add_monoid_hom =
-       g.comp (op_add_equiv : α ≃+ αᵒᵖ).to_add_monoid_hom) : f = g :=
-add_monoid_hom.ext $ λ x, (add_monoid_hom.congr_fun h : _) x.unop
+  (f g : αᵐᵒᵖ →+ β)
+  (h : f.comp (op_add_equiv : α ≃+ αᵐᵒᵖ).to_add_monoid_hom =
+       g.comp (op_add_equiv : α ≃+ αᵐᵒᵖ).to_add_monoid_hom) : f = g :=
+add_monoid_hom.ext $ mul_opposite.rec $ λ x, (add_monoid_hom.congr_fun h : _) x
 
 end ext

--- a/src/algebra/periodic.lean
+++ b/src/algebra/periodic.lean
@@ -101,7 +101,7 @@ h.const_inv_smul₀ a
 lemma periodic.mul_const [division_ring α]
   (h : periodic f c) (a : α) :
   periodic (λ x, f (x * a)) (c * a⁻¹) :=
-h.const_smul₀ $ opposite.op a
+h.const_smul₀ $ mul_opposite.op a
 
 lemma periodic.mul_const' [division_ring α]
   (h : periodic f c) (a : α) :
@@ -111,7 +111,7 @@ by simpa only [div_eq_mul_inv] using h.mul_const a
 lemma periodic.mul_const_inv [division_ring α]
   (h : periodic f c) (a : α) :
   periodic (λ x, f (x * a⁻¹)) (c * a) :=
-h.const_inv_smul₀ $ opposite.op a
+h.const_inv_smul₀ $ mul_opposite.op a
 
 lemma periodic.div_const [division_ring α]
   (h : periodic f c) (a : α) :
@@ -397,7 +397,7 @@ h.const_inv_smul₀ ha
 lemma antiperiodic.mul_const [division_ring α] [has_neg β]
   (h : antiperiodic f c) {a : α} (ha : a ≠ 0) :
   antiperiodic (λ x, f (x * a)) (c * a⁻¹) :=
-h.const_smul₀ $ (opposite.op_ne_zero_iff a).mpr ha
+h.const_smul₀ $ (mul_opposite.op_ne_zero_iff a).mpr ha
 
 lemma antiperiodic.mul_const' [division_ring α] [has_neg β]
   (h : antiperiodic f c) {a : α} (ha : a ≠ 0) :
@@ -407,7 +407,7 @@ by simpa only [div_eq_mul_inv] using h.mul_const ha
 lemma antiperiodic.mul_const_inv [division_ring α] [has_neg β]
   (h : antiperiodic f c) {a : α} (ha : a ≠ 0) :
   antiperiodic (λ x, f (x * a⁻¹)) (c * a) :=
-h.const_inv_smul₀ $ (opposite.op_ne_zero_iff a).mpr ha
+h.const_inv_smul₀ $ (mul_opposite.op_ne_zero_iff a).mpr ha
 
 lemma antiperiodic.div_inv [division_ring α] [has_neg β]
   (h : antiperiodic f c) {a : α} (ha : a ≠ 0) :

--- a/src/algebra/quandle.lean
+++ b/src/algebra/quandle.lean
@@ -76,7 +76,7 @@ Use `open_locale quandles` to use these.
 
 rack, quandle
 -/
-open opposite
+open mul_opposite
 
 universes u v
 
@@ -169,20 +169,15 @@ end
 /--
 The opposite rack, swapping the roles of `◃` and `◃⁻¹`.
 -/
-instance opposite_rack : rack Rᵒᵖ :=
+instance opposite_rack : rack Rᵐᵒᵖ :=
 { act := λ x y, op (inv_act (unop x) (unop y)),
-  self_distrib := λ (x y z : Rᵒᵖ), begin
-    induction x using opposite.rec, induction y using opposite.rec, induction z using opposite.rec,
-    simp only [unop_op, op_inj_iff],
+  self_distrib := mul_opposite.rec $ λ x, mul_opposite.rec $ λ y, mul_opposite.rec $ λ z, begin
+    simp only [unop_op, op_inj],
     exact self_distrib_inv,
   end,
   inv_act := λ x y, op (shelf.act (unop x) (unop y)),
-  left_inv := λ x y, begin
-    induction x using opposite.rec, induction y using opposite.rec, simp,
-  end,
-  right_inv := λ x y, begin
-    induction x using opposite.rec, induction y using opposite.rec, simp,
-  end }
+  left_inv := mul_opposite.rec $ λ x, mul_opposite.rec $ λ y, by simp,
+  right_inv := mul_opposite.rec $ λ x, mul_opposite.rec $ λ y, by simp }
 
 @[simp] lemma op_act_op_eq {x y : R} : (op x) ◃ (op y) = op (x ◃⁻¹ y) := rfl
 @[simp] lemma op_inv_act_op_eq {x y : R} : (op x) ◃⁻¹ (op y) = op (x ◃ y) := rfl
@@ -296,8 +291,8 @@ attribute [simp] fix
 lemma fix_inv {x : Q} : x ◃⁻¹ x = x :=
 by { rw ←left_cancel x, simp }
 
-instance opposite_quandle : quandle Qᵒᵖ :=
-{ fix := λ x, by { induction x using opposite.rec, simp } }
+instance opposite_quandle : quandle Qᵐᵒᵖ :=
+{ fix := λ x, by { induction x using mul_opposite.rec, simp } }
 
 /--
 The conjugation quandle of a group.  Each element of the group acts by

--- a/src/algebra/quaternion.lean
+++ b/src/algebra/quaternion.lean
@@ -298,10 +298,10 @@ instance : star_ring ℍ[R, c₁, c₂] :=
 
 @[simp] lemma star_def (a : ℍ[R, c₁, c₂]) : star a = conj a := rfl
 
-open opposite
+open mul_opposite
 
 /-- Quaternion conjugate as an `alg_equiv` to the opposite ring. -/
-def conj_ae : ℍ[R, c₁, c₂] ≃ₐ[R] (ℍ[R, c₁, c₂]ᵒᵖ) :=
+def conj_ae : ℍ[R, c₁, c₂] ≃ₐ[R] (ℍ[R, c₁, c₂]ᵐᵒᵖ) :=
 { to_fun := op ∘ conj,
   inv_fun := conj ∘ unop,
   map_mul' := λ x y, by simp,
@@ -478,12 +478,12 @@ lemma mul_conj_eq_coe : a * conj a = (a * conj a).re := a.mul_conj_eq_coe
 
 @[simp] lemma conj_sub : (a - b).conj = a.conj - b.conj := a.conj_sub b
 
-open opposite
+open mul_opposite
 
 /-- Quaternion conjugate as an `alg_equiv` to the opposite ring. -/
-def conj_ae : ℍ[R] ≃ₐ[R] (ℍ[R]ᵒᵖ) := quaternion_algebra.conj_ae
+def conj_ae : ℍ[R] ≃ₐ[R] (ℍ[R]ᵐᵒᵖ) := quaternion_algebra.conj_ae
 
-@[simp] lemma coe_conj_ae : ⇑(conj_ae : ℍ[R] ≃ₐ[R] ℍ[R]ᵒᵖ) = op ∘ conj := rfl
+@[simp] lemma coe_conj_ae : ⇑(conj_ae : ℍ[R] ≃ₐ[R] ℍ[R]ᵐᵒᵖ) = op ∘ conj := rfl
 
 /-- Square of the norm. -/
 def norm_sq : monoid_with_zero_hom ℍ[R] R :=

--- a/src/algebra/regular/smul.lean
+++ b/src/algebra/regular/smul.lean
@@ -38,11 +38,11 @@ lemma is_left_regular_iff [has_mul R] {a : R} :
   is_left_regular a ↔ is_smul_regular R a := iff.rfl
 
 lemma is_right_regular.is_smul_regular [has_mul R] {c : R} (h : is_right_regular c) :
-  is_smul_regular R (opposite.op c) := h
+  is_smul_regular R (mul_opposite.op c) := h
 
-/-- Right-regular multiplication on `R` is equivalent to `Rᵒᵖ`-regularity of `R` itself. -/
+/-- Right-regular multiplication on `R` is equivalent to `Rᵐᵒᵖ`-regularity of `R` itself. -/
 lemma is_right_regular_iff [has_mul R] {a : R} :
-  is_right_regular a ↔ is_smul_regular R (opposite.op a) := iff.rfl
+  is_right_regular a ↔ is_smul_regular R (mul_opposite.op a) := iff.rfl
 
 namespace is_smul_regular
 
@@ -73,7 +73,7 @@ is `M`-regular. -/
 lemma is_left_regular [has_mul R] {a : R} (h : is_smul_regular R a) :
   is_left_regular a := h
 
-lemma is_right_regular [has_mul R] {a : R} (h : is_smul_regular R (opposite.op a)) :
+lemma is_right_regular [has_mul R] {a : R} (h : is_smul_regular R (mul_opposite.op a)) :
   is_right_regular a := h
 
 end has_scalar

--- a/src/algebra/smul_with_zero.lean
+++ b/src/algebra/smul_with_zero.lean
@@ -46,7 +46,7 @@ instance mul_zero_class.to_smul_with_zero [mul_zero_class R] : smul_with_zero R 
   zero_smul := zero_mul }
 
 /-- Like `mul_zero_class.to_smul_with_zero`, but multiplies on the right. -/
-instance mul_zero_class.to_opposite_smul_with_zero [mul_zero_class R] : smul_with_zero Rᵒᵖ R :=
+instance mul_zero_class.to_opposite_smul_with_zero [mul_zero_class R] : smul_with_zero Rᵐᵒᵖ R :=
 { smul := (•),
   smul_zero := λ r, zero_mul _,
   zero_smul := mul_zero }
@@ -120,7 +120,7 @@ instance monoid_with_zero.to_mul_action_with_zero : mul_action_with_zero R R :=
 
 /-- Like `monoid_with_zero.to_mul_action_with_zero`, but multiplies on the right. See also
 `semiring.to_opposite_module` -/
-instance monoid_with_zero.to_opposite_mul_action_with_zero : mul_action_with_zero Rᵒᵖ R :=
+instance monoid_with_zero.to_opposite_mul_action_with_zero : mul_action_with_zero Rᵐᵒᵖ R :=
 { ..mul_zero_class.to_opposite_smul_with_zero R,
   ..monoid.to_opposite_mul_action R }
 

--- a/src/algebra/star/basic.lean
+++ b/src/algebra/star/basic.lean
@@ -30,7 +30,7 @@ Our star rings are actually star semirings, but of course we can prove
 
 universes u v
 
-open opposite
+open mul_opposite
 
 /--
 Notation typeclass (with no default notation!) for an algebraic structure with a star operation.
@@ -77,12 +77,12 @@ attribute [simp] star_mul
   star (x * y) = star x * star y :=
 (star_mul x y).trans (mul_comm _ _)
 
-/-- `star` as an `mul_equiv` from `R` to `Rᵒᵖ` -/
+/-- `star` as an `mul_equiv` from `R` to `Rᵐᵒᵖ` -/
 @[simps apply]
-def star_mul_equiv [monoid R] [star_monoid R] : R ≃* Rᵒᵖ :=
-{ to_fun := λ x, opposite.op (star x),
-  map_mul' := λ x y, (star_mul x y).symm ▸ (opposite.op_mul _ _),
-  ..(has_involutive_star.star_involutive.to_equiv star).trans opposite.equiv_to_opposite}
+def star_mul_equiv [monoid R] [star_monoid R] : R ≃* Rᵐᵒᵖ :=
+{ to_fun := λ x, mul_opposite.op (star x),
+  map_mul' := λ x y, (star_mul x y).symm ▸ (mul_opposite.op_mul _ _),
+  ..(has_involutive_star.star_involutive.to_equiv star).trans op_equiv}
 
 /-- `star` as a `mul_aut` for commutative `R`. -/
 @[simps apply]
@@ -94,21 +94,21 @@ def star_mul_aut [comm_monoid R] [star_monoid R] : mul_aut R :=
 variables (R)
 
 @[simp] lemma star_one [monoid R] [star_monoid R] : star (1 : R) = 1 :=
-op_injective $ (star_mul_equiv : R ≃* Rᵒᵖ).map_one.trans (op_one _).symm
+op_injective $ (star_mul_equiv : R ≃* Rᵐᵒᵖ).map_one.trans (op_one _).symm
 
 variables {R}
 
 @[simp] lemma star_pow [monoid R] [star_monoid R] (x : R) (n : ℕ) : star (x ^ n) = star x ^ n :=
 op_injective $
-  ((star_mul_equiv : R ≃* Rᵒᵖ).to_monoid_hom.map_pow x n).trans (op_pow (star x) n).symm
+  ((star_mul_equiv : R ≃* Rᵐᵒᵖ).to_monoid_hom.map_pow x n).trans (op_pow (star x) n).symm
 
 @[simp] lemma star_inv [group R] [star_monoid R] (x : R) : star (x⁻¹) = (star x)⁻¹ :=
 op_injective $
-  ((star_mul_equiv : R ≃* Rᵒᵖ).to_monoid_hom.map_inv x).trans (op_inv (star x)).symm
+  ((star_mul_equiv : R ≃* Rᵐᵒᵖ).to_monoid_hom.map_inv x).trans (op_inv (star x)).symm
 
 @[simp] lemma star_zpow [group R] [star_monoid R] (x : R) (z : ℤ) : star (x ^ z) = star x ^ z :=
 op_injective $
-  ((star_mul_equiv : R ≃* Rᵒᵖ).to_monoid_hom.map_zpow x z).trans (op_zpow (star x) z).symm
+  ((star_mul_equiv : R ≃* Rᵐᵒᵖ).to_monoid_hom.map_zpow x z).trans (op_zpow (star x) z).symm
 
 /-- When multiplication is commutative, `star` preserves division. -/
 @[simp] lemma star_div [comm_group R] [star_monoid R] (x y : R) : star (x / y) = star x / star y :=
@@ -204,11 +204,11 @@ class star_ring (R : Type u) [semiring R] extends star_monoid R :=
 instance star_ring.to_star_add_monoid [semiring R] [star_ring R] : star_add_monoid R :=
 { star_add := star_ring.star_add }
 
-/-- `star` as an `ring_equiv` from `R` to `Rᵒᵖ` -/
+/-- `star` as an `ring_equiv` from `R` to `Rᵐᵒᵖ` -/
 @[simps apply]
-def star_ring_equiv [semiring R] [star_ring R] : R ≃+* Rᵒᵖ :=
-{ to_fun := λ x, opposite.op (star x),
-  ..star_add_equiv.trans (opposite.op_add_equiv : R ≃+ Rᵒᵖ),
+def star_ring_equiv [semiring R] [star_ring R] : R ≃+* Rᵐᵒᵖ :=
+{ to_fun := λ x, mul_opposite.op (star x),
+  ..star_add_equiv.trans (mul_opposite.op_add_equiv : R ≃+ Rᵐᵒᵖ),
   ..star_mul_equiv}
 
 /-- `star` as a `ring_aut` for commutative `R`. This is used to denote complex
@@ -235,12 +235,12 @@ alias star_ring_aut_self_apply ← is_R_or_C.conj_conj
 
 @[simp] lemma star_inv' [division_ring R] [star_ring R] (x : R) : star (x⁻¹) = (star x)⁻¹ :=
 op_injective $
-  ((star_ring_equiv : R ≃+* Rᵒᵖ).to_ring_hom.map_inv x).trans (op_inv (star x)).symm
+  ((star_ring_equiv : R ≃+* Rᵐᵒᵖ).to_ring_hom.map_inv x).trans (op_inv (star x)).symm
 
 @[simp] lemma star_zpow₀ [division_ring R] [star_ring R] (x : R) (z : ℤ) :
   star (x ^ z) = star x ^ z :=
 op_injective $
-  ((star_ring_equiv : R ≃+* Rᵒᵖ).to_ring_hom.map_zpow x z).trans (op_zpow (star x) z).symm
+  ((star_ring_equiv : R ≃+* Rᵐᵒᵖ).to_ring_hom.map_zpow x z).trans (op_zpow (star x) z).symm
 
 /-- When multiplication is commutative, `star` preserves division. -/
 @[simp] lemma star_div' [field R] [star_ring R] (x y : R) : star (x / y) = star x / star y :=
@@ -348,30 +348,30 @@ begin
   rw [ring.inverse_non_unit _ ha, ring.inverse_non_unit _ (mt is_unit_star.mp ha), star_zero],
 end
 
-namespace opposite
+namespace mul_opposite
 
 /-- The opposite type carries the same star operation. -/
-instance [has_star R] : has_star (Rᵒᵖ) :=
+instance [has_star R] : has_star (Rᵐᵒᵖ) :=
 { star := λ r, op (star (r.unop)) }
 
-@[simp] lemma unop_star [has_star R] (r : Rᵒᵖ) : unop (star r) = star (unop r) := rfl
+@[simp] lemma unop_star [has_star R] (r : Rᵐᵒᵖ) : unop (star r) = star (unop r) := rfl
 @[simp] lemma op_star [has_star R] (r : R) : op (star r) = star (op r) := rfl
 
-instance [has_involutive_star R] : has_involutive_star (Rᵒᵖ) :=
+instance [has_involutive_star R] : has_involutive_star (Rᵐᵒᵖ) :=
 { star_involutive := λ r, unop_injective (star_star r.unop) }
 
-instance [monoid R] [star_monoid R] : star_monoid (Rᵒᵖ) :=
+instance [monoid R] [star_monoid R] : star_monoid (Rᵐᵒᵖ) :=
 { star_mul := λ x y, unop_injective (star_mul y.unop x.unop) }
 
-instance [add_monoid R] [star_add_monoid R] : star_add_monoid (Rᵒᵖ) :=
+instance [add_monoid R] [star_add_monoid R] : star_add_monoid (Rᵐᵒᵖ) :=
 { star_add := λ x y, unop_injective (star_add x.unop y.unop) }
 
-instance [semiring R] [star_ring R] : star_ring (Rᵒᵖ) :=
-{ .. opposite.star_add_monoid }
+instance [semiring R] [star_ring R] : star_ring (Rᵐᵒᵖ) :=
+{ .. mul_opposite.star_add_monoid }
 
-end opposite
+end mul_opposite
 
 /-- A commutative star monoid is a star module over its opposite via
 `monoid.to_opposite_mul_action`. -/
-instance star_monoid.to_opposite_star_module [comm_monoid R] [star_monoid R] : star_module Rᵒᵖ R :=
+instance star_monoid.to_opposite_star_module [comm_monoid R] [star_monoid R] : star_module Rᵐᵒᵖ R :=
 ⟨λ r s, star_mul' s r.unop⟩

--- a/src/algebra/star/module.lean
+++ b/src/algebra/star/module.lean
@@ -16,10 +16,10 @@ It is defined on a star algebra `A` over the base ring `R`.
 
 - Define `star_linear_equiv` for noncommutative `R`. We only the commutative case for now since,
   in the noncommutative case, the ring hom needs to reverse the order of multiplication. This
-  requires a ring hom of type `R →+* Rᵒᵖ`, which is very undesirable in the commutative case.
+  requires a ring hom of type `R →+* Rᵐᵒᵖ`, which is very undesirable in the commutative case.
   One way out would be to define a new typeclass `is_op R S` and have an instance `is_op R R`
   for commutative `R`.
-- Also note that such a definition involving `Rᵒᵖ` or `is_op R S` would require adding
+- Also note that such a definition involving `Rᵐᵒᵖ` or `is_op R S` would require adding
   the appropriate `ring_hom_inv_pair` instances to be able to define the semilinear
   equivalence.
 -/

--- a/src/analysis/normed/group/SemiNormedGroup/completion.lean
+++ b/src/analysis/normed/group/SemiNormedGroup/completion.lean
@@ -34,7 +34,7 @@ noncomputable theory
 
 universe u
 
-open uniform_space opposite category_theory normed_group_hom
+open uniform_space mul_opposite category_theory normed_group_hom
 
 namespace SemiNormedGroup
 

--- a/src/analysis/normed_space/units.lean
+++ b/src/analysis/normed_space/units.lean
@@ -263,7 +263,7 @@ end
 end normed_ring
 
 namespace units
-open opposite filter normed_ring
+open mul_opposite filter normed_ring
 
 /-- In a normed ring, the coercion from `units R` (equipped with the induced topology from the
 embedding in `R × R`) to `R` is an open map. -/
@@ -274,7 +274,7 @@ begin
   rw [mem_map, mem_nhds_induced],
   rintros ⟨t, ht, hts⟩,
   obtain ⟨u, hu, v, hv, huvt⟩ :
-    ∃ (u : set R), u ∈ 𝓝 ↑x ∧ ∃ (v : set Rᵒᵖ), v ∈ 𝓝 (opposite.op ↑x⁻¹) ∧ u.prod v ⊆ t,
+    ∃ (u : set R), u ∈ 𝓝 ↑x ∧ ∃ (v : set Rᵐᵒᵖ), v ∈ 𝓝 (op ↑x⁻¹) ∧ u.prod v ⊆ t,
   { simpa [embed_product, mem_nhds_prod_iff] using ht },
   have : u ∩ (op ∘ ring.inverse) ⁻¹' v ∩ (set.range (coe : units R → R)) ∈ 𝓝 ↑x,
   { refine inter_mem (inter_mem hu _) (units.nhds x),

--- a/src/category_theory/monoidal/opposite.lean
+++ b/src/category_theory/monoidal/opposite.lean
@@ -20,34 +20,34 @@ namespace category_theory
 
 open category_theory.monoidal_category
 
-/-- A type synonym for the monoidal opposite. Use the notation `Cᵐᵒᵖ`. -/
+/-- A type synonym for the monoidal opposite. Use the notation `Cᴹᵒᵖ`. -/
 @[nolint has_inhabited_instance]
 def monoidal_opposite (C : Type u₁) := C
 
 namespace monoidal_opposite
 
-notation C `ᵐᵒᵖ`:std.prec.max_plus := monoidal_opposite C
+notation C `ᴹᵒᵖ`:std.prec.max_plus := monoidal_opposite C
 
-/-- Think of an object of `C` as an object of `Cᵐᵒᵖ`. -/
+/-- Think of an object of `C` as an object of `Cᴹᵒᵖ`. -/
 @[pp_nodot]
-def mop (X : C) : Cᵐᵒᵖ := X
+def mop (X : C) : Cᴹᵒᵖ := X
 
-/-- Think of an object of `Cᵐᵒᵖ` as an object of `C`. -/
+/-- Think of an object of `Cᴹᵒᵖ` as an object of `C`. -/
 @[pp_nodot]
-def unmop (X : Cᵐᵒᵖ) : C := X
+def unmop (X : Cᴹᵒᵖ) : C := X
 
-lemma op_injective : function.injective (mop : C → Cᵐᵒᵖ) := λ _ _, id
-lemma unop_injective : function.injective (unmop : Cᵐᵒᵖ → C) := λ _ _, id
+lemma op_injective : function.injective (mop : C → Cᴹᵒᵖ) := λ _ _, id
+lemma unop_injective : function.injective (unmop : Cᴹᵒᵖ → C) := λ _ _, id
 
 @[simp] lemma op_inj_iff (x y : C) : mop x = mop y ↔ x = y := iff.rfl
-@[simp] lemma unop_inj_iff (x y : Cᵐᵒᵖ) : unmop x = unmop y ↔ x = y := iff.rfl
+@[simp] lemma unop_inj_iff (x y : Cᴹᵒᵖ) : unmop x = unmop y ↔ x = y := iff.rfl
 
 attribute [irreducible] monoidal_opposite
 
-@[simp] lemma mop_unmop (X : Cᵐᵒᵖ) : mop (unmop X) = X := rfl
+@[simp] lemma mop_unmop (X : Cᴹᵒᵖ) : mop (unmop X) = X := rfl
 @[simp] lemma unmop_mop (X : C) : unmop (mop X) = X := rfl
 
-instance monoidal_opposite_category [I : category.{v₁} C] : category Cᵐᵒᵖ :=
+instance monoidal_opposite_category [I : category.{v₁} C] : category Cᴹᵒᵖ :=
 { hom := λ X Y, unmop X ⟶ unmop Y,
   id := λ X, 𝟙 (unmop X),
   comp := λ X Y Z f g, f ≫ g, }
@@ -62,9 +62,9 @@ open category_theory.monoidal_opposite
 variables [category.{v₁} C]
 
 /-- The monoidal opposite of a morphism `f : X ⟶ Y` is just `f`, thought of as `mop X ⟶ mop Y`. -/
-def quiver.hom.mop {X Y : C} (f : X ⟶ Y) : @quiver.hom Cᵐᵒᵖ _ (mop X) (mop Y) := f
+def quiver.hom.mop {X Y : C} (f : X ⟶ Y) : @quiver.hom Cᴹᵒᵖ _ (mop X) (mop Y) := f
 /-- We can think of a morphism `f : mop X ⟶ mop Y` as a morphism `X ⟶ Y`. -/
-def quiver.hom.unmop {X Y : Cᵐᵒᵖ} (f : X ⟶ Y) : unmop X ⟶ unmop Y := f
+def quiver.hom.unmop {X Y : Cᴹᵒᵖ} (f : X ⟶ Y) : unmop X ⟶ unmop Y := f
 
 namespace category_theory
 
@@ -72,29 +72,29 @@ lemma mop_inj {X Y : C} :
   function.injective (quiver.hom.mop : (X ⟶ Y) → (mop X ⟶ mop Y)) :=
 λ _ _ H, congr_arg quiver.hom.unmop H
 
-lemma unmop_inj {X Y : Cᵐᵒᵖ} :
+lemma unmop_inj {X Y : Cᴹᵒᵖ} :
   function.injective (quiver.hom.unmop : (X ⟶ Y) → (unmop X ⟶ unmop Y)) :=
 λ _ _ H, congr_arg quiver.hom.mop H
 
 @[simp] lemma unmop_mop {X Y : C} {f : X ⟶ Y} : f.mop.unmop = f := rfl
-@[simp] lemma mop_unmop {X Y : Cᵐᵒᵖ} {f : X ⟶ Y} : f.unmop.mop = f := rfl
+@[simp] lemma mop_unmop {X Y : Cᴹᵒᵖ} {f : X ⟶ Y} : f.unmop.mop = f := rfl
 
 @[simp] lemma mop_comp {X Y Z : C} {f : X ⟶ Y} {g : Y ⟶ Z} :
   (f ≫ g).mop = f.mop ≫ g.mop := rfl
 @[simp] lemma mop_id {X : C} : (𝟙 X).mop = 𝟙 (mop X) := rfl
 
-@[simp] lemma unmop_comp {X Y Z : Cᵐᵒᵖ} {f : X ⟶ Y} {g : Y ⟶ Z} :
+@[simp] lemma unmop_comp {X Y Z : Cᴹᵒᵖ} {f : X ⟶ Y} {g : Y ⟶ Z} :
   (f ≫ g).unmop = f.unmop ≫ g.unmop := rfl
-@[simp] lemma unmop_id {X : Cᵐᵒᵖ} : (𝟙 X).unmop = 𝟙 (unmop X) := rfl
+@[simp] lemma unmop_id {X : Cᴹᵒᵖ} : (𝟙 X).unmop = 𝟙 (unmop X) := rfl
 
 @[simp] lemma unmop_id_mop {X : C} : (𝟙 (mop X)).unmop = 𝟙 X := rfl
-@[simp] lemma mop_id_unmop {X : Cᵐᵒᵖ} : (𝟙 (unmop X)).mop = 𝟙 X := rfl
+@[simp] lemma mop_id_unmop {X : Cᴹᵒᵖ} : (𝟙 (unmop X)).mop = 𝟙 X := rfl
 
 namespace iso
 
 variables {X Y : C}
 
-/-- An isomorphism in `C` gives an isomorphism in `Cᵐᵒᵖ`. -/
+/-- An isomorphism in `C` gives an isomorphism in `Cᴹᵒᵖ`. -/
 @[simps]
 def mop (f : X ≅ Y) : mop X ≅ mop Y :=
 { hom := f.hom.mop,
@@ -151,7 +151,7 @@ instance monoidal_category_op : monoidal_category Cᵒᵖ :=
 lemma op_tensor_obj (X Y : Cᵒᵖ) : X ⊗ Y = op (unop X ⊗ unop Y) := rfl
 lemma op_tensor_unit : (𝟙_ Cᵒᵖ) = op (𝟙_ C) := rfl
 
-instance monoidal_category_mop : monoidal_category Cᵐᵒᵖ :=
+instance monoidal_category_mop : monoidal_category Cᴹᵒᵖ :=
 { tensor_obj := λ X Y, mop (unmop Y ⊗ unmop X),
   tensor_hom := λ X₁ Y₁ X₂ Y₂ f g, (g.unmop ⊗ f.unmop).mop,
   tensor_unit := mop (𝟙_ C),
@@ -191,7 +191,7 @@ instance monoidal_category_mop : monoidal_category Cᵐᵒᵖ :=
     simp [pentagon_inv],
   end }
 
-lemma mop_tensor_obj (X Y : Cᵐᵒᵖ) : X ⊗ Y = mop (unmop Y ⊗ unmop X) := rfl
-lemma mop_tensor_unit : (𝟙_ Cᵐᵒᵖ) = mop (𝟙_ C) := rfl
+lemma mop_tensor_obj (X Y : Cᴹᵒᵖ) : X ⊗ Y = mop (unmop Y ⊗ unmop X) := rfl
+lemma mop_tensor_unit : (𝟙_ Cᴹᵒᵖ) = mop (𝟙_ C) := rfl
 
 end category_theory

--- a/src/computability/turing_machine.lean
+++ b/src/computability/turing_machine.lean
@@ -2036,9 +2036,7 @@ theorem add_bottom_map (L) : (add_bottom L).map ⟨prod.snd, rfl⟩ = L :=
 begin
   simp only [add_bottom, list_blank.map_cons]; convert list_blank.cons_head_tail _,
   generalize : list_blank.tail L = L',
-  refine L'.induction_on _, intro l, simp,
-  rw (_ : _ ∘ _ = id), {simp},
-  funext a, refl
+  refine L'.induction_on (λ l, _), simp
 end
 
 theorem add_bottom_modify_nth (f : (∀ k, option (Γ k)) → (∀ k, option (Γ k))) (L n) :

--- a/src/control/fold.lean
+++ b/src/control/fold.lean
@@ -55,7 +55,7 @@ but the author cannot think of instances of `foldable` that are not also
 
 universes u v
 
-open ulift category_theory opposite
+open ulift category_theory mul_opposite
 
 namespace monoid
 variables {m : Type u → Type u} [monad m]
@@ -101,7 +101,7 @@ calc   const.run (traverse (λ y, const.mk' (flip f y)) [y₀,y₁]) x
 And this is how `const` turns a monoid into an applicative functor and
 how the monoid of endofunctions define `foldl`.
 -/
-@[reducible] def foldl (α : Type u) : Type u := (End α)ᵒᵖ
+@[reducible] def foldl (α : Type u) : Type u := (End α)ᵐᵒᵖ
 def foldl.mk (f : α → α) : foldl α := op f
 def foldl.get (x : foldl α) : α → α := unop x
 def foldl.of_free_monoid (f : β → α → β) (xs : free_monoid α) : monoid.foldl β :=
@@ -114,7 +114,7 @@ def foldr.of_free_monoid (f : α → β → β) (xs : free_monoid α) : monoid.f
 flip (list.foldr f) xs
 
 @[reducible] def mfoldl (m : Type u → Type u) [monad m] (α : Type u) : Type u :=
-opposite $ End $ Kleisli.mk m α
+mul_opposite $ End $ Kleisli.mk m α
 def mfoldl.mk (f : α → m α) : mfoldl m α := op f
 def mfoldl.get (x : mfoldl m α) : α → m α := unop x
 def mfoldl.of_free_monoid (f : β → α → m β) (xs : free_monoid α) : monoid.mfoldl m β :=
@@ -204,7 +204,7 @@ lemma fold_foldl (f : β → α → β) :
   is_monoid_hom (foldl.of_free_monoid f) :=
 { map_one := rfl,
   map_mul := by intros; simp only [free_monoid.mul_def, foldl.of_free_monoid, flip, unop_op,
-    list.foldl_append, op_inj_iff]; refl }
+    list.foldl_append, op_inj]; refl }
 
 lemma foldl.unop_of_free_monoid  (f : β → α → β) (xs : free_monoid α) (a : β) :
   unop (foldl.of_free_monoid f xs) a = list.foldl f a xs := rfl
@@ -367,16 +367,12 @@ end
 
 variables {m : Type u → Type u} [monad m] [is_lawful_monad m]
 
-section
-local attribute [semireducible] opposite
 lemma mfoldl_to_list {f : α → β → m α} {x : α} {xs : t β} :
   mfoldl f x xs = list.mfoldl f x (to_list xs) :=
-begin
-  change _ = unop (mfoldl.of_free_monoid f (to_list xs)) x,
-  simp only [mfoldl, to_list_spec, fold_map_hom_free (fold_mfoldl (λ (β : Type u), m β) f),
+calc mfoldl f x xs = unop (mfoldl.of_free_monoid f (to_list xs)) x :
+  by simp only [mfoldl, to_list_spec, fold_map_hom_free (fold_mfoldl (λ (β : Type u), m β) f),
     mfoldl.of_free_monoid_comp_free_mk, mfoldl.get]
-end
-end
+... = list.mfoldl f x (to_list xs) : by simp only [mfoldl.of_free_monoid, unop_op, flip]
 
 lemma mfoldr_to_list (f : α → β → m β) (x : β) (xs : t α) :
   mfoldr f x xs = list.mfoldr f x (to_list xs) :=

--- a/src/data/complex/is_R_or_C.lean
+++ b/src/data/complex/is_R_or_C.lean
@@ -212,7 +212,7 @@ end
 variables (K)
 /-- Conjugation as a ring equivalence. This is used to convert the inner product into a
 sesquilinear product. -/
-abbreviation conj_to_ring_equiv : K ≃+* Kᵒᵖ := star_ring_equiv
+abbreviation conj_to_ring_equiv : K ≃+* Kᵐᵒᵖ := star_ring_equiv
 
 variables {K}
 

--- a/src/data/equiv/mul_add.lean
+++ b/src/data/equiv/mul_add.lean
@@ -581,7 +581,7 @@ end group_with_zero
 end equiv
 
 /-- When the group is commutative, `equiv.inv` is a `mul_equiv`. There is a variant of this
-`mul_equiv.inv' G : G ≃* Gᵒᵖ` for the non-commutative case. -/
+`mul_equiv.inv' G : G ≃* Gᵐᵒᵖ` for the non-commutative case. -/
 @[to_additive "When the `add_group` is commutative, `equiv.neg` is an `add_equiv`."]
 def mul_equiv.inv (G : Type*) [comm_group G] : G ≃* G :=
 { to_fun := has_inv.inv,

--- a/src/data/equiv/ring.lean
+++ b/src/data/equiv/ring.lean
@@ -101,9 +101,9 @@ instance has_coe_to_mul_equiv : has_coe (R ≃+* S) (R ≃* S) := ⟨ring_equiv.
 
 instance has_coe_to_add_equiv : has_coe (R ≃+* S) (R ≃+ S) := ⟨ring_equiv.to_add_equiv⟩
 
-lemma to_add_equiv_eq_coe (f : R ≃+* S) : f.to_add_equiv = ↑f := rfl
+@[simp] lemma to_add_equiv_eq_coe (f : R ≃+* S) : f.to_add_equiv = ↑f := rfl
 
-lemma to_mul_equiv_eq_coe (f : R ≃+* S) : f.to_mul_equiv = ↑f := rfl
+@[simp] lemma to_mul_equiv_eq_coe (f : R ≃+* S) : f.to_mul_equiv = ↑f := rfl
 
 @[simp, norm_cast] lemma coe_to_mul_equiv (f : R ≃+* S) : ⇑(f : R ≃* S) = f := rfl
 
@@ -177,36 +177,36 @@ e.to_equiv.image_eq_preimage s
 end basic
 
 section opposite
-open opposite
+open mul_opposite
 
-/-- A ring iso `α ≃+* β` can equivalently be viewed as a ring iso `αᵒᵖ ≃+* βᵒᵖ`. -/
+/-- A ring iso `α ≃+* β` can equivalently be viewed as a ring iso `αᵐᵒᵖ ≃+* βᵐᵒᵖ`. -/
 @[simps]
 protected def op {α β} [has_add α] [has_mul α] [has_add β] [has_mul β] :
-  (α ≃+* β) ≃ (αᵒᵖ ≃+* βᵒᵖ) :=
+  (α ≃+* β) ≃ (αᵐᵒᵖ ≃+* βᵐᵒᵖ) :=
 { to_fun    := λ f, { ..f.to_add_equiv.op, ..f.to_mul_equiv.op},
   inv_fun   := λ f, { ..(add_equiv.op.symm f.to_add_equiv), ..(mul_equiv.op.symm f.to_mul_equiv) },
   left_inv  := λ f, by { ext, refl },
   right_inv := λ f, by { ext, refl } }
 
-/-- The 'unopposite' of a ring iso `αᵒᵖ ≃+* βᵒᵖ`. Inverse to `ring_equiv.op`. -/
+/-- The 'unopposite' of a ring iso `αᵐᵒᵖ ≃+* βᵐᵒᵖ`. Inverse to `ring_equiv.op`. -/
 @[simp] protected def unop {α β} [has_add α] [has_mul α] [has_add β] [has_mul β] :
-  (αᵒᵖ ≃+* βᵒᵖ) ≃ (α ≃+* β) := ring_equiv.op.symm
+  (αᵐᵒᵖ ≃+* βᵐᵒᵖ) ≃ (α ≃+* β) := ring_equiv.op.symm
 
 section comm_semiring
 
 variables (R) [comm_semiring R]
 
 /-- A commutative ring is isomorphic to its opposite. -/
-def to_opposite : R ≃+* Rᵒᵖ :=
+def to_opposite : R ≃+* Rᵐᵒᵖ :=
 { map_add' := λ x y, rfl,
   map_mul' := λ x y, mul_comm (op y) (op x),
-  ..equiv_to_opposite }
+  .. mul_opposite.op_equiv }
 
 @[simp]
 lemma to_opposite_apply (r : R) : to_opposite R r = op r := rfl
 
 @[simp]
-lemma to_opposite_symm_apply (r : Rᵒᵖ) : (to_opposite R).symm r = unop r := rfl
+lemma to_opposite_symm_apply (r : Rᵐᵒᵖ) : (to_opposite R).symm r = unop r := rfl
 
 end comm_semiring
 
@@ -371,8 +371,8 @@ lemma map_list_sum [non_assoc_semiring R] [non_assoc_semiring S] (f : R ≃+* S)
   f l.sum = (l.map f).sum := f.to_ring_hom.map_list_sum l
 
 /-- An isomorphism into the opposite ring acts on the product by acting on the reversed elements -/
-lemma unop_map_list_prod [semiring R] [semiring S] (f : R ≃+* Sᵒᵖ) (l : list R) :
-  opposite.unop (f l.prod) = (l.map (opposite.unop ∘ f)).reverse.prod :=
+lemma unop_map_list_prod [semiring R] [semiring S] (f : R ≃+* Sᵐᵒᵖ) (l : list R) :
+  mul_opposite.unop (f l.prod) = (l.map (mul_opposite.unop ∘ f)).reverse.prod :=
 f.to_ring_hom.unop_map_list_prod l
 
 lemma map_multiset_prod [comm_semiring R] [comm_semiring S] (f : R ≃+* S) (s : multiset R) :

--- a/src/data/list/big_operators.lean
+++ b/src/data/list/big_operators.lean
@@ -122,17 +122,17 @@ lemma prod_update_nth : ∀ (L : list α) (n : ℕ) (a : α),
 | (x :: xs) (i+1) a := by simp [update_nth, prod_update_nth xs i a, mul_assoc]
 | []      _     _ := by simp [update_nth, (nat.zero_le _).not_lt]
 
-open opposite
+open mul_opposite
 
-lemma _root_.opposite.op_list_prod : ∀ (l : list α), op (l.prod) = (l.map op).reverse.prod
+lemma _root_.mul_opposite.op_list_prod : ∀ (l : list α), op (l.prod) = (l.map op).reverse.prod
 | [] := rfl
 | (x :: xs) := by rw [list.prod_cons, list.map_cons, list.reverse_cons', list.prod_concat, op_mul,
-                      _root_.opposite.op_list_prod]
+                      _root_.mul_opposite.op_list_prod]
 
-lemma _root_.opposite.unop_list_prod : ∀ (l : list αᵒᵖ), (l.prod).unop = (l.map unop).reverse.prod
-| [] := rfl
-| (x :: xs) := by rw [list.prod_cons, list.map_cons, list.reverse_cons', list.prod_concat, unop_mul,
-                      _root_.opposite.unop_list_prod]
+lemma _root_.mul_opposite.unop_list_prod (l : list αᵐᵒᵖ) :
+  (l.prod).unop = (l.map unop).reverse.prod :=
+by rw [← op_inj, op_unop, mul_opposite.op_list_prod, map_reverse, map_map, reverse_reverse,
+  op_comp_unop, map_id]
 
 end monoid
 
@@ -406,14 +406,13 @@ lemma _root_.monoid_hom.map_list_prod [monoid α] [monoid β] (f : α →* β) (
   f l.prod = (l.map f).prod :=
 (l.prod_hom f).symm
 
-open opposite
+open mul_opposite
 
 /-- A morphism into the opposite monoid acts on the product by acting on the reversed elements -/
-lemma _root_.monoid_hom.unop_map_list_prod [monoid α] [monoid β] (f : α →* βᵒᵖ) (l : list α) :
+lemma _root_.monoid_hom.unop_map_list_prod {α β : Type*} [monoid α] [monoid β] (f : α →* βᵐᵒᵖ)
+  (l : list α) :
   unop (f l.prod) = (l.map (unop ∘ f)).reverse.prod :=
-begin
-  rw [f.map_list_prod l, opposite.unop_list_prod, list.map_map],
-end
+by rw [f.map_list_prod l, unop_list_prod, list.map_map]
 
 @[to_additive]
 lemma prod_map_hom [monoid β] [monoid γ] (L : list α) (f : α → β) (g : β →* γ) :

--- a/src/data/matrix/basic.lean
+++ b/src/data/matrix/basic.lean
@@ -1162,15 +1162,16 @@ lemma transpose_sum [add_comm_monoid α] {ι : Type*} (s : finset ι) (M : ι �
 
 /-- `matrix.transpose` as a `ring_equiv` to the opposite ring -/
 @[simps]
-def transpose_ring_equiv [comm_semiring α] [fintype m] : matrix m m α ≃+* (matrix m m α)ᵒᵖ :=
-{ to_fun := λ M, opposite.op (Mᵀ),
+def transpose_ring_equiv [comm_semiring α] [fintype m] : matrix m m α ≃+* (matrix m m α)ᵐᵒᵖ :=
+{ to_fun := λ M, mul_opposite.op (Mᵀ),
   inv_fun := λ M, M.unopᵀ,
-  map_mul' := λ M N, (congr_arg opposite.op (transpose_mul M N)).trans (opposite.op_mul _ _),
-  ..transpose_add_equiv.trans opposite.op_add_equiv }
+  map_mul' := λ M N, (congr_arg mul_opposite.op (transpose_mul M N)).trans
+    (mul_opposite.op_mul _ _),
+  ..transpose_add_equiv.trans mul_opposite.op_add_equiv }
 
 lemma transpose_list_prod [comm_semiring α] [fintype m] [decidable_eq m] (l : list (matrix m m α)) :
   l.prodᵀ = (l.map transpose).reverse.prod :=
-(transpose_ring_equiv : matrix m m α ≃+* (matrix m m α)ᵒᵖ).unop_map_list_prod l
+(transpose_ring_equiv : matrix m m α ≃+* (matrix m m α)ᵐᵒᵖ).unop_map_list_prod l
 
 end transpose
 
@@ -1242,16 +1243,17 @@ lemma conj_transpose_sum [add_comm_monoid α] [star_add_monoid α] {ι : Type*} 
 /-- `matrix.conj_transpose` as a `ring_equiv` to the opposite ring -/
 @[simps]
 def conj_transpose_ring_equiv [comm_semiring α] [star_ring α] [fintype m] :
-  matrix m m α ≃+* (matrix m m α)ᵒᵖ :=
-{ to_fun := λ M, opposite.op (Mᴴ),
+  matrix m m α ≃+* (matrix m m α)ᵐᵒᵖ :=
+{ to_fun := λ M, mul_opposite.op (Mᴴ),
   inv_fun := λ M, M.unopᴴ,
-  map_mul' := λ M N, (congr_arg opposite.op (conj_transpose_mul M N)).trans (opposite.op_mul _ _),
-  ..conj_transpose_add_equiv.trans opposite.op_add_equiv }
+  map_mul' := λ M N, (congr_arg mul_opposite.op (conj_transpose_mul M N)).trans
+    (mul_opposite.op_mul _ _),
+  ..conj_transpose_add_equiv.trans mul_opposite.op_add_equiv }
 
 lemma conj_transpose_list_prod [comm_semiring α] [star_ring α] [fintype m] [decidable_eq m]
   (l : list (matrix m m α)) :
   l.prodᴴ = (l.map conj_transpose).reverse.prod :=
-(conj_transpose_ring_equiv : matrix m m α ≃+* (matrix m m α)ᵒᵖ).unop_map_list_prod l
+(conj_transpose_ring_equiv : matrix m m α ≃+* (matrix m m α)ᵐᵒᵖ).unop_map_list_prod l
 
 end conj_transpose
 

--- a/src/data/opposite.lean
+++ b/src/data/opposite.lean
@@ -9,20 +9,15 @@ import data.equiv.basic
 # Opposites
 
 In this file we define a type synonym `opposite α := α`, denoted by `αᵒᵖ` and two synonyms for the
-identity map, `op : α → αᵒᵖ` and `unop : αᵒᵖ → α`. The type tag `αᵒᵖ` is used with two different
-meanings:
-
-- if `α` is a category, then `αᵒᵖ` is the opposite category, with all arrows reversed;
-
-- if `α` is a monoid (group, etc), then `αᵒᵖ` is the opposite monoid (group, etc) with
-  `op (x * y) = op x * op y`.
+identity map, `op : α → αᵒᵖ` and `unop : αᵒᵖ → α`. If `α` is a category, then `αᵒᵖ` is the opposite
+category, with all arrows reversed.
 -/
 
 universes v u -- morphism levels before object levels. See note [category_theory universes].
 
 variable (α : Sort u)
 
-/-- The type of objects of the opposite of `α`; used to define the opposite category or group.
+/-- The type of objects of the opposite of `α`; used to define the opposite category.
 
   In order to avoid confusion between `α` and its opposite type, we
   set up the type of objects `opposite α` using the following pattern,

--- a/src/data/polynomial/basic.lean
+++ b/src/data/polynomial/basic.lean
@@ -167,9 +167,9 @@ def to_finsupp_iso : polynomial R ≃+* add_monoid_algebra R ℕ :=
   map_mul' := by { rintros ⟨⟩ ⟨⟩, simp [mul_to_finsupp] },
   map_add' := by { rintros ⟨⟩ ⟨⟩, simp [add_to_finsupp] } }
 
-/-- Ring isomorphism between `(polynomial R)ᵒᵖ` and `polynomial Rᵒᵖ`. -/
+/-- Ring isomorphism between `(polynomial R)ᵐᵒᵖ` and `polynomial Rᵐᵒᵖ`. -/
 @[simps]
-def op_ring_equiv : (polynomial R)ᵒᵖ ≃+* polynomial Rᵒᵖ :=
+def op_ring_equiv : (polynomial R)ᵐᵒᵖ ≃+* polynomial Rᵐᵒᵖ :=
 ((to_finsupp_iso R).op.trans add_monoid_algebra.op_ring_equiv).trans (to_finsupp_iso _).symm
 
 variable {R}

--- a/src/data/prod.lean
+++ b/src/data/prod.lean
@@ -29,6 +29,10 @@ prod.forall
 theorem exists' {p : α → β → Prop} : (∃ x : α × β, p x.1 x.2) ↔ ∃ a b, p a b :=
 prod.exists
 
+@[simp] lemma snd_comp_mk (x : α) : prod.snd ∘ (prod.mk x : β → α × β) = id := rfl
+
+@[simp] lemma fst_comp_mk (x : α) : prod.fst ∘ (prod.mk x : β → α × β) = function.const β x := rfl
+
 @[simp] lemma map_mk (f : α → γ) (g : β → δ) (a : α) (b : β) : map f g (a, b) = (f a, g b) := rfl
 
 lemma map_fst (f : α → γ) (g : β → δ) (p : α × β) : (map f g p).1 = f (p.1) := rfl

--- a/src/group_theory/free_product.lean
+++ b/src/group_theory/free_product.lean
@@ -148,9 +148,10 @@ section group
 variables (G : ι → Type*) [Π i, group (G i)]
 
 instance : has_inv (free_product G) :=
-{ inv := opposite.unop ∘ lift (λ i, (of : G i →* _).op.comp (mul_equiv.inv' (G i)).to_monoid_hom) }
+{ inv := mul_opposite.unop ∘
+    lift (λ i, (of : G i →* _).op.comp (mul_equiv.inv' (G i)).to_monoid_hom) }
 
-lemma inv_def (x : free_product G) : x⁻¹ = opposite.unop
+lemma inv_def (x : free_product G) : x⁻¹ = mul_opposite.unop
   (lift (λ i, (of : G i →* _).op.comp (mul_equiv.inv' (G i)).to_monoid_hom) x) := rfl
 
 instance : group (free_product G) :=
@@ -158,10 +159,11 @@ instance : group (free_product G) :=
     intro m,
     rw inv_def,
     apply m.induction_on,
-    { rw [monoid_hom.map_one, opposite.unop_one, one_mul], },
+    { rw [monoid_hom.map_one, mul_opposite.unop_one, one_mul], },
     { intros i m, change of m⁻¹ * of m = 1, rw [←of.map_mul, mul_left_inv, of.map_one], },
     { intros x y hx hy,
-      rw [monoid_hom.map_mul, opposite.unop_mul, mul_assoc, ←mul_assoc _ x y, hx, one_mul, hy], },
+      rw [monoid_hom.map_mul, mul_opposite.unop_mul, mul_assoc, ← mul_assoc _ x y, hx,
+        one_mul, hy], },
   end,
   ..free_product.has_inv G,
   ..free_product.monoid G }

--- a/src/linear_algebra/clifford_algebra/conjugation.lean
+++ b/src/linear_algebra/clifford_algebra/conjugation.lean
@@ -54,13 +54,13 @@ involute_involutive
 end involute
 
 section reverse
-open opposite
+open mul_opposite
 
 /-- Grade reversion, inverting the multiplication order of basis vectors.
 Also called *transpose* in some literature. -/
 def reverse : clifford_algebra Q →ₗ[R] clifford_algebra Q :=
 (op_linear_equiv R).symm.to_linear_map.comp (
-  clifford_algebra.lift Q ⟨(opposite.op_linear_equiv R).to_linear_map.comp (ι Q),
+  clifford_algebra.lift Q ⟨(mul_opposite.op_linear_equiv R).to_linear_map.comp (ι Q),
     λ m, unop_injective $ by simp⟩).to_linear_map
 
 @[simp] lemma reverse_ι (m : M) : reverse (ι Q m) = ι Q m :=

--- a/src/linear_algebra/sesquilinear_form.lean
+++ b/src/linear_algebra/sesquilinear_form.lean
@@ -37,7 +37,7 @@ open_locale big_operators
 universes u v w
 
 /-- A sesquilinear form over a module  -/
-structure sesq_form (R : Type u) (M : Type v) [ring R] (I : R ≃+* Rᵒᵖ)
+structure sesq_form (R : Type u) (M : Type v) [ring R] (I : R ≃+* Rᵐᵒᵖ)
   [add_comm_group M] [module R M] :=
 (sesq : M → M → R)
 (sesq_add_left : ∀ (x y z : M), sesq (x + y) z = sesq x z + sesq y z)
@@ -49,7 +49,7 @@ namespace sesq_form
 
 section general_ring
 variables {R : Type u} {M : Type v} [ring R] [add_comm_group M] [module R M]
-variables {I : R ≃+* Rᵒᵖ} {S : sesq_form R M I}
+variables {I : R ≃+* Rᵐᵒᵖ} {S : sesq_form R M I}
 
 instance : has_coe_to_fun (sesq_form R M I) (λ _, M → M → R) := ⟨sesq⟩
 
@@ -204,7 +204,7 @@ end general_ring
 section comm_ring
 
 variables {R : Type*} [comm_ring R] {M : Type v} [add_comm_group M] [module R M]
-  {J : R ≃+* Rᵒᵖ} (F : sesq_form R M J) (f : M → M)
+  {J : R ≃+* Rᵐᵒᵖ} (F : sesq_form R M J) (f : M → M)
 
 instance to_module : module R (sesq_form R M J) :=
 { smul := λ c S,
@@ -230,7 +230,7 @@ section is_domain
 
 variables {R : Type*} [ring R] [is_domain R]
   {M : Type v} [add_comm_group M] [module R M]
-  {K : R ≃+* Rᵒᵖ} {G : sesq_form R M K}
+  {K : R ≃+* Rᵐᵒᵖ} {G : sesq_form R M K}
 
 theorem ortho_smul_left {x y : M} {a : R} (ha : a ≠ 0) :
   (is_ortho G x y) ↔ (is_ortho G (a • x) y) :=
@@ -255,7 +255,7 @@ begin
     { exfalso,
       -- `map_eq_zero_iff` doesn't fire here even if marked as a simp lemma, probably bcecause
       -- different instance paths
-      simp only [opposite.unop_eq_zero_iff] at H,
+      simp only [mul_opposite.unop_eq_zero_iff] at H,
       exact ha (K.map_eq_zero_iff.mp H), },
     { exact H }}
 end
@@ -263,7 +263,7 @@ end
 end is_domain
 
 variables {R : Type*} {M : Type*} [ring R] [add_comm_group M] [module R M]
-variables {I : R ≃+* Rᵒᵖ} {S : sesq_form R M I}
+variables {I : R ≃+* Rᵐᵒᵖ} {S : sesq_form R M I}
 
 /-- The proposition that a sesquilinear form is reflexive -/
 def is_refl (S : sesq_form R M I) : Prop := ∀ (x y : M), S x y = 0 → S y x = 0

--- a/src/logic/unique.lean
+++ b/src/logic/unique.lean
@@ -117,7 +117,7 @@ instance subsingleton_unique : subsingleton (unique α) :=
 
 /-- Construct `unique` from `inhabited` and `subsingleton`. Making this an instance would create
 a loop in the class inheritance graph. -/
-def mk' (α : Sort u) [h₁ : inhabited α] [subsingleton α] : unique α :=
+@[reducible] def mk' (α : Sort u) [h₁ : inhabited α] [subsingleton α] : unique α :=
 { uniq := λ x, subsingleton.elim _ _, .. h₁ }
 
 end unique

--- a/src/measure_theory/group/arithmetic.lean
+++ b/src/measure_theory/group/arithmetic.lean
@@ -547,30 +547,30 @@ end mul_action
 -/
 
 section opposite
-open opposite
+open mul_opposite
 
-instance {α : Type*} [h : measurable_space α] : measurable_space αᵒᵖ := measurable_space.map op h
+instance {α : Type*} [h : measurable_space α] : measurable_space αᵐᵒᵖ := measurable_space.map op h
 
-lemma measurable_op {α : Type*} [measurable_space α] : measurable (op : α → αᵒᵖ) := λ s, id
+lemma measurable_op {α : Type*} [measurable_space α] : measurable (op : α → αᵐᵒᵖ) := λ s, id
 
-lemma measurable_unop {α : Type*} [measurable_space α] : measurable (unop : αᵒᵖ → α) := λ s, id
+lemma measurable_unop {α : Type*} [measurable_space α] : measurable (unop : αᵐᵒᵖ → α) := λ s, id
 
 instance {M : Type*} [has_mul M] [measurable_space M] [has_measurable_mul M] :
-  has_measurable_mul Mᵒᵖ :=
+  has_measurable_mul Mᵐᵒᵖ :=
 ⟨λ c, measurable_op.comp (measurable_unop.mul_const _),
   λ c, measurable_op.comp (measurable_unop.const_mul _)⟩
 
 instance {M : Type*} [has_mul M] [measurable_space M] [has_measurable_mul₂ M] :
-  has_measurable_mul₂ Mᵒᵖ :=
+  has_measurable_mul₂ Mᵐᵒᵖ :=
 ⟨measurable_op.comp ((measurable_unop.comp measurable_snd).mul
   (measurable_unop.comp measurable_fst))⟩
 
 instance has_measurable_smul_opposite_of_mul {M : Type*} [has_mul M] [measurable_space M]
-  [has_measurable_mul M] : has_measurable_smul Mᵒᵖ M :=
+  [has_measurable_mul M] : has_measurable_smul Mᵐᵒᵖ M :=
 ⟨λ c, measurable_mul_const (unop c), λ x, measurable_unop.const_mul x⟩
 
 instance has_measurable_smul₂_opposite_of_mul {M : Type*} [has_mul M] [measurable_space M]
-  [has_measurable_mul₂ M] : has_measurable_smul₂ Mᵒᵖ M :=
+  [has_measurable_mul₂ M] : has_measurable_smul₂ Mᵐᵒᵖ M :=
 ⟨measurable_snd.mul (measurable_unop.comp measurable_fst)⟩
 
 end opposite

--- a/src/number_theory/arithmetic_function.lean
+++ b/src/number_theory/arithmetic_function.lean
@@ -366,9 +366,9 @@ end
 theorem coe_mul_zeta_apply [semiring R] {f : arithmetic_function R} {x : ℕ} :
   (f * ζ) x = ∑ i in divisors x, f i :=
 begin
-  apply opposite.op_injective,
+  apply mul_opposite.op_injective,
   rw [op_sum],
-  convert @coe_zeta_mul_apply Rᵒᵖ _ { to_fun := opposite.op ∘ f, map_zero' := by simp} x,
+  convert @coe_zeta_mul_apply Rᵐᵒᵖ _ { to_fun := mul_opposite.op ∘ f, map_zero' := by simp} x,
   rw [mul_apply, mul_apply, op_sum],
   conv_lhs { rw ← map_swap_divisors_antidiagonal, },
   rw sum_map,

--- a/src/ring_theory/ring_invo.lean
+++ b/src/ring_theory/ring_invo.lean
@@ -9,12 +9,12 @@ import algebra.opposites
 /-!
 # Ring involutions
 
-This file defines a ring involution as a structure extending `R ≃+* Rᵒᵖ`,
+This file defines a ring involution as a structure extending `R ≃+* Rᵐᵒᵖ`,
 with the additional fact `f.involution : (f (f x).unop).unop = x`.
 
 ## Notations
 
-We provide a coercion to a function `R → Rᵒᵖ`.
+We provide a coercion to a function `R → Rᵐᵒᵖ`.
 
 ## References
 
@@ -28,22 +28,22 @@ Ring involution
 variables (R : Type*)
 
 /-- A ring involution -/
-structure ring_invo [semiring R] extends R ≃+* Rᵒᵖ :=
+structure ring_invo [semiring R] extends R ≃+* Rᵐᵒᵖ :=
 (involution' : ∀ x, (to_fun (to_fun x).unop).unop = x)
 
 namespace ring_invo
 variables {R} [semiring R]
 
 /-- Construct a ring involution from a ring homomorphism. -/
-def mk' (f : R →+* Rᵒᵖ) (involution : ∀ r, (f (f r).unop).unop = r) :
+def mk' (f : R →+* Rᵐᵒᵖ) (involution : ∀ r, (f (f r).unop).unop = r) :
   ring_invo R :=
 { inv_fun := λ r, (f r.unop).unop,
   left_inv := λ r, involution r,
-  right_inv := λ r, congr_arg opposite.op (involution (r.unop)),
+  right_inv := λ r, mul_opposite.unop_injective $ involution _,
   involution' := involution,
-  ..f }
+  .. f }
 
-instance : has_coe_to_fun (ring_invo R) (λ _, R → Rᵒᵖ) := ⟨λ f, f.to_ring_equiv.to_fun⟩
+instance : has_coe_to_fun (ring_invo R) (λ _, R → Rᵐᵒᵖ) := ⟨λ f, f.to_ring_equiv.to_fun⟩
 
 @[simp]
 lemma to_fun_eq_coe (f : ring_invo R) : f.to_fun = f := rfl
@@ -52,11 +52,11 @@ lemma to_fun_eq_coe (f : ring_invo R) : f.to_fun = f := rfl
 lemma involution (f : ring_invo R) (x : R) : (f (f x).unop).unop = x :=
 f.involution' x
 
-instance has_coe_to_ring_equiv : has_coe (ring_invo R) (R ≃+* Rᵒᵖ) :=
+instance has_coe_to_ring_equiv : has_coe (ring_invo R) (R ≃+* Rᵐᵒᵖ) :=
 ⟨ring_invo.to_ring_equiv⟩
 
 @[norm_cast] lemma coe_ring_equiv (f : ring_invo R) (a : R) :
-  (f : R ≃+* Rᵒᵖ) a = f a := rfl
+  (f : R ≃+* Rᵐᵒᵖ) a = f a := rfl
 
 @[simp] lemma map_eq_zero_iff (f : ring_invo R) {x : R} : f x = 0 ↔ x = 0 :=
 f.to_ring_equiv.map_eq_zero_iff

--- a/src/topology/algebra/monoid.lean
+++ b/src/topology/algebra/monoid.lean
@@ -306,21 +306,21 @@ end has_continuous_mul
 
 section op
 
-open opposite
+open mul_opposite
 
 /-- Put the same topological space structure on the opposite monoid as on the original space. -/
-instance [_i : topological_space α] : topological_space αᵒᵖ :=
-topological_space.induced (unop : αᵒᵖ → α) _i
+instance [_i : topological_space α] : topological_space αᵐᵒᵖ :=
+topological_space.induced (unop : αᵐᵒᵖ → α) _i
 
 variables [topological_space α]
 
-lemma continuous_unop : continuous (unop : αᵒᵖ → α) := continuous_induced_dom
-lemma continuous_op : continuous (op : α → αᵒᵖ) := continuous_induced_rng continuous_id
+lemma continuous_unop : continuous (unop : αᵐᵒᵖ → α) := continuous_induced_dom
+lemma continuous_op : continuous (op : α → αᵐᵒᵖ) := continuous_induced_rng continuous_id
 
 variables [monoid α] [has_continuous_mul α]
 
-/-- If multiplication is continuous in the monoid `α`, then it also is in the monoid `αᵒᵖ`. -/
-instance : has_continuous_mul αᵒᵖ :=
+/-- If multiplication is continuous in the monoid `α`, then it also is in the monoid `αᵐᵒᵖ`. -/
+instance : has_continuous_mul αᵐᵒᵖ :=
 ⟨ let h₁ := @continuous_mul α _ _ _ in
   let h₂ : continuous (λ p : α × α, _) := continuous_snd.prod_mk continuous_fst in
   continuous_induced_rng $ (h₁.comp h₂).comp (continuous_unop.prod_map continuous_unop) ⟩
@@ -329,7 +329,7 @@ end op
 
 namespace units
 
-open opposite
+open mul_opposite
 
 variables [topological_space α] [monoid α]
 
@@ -351,7 +351,7 @@ with respect to the induced topology, is continuous.
 Inversion is also continuous, but we register this in a later file, `topology.algebra.group`,
 because the predicate `has_continuous_inv` has not yet been defined. -/
 instance : has_continuous_mul (units α) :=
-⟨ let h := @continuous_mul (α × αᵒᵖ) _ _ _ in
+⟨ let h := @continuous_mul (α × αᵐᵒᵖ) _ _ _ in
   continuous_induced_rng $ h.comp $ continuous_embed_product.prod_map continuous_embed_product ⟩
 
 end units


### PR DESCRIPTION
Split out `mul_opposite` from `opposite`, to leave room for an `add_opposite` in future.

Multiplicative opposites are now spelt `Aᵐᵒᵖ` instead of `Aᵒᵖ`. `Aᵒᵖ` now refers to the categorical opposite.

Co-authored-by: Yury G. Kudryashov <urkud@urkud.name>

---
This is #10235 without the orthogonal change that makes `opposite` a structure, ~~or the change that renames some `equiv` lemmas in a way that makes them inconsistent with other equiv lemmas~~

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
