### PR TITLE
[Merged by Bors] - feat(*/{group,mul}_action): more lemmas

### DIFF
--- a/src/group_theory/group_action/basic.lean
+++ b/src/group_theory/group_action/basic.lean
@@ -177,10 +177,10 @@ end
 
 variables (α) {β}
 
-@[simp, to_additive] lemma mem_orbit_smul (g : α) (a : β) : a ∈ orbit α (g • a) :=
+@[to_additive] lemma mem_orbit_smul (g : α) (a : β) : a ∈ orbit α (g • a) :=
 by simp only [orbit_smul, mem_orbit_self]
 
-@[simp, to_additive] lemma smul_mem_orbit_smul (g h : α) (a : β) : g • a ∈ orbit α (h • a) :=
+@[to_additive] lemma smul_mem_orbit_smul (g h : α) (a : β) : g • a ∈ orbit α (h • a) :=
 by simp only [orbit_smul, mem_orbit]
 
 variables (α) (β)

--- a/src/group_theory/group_action/basic.lean
+++ b/src/group_theory/group_action/basic.lean
@@ -16,7 +16,7 @@ import data.fintype.card
 universes u v w
 variables {α : Type u} {β : Type v} {γ : Type w}
 
-open_locale big_operators
+open_locale big_operators pointwise
 open function
 
 namespace mul_action
@@ -37,6 +37,25 @@ iff.rfl
 
 @[simp, to_additive] lemma mem_orbit_self (b : β) : b ∈ orbit α b :=
 ⟨1, by simp [mul_action.one_smul]⟩
+
+@[to_additive] lemma maps_to_smul_orbit (a : α) (b : β) :
+  set.maps_to ((•) a) (orbit α b) (orbit α b) :=
+set.range_subset_iff.2 $ λ a', ⟨a * a', mul_smul _ _ _⟩
+
+@[to_additive] lemma smul_orbit_subset (a : α) (b : β) : a • orbit α b ⊆ orbit α b :=
+(maps_to_smul_orbit a b).image_subset
+
+@[to_additive] lemma orbit_smul_subset (a : α) (b : β) : orbit α (a • b) ⊆ orbit α b :=
+set.range_subset_iff.2 $ λ a', mul_smul a' a b ▸ mem_orbit _ _
+
+@[to_additive] instance {b : β} : mul_action α (orbit α b) :=
+{ smul := λ a, (maps_to_smul_orbit a b).restrict _ _ _,
+  one_smul := λ a, subtype.ext (one_smul α a),
+  mul_smul := λ a a' b', subtype.ext (mul_smul a a' b') }
+
+@[simp, to_additive] lemma orbit.coe_smul {b : β} {a : α} {b' : orbit α b} :
+  ↑(a • b') = a • (b' : β) :=
+rfl
 
 variables (α) (β)
 
@@ -89,6 +108,14 @@ variables {β}
 lemma exists_smul_eq [is_pretransitive α β] (x y : β) :
   ∃ m : α, m • x = y := is_pretransitive.exists_smul_eq x y
 
+lemma surjective_smul [is_pretransitive α β] (x : β) :
+  surjective (λ c : α, c • x) :=
+exists_smul_eq α x
+
+lemma orbit_eq_univ [is_pretransitive α β] (x : β) :
+  orbit α x = set.univ :=
+(surjective_smul α x).range_eq
+
 end mul_action
 
 namespace add_action
@@ -99,10 +126,8 @@ variables (α β) [add_monoid α] [add_action α β]
 class is_pretransitive : Prop :=
 (exists_vadd_eq : ∀ x y : β, ∃ g : α, g +ᵥ x = y)
 
-variables {β}
-
-lemma exists_vadd_eq [is_pretransitive α β] (x y : β) :
-  ∃ m : α, m +ᵥ x = y := is_pretransitive.exists_vadd_eq x y
+attribute [to_additive] mul_action.is_pretransitive mul_action.exists_smul_eq
+  mul_action.surjective_smul mul_action.orbit_eq_univ
 
 end add_action
 
@@ -123,25 +148,20 @@ variables {α} {β}
 @[simp, to_additive] lemma mem_stabilizer_iff {b : β} {a : α} :
   a ∈ stabilizer α b ↔ a • b = b := iff.rfl
 
+@[simp, to_additive] lemma smul_orbit (a : α) (b : β) :
+  a • orbit α b = orbit α b :=
+(smul_orbit_subset a b).antisymm $
+  calc orbit α b = a • a⁻¹ • orbit α b : (smul_inv_smul _ _).symm
+             ... ⊆ a • orbit α b       : set.image_subset _ (smul_orbit_subset _ _)
+
+@[simp, to_additive] lemma orbit_smul (a : α) (b : β) : orbit α (a • b) = orbit α b :=
+(orbit_smul_subset a b).antisymm $
+  calc orbit α b = orbit α (a⁻¹ • a • b) : by rw inv_smul_smul
+             ... ⊆ orbit α (a • b)       : orbit_smul_subset _ _
+
 @[to_additive] lemma orbit_eq_iff {a b : β} :
    orbit α a = orbit α b ↔ a ∈ orbit α b:=
-⟨λ h, h ▸ mem_orbit_self _,
-λ ⟨x, (hx : x • b = a)⟩, set.ext (λ c, ⟨λ ⟨y, (hy : y • a = c)⟩, ⟨y * x,
-  show (y * x) • b = c, by rwa [mul_action.mul_smul, hx]⟩,
-  λ ⟨y, (hy : y • b = c)⟩, ⟨y * x⁻¹,
-    show (y * x⁻¹) • a = c, by
-      conv {to_rhs, rw [← hy, ← mul_one y, ← inv_mul_self x, ← mul_assoc,
-        mul_action.mul_smul, hx]}⟩⟩)⟩
-
-@[to_additive] instance {b : β} : mul_action α (orbit α b) :=
-{ smul := λ a b', ⟨a • b', orbit_eq_iff.mp (eq.trans (orbit_eq_iff.mpr (mem_orbit b' a))
-    (orbit_eq_iff.mpr b'.2))⟩,
-  one_smul := λ a, subtype.ext (one_smul α a),
-  mul_smul := λ a a' b', subtype.ext (mul_smul a a' b') }
-
-@[simp, to_additive] lemma orbit.coe_smul {b : β} {a : α} {b' : orbit α b} :
-  ↑(a • b') = a • (b' : β) :=
-rfl
+⟨λ h, h ▸ mem_orbit_self _, λ ⟨c, hc⟩, hc ▸ orbit_smul _ _⟩
 
 @[to_additive] lemma mem_fixed_points_iff_card_orbit_eq_one {a : β}
   [fintype (orbit α a)] : a ∈ fixed_points α β ↔ fintype.card (orbit α a) = 1 :=
@@ -158,10 +178,10 @@ end
 variables (α) {β}
 
 @[simp, to_additive] lemma mem_orbit_smul (g : α) (a : β) : a ∈ orbit α (g • a) :=
-⟨g⁻¹, by simp⟩
+by simp only [orbit_smul, mem_orbit_self]
 
 @[simp, to_additive] lemma smul_mem_orbit_smul (g h : α) (a : β) : g • a ∈ orbit α (h • a) :=
-⟨g * h⁻¹, by simp [mul_smul]⟩
+by simp only [orbit_smul, mem_orbit]
 
 variables (α) (β)
 /-- The relation 'in the same orbit'. -/

--- a/src/topology/algebra/mul_action.lean
+++ b/src/topology/algebra/mul_action.lean
@@ -6,6 +6,7 @@ Authors: Yury Kudryashov
 import topology.algebra.monoid
 import algebra.module.prod
 import topology.homeomorph
+import group_theory.group_action.basic
 
 /-!
 # Continuous monoid action
@@ -32,7 +33,7 @@ Besides homeomorphisms mentioned above, in this file we provide lemmas like `con
 or `filter.tendsto.smul` that provide dot-syntax access to `continuous_smul`.
 -/
 
-open_locale topological_space
+open_locale topological_space pointwise
 open filter
 
 /-- Class `has_continuous_smul M α` says that the scalar multiplication `(•) : M → α → α`
@@ -133,6 +134,15 @@ instance units.has_continuous_smul : has_continuous_smul (units M) α :=
     show continuous ((λ p : M × α, p.fst • p.snd) ∘ (λ p : units M × α, (p.1, p.2))),
     from continuous_smul.comp ((units.continuous_coe.comp continuous_fst).prod_mk continuous_snd) }
 
+@[to_additive]
+lemma smul_closure_subset (c : M) (s : set α) : c • closure s ⊆ closure (c • s) :=
+((set.maps_to_image _ _).closure $ continuous_id.const_smul c).image_subset
+
+@[to_additive]
+lemma smul_closure_orbit_subset (c : M) (x : α) :
+  c • closure (mul_action.orbit M x) ⊆ closure (mul_action.orbit M x) :=
+(smul_closure_subset c _).trans $ closure_mono $ mul_action.smul_orbit_subset _ _
+
 end monoid
 
 section group
@@ -189,9 +199,15 @@ attribute [to_additive] homeomorph.smul
 lemma is_open_map_smul (c : G) : is_open_map (λ x : α, c • x) :=
 (homeomorph.smul c).is_open_map
 
+@[to_additive] lemma is_open.smul {s : set α} (hs : is_open s) (c : G) : is_open (c • s) :=
+is_open_map_smul c s hs
+
 @[to_additive]
 lemma is_closed_map_smul (c : G) : is_closed_map (λ x : α, c • x) :=
 (homeomorph.smul c).is_closed_map
+
+@[to_additive] lemma is_closed.smul {s : set α} (hs : is_closed s) (c : G) : is_closed (c • s) :=
+is_closed_map_smul c s hs
 
 end group
 


### PR DESCRIPTION
* add several lemmas about orbits and pointwise scalar multiplication;
* generalize `mul_action.orbit.mul_action` to a monoid action;
* more lemmas about pretransitive actions, use `to_additive` more;
* add dot notation lemmas `is_open.smul` and `is_closed.smul`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
