### PR TITLE
[Merged by Bors] - feat(analysis/inner_product_space/spectrum): more concrete diagonalization theorem

### DIFF
--- a/docs/overview.yaml
+++ b/docs/overview.yaml
@@ -177,9 +177,9 @@ Linear algebra:
     matrix representation: 'bilin_form.to_matrix'
     quadratic form: 'quadratic_form'
     polar form of a quadratic: 'quadratic_form.polar'
-    Euclidean vector space: 'inner_product_space'
-    Cauchy-Schwarz inequality: 'inner_mul_inner_self_le'
-    self-adjoint endomorphism: 'bilin_form.is_self_adjoint'
+  Finite-dimensional inner product spaces (see also Hilbert spaces, below):
+    existence of orthonormal basis: 'inner_product_space.orthonormal_basis'
+    diagonalization of self-adjoint endomorphisms: 'is_self_adjoint.diagonalization_basis_apply_self_apply'
 
 Topology:
   General topology:
@@ -224,6 +224,7 @@ Topology:
     topological ring: 'topological_ring'
     completion of a topological ring: 'uniform_space.completion.ring'
     topological module: 'has_continuous_smul'
+    continuous linear map: 'continuous_linear_map'
     weak-* topology: 'weak_dual.topological_space'
     Haar measure on a locally compact Hausdorff group: 'measure_theory.measure.haar_measure'
   Metric spaces:
@@ -236,25 +237,34 @@ Topology:
     contraction mapping theorem: 'contracting_with.exists_fixed_point'
     Baire theorem: 'dense_Inter_of_open'
     Arzela-Ascoli theorem: 'bounded_continuous_function.arzela_ascoli'
-    Hausdorff distance: ' emetric.Hausdorff_edist'
+    Hausdorff distance: 'emetric.Hausdorff_edist'
     Gromov-Hausdorff space: 'Gromov_Hausdorff.GH_space'
 
 Analysis:
-  Normed vector spaces:
+  Normed vector spaces/Banach spaces:
     normed vector space over a normed field: 'normed_space'
     topology on a normed vector space: 'semi_normed_space.has_bounded_smul'
     equivalence of norms in finite dimension: 'linear_equiv.to_continuous_linear_equiv'
     finite dimensional normed spaces over complete normed fields are complete: 'submodule.complete_of_finite_dimensional'
     Heine-Borel theorem (finite dimensional normed spaces are proper): 'finite_dimensional.proper'
-    continuous linear map: 'continuous_linear_map'
     norm of a continuous linear map: 'linear_map.mk_continuous'
     Banach open mapping theorem: 'open_mapping'
     absolutely convergent series in Banach spaces: 'summable_of_summable_norm'
     Hahn-Banach theorem: 'exists_extension_norm_eq'
     dual of a normed space: 'normed_space.dual'
-    Fréchet-Riesz representation of the dual of a Hilbert space: 'inner_product_space.to_dual'
     isometric inclusion in double dual: 'normed_space.inclusion_in_double_dual_li'
     completeness of spaces of bounded continuous functions: 'bounded_continuous_function.complete_space'
+
+  Hilbert spaces:
+    Inner product space, over $R$ or $C$: 'inner_product_space'
+    Cauchy-Schwarz inequality: 'inner_mul_inner_self_le'
+    self-adjoint endomorphism: 'is_self_adjoint'
+    orthogonal projection: 'orthogonal_projection'
+    reflection: 'reflection'
+    orthogonal complement: 'submodule.orthogonal'
+    existence of Hilbert basis: 'exists_is_orthonormal_dense_span'
+    eigenvalues from Rayleigh quotient: 'has_eigenvector_of_is_local_extr_on'
+    Fréchet-Riesz representation of the dual of a Hilbert space: 'inner_product_space.to_dual'
 
   Differentiability:
     differentiable function between normed vector spaces: 'has_fderiv_at'

--- a/docs/overview.yaml
+++ b/docs/overview.yaml
@@ -178,7 +178,7 @@ Linear algebra:
     quadratic form: 'quadratic_form'
     polar form of a quadratic: 'quadratic_form.polar'
   Finite-dimensional inner product spaces (see also Hilbert spaces, below):
-    existence of orthonormal basis: 'inner_product_space.orthonormal_basis'
+    existence of orthonormal basis: 'orthonormal_basis'
     diagonalization of self-adjoint endomorphisms: 'is_self_adjoint.diagonalization_basis_apply_self_apply'
 
 Topology:

--- a/docs/overview.yaml
+++ b/docs/overview.yaml
@@ -263,7 +263,7 @@ Analysis:
     reflection: 'reflection'
     orthogonal complement: 'submodule.orthogonal'
     existence of Hilbert basis: 'exists_is_orthonormal_dense_span'
-    eigenvalues from Rayleigh quotient: 'has_eigenvector_of_is_local_extr_on'
+    eigenvalues from Rayleigh quotient: 'is_self_adjoint.has_eigenvector_of_is_local_extr_on'
     Fréchet-Riesz representation of the dual of a Hilbert space: 'inner_product_space.to_dual'
 
   Differentiability:

--- a/docs/undergrad.yaml
+++ b/docs/undergrad.yaml
@@ -225,7 +225,7 @@ Bilinear and Quadratic Forms Over a Vector Space:
     special unitary group:
     self-adjoint endomorphism: 'is_self_adjoint'
     normal endomorphism:
-    diagonalization of a self-adjoint endomorphism: `is_self_adjoint.diagonalization_basis_apply_self_apply`
+    diagonalization of a self-adjoint endomorphism: 'is_self_adjoint.diagonalization_basis_apply_self_apply'
     diagonalization of normal endomorphisms:
     simultaneous diagonalization of two real quadratic forms, with one positive-definite:
     decomposition of an orthogonal transformation as a product of reflections:

--- a/docs/undergrad.yaml
+++ b/docs/undergrad.yaml
@@ -223,9 +223,9 @@ Bilinear and Quadratic Forms Over a Vector Space:
     unitary group:
     special orthogonal group:
     special unitary group:
-    self-adjoint endomorphism: 'bilin_form.is_self_adjoint'
+    self-adjoint endomorphism: 'is_self_adjoint'
     normal endomorphism:
-    diagonalization of a self-adjoint endomorphism:
+    diagonalization of a self-adjoint endomorphism: `is_self_adjoint.diagonalization_basis_apply_self_apply`
     diagonalization of normal endomorphisms:
     simultaneous diagonalization of two real quadratic forms, with one positive-definite:
     decomposition of an orthogonal transformation as a product of reflections:

--- a/src/analysis/inner_product_space/pi_L2.lean
+++ b/src/analysis/inner_product_space/pi_L2.lean
@@ -172,9 +172,7 @@ end
 @[simp] lemma basis.isometry_euclidean_of_orthonormal_symm_apply
   (v : basis ι 𝕜 E) (hv : orthonormal 𝕜 v) (w : euclidean_space 𝕜 ι) :
   (v.isometry_euclidean_of_orthonormal hv).symm w = ∑ i, (w i) • v i :=
-begin
-  sorry
-end
+v.equiv_fun_symm_apply w
 
 end
 

--- a/src/analysis/inner_product_space/pi_L2.lean
+++ b/src/analysis/inner_product_space/pi_L2.lean
@@ -169,6 +169,13 @@ begin
   { rw [← v.equiv_fun.symm_apply_apply y, v.equiv_fun_symm_apply] }
 end
 
+@[simp] lemma basis.isometry_euclidean_of_orthonormal_symm_apply
+  (v : basis ι 𝕜 E) (hv : orthonormal 𝕜 v) (w : euclidean_space 𝕜 ι) :
+  (v.isometry_euclidean_of_orthonormal hv).symm w = ∑ i, (w i) • v i :=
+begin
+  sorry
+end
+
 end
 
 /-- `ℂ` is isometric to `ℝ²` with the Euclidean inner product. -/

--- a/src/analysis/inner_product_space/pi_L2.lean
+++ b/src/analysis/inner_product_space/pi_L2.lean
@@ -169,10 +169,15 @@ begin
   { rw [← v.equiv_fun.symm_apply_apply y, v.equiv_fun_symm_apply] }
 end
 
-@[simp] lemma basis.isometry_euclidean_of_orthonormal_symm_apply
-  (v : basis ι 𝕜 E) (hv : orthonormal 𝕜 v) (w : euclidean_space 𝕜 ι) :
-  (v.isometry_euclidean_of_orthonormal hv).symm w = ∑ i, (w i) • v i :=
-v.equiv_fun_symm_apply w
+@[simp] lemma basis.coe_isometry_euclidean_of_orthonormal
+  (v : basis ι 𝕜 E) (hv : orthonormal 𝕜 v) :
+  (v.isometry_euclidean_of_orthonormal hv : E → euclidean_space 𝕜 ι) = v.equiv_fun :=
+rfl
+
+@[simp] lemma basis.coe_isometry_euclidean_of_orthonormal_symm
+  (v : basis ι 𝕜 E) (hv : orthonormal 𝕜 v) :
+  ((v.isometry_euclidean_of_orthonormal hv).symm : euclidean_space 𝕜 ι → E) = v.equiv_fun.symm :=
+rfl
 
 end
 

--- a/src/analysis/inner_product_space/spectrum.lean
+++ b/src/analysis/inner_product_space/spectrum.lean
@@ -17,12 +17,20 @@ compactness of the operator or finite-dimensionality of the underlying space, no
 * `is_self_adjoint.orthogonal_supr_eigenspaces`: the restriction of the operator to the mutual
   orthogonal complement of the eigenspaces has, itself, no eigenvectors
 
-The second part of the file covers properties of self-adjoint operators in finite dimension.  The
-definition `is_self_adjoint.diagonalization` provides a linear isometry equivalence from a space
-`E` to the direct sum of the eigenspaces of a self-adjoint operator `T` on `E`.  The theorem
-`is_self_adjoint.diagonalization_apply_self_apply` states that, when `T` is transferred via this
-equivalence to an operator on the direct sum, it acts diagonally.  This is the *diagonalization
-theorem* for self-adjoint operators on finite-dimensional inner product spaces.
+The second part of the file covers properties of self-adjoint operators in finite dimension.
+Letting `T` be a self-adjoint operator on a finite-dimensional inner product space `T`,
+* The definition `is_self_adjoint.diagonalization` provides a linear isometry equivalence `E` to
+  the direct sum of the eigenspaces of `T`.  The theorem
+  `is_self_adjoint.diagonalization_apply_self_apply` states that, when `T` is transferred via this
+  equivalence to an operator on the direct sum, it acts diagonally.
+* The definition `is_self_adjoint.eigenvector_basis` provides an orthonormal basis for `E`
+  consisting of eigenvectors of `T`, with `is_self_adjoint.eigenvalues` giving the correspoinding
+  list of eigenvalues, as real numbers.  The definition `is_self_adjoint.diagonalization_basis`
+  gives the associated linear isometry equivalence from `E` to Euclidean space, and the theorem
+  `is_self_adjoint.diagonalization_basis_apply_self_apply` states that, when `T` is transferred via
+  this equivalence to an operator on Euclidean space, it acts diagonally.
+These are forms of the *diagonalization theorem* for self-adjoint operators on finite-dimensional
+inner product spaces.
 
 ## TODO
 
@@ -128,6 +136,8 @@ lemma direct_sum_submodule_is_internal :
 hT.orthogonal_family_eigenspaces'.submodule_is_internal_iff.mpr
   hT.orthogonal_supr_eigenspaces_eq_bot'
 
+section version1
+
 /-- Isometry from an inner product space `E` to the direct sum of the eigenspaces of some
 self-adjoint operator `T` on `E`. -/
 noncomputable def diagonalization : E ≃ₗᵢ[𝕜] pi_Lp 2 (λ μ : eigenvalues T, eigenspace T μ) :=
@@ -139,7 +149,7 @@ hT.direct_sum_submodule_is_internal.isometry_L2_of_orthogonal_family
 hT.direct_sum_submodule_is_internal.isometry_L2_of_orthogonal_family_symm_apply
   hT.orthogonal_family_eigenspaces' w
 
-/-- *Diagonalization theorem*, *spectral theorem*: A self-adjoint operator `T` on a
+/-- *Diagonalization theorem*, *spectral theorem*; version 1: A self-adjoint operator `T` on a
 finite-dimensional inner product space `E` acts diagonally on the decomposition of `E` into the
 direct sum of the eigenspaces of `T`. -/
 lemma diagonalization_apply_self_apply (v : E) (μ : eigenvalues T) :
@@ -156,33 +166,78 @@ begin
   simp [hwT],
 end
 
-/-- An isometry from an inner product space `E` to Euclidean space, induced by a choice of
-orthonormal basis of eigenvectors for a self-adjoint operator `T` on `E`. -/
-noncomputable def diagonalization_basis {n : ℕ} (hn : finite_dimensional.finrank 𝕜 E = n) :
-  E ≃ₗᵢ[𝕜] euclidean_space 𝕜 (fin n) :=
-basis.isometry_euclidean_of_orthonormal
-  (hT.direct_sum_submodule_is_internal.subordinate_orthonormal_basis hn)
-  (hT.direct_sum_submodule_is_internal.subordinate_orthonormal_basis_orthonormal hn
-    hT.orthogonal_family_eigenspaces')
+end version1
 
-/-- An isometry from an inner product space `E` to Euclidean space, induced by a choice of
-orthonormal basis of eigenvectors for a self-adjoint operator `T` on `E`. -/
-noncomputable def eigenvalues_diagonalization_basis {n : ℕ}
-  (hn : finite_dimensional.finrank 𝕜 E = n) (i : fin n) :
-  ℝ :=
-@is_R_or_C.re 𝕜 _ $
-  (hT.direct_sum_submodule_is_internal.subordinate_orthonormal_basis_index hn) i
+section version2
+variables {n : ℕ} (hn : finite_dimensional.finrank 𝕜 E = n)
 
-lemma foo {n : ℕ}
-  (hn : finite_dimensional.finrank 𝕜 E = n) (i : fin n) :
-  (hT.diagonalization_basis hn).symm (λ j, ite (j = i) 1 0)
-  ∈ eigenspace T (hT.eigenvalues_diagonalization_basis hn i) :=
+/-- A choice of orthonormal basis of eigenvectors for self-adjoint operator `T` on a
+finite-dimensional inner product space `E`.
+
+TODO Postcompose with a permutation so that these eigenvectors are listed in increasing order of
+eigenvalue. -/
+noncomputable def eigenvector_basis : basis (fin n) 𝕜 E :=
+hT.direct_sum_submodule_is_internal.subordinate_orthonormal_basis hn
+
+lemma eigenvector_basis_orthonormal : orthonormal 𝕜 (hT.eigenvector_basis hn) :=
+hT.direct_sum_submodule_is_internal.subordinate_orthonormal_basis_orthonormal hn
+  hT.orthogonal_family_eigenspaces'
+
+/-- The sequence of real eigenvalues associated to the standard orthonormal basis of eigenvectors
+for a self-adjoint operator `T` on `E`.
+
+TODO Postcompose with a permutation so that these eigenvalues are listed in increasing order. -/
+noncomputable def eigenvalues (i : fin n) : ℝ :=
+@is_R_or_C.re 𝕜 _ $ hT.direct_sum_submodule_is_internal.subordinate_orthonormal_basis_index hn i
+
+lemma has_eigenvector_eigenvector_basis (i : fin n) :
+  has_eigenvector T (hT.eigenvalues hn i) (hT.eigenvector_basis hn i) :=
 begin
-  convert hT.direct_sum_submodule_is_internal.subordinate_orthonormal_basis_subordinate hn i,
-  { simp [diagonalization_basis, ite_smul, finset.sum_ite_eq] },
-  { simp [eigenvalues_diagonalization_basis, ite_smul, finset.sum_ite_eq],
-    -- ok since real
-   },
+  let v : E := hT.eigenvector_basis hn i,
+  let μ : 𝕜 := hT.direct_sum_submodule_is_internal.subordinate_orthonormal_basis_index hn i,
+  change has_eigenvector T (is_R_or_C.re μ) v,
+  have key : has_eigenvector T μ v,
+  { have H₁ : v ∈ eigenspace T μ,
+    { exact hT.direct_sum_submodule_is_internal.subordinate_orthonormal_basis_subordinate hn i },
+    have H₂ : v ≠ 0 := (hT.eigenvector_basis_orthonormal hn).ne_zero i,
+    exact ⟨H₁, H₂⟩ },
+  have re_μ : ↑(is_R_or_C.re μ) = μ,
+  { rw ← is_R_or_C.eq_conj_iff_re,
+    exact hT.conj_eigenvalue_eq_self (has_eigenvalue_of_has_eigenvector key) },
+  simpa [re_μ] using key,
 end
+
+attribute [irreducible] eigenvector_basis eigenvalues
+
+@[simp] lemma apply_eigenvector_basis (i : fin n) :
+  T (hT.eigenvector_basis hn i) = (hT.eigenvalues hn i : 𝕜) • (hT.eigenvector_basis hn i) :=
+mem_eigenspace_iff.mp (hT.has_eigenvector_eigenvector_basis hn i).1
+
+/-- An isometry from an inner product space `E` to Euclidean space, induced by a choice of
+orthonormal basis of eigenvectors for a self-adjoint operator `T` on `E`. -/
+noncomputable def diagonalization_basis : E ≃ₗᵢ[𝕜] euclidean_space 𝕜 (fin n) :=
+(hT.eigenvector_basis hn).isometry_euclidean_of_orthonormal (hT.eigenvector_basis_orthonormal hn)
+
+@[simp] lemma diagonalization_basis_symm_apply (w : euclidean_space 𝕜 (fin n)) :
+  (hT.diagonalization_basis hn).symm w = ∑ i, w i • hT.eigenvector_basis hn i :=
+(hT.eigenvector_basis hn).isometry_euclidean_of_orthonormal_symm_apply
+  (hT.eigenvector_basis_orthonormal hn) w
+
+/-- *Diagonalization theorem*, *spectral theorem*; version 1: A self-adjoint operator `T` on a
+finite-dimensional inner product space `E` acts diagonally on the identification of `E` with
+Euclidean space induced by an orthonormal basis of eigenvectors of `T`. -/
+lemma diagonalization_basis_apply_self_apply (v : E) (i : fin n) :
+  hT.diagonalization_basis hn (T v) i = hT.eigenvalues hn i * hT.diagonalization_basis hn v i :=
+begin
+  suffices : ∀ w : euclidean_space 𝕜 (fin n),
+    T ((hT.diagonalization_basis hn).symm w)
+    = (hT.diagonalization_basis hn).symm (λ i, hT.eigenvalues hn i * w i),
+  { simpa [-diagonalization_basis_symm_apply] using
+      congr_arg (λ v, hT.diagonalization_basis hn v i) (this (hT.diagonalization_basis hn v)) },
+  intros w,
+  simp [mul_comm, mul_smul],
+end
+
+end version2
 
 end is_self_adjoint

--- a/src/analysis/inner_product_space/spectrum.lean
+++ b/src/analysis/inner_product_space/spectrum.lean
@@ -24,7 +24,7 @@ Letting `T` be a self-adjoint operator on a finite-dimensional inner product spa
   `is_self_adjoint.diagonalization_apply_self_apply` states that, when `T` is transferred via this
   equivalence to an operator on the direct sum, it acts diagonally.
 * The definition `is_self_adjoint.eigenvector_basis` provides an orthonormal basis for `E`
-  consisting of eigenvectors of `T`, with `is_self_adjoint.eigenvalues` giving the correspoinding
+  consisting of eigenvectors of `T`, with `is_self_adjoint.eigenvalues` giving the corresponding
   list of eigenvalues, as real numbers.  The definition `is_self_adjoint.diagonalization_basis`
   gives the associated linear isometry equivalence from `E` to Euclidean space, and the theorem
   `is_self_adjoint.diagonalization_basis_apply_self_apply` states that, when `T` is transferred via
@@ -223,7 +223,7 @@ noncomputable def diagonalization_basis : E ≃ₗᵢ[𝕜] euclidean_space 𝕜
 (hT.eigenvector_basis hn).isometry_euclidean_of_orthonormal_symm_apply
   (hT.eigenvector_basis_orthonormal hn) w
 
-/-- *Diagonalization theorem*, *spectral theorem*; version 1: A self-adjoint operator `T` on a
+/-- *Diagonalization theorem*, *spectral theorem*; version 2: A self-adjoint operator `T` on a
 finite-dimensional inner product space `E` acts diagonally on the identification of `E` with
 Euclidean space induced by an orthonormal basis of eigenvectors of `T`. -/
 lemma diagonalization_basis_apply_self_apply (v : E) (i : fin n) :

--- a/src/analysis/inner_product_space/spectrum.lean
+++ b/src/analysis/inner_product_space/spectrum.lean
@@ -220,8 +220,7 @@ noncomputable def diagonalization_basis : E ≃ₗᵢ[𝕜] euclidean_space 𝕜
 
 @[simp] lemma diagonalization_basis_symm_apply (w : euclidean_space 𝕜 (fin n)) :
   (hT.diagonalization_basis hn).symm w = ∑ i, w i • hT.eigenvector_basis hn i :=
-(hT.eigenvector_basis hn).isometry_euclidean_of_orthonormal_symm_apply
-  (hT.eigenvector_basis_orthonormal hn) w
+by simp [diagonalization_basis]
 
 /-- *Diagonalization theorem*, *spectral theorem*; version 2: A self-adjoint operator `T` on a
 finite-dimensional inner product space `E` acts diagonally on the identification of `E` with

--- a/src/analysis/inner_product_space/spectrum.lean
+++ b/src/analysis/inner_product_space/spectrum.lean
@@ -156,4 +156,33 @@ begin
   simp [hwT],
 end
 
+/-- An isometry from an inner product space `E` to Euclidean space, induced by a choice of
+orthonormal basis of eigenvectors for a self-adjoint operator `T` on `E`. -/
+noncomputable def diagonalization_basis {n : ℕ} (hn : finite_dimensional.finrank 𝕜 E = n) :
+  E ≃ₗᵢ[𝕜] euclidean_space 𝕜 (fin n) :=
+basis.isometry_euclidean_of_orthonormal
+  (hT.direct_sum_submodule_is_internal.subordinate_orthonormal_basis hn)
+  (hT.direct_sum_submodule_is_internal.subordinate_orthonormal_basis_orthonormal hn
+    hT.orthogonal_family_eigenspaces')
+
+/-- An isometry from an inner product space `E` to Euclidean space, induced by a choice of
+orthonormal basis of eigenvectors for a self-adjoint operator `T` on `E`. -/
+noncomputable def eigenvalues_diagonalization_basis {n : ℕ}
+  (hn : finite_dimensional.finrank 𝕜 E = n) (i : fin n) :
+  ℝ :=
+@is_R_or_C.re 𝕜 _ $
+  (hT.direct_sum_submodule_is_internal.subordinate_orthonormal_basis_index hn) i
+
+lemma foo {n : ℕ}
+  (hn : finite_dimensional.finrank 𝕜 E = n) (i : fin n) :
+  (hT.diagonalization_basis hn).symm (λ j, ite (j = i) 1 0)
+  ∈ eigenspace T (hT.eigenvalues_diagonalization_basis hn i) :=
+begin
+  convert hT.direct_sum_submodule_is_internal.subordinate_orthonormal_basis_subordinate hn i,
+  { simp [diagonalization_basis, ite_smul, finset.sum_ite_eq] },
+  { simp [eigenvalues_diagonalization_basis, ite_smul, finset.sum_ite_eq],
+    -- ok since real
+   },
+end
+
 end is_self_adjoint

--- a/src/analysis/inner_product_space/spectrum.lean
+++ b/src/analysis/inner_product_space/spectrum.lean
@@ -210,7 +210,7 @@ end
 attribute [irreducible] eigenvector_basis eigenvalues
 
 @[simp] lemma apply_eigenvector_basis (i : fin n) :
-  T (hT.eigenvector_basis hn i) = (hT.eigenvalues hn i : 𝕜) • (hT.eigenvector_basis hn i) :=
+  T (hT.eigenvector_basis hn i) = (hT.eigenvalues hn i : 𝕜) • hT.eigenvector_basis hn i :=
 mem_eigenspace_iff.mp (hT.has_eigenvector_eigenvector_basis hn i).1
 
 /-- An isometry from an inner product space `E` to Euclidean space, induced by a choice of


### PR DESCRIPTION
This is a second version of the diagonalization theorem for self-adjoint operators on finite-dimensional inner product spaces, stating that a self-adjoint operator admits an orthonormal basis of eigenvectors, and deducing the standard consequences (when expressed with respect to this basis the operator acts diagonally).

I have also updated `undergrad.yaml` and `overview.yaml` to cover the diagonalization theorem and other things proved in the library about Hilbert spaces.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
