### PR TITLE
[Merged by Bors] - feat(linear_algebra/affine_space/barycentric_coords): barycentric coordinates are ratio of determinants

### DIFF
--- a/src/analysis/convex/combination.lean
+++ b/src/analysis/convex/combination.lean
@@ -410,24 +410,24 @@ lemma mem_Icc_of_mem_std_simplex (hf : f ∈ std_simplex R ι) (x) :
 
 /-- The convex hull of an affine basis is the intersection of the half-spaces defined by the
 corresponding barycentric coordinates. -/
-lemma convex_hull_affine_basis_eq_nonneg_barycentric {ι : Type*}
-  {p : ι → E} (h_ind : affine_independent R p) (h_tot : affine_span R (range p) = ⊤) :
-  convex_hull R (range p) = { x | ∀ i, 0 ≤ barycentric_coord h_ind h_tot i x } :=
+lemma convex_hull_affine_basis_eq_nonneg_barycentric {ι : Type*} (b : affine_basis ι R E) :
+  convex_hull R (range b.points) = { x | ∀ i, 0 ≤ b.coord i x } :=
 begin
   rw convex_hull_range_eq_exists_affine_combination,
   ext x,
   split,
   { rintros ⟨s, w, hw₀, hw₁, rfl⟩ i,
     by_cases hi : i ∈ s,
-    { rw barycentric_coord_apply_combination_of_mem h_ind h_tot hi hw₁,
+    { rw b.coord_apply_combination_of_mem hi hw₁,
       exact hw₀ i hi, },
-    { rw barycentric_coord_apply_combination_of_not_mem h_ind h_tot hi hw₁, }, },
+    { rw b.coord_apply_combination_of_not_mem hi hw₁, }, },
   { intros hx,
-    have hx' : x ∈ affine_span R (range p), { rw h_tot, exact affine_subspace.mem_top R E x, },
+    have hx' : x ∈ affine_span R (range b.points),
+    { rw b.tot, exact affine_subspace.mem_top R E x, },
     obtain ⟨s, w, hw₁, rfl⟩ := (mem_affine_span_iff_eq_affine_combination R E).mp hx',
     refine ⟨s, w, _, hw₁, rfl⟩,
     intros i hi,
     specialize hx i,
-    rw barycentric_coord_apply_combination_of_mem h_ind h_tot hi hw₁ at hx,
+    rw b.coord_apply_combination_of_mem hi hw₁ at hx,
     exact hx, },
 end

--- a/src/analysis/normed_space/add_torsor_bases.lean
+++ b/src/analysis/normed_space/add_torsor_bases.lean
@@ -28,19 +28,17 @@ section barycentric
 variables {ι 𝕜 E P : Type*} [nondiscrete_normed_field 𝕜] [complete_space 𝕜]
 variables [normed_group E] [normed_space 𝕜 E] [finite_dimensional 𝕜 E]
 variables [metric_space P] [normed_add_torsor E P]
-variables {p : ι → P} (h_ind : affine_independent 𝕜 p) (h_tot : affine_span 𝕜 (set.range p) = ⊤)
+variables (b : affine_basis ι 𝕜 P)
 
 @[continuity]
-lemma continuous_barycentric_coord (i : ι) : continuous (barycentric_coord h_ind h_tot i) :=
+lemma continuous_barycentric_coord (i : ι) : continuous (b.coord i) :=
 affine_map.continuous_of_finite_dimensional _
 
 local attribute [instance] finite_dimensional.complete
 
 lemma is_open_map_barycentric_coord [nontrivial ι] (i : ι) :
-  is_open_map (barycentric_coord h_ind h_tot i) :=
-open_mapping_affine
-  (continuous_barycentric_coord h_ind h_tot i)
-  (surjective_barycentric_coord h_ind h_tot i)
+  is_open_map (b.coord i) :=
+open_mapping_affine (continuous_barycentric_coord b i) (b.surjective_coord i)
 
 end barycentric
 
@@ -53,27 +51,26 @@ to this basis.
 TODO Restate this result for affine spaces (instead of vector spaces) once the definition of
 convexity is generalised to this setting. -/
 lemma interior_convex_hull_aff_basis {ι E : Type*} [fintype ι] [normed_group E] [normed_space ℝ E]
-  {p : ι → E} (h_ind : affine_independent ℝ p) (h_tot : affine_span ℝ (range p) = ⊤) :
-  interior (convex_hull ℝ (range p)) = { x | ∀ i, 0 < barycentric_coord h_ind h_tot i x } :=
+  (b : affine_basis ι ℝ E) :
+  interior (convex_hull ℝ (range b.points)) = { x | ∀ i, 0 < b.coord i x } :=
 begin
   cases subsingleton_or_nontrivial ι with h h,
   { -- The zero-dimensional case.
     haveI := h,
-    suffices : range p = univ, { simp [this], },
-    refine affine_subspace.eq_univ_of_subsingleton_span_eq_top _ h_tot,
+    suffices : range (b.points) = univ, { simp [this], },
+    refine affine_subspace.eq_univ_of_subsingleton_span_eq_top _ b.tot,
     rw ← image_univ,
-    exact subsingleton.image subsingleton_of_subsingleton p, },
+    exact subsingleton.image subsingleton_of_subsingleton b.points, },
   { -- The positive-dimensional case.
     haveI : finite_dimensional ℝ E,
     { classical,
       obtain ⟨i⟩ := (infer_instance : nonempty ι),
-      have b := basis_of_aff_ind_span_eq_top h_ind h_tot i,
-      exact finite_dimensional.of_fintype_basis b, },
-    have : convex_hull ℝ (range p) = ⋂ i, (barycentric_coord h_ind h_tot i)⁻¹' Ici 0,
-    { rw convex_hull_affine_basis_eq_nonneg_barycentric h_ind h_tot, ext, simp, },
+      exact finite_dimensional.of_fintype_basis (b.basis_of i), },
+    have : convex_hull ℝ (range b.points) = ⋂ i, (b.coord i)⁻¹' Ici 0,
+    { rw convex_hull_affine_basis_eq_nonneg_barycentric b, ext, simp, },
     ext,
     simp only [this, interior_Inter_of_fintype, ← is_open_map.preimage_interior_eq_interior_preimage
-      (continuous_barycentric_coord h_ind h_tot _) (is_open_map_barycentric_coord h_ind h_tot _),
+      (continuous_barycentric_coord b _) (is_open_map_barycentric_coord b _),
       interior_Ici, mem_Inter, mem_set_of_eq, mem_Ioi, mem_preimage], },
 end
 
@@ -140,17 +137,17 @@ begin
     obtain ⟨t, hts, h_tot, h_ind⟩ := exists_affine_independent ℝ V s,
     suffices : (interior (convex_hull ℝ (range (coe : t → V)))).nonempty,
     { rw [subtype.range_coe_subtype, set_of_mem_eq] at this,
-      apply nonempty.mono _ this, 
+      apply nonempty.mono _ this,
       mono* },
     haveI : fintype t := fintype_of_fin_dim_affine_independent ℝ h_ind,
     use finset.centroid ℝ (finset.univ : finset t) (coe : t → V),
     rw [h, ← @set_of_mem_eq V t, ← subtype.range_coe_subtype] at h_tot,
-    rw interior_convex_hull_aff_basis h_ind h_tot,
+    let b : affine_basis t ℝ V := ⟨coe, h_ind, h_tot⟩,
+    rw interior_convex_hull_aff_basis b,
     have htne : (finset.univ : finset t).nonempty,
     { simpa [finset.univ_nonempty_iff] using
         affine_subspace.nonempty_of_affine_span_eq_top ℝ V V h_tot, },
-    simp [finset.centroid_def,
-      barycentric_coord_apply_combination_of_mem h_ind h_tot (finset.mem_univ _)
+    simp [finset.centroid_def, b.coord_apply_combination_of_mem (finset.mem_univ _)
       (finset.sum_centroid_weights_eq_one_of_nonempty ℝ (finset.univ : finset t) htne),
       finset.centroid_weights_apply, nat.cast_pos, inv_pos, finset.card_pos.mpr htne], },
 end

--- a/src/linear_algebra/affine_space/barycentric_coords.lean
+++ b/src/linear_algebra/affine_space/barycentric_coords.lean
@@ -227,7 +227,6 @@ lemma to_matrix_mul_to_matrix :
   (b.to_matrix b₂.points) ⬝ (b₂.to_matrix b.points) = 1 :=
 begin
   ext l m,
-  unfold matrix.mul matrix.dot_product,
   change (b₂.to_matrix b.points).vec_mul (b.coords (b₂.points l)) m = _,
   rw [to_matrix_vec_mul_coords, coords_apply, ← to_matrix_apply, to_matrix_self],
 end

--- a/src/linear_algebra/affine_space/barycentric_coords.lean
+++ b/src/linear_algebra/affine_space/barycentric_coords.lean
@@ -258,8 +258,8 @@ begin
     matrix.vec_mul_one],
 end
 
-/-- If we fix a background affine basis `p`, then for any other basis `q`, we can characterise
-the barycentric coordinates provided by `q` in terms of determinants relative to `p`. -/
+/-- If we fix a background affine basis `b`, then for any other basis `b₂`, we can characterise
+the barycentric coordinates provided by `b₂` in terms of determinants relative to `b`. -/
 lemma det_smul_coords_eq_cramer_coords (x : P) :
   (b.to_matrix b₂.points).det • b₂.coords x = (b.to_matrix b₂.points)ᵀ.cramer (b.coords x) :=
 begin

--- a/src/linear_algebra/affine_space/barycentric_coords.lean
+++ b/src/linear_algebra/affine_space/barycentric_coords.lean
@@ -7,7 +7,7 @@ import linear_algebra.affine_space.independent
 import linear_algebra.determinant
 
 /-!
-# Barycentric coordinates
+# Affine bases and barycentric coordinates
 
 Suppose `P` is an affine space modelled on the module `V` over the ring `k`, and `p : ι → P` is an
 affine-independent family of points spanning `P`. Given this data, each point `q : P` may be written
@@ -24,133 +24,150 @@ barycentric coordinate of `q : P` is `1 - fᵢ (q -ᵥ p i)`.
 
 ## Main definitions
 
- * `barycentric_coord`: the map `P →ᵃ[k] k` corresponding to `i : ι`.
- * `barycentric_coord_apply_eq`: the behaviour of `barycentric_coord i` on `p i`.
- * `barycentric_coord_apply_neq`: the behaviour of `barycentric_coord i` on `p j` when `j ≠ i`.
- * `barycentric_coord_apply`: the behaviour of `barycentric_coord i` on `p j` for general `j`.
- * `barycentric_coord_apply_combination`: the characterisation of `barycentric_coord i` in terms
-    of affine combinations, i.e., `barycentric_coord i (w₀ p₀ + w₁ p₁ + ⋯) = wᵢ`.
+ * `affine_basis`: a structure representing an affine basis of an affine space.
+ * `affine_basis.coord`: the map `P →ᵃ[k] k` corresponding to `i : ι`.
+ * `affine_basis.coord_apply_eq`: the behaviour of `affine_basis.coord i` on `p i`.
+ * `affine_basis.coord_apply_neq`: the behaviour of `affine_basis.coord i` on `p j` when `j ≠ i`.
+ * `affine_basis.coord_apply`: the behaviour of `affine_basis.coord i` on `p j` for general `j`.
+ * `affine_basis.coord_apply_combination`: the characterisation of `affine_basis.coord i` in terms
+    of affine combinations, i.e., `affine_basis.coord i (w₀ p₀ + w₁ p₁ + ⋯) = wᵢ`.
 
 ## TODO
 
  * Construct the affine equivalence between `P` and `{ f : ι →₀ k | f.sum = 1 }`.
 
+ * Consider redefining an affine basis as an `affine_equiv` to a `finsupp` (in the general case) or
+   function type (in the finite-dimensional case) with appropriate proofs of existence when `k` is
+   a field.
+
 -/
 
-open_locale affine big_operators
+open_locale affine big_operators matrix
 open set
 
 universes u₁ u₂ u₃ u₄
 
+/-- An affine basis is a family of affine-independent points whose span is the top subspace. -/
+structure affine_basis (ι : Type u₁) (k : Type u₂) {V : Type u₃} (P : Type u₄)
+  [add_comm_group V] [affine_space V P] [ring k] [module k V] :=
+(points : ι → P)
+(ind : affine_independent k points)
+(tot : affine_span k (range points) = ⊤)
+
 variables {ι : Type u₁} {k : Type u₂} {V : Type u₃} {P : Type u₄}
 variables [add_comm_group V] [affine_space V P]
 
+namespace affine_basis
+
 section ring
 
-variables [ring k] [module k V]
-variables {p : ι → P} (h_ind : affine_independent k p) (h_tot : affine_span k (range p) = ⊤)
-include V h_ind h_tot
+variables [ring k] [module k V] (b : affine_basis ι k P)
 
-/-- Given an affine-independent family of points spanning the point space `P`, if we single out one
-member of the family, we obtain a basis for the model space `V`.
+/-- The unique point in a single-point space is the simplest example of an affine basis. -/
+instance : inhabited (affine_basis punit k punit) :=
+⟨{ points := id,
+   ind    := affine_independent_of_subsingleton k id,
+   tot    := by simp }⟩
 
-The basis correpsonding to the singled-out member `i : ι` is indexed by `{j : ι // j ≠ i}` and its
-`j`th element is `p j -ᵥ p i`. (See `basis_of_aff_ind_span_eq_top_apply`.) -/
-noncomputable def basis_of_aff_ind_span_eq_top (i : ι) : basis {j : ι // j ≠ i} k V :=
-basis.mk ((affine_independent_iff_linear_independent_vsub k p i).mp h_ind)
+/-- Given an affine basis for an affine space `P`, if we single out one member of the family, we
+obtain a linear basis for the model space `V`.
+
+The linear basis correpsonding to the singled-out member `i : ι` is indexed by `{j : ι // j ≠ i}`
+and its `j`th element is `points j -ᵥ points i`. (See `basis_of_apply`.) -/
+noncomputable def basis_of (i : ι) : basis {j : ι // j ≠ i} k V :=
+basis.mk ((affine_independent_iff_linear_independent_vsub k b.points i).mp b.ind)
 begin
-  suffices : submodule.span k (range (λ (j : {x // x ≠ i}), p ↑j -ᵥ p i)) = vector_span k (range p),
-  { rw [this, ← direction_affine_span, h_tot, affine_subspace.direction_top], },
+  suffices : submodule.span k (range (λ (j : {x // x ≠ i}), b.points ↑j -ᵥ b.points i)) =
+             vector_span k (range b.points),
+  { rw [this, ← direction_affine_span, b.tot, affine_subspace.direction_top], },
   conv_rhs { rw ← image_univ, },
-  rw vector_span_image_eq_span_vsub_set_right_ne k p (mem_univ i),
+  rw vector_span_image_eq_span_vsub_set_right_ne k b.points (mem_univ i),
   congr,
   ext v,
   simp,
 end
 
-local notation `basis_of` := basis_of_aff_ind_span_eq_top h_ind h_tot
-
-@[simp] lemma basis_of_aff_ind_span_eq_top_apply (i : ι) (j : {j : ι // j ≠ i}) :
-  basis_of i j = p ↑j -ᵥ p i :=
-by simp [basis_of_aff_ind_span_eq_top]
+@[simp] lemma basis_of_apply (i : ι) (j : {j : ι // j ≠ i}) :
+  b.basis_of i j = b.points ↑j -ᵥ b.points i :=
+by simp [basis_of]
 
 /-- The `i`th barycentric coordinate of a point. -/
-noncomputable def barycentric_coord (i : ι) : P →ᵃ[k] k :=
-{ to_fun    := λ q, 1 - (basis_of i).sum_coords (q -ᵥ p i),
-  linear    := -(basis_of i).sum_coords,
+noncomputable def coord (i : ι) : P →ᵃ[k] k :=
+{ to_fun    := λ q, 1 - (b.basis_of i).sum_coords (q -ᵥ b.points i),
+  linear    := -(b.basis_of i).sum_coords,
   map_vadd' := λ q v, by rw [vadd_vsub_assoc, linear_map.map_add, vadd_eq_add, linear_map.neg_apply,
     sub_add_eq_sub_sub_swap, add_comm, sub_eq_add_neg], }
 
-@[simp] lemma barycentric_coord_apply_eq (i : ι) :
-  barycentric_coord h_ind h_tot i (p i) = 1 :=
-by simp only [barycentric_coord, basis.coe_sum_coords, linear_equiv.map_zero, linear_equiv.coe_coe,
+@[simp] lemma coord_apply_eq (i : ι) :
+  b.coord i (b.points i) = 1 :=
+by simp only [coord, basis.coe_sum_coords, linear_equiv.map_zero, linear_equiv.coe_coe,
   sub_zero, affine_map.coe_mk, finsupp.sum_zero_index, vsub_self]
 
-@[simp] lemma barycentric_coord_apply_neq (i j : ι) (h : j ≠ i) :
-  barycentric_coord h_ind h_tot i (p j) = 0 :=
-by rw [barycentric_coord, affine_map.coe_mk, ← subtype.coe_mk j h,
-  ← basis_of_aff_ind_span_eq_top_apply h_ind h_tot i ⟨j, h⟩, basis.sum_coords_self_apply, sub_self]
+@[simp] lemma coord_apply_neq (i j : ι) (h : j ≠ i) :
+  b.coord i (b.points j) = 0 :=
+by rw [coord, affine_map.coe_mk, ← subtype.coe_mk j h, ← b.basis_of_apply i ⟨j, h⟩,
+  basis.sum_coords_self_apply, sub_self]
 
-lemma barycentric_coord_apply [decidable_eq ι] (i j : ι) :
-  barycentric_coord h_ind h_tot i (p j) = if i = j then 1 else 0 :=
+lemma coord_apply [decidable_eq ι] (i j : ι) :
+  b.coord i (b.points j) = if i = j then 1 else 0 :=
 by { cases eq_or_ne i j; simp [h.symm], simp [h], }
 
-@[simp] lemma barycentric_coord_apply_combination_of_mem
+@[simp] lemma coord_apply_combination_of_mem
   {s : finset ι} {i : ι} (hi : i ∈ s) {w : ι → k} (hw : s.sum w = 1) :
-  barycentric_coord h_ind h_tot i (s.affine_combination p w) = w i :=
+  b.coord i (s.affine_combination b.points w) = w i :=
 begin
   classical,
-  simp only [barycentric_coord_apply, hi, finset.affine_combination_eq_linear_combination, if_true,
-    hw, mul_boole, function.comp_app, smul_eq_mul, s.sum_ite_eq, s.map_affine_combination p w hw],
+  simp only [coord_apply, hi, finset.affine_combination_eq_linear_combination, if_true, mul_boole,
+    hw, function.comp_app, smul_eq_mul, s.sum_ite_eq, s.map_affine_combination b.points w hw],
 end
 
-@[simp] lemma barycentric_coord_apply_combination_of_not_mem
+@[simp] lemma coord_apply_combination_of_not_mem
   {s : finset ι} {i : ι} (hi : i ∉ s) {w : ι → k} (hw : s.sum w = 1) :
-  barycentric_coord h_ind h_tot i (s.affine_combination p w) = 0 :=
+  b.coord i (s.affine_combination b.points w) = 0 :=
 begin
   classical,
-  simp only [barycentric_coord_apply, hi, finset.affine_combination_eq_linear_combination, if_false,
-    hw, mul_boole, function.comp_app, smul_eq_mul, s.sum_ite_eq, s.map_affine_combination p w hw],
+  simp only [coord_apply, hi, finset.affine_combination_eq_linear_combination, if_false, mul_boole,
+    hw, function.comp_app, smul_eq_mul, s.sum_ite_eq, s.map_affine_combination b.points w hw],
 end
 
-@[simp] lemma sum_barycentric_coord_apply_eq_one [fintype ι] (q : P) :
-  ∑ i, barycentric_coord h_ind h_tot i q = 1 :=
+@[simp] lemma sum_coord_apply_eq_one [fintype ι] (q : P) :
+  ∑ i, b.coord i q = 1 :=
 begin
-  have hq : q ∈ affine_span k (range p), { rw h_tot, exact affine_subspace.mem_top k V q, },
+  have hq : q ∈ affine_span k (range b.points), { rw b.tot, exact affine_subspace.mem_top k V q, },
   obtain ⟨w, hw, rfl⟩ := eq_affine_combination_of_mem_affine_span_of_fintype hq,
   convert hw,
   ext i,
-  exact barycentric_coord_apply_combination_of_mem h_ind h_tot (finset.mem_univ i) hw,
+  exact b.coord_apply_combination_of_mem (finset.mem_univ i) hw,
 end
 
-@[simp] lemma affine_combination_barycentric_coord_eq_self [fintype ι] (q : P) :
-  finset.univ.affine_combination p (λ i, barycentric_coord h_ind h_tot i q) = q :=
+@[simp] lemma affine_combination_coord_eq_self [fintype ι] (q : P) :
+  finset.univ.affine_combination b.points (λ i, b.coord i q) = q :=
 begin
-  have hq : q ∈ affine_span k (range p), { rw h_tot, exact affine_subspace.mem_top k V q, },
+  have hq : q ∈ affine_span k (range b.points), { rw b.tot, exact affine_subspace.mem_top k V q, },
   obtain ⟨w, hw, rfl⟩ := eq_affine_combination_of_mem_affine_span_of_fintype hq,
   congr,
   ext i,
-  exact barycentric_coord_apply_combination_of_mem h_ind h_tot (finset.mem_univ i) hw,
+  exact b.coord_apply_combination_of_mem (finset.mem_univ i) hw,
 end
 
-@[simp] lemma coe_barycentric_coord_of_subsingleton_eq_one [subsingleton ι] (i : ι) :
-  (barycentric_coord h_ind h_tot i : P → k) = 1 :=
+@[simp] lemma coe_coord_of_subsingleton_eq_one [subsingleton ι] (i : ι) :
+  (b.coord i : P → k) = 1 :=
 begin
   ext q,
-  have hp : (range p).subsingleton,
+  have hp : (range b.points).subsingleton,
   { rw ← image_univ,
     apply subsingleton.image,
     apply subsingleton_of_subsingleton, },
-  haveI := affine_subspace.subsingleton_of_subsingleton_span_eq_top hp h_tot,
+  haveI := affine_subspace.subsingleton_of_subsingleton_span_eq_top hp b.tot,
   let s : finset ι := {i},
   have hi : i ∈ s, { simp, },
   have hw : s.sum (function.const ι (1 : k)) = 1, { simp, },
-  have hq : q = s.affine_combination p (function.const ι (1 : k)), { simp, },
-  rw [pi.one_apply, hq, barycentric_coord_apply_combination_of_mem h_ind h_tot hi hw],
+  have hq : q = s.affine_combination b.points (function.const ι (1 : k)), { simp, },
+  rw [pi.one_apply, hq, b.coord_apply_combination_of_mem hi hw],
 end
 
-lemma surjective_barycentric_coord [nontrivial ι] (i : ι) :
-  function.surjective $ barycentric_coord h_ind h_tot i :=
+lemma surjective_coord [nontrivial ι] (i : ι) :
+  function.surjective $ b.coord i :=
 begin
   classical,
   intros x,
@@ -160,105 +177,97 @@ begin
   have hj : j ∈ s, { simp, },
   let w : ι → k := λ j', if j' = i then x else 1-x,
   have hw : s.sum w = 1, { simp [hij, finset.sum_ite, finset.filter_insert, finset.filter_eq'], },
-  use s.affine_combination p w,
-  simp [barycentric_coord_apply_combination_of_mem h_ind h_tot hi hw],
+  use s.affine_combination b.points w,
+  simp [b.coord_apply_combination_of_mem hi hw],
 end
 
 /-- The vector of barycentric coordinates of a given point with respect to an affine basis. -/
-noncomputable def barycentric_coords (q : P) (i : ι) := barycentric_coord h_ind h_tot i q
+noncomputable def coords (q : P) (i : ι) := b.coord i q
 
-lemma barycentric_coords_def (q : P) (i : ι) :
-  barycentric_coords h_ind h_tot q i = barycentric_coord h_ind h_tot i q :=
+@[simp] lemma coords_apply (q : P) (i : ι) :
+  b.coords q i = b.coord i q :=
 rfl
 
 /-- Given an affine basis `p`, and a family of points `q : ι' → P`, this is the matrix whose
 rows are the barycentric coordinates of `q` with respect to `p`.
 
 It is an affine equivalent of `basis.to_matrix`. -/
-noncomputable def affine_basis_to_matrix {ι' : Type*} (q : ι' → P) : matrix ι' ι k :=
-λ i j, barycentric_coord h_ind h_tot j (q i)
+noncomputable def to_matrix {ι' : Type*} (q : ι' → P) : matrix ι' ι k :=
+λ i j, b.coord j (q i)
 
-lemma affine_basis_to_matrix_def {ι' : Type*} (q : ι' → P) (i : ι') (j : ι):
-  affine_basis_to_matrix h_ind h_tot q i j = barycentric_coord h_ind h_tot j (q i) :=
+@[simp] lemma to_matrix_apply {ι' : Type*} (q : ι' → P) (i : ι') (j : ι) :
+  b.to_matrix q i j = b.coord j (q i) :=
 rfl
 
-@[simp] lemma affine_basis_to_matrix_self [decidable_eq ι] :
-  affine_basis_to_matrix h_ind h_tot p = (1 : matrix ι ι k) :=
+@[simp] lemma to_matrix_self [decidable_eq ι] :
+  b.to_matrix b.points = (1 : matrix ι ι k) :=
 begin
   ext i j,
-  rw [affine_basis_to_matrix_def, barycentric_coord_apply, matrix.one_eq_pi_single,
-    pi.single_apply],
+  rw [to_matrix_apply, coord_apply, matrix.one_eq_pi_single, pi.single_apply],
 end
 
-variables {q : ι → P} (hq_ind : affine_independent k q) (hq_tot : affine_span k (range q) = ⊤)
-local notation `coords` := barycentric_coords
-open_locale matrix
+variables [fintype ι] (b₂ : affine_basis ι k P)
 
 /-- A change of basis formula for barycentric coordinates.
 
-See also `affine_basis_to_matrix_inv_mul_affine_basis_to_matrix`. -/
-lemma affine_basis_to_matrix_vec_mul_coords [fintype ι] (x : P) :
-  (affine_basis_to_matrix h_ind h_tot q).vec_mul (coords hq_ind hq_tot x) =
-  coords h_ind h_tot x :=
+See also `affine_basis.to_matrix_inv_mul_affine_basis_to_matrix`. -/
+@[simp] lemma to_matrix_vec_mul_coords (x : P) :
+  (b.to_matrix b₂.points).vec_mul (b₂.coords x) = b.coords x :=
 begin
   ext j,
-  change _ = barycentric_coord h_ind h_tot j x,
-  conv_rhs { rw ← affine_combination_barycentric_coord_eq_self hq_ind hq_tot x, },
-  rw finset.map_affine_combination _ _ _ (sum_barycentric_coord_apply_eq_one hq_ind hq_tot x),
-  simp [matrix.vec_mul, matrix.dot_product, affine_basis_to_matrix, barycentric_coords],
+  change _ = b.coord j x,
+  conv_rhs { rw ← b₂.affine_combination_coord_eq_self x, },
+  rw finset.map_affine_combination _ _ _ (b₂.sum_coord_apply_eq_one x),
+  simp [matrix.vec_mul, matrix.dot_product, to_matrix_apply, coords],
 end
 
-lemma affine_basis_to_matrix_mul_affine_basis_to_matrix [decidable_eq ι] [fintype ι] :
-  (affine_basis_to_matrix h_ind h_tot q) ⬝ (affine_basis_to_matrix hq_ind hq_tot p) = 1 :=
+variables [decidable_eq ι]
+
+lemma to_matrix_mul_to_matrix :
+  (b.to_matrix b₂.points) ⬝ (b₂.to_matrix b.points) = 1 :=
 begin
   ext l m,
   unfold matrix.mul matrix.dot_product,
-  change (affine_basis_to_matrix hq_ind hq_tot p).vec_mul (barycentric_coords h_ind h_tot (q l)) m = _,
-  rw [affine_basis_to_matrix_vec_mul_coords, barycentric_coords_def, ← affine_basis_to_matrix_def,
-    affine_basis_to_matrix_self],
+  change (b₂.to_matrix b.points).vec_mul (b.coords (b₂.points l)) m = _,
+  rw [to_matrix_vec_mul_coords, coords_apply, ← to_matrix_apply, to_matrix_self],
 end
 
-lemma is_unit_affine_basis_to_matrix [decidable_eq ι] [fintype ι] :
-  is_unit (affine_basis_to_matrix h_ind h_tot q) :=
-⟨{ val     := affine_basis_to_matrix h_ind h_tot q,
-   inv     := affine_basis_to_matrix hq_ind hq_tot p,
-   val_inv := affine_basis_to_matrix_mul_affine_basis_to_matrix h_ind h_tot hq_ind hq_tot,
-   inv_val := affine_basis_to_matrix_mul_affine_basis_to_matrix hq_ind hq_tot h_ind h_tot, }, rfl⟩
+lemma is_unit_to_matrix :
+  is_unit (b.to_matrix b₂.points) :=
+⟨{ val     := b.to_matrix b₂.points,
+   inv     := b₂.to_matrix b.points,
+   val_inv := b.to_matrix_mul_to_matrix b₂,
+   inv_val := b₂.to_matrix_mul_to_matrix b, }, rfl⟩
 
 end ring
 
 section comm_ring
 
 variables [comm_ring k] [module k V] [decidable_eq ι] [fintype ι]
-variables {p : ι → P} (hp_ind : affine_independent k p) (hp_tot : affine_span k (range p) = ⊤)
-variables {q : ι → P} (hq_ind : affine_independent k q) (hq_tot : affine_span k (range q) = ⊤)
-
-local notation `M` := affine_basis_to_matrix hp_ind hp_tot
-local notation `coords` := barycentric_coords
-
-open_locale matrix
+variables (b b₂ : affine_basis ι k P)
 
 /-- A change of basis formula for barycentric coordinates.
 
-See also `affine_basis_to_matrix_vec_mul_coords`. -/
-lemma affine_basis_to_matrix_inv_mul_affine_basis_to_matrix (x : P) :
-  (affine_basis_to_matrix hp_ind hp_tot q)⁻¹.vec_mul (coords hp_ind hp_tot x) =
-  coords hq_ind hq_tot x :=
+See also `affine_basis.to_matrix_vec_mul_coords`. -/
+@[simp] lemma to_matrix_inv_vec_mul_to_matrix (x : P) :
+  (b.to_matrix b₂.points)⁻¹.vec_mul (b.coords x) = b₂.coords x :=
 begin
-  have hu := is_unit_affine_basis_to_matrix hp_ind hp_tot hq_ind hq_tot,
+  have hu := b.is_unit_to_matrix b₂,
   rw matrix.is_unit_iff_is_unit_det at hu,
-  simp [← affine_basis_to_matrix_vec_mul_coords hp_ind hp_tot hq_ind hq_tot, hu],
+  rw [← b.to_matrix_vec_mul_coords b₂, matrix.vec_mul_vec_mul, matrix.mul_nonsing_inv _ hu,
+    matrix.vec_mul_one],
 end
 
 /-- If we fix a background affine basis `p`, then for any other basis `q`, we can characterise
 the barycentric coordinates provided by `q` in terms of determinants relative to `p`. -/
-lemma det_barycentric_coords_eq_camer_coords (x : P) :
-  (M q).det • coords hq_ind hq_tot x = (M q)ᵀ.cramer (coords hp_ind hp_tot x) :=
+lemma det_smul_coords_eq_camer_coords (x : P) :
+  (b.to_matrix b₂.points).det • b₂.coords x = (b.to_matrix b₂.points)ᵀ.cramer (b.coords x) :=
 begin
-  have hu := is_unit_affine_basis_to_matrix hp_ind hp_tot hq_ind hq_tot,
+  have hu := b.is_unit_to_matrix b₂,
   rw matrix.is_unit_iff_is_unit_det at hu,
-  rw [← affine_basis_to_matrix_inv_mul_affine_basis_to_matrix hp_ind hp_tot hq_ind hq_tot x,
-    matrix.det_smul_inv_vec_mul_eq_cramer_transpose _ _ hu],
+  rw [← b.to_matrix_inv_vec_mul_to_matrix, matrix.det_smul_inv_vec_mul_eq_cramer_transpose _ _ hu],
 end
 
 end comm_ring
+
+end affine_basis

--- a/src/linear_algebra/affine_space/barycentric_coords.lean
+++ b/src/linear_algebra/affine_space/barycentric_coords.lean
@@ -36,10 +36,6 @@ barycentric coordinate of `q : P` is `1 - fᵢ (q -ᵥ p i)`.
 
  * Construct the affine equivalence between `P` and `{ f : ι →₀ k | f.sum = 1 }`.
 
- * Consider redefining an affine basis as an `affine_equiv` to a `finsupp` (in the general case) or
-   function type (in the finite-dimensional case) with appropriate proofs of existence when `k` is
-   a field.
-
 -/
 
 open_locale affine big_operators matrix

--- a/src/linear_algebra/affine_space/barycentric_coords.lean
+++ b/src/linear_algebra/affine_space/barycentric_coords.lean
@@ -260,7 +260,7 @@ end
 
 /-- If we fix a background affine basis `p`, then for any other basis `q`, we can characterise
 the barycentric coordinates provided by `q` in terms of determinants relative to `p`. -/
-lemma det_smul_coords_eq_camer_coords (x : P) :
+lemma det_smul_coords_eq_cramer_coords (x : P) :
   (b.to_matrix b₂.points).det • b₂.coords x = (b.to_matrix b₂.points)ᵀ.cramer (b.coords x) :=
 begin
   have hu := b.is_unit_to_matrix b₂,

--- a/src/linear_algebra/affine_space/basic.lean
+++ b/src/linear_algebra/affine_space/basic.lean
@@ -26,15 +26,8 @@ files:
 * `affine_subspace`: a subset of an affine space closed w.r.t. affine combinations of points;
 * `affine_combination`: an affine combination of points;
 * `affine_independent`: affine independent set of points;
-* `barycentric_coord`: the barycentric coordinate of a point.
+* `affine_basis.coord`: the barycentric coordinate of a point.
 
-## TODO
-
-Some key definitions are not yet present.
-
-* Affine frames.  An affine frame might perhaps be represented as an `affine_equiv` to a `finsupp`
-  (in the general case) or function type (in the finite-dimensional case) that gives the
-  coordinates, with appropriate proofs of existence when `k` is a field.
  -/
 
 localized "notation `affine_space` := add_torsor" in affine

--- a/src/linear_algebra/affine_space/basic.lean
+++ b/src/linear_algebra/affine_space/basic.lean
@@ -29,11 +29,12 @@ files:
 * `affine_basis.coord`: the barycentric coordinate of a point.
 
 ## TODO
+
 Some key definitions are not yet present.
+
 * Affine frames.  An affine frame might perhaps be represented as an `affine_equiv` to a `finsupp`
   (in the general case) or function type (in the finite-dimensional case) that gives the
   coordinates, with appropriate proofs of existence when `k` is a field.
-
  -/
 
 localized "notation `affine_space` := add_torsor" in affine

--- a/src/linear_algebra/affine_space/basic.lean
+++ b/src/linear_algebra/affine_space/basic.lean
@@ -28,6 +28,12 @@ files:
 * `affine_independent`: affine independent set of points;
 * `affine_basis.coord`: the barycentric coordinate of a point.
 
+## TODO
+Some key definitions are not yet present.
+* Affine frames.  An affine frame might perhaps be represented as an `affine_equiv` to a `finsupp`
+  (in the general case) or function type (in the finite-dimensional case) that gives the
+  coordinates, with appropriate proofs of existence when `k` is a field.
+
  -/
 
 localized "notation `affine_space` := add_torsor" in affine

--- a/src/linear_algebra/matrix/adjugate.lean
+++ b/src/linear_algebra/matrix/adjugate.lean
@@ -91,6 +91,9 @@ is_linear_map.mk' (cramer_map A) (cramer_is_linear A)
 
 lemma cramer_apply (i : n) : cramer A b i = (A.update_column i b).det := rfl
 
+lemma cramer_transpose_apply (i : n) : cramer Aᵀ b i = (A.update_row i b).det :=
+by rw [cramer_apply, update_column_transpose, det_transpose]
+
 lemma cramer_transpose_row_self (i : n) :
   Aᵀ.cramer (A i) = pi.single i A.det :=
 begin

--- a/src/linear_algebra/matrix/nonsingular_inverse.lean
+++ b/src/linear_algebra/matrix/nonsingular_inverse.lean
@@ -372,4 +372,10 @@ begin
       smul_smul, h.mul_coe_inv, one_smul]
 end
 
+@[simp] lemma det_smul_inv_vec_mul_eq_cramer_transpose
+  (A : matrix n n α) (b : n → α) (h : is_unit A.det) :
+  A.det • A⁻¹.vec_mul b = cramer Aᵀ b :=
+by rw [← (A⁻¹).transpose_transpose, vec_mul_transpose, transpose_nonsing_inv, ← det_transpose,
+    Aᵀ.det_smul_inv_mul_vec_eq_cramer _ (is_unit_det_transpose A h)]
+
 end matrix

--- a/src/linear_algebra/matrix/nonsingular_inverse.lean
+++ b/src/linear_algebra/matrix/nonsingular_inverse.lean
@@ -372,6 +372,7 @@ begin
       smul_smul, h.mul_coe_inv, one_smul]
 end
 
+/-- One form of **Cramer's rule**. See `matrix.mul_vec_cramer` for a stronger form. -/
 @[simp] lemma det_smul_inv_vec_mul_eq_cramer_transpose
   (A : matrix n n α) (b : n → α) (h : is_unit A.det) :
   A.det • A⁻¹.vec_mul b = cramer Aᵀ b :=


### PR DESCRIPTION
The main goal of this PR is the new lemma `affine_basis.det_smul_coords_eq_camer_coords`

A secondary goal is a minor refactor of barycentric coordinates so that they are associated to a new structure `affine_basis`. As well as making the API for affine spaces more similar to that of modules, this enables an extremely useful dot notation.

The work here could easily be split into two PRs and I will happily do so if requested.

Formalized as part of the Sphere Eversion project.

---

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
