### PR TITLE
[Merged by Bors] - feat(ring_theory/subring): weaken typeclass assumption for `units.pos_subgroup`

### DIFF
--- a/src/ring_theory/subring.lean
+++ b/src/ring_theory/subring.lean
@@ -1000,7 +1000,7 @@ end actions
 -- both ordered ring structures and submonoids available
 
 /-- The subgroup of positive units of a linear ordered commutative ring. -/
-def units.pos_subgroup (R : Type*) [linear_ordered_comm_ring R] [nontrivial R] :
+def units.pos_subgroup (R : Type*) [linear_ordered_semiring R] :
   subgroup (units R) :=
 { carrier := {x | (0 : R) < x},
   inv_mem' := λ x (hx : (0 : R) < x), (zero_lt_mul_left hx).mp $ x.mul_inv.symm ▸ zero_lt_one,

--- a/src/ring_theory/subring.lean
+++ b/src/ring_theory/subring.lean
@@ -1006,5 +1006,5 @@ def units.pos_subgroup (R : Type*) [linear_ordered_semiring R] :
   inv_mem' := λ x (hx : (0 : R) < x), (zero_lt_mul_left hx).mp $ x.mul_inv.symm ▸ zero_lt_one,
   ..(pos_submonoid R).comap (units.coe_hom R)}
 
-@[simp] lemma units.mem_pos_subgroup {R : Type*} [linear_ordered_comm_ring R] [nontrivial R]
+@[simp] lemma units.mem_pos_subgroup {R : Type*} [linear_ordered_semiring R]
   (u : units R) : u ∈ units.pos_subgroup R ↔ (0 : R) < u := iff.rfl


### PR DESCRIPTION


---


[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
