### PR TITLE
[Merged by Bors] - feat(data/fin/basic): extract `div_nat`  and `mod_nat` from `fin_prod_fin_equiv`

### DIFF
--- a/src/data/equiv/fin.lean
+++ b/src/data/equiv/fin.lean
@@ -312,17 +312,15 @@ lemma coe_fin_rotate {n : ℕ} (i : fin n.succ) :
 by rw [fin_rotate_succ_apply, fin.coe_add_one i]
 
 /-- Equivalence between `fin m × fin n` and `fin (m * n)` -/
+@[simps]
 def fin_prod_fin_equiv : fin m × fin n ≃ fin (m * n) :=
-{ to_fun := λ x, ⟨x.2.1 + n * x.1.1,
+{ to_fun := λ x, ⟨x.2 + n * x.1,
     calc x.2.1 + n * x.1.1 + 1
         = x.1.1 * n + x.2.1 + 1 : by ac_refl
     ... ≤ x.1.1 * n + n : nat.add_le_add_left x.2.2 _
     ... = (x.1.1 + 1) * n : eq.symm $ nat.succ_mul _ _
     ... ≤ m * n : nat.mul_le_mul_right _ x.1.2⟩,
-  inv_fun := λ x,
-    have H : 0 < n, from nat.pos_of_ne_zero $ λ H, nat.not_lt_zero x.1 $ by subst H; from x.2,
-    (⟨x.1 / n, (nat.div_lt_iff_lt_mul _ _ H).2 x.2⟩,
-     ⟨x.1 % n, nat.mod_lt _ H⟩),
+  inv_fun := λ x, (x.div_nat, x.mod_nat),
   left_inv := λ ⟨x, y⟩,
     have H : 0 < n, from nat.pos_of_ne_zero $ λ H, nat.not_lt_zero y.1 $ H ▸ y.2,
     prod.ext

--- a/src/data/fin/basic.lean
+++ b/src/data/fin/basic.lean
@@ -63,6 +63,8 @@ This file expands on the development in the core library.
   `fin.last n`;
 * `fin.sub_nat i h` : subtract `m` from `i ≥ m`, generalizes `fin.pred`;
 * `fin.clamp n m` : `min n m` as an element of `fin (m + 1)`;
+* `fin.div_nat i` : divides `i : fin (m * n)` by `n`;
+* `fin.mod_nat i` : takes the mod of `i : fin (m * n)` by `n`;
 
 ### Misc definitions
 
@@ -827,6 +829,22 @@ ext $ add_tsub_cancel_right i m
 by simp [← cast_add_nat]
 
 end pred
+
+section div_mod
+
+/-- Compute `i / n`, where `n` is a `nat` and inferred the type of `i`. -/
+def div_nat (i : fin (m * n)) : fin m :=
+⟨i / n, nat.div_lt_of_lt_mul $ mul_comm m n ▸ i.prop⟩
+
+@[simp] lemma coe_div_nat (i : fin (m * n)) : (i.div_nat : ℕ) = i / n := rfl
+
+/-- Compute `i % n`, where `n` is a `nat` and inferred the type of `i`. -/
+def mod_nat (i : fin (m * n)) : fin n :=
+⟨i % n, nat.mod_lt _ $ pos_of_mul_pos_left ((nat.zero_le i).trans_lt i.is_lt) m.zero_le⟩
+
+@[simp] lemma coe_mod_nat (i : fin (m * n)) : (i.mod_nat : ℕ) = i % n := rfl
+
+end div_mod
 
 section rec
 


### PR DESCRIPTION
This makes it a little easier to tell which component is div and which is mod from the docs alone, and also makes these available earlier than `data/equiv/fin`.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
