### PR TITLE
[Merged by Bors] - chore(ring_theory/subring): fix stale docstring

### DIFF
--- a/src/ring_theory/subring.lean
+++ b/src/ring_theory/subring.lean
@@ -999,7 +999,7 @@ end actions
 -- while this definition is not about subrings, this is the earliest we have
 -- both ordered ring structures and submonoids available
 
-/-- The subgroup of positive units of a linear ordered commutative ring. -/
+/-- The subgroup of positive units of a linear ordered semiring. -/
 def units.pos_subgroup (R : Type*) [linear_ordered_semiring R] :
   subgroup (units R) :=
 { carrier := {x | (0 : R) < x},


### PR DESCRIPTION
Oversight from https://github.com/leanprover-community/mathlib/pull/10332



---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
