### PR TITLE
[Merged by Bors] - feat(linear_algebra/sesquilinear_form): Add is_refl for sesq_form.is_alt

### DIFF
--- a/src/linear_algebra/sesquilinear_form.lean
+++ b/src/linear_algebra/sesquilinear_form.lean
@@ -286,7 +286,7 @@ namespace is_symm
 variable (H : S.is_symm)
 include H
 
-lemma sym (x y : M) : (I (S x y)).unop = S y x := H x y
+protected lemma eq (x y : M) : (I (S x y)).unop = S y x := H x y
 
 lemma is_refl : S.is_refl := λ x y H1, by { rw [←H], simp [H1], }
 

--- a/src/linear_algebra/sesquilinear_form.lean
+++ b/src/linear_algebra/sesquilinear_form.lean
@@ -262,58 +262,42 @@ end
 
 end is_domain
 
-end sesq_form
-
-namespace refl_sesq_form
-
-open refl_sesq_form sesq_form
-
 variables {R : Type*} {M : Type*} [ring R] [add_comm_group M] [module R M]
 variables {I : R ≃+* Rᵒᵖ} {S : sesq_form R M I}
 
 /-- The proposition that a sesquilinear form is reflexive -/
 def is_refl (S : sesq_form R M I) : Prop := ∀ (x y : M), S x y = 0 → S y x = 0
 
+namespace is_refl
+
 variable (H : is_refl S)
 
 lemma eq_zero : ∀ {x y : M}, S x y = 0 → S y x = 0 := λ x y, H x y
 
-lemma ortho_sym {x y : M} :
-is_ortho S x y ↔ is_ortho S y x := ⟨eq_zero H, eq_zero H⟩
+lemma ortho_comm {x y : M} : is_ortho S x y ↔ is_ortho S y x := ⟨eq_zero H, eq_zero H⟩
 
-end refl_sesq_form
-
-namespace sym_sesq_form
-
-open sym_sesq_form sesq_form
-
-variables {R : Type*} {M : Type*} [ring R] [add_comm_group M] [module R M]
-variables {I : R ≃+* Rᵒᵖ} {S : sesq_form R M I}
+end is_refl
 
 /-- The proposition that a sesquilinear form is symmetric -/
-def is_sym (S : sesq_form R M I) : Prop := ∀ (x y : M), (I (S x y)).unop = S y x
+def is_symm (S : sesq_form R M I) : Prop := ∀ (x y : M), (I (S x y)).unop = S y x
 
-variable (H : is_sym S)
+namespace is_symm
+
+variable (H : is_symm S)
 include H
 
 lemma sym (x y : M) : (I (S x y)).unop = S y x := H x y
 
-lemma is_refl : refl_sesq_form.is_refl S := λ x y H1, by { rw [←H], simp [H1], }
+lemma is_refl : S.is_refl := λ x y H1, by { rw [←H], simp [H1], }
 
-lemma ortho_sym {x y : M} :
-is_ortho S x y ↔ is_ortho S y x := refl_sesq_form.ortho_sym (is_refl H)
+lemma ortho_comm {x y : M} : is_ortho S x y ↔ is_ortho S y x := H.is_refl.ortho_comm
 
-end sym_sesq_form
-
-namespace alt_sesq_form
-
-open alt_sesq_form sesq_form
-
-variables {R : Type*} {M : Type*} [ring R] [add_comm_group M] [module R M]
-variables {I : R ≃+* Rᵒᵖ} {S : sesq_form R M I}
+end is_symm
 
 /-- The proposition that a sesquilinear form is alternating -/
 def is_alt (S : sesq_form R M I) : Prop := ∀ (x : M), S x x = 0
+
+namespace is_alt
 
 variable (H : is_alt S)
 include H
@@ -331,4 +315,14 @@ begin
   exact H1,
 end
 
-end alt_sesq_form
+lemma is_refl : S.is_refl :=
+begin
+  intros x y h,
+  rw [← neg H, h, neg_zero],
+end
+
+lemma ortho_comm {x y : M} : is_ortho S x y ↔ is_ortho S y x := H.is_refl.ortho_comm
+
+end is_alt
+
+end sesq_form

--- a/src/linear_algebra/sesquilinear_form.lean
+++ b/src/linear_algebra/sesquilinear_form.lean
@@ -270,7 +270,7 @@ def is_refl (S : sesq_form R M I) : Prop := ∀ (x y : M), S x y = 0 → S y x =
 
 namespace is_refl
 
-variable (H : is_refl S)
+variable (H : S.is_refl)
 
 lemma eq_zero : ∀ {x y : M}, S x y = 0 → S y x = 0 := λ x y, H x y
 
@@ -283,7 +283,7 @@ def is_symm (S : sesq_form R M I) : Prop := ∀ (x y : M), (I (S x y)).unop = S 
 
 namespace is_symm
 
-variable (H : is_symm S)
+variable (H : S.is_symm)
 include H
 
 lemma sym (x y : M) : (I (S x y)).unop = S y x := H x y
@@ -299,7 +299,7 @@ def is_alt (S : sesq_form R M I) : Prop := ∀ (x : M), S x x = 0
 
 namespace is_alt
 
-variable (H : is_alt S)
+variable (H : S.is_alt)
 include H
 
 lemma self_eq_zero (x : M) : S x x = 0 := H x


### PR DESCRIPTION
Lemma `is_refl` shows that an alternating sesquilinear form is reflexive.
Refactored `sesquilinear_form` in a similar way as `bilinear_form` will be in #10338.



---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
