### PR TITLE
[Merged by Bors] - chore(analysis/mean_inequalities): split mean_inequalities into two files

### DIFF
--- a/src/analysis/mean_inequalities.lean
+++ b/src/analysis/mean_inequalities.lean
@@ -205,10 +205,10 @@ by simpa [← rpow_mul, ha, hb, hpq.ne_zero, hpq.symm.ne_zero, div_eq_inv_mul]
 
 /-- Young's inequality, a version for arbitrary real numbers. -/
 theorem young_inequality (a b : ℝ) {p q : ℝ} (hpq : p.is_conjugate_exponent q) :
-  a * b ≤ (abs a)^p / p + (abs b)^q / q :=
-calc a * b ≤ abs (a * b)                   : le_abs_self (a * b)
-       ... = abs a * abs b                 : abs_mul a b
-       ... ≤ (abs a)^p / p + (abs b)^q / q :
+ a * b ≤ |a|^p / p + |b|^q / q :=
+calc a * b ≤ |a * b|                   : le_abs_self (a * b)
+       ... = |a| * |b|                 : abs_mul a b
+       ... ≤ |a|^p / p + |b|^q / q :
   real.young_inequality_of_nonneg (abs_nonneg a) (abs_nonneg b) hpq
 
 end real

--- a/src/analysis/mean_inequalities.lean
+++ b/src/analysis/mean_inequalities.lean
@@ -205,7 +205,7 @@ by simpa [← rpow_mul, ha, hb, hpq.ne_zero, hpq.symm.ne_zero, div_eq_inv_mul]
 
 /-- Young's inequality, a version for arbitrary real numbers. -/
 theorem young_inequality (a b : ℝ) {p q : ℝ} (hpq : p.is_conjugate_exponent q) :
- a * b ≤ |a|^p / p + |b|^q / q :=
+  a * b ≤ |a|^p / p + |b|^q / q :=
 calc a * b ≤ |a * b|                   : le_abs_self (a * b)
        ... = |a| * |b|                 : abs_mul a b
        ... ≤ |a|^p / p + |b|^q / q :

--- a/src/analysis/mean_inequalities.lean
+++ b/src/analysis/mean_inequalities.lean
@@ -34,23 +34,6 @@ a version for real-valued non-negative functions is in the `real` namespace, and
 - `geom_mean_le_arith_mean3_weighted` : weighted version for three numbers;
 - `geom_mean_le_arith_mean4_weighted` : weighted version for four numbers.
 
-### Generalized mean inequality
-
-The inequality says that for two non-negative vectors $w$ and $z$ with $\sum_{i\in s} w_i=1$
-and $p ≤ q$ we have
-$$
-\sqrt[p]{\sum_{i\in s} w_i z_i^p} ≤ \sqrt[q]{\sum_{i\in s} w_i z_i^q}.
-$$
-
-Currently we only prove this inequality for $p=1$. As in the rest of `mathlib`, we provide
-different theorems for natural exponents (`pow_arith_mean_le_arith_mean_pow`), integer exponents
-(`zpow_arith_mean_le_arith_mean_zpow`), and real exponents (`rpow_arith_mean_le_arith_mean_rpow` and
-`arith_mean_le_rpow_mean`). In the first two cases we prove
-$$
-\left(\sum_{i\in s} w_i z_i\right)^n ≤ \sum_{i\in s} w_i z_i^n
-$$
-in order to avoid using real exponents. For real exponents we prove both this and standard versions.
-
 ### Young's inequality
 
 Young's inequality says that for non-negative numbers `a`, `b`, `p`, `q` such that
@@ -59,8 +42,8 @@ $$
 ab ≤ \frac{a^p}{p} + \frac{b^q}{q}.
 $$
 
-This inequality is a special case of the AM-GM inequality. It can be used to prove Hölder's
-inequality (see below) but we use a different proof.
+This inequality is a special case of the AM-GM inequality. It is then used to prove Hölder's
+inequality (see below).
 
 ### Hölder's inequality
 
@@ -74,9 +57,9 @@ $$
 
 We give versions of this result in `ℝ`, `ℝ≥0` and `ℝ≥0∞`.
 
-There are at least two short proofs of this inequality. In one proof we prenormalize both vectors,
-then apply Young's inequality to each $a_ib_i$. We use a different proof deducing this inequality
-from the generalized mean inequality for well-chosen vectors and weights.
+There are at least two short proofs of this inequality. In our proof we prenormalize both vectors,
+then apply Young's inequality to each $a_ib_i$. Another possible proof would be to deduce this
+inequality from the generalized mean inequality for well-chosen vectors and weights.
 
 ### Minkowski's inequality
 
@@ -110,6 +93,10 @@ noncomputable theory
 
 variables {ι : Type u} (s : finset ι)
 
+section geom_mean_le_arith_mean
+
+/-! ### AM-GM inequality -/
+
 namespace real
 
 /-- AM-GM inequality: the **geometric mean is less than or equal to the arithmetic mean**, weighted
@@ -127,7 +114,7 @@ begin
   -- If all numbers `z i` with non-zero weight are positive, then we apply Jensen's inequality
   -- for `exp` and numbers `log (z i)` with weights `w i`.
   { simp only [not_exists, not_and, ne.def, not_not] at A,
-    have := strict_convex_on_exp.convex_on.map_sum_le hw hw' (λ i _, set.mem_univ $ log (z i)),
+    have := convex_on_exp.map_sum_le hw hw' (λ i _, set.mem_univ $ log (z i)),
     simp only [exp_sum, (∘), smul_eq_mul, mul_comm (w _) (log _)] at this,
     convert this using 1; [apply prod_congr rfl, apply sum_congr rfl]; intros i hi,
     { cases eq_or_lt_of_le (hz i hi) with hz hz,
@@ -136,38 +123,6 @@ begin
     { cases eq_or_lt_of_le (hz i hi) with hz hz,
       { simp [A i hi hz.symm] },
       { rw [exp_log hz] } } }
-end
-
-theorem pow_arith_mean_le_arith_mean_pow (w z : ι → ℝ) (hw : ∀ i ∈ s, 0 ≤ w i)
-  (hw' : ∑ i in s, w i = 1) (hz : ∀ i ∈ s, 0 ≤ z i) (n : ℕ) :
-  (∑ i in s, w i * z i) ^ n ≤ ∑ i in s, (w i * z i ^ n) :=
-(convex_on_pow n).map_sum_le hw hw' hz
-
-theorem pow_arith_mean_le_arith_mean_pow_of_even (w z : ι → ℝ) (hw : ∀ i ∈ s, 0 ≤ w i)
-  (hw' : ∑ i in s, w i = 1) {n : ℕ} (hn : even n) :
-  (∑ i in s, w i * z i) ^ n ≤ ∑ i in s, (w i * z i ^ n) :=
-hn.convex_on_pow.map_sum_le hw hw' (λ _ _, trivial)
-
-theorem zpow_arith_mean_le_arith_mean_zpow (w z : ι → ℝ) (hw : ∀ i ∈ s, 0 ≤ w i)
-  (hw' : ∑ i in s, w i = 1) (hz : ∀ i ∈ s, 0 < z i) (m : ℤ) :
-  (∑ i in s, w i * z i) ^ m ≤ ∑ i in s, (w i * z i ^ m) :=
-(convex_on_zpow m).map_sum_le hw hw' hz
-
-theorem rpow_arith_mean_le_arith_mean_rpow (w z : ι → ℝ) (hw : ∀ i ∈ s, 0 ≤ w i)
-  (hw' : ∑ i in s, w i = 1) (hz : ∀ i ∈ s, 0 ≤ z i) {p : ℝ} (hp : 1 ≤ p) :
-  (∑ i in s, w i * z i) ^ p ≤ ∑ i in s, (w i * z i ^ p) :=
-(convex_on_rpow hp).map_sum_le hw hw' hz
-
-theorem arith_mean_le_rpow_mean (w z : ι → ℝ) (hw : ∀ i ∈ s, 0 ≤ w i)
-  (hw' : ∑ i in s, w i = 1) (hz : ∀ i ∈ s, 0 ≤ z i) {p : ℝ} (hp : 1 ≤ p) :
-  ∑ i in s, w i * z i ≤ (∑ i in s, (w i * z i ^ p)) ^ (1 / p) :=
-begin
-  have : 0 < p := lt_of_lt_of_le zero_lt_one hp,
-  rw [← rpow_le_rpow_iff _ _ this, ← rpow_mul, one_div_mul_cancel (ne_of_gt this), rpow_one],
-  exact rpow_arith_mean_le_arith_mean_rpow s w z hw hw' hz hp,
-  all_goals { apply_rules [sum_nonneg, rpow_nonneg_of_nonneg],
-    intros i hi,
-    apply_rules [mul_nonneg, rpow_nonneg_of_nonneg, hw i hi, hz i hi] },
 end
 
 end real
@@ -207,107 +162,7 @@ using geom_mean_le_arith_mean_weighted (univ : finset (fin 4))
   (fin.cons w₁ $ fin.cons w₂ $ fin.cons w₃ $ fin.cons w₄ fin_zero_elim)
   (fin.cons p₁ $ fin.cons p₂ $ fin.cons p₃ $ fin.cons p₄ fin_zero_elim)
 
-/-- Weighted generalized mean inequality, version sums over finite sets, with `ℝ≥0`-valued
-functions and natural exponent. -/
-theorem pow_arith_mean_le_arith_mean_pow (w z : ι → ℝ≥0) (hw' : ∑ i in s, w i = 1) (n : ℕ) :
-  (∑ i in s, w i * z i) ^ n ≤ ∑ i in s, (w i * z i ^ n) :=
-by exact_mod_cast real.pow_arith_mean_le_arith_mean_pow s _ _ (λ i _, (w i).coe_nonneg)
-  (by exact_mod_cast hw') (λ i _, (z i).coe_nonneg) n
-
-/-- Weighted generalized mean inequality, version for sums over finite sets, with `ℝ≥0`-valued
-functions and real exponents. -/
-theorem rpow_arith_mean_le_arith_mean_rpow (w z : ι → ℝ≥0) (hw' : ∑ i in s, w i = 1) {p : ℝ}
-  (hp : 1 ≤ p) :
-  (∑ i in s, w i * z i) ^ p ≤ ∑ i in s, (w i * z i ^ p) :=
-by exact_mod_cast real.rpow_arith_mean_le_arith_mean_rpow s _ _ (λ i _, (w i).coe_nonneg)
-  (by exact_mod_cast hw') (λ i _, (z i).coe_nonneg) hp
-
-/-- Weighted generalized mean inequality, version for two elements of `ℝ≥0` and real exponents. -/
-theorem rpow_arith_mean_le_arith_mean2_rpow (w₁ w₂ z₁ z₂ : ℝ≥0) (hw' : w₁ + w₂ = 1) {p : ℝ}
-  (hp : 1 ≤ p) :
-  (w₁ * z₁ + w₂ * z₂) ^ p ≤ w₁ * z₁ ^ p + w₂ * z₂ ^ p :=
-begin
-  have h := rpow_arith_mean_le_arith_mean_rpow (univ : finset (fin 2))
-    (fin.cons w₁ $ fin.cons w₂ fin_zero_elim) (fin.cons z₁ $ fin.cons z₂ $ fin_zero_elim) _ hp,
-  { simpa [fin.sum_univ_succ, fin.sum_univ_zero, fin.cons_succ, fin.cons_zero] using h, },
-  { simp [hw', fin.sum_univ_succ, fin.sum_univ_zero, fin.cons_succ, fin.cons_zero], },
-end
-
-/-- Weighted generalized mean inequality, version for sums over finite sets, with `ℝ≥0`-valued
-functions and real exponents. -/
-theorem arith_mean_le_rpow_mean (w z : ι → ℝ≥0) (hw' : ∑ i in s, w i = 1) {p : ℝ}
-  (hp : 1 ≤ p) :
-  ∑ i in s, w i * z i ≤ (∑ i in s, (w i * z i ^ p)) ^ (1 / p) :=
-by exact_mod_cast real.arith_mean_le_rpow_mean s _ _ (λ i _, (w i).coe_nonneg)
-  (by exact_mod_cast hw') (λ i _, (z i).coe_nonneg) hp
-
 end nnreal
-
-namespace ennreal
-
-/-- Weighted generalized mean inequality, version for sums over finite sets, with `ℝ≥0∞`-valued
-functions and real exponents. -/
-theorem rpow_arith_mean_le_arith_mean_rpow (w z : ι → ℝ≥0∞) (hw' : ∑ i in s, w i = 1) {p : ℝ}
-  (hp : 1 ≤ p) :
-  (∑ i in s, w i * z i) ^ p ≤ ∑ i in s, (w i * z i ^ p) :=
-begin
-  have hp_pos : 0 < p, from lt_of_lt_of_le zero_lt_one hp,
-  have hp_nonneg : 0 ≤ p, from le_of_lt hp_pos,
-  have hp_not_nonpos : ¬ p ≤ 0, by simp [hp_pos],
-  have hp_not_neg : ¬ p < 0, by simp [hp_nonneg],
-  have h_top_iff_rpow_top : ∀ (i : ι) (hi : i ∈ s), w i * z i = ⊤ ↔ w i * (z i) ^ p = ⊤,
-  by simp [hp_pos, hp_nonneg, hp_not_nonpos, hp_not_neg],
-  refine le_of_top_imp_top_of_to_nnreal_le _ _,
-  { -- first, prove `(∑ i in s, w i * z i) ^ p = ⊤ → ∑ i in s, (w i * z i ^ p) = ⊤`
-    rw [rpow_eq_top_iff, sum_eq_top_iff, sum_eq_top_iff],
-    intro h,
-    simp only [and_false, hp_not_neg, false_or] at h,
-    rcases h.left with ⟨a, H, ha⟩,
-    use [a, H],
-    rwa ←h_top_iff_rpow_top a H, },
-  { -- second, suppose both `(∑ i in s, w i * z i) ^ p ≠ ⊤` and `∑ i in s, (w i * z i ^ p) ≠ ⊤`,
-    -- and prove `((∑ i in s, w i * z i) ^ p).to_nnreal ≤ (∑ i in s, (w i * z i ^ p)).to_nnreal`,
-    -- by using `nnreal.rpow_arith_mean_le_arith_mean_rpow`.
-    intros h_top_rpow_sum _,
-    -- show hypotheses needed to put the `.to_nnreal` inside the sums.
-    have h_top : ∀ (a : ι), a ∈ s → w a * z a ≠ ⊤,
-    { have h_top_sum : ∑ (i : ι) in s, w i * z i ≠ ⊤,
-      { intro h,
-        rw [h, top_rpow_of_pos hp_pos] at h_top_rpow_sum,
-        exact h_top_rpow_sum rfl, },
-      exact λ a ha, (lt_top_of_sum_ne_top h_top_sum ha).ne },
-    have h_top_rpow : ∀ (a : ι), a ∈ s → w a * z a ^ p ≠ ⊤,
-    { intros i hi,
-      specialize h_top i hi,
-      rwa [ne.def, ←h_top_iff_rpow_top i hi], },
-    -- put the `.to_nnreal` inside the sums.
-    simp_rw [to_nnreal_sum h_top_rpow, ←to_nnreal_rpow, to_nnreal_sum h_top, to_nnreal_mul,
-      ←to_nnreal_rpow],
-    -- use corresponding nnreal result
-    refine nnreal.rpow_arith_mean_le_arith_mean_rpow s (λ i, (w i).to_nnreal) (λ i, (z i).to_nnreal)
-      _ hp,
-    -- verify the hypothesis `∑ i in s, (w i).to_nnreal = 1`, using `∑ i in s, w i = 1` .
-    have h_sum_nnreal : (∑ i in s, w i) = ↑(∑ i in s, (w i).to_nnreal),
-    { rw coe_finset_sum,
-      refine sum_congr rfl (λ i hi, (coe_to_nnreal _).symm),
-      refine (lt_top_of_sum_ne_top _ hi).ne,
-      exact hw'.symm ▸ ennreal.one_ne_top },
-    rwa [←coe_eq_coe, ←h_sum_nnreal], },
-end
-
-/-- Weighted generalized mean inequality, version for two elements of `ℝ≥0∞` and real
-exponents. -/
-theorem rpow_arith_mean_le_arith_mean2_rpow (w₁ w₂ z₁ z₂ : ℝ≥0∞) (hw' : w₁ + w₂ = 1) {p : ℝ}
-  (hp : 1 ≤ p) :
-  (w₁ * z₁ + w₂ * z₂) ^ p ≤ w₁ * z₁ ^ p + w₂ * z₂ ^ p :=
-begin
-  have h := rpow_arith_mean_le_arith_mean_rpow (univ : finset (fin 2))
-    (fin.cons w₁ $ fin.cons w₂ fin_zero_elim) (fin.cons z₁ $ fin.cons z₂ $ fin_zero_elim) _ hp,
-  { simpa [fin.sum_univ_succ, fin.sum_univ_zero, fin.cons_succ, fin.cons_zero] using h, },
-  { simp [hw', fin.sum_univ_succ, fin.sum_univ_zero, fin.cons_succ, fin.cons_zero], },
-end
-
-end ennreal
 
 namespace real
 
@@ -330,6 +185,16 @@ theorem geom_mean_le_arith_mean4_weighted {w₁ w₂ w₃ w₄ p₁ p₂ p₃ p�
 nnreal.geom_mean_le_arith_mean4_weighted ⟨w₁, hw₁⟩ ⟨w₂, hw₂⟩ ⟨w₃, hw₃⟩ ⟨w₄, hw₄⟩
   ⟨p₁, hp₁⟩ ⟨p₂, hp₂⟩ ⟨p₃, hp₃⟩ ⟨p₄, hp₄⟩ $ nnreal.coe_eq.1 $ by assumption
 
+end real
+
+end geom_mean_le_arith_mean
+
+section young
+
+/-! ### Young's inequality -/
+
+namespace real
+
 /-- Young's inequality, a version for nonnegative real numbers. -/
 theorem young_inequality_of_nonneg {a b p q : ℝ} (ha : 0 ≤ a) (hb : 0 ≤ b)
   (hpq : p.is_conjugate_exponent q) :
@@ -340,10 +205,10 @@ by simpa [← rpow_mul, ha, hb, hpq.ne_zero, hpq.symm.ne_zero, div_eq_inv_mul]
 
 /-- Young's inequality, a version for arbitrary real numbers. -/
 theorem young_inequality (a b : ℝ) {p q : ℝ} (hpq : p.is_conjugate_exponent q) :
-  a * b ≤ |a|^p / p + |b|^q / q :=
-calc a * b ≤ |a * b|                   : le_abs_self (a * b)
-       ... = |a| * |b|                 : abs_mul a b
-       ... ≤ |a|^p / p + |b|^q / q :
+  a * b ≤ (abs a)^p / p + (abs b)^q / q :=
+calc a * b ≤ abs (a * b)                   : le_abs_self (a * b)
+       ... = abs a * abs b                 : abs_mul a b
+       ... ≤ (abs a)^p / p + (abs b)^q / q :
   real.young_inequality_of_nonneg (abs_nonneg a) (abs_nonneg b) hpq
 
 end real
@@ -365,6 +230,66 @@ begin
   exact young_inequality a b hpq.one_lt_nnreal hpq.inv_add_inv_conj_nnreal,
 end
 
+end nnreal
+
+namespace ennreal
+
+/-- Young's inequality, `ℝ≥0∞` version with real conjugate exponents. -/
+theorem young_inequality (a b : ℝ≥0∞) {p q : ℝ} (hpq : p.is_conjugate_exponent q) :
+  a * b ≤ a ^ p / ennreal.of_real p + b ^ q / ennreal.of_real q :=
+begin
+  by_cases h : a = ⊤ ∨ b = ⊤,
+  { refine le_trans le_top (le_of_eq _),
+    repeat { rw div_eq_mul_inv },
+    cases h; rw h; simp [h, hpq.pos, hpq.symm.pos], },
+  push_neg at h, -- if a ≠ ⊤ and b ≠ ⊤, use the nnreal version: nnreal.young_inequality_real
+  rw [←coe_to_nnreal h.left, ←coe_to_nnreal h.right, ←coe_mul,
+    coe_rpow_of_nonneg _ hpq.nonneg, coe_rpow_of_nonneg _ hpq.symm.nonneg, ennreal.of_real,
+    ennreal.of_real, ←@coe_div (real.to_nnreal p) _ (by simp [hpq.pos]),
+    ←@coe_div (real.to_nnreal q) _ (by simp [hpq.symm.pos]), ←coe_add, coe_le_coe],
+  exact nnreal.young_inequality_real a.to_nnreal b.to_nnreal hpq,
+end
+
+end ennreal
+
+end young
+
+section holder_minkowski
+
+/-! ### Hölder's and Minkowski's inequalities -/
+
+namespace nnreal
+
+private lemma inner_le_Lp_mul_Lp_of_norm_le_one (f g : ι → ℝ≥0) {p q : ℝ}
+  (hpq : p.is_conjugate_exponent q) (hf : ∑ i in s, (f i) ^ p ≤ 1) (hg : ∑ i in s, (g i) ^ q ≤ 1) :
+  ∑ i in s, f i * g i ≤ 1 :=
+begin
+  have hp_ne_zero : real.to_nnreal p ≠ 0, from (zero_lt_one.trans hpq.one_lt_nnreal).ne.symm,
+  have hq_ne_zero : real.to_nnreal q ≠ 0, from (zero_lt_one.trans hpq.symm.one_lt_nnreal).ne.symm,
+  calc ∑ i in s, f i * g i
+      ≤ ∑ i in s, ((f i) ^ p / real.to_nnreal p + (g i) ^ q / real.to_nnreal q) :
+    finset.sum_le_sum (λ i his, young_inequality_real (f i) (g i) hpq)
+  ... = (∑ i in s, (f i) ^ p) / real.to_nnreal p + (∑ i in s, (g i) ^ q) / real.to_nnreal q :
+    by rw [sum_add_distrib, sum_div, sum_div]
+  ... ≤ 1 / real.to_nnreal p + 1 / real.to_nnreal q :
+    by { refine add_le_add _ _,
+      { rwa [div_le_iff hp_ne_zero, div_mul_cancel _ hp_ne_zero], },
+      { rwa [div_le_iff hq_ne_zero, div_mul_cancel _ hq_ne_zero], }, }
+  ... = 1 : hpq.inv_add_inv_conj_nnreal,
+end
+
+private lemma inner_le_Lp_mul_Lp_of_norm_eq_zero (f g : ι → ℝ≥0) {p q : ℝ}
+  (hpq : p.is_conjugate_exponent q) (hf : ∑ i in s, (f i) ^ p = 0) :
+  ∑ i in s, f i * g i ≤ (∑ i in s, (f i) ^ p) ^ (1 / p) * (∑ i in s, (g i) ^ q) ^ (1 / q) :=
+begin
+  simp only [hf, hpq.ne_zero, one_div, sum_eq_zero_iff, zero_rpow, zero_mul, inv_eq_zero,
+    ne.def, not_false_iff, le_zero_iff, mul_eq_zero],
+  intros i his,
+  left,
+  rw sum_eq_zero_iff at hf,
+  exact (rpow_eq_zero_iff.mp (hf i his)).left,
+end
+
 /-- Hölder inequality: the scalar product of two functions is bounded by the product of their
 `L^p` and `L^q` norms when `p` and `q` are conjugate exponents. Version for sums over finite sets,
 with `ℝ≥0`-valued functions. -/
@@ -372,50 +297,27 @@ theorem inner_le_Lp_mul_Lq (f g : ι → ℝ≥0) {p q : ℝ}
   (hpq : p.is_conjugate_exponent q) :
   ∑ i in s, f i * g i ≤ (∑ i in s, (f i) ^ p) ^ (1 / p) * (∑ i in s, (g i) ^ q) ^ (1 / q) :=
 begin
-  -- Let `G=∥g∥_q` be the `L_q`-norm of `g`.
-  set G := (∑ i in s, (g i) ^ q) ^ (1 / q),
-  have hGq : G ^ q = ∑ i in s, (g i) ^ q,
-  { rw [← rpow_mul, one_div_mul_cancel hpq.symm.ne_zero, rpow_one], },
-  -- First consider the trivial case `∥g∥_q=0`
-  by_cases hG : G = 0,
-  { rw [hG, sum_eq_zero, mul_zero],
-    intros i hi,
-    simp only [rpow_eq_zero_iff, sum_eq_zero_iff] at hG,
-    simp [(hG.1 i hi).1] },
-  { -- Move power from right to left
-    rw [← div_le_iff hG, sum_div],
-    -- Now the inequality follows from the weighted generalized mean inequality
-    -- with weights `w_i` and numbers `z_i` given by the following formulas.
-    set w : ι → ℝ≥0 := λ i, (g i) ^ q / G ^ q,
-    set z : ι → ℝ≥0 := λ i, f i * (G / g i) ^ (q / p),
-    -- Show that the sum of weights equals one
-    have A : ∑ i in s, w i = 1,
-    { rw [← sum_div, hGq, div_self],
-      simpa [rpow_eq_zero_iff, hpq.symm.ne_zero] using hG },
-    -- LHS of the goal equals LHS of the weighted generalized mean inequality
-    calc (∑ i in s, f i * g i / G) = (∑ i in s, w i * z i) :
-      begin
-        refine sum_congr rfl (λ i hi, _),
-        have : q - q / p = 1, by field_simp [hpq.ne_zero, hpq.symm.mul_eq_add],
-        dsimp only [w, z],
-        rw [← div_rpow, mul_left_comm, mul_div_assoc, ← @inv_div _ _ _ G, inv_rpow,
-          ← div_eq_mul_inv, ← rpow_sub']; simp [this]
-      end
-    -- Apply the generalized mean inequality
-    ... ≤ (∑ i in s, w i * (z i) ^ p) ^ (1 / p) :
-      nnreal.arith_mean_le_rpow_mean s w z A (le_of_lt hpq.one_lt)
-    -- Simplify the right hand side. Terms with `g i ≠ 0` are equal to `(f i) ^ p`,
-    -- the others are zeros.
-    ... ≤ (∑ i in s, (f i) ^ p) ^ (1 / p) :
-      begin
-        refine rpow_le_rpow (sum_le_sum (λ i hi, _)) hpq.one_div_nonneg,
-        dsimp only [w, z],
-        rw [mul_rpow, mul_left_comm, ← rpow_mul _ _ p, div_mul_cancel _ hpq.ne_zero, div_rpow,
-          div_mul_div, mul_comm (G ^ q), mul_div_mul_right],
-        { nth_rewrite 1 [← mul_one ((f i) ^ p)],
-          exact mul_le_mul_left' (div_self_le _) _ },
-        { simpa [hpq.symm.ne_zero] using hG }
-      end }
+  by_cases hF_zero : ∑ i in s, (f i) ^ p = 0,
+  { exact inner_le_Lp_mul_Lp_of_norm_eq_zero s f g hpq hF_zero, },
+  by_cases hG_zero : ∑ i in s, (g i) ^ q = 0,
+  { calc ∑ i in s, f i * g i
+        = ∑ i in s, g i * f i : by { congr' with i, rw mul_comm, }
+    ... ≤ (∑ i in s, (g i) ^ q) ^ (1 / q) * (∑ i in s, (f i) ^ p) ^ (1 / p) :
+      inner_le_Lp_mul_Lp_of_norm_eq_zero s g f hpq.symm hG_zero
+    ... = (∑ i in s, (f i) ^ p) ^ (1 / p) * (∑ i in s, (g i) ^ q) ^ (1 / q) : mul_comm _ _, },
+  let f' := λ i, (f i) / (∑ i in s, (f i) ^ p) ^ (1 / p),
+  let g' := λ i, (g i) / (∑ i in s, (g i) ^ q) ^ (1 / q),
+  suffices : ∑ i in s, f' i * g' i ≤ 1,
+  { simp_rw [f', g', div_mul_div, ← sum_div] at this,
+    rwa [div_le_iff, one_mul] at this,
+    refine mul_ne_zero _ _,
+    { rw [ne.def, rpow_eq_zero_iff, auto.not_and_eq], exact or.inl hF_zero, },
+    { rw [ne.def, rpow_eq_zero_iff, auto.not_and_eq], exact or.inl hG_zero, }, },
+  refine inner_le_Lp_mul_Lp_of_norm_le_one s f' g' hpq (le_of_eq _) (le_of_eq _),
+  { simp_rw [f', div_rpow, ← sum_div, ← rpow_mul, one_div, inv_mul_cancel hpq.ne_zero, rpow_one,
+      div_self hF_zero], },
+  { simp_rw [g', div_rpow, ← sum_div, ← rpow_mul, one_div, inv_mul_cancel hpq.symm.ne_zero,
+    rpow_one, div_self hG_zero], },
 end
 
 /-- The `L_p` seminorm of a vector `f` is the greatest value of the inner product
@@ -518,22 +420,6 @@ end real
 
 namespace ennreal
 
-/-- Young's inequality, `ℝ≥0∞` version with real conjugate exponents. -/
-theorem young_inequality (a b : ℝ≥0∞) {p q : ℝ} (hpq : p.is_conjugate_exponent q) :
-  a * b ≤ a ^ p / ennreal.of_real p + b ^ q / ennreal.of_real q :=
-begin
-  by_cases h : a = ⊤ ∨ b = ⊤,
-  { refine le_trans le_top (le_of_eq _),
-    repeat { rw div_eq_mul_inv },
-    cases h; rw h; simp [h, hpq.pos, hpq.symm.pos], },
-  push_neg at h, -- if a ≠ ⊤ and b ≠ ⊤, use the nnreal version: nnreal.young_inequality_real
-  rw [←coe_to_nnreal h.left, ←coe_to_nnreal h.right, ←coe_mul,
-    coe_rpow_of_nonneg _ hpq.nonneg, coe_rpow_of_nonneg _ hpq.symm.nonneg, ennreal.of_real,
-    ennreal.of_real, ←@coe_div (real.to_nnreal p) _ (by simp [hpq.pos]),
-    ←@coe_div (real.to_nnreal q) _ (by simp [hpq.symm.pos]), ←coe_add, coe_le_coe],
-  exact nnreal.young_inequality_real a.to_nnreal b.to_nnreal hpq,
-end
-
 variables (f g : ι → ℝ≥0∞)  {p q : ℝ}
 
 /-- Hölder inequality: the scalar product of two functions is bounded by the product of their
@@ -586,69 +472,6 @@ begin
   { apply finset.sum_congr rfl (λ i hi, _), simp [H'.1 i hi, H'.2 i hi] }
 end
 
-private lemma add_rpow_le_one_of_add_le_one {p : ℝ} (a b : ℝ≥0∞) (hab : a + b ≤ 1)
-  (hp1 : 1 ≤ p) :
-  a ^ p + b ^ p ≤ 1 :=
-begin
-  have h_le_one : ∀ x : ℝ≥0∞, x ≤ 1 → x ^ p ≤ x, from λ x hx, rpow_le_self_of_le_one hx hp1,
-  have ha : a ≤ 1, from (self_le_add_right a b).trans hab,
-  have hb : b ≤ 1, from (self_le_add_left b a).trans hab,
-  exact (add_le_add (h_le_one a ha) (h_le_one b hb)).trans hab,
-end
-
-lemma add_rpow_le_rpow_add {p : ℝ} (a b : ℝ≥0∞) (hp1 : 1 ≤ p) :
-  a ^ p + b ^ p ≤ (a + b) ^ p :=
-begin
-  have hp_pos : 0 < p := lt_of_lt_of_le zero_lt_one hp1,
-  by_cases h_top : a + b = ⊤,
-  { rw ←@ennreal.rpow_eq_top_iff_of_pos (a + b) p hp_pos at h_top,
-    rw h_top,
-    exact le_top, },
-  obtain ⟨ha_top, hb_top⟩ := add_ne_top.mp h_top,
-  by_cases h_zero : a + b = 0,
-  { simp [add_eq_zero_iff.mp h_zero, ennreal.zero_rpow_of_pos hp_pos], },
-  have h_nonzero : ¬(a = 0 ∧ b = 0), by rwa add_eq_zero_iff at h_zero,
-  have h_add : a/(a+b) + b/(a+b) = 1, by rw [div_add_div_same, div_self h_zero h_top],
-  have h := add_rpow_le_one_of_add_le_one (a/(a+b)) (b/(a+b)) h_add.le hp1,
-  rw [div_rpow_of_nonneg a (a+b) hp_pos.le, div_rpow_of_nonneg b (a+b) hp_pos.le] at h,
-  have hab_0 : (a + b)^p ≠ 0, by simp [ha_top, hb_top, hp_pos, h_nonzero],
-  have hab_top : (a + b)^p ≠ ⊤, by simp [ha_top, hb_top, hp_pos, h_nonzero],
-  have h_mul : (a + b)^p * (a ^ p / (a + b) ^ p + b ^ p / (a + b) ^ p) ≤ (a + b)^p,
-  { nth_rewrite 3 ←mul_one ((a + b)^p),
-    exact (mul_le_mul_left hab_0 hab_top).mpr h, },
-  rwa [div_eq_mul_inv, div_eq_mul_inv, mul_add, mul_comm (a^p), mul_comm (b^p), ←mul_assoc,
-    ←mul_assoc, mul_inv_cancel hab_0 hab_top, one_mul, one_mul] at h_mul,
-end
-
-lemma rpow_add_rpow_le_add {p : ℝ} (a b : ℝ≥0∞) (hp1 : 1 ≤ p) :
-  (a ^ p + b ^ p) ^ (1/p) ≤ a + b :=
-begin
-  rw ←@ennreal.le_rpow_one_div_iff _ _ (1/p) (by simp [lt_of_lt_of_le zero_lt_one hp1]),
-  rw one_div_one_div,
-  exact add_rpow_le_rpow_add _ _ hp1,
-end
-
-theorem rpow_add_rpow_le {p q : ℝ} (a b : ℝ≥0∞) (hp_pos : 0 < p) (hpq : p ≤ q) :
-  (a ^ q + b ^ q) ^ (1/q) ≤ (a ^ p + b ^ p) ^ (1/p) :=
-begin
-  have h_rpow : ∀ a : ℝ≥0∞, a^q = (a^p)^(q/p),
-    from λ a, by rw [←ennreal.rpow_mul, div_eq_inv_mul, ←mul_assoc,
-      _root_.mul_inv_cancel hp_pos.ne.symm, one_mul],
-  have h_rpow_add_rpow_le_add : ((a^p)^(q/p) + (b^p)^(q/p)) ^ (1/(q/p)) ≤ a^p + b^p,
-  { refine rpow_add_rpow_le_add (a^p) (b^p) _,
-    rwa one_le_div hp_pos, },
-  rw [h_rpow a, h_rpow b, ennreal.le_rpow_one_div_iff hp_pos, ←ennreal.rpow_mul, mul_comm,
-    mul_one_div],
-  rwa one_div_div at h_rpow_add_rpow_le_add,
-end
-
-lemma rpow_add_le_add_rpow {p : ℝ} (a b : ℝ≥0∞) (hp_pos : 0 < p) (hp1 : p ≤ 1) :
-  (a + b) ^ p ≤ a ^ p + b ^ p :=
-begin
-  have h := rpow_add_rpow_le a b hp_pos hp1,
-  rw one_div_one at h,
-  repeat { rw ennreal.rpow_one at h },
-  exact (ennreal.le_rpow_one_div_iff hp_pos).mp h,
-end
-
 end ennreal
+
+end holder_minkowski

--- a/src/analysis/mean_inequalities_pow.lean
+++ b/src/analysis/mean_inequalities_pow.lean
@@ -1,0 +1,257 @@
+/-
+Copyright (c) 2019 Yury Kudryashov. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Yury Kudryashov, Sébastien Gouëzel, Rémy Degenne
+-/
+import analysis.convex.specific_functions
+
+/-!
+# Mean value inequalities
+
+In this file we prove several mean inequalities for finite sums. Versions for integrals of some of
+these inequalities are available in `measure_theory.mean_inequalities`.
+
+## Main theorems: generalized mean inequality
+
+The inequality says that for two non-negative vectors $w$ and $z$ with $\sum_{i\in s} w_i=1$
+and $p ≤ q$ we have
+$$
+\sqrt[p]{\sum_{i\in s} w_i z_i^p} ≤ \sqrt[q]{\sum_{i\in s} w_i z_i^q}.
+$$
+
+Currently we only prove this inequality for $p=1$. As in the rest of `mathlib`, we provide
+different theorems for natural exponents (`pow_arith_mean_le_arith_mean_pow`), integer exponents
+(`zpow_arith_mean_le_arith_mean_zpow`), and real exponents (`rpow_arith_mean_le_arith_mean_rpow` and
+`arith_mean_le_rpow_mean`). In the first two cases we prove
+$$
+\left(\sum_{i\in s} w_i z_i\right)^n ≤ \sum_{i\in s} w_i z_i^n
+$$
+in order to avoid using real exponents. For real exponents we prove both this and standard versions.
+
+## TODO
+
+- each inequality `A ≤ B` should come with a theorem `A = B ↔ _`; one of the ways to prove them
+  is to define `strict_convex_on` functions.
+- generalized mean inequality with any `p ≤ q`, including negative numbers;
+- prove that the power mean tends to the geometric mean as the exponent tends to zero.
+
+-/
+
+universes u v
+
+open finset
+open_locale classical big_operators nnreal ennreal
+noncomputable theory
+
+variables {ι : Type u} (s : finset ι)
+
+namespace real
+
+theorem pow_arith_mean_le_arith_mean_pow (w z : ι → ℝ) (hw : ∀ i ∈ s, 0 ≤ w i)
+  (hw' : ∑ i in s, w i = 1) (hz : ∀ i ∈ s, 0 ≤ z i) (n : ℕ) :
+  (∑ i in s, w i * z i) ^ n ≤ ∑ i in s, (w i * z i ^ n) :=
+(convex_on_pow n).map_sum_le hw hw' hz
+
+theorem pow_arith_mean_le_arith_mean_pow_of_even (w z : ι → ℝ) (hw : ∀ i ∈ s, 0 ≤ w i)
+  (hw' : ∑ i in s, w i = 1) {n : ℕ} (hn : even n) :
+  (∑ i in s, w i * z i) ^ n ≤ ∑ i in s, (w i * z i ^ n) :=
+hn.convex_on_pow.map_sum_le hw hw' (λ _ _, trivial)
+
+theorem zpow_arith_mean_le_arith_mean_zpow (w z : ι → ℝ) (hw : ∀ i ∈ s, 0 ≤ w i)
+  (hw' : ∑ i in s, w i = 1) (hz : ∀ i ∈ s, 0 < z i) (m : ℤ) :
+  (∑ i in s, w i * z i) ^ m ≤ ∑ i in s, (w i * z i ^ m) :=
+(convex_on_zpow m).map_sum_le hw hw' hz
+
+theorem rpow_arith_mean_le_arith_mean_rpow (w z : ι → ℝ) (hw : ∀ i ∈ s, 0 ≤ w i)
+  (hw' : ∑ i in s, w i = 1) (hz : ∀ i ∈ s, 0 ≤ z i) {p : ℝ} (hp : 1 ≤ p) :
+  (∑ i in s, w i * z i) ^ p ≤ ∑ i in s, (w i * z i ^ p) :=
+(convex_on_rpow hp).map_sum_le hw hw' hz
+
+theorem arith_mean_le_rpow_mean (w z : ι → ℝ) (hw : ∀ i ∈ s, 0 ≤ w i)
+  (hw' : ∑ i in s, w i = 1) (hz : ∀ i ∈ s, 0 ≤ z i) {p : ℝ} (hp : 1 ≤ p) :
+  ∑ i in s, w i * z i ≤ (∑ i in s, (w i * z i ^ p)) ^ (1 / p) :=
+begin
+  have : 0 < p := lt_of_lt_of_le zero_lt_one hp,
+  rw [← rpow_le_rpow_iff _ _ this, ← rpow_mul, one_div_mul_cancel (ne_of_gt this), rpow_one],
+  exact rpow_arith_mean_le_arith_mean_rpow s w z hw hw' hz hp,
+  all_goals { apply_rules [sum_nonneg, rpow_nonneg_of_nonneg],
+    intros i hi,
+    apply_rules [mul_nonneg, rpow_nonneg_of_nonneg, hw i hi, hz i hi] },
+end
+
+end real
+
+namespace nnreal
+
+/-- Weighted generalized mean inequality, version sums over finite sets, with `ℝ≥0`-valued
+functions and natural exponent. -/
+theorem pow_arith_mean_le_arith_mean_pow (w z : ι → ℝ≥0) (hw' : ∑ i in s, w i = 1) (n : ℕ) :
+  (∑ i in s, w i * z i) ^ n ≤ ∑ i in s, (w i * z i ^ n) :=
+by exact_mod_cast real.pow_arith_mean_le_arith_mean_pow s _ _ (λ i _, (w i).coe_nonneg)
+  (by exact_mod_cast hw') (λ i _, (z i).coe_nonneg) n
+
+/-- Weighted generalized mean inequality, version for sums over finite sets, with `ℝ≥0`-valued
+functions and real exponents. -/
+theorem rpow_arith_mean_le_arith_mean_rpow (w z : ι → ℝ≥0) (hw' : ∑ i in s, w i = 1) {p : ℝ}
+  (hp : 1 ≤ p) :
+  (∑ i in s, w i * z i) ^ p ≤ ∑ i in s, (w i * z i ^ p) :=
+by exact_mod_cast real.rpow_arith_mean_le_arith_mean_rpow s _ _ (λ i _, (w i).coe_nonneg)
+  (by exact_mod_cast hw') (λ i _, (z i).coe_nonneg) hp
+
+/-- Weighted generalized mean inequality, version for two elements of `ℝ≥0` and real exponents. -/
+theorem rpow_arith_mean_le_arith_mean2_rpow (w₁ w₂ z₁ z₂ : ℝ≥0) (hw' : w₁ + w₂ = 1) {p : ℝ}
+  (hp : 1 ≤ p) :
+  (w₁ * z₁ + w₂ * z₂) ^ p ≤ w₁ * z₁ ^ p + w₂ * z₂ ^ p :=
+begin
+  have h := rpow_arith_mean_le_arith_mean_rpow (univ : finset (fin 2))
+    (fin.cons w₁ $ fin.cons w₂ fin_zero_elim) (fin.cons z₁ $ fin.cons z₂ $ fin_zero_elim) _ hp,
+  { simpa [fin.sum_univ_succ, fin.sum_univ_zero, fin.cons_succ, fin.cons_zero] using h, },
+  { simp [hw', fin.sum_univ_succ, fin.sum_univ_zero, fin.cons_succ, fin.cons_zero], },
+end
+
+/-- Weighted generalized mean inequality, version for sums over finite sets, with `ℝ≥0`-valued
+functions and real exponents. -/
+theorem arith_mean_le_rpow_mean (w z : ι → ℝ≥0) (hw' : ∑ i in s, w i = 1) {p : ℝ}
+  (hp : 1 ≤ p) :
+  ∑ i in s, w i * z i ≤ (∑ i in s, (w i * z i ^ p)) ^ (1 / p) :=
+by exact_mod_cast real.arith_mean_le_rpow_mean s _ _ (λ i _, (w i).coe_nonneg)
+  (by exact_mod_cast hw') (λ i _, (z i).coe_nonneg) hp
+
+end nnreal
+
+namespace ennreal
+
+/-- Weighted generalized mean inequality, version for sums over finite sets, with `ℝ≥0∞`-valued
+functions and real exponents. -/
+theorem rpow_arith_mean_le_arith_mean_rpow (w z : ι → ℝ≥0∞) (hw' : ∑ i in s, w i = 1) {p : ℝ}
+  (hp : 1 ≤ p) :
+  (∑ i in s, w i * z i) ^ p ≤ ∑ i in s, (w i * z i ^ p) :=
+begin
+  have hp_pos : 0 < p, from lt_of_lt_of_le zero_lt_one hp,
+  have hp_nonneg : 0 ≤ p, from le_of_lt hp_pos,
+  have hp_not_nonpos : ¬ p ≤ 0, by simp [hp_pos],
+  have hp_not_neg : ¬ p < 0, by simp [hp_nonneg],
+  have h_top_iff_rpow_top : ∀ (i : ι) (hi : i ∈ s), w i * z i = ⊤ ↔ w i * (z i) ^ p = ⊤,
+  by simp [hp_pos, hp_nonneg, hp_not_nonpos, hp_not_neg],
+  refine le_of_top_imp_top_of_to_nnreal_le _ _,
+  { -- first, prove `(∑ i in s, w i * z i) ^ p = ⊤ → ∑ i in s, (w i * z i ^ p) = ⊤`
+    rw [rpow_eq_top_iff, sum_eq_top_iff, sum_eq_top_iff],
+    intro h,
+    simp only [and_false, hp_not_neg, false_or] at h,
+    rcases h.left with ⟨a, H, ha⟩,
+    use [a, H],
+    rwa ←h_top_iff_rpow_top a H, },
+  { -- second, suppose both `(∑ i in s, w i * z i) ^ p ≠ ⊤` and `∑ i in s, (w i * z i ^ p) ≠ ⊤`,
+    -- and prove `((∑ i in s, w i * z i) ^ p).to_nnreal ≤ (∑ i in s, (w i * z i ^ p)).to_nnreal`,
+    -- by using `nnreal.rpow_arith_mean_le_arith_mean_rpow`.
+    intros h_top_rpow_sum _,
+    -- show hypotheses needed to put the `.to_nnreal` inside the sums.
+    have h_top : ∀ (a : ι), a ∈ s → w a * z a ≠ ⊤,
+    { have h_top_sum : ∑ (i : ι) in s, w i * z i ≠ ⊤,
+      { intro h,
+        rw [h, top_rpow_of_pos hp_pos] at h_top_rpow_sum,
+        exact h_top_rpow_sum rfl, },
+      exact λ a ha, (lt_top_of_sum_ne_top h_top_sum ha).ne },
+    have h_top_rpow : ∀ (a : ι), a ∈ s → w a * z a ^ p ≠ ⊤,
+    { intros i hi,
+      specialize h_top i hi,
+      rwa [ne.def, ←h_top_iff_rpow_top i hi], },
+    -- put the `.to_nnreal` inside the sums.
+    simp_rw [to_nnreal_sum h_top_rpow, ←to_nnreal_rpow, to_nnreal_sum h_top, to_nnreal_mul,
+      ←to_nnreal_rpow],
+    -- use corresponding nnreal result
+    refine nnreal.rpow_arith_mean_le_arith_mean_rpow s (λ i, (w i).to_nnreal) (λ i, (z i).to_nnreal)
+      _ hp,
+    -- verify the hypothesis `∑ i in s, (w i).to_nnreal = 1`, using `∑ i in s, w i = 1` .
+    have h_sum_nnreal : (∑ i in s, w i) = ↑(∑ i in s, (w i).to_nnreal),
+    { rw coe_finset_sum,
+      refine sum_congr rfl (λ i hi, (coe_to_nnreal _).symm),
+      refine (lt_top_of_sum_ne_top _ hi).ne,
+      exact hw'.symm ▸ ennreal.one_ne_top },
+    rwa [←coe_eq_coe, ←h_sum_nnreal], },
+end
+
+/-- Weighted generalized mean inequality, version for two elements of `ℝ≥0∞` and real
+exponents. -/
+theorem rpow_arith_mean_le_arith_mean2_rpow (w₁ w₂ z₁ z₂ : ℝ≥0∞) (hw' : w₁ + w₂ = 1) {p : ℝ}
+  (hp : 1 ≤ p) :
+  (w₁ * z₁ + w₂ * z₂) ^ p ≤ w₁ * z₁ ^ p + w₂ * z₂ ^ p :=
+begin
+  have h := rpow_arith_mean_le_arith_mean_rpow (univ : finset (fin 2))
+    (fin.cons w₁ $ fin.cons w₂ fin_zero_elim) (fin.cons z₁ $ fin.cons z₂ $ fin_zero_elim) _ hp,
+  { simpa [fin.sum_univ_succ, fin.sum_univ_zero, fin.cons_succ, fin.cons_zero] using h, },
+  { simp [hw', fin.sum_univ_succ, fin.sum_univ_zero, fin.cons_succ, fin.cons_zero], },
+end
+
+end ennreal
+
+namespace ennreal
+
+variables (f g : ι → ℝ≥0∞)  {p q : ℝ}
+
+private lemma add_rpow_le_one_of_add_le_one {p : ℝ} (a b : ℝ≥0∞) (hab : a + b ≤ 1)
+  (hp1 : 1 ≤ p) :
+  a ^ p + b ^ p ≤ 1 :=
+begin
+  have h_le_one : ∀ x : ℝ≥0∞, x ≤ 1 → x ^ p ≤ x, from λ x hx, rpow_le_self_of_le_one hx hp1,
+  have ha : a ≤ 1, from (self_le_add_right a b).trans hab,
+  have hb : b ≤ 1, from (self_le_add_left b a).trans hab,
+  exact (add_le_add (h_le_one a ha) (h_le_one b hb)).trans hab,
+end
+
+lemma add_rpow_le_rpow_add {p : ℝ} (a b : ℝ≥0∞) (hp1 : 1 ≤ p) :
+  a ^ p + b ^ p ≤ (a + b) ^ p :=
+begin
+  have hp_pos : 0 < p := lt_of_lt_of_le zero_lt_one hp1,
+  by_cases h_top : a + b = ⊤,
+  { rw ←@ennreal.rpow_eq_top_iff_of_pos (a + b) p hp_pos at h_top,
+    rw h_top,
+    exact le_top, },
+  obtain ⟨ha_top, hb_top⟩ := add_ne_top.mp h_top,
+  by_cases h_zero : a + b = 0,
+  { simp [add_eq_zero_iff.mp h_zero, ennreal.zero_rpow_of_pos hp_pos], },
+  have h_nonzero : ¬(a = 0 ∧ b = 0), by rwa add_eq_zero_iff at h_zero,
+  have h_add : a/(a+b) + b/(a+b) = 1, by rw [div_add_div_same, div_self h_zero h_top],
+  have h := add_rpow_le_one_of_add_le_one (a/(a+b)) (b/(a+b)) h_add.le hp1,
+  rw [div_rpow_of_nonneg a (a+b) hp_pos.le, div_rpow_of_nonneg b (a+b) hp_pos.le] at h,
+  have hab_0 : (a + b)^p ≠ 0, by simp [ha_top, hb_top, hp_pos, h_nonzero],
+  have hab_top : (a + b)^p ≠ ⊤, by simp [ha_top, hb_top, hp_pos, h_nonzero],
+  have h_mul : (a + b)^p * (a ^ p / (a + b) ^ p + b ^ p / (a + b) ^ p) ≤ (a + b)^p,
+  { nth_rewrite 3 ←mul_one ((a + b)^p),
+    exact (mul_le_mul_left hab_0 hab_top).mpr h, },
+  rwa [div_eq_mul_inv, div_eq_mul_inv, mul_add, mul_comm (a^p), mul_comm (b^p), ←mul_assoc,
+    ←mul_assoc, mul_inv_cancel hab_0 hab_top, one_mul, one_mul] at h_mul,
+end
+
+lemma rpow_add_rpow_le_add {p : ℝ} (a b : ℝ≥0∞) (hp1 : 1 ≤ p) :
+  (a ^ p + b ^ p) ^ (1/p) ≤ a + b :=
+begin
+  rw ←@ennreal.le_rpow_one_div_iff _ _ (1/p) (by simp [lt_of_lt_of_le zero_lt_one hp1]),
+  rw one_div_one_div,
+  exact add_rpow_le_rpow_add _ _ hp1,
+end
+
+theorem rpow_add_rpow_le {p q : ℝ} (a b : ℝ≥0∞) (hp_pos : 0 < p) (hpq : p ≤ q) :
+  (a ^ q + b ^ q) ^ (1/q) ≤ (a ^ p + b ^ p) ^ (1/p) :=
+begin
+  have h_rpow : ∀ a : ℝ≥0∞, a^q = (a^p)^(q/p),
+    from λ a, by rw [←ennreal.rpow_mul, div_eq_inv_mul, ←mul_assoc,
+      _root_.mul_inv_cancel hp_pos.ne.symm, one_mul],
+  have h_rpow_add_rpow_le_add : ((a^p)^(q/p) + (b^p)^(q/p)) ^ (1/(q/p)) ≤ a^p + b^p,
+  { refine rpow_add_rpow_le_add (a^p) (b^p) _,
+    rwa one_le_div hp_pos, },
+  rw [h_rpow a, h_rpow b, ennreal.le_rpow_one_div_iff hp_pos, ←ennreal.rpow_mul, mul_comm,
+    mul_one_div],
+  rwa one_div_div at h_rpow_add_rpow_le_add,
+end
+
+lemma rpow_add_le_add_rpow {p : ℝ} (a b : ℝ≥0∞) (hp_pos : 0 < p) (hp1 : p ≤ 1) :
+  (a + b) ^ p ≤ a ^ p + b ^ p :=
+begin
+  have h := rpow_add_rpow_le a b hp_pos hp1,
+  rw one_div_one at h,
+  repeat { rw ennreal.rpow_one at h },
+  exact (ennreal.le_rpow_one_div_iff hp_pos).mp h,
+end
+
+end ennreal

--- a/src/measure_theory/integral/mean_inequalities.lean
+++ b/src/measure_theory/integral/mean_inequalities.lean
@@ -5,6 +5,7 @@ Authors: Rémy Degenne
 -/
 import measure_theory.integral.lebesgue
 import analysis.mean_inequalities
+import analysis.mean_inequalities_pow
 import measure_theory.function.special_functions
 
 /-!


### PR DESCRIPTION
This PR puts all results related to power functions into a new file.

Currently, we prove convexity of `exp` and `pow`, then use those properties in `mean_inequalities`. I am refactoring some parts of the analysis library to reduce the use of derivatives. I want to prove convexity of exp without derivatives (in a future PR), prove Holder's inequality, then use it to prove the convexity of pow. This requires Holder's inequality to be in a file that does not use convexity of pow, hence the split.

I needed to change the proof of Holder's inequality since it used the generalized mean inequality (hence `pow`). I switched to the second possible proof mentioned in the file docstring.

I also moved some lemmas in `mean_inequalities` to have three main sections: AM-GM, then Young and a final section with Holder and Minkowski.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

The result of the whole refactor can be seen in the (stale) branch `pow_split`.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
