### PR TITLE
[Merged by Bors] - feat(data/complex/exponential): Add lemma add_one_le_exp

### DIFF
--- a/src/analysis/special_functions/exp.lean
+++ b/src/analysis/special_functions/exp.lean
@@ -137,7 +137,7 @@ begin
   have A : tendsto (λx:ℝ, x + 1) at_top at_top :=
     tendsto_at_top_add_const_right at_top 1 tendsto_id,
   have B : ∀ᶠ x in at_top, x + 1 ≤ exp x :=
-    eventually_at_top.2 ⟨0, λx hx, add_one_le_exp_of_nonneg hx⟩,
+    eventually_at_top.2 ⟨0, λx hx, add_one_le_exp x⟩,
   exact tendsto_at_top_mono' at_top B A
 end
 

--- a/src/data/complex/exponential.lean
+++ b/src/data/complex/exponential.lean
@@ -1137,6 +1137,7 @@ by rw ← of_real_inj; simp [sinh_three_mul]
 
 open is_absolute_value
 
+/-- Please use `add_one_le_exp`. This is an intermediate step in the proof of `add_one_le_exp` which may become private later. -/
 lemma add_one_le_exp_of_nonneg {x : ℝ} (hx : 0 ≤ x) : x + 1 ≤ exp x :=
 calc x + 1 ≤ lim (⟨(λ n : ℕ, ((exp' x) n).re), is_cau_seq_re (exp' x)⟩ : cau_seq ℝ has_abs.abs) :
   le_lim (cau_seq.le_of_exists ⟨2,

--- a/src/data/complex/exponential.lean
+++ b/src/data/complex/exponential.lean
@@ -1533,13 +1533,13 @@ lemma exp_bound_div_one_sub_of_interval_approx  {x : ℝ} (h1 : 0 ≤ x) (h2 : x
 begin
   norm_num [finset.sum],
   rw [add_assoc, add_comm (x + 1) (x ^ 3 * 4 / 18), ← add_assoc, add_le_add_iff_right,
-      ← add_le_add_iff_left (-(x^2/2)), ← add_assoc, comm_ring.add_left_neg (x^2/2), zero_add,
-      neg_add_eq_sub, sub_half, sq, pow_succ, sq],
+      ← add_le_add_iff_left (-(x ^ 2 / 2)), ← add_assoc, comm_ring.add_left_neg (x ^ 2 / 2),
+      zero_add, neg_add_eq_sub, sub_half, sq, pow_succ, sq],
   have i1 : x * 4 / 18 ≤ 1 / 2 := by linarith,
   have i2 : 0 ≤ x * 4 / 18 := by linarith,
   have i3 := mul_le_mul h1 h1 le_rfl h1,
   rw zero_mul at i3,
-  have t := mul_le_mul (le_refl (x * x)) i1 i2 i3,
+  have t := mul_le_mul le_rfl i1 i2 i3,
   rw ← mul_assoc,
   rwa [mul_one_div, ← mul_div_assoc, ← mul_assoc] at t,
 end
@@ -1547,10 +1547,10 @@ end
 lemma exp_bound_div_one_sub_of_interval {x : ℝ} (h1 : 0 ≤ x) (h2 : x < 1) :
   real.exp x ≤ 1 / (1 - x) :=
 begin
-  have h : ∑ j in (finset.range 3), x^j ≤ 1/(1-x),
+  have h : ∑ j in (finset.range 3), x ^ j ≤ 1 / (1 - x),
   { norm_num [finset.sum],
     have h1x : 0 < 1 - x := by simpa,
-    apply (le_div_iff h1x).2,
+    rw le_div_iff h1x,
     norm_num [← add_assoc, mul_sub_left_distrib, mul_one, add_mul,
               sub_add_eq_sub_sub, pow_succ' x 2],
     have hx3 : 0 ≤ x ^ 3,
@@ -1567,15 +1567,15 @@ begin
   have r1 : (1 - y) * (real.exp y) ≤ 1,
   { cases le_or_lt (1 - y) 0,
     { have h'' : (1 - y) * y.exp ≤ 0,
-    { apply mul_nonpos_iff.2,
-      right,
-      exact ⟨h_1, y.exp_pos.le⟩ },
+      { rw mul_nonpos_iff,
+        right,
+        exact ⟨h_1, y.exp_pos.le⟩ },
     linarith },
     have hy1 : y < 1 := by linarith,
-    apply (le_div_iff' h_1).1,
+    rw  ← le_div_iff' h_1,
     exact exp_bound_div_one_sub_of_interval h hy1 },
   rw inv_eq_one_div,
-  apply (le_div_iff' (real.exp_pos y)).2,
+  rw le_div_iff' y.exp_pos,
   rwa mul_comm at r1,
 end
 

--- a/src/data/complex/exponential.lean
+++ b/src/data/complex/exponential.lean
@@ -1350,6 +1350,18 @@ begin
   convert exp_bound hxc hn; norm_cast
 end
 
+lemma exp_bound' {x : ℝ} (h1 : 0 ≤ x) (h2 : x ≤ 1) {n : ℕ} (hn : 0 < n) :
+  real.exp x ≤ ∑ (m : ℕ) in finset.range n, x ^ m / (m.factorial)
+  + x ^ n * ((n : ℝ) + 1) / (n.factorial * (n : ℝ) ) :=
+begin
+  have h3 : |x| = x, simp, exact h1,
+  have h4 : |x| ≤ 1, rw abs_le, apply and.intro, linarith, linarith,
+  let h' := real.exp_bound h4 hn, rw h3 at h',
+  let h'' := (abs_sub_le_iff.1 h').1,
+  let t := sub_le_iff_le_add'.1 h'',
+  simp at t, rw mul_div_assoc, exact t,
+end
+
 /-- A finite initial segment of the exponential series, followed by an arbitrary tail.
 For fixed `n` this is just a linear map wrt `r`, and each map is a simple linear function
 of the previous (see `exp_near_succ`), with `exp_near n x r ⟶ exp x` as `n ⟶ ∞`,
@@ -1509,38 +1521,26 @@ calc cos 2 = cos (2 * 1) : congr_arg cos (mul_one _).symm
           zero_le_two) _
   ... < 0 : by norm_num
 
-lemma exp_bound_one_minus_approx  {x : ℝ} (h1: 0 ≤ x) (h2 : x ≤ 1) :
+lemma exp_bound_div_one_sub_of_interval_approx  {x : ℝ} (h1 : 0 ≤ x) (h2 : x ≤ 1) :
   ∑ (j : ℕ) in finset.range 3, x ^ j / (j.factorial)
   + x ^ 3 * ((3 : ℕ) + 1) / ((3 : ℕ).factorial * (3 : ℕ))
   ≤ ∑ j in (finset.range 3), x ^ j :=
 begin
   repeat {rw finset.sum}, norm_num,
-  rw add_assoc, rw add_comm (x+1) (x^3*4/18), rw ← add_assoc,
+  rw add_assoc, rw add_comm (x + 1) (x ^ 3 * 4 / 18), rw ← add_assoc,
   rw add_le_add_iff_right, rw ← add_le_add_iff_left (-(x^2/2)),
   rw ← add_assoc, rw comm_ring.add_left_neg (x^2/2), rw zero_add,
   rw neg_add_eq_sub, rw sub_half, repeat{rw pow_succ},
   rw pow_zero, rw mul_one,
   have i1 : x * 4 / 18 ≤ 1 / 2, linarith,
   have i2 : 0 ≤ x * 4 / 18, linarith,
-  let i3 := mul_le_mul h1 h1 (le_refl (0:ℝ)) h1, rw zero_mul at i3,
+  let i3 := mul_le_mul h1 h1 (le_refl (0 : ℝ)) h1, rw zero_mul at i3,
   let t := mul_le_mul (le_refl (x * x)) i1 i2 i3, rw mul_one_div at t,
   rw ← mul_assoc, rw ← mul_div_assoc at t, rw ← mul_assoc at t, exact t,
 end
 
-lemma exp_bound_truncating {x : ℝ} {n : ℕ} (h1: 0 ≤ x) (h2: x ≤ 1) : (0 < n) →
-  real.exp x ≤ ∑ (m : ℕ) in finset.range n, x ^ m / (m.factorial)
-  + x ^ n * ((n : ℝ) + 1) / (n.factorial * (n : ℝ) ) :=
-begin
-    intro hn0,
-    have h3 : |x| = x, simp, exact h1,
-    have h4 : |x| ≤ 1, rw abs_le, apply and.intro, linarith, linarith,
-    let h' := real.exp_bound h4 hn0, rw h3 at h',
-    let h'' := (abs_sub_le_iff.1 h').1,
-    let t := sub_le_iff_le_add'.1 h'',
-    simp at t, rw mul_div_assoc, exact t,
-end
-
-lemma exp_bound_one_minus {x: ℝ} (h1: 0 ≤ x) (h2 : x < 1) : real.exp x ≤ 1 / (1 - x) :=
+lemma exp_bound_div_one_sub_of_interval {x : ℝ} (h1 : 0 ≤ x) (h2 : x < 1) :
+  real.exp x ≤ 1 / (1 - x) :=
 begin
   have h : ∑ j in (finset.range 3), x^j ≤ 1/(1-x),
     repeat {rw finset.sum}, norm_num,
@@ -1551,34 +1551,34 @@ begin
     have hx3 : 0 ≤ x ^ 3, norm_num, exact h1,
     linarith,
   let h03 : 0 < 3, linarith,
-  exact le_trans (exp_bound_truncating h1 (le_of_lt h2) h03)
-   (le_trans (exp_bound_one_minus_approx h1 (le_of_lt h2)) h),
+  exact le_trans (exp_bound' h1 (le_of_lt h2) h03)
+   (le_trans (exp_bound_div_one_sub_of_interval_approx h1 (le_of_lt h2)) h),
 end
 
-lemma one_minus_le_exp_minus_of_pos {y : ℝ} (h : 0 ≤ y) : 1 - y ≤ real.exp (-y) :=
+lemma one_sub_le_exp_minus_of_pos {y : ℝ} (h : 0 ≤ y) : 1 - y ≤ real.exp (-y) :=
 begin
   rw real.exp_neg,
   have r1 : (1 - y) * (real.exp y) ≤ 1,
     by_cases hy1 : y ≥ 1,
-      have h' : 1-y ≤ 0, linarith,
-      have h'' : (1-y) * real.exp y ≤ 0,
+      have h' : 1 - y ≤ 0, linarith,
+      have h'' : (1 - y) * real.exp y ≤ 0,
         apply mul_nonpos_iff.2, right, apply and.intro, exact h', exact le_of_lt (real.exp_pos y),
       linarith,
-    have hy0 : 0 < 1-y, linarith,
-    apply (le_div_iff' hy0).1, simp at hy1, exact exp_bound_one_minus h hy1,
+    have hy0 : 0 < 1 - y, linarith,
+    apply (le_div_iff' hy0).1, simp at hy1, exact exp_bound_div_one_sub_of_interval h hy1,
   rw inv_eq_one_div, apply (le_div_iff' (real.exp_pos y)).2, rw mul_comm, exact r1,
 end
 
-lemma add_one_le_exp_of_nonpos {x:ℝ} (h: x ≤ 0) : x + 1 ≤ real.exp x :=
+lemma add_one_le_exp_of_nonpos {x : ℝ} (h : x ≤ 0) : x + 1 ≤ real.exp x :=
 begin
   rw add_comm,
   have h1 : 0 ≤ -x, linarith,
-  let r := one_minus_le_exp_minus_of_pos h1,
+  let r := one_sub_le_exp_minus_of_pos h1,
   simp at r,
   exact r,
 end
 
-lemma add_one_le_exp (x:ℝ) : x + 1 ≤ real.exp x :=
+lemma add_one_le_exp (x : ℝ) : x + 1 ≤ real.exp x :=
 begin
   by_cases h : 0 ≤ x,
     exact real.add_one_le_exp_of_nonneg h,

--- a/src/data/complex/exponential.lean
+++ b/src/data/complex/exponential.lean
@@ -1537,7 +1537,7 @@ begin
       neg_add_eq_sub, sub_half, sq, pow_succ, sq],
   have i1 : x * 4 / 18 ≤ 1 / 2 := by linarith,
   have i2 : 0 ≤ x * 4 / 18 := by linarith,
-  have i3 := mul_le_mul h1 h1 (le_refl (0 : ℝ)) h1,
+  have i3 := mul_le_mul h1 h1 le_rfl h1,
   rw zero_mul at i3,
   have t := mul_le_mul (le_refl (x * x)) i1 i2 i3,
   rw ← mul_assoc,
@@ -1552,26 +1552,24 @@ begin
     have h1x : 0 < 1 - x := by simpa,
     apply (le_div_iff h1x).2,
     norm_num [← add_assoc, mul_sub_left_distrib, mul_one, add_mul,
-      sub_add_eq_sub_sub, pow_succ' x 2],
+              sub_add_eq_sub_sub, pow_succ' x 2],
     have hx3 : 0 ≤ x ^ 3,
     { norm_num,
       exact h1 },
     linarith },
-  exact le_trans (exp_bound' h1 h2.le (by linarith))
-   (le_trans (exp_bound_div_one_sub_of_interval_approx h1 h2.le) h),
+  exact (exp_bound' h1 h2.le $ by linarith).trans
+        ((exp_bound_div_one_sub_of_interval_approx h1 h2.le).trans h),
 end
 
 lemma one_sub_le_exp_minus_of_pos {y : ℝ} (h : 0 ≤ y) : 1 - y ≤ real.exp (-y) :=
 begin
   rw real.exp_neg,
   have r1 : (1 - y) * (real.exp y) ≤ 1,
-  { cases le_or_lt (1-y) 0, {
-    have h'' : (1 - y) * real.exp y ≤ 0,
+  { cases le_or_lt (1 - y) 0,
+    { have h'' : (1 - y) * y.exp ≤ 0,
     { apply mul_nonpos_iff.2,
       right,
-      apply and.intro,
-      exact h_1,
-      exact (real.exp_pos y).le },
+      exact ⟨h_1, y.exp_pos.le⟩ },
     linarith },
     have hy1 : y < 1 := by linarith,
     apply (le_div_iff' h_1).1,

--- a/src/data/complex/exponential.lean
+++ b/src/data/complex/exponential.lean
@@ -1360,9 +1360,10 @@ begin
   have h4 : |x| ≤ 1,
   { rw abs_le,
     exact ⟨by linarith, h2⟩ },
-  let h' := real.exp_bound h4 hn, rw h3 at h',
-  let h'' := (abs_sub_le_iff.1 h').1,
-  let t := sub_le_iff_le_add'.1 h'',
+  have h' := real.exp_bound h4 hn,
+  rw h3 at h',
+  have h'' := (abs_sub_le_iff.1 h').1,
+  have t := sub_le_iff_le_add'.1 h'',
   simpa [mul_div_assoc] using t
 end
 
@@ -1536,9 +1537,9 @@ begin
       neg_add_eq_sub, sub_half, sq, pow_succ, sq],
   have i1 : x * 4 / 18 ≤ 1 / 2 := by linarith,
   have i2 : 0 ≤ x * 4 / 18 := by linarith,
-  let i3 := mul_le_mul h1 h1 (le_refl (0 : ℝ)) h1,
+  have i3 := mul_le_mul h1 h1 (le_refl (0 : ℝ)) h1,
   rw zero_mul at i3,
-  let t := mul_le_mul (le_refl (x * x)) i1 i2 i3,
+  have t := mul_le_mul (le_refl (x * x)) i1 i2 i3,
   rw ← mul_assoc,
   rwa [mul_one_div, ← mul_div_assoc, ← mul_assoc] at t,
 end
@@ -1547,36 +1548,43 @@ lemma exp_bound_div_one_sub_of_interval {x : ℝ} (h1 : 0 ≤ x) (h2 : x < 1) :
   real.exp x ≤ 1 / (1 - x) :=
 begin
   have h : ∑ j in (finset.range 3), x^j ≤ 1/(1-x),
-    repeat {rw finset.sum}, norm_num,
-    have h1x : 0 < 1 - x, simp, exact h2,
-    apply (le_div_iff h1x).2, rw ← add_assoc, rw mul_sub_left_distrib,
-    rw mul_one, repeat {rw add_mul}, repeat {rw sub_add_eq_sub_sub},
-    rw ← pow_succ' x 2, norm_num,
-    have hx3 : 0 ≤ x ^ 3, norm_num, exact h1,
-    linarith,
-  let h03 : 0 < 3, linarith,
-  exact le_trans (exp_bound' h1 (le_of_lt h2) h03)
-   (le_trans (exp_bound_div_one_sub_of_interval_approx h1 (le_of_lt h2)) h),
+  { norm_num [finset.sum],
+    have h1x : 0 < 1 - x := by simpa,
+    apply (le_div_iff h1x).2,
+    norm_num [← add_assoc, mul_sub_left_distrib, mul_one, add_mul,
+      sub_add_eq_sub_sub, pow_succ' x 2],
+    have hx3 : 0 ≤ x ^ 3,
+    { norm_num,
+      exact h1 },
+    linarith },
+  exact le_trans (exp_bound' h1 h2.le (by linarith))
+   (le_trans (exp_bound_div_one_sub_of_interval_approx h1 h2.le) h),
 end
 
 lemma one_sub_le_exp_minus_of_pos {y : ℝ} (h : 0 ≤ y) : 1 - y ≤ real.exp (-y) :=
 begin
   rw real.exp_neg,
   have r1 : (1 - y) * (real.exp y) ≤ 1,
-    by_cases hy1 : y ≥ 1,
-      have h' : 1 - y ≤ 0, linarith,
-      have h'' : (1 - y) * real.exp y ≤ 0,
-        apply mul_nonpos_iff.2, right, apply and.intro, exact h', exact le_of_lt (real.exp_pos y),
-      linarith,
-    have hy0 : 0 < 1 - y, linarith,
-    apply (le_div_iff' hy0).1, simp at hy1, exact exp_bound_div_one_sub_of_interval h hy1,
-  rw inv_eq_one_div, apply (le_div_iff' (real.exp_pos y)).2, rw mul_comm, exact r1,
+  { cases le_or_lt (1-y) 0, {
+    have h'' : (1 - y) * real.exp y ≤ 0,
+    { apply mul_nonpos_iff.2,
+      right,
+      apply and.intro,
+      exact h_1,
+      exact (real.exp_pos y).le },
+    linarith },
+    have hy1 : y < 1 := by linarith,
+    apply (le_div_iff' h_1).1,
+    exact exp_bound_div_one_sub_of_interval h hy1 },
+  rw inv_eq_one_div,
+  apply (le_div_iff' (real.exp_pos y)).2,
+  rwa mul_comm at r1,
 end
 
 lemma add_one_le_exp_of_nonpos {x : ℝ} (h : x ≤ 0) : x + 1 ≤ real.exp x :=
 begin
   rw add_comm,
-  have h1 : 0 ≤ -x, linarith,
+  have h1 : 0 ≤ -x := by linarith,
   simpa using one_sub_le_exp_minus_of_pos h1
 end
 

--- a/src/data/complex/exponential.lean
+++ b/src/data/complex/exponential.lean
@@ -1137,7 +1137,8 @@ by rw ← of_real_inj; simp [sinh_three_mul]
 
 open is_absolute_value
 
-/-- Please use `add_one_le_exp`. This is an intermediate step in the proof of `add_one_le_exp` which may become private later. -/
+/-- Please use `add_one_le_exp`. This is an intermediate step
+in the proof of `add_one_le_exp` which may become private later. -/
 lemma add_one_le_exp_of_nonneg {x : ℝ} (hx : 0 ≤ x) : x + 1 ≤ exp x :=
 calc x + 1 ≤ lim (⟨(λ n : ℕ, ((exp' x) n).re), is_cau_seq_re (exp' x)⟩ : cau_seq ℝ has_abs.abs) :
   le_lim (cau_seq.le_of_exists ⟨2,

--- a/src/data/complex/exponential.lean
+++ b/src/data/complex/exponential.lean
@@ -1356,12 +1356,14 @@ lemma exp_bound' {x : ℝ} (h1 : 0 ≤ x) (h2 : x ≤ 1) {n : ℕ} (hn : 0 < n) 
   real.exp x ≤ ∑ (m : ℕ) in finset.range n, x ^ m / (m.factorial)
   + x ^ n * ((n : ℝ) + 1) / (n.factorial * (n : ℝ) ) :=
 begin
-  have h3 : |x| = x, simp, exact h1,
-  have h4 : |x| ≤ 1, rw abs_le, apply and.intro, linarith, linarith,
+  have h3 : |x| = x := by simpa,
+  have h4 : |x| ≤ 1,
+  { rw abs_le,
+    exact ⟨by linarith, h2⟩ },
   let h' := real.exp_bound h4 hn, rw h3 at h',
   let h'' := (abs_sub_le_iff.1 h').1,
   let t := sub_le_iff_le_add'.1 h'',
-  simp at t, rw mul_div_assoc, exact t,
+  simpa [mul_div_assoc] using t
 end
 
 /-- A finite initial segment of the exponential series, followed by an arbitrary tail.
@@ -1528,17 +1530,17 @@ lemma exp_bound_div_one_sub_of_interval_approx  {x : ℝ} (h1 : 0 ≤ x) (h2 : x
   + x ^ 3 * ((3 : ℕ) + 1) / ((3 : ℕ).factorial * (3 : ℕ))
   ≤ ∑ j in (finset.range 3), x ^ j :=
 begin
-  repeat {rw finset.sum}, norm_num,
-  rw add_assoc, rw add_comm (x + 1) (x ^ 3 * 4 / 18), rw ← add_assoc,
-  rw add_le_add_iff_right, rw ← add_le_add_iff_left (-(x^2/2)),
-  rw ← add_assoc, rw comm_ring.add_left_neg (x^2/2), rw zero_add,
-  rw neg_add_eq_sub, rw sub_half, repeat{rw pow_succ},
-  rw pow_zero, rw mul_one,
-  have i1 : x * 4 / 18 ≤ 1 / 2, linarith,
-  have i2 : 0 ≤ x * 4 / 18, linarith,
-  let i3 := mul_le_mul h1 h1 (le_refl (0 : ℝ)) h1, rw zero_mul at i3,
-  let t := mul_le_mul (le_refl (x * x)) i1 i2 i3, rw mul_one_div at t,
-  rw ← mul_assoc, rw ← mul_div_assoc at t, rw ← mul_assoc at t, exact t,
+  norm_num [finset.sum],
+  rw [add_assoc, add_comm (x + 1) (x ^ 3 * 4 / 18), ← add_assoc, add_le_add_iff_right,
+      ← add_le_add_iff_left (-(x^2/2)), ← add_assoc, comm_ring.add_left_neg (x^2/2), zero_add,
+      neg_add_eq_sub, sub_half, sq, pow_succ, sq],
+  have i1 : x * 4 / 18 ≤ 1 / 2 := by linarith,
+  have i2 : 0 ≤ x * 4 / 18 := by linarith,
+  let i3 := mul_le_mul h1 h1 (le_refl (0 : ℝ)) h1,
+  rw zero_mul at i3,
+  let t := mul_le_mul (le_refl (x * x)) i1 i2 i3,
+  rw ← mul_assoc,
+  rwa [mul_one_div, ← mul_div_assoc, ← mul_assoc] at t,
 end
 
 lemma exp_bound_div_one_sub_of_interval {x : ℝ} (h1 : 0 ≤ x) (h2 : x < 1) :
@@ -1575,17 +1577,14 @@ lemma add_one_le_exp_of_nonpos {x : ℝ} (h : x ≤ 0) : x + 1 ≤ real.exp x :=
 begin
   rw add_comm,
   have h1 : 0 ≤ -x, linarith,
-  let r := one_sub_le_exp_minus_of_pos h1,
-  simp at r,
-  exact r,
+  simpa using one_sub_le_exp_minus_of_pos h1
 end
 
 lemma add_one_le_exp (x : ℝ) : x + 1 ≤ real.exp x :=
 begin
-  by_cases h : 0 ≤ x,
-    exact real.add_one_le_exp_of_nonneg h,
-  simp at h,
-  exact add_one_le_exp_of_nonpos (le_of_lt h),
+  cases le_or_lt 0 x,
+  { exact real.add_one_le_exp_of_nonneg h },
+  exact add_one_le_exp_of_nonpos h.le,
 end
 
 end real

--- a/src/data/complex/exponential.lean
+++ b/src/data/complex/exponential.lean
@@ -1137,8 +1137,8 @@ by rw ← of_real_inj; simp [sinh_three_mul]
 
 open is_absolute_value
 
-/-- Please use `add_one_le_exp`. This is an intermediate step
-in the proof of `add_one_le_exp` which may become private later. -/
+/-- This is an intermediate result that is later replaced by `real.add_one_le_exp`; use that lemma
+instead. -/
 lemma add_one_le_exp_of_nonneg {x : ℝ} (hx : 0 ≤ x) : x + 1 ≤ exp x :=
 calc x + 1 ≤ lim (⟨(λ n : ℕ, ((exp' x) n).re), is_cau_seq_re (exp' x)⟩ : cau_seq ℝ has_abs.abs) :
   le_lim (cau_seq.le_of_exists ⟨2,
@@ -1353,8 +1353,7 @@ begin
 end
 
 lemma exp_bound' {x : ℝ} (h1 : 0 ≤ x) (h2 : x ≤ 1) {n : ℕ} (hn : 0 < n) :
-  real.exp x ≤ ∑ (m : ℕ) in finset.range n, x ^ m / (m.factorial)
-  + x ^ n * ((n : ℝ) + 1) / (n.factorial * (n : ℝ) ) :=
+  real.exp x ≤ ∑ m in finset.range n, x ^ m / m! + x ^ n * (n + 1) / (n! * n) :=
 begin
   have h3 : |x| = x := by simpa,
   have h4 : |x| ≤ 1,

--- a/src/data/complex/exponential.lean
+++ b/src/data/complex/exponential.lean
@@ -1356,9 +1356,7 @@ lemma exp_bound' {x : ℝ} (h1 : 0 ≤ x) (h2 : x ≤ 1) {n : ℕ} (hn : 0 < n) 
   real.exp x ≤ ∑ m in finset.range n, x ^ m / m! + x ^ n * (n + 1) / (n! * n) :=
 begin
   have h3 : |x| = x := by simpa,
-  have h4 : |x| ≤ 1,
-  { rw abs_le,
-    exact ⟨by linarith, h2⟩ },
+  have h4 : |x| ≤ 1 := by rwa h3,
   have h' := real.exp_bound h4 hn,
   rw h3 at h',
   have h'' := (abs_sub_le_iff.1 h').1,


### PR DESCRIPTION
This PR resolves https://github.com/leanprover-community/mathlib/blob/master/src/data/complex/exponential.lean#L1140

---

[This TODO](https://github.com/leanprover-community/mathlib/blob/master/src/data/complex/exponential.lean#L1140) says that `add_one_le_exp_of_nonneg` should be private.

I could not make `add_one_le_exp_of_nonneg` private because  my proof of  `add_one_le_exp` also uses `real.exp_bound` which is defined after the namespace for `add_one_le_exp_of_nonneg` is closed.

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
