### PR TITLE
[Merged by Bors] - feat(measure_theory/probability_mass_function): Calculate supports of pmf constructions

### DIFF
--- a/src/measure_theory/probability_mass_function/basic.lean
+++ b/src/measure_theory/probability_mass_function/basic.lean
@@ -76,7 +76,6 @@ rfl
 lemma support_pure : (pure a).support = {a} :=
 set.ext (λ a', by simp [mem_support_iff])
 
-@[simp]
 lemma mem_support_pure_iff: a' ∈ (pure a).support ↔ a' = a :=
 by simp
 
@@ -115,8 +114,7 @@ rfl
 lemma support_bind : (p.bind f).support = {b | ∃ a ∈ p.support, b ∈ (f a).support} :=
 set.ext (λ b, by simp [mem_support_iff, tsum_eq_zero_iff (bind.summable p f b), not_or_distrib])
 
-@[simp]
-lemma mem_support_bind (b : β) : b ∈ (p.bind f).support ↔ ∃ a ∈ p.support, b ∈ (f a).support :=
+lemma mem_support_bind_iff (b : β) : b ∈ (p.bind f).support ↔ ∃ a ∈ p.support, b ∈ (f a).support :=
 by simp
 
 lemma coe_bind_apply (p : pmf α) (f : α → pmf β) (b : β) :

--- a/src/measure_theory/probability_mass_function/basic.lean
+++ b/src/measure_theory/probability_mass_function/basic.lean
@@ -68,8 +68,11 @@ def pure (a : α) : pmf α := ⟨λ a', if a' = a then 1 else 0, has_sum_ite_eq 
 
 @[simp] lemma pure_apply (a a' : α) : pure a a' = (if a' = a then 1 else 0) := rfl
 
-lemma mem_support_pure_iff (a a' : α) : a' ∈ (pure a).support ↔ a' = a :=
+@[simp] lemma mem_support_pure_iff (a a' : α) : a' ∈ (pure a).support ↔ a' = a :=
 by simp
+
+@[simp] lemma support_pure (a : α) : (pure a).support = {a} :=
+set.ext (λ a', by simp)
 
 instance [inhabited α] : inhabited (pmf α) := ⟨pure (default α)⟩
 
@@ -98,6 +101,14 @@ def bind (p : pmf α) (f : α → pmf β) : pmf β :=
 
 @[simp] lemma bind_apply (p : pmf α) (f : α → pmf β) (b : β) : p.bind f b = ∑'a, p a * f a b :=
 rfl
+
+@[simp] lemma mem_support_bind (p : pmf α) (f : α → pmf β) (b : β) :
+  b ∈ (p.bind f).support ↔ ∃ a ∈ p.support, b ∈ (f a).support :=
+by simp [tsum_eq_zero_iff (bind.summable p f b), not_or_distrib]
+
+@[simp] lemma support_bind (p : pmf α) (f : α → pmf β) :
+  (p.bind f).support = {b | ∃ a ∈ p.support, b ∈ (f a).support} :=
+set.ext (λ b, mem_support_bind p f b)
 
 lemma coe_bind_apply (p : pmf α) (f : α → pmf β) (b : β) :
   (p.bind f b : ℝ≥0∞) = ∑'a, p a * f a b :=

--- a/src/measure_theory/probability_mass_function/basic.lean
+++ b/src/measure_theory/probability_mass_function/basic.lean
@@ -66,13 +66,19 @@ section pure
   The value of `pure a` is `1` at `a` and `0` elsewhere. -/
 def pure (a : α) : pmf α := ⟨λ a', if a' = a then 1 else 0, has_sum_ite_eq _ _⟩
 
-@[simp] lemma pure_apply (a a' : α) : pure a a' = (if a' = a then 1 else 0) := rfl
+variables (a a' : α)
 
-@[simp] lemma mem_support_pure_iff (a a' : α) : a' ∈ (pure a).support ↔ a' = a :=
-by simp [mem_support_iff]
+@[simp]
+lemma pure_apply : pure a a' = (if a' = a then 1 else 0) :=
+rfl
 
-@[simp] lemma support_pure (a : α) : (pure a).support = {a} :=
-set.ext (λ a', by simp)
+@[simp]
+lemma support_pure : (pure a).support = {a} :=
+set.ext (λ a', by simp [mem_support_iff])
+
+@[simp]
+lemma mem_support_pure_iff: a' ∈ (pure a).support ↔ a' = a :=
+by simp
 
 instance [inhabited α] : inhabited (pmf α) := ⟨pure (default α)⟩
 
@@ -99,16 +105,19 @@ def bind (p : pmf α) (f : α → pmf β) : pmf β :=
       (ennreal.coe_tsum p.summable_coe).symm]
   end⟩
 
-@[simp] lemma bind_apply (p : pmf α) (f : α → pmf β) (b : β) : p.bind f b = ∑'a, p a * f a b :=
+variables (p : pmf α) (f : α → pmf β)
+
+@[simp]
+lemma bind_apply (b : β) : p.bind f b = ∑'a, p a * f a b :=
 rfl
 
-@[simp] lemma mem_support_bind (p : pmf α) (f : α → pmf β) (b : β) :
-  b ∈ (p.bind f).support ↔ ∃ a ∈ p.support, b ∈ (f a).support :=
-by simp [mem_support_iff, tsum_eq_zero_iff (bind.summable p f b), not_or_distrib]
+@[simp]
+lemma support_bind : (p.bind f).support = {b | ∃ a ∈ p.support, b ∈ (f a).support} :=
+set.ext (λ b, by simp [mem_support_iff, tsum_eq_zero_iff (bind.summable p f b), not_or_distrib])
 
-@[simp] lemma support_bind (p : pmf α) (f : α → pmf β) :
-  (p.bind f).support = {b | ∃ a ∈ p.support, b ∈ (f a).support} :=
-set.ext (λ b, mem_support_bind p f b)
+@[simp]
+lemma mem_support_bind (b : β) : b ∈ (p.bind f).support ↔ ∃ a ∈ p.support, b ∈ (f a).support :=
+by simp
 
 lemma coe_bind_apply (p : pmf α) (f : α → pmf β) (b : β) :
   (p.bind f b : ℝ≥0∞) = ∑'a, p a * f a b :=

--- a/src/measure_theory/probability_mass_function/basic.lean
+++ b/src/measure_theory/probability_mass_function/basic.lean
@@ -49,6 +49,7 @@ lemma summable_coe (p : pmf α) : summable p := (p.has_sum_coe_one).summable
 /-- The support of a `pmf` is the set where it is nonzero. -/
 def support (p : pmf α) : set α := function.support p
 
+@[simp]
 lemma mem_support_iff (p : pmf α) (a : α) :
   a ∈ p.support ↔ p a ≠ 0 := iff.rfl
 

--- a/src/measure_theory/probability_mass_function/basic.lean
+++ b/src/measure_theory/probability_mass_function/basic.lean
@@ -49,7 +49,7 @@ lemma summable_coe (p : pmf α) : summable p := (p.has_sum_coe_one).summable
 /-- The support of a `pmf` is the set where it is nonzero. -/
 def support (p : pmf α) : set α := function.support p
 
-@[simp] lemma mem_support_iff (p : pmf α) (a : α) :
+lemma mem_support_iff (p : pmf α) (a : α) :
   a ∈ p.support ↔ p a ≠ 0 := iff.rfl
 
 lemma apply_eq_zero_iff (p : pmf α) (a : α) :
@@ -69,7 +69,7 @@ def pure (a : α) : pmf α := ⟨λ a', if a' = a then 1 else 0, has_sum_ite_eq 
 @[simp] lemma pure_apply (a a' : α) : pure a a' = (if a' = a then 1 else 0) := rfl
 
 @[simp] lemma mem_support_pure_iff (a a' : α) : a' ∈ (pure a).support ↔ a' = a :=
-by simp
+by simp [mem_support_iff]
 
 @[simp] lemma support_pure (a : α) : (pure a).support = {a} :=
 set.ext (λ a', by simp)
@@ -104,7 +104,7 @@ rfl
 
 @[simp] lemma mem_support_bind (p : pmf α) (f : α → pmf β) (b : β) :
   b ∈ (p.bind f).support ↔ ∃ a ∈ p.support, b ∈ (f a).support :=
-by simp [tsum_eq_zero_iff (bind.summable p f b), not_or_distrib]
+by simp [mem_support_iff, tsum_eq_zero_iff (bind.summable p f b), not_or_distrib]
 
 @[simp] lemma support_bind (p : pmf α) (f : α → pmf β) :
   (p.bind f).support = {b | ∃ a ∈ p.support, b ∈ (f a).support} :=

--- a/src/measure_theory/probability_mass_function/basic.lean
+++ b/src/measure_theory/probability_mass_function/basic.lean
@@ -49,12 +49,9 @@ lemma summable_coe (p : pmf α) : summable p := (p.has_sum_coe_one).summable
 /-- The support of a `pmf` is the set where it is nonzero. -/
 def support (p : pmf α) : set α := function.support p
 
-@[simp]
-lemma mem_support_iff (p : pmf α) (a : α) :
-  a ∈ p.support ↔ p a ≠ 0 := iff.rfl
+@[simp] lemma mem_support_iff (p : pmf α) (a : α) : a ∈ p.support ↔ p a ≠ 0 := iff.rfl
 
-lemma apply_eq_zero_iff (p : pmf α) (a : α) :
-  p a = 0 ↔ a ∉ p.support :=
+lemma apply_eq_zero_iff (p : pmf α) (a : α) : p a = 0 ↔ a ∉ p.support :=
 by rw [mem_support_iff, not_not]
 
 lemma coe_le_one (p : pmf α) (a : α) : p a ≤ 1 :=
@@ -69,16 +66,11 @@ def pure (a : α) : pmf α := ⟨λ a', if a' = a then 1 else 0, has_sum_ite_eq 
 
 variables (a a' : α)
 
-@[simp]
-lemma pure_apply : pure a a' = (if a' = a then 1 else 0) :=
-rfl
+@[simp] lemma pure_apply : pure a a' = (if a' = a then 1 else 0) := rfl
 
-@[simp]
-lemma support_pure : (pure a).support = {a} :=
-set.ext (λ a', by simp [mem_support_iff])
+@[simp] lemma support_pure : (pure a).support = {a} := set.ext (λ a', by simp [mem_support_iff])
 
-lemma mem_support_pure_iff: a' ∈ (pure a).support ↔ a' = a :=
-by simp
+lemma mem_support_pure_iff: a' ∈ (pure a).support ↔ a' = a := by simp
 
 instance [inhabited α] : inhabited (pmf α) := ⟨pure (default α)⟩
 
@@ -107,12 +99,9 @@ def bind (p : pmf α) (f : α → pmf β) : pmf β :=
 
 variables (p : pmf α) (f : α → pmf β)
 
-@[simp]
-lemma bind_apply (b : β) : p.bind f b = ∑'a, p a * f a b :=
-rfl
+@[simp] lemma bind_apply (b : β) : p.bind f b = ∑'a, p a * f a b := rfl
 
-@[simp]
-lemma support_bind : (p.bind f).support = {b | ∃ a ∈ p.support, b ∈ (f a).support} :=
+@[simp] lemma support_bind : (p.bind f).support = {b | ∃ a ∈ p.support, b ∈ (f a).support} :=
 set.ext (λ b, by simp [mem_support_iff, tsum_eq_zero_iff (bind.summable p f b), not_or_distrib])
 
 lemma mem_support_bind_iff (b : β) : b ∈ (p.bind f).support ↔ ∃ a ∈ p.support, b ∈ (f a).support :=

--- a/src/measure_theory/probability_mass_function/constructions.lean
+++ b/src/measure_theory/probability_mass_function/constructions.lean
@@ -41,16 +41,12 @@ def map (f : α → β) (p : pmf α) : pmf β := bind p (pure ∘ f)
 
 variables (f : α → β) (p : pmf α) (b : β)
 
-@[simp]
-lemma map_apply : (map f p) b = ∑' a, if b = f a then p a else 0 :=
-by simp [map]
+@[simp] lemma map_apply : (map f p) b = ∑' a, if b = f a then p a else 0 := by simp [map]
 
-@[simp]
-lemma support_map : (map f p).support = f '' p.support :=
+@[simp] lemma support_map : (map f p).support = f '' p.support :=
 set.ext (λ b, by simp [map, @eq_comm β b])
 
-lemma mem_support_map_iff : b ∈ (map f p).support ↔ ∃ a ∈ p.support, f a = b :=
-by simp
+lemma mem_support_map_iff : b ∈ (map f p).support ↔ ∃ a ∈ p.support, f a = b := by simp
 
 lemma bind_pure_comp : bind p (pure ∘ f) = map f p := rfl
 
@@ -71,16 +67,14 @@ def seq (q : pmf (α → β)) (p : pmf α) : pmf β := q.bind (λ m, p.bind $ λ
 
 variables (q : pmf (α → β)) (p : pmf α) (b : β)
 
-@[simp]
-lemma seq_apply : (seq q p) b = ∑' (f : α → β) (a : α), if b = f a then q f * p a else 0 :=
+@[simp] lemma seq_apply : (seq q p) b = ∑' (f : α → β) (a : α), if b = f a then q f * p a else 0 :=
 begin
   simp only [seq, mul_boole, bind_apply, pure_apply],
   refine tsum_congr (λ f, (nnreal.tsum_mul_left (q f) _).symm.trans (tsum_congr (λ a, _))),
   simpa only [mul_zero] using mul_ite (b = f a) (q f) (p a) 0
 end
 
-@[simp]
-lemma support_seq : (seq q p).support = ⋃ f ∈ q.support, f '' p.support :=
+@[simp] lemma support_seq : (seq q p).support = ⋃ f ∈ q.support, f '' p.support :=
 set.ext (λ b, by simp [-mem_support_iff, seq, @eq_comm β b])
 
 lemma mem_support_seq_iff : b ∈ (seq q p).support ↔ ∃ (f ∈ q.support), b ∈ f '' p.support :=
@@ -98,11 +92,9 @@ def of_finset (f : α → ℝ≥0) (s : finset α) (h : ∑ a in s, f a = 1)
 
 variables {f : α → ℝ≥0} {s : finset α} (h : ∑ a in s, f a = 1) (h' : ∀ a ∉ s, f a = 0)
 
-@[simp]
-lemma of_finset_apply (a : α) : of_finset f s h h' a = f a := rfl
+@[simp] lemma of_finset_apply (a : α) : of_finset f s h h' a = f a := rfl
 
-@[simp]
-lemma support_of_finset : (of_finset f s h h').support = s ∩ (function.support f) :=
+@[simp] lemma support_of_finset : (of_finset f s h h').support = s ∩ (function.support f) :=
 set.ext (λ a, by simpa [mem_support_iff] using mt (h' a))
 
 lemma mem_support_of_finset_iff (a : α) : a ∈ (of_finset f s h h').support ↔ a ∈ s ∧ f a ≠ 0 :=
@@ -121,16 +113,11 @@ of_finset f finset.univ h (λ a ha, absurd (finset.mem_univ a) ha)
 
 variables [fintype α] {f : α → ℝ≥0} (h : ∑ a, f a = 1)
 
-@[simp]
-lemma of_fintype_apply (a : α) : of_fintype f h a = f a :=
-rfl
+@[simp] lemma of_fintype_apply (a : α) : of_fintype f h a = f a := rfl
 
-@[simp]
-lemma support_of_fintype : (of_fintype f h).support = function.support f :=
-rfl
+@[simp] lemma support_of_fintype : (of_fintype f h).support = function.support f := rfl
 
-lemma mem_support_of_fintype_iff (a : α) : a ∈ (of_fintype f h).support ↔ f a ≠ 0 :=
-iff.rfl
+lemma mem_support_of_fintype_iff (a : α) : a ∈ (of_fintype f h).support ↔ f a ≠ 0 := iff.rfl
 
 end of_fintype
 
@@ -152,12 +139,9 @@ def of_multiset (s : multiset α) (hs : s ≠ 0) : pmf α :=
 
 variables {s : multiset α} (hs : s ≠ 0)
 
-@[simp]
-lemma of_multiset_apply (a : α) : of_multiset s hs a = s.count a / s.card :=
-rfl
+@[simp] lemma of_multiset_apply (a : α) : of_multiset s hs a = s.count a / s.card := rfl
 
-@[simp]
-lemma support_of_multiset : (of_multiset s hs).support = s.to_finset :=
+@[simp] lemma support_of_multiset : (of_multiset s hs).support = s.to_finset :=
 set.ext (by simp [mem_support_iff, hs])
 
 lemma mem_support_of_multiset_iff (a : α) : a ∈ (of_multiset s hs).support ↔ a ∈ s.to_finset :=
@@ -182,23 +166,18 @@ of_finset (λ a, if a ∈ s then (s.card : ℝ≥0)⁻¹ else 0) s (Exists.rec_o
     ... = 1 : div_self (nat.cast_ne_zero.2 $ finset.card_ne_zero_of_mem hx)
   )) (λ x hx, by simp only [hx, if_false])
 
-variables {s : finset α} (hs : s.nonempty)
+variables {s : finset α} (hs : s.nonempty) {a : α}
 
-@[simp]
-lemma uniform_of_finset_apply (a : α) :
-  uniform_of_finset s hs a = if a ∈ s then (s.card : ℝ≥0)⁻¹ else 0 :=
-rfl
+@[simp] lemma uniform_of_finset_apply (a : α) :
+  uniform_of_finset s hs a = if a ∈ s then (s.card : ℝ≥0)⁻¹ else 0 := rfl
 
-lemma uniform_of_finset_apply_of_mem {a : α} (ha : a ∈ s) :
-  uniform_of_finset s hs a = (s.card)⁻¹ :=
+lemma uniform_of_finset_apply_of_mem (ha : a ∈ s) : uniform_of_finset s hs a = (s.card)⁻¹ :=
 by simp [ha]
 
-lemma uniform_of_finset_apply_of_not_mem {a : α} (ha : a ∉ s) :
-  uniform_of_finset s hs a = 0 :=
+lemma uniform_of_finset_apply_of_not_mem (ha : a ∉ s) : uniform_of_finset s hs a = 0 :=
 by simp [ha]
 
-@[simp]
-lemma support_uniform_of_finset : (uniform_of_finset s hs).support = s :=
+@[simp] lemma support_uniform_of_finset : (uniform_of_finset s hs).support = s :=
 set.ext (let ⟨a, ha⟩ := hs in by simp [mem_support_iff, finset.ne_empty_of_mem ha])
 
 lemma mem_support_uniform_of_finset_iff (a : α) : a ∈ (uniform_of_finset s hs).support ↔ a ∈ s :=
@@ -214,21 +193,17 @@ def uniform_of_fintype (α : Type*) [fintype α] [nonempty α] : pmf α :=
 
 variables [fintype α] [nonempty α]
 
-@[simp]
-lemma uniform_of_fintype_apply (a : α) :
-  uniform_of_fintype α a = (fintype.card α)⁻¹ :=
+@[simp] lemma uniform_of_fintype_apply (a : α) : uniform_of_fintype α a = (fintype.card α)⁻¹ :=
 by simpa only [uniform_of_fintype, finset.mem_univ, if_true, uniform_of_finset_apply]
 
 variable (α)
 
-@[simp]
-lemma support_uniform_of_fintype : (uniform_of_fintype α).support = ⊤ :=
+@[simp] lemma support_uniform_of_fintype : (uniform_of_fintype α).support = ⊤ :=
 set.ext (λ x, by simpa [mem_support_iff] using fintype.card_ne_zero)
 
 variable {α}
 
-lemma mem_support_uniform_of_fintype (a : α) : a ∈ (uniform_of_fintype α).support :=
-by simp
+lemma mem_support_uniform_of_fintype_iff (a : α) : a ∈ (uniform_of_fintype α).support := by simp
 
 end uniform_of_fintype
 
@@ -244,15 +219,12 @@ def normalize (f : α → ℝ≥0) (hf0 : tsum f ≠ 0) : pmf α :=
 
 variables {f : α → ℝ≥0} (hf0 : tsum f ≠ 0)
 
-@[simp]
-lemma normalize_apply (a : α) : (normalize f hf0) a = f a * (∑' x, f x)⁻¹ := rfl
+@[simp] lemma normalize_apply (a : α) : (normalize f hf0) a = f a * (∑' x, f x)⁻¹ := rfl
 
-@[simp]
-lemma support_normalize : (normalize f hf0).support = function.support f :=
+@[simp] lemma support_normalize : (normalize f hf0).support = function.support f :=
 set.ext (by simp [mem_support_iff, hf0])
 
-lemma mem_support_normalize_iff (a : α) : a ∈ (normalize f hf0).support ↔ f a ≠ 0 :=
-by simp
+lemma mem_support_normalize_iff (a : α) : a ∈ (normalize f hf0).support ↔ f a ≠ 0 := by simp
 
 end normalize
 
@@ -271,19 +243,18 @@ by rw [filter, normalize_apply]
 lemma filter_apply_eq_zero_of_not_mem {a : α} (ha : a ∉ s) : (p.filter s h) a = 0 :=
 by rw [filter_apply, set.indicator_apply_eq_zero.mpr (λ ha', absurd ha' ha), zero_mul]
 
-@[simp]
-lemma support_filter_apply : (p.filter s h).support = s ∩ p.support:=
+@[simp] lemma support_filter : (p.filter s h).support = s ∩ p.support:=
 begin
   refine set.ext (λ a, _),
   rw [mem_support_iff, filter_apply, mul_ne_zero_iff, set.indicator_eq_zero_iff],
   exact ⟨λ ha, ha.1, λ ha, ⟨ha, inv_ne_zero (nnreal.tsum_indicator_ne_zero p.2.summable h)⟩⟩
 end
 
-lemma mem_support_filter_apply (a : α) : a ∈ (p.filter s h).support ↔ a ∈ s ∧ a ∈ p.support :=
+lemma mem_support_filter_iff (a : α) : a ∈ (p.filter s h).support ↔ a ∈ s ∧ a ∈ p.support :=
 by simp
 
 lemma filter_apply_eq_zero_iff (a : α) : (p.filter s h) a = 0 ↔ a ∉ s ∨ a ∉ p.support :=
-by erw [apply_eq_zero_iff, support_filter_apply, set.mem_inter_iff, not_and_distrib]
+by erw [apply_eq_zero_iff, support_filter, set.mem_inter_iff, not_and_distrib]
 
 lemma filter_apply_ne_zero_iff (a : α) : (p.filter s h) a ≠ 0 ↔ a ∈ s ∧ a ∈ p.support :=
 by rw [ne.def, filter_apply_eq_zero_iff, not_or_distrib, not_not, not_not]
@@ -296,13 +267,11 @@ section bernoulli
 def bernoulli (p : ℝ≥0) (h : p ≤ 1) : pmf bool :=
 of_fintype (λ b, cond b p (1 - p)) (nnreal.eq $ by simp [h])
 
-variables {p : ℝ≥0} (h : p ≤ 1)
+variables {p : ℝ≥0} (h : p ≤ 1) (b : bool)
 
-@[simp]
-lemma bernoulli_apply (b : bool) : bernoulli p h b = cond b p (1 - p) := rfl
+@[simp] lemma bernoulli_apply : bernoulli p h b = cond b p (1 - p) := rfl
 
-@[simp]
-lemma support_bernoulli : (bernoulli p h).support = {b | cond b (p ≠ 0) (p ≠ 1)} :=
+@[simp] lemma support_bernoulli : (bernoulli p h).support = {b | cond b (p ≠ 0) (p ≠ 1)} :=
 begin
   refine set.ext (λ b, _),
   induction b,
@@ -311,9 +280,7 @@ begin
   { simp only [mem_support_iff, bernoulli_apply, bool.cond_tt, set.mem_set_of_eq], }
 end
 
-lemma mem_support_bernoulli_iff (b : bool) :
-  b ∈ (bernoulli p h).support ↔ cond b (p ≠ 0) (p ≠ 1) :=
-by simp
+lemma mem_support_bernoulli_iff : b ∈ (bernoulli p h).support ↔ cond b (p ≠ 0) (p ≠ 1) := by simp
 
 end bernoulli
 
@@ -347,13 +314,11 @@ end⟩
 
 variables {p : pmf α} (f : Π a ∈ p.support, pmf β)
 
-@[simp]
-lemma bind_on_support_apply (b : β) :
+@[simp] lemma bind_on_support_apply (b : β) :
   p.bind_on_support f b = ∑' a, p a * if h : p a = 0 then 0 else f a h b :=
 rfl
 
-@[simp]
-lemma support_bind_on_support :
+@[simp] lemma support_bind_on_support :
   (p.bind_on_support f).support = {b | ∃ (a : α) (h : a ∈ p.support), b ∈ (f a h).support} :=
 begin
   refine set.ext (λ b, _),

--- a/src/measure_theory/probability_mass_function/constructions.lean
+++ b/src/measure_theory/probability_mass_function/constructions.lean
@@ -74,16 +74,14 @@ variables (q : pmf (α → β)) (p : pmf α) (b : β)
 @[simp]
 lemma seq_apply : (seq q p) b = ∑' (f : α → β) (a : α), if b = f a then q f * p a else 0 :=
 begin
-  simp [seq],
-  refine tsum_congr (λ f, _),
-  rw ← nnreal.tsum_mul_left (q f),
-  refine tsum_congr (λ a, _),
-  split_ifs; simp
+  simp only [seq, mul_boole, bind_apply, pure_apply],
+  refine tsum_congr (λ f, (nnreal.tsum_mul_left (q f) _).symm.trans (tsum_congr (λ a, _))),
+  simpa only [mul_zero] using mul_ite (b = f a) (q f) (p a) 0
 end
 
 @[simp]
 lemma support_seq : (seq q p).support = ⋃ f ∈ q.support, f '' p.support :=
-set.ext (λ b, by simp [seq, @eq_comm β b])
+set.ext (λ b, by simp [-mem_support_iff, seq, @eq_comm β b])
 
 lemma mem_support_seq_iff : b ∈ (seq q p).support ↔ ∃ (f ∈ q.support), b ∈ f '' p.support :=
 by simp

--- a/src/measure_theory/probability_mass_function/constructions.lean
+++ b/src/measure_theory/probability_mass_function/constructions.lean
@@ -49,7 +49,6 @@ by simp [map]
 lemma support_map : (map f p).support = f '' p.support :=
 set.ext (λ b, by simp [map, @eq_comm β b])
 
-@[simp]
 lemma mem_support_map_iff : b ∈ (map f p).support ↔ ∃ a ∈ p.support, f a = b :=
 by simp
 
@@ -86,7 +85,6 @@ end
 lemma support_seq : (seq q p).support = ⋃ f ∈ q.support, f '' p.support :=
 set.ext (λ b, by simp [seq, @eq_comm β b])
 
-@[simp]
 lemma mem_support_seq_iff : b ∈ (seq q p).support ↔ ∃ (f ∈ q.support), b ∈ f '' p.support :=
 by simp
 
@@ -109,7 +107,6 @@ lemma of_finset_apply (a : α) : of_finset f s h h' a = f a := rfl
 lemma support_of_finset : (of_finset f s h h').support = s ∩ (function.support f) :=
 set.ext (λ a, by simpa [mem_support_iff] using mt (h' a))
 
-@[simp]
 lemma mem_support_of_finset_iff (a : α) : a ∈ (of_finset f s h h').support ↔ a ∈ s ∧ f a ≠ 0 :=
 by simp
 
@@ -134,7 +131,6 @@ rfl
 lemma support_of_fintype : (of_fintype f h).support = function.support f :=
 rfl
 
-@[simp]
 lemma mem_support_of_fintype_iff (a : α) : a ∈ (of_fintype f h).support ↔ f a ≠ 0 :=
 iff.rfl
 
@@ -166,7 +162,6 @@ rfl
 lemma support_of_multiset : (of_multiset s hs).support = s.to_finset :=
 set.ext (by simp [mem_support_iff, hs])
 
-@[simp]
 lemma mem_support_of_multiset_iff (a : α) : a ∈ (of_multiset s hs).support ↔ a ∈ s.to_finset :=
 by simp
 
@@ -208,7 +203,6 @@ by simp [ha]
 lemma support_uniform_of_finset : (uniform_of_finset s hs).support = s :=
 set.ext (let ⟨a, ha⟩ := hs in by simp [mem_support_iff, finset.ne_empty_of_mem ha])
 
-@[simp]
 lemma mem_support_uniform_of_finset_iff (a : α) : a ∈ (uniform_of_finset s hs).support ↔ a ∈ s :=
 by simp
 
@@ -235,8 +229,7 @@ set.ext (λ x, by simpa [mem_support_iff] using fintype.card_ne_zero)
 
 variable {α}
 
-@[simp]
-lemma mem_support_uniform_of_fintype_iff (a : α) : a ∈ (uniform_of_fintype α).support :=
+lemma mem_support_uniform_of_fintype (a : α) : a ∈ (uniform_of_fintype α).support :=
 by simp
 
 end uniform_of_fintype
@@ -260,7 +253,6 @@ lemma normalize_apply (a : α) : (normalize f hf0) a = f a * (∑' x, f x)⁻¹ 
 lemma support_normalize : (normalize f hf0).support = function.support f :=
 set.ext (by simp [mem_support_iff, hf0])
 
-@[simp]
 lemma mem_support_normalize_iff (a : α) : a ∈ (normalize f hf0).support ↔ f a ≠ 0 :=
 by simp
 
@@ -289,7 +281,6 @@ begin
   exact ⟨λ ha, ha.1, λ ha, ⟨ha, inv_ne_zero (nnreal.tsum_indicator_ne_zero p.2.summable h)⟩⟩
 end
 
-@[simp]
 lemma mem_support_filter_apply (a : α) : a ∈ (p.filter s h).support ↔ a ∈ s ∧ a ∈ p.support :=
 by simp
 
@@ -322,7 +313,6 @@ begin
   { simp only [mem_support_iff, bernoulli_apply, bool.cond_tt, set.mem_set_of_eq], }
 end
 
-@[simp]
 lemma mem_support_bernoulli_iff (b : bool) :
   b ∈ (bernoulli p h).support ↔ cond b (p ≠ 0) (p ≠ 1) :=
 by simp
@@ -359,11 +349,13 @@ end⟩
 
 variables {p : pmf α} (f : Π a ∈ p.support, pmf β)
 
-@[simp] lemma bind_on_support_apply (b : β) :
+@[simp]
+lemma bind_on_support_apply (b : β) :
   p.bind_on_support f b = ∑' a, p a * if h : p a = 0 then 0 else f a h b :=
 rfl
 
-@[simp] lemma support_bind_on_support :
+@[simp]
+lemma support_bind_on_support :
   (p.bind_on_support f).support = {b | ∃ (a : α) (h : a ∈ p.support), b ∈ (f a h).support} :=
 begin
   refine set.ext (λ b, _),
@@ -373,7 +365,7 @@ begin
     λ hb, let ⟨a, ha, ha'⟩ := hb in ⟨a, ⟨ha, by simpa [(mem_support_iff _ a).1 ha] using ha'⟩⟩⟩
 end
 
-@[simp] lemma mem_support_bind_on_support_iff (b : β) :
+lemma mem_support_bind_on_support_iff (b : β) :
   b ∈ (p.bind_on_support f).support ↔ ∃ (a : α) (h : a ∈ p.support), b ∈ (f a h).support :=
 by simp
 

--- a/src/measure_theory/probability_mass_function/constructions.lean
+++ b/src/measure_theory/probability_mass_function/constructions.lean
@@ -39,14 +39,25 @@ section map
 /-- The functorial action of a function on a `pmf`. -/
 def map (f : α → β) (p : pmf α) : pmf β := bind p (pure ∘ f)
 
-lemma bind_pure_comp (f : α → β) (p : pmf α) : bind p (pure ∘ f) = map f p := rfl
+variables (f : α → β) (p : pmf α) (b : β)
 
-lemma map_id (p : pmf α) : map id p = p := by simp [map]
-
-lemma map_comp (p : pmf α) (f : α → β) (g : β → γ) : (p.map f).map g = p.map (g ∘ f) :=
+@[simp] lemma map_apply : (map f p) b = ∑' a, if b = f a then p a else 0 :=
 by simp [map]
 
-lemma pure_map (a : α) (f : α → β) : (pure a).map f = pure (f a) :=
+@[simp] lemma mem_support_map_iff : b ∈ (map f p).support ↔ ∃ a ∈ p.support, b = f a :=
+by simp [map]
+
+@[simp] lemma support_map : (map f p).support = f '' p.support :=
+set.ext (λ b, by simp [@eq_comm β b])
+
+lemma bind_pure_comp : bind p (pure ∘ f) = map f p := rfl
+
+lemma map_id : map id p = p := by simp [map]
+
+lemma map_comp (g : β → γ) : (p.map f).map g = p.map (g ∘ f) :=
+by simp [map]
+
+lemma pure_map (a : α) : (pure a).map f = pure (f a) :=
 by simp [map]
 
 end map
@@ -54,11 +65,30 @@ end map
 section seq
 
 /-- The monadic sequencing operation for `pmf`. -/
-def seq (f : pmf (α → β)) (p : pmf α) : pmf β := f.bind (λ m, p.bind $ λ a, pure (m a))
+def seq (q : pmf (α → β)) (p : pmf α) : pmf β := q.bind (λ m, p.bind $ λ a, pure (m a))
+
+variables (q : pmf (α → β)) (p : pmf α) (b : β)
+
+@[simp] lemma seq_apply :
+  (seq q p) b = ∑' (f : α → β) (a : α), if b = f a then q f * p a else 0 :=
+begin
+  simp [seq],
+  refine tsum_congr (λ f, _),
+  rw ← nnreal.tsum_mul_left (q f),
+  refine tsum_congr (λ a, _),
+  split_ifs; simp
+end
+
+@[simp] lemma mem_support_seq_iff :
+  b ∈ (seq q p).support ↔ ∃ (f ∈ q.support), b ∈ f '' p.support :=
+by simp [seq, @eq_comm β b]
+
+@[simp] lemma support_seq : (seq q p).support = ⋃ f ∈ q.support, f '' p.support :=
+set.ext (λ x, by simp)
 
 end seq
 
-section of_finite
+section of_finset
 
 /-- Given a finset `s` and a function `f : α → ℝ≥0` with sum `1` on `s`,
   such that `f x = 0` for `x ∉ s`, we get a `pmf` -/
@@ -66,23 +96,38 @@ def of_finset (f : α → ℝ≥0) (s : finset α) (h : ∑ x in s, f x = 1)
   (h' : ∀ x ∉ s, f x = 0) : pmf α :=
 ⟨f, h ▸ has_sum_sum_of_ne_finset_zero h'⟩
 
-@[simp]
-lemma of_finset_apply {f : α → ℝ≥0} {s : finset α} (h : ∑ x in s, f x = 1)
-  (h' : ∀ x ∉ s, f x = 0) (a : α) : of_finset f s h h' a = f a :=
-rfl
+variables {f : α → ℝ≥0} {s : finset α} (h : ∑ x in s, f x = 1) (h' : ∀ x ∉ s, f x = 0)
 
-lemma of_finset_apply_of_not_mem {f : α → ℝ≥0} {s : finset α} (h : ∑ x in s, f x = 1)
-  (h' : ∀ x ∉ s, f x = 0) {a : α} (ha : a ∉ s) : of_finset f s h h' a = 0 :=
+@[simp] lemma of_finset_apply (a : α) : of_finset f s h h' a = f a := rfl
+
+@[simp] lemma mem_support_of_finset_iff (a : α) : a ∈ (of_finset f s h h').support ↔ a ∈ s ∧ f a ≠ 0 :=
+by simpa using mt (h' a)
+
+@[simp] lemma support_of_finset : (of_finset f s h h').support = s ∩ (function.support f) :=
+set.ext (mem_support_of_finset_iff h h')
+
+lemma of_finset_apply_of_not_mem {a : α} (ha : a ∉ s) : of_finset f s h h' a = 0 :=
 h' a ha
+
+end of_finset
+
+section of_fintype
 
 /-- Given a finite type `α` and a function `f : α → ℝ≥0` with sum 1, we get a `pmf`. -/
 def of_fintype [fintype α] (f : α → ℝ≥0) (h : ∑ x, f x = 1) : pmf α :=
 of_finset f finset.univ h (λ x hx, absurd (finset.mem_univ x) hx)
 
-@[simp]
-lemma of_fintype_apply [fintype α] {f : α → ℝ≥0} (h : ∑ x, f x = 1)
-  (a : α) : of_fintype f h a = f a :=
-rfl
+variables [fintype α] {f : α → ℝ≥0} (h : ∑ x, f x = 1)
+
+@[simp] lemma of_fintype_apply (a : α) : of_fintype f h a = f a := rfl
+
+@[simp] lemma mem_support_of_fintype_iff (a : α) : a ∈ (of_fintype f h).support ↔ f a ≠ 0 := iff.rfl
+
+@[simp] lemma support_of_fintype : (of_fintype f h).support = function.support f := rfl
+
+end of_fintype
+
+section of_multiset
 
 /-- Given a non-empty multiset `s` we construct the `pmf` which sends `a` to the fraction of
   elements in `s` that are `a`. -/
@@ -98,18 +143,28 @@ def of_multiset (s : multiset α) (hs : s ≠ 0) : pmf α :=
     simp {contextual := tt},
   end⟩
 
+variables {s : multiset α} (hs : s ≠ 0)
+
 @[simp]
-lemma of_multiset_apply {s : multiset α} (hs : s ≠ 0) (a : α) :
-  of_multiset s hs a = s.count a / s.card :=
+lemma of_multiset_apply (a : α) : of_multiset s hs a = s.count a / s.card :=
 rfl
 
-lemma of_multiset_apply_of_not_mem {s : multiset α} (hs : s ≠ 0)
-  {a : α} (ha : a ∉ s) : of_multiset s hs a = 0 :=
+@[simp]
+lemma mem_support_of_multiset_iff (a : α) : a ∈ (of_multiset s hs).support ↔ a ∈ s.to_finset :=
+by simp [hs]
+
+@[simp]
+lemma support_of_multiset : (of_multiset s hs).support = s.to_finset :=
+set.ext (mem_support_of_multiset_iff hs)
+
+lemma of_multiset_apply_of_not_mem {a : α} (ha : a ∉ s) : of_multiset s hs a = 0 :=
 div_eq_zero_iff.2 (or.inl $ nat.cast_eq_zero.2 $ multiset.count_eq_zero_of_not_mem ha)
 
-end of_finite
+end of_multiset
 
 section uniform
+
+section uniform_of_finset
 
 /-- Uniform distribution taking the same non-zero probability on the nonempty finset `s` -/
 def uniform_of_finset (s : finset α) (hs : s.nonempty) : pmf α :=
@@ -121,27 +176,55 @@ of_finset (λ a, if a ∈ s then (s.card : ℝ≥0)⁻¹ else 0) s (Exists.rec_o
     ... = 1 : div_self (nat.cast_ne_zero.2 $ finset.card_ne_zero_of_mem hx)
   )) (λ x hx, by simp only [hx, if_false])
 
+variables {s : finset α} (hs : s.nonempty)
+
 @[simp]
-lemma uniform_of_finset_apply {s : finset α} (hs : s.nonempty) (a : α) :
+lemma uniform_of_finset_apply (a : α) :
   uniform_of_finset s hs a = if a ∈ s then (s.card : ℝ≥0)⁻¹ else 0 :=
 rfl
 
-lemma uniform_of_finset_apply_of_mem {s : finset α} (hs : s.nonempty) {a : α} (ha : a ∈ s) :
+lemma uniform_of_finset_apply_of_mem {a : α} (ha : a ∈ s) :
   uniform_of_finset s hs a = (s.card)⁻¹ :=
 by simp [ha]
 
-lemma uniform_of_finset_apply_of_not_mem {s : finset α} (hs : s.nonempty) {a : α} (ha : a ∉ s) :
+lemma uniform_of_finset_apply_of_not_mem {a : α} (ha : a ∉ s) :
   uniform_of_finset s hs a = 0 :=
 by simp [ha]
+
+@[simp]
+lemma mem_support_uniform_of_finset_iff (a : α) : a ∈ (uniform_of_finset s hs).support ↔ a ∈ s :=
+let ⟨x, hx⟩ := hs in by simp [finset.ne_empty_of_mem hx]
+
+@[simp]
+lemma support_uniform_of_finset : (uniform_of_finset s hs).support = s :=
+set.ext (mem_support_uniform_of_finset_iff hs)
+
+end uniform_of_finset
+
+section uniform_of_fintype
 
 /-- The uniform pmf taking the same uniform value on all of the fintype `α` -/
 def uniform_of_fintype (α : Type*) [fintype α] [nonempty α] : pmf α :=
   uniform_of_finset (finset.univ) (finset.univ_nonempty)
 
+variables [fintype α] [nonempty α]
+
 @[simp]
-lemma uniform_of_fintype_apply [fintype α] [nonempty α] (a : α) :
+lemma uniform_of_fintype_apply (a : α) :
   uniform_of_fintype α a = (fintype.card α)⁻¹ :=
 by simpa only [uniform_of_fintype, finset.mem_univ, if_true, uniform_of_finset_apply]
+
+@[simp]
+lemma mem_support_uniform_of_fintype_iff (a : α) : a ∈ (uniform_of_fintype α).support :=
+by simpa using fintype.card_ne_zero
+
+variable (α)
+
+@[simp]
+lemma support_uniform_of_fintype : (uniform_of_fintype α).support = ⊤ :=
+set.ext (λ x, by simp)
+
+end uniform_of_fintype
 
 end uniform
 
@@ -153,40 +236,52 @@ def normalize (f : α → ℝ≥0) (hf0 : tsum f ≠ 0) : pmf α :=
   (mul_inv_cancel hf0) ▸ has_sum.mul_right (∑' x, f x)⁻¹
     (not_not.mp (mt tsum_eq_zero_of_not_summable hf0 : ¬¬summable f)).has_sum⟩
 
-lemma normalize_apply {f : α → ℝ≥0} (hf0 : tsum f ≠ 0) (a : α) :
-  (normalize f hf0) a = f a * (∑' x, f x)⁻¹ := rfl
+variables {f : α → ℝ≥0} (hf0 : tsum f ≠ 0)
+
+@[simp]
+lemma normalize_apply (a : α) : (normalize f hf0) a = f a * (∑' x, f x)⁻¹ := rfl
+
+@[simp]
+lemma mem_support_normalize_iff (a : α) : a ∈ (normalize f hf0).support ↔ f a ≠ 0 :=
+by simp [hf0]
+
+@[simp]
+lemma support_normalize : (normalize f hf0).support = function.support f :=
+set.ext (mem_support_normalize_iff hf0)
 
 end normalize
 
 section filter
 
 /-- Create new `pmf` by filtering on a set with non-zero measure and normalizing -/
-def filter (p : pmf α) (s : set α) (h : ∃ a ∈ s, p a ≠ 0) : pmf α :=
+def filter (p : pmf α) (s : set α) (h : ∃ a ∈ s, a ∈ p.support) : pmf α :=
 pmf.normalize (s.indicator p) $ nnreal.tsum_indicator_ne_zero p.2.summable h
 
-lemma filter_apply (p : pmf α) {s : set α} (h : ∃ a ∈ s, p a ≠ 0) {a : α} :
-  (p.filter s h) a = (s.indicator p a) * (∑' x, (s.indicator p) x)⁻¹ :=
+variables {p : pmf α} {s : set α} (h : ∃ a ∈ s, a ∈ p.support)
+
+@[simp]
+lemma filter_apply (a : α) : (p.filter s h) a = (s.indicator p a) * (∑' x, (s.indicator p) x)⁻¹ :=
 by rw [filter, normalize_apply]
 
-lemma filter_apply_eq_zero_of_not_mem (p : pmf α) {s : set α} (h : ∃ a ∈ s, p a ≠ 0)
-  {a : α} (ha : a ∉ s) : (p.filter s h) a = 0 :=
+lemma filter_apply_eq_zero_of_not_mem {a : α} (ha : a ∉ s) : (p.filter s h) a = 0 :=
 by rw [filter_apply, set.indicator_apply_eq_zero.mpr (λ ha', absurd ha' ha), zero_mul]
 
-lemma filter_apply_eq_zero_iff (p : pmf α) {s : set α} (h : ∃ a ∈ s, p a ≠ 0) (a : α) :
-  (p.filter s h) a = 0 ↔ a ∉ (p.support ∩ s) :=
+@[simp]
+lemma mem_support_filter_apply (a : α) : a ∈ (p.filter s h).support ↔ a ∈ s ∧ a ∈ p.support :=
 begin
-  rw [set.mem_inter_iff, p.mem_support_iff, not_and_distrib, not_not],
-  split; intro ha,
-  { rw [filter_apply, mul_eq_zero] at ha,
-    refine ha.by_cases
-      (λ ha, (em (a ∈ s)).by_cases (λ h, or.inl ((set.indicator_apply_eq_zero.mp ha) h)) or.inr)
-      (λ ha, absurd (inv_eq_zero.1 ha) (nnreal.tsum_indicator_ne_zero p.2.summable h)) },
-  { rw [filter_apply, set.indicator_apply_eq_zero.2 (λ h, ha.by_cases id (absurd h)), zero_mul] }
+  rw [mem_support_iff, filter_apply, mul_ne_zero_iff, set.indicator_eq_zero_iff],
+  exact ⟨λ ha, ha.1, λ ha, ⟨ha, inv_ne_zero (nnreal.tsum_indicator_ne_zero p.2.summable h)⟩⟩
 end
 
-lemma filter_apply_ne_zero_iff (p : pmf α) {s : set α} (h : ∃ a ∈ s, p a ≠ 0) (a : α) :
-  (p.filter s h) a ≠ 0 ↔ a ∈ (p.support ∩ s) :=
-by rw [← not_iff, filter_apply_eq_zero_iff, not_iff, not_not]
+@[simp]
+lemma support_filter_apply : (p.filter s h).support = s ∩ p.support:=
+set.ext (mem_support_filter_apply h)
+
+lemma filter_apply_eq_zero_iff (a : α) : (p.filter s h) a = 0 ↔ a ∉ s ∨ a ∉ p.support :=
+by erw [apply_eq_zero_iff, support_filter_apply, set.mem_inter_iff, not_and_distrib]
+
+lemma filter_apply_ne_zero_iff (a : α) : (p.filter s h) a ≠ 0 ↔ a ∈ s ∧ a ∈ p.support :=
+by rw [ne.def, filter_apply_eq_zero_iff, not_or_distrib, not_not, not_not]
 
 end filter
 
@@ -196,16 +291,30 @@ section bernoulli
 def bernoulli (p : ℝ≥0) (h : p ≤ 1) : pmf bool :=
 of_fintype (λ b, cond b p (1 - p)) (nnreal.eq $ by simp [h])
 
+variables {p : ℝ≥0} (h : p ≤ 1)
+
 @[simp]
-lemma bernuolli_apply {p : ℝ≥0} (h : p ≤ 1) (b : bool) :
-  bernoulli p h b = cond b p (1 - p) :=
-rfl
+lemma bernoulli_apply (b : bool) : bernoulli p h b = cond b p (1 - p) := rfl
+
+@[simp]
+lemma mem_support_bernoulli_iff (b : bool) :
+  b ∈ (bernoulli p h).support ↔ cond b (p ≠ 0) (p ≠ 1) :=
+begin
+  induction b,
+  { simp_rw [mem_support_iff, bernoulli_apply, bool.cond_ff, ne.def, tsub_eq_zero_iff_le, not_le],
+    exact ⟨ne_of_lt, lt_of_le_of_ne h⟩ },
+  { simp_rw [mem_support_iff, bernoulli_apply, bool.cond_tt] }
+end
+
+@[simp]
+lemma support_bernoulli : (bernoulli p h).support = {b | cond b (p ≠ 0) (p ≠ 1)} :=
+set.ext (mem_support_bernoulli_iff h)
 
 end bernoulli
 
 section bind_on_support
 
-protected lemma bind_on_support.summable (p : pmf α) (f : ∀ a ∈ p.support, pmf β) (b : β) :
+protected lemma bind_on_support.summable (p : pmf α) (f : Π a ∈ p.support, pmf β) (b : β) :
   summable (λ a : α, p a * if h : p a = 0 then 0 else f a h b) :=
 begin
   refine nnreal.summable_of_le (assume a, _) p.summable_coe,
@@ -217,7 +326,7 @@ end
 
 /-- Generalized version of `bind` allowing `f` to only be defined on the support of `p`.
   `p.bind f` is equivalent to `p.bind_on_support (λ a _, f a)`, see `bind_on_support_eq_bind` -/
-def bind_on_support (p : pmf α) (f : ∀ a ∈ p.support, pmf β) : pmf β :=
+def bind_on_support (p : pmf α) (f : Π a ∈ p.support, pmf β) : pmf β :=
 ⟨λ b, ∑' a, p a * if h : p a = 0 then 0 else f a h b,
 ennreal.has_sum_coe.1 begin
   simp only [ennreal.coe_tsum (bind_on_support.summable p f _)],
@@ -231,34 +340,42 @@ ennreal.has_sum_coe.1 begin
   { simp [← ennreal.coe_tsum (f a h).summable_coe, (f a h).tsum_coe] }
 end⟩
 
-@[simp] lemma bind_on_support_apply (p : pmf α) (f : ∀ a ∈ p.support, pmf β) (b : β) :
-  p.bind_on_support f b = ∑' a, p a * if h : p a = 0 then 0 else f a h b := rfl
+variables {p : pmf α} (f : Π a ∈ p.support, pmf β)
+
+@[simp] lemma bind_on_support_apply (b : β) :
+  p.bind_on_support f b = ∑' a, p a * if h : p a = 0 then 0 else f a h b :=
+rfl
+
+@[simp] lemma mem_support_bind_on_support_iff (b : β) :
+  b ∈ (p.bind_on_support f).support ↔ ∃ (a : α) (h : a ∈ p.support), b ∈ (f a h).support :=
+begin
+  simp only [tsum_eq_zero_iff (bind_on_support.summable p f b), not_or_distrib, mem_support_iff,
+    bind_on_support_apply, ne.def, not_forall, mul_eq_zero],
+  exact ⟨λ hb, let ⟨a, ⟨ha, ha'⟩⟩ := hb in ⟨a, ha, by simpa [ha] using ha'⟩,
+    λ hb, let ⟨a, ha, ha'⟩ := hb in ⟨a, ⟨ha, by simpa [(mem_support_iff _ a).1 ha] using ha'⟩⟩⟩
+end
+
+@[simp] lemma support_bind_on_support :
+  (p.bind_on_support f).support = {b | ∃ (a : α) (h : a ∈ p.support), b ∈ (f a h).support} :=
+set.ext (mem_support_bind_on_support_iff f)
 
 /-- `bind_on_support` reduces to `bind` if `f` doesn't depend on the additional hypothesis -/
 @[simp] lemma bind_on_support_eq_bind (p : pmf α) (f : α → pmf β) :
   p.bind_on_support (λ a _, f a) = p.bind f :=
 begin
   ext b,
-  simp only [p.bind_on_support_apply (λ a _, f a), p.bind_apply f,
+  simp only [bind_on_support_apply (λ a _, f a), p.bind_apply f,
     dite_eq_ite, nnreal.coe_eq, mul_ite, mul_zero],
   refine congr_arg _ (funext (λ a, _)),
   split_ifs with h; simp [h],
 end
 
-lemma coe_bind_on_support_apply (p : pmf α) (f : ∀ a ∈ p.support, pmf β) (b : β) :
+lemma coe_bind_on_support_apply (b : β) :
   (p.bind_on_support f b : ℝ≥0∞) = ∑' a, p a * if h : p a = 0 then 0 else f a h b :=
 by simp only [bind_on_support_apply, ennreal.coe_tsum (bind_on_support.summable p f b),
     dite_cast, ennreal.coe_mul, ennreal.coe_zero]
 
-@[simp] lemma mem_support_bind_on_support_iff (p : pmf α) (f : ∀ a ∈ p.support, pmf β) (b : β) :
-  b ∈ (p.bind_on_support f).support ↔ ∃ a (ha : p a ≠ 0), b ∈ (f a ha).support :=
-begin
-  simp only [mem_support_iff, bind_on_support_apply,
-    tsum_ne_zero_iff (bind_on_support.summable p f b), mul_ne_zero_iff],
-  split; { rintro ⟨a, ha, haf⟩, refine ⟨a, ha, ne_of_eq_of_ne _ haf⟩, simp [ha], },
-end
-
-lemma bind_on_support_eq_zero_iff (p : pmf α) (f : ∀ a ∈ p.support, pmf β) (b : β) :
+lemma bind_on_support_eq_zero_iff (b : β) :
   p.bind_on_support f b = 0 ↔ ∀ a (ha : p a ≠ 0), f a ha b = 0 :=
 begin
   simp only [bind_on_support_apply, tsum_eq_zero_iff (bind_on_support.summable p f b),
@@ -266,7 +383,7 @@ begin
   exact ⟨λ h a ha, trans (dif_neg ha).symm (h a ha), λ h a ha, trans (dif_neg ha) (h a ha)⟩,
 end
 
-@[simp] lemma pure_bind_on_support (a : α) (f : ∀ (a' : α) (ha : a' ∈ (pure a).support), pmf β) :
+@[simp] lemma pure_bind_on_support (a : α) (f : Π (a' : α) (ha : a' ∈ (pure a).support), pmf β) :
   (pure a).bind_on_support f = f a ((mem_support_pure_iff a a).mpr rfl) :=
 begin
   refine pmf.ext (λ b, _),
@@ -284,7 +401,7 @@ by simp only [pmf.bind_pure, pmf.bind_on_support_eq_bind]
   (g : ∀ (b ∈ (p.bind_on_support f).support), pmf γ) :
   (p.bind_on_support f).bind_on_support g =
     p.bind_on_support (λ a ha, (f a ha).bind_on_support
-      (λ b hb, g b ((p.mem_support_bind_on_support_iff f b).mpr ⟨a, ha, hb⟩))) :=
+      (λ b hb, g b ((mem_support_bind_on_support_iff f b).mpr ⟨a, ha, hb⟩))) :=
 begin
   refine pmf.ext (λ a, _),
   simp only [ennreal.coe_eq_coe.symm, coe_bind_on_support_apply, ← tsum_dite_right,

--- a/src/measure_theory/probability_mass_function/constructions.lean
+++ b/src/measure_theory/probability_mass_function/constructions.lean
@@ -101,7 +101,7 @@ variables {f : α → ℝ≥0} {s : finset α} (h : ∑ x in s, f x = 1) (h' : �
 @[simp] lemma of_finset_apply (a : α) : of_finset f s h h' a = f a := rfl
 
 @[simp] lemma mem_support_of_finset_iff (a : α) : a ∈ (of_finset f s h h').support ↔ a ∈ s ∧ f a ≠ 0 :=
-by simpa using mt (h' a)
+by simpa [mem_support_iff] using mt (h' a)
 
 @[simp] lemma support_of_finset : (of_finset f s h h').support = s ∩ (function.support f) :=
 set.ext (mem_support_of_finset_iff h h')
@@ -151,7 +151,7 @@ rfl
 
 @[simp]
 lemma mem_support_of_multiset_iff (a : α) : a ∈ (of_multiset s hs).support ↔ a ∈ s.to_finset :=
-by simp [hs]
+by simp [mem_support_iff, hs]
 
 @[simp]
 lemma support_of_multiset : (of_multiset s hs).support = s.to_finset :=
@@ -193,7 +193,7 @@ by simp [ha]
 
 @[simp]
 lemma mem_support_uniform_of_finset_iff (a : α) : a ∈ (uniform_of_finset s hs).support ↔ a ∈ s :=
-let ⟨x, hx⟩ := hs in by simp [finset.ne_empty_of_mem hx]
+let ⟨x, hx⟩ := hs in by simp [mem_support_iff, finset.ne_empty_of_mem hx]
 
 @[simp]
 lemma support_uniform_of_finset : (uniform_of_finset s hs).support = s :=
@@ -216,7 +216,7 @@ by simpa only [uniform_of_fintype, finset.mem_univ, if_true, uniform_of_finset_a
 
 @[simp]
 lemma mem_support_uniform_of_fintype_iff (a : α) : a ∈ (uniform_of_fintype α).support :=
-by simpa using fintype.card_ne_zero
+by simpa [mem_support_iff] using fintype.card_ne_zero
 
 variable (α)
 
@@ -243,7 +243,7 @@ lemma normalize_apply (a : α) : (normalize f hf0) a = f a * (∑' x, f x)⁻¹ 
 
 @[simp]
 lemma mem_support_normalize_iff (a : α) : a ∈ (normalize f hf0).support ↔ f a ≠ 0 :=
-by simp [hf0]
+by simp [mem_support_iff, hf0]
 
 @[simp]
 lemma support_normalize : (normalize f hf0).support = function.support f :=


### PR DESCRIPTION
This PR gives explicit descriptions for the `support` of the various `pmf` constructions in mathlib. 

This also tries to clean up the variable declarations in the different sections, so that all the lemmas don't need to specify them explicitly.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
