### PR TITLE
[Merged by Bors] - feat(data/nat/interval): add Ico_succ_left_eq_erase

### DIFF
--- a/src/data/nat/interval.lean
+++ b/src/data/nat/interval.lean
@@ -169,7 +169,8 @@ end
 lemma Ico_succ_left_eq_erase_Ico : Ico a.succ b = erase (Ico a b) a :=
 begin
   ext x,
-  rw [Ico_succ_left, mem_erase, mem_Ico, mem_Ioo, ←and_assoc, ne_comm, and_comm (a ≠ x), lt_iff_le_and_ne],
+  rw [Ico_succ_left, mem_erase, mem_Ico, mem_Ioo, ←and_assoc, ne_comm, and_comm (a ≠ x),
+    lt_iff_le_and_ne],
 end
 
 lemma range_image_pred_top_sub (n : ℕ) : (finset.range n).image (λ j, n - 1 - j) = finset.range n :=

--- a/src/data/nat/interval.lean
+++ b/src/data/nat/interval.lean
@@ -166,6 +166,13 @@ begin
         tsub_le_iff_right.1 hb⟩ } }
 end
 
+lemma Ico_succ_left_eq_erase_Ico : Ico a.succ b = erase (Ico a b) a :=
+begin
+  rw Ico_succ_left,
+  ext x,
+  rw [mem_erase, mem_Ico, mem_Ioo, ←and_assoc, ne_comm, lt_iff_ne_and_le],
+end
+
 lemma range_image_pred_top_sub (n : ℕ) : (finset.range n).image (λ j, n - 1 - j) = finset.range n :=
 begin
   cases n,

--- a/src/data/nat/interval.lean
+++ b/src/data/nat/interval.lean
@@ -168,9 +168,8 @@ end
 
 lemma Ico_succ_left_eq_erase_Ico : Ico a.succ b = erase (Ico a b) a :=
 begin
-  rw Ico_succ_left,
   ext x,
-  rw [mem_erase, mem_Ico, mem_Ioo, ←and_assoc, ne_comm, and_comm (a ≠ x), lt_iff_le_and_ne],
+  rw [Ico_succ_left, mem_erase, mem_Ico, mem_Ioo, ←and_assoc, ne_comm, and_comm (a ≠ x), lt_iff_le_and_ne],
 end
 
 lemma range_image_pred_top_sub (n : ℕ) : (finset.range n).image (λ j, n - 1 - j) = finset.range n :=

--- a/src/data/nat/interval.lean
+++ b/src/data/nat/interval.lean
@@ -170,7 +170,7 @@ lemma Ico_succ_left_eq_erase_Ico : Ico a.succ b = erase (Ico a b) a :=
 begin
   rw Ico_succ_left,
   ext x,
-  rw [mem_erase, mem_Ico, mem_Ioo, ←and_assoc, ne_comm, lt_iff_ne_and_le],
+  rw [mem_erase, mem_Ico, mem_Ioo, ←and_assoc, ne_comm, and_comm (a ≠ x), lt_iff_le_and_ne],
 end
 
 lemma range_image_pred_top_sub (n : ℕ) : (finset.range n).image (λ j, n - 1 - j) = finset.range n :=

--- a/src/order/basic.lean
+++ b/src/order/basic.lean
@@ -161,7 +161,7 @@ lemma not_lt_of_le [preorder α] {a b : α} (h : a ≤ b) : ¬ b < a := λ hba, 
 
 alias not_lt_of_le ← has_le.le.not_lt
 
-lemma ne_of_not_le [preorder α] (a b : α) (h : ¬ a ≤ b) : a ≠ b :=
+lemma ne_of_not_le [preorder α] {a b : α} (h : ¬ a ≤ b) : a ≠ b :=
 λ hab, h (le_of_eq hab)
 
 -- See Note [decidable namespace]

--- a/src/order/basic.lean
+++ b/src/order/basic.lean
@@ -161,6 +161,9 @@ lemma not_lt_of_le [preorder α] {a b : α} (h : a ≤ b) : ¬ b < a := λ hba, 
 
 alias not_lt_of_le ← has_le.le.not_lt
 
+lemma ne_of_not_le [preorder α] (a b : α) (h : ¬ a ≤ b) : a ≠ b :=
+λ heq, h (le_of_eq heq)
+
 -- See Note [decidable namespace]
 protected lemma decidable.le_iff_eq_or_lt [partial_order α] [@decidable_rel α (≤)]
   {a b : α} : a ≤ b ↔ a = b ∨ a < b := decidable.le_iff_lt_or_eq.trans or.comm
@@ -197,6 +200,19 @@ protected lemma decidable.ne_iff_lt_iff_le [partial_order α] [@decidable_rel α
 
 @[simp] lemma ne_iff_lt_iff_le [partial_order α] {a b : α} : (a ≠ b ↔ a < b) ↔ a ≤ b :=
 by haveI := classical.dec; exact decidable.ne_iff_lt_iff_le
+
+lemma lt_iff_ne_and_le [partial_order α] (a b : α) : a < b ↔ (a ≠ b) ∧ a ≤ b :=
+begin
+  rw [and_comm, lt_iff_le_not_le],
+  apply and_congr_right,
+  intro h,
+  split,
+  { intro nle,
+    rw ne_comm,
+    exact ne_of_not_le b a nle},
+  { intros ne b_le_a,
+    exact ne (le_antisymm h b_le_a), },
+end
 
 lemma lt_of_not_ge' [linear_order α] {a b : α} (h : ¬ b ≤ a) : a < b :=
 ((le_total _ _).resolve_right h).lt_of_not_le h

--- a/src/order/basic.lean
+++ b/src/order/basic.lean
@@ -162,7 +162,7 @@ lemma not_lt_of_le [preorder α] {a b : α} (h : a ≤ b) : ¬ b < a := λ hba, 
 alias not_lt_of_le ← has_le.le.not_lt
 
 lemma ne_of_not_le [preorder α] (a b : α) (h : ¬ a ≤ b) : a ≠ b :=
-λ heq, h (le_of_eq heq)
+λ hab, h (le_of_eq hab)
 
 -- See Note [decidable namespace]
 protected lemma decidable.le_iff_eq_or_lt [partial_order α] [@decidable_rel α (≤)]

--- a/src/order/basic.lean
+++ b/src/order/basic.lean
@@ -201,19 +201,6 @@ protected lemma decidable.ne_iff_lt_iff_le [partial_order α] [@decidable_rel α
 @[simp] lemma ne_iff_lt_iff_le [partial_order α] {a b : α} : (a ≠ b ↔ a < b) ↔ a ≤ b :=
 by haveI := classical.dec; exact decidable.ne_iff_lt_iff_le
 
-lemma lt_iff_ne_and_le [partial_order α] (a b : α) : a < b ↔ (a ≠ b) ∧ a ≤ b :=
-begin
-  rw [and_comm, lt_iff_le_not_le],
-  apply and_congr_right,
-  intro h,
-  split,
-  { intro nle,
-    rw ne_comm,
-    exact ne_of_not_le b a nle},
-  { intros ne b_le_a,
-    exact ne (le_antisymm h b_le_a), },
-end
-
 lemma lt_of_not_ge' [linear_order α] {a b : α} (h : ¬ b ≤ a) : a < b :=
 ((le_total _ _).resolve_right h).lt_of_not_le h
 


### PR DESCRIPTION
Adds `Ico_succ_left_eq_erase`. Also adds a few order lemmas needed for this.

See [this discussion](https://leanprover.zulipchat.com/#narrow/stream/217875-Is-there.20code.20for.20X.3F/topic/Ico_succ_left_eq_erase_Ico/near/259180476)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
