### PR TITLE
[Merged by Bors] - feat(algebra/algebra/spectrum): define spectrum and prove basic prope...

### DIFF
--- a/src/algebra/algebra/spectrum.lean
+++ b/src/algebra/algebra/spectrum.lean
@@ -47,7 +47,7 @@ variables [comm_ring R] [ring A] [algebra R A]
 /-- Given a commutative ring `R` and an `R`-algebra `A`, the *resolvent* of `a : A`
 is the `set R` consisting of those `r : R` for which `r•1 - a` is a unit of the
 algebra `A`.  -/
-definition resolvent (a : A) : set R :=
+def resolvent (a : A) : set R :=
 { r : R | is_unit (r • 1 - a) }
 
 
@@ -56,7 +56,7 @@ is the `set R` consisting of those `r : R` for which `r•1 - a` is not a unit o
 algebra `A`.
 
 The spectrum is simply the complement of the resolvent.  -/
-definition spectrum (a : A) : set R :=
+def spectrum (a : A) : set R :=
 (resolvent R a)ᶜ
 
 end defs
@@ -66,13 +66,13 @@ variables [comm_ring R] [ring A] [algebra R A]
 
 local notation `σ` := spectrum R
 
-lemma mem_spectrum_iff_not_unit {r : R} {a : A} :
+lemma mem_spectrum_iff {r : R} {a : A} :
   r ∈ σ a ↔ ¬ is_unit (r • 1 - a) :=
 iff.rfl
 
-lemma not_mem_spectrum_iff_unit {r : R} {a : A} :
+lemma not_mem_spectrum_iff {r : R} {a : A} :
   r ∉ σ a ↔ is_unit (r • 1 - a) :=
-by { apply not_iff_not.mp, simp [set.not_not_mem, mem_spectrum_iff_not_unit] }
+by { apply not_iff_not.mp, simp [set.not_not_mem, mem_spectrum_iff] }
 
 lemma mem_resolvent_of_left_right_inverse {r : R} {a b c : A}
   (h₁ : (r • 1 - a) * b = 1) (h₂ : c * (r • 1 - a) = 1) :
@@ -125,7 +125,7 @@ begin
   simp [h_eq],
 end
 
-lemma mul_mem_spectrum_mul {a : A} {s : R} {r : units R} :
+lemma smul_mem_spectrum_smul {a : A} {s : R} {r : units R} :
   r • s ∈ σ (r • a) ↔ s ∈ σ a :=
 begin
   apply not_iff_not.mpr,
@@ -149,11 +149,11 @@ begin
   split,
   { rintro ⟨y,y_mem,hy⟩,
     rw ←hy,
-    exact mul_mem_spectrum_mul.mpr y_mem, },
+    exact smul_mem_spectrum_smul.mpr y_mem, },
   { intro hx,
     have self_inv : x = r•r⁻¹•x, by simp,
     rw self_inv at *,
-    exact mem_left_coset ↑r (mul_mem_spectrum_mul.mp hx), },
+    exact mem_left_coset ↑r (smul_mem_spectrum_smul.mp hx), },
 end
 
 -- `r ∈ σ(a*b) ↔ r ∈ σ(b*a)` for any `r : units R`

--- a/src/algebra/algebra/spectrum.lean
+++ b/src/algebra/algebra/spectrum.lean
@@ -1,0 +1,183 @@
+/-
+Copyright (c) 2021 Jireh Loreaux. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Jireh Loreaux
+-/
+import algebra.algebra.basic
+import tactic
+/-!
+# Spectrum of an element in an algebra
+This file develops the basic theory of the spectrum of an element of an algebra.
+This theory will serve as the foundation for spectral theory in Banach algebras.
+
+## Main definitions
+
+* `resolvent a`: has type `set R` is the resolvent set of an element `a : A` where
+  `A` is an  `R`-algebra.
+* `spectrum a`: has type `set R` is the spectrum of an element `a : A` where
+  `A` is an  `R`-algebra.
+
+## Main statements
+
+* `unit_left_coset_spectrum`: units in the scalar ring commute (multplication) with the spectrum.
+* `left_add_coset_spectrum`: elements of the scalar ring commute (addition) with the spectrum.
+* `unit_mem_spectrum_mul_iff_swap_mul`: the units (of `R`) in `σ (a*b)` coincide
+  with those in `σ (b*a)`.
+
+## Notations
+
+* `σ a` : `spectrum` of `a : A`
+
+## TODO
+
+* Prove the *spectral mapping theorem* for the polynomial functional calculus
+-/
+
+universes u v
+
+variables {R : Type u} {A : Type v}
+variables [comm_ring R] [ring A] [algebra R A]
+
+
+-- definition and basic properties
+
+/-- Given a commutative ring `R` and an `R`-algebra `A`, the *resolvent* of `a : A`
+is the `set R` consisting of those `r : R` for which `r•1 - a` is a unit of the
+algebra `A`.  -/
+definition resolvent (a : A) : set R :=
+{ r : R | is_unit (r • 1 - a) }
+
+
+/-- Given a commutative ring `R` and an `R`-algebra `A`, the *spectrum* of `a : A`
+is the `set R` consisting of those `r : R` for which `r•1 - a` is not a unit of the
+algebra `A`.
+
+The spectrum is simply the complement of the resolvent.  -/
+definition spectrum (a : A) : set R :=
+(resolvent a)ᶜ
+
+local notation `σ` := spectrum
+
+lemma mem_spectrum_iff_not_unit {r : R} {a : A} :
+  r ∈ (σ a : set R) ↔ ¬ is_unit (r • 1 - a) :=
+by { tidy }
+
+lemma not_mem_spectrum_iff_unit {r : R} {a : A} :
+  r ∉ (σ a : set R) ↔ is_unit (r • 1 - a) :=
+by { apply not_iff_not.mp, simp [set.not_not_mem, mem_spectrum_iff_not_unit] }
+
+lemma mem_resolvent_of_left_right_inverse {r : R} {a b c : A}
+  (h₁ : (r • 1 - a) * b = 1) (h₂ : c * (r • 1 - a) = 1) :
+  r ∈ (resolvent a : set R) :=
+units.is_unit ⟨r•1 - a, b, h₁, by rwa ←left_inv_eq_right_inv h₂ h₁⟩
+
+-- products of scalar units and algebra units
+
+/-- Given a commutative ring `R` and an `R`-algebra `A`, and units `r : units R`
+and `a : units A`, then `unit_mul_unit r a` constructs a `units A` with value `r•a`. -/
+definition unit_mul_unit (r : units R) (a : units A) :
+  units A :=
+⟨r•↑a,
+ r⁻¹•↑a⁻¹,
+ by {simp [smul_mul_smul]},
+ by {simp [smul_mul_smul]}⟩
+
+lemma is_unit_smul_smul_sub_smul_iff {r : units R} {s : R} {a : A} :
+  is_unit (r • s • 1 - r • a) ↔ is_unit (s • 1 - a) :=
+begin
+  split,
+  { intro h',
+    have inv_smul_eq : r⁻¹•(r•s•1 - r•a) = s•1 - a,
+      by simp [smul_sub, smul_smul],
+    rw ←inv_smul_eq,
+    exact (unit_mul_unit r⁻¹ h'.unit).is_unit, },
+  { intro h',
+    rw ←smul_sub,
+    exact (unit_mul_unit r h'.unit).is_unit, },
+end
+
+lemma is_unit_smul_smul_sub_iff_is_unit_smul_sub_smul {r : units R} {s : R} {a : A} :
+  is_unit (r • s • 1 - a) ↔ is_unit (s • 1 - r⁻¹ • a) :=
+by { have h_eq : r•s•1 - r•(r⁻¹•a) = r•s•1 - a, by simp,
+     rw [←h_eq,is_unit_smul_smul_sub_smul_iff], }
+
+lemma is_unit_smul_sub_iff_is_unit_sub_smul {r : units R} {a : A} :
+  is_unit (r • 1 - a) ↔ is_unit (1 - r⁻¹ • a) :=
+begin
+  have with_smul_one : is_unit (r•(1 : R)•1 - a) ↔ is_unit ((1 : R)•1 - r⁻¹•a),
+    by exact is_unit_smul_smul_sub_iff_is_unit_smul_sub_smul,
+  simp at with_smul_one,
+  exact with_smul_one,
+end
+
+lemma add_mem_spectrum {a : A} {r s : R} :
+  r ∈ (σ a : set R) ↔ r + s ∈ (σ (s • 1 + a) : set R) :=
+begin
+  apply not_iff_not.mpr,
+  change is_unit (r•1 - a) ↔ is_unit ((r+s)•1 - (s•1 + a)),
+  have h_eq : (r+s)•1 - (s•1 + a) = r•1 - a,
+    by { rw add_smul, noncomm_ring },
+  simp [h_eq],
+end
+
+lemma mul_mem_spectrum_mul {a : A} {s : R} {r : units R} :
+  r • s ∈ (σ (r • a) : set R) ↔ s ∈ (σ a : set R) :=
+begin
+  apply not_iff_not.mpr,
+  change is_unit ((r•s)•1 - r•a) ↔ is_unit (s•1 - a),
+  have h_eq : (r•s)•(1 : A) = r•s•1, by simp,
+  rw h_eq,
+  exact is_unit_smul_smul_sub_smul_iff,
+end
+
+theorem left_add_coset_spectrum (a : A) (r : R) :
+  left_add_coset r (σ a) = (σ (r • 1 + a)) :=
+by { ext, rw [mem_left_add_coset_iff, neg_add_eq_sub, add_mem_spectrum],
+     nth_rewrite 1 ←sub_add_cancel x r, }
+
+-- this one isn't quite as simple because `R` is not a `group` (but it is an `add_group`)
+-- therefore we don't have access to `mem_left_add_coset_iff`
+theorem unit_left_coset_spectrum (a : A) (r : units R) :
+  left_coset ↑r (σ a : set R) = σ (r • a) :=
+begin
+  ext,
+  split,
+  { rintro ⟨y,y_mem,hy⟩,
+    rw ←hy,
+    exact mul_mem_spectrum_mul.mpr y_mem, },
+  { intro hx,
+    have self_inv : x = r•r⁻¹•x, by simp,
+    rw self_inv at *,
+    exact mem_left_coset ↑r (mul_mem_spectrum_mul.mp hx), },
+end
+
+-- general (noncommutative) ring results about units and the identity
+lemma right_inv_of_right_inv_swap {a b c : A} (h : (1 - a * b) * c = 1) :
+  (1 - b * a) * (1 + b * c * a) = 1 :=
+calc (1 - b*a)*(1 + b*c*a) = 1 - b*a + b*((1 - a*b)*c)*a : by noncomm_ring
+...                        = 1                           : by simp [h]
+
+lemma left_inv_of_left_inv_swap {a b c : A} (h : c * (1 - a * b) = 1) :
+  (1 + b * c * a) * (1 - b * a) = 1 :=
+calc (1 + b*c*a)*(1 - b*a) = 1 - b*a + b*(c*(1 - a*b))*a : by noncomm_ring
+...                        = 1                           : by simp [h]
+
+lemma is_unit_one_sub_mul_of_swap {a b : A} (h : is_unit (1 - a * b)) :
+  is_unit (1 - b * a) :=
+by { let h₁ := right_inv_of_right_inv_swap h.unit.val_inv,
+     let h₂ := left_inv_of_left_inv_swap h.unit.inv_val,
+     exact ⟨⟨1-b*a,1+b*h.unit.inv*a,h₁,h₂⟩,rfl⟩, }
+
+lemma is_unit_one_sub_mul_iff_swap {a b : A} :
+  is_unit (1 - a * b) ↔ is_unit (1 - b * a) :=
+by { split, repeat {apply is_unit_one_sub_mul_of_swap}, }
+
+-- `r ∈ σ(a*b) ↔ r ∈ σ(b*a)` for any `r : units R`
+theorem unit_mem_spectrum_mul_iff_swap_mul {a b : A} {r : units R} :
+  ↑r ∈ (σ (a * b) : set R) ↔ ↑r ∈ (σ (b * a) : set R) :=
+begin
+  apply not_iff_not.mpr,
+  change is_unit (r•1 - a*b) ↔ is_unit (r•1 - b*a),
+  repeat {rw [is_unit_smul_sub_iff_is_unit_sub_smul]},
+  rw [←smul_mul_assoc, ←mul_smul_comm r⁻¹ b a, is_unit_one_sub_mul_iff_swap],
+end

--- a/src/algebra/algebra/spectrum.lean
+++ b/src/algebra/algebra/spectrum.lean
@@ -35,6 +35,8 @@ This theory will serve as the foundation for spectral theory in Banach algebras.
 
 universes u v
 
+namespace spectrum
+
 section defs
 
 variables (R : Type u) {A : Type v}
@@ -181,3 +183,5 @@ begin
       { intros, split, repeat {apply is_unit_one_sub_mul_of_swap}, },
   rw [←smul_mul_assoc, ←mul_smul_comm r⁻¹ b a, is_unit_one_sub_mul_iff_swap],
 end
+
+end spectrum

--- a/src/algebra/algebra/spectrum.lean
+++ b/src/algebra/algebra/spectrum.lean
@@ -95,7 +95,7 @@ begin
         ⟨a,
          r•↑(h.unit)⁻¹,
          by rw [mul_smul_comm, ←smul_mul_assoc, is_unit.mul_coe_inv],
-         by {rw [smul_mul_assoc,←mul_smul_comm, is_unit.coe_inv_mul],}⟩,
+         by rw [smul_mul_assoc,←mul_smul_comm, is_unit.coe_inv_mul],⟩,
       exact ⟨a',rfl⟩, },
 end
 

--- a/src/algebra/algebra/spectrum.lean
+++ b/src/algebra/algebra/spectrum.lean
@@ -75,12 +75,6 @@ units.is_unit ⟨r•1 - a, b, h₁, by rwa ←left_inv_eq_right_inv h₂ h₁�
 
 /-- Given a commutative ring `R` and an `R`-algebra `A`, and units `r : units R`
 and `a : units A`, then `unit_mul_unit r a` constructs a `units A` with value `r•a`. -/
-definition unit_mul_unit (r : units R) (a : units A) :
-  units A :=
-⟨r•↑a,
- r⁻¹•↑a⁻¹,
- by {simp [smul_mul_smul]},
- by {simp [smul_mul_smul]}⟩
 
 lemma is_unit_smul_smul_sub_smul_iff {r : units R} {s : R} {a : A} :
   is_unit (r • s • 1 - r • a) ↔ is_unit (s • 1 - a) :=
@@ -90,10 +84,10 @@ begin
     have inv_smul_eq : r⁻¹•(r•s•1 - r•a) = s•1 - a,
       by simp [smul_sub, smul_smul],
     rw ←inv_smul_eq,
-    exact (unit_mul_unit r⁻¹ h'.unit).is_unit, },
+    exact (r⁻¹ • h'.unit).is_unit, },
   { intro h',
     rw ←smul_sub,
-    exact (unit_mul_unit r h'.unit).is_unit, },
+    exact (r • h'.unit).is_unit, },
 end
 
 lemma is_unit_smul_smul_sub_iff_is_unit_smul_sub_smul {r : units R} {s : R} {a : A} :

--- a/src/algebra/algebra/spectrum.lean
+++ b/src/algebra/algebra/spectrum.lean
@@ -135,6 +135,20 @@ begin
   exact is_unit.smul_smul_sub_smul_iff,
 end
 
+open_locale pointwise
+
+theorem spectrum_smul_eq_smul_spectrum (a : A) (r : units R) :
+  σ (r • a) = r • σ a :=
+begin
+  ext,
+  have x_eq : x = r•r⁻¹•x, by simp,
+  nth_rewrite 0 x_eq,
+  rw smul_mem_spectrum_smul,
+  split,
+    { exact λ h, ⟨r⁻¹•x,⟨h,by simp⟩⟩},
+    { rintros ⟨_,_,x'_eq⟩, simpa [←x'_eq],}
+end
+
 theorem left_add_coset_spectrum (a : A) (r : R) :
   left_add_coset r (σ a) = σ (r • 1 + a) :=
 by { ext, rw [mem_left_add_coset_iff, neg_add_eq_sub, add_mem_spectrum],

--- a/src/algebra/algebra/spectrum.lean
+++ b/src/algebra/algebra/spectrum.lean
@@ -85,7 +85,8 @@ iff.rfl
 
 -- products of scalar units and algebra units
 
-lemma is_unit.smul_iff {r : units R} {a : A} :
+lemma is_unit.smul_iff {G : Type u} [group G] [mul_action G A]
+  [smul_comm_class G A A] [is_scalar_tower G A A] {r : G} {a : A} :
   is_unit (r • a) ↔ is_unit a :=
 begin
   split, swap,

--- a/src/algebra/algebra/spectrum.lean
+++ b/src/algebra/algebra/spectrum.lean
@@ -98,7 +98,7 @@ begin
       exact ⟨a',rfl⟩, },
 end
 
-lemma is_unit.smul_sub_iff_is_unit_sub_smul {r : units R} {a : A} :
+lemma is_unit.smul_sub_iff_sub_inv_smul {r : units R} {a : A} :
   is_unit (r • 1 - a) ↔ is_unit (1 - r⁻¹ • a) :=
 begin
   have a_eq : a = r•r⁻¹•a, by simp,
@@ -168,7 +168,7 @@ begin
   simp only [mem_resolvent_iff],
   have coe_smul_eq : ↑r•1 = r•(1 : A), from rfl,
   rw coe_smul_eq,
-  simp only [is_unit.smul_sub_iff_is_unit_sub_smul],
+  simp only [is_unit.smul_sub_iff_sub_inv_smul],
   have right_inv_of_swap : ∀ {x y z : A} (h : (1 - x*y)*z = 1),
     (1 - y*x)*(1 + y*z*x) = 1, from λ x y z h,
       calc (1 - y*x)*(1 + y*z*x) = 1 - y*x + y*((1 - x*y)*z)*x : by noncomm_ring

--- a/src/algebra/algebra/spectrum.lean
+++ b/src/algebra/algebra/spectrum.lean
@@ -68,7 +68,7 @@ local notation `σ` := spectrum R
 
 lemma mem_spectrum_iff_not_unit {r : R} {a : A} :
   r ∈ σ a ↔ ¬ is_unit (r • 1 - a) :=
-by { tidy }
+iff.rfl
 
 lemma not_mem_spectrum_iff_unit {r : R} {a : A} :
   r ∉ σ a ↔ is_unit (r • 1 - a) :=
@@ -81,7 +81,7 @@ units.is_unit ⟨r•1 - a, b, h₁, by rwa ←left_inv_eq_right_inv h₂ h₁�
 
 lemma mem_resolvent_iff {r : R} {a : A} :
   r ∈ resolvent R a ↔ is_unit (r•1 - a) :=
-by { tidy }
+iff.rfl
 
 -- products of scalar units and algebra units
 
@@ -121,7 +121,7 @@ begin
   apply not_iff_not.mpr,
   simp only [mem_resolvent_iff],
   have h_eq : (r+s)•1 - (s•1 + a) = r•1 - a,
-    by { rw add_smul, noncomm_ring },
+    { rw add_smul, noncomm_ring },
   simp [h_eq],
 end
 

--- a/src/algebra/algebra/spectrum.lean
+++ b/src/algebra/algebra/spectrum.lean
@@ -35,7 +35,6 @@ This theory will serve as the foundation for spectral theory in Banach algebras.
 
 universes u v
 
-namespace spectrum
 
 section defs
 
@@ -64,25 +63,6 @@ end defs
 variables {R : Type u} {A : Type v}
 variables [comm_ring R] [ring A] [algebra R A]
 
-local notation `σ` := spectrum R
-
-lemma mem_spectrum_iff {r : R} {a : A} :
-  r ∈ σ a ↔ ¬ is_unit (r • 1 - a) :=
-iff.rfl
-
-lemma not_mem_spectrum_iff {r : R} {a : A} :
-  r ∉ σ a ↔ is_unit (r • 1 - a) :=
-by { apply not_iff_not.mp, simp [set.not_not_mem, mem_spectrum_iff] }
-
-lemma mem_resolvent_of_left_right_inverse {r : R} {a b c : A}
-  (h₁ : (r • 1 - a) * b = 1) (h₂ : c * (r • 1 - a) = 1) :
-  r ∈ resolvent R a :=
-units.is_unit ⟨r•1 - a, b, h₁, by rwa ←left_inv_eq_right_inv h₂ h₁⟩
-
-lemma mem_resolvent_iff {r : R} {a : A} :
-  r ∈ resolvent R a ↔ is_unit (r•1 - a) :=
-iff.rfl
-
 -- products of scalar units and algebra units
 
 lemma is_unit.smul_iff {G : Type u} [group G] [mul_action G A]
@@ -107,7 +87,29 @@ begin
   rw [←smul_sub,is_unit.smul_iff],
 end
 
-lemma add_mem_spectrum {a : A} {r s : R} :
+namespace spectrum
+
+
+local notation `σ` := spectrum R
+
+lemma mem_iff {r : R} {a : A} :
+  r ∈ σ a ↔ ¬ is_unit (r • 1 - a) :=
+iff.rfl
+
+lemma not_mem_iff {r : R} {a : A} :
+  r ∉ σ a ↔ is_unit (r • 1 - a) :=
+by { apply not_iff_not.mp, simp [set.not_not_mem, mem_iff] }
+
+lemma mem_resolvent_of_left_right_inverse {r : R} {a b c : A}
+  (h₁ : (r • 1 - a) * b = 1) (h₂ : c * (r • 1 - a) = 1) :
+  r ∈ resolvent R a :=
+units.is_unit ⟨r•1 - a, b, h₁, by rwa ←left_inv_eq_right_inv h₂ h₁⟩
+
+lemma mem_resolvent_iff {r : R} {a : A} :
+  r ∈ resolvent R a ↔ is_unit (r•1 - a) :=
+iff.rfl
+
+lemma add_mem_iff {a : A} {r s : R} :
   r ∈ σ a ↔ r + s ∈ σ (s • 1 + a) :=
 begin
   apply not_iff_not.mpr,
@@ -117,7 +119,7 @@ begin
   simp [h_eq],
 end
 
-lemma smul_mem_spectrum_smul {a : A} {s : R} {r : units R} :
+lemma smul_mem_smul_iff {a : A} {s : R} {r : units R} :
   r • s ∈ σ (r • a) ↔ s ∈ σ a :=
 begin
   apply not_iff_not.mpr,
@@ -128,25 +130,25 @@ end
 
 open_locale pointwise
 
-theorem spectrum_smul_eq_smul_spectrum (a : A) (r : units R) :
+theorem smul_eq_smul (a : A) (r : units R) :
   σ (r • a) = r • σ a :=
 begin
   ext,
   have x_eq : x = r•r⁻¹•x, by simp,
   nth_rewrite 0 x_eq,
-  rw smul_mem_spectrum_smul,
+  rw smul_mem_smul_iff,
   split,
     { exact λ h, ⟨r⁻¹•x,⟨h,by simp⟩⟩},
     { rintros ⟨_,_,x'_eq⟩, simpa [←x'_eq],}
 end
 
-theorem left_add_coset_spectrum (a : A) (r : R) :
+theorem left_add_coset_eq (a : A) (r : R) :
   left_add_coset r (σ a) = σ (r • 1 + a) :=
-by { ext, rw [mem_left_add_coset_iff, neg_add_eq_sub, add_mem_spectrum],
+by { ext, rw [mem_left_add_coset_iff, neg_add_eq_sub, add_mem_iff],
      nth_rewrite 1 ←sub_add_cancel x r, }
 
 -- `r ∈ σ(a*b) ↔ r ∈ σ(b*a)` for any `r : units R`
-theorem unit_mem_spectrum_mul_iff_swap_mul {a b : A} {r : units R} :
+theorem unit_mem_mul_iff_mem_swap_mul {a b : A} {r : units R} :
   ↑r ∈ σ (a * b) ↔ ↑r ∈ σ (b * a) :=
 begin
   apply not_iff_not.mpr,
@@ -173,8 +175,8 @@ begin
   rw [←smul_mul_assoc, ←mul_smul_comm r⁻¹ b a, is_unit_one_sub_mul_iff_swap],
 end
 
-theorem units_spectrum_mul_iff_swap_mul {a b : A} :
+theorem preimage_units_mul_eq_swap_mul {a b : A} :
   (coe : units R → R) ⁻¹' σ (a * b) = coe ⁻¹'  σ (b * a) :=
-by { ext, exact unit_mem_spectrum_mul_iff_swap_mul, }
+by { ext, exact unit_mem_mul_iff_mem_swap_mul, }
 
 end spectrum

--- a/src/algebra/algebra/spectrum.lean
+++ b/src/algebra/algebra/spectrum.lean
@@ -47,7 +47,7 @@ variables [comm_ring R] [ring A] [algebra R A]
 is the `set R` consisting of those `r : R` for which `r•1 - a` is a unit of the
 algebra `A`.  -/
 def resolvent (a : A) : set R :=
-{ r : R | is_unit (r • 1 - a) }
+{ r : R | is_unit (algebra_map R A r - a) }
 
 
 /-- Given a commutative ring `R` and an `R`-algebra `A`, the *spectrum* of `a : A`
@@ -91,39 +91,40 @@ namespace spectrum
 
 
 local notation `σ` := spectrum R
+local notation `↑ₐ` := algebra_map R A
 
 lemma mem_iff {r : R} {a : A} :
-  r ∈ σ a ↔ ¬ is_unit (r • 1 - a) :=
+  r ∈ σ a ↔ ¬ is_unit (↑ₐr - a) :=
 iff.rfl
 
 lemma not_mem_iff {r : R} {a : A} :
-  r ∉ σ a ↔ is_unit (r • 1 - a) :=
+  r ∉ σ a ↔ is_unit (↑ₐr - a) :=
 by { apply not_iff_not.mp, simp [set.not_not_mem, mem_iff] }
 
 lemma mem_resolvent_of_left_right_inverse {r : R} {a b c : A}
-  (h₁ : (r • 1 - a) * b = 1) (h₂ : c * (r • 1 - a) = 1) :
+  (h₁ : (↑ₐr - a) * b = 1) (h₂ : c * (↑ₐr - a) = 1) :
   r ∈ resolvent R a :=
-units.is_unit ⟨r•1 - a, b, h₁, by rwa ←left_inv_eq_right_inv h₂ h₁⟩
+units.is_unit ⟨↑ₐr - a, b, h₁, by rwa ←left_inv_eq_right_inv h₂ h₁⟩
 
 lemma mem_resolvent_iff {r : R} {a : A} :
-  r ∈ resolvent R a ↔ is_unit (r•1 - a) :=
+  r ∈ resolvent R a ↔ is_unit (↑ₐr - a) :=
 iff.rfl
 
 lemma add_mem_iff {a : A} {r s : R} :
-  r ∈ σ a ↔ r + s ∈ σ (s • 1 + a) :=
+  r ∈ σ a ↔ r + s ∈ σ (↑ₐs + a) :=
 begin
   apply not_iff_not.mpr,
   simp only [mem_resolvent_iff],
-  have h_eq : (r+s)•1 - (s•1 + a) = r•1 - a,
-    { rw add_smul, noncomm_ring },
-  simp [h_eq],
+  have h_eq : ↑ₐ(r+s) - (↑ₐs + a) = ↑ₐr - a,
+    { simp, noncomm_ring },
+  rw h_eq,
 end
 
 lemma smul_mem_smul_iff {a : A} {s : R} {r : units R} :
   r • s ∈ σ (r • a) ↔ s ∈ σ a :=
 begin
   apply not_iff_not.mpr,
-  simp only [mem_resolvent_iff],
+  simp only [mem_resolvent_iff, algebra.algebra_map_eq_smul_one],
   have h_eq : (r•s)•(1 : A) = r•s•1, by simp,
   rw [h_eq,←smul_sub,is_unit.smul_iff],
 end
@@ -143,7 +144,7 @@ begin
 end
 
 theorem left_add_coset_eq (a : A) (r : R) :
-  left_add_coset r (σ a) = σ (r • 1 + a) :=
+  left_add_coset r (σ a) = σ (↑ₐr + a) :=
 by { ext, rw [mem_left_add_coset_iff, neg_add_eq_sub, add_mem_iff],
      nth_rewrite 1 ←sub_add_cancel x r, }
 
@@ -152,7 +153,7 @@ theorem unit_mem_mul_iff_mem_swap_mul {a b : A} {r : units R} :
   ↑r ∈ σ (a * b) ↔ ↑r ∈ σ (b * a) :=
 begin
   apply not_iff_not.mpr,
-  simp only [mem_resolvent_iff],
+  simp only [mem_resolvent_iff, algebra.algebra_map_eq_smul_one],
   have coe_smul_eq : ↑r•1 = r•(1 : A), from rfl,
   rw coe_smul_eq,
   simp only [is_unit.smul_sub_iff_sub_inv_smul],

--- a/src/algebra/algebra/spectrum.lean
+++ b/src/algebra/algebra/spectrum.lean
@@ -151,27 +151,6 @@ begin
     exact mem_left_coset ↑r (mul_mem_spectrum_mul.mp hx), },
 end
 
--- general (noncommutative) ring results about units and the identity
-lemma right_inv_of_right_inv_swap {a b c : A} (h : (1 - a * b) * c = 1) :
-  (1 - b * a) * (1 + b * c * a) = 1 :=
-calc (1 - b*a)*(1 + b*c*a) = 1 - b*a + b*((1 - a*b)*c)*a : by noncomm_ring
-...                        = 1                           : by simp [h]
-
-lemma left_inv_of_left_inv_swap {a b c : A} (h : c * (1 - a * b) = 1) :
-  (1 + b * c * a) * (1 - b * a) = 1 :=
-calc (1 + b*c*a)*(1 - b*a) = 1 - b*a + b*(c*(1 - a*b))*a : by noncomm_ring
-...                        = 1                           : by simp [h]
-
-lemma is_unit_one_sub_mul_of_swap {a b : A} (h : is_unit (1 - a * b)) :
-  is_unit (1 - b * a) :=
-by { let h₁ := right_inv_of_right_inv_swap h.unit.val_inv,
-     let h₂ := left_inv_of_left_inv_swap h.unit.inv_val,
-     exact ⟨⟨1-b*a,1+b*h.unit.inv*a,h₁,h₂⟩,rfl⟩, }
-
-lemma is_unit_one_sub_mul_iff_swap {a b : A} :
-  is_unit (1 - a * b) ↔ is_unit (1 - b * a) :=
-by { split, repeat {apply is_unit_one_sub_mul_of_swap}, }
-
 -- `r ∈ σ(a*b) ↔ r ∈ σ(b*a)` for any `r : units R`
 theorem unit_mem_spectrum_mul_iff_swap_mul {a b : A} {r : units R} :
   ↑r ∈ σ (a * b) ↔ ↑r ∈ σ (b * a) :=
@@ -179,5 +158,21 @@ begin
   apply not_iff_not.mpr,
   change is_unit (r•1 - a*b) ↔ is_unit (r•1 - b*a),
   repeat {rw [is_unit.smul_sub_iff_is_unit_sub_smul]},
+  have right_inv_of_swap : ∀ {x y z : A} (h : (1 - x*y)*z = 1),
+    (1 - y*x)*(1 + y*z*x) = 1, from λ x y z h,
+      calc (1 - y*x)*(1 + y*z*x) = 1 - y*x + y*((1 - x*y)*z)*x : by noncomm_ring
+      ...                        = 1                           : by simp [h],
+  have left_inv_of_swap : ∀ {x y z : A} (h : z*(1 - x*y) = 1),
+    (1 + y*z*x)*(1 - y*x) = 1, from λ x y z h,
+      calc (1 + y*z*x)*(1 - y*x) = 1 - y*x + y*(z*(1 - x*y))*x : by noncomm_ring
+      ...                        = 1                           : by simp [h],
+  have is_unit_one_sub_mul_of_swap : ∀ {x y : A} (h : is_unit (1 - x*y)),
+    is_unit (1 - y*x), from λ x y h, by
+      { let h₁ := right_inv_of_swap h.unit.val_inv,
+        let h₂ := left_inv_of_swap h.unit.inv_val,
+        exact ⟨⟨1-y*x,1+y*h.unit.inv*x,h₁,h₂⟩,rfl⟩, },
+  have is_unit_one_sub_mul_iff_swap : ∀ {x y : A},
+    is_unit (1 - x*y) ↔ is_unit (1 - y*x), by
+      { intros, split, repeat {apply is_unit_one_sub_mul_of_swap}, },
   rw [←smul_mul_assoc, ←mul_smul_comm r⁻¹ b a, is_unit_one_sub_mul_iff_swap],
 end

--- a/src/algebra/algebra/spectrum.lean
+++ b/src/algebra/algebra/spectrum.lean
@@ -106,8 +106,7 @@ lemma is_unit.smul_sub_iff_is_unit_sub_smul {r : units R} {a : A} :
 begin
   have with_smul_one : is_unit (r•(1 : R)•1 - a) ↔ is_unit ((1 : R)•1 - r⁻¹•a),
     by exact is_unit.smul_smul_sub_iff_is_unit_smul_sub_smul,
-  simp at with_smul_one,
-  exact with_smul_one,
+  simpa using with_smul_one,
 end
 
 lemma add_mem_spectrum {a : A} {r s : R} :
@@ -157,7 +156,7 @@ theorem unit_mem_spectrum_mul_iff_swap_mul {a b : A} {r : units R} :
 begin
   apply not_iff_not.mpr,
   change is_unit (r•1 - a*b) ↔ is_unit (r•1 - b*a),
-  repeat {rw [is_unit.smul_sub_iff_is_unit_sub_smul]},
+  simp only [is_unit.smul_sub_iff_is_unit_sub_smul],
   have right_inv_of_swap : ∀ {x y z : A} (h : (1 - x*y)*z = 1),
     (1 - y*x)*(1 + y*z*x) = 1, from λ x y z h,
       calc (1 - y*x)*(1 + y*z*x) = 1 - y*x + y*((1 - x*y)*z)*x : by noncomm_ring

--- a/src/algebra/algebra/spectrum.lean
+++ b/src/algebra/algebra/spectrum.lean
@@ -85,32 +85,25 @@ iff.rfl
 
 -- products of scalar units and algebra units
 
-
-lemma is_unit.smul_smul_sub_smul_iff {r : units R} {s : R} {a : A} :
-  is_unit (r • s • 1 - r • a) ↔ is_unit (s • 1 - a) :=
+lemma is_unit.smul_iff {r : units R} {a : A} :
+  is_unit (r • a) ↔ is_unit a :=
 begin
-  split,
-  { intro h',
-    have inv_smul_eq : r⁻¹•(r•s•1 - r•a) = s•1 - a,
-      by simp [smul_sub, smul_smul],
-    rw ←inv_smul_eq,
-    exact (r⁻¹ • h'.unit).is_unit, },
-  { intro h',
-    rw ←smul_sub,
-    exact (r • h'.unit).is_unit, },
+  split, swap,
+    { exact λ h, (r•h.unit).is_unit, },
+    { intro h, let a' : units A :=
+        ⟨a,
+         r•↑(h.unit)⁻¹,
+         by rw [mul_smul_comm, ←smul_mul_assoc, is_unit.mul_coe_inv],
+         by {rw [smul_mul_assoc,←mul_smul_comm, is_unit.coe_inv_mul],}⟩,
+      exact ⟨a',rfl⟩, },
 end
-
-lemma is_unit.smul_smul_sub_iff_is_unit_smul_sub_smul {r : units R} {s : R} {a : A} :
-  is_unit (r • s • 1 - a) ↔ is_unit (s • 1 - r⁻¹ • a) :=
-by { have h_eq : r•s•1 - r•(r⁻¹•a) = r•s•1 - a, by simp,
-     rw [←h_eq,is_unit.smul_smul_sub_smul_iff], }
 
 lemma is_unit.smul_sub_iff_is_unit_sub_smul {r : units R} {a : A} :
   is_unit (r • 1 - a) ↔ is_unit (1 - r⁻¹ • a) :=
 begin
-  have with_smul_one : is_unit (r•(1 : R)•1 - a) ↔ is_unit ((1 : R)•1 - r⁻¹•a),
-    by exact is_unit.smul_smul_sub_iff_is_unit_smul_sub_smul,
-  simpa using with_smul_one,
+  have a_eq : a = r•r⁻¹•a, by simp,
+  nth_rewrite 0 a_eq,
+  rw [←smul_sub,is_unit.smul_iff],
 end
 
 lemma add_mem_spectrum {a : A} {r s : R} :
@@ -129,8 +122,7 @@ begin
   apply not_iff_not.mpr,
   simp only [mem_resolvent_iff],
   have h_eq : (r•s)•(1 : A) = r•s•1, by simp,
-  rw h_eq,
-  exact is_unit.smul_smul_sub_smul_iff,
+  rw [h_eq,←smul_sub,is_unit.smul_iff],
 end
 
 open_locale pointwise

--- a/src/algebra/algebra/spectrum.lean
+++ b/src/algebra/algebra/spectrum.lean
@@ -85,8 +85,6 @@ iff.rfl
 
 -- products of scalar units and algebra units
 
-/-- Given a commutative ring `R` and an `R`-algebra `A`, and units `r : units R`
-and `a : units A`, then `unit_mul_unit r a` constructs a `units A` with value `r•a`. -/
 
 lemma is_unit.smul_smul_sub_smul_iff {r : units R} {s : R} {a : A} :
   is_unit (r • s • 1 - r • a) ↔ is_unit (s • 1 - a) :=

--- a/src/algebra/algebra/spectrum.lean
+++ b/src/algebra/algebra/spectrum.lean
@@ -82,7 +82,7 @@ units.is_unit ⟨r•1 - a, b, h₁, by rwa ←left_inv_eq_right_inv h₂ h₁�
 /-- Given a commutative ring `R` and an `R`-algebra `A`, and units `r : units R`
 and `a : units A`, then `unit_mul_unit r a` constructs a `units A` with value `r•a`. -/
 
-lemma is_unit_smul_smul_sub_smul_iff {r : units R} {s : R} {a : A} :
+lemma is_unit.smul_smul_sub_smul_iff {r : units R} {s : R} {a : A} :
   is_unit (r • s • 1 - r • a) ↔ is_unit (s • 1 - a) :=
 begin
   split,
@@ -96,16 +96,16 @@ begin
     exact (r • h'.unit).is_unit, },
 end
 
-lemma is_unit_smul_smul_sub_iff_is_unit_smul_sub_smul {r : units R} {s : R} {a : A} :
+lemma is_unit.smul_smul_sub_iff_is_unit_smul_sub_smul {r : units R} {s : R} {a : A} :
   is_unit (r • s • 1 - a) ↔ is_unit (s • 1 - r⁻¹ • a) :=
 by { have h_eq : r•s•1 - r•(r⁻¹•a) = r•s•1 - a, by simp,
-     rw [←h_eq,is_unit_smul_smul_sub_smul_iff], }
+     rw [←h_eq,is_unit.smul_smul_sub_smul_iff], }
 
-lemma is_unit_smul_sub_iff_is_unit_sub_smul {r : units R} {a : A} :
+lemma is_unit.smul_sub_iff_is_unit_sub_smul {r : units R} {a : A} :
   is_unit (r • 1 - a) ↔ is_unit (1 - r⁻¹ • a) :=
 begin
   have with_smul_one : is_unit (r•(1 : R)•1 - a) ↔ is_unit ((1 : R)•1 - r⁻¹•a),
-    by exact is_unit_smul_smul_sub_iff_is_unit_smul_sub_smul,
+    by exact is_unit.smul_smul_sub_iff_is_unit_smul_sub_smul,
   simp at with_smul_one,
   exact with_smul_one,
 end
@@ -127,7 +127,7 @@ begin
   change is_unit ((r•s)•1 - r•a) ↔ is_unit (s•1 - a),
   have h_eq : (r•s)•(1 : A) = r•s•1, by simp,
   rw h_eq,
-  exact is_unit_smul_smul_sub_smul_iff,
+  exact is_unit.smul_smul_sub_smul_iff,
 end
 
 theorem left_add_coset_spectrum (a : A) (r : R) :
@@ -178,6 +178,6 @@ theorem unit_mem_spectrum_mul_iff_swap_mul {a b : A} {r : units R} :
 begin
   apply not_iff_not.mpr,
   change is_unit (r•1 - a*b) ↔ is_unit (r•1 - b*a),
-  repeat {rw [is_unit_smul_sub_iff_is_unit_sub_smul]},
+  repeat {rw [is_unit.smul_sub_iff_is_unit_sub_smul]},
   rw [←smul_mul_assoc, ←mul_smul_comm r⁻¹ b a, is_unit_one_sub_mul_iff_swap],
 end

--- a/src/algebra/algebra/spectrum.lean
+++ b/src/algebra/algebra/spectrum.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jireh Loreaux
 -/
 import algebra.algebra.basic
-import tactic
+import tactic.noncomm_ring
 /-!
 # Spectrum of an element in an algebra
 This file develops the basic theory of the spectrum of an element of an algebra.

--- a/src/algebra/algebra/spectrum.lean
+++ b/src/algebra/algebra/spectrum.lean
@@ -173,7 +173,7 @@ begin
   rw [←smul_mul_assoc, ←mul_smul_comm r⁻¹ b a, is_unit_one_sub_mul_iff_swap],
 end
 
-theorem units_spectrum_mul_iff_swap_mul {a b : A} {r : units R} :
+theorem units_spectrum_mul_iff_swap_mul {a b : A} :
   (coe : units R → R) ⁻¹' σ (a * b) = coe ⁻¹'  σ (b * a) :=
 by { ext, exact unit_mem_spectrum_mul_iff_swap_mul, }
 

--- a/src/algebra/algebra/spectrum.lean
+++ b/src/algebra/algebra/spectrum.lean
@@ -77,6 +77,10 @@ lemma mem_resolvent_of_left_right_inverse {r : R} {a b c : A}
   r ∈ resolvent R a :=
 units.is_unit ⟨r•1 - a, b, h₁, by rwa ←left_inv_eq_right_inv h₂ h₁⟩
 
+lemma mem_resolvent_iff {r : R} {a : A} :
+  r ∈ resolvent R a ↔ is_unit (r•1 - a) :=
+by { tidy }
+
 -- products of scalar units and algebra units
 
 /-- Given a commutative ring `R` and an `R`-algebra `A`, and units `r : units R`
@@ -113,7 +117,7 @@ lemma add_mem_spectrum {a : A} {r s : R} :
   r ∈ σ a ↔ r + s ∈ σ (s • 1 + a) :=
 begin
   apply not_iff_not.mpr,
-  change is_unit (r•1 - a) ↔ is_unit ((r+s)•1 - (s•1 + a)),
+  simp only [mem_resolvent_iff],
   have h_eq : (r+s)•1 - (s•1 + a) = r•1 - a,
     by { rw add_smul, noncomm_ring },
   simp [h_eq],
@@ -123,7 +127,7 @@ lemma mul_mem_spectrum_mul {a : A} {s : R} {r : units R} :
   r • s ∈ σ (r • a) ↔ s ∈ σ a :=
 begin
   apply not_iff_not.mpr,
-  change is_unit ((r•s)•1 - r•a) ↔ is_unit (s•1 - a),
+  simp only [mem_resolvent_iff],
   have h_eq : (r•s)•(1 : A) = r•s•1, by simp,
   rw h_eq,
   exact is_unit.smul_smul_sub_smul_iff,
@@ -155,7 +159,9 @@ theorem unit_mem_spectrum_mul_iff_swap_mul {a b : A} {r : units R} :
   ↑r ∈ σ (a * b) ↔ ↑r ∈ σ (b * a) :=
 begin
   apply not_iff_not.mpr,
-  change is_unit (r•1 - a*b) ↔ is_unit (r•1 - b*a),
+  simp only [mem_resolvent_iff],
+  have coe_smul_eq : ↑r•1 = r•(1 : A), from rfl,
+  rw coe_smul_eq,
   simp only [is_unit.smul_sub_iff_is_unit_sub_smul],
   have right_inv_of_swap : ∀ {x y z : A} (h : (1 - x*y)*z = 1),
     (1 - y*x)*(1 + y*z*x) = 1, from λ x y z h,

--- a/src/algebra/algebra/spectrum.lean
+++ b/src/algebra/algebra/spectrum.lean
@@ -145,22 +145,6 @@ theorem left_add_coset_spectrum (a : A) (r : R) :
 by { ext, rw [mem_left_add_coset_iff, neg_add_eq_sub, add_mem_spectrum],
      nth_rewrite 1 ←sub_add_cancel x r, }
 
--- this one isn't quite as simple because `R` is not a `group` (but it is an `add_group`)
--- therefore we don't have access to `mem_left_add_coset_iff`
-theorem unit_left_coset_spectrum (a : A) (r : units R) :
-  left_coset ↑r (σ a) = σ (r • a) :=
-begin
-  ext,
-  split,
-  { rintro ⟨y,y_mem,hy⟩,
-    rw ←hy,
-    exact smul_mem_spectrum_smul.mpr y_mem, },
-  { intro hx,
-    have self_inv : x = r•r⁻¹•x, by simp,
-    rw self_inv at *,
-    exact mem_left_coset ↑r (smul_mem_spectrum_smul.mp hx), },
-end
-
 -- `r ∈ σ(a*b) ↔ r ∈ σ(b*a)` for any `r : units R`
 theorem unit_mem_spectrum_mul_iff_swap_mul {a b : A} {r : units R} :
   ↑r ∈ σ (a * b) ↔ ↑r ∈ σ (b * a) :=

--- a/src/algebra/algebra/spectrum.lean
+++ b/src/algebra/algebra/spectrum.lean
@@ -184,4 +184,8 @@ begin
   rw [←smul_mul_assoc, ←mul_smul_comm r⁻¹ b a, is_unit_one_sub_mul_iff_swap],
 end
 
+theorem units_spectrum_mul_iff_swap_mul {a b : A} {r : units R} :
+  (coe : units R → R) ⁻¹' σ (a * b) = coe ⁻¹'  σ (b * a) :=
+by { ext, exact unit_mem_spectrum_mul_iff_swap_mul, }
+
 end spectrum

--- a/src/algebra/algebra/spectrum.lean
+++ b/src/algebra/algebra/spectrum.lean
@@ -26,7 +26,7 @@ This theory will serve as the foundation for spectral theory in Banach algebras.
 
 ## Notations
 
-* `σ a` : `spectrum` of `a : A`
+* `σ a` : `spectrum R a` of `a : A`
 
 ## TODO
 
@@ -35,9 +35,10 @@ This theory will serve as the foundation for spectral theory in Banach algebras.
 
 universes u v
 
-variables {R : Type u} {A : Type v}
-variables [comm_ring R] [ring A] [algebra R A]
+section defs
 
+variables (R : Type u) {A : Type v}
+variables [comm_ring R] [ring A] [algebra R A]
 
 -- definition and basic properties
 
@@ -54,21 +55,26 @@ algebra `A`.
 
 The spectrum is simply the complement of the resolvent.  -/
 definition spectrum (a : A) : set R :=
-(resolvent a)ᶜ
+(resolvent R a)ᶜ
 
-local notation `σ` := spectrum
+end defs
+
+variables {R : Type u} {A : Type v}
+variables [comm_ring R] [ring A] [algebra R A]
+
+local notation `σ` := spectrum R
 
 lemma mem_spectrum_iff_not_unit {r : R} {a : A} :
-  r ∈ (σ a : set R) ↔ ¬ is_unit (r • 1 - a) :=
+  r ∈ σ a ↔ ¬ is_unit (r • 1 - a) :=
 by { tidy }
 
 lemma not_mem_spectrum_iff_unit {r : R} {a : A} :
-  r ∉ (σ a : set R) ↔ is_unit (r • 1 - a) :=
+  r ∉ σ a ↔ is_unit (r • 1 - a) :=
 by { apply not_iff_not.mp, simp [set.not_not_mem, mem_spectrum_iff_not_unit] }
 
 lemma mem_resolvent_of_left_right_inverse {r : R} {a b c : A}
   (h₁ : (r • 1 - a) * b = 1) (h₂ : c * (r • 1 - a) = 1) :
-  r ∈ (resolvent a : set R) :=
+  r ∈ resolvent R a :=
 units.is_unit ⟨r•1 - a, b, h₁, by rwa ←left_inv_eq_right_inv h₂ h₁⟩
 
 -- products of scalar units and algebra units
@@ -105,7 +111,7 @@ begin
 end
 
 lemma add_mem_spectrum {a : A} {r s : R} :
-  r ∈ (σ a : set R) ↔ r + s ∈ (σ (s • 1 + a) : set R) :=
+  r ∈ σ a ↔ r + s ∈ σ (s • 1 + a) :=
 begin
   apply not_iff_not.mpr,
   change is_unit (r•1 - a) ↔ is_unit ((r+s)•1 - (s•1 + a)),
@@ -115,7 +121,7 @@ begin
 end
 
 lemma mul_mem_spectrum_mul {a : A} {s : R} {r : units R} :
-  r • s ∈ (σ (r • a) : set R) ↔ s ∈ (σ a : set R) :=
+  r • s ∈ σ (r • a) ↔ s ∈ σ a :=
 begin
   apply not_iff_not.mpr,
   change is_unit ((r•s)•1 - r•a) ↔ is_unit (s•1 - a),
@@ -125,14 +131,14 @@ begin
 end
 
 theorem left_add_coset_spectrum (a : A) (r : R) :
-  left_add_coset r (σ a) = (σ (r • 1 + a)) :=
+  left_add_coset r (σ a) = σ (r • 1 + a) :=
 by { ext, rw [mem_left_add_coset_iff, neg_add_eq_sub, add_mem_spectrum],
      nth_rewrite 1 ←sub_add_cancel x r, }
 
 -- this one isn't quite as simple because `R` is not a `group` (but it is an `add_group`)
 -- therefore we don't have access to `mem_left_add_coset_iff`
 theorem unit_left_coset_spectrum (a : A) (r : units R) :
-  left_coset ↑r (σ a : set R) = σ (r • a) :=
+  left_coset ↑r (σ a) = σ (r • a) :=
 begin
   ext,
   split,
@@ -168,7 +174,7 @@ by { split, repeat {apply is_unit_one_sub_mul_of_swap}, }
 
 -- `r ∈ σ(a*b) ↔ r ∈ σ(b*a)` for any `r : units R`
 theorem unit_mem_spectrum_mul_iff_swap_mul {a b : A} {r : units R} :
-  ↑r ∈ (σ (a * b) : set R) ↔ ↑r ∈ (σ (b * a) : set R) :=
+  ↑r ∈ σ (a * b) ↔ ↑r ∈ σ (b * a) :=
 begin
   apply not_iff_not.mpr,
   change is_unit (r•1 - a*b) ↔ is_unit (r•1 - b*a),

--- a/src/algebra/algebra/spectrum.lean
+++ b/src/algebra/algebra/spectrum.lean
@@ -12,17 +12,17 @@ This theory will serve as the foundation for spectral theory in Banach algebras.
 
 ## Main definitions
 
-* `resolvent a`: has type `set R` is the resolvent set of an element `a : A` where
+* `resolvent a : set R`: the resolvent set of an element `a : A` where
   `A` is an  `R`-algebra.
-* `spectrum a`: has type `set R` is the spectrum of an element `a : A` where
+* `spectrum a : set R`: the spectrum of an element `a : A` where
   `A` is an  `R`-algebra.
 
 ## Main statements
 
-* `unit_left_coset_spectrum`: units in the scalar ring commute (multplication) with the spectrum.
-* `left_add_coset_spectrum`: elements of the scalar ring commute (addition) with the spectrum.
-* `unit_mem_spectrum_mul_iff_swap_mul`: the units (of `R`) in `σ (a*b)` coincide
-  with those in `σ (b*a)`.
+* `smul_eq_smul`: units in the scalar ring commute (multiplication) with the spectrum.
+* `left_add_coset_eq`: elements of the scalar ring commute (addition) with the spectrum.
+* `units_mem_mul_iff_mem_swap_mul` and `preimage_units_mul_eq_swap_mul`: the units
+  (of `R`) in `σ (a*b)` coincide with those in `σ (b*a)`.
 
 ## Notations
 


### PR DESCRIPTION
…rties

Define the resolvent set and the spectrum of an element of an algebra as
a set of elements in the scalar ring. We prove a few basic facts
including that additive cosets of the spectrum commute with the
spectrum, that is, r + σ a = σ (r ⬝ 1 + a). Similarly, multiplicative
cosets of the spectrum also commute when the element r is a unit of
the scalar ring R. Finally, we also show that the units of R in
σ (a*b) coincide with those of σ (b*a).



---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
