### PR TITLE
[Merged by Bors] - feat(analysis/calculus/parametric_integral): generalize, rename

### DIFF
--- a/src/analysis/calculus/fderiv.lean
+++ b/src/analysis/calculus/fderiv.lean
@@ -291,18 +291,29 @@ begin
 end
 
 /-- Converse to the mean value inequality: if `f` is differentiable at `x₀` and `C`-lipschitz
+on a neighborhood of `x₀` then it its derivative at `x₀` has norm bounded by `C`. This version
+only assumes that `∥f x - f x₀∥ ≤ C * ∥x - x₀∥` in a neighborhood of `x`. -/
+lemma has_fderiv_at.le_of_lip' {f : E → F} {f' : E →L[𝕜] F} {x₀ : E} (hf : has_fderiv_at f f' x₀)
+  {C : ℝ} (hC₀ : 0 ≤ C) (hlip : ∀ᶠ x in 𝓝 x₀, ∥f x - f x₀∥ ≤ C * ∥x - x₀∥) : ∥f'∥ ≤ C :=
+begin
+  refine le_of_forall_pos_le_add (λ ε ε0, op_norm_le_of_nhds_zero _ _),
+  exact add_nonneg hC₀ ε0.le,
+  rw [← map_add_left_nhds_zero x₀, eventually_map] at hlip,
+  filter_upwards [is_o_iff.1 (has_fderiv_at_iff_is_o_nhds_zero.1 hf) ε0, hlip], intros y hy hyC,
+  rw add_sub_cancel' at hyC,
+  calc ∥f' y∥ ≤ ∥f (x₀ + y) - f x₀∥ + ∥f (x₀ + y) - f x₀ - f' y∥ : norm_le_insert _ _
+          ... ≤ C * ∥y∥ + ε * ∥y∥                                : add_le_add hyC hy
+          ... = (C + ε) * ∥y∥                                    : (add_mul _ _ _).symm
+end
+
+/-- Converse to the mean value inequality: if `f` is differentiable at `x₀` and `C`-lipschitz
 on a neighborhood of `x₀` then it its derivative at `x₀` has norm bounded by `C`. -/
 lemma has_fderiv_at.le_of_lip {f : E → F} {f' : E →L[𝕜] F} {x₀ : E} (hf : has_fderiv_at f f' x₀)
   {s : set E} (hs : s ∈ 𝓝 x₀) {C : ℝ≥0} (hlip : lipschitz_on_with C f s) : ∥f'∥ ≤ C :=
 begin
-  refine le_of_forall_pos_le_add (λ ε ε0, op_norm_le_of_nhds_zero _ _),
-  exact add_nonneg C.coe_nonneg ε0.le,
-  have hs' := hs, rw [← map_add_left_nhds_zero x₀, mem_map] at hs',
-  filter_upwards [is_o_iff.1 (has_fderiv_at_iff_is_o_nhds_zero.1 hf) ε0, hs'], intros y hy hys,
-  have := hlip.norm_sub_le hys (mem_of_mem_nhds hs), rw add_sub_cancel' at this,
-  calc ∥f' y∥ ≤ ∥f (x₀ + y) - f x₀∥ + ∥f (x₀ + y) - f x₀ - f' y∥ : norm_le_insert _ _
-          ... ≤ C * ∥y∥ + ε * ∥y∥                                : add_le_add this hy
-          ... = (C + ε) * ∥y∥                                    : (add_mul _ _ _).symm
+  refine hf.le_of_lip' C.coe_nonneg _,
+  filter_upwards [hs],
+  exact λ x hx, hlip.norm_sub_le hx (mem_of_mem_nhds hs)
 end
 
 theorem has_fderiv_at_filter.mono (h : has_fderiv_at_filter f f' x L₂) (hst : L₁ ≤ L₂) :

--- a/src/analysis/calculus/parametric_integral.lean
+++ b/src/analysis/calculus/parametric_integral.lean
@@ -56,19 +56,19 @@ noncomputable theory
 open topological_space measure_theory filter metric
 open_locale topological_space filter
 
-variables {α : Type*} [measurable_space α] {μ : measure α}
+variables {α : Type*} [measurable_space α] {μ : measure α} {𝕜 : Type*} [is_R_or_C 𝕜]
           {E : Type*} [normed_group E] [normed_space ℝ E]
+          [normed_space 𝕜 E] [is_scalar_tower ℝ 𝕜 E]
           [complete_space E] [second_countable_topology E]
           [measurable_space E] [borel_space E]
-          {H : Type*} [normed_group H] [normed_space ℝ H]
-          [second_countable_topology $ H →L[ℝ] E]
+          {H : Type*} [normed_group H] [normed_space 𝕜 H] [second_countable_topology $ H →L[𝕜] E]
 
 /-- Differentiation under integral of `x ↦ ∫ F x a` at a given point `x₀`, assuming `F x₀` is
 integrable, `∥F x a - F x₀ a∥ ≤ bound a * ∥x - x₀∥` for `x` in a ball around `x₀` for ae `a` with
 integrable Lipschitz bound `bound` (with a ball radius independent of `a`), and `F x` is
 ae-measurable for `x` in the same ball. See `has_fderiv_at_integral_of_dominated_loc_of_lip` for a
 slightly less general but usually more useful version. -/
-lemma has_fderiv_at_integral_of_dominated_loc_of_lip' {F : H → α → E} {F' : α → (H →L[ℝ] E)}
+lemma has_fderiv_at_integral_of_dominated_loc_of_lip' {F : H → α → E} {F' : α → (H →L[𝕜] E)}
   {x₀ : H} {bound : α → ℝ}
   {ε : ℝ} (ε_pos : 0 < ε)
   (hF_meas : ∀ x ∈ ball x₀ ε, ae_measurable (F x) μ)
@@ -79,6 +79,7 @@ lemma has_fderiv_at_integral_of_dominated_loc_of_lip' {F : H → α → E} {F' :
   (h_diff : ∀ᵐ a ∂μ, has_fderiv_at (λ x, F x a) (F' a) x₀) :
   integrable F' μ ∧ has_fderiv_at (λ x, ∫ a, F x a ∂μ) (∫ a, F' a ∂μ) x₀ :=
 begin
+  letI : measurable_space 𝕜 := borel 𝕜, haveI : opens_measurable_space 𝕜 := ⟨le_rfl⟩,
   have x₀_in : x₀ ∈ ball x₀ ε := mem_ball_self ε_pos,
   have nneg : ∀ x, 0 ≤ ∥x - x₀∥⁻¹ := λ x, inv_nonneg.mpr (norm_nonneg _) ,
   set b : α → ℝ := λ a, |bound a|,
@@ -156,7 +157,7 @@ end
 `F x₀` is integrable, `x ↦ F x a` is locally Lipschitz on a ball around `x₀` for ae `a`
 (with a ball radius independent of `a`) with integrable Lipschitz bound, and `F x` is ae-measurable
 for `x` in a possibly smaller neighborhood of `x₀`. -/
-lemma has_fderiv_at_integral_of_dominated_loc_of_lip {F : H → α → E} {F' : α → (H →L[ℝ] E)} {x₀ : H}
+lemma has_fderiv_at_integral_of_dominated_loc_of_lip {F : H → α → E} {F' : α → (H →L[𝕜] E)} {x₀ : H}
   {bound : α → ℝ}
   {ε : ℝ} (ε_pos : 0 < ε)
   (hF_meas : ∀ᶠ x in 𝓝 x₀, ae_measurable (F x) μ)
@@ -180,7 +181,7 @@ end
 `F x₀` is integrable, `x ↦ F x a` is differentiable on a ball around `x₀` for ae `a` with
 derivative norm uniformly bounded by an integrable function (the ball radius is independent of `a`),
 and `F x` is ae-measurable for `x` in a possibly smaller neighborhood of `x₀`. -/
-lemma has_fderiv_at_integral_of_dominated_of_fderiv_le {F : H → α → E} {F' : H → α → (H →L[ℝ] E)}
+lemma has_fderiv_at_integral_of_dominated_of_fderiv_le {F : H → α → E} {F' : H → α → (H →L[𝕜] E)}
   {x₀ : H} {bound : α → ℝ}
   {ε : ℝ} (ε_pos : 0 < ε)
   (hF_meas : ∀ᶠ x in 𝓝 x₀, ae_measurable (F x) μ)
@@ -205,8 +206,6 @@ begin
                                                hF'_meas this bound_integrable diff_x₀).2
 end
 
-variables {𝕜 : Type*} [is_R_or_C 𝕜] [normed_space 𝕜 E] [is_scalar_tower ℝ 𝕜 E]
-
 /-- Derivative under integral of `x ↦ ∫ F x a` at a given point `x₀ : 𝕜`, `𝕜 = ℝ` or `𝕜 = ℂ`,
 assuming `F x₀` is integrable, `x ↦ F x a` is locally Lipschitz on a ball around `x₀` for ae `a`
 (with ball radius independent of `a`) with integrable Lipschitz bound, and `F x` is
@@ -222,10 +221,9 @@ lemma has_deriv_at_integral_of_dominated_loc_of_lip {F : 𝕜 → α → E} {F' 
   (integrable F' μ) ∧ has_deriv_at (λ x, ∫ a, F x a ∂μ) (∫ a, F' a ∂μ) x₀ :=
 begin
   letI : measurable_space 𝕜 := borel 𝕜, haveI : opens_measurable_space 𝕜 := ⟨le_rfl⟩,
-  set L : E →L[𝕜] (𝕜 →L[ℝ] E) := (continuous_linear_map.restrict_scalarsL _ _ _ _ _).comp
-      (continuous_linear_map.smul_rightL 𝕜 𝕜 E 1),
+  set L : E →L[𝕜] (𝕜 →L[𝕜] E) := (continuous_linear_map.smul_rightL 𝕜 𝕜 E 1),
   replace h_diff : ∀ᵐ a ∂μ, has_fderiv_at (λ x, F x a) (L (F' a)) x₀ :=
-    h_diff.mono (λ x hx, hx.has_fderiv_at.restrict_scalars ℝ),
+    h_diff.mono (λ x hx, hx.has_fderiv_at),
   have hm : ae_measurable (L ∘ F') μ := L.continuous.measurable.comp_ae_measurable hF'_meas,
   cases has_fderiv_at_integral_of_dominated_loc_of_lip ε_pos hF_meas hF_int hm h_lipsch
     bound_integrable h_diff with hF'_int key,

--- a/src/analysis/calculus/parametric_integral.lean
+++ b/src/analysis/calculus/parametric_integral.lean
@@ -192,6 +192,8 @@ lemma has_fderiv_at_integral_of_dominated_of_fderiv_le {F : H → α → E} {F' 
   (h_diff : ∀ᵐ a ∂μ, ∀ x ∈ ball x₀ ε, has_fderiv_at (λ x, F x a) (F' x a) x) :
   has_fderiv_at (λ x, ∫ a, F x a ∂μ) (∫ a, F' x₀ a ∂μ) x₀ :=
 begin
+  letI : normed_space ℝ H := normed_space.restrict_scalars ℝ 𝕜 H,
+  haveI : is_scalar_tower ℝ 𝕜 H := restrict_scalars.is_scalar_tower ℝ 𝕜 H,
   have x₀_in : x₀ ∈ ball x₀ ε := mem_ball_self ε_pos,
   have diff_x₀ : ∀ᵐ a ∂μ, has_fderiv_at (λ x, F x a) (F' x₀ a) x₀ :=
     h_diff.mono (λ a ha, ha x₀ x₀_in),

--- a/src/analysis/calculus/parametric_integral.lean
+++ b/src/analysis/calculus/parametric_integral.lean
@@ -25,21 +25,30 @@ a derivative. The variations come from the assumptions and from the different wa
 derivative, especially Fréchet derivatives vs elementary derivative of function of one real
 variable.
 
-* `has_fderiv_at_of_dominated_loc_of_lip`: this version assumes
-    `F x` is ae-measurable for x near `x₀`, `F x₀` is integrable,
-    `λ x, F x a` has derivative `F' a : H →L[ℝ] E` at `x₀` which is ae-measurable,
-    `λ x, F x a` is locally Lipschitz near `x₀` for almost every `a`, with a Lipschitz bound which
-    is integrable with respect to `a`. A subtle point is that the "near x₀" in the last condition
-    has to be uniform in `a`. This is controlled by a positive number `ε`.
+* `has_fderiv_at_integral_of_dominated_loc_of_lip`: this version assumes that
+  - `F x` is ae-measurable for x near `x₀`,
+  - `F x₀` is integrable,
+  - `λ x, F x a` has derivative `F' a : H →L[ℝ] E` at `x₀` which is ae-measurable,
+  - `λ x, F x a` is locally Lipschitz near `x₀` for almost every `a`, with a Lipschitz bound which
+    is integrable with respect to `a`.
 
-* `has_fderiv_at_of_dominated_of_fderiv_le`: this version assume `λ x, F x a` has derivative
-    `F' x a` for `x` near `x₀` and `F' x` is bounded by an integrable function independent from
-    `x` near `x₀`.
+  A subtle point is that the "near x₀" in the last condition has to be uniform in `a`. This is
+  controlled by a positive number `ε`.
+
+* `has_fderiv_at_integral_of_dominated_of_fderiv_le`: this version assume `λ x, F x a` has
+   derivative `F' x a` for `x` near `x₀` and `F' x` is bounded by an integrable function independent
+   from `x` near `x₀`.
 
 
-`has_deriv_at_of_dominated_loc_of_lip` and `has_deriv_at_of_dominated_loc_of_deriv_le ` are versions
-of the above two results that assume `H = ℝ` and use the high-school derivative `deriv` instead of
-Fréchet derivative `fderiv`.
+`has_deriv_at_integral_of_dominated_loc_of_lip` and
+`has_deriv_at_integral_of_dominated_loc_of_deriv_le` are versions of the above two results that
+assume `H = ℝ` or `H = ℂ` and use the high-school derivative `deriv` instead of Fréchet derivative
+`fderiv`.
+
+We also provide versions of these theorems for set integrals.
+
+## Tags
+integral, derivative
 -/
 
 noncomputable theory
@@ -54,18 +63,18 @@ variables {α : Type*} [measurable_space α] {μ : measure α}
           {H : Type*} [normed_group H] [normed_space ℝ H]
           [second_countable_topology $ H →L[ℝ] E]
 
-/-- Differentiation under integral of `x ↦ ∫ F x a` at a given point `x₀`, assuming
-`F x₀` is integrable, `x ↦ F x a` is locally Lipschitz on a ball around `x₀` for ae `a` with
-integrable Lipschitz bound (with a ball radius independent of `a`), and `F x` is
-ae-measurable for `x` in the same ball. See `has_fderiv_at_of_dominated_loc_of_lip` for a
-slightly more general version. -/
-lemma has_fderiv_at_of_dominated_loc_of_lip' {F : H → α → E} {F' : α → (H →L[ℝ] E)} {x₀ : H}
-  {bound : α → ℝ}
+/-- Differentiation under integral of `x ↦ ∫ F x a` at a given point `x₀`, assuming `F x₀` is
+integrable, `∥F x a - F x₀ a∥ ≤ bound a * ∥x - x₀∥` for `x` in a ball around `x₀` for ae `a` with
+integrable Lipschitz bound `bound` (with a ball radius independent of `a`), and `F x` is
+ae-measurable for `x` in the same ball. See `has_fderiv_at_integral_of_dominated_loc_of_lip` for a
+slightly less general but usually more useful version. -/
+lemma has_fderiv_at_integral_of_dominated_loc_of_lip' {F : H → α → E} {F' : α → (H →L[ℝ] E)}
+  {x₀ : H} {bound : α → ℝ}
   {ε : ℝ} (ε_pos : 0 < ε)
   (hF_meas : ∀ x ∈ ball x₀ ε, ae_measurable (F x) μ)
   (hF_int : integrable (F x₀) μ)
   (hF'_meas : ae_measurable F' μ)
-  (h_lipsch : ∀ᵐ a ∂μ, lipschitz_on_with (real.nnabs $ bound a) (λ x, F x a) (ball x₀ ε))
+  (h_lipsch : ∀ᵐ a ∂μ, ∀ x ∈ ball x₀ ε, ∥F x a - F x₀ a∥ ≤ bound a * ∥x - x₀∥)
   (bound_integrable : integrable (bound : α → ℝ) μ)
   (h_diff : ∀ᵐ a ∂μ, has_fderiv_at (λ x, F x a) (F' a) x₀) :
   integrable F' μ ∧ has_fderiv_at (λ x, ∫ a, F x a ∂μ) (∫ a, F' a ∂μ) x₀ :=
@@ -75,23 +84,24 @@ begin
   set b : α → ℝ := λ a, |bound a|,
   have b_int : integrable b μ := bound_integrable.norm,
   have b_nonneg : ∀ a, 0 ≤ b a := λ a, abs_nonneg _,
+  replace h_lipsch : ∀ᵐ a ∂μ, ∀ x ∈ ball x₀ ε, ∥F x a - F x₀ a∥ ≤ b a * ∥x - x₀∥,
+    from h_lipsch.mono (λ a ha x hx, (ha x hx).trans $
+      mul_le_mul_of_nonneg_right (le_abs_self _) (norm_nonneg _)),
   have hF_int' : ∀ x ∈ ball x₀ ε, integrable (F x) μ,
   { intros x x_in,
-    have : ∀ᵐ a ∂μ, ∥F x₀ a - F x a∥ ≤ ε * ∥(bound a : ℝ)∥,
-    { apply h_lipsch.mono,
-      intros a ha,
-      rw lipschitz_on_with_iff_norm_sub_le at ha,
-      apply (ha x₀ x₀_in x x_in).trans,
-      rw [mul_comm, real.coe_nnabs, real.norm_eq_abs],
-      rw [mem_ball, dist_eq_norm, norm_sub_rev] at x_in,
-      exact mul_le_mul_of_nonneg_right (le_of_lt x_in) (abs_nonneg  _) },
+    have : ∀ᵐ a ∂μ, ∥F x₀ a - F x a∥ ≤ ε * b a,
+    { simp only [norm_sub_rev (F x₀ _)],
+      refine h_lipsch.mono (λ a ha, (ha x x_in).trans _),
+      rw mul_comm ε,
+      rw [mem_ball, dist_eq_norm] at x_in,
+      exact mul_le_mul_of_nonneg_left x_in.le (b_nonneg _) },
     exact integrable_of_norm_sub_le (hF_meas x x_in) hF_int
       (integrable.const_mul bound_integrable.norm ε) this },
   have hF'_int : integrable F' μ,
   { have : ∀ᵐ a ∂μ, ∥F' a∥ ≤ b a,
     { apply (h_diff.and h_lipsch).mono,
       rintros a ⟨ha_diff, ha_lip⟩,
-      exact ha_diff.le_of_lip (ball_mem_nhds _ ε_pos) ha_lip },
+      refine ha_diff.le_of_lip' (b_nonneg a) (mem_of_superset (ball_mem_nhds _ ε_pos) $ ha_lip) },
     exact b_int.mono' hF'_meas this },
   refine ⟨hF'_int, _⟩,
   have h_ball: ball x₀ ε ∈ 𝓝 x₀ := ball_mem_nhds x₀ ε_pos,
@@ -116,9 +126,7 @@ begin
     apply (h_diff.and h_lipsch).mono,
     rintros a ⟨ha_deriv, ha_bound⟩,
     show ∥∥x - x₀∥⁻¹ • (F x a - F x₀ a - F' a (x - x₀))∥ ≤ b a + ∥F' a∥,
-    replace ha_bound : ∥F x a - F x₀ a∥ ≤ b a * ∥x - x₀∥,
-    { rw lipschitz_on_with_iff_norm_sub_le at ha_bound,
-      exact ha_bound _ hx _ x₀_in },
+    replace ha_bound : ∥F x a - F x₀ a∥ ≤ b a * ∥x - x₀∥ := ha_bound x hx,
     calc ∥∥x - x₀∥⁻¹ • (F x a - F x₀ a - F' a (x - x₀))∥
     = ∥∥x - x₀∥⁻¹ • (F x a - F x₀ a) - ∥x - x₀∥⁻¹ • F' a (x - x₀)∥ : by rw smul_sub
     ... ≤  ∥∥x - x₀∥⁻¹ • (F x a - F x₀ a)∥ + ∥∥x - x₀∥⁻¹ • F' a (x - x₀)∥ : norm_sub_le _ _
@@ -148,7 +156,7 @@ end
 `F x₀` is integrable, `x ↦ F x a` is locally Lipschitz on a ball around `x₀` for ae `a`
 (with a ball radius independent of `a`) with integrable Lipschitz bound, and `F x` is ae-measurable
 for `x` in a possibly smaller neighborhood of `x₀`. -/
-lemma has_fderiv_at_of_dominated_loc_of_lip {F : H → α → E} {F' : α → (H →L[ℝ] E)} {x₀ : H}
+lemma has_fderiv_at_integral_of_dominated_loc_of_lip {F : H → α → E} {F' : α → (H →L[ℝ] E)} {x₀ : H}
   {bound : α → ℝ}
   {ε : ℝ} (ε_pos : 0 < ε)
   (hF_meas : ∀ᶠ x in 𝓝 x₀, ae_measurable (F x) μ)
@@ -159,26 +167,21 @@ lemma has_fderiv_at_of_dominated_loc_of_lip {F : H → α → E} {F' : α → (H
   (h_diff : ∀ᵐ a ∂μ, has_fderiv_at (λ x, F x a) (F' a) x₀) :
   integrable F' μ ∧ has_fderiv_at (λ x, ∫ a, F x a ∂μ) (∫ a, F' a ∂μ) x₀ :=
 begin
-  obtain ⟨ε', ε'_pos, h'⟩ : ∃ ε' > 0, ∀ x ∈ ball x₀ ε', ae_measurable (F x) μ,
-  by simpa using nhds_basis_ball.eventually_iff.mp hF_meas,
-  set δ := min ε ε',
-  have δ_pos : 0 < δ := lt_min ε_pos ε'_pos,
-  replace h' : ∀ x, x ∈ ball x₀ δ → ae_measurable (F x) μ,
-  { intros x x_in,
-    exact h' _ (ball_subset_ball (min_le_right ε ε') x_in) },
-  replace h_lip : ∀ᵐ (a : α) ∂μ, lipschitz_on_with (real.nnabs $ bound a) (λ x, F x a) (ball x₀ δ),
-  { apply h_lip.mono,
-    intros a lip,
-    exact lip.mono (ball_subset_ball $ min_le_left ε ε') },
-  apply has_fderiv_at_of_dominated_loc_of_lip' δ_pos ; assumption
+  obtain ⟨δ, δ_pos, hδ⟩ : ∃ δ > 0, ∀ x ∈ ball x₀ δ, ae_measurable (F x) μ ∧ x ∈ ball x₀ ε,
+    from eventually_nhds_iff_ball.mp (hF_meas.and (ball_mem_nhds x₀ ε_pos)),
+  choose hδ_meas hδε using hδ,
+  replace h_lip : ∀ᵐ (a : α) ∂μ, ∀ x ∈ ball x₀ δ, ∥F x a - F x₀ a∥ ≤ |bound a| * ∥x - x₀∥,
+    from h_lip.mono (λ a lip x hx, lip.norm_sub_le (hδε x hx) (mem_ball_self ε_pos)),
+  replace bound_integrable := bound_integrable.norm,
+  apply has_fderiv_at_integral_of_dominated_loc_of_lip' δ_pos; assumption
 end
 
 /-- Differentiation under integral of `x ↦ ∫ F x a` at a given point `x₀`, assuming
 `F x₀` is integrable, `x ↦ F x a` is differentiable on a ball around `x₀` for ae `a` with
 derivative norm uniformly bounded by an integrable function (the ball radius is independent of `a`),
 and `F x` is ae-measurable for `x` in a possibly smaller neighborhood of `x₀`. -/
-lemma has_fderiv_at_of_dominated_of_fderiv_le {F : H → α → E} {F' : H → α → (H →L[ℝ] E)} {x₀ : H}
-  {bound : α → ℝ}
+lemma has_fderiv_at_integral_of_dominated_of_fderiv_le {F : H → α → E} {F' : H → α → (H →L[ℝ] E)}
+  {x₀ : H} {bound : α → ℝ}
   {ε : ℝ} (ε_pos : 0 < ε)
   (hF_meas : ∀ᶠ x in 𝓝 x₀, ae_measurable (F x) μ)
   (hF_int : integrable (F x₀) μ)
@@ -198,15 +201,17 @@ begin
       (λ x x_in, (ha_deriv x x_in).has_fderiv_within_at) (λ x x_in, _),
     rw [← nnreal.coe_le_coe, coe_nnnorm, real.coe_nnabs],
     exact (ha_bound x x_in).trans (le_abs_self _) },
-  exact (has_fderiv_at_of_dominated_loc_of_lip ε_pos hF_meas hF_int
+  exact (has_fderiv_at_integral_of_dominated_loc_of_lip ε_pos hF_meas hF_int
                                                hF'_meas this bound_integrable diff_x₀).2
 end
 
-/-- Derivative under integral of `x ↦ ∫ F x a` at a given point `x₀ : ℝ`, assuming
-`F x₀` is integrable, `x ↦ F x a` is locally Lipschitz on an interval around `x₀` for ae `a`
-(with interval radius independent of `a`) with integrable Lipschitz bound, and `F x` is
+variables {𝕜 : Type*} [is_R_or_C 𝕜] [normed_space 𝕜 E] [is_scalar_tower ℝ 𝕜 E]
+
+/-- Derivative under integral of `x ↦ ∫ F x a` at a given point `x₀ : 𝕜`, `𝕜 = ℝ` or `𝕜 = ℂ`,
+assuming `F x₀` is integrable, `x ↦ F x a` is locally Lipschitz on a ball around `x₀` for ae `a`
+(with ball radius independent of `a`) with integrable Lipschitz bound, and `F x` is
 ae-measurable for `x` in a possibly smaller neighborhood of `x₀`. -/
-lemma has_deriv_at_of_dominated_loc_of_lip {F : ℝ → α → E} {F' : α → E} {x₀ : ℝ}
+lemma has_deriv_at_integral_of_dominated_loc_of_lip {F : 𝕜 → α → E} {F' : α → E} {x₀ : 𝕜}
   {ε : ℝ} (ε_pos : 0 < ε)
   (hF_meas : ∀ᶠ x in 𝓝 x₀, ae_measurable (F x) μ)
   (hF_int : integrable (F x₀) μ)
@@ -216,14 +221,20 @@ lemma has_deriv_at_of_dominated_loc_of_lip {F : ℝ → α → E} {F' : α → E
   (h_diff : ∀ᵐ a ∂μ, has_deriv_at (λ x, F x a) (F' a) x₀) :
   (integrable F' μ) ∧ has_deriv_at (λ x, ∫ a, F x a ∂μ) (∫ a, F' a ∂μ) x₀ :=
 begin
-  have hm := (continuous_linear_map.smul_rightL ℝ ℝ E 1).continuous.measurable.comp_ae_measurable
-             hF'_meas,
-  cases has_fderiv_at_of_dominated_loc_of_lip ε_pos hF_meas hF_int hm h_lipsch bound_integrable
-    h_diff with hF'_int key,
+  letI : measurable_space 𝕜 := borel 𝕜, haveI : opens_measurable_space 𝕜 := ⟨le_rfl⟩,
+  set L : E →L[𝕜] (𝕜 →L[ℝ] E) := (continuous_linear_map.restrict_scalarsL _ _ _ _ _).comp
+      (continuous_linear_map.smul_rightL 𝕜 𝕜 E 1),
+  replace h_diff : ∀ᵐ a ∂μ, has_fderiv_at (λ x, F x a) (L (F' a)) x₀ :=
+    h_diff.mono (λ x hx, hx.has_fderiv_at.restrict_scalars ℝ),
+  have hm : ae_measurable (L ∘ F') μ := L.continuous.measurable.comp_ae_measurable hF'_meas,
+  cases has_fderiv_at_integral_of_dominated_loc_of_lip ε_pos hF_meas hF_int hm h_lipsch
+    bound_integrable h_diff with hF'_int key,
   replace hF'_int : integrable F' μ,
   { rw [← integrable_norm_iff hm] at hF'_int,
-    simpa only [integrable_norm_iff, hF'_meas, one_mul, norm_one,
-                continuous_linear_map.norm_smul_rightL_apply] using hF'_int},
+    simpa only [L, (∘), integrable_norm_iff, hF'_meas, one_mul, norm_one,
+      continuous_linear_map.comp_apply, continuous_linear_map.coe_restrict_scalarsL',
+      continuous_linear_map.norm_restrict_scalars, continuous_linear_map.norm_smul_rightL_apply]
+      using hF'_int },
   refine ⟨hF'_int, _⟩,
   simp_rw has_deriv_at_iff_has_fderiv_at at h_diff ⊢,
   rwa continuous_linear_map.integral_comp_comm _ hF'_int at key,
@@ -234,7 +245,7 @@ end
 `F x₀` is integrable, `x ↦ F x a` is differentiable on an interval around `x₀` for ae `a`
 (with interval radius independent of `a`) with derivative uniformly bounded by an integrable
 function, and `F x` is ae-measurable for `x` in a possibly smaller neighborhood of `x₀`. -/
-lemma has_deriv_at_of_dominated_loc_of_deriv_le {F : ℝ → α → E} {F' : ℝ → α → E} {x₀ : ℝ}
+lemma has_deriv_at_integral_of_dominated_loc_of_deriv_le {F : 𝕜 → α → E} {F' : 𝕜 → α → E} {x₀ : 𝕜}
   {ε : ℝ} (ε_pos : 0 < ε)
   (hF_meas : ∀ᶠ x in 𝓝 x₀, ae_measurable (F x) μ)
   (hF_int : integrable (F x₀) μ)
@@ -248,13 +259,13 @@ begin
   have x₀_in : x₀ ∈ ball x₀ ε := mem_ball_self ε_pos,
   have diff_x₀ : ∀ᵐ a ∂μ, has_deriv_at (λ x, F x a) (F' x₀ a) x₀ :=
     h_diff.mono (λ a ha, ha x₀ x₀_in),
-  have : ∀ᵐ a ∂μ, lipschitz_on_with (real.nnabs (bound a)) (λ (x : ℝ), F x a) (ball x₀ ε),
+  have : ∀ᵐ a ∂μ, lipschitz_on_with (real.nnabs (bound a)) (λ (x : 𝕜), F x a) (ball x₀ ε),
   { apply (h_diff.and h_bound).mono,
     rintros a ⟨ha_deriv, ha_bound⟩,
     refine (convex_ball _ _).lipschitz_on_with_of_nnnorm_has_deriv_within_le
       (λ x x_in, (ha_deriv x x_in).has_deriv_within_at) (λ x x_in, _),
     rw [← nnreal.coe_le_coe, coe_nnnorm, real.coe_nnabs],
     exact (ha_bound x x_in).trans (le_abs_self _) },
-  exact has_deriv_at_of_dominated_loc_of_lip ε_pos hF_meas hF_int hF'_meas this
+  exact has_deriv_at_integral_of_dominated_loc_of_lip ε_pos hF_meas hF_int hF'_meas this
         bound_integrable diff_x₀
 end

--- a/src/measure_theory/function/l1_space.lean
+++ b/src/measure_theory/function/l1_space.lean
@@ -955,19 +955,18 @@ begin
   refl,
 end
 
-variables {E : Type*} [normed_group E] [measurable_space E] [borel_space E] [normed_space ℝ E]
-          {H : Type*} [normed_group H] [normed_space ℝ H]
+variables {E : Type*} [normed_group E] [measurable_space E] [borel_space E]
+          {𝕜 : Type*} [nondiscrete_normed_field 𝕜] [normed_space 𝕜 E]
+          {H : Type*} [normed_group H] [normed_space 𝕜 H]
 
-lemma measure_theory.integrable.apply_continuous_linear_map {φ : α → H →L[ℝ] E}
+lemma measure_theory.integrable.apply_continuous_linear_map {φ : α → H →L[𝕜] E}
   (φ_int : integrable φ μ) (v : H) : integrable (λ a, φ a v) μ :=
 (φ_int.norm.mul_const ∥v∥).mono' (φ_int.ae_measurable.apply_continuous_linear_map v)
   (eventually_of_forall $ λ a, (φ a).le_op_norm v)
 
-variables {𝕜 : Type*} [is_R_or_C 𝕜]
-  {G : Type*} [normed_group G] [normed_space 𝕜 G] [measurable_space G] [borel_space G]
-  {F : Type*} [normed_group F] [normed_space 𝕜 F] [measurable_space F] [opens_measurable_space F]
+variables [measurable_space H] [opens_measurable_space H]
 
-lemma continuous_linear_map.integrable_comp {φ : α → F} (L : F →L[𝕜] G)
+lemma continuous_linear_map.integrable_comp {φ : α → H} (L : H →L[𝕜] E)
   (φ_int : integrable φ μ) : integrable (λ (a : α), L (φ a)) μ :=
 ((integrable.norm φ_int).const_mul ∥L∥).mono' (L.measurable.comp_ae_measurable φ_int.ae_measurable)
   (eventually_of_forall $ λ a, L.le_op_norm (φ a))

--- a/src/measure_theory/integral/set_integral.lean
+++ b/src/measure_theory/integral/set_integral.lean
@@ -784,10 +784,10 @@ begin
   all_goals { assumption }
 end
 
-lemma integral_apply {H : Type*} [normed_group H] [normed_space ℝ H]
-  [second_countable_topology $ H →L[ℝ] E] {φ : α → H →L[ℝ] E} (φ_int : integrable φ μ) (v : H) :
+lemma integral_apply {H : Type*} [normed_group H] [normed_space 𝕜 H]
+  [second_countable_topology $ H →L[𝕜] E] {φ : α → H →L[𝕜] E} (φ_int : integrable φ μ) (v : H) :
   (∫ a, φ a ∂μ) v = ∫ a, φ a v ∂μ :=
-((continuous_linear_map.apply ℝ E v).integral_comp_comm φ_int).symm
+((continuous_linear_map.apply 𝕜 E v).integral_comp_comm φ_int).symm
 
 lemma integral_comp_comm' (L : E →L[𝕜] F) {K} (hL : antilipschitz_with K L) (φ : α → E) :
   ∫ a, L (φ a) ∂μ = L (∫ a, φ a ∂μ) :=


### PR DESCRIPTION
* add `integral` to lemma names;
* a bit more general
  `has_fderiv_at_integral_of_dominated_loc_of_lip'`: only require an
  estimate on `∥F x a - F x₀ a∥` instead of `∥F x a - F y a∥`;
* generalize the `deriv` lemmas to `F : 𝕜 → α → E`, `[is_R_or_C 𝕜]`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
