### PR TITLE
[Merged by Bors] - chore(algebra/algebra and group_theory/group_action): move a lemma

### DIFF
--- a/src/algebra/algebra/spectrum.lean
+++ b/src/algebra/algebra/spectrum.lean
@@ -65,26 +65,13 @@ variables [comm_ring R] [ring A] [algebra R A]
 
 -- products of scalar units and algebra units
 
-lemma is_unit.smul_iff {G : Type u} [group G] [mul_action G A]
-  [smul_comm_class G A A] [is_scalar_tower G A A] {r : G} {a : A} :
-  is_unit (r • a) ↔ is_unit a :=
-begin
-  split, swap,
-    { exact λ h, (r•h.unit).is_unit, },
-    { intro h, let a' : units A :=
-        ⟨a,
-         r•↑(h.unit)⁻¹,
-         by rw [mul_smul_comm, ←smul_mul_assoc, is_unit.mul_coe_inv],
-         by rw [smul_mul_assoc,←mul_smul_comm, is_unit.coe_inv_mul],⟩,
-      exact ⟨a',rfl⟩, },
-end
 
 lemma is_unit.smul_sub_iff_sub_inv_smul {r : units R} {a : A} :
   is_unit (r • 1 - a) ↔ is_unit (1 - r⁻¹ • a) :=
 begin
   have a_eq : a = r•r⁻¹•a, by simp,
   nth_rewrite 0 a_eq,
-  rw [←smul_sub,is_unit.smul_iff],
+  rw [←smul_sub,is_unit_smul_iff],
 end
 
 namespace spectrum
@@ -126,7 +113,7 @@ begin
   apply not_iff_not.mpr,
   simp only [mem_resolvent_iff, algebra.algebra_map_eq_smul_one],
   have h_eq : (r•s)•(1 : A) = r•s•1, by simp,
-  rw [h_eq,←smul_sub,is_unit.smul_iff],
+  rw [h_eq,←smul_sub,is_unit_smul_iff],
 end
 
 open_locale pointwise

--- a/src/group_theory/group_action/group.lean
+++ b/src/group_theory/group_action/group.lean
@@ -261,3 +261,8 @@ exists.elim hu $ λ u hu, hu ▸ smul_eq_zero_iff_eq u
 end distrib_mul_action
 
 end is_unit
+
+@[simp] lemma is_unit_smul_iff [group α] [monoid β] [mul_action α β]
+  [smul_comm_class α β β] [is_scalar_tower α β β] {g : α} {m : β} :
+  is_unit (g • m) ↔ is_unit m :=
+⟨λ h, inv_smul_smul g m ▸ h.smul g⁻¹, is_unit.smul g⟩

--- a/src/group_theory/group_action/units.lean
+++ b/src/group_theory/group_action/units.lean
@@ -86,20 +86,6 @@ instance mul_action' [group G] [monoid M] [mul_action G M] [smul_comm_class G M 
 @[simp] lemma smul_inv [group G] [monoid M] [mul_action G M] [smul_comm_class G M M]
   [is_scalar_tower G M M] (g : G) (m : units M) : (g • m)⁻¹ = g⁻¹ • m⁻¹ := ext rfl
 
-lemma is_unit_smul_iff [group G] [monoid M] [mul_action G M]
-  [smul_comm_class G M M] [is_scalar_tower G M M] {g : G} {m : M} :
-  is_unit (g • m) ↔ is_unit m :=
-begin
-  split, swap,
-    { exact λ h, (g•h.unit).is_unit, },
-    { intro h, let m' : units M :=
-        ⟨m,
-         g•↑(h.unit)⁻¹,
-         by rw [mul_smul_comm, ←smul_mul_assoc, is_unit.mul_coe_inv],
-         by rw [smul_mul_assoc,←mul_smul_comm, is_unit.coe_inv_mul],⟩,
-      exact ⟨m',rfl⟩, },
-end
-
 /-- Transfer `smul_comm_class G H M` to `smul_comm_class G H (units M)` -/
 instance smul_comm_class' [group G] [group H] [monoid M]
   [mul_action G M] [smul_comm_class G M M]
@@ -128,3 +114,8 @@ example [monoid M] [monoid N] [mul_action M N] [smul_comm_class M N N]
   [is_scalar_tower M N N] : mul_action (units M) (units N) := units.mul_action'
 
 end units
+
+lemma is_unit.smul [group G] [monoid M] [mul_action G M]
+  [smul_comm_class G M M] [is_scalar_tower G M M] {m : M} (g : G) (h : is_unit m) :
+  is_unit (g • m) :=
+let ⟨u, hu⟩ := h in hu ▸ ⟨g • u, units.coe_smul _ _⟩

--- a/src/group_theory/group_action/units.lean
+++ b/src/group_theory/group_action/units.lean
@@ -86,6 +86,20 @@ instance mul_action' [group G] [monoid M] [mul_action G M] [smul_comm_class G M 
 @[simp] lemma smul_inv [group G] [monoid M] [mul_action G M] [smul_comm_class G M M]
   [is_scalar_tower G M M] (g : G) (m : units M) : (g • m)⁻¹ = g⁻¹ • m⁻¹ := ext rfl
 
+lemma is_unit_smul_iff [group G] [monoid M] [mul_action G M]
+  [smul_comm_class G M M] [is_scalar_tower G M M] {g : G} {m : M} :
+  is_unit (g • m) ↔ is_unit m :=
+begin
+  split, swap,
+    { exact λ h, (g•h.unit).is_unit, },
+    { intro h, let m' : units M :=
+        ⟨m,
+         g•↑(h.unit)⁻¹,
+         by rw [mul_smul_comm, ←smul_mul_assoc, is_unit.mul_coe_inv],
+         by rw [smul_mul_assoc,←mul_smul_comm, is_unit.coe_inv_mul],⟩,
+      exact ⟨m',rfl⟩, },
+end
+
 /-- Transfer `smul_comm_class G H M` to `smul_comm_class G H (units M)` -/
 instance smul_comm_class' [group G] [group H] [monoid M]
   [mul_action G M] [smul_comm_class G M M]


### PR DESCRIPTION
Move a lemma about the action of a group on the units of a monoid
to a more appropriate place. It accidentally ended up in
`algebra/algebra/spectrum` but a better place is
`group_theory/group_action/units`.



---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
