### PR TITLE
[Merged by Bors] - feat(linear_algebra/multilinear/basic): multilinear maps with respect to an empty family are all constant

### DIFF
--- a/src/linear_algebra/multilinear/basic.lean
+++ b/src/linear_algebra/multilinear/basic.lean
@@ -680,11 +680,11 @@ def dom_dom_congr_linear_equiv {ι₁ ι₂} [decidable_eq ι₁] [decidable_eq 
 to an empty family. -/
 @[simps] def const_linear_equiv_of_is_empty [is_empty ι] : M₂ ≃ₗ[R] multilinear_map R M₁ M₂ :=
 { to_fun    := multilinear_map.const_of_is_empty R,
-  map_add'  := λ x y, by { ext z, simp [multilinear_map.const_of_is_empty], },
-  map_smul' := λ t x, by { ext y, simp [multilinear_map.const_of_is_empty], },
+  map_add'  := λ x y, rfl,
+  map_smul' := λ t x, rfl,
   inv_fun   := λ f, f 0,
-  left_inv  := λ _, by simp,
-  right_inv := λ f, by { ext x, simp [multilinear_map.const_of_is_empty, subsingleton.elim x 0], } }
+  left_inv  := λ _, rfl,
+  right_inv := λ f, ext $ λ x, multilinear_map.congr_arg f $ subsingleton.elim _ _ }
 
 end module
 

--- a/src/linear_algebra/multilinear/basic.lean
+++ b/src/linear_algebra/multilinear/basic.lean
@@ -110,6 +110,10 @@ coe_injective (funext H)
 theorem ext_iff {f g : multilinear_map R M₁ M₂} : f = g ↔ ∀ x, f x = g x :=
 ⟨λ h x, h ▸ rfl, λ h, ext h⟩
 
+@[simp] lemma mk_coe (f : multilinear_map R M₁ M₂) (h₁ h₂) :
+  (⟨f, h₁, h₂⟩ : multilinear_map R M₁ M₂) = f :=
+by { ext, refl, }
+
 @[simp] lemma map_add (m : Πi, M₁ i) (i : ι) (x y : M₁ i) :
   f (update m i (x + y)) = f (update m i x) + f (update m i y) :=
 f.map_add' m i x y
@@ -671,6 +675,16 @@ def dom_dom_congr_linear_equiv {ι₁ ι₂} [decidable_eq ι₁] [decidable_eq 
 { map_smul' := λ c f, by { ext, simp },
   .. (dom_dom_congr_equiv σ : multilinear_map A (λ i : ι₁, M₂) M₃ ≃+
         multilinear_map A (λ i : ι₂, M₂) M₃) }
+
+/-- The space of constant maps is equivalent to the space of maps that are multilinear with respect
+to an empty family. -/
+@[simps] def const_linear_equiv_of_is_empty [is_empty ι] : M₂ ≃ₗ[R] multilinear_map R M₁ M₂ :=
+{ to_fun    := multilinear_map.const_of_is_empty R,
+  map_add'  := λ x y, by { ext z, simp [multilinear_map.const_of_is_empty], },
+  map_smul' := λ t x, by { ext y, simp [multilinear_map.const_of_is_empty], },
+  inv_fun   := λ f, f 0,
+  left_inv  := λ _, by simp,
+  right_inv := λ f, by { ext x, simp [multilinear_map.const_of_is_empty, subsingleton.elim x 0], } }
 
 end module
 


### PR DESCRIPTION
This seemingly-innocuous statement is valuable as a base case for induction.

Formalized as part of the Sphere Eversion project.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
