### PR TITLE
[Merged by Bors] - chore(data/nat/prime): `fact (2.prime)`

### DIFF
--- a/src/data/nat/prime.lean
+++ b/src/data/nat/prime.lean
@@ -112,6 +112,8 @@ theorem not_prime_one : ¬ prime 1 := by simp [prime]
 
 theorem prime_two : prime 2 := dec_trivial
 
+instance fact_prime_two : fact (nat.prime 2) := ⟨nat.prime_two⟩
+
 end
 
 theorem prime.pred_pos {p : ℕ} (pp : prime p) : 0 < pred p :=

--- a/src/data/nat/prime.lean
+++ b/src/data/nat/prime.lean
@@ -1011,9 +1011,9 @@ everywhere. We instead make them as lemmata and make them local instances as req
 -/
 library_note "fact non-instances"
 
-lemma fact_prime_two := fact.mk prime_two
+lemma fact_prime_two : fact (prime 2) := ⟨prime_two⟩
 
-lemma fact_prime_three := fact.mk prime_three
+lemma fact_prime_three : fact (prime 3) := ⟨prime_three⟩
 
 end nat
 

--- a/src/data/nat/prime.lean
+++ b/src/data/nat/prime.lean
@@ -112,8 +112,6 @@ theorem not_prime_one : ¬ prime 1 := by simp [prime]
 
 theorem prime_two : prime 2 := dec_trivial
 
-instance fact_prime_two : fact (nat.prime 2) := ⟨nat.prime_two⟩
-
 end
 
 theorem prime.pred_pos {p : ℕ} (pp : prime p) : 0 < pred p :=
@@ -1005,6 +1003,17 @@ end tactic
 namespace nat
 
 theorem prime_three : prime 3 := by norm_num
+
+/--
+In most cases, we should not have global instances of `fact`; typeclass search only reads the head
+symbol and then tries any instances, which means that adding any such instance will cause slowdowns
+everywhere. We instead make them as lemmata and make them local instances as required.
+-/
+library_note "fact non-instances"
+
+lemma fact_prime_two := fact.mk prime_two
+
+lemma fact_prime_three := fact.mk prime_three
 
 end nat
 

--- a/src/data/nat/prime.lean
+++ b/src/data/nat/prime.lean
@@ -1004,15 +1004,10 @@ namespace nat
 
 theorem prime_three : prime 3 := by norm_num
 
-/--
-In most cases, we should not have global instances of `fact`; typeclass search only reads the head
-symbol and then tries any instances, which means that adding any such instance will cause slowdowns
-everywhere. We instead make them as lemmata and make them local instances as required.
--/
-library_note "fact non-instances"
-
+/-- See note [fact non-instances].-/
 lemma fact_prime_two : fact (prime 2) := ⟨prime_two⟩
 
+/-- See note [fact non-instances].-/
 lemma fact_prime_three : fact (prime 3) := ⟨prime_three⟩
 
 end nat

--- a/src/logic/basic.lean
+++ b/src/logic/basic.lean
@@ -190,6 +190,13 @@ In particular, this class is not intended for turning the type class system
 into an automated theorem prover for first order logic. -/
 class fact (p : Prop) : Prop := (out [] : p)
 
+/--
+In most cases, we should not have global instances of `fact`; typeclass search only reads the head
+symbol and then tries any instances, which means that adding any such instance will cause slowdowns
+everywhere. We instead make them as lemmata and make them local instances as required.
+-/
+library_note "fact non-instances"
+
 lemma fact.elim {p : Prop} (h : fact p) : p := h.1
 lemma fact_iff {p : Prop} : fact p ↔ p := ⟨λ h, h.1, λ h, ⟨h⟩⟩
 

--- a/src/number_theory/quadratic_reciprocity.lean
+++ b/src/number_theory/quadratic_reciprocity.lean
@@ -429,6 +429,8 @@ have hqp0 : (q : zmod p) ≠ 0, from prime_ne_zero p q hpq,
 by rw [eisenstein_lemma q hp1.1 hpq0, eisenstein_lemma p hq1.1 hqp0,
   ← pow_add, sum_mul_div_add_sum_mul_div_eq_mul q p hpq0, mul_comm]
 
+local attribute [instance] nat.fact_prime_two
+
 lemma legendre_sym_two [hp1 : fact (p % 2 = 1)] : legendre_sym 2 p = (-1) ^ (p / 4 + p / 2) :=
 have hp2 : p ≠ 2, from mt (congr_arg (% 2)) (by simpa using hp1.1),
 have hp22 : p / 2 / 2 = _ := div_eq_filter_card (show 0 < 2, from dec_trivial)

--- a/src/number_theory/quadratic_reciprocity.lean
+++ b/src/number_theory/quadratic_reciprocity.lean
@@ -429,10 +429,6 @@ have hqp0 : (q : zmod p) ≠ 0, from prime_ne_zero p q hpq,
 by rw [eisenstein_lemma q hp1.1 hpq0, eisenstein_lemma p hq1.1 hqp0,
   ← pow_add, sum_mul_div_add_sum_mul_div_eq_mul q p hpq0, mul_comm]
 
--- move this
-local attribute [instance]
-lemma fact_prime_two : fact (nat.prime 2) := ⟨nat.prime_two⟩
-
 lemma legendre_sym_two [hp1 : fact (p % 2 = 1)] : legendre_sym 2 p = (-1) ^ (p / 4 + p / 2) :=
 have hp2 : p ≠ 2, from mt (congr_arg (% 2)) (by simpa using hp1.1),
 have hp22 : p / 2 / 2 = _ := div_eq_filter_card (show 0 < 2, from dec_trivial)


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)

- [x] depends on: #10521 [this timed out without this speedup so...]

I'm specifically not putting easy on this as I'm not sure what the repercussions of putting such a global `fact` lemma are, although it is a very limited `fact`