### PR TITLE
[Merged by Bors] - refactor(linear_algebra/sesquilinear_form): Use similar definition as used in `bilinear_map`

### DIFF
--- a/src/analysis/inner_product_space/basic.lean
+++ b/src/analysis/inner_product_space/basic.lean
@@ -437,6 +437,7 @@ linear_map.mk₂'ₛₗ (ring_hom.id 𝕜) (star_ring_aut.to_ring_hom)
   (λ x y z, inner_add_left)
   (λ r x y, inner_smul_left)
 
+/-- The real inner product as a bilinear form. -/
 @[simps]
 def bilin_form_of_real_inner : bilin_form ℝ F :=
 { bilin := inner,

--- a/src/analysis/inner_product_space/basic.lean
+++ b/src/analysis/inner_product_space/basic.lean
@@ -429,14 +429,16 @@ by { rw [inner_smul_right, algebra.smul_def], refl }
 
 /-- The inner product as a sesquilinear form. -/
 @[simps]
-def sesq_form_of_inner : sesq_form 𝕜 E (conj_to_ring_equiv 𝕜) :=
-{ sesq := λ x y, ⟪y, x⟫,    -- Note that sesquilinear forms are linear in the first argument
-  sesq_add_left := λ x y z, inner_add_right,
-  sesq_add_right := λ x y z, inner_add_left,
-  sesq_smul_left := λ r x y, inner_smul_right,
-  sesq_smul_right := λ r x y, inner_smul_left }
+def sesq_form_of_inner : E →ₗ[𝕜] E →ₛₗ[star_ring_aut.to_ring_hom] 𝕜 :=
+linear_map.mk₂'ₛₗ (ring_hom.id 𝕜) (star_ring_aut.to_ring_hom)
+  (λ x y, ⟪y, x⟫)
+  (λ x y z, inner_add_right)
+  (λ r x y, inner_smul_right)
+  (λ x y z, inner_add_left)
+  (λ r x y, by {
+    rw [inner_smul_left, ring_equiv.to_ring_hom_eq_coe, ring_equiv.coe_to_ring_hom],
+    refl })
 
-/-- The real inner product as a bilinear form. -/
 @[simps]
 def bilin_form_of_real_inner : bilin_form ℝ F :=
 { bilin := inner,
@@ -447,13 +449,11 @@ def bilin_form_of_real_inner : bilin_form ℝ F :=
 
 /-- An inner product with a sum on the left. -/
 lemma sum_inner {ι : Type*} (s : finset ι) (f : ι → E) (x : E) :
-  ⟪∑ i in s, f i, x⟫ = ∑ i in s, ⟪f i, x⟫ :=
-sesq_form.sum_right (sesq_form_of_inner) _ _ _
+  ⟪∑ i in s, f i, x⟫ = ∑ i in s, ⟪f i, x⟫ := (sesq_form_of_inner x).map_sum
 
 /-- An inner product with a sum on the right. -/
 lemma inner_sum {ι : Type*} (s : finset ι) (f : ι → E) (x : E) :
-  ⟪x, ∑ i in s, f i⟫ = ∑ i in s, ⟪x, f i⟫ :=
-sesq_form.sum_left (sesq_form_of_inner) _ _ _
+  ⟪x, ∑ i in s, f i⟫ = ∑ i in s, ⟪x, f i⟫ := (linear_map.flip sesq_form_of_inner x).map_sum
 
 /-- An inner product with a sum on the left, `finsupp` version. -/
 lemma finsupp.sum_inner {ι : Type*} (l : ι →₀ 𝕜) (v : ι → E) (x : E) :

--- a/src/analysis/inner_product_space/basic.lean
+++ b/src/analysis/inner_product_space/basic.lean
@@ -429,15 +429,13 @@ by { rw [inner_smul_right, algebra.smul_def], refl }
 
 /-- The inner product as a sesquilinear form. -/
 @[simps]
-def sesq_form_of_inner : E →ₗ[𝕜] E →ₛₗ[star_ring_aut.to_ring_hom] 𝕜 :=
+def sesq_form_of_inner : E →ₗ[𝕜] E →ₗ⋆[𝕜] 𝕜 :=
 linear_map.mk₂'ₛₗ (ring_hom.id 𝕜) (star_ring_aut.to_ring_hom)
   (λ x y, ⟪y, x⟫)
   (λ x y z, inner_add_right)
   (λ r x y, inner_smul_right)
   (λ x y z, inner_add_left)
-  (λ r x y, by {
-    rw [inner_smul_left, ring_equiv.to_ring_hom_eq_coe, ring_equiv.coe_to_ring_hom],
-    refl })
+  (λ r x y, inner_smul_left)
 
 @[simps]
 def bilin_form_of_real_inner : bilin_form ℝ F :=

--- a/src/linear_algebra/sesquilinear_form.lean
+++ b/src/linear_algebra/sesquilinear_form.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Andreas Swerdlow
 -/
 import algebra.module.linear_map
-import tactic.abel
 import linear_algebra.bilinear_map
 
 /-!
@@ -36,28 +35,31 @@ open_locale big_operators
 
 namespace linear_map
 
-section semiring
+section comm_ring
 
 -- the `ₗ` subscript variables are for special cases about linear (as opposed to semilinear) maps
-variables {R : Type*} {M : Type*} [semiring R] [add_comm_monoid M] [module R M]
-  {I : R →+* Rᵐᵒᵖ}
-  {B : M →ₗ[R] M →ₛₗ[I] R}
+variables {R : Type*} {M : Type*} [comm_semiring R] [star_ring R] [add_comm_monoid M] [module R M]
+  {I : R →+* R}
 
 /-- The proposition that two elements of a sesquilinear form space are orthogonal -/
 def is_ortho (B : M →ₗ[R] M →ₛₗ[I] R) (x y) : Prop := B x y = 0
 
-lemma ortho_zero (B : M →ₗ[R] M →ₛₗ[I] R) (x) :
-is_ortho B (0 : M) x :=
-begin
-  dunfold is_ortho,
-  rw [ map_zero B, zero_apply],
-end
+lemma is_ortho_def {B : M →ₗ[R] M →ₛₗ[I] R} {x y : M} :
+  B.is_ortho x y ↔ B x y = 0 := iff.rfl
 
-end semiring
+lemma is_ortho_zero_left (B : M →ₗ[R] M →ₛₗ[I] R) (x) : is_ortho B (0 : M) x :=
+  by { dunfold is_ortho, rw [ map_zero B, zero_apply] }
+
+lemma is_ortho_zero_right (B : M →ₗ[R] M →ₛₗ[I] R) (x) : is_ortho B x (0 : M) :=
+  map_zero (B x)
+
+
+end comm_ring
 section is_domain
 
-variables {R : Type*} {M : Type*} [ring R] [is_domain R] [add_comm_group M] [module R M]
-  {I : R ≃+* Rᵐᵒᵖ} [no_zero_smul_divisors Rᵐᵒᵖ R]
+variables {R : Type*} {M : Type*} [comm_ring R] [star_ring R] [is_domain R] [add_comm_group M]
+  [module R M]
+  {I : R ≃+* R}
   {B : M →ₗ[R] M →ₛₗ[I.to_ring_hom] R}
 
 
@@ -90,8 +92,8 @@ end
 
 end is_domain
 
-variables {R : Type*} {M : Type*} [ring R] [add_comm_group M] [module R M]
-  {I : R →+* Rᵐᵒᵖ}
+variables {R : Type*} {M : Type*} [comm_ring R] [star_ring R] [add_comm_group M] [module R M]
+  {I : R →+* R}
   {B : M →ₗ[R] M →ₛₗ[I] R}
 
 /-- The proposition that a sesquilinear form is reflexive -/
@@ -110,14 +112,14 @@ end is_refl
 
 /-- The proposition that a sesquilinear form is symmetric -/
 def is_symm (B : M →ₗ[R] M →ₛₗ[I] R) : Prop :=
-  ∀ (x y), (I (B x y)).unop = B y x
+  ∀ (x y), (I (B x y)) = B y x
 
 namespace is_symm
 
 variable (H : B.is_symm)
 include H
 
-protected lemma eq (x y) : (I (B x y)).unop = B y x := H x y
+protected lemma eq (x y) : (I (B x y)) = B y x := H x y
 
 lemma is_refl : B.is_refl := λ x y H1, by { rw [←H], simp [H1] }
 
@@ -155,297 +157,3 @@ lemma ortho_comm {x y} : is_ortho B x y ↔ is_ortho B y x := H.is_refl.ortho_co
 end is_alt
 
 end linear_map
-
-
-universes u v w
-
-/-- A sesquilinear form over a module  -/
-structure sesq_form (R : Type u) (M : Type v) [ring R] (I : R ≃+* Rᵐᵒᵖ)
-  [add_comm_group M] [module R M] :=
-(sesq : M → M → R)
-(sesq_add_left : ∀ (x y z : M), sesq (x + y) z = sesq x z + sesq y z)
-(sesq_smul_left : ∀ (a : R) (x y : M), sesq (a • x) y = a * (sesq x y))
-(sesq_add_right : ∀ (x y z : M), sesq x (y + z) = sesq x y + sesq x z)
-(sesq_smul_right : ∀ (a : R) (x y : M), sesq x (a • y) = (I a).unop * (sesq x y))
-
-namespace sesq_form
-
-section general_ring
-variables {R : Type u} {M : Type v} [ring R] [add_comm_group M] [module R M]
-variables {I : R ≃+* Rᵐᵒᵖ} {S : sesq_form R M I}
-
-instance : has_coe_to_fun (sesq_form R M I) (λ _, M → M → R) := ⟨sesq⟩
-
-lemma add_left (x y z : M) : S (x + y) z = S x z + S y z := sesq_add_left S x y z
-
-lemma smul_left (a : R) (x y : M) : S (a • x) y = a * (S x y) := sesq_smul_left S a x y
-
-lemma add_right (x y z : M) : S x (y + z) = S x y + S x z := sesq_add_right S x y z
-
-lemma smul_right (a : R) (x y : M) : S x (a • y) = (I a).unop * (S x y) := sesq_smul_right S a x y
-
-lemma zero_left (x : M) : S 0 x = 0 :=
-by { rw [←zero_smul R (0 : M), smul_left, zero_mul] }
-
-lemma zero_right (x : M) : S x 0 = 0 :=
-by { rw [←zero_smul R (0 : M), smul_right], simp }
-
-lemma neg_left (x y : M) : S (-x) y = -(S x y) :=
-by { rw [←@neg_one_smul R _ _, smul_left, neg_one_mul] }
-
-lemma neg_right (x y : M) : S x (-y) = -(S x y) :=
-by { rw [←@neg_one_smul R _ _, smul_right], simp }
-
-lemma sub_left (x y z : M) :
-  S (x - y) z = S x z - S y z :=
-by simp only [sub_eq_add_neg, add_left, neg_left]
-
-lemma sub_right (x y z : M) :
-  S x (y - z) = S x y - S x z :=
-by simp only [sub_eq_add_neg, add_right, neg_right]
-
-variable {D : sesq_form R M I}
-@[ext] lemma ext (H : ∀ (x y : M), S x y = D x y) : S = D :=
-by {cases S, cases D, congr, funext, exact H _ _}
-
-instance : has_add (sesq_form R M I) :=
-⟨λ S D, { sesq := λ x y, S x y + D x y,
-                  sesq_add_left := λ x y z, by {rw add_left, rw add_left, abel},
-                  sesq_smul_left := λ a x y, by {rw [smul_left, smul_left, mul_add]},
-                  sesq_add_right := λ x y z, by {rw add_right, rw add_right, abel},
-                  sesq_smul_right := λ a x y, by {rw [smul_right, smul_right, mul_add]} }⟩
-
-instance : has_zero (sesq_form R M I) :=
-⟨{ sesq := λ x y, 0,
-            sesq_add_left := λ x y z, (add_zero 0).symm,
-            sesq_smul_left := λ a x y, (mul_zero a).symm,
-            sesq_add_right := λ x y z, (zero_add 0).symm,
-            sesq_smul_right := λ a x y, (mul_zero (I a).unop).symm }⟩
-
-instance : has_neg (sesq_form R M I) :=
-⟨λ S, { sesq := λ x y, - (S.1 x y),
-                sesq_add_left := λ x y z, by rw [sesq_add_left, neg_add],
-                sesq_smul_left := λ a x y, by rw [sesq_smul_left, mul_neg_eq_neg_mul_symm],
-                sesq_add_right := λ x y z, by rw [sesq_add_right, neg_add],
-                sesq_smul_right := λ a x y, by rw [sesq_smul_right, mul_neg_eq_neg_mul_symm] }⟩
-
-instance : add_comm_group (sesq_form R M I) :=
-{ add := (+),
-  add_assoc := by { intros, ext,
-    unfold coe_fn has_coe_to_fun.coe sesq coe_fn has_coe_to_fun.coe sesq, rw add_assoc },
-  zero := 0,
-  zero_add := by { intros, ext, unfold coe_fn has_coe_to_fun.coe sesq, rw zero_add },
-  add_zero := by { intros, ext, unfold coe_fn has_coe_to_fun.coe sesq, rw add_zero },
-  neg := has_neg.neg,
-  add_left_neg := by { intros, ext, unfold coe_fn has_coe_to_fun.coe sesq, rw neg_add_self },
-  add_comm := by { intros, ext, unfold coe_fn has_coe_to_fun.coe sesq, rw add_comm } }
-
-instance : inhabited (sesq_form R M I) := ⟨0⟩
-
-/-- The proposition that two elements of a sesquilinear form space are orthogonal -/
-def is_ortho (S : sesq_form R M I) (x y : M) : Prop :=
-S x y = 0
-
-lemma ortho_zero (x : M) :
-is_ortho S (0 : M) x := zero_left x
-
-/-- For fixed `y : M`, the `R`-linear map sending `x : M` to `S x y`, where `S` is a
-sesquilinear form. -/
-@[simps] def linear_map_left (S : sesq_form R M I) (x : M) : M →ₗ[R] R :=
-{ to_fun := λ z, S z x,
-  map_add' := λ z y, sesq_add_left S _ _ _,
-  map_smul' := λ r m, sesq_smul_left S _ _ _ }
-
-/-- For fixed `x : M`, the `add_monoid_hom` sending `y : M` to `S x y`, where `S` is a
-sesquilinear form. -/
-@[simps] def add_monoid_hom_right (S : sesq_form R M I) (x : M) : M →+ R :=
-{ to_fun := λ z, S x z,
-  map_zero' := zero_right x,
-  map_add' := λ z y, sesq_add_right S _ _ _, }
-
-lemma sum_left {α : Type*} (S : sesq_form R M I) (t : finset α) (g : α → M) (w : M) :
-  S (∑ i in t, g i) w = ∑ i in t, S (g i) w :=
-(linear_map_left S w).map_sum
-
-lemma sum_right {α : Type*} (S : sesq_form R M I) (t : finset α) (g : α → M) (w : M) :
-  S w (∑ i in t, g i) = ∑ i in t, S w (g i) :=
-(add_monoid_hom_right S w).map_sum _ t
-
-variables {M₂ : Type w} [add_comm_group M₂] [module R M₂]
-
-/-- Apply the linear maps `f` and `g` to the left and right arguments of the sesquilinear form. -/
-def comp (S : sesq_form R M I) (f g : M₂ →ₗ[R] M) : sesq_form R M₂ I :=
-{ sesq := λ x y, S (f x) (g y),
-  sesq_add_left := by simp [add_left],
-  sesq_smul_left := by simp [smul_left],
-  sesq_add_right := by simp [add_right],
-  sesq_smul_right := by simp [smul_right] }
-
-/-- Apply the linear map `f` to the left argument of the sesquilinear form. -/
-def comp_left (S : sesq_form R M I) (f : M →ₗ[R] M) : sesq_form R M I :=
-  S.comp f linear_map.id
-
-/-- Apply the linear map `f` to the right argument of the sesquilinear form. -/
-def comp_right (S : sesq_form R M I) (f : M →ₗ[R] M) : sesq_form R M I :=
-  S.comp linear_map.id f
-
-lemma comp_left_comp_right (S : sesq_form R M I) (f g : M →ₗ[R] M) :
-  (S.comp_left f).comp_right g = S.comp f g := rfl
-
-lemma comp_right_comp_left (S : sesq_form R M I) (f g : M →ₗ[R] M) :
-  (S.comp_right g).comp_left f = S.comp f g := rfl
-
-lemma comp_comp {M₃ : Type*} [add_comm_group M₃] [module R M₃]
-  (S : sesq_form R M₃ I) (l r : M →ₗ[R] M₂) (l' r' : M₂ →ₗ[R] M₃) :
-  (S.comp l' r').comp l r = S.comp (l'.comp l) (r'.comp r) := rfl
-
-@[simp] lemma comp_apply (S : sesq_form R M₂ I) (l r : M →ₗ[R] M₂) (v w : M) :
-  S.comp l r v w = S (l v) (r w) := rfl
-
-@[simp] lemma comp_left_apply (S : sesq_form R M I) (f : M →ₗ[R] M) (v w : M) :
-  S.comp_left f v w = S (f v) w := rfl
-
-@[simp] lemma comp_right_apply (S : sesq_form R M I) (f : M →ₗ[R] M) (v w : M) :
-  S.comp_right f v w = S v (f w) := rfl
-
-/-- Let `l`, `r` be surjective linear maps, then two sesquilinear forms are equal if and only if
-  the sesquilinear forms resulting from composition with `l` and `r` are equal. -/
-lemma comp_injective (S₁ S₂ : sesq_form R M₂ I) {l r : M →ₗ[R] M₂}
-  (hl : function.surjective l) (hr : function.surjective r) :
-  S₁.comp l r = S₂.comp l r ↔ S₁ = S₂ :=
-begin
-  split; intros h,
-  { ext,
-    rcases hl x with ⟨x', rfl⟩,
-    rcases hr y with ⟨y', rfl⟩,
-    rw [← comp_apply, ← comp_apply, h], },
-  { rw h },
-end
-
-end general_ring
-
-section comm_ring
-
-variables {R : Type*} [comm_ring R] {M : Type v} [add_comm_group M] [module R M]
-  {J : R ≃+* Rᵐᵒᵖ} (F : sesq_form R M J)
-
-instance to_module : module R (sesq_form R M J) :=
-{ smul := λ c S,
-  { sesq := λ x y, c * S x y,
-    sesq_add_left := λ x y z, by {unfold coe_fn has_coe_to_fun.coe sesq,
-      rw [sesq_add_left, left_distrib]},
-    sesq_smul_left := λ a x y, by {unfold coe_fn has_coe_to_fun.coe sesq,
-      rw [sesq_smul_left, ←mul_assoc, mul_comm c, mul_assoc]},
-    sesq_add_right := λ x y z, by {unfold coe_fn has_coe_to_fun.coe sesq,
-      rw [sesq_add_right, left_distrib]},
-    sesq_smul_right := λ a x y, by {unfold coe_fn has_coe_to_fun.coe sesq,
-      rw [sesq_smul_right, ←mul_assoc, mul_comm c, mul_assoc], refl} },
-  smul_add := λ c S D, by {ext, unfold coe_fn has_coe_to_fun.coe sesq, rw left_distrib},
-  add_smul := λ c S D, by {ext, unfold coe_fn has_coe_to_fun.coe sesq, rw right_distrib},
-  mul_smul := λ a c D, by {ext, unfold coe_fn has_coe_to_fun.coe sesq, rw mul_assoc},
-  one_smul := λ S, by {ext, unfold coe_fn has_coe_to_fun.coe sesq, rw one_mul},
-  zero_smul := λ S, by {ext, unfold coe_fn has_coe_to_fun.coe sesq, rw zero_mul},
-  smul_zero := λ S, by {ext, unfold coe_fn has_coe_to_fun.coe sesq, rw mul_zero} }
-
-end comm_ring
-
-section is_domain
-
-variables {R : Type*} [ring R] [is_domain R]
-  {M : Type v} [add_comm_group M] [module R M]
-  {K : R ≃+* Rᵐᵒᵖ} {G : sesq_form R M K}
-
-theorem ortho_smul_left {x y : M} {a : R} (ha : a ≠ 0) :
-  (is_ortho G x y) ↔ (is_ortho G (a • x) y) :=
-begin
-  dunfold is_ortho,
-  split; intro H,
-  { rw [smul_left, H, mul_zero] },
-  { rw [smul_left, mul_eq_zero] at H,
-    cases H,
-    { trivial },
-    { exact H }}
-end
-
-theorem ortho_smul_right {x y : M} {a : R} (ha : a ≠ 0) :
-  (is_ortho G x y) ↔ (is_ortho G x (a • y)) :=
-begin
-  dunfold is_ortho,
-  split; intro H,
-  { rw [smul_right, H, mul_zero] },
-  { rw [smul_right, mul_eq_zero] at H,
-    cases H,
-    { exfalso,
-      -- `map_eq_zero_iff` doesn't fire here even if marked as a simp lemma, probably bcecause
-      -- different instance paths
-      simp only [mul_opposite.unop_eq_zero_iff] at H,
-      exact ha (K.map_eq_zero_iff.mp H), },
-    { exact H }}
-end
-
-end is_domain
-
-variables {R : Type*} {M : Type*} [ring R] [add_comm_group M] [module R M]
-variables {I : R ≃+* Rᵐᵒᵖ} {S : sesq_form R M I}
-
-/-- The proposition that a sesquilinear form is reflexive -/
-def is_refl (S : sesq_form R M I) : Prop := ∀ (x y : M), S x y = 0 → S y x = 0
-
-namespace is_refl
-
-variable (H : S.is_refl)
-
-lemma eq_zero : ∀ {x y : M}, S x y = 0 → S y x = 0 := λ x y, H x y
-
-lemma ortho_comm {x y : M} : is_ortho S x y ↔ is_ortho S y x := ⟨eq_zero H, eq_zero H⟩
-
-end is_refl
-
-/-- The proposition that a sesquilinear form is symmetric -/
-def is_symm (S : sesq_form R M I) : Prop := ∀ (x y : M), (I (S x y)).unop = S y x
-
-namespace is_symm
-
-variable (H : S.is_symm)
-include H
-
-protected lemma eq (x y : M) : (I (S x y)).unop = S y x := H x y
-
-lemma is_refl : S.is_refl := λ x y H1, by { rw [←H], simp [H1], }
-
-lemma ortho_comm {x y : M} : is_ortho S x y ↔ is_ortho S y x := H.is_refl.ortho_comm
-
-end is_symm
-
-/-- The proposition that a sesquilinear form is alternating -/
-def is_alt (S : sesq_form R M I) : Prop := ∀ (x : M), S x x = 0
-
-namespace is_alt
-
-variable (H : S.is_alt)
-include H
-
-lemma self_eq_zero (x : M) : S x x = 0 := H x
-
-lemma neg (x y : M) :
-- S x y = S y x :=
-begin
-  have H1 : S (x + y) (x + y) = 0,
-  { exact self_eq_zero H (x + y) },
-  rw [add_left, add_right, add_right,
-    self_eq_zero H, self_eq_zero H, ring.zero_add,
-    ring.add_zero, add_eq_zero_iff_neg_eq] at H1,
-  exact H1,
-end
-
-lemma is_refl : S.is_refl :=
-begin
-  intros x y h,
-  rw [← neg H, h, neg_zero],
-end
-
-lemma ortho_comm {x y : M} : is_ortho S x y ↔ is_ortho S y x := H.is_refl.ortho_comm
-
-end is_alt
-
-end sesq_form

--- a/src/linear_algebra/sesquilinear_form.lean
+++ b/src/linear_algebra/sesquilinear_form.lean
@@ -79,14 +79,11 @@ begin
   dunfold is_ortho,
   split; intro H,
   { rw [map_smulₛₗ, H, smul_zero] },
-  {
-    rw [map_smulₛₗ, smul_eq_zero] at H,
+  { rw [map_smulₛₗ, smul_eq_zero] at H,
     cases H,
-    {
-      rw [ring_equiv.to_ring_hom_eq_coe, ring_equiv.coe_to_ring_hom] at H,
+    { rw [ring_equiv.to_ring_hom_eq_coe, ring_equiv.coe_to_ring_hom] at H,
       exfalso,
-      exact ha (I.map_eq_zero_iff.mp H),
-    },
+      exact ha (I.map_eq_zero_iff.mp H) },
     { exact H }}
 end
 

--- a/src/linear_algebra/sesquilinear_form.lean
+++ b/src/linear_algebra/sesquilinear_form.lean
@@ -38,7 +38,7 @@ namespace linear_map
 section comm_ring
 
 -- the `ₗ` subscript variables are for special cases about linear (as opposed to semilinear) maps
-variables {R : Type*} {M : Type*} [comm_semiring R] [star_ring R] [add_comm_monoid M] [module R M]
+variables {R : Type*} {M : Type*} [comm_semiring R] [add_comm_monoid M] [module R M]
   {I : R →+* R}
 
 /-- The proposition that two elements of a sesquilinear form space are orthogonal -/
@@ -57,7 +57,7 @@ lemma is_ortho_zero_right (B : M →ₗ[R] M →ₛₗ[I] R) (x) : is_ortho B x 
 end comm_ring
 section is_domain
 
-variables {R : Type*} {M : Type*} [comm_ring R] [star_ring R] [is_domain R] [add_comm_group M]
+variables {R : Type*} {M : Type*} [comm_ring R] [is_domain R] [add_comm_group M]
   [module R M]
   {I : R ≃+* R}
   {B : M →ₗ[R] M →ₛₗ[I.to_ring_hom] R}
@@ -89,7 +89,7 @@ end
 
 end is_domain
 
-variables {R : Type*} {M : Type*} [comm_ring R] [star_ring R] [add_comm_group M] [module R M]
+variables {R : Type*} {M : Type*} [comm_ring R] [add_comm_group M] [module R M]
   {I : R →+* R}
   {B : M →ₗ[R] M →ₛₗ[I] R}
 


### PR DESCRIPTION
Define sesquilinear forms as `M →ₗ[R] M →ₛₗ[I] R`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
