### PR TITLE
[Merged by Bors] - chore(topology): add 2 missing `inhabited` instances

### DIFF
--- a/src/topology/algebra/ring.lean
+++ b/src/topology/algebra/ring.lean
@@ -39,6 +39,10 @@ If `R` is a ring, then negation is automatically continuous, as it is multiplica
 class topological_ring [topological_space α] [semiring α]
   extends has_continuous_add α, has_continuous_mul α : Prop
 
+@[priority 50]
+instance discrete_topology.topological_ring {α} [topological_space α] [semiring α]
+  [discrete_topology α] : topological_ring α := ⟨⟩
+
 section
 variables {α} [topological_space α] [semiring α] [topological_ring α]
 

--- a/src/topology/category/Top/open_nhds.lean
+++ b/src/topology/category/Top/open_nhds.lean
@@ -60,6 +60,8 @@ instance (x : X) : order_top (open_nhds x) :=
 { top := ⟨⊤, trivial⟩,
   le_top := λ _, le_top }
 
+instance (x : X) : inhabited (open_nhds x) := ⟨⊤⟩
+
 instance open_nhds_category (x : X) : category.{u} (open_nhds x) :=
 by {unfold open_nhds, apply_instance}
 

--- a/src/topology/category/TopCommRing.lean
+++ b/src/topology/category/TopCommRing.lean
@@ -27,6 +27,8 @@ structure TopCommRing :=
 
 namespace TopCommRing
 
+instance : inhabited TopCommRing := ⟨⟨punit⟩⟩
+
 instance : has_coe_to_sort TopCommRing (Type u) := ⟨TopCommRing.α⟩
 
 attribute [instance] is_comm_ring is_topological_space is_topological_ring


### PR DESCRIPTION
Also add an instance from `discrete_topology` to `topological_ring`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
