### PR TITLE
[Merged by Bors] - refactor(topology,algebraic_geometry): use bundled maps here and there

### DIFF
--- a/src/algebraic_geometry/Spec.lean
+++ b/src/algebraic_geometry/Spec.lean
@@ -50,23 +50,17 @@ def Spec.Top_obj (R : CommRing) : Top := Top.of (prime_spectrum R)
 /--
 The induced map of a ring homomorphism on the ring spectra, as a morphism of topological spaces.
 -/
-@[simps] def Spec.Top_map {R S : CommRing} (f : R ⟶ S) :
+def Spec.Top_map {R S : CommRing} (f : R ⟶ S) :
   Spec.Top_obj S ⟶ Spec.Top_obj R :=
-{ to_fun := prime_spectrum.comap f,
-  continuous_to_fun := prime_spectrum.comap_continuous f }
+prime_spectrum.comap f
 
 @[simp] lemma Spec.Top_map_id (R : CommRing) :
   Spec.Top_map (𝟙 R) = 𝟙 (Spec.Top_obj R) :=
-continuous_map.ext $ λ x,
-by erw [Spec.Top_map_to_fun, prime_spectrum.comap_id, id.def, Top.id_app]
+prime_spectrum.comap_id
 
 lemma Spec.Top_map_comp {R S T : CommRing} (f : R ⟶ S) (g : S ⟶ T) :
   Spec.Top_map (f ≫ g) = Spec.Top_map g ≫ Spec.Top_map f :=
-continuous_map.ext $ λ x,
-begin
-  dsimp only [Spec.Top_map_to_fun, Top.comp_app],
-  erw prime_spectrum.comap_comp,
-end
+prime_spectrum.comap_comp _ _
 
 /--
 The spectrum, as a contravariant functor from commutative rings to topological spaces.

--- a/src/algebraic_geometry/prime_spectrum/is_open_comap_C.lean
+++ b/src/algebraic_geometry/prime_spectrum/is_open_comap_C.lean
@@ -39,13 +39,13 @@ end
 This lemma is a reformulation of `exists_coeff_not_mem_C_inverse`. -/
 lemma comap_C_mem_image_of_Df {I : prime_spectrum (polynomial R)}
   (H : I ∈ (zero_locus {f} : set (prime_spectrum (polynomial R)))ᶜ ) :
-  comap (polynomial.C : R →+* polynomial R) I ∈ image_of_Df f :=
+  prime_spectrum.comap (polynomial.C : R →+* polynomial R) I ∈ image_of_Df f :=
 exists_coeff_not_mem_C_inverse (mem_compl_zero_locus_iff_not_mem.mp H)
 
 /-- The open set `image_of_Df f` coincides with the image of `basic_open f` under the
 morphism `C⁺ : Spec R[x] → Spec R`. -/
 lemma image_of_Df_eq_comap_C_compl_zero_locus :
-  image_of_Df f = comap C '' (zero_locus {f})ᶜ :=
+  image_of_Df f = prime_spectrum.comap (C : R →+* polynomial R) '' (zero_locus {f})ᶜ :=
 begin
   refine ext (λ x, ⟨λ hx, ⟨⟨map C x.val, (is_prime_map_C_of_is_prime x.property)⟩, ⟨_, _⟩⟩, _⟩),
   { rw [mem_compl_eq, mem_zero_locus, singleton_subset_iff],
@@ -64,7 +64,7 @@ Stacks Project "Lemma 00FB", first part.
 https://stacks.math.columbia.edu/tag/00FB
 -/
 theorem is_open_map_comap_C :
-  is_open_map (comap (C : R →+* polynomial R)) :=
+  is_open_map (prime_spectrum.comap (C : R →+* polynomial R)) :=
 begin
   rintros U ⟨s, z⟩,
   rw [← compl_compl U, ← z, ← Union_of_singleton_coe s, zero_locus_Union, compl_Inter, image_Union],

--- a/src/algebraic_geometry/structure_sheaf.lean
+++ b/src/algebraic_geometry/structure_sheaf.lean
@@ -856,7 +856,7 @@ begin
   rcases hs ⟨prime_spectrum.comap f p, hUV hpV⟩ with ⟨W, m, iWU, a, b, h_frac⟩,
   -- We claim that we can write our new section as the fraction `f a / f b` on the neighborhood
   -- `(comap f) ⁻¹ W ⊓ V` of `p`.
-  refine ⟨opens.comap (comap_continuous f) W ⊓ V, ⟨m, hpV⟩, opens.inf_le_right _ _, f a, f b, _⟩,
+  refine ⟨opens.comap (comap f) W ⊓ V, ⟨m, hpV⟩, opens.inf_le_right _ _, f a, f b, _⟩,
   rintro ⟨q, ⟨hqW, hqV⟩⟩,
   specialize h_frac ⟨prime_spectrum.comap f q, hqW⟩,
   refine ⟨h_frac.1, _⟩,
@@ -971,7 +971,7 @@ end
 
 @[elementwise, reassoc] lemma to_open_comp_comap (f : R →+* S)
   (U : opens (prime_spectrum.Top R)) :
-  to_open R U ≫ comap f U (opens.comap (comap_continuous f) U) (λ _, id) =
+  to_open R U ≫ comap f U (opens.comap (prime_spectrum.comap f) U) (λ _, id) =
   CommRing.of_hom f ≫ to_open S _ :=
 ring_hom.ext $ λ s, subtype.eq $ funext $ λ p,
 begin

--- a/src/measure_theory/measure/content.lean
+++ b/src/measure_theory/measure/content.lean
@@ -179,7 +179,7 @@ by { have := μ.inner_content_Sup_nat (λ i, ⟨U i, hU i⟩), rwa [opens.supr_d
 
 lemma inner_content_comap (f : G ≃ₜ G)
   (h : ∀ ⦃K : compacts G⦄, μ (K.map f f.continuous) = μ K) (U : opens G) :
-  μ.inner_content (U.comap f.continuous) = μ.inner_content U :=
+  μ.inner_content (opens.comap f.to_continuous_map U) = μ.inner_content U :=
 begin
   refine supr_congr _ ((compacts.equiv f).surjective) _,
   intro K, refine supr_congr_Prop image_subset_iff _,
@@ -190,7 +190,8 @@ end
 @[to_additive]
 lemma is_mul_left_invariant_inner_content [group G] [topological_group G]
   (h : ∀ (g : G) {K : compacts G}, μ (K.map _ $ continuous_mul_left g) = μ K) (g : G)
-  (U : opens G) : μ.inner_content (U.comap $ continuous_mul_left g) = μ.inner_content U :=
+  (U : opens G) :
+  μ.inner_content (opens.comap (homeomorph.mul_left g).to_continuous_map U) = μ.inner_content U :=
 by convert μ.inner_content_comap (homeomorph.mul_left g) (λ K, h g) U
 
 @[to_additive]
@@ -203,7 +204,7 @@ begin
   rcases compact_covered_by_mul_left_translates K.2 this with ⟨s, hs⟩,
   suffices : μ K ≤ s.card * μ.inner_content U,
   { exact (ennreal.mul_pos_iff.mp $ hK.bot_lt.trans_le this).2 },
-  have : K.1 ⊆ ↑⨆ (g ∈ s), U.comap $ continuous_mul_left g,
+  have : K.1 ⊆ ↑⨆ (g ∈ s), opens.comap (homeomorph.mul_left g).to_continuous_map U,
   { simpa only [opens.supr_def, opens.coe_comap, subtype.coe_mk] },
   refine (μ.le_inner_content _ _ this).trans _,
   refine (rel_supr_sum (μ.inner_content) (μ.inner_content_empty) (≤)

--- a/src/topology/opens.lean
+++ b/src/topology/opens.lean
@@ -5,6 +5,7 @@ Authors: Johannes Hölzl, Mario Carneiro, Floris van Doorn
 -/
 import topology.bases
 import topology.homeomorph
+import topology.continuous_function.basic
 /-!
 # Open sets
 
@@ -16,7 +17,6 @@ We define the subtype of open sets in a topological space.
 
 - `opens α` is the type of open subsets of a topological space `α`.
 - `open_nhds_of x` is the type of open subsets of a topological space `α` containing `x : α`.
--
 -/
 
 open filter set
@@ -172,33 +172,39 @@ begin
 end
 
 /-- The preimage of an open set, as an open set. -/
-def comap {f : α → β} (hf : continuous f) (V : opens β) : opens α :=
-⟨f ⁻¹' V.1, V.2.preimage hf⟩
+def comap (f : C(α, β)) : opens β →ₘ opens α :=
+{ to_fun := λ V, ⟨f ⁻¹' V, V.2.preimage f.continuous⟩,
+  monotone' := λ V₁ V₂ hle, monotone_preimage hle }
 
-@[simp] lemma comap_id (U : opens α) : U.comap continuous_id = U := by { ext, refl }
+@[simp] lemma comap_id : comap (continuous_map.id : C(α, α)) = preorder_hom.id :=
+by { ext, refl }
 
-lemma comap_mono {f : α → β} (hf : continuous f) {V W : opens β} (hVW : V ⊆ W) :
-  V.comap hf ⊆ W.comap hf :=
-λ _ h, hVW h
+lemma comap_mono (f : C(α, β)) {V W : opens β} (hVW : V ⊆ W) :
+  comap f V ⊆ comap f W :=
+(comap f).monotone hVW
 
-@[simp] lemma coe_comap {f : α → β} (hf : continuous f) (U : opens β) :
-  ↑(U.comap hf) = f ⁻¹' U := rfl
+@[simp] lemma coe_comap (f : C(α, β)) (U : opens β) : ↑(comap f U) = f ⁻¹' U := rfl
 
-@[simp] lemma comap_val {f : α → β} (hf : continuous f) (U : opens β) :
-  (U.comap hf).1 = f ⁻¹' U := rfl
+@[simp] lemma comap_val (f : C(α, β)) (U : opens β) : (comap f U).1 = f ⁻¹' U := rfl
 
-protected lemma comap_comp {g : β → γ} {f : α → β} (hg : continuous g) (hf : continuous f)
-  (U : opens γ) : U.comap (hg.comp hf) = (U.comap hg).comap hf :=
-by { ext1, simp only [coe_comap, preimage_preimage] }
+protected lemma comap_comp (g : C(β, γ)) (f : C(α, β)) :
+  comap (g.comp f) = (comap f).comp (comap g) :=
+rfl
+
+protected lemma comap_comap (g : C(β, γ)) (f : C(α, β)) (U : opens γ) :
+  comap f (comap g U) = comap (g.comp f) U := rfl
 
 /-- A homeomorphism induces an equivalence on open sets, by taking comaps. -/
 @[simp] protected def equiv (f : α ≃ₜ β) : opens α ≃ opens β :=
-{ to_fun := opens.comap f.symm.continuous,
-  inv_fun := opens.comap f.continuous,
-  left_inv := by { intro U, ext1,
-    simp only [coe_comap, ← preimage_comp, f.symm_comp_self, preimage_id] },
-  right_inv := by { intro U, ext1,
-    simp only [coe_comap, ← preimage_comp, f.self_comp_symm, preimage_id] } }
+{ to_fun := opens.comap f.symm.to_continuous_map,
+  inv_fun := opens.comap f.to_continuous_map,
+  left_inv := by { intro U, ext1, exact f.to_equiv.preimage_symm_preimage _ },
+  right_inv := by { intro U, ext1, exact f.to_equiv.symm_preimage_preimage _ } }
+
+/-- A homeomorphism induces an order isomorphism on open sets, by taking comaps. -/
+@[simp] protected def order_iso (f : α ≃ₜ β) : opens α ≃o opens β :=
+{ to_equiv := opens.equiv f,
+  map_rel_iff' := λ U V, f.symm.surjective.preimage_subset_preimage_iff }
 
 end opens
 


### PR DESCRIPTION
* `opens.comap` now takes a `continuous_map` and returns a `preorder_hom`;
* `prime_spectrum.comap` is now a bundled `continuous_map`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
