### PR TITLE
[Merged by Bors] - feat(group_theory/submonoid/pointwise): pointwise inverse of a submonoid

### DIFF
--- a/src/algebra/pointwise.lean
+++ b/src/algebra/pointwise.lean
@@ -401,6 +401,14 @@ lemma inter_inv [has_inv α] : (s ∩ t)⁻¹ = s⁻¹ ∩ t⁻¹ := preimage_in
 lemma union_inv [has_inv α] : (s ∪ t)⁻¹ = s⁻¹ ∪ t⁻¹ := preimage_union
 
 @[simp, to_additive]
+lemma Inter_inv {ι : Sort*} [has_inv α] (s : ι → set α) : (⋂ i, s i)⁻¹ = ⋂ i, (s i)⁻¹ :=
+preimage_Inter
+
+@[simp, to_additive]
+lemma Union_inv {ι : Sort*} [has_inv α] (s : ι → set α) : (⋃ i, s i)⁻¹ = ⋃ i, (s i)⁻¹ :=
+preimage_Union
+
+@[simp, to_additive]
 lemma compl_inv [has_inv α] : (sᶜ)⁻¹ = (s⁻¹)ᶜ := preimage_compl
 
 @[simp, to_additive]
@@ -424,8 +432,8 @@ hs.preimage $ inv_injective.inj_on _
 by { ext1 y, rw [mem_inv, mem_singleton_iff, mem_singleton_iff, inv_eq_iff_inv_eq, eq_comm], }
 
 @[to_additive] lemma mul_inv_rev [group α] (s t : set α) : (s * t)⁻¹ = t⁻¹ * s⁻¹ :=
-by simp only [←image_inv, ←image2_mul, image_image2, image2_image_left, image2_image_right,
-              mul_inv_rev, image2_swap]
+by simp_rw [←image_inv, ←image2_mul, image_image2, image2_image_left, image2_image_right,
+              mul_inv_rev, image2_swap _ s t]
 
 /-! ### Properties about scalar multiplication -/
 

--- a/src/algebra/pointwise.lean
+++ b/src/algebra/pointwise.lean
@@ -423,6 +423,10 @@ hs.preimage $ inv_injective.inj_on _
 @[to_additive] lemma inv_singleton {β : Type*} [group β] (x : β) : ({x} : set β)⁻¹ = {x⁻¹} :=
 by { ext1 y, rw [mem_inv, mem_singleton_iff, mem_singleton_iff, inv_eq_iff_inv_eq, eq_comm], }
 
+@[to_additive] lemma mul_inv_rev [group α] (s t : set α) : (s * t)⁻¹ = t⁻¹ * s⁻¹ :=
+by simp only [←image_inv, ←image2_mul, image_image2, image2_image_left, image2_image_right,
+              mul_inv_rev, image2_swap]
+
 /-! ### Properties about scalar multiplication -/
 
 /-- The scaling of a set `(x • s : set β)` by a scalar `x ∶ α` is defined as `{x • y | y ∈ s}`

--- a/src/algebra/pointwise.lean
+++ b/src/algebra/pointwise.lean
@@ -431,7 +431,7 @@ hs.preimage $ inv_injective.inj_on _
 @[to_additive] lemma inv_singleton {β : Type*} [group β] (x : β) : ({x} : set β)⁻¹ = {x⁻¹} :=
 by { ext1 y, rw [mem_inv, mem_singleton_iff, mem_singleton_iff, inv_eq_iff_inv_eq, eq_comm], }
 
-@[to_additive] lemma mul_inv_rev [group α] (s t : set α) : (s * t)⁻¹ = t⁻¹ * s⁻¹ :=
+@[to_additive] protected lemma mul_inv_rev [group α] (s t : set α) : (s * t)⁻¹ = t⁻¹ * s⁻¹ :=
 by simp_rw [←image_inv, ←image2_mul, image_image2, image2_image_left, image2_image_right,
               mul_inv_rev, image2_swap _ s t]
 

--- a/src/group_theory/submonoid/pointwise.lean
+++ b/src/group_theory/submonoid/pointwise.lean
@@ -60,7 +60,7 @@ set_like.coe_injective set.inv_inv
 @[simp, to_additive] lemma inv_le_inv (S T : submonoid G) : S⁻¹ ≤ T⁻¹ ↔ S ≤ T :=
 set_like.coe_subset_coe.symm.trans set.inv_subset_inv
 
-@[simp, to_additive] lemma inv_le (S T : submonoid G) : S⁻¹ ≤ T ↔ S ≤ T⁻¹ :=
+@[to_additive] lemma inv_le (S T : submonoid G) : S⁻¹ ≤ T ↔ S ≤ T⁻¹ :=
 set_like.coe_subset_coe.symm.trans set.inv_subset
 
 /-- `submonoid.has_inv` as an order isomorphism. -/

--- a/src/group_theory/submonoid/pointwise.lean
+++ b/src/group_theory/submonoid/pointwise.lean
@@ -63,6 +63,15 @@ set_like.coe_subset_coe.symm.trans set.inv_subset_inv
 @[simp, to_additive] lemma inv_le (S T : submonoid G) : S⁻¹ ≤ T ↔ S ≤ T⁻¹ :=
 set_like.coe_subset_coe.symm.trans set.inv_subset
 
+/-- `submonoid.has_inv` as an order isomorphism. -/
+@[to_additive /-" `add_submonoid.has_neg` as an order isomorphism "-/, simps]
+def inv_order_iso : submonoid G ≃o submonoid G :=
+{ to_fun := has_inv.inv,
+  inv_fun := has_inv.inv,
+  left_inv := inv_inv,
+  right_inv := inv_inv,
+  map_rel_iff' := inv_le_inv }
+
 @[to_additive] lemma closure_inv (s : set G) : closure s⁻¹ = (closure s)⁻¹ :=
 begin
   apply le_antisymm,
@@ -78,8 +87,7 @@ set_like.coe_injective set.inter_inv
 
 @[simp, to_additive]
 lemma inv_sup (S T : submonoid G) : (S ⊔ T)⁻¹ = S⁻¹ ⊔ T⁻¹ :=
-by rw [sup_comm, submonoid.sup_eq_closure, submonoid.sup_eq_closure, ←closure_inv, set.mul_inv_rev,
-       coe_inv, coe_inv]
+(inv_order_iso : submonoid G ≃o submonoid G).map_sup S T
 
 @[simp, to_additive]
 lemma inv_bot : (⊥ : submonoid G)⁻¹ = ⊥ :=
@@ -91,10 +99,11 @@ set_like.coe_injective $ set.inv_univ
 
 @[simp, to_additive]
 lemma inv_infi {ι : Sort*} (S : ι → submonoid G) : (⨅ i, S i)⁻¹ = ⨅ i, (S i)⁻¹ :=
-set_like.coe_injective $ begin
-  rw [coe_inv, coe_infi, coe_infi],
-  exact (set.Inter_inv $ λ i, (S i : set G)),
-end
+(inv_order_iso : submonoid G ≃o submonoid G).map_infi _
+
+@[simp, to_additive]
+lemma inv_supr {ι : Sort*} (S : ι → submonoid G) : (⨆ i, S i)⁻¹ = ⨆ i, (S i)⁻¹ :=
+(inv_order_iso : submonoid G ≃o submonoid G).map_supr _
 
 end submonoid
 

--- a/src/group_theory/submonoid/pointwise.lean
+++ b/src/group_theory/submonoid/pointwise.lean
@@ -44,8 +44,8 @@ protected def has_inv : has_inv (submonoid G):=
 { inv := λ S,
   { carrier := (S : set G)⁻¹,
     one_mem' := show (1 : G)⁻¹ ∈ S, by { rw one_inv, exact S.one_mem },
-    mul_mem' := λ a b (ha : a⁻¹ ∈ S) (hb : b⁻¹ ∈ S), show (a * b)⁻¹ ∈ S, by {
-      rw mul_inv_rev, exact S.mul_mem hb ha } } }
+    mul_mem' := λ a b (ha : a⁻¹ ∈ S) (hb : b⁻¹ ∈ S), show (a * b)⁻¹ ∈ S,
+      by { rw mul_inv_rev, exact S.mul_mem hb ha } } }
 
 localized "attribute [instance] submonoid.has_inv" in pointwise
 open_locale pointwise
@@ -88,6 +88,13 @@ set_like.coe_injective $ (set.inv_singleton 1).trans $ congr_arg _ one_inv
 @[simp, to_additive]
 lemma inv_top : (⊤ : submonoid G)⁻¹ = ⊤ :=
 set_like.coe_injective $ set.inv_univ
+
+@[simp, to_additive]
+lemma inv_infi {ι : Sort*} (S : ι → submonoid G) : (⨅ i, S i)⁻¹ = ⨅ i, (S i)⁻¹ :=
+set_like.coe_injective $ begin
+  rw [coe_inv, coe_infi, coe_infi],
+  exact (set.Inter_inv $ λ i, (S i : set G)),
+end
 
 end submonoid
 

--- a/src/group_theory/submonoid/pointwise.lean
+++ b/src/group_theory/submonoid/pointwise.lean
@@ -13,7 +13,7 @@ This file provides:
 * `submonoid.has_inv`
 * `add_submonoid.has_neg`
 
-and the the actions
+and the actions
 
 * `submonoid.pointwise_mul_action`
 * `add_submonoid.pointwise_mul_action`

--- a/src/group_theory/submonoid/pointwise.lean
+++ b/src/group_theory/submonoid/pointwise.lean
@@ -8,14 +8,19 @@ import algebra.pointwise
 
 /-! # Pointwise instances on `submonoid`s and `add_submonoid`s
 
-This file provides the actions
+This file provides:
+
+* `submonoid.has_inv`
+* `add_submonoid.has_neg`
+
+and the the actions
 
 * `submonoid.pointwise_mul_action`
 * `add_submonoid.pointwise_mul_action`
 
 which matches the action of `mul_action_set`.
 
-These actions are available in the `pointwise` locale.
+These are all available in the `pointwise` locale.
 
 ## Implementation notes
 
@@ -26,7 +31,65 @@ on `set`s.
 
 -/
 
-variables {α : Type*} {M : Type*} {A : Type*} [monoid M] [add_monoid A]
+variables {α : Type*} {M : Type*} {G : Type*} {A : Type*} [monoid M] [add_monoid A]
+
+namespace submonoid
+
+variables [group G]
+
+open_locale pointwise
+
+@[to_additive]
+protected def has_inv : has_inv (submonoid G):=
+{ inv := λ S,
+  { carrier := (S : set G)⁻¹,
+    one_mem' := show (1 : G)⁻¹ ∈ S, by { rw one_inv, exact S.one_mem },
+    mul_mem' := λ a b (ha : a⁻¹ ∈ S) (hb : b⁻¹ ∈ S), show (a * b)⁻¹ ∈ S, by {
+      rw mul_inv_rev, exact S.mul_mem hb ha } } }
+
+localized "attribute [instance] submonoid.has_inv" in pointwise
+open_locale pointwise
+
+@[simp, to_additive] lemma coe_inv (S : submonoid G) : ↑(S⁻¹) = (S : set G)⁻¹ := rfl
+
+@[simp, to_additive] lemma mem_inv {g : G} {S : submonoid G} : g ∈ S⁻¹ ↔ g⁻¹ ∈ S := iff.rfl
+
+@[simp, to_additive] lemma inv_inv (S : submonoid G) : S⁻¹⁻¹ = S :=
+set_like.coe_injective set.inv_inv
+
+@[simp, to_additive] lemma inv_le_inv (S T : submonoid G) : S⁻¹ ≤ T⁻¹ ↔ S ≤ T :=
+set_like.coe_subset_coe.symm.trans set.inv_subset_inv
+
+@[simp, to_additive] lemma inv_le (S T : submonoid G) : S⁻¹ ≤ T ↔ S ≤ T⁻¹ :=
+set_like.coe_subset_coe.symm.trans set.inv_subset
+
+@[to_additive] lemma closure_inv (s : set G) : closure s⁻¹ = (closure s)⁻¹ :=
+begin
+  apply le_antisymm,
+  { rw [closure_le, coe_inv, ←set.inv_subset, set.inv_inv],
+    exact subset_closure },
+  { rw [inv_le, closure_le, coe_inv, ←set.inv_subset],
+    exact subset_closure }
+end
+
+@[simp, to_additive]
+lemma inv_inf (S T : submonoid G) : (S ⊓ T)⁻¹ = S⁻¹ ⊓ T⁻¹ :=
+set_like.coe_injective set.inter_inv
+
+@[simp, to_additive]
+lemma inv_sup (S T : submonoid G) : (S ⊔ T)⁻¹ = S⁻¹ ⊔ T⁻¹ :=
+by rw [sup_comm, submonoid.sup_eq_closure, submonoid.sup_eq_closure, ←closure_inv, set.mul_inv_rev,
+       coe_inv, coe_inv]
+
+@[simp, to_additive]
+lemma inv_bot : (⊥ : submonoid G)⁻¹ = ⊥ :=
+set_like.coe_injective $ (set.inv_singleton 1).trans $ congr_arg _ one_inv
+
+@[simp, to_additive]
+lemma inv_top : (⊤ : submonoid G)⁻¹ = ⊤ :=
+set_like.coe_injective $ set.inv_univ
+
+end submonoid
 
 namespace submonoid
 

--- a/src/group_theory/submonoid/pointwise.lean
+++ b/src/group_theory/submonoid/pointwise.lean
@@ -193,19 +193,7 @@ open_locale pointwise
 @[to_additive]
 lemma mem_closure_inv {G : Type*} [group G] (S : set G) (x : G) :
   x ∈ submonoid.closure S⁻¹ ↔ x⁻¹ ∈ submonoid.closure S :=
-begin
-  suffices : ∀ (S : set G) (x : G), x ∈ submonoid.closure S⁻¹ → x⁻¹ ∈ submonoid.closure S,
-  { refine ⟨this S x, _⟩,
-    have := this S⁻¹ x⁻¹,
-    rwa [inv_inv, set.inv_inv] at this },
-  intros S x hx,
-  refine submonoid.closure_induction hx (λ x hx, _) _ (λ x y hx hy, _),
-  { exact submonoid.subset_closure (set.mem_inv.mp hx), },
-  { rw one_inv,
-    exact submonoid.one_mem _ },
-  { rw mul_inv_rev x y,
-    exact submonoid.mul_mem _ hy hx },
-end
+by rw [closure_inv, mem_inv]
 
 end submonoid
 

--- a/src/group_theory/submonoid/pointwise.lean
+++ b/src/group_theory/submonoid/pointwise.lean
@@ -54,7 +54,7 @@ open_locale pointwise
 
 @[simp, to_additive] lemma mem_inv {g : G} {S : submonoid G} : g ∈ S⁻¹ ↔ g⁻¹ ∈ S := iff.rfl
 
-@[simp, to_additive] lemma inv_inv (S : submonoid G) : S⁻¹⁻¹ = S :=
+@[simp, to_additive] protected lemma inv_inv (S : submonoid G) : S⁻¹⁻¹ = S :=
 set_like.coe_injective set.inv_inv
 
 @[simp, to_additive] lemma inv_le_inv (S T : submonoid G) : S⁻¹ ≤ T⁻¹ ↔ S ≤ T :=
@@ -68,8 +68,8 @@ set_like.coe_subset_coe.symm.trans set.inv_subset
 def inv_order_iso : submonoid G ≃o submonoid G :=
 { to_fun := has_inv.inv,
   inv_fun := has_inv.inv,
-  left_inv := inv_inv,
-  right_inv := inv_inv,
+  left_inv := submonoid.inv_inv,
+  right_inv := submonoid.inv_inv,
   map_rel_iff' := inv_le_inv }
 
 @[to_additive] lemma closure_inv (s : set G) : closure s⁻¹ = (closure s)⁻¹ :=

--- a/src/group_theory/submonoid/pointwise.lean
+++ b/src/group_theory/submonoid/pointwise.lean
@@ -39,7 +39,8 @@ variables [group G]
 
 open_locale pointwise
 
-@[to_additive]
+/-- The submonoid with every element inverted. -/
+@[to_additive /-" The additive submonoid with every element negated. "-/]
 protected def has_inv : has_inv (submonoid G):=
 { inv := λ S,
   { carrier := (S : set G)⁻¹,

--- a/src/order/complete_lattice.lean
+++ b/src/order/complete_lattice.lean
@@ -516,6 +516,19 @@ lemma monotone.le_map_Sup [complete_lattice β] {s : set α} {f : α → β} (hf
   (⨆a∈s, f a) ≤ f (Sup s) :=
 by rw [Sup_eq_supr]; exact hf.le_map_supr2 _
 
+lemma order_iso.map_supr [complete_lattice β] (f : α ≃o β) (x : ι → α) :
+  f (⨆ i, x i) = ⨆ i, f (x i) :=
+begin
+  refine le_antisymm _ f.monotone.le_map_supr,
+  rw ←order_iso.le_symm_apply,
+  refine le_trans _ f.symm.monotone.le_map_supr,
+  simp_rw f.symm_apply_apply,
+end
+
+lemma order_iso.map_Sup [complete_lattice β] (f : α ≃o β) (s : set α) :
+  f (Sup s) = ⨆ a ∈ s, f a :=
+by simp only [Sup_eq_supr, order_iso.map_supr]
+
 lemma supr_comp_le {ι' : Sort*} (f : ι' → α) (g : ι → ι') :
   (⨆ x, f (g x)) ≤ ⨆ y, f y :=
 supr_le_supr2 $ λ x, ⟨_, le_refl _⟩
@@ -604,6 +617,14 @@ lemma monotone.map_infi2_le [complete_lattice β] {f : α → β} (hf : monotone
 lemma monotone.map_Inf_le [complete_lattice β] {s : set α} {f : α → β} (hf : monotone f) :
   f (Inf s) ≤ ⨅ a∈s, f a :=
 by rw [Inf_eq_infi]; exact hf.map_infi2_le _
+
+lemma order_iso.map_infi [complete_lattice β] (f : α ≃o β) (x : ι → α) :
+  f (⨅ i, x i) = ⨅ i, f (x i) :=
+order_iso.map_supr f.dual _
+
+lemma order_iso.map_Inf [complete_lattice β] (f : α ≃o β) (s : set α) :
+  f (Inf s) = ⨅ a ∈ s, f a :=
+order_iso.map_Sup f.dual _
 
 lemma le_infi_comp {ι' : Sort*} (f : ι' → α) (g : ι → ι') :
   (⨅ y, f y) ≤ ⨅ x, f (g x) :=

--- a/src/order/complete_lattice.lean
+++ b/src/order/complete_lattice.lean
@@ -518,12 +518,8 @@ by rw [Sup_eq_supr]; exact hf.le_map_supr2 _
 
 lemma order_iso.map_supr [complete_lattice β] (f : α ≃o β) (x : ι → α) :
   f (⨆ i, x i) = ⨆ i, f (x i) :=
-begin
-  refine le_antisymm _ f.monotone.le_map_supr,
-  rw ←order_iso.le_symm_apply,
-  refine le_trans _ f.symm.monotone.le_map_supr,
-  simp_rw f.symm_apply_apply,
-end
+eq_of_forall_ge_iff $ f.surjective.forall.2 $ λ x,
+  by simp only [f.le_iff_le, supr_le_iff]
 
 lemma order_iso.map_Sup [complete_lattice β] (f : α ≃o β) (s : set α) :
   f (Sup s) = ⨆ a ∈ s, f a :=


### PR DESCRIPTION
This also adds `order_iso.map_{supr,infi,Sup,Inf}` which are used here to provide some short proofs.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
