### PR TITLE
[Merged by Bors] - doc(algebra.lattice_ordered_group): Remove verbose docstrings

### DIFF
--- a/src/algebra/lattice_ordered_group.lean
+++ b/src/algebra/lattice_ordered_group.lean
@@ -68,10 +68,7 @@ instance linear_ordered_comm_group.to_covariant_class (α : Type u)
 variables {α : Type u} [lattice α] [comm_group α]
 
 -- Special case of Bourbaki A.VI.9 (1)
-/--
-Let `α` be a lattice ordered commutative group. For all elements `a`, `b` and `c` in `α`,
-$$c + (a ⊔ b) = (c + a) ⊔ (c + b).$$
--/
+-- c + (a ⊔ b) = (c + a) ⊔ (c + b)
 @[to_additive]
 lemma mul_sup_eq_mul_sup_mul [covariant_class α α (*) (≤)]
   (a b c : α) : c * (a ⊔ b) = (c * a) ⊔ (c * b) :=
@@ -84,10 +81,7 @@ begin
 end
 
 -- Special case of Bourbaki A.VI.9 (2)
-/--
-Let `α` be a lattice ordered commutative group. For all elements `a` and `b` in `α`,
-$$-(a ⊔ b)=(-a) ⊓ (-b).$$
--/
+-- -(a ⊔ b)=(-a) ⊓ (-b)
 @[to_additive]
 lemma inv_sup_eq_inv_inf_inv [covariant_class α α (*) (≤)] (a b : α) : (a ⊔ b)⁻¹ = a⁻¹ ⊓ b⁻¹ :=
 begin
@@ -103,19 +97,13 @@ begin
     { rw ← inv_le_inv_iff, simp, } }
 end
 
-/--
-Let `α` be a lattice ordered commutative group. For all elements `a` and `b` in `α`,
-$$ -(a ⊓ b) = -a ⊔ -b.$$
--/
+-- -(a ⊓ b) = -a ⊔ -b
 @[to_additive]
 lemma inv_inf_eq_sup_inv [covariant_class α α (*) (≤)] (a b : α) : (a ⊓ b)⁻¹ = a⁻¹ ⊔ b⁻¹ :=
 by rw [← inv_inv (a⁻¹ ⊔ b⁻¹), inv_sup_eq_inv_inf_inv a⁻¹ b⁻¹, inv_inv, inv_inv]
 
 -- Bourbaki A.VI.10 Prop 7
-/--
-Let `α` be a lattice ordered commutative group. For all elements `a` and `b` in `α`,
-$$a ⊓ b + (a ⊔ b) = a + b.$$
--/
+-- a ⊓ b + (a ⊔ b) = a + b
 @[to_additive]
 lemma inf_mul_sup [covariant_class α α (*) (≤)] (a b : α) : a ⊓ b * (a ⊔ b) = a * b :=
 calc a⊓b * (a ⊔ b) = a ⊓ b * ((a * b) * (b⁻¹ ⊔ a⁻¹)) :
@@ -155,70 +143,39 @@ instance has_one_lattice_has_neg_part : has_neg_part (α)  := ⟨λa, a⁻¹ ⊔
 @[to_additive neg_part_def]
 lemma m_neg_part_def (a : α) : a⁻ = a⁻¹ ⊔ 1 := rfl
 
-/--
-Let `α` be a lattice ordered commutative group and let `a` be an element in `α` with absolute value
-`|a|`. Then,
-$$a ≤ |a|.$$
--/
 @[to_additive le_abs]
 lemma le_mabs (a : α) : a ≤ |a| := le_sup_left
 
-/--
-Let `α` be a lattice ordered commutative group and let `a` be an element in `α` with absolute value
-`|a|`. Then,
-$$-a ≤ |a|.$$
--/
 @[to_additive]
+-- -a ≤ |a|
 lemma inv_le_abs (a : α) : a⁻¹ ≤ |a| := le_sup_right
 
-/--
-Let `α` be a lattice ordered commutative group and let `a` be an element in `α` with positive
- component `a⁺`. Then `a⁺` is positive.
--/
+-- 0 ≤ a⁺
 @[to_additive pos_pos]
 lemma m_pos_pos (a : α) : 1 ≤ a⁺ := le_sup_right
 
-/--
-Let `α` be a lattice ordered commutative group and let `a` be an element in `α` withnegative
-component `a⁻`. Then `a⁻` is positive.
--/
+-- 0 ≤ a⁻
 @[to_additive neg_pos]
 lemma m_neg_pos (a : α) : 1 ≤ a⁻ := le_sup_right
 
-/--
-Let `α` be a lattice ordered commutative group and let `a` be an element in `α` with positive
-component `a⁺`. Then `a⁺` dominates `a`.
--/
 @[to_additive le_pos]
 lemma m_le_pos (a : α) : a ≤ a⁺ := le_sup_left
 
-/--
-Let `α` be a lattice ordered commutative group and let `a` be an element in `α` with negative
-component `a⁻`. Then `a⁻` dominates `-a`.
--/
+-- -a ≤ a⁻
 @[to_additive le_neg]
 lemma m_le_neg (a : α) : a⁻¹ ≤ a⁻ := le_sup_left
 
 -- Bourbaki A.VI.12
-/--
-Let `α` be a lattice ordered commutative group and let `a` be an element in `α`. Then the negative
-component `a⁻` of `a` is equal to the positive component `(-a)⁺` of `-a`.
-"-/
+--  a⁻ = (-a)⁺
 @[to_additive]
 lemma neg_eq_pos_inv (a : α) : a⁻ = (a⁻¹)⁺ := by rw [ m_neg_part_def, m_pos_part_def]
 
-/--
-Let `α` be a lattice ordered commutative group and let `a` be an element in `α`. Then the positive
-component `a⁺` of `a` is equal to the negative component `(-a)⁻` of `-a`.
--/
+-- a⁺ = (-a)⁻
 @[to_additive]
 lemma pos_eq_neg_inv (a : α) : a⁺ = (a⁻¹)⁻ := by simp [neg_eq_pos_inv]
 
 -- We use this in Bourbaki A.VI.12  Prop 9 a)
-/--
-Let `α` be a lattice ordered commutative group. For all elements `a`, `b` and `c` in `α`,
-$$c + (a ⊓ b) = (c + a) ⊓ (c + b).$$
--/
+-- c + (a ⊓ b) = (c + a) ⊓ (c + b)
 @[to_additive]
 lemma mul_inf_eq_mul_inf_mul [covariant_class α α (*) (≤)]
   (a b c : α) : c * (a ⊓ b) = (c * a) ⊓ (c * b) :=
@@ -230,21 +187,13 @@ begin
 end
 
 -- We use this in Bourbaki A.VI.12  Prop 9 a)
-/--
-Let `α` be a lattice ordered commutative group with identity `0` and let `a` be an element in `α`
-with negative component `a⁻`. Then
-$$a⁻ = -(a ⊓ 0).$$
--/
+-- a⁻ = -(a ⊓ 0)
 @[to_additive]
 lemma neg_eq_inv_inf_one [covariant_class α α (*) (≤)] (a : α) : a⁻ = (a ⊓ 1)⁻¹ :=
 by rw [m_neg_part_def, ← inv_inj, inv_sup_eq_inv_inf_inv, inv_inv, inv_inv, one_inv]
 
 -- Bourbaki A.VI.12  Prop 9 a)
-/--
-Let `α` be a lattice ordered commutative group and let `a` be an element in `α` with positive
-component `a⁺` and negative component `a⁻`. Then `a` can be decomposed as the difference of `a⁺` and
-`a⁻`.
--/
+-- a = a⁺ - a⁻
 @[to_additive]
 lemma pos_inv_neg [covariant_class α α (*) (≤)] (a : α) : a = a⁺ / a⁻ :=
 begin
@@ -258,22 +207,14 @@ end
 lemma pos_div_neg' [covariant_class α α (*) (≤)] (a : α) :  a⁺ / a⁻ = a := (pos_inv_neg _).symm
 
 -- Bourbaki A.VI.12  Prop 9 a)
-/--
-Let `α` be a lattice ordered commutative group and let `a` be an element in `α` with positive
-component `a⁺` and negative component `a⁻`. Then `a⁺` and `a⁻` are co-prime (and, since they are
-positive, disjoint).
--/
+-- a⁺ ⊓ a⁻ = 0 (`a⁺` and `a⁻` are co-prime, and, since they are positive, disjoint)
 @[to_additive]
 lemma pos_inf_neg_eq_one [covariant_class α α (*) (≤)] (a : α) : a⁺ ⊓ a⁻=1 :=
 by rw [←mul_right_inj (a⁻)⁻¹, mul_inf_eq_mul_inf_mul, mul_one, mul_left_inv, mul_comm,
   ←div_eq_mul_inv, pos_div_neg', neg_eq_inv_inf_one, inv_inv]
 
 -- Bourbaki A.VI.12 (with a and b swapped)
-/--
-Let `α` be a lattice ordered commutative group, let `a` and `b` be elements in `α`, and let
-`(a - b)⁺` be the positive componet of `a - b`. Then
-$$a⊔b = b + (a - b)⁺.$$
--/
+-- a⊔b = b + (a - b)⁺
 @[to_additive]
 lemma sup_eq_mul_pos_div [covariant_class α α (*) (≤)] (a b : α) : a ⊔ b = b * (a / b)⁺ :=
 calc  a ⊔ b = (b * (a / b)) ⊔ (b * 1) : by {rw [mul_one b, div_eq_mul_inv, mul_comm a,
@@ -281,11 +222,7 @@ calc  a ⊔ b = (b * (a / b)) ⊔ (b * 1) : by {rw [mul_one b, div_eq_mul_inv, m
 ... = b * ((a / b) ⊔ 1) : by { rw ← mul_sup_eq_mul_sup_mul (a / b) 1 b}
 
 -- Bourbaki A.VI.12 (with a and b swapped)
-/--
-Let `α` be a lattice ordered commutative group, let `a` and `b` be elements in `α`, and let
-`(a - b)⁺` be the positive componet of `a - b`. Then
-$$a⊓b = a - (a - b)⁺.$$
--/
+-- a⊓b = a - (a - b)⁺
 @[to_additive]
 lemma inf_eq_div_pos_div [covariant_class α α (*) (≤)] (a b : α) : a ⊓ b = a / (a / b)⁺ :=
 calc a ⊓ b = (a * 1) ⊓ (a * (b / a)) : by { rw [mul_one a, div_eq_mul_inv, mul_comm b,
@@ -298,11 +235,6 @@ calc a ⊓ b = (a * 1) ⊓ (a * (b / a)) : by { rw [mul_one a, div_eq_mul_inv, m
 ... = a / ((a / b) ⊔ 1)     : by rw [← inv_sup_eq_inv_inf_inv, ← div_eq_mul_inv]
 
 -- Bourbaki A.VI.12 Prop 9 c)
-/--
-Let `α` be a lattice ordered commutative group and let `a` and `b` be elements in `α` with positive
-components `a⁺` and `b⁺` and negative components `a⁻` and `b⁻` respectively. Then `b` dominates `a`
-if and only if `b⁺` dominates `a⁺` and `a⁻` dominates `b⁻`.
--/
 @[to_additive le_iff_pos_le_neg_ge]
 lemma m_le_iff_pos_le_neg_ge [covariant_class α α (*) (≤)] (a b : α) : a ≤ b ↔ a⁺ ≤ b⁺ ∧ b⁻ ≤ a⁻ :=
 begin
@@ -322,11 +254,7 @@ begin
 end
 
 -- The proof from Bourbaki A.VI.12 Prop 9 d)
-/--
-Let `α` be a lattice ordered commutative group and let `a` be an element in `α` with absolute value
-`|a|`, positive component `a⁺` and negative component `a⁻`. Then `|a|` decomposes as the sum of `a⁺`
-and `a⁻`.
--/
+-- |a| = a⁺ - a⁻
 @[to_additive]
 lemma pos_mul_neg [covariant_class α α (*) (≤)] (a : α) : |a| = a⁺ * a⁻ :=
 begin
@@ -370,11 +298,7 @@ begin
       (lattice_ordered_comm_group.inv_le_abs a)), }
 end
 
-/--
-Let `α` be a lattice ordered commutative group, let `a` and `b` be elements in `α` and let `|b - a|`
-be the absolute value of `b - a`. Then,
-$$a ⊔ b - (a ⊓ b) = |b - a|.$$
--/
+-- a ⊔ b - (a ⊓ b) = |b - a|
 @[to_additive]
 lemma sup_div_inf_eq_abs_div [covariant_class α α (*) (≤)] (a b : α) :
   (a ⊔ b) / (a ⊓ b) = |b / a| :=
@@ -386,22 +310,14 @@ begin
   rw [mul_inv_rev, ← div_eq_mul_inv, inv_inv, ← pos_mul_neg],
 end
 
-/--
-Let `α` be a lattice ordered commutative group, let `a` and `b` be elements in `α` and let `|b - a|`
-be the absolute value of `b - a`. Then,
-$$2•(a ⊔ b) = a + b + |b - a|.$$
--/
+-- 2•(a ⊔ b) = a + b + |b - a|
 @[to_additive]
 lemma sup_sq_eq_mul_mul_abs_div [covariant_class α α (*) (≤)] (a b : α) :
   (a ⊔ b)^2 = a * b * |b / a| :=
 by rw [← inf_mul_sup a b, ← sup_div_inf_eq_abs_div, div_eq_mul_inv, ← mul_assoc, mul_comm,
     mul_assoc, ← pow_two, inv_mul_cancel_left]
 
-/--
-Let `α` be a lattice ordered commutative group, let `a` and `b` be elements in `α` and let `|b-a|`
-be the absolute value of `b-a`. Then,
-$$2•(a ⊓ b) = a + b - |b - a|.$$
--/
+-- 2•(a ⊓ b) = a + b - |b - a|
 @[to_additive]
 lemma two_inf_eq_mul_div_abs_div [covariant_class α α (*) (≤)] (a b : α) :
   (a ⊓ b)^2 = a * b / |b / a| :=
@@ -435,12 +351,7 @@ def lattice_ordered_comm_group_to_distrib_lattice (α : Type u)
 
 -- See, e.g. Zaanen, Lectures on Riesz Spaces
 -- 3rd lecture
-/--
-Let `α` be a lattice ordered commutative group and let `a`, `b` and `c` be elements in `α`. Let
-`|a ⊔ c - (b ⊔ c)|`, `|a ⊓ c - b ⊓ c|` and `|a - b|` denote the absolute values of
-`a ⊔ c - (b ⊔ c)`, `a ⊓ c - b ⊓ c` and `a - b` respectively. Then,
-$$|a ⊔ c - (b ⊔ c)| + |a ⊓ c-b ⊓ c| = |a - b|.$$
--/
+-- |a ⊔ c - (b ⊔ c)| + |a ⊓ c-b ⊓ c| = |a - b|
 @[to_additive]
 theorem abs_div_sup_mul_abs_div_inf [covariant_class α α (*) (≤)] (a b c : α) :
   |(a ⊔ c)/(b ⊔ c)| * |(a ⊓ c)/(b ⊓ c)| = |a / b| :=
@@ -464,10 +375,7 @@ begin
   ... = |a / b|           : by rw sup_div_inf_eq_abs_div
 end
 
-/--
-Let `α` be a lattice ordered commutative group and let `a` be a positive element in `α`. Then `a` is
-equal to its positive component `a⁺`.
--/
+-- 0 ≤ a implies a⁺ = a
 @[to_additive pos_pos_id]
 lemma m_pos_pos_id (a : α) (h : 1 ≤ a): a⁺ = a :=
 begin
@@ -475,10 +383,7 @@ begin
   apply sup_of_le_left h,
 end
 
-/--
-Let `α` be a lattice ordered commutative group and let `a` be a positive element in `α`. Then `a` is
-equal to its absolute value `|a|`.
--/
+-- 0 ≤ a implies |a| = a
 @[to_additive abs_pos_eq]
 lemma mabs_pos_eq [covariant_class α α (*) (≤)] (a : α) (h: 1 ≤ a) : |a| = a :=
 begin
@@ -489,10 +394,7 @@ begin
   apply one_le_mul h h,
 end
 
-/--
-Let `α` be a lattice ordered commutative group and let `a` be an element in `α`. Then the absolute
-value `|a|` of `a` is positive.
--/
+-- 0 ≤ |a|
 @[to_additive abs_pos]
 lemma mabs_pos [covariant_class α α (*) (≤)] (a : α) : 1 ≤ |a| :=
 begin
@@ -503,8 +405,7 @@ begin
 end
 
 /--
-Let `α` be a lattice ordered commutative group. The unary operation of taking the absolute value is
-idempotent.
+The unary operation of taking the absolute value is idempotent.
 -/
 @[to_additive abs_idempotent]
 lemma mabs_idempotent [covariant_class α α (*) (≤)] (a : α) : |a| = | |a| | :=
@@ -515,12 +416,7 @@ end
 
 -- Commutative case, Zaanen, 3rd lecture
 -- For the non-commutative case, see Birkhoff Theorem 19 (27)
-/--
-Let `α` be a lattice ordered commutative group and let `a`, `b` and `c` be elements in `α`. Let
-`|a ⊔ c - (b ⊔ c)|`, `|a ⊓ c - b ⊓ c|` and `|a - b|` denote the absolute values of
-`a ⊔ c - (b ⊔ c)`, `a ⊓ c - b ⊓ c` and`a - b` respectively. Then `|a - b|` dominates
-`|a ⊔ c - (b ⊔ c)|` and `|a ⊓ c - b ⊓ c|`.
--/
+-- |(a ⊔ c) - (b ⊔ c)| ⊔ |(a ⊓ c) - (b ⊓ c)| ≤ |a - b|
 @[to_additive Birkhoff_inequalities]
 theorem m_Birkhoff_inequalities [covariant_class α α (*) (≤)] (a b c : α) :
 |(a ⊔ c) / (b ⊔ c)| ⊔ |(a ⊓ c) / (b ⊓ c)| ≤ |a / b| :=
@@ -537,8 +433,7 @@ end
 
 -- Banasiak Proposition 2.12, Zaanen 2nd lecture
 /--
-Let `α` be a lattice ordered commutative group. Then the absolute value satisfies the triangle
-inequality.
+The absolute value satisfies the triangle inequality.
 -/
 @[to_additive abs_triangle]
 lemma mabs_triangle [covariant_class α α (*) (≤)] (a b : α) : |a * b| ≤ |a| * |b| :=
@@ -551,6 +446,36 @@ begin
     apply mul_le_mul',
     apply lattice_ordered_comm_group.inv_le_abs,
     apply lattice_ordered_comm_group.inv_le_abs, }
+end
+
+-- |a - b| = |b - a|
+@[to_additive]
+lemma abs_inv_invariant (a b : α) : |a/b| = |b/a| :=
+begin
+  unfold has_abs.abs,
+  rw [inv_div' a b, ← inv_inv (a / b), inv_div', sup_comm],
+end
+
+-- | |a| - |b| | ≤ |a - b|
+/--
+The absolute value satisfies the reverse triangle inequality.
+-/
+@[to_additive]
+lemma abs_abs_div_abs_le [covariant_class α α (*) (≤)] (a b : α) : | |a| / |b| | ≤ |a / b| :=
+begin
+  unfold has_abs.abs,
+  rw sup_le_iff,
+  split,
+  { apply div_le_iff_le_mul.2,
+    convert mabs_triangle (a/b) b,
+    { rw div_mul_cancel', },
+    { rw div_mul_cancel', },
+    { exact covariant_swap_mul_le_of_covariant_mul_le α, } },
+  { rw [div_eq_mul_inv, mul_inv_rev, inv_inv, mul_inv_le_iff_le_mul, ← abs_eq_sup_inv (a / b),
+      abs_inv_invariant],
+    convert  mabs_triangle (b/a) a,
+    { rw div_mul_cancel', },
+    {rw div_mul_cancel', } },
 end
 
 end lattice_ordered_comm_group

--- a/src/algebra/lattice_ordered_group.lean
+++ b/src/algebra/lattice_ordered_group.lean
@@ -448,34 +448,4 @@ begin
     apply lattice_ordered_comm_group.inv_le_abs, }
 end
 
--- |a - b| = |b - a|
-@[to_additive]
-lemma abs_inv_invariant (a b : α) : |a/b| = |b/a| :=
-begin
-  unfold has_abs.abs,
-  rw [inv_div' a b, ← inv_inv (a / b), inv_div', sup_comm],
-end
-
--- | |a| - |b| | ≤ |a - b|
-/--
-The absolute value satisfies the reverse triangle inequality.
--/
-@[to_additive]
-lemma abs_abs_div_abs_le [covariant_class α α (*) (≤)] (a b : α) : | |a| / |b| | ≤ |a / b| :=
-begin
-  unfold has_abs.abs,
-  rw sup_le_iff,
-  split,
-  { apply div_le_iff_le_mul.2,
-    convert mabs_triangle (a/b) b,
-    { rw div_mul_cancel', },
-    { rw div_mul_cancel', },
-    { exact covariant_swap_mul_le_of_covariant_mul_le α, } },
-  { rw [div_eq_mul_inv, mul_inv_rev, inv_inv, mul_inv_le_iff_le_mul, ← abs_eq_sup_inv (a / b),
-      abs_inv_invariant],
-    convert  mabs_triangle (b/a) a,
-    { rw div_mul_cancel', },
-    {rw div_mul_cancel', } },
-end
-
 end lattice_ordered_comm_group

--- a/src/analysis/normed_space/lattice_ordered_group.lean
+++ b/src/analysis/normed_space/lattice_ordered_group.lean
@@ -62,10 +62,6 @@ Let `α` be a normed group with a partial order. Then the order dual is also a n
 @[priority 100] -- see Note [lower instance priority]
 instance {α : Type*} : Π [normed_group α], normed_group (order_dual α) := id
 
-/--
-Let `α` be a normed lattice ordered group and let `a` and `b` be elements of `α`. Then `a⊓-a ≥ b⊓-b`
-implies `∥a∥ ≤ ∥b∥`.
--/
 lemma dual_solid {α : Type*} [normed_lattice_add_comm_group α] (a b : α) (h: b⊓-b ≤ a⊓-a) :
   ∥a∥ ≤ ∥b∥ :=
 begin
@@ -100,10 +96,6 @@ solid := begin
   finish,
 end, }
 
-/--
-Let `α` be a normed lattice ordered group, let `a` be an element of `α` and let `|a|` be the
-absolute value of `a`. Then `∥|a|∥ = ∥a∥`.
--/
 lemma norm_abs_eq_norm {α : Type*} [normed_lattice_add_comm_group α] (a : α) : ∥|a|∥ = ∥a∥ :=
 begin
   rw le_antisymm_iff,


### PR DESCRIPTION
doc(algebra.lattice_ordered_group): Remove verbose docstrings


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
