### PR TITLE
[Merged by Bors] - feat(group_theory/order_of_element): linear ordered rings

### DIFF
--- a/src/group_theory/order_of_element.lean
+++ b/src/group_theory/order_of_element.lean
@@ -706,7 +706,7 @@ end
 lemma linear_ordered_ring.order_of_le_two : order_of x ≤ 2 :=
 begin
   cases ne_or_eq (|x|) 1 with h h,
-  { convert zero_le_two, exact order_of_abs_ne_one h },
+  { simp [order_of_abs_ne_one h] },
   rcases eq_or_eq_neg_of_abs_eq h with rfl | rfl,
   { simp },
   apply order_of_le_of_pow_eq_one; norm_num

--- a/src/group_theory/order_of_element.lean
+++ b/src/group_theory/order_of_element.lean
@@ -119,6 +119,10 @@ by rwa [order_of, minimal_period, dif_neg]
   order_of x = 0 ↔ ¬ is_of_fin_order x :=
 ⟨λ h H, (order_of_pos' H).ne' h, order_of_eq_zero⟩
 
+@[to_additive add_order_of_eq_zero_iff'] lemma order_of_eq_zero_iff' :
+  order_of x = 0 ↔ ∀ n : ℕ, 0 < n → x ^ n ≠ 1 :=
+by simp_rw [order_of_eq_zero_iff, is_of_fin_order_iff_pow_eq_one, not_exists, not_and]
+
 @[to_additive nsmul_ne_zero_of_lt_add_order_of']
 lemma pow_ne_one_of_lt_order_of' (n0 : n ≠ 0) (h : n < order_of x) : x ^ n ≠ 1 :=
 λ j, not_is_periodic_pt_of_pos_of_lt_minimal_period n0 h
@@ -684,3 +688,28 @@ subgroup_of_idempotent (S ^ (fintype.card G)) ⟨1, one_mem⟩ begin
 end
 
 end pow_is_subgroup
+
+section linear_ordered_ring
+
+variable [linear_ordered_ring G]
+
+lemma order_of_abs_ne_one (h : |x| ≠ 1) : order_of x = 0 :=
+begin
+  rw order_of_eq_zero_iff',
+  intros n hn hx,
+  replace hx : |x| ^ n = 1 := by simpa only [abs_one, abs_pow] using congr_arg abs hx,
+  cases h.lt_or_lt with h h,
+  { exact ((pow_lt_one (abs_nonneg x) h hn.ne').ne hx).elim },
+  { exact ((one_lt_pow h hn.ne').ne' hx).elim }
+end
+
+lemma linear_ordered_ring.order_of_le_two : order_of x ≤ 2 :=
+begin
+  cases ne_or_eq (|x|) 1 with h h,
+  { convert zero_le_two, exact order_of_abs_ne_one h },
+  rcases eq_or_eq_neg_of_abs_eq h with rfl | rfl,
+  { simp },
+  apply order_of_le_of_pow_eq_one; norm_num
+end
+
+end linear_ordered_ring


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:

-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)

I have absolutely no clue where to put this lemma.
