### PR TITLE
[Merged by Bors] - feat(group_theory/group_action/units): add a `mul_distrib_mul_action` instance

### DIFF
--- a/src/group_theory/group_action/units.lean
+++ b/src/group_theory/group_action/units.lean
@@ -113,6 +113,14 @@ instance is_scalar_tower'_left [group G] [monoid M] [mul_action G M] [has_scalar
 example [monoid M] [monoid N] [mul_action M N] [smul_comm_class M N N]
   [is_scalar_tower M N N] : mul_action (units M) (units N) := units.mul_action'
 
+/-- A stronger form of `units.mul_action'`. -/
+instance mul_distrib_mul_action' [group G] [monoid M] [mul_distrib_mul_action G M]
+  [smul_comm_class G M M] [is_scalar_tower G M M] : mul_distrib_mul_action G (units M) :=
+{ smul := (•),
+  smul_one := λ m, units.ext $ smul_one _,
+  smul_mul := λ g m₁ m₂, units.ext $ smul_mul' _ _ _,
+  .. units.mul_action' }
+
 end units
 
 lemma is_unit.smul [group G] [monoid M] [mul_action G M]


### PR DESCRIPTION
This doesn't add any new "data" instances, it just shows the existing instance satisfies stronger properties with stronger assumptions.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)

[Zulip thread](https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/units.2Emul_action'.20diamond/near/262653519).