### PR TITLE
[Merged by Bors] - feat(data/nat/prime): lemma count_factors_mul_of_coprime

### DIFF
--- a/src/data/nat/prime.lean
+++ b/src/data/nat/prime.lean
@@ -727,6 +727,11 @@ begin
   exact perm_factors_mul_of_pos ha hb,
 end
 
+/-- For coprime `a` and `b`, the power of `p` in `a * b` is the sum of the powers in `a` and `b` -/
+lemma factors_mul_add_of_coprime {p a b : ℕ} (hab : coprime a b)  :
+  list.count p (a * b).factors = list.count p a.factors + list.count p b.factors :=
+by { rw [perm_iff_count.mp (perm_factors_mul_of_coprime hab) p, count_append] }
+
 end
 
 lemma succ_dvd_or_succ_dvd_of_succ_sum_dvd_mul {p : ℕ} (p_prime : prime p) {m n k l : ℕ}
@@ -1075,7 +1080,7 @@ for any `b` coprime to `a`. -/
 lemma factors_count_eq_of_coprime_left {p a b : ℕ} (hab : coprime a b) (hpa : p ∈ a.factors) :
   list.count p (a * b).factors = list.count p a.factors :=
 begin
-  rw [perm.count_eq (perm_factors_mul_of_coprime hab) p, count_append],
+  rw factors_mul_add_of_coprime hab,
   simpa only [count_eq_zero_of_not_mem (coprime_factors_disjoint hab hpa)],
 end
 

--- a/src/data/nat/prime.lean
+++ b/src/data/nat/prime.lean
@@ -728,7 +728,7 @@ begin
 end
 
 /-- For coprime `a` and `b`, the power of `p` in `a * b` is the sum of the powers in `a` and `b` -/
-lemma factors_mul_add_of_coprime {p a b : ℕ} (hab : coprime a b)  :
+lemma count_factors_mul_of_coprime {p a b : ℕ} (hab : coprime a b)  :
   list.count p (a * b).factors = list.count p a.factors + list.count p b.factors :=
 by rw [perm_iff_count.mp (perm_factors_mul_of_coprime hab) p, count_append]
 
@@ -1080,7 +1080,7 @@ for any `b` coprime to `a`. -/
 lemma factors_count_eq_of_coprime_left {p a b : ℕ} (hab : coprime a b) (hpa : p ∈ a.factors) :
   list.count p (a * b).factors = list.count p a.factors :=
 begin
-  rw factors_mul_add_of_coprime hab,
+  rw count_factors_mul_of_coprime hab,
   simpa only [count_eq_zero_of_not_mem (coprime_factors_disjoint hab hpa)],
 end
 

--- a/src/data/nat/prime.lean
+++ b/src/data/nat/prime.lean
@@ -730,7 +730,7 @@ end
 /-- For coprime `a` and `b`, the power of `p` in `a * b` is the sum of the powers in `a` and `b` -/
 lemma factors_mul_add_of_coprime {p a b : ℕ} (hab : coprime a b)  :
   list.count p (a * b).factors = list.count p a.factors + list.count p b.factors :=
-by { rw [perm_iff_count.mp (perm_factors_mul_of_coprime hab) p, count_append] }
+by rw [perm_iff_count.mp (perm_factors_mul_of_coprime hab) p, count_append]
 
 end
 


### PR DESCRIPTION
Adding lemma `count_factors_mul_of_coprime` and using it to simplify the proof of `factors_count_eq_of_coprime_left`.
 
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
