### PR TITLE
[Merged by Bors] - doc(field_theory/galois): add comment that separable extensions are a…

### DIFF
--- a/src/field_theory/galois.lean
+++ b/src/field_theory/galois.lean
@@ -42,7 +42,8 @@ section
 
 variables (F : Type*) [field F] (E : Type*) [field E] [algebra F E]
 
-/-- A field extension E/F is galois if it is both separable and normal -/
+/-- A field extension E/F is galois if it is both separable and normal. Note that in mathlib
+a separable extension of fields is by definition algebraic. -/
 class is_galois : Prop :=
 [to_is_separable : is_separable F E]
 [to_normal : normal F E]

--- a/src/field_theory/separable.lean
+++ b/src/field_theory/separable.lean
@@ -611,7 +611,7 @@ variables (F K : Type*) [comm_ring F] [ring K] [algebra F K]
 -- See: https://en.wikipedia.org/wiki/Separable_extension#Separability_of_transcendental_extensions
 -- Note that right now a Galois extension (class `is_galois`) is defined to be an extension which
 -- is separable and normal, so if the definition of separable changes here at some point
--- to allow non-algebraic extensions, then the definition of Galois must also be changed.
+-- to allow non-algebraic extensions, then the definition of `is_galois` must also be changed.
 
 /-- Typeclass for separable field extension: `K` is a separable field extension of `F` iff
 the minimal polynomial of every `x : K` is separable.

--- a/src/field_theory/separable.lean
+++ b/src/field_theory/separable.lean
@@ -609,6 +609,9 @@ variables (F K : Type*) [comm_ring F] [ring K] [algebra F K]
 
 -- TODO: refactor to allow transcendental extensions?
 -- See: https://en.wikipedia.org/wiki/Separable_extension#Separability_of_transcendental_extensions
+-- Note that right now a Galois extension (class `is_galois`) is defined to be an extension which
+-- is separable and normal, so if the definition of separable changes here at some point
+-- to allow non-algebraic extensions, then the definition of Galois must also be changed.
 
 /-- Typeclass for separable field extension: `K` is a separable field extension of `F` iff
 the minimal polynomial of every `x : K` is separable.


### PR DESCRIPTION
…lgebraic

I teach my students that a Galois extension is algebraic, normal and separable, and was
just taken aback when I read the mathlib definition which omits "algebraic". Apparently
there are two conventions for the definition of separability, one implying algebraic and the other not:
https://en.wikipedia.org/wiki/Separable_extension#Separability_of_transcendental_extensions .
Right now we have separability implies algebraic in mathlib so mathematically we're fine; I just
add a note to clarify what's going on. In particular if we act on the TODO in
the separability definition, we may (perhaps unwittingly) break the definition of
`is_galois`; hopefully this note lessens the chance that this happens.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
