### PR TITLE
[Merged by Bors] - Adding a matching TODO back

### DIFF
--- a/src/combinatorics/simple_graph/matching.lean
+++ b/src/combinatorics/simple_graph/matching.lean
@@ -33,6 +33,8 @@ one edge, and the edges of the subgraph represent the paired vertices.
   the cardinality of `V` is even (assuming it's finite)
 
 * Tutte's Theorem
+
+* Hall's Marriage Theorem (see combinatorics.hall)
 -/
 
 universe u


### PR DESCRIPTION
Because we were careless and removed it too early:

https://github.com/leanprover-community/mathlib/pull/10210#discussion_r757640946

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
