### PR TITLE
[Merged by Bors] - feat(topology/connected): Connectedness in sum and sigma type

### DIFF
--- a/src/data/set/lattice.lean
+++ b/src/data/set/lattice.lean
@@ -827,6 +827,9 @@ begin
   { intro h, cases x with i a, exact ⟨i, a, h, rfl⟩ }
 end
 
+lemma sigma.univ (X : α → Type*) : (set.univ : set (Σ a, X a)) = ⋃ a, range (sigma.mk a) :=
+set.ext $ λ x, iff_of_true trivial ⟨range (sigma.mk x.1), set.mem_range_self _, x.2, sigma.eta x⟩
+
 lemma sUnion_mono {s t : set (set α)} (h : s ⊆ t) : (⋃₀ s) ⊆ (⋃₀ t) :=
 sUnion_subset $ λ t' ht', subset_sUnion_of_mem $ h ht'
 

--- a/src/topology/connected.lean
+++ b/src/topology/connected.lean
@@ -353,28 +353,28 @@ begin
   exact hc.image _ (continuous_apply _).continuous_on
 end
 
-lemma sigma.is_connected_iff [Π a, topological_space (π a)] {s : set (Σ a, π a)} :
-  is_connected s ↔ ∃ a t, is_connected t ∧ s = sigma.mk a '' t :=
+lemma sigma.is_connected_iff [Π i, topological_space (π i)] {s : set (Σ i, π i)} :
+  is_connected s ↔ ∃ i t, is_connected t ∧ s = sigma.mk i '' t :=
 begin
   refine ⟨λ hs, _, _⟩,
-  { obtain ⟨⟨a, x⟩, hx⟩ := hs.nonempty,
-    have : s ⊆ set.range (sigma.mk a),
-    { have h : set.range (sigma.mk a) = sigma.fst ⁻¹' {a}, by { ext, simp },
+  { obtain ⟨⟨i, x⟩, hx⟩ := hs.nonempty,
+    have : s ⊆ set.range (sigma.mk i),
+    { have h : set.range (sigma.mk i) = sigma.fst ⁻¹' {i}, by { ext, simp },
       rw h,
       exact is_preconnected.subset_left_of_subset_union
-        (is_open_sigma_fst_preimage _) (is_open_sigma_fst_preimage {x | x ≠ a})
+        (is_open_sigma_fst_preimage _) (is_open_sigma_fst_preimage {x | x ≠ i})
         (set.disjoint_iff.2 $ λ x hx, hx.2 hx.1)
-        (λ y hy, by simp [classical.em]) ⟨⟨a, x⟩, hx, rfl⟩ hs.2 },
-    exact ⟨a, sigma.mk a ⁻¹' s,
+        (λ y hy, by simp [classical.em]) ⟨⟨i, x⟩, hx, rfl⟩ hs.2 },
+    exact ⟨i, sigma.mk i ⁻¹' s,
       hs.preimage_of_open_map sigma_mk_injective is_open_map_sigma_mk this,
       (set.image_preimage_eq_of_subset this).symm⟩ },
-  { rintro ⟨a, t, ht, rfl⟩,
+  { rintro ⟨i, t, ht, rfl⟩,
     exact ht.image _ continuous_sigma_mk.continuous_on }
 end
 
-lemma sigma.is_preconnected_iff [hι : nonempty ι] [Π a, topological_space (π a)]
-  {s : set (Σ a, π a)} :
-  is_preconnected s ↔ ∃ a t, is_preconnected t ∧ s = sigma.mk a '' t :=
+lemma sigma.is_preconnected_iff [hι : nonempty ι] [Π i, topological_space (π i)]
+  {s : set (Σ i, π i)} :
+  is_preconnected s ↔ ∃ i t, is_preconnected t ∧ s = sigma.mk i '' t :=
 begin
   refine ⟨λ hs, _, _⟩,
   { obtain rfl | h := s.eq_empty_or_nonempty,
@@ -929,9 +929,8 @@ have H2 : is_preconnected (prod.snd '' t), from h2.image prod.snd continuous_snd
   (H1.subsingleton ⟨x, hx, rfl⟩ ⟨y, hy, rfl⟩)
   (H2.subsingleton ⟨x, hx, rfl⟩ ⟨y, hy, rfl⟩)⟩
 
-instance {X Y : Type*} [topological_space X] [topological_space Y]
-  [totally_disconnected_space X] [totally_disconnected_space Y] :
-  totally_disconnected_space (X ⊕ Y) :=
+instance [topological_space β] [totally_disconnected_space α] [totally_disconnected_space β] :
+  totally_disconnected_space (α ⊕ β) :=
 begin
   refine ⟨λ s _ hs, _⟩,
   obtain (⟨t, ht, rfl⟩ | ⟨t, ht, rfl⟩) := sum.is_preconnected_iff.1 hs,
@@ -939,8 +938,8 @@ begin
   { exact ht.subsingleton.image _ }
 end
 
-instance [Π a, topological_space (π a)] [∀ a, totally_disconnected_space (π a)] :
-  totally_disconnected_space (Σ a, π a) :=
+instance [Π i, topological_space (π i)] [∀ i, totally_disconnected_space (π i)] :
+  totally_disconnected_space (Σ i, π i) :=
 begin
   refine ⟨λ s _ hs, _⟩,
   obtain rfl | h := s.eq_empty_or_nonempty,

--- a/src/topology/constructions.lean
+++ b/src/topology/constructions.lean
@@ -884,6 +884,19 @@ by simp only [is_open_supr_iff, is_open_coinduced]
 lemma is_closed_sigma_iff {s : set (sigma σ)} : is_closed s ↔ ∀ i, is_closed (sigma.mk i ⁻¹' s) :=
 by simp only [← is_open_compl_iff, is_open_sigma_iff, preimage_compl]
 
+lemma is_open_sigma_fst_preimage (s : set ι) :  is_open (sigma.fst ⁻¹' s : set (Σ a, σ a)) :=
+begin
+  rw is_open_sigma_iff,
+  intros a,
+  by_cases h : a ∈ s,
+  { convert is_open_univ,
+    ext x,
+    simp only [h, set.mem_preimage, set.mem_univ] },
+  { convert is_open_empty,
+    ext x,
+    simp only [h, set.mem_empty_eq, set.mem_preimage] }
+end
+
 lemma is_open_map_sigma_mk {i : ι} : is_open_map (@sigma.mk ι σ i) :=
 begin
   intros s hs,

--- a/src/topology/subset_properties.lean
+++ b/src/topology/subset_properties.lean
@@ -50,7 +50,7 @@ open set filter classical topological_space
 open_locale classical topological_space filter
 
 universes u v
-variables {α : Type u} {β : Type v} [topological_space α] {s t : set α}
+variables {α : Type u} {β : Type v}  {ι : Type*} {π : ι → Type*} [topological_space α] {s t : set α}
 
 /- compact sets -/
 section compact
@@ -812,8 +812,8 @@ instance [compact_space α] [compact_space β] : compact_space (α ⊕ β) :=
   exact (is_compact_range continuous_inl).union (is_compact_range continuous_inr)
 end⟩
 
-instance {α : Type*} [fintype α] (X : α → Type*) [Π a, topological_space (X a)]
-  [∀ a, compact_space (X a)] : compact_space (Σ a, X a) :=
+instance [fintype ι] [Π i, topological_space (π i)] [∀ i, compact_space (π i)] :
+  compact_space (Σ i, π i) :=
 begin
   refine ⟨_⟩,
   rw sigma.univ,
@@ -861,7 +861,7 @@ instance prod.noncompact_space_right [nonempty α] [noncompact_space β] : nonco
 prod.noncompact_space_iff.2 (or.inr ⟨‹_›, ‹_›⟩)
 
 section tychonoff
-variables {ι : Type*} {π : ι → Type*} [∀ i, topological_space (π i)]
+variables [Π i, topological_space (π i)]
 
 /-- **Tychonoff's theorem** -/
 lemma is_compact_pi_infinite {s : Π i, set (π i)} :

--- a/src/topology/subset_properties.lean
+++ b/src/topology/subset_properties.lean
@@ -812,6 +812,14 @@ instance [compact_space α] [compact_space β] : compact_space (α ⊕ β) :=
   exact (is_compact_range continuous_inl).union (is_compact_range continuous_inr)
 end⟩
 
+instance {α : Type*} [fintype α] (X : α → Type*) [Π a, topological_space (X a)]
+  [∀ a, compact_space (X a)] : compact_space (Σ a, X a) :=
+begin
+  refine ⟨_⟩,
+  rw sigma.univ,
+  exact compact_Union (λ i, is_compact_range continuous_sigma_mk),
+end
+
 /-- The coproduct of the cocompact filters on two topological spaces is the cocompact filter on
 their product. -/
 lemma filter.coprod_cocompact :
@@ -1248,6 +1256,10 @@ end
 
 @[simp] lemma is_clopen_discrete [discrete_topology α] (x : set α) : is_clopen x :=
 ⟨is_open_discrete _, is_closed_discrete _⟩
+
+lemma clopen_range_sigma_mk {ι : Type*} {σ : ι → Type*} [Π i, topological_space (σ i)] {i : ι} :
+  is_clopen (set.range (@sigma.mk ι σ i)) :=
+⟨open_embedding_sigma_mk.open_range, closed_embedding_sigma_mk.closed_range⟩
 
 end clopen
 


### PR DESCRIPTION
This provides the `compact_space` and `totally_disconnected_space` instances for `α ⊕ β` and `Σ i, π i`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

From LTE
Co-authored-by: Kevin Buzzard <k.buzzard@imperial.ac.uk>
[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
