### PR TITLE
[Merged by Bors] - feat(topology/[continuous_function, path_connected]): add bundled versions of prod_mk and prod_map

### DIFF
--- a/src/topology/continuous_function/basic.lean
+++ b/src/topology/continuous_function/basic.lean
@@ -215,12 +215,14 @@ section prod
 
 variables {α₁ α₂ β₁ β₂ : Type*}
 
+/-- Given two continuous maps `f` and `g`, this is the continuous map `x ↦ (f x, g x)`. -/
 def prod_mk {α β₁ β₂ : Type*} [topological_space α] [topological_space β₁]
   [topological_space β₂] (f : C(α, β₁)) (g : C(α, β₂)) :
   C(α, β₁ × β₂) :=
 { to_fun := (λ x, (f x, g x)),
   continuous_to_fun := continuous.prod_mk f.continuous g.continuous }
 
+/-- Given two continuous maps `f` and `g`, this is the continuous map `(x, y) ↦ (f x, g y)`. -/
 def prod_map {α₁ α₂ β₁ β₂ : Type*} [topological_space α₁] [topological_space α₂]
   [topological_space β₁] [topological_space β₂] (f : C(α₁, α₂)) (g : C(β₁, β₂)) :
   C(α₁ × β₁, α₂ × β₂) :=

--- a/src/topology/continuous_function/basic.lean
+++ b/src/topology/continuous_function/basic.lean
@@ -211,6 +211,24 @@ end inf'
 
 end lattice
 
+section prod
+
+variables {α₁ α₂ β₁ β₂ : Type*}
+
+def prod_mk {α β₁ β₂ : Type*} [topological_space α] [topological_space β₁]
+  [topological_space β₂] (f : C(α, β₁)) (g : C(α, β₂)) :
+  C(α, β₁ × β₂) :=
+{ to_fun := (λ x, (f x, g x)),
+  continuous_to_fun := continuous.prod_mk f.continuous g.continuous }
+
+def prod_map {α₁ α₂ β₁ β₂ : Type*} [topological_space α₁] [topological_space α₂]
+  [topological_space β₁] [topological_space β₂] (f : C(α₁, α₂)) (g : C(β₁, β₂)) :
+  C(α₁ × β₁, α₂ × β₂) :=
+{ to_fun := prod.map f g,
+  continuous_to_fun := continuous.prod_map f.continuous g.continuous }
+
+end prod
+
 section restrict
 
 variables (s : set α)

--- a/src/topology/path_connected.lean
+++ b/src/topology/path_connected.lean
@@ -372,6 +372,14 @@ begin
     simp [hst, mul_inv_cancel (@two_ne_zero ℝ _ _)] }
 end
 
+/-! #### Product of two paths -/
+
+def path.prod {α β : Type*} [topological_space α] [topological_space β]
+  {x₁ y₁ : α} {x₂ y₂ : β} (γ₁ : path x₁ y₁) (γ₂ : path x₂ y₂) :  path (x₁, x₂) (y₁, y₂) :=
+{ to_continuous_map := continuous_map.prod_mk γ₁.to_continuous_map γ₂.to_continuous_map,
+  source' := by dsimp [continuous_map.prod_mk]; rwa [γ₁.source, γ₂.source],
+  target' := by dsimp [continuous_map.prod_mk]; rwa [γ₁.target, γ₂.target] }
+
 /-! #### Truncating a path -/
 
 /-- `γ.truncate t₀ t₁` is the path which follows the path `γ` on the

--- a/src/topology/path_connected.lean
+++ b/src/topology/path_connected.lean
@@ -374,11 +374,24 @@ end
 
 /-! #### Product of two paths -/
 
-def path.prod {α β : Type*} [topological_space α] [topological_space β]
-  {x₁ y₁ : α} {x₂ y₂ : β} (γ₁ : path x₁ y₁) (γ₂ : path x₂ y₂) :  path (x₁, x₂) (y₁, y₂) :=
+/-- Given a path in `X` and a path in `Y`, we can take their pointwise product to get a path in
+`X × Y`. -/
+protected def prod {a₁ b₁ : X} {a₂ b₂ : Y} (γ₁ : path a₁ b₁) (γ₂ : path a₂ b₂) :  path (a₁, a₂) (b₁, b₂) :=
 { to_continuous_map := continuous_map.prod_mk γ₁.to_continuous_map γ₂.to_continuous_map,
   source' := by dsimp [continuous_map.prod_mk]; rwa [γ₁.source, γ₂.source],
   target' := by dsimp [continuous_map.prod_mk]; rwa [γ₁.target, γ₂.target] }
+
+/-! #### Pointwise multiplication/addition of two paths in a topological (additive) group -/
+
+/-- Pointwise multiplication of paths in a topological group. The additive version is probably more
+useful. -/
+@[to_additive "Pointwise addition of paths in a topological additive group. -/"]
+protected def mul [has_mul X] [has_continuous_mul X] {a₁ b₁ a₂ b₂ : X}
+  (γ₁ : path a₁ b₁) (γ₂ : path a₂ b₂) : path (a₁ * a₂) (b₁ * b₂) :=
+(γ₁.prod γ₂).map continuous_mul
+
+@[to_additive] protected lemma mul_apply [has_mul X] [has_continuous_mul X] {a₁ b₁ a₂ b₂ : X}
+  (γ₁ : path a₁ b₁) (γ₂ : path a₂ b₂) (t : unit_interval) : (γ₁.mul γ₂) t = γ₁ t * γ₂ t := rfl
 
 /-! #### Truncating a path -/
 

--- a/src/topology/path_connected.lean
+++ b/src/topology/path_connected.lean
@@ -376,7 +376,8 @@ end
 
 /-- Given a path in `X` and a path in `Y`, we can take their pointwise product to get a path in
 `X × Y`. -/
-protected def prod {a₁ b₁ : X} {a₂ b₂ : Y} (γ₁ : path a₁ b₁) (γ₂ : path a₂ b₂) :  path (a₁, a₂) (b₁, b₂) :=
+protected def prod {a₁ b₁ : X} {a₂ b₂ : Y} (γ₁ : path a₁ b₁) (γ₂ : path a₂ b₂) :
+  path (a₁, a₂) (b₁, b₂) :=
 { to_continuous_map := continuous_map.prod_mk γ₁.to_continuous_map γ₂.to_continuous_map,
   source' := by dsimp [continuous_map.prod_mk]; rwa [γ₁.source, γ₂.source],
   target' := by dsimp [continuous_map.prod_mk]; rwa [γ₁.target, γ₂.target] }


### PR DESCRIPTION
I also added a definition for pointwise addition of paths, but I'm not sure it would be really useful in general (my use case is the Sphere eversion project, where I need to add together two paths living in complement subspaces of a real TVS).

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
