### PR TITLE
fix(data/fun_like): fix mistake in docstring

### DIFF
--- a/src/data/fun_like.lean
+++ b/src/data/fun_like.lean
@@ -30,7 +30,7 @@ instance : fun_like (my_hom A B) A (λ _, B) :=
 { coe := my_hom.to_fun, coe_injective' := λ f g h, by cases f; cases g; congr' }
 
 /-- Helper instance for when there's too many metavariables to apply `to_fun.to_coe_fn` directly. -/
-instance : has_coe_to_fun (my_hom A B) := to_fun.to_coe_fn
+instance : has_coe_to_fun (my_hom A B) (λ _, A → B) := to_fun.to_coe_fn
 
 @[simp] lemma to_fun_eq_coe {f : my_hom A B} : f.to_fun = (f : A → B) := rfl
 


### PR DESCRIPTION
@YaelDillies pointed out I never updated the `instance : has_coe_to_fun` line in the example to match the `coe_fn` backport #7033.



---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
