### PR TITLE
[Merged by Bors] - chore(*): cleanup unneeded uses of by_cases across the library

### DIFF
--- a/src/analysis/special_functions/pow.lean
+++ b/src/analysis/special_functions/pow.lean
@@ -80,7 +80,7 @@ else by rw [cpow_def, if_neg (one_ne_zero : (1 : ℂ) ≠ 0), if_neg hx, mul_one
 by rw cpow_def; split_ifs; simp [one_ne_zero, *] at *
 
 lemma cpow_add {x : ℂ} (y z : ℂ) (hx : x ≠ 0) : x ^ (y + z) = x ^ y * x ^ z :=
-by simp [cpow_def]; split_ifs; simp [*, exp_add, mul_add] at *
+by simp [cpow_def]; simp [*, exp_add, mul_add] at *
 
 lemma cpow_mul {x y : ℂ} (z : ℂ) (h₁ : -π < (log x * y).im) (h₂ : (log x * y).im ≤ π) :
   x ^ (y * z) = (x ^ y) ^ z :=

--- a/src/data/complex/is_R_or_C.lean
+++ b/src/data/complex/is_R_or_C.lean
@@ -344,7 +344,7 @@ begin
 end
 
 @[simp] lemma inv_I : (I : K)⁻¹ = -I :=
-by { by_cases h : (I : K) = 0; field_simp [h] }
+by field_simp
 
 @[simp] lemma norm_sq_inv (z : K) : norm_sq z⁻¹ = (norm_sq z)⁻¹ :=
 (@norm_sq K _).map_inv z

--- a/src/data/fintype/basic.lean
+++ b/src/data/fintype/basic.lean
@@ -1474,11 +1474,7 @@ begin
   suffices : f ∈ perms_of_list l ∨ ∃ (b ∈ l) (g ∈ perms_of_list l), swap a b * g = f,
   { simpa only [perms_of_list, exists_prop, list.mem_map, mem_append, list.mem_bind] },
   refine or_iff_not_imp_left.2 (λ hfl, ⟨f a, _, swap a (f a) * f, IH this, _⟩),
-  { by_cases hffa : f (f a) = a,
-    { exact mem_of_ne_of_mem hfa (h _ (mt (λ h, f.injective h) hfa)) },
-    { apply this,
-      simp only [mul_apply, swap_apply_def, mul_apply, ne.def, apply_eq_iff_eq],
-      split_ifs; cc } },
+  { exact mem_of_ne_of_mem hfa (h _ (mt (λ h, f.injective h) hfa)), },
   { rw [←mul_assoc, mul_def (swap a (f a)) (swap a (f a)),
         swap_swap, ←perm.one_def, one_mul] }
 end

--- a/src/data/fintype/basic.lean
+++ b/src/data/fintype/basic.lean
@@ -1474,7 +1474,7 @@ begin
   suffices : f ∈ perms_of_list l ∨ ∃ (b ∈ l) (g ∈ perms_of_list l), swap a b * g = f,
   { simpa only [perms_of_list, exists_prop, list.mem_map, mem_append, list.mem_bind] },
   refine or_iff_not_imp_left.2 (λ hfl, ⟨f a, _, swap a (f a) * f, IH this, _⟩),
-  { exact mem_of_ne_of_mem hfa (h _ (mt (λ h, f.injective h) hfa)), },
+  { exact mem_of_ne_of_mem hfa (h _ hfa') },
   { rw [←mul_assoc, mul_def (swap a (f a)) (swap a (f a)),
         swap_swap, ←perm.one_def, one_mul] }
 end

--- a/src/data/list/intervals.lean
+++ b/src/data/list/intervals.lean
@@ -65,14 +65,9 @@ by rw [Ico, Ico, map_add_range', add_tsub_add_eq_tsub_right, add_comm n k]
 
 theorem map_sub (n m k : ℕ) (h₁ : k ≤ n) : (Ico n m).map (λ x, x - k) = Ico (n - k) (m - k) :=
 begin
-  by_cases h₂ : n < m,
-  { rw [Ico, Ico],
-    rw tsub_tsub_tsub_cancel_right h₁,
-    rw [map_sub_range' _ _ _ h₁] },
-  { simp at h₂,
-    rw [eq_nil_of_le h₂],
-    rw [eq_nil_of_le (tsub_le_tsub_right h₂ _)],
-    refl }
+  rw [Ico, Ico],
+  rw tsub_tsub_tsub_cancel_right h₁,
+  rw [map_sub_range' _ _ _ h₁],
 end
 
 @[simp] theorem self_empty {n : ℕ} : Ico n n = [] :=

--- a/src/data/list/intervals.lean
+++ b/src/data/list/intervals.lean
@@ -64,7 +64,6 @@ theorem map_add (n m k : ℕ) : (Ico n m).map ((+) k) = Ico (n + k) (m + k) :=
 by rw [Ico, Ico, map_add_range', add_tsub_add_eq_tsub_right, add_comm n k]
 
 theorem map_sub (n m k : ℕ) (h₁ : k ≤ n) : (Ico n m).map (λ x, x - k) = Ico (n - k) (m - k) :=
-begin
 by rw [Ico, Ico, tsub_tsub_tsub_cancel_right h₁, map_sub_range' _ _ _ h₁]
 
 @[simp] theorem self_empty {n : ℕ} : Ico n n = [] :=

--- a/src/data/list/intervals.lean
+++ b/src/data/list/intervals.lean
@@ -65,10 +65,7 @@ by rw [Ico, Ico, map_add_range', add_tsub_add_eq_tsub_right, add_comm n k]
 
 theorem map_sub (n m k : ℕ) (h₁ : k ≤ n) : (Ico n m).map (λ x, x - k) = Ico (n - k) (m - k) :=
 begin
-  rw [Ico, Ico],
-  rw tsub_tsub_tsub_cancel_right h₁,
-  rw [map_sub_range' _ _ _ h₁],
-end
+by rw [Ico, Ico, tsub_tsub_tsub_cancel_right h₁, map_sub_range' _ _ _ h₁]
 
 @[simp] theorem self_empty {n : ℕ} : Ico n n = [] :=
 eq_nil_of_le (le_refl n)

--- a/src/data/polynomial/algebra_map.lean
+++ b/src/data/polynomial/algebra_map.lean
@@ -325,8 +325,6 @@ lemma dvd_term_of_dvd_eval_of_dvd_terms {z p : S} {f : polynomial S} (i : ℕ)
   (dvd_eval : p ∣ f.eval z) (dvd_terms : ∀ (j ≠ i), p ∣ f.coeff j * z ^ j) :
   p ∣ f.coeff i * z ^ i :=
 begin
-  by_cases hf : f = 0,
-  { simp [hf] },
   by_cases hi : i ∈ f.support,
   { rw [eval, eval₂, sum] at dvd_eval,
     rw [←finset.insert_erase hi, finset.sum_insert (finset.not_mem_erase _ _)] at dvd_eval,

--- a/src/data/rbtree/insert.lean
+++ b/src/data/rbtree/insert.lean
@@ -447,10 +447,11 @@ end
 lemma weak_trichotomous (x y) {p : Prop} (is_lt : ∀ h : lt x y, p)
   (is_eqv : ∀ h : ¬ lt x y ∧ ¬ lt y x, p) (is_gt : ∀ h : lt y x, p) : p :=
 begin
-  by_cases lt x y; by_cases lt y x,
-  any_goals { apply is_lt; assumption },
-  any_goals { apply is_gt; assumption },
-  any_goals { apply is_eqv, constructor; assumption }
+  by_cases lt x y,
+  { apply is_lt, assumption },
+  by_cases lt y x,
+  { apply is_gt, assumption },
+  { apply is_eqv, constructor; assumption }
 end
 
 section find_ins_of_not_eqv

--- a/src/deprecated/subfield.lean
+++ b/src/deprecated/subfield.lean
@@ -102,7 +102,6 @@ have h0 : (0:F) ∈ closure S, from ring_closure_subset $
   end,
   inv_mem := begin
     rintros _ ⟨p, hp, q, hq, rfl⟩,
-    classical, by_cases hp0 : p = 0, by simp [hp0, h0],
     exact ⟨q, hq, p, hp, inv_div.symm⟩
   end,
   ..closure.is_submonoid }

--- a/src/field_theory/ratfunc.lean
+++ b/src/field_theory/ratfunc.lean
@@ -619,7 +619,6 @@ end
 @[simp] lemma num_div_denom (x : ratfunc K) :
   algebra_map _ _ (num x) / algebra_map _ _ (denom x) = x :=
 x.induction_on (λ p q hq, begin
-  by_cases hp : p = 0, { simp [hp] },
   have q_div_ne_zero := right_div_gcd_ne_zero hq,
   rw [num_div p hq, denom_div p hq, ring_hom.map_mul, ring_hom.map_mul,
     mul_div_mul_left, div_eq_div_iff, ← ring_hom.map_mul, ← ring_hom.map_mul, mul_comm _ q,

--- a/src/group_theory/order_of_element.lean
+++ b/src/group_theory/order_of_element.lean
@@ -316,9 +316,6 @@ calc x ^ i = x ^ (i % order_of x + order_of x * (i / order_of x)) :
 lemma pow_inj_iff_of_order_of_eq_zero (h : order_of x = 0) {n m : ℕ} :
   x ^ n = x ^ m ↔ n = m :=
 begin
-  by_cases hx : x = 1,
-  { rw [←order_of_eq_one_iff, h] at hx,
-    contradiction },
   rw [order_of_eq_zero_iff, is_of_fin_order_iff_pow_eq_one] at h,
   push_neg at h,
   induction n with n IH generalizing m,

--- a/src/group_theory/perm/concrete_cycle.lean
+++ b/src/group_theory/perm/concrete_cycle.lean
@@ -62,7 +62,7 @@ begin
         form_perm_apply_mem_eq_self_iff _ hl' _ hx'] at h,
     rcases h with hl | hl'; linarith },
   { intros h x,
-    by_cases hx : x ∈ l; by_cases hx' : x ∈ l',
+    by_cases hx : x ∈ l, by_cases hx' : x ∈ l',
     { exact (h hx hx').elim },
     all_goals { have := form_perm_eq_self_of_not_mem _ _ ‹_›, tauto } }
 end

--- a/src/group_theory/perm/cycles.lean
+++ b/src/group_theory/perm/cycles.lean
@@ -348,15 +348,12 @@ begin
   classical,
   obtain ⟨k, rfl⟩ := h,
   use ((k % order_of f).nat_abs),
-  rw [←zpow_coe_nat, int.nat_abs_of_nonneg, ←zpow_eq_mod_order_of],
-  { refine ⟨_, rfl⟩,
-    rw [←int.coe_nat_lt, int.nat_abs_of_nonneg],
-    { refine (int.mod_lt_of_pos _ _),
-      simpa using order_of_pos _ },
-    { refine int.mod_nonneg _ _,
-      simpa using ne_of_gt (order_of_pos _) } },
-  { refine int.mod_nonneg _ _,
-    simpa using (order_of_pos _).ne' }
+  have h₀ := int.coe_nat_pos.mpr (order_of_pos f),
+  have h₁ := int.mod_nonneg k h₀.ne',
+  rw [←zpow_coe_nat, int.nat_abs_of_nonneg h₁, ←zpow_eq_mod_order_of],
+  refine ⟨_, rfl⟩,
+  rw [←int.coe_nat_lt, int.nat_abs_of_nonneg h₁],
+  exact int.mod_lt_of_pos _ h₀,
 end
 
 lemma same_cycle.nat'' [fintype β] {f : perm β} {x y : β} (h : same_cycle f x y) :

--- a/src/group_theory/perm/cycles.lean
+++ b/src/group_theory/perm/cycles.lean
@@ -347,21 +347,16 @@ lemma same_cycle.nat' [fintype β] {f : perm β} {x y : β} (h : same_cycle f x 
 begin
   classical,
   obtain ⟨k, rfl⟩ := id h,
-  by_cases hk : (k % order_of f) = 0,
-  { use 0,
-    rw ←int.dvd_iff_mod_eq_zero at hk,
-    obtain ⟨m, rfl⟩ := hk,
-    simp [pow_order_of_eq_one, order_of_pos, zpow_mul] },
-  { use ((k % order_of f).nat_abs),
-    rw [←zpow_coe_nat, int.nat_abs_of_nonneg, ←zpow_eq_mod_order_of],
-    { refine ⟨_, rfl⟩,
-      rw [←int.coe_nat_lt, int.nat_abs_of_nonneg],
-      { refine (int.mod_lt_of_pos _ _),
-        simpa using order_of_pos _ },
-      { refine int.mod_nonneg _ _,
-        simpa using ne_of_gt (order_of_pos _) } },
+  use ((k % order_of f).nat_abs),
+  rw [←zpow_coe_nat, int.nat_abs_of_nonneg, ←zpow_eq_mod_order_of],
+  { refine ⟨_, rfl⟩,
+    rw [←int.coe_nat_lt, int.nat_abs_of_nonneg],
+    { refine (int.mod_lt_of_pos _ _),
+      simpa using order_of_pos _ },
     { refine int.mod_nonneg _ _,
-      simpa using (order_of_pos _).ne' } }
+      simpa using ne_of_gt (order_of_pos _) } },
+  { refine int.mod_nonneg _ _,
+    simpa using (order_of_pos _).ne' }
 end
 
 lemma same_cycle.nat'' [fintype β] {f : perm β} {x y : β} (h : same_cycle f x y) :

--- a/src/group_theory/perm/cycles.lean
+++ b/src/group_theory/perm/cycles.lean
@@ -346,7 +346,7 @@ lemma same_cycle.nat' [fintype β] {f : perm β} {x y : β} (h : same_cycle f x 
   ∃ (i : ℕ) (h : i < order_of f), (f ^ i) x = y :=
 begin
   classical,
-  obtain ⟨k, rfl⟩ := id h,
+  obtain ⟨k, rfl⟩ := h,
   use ((k % order_of f).nat_abs),
   rw [←zpow_coe_nat, int.nat_abs_of_nonneg, ←zpow_eq_mod_order_of],
   { refine ⟨_, rfl⟩,

--- a/src/group_theory/perm/list.lean
+++ b/src/group_theory/perm/list.lean
@@ -228,22 +228,14 @@ lemma form_perm_rotate_one (l : list α) (h : nodup l) :
 begin
   have h' : nodup (l.rotate 1),
   { simpa using h },
-  by_cases hl : ∀ (x : α), l ≠ [x],
-  { have hl' : ∀ (x : α), l.rotate 1 ≠ [x],
-    { intro,
-      rw [ne.def, rotate_eq_iff],
-      simpa using hl _ },
-    ext x,
-    by_cases hx : x ∈ l.rotate 1,
-    { obtain ⟨k, hk, rfl⟩ := nth_le_of_mem hx,
-      rw [form_perm_apply_nth_le _ h', nth_le_rotate l, nth_le_rotate l,
-        form_perm_apply_nth_le _ h],
-      simp },
-    { rw [form_perm_apply_of_not_mem _ _ hx, form_perm_apply_of_not_mem],
-      simpa using hx } },
-  { push_neg at hl,
-    obtain ⟨x, rfl⟩ := hl,
-    simp }
+  ext x,
+  by_cases hx : x ∈ l.rotate 1,
+  { obtain ⟨k, hk, rfl⟩ := nth_le_of_mem hx,
+    rw [form_perm_apply_nth_le _ h', nth_le_rotate l, nth_le_rotate l,
+      form_perm_apply_nth_le _ h],
+    simp },
+  { rw [form_perm_apply_of_not_mem _ _ hx, form_perm_apply_of_not_mem],
+    simpa using hx }
 end
 
 lemma form_perm_rotate (l : list α) (h : nodup l) (n : ℕ) :

--- a/src/group_theory/perm/option.lean
+++ b/src/group_theory/perm/option.lean
@@ -30,9 +30,10 @@ by {ext, simp [equiv_functor.map_equiv, equiv_functor.map] }
 begin
   ext (_ | i),
   { simp [swap_apply_of_ne_of_ne] },
-  { by_cases hx : i = x;
+  { by_cases hx : i = x,
+    simp [hx, swap_apply_of_ne_of_ne, equiv_functor.map],
     by_cases hy : i = y;
-    simp [hx, hy, swap_apply_of_ne_of_ne, equiv_functor.map] }
+    simp [hx, hy, swap_apply_of_ne_of_ne, equiv_functor.map], }
 end
 
 @[simp] lemma equiv_functor.option.sign {α : Type*} [decidable_eq α] [fintype α] (e : perm α) :

--- a/src/linear_algebra/matrix/transvection.lean
+++ b/src/linear_algebra/matrix/transvection.lean
@@ -90,7 +90,7 @@ lemma update_row_eq_transvection (c : R) :
     transvection i j c :=
 begin
   ext a b,
-  by_cases ha : i = a; by_cases hb : j = b,
+  by_cases ha : i = a, by_cases hb : j = b,
   { simp only [update_row, transvection, ha, hb, function.update_same, std_basis_matrix.apply_same,
       pi.add_apply, one_apply_eq, pi.smul_apply, mul_one, algebra.id.smul_eq_mul], },
   { simp only [update_row, transvection, ha, hb, std_basis_matrix.apply_of_ne, function.update_same,
@@ -99,9 +99,6 @@ begin
   { simp only [update_row, transvection, ha, ne.symm ha, std_basis_matrix.apply_of_ne, add_zero,
       algebra.id.smul_eq_mul, function.update_noteq, ne.def, not_false_iff, dmatrix.add_apply,
       pi.smul_apply, mul_zero, false_and] },
-  { simp only [update_row, transvection, ha, hb, ne.symm ha, std_basis_matrix.apply_of_ne, add_zero,
-      algebra.id.smul_eq_mul, function.update_noteq, ne.def, not_false_iff, and_self,
-      dmatrix.add_apply, pi.smul_apply, mul_zero] }
 end
 
 lemma transvection_mul_transvection_same (h : i ≠ j) (c d : R) :

--- a/src/linear_algebra/matrix/zpow.lean
+++ b/src/linear_algebra/matrix/zpow.lean
@@ -193,8 +193,6 @@ theorem semiconj_by.zpow_right {A X Y : M} (hx : is_unit X.det) (hy : is_unit Y.
   ∀ m : ℤ, semiconj_by A (X^m) (Y^m)
 | (n : ℕ) := by simp [h.pow_right n]
 | -[1+n]  := begin
-  by_cases ha : A = 0,
-  { simp only [ha, semiconj_by.zero_left] },
   have hx' : is_unit (X ^ n.succ).det,
   { rw det_pow,
     exact hx.pow n.succ },

--- a/src/linear_algebra/trace.lean
+++ b/src/linear_algebra/trace.lean
@@ -86,11 +86,8 @@ by { rw [trace, dif_pos this, ← trace_aux_def], congr' 1, apply trace_aux_eq }
 
 theorem trace_eq_matrix_trace (f : M →ₗ[R] M) :
   trace R M f = matrix.trace ι R R (linear_map.to_matrix b b f) :=
-if hR : nontrivial R
-then by haveI := hR;
-        rw [trace_eq_matrix_trace_of_finset R b.reindex_finset_range,
-            ← trace_aux_def, ← trace_aux_def, trace_aux_eq R b]
-else @subsingleton.elim _ (not_nontrivial_iff_subsingleton.mp hR) _ _
+by rw [trace_eq_matrix_trace_of_finset R b.reindex_finset_range,
+    ← trace_aux_def, ← trace_aux_def, trace_aux_eq R b]
 
 theorem trace_mul_comm (f g : M →ₗ[R] M) :
   trace R M (f * g) = trace R M (g * f) :=

--- a/src/measure_theory/integral/set_integral.lean
+++ b/src/measure_theory/integral/set_integral.lean
@@ -135,10 +135,6 @@ over the whole space is equal to `∫ x in s, f x ∂μ` defined as `∫ x, f x 
 lemma integral_indicator (hs : measurable_set s) :
   ∫ x, indicator s f x ∂μ = ∫ x in s, f x ∂μ :=
 begin
-  by_cases hf : ae_measurable f (μ.restrict s), swap,
-  { rw integral_non_ae_measurable hf,
-    rw [← ae_measurable_indicator_iff hs] at hf,
-    exact integral_non_ae_measurable hf },
   by_cases hfi : integrable_on f s μ, swap,
   { rwa [integral_undef, integral_undef],
     rwa integrable_indicator_iff hs },

--- a/src/number_theory/pythagorean_triples.lean
+++ b/src/number_theory/pythagorean_triples.lean
@@ -70,14 +70,10 @@ by rwa [pythagorean_triple_comm]
 /-- A triple is still a triple if you multiply `x`, `y` and `z`
 by a constant `k`. -/
 lemma mul (k : ℤ) : pythagorean_triple (k * x) (k * y) (k * z) :=
-begin
-  by_cases hk : k = 0,
-  { simp only [pythagorean_triple, hk, zero_mul, zero_add], },
-  { calc (k * x) * (k * x) + (k * y) * (k * y)
-        = k ^ 2 * (x * x + y * y) : by ring
-    ... = k ^ 2 * (z * z)         : by rw h.eq
-    ... = (k * z) * (k * z)       : by ring }
-end
+calc (k * x) * (k * x) + (k * y) * (k * y)
+      = k ^ 2 * (x * x + y * y) : by ring
+  ... = k ^ 2 * (z * z)         : by rw h.eq
+  ... = (k * z) * (k * z)       : by ring
 
 omit h
 

--- a/src/order/compactly_generated.lean
+++ b/src/order/compactly_generated.lean
@@ -79,7 +79,7 @@ begin
   { intros hk s hne hdir hsup,
     obtain ⟨t, ht⟩ := hk s hsup,
     -- certainly every element of t is below something in s, since ↑t ⊆ s.
-    have t_below_s : ∀ x ∈ t, ∃ y ∈ s, x ≤ y, from λ x hxt, ⟨x, ht.left hxt, by refl⟩,
+    have t_below_s : ∀ x ∈ t, ∃ y ∈ s, x ≤ y, from λ x hxt, ⟨x, ht.left hxt, le_rfl⟩,
     obtain ⟨x, ⟨hxs, hsupx⟩⟩ := finset.sup_le_of_le_directed s hne hdir t t_below_s,
     exact ⟨x, ⟨hxs, le_trans ht.right hsupx⟩⟩, },
   { intros hk s hsup,

--- a/src/order/compactly_generated.lean
+++ b/src/order/compactly_generated.lean
@@ -76,22 +76,12 @@ theorem is_compact_element_iff_le_of_directed_Sup_le (k : α) :
 begin
   classical,
   split,
-  { by_cases hbot : k = ⊥,
-    -- Any nonempty directed set certainly has sup above ⊥
-    { rintros _ _ ⟨x, hx⟩ _ _, use x, by simp only [hx, hbot, bot_le, and_self], },
-    { intros hk s hne hdir hsup,
-      obtain ⟨t, ht⟩ := hk s hsup,
-      -- If t were empty, its sup would be ⊥, which is not above k ≠ ⊥.
-      have tne : t.nonempty,
-      { by_contradiction n,
-        rw [finset.nonempty_iff_ne_empty, not_not] at n,
-        simp only [n, true_and, set.empty_subset, finset.coe_empty,
-          finset.sup_empty, le_bot_iff] at ht,
-        exact absurd ht hbot, },
-      -- certainly every element of t is below something in s, since ↑t ⊆ s.
-      have t_below_s : ∀ x ∈ t, ∃ y ∈ s, x ≤ y, from λ x hxt, ⟨x, ht.left hxt, by refl⟩,
-      obtain ⟨x, ⟨hxs, hsupx⟩⟩ := finset.sup_le_of_le_directed s hne hdir t t_below_s,
-      exact ⟨x, ⟨hxs, le_trans ht.right hsupx⟩⟩, }, },
+  { intros hk s hne hdir hsup,
+    obtain ⟨t, ht⟩ := hk s hsup,
+    -- certainly every element of t is below something in s, since ↑t ⊆ s.
+    have t_below_s : ∀ x ∈ t, ∃ y ∈ s, x ≤ y, from λ x hxt, ⟨x, ht.left hxt, by refl⟩,
+    obtain ⟨x, ⟨hxs, hsupx⟩⟩ := finset.sup_le_of_le_directed s hne hdir t t_below_s,
+    exact ⟨x, ⟨hxs, le_trans ht.right hsupx⟩⟩, },
   { intros hk s hsup,
     -- Consider the set of finite joins of elements of the (plain) set s.
     let S : set α := { x | ∃ t : finset α, ↑t ⊆ s ∧ x = t.sup id },

--- a/src/ring_theory/discrete_valuation_ring.lean
+++ b/src/ring_theory/discrete_valuation_ring.lean
@@ -200,8 +200,6 @@ begin
     intros a b h,
     by_cases ha : a = 0,
     { rw ha, simp only [true_or, dvd_zero], },
-    by_cases hb : b = 0,
-    { rw hb, simp only [or_true, dvd_zero], },
     obtain ⟨m, u, rfl⟩ := spec.2 ha,
     rw [mul_assoc, mul_left_comm, is_unit.dvd_mul_left _ _ _ (units.is_unit _)] at h,
     rw is_unit.dvd_mul_right (units.is_unit _),

--- a/src/ring_theory/localization.lean
+++ b/src/ring_theory/localization.lean
@@ -1934,21 +1934,17 @@ theorem is_integral_localization (H : algebra.is_integral R S) :
     : Rₘ →+* _).is_integral :=
 begin
   intro x,
-  by_cases triv : (1 : R) = 0,
-  { have : (1 : Rₘ) = 0 := by convert congr_arg (algebra_map R Rₘ) triv; simp,
-    exact ⟨0, ⟨trans leading_coeff_zero this.symm, eval₂_zero _ _⟩⟩ },
-  { haveI : nontrivial R := nontrivial_of_ne 1 0 triv,
-    obtain ⟨⟨s, ⟨u, hu⟩⟩, hx⟩ := surj (algebra.algebra_map_submonoid S M) x,
-    obtain ⟨v, hv⟩ := hu,
-    obtain ⟨v', hv'⟩ := is_unit_iff_exists_inv'.1 (map_units Rₘ ⟨v, hv.1⟩),
-    refine @is_integral_of_is_integral_mul_unit Rₘ _ _ _
-      (localization_algebra M S) x (algebra_map S Sₘ u) v' _ _,
-    { replace hv' := congr_arg (@algebra_map Rₘ Sₘ _ _ (localization_algebra M S)) hv',
-      rw [ring_hom.map_mul, ring_hom.map_one, ← ring_hom.comp_apply _ (algebra_map R Rₘ)] at hv',
-      erw is_localization.map_comp at hv',
-      exact hv.2 ▸ hv' },
-    { obtain ⟨p, hp⟩ := H s,
-      exact hx.symm ▸ is_integral_localization_at_leading_coeff p hp.2 (hp.1.symm ▸ M.one_mem) } }
+  obtain ⟨⟨s, ⟨u, hu⟩⟩, hx⟩ := surj (algebra.algebra_map_submonoid S M) x,
+  obtain ⟨v, hv⟩ := hu,
+  obtain ⟨v', hv'⟩ := is_unit_iff_exists_inv'.1 (map_units Rₘ ⟨v, hv.1⟩),
+  refine @is_integral_of_is_integral_mul_unit Rₘ _ _ _
+    (localization_algebra M S) x (algebra_map S Sₘ u) v' _ _,
+  { replace hv' := congr_arg (@algebra_map Rₘ Sₘ _ _ (localization_algebra M S)) hv',
+    rw [ring_hom.map_mul, ring_hom.map_one, ← ring_hom.comp_apply _ (algebra_map R Rₘ)] at hv',
+    erw is_localization.map_comp at hv',
+    exact hv.2 ▸ hv' },
+  { obtain ⟨p, hp⟩ := H s,
+    exact hx.symm ▸ is_integral_localization_at_leading_coeff p hp.2 (hp.1.symm ▸ M.one_mem) }
 end
 
 lemma is_integral_localization' {R S : Type*} [comm_ring R] [comm_ring S]

--- a/src/ring_theory/polynomial/content.lean
+++ b/src/ring_theory/polynomial/content.lean
@@ -451,8 +451,6 @@ end
 
 lemma degree_gcd_le_left {p : polynomial R} (hp : p ≠ 0) (q) : (gcd p q).degree ≤ p.degree :=
 begin
-  by_cases hq : q = 0,
-  { simp [hq] },
   have := nat_degree_le_iff_degree_le.mp
     (nat_degree_le_of_dvd (gcd_dvd_left p q) hp),
   rwa degree_eq_nat_degree hp

--- a/src/ring_theory/polynomial/cyclotomic.lean
+++ b/src/ring_theory/polynomial/cyclotomic.lean
@@ -166,12 +166,8 @@ end
 /-- If there is a primitive `n`-th root of unity in `K`, then `X ^ n - 1`splits. -/
 lemma X_pow_sub_one_splits {ζ : K} {n : ℕ} (h : is_primitive_root ζ n) :
   splits (ring_hom.id K) (X ^ n - C (1 : K)) :=
-begin
-  by_cases hzero : n = 0,
-  { simp only [hzero, ring_hom.map_one, splits_zero, pow_zero, sub_self] },
-  rw [splits_iff_card_roots, ← nth_roots, is_primitive_root.card_nth_roots h,
-    nat_degree_X_pow_sub_C],
-end
+by rw [splits_iff_card_roots, ← nth_roots, is_primitive_root.card_nth_roots h,
+    nat_degree_X_pow_sub_C]
 
 /-- If there is a primitive `n`-th root of unity in `K`, then
 `∏ i in nat.divisors n, cyclotomic' i K = X ^ n - 1`. -/
@@ -224,10 +220,6 @@ begin
   { use 1,
     simp only [hzero, cyclotomic'_zero, set.mem_univ, subsemiring.coe_top, eq_self_iff_true,
     coe_map_ring_hom, map_one, and_self] },
-  by_cases hone : k = 1,
-  { use X - 1,
-    simp only [hone, cyclotomic'_one K, set.mem_univ, pnat.one_coe, subsemiring.coe_top,
-    eq_self_iff_true, map_X, coe_map_ring_hom, map_one, and_self, map_sub], },
   let B : polynomial K := ∏ i in nat.proper_divisors k, cyclotomic' i K,
   have Bmo : B.monic,
   { apply monic_prod_of_monic,

--- a/src/set_theory/ordinal_arithmetic.lean
+++ b/src/set_theory/ordinal_arithmetic.lean
@@ -1556,7 +1556,7 @@ le_antisymm
 
 theorem mul_lt_omega_power {a b c : ordinal}
   (c0 : 0 < c) (ha : a < omega ^ c) (hb : b < omega) : a * b < omega ^ c :=
-if b0 : b = 0 then by simp only [b0, mul_zero, power_pos _ omega_pos] else begin
+begin
   rcases zero_or_succ_or_limit c with rfl|⟨c,rfl⟩|l,
   { exact (lt_irrefl _).elim c0 },
   { rw power_succ at ha,

--- a/src/topology/uniform_space/abstract_completion.lean
+++ b/src/topology/uniform_space/abstract_completion.lean
@@ -110,7 +110,7 @@ begin
   exact pkg.dense_inducing.extend_eq hf.continuous a
 end
 
-variables [complete_space β] [separated_space β]
+variables [complete_space β]
 
 lemma uniform_continuous_extend : uniform_continuous (pkg.extend f) :=
 begin
@@ -125,6 +125,8 @@ end
 
 lemma continuous_extend : continuous (pkg.extend f) :=
 pkg.uniform_continuous_extend.continuous
+
+variables [separated_space β]
 
 lemma extend_unique (hf : uniform_continuous f) {g : hatα → β} (hg : uniform_continuous g)
   (h : ∀ a : α, f a = g (ι a)) : pkg.extend f = g :=
@@ -263,12 +265,17 @@ open function
 protected def extend₂ (f : α → β → γ) : hatα → hatβ → γ :=
 curry $ (pkg.prod pkg').extend (uncurry f)
 
+section separated_space
 variables [separated_space γ] {f : α → β → γ}
 
 lemma extension₂_coe_coe (hf : uniform_continuous $ uncurry f) (a : α) (b : β) :
   pkg.extend₂ pkg' f (ι a) (ι' b) = f a b :=
 show (pkg.prod pkg').extend (uncurry f) ((pkg.prod pkg').coe (a, b)) = uncurry f (a, b),
   from (pkg.prod pkg').extend_coe hf _
+
+end separated_space
+
+variables {f : α → β → γ}
 
 variables [complete_space γ] (f)
 

--- a/src/topology/uniform_space/completion.lean
+++ b/src/topology/uniform_space/completion.lean
@@ -230,6 +230,7 @@ if uniform_continuous f then
 else
   λ x, f (classical.inhabited_of_nonempty $ nonempty_Cauchy_iff.1 ⟨x⟩).default
 
+section separated_space
 variables [separated_space β]
 
 lemma extend_pure_cauchy {f : α → β} (hf : uniform_continuous f) (a : α) :
@@ -238,6 +239,8 @@ begin
   rw [extend, if_pos hf],
   exact uniformly_extend_of_ind uniform_inducing_pure_cauchy dense_range_pure_cauchy hf _
 end
+
+end separated_space
 
 variables [_root_.complete_space β]
 
@@ -453,11 +456,7 @@ returns an arbitrary constant value if `f` is not uniformly continuous -/
 protected def extension (f : α → β) : completion α → β :=
 cpkg.extend f
 
-variables [separated_space β]
-
-@[simp] lemma extension_coe (hf : uniform_continuous f) (a : α) :
-  (completion.extension f) a = f a :=
-cpkg.extend_coe hf a
+section complete_space
 
 variables [complete_space β]
 
@@ -466,6 +465,14 @@ cpkg.uniform_continuous_extend
 
 lemma continuous_extension : continuous (completion.extension f) :=
 cpkg.continuous_extend
+
+end complete_space
+
+@[simp] lemma extension_coe [separated_space β] (hf : uniform_continuous f) (a : α) :
+  (completion.extension f) a = f a :=
+cpkg.extend_coe hf a
+
+variables [separated_space β] [complete_space β]
 
 lemma extension_unique (hf : uniform_continuous f) {g : completion α → β}
   (hg : uniform_continuous g) (h : ∀ a : α, f a = g (a : completion α)) :
@@ -554,11 +561,14 @@ open function
 protected def extension₂ (f : α → β → γ) : completion α → completion β → γ :=
 cpkg.extend₂ cpkg f
 
+section separated_space
 variables [separated_space γ] {f}
 
 @[simp] lemma extension₂_coe_coe (hf : uniform_continuous₂ f) (a : α) (b : β) :
   completion.extension₂ f a b = f a b :=
 cpkg.extension₂_coe_coe cpkg hf a b
+
+end separated_space
 
 variables [complete_space γ] (f)
 

--- a/src/topology/uniform_space/uniform_embedding.lean
+++ b/src/topology/uniform_space/uniform_embedding.lean
@@ -430,8 +430,6 @@ include h_f
 
 lemma uniformly_extend_spec [complete_space γ] (a : α) :
   tendsto f (comap e (𝓝 a)) (𝓝 (ψ a)) :=
-let de := (h_e.dense_inducing h_dense) in
-begin
 by simpa only [dense_inducing.extend] using tendsto_nhds_lim (uniformly_extend_exists h_e ‹_› h_f _)
 
 lemma uniform_continuous_uniformly_extend [cγ : complete_space γ] : uniform_continuous ψ :=

--- a/src/topology/uniform_space/uniform_embedding.lean
+++ b/src/topology/uniform_space/uniform_embedding.lean
@@ -432,9 +432,7 @@ lemma uniformly_extend_spec [complete_space γ] (a : α) :
   tendsto f (comap e (𝓝 a)) (𝓝 (ψ a)) :=
 let de := (h_e.dense_inducing h_dense) in
 begin
-  simp only [dense_inducing.extend],
-  exact tendsto_nhds_lim (uniformly_extend_exists h_e h_dense h_f _)
-end
+by simpa only [dense_inducing.extend] using tendsto_nhds_lim (uniformly_extend_exists h_e ‹_› h_f _)
 
 lemma uniform_continuous_uniformly_extend [cγ : complete_space γ] : uniform_continuous ψ :=
 assume d hd,

--- a/src/topology/uniform_space/uniform_embedding.lean
+++ b/src/topology/uniform_space/uniform_embedding.lean
@@ -432,12 +432,8 @@ lemma uniformly_extend_spec [complete_space γ] (a : α) :
   tendsto f (comap e (𝓝 a)) (𝓝 (ψ a)) :=
 let de := (h_e.dense_inducing h_dense) in
 begin
-  by_cases ha : a ∈ range e,
-  { rcases ha with ⟨b, rfl⟩,
-    rw [uniformly_extend_of_ind _ _ h_f, ← de.nhds_eq_comap],
-    exact h_f.continuous.tendsto _ },
-  { simp only [dense_inducing.extend, dif_neg ha],
-    exact tendsto_nhds_lim (uniformly_extend_exists h_e h_dense h_f _) }
+  simp only [dense_inducing.extend],
+  exact tendsto_nhds_lim (uniformly_extend_exists h_e h_dense h_f _)
 end
 
 lemma uniform_continuous_uniformly_extend [cγ : complete_space γ] : uniform_continuous ψ :=

--- a/src/topology/uniform_space/uniform_embedding.lean
+++ b/src/topology/uniform_space/uniform_embedding.lean
@@ -416,16 +416,6 @@ begin
     end⟩
 end
 
-variables [separated_space γ]
-
-lemma uniformly_extend_of_ind (b : β) : ψ (e b) = f b :=
-dense_inducing.extend_eq_at _ h_f.continuous.continuous_at
-
-lemma uniformly_extend_unique {g : α → γ} (hg : ∀ b, g (e b) = f b)
-  (hc : continuous g) :
-  ψ = g :=
-dense_inducing.extend_unique _ hg hc
-
 include h_f
 
 lemma uniformly_extend_spec [complete_space γ] (a : α) :
@@ -473,4 +463,17 @@ show preimage (λp:(α×α), (ψ p.1, ψ p.2)) d ∈ 𝓤 α,
   have (a, b) ∈ s, from @this (a, b) ⟨ha₁, hb₁⟩,
   hs_comp $ show (ψ x₁, ψ x₂) ∈ comp_rel s (comp_rel s s),
     from ⟨a, ha₂, ⟨b, this, hb₂⟩⟩
+
+omit h_f
+
+variables [separated_space γ]
+
+lemma uniformly_extend_of_ind (b : β) : ψ (e b) = f b :=
+dense_inducing.extend_eq_at _ h_f.continuous.continuous_at
+
+lemma uniformly_extend_unique {g : α → γ} (hg : ∀ b, g (e b) = f b)
+  (hc : continuous g) :
+  ψ = g :=
+dense_inducing.extend_unique _ hg hc
+
 end uniform_extension


### PR DESCRIPTION
Many proofs in the library do case splits but then never use the introduced assumption in one of the cases, meaning the case split can be removed and replaced with the general argument.
Its easy to either accidentally introduce these more complicated than needed arguments when writing proofs, or in some cases presumably refactors made assumptions unnecessary, we golf / simplify several of these to simplify these proofs.
Similar things happen for `split_ifs` and explicit `if ... then` proofs.

Rather remarkably the changes to `uniformly_extend_spec` make the separated space assumption unnecessary too, and removing this removes this assumption from around 10 other lemmas in the library too.

Some more random golfs were added in the review process

Found with a work in progress linter.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
