### PR TITLE
refactor(algebra/opposites): split into 2 files

### DIFF
--- a/src/algebra/big_operators/basic.lean
+++ b/src/algebra/big_operators/basic.lean
@@ -3,8 +3,8 @@ Copyright (c) 2017 Johannes Hölzl. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl
 -/
-
 import algebra.group.pi
+import algebra.ring.opposite
 import data.equiv.mul_add
 import data.finset.fold
 import data.fintype.basic

--- a/src/algebra/field/opposite.lean
+++ b/src/algebra/field/opposite.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Kenny Lau
 -/
 import algebra.field.basic
-import algebra.opposites
+import algebra.ring.opposite
 
 /-!
 # Field structure on the multiplicative opposite

--- a/src/algebra/group/opposite.lean
+++ b/src/algebra/group/opposite.lean
@@ -3,8 +3,6 @@ Copyright (c) 2018 Kenny Lau. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Kenny Lau
 -/
-import algebra.group.commute
-import algebra.ring.basic
 import data.equiv.mul_add
 
 /-!
@@ -237,11 +235,6 @@ instance [group α] : group αᵐᵒᵖ :=
 instance [comm_group α] : comm_group αᵐᵒᵖ :=
 { .. mul_opposite.group α, .. mul_opposite.comm_monoid α }
 
-instance [distrib α] : distrib αᵐᵒᵖ :=
-{ left_distrib := λ x y z, unop_injective $ add_mul (unop y) (unop z) (unop x),
-  right_distrib := λ x y z, unop_injective $ mul_add (unop z) (unop x) (unop y),
-  .. mul_opposite.has_add α, .. mul_opposite.has_mul α }
-
 instance [mul_zero_class α] : mul_zero_class αᵐᵒᵖ :=
 { zero := 0,
   mul := (*),
@@ -257,35 +250,10 @@ instance [semigroup_with_zero α] : semigroup_with_zero αᵐᵒᵖ :=
 instance [monoid_with_zero α] : monoid_with_zero αᵐᵒᵖ :=
 { .. mul_opposite.monoid α, .. mul_opposite.mul_zero_one_class α }
 
-instance [non_unital_non_assoc_semiring α] : non_unital_non_assoc_semiring αᵐᵒᵖ :=
-{ .. mul_opposite.add_comm_monoid α, .. mul_opposite.mul_zero_class α, .. mul_opposite.distrib α }
-
-instance [non_unital_semiring α] : non_unital_semiring αᵐᵒᵖ :=
-{ .. mul_opposite.semigroup_with_zero α, .. mul_opposite.non_unital_non_assoc_semiring α }
-
-instance [non_assoc_semiring α] : non_assoc_semiring αᵐᵒᵖ :=
-{ .. mul_opposite.mul_zero_one_class α, .. mul_opposite.non_unital_non_assoc_semiring α }
-
-instance [semiring α] : semiring αᵐᵒᵖ :=
-{ .. mul_opposite.non_unital_semiring α, .. mul_opposite.non_assoc_semiring α,
-  .. mul_opposite.monoid_with_zero α }
-
-instance [comm_semiring α] : comm_semiring αᵐᵒᵖ :=
-{ .. mul_opposite.semiring α, .. mul_opposite.comm_semigroup α }
-
-instance [ring α] : ring αᵐᵒᵖ :=
-{ .. mul_opposite.add_comm_group α, .. mul_opposite.monoid α, .. mul_opposite.semiring α }
-
-instance [comm_ring α] : comm_ring αᵐᵒᵖ :=
-{ .. mul_opposite.ring α, .. mul_opposite.comm_semiring α }
-
 instance [has_zero α] [has_mul α] [no_zero_divisors α] : no_zero_divisors αᵐᵒᵖ :=
 { eq_zero_or_eq_zero_of_mul_eq_zero := λ x y (H : op (_ * _) = op (0:α)),
     or.cases_on (eq_zero_or_eq_zero_of_mul_eq_zero $ op_injective H)
       (λ hy, or.inr $ unop_injective $ hy) (λ hx, or.inl $ unop_injective $ hx), }
-
-instance [ring α] [is_domain α] : is_domain αᵐᵒᵖ :=
-{ .. mul_opposite.no_zero_divisors α, .. mul_opposite.ring α, .. mul_opposite.nontrivial α }
 
 instance [group_with_zero α] : group_with_zero αᵐᵒᵖ :=
 { mul_inv_cancel := λ x hx, unop_injective $ inv_mul_cancel $ unop_injective.ne hx,
@@ -379,15 +347,6 @@ def monoid_hom.to_opposite {R S : Type*} [mul_one_class R] [mul_one_class S] (f 
   map_one' := congr_arg op f.map_one,
   map_mul' := λ x y, by simp [(hf x y).eq] }
 
-/-- A ring homomorphism `f : R →+* S` such that `f x` commutes with `f y` for all `x, y` defines
-a ring homomorphism to `Sᵐᵒᵖ`. -/
-@[simps {fully_applied := ff}]
-def ring_hom.to_opposite {R S : Type*} [semiring R] [semiring S] (f : R →+* S)
-  (hf : ∀ x y, commute (f x) (f y)) : R →+* Sᵐᵒᵖ :=
-{ to_fun := mul_opposite.op ∘ f,
-  .. ((op_add_equiv : S ≃+ Sᵐᵒᵖ).to_add_monoid_hom.comp ↑f : R →+ Sᵐᵒᵖ),
-  .. f.to_monoid_hom.to_opposite hf }
-
 /-- The units of the opposites are equivalent to the opposites of the units. -/
 def units.op_equiv {R} [monoid R] : units Rᵐᵒᵖ ≃* (units R)ᵐᵒᵖ :=
 { to_fun := λ u, op ⟨unop u, unop ↑(u⁻¹), op_injective u.4, op_injective u.3⟩,
@@ -441,20 +400,6 @@ def add_monoid_hom.op {α β} [add_zero_class α] [add_zero_class β] :
 /-- The 'unopposite' of an additive monoid hom `αᵐᵒᵖ →+ βᵐᵒᵖ`. Inverse to `add_monoid_hom.op`. -/
 @[simp] def add_monoid_hom.unop {α β} [add_zero_class α] [add_zero_class β] :
   (αᵐᵒᵖ →+ βᵐᵒᵖ) ≃ (α →+ β) := add_monoid_hom.op.symm
-
-/-- A ring hom `α →+* β` can equivalently be viewed as a ring hom `αᵐᵒᵖ →+* βᵐᵒᵖ`. This is the
-action of the (fully faithful) `ᵐᵒᵖ`-functor on morphisms. -/
-@[simps]
-def ring_hom.op {α β} [non_assoc_semiring α] [non_assoc_semiring β] :
-  (α →+* β) ≃ (αᵐᵒᵖ →+* βᵐᵒᵖ) :=
-{ to_fun    := λ f, { ..f.to_add_monoid_hom.op, ..f.to_monoid_hom.op },
-  inv_fun   := λ f, { ..f.to_add_monoid_hom.unop, ..f.to_monoid_hom.unop },
-  left_inv  := λ f, by { ext, refl },
-  right_inv := λ f, by { ext, simp } }
-
-/-- The 'unopposite' of a ring hom `αᵐᵒᵖ →+* βᵐᵒᵖ`. Inverse to `ring_hom.op`. -/
-@[simp] def ring_hom.unop {α β} [non_assoc_semiring α] [non_assoc_semiring β] :
-  (αᵐᵒᵖ →+* βᵐᵒᵖ) ≃ (α →+* β) := ring_hom.op.symm
 
 /-- A iso `α ≃+ β` can equivalently be viewed as an iso `αᵐᵒᵖ ≃+ βᵐᵒᵖ`. -/
 @[simps]

--- a/src/algebra/group/prod.lean
+++ b/src/algebra/group/prod.lean
@@ -3,7 +3,7 @@ Copyright (c) 2020 Yury Kudryashov. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Simon Hudon, Patrick Massot, Yury Kudryashov
 -/
-import algebra.opposites
+import algebra.group.opposite
 
 /-!
 # Monoid, group etc structures on `M × N`

--- a/src/algebra/hierarchy_design.lean
+++ b/src/algebra/hierarchy_design.lean
@@ -68,7 +68,7 @@ when applicable:
   instance pi.Z [∀ i, Z $ f i] : Z (Π i : I, f i) := ...
   ```
 * Instances transferred to `mul_opposite M`, like `mul_opposite.monoid`.
-  See `algebra.opposites` for more examples.
+  See `algebra.group.opposite` for more examples.
   ```
   instance mul_opposite.Z [Z M] : Z (mul_opposite M) := ...
   ```

--- a/src/algebra/quaternion.lean
+++ b/src/algebra/quaternion.lean
@@ -5,7 +5,7 @@ Authors: Yury Kudryashov
 -/
 import tactic.ring_exp
 import algebra.algebra.basic
-import algebra.opposites
+import algebra.ring.opposite
 import data.equiv.ring
 
 /-!

--- a/src/algebra/ring/opposite.lean
+++ b/src/algebra/ring/opposite.lean
@@ -1,0 +1,85 @@
+/-
+Copyright (c) 2018 Kenny Lau. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kenny Lau
+-/
+import algebra.group.commute
+import algebra.ring.basic
+import data.equiv.mul_add
+import algebra.group.opposite
+
+/-!
+# (Semi)ring structure on multiplicative opposite
+
+In this file we define `ring` and related instances on `mul_opposite α = αᵐᵒᵖ`.
+
+## Notation
+
+`αᵐᵒᵖ = mul_opposite α`
+-/
+
+universes u v
+open function
+
+namespace mul_opposite
+
+variables (α : Type u)
+
+instance [distrib α] : distrib αᵐᵒᵖ :=
+{ left_distrib := λ x y z, unop_injective $ add_mul (unop y) (unop z) (unop x),
+  right_distrib := λ x y z, unop_injective $ mul_add (unop z) (unop x) (unop y),
+  .. mul_opposite.has_add α, .. mul_opposite.has_mul α }
+
+instance [non_unital_non_assoc_semiring α] : non_unital_non_assoc_semiring αᵐᵒᵖ :=
+{ .. mul_opposite.add_comm_monoid α, .. mul_opposite.mul_zero_class α, .. mul_opposite.distrib α }
+
+instance [non_unital_semiring α] : non_unital_semiring αᵐᵒᵖ :=
+{ .. mul_opposite.semigroup_with_zero α, .. mul_opposite.non_unital_non_assoc_semiring α }
+
+instance [non_assoc_semiring α] : non_assoc_semiring αᵐᵒᵖ :=
+{ .. mul_opposite.mul_zero_one_class α, .. mul_opposite.non_unital_non_assoc_semiring α }
+
+instance [semiring α] : semiring αᵐᵒᵖ :=
+{ .. mul_opposite.non_unital_semiring α, .. mul_opposite.non_assoc_semiring α,
+  .. mul_opposite.monoid_with_zero α }
+
+instance [comm_semiring α] : comm_semiring αᵐᵒᵖ :=
+{ .. mul_opposite.semiring α, .. mul_opposite.comm_semigroup α }
+
+instance [ring α] : ring αᵐᵒᵖ :=
+{ .. mul_opposite.add_comm_group α, .. mul_opposite.monoid α, .. mul_opposite.semiring α }
+
+instance [comm_ring α] : comm_ring αᵐᵒᵖ :=
+{ .. mul_opposite.ring α, .. mul_opposite.comm_semiring α }
+
+instance [ring α] [is_domain α] : is_domain αᵐᵒᵖ :=
+{ .. mul_opposite.no_zero_divisors α, .. mul_opposite.ring α, .. mul_opposite.nontrivial α }
+
+variable {α}
+
+end mul_opposite
+
+open mul_opposite
+
+/-- A ring homomorphism `f : R →+* S` such that `f x` commutes with `f y` for all `x, y` defines
+a ring homomorphism to `Sᵐᵒᵖ`. -/
+@[simps {fully_applied := ff}]
+def ring_hom.to_opposite {R S : Type*} [semiring R] [semiring S] (f : R →+* S)
+  (hf : ∀ x y, commute (f x) (f y)) : R →+* Sᵐᵒᵖ :=
+{ to_fun := mul_opposite.op ∘ f,
+  .. ((op_add_equiv : S ≃+ Sᵐᵒᵖ).to_add_monoid_hom.comp ↑f : R →+ Sᵐᵒᵖ),
+  .. f.to_monoid_hom.to_opposite hf }
+
+/-- A ring hom `α →+* β` can equivalently be viewed as a ring hom `αᵐᵒᵖ →+* βᵐᵒᵖ`. This is the
+action of the (fully faithful) `ᵐᵒᵖ`-functor on morphisms. -/
+@[simps]
+def ring_hom.op {α β} [non_assoc_semiring α] [non_assoc_semiring β] :
+  (α →+* β) ≃ (αᵐᵒᵖ →+* βᵐᵒᵖ) :=
+{ to_fun    := λ f, { ..f.to_add_monoid_hom.op, ..f.to_monoid_hom.op },
+  inv_fun   := λ f, { ..f.to_add_monoid_hom.unop, ..f.to_monoid_hom.unop },
+  left_inv  := λ f, by { ext, refl },
+  right_inv := λ f, by { ext, simp } }
+
+/-- The 'unopposite' of a ring hom `αᵐᵒᵖ →+* βᵐᵒᵖ`. Inverse to `ring_hom.op`. -/
+@[simp] def ring_hom.unop {α β} [non_assoc_semiring α] [non_assoc_semiring β] :
+  (αᵐᵒᵖ →+* βᵐᵒᵖ) ≃ (α →+* β) := ring_hom.op.symm

--- a/src/control/fold.lean
+++ b/src/control/fold.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Simon Hudon, Sean Leather
 -/
 import algebra.free_monoid
-import algebra.opposites
+import algebra.group.opposite
 import control.traversable.instances
 import control.traversable.lemmas
 import category_theory.endomorphism

--- a/src/data/equiv/ring.lean
+++ b/src/data/equiv/ring.lean
@@ -5,7 +5,7 @@ Authors: Johannes Hölzl, Callum Sutton, Yury Kudryashov
 -/
 import data.equiv.mul_add
 import algebra.field.basic
-import algebra.opposites
+import algebra.ring.opposite
 import algebra.big_operators.basic
 
 /-!

--- a/src/group_theory/group_action/opposite.lean
+++ b/src/group_theory/group_action/opposite.lean
@@ -3,7 +3,7 @@ Copyright (c) 2020 Eric Wieser. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Eric Wieser
 -/
-import algebra.opposites
+import algebra.group.opposite
 import group_theory.group_action.defs
 
 /-!

--- a/src/ring_theory/ring_invo.lean
+++ b/src/ring_theory/ring_invo.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Andreas Swerdlow, Kenny Lau
 -/
 import data.equiv.ring
-import algebra.opposites
+import algebra.group.opposite
 
 /-!
 # Ring involutions


### PR DESCRIPTION
Split `algebra/opposites` into `algebra/group/opposite` and `algebra/ring/opposite`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
