### PR TITLE
[Merged by Bors] - feat(analysis/normed_space/spectrum and algebra/algebra/spectrum): prove properties of spectrum in a Banach algebra

### DIFF
--- a/src/algebra/algebra/spectrum.lean
+++ b/src/algebra/algebra/spectrum.lean
@@ -16,6 +16,8 @@ This theory will serve as the foundation for spectral theory in Banach algebras.
   `A` is an  `R`-algebra.
 * `spectrum a : set R`: the spectrum of an element `a : A` where
   `A` is an  `R`-algebra.
+* `resolvent : R → A`: the resolvent function is `λ r, ring.inverse (↑ₐr - a)`, and hence
+  when `r ∈ resolvent R A`, it is actually the inverse of the unit `(↑ₐr - a)`.
 
 ## Main statements
 
@@ -58,6 +60,13 @@ The spectrum is simply the complement of the resolvent set.  -/
 def spectrum (a : A) : set R :=
 (resolvent_set R a)ᶜ
 
+variable {R}
+/-- Given an `a : A` where `A` is an `R`-algebra, the *resolvent* is
+    a map `R → A` which sends `r : R` to `(algebra_map R A r - a)⁻¹` when
+    `r ∈ resolvent R A` and `0` when `r ∈ spectrum R A`. -/
+noncomputable def resolvent (a : A) (r : R) : A :=
+ring.inverse (algebra_map R A r - a)
+
 end defs
 
 
@@ -99,6 +108,10 @@ units.is_unit ⟨↑ₐr - a, b, h₁, by rwa ←left_inv_eq_right_inv h₂ h₁
 lemma mem_resolvent_set_iff {r : R} {a : A} :
   r ∈ resolvent_set R a ↔ is_unit (↑ₐr - a) :=
 iff.rfl
+
+lemma resolvent_eq {a : A} {r : R} (h : r ∈ resolvent_set R a) :
+  resolvent a r = ↑h.unit⁻¹ :=
+ring.inverse_unit h.unit
 
 lemma add_mem_iff {a : A} {r s : R} :
   r ∈ σ a ↔ r + s ∈ σ (↑ₐs + a) :=

--- a/src/algebra/algebra/spectrum.lean
+++ b/src/algebra/algebra/spectrum.lean
@@ -12,7 +12,7 @@ This theory will serve as the foundation for spectral theory in Banach algebras.
 
 ## Main definitions
 
-* `resolvent a : set R`: the resolvent set of an element `a : A` where
+* `resolvent_set a : set R`: the resolvent set of an element `a : A` where
   `A` is an  `R`-algebra.
 * `spectrum a : set R`: the spectrum of an element `a : A` where
   `A` is an  `R`-algebra.
@@ -43,10 +43,10 @@ variables [comm_ring R] [ring A] [algebra R A]
 
 -- definition and basic properties
 
-/-- Given a commutative ring `R` and an `R`-algebra `A`, the *resolvent* of `a : A`
+/-- Given a commutative ring `R` and an `R`-algebra `A`, the *resolvent set* of `a : A`
 is the `set R` consisting of those `r : R` for which `r•1 - a` is a unit of the
 algebra `A`.  -/
-def resolvent (a : A) : set R :=
+def resolvent_set (a : A) : set R :=
 { r : R | is_unit (algebra_map R A r - a) }
 
 
@@ -54,9 +54,9 @@ def resolvent (a : A) : set R :=
 is the `set R` consisting of those `r : R` for which `r•1 - a` is not a unit of the
 algebra `A`.
 
-The spectrum is simply the complement of the resolvent.  -/
+The spectrum is simply the complement of the resolvent set.  -/
 def spectrum (a : A) : set R :=
-(resolvent R a)ᶜ
+(resolvent_set R a)ᶜ
 
 end defs
 
@@ -91,20 +91,20 @@ lemma not_mem_iff {r : R} {a : A} :
   r ∉ σ a ↔ is_unit (↑ₐr - a) :=
 by { apply not_iff_not.mp, simp [set.not_not_mem, mem_iff] }
 
-lemma mem_resolvent_of_left_right_inverse {r : R} {a b c : A}
+lemma mem_resolvent_set_of_left_right_inverse {r : R} {a b c : A}
   (h₁ : (↑ₐr - a) * b = 1) (h₂ : c * (↑ₐr - a) = 1) :
-  r ∈ resolvent R a :=
+  r ∈ resolvent_set R a :=
 units.is_unit ⟨↑ₐr - a, b, h₁, by rwa ←left_inv_eq_right_inv h₂ h₁⟩
 
-lemma mem_resolvent_iff {r : R} {a : A} :
-  r ∈ resolvent R a ↔ is_unit (↑ₐr - a) :=
+lemma mem_resolvent_set_iff {r : R} {a : A} :
+  r ∈ resolvent_set R a ↔ is_unit (↑ₐr - a) :=
 iff.rfl
 
 lemma add_mem_iff {a : A} {r s : R} :
   r ∈ σ a ↔ r + s ∈ σ (↑ₐs + a) :=
 begin
   apply not_iff_not.mpr,
-  simp only [mem_resolvent_iff],
+  simp only [mem_resolvent_set_iff],
   have h_eq : ↑ₐ(r+s) - (↑ₐs + a) = ↑ₐr - a,
     { simp, noncomm_ring },
   rw h_eq,
@@ -114,7 +114,7 @@ lemma smul_mem_smul_iff {a : A} {s : R} {r : units R} :
   r • s ∈ σ (r • a) ↔ s ∈ σ a :=
 begin
   apply not_iff_not.mpr,
-  simp only [mem_resolvent_iff, algebra.algebra_map_eq_smul_one],
+  simp only [mem_resolvent_set_iff, algebra.algebra_map_eq_smul_one],
   have h_eq : (r•s)•(1 : A) = r•s•1, by simp,
   rw [h_eq,←smul_sub,is_unit_smul_iff],
 end
@@ -143,7 +143,7 @@ theorem unit_mem_mul_iff_mem_swap_mul {a b : A} {r : units R} :
   ↑r ∈ σ (a * b) ↔ ↑r ∈ σ (b * a) :=
 begin
   apply not_iff_not.mpr,
-  simp only [mem_resolvent_iff, algebra.algebra_map_eq_smul_one],
+  simp only [mem_resolvent_set_iff, algebra.algebra_map_eq_smul_one],
   have coe_smul_eq : ↑r•1 = r•(1 : A), from rfl,
   rw coe_smul_eq,
   simp only [is_unit.smul_sub_iff_sub_inv_smul],
@@ -188,7 +188,7 @@ begin
   intros k hk,
   rw set.mem_compl_singleton_iff at hk,
   have : is_unit (units.mk0 k hk • (1 : A)) := is_unit.smul (units.mk0 k hk) is_unit_one,
-  simpa [mem_resolvent_iff, algebra.algebra_map_eq_smul_one]
+  simpa [mem_resolvent_set_iff, algebra.algebra_map_eq_smul_one]
 end
 
 @[simp] theorem scalar_eq [nontrivial A] (k : 𝕜) : σ (↑ₐk) = {k} :=

--- a/src/algebra/algebra/spectrum.lean
+++ b/src/algebra/algebra/spectrum.lean
@@ -183,17 +183,12 @@ local notation `↑ₐ` := algebra_map 𝕜 A
 /-- Without the assumption `nontrivial A`, then `0 : A` would be invertible. -/
 @[simp] lemma zero_eq [nontrivial A] : σ (0 : A) = {0} :=
 begin
-  apply set.eq_of_subset_of_subset,
-  { change σ (0 : A) with (resolvent 𝕜 (0 : A))ᶜ,
-    rw set.compl_subset_comm,
-    intros k hk,
-    rw set.mem_compl_singleton_iff at hk,
-    have unit_k_one : is_unit (units.mk0 k hk • (1 : A)),
-      from is_unit.smul (units.mk0 k hk) is_unit_one,
-    rw mem_resolvent_iff,
-    simpa [algebra.algebra_map_eq_smul_one], },
-  { rw [set.singleton_subset_iff, mem_iff],
-    simp [algebra.algebra_map_eq_smul_one], },
+  refine set.subset.antisymm _ (by simp [algebra.algebra_map_eq_smul_one, mem_iff]),
+  rw [spectrum, set.compl_subset_comm],
+  intros k hk,
+  rw set.mem_compl_singleton_iff at hk,
+  have : is_unit (units.mk0 k hk • (1 : A)) := is_unit.smul (units.mk0 k hk) is_unit_one,
+  simpa [mem_resolvent_iff, algebra.algebra_map_eq_smul_one]
 end
 
 @[simp] theorem scalar_eq [nontrivial A] (k : 𝕜) : σ (↑ₐk) = {k} :=
@@ -219,14 +214,14 @@ open_locale pointwise
 theorem smul_eq_smul [nontrivial A] (k : 𝕜) (a : A) (ha : (σ a).nonempty) :
   σ (k • a) = k • (σ a) :=
 begin
-  by_cases h : k = 0,
-  { simp [h,ha,zero_smul_set], refl },
+  rcases eq_or_ne k 0 with rfl | h,
+  { simpa [ha, zero_smul_set] },
   { exact unit_smul_eq_smul a (units.mk0 k h) },
 end
 
 theorem nonzero_mul_eq_swap_mul (a b : A) : σ (a * b) \ {0} = σ (b * a) \ {0} :=
 begin
-  suffices h : ∀ (x y : A), σ (x*y) \ {0} ⊆ σ (y*x) \ {0},
+  suffices h : ∀ (x y : A), σ (x * y) \ {0} ⊆ σ (y * x) \ {0},
   { exact set.eq_of_subset_of_subset (h a b) (h b a) },
   { rintros _ _ k ⟨k_mem,k_neq⟩,
     change k with ↑(units.mk0 k k_neq) at k_mem,

--- a/src/algebra/algebra/spectrum.lean
+++ b/src/algebra/algebra/spectrum.lean
@@ -196,12 +196,17 @@ local notation `↑ₐ` := algebra_map 𝕜 A
 /-- Without the assumption `nontrivial A`, then `0 : A` would be invertible. -/
 @[simp] lemma zero_eq [nontrivial A] : σ (0 : A) = {0} :=
 begin
-  refine set.subset.antisymm _ (by simp [algebra.algebra_map_eq_smul_one, mem_iff]),
-  rw [spectrum, set.compl_subset_comm],
-  intros k hk,
-  rw set.mem_compl_singleton_iff at hk,
-  have : is_unit (units.mk0 k hk • (1 : A)) := is_unit.smul (units.mk0 k hk) is_unit_one,
-  simpa [mem_resolvent_set_iff, algebra.algebra_map_eq_smul_one]
+  apply set.eq_of_subset_of_subset,
+  { change σ (0 : A) with (resolvent 𝕜 (0 : A))ᶜ,
+    rw set.compl_subset_comm,
+    intros k hk,
+    rw set.mem_compl_singleton_iff at hk,
+    have unit_k_one : is_unit (units.mk0 k hk • (1 : A)),
+      from is_unit.smul (units.mk0 k hk) is_unit_one,
+    rw mem_resolvent_iff,
+    simpa [algebra.algebra_map_eq_smul_one], },
+  { rw [set.singleton_subset_iff, mem_iff],
+    simp [algebra.algebra_map_eq_smul_one], },
 end
 
 @[simp] theorem scalar_eq [nontrivial A] (k : 𝕜) : σ (↑ₐk) = {k} :=
@@ -227,14 +232,14 @@ open_locale pointwise
 theorem smul_eq_smul [nontrivial A] (k : 𝕜) (a : A) (ha : (σ a).nonempty) :
   σ (k • a) = k • (σ a) :=
 begin
-  rcases eq_or_ne k 0 with rfl | h,
-  { simpa [ha, zero_smul_set] },
+  by_cases h : k = 0,
+  { simp [h,ha,zero_smul_set], refl },
   { exact unit_smul_eq_smul a (units.mk0 k h) },
 end
 
 theorem nonzero_mul_eq_swap_mul (a b : A) : σ (a * b) \ {0} = σ (b * a) \ {0} :=
 begin
-  suffices h : ∀ (x y : A), σ (x * y) \ {0} ⊆ σ (y * x) \ {0},
+  suffices h : ∀ (x y : A), σ (x*y) \ {0} ⊆ σ (y*x) \ {0},
   { exact set.eq_of_subset_of_subset (h a b) (h b a) },
   { rintros _ _ k ⟨k_mem,k_neq⟩,
     change k with ↑(units.mk0 k k_neq) at k_mem,

--- a/src/algebra/algebra/spectrum.lean
+++ b/src/algebra/algebra/spectrum.lean
@@ -69,12 +69,13 @@ ring.inverse (algebra_map R A r - a)
 
 end defs
 
+variables {R : Type u} {A : Type v}
+variables [comm_ring R] [ring A] [algebra R A]
 
 -- products of scalar units and algebra units
 
 
-lemma is_unit.smul_sub_iff_sub_inv_smul {R : Type u} {A : Type v}
-  [comm_ring R] [ring A] [algebra R A] {r : units R} {a : A} :
+lemma is_unit.smul_sub_iff_sub_inv_smul {r : units R} {a : A} :
   is_unit (r • 1 - a) ↔ is_unit (1 - r⁻¹ • a) :=
 begin
   have a_eq : a = r•r⁻¹•a, by simp,
@@ -84,10 +85,6 @@ end
 
 namespace spectrum
 
-section scalar_ring
-
-variables {R : Type u} {A : Type v}
-variables [comm_ring R] [ring A] [algebra R A]
 
 local notation `σ` := spectrum R
 local notation `↑ₐ` := algebra_map R A
@@ -134,7 +131,7 @@ end
 
 open_locale pointwise
 
-theorem unit_smul_eq_smul (a : A) (r : units R) :
+theorem smul_eq_smul (a : A) (r : units R) :
   σ (r • a) = r • σ a :=
 begin
   ext,
@@ -182,70 +179,5 @@ end
 theorem preimage_units_mul_eq_swap_mul {a b : A} :
   (coe : units R → R) ⁻¹' σ (a * b) = coe ⁻¹'  σ (b * a) :=
 by { ext, exact unit_mem_mul_iff_mem_swap_mul, }
-
-end scalar_ring
-
-section scalar_field
-
-variables {𝕜 : Type u} {A : Type v}
-variables [field 𝕜] [ring A] [algebra 𝕜 A]
-
-local notation `σ` := spectrum 𝕜
-local notation `↑ₐ` := algebra_map 𝕜 A
-
-/-- Without the assumption `nontrivial A`, then `0 : A` would be invertible. -/
-@[simp] lemma zero_eq [nontrivial A] : σ (0 : A) = {0} :=
-begin
-  apply set.eq_of_subset_of_subset,
-  { change σ (0 : A) with (resolvent 𝕜 (0 : A))ᶜ,
-    rw set.compl_subset_comm,
-    intros k hk,
-    rw set.mem_compl_singleton_iff at hk,
-    have unit_k_one : is_unit (units.mk0 k hk • (1 : A)),
-      from is_unit.smul (units.mk0 k hk) is_unit_one,
-    rw mem_resolvent_iff,
-    simpa [algebra.algebra_map_eq_smul_one], },
-  { rw [set.singleton_subset_iff, mem_iff],
-    simp [algebra.algebra_map_eq_smul_one], },
-end
-
-@[simp] theorem scalar_eq [nontrivial A] (k : 𝕜) : σ (↑ₐk) = {k} :=
-begin
-  have coset_eq : left_add_coset k {0} = {k}, by
-    { ext, split,
-      { intro hx, simp [left_add_coset] at hx, exact hx, },
-      { intro hx, simp at hx, exact ⟨0,⟨set.mem_singleton 0, by simp [hx]⟩⟩, }, },
-  calc σ (↑ₐk) = σ (↑ₐk + 0)                  : by simp
-    ...        = left_add_coset k (σ (0 : A)) : by rw ←left_add_coset_eq
-    ...        = left_add_coset k {0}         : by rw zero_eq
-    ...        = {k}                          : coset_eq,
-end
-
-@[simp] lemma one_eq [nontrivial A] : σ (1 : A) = {1} :=
-calc σ (1 : A) = σ (↑ₐ1) : by simp [algebra.algebra_map_eq_smul_one]
-  ...          = {1}     : scalar_eq 1
-
-open_locale pointwise
-
-/-- the assumption (σ a).nonempty is necessary and cannot be removed without
-    further conditions on the algebra `A` and scalar field `𝕜`. -/
-theorem smul_eq_smul [nontrivial A] (k : 𝕜) (a : A) (ha : (σ a).nonempty) :
-  σ (k • a) = k • (σ a) :=
-begin
-  by_cases h : k = 0,
-  { simp [h,ha,zero_smul_set], refl },
-  { exact unit_smul_eq_smul a (units.mk0 k h) },
-end
-
-theorem nonzero_mul_eq_swap_mul (a b : A) : σ (a * b) \ {0} = σ (b * a) \ {0} :=
-begin
-  suffices h : ∀ (x y : A), σ (x*y) \ {0} ⊆ σ (y*x) \ {0},
-  { exact set.eq_of_subset_of_subset (h a b) (h b a) },
-  { rintros _ _ k ⟨k_mem,k_neq⟩,
-    change k with ↑(units.mk0 k k_neq) at k_mem,
-    exact ⟨unit_mem_mul_iff_mem_swap_mul.mp k_mem, k_neq⟩ },
-end
-
-end scalar_field
 
 end spectrum

--- a/src/analysis/normed_space/spectrum.lean
+++ b/src/analysis/normed_space/spectrum.lean
@@ -100,46 +100,16 @@ section resolvent_deriv
 variables {𝕜 : Type*} {A : Type*}
 variables [nondiscrete_normed_field 𝕜] [normed_ring A] [normed_algebra 𝕜 A] [complete_space A]
 
-local notation `σ` := spectrum 𝕜
 local notation `ρ` := resolvent_set 𝕜
 local notation `↑ₐ` := algebra_map 𝕜 A
 
-
-open asymptotics normed_ring ring
-
-theorem resolvent_has_deriv_at {a : A} {k : 𝕜} (hk : k ∈ ρ a) :
-  has_deriv_at (resolvent a) (-(resolvent a k)*(resolvent a k)) k :=
+theorem has_deriv_at_resolvent {a : A} {k : 𝕜} (hk : k ∈ ρ a) :
+  has_deriv_at (resolvent a) (-(resolvent a k) * (resolvent a k)) k :=
 begin
-  rw [has_deriv_at_iff_is_o_nhds_zero, resolvent_eq hk, is_o_iff],
-  let ku := hk.unit,
-  rcases is_O.exists_pos (inverse_add_norm_diff_second_order ku) with ⟨C,C_pos,hC⟩,
-  rw is_O_with_iff at hC,
-  intros c hc,
-  simp only [filter.eventually_iff,metric.mem_nhds_iff] at hC ⊢,
-  rcases hC with ⟨ε,ε_pos,hε⟩,
-  use min (c*C⁻¹) ε,
-  have hcC : c*C⁻¹ > 0, by nlinarith [inv_pos.mpr C_pos],
-  split,
-  { exact lt_min hcC ε_pos },
-  { intros k' hk',
-    simp only [lt_min_iff, mem_ball_zero_iff] at hk',
-    have k'_mem : ↑ₐk' ∈ metric.ball (0 : A) ε, by simp [hk'.right],
-    specialize hε k'_mem,
-    rw set.mem_set_of_eq at hε,
-    have res_add : resolvent a (k + k') = inverse (↑ₐk - a + ↑ₐk'),
-      by { apply congr_arg inverse, rw ring_hom.map_add, noncomm_ring, },
-    have k'_smul : k' • (-(↑ku⁻¹) * (↑ku⁻¹)) = -↑ku⁻¹ * ↑ₐk' * ↑ku⁻¹, by
-      by { rw [←algebra.mul_smul_comm k', algebra.smul_def'], norm_cast, noncomm_ring },
-    calc
-      ∥resolvent a (k + k') - ↑ku⁻¹ - k' • (-(↑ku⁻¹) * (↑ku⁻¹))∥
-          = ∥inverse (↑ₐk - a + ↑ₐk') - ↑ku⁻¹  + ↑ku⁻¹ * ↑ₐk' * ↑ku⁻¹∥ : by {rw [res_add,k'_smul], noncomm_ring}
-      ... = ∥inverse (↑ku + ↑ₐk') - ↑ku⁻¹  + ↑ku⁻¹ * ↑ₐk' * ↑ku⁻¹∥ : rfl
-      ... ≤ C * ∥∥↑ₐk'∥^2∥ : hε
-      ... = C * ∥k'∥ * ∥k'∥ : by rw [real.norm_of_nonneg (pow_two_nonneg _),pow_two,mul_assoc,normed_algebra.norm_algebra_map_eq]
-      ... ≤ C * ∥k'∥ * (c * C⁻¹) : mul_le_mul_of_nonneg_left (le_of_lt hk'.left) (by nlinarith [C_pos, norm_nonneg k'])
-      ... = (C * C⁻¹) * c * ∥k'∥ : by ring
-      ... = c * ∥k'∥ : by simp [mul_inv_cancel (ne_of_gt C_pos)],
-    },
+  have H₁ : has_fderiv_at ring.inverse _ (↑ₐk - a) := has_fderiv_at_ring_inverse hk.unit,
+  have H₂ : has_deriv_at (λ k, ↑ₐk - a) 1 k,
+  { simpa using (algebra.linear_map 𝕜 A).has_deriv_at.sub_const a },
+  simpa [resolvent, hk.unit_spec, ← ring.inverse_unit hk.unit] using H₁.comp_has_deriv_at k H₂,
 end
 
 end resolvent_deriv

--- a/src/analysis/normed_space/spectrum.lean
+++ b/src/analysis/normed_space/spectrum.lean
@@ -6,7 +6,7 @@ Authors: Jireh Loreaux
 import algebra.algebra.spectrum
 import analysis.calculus.deriv
 /-!
-# The spectrum of elements in complete normed algebra
+# The spectrum of elements in a complete normed algebra
 
 This file contains the basic theory for the resolvent and spectrum of a Banach algebra.
 

--- a/src/analysis/normed_space/spectrum.lean
+++ b/src/analysis/normed_space/spectrum.lean
@@ -12,7 +12,7 @@ This file contains the basic theory for the resolvent and spectrum of a Banach a
 
 ## Main definitions
 
-* `spectral_radius`: supremum of `abs k` for all `k ∈ spectrum 𝕜 a`
+* `spectral_radius : ℝ≥0∞`: supremum of `∥k∥₊` for all `k ∈ spectrum 𝕜 a`
 
 ## Main statements
 
@@ -20,8 +20,8 @@ This file contains the basic theory for the resolvent and spectrum of a Banach a
 * `is_closed`: the spectrum is closed.
 * `subset_closed_ball_norm`: the spectrum is a subset of closed disk of radius equal to the norm.
 * `is_compact`: the spectrum is compact.
-* `spectral_radius_le_norm`: the spectral radius is bounded above by the norm.
-* `resolvent_has_deriv_at`: the resolvent function is differentiable on the resolvent set.
+* `spectral_radius_le_nnnorm`: the spectral radius is bounded above by the norm.
+* `has_deriv_at_resolvent`: the resolvent function is differentiable on the resolvent set.
 
 
 ## TODO

--- a/src/analysis/normed_space/spectrum.lean
+++ b/src/analysis/normed_space/spectrum.lean
@@ -62,16 +62,10 @@ lemma mem_resolvent_of_norm_lt {a : A} {k : 𝕜} (h : ∥a∥ < ∥k∥) :
   k ∈ ρ a :=
 begin
   rw [resolvent_set,set.mem_set_of_eq,algebra.algebra_map_eq_smul_one],
-  have k_pos := lt_of_le_of_lt (norm_nonneg a) h,
-  let ku := units.mk0 k (ne_zero_of_norm_pos k_pos),
-  have lt_one :=
-    calc  ∥ku⁻¹ • a∥ = ∥↑ku⁻¹ • a∥   : rfl
-      ...            = ∥(↑ku)⁻¹ • a∥ : by rw units.coe_inv' ku
-      ...            = ∥k⁻¹∥ * ∥a∥   : norm_smul k⁻¹ a
-      ...            = ∥k∥⁻¹ * ∥a∥   : by rw normed_field.norm_inv
-      ...            < 1            : (inv_mul_lt_iff k_pos).mpr (by simp [h]),
-  have : is_unit (1 - ku⁻¹ • a), from (units.one_sub (ku⁻¹ • a) lt_one).is_unit,
-  rwa ←is_unit.smul_sub_iff_sub_inv_smul at this,
+  have hk : k ≠ 0 := ne_zero_of_norm_pos (by linarith [norm_nonneg a]),
+  let ku := units.map (↑ₐ).to_monoid_hom (units.mk0 k hk),
+  have hku : ∥-a∥ < ∥(↑ku⁻¹:A)∥⁻¹ := by simpa [ku, algebra_map_isometry] using h,
+  simpa [ku, sub_eq_add_neg, algebra.algebra_map_eq_smul_one] using (ku.add (-a) hku).is_unit,
 end
 
 lemma norm_le_norm_of_mem {a : A} {k : 𝕜} (hk : k ∈ σ a) :

--- a/src/analysis/normed_space/spectrum.lean
+++ b/src/analysis/normed_space/spectrum.lean
@@ -1,0 +1,182 @@
+/-
+Copyright (c) 2021 Jireh Loreaux. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Jireh Loreaux
+-/
+import algebra.algebra.spectrum
+import analysis.calculus.deriv
+/-!
+# The spectrum of elements in complete normed algebra
+
+This file contains the basic theory for the resolvent and spectrum of a Banach algebra.
+
+## Main definitions
+
+* `spectral_radius`: supremum of `abs k` for all `k ∈ spectrum 𝕜 a`
+
+## Main statements
+
+* `is_open_resolvent_set`: the resolvent set is open.
+* `is_closed`: the spectrum is closed.
+* `subset_closed_ball_norm`: the spectrum is a subset of closed disk of radius equal to the norm.
+* `is_compact`: the spectrum is compact.
+* `spectral_radius_le_norm`: the spectral radius is bounded above by the norm.
+* `resolvent_has_deriv_at`: the resolvent function is differentiable on the resolvent set.
+
+
+## TODO
+
+* after we have Liouville's theorem, prove that the spectrum is nonempty when the
+  scalar field is ℂ.
+* compute all derivatives of `resolvent a`.
+
+-/
+
+/-- The *spectral radius* is the supremum of the norm of elements in the spectrum.
+    The spectrum is compact, and so when it is nonempty, this supremum can be
+    achieved. Note that it is possible for `spectrum 𝕜 a = ∅`.  In this case,
+    `spectral_radius a = 0` by the definition of `Sup` on `ℝ`.-/
+noncomputable def spectral_radius (𝕜 : Type*) {A : Type*} [normed_field 𝕜] [ring A]
+  [algebra 𝕜 A] (a : A) : ℝ :=
+Sup (norm '' (spectrum 𝕜 a))
+
+
+namespace spectrum
+
+section spectrum_compact
+
+variables {𝕜 : Type*} {A : Type*}
+variables [normed_field 𝕜] [normed_ring A] [normed_algebra 𝕜 A] [complete_space A]
+
+local notation `σ` := spectrum 𝕜
+local notation `ρ` := resolvent_set 𝕜
+local notation `↑ₐ` := algebra_map 𝕜 A
+
+lemma mem_resolvent_set_of_nearby {a : A} {k k' : 𝕜} (hk : k ∈ ρ a)
+  (hkk' : ∥k' - k∥ < ∥(↑hk.unit⁻¹ : A)∥⁻¹) :
+  k' ∈ ρ a :=
+begin
+  refine (units.unit_of_nearby hk.unit (↑ₐk' - a) _).is_unit,
+  calc ∥(↑ₐk' - a) - (↑ₐk - a)∥
+       = ∥↑ₐ(k' - k)∥         : by rw [ring_hom.map_sub, sub_sub_sub_cancel_right]
+  ...  = ∥k' - k∥ * ∥(1 : A)∥ : by rw [algebra.algebra_map_eq_smul_one,norm_smul]
+  ...  = ∥k' - k∥             : by simp [normed_algebra.norm_one 𝕜 A]
+  ...  < ∥↑hk.unit⁻¹∥⁻¹       : hkk',
+end
+
+lemma is_open_resolvent_set (a : A) : is_open (ρ a) :=
+begin
+  haveI := normed_algebra.nontrivial 𝕜 A,
+  apply metric.is_open_iff.mpr,
+  intros k hk,
+  refine ⟨∥↑hk.unit⁻¹∥⁻¹, inv_pos.mpr (units.norm_pos (hk.unit⁻¹)), _⟩,
+  intros k' hk',
+  rw [metric.mem_ball, dist_eq_norm] at hk',
+  exact mem_resolvent_set_of_nearby hk hk',
+end
+
+/-- The `resolvent_set` as a term of `opens 𝕜` -/
+def open_resolvent_set (a : A) : topological_space.opens 𝕜 :=
+⟨ρ a, is_open_resolvent_set a⟩
+
+lemma is_closed (a : A) : is_closed (σ a) :=
+is_open.is_closed_compl (is_open_resolvent_set a)
+
+lemma mem_resolvent_of_norm_lt {a : A} {k : 𝕜} (h : ∥a∥ < ∥k∥) :
+  k ∈ ρ a :=
+begin
+  rw [resolvent_set,set.mem_set_of_eq,algebra.algebra_map_eq_smul_one],
+  have k_pos := lt_of_le_of_lt (norm_nonneg a) h,
+  let ku := units.mk0 k (ne_zero_of_norm_pos k_pos),
+  have lt_one :=
+    calc  ∥ku⁻¹ • a∥ = ∥↑ku⁻¹ • a∥   : rfl
+      ...            = ∥(↑ku)⁻¹ • a∥ : by rw units.coe_inv' ku
+      ...            = ∥k⁻¹∥ * ∥a∥   : norm_smul k⁻¹ a
+      ...            = ∥k∥⁻¹ * ∥a∥   : by rw normed_field.norm_inv
+      ...            < 1            : (inv_mul_lt_iff k_pos).mpr (by simp [h]),
+  have : is_unit (1 - ku⁻¹ • a), from (units.one_sub (ku⁻¹ • a) lt_one).is_unit,
+  rwa ←is_unit.smul_sub_iff_sub_inv_smul at this,
+end
+
+lemma norm_le_norm_of_mem {a : A} {k : 𝕜} (hk : k ∈ σ a) :
+  ∥k∥ ≤ ∥a∥ :=
+le_of_not_lt (not_imp_not.mpr mem_resolvent_of_norm_lt hk)
+
+lemma subset_closed_ball_norm (a : A) :
+  σ a ⊆ metric.closed_ball (0 : 𝕜) (∥a∥) :=
+λ k hk, by simp [norm_le_norm_of_mem hk]
+
+lemma is_bounded (a : A) : metric.bounded (σ a) :=
+(metric.bounded_iff_subset_ball 0).mpr ⟨∥a∥,subset_closed_ball_norm a⟩
+
+theorem is_compact [proper_space 𝕜] (a : A) : is_compact (σ a) :=
+metric.is_compact_of_is_closed_bounded (is_closed a) (is_bounded a)
+
+-- this lemma is actually true without the assumption `(σ a).nonempty`,
+-- but it would require a `by_cases` split, and it's only for the slightly
+-- silly reason that `Sup (∅ : set ℝ)` is defeq `0`.
+theorem spectral_radius_le_norm (a : A) (ha : (σ a).nonempty) :
+  spectral_radius 𝕜 a ≤ ∥a∥ :=
+begin
+  have ha' : (norm '' (σ a)).nonempty, from
+    ⟨∥ha.some∥,⟨ha.some,set.nonempty.some_mem ha,rfl⟩⟩,
+  have norm_up_bd : ∥a∥ ∈ upper_bounds (norm '' (σ a)), by
+    { apply mem_upper_bounds.mpr,
+      rintros k ⟨k,⟨k_mem,k_eq⟩⟩,
+      subst k_eq,
+      exact norm_le_norm_of_mem k_mem },
+  exact (real.is_lub_Sup (norm '' (σ a)) ha' ⟨∥a∥,norm_up_bd⟩).right norm_up_bd,
+end
+
+end spectrum_compact
+
+section resolvent_deriv
+
+variables {𝕜 : Type*} {A : Type*}
+variables [nondiscrete_normed_field 𝕜] [normed_ring A] [normed_algebra 𝕜 A] [complete_space A]
+
+local notation `σ` := spectrum 𝕜
+local notation `ρ` := resolvent_set 𝕜
+local notation `↑ₐ` := algebra_map 𝕜 A
+
+
+open asymptotics normed_ring ring
+
+theorem resolvent_has_deriv_at {a : A} {k : 𝕜} (hk : k ∈ ρ a) :
+  has_deriv_at (resolvent a) (-(resolvent a k)*(resolvent a k)) k :=
+begin
+  rw [has_deriv_at_iff_is_o_nhds_zero, resolvent_eq hk, is_o_iff],
+  let ku := hk.unit,
+  rcases is_O.exists_pos (inverse_add_norm_diff_second_order ku) with ⟨C,C_pos,hC⟩,
+  rw is_O_with_iff at hC,
+  intros c hc,
+  simp only [filter.eventually_iff,metric.mem_nhds_iff] at hC ⊢,
+  rcases hC with ⟨ε,ε_pos,hε⟩,
+  use min (c*C⁻¹) ε,
+  have hcC : c*C⁻¹ > 0, by nlinarith [inv_pos.mpr C_pos],
+  split,
+  { exact lt_min hcC ε_pos },
+  { intros k' hk',
+    simp only [lt_min_iff, mem_ball_zero_iff] at hk',
+    have k'_mem : ↑ₐk' ∈ metric.ball (0 : A) ε, by simp [hk'.right],
+    specialize hε k'_mem,
+    rw set.mem_set_of_eq at hε,
+    have res_add : resolvent a (k + k') = inverse (↑ₐk - a + ↑ₐk'),
+      by { apply congr_arg inverse, rw ring_hom.map_add, noncomm_ring, },
+    have k'_smul : k' • (-(↑ku⁻¹) * (↑ku⁻¹)) = -↑ku⁻¹ * ↑ₐk' * ↑ku⁻¹, by
+      by { rw [←algebra.mul_smul_comm k', algebra.smul_def'], norm_cast, noncomm_ring },
+    calc
+      ∥resolvent a (k + k') - ↑ku⁻¹ - k' • (-(↑ku⁻¹) * (↑ku⁻¹))∥
+          = ∥inverse (↑ₐk - a + ↑ₐk') - ↑ku⁻¹  + ↑ku⁻¹ * ↑ₐk' * ↑ku⁻¹∥ : by {rw [res_add,k'_smul], noncomm_ring}
+      ... = ∥inverse (↑ku + ↑ₐk') - ↑ku⁻¹  + ↑ku⁻¹ * ↑ₐk' * ↑ku⁻¹∥ : rfl
+      ... ≤ C * ∥∥↑ₐk'∥^2∥ : hε
+      ... = C * ∥k'∥ * ∥k'∥ : by rw [real.norm_of_nonneg (pow_two_nonneg _),pow_two,mul_assoc,normed_algebra.norm_algebra_map_eq]
+      ... ≤ C * ∥k'∥ * (c * C⁻¹) : mul_le_mul_of_nonneg_left (le_of_lt hk'.left) (by nlinarith [C_pos, norm_nonneg k'])
+      ... = (C * C⁻¹) * c * ∥k'∥ : by ring
+      ... = c * ∥k'∥ : by simp [mul_inv_cancel (ne_of_gt C_pos)],
+    },
+end
+
+end resolvent_deriv
+
+end spectrum

--- a/src/analysis/normed_space/spectrum.lean
+++ b/src/analysis/normed_space/spectrum.lean
@@ -16,12 +16,12 @@ This file contains the basic theory for the resolvent and spectrum of a Banach a
 
 ## Main statements
 
-* `is_open_resolvent_set`: the resolvent set is open.
-* `is_closed`: the spectrum is closed.
-* `subset_closed_ball_norm`: the spectrum is a subset of closed disk of radius equal to the norm.
-* `is_compact`: the spectrum is compact.
-* `spectral_radius_le_nnnorm`: the spectral radius is bounded above by the norm.
-* `has_deriv_at_resolvent`: the resolvent function is differentiable on the resolvent set.
+* `spectrum.is_open_resolvent_set`: the resolvent set is open.
+* `spectrum.is_closed`: the spectrum is closed.
+* `spectrum.subset_closed_ball_norm`: the spectrum is a subset of closed disk of radius equal to the norm.
+* `spectrum.is_compact`: the spectrum is compact.
+* `spectrum.spectral_radius_le_nnnorm`: the spectral radius is bounded above by the norm.
+* `spectrum.has_deriv_at_resolvent`: the resolvent function is differentiable on the resolvent set.
 
 
 ## TODO

--- a/src/analysis/normed_space/spectrum.lean
+++ b/src/analysis/normed_space/spectrum.lean
@@ -32,14 +32,14 @@ This file contains the basic theory for the resolvent and spectrum of a Banach a
 
 -/
 
-/-- The *spectral radius* is the supremum of the norm of elements in the spectrum.
-    The spectrum is compact, and so when it is nonempty, this supremum can be
-    achieved. Note that it is possible for `spectrum 𝕜 a = ∅`.  In this case,
-    `spectral_radius a = 0` by the definition of `Sup` on `ℝ`.-/
-noncomputable def spectral_radius (𝕜 : Type*) {A : Type*} [normed_field 𝕜] [ring A]
-  [algebra 𝕜 A] (a : A) : ℝ :=
-Sup (norm '' (spectrum 𝕜 a))
+open_locale ennreal
 
+/-- The *spectral radius* is the supremum of the `nnnorm` (`∥⬝∥₊`) of elements in the spectrum,
+    coerced into an element of `ℝ≥0∞` so that it lives in a `complete_lattice`. Note that it
+    is possible for `spectrum 𝕜 a = ∅`. In this case, `spectral_radius a = 0`-/
+noncomputable def spectral_radius (𝕜 : Type*) {A : Type*} [normed_field 𝕜] [ring A]
+  [algebra 𝕜 A] (a : A) : ℝ≥0∞ :=
+⨆ k ∈ spectrum 𝕜 a, ∥k∥₊
 
 namespace spectrum
 
@@ -107,25 +107,20 @@ lemma subset_closed_ball_norm (a : A) :
 λ k hk, by simp [norm_le_norm_of_mem hk]
 
 lemma is_bounded (a : A) : metric.bounded (σ a) :=
-(metric.bounded_iff_subset_ball 0).mpr ⟨∥a∥,subset_closed_ball_norm a⟩
+(metric.bounded_iff_subset_ball 0).mpr ⟨∥a∥, subset_closed_ball_norm a⟩
 
 theorem is_compact [proper_space 𝕜] (a : A) : is_compact (σ a) :=
 metric.is_compact_of_is_closed_bounded (is_closed a) (is_bounded a)
 
--- this lemma is actually true without the assumption `(σ a).nonempty`,
--- but it would require a `by_cases` split, and it's only for the slightly
--- silly reason that `Sup (∅ : set ℝ)` is defeq `0`.
-theorem spectral_radius_le_norm (a : A) (ha : (σ a).nonempty) :
-  spectral_radius 𝕜 a ≤ ∥a∥ :=
+theorem spectral_radius_le_nnnorm (a : A) :
+  spectral_radius 𝕜 a ≤ ∥a∥₊ :=
 begin
-  have ha' : (norm '' (σ a)).nonempty, from
-    ⟨∥ha.some∥,⟨ha.some,set.nonempty.some_mem ha,rfl⟩⟩,
-  have norm_up_bd : ∥a∥ ∈ upper_bounds (norm '' (σ a)), by
-    { apply mem_upper_bounds.mpr,
-      rintros k ⟨k,⟨k_mem,k_eq⟩⟩,
-      subst k_eq,
-      exact norm_le_norm_of_mem k_mem },
-  exact (real.is_lub_Sup (norm '' (σ a)) ha' ⟨∥a∥,norm_up_bd⟩).right norm_up_bd,
+  suffices h : ∀ (k : 𝕜) (hk : k ∈ σ a), (∥k∥₊ : ℝ≥0∞) ≤ ∥a∥₊,
+  { exact bsupr_le h, },
+  { by_cases ha : (σ a).nonempty,
+    { intros _ hk, exact_mod_cast norm_le_norm_of_mem hk },
+    { rw set.not_nonempty_iff_eq_empty at ha,
+      simp [ha, set.ball_empty_iff] } }
 end
 
 end spectrum_compact

--- a/src/analysis/normed_space/spectrum.lean
+++ b/src/analysis/normed_space/spectrum.lean
@@ -18,7 +18,8 @@ This file contains the basic theory for the resolvent and spectrum of a Banach a
 
 * `spectrum.is_open_resolvent_set`: the resolvent set is open.
 * `spectrum.is_closed`: the spectrum is closed.
-* `spectrum.subset_closed_ball_norm`: the spectrum is a subset of closed disk of radius equal to the norm.
+* `spectrum.subset_closed_ball_norm`: the spectrum is a subset of closed disk of radius
+  equal to the norm.
 * `spectrum.is_compact`: the spectrum is compact.
 * `spectrum.spectral_radius_le_nnnorm`: the spectral radius is bounded above by the norm.
 * `spectrum.has_deriv_at_resolvent`: the resolvent function is differentiable on the resolvent set.

--- a/src/analysis/normed_space/spectrum.lean
+++ b/src/analysis/normed_space/spectrum.lean
@@ -52,32 +52,8 @@ local notation `σ` := spectrum 𝕜
 local notation `ρ` := resolvent_set 𝕜
 local notation `↑ₐ` := algebra_map 𝕜 A
 
-lemma mem_resolvent_set_of_nearby {a : A} {k k' : 𝕜} (hk : k ∈ ρ a)
-  (hkk' : ∥k' - k∥ < ∥(↑hk.unit⁻¹ : A)∥⁻¹) :
-  k' ∈ ρ a :=
-begin
-  refine (units.unit_of_nearby hk.unit (↑ₐk' - a) _).is_unit,
-  calc ∥(↑ₐk' - a) - (↑ₐk - a)∥
-       = ∥↑ₐ(k' - k)∥         : by rw [ring_hom.map_sub, sub_sub_sub_cancel_right]
-  ...  = ∥k' - k∥ * ∥(1 : A)∥ : by rw [algebra.algebra_map_eq_smul_one,norm_smul]
-  ...  = ∥k' - k∥             : by simp [normed_algebra.norm_one 𝕜 A]
-  ...  < ∥↑hk.unit⁻¹∥⁻¹       : hkk',
-end
-
 lemma is_open_resolvent_set (a : A) : is_open (ρ a) :=
-begin
-  haveI := normed_algebra.nontrivial 𝕜 A,
-  apply metric.is_open_iff.mpr,
-  intros k hk,
-  refine ⟨∥↑hk.unit⁻¹∥⁻¹, inv_pos.mpr (units.norm_pos (hk.unit⁻¹)), _⟩,
-  intros k' hk',
-  rw [metric.mem_ball, dist_eq_norm] at hk',
-  exact mem_resolvent_set_of_nearby hk hk',
-end
-
-/-- The `resolvent_set` as a term of `opens 𝕜` -/
-def open_resolvent_set (a : A) : topological_space.opens 𝕜 :=
-⟨ρ a, is_open_resolvent_set a⟩
+units.is_open.preimage ((algebra_map_isometry 𝕜 A).continuous.sub continuous_const)
 
 lemma is_closed (a : A) : is_closed (σ a) :=
 is_open.is_closed_compl (is_open_resolvent_set a)

--- a/src/analysis/normed_space/spectrum.lean
+++ b/src/analysis/normed_space/spectrum.lean
@@ -35,8 +35,10 @@ This file contains the basic theory for the resolvent and spectrum of a Banach a
 open_locale ennreal
 
 /-- The *spectral radius* is the supremum of the `nnnorm` (`∥⬝∥₊`) of elements in the spectrum,
-    coerced into an element of `ℝ≥0∞` so that it lives in a `complete_lattice`. Note that it
-    is possible for `spectrum 𝕜 a = ∅`. In this case, `spectral_radius a = 0`-/
+    coerced into an element of `ℝ≥0∞`. Note that it is possible for `spectrum 𝕜 a = ∅`. In this
+    case, `spectral_radius a = 0`.  It is also possible that `spectrum 𝕜 a` be unbounded (though
+    not for Banach algebras, see `spectrum.is_bounded`, below).  In this case,
+    `spectral_radius a = ∞`. -/
 noncomputable def spectral_radius (𝕜 : Type*) {A : Type*} [normed_field 𝕜] [ring A]
   [algebra 𝕜 A] (a : A) : ℝ≥0∞ :=
 ⨆ k ∈ spectrum 𝕜 a, ∥k∥₊
@@ -61,7 +63,7 @@ lemma is_closed (a : A) : is_closed (σ a) :=
 lemma mem_resolvent_of_norm_lt {a : A} {k : 𝕜} (h : ∥a∥ < ∥k∥) :
   k ∈ ρ a :=
 begin
-  rw [resolvent_set,set.mem_set_of_eq,algebra.algebra_map_eq_smul_one],
+  rw [resolvent_set, set.mem_set_of_eq, algebra.algebra_map_eq_smul_one],
   have hk : k ≠ 0 := ne_zero_of_norm_pos (by linarith [norm_nonneg a]),
   let ku := units.map (↑ₐ).to_monoid_hom (units.mk0 k hk),
   have hku : ∥-a∥ < ∥(↑ku⁻¹:A)∥⁻¹ := by simpa [ku, algebra_map_isometry] using h,
@@ -70,7 +72,7 @@ end
 
 lemma norm_le_norm_of_mem {a : A} {k : 𝕜} (hk : k ∈ σ a) :
   ∥k∥ ≤ ∥a∥ :=
-le_of_not_lt (not_imp_not.mpr mem_resolvent_of_norm_lt hk)
+le_of_not_lt $ mt mem_resolvent_of_norm_lt hk
 
 lemma subset_closed_ball_norm (a : A) :
   σ a ⊆ metric.closed_ball (0 : 𝕜) (∥a∥) :=
@@ -85,10 +87,11 @@ metric.is_compact_of_is_closed_bounded (is_closed a) (is_bounded a)
 theorem spectral_radius_le_nnnorm (a : A) :
   spectral_radius 𝕜 a ≤ ∥a∥₊ :=
 begin
-  suffices h : ∀ (k : 𝕜) (hk : k ∈ σ a), (∥k∥₊ : ℝ≥0∞) ≤ ∥a∥₊,
+  suffices h : ∀ k ∈ σ a, (∥k∥₊ : ℝ≥0∞) ≤ ∥a∥₊,
   { exact bsupr_le h, },
   { by_cases ha : (σ a).nonempty,
-    { intros _ hk, exact_mod_cast norm_le_norm_of_mem hk },
+    { intros _ hk,
+      exact_mod_cast norm_le_norm_of_mem hk },
     { rw set.not_nonempty_iff_eq_empty at ha,
       simp [ha, set.ball_empty_iff] } }
 end

--- a/src/analysis/normed_space/spectrum.lean
+++ b/src/analysis/normed_space/spectrum.lean
@@ -107,12 +107,12 @@ local notation `ρ` := resolvent_set 𝕜
 local notation `↑ₐ` := algebra_map 𝕜 A
 
 theorem has_deriv_at_resolvent {a : A} {k : 𝕜} (hk : k ∈ ρ a) :
-  has_deriv_at (resolvent a) (-(resolvent a k) * (resolvent a k)) k :=
+  has_deriv_at (resolvent a) (-(resolvent a k) ^ 2) k :=
 begin
   have H₁ : has_fderiv_at ring.inverse _ (↑ₐk - a) := has_fderiv_at_ring_inverse hk.unit,
   have H₂ : has_deriv_at (λ k, ↑ₐk - a) 1 k,
   { simpa using (algebra.linear_map 𝕜 A).has_deriv_at.sub_const a },
-  simpa [resolvent, hk.unit_spec, ← ring.inverse_unit hk.unit] using H₁.comp_has_deriv_at k H₂,
+  simpa [resolvent, sq, hk.unit_spec, ← ring.inverse_unit hk.unit] using H₁.comp_has_deriv_at k H₂,
 end
 
 end resolvent_deriv

--- a/src/analysis/normed_space/spectrum.lean
+++ b/src/analysis/normed_space/spectrum.lean
@@ -56,7 +56,7 @@ lemma is_open_resolvent_set (a : A) : is_open (ρ a) :=
 units.is_open.preimage ((algebra_map_isometry 𝕜 A).continuous.sub continuous_const)
 
 lemma is_closed (a : A) : is_closed (σ a) :=
-is_open.is_closed_compl (is_open_resolvent_set a)
+(is_open_resolvent_set a).is_closed_compl
 
 lemma mem_resolvent_of_norm_lt {a : A} {k : 𝕜} (h : ∥a∥ < ∥k∥) :
   k ∈ ρ a :=


### PR DESCRIPTION
Prove that the `spectrum` of an element in a Banach algebra is closed and bounded, hence compact when the scalar field is                               
proper. Compute the derivative of the `resolvent a` function in preparation for showing that the spectrum is nonempty when  the base field is ℂ. Define the `spectral_radius` and prove that it is bounded by the norm. Also rename the resolvent set to `resolvent_set` instead of `resolvent` so that it doesn't clash with the function name.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
