### PR TITLE
[Merged by Bors] - refactor(algebra/group/basic): Migrate `add_group` section into `group` section

### DIFF
--- a/src/algebra/group/basic.lean
+++ b/src/algebra/group/basic.lean
@@ -164,11 +164,13 @@ lemma mul_one_div (x y : G) :
   x * (1 / y) = x / y :=
 by rw [div_eq_mul_inv, one_mul, div_eq_mul_inv]
 
-lemma mul_div_assoc {a b c : G} : a * b / c = a * (b / c) :=
+@[to_additive]
+lemma mul_div_assoc (a b c : G) : a * b / c = a * (b / c) :=
 by rw [div_eq_mul_inv, div_eq_mul_inv, mul_assoc _ _ _]
 
+@[to_additive]
 lemma mul_div_assoc' (a b c : G) : a * (b / c) = (a * b) / c :=
-mul_div_assoc.symm
+(mul_div_assoc _ _ _).symm
 
 @[simp, to_additive] lemma one_div (a : G) : 1 / a = a⁻¹ :=
 (inv_eq_one_div a).symm
@@ -358,9 +360,6 @@ section add_group
 -- TODO: Generalize the contents of this section with to_additive as per
 -- https://leanprover.zulipchat.com/#narrow/stream/144837-PR-reviews/topic/.238667
 variables {G : Type u} [add_group G] {a b c d : G}
-
-lemma add_sub_assoc (a b c : G) : a + b - c = a + (b - c) :=
-by rw [sub_eq_add_neg, add_assoc, ←sub_eq_add_neg]
 
 lemma eq_of_sub_eq_zero (h : a - b = 0) : a = b :=
 calc a = a - b + b : (sub_add_cancel a b).symm

--- a/src/algebra/group/basic.lean
+++ b/src/algebra/group/basic.lean
@@ -423,6 +423,10 @@ by rw [div_eq_mul_inv, mul_inv_eq_iff_eq_mul]
 @[to_additive] theorem eq_iff_eq_of_div_eq_div (H : a / b = c / d) : a = b ↔ c = d :=
 by rw [← div_eq_one, H, div_eq_one]
 
+@[to_additive]
+theorem left_inverse_div_mul_left (c : G) : function.left_inverse (λ x, x / c) (λ x, x * c) :=
+assume x, mul_div_cancel'' x c
+
 end group
 
 section add_group
@@ -431,9 +435,6 @@ section add_group
 variables {G : Type u} [add_group G] {a b c d : G}
 
 local attribute [simp] add_assoc
-
-theorem left_inverse_sub_add_left (c : G) : function.left_inverse (λ x, x - c) (λ x, x + c) :=
-assume x, add_sub_cancel x c
 
 theorem left_inverse_add_left_sub (c : G) : function.left_inverse (λ x, x + c) (λ x, x - c) :=
 assume x, sub_add_cancel x c

--- a/src/algebra/group/basic.lean
+++ b/src/algebra/group/basic.lean
@@ -178,7 +178,7 @@ lemma mul_div_assoc' (a b c : G) : a * (b / c) = (a * b) / c :=
 end div_inv_monoid
 
 section group
-variables {G : Type u} [group G] {a b c : G}
+variables {G : Type u} [group G] {a b c d : G}
 
 @[simp, to_additive]
 lemma inv_mul_cancel_right (a b : G) : a * b⁻¹ * b = a :=
@@ -420,6 +420,9 @@ by rw [div_eq_mul_inv, eq_mul_inv_iff_mul_eq]
 @[to_additive] theorem div_eq_iff_eq_mul : a / b = c ↔ a = c * b :=
 by rw [div_eq_mul_inv, mul_inv_eq_iff_eq_mul]
 
+@[to_additive] theorem eq_iff_eq_of_div_eq_div (H : a / b = c / d) : a = b ↔ c = d :=
+by rw [← div_eq_one, H, div_eq_one]
+
 end group
 
 section add_group
@@ -428,9 +431,6 @@ section add_group
 variables {G : Type u} [add_group G] {a b c d : G}
 
 local attribute [simp] add_assoc
-
-theorem eq_iff_eq_of_sub_eq_sub (H : a - b = c - d) : a = b ↔ c = d :=
-by rw [← sub_eq_zero, H, sub_eq_zero]
 
 theorem left_inverse_sub_add_left (c : G) : function.left_inverse (λ x, x - c) (λ x, x + c) :=
 assume x, add_sub_cancel x c

--- a/src/algebra/group/basic.lean
+++ b/src/algebra/group/basic.lean
@@ -364,6 +364,11 @@ mt eq_of_div_eq_one' h
 @[simp, to_additive] lemma div_inv_eq_mul (a b : G) : a / (b⁻¹) = a * b :=
 by rw [div_eq_mul_inv, inv_inv]
 
+local attribute [simp] mul_assoc
+
+@[to_additive] lemma mul_div (a b c : G) : a * (b / c) = a * b / c :=
+by simp only [mul_assoc, div_eq_mul_inv]
+
 end group
 
 section add_group
@@ -372,9 +377,6 @@ section add_group
 variables {G : Type u} [add_group G] {a b c d : G}
 
 local attribute [simp] add_assoc
-
-lemma add_sub (a b c : G) : a + (b - c) = a + b - c :=
-by simp
 
 lemma sub_add_eq_sub_sub_swap (a b c : G) : a - (b + c) = a - c - b :=
 by simp

--- a/src/algebra/group/basic.lean
+++ b/src/algebra/group/basic.lean
@@ -405,6 +405,9 @@ by simp only [mul_assoc, mul_inv_rev, inv_inv, div_eq_mul_inv]
 @[to_additive] theorem div_eq_one : a / b = 1 ↔ a = b :=
 ⟨eq_of_div_eq_one', λ h, by rw [h, div_self']⟩
 
+alias div_eq_one ↔ _ div_eq_one_of_eq
+alias sub_eq_zero ↔ _ sub_eq_zero_of_eq
+
 end group
 
 section add_group
@@ -413,8 +416,6 @@ section add_group
 variables {G : Type u} [add_group G] {a b c d : G}
 
 local attribute [simp] add_assoc
-
-alias sub_eq_zero ↔ _ sub_eq_zero_of_eq
 
 theorem sub_ne_zero : a - b ≠ 0 ↔ a ≠ b :=
 not_congr sub_eq_zero

--- a/src/algebra/group/basic.lean
+++ b/src/algebra/group/basic.lean
@@ -393,6 +393,9 @@ div_right_injective.eq_iff
 @[simp, to_additive] lemma div_left_inj : b / a = c / a ↔ b = c :=
 by { rw [div_eq_mul_inv, div_eq_mul_inv], exact mul_left_inj _ }
 
+@[to_additive sub_add_sub_cancel] lemma div_mul_div_cancel' (a b c : G) : (a / b) * (b / c) = a / c
+:= by rw [← mul_div_assoc, div_mul_cancel']
+
 end group
 
 section add_group
@@ -401,9 +404,6 @@ section add_group
 variables {G : Type u} [add_group G] {a b c d : G}
 
 local attribute [simp] add_assoc
-
-@[simp] lemma sub_add_sub_cancel (a b c : G) : (a - b) + (b - c) = a - c :=
-by rw [← add_sub_assoc, sub_add_cancel]
 
 @[simp] lemma sub_sub_sub_cancel_right (a b c : G) : (a - c) - (b - c) = a - b :=
 by rw [← neg_sub c b, sub_neg_eq_add, sub_add_sub_cancel]

--- a/src/algebra/group/basic.lean
+++ b/src/algebra/group/basic.lean
@@ -436,6 +436,11 @@ theorem left_inverse_mul_right_inv_mul (c : G) :
   function.left_inverse (λ x, c * x) (λ x, c⁻¹ * x) :=
 assume x, mul_inv_cancel_left c x
 
+@[to_additive]
+theorem left_inverse_inv_mul_mul_right (c : G) :
+  function.left_inverse (λ x, c⁻¹ * x) (λ x, c * x) :=
+assume x, inv_mul_cancel_left c x
+
 end group
 
 section add_group
@@ -444,10 +449,6 @@ section add_group
 variables {G : Type u} [add_group G] {a b c d : G}
 
 local attribute [simp] add_assoc
-
-theorem left_inverse_neg_add_add_right (c : G) :
-  function.left_inverse (λ x, - c + x) (λ x, c + x) :=
-assume x, neg_add_cancel_left c x
 
 end add_group
 

--- a/src/algebra/group/basic.lean
+++ b/src/algebra/group/basic.lean
@@ -358,15 +358,15 @@ by rw [div_eq_mul_inv, mul_inv_cancel_right a b]
 calc a = a / b * b : (div_mul_cancel' a b).symm
    ... = b         : by rw [h, one_mul]
 
+@[to_additive] lemma div_ne_one_of_ne (h : a ≠ b) : a / b ≠ 1 :=
+mt eq_of_div_eq_one' h
+
 end group
 
 section add_group
 -- TODO: Generalize the contents of this section with to_additive as per
 -- https://leanprover.zulipchat.com/#narrow/stream/144837-PR-reviews/topic/.238667
 variables {G : Type u} [add_group G] {a b c d : G}
-
-lemma sub_ne_zero_of_ne (h : a ≠ b) : a - b ≠ 0 :=
-mt eq_of_sub_eq_zero h
 
 @[simp] lemma sub_neg_eq_add (a b : G) : a - (-b) = a + b :=
 by rw [sub_eq_add_neg, neg_neg]

--- a/src/algebra/group/basic.lean
+++ b/src/algebra/group/basic.lean
@@ -348,58 +348,75 @@ inv_eq_of_mul_eq_one ( by rw [div_eq_mul_inv, div_eq_mul_inv, mul_assoc, inv_mul
 lemma div_mul_cancel' (a b : G) : a / b * b = a :=
 by rw [div_eq_mul_inv, inv_mul_cancel_right a b]
 
-@[simp, to_additive sub_self] lemma div_self' (a : G) : a / a = 1 :=
+@[simp, to_additive sub_self]
+lemma div_self' (a : G) : a / a = 1 :=
 by rw [div_eq_mul_inv, mul_right_inv a]
 
-@[simp, to_additive add_sub_cancel] lemma mul_div_cancel'' (a b : G) : a * b / b = a :=
+@[simp, to_additive add_sub_cancel]
+lemma mul_div_cancel'' (a b : G) : a * b / b = a :=
 by rw [div_eq_mul_inv, mul_inv_cancel_right a b]
 
-@[to_additive eq_of_sub_eq_zero] lemma eq_of_div_eq_one' (h : a / b = 1) : a = b :=
+@[to_additive eq_of_sub_eq_zero]
+lemma eq_of_div_eq_one' (h : a / b = 1) : a = b :=
 calc a = a / b * b : (div_mul_cancel' a b).symm
    ... = b         : by rw [h, one_mul]
 
-@[to_additive] lemma div_ne_one_of_ne (h : a ≠ b) : a / b ≠ 1 :=
+@[to_additive]
+lemma div_ne_one_of_ne (h : a ≠ b) : a / b ≠ 1 :=
 mt eq_of_div_eq_one' h
 
-@[simp, to_additive] lemma div_inv_eq_mul (a b : G) : a / (b⁻¹) = a * b :=
+@[simp, to_additive]
+lemma div_inv_eq_mul (a b : G) : a / (b⁻¹) = a * b :=
 by rw [div_eq_mul_inv, inv_inv]
 
 local attribute [simp] mul_assoc
 
-@[to_additive] lemma mul_div (a b c : G) : a * (b / c) = a * b / c :=
+@[to_additive]
+lemma mul_div (a b c : G) : a * (b / c) = a * b / c :=
 by simp only [mul_assoc, div_eq_mul_inv]
 
-@[to_additive] lemma div_mul_eq_div_div_swap (a b c : G) : a / (b * c) = a / c / b :=
+@[to_additive]
+lemma div_mul_eq_div_div_swap (a b c : G) : a / (b * c) = a / c / b :=
 by simp only [mul_assoc, mul_inv_rev , div_eq_mul_inv]
 
-@[simp, to_additive] lemma mul_div_mul_right_eq_div (a b c : G) : (a * c) / (b * c) = a / b :=
+@[simp, to_additive]
+lemma mul_div_mul_right_eq_div (a b c : G) : (a * c) / (b * c) = a / b :=
 by rw [div_mul_eq_div_div_swap]; simp only [mul_left_inj, eq_self_iff_true, mul_div_cancel'']
 
-@[to_additive eq_sub_of_add_eq] lemma eq_div_of_mul_eq' (h : a * c = b) : a = b / c :=
+@[to_additive eq_sub_of_add_eq]
+lemma eq_div_of_mul_eq' (h : a * c = b) : a = b / c :=
 by simp [← h]
 
-@[to_additive sub_eq_of_eq_add] lemma div_eq_of_eq_mul'' (h : a = c * b) : a / b = c :=
+@[to_additive sub_eq_of_eq_add]
+lemma div_eq_of_eq_mul'' (h : a = c * b) : a / b = c :=
 by simp [h]
 
-@[to_additive] lemma eq_mul_of_div_eq (h : a / c = b) : a = b * c :=
+@[to_additive]
+lemma eq_mul_of_div_eq (h : a / c = b) : a = b * c :=
 by simp [← h]
 
-@[to_additive] lemma mul_eq_of_eq_div (h : a = c / b) : a * b = c :=
+@[to_additive]
+lemma mul_eq_of_eq_div (h : a = c / b) : a * b = c :=
 by simp [h]
 
-@[simp, to_additive] lemma div_right_inj : a / b = a / c ↔ b = c :=
+@[simp, to_additive]
+lemma div_right_inj : a / b = a / c ↔ b = c :=
 div_right_injective.eq_iff
 
-@[simp, to_additive] lemma div_left_inj : b / a = c / a ↔ b = c :=
+@[simp, to_additive]
+lemma div_left_inj : b / a = c / a ↔ b = c :=
 by { rw [div_eq_mul_inv, div_eq_mul_inv], exact mul_left_inj _ }
 
-@[to_additive sub_add_sub_cancel] lemma div_mul_div_cancel' (a b c : G) : (a / b) * (b / c) = a / c
-:= by rw [← mul_div_assoc, div_mul_cancel']
+@[to_additive sub_add_sub_cancel]
+lemma div_mul_div_cancel' (a b c : G) : (a / b) * (b / c) = a / c :=
+by rw [← mul_div_assoc, div_mul_cancel']
 
-@[to_additive sub_sub_sub_cancel_right] lemma div_div_div_cancel_right' (a b c : G) :
-(a / c) / (b / c) = a / b := by rw [← inv_div' c b, div_inv_eq_mul, div_mul_div_cancel']
+@[to_additive sub_sub_sub_cancel_right]
+lemma div_div_div_cancel_right' (a b c : G) : (a / c) / (b / c) = a / b :=
+by rw [← inv_div' c b, div_inv_eq_mul, div_mul_div_cancel']
 
-@[to_additive] theorem div_div_assoc_swap : a / (b / c) = a * c / b :=
+@[to_additive]
+theorem div_div_assoc_swap : a / (b / c) = a * c / b :=
 by simp only [mul_assoc, mul_inv_rev, inv_inv, div_eq_mul_inv]
 
 @[to_additive] theorem div_eq_one : a / b = 1 ↔ a = b :=
@@ -408,19 +425,24 @@ by simp only [mul_assoc, mul_inv_rev, inv_inv, div_eq_mul_inv]
 alias div_eq_one ↔ _ div_eq_one_of_eq
 alias sub_eq_zero ↔ _ sub_eq_zero_of_eq
 
-@[to_additive] theorem div_ne_one : a / b ≠ 1 ↔ a ≠ b :=
+@[to_additive]
+theorem div_ne_one : a / b ≠ 1 ↔ a ≠ b :=
 not_congr div_eq_one
 
-@[simp, to_additive] theorem div_eq_self : a / b = a ↔ b = 1 :=
+@[simp, to_additive]
+theorem div_eq_self : a / b = a ↔ b = 1 :=
 by rw [div_eq_mul_inv, mul_right_eq_self, inv_eq_one]
 
-@[to_additive eq_sub_iff_add_eq] theorem eq_div_iff_mul_eq' : a = b / c ↔ a * c = b :=
+@[to_additive eq_sub_iff_add_eq]
+theorem eq_div_iff_mul_eq' : a = b / c ↔ a * c = b :=
 by rw [div_eq_mul_inv, eq_mul_inv_iff_mul_eq]
 
-@[to_additive] theorem div_eq_iff_eq_mul : a / b = c ↔ a = c * b :=
+@[to_additive]
+theorem div_eq_iff_eq_mul : a / b = c ↔ a = c * b :=
 by rw [div_eq_mul_inv, mul_inv_eq_iff_eq_mul]
 
-@[to_additive] theorem eq_iff_eq_of_div_eq_div (H : a / b = c / d) : a = b ↔ c = d :=
+@[to_additive]
+theorem eq_iff_eq_of_div_eq_div (H : a / b = c / d) : a = b ↔ c = d :=
 by rw [← div_eq_one, H, div_eq_one]
 
 @[to_additive]

--- a/src/algebra/group/basic.lean
+++ b/src/algebra/group/basic.lean
@@ -417,6 +417,9 @@ by rw [div_eq_mul_inv, mul_right_eq_self, inv_eq_one]
 @[to_additive eq_sub_iff_add_eq] theorem eq_div_iff_mul_eq' : a = b / c ↔ a * c = b :=
 by rw [div_eq_mul_inv, eq_mul_inv_iff_mul_eq]
 
+@[to_additive] theorem div_eq_iff_eq_mul : a / b = c ↔ a = c * b :=
+by rw [div_eq_mul_inv, mul_inv_eq_iff_eq_mul]
+
 end group
 
 section add_group
@@ -425,9 +428,6 @@ section add_group
 variables {G : Type u} [add_group G] {a b c d : G}
 
 local attribute [simp] add_assoc
-
-theorem sub_eq_iff_eq_add : a - b = c ↔ a = c + b :=
-by rw [sub_eq_add_neg, add_neg_eq_iff_eq_add]
 
 theorem eq_iff_eq_of_sub_eq_sub (H : a - b = c - d) : a = b ↔ c = d :=
 by rw [← sub_eq_zero, H, sub_eq_zero]

--- a/src/algebra/group/basic.lean
+++ b/src/algebra/group/basic.lean
@@ -407,11 +407,11 @@ div_right_injective.eq_iff
 lemma div_left_inj : b / a = c / a ↔ b = c :=
 by { rw [div_eq_mul_inv, div_eq_mul_inv], exact mul_left_inj _ }
 
-@[to_additive sub_add_sub_cancel]
+@[simp, to_additive sub_add_sub_cancel]
 lemma div_mul_div_cancel' (a b c : G) : (a / b) * (b / c) = a / c :=
 by rw [← mul_div_assoc, div_mul_cancel']
 
-@[to_additive sub_sub_sub_cancel_right]
+@[simp, to_additive sub_sub_sub_cancel_right]
 lemma div_div_div_cancel_right' (a b c : G) : (a / c) / (b / c) = a / b :=
 by rw [← inv_div' c b, div_inv_eq_mul, div_mul_div_cancel']
 
@@ -419,7 +419,8 @@ by rw [← inv_div' c b, div_inv_eq_mul, div_mul_div_cancel']
 theorem div_div_assoc_swap : a / (b / c) = a * c / b :=
 by simp only [mul_assoc, mul_inv_rev, inv_inv, div_eq_mul_inv]
 
-@[to_additive] theorem div_eq_one : a / b = 1 ↔ a = b :=
+@[to_additive]
+theorem div_eq_one : a / b = 1 ↔ a = b :=
 ⟨eq_of_div_eq_one', λ h, by rw [h, div_self']⟩
 
 alias div_eq_one ↔ _ div_eq_one_of_eq

--- a/src/algebra/group/basic.lean
+++ b/src/algebra/group/basic.lean
@@ -375,6 +375,9 @@ by simp only [mul_assoc, mul_inv_rev , div_eq_mul_inv]
 @[simp, to_additive] lemma mul_div_mul_right_eq_div (a b c : G) : (a * c) / (b * c) = a / b :=
 by rw [div_mul_eq_div_div_swap]; simp only [mul_left_inj, eq_self_iff_true, mul_div_cancel'']
 
+@[to_additive eq_sub_of_add_eq] lemma eq_div_of_mul_eq' (h : a * c = b) : a = b / c :=
+by simp [← h]
+
 end group
 
 section add_group
@@ -383,9 +386,6 @@ section add_group
 variables {G : Type u} [add_group G] {a b c d : G}
 
 local attribute [simp] add_assoc
-
-lemma eq_sub_of_add_eq (h : a + c = b) : a = b - c :=
-by simp [← h]
 
 lemma sub_eq_of_eq_add (h : a = c + b) : a - b = c :=
 by simp [h]

--- a/src/algebra/group/basic.lean
+++ b/src/algebra/group/basic.lean
@@ -402,6 +402,9 @@ by { rw [div_eq_mul_inv, div_eq_mul_inv], exact mul_left_inj _ }
 @[to_additive] theorem div_div_assoc_swap : a / (b / c) = a * c / b :=
 by simp only [mul_assoc, mul_inv_rev, inv_inv, div_eq_mul_inv]
 
+@[to_additive] theorem div_eq_one : a / b = 1 ↔ a = b :=
+⟨eq_of_div_eq_one', λ h, by rw [h, div_self']⟩
+
 end group
 
 section add_group
@@ -410,9 +413,6 @@ section add_group
 variables {G : Type u} [add_group G] {a b c d : G}
 
 local attribute [simp] add_assoc
-
-theorem sub_eq_zero : a - b = 0 ↔ a = b :=
-⟨eq_of_sub_eq_zero, λ h, by rw [h, sub_self]⟩
 
 alias sub_eq_zero ↔ _ sub_eq_zero_of_eq
 

--- a/src/algebra/group/basic.lean
+++ b/src/algebra/group/basic.lean
@@ -346,15 +346,14 @@ inv_eq_of_mul_eq_one ( by rw [div_eq_mul_inv, div_eq_mul_inv, mul_assoc, inv_mul
 lemma div_mul_cancel' (a b : G) : a / b * b = a :=
 by rw [div_eq_mul_inv, inv_mul_cancel_right a b]
 
+@[simp, to_additive sub_self] lemma div_self' (a : G) : a / a = 1 :=
+by rw [div_eq_mul_inv, mul_right_inv a]
 end group
 
 section add_group
 -- TODO: Generalize the contents of this section with to_additive as per
 -- https://leanprover.zulipchat.com/#narrow/stream/144837-PR-reviews/topic/.238667
 variables {G : Type u} [add_group G] {a b c d : G}
-
-@[simp] lemma sub_self (a : G) : a - a = 0 :=
-by rw [sub_eq_add_neg, add_right_neg a]
 
 @[simp] lemma add_sub_cancel (a b : G) : a + b - b = a :=
 by rw [sub_eq_add_neg, add_neg_cancel_right a b]

--- a/src/algebra/group/basic.lean
+++ b/src/algebra/group/basic.lean
@@ -396,6 +396,9 @@ by { rw [div_eq_mul_inv, div_eq_mul_inv], exact mul_left_inj _ }
 @[to_additive sub_add_sub_cancel] lemma div_mul_div_cancel' (a b c : G) : (a / b) * (b / c) = a / c
 := by rw [← mul_div_assoc, div_mul_cancel']
 
+@[to_additive sub_sub_sub_cancel_right] lemma div_div_div_cancel_right' (a b c : G) :
+(a / c) / (b / c) = a / b := by rw [← inv_div' c b, div_inv_eq_mul, div_mul_div_cancel']
+
 end group
 
 section add_group
@@ -404,9 +407,6 @@ section add_group
 variables {G : Type u} [add_group G] {a b c d : G}
 
 local attribute [simp] add_assoc
-
-@[simp] lemma sub_sub_sub_cancel_right (a b c : G) : (a - c) - (b - c) = a - b :=
-by rw [← neg_sub c b, sub_neg_eq_add, sub_add_sub_cancel]
 
 theorem sub_sub_assoc_swap : a - (b - c) = a + c - b :=
 by simp

--- a/src/algebra/group/basic.lean
+++ b/src/algebra/group/basic.lean
@@ -361,15 +361,15 @@ calc a = a / b * b : (div_mul_cancel' a b).symm
 @[to_additive] lemma div_ne_one_of_ne (h : a ≠ b) : a / b ≠ 1 :=
 mt eq_of_div_eq_one' h
 
+@[simp, to_additive] lemma div_inv_eq_mul (a b : G) : a / (b⁻¹) = a * b :=
+by rw [div_eq_mul_inv, inv_inv]
+
 end group
 
 section add_group
 -- TODO: Generalize the contents of this section with to_additive as per
 -- https://leanprover.zulipchat.com/#narrow/stream/144837-PR-reviews/topic/.238667
 variables {G : Type u} [add_group G] {a b c d : G}
-
-@[simp] lemma sub_neg_eq_add (a b : G) : a - (-b) = a + b :=
-by rw [sub_eq_add_neg, neg_neg]
 
 local attribute [simp] add_assoc
 

--- a/src/algebra/group/basic.lean
+++ b/src/algebra/group/basic.lean
@@ -372,6 +372,9 @@ by simp only [mul_assoc, div_eq_mul_inv]
 @[to_additive] lemma div_mul_eq_div_div_swap (a b c : G) : a / (b * c) = a / c / b :=
 by simp only [mul_assoc, mul_inv_rev , div_eq_mul_inv]
 
+@[simp, to_additive] lemma mul_div_mul_right_eq_div (a b c : G) : (a * c) / (b * c) = a / b :=
+by rw [div_mul_eq_div_div_swap]; simp only [mul_left_inj, eq_self_iff_true, mul_div_cancel'']
+
 end group
 
 section add_group
@@ -380,9 +383,6 @@ section add_group
 variables {G : Type u} [add_group G] {a b c d : G}
 
 local attribute [simp] add_assoc
-
-@[simp] lemma add_sub_add_right_eq_sub (a b c : G) : (a + c) - (b + c) = a - b :=
-by rw [sub_add_eq_sub_sub_swap]; simp
 
 lemma eq_sub_of_add_eq (h : a + c = b) : a = b - c :=
 by simp [← h]

--- a/src/algebra/group/basic.lean
+++ b/src/algebra/group/basic.lean
@@ -387,6 +387,9 @@ by simp [← h]
 @[to_additive] lemma mul_eq_of_eq_div (h : a = c / b) : a * b = c :=
 by simp [h]
 
+@[simp, to_additive] lemma div_right_inj : a / b = a / c ↔ b = c :=
+div_right_injective.eq_iff
+
 end group
 
 section add_group
@@ -395,9 +398,6 @@ section add_group
 variables {G : Type u} [add_group G] {a b c d : G}
 
 local attribute [simp] add_assoc
-
-@[simp] lemma sub_right_inj : a - b = a - c ↔ b = c :=
-sub_right_injective.eq_iff
 
 @[simp] lemma sub_left_inj : b - a = c - a ↔ b = c :=
 by { rw [sub_eq_add_neg, sub_eq_add_neg], exact add_left_inj _ }

--- a/src/algebra/group/basic.lean
+++ b/src/algebra/group/basic.lean
@@ -348,15 +348,16 @@ by rw [div_eq_mul_inv, inv_mul_cancel_right a b]
 
 @[simp, to_additive sub_self] lemma div_self' (a : G) : a / a = 1 :=
 by rw [div_eq_mul_inv, mul_right_inv a]
+
+@[simp, to_additive add_sub_cancel] lemma mul_div_cancel'' (a b : G) : a * b / b = a :=
+by rw [div_eq_mul_inv, mul_inv_cancel_right a b]
+
 end group
 
 section add_group
 -- TODO: Generalize the contents of this section with to_additive as per
 -- https://leanprover.zulipchat.com/#narrow/stream/144837-PR-reviews/topic/.238667
 variables {G : Type u} [add_group G] {a b c d : G}
-
-@[simp] lemma add_sub_cancel (a b : G) : a + b - b = a :=
-by rw [sub_eq_add_neg, add_neg_cancel_right a b]
 
 lemma add_sub_assoc (a b c : G) : a + b - c = a + (b - c) :=
 by rw [sub_eq_add_neg, add_assoc, ←sub_eq_add_neg]

--- a/src/algebra/group/basic.lean
+++ b/src/algebra/group/basic.lean
@@ -390,6 +390,9 @@ by simp [h]
 @[simp, to_additive] lemma div_right_inj : a / b = a / c ↔ b = c :=
 div_right_injective.eq_iff
 
+@[simp, to_additive] lemma div_left_inj : b / a = c / a ↔ b = c :=
+by { rw [div_eq_mul_inv, div_eq_mul_inv], exact mul_left_inj _ }
+
 end group
 
 section add_group
@@ -398,9 +401,6 @@ section add_group
 variables {G : Type u} [add_group G] {a b c d : G}
 
 local attribute [simp] add_assoc
-
-@[simp] lemma sub_left_inj : b - a = c - a ↔ b = c :=
-by { rw [sub_eq_add_neg, sub_eq_add_neg], exact add_left_inj _ }
 
 @[simp] lemma sub_add_sub_cancel (a b c : G) : (a - b) + (b - c) = a - c :=
 by rw [← add_sub_assoc, sub_add_cancel]

--- a/src/algebra/group/basic.lean
+++ b/src/algebra/group/basic.lean
@@ -378,6 +378,9 @@ by rw [div_mul_eq_div_div_swap]; simp only [mul_left_inj, eq_self_iff_true, mul_
 @[to_additive eq_sub_of_add_eq] lemma eq_div_of_mul_eq' (h : a * c = b) : a = b / c :=
 by simp [← h]
 
+@[to_additive sub_eq_of_eq_add] lemma div_eq_of_eq_mul'' (h : a = c * b) : a / b = c :=
+by simp [h]
+
 end group
 
 section add_group
@@ -386,9 +389,6 @@ section add_group
 variables {G : Type u} [add_group G] {a b c d : G}
 
 local attribute [simp] add_assoc
-
-lemma sub_eq_of_eq_add (h : a = c + b) : a - b = c :=
-by simp [h]
 
 lemma eq_add_of_sub_eq (h : a - c = b) : a = b + c :=
 by simp [← h]

--- a/src/algebra/group/basic.lean
+++ b/src/algebra/group/basic.lean
@@ -384,6 +384,9 @@ by simp [h]
 @[to_additive] lemma eq_mul_of_div_eq (h : a / c = b) : a = b * c :=
 by simp [← h]
 
+@[to_additive] lemma mul_eq_of_eq_div (h : a = c / b) : a * b = c :=
+by simp [h]
+
 end group
 
 section add_group
@@ -392,9 +395,6 @@ section add_group
 variables {G : Type u} [add_group G] {a b c d : G}
 
 local attribute [simp] add_assoc
-
-lemma add_eq_of_eq_sub (h : a = c - b) : a + b = c :=
-by simp [h]
 
 @[simp] lemma sub_right_inj : a - b = a - c ↔ b = c :=
 sub_right_injective.eq_iff

--- a/src/algebra/group/basic.lean
+++ b/src/algebra/group/basic.lean
@@ -411,6 +411,9 @@ alias sub_eq_zero ↔ _ sub_eq_zero_of_eq
 @[to_additive] theorem div_ne_one : a / b ≠ 1 ↔ a ≠ b :=
 not_congr div_eq_one
 
+@[simp, to_additive] theorem div_eq_self : a / b = a ↔ b = 1 :=
+by rw [div_eq_mul_inv, mul_right_eq_self, inv_eq_one]
+
 end group
 
 section add_group
@@ -419,9 +422,6 @@ section add_group
 variables {G : Type u} [add_group G] {a b c d : G}
 
 local attribute [simp] add_assoc
-
-@[simp] theorem sub_eq_self : a - b = a ↔ b = 0 :=
-by rw [sub_eq_add_neg, add_right_eq_self, neg_eq_zero]
 
 theorem eq_sub_iff_add_eq : a = b - c ↔ a + c = b :=
 by rw [sub_eq_add_neg, eq_add_neg_iff_add_eq]

--- a/src/algebra/group/basic.lean
+++ b/src/algebra/group/basic.lean
@@ -408,6 +408,9 @@ by simp only [mul_assoc, mul_inv_rev, inv_inv, div_eq_mul_inv]
 alias div_eq_one ↔ _ div_eq_one_of_eq
 alias sub_eq_zero ↔ _ sub_eq_zero_of_eq
 
+@[to_additive] theorem div_ne_one : a / b ≠ 1 ↔ a ≠ b :=
+not_congr div_eq_one
+
 end group
 
 section add_group
@@ -416,9 +419,6 @@ section add_group
 variables {G : Type u} [add_group G] {a b c d : G}
 
 local attribute [simp] add_assoc
-
-theorem sub_ne_zero : a - b ≠ 0 ↔ a ≠ b :=
-not_congr sub_eq_zero
 
 @[simp] theorem sub_eq_self : a - b = a ↔ b = 0 :=
 by rw [sub_eq_add_neg, add_right_eq_self, neg_eq_zero]

--- a/src/algebra/group/basic.lean
+++ b/src/algebra/group/basic.lean
@@ -414,6 +414,9 @@ not_congr div_eq_one
 @[simp, to_additive] theorem div_eq_self : a / b = a ↔ b = 1 :=
 by rw [div_eq_mul_inv, mul_right_eq_self, inv_eq_one]
 
+@[to_additive eq_sub_iff_add_eq] theorem eq_div_iff_mul_eq' : a = b / c ↔ a * c = b :=
+by rw [div_eq_mul_inv, eq_mul_inv_iff_mul_eq]
+
 end group
 
 section add_group
@@ -422,9 +425,6 @@ section add_group
 variables {G : Type u} [add_group G] {a b c d : G}
 
 local attribute [simp] add_assoc
-
-theorem eq_sub_iff_add_eq : a = b - c ↔ a + c = b :=
-by rw [sub_eq_add_neg, eq_add_neg_iff_add_eq]
 
 theorem sub_eq_iff_eq_add : a - b = c ↔ a = c + b :=
 by rw [sub_eq_add_neg, add_neg_eq_iff_eq_add]

--- a/src/algebra/group/basic.lean
+++ b/src/algebra/group/basic.lean
@@ -381,6 +381,9 @@ by simp [← h]
 @[to_additive sub_eq_of_eq_add] lemma div_eq_of_eq_mul'' (h : a = c * b) : a / b = c :=
 by simp [h]
 
+@[to_additive] lemma eq_mul_of_div_eq (h : a / c = b) : a = b * c :=
+by simp [← h]
+
 end group
 
 section add_group
@@ -389,9 +392,6 @@ section add_group
 variables {G : Type u} [add_group G] {a b c d : G}
 
 local attribute [simp] add_assoc
-
-lemma eq_add_of_sub_eq (h : a - c = b) : a = b + c :=
-by simp [← h]
 
 lemma add_eq_of_eq_sub (h : a = c - b) : a + b = c :=
 by simp [h]

--- a/src/algebra/group/basic.lean
+++ b/src/algebra/group/basic.lean
@@ -427,6 +427,10 @@ by rw [← div_eq_one, H, div_eq_one]
 theorem left_inverse_div_mul_left (c : G) : function.left_inverse (λ x, x / c) (λ x, x * c) :=
 assume x, mul_div_cancel'' x c
 
+@[to_additive]
+theorem left_inverse_mul_left_div (c : G) : function.left_inverse (λ x, x * c) (λ x, x / c) :=
+assume x, div_mul_cancel' x c
+
 end group
 
 section add_group
@@ -435,9 +439,6 @@ section add_group
 variables {G : Type u} [add_group G] {a b c d : G}
 
 local attribute [simp] add_assoc
-
-theorem left_inverse_add_left_sub (c : G) : function.left_inverse (λ x, x + c) (λ x, x - c) :=
-assume x, sub_add_cancel x c
 
 theorem left_inverse_add_right_neg_add (c : G) :
   function.left_inverse (λ x, c + x) (λ x, - c + x) :=

--- a/src/algebra/group/basic.lean
+++ b/src/algebra/group/basic.lean
@@ -443,15 +443,6 @@ assume x, inv_mul_cancel_left c x
 
 end group
 
-section add_group
--- TODO: Generalize the contents of this section with to_additive as per
--- https://leanprover.zulipchat.com/#narrow/stream/144837-PR-reviews/topic/.238667
-variables {G : Type u} [add_group G] {a b c d : G}
-
-local attribute [simp] add_assoc
-
-end add_group
-
 section comm_group
 variables {G : Type u} [comm_group G]
 

--- a/src/algebra/group/basic.lean
+++ b/src/algebra/group/basic.lean
@@ -354,16 +354,16 @@ by rw [div_eq_mul_inv, mul_right_inv a]
 @[simp, to_additive add_sub_cancel] lemma mul_div_cancel'' (a b : G) : a * b / b = a :=
 by rw [div_eq_mul_inv, mul_inv_cancel_right a b]
 
+@[to_additive eq_of_sub_eq_zero] lemma eq_of_div_eq_one' (h : a / b = 1) : a = b :=
+calc a = a / b * b : (div_mul_cancel' a b).symm
+   ... = b         : by rw [h, one_mul]
+
 end group
 
 section add_group
 -- TODO: Generalize the contents of this section with to_additive as per
 -- https://leanprover.zulipchat.com/#narrow/stream/144837-PR-reviews/topic/.238667
 variables {G : Type u} [add_group G] {a b c d : G}
-
-lemma eq_of_sub_eq_zero (h : a - b = 0) : a = b :=
-calc a = a - b + b : (sub_add_cancel a b).symm
-   ... = b         : by rw [h, zero_add]
 
 lemma sub_ne_zero_of_ne (h : a ≠ b) : a - b ≠ 0 :=
 mt eq_of_sub_eq_zero h

--- a/src/algebra/group/basic.lean
+++ b/src/algebra/group/basic.lean
@@ -369,6 +369,9 @@ local attribute [simp] mul_assoc
 @[to_additive] lemma mul_div (a b c : G) : a * (b / c) = a * b / c :=
 by simp only [mul_assoc, div_eq_mul_inv]
 
+@[to_additive] lemma div_mul_eq_div_div_swap (a b c : G) : a / (b * c) = a / c / b :=
+by simp only [mul_assoc, mul_inv_rev , div_eq_mul_inv]
+
 end group
 
 section add_group
@@ -377,9 +380,6 @@ section add_group
 variables {G : Type u} [add_group G] {a b c d : G}
 
 local attribute [simp] add_assoc
-
-lemma sub_add_eq_sub_sub_swap (a b c : G) : a - (b + c) = a - c - b :=
-by simp
 
 @[simp] lemma add_sub_add_right_eq_sub (a b c : G) : (a + c) - (b + c) = a - b :=
 by rw [sub_add_eq_sub_sub_swap]; simp

--- a/src/algebra/group/basic.lean
+++ b/src/algebra/group/basic.lean
@@ -399,6 +399,9 @@ by { rw [div_eq_mul_inv, div_eq_mul_inv], exact mul_left_inj _ }
 @[to_additive sub_sub_sub_cancel_right] lemma div_div_div_cancel_right' (a b c : G) :
 (a / c) / (b / c) = a / b := by rw [← inv_div' c b, div_inv_eq_mul, div_mul_div_cancel']
 
+@[to_additive] theorem div_div_assoc_swap : a / (b / c) = a * c / b :=
+by simp only [mul_assoc, mul_inv_rev, inv_inv, div_eq_mul_inv]
+
 end group
 
 section add_group
@@ -407,9 +410,6 @@ section add_group
 variables {G : Type u} [add_group G] {a b c d : G}
 
 local attribute [simp] add_assoc
-
-theorem sub_sub_assoc_swap : a - (b - c) = a + c - b :=
-by simp
 
 theorem sub_eq_zero : a - b = 0 ↔ a = b :=
 ⟨eq_of_sub_eq_zero, λ h, by rw [h, sub_self]⟩

--- a/src/algebra/group/basic.lean
+++ b/src/algebra/group/basic.lean
@@ -431,6 +431,11 @@ assume x, mul_div_cancel'' x c
 theorem left_inverse_mul_left_div (c : G) : function.left_inverse (λ x, x * c) (λ x, x / c) :=
 assume x, div_mul_cancel' x c
 
+@[to_additive]
+theorem left_inverse_mul_right_inv_mul (c : G) :
+  function.left_inverse (λ x, c * x) (λ x, c⁻¹ * x) :=
+assume x, mul_inv_cancel_left c x
+
 end group
 
 section add_group
@@ -439,10 +444,6 @@ section add_group
 variables {G : Type u} [add_group G] {a b c d : G}
 
 local attribute [simp] add_assoc
-
-theorem left_inverse_add_right_neg_add (c : G) :
-  function.left_inverse (λ x, c + x) (λ x, - c + x) :=
-assume x, add_neg_cancel_left c x
 
 theorem left_inverse_neg_add_add_right (c : G) :
   function.left_inverse (λ x, - c + x) (λ x, c + x) :=


### PR DESCRIPTION

---
Currently mathlib has a rich set of lemmas connecting the addition, subtraction and negation additive group operations, but a far thinner collection of results for multiplication, division and inverse multiplicative group operations, despite the fact that the former can be generated easily from the latter via `to_additive`.

This PR refactors the additive results in the `add_group` section as the equivalent multiplicative results in the `group` section and then recovers the additive results via `to_additive`. There is a complication in that unfortunately the multiplicative forms of the names of some of the `add_group` lemmas collide with existing names in `group_with_zero`. I have worked around this by appending an apostrophe to the name and then manually overriding the names generated by to_additive. In a couple of cases, a name with an appended apostrophe already existed. In these cases I have appended a double apostrophe.

[Previous discussion](https://leanprover.zulipchat.com/#narrow/stream/144837-PR-reviews/topic/.238667)

The `add_comm_group` section can be tackled in a subsequent PR.

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
