### PR TITLE
[Merged by Bors] - feat(data/nat/prime): add coprime_of_prime lemmas

### DIFF
--- a/src/data/nat/prime.lean
+++ b/src/data/nat/prime.lean
@@ -589,12 +589,9 @@ by rw [pp.dvd_iff_not_coprime]; apply em
 lemma coprime_of_lt_prime {n p} (n_pos : 0 < n) (hlt : n < p) (pp : prime p) :
   coprime p n :=
 begin
-  have h := coprime_or_dvd_of_prime pp n,
-  cases h,
-  { exact h, },
-  { have hle := le_of_dvd n_pos h,
-    by_contra,
-    exact lt_le_antisymm hlt hle, },
+   cases coprime_or_dvd_of_prime pp n,
+   { exact h },
+   { exfalso, exact lt_le_antisymm hlt (le_of_dvd n_pos h) },
 end
 
 lemma eq_or_coprime_of_le_prime {n p} (n_pos : 0 < n) (hle : n ≤ p) (pp : prime p) :

--- a/src/data/nat/prime.lean
+++ b/src/data/nat/prime.lean
@@ -586,10 +586,10 @@ theorem coprime_pow_primes {p q : ℕ} (n m : ℕ) (pp : prime p) (pq : prime q)
 theorem coprime_or_dvd_of_prime {p} (pp : prime p) (i : ℕ) : coprime p i ∨ p ∣ i :=
 by rw [pp.dvd_iff_not_coprime]; apply em
 
-lemma coprime_of_lt_prime {n k : ℕ} (n_pos : 0 < n) (hlt : n < k) (is_prime : prime k) :
-  coprime k n :=
+lemma coprime_of_lt_prime {n p} (n_pos : 0 < n) (hlt : n < p) (pp : prime p) :
+  coprime p n :=
 begin
-  have h := coprime_or_dvd_of_prime is_prime n,
+  have h := coprime_or_dvd_of_prime pp n,
   cases h,
   { exact h, },
   { have hle := le_of_dvd n_pos h,
@@ -597,13 +597,13 @@ begin
     exact lt_le_antisymm hlt hle, },
 end
 
-lemma eq_or_coprime_of_le_prime {n k : ℕ} (n_pos : 0 < n) (hle : n ≤ k) (is_prime : prime k) :
-  k = n ∨ coprime k n :=
+lemma eq_or_coprime_of_le_prime {n p} (n_pos : 0 < n) (hle : n ≤ p) (pp : prime p) :
+  p = n ∨ coprime p n :=
 begin
-  by_cases k = n,
+  by_cases p = n,
   { exact or.inl h, },
   { right,
-    apply coprime_of_lt_prime n_pos _ is_prime,
+    apply coprime_of_lt_prime n_pos _ pp,
     exact (ne.symm h).le_iff_lt.mp hle, },
 end
 

--- a/src/data/nat/prime.lean
+++ b/src/data/nat/prime.lean
@@ -586,6 +586,27 @@ theorem coprime_pow_primes {p q : ℕ} (n m : ℕ) (pp : prime p) (pq : prime q)
 theorem coprime_or_dvd_of_prime {p} (pp : prime p) (i : ℕ) : coprime p i ∨ p ∣ i :=
 by rw [pp.dvd_iff_not_coprime]; apply em
 
+lemma coprime_of_lt_prime {n k : ℕ} (n_pos : 0 < n) (hlt : n < k) (is_prime : prime k) :
+  coprime k n :=
+begin
+  have h := coprime_or_dvd_of_prime is_prime n,
+  cases h,
+  { exact h, },
+  { have hle := le_of_dvd n_pos h,
+    by_contra,
+    exact lt_le_antisymm hlt hle, },
+end
+
+lemma eq_or_coprime_of_le_prime {n k : ℕ} (n_pos : 0 < n) (hle : n ≤ k) (is_prime : prime k) :
+  k = n ∨ coprime k n :=
+begin
+  by_cases k = n,
+  { exact or.inl h, },
+  { right,
+    apply coprime_of_lt_prime n_pos _ is_prime,
+    exact (ne.symm h).le_iff_lt.mp hle, },
+end
+
 theorem dvd_prime_pow {p : ℕ} (pp : prime p) {m i : ℕ} : i ∣ (p^m) ↔ ∃ k ≤ m, i = p^k :=
 begin
   induction m with m IH generalizing i, {simp [pow_succ, le_zero_iff] at *},

--- a/src/data/nat/prime.lean
+++ b/src/data/nat/prime.lean
@@ -599,9 +599,7 @@ lemma eq_or_coprime_of_le_prime {n p} (n_pos : 0 < n) (hle : n ≤ p) (pp : prim
 begin
   by_cases p = n,
   { exact or.inl h, },
-  { right,
-    apply coprime_of_lt_prime n_pos _ pp,
-    exact (ne.symm h).le_iff_lt.mp hle, },
+  { right, exact coprime_of_lt_prime n_pos ((ne.symm h).le_iff_lt.mp hle) pp },
 end
 
 theorem dvd_prime_pow {p : ℕ} (pp : prime p) {m i : ℕ} : i ∣ (p^m) ↔ ∃ k ≤ m, i = p^k :=


### PR DESCRIPTION

Adds `coprime_of_lt_prime` and `eq_or_coprime_of_le_prime`, which help one to prove a number is coprime to a prime. Spun off of #9080.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
