### PR TITLE
[Merged by Bors] - chore(category_theory/limits/shapes/wide_pullbacks): speed up `wide_cospan`

### DIFF
--- a/src/category_theory/limits/shapes/wide_pullbacks.lean
+++ b/src/category_theory/limits/shapes/wide_pullbacks.lean
@@ -90,15 +90,15 @@ def wide_cospan (B : C) (objs : J → C) (arrows : Π (j : J), objs j ⟶ B) :
     { apply (𝟙 _) },
     { exact arrows j },
   end,
-  map_comp' := λ _ _ _ _ _,
+  map_comp' := λ _ _ _ f g,
   begin
-    tactic.case_bash,
+    cases f,
     { simpa },
-    { simpa },
-    { simpa },
-    { tactic.case_bash,
-      simpa }
+    cases g,
+    simpa
   end }
+
+#exit
 
 /-- Every diagram is naturally isomorphic (actually, equal) to a `wide_cospan` -/
 def diagram_iso_wide_cospan (F : wide_pullback_shape J ⥤ C) :

--- a/src/category_theory/limits/shapes/wide_pullbacks.lean
+++ b/src/category_theory/limits/shapes/wide_pullbacks.lean
@@ -98,8 +98,6 @@ def wide_cospan (B : C) (objs : J → C) (arrows : Π (j : J), objs j ⟶ B) :
     simpa
   end }
 
-#exit
-
 /-- Every diagram is naturally isomorphic (actually, equal) to a `wide_cospan` -/
 def diagram_iso_wide_cospan (F : wide_pullback_shape J ⥤ C) :
   F ≅ wide_cospan (F.obj none) (λ j, F.obj (some j)) (λ j, F.map (hom.term j)) :=

--- a/src/category_theory/limits/shapes/wide_pullbacks.lean
+++ b/src/category_theory/limits/shapes/wide_pullbacks.lean
@@ -88,8 +88,15 @@ def wide_cospan (B : C) (objs : J → C) (arrows : Π (j : J), objs j ⟶ B) :
   begin
     cases f with _ j,
     { apply (𝟙 _) },
-    { exact arrows j }
-  end }
+    { exact arrows j },
+  end,
+  map_comp' := λ _ _ _ _ _, by {
+    tactic.case_bash,
+    { simpa },
+    { simpa },
+    { simpa },
+    { tactic.case_bash,
+      simpa } } }
 
 /-- Every diagram is naturally isomorphic (actually, equal) to a `wide_cospan` -/
 def diagram_iso_wide_cospan (F : wide_pullback_shape J ⥤ C) :

--- a/src/category_theory/limits/shapes/wide_pullbacks.lean
+++ b/src/category_theory/limits/shapes/wide_pullbacks.lean
@@ -88,7 +88,7 @@ def wide_cospan (B : C) (objs : J → C) (arrows : Π (j : J), objs j ⟶ B) :
   begin
     cases f with _ j,
     { apply (𝟙 _) },
-    { exact arrows j },
+    { exact arrows j }
   end,
   map_comp' := λ _ _ _ f g,
   begin

--- a/src/category_theory/limits/shapes/wide_pullbacks.lean
+++ b/src/category_theory/limits/shapes/wide_pullbacks.lean
@@ -90,13 +90,15 @@ def wide_cospan (B : C) (objs : J → C) (arrows : Π (j : J), objs j ⟶ B) :
     { apply (𝟙 _) },
     { exact arrows j },
   end,
-  map_comp' := λ _ _ _ _ _, by {
+  map_comp' := λ _ _ _ _ _,
+  begin
     tactic.case_bash,
     { simpa },
     { simpa },
     { simpa },
     { tactic.case_bash,
-      simpa } } }
+      simpa }
+  end }
 
 /-- Every diagram is naturally isomorphic (actually, equal) to a `wide_cospan` -/
 def diagram_iso_wide_cospan (F : wide_pullback_shape J ⥤ C) :


### PR DESCRIPTION

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)

I am hitting a timeout here in several branches:
https://github.com/leanprover-community/mathlib/runs/4348859683?check_suite_focus=true
https://github.com/leanprover-community/mathlib/runs/4348836590?check_suite_focus=true
https://github.com/leanprover-community/mathlib/runs/4348821404?check_suite_focus=true