### PR TITLE
[Merged by Bors] - feat(data/sigma{lex,order}): Lexicographic and disjoint orders on a sigma type

### DIFF
--- a/src/data/list/lex.lean
+++ b/src/data/list/lex.lean
@@ -13,7 +13,11 @@ The lexicographic order on `list α` is defined by `L < M` iff
 * `(a :: L) < (b :: M)` where `a < b`, or
 * `(a :: L) < (a :: M)` where `L < M`.
 
-See also `order.lexicographic` for the lexicographic order on pairs.
+## See also
+
+The lexicographic order on a product type can be found in `order.lexicographic`.
+
+The lexicographic order on a sigma type can be found in `data.sigma.lex`.
 -/
 
 namespace list

--- a/src/data/sigma/lex.lean
+++ b/src/data/sigma/lex.lean
@@ -7,15 +7,23 @@ import data.sigma.basic
 import order.rel_classes
 
 /-!
-# Lexicographical order on a sigma type
+# Lexicographic order on a sigma type
 
-This defines the lexicographical order of two arbitrary relations on a sigma type.
+This defines the lexicographical order of two arbitrary relations on a sigma type and proves some
+lemmas about `psigma.lex`, which is defined in core Lean.
 
 Given a relation in the index type and a relation on each summand, the lexicographical order on the
 sigma type relates `a` and `b` if their summands are related or they are in the same summand and
 related by the summand's relation.
 
-For the lexicographical order per say, see `data.sigma.order`.
+## See also
+
+For the lexicographic order per say, see `data.sigma.order`.
+
+The lexicographic order on lists can be found in `data.list.lex`.
+
+The lexicographic order on a product type (which can be thought of as the special case of
+`sigma.lex` where all summands are the same) and on `psigma` live in `order.lexicographic`.
 -/
 
 namespace sigma

--- a/src/data/sigma/lex.lean
+++ b/src/data/sigma/lex.lean
@@ -1,0 +1,173 @@
+/-
+Copyright (c) 2021 Yaël Dillies. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Yaël Dillies
+-/
+import data.sigma.basic
+import order.rel_classes
+
+/-!
+# Lexicographical order on a sigma type
+
+This defines the lexicographical order of two arbitrary relations on a sigma type.
+
+Given a relation in the index type and a relation on each summand, the lexicographical order on the
+sigma type relates `a` and `b` if their summands are related or they are in the same summand and
+related by the summand's relation.
+
+For the lexicographical order per say, see `data.sigma.order`.
+-/
+
+namespace sigma
+variables {ι : Type*} {α : ι → Type*} {r r₁ r₂ : ι → ι → Prop} {s s₁ s₂ : Π i, α i → α i → Prop}
+  {a b : Σ i, α i}
+
+/-- The lexicographical order on a sigma type. It takes in a relation on the index type and a
+relation for each summand. `a` is related to `b` iff their summands are related or they are in the
+same summand and are related through the summand's relation. -/
+inductive lex (r : ι → ι → Prop) (s : Π i, α i → α i → Prop) : Π a b : Σ i, α i, Prop
+| left {i j : ι} (a : α i) (b : α j) : r i j → lex ⟨i, a⟩ ⟨j, b⟩
+| right {i : ι} (a b : α i)          : s i a b → lex ⟨i, a⟩ ⟨i, b⟩
+
+lemma lex_iff : lex r s a b ↔ r a.1 b.1 ∨ ∃ h : a.1 = b.1, s _ (h.rec a.2) b.2 :=
+begin
+  split,
+  { rintro (⟨i, j, a, b, hij⟩ | ⟨i, a, b, hab⟩),
+    { exact or.inl hij },
+    { exact or.inr ⟨rfl, hab⟩ } },
+  { obtain ⟨i, a⟩ := a,
+    obtain ⟨j, b⟩ := b,
+    dsimp only,
+    rintro (h | ⟨rfl, h⟩),
+    { exact lex.left _ _ h },
+    { exact lex.right _ _ h } }
+end
+
+instance lex.decidable (r : ι → ι → Prop) (s : Π i, α i → α i → Prop) [decidable_eq ι]
+  [decidable_rel r] [Π i, decidable_rel (s i)] :
+  decidable_rel (lex r s) :=
+λ a b, decidable_of_decidable_of_iff infer_instance lex_iff.symm
+
+lemma lex.mono (hr : ∀ a b, r₁ a b → r₂ a b) (hs : ∀ i a b, s₁ i a b → s₂ i a b) {a b : Σ i, α i}
+  (h : lex r₁ s₁ a b) :
+  lex r₂ s₂ a b :=
+begin
+  obtain (⟨i, j, a, b, hij⟩ | ⟨i, a, b, hab⟩) := h,
+  { exact lex.left _ _ (hr _ _ hij) },
+  { exact lex.right _ _ (hs _ _ _ hab) }
+end
+
+lemma lex.mono_left (hr : ∀ a b, r₁ a b → r₂ a b) {a b : Σ i, α i} (h : lex r₁ s a b) :
+  lex r₂ s a b :=
+h.mono hr $ λ _ _ _, id
+
+lemma lex.mono_right (hs : ∀ i a b, s₁ i a b → s₂ i a b) {a b : Σ i, α i} (h : lex r s₁ a b) :
+  lex r s₂ a b :=
+h.mono (λ _ _, id) hs
+
+instance [Π i, is_refl (α i) (s i)] : is_refl _ (lex r s) := ⟨λ ⟨i, a⟩, lex.right _ _ $ refl _⟩
+
+instance [is_irrefl ι r] [Π i, is_irrefl (α i) (s i)] : is_irrefl _ (lex r s) :=
+⟨begin
+  rintro _ (⟨i, j, a, b, hi⟩ | ⟨i, a, b, ha⟩),
+  { exact irrefl _ hi },
+  { exact irrefl _ ha }
+end⟩
+
+instance [is_trans ι r] [Π i, is_trans (α i) (s i)] : is_trans _ (lex r s) :=
+⟨begin
+  rintro _ _ _ (⟨i, j, a, b, hij⟩ | ⟨i, a, b, hab⟩) (⟨_, k, _, c, hk⟩ | ⟨_, _, c, hc⟩),
+  { exact lex.left _ _ (trans hij hk) },
+  { exact lex.left _ _ hij },
+  { exact lex.left _ _ hk },
+  { exact lex.right _ _ (trans hab hc) }
+end⟩
+
+instance [is_symm ι r] [Π i, is_symm (α i) (s i)] : is_symm _ (lex r s) :=
+⟨begin
+  rintro _ _ (⟨i, j, a, b, hij⟩ | ⟨i, a, b, hab⟩),
+  { exact lex.left _ _ (symm hij) },
+  { exact lex.right _ _ (symm hab) }
+end⟩
+
+local attribute [instance] is_asymm.is_irrefl
+
+instance [is_asymm ι r] [Π i, is_antisymm (α i) (s i)] : is_antisymm _ (lex r s) :=
+⟨begin
+  rintro _ _ (⟨i, j, a, b, hij⟩ | ⟨i, a, b, hab⟩) (⟨_, _, _, _, hji⟩ | ⟨_, _, _, hba⟩),
+  { exact (asymm hij hji).elim },
+  { exact (irrefl _ hij).elim },
+  { exact (irrefl _ hji).elim },
+  { exact ext rfl (heq_of_eq $ antisymm hab hba) }
+end⟩
+
+instance [is_trichotomous ι r] [Π i, is_total (α i) (s i)] : is_total _ (lex r s) :=
+⟨begin
+  rintro ⟨i, a⟩ ⟨j, b⟩,
+  obtain hij | rfl | hji := trichotomous_of r i j,
+  { exact or.inl (lex.left _ _ hij) },
+  { obtain hab | hba := total_of (s i) a b,
+    { exact or.inl (lex.right _ _ hab) },
+    { exact or.inr (lex.right _ _ hba) } },
+  { exact or.inr (lex.left _ _ hji) }
+end⟩
+
+instance [is_trichotomous ι r] [Π i, is_trichotomous (α i) (s i)] : is_trichotomous _ (lex r s) :=
+⟨begin
+  rintro ⟨i, a⟩ ⟨j, b⟩,
+  obtain hij | rfl | hji := trichotomous_of r i j,
+  { exact or.inl (lex.left _ _ hij) },
+  { obtain hab | rfl | hba := trichotomous_of (s i) a b,
+    { exact or.inl (lex.right _ _ hab) },
+    { exact or.inr (or.inl rfl) },
+    { exact or.inr (or.inr $ lex.right _ _ hba) } },
+  { exact or.inr (or.inr $ lex.left _ _ hji) }
+end⟩
+
+end sigma
+
+/-! ### `psigma` -/
+
+namespace psigma
+variables {ι : Sort*} {α : ι → Sort*} {r r₁ r₂ : ι → ι → Prop} {s s₁ s₂ : Π i, α i → α i → Prop}
+
+lemma lex_iff {a b : Σ' i, α i} : lex r s a b ↔ r a.1 b.1 ∨ ∃ h : a.1 = b.1, s _ (h.rec a.2) b.2 :=
+begin
+  split,
+  { rintro (⟨i, j, a, b, hij⟩ | ⟨i, a, b, hab⟩),
+    { exact or.inl hij },
+    { exact or.inr ⟨rfl, hab⟩ } },
+  { obtain ⟨i, a⟩ := a,
+    obtain ⟨j, b⟩ := b,
+    dsimp only,
+    rintro (h | ⟨rfl, h⟩),
+    { exact lex.left _ _ h },
+    { exact lex.right _ h } }
+end
+
+instance lex.decidable (r : ι → ι → Prop) (s : Π i, α i → α i → Prop) [decidable_eq ι]
+  [decidable_rel r] [Π i, decidable_rel (s i)] :
+  decidable_rel (lex r s) :=
+λ a b, decidable_of_decidable_of_iff infer_instance lex_iff.symm
+
+lemma lex.mono {r₁ r₂ : ι → ι → Prop} {s₁ s₂ : Π i, α i → α i → Prop}
+  (hr : ∀ a b, r₁ a b → r₂ a b) (hs : ∀ i a b, s₁ i a b → s₂ i a b) {a b : Σ' i, α i}
+  (h : lex r₁ s₁ a b) :
+  lex r₂ s₂ a b :=
+begin
+  obtain (⟨i, j, a, b, hij⟩ | ⟨i, a, b, hab⟩) := h,
+  { exact lex.left _ _ (hr _ _ hij) },
+  { exact lex.right _ (hs _ _ _ hab) }
+end
+
+lemma lex.mono_left {r₁ r₂ : ι → ι → Prop} {s : Π i, α i → α i → Prop}
+  (hr : ∀ a b, r₁ a b → r₂ a b) {a b : Σ' i, α i} (h : lex r₁ s a b) :
+  lex r₂ s a b :=
+h.mono hr $ λ _ _ _, id
+
+lemma lex.mono_right {r : ι → ι → Prop} {s₁ s₂ : Π i, α i → α i → Prop}
+  (hs : ∀ i a b, s₁ i a b → s₂ i a b) {a b : Σ' i, α i} (h : lex r s₁ a b) :
+  lex r s₂ a b :=
+h.mono (λ _ _, id) hs
+
+end psigma

--- a/src/data/sigma/order.lean
+++ b/src/data/sigma/order.lean
@@ -1,0 +1,99 @@
+/-
+Copyright (c) 2021 Yaël Dillies. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Yaël Dillies
+-/
+import data.sigma.lex
+
+/-!
+# Orders on a sigma type
+
+This file defines two orders on a sigma type:
+* The disjoint sum of orders. `a` is less `b` iff `a` and `b` are in the same summand and `a` is
+  less than `b` there.
+* The lexicographical order. `a` is less than `b` if its summand is strictly less than the summand
+  of `b` or they are in the same summand and `a` is less than `b` there.
+
+## Implementation notes
+
+We declare the disjoint sum of orders as the default instances. The lexicographical order can
+override it in local by opening locale `lex`.
+-/
+
+namespace sigma
+variables {ι : Type*} {α : ι → Type*}
+
+/-! ### Disjoint sum of orders on `sigma` -/
+
+/-- Disjoint sum of orders. `⟨i, a⟩ ≤ ⟨j, b⟩` iff `i = j` and `a ≤ b`. -/
+inductive le [Π i, has_le (α i)] : Π a b : Σ i, α i, Prop
+| fiber (i : ι) (a b : α i) : a ≤ b → le ⟨i, a⟩ ⟨i, b⟩
+
+instance [Π i, has_le (α i)] : has_le (Σ i, α i) := ⟨le⟩
+
+instance [Π i, preorder (α i)] : preorder (Σ i, α i) :=
+{ le_refl := λ ⟨i, a⟩, le.fiber i a a le_rfl,
+  le_trans := begin
+    rintro _ _ _ ⟨i, a, b, hab⟩ ⟨_, _, c, hbc⟩,
+    exact le.fiber i a c (hab.trans hbc),
+  end,
+  .. sigma.has_le }
+
+instance [Π i, partial_order (α i)] : partial_order (Σ i, α i) :=
+{ le_antisymm := begin
+    rintro _ _ ⟨i, a, b, hab⟩ ⟨_, _, _, hba⟩,
+    exact ext rfl (heq_of_eq $ hab.antisymm hba),
+  end,
+  .. sigma.preorder }
+
+/-! ### Lexicographical order on `sigma` -/
+
+localized "attribute [-instance] sigma.has_le" in lex
+localized "attribute [-instance] sigma.preorder" in lex
+localized "attribute [-instance] sigma.partial_order" in lex
+
+/-- The lexicographical `≤` on a sigma type. Turn this on by opening locale `lex`. -/
+def lex.has_le [has_lt ι] [Π i, has_le (α i)] : has_le (Σ i, α i) := ⟨lex (<) (λ i, (≤))⟩
+
+/-- The lexicographical `<` on a sigma type. Turn this on by opening locale `lex`. -/
+def lex.has_lt [has_lt ι] [Π i, has_lt (α i)] : has_lt (Σ i, α i) := ⟨lex (<) (λ i, (<))⟩
+
+localized "attribute [instance] lex.has_le" in lex
+localized "attribute [instance] lex.has_lt" in lex
+
+/-- The lexicographical preorder on a sigma type. Turn this on by opening locale `lex`. -/
+def lex.preorder [preorder ι] [Π i, preorder (α i)] : preorder (Σ i, α i) :=
+{ le_refl := λ ⟨i, a⟩, lex.right a a le_rfl,
+  le_trans := λ _ _ _, trans,
+  lt_iff_le_not_le := begin
+    refine λ a b, ⟨λ hab, ⟨hab.mono_right (λ i a b, le_of_lt), _⟩, _⟩,
+    { rintro (⟨j, i, b, a, hji⟩ | ⟨i, b, a, hba⟩);
+        obtain (⟨_, _, _, _, hij⟩ | ⟨_, _, _, hab⟩) := hab,
+      { exact hij.not_lt hji },
+      { exact lt_irrefl _ hji },
+      { exact lt_irrefl _ hij },
+      { exact hab.not_le hba } },
+    { rintro ⟨⟨i, j, a, b, hij⟩ |⟨i, a, b, hab⟩, hba⟩,
+      { exact lex.left _ _ hij },
+      { exact lex.right _ _ (hab.lt_of_not_le $ λ h, hba $ lex.right _ _ h) } }
+  end,
+  .. lex.has_le,
+  .. lex.has_lt }
+
+localized "attribute [instance] lex.preorder" in lex
+
+/-- The lexicographical partial order on a sigma type. Turn this on by opening locale `lex`. -/
+def lex.partial_order [preorder ι] [Π i, partial_order (α i)] : partial_order (Σ i, α i) :=
+{ le_antisymm := λ _ _, antisymm,
+  .. lex.preorder }
+
+localized "attribute [instance] lex.partial_order" in lex
+
+/-- The lexicographical linear order on a sigma type. Turn this on by opening locale `lex`. -/
+def lex.linear_order [linear_order ι] [Π i, linear_order (α i)] : linear_order (Σ i, α i) :=
+{ le_total := total_of _,
+  decidable_eq := sigma.decidable_eq,
+  decidable_le := lex.decidable _ _,
+  .. lex.partial_order }
+
+end sigma

--- a/src/data/sigma/order.lean
+++ b/src/data/sigma/order.lean
@@ -18,6 +18,11 @@ This file defines two orders on a sigma type:
 
 We declare the disjoint sum of orders as the default instances. The lexicographical order can
 override it in local by opening locale `lex`.
+
+## TODO
+
+The lexicographic order on `psigma` currently lives in `order.lexicographic`. Should we bring it
+here?
 -/
 
 namespace sigma

--- a/src/order/lexicographic.lean
+++ b/src/order/lexicographic.lean
@@ -21,7 +21,9 @@ and linear orders.
 
 ## See also
 
-The lexicographic ordering on lists is provided in `data.list.basic`.
+The lexicographic order on lists is provided in `data.list.lex`.
+
+The lexicographic order on a sigma type is to be found in `data.sigma.lex`.
 -/
 
 universes u v


### PR DESCRIPTION
This defines the two natural order on a sigma type: the one where we just juxtapose the summands with their respective order, and the one where we also add in an order between summands.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
This is basically duplicating a good chunk of `order.lexicographic`, except that it's about `sigma`, not `psigma`.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
