### PR TITLE
[Merged by Bors] - doc(group_theory/index): add a theorem name and fix a to_additive

### DIFF
--- a/src/group_theory/index.lean
+++ b/src/group_theory/index.lean
@@ -11,6 +11,7 @@ import set_theory.fincard
 # Index of a Subgroup
 
 In this file we define the index of a subgroup, and prove several divisibility properties.
+Several theorems proved in this file are known as Lagrange's theorem.
 
 ## Main definitions
 
@@ -21,6 +22,7 @@ In this file we define the index of a subgroup, and prove several divisibility p
 
 # Main results
 
+- `card_mul_index` : `nat.card H * H.index = nat.card G`
 - `index_mul_card` : `H.index * fintype.card H = fintype.card G`
 - `index_dvd_card` : `H.index ∣ fintype.card G`
 - `index_eq_mul_of_le` : If `H ≤ K`, then `H.index = K.index * (H.subgroup_of K).index`
@@ -177,7 +179,7 @@ nat.dvd_antisymm (H.index_map_dvd hf1) (H.dvd_index_map hf2)
   H.index = fintype.card (quotient_group.quotient H) :=
 nat.card_eq_fintype_card
 
-@[to_additive] lemma index_mul_card [fintype G] [hH : fintype H] :
+@[to_additive index_mul_card] lemma index_mul_card [fintype G] [hH : fintype H] :
   H.index * fintype.card H = fintype.card G :=
 by rw [←relindex_bot_left_eq_card, ←index_bot_eq_card, mul_comm]; exact relindex_mul_index bot_le
 


### PR DESCRIPTION
I wanted to find the theorem I know as "Lagrange's theorem" but couldn't by searching.
This PR adds the name Lagrange's theorem to the relevant file, and also fixes an extra eager `to_additive` renaming that creates a lemma `add_subgroup.index_add_card` which talks about multiplication previously.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
