### PR TITLE
[Merged by Bors] - refactor(algebra/group/basic): Migrate add_comm_group section into comm_group section

### DIFF
--- a/src/algebra/group/basic.lean
+++ b/src/algebra/group/basic.lean
@@ -533,6 +533,9 @@ by simp
 @[to_additive] lemma div_eq_div_mul_div (a b c : G) : a / b = c / b * (a / c) :=
 begin simp, rw [mul_left_comm c], simp end
 
+@[to_additive] lemma inv_inv_div_inv (a b : G) : (a⁻¹ / b⁻¹)⁻¹ = a / b :=
+by simp
+
 end comm_group
 
 section add_comm_group
@@ -541,9 +544,6 @@ section add_comm_group
 variables {G : Type u} [add_comm_group G] {a b c d : G}
 
 local attribute [simp] add_assoc add_comm add_left_comm sub_eq_add_neg
-
-lemma neg_neg_sub_neg (a b : G) : - (-a - -b) = a - b :=
-by simp
 
 @[simp] lemma sub_sub_cancel (a b : G) : a - (a - b) = b := sub_sub_self a b
 

--- a/src/algebra/group/basic.lean
+++ b/src/algebra/group/basic.lean
@@ -526,6 +526,10 @@ begin simp [h], rw [mul_comm c, mul_inv_cancel_left] end
 lemma div_div_self' (a b : G) : a / (a / b) = b :=
 by simpa using mul_inv_cancel_left a b
 
+@[to_additive add_sub_comm]
+lemma mul_div_comm' (a b c d : G) : a * b / (c * d) = (a / c) * (b / d) :=
+by simp
+
 end comm_group
 
 section add_comm_group
@@ -534,9 +538,6 @@ section add_comm_group
 variables {G : Type u} [add_comm_group G] {a b c d : G}
 
 local attribute [simp] add_assoc add_comm add_left_comm sub_eq_add_neg
-
-lemma add_sub_comm (a b c d : G) : a + b - (c + d) = (a - c) + (b - d) :=
-by simp
 
 lemma sub_eq_sub_add_sub (a b c : G) : a - b = c - b + (a - c) :=
 begin simp, rw [add_left_comm c], simp end

--- a/src/algebra/group/basic.lean
+++ b/src/algebra/group/basic.lean
@@ -578,8 +578,13 @@ by rw [← inv_div', mul_div_cancel''']
 
 -- This lemma is in the `simp` set under the name `add_neg_cancel_comm_assoc`,
 -- defined  in `algebra/group/commute`
-@[to_additive] lemma mul_mul_inv_cancel'_right (a b : G) : a * (b * a⁻¹) = b :=
+@[to_additive]
+lemma mul_mul_inv_cancel'_right (a b : G) : a * (b * a⁻¹) = b :=
 by rw [← div_eq_mul_inv, mul_div_cancel'_right a b]
+
+@[to_additive sub_right_comm]
+lemma div_right_comm' (a b c : G) : a / b / c = a / c / b :=
+by { repeat { rw div_eq_mul_inv }, exact mul_right_comm _ _ _ }
 
 end comm_group
 
@@ -589,9 +594,6 @@ section add_comm_group
 variables {G : Type u} [add_comm_group G] {a b c d : G}
 
 local attribute [simp] add_assoc add_comm add_left_comm sub_eq_add_neg
-
-lemma sub_right_comm (a b c : G) : a - b - c = a - c - b :=
-by { repeat { rw sub_eq_add_neg }, exact add_right_comm _ _ _ }
 
 @[simp] lemma add_add_sub_cancel (a b c : G) : (a + c) + (b - c) = a + b :=
 by rw [add_assoc, add_sub_cancel'_right]

--- a/src/algebra/group/basic.lean
+++ b/src/algebra/group/basic.lean
@@ -489,6 +489,9 @@ local attribute [simp] mul_assoc mul_comm mul_left_comm div_eq_mul_inv
 @[to_additive] lemma div_mul_eq_div_div (a b c : G) : a / (b * c) = a / b / c :=
 by simp
 
+@[to_additive] lemma inv_mul_eq_div (a b : G) : a⁻¹ * b = b / a :=
+by simp
+
 end comm_group
 
 section add_comm_group
@@ -497,9 +500,6 @@ section add_comm_group
 variables {G : Type u} [add_comm_group G] {a b c d : G}
 
 local attribute [simp] add_assoc add_comm add_left_comm sub_eq_add_neg
-
-lemma neg_add_eq_sub (a b : G) : -a + b = b - a :=
-by simp
 
 lemma sub_add_eq_add_sub (a b c : G) : a - b + c = a + c - b :=
 by simp

--- a/src/algebra/group/basic.lean
+++ b/src/algebra/group/basic.lean
@@ -521,6 +521,11 @@ by simp [h.symm]
 @[to_additive]
 lemma mul_eq_of_eq_div' (h : b = c / a) : a * b = c :=
 begin simp [h], rw [mul_comm c, mul_inv_cancel_left] end
+
+@[to_additive sub_sub_self]
+lemma div_div_self' (a b : G) : a / (a / b) = b :=
+by simpa using mul_inv_cancel_left a b
+
 end comm_group
 
 section add_comm_group
@@ -529,9 +534,6 @@ section add_comm_group
 variables {G : Type u} [add_comm_group G] {a b c d : G}
 
 local attribute [simp] add_assoc add_comm add_left_comm sub_eq_add_neg
-
-lemma sub_sub_self (a b : G) : a - (a - b) = b :=
-by simpa using add_neg_cancel_left a b
 
 lemma add_sub_comm (a b c d : G) : a + b - (c + d) = (a - c) + (b - d) :=
 by simp

--- a/src/algebra/group/basic.lean
+++ b/src/algebra/group/basic.lean
@@ -541,6 +541,10 @@ by simp
 @[simp, to_additive]
 lemma div_div_cancel (a b : G) : a / (a / b) = b := div_div_self' a b
 
+@[to_additive sub_eq_neg_add]
+lemma div_eq_inv_mul' (a b : G) : a / b = b⁻¹ * a :=
+by rw [div_eq_mul_inv, mul_comm _ _]
+
 end comm_group
 
 section add_comm_group
@@ -551,9 +555,6 @@ variables {G : Type u} [add_comm_group G] {a b c d : G}
 local attribute [simp] add_assoc add_comm add_left_comm sub_eq_add_neg
 
 @[simp] lemma sub_sub_cancel_left (a b : G) : a - b - a = -b := by simp
-
-lemma sub_eq_neg_add (a b : G) : a - b = -b + a :=
-by rw [sub_eq_add_neg, add_comm _ _]
 
 theorem neg_add' (a b : G) : -(a + b) = -a - b :=
 by rw [sub_eq_add_neg, neg_add a b]

--- a/src/algebra/group/basic.lean
+++ b/src/algebra/group/basic.lean
@@ -486,10 +486,16 @@ variables {a b c d : G}
 
 local attribute [simp] mul_assoc mul_comm mul_left_comm div_eq_mul_inv
 
-@[to_additive] lemma div_mul_eq_div_div (a b c : G) : a / (b * c) = a / b / c :=
+@[to_additive]
+lemma div_mul_eq_div_div (a b c : G) : a / (b * c) = a / b / c :=
 by simp
 
-@[to_additive] lemma inv_mul_eq_div (a b : G) : a⁻¹ * b = b / a :=
+@[to_additive]
+lemma inv_mul_eq_div (a b : G) : a⁻¹ * b = b / a :=
+by simp
+
+@[to_additive sub_add_eq_add_sub]
+lemma div_mul_eq_mul_div' (a b c : G) : a / b * c = a * c / b :=
 by simp
 
 end comm_group
@@ -500,9 +506,6 @@ section add_comm_group
 variables {G : Type u} [add_comm_group G] {a b c d : G}
 
 local attribute [simp] add_assoc add_comm add_left_comm sub_eq_add_neg
-
-lemma sub_add_eq_add_sub (a b c : G) : a - b + c = a + c - b :=
-by simp
 
 lemma sub_sub (a b c : G) : a - b - c = a - (b + c) :=
 by simp

--- a/src/algebra/group/basic.lean
+++ b/src/algebra/group/basic.lean
@@ -504,6 +504,9 @@ by simp
 @[to_additive] lemma div_mul (a b c : G) : a / b * c = a / (b / c) :=
 by simp
 
+@[simp, to_additive] lemma mul_div_mul_left_eq_div (a b c : G) : (c * a) / (c * b) = a / b :=
+by simp
+
 end comm_group
 
 section add_comm_group
@@ -512,9 +515,6 @@ section add_comm_group
 variables {G : Type u} [add_comm_group G] {a b c d : G}
 
 local attribute [simp] add_assoc add_comm add_left_comm sub_eq_add_neg
-
-@[simp] lemma add_sub_add_left_eq_sub (a b c : G) : (c + a) - (c + b) = a - b :=
-by simp
 
 lemma eq_sub_of_add_eq' (h : c + a = b) : a = b - c :=
 by simp [h.symm]

--- a/src/algebra/group/basic.lean
+++ b/src/algebra/group/basic.lean
@@ -564,6 +564,10 @@ by rw [eq_div_iff_mul_eq', mul_comm]
 lemma div_eq_iff_eq_mul' : a / b = c ↔ a = b * c :=
 by rw [div_eq_iff_eq_mul, mul_comm]
 
+@[simp, to_additive add_sub_cancel']
+lemma mul_div_cancel''' (a b : G) : a * b / a = b :=
+by rw [div_eq_inv_mul', inv_mul_cancel_left]
+
 end comm_group
 
 section add_comm_group
@@ -573,9 +577,6 @@ variables {G : Type u} [add_comm_group G] {a b c d : G}
 
 local attribute [simp] add_assoc add_comm add_left_comm sub_eq_add_neg
 
-@[simp]
-lemma add_sub_cancel' (a b : G) : a + b - a = b :=
-by rw [sub_eq_neg_add, neg_add_cancel_left]
 
 @[simp]
 lemma add_sub_cancel'_right (a b : G) : a + (b - a) = b :=

--- a/src/algebra/group/basic.lean
+++ b/src/algebra/group/basic.lean
@@ -590,6 +590,10 @@ by { repeat { rw div_eq_mul_inv }, exact mul_right_comm _ _ _ }
 lemma mul_mul_div_cancel (a b c : G) : (a * c) * (b / c) = a * b :=
 by rw [mul_assoc, mul_div_cancel'_right]
 
+@[simp, to_additive]
+lemma div_mul_mul_cancel (a b c : G) : (a / c) * (b * c) = a * b :=
+by rw [mul_left_comm, div_mul_cancel', mul_comm]
+
 end comm_group
 
 section add_comm_group
@@ -598,9 +602,6 @@ section add_comm_group
 variables {G : Type u} [add_comm_group G] {a b c d : G}
 
 local attribute [simp] add_assoc add_comm add_left_comm sub_eq_add_neg
-
-@[simp] lemma sub_add_add_cancel (a b c : G) : (a - c) + (b + c) = a + b :=
-by rw [add_left_comm, sub_add_cancel, add_comm]
 
 @[simp] lemma sub_add_sub_cancel' (a b c : G) : (a - b) + (c - a) = c - b :=
 by rw add_comm; apply sub_add_sub_cancel

--- a/src/algebra/group/basic.lean
+++ b/src/algebra/group/basic.lean
@@ -556,6 +556,10 @@ by rw [div_eq_mul_inv, mul_inv a b]
 lemma inv_div_inv (a b : G) : a⁻¹ / b⁻¹ = b / a :=
 by simp [div_eq_inv_mul', mul_comm]
 
+@[to_additive eq_sub_iff_add_eq']
+lemma eq_div_iff_mul_eq'' : a = b / c ↔ c * a = b :=
+by rw [eq_div_iff_mul_eq', mul_comm]
+
 end comm_group
 
 section add_comm_group
@@ -564,9 +568,6 @@ section add_comm_group
 variables {G : Type u} [add_comm_group G] {a b c d : G}
 
 local attribute [simp] add_assoc add_comm add_left_comm sub_eq_add_neg
-
-lemma eq_sub_iff_add_eq' : a = b - c ↔ c + a = b :=
-by rw [eq_sub_iff_add_eq, add_comm]
 
 lemma sub_eq_iff_eq_add' : a - b = c ↔ a = b + c :=
 by rw [sub_eq_iff_eq_add, add_comm]

--- a/src/algebra/group/basic.lean
+++ b/src/algebra/group/basic.lean
@@ -518,6 +518,9 @@ by simp [h.symm]
 lemma eq_mul_of_div_eq' (h : a / b = c) : a = b * c :=
 by simp [h.symm]
 
+@[to_additive]
+lemma mul_eq_of_eq_div' (h : b = c / a) : a * b = c :=
+begin simp [h], rw [mul_comm c, mul_inv_cancel_left] end
 end comm_group
 
 section add_comm_group
@@ -526,9 +529,6 @@ section add_comm_group
 variables {G : Type u} [add_comm_group G] {a b c d : G}
 
 local attribute [simp] add_assoc add_comm add_left_comm sub_eq_add_neg
-
-lemma add_eq_of_eq_sub' (h : b = c - a) : a + b = c :=
-begin simp [h], rw [add_comm c, add_neg_cancel_left] end
 
 lemma sub_sub_self (a b : G) : a - (a - b) = b :=
 by simpa using add_neg_cancel_left a b

--- a/src/algebra/group/basic.lean
+++ b/src/algebra/group/basic.lean
@@ -498,6 +498,9 @@ by simp
 lemma div_mul_eq_mul_div' (a b c : G) : a / b * c = a * c / b :=
 by simp
 
+@[to_additive] lemma div_div (a b c : G) : a / b / c = a / (b * c) :=
+by simp
+
 end comm_group
 
 section add_comm_group
@@ -506,9 +509,6 @@ section add_comm_group
 variables {G : Type u} [add_comm_group G] {a b c d : G}
 
 local attribute [simp] add_assoc add_comm add_left_comm sub_eq_add_neg
-
-lemma sub_sub (a b c : G) : a - b - c = a - (b + c) :=
-by simp
 
 lemma sub_add (a b c : G) : a - b + c = a - (b - c) :=
 by simp

--- a/src/algebra/group/basic.lean
+++ b/src/algebra/group/basic.lean
@@ -598,8 +598,13 @@ by rw [mul_left_comm, div_mul_cancel', mul_comm]
 lemma div_mul_div_cancel'' (a b c : G) : (a / b) * (c / a) = c / b :=
 by rw mul_comm; apply div_mul_div_cancel'
 
-@[simp, to_additive] lemma mul_div_div_cancel (a b c : G) : (a * b) / (a / c) = b * c :=
+@[simp, to_additive]
+lemma mul_div_div_cancel (a b c : G) : (a * b) / (a / c) = b * c :=
 by rw [← div_mul, mul_div_cancel''']
+
+@[simp, to_additive]
+lemma div_div_div_cancel_left (a b c : G) : (c / a) / (c / b) = b / a :=
+by rw [← inv_div' b c, div_inv_eq_mul, mul_comm, div_mul_div_cancel']
 
 end comm_group
 
@@ -609,9 +614,6 @@ section add_comm_group
 variables {G : Type u} [add_comm_group G] {a b c d : G}
 
 local attribute [simp] add_assoc add_comm add_left_comm sub_eq_add_neg
-
-@[simp] lemma sub_sub_sub_cancel_left (a b c : G) : (c - a) - (c - b) = b - a :=
-by rw [← neg_sub b c, sub_neg_eq_add, add_comm, sub_add_sub_cancel]
 
 lemma sub_eq_sub_iff_add_eq_add : a - b = c - d ↔ a + d = c + b :=
 begin

--- a/src/algebra/group/basic.lean
+++ b/src/algebra/group/basic.lean
@@ -568,6 +568,10 @@ by rw [div_eq_iff_eq_mul, mul_comm]
 lemma mul_div_cancel''' (a b : G) : a * b / a = b :=
 by rw [div_eq_inv_mul', inv_mul_cancel_left]
 
+@[simp, to_additive]
+lemma mul_div_cancel'_right (a b : G) : a * (b / a) = b :=
+by rw [← mul_div_assoc, mul_div_cancel''']
+
 end comm_group
 
 section add_comm_group
@@ -576,11 +580,6 @@ section add_comm_group
 variables {G : Type u} [add_comm_group G] {a b c d : G}
 
 local attribute [simp] add_assoc add_comm add_left_comm sub_eq_add_neg
-
-
-@[simp]
-lemma add_sub_cancel'_right (a b : G) : a + (b - a) = b :=
-by rw [← add_sub_assoc, add_sub_cancel']
 
 @[simp] lemma sub_add_cancel' (a b : G) : a - (a + b) = -b :=
 by rw [← neg_sub, add_sub_cancel']

--- a/src/algebra/group/basic.lean
+++ b/src/algebra/group/basic.lean
@@ -510,10 +510,12 @@ by simp
 lemma mul_div_mul_left_eq_div (a b c : G) : (c * a) / (c * b) = a / b :=
 by simp
 
-
-
 @[to_additive eq_sub_of_add_eq']
 lemma eq_div_of_mul_eq'' (h : c * a = b) : a = b / c :=
+by simp [h.symm]
+
+@[to_additive]
+lemma eq_mul_of_div_eq' (h : a / b = c) : a = b * c :=
 by simp [h.symm]
 
 end comm_group
@@ -524,9 +526,6 @@ section add_comm_group
 variables {G : Type u} [add_comm_group G] {a b c d : G}
 
 local attribute [simp] add_assoc add_comm add_left_comm sub_eq_add_neg
-
-lemma eq_add_of_sub_eq' (h : a - b = c) : a = b + c :=
-by simp [h.symm]
 
 lemma add_eq_of_eq_sub' (h : b = c - a) : a + b = c :=
 begin simp [h], rw [add_comm c, add_neg_cancel_left] end

--- a/src/algebra/group/basic.lean
+++ b/src/algebra/group/basic.lean
@@ -530,11 +530,16 @@ by simpa using mul_inv_cancel_left a b
 lemma mul_div_comm' (a b c d : G) : a * b / (c * d) = (a / c) * (b / d) :=
 by simp
 
-@[to_additive] lemma div_eq_div_mul_div (a b c : G) : a / b = c / b * (a / c) :=
+@[to_additive]
+lemma div_eq_div_mul_div (a b c : G) : a / b = c / b * (a / c) :=
 begin simp, rw [mul_left_comm c], simp end
 
-@[to_additive] lemma inv_inv_div_inv (a b : G) : (a⁻¹ / b⁻¹)⁻¹ = a / b :=
+@[to_additive]
+lemma inv_inv_div_inv (a b : G) : (a⁻¹ / b⁻¹)⁻¹ = a / b :=
 by simp
+
+@[simp, to_additive]
+lemma div_div_cancel (a b : G) : a / (a / b) = b := div_div_self' a b
 
 end comm_group
 
@@ -544,8 +549,6 @@ section add_comm_group
 variables {G : Type u} [add_comm_group G] {a b c d : G}
 
 local attribute [simp] add_assoc add_comm add_left_comm sub_eq_add_neg
-
-@[simp] lemma sub_sub_cancel (a b : G) : a - (a - b) = b := sub_sub_self a b
 
 @[simp] lemma sub_sub_cancel_left (a b : G) : a - b - a = -b := by simp
 

--- a/src/algebra/group/basic.lean
+++ b/src/algebra/group/basic.lean
@@ -598,6 +598,9 @@ by rw [mul_left_comm, div_mul_cancel', mul_comm]
 lemma div_mul_div_cancel'' (a b c : G) : (a / b) * (c / a) = c / b :=
 by rw mul_comm; apply div_mul_div_cancel'
 
+@[simp, to_additive] lemma mul_div_div_cancel (a b c : G) : (a * b) / (a / c) = b * c :=
+by rw [← div_mul, mul_div_cancel''']
+
 end comm_group
 
 section add_comm_group
@@ -606,9 +609,6 @@ section add_comm_group
 variables {G : Type u} [add_comm_group G] {a b c d : G}
 
 local attribute [simp] add_assoc add_comm add_left_comm sub_eq_add_neg
-
-@[simp] lemma add_sub_sub_cancel (a b c : G) : (a + b) - (a - c) = b + c :=
-by rw [← sub_add, add_sub_cancel']
 
 @[simp] lemma sub_sub_sub_cancel_left (a b c : G) : (c - a) - (c - b) = b - a :=
 by rw [← neg_sub b c, sub_neg_eq_add, add_comm, sub_add_sub_cancel]

--- a/src/algebra/group/basic.lean
+++ b/src/algebra/group/basic.lean
@@ -482,6 +482,13 @@ lemma div_mul_comm (a b c d : G) : a / b * (c / d) = a * c / (b * d) :=
 by rw [div_eq_mul_inv, div_eq_mul_inv, div_eq_mul_inv, mul_inv_rev, mul_assoc, mul_assoc,
   mul_left_cancel_iff, mul_comm, mul_assoc]
 
+variables {a b c d : G}
+
+local attribute [simp] mul_assoc mul_comm mul_left_comm div_eq_mul_inv
+
+@[to_additive] lemma div_mul_eq_div_div (a b c : G) : a / (b * c) = a / b / c :=
+by simp
+
 end comm_group
 
 section add_comm_group
@@ -490,9 +497,6 @@ section add_comm_group
 variables {G : Type u} [add_comm_group G] {a b c d : G}
 
 local attribute [simp] add_assoc add_comm add_left_comm sub_eq_add_neg
-
-lemma sub_add_eq_sub_sub (a b c : G) : a - (b + c) = a - b - c :=
-by simp
 
 lemma neg_add_eq_sub (a b : G) : -a + b = b - a :=
 by simp

--- a/src/algebra/group/basic.lean
+++ b/src/algebra/group/basic.lean
@@ -545,6 +545,9 @@ lemma div_div_cancel (a b : G) : a / (a / b) = b := div_div_self' a b
 lemma div_eq_inv_mul' (a b : G) : a / b = b⁻¹ * a :=
 by rw [div_eq_mul_inv, mul_comm _ _]
 
+@[simp, to_additive]
+lemma div_div_cancel_left (a b : G) : a / b / a = b⁻¹ := by simp
+
 end comm_group
 
 section add_comm_group
@@ -553,8 +556,6 @@ section add_comm_group
 variables {G : Type u} [add_comm_group G] {a b c d : G}
 
 local attribute [simp] add_assoc add_comm add_left_comm sub_eq_add_neg
-
-@[simp] lemma sub_sub_cancel_left (a b : G) : a - b - a = -b := by simp
 
 theorem neg_add' (a b : G) : -(a + b) = -a - b :=
 by rw [sub_eq_add_neg, neg_add a b]

--- a/src/algebra/group/basic.lean
+++ b/src/algebra/group/basic.lean
@@ -548,6 +548,10 @@ by rw [div_eq_mul_inv, mul_comm _ _]
 @[simp, to_additive]
 lemma div_div_cancel_left (a b : G) : a / b / a = b⁻¹ := by simp
 
+@[to_additive]
+theorem inv_mul' (a b : G) : (a * b)⁻¹ = a⁻¹ / b :=
+by rw [div_eq_mul_inv, mul_inv a b]
+
 end comm_group
 
 section add_comm_group
@@ -556,9 +560,6 @@ section add_comm_group
 variables {G : Type u} [add_comm_group G] {a b c d : G}
 
 local attribute [simp] add_assoc add_comm add_left_comm sub_eq_add_neg
-
-theorem neg_add' (a b : G) : -(a + b) = -a - b :=
-by rw [sub_eq_add_neg, neg_add a b]
 
 @[simp]
 lemma neg_sub_neg (a b : G) : -a - -b = b - a :=

--- a/src/algebra/group/basic.lean
+++ b/src/algebra/group/basic.lean
@@ -572,6 +572,10 @@ by rw [div_eq_inv_mul', inv_mul_cancel_left]
 lemma mul_div_cancel'_right (a b : G) : a * (b / a) = b :=
 by rw [← mul_div_assoc, mul_div_cancel''']
 
+@[simp, to_additive sub_add_cancel']
+lemma div_mul_cancel'' (a b : G) : a / (a * b) = b⁻¹ :=
+by rw [← inv_div', mul_div_cancel''']
+
 end comm_group
 
 section add_comm_group
@@ -580,9 +584,6 @@ section add_comm_group
 variables {G : Type u} [add_comm_group G] {a b c d : G}
 
 local attribute [simp] add_assoc add_comm add_left_comm sub_eq_add_neg
-
-@[simp] lemma sub_add_cancel' (a b : G) : a - (a + b) = -b :=
-by rw [← neg_sub, add_sub_cancel']
 
 -- This lemma is in the `simp` set under the name `add_neg_cancel_comm_assoc`,
 -- defined  in `algebra/group/commute`

--- a/src/algebra/group/basic.lean
+++ b/src/algebra/group/basic.lean
@@ -612,6 +612,9 @@ begin
   simp only [mul_comm, eq_comm]
 end
 
+@[to_additive] lemma div_eq_div_iff_div_eq_div : a / b = c / d ↔ a / c = b / d :=
+by rw [div_eq_iff_eq_mul, div_mul_eq_mul_div', div_eq_iff_eq_mul', mul_div_assoc]
+
 end comm_group
 
 section add_comm_group
@@ -620,8 +623,5 @@ section add_comm_group
 variables {G : Type u} [add_comm_group G] {a b c d : G}
 
 local attribute [simp] add_assoc add_comm add_left_comm sub_eq_add_neg
-
-lemma sub_eq_sub_iff_sub_eq_sub : a - b = c - d ↔ a - c = b - d :=
-by rw [sub_eq_iff_eq_add, sub_add_eq_add_sub, sub_eq_iff_eq_add', add_sub_assoc]
 
 end add_comm_group

--- a/src/algebra/group/basic.lean
+++ b/src/algebra/group/basic.lean
@@ -501,6 +501,9 @@ by simp
 @[to_additive] lemma div_div (a b c : G) : a / b / c = a / (b * c) :=
 by simp
 
+@[to_additive] lemma div_mul (a b c : G) : a / b * c = a / (b / c) :=
+by simp
+
 end comm_group
 
 section add_comm_group
@@ -509,9 +512,6 @@ section add_comm_group
 variables {G : Type u} [add_comm_group G] {a b c d : G}
 
 local attribute [simp] add_assoc add_comm add_left_comm sub_eq_add_neg
-
-lemma sub_add (a b c : G) : a - b + c = a - (b - c) :=
-by simp
 
 @[simp] lemma add_sub_add_left_eq_sub (a b c : G) : (c + a) - (c + b) = a - b :=
 by simp

--- a/src/algebra/group/basic.lean
+++ b/src/algebra/group/basic.lean
@@ -560,6 +560,10 @@ by simp [div_eq_inv_mul', mul_comm]
 lemma eq_div_iff_mul_eq'' : a = b / c ↔ c * a = b :=
 by rw [eq_div_iff_mul_eq', mul_comm]
 
+@[to_additive]
+lemma div_eq_iff_eq_mul' : a / b = c ↔ a = b * c :=
+by rw [div_eq_iff_eq_mul, mul_comm]
+
 end comm_group
 
 section add_comm_group
@@ -568,9 +572,6 @@ section add_comm_group
 variables {G : Type u} [add_comm_group G] {a b c d : G}
 
 local attribute [simp] add_assoc add_comm add_left_comm sub_eq_add_neg
-
-lemma sub_eq_iff_eq_add' : a - b = c ↔ a = b + c :=
-by rw [sub_eq_iff_eq_add, add_comm]
 
 @[simp]
 lemma add_sub_cancel' (a b : G) : a + b - a = b :=

--- a/src/algebra/group/basic.lean
+++ b/src/algebra/group/basic.lean
@@ -586,6 +586,10 @@ by rw [← div_eq_mul_inv, mul_div_cancel'_right a b]
 lemma div_right_comm' (a b c : G) : a / b / c = a / c / b :=
 by { repeat { rw div_eq_mul_inv }, exact mul_right_comm _ _ _ }
 
+@[simp, to_additive]
+lemma mul_mul_div_cancel (a b c : G) : (a * c) * (b / c) = a * b :=
+by rw [mul_assoc, mul_div_cancel'_right]
+
 end comm_group
 
 section add_comm_group
@@ -594,9 +598,6 @@ section add_comm_group
 variables {G : Type u} [add_comm_group G] {a b c d : G}
 
 local attribute [simp] add_assoc add_comm add_left_comm sub_eq_add_neg
-
-@[simp] lemma add_add_sub_cancel (a b c : G) : (a + c) + (b - c) = a + b :=
-by rw [add_assoc, add_sub_cancel'_right]
 
 @[simp] lemma sub_add_add_cancel (a b c : G) : (a - c) + (b + c) = a + b :=
 by rw [add_left_comm, sub_add_cancel, add_comm]

--- a/src/algebra/group/basic.lean
+++ b/src/algebra/group/basic.lean
@@ -530,6 +530,9 @@ by simpa using mul_inv_cancel_left a b
 lemma mul_div_comm' (a b c d : G) : a * b / (c * d) = (a / c) * (b / d) :=
 by simp
 
+@[to_additive] lemma div_eq_div_mul_div (a b c : G) : a / b = c / b * (a / c) :=
+begin simp, rw [mul_left_comm c], simp end
+
 end comm_group
 
 section add_comm_group
@@ -538,9 +541,6 @@ section add_comm_group
 variables {G : Type u} [add_comm_group G] {a b c d : G}
 
 local attribute [simp] add_assoc add_comm add_left_comm sub_eq_add_neg
-
-lemma sub_eq_sub_add_sub (a b c : G) : a - b = c - b + (a - c) :=
-begin simp, rw [add_left_comm c], simp end
 
 lemma neg_neg_sub_neg (a b : G) : - (-a - -b) = a - b :=
 by simp

--- a/src/algebra/group/basic.lean
+++ b/src/algebra/group/basic.lean
@@ -616,12 +616,3 @@ end
 by rw [div_eq_iff_eq_mul, div_mul_eq_mul_div', div_eq_iff_eq_mul', mul_div_assoc]
 
 end comm_group
-
-section add_comm_group
--- TODO: Generalize the contents of this section with to_additive as per
--- https://leanprover.zulipchat.com/#narrow/stream/144837-PR-reviews/topic/.238667
-variables {G : Type u} [add_comm_group G] {a b c d : G}
-
-local attribute [simp] add_assoc add_comm add_left_comm sub_eq_add_neg
-
-end add_comm_group

--- a/src/algebra/group/basic.lean
+++ b/src/algebra/group/basic.lean
@@ -606,6 +606,12 @@ by rw [← div_mul, mul_div_cancel''']
 lemma div_div_div_cancel_left (a b c : G) : (c / a) / (c / b) = b / a :=
 by rw [← inv_div' b c, div_inv_eq_mul, mul_comm, div_mul_div_cancel']
 
+@[to_additive] lemma div_eq_div_iff_mul_eq_mul : a / b = c / d ↔ a * d = c * b :=
+begin
+  rw [div_eq_iff_eq_mul, div_mul_eq_mul_div', eq_comm, div_eq_iff_eq_mul'],
+  simp only [mul_comm, eq_comm]
+end
+
 end comm_group
 
 section add_comm_group
@@ -614,12 +620,6 @@ section add_comm_group
 variables {G : Type u} [add_comm_group G] {a b c d : G}
 
 local attribute [simp] add_assoc add_comm add_left_comm sub_eq_add_neg
-
-lemma sub_eq_sub_iff_add_eq_add : a - b = c - d ↔ a + d = c + b :=
-begin
-  rw [sub_eq_iff_eq_add, sub_add_eq_add_sub, eq_comm, sub_eq_iff_eq_add'],
-  simp only [add_comm, eq_comm]
-end
 
 lemma sub_eq_sub_iff_sub_eq_sub : a - b = c - d ↔ a - c = b - d :=
 by rw [sub_eq_iff_eq_add, sub_add_eq_add_sub, sub_eq_iff_eq_add', add_sub_assoc]

--- a/src/algebra/group/basic.lean
+++ b/src/algebra/group/basic.lean
@@ -498,14 +498,23 @@ by simp
 lemma div_mul_eq_mul_div' (a b c : G) : a / b * c = a * c / b :=
 by simp
 
-@[to_additive] lemma div_div (a b c : G) : a / b / c = a / (b * c) :=
+@[to_additive]
+lemma div_div (a b c : G) : a / b / c = a / (b * c) :=
 by simp
 
-@[to_additive] lemma div_mul (a b c : G) : a / b * c = a / (b / c) :=
+@[to_additive]
+lemma div_mul (a b c : G) : a / b * c = a / (b / c) :=
 by simp
 
-@[simp, to_additive] lemma mul_div_mul_left_eq_div (a b c : G) : (c * a) / (c * b) = a / b :=
+@[simp, to_additive]
+lemma mul_div_mul_left_eq_div (a b c : G) : (c * a) / (c * b) = a / b :=
 by simp
+
+
+
+@[to_additive eq_sub_of_add_eq']
+lemma eq_div_of_mul_eq'' (h : c * a = b) : a = b / c :=
+by simp [h.symm]
 
 end comm_group
 
@@ -515,9 +524,6 @@ section add_comm_group
 variables {G : Type u} [add_comm_group G] {a b c d : G}
 
 local attribute [simp] add_assoc add_comm add_left_comm sub_eq_add_neg
-
-lemma eq_sub_of_add_eq' (h : c + a = b) : a = b - c :=
-by simp [h.symm]
 
 lemma eq_add_of_sub_eq' (h : a - b = c) : a = b + c :=
 by simp [h.symm]

--- a/src/algebra/group/basic.lean
+++ b/src/algebra/group/basic.lean
@@ -576,6 +576,11 @@ by rw [← mul_div_assoc, mul_div_cancel''']
 lemma div_mul_cancel'' (a b : G) : a / (a * b) = b⁻¹ :=
 by rw [← inv_div', mul_div_cancel''']
 
+-- This lemma is in the `simp` set under the name `add_neg_cancel_comm_assoc`,
+-- defined  in `algebra/group/commute`
+@[to_additive] lemma mul_mul_inv_cancel'_right (a b : G) : a * (b * a⁻¹) = b :=
+by rw [← div_eq_mul_inv, mul_div_cancel'_right a b]
+
 end comm_group
 
 section add_comm_group
@@ -584,11 +589,6 @@ section add_comm_group
 variables {G : Type u} [add_comm_group G] {a b c d : G}
 
 local attribute [simp] add_assoc add_comm add_left_comm sub_eq_add_neg
-
--- This lemma is in the `simp` set under the name `add_neg_cancel_comm_assoc`,
--- defined  in `algebra/group/commute`
-lemma add_add_neg_cancel'_right (a b : G) : a + (b + -a) = b :=
-by rw [← sub_eq_add_neg, add_sub_cancel'_right a b]
 
 lemma sub_right_comm (a b c : G) : a - b - c = a - c - b :=
 by { repeat { rw sub_eq_add_neg }, exact add_right_comm _ _ _ }

--- a/src/algebra/group/basic.lean
+++ b/src/algebra/group/basic.lean
@@ -594,6 +594,10 @@ by rw [mul_assoc, mul_div_cancel'_right]
 lemma div_mul_mul_cancel (a b c : G) : (a / c) * (b * c) = a * b :=
 by rw [mul_left_comm, div_mul_cancel', mul_comm]
 
+@[simp, to_additive sub_add_sub_cancel']
+lemma div_mul_div_cancel'' (a b c : G) : (a / b) * (c / a) = c / b :=
+by rw mul_comm; apply div_mul_div_cancel'
+
 end comm_group
 
 section add_comm_group
@@ -602,9 +606,6 @@ section add_comm_group
 variables {G : Type u} [add_comm_group G] {a b c d : G}
 
 local attribute [simp] add_assoc add_comm add_left_comm sub_eq_add_neg
-
-@[simp] lemma sub_add_sub_cancel' (a b c : G) : (a - b) + (c - a) = c - b :=
-by rw add_comm; apply sub_add_sub_cancel
 
 @[simp] lemma add_sub_sub_cancel (a b c : G) : (a + b) - (a - c) = b + c :=
 by rw [← sub_add, add_sub_cancel']

--- a/src/algebra/group/basic.lean
+++ b/src/algebra/group/basic.lean
@@ -552,6 +552,10 @@ lemma div_div_cancel_left (a b : G) : a / b / a = b⁻¹ := by simp
 theorem inv_mul' (a b : G) : (a * b)⁻¹ = a⁻¹ / b :=
 by rw [div_eq_mul_inv, mul_inv a b]
 
+@[simp, to_additive]
+lemma inv_div_inv (a b : G) : a⁻¹ / b⁻¹ = b / a :=
+by simp [div_eq_inv_mul', mul_comm]
+
 end comm_group
 
 section add_comm_group
@@ -560,10 +564,6 @@ section add_comm_group
 variables {G : Type u} [add_comm_group G] {a b c d : G}
 
 local attribute [simp] add_assoc add_comm add_left_comm sub_eq_add_neg
-
-@[simp]
-lemma neg_sub_neg (a b : G) : -a - -b = b - a :=
-by simp [sub_eq_neg_add, add_comm]
 
 lemma eq_sub_iff_add_eq' : a = b - c ↔ c + a = b :=
 by rw [eq_sub_iff_add_eq, add_comm]

--- a/src/algebra/group/basic.lean
+++ b/src/algebra/group/basic.lean
@@ -576,7 +576,8 @@ by rw [← mul_div_assoc, mul_div_cancel''']
 lemma div_mul_cancel'' (a b : G) : a / (a * b) = b⁻¹ :=
 by rw [← inv_div', mul_div_cancel''']
 
--- This lemma is in the `simp` set under the name `add_neg_cancel_comm_assoc`,
+-- This lemma is in the `simp` set under the name `mul_inv_cancel_comm_assoc`,
+-- along with the additive version `add_neg_cancel_comm_assoc`,
 -- defined  in `algebra/group/commute`
 @[to_additive]
 lemma mul_mul_inv_cancel'_right (a b : G) : a * (b * a⁻¹) = b :=


### PR DESCRIPTION
Currently mathlib has a rich set of lemmas connecting the addition, subtraction and negation additive commutative group operations, but a far thinner collection of results for multiplication, division and inverse multiplicative commutative group operations, despite the fact that the former can be generated easily from the latter via to_additive.

This PR refactors the additive results in the `add_comm_group` section as the equivalent multiplicative results in the `comm_group` section and then recovers the additive results via to_additive. There is a complication in that unfortunately the multiplicative forms of the names of some of the `add_comm_group` lemmas collide with existing names in `group_with_zero`. I have worked around this by appending an apostrophe to the name and then manually overriding the names generated by to_additive. In a few cases, names with `1...n` appended apostrophes already existed. In these cases I have appended `n+1` apostrophes.

Previous discussion

The `add_group` section was previously tackled in #10532.

---

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
