### PR TITLE
[Merged by Bors] - feat(data/finsupp/basic): add `finsupp.prod_congr` and `sum_congr`

### DIFF
--- a/src/data/finsupp/basic.lean
+++ b/src/data/finsupp/basic.lean
@@ -770,6 +770,14 @@ lemma _root_.submonoid.finsupp_prod_mem (S : submonoid N) (f : α →₀ M) (g :
   (h : ∀ c, f c ≠ 0 → g c (f c) ∈ S) : f.prod g ∈ S :=
 S.prod_mem $ λ i hi, h _ (finsupp.mem_support_iff.mp hi)
 
+lemma finsupp.prod_mul_distrib [has_zero M] [comm_monoid N] {f : α →₀ M} (g1 g2 : α → M → N) :
+  f.prod (g1 * g2) = (f.prod g1) * (f.prod g2) :=
+by simp [finsupp.prod, finset.prod_mul_distrib]
+
+lemma finsupp.prod_congr [has_zero M] [comm_monoid N] {f : α →₀ M} (g1 g2 : α → M → N) :
+  (∀ x ∈ f.support, g1 x (f x) = g2 x (f x)) → (f.prod g1 = f.prod g2) :=
+fold_congr
+
 end sum_prod
 
 /-!

--- a/src/data/finsupp/basic.lean
+++ b/src/data/finsupp/basic.lean
@@ -771,7 +771,7 @@ lemma _root_.submonoid.finsupp_prod_mem (S : submonoid N) (f : α →₀ M) (g :
 S.prod_mem $ λ i hi, h _ (finsupp.mem_support_iff.mp hi)
 
 @[to_additive]
-lemma prod_congr [has_zero M] [comm_monoid N] {f : α →₀ M} {g1 g2 : α → M → N}
+lemma prod_congr {f : α →₀ M} {g1 g2 : α → M → N}
   (h : ∀ x ∈ f.support, g1 x (f x) = g2 x (f x)) : f.prod g1 = f.prod g2 :=
 finset.prod_congr rfl h
 

--- a/src/data/finsupp/basic.lean
+++ b/src/data/finsupp/basic.lean
@@ -1443,7 +1443,7 @@ begin
   refine ((sum_sum_index _ _).trans _).symm,
   { intros, exact single_zero },
   { intros, exact single_add },
-  refine sum_congr rfl (λ _ _, sum_single_index _),
+  refine finset.sum_congr rfl (λ _ _, sum_single_index _),
   { exact single_zero }
 end
 
@@ -1502,7 +1502,7 @@ finset.subset.trans support_sum $
 lemma prod_map_domain_index [comm_monoid N] {f : α → β} {s : α →₀ M}
   {h : β → M → N} (h_zero : ∀b, h b 0 = 1) (h_add : ∀b m₁ m₂, h b (m₁ + m₂) = h b m₁ * h b m₂) :
   (map_domain f s).prod h = s.prod (λa m, h (f a) m) :=
-(prod_sum_index h_zero h_add).trans $ prod_congr rfl $ λ _ _, prod_single_index (h_zero _)
+(prod_sum_index h_zero h_add).trans $ finset.prod_congr rfl $ λ _ _, prod_single_index (h_zero _)
 
 /--
 A version of `sum_map_domain_index` that takes a bundled `add_monoid_hom`,

--- a/src/data/finsupp/basic.lean
+++ b/src/data/finsupp/basic.lean
@@ -1502,7 +1502,7 @@ finset.subset.trans support_sum $
 lemma prod_map_domain_index [comm_monoid N] {f : α → β} {s : α →₀ M}
   {h : β → M → N} (h_zero : ∀b, h b 0 = 1) (h_add : ∀b m₁ m₂, h b (m₁ + m₂) = h b m₁ * h b m₂) :
   (map_domain f s).prod h = s.prod (λa m, h (f a) m) :=
-(prod_sum_index h_zero h_add).trans $ prod_congr  $ λ _ _, prod_single_index (h_zero _)
+(prod_sum_index h_zero h_add).trans $ prod_congr $ λ _ _, prod_single_index (h_zero _)
 
 /--
 A version of `sum_map_domain_index` that takes a bundled `add_monoid_hom`,

--- a/src/data/finsupp/basic.lean
+++ b/src/data/finsupp/basic.lean
@@ -771,7 +771,7 @@ lemma _root_.submonoid.finsupp_prod_mem (S : submonoid N) (f : α →₀ M) (g :
 S.prod_mem $ λ i hi, h _ (finsupp.mem_support_iff.mp hi)
 
 @[to_additive]
-lemma prod_congr [has_zero M] [comm_monoid N] {f : α →₀ M} (g1 g2 : α → M → N)
+lemma prod_congr [has_zero M] [comm_monoid N] {f : α →₀ M} {g1 g2 : α → M → N}
   (h : ∀ x ∈ f.support, g1 x (f x) = g2 x (f x)) : f.prod g1 = f.prod g2 :=
 finset.prod_congr rfl h
 
@@ -1443,7 +1443,7 @@ begin
   refine ((sum_sum_index _ _).trans _).symm,
   { intros, exact single_zero },
   { intros, exact single_add },
-  refine finset.sum_congr rfl (λ _ _, sum_single_index _),
+  refine sum_congr (λ _ _, sum_single_index _),
   { exact single_zero }
 end
 

--- a/src/data/finsupp/basic.lean
+++ b/src/data/finsupp/basic.lean
@@ -770,10 +770,6 @@ lemma _root_.submonoid.finsupp_prod_mem (S : submonoid N) (f : α →₀ M) (g :
   (h : ∀ c, f c ≠ 0 → g c (f c) ∈ S) : f.prod g ∈ S :=
 S.prod_mem $ λ i hi, h _ (finsupp.mem_support_iff.mp hi)
 
-lemma finsupp.prod_mul_distrib [has_zero M] [comm_monoid N] {f : α →₀ M} (g1 g2 : α → M → N) :
-  f.prod (g1 * g2) = (f.prod g1) * (f.prod g2) :=
-by simp [finsupp.prod, finset.prod_mul_distrib]
-
 @[to_additive]
 lemma prod_congr [has_zero M] [comm_monoid N] {f : α →₀ M} (g1 g2 : α → M → N)
   (h : ∀ x ∈ f.support, g1 x (f x) = g2 x (f x)) : f.prod g1 = f.prod g2 :=

--- a/src/data/finsupp/basic.lean
+++ b/src/data/finsupp/basic.lean
@@ -774,9 +774,10 @@ lemma finsupp.prod_mul_distrib [has_zero M] [comm_monoid N] {f : α →₀ M} (g
   f.prod (g1 * g2) = (f.prod g1) * (f.prod g2) :=
 by simp [finsupp.prod, finset.prod_mul_distrib]
 
-lemma finsupp.prod_congr [has_zero M] [comm_monoid N] {f : α →₀ M} (g1 g2 : α → M → N) :
-  (∀ x ∈ f.support, g1 x (f x) = g2 x (f x)) → (f.prod g1 = f.prod g2) :=
-fold_congr
+@[to_additive]
+lemma prod_congr [has_zero M] [comm_monoid N] {f : α →₀ M} (g1 g2 : α → M → N)
+  (h : ∀ x ∈ f.support, g1 x (f x) = g2 x (f x)) : f.prod g1 = f.prod g2 :=
+finset.prod_congr rfl h
 
 end sum_prod
 

--- a/src/data/finsupp/basic.lean
+++ b/src/data/finsupp/basic.lean
@@ -1502,7 +1502,7 @@ finset.subset.trans support_sum $
 lemma prod_map_domain_index [comm_monoid N] {f : α → β} {s : α →₀ M}
   {h : β → M → N} (h_zero : ∀b, h b 0 = 1) (h_add : ∀b m₁ m₂, h b (m₁ + m₂) = h b m₁ * h b m₂) :
   (map_domain f s).prod h = s.prod (λa m, h (f a) m) :=
-(prod_sum_index h_zero h_add).trans $ finset.prod_congr rfl $ λ _ _, prod_single_index (h_zero _)
+(prod_sum_index h_zero h_add).trans $ prod_congr  $ λ _ _, prod_single_index (h_zero _)
 
 /--
 A version of `sum_map_domain_index` that takes a bundled `add_monoid_hom`,


### PR DESCRIPTION
These are the counterparts for `finsupp` of a simpler form of `finset.prod_congr`

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
