### PR TITLE
[Merged by Bors] - feat(data/finsupp/basic): add `nat.cast_finsupp_prod` and 3 others

### DIFF
--- a/src/data/finsupp/basic.lean
+++ b/src/data/finsupp/basic.lean
@@ -2761,11 +2761,11 @@ variables [has_zero M] (f : α →₀ M)
 namespace nat
 
 @[simp, norm_cast] lemma cast_finsupp_prod [comm_semiring R] (g : α → M → ℕ) :
-  (↑(f.prod g) : R) = f.prod (λ a b, (↑(g a b))) :=
+  (↑(f.prod g) : R) = f.prod (λ a b, ↑(g a b)) :=
 nat.cast_prod _ _
 
 @[simp, norm_cast] lemma cast_finsupp_sum [comm_semiring R] (g : α → M → ℕ) :
-  (↑(f.sum g) : R) = f.sum (λ a b, (↑(g a b))) :=
+  (↑(f.sum g) : R) = f.sum (λ a b, ↑(g a b)) :=
 nat.cast_sum _ _
 
 end nat
@@ -2773,11 +2773,11 @@ end nat
 namespace int
 
 @[simp, norm_cast] lemma cast_finsupp_prod [comm_ring R] (g : α → M → ℤ) :
-  (↑(f.prod g) : R) = f.prod (λ a b, (↑(g a b))) :=
+  (↑(f.prod g) : R) = f.prod (λ a b, ↑(g a b)) :=
 int.cast_prod _ _
 
 @[simp, norm_cast] lemma cast_finsupp_sum [comm_ring R] (g : α → M → ℤ) :
-  (↑(f.sum g) : R) = f.sum (λ a b, (↑(g a b))) :=
+  (↑(f.sum g) : R) = f.sum (λ a b, ↑(g a b)) :=
 int.cast_sum _ _
 
 end int

--- a/src/data/finsupp/basic.lean
+++ b/src/data/finsupp/basic.lean
@@ -2754,3 +2754,31 @@ lemma to_finsuppstrict_mono : strict_mono (@to_finsupp α) :=
 finsupp.order_iso_multiset.symm.strict_mono
 
 end multiset
+
+section cast_finsupp
+variables [has_zero M] {f : α →₀ M}
+
+namespace nat
+
+@[simp, norm_cast] lemma cast_finsupp_prod [comm_semiring R] (g : α → M → ℕ) :
+  (↑(f.prod g) : R) = f.prod (λ a b, (↑(g a b))) :=
+by push_cast [finsupp.prod]
+
+@[simp, norm_cast] lemma cast_finsupp_sum [comm_semiring R] (g : α → M → ℕ) :
+  (↑(f.sum g) : R) = f.sum (λ a b, (↑(g a b))) :=
+by push_cast [finsupp.sum]
+
+end nat
+
+namespace int
+
+@[simp, norm_cast] lemma cast_finsupp_prod [comm_ring R] (g : α → M → ℤ) :
+  (↑(f.prod g) : R) = f.prod (λ a b, (↑(g a b))) :=
+by push_cast [finsupp.prod]
+
+@[simp, norm_cast] lemma cast_finsupp_sum [comm_ring R] (g : α → M → ℤ) :
+  (↑(f.sum g) : R) = f.sum (λ a b, (↑(g a b))) :=
+by push_cast [finsupp.sum]
+
+end int
+end cast_finsupp

--- a/src/data/finsupp/basic.lean
+++ b/src/data/finsupp/basic.lean
@@ -2756,17 +2756,17 @@ finsupp.order_iso_multiset.symm.strict_mono
 end multiset
 
 section cast_finsupp
-variables [has_zero M] {f : α →₀ M}
+variables [has_zero M] (f : α →₀ M)
 
 namespace nat
 
 @[simp, norm_cast] lemma cast_finsupp_prod [comm_semiring R] (g : α → M → ℕ) :
   (↑(f.prod g) : R) = f.prod (λ a b, (↑(g a b))) :=
-by push_cast [finsupp.prod]
+nat.cast_prod _ _
 
 @[simp, norm_cast] lemma cast_finsupp_sum [comm_semiring R] (g : α → M → ℕ) :
   (↑(f.sum g) : R) = f.sum (λ a b, (↑(g a b))) :=
-by push_cast [finsupp.sum]
+nat.cast_sum _ _
 
 end nat
 
@@ -2774,11 +2774,11 @@ namespace int
 
 @[simp, norm_cast] lemma cast_finsupp_prod [comm_ring R] (g : α → M → ℤ) :
   (↑(f.prod g) : R) = f.prod (λ a b, (↑(g a b))) :=
-by push_cast [finsupp.prod]
+int.cast_prod _ _
 
 @[simp, norm_cast] lemma cast_finsupp_sum [comm_ring R] (g : α → M → ℤ) :
   (↑(f.sum g) : R) = f.sum (λ a b, (↑(g a b))) :=
-by push_cast [finsupp.sum]
+int.cast_sum _ _
 
 end int
 end cast_finsupp


### PR DESCRIPTION
Add counterparts for `finsupp` of `nat.cast_prod` etc., as discussed in this thread https://leanprover.zulipchat.com/#narrow/stream/217875-Is-there.20code.20for.20X.3F/topic/push_cast



---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
