### PR TITLE
[Merged by Bors] - feat(data/finset/basic): add ite_subset_union, inter_subset_ite for finset

### DIFF
--- a/src/data/finset/basic.lean
+++ b/src/data/finset/basic.lean
@@ -840,14 +840,6 @@ begin
     exact ⟨hk hbj, trans hti hk'⟩ }
 end
 
-lemma ite_subset_union (s s' : finset α) (P : Prop) [decidable P] :
-  ite P s s' ⊆ s ∪ s' :=
-begin
-  split_ifs,
-  exact finset.subset_union_left s s',
-  exact finset.subset_union_right s s',
-end
-
 /-! ### inter -/
 
 /-- `s ∩ t` is the set such that `a ∈ s ∩ t` iff `a ∈ s` and `a ∈ t`. -/
@@ -956,14 +948,6 @@ finset.inter_subset_inter h (finset.subset.refl _)
 lemma inter_subset_inter_left {x y s : finset α} (h : x ⊆ y) : s ∩ x ⊆ s ∩ y :=
 finset.inter_subset_inter (finset.subset.refl _) h
 
-lemma inter_subset_ite (s s' : finset α) (P : Prop) [decidable P] :
-  s ∩ s' ⊆ ite P s s' :=
-begin
-  split_ifs,
-  exact finset.inter_subset_left s s',
-  exact finset.inter_subset_right s s',
-end
-
 /-! ### lattice laws -/
 
 instance : lattice (finset α) :=
@@ -1023,6 +1007,12 @@ theorem inter_eq_left_iff_subset (s t : finset α) :
 theorem inter_eq_right_iff_subset (s t : finset α) :
   t ∩ s = s ↔ s ⊆ t :=
 (inf_eq_right : t ⊓ s = s ↔ s ≤ t)
+
+lemma ite_subset_union (s s' : finset α) (P : Prop) [decidable P] :
+  ite P s s' ⊆ s ∪ s' := ite_le_sup s s' P
+
+lemma inter_subset_ite (s s' : finset α) (P : Prop) [decidable P] :
+  s ∩ s' ⊆ ite P s s' := inf_le_ite s s' P
 
 /-! ### erase -/
 

--- a/src/data/finset/basic.lean
+++ b/src/data/finset/basic.lean
@@ -840,6 +840,14 @@ begin
     exact ⟨hk hbj, trans hti hk'⟩ }
 end
 
+lemma ite_subset_union (s s' : finset α) (P : Prop) [decidable P] :
+  ite P s s' ⊆ s ∪ s' :=
+begin
+  split_ifs,
+  exact finset.subset_union_left s s',
+  exact finset.subset_union_right s s',
+end
+
 /-! ### inter -/
 
 /-- `s ∩ t` is the set such that `a ∈ s ∩ t` iff `a ∈ s` and `a ∈ t`. -/
@@ -947,6 +955,14 @@ finset.inter_subset_inter h (finset.subset.refl _)
 
 lemma inter_subset_inter_left {x y s : finset α} (h : x ⊆ y) : s ∩ x ⊆ s ∩ y :=
 finset.inter_subset_inter (finset.subset.refl _) h
+
+lemma inter_subset_ite (s s' : finset α) (P : Prop) [decidable P] :
+  s ∩ s' ⊆ ite P s s' :=
+begin
+  split_ifs,
+  exact finset.inter_subset_left s s',
+  exact finset.inter_subset_right s s',
+end
 
 /-! ### lattice laws -/
 

--- a/src/order/lattice.lean
+++ b/src/order/lattice.lean
@@ -273,6 +273,9 @@ begin
   exacts [⟨a, b, (hb a).lt_of_ne hne⟩, ⟨b, H⟩]
 end
 
+lemma ite_le_sup (s s' : α) (P : Prop) [decidable P] : ite P s s' ≤ s ⊔ s' :=
+if h : P then (if_pos h).trans_le le_sup_left else (if_neg h).trans_le le_sup_right
+
 end semilattice_sup
 
 /-!
@@ -427,6 +430,9 @@ semilattice_inf.ext $ λ _ _, iff.rfl
 theorem exists_lt_of_inf (α : Type*) [semilattice_inf α] [nontrivial α] :
   ∃ a b : α, a < b :=
 let ⟨a, b, h⟩ := exists_lt_of_sup (order_dual α) in ⟨b, a, h⟩
+
+lemma inf_le_ite (s s' : α) (P : Prop) [decidable P] : s ⊓ s' ≤ ite P s s' :=
+if h : P then inf_le_left.trans_eq (if_pos h).symm else inf_le_right.trans_eq (if_neg h).symm
 
 end semilattice_inf
 


### PR DESCRIPTION
Just a couple of lemmas to simplify expressions involving ite and union / inter on finsets, note that this is not related to `set.ite`.
From flt-regular.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
