### PR TITLE
[Merged by Bors] - feat(data/int/basic): four lemmas about integer divisibility

### DIFF
--- a/src/algebra/ring/basic.lean
+++ b/src/algebra/ring/basic.lean
@@ -582,6 +582,10 @@ protected def function.surjective.comm_semiring [has_zero γ] [has_one γ] [has_
 lemma add_mul_self_eq (a b : α) : (a + b) * (a + b) = a*a + 2*a*b + b*b :=
 by simp only [two_mul, add_mul, mul_add, add_assoc, mul_comm b]
 
+lemma dvd_linear {α : Type*} [comm_semiring α] {d x y a b : α} (hdx : d ∣ x) (hdy : d ∣ y) :
+  d ∣ (a*x + b*y) :=
+dvd_add (hdx.mul_left a) (hdy.mul_left b)
+
 end comm_semiring
 
 /-!

--- a/src/algebra/ring/basic.lean
+++ b/src/algebra/ring/basic.lean
@@ -582,8 +582,8 @@ protected def function.surjective.comm_semiring [has_zero γ] [has_one γ] [has_
 lemma add_mul_self_eq (a b : α) : (a + b) * (a + b) = a*a + 2*a*b + b*b :=
 by simp only [two_mul, add_mul, mul_add, add_assoc, mul_comm b]
 
-lemma dvd_linear {α : Type*} [comm_semiring α] {d x y a b : α} (hdx : d ∣ x) (hdy : d ∣ y) :
-  d ∣ (a*x + b*y) :=
+lemma has_dvd.dvd.linear_comb {d x y : α} (hdx : d ∣ x) (hdy : d ∣ y) (a b : α) :
+  d ∣ (a * x + b * y) :=
 dvd_add (hdx.mul_left a) (hdy.mul_left b)
 
 end comm_semiring

--- a/src/data/int/basic.lean
+++ b/src/data/int/basic.lean
@@ -1047,27 +1047,16 @@ end
 @[simp] theorem neg_add_neg (m n : ℕ) : -[1+m] + -[1+n] = -[1+nat.succ(m+n)] := rfl
 
 lemma dvd_linear {d x y a b : ℤ} (hdx : d ∣ x) (hdy : d ∣ y) :  d ∣ (a*x + b*y) :=
-begin
-  rcases hdx with ⟨c1, hc1⟩,
-  rcases hdy with ⟨c2, hc2⟩,
-  simp only [hc1, hc2, mul_left_comm a d c1, mul_left_comm b d c2, ←mul_add, dvd_mul_right],
-end
+dvd_add (hdx.mul_left a) (hdy.mul_left b)
 
-lemma abs_le_of_dvd_ne_zero {s t : ℤ} (hst : s ∣ t) (ht : t ≠ 0) : nat_abs s ≤ nat_abs t :=
-  not_lt.mp (mt (eq_zero_of_dvd_of_nat_abs_lt_nat_abs hst) ht)
+lemma nat_abs_le_of_dvd_ne_zero {s t : ℤ} (hst : s ∣ t) (ht : t ≠ 0) : nat_abs s ≤ nat_abs t :=
+not_lt.mp (mt (eq_zero_of_dvd_of_nat_abs_lt_nat_abs hst) ht)
 
 lemma abs_eq_of_dvd_dvd {s t : ℤ} (hst : s ∣ t) (hts : t ∣ s) : nat_abs s = nat_abs t :=
-begin
-  by_cases hs : s = 0, { rw hs at hst, rw [hs, zero_dvd_iff.mp hst] },
-  by_cases ht : t = 0, { rw ht at hts, rw [ht, zero_dvd_iff.mp hts] },
-  exact le_antisymm (abs_le_of_dvd_ne_zero hst ht) (abs_le_of_dvd_ne_zero hts hs),
-end
+nat.dvd_antisymm (nat_abs_dvd_iff_dvd.mpr hst) (nat_abs_dvd_iff_dvd.mpr hts)
 
-lemma div_dvd_of_neq_zero_dvd {s t : ℤ} (hst : s ∣ t) (hs : s ≠ 0) : (t / s) ∣ t :=
-begin
-  rcases hst with ⟨c, hc⟩,
-  simp [hc, int.mul_div_cancel_left _ hs],
-end
+lemma div_dvd_of_ne_zero_dvd {s t : ℤ} (hst : s ∣ t) (hs : s ≠ 0) : (t / s) ∣ t :=
+by { rcases hst with ⟨c, hc⟩, simp [hc, int.mul_div_cancel_left _ hs] }
 
 /-! ### to_nat -/
 

--- a/src/data/int/basic.lean
+++ b/src/data/int/basic.lean
@@ -1046,6 +1046,29 @@ end
 
 @[simp] theorem neg_add_neg (m n : ℕ) : -[1+m] + -[1+n] = -[1+nat.succ(m+n)] := rfl
 
+lemma dvd_linear {d x y a b : ℤ} (hdx : d ∣ x) (hdy : d ∣ y) :  d ∣ (a*x + b*y) :=
+begin
+  rcases hdx with ⟨c1, hc1⟩,
+  rcases hdy with ⟨c2, hc2⟩,
+  simp only [hc1, hc2, mul_left_comm a d c1, mul_left_comm b d c2, ←mul_add, dvd_mul_right],
+end
+
+lemma abs_le_of_dvd_ne_zero {s t : ℤ} (hst : s ∣ t) (ht : t ≠ 0) : nat_abs s ≤ nat_abs t :=
+  not_lt.mp (mt (eq_zero_of_dvd_of_nat_abs_lt_nat_abs hst) ht)
+
+lemma abs_eq_of_dvd_dvd {s t : ℤ} (hst : s ∣ t) (hts : t ∣ s) : nat_abs s = nat_abs t :=
+begin
+  by_cases hs : s = 0, { rw hs at hst, rw [hs, zero_dvd_iff.mp hst] },
+  by_cases ht : t = 0, { rw ht at hts, rw [ht, zero_dvd_iff.mp hts] },
+  exact le_antisymm (abs_le_of_dvd_ne_zero hst ht) (abs_le_of_dvd_ne_zero hts hs),
+end
+
+lemma div_dvd_of_neq_zero_dvd {s t : ℤ} (hst : s ∣ t) (hs : s ≠ 0) : (t / s) ∣ t :=
+begin
+  rcases hst with ⟨c, hc⟩,
+  simp [hc, int.mul_div_cancel_left _ hs],
+end
+
 /-! ### to_nat -/
 
 theorem to_nat_eq_max : ∀ (a : ℤ), (to_nat a : ℤ) = max a 0

--- a/src/data/int/basic.lean
+++ b/src/data/int/basic.lean
@@ -1049,7 +1049,7 @@ end
 lemma nat_abs_le_of_dvd_ne_zero {s t : ℤ} (hst : s ∣ t) (ht : t ≠ 0) : nat_abs s ≤ nat_abs t :=
 not_lt.mp (mt (eq_zero_of_dvd_of_nat_abs_lt_nat_abs hst) ht)
 
-lemma abs_eq_of_dvd_dvd {s t : ℤ} (hst : s ∣ t) (hts : t ∣ s) : nat_abs s = nat_abs t :=
+lemma nat_abs_eq_of_dvd_dvd {s t : ℤ} (hst : s ∣ t) (hts : t ∣ s) : nat_abs s = nat_abs t :=
 nat.dvd_antisymm (nat_abs_dvd_iff_dvd.mpr hst) (nat_abs_dvd_iff_dvd.mpr hts)
 
 lemma div_dvd_of_ne_zero_dvd {s t : ℤ} (hst : s ∣ t) (hs : s ≠ 0) : (t / s) ∣ t :=

--- a/src/data/int/basic.lean
+++ b/src/data/int/basic.lean
@@ -1046,9 +1046,6 @@ end
 
 @[simp] theorem neg_add_neg (m n : ℕ) : -[1+m] + -[1+n] = -[1+nat.succ(m+n)] := rfl
 
-lemma dvd_linear {d x y a b : ℤ} (hdx : d ∣ x) (hdy : d ∣ y) :  d ∣ (a*x + b*y) :=
-dvd_add (hdx.mul_left a) (hdy.mul_left b)
-
 lemma nat_abs_le_of_dvd_ne_zero {s t : ℤ} (hst : s ∣ t) (ht : t ≠ 0) : nat_abs s ≤ nat_abs t :=
 not_lt.mp (mt (eq_zero_of_dvd_of_nat_abs_lt_nat_abs hst) ht)
 


### PR DESCRIPTION
Theorem 1.1, parts (c), (i), (j), and (k) of Apostol (1976) Introduction to Analytic Number Theory

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
