### PR TITLE
[Merged by Bors] - feat(data/finset/basic): val_le_iff_val_subset

### DIFF
--- a/src/data/finset/basic.lean
+++ b/src/data/finset/basic.lean
@@ -1782,7 +1782,7 @@ namespace finset
 @[simp] lemma val_to_finset [decidable_eq α] (s : finset α) : s.val.to_finset = s :=
 by { ext, rw [multiset.mem_to_finset, ←mem_def] }
 
-lemma val_le_iff_val_subset [decidable_eq α] {a : finset α} {b : multiset α} :
+lemma val_le_iff_val_subset {a : finset α} {b : multiset α} :
   a.val ≤ b ↔ a.val ⊆ b := multiset.le_iff_subset a.nodup
 
 end finset

--- a/src/data/finset/basic.lean
+++ b/src/data/finset/basic.lean
@@ -1782,6 +1782,9 @@ namespace finset
 @[simp] lemma val_to_finset [decidable_eq α] (s : finset α) : s.val.to_finset = s :=
 by { ext, rw [multiset.mem_to_finset, ←mem_def] }
 
+lemma val_le_of_val_subset [decidable_eq α] {a : finset α} {b : multiset α} (h : a.val ⊆ b) :
+  a.val ≤ b := le_of_subset_of_nodup h a.nodup
+
 end finset
 
 namespace list

--- a/src/data/finset/basic.lean
+++ b/src/data/finset/basic.lean
@@ -1783,7 +1783,7 @@ namespace finset
 by { ext, rw [multiset.mem_to_finset, ←mem_def] }
 
 lemma val_le_of_val_subset [decidable_eq α] {a : finset α} {b : multiset α} (h : a.val ⊆ b) :
-  a.val ≤ b := le_of_subset_of_nodup h a.nodup
+  a.val ≤ b := multiset.le_of_subset_of_nodup h a.nodup
 
 end finset
 

--- a/src/data/finset/basic.lean
+++ b/src/data/finset/basic.lean
@@ -1782,8 +1782,8 @@ namespace finset
 @[simp] lemma val_to_finset [decidable_eq α] (s : finset α) : s.val.to_finset = s :=
 by { ext, rw [multiset.mem_to_finset, ←mem_def] }
 
-lemma val_le_of_val_subset [decidable_eq α] {a : finset α} {b : multiset α} (h : a.val ⊆ b) :
-  a.val ≤ b := multiset.le_of_subset_of_nodup h a.nodup
+lemma val_le_iff_val_subset [decidable_eq α] {a : finset α} {b : multiset α} :
+  a.val ≤ b ↔ a.val ⊆ b := multiset.le_iff_subset a.nodup
 
 end finset
 

--- a/src/data/multiset/basic.lean
+++ b/src/data/multiset/basic.lean
@@ -2043,7 +2043,8 @@ theorem count_ne_zero {a : α} {s : multiset α} : count a s ≠ 0 ↔ a ∈ s :
 by simp [ne.def, count_eq_zero]
 
 theorem one_le_count_of_mem {x :α} {a : multiset α} (h : x ∈ a) : 1 ≤ a.count x :=
-by simpa only [multiset.count_singleton, if_pos] using multiset.count_le_of_le x ( multiset.singleton_le.2 h)
+by simpa only [multiset.count_singleton, if_pos] using multiset.count_le_of_le x
+  ( multiset.singleton_le.2 h)
 
 @[simp] theorem count_repeat_self (a : α) (n : ℕ) : count a (repeat a n) = n :=
 by simp [repeat]

--- a/src/data/multiset/basic.lean
+++ b/src/data/multiset/basic.lean
@@ -2043,7 +2043,8 @@ theorem count_ne_zero {a : α} {s : multiset α} : count a s ≠ 0 ↔ a ∈ s :
 by simp [ne.def, count_eq_zero]
 
 theorem one_le_count_iff_mem {x : α} {a : multiset α} : 1 ≤ a.count x ↔ x ∈ a :=
-⟨count_ne_zero.1 ∘ one_le_iff_ne_zero.1 , λ h, count_singleton_self x ▸ count_le_of_le x $ singleton_le.2 h⟩
+⟨count_ne_zero.1 ∘ one_le_iff_ne_zero.1 ,
+  λ h, count_singleton_self x ▸ count_le_of_le x $ singleton_le.2 h⟩
 
 @[simp] theorem count_repeat_self (a : α) (n : ℕ) : count a (repeat a n) = n :=
 by simp [repeat]

--- a/src/data/multiset/basic.lean
+++ b/src/data/multiset/basic.lean
@@ -2032,6 +2032,9 @@ by induction n; simp [*, succ_nsmul', succ_mul, zero_nsmul]
 theorem count_pos {a : α} {s : multiset α} : 0 < count a s ↔ a ∈ s :=
 by simp [count, countp_pos]
 
+theorem one_le_count_iff_mem {a : α} {s : multiset α} : 1 ≤ count a s ↔ a ∈ s :=
+by rw [succ_le_iff, count_pos]
+
 @[simp, priority 980]
 theorem count_eq_zero_of_not_mem {a : α} {s : multiset α} (h : a ∉ s) : count a s = 0 :=
 by_contradiction $ λ h', h $ count_pos.1 (nat.pos_of_ne_zero h')
@@ -2041,10 +2044,6 @@ iff_not_comm.1 $ count_pos.symm.trans pos_iff_ne_zero
 
 theorem count_ne_zero {a : α} {s : multiset α} : count a s ≠ 0 ↔ a ∈ s :=
 by simp [ne.def, count_eq_zero]
-
-theorem one_le_count_iff_mem {x : α} {a : multiset α} : 1 ≤ a.count x ↔ x ∈ a :=
-⟨count_ne_zero.1 ∘ one_le_iff_ne_zero.1 ,
-  λ h, count_singleton_self x ▸ count_le_of_le x $ singleton_le.2 h⟩
 
 @[simp] theorem count_repeat_self (a : α) (n : ℕ) : count a (repeat a n) = n :=
 by simp [repeat]

--- a/src/data/multiset/basic.lean
+++ b/src/data/multiset/basic.lean
@@ -2042,11 +2042,8 @@ iff_not_comm.1 $ count_pos.symm.trans pos_iff_ne_zero
 theorem count_ne_zero {a : α} {s : multiset α} : count a s ≠ 0 ↔ a ∈ s :=
 by simp [ne.def, count_eq_zero]
 
-theorem one_le_count_of_mem {x : α} {a : multiset α} (h : x ∈ a) : 1 ≤ a.count x :=
-count_singleton_self x ▸ count_le_of_le x $ singleton_le.2 h
-
 theorem one_le_count_iff_mem {x : α} {a : multiset α} : 1 ≤ a.count x ↔ x ∈ a :=
-⟨count_ne_zero.1 ∘ one_le_iff_ne_zero.1 , one_le_count_of_mem⟩
+⟨count_ne_zero.1 ∘ one_le_iff_ne_zero.1 , λ h, count_singleton_self x ▸ count_le_of_le x $ singleton_le.2 h⟩
 
 @[simp] theorem count_repeat_self (a : α) (n : ℕ) : count a (repeat a n) = n :=
 by simp [repeat]

--- a/src/data/multiset/basic.lean
+++ b/src/data/multiset/basic.lean
@@ -2042,6 +2042,9 @@ iff_not_comm.1 $ count_pos.symm.trans pos_iff_ne_zero
 theorem count_ne_zero {a : α} {s : multiset α} : count a s ≠ 0 ↔ a ∈ s :=
 by simp [ne.def, count_eq_zero]
 
+theorem one_le_count_of_mem {x :α} {a : multiset α} (h : x ∈ a) : 1 ≤ a.count x :=
+by simpa only [multiset.count_singleton, if_pos] using multiset.count_le_of_le x ( multiset.singleton_le.2 h)
+
 @[simp] theorem count_repeat_self (a : α) (n : ℕ) : count a (repeat a n) = n :=
 by simp [repeat]
 

--- a/src/data/multiset/basic.lean
+++ b/src/data/multiset/basic.lean
@@ -2045,6 +2045,9 @@ by simp [ne.def, count_eq_zero]
 theorem one_le_count_of_mem {x : α} {a : multiset α} (h : x ∈ a) : 1 ≤ a.count x :=
 count_singleton_self x ▸ count_le_of_le x $ singleton_le.2 h
 
+theorem one_le_count_iff_mem {x : α} {a : multiset α} : 1 ≤ a.count x ↔ x ∈ a :=
+⟨count_ne_zero.1 ∘ one_le_iff_ne_zero.1 , one_le_count_of_mem⟩
+
 @[simp] theorem count_repeat_self (a : α) (n : ℕ) : count a (repeat a n) = n :=
 by simp [repeat]
 

--- a/src/data/multiset/basic.lean
+++ b/src/data/multiset/basic.lean
@@ -2042,9 +2042,8 @@ iff_not_comm.1 $ count_pos.symm.trans pos_iff_ne_zero
 theorem count_ne_zero {a : α} {s : multiset α} : count a s ≠ 0 ↔ a ∈ s :=
 by simp [ne.def, count_eq_zero]
 
-theorem one_le_count_of_mem {x :α} {a : multiset α} (h : x ∈ a) : 1 ≤ a.count x :=
-by simpa only [multiset.count_singleton, if_pos] using multiset.count_le_of_le x
-  ( multiset.singleton_le.2 h)
+theorem one_le_count_of_mem {x : α} {a : multiset α} (h : x ∈ a) : 1 ≤ a.count x :=
+count_singleton_self x ▸ count_le_of_le x $ singleton_le.2 h
 
 @[simp] theorem count_repeat_self (a : α) (n : ℕ) : count a (repeat a n) = n :=
 by simp [repeat]

--- a/src/data/multiset/nodup.lean
+++ b/src/data/multiset/nodup.lean
@@ -62,18 +62,6 @@ quot.induction_on s $ λ l, nodup_iff_count_le_one
   (d : nodup s) (h : a ∈ s) : count a s = 1 :=
 le_antisymm (nodup_iff_count_le_one.1 d a) (count_pos.2 h)
 
-theorem le_of_subset_of_nodup [decidable_eq α] {a b : multiset α} (h : a ⊆ b) (h' : a.nodup) :
-  a ≤ b :=
-begin
-  apply le_iff_count.2,
-  intro x,
-  by_cases c : x ∈ a,
-  { rw count_eq_one_of_mem h' c,
-    exact one_le_count_of_mem (multiset.mem_of_subset h c) },
-  rw multiset.count_eq_zero_of_not_mem c,
-  simp,
-end
-
 lemma nodup_iff_pairwise {α} {s : multiset α} : nodup s ↔ pairwise (≠) s :=
 quotient.induction_on s $ λ l, (pairwise_coe_iff_pairwise (by exact λ a b, ne.symm)).symm
 

--- a/src/data/multiset/nodup.lean
+++ b/src/data/multiset/nodup.lean
@@ -62,6 +62,18 @@ quot.induction_on s $ λ l, nodup_iff_count_le_one
   (d : nodup s) (h : a ∈ s) : count a s = 1 :=
 le_antisymm (nodup_iff_count_le_one.1 d a) (count_pos.2 h)
 
+theorem le_of_subset_of_nodup [decidable_eq α] {a b : multiset α} (h : a ⊆ b) (h' : a.nodup) :
+  a ≤ b :=
+begin
+  apply le_iff_count.2,
+  intro x,
+  by_cases c : x ∈ a,
+  { rw count_eq_one_of_mem h' c,
+    exact one_le_count_of_mem (multiset.mem_of_subset h c) },
+  rw multiset.count_eq_zero_of_not_mem c,
+  simp,
+end
+
 lemma nodup_iff_pairwise {α} {s : multiset α} : nodup s ↔ pairwise (≠) s :=
 quotient.induction_on s $ λ l, (pairwise_coe_iff_pairwise (by exact λ a b, ne.symm)).symm
 


### PR DESCRIPTION
I'm not sure if we have something like this already on mathlib. The application of `val_le_of_val_subset` that I have in mind is to deduce

```
theorem polynomial.card_roots'' {F : Type u} [field F]{p : polynomial F}(h : p ≠ 0)
{Z : finset F} (hZ : ∀ z ∈ Z, polynomial.eval z p = 0) : Z.card ≤ p.nat_degree
```
from [polynomial.card_roots' ](https://github.com/leanprover-community/mathlib/blob/1376f53dacd3c3ccd3c345b6b8552cce96c5d0c8/src/data/polynomial/ring_division.lean#L318)

If this approach seems right, I will send the proof of `polynomial.card_roots''` in a follow up PR.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
