### PR TITLE
[Merged by Bors] - feat(data/int/basic): add `nat_abs_eq_nat_abs_iff_*` lemmas for nonnegative and nonpositive arguments

### DIFF
--- a/src/data/int/basic.lean
+++ b/src/data/int/basic.lean
@@ -351,25 +351,25 @@ begin
   cases hk; exact ⟨_, hk⟩
 end
 
-lemma nat_abs_eq_nat_abs_iff_of_nonneg_of_nonneg {a b : ℤ} (ha : 0 ≤ a) (hb : 0 ≤ b) :
+lemma nat_abs_inj_of_nonneg_of_nonneg {a b : ℤ} (ha : 0 ≤ a) (hb : 0 ≤ b) :
   nat_abs a = nat_abs b ↔ a = b :=
 by rw [←sq_eq_sq ha hb, ←nat_abs_eq_iff_sq_eq]
 
-lemma nat_abs_eq_nat_abs_iff_of_nonpos_of_nonpos {a b : ℤ} (ha : a ≤ 0) (hb : b ≤ 0) :
+lemma nat_abs_inj_of_nonpos_of_nonpos {a b : ℤ} (ha : a ≤ 0) (hb : b ≤ 0) :
   nat_abs a = nat_abs b ↔ a = b :=
 by simpa only [int.nat_abs_neg, neg_inj]
- using nat_abs_eq_nat_abs_iff_of_nonneg_of_nonneg
+ using nat_abs_inj_of_nonneg_of_nonneg
   (neg_nonneg_of_nonpos ha) (neg_nonneg_of_nonpos hb)
 
-lemma nat_abs_eq_nat_abs_iff_of_nonneg_of_nonpos {a b : ℤ} (ha : 0 ≤ a) (hb : b ≤ 0) :
+lemma nat_abs_inj_of_nonneg_of_nonpos {a b : ℤ} (ha : 0 ≤ a) (hb : b ≤ 0) :
   nat_abs a = nat_abs b ↔ a = -b :=
 by simpa only [int.nat_abs_neg]
-  using nat_abs_eq_nat_abs_iff_of_nonneg_of_nonneg ha (neg_nonneg_of_nonpos hb)
+  using nat_abs_inj_of_nonneg_of_nonneg ha (neg_nonneg_of_nonpos hb)
 
-lemma nat_abs_eq_nat_abs_iff_of_nonpos_of_nonneg {a b : ℤ} (ha : a ≤ 0) (hb : 0 ≤ b) :
+lemma nat_abs_inj_of_nonpos_of_nonneg {a b : ℤ} (ha : a ≤ 0) (hb : 0 ≤ b) :
   nat_abs a = nat_abs b ↔ -a = b :=
 by simpa only [int.nat_abs_neg]
-  using nat_abs_eq_nat_abs_iff_of_nonneg_of_nonneg (neg_nonneg_of_nonpos ha) hb
+  using nat_abs_inj_of_nonneg_of_nonneg (neg_nonneg_of_nonpos ha) hb
 
 section intervals
 open set

--- a/src/data/int/basic.lean
+++ b/src/data/int/basic.lean
@@ -351,7 +351,7 @@ begin
   cases hk; exact ⟨_, hk⟩
 end
 
-lemma eq_of_nat_abs_eq_non_neg {a b : ℤ} (ha : 0 ≤ a) (hb : 0 ≤ b) (h : nat_abs a = nat_abs b) :
+lemma eq_of_nat_abs_eq_nonneg {a b : ℤ} (ha : 0 ≤ a) (hb : 0 ≤ b) (h : nat_abs a = nat_abs b) :
   a = b :=
 by rwa [←sq_eq_sq ha hb, ←nat_abs_eq_iff_sq_eq]
 

--- a/src/data/int/basic.lean
+++ b/src/data/int/basic.lean
@@ -351,7 +351,7 @@ begin
   cases hk; exact ⟨_, hk⟩
 end
 
-lemma eq_of_nat_abs_eq_pos {a b : ℤ} (ha : 0 ≤ a) (hb : 0 ≤ b) (h : nat_abs a = nat_abs b) :
+lemma eq_of_nat_abs_eq_non_neg {a b : ℤ} (ha : 0 ≤ a) (hb : 0 ≤ b) (h : nat_abs a = nat_abs b) :
   a = b :=
 by rwa [←sq_eq_sq ha hb, ←nat_abs_eq_iff_sq_eq]
 

--- a/src/data/int/basic.lean
+++ b/src/data/int/basic.lean
@@ -378,11 +378,8 @@ lemma strict_mono_on_nat_abs : strict_mono_on nat_abs (Ici 0) :=
 λ a ha b hb hab, nat_abs_lt_nat_abs_of_nonneg_of_lt ha hab
 
 lemma strict_anti_on_nat_abs : strict_anti_on nat_abs (Iic 0) :=
-begin
-  intros a ha b hb hab,
-  simpa [int.nat_abs_neg]
-    using nat_abs_lt_nat_abs_of_nonneg_of_lt (right.nonneg_neg_iff.mpr hb) (neg_lt_neg_iff.mpr hab),
-end
+λ a ha b hb hab, by simpa [int.nat_abs_neg]
+  using nat_abs_lt_nat_abs_of_nonneg_of_lt (right.nonneg_neg_iff.mpr hb) (neg_lt_neg_iff.mpr hab)
 
 lemma inj_on_nat_abs_Ici : inj_on nat_abs (Ici 0) := strict_mono_on_nat_abs.inj_on
 

--- a/src/data/int/basic.lean
+++ b/src/data/int/basic.lean
@@ -358,8 +358,8 @@ by rw [←sq_eq_sq ha hb, ←nat_abs_eq_iff_sq_eq]
 lemma nat_abs_eq_nat_abs_iff_of_nonpos_of_nonpos {a b : ℤ} (ha : a ≤ 0) (hb : b ≤ 0) :
   nat_abs a = nat_abs b ↔ a = b :=
 by simpa only [int.nat_abs_neg, neg_inj]
-  using nat_abs_eq_nat_abs_iff_of_nonneg_of_nonneg
-    (neg_nonneg_of_nonpos ha) (neg_nonneg_of_nonpos hb)
+ using nat_abs_eq_nat_abs_iff_of_nonneg_of_nonneg
+  (neg_nonneg_of_nonpos ha) (neg_nonneg_of_nonpos hb)
 
 lemma nat_abs_eq_nat_abs_iff_of_nonneg_of_nonpos {a b : ℤ} (ha : 0 ≤ a) (hb : b ≤ 0) :
   nat_abs a = nat_abs b ↔ a = -b :=

--- a/src/data/int/basic.lean
+++ b/src/data/int/basic.lean
@@ -357,28 +357,19 @@ by rw [←sq_eq_sq ha hb, ←nat_abs_eq_iff_sq_eq]
 
 lemma nat_abs_eq_nat_abs_iff_of_nonpos_of_nonpos {a b : ℤ} (ha : a ≤ 0) (hb : b ≤ 0) :
   nat_abs a = nat_abs b ↔ a = b :=
-begin
-  have := nat_abs_eq_nat_abs_iff_of_nonneg_of_nonneg
-    (neg_nonneg_of_nonpos ha) (neg_nonneg_of_nonpos hb),
-  simp only [int.nat_abs_neg, neg_inj] at this,
-  exact this,
-end
+by simpa only [int.nat_abs_neg, neg_inj]
+ using nat_abs_eq_nat_abs_iff_of_nonneg_of_nonneg
+  (neg_nonneg_of_nonpos ha) (neg_nonneg_of_nonpos hb)
 
 lemma nat_abs_eq_nat_abs_iff_of_nonneg_of_nonpos {a b : ℤ} (ha : 0 ≤ a) (hb : b ≤ 0) :
   nat_abs a = nat_abs b ↔ a = -b :=
-begin
-  have := nat_abs_eq_nat_abs_iff_of_nonneg_of_nonneg ha (neg_nonneg_of_nonpos hb),
-  simp only [int.nat_abs_neg] at this,
-  exact this,
-end
+by simpa only [int.nat_abs_neg]
+  using nat_abs_eq_nat_abs_iff_of_nonneg_of_nonneg ha (neg_nonneg_of_nonpos hb)
 
 lemma nat_abs_eq_nat_abs_iff_of_nonpos_of_nonneg {a b : ℤ} (ha : a ≤ 0) (hb : 0 ≤ b) :
   nat_abs a = nat_abs b ↔ -a = b :=
-begin
-  have := nat_abs_eq_nat_abs_iff_of_nonneg_of_nonneg (neg_nonneg_of_nonpos ha) hb,
-  simp at this,
-  exact this,
-end
+by simpa only [int.nat_abs_neg]
+  using nat_abs_eq_nat_abs_iff_of_nonneg_of_nonneg (neg_nonneg_of_nonpos ha) hb
 
 /-! ### `/`  -/
 

--- a/src/data/int/basic.lean
+++ b/src/data/int/basic.lean
@@ -355,6 +355,31 @@ lemma nat_abs_eq_nat_abs_iff_of_nonneg_of_nonneg {a b : ℤ} (ha : 0 ≤ a) (hb 
   nat_abs a = nat_abs b ↔ a = b :=
 by rw [←sq_eq_sq ha hb, ←nat_abs_eq_iff_sq_eq]
 
+lemma nat_abs_eq_nat_abs_iff_of_nonpos_of_nonpos {a b : ℤ} (ha : a ≤ 0) (hb : b ≤ 0) :
+  nat_abs a = nat_abs b ↔ a = b :=
+begin
+  have := nat_abs_eq_nat_abs_iff_of_nonneg_of_nonneg
+    (neg_nonneg_of_nonpos ha) (neg_nonneg_of_nonpos hb),
+  simp only [int.nat_abs_neg, neg_inj] at this,
+  exact this,
+end
+
+lemma nat_abs_eq_nat_abs_iff_of_nonneg_of_nonpos {a b : ℤ} (ha : 0 ≤ a) (hb : b ≤ 0) :
+  nat_abs a = nat_abs b ↔ a = -b :=
+begin
+  have := nat_abs_eq_nat_abs_iff_of_nonneg_of_nonneg ha (neg_nonneg_of_nonpos hb),
+  simp only [int.nat_abs_neg] at this,
+  exact this,
+end
+
+lemma nat_abs_eq_nat_abs_iff_of_nonpos_of_nonneg {a b : ℤ} (ha : a ≤ 0) (hb : 0 ≤ b) :
+  nat_abs a = nat_abs b ↔ -a = b :=
+begin
+  have := nat_abs_eq_nat_abs_iff_of_nonneg_of_nonneg (neg_nonneg_of_nonpos ha) hb,
+  simp at this,
+  exact this,
+end
+
 /-! ### `/`  -/
 
 @[simp] theorem of_nat_div (m n : ℕ) : of_nat (m / n) = (of_nat m) / (of_nat n) := rfl

--- a/src/data/int/basic.lean
+++ b/src/data/int/basic.lean
@@ -371,6 +371,36 @@ lemma nat_abs_eq_nat_abs_iff_of_nonpos_of_nonneg {a b : ℤ} (ha : a ≤ 0) (hb 
 by simpa only [int.nat_abs_neg]
   using nat_abs_eq_nat_abs_iff_of_nonneg_of_nonneg (neg_nonneg_of_nonpos ha) hb
 
+section intervals
+open set
+lemma strict_mono_on_nat_abs : strict_mono_on nat_abs (Ici 0) :=
+begin
+  unfold strict_mono_on,
+  intros a ha b hb hab,
+  unfold Ici at ha hb,
+  simp at ha hb,
+  exact nat_abs_lt_nat_abs_of_nonneg_of_lt ha hab,
+end
+
+lemma strict_anti_on_nat_abs : strict_anti_on nat_abs (Iic 0) :=
+begin
+  unfold strict_anti_on,
+  intros a ha b hb hab,
+  unfold Iic at ha hb,
+  simp at ha hb,
+  suffices : (-b).nat_abs < (-a).nat_abs, {
+    simp at this, exact this,
+  },
+  apply nat_abs_lt_nat_abs_of_nonneg_of_lt;
+  simpa,
+end
+
+lemma inj_on_nat_abs_Ici : inj_on nat_abs (Ici 0) := strict_mono_on_nat_abs.inj_on
+
+lemma inj_on_nat_abs_Iic : inj_on nat_abs (Iic 0) := strict_anti_on_nat_abs.inj_on
+
+end intervals
+
 /-! ### `/`  -/
 
 @[simp] theorem of_nat_div (m n : ℕ) : of_nat (m / n) = (of_nat m) / (of_nat n) := rfl

--- a/src/data/int/basic.lean
+++ b/src/data/int/basic.lean
@@ -373,19 +373,15 @@ by simpa only [int.nat_abs_neg]
 
 section intervals
 open set
+
 lemma strict_mono_on_nat_abs : strict_mono_on nat_abs (Ici 0) :=
 λ a ha b hb hab, nat_abs_lt_nat_abs_of_nonneg_of_lt ha hab
 
 lemma strict_anti_on_nat_abs : strict_anti_on nat_abs (Iic 0) :=
 begin
   intros a ha b hb hab,
-  suffices : (-b).nat_abs < (-a).nat_abs, {
-    simp only [int.nat_abs_neg] at this,
-    exact this,
-  },
-  apply nat_abs_lt_nat_abs_of_nonneg_of_lt,
-  simpa only [right.nonneg_neg_iff],
-  simpa only [neg_lt_neg_iff],
+  simpa [int.nat_abs_neg]
+    using nat_abs_lt_nat_abs_of_nonneg_of_lt (right.nonneg_neg_iff.mpr hb) (neg_lt_neg_iff.mpr hab),
 end
 
 lemma inj_on_nat_abs_Ici : inj_on nat_abs (Ici 0) := strict_mono_on_nat_abs.inj_on

--- a/src/data/int/basic.lean
+++ b/src/data/int/basic.lean
@@ -374,25 +374,18 @@ by simpa only [int.nat_abs_neg]
 section intervals
 open set
 lemma strict_mono_on_nat_abs : strict_mono_on nat_abs (Ici 0) :=
-begin
-  unfold strict_mono_on,
-  intros a ha b hb hab,
-  unfold Ici at ha hb,
-  simp at ha hb,
-  exact nat_abs_lt_nat_abs_of_nonneg_of_lt ha hab,
-end
+λ a ha b hb hab, nat_abs_lt_nat_abs_of_nonneg_of_lt ha hab
 
 lemma strict_anti_on_nat_abs : strict_anti_on nat_abs (Iic 0) :=
 begin
-  unfold strict_anti_on,
   intros a ha b hb hab,
-  unfold Iic at ha hb,
-  simp at ha hb,
   suffices : (-b).nat_abs < (-a).nat_abs, {
-    simp at this, exact this,
+    simp only [int.nat_abs_neg] at this,
+    exact this,
   },
-  apply nat_abs_lt_nat_abs_of_nonneg_of_lt;
-  simpa,
+  apply nat_abs_lt_nat_abs_of_nonneg_of_lt,
+  simpa only [right.nonneg_neg_iff],
+  simpa only [neg_lt_neg_iff],
 end
 
 lemma inj_on_nat_abs_Ici : inj_on nat_abs (Ici 0) := strict_mono_on_nat_abs.inj_on

--- a/src/data/int/basic.lean
+++ b/src/data/int/basic.lean
@@ -351,9 +351,9 @@ begin
   cases hk; exact ⟨_, hk⟩
 end
 
-lemma eq_of_nat_abs_eq_nonneg {a b : ℤ} (ha : 0 ≤ a) (hb : 0 ≤ b) (h : nat_abs a = nat_abs b) :
-  a = b :=
-by rwa [←sq_eq_sq ha hb, ←nat_abs_eq_iff_sq_eq]
+lemma nat_abs_eq_nat_abs_iff_of_nonneg_of_nonneg {a b : ℤ} (ha : 0 ≤ a) (hb : 0 ≤ b) :
+  nat_abs a = nat_abs b ↔ a = b :=
+by rw [←sq_eq_sq ha hb, ←nat_abs_eq_iff_sq_eq]
 
 /-! ### `/`  -/
 

--- a/src/data/int/basic.lean
+++ b/src/data/int/basic.lean
@@ -351,6 +351,10 @@ begin
   cases hk; exact ⟨_, hk⟩
 end
 
+lemma eq_of_nat_abs_eq_pos {a b : ℤ} (ha : 0 ≤ a) (hb : 0 ≤ b) (h : nat_abs a = nat_abs b) :
+  a = b :=
+by rwa [←sq_eq_sq ha hb, ←nat_abs_eq_iff_sq_eq]
+
 /-! ### `/`  -/
 
 @[simp] theorem of_nat_div (m n : ℕ) : of_nat (m / n) = (of_nat m) / (of_nat n) := rfl

--- a/src/data/int/basic.lean
+++ b/src/data/int/basic.lean
@@ -358,8 +358,8 @@ by rw [←sq_eq_sq ha hb, ←nat_abs_eq_iff_sq_eq]
 lemma nat_abs_eq_nat_abs_iff_of_nonpos_of_nonpos {a b : ℤ} (ha : a ≤ 0) (hb : b ≤ 0) :
   nat_abs a = nat_abs b ↔ a = b :=
 by simpa only [int.nat_abs_neg, neg_inj]
- using nat_abs_eq_nat_abs_iff_of_nonneg_of_nonneg
-  (neg_nonneg_of_nonpos ha) (neg_nonneg_of_nonpos hb)
+  using nat_abs_eq_nat_abs_iff_of_nonneg_of_nonneg
+    (neg_nonneg_of_nonpos ha) (neg_nonneg_of_nonpos hb)
 
 lemma nat_abs_eq_nat_abs_iff_of_nonneg_of_nonpos {a b : ℤ} (ha : 0 ≤ a) (hb : b ≤ 0) :
   nat_abs a = nat_abs b ↔ a = -b :=


### PR DESCRIPTION

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
