### PR TITLE
[Merged by Bors] - fix(topology/algebra/uniform_field): remove unnecessary topological_r…

### DIFF
--- a/src/topology/algebra/uniform_field.lean
+++ b/src/topology/algebra/uniform_field.lean
@@ -112,7 +112,7 @@ begin
     { exact λ H, h (dense_embedding_coe.inj H) } }
 end
 
-variables [uniform_add_group K] [topological_ring K]
+variables [uniform_add_group K]
 
 lemma mul_hat_inv_cancel {x : hat K} (x_ne : x ≠ 0) : x*hat_inv x = 1 :=
 begin


### PR DESCRIPTION
…ing variable

Right now the last three definitions in `topology.algebra.uniform_field` (after line 115) have `[topological_division_ring K]` and `[topological_ring K]`. For example

```
mul_hat_inv_cancel :
  ∀ {K : Type u_1} [_inst_1 : field K] [_inst_2 : uniform_space K] [_inst_3 : topological_division_ring K]
  [_inst_4 : completable_top_field K] [_inst_5 : uniform_add_group K] [_inst_6 : topological_ring K]
  {x : uniform_space.completion K}, x ≠ 0 → x * hat_inv x = 1
```

Whilst it is not obvious from the notation, both of these are `Prop`s so there is no danger of diamonds. The full logic is: `field` and `uniform_space` are data, and the rest are Props (so should be called things like `is_topological_ring` etc IMO). `topological_division_ring` is the assertion of continuity of `add`, `neg`, `mul` and `inv` (away from 0), `completable_top_field` is another assertion about how inversion plays well with the topology (and which is not implied by `topological_division_ring`), `uniform_add_group` is the assertion about `add` and `neg` playing well with the uniform structure, and then `topological_ring` is a prop which is implied by `topological_division_ring`. I am not sure I see the benefits of carrying around the extra `topological_ring` for these three definitions so I've removed it to see if mathlib still compiles. Edit: it does.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
