### PR TITLE
[Merged by Bors] - feat(topology/algebra/ordered/basic): Add alternative formulations of four lemmas.

### DIFF
--- a/src/topology/algebra/ordered/basic.lean
+++ b/src/topology/algebra/ordered/basic.lean
@@ -2679,5 +2679,3 @@ lemma monotone.tendsto_nhds_within_Ioi
 end conditionally_complete_linear_order
 
 end order_topology
-
-#lint

--- a/src/topology/algebra/ordered/basic.lean
+++ b/src/topology/algebra/ordered/basic.lean
@@ -2212,17 +2212,17 @@ begin
     rw closure_Ioo hab }
 end
 
-@[simp] lemma interior_Ici [no_bot_order α] {a : α} : interior (Ici a) = Ioi a :=
-by rw [← compl_Iio, interior_compl, closure_Iio, compl_Iic]
-
 @[simp] lemma interior_Ici' {a : α} (ha : (Iio a).nonempty) : interior (Ici a) = Ioi a :=
 let ⟨b, hb⟩ := ha in by rw [← compl_Iio, interior_compl, closure_Iio' hb, compl_Iic]
 
-@[simp] lemma interior_Iic [no_top_order α] {a : α} : interior (Iic a) = Iio a :=
-by rw [← compl_Ioi, interior_compl, closure_Ioi, compl_Ici]
+lemma interior_Ici [no_bot_order α] {a : α} : interior (Ici a) = Ioi a :=
+by rw [← compl_Iio, interior_compl, closure_Iio, compl_Iic]
 
 @[simp] lemma interior_Iic' {a : α} (ha : (Ioi a).nonempty) : interior (Iic a) = Iio a :=
 let ⟨b, hb⟩ := ha in by rw [← compl_Ioi, interior_compl, closure_Ioi' hb, compl_Ici]
+
+lemma interior_Iic [no_top_order α] {a : α} : interior (Iic a) = Iio a :=
+by rw [← compl_Ioi, interior_compl, closure_Ioi, compl_Ici]
 
 @[simp] lemma interior_Icc [no_bot_order α] [no_top_order α] {a b : α}:
   interior (Icc a b) = Ioo a b :=
@@ -2234,29 +2234,29 @@ by rw [← Ici_inter_Iio, interior_inter, interior_Ici, interior_Iio, Ioi_inter_
 @[simp] lemma interior_Ioc [no_top_order α] {a b : α} : interior (Ioc a b) = Ioo a b :=
 by rw [← Ioi_inter_Iic, interior_inter, interior_Ioi, interior_Iic, Ioi_inter_Iio]
 
-@[simp] lemma frontier_Ici [no_bot_order α] {a : α} : frontier (Ici a) = {a} :=
-by simp [frontier]
-
 @[simp] lemma frontier_Ici' {a : α} (ha : (Iio a).nonempty) : frontier (Ici a) = {a} :=
 by simp [frontier, ha]
 
-@[simp] lemma frontier_Iic [no_top_order α] {a : α} : frontier (Iic a) = {a} :=
+lemma frontier_Ici [no_bot_order α] {a : α} : frontier (Ici a) = {a} :=
 by simp [frontier]
 
 @[simp] lemma frontier_Iic' {a : α} (ha : (Ioi a).nonempty) : frontier (Iic a) = {a} :=
 by simp [frontier, ha]
 
-@[simp] lemma frontier_Ioi [no_top_order α] {a : α} : frontier (Ioi a) = {a} :=
+lemma frontier_Iic [no_top_order α] {a : α} : frontier (Iic a) = {a} :=
 by simp [frontier]
 
 @[simp] lemma frontier_Ioi' {a : α} (ha : (Ioi a).nonempty) : frontier (Ioi a) = {a} :=
 let ⟨b, hb⟩ := ha in by simp [frontier, closure_Ioi' hb, Iic_diff_Iio, Icc_self]
 
-@[simp] lemma frontier_Iio [no_bot_order α] {a : α} : frontier (Iio a) = {a} :=
+lemma frontier_Ioi [no_top_order α] {a : α} : frontier (Ioi a) = {a} :=
 by simp [frontier]
 
 @[simp] lemma frontier_Iio' {a : α} (ha : (Iio a).nonempty) : frontier (Iio a) = {a} :=
 let ⟨b, hb⟩ := ha in by simp [frontier, closure_Iio' hb, Iic_diff_Iio, Icc_self]
+
+lemma frontier_Iio [no_bot_order α] {a : α} : frontier (Iio a) = {a} :=
+by simp [frontier]
 
 @[simp] lemma frontier_Icc [no_bot_order α] [no_top_order α] {a b : α} (h : a < b) :
   frontier (Icc a b) = {a, b} :=

--- a/src/topology/algebra/ordered/basic.lean
+++ b/src/topology/algebra/ordered/basic.lean
@@ -2215,8 +2215,14 @@ end
 @[simp] lemma interior_Ici [no_bot_order α] {a : α} : interior (Ici a) = Ioi a :=
 by rw [← compl_Iio, interior_compl, closure_Iio, compl_Iic]
 
+@[simp] lemma interior_Ici' {a : α} (ha : (Iio a).nonempty) : interior (Ici a) = Ioi a :=
+let ⟨b, hb⟩ := ha in by rw [← compl_Iio, interior_compl, closure_Iio' hb, compl_Iic]
+
 @[simp] lemma interior_Iic [no_top_order α] {a : α} : interior (Iic a) = Iio a :=
 by rw [← compl_Ioi, interior_compl, closure_Ioi, compl_Ici]
+
+@[simp] lemma interior_Iic' {a : α} (ha : (Ioi a).nonempty) : interior (Iic a) = Iio a :=
+let ⟨b, hb⟩ := ha in by rw [← compl_Ioi, interior_compl, closure_Ioi' hb, compl_Ici]
 
 @[simp] lemma interior_Icc [no_bot_order α] [no_top_order α] {a b : α}:
   interior (Icc a b) = Ioo a b :=
@@ -2231,8 +2237,14 @@ by rw [← Ioi_inter_Iic, interior_inter, interior_Ioi, interior_Iic, Ioi_inter_
 @[simp] lemma frontier_Ici [no_bot_order α] {a : α} : frontier (Ici a) = {a} :=
 by simp [frontier]
 
+@[simp] lemma frontier_Ici' {a : α} (ha : (Iio a).nonempty) : frontier (Ici a) = {a} :=
+by simp [frontier, ha]
+
 @[simp] lemma frontier_Iic [no_top_order α] {a : α} : frontier (Iic a) = {a} :=
 by simp [frontier]
+
+@[simp] lemma frontier_Iic' {a : α} (ha : (Ioi a).nonempty) : frontier (Iic a) = {a} :=
+by simp [frontier, ha]
 
 @[simp] lemma frontier_Ioi [no_top_order α] {a : α} : frontier (Ioi a) = {a} :=
 by simp [frontier]

--- a/src/topology/algebra/ordered/basic.lean
+++ b/src/topology/algebra/ordered/basic.lean
@@ -2249,8 +2249,14 @@ by simp [frontier, ha]
 @[simp] lemma frontier_Ioi [no_top_order α] {a : α} : frontier (Ioi a) = {a} :=
 by simp [frontier]
 
+@[simp] lemma frontier_Ioi' {a : α} (ha : (Ioi a).nonempty) : frontier (Ioi a) = {a} :=
+let ⟨b, hb⟩ := ha in by simp [frontier, closure_Ioi' hb, Iic_diff_Iio, Icc_self]
+
 @[simp] lemma frontier_Iio [no_bot_order α] {a : α} : frontier (Iio a) = {a} :=
 by simp [frontier]
+
+@[simp] lemma frontier_Iio' {a : α} (ha : (Iio a).nonempty) : frontier (Iio a) = {a} :=
+let ⟨b, hb⟩ := ha in by simp [frontier, closure_Iio' hb, Iic_diff_Iio, Icc_self]
 
 @[simp] lemma frontier_Icc [no_bot_order α] [no_top_order α] {a b : α} (h : a < b) :
   frontier (Icc a b) = {a, b} :=
@@ -2671,3 +2677,5 @@ lemma monotone.tendsto_nhds_within_Ioi
 end conditionally_complete_linear_order
 
 end order_topology
+
+#lint

--- a/src/topology/algebra/ordered/basic.lean
+++ b/src/topology/algebra/ordered/basic.lean
@@ -2158,11 +2158,10 @@ element. -/
 lemma closure_Ioi' {a : α} (h : (Ioi a).nonempty) :
   closure (Ioi a) = Ici a :=
 begin
-  cases h with b hb,
   apply subset.antisymm,
   { exact closure_minimal Ioi_subset_Ici_self is_closed_Ici },
   { rw [← diff_subset_closure_iff, Ici_diff_Ioi_same, singleton_subset_iff],
-    exact is_glb_Ioi.mem_closure ⟨_, hb⟩, }
+    exact is_glb_Ioi.mem_closure h }
 end
 
 /-- The closure of the interval `(a, +∞)` is the closed interval `[a, +∞)`. -/
@@ -2220,7 +2219,7 @@ lemma interior_Ici [no_bot_order α] {a : α} : interior (Ici a) = Ioi a :=
 interior_Ici' nonempty_Iio
 
 @[simp] lemma interior_Iic' {a : α} (ha : (Ioi a).nonempty) : interior (Iic a) = Iio a :=
-by rw [← compl_Ioi, interior_compl, closure_Ioi' ha, compl_Ici]
+@interior_Ici' (order_dual α) _ _ _ _ _ ha
 
 lemma interior_Iic [no_top_order α] {a : α} : interior (Iic a) = Iio a :=
 interior_Iic' nonempty_Ioi
@@ -2272,15 +2271,15 @@ by simp [frontier, h, le_of_lt h, Icc_diff_Ioo_same]
 @[simp] lemma frontier_Ioc [no_top_order α] {a b : α} (h : a < b) : frontier (Ioc a b) = {a, b} :=
 by simp [frontier, h, le_of_lt h, Icc_diff_Ioo_same]
 
-lemma nhds_within_Ioi_ne_bot' {a b c : α} (H₁ : a < c) (H₂ : a ≤ b) :
+lemma nhds_within_Ioi_ne_bot' {a b : α} (H₁ : (Ioi a).nonempty) (H₂ : a ≤ b) :
   ne_bot (𝓝[Ioi a] b) :=
-mem_closure_iff_nhds_within_ne_bot.1 $ by { rw [closure_Ioi' (nonempty_of_mem H₁)], exact H₂ }
+mem_closure_iff_nhds_within_ne_bot.1 $ by rwa [closure_Ioi' H₁]
 
 lemma nhds_within_Ioi_ne_bot [no_top_order α] {a b : α} (H : a ≤ b) :
   ne_bot (𝓝[Ioi a] b) :=
-let ⟨c, hc⟩ := no_top a in nhds_within_Ioi_ne_bot' hc H
+nhds_within_Ioi_ne_bot' nonempty_Ioi H
 
-lemma nhds_within_Ioi_self_ne_bot' {a b : α} (H : a < b) :
+lemma nhds_within_Ioi_self_ne_bot' {a : α} (H : (Ioi a).nonempty) :
   ne_bot (𝓝[Ioi a] a) :=
 nhds_within_Ioi_ne_bot' H (le_refl a)
 
@@ -2294,16 +2293,15 @@ lemma filter.eventually.exists_gt [no_top_order α] {a : α} {p : α → Prop} (
 by simpa only [exists_prop, gt_iff_lt, and_comm]
   using ((h.filter_mono (@nhds_within_le_nhds _ _ a (Ioi a))).and self_mem_nhds_within).exists
 
-lemma nhds_within_Iio_ne_bot' {a b c : α} (H₁ : a < c) (H₂ : b ≤ c) :
+lemma nhds_within_Iio_ne_bot' {b c : α} (H₁ : (Iio c).nonempty) (H₂ : b ≤ c) :
   ne_bot (𝓝[Iio c] b) :=
-mem_closure_iff_nhds_within_ne_bot.1 $ by { rw [closure_Iio' (nonempty_of_mem (mem_Iio.mpr H₁))],
-                                            exact H₂ }
+mem_closure_iff_nhds_within_ne_bot.1 $ by rwa closure_Iio' H₁
 
 lemma nhds_within_Iio_ne_bot [no_bot_order α] {a b : α} (H : a ≤ b) :
   ne_bot (𝓝[Iio b] a) :=
-let ⟨c, hc⟩ := no_bot b in nhds_within_Iio_ne_bot' hc H
+nhds_within_Iio_ne_bot' nonempty_Iio H
 
-lemma nhds_within_Iio_self_ne_bot' {a b : α} (H : a < b) :
+lemma nhds_within_Iio_self_ne_bot' {b : α} (H : (Iio b).nonempty) :
   ne_bot (𝓝[Iio b] b) :=
 nhds_within_Iio_ne_bot' H (le_refl b)
 

--- a/src/topology/algebra/ordered/basic.lean
+++ b/src/topology/algebra/ordered/basic.lean
@@ -2155,30 +2155,31 @@ variables [topological_space α] [linear_order α] [order_topology α] [densely_
 
 /-- The closure of the interval `(a, +∞)` is the closed interval `[a, +∞)`, unless `a` is a top
 element. -/
-lemma closure_Ioi' {a b : α} (hab : a < b) :
+lemma closure_Ioi' {a : α} (h : (Ioi a).nonempty) :
   closure (Ioi a) = Ici a :=
 begin
+  cases h with b hb,
   apply subset.antisymm,
   { exact closure_minimal Ioi_subset_Ici_self is_closed_Ici },
   { rw [← diff_subset_closure_iff, Ici_diff_Ioi_same, singleton_subset_iff],
-    exact is_glb_Ioi.mem_closure ⟨_, hab⟩ }
+    exact is_glb_Ioi.mem_closure ⟨_, hb⟩, }
 end
 
 /-- The closure of the interval `(a, +∞)` is the closed interval `[a, +∞)`. -/
 @[simp] lemma closure_Ioi (a : α) [no_top_order α] :
   closure (Ioi a) = Ici a :=
-let ⟨b, hb⟩ := no_top a in closure_Ioi' hb
+closure_Ioi' nonempty_Ioi
 
 /-- The closure of the interval `(-∞, a)` is the closed interval `(-∞, a]`, unless `a` is a bottom
 element. -/
-lemma closure_Iio' {a b : α} (hab : b < a) :
+lemma closure_Iio' {a : α} (h : (Iio a).nonempty) :
   closure (Iio a) = Iic a :=
-@closure_Ioi' (order_dual α) _ _ _ _ _ _ hab
+@closure_Ioi' (order_dual α) _ _ _ _ _ h
 
 /-- The closure of the interval `(-∞, a)` is the interval `(-∞, a]`. -/
 @[simp] lemma closure_Iio (a : α) [no_bot_order α] :
   closure (Iio a) = Iic a :=
-let ⟨b, hb⟩ := no_bot a in closure_Iio' hb
+closure_Iio' nonempty_Iio
 
 /-- The closure of the open interval `(a, b)` is the closed interval `[a, b]`. -/
 @[simp] lemma closure_Ioo {a b : α} (hab : a < b) :
@@ -2213,13 +2214,13 @@ begin
 end
 
 @[simp] lemma interior_Ici' {a : α} (ha : (Iio a).nonempty) : interior (Ici a) = Ioi a :=
-let ⟨b, hb⟩ := ha in by rw [← compl_Iio, interior_compl, closure_Iio' hb, compl_Iic]
+by rw [← compl_Iio, interior_compl, closure_Iio' ha, compl_Iic]
 
 lemma interior_Ici [no_bot_order α] {a : α} : interior (Ici a) = Ioi a :=
 interior_Ici' nonempty_Iio
 
 @[simp] lemma interior_Iic' {a : α} (ha : (Ioi a).nonempty) : interior (Iic a) = Iio a :=
-let ⟨b, hb⟩ := ha in by rw [← compl_Ioi, interior_compl, closure_Ioi' hb, compl_Ici]
+by rw [← compl_Ioi, interior_compl, closure_Ioi' ha, compl_Ici]
 
 lemma interior_Iic [no_top_order α] {a : α} : interior (Iic a) = Iio a :=
 interior_Iic' nonempty_Ioi
@@ -2247,13 +2248,13 @@ lemma frontier_Iic [no_top_order α] {a : α} : frontier (Iic a) = {a} :=
 frontier_Iic' nonempty_Ioi
 
 @[simp] lemma frontier_Ioi' {a : α} (ha : (Ioi a).nonempty) : frontier (Ioi a) = {a} :=
-let ⟨b, hb⟩ := ha in by simp [frontier, closure_Ioi' hb, Iic_diff_Iio, Icc_self]
+by simp [frontier, closure_Ioi' ha, Iic_diff_Iio, Icc_self]
 
 lemma frontier_Ioi [no_top_order α] {a : α} : frontier (Ioi a) = {a} :=
 frontier_Ioi' nonempty_Ioi
 
 @[simp] lemma frontier_Iio' {a : α} (ha : (Iio a).nonempty) : frontier (Iio a) = {a} :=
-let ⟨b, hb⟩ := ha in by simp [frontier, closure_Iio' hb, Iic_diff_Iio, Icc_self]
+by simp [frontier, closure_Iio' ha, Iic_diff_Iio, Icc_self]
 
 lemma frontier_Iio [no_bot_order α] {a : α} : frontier (Iio a) = {a} :=
 frontier_Iio' nonempty_Iio
@@ -2273,7 +2274,7 @@ by simp [frontier, h, le_of_lt h, Icc_diff_Ioo_same]
 
 lemma nhds_within_Ioi_ne_bot' {a b c : α} (H₁ : a < c) (H₂ : a ≤ b) :
   ne_bot (𝓝[Ioi a] b) :=
-mem_closure_iff_nhds_within_ne_bot.1 $ by { rw [closure_Ioi' H₁], exact H₂ }
+mem_closure_iff_nhds_within_ne_bot.1 $ by { rw [closure_Ioi' (nonempty_of_mem H₁)], exact H₂ }
 
 lemma nhds_within_Ioi_ne_bot [no_top_order α] {a b : α} (H : a ≤ b) :
   ne_bot (𝓝[Ioi a] b) :=
@@ -2295,7 +2296,8 @@ by simpa only [exists_prop, gt_iff_lt, and_comm]
 
 lemma nhds_within_Iio_ne_bot' {a b c : α} (H₁ : a < c) (H₂ : b ≤ c) :
   ne_bot (𝓝[Iio c] b) :=
-mem_closure_iff_nhds_within_ne_bot.1 $ by { rw [closure_Iio' H₁], exact H₂ }
+mem_closure_iff_nhds_within_ne_bot.1 $ by { rw [closure_Iio' (nonempty_of_mem (mem_Iio.mpr H₁))],
+                                            exact H₂ }
 
 lemma nhds_within_Iio_ne_bot [no_bot_order α] {a b : α} (H : a ≤ b) :
   ne_bot (𝓝[Iio b] a) :=

--- a/src/topology/algebra/ordered/basic.lean
+++ b/src/topology/algebra/ordered/basic.lean
@@ -2216,13 +2216,13 @@ end
 let ⟨b, hb⟩ := ha in by rw [← compl_Iio, interior_compl, closure_Iio' hb, compl_Iic]
 
 lemma interior_Ici [no_bot_order α] {a : α} : interior (Ici a) = Ioi a :=
-by rw [← compl_Iio, interior_compl, closure_Iio, compl_Iic]
+interior_Ici' nonempty_Iio
 
 @[simp] lemma interior_Iic' {a : α} (ha : (Ioi a).nonempty) : interior (Iic a) = Iio a :=
 let ⟨b, hb⟩ := ha in by rw [← compl_Ioi, interior_compl, closure_Ioi' hb, compl_Ici]
 
 lemma interior_Iic [no_top_order α] {a : α} : interior (Iic a) = Iio a :=
-by rw [← compl_Ioi, interior_compl, closure_Ioi, compl_Ici]
+interior_Iic' nonempty_Ioi
 
 @[simp] lemma interior_Icc [no_bot_order α] [no_top_order α] {a b : α}:
   interior (Icc a b) = Ioo a b :=
@@ -2238,25 +2238,25 @@ by rw [← Ioi_inter_Iic, interior_inter, interior_Ioi, interior_Iic, Ioi_inter_
 by simp [frontier, ha]
 
 lemma frontier_Ici [no_bot_order α] {a : α} : frontier (Ici a) = {a} :=
-by simp [frontier]
+frontier_Ici' nonempty_Iio
 
 @[simp] lemma frontier_Iic' {a : α} (ha : (Ioi a).nonempty) : frontier (Iic a) = {a} :=
 by simp [frontier, ha]
 
 lemma frontier_Iic [no_top_order α] {a : α} : frontier (Iic a) = {a} :=
-by simp [frontier]
+frontier_Iic' nonempty_Ioi
 
 @[simp] lemma frontier_Ioi' {a : α} (ha : (Ioi a).nonempty) : frontier (Ioi a) = {a} :=
 let ⟨b, hb⟩ := ha in by simp [frontier, closure_Ioi' hb, Iic_diff_Iio, Icc_self]
 
 lemma frontier_Ioi [no_top_order α] {a : α} : frontier (Ioi a) = {a} :=
-by simp [frontier]
+frontier_Ioi' nonempty_Ioi
 
 @[simp] lemma frontier_Iio' {a : α} (ha : (Iio a).nonempty) : frontier (Iio a) = {a} :=
 let ⟨b, hb⟩ := ha in by simp [frontier, closure_Iio' hb, Iic_diff_Iio, Icc_self]
 
 lemma frontier_Iio [no_bot_order α] {a : α} : frontier (Iio a) = {a} :=
-by simp [frontier]
+frontier_Iio' nonempty_Iio
 
 @[simp] lemma frontier_Icc [no_bot_order α] [no_top_order α] {a b : α} (h : a < b) :
   frontier (Icc a b) = {a, b} :=

--- a/src/topology/algebra/ordered/intermediate_value.lean
+++ b/src/topology/algebra/ordered/intermediate_value.lean
@@ -382,7 +382,7 @@ begin
   rintros x ⟨hxs, hxab⟩ y hyxb,
   have : s ∩ Ioc x y ∈ 𝓝[Ioi x] x,
     from inter_mem (hgt x ⟨hxs, hxab⟩) (Ioc_mem_nhds_within_Ioi ⟨le_refl _, hyxb⟩),
-  exact (nhds_within_Ioi_self_ne_bot' hxab.2).nonempty_of_mem this
+  exact (nhds_within_Ioi_self_ne_bot' ⟨b, hxab.2⟩).nonempty_of_mem this
 end
 
 /-- A closed interval in a densely ordered conditionally complete linear order is preconnected. -/

--- a/src/topology/instances/ennreal.lean
+++ b/src/topology/instances/ennreal.lean
@@ -187,7 +187,7 @@ lemma nhds_zero_basis : (𝓝 (0 : ℝ≥0∞)).has_basis (λ a : ℝ≥0∞, 0 
 lemma nhds_zero_basis_Iic : (𝓝 (0 : ℝ≥0∞)).has_basis (λ a : ℝ≥0∞, 0 < a) Iic := nhds_bot_basis_Iic
 
 @[instance] lemma nhds_within_Ioi_coe_ne_bot {r : ℝ≥0} : (𝓝[Ioi r] (r : ℝ≥0∞)).ne_bot :=
-nhds_within_Ioi_self_ne_bot' ennreal.coe_lt_top
+nhds_within_Ioi_self_ne_bot' ⟨⊤, ennreal.coe_lt_top⟩
 
 @[instance] lemma nhds_within_Ioi_zero_ne_bot : (𝓝[Ioi 0] (0 : ℝ≥0∞)).ne_bot :=
 nhds_within_Ioi_coe_ne_bot
@@ -350,7 +350,7 @@ begin
   have : tendsto (* x) (𝓝[Iio 1] 1) (𝓝 (1 * x)) :=
     (ennreal.continuous_at_mul_const (or.inr one_ne_zero)).mono_left inf_le_left,
   rw one_mul at this,
-  haveI : (𝓝[Iio 1] (1 : ℝ≥0∞)).ne_bot := nhds_within_Iio_self_ne_bot' ennreal.zero_lt_one,
+  haveI : (𝓝[Iio 1] (1 : ℝ≥0∞)).ne_bot := nhds_within_Iio_self_ne_bot' ⟨0, ennreal.zero_lt_one⟩,
   exact le_of_tendsto this (eventually_nhds_within_iff.2 $ eventually_of_forall h)
 end
 


### PR DESCRIPTION
Add alternative formulations of lemmas about interiors and frontiers of `Iic` and `Ici`. The existing formulations make typeclass assumptions `[no_top_order]` or `[no_bot_order]`. These alternative formulations assume instead that the endpoint of the interval is not top or bottom; and as such they can be applied in, e.g., `nnreal` and `ennreal`.

Also, some lemmas now assume `(Ioi a).nonempty` or `(Iio a).nonempty` instead of `{b} (h : a < b)` or `{b} (h : b < a)`, respectively.

---

There was a [Zulip conversation](https://leanprover.zulipchat.com/#narrow/stream/217875-Is-there.20code.20for.20X.3F/topic/ennreal.2Efrontier_Iic/near/263755323) about this.

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
