### PR TITLE
[Merged by Bors] - feat(linear_algebra/multilinear/basic,linear_algebra/alternating): comp_linear_map lemmas

### DIFF
--- a/src/linear_algebra/alternating.lean
+++ b/src/linear_algebra/alternating.lean
@@ -363,10 +363,7 @@ end
 /-- Composing an alternating map with the identity linear map in each argument. -/
 @[simp] lemma comp_linear_map_id (f : alternating_map R M N ι) :
   f.comp_linear_map linear_map.id = f :=
-begin
-  ext,
-  refl
-end
+ext $ λ _, rfl
 
 /-- Composing an alternating map with the same linear equiv on each argument gives the zero map
 if and only if the alternating map is the zero map. -/

--- a/src/linear_algebra/alternating.lean
+++ b/src/linear_algebra/alternating.lean
@@ -326,6 +326,7 @@ end linear_map
 namespace alternating_map
 
 variables {M₂ : Type*} [add_comm_monoid M₂] [module R M₂]
+variables {M₃ : Type*} [add_comm_monoid M₃] [module R M₃]
 
 /-- Composing a alternating map with the same linear map on each argument gives again an
 alternating map. -/
@@ -338,6 +339,11 @@ lemma coe_comp_linear_map (f : alternating_map R M N ι) (g : M₂ →ₗ[R] M) 
 
 @[simp] lemma comp_linear_map_apply (f : alternating_map R M N ι) (g : M₂ →ₗ[R] M) (v : ι → M₂) :
   f.comp_linear_map g v = f (λ i, g (v i)) := rfl
+
+/-- Composing an alternating map twice with the same linear map in each argument. -/
+lemma comp_linear_map_assoc (f : alternating_map R M N ι) (g₁ : M₂ →ₗ[R] M) (g₂ : M₃ →ₗ[R] M₂) :
+  (f.comp_linear_map g₁).comp_linear_map g₂ = f.comp_linear_map (g₁ ∘ₗ g₂) :=
+rfl
 
 @[simp] lemma zero_comp_linear_map (g : M₂ →ₗ[R] M) :
   (0 : alternating_map R M N ι).comp_linear_map g = 0 :=
@@ -352,6 +358,23 @@ by { ext, simp only [comp_linear_map_apply, add_apply] }
 begin
   ext,
   simp_rw [comp_linear_map_apply, linear_map.zero_apply, ←pi.zero_def, map_zero, zero_apply],
+end
+
+/-- Composing an alternating map with the identity linear map in each argument. -/
+@[simp] lemma comp_linear_map_id (f : alternating_map R M N ι) :
+  f.comp_linear_map linear_map.id = f :=
+begin
+  ext,
+  refl
+end
+
+/-- Composing an alternating map with the same linear equiv on each argument gives the zero map
+if and only if the alternating map is the zero map. -/
+@[simp] lemma comp_linear_equiv_eq_zero_iff (f : alternating_map R M N ι) (g : M ≃ₗ[R] M) :
+  f.comp_linear_map (g : M →ₗ[R] M) = 0 ↔ f = 0 :=
+begin
+  simp_rw ←alternating_map.coe_multilinear_map_injective.eq_iff,
+  exact multilinear_map.comp_linear_equiv_eq_zero_iff _ _
 end
 
 variables (f f' : alternating_map R M N ι)

--- a/src/linear_algebra/alternating.lean
+++ b/src/linear_algebra/alternating.lean
@@ -340,7 +340,8 @@ lemma coe_comp_linear_map (f : alternating_map R M N ι) (g : M₂ →ₗ[R] M) 
 @[simp] lemma comp_linear_map_apply (f : alternating_map R M N ι) (g : M₂ →ₗ[R] M) (v : ι → M₂) :
   f.comp_linear_map g v = f (λ i, g (v i)) := rfl
 
-/-- Composing an alternating map twice with the same linear map in each argument. -/
+/-- Composing an alternating map twice with the same linear map in each argument is
+the same as composing with their composition. -/
 lemma comp_linear_map_assoc (f : alternating_map R M N ι) (g₁ : M₂ →ₗ[R] M) (g₂ : M₃ →ₗ[R] M₂) :
   (f.comp_linear_map g₁).comp_linear_map g₂ = f.comp_linear_map (g₁ ∘ₗ g₂) :=
 rfl

--- a/src/linear_algebra/alternating.lean
+++ b/src/linear_algebra/alternating.lean
@@ -366,6 +366,16 @@ end
   f.comp_linear_map linear_map.id = f :=
 ext $ λ _, rfl
 
+/-- Composing with a surjective linear map is injective. -/
+lemma comp_linear_map_injective (f : M₂ →ₗ[R] M) (hf : function.surjective f) :
+  function.injective (λ g : alternating_map R M N ι, g.comp_linear_map f) :=
+λ g₁ g₂ h, ext $ λ x,
+by simpa [function.surj_inv_eq hf] using ext_iff.mp h (function.surj_inv hf ∘ x)
+
+lemma comp_linear_map_inj (f : M₂ →ₗ[R] M) (hf : function.surjective f)
+  (g₁ g₂ : alternating_map R M N ι) : g₁.comp_linear_map f = g₂.comp_linear_map f ↔ g₁ = g₂ :=
+(comp_linear_map_injective _ hf).eq_iff
+
 /-- Composing an alternating map with the same linear equiv on each argument gives the zero map
 if and only if the alternating map is the zero map. -/
 @[simp] lemma comp_linear_equiv_eq_zero_iff (f : alternating_map R M N ι) (g : M ≃ₗ[R] M) :

--- a/src/linear_algebra/multilinear/basic.lean
+++ b/src/linear_algebra/multilinear/basic.lean
@@ -302,18 +302,23 @@ ext $ λ _, rfl
   g.comp_linear_map (λ i, linear_map.id) = g :=
 ext $ λ _, rfl
 
+/-- Composing with a family of surjective linear maps is injective. -/
+lemma comp_linear_map_injective (f : Π i, M₁ i →ₗ[R] M₁' i) (hf : ∀ i, surjective (f i)) :
+  injective (λ g : multilinear_map R M₁' M₂, g.comp_linear_map f) :=
+λ g₁ g₂ h, ext $ λ x,
+  by simpa [λ i, surj_inv_eq (hf i)] using ext_iff.mp h (λ i, surj_inv (hf i) (x i))
+
+lemma comp_linear_map_inj (f : Π i, M₁ i →ₗ[R] M₁' i) (hf : ∀ i, surjective (f i))
+  (g₁ g₂ : multilinear_map R M₁' M₂) : g₁.comp_linear_map f = g₂.comp_linear_map f ↔ g₁ = g₂ :=
+(comp_linear_map_injective _ hf).eq_iff
+
 /-- Composing a multilinear map with a linear equiv on each argument gives the zero map
 if and only if the multilinear map is the zero map. -/
 @[simp] lemma comp_linear_equiv_eq_zero_iff (g : multilinear_map R M₁' M₂)
   (f : Π i, M₁ i ≃ₗ[R] M₁' i) : g.comp_linear_map (λ i, (f i : M₁ i →ₗ[R] M₁' i)) = 0 ↔ g = 0 :=
 begin
-  split,
-  { intro h,
-    have h' : (g.comp_linear_map (λ i, (f i : M₁ i →ₗ[R] M₁' i))).comp_linear_map
-      (λ i, ((f i).symm : M₁' i →ₗ[R] M₁ i)) = 0, by simp [h],
-    simpa [comp_linear_map_assoc] using h' },
-  { rintro rfl,
-    exact zero_comp_linear_map _ }
+  set f' := (λ i, (f i : M₁ i →ₗ[R] M₁' i)),
+  rw [←zero_comp_linear_map f', comp_linear_map_inj f' (λ i, (f i).surjective)],
 end
 
 end

--- a/src/linear_algebra/multilinear/basic.lean
+++ b/src/linear_algebra/multilinear/basic.lean
@@ -312,8 +312,8 @@ begin
     have h' : (g.comp_linear_map (λ i, (f i : M₁ i →ₗ[R] M₁' i))).comp_linear_map
       (λ i, ((f i).symm : M₁' i →ₗ[R] M₁ i)) = 0, by simp [h],
     simpa [comp_linear_map_assoc] using h' },
-  { intro h,
-    simp [h] }
+  { rintro rfl,
+    exact zero_comp_linear_map _ }
 end
 
 end

--- a/src/linear_algebra/multilinear/basic.lean
+++ b/src/linear_algebra/multilinear/basic.lean
@@ -295,10 +295,7 @@ rfl
 /-- Composing the zero multilinear map with a linear map in each argument. -/
 @[simp] lemma zero_comp_linear_map (f : Π i, M₁ i →ₗ[R] M₁' i) :
   (0 : multilinear_map R M₁' M₂).comp_linear_map f = 0 :=
-begin
-  ext,
-  simp
-end
+ext $ λ _, rfl
 
 /-- Composing a multilinear map with the identity linear map in each argument. -/
 @[simp] lemma comp_linear_map_id (g : multilinear_map R M₁' M₂) :

--- a/src/linear_algebra/multilinear/basic.lean
+++ b/src/linear_algebra/multilinear/basic.lean
@@ -285,7 +285,8 @@ def comp_linear_map (g : multilinear_map R M₁' M₂) (f : Π i, M₁ i →ₗ[
   g.comp_linear_map f m = g (λ i, f i (m i)) :=
 rfl
 
-/-- Composing a multilinear map twice with a linear map in each argument. -/
+/-- Composing a multilinear map twice with a linear map in each argument is
+the same as composing with their composition. -/
 lemma comp_linear_map_assoc (g : multilinear_map R M₁'' M₂) (f₁ : Π i, M₁' i →ₗ[R] M₁'' i)
   (f₂ : Π i, M₁ i →ₗ[R] M₁' i) :
   (g.comp_linear_map f₁).comp_linear_map f₂ = g.comp_linear_map (λ i, f₁ i ∘ₗ f₂ i) :=

--- a/src/linear_algebra/multilinear/basic.lean
+++ b/src/linear_algebra/multilinear/basic.lean
@@ -300,10 +300,7 @@ ext $ λ _, rfl
 /-- Composing a multilinear map with the identity linear map in each argument. -/
 @[simp] lemma comp_linear_map_id (g : multilinear_map R M₁' M₂) :
   g.comp_linear_map (λ i, linear_map.id) = g :=
-begin
-  ext,
-  refl
-end
+ext $ λ _, rfl
 
 /-- Composing a multilinear map with a linear equiv on each argument gives the zero map
 if and only if the multilinear map is the zero map. -/

--- a/src/linear_algebra/multilinear/basic.lean
+++ b/src/linear_algebra/multilinear/basic.lean
@@ -263,6 +263,7 @@ by rw [← update_snoc_last x m (c • x), f.map_smul, update_snoc_last]
 section
 
 variables {M₁' : ι → Type*} [Π i, add_comm_monoid (M₁' i)] [Π i, module R (M₁' i)]
+variables {M₁'' : ι → Type*} [Π i, add_comm_monoid (M₁'' i)] [Π i, module R (M₁'' i)]
 
 /-- If `g` is a multilinear map and `f` is a collection of linear maps,
 then `g (f₁ m₁, ..., fₙ mₙ)` is again a multilinear map, that we call
@@ -283,6 +284,42 @@ def comp_linear_map (g : multilinear_map R M₁' M₂) (f : Π i, M₁ i →ₗ[
   (m : Π i, M₁ i) :
   g.comp_linear_map f m = g (λ i, f i (m i)) :=
 rfl
+
+/-- Composing a multilinear map twice with a linear map in each argument. -/
+lemma comp_linear_map_assoc (g : multilinear_map R M₁'' M₂) (f₁ : Π i, M₁' i →ₗ[R] M₁'' i)
+  (f₂ : Π i, M₁ i →ₗ[R] M₁' i) :
+  (g.comp_linear_map f₁).comp_linear_map f₂ = g.comp_linear_map (λ i, f₁ i ∘ₗ f₂ i) :=
+rfl
+
+/-- Composing the zero multilinear map with a linear map in each argument. -/
+@[simp] lemma zero_comp_linear_map (f : Π i, M₁ i →ₗ[R] M₁' i) :
+  (0 : multilinear_map R M₁' M₂).comp_linear_map f = 0 :=
+begin
+  ext,
+  simp
+end
+
+/-- Composing a multilinear map with the identity linear map in each argument. -/
+@[simp] lemma comp_linear_map_id (g : multilinear_map R M₁' M₂) :
+  g.comp_linear_map (λ i, linear_map.id) = g :=
+begin
+  ext,
+  refl
+end
+
+/-- Composing a multilinear map with a linear equiv on each argument gives the zero map
+if and only if the multilinear map is the zero map. -/
+@[simp] lemma comp_linear_equiv_eq_zero_iff (g : multilinear_map R M₁' M₂)
+  (f : Π i, M₁ i ≃ₗ[R] M₁' i) : g.comp_linear_map (λ i, (f i : M₁ i →ₗ[R] M₁' i)) = 0 ↔ g = 0 :=
+begin
+  split,
+  { intro h,
+    have h' : (g.comp_linear_map (λ i, (f i : M₁ i →ₗ[R] M₁' i))).comp_linear_map
+      (λ i, ((f i).symm : M₁' i →ₗ[R] M₁ i)) = 0, by simp [h],
+    simpa [comp_linear_map_assoc] using h' },
+  { intro h,
+    simp [h] }
+end
 
 end
 


### PR DESCRIPTION
Add more lemmas about composing multilinear and alternating maps with
linear maps in each argument.

Where I wanted a lemma for either of multilinear or alternating maps,
I added it for both.  There are however some lemmas for
`alternating_map.comp_linear_map` that don't have equivalents at
present for `multilinear_map.comp_linear_map` (I added one such
equivalent `multilinear_map.zero_comp_linear_map` because I needed it
for another lemma, but didn't try adding such equivalents of existing
lemmas where I didn't need them).



---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
