### PR TITLE
refactor(algebra/direct_sum): unbundle `direct_sum.of`

### DIFF
--- a/src/algebra/direct_sum/algebra.lean
+++ b/src/algebra/direct_sum/algebra.lean
@@ -110,10 +110,12 @@ def to_algebra
 
 See note [partially-applied ext lemmas]. -/
 @[ext]
-lemma alg_hom_ext ⦃f g : (⨁ i, A i) →ₐ[R] B⦄
+lemma alg_hom_ext' ⦃f g : (⨁ i, A i) →ₐ[R] B⦄
   (h : ∀ i, f.to_linear_map.comp (lof _ _ A i) = g.to_linear_map.comp (lof _ _ A i)) : f = g :=
-alg_hom.coe_ring_hom_injective $
-  direct_sum.ring_hom_ext $ λ i, add_monoid_hom.ext $ linear_map.congr_fun (h i)
+alg_hom.to_linear_map_injective $ direct_sum.linear_map_ext _ h
+
+lemma alg_hom_ext ⦃f g : (⨁ i, A i) →ₐ[R] B⦄ (h : ∀ i x, f (of A i x) = g (of A i x)) : f = g :=
+alg_hom_ext' R A $ λ i, linear_map.ext $ h i
 
 end direct_sum
 

--- a/src/algebra/direct_sum/algebra.lean
+++ b/src/algebra/direct_sum/algebra.lean
@@ -55,30 +55,30 @@ end
 variables [semiring B] [galgebra R A] [algebra R B]
 
 instance : algebra R (⨁ i, A i) :=
-{ to_fun := (direct_sum.of A 0).comp galgebra.to_fun,
+{ to_fun := (direct_sum.of_add_hom A 0).comp galgebra.to_fun,
   map_zero' := add_monoid_hom.map_zero _,
   map_add' := add_monoid_hom.map_add _,
-  map_one' := (direct_sum.of A 0).congr_arg galgebra.map_one,
+  map_one' := (direct_sum.of_add_hom A 0).congr_arg galgebra.map_one,
   map_mul' := λ a b, begin
-    simp only [add_monoid_hom.comp_apply],
+    simp only [add_monoid_hom.comp_apply, of_add_hom_apply],
     rw of_mul_of,
     apply dfinsupp.single_eq_of_sigma_eq (galgebra.map_mul a b),
   end,
   commutes' := λ r x, begin
-    change add_monoid_hom.mul (direct_sum.of _ _ _) x =
-      add_monoid_hom.mul.flip (direct_sum.of _ _ _) x,
+    change add_monoid_hom.mul (of_add_hom _ _ _) x = add_monoid_hom.mul.flip (of_add_hom _ _ _) x,
     apply add_monoid_hom.congr_fun _ x,
     ext i xi : 2,
-    dsimp only [add_monoid_hom.comp_apply, add_monoid_hom.mul_apply, add_monoid_hom.flip_apply],
+    dsimp only [add_monoid_hom.comp_apply, add_monoid_hom.mul_apply, add_monoid_hom.flip_apply,
+      of_add_hom_apply],
     rw [of_mul_of, of_mul_of],
     apply dfinsupp.single_eq_of_sigma_eq (galgebra.commutes r ⟨i, xi⟩),
   end,
   smul_def' := λ r x, begin
-    change distrib_mul_action.to_add_monoid_hom _ r x = add_monoid_hom.mul (direct_sum.of _ _ _) x,
+    change distrib_mul_action.to_add_monoid_hom _ r x = add_monoid_hom.mul (of_add_hom _ _ _) x,
     apply add_monoid_hom.congr_fun _ x,
     ext i xi : 2,
     dsimp only [add_monoid_hom.comp_apply, distrib_mul_action.to_add_monoid_hom_apply,
-      add_monoid_hom.mul_apply],
+      add_monoid_hom.mul_apply, of_add_hom_apply],
     rw [direct_sum.of_mul_of, ←of_smul],
     apply dfinsupp.single_eq_of_sigma_eq (galgebra.smul_def r ⟨i, xi⟩),
   end }
@@ -87,7 +87,7 @@ lemma algebra_map_apply (r : R) :
   algebra_map R (⨁ i, A i) r = direct_sum.of A 0 (galgebra.to_fun r) := rfl
 
 lemma algebra_map_to_add_monoid_hom :
-  ↑(algebra_map R (⨁ i, A i)) = (direct_sum.of A 0).comp (galgebra.to_fun : R →+ A 0) := rfl
+  ↑(algebra_map R (⨁ i, A i)) = (direct_sum.of_add_hom A 0).comp (galgebra.to_fun : R →+ A 0) := rfl
 
 /-- A family of `linear_map`s preserving `direct_sum.ghas_one.one` and `direct_sum.ghas_mul.mul`
 describes an `alg_hom` on `⨁ i, A i`. This is a stronger version of `direct_sum.to_semiring`.

--- a/src/algebra/direct_sum/ring.lean
+++ b/src/algebra/direct_sum/ring.lean
@@ -138,7 +138,7 @@ def gmul_hom {i j} : A i →+ A j →+ A (i + j) :=
 def mul_hom : (⨁ i, A i) →+ (⨁ i, A i) →+ ⨁ i, A i :=
 direct_sum.to_add_monoid $ λ i,
   add_monoid_hom.flip $ direct_sum.to_add_monoid $ λ j, add_monoid_hom.flip $
-    (direct_sum.of A _).comp_hom.comp $ gmul_hom A
+    (direct_sum.of_add_hom A _).comp_hom.comp $ gmul_hom A
 
 instance : non_unital_non_assoc_semiring (⨁ i, A i) :=
 { mul := λ a b, mul_hom A a b,
@@ -157,7 +157,7 @@ lemma mul_hom_of_of {i j} (a : A i) (b : A j) :
 begin
   unfold mul_hom,
   rw [to_add_monoid_of, flip_apply, to_add_monoid_of, flip_apply, coe_comp, function.comp_app,
-      comp_hom_apply_apply, coe_comp, function.comp_app, gmul_hom_apply_apply],
+      comp_hom_apply_apply, coe_comp, function.comp_app, gmul_hom_apply_apply, of_add_hom_apply],
 end
 
 lemma of_mul_of {i j} (a : A i) (b : A j) :
@@ -198,7 +198,8 @@ suffices (mul_hom A).comp_hom.comp (mul_hom A)            -- `λ a b c, a * b * 
   from add_monoid_hom.congr_fun (add_monoid_hom.congr_fun (add_monoid_hom.congr_fun this a) b) c,
 begin
   ext ai ax bi bx ci cx : 6,
-  dsimp only [coe_comp, function.comp_app, comp_hom_apply_apply, flip_apply, flip_hom_apply],
+  dsimp only [coe_comp, function.comp_app, comp_hom_apply_apply, flip_apply, flip_hom_apply,
+    of_add_hom_apply],
   rw [mul_hom_of_of, mul_hom_of_of, mul_hom_of_of, mul_hom_of_of],
   exact of_eq_of_graded_monoid_eq (mul_assoc (graded_monoid.mk ai ax) ⟨bi, bx⟩ ⟨ci, cx⟩),
 end
@@ -307,12 +308,12 @@ of_zero_smul A a b
 
 instance grade_zero.non_unital_non_assoc_semiring : non_unital_non_assoc_semiring (A 0) :=
 function.injective.non_unital_non_assoc_semiring (of A 0) dfinsupp.single_injective
-  (of A 0).map_zero (of A 0).map_add (of_zero_mul A)
+  (of_add_hom A 0).map_zero (of_add_hom A 0).map_add (of_zero_mul A)
 
 instance grade_zero.smul_with_zero (i : ι) : smul_with_zero (A 0) (A i) :=
 begin
-  letI := smul_with_zero.comp_hom (⨁ i, A i) (of A 0).to_zero_hom,
-  refine dfinsupp.single_injective.smul_with_zero (of A i).to_zero_hom (of_zero_smul A),
+  letI := smul_with_zero.comp_hom (⨁ i, A i) (of_add_hom A 0).to_zero_hom,
+  refine dfinsupp.single_injective.smul_with_zero (of_add_hom A i).to_zero_hom (of_zero_smul A),
 end
 
 end mul
@@ -323,11 +324,11 @@ variables [Π i, add_comm_monoid (A i)] [add_monoid ι] [gsemiring A]
 /-- The `semiring` structure derived from `gsemiring A`. -/
 instance grade_zero.semiring : semiring (A 0) :=
 function.injective.semiring (of A 0) dfinsupp.single_injective
-  (of A 0).map_zero (of_zero_one A) (of A 0).map_add (of_zero_mul A)
+  (of_zero A 0) (of_zero_one A) (of_add A 0) (of_zero_mul A)
 
 /-- `of A 0` is a `ring_hom`, using the `direct_sum.grade_zero.semiring` structure. -/
 def of_zero_ring_hom : A 0 →+* (⨁ i, A i) :=
-{ map_one' := of_zero_one A, map_mul' := of_zero_mul A, ..(of _ 0) }
+{ map_one' := of_zero_one A, map_mul' := of_zero_mul A, ..(of_add_hom _ 0) }
 
 /-- Each grade `A i` derives a `A 0`-module structure from `gsemiring A`. Note that this results
 in an overall `module (A 0) (⨁ i, A i)` structure via `direct_sum.module`.
@@ -335,7 +336,7 @@ in an overall `module (A 0) (⨁ i, A i)` structure via `direct_sum.module`.
 instance grade_zero.module {i} : module (A 0) (A i) :=
 begin
   letI := module.comp_hom (⨁ i, A i) (of_zero_ring_hom A),
-  exact dfinsupp.single_injective.module (A 0) (of A i) (λ a, of_zero_smul A a),
+  exact dfinsupp.single_injective.module (A 0) (of_add_hom A i) (λ a, of_zero_smul A a),
 end
 
 end semiring
@@ -347,7 +348,7 @@ variables [Π i, add_comm_monoid (A i)] [add_comm_monoid ι] [gcomm_semiring A]
 /-- The `comm_semiring` structure derived from `gcomm_semiring A`. -/
 instance grade_zero.comm_semiring : comm_semiring (A 0) :=
 function.injective.comm_semiring (of A 0) dfinsupp.single_injective
-  (of A 0).map_zero (of_zero_one A) (of A 0).map_add (of_zero_mul A)
+  (of_zero A 0) (of_zero_one A) (of_add A 0) (of_zero_mul A)
 
 end comm_semiring
 
@@ -357,8 +358,8 @@ variables [Π i, add_comm_group (A i)] [add_comm_monoid ι] [gsemiring A]
 /-- The `ring` derived from `gsemiring A`. -/
 instance grade_zero.ring : ring (A 0) :=
 function.injective.ring (of A 0) dfinsupp.single_injective
-  (of A 0).map_zero (of_zero_one A) (of A 0).map_add (of_zero_mul A)
-  (of A 0).map_neg (of A 0).map_sub
+  (of_zero A 0) (of_zero_one A) (of_add A 0) (of_zero_mul A)
+  (of_add_hom A 0).map_neg (of_add_hom A 0).map_sub
 
 end ring
 
@@ -368,8 +369,8 @@ variables [Π i, add_comm_group (A i)] [add_comm_monoid ι] [gcomm_semiring A]
 /-- The `comm_ring` derived from `gcomm_semiring A`. -/
 instance grade_zero.comm_ring : comm_ring (A 0) :=
 function.injective.comm_ring (of A 0) dfinsupp.single_injective
-  (of A 0).map_zero (of_zero_one A) (of A 0).map_add (of_zero_mul A)
-  (of A 0).map_neg (of A 0).map_sub
+  (of_zero A 0) (of_zero_one A) (of_add A 0) (of_zero_mul A)
+  (of_add_hom A 0).map_neg (of_add_hom A 0).map_sub
 
 end comm_ring
 
@@ -385,8 +386,8 @@ then they are equal.
 
 See note [partially-applied ext lemmas]. -/
 @[ext]
-lemma ring_hom_ext' (F G : (⨁ i, A i) →+* R)
-  (h : ∀ i, (F : (⨁ i, A i) →+ R).comp (of _ i) = (G : (⨁ i, A i) →+ R).comp (of _ i)) : F = G :=
+lemma ring_hom_ext ⦃F G : (⨁ i, A i) →+* R⦄
+  (h : ∀ i, (↑F : _ →+ R).comp (of_add_hom A i) = (↑G : _ →+ R).comp (of_add_hom A i)) : F = G :=
 ring_hom.coe_add_monoid_hom_injective $ direct_sum.add_hom_ext' h
 
 /-- A family of `add_monoid_hom`s preserving `direct_sum.ghas_one.one` and `direct_sum.ghas_mul.mul`
@@ -435,12 +436,12 @@ def lift_ring_hom :
     ((⨁ i, A i) →+* R) :=
 { to_fun := λ f, to_semiring f.1 f.2.1 f.2.2,
   inv_fun := λ F,
-    ⟨λ i, (F : (⨁ i, A i) →+ R).comp (of _ i), begin
+    ⟨λ i, (F : (⨁ i, A i) →+ R).comp (of_add_hom _ i), begin
       simp only [add_monoid_hom.comp_apply, ring_hom.coe_add_monoid_hom],
       rw ←F.map_one,
       refl
     end, λ i j ai aj, begin
-      simp only [add_monoid_hom.comp_apply, ring_hom.coe_add_monoid_hom],
+      simp only [add_monoid_hom.comp_apply, ring_hom.coe_add_monoid_hom, of_add_hom_apply],
       rw [←F.map_mul, of_mul_of],
     end⟩,
   left_inv := λ f, begin
@@ -453,17 +454,8 @@ def lift_ring_hom :
     simp only [ring_hom.coe_add_monoid_hom_mk,
       direct_sum.to_add_monoid_of,
       add_monoid_hom.mk_coe,
-      add_monoid_hom.comp_apply, to_semiring_coe_add_monoid_hom],
+      add_monoid_hom.comp_apply, to_semiring_coe_add_monoid_hom, of_add_hom_apply],
   end}
-
-/-- Two `ring_hom`s out of a direct sum are equal if they agree on the generators.
-
-See note [partially-applied ext lemmas]. -/
-@[ext]
-lemma ring_hom_ext ⦃f g : (⨁ i, A i) →+* R⦄
-  (h : ∀ i, (↑f : (⨁ i, A i) →+ R).comp (of A i) = (↑g : (⨁ i, A i) →+ R).comp (of A i)) :
-  f = g :=
-direct_sum.lift_ring_hom.symm.injective $ subtype.ext $ funext h
 
 end to_semiring
 

--- a/src/algebra/direct_sum/ring.lean
+++ b/src/algebra/direct_sum/ring.lean
@@ -385,9 +385,14 @@ then they are equal.
 
 See note [partially-applied ext lemmas]. -/
 @[ext]
-lemma ring_hom_ext' (F G : (⨁ i, A i) →+* R)
-  (h : ∀ i, (F : (⨁ i, A i) →+ R).comp (of _ i) = (G : (⨁ i, A i) →+ R).comp (of _ i)) : F = G :=
+lemma ring_hom_ext' ⦃F G : (⨁ i, A i) →+* R⦄
+  (h : ∀ i, (↑F : _ →+ R).comp (of A i) = (↑G : _ →+ R).comp (of A i)) : F = G :=
 ring_hom.coe_add_monoid_hom_injective $ direct_sum.add_hom_ext' h
+
+/-- Two `ring_hom`s out of a direct sum are equal if they agree on the generators. -/
+lemma ring_hom_ext ⦃f g : (⨁ i, A i) →+* R⦄ (h : ∀ i x, f (of A i x) = g (of A i x)) :
+  f = g :=
+ring_hom_ext' $ λ i, add_monoid_hom.ext $ h i
 
 /-- A family of `add_monoid_hom`s preserving `direct_sum.ghas_one.one` and `direct_sum.ghas_mul.mul`
 describes a `ring_hom`s on `⨁ i, A i`. This is a stronger version of `direct_sum.to_monoid`.
@@ -455,15 +460,6 @@ def lift_ring_hom :
       add_monoid_hom.mk_coe,
       add_monoid_hom.comp_apply, to_semiring_coe_add_monoid_hom],
   end}
-
-/-- Two `ring_hom`s out of a direct sum are equal if they agree on the generators.
-
-See note [partially-applied ext lemmas]. -/
-@[ext]
-lemma ring_hom_ext ⦃f g : (⨁ i, A i) →+* R⦄
-  (h : ∀ i, (↑f : (⨁ i, A i) →+ R).comp (of A i) = (↑g : (⨁ i, A i) →+ R).comp (of A i)) :
-  f = g :=
-direct_sum.lift_ring_hom.symm.injective $ subtype.ext $ funext h
 
 end to_semiring
 

--- a/src/algebra/direct_sum/ring.lean
+++ b/src/algebra/direct_sum/ring.lean
@@ -117,6 +117,9 @@ variables [has_zero ι] [graded_monoid.ghas_one A] [Π i, add_comm_monoid (A i)]
 instance : has_one (⨁ i, A i) :=
 { one := direct_sum.of (λ i, A i) 0 graded_monoid.ghas_one.one}
 
+@[simp] lemma of_zero_eq_one (x : A 0) : of A 0 x = 1 ↔ x = graded_monoid.ghas_one.one :=
+dfinsupp.single_injective.eq_iff
+
 end one
 
 section mul
@@ -386,7 +389,7 @@ then they are equal.
 
 See note [partially-applied ext lemmas]. -/
 @[ext]
-lemma ring_hom_ext ⦃F G : (⨁ i, A i) →+* R⦄
+lemma ring_hom_ext' ⦃F G : (⨁ i, A i) →+* R⦄
   (h : ∀ i, (↑F : _ →+ R).comp (of_add_hom A i) = (↑G : _ →+ R).comp (of_add_hom A i)) : F = G :=
 ring_hom.coe_add_monoid_hom_injective $ direct_sum.add_hom_ext' h
 

--- a/src/algebra/graded_monoid.lean
+++ b/src/algebra/graded_monoid.lean
@@ -332,6 +332,11 @@ instance set_like.ghas_mul {S : Type*} [set_like S R] [has_mul R] [has_add ι] (
   [set_like.has_graded_mul A] {i j : ι} (x : A i) (y : A j) :
     ↑(@graded_monoid.ghas_mul.mul _ (λ i, A i) _ _ _ _ x y) = (x * y : R) := rfl
 
+@[simp] lemma set_like.mk_ghas_mul_mk {S : Type*} [set_like S R] [has_mul R] [has_add ι] (A : ι → S)
+  [set_like.has_graded_mul A] {i j : ι} (x y) (hx : x ∈ A i) (hy : y ∈ A j) :
+    (@graded_monoid.ghas_mul.mul _ (λ i, A i) _ _ _ _ ⟨x, hx⟩ ⟨y, hy⟩) =
+      ⟨x * y, set_like.has_graded_mul.mul_mem hx hy⟩ := rfl
+
 /-- A version of `graded_monoid.gmonoid` for internally graded objects. -/
 class set_like.graded_monoid {S : Type*} [set_like S R] [monoid R] [add_monoid ι]
   (A : ι → S) extends set_like.has_graded_one A, set_like.has_graded_mul A : Prop

--- a/src/algebra/monoid_algebra/grading.lean
+++ b/src/algebra/monoid_algebra/grading.lean
@@ -113,22 +113,28 @@ by apply grade_by.graded_monoid (add_monoid_hom.id _)
 
 variables {R} [add_monoid M] [decidable_eq ι] [add_monoid ι] [comm_semiring R] (f : M →+ ι)
 
+-- @[congr]
+lemma set_like.dep_congr {ι α β P} [set_like P α]
+  {p : ι → P} (f : Π i, p i → β) :
+  ∀ {i j} (x : p i) (h : i = j), f i x = f j ⟨x, h ▸ x.prop⟩
+| i _ ⟨x, px⟩ rfl := rfl
+
 /-- The canonical grade decomposition. -/
 def to_grades_by : add_monoid_algebra R M →ₐ[R] ⨁ i : ι, grade_by R f i :=
 add_monoid_algebra.lift R M _
 { to_fun := λ m, direct_sum.of (λ i : ι, grade_by R f i) (f m.to_add)
     ⟨finsupp.single m.to_add 1, single_mem_grade_by _ _ _ rfl _⟩,
-  map_one' := direct_sum.of_eq_of_graded_monoid_eq (by congr' 2; try {ext};
-    simp only [submodule.mem_to_add_submonoid, to_add_one, add_monoid_hom.map_zero]),
+  map_one' := by sorry,
   map_mul' := λ i j, begin
-    symmetry,
-    convert direct_sum.of_mul_of _ _,
-    apply direct_sum.of_eq_of_graded_monoid_eq,
-    congr' 2,
-    { rw [to_add_mul, add_monoid_hom.map_add] },
-    { ext,
-      simp only [submodule.mem_to_add_submonoid, add_monoid_hom.map_add, to_add_mul] },
-    { exact eq.trans (by rw [one_mul, to_add_mul]) single_mul_single.symm }
+    simp only [direct_sum.of_mul_of, set_like.mk_ghas_mul_mk, single_mul_single, one_mul],
+    sorry,
+    -- simp,
+    -- symmetry,
+    -- convert direct_sum.of_mul_of _ _,
+    -- { rw [to_add_mul, add_monoid_hom.map_add] },
+    -- { ext,
+    --   simp only [submodule.mem_to_add_submonoid, add_monoid_hom.map_add, to_add_mul] },
+    -- { exact eq.trans (by rw [one_mul, to_add_mul]) single_mul_single.symm }
   end }
 
 /-- The canonical grade decomposition. -/
@@ -171,7 +177,7 @@ begin
   refine finsupp.induction x _ _,
   { intros hx,
     symmetry,
-    exact add_monoid_hom.map_zero _ },
+    exact direct_sum.of_zero _ _ },
   { intros m b y hmy hb ih hmby,
     have : disjoint (finsupp.single m b).support y.support,
     { simpa only [finsupp.support_single_ne_zero hb, finset.disjoint_singleton_left] },
@@ -184,7 +190,7 @@ begin
     simp only [alg_hom.map_add, submodule.coe_mk, to_grades_by_single' f i m this],
     let ih' := ih h2,
     dsimp at ih',
-    rw [ih', ← add_monoid_hom.map_add],
+    rw [ih', ← direct_sum.of_add],
     apply direct_sum.of_eq_of_graded_monoid_eq,
     congr' 2 }
 end


### PR DESCRIPTION
If this is bundled into an `add_monoid_hom`, then `simp` is not able to rewrite `of _ i (f j)` into `of _ j (f j)`, because it doesn't know how to rewrite the `add_monoid` term that is part of the type.
In practice this change isn't too annoying elsewhere, as all we need are a few rewrites by the `of_add_hom_apply` lemma.

[Zulip thread](https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/congr.20gets.20stuck.20on.20bundled.20homs/near/263773820) about `congr` getting stuck on the bundled version.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
-->
- [x] depends on: #10640

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
