### PR TITLE
[Merged by Bors] - chore(*): fix last line length and notation style linter errors

### DIFF
--- a/src/data/pfunctor/multivariate/M.lean
+++ b/src/data/pfunctor/multivariate/M.lean
@@ -40,7 +40,8 @@ that `A` is a possibly infinite tree.
 
 ## Reference
 
- * [Jeremy Avigad, Mario M. Carneiro and Simon Hudon, *Data Types as Quotients of Polynomial Functors*][avigad-carneiro-hudon2019]
+ * [Jeremy Avigad, Mario M. Carneiro and Simon Hudon.
+   [*Data Types as Quotients of Polynomial Functors*][avigad-carneiro-hudon2019]
 -/
 
 universe u

--- a/src/data/pfunctor/multivariate/M.lean
+++ b/src/data/pfunctor/multivariate/M.lean
@@ -40,7 +40,7 @@ that `A` is a possibly infinite tree.
 
 ## Reference
 
- * [Jeremy Avigad, Mario M. Carneiro and Simon Hudon.
+ * Jeremy Avigad, Mario M. Carneiro and Simon Hudon.
    [*Data Types as Quotients of Polynomial Functors*][avigad-carneiro-hudon2019]
 -/
 

--- a/src/data/pfunctor/multivariate/W.lean
+++ b/src/data/pfunctor/multivariate/W.lean
@@ -39,7 +39,8 @@ its valid paths to values of `α`
 
 ## Reference
 
- * [Jeremy Avigad, Mario M. Carneiro and Simon Hudon, *Data Types as Quotients of Polynomial Functors*][avigad-carneiro-hudon2019]
+ * [Jeremy Avigad, Mario M. Carneiro and Simon Hudon.
+   [*Data Types as Quotients of Polynomial Functors*][avigad-carneiro-hudon2019]
 -/
 
 universes u v

--- a/src/data/pfunctor/multivariate/W.lean
+++ b/src/data/pfunctor/multivariate/W.lean
@@ -39,7 +39,7 @@ its valid paths to values of `α`
 
 ## Reference
 
- * [Jeremy Avigad, Mario M. Carneiro and Simon Hudon.
+ * Jeremy Avigad, Mario M. Carneiro and Simon Hudon.
    [*Data Types as Quotients of Polynomial Functors*][avigad-carneiro-hudon2019]
 -/
 

--- a/src/data/qpf/multivariate/constructions/cofix.lean
+++ b/src/data/qpf/multivariate/constructions/cofix.lean
@@ -35,7 +35,7 @@ We define the relation `Mcongr` and take its quotient as the definition of `cofi
 
 ## Reference
 
- * [Jeremy Avigad, Mario M. Carneiro and Simon Hudon.
+ * Jeremy Avigad, Mario M. Carneiro and Simon Hudon.
    [*Data Types as Quotients of Polynomial Functors*][avigad-carneiro-hudon2019]
 -/
 

--- a/src/data/qpf/multivariate/constructions/cofix.lean
+++ b/src/data/qpf/multivariate/constructions/cofix.lean
@@ -35,7 +35,8 @@ We define the relation `Mcongr` and take its quotient as the definition of `cofi
 
 ## Reference
 
- * [Jeremy Avigad, Mario M. Carneiro and Simon Hudon, *Data Types as Quotients of Polynomial Functors*][avigad-carneiro-hudon2019]
+ * [Jeremy Avigad, Mario M. Carneiro and Simon Hudon.
+   [*Data Types as Quotients of Polynomial Functors*][avigad-carneiro-hudon2019]
 -/
 
 universe u

--- a/src/data/qpf/multivariate/constructions/fix.lean
+++ b/src/data/qpf/multivariate/constructions/fix.lean
@@ -44,7 +44,7 @@ See [avigad-carneiro-hudon2019] for more details.
 
 ## Reference
 
- * [Jeremy Avigad, Mario M. Carneiro and Simon Hudon.
+ * Jeremy Avigad, Mario M. Carneiro and Simon Hudon.
    [*Data Types as Quotients of Polynomial Functors*][avigad-carneiro-hudon2019]
 -/
 

--- a/src/data/qpf/multivariate/constructions/fix.lean
+++ b/src/data/qpf/multivariate/constructions/fix.lean
@@ -44,7 +44,8 @@ See [avigad-carneiro-hudon2019] for more details.
 
 ## Reference
 
- * [Jeremy Avigad, Mario M. Carneiro and Simon Hudon, *Data Types as Quotients of Polynomial Functors*][avigad-carneiro-hudon2019]
+ * [Jeremy Avigad, Mario M. Carneiro and Simon Hudon.
+   [*Data Types as Quotients of Polynomial Functors*][avigad-carneiro-hudon2019]
 -/
 
 universes u v

--- a/src/tactic/induction.lean
+++ b/src/tactic/induction.lean
@@ -1325,8 +1325,6 @@ meta def generalisation_mode_parser : lean.parser generalization_mode :=
   <|>
   pure (generalization_mode.generalize_all_except [])
 
-precedence `fixing`:0
-
 /--
 A variant of `tactic.interactive.induction`, with the following differences:
 

--- a/src/tactic/reserved_notation.lean
+++ b/src/tactic/reserved_notation.lean
@@ -47,6 +47,9 @@ reserve notation `to`
 -- used in `tactic/rcases.lean`
 precedence `?`:max
 
+-- used in `tactic/induction.lean`
+precedence `fixing`:0
+
 -- used in `order/lattice.lean`
 reserve infixl ` ⊓ `:70
 reserve infixl ` ⊔ `:65


### PR DESCRIPTION
These are the last non-module doc style linter errors (from https://github.com/leanprover-community/mathlib/blob/master/scripts/style-exceptions.txt).

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
