### PR TITLE
feat(data/finsupp/basic): add `finsupp.not_mem_erase`

### DIFF
--- a/src/data/finsupp/basic.lean
+++ b/src/data/finsupp/basic.lean
@@ -680,6 +680,14 @@ end
 @[simp] lemma erase_zero (a : α) : erase a (0 : α →₀ M) = 0 :=
 by rw [← support_eq_empty, support_erase, support_zero, erase_empty]
 
+theorem finsupp.not_mem_erase {α : Type*} {M : Type*} [decidable_eq α] [has_zero M]
+  (f : α →₀ M) (a : α) : a ∉ (erase a f).support :=
+begin
+  intro H,
+  apply (finset.not_mem_erase a f.support),
+  convert H,
+end
+
 end erase
 
 /-!

--- a/src/data/finsupp/basic.lean
+++ b/src/data/finsupp/basic.lean
@@ -680,8 +680,7 @@ end
 @[simp] lemma erase_zero (a : α) : erase a (0 : α →₀ M) = 0 :=
 by rw [← support_eq_empty, support_erase, support_zero, erase_empty]
 
-theorem finsupp.not_mem_erase {α : Type*} {M : Type*} [decidable_eq α] [has_zero M]
-  (f : α →₀ M) (a : α) : a ∉ (erase a f).support :=
+lemma not_mem_erase (f : α →₀ M) (a : α) : a ∉ (erase a f).support :=
 begin
   intro H,
   apply (finset.not_mem_erase a f.support),


### PR DESCRIPTION
Adding `finsupp.not_mem_erase` to avoid an issue discussed in this Zulip thread: https://leanprover.zulipchat.com/#narrow/stream/113489-new-members/topic/finsupp.2Esupport_erase



---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
