### PR TITLE
[Merged by Bors] - feat(order/basic): Add `lt_iff` lemma on `α × β`

### DIFF
--- a/src/order/basic.lean
+++ b/src/order/basic.lean
@@ -498,38 +498,33 @@ namespace prod
 instance (α : Type u) (β : Type v) [has_le α] [has_le β] : has_le (α × β) :=
 ⟨λ p q, p.1 ≤ q.1 ∧ p.2 ≤ q.2⟩
 
-instance (α β : Type*) [has_le α] [has_lt α] [has_le β] [has_lt β] : has_lt (α × β) :=
-⟨λ a b, a.1 < b.1 ∧ a.2 ≤ b.2 ∨ a.1 ≤ b.1 ∧ a.2 < b.2⟩
-
 lemma le_def [has_le α] [has_le β] {x y : α × β} : x ≤ y ↔ x.1 ≤ y.1 ∧ x.2 ≤ y.2 := iff.rfl
-
-lemma lt_def [has_le α] [has_lt α] [has_le β] [has_lt β] {x y : α × β} :
-  x < y ↔ x.1 < y.1 ∧ x.2 ≤ y.2 ∨ x.1 ≤ y.1 ∧ x.2 < y.2 :=
-iff.rfl
 
 @[simp] lemma mk_le_mk [has_le α] [has_le β] {x₁ x₂ : α} {y₁ y₂ : β} :
   (x₁, y₁) ≤ (x₂, y₂) ↔ x₁ ≤ x₂ ∧ y₁ ≤ y₂ :=
-iff.rfl
-
-@[simp] lemma mk_lt_mk [has_le α] [has_lt α] [has_le β] [has_lt β] {x₁ x₂ : α} {y₁ y₂ : β} :
-  (x₁, y₁) < (x₂, y₂) ↔ x₁ < x₂ ∧ y₁ ≤ y₂ ∨ x₁ ≤ x₂ ∧ y₁ < y₂ :=
 iff.rfl
 
 instance (α : Type u) (β : Type v) [preorder α] [preorder β] : preorder (α × β) :=
 { le_refl  := λ ⟨a, b⟩, ⟨le_refl a, le_refl b⟩,
   le_trans := λ ⟨a, b⟩ ⟨c, d⟩ ⟨e, f⟩ ⟨hac, hbd⟩ ⟨hce, hdf⟩,
     ⟨le_trans hac hce, le_trans hbd hdf⟩,
-  lt_iff_le_not_le := λ a b, begin
-    refine ⟨_, λ h, _⟩,
-    { rintro (⟨h₁, h₂⟩ | ⟨h₁, h₂⟩),
-      { exact ⟨⟨h₁.le, h₂⟩, λ h, h₁.not_le h.1⟩ },
-      { exact ⟨⟨h₁, h₂.le⟩, λ h, h₂.not_le h.2⟩ } },
-    { by_cases h₁ : b.1 ≤ a.1,
-      { exact or.inr ⟨h.1.1, h.1.2.lt_of_not_le $ λ h₂, h.2 ⟨h₁, h₂⟩⟩ },
-      { exact or.inl ⟨h.1.1.lt_of_not_le h₁, h.1.2⟩ } }
-  end,
-  .. prod.has_le α β,
-  .. prod.has_lt α β }
+  .. prod.has_le α β }
+
+lemma lt_iff [preorder α] [preorder β] {a b : α × β} :
+  a < b ↔ a.1 < b.1 ∧ a.2 ≤ b.2 ∨ a.1 ≤ b.1 ∧ a.2 < b.2 :=
+begin
+  refine ⟨λ h, _, _⟩,
+  { by_cases h₁ : b.1 ≤ a.1,
+    { exact or.inr ⟨h.1.1, h.1.2.lt_of_not_le $ λ h₂, h.2 ⟨h₁, h₂⟩⟩ },
+    { exact or.inl ⟨h.1.1.lt_of_not_le h₁, h.1.2⟩ } },
+  { rintro (⟨h₁, h₂⟩ | ⟨h₁, h₂⟩),
+    { exact ⟨⟨h₁.le, h₂⟩, λ h, h₁.not_le h.1⟩ },
+    { exact ⟨⟨h₁, h₂.le⟩, λ h, h₂.not_le h.2⟩ } }
+end
+
+@[simp] lemma mk_lt_mk [preorder α] [preorder β] {x₁ x₂ : α} {y₁ y₂ : β} :
+  (x₁, y₁) < (x₂, y₂) ↔ x₁ < x₂ ∧ y₁ ≤ y₂ ∨ x₁ ≤ x₂ ∧ y₁ < y₂ :=
+lt_iff
 
 /-- The pointwise partial order on a product.
     (The lexicographic ordering is defined in order/lexicographic.lean, and the instances are

--- a/src/order/basic.lean
+++ b/src/order/basic.lean
@@ -486,23 +486,50 @@ instance subtype.linear_order {α} [linear_order α] (p : α → Prop) : linear_
 { decidable_eq := subtype.decidable_eq,
   .. linear_order.lift coe subtype.coe_injective }
 
+/-!
+### Pointwise order on `α × β`
+
+The lexicographic order is defined in `order.lexicographic`, and the instances are available via the
+type synonym `lex α β = α × β`.
+-/
+
 namespace prod
 
 instance (α : Type u) (β : Type v) [has_le α] [has_le β] : has_le (α × β) :=
 ⟨λ p q, p.1 ≤ q.1 ∧ p.2 ≤ q.2⟩
 
-lemma le_def {α β : Type*} [has_le α] [has_le β] {x y : α × β} :
-  x ≤ y ↔ x.1 ≤ y.1 ∧ x.2 ≤ y.2 := iff.rfl
+instance (α β : Type*) [has_le α] [has_lt α] [has_le β] [has_lt β] : has_lt (α × β) :=
+⟨λ a b, a.1 < b.1 ∧ a.2 ≤ b.2 ∨ a.1 ≤ b.1 ∧ a.2 < b.2⟩
 
-@[simp] lemma mk_le_mk {α β : Type*} [has_le α] [has_le β] {x₁ x₂ : α} {y₁ y₂ : β} :
+lemma le_def [has_le α] [has_le β] {x y : α × β} : x ≤ y ↔ x.1 ≤ y.1 ∧ x.2 ≤ y.2 := iff.rfl
+
+lemma lt_def [has_le α] [has_lt α] [has_le β] [has_lt β] {x y : α × β} :
+  x < y ↔ x.1 < y.1 ∧ x.2 ≤ y.2 ∨ x.1 ≤ y.1 ∧ x.2 < y.2 :=
+iff.rfl
+
+@[simp] lemma mk_le_mk [has_le α] [has_le β] {x₁ x₂ : α} {y₁ y₂ : β} :
   (x₁, y₁) ≤ (x₂, y₂) ↔ x₁ ≤ x₂ ∧ y₁ ≤ y₂ :=
+iff.rfl
+
+@[simp] lemma mk_lt_mk [has_le α] [has_lt α] [has_le β] [has_lt β] {x₁ x₂ : α} {y₁ y₂ : β} :
+  (x₁, y₁) < (x₂, y₂) ↔ x₁ < x₂ ∧ y₁ ≤ y₂ ∨ x₁ ≤ x₂ ∧ y₁ < y₂ :=
 iff.rfl
 
 instance (α : Type u) (β : Type v) [preorder α] [preorder β] : preorder (α × β) :=
 { le_refl  := λ ⟨a, b⟩, ⟨le_refl a, le_refl b⟩,
   le_trans := λ ⟨a, b⟩ ⟨c, d⟩ ⟨e, f⟩ ⟨hac, hbd⟩ ⟨hce, hdf⟩,
     ⟨le_trans hac hce, le_trans hbd hdf⟩,
-  .. prod.has_le α β }
+  lt_iff_le_not_le := λ a b, begin
+    refine ⟨_, λ h, _⟩,
+    { rintro (⟨h₁, h₂⟩ | ⟨h₁, h₂⟩),
+      { exact ⟨⟨h₁.le, h₂⟩, λ h, h₁.not_le h.1⟩ },
+      { exact ⟨⟨h₁, h₂.le⟩, λ h, h₂.not_le h.2⟩ } },
+    { by_cases h₁ : b.1 ≤ a.1,
+      { exact or.inr ⟨h.1.1, h.1.2.lt_of_not_le $ λ h₂, h.2 ⟨h₁, h₂⟩⟩ },
+      { exact or.inl ⟨h.1.1.lt_of_not_le h₁, h.1.2⟩ } }
+  end,
+  .. prod.has_le α β,
+  .. prod.has_lt α β }
 
 /-- The pointwise partial order on a product.
     (The lexicographic ordering is defined in order/lexicographic.lean, and the instances are


### PR DESCRIPTION
This prove that `a < b` on `prod` is equivalent to `a.1 < b.1 ∧ a.2 ≤ b.2 ∨ a.1 ≤ b.1 ∧ a.2 < b.2`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
Given that this new definition is the correct one only classically, I can understand that people might not want to merge that. Nevertheless, this `or` definition sounds like the useful one, while the current one remains accessible through `lt_iff_le_not_le`.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
