### PR TITLE
[Merged by Bors] - fix(data/finsupp/basic): add missing decidable arguments

### DIFF
--- a/src/data/finsupp/basic.lean
+++ b/src/data/finsupp/basic.lean
@@ -399,15 +399,15 @@ by convert rfl
 by { ext, simp }
 
 lemma support_update [decidable_eq α] : support (f.update a b) =
-  if b = 0 then f.support.erase a else insert a f.support := rfl
+  if b = 0 then f.support.erase a else insert a f.support := by convert rfl
 
 @[simp] lemma support_update_zero [decidable_eq α] :
-  support (f.update a 0) = f.support.erase a := if_pos rfl
+  support (f.update a 0) = f.support.erase a := by convert if_pos rfl
 
 variables {b}
 
 lemma support_update_ne_zero [decidable_eq α] (h : b ≠ 0) :
-  support (f.update a b) = insert a f.support := if_neg h
+  support (f.update a b) = insert a f.support := by convert if_neg h
 
 end update
 

--- a/src/data/finsupp/basic.lean
+++ b/src/data/finsupp/basic.lean
@@ -211,10 +211,10 @@ if_pos rfl
 @[simp] lemma single_eq_of_ne (h : a ≠ a') : (single a b : α →₀ M) a' = 0 :=
 if_neg h
 
-lemma single_eq_update : ⇑(single a b) = function.update 0 a b :=
+lemma single_eq_update [decidable_eq α] : ⇑(single a b) = function.update 0 a b :=
 by rw [single_eq_indicator, ← set.piecewise_eq_indicator, set.piecewise_singleton]
 
-lemma single_eq_pi_single : ⇑(single a b) = pi.single a b :=
+lemma single_eq_pi_single [decidable_eq α] : ⇑(single a b) = pi.single a b :=
 single_eq_update
 
 @[simp] lemma single_zero : (single a 0 : α →₀ M) = 0 :=
@@ -300,7 +300,7 @@ begin
   simpa [H]
 end
 
-lemma support_single_disjoint {b' : M} (hb : b ≠ 0) (hb' : b' ≠ 0) {i j : α} :
+lemma support_single_disjoint [decidable_eq α] {b' : M} (hb : b ≠ 0) (hb' : b' ≠ 0) {i j : α} :
   disjoint (single i b).support (single j b').support ↔ i ≠ j :=
 by rw [support_single_ne_zero hb, support_single_ne_zero hb', disjoint_singleton]
 
@@ -363,11 +363,11 @@ lemma card_support_le_one' [nonempty α] {f : α →₀ M} :
   card f.support ≤ 1 ↔ ∃ a b, f = single a b :=
 by simp only [card_le_one_iff_subset_singleton, support_subset_singleton']
 
-@[simp] lemma equiv_fun_on_fintype_single [fintype α] (x : α) (m : M) :
+@[simp] lemma equiv_fun_on_fintype_single [decidable_eq α] [fintype α] (x : α) (m : M) :
   (@finsupp.equiv_fun_on_fintype α M _ _) (finsupp.single x m) = pi.single x m :=
 by { ext, simp [finsupp.single_eq_pi_single, finsupp.equiv_fun_on_fintype], }
 
-@[simp] lemma equiv_fun_on_fintype_symm_single [fintype α] (x : α) (m : M) :
+@[simp] lemma equiv_fun_on_fintype_symm_single [decidable_eq α] [fintype α] (x : α) (m : M) :
   (@finsupp.equiv_fun_on_fintype α M _ _).symm (pi.single x m) = finsupp.single x m :=
 by { ext, simp [finsupp.single_eq_pi_single, finsupp.equiv_fun_on_fintype], }
 
@@ -393,18 +393,21 @@ def update : α →₀ M :=
     simp [ha, hb]
   end⟩
 
-@[simp] lemma coe_update : (f.update a b : α → M) = function.update f a b := rfl
+@[simp] lemma coe_update [decidable_eq α] : (f.update a b : α → M) = function.update f a b :=
+by convert rfl
 @[simp] lemma update_self : f.update a (f a) = f :=
 by { ext, simp }
 
-lemma support_update : support (f.update a b) =
+lemma support_update [decidable_eq α] : support (f.update a b) =
   if b = 0 then f.support.erase a else insert a f.support := rfl
 
-@[simp] lemma support_update_zero : support (f.update a 0) = f.support.erase a := if_pos rfl
+@[simp] lemma support_update_zero [decidable_eq α] :
+  support (f.update a 0) = f.support.erase a := if_pos rfl
 
 variables {b}
 
-lemma support_update_ne_zero (h : b ≠ 0) : support (f.update a b) = insert a f.support := if_neg h
+lemma support_update_ne_zero [decidable_eq α] (h : b ≠ 0) :
+  support (f.update a b) = insert a f.support := if_neg h
 
 end update
 
@@ -1940,9 +1943,9 @@ to_multiset.map_add m n
 lemma to_multiset_apply (f : α →₀ ℕ) : f.to_multiset = f.sum (λ a n, n • {a}) := rfl
 
 @[simp]
-lemma to_multiset_symm_apply (s : multiset α) (x : α) :
+lemma to_multiset_symm_apply [decidable_eq α] (s : multiset α) (x : α) :
   finsupp.to_multiset.symm s x = s.count x :=
-rfl
+by convert rfl
 
 @[simp] lemma to_multiset_single (a : α) (n : ℕ) : to_multiset (single a n) = n • {a} :=
 by rw [to_multiset_apply, sum_single_index]; apply zero_nsmul

--- a/src/data/finsupp/lattice.lean
+++ b/src/data/finsupp/lattice.lean
@@ -12,7 +12,6 @@ This file provides instances of ordered structures on finsupps.
 
 -/
 
-open_locale classical
 noncomputable theory
 variables {α : Type*} {β : Type*} [has_zero β] {μ : Type*} [canonically_ordered_add_monoid μ]
 variables {γ : Type*} [canonically_linear_ordered_add_monoid γ]
@@ -30,7 +29,7 @@ instance [semilattice_inf β] : semilattice_inf (α →₀ β) :=
 lemma inf_apply [semilattice_inf β] {a : α} {f g : α →₀ β} : (f ⊓ g) a = f a ⊓ g a := rfl
 
 @[simp]
-lemma support_inf {f g : α →₀ γ} : (f ⊓ g).support = f.support ∩ g.support :=
+lemma support_inf [decidable_eq α] {f g : α →₀ γ} : (f ⊓ g).support = f.support ∩ g.support :=
 begin
   ext, simp only [inf_apply, mem_support_iff,  ne.def,
     finset.mem_union, finset.mem_filter, finset.mem_inter],
@@ -48,7 +47,7 @@ instance [semilattice_sup β] : semilattice_sup (α →₀ β) :=
 lemma sup_apply [semilattice_sup β] {a : α} {f g : α →₀ β} : (f ⊔ g) a = f a ⊔ g a := rfl
 
 @[simp]
-lemma support_sup {f g : α →₀ γ} : (f ⊔ g).support = f.support ∪ g.support :=
+lemma support_sup [decidable_eq α] {f g : α →₀ γ} : (f ⊔ g).support = f.support ∪ g.support :=
 begin
   ext, simp only [finset.mem_union, mem_support_iff, sup_apply, ne.def, ← bot_eq_zero],
   rw sup_eq_bot_iff, tauto,
@@ -59,7 +58,7 @@ instance lattice [lattice β] : lattice (α →₀ β) :=
 
 lemma bot_eq_zero : (⊥ : α →₀ γ) = 0 := rfl
 
-lemma disjoint_iff {x y : α →₀ γ} : disjoint x y ↔ disjoint x.support y.support :=
+lemma disjoint_iff [decidable_eq α] {x y : α →₀ γ} : disjoint x y ↔ disjoint x.support y.support :=
 begin
   unfold disjoint, repeat {rw le_bot_iff},
   rw [finsupp.bot_eq_zero, ← finsupp.support_eq_empty, finsupp.support_inf], refl,

--- a/src/data/finsupp/pointwise.lean
+++ b/src/data/finsupp/pointwise.lean
@@ -15,7 +15,6 @@ and `monoid_algebra`.
 -/
 
 noncomputable theory
-open_locale classical
 
 open finset
 
@@ -36,7 +35,7 @@ instance : has_mul (α →₀ β) := ⟨zip_with (*) (mul_zero 0)⟩
 @[simp] lemma mul_apply {g₁ g₂ : α →₀ β} {a : α} : (g₁ * g₂) a = g₁ a * g₂ a :=
 rfl
 
-lemma support_mul {g₁ g₂ : α →₀ β} : (g₁ * g₂).support ⊆ g₁.support ∩ g₂.support :=
+lemma support_mul [decidable_eq α] {g₁ g₂ : α →₀ β} : (g₁ * g₂).support ⊆ g₁.support ∩ g₂.support :=
 begin
   intros a h,
   simp only [mul_apply, mem_support_iff] at h,

--- a/src/data/polynomial/basic.lean
+++ b/src/data/polynomial/basic.lean
@@ -607,7 +607,6 @@ begin
   ext,
   cases p,
   simp only [coeff, update, function.update_apply, coe_update],
-  congr
 end
 
 lemma coeff_update_apply (p : polynomial R) (n : ℕ) (a : R) (i : ℕ) :


### PR DESCRIPTION
`finsupp` is classical, meaning that `def`s should just use noncomputable decidable instances rather than taking arguments that make more work for mathematicians.

However, this doesn't mean that lemma _statements_ should use noncomputable decidable instances, as this just makes the lemma less general and harder to apply (as shown by the `congr` removed elsewhere in the diff).

These were found by removing `open_locale classical` from the top of the file, adding `by classical; exact` to some definitions, and then fixing the broken lemma statements. In future we should detect this type of mistake with a linter.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)

I expect this to fail CI with a ~~bunch of~~ _single_ `congr`s saying there are no goals left to solve