### PR TITLE
[Merged by Bors] - chore(ring_theory/noetherian): rename `submodule.fg_map` to `submodule.fg.map`

### DIFF
--- a/src/ring_theory/finiteness.lean
+++ b/src/ring_theory/finiteness.lean
@@ -78,7 +78,7 @@ lemma of_surjective [hM : finite R M] (f : M →ₗ[R] N) (hf : surjective f) :
   finite R N :=
 ⟨begin
   rw [← linear_map.range_eq_top.2 hf, ← submodule.map_top],
-  exact submodule.fg_map hM.1
+  exact hM.1.map f
 end⟩
 
 lemma of_injective [is_noetherian R N] (f : M →ₗ[R] N)
@@ -311,13 +311,13 @@ variable {R}
 
 /-- The quotient of a finitely presented algebra by a finitely generated ideal is finitely
 presented. -/
-protected lemma quotient {I : ideal A} (h : submodule.fg I) (hfp : finite_presentation R A) :
+protected lemma quotient {I : ideal A} (h : I.fg) (hfp : finite_presentation R A) :
   finite_presentation R (A ⧸ I) :=
 begin
   obtain ⟨n, f, hf⟩ := hfp,
   refine ⟨n, (ideal.quotient.mkₐ R I).comp f, _, _⟩,
   { exact (ideal.quotient.mkₐ_surjective R I).comp hf.1 },
-  { refine submodule.fg_ker_ring_hom_comp _ _ hf.2 _ hf.1,
+  { refine ideal.fg_ker_comp _ _ hf.2 _ hf.1,
     simp [h] }
 end
 
@@ -347,7 +347,7 @@ begin
     set ulift_var := mv_polynomial.rename_equiv R equiv.ulift,
     refine ⟨ulift (fin n), infer_instance, f.comp ulift_var.to_alg_hom,
       hfs.comp ulift_var.surjective,
-      submodule.fg_ker_ring_hom_comp _ _ _ hfk ulift_var.surjective⟩,
+      ideal.fg_ker_comp _ _ _ hfk ulift_var.surjective⟩,
     convert submodule.fg_bot,
     exact ring_hom.ker_coe_equiv ulift_var.to_ring_equiv, },
   { rintro ⟨ι, hfintype, f, hf⟩,
@@ -356,7 +356,7 @@ begin
     replace equiv := mv_polynomial.rename_equiv R equiv,
     refine ⟨fintype.card ι, f.comp equiv.symm,
       hf.1.comp (alg_equiv.symm equiv).surjective,
-      submodule.fg_ker_ring_hom_comp _ f _ hf.2 equiv.symm.surjective⟩,
+      ideal.fg_ker_comp _ f _ hf.2 equiv.symm.surjective⟩,
     convert submodule.fg_bot,
     exact ring_hom.ker_coe_equiv (equiv.symm.to_ring_equiv), }
 end
@@ -373,11 +373,11 @@ begin
   let g := (mv_polynomial.map_alg_hom f).comp (mv_polynomial.sum_alg_equiv R ι ι').to_alg_hom,
   refine ⟨ι ⊕ ι', by apply_instance, g,
     (mv_polynomial.map_surjective f.to_ring_hom hf_surj).comp (alg_equiv.surjective _),
-    submodule.fg_ker_ring_hom_comp _ _ _ _ (alg_equiv.surjective _)⟩,
+    ideal.fg_ker_comp _ _ _ _ (alg_equiv.surjective _)⟩,
   { convert submodule.fg_bot,
     exact ring_hom.ker_coe_equiv _, },
   { rw [alg_hom.to_ring_hom_eq_coe, mv_polynomial.map_alg_hom_coe_ring_hom, mv_polynomial.ker_map],
-    exact submodule.map_fg_of_fg _ hf_ker mv_polynomial.C, }
+    exact hf_ker.map mv_polynomial.C, }
 end
 
 /-- If `A` is an `R`-algebra and `S` is an `A`-algebra, both finitely presented, then `S` is

--- a/src/ring_theory/fractional_ideal.lean
+++ b/src/ring_theory/fractional_ideal.lean
@@ -685,7 +685,7 @@ submodule.mem_span_mul_finite_of_mem_mul (by simpa using mem_coe.mpr hx)
 variables (S)
 
 lemma coe_ideal_fg (inj : function.injective (algebra_map R P)) (I : ideal R) :
-  fg ((I : fractional_ideal S P) : submodule R P) ↔ fg I :=
+  fg ((I : fractional_ideal S P) : submodule R P) ↔ I.fg :=
 coe_submodule_fg _ inj _
 
 variables {S}
@@ -1013,7 +1013,7 @@ variables [algebra R₁ K] [is_fraction_ring R₁ K]
 
 open_locale classical
 
-open submodule submodule.is_principal
+open submodule.is_principal
 
 include loc
 
@@ -1280,7 +1280,7 @@ begin
   rw is_noetherian_iff,
   intros J hJ,
   obtain ⟨J, rfl⟩ := le_one_iff_exists_coe_ideal.mp (le_trans hJ coe_ideal_le_one),
-  exact fg_map (is_noetherian.noetherian J),
+  exact (is_noetherian.noetherian J).map _,
 end
 
 include frac

--- a/src/ring_theory/localization.lean
+++ b/src/ring_theory/localization.lean
@@ -1330,7 +1330,7 @@ submodule.map_mul _ _ (algebra.of_id R S)
 lemma coe_submodule_fg
   (hS : function.injective (algebra_map R S)) (I : ideal R) :
   submodule.fg (coe_submodule S I) ↔ submodule.fg I :=
-⟨submodule.fg_of_fg_map _ (linear_map.ker_eq_bot.mpr hS), submodule.fg_map⟩
+⟨submodule.fg_of_fg_map _ (linear_map.ker_eq_bot.mpr hS), submodule.fg.map _⟩
 
 @[simp]
 lemma coe_submodule_span (s : set R) :

--- a/src/ring_theory/nakayama.lean
+++ b/src/ring_theory/nakayama.lean
@@ -76,17 +76,15 @@ begin
   have hNN' : N ⊔ N' = N ⊔ I • N',
     from le_antisymm hNN
       (sup_le_sup_left (submodule.smul_le.2 (λ _ _ _, submodule.smul_mem _ _)) _),
+  have h_comap := submodule.comap_injective_of_surjective (linear_map.range_eq_top.1 (N.range_mkq)),
   have : (I • N').map N.mkq = N'.map N.mkq,
-  { rw ← (submodule.comap_injective_of_surjective
-        (linear_map.range_eq_top.1 (submodule.range_mkq N))).eq_iff,
+  { rw ←h_comap.eq_iff,
     simpa [comap_map_eq, sup_comm, eq_comm] using hNN' },
   have := @submodule.eq_smul_of_le_smul_of_le_jacobson _ _ _ _ _ I J
-    (N'.map N.mkq) (fg_map hN')
+    (N'.map N.mkq) (hN'.map _)
     (by rw [← map_smul'', this]; exact le_refl _)
     hIJ,
-  rw [← map_smul'', ← (submodule.comap_injective_of_surjective
-        (linear_map.range_eq_top.1 (submodule.range_mkq N))).eq_iff,
-        comap_map_eq, comap_map_eq, submodule.ker_mkq, sup_comm,
+  rw [← map_smul'', ←h_comap.eq_iff, comap_map_eq, comap_map_eq, submodule.ker_mkq, sup_comm,
         hNN'] at this,
   rw [this, sup_comm]
 end


### PR DESCRIPTION
This renames:
* `submodule.fg_map` to `submodule.fg.map` (to match `submonoid.fg.map` and enable dot notation)
* `submodule.map_fg_of_fg` to `ideal.fg.map`
* `submodule.fg_ker_ring_hom_comp` to `ideal.fg_ker_comp` to match `submodule.fg_ker_comp`

and defines a new `ideal.fg` alias to avoid unfolding to `submodule R R` and `submodule.span`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
