### PR TITLE
[Merged by Bors] - feat(data/finsupp/basic): Add `finsupp.erase_of_not_mem_support`

### DIFF
--- a/src/data/finsupp/basic.lean
+++ b/src/data/finsupp/basic.lean
@@ -680,6 +680,13 @@ begin
   { rw [erase_ne hs] }
 end
 
+@[simp] lemma erase_of_not_mem_support {f : α →₀ M} {a} (haf : a ∉ f.support) : erase a f = f :=
+begin
+  ext b, by_cases hab : a = b,
+  { rwa [←hab, erase_same, eq_comm, ←not_mem_support_iff] },
+  { rw erase_ne (ne.symm hab) }
+end
+
 @[simp] lemma erase_zero (a : α) : erase a (0 : α →₀ M) = 0 :=
 by rw [← support_eq_empty, support_erase, support_zero, erase_empty]
 

--- a/src/data/finsupp/basic.lean
+++ b/src/data/finsupp/basic.lean
@@ -682,9 +682,9 @@ end
 
 @[simp] lemma erase_of_not_mem_support {f : α →₀ M} {a} (haf : a ∉ f.support) : erase a f = f :=
 begin
-  ext b, by_cases hab : a = b,
-  { rwa [←hab, erase_same, eq_comm, ←not_mem_support_iff] },
-  { rw erase_ne (ne.symm hab) }
+  ext b, by_cases hab : b = a,
+  { rwa [hab, erase_same, eq_comm, ←not_mem_support_iff] },
+  { rw erase_ne hab }
 end
 
 @[simp] lemma erase_zero (a : α) : erase a (0 : α →₀ M) = 0 :=


### PR DESCRIPTION
Analogous to `list.erase_of_not_mem`


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
