### PR TITLE
[Merged by Bors] - feat(logic/function/basic): surjective function is an epimorphism

### DIFF
--- a/src/algebra/group/hom.lean
+++ b/src/algebra/group/hom.lean
@@ -467,23 +467,23 @@ lemma monoid_with_zero_hom.comp_assoc {Q : Type*}
 lemma one_hom.cancel_right [has_one M] [has_one N] [has_one P]
   {g₁ g₂ : one_hom N P} {f : one_hom M N} (hf : function.surjective f) :
   g₁.comp f = g₂.comp f ↔ g₁ = g₂ :=
-⟨λ h, one_hom.ext $ (forall_iff_forall_surj hf).1 (one_hom.ext_iff.1 h), λ h, h ▸ rfl⟩
+⟨λ h, one_hom.ext $ hf.forall.2 (one_hom.ext_iff.1 h), λ h, h ▸ rfl⟩
 @[to_additive]
 lemma mul_hom.cancel_right [has_mul M] [has_mul N] [has_mul P]
   {g₁ g₂ : mul_hom N P} {f : mul_hom M N} (hf : function.surjective f) :
   g₁.comp f = g₂.comp f ↔ g₁ = g₂ :=
-⟨λ h, mul_hom.ext $ (forall_iff_forall_surj hf).1 (mul_hom.ext_iff.1 h), λ h, h ▸ rfl⟩
+⟨λ h, mul_hom.ext $ hf.forall.2 (mul_hom.ext_iff.1 h), λ h, h ▸ rfl⟩
 @[to_additive]
 lemma monoid_hom.cancel_right
   [mul_one_class M] [mul_one_class N] [mul_one_class P]
   {g₁ g₂ : N →* P} {f : M →* N} (hf : function.surjective f) :
   g₁.comp f = g₂.comp f ↔ g₁ = g₂ :=
-⟨λ h, monoid_hom.ext $ (forall_iff_forall_surj hf).1 (monoid_hom.ext_iff.1 h), λ h, h ▸ rfl⟩
+⟨λ h, monoid_hom.ext $ hf.forall.2 (monoid_hom.ext_iff.1 h), λ h, h ▸ rfl⟩
 lemma monoid_with_zero_hom.cancel_right
   [mul_zero_one_class M] [mul_zero_one_class N] [mul_zero_one_class P]
   {g₁ g₂ : monoid_with_zero_hom N P} {f : monoid_with_zero_hom M N} (hf : function.surjective f) :
   g₁.comp f = g₂.comp f ↔ g₁ = g₂ :=
-⟨λ h, monoid_with_zero_hom.ext $ (forall_iff_forall_surj hf).1 (monoid_with_zero_hom.ext_iff.1 h),
+⟨λ h, monoid_with_zero_hom.ext $ hf.forall.2 (monoid_with_zero_hom.ext_iff.1 h),
  λ h, h ▸ rfl⟩
 
 @[to_additive]

--- a/src/algebra/ring/basic.lean
+++ b/src/algebra/ring/basic.lean
@@ -526,7 +526,7 @@ include rβ rγ
 
 lemma cancel_right {g₁ g₂ : β →+* γ} {f : α →+* β} (hf : surjective f) :
   g₁.comp f = g₂.comp f ↔ g₁ = g₂ :=
-⟨λ h, ring_hom.ext $ (forall_iff_forall_surj hf).1 (ext_iff.1 h), λ h, h ▸ rfl⟩
+⟨λ h, ring_hom.ext $ hf.forall.2 (ext_iff.1 h), λ h, h ▸ rfl⟩
 
 lemma cancel_left {g : β →+* γ} {f₁ f₂ : α →+* β} (hg : injective g) :
   g.comp f₁ = g.comp f₂ ↔ f₁ = f₂ :=

--- a/src/category_theory/types.lean
+++ b/src/category_theory/types.lean
@@ -170,10 +170,7 @@ begin
     resetI,
     rw ←hom_of_element_eq_iff at ⊢ h,
     exact (cancel_mono f).mp h },
-  { refine λ H, ⟨λ Z g h H₂, _⟩,
-    ext z,
-    replace H₂ := congr_fun H₂ z,
-    exact H H₂ }
+  { exact λ H, ⟨λ Z, H.comp_left⟩ }
 end
 
 /--
@@ -184,28 +181,13 @@ See https://stacks.math.columbia.edu/tag/003C.
 lemma epi_iff_surjective {X Y : Type u} (f : X ⟶ Y) : epi f ↔ function.surjective f :=
 begin
   split,
-  { intros H,
-    let g : Y ⟶ ulift Prop := λ y, ⟨true⟩,
-    let h : Y ⟶ ulift Prop := λ y, ⟨∃ x, f x = y⟩,
-    suffices : f ≫ g = f ≫ h,
-    { resetI,
-      rw cancel_epi at this,
-      intro y,
-      replace this := congr_fun this y,
-      replace this : true = ∃ x, f x = y := congr_arg ulift.down this,
-      rw ←this,
-      trivial },
-    ext x,
-    change true ↔ ∃ x', f x' = f x,
-    rw true_iff,
-    exact ⟨x, rfl⟩ },
-  { intro H,
-    constructor,
-    intros Z g h H₂,
-    apply funext,
-    rw ←forall_iff_forall_surj H,
-    intro x,
-    exact (congr_fun H₂ x : _) }
+  { rintros ⟨H⟩,
+    refine function.surjective_of_right_cancellable_Prop (λ g₁ g₂ hg, _),
+    rw [← equiv.ulift.symm.injective.comp_left.eq_iff],
+    apply H,
+    change ulift.up ∘ (g₁ ∘ f) = ulift.up ∘ (g₂ ∘ f),
+    rw hg },
+  { exact λ H, ⟨λ Z, H.injective_comp_right⟩ }
 end
 
 section

--- a/src/logic/basic.lean
+++ b/src/logic/basic.lean
@@ -1056,13 +1056,6 @@ by simp [or_comm, decidable.forall_or_distrib_left]
 theorem forall_or_distrib_right {q : Prop} {p : α → Prop} :
   (∀x, p x ∨ q) ↔ (∀x, p x) ∨ q := decidable.forall_or_distrib_right
 
-/-- A predicate holds everywhere on the image of a surjective functions iff
-    it holds everywhere. -/
-theorem forall_iff_forall_surj
-  {α β : Type*} {f : α → β} (h : function.surjective f) {P : β → Prop} :
-  (∀ a, P (f a)) ↔ ∀ b, P b :=
-⟨λ ha b, by cases h b with a hab; rw ←hab; exact ha a, λ hb a, hb $ f a⟩
-
 @[simp] theorem exists_prop {p q : Prop} : (∃ h : p, q) ↔ p ∧ q :=
 ⟨λ ⟨h₁, h₂⟩, ⟨h₁, h₂⟩, λ ⟨h₁, h₂⟩, ⟨h₁, h₂⟩⟩
 

--- a/src/logic/function/basic.lean
+++ b/src/logic/function/basic.lean
@@ -122,7 +122,7 @@ lemma surjective.of_comp_iff (f : α → β) {g : γ → α} (hg : surjective g)
   surjective (f ∘ g) ↔ surjective f :=
 ⟨surjective.of_comp, λ h, h.comp hg⟩
 
-lemma surjective.of_comp_iff' {f : α → β} (hf : bijective f) (g : γ → α) :
+lemma surjective.of_comp_iff' (hf : bijective f) (g : γ → α) :
   surjective (f ∘ g) ↔ surjective g :=
 ⟨λ h x, let ⟨x', hx'⟩ := h (f x) in ⟨x', hf.injective hx'⟩, hf.surjective.comp⟩
 
@@ -130,29 +130,47 @@ instance decidable_eq_pfun (p : Prop) [decidable p] (α : p → Type*)
   [Π hp, decidable_eq (α hp)] : decidable_eq (Π hp, α hp)
 | f g := decidable_of_iff (∀ hp, f hp = g hp) funext_iff.symm
 
-protected theorem surjective.forall {f : α → β} (hf : surjective f) {p : β → Prop} :
+protected theorem surjective.forall (hf : surjective f) {p : β → Prop} :
   (∀ y, p y) ↔ ∀ x, p (f x) :=
 ⟨λ h x, h (f x), λ h y, let ⟨x, hx⟩ := hf y in hx ▸ h x⟩
 
-protected theorem surjective.forall₂ {f : α → β} (hf : surjective f) {p : β → β → Prop} :
+protected theorem surjective.forall₂ (hf : surjective f) {p : β → β → Prop} :
   (∀ y₁ y₂, p y₁ y₂) ↔ ∀ x₁ x₂, p (f x₁) (f x₂) :=
 hf.forall.trans $ forall_congr $ λ x, hf.forall
 
-protected theorem surjective.forall₃ {f : α → β} (hf : surjective f) {p : β → β → β → Prop} :
+protected theorem surjective.forall₃ (hf : surjective f) {p : β → β → β → Prop} :
   (∀ y₁ y₂ y₃, p y₁ y₂ y₃) ↔ ∀ x₁ x₂ x₃, p (f x₁) (f x₂) (f x₃) :=
 hf.forall.trans $ forall_congr $ λ x, hf.forall₂
 
-protected theorem surjective.exists {f : α → β} (hf : surjective f) {p : β → Prop} :
+protected theorem surjective.exists (hf : surjective f) {p : β → Prop} :
   (∃ y, p y) ↔ ∃ x, p (f x) :=
 ⟨λ ⟨y, hy⟩, let ⟨x, hx⟩ := hf y in ⟨x, hx.symm ▸ hy⟩, λ ⟨x, hx⟩, ⟨f x, hx⟩⟩
 
-protected theorem surjective.exists₂ {f : α → β} (hf : surjective f) {p : β → β → Prop} :
+protected theorem surjective.exists₂ (hf : surjective f) {p : β → β → Prop} :
   (∃ y₁ y₂, p y₁ y₂) ↔ ∃ x₁ x₂, p (f x₁) (f x₂) :=
 hf.exists.trans $ exists_congr $ λ x, hf.exists
 
-protected theorem surjective.exists₃ {f : α → β} (hf : surjective f) {p : β → β → β → Prop} :
+protected theorem surjective.exists₃ (hf : surjective f) {p : β → β → β → Prop} :
   (∃ y₁ y₂ y₃, p y₁ y₂ y₃) ↔ ∃ x₁ x₂ x₃, p (f x₁) (f x₂) (f x₃) :=
 hf.exists.trans $ exists_congr $ λ x, hf.exists₂
+
+lemma surjective.injective_comp_right (hf : surjective f) :
+  injective (λ g : β → γ, g ∘ f) :=
+λ g₁ g₂ h, funext $ hf.forall.2 $ congr_fun h
+
+protected lemma surjective.right_cancellable (hf : surjective f) {g₁ g₂ : β → γ} :
+  g₁ ∘ f = g₂ ∘ f ↔ g₁ = g₂ :=
+hf.injective_comp_right.eq_iff
+
+lemma surjective_of_right_cancellable_Prop (h : ∀ g₁ g₂ : β → Prop, g₁ ∘ f = g₂ ∘ f → g₁ = g₂) :
+  surjective f :=
+begin
+  specialize h (λ _, true) (λ y, ∃ x, f x = y) (funext $ λ x, _),
+  { simp only [(∘), exists_apply_eq_apply] },
+  { intro y,
+    have : true = ∃ x, f x = y, from congr_fun h y,
+    rw ← this, exact trivial }
+end
 
 lemma bijective_iff_exists_unique (f : α → β) : bijective f ↔
   ∀ b : β, ∃! (a : α), f a = b :=

--- a/src/logic/function/basic.lean
+++ b/src/logic/function/basic.lean
@@ -400,13 +400,13 @@ lemma surjective_to_subsingleton [na : nonempty α] [subsingleton β] (f : α �
 λ y, let ⟨a⟩ := na in ⟨a, subsingleton.elim _ _⟩
 
 /-- Composition by an surjective function on the left is itself surjective. -/
-lemma surjective.comp_left {g : β → γ} (hg : function.surjective g) :
-  function.surjective ((∘) g : (α → β) → (α → γ)) :=
+lemma surjective.comp_left {g : β → γ} (hg : surjective g) :
+  surjective ((∘) g : (α → β) → (α → γ)) :=
 λ f, ⟨surj_inv hg ∘ f, funext $ λ x, right_inverse_surj_inv _ _⟩
 
 /-- Composition by an bijective function on the left is itself bijective. -/
-lemma bijective.comp_left {g : β → γ} (hg : function.bijective g) :
-  function.bijective ((∘) g : (α → β) → (α → γ)) :=
+lemma bijective.comp_left {g : β → γ} (hg : bijective g) :
+  bijective ((∘) g : (α → β) → (α → γ)) :=
 ⟨hg.injective.comp_left, hg.surjective.comp_left⟩
 
 end surj_inv
@@ -565,6 +565,20 @@ end
 @[simp] lemma extend_comp (hf : injective f) (g : α → γ) (e' : β → γ) :
   extend f g e' ∘ f = g :=
 funext $ λ a, extend_apply hf g e' a
+
+lemma injective.surjective_comp_right' (hf : injective f) (g₀ : β → γ) :
+  surjective (λ g : β → γ, g ∘ f) :=
+λ g, ⟨extend f g g₀, extend_comp hf _ _⟩
+
+lemma injective.surjective_comp_right [nonempty γ] (hf : injective f) :
+  surjective (λ g : β → γ, g ∘ f) :=
+hf.surjective_comp_right' (λ _, classical.choice ‹_›)
+
+lemma bijective.comp_right (hf : bijective f) :
+  bijective (λ g : β → γ, g ∘ f) :=
+⟨hf.surjective.injective_comp_right,
+  λ g, ⟨g ∘ surj_inv hf.surjective,
+    by simp only [comp.assoc g _ f, (left_inverse_surj_inv hf).comp_eq_id, comp.right_id]⟩⟩
 
 end extend
 


### PR DESCRIPTION
* Move proofs about `surjective`/`injective` and `epi`/`mono` to `logic.function.basic` (formulated in terms of injectivity of composition), make them universe polymorphic.
* drop `forall_iff_forall_surj`, use `function.surjective.forall` instead.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
