### PR TITLE
[Merged by Bors] - feat(data/polynomial/degree/definitions): add pow lemmas

### DIFF
--- a/src/data/polynomial/degree/definitions.lean
+++ b/src/data/polynomial/degree/definitions.lean
@@ -750,20 +750,20 @@ end
 begin
   induction n with i hi,
   { simp },
-  { by_cases hp1 : p.leading_coeff ^ i = 0; repeat { rw pow_succ' },
-    { by_cases hp2 : p ^ i = 0; rw [hp1, zero_mul],
+  { rw [pow_succ', pow_succ', nat.succ_mul],
+    by_cases hp1 : p.leading_coeff ^ i = 0,
+    { rw [hp1, zero_mul],
+      by_cases hp2 : p ^ i = 0,
       { rw [hp2, zero_mul, coeff_zero] },
-      { have h1 : (p ^ i).nat_degree < i * p.nat_degree,
+      { apply coeff_eq_zero_of_nat_degree_lt,
+        have h1 : (p ^ i).nat_degree < i * p.nat_degree,
         { by_contra h,
           replace h := eq_iff_le_not_lt.mpr ⟨nat_degree_pow_le, h⟩,
           rw [←h, hp1] at hi,
           exact (leading_coeff_ne_zero.mpr hp2) hi },
-        have h2 : (p ^ i * p).nat_degree < i.succ * p.nat_degree,
-        by calc (p ^ i * p).nat_degree ≤ (p ^ i).nat_degree + p.nat_degree : nat_degree_mul_le
-                                   ... < i * p.nat_degree + p.nat_degree : nat.add_lt_add_right h1 _
-                                   ... = i.succ * p.nat_degree : by rw ←nat.succ_mul,
-        rw coeff_eq_zero_of_nat_degree_lt h2 } },
-    { rw [nat.succ_mul, ←nat_degree_pow' hp1, ←leading_coeff_pow' hp1],
+        calc (p ^ i * p).nat_degree ≤ (p ^ i).nat_degree + p.nat_degree : nat_degree_mul_le
+                                ... < i * p.nat_degree + p.nat_degree : add_lt_add_right h1 _ } },
+    { rw [←nat_degree_pow' hp1, ←leading_coeff_pow' hp1],
       exact coeff_mul_degree_add_degree _ _ } }
 end
 

--- a/src/data/polynomial/degree/definitions.lean
+++ b/src/data/polynomial/degree/definitions.lean
@@ -745,7 +745,7 @@ begin
     exact add_le_add_left hi _ }
 end
 
-@[simp] lemma coeff_pow_degree_mul_degree (p : polynomial R) (n : ℕ) :
+@[simp] lemma coeff_pow_mul_nat_degree (p : polynomial R) (n : ℕ) :
   (p ^ n).coeff (n * p.nat_degree) = p.leading_coeff ^ n :=
 begin
   induction n with i hi,

--- a/src/data/polynomial/degree/definitions.lean
+++ b/src/data/polynomial/degree/definitions.lean
@@ -736,6 +736,37 @@ begin
   refine add_le_add _ _; apply degree_le_nat_degree,
 end
 
+lemma nat_degree_pow_le {p : polynomial R} {n : ℕ} : (p ^ n).nat_degree ≤ n * p.nat_degree :=
+begin
+  induction n with i hi,
+  { simp },
+  { rw [pow_succ, nat.succ_mul, add_comm],
+    apply le_trans nat_degree_mul_le,
+    exact add_le_add_left hi _ }
+end
+
+@[simp] lemma coeff_pow_degree_mul_degree (p : polynomial R) (n : ℕ) :
+  (p ^ n).coeff (n * p.nat_degree) = p.leading_coeff ^ n :=
+begin
+  induction n with i hi,
+  { simp },
+  { by_cases hp1 : p.leading_coeff ^ i = 0; repeat { rw pow_succ' },
+    { by_cases hp2 : p ^ i = 0; rw [hp1, zero_mul],
+      { rw [hp2, zero_mul, coeff_zero] },
+      { have h1 : (p ^ i).nat_degree < i * p.nat_degree,
+        { by_contra h,
+          replace h := eq_iff_le_not_lt.mpr ⟨nat_degree_pow_le, h⟩,
+          rw [←h, hp1] at hi,
+          exact (leading_coeff_ne_zero.mpr hp2) hi },
+        have h2 : (p ^ i * p).nat_degree < i.succ * p.nat_degree,
+        by calc (p ^ i * p).nat_degree ≤ (p ^ i).nat_degree + p.nat_degree : nat_degree_mul_le
+                                   ... < i * p.nat_degree + p.nat_degree : nat.add_lt_add_right h1 _
+                                   ... = i.succ * p.nat_degree : by rw ←nat.succ_mul,
+        rw coeff_eq_zero_of_nat_degree_lt h2 } },
+    { rw [nat.succ_mul, ←nat_degree_pow' hp1, ←leading_coeff_pow' hp1],
+      exact coeff_mul_degree_add_degree _ _ } }
+end
+
 lemma subsingleton_of_monic_zero (h : monic (0 : polynomial R)) :
   (∀ p q : polynomial R, p = q) ∧ (∀ a b : R, a = b) :=
 by rw [monic.def, leading_coeff_zero] at h;

--- a/src/data/polynomial/degree/definitions.lean
+++ b/src/data/polynomial/degree/definitions.lean
@@ -757,10 +757,9 @@ begin
       { rw [hp2, zero_mul, coeff_zero] },
       { apply coeff_eq_zero_of_nat_degree_lt,
         have h1 : (p ^ i).nat_degree < i * p.nat_degree,
-        { by_contra h,
-          replace h := eq_iff_le_not_lt.mpr ⟨nat_degree_pow_le, h⟩,
+        { apply lt_of_le_of_ne nat_degree_pow_le (λ h, hp2 _),
           rw [←h, hp1] at hi,
-          exact (leading_coeff_ne_zero.mpr hp2) hi },
+          exact leading_coeff_eq_zero.mp hi },
         calc (p ^ i * p).nat_degree ≤ (p ^ i).nat_degree + p.nat_degree : nat_degree_mul_le
                                 ... < i * p.nat_degree + p.nat_degree : add_lt_add_right h1 _ } },
     { rw [←nat_degree_pow' hp1, ←leading_coeff_pow' hp1],


### PR DESCRIPTION
Add lemmas `nat_degree_pow_le` and `coeff_pow_degree_mul_degree`

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
Some discussion on this PR [here](https://leanprover.zulipchat.com/#narrow/stream/113489-new-members/topic/contribution.3A.20induction.20on.20polynomial.20degree). I chose to use induction for `nat_degree_pow_le` because it is simpler.
[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
