### PR TITLE
[Merged by Bors] - docs(topology/homotopy): add namespace in docstring to fix links

### DIFF
--- a/src/topology/homotopy/basic.lean
+++ b/src/topology/homotopy/basic.lean
@@ -12,35 +12,41 @@ import topology.compact_open
 /-!
 # Homotopy between functions
 
-In this file, we define a homotopy between two functions `f₀` and `f₁`. First we define `homotopy`
-between the two functions, with no restrictions on the intermediate maps. Then, as in the
-formalisation in HOL-Analysis, we define `homotopy_with f₀ f₁ P`, for homotopies between `f₀` and
-`f₁`, where the intermediate maps satisfy the predicate `P`. Finally, we define
-`homotopy_rel f₀ f₁ S`, for homotopies between `f₀` and `f₁` which are fixed on `S`.
+In this file, we define a homotopy between two functions `f₀` and `f₁`. First we define 
+`continuous_map.homotopy` between the two functions, with no restrictions on the intermediate 
+maps. Then, as in the formalisation in HOL-Analysis, we define 
+`continuous_map.homotopy_with f₀ f₁ P`, for homotopies between `f₀` and `f₁`, where the 
+intermediate maps satisfy the predicate `P`. Finally, we define 
+`continuous_map.homotopy_rel f₀ f₁ S`, for homotopies between `f₀` and `f₁` which are fixed 
+on `S`.
 
 ## Definitions
 
-* `homotopy f₀ f₁` is the type of homotopies between `f₀` and `f₁`.
-* `homotopy_with f₀ f₁ P` is the type of homotopies between `f₀` and `f₁`, where the intermediate
-  maps satisfy the predicate `P`.
-* `homotopy_rel f₀ f₁ S` is the type of homotopies between `f₀` and `f₁` which are fixed on `S`.
+* `continuous_map.homotopy f₀ f₁` is the type of homotopies between `f₀` and `f₁`.
+* `continuous_map.homotopy_with f₀ f₁ P` is the type of homotopies between `f₀` and `f₁`, where
+  the intermediate maps satisfy the predicate `P`.
+* `continuous_map.homotopy_rel f₀ f₁ S` is the type of homotopies between `f₀` and `f₁` which 
+  are fixed on `S`.
 
 For each of the above, we have
 
 * `refl f`, which is the constant homotopy from `f` to `f`.
-* `symm F`, which reverses the homotopy `F`. For example, if `F : homotopy f₀ f₁`, then
-  `F.symm : homotopy f₁ f₀`.
-* `trans F G`, which concatenates the homotopies `F` and `G`. For example, if `F : homotopy f₀ f₁`
-  and `G : homotopy f₁ f₂`, then `F.trans G : homotopy f₀ f₂`.
+* `symm F`, which reverses the homotopy `F`. For example, if `F : continuous_map.homotopy f₀ f₁`,
+  then `F.symm : continuous_map.homotopy f₁ f₀`.
+* `trans F G`, which concatenates the homotopies `F` and `G`. For example, if 
+  `F : continuous_map.homotopy f₀ f₁` and `G : continuous_map.homotopy f₁ f₂`, then 
+  `F.trans G : continuous_map.homotopy f₀ f₂`.
 
 We also define the relations
 
-* `homotopic f₀ f₁` is defined to be `nonempty (homotopy f₀ f₁)`
-* `homotopic_with f₀ f₁ P` is defined to be `nonempty (homotopy_with f₀ f₁ P)`
-* `homotopic_rel f₀ f₁ P` is defined to be `nonempty (homotopy_rel f₀ f₁ P)`
+* `continuous_map.homotopic f₀ f₁` is defined to be `nonempty (continuous_map.homotopy f₀ f₁)`
+* `continuous_map.homotopic_with f₀ f₁ P` is defined to be 
+  `nonempty (continuous_map.homotopy_with f₀ f₁ P)`
+* `continuous_map.homotopic_rel f₀ f₁ P` is defined to be 
+  `nonempty (continuous_map.homotopy_rel f₀ f₁ P)`
 
-and for `homotopic` and `homotopic_rel`, we also define the `setoid` and `quotient` in `C(X, Y)` by
-these relations.
+and for `continuous_map.homotopic` and `continuous_map.homotopic_rel`, we also define the 
+`setoid` and `quotient` in `C(X, Y)` by these relations.
 
 ## References
 


### PR DESCRIPTION
Currently all the occurences of `homotopy` in the docs link to `algebra/homology/homotopy`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
