### PR TITLE
feat(logic/indexed_eq): Indexed equality

### DIFF
--- a/src/logic/indexed_eq.lean
+++ b/src/logic/indexed_eq.lean
@@ -1,0 +1,74 @@
+/-
+Copyright (c) 2021 Eric Wieser. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Eric Wieser
+-/
+import logic.basic
+
+/-!
+# Indexed equality
+
+This file provides `indeq` with notation `a =ᵢ b`, which provide a different notion of heterogeneous
+equality to `heq` (`a == b`).
+
+In particular, `indeq` is for when `a : A i` and `b : A j`, where `A : ι → Sort u` is an indexed
+family of types. Instead of `type_eq_of_heq` which states `A i = A j` for `a == b`, this provides
+`indeq.index_eq` which states `i = j` for `a =ᵢ b`.begin
+
+Note that in the degerate case when `A = id`, this is equivalent to `heq`.
+-/
+
+universes ui ui' u u'
+
+section
+
+variables {ι : Sort ui} {ι' : Sort ui'} {A : ι → Sort u} {A' : ι' → Sort u'}
+
+/-- Indexed equality; `(ai : A i) =ᵢ (aj : A j)` if `i = j` -/
+inductive indeq {i : ι} (ai : A i) : Π {j} (aj : A j), Prop
+| refl [] : indeq ai
+
+infix ` =ᵢ `:50 := indeq
+
+attribute [refl] indeq.refl
+
+variables {i j k : ι} {a a' : A i} {b : A j} {c : A k}
+
+
+@[symm] lemma indeq.symm (h : a =ᵢ b) : b =ᵢ a :=
+indeq.rec_on h (indeq.refl a)
+
+@[trans] lemma indeq.trans (h₁ : a =ᵢ b) (h₂ : b =ᵢ c) : a =ᵢ c :=
+indeq.rec_on h₂ h₁
+
+lemma indeq_of_eq (h : a = a') : a =ᵢ a' :=
+eq.subst h (indeq.refl a)
+
+lemma indeq.index_eq (h : a =ᵢ b) : i = j :=
+indeq.rec_on h (eq.refl _)
+
+lemma indeq.heq (h : a =ᵢ b) : a == b :=
+indeq.rec_on h (heq.refl _)
+
+lemma indeq_of_eq_of_heq (hij : i = j) (hab : a == b) : a =ᵢ b :=
+by { cases hij, cases hab, refl }
+
+lemma indeq_iff : a =ᵢ b ↔ i = j ∧ a == b :=
+⟨λ h, ⟨h.index_eq, h.heq⟩, and.rec $ indeq_of_eq_of_heq⟩
+
+lemma indeq_id_iff_heq {α β} {a : α} {b : β} : @indeq (Sort u) id _ a _ b ↔ a == b :=
+by split; { intro h, cases h, refl }
+
+/-- In the degenerate case when `A = id`, then `indeq` is just `heq` -/
+@[simp] lemma indeq_id_eq_heq : @indeq (Sort u) id = @heq :=
+funext $ λ α, funext $ λ a, funext $ λ β, funext $ λ b, propext indeq_id_iff_heq
+
+lemma indeq_congr_arg {I : Π i, A i → ι'} (f : Π i (a : A i), A' (I i a)) (h : a =ᵢ b) :
+  f _ a =ᵢ f _ b :=
+indeq.rec_on h (indeq.refl _)
+
+lemma sigma_mk_eq_iff_indeq {ι : Type*} {A : ι → Type u} {i j} {a : A i} {b : A j} :
+  sigma.mk _ a = sigma.mk _ b ↔ a =ᵢ b :=
+(iff_of_eq (sigma.mk.inj_eq _ _ _ _)).trans indeq_iff.symm
+
+end

--- a/src/logic/indexed_eq.lean
+++ b/src/logic/indexed_eq.lean
@@ -13,9 +13,9 @@ equality to `heq` (`a == b`).
 
 In particular, `indeq` is for when `a : A i` and `b : A j`, where `A : ι → Sort u` is an indexed
 family of types. Instead of `type_eq_of_heq` which states `A i = A j` for `a == b`, this provides
-`indeq.index_eq` which states `i = j` for `a =ᵢ b`.begin
+`indeq.index_eq` which states `i = j` for `a =ᵢ b`.
 
-Note that in the degerate case when `A = id`, this is equivalent to `heq`.
+Note that in the degenerate case when `A = id`, this is equivalent to `heq`.
 -/
 
 universes ui ui' u u'
@@ -33,21 +33,19 @@ infix ` =ᵢ `:50 := indeq
 attribute [refl] indeq.refl
 
 variables {i j k : ι} {a a' : A i} {b : A j} {c : A k}
-
-
 @[symm] lemma indeq.symm (h : a =ᵢ b) : b =ᵢ a :=
 indeq.rec_on h (indeq.refl a)
 
 @[trans] lemma indeq.trans (h₁ : a =ᵢ b) (h₂ : b =ᵢ c) : a =ᵢ c :=
 indeq.rec_on h₂ h₁
 
-lemma indeq_of_eq (h : a = a') : a =ᵢ a' :=
+protected lemma eq.indeq (h : a = a') : a =ᵢ a' :=
 eq.subst h (indeq.refl a)
 
 lemma indeq.index_eq (h : a =ᵢ b) : i = j :=
 indeq.rec_on h (eq.refl _)
 
-lemma indeq.heq (h : a =ᵢ b) : a == b :=
+protected lemma indeq.heq (h : a =ᵢ b) : a == b :=
 indeq.rec_on h (heq.refl _)
 
 lemma indeq_of_eq_of_heq (hij : i = j) (hab : a == b) : a =ᵢ b :=


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[Zulip thread](https://leanprover.zulipchat.com/#narrow/stream/217875-Is-there.20code.20for.20X.3F/topic/Indexed.20equality/near/264481679).

I wonder if this would be more useful for working with graded monoid / rings than using sigma equality.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
