### PR TITLE
[Merged by Bors] - feat(algebra/{group,ring}/opposite): `{ring,monoid}_hom.from_opposite`

### DIFF
--- a/src/algebra/group/opposite.lean
+++ b/src/algebra/group/opposite.lean
@@ -192,6 +192,15 @@ def monoid_hom.to_opposite {R S : Type*} [mul_one_class R] [mul_one_class S] (f 
   map_one' := congr_arg op f.map_one,
   map_mul' := λ x y, by simp [(hf x y).eq] }
 
+/-- A monoid homomorphism `f : R →* S` such that `f x` commutes with `f y` for all `x, y` defines
+a monoid homomorphism from `Rᵐᵒᵖ`. -/
+@[simps {fully_applied := ff}]
+def monoid_hom.from_opposite {R S : Type*} [mul_one_class R] [mul_one_class S] (f : R →* S)
+  (hf : ∀ x y, commute (f x) (f y)) : Rᵐᵒᵖ →* S :=
+{ to_fun := f ∘ mul_opposite.unop,
+  map_one' := f.map_one,
+  map_mul' := λ x y, (f.map_mul _ _).trans (hf _ _).eq }
+
 /-- The units of the opposites are equivalent to the opposites of the units. -/
 def units.op_equiv {R} [monoid R] : units Rᵐᵒᵖ ≃* (units R)ᵐᵒᵖ :=
 { to_fun := λ u, op ⟨unop u, unop ↑(u⁻¹), op_injective u.4, op_injective u.3⟩,

--- a/src/algebra/ring/opposite.lean
+++ b/src/algebra/ring/opposite.lean
@@ -83,6 +83,15 @@ def ring_hom.to_opposite {R S : Type*} [semiring R] [semiring S] (f : R →+* S)
   .. ((op_add_equiv : S ≃+ Sᵐᵒᵖ).to_add_monoid_hom.comp ↑f : R →+ Sᵐᵒᵖ),
   .. f.to_monoid_hom.to_opposite hf }
 
+/-- A monoid homomorphism `f : R →* S` such that `f x` commutes with `f y` for all `x, y` defines
+a monoid homomorphism from `Rᵐᵒᵖ`. -/
+@[simps {fully_applied := ff}]
+def ring_hom.from_opposite {R S : Type*} [semiring R] [semiring S] (f : R →+* S)
+  (hf : ∀ x y, commute (f x) (f y)) : Rᵐᵒᵖ →+* S :=
+{ to_fun := f ∘ mul_opposite.unop,
+  .. (f.to_add_monoid_hom.comp (op_add_equiv : R ≃+ Rᵐᵒᵖ).symm.to_add_monoid_hom : Rᵐᵒᵖ →+ S),
+  .. f.to_monoid_hom.from_opposite hf }
+
 /-- A ring hom `α →+* β` can equivalently be viewed as a ring hom `αᵐᵒᵖ →+* βᵐᵒᵖ`. This is the
 action of the (fully faithful) `ᵐᵒᵖ`-functor on morphisms. -/
 @[simps]


### PR DESCRIPTION
We already have the `to_opposite` versions.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
