### PR TITLE
[Merged by Bors] - feat(order/well_founded) Added `strict_mono.id_le_of_wo`

### DIFF
--- a/src/order/well_founded.lean
+++ b/src/order/well_founded.lean
@@ -158,9 +158,8 @@ not_lt.mp $ not_lt_argmin f h a
   (hs : s.nonempty := set.nonempty_of_mem ha) : f (argmin_on f h s hs) ≤ f a :=
 not_lt.mp $ not_lt_argmin_on f h s ha hs
 
-theorem strict_mono.self_le_of_well_founded {φ : β → β} (hφ : strict_mono φ)
-(h : well_founded ((<) : β → β → Prop)) :
-  ∀ n, n ≤ φ n :=
+include h
+theorem strict_mono.self_le_of_well_founded {φ : β → β} (hφ : strict_mono φ) : ∀ n, n ≤ φ n :=
 begin
   by_contra h',
   push_neg at h',

--- a/src/order/well_founded.lean
+++ b/src/order/well_founded.lean
@@ -168,5 +168,5 @@ theorem strict_mono.id_le_of_wo {α : Type*} [linear_order α] {φ : α → α}
 begin
   by_contra h',
   push_neg at h',
-  exact (H.not_lt_min _ h' (@h _ (H.min _ h') (H.min_mem _ h'))) (le_of_lt (H.min_mem _ h')),
+  exact (H.not_lt_min _ h' (@h _ (H.min _ h') (H.min_mem _ h'))) (le_of_lt (H.min_mem _ h'))
 end

--- a/src/order/well_founded.lean
+++ b/src/order/well_founded.lean
@@ -159,7 +159,7 @@ not_lt.mp $ not_lt_argmin f h a
 not_lt.mp $ not_lt_argmin_on f h s ha hs
 
 include h
-theorem strict_mono.self_le_of_well_founded {φ : β → β} (hφ : strict_mono φ) : ∀ n, n ≤ φ n :=
+theorem well_founded.self_le_of_strict_mono {φ : β → β} (hφ : strict_mono φ) : ∀ n, n ≤ φ n :=
 begin
   by_contra h',
   push_neg at h',

--- a/src/order/well_founded.lean
+++ b/src/order/well_founded.lean
@@ -162,8 +162,8 @@ end linear_order
 
 end function
 
-theorem strict_mono.id_le_of_wo {α : Type*} [linear_order α] {φ : α → α}
-(H : @well_founded α (<)) (h : strict_mono φ) :
+theorem strict_mono.id_le_of_wo {α : Type*} [linear_order α] {φ : α → α} (h : strict_mono φ)
+(H : @well_founded α (<)) :
   ∀ n, n ≤ φ n :=
 begin
   by_contra h',

--- a/src/order/well_founded.lean
+++ b/src/order/well_founded.lean
@@ -158,15 +158,15 @@ not_lt.mp $ not_lt_argmin f h a
   (hs : s.nonempty := set.nonempty_of_mem ha) : f (argmin_on f h s hs) ≤ f a :=
 not_lt.mp $ not_lt_argmin_on f h s ha hs
 
-end linear_order
-
-end function
-
-theorem strict_mono.id_le_of_wo {α : Type*} [linear_order α] {φ : α → α} (h : strict_mono φ)
-(H : @well_founded α (<)) :
+theorem strict_mono.self_le_of_well_founded {φ : β → β} (hφ : strict_mono φ)
+(h : well_founded ((<) : β → β → Prop)) :
   ∀ n, n ≤ φ n :=
 begin
   by_contra h',
   push_neg at h',
-  exact H.not_lt_min _ h' (@h _ (H.min _ h') (H.min_mem _ h')) (H.min_mem _ h')
+  exact h.not_lt_min _ h' (@hφ _ (h.min _ h') (h.min_mem _ h')) (h.min_mem _ h')
 end
+
+end linear_order
+
+end function

--- a/src/order/well_founded.lean
+++ b/src/order/well_founded.lean
@@ -163,10 +163,10 @@ end linear_order
 end function
 
 theorem strict_mono.id_le_of_wo {α : Type*} [linear_order α] {φ : α → α}
-(H : @well_founded α (≤)) (h : strict_mono φ) :
+(H : @well_founded α (<)) (h : strict_mono φ) :
   ∀ n, n ≤ φ n :=
 begin
   by_contra h',
   push_neg at h',
-  exact (H.not_lt_min _ h' (@h _ (H.min _ h') (H.min_mem _ h'))) (le_of_lt (H.min_mem _ h'))
+  exact H.not_lt_min _ h' (@h _ (H.min _ h') (H.min_mem _ h')) (H.min_mem _ h')
 end

--- a/src/order/well_founded.lean
+++ b/src/order/well_founded.lean
@@ -161,3 +161,12 @@ not_lt.mp $ not_lt_argmin_on f h s ha hs
 end linear_order
 
 end function
+
+theorem strict_mono.id_le_of_wo {α : Type*} [linear_order α] {φ : α → α}
+(H : @well_founded α (≤)) (h : strict_mono φ) :
+  ∀ n, n ≤ φ n :=
+begin
+  by_contra h',
+  push_neg at h',
+  exact (H.not_lt_min _ h' (@h _ (H.min _ h') (H.min_mem _ h'))) (le_of_lt (H.min_mem _ h')),
+end


### PR DESCRIPTION
This generalizes `strict_mono.id_le`.



---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
