### PR TITLE
[Merged by Bors] - feat(linear_algebra/orientation): inherit an action by `units R` on `module.ray R M`

### DIFF
--- a/src/linear_algebra/orientation.lean
+++ b/src/linear_algebra/orientation.lean
@@ -186,7 +186,7 @@ end action
 namespace module.ray
 
 /-- Scaling by a positive unit is a no-op. -/
-lemma unit_smul_of_pos [nontrivial R] (u : units R) (hu : 0 < (u : R)) (v : module.ray R M) :
+lemma units_smul_of_pos [nontrivial R] (u : units R) (hu : 0 < (u : R)) (v : module.ray R M) :
   u • v = v :=
 begin
   induction v using module.ray.ind,
@@ -298,7 +298,7 @@ begin
 end
 
 /-- Scaling by a negative unit is negation. -/
-lemma unit_smul_of_neg [nontrivial R] (u : units R) (hu : (u : R) < 0) (v : module.ray R M) :
+lemma units_smul_of_neg [nontrivial R] (u : units R) (hu : (u : R) < 0) (v : module.ray R M) :
   u • v = -v :=
 begin
   induction v using module.ray.ind,
@@ -334,9 +334,12 @@ begin
   exact same_ray_pos_smul_left _ hr,
 end
 
+section
+variables [no_zero_smul_divisors R M]
+
 /-- A nonzero vector is in the same ray as a multiple of itself if and only if that multiple
 is positive. -/
-@[simp] lemma same_ray_smul_right_iff [no_zero_smul_divisors R M] {v : M} (hv : v ≠ 0) (r : R) :
+@[simp] lemma same_ray_smul_right_iff {v : M} (hv : v ≠ 0) (r : R) :
   same_ray R v (r • v) ↔ 0 < r :=
 begin
   split,
@@ -352,7 +355,7 @@ end
 
 /-- A multiple of a nonzero vector is in the same ray as that vector if and only if that multiple
 is positive. -/
-@[simp] lemma same_ray_smul_left_iff [no_zero_smul_divisors R M] {v : M} (hv : v ≠ 0) (r : R) :
+@[simp] lemma same_ray_smul_left_iff {v : M} (hv : v ≠ 0) (r : R) :
   same_ray R (r • v) v ↔ 0 < r :=
 begin
   rw (symmetric_same_ray R M).iff,
@@ -361,8 +364,8 @@ end
 
 /-- The negation of a nonzero vector is in the same ray as a multiple of that vector if and
 only if that multiple is negative. -/
-@[simp] lemma same_ray_neg_smul_right_iff [no_zero_smul_divisors R M] {v : M} (hv : v ≠ 0)
-  (r : R) : same_ray R (-v) (r • v) ↔ r < 0 :=
+@[simp] lemma same_ray_neg_smul_right_iff {v : M} (hv : v ≠ 0) (r : R) :
+  same_ray R (-v) (r • v) ↔ r < 0 :=
 begin
   rw [←same_ray_neg_iff, neg_neg, ←neg_smul, same_ray_smul_right_iff hv (-r)],
   exact right.neg_pos_iff
@@ -370,11 +373,33 @@ end
 
 /-- A multiple of a nonzero vector is in the same ray as the negation of that vector if and
 only if that multiple is negative. -/
-@[simp] lemma same_ray_neg_smul_left_iff [no_zero_smul_divisors R M] {v : M} (hv : v ≠ 0)
-  (r : R) : same_ray R (r • v) (-v) ↔ r < 0 :=
+@[simp] lemma same_ray_neg_smul_left_iff {v : M} (hv : v ≠ 0) (r : R) :
+  same_ray R (r • v) (-v) ↔ r < 0 :=
 begin
   rw [←same_ray_neg_iff, neg_neg, ←neg_smul, same_ray_smul_left_iff hv (-r)],
   exact left.neg_pos_iff
+end
+
+/-- A nonzero vector is in the same ray as a multiple of itself if and only if that multiple
+is positive. -/
+@[simp] lemma units_smul_eq_self_iff {u : units R} {v : module.ray R M} :
+  u • v = v ↔ (0 : R) < u :=
+begin
+  induction v using module.ray.ind with v hv,
+  rw [smul_ray_of_ne_zero, ray_eq_iff, units.smul_def],
+  exact same_ray_smul_left_iff hv _,
+end
+
+/-- A nonzero vector is in the same ray as a multiple of itself if and only if that multiple
+is positive. -/
+@[simp] lemma units_smul_eq_neg_iff {u : units R} {v : module.ray R M} :
+  u • v = -v ↔ ↑u < (0 : R) :=
+begin
+  induction v using module.ray.ind with v hv,
+  rw [smul_ray_of_ne_zero, ←ray_neg, ray_eq_iff, units.smul_def],
+  exact same_ray_neg_smul_left_iff hv _,
+end
+
 end
 
 namespace basis

--- a/src/linear_algebra/orientation.lean
+++ b/src/linear_algebra/orientation.lean
@@ -181,17 +181,18 @@ instance : mul_action G (module.ray R M) :=
 @[simp] lemma smul_ray_of_ne_zero (g : G) (v : M) (hv) :
   g • ray_of_ne_zero R v hv = ray_of_ne_zero R (g • v) ((smul_ne_zero_iff_ne _).2 hv) := rfl
 
+end action
+
+namespace module.ray
+
 /-- Scaling by a positive unit is a no-op. -/
-lemma module.ray.smul_pos_unit (u : units R) (hu : 0 < (u : R)) (v : module.ray R M) : u • v = v :=
+lemma unit_smul_of_pos [nontrivial R] (u : units R) (hu : 0 < (u : R)) (v : module.ray R M) :
+  u • v = v :=
 begin
   induction v using module.ray.ind,
   rw [smul_ray_of_ne_zero, ray_eq_iff],
   exact same_ray_pos_smul_left _ hu,
 end
-
-end action
-
-namespace module.ray
 
 /-- An arbitrary `ray_vector` giving a ray. -/
 def some_ray_vector [nontrivial R] (x : module.ray R M) : ray_vector M :=

--- a/src/linear_algebra/orientation.lean
+++ b/src/linear_algebra/orientation.lean
@@ -174,10 +174,7 @@ end
 
 /-- An equivalence between modules implies an equivalence between ray vectors. -/
 def ray_vector.map_linear_equiv (e : M ≃ₗ[R] N) : ray_vector M ≃ ray_vector N :=
-{ to_fun := (subtype.map e $ λ a, e.map_ne_zero_iff.2),
-  inv_fun := (subtype.map e.symm $ λ a, e.symm.map_ne_zero_iff.2),
-  left_inv := λ ⟨m, hm⟩, subtype.ext $ e.symm_apply_apply m,
-  right_inv := λ ⟨m, hm⟩, subtype.ext $ e.apply_symm_apply m }
+equiv.subtype_equiv e.to_equiv $ λ _, e.map_ne_zero_iff.symm
 
 /-- An equivalence between modules implies an equivalence between rays. -/
 def module.ray.map [nontrivial R] (e : M ≃ₗ[R] N) : module.ray R M ≃ module.ray R N :=


### PR DESCRIPTION
This action is just the action inherited on the elements of the module under the quotient.
We provide it generally for any group `G` that satisfies the required properties, but are only really interested in `G = units R`.

This PR also provides `module.ray.map`, for sending a ray through a linear equivalence.

This generalization also provides us with `mul_action (M ≃ₗ[R] M) (module.ray R M)`, which might also turn out to be useful.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
