### PR TITLE
[Merged by Bors] - split(data/set/prod): split off `data.set.basic`

### DIFF
--- a/archive/imo/imo1972_b2.lean
+++ b/archive/imo/imo1972_b2.lean
@@ -5,7 +5,6 @@ Authors: Ruben Van de Velde, Stanislas Polu
 -/
 
 import data.real.basic
-import data.set.basic
 import analysis.normed_space.basic
 
 /-!

--- a/archive/imo/imo2008_q2.lean
+++ b/archive/imo/imo2008_q2.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Manuel Candales
 -/
 import data.real.basic
-import data.set.basic
 import data.set.finite
 
 /-!

--- a/src/algebra/ring/basic.lean
+++ b/src/algebra/ring/basic.lean
@@ -6,7 +6,6 @@ Neil Strickland
 -/
 import algebra.divisibility
 import algebra.regular.basic
-import data.set.basic
 
 /-!
 # Properties and homomorphisms of semirings and rings

--- a/src/data/part.lean
+++ b/src/data/part.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro, Jeremy Avigad, Simon Hudon
 -/
 import data.equiv.basic
+import data.set.basic
 
 /-!
 # Partial values of a type

--- a/src/data/part.lean
+++ b/src/data/part.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro, Jeremy Avigad, Simon Hudon
 -/
 import data.equiv.basic
-import data.set.basic
 
 /-!
 # Partial values of a type

--- a/src/data/set/basic.lean
+++ b/src/data/set/basic.lean
@@ -34,8 +34,6 @@ Notation used here:
 
 Definitions in the file:
 
-* `strict_subset s₁ s₂ : Prop` : the predicate `s₁ ⊆ s₂` but `s₁ ≠ s₂`.
-
 * `nonempty s : Prop` : the predicate `s ≠ ∅`. Note that this is the preferred way to express the
   fact that `s` has an element (see the Implementation Notes).
 
@@ -45,8 +43,6 @@ Definitions in the file:
 
 * `range f : set β` : the image of `univ` under `f`.
   Also works for `{p : Prop} (f : p → α)` (unlike `image`)
-
-* `s.prod t : set (α × β)` : the subset `s × t`.
 
 * `inclusion s₁ s₂ : ↥s₁ → ↥s₂` : the map `↥s₁ → ↥s₂` induced by an inclusion `s₁ ⊆ s₂`.
 
@@ -448,15 +444,6 @@ by simp [subset_def]
 
 lemma univ_unique [unique α] : @set.univ α = {default α} :=
 set.ext $ λ x, iff_of_true trivial $ subsingleton.elim x $ default α
-
-/-! ### Diagonal -/
-
-/-- `diagonal α` is the subset of `α × α` consisting of all pairs of the form `(a, a)`. -/
-def diagonal (α : Type*) : set (α × α) := {p | p.1 = p.2}
-
-@[simp]
-lemma mem_diagonal {α : Type*} (x : α) : (x, x) ∈ diagonal α :=
-by simp [diagonal]
 
 /-! ### Lemmas about union -/
 
@@ -1277,13 +1264,6 @@ theorem eq_preimage_subtype_val_iff {p : α → Prop} {s : set (subtype p)} {t :
 ⟨assume s_eq x h, by { rw [s_eq], simp },
  assume h, ext $ λ ⟨x, hx⟩, by simp [h]⟩
 
-lemma preimage_coe_coe_diagonal {α : Type*} (s : set α) :
-  (prod.map coe coe) ⁻¹' (diagonal α) = diagonal s :=
-begin
-  ext ⟨⟨x, x_in⟩, ⟨y, y_in⟩⟩,
-  simp [set.diagonal],
-end
-
 end preimage
 
 /-! ### Image of a set under a function -/
@@ -1825,8 +1805,8 @@ range_subset_iff.2 $ λ x, rfl
 | ⟨x⟩ c := subset.antisymm range_const_subset $
   assume y hy, (mem_singleton_iff.1 hy).symm ▸ mem_range_self x
 
-lemma diagonal_eq_range {α : Type*} : diagonal α = range (λ x, (x, x)) :=
-by { ext ⟨x, y⟩, simp [diagonal, eq_comm] }
+lemma image_swap_eq_preimage_swap : image (@prod.swap α β) = preimage prod.swap :=
+image_eq_preimage_of_inverse prod.swap_left_inverse prod.swap_right_inverse
 
 theorem preimage_singleton_nonempty {f : α → β} {y : β} :
   (f ⁻¹' {y}).nonempty ↔ y ∈ range f :=
@@ -2140,407 +2120,6 @@ end subtype
 
 namespace set
 
-/-! ### Lemmas about cartesian product of sets -/
-
-section prod
-
-variables {α : Type*} {β : Type*} {γ : Type*} {δ : Type*}
-variables {s s₁ s₂ : set α} {t t₁ t₂ : set β}
-
-/-- The cartesian product `prod s t` is the set of `(a, b)`
-  such that `a ∈ s` and `b ∈ t`. -/
-protected def prod (s : set α) (t : set β) : set (α × β) :=
-{p | p.1 ∈ s ∧ p.2 ∈ t}
-
-lemma prod_eq (s : set α) (t : set β) : s.prod t = prod.fst ⁻¹' s ∩ prod.snd ⁻¹' t := rfl
-
-theorem mem_prod_eq {p : α × β} : p ∈ s.prod t = (p.1 ∈ s ∧ p.2 ∈ t) := rfl
-
-@[simp] theorem mem_prod {p : α × β} : p ∈ s.prod t ↔ p.1 ∈ s ∧ p.2 ∈ t := iff.rfl
-
-@[simp] theorem prod_mk_mem_set_prod_eq {a : α} {b : β} :
-  (a, b) ∈ s.prod t = (a ∈ s ∧ b ∈ t) := rfl
-
-lemma mk_mem_prod {a : α} {b : β} (a_in : a ∈ s) (b_in : b ∈ t) : (a, b) ∈ s.prod t :=
-⟨a_in, b_in⟩
-
-theorem prod_mono {s₁ s₂ : set α} {t₁ t₂ : set β} (hs : s₁ ⊆ s₂) (ht : t₁ ⊆ t₂) :
-  s₁.prod t₁ ⊆ s₂.prod t₂ :=
-assume x ⟨h₁, h₂⟩, ⟨hs h₁, ht h₂⟩
-
-lemma prod_subset_iff {P : set (α × β)} :
-  (s.prod t ⊆ P) ↔ ∀ (x ∈ s) (y ∈ t), (x, y) ∈ P :=
-⟨λ h _ xin _ yin, h (mk_mem_prod xin yin), λ h ⟨_, _⟩ pin, h _ pin.1 _ pin.2⟩
-
-lemma forall_prod_set {p : α × β → Prop} :
-  (∀ x ∈ s.prod t, p x) ↔ ∀ (x ∈ s) (y ∈ t), p (x, y) :=
-prod_subset_iff
-
-lemma exists_prod_set {p : α × β → Prop} :
-  (∃ x ∈ s.prod t, p x) ↔ ∃ (x ∈ s) (y ∈ t), p (x, y) :=
-by simp [and_assoc]
-
-@[simp] theorem prod_empty : s.prod ∅ = (∅ : set (α × β)) :=
-by { ext, simp }
-
-@[simp] theorem empty_prod : set.prod ∅ t = (∅ : set (α × β)) :=
-by { ext, simp }
-
-@[simp] theorem univ_prod_univ : (@univ α).prod (@univ β) = univ :=
-by { ext ⟨x, y⟩, simp }
-
-lemma univ_prod {t : set β} : set.prod (univ : set α) t = prod.snd ⁻¹' t :=
-by simp [prod_eq]
-
-lemma prod_univ {s : set α} : set.prod s (univ : set β) = prod.fst ⁻¹' s :=
-by simp [prod_eq]
-
-@[simp] theorem singleton_prod {a : α} : set.prod {a} t = prod.mk a '' t :=
-by { ext ⟨x, y⟩, simp [and.left_comm, eq_comm] }
-
-@[simp] theorem prod_singleton {b : β} : s.prod {b} = (λ a, (a, b)) '' s :=
-by { ext ⟨x, y⟩, simp [and.left_comm, eq_comm] }
-
-theorem singleton_prod_singleton {a : α} {b : β} : set.prod {a} {b} = ({(a, b)} : set (α × β)) :=
-by simp
-
-@[simp] theorem union_prod : (s₁ ∪ s₂).prod t = s₁.prod t ∪ s₂.prod t :=
-by { ext ⟨x, y⟩, simp [or_and_distrib_right] }
-
-@[simp] theorem prod_union : s.prod (t₁ ∪ t₂) = s.prod t₁ ∪ s.prod t₂ :=
-by { ext ⟨x, y⟩, simp [and_or_distrib_left] }
-
-theorem prod_inter_prod : s₁.prod t₁ ∩ s₂.prod t₂ = (s₁ ∩ s₂).prod (t₁ ∩ t₂) :=
-by { ext ⟨x, y⟩, simp [and_assoc, and.left_comm] }
-
-theorem insert_prod {a : α} : (insert a s).prod t = (prod.mk a '' t) ∪ s.prod t :=
-by { ext ⟨x, y⟩, simp [image, iff_def, or_imp_distrib, imp.swap] {contextual := tt} }
-
-theorem prod_insert {b : β} : s.prod (insert b t) = ((λa, (a, b)) '' s) ∪ s.prod t :=
-by { ext ⟨x, y⟩, simp [image, iff_def, or_imp_distrib, imp.swap] {contextual := tt} }
-
-theorem prod_preimage_eq {f : γ → α} {g : δ → β} :
-  (f ⁻¹' s).prod (g ⁻¹' t) = (λ p, (f p.1, g p.2)) ⁻¹' s.prod t := rfl
-
-lemma prod_preimage_left {f : γ → α} : (f ⁻¹' s).prod t = (λp, (f p.1, p.2)) ⁻¹' (s.prod t) := rfl
-
-lemma prod_preimage_right {g : δ → β} : s.prod (g ⁻¹' t) = (λp, (p.1, g p.2)) ⁻¹' (s.prod t) := rfl
-
-lemma preimage_prod_map_prod (f : α → β) (g : γ → δ) (s : set β) (t : set δ) :
-  prod.map f g ⁻¹' (s.prod t) = (f ⁻¹' s).prod (g ⁻¹' t) :=
-rfl
-
-lemma mk_preimage_prod (f : γ → α) (g : γ → β) :
-  (λ x, (f x, g x)) ⁻¹' s.prod t = f ⁻¹' s ∩ g ⁻¹' t := rfl
-
-@[simp] lemma mk_preimage_prod_left {y : β} (h : y ∈ t) : (λ x, (x, y)) ⁻¹' s.prod t = s :=
-by { ext x, simp [h] }
-
-@[simp] lemma mk_preimage_prod_right {x : α} (h : x ∈ s) : prod.mk x ⁻¹' s.prod t = t :=
-by { ext y, simp [h] }
-
-@[simp] lemma mk_preimage_prod_left_eq_empty {y : β} (hy : y ∉ t) :
-  (λ x, (x, y)) ⁻¹' s.prod t = ∅ :=
-by { ext z, simp [hy] }
-
-@[simp] lemma mk_preimage_prod_right_eq_empty {x : α} (hx : x ∉ s) :
-  prod.mk x ⁻¹' s.prod t = ∅ :=
-by { ext z, simp [hx] }
-
-lemma mk_preimage_prod_left_eq_if {y : β} [decidable_pred (∈ t)] :
-  (λ x, (x, y)) ⁻¹' s.prod t = if y ∈ t then s else ∅ :=
-by { split_ifs; simp [h] }
-
-lemma mk_preimage_prod_right_eq_if {x : α} [decidable_pred (∈ s)] :
-  prod.mk x ⁻¹' s.prod t = if x ∈ s then t else ∅ :=
-by { split_ifs; simp [h] }
-
-lemma mk_preimage_prod_left_fn_eq_if {y : β} [decidable_pred (∈ t)] (f : γ → α) :
-  (λ x, (f x, y)) ⁻¹' s.prod t = if y ∈ t then f ⁻¹' s else ∅ :=
-by rw [← mk_preimage_prod_left_eq_if, prod_preimage_left, preimage_preimage]
-
-lemma mk_preimage_prod_right_fn_eq_if {x : α} [decidable_pred (∈ s)] (g : δ → β) :
-  (λ y, (x, g y)) ⁻¹' s.prod t = if x ∈ s then g ⁻¹' t else ∅ :=
-by rw [← mk_preimage_prod_right_eq_if, prod_preimage_right, preimage_preimage]
-
-theorem image_swap_eq_preimage_swap : image (@prod.swap α β) = preimage prod.swap :=
-image_eq_preimage_of_inverse prod.swap_left_inverse prod.swap_right_inverse
-
-theorem preimage_swap_prod {s : set α} {t : set β} : prod.swap ⁻¹' t.prod s = s.prod t :=
-by { ext ⟨x, y⟩, simp [and_comm] }
-
-theorem image_swap_prod : prod.swap '' t.prod s = s.prod t :=
-by rw [image_swap_eq_preimage_swap, preimage_swap_prod]
-
-theorem prod_image_image_eq {m₁ : α → γ} {m₂ : β → δ} :
-  (m₁ '' s).prod (m₂ '' t) = image (λp:α×β, (m₁ p.1, m₂ p.2)) (s.prod t) :=
-ext $ by simp [-exists_and_distrib_right, exists_and_distrib_right.symm, and.left_comm,
-  and.assoc, and.comm]
-
-theorem prod_range_range_eq {α β γ δ} {m₁ : α → γ} {m₂ : β → δ} :
-  (range m₁).prod (range m₂) = range (λp:α×β, (m₁ p.1, m₂ p.2)) :=
-ext $ by simp [range]
-
-@[simp] theorem range_prod_map {α β γ δ} {m₁ : α → γ} {m₂ : β → δ} :
-  range (prod.map m₁ m₂) = (range m₁).prod (range m₂) :=
-prod_range_range_eq.symm
-
-theorem prod_range_univ_eq {α β γ} {m₁ : α → γ} :
-  (range m₁).prod (univ : set β) = range (λp:α×β, (m₁ p.1, p.2)) :=
-ext $ by simp [range]
-
-theorem prod_univ_range_eq {α β δ} {m₂ : β → δ} :
-  (univ : set α).prod (range m₂) = range (λp:α×β, (p.1, m₂ p.2)) :=
-ext $ by simp [range]
-
-lemma range_pair_subset {α β γ : Type*} (f : α → β) (g : α → γ) :
-  range (λ x, (f x, g x)) ⊆ (range f).prod (range g) :=
-have (λ x, (f x, g x)) = prod.map f g ∘ (λ x, (x, x)), from funext (λ x, rfl),
-by { rw [this, ← range_prod_map], apply range_comp_subset_range }
-
-theorem nonempty.prod : s.nonempty → t.nonempty → (s.prod t).nonempty
-| ⟨x, hx⟩ ⟨y, hy⟩ := ⟨(x, y), ⟨hx, hy⟩⟩
-
-theorem nonempty.fst : (s.prod t).nonempty → s.nonempty
-| ⟨p, hp⟩ := ⟨p.1, hp.1⟩
-
-theorem nonempty.snd : (s.prod t).nonempty → t.nonempty
-| ⟨p, hp⟩ := ⟨p.2, hp.2⟩
-
-theorem prod_nonempty_iff : (s.prod t).nonempty ↔ s.nonempty ∧ t.nonempty :=
-⟨λ h, ⟨h.fst, h.snd⟩, λ h, nonempty.prod h.1 h.2⟩
-
-theorem prod_eq_empty_iff :
-  s.prod t = ∅ ↔ (s = ∅ ∨ t = ∅) :=
-by simp only [not_nonempty_iff_eq_empty.symm, prod_nonempty_iff, not_and_distrib]
-
-lemma prod_sub_preimage_iff {W : set γ} {f : α × β → γ} :
-  s.prod t ⊆ f ⁻¹' W ↔ ∀ a b, a ∈ s → b ∈ t → f (a, b) ∈ W :=
-by simp [subset_def]
-
-lemma fst_image_prod_subset (s : set α) (t : set β) :
-  prod.fst '' (s.prod t) ⊆ s :=
-λ _ h, let ⟨_, ⟨h₂, _⟩, h₁⟩ := (set.mem_image _ _ _).1 h in h₁ ▸ h₂
-
-lemma prod_subset_preimage_fst (s : set α) (t : set β) :
-  s.prod t ⊆ prod.fst ⁻¹' s :=
-image_subset_iff.1 (fst_image_prod_subset s t)
-
-lemma fst_image_prod (s : set β) {t : set α} (ht : t.nonempty) :
-  prod.fst '' (s.prod t) = s :=
-set.subset.antisymm (fst_image_prod_subset _ _)
-  $ λ y y_in, let ⟨x, x_in⟩ := ht in
-    ⟨(y, x), ⟨y_in, x_in⟩, rfl⟩
-
-lemma snd_image_prod_subset (s : set α) (t : set β) :
-  prod.snd '' (s.prod t) ⊆ t :=
-λ _ h, let ⟨_, ⟨_, h₂⟩, h₁⟩ := (set.mem_image _ _ _).1 h in h₁ ▸ h₂
-
-lemma prod_subset_preimage_snd (s : set α) (t : set β) :
-  s.prod t ⊆ prod.snd ⁻¹' t :=
-image_subset_iff.1 (snd_image_prod_subset s t)
-
-lemma snd_image_prod {s : set α} (hs : s.nonempty) (t : set β) :
-  prod.snd '' (s.prod t) = t :=
-set.subset.antisymm (snd_image_prod_subset _ _)
-  $ λ y y_in, let ⟨x, x_in⟩ := hs in
-    ⟨(x, y), ⟨x_in, y_in⟩, rfl⟩
-
-lemma prod_diff_prod : s.prod t \ s₁.prod t₁ = s.prod (t \ t₁) ∪ (s \ s₁).prod t :=
-by { ext x, by_cases h₁ : x.1 ∈ s₁; by_cases h₂ : x.2 ∈ t₁; simp * }
-
-/-- A product set is included in a product set if and only factors are included, or a factor of the
-first set is empty. -/
-lemma prod_subset_prod_iff :
-  (s.prod t ⊆ s₁.prod t₁) ↔ (s ⊆ s₁ ∧ t ⊆ t₁) ∨ (s = ∅) ∨ (t = ∅) :=
-begin
-  classical,
-  cases (s.prod t).eq_empty_or_nonempty with h h,
-  { simp [h, prod_eq_empty_iff.1 h] },
-  { have st : s.nonempty ∧ t.nonempty, by rwa [prod_nonempty_iff] at h,
-    split,
-    { assume H : s.prod t ⊆ s₁.prod t₁,
-      have h' : s₁.nonempty ∧ t₁.nonempty := prod_nonempty_iff.1 (h.mono H),
-      refine or.inl ⟨_, _⟩,
-      show s ⊆ s₁,
-      { have := image_subset (prod.fst : α × β → α) H,
-        rwa [fst_image_prod _ st.2, fst_image_prod _ h'.2] at this },
-      show t ⊆ t₁,
-      { have := image_subset (prod.snd : α × β → β) H,
-        rwa [snd_image_prod st.1, snd_image_prod h'.1] at this } },
-    { assume H,
-      simp only [st.1.ne_empty, st.2.ne_empty, or_false] at H,
-      exact prod_mono H.1 H.2 } }
-end
-
-end prod
-
-/-! ### Lemmas about set-indexed products of sets -/
-
-section pi
-variables {ι : Type*} {α : ι → Type*} {s s₁ : set ι} {t t₁ t₂ : Π i, set (α i)}
-
-/-- Given an index set `ι` and a family of sets `t : Π i, set (α i)`, `pi s t`
-is the set of dependent functions `f : Πa, π a` such that `f a` belongs to `t a`
-whenever `a ∈ s`. -/
-def pi (s : set ι) (t : Π i, set (α i)) : set (Π i, α i) := { f | ∀i ∈ s, f i ∈ t i }
-
-@[simp] lemma mem_pi {f : Π i, α i} : f ∈ s.pi t ↔ ∀ i ∈ s, f i ∈ t i :=
-by refl
-
-@[simp] lemma mem_univ_pi {f : Π i, α i} : f ∈ pi univ t ↔ ∀ i, f i ∈ t i :=
-by simp
-
-@[simp] lemma empty_pi (s : Π i, set (α i)) : pi ∅ s = univ := by { ext, simp [pi] }
-
-@[simp] lemma pi_univ (s : set ι) : pi s (λ i, (univ : set (α i))) = univ :=
-eq_univ_of_forall $ λ f i hi, mem_univ _
-
-lemma pi_mono (h : ∀ i ∈ s, t₁ i ⊆ t₂ i) : pi s t₁ ⊆ pi s t₂ :=
-λ x hx i hi, (h i hi $ hx i hi)
-
-lemma pi_inter_distrib : s.pi (λ i, t i ∩ t₁ i) = s.pi t ∩ s.pi t₁ :=
-ext $ λ x, by simp only [forall_and_distrib, mem_pi, mem_inter_eq]
-
-lemma pi_congr (h : s = s₁) (h' : ∀ i ∈ s, t i = t₁ i) : pi s t = pi s₁ t₁ :=
-h ▸ (ext $ λ x, forall_congr $ λ i, forall_congr $ λ hi, h' i hi ▸ iff.rfl)
-
-lemma pi_eq_empty {i : ι} (hs : i ∈ s) (ht : t i = ∅) : s.pi t = ∅ :=
-by { ext f, simp only [mem_empty_eq, not_forall, iff_false, mem_pi, not_imp],
-     exact ⟨i, hs, by simp [ht]⟩ }
-
-lemma univ_pi_eq_empty {i : ι} (ht : t i = ∅) : pi univ t = ∅ :=
-pi_eq_empty (mem_univ i) ht
-
-lemma pi_nonempty_iff : (s.pi t).nonempty ↔ ∀ i, ∃ x, i ∈ s → x ∈ t i :=
-by simp [classical.skolem, set.nonempty]
-
-lemma univ_pi_nonempty_iff : (pi univ t).nonempty ↔ ∀ i, (t i).nonempty :=
-by simp [classical.skolem, set.nonempty]
-
-lemma pi_eq_empty_iff : s.pi t = ∅ ↔ ∃ i, (α i → false) ∨ (i ∈ s ∧ t i = ∅) :=
-begin
-  rw [← not_nonempty_iff_eq_empty, pi_nonempty_iff], push_neg, apply exists_congr, intro i,
-  split,
-  { intro h, by_cases hα : nonempty (α i),
-    { cases hα with x, refine or.inr ⟨(h x).1, by simp [eq_empty_iff_forall_not_mem, h]⟩ },
-    { exact or.inl (λ x, hα ⟨x⟩) }},
-  { rintro (h|h) x, exfalso, exact h x, simp [h] }
-end
-
-lemma univ_pi_eq_empty_iff : pi univ t = ∅ ↔ ∃ i, t i = ∅ :=
-by simp [← not_nonempty_iff_eq_empty, univ_pi_nonempty_iff]
-
-@[simp] lemma univ_pi_empty [h : nonempty ι] : pi univ (λ i, ∅ : Π i, set (α i)) = ∅ :=
-univ_pi_eq_empty_iff.2 $ h.elim $ λ x, ⟨x, rfl⟩
-
-@[simp] lemma range_dcomp {β : ι → Type*} (f : Π i, α i → β i) :
-  range (λ (g : Π i, α i), (λ i, f i (g i))) = pi univ (λ i, range (f i)) :=
-begin
-  apply subset.antisymm,
-  { rintro _ ⟨x, rfl⟩ i -,
-    exact ⟨x i, rfl⟩ },
-  { intros x hx,
-    choose y hy using hx,
-    exact ⟨λ i, y i trivial, funext $ λ i, hy i trivial⟩ }
-end
-
-@[simp] lemma insert_pi (i : ι) (s : set ι) (t : Π i, set (α i)) :
-  pi (insert i s) t = (eval i ⁻¹' t i) ∩ pi s t :=
-by { ext, simp [pi, or_imp_distrib, forall_and_distrib] }
-
-@[simp] lemma singleton_pi (i : ι) (t : Π i, set (α i)) :
-  pi {i} t = (eval i ⁻¹' t i) :=
-by { ext, simp [pi] }
-
-lemma singleton_pi' (i : ι) (t : Π i, set (α i)) : pi {i} t = {x | x i ∈ t i} :=
-singleton_pi i t
-
-lemma pi_if {p : ι → Prop} [h : decidable_pred p] (s : set ι) (t₁ t₂ : Π i, set (α i)) :
-  pi s (λ i, if p i then t₁ i else t₂ i) = pi {i ∈ s | p i} t₁ ∩ pi {i ∈ s | ¬ p i} t₂ :=
-begin
-  ext f,
-  split,
-  { assume h, split; { rintros i ⟨his, hpi⟩, simpa [*] using h i } },
-  { rintros ⟨ht₁, ht₂⟩ i his,
-    by_cases p i; simp * at * }
-end
-
-lemma union_pi : (s ∪ s₁).pi t = s.pi t ∩ s₁.pi t :=
-by simp [pi, or_imp_distrib, forall_and_distrib, set_of_and]
-
-@[simp] lemma pi_inter_compl (s : set ι) : pi s t ∩ pi sᶜ t = pi univ t :=
-by rw [← union_pi, union_compl_self]
-
-lemma pi_update_of_not_mem [decidable_eq ι] {β : Π i, Type*} {i : ι} (hi : i ∉ s) (f : Π j, α j)
-  (a : α i) (t : Π j, α j → set (β j)) :
-  s.pi (λ j, t j (update f i a j)) = s.pi (λ j, t j (f j)) :=
-pi_congr rfl $ λ j hj, by { rw update_noteq, exact λ h, hi (h ▸ hj) }
-
-lemma pi_update_of_mem [decidable_eq ι] {β : Π i, Type*} {i : ι} (hi : i ∈ s) (f : Π j, α j)
-  (a : α i) (t : Π j, α j → set (β j)) :
-  s.pi (λ j, t j (update f i a j)) = {x | x i ∈ t i a} ∩ (s \ {i}).pi (λ j, t j (f j)) :=
-calc s.pi (λ j, t j (update f i a j)) = ({i} ∪ s \ {i}).pi (λ j, t j (update f i a j)) :
-  by rw [union_diff_self, union_eq_self_of_subset_left (singleton_subset_iff.2 hi)]
-... = {x | x i ∈ t i a} ∩ (s \ {i}).pi (λ j, t j (f j)) :
-  by { rw [union_pi, singleton_pi', update_same, pi_update_of_not_mem], simp }
-
-lemma univ_pi_update [decidable_eq ι] {β : Π i, Type*} (i : ι) (f : Π j, α j)
-  (a : α i) (t : Π j, α j → set (β j)) :
-  pi univ (λ j, t j (update f i a j)) = {x | x i ∈ t i a} ∩ pi {i}ᶜ (λ j, t j (f j)) :=
-by rw [compl_eq_univ_diff, ← pi_update_of_mem (mem_univ _)]
-
-lemma univ_pi_update_univ [decidable_eq ι] (i : ι) (s : set (α i)) :
-  pi univ (update (λ j : ι, (univ : set (α j))) i s) = eval i ⁻¹' s :=
-by rw [univ_pi_update i (λ j, (univ : set (α j))) s (λ j t, t), pi_univ, inter_univ, preimage]
-
-open_locale classical
-
-lemma eval_image_pi {i : ι} (hs : i ∈ s) (ht : (s.pi t).nonempty) : eval i '' s.pi t = t i :=
-begin
-  ext x, rcases ht with ⟨f, hf⟩, split,
-  { rintro ⟨g, hg, rfl⟩, exact hg i hs },
-  { intro hg, refine ⟨update f i x, _, by simp⟩,
-    intros j hj, by_cases hji : j = i,
-    { subst hji, simp [hg] },
-    { rw [mem_pi] at hf, simp [hji, hf, hj] }},
-end
-
-@[simp] lemma eval_image_univ_pi {i : ι} (ht : (pi univ t).nonempty) :
-  (λ f : Π i, α i, f i) '' pi univ t = t i :=
-eval_image_pi (mem_univ i) ht
-
-lemma eval_preimage {ι} {α : ι → Type*} {i : ι} {s : set (α i)} :
-  eval i ⁻¹' s = pi univ (update (λ i, univ) i s) :=
-by { ext x, simp [@forall_update_iff _ (λ i, set (α i)) _ _ _ _ (λ i' y, x i' ∈ y)] }
-
-lemma eval_preimage' {ι} {α : ι → Type*} {i : ι} {s : set (α i)} :
-  eval i ⁻¹' s = pi {i} (update (λ i, univ) i s) :=
-by { ext, simp }
-
-lemma update_preimage_pi {i : ι} {f : Π i, α i} (hi : i ∈ s)
-  (hf : ∀ j ∈ s, j ≠ i → f j ∈ t j) : (update f i) ⁻¹' s.pi t = t i :=
-begin
-  ext x, split,
-  { intro h, convert h i hi, simp },
-  { intros hx j hj, by_cases h : j = i,
-    { cases h, simpa },
-    { rw [update_noteq h], exact hf j hj h }}
-end
-
-lemma update_preimage_univ_pi {i : ι} {f : Π i, α i} (hf : ∀ j ≠ i, f j ∈ t j) :
-  (update f i) ⁻¹' pi univ t = t i :=
-update_preimage_pi (mem_univ i) (λ j _, hf j)
-
-lemma subset_pi_eval_image (s : set ι) (u : set (Π i, α i)) : u ⊆ pi s (λ i, eval i '' u) :=
-λ f hf i hi, ⟨f, hf, rfl⟩
-
-lemma univ_pi_ite (s : set ι) (t : Π i, set (α i)) :
-  pi univ (λ i, if i ∈ s then t i else univ) = s.pi t :=
-by { ext, simp_rw [mem_univ_pi], apply forall_congr, intro i, split_ifs; simp [h] }
-
-end pi
-
 /-! ### Lemmas about `inclusion`, the injection of subtypes induced by `⊆` -/
 
 section inclusion
@@ -2780,11 +2359,6 @@ by simp [nonempty_def.mp h, ext_iff]
 
 @[simp] lemma image2_right (h : s.nonempty) : image2 (λ x y, y) s t = t :=
 by simp [nonempty_def.mp h, ext_iff]
-
-@[simp] lemma image_prod (f : α → β → γ) : (λ x : α × β, f x.1 x.2) '' s.prod t = image2 f s t :=
-set.ext $ λ a,
-⟨ by { rintros ⟨_, _, rfl⟩, exact ⟨_, _, (mem_prod.mp ‹_›).1, (mem_prod.mp ‹_›).2, rfl⟩ },
-  by { rintros ⟨_, _, _, _, rfl⟩, exact ⟨(_, _), mem_prod.mpr ⟨‹_›, ‹_›⟩, rfl⟩ }⟩
 
 lemma nonempty.image2 (hs : s.nonempty) (ht : t.nonempty) : (image2 f s t).nonempty :=
 by { cases hs with a ha, cases ht with b hb, exact ⟨f a b, ⟨a, b, ha, hb, rfl⟩⟩ }

--- a/src/data/set/function.lean
+++ b/src/data/set/function.lean
@@ -3,7 +3,7 @@ Copyright (c) 2014 Jeremy Avigad. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jeremy Avigad, Andrew Zipperer, Haitao Zhang, Minchao Wu, Yury Kudryashov
 -/
-import data.set.basic
+import data.set.prod
 import logic.function.conjugate
 
 /-!

--- a/src/data/set/intervals/basic.lean
+++ b/src/data/set/intervals/basic.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl, Mario Carneiro, Patrick Massot, Yury Kudryashov, Rémy Degenne
 -/
 import algebra.order.group
-import data.set.basic
 import order.rel_iso
 import order.order_dual
 

--- a/src/data/set/prod.lean
+++ b/src/data/set/prod.lean
@@ -8,26 +8,25 @@ import data.set.basic
 /-!
 # Sets in product and pi types
 
-This file defines the product of sets in `α × β` and in `Π i, α i`.
+This file defines the product of sets in `α × β` and in `Π i, α i` along with the diagonal of a
+type.
 
 ## Main declarations
 
 * `set.prod`: Binary product of sets. For `s : set α`, `t : set β`, we have
   `s.prod t : set (α × β)`.
-* `set.diagonal`: Diagonal of a set. `s.diagonal = {(x, x) | x ∈ s}`.
+* `set.diagonal`: Diagonal of a type. `set.diagonal α = {(x, x) | x : α}`.
 * `set.pi`: Arbitrary product of sets.
 -/
 
 open function
-
-variables {ι α β γ δ : Type*} {σ : ι → Type*}
 
 namespace set
 
 /-! ### Cartesian binary product of sets -/
 
 section prod
-variables {s s₁ s₂ : set α} {t t₁ t₂ : set β} {a : α} {b : β}
+variables {α β γ δ : Type*} {s s₁ s₂ : set α} {t t₁ t₂ : set β} {a : α} {b : β}
 
 /-- The cartesian product `prod s t` is the set of `(a, b)`
   such that `a ∈ s` and `b ∈ t`. -/
@@ -47,7 +46,7 @@ lemma prod_mono (hs : s₁ ⊆ s₂) (ht : t₁ ⊆ t₂) : s₁.prod t₁ ⊆ s
 λ x ⟨h₁, h₂⟩, ⟨hs h₁, ht h₂⟩
 
 lemma prod_subset_iff {P : set (α × β)} : (s.prod t ⊆ P) ↔ ∀ (x ∈ s) (y ∈ t), (x, y) ∈ P :=
-⟨λ h _ xin _ yin, h (mk_mem_prod xin yin), λ h ⟨_, _⟩ pin, h _ pin.1 _ pin.2⟩
+⟨λ h _ hx _ hy, h (mk_mem_prod hx hy), λ h ⟨_, _⟩ hp, h _ hp.1 _ hp.2⟩
 
 lemma forall_prod_set {p : α × β → Prop} : (∀ x ∈ s.prod t, p x) ↔ ∀ (x ∈ s) (y ∈ t), p (x, y) :=
 prod_subset_iff
@@ -137,12 +136,12 @@ lemma image_swap_prod : prod.swap '' t.prod s = s.prod t :=
 by rw [image_swap_eq_preimage_swap, preimage_swap_prod]
 
 lemma prod_image_image_eq {m₁ : α → γ} {m₂ : β → δ} :
-  (m₁ '' s).prod (m₂ '' t) = image (λp:α×β, (m₁ p.1, m₂ p.2)) (s.prod t) :=
+  (m₁ '' s).prod (m₂ '' t) = image (λ p : α × β, (m₁ p.1, m₂ p.2)) (s.prod t) :=
 ext $ by simp [-exists_and_distrib_right, exists_and_distrib_right.symm, and.left_comm,
   and.assoc, and.comm]
 
 lemma prod_range_range_eq {m₁ : α → γ} {m₂ : β → δ} :
-  (range m₁).prod (range m₂) = range (λp:α×β, (m₁ p.1, m₂ p.2)) :=
+  (range m₁).prod (range m₂) = range (λ p : α × β, (m₁ p.1, m₂ p.2)) :=
 ext $ by simp [range]
 
 @[simp] lemma range_prod_map {m₁ : α → γ} {m₂ : β → δ} :
@@ -150,11 +149,11 @@ ext $ by simp [range]
 prod_range_range_eq.symm
 
 lemma prod_range_univ_eq {m₁ : α → γ} :
-  (range m₁).prod (univ : set β) = range (λp:α×β, (m₁ p.1, p.2)) :=
+  (range m₁).prod (univ : set β) = range (λ p : α × β, (m₁ p.1, p.2)) :=
 ext $ by simp [range]
 
 lemma prod_univ_range_eq {m₂ : β → δ} :
-  (univ : set α).prod (range m₂) = range (λp:α×β, (p.1, m₂ p.2)) :=
+  (univ : set α).prod (range m₂) = range (λ p : α × β, (p.1, m₂ p.2)) :=
 ext $ by simp [range]
 
 lemma range_pair_subset (f : α → β) (g : α → γ) :
@@ -162,11 +161,10 @@ lemma range_pair_subset (f : α → β) (g : α → γ) :
 have (λ x, (f x, g x)) = prod.map f g ∘ (λ x, (x, x)), from funext (λ x, rfl),
 by { rw [this, ← range_prod_map], apply range_comp_subset_range }
 
-lemma nonempty.prod : s.nonempty → t.nonempty → (s.prod t).nonempty
-| ⟨x, hx⟩ ⟨y, hy⟩ := ⟨(x, y), ⟨hx, hy⟩⟩
+lemma nonempty.prod : s.nonempty → t.nonempty → (s.prod t).nonempty :=
+λ ⟨x, hx⟩ ⟨y, hy⟩, ⟨(x, y), ⟨hx, hy⟩⟩
 
 lemma nonempty.fst : (s.prod t).nonempty → s.nonempty := λ ⟨x, hx⟩, ⟨x.1, hx.1⟩
-
 lemma nonempty.snd : (s.prod t).nonempty → t.nonempty := λ ⟨x, hx⟩, ⟨x.2, hx.2⟩
 
 lemma prod_nonempty_iff : (s.prod t).nonempty ↔ s.nonempty ∧ t.nonempty :=
@@ -186,8 +184,7 @@ lemma prod_subset_preimage_fst (s : set α) (t : set β) : s.prod t ⊆ prod.fst
 image_subset_iff.1 (fst_image_prod_subset s t)
 
 lemma fst_image_prod (s : set β) {t : set α} (ht : t.nonempty) : prod.fst '' (s.prod t) = s :=
-(fst_image_prod_subset _ _).antisymm $ λ y y_in, let ⟨x, x_in⟩ := ht in
-    ⟨(y, x), ⟨y_in, x_in⟩, rfl⟩
+(fst_image_prod_subset _ _).antisymm $ λ y hy, let ⟨x, hx⟩ := ht in ⟨(y, x), ⟨hy, hx⟩, rfl⟩
 
 lemma snd_image_prod_subset (s : set α) (t : set β) : prod.snd '' (s.prod t) ⊆ t :=
 λ _ h, let ⟨_, ⟨_, h₂⟩, h₁⟩ := (set.mem_image _ _ _).1 h in h₁ ▸ h₂
@@ -196,34 +193,26 @@ lemma prod_subset_preimage_snd (s : set α) (t : set β) : s.prod t ⊆ prod.snd
 image_subset_iff.1 (snd_image_prod_subset s t)
 
 lemma snd_image_prod {s : set α} (hs : s.nonempty) (t : set β) : prod.snd '' (s.prod t) = t :=
-set.subset.antisymm (snd_image_prod_subset _ _)
-  $ λ y y_in, let ⟨x, x_in⟩ := hs in
-    ⟨(x, y), ⟨x_in, y_in⟩, rfl⟩
+(snd_image_prod_subset _ _).antisymm $ λ y y_in, let ⟨x, x_in⟩ := hs in ⟨(x, y), ⟨x_in, y_in⟩, rfl⟩
 
 lemma prod_diff_prod : s.prod t \ s₁.prod t₁ = s.prod (t \ t₁) ∪ (s \ s₁).prod t :=
 by { ext x, by_cases h₁ : x.1 ∈ s₁; by_cases h₂ : x.2 ∈ t₁; simp * }
 
 /-- A product set is included in a product set if and only factors are included, or a factor of the
 first set is empty. -/
-lemma prod_subset_prod_iff : (s.prod t ⊆ s₁.prod t₁) ↔ (s ⊆ s₁ ∧ t ⊆ t₁) ∨ (s = ∅) ∨ (t = ∅) :=
+lemma prod_subset_prod_iff : s.prod t ⊆ s₁.prod t₁ ↔ s ⊆ s₁ ∧ t ⊆ t₁ ∨ s = ∅ ∨ t = ∅ :=
 begin
-  classical,
   cases (s.prod t).eq_empty_or_nonempty with h h,
   { simp [h, prod_eq_empty_iff.1 h] },
-  { have st : s.nonempty ∧ t.nonempty, by rwa [prod_nonempty_iff] at h,
-    split,
-    { assume H : s.prod t ⊆ s₁.prod t₁,
-      have h' : s₁.nonempty ∧ t₁.nonempty := prod_nonempty_iff.1 (h.mono H),
-      refine or.inl ⟨_, _⟩,
-      show s ⊆ s₁,
-      { have := image_subset (prod.fst : α × β → α) H,
-        rwa [fst_image_prod _ st.2, fst_image_prod _ h'.2] at this },
-      show t ⊆ t₁,
-      { have := image_subset (prod.snd : α × β → β) H,
-        rwa [snd_image_prod st.1, snd_image_prod h'.1] at this } },
-    { assume H,
-      simp only [st.1.ne_empty, st.2.ne_empty, or_false] at H,
-      exact prod_mono H.1 H.2 } }
+  have st : s.nonempty ∧ t.nonempty, by rwa [prod_nonempty_iff] at h,
+  refine ⟨λ H, or.inl ⟨_, _⟩, _⟩,
+  { have := image_subset (prod.fst : α × β → α) H,
+    rwa [fst_image_prod _ st.2, fst_image_prod _ (h.mono H).snd] at this },
+  { have := image_subset (prod.snd : α × β → β) H,
+    rwa [snd_image_prod st.1, snd_image_prod (h.mono H).fst] at this },
+  { intro H,
+    simp only [st.1.ne_empty, st.2.ne_empty, or_false] at H,
+    exact prod_mono H.1 H.2 }
 end
 
 @[simp] lemma image_prod (f : α → β → γ) : (λ x : α × β, f x.1 x.2) '' s.prod t = image2 f s t :=
@@ -236,21 +225,17 @@ end prod
 /-! ### Diagonal -/
 
 section diagonal
+variables {α : Type*}
 
-/-- `diagonal α` is the subset of `α × α` consisting of all pairs of the form `(a, a)`. -/
+/-- `diagonal α` is the set of `α × α` consisting of all pairs of the form `(a, a)`. -/
 def diagonal (α : Type*) : set (α × α) := {p | p.1 = p.2}
 
-@[simp]
-lemma mem_diagonal {α : Type*} (x : α) : (x, x) ∈ diagonal α := by simp [diagonal]
+@[simp] lemma mem_diagonal (x : α) : (x, x) ∈ diagonal α := by simp [diagonal]
 
-lemma preimage_coe_coe_diagonal {α : Type*} (s : set α) :
-  (prod.map coe coe) ⁻¹' (diagonal α) = diagonal s :=
-begin
-  ext ⟨⟨x, x_in⟩, ⟨y, y_in⟩⟩,
-  simp [set.diagonal],
-end
+lemma preimage_coe_coe_diagonal (s : set α) : (prod.map coe coe) ⁻¹' (diagonal α) = diagonal s :=
+by { ext ⟨⟨x, hx⟩, ⟨y, hy⟩⟩, simp [set.diagonal] }
 
-lemma diagonal_eq_range {α : Type*} : diagonal α = range (λ x, (x, x)) :=
+lemma diagonal_eq_range : diagonal α = range (λ x, (x, x)) :=
 by { ext ⟨x, y⟩, simp [diagonal, eq_comm] }
 
 end diagonal
@@ -258,20 +243,20 @@ end diagonal
 /-! ### Cartesian set-indexed product of sets -/
 
 section pi
-variables {ι : Type*} {α : ι → Type*} {s s₁ : set ι} {t t₁ t₂ : Π i, set (σ i)}
+variables {ι : Type*} {α β : ι → Type*} {s s₁ s₂ : set ι} {t t₁ t₂ : Π i, set (α i)} {i : ι}
 
-/-- Given an index set `ι` and a family of sets `t : Π i, set (σ i)`, `pi s t`
+/-- Given an index set `ι` and a family of sets `t : Π i, set (α i)`, `pi s t`
 is the set of dependent functions `f : Πa, π a` such that `f a` belongs to `t a`
 whenever `a ∈ s`. -/
-def pi (s : set ι) (t : Π i, set (σ i)) : set (Π i, σ i) := { f | ∀ i ∈ s, f i ∈ t i }
+def pi (s : set ι) (t : Π i, set (α i)) : set (Π i, α i) := {f | ∀ i ∈ s, f i ∈ t i}
 
-@[simp] lemma mem_pi {f : Π i, σ i} : f ∈ s.pi t ↔ ∀ i ∈ s, f i ∈ t i := iff.rfl
+@[simp] lemma mem_pi {f : Π i, α i} : f ∈ s.pi t ↔ ∀ i ∈ s, f i ∈ t i := iff.rfl
 
-@[simp] lemma mem_univ_pi {f : Π i, σ i} : f ∈ pi univ t ↔ ∀ i, f i ∈ t i := by simp
+@[simp] lemma mem_univ_pi {f : Π i, α i} : f ∈ pi univ t ↔ ∀ i, f i ∈ t i := by simp
 
-@[simp] lemma empty_pi (s : Π i, set (σ i)) : pi ∅ s = univ := by { ext, simp [pi] }
+@[simp] lemma empty_pi (s : Π i, set (α i)) : pi ∅ s = univ := by { ext, simp [pi] }
 
-@[simp] lemma pi_univ (s : set ι) : pi s (λ i, (univ : set (σ i))) = univ :=
+@[simp] lemma pi_univ (s : set ι) : pi s (λ i, (univ : set (α i))) = univ :=
 eq_univ_of_forall $ λ f i hi, mem_univ _
 
 lemma pi_mono (h : ∀ i ∈ s, t₁ i ⊆ t₂ i) : pi s t₁ ⊆ pi s t₂ :=
@@ -280,14 +265,14 @@ lemma pi_mono (h : ∀ i ∈ s, t₁ i ⊆ t₂ i) : pi s t₁ ⊆ pi s t₂ :=
 lemma pi_inter_distrib : s.pi (λ i, t i ∩ t₁ i) = s.pi t ∩ s.pi t₁ :=
 ext $ λ x, by simp only [forall_and_distrib, mem_pi, mem_inter_eq]
 
-lemma pi_congr (h : s = s₁) (h' : ∀ i ∈ s, t i = t₁ i) : pi s t = pi s₁ t₁ :=
+lemma pi_congr (h : s₁ = s₂) (h' : ∀ i ∈ s₁, t₁ i = t₂ i) : s₁.pi t₁ = s₂.pi t₂ :=
 h ▸ (ext $ λ x, forall_congr $ λ i, forall_congr $ λ hi, h' i hi ▸ iff.rfl)
 
-lemma pi_eq_empty {i : ι} (hs : i ∈ s) (ht : t i = ∅) : s.pi t = ∅ :=
+lemma pi_eq_empty (hs : i ∈ s) (ht : t i = ∅) : s.pi t = ∅ :=
 by { ext f, simp only [mem_empty_eq, not_forall, iff_false, mem_pi, not_imp],
      exact ⟨i, hs, by simp [ht]⟩ }
 
-lemma univ_pi_eq_empty {i : ι} (ht : t i = ∅) : pi univ t = ∅ := pi_eq_empty (mem_univ i) ht
+lemma univ_pi_eq_empty (ht : t i = ∅) : pi univ t = ∅ := pi_eq_empty (mem_univ i) ht
 
 lemma pi_nonempty_iff : (s.pi t).nonempty ↔ ∀ i, ∃ x, i ∈ s → x ∈ t i :=
 by simp [classical.skolem, set.nonempty]
@@ -295,125 +280,130 @@ by simp [classical.skolem, set.nonempty]
 lemma univ_pi_nonempty_iff : (pi univ t).nonempty ↔ ∀ i, (t i).nonempty :=
 by simp [classical.skolem, set.nonempty]
 
-lemma pi_eq_empty_iff : s.pi t = ∅ ↔ ∃ i, (σ i → false) ∨ (i ∈ s ∧ t i = ∅) :=
+lemma pi_eq_empty_iff : s.pi t = ∅ ↔ ∃ i, is_empty (α i) ∨ i ∈ s ∧ t i = ∅ :=
 begin
-  rw [← not_nonempty_iff_eq_empty, pi_nonempty_iff], push_neg, apply exists_congr, intro i,
-  split,
-  { intro h, by_cases hα : nonempty (σ i),
-    { cases hα with x, refine or.inr ⟨(h x).1, by simp [eq_empty_iff_forall_not_mem, h]⟩ },
-    { exact or.inl (λ x, hα ⟨x⟩) }},
-  { rintro (h|h) x, exfalso, exact h x, simp [h] }
+  rw [← not_nonempty_iff_eq_empty, pi_nonempty_iff],
+  push_neg,
+  refine exists_congr (λ i, ⟨λ h, (is_empty_or_nonempty (α i)).imp_right _, _⟩),
+  { rintro ⟨x⟩,
+    exact ⟨(h x).1, by simp [eq_empty_iff_forall_not_mem, h]⟩ },
+  { rintro (h | h) x,
+    { exact h.elim' x },
+    { simp [h] } }
 end
 
 lemma univ_pi_eq_empty_iff : pi univ t = ∅ ↔ ∃ i, t i = ∅ :=
 by simp [← not_nonempty_iff_eq_empty, univ_pi_nonempty_iff]
 
-@[simp] lemma univ_pi_empty [h : nonempty ι] : pi univ (λ i, ∅ : Π i, set (σ i)) = ∅ :=
+@[simp] lemma univ_pi_empty [h : nonempty ι] : pi univ (λ i, ∅ : Π i, set (α i)) = ∅ :=
 univ_pi_eq_empty_iff.2 $ h.elim $ λ x, ⟨x, rfl⟩
 
-@[simp] lemma range_dcomp {β : ι → Type*} (f : Π i, σ i → β i) :
-  range (λ (g : Π i, σ i), (λ i, f i (g i))) = pi univ (λ i, range (f i)) :=
+@[simp] lemma range_dcomp (f : Π i, α i → β i) :
+  range (λ (g : Π i, α i), (λ i, f i (g i))) = pi univ (λ i, range (f i)) :=
 begin
-  apply subset.antisymm,
+  apply subset.antisymm _ (λ x hx, _),
   { rintro _ ⟨x, rfl⟩ i -,
     exact ⟨x i, rfl⟩ },
-  { intros x hx,
-    choose y hy using hx,
+  { choose y hy using hx,
     exact ⟨λ i, y i trivial, funext $ λ i, hy i trivial⟩ }
 end
 
-@[simp] lemma insert_pi (i : ι) (s : set ι) (t : Π i, set (σ i)) :
+@[simp] lemma insert_pi (i : ι) (s : set ι) (t : Π i, set (α i)) :
   pi (insert i s) t = (eval i ⁻¹' t i) ∩ pi s t :=
 by { ext, simp [pi, or_imp_distrib, forall_and_distrib] }
 
-@[simp] lemma singleton_pi (i : ι) (t : Π i, set (σ i)) : pi {i} t = (eval i ⁻¹' t i) :=
+@[simp] lemma singleton_pi (i : ι) (t : Π i, set (α i)) : pi {i} t = (eval i ⁻¹' t i) :=
 by { ext, simp [pi] }
 
-lemma singleton_pi' (i : ι) (t : Π i, set (σ i)) : pi {i} t = {x | x i ∈ t i} :=
-singleton_pi i t
+lemma singleton_pi' (i : ι) (t : Π i, set (α i)) : pi {i} t = {x | x i ∈ t i} := singleton_pi i t
 
-lemma pi_if {p : ι → Prop} [h : decidable_pred p] (s : set ι) (t₁ t₂ : Π i, set (σ i)) :
+lemma pi_if {p : ι → Prop} [h : decidable_pred p] (s : set ι) (t₁ t₂ : Π i, set (α i)) :
   pi s (λ i, if p i then t₁ i else t₂ i) = pi {i ∈ s | p i} t₁ ∩ pi {i ∈ s | ¬ p i} t₂ :=
 begin
   ext f,
-  split,
-  { assume h, split; { rintro i ⟨his, hpi⟩, simpa [*] using h i } },
+  refine ⟨λ h, _, _⟩,
+  { split; { rintro i ⟨his, hpi⟩, simpa [*] using h i } },
   { rintro ⟨ht₁, ht₂⟩ i his,
     by_cases p i; simp * at * }
 end
 
-lemma union_pi : (s ∪ s₁).pi t = s.pi t ∩ s₁.pi t :=
+lemma union_pi : (s₁ ∪ s₂).pi t = s₁.pi t ∩ s₂.pi t :=
 by simp [pi, or_imp_distrib, forall_and_distrib, set_of_and]
 
 @[simp] lemma pi_inter_compl (s : set ι) : pi s t ∩ pi sᶜ t = pi univ t :=
 by rw [← union_pi, union_compl_self]
 
-lemma pi_update_of_not_mem [decidable_eq ι] {β : Π i, Type*} {i : ι} (hi : i ∉ s) (f : Π j, α j)
-  (a : σ i) (t : Π j, α j → set (β j)) :
+lemma pi_update_of_not_mem [decidable_eq ι] (hi : i ∉ s) (f : Π j, α j) (a : α i)
+  (t : Π j, α j → set (β j)) :
   s.pi (λ j, t j (update f i a j)) = s.pi (λ j, t j (f j)) :=
 pi_congr rfl $ λ j hj, by { rw update_noteq, exact λ h, hi (h ▸ hj) }
 
-lemma pi_update_of_mem [decidable_eq ι] {β : Π i, Type*} {i : ι} (hi : i ∈ s) (f : Π j, α j)
-  (a : σ i) (t : Π j, α j → set (β j)) :
+lemma pi_update_of_mem [decidable_eq ι] (hi : i ∈ s) (f : Π j, α j) (a : α i)
+  (t : Π j, α j → set (β j)) :
   s.pi (λ j, t j (update f i a j)) = {x | x i ∈ t i a} ∩ (s \ {i}).pi (λ j, t j (f j)) :=
 calc s.pi (λ j, t j (update f i a j)) = ({i} ∪ s \ {i}).pi (λ j, t j (update f i a j)) :
   by rw [union_diff_self, union_eq_self_of_subset_left (singleton_subset_iff.2 hi)]
 ... = {x | x i ∈ t i a} ∩ (s \ {i}).pi (λ j, t j (f j)) :
   by { rw [union_pi, singleton_pi', update_same, pi_update_of_not_mem], simp }
 
-lemma univ_pi_update [decidable_eq ι] {β : Π i, Type*} (i : ι) (f : Π j, α j)
-  (a : σ i) (t : Π j, α j → set (β j)) :
+lemma univ_pi_update [decidable_eq ι] {β : Π i, Type*} (i : ι) (f : Π j, α j) (a : α i)
+  (t : Π j, α j → set (β j)) :
   pi univ (λ j, t j (update f i a j)) = {x | x i ∈ t i a} ∩ pi {i}ᶜ (λ j, t j (f j)) :=
 by rw [compl_eq_univ_diff, ← pi_update_of_mem (mem_univ _)]
 
-lemma univ_pi_update_univ [decidable_eq ι] (i : ι) (s : set (σ i)) :
+lemma univ_pi_update_univ [decidable_eq ι] (i : ι) (s : set (α i)) :
   pi univ (update (λ j : ι, (univ : set (α j))) i s) = eval i ⁻¹' s :=
 by rw [univ_pi_update i (λ j, (univ : set (α j))) s (λ j t, t), pi_univ, inter_univ, preimage]
 
-open_locale classical
-
-lemma eval_image_pi {i : ι} (hs : i ∈ s) (ht : (s.pi t).nonempty) : eval i '' s.pi t = t i :=
+lemma eval_image_pi (hs : i ∈ s) (ht : (s.pi t).nonempty) : eval i '' s.pi t = t i :=
 begin
-  ext x, rcases ht with ⟨f, hf⟩, split,
-  { rintro ⟨g, hg, rfl⟩, exact hg i hs },
-  { intro hg, refine ⟨update f i x, _, by simp⟩,
-    intros j hj, by_cases hji : j = i,
-    { subst hji, simp [hg] },
-    { rw [mem_pi] at hf, simp [hji, hf, hj] }},
+  classical,
+  ext x,
+  obtain ⟨f, hf⟩ := ht,
+  refine ⟨_, λ hg, ⟨update f i x, λ j hj, _, by simp⟩⟩,
+  { rintro ⟨g, hg, rfl⟩,
+    exact hg i hs },
+  { obtain rfl | hji := eq_or_ne j i,
+    { simp [hg] },
+    { rw [mem_pi] at hf, simp [hji, hf _ hj] } }
 end
 
-@[simp] lemma eval_image_univ_pi {i : ι} (ht : (pi univ t).nonempty) :
-  (λ f : Π i, σ i, f i) '' pi univ t = t i :=
+@[simp] lemma eval_image_univ_pi (ht : (pi univ t).nonempty) :
+  (λ f : Π i, α i, f i) '' pi univ t = t i :=
 eval_image_pi (mem_univ i) ht
 
-lemma eval_preimage {ι} {α : ι → Type*} {i : ι} {s : set (σ i)} :
+lemma eval_preimage [decidable_eq ι] {s : set (α i)} :
   eval i ⁻¹' s = pi univ (update (λ i, univ) i s) :=
-by { ext x, simp [@forall_update_iff _ (λ i, set (σ i)) _ _ _ _ (λ i' y, x i' ∈ y)] }
+by { ext x, simp [@forall_update_iff _ (λ i, set (α i)) _ _ _ _ (λ i' y, x i' ∈ y)] }
 
-lemma eval_preimage' {ι} {α : ι → Type*} {i : ι} {s : set (σ i)} :
+lemma eval_preimage' [decidable_eq ι] {s : set (α i)} :
   eval i ⁻¹' s = pi {i} (update (λ i, univ) i s) :=
 by { ext, simp }
 
-lemma update_preimage_pi {i : ι} {f : Π i, σ i} (hi : i ∈ s) (hf : ∀ j ∈ s, j ≠ i → f j ∈ t j) :
+lemma update_preimage_pi [decidable_eq ι] {f : Π i, α i} (hi : i ∈ s)
+  (hf : ∀ j ∈ s, j ≠ i → f j ∈ t j) :
   (update f i) ⁻¹' s.pi t = t i :=
 begin
-  ext x, split,
-  { intro h, convert h i hi, simp },
-  { intros hx j hj, by_cases h : j = i,
-    { cases h, simpa },
-    { rw [update_noteq h], exact hf j hj h }}
+  ext x,
+  refine ⟨λ h, _, λ hx j hj, _⟩,
+  { convert h i hi,
+    simp },
+  { obtain rfl | h := eq_or_ne j i,
+    { simpa },
+    { rw update_noteq h,
+      exact hf j hj h } }
 end
 
-lemma update_preimage_univ_pi {i : ι} {f : Π i, σ i} (hf : ∀ j ≠ i, f j ∈ t j) :
+lemma update_preimage_univ_pi [decidable_eq ι] {f : Π i, α i} (hf : ∀ j ≠ i, f j ∈ t j) :
   (update f i) ⁻¹' pi univ t = t i :=
 update_preimage_pi (mem_univ i) (λ j _, hf j)
 
-lemma subset_pi_eval_image (s : set ι) (u : set (Π i, σ i)) : u ⊆ pi s (λ i, eval i '' u) :=
+lemma subset_pi_eval_image (s : set ι) (u : set (Π i, α i)) : u ⊆ pi s (λ i, eval i '' u) :=
 λ f hf i hi, ⟨f, hf, rfl⟩
 
-lemma univ_pi_ite (s : set ι) (t : Π i, set (σ i)) :
+lemma univ_pi_ite (s : set ι) [decidable_pred (∈ s)] (t : Π i, set (α i)) :
   pi univ (λ i, if i ∈ s then t i else univ) = s.pi t :=
-by { ext, simp_rw [mem_univ_pi], apply forall_congr, intro i, split_ifs; simp [h] }
+by { ext, simp_rw [mem_univ_pi], refine forall_congr (λ i, _), split_ifs; simp [h] }
 
 end pi
 end set

--- a/src/data/set/prod.lean
+++ b/src/data/set/prod.lean
@@ -1,0 +1,419 @@
+/-
+Copyright (c) 2017 Mario Carneiro. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Mario Carneiro, Johannes Hölzl
+-/
+import data.set.basic
+
+/-!
+# Sets in product and pi types
+
+This file defines the product of sets in `α × β` and in `Π i, α i`.
+
+## Main declarations
+
+* `set.prod`: Binary product of sets. For `s : set α`, `t : set β`, we have
+  `s.prod t : set (α × β)`.
+* `set.diagonal`: Diagonal of a set. `s.diagonal = {(x, x) | x ∈ s}`.
+* `set.pi`: Arbitrary product of sets.
+-/
+
+open function
+
+variables {ι α β γ δ : Type*} {σ : ι → Type*}
+
+namespace set
+
+/-! ### Cartesian binary product of sets -/
+
+section prod
+variables {s s₁ s₂ : set α} {t t₁ t₂ : set β} {a : α} {b : β}
+
+/-- The cartesian product `prod s t` is the set of `(a, b)`
+  such that `a ∈ s` and `b ∈ t`. -/
+protected def prod (s : set α) (t : set β) : set (α × β) := {p | p.1 ∈ s ∧ p.2 ∈ t}
+
+lemma prod_eq (s : set α) (t : set β) : s.prod t = prod.fst ⁻¹' s ∩ prod.snd ⁻¹' t := rfl
+
+lemma mem_prod_eq {p : α × β} : p ∈ s.prod t = (p.1 ∈ s ∧ p.2 ∈ t) := rfl
+
+@[simp] lemma mem_prod {p : α × β} : p ∈ s.prod t ↔ p.1 ∈ s ∧ p.2 ∈ t := iff.rfl
+
+@[simp] lemma prod_mk_mem_set_prod_eq : (a, b) ∈ s.prod t = (a ∈ s ∧ b ∈ t) := rfl
+
+lemma mk_mem_prod (ha : a ∈ s) (hb : b ∈ t) : (a, b) ∈ s.prod t := ⟨ha, hb⟩
+
+lemma prod_mono (hs : s₁ ⊆ s₂) (ht : t₁ ⊆ t₂) : s₁.prod t₁ ⊆ s₂.prod t₂ :=
+λ x ⟨h₁, h₂⟩, ⟨hs h₁, ht h₂⟩
+
+lemma prod_subset_iff {P : set (α × β)} : (s.prod t ⊆ P) ↔ ∀ (x ∈ s) (y ∈ t), (x, y) ∈ P :=
+⟨λ h _ xin _ yin, h (mk_mem_prod xin yin), λ h ⟨_, _⟩ pin, h _ pin.1 _ pin.2⟩
+
+lemma forall_prod_set {p : α × β → Prop} : (∀ x ∈ s.prod t, p x) ↔ ∀ (x ∈ s) (y ∈ t), p (x, y) :=
+prod_subset_iff
+
+lemma exists_prod_set {p : α × β → Prop} : (∃ x ∈ s.prod t, p x) ↔ ∃ (x ∈ s) (y ∈ t), p (x, y) :=
+by simp [and_assoc]
+
+@[simp] lemma prod_empty : s.prod ∅ = (∅ : set (α × β)) := by { ext, exact and_false _ }
+
+@[simp] lemma empty_prod : set.prod ∅ t = (∅ : set (α × β)) := by { ext, exact false_and _ }
+
+@[simp] lemma univ_prod_univ : (@univ α).prod (@univ β) = univ := by { ext, exact true_and _ }
+
+lemma univ_prod {t : set β} : set.prod (univ : set α) t = prod.snd ⁻¹' t := by simp [prod_eq]
+
+lemma prod_univ {s : set α} : set.prod s (univ : set β) = prod.fst ⁻¹' s := by simp [prod_eq]
+
+@[simp] lemma singleton_prod : set.prod {a} t = prod.mk a '' t :=
+by { ext ⟨x, y⟩, simp [and.left_comm, eq_comm] }
+
+@[simp] lemma prod_singleton : s.prod {b} = (λ a, (a, b)) '' s :=
+by { ext ⟨x, y⟩, simp [and.left_comm, eq_comm] }
+
+lemma singleton_prod_singleton : set.prod {a} {b} = ({(a, b)} : set (α × β)) := by simp
+
+@[simp] lemma union_prod : (s₁ ∪ s₂).prod t = s₁.prod t ∪ s₂.prod t :=
+by { ext ⟨x, y⟩, simp [or_and_distrib_right] }
+
+@[simp] lemma prod_union : s.prod (t₁ ∪ t₂) = s.prod t₁ ∪ s.prod t₂ :=
+by { ext ⟨x, y⟩, simp [and_or_distrib_left] }
+
+lemma prod_inter_prod : s₁.prod t₁ ∩ s₂.prod t₂ = (s₁ ∩ s₂).prod (t₁ ∩ t₂) :=
+by { ext ⟨x, y⟩, simp [and_assoc, and.left_comm] }
+
+lemma insert_prod : (insert a s).prod t = (prod.mk a '' t) ∪ s.prod t :=
+by { ext ⟨x, y⟩, simp [image, iff_def, or_imp_distrib, imp.swap] {contextual := tt} }
+
+lemma prod_insert : s.prod (insert b t) = ((λa, (a, b)) '' s) ∪ s.prod t :=
+by { ext ⟨x, y⟩, simp [image, iff_def, or_imp_distrib, imp.swap] {contextual := tt} }
+
+lemma prod_preimage_eq {f : γ → α} {g : δ → β} :
+  (f ⁻¹' s).prod (g ⁻¹' t) = (λ p, (f p.1, g p.2)) ⁻¹' s.prod t := rfl
+
+lemma prod_preimage_left {f : γ → α} : (f ⁻¹' s).prod t = (λp, (f p.1, p.2)) ⁻¹' (s.prod t) := rfl
+
+lemma prod_preimage_right {g : δ → β} : s.prod (g ⁻¹' t) = (λp, (p.1, g p.2)) ⁻¹' (s.prod t) := rfl
+
+lemma preimage_prod_map_prod (f : α → β) (g : γ → δ) (s : set β) (t : set δ) :
+  prod.map f g ⁻¹' (s.prod t) = (f ⁻¹' s).prod (g ⁻¹' t) :=
+rfl
+
+lemma mk_preimage_prod (f : γ → α) (g : γ → β) :
+  (λ x, (f x, g x)) ⁻¹' s.prod t = f ⁻¹' s ∩ g ⁻¹' t := rfl
+
+@[simp] lemma mk_preimage_prod_left (hb : b ∈ t) : (λ a, (a, b)) ⁻¹' s.prod t = s :=
+by { ext a, simp [hb] }
+
+@[simp] lemma mk_preimage_prod_right (ha : a ∈ s) : prod.mk a ⁻¹' s.prod t = t :=
+by { ext b, simp [ha] }
+
+@[simp] lemma mk_preimage_prod_left_eq_empty (hb : b ∉ t) : (λ a, (a, b)) ⁻¹' s.prod t = ∅ :=
+by { ext a, simp [hb] }
+
+@[simp] lemma mk_preimage_prod_right_eq_empty (ha : a ∉ s) : prod.mk a ⁻¹' s.prod t = ∅ :=
+by { ext b, simp [ha] }
+
+lemma mk_preimage_prod_left_eq_if [decidable_pred (∈ t)] :
+  (λ a, (a, b)) ⁻¹' s.prod t = if b ∈ t then s else ∅ :=
+by split_ifs; simp [h]
+
+lemma mk_preimage_prod_right_eq_if [decidable_pred (∈ s)] :
+  prod.mk a ⁻¹' s.prod t = if a ∈ s then t else ∅ :=
+by split_ifs; simp [h]
+
+lemma mk_preimage_prod_left_fn_eq_if [decidable_pred (∈ t)] (f : γ → α) :
+  (λ a, (f a, b)) ⁻¹' s.prod t = if b ∈ t then f ⁻¹' s else ∅ :=
+by rw [← mk_preimage_prod_left_eq_if, prod_preimage_left, preimage_preimage]
+
+lemma mk_preimage_prod_right_fn_eq_if [decidable_pred (∈ s)] (g : δ → β) :
+  (λ b, (a, g b)) ⁻¹' s.prod t = if a ∈ s then g ⁻¹' t else ∅ :=
+by rw [← mk_preimage_prod_right_eq_if, prod_preimage_right, preimage_preimage]
+
+lemma preimage_swap_prod {s : set α} {t : set β} : prod.swap ⁻¹' t.prod s = s.prod t :=
+by { ext ⟨x, y⟩, simp [and_comm] }
+
+lemma image_swap_prod : prod.swap '' t.prod s = s.prod t :=
+by rw [image_swap_eq_preimage_swap, preimage_swap_prod]
+
+lemma prod_image_image_eq {m₁ : α → γ} {m₂ : β → δ} :
+  (m₁ '' s).prod (m₂ '' t) = image (λp:α×β, (m₁ p.1, m₂ p.2)) (s.prod t) :=
+ext $ by simp [-exists_and_distrib_right, exists_and_distrib_right.symm, and.left_comm,
+  and.assoc, and.comm]
+
+lemma prod_range_range_eq {m₁ : α → γ} {m₂ : β → δ} :
+  (range m₁).prod (range m₂) = range (λp:α×β, (m₁ p.1, m₂ p.2)) :=
+ext $ by simp [range]
+
+@[simp] lemma range_prod_map {m₁ : α → γ} {m₂ : β → δ} :
+  range (prod.map m₁ m₂) = (range m₁).prod (range m₂) :=
+prod_range_range_eq.symm
+
+lemma prod_range_univ_eq {m₁ : α → γ} :
+  (range m₁).prod (univ : set β) = range (λp:α×β, (m₁ p.1, p.2)) :=
+ext $ by simp [range]
+
+lemma prod_univ_range_eq {m₂ : β → δ} :
+  (univ : set α).prod (range m₂) = range (λp:α×β, (p.1, m₂ p.2)) :=
+ext $ by simp [range]
+
+lemma range_pair_subset (f : α → β) (g : α → γ) :
+  range (λ x, (f x, g x)) ⊆ (range f).prod (range g) :=
+have (λ x, (f x, g x)) = prod.map f g ∘ (λ x, (x, x)), from funext (λ x, rfl),
+by { rw [this, ← range_prod_map], apply range_comp_subset_range }
+
+lemma nonempty.prod : s.nonempty → t.nonempty → (s.prod t).nonempty
+| ⟨x, hx⟩ ⟨y, hy⟩ := ⟨(x, y), ⟨hx, hy⟩⟩
+
+lemma nonempty.fst : (s.prod t).nonempty → s.nonempty := λ ⟨x, hx⟩, ⟨x.1, hx.1⟩
+
+lemma nonempty.snd : (s.prod t).nonempty → t.nonempty := λ ⟨x, hx⟩, ⟨x.2, hx.2⟩
+
+lemma prod_nonempty_iff : (s.prod t).nonempty ↔ s.nonempty ∧ t.nonempty :=
+⟨λ h, ⟨h.fst, h.snd⟩, λ h, h.1.prod h.2⟩
+
+lemma prod_eq_empty_iff : s.prod t = ∅ ↔ (s = ∅ ∨ t = ∅) :=
+by simp only [not_nonempty_iff_eq_empty.symm, prod_nonempty_iff, not_and_distrib]
+
+lemma prod_sub_preimage_iff {W : set γ} {f : α × β → γ} :
+  s.prod t ⊆ f ⁻¹' W ↔ ∀ a b, a ∈ s → b ∈ t → f (a, b) ∈ W :=
+by simp [subset_def]
+
+lemma fst_image_prod_subset (s : set α) (t : set β) : prod.fst '' (s.prod t) ⊆ s :=
+λ _ h, let ⟨_, ⟨h₂, _⟩, h₁⟩ := (set.mem_image _ _ _).1 h in h₁ ▸ h₂
+
+lemma prod_subset_preimage_fst (s : set α) (t : set β) : s.prod t ⊆ prod.fst ⁻¹' s :=
+image_subset_iff.1 (fst_image_prod_subset s t)
+
+lemma fst_image_prod (s : set β) {t : set α} (ht : t.nonempty) : prod.fst '' (s.prod t) = s :=
+(fst_image_prod_subset _ _).antisymm $ λ y y_in, let ⟨x, x_in⟩ := ht in
+    ⟨(y, x), ⟨y_in, x_in⟩, rfl⟩
+
+lemma snd_image_prod_subset (s : set α) (t : set β) : prod.snd '' (s.prod t) ⊆ t :=
+λ _ h, let ⟨_, ⟨_, h₂⟩, h₁⟩ := (set.mem_image _ _ _).1 h in h₁ ▸ h₂
+
+lemma prod_subset_preimage_snd (s : set α) (t : set β) : s.prod t ⊆ prod.snd ⁻¹' t :=
+image_subset_iff.1 (snd_image_prod_subset s t)
+
+lemma snd_image_prod {s : set α} (hs : s.nonempty) (t : set β) : prod.snd '' (s.prod t) = t :=
+set.subset.antisymm (snd_image_prod_subset _ _)
+  $ λ y y_in, let ⟨x, x_in⟩ := hs in
+    ⟨(x, y), ⟨x_in, y_in⟩, rfl⟩
+
+lemma prod_diff_prod : s.prod t \ s₁.prod t₁ = s.prod (t \ t₁) ∪ (s \ s₁).prod t :=
+by { ext x, by_cases h₁ : x.1 ∈ s₁; by_cases h₂ : x.2 ∈ t₁; simp * }
+
+/-- A product set is included in a product set if and only factors are included, or a factor of the
+first set is empty. -/
+lemma prod_subset_prod_iff : (s.prod t ⊆ s₁.prod t₁) ↔ (s ⊆ s₁ ∧ t ⊆ t₁) ∨ (s = ∅) ∨ (t = ∅) :=
+begin
+  classical,
+  cases (s.prod t).eq_empty_or_nonempty with h h,
+  { simp [h, prod_eq_empty_iff.1 h] },
+  { have st : s.nonempty ∧ t.nonempty, by rwa [prod_nonempty_iff] at h,
+    split,
+    { assume H : s.prod t ⊆ s₁.prod t₁,
+      have h' : s₁.nonempty ∧ t₁.nonempty := prod_nonempty_iff.1 (h.mono H),
+      refine or.inl ⟨_, _⟩,
+      show s ⊆ s₁,
+      { have := image_subset (prod.fst : α × β → α) H,
+        rwa [fst_image_prod _ st.2, fst_image_prod _ h'.2] at this },
+      show t ⊆ t₁,
+      { have := image_subset (prod.snd : α × β → β) H,
+        rwa [snd_image_prod st.1, snd_image_prod h'.1] at this } },
+    { assume H,
+      simp only [st.1.ne_empty, st.2.ne_empty, or_false] at H,
+      exact prod_mono H.1 H.2 } }
+end
+
+@[simp] lemma image_prod (f : α → β → γ) : (λ x : α × β, f x.1 x.2) '' s.prod t = image2 f s t :=
+set.ext $ λ a,
+⟨ by { rintro ⟨_, _, rfl⟩, exact ⟨_, _, (mem_prod.mp ‹_›).1, (mem_prod.mp ‹_›).2, rfl⟩ },
+  by { rintro ⟨_, _, _, _, rfl⟩, exact ⟨(_, _), mem_prod.mpr ⟨‹_›, ‹_›⟩, rfl⟩ }⟩
+
+end prod
+
+/-! ### Diagonal -/
+
+section diagonal
+
+/-- `diagonal α` is the subset of `α × α` consisting of all pairs of the form `(a, a)`. -/
+def diagonal (α : Type*) : set (α × α) := {p | p.1 = p.2}
+
+@[simp]
+lemma mem_diagonal {α : Type*} (x : α) : (x, x) ∈ diagonal α := by simp [diagonal]
+
+lemma preimage_coe_coe_diagonal {α : Type*} (s : set α) :
+  (prod.map coe coe) ⁻¹' (diagonal α) = diagonal s :=
+begin
+  ext ⟨⟨x, x_in⟩, ⟨y, y_in⟩⟩,
+  simp [set.diagonal],
+end
+
+lemma diagonal_eq_range {α : Type*} : diagonal α = range (λ x, (x, x)) :=
+by { ext ⟨x, y⟩, simp [diagonal, eq_comm] }
+
+end diagonal
+
+/-! ### Cartesian set-indexed product of sets -/
+
+section pi
+variables {ι : Type*} {α : ι → Type*} {s s₁ : set ι} {t t₁ t₂ : Π i, set (σ i)}
+
+/-- Given an index set `ι` and a family of sets `t : Π i, set (σ i)`, `pi s t`
+is the set of dependent functions `f : Πa, π a` such that `f a` belongs to `t a`
+whenever `a ∈ s`. -/
+def pi (s : set ι) (t : Π i, set (σ i)) : set (Π i, σ i) := { f | ∀ i ∈ s, f i ∈ t i }
+
+@[simp] lemma mem_pi {f : Π i, σ i} : f ∈ s.pi t ↔ ∀ i ∈ s, f i ∈ t i := iff.rfl
+
+@[simp] lemma mem_univ_pi {f : Π i, σ i} : f ∈ pi univ t ↔ ∀ i, f i ∈ t i := by simp
+
+@[simp] lemma empty_pi (s : Π i, set (σ i)) : pi ∅ s = univ := by { ext, simp [pi] }
+
+@[simp] lemma pi_univ (s : set ι) : pi s (λ i, (univ : set (σ i))) = univ :=
+eq_univ_of_forall $ λ f i hi, mem_univ _
+
+lemma pi_mono (h : ∀ i ∈ s, t₁ i ⊆ t₂ i) : pi s t₁ ⊆ pi s t₂ :=
+λ x hx i hi, (h i hi $ hx i hi)
+
+lemma pi_inter_distrib : s.pi (λ i, t i ∩ t₁ i) = s.pi t ∩ s.pi t₁ :=
+ext $ λ x, by simp only [forall_and_distrib, mem_pi, mem_inter_eq]
+
+lemma pi_congr (h : s = s₁) (h' : ∀ i ∈ s, t i = t₁ i) : pi s t = pi s₁ t₁ :=
+h ▸ (ext $ λ x, forall_congr $ λ i, forall_congr $ λ hi, h' i hi ▸ iff.rfl)
+
+lemma pi_eq_empty {i : ι} (hs : i ∈ s) (ht : t i = ∅) : s.pi t = ∅ :=
+by { ext f, simp only [mem_empty_eq, not_forall, iff_false, mem_pi, not_imp],
+     exact ⟨i, hs, by simp [ht]⟩ }
+
+lemma univ_pi_eq_empty {i : ι} (ht : t i = ∅) : pi univ t = ∅ := pi_eq_empty (mem_univ i) ht
+
+lemma pi_nonempty_iff : (s.pi t).nonempty ↔ ∀ i, ∃ x, i ∈ s → x ∈ t i :=
+by simp [classical.skolem, set.nonempty]
+
+lemma univ_pi_nonempty_iff : (pi univ t).nonempty ↔ ∀ i, (t i).nonempty :=
+by simp [classical.skolem, set.nonempty]
+
+lemma pi_eq_empty_iff : s.pi t = ∅ ↔ ∃ i, (σ i → false) ∨ (i ∈ s ∧ t i = ∅) :=
+begin
+  rw [← not_nonempty_iff_eq_empty, pi_nonempty_iff], push_neg, apply exists_congr, intro i,
+  split,
+  { intro h, by_cases hα : nonempty (σ i),
+    { cases hα with x, refine or.inr ⟨(h x).1, by simp [eq_empty_iff_forall_not_mem, h]⟩ },
+    { exact or.inl (λ x, hα ⟨x⟩) }},
+  { rintro (h|h) x, exfalso, exact h x, simp [h] }
+end
+
+lemma univ_pi_eq_empty_iff : pi univ t = ∅ ↔ ∃ i, t i = ∅ :=
+by simp [← not_nonempty_iff_eq_empty, univ_pi_nonempty_iff]
+
+@[simp] lemma univ_pi_empty [h : nonempty ι] : pi univ (λ i, ∅ : Π i, set (σ i)) = ∅ :=
+univ_pi_eq_empty_iff.2 $ h.elim $ λ x, ⟨x, rfl⟩
+
+@[simp] lemma range_dcomp {β : ι → Type*} (f : Π i, σ i → β i) :
+  range (λ (g : Π i, σ i), (λ i, f i (g i))) = pi univ (λ i, range (f i)) :=
+begin
+  apply subset.antisymm,
+  { rintro _ ⟨x, rfl⟩ i -,
+    exact ⟨x i, rfl⟩ },
+  { intros x hx,
+    choose y hy using hx,
+    exact ⟨λ i, y i trivial, funext $ λ i, hy i trivial⟩ }
+end
+
+@[simp] lemma insert_pi (i : ι) (s : set ι) (t : Π i, set (σ i)) :
+  pi (insert i s) t = (eval i ⁻¹' t i) ∩ pi s t :=
+by { ext, simp [pi, or_imp_distrib, forall_and_distrib] }
+
+@[simp] lemma singleton_pi (i : ι) (t : Π i, set (σ i)) : pi {i} t = (eval i ⁻¹' t i) :=
+by { ext, simp [pi] }
+
+lemma singleton_pi' (i : ι) (t : Π i, set (σ i)) : pi {i} t = {x | x i ∈ t i} :=
+singleton_pi i t
+
+lemma pi_if {p : ι → Prop} [h : decidable_pred p] (s : set ι) (t₁ t₂ : Π i, set (σ i)) :
+  pi s (λ i, if p i then t₁ i else t₂ i) = pi {i ∈ s | p i} t₁ ∩ pi {i ∈ s | ¬ p i} t₂ :=
+begin
+  ext f,
+  split,
+  { assume h, split; { rintro i ⟨his, hpi⟩, simpa [*] using h i } },
+  { rintro ⟨ht₁, ht₂⟩ i his,
+    by_cases p i; simp * at * }
+end
+
+lemma union_pi : (s ∪ s₁).pi t = s.pi t ∩ s₁.pi t :=
+by simp [pi, or_imp_distrib, forall_and_distrib, set_of_and]
+
+@[simp] lemma pi_inter_compl (s : set ι) : pi s t ∩ pi sᶜ t = pi univ t :=
+by rw [← union_pi, union_compl_self]
+
+lemma pi_update_of_not_mem [decidable_eq ι] {β : Π i, Type*} {i : ι} (hi : i ∉ s) (f : Π j, α j)
+  (a : σ i) (t : Π j, α j → set (β j)) :
+  s.pi (λ j, t j (update f i a j)) = s.pi (λ j, t j (f j)) :=
+pi_congr rfl $ λ j hj, by { rw update_noteq, exact λ h, hi (h ▸ hj) }
+
+lemma pi_update_of_mem [decidable_eq ι] {β : Π i, Type*} {i : ι} (hi : i ∈ s) (f : Π j, α j)
+  (a : σ i) (t : Π j, α j → set (β j)) :
+  s.pi (λ j, t j (update f i a j)) = {x | x i ∈ t i a} ∩ (s \ {i}).pi (λ j, t j (f j)) :=
+calc s.pi (λ j, t j (update f i a j)) = ({i} ∪ s \ {i}).pi (λ j, t j (update f i a j)) :
+  by rw [union_diff_self, union_eq_self_of_subset_left (singleton_subset_iff.2 hi)]
+... = {x | x i ∈ t i a} ∩ (s \ {i}).pi (λ j, t j (f j)) :
+  by { rw [union_pi, singleton_pi', update_same, pi_update_of_not_mem], simp }
+
+lemma univ_pi_update [decidable_eq ι] {β : Π i, Type*} (i : ι) (f : Π j, α j)
+  (a : σ i) (t : Π j, α j → set (β j)) :
+  pi univ (λ j, t j (update f i a j)) = {x | x i ∈ t i a} ∩ pi {i}ᶜ (λ j, t j (f j)) :=
+by rw [compl_eq_univ_diff, ← pi_update_of_mem (mem_univ _)]
+
+lemma univ_pi_update_univ [decidable_eq ι] (i : ι) (s : set (σ i)) :
+  pi univ (update (λ j : ι, (univ : set (α j))) i s) = eval i ⁻¹' s :=
+by rw [univ_pi_update i (λ j, (univ : set (α j))) s (λ j t, t), pi_univ, inter_univ, preimage]
+
+open_locale classical
+
+lemma eval_image_pi {i : ι} (hs : i ∈ s) (ht : (s.pi t).nonempty) : eval i '' s.pi t = t i :=
+begin
+  ext x, rcases ht with ⟨f, hf⟩, split,
+  { rintro ⟨g, hg, rfl⟩, exact hg i hs },
+  { intro hg, refine ⟨update f i x, _, by simp⟩,
+    intros j hj, by_cases hji : j = i,
+    { subst hji, simp [hg] },
+    { rw [mem_pi] at hf, simp [hji, hf, hj] }},
+end
+
+@[simp] lemma eval_image_univ_pi {i : ι} (ht : (pi univ t).nonempty) :
+  (λ f : Π i, σ i, f i) '' pi univ t = t i :=
+eval_image_pi (mem_univ i) ht
+
+lemma eval_preimage {ι} {α : ι → Type*} {i : ι} {s : set (σ i)} :
+  eval i ⁻¹' s = pi univ (update (λ i, univ) i s) :=
+by { ext x, simp [@forall_update_iff _ (λ i, set (σ i)) _ _ _ _ (λ i' y, x i' ∈ y)] }
+
+lemma eval_preimage' {ι} {α : ι → Type*} {i : ι} {s : set (σ i)} :
+  eval i ⁻¹' s = pi {i} (update (λ i, univ) i s) :=
+by { ext, simp }
+
+lemma update_preimage_pi {i : ι} {f : Π i, σ i} (hi : i ∈ s) (hf : ∀ j ∈ s, j ≠ i → f j ∈ t j) :
+  (update f i) ⁻¹' s.pi t = t i :=
+begin
+  ext x, split,
+  { intro h, convert h i hi, simp },
+  { intros hx j hj, by_cases h : j = i,
+    { cases h, simpa },
+    { rw [update_noteq h], exact hf j hj h }}
+end
+
+lemma update_preimage_univ_pi {i : ι} {f : Π i, σ i} (hf : ∀ j ≠ i, f j ∈ t j) :
+  (update f i) ⁻¹' pi univ t = t i :=
+update_preimage_pi (mem_univ i) (λ j _, hf j)
+
+lemma subset_pi_eval_image (s : set ι) (u : set (Π i, σ i)) : u ⊆ pi s (λ i, eval i '' u) :=
+λ f hf i hi, ⟨f, hf, rfl⟩
+
+lemma univ_pi_ite (s : set ι) (t : Π i, set (σ i)) :
+  pi univ (λ i, if i ∈ s then t i else univ) = s.pi t :=
+by { ext, simp_rw [mem_univ_pi], apply forall_congr, intro i, split_ifs; simp [h] }
+
+end pi
+end set

--- a/src/data/set/prod.lean
+++ b/src/data/set/prod.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2017 Mario Carneiro. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Mario Carneiro, Johannes Hölzl
+Authors: Mario Carneiro, Johannes Hölzl, Patrick Massot
 -/
 import data.set.basic
 

--- a/src/topology/algebra/nonarchimedean/basic.lean
+++ b/src/topology/algebra/nonarchimedean/basic.lean
@@ -3,10 +3,9 @@ Copyright (c) 2021 Ashwin Iyengar. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Kevin Buzzard, Johan Commelin, Ashwin Iyengar, Patrick Massot
 -/
-import topology.algebra.ring
-import topology.algebra.open_subgroup
-import data.set.basic
 import group_theory.subgroup.basic
+import topology.algebra.open_subgroup
+import topology.algebra.ring
 
 /-!
 # Nonarchimedean Topology

--- a/test/lift.lean
+++ b/test/lift.lean
@@ -1,6 +1,5 @@
-import tactic.lift
-import data.set.basic
 import data.int.basic
+import tactic.lift
 
 /-! Some tests of the `lift` tactic. -/
 


### PR DESCRIPTION
This moves `set.prod`, `set.pi` and `set.diagonal` from `data.set.basic` to a new file `data.set.prod`.

I'm crediting
* Mario for `set.prod` from bd013e8089378e8057dc7e93c9eaf2c8ebaf25a2
* Johannes for `set.pi` from da7bbd7fc2c80a785f7992bb7751304f6cafe235
* Patrick for `set.diagonal` from #3118

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
