### PR TITLE
[Merged by Bors] - feat(tactic/itauto): add support for [decidable p] assumptions

### DIFF
--- a/src/tactic/itauto.lean
+++ b/src/tactic/itauto.lean
@@ -572,6 +572,9 @@ meta def apply_proof : name_map expr → proof → tactic unit
   e ← intro_core `_, let n := e.local_uniq_name,
   apply_proof (Γ.insert n e) (p.app (proof.intro x (proof.hyp n)))
 
+end itauto
+
+open itauto
 
 /-- A decision procedure for intuitionistic propositional logic.
 
@@ -639,11 +642,8 @@ using_new_ref mk_name_map $ λ hs, do
   end,
   hs ← read_ref hs, apply_proof hs p
 
-end itauto
-
 namespace interactive
 setup_tactic_parser
-open itauto
 
 /-- A decision procedure for intuitionistic propositional logic. Unlike `finish` and `tauto!` this
 tactic never uses the law of excluded middle (without the `!` option), and the proof search is
@@ -661,9 +661,9 @@ find among the atomic propositions, and `itauto! *` will case on all proposition
 -/
 meta def itauto (classical : parse (tk "!")?)
   : parse (some <$> pexpr_list <|> none <$ tk "*")? → tactic unit
-| none := tactic.itauto.itauto false classical.is_some []
-| (some none) := tactic.itauto.itauto true classical.is_some []
-| (some (some ls)) := ls.mmap i_to_expr >>= tactic.itauto.itauto false classical.is_some
+| none := tactic.itauto false classical.is_some []
+| (some none) := tactic.itauto true classical.is_some []
+| (some (some ls)) := ls.mmap i_to_expr >>= tactic.itauto false classical.is_some
 
 add_hint_tactic "itauto"
 

--- a/src/tactic/itauto.lean
+++ b/src/tactic/itauto.lean
@@ -562,6 +562,9 @@ tactic never uses the law of excluded middle, and the proof search is tailored f
 ```lean
 example (p : Prop) : ¬ (p ↔ ¬ p) := by itauto
 ```
+
+Using `itauto!` allows the use of LEM in proofs, which turns this into a complete decision
+procedure for classical propositional logic. It still uses intuitionistic rules when it can.
 -/
 meta def itauto (dec : parse (tk "!")?) : tactic unit :=
 using_new_ref mk_buffer $ λ atoms,

--- a/src/tactic/itauto.lean
+++ b/src/tactic/itauto.lean
@@ -159,6 +159,8 @@ end
 /-- A reified inductive proof type for intuitionistic propositional logic. -/
 @[derive has_reflect]
 inductive proof
+-- ⊢ A, causes failure during reconstruction
+| «sorry» : proof
 -- (n: A) ⊢ A
 | hyp (n : name) : proof
 -- ⊢ ⊤
@@ -214,6 +216,7 @@ instance : inhabited proof := ⟨proof.triv⟩
 
 /-- Debugging printer for proof objects. -/
 meta def proof.to_format : proof → format
+| proof.sorry := "sorry"
 | (proof.hyp i) := to_fmt i
 | proof.triv := "triv"
 | (proof.exfalso' p) := format!"(exfalso {p.to_format})"
@@ -309,8 +312,8 @@ meta def proof.check : name_map prop → proof → option prop
 -/
 
 /-- Get a new name in the pattern `h0, h1, h2, ...` -/
-@[inline] meta def fresh_name {m} [monad m] : state_t ℕ m name :=
-⟨λ n, pure (mk_simple_name ("h" ++ to_string n), n+1)⟩
+@[inline] meta def fresh_name : ℕ → name × ℕ :=
+λ n, (mk_simple_name ("h" ++ to_string n), n+1)
 
 /-- The context during proof search is a map from propositions to proof values. -/
 meta def context := native.rb_map prop proof
@@ -347,12 +350,26 @@ meta def context.add : prop → proof → context → except (prop → proof) co
 /-- Add `A` to the context `Γ` with proof `p`. This version of `context.add` takes a continuation
 and a target proposition `B`, so that in the case that `⊥` is found we can skip the continuation
 and just prove `B` outright. -/
-@[inline] meta def context.with_add {m} [monad m] (Γ : context) (A : prop) (p : proof)
-  (B : prop) (f : context → prop → m proof) : m proof :=
+@[inline] meta def context.with_add (Γ : context) (A : prop) (p : proof)
+  (B : prop) (f : context → prop → ℕ → bool × proof × ℕ) (n : ℕ) : bool × proof × ℕ :=
 match Γ.add A p with
-| except.ok Γ_A := f Γ_A B
-| except.error p := pure (p B)
+| except.ok Γ_A := f Γ_A B n
+| except.error p := (tt, p B, n)
 end
+
+/-- Map a function over the proof (regardless of whether the proof is successful or not). -/
+def map_proof (f : proof → proof) : bool × proof × ℕ → bool × proof × ℕ
+| (b, p, n) := (b, f p, n)
+
+/-- Convert a value-with-success to an optional value. -/
+def is_ok {α} : bool × α → option α
+| (ff, p) := none
+| (tt, p) := some p
+
+/-- Skip the continuation and return a failed proof if the boolean is false. -/
+def when_ok : bool → (ℕ → bool × proof × ℕ) → ℕ → bool × proof × ℕ
+| ff f n := (ff, proof.sorry, n)
+| tt f n := f n
 
 /-- The search phase, which deals with the level 3 rules, which are rules that are not validity
 preserving and so require proof search. One obvious one is the or-introduction rule: we prove
@@ -365,33 +382,38 @@ prove `A₁ → A₂`, which can be written `A₂ → C, A₁ ⊢ A₂` (where w
 `(A₁ → A₂) → C`), and one to use the consequent, `C ⊢ B`. The search here is that there are
 potentially many implications to split like this, and we have to try all of them if we want to be
 complete. -/
-meta def search (prove : context → prop → state_t ℕ option proof) :
-  context → prop → state_t ℕ option proof
-| Γ B := match Γ.find B with
-  | some p := pure p
+meta def search (prove : context → prop → ℕ → bool × proof × ℕ) :
+  context → prop → ℕ → bool × proof × ℕ
+| Γ B n := match Γ.find B with
+  | some p := (tt, p, n)
   | none :=
-    ⟨λ n, Γ.fold none $ λ A p r, match r with
-      | some r := some r
-      | none := match A with
-        | prop.imp A' C := match Γ.find A' with
-          | some q := (context.with_add (Γ.erase A) C (p.app q) B prove).1 n
-          | none := match A' with
-            | prop.imp A₁ A₂ :=
-              (do
-              { let Γ : context := Γ.erase A,
-                a ← fresh_name,
-                p₁ ← Γ.with_add A₁ (proof.hyp a) A₂ $ λ Γ_A₁ A₂,
-                  Γ_A₁.with_add (prop.imp A₂ C) (proof.imp_imp_simp a p) A₂ prove,
-                Γ.with_add C (p.app (proof.intro a p₁)) B prove } : state_t ℕ option proof).1 n
-            | _ := none
-            end
+    let search₁ := Γ.fold none $ λ A p r, match r with
+    | some r := some r
+    | none := match A with
+      | prop.imp A' C := match Γ.find A' with
+        | some q := is_ok $ context.with_add (Γ.erase A) C (p.app q) B prove n
+        | none := match A' with
+          | prop.imp A₁ A₂ := do
+            let Γ : context := Γ.erase A,
+            let (a, n) := fresh_name n,
+            (p₁, n) ← is_ok $ Γ.with_add A₁ (proof.hyp a) A₂ (λ Γ_A₁ A₂,
+              Γ_A₁.with_add (prop.imp A₂ C) (proof.imp_imp_simp a p) A₂ prove) n,
+            is_ok $ Γ.with_add C (p.app (proof.intro a p₁)) B prove n
+          | _ := none
           end
-        | _ := none
         end
-      end⟩ <|>
-    match B with
-    | prop.or B₁ B₂ := proof.or_inl <$> prove Γ B₁ <|> proof.or_inr <$> prove Γ B₂
-    | _ := failure
+      | _ := none
+      end
+    end in
+    match search₁ with
+    | some r := (tt, r)
+    | none := match B with
+      | prop.or B₁ B₂ := match map_proof proof.or_inl (prove Γ B₁ n) with
+        | (ff, _) := map_proof proof.or_inr (prove Γ B₂ n)
+        | r := r
+        end
+      | _ := (ff, proof.sorry, n)
+      end
     end
   end
 
@@ -410,26 +432,25 @@ handle. The rule `Γ ⊢ A ∧ B` is a level 2 rule, also handled here. If none 
 the level 2 rule `A ∨ B ⊢ C` by searching the context and splitting all ors we find. Finally, if
 we don't make any more progress, we go to the search phase.
 -/
-meta def prove : context → prop → state_t ℕ option proof
-| Γ prop.true := pure proof.triv
-| Γ (prop.imp A B) := do
-  a ← fresh_name,
-  proof.intro a <$> Γ.with_add A (proof.hyp a) B prove
-| Γ (prop.and' ak A B) := do
-  let (A, B) := ak.sides A B,
-  p ← prove Γ A,
-  q ← prove Γ B,
-  pure (p.and_intro ak q)
-| Γ B := Γ.fold (λ b Γ, cond b prove (search prove) Γ B) (λ A p IH b Γ,
+meta def prove : context → prop → ℕ → bool × proof × ℕ
+| Γ prop.true n := (tt, proof.triv, n)
+| Γ (prop.imp A B) n :=
+  let (a, n) := fresh_name n in
+  map_proof (proof.intro a) $ Γ.with_add A (proof.hyp a) B prove n
+| Γ (prop.and' ak A B) n :=
+  let (A, B) := ak.sides A B in
+  let (b, p, n) := prove Γ A n in
+  map_proof (p.and_intro ak) $ when_ok b (prove Γ B) n
+| Γ B n := Γ.fold (λ b Γ, cond b prove (search prove) Γ B) (λ A p IH b Γ n,
     match A with
-    | prop.or A₁ A₂ := do
-      let Γ : context := Γ.erase A,
-      a ← fresh_name,
-      p₁ ← Γ.with_add A₁ (proof.hyp a) B (λ Γ _, IH tt Γ),
-      p₂ ← Γ.with_add A₂ (proof.hyp a) B (λ Γ _, IH tt Γ),
-      pure (proof.or_elim p a p₁ p₂)
-    | _ := IH b Γ
-    end) ff Γ
+    | prop.or A₁ A₂ :=
+      let Γ : context := Γ.erase A in
+      let (a, n) := fresh_name n in
+      let (b, p₁, n) := Γ.with_add A₁ (proof.hyp a) B (λ Γ _, IH tt Γ) n in
+      map_proof (proof.or_elim p a p₁) $
+        when_ok b (Γ.with_add A₂ (proof.hyp a) B (λ Γ _, IH tt Γ)) n
+    | _ := IH b Γ n
+    end) ff Γ n
 
 /-- Reifies an atomic or otherwise unrecognized proposition. If it is defeq to a proposition we
 have already allocated, we reuse it, otherwise we name it with a new index. -/
@@ -463,6 +484,7 @@ meta def reify (atoms : ref (buffer expr)) : expr → tactic prop
 annoying because `applyc` gets the arguments wrong sometimes so we have to use `to_expr` instead.)
 -/
 meta def apply_proof : name_map expr → proof → tactic unit
+| Γ proof.sorry := fail "itauto failed"
 | Γ (proof.hyp n) := do e ← Γ.find n, exact e
 | Γ proof.triv := triv
 | Γ (proof.exfalso' p) := do
@@ -550,6 +572,73 @@ meta def apply_proof : name_map expr → proof → tactic unit
   e ← intro_core `_, let n := e.local_uniq_name,
   apply_proof (Γ.insert n e) (p.app (proof.intro x (proof.hyp n)))
 
+
+/-- A decision procedure for intuitionistic propositional logic.
+
+* `use_dec` will add `a ∨ ¬ a` to the context for every decidable atomic proposition `a`.
+* `use_classical` will allow `a ∨ ¬ a` to be added even if the proposition is not decidable,
+  using classical logic.
+* `extra_dec` will add `a ∨ ¬ a` to the context for specified (not necessarily atomic)
+  propositions `a`.
+-/
+meta def itauto (use_dec use_classical : bool) (extra_dec : list expr) : tactic unit :=
+using_new_ref mk_buffer $ λ atoms,
+using_new_ref mk_name_map $ λ hs, do
+  t ← target,
+  t ← mcond (is_prop t) (reify atoms t) (tactic.exfalso $> prop.false),
+  hyps ← local_context,
+  (Γ, decs) ← hyps.mfoldl
+    (λ (Γ : except (prop → proof) context × native.rb_map prop (bool × expr)) h, do
+      e ← infer_type h,
+      mcond (is_prop e)
+        (do A ← reify atoms e,
+          let n := h.local_uniq_name,
+          read_ref hs >>= λ Γ, write_ref hs (Γ.insert n h),
+          pure (Γ.1 >>= λ Γ', Γ'.add A (proof.hyp n), Γ.2))
+        (match e with
+        | `(decidable %%p) :=
+          if use_dec then do
+            A ← reify atoms p,
+            let n := h.local_uniq_name,
+            pure (Γ.1, Γ.2.insert A (ff, h))
+          else pure Γ
+        | _ := pure Γ
+        end))
+    (except.ok native.mk_rb_map, native.mk_rb_map),
+  let add_dec (force : bool) (decs : native.rb_map prop (bool × expr)) (e : expr) := (do
+    A ← reify atoms e,
+    dec_e ← mk_app ``decidable [e],
+    res ← try_core (mk_instance dec_e),
+    if res.is_none ∧ ¬ use_classical then
+      if force then do
+        m ← mk_meta_var dec_e,
+        set_goals [m] >> apply_instance >> failure
+      else pure decs
+    else
+      pure (native.rb_map.insert decs A (res.elim (tt, e) (prod.mk ff)))),
+  decs ← extra_dec.mfoldl (add_dec tt) decs,
+  decs ← if use_dec then do
+    let decided := match Γ with
+    | except.ok Γ := Γ.fold native.mk_rb_set $ λ p _ m, match p with
+      | prop.var i := m.insert i
+      | prop.not (prop.var i) := m.insert i
+      | _ := m
+      end
+    | except.error _ := native.mk_rb_set
+    end,
+    read_ref atoms >>= λ ats, ats.2.iterate (pure decs) $ λ i e r,
+      if decided.contains i.1 then r else r >>= λ decs, add_dec ff decs e
+  else pure decs,
+  Γ ← decs.fold (pure Γ) (λ A ⟨cl, pf⟩ r, r >>= λ Γ, do
+    n ← mk_fresh_name,
+    read_ref hs >>= λ Γ, write_ref hs (Γ.insert n pf),
+    pure (Γ >>= λ Γ', Γ'.add (A.or A.not) (proof.em cl n))),
+  let p := match Γ with
+  | except.ok Γ := (prove Γ t 0).2.1
+  | except.error p := p t
+  end,
+  hs ← read_ref hs, apply_proof hs p
+
 end itauto
 
 namespace interactive
@@ -557,58 +646,24 @@ setup_tactic_parser
 open itauto
 
 /-- A decision procedure for intuitionistic propositional logic. Unlike `finish` and `tauto!` this
-tactic never uses the law of excluded middle, and the proof search is tailored for this use case.
+tactic never uses the law of excluded middle (without the `!` option), and the proof search is
+tailored for this use case. (`itauto!` will work as a classical SAT solver, but the algorithm is
+not very good in this situation.)
 
 ```lean
 example (p : Prop) : ¬ (p ↔ ¬ p) := by itauto
 ```
 
-Using `itauto!` allows the use of LEM in proofs, which turns this into a complete decision
-procedure for classical propositional logic. It still uses intuitionistic rules when it can.
+`itauto [a, b]` will additionally attempt case analysis on `a` and `b` assuming that it can derive
+`decidable a` and `decidable b`. `itauto *` will case on all decidable propositions that it can
+find among the atomic propositions, and `itauto! *` will case on all propositional atoms.
+*Warning:* This can blow up the proof search, so it should be used sparingly.
 -/
-meta def itauto (dec : parse (tk "!")?) : tactic unit :=
-using_new_ref mk_buffer $ λ atoms,
-using_new_ref mk_name_map $ λ hs, do
-  t ← target,
-  t ← mcond (is_prop t) (reify atoms t) (tactic.exfalso $> prop.false),
-  hyps ← local_context,
-  Γ ← hyps.mfoldl
-    (λ (Γ : except (prop → proof) context) h, do
-      e ← infer_type h,
-      mcond (is_prop e)
-        (do A ← reify atoms e,
-          let n := h.local_uniq_name,
-          read_ref hs >>= λ Γ, write_ref hs (Γ.insert n h),
-          pure (Γ >>= λ Γ', Γ'.add A (proof.hyp n)))
-        (match e with
-        | `(decidable %%p) := do
-          A ← reify atoms p,
-          let n := h.local_uniq_name,
-          read_ref hs >>= λ Γ, write_ref hs (Γ.insert n h),
-          pure (Γ >>= λ Γ', Γ'.add (A.or A.not) (proof.em ff n))
-        | _ := pure Γ
-        end))
-    (except.ok (native.rb_map.mk _ _)),
-  Γ ← read_ref atoms >>= λ ats, ats.2.iterate (pure Γ) (λ i e r, r >>= λ Γ, do
-    res ← try_core (mk_app ``decidable [e] >>= mk_instance),
-    let add_proof (cl : bool) pf := (do
-      n ← mk_fresh_name,
-      let A := prop.var i.1,
-      read_ref hs >>= λ Γ, write_ref hs (Γ.insert n pf),
-      pure (Γ >>= λ Γ', Γ'.add (A.or A.not) (proof.em cl n))),
-    match res with
-    | some (expr.local_const _ _ _ _) := pure Γ
-    | some pf := add_proof ff pf
-    | none := if dec.is_some then add_proof tt e else pure Γ
-    end),
-  let o := state_t.run (match Γ with
-  | except.ok Γ := prove Γ t
-  | except.error p := pure (p t)
-  end) 0,
-  match o with
-  | none := fail "itauto failed"
-  | some (p, _) := do hs ← read_ref hs, apply_proof hs p
-  end
+meta def itauto (classical : parse (tk "!")?)
+  : parse (some <$> pexpr_list <|> none <$ tk "*")? → tactic unit
+| none := tactic.itauto.itauto false classical.is_some []
+| (some none) := tactic.itauto.itauto true classical.is_some []
+| (some (some ls)) := ls.mmap i_to_expr >>= tactic.itauto.itauto false classical.is_some
 
 add_hint_tactic "itauto"
 

--- a/test/itauto.lean
+++ b/test/itauto.lean
@@ -50,6 +50,9 @@ example (xl yl zl xr yr zr : Prop) :
     xl ∧ (yl ∧ zl ∨ yr ∧ zr) ∨ xr ∧ (yl ∧ zr ∨ yr ∧ zl) :=
 by itauto
 
+example : 0 < 1 ∨ ¬ 0 < 1 := by itauto
+example (p : Prop) (h : 0 < 1 → p) (h2 : ¬ 0 < 1 → p) : p := by itauto
+
 -- failure tests
 example (p q r : Prop) : true :=
 begin

--- a/test/itauto.lean
+++ b/test/itauto.lean
@@ -25,7 +25,7 @@ example (p : Prop) : p ∨ false ↔ p := by itauto
 example (p q : Prop) (h0 : q) : p → q := by itauto
 example (p q r : Prop) : p ∨ (q ∧ r) → (p ∨ q) ∧ (r ∨ p ∨ r) := by itauto
 example (p q r : Prop) : p ∨ (q ∧ r) → (p ∨ q) ∧ (r ∨ p ∨ r) := by itauto
--- example (p q r : Prop) (h : p) : (p → q ∨ r) → q ∨ r := by itauto
+example (p q r : Prop) (h : p) : (p → q ∨ r) → q ∨ r := by itauto
 example (p q : Prop) (h : ¬ (p ↔ q)) (h' : p) : ¬ q := by itauto
 example (p q : Prop) (h : ¬ (p ↔ q)) (h' : q) : ¬ p := by itauto
 example (p q : Prop) (h : ¬ (p ↔ q)) (h' : ¬ q) (h'' : ¬ p) : false := by itauto
@@ -42,7 +42,7 @@ example (p : Prop) (em : p ∨ ¬ p) : ¬ (p ↔ ¬ p) := by itauto
 
 example (p : Prop) [decidable p] : p ∨ ¬ p := by itauto
 example (p : Prop) [decidable p] : ¬ (p ↔ ¬ p) := by itauto
--- example (p q r : Prop) [decidable p] : (p → (q ∨ r)) → ((p → q) ∨ (p → r)) := by itauto
+example (p q r : Prop) [decidable p] : (p → (q ∨ r)) → ((p → q) ∨ (p → r)) := by itauto
 example (p q r : Prop) [decidable q] : (p → (q ∨ r)) → ((p → q) ∨ (p → r)) := by itauto
 
 example (xl yl zl xr yr zr : Prop) :

--- a/test/itauto.lean
+++ b/test/itauto.lean
@@ -25,6 +25,7 @@ example (p : Prop) : p ∨ false ↔ p := by itauto
 example (p q : Prop) (h0 : q) : p → q := by itauto
 example (p q r : Prop) : p ∨ (q ∧ r) → (p ∨ q) ∧ (r ∨ p ∨ r) := by itauto
 example (p q r : Prop) : p ∨ (q ∧ r) → (p ∨ q) ∧ (r ∨ p ∨ r) := by itauto
+-- example (p q r : Prop) (h : p) : (p → q ∨ r) → q ∨ r := by itauto
 example (p q : Prop) (h : ¬ (p ↔ q)) (h' : p) : ¬ q := by itauto
 example (p q : Prop) (h : ¬ (p ↔ q)) (h' : q) : ¬ p := by itauto
 example (p q : Prop) (h : ¬ (p ↔ q)) (h' : ¬ q) (h'' : ¬ p) : false := by itauto
@@ -38,6 +39,11 @@ example (p q r : Prop) (h : ¬ (p ↔ q)) (h' : r ↔ q) : ¬ (p ↔ r) := by it
 example (p : Prop) : p → ¬ (p → ¬ p) := by itauto
 
 example (p : Prop) (em : p ∨ ¬ p) : ¬ (p ↔ ¬ p) := by itauto
+
+example (p : Prop) [decidable p] : p ∨ ¬ p := by itauto
+example (p : Prop) [decidable p] : ¬ (p ↔ ¬ p) := by itauto
+-- example (p q r : Prop) [decidable p] : (p → (q ∨ r)) → ((p → q) ∨ (p → r)) := by itauto
+example (p q r : Prop) [decidable q] : (p → (q ∨ r)) → ((p → q) ∨ (p → r)) := by itauto
 
 example (xl yl zl xr yr zr : Prop) :
   (xl ∧ yl ∨ xr ∧ yr) ∧ zl ∨ (xl ∧ yr ∨ xr ∧ yl) ∧ zr ↔

--- a/test/itauto.lean
+++ b/test/itauto.lean
@@ -53,6 +53,9 @@ by itauto
 example : 0 < 1 ∨ ¬ 0 < 1 := by itauto
 example (p : Prop) (h : 0 < 1 → p) (h2 : ¬ 0 < 1 → p) : p := by itauto
 
+example (b : bool) : ¬ b ∨ b := by itauto
+example (p : Prop) : ¬ p ∨ p := by itauto!
+
 -- failure tests
 example (p q r : Prop) : true :=
 begin

--- a/test/itauto.lean
+++ b/test/itauto.lean
@@ -40,21 +40,22 @@ example (p : Prop) : p → ¬ (p → ¬ p) := by itauto
 
 example (p : Prop) (em : p ∨ ¬ p) : ¬ (p ↔ ¬ p) := by itauto
 
-example (p : Prop) [decidable p] : p ∨ ¬ p := by itauto
+example (p : Prop) [decidable p] : p ∨ ¬ p := by itauto*
 example (p : Prop) [decidable p] : ¬ (p ↔ ¬ p) := by itauto
-example (p q r : Prop) [decidable p] : (p → (q ∨ r)) → ((p → q) ∨ (p → r)) := by itauto
-example (p q r : Prop) [decidable q] : (p → (q ∨ r)) → ((p → q) ∨ (p → r)) := by itauto
+example (p q r : Prop) [decidable p] : (p → (q ∨ r)) → ((p → q) ∨ (p → r)) := by itauto*
+example (p q r : Prop) [decidable q] : (p → (q ∨ r)) → ((p → q) ∨ (p → r)) := by itauto [q]
 
 example (xl yl zl xr yr zr : Prop) :
   (xl ∧ yl ∨ xr ∧ yr) ∧ zl ∨ (xl ∧ yr ∨ xr ∧ yl) ∧ zr ↔
     xl ∧ (yl ∧ zl ∨ yr ∧ zr) ∨ xr ∧ (yl ∧ zr ∨ yr ∧ zl) :=
 by itauto
 
-example : 0 < 1 ∨ ¬ 0 < 1 := by itauto
-example (p : Prop) (h : 0 < 1 → p) (h2 : ¬ 0 < 1 → p) : p := by itauto
+example : 0 < 1 ∨ ¬ 0 < 1 := by itauto*
+example (p : Prop) (h : 0 < 1 → p) (h2 : ¬ 0 < 1 → p) : p := by itauto*
 
-example (b : bool) : ¬ b ∨ b := by itauto
-example (p : Prop) : ¬ p ∨ p := by itauto!
+example (b : bool) : ¬ b ∨ b := by itauto*
+example (p : Prop) : ¬ p ∨ p := by itauto! [p]
+example (p : Prop) : ¬ p ∨ p := by itauto!*
 
 -- failure tests
 example (p q r : Prop) : true :=


### PR DESCRIPTION
This allows proving theorems like the following, which use excluded middle selectively through `decidable` assumptions:
```
example (p q r : Prop) [decidable p] : (p → (q ∨ r)) → ((p → q) ∨ (p → r)) := by itauto
```
This also fixes a bug in the proof search order of the original itauto implementation causing nontermination in one of the new tests, which also makes the "big test" at the end run instantly.

Also adds a `!` option to enable decidability for all propositions using classical logic.

Because adding decidability instances can be expensive for proof search, they are disabled by default. You can specify specific decidable instances to add by `itauto [p, q]`, or use `itauto*` which adds all decidable atoms. (The `!` option is useless on its own, and should be combined with `*` or `[p]` options.)