### PR TITLE
[Merged by Bors] - chore(order): rename `preorder_hom` to `order_hom`

### DIFF
--- a/src/algebra/lie/solvable.lean
+++ b/src/algebra/lie/solvable.lean
@@ -5,7 +5,7 @@ Authors: Oliver Nash
 -/
 import algebra.lie.ideal_operations
 import algebra.lie.abelian
-import order.preorder_hom
+import order.order_hom
 
 /-!
 # Solvable Lie algebras

--- a/src/algebraic_topology/cech_nerve.lean
+++ b/src/algebraic_topology/cech_nerve.lean
@@ -44,7 +44,7 @@ def cech_nerve : simplicial_object C :=
 { obj := λ n, wide_pullback f.right
     (λ i : ulift (fin (n.unop.len + 1)), f.left) (λ i, f.hom),
   map := λ m n g, wide_pullback.lift (wide_pullback.base _)
-    (λ i, wide_pullback.π (λ i, f.hom) $ ulift.up $ g.unop.to_preorder_hom i.down) $ λ j, by simp,
+    (λ i, wide_pullback.π (λ i, f.hom) $ ulift.up $ g.unop.to_order_hom i.down) $ λ j, by simp,
   map_id' := λ x, by { ext ⟨⟩, { simpa }, { simp } },
   map_comp' := λ x y z f g, by { ext ⟨⟩, { simpa }, { simp } } }
 
@@ -200,7 +200,7 @@ def cech_conerve : cosimplicial_object C :=
 { obj := λ n, wide_pushout f.left
     (λ i : ulift (fin (n.len + 1)), f.right) (λ i, f.hom),
   map := λ m n g, wide_pushout.desc (wide_pushout.head _)
-    (λ i, wide_pushout.ι (λ i, f.hom) $ ulift.up $ g.to_preorder_hom i.down) $
+    (λ i, wide_pushout.ι (λ i, f.hom) $ ulift.up $ g.to_order_hom i.down) $
     λ i, by { rw [wide_pushout.arrow_ι (λ i, f.hom)] },
   map_id' := λ x, by { ext ⟨⟩, { simpa }, { simp } },
   map_comp' := λ x y z f g, by { ext ⟨⟩, { simpa }, { simp } } }

--- a/src/algebraic_topology/simplex_category.lean
+++ b/src/algebraic_topology/simplex_category.lean
@@ -25,7 +25,7 @@ We provide the following functions to work with these objects:
   Use the notation `[n]` in the `simplicial` locale.
 2. `simplex_category.len` gives the "length" of an object of `simplex_category`, as a natural.
 3. `simplex_category.hom.mk` makes a morphism out of a monotone map between `fin`'s.
-4. `simplex_category.hom.to_preorder_hom` gives the underlying monotone map associated to a
+4. `simplex_category.hom.to_order_hom` gives the underlying monotone map associated to a
   term of `simplex_category.hom`.
 
 -/
@@ -75,36 +75,36 @@ def mk {a b : simplex_category.{u}} (f : fin (a.len + 1) →ₘ fin (b.len + 1))
 ulift.up f
 
 /-- Recover the monotone map from a morphism in the simplex category. -/
-def to_preorder_hom {a b : simplex_category.{u}} (f : simplex_category.hom a b) :
+def to_order_hom {a b : simplex_category.{u}} (f : simplex_category.hom a b) :
   fin (a.len + 1) →ₘ fin (b.len + 1) :=
 ulift.down f
 
 @[ext] lemma ext {a b : simplex_category.{u}} (f g : simplex_category.hom a b) :
-  f.to_preorder_hom = g.to_preorder_hom → f = g := ulift.ext _ _
+  f.to_order_hom = g.to_order_hom → f = g := ulift.ext _ _
 
-@[simp] lemma mk_to_preorder_hom {a b : simplex_category.{u}}
-  (f : simplex_category.hom a b) : mk (f.to_preorder_hom) = f :=
+@[simp] lemma mk_to_order_hom {a b : simplex_category.{u}}
+  (f : simplex_category.hom a b) : mk (f.to_order_hom) = f :=
 by {cases f, refl}
 
-@[simp] lemma to_preorder_hom_mk {a b : simplex_category.{u}}
-  (f : fin (a.len + 1) →ₘ fin (b.len + 1)) : (mk f).to_preorder_hom = f :=
-by simp [to_preorder_hom, mk]
+@[simp] lemma to_order_hom_mk {a b : simplex_category.{u}}
+  (f : fin (a.len + 1) →ₘ fin (b.len + 1)) : (mk f).to_order_hom = f :=
+by simp [to_order_hom, mk]
 
-lemma mk_to_preorder_hom_apply {a b : simplex_category.{u}}
+lemma mk_to_order_hom_apply {a b : simplex_category.{u}}
   (f : fin (a.len + 1) →ₘ fin (b.len + 1)) (i : fin (a.len + 1)) :
-  (mk f).to_preorder_hom i = f i := rfl
+  (mk f).to_order_hom i = f i := rfl
 
 /-- Identity morphisms of `simplex_category`. -/
 @[simp]
 def id (a : simplex_category.{u}) :
   simplex_category.hom a a :=
-mk preorder_hom.id
+mk order_hom.id
 
 /-- Composition of morphisms of `simplex_category`. -/
 @[simp]
 def comp {a b c : simplex_category.{u}} (f : simplex_category.hom b c)
   (g : simplex_category.hom a b) : simplex_category.hom a c :=
-mk $ f.to_preorder_hom.comp g.to_preorder_hom
+mk $ f.to_order_hom.comp g.to_order_hom
 
 end hom
 
@@ -120,7 +120,7 @@ def const (x : simplex_category.{u}) (i : fin (x.len+1)) : [0] ⟶ x :=
 
 @[simp]
 lemma const_comp (x y : simplex_category.{u}) (i : fin (x.len + 1)) (f : x ⟶ y) :
-  const x i ≫ f = const y (f.to_preorder_hom i) := rfl
+  const x i ≫ f = const y (f.to_order_hom i) := rfl
 
 /--
 Make a morphism `[n] ⟶ [m]` from a monotone map between fin's.
@@ -148,7 +148,7 @@ one given by the following generators and relations.
 
 /-- The `i`-th face map from `[n]` to `[n+1]` -/
 def δ {n} (i : fin (n+2)) : [n] ⟶ [n+1] :=
-mk_hom (fin.succ_above i).to_preorder_hom
+mk_hom (fin.succ_above i).to_order_hom
 
 /-- The `i`-th degeneracy map from `[n+1]` to `[n]` -/
 def σ {n} (i : fin (n+1)) : [n+1] ⟶ [n] := mk_hom
@@ -161,11 +161,11 @@ lemma δ_comp_δ {n} {i j : fin (n+2)} (H : i ≤ j) :
 begin
   ext k,
   dsimp [δ, fin.succ_above],
-  simp only [order_embedding.to_preorder_hom_coe,
+  simp only [order_embedding.to_order_hom_coe,
     order_embedding.coe_of_strict_mono,
     function.comp_app,
-    simplex_category.hom.to_preorder_hom_mk,
-    preorder_hom.comp_coe],
+    simplex_category.hom.to_order_hom_mk,
+    order_hom.comp_coe],
   rcases i with ⟨i, _⟩,
   rcases j with ⟨j, _⟩,
   rcases k with ⟨k, _⟩,
@@ -317,7 +317,7 @@ of `NonemptyFinLinOrd` -/
 def skeletal_functor : simplex_category.{u} ⥤ NonemptyFinLinOrd.{v} :=
 { obj := λ a, NonemptyFinLinOrd.of $ ulift (fin (a.len + 1)),
   map := λ a b f,
-    ⟨λ i, ulift.up (f.to_preorder_hom i.down), λ i j h, f.to_preorder_hom.monotone h⟩,
+    ⟨λ i, ulift.up (f.to_order_hom i.down), λ i j h, f.to_order_hom.monotone h⟩,
   map_id' := λ a, by { ext, simp, },
   map_comp' := λ a b c f g, by { ext, simp, }, }
 
@@ -406,7 +406,7 @@ section concrete
 instance : concrete_category.{0} simplex_category.{u} :=
 { forget :=
   { obj := λ i, fin (i.len + 1),
-    map := λ i j f, f.to_preorder_hom },
+    map := λ i j f, f.to_order_hom },
   forget_faithful := {} }
 
 end concrete
@@ -416,13 +416,13 @@ section epi_mono
 /-- A morphism in `simplex_category` is a monomorphism precisely when it is an injective function
 -/
 theorem mono_iff_injective {n m : simplex_category.{u}} {f : n ⟶ m} :
-  mono f ↔ function.injective f.to_preorder_hom :=
+  mono f ↔ function.injective f.to_order_hom :=
 begin
   split,
   { introsI m x y h,
     have H : const n x ≫ f = const n y ≫ f,
     { dsimp, rw h },
-    change (n.const x).to_preorder_hom 0 = (n.const y).to_preorder_hom 0,
+    change (n.const x).to_order_hom 0 = (n.const y).to_order_hom 0,
     rw cancel_mono f at H,
     rw H },
   { exact concrete_category.mono_of_injective f }
@@ -431,7 +431,7 @@ end
 /-- A morphism in `simplex_category` is an epimorphism if and only if it is a surjective function
 -/
 lemma epi_iff_surjective {n m : simplex_category.{u}} {f: n ⟶ m} :
-  epi f ↔ function.surjective f.to_preorder_hom :=
+  epi f ↔ function.surjective f.to_order_hom :=
 begin
   split,
   { introsI hyp_f_epi x,
@@ -463,7 +463,7 @@ begin
       simp [le_iff_lt_or_eq, h_ab x_1] },
     -- We now just have to show the two auxiliary functions are not equal.
     rw category_theory.cancel_epi f at f_comp_chi_i, rename f_comp_chi_i eq_chi_i,
-    apply_fun (λ e, e.to_preorder_hom x) at eq_chi_i,
+    apply_fun (λ e, e.to_order_hom x) at eq_chi_i,
     suffices : (0 : fin 2) = 1, by exact bot_ne_top this,
     simpa using eq_chi_i },
   { exact concrete_category.epi_of_surjective f }
@@ -474,9 +474,9 @@ lemma len_le_of_mono {x y : simplex_category.{u}} {f : x ⟶ y} :
   mono f → (x.len ≤ y.len) :=
 begin
   intro hyp_f_mono,
-  have f_inj : function.injective f.to_preorder_hom.to_fun,
+  have f_inj : function.injective f.to_order_hom.to_fun,
   { exact mono_iff_injective.elim_left (hyp_f_mono) },
-  simpa using fintype.card_le_of_injective f.to_preorder_hom.to_fun f_inj,
+  simpa using fintype.card_le_of_injective f.to_order_hom.to_fun f_inj,
 end
 
 lemma le_of_mono {n m : ℕ} {f : [n] ⟶ [m]} : (category_theory.mono f) → (n ≤ m) :=
@@ -487,9 +487,9 @@ lemma len_le_of_epi {x y : simplex_category.{u}} {f : x ⟶ y} :
   epi f → y.len ≤ x.len :=
 begin
   intro hyp_f_epi,
-  have f_surj : function.surjective f.to_preorder_hom.to_fun,
+  have f_surj : function.surjective f.to_order_hom.to_fun,
   { exact epi_iff_surjective.elim_left (hyp_f_epi) },
-  simpa using fintype.card_le_of_surjective f.to_preorder_hom.to_fun f_surj,
+  simpa using fintype.card_le_of_surjective f.to_order_hom.to_fun f_surj,
 end
 
 lemma le_of_epi {n m : ℕ} {f : [n] ⟶ [m]} : epi f → (m ≤ n) :=

--- a/src/algebraic_topology/simplicial_set.lean
+++ b/src/algebraic_topology/simplicial_set.lean
@@ -56,15 +56,15 @@ section
 
 /-- The `m`-simplices of the `n`-th standard simplex are
 the monotone maps from `fin (m+1)` to `fin (n+1)`. -/
-def as_preorder_hom {n} {m} (α : Δ[n].obj m) :
-  preorder_hom (fin (m.unop.len+1)) (fin (n+1)) := α.to_preorder_hom
+def as_order_hom {n} {m} (α : Δ[n].obj m) :
+  order_hom (fin (m.unop.len+1)) (fin (n+1)) := α.to_order_hom
 end
 
 /-- The boundary `∂Δ[n]` of the `n`-th standard simplex consists of
 all `m`-simplices of `standard_simplex n` that are not surjective
 (when viewed as monotone function `m → n`). -/
 def boundary (n : ℕ) : sSet :=
-{ obj := λ m, {α : Δ[n].obj m // ¬ function.surjective (as_preorder_hom α)},
+{ obj := λ m, {α : Δ[n].obj m // ¬ function.surjective (as_order_hom α)},
   map := λ m₁ m₂ f α, ⟨f.unop ≫ (α : Δ[n].obj m₁),
   by { intro h, apply α.property, exact function.surjective.of_comp h }⟩ }
 
@@ -81,7 +81,7 @@ for which the union of `{i}` and the range of `α` is not all of `n`
 (when viewing `α` as monotone function `m → n`). -/
 def horn (n : ℕ) (i : fin (n+1)) : sSet :=
 { obj := λ m,
-  { α : Δ[n].obj m // set.range (as_preorder_hom α) ∪ {i} ≠ set.univ },
+  { α : Δ[n].obj m // set.range (as_order_hom α) ∪ {i} ≠ set.univ },
   map := λ m₁ m₂ f α, ⟨f.unop ≫ (α : Δ[n].obj m₁),
   begin
     intro h, apply α.property,

--- a/src/control/lawful_fix.lean
+++ b/src/control/lawful_fix.lean
@@ -138,7 +138,7 @@ begin
     apply' le_ωSup_of_le i.succ,
     dsimp [approx], refl', },
   { apply ωSup_le _ _ _,
-    simp only [fix.approx_chain, preorder_hom.coe_fun_mk],
+    simp only [fix.approx_chain, order_hom.coe_fun_mk],
     intros y x, apply approx_le_fix f },
 end
 
@@ -146,7 +146,7 @@ lemma fix_le {X : Π a, part $ β a} (hX : f X ≤ X) : part.fix f ≤ X :=
 begin
   rw fix_eq_ωSup f,
   apply ωSup_le _ _ _,
-  simp only [fix.approx_chain, preorder_hom.coe_fun_mk],
+  simp only [fix.approx_chain, order_hom.coe_fun_mk],
   intros i,
   induction i, dsimp [fix.approx], apply' bot_le,
   transitivity' f X, apply f.monotone i_ih,

--- a/src/data/finset/option.lean
+++ b/src/data/finset/option.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yury Kudryashov, Mario Carneiro, Sean Leather
 -/
 import data.finset.basic
-import order.preorder_hom
+import order.order_hom
 
 /-!
 # Finite sets in `option α`
@@ -70,7 +70,7 @@ by simp [insert_none]
 /-- Given `s : finset (option α)`, `s.erase_none : finset α` is the set of `x : α` such that
 `some x ∈ s`. -/
 def erase_none : finset (option α) →ₘ finset α :=
-(finset.map_embedding (equiv.option_is_some_equiv α).to_embedding).to_preorder_hom.comp
+(finset.map_embedding (equiv.option_is_some_equiv α).to_embedding).to_order_hom.comp
   ⟨finset.subtype _, subtype_mono⟩
 
 @[simp] lemma mem_erase_none {s : finset (option α)} {x : α} :

--- a/src/linear_algebra/eigenspace.lean
+++ b/src/linear_algebra/eigenspace.lean
@@ -7,7 +7,7 @@ Authors: Alexander Bentkamp
 import field_theory.is_alg_closed.basic
 import linear_algebra.finsupp
 import linear_algebra.matrix.to_lin
-import order.preorder_hom
+import order.order_hom
 import linear_algebra.charpoly.basic
 
 /-!
@@ -405,7 +405,7 @@ lemma has_generalized_eigenvalue_of_has_eigenvalue
   f.has_generalized_eigenvalue μ k :=
 begin
   apply has_generalized_eigenvalue_of_has_generalized_eigenvalue_of_le hk,
-  rw [has_generalized_eigenvalue, generalized_eigenspace, preorder_hom.coe_fun_mk, pow_one],
+  rw [has_generalized_eigenvalue, generalized_eigenspace, order_hom.coe_fun_mk, pow_one],
   exact hμ,
 end
 
@@ -445,7 +445,7 @@ lemma generalized_eigenspace_restrict
   generalized_eigenspace (linear_map.restrict f hfp) μ k =
     submodule.comap p.subtype (f.generalized_eigenspace μ k) :=
 begin
-  simp only [generalized_eigenspace, preorder_hom.coe_fun_mk, ← linear_map.ker_comp],
+  simp only [generalized_eigenspace, order_hom.coe_fun_mk, ← linear_map.ker_comp],
   induction k with k ih,
   { rw [pow_zero, pow_zero, linear_map.one_eq_id],
     apply (submodule.ker_subtype _).symm },
@@ -473,7 +473,7 @@ begin
         (f.generalized_eigenspace μ (finrank K V))
       = ((f - algebra_map _ _ μ) ^ finrank K V *
           (f - algebra_map K (End K V) μ) ^ finrank K V).ker :
-        by { simpa only [generalized_eigenspace, preorder_hom.coe_fun_mk, ← linear_map.ker_comp] }
+        by { simpa only [generalized_eigenspace, order_hom.coe_fun_mk, ← linear_map.ker_comp] }
   ... = f.generalized_eigenspace μ (finrank K V + finrank K V) :
         by { rw ←pow_add, refl }
   ... = f.generalized_eigenspace μ (finrank K V) :

--- a/src/order/category/Preorder.lean
+++ b/src/order/category/Preorder.lean
@@ -5,7 +5,7 @@ Authors: Johan Commelin
 -/
 import category_theory.concrete_category.bundled_hom
 import algebra.punit_instances
-import order.preorder_hom
+import order.order_hom
 
 /-! # Category of preorders -/
 
@@ -16,11 +16,11 @@ def Preorder := bundled preorder
 
 namespace Preorder
 
-instance : bundled_hom @preorder_hom :=
-{ to_fun := @preorder_hom.to_fun,
-  id := @preorder_hom.id,
-  comp := @preorder_hom.comp,
-  hom_ext := @preorder_hom.ext }
+instance : bundled_hom @order_hom :=
+{ to_fun := @order_hom.to_fun,
+  id := @order_hom.id,
+  comp := @order_hom.comp,
+  hom_ext := @order_hom.ext }
 
 attribute [derive [large_category, concrete_category]] Preorder
 

--- a/src/order/category/omega_complete_partial_order.lean
+++ b/src/order/category/omega_complete_partial_order.lean
@@ -60,7 +60,7 @@ namespace has_products
 
 /-- The pi-type gives a cone for a product. -/
 def product {J : Type v} (f : J → ωCPO.{v}) : fan f :=
-fan.mk (of (Π j, f j)) (λ j, continuous_hom.of_mono (pi.eval_preorder_hom j) (λ c, rfl))
+fan.mk (of (Π j, f j)) (λ j, continuous_hom.of_mono (pi.eval_order_hom j) (λ c, rfl))
 
 /-- The pi-type is a limit cone for the product. -/
 def is_product (J : Type v) (f : J → ωCPO) : is_limit (product f) :=
@@ -97,7 +97,7 @@ namespace has_equalizers
 def equalizer_ι {α β : Type*} [omega_complete_partial_order α] [omega_complete_partial_order β]
   (f g : α →𝒄 β) :
   {a : α // f a = g a} →𝒄 α :=
-continuous_hom.of_mono (preorder_hom.subtype.val _) (λ c, rfl)
+continuous_hom.of_mono (order_hom.subtype.val _) (λ c, rfl)
 
 /-- A construction of the equalizer fork. -/
 def equalizer {X Y : ωCPO.{v}} (f g : X ⟶ Y) :

--- a/src/order/closure.lean
+++ b/src/order/closure.lean
@@ -6,7 +6,7 @@ Authors: Bhavik Mehta, Yaël Dillies
 import data.set.lattice
 import data.set_like.basic
 import order.galois_connection
-import order.preorder_hom
+import order.order_hom
 import tactic.monotonicity
 
 /-!
@@ -65,7 +65,7 @@ instance [preorder α] : has_coe_to_fun (closure_operator α) (λ _, α → α) 
 /-- See Note [custom simps projection] -/
 def simps.apply [preorder α] (f : closure_operator α) : α → α := f
 
-initialize_simps_projections closure_operator (to_preorder_hom_to_fun → apply, -to_preorder_hom)
+initialize_simps_projections closure_operator (to_order_hom_to_fun → apply, -to_order_hom)
 
 section partial_order
 variable [partial_order α]
@@ -73,7 +73,7 @@ variable [partial_order α]
 /-- The identity function as a closure operator. -/
 @[simps]
 def id : closure_operator α :=
-{ to_preorder_hom := preorder_hom.id,
+{ to_order_hom := order_hom.id,
   le_closure' := λ _, le_rfl,
   idempotent' := λ _, rfl }
 

--- a/src/order/fixed_points.lean
+++ b/src/order/fixed_points.lean
@@ -3,7 +3,7 @@ Copyright (c) 2017 Johannes Hölzl. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl, Kenny Lau, Yury Kudryashov
 -/
-import order.preorder_hom
+import order.order_hom
 import dynamics.fixed_points.basic
 
 /-!
@@ -13,11 +13,11 @@ This file sets up the basic theory of fixed points of a monotone function in a c
 
 ## Main definitions
 
-* `preorder_hom.lfp`: The least fixed point of a bundled monotone function.
-* `preorder_hom.gfp`: The greatest fixed point of a bundled monotone function.
-* `preorder_hom.prev_fixed`: The greatest fixed point of a bundled monotone function smaller than or
+* `order_hom.lfp`: The least fixed point of a bundled monotone function.
+* `order_hom.gfp`: The greatest fixed point of a bundled monotone function.
+* `order_hom.prev_fixed`: The greatest fixed point of a bundled monotone function smaller than or
   equal to a given element.
-* `preorder_hom.next_fixed`: The least fixed point of a bundled monotone function greater than or
+* `order_hom.next_fixed`: The least fixed point of a bundled monotone function greater than or
   equal to a given element.
 * `fixed_points.complete_lattice`: The Knaster-Tarski theorem: fixed points of a monotone
   self-map of a complete lattice form themselves a complete lattice.
@@ -32,7 +32,7 @@ variables {α : Type u} {β : Type v} {γ : Type w}
 
 open function (fixed_points is_fixed_pt)
 
-namespace preorder_hom
+namespace order_hom
 
 section basic
 
@@ -139,8 +139,8 @@ end
 
 lemma gfp_gfp (h : α →ₘ α →ₘ α) :
   gfp (gfp.comp h) = gfp h.on_diag :=
-@lfp_lfp (order_dual α) _ $ (preorder_hom.dual_iso (order_dual α)
-  (order_dual α)).symm.to_order_embedding.to_preorder_hom.comp h.dual
+@lfp_lfp (order_dual α) _ $ (order_hom.dual_iso (order_dual α)
+  (order_dual α)).symm.to_order_embedding.to_order_hom.comp h.dual
 
 end eqn
 
@@ -203,11 +203,11 @@ le_Inf $ λ x hx, (hA hx) ▸ (f.mono $ Inf_le hx)
 
 end prev_next
 
-end preorder_hom
+end order_hom
 
 namespace fixed_points
 
-open preorder_hom
+open order_hom
 
 variables [complete_lattice α] (f : α →ₘ α)
 

--- a/src/order/omega_complete_partial_order.lean
+++ b/src/order/omega_complete_partial_order.lean
@@ -5,7 +5,7 @@ Authors: Simon Hudon
 -/
 import control.monad.basic
 import data.part
-import order.preorder_hom
+import order.order_hom
 import tactic.monotonicity
 import tactic.wlog
 
@@ -57,7 +57,7 @@ universes u v
 local attribute [-simp] part.bind_eq_bind part.map_eq_map
 open_locale classical
 
-namespace preorder_hom
+namespace order_hom
 
 variables (α : Type*) (β : Type*) {γ : Type*} {φ : Type*}
 variables [preorder α] [preorder β] [preorder γ] [preorder φ]
@@ -79,7 +79,7 @@ def bind {β γ} (f : α →ₘ part β) (g : α →ₘ β → part γ) : α →
     refine ⟨b, f.monotone h _ hb, g.monotone h _ _ ha⟩,
   end }
 
-end preorder_hom
+end order_hom
 
 namespace omega_complete_partial_order
 
@@ -94,7 +94,7 @@ namespace chain
 variables {α : Type u} {β : Type v} {γ : Type*}
 variables [preorder α] [preorder β] [preorder γ]
 
-instance : has_coe_to_fun (chain α) (λ _, ℕ → α) := preorder_hom.has_coe_to_fun
+instance : has_coe_to_fun (chain α) (λ _, ℕ → α) := order_hom.has_coe_to_fun
 
 instance [inhabited α] : inhabited (chain α) :=
 ⟨ ⟨ λ _, default _, λ _ _ _, le_refl _ ⟩ ⟩
@@ -125,8 +125,8 @@ lemma mem_map_iff {b : β} : b ∈ c.map f ↔ ∃ a, a ∈ c ∧ f a = b :=
 ⟨ exists_of_mem_map _, λ h, by { rcases h with ⟨w,h,h'⟩, subst b, apply mem_map c _ h, } ⟩
 
 @[simp]
-lemma map_id : c.map preorder_hom.id = c :=
-preorder_hom.comp_id _
+lemma map_id : c.map order_hom.id = c :=
+order_hom.comp_id _
 
 lemma map_comp : (c.map f).map g = c.map (g.comp f) := rfl
 
@@ -137,7 +137,7 @@ lemma map_le_map {g : α →ₘ β} (h : f ≤ g) : c.map f ≤ c.map g :=
 /-- `chain.zip` pairs up the elements of two chains that have the same index -/
 @[simps]
 def zip (c₀ : chain α) (c₁ : chain β) : chain (α × β) :=
-preorder_hom.prod c₀ c₁
+order_hom.prod c₀ c₁
 
 end chain
 
@@ -210,8 +210,8 @@ def subtype {α : Type*} [omega_complete_partial_order α] (p : α → Prop)
   (hp : ∀ (c : chain α), (∀ i ∈ c, p i) → p (ωSup c)) :
   omega_complete_partial_order (subtype p) :=
 omega_complete_partial_order.lift
-  (preorder_hom.subtype.val p)
-  (λ c, ⟨ωSup _, hp (c.map (preorder_hom.subtype.val p)) (λ i ⟨n, q⟩, q.symm ▸ (c n).2)⟩)
+  (order_hom.subtype.val p)
+  (λ c, ⟨ωSup _, hp (c.map (order_hom.subtype.val p)) (λ i ⟨n, q⟩, q.symm ▸ (c n).2)⟩)
   (λ x y h, h)
   (λ c, rfl)
 
@@ -250,7 +250,7 @@ lemma continuous'.to_bundled (f : α → β) (hf : continuous' f) :
 
 variables (f : α →ₘ β) (g : β →ₘ γ)
 
-lemma continuous_id : continuous (@preorder_hom.id α _) :=
+lemma continuous_id : continuous (@order_hom.id α _) :=
 by intro; rw c.map_id; refl
 
 lemma continuous_comp (hfc : continuous f) (hgc : continuous g) : continuous (g.comp f):=
@@ -262,11 +262,11 @@ end
 lemma id_continuous' : continuous' (@id α) :=
 continuous_id.of_bundled' _
 
-lemma continuous_const (x : β) : continuous (preorder_hom.const α x) :=
+lemma continuous_const (x : β) : continuous (order_hom.const α x) :=
 λ c, eq_of_forall_ge_iff $ λ z, by simp [ωSup_le_iff]
 
 lemma const_continuous' (x: β) : continuous' (function.const α x) :=
-continuous.of_bundled' (preorder_hom.const α x) (continuous_const x)
+continuous.of_bundled' (order_hom.const α x) (continuous_const x)
 
 end continuity
 
@@ -340,7 +340,7 @@ variables {α : Type*} {β : α → Type*} {γ : Type*}
 open omega_complete_partial_order omega_complete_partial_order.chain
 
 instance [∀a, omega_complete_partial_order (β a)] : omega_complete_partial_order (Πa, β a) :=
-{ ωSup    := λc a, ωSup (c.map (pi.eval_preorder_hom a)),
+{ ωSup    := λc a, ωSup (c.map (pi.eval_order_hom a)),
   ωSup_le := assume c f hf a, ωSup_le _ _ $ by { rintro i, apply hf },
   le_ωSup := assume c i x, le_ωSup_of_le _ $ le_refl _ }
 
@@ -377,14 +377,14 @@ variables [omega_complete_partial_order γ]
 /-- The supremum of a chain in the product `ω`-CPO. -/
 @[simps]
 protected def ωSup (c : chain (α × β)) : α × β :=
-(ωSup (c.map preorder_hom.fst), ωSup (c.map preorder_hom.snd))
+(ωSup (c.map order_hom.fst), ωSup (c.map order_hom.snd))
 
 @[simps ωSup_fst ωSup_snd]
 instance : omega_complete_partial_order (α × β) :=
 { ωSup := prod.ωSup,
   ωSup_le := λ c ⟨x,x'⟩ h, ⟨ωSup_le _ _ $ λ i, (h i).1, ωSup_le _ _ $ λ i, (h i).2⟩,
   le_ωSup := λ c i,
-    ⟨le_ωSup (c.map preorder_hom.fst) i, le_ωSup (c.map preorder_hom.snd) i⟩ }
+    ⟨le_ωSup (c.map order_hom.fst) i, le_ωSup (c.map order_hom.snd) i⟩ }
 
 end prod
 
@@ -397,9 +397,9 @@ of arbitrary suprema. -/
 @[priority 100] -- see Note [lower instance priority]
 instance [complete_lattice α] : omega_complete_partial_order α :=
 { ωSup    := λc, ⨆ i, c i,
-  ωSup_le := λ ⟨c, _⟩ s hs, by simp only [supr_le_iff, preorder_hom.coe_fun_mk] at ⊢ hs;
+  ωSup_le := λ ⟨c, _⟩ s hs, by simp only [supr_le_iff, order_hom.coe_fun_mk] at ⊢ hs;
     intros i; apply hs i,
-  le_ωSup := assume ⟨c, _⟩ i, by simp only [preorder_hom.coe_fun_mk]; apply le_supr_of_le i; refl }
+  le_ωSup := assume ⟨c, _⟩ i, by simp only [order_hom.coe_fun_mk]; apply le_supr_of_le i; refl }
 
 variables {α} {β : Type v} [omega_complete_partial_order α] [complete_lattice β]
 open omega_complete_partial_order
@@ -410,7 +410,7 @@ begin
   intro c,
   apply eq_of_forall_ge_iff, intro z,
   simp only [inf_le_iff, hf c, hg c, ωSup_le_iff, ←forall_or_distrib_left, ←forall_or_distrib_right,
-             function.comp_app, chain.map_coe, preorder_hom.has_inf_inf_coe],
+             function.comp_app, chain.map_coe, order_hom.has_inf_inf_coe],
   split,
   { introv h, apply h },
   { intros h i j,
@@ -454,7 +454,7 @@ lemma top_continuous :
 begin
   intro c, apply eq_of_forall_ge_iff, intro z,
   simp only [ωSup_le_iff, forall_const, chain.map_coe, (∘), function.const,
-             preorder_hom.has_top_top, preorder_hom.const_coe_coe],
+             order_hom.has_top_top, order_hom.const_coe_coe],
 end
 
 lemma bot_continuous :
@@ -474,48 +474,48 @@ variables [omega_complete_partial_order α] [omega_complete_partial_order β]
 variables [omega_complete_partial_order γ] [omega_complete_partial_order φ]
 variables [omega_complete_partial_order α'] [omega_complete_partial_order β']
 
-namespace preorder_hom
+namespace order_hom
 
 /-- The `ωSup` operator for monotone functions. -/
 @[simps]
 protected def ωSup (c : chain (α →ₘ β)) : α →ₘ β :=
-{ to_fun := λ a, ωSup (c.map (preorder_hom.apply a)),
+{ to_fun := λ a, ωSup (c.map (order_hom.apply a)),
   monotone' := λ x y h, ωSup_le_ωSup_of_le (chain.map_le_map _ $ λ a, a.monotone h) }
 
 @[simps ωSup_coe]
 instance omega_complete_partial_order : omega_complete_partial_order (α →ₘ β) :=
-omega_complete_partial_order.lift preorder_hom.coe_fn_hom preorder_hom.ωSup
+omega_complete_partial_order.lift order_hom.coe_fn_hom order_hom.ωSup
   (λ x y h, h) (λ c, rfl)
 
-end preorder_hom
+end order_hom
 
 section
 variables (α β)
 
 /-- A monotone function on `ω`-continuous partial orders is said to be continuous
 if for every chain `c : chain α`, `f (⊔ i, c i) = ⊔ i, f (c i)`.
-This is just the bundled version of `preorder_hom.continuous`. -/
-structure continuous_hom extends preorder_hom α β :=
-(cont : continuous (preorder_hom.mk to_fun monotone'))
+This is just the bundled version of `order_hom.continuous`. -/
+structure continuous_hom extends order_hom α β :=
+(cont : continuous (order_hom.mk to_fun monotone'))
 
-attribute [nolint doc_blame] continuous_hom.to_preorder_hom
+attribute [nolint doc_blame] continuous_hom.to_order_hom
 
 infixr ` →𝒄 `:25 := continuous_hom -- Input: \r\MIc
 
-instance : has_coe_to_fun (α →𝒄 β) (λ _, α → β) := ⟨λ f, f.to_preorder_hom.to_fun⟩
+instance : has_coe_to_fun (α →𝒄 β) (λ _, α → β) := ⟨λ f, f.to_order_hom.to_fun⟩
 
 instance : has_coe (α →𝒄 β) (α →ₘ β) :=
-{ coe :=  continuous_hom.to_preorder_hom }
+{ coe :=  continuous_hom.to_order_hom }
 
 instance : partial_order (α →𝒄 β) :=
-partial_order.lift (λ f, f.to_preorder_hom.to_fun) $ by rintro ⟨⟨⟩⟩ ⟨⟨⟩⟩ h; congr; exact h
+partial_order.lift (λ f, f.to_order_hom.to_fun) $ by rintro ⟨⟨⟩⟩ ⟨⟨⟩⟩ h; congr; exact h
 
 /-- See Note [custom simps projection]. We need to specify this projection explicitly in this case,
   because it is a composition of multiple projections. -/
 def continuous_hom.simps.apply (h : α →𝒄 β) : α → β := h
 
 initialize_simps_projections continuous_hom
-  (to_preorder_hom_to_fun → apply, -to_preorder_hom)
+  (to_order_hom_to_fun → apply, -to_order_hom)
 
 end
 
@@ -530,7 +530,7 @@ congr_arg (λ x : α, f x) h
 protected lemma monotone (f : α →𝒄 β) : monotone f := f.monotone'
 
 @[mono] lemma apply_mono {f g : α →𝒄 β} {x y : α} (h₁ : f ≤ g) (h₂ : x ≤ y) : f x ≤ g y :=
-preorder_hom.apply_mono (show (f : α →ₘ β) ≤ g, from h₁) h₂
+order_hom.apply_mono (show (f : α →ₘ β) ≤ g, from h₁) h₂
 
 lemma ite_continuous' {p : Prop} [hp : decidable p] (f g : α → β)
   (hf : continuous' f) (hg : continuous' g) : continuous' (λ x, if p then f x else g x) :=
@@ -540,23 +540,23 @@ lemma ωSup_bind {β γ : Type v} (c : chain α) (f : α →ₘ part β) (g : α
   ωSup (c.map (f.bind g)) = ωSup (c.map f) >>= ωSup (c.map g) :=
 begin
   apply eq_of_forall_ge_iff, intro x,
-  simp only [ωSup_le_iff, part.bind_le, chain.mem_map_iff, and_imp, preorder_hom.bind_coe,
+  simp only [ωSup_le_iff, part.bind_le, chain.mem_map_iff, and_imp, order_hom.bind_coe,
     exists_imp_distrib],
   split; intro h''',
   { intros b hb, apply ωSup_le _ _ _,
     rintros i y hy, simp only [part.mem_ωSup] at hb,
     rcases hb with ⟨j,hb⟩, replace hb := hb.symm,
-    simp only [part.eq_some_iff, chain.map_coe, function.comp_app, preorder_hom.apply_coe]
+    simp only [part.eq_some_iff, chain.map_coe, function.comp_app, order_hom.apply_coe]
       at hy hb,
     replace hb : b ∈ f (c (max i j))   := f.mono (c.mono (le_max_right i j)) _ hb,
     replace hy : y ∈ g (c (max i j)) b := g.mono (c.mono (le_max_left i j)) _ _ hy,
     apply h''' (max i j),
     simp only [exists_prop, part.bind_eq_bind, part.mem_bind_iff, chain.map_coe,
-               function.comp_app, preorder_hom.bind_coe],
+               function.comp_app, order_hom.bind_coe],
     exact ⟨_,hb,hy⟩, },
   { intros i, intros y hy,
     simp only [exists_prop, part.bind_eq_bind, part.mem_bind_iff, chain.map_coe,
-               function.comp_app, preorder_hom.bind_coe] at hy,
+               function.comp_app, order_hom.bind_coe] at hy,
     rcases hy with ⟨b,hb₀,hb₁⟩,
     apply h''' b _,
     { apply le_ωSup (c.map g) _ _ _ hb₁ },
@@ -567,7 +567,7 @@ lemma bind_continuous' {β γ : Type v} (f : α → part β) (g : α → β → 
   continuous' f → continuous' g →
   continuous' (λ x, f x >>= g x)
 | ⟨hf,hf'⟩ ⟨hg,hg'⟩ :=
-continuous.of_bundled' (preorder_hom.bind ⟨f,hf⟩ ⟨g,hg⟩)
+continuous.of_bundled' (order_hom.bind ⟨f,hf⟩ ⟨g,hg⟩)
   (by intro c; rw [ωSup_bind, ← hf', ← hg']; refl)
 
 lemma map_continuous' {β γ : Type v} (f : β → γ) (g : α → part β)
@@ -592,7 +592,7 @@ continuous_hom.cont _ _
 they are equal. -/
 @[simps, reducible]
 def of_fun (f : α → β) (g : α →𝒄 β) (h : f = g) : α →𝒄 β :=
-by refine {to_preorder_hom := {to_fun := f, ..}, ..}; subst h; rcases g with ⟨⟨⟩⟩; assumption
+by refine {to_order_hom := {to_fun := f, ..}, ..}; subst h; rcases g with ⟨⟨⟩⟩; assumption
 
 /-- Construct a continuous function from a monotone function with a proof of continuity. -/
 @[simps, reducible]
@@ -604,12 +604,12 @@ def of_mono (f : α →ₘ β) (h : ∀ c : chain α, f (ωSup c) = ωSup (c.map
 /-- The identity as a continuous function. -/
 @[simps]
 def id : α →𝒄 α :=
-of_mono preorder_hom.id continuous_id
+of_mono order_hom.id continuous_id
 
 /-- The composition of continuous functions. -/
 @[simps]
 def comp (f : β →𝒄 γ) (g : α →𝒄 β) : α →𝒄 γ :=
-of_mono (preorder_hom.comp (↑f) (↑g)) (continuous_comp _ _ g.cont f.cont)
+of_mono (order_hom.comp (↑f) (↑g)) (continuous_comp _ _ g.cont f.cont)
 
 @[ext]
 protected lemma ext (f g : α →𝒄 β) (h : ∀ x, f x = g x) : f = g :=
@@ -633,7 +633,7 @@ lemma coe_apply (a : α) (f : α →𝒄 β) : (f : α →ₘ β) a = f a := rfl
 
 /-- `function.const` is a continuous function. -/
 def const (x : β) : α →𝒄 β :=
-of_mono (preorder_hom.const _ x) (continuous_const x)
+of_mono (order_hom.const _ x) (continuous_const x)
 
 @[simp] theorem const_apply (f : β) (a : α) : const f a = f := rfl
 
@@ -690,8 +690,8 @@ continuous_hom.of_mono (ωSup $ c.map to_mono)
 begin
   intro c',
   apply eq_of_forall_ge_iff, intro z,
-  simp only [ωSup_le_iff, (c _).continuous, chain.map_coe, preorder_hom.apply_coe,
-    to_mono_coe, coe_apply, preorder_hom.omega_complete_partial_order_ωSup_coe,
+  simp only [ωSup_le_iff, (c _).continuous, chain.map_coe, order_hom.apply_coe,
+    to_mono_coe, coe_apply, order_hom.omega_complete_partial_order_ωSup_coe,
     forall_forall_merge, forall_forall_merge', (∘), function.eval],
 end
 
@@ -707,10 +707,10 @@ lemma ωSup_ωSup (c₀ : chain (α →𝒄 β)) (c₁ : chain α) :
 begin
   apply eq_of_forall_ge_iff, intro z,
   simp only [ωSup_le_iff, (c₀ _).continuous, chain.map_coe, to_mono_coe, coe_apply,
-    preorder_hom.omega_complete_partial_order_ωSup_coe, ωSup_def, forall_forall_merge,
-    chain.zip_coe, preorder_hom.prod_map_coe, preorder_hom.diag_coe, prod.map_mk,
-    preorder_hom.apply_coe, function.comp_app, prod.apply_coe,
-    preorder_hom.comp_coe, ωSup_apply, function.eval],
+    order_hom.omega_complete_partial_order_ωSup_coe, ωSup_def, forall_forall_merge,
+    chain.zip_coe, order_hom.prod_map_coe, order_hom.diag_coe, prod.map_mk,
+    order_hom.apply_coe, function.comp_app, prod.apply_coe,
+    order_hom.comp_coe, ωSup_apply, function.eval],
 end
 
 /-- A family of continuous functions yields a continuous family of functions. -/
@@ -724,8 +724,8 @@ def flip {α : Type*} (f : α → β →𝒄 γ) : β →𝒄 α → γ :=
 @[simps { rhs_md := reducible }]
 noncomputable def bind {β γ : Type v}
   (f : α →𝒄 part β) (g : α →𝒄 β → part γ) : α →𝒄 part γ :=
-of_mono (preorder_hom.bind (↑f) (↑g)) $ λ c, begin
-  rw [preorder_hom.bind, ← preorder_hom.bind, ωSup_bind, ← f.continuous, ← g.continuous],
+of_mono (order_hom.bind (↑f) (↑g)) $ λ c, begin
+  rw [order_hom.bind, ← order_hom.bind, ωSup_bind, ← f.continuous, ← g.continuous],
   refl
 end
 
@@ -733,8 +733,8 @@ end
 @[simps {rhs_md := reducible}]
 noncomputable def map {β γ : Type v} (f : β → γ) (g : α →𝒄 part β) : α →𝒄 part γ :=
 of_fun (λ x, f <$> g x) (bind g (const (pure ∘ f))) $
-by ext; simp only [map_eq_bind_pure_comp, bind_apply, preorder_hom.bind_coe, const_apply,
-  preorder_hom.const_coe_coe, coe_apply]
+by ext; simp only [map_eq_bind_pure_comp, bind_apply, order_hom.bind_coe, const_apply,
+  order_hom.const_coe_coe, coe_apply]
 
 /-- `part.seq` as a continuous function. -/
 @[simps {rhs_md := reducible}]
@@ -742,7 +742,7 @@ noncomputable def seq {β γ : Type v} (f : α →𝒄 part (β → γ)) (g : α
   α →𝒄 part γ :=
 of_fun (λ x, f x <*> g x) (bind f $ (flip $ _root_.flip map g))
   (by ext; simp only [seq_eq_bind_map, flip, part.bind_eq_bind, map_apply, part.mem_bind_iff,
-                      bind_apply, preorder_hom.bind_coe, coe_apply, flip_apply]; refl)
+                      bind_apply, order_hom.bind_coe, coe_apply, flip_apply]; refl)
 
 end continuous_hom
 

--- a/src/order/order_hom.lean
+++ b/src/order/order_hom.lean
@@ -17,43 +17,43 @@ homomorphism `f : α →ₘ β` is a function `α → β` along with a proof tha
 
 ## Main definitions
 
-In this file we define `preorder_hom α β` a.k.a. `α →ₘ β` to be a bundled monotone map.
+In this file we define `order_hom α β` a.k.a. `α →ₘ β` to be a bundled monotone map.
 
-We also define many `preorder_hom`s. In some cases we define two versions, one with `ₘ` suffix and
-one without it (e.g., `preorder_hom.compₘ` and `preorder_hom.comp`). This means that the former
+We also define many `order_hom`s. In some cases we define two versions, one with `ₘ` suffix and
+one without it (e.g., `order_hom.compₘ` and `order_hom.comp`). This means that the former
 function is a "more bundled" version of the latter. We can't just drop the "less bundled" version
 because the more bundled version usually does not work with dot notation.
 
-* `preorder_hom.id`: identity map as `α →ₘ α`;
-* `preorder_hom.curry`: an order isomorphism between `α × β →ₘ γ` and `α →ₘ β →ₘ γ`;
-* `preorder_hom.comp`: composition of two bundled monotone maps;
-* `preorder_hom.compₘ`: composition of bundled monotone maps as a bundled monotone map;
-* `preorder_hom.const`: constant function as a bundled monotone map;
-* `preorder_hom.prod`: combine `α →ₘ β` and `α →ₘ γ` into `α →ₘ β × γ`;
-* `preorder_hom.prodₘ`: a more bundled version of `preorder_hom.prod`;
-* `preorder_hom.prod_iso`: order isomorphism between `α →ₘ β × γ` and `(α →ₘ β) × (α →ₘ γ)`;
-* `preorder_hom.diag`: diagonal embedding of `α` into `α × α` as a bundled monotone map;
-* `preorder_hom.on_diag`: restrict a monotone map `α →ₘ α →ₘ β` to the diagonal;
-* `preorder_hom.fst`: projection `prod.fst : α × β → α` as a bundled monotone map;
-* `preorder_hom.snd`: projection `prod.snd : α × β → β` as a bundled monotone map;
-* `preorder_hom.prod_map`: `prod.map f g` as a bundled monotone map;
-* `pi.eval_preorder_hom`: evaluation of a function at a point `function.eval i` as a bundled
+* `order_hom.id`: identity map as `α →ₘ α`;
+* `order_hom.curry`: an order isomorphism between `α × β →ₘ γ` and `α →ₘ β →ₘ γ`;
+* `order_hom.comp`: composition of two bundled monotone maps;
+* `order_hom.compₘ`: composition of bundled monotone maps as a bundled monotone map;
+* `order_hom.const`: constant function as a bundled monotone map;
+* `order_hom.prod`: combine `α →ₘ β` and `α →ₘ γ` into `α →ₘ β × γ`;
+* `order_hom.prodₘ`: a more bundled version of `order_hom.prod`;
+* `order_hom.prod_iso`: order isomorphism between `α →ₘ β × γ` and `(α →ₘ β) × (α →ₘ γ)`;
+* `order_hom.diag`: diagonal embedding of `α` into `α × α` as a bundled monotone map;
+* `order_hom.on_diag`: restrict a monotone map `α →ₘ α →ₘ β` to the diagonal;
+* `order_hom.fst`: projection `prod.fst : α × β → α` as a bundled monotone map;
+* `order_hom.snd`: projection `prod.snd : α × β → β` as a bundled monotone map;
+* `order_hom.prod_map`: `prod.map f g` as a bundled monotone map;
+* `pi.eval_order_hom`: evaluation of a function at a point `function.eval i` as a bundled
   monotone map;
-* `preorder_hom.coe_fn_hom`: coercion to function as a bundled monotone map;
-* `preorder_hom.apply`: application of a `preorder_hom` at a point as a bundled monotone map;
-* `preorder_hom.pi`: combine a family of monotone maps `f i : α →ₘ π i` into a monotone map
+* `order_hom.coe_fn_hom`: coercion to function as a bundled monotone map;
+* `order_hom.apply`: application of a `order_hom` at a point as a bundled monotone map;
+* `order_hom.pi`: combine a family of monotone maps `f i : α →ₘ π i` into a monotone map
   `α →ₘ Π i, π i`;
-* `preorder_hom.pi_iso`: order isomorphism between `α →ₘ Π i, π i` and `Π i, α →ₘ π i`;
-* `preorder_hom.subtyle.val`: embedding `subtype.val : subtype p → α` as a bundled monotone map;
-* `preorder_hom.dual`: reinterpret a monotone map `α →ₘ β` as a monotone map
+* `order_hom.pi_iso`: order isomorphism between `α →ₘ Π i, π i` and `Π i, α →ₘ π i`;
+* `order_hom.subtyle.val`: embedding `subtype.val : subtype p → α` as a bundled monotone map;
+* `order_hom.dual`: reinterpret a monotone map `α →ₘ β` as a monotone map
   `order_dual α →ₘ order_dual β`;
-* `preorder_hom.dual_iso`: order isomorphism between `α →ₘ β` and
+* `order_hom.dual_iso`: order isomorphism between `α →ₘ β` and
   `order_dual (order_dual α →ₘ order_dual β)`;
 
 We also define two functions to convert other bundled maps to `α →ₘ β`:
 
-* `order_embedding.to_preorder_hom`: convert `α ↪o β` to `α →ₘ β`;
-* `rel_hom.to_preorder_hom`: conver a `rel_hom` between strict orders to a `preorder_hom`.
+* `order_embedding.to_order_hom`: convert `α ↪o β` to `α →ₘ β`;
+* `rel_hom.to_order_hom`: conver a `rel_hom` between strict orders to a `order_hom`.
 
 ## Tags
 
@@ -61,18 +61,18 @@ monotone map, bundled morphism
 -/
 
 /-- Bundled monotone (aka, increasing) function -/
-structure preorder_hom (α β : Type*) [preorder α] [preorder β] :=
+structure order_hom (α β : Type*) [preorder α] [preorder β] :=
 (to_fun   : α → β)
 (monotone' : monotone to_fun)
 
-infixr ` →ₘ `:25 := preorder_hom
+infixr ` →ₘ `:25 := order_hom
 
-namespace preorder_hom
+namespace order_hom
 variables {α β γ δ : Type*} [preorder α] [preorder β] [preorder γ] [preorder δ]
 
-instance : has_coe_to_fun (α →ₘ β) (λ _, α → β) := ⟨preorder_hom.to_fun⟩
+instance : has_coe_to_fun (α →ₘ β) (λ _, α → β) := ⟨order_hom.to_fun⟩
 
-initialize_simps_projections preorder_hom (to_fun → coe)
+initialize_simps_projections order_hom (to_fun → coe)
 
 protected lemma monotone (f : α →ₘ β) : monotone f := f.monotone'
 protected lemma mono (f : α →ₘ β) : monotone f := f.monotone
@@ -145,7 +145,7 @@ by { ext, refl }
 @[simp] lemma id_comp (f : α →ₘ β) : comp id f = f :=
 by { ext, refl }
 
-/-- Constant function bundled as a `preorder_hom`. -/
+/-- Constant function bundled as a `order_hom`. -/
 @[simps {fully_applied := ff}]
 def const (α : Type*) [preorder α] {β : Type*} [preorder β] : β →ₘ α →ₘ β :=
 { to_fun := λ b, ⟨function.const α b, λ _ _ _, le_rfl⟩,
@@ -157,7 +157,7 @@ def const (α : Type*) [preorder α] {β : Type*} [preorder β] : β →ₘ α �
   f.comp (const γ c) = const γ (f c) := rfl
 
 /-- Given two bundled monotone maps `f`, `g`, `f.prod g` is the map `x ↦ (f x, g x)` bundled as a
-`preorder_hom`. -/
+`order_hom`. -/
 @[simps] protected def prod (f : α →ₘ β) (g : α →ₘ γ) : α →ₘ (β × γ) :=
 ⟨λ x, (f x, g x), λ x y h, ⟨f.mono h, g.mono h⟩⟩
 
@@ -170,20 +170,20 @@ lemma comp_prod_comp_same (f₁ f₂ : β →ₘ γ) (g : α →ₘ β) :
 rfl
 
 /-- Given two bundled monotone maps `f`, `g`, `f.prod g` is the map `x ↦ (f x, g x)` bundled as a
-`preorder_hom`. This is a fully bundled version. -/
+`order_hom`. This is a fully bundled version. -/
 @[simps] def prodₘ : (α →ₘ β) →ₘ (α →ₘ γ) →ₘ α →ₘ β × γ :=
 curry ⟨λ f : (α →ₘ β) × (α →ₘ γ), f.1.prod f.2, λ f₁ f₂ h, prod_mono h.1 h.2⟩
 
-/-- Diagonal embedding of `α` into `α × α` as a `preorder_hom`. -/
+/-- Diagonal embedding of `α` into `α × α` as a `order_hom`. -/
 @[simps] def diag : α →ₘ α × α := id.prod id
 
 /-- Restriction of `f : α →ₘ α →ₘ β` to the diagonal. -/
 @[simps {simp_rhs := tt}] def on_diag (f : α →ₘ α →ₘ β) : α →ₘ β := (curry.symm f).comp diag
 
-/-- `prod.fst` as a `preorder_hom`. -/
+/-- `prod.fst` as a `order_hom`. -/
 @[simps] def fst : α × β →ₘ α := ⟨prod.fst, λ x y h, h.1⟩
 
-/-- `prod.snd` as a `preorder_hom`. -/
+/-- `prod.snd` as a `order_hom`. -/
 @[simps] def snd : α × β →ₘ β := ⟨prod.snd, λ x y h, h.2⟩
 
 @[simp] lemma fst_prod_snd : (fst : α × β →ₘ α).prod snd = id :=
@@ -202,15 +202,15 @@ of monotone maps to `β` and `γ`. -/
   right_inv := λ f, by ext; refl,
   map_rel_iff' := λ f g, forall_and_distrib.symm }
 
-/-- `prod.map` of two `preorder_hom`s as a `preorder_hom`. -/
+/-- `prod.map` of two `order_hom`s as a `order_hom`. -/
 @[simps] def prod_map (f : α →ₘ β) (g : γ →ₘ δ) : α × γ →ₘ β × δ :=
 ⟨prod.map f g, λ x y h, ⟨f.mono h.1, g.mono h.2⟩⟩
 
 variables {ι : Type*} {π : ι → Type*} [Π i, preorder (π i)]
 
-/-- Evaluation of an unbundled function at a point (`function.eval`) as a `preorder_hom`. -/
+/-- Evaluation of an unbundled function at a point (`function.eval`) as a `order_hom`. -/
 @[simps {fully_applied := ff}]
-def _root_.pi.eval_preorder_hom (i : ι) : (Π j, π j) →ₘ π i :=
+def _root_.pi.eval_order_hom (i : ι) : (Π j, π j) →ₘ π i :=
 ⟨function.eval i, function.monotone_eval i⟩
 
 /-- The "forgetful functor" from `α →ₘ β` to `α → β` that takes the underlying function,
@@ -220,9 +220,9 @@ is monotone. -/
   monotone' := λ x y h, h }
 
 /-- Function application `λ f, f a` (for fixed `a`) is a monotone function from the
-monotone function space `α →ₘ β` to `β`. See also `pi.eval_preorder_hom`.  -/
+monotone function space `α →ₘ β` to `β`. See also `pi.eval_order_hom`.  -/
 @[simps {fully_applied := ff}] def apply (x : α) : (α →ₘ β) →ₘ β :=
-(pi.eval_preorder_hom x).comp coe_fn_hom
+(pi.eval_order_hom x).comp coe_fn_hom
 
 /-- Construct a bundled monotone map `α →ₘ Π i, π i` from a family of monotone maps
 `f i : α →ₘ π i`. -/
@@ -232,7 +232,7 @@ monotone function space `α →ₘ β` to `β`. See also `pi.eval_preorder_hom`.
 /-- Order isomorphism between bundled monotone maps `α →ₘ Π i, π i` and families of bundled monotone
 maps `Π i, α →ₘ π i`. -/
 @[simps] def pi_iso : (α →ₘ Π i, π i) ≃o Π i, α →ₘ π i :=
-{ to_fun := λ f i, (pi.eval_preorder_hom i).comp f,
+{ to_fun := λ f i, (pi.eval_order_hom i).comp f,
   inv_fun := pi,
   left_inv := λ f, by { ext x i, refl },
   right_inv := λ f, by { ext x i, refl },
@@ -247,9 +247,9 @@ def subtype.val (p : α → Prop) : subtype p →ₘ α :=
 /-- There is a unique monotone map from a subsingleton to itself. -/
 local attribute [instance]
 def unique [subsingleton α] : unique (α →ₘ α) :=
-{ default := preorder_hom.id, uniq := λ a, ext _ _ (subsingleton.elim _ _) }
+{ default := order_hom.id, uniq := λ a, ext _ _ (subsingleton.elim _ _) }
 
-lemma preorder_hom_eq_id [subsingleton α] (g : α →ₘ α) : g = preorder_hom.id :=
+lemma order_hom_eq_id [subsingleton α] (g : α →ₘ α) : g = order_hom.id :=
 subsingleton.elim _ _
 
 /-- Reinterpret a bundled monotone function as a monotone function between dual orders. -/
@@ -259,10 +259,10 @@ subsingleton.elim _ _
   left_inv := λ f, ext _ _ rfl,
   right_inv := λ f, ext _ _ rfl }
 
-/-- `preorder_hom.dual` as an order isomorphism. -/
+/-- `order_hom.dual` as an order isomorphism. -/
 def dual_iso (α β : Type*) [preorder α] [preorder β] :
   (α →ₘ β) ≃o order_dual (order_dual α →ₘ order_dual β) :=
-{ to_equiv := preorder_hom.dual.trans order_dual.to_dual,
+{ to_equiv := order_hom.dual.trans order_dual.to_dual,
   map_rel_iff' := λ f g, iff.rfl }
 
 @[simps]
@@ -341,8 +341,8 @@ instance {β : Type*} [complete_lattice β] : complete_lattice (α →ₘ β) :=
   le_Inf := λ s f hf x, le_binfi (λ g hg, hf g hg x),
   Inf_le := λ s f hf x, infi_le_of_le f (infi_le _ hf),
   .. (_ : lattice (α →ₘ β)),
-  .. preorder_hom.order_top,
-  .. preorder_hom.order_bot }
+  .. order_hom.order_top,
+  .. order_hom.order_bot }
 
 lemma iterate_sup_le_sup_iff {α : Type*} [semilattice_sup α] (f : α →ₘ α) :
   (∀ n₁ n₂ a₁ a₂, f^[n₁ + n₂] (a₁ ⊔ a₂) ≤ (f^[n₁] a₁) ⊔ (f^[n₂] a₂)) ↔
@@ -364,13 +364,13 @@ begin
                            ... ≤ (f^[n₁] a₁) ⊔ (f^[n₂] a₂) : h' n₁ a₁ _, },
 end
 
-end preorder_hom
+end order_hom
 
 namespace order_embedding
 
-/-- Convert an `order_embedding` to a `preorder_hom`. -/
+/-- Convert an `order_embedding` to a `order_hom`. -/
 @[simps {fully_applied := ff}]
-def to_preorder_hom {X Y : Type*} [preorder X] [preorder Y] (f : X ↪o Y) : X →ₘ Y :=
+def to_order_hom {X Y : Type*} [preorder X] [preorder Y] (f : X ↪o Y) : X →ₘ Y :=
 { to_fun := f,
   monotone' := f.monotone }
 
@@ -386,14 +386,14 @@ variables (f : ((<) : α → α → Prop) →r ((<) : β → β → Prop))
 /-- A bundled expression of the fact that a map between partial orders that is strictly monotone
 is weakly monotone. -/
 @[simps {fully_applied := ff}]
-def to_preorder_hom : α →ₘ β :=
+def to_order_hom : α →ₘ β :=
 { to_fun    := f,
   monotone' := strict_mono.monotone (λ x y, f.map_rel), }
 
 end rel_hom
 
-lemma rel_embedding.to_preorder_hom_injective (f : ((<) : α → α → Prop) ↪r ((<) : β → β → Prop)) :
-  function.injective (f : ((<) : α → α → Prop) →r ((<) : β → β → Prop)).to_preorder_hom :=
+lemma rel_embedding.to_order_hom_injective (f : ((<) : α → α → Prop) ↪r ((<) : β → β → Prop)) :
+  function.injective (f : ((<) : α → α → Prop) →r ((<) : β → β → Prop)).to_order_hom :=
 λ _ _ h, f.injective h
 
 end rel_hom

--- a/src/order/order_hom.lean
+++ b/src/order/order_hom.lean
@@ -10,9 +10,9 @@ import order.bounded_order
 import logic.function.iterate
 
 /-!
-# Preorder homomorphisms
+# Order homomorphisms
 
-This file defines preorder homomorphisms, which are bundled monotone functions. A preorder
+This file defines order homomorphisms, which are bundled monotone functions. A preorder
 homomorphism `f : α →ₘ β` is a function `α → β` along with a proof that `∀ x y, x ≤ y → f x ≤ f y`.
 
 ## Main definitions

--- a/src/order/order_iso_nat.lean
+++ b/src/order/order_iso_nat.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro
 -/
 import data.equiv.denumerable
-import order.preorder_hom
+import order.order_hom
 import data.nat.lattice
 
 /-!
@@ -166,8 +166,8 @@ begin
     use n, intros m hm, rw ← hn at range_bounded, symmetry,
     apply range_bounded (a m) (set.mem_range_self _) (a.monotone hm), },
   { rw rel_embedding.well_founded_iff_no_descending_seq, refine ⟨λ a, _⟩,
-    obtain ⟨n, hn⟩ := h (a.swap : ((<) : ℕ → ℕ → Prop) →r ((<) : α → α → Prop)).to_preorder_hom,
-    exact n.succ_ne_self.symm (rel_embedding.to_preorder_hom_injective _ (hn _ n.le_succ)), },
+    obtain ⟨n, hn⟩ := h (a.swap : ((<) : ℕ → ℕ → Prop) →r ((<) : α → α → Prop)).to_order_hom,
+    exact n.succ_ne_self.symm (rel_embedding.to_order_hom_injective _ (hn _ n.le_succ)), },
 end
 
 /-- Given an eventually-constant monotone sequence `a₀ ≤ a₁ ≤ a₂ ≤ ...` in a partially-ordered

--- a/src/order/partial_sups.lean
+++ b/src/order/partial_sups.lean
@@ -5,7 +5,7 @@ Authors: Scott Morrison
 -/
 import data.finset.lattice
 import data.set.pairwise
-import order.preorder_hom
+import order.order_hom
 
 /-!
 # The monotone sequence of partial supremums of a sequence
@@ -95,10 +95,10 @@ def partial_sups.gi : galois_insertion (partial_sups : (ℕ → α) → ℕ →�
   gc := λ f g, begin
     refine ⟨(le_partial_sups f).trans, λ h, _⟩,
     convert partial_sups_mono h,
-    exact preorder_hom.ext _ _ g.monotone.partial_sups_eq.symm,
+    exact order_hom.ext _ _ g.monotone.partial_sups_eq.symm,
   end,
   le_l_u := λ f, le_partial_sups f,
-  choice_eq := λ f h, preorder_hom.ext _ _ ((le_partial_sups f).antisymm h) }
+  choice_eq := λ f h, order_hom.ext _ _ ((le_partial_sups f).antisymm h) }
 
 lemma partial_sups_eq_sup'_range (f : ℕ → α) (n : ℕ) :
   partial_sups f n = (finset.range (n + 1)).sup' ⟨n, finset.self_mem_range_succ n⟩ f :=

--- a/src/topology/omega_complete_partial_order.lean
+++ b/src/topology/omega_complete_partial_order.lean
@@ -109,7 +109,7 @@ begin
   existsi h, rintros c,
   apply eq_of_forall_ge_iff, intro z,
   rw ωSup_le_iff,
-  simp only [ωSup_le_iff, not_below, set.mem_set_of_eq, le_Prop_eq, preorder_hom.coe_fun_mk,
+  simp only [ωSup_le_iff, not_below, set.mem_set_of_eq, le_Prop_eq, order_hom.coe_fun_mk,
              chain.map_coe, function.comp_app, exists_imp_distrib, not_forall],
 end
 
@@ -142,10 +142,10 @@ begin
   apply eq_of_forall_ge_iff, intro z,
   specialize (hf _ (not_below_is_open z)),
   cases hf, specialize hf_h c,
-  simp only [not_below, preorder_hom.coe_fun_mk, eq_iff_iff, set.mem_set_of_eq] at hf_h,
+  simp only [not_below, order_hom.coe_fun_mk, eq_iff_iff, set.mem_set_of_eq] at hf_h,
   rw [← not_iff_not],
   simp only [ωSup_le_iff, hf_h, ωSup, supr, Sup, complete_lattice.Sup, complete_semilattice_Sup.Sup,
-    exists_prop, set.mem_range, preorder_hom.coe_fun_mk, chain.map_coe, function.comp_app,
+    exists_prop, set.mem_range, order_hom.coe_fun_mk, chain.map_coe, function.comp_app,
     eq_iff_iff, not_forall],
   tauto,
 end

--- a/src/topology/opens.lean
+++ b/src/topology/opens.lean
@@ -176,7 +176,7 @@ def comap (f : C(α, β)) : opens β →ₘ opens α :=
 { to_fun := λ V, ⟨f ⁻¹' V, V.2.preimage f.continuous⟩,
   monotone' := λ V₁ V₂ hle, monotone_preimage hle }
 
-@[simp] lemma comap_id : comap (continuous_map.id : C(α, α)) = preorder_hom.id :=
+@[simp] lemma comap_id : comap (continuous_map.id : C(α, α)) = order_hom.id :=
 by { ext, refl }
 
 lemma comap_mono (f : C(α, β)) {V W : opens β} (hVW : V ⊆ W) :


### PR DESCRIPTION
For consistency with `order_embedding` and `order_iso`, this PR renames `preorder_hom` to `order_hom`, at the request of @YaelDillies.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
