### PR TITLE
[Merged by Bors] - chore(order/hom): rearrange definitions of `order_{hom,iso,embedding}`

### DIFF
--- a/src/algebra/lie/solvable.lean
+++ b/src/algebra/lie/solvable.lean
@@ -3,9 +3,9 @@ Copyright (c) 2021 Oliver Nash. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Oliver Nash
 -/
-import algebra.lie.ideal_operations
 import algebra.lie.abelian
-import order.order_hom
+import algebra.lie.ideal_operations
+import order.hom.basic
 
 /-!
 # Solvable Lie algebras

--- a/src/algebra/order/monoid.lean
+++ b/src/algebra/order/monoid.lean
@@ -9,7 +9,7 @@ import algebra.group.prod
 import algebra.order.monoid_lemmas
 import order.bounded_order
 import order.min_max
-import order.rel_iso
+import order.hom.basic
 
 /-!
 # Ordered monoids

--- a/src/combinatorics/set_family/shadow.lean
+++ b/src/combinatorics/set_family/shadow.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Bhavik Mehta, Alena Gusakov, Yaël Dillies
 -/
 import data.finset.lattice
+import logic.function.iterate
 
 /-!
 # Shadows

--- a/src/data/finset/option.lean
+++ b/src/data/finset/option.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yury Kudryashov, Mario Carneiro, Sean Leather
 -/
 import data.finset.basic
-import order.order_hom
+import order.hom.basic
 
 /-!
 # Finite sets in `option α`

--- a/src/data/nat/fib.lean
+++ b/src/data/nat/fib.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Kevin Kappelmann
 -/
 import data.nat.gcd
+import logic.function.iterate
 import tactic.ring
 
 /-!

--- a/src/linear_algebra/eigenspace.lean
+++ b/src/linear_algebra/eigenspace.lean
@@ -5,10 +5,10 @@ Authors: Alexander Bentkamp
 -/
 
 import field_theory.is_alg_closed.basic
+import linear_algebra.charpoly.basic
 import linear_algebra.finsupp
 import linear_algebra.matrix.to_lin
-import order.order_hom
-import linear_algebra.charpoly.basic
+import order.hom.basic
 
 /-!
 # Eigenvectors and eigenvalues

--- a/src/order/category/Preorder.lean
+++ b/src/order/category/Preorder.lean
@@ -5,7 +5,7 @@ Authors: Johan Commelin
 -/
 import category_theory.concrete_category.bundled_hom
 import algebra.punit_instances
-import order.order_hom
+import order.hom.basic
 
 /-! # Category of preorders -/
 

--- a/src/order/closure.lean
+++ b/src/order/closure.lean
@@ -6,7 +6,7 @@ Authors: Bhavik Mehta, Yaël Dillies
 import data.set.lattice
 import data.set_like.basic
 import order.galois_connection
-import order.order_hom
+import order.hom.basic
 import tactic.monotonicity
 
 /-!

--- a/src/order/fixed_points.lean
+++ b/src/order/fixed_points.lean
@@ -3,8 +3,8 @@ Copyright (c) 2017 Johannes Hölzl. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl, Kenny Lau, Yury Kudryashov
 -/
-import order.order_hom
 import dynamics.fixed_points.basic
+import order.hom.lattice
 
 /-!
 # Fixed point construction on complete lattices

--- a/src/order/hom/basic.lean
+++ b/src/order/hom/basic.lean
@@ -3,11 +3,8 @@ Copyright (c) 2020 Johan Commelin. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johan Commelin
 -/
-import order.galois_connection
-import order.complete_lattice
-import tactic.monotonicity
-import order.bounded_order
-import logic.function.iterate
+import order.rel_iso
+import tactic.monotonicity.basic
 
 /-!
 # Order homomorphisms
@@ -264,105 +261,6 @@ def dual_iso (α β : Type*) [preorder α] [preorder β] :
   (α →ₘ β) ≃o order_dual (order_dual α →ₘ order_dual β) :=
 { to_equiv := order_hom.dual.trans order_dual.to_dual,
   map_rel_iff' := λ f g, iff.rfl }
-
-@[simps]
-instance {β : Type*} [semilattice_sup β] : has_sup (α →ₘ β) :=
-{ sup := λ f g, ⟨λ a, f a ⊔ g a, f.mono.sup g.mono⟩ }
-
-instance {β : Type*} [semilattice_sup β] : semilattice_sup (α →ₘ β) :=
-{ sup := has_sup.sup,
-  le_sup_left := λ a b x, le_sup_left,
-  le_sup_right := λ a b x, le_sup_right,
-  sup_le := λ a b c h₀ h₁ x, sup_le (h₀ x) (h₁ x),
-  .. (_ : partial_order (α →ₘ β)) }
-
-@[simps]
-instance {β : Type*} [semilattice_inf β] : has_inf (α →ₘ β) :=
-{ inf := λ f g, ⟨λ a, f a ⊓ g a, f.mono.inf g.mono⟩ }
-
-instance {β : Type*} [semilattice_inf β] : semilattice_inf (α →ₘ β) :=
-{ inf := (⊓),
-  .. (_ : partial_order (α →ₘ β)),
-  .. (dual_iso α β).symm.to_galois_insertion.lift_semilattice_inf }
-
-instance {β : Type*} [lattice β] : lattice (α →ₘ β) :=
-{ .. (_ : semilattice_sup (α →ₘ β)),
-  .. (_ : semilattice_inf (α →ₘ β)) }
-
-@[simps]
-instance {β : Type*} [preorder β] [order_bot β] : has_bot (α →ₘ β) :=
-{ bot := const α ⊥ }
-
-instance {β : Type*} [preorder β] [order_bot β] : order_bot (α →ₘ β) :=
-{ bot := ⊥,
-  bot_le := λ a x, bot_le }
-
-@[simps]
-instance {β : Type*} [preorder β] [order_top β] : has_top (α →ₘ β) :=
-{ top := const α ⊤ }
-
-instance {β : Type*} [preorder β] [order_top β] : order_top (α →ₘ β) :=
-{ top := ⊤,
-  le_top := λ a x, le_top }
-
-instance {β : Type*} [complete_lattice β] : has_Inf (α →ₘ β) :=
-{ Inf := λ s, ⟨λ x, ⨅ f ∈ s, (f : _) x, λ x y h, binfi_le_binfi (λ f _, f.mono h)⟩ }
-
-@[simp] lemma Inf_apply {β : Type*} [complete_lattice β] (s : set (α →ₘ β)) (x : α) :
-  Inf s x = ⨅ f ∈ s, (f : _) x := rfl
-
-lemma infi_apply {ι : Sort*} {β : Type*} [complete_lattice β] (f : ι → α →ₘ β) (x : α) :
-  (⨅ i, f i) x = ⨅ i, f i x :=
-(Inf_apply _ _).trans infi_range
-
-@[simp, norm_cast] lemma coe_infi {ι : Sort*} {β : Type*} [complete_lattice β] (f : ι → α →ₘ β) :
-  ((⨅ i, f i : α →ₘ β) : α → β) = ⨅ i, f i :=
-funext $ λ x, (infi_apply f x).trans (@_root_.infi_apply _ _ _ _ (λ i, f i) _).symm
-
-instance {β : Type*} [complete_lattice β] : has_Sup (α →ₘ β) :=
-{ Sup := λ s, ⟨λ x, ⨆ f ∈ s, (f : _) x, λ x y h, bsupr_le_bsupr (λ f _, f.mono h)⟩ }
-
-@[simp] lemma Sup_apply {β : Type*} [complete_lattice β] (s : set (α →ₘ β)) (x : α) :
-  Sup s x = ⨆ f ∈ s, (f : _) x := rfl
-
-lemma supr_apply {ι : Sort*} {β : Type*} [complete_lattice β] (f : ι → α →ₘ β) (x : α) :
-  (⨆ i, f i) x = ⨆ i, f i x :=
-(Sup_apply _ _).trans supr_range
-
-@[simp, norm_cast] lemma coe_supr {ι : Sort*} {β : Type*} [complete_lattice β] (f : ι → α →ₘ β) :
-  ((⨆ i, f i : α →ₘ β) : α → β) = ⨆ i, f i :=
-funext $ λ x, (supr_apply f x).trans (@_root_.supr_apply _ _ _ _ (λ i, f i) _).symm
-
-instance {β : Type*} [complete_lattice β] : complete_lattice (α →ₘ β) :=
-{ Sup := Sup,
-  le_Sup := λ s f hf x, le_supr_of_le f (le_supr _ hf),
-  Sup_le := λ s f hf x, bsupr_le (λ g hg, hf g hg x),
-  Inf := Inf,
-  le_Inf := λ s f hf x, le_binfi (λ g hg, hf g hg x),
-  Inf_le := λ s f hf x, infi_le_of_le f (infi_le _ hf),
-  .. (_ : lattice (α →ₘ β)),
-  .. order_hom.order_top,
-  .. order_hom.order_bot }
-
-lemma iterate_sup_le_sup_iff {α : Type*} [semilattice_sup α] (f : α →ₘ α) :
-  (∀ n₁ n₂ a₁ a₂, f^[n₁ + n₂] (a₁ ⊔ a₂) ≤ (f^[n₁] a₁) ⊔ (f^[n₂] a₂)) ↔
-  (∀ a₁ a₂, f (a₁ ⊔ a₂) ≤ (f a₁) ⊔ a₂) :=
-begin
-  split; intros h,
-  { exact h 1 0, },
-  { intros n₁ n₂ a₁ a₂, have h' : ∀ n a₁ a₂, f^[n] (a₁ ⊔ a₂) ≤ (f^[n] a₁) ⊔ a₂,
-    { intros n, induction n with n ih; intros a₁ a₂,
-      { refl, },
-      { calc f^[n + 1] (a₁ ⊔ a₂) = (f^[n] (f (a₁ ⊔ a₂))) : function.iterate_succ_apply f n _
-                             ... ≤ (f^[n] ((f a₁) ⊔ a₂)) : f.mono.iterate n (h a₁ a₂)
-                             ... ≤ (f^[n] (f a₁)) ⊔ a₂ : ih _ _
-                             ... = (f^[n + 1] a₁) ⊔ a₂ : by rw ← function.iterate_succ_apply, }, },
-    calc f^[n₁ + n₂] (a₁ ⊔ a₂) = (f^[n₁] (f^[n₂] (a₁ ⊔ a₂))) : function.iterate_add_apply f n₁ n₂ _
-                           ... = (f^[n₁] (f^[n₂] (a₂ ⊔ a₁))) : by rw sup_comm
-                           ... ≤ (f^[n₁] ((f^[n₂] a₂) ⊔ a₁)) : f.mono.iterate n₁ (h' n₂ _ _)
-                           ... = (f^[n₁] (a₁ ⊔ (f^[n₂] a₂))) : by rw sup_comm
-                           ... ≤ (f^[n₁] a₁) ⊔ (f^[n₂] a₂) : h' n₁ a₁ _, },
-end
 
 end order_hom
 

--- a/src/order/hom/basic.lean
+++ b/src/order/hom/basic.lean
@@ -14,7 +14,15 @@ homomorphism `f : α →ₘ β` is a function `α → β` along with a proof tha
 
 ## Main definitions
 
-In this file we define `order_hom α β` a.k.a. `α →ₘ β` to be a bundled monotone map.
+In this file we define the following bundled monotone maps:
+ * `order_hom α β` a.k.a. `α →ₘ β`: Preorder homomorphism.
+    An `order_hom α β` is a function `f : α → β` such that `a₁ ≤ a₂ → f a₁ ≤ f a₂`
+ * `order_embedding α β` a.k.a. `α ↪o β`: Relation embedding.
+    An `order_embedding α β` is an embedding `f : α ↪ β` such that `a ≤ b ↔ f a ≤ f b`.
+    Defined as an abbreviation of `@rel_embedding α β (≤) (≤)`.
+* `order_iso`: Relation isomorphism.
+    An `order_iso α β` is an equivalence `f : α ≃ β` such that `a ≤ b ↔ f a ≤ f b`.
+    Defined as an abbreviation of `@rel_iso α β (≤) (≤)`.
 
 We also define many `order_hom`s. In some cases we define two versions, one with `ₘ` suffix and
 one without it (e.g., `order_hom.compₘ` and `order_hom.comp`). This means that the former
@@ -64,8 +72,23 @@ structure order_hom (α β : Type*) [preorder α] [preorder β] :=
 
 infixr ` →ₘ `:25 := order_hom
 
+/-- An order embedding is an embedding `f : α ↪ β` such that `a ≤ b ↔ (f a) ≤ (f b)`.
+This definition is an abbreviation of `rel_embedding (≤) (≤)`. -/
+abbreviation order_embedding (α β : Type*) [has_le α] [has_le β] :=
+@rel_embedding α β (≤) (≤)
+
+infix ` ↪o `:25 := order_embedding
+
+/-- An order isomorphism is an equivalence such that `a ≤ b ↔ (f a) ≤ (f b)`.
+This definition is an abbreviation of `rel_iso (≤) (≤)`. -/
+abbreviation order_iso (α β : Type*) [has_le α] [has_le β] := @rel_iso α β (≤) (≤)
+
+infix ` ≃o `:25 := order_iso
+
+variables {α β γ δ : Type*}
+
 namespace order_hom
-variables {α β γ δ : Type*} [preorder α] [preorder β] [preorder γ] [preorder δ]
+variables [preorder α] [preorder β] [preorder γ] [preorder δ]
 
 instance : has_coe_to_fun (α →ₘ β) (λ _, α → β) := ⟨order_hom.to_fun⟩
 
@@ -264,7 +287,74 @@ def dual_iso (α β : Type*) [preorder α] [preorder β] :
 
 end order_hom
 
+/-- Embeddings of partial orders that preserve `<` also preserve `≤`. -/
+def rel_embedding.order_embedding_of_lt_embedding [partial_order α] [partial_order β]
+  (f : ((<) : α → α → Prop) ↪r ((<) : β → β → Prop)) :
+  α ↪o β :=
+{ map_rel_iff' := by { intros, simp [le_iff_lt_or_eq,f.map_rel_iff, f.injective.eq_iff] }, .. f }
+
+@[simp]
+lemma rel_embedding.order_embedding_of_lt_embedding_apply [partial_order α] [partial_order β]
+  {f : ((<) : α → α → Prop) ↪r ((<) : β → β → Prop)} {x : α} :
+  rel_embedding.order_embedding_of_lt_embedding f x = f x := rfl
+
 namespace order_embedding
+
+variables [preorder α] [preorder β] (f : α ↪o β)
+
+/-- `<` is preserved by order embeddings of preorders. -/
+def lt_embedding : ((<) : α → α → Prop) ↪r ((<) : β → β → Prop) :=
+{ map_rel_iff' := by intros; simp [lt_iff_le_not_le, f.map_rel_iff], .. f }
+
+@[simp] lemma lt_embedding_apply (x : α) : f.lt_embedding x = f x := rfl
+
+@[simp] theorem le_iff_le {a b} : (f a) ≤ (f b) ↔ a ≤ b := f.map_rel_iff
+
+@[simp] theorem lt_iff_lt {a b} : f a < f b ↔ a < b :=
+f.lt_embedding.map_rel_iff
+
+@[simp] lemma eq_iff_eq {a b} : f a = f b ↔ a = b := f.injective.eq_iff
+
+protected theorem monotone : monotone f := λ x y, f.le_iff_le.2
+
+protected theorem strict_mono : strict_mono f := λ x y, f.lt_iff_lt.2
+
+protected theorem acc (a : α) : acc (<) (f a) → acc (<) a :=
+f.lt_embedding.acc a
+
+protected theorem well_founded :
+  well_founded ((<) : β → β → Prop) → well_founded ((<) : α → α → Prop) :=
+f.lt_embedding.well_founded
+
+protected theorem is_well_order [is_well_order β (<)] : is_well_order α (<) :=
+f.lt_embedding.is_well_order
+
+/-- An order embedding is also an order embedding between dual orders. -/
+protected def dual : order_dual α ↪o order_dual β :=
+⟨f.to_embedding, λ a b, f.map_rel_iff⟩
+
+/--
+To define an order embedding from a partial order to a preorder it suffices to give a function
+together with a proof that it satisfies `f a ≤ f b ↔ a ≤ b`.
+-/
+def of_map_le_iff {α β} [partial_order α] [preorder β] (f : α → β)
+  (hf : ∀ a b, f a ≤ f b ↔ a ≤ b) : α ↪o β :=
+rel_embedding.of_map_rel_iff f hf
+
+@[simp] lemma coe_of_map_le_iff {α β} [partial_order α] [preorder β] {f : α → β} (h) :
+  ⇑(of_map_le_iff f h) = f := rfl
+
+/-- A strictly monotone map from a linear order is an order embedding. --/
+def of_strict_mono {α β} [linear_order α] [preorder β] (f : α → β)
+  (h : strict_mono f) : α ↪o β :=
+of_map_le_iff f (λ _ _, h.le_iff_le)
+
+@[simp] lemma coe_of_strict_mono {α β} [linear_order α] [preorder β] {f : α → β}
+  (h : strict_mono f) : ⇑(of_strict_mono f h) = f := rfl
+
+/-- Embedding of a subtype into the ambient type as an `order_embedding`. -/
+@[simps {fully_applied := ff}] def subtype (p : α → Prop) : subtype p ↪o α :=
+⟨function.embedding.subtype p, λ x y, iff.rfl⟩
 
 /-- Convert an `order_embedding` to a `order_hom`. -/
 @[simps {fully_applied := ff}]
@@ -275,7 +365,7 @@ def to_order_hom {X Y : Type*} [preorder X] [preorder Y] (f : X ↪o Y) : X →�
 end order_embedding
 section rel_hom
 
-variables {α β : Type*} [partial_order α] [preorder β]
+variables [partial_order α] [preorder β]
 
 namespace rel_hom
 
@@ -295,3 +385,275 @@ lemma rel_embedding.to_order_hom_injective (f : ((<) : α → α → Prop) ↪r 
 λ _ _ h, f.injective h
 
 end rel_hom
+
+namespace order_iso
+
+section has_le
+
+variables [has_le α] [has_le β] [has_le γ]
+
+/-- Reinterpret an order isomorphism as an order embedding. -/
+def to_order_embedding (e : α ≃o β) : α ↪o β :=
+e.to_rel_embedding
+
+@[simp] lemma coe_to_order_embedding (e : α ≃o β) :
+  ⇑(e.to_order_embedding) = e := rfl
+
+protected lemma bijective (e : α ≃o β) : function.bijective e := e.to_equiv.bijective
+protected lemma injective (e : α ≃o β) : function.injective e := e.to_equiv.injective
+protected lemma surjective (e : α ≃o β) : function.surjective e := e.to_equiv.surjective
+
+@[simp] lemma range_eq (e : α ≃o β) : set.range e = set.univ := e.surjective.range_eq
+
+@[simp] lemma apply_eq_iff_eq (e : α ≃o β) {x y : α} : e x = e y ↔ x = y :=
+e.to_equiv.apply_eq_iff_eq
+
+/-- Identity order isomorphism. -/
+def refl (α : Type*) [has_le α] : α ≃o α := rel_iso.refl (≤)
+
+@[simp] lemma coe_refl : ⇑(refl α) = id := rfl
+
+lemma refl_apply (x : α) : refl α x = x := rfl
+
+@[simp] lemma refl_to_equiv : (refl α).to_equiv = equiv.refl α := rfl
+
+/-- Inverse of an order isomorphism. -/
+def symm (e : α ≃o β) : β ≃o α := e.symm
+
+@[simp] lemma apply_symm_apply (e : α ≃o β) (x : β) : e (e.symm x) = x :=
+e.to_equiv.apply_symm_apply x
+
+@[simp] lemma symm_apply_apply (e : α ≃o β) (x : α) : e.symm (e x) = x :=
+e.to_equiv.symm_apply_apply x
+
+@[simp] lemma symm_refl (α : Type*) [has_le α] : (refl α).symm = refl α := rfl
+
+lemma apply_eq_iff_eq_symm_apply (e : α ≃o β) (x : α) (y : β) : e x = y ↔ x = e.symm y :=
+e.to_equiv.apply_eq_iff_eq_symm_apply
+
+theorem symm_apply_eq (e : α ≃o β) {x : α} {y : β} : e.symm y = x ↔ y = e x :=
+e.to_equiv.symm_apply_eq
+
+@[simp] lemma symm_symm (e : α ≃o β) : e.symm.symm = e := by { ext, refl }
+
+lemma symm_injective : function.injective (symm : (α ≃o β) → (β ≃o α)) :=
+λ e e' h, by rw [← e.symm_symm, h, e'.symm_symm]
+
+@[simp] lemma to_equiv_symm (e : α ≃o β) : e.to_equiv.symm = e.symm.to_equiv := rfl
+
+@[simp] lemma symm_image_image (e : α ≃o β) (s : set α) : e.symm '' (e '' s) = s :=
+e.to_equiv.symm_image_image s
+
+@[simp] lemma image_symm_image (e : α ≃o β) (s : set β) : e '' (e.symm '' s) = s :=
+e.to_equiv.image_symm_image s
+
+lemma image_eq_preimage (e : α ≃o β) (s : set α) : e '' s = e.symm ⁻¹' s :=
+e.to_equiv.image_eq_preimage s
+
+@[simp] lemma preimage_symm_preimage (e : α ≃o β) (s : set α) : e ⁻¹' (e.symm ⁻¹' s) = s :=
+e.to_equiv.preimage_symm_preimage s
+
+@[simp] lemma symm_preimage_preimage (e : α ≃o β) (s : set β) : e.symm ⁻¹' (e ⁻¹' s) = s :=
+e.to_equiv.symm_preimage_preimage s
+
+@[simp] lemma image_preimage (e : α ≃o β) (s : set β) : e '' (e ⁻¹' s) = s :=
+e.to_equiv.image_preimage s
+
+@[simp] lemma preimage_image (e : α ≃o β) (s : set α) : e ⁻¹' (e '' s) = s :=
+e.to_equiv.preimage_image s
+
+/-- Composition of two order isomorphisms is an order isomorphism. -/
+@[trans] def trans (e : α ≃o β) (e' : β ≃o γ) : α ≃o γ := e.trans e'
+
+@[simp] lemma coe_trans (e : α ≃o β) (e' : β ≃o γ) : ⇑(e.trans e') = e' ∘ e := rfl
+
+lemma trans_apply (e : α ≃o β) (e' : β ≃o γ) (x : α) : e.trans e' x = e' (e x) := rfl
+
+@[simp] lemma refl_trans (e : α ≃o β) : (refl α).trans e = e := by { ext x, refl }
+
+@[simp] lemma trans_refl (e : α ≃o β) : e.trans (refl β) = e := by { ext x, refl }
+
+end has_le
+
+open set
+
+section le
+
+variables [has_le α] [has_le β] [has_le γ]
+
+@[simp] lemma le_iff_le (e : α ≃o β) {x y : α} : e x ≤ e y ↔ x ≤ y := e.map_rel_iff
+
+lemma le_symm_apply (e : α ≃o β) {x : α} {y : β} : x ≤ e.symm y ↔ e x ≤ y :=
+e.rel_symm_apply
+
+lemma symm_apply_le (e : α ≃o β) {x : α} {y : β} : e.symm y ≤ x ↔ y ≤ e x :=
+e.symm_apply_rel
+
+end le
+
+variables [preorder α] [preorder β] [preorder γ]
+
+protected lemma monotone (e : α ≃o β) : monotone e := e.to_order_embedding.monotone
+
+protected lemma strict_mono (e : α ≃o β) : strict_mono e := e.to_order_embedding.strict_mono
+
+@[simp] lemma lt_iff_lt (e : α ≃o β) {x y : α} : e x < e y ↔ x < y :=
+e.to_order_embedding.lt_iff_lt
+
+/-- To show that `f : α → β`, `g : β → α` make up an order isomorphism of linear orders,
+    it suffices to prove `cmp a (g b) = cmp (f a) b`. --/
+def of_cmp_eq_cmp {α β} [linear_order α] [linear_order β] (f : α → β) (g : β → α)
+  (h : ∀ (a : α) (b : β), cmp a (g b) = cmp (f a) b) : α ≃o β :=
+have gf : ∀ (a : α), a = g (f a) := by { intro, rw [←cmp_eq_eq_iff, h, cmp_self_eq_eq] },
+{ to_fun := f,
+  inv_fun := g,
+  left_inv := λ a, (gf a).symm,
+  right_inv := by { intro, rw [←cmp_eq_eq_iff, ←h, cmp_self_eq_eq] },
+  map_rel_iff' := by { intros, apply le_iff_le_of_cmp_eq_cmp, convert (h _ _).symm, apply gf } }
+
+/-- Order isomorphism between two equal sets. -/
+def set_congr (s t : set α) (h : s = t) : s ≃o t :=
+{ to_equiv := equiv.set_congr h,
+  map_rel_iff' := λ x y, iff.rfl }
+
+/-- Order isomorphism between `univ : set α` and `α`. -/
+def set.univ : (set.univ : set α) ≃o α :=
+{ to_equiv := equiv.set.univ α,
+  map_rel_iff' := λ x y, iff.rfl }
+
+/-- Order isomorphism between `α → β` and `β`, where `α` has a unique element. -/
+@[simps to_equiv apply] def fun_unique (α β : Type*) [unique α] [preorder β] :
+  (α → β) ≃o β :=
+{ to_equiv := equiv.fun_unique α β,
+  map_rel_iff' := λ f g, by simp [pi.le_def, unique.forall_iff] }
+
+@[simp] lemma fun_unique_symm_apply {α β : Type*} [unique α] [preorder β] :
+  ((fun_unique α β).symm : β → α → β) = function.const α := rfl
+
+end order_iso
+
+namespace equiv
+
+variables [preorder α] [preorder β]
+
+/-- If `e` is an equivalence with monotone forward and inverse maps, then `e` is an
+order isomorphism. -/
+def to_order_iso (e : α ≃ β) (h₁ : monotone e) (h₂ : monotone e.symm) :
+  α ≃o β :=
+⟨e, λ x y, ⟨λ h, by simpa only [e.symm_apply_apply] using h₂ h, λ h, h₁ h⟩⟩
+
+@[simp] lemma coe_to_order_iso (e : α ≃ β) (h₁ : monotone e) (h₂ : monotone e.symm) :
+  ⇑(e.to_order_iso h₁ h₂) = e := rfl
+
+@[simp] lemma to_order_iso_to_equiv (e : α ≃ β) (h₁ : monotone e) (h₂ : monotone e.symm) :
+  (e.to_order_iso h₁ h₂).to_equiv = e := rfl
+
+end equiv
+
+/-- If a function `f` is strictly monotone on a set `s`, then it defines an order isomorphism
+between `s` and its image. -/
+protected noncomputable def strict_mono_on.order_iso {α β} [linear_order α] [preorder β]
+  (f : α → β) (s : set α) (hf : strict_mono_on f s) :
+  s ≃o f '' s :=
+{ to_equiv := hf.inj_on.bij_on_image.equiv _,
+  map_rel_iff' := λ x y, hf.le_iff_le x.2 y.2 }
+
+/-- A strictly monotone function from a linear order is an order isomorphism between its domain and
+its range. -/
+protected noncomputable def strict_mono.order_iso {α β} [linear_order α] [preorder β] (f : α → β)
+  (h_mono : strict_mono f) : α ≃o set.range f :=
+{ to_equiv := equiv.of_injective f h_mono.injective,
+  map_rel_iff' := λ a b, h_mono.le_iff_le }
+
+/-- A strictly monotone surjective function from a linear order is an order isomorphism. -/
+noncomputable def strict_mono.order_iso_of_surjective {α β} [linear_order α] [preorder β]
+  (f : α → β) (h_mono : strict_mono f) (h_surj : function.surjective f) : α ≃o β :=
+(h_mono.order_iso f).trans $ (order_iso.set_congr _ _ h_surj.range_eq).trans order_iso.set.univ
+
+/-- An order isomorphism is also an order isomorphism between dual orders. -/
+protected def order_iso.dual [has_le α] [has_le β] (f : α ≃o β) :
+  order_dual α ≃o order_dual β := ⟨f.to_equiv, λ _ _, f.map_rel_iff⟩
+
+section lattice_isos
+
+lemma order_iso.map_bot' [has_le α] [partial_order β] (f : α ≃o β) {x : α} {y : β}
+  (hx : ∀ x', x ≤ x') (hy : ∀ y', y ≤ y') : f x = y :=
+by { refine le_antisymm _ (hy _), rw [← f.apply_symm_apply y, f.map_rel_iff], apply hx }
+
+lemma order_iso.map_bot [has_le α] [partial_order β] [order_bot α] [order_bot β] (f : α ≃o β) :
+  f ⊥ = ⊥ :=
+f.map_bot' (λ _, bot_le) (λ _, bot_le)
+
+lemma order_iso.map_top' [has_le α] [partial_order β] (f : α ≃o β) {x : α} {y : β}
+  (hx : ∀ x', x' ≤ x) (hy : ∀ y', y' ≤ y) : f x = y :=
+f.dual.map_bot' hx hy
+
+lemma order_iso.map_top [has_le α] [partial_order β] [order_top α] [order_top β] (f : α ≃o β) :
+  f ⊤ = ⊤ :=
+f.dual.map_bot
+
+lemma order_embedding.map_inf_le [semilattice_inf α] [semilattice_inf β]
+  (f : α ↪o β) (x y : α) :
+  f (x ⊓ y) ≤ f x ⊓ f y :=
+f.monotone.map_inf_le x y
+
+lemma order_iso.map_inf [semilattice_inf α] [semilattice_inf β]
+  (f : α ≃o β) (x y : α) :
+  f (x ⊓ y) = f x ⊓ f y :=
+begin
+  refine (f.to_order_embedding.map_inf_le x y).antisymm _,
+  simpa [← f.symm.le_iff_le] using f.symm.to_order_embedding.map_inf_le (f x) (f y)
+end
+
+/-- Note that this goal could also be stated `(disjoint on f) a b` -/
+lemma disjoint.map_order_iso [semilattice_inf α] [order_bot α] [semilattice_inf β] [order_bot β]
+  {a b : α} (f : α ≃o β) (ha : disjoint a b) : disjoint (f a) (f b) :=
+begin
+  rw [disjoint, ←f.map_inf, ←f.map_bot],
+  exact f.monotone ha,
+end
+
+@[simp] lemma disjoint_map_order_iso_iff [semilattice_inf α] [order_bot α] [semilattice_inf β]
+  [order_bot β] {a b : α} (f : α ≃o β) : disjoint (f a) (f b) ↔ disjoint a b :=
+⟨λ h, f.symm_apply_apply a ▸ f.symm_apply_apply b ▸ h.map_order_iso f.symm, λ h, h.map_order_iso f⟩
+
+lemma order_embedding.le_map_sup [semilattice_sup α] [semilattice_sup β]
+  (f : α ↪o β) (x y : α) :
+  f x ⊔ f y ≤ f (x ⊔ y) :=
+f.monotone.le_map_sup x y
+
+lemma order_iso.map_sup [semilattice_sup α] [semilattice_sup β]
+  (f : α ≃o β) (x y : α) :
+  f (x ⊔ y) = f x ⊔ f y :=
+f.dual.map_inf x y
+
+section bounded_order
+
+variables [lattice α] [lattice β] [bounded_order α] [bounded_order β] (f : α ≃o β)
+include f
+
+lemma order_iso.is_compl {x y : α} (h : is_compl x y) : is_compl (f x) (f y) :=
+⟨by { rw [← f.map_bot, ← f.map_inf, f.map_rel_iff], exact h.1 },
+  by { rw [← f.map_top, ← f.map_sup, f.map_rel_iff], exact h.2 }⟩
+
+theorem order_iso.is_compl_iff {x y : α} :
+  is_compl x y ↔ is_compl (f x) (f y) :=
+⟨f.is_compl, λ h, begin
+  rw [← f.symm_apply_apply x, ← f.symm_apply_apply y],
+  exact f.symm.is_compl h,
+end⟩
+
+lemma order_iso.is_complemented
+  [is_complemented α] : is_complemented β :=
+⟨λ x, begin
+  obtain ⟨y, hy⟩ := exists_is_compl (f.symm x),
+  rw ← f.symm_apply_apply y at hy,
+  refine ⟨f y, f.symm.is_compl_iff.2 hy⟩,
+end⟩
+
+theorem order_iso.is_complemented_iff :
+  is_complemented α ↔ is_complemented β :=
+⟨by { introI, exact f.is_complemented }, by { introI, exact f.symm.is_complemented }⟩
+
+end bounded_order
+end lattice_isos

--- a/src/order/hom/lattice.lean
+++ b/src/order/hom/lattice.lean
@@ -10,7 +10,8 @@ import order.hom.basic
 /-!
 # Lattice structure on order homomorphisms
 
-This file defines the lattice structure on order homomorphisms, which are bundled monotone functions.
+This file defines the lattice structure on order homomorphisms, which are bundled
+monotone functions.
 
 ## Main definitions
 

--- a/src/order/hom/lattice.lean
+++ b/src/order/hom/lattice.lean
@@ -1,0 +1,133 @@
+/-
+Copyright (c) 2021 Anne Baanen. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Johan Commelin, Anne Baanen
+-/
+import logic.function.iterate
+import order.galois_connection
+import order.hom.basic
+
+/-!
+# Lattice structure on order homomorphisms
+
+This file defines the lattice structure on order homomorphisms, which are bundled monotone functions.
+
+## Main definitions
+
+ * `order_hom.complete_lattice`: if `β` is a complete lattice, so is `α →ₘ β`
+
+## Tags
+
+monotone map, bundled morphism
+-/
+
+namespace order_hom
+
+variables {α β : Type*}
+
+section preorder
+
+variables [preorder α]
+
+@[simps]
+instance [semilattice_sup β] : has_sup (α →ₘ β) :=
+{ sup := λ f g, ⟨λ a, f a ⊔ g a, f.mono.sup g.mono⟩ }
+
+instance [semilattice_sup β] : semilattice_sup (α →ₘ β) :=
+{ sup := has_sup.sup,
+  le_sup_left := λ a b x, le_sup_left,
+  le_sup_right := λ a b x, le_sup_right,
+  sup_le := λ a b c h₀ h₁ x, sup_le (h₀ x) (h₁ x),
+  .. (_ : partial_order (α →ₘ β)) }
+
+@[simps]
+instance [semilattice_inf β] : has_inf (α →ₘ β) :=
+{ inf := λ f g, ⟨λ a, f a ⊓ g a, f.mono.inf g.mono⟩ }
+
+instance [semilattice_inf β] : semilattice_inf (α →ₘ β) :=
+{ inf := (⊓),
+  .. (_ : partial_order (α →ₘ β)),
+  .. (dual_iso α β).symm.to_galois_insertion.lift_semilattice_inf }
+
+instance [lattice β] : lattice (α →ₘ β) :=
+{ .. (_ : semilattice_sup (α →ₘ β)),
+  .. (_ : semilattice_inf (α →ₘ β)) }
+
+@[simps]
+instance [preorder β] [order_bot β] : has_bot (α →ₘ β) :=
+{ bot := const α ⊥ }
+
+instance [preorder β] [order_bot β] : order_bot (α →ₘ β) :=
+{ bot := ⊥,
+  bot_le := λ a x, bot_le }
+
+@[simps]
+instance [preorder β] [order_top β] : has_top (α →ₘ β) :=
+{ top := const α ⊤ }
+
+instance [preorder β] [order_top β] : order_top (α →ₘ β) :=
+{ top := ⊤,
+  le_top := λ a x, le_top }
+
+instance [complete_lattice β] : has_Inf (α →ₘ β) :=
+{ Inf := λ s, ⟨λ x, ⨅ f ∈ s, (f : _) x, λ x y h, binfi_le_binfi (λ f _, f.mono h)⟩ }
+
+@[simp] lemma Inf_apply [complete_lattice β] (s : set (α →ₘ β)) (x : α) :
+  Inf s x = ⨅ f ∈ s, (f : _) x := rfl
+
+lemma infi_apply {ι : Sort*} [complete_lattice β] (f : ι → α →ₘ β) (x : α) :
+  (⨅ i, f i) x = ⨅ i, f i x :=
+(Inf_apply _ _).trans infi_range
+
+@[simp, norm_cast] lemma coe_infi {ι : Sort*} [complete_lattice β] (f : ι → α →ₘ β) :
+  ((⨅ i, f i : α →ₘ β) : α → β) = ⨅ i, f i :=
+funext $ λ x, (infi_apply f x).trans (@_root_.infi_apply _ _ _ _ (λ i, f i) _).symm
+
+instance [complete_lattice β] : has_Sup (α →ₘ β) :=
+{ Sup := λ s, ⟨λ x, ⨆ f ∈ s, (f : _) x, λ x y h, bsupr_le_bsupr (λ f _, f.mono h)⟩ }
+
+@[simp] lemma Sup_apply [complete_lattice β] (s : set (α →ₘ β)) (x : α) :
+  Sup s x = ⨆ f ∈ s, (f : _) x := rfl
+
+lemma supr_apply {ι : Sort*} [complete_lattice β] (f : ι → α →ₘ β) (x : α) :
+  (⨆ i, f i) x = ⨆ i, f i x :=
+(Sup_apply _ _).trans supr_range
+
+@[simp, norm_cast] lemma coe_supr {ι : Sort*} [complete_lattice β] (f : ι → α →ₘ β) :
+  ((⨆ i, f i : α →ₘ β) : α → β) = ⨆ i, f i :=
+funext $ λ x, (supr_apply f x).trans (@_root_.supr_apply _ _ _ _ (λ i, f i) _).symm
+
+instance [complete_lattice β] : complete_lattice (α →ₘ β) :=
+{ Sup := Sup,
+  le_Sup := λ s f hf x, le_supr_of_le f (le_supr _ hf),
+  Sup_le := λ s f hf x, bsupr_le (λ g hg, hf g hg x),
+  Inf := Inf,
+  le_Inf := λ s f hf x, le_binfi (λ g hg, hf g hg x),
+  Inf_le := λ s f hf x, infi_le_of_le f (infi_le _ hf),
+  .. (_ : lattice (α →ₘ β)),
+  .. order_hom.order_top,
+  .. order_hom.order_bot }
+
+lemma iterate_sup_le_sup_iff {α : Type*} [semilattice_sup α] (f : α →ₘ α) :
+  (∀ n₁ n₂ a₁ a₂, f^[n₁ + n₂] (a₁ ⊔ a₂) ≤ (f^[n₁] a₁) ⊔ (f^[n₂] a₂)) ↔
+  (∀ a₁ a₂, f (a₁ ⊔ a₂) ≤ (f a₁) ⊔ a₂) :=
+begin
+  split; intros h,
+  { exact h 1 0, },
+  { intros n₁ n₂ a₁ a₂, have h' : ∀ n a₁ a₂, f^[n] (a₁ ⊔ a₂) ≤ (f^[n] a₁) ⊔ a₂,
+    { intros n, induction n with n ih; intros a₁ a₂,
+      { refl, },
+      { calc f^[n + 1] (a₁ ⊔ a₂) = (f^[n] (f (a₁ ⊔ a₂))) : function.iterate_succ_apply f n _
+                             ... ≤ (f^[n] ((f a₁) ⊔ a₂)) : f.mono.iterate n (h a₁ a₂)
+                             ... ≤ (f^[n] (f a₁)) ⊔ a₂ : ih _ _
+                             ... = (f^[n + 1] a₁) ⊔ a₂ : by rw ← function.iterate_succ_apply, }, },
+    calc f^[n₁ + n₂] (a₁ ⊔ a₂) = (f^[n₁] (f^[n₂] (a₁ ⊔ a₂))) : function.iterate_add_apply f n₁ n₂ _
+                           ... = (f^[n₁] (f^[n₂] (a₂ ⊔ a₁))) : by rw sup_comm
+                           ... ≤ (f^[n₁] ((f^[n₂] a₂) ⊔ a₁)) : f.mono.iterate n₁ (h' n₂ _ _)
+                           ... = (f^[n₁] (a₁ ⊔ (f^[n₂] a₂))) : by rw sup_comm
+                           ... ≤ (f^[n₁] a₁) ⊔ (f^[n₂] a₂) : h' n₁ a₁ _, },
+end
+
+end preorder
+
+end order_hom

--- a/src/order/omega_complete_partial_order.lean
+++ b/src/order/omega_complete_partial_order.lean
@@ -5,7 +5,7 @@ Authors: Simon Hudon
 -/
 import control.monad.basic
 import data.part
-import order.order_hom
+import order.hom.lattice
 import tactic.monotonicity
 import tactic.wlog
 

--- a/src/order/order_iso_nat.lean
+++ b/src/order/order_iso_nat.lean
@@ -4,8 +4,9 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro
 -/
 import data.equiv.denumerable
-import order.order_hom
 import data.nat.lattice
+import logic.function.iterate
+import order.hom.basic
 
 /-!
 # Relation embeddings from the naturals

--- a/src/order/partial_sups.lean
+++ b/src/order/partial_sups.lean
@@ -5,7 +5,7 @@ Authors: Scott Morrison
 -/
 import data.finset.lattice
 import data.set.pairwise
-import order.order_hom
+import order.hom.basic
 
 /-!
 # The monotone sequence of partial supremums of a sequence

--- a/src/order/rel_iso.lean
+++ b/src/order/rel_iso.lean
@@ -22,10 +22,6 @@ isomorphisms.
   `r a b ↔ s (f a) (f b)`.
 * `rel_iso`: Relation isomorphism. A `rel_iso r s` is an equivalence `f : α ≃ β` such that
   `r a b ↔ s (f a) (f b)`.
-* `order_embedding`: Relation embedding. An `order_embedding α β` is an embedding `f : α ↪ β` such
-  that `a ≤ b ↔ f a ≤ f b`. Defined as an abbreviation of `@rel_embedding α β (≤) (≤)`.
-* `order_iso`: Relation isomorphism. An `order_iso α β` is an equivalence `f : α ≃ β` such that
-  `a ≤ b ↔ f a ≤ f b`. Defined as an abbreviation of `@rel_iso α β (≤) (≤)`.
 * `sum_lex_congr`, `prod_lex_congr`: Creates a relation homomorphism between two `sum_lex` or two
   `prod_lex` from relation homomorphisms between their arguments.
 
@@ -34,8 +30,6 @@ isomorphisms.
 * `→r`: `rel_hom`
 * `↪r`: `rel_embedding`
 * `≃r`: `rel_iso`
-* `↪o`: `order_embedding`
-* `≃o`: `order_iso`
 -/
 
 open function
@@ -148,13 +142,6 @@ structure rel_embedding {α β : Type*} (r : α → α → Prop) (s : β → β 
 (map_rel_iff' : ∀ {a b}, s (to_embedding a) (to_embedding b) ↔ r a b)
 
 infix ` ↪r `:25 := rel_embedding
-
-/-- An order embedding is an embedding `f : α ↪ β` such that `a ≤ b ↔ (f a) ≤ (f b)`.
-This definition is an abbreviation of `rel_embedding (≤) (≤)`. -/
-abbreviation order_embedding (α β : Type*) [has_le α] [has_le β] :=
-@rel_embedding α β (≤) (≤)
-
-infix ` ↪o `:25 := order_embedding
 
 /-- The induced relation on a subtype is an embedding under the natural inclusion. -/
 definition subtype.rel_embedding {X : Type*} (r : X → X → Prop) (p : X → Prop) :
@@ -316,90 +303,13 @@ end
 @[simp] theorem of_monotone_coe [is_trichotomous α r] [is_asymm β s] (f : α → β) (H) :
   (@of_monotone _ _ r s _ _ f H : α → β) = f := rfl
 
-/-- Embeddings of partial orders that preserve `<` also preserve `≤`. -/
-def order_embedding_of_lt_embedding [partial_order α] [partial_order β]
-  (f : ((<) : α → α → Prop) ↪r ((<) : β → β → Prop)) :
-  α ↪o β :=
-{ map_rel_iff' := by { intros, simp [le_iff_lt_or_eq,f.map_rel_iff, f.injective.eq_iff] }, .. f }
-
-@[simp]
-lemma order_embedding_of_lt_embedding_apply [partial_order α] [partial_order β]
-  {f : ((<) : α → α → Prop) ↪r ((<) : β → β → Prop)} {x : α} :
-  order_embedding_of_lt_embedding f x = f x := rfl
-
 end rel_embedding
-
-namespace order_embedding
-
-variables [preorder α] [preorder β] (f : α ↪o β)
-
-/-- `<` is preserved by order embeddings of preorders. -/
-def lt_embedding : ((<) : α → α → Prop) ↪r ((<) : β → β → Prop) :=
-{ map_rel_iff' := by intros; simp [lt_iff_le_not_le, f.map_rel_iff], .. f }
-
-@[simp] lemma lt_embedding_apply (x : α) : f.lt_embedding x = f x := rfl
-
-@[simp] theorem le_iff_le {a b} : (f a) ≤ (f b) ↔ a ≤ b := f.map_rel_iff
-
-@[simp] theorem lt_iff_lt {a b} : f a < f b ↔ a < b :=
-f.lt_embedding.map_rel_iff
-
-@[simp] lemma eq_iff_eq {a b} : f a = f b ↔ a = b := f.injective.eq_iff
-
-protected theorem monotone : monotone f := λ x y, f.le_iff_le.2
-
-protected theorem strict_mono : strict_mono f := λ x y, f.lt_iff_lt.2
-
-protected theorem acc (a : α) : acc (<) (f a) → acc (<) a :=
-f.lt_embedding.acc a
-
-protected theorem well_founded :
-  well_founded ((<) : β → β → Prop) → well_founded ((<) : α → α → Prop) :=
-f.lt_embedding.well_founded
-
-protected theorem is_well_order [is_well_order β (<)] : is_well_order α (<) :=
-f.lt_embedding.is_well_order
-
-/-- An order embedding is also an order embedding between dual orders. -/
-protected def dual : order_dual α ↪o order_dual β :=
-⟨f.to_embedding, λ a b, f.map_rel_iff⟩
-
-/--
-To define an order embedding from a partial order to a preorder it suffices to give a function
-together with a proof that it satisfies `f a ≤ f b ↔ a ≤ b`.
--/
-def of_map_le_iff {α β} [partial_order α] [preorder β] (f : α → β)
-  (hf : ∀ a b, f a ≤ f b ↔ a ≤ b) : α ↪o β :=
-rel_embedding.of_map_rel_iff f hf
-
-@[simp] lemma coe_of_map_le_iff {α β} [partial_order α] [preorder β] {f : α → β} (h) :
-  ⇑(of_map_le_iff f h) = f := rfl
-
-/-- A strictly monotone map from a linear order is an order embedding. --/
-def of_strict_mono {α β} [linear_order α] [preorder β] (f : α → β)
-  (h : strict_mono f) : α ↪o β :=
-of_map_le_iff f (λ _ _, h.le_iff_le)
-
-@[simp] lemma coe_of_strict_mono {α β} [linear_order α] [preorder β] {f : α → β}
-  (h : strict_mono f) : ⇑(of_strict_mono f h) = f := rfl
-
-/-- Embedding of a subtype into the ambient type as an `order_embedding`. -/
-@[simps {fully_applied := ff}] def subtype (p : α → Prop) : subtype p ↪o α :=
-⟨embedding.subtype p, λ x y, iff.rfl⟩
-
-end order_embedding
 
 /-- A relation isomorphism is an equivalence that is also a relation embedding. -/
 structure rel_iso {α β : Type*} (r : α → α → Prop) (s : β → β → Prop) extends α ≃ β :=
 (map_rel_iff' : ∀ {a b}, s (to_equiv a) (to_equiv b) ↔ r a b)
 
 infix ` ≃r `:25 := rel_iso
-
-/-- An order isomorphism is an equivalence such that `a ≤ b ↔ (f a) ≤ (f b)`.
-This definition is an abbreviation of `rel_iso (≤) (≤)`. -/
-abbreviation order_iso (α β : Type*) [has_le α] [has_le β] := @rel_iso α β (≤) (≤)
-
-infix ` ≃o `:25 := order_iso
 
 namespace rel_iso
 
@@ -541,190 +451,6 @@ lemma mul_apply (e₁ e₂ : r ≃r r) (x : α) : (e₁ * e₂) x = e₁ (e₂ x
 
 end rel_iso
 
-namespace order_iso
-
-section has_le
-
-variables [has_le α] [has_le β] [has_le γ]
-
-/-- Reinterpret an order isomorphism as an order embedding. -/
-def to_order_embedding (e : α ≃o β) : α ↪o β :=
-e.to_rel_embedding
-
-@[simp] lemma coe_to_order_embedding (e : α ≃o β) :
-  ⇑(e.to_order_embedding) = e := rfl
-
-protected lemma bijective (e : α ≃o β) : bijective e := e.to_equiv.bijective
-protected lemma injective (e : α ≃o β) : injective e := e.to_equiv.injective
-protected lemma surjective (e : α ≃o β) : surjective e := e.to_equiv.surjective
-
-@[simp] lemma range_eq (e : α ≃o β) : set.range e = set.univ := e.surjective.range_eq
-
-@[simp] lemma apply_eq_iff_eq (e : α ≃o β) {x y : α} : e x = e y ↔ x = y :=
-e.to_equiv.apply_eq_iff_eq
-
-/-- Identity order isomorphism. -/
-def refl (α : Type*) [has_le α] : α ≃o α := rel_iso.refl (≤)
-
-@[simp] lemma coe_refl : ⇑(refl α) = id := rfl
-
-lemma refl_apply (x : α) : refl α x = x := rfl
-
-@[simp] lemma refl_to_equiv : (refl α).to_equiv = equiv.refl α := rfl
-
-/-- Inverse of an order isomorphism. -/
-def symm (e : α ≃o β) : β ≃o α := e.symm
-
-@[simp] lemma apply_symm_apply (e : α ≃o β) (x : β) : e (e.symm x) = x :=
-e.to_equiv.apply_symm_apply x
-
-@[simp] lemma symm_apply_apply (e : α ≃o β) (x : α) : e.symm (e x) = x :=
-e.to_equiv.symm_apply_apply x
-
-@[simp] lemma symm_refl (α : Type*) [has_le α] : (refl α).symm = refl α := rfl
-
-lemma apply_eq_iff_eq_symm_apply (e : α ≃o β) (x : α) (y : β) : e x = y ↔ x = e.symm y :=
-e.to_equiv.apply_eq_iff_eq_symm_apply
-
-theorem symm_apply_eq (e : α ≃o β) {x : α} {y : β} : e.symm y = x ↔ y = e x :=
-e.to_equiv.symm_apply_eq
-
-@[simp] lemma symm_symm (e : α ≃o β) : e.symm.symm = e := by { ext, refl }
-
-lemma symm_injective : injective (symm : (α ≃o β) → (β ≃o α)) :=
-λ e e' h, by rw [← e.symm_symm, h, e'.symm_symm]
-
-@[simp] lemma to_equiv_symm (e : α ≃o β) : e.to_equiv.symm = e.symm.to_equiv := rfl
-
-@[simp] lemma symm_image_image (e : α ≃o β) (s : set α) : e.symm '' (e '' s) = s :=
-e.to_equiv.symm_image_image s
-
-@[simp] lemma image_symm_image (e : α ≃o β) (s : set β) : e '' (e.symm '' s) = s :=
-e.to_equiv.image_symm_image s
-
-lemma image_eq_preimage (e : α ≃o β) (s : set α) : e '' s = e.symm ⁻¹' s :=
-e.to_equiv.image_eq_preimage s
-
-@[simp] lemma preimage_symm_preimage (e : α ≃o β) (s : set α) : e ⁻¹' (e.symm ⁻¹' s) = s :=
-e.to_equiv.preimage_symm_preimage s
-
-@[simp] lemma symm_preimage_preimage (e : α ≃o β) (s : set β) : e.symm ⁻¹' (e ⁻¹' s) = s :=
-e.to_equiv.symm_preimage_preimage s
-
-@[simp] lemma image_preimage (e : α ≃o β) (s : set β) : e '' (e ⁻¹' s) = s :=
-e.to_equiv.image_preimage s
-
-@[simp] lemma preimage_image (e : α ≃o β) (s : set α) : e ⁻¹' (e '' s) = s :=
-e.to_equiv.preimage_image s
-
-/-- Composition of two order isomorphisms is an order isomorphism. -/
-@[trans] def trans (e : α ≃o β) (e' : β ≃o γ) : α ≃o γ := e.trans e'
-
-@[simp] lemma coe_trans (e : α ≃o β) (e' : β ≃o γ) : ⇑(e.trans e') = e' ∘ e := rfl
-
-lemma trans_apply (e : α ≃o β) (e' : β ≃o γ) (x : α) : e.trans e' x = e' (e x) := rfl
-
-@[simp] lemma refl_trans (e : α ≃o β) : (refl α).trans e = e := by { ext x, refl }
-
-@[simp] lemma trans_refl (e : α ≃o β) : e.trans (refl β) = e := by { ext x, refl }
-
-end has_le
-
-open set
-
-section le
-
-variables [has_le α] [has_le β] [has_le γ]
-
-@[simp] lemma le_iff_le (e : α ≃o β) {x y : α} : e x ≤ e y ↔ x ≤ y := e.map_rel_iff
-
-lemma le_symm_apply (e : α ≃o β) {x : α} {y : β} : x ≤ e.symm y ↔ e x ≤ y :=
-e.rel_symm_apply
-
-lemma symm_apply_le (e : α ≃o β) {x : α} {y : β} : e.symm y ≤ x ↔ y ≤ e x :=
-e.symm_apply_rel
-
-end le
-
-variables [preorder α] [preorder β] [preorder γ]
-
-protected lemma monotone (e : α ≃o β) : monotone e := e.to_order_embedding.monotone
-
-protected lemma strict_mono (e : α ≃o β) : strict_mono e := e.to_order_embedding.strict_mono
-
-@[simp] lemma lt_iff_lt (e : α ≃o β) {x y : α} : e x < e y ↔ x < y :=
-e.to_order_embedding.lt_iff_lt
-
-/-- To show that `f : α → β`, `g : β → α` make up an order isomorphism of linear orders,
-    it suffices to prove `cmp a (g b) = cmp (f a) b`. --/
-def of_cmp_eq_cmp {α β} [linear_order α] [linear_order β] (f : α → β) (g : β → α)
-  (h : ∀ (a : α) (b : β), cmp a (g b) = cmp (f a) b) : α ≃o β :=
-have gf : ∀ (a : α), a = g (f a) := by { intro, rw [←cmp_eq_eq_iff, h, cmp_self_eq_eq] },
-{ to_fun := f,
-  inv_fun := g,
-  left_inv := λ a, (gf a).symm,
-  right_inv := by { intro, rw [←cmp_eq_eq_iff, ←h, cmp_self_eq_eq] },
-  map_rel_iff' := by { intros, apply le_iff_le_of_cmp_eq_cmp, convert (h _ _).symm, apply gf } }
-
-/-- Order isomorphism between two equal sets. -/
-def set_congr (s t : set α) (h : s = t) : s ≃o t :=
-{ to_equiv := equiv.set_congr h,
-  map_rel_iff' := λ x y, iff.rfl }
-
-/-- Order isomorphism between `univ : set α` and `α`. -/
-def set.univ : (set.univ : set α) ≃o α :=
-{ to_equiv := equiv.set.univ α,
-  map_rel_iff' := λ x y, iff.rfl }
-
-/-- Order isomorphism between `α → β` and `β`, where `α` has a unique element. -/
-@[simps to_equiv apply] def fun_unique (α β : Type*) [unique α] [preorder β] :
-  (α → β) ≃o β :=
-{ to_equiv := equiv.fun_unique α β,
-  map_rel_iff' := λ f g, by simp [pi.le_def, unique.forall_iff] }
-
-@[simp] lemma fun_unique_symm_apply {α β : Type*} [unique α] [preorder β] :
-  ((fun_unique α β).symm : β → α → β) = function.const α := rfl
-
-end order_iso
-
-namespace equiv
-
-variables [preorder α] [preorder β]
-
-/-- If `e` is an equivalence with monotone forward and inverse maps, then `e` is an
-order isomorphism. -/
-def to_order_iso (e : α ≃ β) (h₁ : monotone e) (h₂ : monotone e.symm) :
-  α ≃o β :=
-⟨e, λ x y, ⟨λ h, by simpa only [e.symm_apply_apply] using h₂ h, λ h, h₁ h⟩⟩
-
-@[simp] lemma coe_to_order_iso (e : α ≃ β) (h₁ : monotone e) (h₂ : monotone e.symm) :
-  ⇑(e.to_order_iso h₁ h₂) = e := rfl
-
-@[simp] lemma to_order_iso_to_equiv (e : α ≃ β) (h₁ : monotone e) (h₂ : monotone e.symm) :
-  (e.to_order_iso h₁ h₂).to_equiv = e := rfl
-
-end equiv
-
-/-- If a function `f` is strictly monotone on a set `s`, then it defines an order isomorphism
-between `s` and its image. -/
-protected noncomputable def strict_mono_on.order_iso {α β} [linear_order α] [preorder β]
-  (f : α → β) (s : set α) (hf : strict_mono_on f s) :
-  s ≃o f '' s :=
-{ to_equiv := hf.inj_on.bij_on_image.equiv _,
-  map_rel_iff' := λ x y, hf.le_iff_le x.2 y.2 }
-
-/-- A strictly monotone function from a linear order is an order isomorphism between its domain and
-its range. -/
-protected noncomputable def strict_mono.order_iso {α β} [linear_order α] [preorder β] (f : α → β)
-  (h_mono : strict_mono f) : α ≃o set.range f :=
-{ to_equiv := equiv.of_injective f h_mono.injective,
-  map_rel_iff' := λ a b, h_mono.le_iff_le }
-
-/-- A strictly monotone surjective function from a linear order is an order isomorphism. -/
-noncomputable def strict_mono.order_iso_of_surjective {α β} [linear_order α] [preorder β]
-  (f : α → β) (h_mono : strict_mono f) (h_surj : surjective f) : α ≃o β :=
-(h_mono.order_iso f).trans $ (order_iso.set_congr _ _ h_surj.range_eq).trans order_iso.set.univ
-
 /-- `subrel r p` is the inherited relation on a subset. -/
 def subrel (r : α → α → Prop) (p : set α) : p → p → Prop :=
 (coe : p → α) ⁻¹'o r
@@ -753,91 +479,3 @@ def rel_embedding.cod_restrict (p : set β) (f : r ↪r s) (H : ∀ a, f a ∈ p
 
 @[simp] theorem rel_embedding.cod_restrict_apply (p) (f : r ↪r s) (H a) :
   rel_embedding.cod_restrict p f H a = ⟨f a, H a⟩ := rfl
-
-/-- An order isomorphism is also an order isomorphism between dual orders. -/
-protected def order_iso.dual [has_le α] [has_le β] (f : α ≃o β) :
-  order_dual α ≃o order_dual β := ⟨f.to_equiv, λ _ _, f.map_rel_iff⟩
-
-section lattice_isos
-
-lemma order_iso.map_bot' [has_le α] [partial_order β] (f : α ≃o β) {x : α} {y : β}
-  (hx : ∀ x', x ≤ x') (hy : ∀ y', y ≤ y') : f x = y :=
-by { refine le_antisymm _ (hy _), rw [← f.apply_symm_apply y, f.map_rel_iff], apply hx }
-
-lemma order_iso.map_bot [has_le α] [partial_order β] [order_bot α] [order_bot β] (f : α ≃o β) :
-  f ⊥ = ⊥ :=
-f.map_bot' (λ _, bot_le) (λ _, bot_le)
-
-lemma order_iso.map_top' [has_le α] [partial_order β] (f : α ≃o β) {x : α} {y : β}
-  (hx : ∀ x', x' ≤ x) (hy : ∀ y', y' ≤ y) : f x = y :=
-f.dual.map_bot' hx hy
-
-lemma order_iso.map_top [has_le α] [partial_order β] [order_top α] [order_top β] (f : α ≃o β) :
-  f ⊤ = ⊤ :=
-f.dual.map_bot
-
-lemma order_embedding.map_inf_le [semilattice_inf α] [semilattice_inf β]
-  (f : α ↪o β) (x y : α) :
-  f (x ⊓ y) ≤ f x ⊓ f y :=
-f.monotone.map_inf_le x y
-
-lemma order_iso.map_inf [semilattice_inf α] [semilattice_inf β]
-  (f : α ≃o β) (x y : α) :
-  f (x ⊓ y) = f x ⊓ f y :=
-begin
-  refine (f.to_order_embedding.map_inf_le x y).antisymm _,
-  simpa [← f.symm.le_iff_le] using f.symm.to_order_embedding.map_inf_le (f x) (f y)
-end
-
-/-- Note that this goal could also be stated `(disjoint on f) a b` -/
-lemma disjoint.map_order_iso [semilattice_inf α] [order_bot α] [semilattice_inf β] [order_bot β]
-  {a b : α} (f : α ≃o β) (ha : disjoint a b) : disjoint (f a) (f b) :=
-begin
-  rw [disjoint, ←f.map_inf, ←f.map_bot],
-  exact f.monotone ha,
-end
-
-@[simp] lemma disjoint_map_order_iso_iff [semilattice_inf α] [order_bot α] [semilattice_inf β]
-  [order_bot β] {a b : α} (f : α ≃o β) : disjoint (f a) (f b) ↔ disjoint a b :=
-⟨λ h, f.symm_apply_apply a ▸ f.symm_apply_apply b ▸ h.map_order_iso f.symm, λ h, h.map_order_iso f⟩
-
-lemma order_embedding.le_map_sup [semilattice_sup α] [semilattice_sup β]
-  (f : α ↪o β) (x y : α) :
-  f x ⊔ f y ≤ f (x ⊔ y) :=
-f.monotone.le_map_sup x y
-
-lemma order_iso.map_sup [semilattice_sup α] [semilattice_sup β]
-  (f : α ≃o β) (x y : α) :
-  f (x ⊔ y) = f x ⊔ f y :=
-f.dual.map_inf x y
-
-section bounded_order
-
-variables [lattice α] [lattice β] [bounded_order α] [bounded_order β] (f : α ≃o β)
-include f
-
-lemma order_iso.is_compl {x y : α} (h : is_compl x y) : is_compl (f x) (f y) :=
-⟨by { rw [← f.map_bot, ← f.map_inf, f.map_rel_iff], exact h.1 },
-  by { rw [← f.map_top, ← f.map_sup, f.map_rel_iff], exact h.2 }⟩
-
-theorem order_iso.is_compl_iff {x y : α} :
-  is_compl x y ↔ is_compl (f x) (f y) :=
-⟨f.is_compl, λ h, begin
-  rw [← f.symm_apply_apply x, ← f.symm_apply_apply y],
-  exact f.symm.is_compl h,
-end⟩
-
-lemma order_iso.is_complemented
-  [is_complemented α] : is_complemented β :=
-⟨λ x, begin
-  obtain ⟨y, hy⟩ := exists_is_compl (f.symm x),
-  rw ← f.symm_apply_apply y at hy,
-  refine ⟨f y, f.symm.is_compl_iff.2 hy⟩,
-end⟩
-
-theorem order_iso.is_complemented_iff :
-  is_complemented α ↔ is_complemented β :=
-⟨by { introI, exact f.is_complemented }, by { introI, exact f.symm.is_complemented }⟩
-
-end bounded_order
-end lattice_isos


### PR DESCRIPTION
We symmetrize the locations of `rel_{hom,iso,embedding}` and `order_{hom,iso,embedding}` by putting the `rel_` definitions in `order/rel_iso.lean` and the `order_` definitions in `order/hom/basic.lean`. (`order_hom.lean` needed to be split up to fix an import loop.) Requested by @YaelDillies.

## Moved definitions
 * `order_hom`, `order_iso`, `order_embedding` are now in `order/hom/basic.lean`
 * `order_hom.has_sup` ... `order_hom.complete_lattice` are now in `order/hom/lattice.lean`

## Other changes

Some import cleanup.

---

- [x] depends on: #10750

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
