### PR TITLE
[Merged by Bors] - feat(order): define a `rel_hom_class` for types of relation-preserving maps

### DIFF
--- a/src/algebra/lie/subalgebra.lean
+++ b/src/algebra/lie/subalgebra.lean
@@ -366,13 +366,11 @@ variables (R L)
 
 lemma well_founded_of_noetherian [is_noetherian R L] :
   well_founded ((>) : lie_subalgebra R L → lie_subalgebra R L → Prop) :=
-begin
   let f : ((>) : lie_subalgebra R L → lie_subalgebra R L → Prop) →r
           ((>) : submodule R L → submodule R L → Prop) :=
   { to_fun       := coe,
-    map_rel' := λ N N' h, h, },
-  apply f.well_founded, rw ← is_noetherian_iff_well_founded, apply_instance,
-end
+    map_rel' := λ N N' h, h, }
+in rel_hom_class.well_founded f (is_noetherian_iff_well_founded.mp infer_instance)
 
 variables {R L K K' f}
 

--- a/src/algebra/lie/submodule.lean
+++ b/src/algebra/lie/submodule.lean
@@ -346,13 +346,12 @@ variables (R L M)
 
 lemma well_founded_of_noetherian [is_noetherian R M] :
   well_founded ((>) : lie_submodule R L M → lie_submodule R L M → Prop) :=
-begin
-  let f : ((>) : lie_submodule R L M → lie_submodule R L M → Prop) →r
-          ((>) : submodule R M → submodule R M → Prop) :=
-  { to_fun       := coe,
-    map_rel' := λ N N' h, h, },
-  apply f.well_founded, rw ← is_noetherian_iff_well_founded, apply_instance,
-end
+
+let f : ((>) : lie_submodule R L M → lie_submodule R L M → Prop) →r
+        ((>) : submodule R M → submodule R M → Prop) :=
+{ to_fun       := coe,
+  map_rel' := λ N N' h, h, }
+in rel_hom_class.well_founded f (is_noetherian_iff_well_founded.mp infer_instance)
 
 @[simp] lemma subsingleton_iff : subsingleton (lie_submodule R L M) ↔ subsingleton M :=
 have h : subsingleton (lie_submodule R L M) ↔ subsingleton (submodule R M),

--- a/src/order/compactly_generated.lean
+++ b/src/order/compactly_generated.lean
@@ -178,7 +178,7 @@ begin
     apply lt_irrefl (a (n+1)), apply lt_of_le_of_lt _ h', apply le_Sup, apply set.mem_range_self, },
   apply h (set.range a),
   { use a 37, apply set.mem_range_self, },
-  { rintros x y ⟨m, hm⟩ ⟨n, hn⟩, use m ⊔ n, rw [← hm, ← hn], apply a.to_rel_hom.map_sup, },
+  { rintros x y ⟨m, hm⟩ ⟨n, hn⟩, use m ⊔ n, rw [← hm, ← hn], apply rel_hom_class.map_sup a, },
 end
 
 lemma is_Sup_finite_compact_iff_all_elements_compact :

--- a/src/order/hom/basic.lean
+++ b/src/order/hom/basic.lean
@@ -72,6 +72,10 @@ structure order_hom (α β : Type*) [preorder α] [preorder β] :=
 
 infixr ` →ₘ `:25 := order_hom
 
+/-- `order_hom_class F α b` asserts that `F` is a type of `≤`-preserving morphisms. -/
+abbreviation order_hom_class (F : Type*) (α β : out_param Type*) [preorder α] [preorder β] :=
+rel_hom_class F ((≤) : α → α → Prop) ((≤) : β → β → Prop).
+
 /-- An order embedding is an embedding `f : α ↪ β` such that `a ≤ b ↔ (f a) ≤ (f b)`.
 This definition is an abbreviation of `rel_embedding (≤) (≤)`. -/
 abbreviation order_embedding (α β : Type*) [has_le α] [has_le β] :=
@@ -87,6 +91,15 @@ infix ` ≃o `:25 := order_iso
 
 variables {α β γ δ : Type*}
 
+namespace order_hom_class
+
+variables {F : Type*} [preorder α] [preorder β] [order_hom_class F α β]
+
+protected lemma monotone (f : F) : monotone (f : α → β) := λ _ _, map_rel f
+protected lemma mono (f : F) : monotone (f : α → β) := λ _ _, map_rel f
+
+end order_hom_class
+
 namespace order_hom
 variables [preorder α] [preorder β] [preorder γ] [preorder δ]
 
@@ -97,12 +110,16 @@ initialize_simps_projections order_hom (to_fun → coe)
 protected lemma monotone (f : α →ₘ β) : monotone f := f.monotone'
 protected lemma mono (f : α →ₘ β) : monotone f := f.monotone
 
+instance : order_hom_class (α →ₘ β) α β :=
+{ coe := to_fun,
+  coe_injective' := λ f g h, by { cases f, cases g, congr' },
+  map_rel := λ f, f.monotone }
+
 @[simp] lemma to_fun_eq_coe {f : α →ₘ β} : f.to_fun = f := rfl
 @[simp] lemma coe_fun_mk {f : α → β} (hf : _root_.monotone f) : (mk f hf : α → β) = f := rfl
 
 @[ext] -- See library note [partially-applied ext lemmas]
-lemma ext (f g : α →ₘ β) (h : (f : α → β) = g) : f = g :=
-by { cases f, cases g, congr, exact h }
+lemma ext (f g : α →ₘ β) (h : (f : α → β) = g) : f = g := fun_like.coe_injective h
 
 /-- One can lift an unbundled monotone function to a bundled one. -/
 instance : can_lift (α → β) (α →ₘ β) :=
@@ -315,7 +332,7 @@ f.lt_embedding.map_rel_iff
 
 @[simp] lemma eq_iff_eq {a b} : f a = f b ↔ a = b := f.injective.eq_iff
 
-protected theorem monotone : monotone f := λ x y, f.le_iff_le.2
+protected theorem monotone : monotone f := order_hom_class.monotone f
 
 protected theorem strict_mono : strict_mono f := λ x y, f.lt_iff_lt.2
 

--- a/src/order/rel_iso.lean
+++ b/src/order/rel_iso.lean
@@ -5,6 +5,7 @@ Authors: Mario Carneiro
 -/
 import algebra.group.defs
 import data.equiv.set
+import data.fun_like
 import logic.embedding
 import order.rel_classes
 
@@ -46,13 +47,65 @@ structure rel_hom {α β : Type*} (r : α → α → Prop) (s : β → β → Pr
 
 infix ` →r `:25 := rel_hom
 
+/-- `rel_hom_class F r s` asserts that `F` is a type of functions such that all `f : F`
+satisfy `r a b → s (f a) (f b)`.
+
+The relations `r` and `s` are `out_param`s since figuring them out from a goal is a higher-order
+matching problem that Lean usually can't do unaided.
+-/
+class rel_hom_class (F : Type*) {α β : Type*}
+  (r : out_param $ α → α → Prop) (s : out_param $ β → β → Prop)
+  extends fun_like F α (λ _, β) :=
+(map_rel : ∀ (f : F) {a b}, r a b → s (f a) (f b))
+
+export rel_hom_class (map_rel)
+
+namespace rel_hom_class
+
+variables {F : Type*}
+
+lemma map_inf [semilattice_inf α] [linear_order β]
+  [rel_hom_class F ((<) : β → β → Prop) ((<) : α → α → Prop)]
+  (a : F) (m n : β) : a (m ⊓ n) = a m ⊓ a n :=
+(strict_mono.monotone $ λ x y, map_rel a).map_inf m n
+
+lemma map_sup [semilattice_sup α] [linear_order β]
+  [rel_hom_class F ((>) : β → β → Prop) ((>) : α → α → Prop)]
+  (a : F) (m n : β) : a (m ⊔ n) = a m ⊔ a n :=
+@map_inf (order_dual α) (order_dual β) _ _ _ _ _ _ _
+
+protected theorem is_irrefl [rel_hom_class F r s] (f : F) : ∀ [is_irrefl β s], is_irrefl α r
+| ⟨H⟩ := ⟨λ a h, H _ (map_rel f h)⟩
+
+protected theorem is_asymm [rel_hom_class F r s] (f : F) : ∀ [is_asymm β s], is_asymm α r
+| ⟨H⟩ := ⟨λ a b h₁ h₂, H _ _ (map_rel f h₁) (map_rel f h₂)⟩
+
+protected theorem acc [rel_hom_class F r s] (f : F) (a : α) : acc s (f a) → acc r a :=
+begin
+  generalize h : f a = b, intro ac,
+  induction ac with _ H IH generalizing a, subst h,
+  exact ⟨_, λ a' h, IH (f a') (map_rel f h) _ rfl⟩
+end
+
+protected theorem well_founded [rel_hom_class F r s] (f : F) :
+  ∀ (h : well_founded s), well_founded r
+| ⟨H⟩ := ⟨λ a, rel_hom_class.acc f _ (H _)⟩
+
+end rel_hom_class
+
 namespace rel_hom
 
+instance : rel_hom_class (r →r s) r s :=
+{ coe := λ o, o.to_fun,
+  coe_injective' := λ f g h, by { cases f, cases g, congr' },
+  map_rel := map_rel' }
+
+/-- Auxiliary instance if `rel_hom_class.to_fun_like.to_has_coe_to_fun` isn't found -/
 instance : has_coe_to_fun (r →r s) (λ _, α → β) := ⟨λ o, o.to_fun⟩
 
 initialize_simps_projections rel_hom (to_fun → apply)
 
-theorem map_rel (f : r →r s) : ∀ {a b}, r a b → s (f a) (f b) := f.map_rel'
+protected theorem map_rel (f : r →r s) : ∀ {a b}, r a b → s (f a) (f b) := f.map_rel'
 
 @[simp] theorem coe_fn_mk (f : α → β) (o) :
   (@rel_hom.mk _ _ r s f o : α → β) = f := rfl
@@ -60,14 +113,14 @@ theorem map_rel (f : r →r s) : ∀ {a b}, r a b → s (f a) (f b) := f.map_rel
 @[simp] theorem coe_fn_to_fun (f : r →r s) : (f.to_fun : α → β) = f := rfl
 
 /-- The map `coe_fn : (r →r s) → (α → β)` is injective. -/
-theorem coe_fn_injective : @function.injective (r →r s) (α → β) coe_fn
-| ⟨f₁, o₁⟩ ⟨f₂, o₂⟩ h := by { congr, exact h }
+theorem coe_fn_injective : @function.injective (r →r s) (α → β) coe_fn :=
+fun_like.coe_injective
 
 @[ext] theorem ext ⦃f g : r →r s⦄ (h : ∀ x, f x = g x) : f = g :=
-coe_fn_injective (funext h)
+fun_like.ext f g h
 
 theorem ext_iff {f g : r →r s} : f = g ↔ ∀ x, f x = g x :=
-⟨λ h x, h ▸ rfl, λ h, ext h⟩
+fun_like.ext_iff
 
 /-- Identity map is a relation homomorphism. -/
 @[refl, simps] protected def id (r : α → α → Prop) : r →r r :=
@@ -83,30 +136,6 @@ protected def swap (f : r →r s) : swap r →r swap s :=
 
 /-- A function is a relation homomorphism from the preimage relation of `s` to `s`. -/
 def preimage (f : α → β) (s : β → β → Prop) : f ⁻¹'o s →r s := ⟨f, λ a b, id⟩
-
-protected theorem is_irrefl : ∀ (f : r →r s) [is_irrefl β s], is_irrefl α r
-| ⟨f, o⟩ ⟨H⟩ := ⟨λ a h, H _ (o h)⟩
-
-protected theorem is_asymm : ∀ (f : r →r s) [is_asymm β s], is_asymm α r
-| ⟨f, o⟩ ⟨H⟩ := ⟨λ a b h₁ h₂, H _ _ (o h₁) (o h₂)⟩
-
-protected theorem acc (f : r →r s) (a : α) : acc s (f a) → acc r a :=
-begin
-  generalize h : f a = b, intro ac,
-  induction ac with _ H IH generalizing a, subst h,
-  exact ⟨_, λ a' h, IH (f a') (f.map_rel h) _ rfl⟩
-end
-
-protected theorem well_founded : ∀ (f : r →r s) (h : well_founded s), well_founded r
-| f ⟨H⟩ := ⟨λ a, f.acc _ (H _)⟩
-
-lemma map_inf {α β : Type*} [semilattice_inf α] [linear_order β]
-  (a : ((<) : β → β → Prop) →r ((<) : α → α → Prop)) (m n : β) : a (m ⊓ n) = a m ⊓ a n :=
-(strict_mono.monotone $ λ x y, a.map_rel).map_inf m n
-
-lemma map_sup {α β : Type*} [semilattice_sup α] [linear_order β]
-  (a : ((>) : β → β → Prop) →r ((>) : α → α → Prop)) (m n : β) : a (m ⊔ n) = a m ⊔ a n :=
-@rel_hom.map_inf (order_dual α) (order_dual β) _ _ _ _ _
 
 end rel_hom
 
@@ -126,15 +155,15 @@ lemma rel_hom.injective_of_increasing [is_trichotomous α r]
   [is_irrefl β s] (f : r →r s) : injective f :=
 injective_of_increasing r s f (λ x y, f.map_rel)
 
+-- TODO: define a `rel_iff_class` so we don't have to do all the `convert` trickery?
 theorem surjective.well_founded_iff {f : α → β} (hf : surjective f)
   (o : ∀ {a b}, r a b ↔ s (f a) (f b)) : well_founded r ↔ well_founded s :=
 iff.intro (begin
-  apply rel_hom.well_founded,
-  refine rel_hom.mk _ _,
-  {exact classical.some hf.has_right_inverse},
+  refine rel_hom_class.well_founded (rel_hom.mk _ _ : s →r r),
+  { exact classical.some hf.has_right_inverse },
   intros a b h, apply o.2, convert h,
   iterate 2 { apply classical.some_spec hf.has_right_inverse },
-end) (rel_hom.well_founded ⟨f, λ _ _, o.1⟩)
+end) (rel_hom_class.well_founded (⟨f, λ _ _, o.1⟩ : r →r s))
 
 /-- A relation embedding with respect to a given pair of relations `r` and `s`
 is an embedding `f : α ↪ β` such that `r a b ↔ s (f a) (f b)`. -/
@@ -163,6 +192,12 @@ instance : has_coe (r ↪r s) (r →r s) := ⟨to_rel_hom⟩
 -- see Note [function coercion]
 instance : has_coe_to_fun (r ↪r s) (λ _, α → β) := ⟨λ o, o.to_embedding⟩
 
+-- TODO: define and instantiate a `rel_embedding_class` when `embedding_like` is defined
+instance : rel_hom_class (r ↪r s) r s :=
+{ coe := coe_fn,
+  coe_injective' := λ f g h, by { rcases f with ⟨⟨⟩⟩, rcases g with ⟨⟨⟩⟩, congr' },
+  map_rel := λ f a b, iff.mpr (map_rel_iff' f) }
+
 /-- See Note [custom simps projection]. We need to specify this projection explicitly in this case,
 because it is a composition of multiple projections. -/
 def simps.apply (h : r ↪r s) : α → β := h
@@ -183,14 +218,11 @@ theorem map_rel_iff (f : r ↪r s) : ∀ {a b}, s (f a) (f b) ↔ r a b := f.map
 @[simp] theorem coe_fn_to_embedding (f : r ↪r s) : (f.to_embedding : α → β) = f := rfl
 
 /-- The map `coe_fn : (r ↪r s) → (α → β)` is injective. -/
-theorem coe_fn_injective : @function.injective (r ↪r s) (α → β) coe_fn
-| ⟨⟨f₁, h₁⟩, o₁⟩ ⟨⟨f₂, h₂⟩, o₂⟩ h := by { congr, exact h }
+theorem coe_fn_injective : @function.injective (r ↪r s) (α → β) coe_fn := fun_like.coe_injective
 
-@[ext] theorem ext ⦃f g : r ↪r s⦄ (h : ∀ x, f x = g x) : f = g :=
-coe_fn_injective (funext h)
+@[ext] theorem ext ⦃f g : r ↪r s⦄ (h : ∀ x, f x = g x) : f = g := fun_like.ext _ _ h
 
-theorem ext_iff {f g : r ↪r s} : f = g ↔ ∀ x, f x = g x :=
-⟨λ h x, h ▸ rfl, λ h, ext h⟩
+theorem ext_iff {f g : r ↪r s} : f = g ↔ ∀ x, f x = g x := fun_like.ext_iff
 
 /-- Identity map is a relation embedding. -/
 @[refl, simps] protected def refl (r : α → α → Prop) : r ↪r r :=
@@ -319,9 +351,18 @@ in the target type. -/
 def to_rel_embedding (f : r ≃r s) : r ↪r s :=
 ⟨f.to_equiv.to_embedding, f.map_rel_iff'⟩
 
+theorem to_equiv_injective : injective (to_equiv : (r ≃r s) → α ≃ β)
+| ⟨e₁, o₁⟩ ⟨e₂, o₂⟩ h := by { congr, exact h }
+
 instance : has_coe (r ≃r s) (r ↪r s) := ⟨to_rel_embedding⟩
 -- see Note [function coercion]
 instance : has_coe_to_fun (r ≃r s) (λ _, α → β) := ⟨λ f, f⟩
+
+-- TODO: define and instantiate a `rel_iso_class` when `equiv_like` is defined
+instance : rel_hom_class (r ≃r s) r s :=
+{ coe := coe_fn,
+  coe_injective' := equiv.coe_fn_injective.comp to_equiv_injective,
+  map_rel := λ f a b, iff.mpr (map_rel_iff' f) }
 
 @[simp] lemma to_rel_embedding_eq_coe (f : r ≃r s) : f.to_rel_embedding = f := rfl
 
@@ -334,19 +375,13 @@ theorem map_rel_iff (f : r ≃r s) : ∀ {a b}, s (f a) (f b) ↔ r a b := f.map
 
 @[simp] theorem coe_fn_to_equiv (f : r ≃r s) : (f.to_equiv : α → β) = f := rfl
 
-theorem to_equiv_injective : injective (to_equiv : (r ≃r s) → α ≃ β)
-| ⟨e₁, o₁⟩ ⟨e₂, o₂⟩ h := by { congr, exact h }
-
 /-- The map `coe_fn : (r ≃r s) → (α → β)` is injective. Lean fails to parse
 `function.injective (λ e : r ≃r s, (e : α → β))`, so we use a trick to say the same. -/
-theorem coe_fn_injective : @function.injective (r ≃r s) (α → β) coe_fn :=
-equiv.coe_fn_injective.comp to_equiv_injective
+theorem coe_fn_injective : @function.injective (r ≃r s) (α → β) coe_fn := fun_like.coe_injective
 
-@[ext] theorem ext ⦃f g : r ≃r s⦄ (h : ∀ x, f x = g x) : f = g :=
-coe_fn_injective (funext h)
+@[ext] theorem ext ⦃f g : r ≃r s⦄ (h : ∀ x, f x = g x) : f = g := fun_like.ext f g h
 
-theorem ext_iff {f g : r ≃r s} : f = g ↔ ∀ x, f x = g x :=
-⟨λ h x, h ▸ rfl, λ h, ext h⟩
+theorem ext_iff {f g : r ≃r s} : f = g ↔ ∀ x, f x = g x := fun_like.ext_iff
 
 /-- Inverse map of a relation isomorphism is a relation isomorphism. -/
 @[symm] protected def symm (f : r ≃r s) : s ≃r r :=

--- a/src/order/rel_iso.lean
+++ b/src/order/rel_iso.lean
@@ -53,7 +53,7 @@ satisfy `r a b → s (f a) (f b)`.
 The relations `r` and `s` are `out_param`s since figuring them out from a goal is a higher-order
 matching problem that Lean usually can't do unaided.
 -/
-class rel_hom_class (F : Type*) {α β : Type*}
+class rel_hom_class (F : Type*) {α β : out_param $ Type*}
   (r : out_param $ α → α → Prop) (s : out_param $ β → β → Prop)
   extends fun_like F α (λ _, β) :=
 (map_rel : ∀ (f : F) {a b}, r a b → s (f a) (f b))

--- a/src/order/rel_iso.lean
+++ b/src/order/rel_iso.lean
@@ -57,8 +57,10 @@ class rel_hom_class (F : Type*) {α β : out_param $ Type*}
   (r : out_param $ α → α → Prop) (s : out_param $ β → β → Prop)
   extends fun_like F α (λ _, β) :=
 (map_rel : ∀ (f : F) {a b}, r a b → s (f a) (f b))
-
 export rel_hom_class (map_rel)
+
+-- The free parameters `r` and `s` are `out_param`s so this is not dangerous.
+attribute [nolint dangerous_instance] rel_hom_class.to_fun_like
 
 namespace rel_hom_class
 

--- a/src/ring_theory/int/basic.lean
+++ b/src/ring_theory/int/basic.lean
@@ -67,13 +67,14 @@ namespace nat
 
 instance : wf_dvd_monoid ℕ :=
 ⟨begin
-  apply rel_hom.well_founded _ (with_top.well_founded_lt nat.lt_wf),
-  refine ⟨λ x, if x = 0 then ⊤ else x, _⟩,
+  refine rel_hom_class.well_founded
+    (⟨λ (x : ℕ), if x = 0 then (⊤ : with_top ℕ) else x, _⟩ : dvd_not_unit →r (<))
+    (with_top.well_founded_lt nat.lt_wf),
   intros a b h,
   cases a,
   { exfalso, revert h, simp [dvd_not_unit] },
   cases b,
-  {simp [succ_ne_zero, with_top.coe_lt_top]},
+  { simp [succ_ne_zero, with_top.coe_lt_top] },
   cases dvd_and_not_dvd_iff.2 h with h1 h2,
   simp only [succ_ne_zero, with_top.coe_lt_coe, if_false],
   apply lt_of_le_of_ne (nat.le_of_dvd (nat.succ_pos _) h1) (λ con, h2 _),

--- a/src/ring_theory/polynomial/basic.lean
+++ b/src/ring_theory/polynomial/basic.lean
@@ -606,8 +606,9 @@ instance {R : Type*} [comm_ring R] [is_domain R] [wf_dvd_monoid R] :
   wf_dvd_monoid (polynomial R) :=
 { well_founded_dvd_not_unit := begin
     classical,
-    refine rel_hom.well_founded
-      ⟨λ p, (if p = 0 then ⊤ else ↑p.degree, p.leading_coeff), _⟩
+    refine rel_hom_class.well_founded (⟨λ (p : polynomial R),
+        ((if p = 0 then ⊤ else ↑p.degree : with_top (with_bot ℕ)), p.leading_coeff), _⟩ :
+        dvd_not_unit →r prod.lex (<) dvd_not_unit)
       (prod.lex_wf (with_top.well_founded_lt $ with_bot.well_founded_lt nat.lt_wf)
         ‹wf_dvd_monoid R›.well_founded_dvd_not_unit),
     rintros a b ⟨ane0, ⟨c, ⟨not_unit_c, rfl⟩⟩⟩,

--- a/src/ring_theory/unique_factorization_domain.lean
+++ b/src/ring_theory/unique_factorization_domain.lean
@@ -256,7 +256,9 @@ include pf
 lemma wf_dvd_monoid.of_exists_prime_factors : wf_dvd_monoid α :=
 ⟨begin
   classical,
-  apply rel_hom.well_founded (rel_hom.mk _ _) (with_top.well_founded_lt nat.lt_wf),
+  refine rel_hom_class.well_founded
+    (rel_hom.mk _ _ : (dvd_not_unit : α → α → Prop) →r ((<) : with_top ℕ → with_top ℕ → Prop))
+    (with_top.well_founded_lt nat.lt_wf),
   { intro a,
     by_cases h : a = 0, { exact ⊤ },
     exact (classical.some (pf a h)).card },


### PR DESCRIPTION
Use the design of #9888 to define a class `rel_hom_class F r s` for types of maps such that all `f : F` satisfy `r a b → s (f a) (f b)`. Requested by @YaelDillies.

`order_hom_class F α β` is defined as an abbreviation for `rel_hom_class F (≤) (≤)`.

---

- [x] depends on: #10752 (to avoid conflicts)

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
