### PR TITLE
[Merged by Bors] - chore(combinatorics/simple_graph): fix name mixup

### DIFF
--- a/src/combinatorics/simple_graph/subgraph.lean
+++ b/src/combinatorics/simple_graph/subgraph.lean
@@ -260,7 +260,7 @@ instance : bounded_order (subgraph G) :=
 
 @[simp] lemma bot_verts : (⊥ : subgraph G).verts = ∅ := rfl
 
-@[simp] lemma bot_adj_iff {v w : V} : ¬(⊥ : subgraph G).adj v w := not_false
+@[simp] lemma not_bot_adj {v w : V} : ¬(⊥ : subgraph G).adj v w := not_false
 
 @[simp] lemma spanning_coe_top : (⊤ : subgraph G).spanning_coe = G :=
 by { ext, refl }

--- a/src/combinatorics/simple_graph/subgraph.lean
+++ b/src/combinatorics/simple_graph/subgraph.lean
@@ -254,13 +254,13 @@ instance : bounded_order (subgraph G) :=
   bot_le := λ x, ⟨set.empty_subset _, (λ v w h, false.rec _ h)⟩ }
 
 -- TODO simp lemmas for the other lattice operations on subgraphs
-@[simp] lemma top_adj_iff {v w : V} : (⊤ : subgraph G).adj v w ↔ G.adj v w := iff.rfl
-
 @[simp] lemma top_verts : (⊤ : subgraph G).verts = set.univ := rfl
 
-@[simp] lemma bot_adj_iff : (⊥ : subgraph G).verts = ∅ := rfl
+@[simp] lemma top_adj_iff {v w : V} : (⊤ : subgraph G).adj v w ↔ G.adj v w := iff.rfl
 
-@[simp] lemma bot_verts {v w : V} : ¬(⊥ : subgraph G).adj v w := not_false
+@[simp] lemma bot_verts : (⊥ : subgraph G).verts = ∅ := rfl
+
+@[simp] lemma bot_adj_iff {v w : V} : ¬(⊥ : subgraph G).adj v w := not_false
 
 @[simp] lemma spanning_coe_top : (⊤ : subgraph G).spanning_coe = G :=
 by { ext, refl }


### PR DESCRIPTION
Fixes the name mixup from #10778 and reorders lemmas to make the difference more clear.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
