### PR TITLE
[Merged by Bors] - feat(analysis/mean_inequalities): corollary of Hölder inequality

### DIFF
--- a/src/data/real/conjugate_exponents.lean
+++ b/src/data/real/conjugate_exponents.lean
@@ -81,6 +81,12 @@ by simpa only [sub_mul, sub_eq_iff_eq_add, one_mul] using h.sub_one_mul_conj
 { one_lt := by { rw [h.conj_eq], exact (one_lt_div h.sub_one_pos).mpr (sub_one_lt p) },
   inv_add_inv_conj := by simpa [add_comm] using h.inv_add_inv_conj }
 
+lemma div_conj_eq_sub_one : p / q = p - 1 :=
+begin
+  field_simp [h.symm.ne_zero],
+  rw h.sub_one_mul_conj
+end
+
 lemma one_lt_nnreal : 1 < real.to_nnreal p :=
 begin
   rw [←real.to_nnreal_one, real.to_nnreal_lt_to_nnreal_iff h.pos],


### PR DESCRIPTION
Several versions of the fact that
```
(∑ i in s, f i) ^ p ≤ (card s) ^ (p - 1) * ∑ i in s, (f i) ^ p
```
for `1 ≤ p`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
