### PR TITLE
[Merged by Bors] - feat(data/finsupp/basic): add lemma `disjoint_prod_add`

### DIFF
--- a/src/data/finsupp/basic.lean
+++ b/src/data/finsupp/basic.lean
@@ -1428,23 +1428,9 @@ lemma disjoint_prod_add_aux {f1 f2 : α →₀ M} (hd : disjoint f1.support f2.s
 (∏ (x : α) in f1.support, g x (f1 x + f2 x)) = f1.prod g :=
 begin
   unfold finsupp.prod,
-  have h : ∀ x ∈ f1.support, g x (f1 x + f2 x) = g x (f1 x), {
-    intros x hx,
-    simp only [not_mem_support_iff.mp (finset.disjoint_left.mp hd hx), add_zero] },
-
-
-  -- simp only [h],
-
-  -- have := prod_congr,
-  -- have := not_mem_support_iff.mp,
-  --  (finset.disjoint_left.mp hd hx),
-  have := @prod_congr α M β _ _ f1 _ _ h,
-
-    -- (λ y, (f1 y) + (f2 y)),
-  sorry,
-  -- rw prod_congr rfl,
-  -- intros x hx,
-  -- simp only [not_mem_support_iff.mp (finset.disjoint_left.mp hd hx), add_zero],
+  rw finset.prod_congr rfl,
+  intros x hx,
+  simp only [not_mem_support_iff.mp (finset.disjoint_left.mp hd hx), add_zero],
 end
 
 lemma disjoint_prod_add {f1 f2 : α →₀ M} (hd : disjoint f1.support f2.support)
@@ -1454,7 +1440,7 @@ begin
   rw [←disjoint_prod_add_aux hd, ←disjoint_prod_add_aux (disjoint.comm.mp hd)],
   simp only [add_comm, finsupp.prod, support_add_eq hd, prod_union hd, add_apply],
 end
-#exit
+
 end add_monoid_hom
 
 end map_range

--- a/src/data/finsupp/basic.lean
+++ b/src/data/finsupp/basic.lean
@@ -1291,11 +1291,9 @@ have ∀ {f1 f2 : α →₀ M}, disjoint f1.support f2.support →
   ∏ x in f1.support, g x (f1 x + f2 x) = f1.prod g :=
   λ f1 f2 hd, finset.prod_congr rfl (λ x hx,
     by simp only [not_mem_support_iff.mp (disjoint_left.mp hd hx), add_zero]),
-begin
-  rw [←this hd, ←this hd.symm],
-  simp only [add_comm, finsupp.prod, support_add_eq hd, prod_union hd, add_apply],
-end
-#exit
+by simp_rw [← this hd, ← this hd.symm,
+  add_comm (f2 _), finsupp.prod, support_add_eq hd, prod_union hd, add_apply]
+
 section map_range
 
 section equiv

--- a/src/data/finsupp/basic.lean
+++ b/src/data/finsupp/basic.lean
@@ -1421,8 +1421,6 @@ lemma map_range.add_equiv_to_equiv (f : M ≃+ N) :
     (map_range.equiv f.to_equiv f.map_zero f.symm.map_zero : (α →₀ _) ≃ _) :=
 equiv.ext $ λ _, rfl
 
-/-- For disjoint `f1` and `f2`, and function `g`
- the product of `g x (f1 x + f2 x))` over `f1.support` equals the product of `g` over `f1.support` -/
 lemma disjoint_prod_add_aux {f1 f2 : α →₀ M} (hd : disjoint f1.support f2.support)
   {β : Type*} [comm_monoid β] {g : α → M → β} :
 (∏ (x : α) in f1.support, g x (f1 x + f2 x)) = f1.prod g :=
@@ -1433,6 +1431,8 @@ begin
   simp only [not_mem_support_iff.mp (finset.disjoint_left.mp hd hx), add_zero],
 end
 
+/-- For disjoint `f1` and `f2`, and function `g`, the product of the products of `g`
+over `f1` and `f2` equals the product of `g` over `f1 + f2` -/
 lemma disjoint_prod_add {f1 f2 : α →₀ M} (hd : disjoint f1.support f2.support)
   {β : Type*} [comm_monoid β] {g : α → M → β} :
   f1.prod g * f2.prod g = (f1 + f2).prod g :=

--- a/src/data/finsupp/basic.lean
+++ b/src/data/finsupp/basic.lean
@@ -1288,15 +1288,12 @@ over `f1` and `f2` equals the product of `g` over `f1 + f2` -/
 lemma prod_add_index_of_disjoint {f1 f2 : α →₀ M} (hd : disjoint f1.support f2.support)
   {β : Type*} [comm_monoid β] (g : α → M → β) :
   (f1 + f2).prod g = f1.prod g * f2.prod g :=
+have ∀ {f1 f2 : α →₀ M}, disjoint f1.support f2.support →
+  ∏ x in f1.support, g x (f1 x + f2 x) = f1.prod g :=
+  λ f1 f2 hd, finset.prod_congr rfl (λ x hx,
+    by simp only [not_mem_support_iff.mp (disjoint_left.mp hd hx), add_zero]),
 begin
-  have aux : ∀ {f1 f2 : α →₀ M},
-    disjoint f1.support f2.support → f1.prod g = (∏ (x : α) in f1.support, g x (f1 x + f2 x)),
-  { intros f1 f2 hd,
-    unfold finsupp.prod,
-    rw finset.prod_congr rfl,
-    intros x hx,
-    simp only [not_mem_support_iff.mp (finset.disjoint_left.mp hd hx), add_zero] },
-  rw [aux hd, aux (disjoint.comm.mp hd)],
+  rw [←this hd, ←this hd.symm],
   simp only [add_comm, finsupp.prod, support_add_eq hd, prod_union hd, add_apply],
 end
 end disjoint_prod_add

--- a/src/data/finsupp/basic.lean
+++ b/src/data/finsupp/basic.lean
@@ -1281,12 +1281,11 @@ lemma multiset_sum_sum [has_zero M] [add_comm_monoid N] {f : α →₀ M} {h : �
   multiset.sum (f.sum h) = f.sum (λa b, multiset.sum (h a b)) :=
 (multiset.sum_add_monoid_hom : multiset N →+ N).map_sum _ f.support
 
-section disjoint_prod_add
-variables [add_comm_monoid M]
+
 /-- For disjoint `f1` and `f2`, and function `g`, the product of the products of `g`
 over `f1` and `f2` equals the product of `g` over `f1 + f2` -/
-lemma prod_add_index_of_disjoint {f1 f2 : α →₀ M} (hd : disjoint f1.support f2.support)
-  {β : Type*} [comm_monoid β] (g : α → M → β) :
+lemma prod_add_index_of_disjoint [add_comm_monoid M] {f1 f2 : α →₀ M}
+  (hd : disjoint f1.support f2.support) {β : Type*} [comm_monoid β] (g : α → M → β) :
   (f1 + f2).prod g = f1.prod g * f2.prod g :=
 have ∀ {f1 f2 : α →₀ M}, disjoint f1.support f2.support →
   ∏ x in f1.support, g x (f1 x + f2 x) = f1.prod g :=
@@ -1296,8 +1295,7 @@ begin
   rw [←this hd, ←this hd.symm],
   simp only [add_comm, finsupp.prod, support_add_eq hd, prod_union hd, add_apply],
 end
-end disjoint_prod_add
-
+#exit
 section map_range
 
 section equiv

--- a/src/data/finsupp/basic.lean
+++ b/src/data/finsupp/basic.lean
@@ -1281,6 +1281,29 @@ lemma multiset_sum_sum [has_zero M] [add_comm_monoid N] {f : α →₀ M} {h : �
   multiset.sum (f.sum h) = f.sum (λa b, multiset.sum (h a b)) :=
 (multiset.sum_add_monoid_hom : multiset N →+ N).map_sum _ f.support
 
+section disjoint_prod_add
+variables [add_comm_monoid M]
+lemma disjoint_prod_add_aux  {f1 f2 : α →₀ M} (hd : disjoint f1.support f2.support)
+  {β : Type*} [comm_monoid β] {g : α → M → β} :
+(∏ (x : α) in f1.support, g x (f1 x + f2 x)) = f1.prod g :=
+begin
+  unfold finsupp.prod,
+  rw finset.prod_congr rfl,
+  intros x hx,
+  simp only [not_mem_support_iff.mp (finset.disjoint_left.mp hd hx), add_zero],
+end
+
+/-- For disjoint `f1` and `f2`, and function `g`, the product of the products of `g`
+over `f1` and `f2` equals the product of `g` over `f1 + f2` -/
+lemma disjoint_prod_add  {f1 f2 : α →₀ M} (hd : disjoint f1.support f2.support)
+  {β : Type*} [comm_monoid β] {g : α → M → β} :
+  f1.prod g * f2.prod g = (f1 + f2).prod g :=
+begin
+  rw [←disjoint_prod_add_aux hd, ←disjoint_prod_add_aux (disjoint.comm.mp hd)],
+  simp only [add_comm, finsupp.prod, support_add_eq hd, prod_union hd, add_apply],
+end
+end disjoint_prod_add
+
 section map_range
 
 section equiv
@@ -1420,26 +1443,6 @@ lemma map_range.add_equiv_to_equiv (f : M ≃+ N) :
   (map_range.add_equiv f).to_equiv =
     (map_range.equiv f.to_equiv f.map_zero f.symm.map_zero : (α →₀ _) ≃ _) :=
 equiv.ext $ λ _, rfl
-
-lemma disjoint_prod_add_aux {f1 f2 : α →₀ M} (hd : disjoint f1.support f2.support)
-  {β : Type*} [comm_monoid β] {g : α → M → β} :
-(∏ (x : α) in f1.support, g x (f1 x + f2 x)) = f1.prod g :=
-begin
-  unfold finsupp.prod,
-  rw finset.prod_congr rfl,
-  intros x hx,
-  simp only [not_mem_support_iff.mp (finset.disjoint_left.mp hd hx), add_zero],
-end
-
-/-- For disjoint `f1` and `f2`, and function `g`, the product of the products of `g`
-over `f1` and `f2` equals the product of `g` over `f1 + f2` -/
-lemma disjoint_prod_add {f1 f2 : α →₀ M} (hd : disjoint f1.support f2.support)
-  {β : Type*} [comm_monoid β] {g : α → M → β} :
-  f1.prod g * f2.prod g = (f1 + f2).prod g :=
-begin
-  rw [←disjoint_prod_add_aux hd, ←disjoint_prod_add_aux (disjoint.comm.mp hd)],
-  simp only [add_comm, finsupp.prod, support_add_eq hd, prod_union hd, add_apply],
-end
 
 end add_monoid_hom
 

--- a/src/data/finsupp/basic.lean
+++ b/src/data/finsupp/basic.lean
@@ -1283,33 +1283,21 @@ lemma multiset_sum_sum [has_zero M] [add_comm_monoid N] {f : α →₀ M} {h : �
 
 section disjoint_prod_add
 variables [add_comm_monoid M]
-lemma disjoint_prod_add_aux {f1 f2 : α →₀ M} (hd : disjoint f1.support f2.support)
-  {β : Type*} [comm_monoid β] (g : α → M → β) :
-(∏ (x : α) in f1.support, g x (f1 x + f2 x)) = f1.prod g :=
-begin
-  unfold finsupp.prod,
-  rw finset.prod_congr rfl,
-  intros x hx,
-  simp only [not_mem_support_iff.mp (finset.disjoint_left.mp hd hx), add_zero],
-end
-
 /-- For disjoint `f1` and `f2`, and function `g`, the product of the products of `g`
 over `f1` and `f2` equals the product of `g` over `f1 + f2` -/
 lemma prod_add_index_of_disjoint {f1 f2 : α →₀ M} (hd : disjoint f1.support f2.support)
   {β : Type*} [comm_monoid β] (g : α → M → β) :
   (f1 + f2).prod g = f1.prod g * f2.prod g :=
 begin
---   have disjoint_prod_add_aux : (∏ (x : α) in f1.support, g x (f1 x + f2 x)) = f1.prod g,
--- {
---   unfold finsupp.prod,
---   rw finset.prod_congr rfl,
---   intros x hx,
---   simp only [not_mem_support_iff.mp (finset.disjoint_left.mp hd hx), add_zero],
--- },
-  -- have := (disjoint.comm.mp hd),
-  rw [←disjoint_prod_add_aux hd, ←disjoint_prod_add_aux (disjoint.comm.mp hd)],
+  have aux : ∀ {f1 f2 : α →₀ M},
+    disjoint f1.support f2.support → f1.prod g = (∏ (x : α) in f1.support, g x (f1 x + f2 x)),
+  { intros f1 f2 hd,
+    unfold finsupp.prod,
+    rw finset.prod_congr rfl,
+    intros x hx,
+    simp only [not_mem_support_iff.mp (finset.disjoint_left.mp hd hx), add_zero] },
+  rw [aux hd, aux (disjoint.comm.mp hd)],
   simp only [add_comm, finsupp.prod, support_add_eq hd, prod_union hd, add_apply],
-  -- sorry,
 end
 end disjoint_prod_add
 #exit

--- a/src/data/finsupp/basic.lean
+++ b/src/data/finsupp/basic.lean
@@ -1428,6 +1428,19 @@ lemma disjoint_prod_add_aux {f1 f2 : α →₀ M} (hd : disjoint f1.support f2.s
 (∏ (x : α) in f1.support, g x (f1 x + f2 x)) = f1.prod g :=
 begin
   unfold finsupp.prod,
+  have h : ∀ x ∈ f1.support, g x (f1 x + f2 x) = g x (f1 x), {
+    intros x hx,
+    simp only [not_mem_support_iff.mp (finset.disjoint_left.mp hd hx), add_zero] },
+
+
+  -- simp only [h],
+
+  -- have := prod_congr,
+  -- have := not_mem_support_iff.mp,
+  --  (finset.disjoint_left.mp hd hx),
+  have := @prod_congr α M β _ _ f1 _ _ h,
+
+    -- (λ y, (f1 y) + (f2 y)),
   sorry,
   -- rw prod_congr rfl,
   -- intros x hx,

--- a/src/data/finsupp/basic.lean
+++ b/src/data/finsupp/basic.lean
@@ -1299,11 +1299,20 @@ lemma prod_add_index_of_disjoint {f1 f2 : α →₀ M} (hd : disjoint f1.support
   {β : Type*} [comm_monoid β] (g : α → M → β) :
   (f1 + f2).prod g = f1.prod g * f2.prod g :=
 begin
+--   have disjoint_prod_add_aux : (∏ (x : α) in f1.support, g x (f1 x + f2 x)) = f1.prod g,
+-- {
+--   unfold finsupp.prod,
+--   rw finset.prod_congr rfl,
+--   intros x hx,
+--   simp only [not_mem_support_iff.mp (finset.disjoint_left.mp hd hx), add_zero],
+-- },
+  -- have := (disjoint.comm.mp hd),
   rw [←disjoint_prod_add_aux hd, ←disjoint_prod_add_aux (disjoint.comm.mp hd)],
   simp only [add_comm, finsupp.prod, support_add_eq hd, prod_union hd, add_apply],
+  -- sorry,
 end
 end disjoint_prod_add
-
+#exit
 section map_range
 
 section equiv

--- a/src/data/finsupp/basic.lean
+++ b/src/data/finsupp/basic.lean
@@ -1421,6 +1421,27 @@ lemma map_range.add_equiv_to_equiv (f : M ≃+ N) :
     (map_range.equiv f.to_equiv f.map_zero f.symm.map_zero : (α →₀ _) ≃ _) :=
 equiv.ext $ λ _, rfl
 
+/-- For disjoint `f1` and `f2`, and function `g`
+ the product of `g x (f1 x + f2 x))` over `f1.support` equals the product of `g` over `f1.support` -/
+lemma disjoint_prod_add_aux {f1 f2 : α →₀ M} (hd : disjoint f1.support f2.support)
+  {β : Type*} [comm_monoid β] {g : α → M → β} :
+(∏ (x : α) in f1.support, g x (f1 x + f2 x)) = f1.prod g :=
+begin
+  unfold finsupp.prod,
+  sorry,
+  -- rw prod_congr rfl,
+  -- intros x hx,
+  -- simp only [not_mem_support_iff.mp (finset.disjoint_left.mp hd hx), add_zero],
+end
+
+lemma disjoint_prod_add {f1 f2 : α →₀ M} (hd : disjoint f1.support f2.support)
+  {β : Type*} [comm_monoid β] {g : α → M → β} :
+  f1.prod g * f2.prod g = (f1 + f2).prod g :=
+begin
+  rw [←disjoint_prod_add_aux hd, ←disjoint_prod_add_aux (disjoint.comm.mp hd)],
+  simp only [add_comm, finsupp.prod, support_add_eq hd, prod_union hd, add_apply],
+end
+#exit
 end add_monoid_hom
 
 end map_range

--- a/src/data/finsupp/basic.lean
+++ b/src/data/finsupp/basic.lean
@@ -1283,7 +1283,7 @@ lemma multiset_sum_sum [has_zero M] [add_comm_monoid N] {f : α →₀ M} {h : �
 
 section disjoint_prod_add
 variables [add_comm_monoid M]
-lemma disjoint_prod_add_aux  {f1 f2 : α →₀ M} (hd : disjoint f1.support f2.support)
+lemma disjoint_prod_add_aux {f1 f2 : α →₀ M} (hd : disjoint f1.support f2.support)
   {β : Type*} [comm_monoid β] {g : α → M → β} :
 (∏ (x : α) in f1.support, g x (f1 x + f2 x)) = f1.prod g :=
 begin
@@ -1295,9 +1295,9 @@ end
 
 /-- For disjoint `f1` and `f2`, and function `g`, the product of the products of `g`
 over `f1` and `f2` equals the product of `g` over `f1 + f2` -/
-lemma disjoint_prod_add  {f1 f2 : α →₀ M} (hd : disjoint f1.support f2.support)
+lemma prod_add_index_of_disjoint {f1 f2 : α →₀ M} (hd : disjoint f1.support f2.support)
   {β : Type*} [comm_monoid β] {g : α → M → β} :
-  f1.prod g * f2.prod g = (f1 + f2).prod g :=
+  (f1 + f2).prod g = f1.prod g * f2.prod g :=
 begin
   rw [←disjoint_prod_add_aux hd, ←disjoint_prod_add_aux (disjoint.comm.mp hd)],
   simp only [add_comm, finsupp.prod, support_add_eq hd, prod_union hd, add_apply],

--- a/src/data/finsupp/basic.lean
+++ b/src/data/finsupp/basic.lean
@@ -1284,7 +1284,7 @@ lemma multiset_sum_sum [has_zero M] [add_comm_monoid N] {f : α →₀ M} {h : �
 section disjoint_prod_add
 variables [add_comm_monoid M]
 lemma disjoint_prod_add_aux {f1 f2 : α →₀ M} (hd : disjoint f1.support f2.support)
-  {β : Type*} [comm_monoid β] {g : α → M → β} :
+  {β : Type*} [comm_monoid β] (g : α → M → β) :
 (∏ (x : α) in f1.support, g x (f1 x + f2 x)) = f1.prod g :=
 begin
   unfold finsupp.prod,
@@ -1296,7 +1296,7 @@ end
 /-- For disjoint `f1` and `f2`, and function `g`, the product of the products of `g`
 over `f1` and `f2` equals the product of `g` over `f1 + f2` -/
 lemma prod_add_index_of_disjoint {f1 f2 : α →₀ M} (hd : disjoint f1.support f2.support)
-  {β : Type*} [comm_monoid β] {g : α → M → β} :
+  {β : Type*} [comm_monoid β] (g : α → M → β) :
   (f1 + f2).prod g = f1.prod g * f2.prod g :=
 begin
   rw [←disjoint_prod_add_aux hd, ←disjoint_prod_add_aux (disjoint.comm.mp hd)],

--- a/src/data/finsupp/basic.lean
+++ b/src/data/finsupp/basic.lean
@@ -1300,7 +1300,7 @@ begin
   simp only [add_comm, finsupp.prod, support_add_eq hd, prod_union hd, add_apply],
 end
 end disjoint_prod_add
-#exit
+
 section map_range
 
 section equiv


### PR DESCRIPTION
For disjoint finsupps `f1` and `f2`, and function `g`, the product of the products of `g` over `f1` and `f2` equals the product of `g` over `f1 + f2`

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
