### PR TITLE
[Merged by Bors] - feat(ring_theory/localization,group_theory/monoid_localization): other scalar action instances

### DIFF
--- a/src/group_theory/monoid_localization.lean
+++ b/src/group_theory/monoid_localization.lean
@@ -363,7 +363,7 @@ instance [has_scalar R₁ M] [has_scalar R₂ M] [is_scalar_tower R₁ M M] [is_
     by simp only [smul_mk, smul_assoc s t r] }
 
 instance smul_comm_class_right {R : Type*} [has_scalar R M] [is_scalar_tower R M M] :
-  smul_comm_class S (localization S) (localization S) :=
+  smul_comm_class R (localization S) (localization S) :=
 { smul_comm := λ s, localization.ind $ prod.rec $ by exact λ r₁ x₁,
                     localization.ind $ prod.rec $ by exact λ r₂ x₂,
     by simp only [smul_mk, smul_eq_mul, mk_mul, mul_comm r₁, smul_mul_assoc] }

--- a/src/group_theory/monoid_localization.lean
+++ b/src/group_theory/monoid_localization.lean
@@ -326,6 +326,35 @@ r_iff_exists.2 ⟨1, by rw h⟩
 @[to_additive] lemma mk_self (a : S) : mk (a : M) a = 1 :=
 by { symmetry, rw [← mk_one, mk_eq_mk_iff], exact one_rel a }
 
+/-- Scalar multiplication in a monoid localization is defined as `c • ⟨a, b⟩ = ⟨c • a, b⟩`. -/
+@[irreducible] protected def smul {R : Type*} [has_scalar R M] [is_scalar_tower R M M]
+  (c : R) (z : localization S) : localization S :=
+localization.lift_on z (λ a b, mk (c • a) b) $
+  λ a a' b b' h, mk_eq_mk_iff.2
+begin
+  cases b with b hb,
+  cases b' with b' hb',
+  rw r_eq_r' at h ⊢,
+  cases h with t ht,
+  use t,
+  simp only [smul_mul_assoc, ht]
+end
+
+instance {R : Type*} [has_scalar R M] [is_scalar_tower R M M] :
+  has_scalar R (localization S) :=
+{ smul := localization.smul }
+
+lemma smul_mk {R : Type*} [has_scalar R M] [is_scalar_tower R M M]
+  (c : R) (a b) : c • (mk a b : localization S) = mk (c • a) b :=
+by { unfold has_scalar.smul localization.smul, apply lift_on_mk }
+
+instance {R : Type*} [monoid R] [mul_action R M] [is_scalar_tower R M M] :
+  mul_action R (localization S) :=
+{ one_smul := localization.ind $ prod.rec $
+    by { intros, simp only [localization.smul_mk, one_smul] },
+  mul_smul := λ s₁ s₂, localization.ind $ prod.rec $
+    by { intros, simp only [localization.smul_mk, mul_smul] } }
+
 end localization
 
 variables {S N}

--- a/src/ring_theory/localization.lean
+++ b/src/ring_theory/localization.lean
@@ -1359,7 +1359,7 @@ begin
 end
 
 instance (p : ideal (localization M)) [p.is_prime] : algebra R (localization.at_prime p) :=
-((algebra_map (localization M) _).comp (algebra_map R _)).to_algebra
+localization.algebra
 
 instance (p : ideal (localization M)) [p.is_prime] :
   is_scalar_tower R (localization M) (localization.at_prime p) :=

--- a/src/ring_theory/localization.lean
+++ b/src/ring_theory/localization.lean
@@ -791,28 +791,6 @@ lemma mk_zero (b) : (mk 0 b : localization M) = 0 :=
 calc mk 0 b = mk 0 1 : mk_eq_mk_iff.mpr (r_of_eq (by simp))
 ... = 0 : by  unfold has_zero.zero localization.zero
 
-/-- Scalar multiplication in a ring localization is defined as `c • ⟨a, b⟩ = ⟨c • a, c • b⟩`. -/
-@[irreducible] protected def smul {S : Type*} [has_scalar S R] [is_scalar_tower S R R]
-  (c : S) (z : localization M) : localization M :=
-localization.lift_on z (λ a b, mk (c • a) b) $
-  λ a a' b b' h, mk_eq_mk_iff.2
-begin
-  cases b with b hb,
-  cases b' with b' hb',
-  rw r_eq_r' at h ⊢,
-  cases h with t ht,
-  use t,
-  simp only [smul_mul_assoc, ht]
-end
-
-instance {S : Type*} [has_scalar S R] [is_scalar_tower S R R] :
-  has_scalar S (localization M) :=
-{ smul := localization.smul }
-
-lemma smul_mk {S : Type*} [has_scalar S R] [is_scalar_tower S R R]
-  (c : S) (a b) : c • (mk a b : localization M) = mk (c • a) b :=
-by { unfold has_scalar.smul localization.smul, apply lift_on_mk }
-
 private meta def tac := `[
 { intros,
   simp only [add_mk, localization.mk_mul, neg_mk, ← mk_zero 1],
@@ -849,13 +827,6 @@ instance : comm_ring (localization M) :=
   left_distrib   := λ m n k, localization.induction_on₃ m n k (by tac),
   right_distrib  := λ m n k, localization.induction_on₃ m n k (by tac),
    ..localization.comm_monoid M }
-
-instance {S : Type*} [monoid S] [mul_action S R] [is_scalar_tower S R R] :
-  mul_action S (localization M) :=
-{ one_smul := localization.ind $ prod.rec $
-    by { intros, simp only [localization.smul_mk, one_smul] },
-  mul_smul := λ s₁ s₂, localization.ind $ prod.rec $
-    by { intros, simp only [localization.smul_mk, mul_smul] } }
 
 instance {S : Type*} [monoid S] [distrib_mul_action S R] [is_scalar_tower S R R] :
   distrib_mul_action S (localization M) :=

--- a/src/ring_theory/localization.lean
+++ b/src/ring_theory/localization.lean
@@ -846,13 +846,49 @@ instance : comm_ring (localization M) :=
   right_distrib  := λ m n k, localization.induction_on₃ m n k (by tac),
    ..localization.comm_monoid M }
 
-instance : algebra R (localization M) :=
-ring_hom.to_algebra $
-{ to_fun := (monoid_of M).to_map,
-  map_zero' := by rw [← mk_zero (1 : M), mk_one_eq_monoid_of_mk],
-  map_add' := λ x y,
-    by simp only [← mk_one_eq_monoid_of_mk, add_mk, submonoid.coe_one, one_mul, add_comm],
-  .. localization.monoid_of M }
+instance {S : Type*} [monoid S] [mul_action S R] [is_scalar_tower S R R] :
+  mul_action S (localization M) :=
+{ smul := localization.smul,
+  one_smul := localization.ind $ prod.rec $
+    by { intros, simp only [localization.smul_mk, one_smul] },
+  mul_smul := λ s₁ s₂, localization.ind $ prod.rec $
+    by { intros, simp only [localization.smul_mk, mul_smul] } }
+
+instance {S : Type*} [monoid S] [distrib_mul_action S R] [is_scalar_tower S R R] :
+  distrib_mul_action S (localization M) :=
+{ smul := localization.smul,
+  smul_zero := λ s, by simp only [←localization.mk_zero 1, localization.smul_mk, smul_zero],
+  smul_add := λ s x y, localization.induction_on₂ x y $
+    prod.rec $ by exact λ r₁ x₁, prod.rec $ by exact λ r₂ x₂,
+      by simp only [localization.smul_mk, localization.add_mk, smul_add, mul_comm _ (s • _),
+                    mul_comm _ r₁, mul_comm _ r₂, smul_mul_assoc],
+  ..localization.mul_action }
+
+instance {S : Type*} [semiring S] [module S R] [is_scalar_tower S R R] :
+  module S (localization M) :=
+{ smul := localization.smul,
+  zero_smul := localization.ind $ prod.rec $
+    by { intros, simp only [localization.smul_mk, zero_smul, mk_zero] },
+  add_smul := λ s₁ s₂, localization.ind $ prod.rec $
+    by { intros, simp only [localization.smul_mk, add_smul, add_mk_self] },
+  ..localization.distrib_mul_action }
+
+instance {S : Type*} [comm_semiring S] [algebra S R] : algebra S (localization M) :=
+{ to_ring_hom :=
+  ring_hom.comp
+  { to_fun := (monoid_of M).to_map,
+    map_zero' := by rw [← mk_zero (1 : M), mk_one_eq_monoid_of_mk],
+    map_add' := λ x y,
+      by simp only [← mk_one_eq_monoid_of_mk, add_mk, submonoid.coe_one, one_mul, add_comm],
+    .. localization.monoid_of M } (algebra_map S R),
+  smul_def' := λ r, localization.ind $ prod.rec $ begin
+    dsimp,
+    sorry
+  end,
+  commutes' := λ r, localization.ind $ prod.rec $ begin
+    dsimp,
+    sorry
+  end }
 
 instance : is_localization M (localization M) :=
 { map_units := (localization.monoid_of M).map_units,

--- a/src/ring_theory/localization.lean
+++ b/src/ring_theory/localization.lean
@@ -813,6 +813,24 @@ lemma smul_mk {S : Type*} [has_scalar S R] [is_scalar_tower S R R]
   (c : S) (a b) : c • (mk a b : localization M) = mk (c • a) b :=
 by { unfold has_scalar.smul localization.smul, apply lift_on_mk }
 
+instance {S T : Type*} [has_scalar S R] [has_scalar T R]
+  [is_scalar_tower S R R] [is_scalar_tower T R R]
+  [smul_comm_class S T R] : smul_comm_class S T (localization M) :=
+{ smul_comm := λ s t, localization.ind $ prod.rec $ by exact λ r x,
+    by simp only [smul_mk, smul_comm s t r]  }
+
+instance {S T : Type*} [has_scalar S R] [has_scalar T R]
+  [is_scalar_tower S R R] [is_scalar_tower T R R]
+  [has_scalar S T] [is_scalar_tower S T R] : is_scalar_tower S T (localization M) :=
+{ smul_assoc := λ s t, localization.ind $ prod.rec $ by exact λ r x,
+    by simp only [smul_mk, smul_assoc s t r]  }
+
+instance {S : Type*} [has_scalar S R] [has_scalar Sᵐᵒᵖ R]
+  [is_scalar_tower S R R] [is_scalar_tower Sᵐᵒᵖ R R]
+  [is_central_scalar S R] : is_central_scalar S (localization M) :=
+{ op_smul_eq_smul := λ s, localization.ind $ prod.rec $ by exact λ r x,
+    by simp only [smul_mk, op_smul_eq_smul] }
+
 private meta def tac := `[
 { intros,
   simp only [add_mk, localization.mk_mul, neg_mk, ← mk_zero 1],
@@ -856,6 +874,18 @@ instance {S : Type*} [monoid S] [mul_action S R] [is_scalar_tower S R R] :
     by { intros, simp only [localization.smul_mk, one_smul] },
   mul_smul := λ s₁ s₂, localization.ind $ prod.rec $
     by { intros, simp only [localization.smul_mk, mul_smul] } }
+
+instance is_scalar_tower_right {S : Type*} [has_scalar S R] [is_scalar_tower S R R] :
+  is_scalar_tower S (localization M) (localization M) :=
+{ smul_assoc := λ s, localization.ind $ prod.rec $ by exact λ r₁ x₁,
+                     localization.ind $ prod.rec $ by exact λ r₂ x₂,
+    by simp only [smul_mk, smul_eq_mul, mk_mul, smul_mul_assoc] }
+
+instance smul_comm_class_right {S : Type*} [has_scalar S R] [is_scalar_tower S R R] :
+  smul_comm_class S (localization M) (localization M) :=
+{ smul_comm := λ s, localization.ind $ prod.rec $ by exact λ r₁ x₁,
+                    localization.ind $ prod.rec $ by exact λ r₂ x₂,
+    by simp only [smul_mk, smul_eq_mul, mk_mul, mul_comm r₁, smul_mul_assoc] }
 
 instance {S : Type*} [monoid S] [distrib_mul_action S R] [is_scalar_tower S R R] :
   distrib_mul_action S (localization M) :=

--- a/src/ring_theory/localization.lean
+++ b/src/ring_theory/localization.lean
@@ -805,8 +805,12 @@ begin
   simp only [smul_mul_assoc, ht]
 end
 
+instance {S : Type*} [has_scalar S R] [is_scalar_tower S R R] :
+  has_scalar S (localization M) :=
+{ smul := localization.smul }
+
 lemma smul_mk {S : Type*} [has_scalar S R] [is_scalar_tower S R R]
-  (c : S) (a b) : localization.smul c (mk a b : localization M) = mk (c • a) b :=
+  (c : S) (a b) : c • (mk a b : localization M) = mk (c • a) b :=
 by { unfold has_scalar.smul localization.smul, apply lift_on_mk }
 
 private meta def tac := `[
@@ -822,12 +826,12 @@ instance : comm_ring (localization M) :=
   add  := (+),
   mul  := (*),
   npow := localization.npow _,
-  nsmul := localization.smul,
+  nsmul := (•),
   nsmul_zero' := λ x, localization.induction_on x
     (λ x, by simp only [smul_mk, zero_nsmul, mk_zero]),
   nsmul_succ' := λ n x, localization.induction_on x
     (λ x, by simp only [smul_mk, succ_nsmul, add_mk_self]),
-  zsmul := localization.smul,
+  zsmul := (•),
   zsmul_zero' := λ x, localization.induction_on x
     (λ x, by simp only [smul_mk, zero_zsmul, mk_zero]),
   zsmul_succ' := λ n x, localization.induction_on x
@@ -848,16 +852,14 @@ instance : comm_ring (localization M) :=
 
 instance {S : Type*} [monoid S] [mul_action S R] [is_scalar_tower S R R] :
   mul_action S (localization M) :=
-{ smul := localization.smul,
-  one_smul := localization.ind $ prod.rec $
+{ one_smul := localization.ind $ prod.rec $
     by { intros, simp only [localization.smul_mk, one_smul] },
   mul_smul := λ s₁ s₂, localization.ind $ prod.rec $
     by { intros, simp only [localization.smul_mk, mul_smul] } }
 
 instance {S : Type*} [monoid S] [distrib_mul_action S R] [is_scalar_tower S R R] :
   distrib_mul_action S (localization M) :=
-{ smul := localization.smul,
-  smul_zero := λ s, by simp only [←localization.mk_zero 1, localization.smul_mk, smul_zero],
+{ smul_zero := λ s, by simp only [←localization.mk_zero 1, localization.smul_mk, smul_zero],
   smul_add := λ s x y, localization.induction_on₂ x y $
     prod.rec $ by exact λ r₁ x₁, prod.rec $ by exact λ r₂ x₂,
       by simp only [localization.smul_mk, localization.add_mk, smul_add, mul_comm _ (s • _),
@@ -866,8 +868,7 @@ instance {S : Type*} [monoid S] [distrib_mul_action S R] [is_scalar_tower S R R]
 
 instance {S : Type*} [semiring S] [module S R] [is_scalar_tower S R R] :
   module S (localization M) :=
-{ smul := localization.smul,
-  zero_smul := localization.ind $ prod.rec $
+{ zero_smul := localization.ind $ prod.rec $
     by { intros, simp only [localization.smul_mk, zero_smul, mk_zero] },
   add_smul := λ s₁ s₂, localization.ind $ prod.rec $
     by { intros, simp only [localization.smul_mk, add_smul, add_mk_self] },
@@ -881,13 +882,16 @@ instance {S : Type*} [comm_semiring S] [algebra S R] : algebra S (localization M
     map_add' := λ x y,
       by simp only [← mk_one_eq_monoid_of_mk, add_mk, submonoid.coe_one, one_mul, add_comm],
     .. localization.monoid_of M } (algebra_map S R),
-  smul_def' := λ r, localization.ind $ prod.rec $ begin
+  smul_def' := λ s, localization.ind $ prod.rec $ begin
+    intros r x,
     dsimp,
-    sorry
+    simp only [←mk_one_eq_monoid_of_mk, mk_mul, localization.smul_mk, one_mul, algebra.smul_def],
   end,
-  commutes' := λ r, localization.ind $ prod.rec $ begin
+  commutes' := λ s, localization.ind $ prod.rec $ begin
+    intros r x,
     dsimp,
-    sorry
+    simp only [←mk_one_eq_monoid_of_mk, mk_mul, localization.smul_mk, one_mul, mul_one,
+               algebra.commutes],
   end }
 
 instance : is_localization M (localization M) :=


### PR DESCRIPTION
As requested by @pechersky. With this instance it's possible to state:
```lean
import field_theory.ratfunc
import data.complex.basic
import ring_theory.laurent_series

noncomputable example : ratfunc ℂ ≃ₐ[ℂ] fraction_ring (polynomial ℂ) := sorry
```

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
