### PR TITLE
[Merged by Bors] - chore(computability/regular_expressions): eliminate `finish`

### DIFF
--- a/src/computability/regular_expressions.lean
+++ b/src/computability/regular_expressions.lean
@@ -302,4 +302,3 @@ begin
 end
 
 end regular_expression
-#lint

--- a/src/computability/regular_expressions.lean
+++ b/src/computability/regular_expressions.lean
@@ -131,9 +131,7 @@ lemma add_rmatch_iff (P Q : regular_expression α) (x : list α) :
   (P + Q).rmatch x ↔ P.rmatch x ∨ Q.rmatch x :=
 begin
   induction x with _ _ ih generalizing P Q,
-  { repeat {rw rmatch},
-    rw match_epsilon,
-    finish },
+  { simp only [rmatch, match_epsilon, bor_coe_iff] },
   { repeat {rw rmatch},
     rw deriv,
     exact ih _ _ }
@@ -154,7 +152,7 @@ begin
       subst ht,
       subst hu,
       repeat {rw rmatch at h₂},
-      finish } },
+      simp [h₂] } },
   { rw [rmatch, deriv],
     split_ifs with hepsilon,
     { rw [add_rmatch_iff, ih],
@@ -169,20 +167,22 @@ begin
           rw ←h at hQ,
           exact hQ },
         { left,
-          refine ⟨ t, u, by finish, _, hQ ⟩,
+          simp only [list.cons_append] at h,
+          refine ⟨ t, u, h.2, _, hQ ⟩,
           rw rmatch at hP,
           convert hP,
-          finish } } },
+          exact h.1 } } },
     { rw ih,
       split;
       rintro ⟨ t, u, h, hP, hQ ⟩,
       { exact ⟨ a :: t, u, by tauto ⟩ },
       { cases t with b t,
         { contradiction },
-        { refine ⟨ t, u, by finish, _, hQ ⟩,
+        { simp only [list.cons_append] at h,
+          refine ⟨ t, u, h.2, _, hQ ⟩,
           rw rmatch at hP,
           convert hP,
-          finish } } } }
+          exact h.1 } } } }
 end
 
 lemma star_rmatch_iff (P : regular_expression α) : ∀ (x : list α),
@@ -210,7 +210,7 @@ begin
       rcases hu with ⟨ S', hsum, helem ⟩,
       use (a :: t) :: S',
       split,
-      { finish },
+      { simp [hs, hsum] },
       { intros t' ht',
         cases ht' with ht' ht',
         { rw ht',
@@ -223,17 +223,18 @@ begin
       cases S with t' U,
       { exact ⟨ [], [], by tauto ⟩ },
       { cases t' with b t,
-        { finish },
-        refine ⟨ t, U.join, by finish, _, _ ⟩,
-        { specialize helem (b :: t) _,
-          { finish },
+        { simp only [forall_eq_or_imp, list.mem_cons_iff] at helem,
+          simp only [eq_self_iff_true, not_true, ne.def, false_and] at helem,
+          cases helem },
+        simp only [list.join, list.cons_append] at hsum,
+        refine ⟨ t, U.join, hsum.2, _, _ ⟩,
+        { specialize helem (b :: t) (by simp),
           rw rmatch at helem,
           convert helem.2,
-          finish },
+          exact hsum.1 },
         { have hwf : U.join.length < (list.cons a x).length,
-          { rw hsum,
-            simp only
-              [list.join, list.length_append, list.cons_append, list.length_join, list.length],
+          { rw [hsum.1, hsum.2],
+            simp only [list.length_append, list.length_join, list.length],
             apply A },
           rw IH _ hwf,
           refine ⟨ U, rfl, λ t h, helem t _ ⟩,
@@ -301,3 +302,4 @@ begin
 end
 
 end regular_expression
+#lint


### PR DESCRIPTION
Removing uses of `finish`, as discussed in this Zulip thread (https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/mathlib.20sat.20solvers)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
