### PR TITLE
[Merged by Bors] - feat(linear_algebra/orientation): add orientation.map

### DIFF
--- a/src/linear_algebra/alternating.lean
+++ b/src/linear_algebra/alternating.lean
@@ -378,8 +378,8 @@ lemma comp_linear_map_inj (f : M₂ →ₗ[R] M) (hf : function.surjective f)
 
 /-- Composing an alternating map with the same linear equiv on each argument gives the zero map
 if and only if the alternating map is the zero map. -/
-@[simp] lemma comp_linear_equiv_eq_zero_iff (f : alternating_map R M N ι) (g : M ≃ₗ[R] M) :
-  f.comp_linear_map (g : M →ₗ[R] M) = 0 ↔ f = 0 :=
+@[simp] lemma comp_linear_equiv_eq_zero_iff (f : alternating_map R M N ι) (g : M₂ ≃ₗ[R] M) :
+  f.comp_linear_map (g : M₂ →ₗ[R] M) = 0 ↔ f = 0 :=
 begin
   simp_rw ←alternating_map.coe_multilinear_map_injective.eq_iff,
   exact multilinear_map.comp_linear_equiv_eq_zero_iff _ _

--- a/src/linear_algebra/alternating.lean
+++ b/src/linear_algebra/alternating.lean
@@ -376,14 +376,39 @@ lemma comp_linear_map_inj (f : M₂ →ₗ[R] M) (hf : function.surjective f)
   (g₁ g₂ : alternating_map R M N ι) : g₁.comp_linear_map f = g₂.comp_linear_map f ↔ g₁ = g₂ :=
 (comp_linear_map_injective _ hf).eq_iff
 
+section dom_lcongr
+
+variables (ι R N) (S : Type*) [semiring S] [module S N] [smul_comm_class R S N]
+
+/-- Construct a linear equivalence between maps from a linear equivalence between domains. -/
+@[simps apply]
+def dom_lcongr (e : M ≃ₗ[R] M₂) : alternating_map R M N ι ≃ₗ[S] alternating_map R M₂ N ι :=
+{ to_fun := λ f, f.comp_linear_map e.symm,
+  inv_fun := λ g, g.comp_linear_map e,
+  map_add' := λ _ _, rfl,
+  map_smul' := λ _ _, rfl,
+  left_inv := λ f, alternating_map.ext $ λ v, f.congr_arg $ funext $ λ i, e.symm_apply_apply _,
+  right_inv := λ f, alternating_map.ext $ λ v, f.congr_arg $ funext $ λ i, e.apply_symm_apply _ }
+
+@[simp] lemma dom_lcongr_refl :
+  dom_lcongr R N ι S (linear_equiv.refl R M) = linear_equiv.refl S _ :=
+linear_equiv.ext $ λ _, alternating_map.ext $ λ v, rfl
+
+@[simp] lemma dom_lcongr_symm (e : M ≃ₗ[R] M₂) :
+  (dom_lcongr R N ι S e).symm = dom_lcongr R N ι S e.symm :=
+rfl
+
+lemma dom_lcongr_trans (e : M ≃ₗ[R] M₂) (f : M₂ ≃ₗ[R] M₃):
+  (dom_lcongr R N ι S e).trans (dom_lcongr R N ι S f) = dom_lcongr R N ι S (e.trans f) :=
+rfl
+
+end dom_lcongr
+
 /-- Composing an alternating map with the same linear equiv on each argument gives the zero map
 if and only if the alternating map is the zero map. -/
 @[simp] lemma comp_linear_equiv_eq_zero_iff (f : alternating_map R M N ι) (g : M₂ ≃ₗ[R] M) :
   f.comp_linear_map (g : M₂ →ₗ[R] M) = 0 ↔ f = 0 :=
-begin
-  simp_rw ←alternating_map.coe_multilinear_map_injective.eq_iff,
-  exact multilinear_map.comp_linear_equiv_eq_zero_iff _ _
-end
+(dom_lcongr R N ι ℕ g.symm).map_eq_zero_iff
 
 variables (f f' : alternating_map R M N ι)
 variables (g g₂ : alternating_map R M N' ι)

--- a/src/linear_algebra/orientation.lean
+++ b/src/linear_algebra/orientation.lean
@@ -194,13 +194,7 @@ equiv.ext $ module.ray.ind R $ λ _ _, rfl
 
 /-- An equivalence between modules implies an equivalence between orientations. -/
 def orientation.map [nontrivial R] (e : M ≃ₗ[R] N) : orientation R M ι ≃ orientation R N ι :=
-module.ray.map
-  { to_fun := λ f, f.comp_linear_map e.symm,
-    inv_fun := λ g, g.comp_linear_map e,
-    map_add' := λ _ _, rfl,
-    map_smul' := λ _ _, rfl,
-    left_inv := λ f, alternating_map.ext $ λ v, f.congr_arg $ funext $ λ i, e.symm_apply_apply _,
-    right_inv := λ f, alternating_map.ext $ λ v, f.congr_arg $ funext $ λ i, e.apply_symm_apply _ }
+module.ray.map $ alternating_map.dom_lcongr R R ι R e
 
 @[simp] lemma orientation.map_apply [nontrivial R] (e : M ≃ₗ[R] N) (v : alternating_map R M R ι)
   (hv : v ≠ 0) :
@@ -209,10 +203,7 @@ module.ray.map
 
 @[simp] lemma orientation.map_refl [nontrivial R] :
   (orientation.map ι $ linear_equiv.refl R M) = equiv.refl _ :=
-equiv.ext $ module.ray.ind R $ λ _ _, begin
-  dsimp,
-  simp_rw alternating_map.comp_linear_map_id,
-end
+by rw [orientation.map, alternating_map.dom_lcongr_refl, module.ray.map_refl]
 
 @[simp] lemma orientation.map_symm [nontrivial R] (e : M ≃ₗ[R] N) :
   (orientation.map ι e).symm = orientation.map ι e.symm := rfl

--- a/src/linear_algebra/orientation.lean
+++ b/src/linear_algebra/orientation.lean
@@ -192,6 +192,31 @@ equiv.ext $ module.ray.ind R $ λ _ _, rfl
 @[simp] lemma module.ray.map_symm [nontrivial R] (e : M ≃ₗ[R] N) :
   (module.ray.map e).symm = module.ray.map e.symm := rfl
 
+/-- An equivalence between modules implies an equivalence between orientations. -/
+def orientation.map [nontrivial R] (e : M ≃ₗ[R] N) : orientation R M ι ≃ orientation R N ι :=
+module.ray.map
+  { to_fun := λ f, f.comp_linear_map e.symm,
+    inv_fun := λ g, g.comp_linear_map e,
+    map_add' := λ _ _, rfl,
+    map_smul' := λ _ _, rfl,
+    left_inv := λ f, alternating_map.ext $ λ v, f.congr_arg $ funext $ λ i, e.symm_apply_apply _,
+    right_inv := λ f, alternating_map.ext $ λ v, f.congr_arg $ funext $ λ i, e.apply_symm_apply _ }
+
+@[simp] lemma orientation.map_apply [nontrivial R] (e : M ≃ₗ[R] N) (v : alternating_map R M R ι)
+  (hv : v ≠ 0) :
+  orientation.map ι e (ray_of_ne_zero _ v hv) = ray_of_ne_zero _ (v.comp_linear_map e.symm)
+      (mt (v.comp_linear_equiv_eq_zero_iff e.symm).mp hv) := rfl
+
+@[simp] lemma orientation.map_refl [nontrivial R] :
+  (orientation.map ι $ linear_equiv.refl R M) = equiv.refl _ :=
+equiv.ext $ module.ray.ind R $ λ _ _, begin
+  dsimp,
+  simp_rw alternating_map.comp_linear_map_id,
+end
+
+@[simp] lemma orientation.map_symm [nontrivial R] (e : M ≃ₗ[R] N) :
+  (orientation.map ι e).symm = orientation.map ι e.symm := rfl
+
 section action
 variables {G : Type*} [group G] [nontrivial R] [distrib_mul_action G M] [smul_comm_class R G M]
 


### PR DESCRIPTION
This also adds `alternating_map.dom_lcongr` following the naming established by `finsupp.dom_lcongr`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
