### PR TITLE
[Merged by Bors] - chore(field_theory/ratfunc): has_scalar in terms of localization

### DIFF
--- a/src/field_theory/ratfunc.lean
+++ b/src/field_theory/ratfunc.lean
@@ -274,17 +274,28 @@ by simpa only [← of_fraction_ring_inv, ← of_fraction_ring_mul, ← of_fracti
 
 section has_scalar
 
-variables {R : Type*} [monoid R] [distrib_mul_action R (polynomial K)]
+variables {R : Type*} [monoid R]
+
+/-- Scalar multiplication of rational functions. -/
+@[irreducible] protected def smul [has_scalar R (fraction_ring (polynomial K))] :
+  R → ratfunc K → ratfunc K
+| r ⟨p⟩ := ⟨r • p⟩
+
+instance [has_scalar R (fraction_ring (polynomial K))] : has_scalar R (ratfunc K) :=
+⟨ratfunc.smul⟩
+
+lemma of_fraction_ring_smul [has_scalar R (fraction_ring (polynomial K))]
+  (c : R) (p : fraction_ring (polynomial K)) :
+  of_fraction_ring (c • p) = c • of_fraction_ring p :=
+by unfold has_scalar.smul ratfunc.smul
+lemma to_fraction_ring_smul [has_scalar R (fraction_ring (polynomial K))]
+  (c : R) (p : ratfunc K) :
+  to_fraction_ring (c • p) = c • to_fraction_ring p :=
+by { cases p, rw ←of_fraction_ring_smul }
+
+variables [distrib_mul_action R (polynomial K)]
 variables [htower : is_scalar_tower R (polynomial K) (polynomial K)]
 include htower
-
-instance : has_scalar R (ratfunc K) :=
-⟨λ c p, of_fraction_ring (c • to_fraction_ring p)⟩
-
-lemma of_fraction_ring_smul (c : R) (p : fraction_ring (polynomial K)) :
-  of_fraction_ring (c • p) = c • of_fraction_ring p := rfl
-lemma to_fraction_ring_smul (c : R) (p : ratfunc K) :
-  to_fraction_ring (c • p) = c • to_fraction_ring p := rfl
 
 lemma mk_smul (c : R) (p q : polynomial K) :
   ratfunc.mk (c • p) q = c • ratfunc.mk p q :=

--- a/src/field_theory/ratfunc.lean
+++ b/src/field_theory/ratfunc.lean
@@ -273,6 +273,7 @@ by simpa only [← of_fraction_ring_inv, ← of_fraction_ring_mul, ← of_fracti
   using _root_.mul_inv_cancel this
 
 section has_scalar
+omit hdomain
 
 variables {R : Type*} [monoid R]
 
@@ -293,6 +294,7 @@ lemma to_fraction_ring_smul [has_scalar R (fraction_ring (polynomial K))]
   to_fraction_ring (c • p) = c • to_fraction_ring p :=
 by { cases p, rw ←of_fraction_ring_smul }
 
+include hdomain
 variables [distrib_mul_action R (polynomial K)]
 variables [htower : is_scalar_tower R (polynomial K) (polynomial K)]
 include htower

--- a/src/field_theory/ratfunc.lean
+++ b/src/field_theory/ratfunc.lean
@@ -275,7 +275,7 @@ by simpa only [← of_fraction_ring_inv, ← of_fraction_ring_mul, ← of_fracti
 section has_scalar
 omit hdomain
 
-variables {R : Type*} [monoid R]
+variables {R : Type*}
 
 /-- Scalar multiplication of rational functions. -/
 @[irreducible] protected def smul [has_scalar R (fraction_ring (polynomial K))] :
@@ -295,7 +295,7 @@ lemma to_fraction_ring_smul [has_scalar R (fraction_ring (polynomial K))]
 by { cases p, rw ←of_fraction_ring_smul }
 
 include hdomain
-variables [distrib_mul_action R (polynomial K)]
+variables [monoid R] [distrib_mul_action R (polynomial K)]
 variables [htower : is_scalar_tower R (polynomial K) (polynomial K)]
 include htower
 

--- a/src/field_theory/ratfunc.lean
+++ b/src/field_theory/ratfunc.lean
@@ -278,18 +278,22 @@ variables {R : Type*} [monoid R] [distrib_mul_action R (polynomial K)]
 variables [htower : is_scalar_tower R (polynomial K) (polynomial K)]
 include htower
 
--- Can't define this in terms of `localization.has_scalar`, because that one
--- is not general enough.
 instance : has_scalar R (ratfunc K) :=
-⟨λ c p, p.lift_on (λ p q, ratfunc.mk (c • p) q) (λ p q p' q' hq hq' h, (mk_eq_mk hq hq').mpr $
-  by rw [smul_mul_assoc, h, smul_mul_assoc])⟩
+⟨λ c p, of_fraction_ring (c • to_fraction_ring p)⟩
+
+lemma of_fraction_ring_smul (c : R) (p : fraction_ring (polynomial K)) :
+  of_fraction_ring (c • p) = c • of_fraction_ring p := rfl
+lemma to_fraction_ring_smul (c : R) (p : ratfunc K) :
+  to_fraction_ring (c • p) = c • to_fraction_ring p := rfl
 
 lemma mk_smul (c : R) (p q : polynomial K) :
   ratfunc.mk (c • p) q = c • ratfunc.mk p q :=
-show ratfunc.mk (c • p) q = (ratfunc.mk p q).lift_on _ _,
-from symm $ (lift_on_mk p q _ (λ p, show ratfunc.mk (c • p) 0 = ratfunc.mk (c • 0) 1,
-  by rw [mk_zero, smul_zero, mk_eq_localization_mk (0 : polynomial K) one_ne_zero,
-         localization.mk_zero]) _)
+begin
+  by_cases hq : q = 0,
+  { rw [hq, mk_zero, mk_zero, ←of_fraction_ring_smul, smul_zero] },
+  { rw [mk_eq_localization_mk _ hq, mk_eq_localization_mk _ hq,
+         ←localization.smul_mk, ←of_fraction_ring_smul] }
+end
 
 instance : is_scalar_tower R (polynomial K) (ratfunc K) :=
 ⟨λ c p q, q.induction_on' (λ q r _, by rw [← mk_smul, smul_assoc, mk_smul, mk_smul])⟩


### PR DESCRIPTION
Now that `localization.has_scalar` is general enough, fix a TODO



---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
