### PR TITLE
[Merged by Bors] - chore(analysis/mean_inequalities_pow): nnreal versions of some ennreal inequalities

### DIFF
--- a/src/analysis/special_functions/pow.lean
+++ b/src/analysis/special_functions/pow.lean
@@ -920,6 +920,13 @@ real.rpow_lt_rpow_iff x.2 y.2 hz
 lemma rpow_le_rpow_iff {x y : ℝ≥0} {z : ℝ} (hz : 0 < z) : x ^ z ≤ y ^ z ↔ x ≤ y :=
 real.rpow_le_rpow_iff x.2 y.2 hz
 
+lemma le_rpow_one_div_iff {x y : ℝ≥0} {z : ℝ} (hz : 0 < z) :  x ≤ y ^ (1 / z) ↔ x ^ z ≤ y :=
+begin
+  nth_rewrite 0 ←rpow_one x,
+  nth_rewrite 0 ←@_root_.mul_inv_cancel _ _ z  hz.ne',
+  rw [rpow_mul, ←one_div, @rpow_le_rpow_iff _ _ (1/z) (by simp [hz])],
+end
+
 lemma rpow_lt_rpow_of_exponent_lt {x : ℝ≥0} {y z : ℝ} (hx : 1 < x) (hyz : y < z) : x^y < x^z :=
 real.rpow_lt_rpow_of_exponent_lt hx hyz
 
@@ -959,6 +966,15 @@ real.one_lt_rpow_of_pos_of_lt_one_of_neg hx1 hx2 hz
 lemma one_le_rpow_of_pos_of_le_one_of_nonpos {x : ℝ≥0} {z : ℝ} (hx1 : 0 < x) (hx2 : x ≤ 1)
   (hz : z ≤ 0) : 1 ≤ x^z :=
 real.one_le_rpow_of_pos_of_le_one_of_nonpos hx1 hx2 hz
+
+lemma rpow_le_self_of_le_one {x : ℝ≥0} {z : ℝ} (hx : x ≤ 1) (h_one_le : 1 ≤ z) : x ^ z ≤ x :=
+begin
+  rcases eq_bot_or_bot_lt x with rfl | (h : 0 < x),
+  { have : z ≠ 0 := by linarith,
+    simp [this] },
+  nth_rewrite 1 ←nnreal.rpow_one x,
+  exact nnreal.rpow_le_rpow_of_exponent_ge h hx h_one_le,
+end
 
 lemma pow_nat_rpow_nat_inv (x : ℝ≥0) {n : ℕ} (hn : 0 < n) :
   (x ^ n) ^ (n⁻¹ : ℝ) = x :=

--- a/src/order/bounded_order.lean
+++ b/src/order/bounded_order.lean
@@ -94,6 +94,15 @@ top_le_iff.1 $ h₂ ▸ h
 
 lemma lt_top_iff_ne_top : a < ⊤ ↔ a ≠ ⊤ := le_top.lt_iff_ne
 
+lemma eq_top_or_lt_top : a = ⊤ ∨ a < ⊤ :=
+begin
+  by_cases h : a = ⊤,
+  { exact or.inl h },
+  right,
+  rw lt_top_iff_ne_top,
+  exact h,
+end
+
 lemma ne_top_of_lt (h : a < b) : a ≠ ⊤ :=
 lt_top_iff_ne_top.1 $ lt_of_lt_of_le h le_top
 
@@ -168,6 +177,15 @@ begin
   haveI := classical.dec_eq α,
   haveI : decidable (a ≤ ⊥) := decidable_of_iff' _ le_bot_iff,
   simp only [lt_iff_le_not_le, not_iff_not.mpr le_bot_iff, true_and, bot_le],
+end
+
+lemma eq_bot_or_bot_lt : a = ⊥ ∨ ⊥ < a :=
+begin
+  by_cases h : a = ⊥,
+  { exact or.inl h },
+  right,
+  rw bot_lt_iff_ne_bot,
+  exact h,
 end
 
 lemma ne_bot_of_gt (h : a < b) : b ≠ ⊥ :=

--- a/src/order/bounded_order.lean
+++ b/src/order/bounded_order.lean
@@ -94,7 +94,7 @@ top_le_iff.1 $ h₂ ▸ h
 
 lemma lt_top_iff_ne_top : a < ⊤ ↔ a ≠ ⊤ := le_top.lt_iff_ne
 
-lemma eq_top_or_lt_top : a = ⊤ ∨ a < ⊤ :=
+lemma eq_top_or_lt_top (a : α) : a = ⊤ ∨ a < ⊤ :=
 begin
   by_cases h : a = ⊤,
   { exact or.inl h },
@@ -179,7 +179,7 @@ begin
   simp only [lt_iff_le_not_le, not_iff_not.mpr le_bot_iff, true_and, bot_le],
 end
 
-lemma eq_bot_or_bot_lt : a = ⊥ ∨ ⊥ < a :=
+lemma eq_bot_or_bot_lt (a : α) : a = ⊥ ∨ ⊥ < a :=
 begin
   by_cases h : a = ⊥,
   { exact or.inl h },


### PR DESCRIPTION
Make `nnreal` versions of the existing `ennreal` lemmas
```lean
lemma add_rpow_le_rpow_add {p : ℝ} (a b : ℝ≥0∞) (hp1 : 1 ≤ p) :
  a ^ p + b ^ p ≤ (a + b) ^ p 
```
and similar, introduced by @RemyDegenne in #5828.  Refactor the proofs of the `ennreal` versions to pass through these.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
