### PR TITLE
[Merged by Bors] - feat(topology/subset_properties): open/closed sets are locally compact spaces

### DIFF
--- a/src/topology/maps.lean
+++ b/src/topology/maps.lean
@@ -81,10 +81,14 @@ lemma inducing.map_nhds_of_mem {f : α → β} (hf : inducing f) (a : α) (h : r
   (𝓝 a).map f = 𝓝 (f a) :=
 hf.induced.symm ▸ map_nhds_induced_of_mem h
 
+lemma inducing.image_mem_nhds_within {f : α → β} (hf : inducing f) {a : α} {s : set α}
+  (hs : s ∈ 𝓝 a) : f '' s ∈ 𝓝[range f] (f a) :=
+hf.map_nhds_eq a ▸ image_mem_map hs
+
 lemma inducing.tendsto_nhds_iff {ι : Type*}
   {f : ι → β} {g : β → γ} {a : filter ι} {b : β} (hg : inducing g) :
   tendsto f a (𝓝 b) ↔ tendsto (g ∘ f) a (𝓝 (g b)) :=
-by rw [tendsto, tendsto, hg.induced, nhds_induced, ← map_le_iff_le_comap, filter.map_map]
+by rw [hg.nhds_eq_comap, tendsto_comap_iff]
 
 lemma inducing.continuous_at_iff {f : α → β} {g : β → γ} (hg : inducing g) {x : α} :
   continuous_at f x ↔ continuous_at (g ∘ f) x :=
@@ -375,7 +379,7 @@ hf.to_embedding.to_inducing.is_open_map hf.open_range
 
 lemma open_embedding.map_nhds_eq {f : α → β} (hf : open_embedding f) (a : α) :
   map f (𝓝 a) = 𝓝 (f a) :=
-hf.to_embedding.map_nhds_of_mem _ $ is_open.mem_nhds hf.open_range $ mem_range_self _
+hf.to_embedding.map_nhds_of_mem _ $ hf.open_range.mem_nhds $ mem_range_self _
 
 lemma open_embedding.open_iff_image_open {f : α → β} (hf : open_embedding f)
   {s : set α} : is_open s ↔ is_open (f '' s) :=


### PR DESCRIPTION
* add `inducing.image_mem_nhds_within`;
* move `inducing.is_compact_iff` up, use it to prove `embedding.is_compact_iff_is_compact_image`;
* prove `closed_embedding.is_compact_preimage`, use it to prove `closed_embedding.tendsto_cocompact`;
* prove `closed_embedding.locally_compact_space`, `open_embedding.locally_compact_space`;
* specialize to `is_closed.locally_compact_space`, `is_open.locally_compact_space`;
* rename `locally_finite.countable_of_sigma_compact` to `locally_finite.countable_univ`, provide `locally_finite.encodable`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
