### PR TITLE
[Merged by Bors] - feat(data/polynomial): add some simp attributes and commuted versions of coeff_mul_X_pow

### DIFF
--- a/src/data/polynomial/basic.lean
+++ b/src/data/polynomial/basic.lean
@@ -333,6 +333,8 @@ by rw [mul_assoc, X_pow_mul, ←mul_assoc]
 
 lemma commute_X (p : polynomial R) : commute X p := X_mul
 
+lemma commute_X_pow (p : polynomial R) (n : ℕ) : commute (X ^ n) p := X_pow_mul
+
 @[simp]
 lemma monomial_mul_X (n : ℕ) (r : R) : monomial n r * X = monomial (n+1) r :=
 by erw [monomial_mul_monomial, mul_one]

--- a/src/data/polynomial/coeff.lean
+++ b/src/data/polynomial/coeff.lean
@@ -125,6 +125,7 @@ lemma coeff_X_pow_self (n : ℕ) :
   coeff (X^n : polynomial R) n = 1 :=
 by simp [coeff_X_pow]
 
+@[simp]
 theorem coeff_mul_X_pow (p : polynomial R) (n d : ℕ) :
   coeff (p * polynomial.X ^ n) (d + n) = coeff p d :=
 begin
@@ -134,6 +135,12 @@ begin
   { exact λ h1, (h1 (nat.mem_antidiagonal.2 rfl)).elim }
 end
 
+@[simp]
+theorem coeff_X_pow_mul (p : polynomial R) (n d : ℕ) :
+  coeff (polynomial.X ^ n * p) (d + n) = coeff p d :=
+by rw [(commute_X_pow p n).eq, coeff_mul_X_pow]
+
+@[simp]
 lemma coeff_mul_X_pow' (p : polynomial R) (n d : ℕ) :
   (p * X ^ n).coeff d = ite (n ≤ d) (p.coeff (d - n)) 0 :=
 begin
@@ -145,9 +152,17 @@ begin
       (le_of_eq (finset.nat.mem_antidiagonal.mp hx))) (not_le.mp h)) },
 end
 
+@[simp]
+lemma coeff_X_pow_mul' (p : polynomial R) (n d : ℕ) :
+  (X ^ n * p).coeff d = ite (n ≤ d) (p.coeff (d - n)) 0 :=
+by rw [(commute_X_pow p n).eq, coeff_mul_X_pow']
+
 @[simp] theorem coeff_mul_X (p : polynomial R) (n : ℕ) :
   coeff (p * X) (n + 1) = coeff p n :=
 by simpa only [pow_one] using coeff_mul_X_pow p 1 n
+
+@[simp] theorem coeff_X_mul (p : polynomial R) (n : ℕ) :
+  coeff (X * p) (n + 1) = coeff p n := by rw [(commute_X p).eq, coeff_mul_X]
 
 theorem mul_X_pow_eq_zero {p : polynomial R} {n : ℕ}
   (H : p * X ^ n = 0) : p = 0 :=

--- a/src/data/polynomial/coeff.lean
+++ b/src/data/polynomial/coeff.lean
@@ -125,6 +125,7 @@ lemma coeff_X_pow_self (n : ℕ) :
   coeff (X^n : polynomial R) n = 1 :=
 by simp [coeff_X_pow]
 
+@[simp]
 theorem coeff_mul_X_pow (p : polynomial R) (n d : ℕ) :
   coeff (p * polynomial.X ^ n) (d + n) = coeff p d :=
 begin
@@ -134,11 +135,11 @@ begin
   { exact λ h1, (h1 (nat.mem_antidiagonal.2 rfl)).elim }
 end
 
+@[simp]
 theorem coeff_X_pow_mul (p : polynomial R) (n d : ℕ) :
   coeff (polynomial.X ^ n * p) (d + n) = coeff p d :=
 by rw [(commute_X_pow p n).eq, coeff_mul_X_pow]
 
-@[simp]
 lemma coeff_mul_X_pow' (p : polynomial R) (n d : ℕ) :
   (p * X ^ n).coeff d = ite (n ≤ d) (p.coeff (d - n)) 0 :=
 begin
@@ -150,7 +151,6 @@ begin
       (le_of_eq (finset.nat.mem_antidiagonal.mp hx))) (not_le.mp h)) },
 end
 
-@[simp]
 lemma coeff_X_pow_mul' (p : polynomial R) (n d : ℕ) :
   (X ^ n * p).coeff d = ite (n ≤ d) (p.coeff (d - n)) 0 :=
 by rw [(commute_X_pow p n).eq, coeff_mul_X_pow']

--- a/src/data/polynomial/coeff.lean
+++ b/src/data/polynomial/coeff.lean
@@ -125,7 +125,6 @@ lemma coeff_X_pow_self (n : ℕ) :
   coeff (X^n : polynomial R) n = 1 :=
 by simp [coeff_X_pow]
 
-@[simp]
 theorem coeff_mul_X_pow (p : polynomial R) (n d : ℕ) :
   coeff (p * polynomial.X ^ n) (d + n) = coeff p d :=
 begin
@@ -135,7 +134,6 @@ begin
   { exact λ h1, (h1 (nat.mem_antidiagonal.2 rfl)).elim }
 end
 
-@[simp]
 theorem coeff_X_pow_mul (p : polynomial R) (n d : ℕ) :
   coeff (polynomial.X ^ n * p) (d + n) = coeff p d :=
 by rw [(commute_X_pow p n).eq, coeff_mul_X_pow]


### PR DESCRIPTION
I couldn't find these before and accidentally rewrote them from scratch, I think part of the reason is that I would have expected all of these vesions to be simp lemmas, so we add some more versions of these lemmas and tag everything as simp.

From flt-regular

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
