### PR TITLE
[Merged by Bors] - feat(ring_theory/integral_closure): `is_field_iff_is_field`

### DIFF
--- a/src/ring_theory/integral_closure.lean
+++ b/src/ring_theory/integral_closure.lean
@@ -719,10 +719,9 @@ begin
   letI := hR.to_field R,
   refine ⟨⟨0, 1, zero_ne_one⟩, mul_comm, λ x hx, _⟩,
   let A := algebra.adjoin R ({x} : set S),
-  haveI : is_noetherian R A.to_submodule :=
+  haveI : is_noetherian R A :=
   is_noetherian_of_fg_of_noetherian A.to_submodule (fg_adjoin_singleton_of_integral x (H x)),
-  haveI : module.finite R A :=
-  show module.finite R A.to_submodule, from module.is_noetherian.finite R A,
+  haveI : module.finite R A := module.is_noetherian.finite R A,
   obtain ⟨y, hy⟩ := linear_map.surjective_of_injective (@lmul_left_injective R A _ _ _ _
     ⟨x, subset_adjoin (set.mem_singleton x)⟩ (λ h, hx (subtype.ext_iff.mp h))) 1,
   exact ⟨y, subtype.ext_iff.mp hy⟩,

--- a/src/ring_theory/integral_closure.lean
+++ b/src/ring_theory/integral_closure.lean
@@ -712,8 +712,8 @@ begin
 end
 
 lemma is_field_of_is_integral_of_is_field'
-  {R S : Type*} [comm_ring R] [is_domain R] [comm_ring S] [is_domain S]
-  [algebra R S] (H : algebra.is_integral R S) (hR : is_field R) :
+  {R S : Type*} [comm_ring R] [is_domain R] [comm_ring S] [is_domain S] [algebra R S]
+  (H : algebra.is_integral R S) (hR : is_field R) :
   is_field S :=
 begin
   letI := hR.to_field R,
@@ -735,8 +735,9 @@ begin
   exact ⟨y, subtype.ext_iff.mp hy⟩,
 end
 
-lemma is_field_iff_is_field {R S : Type*} [comm_ring R] [is_domain R] [comm_ring S] [is_domain S]
-  [algebra R S] (H : algebra.is_integral R S) (hRS : function.injective (algebra_map R S)) :
+lemma is_integral.is_field_iff_is_field
+  {R S : Type*} [comm_ring R] [is_domain R] [comm_ring S] [is_domain S] [algebra R S]
+  (H : algebra.is_integral R S) (hRS : function.injective (algebra_map R S)) :
   is_field R ↔ is_field S :=
 ⟨is_field_of_is_integral_of_is_field' H, is_field_of_is_integral_of_is_field H hRS⟩
 

--- a/src/ring_theory/integral_closure.lean
+++ b/src/ring_theory/integral_closure.lean
@@ -670,7 +670,7 @@ end
 
 /-- If the integral extension `R → S` is injective, and `S` is a field, then `R` is also a field. -/
 lemma is_field_of_is_integral_of_is_field
-  {R S : Type*} [comm_ring R] [is_domain R] [comm_ring S] [is_domain S]
+  {R S : Type*} [comm_ring R] [nontrivial R] [comm_ring S] [is_domain S]
   [algebra R S] (H : is_integral R S) (hRS : function.injective (algebra_map R S))
   (hS : is_field S) : is_field R :=
 begin
@@ -712,7 +712,7 @@ begin
 end
 
 lemma is_field_of_is_integral_of_is_field'
-  {R S : Type*} [comm_ring R] [is_domain R] [comm_ring S] [is_domain S] [algebra R S]
+  {R S : Type*} [comm_ring R] [comm_ring S] [is_domain S] [algebra R S]
   (H : algebra.is_integral R S) (hR : is_field R) :
   is_field S :=
 begin
@@ -728,7 +728,7 @@ begin
 end
 
 lemma is_integral.is_field_iff_is_field
-  {R S : Type*} [comm_ring R] [is_domain R] [comm_ring S] [is_domain S] [algebra R S]
+  {R S : Type*} [comm_ring R] [nontrivial R] [comm_ring S] [is_domain S] [algebra R S]
   (H : algebra.is_integral R S) (hRS : function.injective (algebra_map R S)) :
   is_field R ↔ is_field S :=
 ⟨is_field_of_is_integral_of_is_field' H, is_field_of_is_integral_of_is_field H hRS⟩

--- a/src/ring_theory/integral_closure.lean
+++ b/src/ring_theory/integral_closure.lean
@@ -719,19 +719,12 @@ begin
   letI := hR.to_field R,
   refine ⟨⟨0, 1, zero_ne_one⟩, mul_comm, λ x hx, _⟩,
   let A := algebra.adjoin R ({x} : set S),
-  let f : A →ₗ[R] A :=
-  { to_fun := λ y, ⟨x, algebra.mem_adjoin_iff.mpr (subring.mem_closure.mpr (λ T hT,
-      show _, from set.singleton_subset_iff.mp (set.union_subset_iff.mp hT).2))⟩ * y,
-    map_add' := λ y z, mul_add ⟨x, _⟩ y z,
-    map_smul' := λ y z, mul_smul_comm y ⟨x, _⟩ z },
-  have hf : function.injective f :=
-  linear_map.ker_eq_bot.mp (le_bot_iff.mp (λ y hy,
-    (eq_zero_or_eq_zero_of_mul_eq_zero hy).resolve_left (hx ∘ subtype.ext_iff.mp))),
   haveI : is_noetherian R A.to_submodule :=
   is_noetherian_of_fg_of_noetherian A.to_submodule (fg_adjoin_singleton_of_integral x (H x)),
   haveI : module.finite R A :=
   show module.finite R A.to_submodule, from module.is_noetherian.finite R A,
-  obtain ⟨y, hy⟩ := linear_map.surjective_of_injective hf 1,
+  obtain ⟨y, hy⟩ := linear_map.surjective_of_injective (@lmul_left_injective R A _ _ _ _
+    ⟨x, subset_adjoin (set.mem_singleton x)⟩ (λ h, hx (subtype.ext_iff.mp h))) 1,
   exact ⟨y, subtype.ext_iff.mp hy⟩,
 end
 


### PR DESCRIPTION
If `R/S` is an integral extension, then `R` is a field if and only if `S` is a field. One direction was already in mathlib, and this PR proves the converse direction.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
