### PR TITLE
[Merged by Bors] - feat(ring_theory/tensor_product): Range of `tensor_product.product_map`

### DIFF
--- a/src/ring_theory/tensor_product.lean
+++ b/src/ring_theory/tensor_product.lean
@@ -707,6 +707,18 @@ rfl
 @[simp] lemma map_comp_include_right (f : A →ₐ[R] B) (g : C →ₐ[R] D) :
   (map f g).comp include_right = include_right.comp g := alg_hom.ext $ by simp
 
+lemma map_range (f : A →ₐ[R] B) (g : C →ₐ[R] D) :
+  (map f g).range = (include_left.comp f).range ⊔ (include_right.comp g).range :=
+begin
+  apply le_antisymm,
+  { rw [←map_top, ←adjoin_tmul_eq_top, ←adjoin_image, adjoin_le_iff],
+    rintros _ ⟨_, ⟨a, b, rfl⟩, rfl⟩,
+    rw [map_tmul, ←_root_.mul_one (f a), ←_root_.one_mul (g b), ←tmul_mul_tmul],
+    exact mul_mem_sup (alg_hom.mem_range_self _ a) (alg_hom.mem_range_self _ b) },
+  { rw [←map_comp_include_left f g, ←map_comp_include_right f g],
+    exact sup_le (alg_hom.range_comp_le_range _ _) (alg_hom.range_comp_le_range _ _) },
+end
+
 /--
 Construct an isomorphism between tensor products of R-algebras
 from isomorphisms between the tensor factors.
@@ -773,16 +785,17 @@ lemma product_map_right_apply (b : B) : product_map f g (include_right b) = g b 
 
 @[simp] lemma product_map_right : (product_map f g).comp include_right = g := alg_hom.ext $ by simp
 
+lemma alg_hom.map_sup {R A B : Type*} [comm_semiring R] [semiring A] [semiring B]
+  [algebra R A] [algebra R B] (f : A →ₐ[R] B) (S T : subalgebra R A) :
+  (S ⊔ T).map f = S.map f ⊔ T.map f :=
+le_antisymm (subalgebra.map_le.mpr (sup_le (subalgebra.map_le.mp le_sup_left)
+  (subalgebra.map_le.mp le_sup_right)))
+  (sup_le (subalgebra.map_mono le_sup_left) (subalgebra.map_mono le_sup_right))
+
 lemma product_map_range : (product_map f g).range = f.range ⊔ g.range :=
-begin
-  refine le_antisymm _ (sup_le (le_trans (ge_of_eq (congr_arg _ (product_map_left f g)))
-    (include_left.range_comp_le_range (product_map f g))) (le_trans (ge_of_eq (congr_arg _
-    (product_map_right f g))) (include_right.range_comp_le_range (product_map f g)))),
-  rw [←map_top, ←adjoin_tmul_eq_top, ←adjoin_image, adjoin_le_iff],
-  rintros _ ⟨_, ⟨a, b, rfl⟩, rfl⟩,
-  rw product_map_apply_tmul,
-  exact mul_mem_sup (f.mem_range_self a) (g.mem_range_self b),
-end
+by rw [product_map, alg_hom.range_comp, map_range, alg_hom.map_sup, ←alg_hom.range_comp,
+    ←alg_hom.range_comp, ←alg_hom.comp_assoc, ←alg_hom.comp_assoc, lmul'_comp_include_left,
+    lmul'_comp_include_right, alg_hom.id_comp, alg_hom.id_comp]
 
 end
 end tensor_product

--- a/src/ring_theory/tensor_product.lean
+++ b/src/ring_theory/tensor_product.lean
@@ -784,15 +784,8 @@ lemma product_map_right_apply (b : B) : product_map f g (include_right b) = g b 
 
 @[simp] lemma product_map_right : (product_map f g).comp include_right = g := alg_hom.ext $ by simp
 
-lemma alg_hom.map_sup {R A B : Type*} [comm_semiring R] [semiring A] [semiring B]
-  [algebra R A] [algebra R B] (f : A →ₐ[R] B) (S T : subalgebra R A) :
-  (S ⊔ T).map f = S.map f ⊔ T.map f :=
-le_antisymm (subalgebra.map_le.mpr (sup_le (subalgebra.map_le.mp le_sup_left)
-  (subalgebra.map_le.mp le_sup_right)))
-  (sup_le (subalgebra.map_mono le_sup_left) (subalgebra.map_mono le_sup_right))
-
 lemma product_map_range : (product_map f g).range = f.range ⊔ g.range :=
-by rw [product_map, alg_hom.range_comp, map_range, alg_hom.map_sup, ←alg_hom.range_comp,
+by rw [product_map, alg_hom.range_comp, map_range, map_sup, ←alg_hom.range_comp,
     ←alg_hom.range_comp, ←alg_hom.comp_assoc, ←alg_hom.comp_assoc, lmul'_comp_include_left,
     lmul'_comp_include_right, alg_hom.id_comp, alg_hom.id_comp]
 

--- a/src/ring_theory/tensor_product.lean
+++ b/src/ring_theory/tensor_product.lean
@@ -4,8 +4,9 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Scott Morrison, Johan Commelin
 -/
 
-import linear_algebra.tensor_product
 import algebra.algebra.tower
+import ring_theory.adjoin.basic
+import linear_algebra.tensor_product
 
 /-!
 # The tensor product of R-algebras
@@ -649,6 +650,9 @@ theorem comm_tmul (a : A) (b : B) :
   (tensor_product.comm R A B : (A ⊗[R] B → B ⊗[R] A)) (a ⊗ₜ b) = (b ⊗ₜ a) :=
 by simp [tensor_product.comm]
 
+lemma adjoin_tmul_eq_top : adjoin R {t : A ⊗[R] B | ∃ a b, a ⊗ₜ[R] b = t} = ⊤ :=
+top_le_iff.mp ((top_le_iff.mpr (span_tmul_eq_top R A B)).trans (span_le_adjoin R _))
+
 end
 
 section
@@ -768,6 +772,17 @@ lemma product_map_left_apply (a : A) : product_map f g (include_left a) = f a :=
 lemma product_map_right_apply (b : B) : product_map f g (include_right b) = g b := by simp
 
 @[simp] lemma product_map_right : (product_map f g).comp include_right = g := alg_hom.ext $ by simp
+
+lemma product_map_range : (product_map f g).range = f.range ⊔ g.range :=
+begin
+  refine le_antisymm _ (sup_le (le_trans (ge_of_eq (congr_arg _ (product_map_left f g)))
+    (include_left.range_comp_le_range (product_map f g))) (le_trans (ge_of_eq (congr_arg _
+    (product_map_right f g))) (include_right.range_comp_le_range (product_map f g)))),
+  rw [←map_top, ←adjoin_tmul_eq_top, ←adjoin_image, adjoin_le_iff],
+  rintros _ ⟨_, ⟨a, b, rfl⟩, rfl⟩,
+  rw product_map_apply_tmul,
+  exact mul_mem_sup (f.mem_range_self a) (g.mem_range_self b),
+end
 
 end
 end tensor_product


### PR DESCRIPTION
This PR proves `(product_map f g).range = f.range ⊔ g.range`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

- [x] depends on: #10899
- [x] depends on: #10900

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
