### PR TITLE
[Merged by Bors] - feat(data/list/sort): subperm sorted implies sublist

### DIFF
--- a/src/data/list/sort.lean
+++ b/src/data/list/sort.lean
@@ -72,6 +72,10 @@ begin
     split; simp [iff_true_intro this, or_comm] }
 end
 
+theorem sublist_of_subperm_of_sorted [is_antisymm α r]
+  {l₁ l₂ : list α} (p : l₁ <+~ l₂) (s₁ : l₁.sorted r) (s₂ : l₂.sorted r) : l₁ <+ l₂ :=
+let ⟨_, h, h'⟩ := p in by rwa ←list.eq_of_perm_of_sorted h (list.pairwise_of_sublist h' s₂) s₁
+
 @[simp] theorem sorted_singleton (a : α) : sorted r [a] := pairwise_singleton _ _
 
 lemma sorted.rel_nth_le_of_lt {l : list α}


### PR DESCRIPTION
A "sub" version of the lemma directly above.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
