### PR TITLE
[Merged by Bors] - feat(group_theory/submonoid/membership): upgrade definition of pow from a set morphism to a monoid morphism

### DIFF
--- a/src/group_theory/submonoid/membership.lean
+++ b/src/group_theory/submonoid/membership.lean
@@ -235,7 +235,7 @@ subtype.coe_injective.of_comp_iff (pow n)
 
 /-- The exponentiation map is an isomorphism from the additive monoid on natural numbers to powers
 when it is injective. The inverse is given by the logarithms. -/
-def pow_log_equiv [decidable_eq M] {n : M} (h : function.injective (λ m : ℕ, n ^ m)) (m : ℕ) :
+def pow_log_equiv [decidable_eq M] {n : M} (h : function.injective (λ m : ℕ, n ^ m)):
   multiplicative ℕ ≃* powers n :=
 { to_fun := pow n,
   inv_fun := log,
@@ -244,7 +244,7 @@ def pow_log_equiv [decidable_eq M] {n : M} (h : function.injective (λ m : ℕ, 
   map_mul' := λ x y, by { simp only [pow, map_mul] } }
 
 theorem log_pow_int_eq_self {x : ℤ} (h : 1 < x.nat_abs) (m : ℕ) : log (pow x m) = m :=
-(pow_log_equiv (int.pow_right_injective h) m).left_inv _
+(pow_log_equiv (int.pow_right_injective h)).left_inv _
 
 @[simp] lemma map_powers {N : Type*} [monoid N] (f : M →* N) (m : M) :
   (powers m).map f = powers (f m) :=

--- a/src/group_theory/submonoid/membership.lean
+++ b/src/group_theory/submonoid/membership.lean
@@ -220,7 +220,8 @@ lemma powers_subset {n : M} {P : submonoid M} (h : n ∈ P) : powers n ≤ P :=
 λ x hx, match x, hx with _, ⟨i, rfl⟩ := P.pow_mem h i end
 
 /-- Exponentiation map from natural numbers to powers. -/
-def pow (n : M) (m : ℕ) : powers n := (powers_hom M n).mrange_restrict m
+def pow (n : M) (m : ℕ) : powers n :=
+(powers_hom M n).mrange_restrict (multiplicative.of_add m)
 
 /-- Logarithms from powers to natural numbers. -/
 def log [decidable_eq M] {n : M} (p : powers n) : ℕ :=

--- a/src/group_theory/submonoid/membership.lean
+++ b/src/group_theory/submonoid/membership.lean
@@ -234,6 +234,10 @@ lemma pow_right_injective_iff_pow_injective {n : M} :
   function.injective (λ m : ℕ, n ^ m) ↔ function.injective (pow n) :=
 subtype.coe_injective.of_comp_iff (pow n)
 
+theorem log_pow_eq_self [decidable_eq M] {n : M} (h : function.injective (λ m : ℕ, n ^ m)) (m : ℕ) :
+  log (pow n m) = m :=
+pow_right_injective_iff_pow_injective.mp h $ pow_log_eq_self _
+
 /-- The exponentiation map is an isomorphism from the additive monoid on natural numbers to powers
 when it is injective. The inverse is given by the logarithms. -/
 @[simps]
@@ -241,7 +245,7 @@ def pow_log_equiv [decidable_eq M] {n : M} (h : function.injective (λ m : ℕ, 
   multiplicative ℕ ≃* powers n :=
 { to_fun := λ m, pow n m.to_add,
   inv_fun := λ m, multiplicative.of_add (log m),
-  left_inv := λ _, pow_right_injective_iff_pow_injective.mp h $ pow_log_eq_self _,
+  left_inv := log_pow_eq_self h,
   right_inv := pow_log_eq_self,
   map_mul' := λ _ _, by { simp only [pow, map_mul, of_add_add, to_add_mul] } }
 

--- a/src/group_theory/submonoid/membership.lean
+++ b/src/group_theory/submonoid/membership.lean
@@ -220,8 +220,8 @@ lemma powers_subset {n : M} {P : submonoid M} (h : n ∈ P) : powers n ≤ P :=
 λ x hx, match x, hx with _, ⟨i, rfl⟩ := P.pow_mem h i end
 
 /-- Exponentiation map from natural numbers to powers. -/
-def pow (n : M) (m : ℕ) : powers n := (powers_hom M n).mrange_restrict (multiplicative.of_add m)
-
+@[simps] def pow (n : M) (m : ℕ) : powers n :=
+(powers_hom M n).mrange_restrict (multiplicative.of_add m)
 
 /-- Logarithms from powers to natural numbers. -/
 def log [decidable_eq M] {n : M} (p : powers n) : ℕ :=

--- a/src/group_theory/submonoid/membership.lean
+++ b/src/group_theory/submonoid/membership.lean
@@ -220,7 +220,8 @@ lemma powers_subset {n : M} {P : submonoid M} (h : n ∈ P) : powers n ≤ P :=
 λ x hx, match x, hx with _, ⟨i, rfl⟩ := P.pow_mem h i end
 
 /-- Exponentiation map from natural numbers to powers. -/
-def pow (n : M) (m : ℕ) : powers n := (powers_hom M n).mrange_restrict m
+def pow (n : M) (m : ℕ) : powers n := (powers_hom M n).mrange_restrict (multiplicative.of_add m)
+
 
 /-- Logarithms from powers to natural numbers. -/
 def log [decidable_eq M] {n : M} (p : powers n) : ℕ :=
@@ -238,11 +239,11 @@ when it is injective. The inverse is given by the logarithms. -/
 @[simps]
 def pow_log_equiv [decidable_eq M] {n : M} (h : function.injective (λ m : ℕ, n ^ m)):
   multiplicative ℕ ≃* powers n :=
-{ to_fun := pow n,
-  inv_fun := log,
+{ to_fun := λ m, pow n m.to_add,
+  inv_fun := λ m, multiplicative.of_add (log m),
   left_inv := λ _, pow_right_injective_iff_pow_injective.mp h $ pow_log_eq_self _,
   right_inv := pow_log_eq_self,
-  map_mul' := λ x y, by { simp only [pow, map_mul] } }
+  map_mul' := λ _ _, by { simp only [pow, map_mul, of_add_add, to_add_mul] } }
 
 theorem log_pow_int_eq_self {x : ℤ} (h : 1 < x.nat_abs) (m : ℕ) : log (pow x m) = m :=
 (pow_log_equiv (int.pow_right_injective h)).symm_apply_apply _

--- a/src/group_theory/submonoid/membership.lean
+++ b/src/group_theory/submonoid/membership.lean
@@ -235,8 +235,8 @@ subtype.coe_injective.of_comp_iff (pow n)
 
 /-- The exponentiation map is an isomorphism from the additive monoid on natural numbers to powers
 when it is injective. The inverse is given by the logarithms. -/
-def pow_log_equiv [decidable_eq M] {n : M} (h : function.injective (λ m : ℕ, n ^ m)) (m : ℕ) : multiplicative ℕ ≃* powers n := {
-  to_fun := pow n,
+def pow_log_equiv [decidable_eq M] {n : M} (h : function.injective (λ m : ℕ, n ^ m)) (m : ℕ) : multiplicative ℕ ≃* powers n :=
+{ to_fun := pow n,
   inv_fun := log,
   left_inv := λ _, pow_right_injective_iff_pow_injective.mp h $ pow_log_eq_self _,
   right_inv := pow_log_eq_self,

--- a/src/group_theory/submonoid/membership.lean
+++ b/src/group_theory/submonoid/membership.lean
@@ -237,7 +237,7 @@ subtype.coe_injective.of_comp_iff (pow n)
 /-- The exponentiation map is an isomorphism from the additive monoid on natural numbers to powers
 when it is injective. The inverse is given by the logarithms. -/
 @[simps]
-def pow_log_equiv [decidable_eq M] {n : M} (h : function.injective (λ m : ℕ, n ^ m)):
+def pow_log_equiv [decidable_eq M] {n : M} (h : function.injective (λ m : ℕ, n ^ m)) :
   multiplicative ℕ ≃* powers n :=
 { to_fun := λ m, pow n m.to_add,
   inv_fun := λ m, multiplicative.of_add (log m),

--- a/src/group_theory/submonoid/membership.lean
+++ b/src/group_theory/submonoid/membership.lean
@@ -220,7 +220,7 @@ lemma powers_subset {n : M} {P : submonoid M} (h : n ∈ P) : powers n ≤ P :=
 λ x hx, match x, hx with _, ⟨i, rfl⟩ := P.pow_mem h i end
 
 /-- Exponentiation map from natural numbers to powers. -/
-def pow (n : M) (m : ℕ) : powers n := ⟨n ^ m, m, rfl⟩
+def pow (n : M) (m : ℕ) : powers n := (powers_hom M n).mrange_restrict m
 
 /-- Logarithms from powers to natural numbers. -/
 def log [decidable_eq M] {n : M} (p : powers n) : ℕ :=
@@ -233,12 +233,17 @@ lemma pow_right_injective_iff_pow_injective {n : M} :
   function.injective (λ m : ℕ, n ^ m) ↔ function.injective (pow n) :=
 subtype.coe_injective.of_comp_iff (pow n)
 
-theorem log_pow_eq_self [decidable_eq M] {n : M} (h : function.injective (λ m : ℕ, n ^ m)) (m : ℕ) :
-  log (pow n m) = m :=
-pow_right_injective_iff_pow_injective.mp h $ pow_log_eq_self _
+/-- The exponentiation map is an isomorphism from the additive monoid on natural numbers to powers
+when it is injective. The inverse is given by the logarithms. -/
+def pow_log_equiv [decidable_eq M] {n : M} (h : function.injective (λ m : ℕ, n ^ m)) (m : ℕ) : multiplicative ℕ ≃* powers n := {
+  to_fun := pow n,
+  inv_fun := log,
+  left_inv := λ _, pow_right_injective_iff_pow_injective.mp h $ pow_log_eq_self _,
+  right_inv := pow_log_eq_self,
+  map_mul' := λ x y, by { simp only [pow, map_mul] } }
 
 theorem log_pow_int_eq_self {x : ℤ} (h : 1 < x.nat_abs) (m : ℕ) : log (pow x m) = m :=
-log_pow_eq_self (int.pow_right_injective h) _
+(pow_log_equiv (int.pow_right_injective h) m).left_inv _
 
 @[simp] lemma map_powers {N : Type*} [monoid N] (f : M →* N) (m : M) :
   (powers m).map f = powers (f m) :=

--- a/src/group_theory/submonoid/membership.lean
+++ b/src/group_theory/submonoid/membership.lean
@@ -220,8 +220,7 @@ lemma powers_subset {n : M} {P : submonoid M} (h : n ∈ P) : powers n ≤ P :=
 λ x hx, match x, hx with _, ⟨i, rfl⟩ := P.pow_mem h i end
 
 /-- Exponentiation map from natural numbers to powers. -/
-def pow (n : M) (m : ℕ) : powers n :=
-(powers_hom M n).mrange_restrict (multiplicative.of_add m)
+def pow (n : M) (m : ℕ) : powers n := (powers_hom M n).mrange_restrict m
 
 /-- Logarithms from powers to natural numbers. -/
 def log [decidable_eq M] {n : M} (p : powers n) : ℕ :=

--- a/src/group_theory/submonoid/membership.lean
+++ b/src/group_theory/submonoid/membership.lean
@@ -235,6 +235,7 @@ subtype.coe_injective.of_comp_iff (pow n)
 
 /-- The exponentiation map is an isomorphism from the additive monoid on natural numbers to powers
 when it is injective. The inverse is given by the logarithms. -/
+@[simps]
 def pow_log_equiv [decidable_eq M] {n : M} (h : function.injective (λ m : ℕ, n ^ m)):
   multiplicative ℕ ≃* powers n :=
 { to_fun := pow n,
@@ -244,7 +245,7 @@ def pow_log_equiv [decidable_eq M] {n : M} (h : function.injective (λ m : ℕ, 
   map_mul' := λ x y, by { simp only [pow, map_mul] } }
 
 theorem log_pow_int_eq_self {x : ℤ} (h : 1 < x.nat_abs) (m : ℕ) : log (pow x m) = m :=
-(pow_log_equiv (int.pow_right_injective h)).left_inv _
+(pow_log_equiv (int.pow_right_injective h)).symm_apply_apply _
 
 @[simp] lemma map_powers {N : Type*} [monoid N] (f : M →* N) (m : M) :
   (powers m).map f = powers (f m) :=

--- a/src/group_theory/submonoid/membership.lean
+++ b/src/group_theory/submonoid/membership.lean
@@ -235,7 +235,8 @@ subtype.coe_injective.of_comp_iff (pow n)
 
 /-- The exponentiation map is an isomorphism from the additive monoid on natural numbers to powers
 when it is injective. The inverse is given by the logarithms. -/
-def pow_log_equiv [decidable_eq M] {n : M} (h : function.injective (λ m : ℕ, n ^ m)) (m : ℕ) : multiplicative ℕ ≃* powers n :=
+def pow_log_equiv [decidable_eq M] {n : M} (h : function.injective (λ m : ℕ, n ^ m)) (m : ℕ) :
+  multiplicative ℕ ≃* powers n :=
 { to_fun := pow n,
   inv_fun := log,
   left_inv := λ _, pow_right_injective_iff_pow_injective.mp h $ pow_log_eq_self _,


### PR DESCRIPTION
This comes at no extra cost. All the prerequisite definitions and lemmas were already in mathlib.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
