### PR TITLE
[Merged by Bors] - feat(group_theory/index): `relindex_eq_zero_of_le_left`

### DIFF
--- a/src/group_theory/index.lean
+++ b/src/group_theory/index.lean
@@ -85,14 +85,14 @@ dvd_of_mul_left_eq (H.relindex K) (relindex_mul_index h)
   (H.subgroup_of L).relindex (K.subgroup_of L) = H.relindex K :=
 ((index_comap (H.subgroup_of L) (inclusion hKL)).trans (congr_arg _ (inclusion_range hKL))).symm
 
+variables (H K L)
+
 @[to_additive] lemma relindex_mul_relindex (hHK : H ≤ K) (hKL : K ≤ L) :
   H.relindex K * K.relindex L = H.relindex L :=
 begin
   rw [←relindex_subgroup_of hKL],
   exact relindex_mul_index (λ x hx, hHK hx),
 end
-
-variables (H K L)
 
 lemma inf_relindex_right : (H ⊓ K).relindex K = H.relindex K :=
 begin
@@ -116,7 +116,7 @@ lemma relindex_dvd_of_le_left (hHK : H ≤ K) :
 begin
   apply dvd_of_mul_left_eq ((H ⊓ L).relindex (K ⊓ L)),
   rw [←inf_relindex_right H L, ←inf_relindex_right K L],
-  exact relindex_mul_relindex (inf_le_inf_right L hHK) inf_le_right,
+  exact relindex_mul_relindex (H ⊓ L) (K ⊓ L) L (inf_le_inf_right L hHK) inf_le_right,
 end
 
 variables (H K)
@@ -189,7 +189,11 @@ begin
   exact ⟨fintype.card H, H.index_mul_card.symm⟩,
 end
 
-variables {H}
+variables {H K L}
+
+lemma relindex_eq_zero_of_le_left (hHK : H ≤ K) (hKL : K.relindex L = 0) : H.relindex L = 0 :=
+by rw [←inf_relindex_right, ←relindex_mul_relindex (H ⊓ L) (K ⊓ L) L
+  (inf_le_inf_right L hHK) inf_le_right, inf_relindex_right, hKL, mul_zero]
 
 @[simp] lemma index_eq_one : H.index = 1 ↔ H = ⊤ :=
 ⟨λ h, quotient_group.subgroup_eq_top_of_subsingleton H (cardinal.to_nat_eq_one_iff_unique.mp h).1,


### PR DESCRIPTION
If `K` has infinite index in `L`, then so does any `H ≤ K`.
The `right`-version is forthcoming.
Making the subgroups explicit in `relindex_mul_relindex` makes rewriting much easier (both in this situation, and in others).

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
