### PR TITLE
[Merged by Bors] - chore(data/finset/prod): eliminate `finish`

### DIFF
--- a/src/data/finset/prod.lean
+++ b/src/data/finset/prod.lean
@@ -153,7 +153,8 @@ by { simp only [off_diag, mem_filter, mem_product], split; intros h;
 
 @[simp] lemma diag_card : (diag s).card = s.card :=
 begin
-  suffices : diag s = s.image (λ a, (a, a)), { rw this, apply card_image_of_inj_on, finish },
+  suffices : diag s = s.image (λ a, (a, a)),
+  { rw this, apply card_image_of_inj_on, exact λ x1 h1 x2 h2 h3, (prod.mk.inj h3).1 },
   ext ⟨a₁, a₂⟩, rw mem_diag, split; intros; finish,
 end
 

--- a/src/data/finset/prod.lean
+++ b/src/data/finset/prod.lean
@@ -163,7 +163,7 @@ end
 @[simp] lemma off_diag_card : (off_diag s).card = s.card * s.card - s.card :=
 begin
   suffices : (diag s).card + (off_diag s).card = s.card * s.card,
-  { nth_rewrite 2 ← s.diag_card, finish },
+  { nth_rewrite 2 ← s.diag_card, simp only [diag_card] at *, rw tsub_eq_of_eq_add_rev, rw this },
   rw ← card_product,
   apply filter_card_add_filter_neg_card_eq_card,
 end

--- a/src/data/finset/prod.lean
+++ b/src/data/finset/prod.lean
@@ -144,7 +144,9 @@ for `a, b ∈ s`. -/
 def off_diag := (s.product s).filter (λ (a : α × α), a.fst ≠ a.snd)
 
 @[simp] lemma mem_diag (x : α × α) : x ∈ s.diag ↔ x.1 ∈ s ∧ x.1 = x.2 :=
-by { simp only [diag, mem_filter, mem_product], split; intros; finish }
+by { simp only [diag, mem_filter, mem_product], split; intros h,
+     rcases h with ⟨⟨h1, h2⟩, h3⟩, use h1, use h3,
+     rcases h with ⟨h1, h2⟩, simp only [←h2, and_true, eq_self_iff_true, and_self, h1] }
 
 @[simp] lemma mem_off_diag (x : α × α) : x ∈ s.off_diag ↔ x.1 ∈ s ∧ x.2 ∈ s ∧ x.1 ≠ x.2 :=
 by { simp only [off_diag, mem_filter, mem_product], split; intros; finish }

--- a/src/data/finset/prod.lean
+++ b/src/data/finset/prod.lean
@@ -87,7 +87,7 @@ begin
   { apply congr_arg, ext ⟨a, b⟩, simp only [filter_union_right, mem_filter, mem_product],
     split; intros h; use h.1,
     simp only [function.comp_app, and_self, h.2, em (q b)],
-    cases h.2; {try {simp at h_1}, simp [h_1]} },
+    cases h.2; { try { simp at h_1 }, simp [h_1] } },
   { rw disjoint_iff, change _ ∩ _ = ∅, ext ⟨a, b⟩, rw mem_inter,
     simp only [and_imp, mem_filter, not_and, not_not, function.comp_app, iff_false, mem_product,
      not_mem_empty], intros, assumption }

--- a/src/data/finset/prod.lean
+++ b/src/data/finset/prod.lean
@@ -74,7 +74,8 @@ multiset.card_product _ _
 
 lemma filter_product (p : α → Prop) (q : β → Prop) [decidable_pred p] [decidable_pred q] :
   (s.product t).filter (λ (x : α × β), p x.1 ∧ q x.2) = (s.filter p).product (t.filter q) :=
-by { ext ⟨a, b⟩, simp only [mem_filter, mem_product], finish }
+by { ext ⟨a, b⟩, simp only [mem_filter, mem_product],
+     exact and_and_and_comm (a ∈ s) (b ∈ t) (p a) (q b) }
 
 lemma filter_product_card (s : finset α) (t : finset β)
   (p : α → Prop) (q : β → Prop) [decidable_pred p] [decidable_pred q] :

--- a/src/data/finset/prod.lean
+++ b/src/data/finset/prod.lean
@@ -155,7 +155,9 @@ by { simp only [off_diag, mem_filter, mem_product], split; intros h;
 begin
   suffices : diag s = s.image (λ a, (a, a)),
   { rw this, apply card_image_of_inj_on, exact λ x1 h1 x2 h2 h3, (prod.mk.inj h3).1 },
-  ext ⟨a₁, a₂⟩, rw mem_diag, split; intros; finish,
+  ext ⟨a₁, a₂⟩, rw mem_diag, split; intros h; rw finset.mem_image at *,
+  { use [a₁, h.1, prod.mk.inj_iff.mpr ⟨rfl, h.2⟩] },
+  { rcases h with ⟨a, h1, h2⟩, have h := prod.mk.inj h2, rw [←h.1, ←h.2], use h1 },
 end
 
 @[simp] lemma off_diag_card : (off_diag s).card = s.card * s.card - s.card :=

--- a/src/data/finset/prod.lean
+++ b/src/data/finset/prod.lean
@@ -144,12 +144,12 @@ for `a, b ∈ s`. -/
 def off_diag := (s.product s).filter (λ (a : α × α), a.fst ≠ a.snd)
 
 @[simp] lemma mem_diag (x : α × α) : x ∈ s.diag ↔ x.1 ∈ s ∧ x.1 = x.2 :=
-by { simp only [diag, mem_filter, mem_product], split; intros h,
-     rcases h with ⟨⟨h1, h2⟩, h3⟩, use h1, use h3,
-     rcases h with ⟨h1, h2⟩, simp only [←h2, and_true, eq_self_iff_true, and_self, h1] }
+by { simp only [diag, mem_filter, mem_product], split; intros h;
+     simp only [h, and_true, eq_self_iff_true, and_self], rw ←h.2, exact h.1 }
 
 @[simp] lemma mem_off_diag (x : α × α) : x ∈ s.off_diag ↔ x.1 ∈ s ∧ x.2 ∈ s ∧ x.1 ≠ x.2 :=
-by { simp only [off_diag, mem_filter, mem_product], split; intros; finish }
+by { simp only [off_diag, mem_filter, mem_product], split; intros h;
+     simp only [h, ne.def, not_false_iff, and_self] }
 
 @[simp] lemma diag_card : (diag s).card = s.card :=
 begin

--- a/src/data/finset/prod.lean
+++ b/src/data/finset/prod.lean
@@ -85,8 +85,12 @@ begin
   classical,
   rw [← card_product, ← card_product, ← filter_product, ← filter_product, ← card_union_eq],
   { apply congr_arg, ext ⟨a, b⟩, simp only [filter_union_right, mem_filter, mem_product],
-    split; intros; finish },
-  { rw disjoint_iff, change _ ∩ _ = ∅, ext ⟨a, b⟩, rw mem_inter, finish }
+    split; intros h; use h.1,
+    simp only [function.comp_app, and_self, h.2, em (q b)],
+    cases h.2; {try {simp at h_1}, simp [h_1]} },
+  { rw disjoint_iff, change _ ∩ _ = ∅, ext ⟨a, b⟩, rw mem_inter,
+    simp only [and_imp, mem_filter, not_and, not_not, function.comp_app, iff_false, mem_product,
+     not_mem_empty], intros, assumption }
 end
 
 lemma empty_product (t : finset β) : (∅ : finset α).product t = ∅ := rfl


### PR DESCRIPTION
Removing uses of finish, as discussed in this Zulip thread (https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/mathlib.20sat.20solvers)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
