### PR TITLE
chore(tactic/default): remove `import tactic.omega`

### DIFF
--- a/src/tactic/default.lean
+++ b/src/tactic/default.lean
@@ -22,7 +22,6 @@ import tactic.abel
 import tactic.ring_exp
 import tactic.noncomm_ring
 import tactic.linarith
-import tactic.omega
 import tactic.tfae
 import tactic.apply_fun
 import tactic.interval_cases


### PR DESCRIPTION
`omega` is semi-deprecated (pending rewrite for Lean 4), so we shouldn't encourage users to use it.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
