### PR TITLE
[Merged by Bors] - feat(testing/slim_check): teach slim_check about `finsupp`s

### DIFF
--- a/src/testing/slim_check/functions.lean
+++ b/src/testing/slim_check/functions.lean
@@ -177,10 +177,10 @@ def apply_finsupp (tf : total_function α β) : α →₀ β :=
 instance finsupp.sampleable_ext [has_repr α] [has_repr β] : sampleable_ext (α →₀ β) :=
 { proxy_repr := total_function α β,
   interp := total_function.apply_finsupp,
-  sample := do {
+  sample := (do
     xs ← (sampleable.sample (list (α × β)) : gen ((list (α × β)))),
     ⟨x⟩ ← (uliftable.up $ sample β : gen (ulift.{max u v} β)),
-    pure $ total_function.with_default (list.to_finmap' xs) x },
+    pure $ total_function.with_default (list.to_finmap' xs) x),
   shrink := total_function.shrink }
 
 end finsupp

--- a/src/testing/slim_check/functions.lean
+++ b/src/testing/slim_check/functions.lean
@@ -132,9 +132,6 @@ end
 
 section finsupp
 
-variables [sampleable α] [sampleable β]
-
-variables [decidable_eq α] [decidable_eq β]
 
 variables [has_zero β]
 

--- a/src/testing/slim_check/functions.lean
+++ b/src/testing/slim_check/functions.lean
@@ -141,6 +141,7 @@ def zero_default : total_function α β →
                    total_function α β
 | (with_default A y) := with_default A 0
 
+variables [sampleable α] [sampleable β]
 /-- The suppport of a zero default `total_function`. -/
 @[simp]
 def zero_default_supp : total_function α β → finset α

--- a/src/testing/slim_check/functions.lean
+++ b/src/testing/slim_check/functions.lean
@@ -134,20 +134,21 @@ section finsupp
 
 
 variables [has_zero β]
-variables [decidable_eq α] [decidable_eq β]
 /-- Map a total_function to one whose default value is zero so that it represents a finsupp. -/
 @[simp]
 def zero_default : total_function α β →
                    total_function α β
 | (with_default A y) := with_default A 0
 
-variables [sampleable α] [sampleable β]
+variables [decidable_eq α] [decidable_eq β]
 /-- The suppport of a zero default `total_function`. -/
 @[simp]
 def zero_default_supp : total_function α β → finset α
 | (with_default A y) :=
   list.to_finset $ (A.erase_dupkeys.filter (λ ab, sigma.snd ab ≠ 0)).map sigma.fst
 
+/-- Create a finitely supported function from a total function by taking the default value to
+zero. -/
 def apply_finsupp (tf : total_function α β) : α →₀ β :=
 { support := zero_default_supp tf,
   to_fun := tf.zero_default.apply,
@@ -172,6 +173,7 @@ def apply_finsupp (tf : total_function α β) : α →₀ β :=
       { simp, }, }
   end }
 
+variables [sampleable α] [sampleable β]
 instance finsupp.sampleable_ext [has_repr α] [has_repr β] : sampleable_ext (α →₀ β) :=
 { proxy_repr := total_function α β,
   interp := total_function.apply_finsupp,

--- a/src/testing/slim_check/functions.lean
+++ b/src/testing/slim_check/functions.lean
@@ -134,7 +134,7 @@ section finsupp
 
 
 variables [has_zero β]
-
+variables [decidable_eq α] [decidable_eq β]
 /-- Map a total_function to one whose default value is zero so that it represents a finsupp. -/
 @[simp]
 def zero_default : total_function α β →

--- a/src/testing/slim_check/functions.lean
+++ b/src/testing/slim_check/functions.lean
@@ -6,6 +6,7 @@ Authors: Simon Hudon
 import data.list.sigma
 import data.int.range
 import data.finsupp.basic
+import data.finsupp.to_dfinsupp
 import tactic.pretty_cases
 import testing.slim_check.sampleable
 import testing.slim_check.testable
@@ -132,7 +133,6 @@ end
 
 section finsupp
 
-
 variables [has_zero β]
 /-- Map a total_function to one whose default value is zero so that it represents a finsupp. -/
 @[simp]
@@ -177,6 +177,15 @@ variables [sampleable α] [sampleable β]
 instance finsupp.sampleable_ext [has_repr α] [has_repr β] : sampleable_ext (α →₀ β) :=
 { proxy_repr := total_function α β,
   interp := total_function.apply_finsupp,
+  sample := (do
+    xs ← (sampleable.sample (list (α × β)) : gen ((list (α × β)))),
+    ⟨x⟩ ← (uliftable.up $ sample β : gen (ulift.{max u v} β)),
+    pure $ total_function.with_default (list.to_finmap' xs) x),
+  shrink := total_function.shrink }
+
+instance dfinsupp.sampleable_ext [has_repr α] [has_repr β] : sampleable_ext (Π₀ a : α, β) :=
+{ proxy_repr := total_function α β,
+  interp := finsupp.to_dfinsupp ∘ total_function.apply_finsupp,
   sample := (do
     xs ← (sampleable.sample (list (α × β)) : gen ((list (α × β)))),
     ⟨x⟩ ← (uliftable.up $ sample β : gen (ulift.{max u v} β)),

--- a/src/testing/slim_check/functions.lean
+++ b/src/testing/slim_check/functions.lean
@@ -141,7 +141,7 @@ def zero_default : total_function α β →
 | (with_default A y) := with_default A 0
 
 variables [decidable_eq α] [decidable_eq β]
-/-- The suppport of a zero default `total_function`. -/
+/-- The support of a zero default `total_function`. -/
 @[simp]
 def zero_default_supp : total_function α β → finset α
 | (with_default A y) :=

--- a/src/testing/slim_check/functions.lean
+++ b/src/testing/slim_check/functions.lean
@@ -136,8 +136,7 @@ section finsupp
 variables [has_zero β]
 /-- Map a total_function to one whose default value is zero so that it represents a finsupp. -/
 @[simp]
-def zero_default : total_function α β →
-                   total_function α β
+def zero_default : total_function α β → total_function α β
 | (with_default A y) := with_default A 0
 
 variables [decidable_eq α] [decidable_eq β]
@@ -178,7 +177,7 @@ instance finsupp.sampleable_ext [has_repr α] [has_repr β] : sampleable_ext (α
 { proxy_repr := total_function α β,
   interp := total_function.apply_finsupp,
   sample := (do
-    xs ← (sampleable.sample (list (α × β)) : gen ((list (α × β)))),
+    xs ← (sampleable.sample (list (α × β)) : gen (list (α × β))),
     ⟨x⟩ ← (uliftable.up $ sample β : gen (ulift.{max u v} β)),
     pure $ total_function.with_default (list.to_finmap' xs) x),
   shrink := total_function.shrink }
@@ -188,7 +187,7 @@ instance dfinsupp.sampleable_ext [has_repr α] [has_repr β] : sampleable_ext (�
 { proxy_repr := total_function α β,
   interp := finsupp.to_dfinsupp ∘ total_function.apply_finsupp,
   sample := (do
-    xs ← (sampleable.sample (list (α × β)) : gen ((list (α × β)))),
+    xs ← (sampleable.sample (list (α × β)) : gen (list (α × β))),
     ⟨x⟩ ← (uliftable.up $ sample β : gen (ulift.{max u v} β)),
     pure $ total_function.with_default (list.to_finmap' xs) x),
   shrink := total_function.shrink }

--- a/src/testing/slim_check/functions.lean
+++ b/src/testing/slim_check/functions.lean
@@ -183,6 +183,7 @@ instance finsupp.sampleable_ext [has_repr α] [has_repr β] : sampleable_ext (α
     pure $ total_function.with_default (list.to_finmap' xs) x),
   shrink := total_function.shrink }
 
+-- TODO: support a non-constant codomain type
 instance dfinsupp.sampleable_ext [has_repr α] [has_repr β] : sampleable_ext (Π₀ a : α, β) :=
 { proxy_repr := total_function α β,
   interp := finsupp.to_dfinsupp ∘ total_function.apply_finsupp,

--- a/test/slim_check.lean
+++ b/test/slim_check.lean
@@ -409,3 +409,20 @@ f := [0 ↦ 1, _ ↦ 0]
   admit,
   trivial,
 end
+
+example (f : Π₀ n : ℕ, ℕ) : true :=
+begin
+  have : f.update 0 0 = 0,
+  success_if_fail_with_msg
+  { slim_check { random_seed := some 257 } }
+"
+===================
+Found problems!
+
+f := [1 ↦ 1, _ ↦ 0]
+(1 shrinks)
+-------------------
+",
+  admit,
+  trivial,
+end

--- a/test/slim_check.lean
+++ b/test/slim_check.lean
@@ -392,3 +392,20 @@ issue: ¬ true does not hold
   admit,
   trivial,
 end
+
+example (f : ℕ →₀ ℕ) : true :=
+begin
+  have : f = 0,
+  success_if_fail_with_msg
+  { slim_check { random_seed := some 257 } }
+"
+===================
+Found problems!
+
+f := [0 ↦ 1, _ ↦ 0]
+(2 shrinks)
+-------------------
+",
+  admit,
+  trivial,
+end


### PR DESCRIPTION
We add some instances so that `slim_check` can generate `finsupp`s and hence try to provide counterexamples for them.
As the way the original slim_check for functions works is to generate a finite list of random values and pick a default for the rest of the values these `total_functions` are quite close to finsupps already, we just have to map the default value to zero, and prove various things about the support.
There might be conceptually nicer ways of building this instance but this seems functional enough.

Seeing as many finsupp defs are classical (and noncomputable) this isn't quite as useful for generating counterexamples as I originally hoped.

See the test at `test/slim_check.lean` for a basic example of usage

I wrote this while working on flt-regular but it is hopefully useful outside of that


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
