### PR TITLE
[Merged by Bors] - chore(category_theory/filtered): avoid `finish`

### DIFF
--- a/src/category_theory/filtered.lean
+++ b/src/category_theory/filtered.lean
@@ -199,7 +199,12 @@ begin
       { subst hf,
         apply coeq_condition, },
       { rw @w' _ _ mX mY f' (by simpa [hf ∘ eq.symm] using mf') }, },
-    { rw @w' _ _ mX' mY' f' (by finish), }, },
+    { rw @w' _ _ mX' mY' f' _,
+      apply finset.mem_of_mem_insert_of_ne mf',
+      contrapose! h,
+      obtain ⟨rfl, h⟩ := h,
+      rw [heq_iff_eq, psigma.mk.inj_iff] at h,
+      exact ⟨rfl, h.1.symm⟩ }, },
 end
 
 /--
@@ -572,7 +577,12 @@ begin
       { subst hf,
         apply eq_condition, },
       { rw @w' _ _ mX mY f' (by simpa [hf ∘ eq.symm] using mf') }, },
-    { rw @w' _ _ mX' mY' f' (by finish), }, },
+    { rw @w' _ _ mX' mY' f' _,
+      apply finset.mem_of_mem_insert_of_ne mf',
+      contrapose! h,
+      obtain ⟨rfl, h⟩ := h,
+      rw [heq_iff_eq, psigma.mk.inj_iff] at h,
+      exact ⟨rfl, h.1.symm⟩ }, },
 end
 
 /--


### PR DESCRIPTION
Removing uses of finish, as discussed on Zulip (https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/mathlib.20sat.20solvers).

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
