### PR TITLE
[Merged by Bors] - feat(data/mv_polynomial): API for mv polynomial.rename

### DIFF
--- a/src/data/finset/lattice.lean
+++ b/src/data/finset/lattice.lean
@@ -47,13 +47,15 @@ fold_image_idem
   (s.map f).sup g = s.sup (g ∘ f) :=
 fold_map
 
-@[simp] lemma sup_map_multiset (s : finset α) {f : β → γ} (h : function.injective f)
-(g : α → multiset β) : multiset.map f (s.sup g) = s.sup (λ x,  multiset.map f (g x)) :=
+lemma sup_map_multiset [decidable_eq α] [decidable_eq β] (s : finset γ) (f : γ → multiset β)
+  (g : β ↪ α) : multiset.map g (s.sup f) = s.sup (multiset.map g ∘ f) :=
 begin
   apply finset.cons_induction_on s,
   simp,
   intros a s' h_a_s h_ind,
-  simp [finset.sup_cons, ← h_ind, multiset.map_union h],
+  simp only [sup_cons, ←h_ind, multiset.sup_eq_union, function.comp_app],
+  rw multiset.map_union,
+  exact g.inj',
 end
 
 @[simp] lemma sup_singleton {b : β} : ({b} : finset β).sup f = f b :=
@@ -299,10 +301,6 @@ fold_image_idem
 @[simp] lemma inf_map (s : finset γ) (f : γ ↪ β) (g : β → α) :
   (s.map f).inf g = s.inf (g ∘ f) :=
 fold_map
-
-@[simp] lemma inf_map_multiset (s : finset α) {f : β → γ} (h : function.injective f)
-  (g : α → multiset β) :  multiset.map f (s.inf g) = s.inf (λ x,  multiset.map f (g x)) :=
-:= sorry
 
 @[simp] lemma inf_singleton {b : β} : ({b} : finset β).inf f = f b :=
 inf_singleton

--- a/src/data/finset/lattice.lean
+++ b/src/data/finset/lattice.lean
@@ -982,8 +982,8 @@ namespace multiset
 
 lemma map_finset_sup [decidable_eq α] [decidable_eq β]
   (s : finset γ) (f : γ → multiset β) (g : β → α) (hg : function.injective g) :
-  multiset.map g (s.sup f) = s.sup (multiset.map g ∘ f) :=
-finset.comp_sup_eq_sup_comp _ (λ _ _, multiset.map_union hg) (multiset.map_zero _)
+  map g (s.sup f) = s.sup (map g ∘ f) :=
+finset.comp_sup_eq_sup_comp _ (λ _ _, map_union hg) (map_zero _)
 
 lemma count_finset_sup [decidable_eq β] (s : finset α) (f : α → multiset β) (b : β) :
   count b (s.sup f) = s.sup (λa, count b (f a)) :=

--- a/src/data/finset/lattice.lean
+++ b/src/data/finset/lattice.lean
@@ -47,7 +47,7 @@ fold_image_idem
   (s.map f).sup g = s.sup (g ∘ f) :=
 fold_map
 
-lemma sup_map_multiset {α : Type*} [decidable_eq α] [decidable_eq β]
+lemma multiset_map_sup {α : Type*} [decidable_eq α] [decidable_eq β]
   (s : finset γ) (f : γ → multiset β) (g : β ↪ α) :
   multiset.map g (s.sup f) = s.sup (multiset.map g ∘ f) :=
 begin

--- a/src/data/finset/lattice.lean
+++ b/src/data/finset/lattice.lean
@@ -47,8 +47,9 @@ fold_image_idem
   (s.map f).sup g = s.sup (g ∘ f) :=
 fold_map
 
-lemma sup_map_multiset [decidable_eq α] [decidable_eq β] (s : finset γ) (f : γ → multiset β)
-  (g : β ↪ α) : multiset.map g (s.sup f) = s.sup (multiset.map g ∘ f) :=
+lemma sup_map_multiset {α : Type*} [decidable_eq α] [decidable_eq β]
+  (s : finset γ) (f : γ → multiset β) (g : β ↪ α) :
+  multiset.map g (s.sup f) = s.sup (multiset.map g ∘ f) :=
 begin
   apply finset.cons_induction_on s,
   simp,

--- a/src/data/finset/lattice.lean
+++ b/src/data/finset/lattice.lean
@@ -47,6 +47,15 @@ fold_image_idem
   (s.map f).sup g = s.sup (g ∘ f) :=
 fold_map
 
+@[simp] lemma sup_map_multiset (s : finset α) {f : β → γ} (h : function.injective f)
+(g : α → multiset β) : multiset.map f (s.sup g) = s.sup (λ x,  multiset.map f (g x)) :=
+begin
+  apply finset.cons_induction_on s,
+  simp,
+  intros a s' h_a_s h_ind,
+  simp [finset.sup_cons, ← h_ind, multiset.map_union h],
+end
+
 @[simp] lemma sup_singleton {b : β} : ({b} : finset β).sup f = f b :=
 sup_singleton
 
@@ -290,6 +299,10 @@ fold_image_idem
 @[simp] lemma inf_map (s : finset γ) (f : γ ↪ β) (g : β → α) :
   (s.map f).inf g = s.inf (g ∘ f) :=
 fold_map
+
+@[simp] lemma inf_map_multiset (s : finset α) {f : β → γ} (h : function.injective f) (g : α → multiset β) :
+  multiset.map f (s.inf g) = s.inf (λ x,  multiset.map f (g x)) :=
+:= sorry
 
 @[simp] lemma inf_singleton {b : β} : ({b} : finset β).inf f = f b :=
 inf_singleton

--- a/src/data/finset/lattice.lean
+++ b/src/data/finset/lattice.lean
@@ -52,11 +52,11 @@ lemma _root_.multiset.map_finset_sup {α : Type*} [decidable_eq α] [decidable_e
   multiset.map g (s.sup f) = s.sup (multiset.map g ∘ f) :=
 begin
   apply finset.cons_induction_on s,
-  simp,
-  intros a s' h_a_s h_ind,
-  simp only [sup_cons, ←h_ind, multiset.sup_eq_union, function.comp_app],
-  rw multiset.map_union,
-  exact g.inj',
+  { simp },
+  { intros a s' h_a_s h_ind,
+    simp only [sup_cons, ←h_ind, multiset.sup_eq_union, function.comp_app],
+    rw multiset.map_union,
+    exact g.inj' },
 end
 
 @[simp] lemma sup_singleton {b : β} : ({b} : finset β).sup f = f b :=

--- a/src/data/finset/lattice.lean
+++ b/src/data/finset/lattice.lean
@@ -47,18 +47,6 @@ fold_image_idem
   (s.map f).sup g = s.sup (g ∘ f) :=
 fold_map
 
-lemma _root_.multiset.map_finset_sup {α : Type*} [decidable_eq α] [decidable_eq β]
-  (s : finset γ) (f : γ → multiset β) (g : β ↪ α) :
-  multiset.map g (s.sup f) = s.sup (multiset.map g ∘ f) :=
-begin
-  apply finset.cons_induction_on s,
-  { simp },
-  { intros a s' h_a_s h_ind,
-    simp only [sup_cons, ←h_ind, multiset.sup_eq_union, function.comp_app],
-    rw multiset.map_union,
-    exact g.inj' },
-end
-
 @[simp] lemma sup_singleton {b : β} : ({b} : finset β).sup f = f b :=
 sup_singleton
 
@@ -991,6 +979,11 @@ end exists_max_min
 end finset
 
 namespace multiset
+
+lemma map_finset_sup [decidable_eq α] [decidable_eq β]
+  (s : finset γ) (f : γ → multiset β) (g : β → α) (hg : function.injective g) :
+  multiset.map g (s.sup f) = s.sup (multiset.map g ∘ f) :=
+finset.comp_sup_eq_sup_comp _ (λ _ _, multiset.map_union hg) (multiset.map_zero _)
 
 lemma count_finset_sup [decidable_eq β] (s : finset α) (f : α → multiset β) (b : β) :
   count b (s.sup f) = s.sup (λa, count b (f a)) :=

--- a/src/data/finset/lattice.lean
+++ b/src/data/finset/lattice.lean
@@ -47,7 +47,7 @@ fold_image_idem
   (s.map f).sup g = s.sup (g ∘ f) :=
 fold_map
 
-lemma multiset_map_sup {α : Type*} [decidable_eq α] [decidable_eq β]
+lemma _root_.multiset.map_finset_sup {α : Type*} [decidable_eq α] [decidable_eq β]
   (s : finset γ) (f : γ → multiset β) (g : β ↪ α) :
   multiset.map g (s.sup f) = s.sup (multiset.map g ∘ f) :=
 begin

--- a/src/data/finset/lattice.lean
+++ b/src/data/finset/lattice.lean
@@ -300,8 +300,8 @@ fold_image_idem
   (s.map f).inf g = s.inf (g ∘ f) :=
 fold_map
 
-@[simp] lemma inf_map_multiset (s : finset α) {f : β → γ} (h : function.injective f) (g : α → multiset β) :
-  multiset.map f (s.inf g) = s.inf (λ x,  multiset.map f (g x)) :=
+@[simp] lemma inf_map_multiset (s : finset α) {f : β → γ} (h : function.injective f)
+  (g : α → multiset β) :  multiset.map f (s.inf g) = s.inf (λ x,  multiset.map f (g x)) :=
 := sorry
 
 @[simp] lemma inf_singleton {b : β} : ({b} : finset β).inf f = f b :=

--- a/src/data/finsupp/basic.lean
+++ b/src/data/finsupp/basic.lean
@@ -1597,6 +1597,7 @@ begin
   rwa [map_domain_apply hf, map_domain_apply hf] at this,
 end
 
+/-- When `f` is injective we have an embedding `(α →₀ ℕ)  ↪ (β →₀ ℕ)` given by `map_domain`. -/
 def map_domain_embedding_of_injective {α β : Type*} {f : α → β} (h : function.injective f) :
  (α →₀ ℕ)  ↪ (β →₀ ℕ) := ⟨finsupp.map_domain f, finsupp.map_domain_injective h⟩
 

--- a/src/data/finsupp/basic.lean
+++ b/src/data/finsupp/basic.lean
@@ -1599,7 +1599,7 @@ end
 
 /-- When `f` is an embedding we have an embedding `(α →₀ ℕ)  ↪ (β →₀ ℕ)` given by `map_domain`. -/
 def map_domain_embedding {α β : Type*} (f : α ↪ β) : (α →₀ ℕ) ↪ (β →₀ ℕ) :=
-  ⟨finsupp.map_domain f.to_fun, finsupp.map_domain_injective f.inj'⟩
+⟨finsupp.map_domain f.to_fun, finsupp.map_domain_injective f.inj'⟩
 
 lemma map_domain.add_monoid_hom_comp_map_range [add_comm_monoid N] (f : α → β) (g : M →+ N) :
   (map_domain.add_monoid_hom f).comp (map_range.add_monoid_hom g) =

--- a/src/data/finsupp/basic.lean
+++ b/src/data/finsupp/basic.lean
@@ -1599,7 +1599,7 @@ end
 
 /-- When `f` is an embedding we have an embedding `(α →₀ ℕ)  ↪ (β →₀ ℕ)` given by `map_domain`. -/
 def map_domain_embedding {α β : Type*} (f : α ↪ β) : (α →₀ ℕ) ↪ (β →₀ ℕ) :=
-  ⟨finsupp.map_domain f.to_fun, finsupp.map_domain_injective h⟩
+  ⟨finsupp.map_domain f.to_fun, finsupp.map_domain_injective f.inj'⟩
 
 lemma map_domain.add_monoid_hom_comp_map_range [add_comm_monoid N] (f : α → β) (g : M →+ N) :
   (map_domain.add_monoid_hom f).comp (map_range.add_monoid_hom g) =

--- a/src/data/finsupp/basic.lean
+++ b/src/data/finsupp/basic.lean
@@ -1598,8 +1598,8 @@ begin
 end
 
 /-- When `f` is injective we have an embedding `(α →₀ ℕ)  ↪ (β →₀ ℕ)` given by `map_domain`. -/
-def map_domain_embedding {α β : Type*} {f : α → β} (h : function.injective f) :
-  (α →₀ ℕ) ↪ (β →₀ ℕ) := ⟨finsupp.map_domain f, finsupp.map_domain_injective h⟩
+def map_domain_embedding {α β : Type*} (f : α ↪ β) :
+  (α →₀ ℕ) ↪ (β →₀ ℕ) := ⟨finsupp.map_domain f.to_fun, finsupp.map_domain_injective h⟩
 
 lemma map_domain.add_monoid_hom_comp_map_range [add_comm_monoid N] (f : α → β) (g : M →+ N) :
   (map_domain.add_monoid_hom f).comp (map_range.add_monoid_hom g) =

--- a/src/data/finsupp/basic.lean
+++ b/src/data/finsupp/basic.lean
@@ -1598,8 +1598,8 @@ begin
 end
 
 /-- When `f` is injective we have an embedding `(α →₀ ℕ)  ↪ (β →₀ ℕ)` given by `map_domain`. -/
-def map_domain_embedding_of_injective {α β : Type*} {f : α → β} (h : function.injective f) :
- (α →₀ ℕ)  ↪ (β →₀ ℕ) := ⟨finsupp.map_domain f, finsupp.map_domain_injective h⟩
+def map_domain_embedding {α β : Type*} {f : α → β} (h : function.injective f) :
+  (α →₀ ℕ) ↪ (β →₀ ℕ) := ⟨finsupp.map_domain f, finsupp.map_domain_injective h⟩
 
 lemma map_domain.add_monoid_hom_comp_map_range [add_comm_monoid N] (f : α → β) (g : M →+ N) :
   (map_domain.add_monoid_hom f).comp (map_range.add_monoid_hom g) =

--- a/src/data/finsupp/basic.lean
+++ b/src/data/finsupp/basic.lean
@@ -1597,9 +1597,9 @@ begin
   rwa [map_domain_apply hf, map_domain_apply hf] at this,
 end
 
-/-- When `f` is injective we have an embedding `(α →₀ ℕ)  ↪ (β →₀ ℕ)` given by `map_domain`. -/
-def map_domain_embedding {α β : Type*} (f : α ↪ β) :
-  (α →₀ ℕ) ↪ (β →₀ ℕ) := ⟨finsupp.map_domain f.to_fun, finsupp.map_domain_injective h⟩
+/-- When `f` is an embedding we have an embedding `(α →₀ ℕ)  ↪ (β →₀ ℕ)` given by `map_domain`. -/
+def map_domain_embedding {α β : Type*} (f : α ↪ β) : (α →₀ ℕ) ↪ (β →₀ ℕ) :=
+  ⟨finsupp.map_domain f.to_fun, finsupp.map_domain_injective h⟩
 
 lemma map_domain.add_monoid_hom_comp_map_range [add_comm_monoid N] (f : α → β) (g : M →+ N) :
   (map_domain.add_monoid_hom f).comp (map_range.add_monoid_hom g) =

--- a/src/data/finsupp/basic.lean
+++ b/src/data/finsupp/basic.lean
@@ -1554,10 +1554,10 @@ finset.subset.trans support_sum $
 
 lemma map_domain_support_of_injective [decidable_eq β] {f : α → β} (hf : function.injective f)
   (s : α →₀ M) : (map_domain f s).support = finset.image f s.support :=
-finset.subset.antisymm finsupp.map_domain_support $ begin
+finset.subset.antisymm map_domain_support $ begin
   rw finset.image_subset_iff_subset_preimage (hf.inj_on _),
   intros x hx,
-  simp[map_domain_apply hf, finsupp.mem_support_iff.mp hx],
+  simp [map_domain_apply hf, mem_support_iff.mp hx],
 end
 
 @[to_additive]
@@ -1606,8 +1606,8 @@ begin
 end
 
 /-- When `f` is an embedding we have an embedding `(α →₀ ℕ)  ↪ (β →₀ ℕ)` given by `map_domain`. -/
-def map_domain_embedding {α β : Type*} (f : α ↪ β) : (α →₀ ℕ) ↪ (β →₀ ℕ) :=
-⟨finsupp.map_domain f.to_fun, finsupp.map_domain_injective f.inj'⟩
+@[simps] def map_domain_embedding {α β : Type*} (f : α ↪ β) : (α →₀ ℕ) ↪ (β →₀ ℕ) :=
+⟨finsupp.map_domain f, finsupp.map_domain_injective f.injective⟩
 
 lemma map_domain.add_monoid_hom_comp_map_range [add_comm_monoid N] (f : α → β) (g : M →+ N) :
   (map_domain.add_monoid_hom f).comp (map_range.add_monoid_hom g) =

--- a/src/data/finsupp/basic.lean
+++ b/src/data/finsupp/basic.lean
@@ -1597,6 +1597,9 @@ begin
   rwa [map_domain_apply hf, map_domain_apply hf] at this,
 end
 
+def map_domain_embedding_of_injective {α β : Type*} {f : α → β} (h : function.injective f) :
+ (α →₀ ℕ)  ↪ (β →₀ ℕ) := ⟨finsupp.map_domain f, finsupp.map_domain_injective h⟩
+
 lemma map_domain.add_monoid_hom_comp_map_range [add_comm_monoid N] (f : α → β) (g : M →+ N) :
   (map_domain.add_monoid_hom f).comp (map_range.add_monoid_hom g) =
     (map_range.add_monoid_hom g).comp (map_domain.add_monoid_hom f) :=

--- a/src/data/finsupp/basic.lean
+++ b/src/data/finsupp/basic.lean
@@ -1552,6 +1552,14 @@ finset.subset.trans support_sum $
   finset.subset.trans (finset.bUnion_mono $ assume a ha, support_single_subset) $
   by rw [finset.bUnion_singleton]; exact subset.refl _
 
+lemma map_domain_support_of_injective [decidable_eq β] {f : α → β} (hf : function.injective f)
+  (s : α →₀ M) : (map_domain f s).support = finset.image f s.support :=
+finset.subset.antisymm finsupp.map_domain_support $ begin
+  rw finset.image_subset_iff_subset_preimage (hf.inj_on _),
+  intros x hx,
+  simp[map_domain_apply hf, finsupp.mem_support_iff.mp hx],
+end
+
 @[to_additive]
 lemma prod_map_domain_index [comm_monoid N] {f : α → β} {s : α →₀ M}
   {h : β → M → N} (h_zero : ∀b, h b 0 = 1) (h_add : ∀b m₁ m₂, h b (m₁ + m₂) = h b m₁ * h b m₂) :

--- a/src/data/multiset/lattice.lean
+++ b/src/data/multiset/lattice.lean
@@ -99,7 +99,7 @@ fold_cons_left _ _ _ _
 @[simp] lemma inf_singleton {a : α} : ({a} : multiset α).inf = a :=
 inf_top_eq
 
-@[simp] lemma sup_map (s : finset α) {f : β → γ} (h : function.injective f) (g : α → multiset β) :
+@[simp] lemma inf_map (s : finset α) {f : β → γ} (h : function.injective f) (g : α → multiset β) :
   multiset.map f (s.inf g) = s.inf (λ x,  multiset.map f (g x)) :=
 := sorry
 

--- a/src/data/multiset/lattice.lean
+++ b/src/data/multiset/lattice.lean
@@ -11,7 +11,7 @@ import data.multiset.fold
 -/
 
 namespace multiset
-variables {α β γ : Type*}
+variables {α : Type*}
 
 /-! ### sup -/
 section sup

--- a/src/data/multiset/lattice.lean
+++ b/src/data/multiset/lattice.lean
@@ -11,7 +11,7 @@ import data.multiset.fold
 -/
 
 namespace multiset
-variables {α : Type*}
+variables {α β γ : Type*}
 
 /-! ### sup -/
 section sup
@@ -30,6 +30,15 @@ fold_cons_left _ _ _ _
 
 @[simp] lemma sup_singleton {a : α} : ({a} : multiset α).sup = a :=
 sup_bot_eq
+
+@[simp] lemma sup_map (s : finset α) {f : β → γ} (h : function.injective f) (g : α → multiset β) :
+  multiset.map f (s.sup g) = s.sup (λ x,  multiset.map f (g x)) :=
+begin
+  apply finset.cons_induction_on s,
+  simp,
+  intros a s' h_a_s h_ind,
+  simp [finset.sup_cons, ← h_ind, multiset.map_union h],
+end
 
 @[simp] lemma sup_add (s₁ s₂ : multiset α) : (s₁ + s₂).sup = s₁.sup ⊔ s₂.sup :=
 eq.trans (by simp [sup]) (fold_add _ _ _ _ _)
@@ -89,6 +98,10 @@ fold_cons_left _ _ _ _
 
 @[simp] lemma inf_singleton {a : α} : ({a} : multiset α).inf = a :=
 inf_top_eq
+
+@[simp] lemma sup_map (s : finset α) {f : β → γ} (h : function.injective f) (g : α → multiset β) :
+  multiset.map f (s.inf g) = s.inf (λ x,  multiset.map f (g x)) :=
+:= sorry
 
 @[simp] lemma inf_add (s₁ s₂ : multiset α) : (s₁ + s₂).inf = s₁.inf ⊓ s₂.inf :=
 eq.trans (by simp [inf]) (fold_add _ _ _ _ _)

--- a/src/data/multiset/lattice.lean
+++ b/src/data/multiset/lattice.lean
@@ -31,15 +31,6 @@ fold_cons_left _ _ _ _
 @[simp] lemma sup_singleton {a : α} : ({a} : multiset α).sup = a :=
 sup_bot_eq
 
-@[simp] lemma sup_map (s : finset α) {f : β → γ} (h : function.injective f) (g : α → multiset β) :
-  multiset.map f (s.sup g) = s.sup (λ x,  multiset.map f (g x)) :=
-begin
-  apply finset.cons_induction_on s,
-  simp,
-  intros a s' h_a_s h_ind,
-  simp [finset.sup_cons, ← h_ind, multiset.map_union h],
-end
-
 @[simp] lemma sup_add (s₁ s₂ : multiset α) : (s₁ + s₂).sup = s₁.sup ⊔ s₂.sup :=
 eq.trans (by simp [sup]) (fold_add _ _ _ _ _)
 
@@ -98,10 +89,6 @@ fold_cons_left _ _ _ _
 
 @[simp] lemma inf_singleton {a : α} : ({a} : multiset α).inf = a :=
 inf_top_eq
-
-@[simp] lemma inf_map (s : finset α) {f : β → γ} (h : function.injective f) (g : α → multiset β) :
-  multiset.map f (s.inf g) = s.inf (λ x,  multiset.map f (g x)) :=
-:= sorry
 
 @[simp] lemma inf_add (s₁ s₂ : multiset α) : (s₁ + s₂).inf = s₁.inf ⊓ s₂.inf :=
 eq.trans (by simp [inf]) (fold_add _ _ _ _ _)

--- a/src/data/mv_polynomial/rename.lean
+++ b/src/data/mv_polynomial/rename.lean
@@ -245,8 +245,8 @@ end coeff
 
 section support
 
-lemma support_rename_injective {p : mv_polynomial σ R} {f : σ → τ} (h : function.injective f) :
-  (rename f p).support = finset.map (map_domain_embedding_of_injective h) p.support :=
+lemma support_rename_of_injective {p : mv_polynomial σ R} {f : σ → τ} (h : function.injective f) :
+  (rename f p).support = finset.map (map_domain_embedding h) p.support :=
 begin
   rw finset.ext_iff,
   intro a,
@@ -255,10 +255,10 @@ begin
   intro h1,
   cases coeff_rename_ne_zero f p a h1 with d hd,
   use d,
-  simpa only [map_domain_embedding_of_injective, function.embedding.coe_fn_mk] using hd.symm,
+  simpa only [map_domain_embedding, function.embedding.coe_fn_mk] using hd.symm,
   intro h,
   cases h with b hb,
-  simpa only [← hb.2, map_domain_embedding_of_injective, function.embedding.coe_fn_mk,
+  simpa only [← hb.2, map_domain_embedding, function.embedding.coe_fn_mk,
               coeff_rename_map_domain f h p b] using hb.1,
 end
 

--- a/src/data/mv_polynomial/rename.lean
+++ b/src/data/mv_polynomial/rename.lean
@@ -246,7 +246,7 @@ end coeff
 section support
 
 lemma support_rename_of_injective {p : mv_polynomial σ R} {f : σ → τ} (h : function.injective f) :
-  (rename f p).support = finset.map (map_domain_embedding ⟨f,h⟩) p.support :=
+  (rename f p).support = finset.image (map_domain f) p.support :=
 begin
   rw finset.ext_iff,
   intro a,
@@ -254,9 +254,13 @@ begin
   apply iff.intro,
   intro h1,
   cases coeff_rename_ne_zero f p a h1 with d hd,
-  use d,
-  simpa only [map_domain_embedding, function.embedding.coe_fn_mk] using hd.symm,
+  rw ← hd.1,
+  simp only [map_domain_embedding, function.embedding.coe_fn_mk, exists_prop, mem_support_iff, finset.mem_image,
+  ne.def],
+  exact ⟨d, ⟨hd.2, by refl⟩⟩,
   intro h,
+  simp only [map_domain_embedding, exists_prop, mem_support_iff, function.embedding.coe_fn_mk, finset.mem_image,
+  ne.def] at h,
   cases h with b hb,
   simpa only [← hb.2, map_domain_embedding, function.embedding.coe_fn_mk,
               coeff_rename_map_domain f h p b] using hb.1,

--- a/src/data/mv_polynomial/rename.lean
+++ b/src/data/mv_polynomial/rename.lean
@@ -274,7 +274,7 @@ begin
     = λ x, (x.map_domain f).to_multiset,
   { ext,
     rw finsupp.to_multiset_map, },
-  simp only [degrees, multiset.sup_map h, h1, support_rename_injective h, finset.sup_map],
+  simp only [degrees, finset.sup_map_multiset h, h1, support_rename_injective h, finset.sup_map],
   congr,
 end
 

--- a/src/data/mv_polynomial/rename.lean
+++ b/src/data/mv_polynomial/rename.lean
@@ -252,13 +252,13 @@ begin
   intro a,
   simp only [exists_prop, mem_support_iff, finset.mem_image, ne.def],
   apply iff.intro,
-  intro h1,
-  cases coeff_rename_ne_zero f p a h1 with d hd,
-  rw ← hd.1,
-  exact ⟨d, ⟨hd.2, by refl⟩⟩,
-  intro h,
-  cases h with b hb,
-  simpa only [←hb.right, coeff_rename_map_domain f h p b] using hb.left,
+  { intro h1,
+    cases coeff_rename_ne_zero f p a h1 with d hd,
+    rw ← hd.1,
+    exact ⟨d, ⟨hd.2, by refl⟩⟩ },
+  { intro h,
+    cases h with b hb,
+    simpa only [←hb.right, coeff_rename_map_domain f h p b] using hb.left },
 end
 
 end support

--- a/src/data/mv_polynomial/rename.lean
+++ b/src/data/mv_polynomial/rename.lean
@@ -248,17 +248,8 @@ section support
 lemma support_rename_of_injective {p : mv_polynomial σ R} {f : σ → τ} (h : function.injective f) :
   (rename f p).support = finset.image (map_domain f) p.support :=
 begin
-  rw finset.ext_iff,
-  intro a,
-  simp only [exists_prop, mem_support_iff, finset.mem_image, ne.def],
-  split,
-  { intro h1,
-    cases coeff_rename_ne_zero f p a h1 with d hd,
-    rw ← hd.1,
-    exact ⟨d, ⟨hd.2, by refl⟩⟩ },
-  { intro h,
-    cases h with b hb,
-    simpa only [←hb.right, coeff_rename_map_domain f h p b] using hb.left },
+  rw rename_eq,
+  exact finsupp.map_domain_support_of_injective (map_domain_injective h) _,
 end
 
 end support

--- a/src/data/mv_polynomial/rename.lean
+++ b/src/data/mv_polynomial/rename.lean
@@ -250,20 +250,15 @@ lemma support_rename_of_injective {p : mv_polynomial σ R} {f : σ → τ} (h : 
 begin
   rw finset.ext_iff,
   intro a,
-  simp only [exists_prop, finset.mem_map, mem_support_iff, ne.def],
+  simp only [exists_prop, mem_support_iff, finset.mem_image, ne.def],
   apply iff.intro,
   intro h1,
   cases coeff_rename_ne_zero f p a h1 with d hd,
   rw ← hd.1,
-  simp only [map_domain_embedding, function.embedding.coe_fn_mk, exists_prop, mem_support_iff, finset.mem_image,
-  ne.def],
   exact ⟨d, ⟨hd.2, by refl⟩⟩,
   intro h,
-  simp only [map_domain_embedding, exists_prop, mem_support_iff, function.embedding.coe_fn_mk, finset.mem_image,
-  ne.def] at h,
   cases h with b hb,
-  simpa only [← hb.2, map_domain_embedding, function.embedding.coe_fn_mk,
-              coeff_rename_map_domain f h p b] using hb.1,
+  simpa only [←hb.right, coeff_rename_map_domain f h p b] using hb.left,
 end
 
 end support

--- a/src/data/mv_polynomial/rename.lean
+++ b/src/data/mv_polynomial/rename.lean
@@ -265,25 +265,4 @@ end
 
 end support
 
-section degree
-
-lemma rename_degrees_of_injective {R σ τ : Type*} [comm_semiring R] {p : mv_polynomial σ R}
-  {f : σ → τ} (h : function.injective f) : degrees (rename f p) = (degrees p).map f :=
-begin
-  have h1 : (λ (x : σ →₀ ℕ), multiset.map f (finsupp.to_multiset x))
-    = λ x, (x.map_domain f).to_multiset,
-  { ext,
-    rw finsupp.to_multiset_map, },
-  simp only [degrees, finset.sup_map_multiset _ _ (map_domain_embedding_of_injective h),
-             h1, support_rename_injective h, finset.sup_map],
-  congr,
-end
-
-lemma degree_of_rename_of_injective {R σ τ : Type*} [comm_semiring R] {p : mv_polynomial σ R}
-  {f : σ → τ} (h : function.injective f) (i : σ) : degree_of i p = degree_of (f i) (rename f p) :=
-by simp only [degree_of, rename_degrees_of_injective h,
-              multiset.count_map_eq_count' f (p.degrees) h]
-
-end degree
-
 end mv_polynomial

--- a/src/data/mv_polynomial/rename.lean
+++ b/src/data/mv_polynomial/rename.lean
@@ -246,8 +246,7 @@ end coeff
 section support
 
 lemma support_rename_injective {p : mv_polynomial σ R} {f : σ → τ} (h : function.injective f) :
-  ((rename f p).support : finset (τ →₀ ℕ)) =
-  finset.map (map_domain_embedding_of_injective h) p.support :=
+  (rename f p).support = finset.map (map_domain_embedding_of_injective h) p.support :=
 begin
   rw finset.ext_iff,
   intro a,

--- a/src/data/mv_polynomial/rename.lean
+++ b/src/data/mv_polynomial/rename.lean
@@ -279,8 +279,9 @@ begin
 end
 
 lemma degree_of_rename_of_injective {R σ τ : Type*} [comm_semiring R] {p : mv_polynomial σ R}
-{f : σ → τ} (h : function.injective f) (i : σ) : degree_of i p = degree_of (f i) (rename f p) :=
-by simp only [degree_of, rename_degrees_of_injective h, multiset.count_map_eq_count' f (p.degrees) h]
+  {f : σ → τ} (h : function.injective f) (i : σ) : degree_of i p = degree_of (f i) (rename f p) :=
+by simp only [degree_of, rename_degrees_of_injective h,
+              multiset.count_map_eq_count' f (p.degrees) h]
 
 end degree
 

--- a/src/data/mv_polynomial/rename.lean
+++ b/src/data/mv_polynomial/rename.lean
@@ -246,7 +246,7 @@ end coeff
 section support
 
 lemma support_rename_of_injective {p : mv_polynomial σ R} {f : σ → τ} (h : function.injective f) :
-  (rename f p).support = finset.map (map_domain_embedding h) p.support :=
+  (rename f p).support = finset.map (map_domain_embedding ⟨f,h⟩) p.support :=
 begin
   rw finset.ext_iff,
   intro a,

--- a/src/data/mv_polynomial/rename.lean
+++ b/src/data/mv_polynomial/rename.lean
@@ -274,7 +274,8 @@ begin
     = λ x, (x.map_domain f).to_multiset,
   { ext,
     rw finsupp.to_multiset_map, },
-  simp only [degrees, finset.sup_map_multiset h, h1, support_rename_injective h, finset.sup_map],
+  simp only [degrees, finset.sup_map_multiset _ _ (map_domain_embedding_of_injective h),
+             h1, support_rename_injective h, finset.sup_map],
   congr,
 end
 

--- a/src/data/mv_polynomial/rename.lean
+++ b/src/data/mv_polynomial/rename.lean
@@ -251,7 +251,7 @@ begin
   rw finset.ext_iff,
   intro a,
   simp only [exists_prop, mem_support_iff, finset.mem_image, ne.def],
-  apply iff.intro,
+  split,
   { intro h1,
     cases coeff_rename_ne_zero f p a h1 with d hd,
     rw ← hd.1,

--- a/src/data/mv_polynomial/rename.lean
+++ b/src/data/mv_polynomial/rename.lean
@@ -243,4 +243,45 @@ end
 
 end coeff
 
+section support
+
+lemma support_rename_injective {p : mv_polynomial σ R} {f : σ → τ} (h : function.injective f) :
+  ((rename f p).support : finset (τ →₀ ℕ)) =
+  finset.map (map_domain_embedding_of_injective h) p.support :=
+begin
+  rw finset.ext_iff,
+  intro a,
+  simp only [exists_prop, finset.mem_map, mem_support_iff, ne.def],
+  apply iff.intro,
+  intro h1,
+  cases coeff_rename_ne_zero f p a h1 with d hd,
+  use d,
+  simpa only [map_domain_embedding_of_injective, function.embedding.coe_fn_mk] using hd.symm,
+  intro h,
+  cases h with b hb,
+  simpa only [← hb.2, map_domain_embedding_of_injective, function.embedding.coe_fn_mk,
+              coeff_rename_map_domain f h p b] using hb.1,
+end
+
+end support
+
+section degree
+
+lemma rename_degrees_of_injective {R σ τ : Type*} [comm_semiring R] {p : mv_polynomial σ R}
+  {f : σ → τ} (h : function.injective f) : degrees (rename f p) = (degrees p).map f :=
+begin
+  have h1 : (λ (x : σ →₀ ℕ), multiset.map f (finsupp.to_multiset x))
+    = λ x, (x.map_domain f).to_multiset,
+  { ext,
+    rw finsupp.to_multiset_map, },
+  simp only [degrees, multiset.sup_map h, h1, support_rename_injective h, finset.sup_map],
+  congr,
+end
+
+lemma degree_of_rename_of_injective {R σ τ : Type*} [comm_semiring R] {p : mv_polynomial σ R}
+{f : σ → τ} (h : function.injective f) (i : σ) : degree_of i p = degree_of (f i) (rename f p) :=
+by simp only [degree_of, rename_degrees_of_injective h, multiset.count_map_eq_count' f (p.degrees) h]
+
+end degree
+
 end mv_polynomial

--- a/src/data/mv_polynomial/variables.lean
+++ b/src/data/mv_polynomial/variables.lean
@@ -224,16 +224,14 @@ lemma degrees_map_of_injective [comm_semiring S] (p : mv_polynomial σ R)
   {f : R →+* S} (hf : injective f) : (map f p).degrees = p.degrees :=
 by simp only [degrees, mv_polynomial.support_map_of_injective _ hf]
 
-lemma rename_degrees_of_injective {R σ τ : Type*} [comm_semiring R] {p : mv_polynomial σ R}
+lemma degrees_rename_of_injective {R σ τ : Type*} [comm_semiring R] {p : mv_polynomial σ R}
   {f : σ → τ} (h : function.injective f) : degrees (rename f p) = (degrees p).map f :=
 begin
   have t :=multiset.map_finset_sup p.support finsupp.to_multiset ⟨f,h⟩,
   simp only [embedding.coe_fn_mk] at t,
   simp only [degrees, t, support_rename_of_injective h, finset.sup_image],
-  congr,
-  ext,
-  congr,
-  simp only [comp_apply, finsupp.to_multiset_map],
+  refine finset.sup_congr rfl (λ x hx, _),
+  exact (finsupp.to_multiset_map _ _).symm,
 end
 
 end degrees
@@ -506,7 +504,7 @@ end
 
 lemma degree_of_rename_of_injective {R σ τ : Type*} [comm_semiring R] {p : mv_polynomial σ R}
   {f : σ → τ} (h : function.injective f) (i : σ) : degree_of (f i) (rename f p) = degree_of i p :=
-by simp only [degree_of, rename_degrees_of_injective h,
+by simp only [degree_of, degrees_rename_of_injective h,
               multiset.count_map_eq_count' f (p.degrees) h]
 
 end degree_of

--- a/src/data/mv_polynomial/variables.lean
+++ b/src/data/mv_polynomial/variables.lean
@@ -224,11 +224,10 @@ lemma degrees_map_of_injective [comm_semiring S] (p : mv_polynomial σ R)
   {f : R →+* S} (hf : injective f) : (map f p).degrees = p.degrees :=
 by simp only [degrees, mv_polynomial.support_map_of_injective _ hf]
 
-lemma degrees_rename_of_injective {p : mv_polynomial σ R}
-  {f : σ → τ} (h : function.injective f) : degrees (rename f p) = (degrees p).map f :=
+lemma degrees_rename_of_injective {p : mv_polynomial σ R} {f : σ → τ} (h : function.injective f) :
+  degrees (rename f p) = (degrees p).map f :=
 begin
   have t :=multiset.map_finset_sup p.support finsupp.to_multiset f h,
-  simp only [embedding.coe_fn_mk] at t,
   simp only [degrees, t, support_rename_of_injective h, finset.sup_image],
   refine finset.sup_congr rfl (λ x hx, _),
   exact (finsupp.to_multiset_map _ _).symm,

--- a/src/data/mv_polynomial/variables.lean
+++ b/src/data/mv_polynomial/variables.lean
@@ -227,10 +227,10 @@ by simp only [degrees, mv_polynomial.support_map_of_injective _ hf]
 lemma rename_degrees_of_injective {R σ τ : Type*} [comm_semiring R] {p : mv_polynomial σ R}
   {f : σ → τ} (h : function.injective f) : degrees (rename f p) = (degrees p).map f :=
 begin
-  have t :=finset.sup_map_multiset p.support finsupp.to_multiset ⟨f,h⟩,
+  have t :=finset.multiset_map_sup p.support finsupp.to_multiset ⟨f,h⟩,
   simp only [embedding.coe_fn_mk] at t,
-  simp only [degrees, t, support_rename_injective h, finset.sup_map,
-             map_domain_embedding_of_injective, embedding.coe_fn_mk, finsupp.to_multiset_map],
+  simp only [degrees, t, support_rename_of_injective h, finset.sup_map,
+             map_domain_embedding, embedding.coe_fn_mk, finsupp.to_multiset_map],
   congr,
   ext,
   congr,
@@ -506,7 +506,7 @@ begin
 end
 
 lemma degree_of_rename_of_injective {R σ τ : Type*} [comm_semiring R] {p : mv_polynomial σ R}
-  {f : σ → τ} (h : function.injective f) (i : σ) : degree_of i p = degree_of (f i) (rename f p) :=
+  {f : σ → τ} (h : function.injective f) (i : σ) : degree_of (f i) (rename f p) = degree_of i p :=
 by simp only [degree_of, rename_degrees_of_injective h,
               multiset.count_map_eq_count' f (p.degrees) h]
 

--- a/src/data/mv_polynomial/variables.lean
+++ b/src/data/mv_polynomial/variables.lean
@@ -224,10 +224,10 @@ lemma degrees_map_of_injective [comm_semiring S] (p : mv_polynomial σ R)
   {f : R →+* S} (hf : injective f) : (map f p).degrees = p.degrees :=
 by simp only [degrees, mv_polynomial.support_map_of_injective _ hf]
 
-lemma degrees_rename_of_injective {R σ τ : Type*} [comm_semiring R] {p : mv_polynomial σ R}
+lemma degrees_rename_of_injective {p : mv_polynomial σ R}
   {f : σ → τ} (h : function.injective f) : degrees (rename f p) = (degrees p).map f :=
 begin
-  have t :=multiset.map_finset_sup p.support finsupp.to_multiset ⟨f,h⟩,
+  have t :=multiset.map_finset_sup p.support finsupp.to_multiset f h,
   simp only [embedding.coe_fn_mk] at t,
   simp only [degrees, t, support_rename_of_injective h, finset.sup_image],
   refine finset.sup_congr rfl (λ x hx, _),

--- a/src/data/mv_polynomial/variables.lean
+++ b/src/data/mv_polynomial/variables.lean
@@ -224,6 +224,34 @@ lemma degrees_map_of_injective [comm_semiring S] (p : mv_polynomial σ R)
   {f : R →+* S} (hf : injective f) : (map f p).degrees = p.degrees :=
 by simp only [degrees, mv_polynomial.support_map_of_injective _ hf]
 
+lemma sup_map_multiset {α β γ: Type*} [semilattice_sup α] [has_bot α] [decidable_eq α]
+ [decidable_eq β] (s : finset γ) (f : γ → multiset β) (g : β ↪ α) :
+   multiset.map g (s.sup f) = s.sup (multiset.map g ∘ f) :=
+begin
+  apply finset.cons_induction_on s,
+  simp,
+  intros a s' h_a_s h_ind,
+  simp only [finset.sup_cons, ←h_ind, multiset.sup_eq_union, function.comp_app],
+  rw multiset.map_union,
+  exact g.inj',
+end
+
+local attribute [instance] classical.prop_decidable-- todo remove this
+
+lemma rename_degrees_of_injective {R σ τ : Type*} [comm_semiring R] {p : mv_polynomial σ R}
+  {f : σ → τ} (h : function.injective f) : degrees (rename f p) = (degrees p).map f :=
+begin
+  have h1 : (λ (x : σ →₀ ℕ), multiset.map f (finsupp.to_multiset x))
+    = λ x, (x.map_domain f).to_multiset,
+  { ext,
+    rw finsupp.to_multiset_map, },
+  simp only [degrees],
+  have t :=finset.sup_map_multiset p.support finsupp.to_multiset ⟨f,h⟩,
+  squeeze_simp at t,
+  simp only [t, h1, support_rename_injective h, finset.sup_map],
+  congr,
+end
+
 end degrees
 
 section vars
@@ -491,6 +519,11 @@ begin
   convert multiset.count_le_of_le j (degrees_X' j),
   rw multiset.count_singleton_self,
 end
+
+lemma degree_of_rename_of_injective {R σ τ : Type*} [comm_semiring R] {p : mv_polynomial σ R}
+  {f : σ → τ} (h : function.injective f) (i : σ) : degree_of i p = degree_of (f i) (rename f p) :=
+by simp only [degree_of, rename_degrees_of_injective h,
+              multiset.count_map_eq_count' f (p.degrees) h]
 
 end degree_of
 

--- a/src/data/mv_polynomial/variables.lean
+++ b/src/data/mv_polynomial/variables.lean
@@ -224,18 +224,6 @@ lemma degrees_map_of_injective [comm_semiring S] (p : mv_polynomial σ R)
   {f : R →+* S} (hf : injective f) : (map f p).degrees = p.degrees :=
 by simp only [degrees, mv_polynomial.support_map_of_injective _ hf]
 
-lemma sup_map_multiset {α β γ: Type*} [semilattice_sup α] [has_bot α] [decidable_eq α]
- [decidable_eq β] (s : finset γ) (f : γ → multiset β) (g : β ↪ α) :
-   multiset.map g (s.sup f) = s.sup (multiset.map g ∘ f) :=
-begin
-  apply finset.cons_induction_on s,
-  simp,
-  intros a s' h_a_s h_ind,
-  simp only [finset.sup_cons, ←h_ind, multiset.sup_eq_union, function.comp_app],
-  rw multiset.map_union,
-  exact g.inj',
-end
-
 local attribute [instance] classical.prop_decidable-- todo remove this
 
 lemma rename_degrees_of_injective {R σ τ : Type*} [comm_semiring R] {p : mv_polynomial σ R}

--- a/src/data/mv_polynomial/variables.lean
+++ b/src/data/mv_polynomial/variables.lean
@@ -501,8 +501,8 @@ begin
   rw multiset.count_singleton_self,
 end
 
-lemma degree_of_rename_of_injective {R σ τ : Type*} [comm_semiring R] {p : mv_polynomial σ R}
-  {f : σ → τ} (h : function.injective f) (i : σ) : degree_of (f i) (rename f p) = degree_of i p :=
+lemma degree_of_rename_of_injective {p : mv_polynomial σ R} {f : σ → τ} (h : function.injective f)
+  (i : σ) : degree_of (f i) (rename f p) = degree_of i p :=
 by simp only [degree_of, degrees_rename_of_injective h,
               multiset.count_map_eq_count' f (p.degrees) h]
 

--- a/src/data/mv_polynomial/variables.lean
+++ b/src/data/mv_polynomial/variables.lean
@@ -227,8 +227,8 @@ by simp only [degrees, mv_polynomial.support_map_of_injective _ hf]
 lemma degrees_rename_of_injective {p : mv_polynomial σ R} {f : σ → τ} (h : function.injective f) :
   degrees (rename f p) = (degrees p).map f :=
 begin
-  have t :=multiset.map_finset_sup p.support finsupp.to_multiset f h,
-  simp only [degrees, t, support_rename_of_injective h, finset.sup_image],
+  simp only [degrees, multiset.map_finset_sup p.support finsupp.to_multiset f h,
+             support_rename_of_injective h, finset.sup_image],
   refine finset.sup_congr rfl (λ x hx, _),
   exact (finsupp.to_multiset_map _ _).symm,
 end

--- a/src/data/mv_polynomial/variables.lean
+++ b/src/data/mv_polynomial/variables.lean
@@ -224,20 +224,17 @@ lemma degrees_map_of_injective [comm_semiring S] (p : mv_polynomial σ R)
   {f : R →+* S} (hf : injective f) : (map f p).degrees = p.degrees :=
 by simp only [degrees, mv_polynomial.support_map_of_injective _ hf]
 
-local attribute [instance] classical.prop_decidable-- todo remove this
-
 lemma rename_degrees_of_injective {R σ τ : Type*} [comm_semiring R] {p : mv_polynomial σ R}
   {f : σ → τ} (h : function.injective f) : degrees (rename f p) = (degrees p).map f :=
 begin
-  have h1 : (λ (x : σ →₀ ℕ), multiset.map f (finsupp.to_multiset x))
-    = λ x, (x.map_domain f).to_multiset,
-  { ext,
-    rw finsupp.to_multiset_map, },
-  simp only [degrees],
   have t :=finset.sup_map_multiset p.support finsupp.to_multiset ⟨f,h⟩,
-  squeeze_simp at t,
-  simp only [t, h1, support_rename_injective h, finset.sup_map],
+  simp only [embedding.coe_fn_mk] at t,
+  simp only [degrees, t, support_rename_injective h, finset.sup_map,
+             map_domain_embedding_of_injective, embedding.coe_fn_mk, finsupp.to_multiset_map],
   congr,
+  ext,
+  congr,
+  simp only [comp_apply, finsupp.to_multiset_map],
 end
 
 end degrees

--- a/src/data/mv_polynomial/variables.lean
+++ b/src/data/mv_polynomial/variables.lean
@@ -227,7 +227,7 @@ by simp only [degrees, mv_polynomial.support_map_of_injective _ hf]
 lemma rename_degrees_of_injective {R σ τ : Type*} [comm_semiring R] {p : mv_polynomial σ R}
   {f : σ → τ} (h : function.injective f) : degrees (rename f p) = (degrees p).map f :=
 begin
-  have t :=finset.multiset_map_sup p.support finsupp.to_multiset ⟨f,h⟩,
+  have t :=multiset.map_finset_sup p.support finsupp.to_multiset ⟨f,h⟩,
   simp only [embedding.coe_fn_mk] at t,
   simp only [degrees, t, support_rename_of_injective h, finset.sup_map,
              map_domain_embedding, embedding.coe_fn_mk, finsupp.to_multiset_map],

--- a/src/data/mv_polynomial/variables.lean
+++ b/src/data/mv_polynomial/variables.lean
@@ -229,8 +229,7 @@ lemma rename_degrees_of_injective {R σ τ : Type*} [comm_semiring R] {p : mv_po
 begin
   have t :=multiset.map_finset_sup p.support finsupp.to_multiset ⟨f,h⟩,
   simp only [embedding.coe_fn_mk] at t,
-  simp only [degrees, t, support_rename_of_injective h, finset.sup_map,
-             map_domain_embedding, embedding.coe_fn_mk, finsupp.to_multiset_map],
+  simp only [degrees, t, support_rename_of_injective h, finset.sup_image],
   congr,
   ext,
   congr,


### PR DESCRIPTION
Relation between `rename` and `support`, `degrees` and `degree_of` when `f : σ → τ` is injective.

- I'm not sure if we already have something like `sup_map_multiset`.
- I've stated `sup_map_multiset`using `embedding` but I've used `injective` elsewhere because `mv_polynomial.rename` is written using `injective`.
-  I'm not sure if we should have `map_domain_embedding_of_injective`.
 
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
