### PR TITLE
[Merged by Bors] - chore(algebra/big_operators/finprod): Eliminate `finish`

### DIFF
--- a/src/algebra/big_operators/finprod.lean
+++ b/src/algebra/big_operators/finprod.lean
@@ -876,13 +876,10 @@ iterating this lemma, e.g., if we have `f : α × β × γ → M`. -/
 begin
   have : ∀ a, ∏ (i : β) in (s.filter (λ ab, prod.fst ab = a)).image prod.snd, f (a, i) =
     (finset.filter (λ ab, prod.fst ab = a) s).prod f,
-  { intros a, apply finset.prod_bij (λ b _, (a, b)), -- `finish` could close the goals here
-  { suffices : ∀ (a_1 : α) (b : β), (a_1, b) ∈ s → a_1 = a → (a, b) ∈ s ∧ a_1 = a, { simp },
-    intros a' b p ha, rw ←ha, use p },
-  { simp },
-  { simp },
-  { suffices : ∀ (a_1 : α) (b : β), (a_1, b) ∈ s → a_1 = a → (a, b) ∈ s ∧ a_1 = a, { simpa },
-    intros a' b p ha, rw ←ha, use p } },
+  { refine (λ a, finset.prod_bij (λ b _, (a, b)) _ _ _ _); -- `finish` closes this goal
+    try { simp },
+    intros a' b hp ha,
+    simp [←ha, hp] },
   rw finprod_mem_finset_eq_prod,
   simp_rw [finprod_mem_finset_eq_prod, this],
   rw [finprod_eq_prod_of_mul_support_subset _

--- a/src/algebra/big_operators/finprod.lean
+++ b/src/algebra/big_operators/finprod.lean
@@ -876,10 +876,11 @@ iterating this lemma, e.g., if we have `f : α × β × γ → M`. -/
 begin
   have : ∀ a, ∏ (i : β) in (s.filter (λ ab, prod.fst ab = a)).image prod.snd, f (a, i) =
     (finset.filter (λ ab, prod.fst ab = a) s).prod f,
-  { refine (λ a, finset.prod_bij (λ b _, (a, b)) _ _ _ _); -- `finish` closes this goal
-    try { simp },
-    intros a' b hp ha,
-    simp [←ha, hp] },
+  { refine (λ a, finset.prod_bij (λ b _, (a, b)) _ _ _ _); -- `finish` closes these goals
+    try { simp, done },
+    suffices : ∀ a' b, (a', b) ∈ s → a' = a → (a, b) ∈ s ∧ a' = a, by simpa,
+    rintros a' b hp rfl,
+    exact ⟨hp, rfl⟩ },
   rw finprod_mem_finset_eq_prod,
   simp_rw [finprod_mem_finset_eq_prod, this],
   rw [finprod_eq_prod_of_mul_support_subset _

--- a/src/algebra/big_operators/finprod.lean
+++ b/src/algebra/big_operators/finprod.lean
@@ -888,11 +888,8 @@ begin
   rw [finprod_eq_prod_of_mul_support_subset _
     (s.mul_support_of_fiberwise_prod_subset_image f prod.fst),
     ← finset.prod_fiberwise_of_maps_to _ f],  -- `finish` could close the goal here
-  intros x hx,
-  simp only [exists_eq_right, finset.mem_image, prod.exists],
-  use [x.1, x.2],
-  simp only [prod.mk.eta, and_true, eq_self_iff_true],
-  exact hx,
+  simp only [finset.mem_image, prod.mk.eta],
+  exact λ x hx, ⟨x, hx, rfl⟩,
 end
 
 /-- See also `finprod_mem_finset_product'`. -/

--- a/src/algebra/big_operators/finprod.lean
+++ b/src/algebra/big_operators/finprod.lean
@@ -876,12 +876,13 @@ iterating this lemma, e.g., if we have `f : α × β × γ → M`. -/
 begin
   have : ∀ a, ∏ (i : β) in (s.filter (λ ab, prod.fst ab = a)).image prod.snd, f (a, i) =
     (finset.filter (λ ab, prod.fst ab = a) s).prod f,
-  { intros a, apply finset.prod_bij (λ b _, (a, b));
-  simp,
-  intros a' b p ha, rw ←ha,
-  use p,
-  -- finish,
-  },
+  { intros a, apply finset.prod_bij (λ b _, (a, b)),
+  { suffices : ∀ (a_1 : α) (b : β), (a_1, b) ∈ s → a_1 = a → (a, b) ∈ s ∧ a_1 = a, { simp },
+    intros a' b p ha, rw ←ha, use p },
+  { simp },
+  { simp },
+  { suffices : ∀ (a_1 : α) (b : β), (a_1, b) ∈ s → a_1 = a → (a, b) ∈ s ∧ a_1 = a, { simpa },
+    intros a' b p ha, rw ←ha, use p } },
   rw finprod_mem_finset_eq_prod,
   simp_rw [finprod_mem_finset_eq_prod, this],
   rw [finprod_eq_prod_of_mul_support_subset _

--- a/src/algebra/big_operators/finprod.lean
+++ b/src/algebra/big_operators/finprod.lean
@@ -876,7 +876,7 @@ iterating this lemma, e.g., if we have `f : α × β × γ → M`. -/
 begin
   have : ∀ a, ∏ (i : β) in (s.filter (λ ab, prod.fst ab = a)).image prod.snd, f (a, i) =
     (finset.filter (λ ab, prod.fst ab = a) s).prod f,
-  { intros a, apply finset.prod_bij (λ b _, (a, b)),
+  { intros a, apply finset.prod_bij (λ b _, (a, b)), -- `finish` could close the goals here
   { suffices : ∀ (a_1 : α) (b : β), (a_1, b) ∈ s → a_1 = a → (a, b) ∈ s ∧ a_1 = a, { simp },
     intros a' b p ha, rw ←ha, use p },
   { simp },
@@ -887,7 +887,7 @@ begin
   simp_rw [finprod_mem_finset_eq_prod, this],
   rw [finprod_eq_prod_of_mul_support_subset _
     (s.mul_support_of_fiberwise_prod_subset_image f prod.fst),
-    ← finset.prod_fiberwise_of_maps_to _ f],
+    ← finset.prod_fiberwise_of_maps_to _ f],  -- `finish` could close the goal here
   intros x hx,
   simp only [exists_eq_right, finset.mem_image, prod.exists],
   use [x.1, x.2],

--- a/src/algebra/big_operators/finprod.lean
+++ b/src/algebra/big_operators/finprod.lean
@@ -887,10 +887,11 @@ begin
   rw [finprod_eq_prod_of_mul_support_subset _
     (s.mul_support_of_fiberwise_prod_subset_image f prod.fst),
     ← finset.prod_fiberwise_of_maps_to _ f],
-  simp,
-  intros a b p,
-  use [b,p],
-  -- finish,
+  intros x hx,
+  simp only [exists_eq_right, finset.mem_image, prod.exists],
+  use [x.1, x.2],
+  simp only [prod.mk.eta, and_true, eq_self_iff_true],
+  exact hx,
 end
 
 /-- See also `finprod_mem_finset_product'`. -/

--- a/src/algebra/big_operators/finprod.lean
+++ b/src/algebra/big_operators/finprod.lean
@@ -876,13 +876,21 @@ iterating this lemma, e.g., if we have `f : α × β × γ → M`. -/
 begin
   have : ∀ a, ∏ (i : β) in (s.filter (λ ab, prod.fst ab = a)).image prod.snd, f (a, i) =
     (finset.filter (λ ab, prod.fst ab = a) s).prod f,
-  { intros a, apply finset.prod_bij (λ b _, (a, b)); finish, },
+  { intros a, apply finset.prod_bij (λ b _, (a, b));
+  simp,
+  intros a' b p ha, rw ←ha,
+  use p,
+  -- finish,
+  },
   rw finprod_mem_finset_eq_prod,
   simp_rw [finprod_mem_finset_eq_prod, this],
   rw [finprod_eq_prod_of_mul_support_subset _
     (s.mul_support_of_fiberwise_prod_subset_image f prod.fst),
     ← finset.prod_fiberwise_of_maps_to _ f],
-  finish,
+  simp,
+  intros a b p,
+  use [b,p],
+  -- finish,
 end
 
 /-- See also `finprod_mem_finset_product'`. -/


### PR DESCRIPTION
Removing uses of finish, as discussed in this Zulip thread (https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/mathlib.20sat.20solvers)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
