### PR TITLE
[Merged by Bors] - feat(algebraic_topology): alternating face map complex of a simplicial object

### DIFF
--- a/src/algebraic_topology/alternating_face_map_complex.lean
+++ b/src/algebraic_topology/alternating_face_map_complex.lean
@@ -51,8 +51,7 @@ namespace alternating_face_map_complex
 /-- In degree n, the alternating face map complex is given by
 the nth-object of the simplicial object -/
 @[simp]
-def obj_X {C : Type*} [category C] (X : simplicial_object C) (n : ℕ) :=
-X.obj (op [n])
+def obj_X {C : Type*} [category C] (X : simplicial_object C) (n : ℕ) := X _[n]
 
 variables {C : Type*} [category C] [preadditive C]
 variables (X : simplicial_object C)
@@ -61,7 +60,7 @@ variables (Y : simplicial_object C)
 /-- The differential on the alternating face map complex is the alternate
 sum of the face maps -/
 @[simp]
-def obj_d (n : ℕ) : obj_X X (n+1) ⟶ obj_X X n :=
+def obj_d (n : ℕ) : X _[n+1] ⟶ X _[n] :=
 ∑ (i : fin (n+2)), (-1 : ℤ)^(i : ℕ) • X.δ i
 
 /--

--- a/src/algebraic_topology/alternating_face_map_complex.lean
+++ b/src/algebraic_topology/alternating_face_map_complex.lean
@@ -36,16 +36,18 @@ open opposite
 open_locale big_operators
 
 noncomputable theory
-namespace algebraic_topology
 
-variables {C : Type*} [category C] [preadditive C]
-variables (X : simplicial_object C)
-variables (Y : simplicial_object C)
+namespace algebraic_topology
 
 namespace alternating_face_map_complex
 
 @[simp]
-def obj_X (n : ℕ) := X.obj(op(simplex_category.mk n))
+def obj_X {C : Type*} [category C] (X : simplicial_object C) (n : ℕ) :=
+X.obj(op(simplex_category.mk n))
+
+variables {C : Type*} [category C] [preadditive C]
+variables (X : simplicial_object C)
+variables (Y : simplicial_object C)
 
 @[simp]
 def obj_d (n : ℕ) : (obj_X X (n+1)) ⟶ (obj_X X n) :=
@@ -135,12 +137,6 @@ end
 def indices (n : ℕ) : finset (ℕ × ℕ) := 
 finset.product (finset.range(n+1)) (finset.range(n+2))
 
-def τ' {n : ℕ} : Π (x : ℕ × ℕ), x ∈ indices n → ℕ × ℕ := 
-λ x hx, τ x
-
-@[simp] lemma τ'_eq_τ {n : ℕ} (x : ℕ × ℕ) (hx : x ∈ indices n) :
-τ' x hx = τ x := by refl
-
 /-- τ stabilises {0,...,n} × {0,...,n+1} -/
 lemma τ'_mem' {n : ℕ} (x : ℕ × ℕ) (hx : x ∈ indices n) : τ x ∈ indices n :=
 begin
@@ -156,18 +152,6 @@ begin
     simp only [indices, finset.mem_product, finset.mem_range],
     split; linarith, }
 end
-
-lemma τ'_mem {n : ℕ} (x : ℕ × ℕ) (hx : x ∈ indices n) : τ' x hx ∈ indices n :=
-by { rw τ'_eq_τ, exact τ'_mem' x hx, }
-
-/-- τ' has no fixed point -/
-lemma τ'_ne' {n : ℕ} (x : ℕ × ℕ) (hx : x ∈ indices n) : τ' x hx ≠ x :=
-by { rw τ'_eq_τ, exact τ_ne' x, }
-
-/-! τ' is an involution. -/
-lemma τ'_inv {n : ℕ} (x : ℕ × ℕ) (hx : x ∈ indices n) :
-  τ' (τ' x hx) (τ'_mem x hx) = x :=
-by { simp only [τ'_eq_τ], exact τ_inv x, }
 
 /-!
 ### Cancellation of "antisymmetric" sums indexed by {0,...,n} × {0,...,n+1}
@@ -196,13 +180,16 @@ begin
     have eq := hf_case2 (τ x) (τ_of_case1_is_case2 x h1x) (τ'_mem' x hx),
     rw τ_inv x at eq,
     exact eq, },
+  let τ' : ∀ (x : ℕ × ℕ), x ∈ indices n → ℕ × ℕ := λ x hx, τ x,
+  have τ'_eq_τ : ∀ (x : ℕ × ℕ) (hx : x ∈ indices n), τ' x hx = τ x := by { intros x hx, refl, },
   have hf : ∀ (x : ℕ × ℕ) (hx : x ∈ indices n), f x + f (τ' x hx) = 0,
   { intros x hx,
-    rw τ'_eq_τ,
+    rw τ'_eq_τ x hx,
     by_cases x.1<x.2,
     { exact hf_case1 x h hx, },
     { exact hf_case2 x h hx, }, },
-  exact finset.sum_involution τ' hf (λ x hx _, τ'_ne' x hx) τ'_mem τ'_inv,
+  exact finset.sum_involution τ' hf (λ x _ _, τ_ne' x)
+    τ'_mem' (λ x _, τ_inv x),
 end
 
 
@@ -289,7 +276,7 @@ chain_complex.of_hom _ _ _ _ _ _
 
 end alternating_face_map_complex
 
-variables (C)
+variables (C : Type*) [category C] [preadditive C]
 
 @[simps]
 def alternating_face_map_complex : simplicial_object C ⥤ chain_complex C ℕ :=
@@ -364,3 +351,4 @@ def inclusion_of_Moore_complex :
 { app := inclusion_of_Moore_complex_map, }
 
 end algebraic_topology
+

--- a/src/algebraic_topology/alternating_face_map_complex.lean
+++ b/src/algebraic_topology/alternating_face_map_complex.lean
@@ -15,14 +15,14 @@ import tactic.ring_exp
 
 # The alternating face map complex of a simplicial object in a preadditive category
 
-We construct the alternating face map complex, as a 
+We construct the alternating face map complex, as a
 functor `alternating_face_map_complex : simplicial_object C ⥤ chain_complex C ℕ`
 for any preadditive category `C`. For any simplicial object `X` in `C`,
 this is the homological complex `... → X_2 → X_1 → X_0`
 where the differentials are alternate sums of faces.
 
 We also construct the natural transformation `inclusion_of_Moore_complex :
-nat_trans (normalized_Moore_complex A) (alternating_face_map_complex A)` 
+nat_trans (normalized_Moore_complex A) (alternating_face_map_complex A)`
 when `A` is an abelian category
 
 ## References
@@ -41,6 +41,8 @@ namespace algebraic_topology
 
 namespace alternating_face_map_complex
 
+/-- In degree n, the alternating face map complex is given by
+the nth-object of the simplicial object -/
 @[simp]
 def obj_X {C : Type*} [category C] (X : simplicial_object C) (n : ℕ) :=
 X.obj(op(simplex_category.mk n))
@@ -49,12 +51,14 @@ variables {C : Type*} [category C] [preadditive C]
 variables (X : simplicial_object C)
 variables (Y : simplicial_object C)
 
+/-- The differential on the alternating face map complex is the alternate
+sum of the face maps -/
 @[simp]
 def obj_d (n : ℕ) : (obj_X X (n+1)) ⟶ (obj_X X n) :=
 ∑ i in finset.range(n+2), ((-1 : ℤ)^i • X.δ i)
 
 /-!
-## Proof of the chain complex relation `d ≫ d` 
+## Proof of the chain complex relation `d ≫ d`
 
 The expansion of `d ≫ d` involves a double sum, or a sum of terms
 indexed by a set of the form {0,...,n} × {0,...,n+1}. We shall show
@@ -117,7 +121,7 @@ begin
   have case1 : ∀ (y : ℕ × ℕ), y.1<y.2 → τ y ≠ y,
   { intros y hy h1,
     rw τ_case1 y hy at h1,
-    have h2 := congr_arg prod.snd h1, 
+    have h2 := congr_arg prod.snd h1,
     simp only at h2,
     linarith, },
   have case2 : ∀ (y : ℕ × ℕ), ¬y.1<y.2 → τ y ≠ y,
@@ -130,11 +134,10 @@ end
 
 /-!
 ### Verification that τ induces an involution τ' on {0,...,n} × {0,...,n+1}
-
-`indices n` denotes `{0,...,n} × {0,...,n+1}` as a finite subset of `ℕ × ℕ`
 -/
 
-def indices (n : ℕ) : finset (ℕ × ℕ) := 
+/-- `indices n` denotes `{0,...,n} × {0,...,n+1}` as a finite subset of `ℕ × ℕ` -/
+def indices (n : ℕ) : finset (ℕ × ℕ) :=
 finset.product (finset.range(n+1)) (finset.range(n+2))
 
 /-- τ stabilises {0,...,n} × {0,...,n+1} -/
@@ -166,14 +169,14 @@ lemma antisymmetric_sum_cancels [add_comm_group α] {n : ℕ} (f : ℕ × ℕ �
   (antisymmetry_f : ∀ (i j : ℕ), i≤j → j≤n → f (i,j+1) = - f (j,i)) :
   ∑ x in (indices n), f x = 0 :=
 begin
-  have hf_case2 : ∀ (x : ℕ × ℕ) (h2x : ¬x.1<x.2) 
+  have hf_case2 : ∀ (x : ℕ × ℕ) (h2x : ¬x.1<x.2)
     (hx : x ∈ indices n), f x + f (τ x) = 0,
   { intros x h2x hx,
     rw τ_case2 x h2x,
     simp only [indices, finset.mem_product, finset.mem_range] at hx,
     rw antisymmetry_f x.2 x.1 (by linarith) (by linarith),
     simp only [prod.mk.eta, add_right_neg], },
-  have hf_case1 : ∀ (x : ℕ × ℕ) (h1x : x.1<x.2) 
+  have hf_case1 : ∀ (x : ℕ × ℕ) (h1x : x.1<x.2)
     (hx : x ∈ indices n), f x + f (τ x) = 0,
   { intros x h1x hx,
     rw add_comm,
@@ -197,13 +200,14 @@ end
 ### Antisymmetry property for the terms that appear in the expansion of `d ≫ d`
 -/
 
-def di_dj (n : ℕ) (x : ℕ × ℕ) : (obj_X X (n+2)) ⟶ (obj_X X n) :=
+/-- εdi_dj n (i,j) is the composite `(-1)^j d_j ≫ (-1)^i d_i` -/
+def εdi_dj (n : ℕ) (x : ℕ × ℕ) : (obj_X X (n+2)) ⟶ (obj_X X n) :=
 ((-1 : ℤ)^x.2 • X.δ x.2) ≫ ((-1 : ℤ)^x.1 • X.δ x.1)
 
-lemma di_dj_antisymm (n i j : ℕ) (hij : i≤j) (hjn : j≤n+1) :
-  (di_dj X n (i,j+1)) = - di_dj X n (j,i) :=
+lemma εdi_dj_antisymm (n i j : ℕ) (hij : i≤j) (hjn : j≤n+1) :
+  (εdi_dj X n (i,j+1)) = - εdi_dj X n (j,i) :=
 begin
-  repeat { rw di_dj },
+  repeat { rw εdi_dj },
   simp only,
   repeat { rw category_theory.preadditive.comp_zsmul },
   repeat { rw category_theory.preadditive.zsmul_comp },
@@ -242,21 +246,23 @@ begin
   let d_l := (λ (j:ℕ), (-1 : ℤ)^j • X.δ (j : fin(n+3))),
   let d_r := (λ (i:ℕ), (-1 : ℤ)^i • X.δ (i : fin(n+2))),
   rw [show (λ i, (∑ j in finset.range(n+3), d_l j) ≫ d_r i) =
-    (λ i, ∑ j in finset.range(n+3), di_dj X n (i,j)),
+    (λ i, ∑ j in finset.range(n+3), εdi_dj X n (i,j)),
     by { ext, rw preadditive.sum_comp, refl }],
   rw ← finset.sum_product',
   clear d_l d_r,
-  exact antisymmetric_sum_cancels (di_dj X n) (di_dj_antisymm X n),
+  exact antisymmetric_sum_cancels (εdi_dj X n) (εdi_dj_antisymm X n),
 end
 
 /-!
 ## Construction of the alternating face map complex functor
 -/
 
+/-- The alternating face map complex, on objects -/
 def obj : chain_complex C ℕ := chain_complex.of (obj_X X) (obj_d X) (d_squared X)
 
 variables {X} {Y}
 
+/-- The alternating face map complex, on morphisms -/
 @[simp]
 def map (f : X ⟶ Y) : obj X ⟶ obj Y :=
 chain_complex.of_hom _ _ _ _ _ _
@@ -278,6 +284,7 @@ end alternating_face_map_complex
 
 variables (C : Type*) [category C] [preadditive C]
 
+/-- The alternating face map complex, as a functor -/
 @[simps]
 def alternating_face_map_complex : simplicial_object C ⥤ chain_complex C ℕ :=
 { obj := alternating_face_map_complex.obj,
@@ -288,9 +295,11 @@ def alternating_face_map_complex : simplicial_object C ⥤ chain_complex C ℕ :
 -/
 
 variables {A : Type*} [category A] [abelian A]
-def inclusion_of_Moore_complex_map (X : simplicial_object A) :  
+
+/-- The inclusion map of the Moore complex in the alternating face map complex -/
+def inclusion_of_Moore_complex_map (X : simplicial_object A) :
   (normalized_Moore_complex A).obj X ⟶ (alternating_face_map_complex A).obj X :=
-chain_complex.of_hom _ _ _ _ _ _ 
+chain_complex.of_hom _ _ _ _ _ _
   (λ n, (normalized_Moore_complex.obj_X X n).arrow)
   (λ n,
     begin
@@ -345,6 +354,8 @@ chain_complex.of_hom_f _ _ _ _ _ _ _ _ n
 
 variables (A)
 
+/-- The inclusion map of the Moore complex in the alternating face map complex,
+as a natural transformation -/
 @[simps]
 def inclusion_of_Moore_complex :
   nat_trans (normalized_Moore_complex A) (alternating_face_map_complex A) :=

--- a/src/algebraic_topology/alternating_face_map_complex.lean
+++ b/src/algebraic_topology/alternating_face_map_complex.lean
@@ -65,7 +65,7 @@ def obj_d (n : ℕ) : X _[n+1] ⟶ X _[n] :=
 lemma d_squared (n : ℕ) : obj_d X (n+1) ≫ obj_d X n = 0 :=
 begin
   /- we start by expanding d ≫ d as a double sum -/
-  repeat { rw obj_d },
+  dsimp,
   rw comp_sum,
   let d_l := λ (j : fin (n+3)), (-1 : ℤ)^(j : ℕ) • X.δ j,
   let d_r := λ (i : fin (n+2)), (-1 : ℤ)^(i : ℕ) • X.δ i,

--- a/src/algebraic_topology/alternating_face_map_complex.lean
+++ b/src/algebraic_topology/alternating_face_map_complex.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2021 Joël Riou. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Author: Joël Riou
+Authors: Joël Riou
 -/
 
 import algebra.homology.homological_complex
@@ -21,8 +21,8 @@ for any preadditive category `C`. For any simplicial object `X` in `C`,
 this is the homological complex `... → X_2 → X_1 → X_0`
 where the differentials are alternate sums of faces.
 
-We also construct the natural transformation 
-`inclusion_of_Moore_complex : nat_trans (normalized_Moore_complex A) (alternating_face_map_complex A)` 
+We also construct the natural transformation `inclusion_of_Moore_complex :
+nat_trans (normalized_Moore_complex A) (alternating_face_map_complex A)` 
 when `A` is an abelian category
 
 ## References
@@ -298,7 +298,7 @@ def alternating_face_map_complex : simplicial_object C ⥤ chain_complex C ℕ :
   map := λ X Y f, alternating_face_map_complex.map f }
 
 /-!
-## Construction of the natural inclusion of the normalized Moore complex into the alternating face map complex
+## Construction of the natural inclusion of the normalized Moore complex
 -/
 
 variables {A : Type*} [category A] [abelian A]

--- a/src/algebraic_topology/alternating_face_map_complex.lean
+++ b/src/algebraic_topology/alternating_face_map_complex.lean
@@ -33,6 +33,7 @@ when `A` is an abelian category.
 -/
 
 open category_theory category_theory.limits category_theory.subobject
+open category_theory.preadditive
 open opposite
 
 open_locale big_operators
@@ -47,11 +48,6 @@ namespace alternating_face_map_complex
 /-!
 ## Construction of the alternating face map complex
 -/
-
-/-- In degree n, the alternating face map complex is given by
-the nth-object of the simplicial object -/
-@[simp]
-def obj_X {C : Type*} [category C] (X : simplicial_object C) (n : ℕ) := X _[n]
 
 variables {C : Type*} [category C] [preadditive C]
 variables (X : simplicial_object C)
@@ -70,13 +66,13 @@ lemma d_squared (n : ℕ) : obj_d X (n+1) ≫ obj_d X n = 0 :=
 begin
   /- we start by expanding d ≫ d as a double sum -/
   repeat { rw obj_d },
-  rw preadditive.comp_sum,
+  rw comp_sum,
   let d_l := λ (j : fin (n+3)), (-1 : ℤ)^(j : ℕ) • X.δ j,
   let d_r := λ (i : fin (n+2)), (-1 : ℤ)^(i : ℕ) • X.δ i,
   rw [show (λ i , (∑ j : fin (n+3), d_l j) ≫ d_r i) =
-    (λ i, ∑ j : fin (n+3), (d_l j ≫ d_r i)), by { ext i, rw preadditive.sum_comp, }],
+    (λ i, ∑ j : fin (n+3), (d_l j ≫ d_r i)), by { ext i, rw sum_comp, }],
   rw ← finset.sum_product',
-  /- then, we decompose the index set P into a subet S and its complement Sᶜ -/ 
+  /- then, we decompose the index set P into a subet S and its complement Sᶜ -/
   let P := fin (n+2) × fin (n+3),
   let S := finset.univ.filter (λ (ij : P), (ij.2 : ℕ) ≤ (ij.1 : ℕ)),
   let term := λ (ij : P), d_l ij.2 ≫ d_r ij.1,
@@ -85,7 +81,7 @@ begin
   rw [← eq_neg_iff_add_eq_zero, ← finset.sum_neg_distrib],
   /- we are reduced to showing that two sums are equal, and this is obtained
   by constructing a bijection φ : S -> Sᶜ, which maps (i,j) to (j,i+1),
-  and by comparing the terms -/ 
+  and by comparing the terms -/
   let φ : Π (ij : P), ij ∈ S → P := λ ij hij,
     (fin.cast_lt ij.2
       (lt_of_le_of_lt (finset.mem_filter.mp hij).right (fin.is_lt ij.1)), ij.1.succ),
@@ -102,8 +98,7 @@ begin
     simp only [term, d_l, d_r, φ],
     simp only,
     clear term d_l d_r,
-    repeat { rw [category_theory.preadditive.comp_zsmul,
-      category_theory.preadditive.zsmul_comp], },
+    repeat { rw [comp_zsmul, zsmul_comp], },
     rw [← neg_smul, ← mul_smul, ← mul_smul],
     rw [← show (-1 : ℤ)^(i : ℕ) * (-1 : ℤ)^(j : ℕ) =
         - (-1 : ℤ)^(jj : ℕ) * (-1 : ℤ)^(i.succ : ℕ), by
@@ -144,7 +139,7 @@ end
 -/
 
 /-- The alternating face map complex, on objects -/
-def obj : chain_complex C ℕ := chain_complex.of (obj_X X) (obj_d X) (d_squared X)
+def obj : chain_complex C ℕ := chain_complex.of (λ n, X _[n]) (obj_d X) (d_squared X)
 
 variables {X} {Y}
 
@@ -156,11 +151,10 @@ chain_complex.of_hom _ _ _ _ _ _
   (λ n,
     begin
       repeat { rw obj_d },
-      rw [preadditive.comp_sum, preadditive.sum_comp],
+      rw [comp_sum, sum_comp],
       apply congr_arg,
       ext,
-      rw category_theory.preadditive.comp_zsmul,
-      rw category_theory.preadditive.zsmul_comp,
+      rw [comp_zsmul, zsmul_comp],
       apply congr_arg,
       erw f.naturality,
       refl,
@@ -194,7 +188,7 @@ chain_complex.of_hom _ _ _ _ _ _
          we first get rid of the terms of the alternating sum that are obviously
          zero on the normalized_Moore_complex -/
       simp only [alternating_face_map_complex.obj_d],
-      rw preadditive.comp_sum,
+      rw comp_sum,
       let t := λ (j : fin (n+2)), (normalized_Moore_complex.obj_X X (n+1)).arrow ≫
         ((-1 : ℤ)^(j : ℕ) • X.δ j),
       have def_t : (∀ j : fin (n+2), t j = (normalized_Moore_complex.obj_X X (n+1)).arrow ≫
@@ -203,7 +197,7 @@ chain_complex.of_hom _ _ _ _ _ _
       have null : ∀ j : fin (n+1), t j.succ = 0,
       { intro j,
         rw def_t,
-        rw preadditive.comp_zsmul,
+        rw comp_zsmul,
         rw ← zsmul_zero ((-1 : ℤ)^(j.succ : ℕ)),
         apply congr_arg,
         rw normalized_Moore_complex.obj_X,
@@ -237,4 +231,3 @@ def inclusion_of_Moore_complex :
 { app := inclusion_of_Moore_complex_map, }
 
 end algebraic_topology
-

--- a/src/algebraic_topology/alternating_face_map_complex.lean
+++ b/src/algebraic_topology/alternating_face_map_complex.lean
@@ -266,7 +266,7 @@ variables {X} {Y}
 @[simp]
 def map (f : X ⟶ Y) : obj X ⟶ obj Y :=
 chain_complex.of_hom _ _ _ _ _ _
-  (λ n, f.app(op(simplex_category.mk n)))
+  (λ n, f.app (op (simplex_category.mk n)))
   (λ n,
     begin
       repeat { rw obj_d },

--- a/src/algebraic_topology/alternating_face_map_complex.lean
+++ b/src/algebraic_topology/alternating_face_map_complex.lean
@@ -23,7 +23,7 @@ where the differentials are alternating sums of faces.
 
 We also construct the natural transformation
 `inclusion_of_Moore_complex : normalized_Moore_complex A ⟶ alternating_face_map_complex A`
-when `A` is an abelian category
+when `A` is an abelian category.
 
 ## References
 * https://stacks.math.columbia.edu/tag/0194

--- a/src/algebraic_topology/alternating_face_map_complex.lean
+++ b/src/algebraic_topology/alternating_face_map_complex.lean
@@ -225,7 +225,7 @@ variables (A)
 as a natural transformation -/
 @[simps]
 def inclusion_of_Moore_complex :
-  nat_trans (normalized_Moore_complex A) (alternating_face_map_complex A) :=
+  (normalized_Moore_complex A) ⟶ (alternating_face_map_complex A) :=
 { app := inclusion_of_Moore_complex_map, }
 
 end algebraic_topology

--- a/src/algebraic_topology/alternating_face_map_complex.lean
+++ b/src/algebraic_topology/alternating_face_map_complex.lean
@@ -210,7 +210,6 @@ chain_complex.of_hom _ _ _ _ _ _
       rw [show (-1 : ℤ)^((0 : fin (n+2)) : ℕ) = 1, by ring] at eq,
       rw one_smul at eq,
       rw eq,
-      clear eq null def_t t,
       cases n; dsimp; simp,
     end)
 

--- a/src/algebraic_topology/alternating_face_map_complex.lean
+++ b/src/algebraic_topology/alternating_face_map_complex.lean
@@ -196,9 +196,7 @@ chain_complex.of_hom _ _ _ _ _ _
       rw [fin.sum_univ_succ t],
       have null : ∀ j : fin (n+1), t j.succ = 0,
       { intro j,
-        rw def_t,
-        rw comp_zsmul,
-        rw ← zsmul_zero ((-1 : ℤ)^(j.succ : ℕ)),
+        rw [def_t, comp_zsmul, ← zsmul_zero ((-1 : ℤ)^(j.succ : ℕ))],
         apply congr_arg,
         rw normalized_Moore_complex.obj_X,
         rw ← factor_thru_arrow _ _

--- a/src/algebraic_topology/alternating_face_map_complex.lean
+++ b/src/algebraic_topology/alternating_face_map_complex.lean
@@ -21,8 +21,8 @@ for any preadditive category `C`. For any simplicial object `X` in `C`,
 this is the homological complex `... → X_2 → X_1 → X_0`
 where the differentials are alternating sums of faces.
 
-We also construct the natural transformation `inclusion_of_Moore_complex :
-nat_trans (normalized_Moore_complex A) (alternating_face_map_complex A)`
+We also construct the natural transformation
+`inclusion_of_Moore_complex : normalized_Moore_complex A ⟶ alternating_face_map_complex A`
 when `A` is an abelian category
 
 ## References

--- a/src/algebraic_topology/alternating_face_map_complex.lean
+++ b/src/algebraic_topology/alternating_face_map_complex.lean
@@ -92,8 +92,7 @@ begin
   { intro htx,
     rw nat.succ_sub_one at htx,
     have h1 := nat.le_of_lt_succ hx,
-    linarith,
-    },
+    linarith, },
 end
 
 lemma τ_inv (x : ℕ × ℕ) : τ (τ x) = x :=

--- a/src/algebraic_topology/alternating_face_map_complex.lean
+++ b/src/algebraic_topology/alternating_face_map_complex.lean
@@ -10,6 +10,7 @@ import algebraic_topology.Moore_complex
 import category_theory.abelian.basic
 import algebra.big_operators.basic
 import tactic.ring_exp
+import data.fintype.card
 
 /-!
 
@@ -33,7 +34,9 @@ when `A` is an abelian category.
 
 open category_theory category_theory.limits category_theory.subobject
 open opposite
+
 open_locale big_operators
+open_locale simplicial
 
 noncomputable theory
 
@@ -41,11 +44,15 @@ namespace algebraic_topology
 
 namespace alternating_face_map_complex
 
+/-!
+## Construction of the alternating face map complex
+-/
+
 /-- In degree n, the alternating face map complex is given by
 the nth-object of the simplicial object -/
 @[simp]
 def obj_X {C : Type*} [category C] (X : simplicial_object C) (n : ℕ) :=
-X.obj (op (simplex_category.mk n))
+X.obj (op [n])
 
 variables {C : Type*} [category C] [preadditive C]
 variables (X : simplicial_object C)
@@ -55,202 +62,82 @@ variables (Y : simplicial_object C)
 sum of the face maps -/
 @[simp]
 def obj_d (n : ℕ) : obj_X X (n+1) ⟶ obj_X X n :=
-∑ i in finset.range (n+2), (-1 : ℤ)^i • X.δ i
-
-/-!
-## Proof of the chain complex relation `d ≫ d`
-
-The expansion of `d ≫ d` involves a double sum, or a sum of terms
-indexed by a set of the form {0,...,n} × {0,...,n+1}. We shall show
-a general cancellation lemma `antisymmetric_sum_cancels` of such sums when
-the terms f_{i,j} satisfy an "antisymmetry" relation f_{i,j+1} = -f_{j,i}
-for i≤j, The cancellation lemma follows from the study of a certain
-involution `τ` on `ℕ × ℕ`.
-
-### Definition of an involution `τ : ℕ × ℕ → ℕ × ℕ`
-
--/
+∑ (i : fin (n+2)), (-1 : ℤ)^(i : ℕ) • X.δ i
 
 /--
-We split elements `ℕ × ℕ` into two cases. "Case 1" is the situation of
-tuples `(i,j)` such that `i<j`, and "Case 2" is the other situation. These
-two subsets are exchanged by τ
--/
-def τ (x : ℕ × ℕ ) : ℕ × ℕ :=
-if x.1 < x.2
-  then (x.2-1,x.1)
-  else (x.2,x.1+1)
-
-lemma τ_case1 (x : ℕ × ℕ) (hx : (x.1<x.2)) : τ x = (x.2-1,x.1) :=
-by { rw τ, split_ifs, refl }
-
-lemma τ_case2 (x : ℕ × ℕ) (hx : ¬x.1<x.2) : τ x = (x.2,x.1+1) :=
-by { rw τ, split_ifs, refl }
-
-lemma τ_of_case2_is_case1 (x : ℕ × ℕ) (hx : ¬x.1<x.2) : (τ x).1<(τ x).2 :=
-by { rw τ_case2 x hx, linarith, }
-
-lemma τ_of_case1_is_case2 (x : ℕ × ℕ) (hx : x.1<x.2) : ¬(τ x).1<(τ x).2 :=
-begin
-  rw τ_case1 x hx,
-  cases x.2,
-  { exfalso, linarith, },
-  { intro htx,
-    rw nat.succ_sub_one at htx,
-    have h1 := nat.le_of_lt_succ hx,
-    linarith, },
-end
-
-lemma τ_inv (x : ℕ × ℕ) : τ (τ x) = x :=
-begin
-  by_cases x.1<x.2,
-  { rw τ_case2 (τ x) (τ_of_case1_is_case2 x h),
-    rw τ_case1 x h,
-    ext; simp only,
-      cases x.2 with m,
-      { linarith, },
-      { exact nat.succ_sub_one m.succ, }, },
-  { rw τ_case1 (τ x) (τ_of_case2_is_case1 x h),
-    rw τ_case2 x h,
-    simp only [nat.add_succ_sub_one, add_zero, prod.mk.eta], },
-end
-
-/-- τ has no fixed point -/
-lemma τ_ne' (x : ℕ × ℕ) : τ x ≠ x :=
-begin
-  have case1 : ∀ (y : ℕ × ℕ), y.1<y.2 → τ y ≠ y,
-  { intros y hy h1,
-    rw τ_case1 y hy at h1,
-    have h2 := congr_arg prod.snd h1,
-    simp only at h2,
-    linarith, },
-  have case2 : ∀ (y : ℕ × ℕ), ¬y.1<y.2 → τ y ≠ y,
-  { intros y hy h1,
-    exact case1 (τ y) (τ_of_case2_is_case1 y hy) (congr_arg τ h1), },
-  by_cases x.1<x.2,
-  { exact case1 x h, },
-  { exact case2 x h, },
-end
-
-/-!
-### Verification that τ induces an involution τ' on {0,...,n} × {0,...,n+1}
--/
-
-/-- `indices n` denotes `{0,...,n} × {0,...,n+1}` as a finite subset of `ℕ × ℕ` -/
-def indices (n : ℕ) : finset (ℕ × ℕ) :=
-finset.product (finset.range(n+1)) (finset.range(n+2))
-
-/-- τ stabilises {0,...,n} × {0,...,n+1} -/
-lemma τ'_mem' {n : ℕ} (x : ℕ × ℕ) (hx : x ∈ indices n) : τ x ∈ indices n :=
-begin
-  simp only [indices, finset.mem_product, finset.mem_range] at hx,
-  cases hx with hx1 hx2,
-  by_cases x.1<x.2,
-  { rw τ_case1 x h,
-    simp only [indices, finset.mem_product, finset.mem_range],
-    split,
-      { exact nat.pred_lt_pred (show x.2 ≠ 0, by linarith) hx2, },
-      { linarith, }, },
-  { rw τ_case2 x h,
-    simp only [indices, finset.mem_product, finset.mem_range],
-    split; linarith, }
-end
-
-/-!
-### Cancellation of "antisymmetric" sums indexed by {0,...,n} × {0,...,n+1}
--/
-
-variables {α : Type*}
-
-/-- The proof uses finset.sum_involution. Then, from the assumption, we need
-to show that for all x in {0,...,n} × {0,...,n+1}, we have `f x + f (τ x) = 0`.
--/
-lemma antisymmetric_sum_cancels [add_comm_group α] {n : ℕ} (f : ℕ × ℕ → α)
-  (antisymmetry_f : ∀ (i j : ℕ), i≤j → j≤n → f (i,j+1) = - f (j,i)) :
-  ∑ x in (indices n), f x = 0 :=
-begin
-  have hf_case2 : ∀ (x : ℕ × ℕ) (h2x : ¬x.1<x.2)
-    (hx : x ∈ indices n), f x + f (τ x) = 0,
-  { intros x h2x hx,
-    rw τ_case2 x h2x,
-    simp only [indices, finset.mem_product, finset.mem_range] at hx,
-    rw antisymmetry_f x.2 x.1 (by linarith) (by linarith),
-    simp only [prod.mk.eta, add_right_neg], },
-  have hf_case1 : ∀ (x : ℕ × ℕ) (h1x : x.1<x.2)
-    (hx : x ∈ indices n), f x + f (τ x) = 0,
-  { intros x h1x hx,
-    rw add_comm,
-    have eq := hf_case2 (τ x) (τ_of_case1_is_case2 x h1x) (τ'_mem' x hx),
-    rw τ_inv x at eq,
-    exact eq, },
-  let τ' : ∀ (x : ℕ × ℕ), x ∈ indices n → ℕ × ℕ := λ x hx, τ x,
-  have τ'_eq_τ : ∀ (x : ℕ × ℕ) (hx : x ∈ indices n), τ' x hx = τ x := by { intros x hx, refl, },
-  have hf : ∀ (x : ℕ × ℕ) (hx : x ∈ indices n), f x + f (τ' x hx) = 0,
-  { intros x hx,
-    rw τ'_eq_τ x hx,
-    by_cases x.1<x.2,
-    { exact hf_case1 x h hx, },
-    { exact hf_case2 x h hx, }, },
-  exact finset.sum_involution τ' hf (λ x _ _, τ_ne' x)
-    τ'_mem' (λ x _, τ_inv x),
-end
-
-
-/-!
-### Antisymmetry property for the terms that appear in the expansion of `d ≫ d`
--/
-
-/-- εdi_dj n (i,j) is the composite `(-1)^j d_j ≫ (-1)^i d_i` -/
-def εdi_dj (n : ℕ) (x : ℕ × ℕ) : (obj_X X (n+2)) ⟶ (obj_X X n) :=
-((-1 : ℤ)^x.2 • X.δ x.2) ≫ ((-1 : ℤ)^x.1 • X.δ x.1)
-
-lemma εdi_dj_antisymm (n i j : ℕ) (hij : i≤j) (hjn : j≤n+1) :
-  (εdi_dj X n (i,j+1)) = - εdi_dj X n (j,i) :=
-begin
-  repeat { rw εdi_dj },
-  simp only,
-  repeat { rw category_theory.preadditive.comp_zsmul },
-  repeat { rw category_theory.preadditive.zsmul_comp },
-  repeat { rw ← mul_smul },
-  have eq : -((-1)^i * (-1)^j : ℤ) = (-1)^i * (-1)^(j+1) := by ring_exp,
-  rw [← eq, mul_comm, ← neg_smul],
-  apply congr_arg,
-  /- the equality shall follow from simplicial identities -/
-  have ineq : (i : fin(n+2)) ≤ j,
-  { rw ← fin.coe_fin_le,
-    rw fin.coe_coe_of_lt (show i<n+2, by linarith),
-    rw fin.coe_coe_of_lt (show j<n+2, by linarith),
-    exact hij, },
-  have hi : fin.cast_succ (i : fin(n+2)) = (i : fin(n+3)),
-  { ext,
-    rw fin.coe_cast_succ,
-    rw fin.coe_coe_of_lt (show i<n+2, by linarith),
-    rw fin.coe_coe_of_lt (show i<n+3, by linarith), },
-  have hj : (j : fin(n+2)).succ = ((j+1) : ℕ),
-  { ext,
-    rw fin.coe_succ,
-    rw fin.coe_coe_of_lt (show j+1<n+3, by linarith),
-    rw fin.coe_coe_of_lt (show j<n+2, by linarith), },
-  have seq := category_theory.simplicial_object.δ_comp_δ X ineq,
-  rw [hi, hj] at seq,
-  exact seq,
-end
-
-/-!
-### End of the proof of `d ≫ d = 0`
+## The chain complex relation `d ≫ d`
 -/
 lemma d_squared (n : ℕ) : obj_d X (n+1) ≫ obj_d X n = 0 :=
 begin
+  /- we start by expanding d ≫ d as a double sum -/
   repeat { rw obj_d },
   rw preadditive.comp_sum,
-  let d_l := (λ (j:ℕ), (-1 : ℤ)^j • X.δ (j : fin(n+3))),
-  let d_r := (λ (i:ℕ), (-1 : ℤ)^i • X.δ (i : fin(n+2))),
-  rw [show (λ i, (∑ j in finset.range(n+3), d_l j) ≫ d_r i) =
-    (λ i, ∑ j in finset.range(n+3), εdi_dj X n (i,j)),
-    by { ext, rw preadditive.sum_comp, refl }],
+  let d_l := λ (j : fin (n+3)), (-1 : ℤ)^(j : ℕ) • X.δ j,
+  let d_r := λ (i : fin (n+2)), (-1 : ℤ)^(i : ℕ) • X.δ i,
+  rw [show (λ i , (∑ j : fin (n+3), d_l j) ≫ d_r i) =
+    (λ i, ∑ j : fin (n+3), (d_l j ≫ d_r i)), by { ext i, rw preadditive.sum_comp, }],
   rw ← finset.sum_product',
-  clear d_l d_r,
-  exact antisymmetric_sum_cancels (εdi_dj X n) (εdi_dj_antisymm X n),
+  /- then, we decompose the index set P into a subet S and its complement Sᶜ -/ 
+  let P := fin (n+2) × fin (n+3),
+  let S := finset.univ.filter (λ (ij : P), (ij.2 : ℕ) ≤ (ij.1 : ℕ)),
+  let term := λ (ij : P), d_l ij.2 ≫ d_r ij.1,
+  erw [show ∑ (ij : P), term ij =
+    (∑ ij in S, term ij) + (∑ ij in Sᶜ, term ij), by rw finset.sum_add_sum_compl],
+  rw [← eq_neg_iff_add_eq_zero, ← finset.sum_neg_distrib],
+  /- we are reduced to showing that two sums are equal, and this is obtained
+  by constructing a bijection φ : S -> Sᶜ, which maps (i,j) to (j,i+1),
+  and by comparing the terms -/ 
+  let φ : Π (ij : P), ij ∈ S → P := λ ij hij,
+    (fin.cast_lt ij.2
+      (lt_of_le_of_lt (finset.mem_filter.mp hij).right (fin.is_lt ij.1)), ij.1.succ),
+  apply finset.sum_bij φ,
+  { -- φ(S) is contained in Sᶜ
+    intros ij hij,
+    simp only [finset.mem_univ, finset.compl_filter, finset.mem_filter, true_and,
+      fin.coe_succ, fin.coe_cast_lt] at hij ⊢,
+    linarith, },
+  { /- identification of corresponding terms in both sums -/
+    rintro ⟨i, j⟩ hij,
+    let jj : fin (n+2) := (φ (i,j) hij).1,
+    simp only [finset.mem_filter, finset.mem_univ, true_and] at hij,
+    simp only [term, d_l, d_r, φ],
+    simp only,
+    clear term d_l d_r,
+    repeat { rw [category_theory.preadditive.comp_zsmul,
+      category_theory.preadditive.zsmul_comp], },
+    rw [← neg_smul, ← mul_smul, ← mul_smul],
+    rw [← show (-1 : ℤ)^(i : ℕ) * (-1 : ℤ)^(j : ℕ) =
+        - (-1 : ℤ)^(jj : ℕ) * (-1 : ℤ)^(i.succ : ℕ), by
+      { simp only [fin.coe_succ, fin.coe_cast_lt], ring_exp, }],
+    apply congr_arg,
+    have ineq : jj ≤ i, { rw ← fin.coe_fin_le, exact hij, },
+    rw category_theory.simplicial_object.δ_comp_δ X ineq,
+    simp only [fin.cast_succ_cast_lt], },
+  { -- φ : S → Sᶜ is injective
+    rintro ⟨i, j⟩ ⟨i', j'⟩ hij hij' h,
+    rw [prod.mk.inj_iff],
+    split,
+    { have h1 := congr_arg prod.snd h,
+      simp only [fin.succ_inj] at h1,
+      exact congr_arg _ h1 },
+    { have h1 := congr_arg fin.cast_succ (congr_arg prod.fst h),
+      simp only [fin.cast_succ_cast_lt] at h1,
+      exact h1, }, },
+  { -- φ : S → Sᶜ is surjective
+    clear term d_l d_r,
+    rintro ⟨i', j'⟩ hij',
+    simp only [true_and, finset.mem_univ, finset.compl_filter, not_le,
+      finset.mem_filter] at hij',
+    refine ⟨(j'.pred _,fin.cast_succ i'),_,_⟩,
+    { intro H,
+      rw [H] at hij',
+      simp only [nat.not_lt_zero, fin.coe_zero] at hij',
+      exact hij', },
+    { simp only [true_and, finset.mem_univ, fin.coe_cast_succ, fin.coe_pred,
+        finset.mem_filter],
+      exact nat.le_pred_of_lt hij', },
+    { simp only [prod.mk.inj_iff, fin.succ_pred, fin.cast_lt_cast_succ],
+      split; refl, }, },
 end
 
 /-!
@@ -266,12 +153,12 @@ variables {X} {Y}
 @[simp]
 def map (f : X ⟶ Y) : obj X ⟶ obj Y :=
 chain_complex.of_hom _ _ _ _ _ _
-  (λ n, f.app (op (simplex_category.mk n)))
+  (λ n, f.app (op [n]))
   (λ n,
     begin
       repeat { rw obj_d },
       rw [preadditive.comp_sum, preadditive.sum_comp],
-      apply congr_arg (finset.range(n+2)).sum,
+      apply congr_arg,
       ext,
       rw category_theory.preadditive.comp_zsmul,
       rw category_theory.preadditive.zsmul_comp,
@@ -309,41 +196,30 @@ chain_complex.of_hom _ _ _ _ _ _
          zero on the normalized_Moore_complex -/
       simp only [alternating_face_map_complex.obj_d],
       rw preadditive.comp_sum,
-      let t := λ (j : ℕ), (normalized_Moore_complex.obj_X X (n+1)).arrow ≫
-        ((-1 : ℤ)^j • X.δ j),
-      have def_t : (∀ j, t j = (normalized_Moore_complex.obj_X X (n+1)).arrow ≫
-        ((-1 : ℤ)^j • X.δ j)) := by { intro j, refl, },
-      have h := finset.sum_range_add t 1 (n+1),
-      rw finset.sum_range_one at h,
-      have null : (∀ j, j ∈ finset.range(n+1) → t (1+j) = 0),
-      { intros j hj,
-        simp only [finset.mem_range] at hj,
+      let t := λ (j : fin (n+2)), (normalized_Moore_complex.obj_X X (n+1)).arrow ≫
+        ((-1 : ℤ)^(j : ℕ) • X.δ j),
+      have def_t : (∀ j : fin (n+2), t j = (normalized_Moore_complex.obj_X X (n+1)).arrow ≫
+        ((-1 : ℤ)^(j : ℕ) • X.δ j)) := by { intro j, refl, },
+      rw [fin.sum_univ_succ t],
+      have null : ∀ j : fin (n+1), t j.succ = 0,
+      { intro j,
         rw def_t,
         rw preadditive.comp_zsmul,
-        rw ← zsmul_zero ((-1 : ℤ)^(1+j)),
+        rw ← zsmul_zero ((-1 : ℤ)^(j.succ : ℕ)),
         apply congr_arg,
         rw normalized_Moore_complex.obj_X,
-        rw [show ((1+j : ℕ) : (fin(n+2))) = (j : fin(n+1)).succ, by
-          { ext,
-            rw fin.coe_succ,
-            rw fin.coe_coe_of_lt (show j<n+1, by linarith),
-            rw fin.coe_coe_of_lt (show 1+j<n+2, by linarith),
-            rw add_comm, }],
         rw ← factor_thru_arrow _ _
-          (finset_inf_arrow_factors finset.univ _ (j : fin(n+1)) (by simp)),
-        slice_lhs 2 3 { erw kernel_subobject_arrow_comp (X.δ (j:fin(n+1)).succ), },
-        simp, },
-      rw finset.sum_eq_zero null at h,
-      rw [show 1+(n+1)=n+2, by linarith] at h,
-      rw h,
+          (finset_inf_arrow_factors finset.univ _ j (by simp only [finset.mem_univ])),
+        slice_lhs 2 3 { erw kernel_subobject_arrow_comp (X.δ j.succ), },
+        simp only [comp_zero], },
+      rw [fintype.sum_eq_zero _ null],
       simp only [add_zero],
-
       /- finally, we study the remaining term which is induced by X.δ 0 -/
       let eq := def_t 0,
-      rw [show (-1 : ℤ)^0 = 1, by ring] at eq,
+      rw [show (-1 : ℤ)^((0 : fin (n+2)) : ℕ) = 1, by ring] at eq,
       rw one_smul at eq,
       rw eq,
-      clear eq null def_t h t,
+      clear eq null def_t t,
       cases n; dsimp; simp,
     end)
 

--- a/src/algebraic_topology/alternating_face_map_complex.lean
+++ b/src/algebraic_topology/alternating_face_map_complex.lean
@@ -54,8 +54,8 @@ variables (Y : simplicial_object C)
 /-- The differential on the alternating face map complex is the alternate
 sum of the face maps -/
 @[simp]
-def obj_d (n : ℕ) : (obj_X X (n+1)) ⟶ (obj_X X n) :=
-∑ i in finset.range(n+2), ((-1 : ℤ)^i • X.δ i)
+def obj_d (n : ℕ) : obj_X X (n+1) ⟶ obj_X X n :=
+∑ i in finset.range (n+2), (-1 : ℤ)^i • X.δ i
 
 /-!
 ## Proof of the chain complex relation `d ≫ d`

--- a/src/algebraic_topology/alternating_face_map_complex.lean
+++ b/src/algebraic_topology/alternating_face_map_complex.lean
@@ -45,7 +45,7 @@ namespace alternating_face_map_complex
 the nth-object of the simplicial object -/
 @[simp]
 def obj_X {C : Type*} [category C] (X : simplicial_object C) (n : ℕ) :=
-X.obj(op(simplex_category.mk n))
+X.obj (op (simplex_category.mk n))
 
 variables {C : Type*} [category C] [preadditive C]
 variables (X : simplicial_object C)

--- a/src/algebraic_topology/alternating_face_map_complex.lean
+++ b/src/algebraic_topology/alternating_face_map_complex.lean
@@ -1,0 +1,367 @@
+/-
+Copyright (c) 2021 Joël Riou. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Author: Joël Riou
+-/
+
+import algebra.homology.homological_complex
+import algebraic_topology.simplicial_object
+import algebraic_topology.Moore_complex
+import category_theory.abelian.basic
+import algebra.big_operators.basic
+import tactic.ring_exp
+
+/-!
+
+# The alternating face map complex of a simplicial object in a preadditive category
+
+We construct the alternating face map complex, as a 
+functor `alternating_face_map_complex : simplicial_object C ⥤ chain_complex C ℕ`
+for any preadditive category `C`. For any simplicial object `X` in `C`,
+this is the homological complex `... → X_2 → X_1 → X_0`
+where the differentials are alternate sums of faces.
+
+We also construct the natural transformation 
+`inclusion_of_Moore_complex : nat_trans (normalized_Moore_complex A) (alternating_face_map_complex A)` 
+when `A` is an abelian category
+
+## References
+* https://stacks.math.columbia.edu/tag/0194
+* https://ncatlab.org/nlab/show/Moore+complex
+
+-/
+
+open category_theory category_theory.limits category_theory.subobject
+open opposite
+open_locale big_operators
+
+noncomputable theory
+namespace algebraic_topology
+
+variables {C : Type*} [category C] [preadditive C]
+variables (X : simplicial_object C)
+variables (Y : simplicial_object C)
+
+namespace alternating_face_map_complex
+
+@[simp]
+def obj_X (n : ℕ) := X.obj(op(simplex_category.mk n))
+
+@[simp]
+def obj_d (n : ℕ) : (obj_X X (n+1)) ⟶ (obj_X X n) :=
+∑ i in finset.range(n+2), ((-1 : ℤ)^i • X.δ i)
+
+/-!
+## Proof of the chain complex relation `d ≫ d` 
+
+The expansion of `d ≫ d` involves a double sum, or a sum of terms
+indexed by a set of the form {0,...,n} × {0,...,n+1}. We shall show
+a general cancellation lemma `antisymmetric_sum_cancels` of such sums when
+the terms f_{i,j} satisfy an "antisymmetry" relation f_{i,j+1} = -f_{j,i}
+for i≤j, The cancellation lemma follows from the study of a certain
+involution `τ` on `ℕ × ℕ`.
+
+### Definition of an involution `τ : ℕ × ℕ → ℕ × ℕ`
+
+-/
+
+/--
+We split elements `ℕ × ℕ` into two cases. "Case 1" is the situation of
+tuples `(i,j)` such that `i<j`, and "Case 2" is the other situation. These
+two subsets are exchanged by τ
+-/
+def τ (x : ℕ × ℕ ) : ℕ × ℕ :=
+if x.1 < x.2
+  then (x.2-1,x.1)
+  else (x.2,x.1+1)
+
+lemma τ_case1 (x : ℕ × ℕ) (hx : (x.1<x.2)) : τ x = (x.2-1,x.1) :=
+by { rw τ, split_ifs, refl }
+
+lemma τ_case2 (x : ℕ × ℕ) (hx : ¬x.1<x.2) : τ x = (x.2,x.1+1) :=
+by { rw τ, split_ifs, refl }
+
+lemma τ_of_case2_is_case1 (x : ℕ × ℕ) (hx : ¬x.1<x.2) : (τ x).1<(τ x).2 :=
+by { rw τ_case2 x hx, linarith, }
+
+lemma τ_of_case1_is_case2 (x : ℕ × ℕ) (hx : x.1<x.2) : ¬(τ x).1<(τ x).2 :=
+begin
+  rw τ_case1 x hx,
+  cases x.2,
+  { exfalso, linarith, },
+  { intro htx,
+    rw nat.succ_sub_one at htx,
+    have h1 := nat.le_of_lt_succ hx,
+    linarith,
+    },
+end
+
+lemma τ_inv (x : ℕ × ℕ) : τ (τ x) = x :=
+begin
+  by_cases x.1<x.2,
+  { rw τ_case2 (τ x) (τ_of_case1_is_case2 x h),
+    rw τ_case1 x h,
+    ext; simp only,
+      cases x.2 with m,
+      { linarith, },
+      { exact nat.succ_sub_one m.succ, }, },
+  { rw τ_case1 (τ x) (τ_of_case2_is_case1 x h),
+    rw τ_case2 x h,
+    simp only [nat.add_succ_sub_one, add_zero, prod.mk.eta], },
+end
+
+/-- τ has no fixed point -/
+lemma τ_ne' (x : ℕ × ℕ) : τ x ≠ x :=
+begin
+  have case1 : ∀ (y : ℕ × ℕ), y.1<y.2 → τ y ≠ y,
+  { intros y hy h1,
+    rw τ_case1 y hy at h1,
+    have h2 := congr_arg prod.snd h1, 
+    simp only at h2,
+    linarith, },
+  have case2 : ∀ (y : ℕ × ℕ), ¬y.1<y.2 → τ y ≠ y,
+  { intros y hy h1,
+    exact case1 (τ y) (τ_of_case2_is_case1 y hy) (congr_arg τ h1), },
+  by_cases x.1<x.2,
+  { exact case1 x h, },
+  { exact case2 x h, },
+end
+
+/-!
+### Verification that τ induces an involution τ' on {0,...,n} × {0,...,n+1}
+
+`indices n` denotes `{0,...,n} × {0,...,n+1}` as a finite subset of `ℕ × ℕ`
+-/
+
+def indices (n : ℕ) : finset (ℕ × ℕ) := 
+finset.product (finset.range(n+1)) (finset.range(n+2))
+
+def τ' {n : ℕ} : Π (x : ℕ × ℕ), x ∈ indices n → ℕ × ℕ := 
+λ x hx, τ x
+
+@[simp] lemma τ'_eq_τ {n : ℕ} (x : ℕ × ℕ) (hx : x ∈ indices n) :
+τ' x hx = τ x := by refl
+
+/-- τ stabilises {0,...,n} × {0,...,n+1} -/
+lemma τ'_mem' {n : ℕ} (x : ℕ × ℕ) (hx : x ∈ indices n) : τ x ∈ indices n :=
+begin
+  simp only [indices, finset.mem_product, finset.mem_range] at hx,
+  cases hx with hx1 hx2,
+  by_cases x.1<x.2,
+  { rw τ_case1 x h,
+    simp only [indices, finset.mem_product, finset.mem_range],
+    split,
+      { exact nat.pred_lt_pred (show x.2 ≠ 0, by linarith) hx2, },
+      { linarith, }, },
+  { rw τ_case2 x h,
+    simp only [indices, finset.mem_product, finset.mem_range],
+    split; linarith, }
+end
+
+lemma τ'_mem {n : ℕ} (x : ℕ × ℕ) (hx : x ∈ indices n) : τ' x hx ∈ indices n :=
+by { rw τ'_eq_τ, exact τ'_mem' x hx, }
+
+/-- τ' has no fixed point -/
+lemma τ'_ne' {n : ℕ} (x : ℕ × ℕ) (hx : x ∈ indices n) : τ' x hx ≠ x :=
+by { rw τ'_eq_τ, exact τ_ne' x, }
+
+/-! τ' is an involution. -/
+lemma τ'_inv {n : ℕ} (x : ℕ × ℕ) (hx : x ∈ indices n) :
+  τ' (τ' x hx) (τ'_mem x hx) = x :=
+by { simp only [τ'_eq_τ], exact τ_inv x, }
+
+/-!
+### Cancellation of "antisymmetric" sums indexed by {0,...,n} × {0,...,n+1}
+-/
+
+variables {α : Type*}
+
+/-- The proof uses finset.sum_involution. Then, from the assumption, we need
+to show that for all x in {0,...,n} × {0,...,n+1}, we have `f x + f (τ x) = 0`.
+-/
+lemma antisymmetric_sum_cancels [add_comm_group α] {n : ℕ} (f : ℕ × ℕ → α)
+  (antisymmetry_f : ∀ (i j : ℕ), i≤j → j≤n → f (i,j+1) = - f (j,i)) :
+  ∑ x in (indices n), f x = 0 :=
+begin
+  have hf_case2 : ∀ (x : ℕ × ℕ) (h2x : ¬x.1<x.2) 
+    (hx : x ∈ indices n), f x + f (τ x) = 0,
+  { intros x h2x hx,
+    rw τ_case2 x h2x,
+    simp only [indices, finset.mem_product, finset.mem_range] at hx,
+    rw antisymmetry_f x.2 x.1 (by linarith) (by linarith),
+    simp only [prod.mk.eta, add_right_neg], },
+  have hf_case1 : ∀ (x : ℕ × ℕ) (h1x : x.1<x.2) 
+    (hx : x ∈ indices n), f x + f (τ x) = 0,
+  { intros x h1x hx,
+    rw add_comm,
+    have eq := hf_case2 (τ x) (τ_of_case1_is_case2 x h1x) (τ'_mem' x hx),
+    rw τ_inv x at eq,
+    exact eq, },
+  have hf : ∀ (x : ℕ × ℕ) (hx : x ∈ indices n), f x + f (τ' x hx) = 0,
+  { intros x hx,
+    rw τ'_eq_τ,
+    by_cases x.1<x.2,
+    { exact hf_case1 x h hx, },
+    { exact hf_case2 x h hx, }, },
+  exact finset.sum_involution τ' hf (λ x hx _, τ'_ne' x hx) τ'_mem τ'_inv,
+end
+
+
+/-!
+### Antisymmetry property for the terms that appear in the expansion of `d ≫ d`
+-/
+
+def di_dj (n : ℕ) (x : ℕ × ℕ) : (obj_X X (n+2)) ⟶ (obj_X X n) :=
+((-1 : ℤ)^x.2 • X.δ x.2) ≫ ((-1 : ℤ)^x.1 • X.δ x.1)
+
+lemma di_dj_antisymm (n i j : ℕ) (hij : i≤j) (hjn : j≤n+1) :
+  (di_dj X n (i,j+1)) = - di_dj X n (j,i) :=
+begin
+  repeat { rw di_dj },
+  simp only,
+  repeat { rw category_theory.preadditive.comp_zsmul },
+  repeat { rw category_theory.preadditive.zsmul_comp },
+  repeat { rw ← mul_smul },
+  have eq : -((-1)^i * (-1)^j : ℤ) = (-1)^i * (-1)^(j+1) := by ring_exp,
+  rw [← eq, mul_comm, ← neg_smul],
+  apply congr_arg,
+  /- the equality shall follow from simplicial identities -/
+  have ineq : (i : fin(n+2)) ≤ j,
+  { rw ← fin.coe_fin_le,
+    rw fin.coe_coe_of_lt (show i<n+2, by linarith),
+    rw fin.coe_coe_of_lt (show j<n+2, by linarith),
+    exact hij, },
+  have hi : fin.cast_succ (i : fin(n+2)) = (i : fin(n+3)),
+  { ext,
+    rw fin.coe_cast_succ,
+    rw fin.coe_coe_of_lt (show i<n+2, by linarith),
+    rw fin.coe_coe_of_lt (show i<n+3, by linarith), },
+  have hj : (j : fin(n+2)).succ = ((j+1) : ℕ),
+  { ext,
+    rw fin.coe_succ,
+    rw fin.coe_coe_of_lt (show j+1<n+3, by linarith),
+    rw fin.coe_coe_of_lt (show j<n+2, by linarith), },
+  have seq := category_theory.simplicial_object.δ_comp_δ X ineq,
+  rw [hi, hj] at seq,
+  exact seq,
+end
+
+/-!
+### End of the proof of `d ≫ d = 0`
+-/
+lemma d_squared (n : ℕ) : obj_d X (n+1) ≫ obj_d X n = 0 :=
+begin
+  repeat { rw obj_d },
+  rw preadditive.comp_sum,
+  let d_l := (λ (j:ℕ), (-1 : ℤ)^j • X.δ (j : fin(n+3))),
+  let d_r := (λ (i:ℕ), (-1 : ℤ)^i • X.δ (i : fin(n+2))),
+  rw [show (λ i, (∑ j in finset.range(n+3), d_l j) ≫ d_r i) =
+    (λ i, ∑ j in finset.range(n+3), di_dj X n (i,j)),
+    by { ext, rw preadditive.sum_comp, refl }],
+  rw ← finset.sum_product',
+  clear d_l d_r,
+  exact antisymmetric_sum_cancels (di_dj X n) (di_dj_antisymm X n),
+end
+
+/-!
+## Construction of the alternating face map complex functor
+-/
+
+def obj : chain_complex C ℕ := chain_complex.of (obj_X X) (obj_d X) (d_squared X)
+
+variables {X} {Y}
+
+@[simp]
+def map (f : X ⟶ Y) : obj X ⟶ obj Y :=
+chain_complex.of_hom _ _ _ _ _ _
+  (λ n, f.app(op(simplex_category.mk n)))
+  (λ n,
+    begin
+      repeat { rw obj_d },
+      rw [preadditive.comp_sum, preadditive.sum_comp],
+      apply congr_arg (finset.range(n+2)).sum,
+      ext,
+      rw category_theory.preadditive.comp_zsmul,
+      rw category_theory.preadditive.zsmul_comp,
+      apply congr_arg,
+      erw f.naturality,
+      refl,
+    end)
+
+end alternating_face_map_complex
+
+variables (C)
+
+@[simps]
+def alternating_face_map_complex : simplicial_object C ⥤ chain_complex C ℕ :=
+{ obj := alternating_face_map_complex.obj,
+  map := λ X Y f, alternating_face_map_complex.map f }
+
+/-!
+## Construction of the natural inclusion of the normalized Moore complex into the alternating face map complex
+-/
+
+variables {A : Type*} [category A] [abelian A]
+def inclusion_of_Moore_complex_map (X : simplicial_object A) :  
+  (normalized_Moore_complex A).obj X ⟶ (alternating_face_map_complex A).obj X :=
+chain_complex.of_hom _ _ _ _ _ _ 
+  (λ n, (normalized_Moore_complex.obj_X X n).arrow)
+  (λ n,
+    begin
+      /- we have to show the compatibility of the differentials on the alternating
+         face map complex with those defined on the normalized Moore complex:
+         we first get rid of the terms of the alternating sum that are obviously
+         zero on the normalized_Moore_complex -/
+      simp only [alternating_face_map_complex.obj_d],
+      rw preadditive.comp_sum,
+      let t := λ (j : ℕ), (normalized_Moore_complex.obj_X X (n+1)).arrow ≫
+        ((-1 : ℤ)^j • X.δ j),
+      have def_t : (∀ j, t j = (normalized_Moore_complex.obj_X X (n+1)).arrow ≫
+        ((-1 : ℤ)^j • X.δ j)) := by { intro j, refl, },
+      have h := finset.sum_range_add t 1 (n+1),
+      rw finset.sum_range_one at h,
+      have null : (∀ j, j ∈ finset.range(n+1) → t (1+j) = 0),
+      { intros j hj,
+        simp only [finset.mem_range] at hj,
+        rw def_t,
+        rw preadditive.comp_zsmul,
+        rw ← zsmul_zero ((-1 : ℤ)^(1+j)),
+        apply congr_arg,
+        rw normalized_Moore_complex.obj_X,
+        rw [show ((1+j : ℕ) : (fin(n+2))) = (j : fin(n+1)).succ, by
+          { ext,
+            rw fin.coe_succ,
+            rw fin.coe_coe_of_lt (show j<n+1, by linarith),
+            rw fin.coe_coe_of_lt (show 1+j<n+2, by linarith),
+            rw add_comm, }],
+        rw ← factor_thru_arrow _ _
+          (finset_inf_arrow_factors finset.univ _ (j : fin(n+1)) (by simp)),
+        slice_lhs 2 3 { erw kernel_subobject_arrow_comp (X.δ (j:fin(n+1)).succ), },
+        simp, },
+      rw finset.sum_eq_zero null at h,
+      rw [show 1+(n+1)=n+2, by linarith] at h,
+      rw h,
+      simp only [add_zero],
+
+      /- finally, we study the remaining term which is induced by X.δ 0 -/
+      let eq := def_t 0,
+      rw [show (-1 : ℤ)^0 = 1, by ring] at eq,
+      rw one_smul at eq,
+      rw eq,
+      clear eq null def_t h t,
+      cases n; dsimp; simp,
+    end)
+
+@[simp]
+lemma inclusion_of_Moore_complex_map_f (X : simplicial_object A) (n : ℕ) :
+  (inclusion_of_Moore_complex_map X).f n = (normalized_Moore_complex.obj_X X n).arrow :=
+chain_complex.of_hom_f _ _ _ _ _ _ _ _ n
+
+variables (A)
+
+@[simps]
+def inclusion_of_Moore_complex :
+  nat_trans (normalized_Moore_complex A) (alternating_face_map_complex A) :=
+{ app := inclusion_of_Moore_complex_map, }
+
+end algebraic_topology

--- a/src/algebraic_topology/alternating_face_map_complex.lean
+++ b/src/algebraic_topology/alternating_face_map_complex.lean
@@ -19,7 +19,7 @@ We construct the alternating face map complex, as a
 functor `alternating_face_map_complex : simplicial_object C ⥤ chain_complex C ℕ`
 for any preadditive category `C`. For any simplicial object `X` in `C`,
 this is the homological complex `... → X_2 → X_1 → X_0`
-where the differentials are alternate sums of faces.
+where the differentials are alternating sums of faces.
 
 We also construct the natural transformation `inclusion_of_Moore_complex :
 nat_trans (normalized_Moore_complex A) (alternating_face_map_complex A)`


### PR DESCRIPTION
added the alternating face map complex of a simplicial object in a preadditive category and the natural inclusion of the normalized_Moore_complex

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
