### PR TITLE
[Merged by Bors] - feat(topology/[path_]connected): add random [path-]connectedness lemmas

### DIFF
--- a/src/topology/connected.lean
+++ b/src/topology/connected.lean
@@ -528,8 +528,7 @@ begin
   { intros h,
     casesI is_empty_or_nonempty α with hα hα,
     { exact ⟨by { rw (univ_eq_empty_iff.mpr hα), exact is_preconnected_empty }⟩ },
-    { let x := classical.choice hα,
-      exact ⟨by { rw ← h x, exact is_preconnected_connected_component }⟩ } }
+    { exact ⟨by { rw ← h (classical.choice hα), exact is_preconnected_connected_component }⟩ } }
 end
 
 @[simp] lemma preconnected.connected_component_eq_univ {X : Type*} [topological_space X]

--- a/src/topology/connected.lean
+++ b/src/topology/connected.lean
@@ -526,19 +526,15 @@ begin
     exactI (eq_univ_of_univ_subset $
       is_preconnected_univ.subset_connected_component (mem_univ x)) },
   { intros h,
-    by_cases hα : is_empty α,
+    casesI is_empty_or_nonempty α with hα hα,
     { exact ⟨by { rw (univ_eq_empty_iff.mpr hα), exact is_preconnected_empty }⟩ },
-    { rw not_is_empty_iff at hα,
-      rcases hα with ⟨x⟩,
+    { let x := classical.choice hα,
       exact ⟨by { rw ← h x, exact is_preconnected_connected_component }⟩ } }
 end
 
-lemma preconnected.connected_component_eq_univ {X : Type*} [topological_space X]
+@[simp] lemma preconnected.connected_component_eq_univ {X : Type*} [topological_space X]
   [h : preconnected_space X] (x : X) : connected_component x = univ :=
-begin
-  rw preconnected_space_iff_connected_component at h,
-  exact h x
-end
+preconnected_space_iff_connected_component.mp h x
 
 instance [topological_space β] [preconnected_space α] [preconnected_space β] :
   preconnected_space (α × β) :=

--- a/src/topology/connected.lean
+++ b/src/topology/connected.lean
@@ -518,6 +518,28 @@ begin
     exact ⟨⟨x⟩⟩ }
 end
 
+lemma preconnected_space_iff_connected_component :
+  preconnected_space α ↔ ∀ x : α, connected_component x = univ :=
+begin
+  split,
+  { intros h x,
+    exactI (eq_univ_of_univ_subset $
+      is_preconnected_univ.subset_connected_component (mem_univ x)) },
+  { intros h,
+    by_cases hα : is_empty α,
+    { exact ⟨by { rw (univ_eq_empty_iff.mpr hα), exact is_preconnected_empty }⟩ },
+    { rw not_is_empty_iff at hα,
+      rcases hα with ⟨x⟩,
+      exact ⟨by { rw ← h x, exact is_preconnected_connected_component }⟩ } }
+end
+
+lemma preconnected.connected_component_eq_univ {X : Type*} [topological_space X]
+  [h : preconnected_space X] (x : X) : connected_component x = univ :=
+begin
+  rw preconnected_space_iff_connected_component at h,
+  exact h x
+end
+
 instance [topological_space β] [preconnected_space α] [preconnected_space β] :
   preconnected_space (α × β) :=
 ⟨by { rw ← univ_prod_univ, exact is_preconnected_univ.prod is_preconnected_univ }⟩

--- a/src/topology/connected.lean
+++ b/src/topology/connected.lean
@@ -531,7 +531,7 @@ begin
     { exact ⟨by { rw ← h (classical.choice hα), exact is_preconnected_connected_component }⟩ } }
 end
 
-@[simp] lemma preconnected.connected_component_eq_univ {X : Type*} [topological_space X]
+@[simp] lemma preconnected_space.connected_component_eq_univ {X : Type*} [topological_space X]
   [h : preconnected_space X] (x : X) : connected_component x = univ :=
 preconnected_space_iff_connected_component.mp h x
 

--- a/src/topology/path_connected.lean
+++ b/src/topology/path_connected.lean
@@ -884,6 +884,13 @@ begin
   exact (by simpa using hx : path_component x = univ) ▸ path_component_subset_component x
 end
 
+lemma is_path_connected.is_connected (hF : is_path_connected F) : is_connected F :=
+begin
+  rw is_connected_iff_connected_space,
+  rw is_path_connected_iff_path_connected_space at hF,
+  exact @path_connected_space.connected_space _ _ hF
+end
+
 namespace path_connected_space
 variables [path_connected_space X]
 


### PR DESCRIPTION
From sphere-eversion

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
