### PR TITLE
[Merged by Bors] - [Merged by Bors] - feat(field_theory/adjoin): `intermediate_field.to_subalgebra` distributes over supremum

### DIFF
--- a/src/field_theory/adjoin.lean
+++ b/src/field_theory/adjoin.lean
@@ -786,7 +786,7 @@ begin
   exact is_integral_sup.mpr ⟨h1, h2⟩,
 end
 
-end finite_dimensional_sup
+end supremum
 
 end intermediate_field
 

--- a/src/field_theory/adjoin.lean
+++ b/src/field_theory/adjoin.lean
@@ -757,6 +757,33 @@ end
 
 end alg_hom_mk_adjoin_splits
 
+section finite_dimensional_sup
+
+lemma intermediate_field.sup_to_subalgebra {K L : Type*} [field K] [field L] [algebra K L]
+  (E1 E2 : intermediate_field K L) [h1 : finite_dimensional K E1] [h2 : finite_dimensional K E2] :
+  (E1 ⊔ E2).to_subalgebra = E1.to_subalgebra ⊔ E2.to_subalgebra :=
+begin
+  let S1 := E1.to_subalgebra,
+  let S2 := E2.to_subalgebra,
+  refine le_antisymm (show _ ≤ (S1 ⊔ S2).to_intermediate_field _, from
+    (sup_le (show S1 ≤ _, from le_sup_left) (show S2 ≤ _, from le_sup_right)))
+    (sup_le (show E1 ≤ _, from le_sup_left) (show E2 ≤ E1 ⊔ E2, from le_sup_right)),
+  suffices : is_field ↥(S1 ⊔ S2),
+  { intros x hx,
+    by_cases hx' : (⟨x, hx⟩ : S1 ⊔ S2) = 0,
+    { rw [←subtype.coe_mk x hx, hx', subalgebra.coe_zero, inv_zero],
+      exact (S1 ⊔ S2).zero_mem },
+    { obtain ⟨y, h⟩ := this.mul_inv_cancel hx',
+      exact (congr_arg (∈ S1 ⊔ S2) (eq_inv_of_mul_right_eq_one (subtype.ext_iff.mp h))).mp y.2 } },
+  refine is_field_of_is_integral_of_is_field' _ (field.to_is_field K),
+  have h1 : algebra.is_algebraic K E1 := algebra.is_algebraic_of_finite,
+  have h2 : algebra.is_algebraic K E2 := algebra.is_algebraic_of_finite,
+  rw is_algebraic_iff_is_integral' at h1 h2,
+  exact is_integral_sup.mpr ⟨h1, h2⟩,
+end
+
+end finite_dimensional_sup
+
 end intermediate_field
 
 section power_basis

--- a/src/field_theory/adjoin.lean
+++ b/src/field_theory/adjoin.lean
@@ -759,15 +759,19 @@ end alg_hom_mk_adjoin_splits
 
 section finite_dimensional_sup
 
+lemma le_sup_to_subalgebra {K L : Type*} [field K] [field L] [algebra K L]
+  (E1 E2 : intermediate_field K L) :
+  E1.to_subalgebra ⊔ E2.to_subalgebra ≤ (E1 ⊔ E2).to_subalgebra :=
+sup_le (show E1 ≤ E1 ⊔ E2, from le_sup_left) (show E2 ≤ E1 ⊔ E2, from le_sup_right)
+
 lemma sup_to_subalgebra {K L : Type*} [field K] [field L] [algebra K L]
   (E1 E2 : intermediate_field K L) [h1 : finite_dimensional K E1] [h2 : finite_dimensional K E2] :
   (E1 ⊔ E2).to_subalgebra = E1.to_subalgebra ⊔ E2.to_subalgebra :=
 begin
   let S1 := E1.to_subalgebra,
   let S2 := E2.to_subalgebra,
-  refine le_antisymm (show _ ≤ (S1 ⊔ S2).to_intermediate_field _, from
-    (sup_le (show S1 ≤ _, from le_sup_left) (show S2 ≤ _, from le_sup_right)))
-    (sup_le (show E1 ≤ _, from le_sup_left) (show E2 ≤ E1 ⊔ E2, from le_sup_right)),
+  refine le_antisymm (show _ ≤ (S1 ⊔ S2).to_intermediate_field _, from (sup_le (show S1 ≤ _,
+    from le_sup_left) (show S2 ≤ _, from le_sup_right))) (le_sup_to_subalgebra E1 E2),
   suffices : is_field ↥(S1 ⊔ S2),
   { intros x hx,
     by_cases hx' : (⟨x, hx⟩ : S1 ⊔ S2) = 0,

--- a/src/field_theory/adjoin.lean
+++ b/src/field_theory/adjoin.lean
@@ -759,7 +759,7 @@ end alg_hom_mk_adjoin_splits
 
 section finite_dimensional_sup
 
-lemma intermediate_field.sup_to_subalgebra {K L : Type*} [field K] [field L] [algebra K L]
+lemma sup_to_subalgebra {K L : Type*} [field K] [field L] [algebra K L]
   (E1 E2 : intermediate_field K L) [h1 : finite_dimensional K E1] [h2 : finite_dimensional K E2] :
   (E1 ⊔ E2).to_subalgebra = E1.to_subalgebra ⊔ E2.to_subalgebra :=
 begin

--- a/src/field_theory/adjoin.lean
+++ b/src/field_theory/adjoin.lean
@@ -757,7 +757,7 @@ end
 
 end alg_hom_mk_adjoin_splits
 
-section finite_dimensional_sup
+section supremum
 
 lemma le_sup_to_subalgebra {K L : Type*} [field K] [field L] [algebra K L]
   (E1 E2 : intermediate_field K L) :

--- a/src/ring_theory/integral_closure.lean
+++ b/src/ring_theory/integral_closure.lean
@@ -373,6 +373,10 @@ lemma le_integral_closure_iff_is_integral {S : subalgebra R A} :
 set_like.forall.symm.trans (forall_congr (λ x, show is_integral R (algebra_map S A x)
   ↔ is_integral R x, from is_integral_algebra_map_iff subtype.coe_injective))
 
+lemma is_integral_sup {S T : subalgebra R A} :
+  algebra.is_integral R ↥(S ⊔ T) ↔ algebra.is_integral R S ∧ algebra.is_integral R T :=
+by simp only [←le_integral_closure_iff_is_integral, sup_le_iff]
+
 /-- Mapping an integral closure along an `alg_equiv` gives the integral closure. -/
 lemma integral_closure_map_alg_equiv (f : A ≃ₐ[R] B) :
   (integral_closure R A).map (f : A →ₐ[R] B) = integral_closure R B :=


### PR DESCRIPTION
This PR proves `(E1 ⊔ E2).to_subalgebra = E1.to_subalgebra ⊔ E2.to_subalgebra`, under the assumption that `E1` and `E2` are finite-dimensional over `F`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
