### PR TITLE
[Merged by Bors] - feat(algebra/associated): add lemmas to split #9345

### DIFF
--- a/src/algebra/associated.lean
+++ b/src/algebra/associated.lean
@@ -750,7 +750,7 @@ begin
   exact hp (or.resolve_right ((irreducible_iff.1 hcontra).right p x hx') hx),
 end
 
-lemma not_unit_of_dvd_not_unit [cancel_comm_monoid_with_zero α] {p q : α}
+lemma dvd_not_unit.not_unit [cancel_comm_monoid_with_zero α] {p q : α}
   (hp : dvd_not_unit p q) : ¬ is_unit q :=
 begin
   obtain ⟨h, x, hx⟩ := hp,

--- a/src/algebra/associated.lean
+++ b/src/algebra/associated.lean
@@ -742,7 +742,7 @@ end associates
 
 section cancel_comm_monoid_with_zero
 
-lemma not_prime_of_not_unit_dvd_not_unit [cancel_comm_monoid_with_zero α] {p q : α}
+lemma not_irreducible_of_not_unit_dvd_not_unit [cancel_comm_monoid_with_zero α] {p q : α}
   (hp : ¬is_unit p) (h : dvd_not_unit p q) : ¬ irreducible q :=
 begin
   by_contra hcontra,
@@ -794,18 +794,9 @@ begin
   { use x * ↑(u⁻¹),
     split,
     { suffices : dvd_not_unit ↑u⁻¹ (x * ↑u⁻¹),
-      { exact not_unit_of_dvd_not_unit this },
+      { exact dvd_not_unit.not_unit this },
       exact ⟨(units.is_unit u⁻¹).ne_zero, by { use x, exact ⟨hx.left, mul_comm x ↑u⁻¹⟩, } ⟩ },
     { rw [← mul_assoc, ← hx.right, mul_assoc, units.mul_inv, mul_one] } },
-end
-
-theorem ne_zero_of_dvd_ne_zero [cancel_comm_monoid_with_zero α] {p q : α} (h₁ : q ≠ 0)
-  (h₂ : p ∣ q) : p ≠ 0 :=
-begin
-  by_contra hcontra,
-  obtain ⟨u, hu⟩ := h₂,
-  apply h₁,
-  simp only [hcontra, hu, zero_mul],
 end
 
 lemma dvd_not_unit.ne [cancel_comm_monoid_with_zero α] {p q : α}
@@ -830,7 +821,7 @@ begin
     { exact this (lt_of_not_ge h') } },
 
   intros n m h,
-  apply ne_of_dvd_not_unit,
+  apply dvd_not_unit.ne,
   split,
   { exact pow_ne_zero n hq' },
   { use q^(m - n),

--- a/src/algebra/associated.lean
+++ b/src/algebra/associated.lean
@@ -794,23 +794,9 @@ end
 lemma pow_injective_of_not_unit [cancel_comm_monoid_with_zero α] {q : α}
   (hq : ¬ is_unit q) (hq' : q ≠ 0): function.injective (λ (n : ℕ), q^n) :=
 begin
-  suffices : ∀ {n m : ℕ}, n < m → q^n ≠ q^m,
-  { intros n m,
-    contrapose!,
-    intro h,
-    by_cases h' : m ≤ n,
-    { exact (this (lt_of_le_of_ne h' h.symm)).symm },
-    { exact this (lt_of_not_ge h') } },
-
-  intros n m h,
-  apply dvd_not_unit.ne,
-  split,
-  { exact pow_ne_zero n hq' },
-  { use q^(m - n),
-  split,
-  { exact not_is_unit_of_not_is_unit_dvd hq
-      (dvd_pow (dvd_refl _) (ne_of_lt (nat.sub_pos_of_lt h)).symm) },
-  { exact (pow_mul_pow_sub q (le_of_lt h)).symm  } },
+  refine injective_of_lt_imp_ne (λ n m h, dvd_not_unit.ne ⟨pow_ne_zero n hq', q^(m - n), _, _⟩),
+  { exact not_is_unit_of_not_is_unit_dvd hq (dvd_pow (dvd_refl _) (nat.sub_pos_of_lt h).ne') },
+  { exact (pow_mul_pow_sub q h.le).symm  }
 end
 
 end cancel_comm_monoid_with_zero

--- a/src/algebra/associated.lean
+++ b/src/algebra/associated.lean
@@ -771,7 +771,7 @@ begin
   apply is_unit_of_mul_eq_one b ↑a (mul_left_cancel₀ hp ha)
 end
 
-lemma not_associated_of_dvd_not_unit [cancel_comm_monoid_with_zero α] {p q : α}
+lemma dvd_not_unit.not_associated [cancel_comm_monoid_with_zero α] {p q : α}
   (h : dvd_not_unit p q) : ¬ associated p q :=
 begin
   by_contra hcontra,

--- a/src/algebra/associated.lean
+++ b/src/algebra/associated.lean
@@ -775,16 +775,10 @@ end
 lemma dvd_not_unit_of_dvd_not_unit_associated [cancel_comm_monoid_with_zero α]
 [nontrivial α] {p q r : α} (h : dvd_not_unit p q) (h' : associated q r) : dvd_not_unit p r :=
 begin
-  obtain ⟨hp, x, hx⟩ := h,
   obtain ⟨u, rfl⟩ := associated.symm h',
-  split,
-  { exact hp },
-  { use x * ↑(u⁻¹),
-    split,
-    { suffices : dvd_not_unit ↑u⁻¹ (x * ↑u⁻¹),
-      { exact dvd_not_unit.not_unit this },
-      exact ⟨(units.is_unit u⁻¹).ne_zero, by { use x, exact ⟨hx.left, mul_comm x ↑u⁻¹⟩, } ⟩ },
-    { rw [← mul_assoc, ← hx.right, mul_assoc, units.mul_inv, mul_one] } },
+  obtain ⟨hp, x, hx⟩ := h,
+  refine ⟨hp, x * ↑(u⁻¹), dvd_not_unit.not_unit ⟨u⁻¹.ne_zero, x, hx.left, mul_comm _ _⟩, _⟩,
+  rw [← mul_assoc, ← hx.right, mul_assoc, units.mul_inv, mul_one]
 end
 
 lemma dvd_not_unit.ne [cancel_comm_monoid_with_zero α] {p q : α}

--- a/src/algebra/associated.lean
+++ b/src/algebra/associated.lean
@@ -470,7 +470,7 @@ instance : preorder (associates α) :=
   le_refl := dvd_refl,
   le_trans := λ a b c, dvd_trans}
 
-lemma bot_eq_one [monoid_with_zero α] :
+lemma bot_eq_one :
   (⊥ : associates α) = 1 := rfl
 
 @[simp] lemma mk_one : associates.mk (1 : α) = 1 := rfl
@@ -734,8 +734,7 @@ theorem dvd_not_unit_iff_lt {a b : associates α} :
   dvd_not_unit a b ↔ a < b :=
 dvd_and_not_dvd_iff.symm
 
-lemma le_one_iff [cancel_comm_monoid_with_zero α]
-  {p : associates α} : p ≤ 1 ↔ p = 1 :=
+lemma le_one_iff {p : associates α} : p ≤ 1 ↔ p = 1 :=
 by rw [← associates.bot_eq_one, le_bot_iff]
 
 end cancel_comm_monoid_with_zero
@@ -820,7 +819,7 @@ begin
   exact hx' is_unit_one,
 end
 
-lemma pow_inj_of_not_unit {M : Type*} [cancel_comm_monoid_with_zero α] {q : α}
+lemma pow_inj_of_not_unit [cancel_comm_monoid_with_zero α] {q : α}
   (hq : ¬ is_unit q) (hq' : q ≠ 0): function.injective (λ (n : ℕ), q^n) :=
 begin
   suffices : ∀ {n m : ℕ}, n < m → q^n ≠ q^m,
@@ -841,6 +840,5 @@ begin
       (dvd_pow (dvd_refl _) (ne_of_lt (nat.sub_pos_of_lt h)).symm) },
   { exact (pow_mul_pow_sub q (le_of_lt h)).symm  } },
 end
-
 
 end cancel_comm_monoid_with_zero

--- a/src/algebra/associated.lean
+++ b/src/algebra/associated.lean
@@ -808,7 +808,7 @@ begin
   simp only [hcontra, hu, zero_mul],
 end
 
-lemma ne_of_dvd_not_unit [cancel_comm_monoid_with_zero α] {p q : α}
+lemma dvd_not_unit.ne [cancel_comm_monoid_with_zero α] {p q : α}
   (h : dvd_not_unit p q) : p ≠ q :=
 begin
   by_contra hcontra,

--- a/src/algebra/associated.lean
+++ b/src/algebra/associated.lean
@@ -734,13 +734,16 @@ end associates
 
 section cancel_comm_monoid_with_zero
 
+lemma dvd_not_unit.is_unit_of_irreducible_right [cancel_comm_monoid_with_zero α] {p q : α}
+  (h : dvd_not_unit p q) (hq : irreducible q) : is_unit p :=
+begin
+  obtain ⟨hp', x, hx, hx'⟩ := h,
+  exact or.resolve_right ((irreducible_iff.1 hq).right p x hx') hx
+end
+
 lemma not_irreducible_of_not_unit_dvd_not_unit [cancel_comm_monoid_with_zero α] {p q : α}
   (hp : ¬is_unit p) (h : dvd_not_unit p q) : ¬ irreducible q :=
-begin
-  by_contra hcontra,
-  obtain ⟨hp', x, hx, hx'⟩ := h,
-  exact hp (or.resolve_right ((irreducible_iff.1 hcontra).right p x hx') hx),
-end
+mt h.is_unit_of_irreducible_right hp
 
 lemma dvd_not_unit.not_unit [cancel_comm_monoid_with_zero α] {p q : α}
   (hp : dvd_not_unit p q) : ¬ is_unit q :=

--- a/src/algebra/associated.lean
+++ b/src/algebra/associated.lean
@@ -517,11 +517,7 @@ calc is_unit (associates.mk a) ↔ a ~ᵤ 1 :
   ... ↔ is_unit a : associated_one_iff_is_unit
 
 lemma mk_injective [unique (units α)] : function.injective (@associates.mk α _) :=
-begin
-  intros a b h,
-  rw [associates.mk_eq_mk_iff_associated, associated_iff_eq] at h,
-  exact h
-end
+λ a b h, associated_iff_eq.mp (associates.mk_eq_mk_iff_associated.mp h)
 
 section order
 

--- a/src/algebra/associated.lean
+++ b/src/algebra/associated.lean
@@ -228,10 +228,6 @@ iff.intro
   (assume h, let ⟨c, h⟩ := h.symm in h ▸ ⟨c, (one_mul _).symm⟩)
   (assume ⟨c, h⟩, associated.symm ⟨c, by simp [h]⟩)
 
-lemma is_unit_of_associated_is_unit [monoid α] {p q : α}
-  (h : associated p q) (hp : is_unit p) : is_unit q :=
-by { obtain ⟨a, rfl⟩:= h, exact is_unit.mul hp (units.is_unit a) }
-
 theorem associated_zero_iff_eq_zero [monoid_with_zero α] (a : α) : a ~ᵤ 0 ↔ a = 0 :=
 iff.intro
   (assume h, let ⟨u, h⟩ := h.symm in by simpa using h.symm)

--- a/src/algebra/associated.lean
+++ b/src/algebra/associated.lean
@@ -834,12 +834,12 @@ begin
   intros n m h,
   apply ne_of_dvd_not_unit,
   split,
-  exact pow_ne_zero n hq',
-  use q^(m - n),
+  { exact pow_ne_zero n hq' },
+  { use q^(m - n),
   split,
-  exact not_is_unit_of_not_is_unit_dvd hq
-    (dvd_pow (dvd_refl _) (ne_of_lt (nat.sub_pos_of_lt h)).symm),
-  exact (pow_mul_pow_sub q (le_of_lt h)).symm,
+  { exact not_is_unit_of_not_is_unit_dvd hq
+      (dvd_pow (dvd_refl _) (ne_of_lt (nat.sub_pos_of_lt h)).symm) },
+  { exact (pow_mul_pow_sub q (le_of_lt h)).symm  } },
 end
 
 

--- a/src/algebra/associated.lean
+++ b/src/algebra/associated.lean
@@ -756,11 +756,9 @@ end
 lemma is_unit_of_associated_mul [cancel_comm_monoid_with_zero α]
   {p b : α} (h : associated (p * b) p) (hp : p ≠ 0) : is_unit b :=
 begin
-  rw associated at h,
-  obtain ⟨a, ha⟩ := h,
-  conv_rhs at ha {rw ← mul_one p},
-  rw mul_assoc at ha,
-  apply is_unit_of_mul_eq_one b ↑a (mul_left_cancel₀ hp ha)
+  cases h with a ha,
+  refine is_unit_of_mul_eq_one b a ((mul_right_inj' hp).mp _),
+  rwa [← mul_assoc, mul_one],
 end
 
 lemma dvd_not_unit.not_associated [cancel_comm_monoid_with_zero α] {p q : α}

--- a/src/algebra/associated.lean
+++ b/src/algebra/associated.lean
@@ -818,7 +818,7 @@ begin
   exact hx' is_unit_one,
 end
 
-lemma pow_inj_of_not_unit [cancel_comm_monoid_with_zero α] {q : α}
+lemma pow_injective_of_not_unit [cancel_comm_monoid_with_zero α] {q : α}
   (hq : ¬ is_unit q) (hq' : q ≠ 0): function.injective (λ (n : ℕ), q^n) :=
 begin
   suffices : ∀ {n m : ℕ}, n < m → q^n ≠ q^m,

--- a/src/algebra/associated.lean
+++ b/src/algebra/associated.lean
@@ -780,7 +780,7 @@ lemma dvd_not_unit.ne [cancel_comm_monoid_with_zero α] {p q : α}
 begin
   by_contra hcontra,
   obtain ⟨hp, x, hx', hx''⟩ := h,
-  conv_lhs at hx'' {rw [← hcontra,← mul_one p]},
+  conv_lhs at hx'' {rw [← hcontra, ← mul_one p]},
   rw (mul_left_cancel₀ hp hx'').symm at hx',
   exact hx' is_unit_one,
 end

--- a/src/algebra/associated.lean
+++ b/src/algebra/associated.lean
@@ -766,14 +766,10 @@ end
 lemma dvd_not_unit.not_associated [cancel_comm_monoid_with_zero α] {p q : α}
   (h : dvd_not_unit p q) : ¬ associated p q :=
 begin
-  by_contra hcontra,
-  rw dvd_not_unit at h,
+  rintro ⟨a, rfl⟩,
   obtain ⟨hp, x, hx, hx'⟩ := h,
-  apply hx,
-  obtain ⟨a, rfl⟩ := hcontra,
-  rw mul_eq_mul_left_iff at hx',
-  rw ← or.resolve_right hx' hp,
-  exact units.is_unit a,
+  rcases (mul_right_inj' hp).mp hx' with rfl,
+  exact hx a.is_unit,
 end
 
 lemma dvd_not_unit_of_dvd_not_unit_associated [cancel_comm_monoid_with_zero α]

--- a/src/algebra/associated.lean
+++ b/src/algebra/associated.lean
@@ -749,12 +749,8 @@ end
 lemma dvd_not_unit.not_unit [cancel_comm_monoid_with_zero α] {p q : α}
   (hp : dvd_not_unit p q) : ¬ is_unit q :=
 begin
-  obtain ⟨h, x, hx⟩ := hp,
-  by_contra hcontra,
-  apply hx.left,
-  rw is_unit_iff_dvd_one at hcontra,
-  rw is_unit_iff_dvd_one,
-  exact dvd_trans (show x ∣ q, from by {use p, rw mul_comm, exact hx.right}) hcontra,
+  obtain ⟨-, x, hx, rfl⟩ := hp,
+  exact λ hc, hx (is_unit_iff_dvd_one.mpr (dvd_of_mul_left_dvd (is_unit_iff_dvd_one.mp hc))),
 end
 
 lemma is_unit_of_associated_mul [cancel_comm_monoid_with_zero α]

--- a/src/algebra/associated.lean
+++ b/src/algebra/associated.lean
@@ -470,8 +470,7 @@ instance : preorder (associates α) :=
   le_refl := dvd_refl,
   le_trans := λ a b c, dvd_trans}
 
-lemma bot_eq_one :
-  (⊥ : associates α) = 1 := rfl
+lemma bot_eq_one : (⊥ : associates α) = 1 := rfl
 
 @[simp] lemma mk_one : associates.mk (1 : α) = 1 := rfl
 

--- a/src/algebra/divisibility.lean
+++ b/src/algebra/divisibility.lean
@@ -265,3 +265,18 @@ begin
 end
 
 end comm_monoid_with_zero
+
+section monoid_with_zero
+
+variable [monoid_with_zero α]
+
+theorem ne_zero_of_dvd_ne_zero {p q : α} (h₁ : q ≠ 0)
+  (h₂ : p ∣ q) : p ≠ 0 :=
+begin
+  by_contra hcontra,
+  obtain ⟨u, hu⟩ := h₂,
+  apply h₁,
+  simp only [hcontra, hu, zero_mul],
+end
+
+end monoid_with_zero

--- a/src/algebra/divisibility.lean
+++ b/src/algebra/divisibility.lean
@@ -273,10 +273,8 @@ variable [monoid_with_zero α]
 theorem ne_zero_of_dvd_ne_zero {p q : α} (h₁ : q ≠ 0)
   (h₂ : p ∣ q) : p ≠ 0 :=
 begin
-  by_contra hcontra,
-  obtain ⟨u, hu⟩ := h₂,
-  apply h₁,
-  simp only [hcontra, hu, zero_mul],
+  rcases h₂ with ⟨u, rfl⟩,
+  exact left_ne_zero_of_mul h₁,
 end
 
 end monoid_with_zero


### PR DESCRIPTION
This PR contains lemmas from PR [#9345](https://github.com/leanprover-community/mathlib/pull/9345), which was starting to get quite lengthy. 

Co-authored-by: Anne Baanen.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
