### PR TITLE
[Merged by Bors] - feat(order/galois_connection, linear_algebra/basic): `x ∈ R ∙ y` is a transitive relation

### DIFF
--- a/src/linear_algebra/basic.lean
+++ b/src/linear_algebra/basic.lean
@@ -945,6 +945,11 @@ begin
   exact smul_mem (span R s) r (subset_span hx),
 end
 
+lemma subset_span_trans {U V W : set M} (hUV : U ⊆ submodule.span R V)
+  (hVW : V ⊆ submodule.span R W) :
+  U ⊆ submodule.span R W :=
+(submodule.gi R M).gc.le_u_l_trans hUV hVW
+
 /-- See `submodule.span_smul_eq` (in `ring_theory.ideal.operations`) for
 `span R (r • s) = r • span R s` that holds for arbitrary `r` in a `comm_semiring`. -/
 lemma span_smul_eq_of_is_unit (s : set M) (r : R) (hr : is_unit r) :
@@ -1104,6 +1109,13 @@ lemma disjoint_span_singleton' {K E : Type*} [division_ring K] [add_comm_group E
   {p : submodule K E} {x : E} (x0 : x ≠ 0) :
   disjoint p (K ∙ x) ↔ x ∉ p :=
 disjoint_span_singleton.trans ⟨λ h₁ h₂, x0 (h₁ h₂), λ h₁ h₂, (h₁ h₂).elim⟩
+
+lemma mem_span_singleton_trans {x y z : M} (hxy : x ∈ R ∙ y) (hyz : y ∈ R ∙ z) :
+  x ∈ R ∙ z :=
+begin
+  rw [← set_like.mem_coe, ← singleton_subset_iff] at *,
+  exact submodule.subset_span_trans hxy hyz
+end
 
 lemma mem_span_insert {y} : x ∈ span R (insert y s) ↔ ∃ (a:R) (z ∈ span R s), x = a • y + z :=
 begin

--- a/src/order/galois_connection.lean
+++ b/src/order/galois_connection.lean
@@ -119,6 +119,18 @@ lemma is_glb_l {a : α} : is_glb {b | a ≤ u b} (l a) := gc.is_least_l.is_glb
 
 lemma is_lub_u {b : β} : is_lub { a | l a ≤ b } (u b) := gc.is_greatest_u.is_lub
 
+/-- If `(l, u)` is a Galois connection, then the relation `x ≤ u (l y)` is a transitive relation.
+If `l` is a closure operator (`submodule.span`, `subgroup.closure`, ...) and `u` is the coercion to
+`set`, this reads as "if `U` is in the closure of `V` and `V` is in the closure of `W` then `U` is
+in the closure of `W`". -/
+lemma le_u_l_trans {x y z : α} (hxy : x ≤ u (l y)) (hyz : y ≤ u (l z)) :
+  x ≤ u (l z) :=
+hxy.trans (gc.monotone_u $ gc.l_le hyz)
+
+lemma l_u_le_trans {x y z : β} (hxy : l (u x) ≤ y) (hyz : l (u y) ≤ z) :
+  l (u x) ≤ z :=
+(gc.monotone_l $ gc.le_u hxy).trans hyz
+
 end
 
 section partial_order


### PR DESCRIPTION

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

Maybe I'm being a bit over-specific here, but I used this in the Sphere Eversion project and thought it deserved its own lemma.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
