### PR TITLE
[Merged by Bors] - [Merged by Bors] - feat(ring_theory/finiteness): prove that a surjective endomorphism of a finite module over a comm ring is injective

### DIFF
--- a/src/ring_theory/finiteness.lean
+++ b/src/ring_theory/finiteness.lean
@@ -930,8 +930,18 @@ noncomputable theory
 /-- The structure of a module `M` over a ring `R` as a module over `polynomial R` when given a
 choice of how `X` acts by choosing a linear map `f : M →ₗ[R] M` -/
 @[simps]
-def module_polynomial_ring_endo : module (polynomial R) M :=
+def module_polynomial_of_endo : module (polynomial R) M :=
 module.comp_hom M (polynomial.aeval f).to_ring_hom
+
+include f
+lemma module_polynomial_of_endo.is_scalar_tower : @is_scalar_tower R (polynomial R) M _
+  (by { letI := module_polynomial_of_endo f, apply_instance }) _ :=
+begin
+  letI := module_polynomial_of_endo f,
+  constructor,
+  intros x y z,
+  simp,
+end
 
 open polynomial module
 
@@ -944,7 +954,9 @@ commutative case, but does not use a Noetherian hypothesis. -/
 theorem module.finite.injective_of_surjective_endomorphism [hfg : finite R M]
   (f_surj : function.surjective f) : function.injective f :=
 begin
-  letI := module_polynomial_ring_endo f,
+  letI := module_polynomial_of_endo f,
+  haveI : is_scalar_tower R (polynomial R) M := module_polynomial_of_endo.is_scalar_tower f,
+  have hfgpoly : finite (polynomial R) M, from finite.of_restrict_scalars_finite R _ _,
   have X_mul : ∀ o, (X : polynomial R) • o = f o,
   { intro,
     simp, },
@@ -953,8 +965,6 @@ begin
     obtain ⟨y, rfl⟩ := f_surj a,
     rw [← X_mul y],
     exact submodule.smul_mem_smul (ideal.mem_span_singleton.mpr (dvd_refl _)) trivial, },
-  haveI : is_scalar_tower R (polynomial R) M := ⟨λ x y z, by simp⟩,
-  have hfgpoly : finite (polynomial R) M, from finite.of_restrict_scalars_finite R _ _,
   obtain ⟨F, hFa, hFb⟩ := submodule.exists_sub_one_mem_and_smul_eq_zero_of_fg_of_le_smul _
     (⊤ : submodule (polynomial R) M) (finite_def.mp hfgpoly) this,
   rw [← linear_map.ker_eq_bot, linear_map.ker_eq_bot'],
@@ -966,4 +976,5 @@ begin
     rwa [← sub_add_cancel F 1, add_smul, one_smul, this, zero_add] at Fmzero, },
   rw [← hG, mul_smul, X_mul m, hm, smul_zero],
 end
+
 end vasconcelos

--- a/src/ring_theory/finiteness.lean
+++ b/src/ring_theory/finiteness.lean
@@ -941,8 +941,8 @@ https://math.stackexchange.com/a/239419/31917,
 https://www.ams.org/journals/tran/1969-138-00/S0002-9947-1969-0238839-5/.
 This is similar to `is_noetherian.injective_of_surjective_endomorphism` but only applies in the
 commutative case, but does not use a Noetherian hypothesis. -/
-theorem fg_comm_mod_surj_inj [hfg : finite R M] (f_surj : function.surjective f) :
-  function.injective f :=
+theorem module.finite.injective_of_surjective_endomorphism [hfg : finite R M]
+  (f_surj : function.surjective f) : function.injective f :=
 begin
   letI := module_polynomial_ring_endo f,
   have X_mul : ∀ o, (X : polynomial R) • o = f o,

--- a/src/ring_theory/finiteness.lean
+++ b/src/ring_theory/finiteness.lean
@@ -921,3 +921,49 @@ by simpa [group.fg_iff_monoid.fg] using finite_type_iff_fg
 end monoid_algebra
 
 end monoid_algebra
+
+section vasconcelos
+variables {R : Type*} [comm_ring R] {M : Type*} [add_comm_group M] [module R M] (f : M →ₗ[R] M)
+
+noncomputable theory
+
+/-- The structure of a module `M` over a ring `R` as a module over `polynomial R` when given a
+choice of how `X` acts by choosing a linear map `f : M →ₗ[R] M` -/
+@[simps]
+def module_polynomial_ring_endo : module (polynomial R) M :=
+module.comp_hom M (polynomial.aeval f).to_ring_hom
+
+open polynomial module
+
+/-- A theorem/proof by Vasconcelos, given a finite module `M` over a commutative ring, any
+surjective endomorphism of `M` is also injective. Based on,
+https://math.stackexchange.com/a/239419/31917,
+https://www.ams.org/journals/tran/1969-138-00/S0002-9947-1969-0238839-5/.
+This is similar to `is_noetherian.injective_of_surjective_endomorphism` but only applies in the
+commutative case, but does not use a Noetherian hypothesis. -/
+theorem fg_comm_mod_surj_inj [hfg : finite R M] (f_surj : function.surjective f) :
+  function.injective f :=
+begin
+  letI := module_polynomial_ring_endo f,
+  have X_mul : ∀ o, (X : polynomial R) • o = f o,
+  { intro,
+    simp, },
+  have : (⊤ : submodule (polynomial R) M) ≤ ideal.span {X} • ⊤,
+  { intros a ha,
+    obtain ⟨y, rfl⟩ := f_surj a,
+    rw [← X_mul y],
+    exact submodule.smul_mem_smul (ideal.mem_span_singleton.mpr (dvd_refl _)) trivial, },
+  haveI : is_scalar_tower R (polynomial R) M := ⟨λ x y z, by simp⟩,
+  have hfgpoly : finite (polynomial R) M, from finite.of_restrict_scalars_finite R _ _,
+  obtain ⟨F, hFa, hFb⟩ := submodule.exists_sub_one_mem_and_smul_eq_zero_of_fg_of_le_smul _
+    (⊤ : submodule (polynomial R) M) (finite_def.mp hfgpoly) this,
+  rw [← linear_map.ker_eq_bot, linear_map.ker_eq_bot'],
+  intros m hm,
+  rw ideal.mem_span_singleton' at hFa,
+  obtain ⟨G, hG⟩ := hFa,
+  suffices : (F - 1) • m = 0,
+  { have Fmzero := hFb m (by simp),
+    rwa [← sub_add_cancel F 1, add_smul, one_smul, this, zero_add] at Fmzero, },
+  rw [← hG, mul_smul, X_mul m, hm, smul_zero],
+end
+end vasconcelos


### PR DESCRIPTION
Using an approach of Vasconcelos, treating the module as a module over the polynomial ring, with action induced by the endomorphism.

This result was rescued from #1822.

---

I'm not sure of the best location for `module_polynomial_ring_endo` / whether we want more lemmata for it, I only needed the autognerated simp lemams

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
