### PR TITLE
[Merged by Bors] - chore(data/nat/digits): Eliminate `finish`

### DIFF
--- a/src/data/nat/digits.lean
+++ b/src/data/nat/digits.lean
@@ -294,7 +294,7 @@ private lemma digits_last_aux {b n : ℕ} (h : 2 ≤ b) (w : 0 < n) :
   digits b n = ((n % b) :: digits b (n / b)) :=
 begin
   rcases b with _|_|b,
-  { rw digits_zero_succ' w, simp },
+  { rw [digits_zero_succ' w, nat.mod_zero, nat.div_zero, nat.digits_zero_zero] },
   { norm_num at h },
   rcases n with _|n,
   { norm_num at w },

--- a/src/data/nat/digits.lean
+++ b/src/data/nat/digits.lean
@@ -294,7 +294,8 @@ private lemma digits_last_aux {b n : ℕ} (h : 2 ≤ b) (w : 0 < n) :
   digits b n = ((n % b) :: digits b (n / b)) :=
 begin
   rcases b with _|_|b,
-  { finish },
+  { simp only [nat.nat_zero_eq_zero, nat.mod_zero, nat.digits_zero_zero, nat.div_zero],
+    exact digits_zero_succ' w },
   { norm_num at h },
   rcases n with _|n,
   { norm_num at w },

--- a/src/data/nat/digits.lean
+++ b/src/data/nat/digits.lean
@@ -322,8 +322,8 @@ lemma last_digit_ne_zero (b : ℕ) {m : ℕ} (hm : m ≠ 0) :
   (digits b m).last (digits_ne_nil_iff_ne_zero.mpr hm) ≠ 0 :=
 begin
   rcases b with _|_|b,
-  { cases m, { refine absurd hm _, simp }, { simp } },
-  { cases m, { refine absurd hm _, simp },
+  { cases m, cases hm (rfl), simp },
+  { cases m, cases hm (rfl),
     simp_rw [digits_one, list.last_repeat_succ 1 m],
     norm_num },
   revert hm,
@@ -338,7 +338,7 @@ begin
     { rw ←pos_iff_ne_zero,
       exact nat.div_pos (le_of_not_lt hnb) dec_trivial } },
 end
-#exit
+
 /-- The digits in the base b+2 expansion of n are all less than b+2 -/
 lemma digits_lt_base' {b m : ℕ} : ∀ {d}, d ∈ digits (b+2) m → d < b+2 :=
 begin

--- a/src/data/nat/digits.lean
+++ b/src/data/nat/digits.lean
@@ -294,8 +294,7 @@ private lemma digits_last_aux {b n : ℕ} (h : 2 ≤ b) (w : 0 < n) :
   digits b n = ((n % b) :: digits b (n / b)) :=
 begin
   rcases b with _|_|b,
-  { simp only [nat.nat_zero_eq_zero, nat.mod_zero, nat.digits_zero_zero, nat.div_zero],
-    exact digits_zero_succ' w },
+  { rw digits_zero_succ' w, simp },
   { norm_num at h },
   rcases n with _|n,
   { norm_num at w },

--- a/src/data/nat/digits.lean
+++ b/src/data/nat/digits.lean
@@ -322,8 +322,8 @@ lemma last_digit_ne_zero (b : ℕ) {m : ℕ} (hm : m ≠ 0) :
   (digits b m).last (digits_ne_nil_iff_ne_zero.mpr hm) ≠ 0 :=
 begin
   rcases b with _|_|b,
-  { cases m; finish },
-  { cases m, { finish },
+  { cases m, { refine absurd hm _, simp }, { simp } },
+  { cases m, { refine absurd hm _, simp },
     simp_rw [digits_one, list.last_repeat_succ 1 m],
     norm_num },
   revert hm,
@@ -338,7 +338,7 @@ begin
     { rw ←pos_iff_ne_zero,
       exact nat.div_pos (le_of_not_lt hnb) dec_trivial } },
 end
-
+#exit
 /-- The digits in the base b+2 expansion of n are all less than b+2 -/
 lemma digits_lt_base' {b m : ℕ} : ∀ {d}, d ∈ digits (b+2) m → d < b+2 :=
 begin

--- a/src/data/nat/digits.lean
+++ b/src/data/nat/digits.lean
@@ -324,7 +324,7 @@ begin
   { cases m,
     { cases hm rfl },
     { simp } },
-  { cases m, cases hm rfl,
+  { cases m, { cases hm rfl },
     simp_rw [digits_one, list.last_repeat_succ 1 m],
     norm_num },
   revert hm,

--- a/src/data/nat/digits.lean
+++ b/src/data/nat/digits.lean
@@ -321,7 +321,9 @@ lemma last_digit_ne_zero (b : ℕ) {m : ℕ} (hm : m ≠ 0) :
   (digits b m).last (digits_ne_nil_iff_ne_zero.mpr hm) ≠ 0 :=
 begin
   rcases b with _|_|b,
-  { cases m, cases hm rfl, simp },
+  { cases m,
+    { cases hm rfl },
+    { simp } },
   { cases m, cases hm rfl,
     simp_rw [digits_one, list.last_repeat_succ 1 m],
     norm_num },

--- a/src/data/nat/digits.lean
+++ b/src/data/nat/digits.lean
@@ -321,8 +321,8 @@ lemma last_digit_ne_zero (b : ℕ) {m : ℕ} (hm : m ≠ 0) :
   (digits b m).last (digits_ne_nil_iff_ne_zero.mpr hm) ≠ 0 :=
 begin
   rcases b with _|_|b,
-  { cases m, cases hm (rfl), simp },
-  { cases m, cases hm (rfl),
+  { cases m, cases hm rfl, simp },
+  { cases m, cases hm rfl,
     simp_rw [digits_one, list.last_repeat_succ 1 m],
     norm_num },
   revert hm,


### PR DESCRIPTION
Removing uses of finish, as discussed in this Zulip thread (https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/mathlib.20sat.20solvers)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
