### PR TITLE
[Merged by Bors] - chore(data/matrix/block): Eliminate `finish`

### DIFF
--- a/src/data/matrix/block.lean
+++ b/src/data/matrix/block.lean
@@ -265,7 +265,11 @@ by { ext, simp [block_diagonal_apply] }
 begin
   ext ⟨i, k⟩ ⟨j, k'⟩,
   simp only [block_diagonal_apply, diagonal],
-  split_ifs; finish
+  split_ifs; -- `finish` can close these goals
+  try { refl }; exfalso; rw prod.mk.inj_iff at *; try { subst h, subst h_1 },
+  { exact not_and.mp h_2 rfl rfl },
+  { exact not_and_of_not_left _ h_1 h_2 },
+  { exact not_and_of_not_right _ h h_1 },
 end
 
 @[simp] lemma block_diagonal_one [decidable_eq m] [has_one α] :
@@ -387,7 +391,11 @@ by { ext, simp [block_diagonal'_apply] }
 begin
   ext ⟨i, k⟩ ⟨j, k'⟩,
   simp only [block_diagonal'_apply, diagonal],
-  split_ifs; finish
+  split_ifs; -- `finish` can close these goals
+  try { refl }; exfalso,
+  { apply h_2, simp only at h, subst h, rw [cast_eq] at h_1, simp [h_1] },
+  { apply h_1, cases h_2, subst h_2_left, rw [heq_iff_eq.mp h_2_right, cast_eq] },
+  { simp_rw h_1.1 at h, exact h rfl },
 end
 
 @[simp] lemma block_diagonal'_one [∀ i, decidable_eq (m' i)] [has_one α] :

--- a/src/data/matrix/block.lean
+++ b/src/data/matrix/block.lean
@@ -264,12 +264,9 @@ by { ext, simp [block_diagonal_apply] }
   block_diagonal (λ k, diagonal (d k)) = diagonal (λ ik, d ik.2 ik.1) :=
 begin
   ext ⟨i, k⟩ ⟨j, k'⟩,
-  simp only [block_diagonal_apply, diagonal],
-  split_ifs; -- `finish` can close these goals
-  try { refl }; exfalso; rw prod.mk.inj_iff at *; try { subst h, subst h_1 },
-  { exact not_and.mp h_2 rfl rfl },
-  { exact not_and_of_not_left _ h_1 h_2 },
-  { exact not_and_of_not_right _ h h_1 },
+  simp only [block_diagonal_apply, diagonal, prod.mk.inj_iff, ← ite_and],
+  congr' 1,
+  rw and_comm,
 end
 
 @[simp] lemma block_diagonal_one [decidable_eq m] [has_one α] :

--- a/src/data/matrix/block.lean
+++ b/src/data/matrix/block.lean
@@ -390,9 +390,9 @@ begin
   simp only [block_diagonal'_apply, diagonal],
   split_ifs; -- `finish` can close these goals
   try { refl }; exfalso,
-  { apply h_2, simp only at h, subst h, rw [cast_eq] at h_1, simp [h_1] },
-  { apply h_1, cases h_2, subst h_2_left, rw [heq_iff_eq.mp h_2_right, cast_eq] },
-  { simp_rw h_1.1 at h, exact h rfl },
+  { exact h_2 ⟨h, (cast_eq_iff_heq.mp h_1.symm).symm⟩ },
+  { exact h_1 (cast_eq_iff_heq.mpr h_2.right.symm).symm },
+  { tauto },
 end
 
 @[simp] lemma block_diagonal'_one [∀ i, decidable_eq (m' i)] [has_one α] :


### PR DESCRIPTION
Removing uses of finish, as discussed in this Zulip thread (https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/mathlib.20sat.20solvers)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
