### PR TITLE
[Merged by Bors] - chore(group_theory/group_action/defs): add instances to copy statements about left actions to right actions when the two are equal

### DIFF
--- a/src/group_theory/group_action/defs.lean
+++ b/src/group_theory/group_action/defs.lean
@@ -195,6 +195,32 @@ mul_opposite.rec (by exact λ m, (is_central_scalar.op_smul_eq_smul _ _).symm) m
 
 export is_central_scalar (op_smul_eq_smul unop_smul_eq_smul)
 
+-- these instances are very low priority, as there is usually a faster way to find these instances
+
+@[priority 50]
+instance smul_comm_class.op_left [has_scalar M α] [has_scalar Mᵐᵒᵖ α]
+  [is_central_scalar M α] [has_scalar N α] [smul_comm_class M N α] : smul_comm_class Mᵐᵒᵖ N α :=
+⟨λ m n a, by rw [←unop_smul_eq_smul m (n • a), ←unop_smul_eq_smul m a, smul_comm]⟩
+
+@[priority 50]
+instance smul_comm_class.op_right [has_scalar M α] [has_scalar N α] [has_scalar Nᵐᵒᵖ α]
+  [is_central_scalar N α] [smul_comm_class M N α] : smul_comm_class M Nᵐᵒᵖ α :=
+⟨λ m n a, by rw [←unop_smul_eq_smul n (m • a), ←unop_smul_eq_smul n a, smul_comm]⟩
+
+@[priority 50]
+instance is_scalar_tower.op_left
+  [has_scalar M α] [has_scalar Mᵐᵒᵖ α] [is_central_scalar M α]
+  [has_scalar M N] [has_scalar Mᵐᵒᵖ N] [is_central_scalar M N]
+  [has_scalar N α] [is_scalar_tower M N α] : is_scalar_tower Mᵐᵒᵖ N α :=
+⟨λ m n a, by rw [←unop_smul_eq_smul m (n • a), ←unop_smul_eq_smul m n, smul_assoc]⟩
+
+@[priority 50]
+instance is_scalar_tower.op_right [has_scalar M α] [has_scalar M N]
+  [has_scalar N α] [has_scalar Nᵐᵒᵖ α] [is_central_scalar N α]
+  [is_scalar_tower M N α] : is_scalar_tower M Nᵐᵒᵖ α :=
+⟨λ m n a, by rw [←unop_smul_eq_smul n a, ←unop_smul_eq_smul (m • n) a, mul_opposite.unop_smul,
+                 smul_assoc]⟩
+
 namespace has_scalar
 variables [has_scalar M α]
 

--- a/src/group_theory/group_action/defs.lean
+++ b/src/group_theory/group_action/defs.lean
@@ -222,11 +222,12 @@ instance is_scalar_tower.op_right [has_scalar M α] [has_scalar M N]
                  smul_assoc]⟩
 
 namespace has_scalar
+variables [has_scalar M α]
 
 /-- Auxiliary definition for `has_scalar.comp`, `mul_action.comp_hom`,
 `distrib_mul_action.comp_hom`, `module.comp_hom`, etc. -/
 @[simp, to_additive  /-" Auxiliary definition for `has_vadd.comp`, `add_action.comp_hom`, etc. "-/]
-def comp.smul [has_scalar M α] (g : N → M) (n : N) (a : α) : α :=
+def comp.smul (g : N → M) (n : N) (a : α) : α :=
 g n • a
 
 variables (α)
@@ -237,7 +238,7 @@ See note [reducible non-instances]. Since this is reducible, we make sure to go 
 `has_scalar.comp.smul` to prevent typeclass inference unfolding too far. -/
 @[reducible, to_additive /-" An additive action of `M` on `α` and a function `N → M` induces
   an additive action of `N` on `α` "-/]
-def comp [has_scalar M α] (g : N → M) : has_scalar N α :=
+def comp (g : N → M) : has_scalar N α :=
 { smul := has_scalar.comp.smul g }
 
 variables {α}
@@ -245,23 +246,31 @@ variables {α}
 /-- Given a tower of scalar actions `M → α → β`, if we use `has_scalar.comp`
 to pull back both of `M`'s actions by a map `g : N → M`, then we obtain a new
 tower of scalar actions `N → α → β`.
+
+This cannot be an instance because it can cause infinite loops whenever the `has_scalar` arguments
+are still metavariables.
 -/
 @[priority 100]
-instance comp.is_scalar_tower {_ : has_scalar M α} {_ : has_scalar M β}
-  [has_scalar α β] [is_scalar_tower M α β]
+lemma comp.is_scalar_tower [has_scalar M β] [has_scalar α β] [is_scalar_tower M α β]
   (g : N → M) :
   (by haveI := comp α g; haveI := comp β g; exact is_scalar_tower N α β) :=
 by exact {smul_assoc := λ n, @smul_assoc _ _ _ _ _ _ _ (g n) }
 
+/--
+This cannot be an instance because it can cause infinite loops whenever the `has_scalar` arguments
+are still metavariables.
+-/
 @[priority 100]
-instance comp.smul_comm_class  {_ : has_scalar M α} {_ : has_scalar M β}
-  [has_scalar β α] [smul_comm_class M β α] (g : N → M) :
+lemma comp.smul_comm_class [has_scalar β α] [smul_comm_class M β α] (g : N → M) :
   (by haveI := comp α g; exact smul_comm_class N β α) :=
 by exact {smul_comm := λ n, @smul_comm _ _ _ _ _ _ (g n) }
 
+/--
+This cannot be an instance because it can cause infinite loops whenever the `has_scalar` arguments
+are still metavariables.
+-/
 @[priority 100]
-instance comp.smul_comm_class' {_ : has_scalar M α} {_ : has_scalar M β}
-  [has_scalar β α] [smul_comm_class β M α] (g : N → M) :
+lemma comp.smul_comm_class' [has_scalar β α] [smul_comm_class β M α] (g : N → M) :
   (by haveI := comp α g; exact smul_comm_class β N α) :=
 by exact {smul_comm := λ _ n, @smul_comm _ _ _ _ _ _ _ (g n) }
 

--- a/src/group_theory/group_action/defs.lean
+++ b/src/group_theory/group_action/defs.lean
@@ -222,12 +222,11 @@ instance is_scalar_tower.op_right [has_scalar M α] [has_scalar M N]
                  smul_assoc]⟩
 
 namespace has_scalar
-variables [has_scalar M α]
 
 /-- Auxiliary definition for `has_scalar.comp`, `mul_action.comp_hom`,
 `distrib_mul_action.comp_hom`, `module.comp_hom`, etc. -/
 @[simp, to_additive  /-" Auxiliary definition for `has_vadd.comp`, `add_action.comp_hom`, etc. "-/]
-def comp.smul (g : N → M) (n : N) (a : α) : α :=
+def comp.smul [has_scalar M α] (g : N → M) (n : N) (a : α) : α :=
 g n • a
 
 variables (α)
@@ -238,7 +237,7 @@ See note [reducible non-instances]. Since this is reducible, we make sure to go 
 `has_scalar.comp.smul` to prevent typeclass inference unfolding too far. -/
 @[reducible, to_additive /-" An additive action of `M` on `α` and a function `N → M` induces
   an additive action of `N` on `α` "-/]
-def comp (g : N → M) : has_scalar N α :=
+def comp [has_scalar M α] (g : N → M) : has_scalar N α :=
 { smul := has_scalar.comp.smul g }
 
 variables {α}
@@ -246,31 +245,23 @@ variables {α}
 /-- Given a tower of scalar actions `M → α → β`, if we use `has_scalar.comp`
 to pull back both of `M`'s actions by a map `g : N → M`, then we obtain a new
 tower of scalar actions `N → α → β`.
-
-This cannot be an instance because it can cause infinite loops whenever the `has_scalar` arguments
-are still metavariables.
 -/
 @[priority 100]
-lemma comp.is_scalar_tower [has_scalar M β] [has_scalar α β] [is_scalar_tower M α β]
+instance comp.is_scalar_tower {_ : has_scalar M α} {_ : has_scalar M β}
+  [has_scalar α β] [is_scalar_tower M α β]
   (g : N → M) :
   (by haveI := comp α g; haveI := comp β g; exact is_scalar_tower N α β) :=
 by exact {smul_assoc := λ n, @smul_assoc _ _ _ _ _ _ _ (g n) }
 
-/--
-This cannot be an instance because it can cause infinite loops whenever the `has_scalar` arguments
-are still metavariables.
--/
 @[priority 100]
-lemma comp.smul_comm_class [has_scalar β α] [smul_comm_class M β α] (g : N → M) :
+instance comp.smul_comm_class  {_ : has_scalar M α} {_ : has_scalar M β}
+  [has_scalar β α] [smul_comm_class M β α] (g : N → M) :
   (by haveI := comp α g; exact smul_comm_class N β α) :=
 by exact {smul_comm := λ n, @smul_comm _ _ _ _ _ _ (g n) }
 
-/--
-This cannot be an instance because it can cause infinite loops whenever the `has_scalar` arguments
-are still metavariables.
--/
 @[priority 100]
-lemma comp.smul_comm_class' [has_scalar β α] [smul_comm_class β M α] (g : N → M) :
+instance comp.smul_comm_class' {_ : has_scalar M α} {_ : has_scalar M β}
+  [has_scalar β α] [smul_comm_class β M α] (g : N → M) :
   (by haveI := comp α g; exact smul_comm_class β N α) :=
 by exact {smul_comm := λ _ n, @smul_comm _ _ _ _ _ _ _ (g n) }
 

--- a/src/group_theory/group_action/defs.lean
+++ b/src/group_theory/group_action/defs.lean
@@ -256,13 +256,21 @@ lemma comp.is_scalar_tower [has_scalar M β] [has_scalar α β] [is_scalar_tower
   (by haveI := comp α g; haveI := comp β g; exact is_scalar_tower N α β) :=
 by exact {smul_assoc := λ n, @smul_assoc _ _ _ _ _ _ _ (g n) }
 
+/--
+This cannot be an instance because it can cause infinite loops whenever the `has_scalar` arguments
+are still metavariables.
+-/
 @[priority 100]
-instance comp.smul_comm_class [has_scalar β α] [smul_comm_class M β α] (g : N → M) :
+lemma comp.smul_comm_class [has_scalar β α] [smul_comm_class M β α] (g : N → M) :
   (by haveI := comp α g; exact smul_comm_class N β α) :=
 by exact {smul_comm := λ n, @smul_comm _ _ _ _ _ _ (g n) }
 
+/--
+This cannot be an instance because it can cause infinite loops whenever the `has_scalar` arguments
+are still metavariables.
+-/
 @[priority 100]
-instance comp.smul_comm_class' [has_scalar β α] [smul_comm_class β M α] (g : N → M) :
+lemma comp.smul_comm_class' [has_scalar β α] [smul_comm_class β M α] (g : N → M) :
   (by haveI := comp α g; exact smul_comm_class β N α) :=
 by exact {smul_comm := λ _ n, @smul_comm _ _ _ _ _ _ _ (g n) }
 


### PR DESCRIPTION
While these instances are usually available elsewhere, these shortcuts can reduce the number of typeclass assumptions other lemmas needs.
Since the instances carry no data, the only harm they can cause is performance.

There were some typeclass loops brought on by some bad instance unification, similar to the ones removed by @Vierkantor in 9ee2a50aa439d092c8dea16c1f82f7f8e1f1ea2c. We turn these into `lemma`s and  duplicate the docstring explaining the problem. That commit has a much longer explanation of the problem.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
