### PR TITLE
[Merged by Bors] - refactor(ring_theory/derivation): use weaker TC assumptions

### DIFF
--- a/src/geometry/manifold/algebra/left_invariant_derivation.lean
+++ b/src/geometry/manifold/algebra/left_invariant_derivation.lean
@@ -78,8 +78,8 @@ lemma coe_derivation_injective : function.injective
 
 /-- Premature version of the lemma. Prefer using `left_invariant` instead. -/
 lemma left_invariant' :
-  𝒅ₕ(smooth_left_mul_one I g) (derivation.eval_at (1 : G) ↑X) = derivation.eval_at g ↑X :=
-by rw [←to_derivation_eq_coe]; exact left_invariant'' X g
+  𝒅ₕ (smooth_left_mul_one I g) (derivation.eval_at (1 : G) ↑X) = derivation.eval_at g ↑X :=
+left_invariant'' X g
 
 @[simp] lemma map_add : X (f + f') = X f + X f' := derivation.map_add X f f'
 @[simp] lemma map_zero : X 0 = 0 := derivation.map_zero X
@@ -98,12 +98,10 @@ instance : has_add (left_invariant_derivation I G) :=
     left_invariant', pi.add_apply]⟩ }
 
 instance : has_neg (left_invariant_derivation I G) :=
-{ neg := λ X, ⟨-X, λ g, by simp only [linear_map.map_neg, derivation.coe_neg, left_invariant',
-    pi.neg_apply]⟩ }
+{ neg := λ X, ⟨-X, λ g, by simp [left_invariant']⟩ }
 
 instance : has_sub (left_invariant_derivation I G) :=
-{ sub := λ X Y, ⟨X - Y, λ g, by simp only [linear_map.map_sub, derivation.coe_sub,
-    left_invariant', pi.sub_apply]⟩ }
+{ sub := λ X Y, ⟨X - Y, λ g, by simp [left_invariant']⟩ }
 
 @[simp] lemma coe_add : ⇑(X + Y) = X + Y := rfl
 @[simp] lemma coe_zero : ⇑(0 : left_invariant_derivation I G) = 0 := rfl
@@ -118,7 +116,7 @@ instance : add_comm_group (left_invariant_derivation I G) :=
 coe_injective.add_comm_group _ coe_zero coe_add coe_neg coe_sub
 
 instance : has_scalar 𝕜 (left_invariant_derivation I G) :=
-{ smul := λ r X, ⟨r • X, λ g, by simp only [derivation.Rsmul_apply, algebra.id.smul_eq_mul,
+{ smul := λ r X, ⟨r • X, λ g, by simp only [derivation.smul_apply, smul_eq_mul,
             mul_eq_mul_left_iff, linear_map.map_smul, left_invariant']⟩ }
 
 variables (r X)

--- a/src/geometry/manifold/derivation_bundle.lean
+++ b/src/geometry/manifold/derivation_bundle.lean
@@ -104,13 +104,13 @@ differential takes `h : f x = y`. It is particularly handy to deal with situatio
 on where it has to be evaluated are equal but not definitionally equal. -/
 def hfdifferential {f : C^∞⟮I, M; I', M'⟯} {x : M} {y : M'} (h : f x = y) :
   point_derivation I x →ₗ[𝕜] point_derivation I' y :=
-{ to_fun := λ v, { to_linear_map :=
+{ to_fun := λ v, derivation.mk'
     { to_fun := λ g, v (g.comp f),
       map_add' := λ g g', by rw [smooth_map.add_comp, derivation.map_add],
       map_smul' := λ k g,
-        by simp only [smooth_map.smul_comp, derivation.map_smul, ring_hom.id_apply], },
-    leibniz' := λ g g', by simp only [derivation.leibniz, smooth_map.mul_comp,
-      pointed_smooth_map.smul_def, times_cont_mdiff_map.comp_apply, h] },
+        by simp only [smooth_map.smul_comp, derivation.map_smul, ring_hom.id_apply], }
+    (λ g g', by simp only [derivation.leibniz, smooth_map.mul_comp, linear_map.coe_mk,
+      pointed_smooth_map.smul_def, times_cont_mdiff_map.comp_apply, h]),
   map_smul' := λ k v, rfl,
   map_add' := λ v w, rfl }
 

--- a/src/ring_theory/derivation.lean
+++ b/src/ring_theory/derivation.lean
@@ -28,7 +28,7 @@ open algebra
 
 /-- `D : derivation R A M` is an `R`-linear map from `A` to `M` that satisfies the `leibniz`
 equality. We also require that `D 1 = 0`. See `derivation.mk'` for a constructor that deduces this
-assumption from the Leibniz rule.
+assumption from the Leibniz rule when `M` is cancellative.
 
 TODO: update this when bimodules are defined. -/
 @[protect_proj]

--- a/src/ring_theory/derivation.lean
+++ b/src/ring_theory/derivation.lean
@@ -213,7 +213,8 @@ section cancel
 variables {R : Type*} [comm_semiring R] {A : Type*} [comm_semiring A] [algebra R A]
   {M : Type*} [add_cancel_comm_monoid M] [module R M] [module A M] [is_scalar_tower R A M]
 
-/-- Define `derivation R A M` from a linear map by verifying the Leibniz rule. -/
+/-- Define `derivation R A M` from a linear map when `M` is cancellative by verifying the Leibniz
+rule. -/
 def mk' (D : A →ₗ[R] M) (h : ∀ a b, D (a * b) = a • D b + b • D a) : derivation R A M :=
 { to_linear_map := D,
   map_one_eq_zero' := add_right_eq_self.1 $ by simpa only [one_smul, one_mul] using (h 1 1).symm,

--- a/src/ring_theory/derivation.lean
+++ b/src/ring_theory/derivation.lean
@@ -27,14 +27,17 @@ definitive definition of derivation will be implemented.
 open algebra
 
 /-- `D : derivation R A M` is an `R`-linear map from `A` to `M` that satisfies the `leibniz`
-equality.
+equality. We also require that `D 1 = 0`. See `derivation.mk'` for a constructor that deduces this
+assumption from the Leibniz rule.
+
 TODO: update this when bimodules are defined. -/
 @[protect_proj]
 structure derivation (R : Type*) (A : Type*) [comm_semiring R] [comm_semiring A]
-  [algebra R A] (M : Type*) [add_cancel_comm_monoid M] [module A M] [module R M]
+  [algebra R A] (M : Type*) [add_comm_monoid M] [module A M] [module R M]
   [is_scalar_tower R A M]
   extends A →ₗ[R] M :=
-(leibniz' (a b : A) : to_fun (a * b) = a • to_fun b + b • to_fun a)
+(map_one_eq_zero' : to_linear_map 1 = 0)
+(leibniz' (a b : A) : to_linear_map (a * b) = a • to_linear_map b + b • to_linear_map a)
 
 /-- The `linear_map` underlying a `derivation`. -/
 add_decl_doc derivation.to_linear_map
@@ -45,7 +48,7 @@ section
 
 variables {R : Type*} [comm_semiring R]
 variables {A : Type*} [comm_semiring A] [algebra R A]
-variables {M : Type*} [add_cancel_comm_monoid M] [module A M] [module R M]
+variables {M : Type*} [add_comm_monoid M] [module A M] [module R M]
 variables [is_scalar_tower R A M]
 variables (D : derivation R A M) {D1 D2 : derivation R A M} (r : R) (a b : A)
 
@@ -66,8 +69,8 @@ instance has_coe_to_linear_map : has_coe (derivation R A M) (A →ₗ[R] M) :=
 
 @[simp] lemma to_linear_map_eq_coe : D.to_linear_map = D := rfl
 
-@[simp] lemma mk_coe (f : A →ₗ[R] M) (h) :
-  ((⟨f, h⟩ : derivation R A M) : A → M) = f := rfl
+@[simp] lemma mk_coe (f : A →ₗ[R] M) (h₁ h₂) :
+  ((⟨f, h₁, h₂⟩ : derivation R A M) : A → M) = f := rfl
 
 @[simp, norm_cast]
 lemma coe_fn_coe (f : derivation R A M) : ⇑(f : A →ₗ[R] M) = f := rfl
@@ -85,11 +88,7 @@ protected lemma map_zero : D 0 = 0 := map_zero D
 @[simp] lemma map_smul : D (r • a) = r • D a := D.to_linear_map.map_smul r a
 @[simp] lemma leibniz : D (a * b) = a • D b + b • D a := D.leibniz' _ _
 
-@[simp] lemma map_one_eq_zero : D 1 = 0 :=
-begin
-  have h : D 1 = D (1 * 1) := by rw mul_one,
-  rwa [leibniz D 1 1, one_smul, self_eq_add_right] at h
-end
+@[simp] lemma map_one_eq_zero : D 1 = 0 := D.map_one_eq_zero'
 
 @[simp] lemma map_algebra_map : D (algebra_map R A r) = 0 :=
 by rw [←mul_one r, ring_hom.map_mul, ring_hom.map_one, ←smul_def, map_smul, map_one_eq_zero,
@@ -120,43 +119,25 @@ ext $ λ a, eq_on_adjoin h $ hs.symm ▸ trivial
 /- Data typeclasses -/
 
 instance : has_zero (derivation R A M) :=
-⟨{ leibniz' := λ a b, by simp only [add_zero, linear_map.zero_apply, linear_map.to_fun_eq_coe,
-     smul_zero],
-   ..(0 : A →ₗ[R] M) }⟩
+⟨{ to_linear_map := 0,
+   map_one_eq_zero' := rfl,
+   leibniz' := λ a b, by simp only [add_zero, linear_map.zero_apply, smul_zero] }⟩
 
 @[simp] lemma coe_zero : ⇑(0 : derivation R A M) = 0 := rfl
 @[simp] lemma coe_zero_linear_map : ↑(0 : derivation R A M) = (0 : A →ₗ[R] M) := rfl
 lemma zero_apply (a : A) : (0 : derivation R A M) a = 0 := rfl
 
 instance : has_add (derivation R A M) :=
-⟨λ D1 D2, { leibniz' := λ a b, by simp only [leibniz, linear_map.add_apply,
-              linear_map.to_fun_eq_coe, coe_fn_coe, smul_add, add_add_add_comm],
-            ..(D1 + D2 : A →ₗ[R] M) }⟩
+⟨λ D1 D2,
+  { to_linear_map := D1 + D2,
+    map_one_eq_zero' := by simp,
+    leibniz' := λ a b, by simp only [leibniz, linear_map.add_apply,
+      coe_fn_coe, smul_add, add_add_add_comm] }⟩
 
 @[simp] lemma coe_add (D1 D2 : derivation R A M) : ⇑(D1 + D2) = D1 + D2 := rfl
 @[simp] lemma coe_add_linear_map (D1 D2 : derivation R A M) : ↑(D1 + D2) = (D1 + D2 : A →ₗ[R] M) :=
 rfl
 lemma add_apply : (D1 + D2) a = D1 a + D2 a := rfl
-
-instance Rscalar : has_scalar R (derivation R A M) :=
-⟨λ r D, { leibniz' := λ a b, by simp only [linear_map.smul_apply, leibniz,
-            linear_map.to_fun_eq_coe, smul_algebra_smul_comm, coe_fn_coe, smul_add, add_comm],
-          ..(r • D : A →ₗ[R] M) }⟩
-
-@[simp] lemma coe_Rsmul (r : R) (D : derivation R A M) : ⇑(r • D) = r • D := rfl
-@[simp] lemma coe_Rsmul_linear_map (r : R) (D : derivation R A M) :
-  ↑(r • D) = (r • D : A →ₗ[R] M) := rfl
-lemma Rsmul_apply (r : R) (D : derivation R A M) : (r • D) a = r • D a := rfl
-
-instance has_scalar : has_scalar A (derivation R A M) :=
-⟨λ a D, { leibniz' := λ b c, by
-          { dsimp, simp only [smul_add, leibniz, smul_comm a, add_comm] },
-          ..(a • D : A →ₗ[R] M) }⟩
-
-@[simp] lemma coe_smul (a : A) (D : derivation R A M) : ⇑(a • D) = a • D := rfl
-@[simp] lemma coe_smul_linear_map (a : A) (D : derivation R A M) :
-  ↑(a • D) = (a • D : A →ₗ[R] M) := rfl
-lemma smul_apply (a : A) (D : derivation R A M) (b : A) : (a • D) b = a • D b := rfl
 
 instance : inhabited (derivation R A M) := ⟨0⟩
 
@@ -167,29 +148,51 @@ coe_injective.add_comm_monoid _ coe_zero coe_add
 def coe_fn_add_monoid_hom : derivation R A M →+ (A → M) :=
 { to_fun := coe_fn, map_zero' := coe_zero, map_add' := coe_add }
 
-@[priority 100]
-instance derivation.Rmodule : module R (derivation R A M) :=
-function.injective.module R coe_fn_add_monoid_hom coe_injective coe_Rsmul
+section scalar
 
-instance : module A (derivation R A M) :=
-function.injective.module A coe_fn_add_monoid_hom coe_injective coe_smul
+variables {S : Type*} [monoid S] [distrib_mul_action S M] [smul_comm_class R S M]
+  [smul_comm_class S A M]
+
+@[priority 100]
+instance : has_scalar S (derivation R A M) :=
+⟨λ r D,
+  { to_linear_map := r • D,
+    map_one_eq_zero' := by rw [linear_map.smul_apply, coe_fn_coe, D.map_one_eq_zero, smul_zero],
+    leibniz' := λ a b, by simp only [linear_map.smul_apply, coe_fn_coe, leibniz, smul_add,
+      smul_comm r] }⟩
+
+@[simp] lemma coe_smul (r : S) (D : derivation R A M) : ⇑(r • D) = r • D := rfl
+@[simp] lemma coe_smul_linear_map (r : S) (D : derivation R A M) :
+  ↑(r • D) = (r • D : A →ₗ[R] M) := rfl
+lemma smul_apply (r : S) (D : derivation R A M) : (r • D) a = r • D a := rfl
+
+@[priority 100]
+instance : distrib_mul_action S (derivation R A M) :=
+function.injective.distrib_mul_action coe_fn_add_monoid_hom coe_injective coe_smul
+
+end scalar
+
+@[priority 100]
+instance {S : Type*} [semiring S] [module S M] [smul_comm_class R S M] [smul_comm_class S A M] :
+  module S (derivation R A M) :=
+function.injective.module S coe_fn_add_monoid_hom coe_injective coe_smul
 
 instance : is_scalar_tower R A (derivation R A M) :=
 ⟨λ x y z, ext (λ a, smul_assoc _ _ _)⟩
 
 section push_forward
 
-variables {N : Type*} [add_cancel_comm_monoid N] [module A N] [module R N] [is_scalar_tower R A N]
+variables {N : Type*} [add_comm_monoid N] [module A N] [module R N] [is_scalar_tower R A N]
 variables (f : M →ₗ[A] N)
 
 /-- We can push forward derivations using linear maps, i.e., the composition of a derivation with a
 linear map is a derivation. Furthermore, this operation is linear on the spaces of derivations. -/
 def _root_.linear_map.comp_der : derivation R A M →ₗ[R] derivation R A N :=
 { to_fun    := λ D,
-  { leibniz'  := λ a b, by simp only [coe_fn_coe, function.comp_app, linear_map.coe_comp,
-                      linear_map.map_add, leibniz, linear_map.coe_coe_is_scalar_tower,
-                      linear_map.map_smul, linear_map.to_fun_eq_coe],
-    .. (f : M →ₗ[R] N).comp (D : A →ₗ[R] M), },
+  { to_linear_map := (f : M →ₗ[R] N).comp (D : A →ₗ[R] M),
+    map_one_eq_zero' := by simp only [linear_map.comp_apply, coe_fn_coe, map_one_eq_zero, map_zero],
+    leibniz'  := λ a b, by simp only [coe_fn_coe, linear_map.comp_apply, linear_map.map_add,
+      leibniz, linear_map.coe_coe_is_scalar_tower, linear_map.map_smul] },
   map_add'  := λ D₁ D₂, by { ext, exact linear_map.map_add _ _ _, },
   map_smul' := λ r D, by { ext, exact linear_map.map_smul _ _ _, }, }
 
@@ -204,6 +207,22 @@ rfl
 end push_forward
 
 end
+
+section cancel
+
+variables {R : Type*} [comm_semiring R] {A : Type*} [comm_semiring A] [algebra R A]
+  {M : Type*} [add_cancel_comm_monoid M] [module R M] [module A M] [is_scalar_tower R A M]
+
+/-- Define `derivation R A M` from a linear map by verifying the Leibniz rule. -/
+def mk' (D : A →ₗ[R] M) (h : ∀ a b, D (a * b) = a • D b + b • D a) : derivation R A M :=
+{ to_linear_map := D,
+  map_one_eq_zero' := add_right_eq_self.1 $ by simpa only [one_smul, one_mul] using (h 1 1).symm,
+  leibniz' := h }
+
+@[simp] lemma coe_mk' (D : A →ₗ[R] M) (h) : ⇑(mk' D h) = D := rfl
+@[simp] lemma coe_mk'_linear_map (D : A →ₗ[R] M) (h) : (mk' D h : A →ₗ[R] M) = D := rfl
+
+end cancel
 
 section
 
@@ -239,9 +258,8 @@ begin
 end
 
 instance : has_neg (derivation R A M) :=
-⟨λ D, { leibniz' := λ a b, by simp only [linear_map.neg_apply, smul_neg, neg_add_rev, leibniz,
-          linear_map.to_fun_eq_coe, coe_fn_coe, add_comm],
-        ..(-D : A →ₗ[R] M)}⟩
+⟨λ D, mk' (-D) $  λ a b,
+  by simp only [linear_map.neg_apply, smul_neg, neg_add_rev, leibniz, coe_fn_coe, add_comm]⟩
 
 @[simp] lemma coe_neg (D : derivation R A M) : ⇑(-D) = -D := rfl
 @[simp] lemma coe_neg_linear_map (D : derivation R A M) : ↑(-D) = (-D : A →ₗ[R] M) :=
@@ -249,9 +267,8 @@ rfl
 lemma neg_apply : (-D) a = -D a := rfl
 
 instance : has_sub (derivation R A M) :=
-⟨λ D1 D2, { leibniz' := λ a b, by { simp only [linear_map.to_fun_eq_coe, linear_map.sub_apply,
-              leibniz, coe_fn_coe, smul_sub], abel },
-            ..(D1 - D2 : A →ₗ[R] M)}⟩
+⟨λ D1 D2, mk' (D1 - D2 : A →ₗ[R] M) $ λ a b,
+  by simp only [linear_map.sub_apply, leibniz, coe_fn_coe, smul_sub, add_sub_comm]⟩
 
 @[simp] lemma coe_sub (D1 D2 : derivation R A M) : ⇑(D1 - D2) = D1 - D2 := rfl
 @[simp] lemma coe_sub_linear_map (D1 D2 : derivation R A M) : ↑(D1 - D2) = (D1 - D2 : A →ₗ[R] M) :=
@@ -271,10 +288,9 @@ variables (D : derivation R A A) {D1 D2 : derivation R A A} (r : R) (a b : A)
 
 /-- The commutator of derivations is again a derivation. -/
 instance : has_bracket (derivation R A A) (derivation R A A) :=
-⟨λ D1 D2, { leibniz' := λ a b, by
-            { simp only [ring.lie_def, map_add, id.smul_eq_mul, linear_map.mul_apply, leibniz,
-                        linear_map.to_fun_eq_coe, coe_fn_coe, linear_map.sub_apply], ring, },
-            to_linear_map := ⁅(D1 : module.End R A), (D2 : module.End R A)⁆, }⟩
+⟨λ D1 D2, mk' (⁅(D1 : module.End R A), (D2 : module.End R A)⁆) $ λ a b,
+  by { simp only [ring.lie_def, map_add, id.smul_eq_mul, linear_map.mul_apply, leibniz, coe_fn_coe,
+    linear_map.sub_apply], ring, }⟩
 
 @[simp] lemma commutator_coe_linear_map :
   ↑⁅D1, D2⁆ = ⁅(D1 : module.End R A), (D2 : module.End R A)⁆ := rfl
@@ -289,8 +305,8 @@ instance : lie_ring (derivation R A A) :=
     by { ext a, simp only [commutator_apply, add_apply, sub_apply, map_sub], ring, } }
 
 instance : lie_algebra R (derivation R A A) :=
-{ lie_smul := λ r d e, by { ext a, simp only [commutator_apply, map_smul, smul_sub, Rsmul_apply]},
-  ..derivation.Rmodule }
+{ lie_smul := λ r d e, by { ext a, simp only [commutator_apply, map_smul, smul_sub, smul_apply]},
+  ..derivation.module }
 
 end lie_structures
 


### PR DESCRIPTION
Don't assume `[add_cancel_comm_monoid M]`, add `map_one_eq_zero` as an axiom instead. Add a constructor `derivation.mk'` that deduces `map_one_eq_zero` from `leibniz`.

Also generalize `smul`/`module` instances.

---

I tried to turn `mv_polynomial.pderiv` into a `derivation` and failed because `pderiv` doesn't assume `R` to be cancellative.
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
