### PR TITLE
[Merged by Bors] - split(data/psigma/order): Split off `order.lexicographic`

### DIFF
--- a/src/combinatorics/colex.lean
+++ b/src/combinatorics/colex.lean
@@ -31,9 +31,13 @@ fixed size. If the size is 3, colex on ℕ starts
 * `sum_two_pow_le_iff_lt`: colex for α = ℕ is the same as binary
   (this also proves binary expansions are unique)
 
-## Notation
-We define `<` and `≤` to denote colex ordering, useful in particular when
-multiple orderings are available in context.
+## See also
+
+Related files are:
+* `data.list.lex`: Lexicographic order on lists.
+* `data.psigma.order`: Lexicographic order on `Σ' i, α i`.
+* `data.sigma.order`: Lexicographic order on `Σ i, α i`.
+* `order.lexicographic`: Lexicographic order on `α × β`.
 
 ## Tags
 colex, colexicographic, binary

--- a/src/data/list/lex.lean
+++ b/src/data/list/lex.lean
@@ -15,9 +15,11 @@ The lexicographic order on `list α` is defined by `L < M` iff
 
 ## See also
 
-The lexicographic order on a product type can be found in `order.lexicographic`.
-
-The lexicographic order on a sigma type can be found in `data.sigma.lex`.
+Related files are:
+* `data.finset.colex`: Colexicographic order on finite sets.
+* `data.psigma.order`: Lexicographic order on `Σ' i, α i`.
+* `data.sigma.order`: Lexicographic order on `Σ i, α i`.
+* `order.lexicographic`: Lexicographic order on `α × β`.
 -/
 
 namespace list

--- a/src/data/psigma/order.lean
+++ b/src/data/psigma/order.lean
@@ -9,7 +9,11 @@ import order.basic
 /-!
 # Lexicographic order on a sigma type
 
-This file defines the lexicographic order on `Σ' i, α i`.
+This file defines the lexicographic order on `Σ' i, α i` as the default order.
+
+We mark these as instances because the 'pointwise' partial order `prod.has_le` doesn't make sense
+for dependent pairs. However in the future we will want to make the disjoint order the default
+instead, where `x ≤ y` only if `x.fst = y.fst`.
 
 ## See also
 

--- a/src/data/psigma/order.lean
+++ b/src/data/psigma/order.lean
@@ -1,0 +1,92 @@
+/-
+Copyright (c) 2019 Scott Morrison. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Scott Morrison, Minchao Wu
+-/
+import data.sigma.lex
+import order.basic
+
+/-!
+# Lexicographic order on a sigma type
+
+This file defines the lexicographic order on `Σ' i, α i`.
+
+## See also
+
+Related files are:
+* `data.finset.colex`: Colexicographic order on finite sets.
+* `data.list.lex`: Lexicographic order on lists.
+* `data.sigma.order`: Lexicographic order on `Σ i, α i`. Basically a twin of this file.
+* `order.lexicographic`: Lexicographic order on `α × β`.
+-/
+
+variables {ι : Type*} {α : ι → Type*}
+
+namespace psigma
+
+/-- The lexicographical `≤` on a sigma type. -/
+instance lex.has_le [has_lt ι] [Π i, has_le (α i)] : has_le (Σ' i, α i) :=
+{ le := lex (<) (λ i, (≤)) }
+
+/-- The lexicographical `<` on a sigma type. -/
+instance lex.has_lt [has_lt ι] [Π i, has_lt (α i)] : has_lt (Σ' i, α i) :=
+{ lt := lex (<) (λ i, (<)) }
+
+instance lex.preorder [preorder ι] [Π i, preorder (α i)] : preorder (Σ' i, α i) :=
+{ le_refl := λ ⟨i, a⟩, lex.right _ le_rfl,
+  le_trans :=
+  begin
+    rintro ⟨a₁, b₁⟩ ⟨a₂, b₂⟩ ⟨a₃, b₃⟩ ⟨h₁l, h₁r⟩ ⟨h₂l, h₂r⟩,
+    { left, apply lt_trans, repeat { assumption } },
+    { left, assumption },
+    { left, assumption },
+    { right, apply le_trans, repeat { assumption } }
+  end,
+  lt_iff_le_not_le :=
+  begin
+    refine λ a b, ⟨λ hab, ⟨hab.mono_right (λ i a b, le_of_lt), _⟩, _⟩,
+    { rintro (⟨j, i, b, a, hji⟩ | ⟨i, b, a, hba⟩);
+        obtain (⟨_, _, _, _, hij⟩ | ⟨_, _, _, hab⟩) := hab,
+      { exact hij.not_lt hji },
+      { exact lt_irrefl _ hji },
+      { exact lt_irrefl _ hij },
+      { exact hab.not_le hba } },
+    { rintro ⟨⟨i, j, a, b, hij⟩ |⟨i, a, b, hab⟩, hba⟩,
+      { exact lex.left _ _ hij },
+      { exact lex.right _ (hab.lt_of_not_le $ λ h, hba $ lex.right _ h) } }
+  end,
+  .. lex.has_le,
+  .. lex.has_lt }
+
+/-- Dictionary / lexicographic partial_order for dependent pairs. -/
+instance lex.partial_order [partial_order ι] [Π i, partial_order (α i)] :
+  partial_order (Σ' i, α i) :=
+{ le_antisymm :=
+  begin
+    rintro ⟨a₁, b₁⟩ ⟨a₂, b₂⟩
+      (⟨_, _, _, _, hlt₁⟩ | ⟨_, _, _, hlt₁⟩) (⟨_, _, _, _, hlt₂⟩ | ⟨_, _, _, hlt₂⟩),
+    { exact (lt_irrefl a₁ $ hlt₁.trans hlt₂).elim },
+    { exact (lt_irrefl a₁ hlt₁).elim },
+    { exact (lt_irrefl a₁ hlt₂).elim },
+    { rw hlt₁.antisymm hlt₂ }
+  end
+  .. lex.preorder }
+
+/-- Dictionary / lexicographic linear_order for pairs. -/
+instance lex.linear_order [linear_order ι] [Π i, linear_order (α i)] : linear_order (Σ' i, α i) :=
+{ le_total :=
+  begin
+  rintro ⟨i, a⟩ ⟨j, b⟩,
+  obtain hij | rfl | hji := lt_trichotomy i j,
+  { exact or.inl (lex.left _ _ hij) },
+  { obtain hab | hba := le_total a b,
+    { exact or.inl (lex.right _ hab) },
+    { exact or.inr (lex.right _ hba) } },
+  { exact or.inr (lex.left _ _ hji) }
+  end,
+  decidable_eq := psigma.decidable_eq,
+  decidable_le := lex.decidable _ _,
+  decidable_lt := lex.decidable _ _,
+  .. lex.partial_order }
+
+end psigma

--- a/src/data/sigma/lex.lean
+++ b/src/data/sigma/lex.lean
@@ -18,12 +18,13 @@ related by the summand's relation.
 
 ## See also
 
-For the lexicographic order per say, see `data.sigma.order`.
-
-The lexicographic order on lists can be found in `data.list.lex`.
-
-The lexicographic order on a product type (which can be thought of as the special case of
-`sigma.lex` where all summands are the same) and on `psigma` live in `order.lexicographic`.
+Related files are:
+* `data.finset.colex`: Colexicographic order on finite sets.
+* `data.list.lex`: Lexicographic order on lists.
+* `data.sigma.order`: Lexicographic order on `Σ i, α i` per say.
+* `data.psigma.order`: Lexicographic order on `Σ' i, α i`.
+* `order.lexicographic`: Lexicographic order on `α × β`. Can be thought of as the special case of
+  `sigma.lex` where all summands are the same
 -/
 
 namespace sigma

--- a/src/data/sigma/order.lean
+++ b/src/data/sigma/order.lean
@@ -18,11 +18,6 @@ This file defines two orders on a sigma type:
 
 We declare the disjoint sum of orders as the default instances. The lexicographical order can
 override it in local by opening locale `lex`.
-
-## TODO
-
-The lexicographic order on `psigma` currently lives in `order.lexicographic`. Should we bring it
-here?
 -/
 
 namespace sigma

--- a/src/order/lexicographic.lean
+++ b/src/order/lexicographic.lean
@@ -17,8 +17,6 @@ and linear orders.
 * `lex α β`: Synonym of `α × β` to equip it with lexicographic order without creating conflicting
   instances.
 * `lex_<pre/partial_/linear_>order`: Instances lifting the orders on `α` and `β` to `lex α β`
-* `dlex_<pre/partial_/linear_>order`: Instances lifting the orders on every `Z a` to the dependent
-  pair `Z`.
 
 ## See also
 

--- a/src/order/lexicographic.lean
+++ b/src/order/lexicographic.lean
@@ -22,9 +22,11 @@ and linear orders.
 
 ## See also
 
-The lexicographic order on lists is provided in `data.list.lex`.
-
-The lexicographic order on a sigma type is to be found in `data.sigma.lex`.
+Related files are:
+* `data.finset.colex`: Colexicographic order on finite sets.
+* `data.list.lex`: Lexicographic order on lists.
+* `data.psigma.order`: Lexicographic order on `Σ' i, α i`.
+* `data.sigma.order`: Lexicographic order on `Σ i, α i`.
 -/
 
 universes u v
@@ -144,107 +146,3 @@ instance lex_linear_order [linear_order α] [linear_order β] : linear_order (le
       { right, left, apply lt_of_le_of_ne, repeat { assumption } } }
   end,
   .. lex_partial_order }.
-
-variables {Z : α → Type v}
-/--
-Dictionary / lexicographic ordering on dependent pairs.
-
-The 'pointwise' partial order `prod.has_le` doesn't make
-sense for dependent pairs, so it's safe to mark these as
-instances here.
--/
-instance dlex_has_le [preorder α] [∀ a, preorder (Z a)] : has_le (Σ' a, Z a) :=
-{ le := psigma.lex (<) (λ a, (≤)) }
-
-instance dlex_has_lt [preorder α] [∀ a, preorder (Z a)] : has_lt (Σ' a, Z a) :=
-{ lt := psigma.lex (<) (λ a, (<)) }
-
-/-- Dictionary / lexicographic preorder on dependent pairs. -/
-instance dlex_preorder [preorder α] [∀ a, preorder (Z a)] : preorder (Σ' a, Z a) :=
-{ le_refl := λ ⟨l, r⟩, by { right, apply le_refl },
-  le_trans :=
-  begin
-    rintros ⟨a₁, b₁⟩ ⟨a₂, b₂⟩ ⟨a₃, b₃⟩ ⟨h₁l, h₁r⟩ ⟨h₂l, h₂r⟩,
-    { left, apply lt_trans, repeat { assumption } },
-    { left, assumption },
-    { left, assumption },
-    { right, apply le_trans, repeat { assumption } }
-  end,
-  lt_iff_le_not_le :=
-  begin
-    rintros ⟨a₁, b₁⟩ ⟨a₂, b₂⟩,
-    split,
-    { rintros (⟨_, _, _, _, hlt⟩ | ⟨_, _, _, hlt⟩),
-     { split,
-       { left, assumption },
-       { rintro ⟨l,r⟩,
-         { apply lt_asymm hlt, assumption },
-         { apply lt_irrefl _ hlt } } },
-     { split,
-       { right, rw lt_iff_le_not_le at hlt, exact hlt.1 },
-       { rintro ⟨l,r⟩,
-         { apply lt_irrefl a₁, assumption },
-         { rw lt_iff_le_not_le at hlt, apply hlt.2, assumption } } } },
-    { rintros ⟨⟨h₁ll, h₁lr⟩, h₂r⟩,
-      { left, assumption },
-      { right, rw lt_iff_le_not_le, split,
-        { assumption },
-        { intro h, apply h₂r, right, exact h } } }
-  end,
-  .. dlex_has_le,
-  .. dlex_has_lt }
-
-/-- Dictionary / lexicographic partial_order for dependent pairs. -/
-instance dlex_partial_order [partial_order α] [∀ a, partial_order (Z a)] :
-  partial_order (Σ' a, Z a) :=
-{ le_antisymm :=
-  begin
-    rintros ⟨a₁, b₁⟩ ⟨a₂, b₂⟩
-      (⟨_, _, _, _, hlt₁⟩ | ⟨_, _, _, hlt₁⟩) (⟨_, _, _, _, hlt₂⟩ | ⟨_, _, _, hlt₂⟩),
-    { exfalso, exact lt_irrefl a₁ (lt_trans hlt₁ hlt₂) },
-    { exfalso, exact lt_irrefl a₁ hlt₁ },
-    { exfalso, exact lt_irrefl a₁ hlt₂ },
-    { have := le_antisymm hlt₁ hlt₂, simp [this] }
-  end
-  .. dlex_preorder }
-
-/-- Dictionary / lexicographic linear_order for pairs. -/
-instance dlex_linear_order [linear_order α] [∀ a, linear_order (Z a)] : linear_order (Σ' a, Z a) :=
-{ le_total :=
-  begin
-    rintros ⟨a₁, b₁⟩ ⟨a₂, b₂⟩,
-    obtain ha | ha := le_total a₁ a₂;
-      cases lt_or_eq_of_le ha with a_lt a_eq,
-    -- Deal with the two goals with a₁ ≠ a₂
-    { left, left, exact a_lt },
-    swap,
-    { right, left, exact a_lt },
-    -- Now deal with the two goals with a₁ = a₂
-    all_goals { subst a_eq, obtain hb | hb := le_total b₁ b₂ },
-    { left, right, exact hb },
-    { right, right, exact hb },
-    { left, right, exact hb },
-    { right, right, exact hb },
-  end,
-  decidable_le :=
-  begin
-    rintros ⟨a₁, b₁⟩ ⟨a₂, b₂⟩,
-    obtain a_lt | a_le := linear_order.decidable_le a₁ a₂,
-    { -- a₂ < a₁
-      left, rw not_le at a_lt, rintro ⟨l, r⟩,
-      { apply lt_irrefl a₂, apply lt_trans, repeat { assumption } },
-      { apply lt_irrefl a₁, assumption } },
-    { -- a₁ ≤ a₂
-      by_cases h : a₁ = a₂,
-      { subst h,
-        obtain b_lt | b_le := linear_order.decidable_le b₁ b₂,
-        { -- b₂ < b₁
-          left, rw not_le at b_lt, rintro ⟨l, r⟩,
-          { apply lt_irrefl a₁, assumption },
-          { apply lt_irrefl b₂, apply lt_of_lt_of_le, repeat { assumption } } },
-          -- b₁ ≤ b₂
-         { right, right, assumption } },
-      -- a₁ < a₂
-      { right, left, apply lt_of_le_of_ne, repeat { assumption } } }
-  end,
-  .. dlex_partial_order }.


### PR DESCRIPTION
This moves all the stuff about `Σ' i, α i` to a new file `data.psigma.order`. This mimics the file organisation of `sigma`.

I'm crediting:
* Scott for #820
* Minchao for #914

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
