### PR TITLE
[Merged by Bors] - feat(algebra/order/field, data/real/basic): lemmas about `Sup` and `is_lub`

### DIFF
--- a/src/algebra/order/field.lean
+++ b/src/algebra/order/field.lean
@@ -6,6 +6,7 @@ Authors: Robert Lewis, Leonardo de Moura, Mario Carneiro, Floris van Doorn
 import algebra.field.basic
 import algebra.group_power.order
 import algebra.order.ring
+import order.bounds
 import tactic.monotonicity.basic
 
 /-!
@@ -724,5 +725,35 @@ lemma one_div_pow_mono (a1 : 1 ≤ a) : monotone (λ n : ℕ, order_dual.to_dual
 
 lemma one_div_pow_strict_mono (a1 : 1 < a) : strict_mono (λ n : ℕ, order_dual.to_dual 1 / a ^ n) :=
 λ m n, one_div_pow_lt_one_div_pow_of_lt a1
+
+/-! ### Results about `has_lub` and `has_glb` -/
+
+lemma is_lub_mul {s : set α} (hc : 0 ≤ a) (hs : is_lub s b) :
+  is_lub {x | ∃ y ∈ s, a * y = x} (a * b) :=
+begin
+  rcases lt_or_eq_of_le hc with hc | rfl,
+  { rw ← (order_iso.mul_left₀ _ hc).is_lub_image' at hs,
+    convert hs using 1,
+    ext x,
+    simp },
+  { convert is_lub_singleton using 1,
+    ext x,
+    have : s.nonempty ∧ 0 = x ↔ x = 0 := by rw [and_iff_right hs.nonempty, eq_comm],
+    simpa using this },
+end
+
+lemma is_glb_mul {s : set α} (hc : 0 ≤ a) (hs : is_glb s b) :
+  is_glb {x | ∃ y ∈ s, a * y = x} (a * b) :=
+begin
+  rcases lt_or_eq_of_le hc with hc | rfl,
+  { rw ← (order_iso.mul_left₀ _ hc).is_glb_image' at hs,
+    convert hs using 1,
+    ext x,
+    simp },
+  { convert is_glb_singleton using 1,
+    ext y,
+    have : s.nonempty ∧ 0 = y ↔ y = 0 := by rw [and_iff_right hs.nonempty, eq_comm],
+    simpa using this },
+end
 
 end linear_ordered_field

--- a/src/algebra/order/field.lean
+++ b/src/algebra/order/field.lean
@@ -752,8 +752,8 @@ begin
     exact is_glb_singleton },
 end
 
-lemma is_glb.mul_right {s : set α} (hc : 0 ≤ a) (hs : is_lub s b) :
-  is_lub ((λ b, b * a) '' s) (b * a) :=
+lemma is_glb.mul_right {s : set α} (hc : 0 ≤ a) (hs : is_glb s b) :
+  is_glb ((λ b, b * a) '' s) (b * a) :=
 by simpa [mul_comm] using hs.mul_left hc
 
 end linear_ordered_field

--- a/src/algebra/order/field.lean
+++ b/src/algebra/order/field.lean
@@ -726,7 +726,7 @@ lemma one_div_pow_mono (a1 : 1 ≤ a) : monotone (λ n : ℕ, order_dual.to_dual
 lemma one_div_pow_strict_mono (a1 : 1 < a) : strict_mono (λ n : ℕ, order_dual.to_dual 1 / a ^ n) :=
 λ m n, one_div_pow_lt_one_div_pow_of_lt a1
 
-/-! ### Results about `has_lub` and `has_glb` -/
+/-! ### Results about `is_lub` and `is_glb` -/
 
 lemma is_lub.mul_left {s : set α} (hc : 0 ≤ a) (hs : is_lub s b) :
   is_lub ((λ b, a * b) '' s) (a * b) :=

--- a/src/algebra/order/field.lean
+++ b/src/algebra/order/field.lean
@@ -729,31 +729,23 @@ lemma one_div_pow_strict_mono (a1 : 1 < a) : strict_mono (λ n : ℕ, order_dual
 /-! ### Results about `has_lub` and `has_glb` -/
 
 lemma is_lub_mul {s : set α} (hc : 0 ≤ a) (hs : is_lub s b) :
-  is_lub {x | ∃ y ∈ s, a * y = x} (a * b) :=
+  is_lub ((λ b, a * b) '' s) (a * b) :=
 begin
   rcases lt_or_eq_of_le hc with hc | rfl,
-  { rw ← (order_iso.mul_left₀ _ hc).is_lub_image' at hs,
-    convert hs using 1,
-    ext x,
-    simp },
-  { convert is_lub_singleton using 1,
-    ext x,
-    have : s.nonempty ∧ 0 = x ↔ x = 0 := by rw [and_iff_right hs.nonempty, eq_comm],
-    simpa using this },
+  { exact (order_iso.mul_left₀ _ hc).is_lub_image'.2 hs, },
+  { simp_rw zero_mul,
+    rw hs.nonempty.image_const,
+    exact is_lub_singleton },
 end
 
 lemma is_glb_mul {s : set α} (hc : 0 ≤ a) (hs : is_glb s b) :
-  is_glb {x | ∃ y ∈ s, a * y = x} (a * b) :=
+  is_glb ((λ b, a * b) '' s) (a * b) :=
 begin
   rcases lt_or_eq_of_le hc with hc | rfl,
-  { rw ← (order_iso.mul_left₀ _ hc).is_glb_image' at hs,
-    convert hs using 1,
-    ext x,
-    simp },
-  { convert is_glb_singleton using 1,
-    ext y,
-    have : s.nonempty ∧ 0 = y ↔ y = 0 := by rw [and_iff_right hs.nonempty, eq_comm],
-    simpa using this },
+  { exact (order_iso.mul_left₀ _ hc).is_glb_image'.2 hs, },
+  { simp_rw zero_mul,
+    rw hs.nonempty.image_const,
+    exact is_glb_singleton },
 end
 
 end linear_ordered_field

--- a/src/algebra/order/field.lean
+++ b/src/algebra/order/field.lean
@@ -728,32 +728,32 @@ lemma one_div_pow_strict_mono (a1 : 1 < a) : strict_mono (λ n : ℕ, order_dual
 
 /-! ### Results about `is_lub` and `is_glb` -/
 
-lemma is_lub.mul_left {s : set α} (hc : 0 ≤ a) (hs : is_lub s b) :
+lemma is_lub.mul_left {s : set α} (ha : 0 ≤ a) (hs : is_lub s b) :
   is_lub ((λ b, a * b) '' s) (a * b) :=
 begin
-  rcases lt_or_eq_of_le hc with hc | rfl,
-  { exact (order_iso.mul_left₀ _ hc).is_lub_image'.2 hs, },
+  rcases lt_or_eq_of_le ha with ha | rfl,
+  { exact (order_iso.mul_left₀ _ ha).is_lub_image'.2 hs, },
   { simp_rw zero_mul,
     rw hs.nonempty.image_const,
     exact is_lub_singleton },
 end
 
-lemma is_lub.mul_right {s : set α} (hc : 0 ≤ a) (hs : is_lub s b) :
+lemma is_lub.mul_right {s : set α} (ha : 0 ≤ a) (hs : is_lub s b) :
   is_lub ((λ b, b * a) '' s) (b * a) :=
-by simpa [mul_comm] using hs.mul_left hc
+by simpa [mul_comm] using hs.mul_left ha
 
-lemma is_glb.mul_left {s : set α} (hc : 0 ≤ a) (hs : is_glb s b) :
+lemma is_glb.mul_left {s : set α} (ha : 0 ≤ a) (hs : is_glb s b) :
   is_glb ((λ b, a * b) '' s) (a * b) :=
 begin
-  rcases lt_or_eq_of_le hc with hc | rfl,
-  { exact (order_iso.mul_left₀ _ hc).is_glb_image'.2 hs, },
+  rcases lt_or_eq_of_le ha with ha | rfl,
+  { exact (order_iso.mul_left₀ _ ha).is_glb_image'.2 hs, },
   { simp_rw zero_mul,
     rw hs.nonempty.image_const,
     exact is_glb_singleton },
 end
 
-lemma is_glb.mul_right {s : set α} (hc : 0 ≤ a) (hs : is_glb s b) :
+lemma is_glb.mul_right {s : set α} (ha : 0 ≤ a) (hs : is_glb s b) :
   is_glb ((λ b, b * a) '' s) (b * a) :=
-by simpa [mul_comm] using hs.mul_left hc
+by simpa [mul_comm] using hs.mul_left ha
 
 end linear_ordered_field

--- a/src/algebra/order/field.lean
+++ b/src/algebra/order/field.lean
@@ -739,7 +739,7 @@ begin
 end
 
 lemma is_lub.mul_right {s : set α} (hc : 0 ≤ a) (hs : is_lub s b) :
-  is_lub (((λ b, b * a)) '' s) (b * a) :=
+  is_lub ((λ b, b * a) '' s) (b * a) :=
 by simpa [mul_comm] using hs.mul_left hc
 
 lemma is_glb.mul_left {s : set α} (hc : 0 ≤ a) (hs : is_glb s b) :

--- a/src/algebra/order/field.lean
+++ b/src/algebra/order/field.lean
@@ -728,7 +728,7 @@ lemma one_div_pow_strict_mono (a1 : 1 < a) : strict_mono (λ n : ℕ, order_dual
 
 /-! ### Results about `has_lub` and `has_glb` -/
 
-lemma is_lub_mul {s : set α} (hc : 0 ≤ a) (hs : is_lub s b) :
+lemma is_lub.mul_left {s : set α} (hc : 0 ≤ a) (hs : is_lub s b) :
   is_lub ((λ b, a * b) '' s) (a * b) :=
 begin
   rcases lt_or_eq_of_le hc with hc | rfl,
@@ -738,7 +738,11 @@ begin
     exact is_lub_singleton },
 end
 
-lemma is_glb_mul {s : set α} (hc : 0 ≤ a) (hs : is_glb s b) :
+lemma is_lub.mul_right {s : set α} (hc : 0 ≤ a) (hs : is_lub s b) :
+  is_lub (((λ b, b * a)) '' s) (b * a) :=
+by simpa [mul_comm] using hs.mul_left hc
+
+lemma is_glb.mul_left {s : set α} (hc : 0 ≤ a) (hs : is_glb s b) :
   is_glb ((λ b, a * b) '' s) (a * b) :=
 begin
   rcases lt_or_eq_of_le hc with hc | rfl,
@@ -747,5 +751,9 @@ begin
     rw hs.nonempty.image_const,
     exact is_glb_singleton },
 end
+
+lemma is_glb.mul_right {s : set α} (hc : 0 ≤ a) (hs : is_lub s b) :
+  is_lub ((λ b, b * a) '' s) (b * a) :=
+by simpa [mul_comm] using hs.mul_left hc
 
 end linear_ordered_field

--- a/src/data/real/basic.lean
+++ b/src/data/real/basic.lean
@@ -458,6 +458,21 @@ end
 
 @[simp] theorem Sup_empty : Sup (∅ : set ℝ) = 0 := dif_neg $ by simp
 
+lemma csupr_empty {α : Sort*} [is_empty α] (f : α → ℝ) : (⨆ i, f i) = 0 :=
+begin
+  dsimp [supr],
+  convert real.Sup_empty,
+  rw set.range_eq_empty_iff,
+  apply_instance
+end
+
+@[simp] lemma csupr_const_zero {α : Sort*} : (⨆ i : α, (0:ℝ)) = 0 :=
+begin
+  cases is_empty_or_nonempty α; resetI,
+  { exact real.csupr_empty _ },
+  { exact csupr_const },
+end
+
 theorem Sup_of_not_bdd_above {s : set ℝ} (hs : ¬ bdd_above s) : Sup s = 0 :=
 dif_neg $ assume h, hs h.2
 
@@ -466,6 +481,21 @@ real.Sup_of_not_bdd_above $ λ ⟨x, h⟩, not_le_of_lt (lt_add_one _) $ h (set.
 
 @[simp] theorem Inf_empty : Inf (∅ : set ℝ) = 0 :=
 by simp [Inf_def, Sup_empty]
+
+lemma cinfi_empty {α : Sort*} [is_empty α] (f : α → ℝ) : (⨅ i, f i) = 0 :=
+begin
+  dsimp [infi],
+  convert real.Inf_empty,
+  rw set.range_eq_empty_iff,
+  apply_instance
+end
+
+@[simp] lemma cinfi_const_zero {α : Sort*} : (⨅ i : α, (0:ℝ)) = 0 :=
+begin
+  cases is_empty_or_nonempty α; resetI,
+  { exact real.cinfi_empty _ },
+  { exact cinfi_const },
+end
 
 theorem Inf_of_not_bdd_below {s : set ℝ} (hs : ¬ bdd_below s) : Inf s = 0 :=
 neg_eq_zero.2 $ Sup_of_not_bdd_above $ mt bdd_above_neg.1 hs

--- a/src/data/real/basic.lean
+++ b/src/data/real/basic.lean
@@ -468,7 +468,7 @@ end
 
 @[simp] lemma csupr_const_zero {α : Sort*} : (⨆ i : α, (0:ℝ)) = 0 :=
 begin
-  cases is_empty_or_nonempty α; resetI,
+  casesI is_empty_or_nonempty α,
   { exact real.csupr_empty _ },
   { exact csupr_const },
 end
@@ -492,7 +492,7 @@ end
 
 @[simp] lemma cinfi_const_zero {α : Sort*} : (⨅ i : α, (0:ℝ)) = 0 :=
 begin
-  cases is_empty_or_nonempty α; resetI,
+  casesI is_empty_or_nonempty α,
   { exact real.cinfi_empty _ },
   { exact cinfi_const },
 end


### PR DESCRIPTION
Add a lemma stating that for `f : α → ℝ` with `α` empty, `(⨆ i, f i) = 0`; a lemma stating that in an ordered field `is_lub` scales under multiplication by a nonnegative constant, and some variants.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
