### PR TITLE
[Merged by Bors] - feat(algebra/group_with_zero): add zero_mul_eq_const and mul_zero_eq_const

### DIFF
--- a/src/algebra/group_with_zero/basic.lean
+++ b/src/algebra/group_with_zero/basic.lean
@@ -90,6 +90,12 @@ lemma mul_eq_zero_of_ne_zero_imp_eq_zero {a b : M₀} (h : a ≠ 0 → b = 0) :
   a * b = 0 :=
 if ha : a = 0 then by rw [ha, zero_mul] else by rw [h ha, mul_zero]
 
+/-- To match `one_mul_eq_id`. -/
+lemma zero_mul_eq_const : ((*) (0 : M₀)) = function.const _ 0 := funext zero_mul
+
+/-- To match `mul_one_eq_id`. -/
+lemma mul_zero_eq_const : (* (0 : M₀)) = function.const _ 0 := funext mul_zero
+
 end mul_zero_class
 
 /-- Pushforward a `no_zero_divisors` instance along an injective function. -/


### PR DESCRIPTION
These are to match the corresponding lemmas about unapplied application of multiplication by 1. Like those lemmas, these are not marked simp.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
