### PR TITLE
[Merged by Bors] - chore(algebra/*): Eliminate `finish`

### DIFF
--- a/src/algebra/big_operators/basic.lean
+++ b/src/algebra/big_operators/basic.lean
@@ -1030,7 +1030,7 @@ lemma prod_comp [decidable_eq γ] (f : γ → β) (g : α → γ) :
   ∏ a in s, f (g a) = ∏ b in s.image g, f b ^ (s.filter (λ a, g a = b)).card  :=
 calc ∏ a in s, f (g a)
     = ∏ x in (s.image g).sigma (λ b : γ, s.filter (λ a, g a = b)), f (g x.2) :
-  prod_bij (λ a ha, ⟨g a, a⟩) (by simp; tauto) (λ _ _, rfl) (by simp)
+  prod_bij (λ a ha, ⟨g a, a⟩) (by simp; tauto) (λ _ _, rfl) (by simp) -- `(by finish)` closes this
   (by { rintro ⟨b_fst, b_snd⟩ H,
         simp only [mem_image, exists_prop, mem_filter, mem_sigma] at H,
         tauto })

--- a/src/algebra/big_operators/basic.lean
+++ b/src/algebra/big_operators/basic.lean
@@ -1030,7 +1030,10 @@ lemma prod_comp [decidable_eq γ] (f : γ → β) (g : α → γ) :
   ∏ a in s, f (g a) = ∏ b in s.image g, f b ^ (s.filter (λ a, g a = b)).card  :=
 calc ∏ a in s, f (g a)
     = ∏ x in (s.image g).sigma (λ b : γ, s.filter (λ a, g a = b)), f (g x.2) :
-  prod_bij (λ a ha, ⟨g a, a⟩) (by simp; tauto) (λ _ _, rfl) (by simp) (by finish)
+  prod_bij (λ a ha, ⟨g a, a⟩) (by simp; tauto) (λ _ _, rfl) (by simp)
+  (by { rintro ⟨b_fst, b_snd⟩ H,
+        simp only [mem_image, exists_prop, mem_filter, mem_sigma] at H,
+        tauto })
 ... = ∏ b in s.image g, ∏ a in s.filter (λ a, g a = b), f (g a) : prod_sigma _ _ _
 ... = ∏ b in s.image g, ∏ a in s.filter (λ a, g a = b), f b :
   prod_congr rfl (λ b hb, prod_congr rfl (by simp {contextual := tt}))

--- a/src/algebra/continued_fractions/computation/approximations.lean
+++ b/src/algebra/continued_fractions/computation/approximations.lean
@@ -157,7 +157,7 @@ begin
       nth_of_eq_some_of_succ_nth_int_fract_pair_stream stream_succ_nth_eq,
     have : some gp = some ⟨1, ifp.b⟩, by rwa nth_s_eq at this,
     injection this },
-  finish
+    simp [this],
 end
 
 /-- Shows that the partial numerators `aᵢ` are equal to one. -/

--- a/src/algebra/continued_fractions/computation/approximations.lean
+++ b/src/algebra/continued_fractions/computation/approximations.lean
@@ -157,7 +157,7 @@ begin
       nth_of_eq_some_of_succ_nth_int_fract_pair_stream stream_succ_nth_eq,
     have : some gp = some ⟨1, ifp.b⟩, by rwa nth_s_eq at this,
     injection this },
-    simp [this],
+  simp [this],
 end
 
 /-- Shows that the partial numerators `aᵢ` are equal to one. -/

--- a/src/algebra/continued_fractions/computation/approximations.lean
+++ b/src/algebra/continued_fractions/computation/approximations.lean
@@ -278,20 +278,16 @@ begin
   set g := of v with g_eq,
   obtain ⟨gp_n, nth_s_eq, gpnb_eq_b⟩ : ∃ gp_n, g.s.nth n = some gp_n ∧ gp_n.b = b, from
     exists_s_b_of_part_denom nth_part_denom_eq,
+  subst gpnb_eq_b,
   let conts := g.continuants_aux (n + 2),
   set pconts := g.continuants_aux (n + 1) with pconts_eq,
   set ppconts := g.continuants_aux n with ppconts_eq,
+  have h1 : 0 ≤ ppconts.b, from zero_le_of_continuants_aux_b,
+  have h2 : gp_n.b * pconts.b ≤ ppconts.b + gp_n.b * pconts.b,
+  { solve_by_elim [le_add_of_nonneg_of_le, le_refl] },
   -- use the recurrence of continuants_aux and the fact that gp_n.a = 1
-  suffices : gp_n.b * pconts.b ≤ ppconts.b + gp_n.b * pconts.b, by
-  { simp only
-      [this, one_mul, ←pconts_eq, ←ppconts_eq, of_part_num_eq_one (part_num_eq_s_a nth_s_eq),
-      generalized_continued_fraction.continuants_aux_recurrence nth_s_eq ppconts_eq pconts_eq],
-    induction gpnb_eq_b,
-    simp only [le_add_iff_nonneg_right],
-    simp only [le_add_iff_nonneg_left] at this,
-    assumption },
-  have : 0 ≤ ppconts.b, from zero_le_of_continuants_aux_b,
-  solve_by_elim [le_add_of_nonneg_of_le, le_refl]
+  simp [h1, h2, of_part_num_eq_one (part_num_eq_s_a nth_s_eq),
+     generalized_continued_fraction.continuants_aux_recurrence nth_s_eq ppconts_eq pconts_eq],
 end
 
 /-- Shows that `bₙ * Bₙ ≤ Bₙ₊₁`, where `bₙ` is the `n`th partial denominator and `Bₙ₊₁` and `Bₙ` are

--- a/src/algebra/continued_fractions/computation/approximations.lean
+++ b/src/algebra/continued_fractions/computation/approximations.lean
@@ -283,9 +283,13 @@ begin
   set ppconts := g.continuants_aux n with ppconts_eq,
   -- use the recurrence of continuants_aux and the fact that gp_n.a = 1
   suffices : gp_n.b * pconts.b ≤ ppconts.b + gp_n.b * pconts.b, by
-  { have : gp_n.a = 1, from of_part_num_eq_one (part_num_eq_s_a nth_s_eq),
-    finish
-      [generalized_continued_fraction.continuants_aux_recurrence nth_s_eq ppconts_eq pconts_eq] },
+  { simp only
+      [this, one_mul, ←pconts_eq, ←ppconts_eq, of_part_num_eq_one (part_num_eq_s_a nth_s_eq),
+      generalized_continued_fraction.continuants_aux_recurrence nth_s_eq ppconts_eq pconts_eq],
+    induction gpnb_eq_b,
+    simp only [le_add_iff_nonneg_right],
+    simp only [le_add_iff_nonneg_left] at this,
+    assumption },
   have : 0 ≤ ppconts.b, from zero_le_of_continuants_aux_b,
   solve_by_elim [le_add_of_nonneg_of_le, le_refl]
 end


### PR DESCRIPTION
Removing uses of `finish`, as discussed in this Zulip thread (https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/mathlib.20sat.20solvers)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
