### PR TITLE
[Merged by Bors] - feat(combinatorics/simple_graph/basic): edge deletion

### DIFF
--- a/src/combinatorics/simple_graph/basic.lean
+++ b/src/combinatorics/simple_graph/basic.lean
@@ -494,6 +494,10 @@ def delete_edges (s : set (sym2 V)) : simple_graph V :=
 @[simp] lemma delete_edges_adj (s : set (sym2 V)) (v w : V) :
   (G.delete_edges s).adj v w ↔ G.adj v w ∧ ¬ ⟦(v, w)⟧ ∈ s := iff.rfl
 
+lemma sdiff_eq_delete_edges (G G' : simple_graph V) :
+  G \ G' = G.delete_edges G'.edge_set :=
+by { ext, simp }
+
 @[simp] lemma delete_edges_delete_edges (s s' : set (sym2 V)) :
   (G.delete_edges s).delete_edges s' = G.delete_edges (s ∪ s') :=
 by { ext, simp [and_assoc, not_or_distrib] }

--- a/src/combinatorics/simple_graph/basic.lean
+++ b/src/combinatorics/simple_graph/basic.lean
@@ -489,10 +489,12 @@ section finite_at
 
 /-- Given a set of vertex pairs, remove all of the corresponding edges from the edge set.
 It is fine to delete edges outside the edge set. -/
-@[simps]
 def delete_edges (s : set (sym2 V)) : simple_graph V :=
-{ adj := λ a b, G.adj a b ∧ ¬ ⟦(a, b)⟧ ∈ s,
-  symm := λ a b h, by rwa [adj_comm, sym2.eq_swap] }
+{ adj := G.adj \ sym2.to_rel s,
+  symm := λ a b, by simp [adj_comm, sym2.eq_swap] }
+
+@[simp] lemma delete_edges_adj (s : set (sym2 V)) (v w : V) :
+  (G.delete_edges s).adj v w ↔ G.adj v w ∧ ¬ ⟦(v, w)⟧ ∈ s := iff.rfl
 
 @[simp] lemma delete_edges_delete_edges (s s' : set (sym2 V)) :
   (G.delete_edges s).delete_edges s' = G.delete_edges (s ∪ s') :=

--- a/src/combinatorics/simple_graph/basic.lean
+++ b/src/combinatorics/simple_graph/basic.lean
@@ -483,8 +483,6 @@ vertex and the set of vertices adjacent to the vertex.
 
 end incidence
 
-section finite_at
-
 /-! ## Edge deletion -/
 
 /-- Given a set of vertex pairs, remove all of the corresponding edges from the edge set.
@@ -519,6 +517,8 @@ end
 lemma delete_edges_eq_inter_edge_set (s : set (sym2 V)) :
   G.delete_edges s = G.delete_edges (s ∩ G.edge_set) :=
 by { ext, simp [imp_false] { contextual := tt } }
+
+section finite_at
 
 /-!
 ## Finiteness at a vertex

--- a/src/combinatorics/simple_graph/basic.lean
+++ b/src/combinatorics/simple_graph/basic.lean
@@ -485,6 +485,39 @@ end incidence
 
 section finite_at
 
+/-! ## Edge deletion -/
+
+/-- Given a set of vertex pairs, remove all of the corresponding edges from the edge set.
+It is fine to delete edges outside the edge set. -/
+@[simps]
+def delete_edges (s : set (sym2 V)) : simple_graph V :=
+{ adj := λ a b, G.adj a b ∧ ¬ ⟦(a, b)⟧ ∈ s,
+  symm := λ a b h, by rwa [adj_comm, sym2.eq_swap] }
+
+@[simp] lemma delete_edges_delete_edges (s s' : set (sym2 V)) :
+  (G.delete_edges s).delete_edges s' = G.delete_edges (s ∪ s') :=
+by { ext v w, simp [and_assoc, not_or_distrib] }
+
+@[simp] lemma delete_edges_empty_eq : G.delete_edges ∅ = G :=
+by ext; simp
+
+@[simp] lemma delete_edges_univ_eq : G.delete_edges set.univ = ⊥ :=
+by ext; simp
+
+lemma delete_edges_le (s : set (sym2 V)) : G.delete_edges s ≤ G :=
+by { intro, simp { contextual := tt } }
+
+lemma delete_edges_le_of_le {s s' : set (sym2 V)} (h : s ⊆ s') :
+  G.delete_edges s' ≤ G.delete_edges s :=
+λ v w, begin
+  simp only [delete_edges_adj, and_imp, true_and] { contextual := tt },
+  exact λ ha hn hs, hn (h hs),
+end
+
+lemma delete_edges_eq_inter_edge_set (s : set (sym2 V)) :
+  G.delete_edges s = G.delete_edges (s ∩ G.edge_set) :=
+by { ext v w, simp [imp_false] { contextual := tt } }
+
 /-!
 ## Finiteness at a vertex
 

--- a/src/combinatorics/simple_graph/basic.lean
+++ b/src/combinatorics/simple_graph/basic.lean
@@ -496,13 +496,13 @@ def delete_edges (s : set (sym2 V)) : simple_graph V :=
 
 @[simp] lemma delete_edges_delete_edges (s s' : set (sym2 V)) :
   (G.delete_edges s).delete_edges s' = G.delete_edges (s ∪ s') :=
-by { ext v w, simp [and_assoc, not_or_distrib] }
+by { ext, simp [and_assoc, not_or_distrib] }
 
 @[simp] lemma delete_edges_empty_eq : G.delete_edges ∅ = G :=
-by ext; simp
+by { ext, simp }
 
 @[simp] lemma delete_edges_univ_eq : G.delete_edges set.univ = ⊥ :=
-by ext; simp
+by { ext, simp }
 
 lemma delete_edges_le (s : set (sym2 V)) : G.delete_edges s ≤ G :=
 by { intro, simp { contextual := tt } }
@@ -516,7 +516,7 @@ end
 
 lemma delete_edges_eq_inter_edge_set (s : set (sym2 V)) :
   G.delete_edges s = G.delete_edges (s ∩ G.edge_set) :=
-by { ext v w, simp [imp_false] { contextual := tt } }
+by { ext, simp [imp_false] { contextual := tt } }
 
 /-!
 ## Finiteness at a vertex

--- a/src/combinatorics/simple_graph/basic.lean
+++ b/src/combinatorics/simple_graph/basic.lean
@@ -498,6 +498,10 @@ lemma sdiff_eq_delete_edges (G G' : simple_graph V) :
   G \ G' = G.delete_edges G'.edge_set :=
 by { ext, simp }
 
+lemma compl_eq_delete_edges :
+  Gᶜ = (⊤ : simple_graph V).delete_edges G.edge_set :=
+by { ext, simp }
+
 @[simp] lemma delete_edges_delete_edges (s s' : set (sym2 V)) :
   (G.delete_edges s).delete_edges s' = G.delete_edges (s ∪ s') :=
 by { ext, simp [and_assoc, not_or_distrib] }

--- a/src/combinatorics/simple_graph/subgraph.lean
+++ b/src/combinatorics/simple_graph/subgraph.lean
@@ -279,7 +279,7 @@ rel.dom_mono h.2
 lemma _root_.simple_graph.to_subgraph.is_spanning (H : simple_graph V) (h : H ≤ G) :
   (H.to_subgraph h).is_spanning := set.mem_univ
 
-lemma spanning_coe.is_subgraph_of_is_subgraph {H H' : subgraph G} (h : H ≤ H') :
+lemma spanning_coe_le_of_le {H H' : subgraph G} (h : H ≤ H') :
   H.spanning_coe ≤ H'.spanning_coe := h.2
 
 /-- The top of the `subgraph G` lattice is equivalent to the graph itself. -/
@@ -386,6 +386,46 @@ begin
   rw [← finset_card_neighbor_set_eq_degree, finset.card_eq_one, finset.singleton_iff_unique_mem],
   simp only [set.mem_to_finset, mem_neighbor_set],
 end
+
+/-- Given a subgraph `G'`and a set pairs, remove all of those pairs from the edge set
+of `G'` (if they were present). -/
+@[simps]
+def delete_edges (G' : G.subgraph) (s : set (sym2 V)) : G.subgraph :=
+{ verts := G'.verts,
+  adj := λ a b, G'.adj a b ∧ ¬ ⟦(a, b)⟧ ∈ s,
+  adj_sub := λ a b h', G'.adj_sub h'.1,
+  edge_vert := λ a b h', G'.edge_vert h'.1,
+  symm := λ a b h, by rwa [G'.adj_comm, sym2.eq_swap] }
+
+@[simp] lemma delete_edges_delete_edges (G' : G.subgraph) (s s' : set (sym2 V)) :
+  (G'.delete_edges s).delete_edges s' = G'.delete_edges (s ∪ s') :=
+begin
+  ext v,
+  { simp, },
+  { ext v w,
+    simp [and_assoc, not_or_distrib], },
+end
+
+@[simp] lemma delete_edges_empty_eq (G' : G.subgraph) : G'.delete_edges ∅ = G' :=
+by ext; simp
+
+lemma delete_edges_le (G' : G.subgraph) (s : set (sym2 V)) : G'.delete_edges s ≤ G' :=
+⟨by simp, by simp { contextual := tt }⟩
+
+lemma delete_edges_le_of_le (G' : G.subgraph) {s s' : set (sym2 V)} (h : s ⊆ s') :
+  G'.delete_edges s' ≤ G'.delete_edges s :=
+⟨by simp, λ v w, begin
+  simp only [delete_edges_adj, and_imp, true_and] { contextual := tt },
+  exact λ ha hn hs, hn (h hs),
+end⟩
+
+lemma coe_delete_edges_le (G' : G.subgraph) (s : set (sym2 V)) :
+  (G'.delete_edges s).coe ≤ (G'.coe : simple_graph G'.verts) :=
+λ v w, by simp { contextual := tt }
+
+lemma spanning_coe_delete_edges_le (G' : G.subgraph) (s : set (sym2 V)) :
+  (G'.delete_edges s).spanning_coe ≤ G'.spanning_coe :=
+spanning_coe_le_of_le (delete_edges_le G' s)
 
 end subgraph
 

--- a/src/combinatorics/simple_graph/subgraph.lean
+++ b/src/combinatorics/simple_graph/subgraph.lean
@@ -387,7 +387,7 @@ begin
   simp only [set.mem_to_finset, mem_neighbor_set],
 end
 
-/-- Given a subgraph `G'`and a set pairs, remove all of those pairs from the edge set
+/-- Given a subgraph `G'` and a set of pairs, remove all of those pairs from the edge set
 of `G'` (if they were present). -/
 @[simps]
 def delete_edges (G' : G.subgraph) (s : set (sym2 V)) : G.subgraph :=

--- a/src/combinatorics/simple_graph/subgraph.lean
+++ b/src/combinatorics/simple_graph/subgraph.lean
@@ -387,46 +387,6 @@ begin
   simp only [set.mem_to_finset, mem_neighbor_set],
 end
 
-/-- Given a subgraph `G'`and a set pairs, remove all of those pairs from the edge set
-of `G'` (if they were present). -/
-@[simps]
-def delete_edges (G' : G.subgraph) (s : set (sym2 V)) : G.subgraph :=
-{ verts := G'.verts,
-  adj := λ a b, G'.adj a b ∧ ¬ ⟦(a, b)⟧ ∈ s,
-  adj_sub := λ a b h', G'.adj_sub h'.1,
-  edge_vert := λ a b h', G'.edge_vert h'.1,
-  symm := λ a b h, by rwa [G'.adj_comm, sym2.eq_swap] }
-
-@[simp] lemma delete_edges_delete_edges (G' : G.subgraph) (s s' : set (sym2 V)) :
-  (G'.delete_edges s).delete_edges s' = G'.delete_edges (s ∪ s') :=
-begin
-  ext v,
-  { simp, },
-  { ext v w,
-    simp [and_assoc, not_or_distrib], },
-end
-
-@[simp] lemma delete_edges_empty_eq (G' : G.subgraph) : G'.delete_edges ∅ = G' :=
-by ext; simp
-
-lemma delete_edges_le (G' : G.subgraph) (s : set (sym2 V)) : G'.delete_edges s ≤ G' :=
-⟨by simp, by simp { contextual := tt }⟩
-
-lemma delete_edges_le_of_le (G' : G.subgraph) {s s' : set (sym2 V)} (h : s ⊆ s') :
-  G'.delete_edges s' ≤ G'.delete_edges s :=
-⟨by simp, λ v w, begin
-  simp only [delete_edges_adj, and_imp, true_and] { contextual := tt },
-  exact λ ha hn hs, hn (h hs),
-end⟩
-
-lemma coe_delete_edges_le (G' : G.subgraph) (s : set (sym2 V)) :
-  (G'.delete_edges s).coe ≤ (G'.coe : simple_graph G'.verts) :=
-λ v w, by simp { contextual := tt }
-
-lemma spanning_coe_delete_edges_le (G' : G.subgraph) (s : set (sym2 V)) :
-  (G'.delete_edges s).spanning_coe ≤ G'.spanning_coe :=
-spanning_coe_le_of_le (delete_edges_le G' s)
-
 end subgraph
 
 end simple_graph

--- a/src/data/sym/sym2.lean
+++ b/src/data/sym/sym2.lean
@@ -304,7 +304,7 @@ instance from_rel.decidable_pred (sym : symmetric r) [h : decidable_rel r] :
   decidable_pred (∈ sym2.from_rel sym) :=
 λ z, quotient.rec_on_subsingleton z (λ x, h _ _)
 
-/-- The inverse to `sym2.from_rel`. Given a set on `sym2 α`, give a symmetric relation
+/-- The inverse to `sym2.from_rel`. Given a set on `sym2 α`, give a symmetric relation on `α`
 (see `sym2.to_rel_symmetric`). -/
 def to_rel (s : set (sym2 α)) (x y : α) : Prop := ⟦(x, y)⟧ ∈ s
 

--- a/src/data/sym/sym2.lean
+++ b/src/data/sym/sym2.lean
@@ -304,6 +304,19 @@ instance from_rel.decidable_pred (sym : symmetric r) [h : decidable_rel r] :
   decidable_pred (∈ sym2.from_rel sym) :=
 λ z, quotient.rec_on_subsingleton z (λ x, h _ _)
 
+/-- The inverse to `sym2.from_rel`. Given a set on `sym2 α`, give a symmetric relation
+(see `sym2.to_rel_symmetric`). -/
+def to_rel (s : set (sym2 α)) (x y : α) : Prop := ⟦(x, y)⟧ ∈ s
+
+@[simp] lemma to_rel_prop (s : set (sym2 α)) (x y : α) : to_rel s x y ↔ ⟦(x, y)⟧ ∈ s := iff.rfl
+
+lemma to_rel_symmetric (s : set (sym2 α)) : symmetric (to_rel s) := λ x y, by simp [eq_swap]
+
+lemma to_rel_from_rel (sym : symmetric r) : to_rel (from_rel sym) = r := rfl
+
+lemma from_rel_to_rel (s : set (sym2 α)) : from_rel (to_rel_symmetric s) = s :=
+set.ext (λ z, sym2.ind (λ x y, iff.rfl) z)
+
 end relations
 
 section sym_equiv


### PR DESCRIPTION
Function to delete edges from a simple graph, and some associated lemmas.

Also defines `sym2.to_rel` as an inverse to `sym2.from_rel`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
