### PR TITLE
[Merged by Bors] - chore(data/nat/prime): move some results

### DIFF
--- a/src/data/nat/prime.lean
+++ b/src/data/nat/prime.lean
@@ -3,12 +3,12 @@ Copyright (c) 2015 Microsoft Corporation. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Leonardo de Moura, Jeremy Avigad, Mario Carneiro
 -/
+import algebra.associated
 import data.list.sort
 import data.nat.gcd
 import data.nat.sqrt
 import tactic.norm_num
 import tactic.wlog
-import algebra.associated
 
 /-!
 # Prime numbers
@@ -23,6 +23,8 @@ This file deals with prime numbers: natural numbers `p ≥ 2` whose only divisor
 - `nat.exists_infinite_primes`: Euclid's theorem that there exist infinitely many prime numbers
 - `nat.factors n`: the prime factorization of `n`
 - `nat.factors_unique`: uniqueness of the prime factorisation
+* `nat.prime_iff`: `nat.prime` coincides with the general definition of `prime`
+* `nat.irreducible_iff_prime`: a non-unit natural number is only divisible by `1` iff it is prime
 
 -/
 
@@ -35,6 +37,8 @@ namespace nat
   at least 2 whose only divisors are `p` and `1`. -/
 @[pp_nodot]
 def prime (p : ℕ) := _root_.irreducible p
+
+theorem _root_.irreducible_iff_nat_prime (a : ℕ) : irreducible a ↔ nat.prime a := iff.rfl
 
 theorem not_prime_zero : ¬ prime 0
 | h := h.ne_zero rfl
@@ -524,6 +528,12 @@ theorem prime.dvd_mul {p m n : ℕ} (pp : prime p) : p ∣ m * n ↔ p ∣ m ∨
 theorem prime.not_dvd_mul {p m n : ℕ} (pp : prime p)
   (Hm : ¬ p ∣ m) (Hn : ¬ p ∣ n) : ¬ p ∣ m * n :=
 mt pp.dvd_mul.1 $ by simp [Hm, Hn]
+
+theorem prime_iff {p : ℕ} : p.prime ↔ _root_.prime p :=
+⟨λ h, ⟨h.ne_zero, h.not_unit, λ a b, h.dvd_mul.mp⟩, prime.irreducible⟩
+
+theorem irreducible_iff_prime {p : ℕ} : irreducible p ↔ _root_.prime p :=
+by rw [←prime_iff, prime]
 
 /-- Prime `p` divides the product of `L : list ℕ` iff it divides some `a ∈ L` -/
 lemma prime.dvd_prod_iff {p : ℕ} {L : list ℕ} (pp : p.prime) :

--- a/src/ring_theory/int/basic.lean
+++ b/src/ring_theory/int/basic.lean
@@ -14,8 +14,6 @@ their proofs or cases of ℕ and ℤ being examples of structures in abstract al
 
 ## Main statements
 
-* `nat.prime_iff`: `nat.prime` coincides with the general definition of `prime`
-* `nat.irreducible_iff_prime`: a non-unit natural number is only divisible by `1` iff it is prime
 * `nat.factors_eq`: the multiset of elements of `nat.factors` is equal to the factors
    given by the `unique_factorization_monoid` instance
 * ℤ is a `normalization_monoid`
@@ -27,12 +25,6 @@ prime, irreducible, natural numbers, integers, normalization monoid, gcd monoid,
 greatest common divisor, prime factorization, prime factors, unique factorization,
 unique factors
 -/
-
-theorem nat.prime_iff {p : ℕ} : p.prime ↔ prime p :=
-⟨λ h, ⟨h.ne_zero, h.not_unit, λ a b, h.dvd_mul.mp⟩, prime.irreducible⟩
-
-theorem nat.irreducible_iff_prime {p : ℕ} : irreducible p ↔ prime p :=
-by rw [←nat.prime_iff, nat.prime]
 
 namespace nat
 
@@ -208,8 +200,6 @@ begin
 end
 
 end int
-
-theorem irreducible_iff_nat_prime (a : ℕ) : irreducible a ↔ nat.prime a := iff.rfl
 
 lemma nat.prime_iff_prime_int {p : ℕ} : p.prime ↔ _root_.prime (p : ℤ) :=
 ⟨λ hp, ⟨int.coe_nat_ne_zero_iff_pos.2 hp.pos, mt int.is_unit_iff_nat_abs_eq.1 hp.ne_one,


### PR DESCRIPTION
I was expecting there'd be more that could be moved, but it doesn't seem like it.



---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
