### PR TITLE
[Merged by Bors] - chore(group_theory/sub{monoid,group}, linear_algebra/basic): rename equivalences to mapped subobjects

### DIFF
--- a/src/algebra/lie/subalgebra.lean
+++ b/src/algebra/lie/subalgebra.lean
@@ -513,11 +513,11 @@ variables (e : L₁ ≃ₗ⁅R⁆ L₂)
 
 /-- An equivalence of Lie algebras restricts to an equivalence from any Lie subalgebra onto its
 image. -/
-def of_subalgebra : L₁'' ≃ₗ⁅R⁆ (L₁''.map e : lie_subalgebra R L₂) :=
+def lie_subalgebra_map : L₁'' ≃ₗ⁅R⁆ (L₁''.map e : lie_subalgebra R L₂) :=
 { map_lie' := λ x y, by { apply set_coe.ext, exact lie_hom.map_lie (↑e : L₁ →ₗ⁅R⁆ L₂) ↑x ↑y, }
-  ..(linear_equiv.of_submodule (e : L₁ ≃ₗ[R] L₂) ↑L₁'') }
+  ..(linear_equiv.submodule_map (e : L₁ ≃ₗ[R] L₂) ↑L₁'') }
 
-@[simp] lemma of_subalgebra_apply (x : L₁'') : ↑(e.of_subalgebra _  x) = e x := rfl
+@[simp] lemma lie_subalgebra_map_apply (x : L₁'') : ↑(e.lie_subalgebra_map _  x) = e x := rfl
 
 /-- An equivalence of Lie algebras restricts to an equivalence from any Lie subalgebra onto its
 image. -/

--- a/src/group_theory/group_action/basic.lean
+++ b/src/group_theory/group_action/basic.lean
@@ -212,7 +212,7 @@ let g : α := classical.some h in
 have hg : g • y = x := classical.some_spec h,
 have this : stabilizer α x = (stabilizer α y).map (mul_aut.conj g).to_monoid_hom,
   by rw [← hg, stabilizer_smul_eq_stabilizer_map_conj],
-(mul_equiv.subgroup_congr this).trans ((mul_aut.conj g).subgroup_equiv_map $ stabilizer α y).symm
+(mul_equiv.subgroup_congr this).trans ((mul_aut.conj g).subgroup_map $ stabilizer α y).symm
 
 end mul_action
 
@@ -239,7 +239,7 @@ have hg : g +ᵥ y = x := classical.some_spec h,
 have this : stabilizer α x = (stabilizer α y).map (add_aut.conj g).to_add_monoid_hom,
   by rw [← hg, stabilizer_vadd_eq_stabilizer_map_conj],
 (add_equiv.add_subgroup_congr this).trans
-  ((add_aut.conj g).add_subgroup_equiv_map $ stabilizer α y).symm
+  ((add_aut.conj g).add_subgroup_map $ stabilizer α y).symm
 
 end add_action
 

--- a/src/group_theory/subgroup/basic.lean
+++ b/src/group_theory/subgroup/basic.lean
@@ -2145,9 +2145,9 @@ def subgroup_congr (h : H = K) : H ≃* K :=
 a subgroup `H ≤ G` and the subgroup `φ(H) ≤ G'`. -/
 @[to_additive "An `add_equiv` `φ` between two additive groups `G` and `G'` induces an `add_equiv`
 between a subgroup `H ≤ G` and the subgroup `φ(H) ≤ G'`. "]
-def subgroup_equiv_map {G'} [group G'] (e : G ≃* G') (H : subgroup G) :
+def subgroup_map {G'} [group G'] (e : G ≃* G') (H : subgroup G) :
   H ≃* H.map e.to_monoid_hom :=
-e.submonoid_equiv_map H.to_submonoid
+e.submonoid_map H.to_submonoid
 
 end mul_equiv
 

--- a/src/group_theory/subgroup/pointwise.lean
+++ b/src/group_theory/subgroup/pointwise.lean
@@ -91,7 +91,7 @@ subset_set_smul_iff
 
 /-- Applying a `mul_distrib_mul_action` results in an isomorphic subgroup -/
 @[simps] def equiv_smul (a : α) (H : subgroup G) : H ≃* (a • H : subgroup G) :=
-(mul_distrib_mul_action.to_mul_equiv G a).subgroup_equiv_map H
+(mul_distrib_mul_action.to_mul_equiv G a).subgroup_map H
 
 end group
 

--- a/src/group_theory/submonoid/operations.lean
+++ b/src/group_theory/submonoid/operations.lean
@@ -744,9 +744,9 @@ def submonoid_comap (f : M →* N) (N' : submonoid N) :
   map_mul' := λ x y, subtype.eq (f.map_mul x y) }
 
 /-- The `monoid_hom` from a submonoid to its image.
-See `mul_equiv.submonoid_equiv_map` for a variant for `mul_equiv`s. -/
+See `mul_equiv.submonoid_map` for a variant for `mul_equiv`s. -/
 @[to_additive "the `add_monoid_hom` from an additive submonoid to its image. See
-`add_equiv.add_submonoid_equiv_map` for a variant for `add_equiv`s.", simps]
+`add_equiv.add_submonoid_map` for a variant for `add_equiv`s.", simps]
 def submonoid_map (f : M →* N) (M' : submonoid M) :
   M' →* M'.map f :=
 { to_fun := λ x, ⟨f x, ⟨x, x.prop, rfl⟩⟩,
@@ -856,7 +856,7 @@ See `monoid_hom.submonoid_map` for a variant for `monoid_hom`s. -/
 @[to_additive "An `add_equiv` `φ` between two additive monoids `M` and `N` induces an `add_equiv`
 between a submonoid `S ≤ M` and the submonoid `φ(S) ≤ N`. See `add_monoid_hom.add_submonoid_map`
 for a variant for `add_monoid_hom`s.", simps]
-def submonoid_equiv_map (e : M ≃* N) (S : submonoid M) : S ≃* S.map e.to_monoid_hom :=
+def submonoid_map (e : M ≃* N) (S : submonoid M) : S ≃* S.map e.to_monoid_hom :=
 { to_fun := λ x, ⟨e x, _⟩,
   inv_fun := λ x, ⟨e.symm x, _⟩, -- we restate this for `simps` to avoid `⇑e.symm.to_equiv x`
   ..e.to_monoid_hom.submonoid_map S,

--- a/src/linear_algebra/basic.lean
+++ b/src/linear_algebra/basic.lean
@@ -1981,8 +1981,11 @@ set_like.coe_injective $ by simp [e.image_eq_preimage]
 /-- A linear equivalence of two modules restricts to a linear equivalence from any submodule
 `p` of the domain onto the image of that submodule.
 
+This is the linear version of `add_equiv.submonoid_map` and `add_equiv.subgroup_map`.
+
 This is `linear_equiv.of_submodule'` but with `map` on the right instead of `comap` on the left. -/
-def of_submodule (p : submodule R M) : p ≃ₛₗ[σ₁₂] ↥(p.map (e : M →ₛₗ[σ₁₂] M₂) : submodule R₂ M₂) :=
+def submodule_map (p : submodule R M) :
+  p ≃ₛₗ[σ₁₂] ↥(p.map (e : M →ₛₗ[σ₁₂] M₂) : submodule R₂ M₂) :=
 { inv_fun   := λ y, ⟨(e.symm : M₂ →ₛₗ[σ₂₁] M) y, by
   { rcases y with ⟨y', hy⟩, rw submodule.mem_map at hy, rcases hy with ⟨x, hx, hxy⟩, subst hxy,
     simp only [symm_apply_apply, submodule.coe_mk, coe_coe, hx], }⟩,
@@ -1992,11 +1995,12 @@ def of_submodule (p : submodule R M) : p ≃ₛₗ[σ₁₂] ↥(p.map (e : M �
   (λ x, ⟨x, by simp⟩) }
 
 include σ₂₁
-@[simp] lemma of_submodule_apply (p : submodule R M) (x : p) :
-  ↑(e.of_submodule p x) = e x := rfl
+@[simp] lemma submodule_map_apply (p : submodule R M) (x : p) :
+  ↑(e.submodule_map p x) = e x := rfl
 
-@[simp] lemma of_submodule_symm_apply (p : submodule R M)
-  (x : (p.map (e : M →ₛₗ[σ₁₂] M₂) : submodule R₂ M₂)) : ↑((e.of_submodule p).symm x) = e.symm x :=
+@[simp] lemma submodule_map_symm_apply (p : submodule R M)
+  (x : (p.map (e : M →ₛₗ[σ₁₂] M₂) : submodule R₂ M₂)) :
+  ↑((e.submodule_map p).symm x) = e.symm x :=
 rfl
 
 omit σ₂₁
@@ -2088,7 +2092,7 @@ include σ₂₁
 /-- A linear equivalence which maps a submodule of one module onto another, restricts to a linear
 equivalence of the two submodules. -/
 def of_submodules (p : submodule R M) (q : submodule R₂ M₂) (h : p.map (e : M →ₛₗ[σ₁₂] M₂) = q) :
-p ≃ₛₗ[σ₁₂] q := (e.of_submodule p).trans (linear_equiv.of_eq _ _ h)
+p ≃ₛₗ[σ₁₂] q := (e.submodule_map p).trans (linear_equiv.of_eq _ _ h)
 
 
 @[simp] lemma of_submodules_apply {p : submodule R M} {q : submodule R₂ M₂}

--- a/src/linear_algebra/basic.lean
+++ b/src/linear_algebra/basic.lean
@@ -594,7 +594,7 @@ end
 
 include σ₂₁
 /-- The pushforward of a submodule by an injective linear map is
-linearly equivalent to the original submodule. See also `linear_equiv.map_submodule` for a
+linearly equivalent to the original submodule. See also `linear_equiv.submodule_map` for a
 computable version when `f` has an explicit inverse. -/
 noncomputable def equiv_map_of_injective (f : M →ₛₗ[σ₁₂] M₂) (i : injective f)
   (p : submodule R M) : p ≃ₛₗ[σ₁₂] p.map f :=

--- a/src/linear_algebra/basic.lean
+++ b/src/linear_algebra/basic.lean
@@ -594,7 +594,8 @@ end
 
 include σ₂₁
 /-- The pushforward of a submodule by an injective linear map is
-linearly equivalent to the original submodule. -/
+linearly equivalent to the original submodule. See also `linear_equiv.map_submodule` for a
+computable version when `f` has an explicit inverse. -/
 noncomputable def equiv_map_of_injective (f : M →ₛₗ[σ₁₂] M₂) (i : injective f)
   (p : submodule R M) : p ≃ₛₗ[σ₁₂] p.map f :=
 { map_add' := by { intros, simp, refl, },

--- a/src/linear_algebra/dimension.lean
+++ b/src/linear_algebra/dimension.lean
@@ -198,7 +198,7 @@ lemma dim_eq_of_injective (f : M →ₗ[R] M₁) (h : injective f) :
 /-- Pushforwards of submodules along a `linear_equiv` have the same dimension. -/
 lemma linear_equiv.dim_map_eq (f : M ≃ₗ[R] M₁) (p : submodule R M) :
   module.rank R (p.map (f : M →ₗ[R] M₁)) = module.rank R p :=
-(f.of_submodule p).dim_eq.symm
+(f.submodule_map p).dim_eq.symm
 
 variables (R M)
 

--- a/src/linear_algebra/finite_dimensional.lean
+++ b/src/linear_algebra/finite_dimensional.lean
@@ -802,7 +802,7 @@ end
 /-- Pushforwards of finite-dimensional submodules along a `linear_equiv` have the same finrank. -/
 lemma finrank_map_eq (f : V ≃ₗ[K] V₂) (p : submodule K V) [finite_dimensional K p] :
   finrank K (p.map (f : V →ₗ[K] V₂)) = finrank K p :=
-(f.of_submodule p).finrank_eq.symm
+(f.submodule_map p).finrank_eq.symm
 
 end linear_equiv
 


### PR DESCRIPTION
This makes the names shorter and more uniform:

* `add_equiv.map_add_submonoid`
* `add_equiv.map_add_subgroup`
* `linear_equiv.map_submodule`



---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
