### PR TITLE
[Merged by Bors] - feat(data/polynomial/ring_division): golf and generalize `leading_coeff_div_by_monic_of_monic`

### DIFF
--- a/src/data/polynomial/degree/definitions.lean
+++ b/src/data/polynomial/degree/definitions.lean
@@ -712,6 +712,15 @@ option.some_inj.1 $ show (nat_degree (p ^ n) : with_bot ℕ) = (n * nat_degree p
   by rw [← degree_eq_nat_degree hpn, degree_pow' h, degree_eq_nat_degree hp0,
     ← with_bot.coe_nsmul]; simp
 
+theorem leading_coeff_monic_mul {p q : polynomial R} (hp : monic p) :
+  leading_coeff (p * q) = leading_coeff q :=
+begin
+  rcases eq_or_ne q 0 with rfl|H,
+  { simp },
+  { rw [leading_coeff_mul', hp.leading_coeff, one_mul],
+    rwa [hp.leading_coeff, one_mul, ne.def, leading_coeff_eq_zero] }
+end
+
 theorem leading_coeff_mul_monic {p q : polynomial R} (hq : monic q) :
   leading_coeff (p * q) = leading_coeff p :=
 decidable.by_cases

--- a/src/data/polynomial/ring_division.lean
+++ b/src/data/polynomial/ring_division.lean
@@ -660,25 +660,18 @@ this.elim
   (λ hgu, by rw [hg, degree_mul, degree_X_sub_C, degree_eq_zero_of_is_unit hgu, add_zero])
 
 /-- Division by a monic polynomial doesn't change the leading coefficient. -/
-lemma leading_coeff_div_by_monic_of_monic {R : Type u} [comm_ring R] [is_domain R]
+lemma leading_coeff_div_by_monic_of_monic {R : Type u} [comm_ring R]
   {p q : polynomial R} (hmonic : q.monic) (hdegree : q.degree ≤ p.degree) :
   (p /ₘ q).leading_coeff = p.leading_coeff :=
 begin
-  have hp := mod_by_monic_add_div p hmonic,
-  have hzero : (p /ₘ q) ≠ 0,
-  { intro h,
-    exact not_lt_of_le hdegree ((div_by_monic_eq_zero_iff hmonic).1 h) },
-  have deglt : (p %ₘ q).degree < (q * (p /ₘ q)).degree,
-  { rw degree_mul,
-    refine lt_of_lt_of_le (degree_mod_by_monic_lt p hmonic) _,
-    rw [degree_eq_nat_degree (monic.ne_zero hmonic), degree_eq_nat_degree hzero],
-    norm_cast,
-    simp only [zero_le, le_add_iff_nonneg_right] },
-  have hrew := (leading_coeff_add_of_degree_lt deglt),
-  rw leading_coeff_mul q (p /ₘ q) at hrew,
-  simp only [hmonic, one_mul, monic.leading_coeff] at hrew,
-  nth_rewrite 1 ← hp,
-  exact hrew.symm
+  nontriviality,
+  have h : q.leading_coeff * (p /ₘ q).leading_coeff ≠ 0,
+  { simpa [div_by_monic_eq_zero_iff hmonic, hmonic.leading_coeff, nat.with_bot.one_le_iff_zero_lt]
+      using hdegree },
+  nth_rewrite_rhs 0 ←mod_by_monic_add_div p hmonic,
+  rw [leading_coeff_add_of_degree_lt, leading_coeff_monic_mul hmonic],
+  rw [degree_mul' h, degree_add_div_by_monic hmonic hdegree],
+  exact (degree_mod_by_monic_lt p hmonic).trans_le hdegree
 end
 
 lemma eq_of_monic_of_dvd_of_nat_degree_le (hp : p.monic) (hq : q.monic) (hdiv : p ∣ q)


### PR DESCRIPTION
No longer require that the underlying ring is a domain.
Also added helper API lemma `leading_coeff_monic_mul`.



---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
