### PR TITLE
[Merged by Bors] - feat(algebra/opposites): add `add_opposite`

### DIFF
--- a/src/algebra/group/opposite.lean
+++ b/src/algebra/group/opposite.lean
@@ -340,7 +340,8 @@ def mul_equiv.op {α β} [has_mul α] [has_mul β] :
   right_inv := λ f, by { ext, simp } }
 
 /-- The 'unopposite' of an iso `αᵐᵒᵖ ≃* βᵐᵒᵖ`. Inverse to `mul_equiv.op`. -/
-@[simp, to_additive] def mul_equiv.unop {α β} [has_mul α] [has_mul β] :
+@[simp, to_additive "The 'unopposite' of an iso `αᵃᵒᵖ ≃+ βᵃᵒᵖ`. Inverse to `add_equiv.op`]
+def mul_equiv.unop {α β} [has_mul α] [has_mul β] :
   (αᵐᵒᵖ ≃* βᵐᵒᵖ) ≃ (α ≃* β) := mul_equiv.op.symm
 
 section ext

--- a/src/algebra/group/opposite.lean
+++ b/src/algebra/group/opposite.lean
@@ -340,7 +340,7 @@ def mul_equiv.op {α β} [has_mul α] [has_mul β] :
   right_inv := λ f, by { ext, simp } }
 
 /-- The 'unopposite' of an iso `αᵐᵒᵖ ≃* βᵐᵒᵖ`. Inverse to `mul_equiv.op`. -/
-@[simp, to_additive "The 'unopposite' of an iso `αᵃᵒᵖ ≃+ βᵃᵒᵖ`. Inverse to `add_equiv.op`]
+@[simp, to_additive "The 'unopposite' of an iso `αᵃᵒᵖ ≃+ βᵃᵒᵖ`. Inverse to `add_equiv.op`."]
 def mul_equiv.unop {α β} [has_mul α] [has_mul β] :
   (αᵐᵒᵖ ≃* βᵐᵒᵖ) ≃ (α ≃* β) := mul_equiv.op.symm
 

--- a/src/algebra/group/opposite.lean
+++ b/src/algebra/group/opposite.lean
@@ -9,12 +9,16 @@ import algebra.opposites
 import data.equiv.mul_add
 
 /-!
-# Group structures on the multiplicative opposite
+# Group structures on the multiplicative and additive opposites
 -/
 universes u v
 variables (α : Type u)
 
 namespace mul_opposite
+
+/-!
+### Additive structures on `αᵐᵒᵖ`
+-/
 
 instance [add_semigroup α] : add_semigroup (αᵐᵒᵖ) :=
 unop_injective.add_semigroup _ (λ x y, rfl)
@@ -49,49 +53,55 @@ unop_injective.add_group_smul _ rfl (λ _ _, rfl) (λ _, rfl)
 instance [add_comm_group α] : add_comm_group αᵐᵒᵖ :=
 { .. mul_opposite.add_group α, .. mul_opposite.add_comm_monoid α }
 
-instance [semigroup α] : semigroup αᵐᵒᵖ :=
+/-!
+### Multiplicative structures on `αᵐᵒᵖ`
+
+We also generate additive structures on `αᵃᵒᵖ` using `to_additive`
+-/
+
+@[to_additive] instance [semigroup α] : semigroup αᵐᵒᵖ :=
 { mul_assoc := λ x y z, unop_injective $ eq.symm $ mul_assoc (unop z) (unop y) (unop x),
   .. mul_opposite.has_mul α }
 
-instance [right_cancel_semigroup α] : left_cancel_semigroup αᵐᵒᵖ :=
+@[to_additive] instance [right_cancel_semigroup α] : left_cancel_semigroup αᵐᵒᵖ :=
 { mul_left_cancel := λ x y z H, unop_injective $ mul_right_cancel $ op_injective H,
   .. mul_opposite.semigroup α }
 
-instance [left_cancel_semigroup α] : right_cancel_semigroup αᵐᵒᵖ :=
+@[to_additive] instance [left_cancel_semigroup α] : right_cancel_semigroup αᵐᵒᵖ :=
 { mul_right_cancel := λ x y z H, unop_injective $ mul_left_cancel $ op_injective H,
   .. mul_opposite.semigroup α }
 
-instance [comm_semigroup α] : comm_semigroup αᵐᵒᵖ :=
+@[to_additive] instance [comm_semigroup α] : comm_semigroup αᵐᵒᵖ :=
 { mul_comm := λ x y, unop_injective $ mul_comm (unop y) (unop x),
   .. mul_opposite.semigroup α }
 
-instance [mul_one_class α] : mul_one_class αᵐᵒᵖ :=
+@[to_additive] instance [mul_one_class α] : mul_one_class αᵐᵒᵖ :=
 { one_mul := λ x, unop_injective $ mul_one $ unop x,
   mul_one := λ x, unop_injective $ one_mul $ unop x,
   .. mul_opposite.has_mul α, .. mul_opposite.has_one α }
 
-instance [monoid α] : monoid αᵐᵒᵖ :=
+@[to_additive] instance [monoid α] : monoid αᵐᵒᵖ :=
 { npow := λ n x, op $ x.unop ^ n,
   npow_zero' := λ x, unop_injective $ monoid.npow_zero' x.unop,
   npow_succ' := λ n x, unop_injective $ pow_succ' x.unop n,
   .. mul_opposite.semigroup α, .. mul_opposite.mul_one_class α }
 
-instance [right_cancel_monoid α] : left_cancel_monoid αᵐᵒᵖ :=
+@[to_additive] instance [right_cancel_monoid α] : left_cancel_monoid αᵐᵒᵖ :=
 { .. mul_opposite.left_cancel_semigroup α, .. mul_opposite.monoid α }
 
-instance [left_cancel_monoid α] : right_cancel_monoid αᵐᵒᵖ :=
+@[to_additive] instance [left_cancel_monoid α] : right_cancel_monoid αᵐᵒᵖ :=
 { .. mul_opposite.right_cancel_semigroup α, .. mul_opposite.monoid α }
 
-instance [cancel_monoid α] : cancel_monoid αᵐᵒᵖ :=
+@[to_additive] instance [cancel_monoid α] : cancel_monoid αᵐᵒᵖ :=
 { .. mul_opposite.right_cancel_monoid α, .. mul_opposite.left_cancel_monoid α }
 
-instance [comm_monoid α] : comm_monoid αᵐᵒᵖ :=
+@[to_additive] instance [comm_monoid α] : comm_monoid αᵐᵒᵖ :=
 { .. mul_opposite.monoid α, .. mul_opposite.comm_semigroup α }
 
-instance [cancel_comm_monoid α] : cancel_comm_monoid αᵐᵒᵖ :=
+@[to_additive] instance [cancel_comm_monoid α] : cancel_comm_monoid αᵐᵒᵖ :=
 { .. mul_opposite.cancel_monoid α, .. mul_opposite.comm_monoid α }
 
-instance [div_inv_monoid α] : div_inv_monoid αᵐᵒᵖ :=
+@[to_additive] instance [div_inv_monoid α] : div_inv_monoid αᵐᵒᵖ :=
 { zpow := λ n x, op $ x.unop ^ n,
   zpow_zero' := λ x, unop_injective $ div_inv_monoid.zpow_zero' x.unop,
   zpow_succ' := λ n x, unop_injective $
@@ -99,71 +109,46 @@ instance [div_inv_monoid α] : div_inv_monoid αᵐᵒᵖ :=
   zpow_neg' := λ z x, unop_injective $ div_inv_monoid.zpow_neg' z x.unop,
   .. mul_opposite.monoid α, .. mul_opposite.has_inv α }
 
-instance [group α] : group αᵐᵒᵖ :=
+@[to_additive] instance [group α] : group αᵐᵒᵖ :=
 { mul_left_inv := λ x, unop_injective $ mul_inv_self $ unop x,
   .. mul_opposite.div_inv_monoid α, }
 
-instance [comm_group α] : comm_group αᵐᵒᵖ :=
+@[to_additive] instance [comm_group α] : comm_group αᵐᵒᵖ :=
 { .. mul_opposite.group α, .. mul_opposite.comm_monoid α }
 
 variable {α}
 
-lemma semiconj_by.op [has_mul α] {a x y : α} (h : semiconj_by a x y) :
-  semiconj_by (op a) (op y) (op x) :=
-begin
-  dunfold semiconj_by,
-  rw [← op_mul, ← op_mul, h.eq]
-end
-
-lemma semiconj_by.unop [has_mul α] {a x y : αᵐᵒᵖ} (h : semiconj_by a x y) :
-  semiconj_by (unop a) (unop y) (unop x) :=
-begin
-  dunfold semiconj_by,
-  rw [← unop_mul, ← unop_mul, h.eq]
-end
-
-@[simp] lemma semiconj_by_op [has_mul α] {a x y : α} :
+@[simp, to_additive] lemma semiconj_by_op [has_mul α] {a x y : α} :
   semiconj_by (op a) (op y) (op x) ↔ semiconj_by a x y :=
-begin
-  split,
-  { intro h,
-    rw [← unop_op a, ← unop_op x, ← unop_op y],
-    exact semiconj_by.unop h },
-  { intro h,
-    exact semiconj_by.op h }
-end
+by simp only [semiconj_by, ← op_mul, op_inj, eq_comm]
 
-@[simp] lemma semiconj_by_unop [has_mul α] {a x y : αᵐᵒᵖ} :
+@[simp, to_additive] lemma semiconj_by_unop [has_mul α] {a x y : αᵐᵒᵖ} :
   semiconj_by (unop a) (unop y) (unop x) ↔ semiconj_by a x y :=
 by conv_rhs { rw [← op_unop a, ← op_unop x, ← op_unop y, semiconj_by_op] }
 
-lemma commute.op [has_mul α] {x y : α} (h : commute x y) : commute (op x) (op y) :=
-begin
-  dunfold commute at h ⊢,
-  exact semiconj_by.op h
-end
+@[to_additive] lemma _root_.semiconj_by.op [has_mul α] {a x y : α} (h : semiconj_by a x y) :
+  semiconj_by (op a) (op y) (op x) :=
+semiconj_by_op.2 h
 
-lemma commute.unop [has_mul α] {x y : αᵐᵒᵖ} (h : commute x y) : commute (unop x) (unop y) :=
-begin
-  dunfold commute at h ⊢,
-  exact semiconj_by.unop h
-end
+@[to_additive] lemma _root_.semiconj_by.unop [has_mul α] {a x y : αᵐᵒᵖ} (h : semiconj_by a x y) :
+  semiconj_by (unop a) (unop y) (unop x) :=
+semiconj_by_unop.2 h
 
-@[simp] lemma commute_op [has_mul α] {x y : α} :
+@[to_additive] lemma _root_.commute.op [has_mul α] {x y : α} (h : commute x y) :
+  commute (op x) (op y) := h.op
+
+@[to_additive] lemma commute.unop [has_mul α] {x y : αᵐᵒᵖ} (h : commute x y) :
+  commute (unop x) (unop y) := h.unop
+
+@[to_additive, simp] lemma commute_op [has_mul α] {x y : α} :
   commute (op x) (op y) ↔ commute x y :=
-begin
-  dunfold commute,
-  rw semiconj_by_op
-end
+semiconj_by_op
 
-@[simp] lemma commute_unop [has_mul α] {x y : αᵐᵒᵖ} :
+@[to_additive, simp] lemma commute_unop [has_mul α] {x y : αᵐᵒᵖ} :
   commute (unop x) (unop y) ↔ commute x y :=
-begin
-  dunfold commute,
-  rw semiconj_by_unop
-end
+semiconj_by_unop
 
-/-- The function `unop` is an additive equivalence. -/
+/-- The function `mul_opposite.op` is an additive equivalence. -/
 @[simps { fully_applied := ff, simp_rhs := tt }]
 def op_add_equiv [has_add α] : α ≃+ αᵐᵒᵖ :=
 { map_add' := λ a b, rfl, .. op_equiv }
@@ -174,56 +159,122 @@ rfl
 
 end mul_opposite
 
+/-!
+### Multiplicative structures on `αᵃᵒᵖ`
+-/
+
+namespace add_opposite
+
+instance [semigroup α] : semigroup (αᵃᵒᵖ) :=
+unop_injective.semigroup _ (λ x y, rfl)
+
+instance [left_cancel_semigroup α] : left_cancel_semigroup αᵃᵒᵖ :=
+unop_injective.left_cancel_semigroup _ (λ x y, rfl)
+
+instance [right_cancel_semigroup α] : right_cancel_semigroup αᵃᵒᵖ :=
+unop_injective.right_cancel_semigroup _ (λ x y, rfl)
+
+instance [comm_semigroup α] : comm_semigroup αᵃᵒᵖ :=
+{ mul_comm := λ x y, unop_injective $ mul_comm (unop x) (unop y),
+  .. add_opposite.semigroup α }
+
+instance [mul_one_class α] : mul_one_class αᵃᵒᵖ :=
+unop_injective.mul_one_class _ rfl (λ x y, rfl)
+
+instance {β} [has_pow α β] : has_pow αᵃᵒᵖ β := { pow := λ a b, op (unop a ^ b) }
+
+@[simp] lemma op_pow {β} [has_pow α β] (a : α) (b : β) : op (a ^ b) = op a ^ b := rfl
+@[simp] lemma unop_pow {β} [has_pow α β] (a : αᵃᵒᵖ) (b : β) : unop (a ^ b) = unop a ^ b := rfl
+
+instance [monoid α] : monoid αᵃᵒᵖ :=
+unop_injective.monoid_pow _ rfl (λ _ _, rfl) (λ _ _, rfl)
+
+instance [comm_monoid α] : comm_monoid αᵃᵒᵖ :=
+{ .. add_opposite.monoid α, .. add_opposite.comm_semigroup α }
+
+instance [div_inv_monoid α] : div_inv_monoid αᵃᵒᵖ :=
+unop_injective.div_inv_monoid_pow _ rfl (λ _ _, rfl) (λ _, rfl)
+  (λ _ _, rfl) (λ _ _, rfl) (λ _ _, rfl)
+
+instance [group α] : group αᵃᵒᵖ :=
+unop_injective.group_pow _ rfl (λ _ _, rfl) (λ _, rfl)
+  (λ _ _, rfl) (λ _ _, rfl) (λ _ _, rfl)
+
+instance [comm_group α] : comm_group αᵃᵒᵖ :=
+{ .. add_opposite.group α, .. add_opposite.comm_monoid α }
+
+variable {α}
+
+/-- The function `add_opposite.op` is a multiplicative equivalence. -/
+@[simps { fully_applied := ff, simp_rhs := tt }]
+def op_mul_equiv [has_mul α] : α ≃* αᵃᵒᵖ :=
+{ map_mul' := λ a b, rfl, .. op_equiv }
+
+@[simp] lemma op_mul_equiv_to_equiv [has_mul α] :
+  (op_mul_equiv : α ≃* αᵃᵒᵖ).to_equiv = op_equiv :=
+rfl
+
+end add_opposite
+
 open mul_opposite
 
 /-- Inversion on a group is a `mul_equiv` to the opposite group. When `G` is commutative, there is
 `mul_equiv.inv`. -/
-@[simps { fully_applied := ff, simp_rhs := tt }]
+@[to_additive "/-- Negation on an additive group is an `add_equiv` to the opposite group. When `G`
+is commutative, there is `add_equiv.inv`. -/", simps { fully_applied := ff, simp_rhs := tt }]
 def mul_equiv.inv' (G : Type*) [group G] : G ≃* Gᵐᵒᵖ :=
 { map_mul' := λ x y, unop_injective $ mul_inv_rev x y,
   .. (equiv.inv G).trans op_equiv }
 
-/-- A monoid homomorphism `f : R →* S` such that `f x` commutes with `f y` for all `x, y` defines
-a monoid homomorphism to `Sᵐᵒᵖ`. -/
-@[simps {fully_applied := ff}]
-def monoid_hom.to_opposite {R S : Type*} [mul_one_class R] [mul_one_class S] (f : R →* S)
-  (hf : ∀ x y, commute (f x) (f y)) : R →* Sᵐᵒᵖ :=
+/-- A monoid homomorphism `f : M →* N` such that `f x` commutes with `f y` for all `x, y` defines
+a monoid homomorphism to `Nᵐᵒᵖ`. -/
+@[to_additive "/-- An additive monoid homomorphism `f : M →+ N` such that `f x` additively commutes
+with `f y` for all `x, y` defines an additive monoid homomorphism to `Sᵃᵒᵖ`. -/",
+  simps {fully_applied := ff}]
+def monoid_hom.to_opposite {M N : Type*} [mul_one_class M] [mul_one_class N] (f : M →* N)
+  (hf : ∀ x y, commute (f x) (f y)) : M →* Nᵐᵒᵖ :=
 { to_fun := mul_opposite.op ∘ f,
   map_one' := congr_arg op f.map_one,
   map_mul' := λ x y, by simp [(hf x y).eq] }
 
-/-- A monoid homomorphism `f : R →* S` such that `f x` commutes with `f y` for all `x, y` defines
-a monoid homomorphism from `Rᵐᵒᵖ`. -/
-@[simps {fully_applied := ff}]
-def monoid_hom.from_opposite {R S : Type*} [mul_one_class R] [mul_one_class S] (f : R →* S)
-  (hf : ∀ x y, commute (f x) (f y)) : Rᵐᵒᵖ →* S :=
+/-- A monoid homomorphism `f : M →* N` such that `f x` commutes with `f y` for all `x, y` defines
+a monoid homomorphism from `Mᵐᵒᵖ`. -/
+@[to_additive "/-- An additive monoid homomorphism `f : M →+ N` such that `f x` additively commutes
+with `f y` for all `x`, `y` defines an additive monoid homomorphism from `Mᵃᵒᵖ`. -/",
+  simps {fully_applied := ff}]
+def monoid_hom.from_opposite {M N : Type*} [mul_one_class M] [mul_one_class N] (f : M →* N)
+  (hf : ∀ x y, commute (f x) (f y)) : Mᵐᵒᵖ →* N :=
 { to_fun := f ∘ mul_opposite.unop,
   map_one' := f.map_one,
   map_mul' := λ x y, (f.map_mul _ _).trans (hf _ _).eq }
 
 /-- The units of the opposites are equivalent to the opposites of the units. -/
-def units.op_equiv {R} [monoid R] : units Rᵐᵒᵖ ≃* (units R)ᵐᵒᵖ :=
+@[to_additive "The additive units of the additive opposites are equivalent to the additive opposites
+of the additive units."]
+def units.op_equiv {M} [monoid M] : units Mᵐᵒᵖ ≃* (units M)ᵐᵒᵖ :=
 { to_fun := λ u, op ⟨unop u, unop ↑(u⁻¹), op_injective u.4, op_injective u.3⟩,
   inv_fun := mul_opposite.rec $ λ u, ⟨op ↑(u), op ↑(u⁻¹), unop_injective $ u.4, unop_injective u.3⟩,
   map_mul' := λ x y, unop_injective $ units.ext $ rfl,
   left_inv := λ x, units.ext $ by simp,
   right_inv := λ x, unop_injective $ units.ext $ rfl }
 
-@[simp]
-lemma units.coe_unop_op_equiv {R} [monoid R] (u : units Rᵐᵒᵖ) :
-  ((units.op_equiv u).unop : R) = unop (u : Rᵐᵒᵖ) :=
+@[simp, to_additive]
+lemma units.coe_unop_op_equiv {M} [monoid M] (u : units Mᵐᵒᵖ) :
+  ((units.op_equiv u).unop : M) = unop (u : Mᵐᵒᵖ) :=
 rfl
 
-@[simp]
-lemma units.coe_op_equiv_symm {R} [monoid R] (u : (units R)ᵐᵒᵖ) :
-  (units.op_equiv.symm u : Rᵐᵒᵖ) = op (u.unop : R) :=
+@[simp, to_additive]
+lemma units.coe_op_equiv_symm {M} [monoid M] (u : (units M)ᵐᵒᵖ) :
+  (units.op_equiv.symm u : Mᵐᵒᵖ) = op (u.unop : M) :=
 rfl
 
-/-- A hom `α →* β` can equivalently be viewed as a hom `αᵐᵒᵖ →* βᵐᵒᵖ`. This is the action of the
-(fully faithful) `ᵐᵒᵖ`-functor on morphisms. -/
-@[simps]
-def monoid_hom.op {α β} [mul_one_class α] [mul_one_class β] :
-  (α →* β) ≃ (αᵐᵒᵖ →* βᵐᵒᵖ) :=
+/-- A monoid homomorphism `M →* N` can equivalently be viewed as a monoid homomorphism
+`Mᵐᵒᵖ →* Nᵐᵒᵖ`. This is the action of the (fully faithful) `ᵐᵒᵖ`-functor on morphisms. -/
+@[to_additive "/-- An additive monoid homomorphism `M →+ N` can equivalently be viewed as an
+additive monoid homomorphism `Mᵃᵒᵖ →+ Nᵃᵒᵖ`. This is the action of the (fully faithful)
+`ᵃᵒᵖ`-functor on morphisms. -/", simps]
+def monoid_hom.op {M N} [mul_one_class M] [mul_one_class N] :
+  (M →* N) ≃ (Mᵐᵒᵖ →* Nᵐᵒᵖ) :=
 { to_fun    := λ f, { to_fun   := op ∘ f ∘ unop,
                       map_one' := congr_arg op f.map_one,
                       map_mul' := λ x y, unop_injective (f.map_mul y.unop x.unop) },
@@ -233,15 +284,17 @@ def monoid_hom.op {α β} [mul_one_class α] [mul_one_class β] :
   left_inv  := λ f, by { ext, refl },
   right_inv := λ f, by { ext x, simp } }
 
-/-- The 'unopposite' of a monoid hom `αᵐᵒᵖ →* βᵐᵒᵖ`. Inverse to `monoid_hom.op`. -/
-@[simp] def monoid_hom.unop {α β} [mul_one_class α] [mul_one_class β] :
-  (αᵐᵒᵖ →* βᵐᵒᵖ) ≃ (α →* β) := monoid_hom.op.symm
+/-- The 'unopposite' of a monoid homomorphism `Mᵐᵒᵖ →* Nᵐᵒᵖ`. Inverse to `monoid_hom.op`. -/
+@[simp, to_additive "The 'unopposite' of an additive monoid homomorphism `Mᵃᵒᵖ →+ Nᵃᵒᵖ`. Inverse to
+`add_monoid_hom.op`."]
+def monoid_hom.unop {M N} [mul_one_class M] [mul_one_class N] :
+  (Mᵐᵒᵖ →* Nᵐᵒᵖ) ≃ (M →* N) := monoid_hom.op.symm
 
-/-- A hom `α →+ β` can equivalently be viewed as a hom `αᵐᵒᵖ →+ βᵐᵒᵖ`. This is the action of the
-(fully faithful) `ᵐᵒᵖ`-functor on morphisms. -/
+/-- An additive homomorphism `M →+ N` can equivalently be viewed as an additive homomorphism
+`Mᵐᵒᵖ →+ Nᵐᵒᵖ`. This is the action of the (fully faithful) `ᵐᵒᵖ`-functor on morphisms. -/
 @[simps]
-def add_monoid_hom.op {α β} [add_zero_class α] [add_zero_class β] :
-  (α →+ β) ≃ (αᵐᵒᵖ →+ βᵐᵒᵖ) :=
+def add_monoid_hom.mul_op {M N} [add_zero_class M] [add_zero_class N] :
+  (M →+ N) ≃ (Mᵐᵒᵖ →+ Nᵐᵒᵖ) :=
 { to_fun    := λ f, { to_fun    := op ∘ f ∘ unop,
                       map_zero' := unop_injective f.map_zero,
                       map_add'  := λ x y, unop_injective (f.map_add x.unop y.unop) },
@@ -251,25 +304,26 @@ def add_monoid_hom.op {α β} [add_zero_class α] [add_zero_class β] :
   left_inv  := λ f, by { ext, refl },
   right_inv := λ f, by { ext, simp } }
 
-/-- The 'unopposite' of an additive monoid hom `αᵐᵒᵖ →+ βᵐᵒᵖ`. Inverse to `add_monoid_hom.op`. -/
-@[simp] def add_monoid_hom.unop {α β} [add_zero_class α] [add_zero_class β] :
-  (αᵐᵒᵖ →+ βᵐᵒᵖ) ≃ (α →+ β) := add_monoid_hom.op.symm
+/-- The 'unopposite' of an additive monoid hom `αᵐᵒᵖ →+ βᵐᵒᵖ`. Inverse to
+`add_monoid_hom.mul_op`. -/
+@[simp] def add_monoid_hom.mul_unop {α β} [add_zero_class α] [add_zero_class β] :
+  (αᵐᵒᵖ →+ βᵐᵒᵖ) ≃ (α →+ β) := add_monoid_hom.mul_op.symm
 
 /-- A iso `α ≃+ β` can equivalently be viewed as an iso `αᵐᵒᵖ ≃+ βᵐᵒᵖ`. -/
 @[simps]
-def add_equiv.op {α β} [has_add α] [has_add β] :
+def add_equiv.mul_op {α β} [has_add α] [has_add β] :
   (α ≃+ β) ≃ (αᵐᵒᵖ ≃+ βᵐᵒᵖ) :=
 { to_fun    := λ f, op_add_equiv.symm.trans (f.trans op_add_equiv),
   inv_fun   := λ f, op_add_equiv.trans (f.trans op_add_equiv.symm),
   left_inv  := λ f, by { ext, refl },
   right_inv := λ f, by { ext, simp } }
 
-/-- The 'unopposite' of an iso `αᵐᵒᵖ ≃+ βᵐᵒᵖ`. Inverse to `add_equiv.op`. -/
-@[simp] def add_equiv.unop {α β} [has_add α] [has_add β] :
-  (αᵐᵒᵖ ≃+ βᵐᵒᵖ) ≃ (α ≃+ β) := add_equiv.op.symm
+/-- The 'unopposite' of an iso `αᵐᵒᵖ ≃+ βᵐᵒᵖ`. Inverse to `add_equiv.mul_op`. -/
+@[simp] def add_equiv.mul_unop {α β} [has_add α] [has_add β] :
+  (αᵐᵒᵖ ≃+ βᵐᵒᵖ) ≃ (α ≃+ β) := add_equiv.mul_op.symm
 
-/-- A iso `α ≃* β` can equivalently be viewed as an iso `αᵐᵒᵖ ≃+ βᵐᵒᵖ`. -/
-@[simps]
+/-- A iso `α ≃* β` can equivalently be viewed as an iso `αᵐᵒᵖ ≃* βᵐᵒᵖ`. -/
+@[to_additive "A iso `α ≃+ β` can equivalently be viewed as an iso `αᵃᵒᵖ ≃+ βᵃᵒᵖ`. -/", simps]
 def mul_equiv.op {α β} [has_mul α] [has_mul β] :
   (α ≃* β) ≃ (αᵐᵒᵖ ≃* βᵐᵒᵖ) :=
 { to_fun    := λ f, { to_fun   := op ∘ f ∘ unop,
@@ -286,7 +340,7 @@ def mul_equiv.op {α β} [has_mul α] [has_mul β] :
   right_inv := λ f, by { ext, simp } }
 
 /-- The 'unopposite' of an iso `αᵐᵒᵖ ≃* βᵐᵒᵖ`. Inverse to `mul_equiv.op`. -/
-@[simp] def mul_equiv.unop {α β} [has_mul α] [has_mul β] :
+@[simp, to_additive] def mul_equiv.unop {α β} [has_mul α] [has_mul β] :
   (αᵐᵒᵖ ≃* βᵐᵒᵖ) ≃ (α ≃* β) := mul_equiv.op.symm
 
 section ext
@@ -295,7 +349,7 @@ section ext
 This is useful because there are often ext lemmas for specific `α`s that will apply
 to an equality of `α →+ β` such as `finsupp.add_hom_ext'`. -/
 @[ext]
-lemma add_monoid_hom.op_ext {α β} [add_zero_class α] [add_zero_class β]
+lemma add_monoid_hom.mul_op_ext {α β} [add_zero_class α] [add_zero_class β]
   (f g : αᵐᵒᵖ →+ β)
   (h : f.comp (op_add_equiv : α ≃+ αᵐᵒᵖ).to_add_monoid_hom =
        g.comp (op_add_equiv : α ≃+ αᵐᵒᵖ).to_add_monoid_hom) : f = g :=

--- a/src/algebra/opposites.lean
+++ b/src/algebra/opposites.lean
@@ -10,14 +10,24 @@ import logic.nontrivial
 /-!
 # Multiplicative opposite and algebraic operations on it
 
-In this file we define `mul_opposite α = αᵐᵒᵖ` to be the multiplicative opposite of `α`. It
-inherits all additive algebraic structures on `α` (in other files), and reverses the order of
-multipliers in multiplicative structures, i.e., `op (x * y) = op x * op y`, where `mul_opposite.op`
-is the canonical map from `α` to `αᵐᵒᵖ`.
+In this file we define `mul_opposite α = αᵐᵒᵖ` to be the multiplicative opposite of `α`. It inherits
+all additive algebraic structures on `α` (in other files), and reverses the order of multipliers in
+multiplicative structures, i.e., `op (x * y) = op y * op x`, where `mul_opposite.op` is the
+canonical map from `α` to `αᵐᵒᵖ`.
+
+We also define `add_opposite α = αᵃᵒᵖ` to be the additive opposite of `α`. It inherits all
+multiplicative algebraic structures on `α` (in other files), and reverses the order of summands in
+additive structures, i.e. `op (x + y) = op y + op x`, where `add_opposite.op` is the canonical map
+from `α` to `αᵃᵒᵖ`.
 
 ## Notation
 
-`αᵐᵒᵖ = mul_opposite α`
+* `αᵐᵒᵖ = mul_opposite α`
+* `αᵃᵒᵖ = add_opposite α`
+
+## Tags
+
+multiplicative opposite, additive opposite
 -/
 
 universes u v
@@ -25,59 +35,62 @@ open function
 
 /-- Multiplicative opposite of a type. This type inherits all additive structures on `α` and
 reverses left and right in multiplication.-/
+@[to_additive "/-- Additive opposite of a type. This type inherits all multiplicative structures on
+`α` and reverses left and right in addition. -/"]
 def mul_opposite (α : Type u) : Type u := α
 
 postfix `ᵐᵒᵖ`:std.prec.max_plus := mul_opposite
-
-namespace mul_opposite
+postfix `ᵃᵒᵖ`:std.prec.max_plus := add_opposite
 
 variables {α : Type u}
 
+namespace mul_opposite
+
 /-- The element of `mul_opposite α` that represents `x : α`. -/
-@[pp_nodot]
-def op : α → αᵐᵒᵖ := id
+@[pp_nodot, to_additive] def op : α → αᵐᵒᵖ := id
 
 /-- The element of `α` represented by `x : αᵐᵒᵖ`. -/
-@[pp_nodot]
-def unop : αᵐᵒᵖ → α := id
+@[pp_nodot, to_additive] def unop : αᵐᵒᵖ → α := id
 
-@[simp] lemma unop_op (x : α) : unop (op x) = x := rfl
-@[simp] lemma op_unop (x : αᵐᵒᵖ) : op (unop x) = x := rfl
-@[simp] lemma op_comp_unop : (op : α → αᵐᵒᵖ) ∘ unop = id := rfl
-@[simp] lemma unop_comp_op : (unop : αᵐᵒᵖ → α) ∘ op = id := rfl
+attribute [pp_nodot] add_opposite.op add_opposite.unop
+
+@[simp, to_additive] lemma unop_op (x : α) : unop (op x) = x := rfl
+@[simp, to_additive] lemma op_unop (x : αᵐᵒᵖ) : op (unop x) = x := rfl
+@[simp, to_additive] lemma op_comp_unop : (op : α → αᵐᵒᵖ) ∘ unop = id := rfl
+@[simp, to_additive] lemma unop_comp_op : (unop : αᵐᵒᵖ → α) ∘ op = id := rfl
 
 attribute [irreducible] mul_opposite
 
 /-- A recursor for `opposite`. Use as `induction x using mul_opposite.rec`. -/
-@[simp]
+@[simp, to_additive]
 protected def rec {F : Π (X : αᵐᵒᵖ), Sort v} (h : Π X, F (op X)) : Π X, F X :=
 λ X, h (unop X)
 
 /-- The canonical bijection between `αᵐᵒᵖ` and `α`. -/
-@[simps apply symm_apply { fully_applied := ff }]
+@[to_additive, simps apply symm_apply { fully_applied := ff }]
 def op_equiv : α ≃ αᵐᵒᵖ := ⟨op, unop, unop_op, op_unop⟩
 
-lemma op_bijective : bijective (op : α → αᵐᵒᵖ) := op_equiv.bijective
-lemma unop_bijective : bijective (unop : αᵐᵒᵖ → α) := op_equiv.symm.bijective
-lemma op_injective : injective (op : α → αᵐᵒᵖ) := op_bijective.injective
-lemma op_surjective : surjective (op : α → αᵐᵒᵖ) := op_bijective.surjective
-lemma unop_injective : injective (unop : αᵐᵒᵖ → α) := unop_bijective.injective
-lemma unop_surjective : surjective (unop : αᵐᵒᵖ → α) := unop_bijective.surjective
+@[to_additive] lemma op_bijective : bijective (op : α → αᵐᵒᵖ) := op_equiv.bijective
+@[to_additive] lemma unop_bijective : bijective (unop : αᵐᵒᵖ → α) := op_equiv.symm.bijective
+@[to_additive] lemma op_injective : injective (op : α → αᵐᵒᵖ) := op_bijective.injective
+@[to_additive] lemma op_surjective : surjective (op : α → αᵐᵒᵖ) := op_bijective.surjective
+@[to_additive] lemma unop_injective : injective (unop : αᵐᵒᵖ → α) := unop_bijective.injective
+@[to_additive] lemma unop_surjective : surjective (unop : αᵐᵒᵖ → α) := unop_bijective.surjective
 
-@[simp] lemma op_inj {x y : α} : op x = op y ↔ x = y := op_injective.eq_iff
-@[simp] lemma unop_inj {x y : αᵐᵒᵖ} : unop x = unop y ↔ x = y := unop_injective.eq_iff
+@[simp, to_additive] lemma op_inj {x y : α} : op x = op y ↔ x = y := op_injective.eq_iff
+@[simp, to_additive] lemma unop_inj {x y : αᵐᵒᵖ} : unop x = unop y ↔ x = y := unop_injective.eq_iff
 
 variable (α)
 
-instance [nontrivial α] : nontrivial αᵐᵒᵖ := op_injective.nontrivial
-instance [inhabited α] : inhabited αᵐᵒᵖ := ⟨op (default α)⟩
-instance [subsingleton α] : subsingleton αᵐᵒᵖ := unop_injective.subsingleton
-instance [unique α] : unique αᵐᵒᵖ := unique.mk' _
-instance [is_empty α] : is_empty αᵐᵒᵖ := function.is_empty unop
+@[to_additive] instance [nontrivial α] : nontrivial αᵐᵒᵖ := op_injective.nontrivial
+@[to_additive] instance [inhabited α] : inhabited αᵐᵒᵖ := ⟨op (default α)⟩
+@[to_additive] instance [subsingleton α] : subsingleton αᵐᵒᵖ := unop_injective.subsingleton
+@[to_additive] instance [unique α] : unique αᵐᵒᵖ := unique.mk' _
+@[to_additive] instance [is_empty α] : is_empty αᵐᵒᵖ := function.is_empty unop
 
 instance [has_zero α] : has_zero αᵐᵒᵖ := { zero := op 0 }
 
-instance [has_one α] : has_one αᵐᵒᵖ := { one := op 1 }
+@[to_additive] instance [has_one α] : has_one αᵐᵒᵖ := { one := op 1 }
 
 instance [has_add α] : has_add αᵐᵒᵖ :=
 { add := λ x y, op (unop x + unop y) }
@@ -88,13 +101,13 @@ instance [has_sub α] : has_sub αᵐᵒᵖ :=
 instance [has_neg α] : has_neg αᵐᵒᵖ :=
 { neg := λ x, op $ -(unop x) }
 
-instance [has_mul α] : has_mul αᵐᵒᵖ :=
+@[to_additive] instance [has_mul α] : has_mul αᵐᵒᵖ :=
 { mul := λ x y, op (unop y * unop x) }
 
-instance [has_inv α] : has_inv αᵐᵒᵖ :=
+@[to_additive] instance [has_inv α] : has_inv αᵐᵒᵖ :=
 { inv := λ x, op $ (unop x)⁻¹ }
 
-instance (R : Type*) [has_scalar R α] : has_scalar R αᵐᵒᵖ :=
+@[to_additive] instance (R : Type*) [has_scalar R α] : has_scalar R αᵐᵒᵖ :=
 { smul := λ c x, op (c • unop x) }
 
 section
@@ -103,8 +116,8 @@ variables (α)
 @[simp] lemma op_zero [has_zero α] : op (0 : α) = 0 := rfl
 @[simp] lemma unop_zero [has_zero α] : unop (0 : αᵐᵒᵖ) = 0 := rfl
 
-@[simp] lemma op_one [has_one α] : op (1 : α) = 1 := rfl
-@[simp] lemma unop_one [has_one α] : unop (1 : αᵐᵒᵖ) = 1 := rfl
+@[simp, to_additive] lemma op_one [has_one α] : op (1 : α) = 1 := rfl
+@[simp, to_additive] lemma unop_one [has_one α] : unop (1 : αᵐᵒᵖ) = 1 := rfl
 
 variable {α}
 
@@ -114,37 +127,70 @@ variable {α}
 @[simp] lemma op_neg [has_neg α] (x : α) : op (-x) = -op x := rfl
 @[simp] lemma unop_neg [has_neg α] (x : αᵐᵒᵖ) : unop (-x) = -unop x := rfl
 
-@[simp] lemma op_mul [has_mul α] (x y : α) : op (x * y) = op y * op x := rfl
-@[simp] lemma unop_mul [has_mul α] (x y : αᵐᵒᵖ) : unop (x * y) = unop y * unop x := rfl
+@[simp, to_additive] lemma op_mul [has_mul α] (x y : α) : op (x * y) = op y * op x := rfl
+@[simp, to_additive] lemma unop_mul [has_mul α] (x y : αᵐᵒᵖ) : unop (x * y) = unop y * unop x := rfl
 
-@[simp] lemma op_inv [has_inv α] (x : α) : op (x⁻¹) = (op x)⁻¹ := rfl
-@[simp] lemma unop_inv [has_inv α] (x : αᵐᵒᵖ) : unop (x⁻¹) = (unop x)⁻¹ := rfl
+@[simp, to_additive] lemma op_inv [has_inv α] (x : α) : op (x⁻¹) = (op x)⁻¹ := rfl
+@[simp, to_additive] lemma unop_inv [has_inv α] (x : αᵐᵒᵖ) : unop (x⁻¹) = (unop x)⁻¹ := rfl
 
 @[simp] lemma op_sub [has_sub α] (x y : α) : op (x - y) = op x - op y := rfl
 @[simp] lemma unop_sub [has_sub α] (x y : αᵐᵒᵖ) : unop (x - y) = unop x - unop y := rfl
 
-@[simp] lemma op_smul {R : Type*} [has_scalar R α] (c : R) (a : α) : op (c • a) = c • op a := rfl
-@[simp] lemma unop_smul {R : Type*} [has_scalar R α] (c : R) (a : αᵐᵒᵖ) :
+@[simp, to_additive] lemma op_smul {R : Type*} [has_scalar R α] (c : R) (a : α) :
+  op (c • a) = c • op a := rfl
+
+@[simp, to_additive] lemma unop_smul {R : Type*} [has_scalar R α] (c : R) (a : αᵐᵒᵖ) :
   unop (c • a) = c • unop a := rfl
 
 end
 
-@[simp] lemma unop_eq_zero_iff {α} [has_zero α] (a : αᵐᵒᵖ) : a.unop = (0 : α) ↔ a = (0 : αᵐᵒᵖ) :=
+variable {α}
+
+@[simp] lemma unop_eq_zero_iff [has_zero α] (a : αᵐᵒᵖ) : a.unop = (0 : α) ↔ a = (0 : αᵐᵒᵖ) :=
 unop_injective.eq_iff' rfl
 
-@[simp] lemma op_eq_zero_iff {α} [has_zero α] (a : α) : op a = (0 : αᵐᵒᵖ) ↔ a = (0 : α) :=
+@[simp] lemma op_eq_zero_iff [has_zero α] (a : α) : op a = (0 : αᵐᵒᵖ) ↔ a = (0 : α) :=
 op_injective.eq_iff' rfl
 
-lemma unop_ne_zero_iff {α} [has_zero α] (a : αᵐᵒᵖ) : a.unop ≠ (0 : α) ↔ a ≠ (0 : αᵐᵒᵖ) :=
+lemma unop_ne_zero_iff [has_zero α] (a : αᵐᵒᵖ) : a.unop ≠ (0 : α) ↔ a ≠ (0 : αᵐᵒᵖ) :=
 not_congr $ unop_eq_zero_iff a
 
-lemma op_ne_zero_iff {α} [has_zero α] (a : α) : op a ≠ (0 : αᵐᵒᵖ) ↔ a ≠ (0 : α) :=
+lemma op_ne_zero_iff [has_zero α] (a : α) : op a ≠ (0 : αᵐᵒᵖ) ↔ a ≠ (0 : α) :=
 not_congr $ op_eq_zero_iff a
 
-@[simp] lemma unop_eq_one_iff {α} [has_one α] (a : αᵐᵒᵖ) : a.unop = 1 ↔ a = 1 :=
+@[simp, to_additive] lemma unop_eq_one_iff [has_one α] (a : αᵐᵒᵖ) : a.unop = 1 ↔ a = 1 :=
 unop_injective.eq_iff' rfl
 
-@[simp] lemma op_eq_one_iff {α} [has_one α] (a : α) : op a = 1 ↔ a = 1 :=
+@[simp, to_additive] lemma op_eq_one_iff [has_one α] (a : α) : op a = 1 ↔ a = 1 :=
 op_injective.eq_iff' rfl
 
 end mul_opposite
+
+namespace add_opposite
+
+instance [has_one α] : has_one αᵃᵒᵖ := { one := op 1 }
+
+@[simp] lemma op_one [has_one α] : op (1 : α) = 1 := rfl
+@[simp] lemma unop_one [has_one α] : unop 1 = (1 : α) := rfl
+
+@[simp] lemma op_eq_one_iff [has_one α] {a : α} : op a = 1 ↔ a = 1 := op_injective.eq_iff' op_one
+
+@[simp] lemma unop_eq_one_iff [has_one α] {a : αᵃᵒᵖ} : unop a = 1 ↔ a = 1 :=
+unop_injective.eq_iff' unop_one
+
+instance [has_mul α] : has_mul αᵃᵒᵖ := { mul := λ a b, op (unop a * unop b) }
+
+@[simp] lemma op_mul [has_mul α] (a b : α) : op (a * b) = op a * op b := rfl
+@[simp] lemma unop_mul [has_mul α] (a b : αᵃᵒᵖ) : unop (a * b) = unop a * unop b := rfl
+
+instance [has_inv α] : has_inv αᵃᵒᵖ := { inv := λ a, op (unop a)⁻¹ }
+
+@[simp] lemma op_inv [has_inv α] (a : α) : op a⁻¹ := (op a)⁻¹ := rfl
+@[simp] lemma unop_inv [has_inv α] (a : αᵃᵒᵖ) : unop a⁻¹ = (unop a)⁻¹ := rfl
+
+instance [has_div α] : has_div αᵃᵒᵖ := { div := λ a b, op (unop a / unop b) }
+
+@[simp] lemma op_div [has_div α] (a b : α) : op (a / b) = op a / op b := rfl
+@[simp] lemma unop_div [has_div α] (a b : α) : unop (a / b) = unop a / unop b := rfl
+
+end add_opposite

--- a/src/algebra/opposites.lean
+++ b/src/algebra/opposites.lean
@@ -68,8 +68,9 @@ attribute [irreducible] mul_opposite
 protected def rec {F : Π (X : αᵐᵒᵖ), Sort v} (h : Π X, F (op X)) : Π X, F X :=
 λ X, h (unop X)
 
-/-- The canonical bijection between `αᵐᵒᵖ` and `α`. -/
-@[to_additive, simps apply symm_apply { fully_applied := ff }]
+/-- The canonical bijection between `α` and `αᵐᵒᵖ`. -/
+@[to_additive "The canonical bijection between `α` and `αᵃᵒᵖ`.",
+  simps apply symm_apply { fully_applied := ff }]
 def op_equiv : α ≃ αᵐᵒᵖ := ⟨op, unop, unop_op, op_unop⟩
 
 @[to_additive] lemma op_bijective : bijective (op : α → αᵐᵒᵖ) := op_equiv.bijective

--- a/src/algebra/opposites.lean
+++ b/src/algebra/opposites.lean
@@ -47,10 +47,12 @@ variables {α : Type u}
 namespace mul_opposite
 
 /-- The element of `mul_opposite α` that represents `x : α`. -/
-@[pp_nodot, to_additive] def op : α → αᵐᵒᵖ := id
+@[pp_nodot, to_additive "The element of `αᵃᵒᵖ` that represents `x : α`."]
+def op : α → αᵐᵒᵖ := id
 
 /-- The element of `α` represented by `x : αᵐᵒᵖ`. -/
-@[pp_nodot, to_additive] def unop : αᵐᵒᵖ → α := id
+@[pp_nodot, to_additive "The element of `α` represented by `x : αᵃᵒᵖ`."]
+def unop : αᵐᵒᵖ → α := id
 
 attribute [pp_nodot] add_opposite.op add_opposite.unop
 
@@ -61,8 +63,8 @@ attribute [pp_nodot] add_opposite.op add_opposite.unop
 
 attribute [irreducible] mul_opposite
 
-/-- A recursor for `opposite`. Use as `induction x using mul_opposite.rec`. -/
-@[simp, to_additive]
+/-- A recursor for `mul_opposite`. Use as `induction x using mul_opposite.rec`. -/
+@[simp, to_additive "A recursor for `add_opposite`. Use as `induction x using add_opposite.rec`."]
 protected def rec {F : Π (X : αᵐᵒᵖ), Sort v} (h : Π X, F (op X)) : Π X, F X :=
 λ X, h (unop X)
 

--- a/src/algebra/opposites.lean
+++ b/src/algebra/opposites.lean
@@ -185,7 +185,7 @@ instance [has_mul α] : has_mul αᵃᵒᵖ := { mul := λ a b, op (unop a * uno
 
 instance [has_inv α] : has_inv αᵃᵒᵖ := { inv := λ a, op (unop a)⁻¹ }
 
-@[simp] lemma op_inv [has_inv α] (a : α) : op a⁻¹ := (op a)⁻¹ := rfl
+@[simp] lemma op_inv [has_inv α] (a : α) : op a⁻¹ = (op a)⁻¹ := rfl
 @[simp] lemma unop_inv [has_inv α] (a : αᵃᵒᵖ) : unop a⁻¹ = (unop a)⁻¹ := rfl
 
 instance [has_div α] : has_div αᵃᵒᵖ := { div := λ a b, op (unop a / unop b) }

--- a/src/algebra/ring/opposite.lean
+++ b/src/algebra/ring/opposite.lean
@@ -97,8 +97,8 @@ action of the (fully faithful) `ᵐᵒᵖ`-functor on morphisms. -/
 @[simps]
 def ring_hom.op {α β} [non_assoc_semiring α] [non_assoc_semiring β] :
   (α →+* β) ≃ (αᵐᵒᵖ →+* βᵐᵒᵖ) :=
-{ to_fun    := λ f, { ..f.to_add_monoid_hom.op, ..f.to_monoid_hom.op },
-  inv_fun   := λ f, { ..f.to_add_monoid_hom.unop, ..f.to_monoid_hom.unop },
+{ to_fun    := λ f, { ..f.to_add_monoid_hom.mul_op, ..f.to_monoid_hom.op },
+  inv_fun   := λ f, { ..f.to_add_monoid_hom.mul_unop, ..f.to_monoid_hom.unop },
   left_inv  := λ f, by { ext, refl },
   right_inv := λ f, by { ext, simp } }
 

--- a/src/data/equiv/ring.lean
+++ b/src/data/equiv/ring.lean
@@ -185,8 +185,8 @@ open mul_opposite
 @[simps]
 protected def op {α β} [has_add α] [has_mul α] [has_add β] [has_mul β] :
   (α ≃+* β) ≃ (αᵐᵒᵖ ≃+* βᵐᵒᵖ) :=
-{ to_fun    := λ f, { ..f.to_add_equiv.op, ..f.to_mul_equiv.op},
-  inv_fun   := λ f, { ..(add_equiv.op.symm f.to_add_equiv), ..(mul_equiv.op.symm f.to_mul_equiv) },
+{ to_fun    := λ f, { ..f.to_add_equiv.mul_op, ..f.to_mul_equiv.op},
+  inv_fun   := λ f, { ..add_equiv.mul_op.symm f.to_add_equiv, ..mul_equiv.op.symm f.to_mul_equiv },
   left_inv  := λ f, by { ext, refl },
   right_inv := λ f, by { ext, refl } }
 

--- a/src/group_theory/group_action/opposite.lean
+++ b/src/group_theory/group_action/opposite.lean
@@ -25,7 +25,7 @@ Actions on the opposite type just act on the underlying type.
 
 namespace mul_opposite
 
-instance (R : Type*) [monoid R] [mul_action R α] : mul_action R αᵐᵒᵖ :=
+@[to_additive] instance (R : Type*) [monoid R] [mul_action R α] : mul_action R αᵐᵒᵖ :=
 { one_smul := λ x, unop_injective $ one_smul R (unop x),
   mul_smul := λ r₁ r₂ x, unop_injective $ mul_smul r₁ r₂ (unop x),
   .. mul_opposite.has_scalar α R }
@@ -46,7 +46,7 @@ instance {M N} [has_scalar M N] [has_scalar M α] [has_scalar N α] [is_scalar_t
   is_scalar_tower M N αᵐᵒᵖ :=
 ⟨λ x y z, unop_injective $ smul_assoc _ _ _⟩
 
-instance {M N} [has_scalar M α] [has_scalar N α] [smul_comm_class M N α] :
+@[to_additive] instance {M N} [has_scalar M α] [has_scalar N α] [smul_comm_class M N α] :
   smul_comm_class M N αᵐᵒᵖ :=
 ⟨λ x y z, unop_injective $ smul_comm _ _ _⟩
 
@@ -76,30 +76,29 @@ open mul_opposite
 /-- Like `has_mul.to_has_scalar`, but multiplies on the right.
 
 See also `monoid.to_opposite_mul_action` and `monoid_with_zero.to_opposite_mul_action_with_zero`. -/
-instance has_mul.to_has_opposite_scalar [has_mul α] : has_scalar αᵐᵒᵖ α :=
+@[to_additive] instance has_mul.to_has_opposite_scalar [has_mul α] : has_scalar αᵐᵒᵖ α :=
 { smul := λ c x, x * c.unop }
 
-@[simp] lemma op_smul_eq_mul [has_mul α] {a a' : α} : op a • a' = a' * a := rfl
+@[simp, to_additive] lemma op_smul_eq_mul [has_mul α] {a a' : α} : op a • a' = a' * a := rfl
 
--- TODO: add an additive version once we have additive opposites
 /-- The right regular action of a group on itself is transitive. -/
-instance mul_action.opposite_regular.is_pretransitive {G : Type*} [group G] :
+@[to_additive] instance mul_action.opposite_regular.is_pretransitive {G : Type*} [group G] :
   mul_action.is_pretransitive Gᵐᵒᵖ G :=
 ⟨λ x y, ⟨op (x⁻¹ * y), mul_inv_cancel_left _ _⟩⟩
 
-instance semigroup.opposite_smul_comm_class [semigroup α] :
+@[to_additive] instance semigroup.opposite_smul_comm_class [semigroup α] :
   smul_comm_class αᵐᵒᵖ α α :=
 { smul_comm := λ x y z, (mul_assoc _ _ _) }
 
-instance semigroup.opposite_smul_comm_class' [semigroup α] :
+@[to_additive] instance semigroup.opposite_smul_comm_class' [semigroup α] :
   smul_comm_class α αᵐᵒᵖ α :=
-{ smul_comm := λ x y z, (mul_assoc _ _ _).symm }
+smul_comm_class.symm _ _ _
 
 instance comm_semigroup.is_central_scalar [comm_semigroup α] : is_central_scalar α α :=
 ⟨λ r m, mul_comm _ _⟩
 
 /-- Like `monoid.to_mul_action`, but multiplies on the right. -/
-instance monoid.to_opposite_mul_action [monoid α] : mul_action αᵐᵒᵖ α :=
+@[to_additive] instance monoid.to_opposite_mul_action [monoid α] : mul_action αᵐᵒᵖ α :=
 { smul := (•),
   one_smul := mul_one,
   mul_smul := λ x y r, (mul_assoc _ _ _).symm }
@@ -119,7 +118,7 @@ instance smul_comm_class.opposite_mid {M N} [monoid N] [has_scalar M N]
 example [monoid α] : monoid.to_mul_action αᵐᵒᵖ = mul_opposite.mul_action α αᵐᵒᵖ := rfl
 
 /-- `monoid.to_opposite_mul_action` is faithful on cancellative monoids. -/
-instance left_cancel_monoid.to_has_faithful_opposite_scalar [left_cancel_monoid α] :
+@[to_additive] instance left_cancel_monoid.to_has_faithful_opposite_scalar [left_cancel_monoid α] :
   has_faithful_scalar αᵐᵒᵖ α :=
 ⟨λ x y h, unop_injective $ mul_left_cancel (h 1)⟩
 


### PR DESCRIPTION
Add `add_opposite`, add `to_additive` here and there. More `to_additive` can be added as needed later.

---

I'm going to rewrite left/right-invariant measures in terms of smul invariant measures. Right invariant measures will be encoded as the measures invariant under the action of the opposite group. In order to get this machinery work with, e.g., Lebesgue measure on `real`, we need additive version of `mul_opposite`.

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
