### PR TITLE
feat(algebra/*): add some `*_hom_class` instances

### DIFF
--- a/src/algebra/algebra/basic.lean
+++ b/src/algebra/algebra/basic.lean
@@ -794,12 +794,16 @@ protected lemma congr_fun {f g : A₁ ≃ₐ[R] A₂} (h : f = g) (x : A₁) : f
 lemma ext_iff {f g : A₁ ≃ₐ[R] A₂} : f = g ↔ ∀ x, f x = g x :=
 ⟨λ h x, h ▸ rfl, ext⟩
 
+instance : ring_hom_class (A₁ ≃ₐ[R] A₂) A₁ A₂ :=
+{ coe := coe_fn,
+  coe_injective' := λ f g h, ext $ congr_fun h,
+  map_mul := map_mul',
+  map_one := λ e, e.to_mul_equiv.map_one,
+  map_add := map_add',
+  map_zero := λ e, e.to_add_equiv.map_zero }
+
 lemma coe_fun_injective : @function.injective (A₁ ≃ₐ[R] A₂) (A₁ → A₂) (λ e, (e : A₁ → A₂)) :=
-begin
-  intros f g w,
-  ext,
-  exact congr_fun w a,
-end
+fun_like.coe_injective
 
 instance has_coe_to_ring_equiv : has_coe (A₁ ≃ₐ[R] A₂) (A₁ ≃+* A₂) := ⟨alg_equiv.to_ring_equiv⟩
 
@@ -820,13 +824,13 @@ lemma coe_ring_equiv' : (e.to_ring_equiv : A₁ → A₂) = e := rfl
 lemma coe_ring_equiv_injective : function.injective (coe : (A₁ ≃ₐ[R] A₂) → (A₁ ≃+* A₂)) :=
 λ e₁ e₂ h, ext $ ring_equiv.congr_fun h
 
-@[simp] lemma map_add : ∀ x y, e (x + y) = e x + e y := e.to_add_equiv.map_add
+lemma map_add : ∀ x y, e (x + y) = e x + e y := e.to_add_equiv.map_add
 
-@[simp] lemma map_zero : e 0 = 0 := e.to_add_equiv.map_zero
+lemma map_zero : e 0 = 0 := e.to_add_equiv.map_zero
 
-@[simp] lemma map_mul : ∀ x y, e (x * y) = (e x) * (e y) := e.to_mul_equiv.map_mul
+lemma map_mul : ∀ x y, e (x * y) = (e x) * (e y) := e.to_mul_equiv.map_mul
 
-@[simp] lemma map_one : e 1 = 1 := e.to_mul_equiv.map_one
+lemma map_one : e 1 = 1 := e.to_mul_equiv.map_one
 
 @[simp] lemma commutes : ∀ (r : R), e (algebra_map R A₁ r) = algebra_map R A₂ r :=
   e.commutes'

--- a/src/data/equiv/mul_add.lean
+++ b/src/data/equiv/mul_add.lean
@@ -274,6 +274,10 @@ lemma map_ne_one_iff {M N} [mul_one_class M] [mul_one_class N] (h : M ≃* N) {x
   h x ≠ 1 ↔ x ≠ 1 :=
 ⟨mt h.map_eq_one_iff.2, mt h.map_eq_one_iff.1⟩
 
+@[to_additive]
+instance {M N} [mul_one_class M] [mul_one_class N] : monoid_hom_class (M ≃* N) M N :=
+⟨coe_fn, λ e₁ e₂ h, ext $ congr_fun h, map_mul, map_one⟩
+
 /-- A bijective `monoid` homomorphism is an isomorphism -/
 @[to_additive "A bijective `add_monoid` homomorphism is an isomorphism"]
 noncomputable def of_bijective {M N} [mul_one_class M] [mul_one_class N] (f : M →* N)

--- a/src/data/equiv/mul_add.lean
+++ b/src/data/equiv/mul_add.lean
@@ -243,6 +243,10 @@ protected lemma congr_arg {f : mul_equiv M N} : Π {x x' : M}, x = x' → f x = 
 @[to_additive]
 protected lemma congr_fun {f g : mul_equiv M N} (h : f = g) (x : M) : f x = g x := h ▸ rfl
 
+@[to_additive]
+instance : mul_hom_class (M ≃* N) M N :=
+⟨coe_fn, λ e₁ e₂ h, ext $ congr_fun h, map_mul⟩
+
 /-- The `mul_equiv` between two monoids with a unique element. -/
 @[to_additive "The `add_equiv` between two add_monoids with a unique element."]
 def mul_equiv_of_unique_of_unique {M N}
@@ -276,7 +280,7 @@ lemma map_ne_one_iff {M N} [mul_one_class M] [mul_one_class N] (h : M ≃* N) {x
 
 @[to_additive]
 instance {M N} [mul_one_class M] [mul_one_class N] : monoid_hom_class (M ≃* N) M N :=
-⟨coe_fn, λ e₁ e₂ h, ext $ congr_fun h, map_mul, map_one⟩
+{ map_one := map_one, .. mul_equiv.mul_hom_class }
 
 /-- A bijective `monoid` homomorphism is an isomorphism -/
 @[to_additive "A bijective `add_monoid` homomorphism is an isomorphism"]

--- a/src/data/equiv/ring.lean
+++ b/src/data/equiv/ring.lean
@@ -284,10 +284,12 @@ lemma to_ring_hom_eq_coe (f : R ≃+* S) : f.to_ring_hom = ↑f := rfl
 
 @[simp, norm_cast] lemma coe_to_ring_hom (f : R ≃+* S) : ⇑(f : R →+* S) = f := rfl
 
-lemma coe_ring_hom_inj_iff {R S : Type*} [non_assoc_semiring R] [non_assoc_semiring S]
-  (f g : R ≃+* S) :
+lemma coe_ring_hom_inj_iff (f g : R ≃+* S) :
   f = g ↔ (f : R →+* S) = g :=
 ⟨congr_arg _, λ h, ext $ ring_hom.ext_iff.mp h⟩
+
+instance : ring_hom_class (R ≃+* S) R S :=
+⟨coe_fn, λ f g h, ext $ congr_fun h, map_mul, map_one, map_add, map_zero⟩
 
 /-- Reinterpret a ring equivalence as a monoid homomorphism. -/
 abbreviation to_monoid_hom (e : R ≃+* S) : R →* S := e.to_ring_hom.to_monoid_hom


### PR DESCRIPTION
Add instances for `mul_equiv`, `add_equiv`, `ring_equiv`, `alg_equiv`, and `absolute_value`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
