### PR TITLE
[Merged by Bors] - feat(combinatorics/simple_graph/connectivity): add functions to split walks and to create paths

### DIFF
--- a/src/combinatorics/simple_graph/connectivity.lean
+++ b/src/combinatorics/simple_graph/connectivity.lean
@@ -412,8 +412,9 @@ def take_until : Π {v w : V} (p : G.walk v w) (u : V) (h : u ∈ p.support), G.
   then by subst u
   else cons r (take_until p _ $ h.cases_on (λ h', (hx h'.symm).elim) id)
 
-/-- Given a vertex in the support of a path, give the path from (and including) that vertex to the end.
-In other words, drop vertices from the front of a path until (and not including) that vertex. -/
+/-- Given a vertex in the support of a path, give the path from (and including) that vertex to
+the end. In other words, drop vertices from the front of a path until (and not including)
+that vertex. -/
 def drop_until : Π {v w : V} (p : G.walk v w) (u : V) (h : u ∈ p.support), G.walk u w
 | v w nil u h := by rw mem_support_nil_iff.mp h
 | v w (cons r p) u h :=

--- a/src/combinatorics/simple_graph/connectivity.lean
+++ b/src/combinatorics/simple_graph/connectivity.lean
@@ -33,7 +33,7 @@ counterparts in [Chou1994].
 
 * `simple_graph.walk`
 
-* `simple_graph.is_trail`, `simple_graph.is_path`, and `simple_graph.is_cycle`.
+* `simple_graph.walk.is_trail`, `simple_graph.walk.is_path`, and `simple_graph.walk.is_cycle`.
 
 * `simple_graph.path`
 

--- a/src/combinatorics/simple_graph/connectivity.lean
+++ b/src/combinatorics/simple_graph/connectivity.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Kyle Miller
 -/
 import combinatorics.simple_graph.basic
+import data.list
 /-!
 
 # Graph connectivity
@@ -210,6 +211,8 @@ lemma mem_support_iff {u v w : V} (p : G.walk u v) :
   w ∈ p.support ↔ w = u ∨ w ∈ p.support.tail :=
 by cases p; simp
 
+lemma mem_support_nil_iff {u v : V} : u ∈ (nil : G.walk v v).support ↔ u = v := by simp
+
 @[simp]
 lemma mem_tail_support_append_iff {t u v w : V} (p : G.walk u v) (p' : G.walk v w) :
   t ∈ (p.append p').support.tail ↔ t ∈ p.support.tail ∨ t ∈ p'.support.tail :=
@@ -298,6 +301,8 @@ begin
   { simp only [edges_cons, support_cons, list.nodup_cons] at h ⊢,
     exact ⟨λ h', h.1 (mem_support_of_mem_edges p_p h'), p_ih h.2⟩, }
 end
+
+/-! ### Trails, paths, circuits, cycles -/
 
 /-- A *trail* is a walk with no repeating edges. -/
 structure is_trail {u v : V} (p : G.walk u v) : Prop :=
@@ -393,6 +398,228 @@ begin
   rw reverse_append at h,
   apply h.of_append_left,
 end
+
+/-! ### Walk decompositions -/
+
+section walk_decomp
+variables [decidable_eq V]
+
+/-- Given a vertex in the support of a path, give the path up until (and including) that vertex. -/
+def take_until : Π {v w : V} (p : G.walk v w) (u : V) (h : u ∈ p.support), G.walk v u
+| v w nil u h := by rw mem_support_nil_iff.mp h
+| v w (cons r p) u h :=
+  if hx : v = u
+  then by subst u
+  else cons r (take_until p _ $ h.cases_on (λ h', (hx h'.symm).elim) id)
+
+/-- Given a vertex in the support of a path, give the path from that vertex to the end. -/
+def drop_until : Π {v w : V} (p : G.walk v w) (u : V) (h : u ∈ p.support), G.walk u w
+| v w nil u h := by rw mem_support_nil_iff.mp h
+| v w (cons r p) u h :=
+  if hx : v = u
+  then by { subst u, exact cons r p }
+  else drop_until p _ $ h.cases_on (λ h', (hx h'.symm).elim) id
+
+/-- The `take_until` and `drop_until` functions split a walk into two pieces.
+The lemma `count_support_take_until_eq_one` specifies where this split occurs. -/
+@[simp]
+lemma take_spec {u v w : V} (p : G.walk v w) (h : u ∈ p.support) :
+  (p.take_until u h).append (p.drop_until u h) = p :=
+begin
+  induction p,
+  { rw mem_support_nil_iff at h,
+    subst u,
+    refl, },
+  { obtain (rfl|h) := h,
+    { simp! },
+    { simp! only,
+      split_ifs with h'; subst_vars; simp [*], } },
+end
+
+@[simp]
+lemma count_support_take_until_eq_one {u v w : V} (p : G.walk v w) (h : u ∈ p.support) :
+  (p.take_until u h).support.count u = 1 :=
+begin
+  induction p,
+  { rw mem_support_nil_iff at h,
+    subst u,
+    simp!, },
+  { obtain (rfl|h) := h,
+    { simp! },
+    { simp! only,
+      split_ifs with h'; rw eq_comm at h'; subst_vars; simp! [*, list.count_cons], } },
+end
+
+lemma count_edges_take_until_le_one {u v w : V} (p : G.walk v w) (h : u ∈ p.support) (x : V) :
+  (p.take_until u h).edges.count ⟦(u, x)⟧ ≤ 1 :=
+begin
+  induction p with u' u' v' w' ha p' ih,
+  { rw mem_support_nil_iff at h,
+    subst u,
+    simp!, },
+  { obtain (rfl|h) := h,
+    { simp!, },
+    { simp! only,
+      split_ifs with h',
+      { subst h',
+        simp, },
+      { rw [edges_cons, list.count_cons],
+        split_ifs with h'',
+        { rw sym2.eq_iff at h'',
+          obtain (⟨rfl,rfl⟩|⟨rfl,rfl⟩) := h'',
+          { exact (h' rfl).elim },
+          { cases p'; simp! } },
+        { apply ih, } } } },
+end
+
+lemma support_take_until_subset {u v w : V} (p : G.walk v w) (h : u ∈ p.support) :
+  (p.take_until u h).support ⊆ p.support :=
+λ x hx, by { rw [← take_spec p h, mem_support_append_iff], exact or.inl hx }
+
+lemma support_drop_until_subset {u v w : V} (p : G.walk v w) (h : u ∈ p.support) :
+  (p.drop_until u h).support ⊆ p.support :=
+λ x hx, by { rw [← take_spec p h, mem_support_append_iff], exact or.inr hx }
+
+lemma edges_take_until_subset {u v w : V} (p : G.walk v w) (h : u ∈ p.support) :
+  (p.take_until u h).edges ⊆ p.edges :=
+λ x hx, by { rw [← take_spec p h, edges_append, list.mem_append], exact or.inl hx }
+
+lemma edges_drop_until_subset {u v w : V} (p : G.walk v w) (h : u ∈ p.support) :
+  (p.drop_until u h).edges ⊆ p.edges :=
+λ x hx, by { rw [← take_spec p h, edges_append, list.mem_append], exact or.inr hx }
+
+lemma is_trail.take_until {u v w : V} {p : G.walk v w} (hc : p.is_trail) (h : u ∈ p.support) :
+  (p.take_until u h).is_trail :=
+is_trail.of_append_left (by rwa ← take_spec _ h at hc)
+
+lemma is_trail.drop_until {u v w : V} {p : G.walk v w} (hc : p.is_trail) (h : u ∈ p.support) :
+  (p.drop_until u h).is_trail :=
+is_trail.of_append_right (by rwa ← take_spec _ h at hc)
+
+lemma is_path.take_until {u v w : V} {p : G.walk v w} (hc : p.is_path) (h : u ∈ p.support) :
+  (p.take_until u h).is_path :=
+is_path.of_append_left (by rwa ← take_spec _ h at hc)
+
+lemma is_path.drop_until {u v w : V} (p : G.walk v w) (hc : p.is_path) (h : u ∈ p.support) :
+  (p.drop_until u h).is_path :=
+is_path.of_append_right (by rwa ← take_spec _ h at hc)
+
+/-- Rotate a loop walk such that it is centered at the given vertex. -/
+def rotate {u v : V} (c : G.walk v v) (h : u ∈ c.support) : G.walk u u :=
+(c.drop_until u h).append (c.take_until u h)
+
+@[simp]
+lemma rotate_support {u v : V} (c : G.walk v v) (h : u ∈ c.support) :
+  (c.rotate h).support.tail ~r c.support.tail :=
+begin
+  simp only [rotate, tail_support_append],
+  apply list.is_rotated.trans list.is_rotated_append,
+  rw [←tail_support_append, take_spec],
+end
+
+lemma rotate_edges {u v : V} (c : G.walk v v) (h : u ∈ c.support) :
+  (c.rotate h).edges ~r c.edges :=
+begin
+  simp only [rotate, edges_append],
+  apply list.is_rotated.trans list.is_rotated_append,
+  rw [←edges_append, take_spec],
+end
+
+lemma is_trail.rotate {u v : V} {c : G.walk v v} (hc : c.is_trail) (h : u ∈ c.support) :
+  (c.rotate h).is_trail :=
+begin
+  rw [is_trail_def, (c.rotate_edges h).perm.nodup_iff],
+  exact hc.edges_nodup,
+end
+
+lemma is_circuit.rotate {u v : V} {c : G.walk v v} (hc : c.is_circuit) (h : u ∈ c.support) :
+  (c.rotate h).is_circuit :=
+begin
+  refine ⟨hc.to_trail.rotate _, _⟩,
+  cases c,
+  { exact (hc.ne_nil rfl).elim, },
+  { intro hn,
+    have hn' := congr_arg length hn,
+    rw [rotate, length_append, add_comm, ← length_append, take_spec] at hn',
+    simpa using hn', },
+end
+
+lemma is_cycle.rotate {u v : V} {c : G.walk v v} (hc : c.is_cycle) (h : u ∈ c.support) :
+  (c.rotate h).is_cycle :=
+begin
+  refine ⟨hc.to_circuit.rotate _, _⟩,
+  rw list.is_rotated.nodup_iff (rotate_support _ _),
+  exact hc.support_nodup,
+end
+
+end walk_decomp
+
+end walk
+
+/-! ### Walks to paths -/
+
+/-- The type for paths between two vertices. -/
+abbreviation path (u v : V) := {p : G.walk u v // p.is_path}
+
+namespace walk
+variables {G} [decidable_eq V]
+
+/-- Given a walk, produces a walk with the same endpoints and no repeated vertices. -/
+def to_path_aux : Π {u v : V}, G.walk u v → G.walk u v
+| u v nil := nil
+| u v (cons ha p) :=
+  let p' := p.to_path_aux
+  in if hs : u ∈ p'.support
+     then p'.drop_until u hs
+     else cons ha p'
+
+lemma to_path_aux_is_path {u v : V} (p : G.walk u v) : p.to_path_aux.is_path :=
+begin
+  induction p,
+  { simp!, },
+  { simp only [to_path_aux],
+    split_ifs,
+    { apply is_path.drop_until,
+      assumption, },
+    { simp [*, cons_is_path_iff], } },
+end
+
+/-- Given a walk, produces a path with the same endpoints using `simple_graph.walk.to_path_aux`. -/
+def to_path {u v : V} (p : G.walk u v) : G.path u v := ⟨p.to_path_aux, p.to_path_aux_is_path⟩
+
+lemma support_to_path_aux_subset {u v : V} (p : G.walk u v) : p.to_path_aux.support ⊆ p.support :=
+begin
+  induction p,
+  { simp!, },
+  { simp! only,
+    split_ifs,
+    { apply list.subset.trans (support_drop_until_subset _ _),
+      apply list.subset_cons_of_subset,
+      assumption, },
+    { rw support_cons,
+      apply list.cons_subset_cons,
+      assumption, }, },
+end
+
+lemma support_to_path_subset {u v : V} (p : G.walk u v) :
+  (p.to_path : G.walk u v).support ⊆ p.support :=
+by simp [to_path, support_to_path_aux_subset]
+
+lemma edges_to_path_aux_subset {u v : V} (p : G.walk u v) : p.to_path_aux.edges ⊆ p.edges :=
+begin
+  induction p,
+  { simp!, },
+  { simp! only,
+    split_ifs,
+    { apply list.subset.trans (edges_drop_until_subset _ _),
+      apply list.subset_cons_of_subset _ p_ih, },
+    { rw edges_cons,
+      exact list.cons_subset_cons _ p_ih, }, },
+end
+
+lemma edges_to_path_subset {u v : V} (p : G.walk u v) :
+  (p.to_path : G.walk u v).edges ⊆ p.edges :=
+by simp [to_path, edges_to_path_aux_subset]
 
 end walk
 


### PR DESCRIPTION
This is chunk 3 of #8737. Introduces `take_until` and `drop_until` to split walks at a vertex, `rotate` to rotate cycles, and `to_path` to remove internal redundancy from a walk to create a path with the same endpoints.

This also defines a bundled `path` type for `is_path` since `G.path u v` is a useful type.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
