### PR TITLE
[Merged by Bors] - chore(data/*): Eliminate `finish`

### DIFF
--- a/src/data/complex/exponential.lean
+++ b/src/data/complex/exponential.lean
@@ -205,7 +205,7 @@ begin
   rw [← sum_sdiff (@filter_subset _ (λ k, n ≤ k) _ (range m)),
     sub_eq_iff_eq_add, ← eq_sub_iff_add_eq, add_sub_cancel'],
   refine finset.sum_congr
-    (finset.ext $ λ a, ⟨λ h, by simp at *; finish,
+    (finset.ext $ λ a, ⟨λ h, by simp at *; tauto,
     λ h, have ham : a < m := lt_of_lt_of_le (mem_range.1 h) hnm,
       by simp * at *⟩)
     (λ _ _, rfl),

--- a/src/data/equiv/set.lean
+++ b/src/data/equiv/set.lean
@@ -205,7 +205,9 @@ protected def of_eq {α : Type u} {s t : set α} (h : s = t) : s ≃ t :=
 protected def insert {α} {s : set.{u} α} [decidable_pred (∈ s)] {a : α} (H : a ∉ s) :
   (insert a s : set α) ≃ s ⊕ punit.{u+1} :=
 calc (insert a s : set α) ≃ ↥(s ∪ {a}) : equiv.set.of_eq (by simp)
-... ≃ s ⊕ ({a} : set α) : equiv.set.union (by finish [set.subset_def])
+... ≃ s ⊕ ({a} : set α) : equiv.set.union (by { -- `finish [set.subset_def]` closes this goal
+  simp only [set.subset_def, mem_inter_eq, mem_empty_eq, mem_singleton_iff, and_imp],
+  exact λ x hx hxa, H (by rwa ←hxa) })
 ... ≃ s ⊕ punit.{u+1} : sum_congr (equiv.refl _) (equiv.set.singleton _)
 
 @[simp] lemma insert_symm_apply_inl {α} {s : set.{u} α} [decidable_pred (∈ s)] {a : α} (H : a ∉ s)

--- a/src/data/equiv/set.lean
+++ b/src/data/equiv/set.lean
@@ -205,9 +205,7 @@ protected def of_eq {α : Type u} {s t : set α} (h : s = t) : s ≃ t :=
 protected def insert {α} {s : set.{u} α} [decidable_pred (∈ s)] {a : α} (H : a ∉ s) :
   (insert a s : set α) ≃ s ⊕ punit.{u+1} :=
 calc (insert a s : set α) ≃ ↥(s ∪ {a}) : equiv.set.of_eq (by simp)
-... ≃ s ⊕ ({a} : set α) : equiv.set.union (by { -- `finish [set.subset_def]` closes this goal
-  simp only [set.subset_def, mem_inter_eq, mem_empty_eq, mem_singleton_iff, and_imp],
-  exact λ x hx hxa, H (by rwa ←hxa) })
+... ≃ s ⊕ ({a} : set α) : equiv.set.union (λ x ⟨hx, hx'⟩, by simp [*] at *)
 ... ≃ s ⊕ punit.{u+1} : sum_congr (equiv.refl _) (equiv.set.singleton _)
 
 @[simp] lemma insert_symm_apply_inl {α} {s : set.{u} α} [decidable_pred (∈ s)] {a : α} (H : a ∉ s)

--- a/src/data/list/min_max.lean
+++ b/src/data/list/min_max.lean
@@ -86,10 +86,10 @@ list.reverse_rec_on l (by simp [eq_comm])
     { simp {contextual := tt} },
     { dsimp only, split_ifs,
       { -- `finish [ih _ _ hf]` closes this goal
-        intro H,
-        have := ih a m (by rwa hf),
-        simp only [list.mem_cons_iff, list.mem_append] at *,
-        tauto },
+        rcases ih _ _ hf with rfl | H,
+        { simp only [mem_cons_iff, mem_append, mem_singleton, option.mem_def], tauto },
+        { apply λ hm, or.inr (list.mem_append.mpr $ or.inl _),
+          exact (option.mem_some_iff.mp hm ▸ H)} },
       { simp {contextual := tt} } }
   end
 

--- a/src/data/list/min_max.lean
+++ b/src/data/list/min_max.lean
@@ -85,7 +85,10 @@ list.reverse_rec_on l (by simp [eq_comm])
     cases hf : foldl (argmax₂ f) (some a) tl,
     { simp {contextual := tt} },
     { dsimp only, split_ifs,
-      { finish [ih _ _ hf] },
+      { intro H,
+        have := ih a m (by rwa hf),
+        simp only [list.mem_cons_iff, list.mem_append] at *,
+        tauto },
       { simp {contextual := tt} } }
   end
 

--- a/src/data/list/min_max.lean
+++ b/src/data/list/min_max.lean
@@ -85,7 +85,8 @@ list.reverse_rec_on l (by simp [eq_comm])
     cases hf : foldl (argmax₂ f) (some a) tl,
     { simp {contextual := tt} },
     { dsimp only, split_ifs,
-      { intro H,
+      { -- `finish [ih _ _ hf]` closes this goal
+        intro H,
         have := ih a m (by rwa hf),
         simp only [list.mem_cons_iff, list.mem_append] at *,
         tauto },

--- a/src/data/nat/totient.lean
+++ b/src/data/nat/totient.lean
@@ -134,7 +134,7 @@ calc ∑ m in (range n.succ).filter (∣ n), φ m
 ... = ((filter (∣ n) (range n.succ)).bUnion (λ d, (range n).filter (λ m, gcd n m = d))).card :
   (card_bUnion (by intros; apply disjoint_filter.2; cc)).symm
 ... = (range n).card :
-  congr_arg card (finset.ext (λ m, ⟨by finish,
+  congr_arg card (finset.ext (λ m, ⟨by simp,
     λ hm, have h : m < n, from mem_range.1 hm,
       mem_bUnion.2 ⟨gcd n m, mem_filter.2
         ⟨mem_range.2 (lt_succ_of_le (le_of_dvd (lt_of_le_of_lt (zero_le _) h)

--- a/src/data/option/defs.lean
+++ b/src/data/option/defs.lean
@@ -35,6 +35,9 @@ theorem is_none_iff_eq_none {o : option α} : o.is_none = tt ↔ o = none :=
 
 theorem some_inj {a b : α} : some a = some b ↔ a = b := by simp
 
+lemma mem_some_iff {α : Type*} {a b : α} : a ∈ some b ↔ b = a :=
+by simp
+
 /--
 `o = none` is decidable even if the wrapped type does not have decidable equality.
 

--- a/src/data/pequiv.lean
+++ b/src/data/pequiv.lean
@@ -355,10 +355,11 @@ instance [decidable_eq α] [decidable_eq β] : semilattice_inf (α ≃. β) :=
   inf_le_left := λ _ _ _ _, by simp; split_ifs; cc,
   inf_le_right := λ _ _ _ _, by simp; split_ifs; cc,
   le_inf := λ f g h fg gh a b, begin
-    have := fg a b,
-    have := gh a b,
-    simp [le_def],
-    split_ifs; finish
+    intro H,
+    have hf := fg a b H,
+    have hg := gh a b H,
+    simp only [option.mem_def, pequiv.coe_mk_apply],
+    split_ifs with h1, { exact hf }, { exact h1 (hf.trans hg.symm) },
   end,
   ..pequiv.partial_order }
 

--- a/src/data/pequiv.lean
+++ b/src/data/pequiv.lean
@@ -338,9 +338,19 @@ instance [decidable_eq α] [decidable_eq β] : semilattice_inf (α ≃. β) :=
   { to_fun := λ a, if f a = g a then f a else none,
     inv_fun := λ b, if f.symm b = g.symm b then f.symm b else none,
     inv := λ a b, begin
-      have := @mem_iff_mem _ _ f a b,
-      have := @mem_iff_mem _ _ g a b,
-      split_ifs; finish
+      have hf := @mem_iff_mem _ _ f a b,
+      have hg := @mem_iff_mem _ _ g a b, -- `split_ifs; finish` closes this goal from here
+      split_ifs with h1 h2 h2; try { simp [hf] },
+      { contrapose! h2,
+        rw h2,
+        rw [←h1,hf,h2] at hg,
+        simp only [mem_def, true_iff, eq_self_iff_true] at hg,
+        rw [hg] },
+      { contrapose! h1,
+        rw h1 at *,
+        rw ←h2 at hg,
+        simp only [mem_def, eq_self_iff_true, iff_true] at hf hg,
+        rw [hf,hg] },
     end },
   inf_le_left := λ _ _ _ _, by simp; split_ifs; cc,
   inf_le_right := λ _ _ _ _, by simp; split_ifs; cc,

--- a/src/data/setoid/partition.lean
+++ b/src/data/setoid/partition.lean
@@ -172,7 +172,7 @@ eqv_classes_disjoint hc.2
 lemma is_partition.sUnion_eq_univ {c : set (set α)} (hc : is_partition c) :
   ⋃₀ c = set.univ :=
 set.eq_univ_of_forall $ λ x, set.mem_sUnion.2 $
-  let ⟨t, ht⟩ := hc.2 x in ⟨t, by clear_aux_decl; finish⟩
+  let ⟨t, ht⟩ := hc.2 x in ⟨t, by { simp only [exists_unique_iff_exists] at ht, tauto }⟩
 
 /-- All elements of a partition of α are the equivalence class of some y ∈ α. -/
 lemma exists_of_mem_partition {c : set (set α)} (hc : is_partition c) {s} (hs : s ∈ c) :


### PR DESCRIPTION
Removing uses of `finish`, as discussed in this Zulip thread (https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/mathlib.20sat.20solvers)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
