### PR TITLE
[Merged by Bors] - chore(ring_theory/*): Eliminate `finish`

### DIFF
--- a/src/ring_theory/ideal/basic.lean
+++ b/src/ring_theory/ideal/basic.lean
@@ -574,7 +574,7 @@ lemma bot_lt_of_maximal (M : ideal R) [hm : M.is_maximal] (non_field : ¬ is_fie
 begin
   rcases (ring.not_is_field_iff_exists_ideal_bot_lt_and_lt_top.1 non_field)
     with ⟨I, Ibot, Itop⟩,
-  split, finish,
+  split, { simp },
   intro mle,
   apply @irrefl _ (<) _ (⊤ : ideal R),
   have : M = ⊥ := eq_bot_iff.mpr mle,

--- a/src/ring_theory/principal_ideal_domain.lean
+++ b/src/ring_theory/principal_ideal_domain.lean
@@ -168,12 +168,8 @@ instance euclidean_domain.to_principal_ideal_domain : is_principal_ideal_ring R 
         have (x % (well_founded.min wf {x : R | x ∈ S ∧ x ≠ 0} h) ∉ {x : R | x ∈ S ∧ x ≠ 0}),
           from λ h₁, well_founded.not_lt_min wf _ h h₁ (mod_lt x hmin.2),
         have x % well_founded.min wf {x : R | x ∈ S ∧ x ≠ 0} h = 0,
-          by {
-               simp only [not_and_distrib, set.mem_set_of_eq, not_ne_iff] at this,
-              -- apply (or_iff_right_of_imp _).mp this, exact λ H,
-              -- absurd ((mod_mem_iff hmin.1).2 hx) H,
-               cases this, { have := (mod_mem_iff hmin.1).2 hx, contradiction }, { exact this },
-            },
+          by { simp only [not_and_distrib, set.mem_set_of_eq, not_ne_iff] at this,
+               cases this, cases this ((mod_mem_iff hmin.1).2 hx), exact this },
         by simp *),
       λ hx, let ⟨y, hy⟩ := ideal.mem_span_singleton.1 hx in hy.symm ▸ S.mul_mem_right _ hmin.1⟩⟩
     else ⟨0, submodule.ext $ λ a,

--- a/src/ring_theory/principal_ideal_domain.lean
+++ b/src/ring_theory/principal_ideal_domain.lean
@@ -168,7 +168,12 @@ instance euclidean_domain.to_principal_ideal_domain : is_principal_ideal_ring R 
         have (x % (well_founded.min wf {x : R | x ∈ S ∧ x ≠ 0} h) ∉ {x : R | x ∈ S ∧ x ≠ 0}),
           from λ h₁, well_founded.not_lt_min wf _ h h₁ (mod_lt x hmin.2),
         have x % well_founded.min wf {x : R | x ∈ S ∧ x ≠ 0} h = 0,
-          by finish [(mod_mem_iff hmin.1).2 hx],
+          by {
+               simp only [not_and_distrib, set.mem_set_of_eq, not_ne_iff] at this,
+              -- apply (or_iff_right_of_imp _).mp this, exact λ H,
+              -- absurd ((mod_mem_iff hmin.1).2 hx) H,
+               cases this, { have := (mod_mem_iff hmin.1).2 hx, contradiction }, { exact this },
+            },
         by simp *),
       λ hx, let ⟨y, hy⟩ := ideal.mem_span_singleton.1 hx in hy.symm ▸ S.mul_mem_right _ hmin.1⟩⟩
     else ⟨0, submodule.ext $ λ a,


### PR DESCRIPTION
Removing uses of `finish`, as discussed in this Zulip thread (https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/mathlib.20sat.20solvers)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
