### PR TITLE
[Merged by Bors] - chore(computability/NFA): Eliminate `finish`

### DIFF
--- a/src/computability/NFA.lean
+++ b/src/computability/NFA.lean
@@ -119,7 +119,8 @@ begin
     assumption },
   { intro h,
     use M.eval x,
-    finish }
+    simp only [set.mem_singleton_iff],
+    exact ⟨h, rfl⟩ }
 end
 
 end DFA

--- a/src/computability/NFA.lean
+++ b/src/computability/NFA.lean
@@ -68,7 +68,7 @@ begin
   ext x,
   rw [accepts, DFA.accepts, eval, DFA.eval],
   change list.foldl _ _ _ ∈ {S | _} ↔ _,
-  finish
+  split; { exact λ ⟨w, h2, h3⟩, ⟨w, h3, h2⟩ },
 end
 
 lemma pumping_lemma [fintype σ] {x : list α} (hx : x ∈ M.accepts)

--- a/src/computability/NFA.lean
+++ b/src/computability/NFA.lean
@@ -98,9 +98,10 @@ begin
   induction s with a s ih generalizing start,
   { tauto },
   { rw [list.foldl, list.foldl],
-    have h : M.to_NFA.step_set {start} a = {M.step start a},
-    { rw NFA.step_set,
-      finish },
+    have h : M.to_NFA.step_set {start} a = {M.step start a}, -- `rw NFA.step_set, finish` closes
+    { have : M.to_NFA.step_set {start} a = M.to_NFA.step start a, {simp [NFA.step_set]},
+      rw this,
+      refl },
     rw h,
     tauto }
 end

--- a/src/computability/NFA.lean
+++ b/src/computability/NFA.lean
@@ -97,12 +97,8 @@ begin
   change list.foldl M.to_NFA.step_set {start} s = {list.foldl M.step start s},
   induction s with a s ih generalizing start,
   { tauto },
-  { rw [list.foldl, list.foldl],
-    have h : M.to_NFA.step_set {start} a = {M.step start a}, -- `rw NFA.step_set, finish` closes
-    { have : M.to_NFA.step_set {start} a = M.to_NFA.step start a, {simp [NFA.step_set]},
-      rw this,
-      refl },
-    rw h,
+  { rw [list.foldl, list.foldl,
+        show M.to_NFA.step_set {start} a = {M.step start a}, by simpa [NFA.step_set]],
     tauto }
 end
 
@@ -114,13 +110,8 @@ begin
   rw to_NFA_eval_from_match,
   split,
   { rintro ⟨ S, hS₁, hS₂ ⟩,
-    rw set.mem_singleton_iff at hS₂,
-    rw hS₂ at hS₁,
-    assumption },
-  { intro h,
-    use M.eval x,
-    simp only [set.mem_singleton_iff],
-    exact ⟨h, rfl⟩ }
+    rwa set.mem_singleton_iff.mp hS₂ at hS₁ },
+  { exact λ h, ⟨M.eval x, h, rfl⟩ }
 end
 
 end DFA


### PR DESCRIPTION
Removing uses of `finish`, as discussed in this Zulip thread (https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/mathlib.20sat.20solvers)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
