### PR TITLE
[Merged by Bors] - refactor(algebra/big_operators/basic): Reorder lemmas

### DIFF
--- a/src/algebra/big_operators/basic.lean
+++ b/src/algebra/big_operators/basic.lean
@@ -463,7 +463,7 @@ end
 @[to_additive]
 lemma prod_product {s : finset γ} {t : finset α} {f : γ×α → β} :
   (∏ x in s.product t, f x) = ∏ x in s, ∏ y in t, f (x, y) :=
-prod_subset_product (s.product t) s (λ a, t) (λ p, mem_product)
+prod_finset_product (s.product t) s (λ a, t) (λ p, mem_product)
 
 /-- An uncurried version of `finset.prod_product`. -/
 @[to_additive "An uncurried version of `finset.sum_product`"]

--- a/src/algebra/big_operators/basic.lean
+++ b/src/algebra/big_operators/basic.lean
@@ -390,7 +390,7 @@ begin
   {intros b hb, use j b hb, use hj b hb, exact (right_inv b hb).symm,},
 end
 
-@[to_additive] lemma prod_subset_product
+@[to_additive] lemma prod_finset_product
   (r : finset (γ × α)) (s : finset γ) (t : γ → finset α)
   (h : ∀ p : γ × α, p ∈ r ↔ p.1 ∈ s ∧ p.2 ∈ t p.1) {f : γ × α → β} :
   ∏ p in r, f p = ∏ c in s, ∏ a in t c, f (c, a) :=
@@ -401,13 +401,13 @@ begin
     (λ p, (h (p.1, p.2)).mpr ∘ mem_sigma.mp) (λ p hp, prod.mk.eta) (λ p hp, p.eta),
 end
 
-@[to_additive] lemma prod_subset_product'
+@[to_additive] lemma prod_finset_product'
   (r : finset (γ × α)) (s : finset γ) (t : γ → finset α)
   (h : ∀ p : γ × α, p ∈ r ↔ p.1 ∈ s ∧ p.2 ∈ t p.1) {f : γ → α → β} :
   ∏ p in r, f p.1 p.2 = ∏ c in s, ∏ a in t c, f c a :=
 prod_subset_product r s t h
 
-@[to_additive] lemma prod_subset_product_right
+@[to_additive] lemma prod_finset_product_right
   (r : finset (α × γ)) (s : finset γ) (t : γ → finset α)
   (h : ∀ p : α × γ, p ∈ r ↔ p.2 ∈ s ∧ p.1 ∈ t p.2) {f : α × γ → β} :
   ∏ p in r, f p = ∏ c in s, ∏ a in t c, f (a, c) :=
@@ -418,7 +418,7 @@ begin
     (λ p, (h (p.2, p.1)).mpr ∘ mem_sigma.mp) (λ p hp, prod.mk.eta) (λ p hp, p.eta),
 end
 
-@[to_additive] lemma prod_subset_product_right'
+@[to_additive] lemma prod_finset_product_right'
   (r : finset (α × γ)) (s : finset γ) (t : γ → finset α)
   (h : ∀ p : α × γ, p ∈ r ↔ p.2 ∈ s ∧ p.1 ∈ t p.2) {f : α → γ → β} :
   ∏ p in r, f p.1 p.2 = ∏ c in s, ∏ a in t c, f a c :=

--- a/src/algebra/big_operators/basic.lean
+++ b/src/algebra/big_operators/basic.lean
@@ -405,7 +405,7 @@ end
   (r : finset (γ × α)) (s : finset γ) (t : γ → finset α)
   (h : ∀ p : γ × α, p ∈ r ↔ p.1 ∈ s ∧ p.2 ∈ t p.1) {f : γ → α → β} :
   ∏ p in r, f p.1 p.2 = ∏ c in s, ∏ a in t c, f c a :=
-prod_subset_product r s t h
+prod_finset_product r s t h
 
 @[to_additive] lemma prod_finset_product_right
   (r : finset (α × γ)) (s : finset γ) (t : γ → finset α)
@@ -422,7 +422,7 @@ end
   (r : finset (α × γ)) (s : finset γ) (t : γ → finset α)
   (h : ∀ p : α × γ, p ∈ r ↔ p.2 ∈ s ∧ p.1 ∈ t p.2) {f : α → γ → β} :
   ∏ p in r, f p.1 p.2 = ∏ c in s, ∏ a in t c, f a c :=
-prod_subset_product_right r s t h
+prod_finset_product_right r s t h
 
 @[to_additive]
 lemma prod_fiberwise_of_maps_to [decidable_eq γ] {s : finset α} {t : finset γ} {g : α → γ}

--- a/src/algebra/big_operators/basic.lean
+++ b/src/algebra/big_operators/basic.lean
@@ -325,26 +325,6 @@ begin
     rw [bUnion_insert, prod_insert hxs, prod_union this, ih hs.1] }
 end
 
-@[to_additive]
-lemma prod_product {s : finset γ} {t : finset α} {f : γ×α → β} :
-  (∏ x in s.product t, f x) = ∏ x in s, ∏ y in t, f (x, y) :=
-begin
-  haveI := classical.dec_eq α, haveI := classical.dec_eq γ,
-  rw [product_eq_bUnion, prod_bUnion],
-  { congr, funext, exact prod_image (λ _ _ _ _ H, (prod.mk.inj H).2) },
-  simp only [disjoint_iff_ne, mem_image],
-  rintro x _ y _ h ⟨i, z⟩ hz,
-  rw [inf_eq_inter, mem_inter, mem_image, mem_image] at hz,
-  obtain ⟨⟨_, _, rfl, _⟩, _, _, rfl, _⟩ := hz,
-  exact h rfl,
-end
-
-/-- An uncurried version of `finset.prod_product`. -/
-@[to_additive "An uncurried version of `finset.sum_product`"]
-lemma prod_product' {s : finset γ} {t : finset α} {f : γ → α → β} :
-  (∏ x in s.product t, f x.1 x.2) = ∏ x in s, ∏ y in t, f x y :=
-prod_product
-
 /-- Product over a sigma type equals the product of fiberwise products. For rewriting
 in the reverse direction, use `finset.prod_sigma'`.  -/
 @[to_additive "Sum over a sigma type equals the sum of fiberwise sums. For rewriting
@@ -367,6 +347,82 @@ lemma prod_sigma' {σ : α → Type*}
   (s : finset α) (t : Π a, finset (σ a)) (f : Π a, σ a → β) :
   (∏ a in s, ∏ s in (t a), f a s) = ∏ x in s.sigma t, f x.1 x.2 :=
 eq.symm $ prod_sigma s t (λ x, f x.1 x.2)
+
+/--
+  Reorder a product.
+
+  The difference with `prod_bij'` is that the bijection is specified as a surjective injection,
+  rather than by an inverse function.
+-/
+@[to_additive "
+  Reorder a sum.
+
+  The difference with `sum_bij'` is that the bijection is specified as a surjective injection,
+  rather than by an inverse function.
+"]
+lemma prod_bij {s : finset α} {t : finset γ} {f : α → β} {g : γ → β}
+  (i : Π a ∈ s, γ) (hi : ∀ a ha, i a ha ∈ t) (h : ∀ a ha, f a = g (i a ha))
+  (i_inj : ∀ a₁ a₂ ha₁ ha₂, i a₁ ha₁ = i a₂ ha₂ → a₁ = a₂) (i_surj : ∀ b ∈ t, ∃ a ha, b = i a ha) :
+  (∏ x in s, f x) = (∏ x in t, g x) :=
+congr_arg multiset.prod
+  (multiset.map_eq_map_of_bij_of_nodup f g s.2 t.2 i hi h i_inj i_surj)
+
+/--
+  Reorder a product.
+
+  The difference with `prod_bij` is that the bijection is specified with an inverse, rather than
+  as a surjective injection.
+-/
+@[to_additive "
+  Reorder a sum.
+
+  The difference with `sum_bij` is that the bijection is specified with an inverse, rather than
+  as a surjective injection.
+"]
+lemma prod_bij' {s : finset α} {t : finset γ} {f : α → β} {g : γ → β}
+  (i : Π a ∈ s, γ) (hi : ∀ a ha, i a ha ∈ t) (h : ∀ a ha, f a = g (i a ha))
+  (j : Π a ∈ t, α) (hj : ∀ a ha, j a ha ∈ s) (left_inv : ∀ a ha, j (i a ha) (hi a ha) = a)
+  (right_inv : ∀ a ha, i (j a ha) (hj a ha) = a) :
+  (∏ x in s, f x) = (∏ x in t, g x) :=
+begin
+  refine prod_bij i hi h _ _,
+  {intros a1 a2 h1 h2 eq, rw [←left_inv a1 h1, ←left_inv a2 h2], cc,},
+  {intros b hb, use j b hb, use hj b hb, exact (right_inv b hb).symm,},
+end
+
+@[to_additive] lemma prod_subset_product
+  (r : finset (γ × α)) (s : finset γ) (t : γ → finset α)
+  (h : ∀ p : γ × α, p ∈ r ↔ p.1 ∈ s ∧ p.2 ∈ t p.1) {f : γ × α → β} :
+  ∏ p in r, f p = ∏ c in s, ∏ a in t c, f (c, a) :=
+begin
+  refine eq.trans _ (prod_sigma s t (λ p, f (p.1, p.2))),
+  exact prod_bij' (λ p hp, ⟨p.1, p.2⟩) (λ p, mem_sigma.mpr ∘ (h p).mp)
+    (λ p hp, congr_arg f prod.mk.eta.symm) (λ p hp, (p.1, p.2))
+    (λ p, (h (p.1, p.2)).mpr ∘ mem_sigma.mp) (λ p hp, prod.mk.eta) (λ p hp, p.eta),
+end
+
+@[to_additive] lemma prod_subset_product'
+  (r : finset (γ × α)) (s : finset γ) (t : γ → finset α)
+  (h : ∀ p : γ × α, p ∈ r ↔ p.1 ∈ s ∧ p.2 ∈ t p.1) {f : γ → α → β} :
+  ∏ p in r, f p.1 p.2 = ∏ c in s, ∏ a in t c, f c a :=
+prod_subset_product r s t h
+
+@[to_additive] lemma prod_subset_product_right
+  (r : finset (α × γ)) (s : finset γ) (t : γ → finset α)
+  (h : ∀ p : α × γ, p ∈ r ↔ p.2 ∈ s ∧ p.1 ∈ t p.2) {f : α × γ → β} :
+  ∏ p in r, f p = ∏ c in s, ∏ a in t c, f (a, c) :=
+begin
+  refine eq.trans _ (prod_sigma s t (λ p, f (p.2, p.1))),
+  exact prod_bij' (λ p hp, ⟨p.2, p.1⟩) (λ p, mem_sigma.mpr ∘ (h p).mp)
+    (λ p hp, congr_arg f prod.mk.eta.symm) (λ p hp, (p.2, p.1))
+    (λ p, (h (p.2, p.1)).mpr ∘ mem_sigma.mp) (λ p hp, prod.mk.eta) (λ p hp, p.eta),
+end
+
+@[to_additive] lemma prod_subset_product_right'
+  (r : finset (α × γ)) (s : finset γ) (t : γ → finset α)
+  (h : ∀ p : α × γ, p ∈ r ↔ p.2 ∈ s ∧ p.1 ∈ t p.2) {f : α → γ → β} :
+  ∏ p in r, f p.1 p.2 = ∏ c in s, ∏ a in t c, f a c :=
+prod_subset_product_right r s t h
 
 @[to_additive]
 lemma prod_fiberwise_of_maps_to [decidable_eq γ] {s : finset α} {t : finset γ} {g : α → γ}
@@ -403,6 +459,17 @@ begin
   { intros _ _ H ih,
     simp only [prod_insert H, prod_mul_distrib, ih] }
 end
+
+@[to_additive]
+lemma prod_product {s : finset γ} {t : finset α} {f : γ×α → β} :
+  (∏ x in s.product t, f x) = ∏ x in s, ∏ y in t, f (x, y) :=
+prod_subset_product (s.product t) s (λ a, t) (λ p, mem_product)
+
+/-- An uncurried version of `finset.prod_product`. -/
+@[to_additive "An uncurried version of `finset.sum_product`"]
+lemma prod_product' {s : finset γ} {t : finset α} {f : γ → α → β} :
+  (∏ x in s.product t, f x.1 x.2) = ∏ x in s, ∏ y in t, f x y :=
+prod_product
 
 @[to_additive]
 lemma prod_product_right {s : finset γ} {t : finset α} {f : γ×α → β} :
@@ -696,48 +763,6 @@ sum_dite_eq' _ _ _
   [decidable_eq ι] [Π i, add_comm_monoid (M i)] (i : ι) (f : Π i, M i) (s : finset ι) :
   ∑ j in s, pi.single j (f j) i = if i ∈ s then f i else 0 :=
 sum_dite_eq _ _ _
-
-/--
-  Reorder a product.
-
-  The difference with `prod_bij'` is that the bijection is specified as a surjective injection,
-  rather than by an inverse function.
--/
-@[to_additive "
-  Reorder a sum.
-
-  The difference with `sum_bij'` is that the bijection is specified as a surjective injection,
-  rather than by an inverse function.
-"]
-lemma prod_bij {s : finset α} {t : finset γ} {f : α → β} {g : γ → β}
-  (i : Π a ∈ s, γ) (hi : ∀ a ha, i a ha ∈ t) (h : ∀ a ha, f a = g (i a ha))
-  (i_inj : ∀ a₁ a₂ ha₁ ha₂, i a₁ ha₁ = i a₂ ha₂ → a₁ = a₂) (i_surj : ∀ b ∈ t, ∃ a ha, b = i a ha) :
-  (∏ x in s, f x) = (∏ x in t, g x) :=
-congr_arg multiset.prod
-  (multiset.map_eq_map_of_bij_of_nodup f g s.2 t.2 i hi h i_inj i_surj)
-
-/--
-  Reorder a product.
-
-  The difference with `prod_bij` is that the bijection is specified with an inverse, rather than
-  as a surjective injection.
--/
-@[to_additive "
-  Reorder a sum.
-
-  The difference with `sum_bij` is that the bijection is specified with an inverse, rather than
-  as a surjective injection.
-"]
-lemma prod_bij' {s : finset α} {t : finset γ} {f : α → β} {g : γ → β}
-  (i : Π a ∈ s, γ) (hi : ∀ a ha, i a ha ∈ t) (h : ∀ a ha, f a = g (i a ha))
-  (j : Π a ∈ t, α) (hj : ∀ a ha, j a ha ∈ s) (left_inv : ∀ a ha, j (i a ha) (hi a ha) = a)
-  (right_inv : ∀ a ha, i (j a ha) (hj a ha) = a) :
-  (∏ x in s, f x) = (∏ x in t, g x) :=
-begin
-  refine prod_bij i hi h _ _,
-  {intros a1 a2 h1 h2 eq, rw [←left_inv a1 h1, ←left_inv a2 h2], cc,},
-  {intros b hb, use j b hb, use hj b hb, exact (right_inv b hb).symm,},
-end
 
 @[to_additive]
 lemma prod_bij_ne_one {s : finset α} {t : finset γ} {f : α → β} {g : γ → β}


### PR DESCRIPTION
This PR does the following things:
- Move `prod_bij` and `prod_bij'` earlier in the file, so that they can be put to use.
- Move `prod_product` and `prod_product'` past `prod_sigma` and `prod_sigma'` down to `prod_product_right` and `prod_product_right'`.
- Use `prod_bij` and `prod_sigma` to give an easier proof of `prod_product`.
- The new proof introduces `prod_finset_product` and the remaining three analogs of the four `prod_product` lemmas.
`prod_finset_product` is a lemma that I found helpful in my own work.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
