### PR TITLE
[Merged by Bors] - feat(analysis/inner_product_space/adjoint): define the adjoint for linear maps between finite-dimensional spaces

### DIFF
--- a/src/analysis/inner_product_space/adjoint.lean
+++ b/src/analysis/inner_product_space/adjoint.lean
@@ -179,17 +179,82 @@ end continuous_linear_map
 
 namespace linear_map
 
-variables [finite_dimensional 𝕜 E] [finite_dimensional 𝕜 F]
+variables [finite_dimensional 𝕜 E] [finite_dimensional 𝕜 F] [finite_dimensional 𝕜 G]
 local attribute [instance, priority 20] finite_dimensional.complete
 
 /-- The adjoint of an operator from the finite-dimensional inner product space E to the finite-
 dimensional inner product space F. -/
 def adjoint : (E →ₗ[𝕜] F) ≃ₗ⋆[𝕜] (F →ₗ[𝕜] E) :=
-{ to_fun := λ A, continuous_linear_map.adjoint A.to_continuous_linear_map,
-  inv_fun := λ A, continuous_linear_map.adjoint.symm A.to_continuous_linear_map,
-  map_add' := λ A B, by simp only [map_add, linear_isometry_equiv.map_add, coe_add],
-  map_smul' := λ r A, by simp only [linear_equiv.map_smulₛₗ, linear_isometry_equiv.map_smulₛₗ, continuous_linear_map.coe_smul, ring_hom.id_apply],
-  left_inv := λ A, by { sorry },
-  right_inv := sorry }
+  (linear_map.to_continuous_linear_map.trans continuous_linear_map.adjoint.to_linear_equiv).trans
+    linear_map.to_continuous_linear_map.symm
+
+lemma adjoint_to_continuous_linear_map (A : E →ₗ[𝕜] F) :
+  (adjoint A).to_continuous_linear_map = A.to_continuous_linear_map.adjoint := rfl
+
+@[simp] lemma adjoint_coe_eq (A : E →ₗ[𝕜] F) :
+  adjoint (A.to_continuous_linear_map : E →ₗ[𝕜] F) = A.to_continuous_linear_map.adjoint := rfl
+
+/-- The fundamental property of the adjoint. -/
+lemma adjoint_inner_left (A : E →ₗ[𝕜] F) (x : E) (y : F) : ⟪adjoint A y, x⟫ = ⟪y, A x⟫ :=
+begin
+  rw [←coe_to_continuous_linear_map A, adjoint_coe_eq],
+  exact continuous_linear_map.adjoint_inner_left _ x y,
+end
+
+/-- The fundamental property of the adjoint. -/
+lemma adjoint_inner_right (A : E →ₗ[𝕜] F) (x : E) (y : F) : ⟪x, adjoint A y⟫ = ⟪A x, y⟫ :=
+begin
+  rw [←coe_to_continuous_linear_map A, adjoint_coe_eq],
+  exact continuous_linear_map.adjoint_inner_right _ x y,
+end
+
+/-- The adjoint is involutive -/
+@[simp] lemma adjoint_adjoint (A : E →ₗ[𝕜] F) : adjoint (adjoint A) = A :=
+begin
+  ext v,
+  refine ext_inner_left 𝕜 (λ w, _),
+  rw [adjoint_inner_right, adjoint_inner_left],
+end
+
+/-- The adjoint of the composition of two operators is the composition of the two adjoints
+in reverse order. -/
+@[simp] lemma adjoint_comp (A : F →ₗ[𝕜] G) (B : E →ₗ[𝕜] F) :
+  adjoint (A ∘ₗ B) = (adjoint B) ∘ₗ (adjoint A) :=
+begin
+  ext v,
+  refine ext_inner_left 𝕜 (λ w, _),
+  simp only [adjoint_inner_right, linear_map.coe_comp, function.comp_app],
+end
+
+/-- The adjoint is unique: a map `A` is the adjoint of `B` iff it satisfies `⟪A x, y⟫ = ⟪x, B y⟫`
+for all `x` and `y`. -/
+lemma eq_adjoint_iff (A : E →ₗ[𝕜] F) (B : F →ₗ[𝕜] E) :
+  A = adjoint B ↔ (∀ x y, ⟪A x, y⟫ = ⟪x, B y⟫) :=
+begin
+  refine ⟨λ h x y, by rw [h, adjoint_inner_left], λ h, _⟩,
+  ext x,
+  exact ext_inner_right 𝕜 (λ y, by simp only [adjoint_inner_left, h x y])
+end
+
+/-- `E →ₗ[𝕜] E` is a star algebra with the adjoint as the star operation. -/
+instance : has_star (E →ₗ[𝕜] E) := ⟨adjoint⟩
+instance : has_involutive_star (E →ₗ[𝕜] E) := ⟨adjoint_adjoint⟩
+instance : star_monoid (E →ₗ[𝕜] E) := ⟨adjoint_comp⟩
+instance : star_ring (E →ₗ[𝕜] E) := ⟨linear_equiv.map_add adjoint⟩
+instance : star_module 𝕜 (E →ₗ[𝕜] E) := ⟨linear_equiv.map_smulₛₗ adjoint⟩
+
+lemma star_eq_adjoint (A : E →ₗ[𝕜] E) : star A = A.adjoint := rfl
+
+section real
+
+variables {E' : Type*} {F' : Type*} [inner_product_space ℝ E'] [inner_product_space ℝ F']
+variables [finite_dimensional ℝ E'] [finite_dimensional ℝ F']
+
+lemma is_adjoint_pair (A : E' →ₗ[ℝ] F') :
+  bilin_form.is_adjoint_pair (bilin_form_of_real_inner : bilin_form ℝ E')
+  (bilin_form_of_real_inner : bilin_form ℝ F') A A.adjoint :=
+λ x y, by simp only [adjoint_inner_right, bilin_form_of_real_inner_apply]
+
+end real
 
 end linear_map

--- a/src/analysis/inner_product_space/adjoint.lean
+++ b/src/analysis/inner_product_space/adjoint.lean
@@ -24,7 +24,7 @@ finite dimensional spaces.
 * `continuous_linear_map.adjoint : (E →L[𝕜] F) ≃ₗᵢ⋆[𝕜] (F →L[𝕜] E)`: the adjoint of a continuous
   linear map, bundled as a conjugate-linear isometric equivalence.
 * `linear_map.adjoint : (E →ₗ[𝕜] F) ≃ₗ⋆[𝕜] (F →ₗ[𝕜] E)`: the adjoint of a linear map between
-  finite-dimensional spaces, this time only as a linear isometric equivalence, since there is no
+  finite-dimensional spaces, this time only as a conjugate-linear equivalence, since there is no
   norm defined on these maps.
 
 ## Implementation notes

--- a/src/analysis/inner_product_space/adjoint.lean
+++ b/src/analysis/inner_product_space/adjoint.lean
@@ -19,10 +19,17 @@ operation.
 This construction is used to define an adjoint for linear maps (i.e. not continuous) between
 finite dimensional spaces.
 
+## Main definitions
+
+* `continuous_linear_map.adjoint : (E →L[𝕜] F) ≃ₗᵢ⋆[𝕜] (F →L[𝕜] E)`: the adjoint of a continuous
+  linear map, bundled as a conjugate-linear isometric equivalence.
+* `linear_map.adjoint : (E →ₗ[𝕜] F) ≃ₗ⋆[𝕜] (F →ₗ[𝕜] E)`: the adjoint of a linear map between
+  finite-dimensional spaces, this time only as a linear isometric equivalence, since there is no
+  norm defined on these maps.
+
 ## Implementation notes
 
-* The adjoint is defined as a conjugate-linear isometric equivalence between `E →L[𝕜] F` and
-  `F →L[𝕜] E`. The continuous conjugate-linear version `adjoint_aux` is only an intermediate
+* The continuous conjugate-linear version `adjoint_aux` is only an intermediate
   definition and is not meant to be used outside this file.
 
 ## Tags
@@ -196,7 +203,6 @@ lemma adjoint_to_continuous_linear_map (A : E →ₗ[𝕜] F) :
 
 lemma adjoint_eq_to_clm_adjoint (A : E →ₗ[𝕜] F) :
   A.adjoint = A.to_continuous_linear_map.adjoint := rfl
-
 
 /-- The fundamental property of the adjoint. -/
 lemma adjoint_inner_left (A : E →ₗ[𝕜] F) (x : E) (y : F) : ⟪adjoint A y, x⟫ = ⟪y, A x⟫ :=

--- a/src/analysis/inner_product_space/adjoint.lean
+++ b/src/analysis/inner_product_space/adjoint.lean
@@ -34,11 +34,11 @@ open_locale complex_conjugate
 
 variables {𝕜 E F G : Type*} [is_R_or_C 𝕜]
 variables [inner_product_space 𝕜 E] [inner_product_space 𝕜 F] [inner_product_space 𝕜 G]
-variables [complete_space E] [complete_space G]
-
 local notation `⟪`x`, `y`⟫` := @inner 𝕜 _ _ x y
 
 namespace continuous_linear_map
+
+variables [complete_space E] [complete_space G]
 
 /-- The adjoint, as a continuous conjugate-linear map.  This is only meant as an auxiliary
 definition for the main definition `adjoint`, where this is bundled as a conjugate-linear isometric
@@ -176,3 +176,20 @@ lemma is_adjoint_pair (A : E' →L[ℝ] F') :
 end real
 
 end continuous_linear_map
+
+namespace linear_map
+
+variables [finite_dimensional 𝕜 E] [finite_dimensional 𝕜 F]
+local attribute [instance, priority 20] finite_dimensional.complete
+
+/-- The adjoint of an operator from the finite-dimensional inner product space E to the finite-
+dimensional inner product space F. -/
+def adjoint : (E →ₗ[𝕜] F) ≃ₗ⋆[𝕜] (F →ₗ[𝕜] E) :=
+{ to_fun := λ A, continuous_linear_map.adjoint A.to_continuous_linear_map,
+  inv_fun := λ A, continuous_linear_map.adjoint.symm A.to_continuous_linear_map,
+  map_add' := λ A B, by simp only [map_add, linear_isometry_equiv.map_add, coe_add],
+  map_smul' := λ r A, by simp only [linear_equiv.map_smulₛₗ, linear_isometry_equiv.map_smulₛₗ, continuous_linear_map.coe_smul, ring_hom.id_apply],
+  left_inv := λ A, by { sorry },
+  right_inv := sorry }
+
+end linear_map

--- a/src/analysis/inner_product_space/adjoint.lean
+++ b/src/analysis/inner_product_space/adjoint.lean
@@ -194,20 +194,21 @@ def adjoint : (E →ₗ[𝕜] F) ≃ₗ⋆[𝕜] (F →ₗ[𝕜] E) :=
 lemma adjoint_to_continuous_linear_map (A : E →ₗ[𝕜] F) :
   A.adjoint.to_continuous_linear_map = A.to_continuous_linear_map.adjoint := rfl
 
-@[simp] lemma adjoint_coe_eq (A : E →ₗ[𝕜] F) :
-  (A.to_continuous_linear_map : E →ₗ[𝕜] F).adjoint = A.to_continuous_linear_map.adjoint := rfl
+lemma adjoint_eq_to_clm_adjoint (A : E →ₗ[𝕜] F) :
+  A.adjoint = A.to_continuous_linear_map.adjoint := rfl
+
 
 /-- The fundamental property of the adjoint. -/
 lemma adjoint_inner_left (A : E →ₗ[𝕜] F) (x : E) (y : F) : ⟪adjoint A y, x⟫ = ⟪y, A x⟫ :=
 begin
-  rw [←coe_to_continuous_linear_map A, adjoint_coe_eq],
+  rw [←coe_to_continuous_linear_map A, adjoint_eq_to_clm_adjoint],
   exact continuous_linear_map.adjoint_inner_left _ x y,
 end
 
 /-- The fundamental property of the adjoint. -/
 lemma adjoint_inner_right (A : E →ₗ[𝕜] F) (x : E) (y : F) : ⟪x, adjoint A y⟫ = ⟪A x, y⟫ :=
 begin
-  rw [←coe_to_continuous_linear_map A, adjoint_coe_eq],
+  rw [←coe_to_continuous_linear_map A, adjoint_eq_to_clm_adjoint],
   exact continuous_linear_map.adjoint_inner_right _ x y,
 end
 

--- a/src/analysis/inner_product_space/adjoint.lean
+++ b/src/analysis/inner_product_space/adjoint.lean
@@ -16,6 +16,9 @@ Given an operator `A : E →L[𝕜] F`, where `E` and `F` are Hilbert spaces, it
 We then use this to put a C⋆-algebra structure on `E →L[𝕜] E` with the adjoint as the star
 operation.
 
+This construction is used to define an adjoint for linear maps (i.e. not continuous) between
+finite dimensional spaces.
+
 ## Implementation notes
 
 * The adjoint is defined as a conjugate-linear isometric equivalence between `E →L[𝕜] F` and
@@ -189,10 +192,10 @@ def adjoint : (E →ₗ[𝕜] F) ≃ₗ⋆[𝕜] (F →ₗ[𝕜] E) :=
     linear_map.to_continuous_linear_map.symm
 
 lemma adjoint_to_continuous_linear_map (A : E →ₗ[𝕜] F) :
-  (adjoint A).to_continuous_linear_map = A.to_continuous_linear_map.adjoint := rfl
+  A.adjoint.to_continuous_linear_map = A.to_continuous_linear_map.adjoint := rfl
 
 @[simp] lemma adjoint_coe_eq (A : E →ₗ[𝕜] F) :
-  adjoint (A.to_continuous_linear_map : E →ₗ[𝕜] F) = A.to_continuous_linear_map.adjoint := rfl
+  (A.to_continuous_linear_map : E →ₗ[𝕜] F).adjoint = A.to_continuous_linear_map.adjoint := rfl
 
 /-- The fundamental property of the adjoint. -/
 lemma adjoint_inner_left (A : E →ₗ[𝕜] F) (x : E) (y : F) : ⟪adjoint A y, x⟫ = ⟪y, A x⟫ :=
@@ -209,7 +212,7 @@ begin
 end
 
 /-- The adjoint is involutive -/
-@[simp] lemma adjoint_adjoint (A : E →ₗ[𝕜] F) : adjoint (adjoint A) = A :=
+@[simp] lemma adjoint_adjoint (A : E →ₗ[𝕜] F) : A.adjoint.adjoint = A :=
 begin
   ext v,
   refine ext_inner_left 𝕜 (λ w, _),
@@ -219,7 +222,7 @@ end
 /-- The adjoint of the composition of two operators is the composition of the two adjoints
 in reverse order. -/
 @[simp] lemma adjoint_comp (A : F →ₗ[𝕜] G) (B : E →ₗ[𝕜] F) :
-  adjoint (A ∘ₗ B) = (adjoint B) ∘ₗ (adjoint A) :=
+  (A ∘ₗ B).adjoint = B.adjoint ∘ₗ A.adjoint :=
 begin
   ext v,
   refine ext_inner_left 𝕜 (λ w, _),
@@ -229,7 +232,7 @@ end
 /-- The adjoint is unique: a map `A` is the adjoint of `B` iff it satisfies `⟪A x, y⟫ = ⟪x, B y⟫`
 for all `x` and `y`. -/
 lemma eq_adjoint_iff (A : E →ₗ[𝕜] F) (B : F →ₗ[𝕜] E) :
-  A = adjoint B ↔ (∀ x y, ⟪A x, y⟫ = ⟪x, B y⟫) :=
+  A = B.adjoint ↔ (∀ x y, ⟪A x, y⟫ = ⟪x, B y⟫) :=
 begin
   refine ⟨λ h x y, by rw [h, adjoint_inner_left], λ h, _⟩,
   ext x,


### PR DESCRIPTION
This PR defines the adjoint of a linear map between finite-dimensional inner product spaces. We use the fact that such maps are always continuous and define it as the adjoint of the corresponding continuous linear map.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
