### PR TITLE
[Merged by Bors] - chore(algebra/continued_fractions/computation/translations): Eliminate `finish`

### DIFF
--- a/src/algebra/continued_fractions/computation/translations.lean
+++ b/src/algebra/continued_fractions/computation/translations.lean
@@ -112,7 +112,7 @@ begin
     simp only [int_fract_pair.stream, stream_nth_eq, ifp_n_fr_ne_zero, option.some_bind, if_false]
       at stream_succ_nth_eq,
     injection stream_succ_nth_eq },
-  { rintro ⟨⟨_⟩, ifp_n_props⟩,
+  { rintro ⟨⟨_⟩, ifp_n_props⟩, -- `finish [int_fract_pair.stream, ifp_n_props]` closes this goal
     simp only [int_fract_pair.stream, ifp_n_props, option.some_bind, if_false],
     refl }
 end

--- a/src/algebra/continued_fractions/computation/translations.lean
+++ b/src/algebra/continued_fractions/computation/translations.lean
@@ -112,7 +112,9 @@ begin
     simp only [int_fract_pair.stream, stream_nth_eq, ifp_n_fr_ne_zero, option.some_bind, if_false]
       at stream_succ_nth_eq,
     injection stream_succ_nth_eq },
-  { rintro ⟨⟨_⟩, ifp_n_props⟩, finish [int_fract_pair.stream, ifp_n_props] }
+  { rintro ⟨⟨_⟩, ifp_n_props⟩,
+    simp only [int_fract_pair.stream, ifp_n_props, option.some_bind, if_false],
+    refl }
 end
 
 lemma exists_succ_nth_stream_of_fr_zero {ifp_succ_n : int_fract_pair K}

--- a/src/algebra/continued_fractions/computation/translations.lean
+++ b/src/algebra/continued_fractions/computation/translations.lean
@@ -72,8 +72,13 @@ begin
   case option.none : { simp [stream_nth_eq, int_fract_pair.stream] },
   case option.some :
   { cases ifp with _ fr,
-    cases decidable.em (fr = 0);
-    finish [int_fract_pair.stream] }
+    cases decidable.em (fr = 0), -- `finish [int_fract_pair.stream]` closes these goals
+    { simp [h, stream_eq_none_of_fr_eq_zero stream_nth_eq h] },
+    { simp only [h, exists_eq_left', iff_false, or_self, int_fract_pair.stream],
+      simp only [exists_prop, not_not, option.bind_eq_none, option.mem_def, not_forall],
+      use [(int_fract_pair.of fr⁻¹), {b := ifp_b, fr := fr}, stream_nth_eq],
+      simp only [h, if_congr, if_false],
+      refl } }
 end
 
 /--

--- a/src/algebra/continued_fractions/computation/translations.lean
+++ b/src/algebra/continued_fractions/computation/translations.lean
@@ -129,7 +129,7 @@ begin
   existsi ifp_n,
   cases ifp_n with _ ifp_n_fr,
   suffices : ifp_n_fr⁻¹ = ⌊ifp_n_fr⁻¹⌋, by simpa [stream_nth_eq],
-  have : int_fract_pair.of ifp_n_fr⁻¹ = ifp_succ_n, by finish,
+  have : int_fract_pair.of ifp_n_fr⁻¹ = ifp_succ_n := h_right_right,
   cases ifp_succ_n with _ ifp_succ_n_fr,
   change ifp_succ_n_fr = 0 at succ_nth_fr_eq_zero,
   have : int.fract ifp_n_fr⁻¹ = ifp_succ_n_fr, by injection this,

--- a/src/algebra/continued_fractions/computation/translations.lean
+++ b/src/algebra/continued_fractions/computation/translations.lean
@@ -72,13 +72,11 @@ begin
   case option.none : { simp [stream_nth_eq, int_fract_pair.stream] },
   case option.some :
   { cases ifp with _ fr,
-    cases decidable.em (fr = 0), -- `finish [int_fract_pair.stream]` closes these goals
-    { simp [h, stream_eq_none_of_fr_eq_zero stream_nth_eq h] },
-    { simp only [h, exists_eq_left', iff_false, or_self, int_fract_pair.stream],
-      simp only [exists_prop, not_not, option.bind_eq_none, option.mem_def, not_forall],
-      use [(int_fract_pair.of fr⁻¹), {b := ifp_b, fr := fr}, stream_nth_eq],
-      simp only [h, if_congr, if_false],
-      refl } }
+    by_cases h : fr = 0, -- `finish [int_fract_pair.stream]` closes both goals
+    { simp [int_fract_pair.stream, h, stream_nth_eq] },
+    { suffices : ¬ (int_fract_pair.of fr⁻¹: option $ int_fract_pair K) = none,
+        by simp [int_fract_pair.stream, h, stream_nth_eq, this],
+      exact λ h, option.no_confusion h } }
 end
 
 /--
@@ -113,8 +111,7 @@ begin
       at stream_succ_nth_eq,
     injection stream_succ_nth_eq },
   { rintro ⟨⟨_⟩, ifp_n_props⟩, -- `finish [int_fract_pair.stream, ifp_n_props]` closes this goal
-    simp only [int_fract_pair.stream, ifp_n_props, option.some_bind, if_false],
-    refl }
+    simpa only [int_fract_pair.stream, ifp_n_props, option.some_bind, if_false] }
 end
 
 lemma exists_succ_nth_stream_of_fr_zero {ifp_succ_n : int_fract_pair K}


### PR DESCRIPTION
Removing uses of `finish`, as discussed in this Zulip thread (https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/mathlib.20sat.20solvers)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
