### PR TITLE
[Merged by Bors] - chore(number_theory/quadratic_reciprocity): Eliminate `finish`

### DIFF
--- a/src/number_theory/quadratic_reciprocity.lean
+++ b/src/number_theory/quadratic_reciprocity.lean
@@ -413,7 +413,7 @@ begin
   rw [euler_criterion p ha0, legendre_sym, if_neg ha0],
   split_ifs,
   { simp only [h, eq_self_iff_true] },
-  finish -- this is quite slow. I'm actually surprised that it can close the goal at all!
+  { simp only [h, iff_false], tauto }
 end
 
 lemma eisenstein_lemma [fact (p % 2 = 1)] {a : ℕ} (ha1 : a % 2 = 1) (ha0 : (a : zmod p) ≠ 0) :

--- a/src/number_theory/quadratic_reciprocity.lean
+++ b/src/number_theory/quadratic_reciprocity.lean
@@ -439,7 +439,7 @@ have hcard : (Ico 1 (p / 2).succ).card = p / 2, by simp,
 have hx2 : ∀ x ∈ Ico 1 (p / 2).succ, (2 * x : zmod p).val = 2 * x,
   from λ x hx, have h2xp : 2 * x < p,
       from calc 2 * x ≤ 2 * (p / 2) : mul_le_mul_of_nonneg_left
-        (le_of_lt_succ $ by finish) dec_trivial
+        (le_of_lt_succ $ (mem_Ico.mp hx).2) dec_trivial
       ... < _ : by conv_rhs {rw [← div_add_mod p 2, hp1.1]}; exact lt_succ_self _,
     by rw [← nat.cast_two, ← nat.cast_mul, val_cast_of_lt h2xp],
 have hdisj : disjoint

--- a/src/number_theory/quadratic_reciprocity.lean
+++ b/src/number_theory/quadratic_reciprocity.lean
@@ -285,7 +285,7 @@ else
       div_eq_filter_card (nat.pos_of_ne_zero hp0)
         (calc x * q / p ≤ (p / 2) * q / p :
             nat.div_le_div_right (mul_le_mul_of_nonneg_right
-              (le_of_lt_succ $ by finish)
+              (le_of_lt_succ $ (mem_Ico.mp hx).2)
               (nat.zero_le _))
           ... ≤ _ : nat.div_mul_div_le_div _ _ _)
   ... = _ : by rw [← card_sigma];


### PR DESCRIPTION
Removing uses of `finish`, as discussed in this Zulip thread (https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/mathlib.20sat.20solvers)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
