### PR TITLE
[Merged by Bors] - chore(*): Eliminate some more instances of `finish`

### DIFF
--- a/src/category_theory/monad/equiv_mon.lean
+++ b/src/category_theory/monad/equiv_mon.lean
@@ -71,8 +71,8 @@ def Mon_to_Monad : Mon_ (C ⥤ C) ⥤ monad C :=
     end,
     app_μ' := begin
       intro X,
-      erw [←nat_trans.comp_app, f.mul_hom],
-      finish,
+      erw [←nat_trans.comp_app, f.mul_hom], -- `finish` closes this goal
+      simpa only [nat_trans.naturality, nat_trans.hcomp_app, assoc, nat_trans.comp_app, of_Mon_μ],
     end,
     ..f.hom } }
 

--- a/src/group_theory/perm/sign.lean
+++ b/src/group_theory/perm/sign.lean
@@ -37,7 +37,7 @@ def mod_swap [decidable_eq α] (i j : α) : setoid (perm α) :=
 ⟨λ σ τ, σ = τ ∨ σ = swap i j * τ,
  λ σ, or.inl (refl σ),
  λ σ τ h, or.cases_on h (λ h, or.inl h.symm) (λ h, or.inr (by rw [h, swap_mul_self_mul])),
- λ σ τ υ hστ hτυ, by cases hστ; cases hτυ; try {rw [hστ, hτυ, swap_mul_self_mul]}; finish⟩
+ λ σ τ υ hστ hτυ, by cases hστ; cases hτυ; try {rw [hστ, hτυ, swap_mul_self_mul]}; simp [hστ, hτυ] ⟩
 
 instance {α : Type*} [fintype α] [decidable_eq α] (i j : α) : decidable_rel (mod_swap i j).r :=
 λ σ τ, or.decidable

--- a/src/set_theory/game/impartial.lean
+++ b/src/set_theory/game/impartial.lean
@@ -119,7 +119,12 @@ begin
 end
 
 lemma not_first_wins (G : pgame) [G.impartial] : ¬G.first_wins ↔ G.first_loses :=
-by cases winner_cases G; finish using [not_first_loses_of_first_wins]
+begin
+  cases winner_cases G; -- `finish using [not_first_loses_of_first_wins]` can close these goals
+  simp only [h, iff_true, false_iff, not_true, not_first_loses_of_first_wins],
+  exact not_first_wins_of_first_loses h,
+  simp,
+end
 
 lemma not_first_loses (G : pgame) [G.impartial] : ¬G.first_loses ↔ G.first_wins :=
 iff.symm $ iff_not_comm.1 $ iff.symm $ not_first_wins G

--- a/src/set_theory/game/impartial.lean
+++ b/src/set_theory/game/impartial.lean
@@ -121,9 +121,7 @@ end
 lemma not_first_wins (G : pgame) [G.impartial] : ¬G.first_wins ↔ G.first_loses :=
 begin
   cases winner_cases G; -- `finish using [not_first_loses_of_first_wins]` can close these goals
-  simp only [h, iff_true, false_iff, not_true, not_first_loses_of_first_wins],
-  exact not_first_wins_of_first_loses h,
-  simp,
+  simp [not_first_loses_of_first_wins, not_first_wins_of_first_loses, h]
 end
 
 lemma not_first_loses (G : pgame) [G.impartial] : ¬G.first_loses ↔ G.first_wins :=


### PR DESCRIPTION
Removing uses of `finish`, as discussed in this Zulip thread (https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/mathlib.20sat.20solvers)

This (and the previous series of PRs) eliminates the last few instances of `finish` in the main body of mathlib, leaving only instances in the `scripts`, `test`, `tactic`, and `archive` folders.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
