### PR TITLE
[Merged by Bors] - feat(data/quot): Add quotient pi induction

### DIFF
--- a/src/data/quot.lean
+++ b/src/data/quot.lean
@@ -250,6 +250,7 @@ by rw [← quotient.eq_mk_iff_out, quotient.out_eq]
 ⟨λ h, quotient.out_equiv_out.1 $ h ▸ setoid.refl _, λ h, h ▸ rfl⟩
 
 section pi
+
 instance pi_setoid {ι : Sort*} {α : ι → Sort*} [∀ i, setoid (α i)] : setoid (Π i, α i) :=
 { r := λ a b, ∀ i, a i ≈ b i,
   iseqv := ⟨
@@ -267,7 +268,6 @@ noncomputable def quotient.choice {ι : Type*} {α : ι → Type*} [S : Π i, se
   (f : Π i, α i) : quotient.choice (λ i, ⟦f i⟧) = ⟦f⟧ :=
 quotient.sound $ λ i, quotient.mk_out _
 
-
 @[elab_as_eliminator] lemma quotient.induction_on_pi
    {ι : Type*} {α : ι → Sort*} [s : ∀ i, setoid (α i)]
    {p : (Π i, quotient (s i)) → Prop} (f : Π i, quotient (s i))
@@ -276,6 +276,7 @@ begin
   rw ← (funext (λ i, quotient.out_eq (f i)) : (λ i,  ⟦(f i).out⟧) = f),
   apply h,
 end
+
 end pi
 
 lemma nonempty_quotient_iff (s : setoid α) : nonempty (quotient s) ↔ nonempty α :=

--- a/src/data/quot.lean
+++ b/src/data/quot.lean
@@ -271,7 +271,7 @@ quotient.sound $ λ i, quotient.mk_out _
 @[elab_as_eliminator] lemma quotient.induction_on_pi
    {ι : Type*} {α : ι → Sort*} [s : ∀ i, setoid (α i)]
    {p : (Π i, quotient (s i)) → Prop} (f : Π i, quotient (s i))
-   (h : ∀ a : Π i, α i, p (λ i, ⟦a i⟧)) : φ f :=
+   (h : ∀ a : Π i, α i, p (λ i, ⟦a i⟧)) : p f :=
 begin
   rw ← (funext (λ i, quotient.out_eq (f i)) : (λ i,  ⟦(f i).out⟧) = f),
   apply h,

--- a/src/data/quot.lean
+++ b/src/data/quot.lean
@@ -268,13 +268,12 @@ noncomputable def quotient.choice {ι : Type*} {α : ι → Type*} [S : Π i, se
 quotient.sound $ λ i, quotient.mk_out _
 
 
-attribute [elab_as_eliminator]
-lemma quotient.induction_on_pi
+@[elab_as_eliminator] lemma quotient.induction_on_pi
    {ι : Type*} {α : ι → Sort*} [s : ∀ i, setoid (α i)]
-   {φ : (Π i, quotient (s i)) → Prop} (q : Π i, quotient (s i))
-   (h : ∀ a : Π i, α i, φ (λ i, ⟦a i⟧)) : φ q :=
+   {p : (Π i, quotient (s i)) → Prop} (f : Π i, quotient (s i))
+   (h : ∀ a : Π i, α i, p (λ i, ⟦a i⟧)) : φ f :=
 begin
-  rw ← (funext (λ i, quotient.out_eq (q i)) : (λ i,  ⟦(q i).out⟧) = q),
+  rw ← (funext (λ i, quotient.out_eq (f i)) : (λ i,  ⟦(f i).out⟧) = f),
   apply h,
 end
 end pi

--- a/src/data/quot.lean
+++ b/src/data/quot.lean
@@ -249,6 +249,7 @@ by rw [← quotient.eq_mk_iff_out, quotient.out_eq]
   x.out = y.out ↔ x = y :=
 ⟨λ h, quotient.out_equiv_out.1 $ h ▸ setoid.refl _, λ h, h ▸ rfl⟩
 
+section pi
 instance pi_setoid {ι : Sort*} {α : ι → Sort*} [∀ i, setoid (α i)] : setoid (Π i, α i) :=
 { r := λ a b, ∀ i, a i ≈ b i,
   iseqv := ⟨
@@ -262,9 +263,21 @@ noncomputable def quotient.choice {ι : Type*} {α : ι → Type*} [S : Π i, se
   (f : Π i, quotient (S i)) : @quotient (Π i, α i) (by apply_instance) :=
 ⟦λ i, (f i).out⟧
 
-theorem quotient.choice_eq {ι : Type*} {α : ι → Type*} [Π i, setoid (α i)]
+@[simp] theorem quotient.choice_eq {ι : Type*} {α : ι → Type*} [Π i, setoid (α i)]
   (f : Π i, α i) : quotient.choice (λ i, ⟦f i⟧) = ⟦f⟧ :=
 quotient.sound $ λ i, quotient.mk_out _
+
+
+attribute [elab_as_eliminator]
+lemma quotient.induction_on_pi
+   {ι : Type*} {α : ι → Sort*} [s : ∀ i, setoid (α i)]
+   {φ : (Π i, quotient (s i)) → Prop} (q : Π i, quotient (s i))
+   (h : ∀ a : Π i, α i, φ (λ i, ⟦a i⟧)) : φ q :=
+begin
+  rw ← (funext (λ i, quotient.out_eq (q i)) : (λ i,  ⟦(q i).out⟧) = q),
+  apply h,
+end
+end pi
 
 lemma nonempty_quotient_iff (s : setoid α) : nonempty (quotient s) ↔ nonempty α :=
 ⟨assume ⟨a⟩, quotient.induction_on a nonempty.intro, assume ⟨a⟩, ⟨⟦a⟧⟩⟩


### PR DESCRIPTION
I am planning to use this later to show that the (pi) product of homotopy classes of paths is well-defined, and prove
properties about that product. 

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
