### PR TITLE
[Merged by Bors] - chore(data/sym/basic): golf and add missing simp lemmas

### DIFF
--- a/src/data/setoid/basic.lean
+++ b/src/data/setoid/basic.lean
@@ -37,6 +37,8 @@ variables {α : Type*} {β : Type*}
 /-- A version of `setoid.r` that takes the equivalence relation as an explicit argument. -/
 def setoid.rel (r : setoid α) : α → α → Prop := @setoid.r _ r
 
+instance setoid.decidable_rel (r : setoid α) [h : decidable_rel r.r] : decidable_rel r.rel := h
+
 /-- A version of `quotient.eq'` compatible with `setoid.rel`, to make rewriting possible. -/
 lemma quotient.eq_rel {r : setoid α} {x y} :
   (quotient.mk' x : quotient r) = quotient.mk' y ↔ r.rel x y := quotient.eq

--- a/src/data/setoid/basic.lean
+++ b/src/data/setoid/basic.lean
@@ -316,7 +316,10 @@ lemma map_of_surjective_eq_map (h : ker f ≤ r) (hf : surjective f) :
 by rw ←eqv_gen_of_setoid (map_of_surjective r f h hf); refl
 
 /-- Given a function `f : α → β`, an equivalence relation `r` on `β` induces an equivalence
-    relation on `α` defined by '`x ≈ y` iff `f(x)` is related to `f(y)` by `r`'. -/
+relation on `α` defined by '`x ≈ y` iff `f(x)` is related to `f(y)` by `r`'.
+
+See note [reducible non-instances]. -/
+@[reducible]
 def comap (f : α → β) (r : setoid β) : setoid α :=
 ⟨r.rel on f, r.iseqv.comap _⟩
 


### PR DESCRIPTION
By changing `cons` to not use pattern matching, `(a :: s).1 = a ::ₘ s.1` is true by `rfl`, which is convenient here and there for golfing.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
