### PR TITLE
[Merged by Bors] - feat(group_theory/specific_groups/*): computes the exponents of the dihedral and generalised quaternion groups

### DIFF
--- a/src/group_theory/specific_groups/dihedral.lean
+++ b/src/group_theory/specific_groups/dihedral.lean
@@ -190,7 +190,7 @@ begin
     rintro (m | m),
     { rw [←order_of_dvd_iff_pow_eq_one, order_of_r],
       refine nat.dvd_trans ⟨gcd n m.val, _⟩ (dvd_lcm_left n 2),
-      { exact (nat.div_mul_cancel (nat.gcd_dvd_left n (zmod.val m))).symm } },
+      { exact (nat.div_mul_cancel (nat.gcd_dvd_left n m.val)).symm } },
     { rw [←order_of_dvd_iff_pow_eq_one, order_of_sr],
       exact dvd_lcm_right n 2 } },
   { apply lcm_dvd,

--- a/src/group_theory/specific_groups/dihedral.lean
+++ b/src/group_theory/specific_groups/dihedral.lean
@@ -194,18 +194,26 @@ begin
   rw [←r_one_pow, order_of_pow, order_of_r_one]
 end
 
-lemma exponent [fact (0 < n)] : monoid.exponent (dihedral_group n) = lcm n 2 :=
+@[simp] lemma order_of_r_one' : order_of (r (1 : zmod 0)) = 0 :=
 begin
+  rw order_of_eq_zero_iff',
+  intros n hn,
+  rw [r_one_pow, one_def],
+  apply mt r.inj,
+  simpa using hn.ne'
+end
+
+lemma exponent : monoid.exponent (dihedral_group n) = lcm n 2 :=
+begin
+  rcases n.eq_zero_or_pos with rfl | hn,
+  { exact monoid.exponent_eq_zero_of_order_zero (order_of_r_one') },
+  haveI := fact.mk hn,
   apply nat.dvd_antisymm,
   { apply monoid.exponent_dvd_of_forall_pow_eq_one,
-    intro g,
-    cases g with m,
+    rintro (m | m),
     { rw [←order_of_dvd_iff_pow_eq_one, order_of_r],
-      apply nat.dvd_trans,
-      { show n / n.gcd m.val ∣ n,
-        use gcd n m.val,
-        exact (nat.div_mul_cancel (nat.gcd_dvd_left n (zmod.val m))).symm },
-      { exact dvd_lcm_left n 2 } },
+      refine nat.dvd_trans ⟨gcd n m.val, _⟩ (dvd_lcm_left n 2),
+      { exact (nat.div_mul_cancel (nat.gcd_dvd_left n (zmod.val m))).symm } },
     { rw [←order_of_dvd_iff_pow_eq_one, order_of_sr],
       exact dvd_lcm_right n 2 } },
   { apply lcm_dvd,

--- a/src/group_theory/specific_groups/dihedral.lean
+++ b/src/group_theory/specific_groups/dihedral.lean
@@ -5,7 +5,8 @@ Authors: Shing Tak Lam
 -/
 import data.fintype.card
 import data.zmod.basic
-import group_theory.order_of_element
+import group_theory.exponent
+import data.int.parity
 
 /-!
 # Dihedral Groups
@@ -191,6 +192,27 @@ lemma order_of_r [fact (0 < n)] (i : zmod n) : order_of (r i) = n / nat.gcd n i.
 begin
   conv_lhs { rw ←zmod.nat_cast_zmod_val i },
   rw [←r_one_pow, order_of_pow, order_of_r_one]
+end
+
+lemma exponent [fact (0 < n)] : monoid.exponent (dihedral_group n) = lcm n 2 :=
+begin
+  apply nat.dvd_antisymm,
+  { apply monoid.exponent_dvd_of_forall_pow_eq_one,
+    intro g,
+    cases g with m,
+    { rw [←order_of_dvd_iff_pow_eq_one, order_of_r],
+      apply nat.dvd_trans,
+      { show n / n.gcd m.val ∣ n,
+        use gcd n m.val,
+        exact (nat.div_mul_cancel (nat.gcd_dvd_left n (zmod.val m))).symm },
+      { exact dvd_lcm_left n 2 } },
+    { rw [←order_of_dvd_iff_pow_eq_one, order_of_sr],
+      exact dvd_lcm_right n 2 } },
+  { apply lcm_dvd,
+    { convert monoid.order_dvd_exponent (r 1),
+      exact order_of_r_one.symm },
+    { convert monoid.order_dvd_exponent (sr 0),
+      exact (order_of_sr 0).symm } }
 end
 
 end dihedral_group

--- a/src/group_theory/specific_groups/dihedral.lean
+++ b/src/group_theory/specific_groups/dihedral.lean
@@ -154,35 +154,21 @@ If `0 < n`, then `r 1` has order `n`.
 -/
 @[simp] lemma order_of_r_one : order_of (r 1 : dihedral_group n) = n :=
 begin
-  by_cases hnpos : 0 < n,
-  { haveI : fact (0 < n) := ⟨hnpos⟩,
-    cases lt_or_eq_of_le (nat.le_of_dvd hnpos (order_of_dvd_of_pow_eq_one (@r_one_pow_n n)))
-      with h h,
-    { have h1 : (r 1 : dihedral_group n)^(order_of (r 1)) = 1,
-      { exact pow_order_of_eq_one _ },
-      rw r_one_pow at h1,
-      injection h1 with h2,
-      rw [← zmod.val_eq_zero, zmod.val_nat_cast, nat.mod_eq_of_lt h] at h2,
-      apply absurd h2.symm,
-      apply ne_of_lt,
-      exact absurd h2.symm (ne_of_lt (order_of_pos _)) },
-    { exact h } },
-  { simp only [not_lt, nonpos_iff_eq_zero] at hnpos,
-    rw hnpos,
-    apply order_of_eq_zero,
-    rw is_of_fin_order_iff_pow_eq_one,
-    push_neg,
-    intros m hm,
+  rcases n.eq_zero_or_pos with rfl | hn,
+  { rw order_of_eq_zero_iff',
+    intros n hn,
     rw [r_one_pow, one_def],
-    by_contradiction h,
-    have h' : (m : zmod 0) = 0,
-    { exact r.inj h, },
-    have h'' : m = 0,
-    { simp only [int.coe_nat_eq_zero, int.nat_cast_eq_coe_nat] at h',
-      exact h', },
-    rw h'' at hm,
-    apply nat.lt_irrefl,
-    exact hm },
+    apply mt r.inj,
+    simpa using hn.ne' },
+  { haveI := fact.mk hn,
+    apply (nat.le_of_dvd hn $ order_of_dvd_of_pow_eq_one $ @r_one_pow_n n).lt_or_eq.resolve_left,
+    intro h,
+    have h1 : (r 1 : dihedral_group n)^(order_of (r 1)) = 1,
+    { exact pow_order_of_eq_one _ },
+    rw r_one_pow at h1,
+    injection h1 with h2,
+    rw [← zmod.val_eq_zero, zmod.val_nat_cast, nat.mod_eq_of_lt h] at h2,
+    exact absurd h2.symm (order_of_pos _).ne },
 end
 
 /--
@@ -194,19 +180,10 @@ begin
   rw [←r_one_pow, order_of_pow, order_of_r_one]
 end
 
-@[simp] lemma order_of_r_one' : order_of (r (1 : zmod 0)) = 0 :=
-begin
-  rw order_of_eq_zero_iff',
-  intros n hn,
-  rw [r_one_pow, one_def],
-  apply mt r.inj,
-  simpa using hn.ne'
-end
-
 lemma exponent : monoid.exponent (dihedral_group n) = lcm n 2 :=
 begin
   rcases n.eq_zero_or_pos with rfl | hn,
-  { exact monoid.exponent_eq_zero_of_order_zero (order_of_r_one') },
+  { exact monoid.exponent_eq_zero_of_order_zero order_of_r_one },
   haveI := fact.mk hn,
   apply nat.dvd_antisymm,
   { apply monoid.exponent_dvd_of_forall_pow_eq_one,

--- a/src/group_theory/specific_groups/quaternion.lean
+++ b/src/group_theory/specific_groups/quaternion.lean
@@ -234,16 +234,23 @@ end
 /--
 If `0 < n`, then `a 1` has order `2 * n`.
 -/
-@[simp] lemma order_of_a_one [hn : fact (0 < n)] : order_of (a 1 : quaternion_group n) = 2 * n :=
+@[simp] lemma order_of_a_one : order_of (a 1 : quaternion_group n) = 2 * n :=
 begin
-  cases (nat.le_of_dvd (nat.succ_mul_pos _ hn.1)
-    (order_of_dvd_of_pow_eq_one (@a_one_pow_n n))).lt_or_eq with h h,
-  { have h1 : (a 1 : quaternion_group n)^(order_of (a 1)) = 1 := pow_order_of_eq_one _,
-    rw a_one_pow at h1,
-    injection h1 with h2,
-    rw [← zmod.val_eq_zero, zmod.val_nat_cast, nat.mod_eq_of_lt h] at h2,
-    exact absurd h2.symm (order_of_pos _).ne },
-  { exact h }
+  rcases n.eq_zero_or_pos with rfl | hn,
+  { simp_rw [mul_zero, order_of_eq_zero_iff'],
+    intros n hn,
+    rw [one_def, a_one_pow],
+    apply mt a.inj,
+    simpa using hn.ne' },
+  haveI := fact.mk hn,
+  apply (nat.le_of_dvd (nat.succ_mul_pos _ hn)
+                       (order_of_dvd_of_pow_eq_one (@a_one_pow_n n))).lt_or_eq.resolve_left,
+  intro h,
+  have h1 : (a 1 : quaternion_group n)^(order_of (a 1)) = 1 := pow_order_of_eq_one _,
+  rw a_one_pow at h1,
+  injection h1 with h2,
+  rw [← zmod.val_eq_zero, zmod.val_nat_cast, nat.mod_eq_of_lt h] at h2,
+  exact absurd h2.symm (order_of_pos _).ne
 end
 
 /--

--- a/src/group_theory/specific_groups/quaternion.lean
+++ b/src/group_theory/specific_groups/quaternion.lean
@@ -263,20 +263,20 @@ begin
   rw [← a_one_pow, order_of_pow, order_of_a_one]
 end
 
-lemma exponent [fact (0 < n)] : monoid.exponent (quaternion_group n) = 2 * lcm n 2 :=
+lemma exponent : monoid.exponent (quaternion_group n) = 2 * lcm n 2 :=
 begin
   rw [←normalize_eq 2, ←lcm_mul_left, normalize_eq],
   norm_num,
+  rcases n.eq_zero_or_pos with rfl | hn,
+  { simp only [lcm_zero_left, mul_zero],
+    exact monoid.exponent_eq_zero_of_order_zero order_of_a_one },
+  haveI := fact.mk hn,
   apply nat.dvd_antisymm,
   { apply monoid.exponent_dvd_of_forall_pow_eq_one,
-    intro g,
-    cases g with m,
+    rintro (m | m),
     { rw [←order_of_dvd_iff_pow_eq_one, order_of_a],
-      apply nat.dvd_trans,
-      { show 2 * n / (2 * n).gcd m.val ∣ (2 * n),
-        use gcd (2 * n) m.val,
-        exact (nat.div_mul_cancel (nat.gcd_dvd_left (2 * n) (m.val))).symm },
-      { exact dvd_lcm_left (2 * n) 4 } },
+      refine nat.dvd_trans ⟨gcd (2 * n) m.val, _⟩ (dvd_lcm_left (2 * n) 4),
+      exact (nat.div_mul_cancel (nat.gcd_dvd_left (2 * n) (m.val))).symm },
     { rw [←order_of_dvd_iff_pow_eq_one, order_of_xa],
       exact dvd_lcm_right (2 * n) 4 } },
   { apply lcm_dvd,

--- a/src/group_theory/specific_groups/quaternion.lean
+++ b/src/group_theory/specific_groups/quaternion.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Julian Kuelshammer
 -/
 import data.zmod.basic
-import group_theory.order_of_element
 import data.nat.basic
 import tactic.interval_cases
 import group_theory.specific_groups.dihedral
@@ -255,6 +254,29 @@ lemma order_of_a [fact (0 < n)] (i : zmod (2 * n)) :
 begin
   conv_lhs { rw ← zmod.nat_cast_zmod_val i },
   rw [← a_one_pow, order_of_pow, order_of_a_one]
+end
+
+lemma exponent [fact (0 < n)] : monoid.exponent (quaternion_group n) = 2 * lcm n 2 :=
+begin
+  rw [←normalize_eq 2, ←lcm_mul_left, normalize_eq],
+  norm_num,
+  apply nat.dvd_antisymm,
+  { apply monoid.exponent_dvd_of_forall_pow_eq_one,
+    intro g,
+    cases g with m,
+    { rw [←order_of_dvd_iff_pow_eq_one, order_of_a],
+      apply nat.dvd_trans,
+      { show 2 * n / (2 * n).gcd m.val ∣ (2 * n),
+        use gcd (2 * n) m.val,
+        exact (nat.div_mul_cancel (nat.gcd_dvd_left (2 * n) (m.val))).symm },
+      { exact dvd_lcm_left (2 * n) 4 } },
+    { rw [←order_of_dvd_iff_pow_eq_one, order_of_xa],
+      exact dvd_lcm_right (2 * n) 4 } },
+  { apply lcm_dvd,
+    { convert monoid.order_dvd_exponent (a 1),
+      exact order_of_a_one.symm },
+    { convert monoid.order_dvd_exponent (xa 0),
+      exact (order_of_xa 0).symm } }
 end
 
 end quaternion_group


### PR DESCRIPTION
This PR shows that the exponent of the dihedral group of order `2n` is equal to `lcm n 2` and that the exponent of the generalised quaternion group of order `4n` is `2 * lcm n 2`

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
