### PR TITLE
[Merged by Bors] - feat(data/dfinsupp/interval): Finitely supported dependent functions to locally finite orders are locally finite

### DIFF
--- a/src/data/dfinsupp/basic.lean
+++ b/src/data/dfinsupp/basic.lean
@@ -438,8 +438,8 @@ def mk (s : finset ι) (x : Π i : (↑s : set ι), β (i : ι)) : Π₀ i, β i
 variables {s : finset ι} {x : Π i : (↑s : set ι), β i} {i : ι}
 
 @[simp] lemma mk_apply : (mk s x : Π i, β i) i = if H : i ∈ s then x ⟨i, H⟩ else 0 := rfl
-@[simp] lemma mk_of_mem (hi : i ∈ s) : (mk s x : Π i, β i) i = x ⟨i, hi⟩ := dif_pos hi
-@[simp] lemma mk_of_not_mem (hi : i ∉ s) : (mk s x : Π i, β i) i = 0 := dif_neg hi
+lemma mk_of_mem (hi : i ∈ s) : (mk s x : Π i, β i) i = x ⟨i, hi⟩ := dif_pos hi
+lemma mk_of_not_mem (hi : i ∉ s) : (mk s x : Π i, β i) i = 0 := dif_neg hi
 
 theorem mk_injective (s : finset ι) : function.injective (@mk ι β _ _ s) :=
 begin

--- a/src/data/dfinsupp/basic.lean
+++ b/src/data/dfinsupp/basic.lean
@@ -435,9 +435,11 @@ def mk (s : finset ι) (x : Π i : (↑s : set ι), β (i : ι)) : Π₀ i, β i
 ⟦⟨λ i, if H : i ∈ s then x ⟨i, H⟩ else 0, s.1,
 λ i, if H : i ∈ s then or.inl H else or.inr $ dif_neg H⟩⟧
 
-@[simp] lemma mk_apply {s : finset ι} {x : Π i : (↑s : set ι), β i} {i : ι} :
-  (mk s x : Π i, β i) i = if H : i ∈ s then x ⟨i, H⟩ else 0 :=
-rfl
+variables {s : finset ι} {x : Π i : (↑s : set ι), β i} {i : ι}
+
+@[simp] lemma mk_apply : (mk s x : Π i, β i) i = if H : i ∈ s then x ⟨i, H⟩ else 0 := rfl
+@[simp] lemma mk_of_mem (hi : i ∈ s) : (mk s x : Π i, β i) i = x ⟨i, hi⟩ := dif_pos hi
+@[simp] lemma mk_of_not_mem (hi : i ∉ s) : (mk s x : Π i, β i) i = 0 := dif_neg hi
 
 theorem mk_injective (s : finset ι) : function.injective (@mk ι β _ _ s) :=
 begin
@@ -619,7 +621,7 @@ by rw [erase_single, if_neg h]
 
 section update
 
-variables (f : Π₀ i, β i) (i : ι) (b : β i) [decidable (b = 0)]
+variables (f : Π₀ i, β i) (i) (b : β i) [decidable (b = 0)]
 
 /-- Replace the value of a `Π₀ i, β i` at a given point `i : ι` by a given value `b : β i`.
 If `b = 0`, this amounts to removing `i` from the support.
@@ -896,8 +898,10 @@ end
 
 @[simp] lemma support_zero : (0 : Π₀ i, β i).support = ∅ := rfl
 
-lemma mem_support_iff (f : Π₀ i, β i) : ∀i:ι, i ∈ f.support ↔ f i ≠ 0 :=
-f.mem_support_to_fun
+lemma mem_support_iff {f : Π₀ i, β i} {i : ι} : i ∈ f.support ↔ f i ≠ 0 := f.mem_support_to_fun _
+
+lemma not_mem_support_iff {f : Π₀ i, β i} {i : ι} : i ∉ f.support ↔ f i = 0 :=
+not_iff_comm.1 mem_support_iff.symm
 
 @[simp] lemma support_eq_empty {f : Π₀ i, β i} : f.support = ∅ ↔ f = 0 :=
 ⟨λ H, ext $ by simpa [finset.ext_iff] using H, by simp {contextual:=tt}⟩
@@ -1033,8 +1037,8 @@ instance [Π i, has_zero (β i)] [Π i, decidable_eq (β i)] : decidable_eq (Π�
 assume f g, decidable_of_iff (f.support = g.support ∧ (∀i∈f.support, f i = g i))
   ⟨assume ⟨h₁, h₂⟩, ext $ assume i,
       if h : i ∈ f.support then h₂ i h else
-        have hf : f i = 0, by rwa [f.mem_support_iff, not_not] at h,
-        have hg : g i = 0, by rwa [h₁, g.mem_support_iff, not_not] at h,
+        have hf : f i = 0, by rwa [mem_support_iff, not_not] at h,
+        have hg : g i = 0, by rwa [h₁, mem_support_iff, not_not] at h,
         by rw [hf, hg],
     by intro h; subst h; simp⟩
 
@@ -1112,7 +1116,7 @@ have ∀i₁ : ι, f.sum (λ (i : ι₁) (b : β₁ i), (g i b) i₁) ≠ 0 →
     (∃ (i : ι₁), f i ≠ 0 ∧ ¬ (g i (f i)) i₁ = 0),
   from assume i₁ h,
   let ⟨i, hi, ne⟩ := finset.exists_ne_zero_of_sum_ne_zero h in
-  ⟨i, (f.mem_support_iff i).mp hi, ne⟩,
+  ⟨i, mem_support_iff.1 hi, ne⟩,
 by simpa [finset.subset_iff, mem_support_iff, finset.mem_bUnion, sum_apply] using this
 
 @[simp, to_additive] lemma prod_one [Π i, add_comm_monoid (β i)] [Π i (x : β i), decidable (x ≠ 0)]
@@ -1154,7 +1158,7 @@ calc ∏ i in (f + g).support, h i ((f + g) i) =
 lemma _root_.submonoid.dfinsupp_prod_mem [Π i, has_zero (β i)] [Π i (x : β i), decidable (x ≠ 0)]
   [comm_monoid γ] (S : submonoid γ)
   (f : Π₀ i, β i) (g : Π i, β i → γ) (h : ∀ c, f c ≠ 0 → g c (f c) ∈ S) : f.prod g ∈ S :=
-S.prod_mem $ λ i hi, h _ $ (f.mem_support_iff _).mp hi
+S.prod_mem $ λ i hi, h _ $ mem_support_iff.1 hi
 
 @[simp, to_additive] lemma prod_eq_prod_fintype [fintype ι] [Π i, has_zero (β i)]
   [Π (i : ι) (x : β i), decidable (x ≠ 0)] [comm_monoid γ] (v : Π₀ i, β i) {f : Π i, β i → γ}

--- a/src/data/dfinsupp/interval.lean
+++ b/src/data/dfinsupp/interval.lean
@@ -1,0 +1,164 @@
+/-
+Copyright (c) 2021 Yaël Dillies. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Yaël Dillies
+-/
+import data.finset.locally_finite
+import data.dfinsupp.order
+
+/-!
+# Finite intervals of finitely supported functions
+
+This file provides the `locally_finite_order` instance for `Π₀ i, α i` when `α` itself is locally
+finite and calculates the cardinality of its finite intervals.
+-/
+
+open dfinsupp finset
+open_locale big_operators pointwise
+
+variables {ι : Type*} {α : ι → Type*}
+
+namespace finset
+variables [decidable_eq ι] [Π i, has_zero (α i)] {s : finset ι} {f : Π₀ i, α i}
+  {t : Π i, finset (α i)}
+
+/-- Finitely supported product of finsets. -/
+def dfinsupp (s : finset ι) (t : Π i, finset (α i)) : finset (Π₀ i, α i) :=
+(s.pi t).map ⟨λ f, dfinsupp.mk s $ λ i, f i i.2, begin
+  refine (mk_injective _).comp (λ f g h, _),
+  ext i hi,
+  convert congr_fun h ⟨i, hi⟩,
+  end⟩
+
+@[simp] lemma card_dfinsupp (s : finset ι) (t : Π i, finset (α i)) :
+  (s.dfinsupp t).card = ∏ i in s, (t i).card :=
+(card_map _).trans $ card_pi _ _
+
+variables [Π i, decidable_eq (α i)]
+
+lemma mem_dfinsupp_iff : f ∈ s.dfinsupp t ↔ f.support ⊆ s ∧ ∀ i ∈ s, f i ∈ t i :=
+begin
+  refine mem_map.trans ⟨_, _⟩,
+  { rintro ⟨f, hf, rfl⟩,
+    refine ⟨support_mk_subset, λ i hi, _⟩,
+    convert mem_pi.1 hf i hi,
+    exact mk_of_mem hi },
+  { refine λ h, ⟨λ i _, f i, mem_pi.2 h.2, _⟩,
+    ext i,
+    dsimp,
+    exact ite_eq_left_iff.2 (λ hi, (not_mem_support_iff.1 $ λ H, hi $ h.1 H).symm) }
+end
+
+/-- When `t` is supported on `s`, `f ∈ s.dfinsupp t` precisely means that `f` is pointwise in `t`.
+-/
+@[simp] lemma mem_dfinsupp_iff_of_support_subset {t : Π₀ i, finset (α i)} (ht : t.support ⊆ s) :
+  f ∈ s.dfinsupp t ↔ ∀ i, f i ∈ t i :=
+begin
+  refine mem_dfinsupp_iff.trans (forall_and_distrib.symm.trans $ forall_congr $ λ i, ⟨λ h, _,
+    λ h, ⟨λ hi, ht $ mem_support_iff.2 $ λ H, mem_support_iff.1 hi _, λ _, h⟩⟩),
+  { by_cases hi : i ∈ s,
+    { exact h.2 hi },
+    { rw [not_mem_support_iff.1 (mt h.1 hi), not_mem_support_iff.1 (not_mem_mono ht hi)],
+      exact zero_mem_zero } },
+  { rwa [H, mem_zero] at h }
+end
+
+end finset
+
+open finset
+
+namespace dfinsupp
+variables [decidable_eq ι] [Π i, decidable_eq (α i)]
+
+section bundled_singleton
+variables [Π i, has_zero (α i)] {f : Π₀ i, α i} {i : ι} {a : α i}
+
+/-- Pointwise `finset.singleton` bundled as a `dfinsupp`. -/
+def singleton (f : Π₀ i, α i) : Π₀ i, finset (α i) :=
+⟦{ to_fun := λ i, {f i},
+  pre_support := f.support.1,
+  zero := λ i, (ne_or_eq (f i) 0).imp mem_support_iff.2 (congr_arg _) }⟧
+
+lemma mem_singleton_apply_iff : a ∈ f.singleton i ↔ a = f i := mem_singleton
+
+end bundled_singleton
+
+section bundled_Icc
+variables [Π i, has_zero (α i)] [Π i, partial_order (α i)] [Π i, locally_finite_order (α i)]
+  {f g : Π₀ i, α i} {i : ι} {a : α i}
+
+/-- Pointwise `finset.Icc` bundled as a `dfinsupp`. -/
+def range_Icc (f g : Π₀ i, α i) : Π₀ i, finset (α i) :=
+⟦{ to_fun := λ i, Icc (f i) (g i),
+  pre_support := f.support.1 + g.support.1,
+  zero := λ i, begin
+    refine or_iff_not_imp_left.2 (λ h, _),
+    rw [not_mem_support_iff.1 (multiset.not_mem_mono (multiset.le_add_right _ _).subset h),
+      not_mem_support_iff.1 (multiset.not_mem_mono (multiset.le_add_left _ _).subset h)],
+    exact Icc_self _,
+  end }⟧
+
+@[simp] lemma range_Icc_apply (f g : Π₀ i, α i) (i : ι) : f.range_Icc g i = Icc (f i) (g i) := rfl
+
+lemma mem_range_Icc_apply_iff : a ∈ f.range_Icc g i ↔ f i ≤ a ∧ a ≤ g i := mem_Icc
+
+lemma support_range_Icc_subset : (f.range_Icc g).support ⊆ f.support ∪ g.support :=
+begin
+  refine λ x hx, _,
+  by_contra,
+  refine not_mem_support_iff.2 _ hx,
+  rw [range_Icc_apply,
+    not_mem_support_iff.1 (not_mem_mono (subset_union_left _ _) h),
+      not_mem_support_iff.1 (not_mem_mono (subset_union_right _ _) h)],
+  exact Icc_self _,
+end
+
+
+end bundled_Icc
+
+section pi
+variables [Π i, has_zero (α i)]
+
+/-- Given a finitely supported function `f : Π₀ i, finset (α i)`, one can define the finset
+`f.pi` of all finitely supported functions whose value at `i` is in `f i` for all `i`. -/
+def pi (f : Π₀ i, finset (α i)) : finset (Π₀ i, α i) := f.support.dfinsupp f
+
+@[simp] lemma mem_pi {f : Π₀ i, finset (α i)} {g : Π₀ i, α i} : g ∈ f.pi ↔ ∀ i, g i ∈ f i :=
+mem_dfinsupp_iff_of_support_subset $ subset.refl _
+
+@[simp] lemma card_pi (f : Π₀ i, finset (α i)) : f.pi.card = f.prod (λ i, (f i).card) :=
+begin
+  rw [pi, card_dfinsupp],
+  exact finset.prod_congr rfl (λ i _, by simp only [pi.nat_apply, nat.cast_id]),
+end
+
+end pi
+
+section locally_finite
+variables [Π i, partial_order (α i)] [Π i, has_zero (α i)] [Π i, locally_finite_order (α i)]
+
+instance : locally_finite_order (Π₀ i, α i) :=
+locally_finite_order.of_Icc (Π₀ i, α i)
+  (λ f g, (f.support ∪ g.support).dfinsupp $ f.range_Icc g)
+  (λ f g x, begin
+    refine (mem_dfinsupp_iff_of_support_subset $ support_range_Icc_subset).trans _,
+    simp_rw [mem_range_Icc_apply_iff, forall_and_distrib],
+    refl,
+  end)
+
+variables (f g : Π₀ i, α i)
+
+lemma card_Icc : (Icc f g).card = ∏ i in f.support ∪ g.support, (Icc (f i) (g i)).card :=
+card_dfinsupp _ _
+
+lemma card_Ico : (Ico f g).card = ∏ i in f.support ∪ g.support, (Icc (f i) (g i)).card - 1 :=
+by rw [card_Ico_eq_card_Icc_sub_one, card_Icc]
+
+lemma card_Ioc : (Ioc f g).card = ∏ i in f.support ∪ g.support, (Icc (f i) (g i)).card - 1 :=
+by rw [card_Ioc_eq_card_Icc_sub_one, card_Icc]
+
+lemma card_Ioo : (Ioo f g).card = ∏ i in f.support ∪ g.support, (Icc (f i) (g i)).card - 2 :=
+by rw [card_Ioo_eq_card_Icc_sub_two, card_Icc]
+
+end locally_finite
+end dfinsupp

--- a/src/data/dfinsupp/order.lean
+++ b/src/data/dfinsupp/order.lean
@@ -20,17 +20,13 @@ This file lifts order structures on the `α i` to `Π₀ i, α i`.
 Add `is_well_order (Π₀ i, α i) (<)`.
 -/
 
-noncomputable theory
-open_locale classical big_operators
+open_locale big_operators
 
 open finset
 
 variables {ι : Type*} {α : ι → Type*}
 
 namespace dfinsupp
-
-lemma not_mem_support_iff [Π i, has_zero (α i)] {f : Π₀ i, α i} {i : ι} : i ∉ f.support ↔ f i = 0 :=
-by rw [mem_support_iff, not_ne_iff]
 
 /-! ### Order structures -/
 
@@ -140,11 +136,14 @@ protected lemma bot_eq_zero : (⊥ : Π₀ i, α i) = 0 := rfl
 @[simp] lemma add_eq_zero_iff (f g : Π₀ i, α i) : f + g = 0 ↔ f = 0 ∧ g = 0 :=
 by simp [ext_iff, forall_and_distrib]
 
-lemma le_iff' {f g : Π₀ i, α i} {s : finset ι} (hf : f.support ⊆ s) : f ≤ g ↔ ∀ i ∈ s, f i ≤ g i :=
+section le
+variables [decidable_eq ι] [Π i (x : α i), decidable (x ≠ 0)] {f g : Π₀ i, α i} {s : finset ι}
+
+lemma le_iff' (hf : f.support ⊆ s) : f ≤ g ↔ ∀ i ∈ s, f i ≤ g i :=
 ⟨λ h s hs, h s,
 λ h s, if H : s ∈ f.support then h s (hf H) else (not_mem_support_iff.1 H).symm ▸ zero_le (g s)⟩
 
-lemma le_iff {f g : Π₀ i, α i} : f ≤ g ↔ ∀ i ∈ f.support, f i ≤ g i := le_iff' $ subset.refl _
+lemma le_iff : f ≤ g ↔ ∀ i ∈ f.support, f i ≤ g i := le_iff' $ subset.refl _
 
 variables (α)
 
@@ -154,8 +153,10 @@ instance decidable_le [Π i, decidable_rel (@has_le.le (α i) _)] :
 
 variables {α}
 
-@[simp] lemma single_le_iff {i : ι} {a : α i} {f : Π₀ i, α i} : single i a ≤ f ↔ a ≤ f i :=
+@[simp] lemma single_le_iff {i : ι} {a : α i} : single i a ≤ f ↔ a ≤ f i :=
 (le_iff' support_single_subset).trans $ by simp
+
+end le
 
 variables (α) [Π i, has_sub (α i)] [Π i, has_ordered_sub (α i)] {f g : Π₀ i, α i} {i : ι}
   {a b : α i}
@@ -188,7 +189,7 @@ instance : canonically_ordered_add_monoid (Π₀ i, α i) :=
  .. dfinsupp.order_bot α,
  .. dfinsupp.ordered_add_comm_monoid α }
 
-variables {α}
+variables {α} [decidable_eq ι]
 
 @[simp] lemma single_tsub : single i (a - b) = single i a - single i b :=
 begin
@@ -197,6 +198,8 @@ begin
   { rw [tsub_apply, single_eq_same, single_eq_same, single_eq_same] },
   { rw [tsub_apply, single_eq_of_ne h, single_eq_of_ne h, single_eq_of_ne h, tsub_self] }
 end
+
+variables [Π i (x : α i), decidable (x ≠ 0)]
 
 lemma support_tsub : (f - g).support ⊆ f.support :=
 by simp only [subset_iff, tsub_eq_zero_iff_le, mem_support_iff, ne.def, coe_tsub, pi.sub_apply,

--- a/src/data/finset/basic.lean
+++ b/src/data/finset/basic.lean
@@ -228,6 +228,7 @@ instance : has_subset (finset α) := ⟨λ s₁ s₂, ∀ ⦃a⦄, a ∈ s₁ �
 theorem subset_def {s₁ s₂ : finset α} : s₁ ⊆ s₂ ↔ s₁.1 ⊆ s₂.1 := iff.rfl
 
 @[simp] theorem subset.refl (s : finset α) : s ⊆ s := subset.refl _
+protected lemma subset.rfl {s :finset α} : s ⊆ s := subset.refl _
 
 theorem subset_of_eq {s t : finset α} (h : s = t) : s ⊆ t := h ▸ subset.refl _
 
@@ -240,6 +241,8 @@ theorem superset.trans {s₁ s₂ s₃ : finset α} : s₁ ⊇ s₂ → s₂ ⊇
 local attribute [trans] subset.trans superset.trans
 
 theorem mem_of_subset {s₁ s₂ : finset α} {a : α} : s₁ ⊆ s₂ → a ∈ s₁ → a ∈ s₂ := mem_of_subset
+
+lemma not_mem_mono {s t : finset α} (h : s ⊆ t) {a : α} : a ∉ t → a ∉ s := mt $ @h _
 
 theorem subset.antisymm {s₁ s₂ : finset α} (H₁ : s₁ ⊆ s₂) (H₂ : s₂ ⊆ s₁) : s₁ = s₂ :=
 ext $ λ a, ⟨@H₁ a, @H₂ a⟩

--- a/src/data/multiset/basic.lean
+++ b/src/data/multiset/basic.lean
@@ -295,8 +295,12 @@ instance : partial_order (multiset α) :=
 theorem subset_of_le {s t : multiset α} : s ≤ t → s ⊆ t :=
 quotient.induction_on₂ s t $ λ l₁ l₂, subperm.subset
 
+alias subset_of_le ← multiset.le.subset
+
 theorem mem_of_le {s t : multiset α} {a : α} (h : s ≤ t) : a ∈ s → a ∈ t :=
 mem_of_subset (subset_of_le h)
+
+lemma not_mem_mono (h : s ⊆ t) {a : α} : a ∉ t → a ∉ s := mt $ @h _
 
 @[simp] theorem coe_le {l₁ l₂ : list α} : (l₁ : multiset α) ≤ l₂ ↔ l₁ <+~ l₂ := iff.rfl
 

--- a/src/data/multiset/basic.lean
+++ b/src/data/multiset/basic.lean
@@ -292,15 +292,16 @@ instance : partial_order (multiset α) :=
   le_trans    := by rintros ⟨l₁⟩ ⟨l₂⟩ ⟨l₃⟩; exact @subperm.trans _ _ _ _,
   le_antisymm := by rintros ⟨l₁⟩ ⟨l₂⟩ h₁ h₂; exact quot.sound (subperm.antisymm h₁ h₂) }
 
-theorem subset_of_le {s t : multiset α} : s ≤ t → s ⊆ t :=
-quotient.induction_on₂ s t $ λ l₁ l₂, subperm.subset
+section
+variables {s t : multiset α} {a : α}
+
+lemma subset_of_le : s ≤ t → s ⊆ t := quotient.induction_on₂ s t $ λ l₁ l₂, subperm.subset
 
 alias subset_of_le ← multiset.le.subset
 
-theorem mem_of_le {s t : multiset α} {a : α} (h : s ≤ t) : a ∈ s → a ∈ t :=
-mem_of_subset (subset_of_le h)
+lemma mem_of_le (h : s ≤ t) : a ∈ s → a ∈ t := mem_of_subset (subset_of_le h)
 
-lemma not_mem_mono (h : s ⊆ t) {a : α} : a ∉ t → a ∉ s := mt $ @h _
+lemma not_mem_mono (h : s ⊆ t) : a ∉ t → a ∉ s := mt $ @h _
 
 @[simp] theorem coe_le {l₁ l₂ : list α} : (l₁ : multiset α) ≤ l₂ ↔ l₁ <+~ l₂ := iff.rfl
 
@@ -313,8 +314,7 @@ quotient.induction_on₂ s t (λ l₁ l₂ ⟨l, p, s⟩,
 theorem zero_le (s : multiset α) : 0 ≤ s :=
 quot.induction_on s $ λ l, (nil_sublist l).subperm
 
-theorem le_zero {s : multiset α} : s ≤ 0 ↔ s = 0 :=
-⟨λ h, le_antisymm h (zero_le _), le_of_eq⟩
+lemma le_zero : s ≤ 0 ↔ s = 0 := ⟨λ h, le_antisymm h (zero_le _), le_of_eq⟩
 
 theorem lt_cons_self (s : multiset α) (a : α) : s < a ::ₘ s :=
 quot.induction_on s $ λ l,
@@ -326,13 +326,12 @@ suffices l <+~ a :: l ∧ (¬l ~ a :: l),
 theorem le_cons_self (s : multiset α) (a : α) : s ≤ a ::ₘ s :=
 le_of_lt $ lt_cons_self _ _
 
-theorem cons_le_cons_iff (a : α) {s t : multiset α} : a ::ₘ s ≤ a ::ₘ t ↔ s ≤ t :=
+lemma cons_le_cons_iff (a : α) : a ::ₘ s ≤ a ::ₘ t ↔ s ≤ t :=
 quotient.induction_on₂ s t $ λ l₁ l₂, subperm_cons a
 
-theorem cons_le_cons (a : α) {s t : multiset α} : s ≤ t → a ::ₘ s ≤ a ::ₘ t :=
-(cons_le_cons_iff a).2
+lemma cons_le_cons (a : α) : s ≤ t → a ::ₘ s ≤ a ::ₘ t := (cons_le_cons_iff a).2
 
-theorem le_cons_of_not_mem {a : α} {s t : multiset α} (m : a ∉ s) : s ≤ a ::ₘ t ↔ s ≤ t :=
+lemma le_cons_of_not_mem (m : a ∉ s) : s ≤ a ::ₘ t ↔ s ≤ t :=
 begin
   refine ⟨_, λ h, le_trans h $ le_cons_self _ _⟩,
   suffices : ∀ {t'} (_ : s ≤ t') (_ : a ∈ t'), a ::ₘ s ≤ t',
@@ -342,6 +341,8 @@ begin
   rcases mem_split m₂ with ⟨r₁, r₂, rfl⟩,
   exact perm_middle.subperm_left.2 ((subperm_cons _).2 $
     ((sublist_or_mem_of_sublist s).resolve_right m₁).subperm)
+end
+
 end
 
 /-! ### Singleton -/


### PR DESCRIPTION
This provides the ` locally_finite_order` instance for `Π₀ i, α i` in a new file `data.dfinsupp.interval`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
