### PR TITLE
[Merged by Bors] - chore(order/rel_classes): Removed unnecessary `classical`

### DIFF
--- a/src/order/rel_classes.lean
+++ b/src/order/rel_classes.lean
@@ -278,13 +278,10 @@ def unbounded (r : α → α → Prop) (s : set α) : Prop := ∀ a, ∃ b ∈ s
 def bounded (r : α → α → Prop) (s : set α) : Prop := ∃a, ∀ b ∈ s, r b a
 
 @[simp] lemma not_bounded_iff {r : α → α → Prop} (s : set α) : ¬bounded r s ↔ unbounded r s :=
-begin
-  classical,
-  simp only [bounded, unbounded, not_forall, not_exists, exists_prop, not_and, not_not]
-end
+by simp only [bounded, unbounded, not_forall, not_exists, exists_prop, not_and, not_not]
 
 @[simp] lemma not_unbounded_iff {r : α → α → Prop} (s : set α) : ¬unbounded r s ↔ bounded r s :=
-by { classical, rw [not_iff_comm, not_bounded_iff] }
+by rw [not_iff_comm, not_bounded_iff]
 
 namespace prod
 


### PR DESCRIPTION
Not sure what that was doing here.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
