### PR TITLE
[Merged by Bors] - feat(data/nat/digits): digits_len

### DIFF
--- a/src/data/nat/digits.lean
+++ b/src/data/nat/digits.lean
@@ -325,7 +325,7 @@ begin
   rw [digits_eq_cons_digits_div hb hn, list.length],
   cases (n / b).eq_zero_or_pos with h h,
   { have posb : 0 < b := zero_lt_two.trans_le hb,
-    simp [←h, log_eq_zero_iff, ←nat.div_eq_zero_iff posb] },
+    simp [h, log_eq_zero_iff, ←nat.div_eq_zero_iff posb] },
   { have hb' : 1 < b := one_lt_two.trans_le hb,
     have : n / b < n := div_lt_self hn hb',
     rw [IH _ this h, log_div_base, tsub_add_cancel_of_le],

--- a/src/data/nat/digits.lean
+++ b/src/data/nat/digits.lean
@@ -318,12 +318,12 @@ function.left_inverse.injective (of_digits_digits b)
   b.digits n = b.digits m ↔ n = m :=
 (digits.injective b).eq_iff
 
-lemma length_digits (b n : ℕ) (hb : 2 ≤ b) (hn : 0 < n) :
+lemma digits_len (b n : ℕ) (hb : 2 ≤ b) (hn : 0 < n) :
   (b.digits n).length = b.log n + 1 :=
 begin
   induction n using nat.strong_induction_on with n IH,
   rw [digits_eq_cons_digits_div hb hn, list.length],
-  cases (n / b).zero_le.eq_or_lt with h h,
+  cases (n / b).eq_zero_or_pos with h h,
   { have posb : 0 < b := zero_lt_two.trans_le hb,
     simp [←h, log_eq_zero_iff, ←nat.div_eq_zero_iff posb] },
   { have hb' : 1 < b := one_lt_two.trans_le hb,
@@ -422,25 +422,14 @@ by rw [of_digits_append, of_digits_digits, of_digits_digits]
 
 lemma digits_len_le_digits_len_succ (b n : ℕ) : (digits b n).length ≤ (digits b (n + 1)).length :=
 begin
-  cases b,
-  { -- base 0
-    cases n; simp },
-  { cases b,
-    { -- base 1
-      simp },
-    { -- base >= 2
-      apply nat.strong_induction_on n,
-      clear n,
-      intros n IH,
-      cases n,
-      { simp },
-      { rw [digits_add_two_add_one, digits_add_two_add_one],
-        by_cases hdvd : (b.succ.succ) ∣ (n.succ+1),
-        { rw [nat.succ_div_of_dvd hdvd, list.length_cons, list.length_cons, nat.succ_le_succ_iff],
-          apply IH,
-          exact nat.div_lt_self (by linarith) (by linarith) },
-        { rw nat.succ_div_of_not_dvd hdvd,
-          refl } } } }
+  rcases n.eq_zero_or_pos with rfl|hn,
+  { simp },
+  cases lt_or_le b 2 with hb hb,
+  { rcases b with _|_|b,
+    { simp [digits_zero_succ', hn] },
+    { simp, },
+    { simpa [succ_lt_succ_iff] using hb } },
+  simpa [digits_len, hb, hn] using log_le_log_of_le (le_succ _)
 end
 
 lemma le_digits_len_le (b n m : ℕ) (h : n ≤ m) : (digits b n).length ≤ (digits b m).length :=


### PR DESCRIPTION
Via a new `data.nat.log` import.
Also unprivate `digits_eq_cons_digits_div`.

The file needs a refactor to make the names more mathlib-like,
otherwise I would have named it `length_digits`.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
