### PR TITLE
[Merged by Bors] - feat(linear_algebra/matrix/basis): `to_matrix_units_smul` and `to_matrix_is_unit_smul`

### DIFF
--- a/src/linear_algebra/matrix/basis.lean
+++ b/src/linear_algebra/matrix/basis.lean
@@ -83,6 +83,21 @@ begin
   { rw update_noteq h },
 end
 
+/-- The basis constructed by `units_smul` has vectors given by a diagonal matrix. -/
+@[simp] lemma to_matrix_units_smul [decidable_eq ι] (w : ι → units R) :
+  e.to_matrix (e.units_smul w) = diagonal (coe ∘ w) :=
+begin
+  ext i j,
+  by_cases h : i = j,
+  { simp [h, to_matrix_apply, units_smul_apply, units.smul_def] },
+  { simp [h, to_matrix_apply, units_smul_apply, units.smul_def, ne.symm h] }
+end
+
+/-- The basis constructed by `is_unit_smul` has vectors given by a diagonal matrix. -/
+@[simp] lemma to_matrix_is_unit_smul [decidable_eq ι] {w : ι → R} (hw : ∀ i, is_unit (w i)) :
+  e.to_matrix (e.is_unit_smul hw) = diagonal w :=
+e.to_matrix_units_smul _
+
 @[simp] lemma sum_to_matrix_smul_self [fintype ι] : ∑ (i : ι), e.to_matrix v i j • e i = v j :=
 by simp_rw [e.to_matrix_apply, e.sum_repr]
 


### PR DESCRIPTION
Add lemmas that applying `to_matrix` to a basis constructed with
`units_smul` or `is_unit_smul` produces the corresponding diagonal
matrix.



---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
