### PR TITLE
[Merged by Bors] - chore(measure_theory/group/arithmetic): use implicit argument for measurable_space

### DIFF
--- a/src/measure_theory/function/conditional_expectation.lean
+++ b/src/measure_theory/function/conditional_expectation.lean
@@ -101,7 +101,7 @@ lemma add [has_add β] [has_measurable_add₂ β] (hf : ae_measurable' m f μ)
 begin
   rcases hf with ⟨f', h_f'_meas, hff'⟩,
   rcases hg with ⟨g', h_g'_meas, hgg'⟩,
-  exact ⟨f' + g', @measurable.add _ _ _ _ m _ f' g' h_f'_meas h_g'_meas, hff'.add hgg'⟩,
+  exact ⟨f' + g', h_f'_meas.add h_g'_meas, hff'.add hgg'⟩,
 end
 
 lemma neg [has_neg β] [has_measurable_neg β] {f : α → β} (hfm : ae_measurable' m f μ) :
@@ -129,7 +129,7 @@ lemma const_smul [has_scalar 𝕜 β] [has_measurable_smul 𝕜 β] (c : 𝕜) (
   ae_measurable' m (c • f) μ :=
 begin
   rcases hf with ⟨f', h_f'_meas, hff'⟩,
-  refine ⟨c • f', @measurable.const_smul _ _ _ _ _ _ m _ f' h_f'_meas c, _⟩,
+  refine ⟨c • f', h_f'_meas.const_smul c, _⟩,
   exact eventually_eq.fun_comp hff' (λ x, c • x),
 end
 

--- a/src/measure_theory/function/conditional_expectation.lean
+++ b/src/measure_theory/function/conditional_expectation.lean
@@ -85,7 +85,7 @@ function. This is similar to `ae_measurable`, but the `measurable_space` structu
 measurability statement and for the measure are different. -/
 def ae_measurable' {α β} [measurable_space β] (m : measurable_space α) {m0 : measurable_space α}
   (f : α → β) (μ : measure α) : Prop :=
-∃ g : α → β, @measurable α β m _ g ∧ f =ᵐ[μ] g
+∃ g : α → β, measurable[m] g ∧ f =ᵐ[μ] g
 
 namespace ae_measurable'
 
@@ -108,7 +108,7 @@ lemma neg [has_neg β] [has_measurable_neg β] {f : α → β} (hfm : ae_measura
   ae_measurable' m (-f) μ :=
 begin
   rcases hfm with ⟨f', hf'_meas, hf_ae⟩,
-  refine ⟨-f', @measurable.neg _ _ _ _ _ m _ hf'_meas, hf_ae.mono (λ x hx, _)⟩,
+  refine ⟨-f', hf'_meas.neg, hf_ae.mono (λ x hx, _)⟩,
   simp_rw pi.neg_apply,
   rw hx,
 end
@@ -119,8 +119,7 @@ lemma sub [has_sub β] [has_measurable_sub₂ β] {f g : α → β}
 begin
   rcases hfm with ⟨f', hf'_meas, hf_ae⟩,
   rcases hgm with ⟨g', hg'_meas, hg_ae⟩,
-  refine ⟨f'-g', @measurable.sub _ _ _ _ m _ _ _ hf'_meas hg'_meas,
-    hf_ae.mp (hg_ae.mono (λ x hx1 hx2, _))⟩,
+  refine ⟨f'-g', hf'_meas.sub hg'_meas, hf_ae.mp (hg_ae.mono (λ x hx1 hx2, _))⟩,
   simp_rw pi.sub_apply,
   rw [hx1, hx2],
 end
@@ -139,8 +138,7 @@ lemma const_inner {𝕜} [is_R_or_C 𝕜] [inner_product_space 𝕜 β]
   ae_measurable' m (λ x, (inner c (f x) : 𝕜)) μ :=
 begin
   rcases hfm with ⟨f', hf'_meas, hf_ae⟩,
-  refine ⟨λ x, (inner c (f' x) : 𝕜),
-    @measurable.inner _ _ _ _ _ m _ _ _ _ _ (@measurable_const _ _ _ m _) hf'_meas,
+  refine ⟨λ x, (inner c (f' x) : 𝕜), (@measurable_const _ _ _ m _).inner hf'_meas,
     hf_ae.mono (λ x hx, _)⟩,
   dsimp only,
   rw hx,
@@ -380,7 +378,7 @@ begin
   ext1,
   refine eventually_eq.trans _ (Lp.coe_fn_add _ _).symm,
   refine ae_eq_trim_of_measurable hm (Lp.measurable _) _ _,
-  { exact @measurable.add _ _ _ _ m _ _ _ (Lp.measurable _) (Lp.measurable _), },
+  { exact (Lp.measurable _).add (Lp.measurable _), },
   refine (Lp_meas_subgroup_to_Lp_trim_ae_eq hm _).trans _,
   refine eventually_eq.trans _
     (eventually_eq.add (Lp_meas_subgroup_to_Lp_trim_ae_eq hm f).symm
@@ -418,7 +416,7 @@ begin
   ext1,
   refine eventually_eq.trans _ (Lp.coe_fn_smul _ _).symm,
   refine ae_eq_trim_of_measurable hm (Lp.measurable _) _ _,
-  { exact @measurable.const_smul _ _ α _ _ _ m _ _ (Lp.measurable _) c, },
+  { exact (Lp.measurable _).const_smul c, },
   refine (Lp_meas_to_Lp_trim_ae_eq hm _).trans _,
   refine (Lp.coe_fn_smul _ _).trans _,
   refine (Lp_meas_to_Lp_trim_ae_eq hm f).mono (λ x hx, _),
@@ -967,7 +965,7 @@ end
 variables {𝕜}
 
 lemma set_lintegral_nnnorm_condexp_L2_indicator_le (hm : m ≤ m0) (hs : measurable_set s)
-  (hμs : μ s ≠ ∞) (x : E') {t : set α} (ht : @measurable_set _ m t) (hμt : μ t ≠ ∞) :
+  (hμs : μ s ≠ ∞) (x : E') {t : set α} (ht : measurable_set[m] t) (hμt : μ t ≠ ∞) :
   ∫⁻ a in t, ∥condexp_L2 𝕜 hm (indicator_const_Lp 2 hs hμs x) a∥₊ ∂μ ≤ μ (s ∩ t) * ∥x∥₊ :=
 calc ∫⁻ a in t, ∥condexp_L2 𝕜 hm (indicator_const_Lp 2 hs hμs x) a∥₊ ∂μ
     = ∫⁻ a in t, ∥(condexp_L2 ℝ hm (indicator_const_Lp 2 hs hμs (1 : ℝ)) a) • x∥₊ ∂μ :
@@ -1054,7 +1052,7 @@ lemma condexp_ind_smul_ae_eq_smul (hm : m ≤ m0) (hs : measurable_set s) (hμs 
 (to_span_singleton ℝ x).coe_fn_comp_LpL _
 
 lemma set_lintegral_nnnorm_condexp_ind_smul_le (hm : m ≤ m0) (hs : measurable_set s)
-  (hμs : μ s ≠ ∞) (x : G) {t : set α} (ht : @measurable_set _ m t) (hμt : μ t ≠ ∞) :
+  (hμs : μ s ≠ ∞) (x : G) {t : set α} (ht : measurable_set[m] t) (hμt : μ t ≠ ∞) :
   ∫⁻ a in t, ∥condexp_ind_smul hm hs hμs x a∥₊ ∂μ ≤ μ (s ∩ t) * ∥x∥₊ :=
 calc ∫⁻ a in t, ∥condexp_ind_smul hm hs hμs x a∥₊ ∂μ
     = ∫⁻ a in t, ∥condexp_L2 ℝ hm (indicator_const_Lp 2 hs hμs (1 : ℝ)) a • x∥₊ ∂μ :

--- a/src/measure_theory/function/special_functions.lean
+++ b/src/measure_theory/function/special_functions.lean
@@ -89,7 +89,7 @@ end is_R_or_C
 
 section real_composition
 open real
-variables {α : Type*} [measurable_space α] {f : α → ℝ} (hf : measurable f)
+variables {α : Type*} {m : measurable_space α} {f : α → ℝ} (hf : measurable f)
 
 @[measurability] lemma measurable.exp : measurable (λ x, real.exp (f x)) :=
 real.measurable_exp.comp hf
@@ -119,7 +119,7 @@ end real_composition
 
 section complex_composition
 open complex
-variables {α : Type*} [measurable_space α] {f : α → ℂ} (hf : measurable f)
+variables {α : Type*} {m : measurable_space α} {f : α → ℂ} (hf : measurable f)
 
 @[measurability] lemma measurable.cexp : measurable (λ x, complex.exp (f x)) :=
 complex.measurable_exp.comp hf
@@ -146,8 +146,10 @@ end complex_composition
 
 section is_R_or_C_composition
 
-variables {α 𝕜 : Type*} [is_R_or_C 𝕜] [measurable_space α]
+variables {α 𝕜 : Type*} [is_R_or_C 𝕜] {m : measurable_space α}
   {f : α → 𝕜} {μ : measure_theory.measure α}
+
+include m
 
 @[measurability] lemma measurable.re (hf : measurable f) : measurable (λ x, is_R_or_C.re (f x)) :=
 is_R_or_C.measurable_re.comp hf
@@ -162,6 +164,8 @@ is_R_or_C.measurable_im.comp hf
 @[measurability] lemma ae_measurable.im (hf : ae_measurable f μ) :
   ae_measurable (λ x, is_R_or_C.im (f x)) μ :=
 is_R_or_C.measurable_im.comp_ae_measurable hf
+
+omit m
 
 end is_R_or_C_composition
 
@@ -231,14 +235,14 @@ variables {α : Type*} {𝕜 : Type*} {E : Type*} [is_R_or_C 𝕜] [inner_produc
 local notation `⟪`x`, `y`⟫` := @inner 𝕜 _ _ x y
 
 @[measurability]
-lemma measurable.inner [measurable_space α] [measurable_space E] [opens_measurable_space E]
+lemma measurable.inner {m : measurable_space α} [measurable_space E] [opens_measurable_space E]
   [topological_space.second_countable_topology E]
   {f g : α → E} (hf : measurable f) (hg : measurable g) :
   measurable (λ t, ⟪f t, g t⟫) :=
 continuous.measurable2 continuous_inner hf hg
 
 @[measurability]
-lemma ae_measurable.inner [measurable_space α] [measurable_space E] [opens_measurable_space E]
+lemma ae_measurable.inner {m : measurable_space α} [measurable_space E] [opens_measurable_space E]
   [topological_space.second_countable_topology E]
   {μ : measure_theory.measure α} {f g : α → E} (hf : ae_measurable f μ) (hg : ae_measurable g μ) :
   ae_measurable (λ x, ⟪f x, g x⟫) μ :=
@@ -247,8 +251,7 @@ begin
   refine hf.ae_eq_mk.mp (hg.ae_eq_mk.mono (λ x hxg hxf, _)),
   dsimp only,
   congr,
-  { exact hxf, },
-  { exact hxg, },
+  exacts [hxf, hxg],
 end
 
 end

--- a/src/measure_theory/group/arithmetic.lean
+++ b/src/measure_theory/group/arithmetic.lean
@@ -475,10 +475,14 @@ lemma ae_measurable.smul [has_measurable_smul₂ M β]
   ae_measurable (λ x, f x • g x) μ :=
 has_measurable_smul₂.measurable_smul.comp_ae_measurable (hf.prod_mk hg)
 
+omit m
+
 @[priority 100, to_additive]
 instance has_measurable_smul₂.to_has_measurable_smul [has_measurable_smul₂ M β] :
   has_measurable_smul M β :=
 ⟨λ c, measurable_const.smul measurable_id, λ y, measurable_id.smul measurable_const⟩
+
+include m
 
 variables [has_measurable_smul M β] {μ : measure α}
 

--- a/src/measure_theory/group/arithmetic.lean
+++ b/src/measure_theory/group/arithmetic.lean
@@ -83,52 +83,53 @@ export has_measurable_mul₂ (measurable_mul)
 
 section mul
 
-variables {M α : Type*} [measurable_space M] [has_mul M] [measurable_space α]
+variables {M α : Type*} [measurable_space M] [has_mul M] {m : measurable_space α}
+  {f g : α → M} {μ : measure α}
+
+include m
 
 @[to_additive, measurability]
-lemma measurable.const_mul [has_measurable_mul M] {f : α → M} (hf : measurable f) (c : M) :
+lemma measurable.const_mul [has_measurable_mul M] (hf : measurable f) (c : M) :
   measurable (λ x, c * f x) :=
 (measurable_const_mul c).comp hf
 
 @[to_additive, measurability]
-lemma ae_measurable.const_mul [has_measurable_mul M] {f : α → M} {μ : measure α}
-  (hf : ae_measurable f μ) (c : M) :
+lemma ae_measurable.const_mul [has_measurable_mul M] (hf : ae_measurable f μ) (c : M) :
   ae_measurable (λ x, c * f x) μ :=
 (has_measurable_mul.measurable_const_mul c).comp_ae_measurable hf
 
 @[to_additive, measurability]
-lemma measurable.mul_const [has_measurable_mul M] {f : α → M} (hf : measurable f) (c : M) :
+lemma measurable.mul_const [has_measurable_mul M] (hf : measurable f) (c : M) :
   measurable (λ x, f x * c) :=
 (measurable_mul_const c).comp hf
 
 @[to_additive, measurability]
-lemma ae_measurable.mul_const [has_measurable_mul M] {f : α → M} {μ : measure α}
-  (hf : ae_measurable f μ) (c : M) :
+lemma ae_measurable.mul_const [has_measurable_mul M] (hf : ae_measurable f μ) (c : M) :
   ae_measurable (λ x, f x * c) μ :=
 (measurable_mul_const c).comp_ae_measurable hf
 
 @[to_additive, measurability]
-lemma measurable.mul' [has_measurable_mul₂ M] {f g : α → M} (hf : measurable f)
-  (hg : measurable g) :
+lemma measurable.mul' [has_measurable_mul₂ M] (hf : measurable f) (hg : measurable g) :
   measurable (f * g) :=
 measurable_mul.comp (hf.prod_mk hg)
 
 @[to_additive, measurability]
-lemma measurable.mul [has_measurable_mul₂ M] {f g : α → M} (hf : measurable f) (hg : measurable g) :
+lemma measurable.mul [has_measurable_mul₂ M] (hf : measurable f) (hg : measurable g) :
   measurable (λ a, f a * g a) :=
 measurable_mul.comp (hf.prod_mk hg)
 
 @[to_additive, measurability]
-lemma ae_measurable.mul' [has_measurable_mul₂ M] {μ : measure α} {f g : α → M}
-  (hf : ae_measurable f μ) (hg : ae_measurable g μ) :
+lemma ae_measurable.mul' [has_measurable_mul₂ M] (hf : ae_measurable f μ)
+  (hg : ae_measurable g μ) :
   ae_measurable (f * g) μ :=
 measurable_mul.comp_ae_measurable (hf.prod_mk hg)
 
 @[to_additive, measurability]
-lemma ae_measurable.mul [has_measurable_mul₂ M] {μ : measure α} {f g : α → M}
-  (hf : ae_measurable f μ) (hg : ae_measurable g μ) :
+lemma ae_measurable.mul [has_measurable_mul₂ M] (hf : ae_measurable f μ) (hg : ae_measurable g μ) :
   ae_measurable (λ a, f a * g a) μ :=
 measurable_mul.comp_ae_measurable (hf.prod_mk hg)
+
+omit m
 
 @[priority 100, to_additive]
 instance has_measurable_mul₂.to_has_measurable_mul [has_measurable_mul₂ M] :
@@ -137,6 +138,7 @@ instance has_measurable_mul₂.to_has_measurable_mul [has_measurable_mul₂ M] :
 
 attribute [measurability] measurable.add' measurable.add ae_measurable.add ae_measurable.add'
   measurable.const_add ae_measurable.const_add measurable.add_const ae_measurable.add_const
+
 
 end mul
 
@@ -159,38 +161,41 @@ end⟩
 section pow
 
 variables {β γ α : Type*} [measurable_space β] [measurable_space γ] [has_pow β γ]
-  [has_measurable_pow β γ] [measurable_space α]
+  [has_measurable_pow β γ] {m : measurable_space α} {μ : measure α} {f : α → β} {g : α → γ}
+
+include m
 
 @[measurability]
-lemma measurable.pow {f : α → β} {g : α → γ} (hf : measurable f) (hg : measurable g) :
+lemma measurable.pow (hf : measurable f) (hg : measurable g) :
   measurable (λ x, f x ^ g x) :=
 measurable_pow.comp (hf.prod_mk hg)
 
 @[measurability]
-lemma ae_measurable.pow {μ : measure α} {f : α → β} {g : α → γ} (hf : ae_measurable f μ)
-  (hg : ae_measurable g μ) :
+lemma ae_measurable.pow (hf : ae_measurable f μ) (hg : ae_measurable g μ) :
   ae_measurable (λ x, f x ^ g x) μ :=
 measurable_pow.comp_ae_measurable (hf.prod_mk hg)
 
 @[measurability]
-lemma measurable.pow_const {f : α → β} (hf : measurable f) (c : γ) :
+lemma measurable.pow_const (hf : measurable f) (c : γ) :
   measurable (λ x, f x ^ c) :=
 hf.pow measurable_const
 
 @[measurability]
-lemma ae_measurable.pow_const {μ : measure α} {f : α → β} (hf : ae_measurable f μ) (c : γ) :
+lemma ae_measurable.pow_const (hf : ae_measurable f μ) (c : γ) :
   ae_measurable (λ x, f x ^ c) μ :=
 hf.pow ae_measurable_const
 
 @[measurability]
-lemma measurable.const_pow {f : α → γ} (hf : measurable f) (c : β) :
-  measurable (λ x, c ^ f x) :=
-measurable_const.pow hf
+lemma measurable.const_pow (hg : measurable g) (c : β) :
+  measurable (λ x, c ^ g x) :=
+measurable_const.pow hg
 
 @[measurability]
-lemma ae_measurable.const_pow {μ : measure α} {f : α → γ} (hf : ae_measurable f μ) (c : β) :
-  ae_measurable (λ x, c ^ f x) μ :=
-ae_measurable_const.pow hf
+lemma ae_measurable.const_pow (hg : ae_measurable g μ) (c : β) :
+  ae_measurable (λ x, c ^ g x) μ :=
+ae_measurable_const.pow hg
+
+omit m
 
 end pow
 
@@ -223,64 +228,66 @@ export has_measurable_div₂ (measurable_div)
 
 section div
 
-variables {G α : Type*} [measurable_space G] [has_div G] [measurable_space α]
+variables {G α : Type*} [measurable_space G] [has_div G] {m : measurable_space α} {f g : α → G}
+  {μ : measure α}
+
+include m
 
 @[to_additive, measurability]
-lemma measurable.const_div [has_measurable_div G] {f : α → G} (hf : measurable f) (c : G) :
+lemma measurable.const_div [has_measurable_div G] (hf : measurable f) (c : G) :
   measurable (λ x, c / f x) :=
 (has_measurable_div.measurable_const_div c).comp hf
 
 @[to_additive, measurability]
-lemma ae_measurable.const_div [has_measurable_div G] {f : α → G} {μ : measure α}
-  (hf : ae_measurable f μ) (c : G) :
+lemma ae_measurable.const_div [has_measurable_div G] (hf : ae_measurable f μ) (c : G) :
   ae_measurable (λ x, c / f x) μ :=
 (has_measurable_div.measurable_const_div c).comp_ae_measurable hf
 
 @[to_additive, measurability]
-lemma measurable.div_const [has_measurable_div G] {f : α → G} (hf : measurable f) (c : G) :
+lemma measurable.div_const [has_measurable_div G] (hf : measurable f) (c : G) :
   measurable (λ x, f x / c) :=
 (has_measurable_div.measurable_div_const c).comp hf
 
 @[to_additive, measurability]
-lemma ae_measurable.div_const [has_measurable_div G] {f : α → G} {μ : measure α}
-  (hf : ae_measurable f μ) (c : G) :
+lemma ae_measurable.div_const [has_measurable_div G] (hf : ae_measurable f μ) (c : G) :
   ae_measurable (λ x, f x / c) μ :=
 (has_measurable_div.measurable_div_const c).comp_ae_measurable hf
 
 @[to_additive, measurability]
-lemma measurable.div' [has_measurable_div₂ G] {f g : α → G} (hf : measurable f)
-  (hg : measurable g) :
+lemma measurable.div' [has_measurable_div₂ G] (hf : measurable f) (hg : measurable g) :
   measurable (f / g) :=
 measurable_div.comp (hf.prod_mk hg)
 
 @[to_additive, measurability]
-lemma measurable.div [has_measurable_div₂ G] {f g : α → G} (hf : measurable f) (hg : measurable g) :
+lemma measurable.div [has_measurable_div₂ G] (hf : measurable f) (hg : measurable g) :
   measurable (λ a, f a / g a) :=
 measurable_div.comp (hf.prod_mk hg)
 
 @[to_additive, measurability]
-lemma ae_measurable.div' [has_measurable_div₂ G] {f g : α → G} {μ : measure α}
-  (hf : ae_measurable f μ) (hg : ae_measurable g μ) :
+lemma ae_measurable.div' [has_measurable_div₂ G] (hf : ae_measurable f μ)
+  (hg : ae_measurable g μ) :
   ae_measurable (f / g) μ :=
 measurable_div.comp_ae_measurable (hf.prod_mk hg)
 
 @[to_additive, measurability]
-lemma ae_measurable.div [has_measurable_div₂ G] {f g : α → G} {μ : measure α}
-  (hf : ae_measurable f μ) (hg : ae_measurable g μ) :
+lemma ae_measurable.div [has_measurable_div₂ G] (hf : ae_measurable f μ) (hg : ae_measurable g μ) :
   ae_measurable (λ a, f a / g a) μ :=
 measurable_div.comp_ae_measurable (hf.prod_mk hg)
+
+attribute [measurability] measurable.sub measurable.sub' ae_measurable.sub ae_measurable.sub'
+  measurable.const_sub ae_measurable.const_sub measurable.sub_const ae_measurable.sub_const
+
+omit m
 
 @[priority 100, to_additive]
 instance has_measurable_div₂.to_has_measurable_div [has_measurable_div₂ G] :
   has_measurable_div G :=
 ⟨λ c, measurable_const.div measurable_id, λ c, measurable_id.div measurable_const⟩
 
-attribute [measurability] measurable.sub measurable.sub' ae_measurable.sub ae_measurable.sub'
-  measurable.const_sub ae_measurable.const_sub measurable.sub_const ae_measurable.sub_const
-
 @[measurability]
-lemma measurable_set_eq_fun {E} [measurable_space E] [add_group E] [measurable_singleton_class E]
-  [has_measurable_sub₂ E] {f g : α → E} (hf : measurable f) (hg : measurable g) :
+lemma measurable_set_eq_fun {m : measurable_space α} {E} [measurable_space E] [add_group E]
+  [measurable_singleton_class E] [has_measurable_sub₂ E] {f g : α → E}
+  (hf : measurable f) (hg : measurable g) :
   measurable_set {x | f x = g x} :=
 begin
   suffices h_set_eq : {x : α | f x = g x} = {x | (f-g) x = (0 : E)},
@@ -324,29 +331,26 @@ instance has_measurable_div_of_mul_inv (G : Type*) [measurable_space G]
 
 section inv
 
-variables {G α : Type*} [has_inv G] [measurable_space G] [has_measurable_inv G] [measurable_space α]
+variables {G α : Type*} [has_inv G] [measurable_space G] [has_measurable_inv G]
+  {m : measurable_space α} {f : α → G} {μ : measure α}
+
+include m
 
 @[to_additive, measurability]
-lemma measurable.inv {f : α → G} (hf : measurable f) :
-  measurable (λ x, (f x)⁻¹) :=
-measurable_inv.comp hf
+lemma measurable.inv (hf : measurable f) : measurable (λ x, (f x)⁻¹) := measurable_inv.comp hf
 
 @[to_additive, measurability]
-lemma ae_measurable.inv {f : α → G} {μ : measure α} (hf : ae_measurable f μ) :
-  ae_measurable (λ x, (f x)⁻¹) μ :=
+lemma ae_measurable.inv (hf : ae_measurable f μ) : ae_measurable (λ x, (f x)⁻¹) μ :=
 measurable_inv.comp_ae_measurable hf
 
 attribute [measurability] measurable.neg ae_measurable.neg
-
-@[to_additive] lemma measurable_set.inv {s : set G} (hs : measurable_set s) : measurable_set s⁻¹ :=
-measurable_inv hs
 
 @[simp, to_additive] lemma measurable_inv_iff {G : Type*} [group G] [measurable_space G]
   [has_measurable_inv G] {f : α → G} : measurable (λ x, (f x)⁻¹) ↔ measurable f :=
 ⟨λ h, by simpa only [inv_inv] using h.inv, λ h, h.inv⟩
 
 @[simp, to_additive] lemma ae_measurable_inv_iff {G : Type*} [group G] [measurable_space G]
-  [has_measurable_inv G] {f : α → G} {μ : measure α} :
+  [has_measurable_inv G] {f : α → G} :
   ae_measurable (λ x, (f x)⁻¹) μ ↔ ae_measurable f μ :=
 ⟨λ h, by simpa only [inv_inv] using h.inv, λ h, h.inv⟩
 
@@ -356,9 +360,14 @@ measurable_inv hs
 ⟨λ h, by simpa only [inv_inv₀] using h.inv, λ h, h.inv⟩
 
 @[simp] lemma ae_measurable_inv_iff₀ {G₀ : Type*} [group_with_zero G₀]
-  [measurable_space G₀] [has_measurable_inv G₀] {f : α → G₀} {μ : measure α} :
+  [measurable_space G₀] [has_measurable_inv G₀] {f : α → G₀} :
   ae_measurable (λ x, (f x)⁻¹) μ ↔ ae_measurable f μ :=
 ⟨λ h, by simpa only [inv_inv₀] using h.inv, λ h, h.inv⟩
+
+omit m
+
+@[to_additive] lemma measurable_set.inv {s : set G} (hs : measurable_set s) : measurable_set s⁻¹ :=
+measurable_inv hs
 
 end inv
 
@@ -451,17 +460,18 @@ s.to_submonoid.has_measurable_smul
 section smul
 
 variables {M β α : Type*} [measurable_space M] [measurable_space β] [has_scalar M β]
-  [measurable_space α]
+  {m : measurable_space α} {f : α → M} {g : α → β}
+
+include m
 
 @[measurability, to_additive]
-lemma measurable.smul [has_measurable_smul₂ M β]
-  {f : α → M} {g : α → β} (hf : measurable f) (hg : measurable g) :
+lemma measurable.smul [has_measurable_smul₂ M β] (hf : measurable f) (hg : measurable g) :
   measurable (λ x, f x • g x) :=
 measurable_smul.comp (hf.prod_mk hg)
 
 @[measurability, to_additive]
 lemma ae_measurable.smul [has_measurable_smul₂ M β]
-  {f : α → M} {g : α → β} {μ : measure α} (hf : ae_measurable f μ) (hg : ae_measurable g μ) :
+  {μ : measure α} (hf : ae_measurable f μ) (hg : ae_measurable g μ) :
   ae_measurable (λ x, f x • g x) μ :=
 has_measurable_smul₂.measurable_smul.comp_ae_measurable (hf.prod_mk hg)
 
@@ -473,33 +483,36 @@ instance has_measurable_smul₂.to_has_measurable_smul [has_measurable_smul₂ M
 variables [has_measurable_smul M β] {μ : measure α}
 
 @[measurability, to_additive]
-lemma measurable.smul_const {f : α → M} (hf : measurable f) (y : β) : measurable (λ x, f x • y) :=
+lemma measurable.smul_const (hf : measurable f) (y : β) :
+  measurable (λ x, f x • y) :=
 (has_measurable_smul.measurable_smul_const y).comp hf
 
 @[measurability, to_additive]
-lemma ae_measurable.smul_const {f : α → M} (hf : ae_measurable f μ) (y : β) :
+lemma ae_measurable.smul_const (hf : ae_measurable f μ) (y : β) :
   ae_measurable (λ x, f x • y) μ :=
 (has_measurable_smul.measurable_smul_const y).comp_ae_measurable hf
 
 @[measurability, to_additive]
-lemma measurable.const_smul' {f : α → β} (hf : measurable f) (c : M) :
-  measurable (λ x, c • f x) :=
-(has_measurable_smul.measurable_const_smul c).comp hf
+lemma measurable.const_smul' (hg : measurable g) (c : M) :
+  measurable (λ x, c • g x) :=
+(has_measurable_smul.measurable_const_smul c).comp hg
 
 @[measurability, to_additive]
-lemma measurable.const_smul {f : α → β} (hf : measurable f) (c : M) :
-  measurable (c • f) :=
+lemma measurable.const_smul (hg : measurable g) (c : M) :
+  measurable (c • g) :=
+hg.const_smul' c
+
+@[measurability, to_additive]
+lemma ae_measurable.const_smul' (hg : ae_measurable g μ) (c : M) :
+  ae_measurable (λ x, c • g x) μ :=
+(has_measurable_smul.measurable_const_smul c).comp_ae_measurable hg
+
+@[measurability, to_additive]
+lemma ae_measurable.const_smul (hf : ae_measurable g μ) (c : M) :
+  ae_measurable (c • g) μ :=
 hf.const_smul' c
 
-@[measurability, to_additive]
-lemma ae_measurable.const_smul' {f : α → β} (hf : ae_measurable f μ) (c : M) :
-  ae_measurable (λ x, c • f x) μ :=
-(has_measurable_smul.measurable_const_smul c).comp_ae_measurable hf
-
-@[measurability, to_additive]
-lemma ae_measurable.const_smul {f : α → β} (hf : ae_measurable f μ) (c : M) :
-  ae_measurable (c • f) μ :=
-hf.const_smul' c
+omit m
 
 end smul
 
@@ -591,7 +604,10 @@ end opposite
 -/
 
 section monoid
-variables {M α : Type*} [monoid M] [measurable_space M] [has_measurable_mul₂ M] [measurable_space α]
+variables {M α : Type*} [monoid M] [measurable_space M] [has_measurable_mul₂ M]
+  {m : measurable_space α} {μ : measure α}
+
+include m
 
 @[to_additive, measurability]
 lemma list.measurable_prod' (l : list (α → M)) (hl : ∀ f ∈ l, measurable f) :
@@ -604,7 +620,7 @@ begin
 end
 
 @[to_additive, measurability]
-lemma list.ae_measurable_prod' {μ : measure α} (l : list (α → M))
+lemma list.ae_measurable_prod' (l : list (α → M))
   (hl : ∀ f ∈ l, ae_measurable f μ) : ae_measurable l.prod μ :=
 begin
   induction l with f l ihl, { exact ae_measurable_one },
@@ -619,15 +635,19 @@ lemma list.measurable_prod (l : list (α → M)) (hl : ∀ f ∈ l, measurable f
 by simpa only [← pi.list_prod_apply] using l.measurable_prod' hl
 
 @[to_additive, measurability]
-lemma list.ae_measurable_prod {μ : measure α} (l : list (α → M)) (hl : ∀ f ∈ l, ae_measurable f μ) :
+lemma list.ae_measurable_prod (l : list (α → M)) (hl : ∀ f ∈ l, ae_measurable f μ) :
   ae_measurable (λ x, (l.map (λ f : α → M, f x)).prod) μ :=
 by simpa only [← pi.list_prod_apply] using l.ae_measurable_prod' hl
+
+omit m
 
 end monoid
 
 section comm_monoid
 variables {M ι α : Type*} [comm_monoid M] [measurable_space M] [has_measurable_mul₂ M]
-  [measurable_space α]
+  {m : measurable_space α} {μ : measure α} {f : ι → α → M}
+
+include m
 
 @[to_additive, measurability]
 lemma multiset.measurable_prod' (l : multiset (α → M)) (hl : ∀ f ∈ l, measurable f) :
@@ -635,7 +655,7 @@ lemma multiset.measurable_prod' (l : multiset (α → M)) (hl : ∀ f ∈ l, mea
 by { rcases l with ⟨l⟩, simpa using l.measurable_prod' (by simpa using hl) }
 
 @[to_additive, measurability]
-lemma multiset.ae_measurable_prod' {μ : measure α} (l : multiset (α → M))
+lemma multiset.ae_measurable_prod' (l : multiset (α → M))
   (hl : ∀ f ∈ l, ae_measurable f μ) : ae_measurable l.prod μ :=
 by { rcases l with ⟨l⟩, simpa using l.ae_measurable_prod' (by simpa using hl) }
 
@@ -645,32 +665,32 @@ lemma multiset.measurable_prod (s : multiset (α → M)) (hs : ∀ f ∈ s, meas
 by simpa only [← pi.multiset_prod_apply] using s.measurable_prod' hs
 
 @[to_additive, measurability]
-lemma multiset.ae_measurable_prod {μ : measure α} (s : multiset (α → M))
+lemma multiset.ae_measurable_prod (s : multiset (α → M))
   (hs : ∀ f ∈ s, ae_measurable f μ) : ae_measurable (λ x, (s.map (λ f : α → M, f x)).prod) μ :=
 by simpa only [← pi.multiset_prod_apply] using s.ae_measurable_prod' hs
 
 @[to_additive, measurability]
-lemma finset.measurable_prod' {f : ι → α → M} (s : finset ι) (hf : ∀i ∈ s, measurable (f i)) :
+lemma finset.measurable_prod' (s : finset ι) (hf : ∀i ∈ s, measurable (f i)) :
   measurable (∏ i in s, f i) :=
 finset.prod_induction _ _ (λ _ _, measurable.mul) (@measurable_one M _ _ _ _) hf
 
 @[to_additive, measurability]
-lemma finset.measurable_prod {f : ι → α → M} (s : finset ι) (hf : ∀i ∈ s, measurable (f i)) :
+lemma finset.measurable_prod (s : finset ι) (hf : ∀i ∈ s, measurable (f i)) :
   measurable (λ a, ∏ i in s, f i a) :=
 by simpa only [← finset.prod_apply] using s.measurable_prod' hf
 
 @[to_additive, measurability]
-lemma finset.ae_measurable_prod' {μ : measure α} {f : ι → α → M} (s : finset ι)
-  (hf : ∀i ∈ s, ae_measurable (f i) μ) :
+lemma finset.ae_measurable_prod' (s : finset ι) (hf : ∀i ∈ s, ae_measurable (f i) μ) :
   ae_measurable (∏ i in s, f i) μ :=
 multiset.ae_measurable_prod' _ $
   λ g hg, let ⟨i, hi, hg⟩ := multiset.mem_map.1 hg in (hg ▸ hf _ hi)
 
 @[to_additive, measurability]
-lemma finset.ae_measurable_prod {f : ι → α → M} {μ : measure α} (s : finset ι)
-  (hf : ∀i ∈ s, ae_measurable (f i) μ) :
+lemma finset.ae_measurable_prod (s : finset ι) (hf : ∀i ∈ s, ae_measurable (f i) μ) :
   ae_measurable (λ a, ∏ i in s, f i a) μ :=
 by simpa only [← finset.prod_apply] using s.ae_measurable_prod' hf
+
+omit m
 
 end comm_monoid
 


### PR DESCRIPTION
The `measurable_space` argument is inferred from other arguments (like `measurable f` or a measure for example) instead of being a type class. This ensures that the lemmas are usable without `@` when several measurable space structures are used for the same type.

Also use more `variables`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
