### PR TITLE
[Merged by Bors] - chore(algebra/module/submodule): switch `subtype_eq_val` to `coe_subtype`

### DIFF
--- a/src/algebra/module/submodule.lean
+++ b/src/algebra/module/submodule.lean
@@ -204,7 +204,7 @@ by refine {to_fun := coe, ..}; simp [coe_smul]
 
 @[simp] theorem subtype_apply (x : p) : p.subtype x = x := rfl
 
-lemma subtype_eq_val : ((submodule.subtype p) : p → M) = subtype.val := rfl
+lemma subtype_eq_coe : ((submodule.subtype p) : p → M) = coe := rfl
 
 /-- Note the `add_submonoid` version of this lemma is called `add_submonoid.coe_finset_sum`. -/
 @[simp] lemma coe_sum (x : ι → p) (s : finset ι) : ↑(∑ i in s, x i) = ∑ i in s, (x i : M) :=

--- a/src/algebra/module/submodule.lean
+++ b/src/algebra/module/submodule.lean
@@ -204,7 +204,7 @@ by refine {to_fun := coe, ..}; simp [coe_smul]
 
 @[simp] theorem subtype_apply (x : p) : p.subtype x = x := rfl
 
-lemma subtype_eq_coe : ((submodule.subtype p) : p → M) = coe := rfl
+lemma coe_subtype : ((submodule.subtype p) : p → M) = coe := rfl
 
 /-- Note the `add_submonoid` version of this lemma is called `add_submonoid.coe_finset_sum`. -/
 @[simp] lemma coe_sum (x : ι → p) (s : finset ι) : ↑(∑ i in s, x i) = ∑ i in s, (x i : M) :=

--- a/src/linear_algebra/basis.lean
+++ b/src/linear_algebra/basis.lean
@@ -926,11 +926,13 @@ basis.mk (linear_independent_span hli) $
 begin
   rw eq_top_iff,
   intros x _,
-  have h₁ : subtype.val '' set.range (λ i, subtype.mk (v i) _) = range v,
-  { rw ← set.range_comp },
+  have h₁ : (coe : {x // x ∈ span R (range v)} → M) '' set.range (λ i, subtype.mk (v i) _)
+    = range v,
+  { rw ← set.range_comp,
+    refl },
   have h₂ : map (submodule.subtype _) (span R (set.range (λ i, subtype.mk (v i) _)))
     = span R (range v),
-  { rw [← span_image, submodule.subtype_eq_val, h₁] },
+  { rw [← span_image, submodule.subtype_eq_coe, h₁] },
   have h₃ : (x : M) ∈ map (submodule.subtype _) (span R (set.range (λ i, subtype.mk (v i) _))),
   { rw h₂, apply subtype.mem x },
   rcases mem_map.1 h₃ with ⟨y, hy₁, hy₂⟩,

--- a/src/linear_algebra/basis.lean
+++ b/src/linear_algebra/basis.lean
@@ -926,8 +926,7 @@ basis.mk (linear_independent_span hli) $
 begin
   rw eq_top_iff,
   intros x _,
-  have h₁ : (coe : {x // x ∈ span R (range v)} → M) '' set.range (λ i, subtype.mk (v i) _)
-    = range v,
+  have h₁ : (coe : span R (range v) → M) '' set.range (λ i, subtype.mk (v i) _) = range v,
   { rw ← set.range_comp,
     refl },
   have h₂ : map (submodule.subtype _) (span R (set.range (λ i, subtype.mk (v i) _)))

--- a/src/linear_algebra/basis.lean
+++ b/src/linear_algebra/basis.lean
@@ -931,7 +931,7 @@ begin
     refl },
   have h₂ : map (submodule.subtype _) (span R (set.range (λ i, subtype.mk (v i) _)))
     = span R (range v),
-  { rw [← span_image, submodule.subtype_eq_coe, h₁] },
+  { rw [← span_image, submodule.coe_subtype, h₁] },
   have h₃ : (x : M) ∈ map (submodule.subtype _) (span R (set.range (λ i, subtype.mk (v i) _))),
   { rw h₂, apply subtype.mem x },
   rcases mem_map.1 h₃ with ⟨y, hy₁, hy₂⟩,

--- a/src/linear_algebra/finite_dimensional.lean
+++ b/src/linear_algebra/finite_dimensional.lean
@@ -348,15 +348,15 @@ begin
   set b := basis.extend this with b_eq,
   letI : fintype (this.extend _) :=
     (finite_of_linear_independent (by simpa using b.linear_independent)).fintype,
-  letI : fintype (subtype.val '' basis.of_vector_space_index K S) :=
+  letI : fintype (coe '' basis.of_vector_space_index K S) :=
     (finite_of_linear_independent this).fintype,
   letI : fintype (basis.of_vector_space_index K S) :=
     (finite_of_linear_independent (by simpa using bS.linear_independent)).fintype,
-  have : subtype.val '' (basis.of_vector_space_index K S) = this.extend (set.subset_univ _),
+  have : coe '' (basis.of_vector_space_index K S) = this.extend (set.subset_univ _),
   from set.eq_of_subset_of_card_le (this.subset_extend _)
-    (by rw [set.card_image_of_injective _ subtype.val_injective, ← finrank_eq_card_basis bS,
+    (by rw [set.card_image_of_injective _ subtype.coe_injective, ← finrank_eq_card_basis bS,
          ← finrank_eq_card_basis b, h]; apply_instance),
-  rw [← b.span_eq, b_eq, basis.coe_extend, subtype.range_coe, ← this, ← subtype_eq_val, span_image],
+  rw [← b.span_eq, b_eq, basis.coe_extend, subtype.range_coe, ← this, ← subtype_eq_coe, span_image],
   have := bS.span_eq,
   rw [bS_eq, basis.coe_of_vector_space, subtype.range_coe] at this,
   rw [this, map_top (submodule.subtype S), range_subtype],

--- a/src/linear_algebra/finite_dimensional.lean
+++ b/src/linear_algebra/finite_dimensional.lean
@@ -356,7 +356,8 @@ begin
   from set.eq_of_subset_of_card_le (this.subset_extend _)
     (by rw [set.card_image_of_injective _ subtype.coe_injective, ← finrank_eq_card_basis bS,
          ← finrank_eq_card_basis b, h]; apply_instance),
-  rw [← b.span_eq, b_eq, basis.coe_extend, subtype.range_coe, ← this, ← coe_subtype, span_image],
+  rw [← b.span_eq, b_eq, basis.coe_extend, subtype.range_coe, ← this, ← submodule.coe_subtype,
+    span_image],
   have := bS.span_eq,
   rw [bS_eq, basis.coe_of_vector_space, subtype.range_coe] at this,
   rw [this, map_top (submodule.subtype S), range_subtype],

--- a/src/linear_algebra/finite_dimensional.lean
+++ b/src/linear_algebra/finite_dimensional.lean
@@ -356,7 +356,7 @@ begin
   from set.eq_of_subset_of_card_le (this.subset_extend _)
     (by rw [set.card_image_of_injective _ subtype.coe_injective, ← finrank_eq_card_basis bS,
          ← finrank_eq_card_basis b, h]; apply_instance),
-  rw [← b.span_eq, b_eq, basis.coe_extend, subtype.range_coe, ← this, ← subtype_eq_coe, span_image],
+  rw [← b.span_eq, b_eq, basis.coe_extend, subtype.range_coe, ← this, ← coe_subtype, span_image],
   have := bS.span_eq,
   rw [bS_eq, basis.coe_of_vector_space, subtype.range_coe] at this,
   rw [this, map_top (submodule.subtype S), range_subtype],


### PR DESCRIPTION
Change the name and form of a lemma, from
```lean
lemma subtype_eq_val : ((submodule.subtype p) : p → M) = subtype.val := rfl
```
to
```lean
lemma coe_subtype : ((submodule.subtype p) : p → M) = coe := rfl
```
The latter is the simp-normal form so I claim it should be preferred.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
