### PR TITLE
[Merged by Bors] - fix(algebra/star/basic): redefine `star_ordered_ring`

### DIFF
--- a/src/algebra/star/basic.lean
+++ b/src/algebra/star/basic.lean
@@ -21,12 +21,23 @@ These are implemented as "mixin" typeclasses, so to summon a star ring (for exam
 one needs to write `(R : Type) [ring R] [star_ring R]`.
 This avoids difficulties with diamond inheritance.
 
+We also define the class `star_ordered_ring R`, which says that the order on `R` respects the
+star operation, i.e. an element `r` is nonnegative iff there exists an `s` such that
+`r = star s * s`.
+
 For now we simply do not introduce notations,
 as different users are expected to feel strongly about the relative merits of
 `r^*`, `r†`, `rᘁ`, and so on.
 
 Our star rings are actually star semirings, but of course we can prove
 `star_neg : star (-r) = - star r` when the underlying semiring is a ring.
+
+## TODO
+
+* In a Banach star algebra without a well-defined square root, the natural ordering is given by the
+positive cone which is the closure of the sums of elements `star r * r`. A weaker version of
+`star_ordered_ring` could be defined for this case. Note that the current definition has the
+advantage of not requiring a topology.
 -/
 
 
@@ -266,18 +277,31 @@ def star_ring_of_comm {R : Type*} [comm_semiring R] : star_ring R :=
   ..star_monoid_of_comm }
 
 /--
-An ordered `*`-ring is a ring which is both an ordered ring and a `*`-ring,
-and `0 ≤ star r * r` for every `r`.
-
-(In a Banach algebra, the natural ordering is given by the positive cone
-which is the closure of the sums of elements `star r * r`.
-This ordering makes the Banach algebra an ordered `*`-ring.)
+An ordered `*`-ring is a ring which is both an `ordered_add_comm_group` and a `*`-ring,
+and `0 ≤ r ↔ ∃ s, r = star s * s`.
 -/
-class star_ordered_ring (R : Type u) [ordered_semiring R] extends star_ring R :=
-(star_mul_self_nonneg : ∀ r : R, 0 ≤ star r * r)
+class star_ordered_ring (R : Type u) [ring R] [partial_order R] extends star_ring R :=
+(add_le_add_left       : ∀ a b : R, a ≤ b → ∀ c : R, c + a ≤ c + b)
+(nonneg_iff            : ∀ r : R, 0 ≤ r ↔ ∃ s, r = star s * s)
 
-lemma star_mul_self_nonneg [ordered_semiring R] [star_ordered_ring R] {r : R} : 0 ≤ star r * r :=
-star_ordered_ring.star_mul_self_nonneg r
+namespace star_ordered_ring
+
+variables [ring R] [partial_order R] [star_ordered_ring R]
+
+instance : ordered_add_comm_group R :=
+{ ..show ring R, by apply_instance,
+  ..show partial_order R, by apply_instance,
+  ..show star_ordered_ring R, by apply_instance }
+
+end star_ordered_ring
+
+lemma star_mul_self_nonneg [ring R] [partial_order R] [star_ordered_ring R] {r : R} :
+  0 ≤ star r * r :=
+(star_ordered_ring.nonneg_iff _).mpr ⟨r, rfl⟩
+
+lemma star_mul_self_nonneg' [ring R] [partial_order R] [star_ordered_ring R] {r : R} :
+  0 ≤ r * star r :=
+by { nth_rewrite_rhs 0 [←star_star r], exact star_mul_self_nonneg }
 
 /--
 A star module `A` over a star ring `R` is a module which is a star add monoid,

--- a/src/algebra/star/basic.lean
+++ b/src/algebra/star/basic.lean
@@ -288,6 +288,7 @@ namespace star_ordered_ring
 
 variables [ring R] [partial_order R] [star_ordered_ring R]
 
+@[priority 100] -- see note [lower instance priority]
 instance : ordered_add_comm_group R :=
 { ..show ring R, by apply_instance,
   ..show partial_order R, by apply_instance,

--- a/src/data/complex/basic.lean
+++ b/src/data/complex/basic.lean
@@ -198,6 +198,8 @@ instance : star_ring ℂ :=
   star_mul := λ a b, by ext; simp [add_comm]; ring,
   star_add := λ a b, by ext; simp [add_comm] }
 
+@[simp] lemma star_eq_conj (z : ℂ) : star z = conj z := rfl
+
 @[simp] lemma conj_re (z : ℂ) : (conj z).re = z.re := rfl
 @[simp] lemma conj_im (z : ℂ) : (conj z).im = -z.im := rfl
 
@@ -582,14 +584,21 @@ localized "attribute [instance] complex.ordered_comm_ring" in complex_order
 
 /--
 With `z ≤ w` iff `w - z` is real and nonnegative, `ℂ` is a star ordered ring.
-(That is, an ordered ring in which every element of the form `star z * z` is nonnegative.)
-
-In fact, the nonnegative elements are precisely those of this form.
-This hold in any `C^*`-algebra, e.g. `ℂ`,
-but we don't yet have `C^*`-algebras in mathlib.
+(That is, a star ring in which the nonnegative elements are those of the form `star z * z`.)
 -/
 protected def star_ordered_ring : star_ordered_ring ℂ :=
-{ star_mul_self_nonneg := λ z, ⟨by simp [add_nonneg, mul_self_nonneg], by simp [mul_comm]⟩ }
+{ nonneg_iff := λ r, by
+  { refine ⟨λ hr, ⟨real.sqrt r.re, _⟩, λ h, _⟩,
+    { have h₁ : 0 ≤ r.re := by { rw [le_def] at hr, exact hr.1 },
+      have h₂ : r.im = 0 := by { rw [le_def] at hr, exact hr.2.symm },
+      ext,
+      { simp only [of_real_im, star_def, of_real_re, sub_zero, conj_re, mul_re, mul_zero,
+                   ←real.sqrt_mul h₁ r.re, real.sqrt_mul_self h₁] },
+      { simp only [h₂, add_zero, of_real_im, star_def, zero_mul, conj_im,
+                   mul_im, mul_zero, neg_zero] } },
+    { obtain ⟨s, rfl⟩ := h,
+      simp only [←norm_sq_eq_conj_mul_self, norm_sq_nonneg, zero_le_real, star_def] } },
+  ..complex.ordered_comm_ring }
 
 localized "attribute [instance] complex.star_ordered_ring" in complex_order
 

--- a/src/data/complex/basic.lean
+++ b/src/data/complex/basic.lean
@@ -198,8 +198,6 @@ instance : star_ring ℂ :=
   star_mul := λ a b, by ext; simp [add_comm]; ring,
   star_add := λ a b, by ext; simp [add_comm] }
 
-@[simp] lemma star_eq_conj (z : ℂ) : star z = conj z := rfl
-
 @[simp] lemma conj_re (z : ℂ) : (conj z).re = z.re := rfl
 @[simp] lemma conj_im (z : ℂ) : (conj z).im = -z.im := rfl
 

--- a/src/data/real/basic.lean
+++ b/src/data/real/basic.lean
@@ -241,10 +241,6 @@ noncomputable instance : linear_ordered_semiring ℝ    := by apply_instance
 instance : is_domain ℝ :=
 { .. real.nontrivial, .. real.comm_ring, .. linear_ordered_ring.is_domain }
 
-/-- The real numbers are an ordered `*`-ring, with the trivial `*`-structure. -/
-instance : star_ordered_ring ℝ :=
-{ star_mul_self_nonneg := λ r, mul_self_nonneg r, }
-
 @[irreducible] private noncomputable def inv' : ℝ → ℝ | ⟨a⟩ := ⟨a⁻¹⟩
 noncomputable instance : has_inv ℝ := ⟨inv'⟩
 lemma inv_cauchy {f} : (⟨f⟩ : ℝ)⁻¹ = ⟨f⁻¹⟩ := show inv' _ = _, by rw inv'

--- a/src/data/real/sqrt.lean
+++ b/src/data/real/sqrt.lean
@@ -307,6 +307,13 @@ theorem neg_sqrt_lt_of_sq_lt (h : x^2 < y) : -sqrt y < x := (sq_lt.mp h).1
 
 theorem lt_sqrt_of_sq_lt (h : x^2 < y) : x < sqrt y := (sq_lt.mp h).2
 
+instance : star_ordered_ring ℝ :=
+{ nonneg_iff := λ r, by
+  { refine ⟨λ hr, ⟨sqrt r, show r = sqrt r * sqrt r, by rw [←sqrt_mul hr, sqrt_mul_self hr]⟩, _⟩,
+    rintros ⟨s, rfl⟩,
+    exact mul_self_nonneg s },
+  ..real.ordered_add_comm_group }
+
 end real
 
 open real


### PR DESCRIPTION
This PR redefines `star_ordered_ring` to remove the `ordered_semiring` assumption, which includes undesirable axioms such as `∀ (a b c : α), a < b → 0 < c → c * a < c * b`. See the discussion on Zulip [here](https://leanprover.zulipchat.com/#narrow/stream/116395-maths/topic/Star.20ordered.20ring).

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
