### PR TITLE
[Merged by Bors] - feat(set_theory/ordinal_arithmetic): Proved `add_log_le_log_mul`

### DIFF
--- a/src/set_theory/ordinal_arithmetic.lean
+++ b/src/set_theory/ordinal_arithmetic.lean
@@ -1194,6 +1194,15 @@ if b1 : 1 < b then
   le_trans (le_power_self _ b1) (power_log_le b (ordinal.pos_iff_ne_zero.2 x0))
 else by simp only [log_not_one_lt b1, ordinal.zero_le]
 
+theorem add_log_le_log_mul {b u v : ordinal} (hu : 0 < u) (hv : 0 < v) :
+  log b u + log b v ≤ log b (u * v) :=
+begin
+  by_cases hb : 1 < b,
+  { rw [le_log hb (mul_pos hu hv), power_add],
+    exact mul_le_mul (power_log_le b hu) (power_log_le b hv) },
+  simp only [log_not_one_lt hb, zero_add]
+end
+
 /-! ### The Cantor normal form -/
 
 theorem CNF_aux {b o : ordinal} (b0 : b ≠ 0) (o0 : o ≠ 0) :

--- a/src/set_theory/ordinal_arithmetic.lean
+++ b/src/set_theory/ordinal_arithmetic.lean
@@ -1194,12 +1194,12 @@ if b1 : 1 < b then
   le_trans (le_power_self _ b1) (power_log_le b (ordinal.pos_iff_ne_zero.2 x0))
 else by simp only [log_not_one_lt b1, ordinal.zero_le]
 
-theorem add_log_le_log_mul {b u v : ordinal} (hu : 0 < u) (hv : 0 < v) :
-  log b u + log b v ≤ log b (u * v) :=
+theorem add_log_le_log_mul {x y : ordinal} (b : ordinal) (x0 : 0 < x) (y0 : 0 < y) :
+  log b x + log b y ≤ log b (x * y) :=
 begin
   by_cases hb : 1 < b,
-  { rw [le_log hb (mul_pos hu hv), power_add],
-    exact mul_le_mul (power_log_le b hu) (power_log_le b hv) },
+  { rw [le_log hb (mul_pos x0 y0), power_add],
+    exact mul_le_mul (power_log_le b x0) (power_log_le b y0) },
   simp only [log_not_one_lt hb, zero_add]
 end
 


### PR DESCRIPTION
That is, `log b u + log b v ≤ log b (u * v)`. The other direction holds only when `b ≠ 2` and `b` is principal multiplicative, and will be added at a much later PR.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
