### PR TITLE
[Merged by Bors] - chore(measure_theory/measurable_space): use implicit measurable_space argument

### DIFF
--- a/src/measure_theory/function/conditional_expectation.lean
+++ b/src/measure_theory/function/conditional_expectation.lean
@@ -217,7 +217,7 @@ variables (F)
 def Lp_meas_subgroup (m : measurable_space α) [measurable_space α] (p : ℝ≥0∞) (μ : measure α) :
   add_subgroup (Lp F p μ) :=
 { carrier   := {f : (Lp F p μ) | ae_measurable' m f μ} ,
-  zero_mem' := ⟨(0 : α → F), @measurable_zero _ α _ m _, Lp.coe_fn_zero _ _ _⟩,
+  zero_mem' := ⟨(0 : α → F), @measurable_zero _ α m _ _, Lp.coe_fn_zero _ _ _⟩,
   add_mem'  := λ f g hf hg, (hf.add hg).congr (Lp.coe_fn_add f g).symm,
   neg_mem' := λ f hf, ae_measurable'.congr hf.neg (Lp.coe_fn_neg f).symm, }
 
@@ -228,7 +228,7 @@ def Lp_meas [opens_measurable_space 𝕜] (m : measurable_space α) [measurable_
   (μ : measure α) :
   submodule 𝕜 (Lp F p μ) :=
 { carrier   := {f : (Lp F p μ) | ae_measurable' m f μ} ,
-  zero_mem' := ⟨(0 : α → F), @measurable_zero _ α _ m _, Lp.coe_fn_zero _ _ _⟩,
+  zero_mem' := ⟨(0 : α → F), @measurable_zero _ α m _ _, Lp.coe_fn_zero _ _ _⟩,
   add_mem'  := λ f g hf hg, (hf.add hg).congr (Lp.coe_fn_add f g).symm,
   smul_mem' := λ c f hf, (hf.const_smul c).congr (Lp.coe_fn_smul c f).symm, }
 variables {F 𝕜}
@@ -264,9 +264,7 @@ coe_fn_coe_base f
 lemma mem_Lp_meas_indicator_const_Lp {m m0 : measurable_space α} (hm : m ≤ m0)
   {μ : measure α} {s : set α} (hs : measurable_set[m] s) (hμs : μ s ≠ ∞) {c : F} :
   indicator_const_Lp p (hm s hs) hμs c ∈ Lp_meas F 𝕜 m p μ :=
-⟨s.indicator (λ x : α, c),
-  @measurable.indicator α _ m _ _ s (λ x, c) (@measurable_const _ α _ m _) hs,
-  indicator_const_Lp_coe_fn⟩
+⟨s.indicator (λ x : α, c), (@measurable_const _ α _ m _).indicator hs, indicator_const_Lp_coe_fn⟩
 
 section complete_subspace
 
@@ -1585,7 +1583,7 @@ begin
     exact ae_measurable'_condexp_L1_clm _, },
   { rw condexp_L1_undef hf,
     refine ae_measurable'.congr _ (coe_fn_zero _ _ _).symm,
-    exact measurable.ae_measurable' (@measurable_zero _ _ _ m _), },
+    exact measurable.ae_measurable' (@measurable_zero _ _ m _ _), },
 end
 
 lemma integrable_condexp_L1 (f : α → F') : integrable (condexp_L1 hm μ f) μ :=
@@ -1688,7 +1686,7 @@ begin
 end
 
 @[simp] lemma condexp_zero : μ[(0 : α → F')|m,hm] = 0 :=
-condexp_of_measurable (@measurable_zero _ _ _ m _) (integrable_zero _ _ _)
+condexp_of_measurable (@measurable_zero _ _ m _ _) (integrable_zero _ _ _)
 
 lemma measurable_condexp : measurable[m] (μ[f|m,hm]) :=
 begin

--- a/src/measure_theory/measurable_space.lean
+++ b/src/measure_theory/measurable_space.lean
@@ -271,7 +271,6 @@ begin
   exact (hf ht).inter h.measurable_set.of_compl,
 end
 
-omit m
 
 end measurable_functions
 
@@ -463,7 +462,6 @@ lemma measurable_of_measurable_on_compl_singleton [measurable_singleton_class α
   measurable f :=
 measurable_of_measurable_on_compl_finite {a} (finite_singleton a) hf
 
-omit m
 
 end subtype
 
@@ -572,8 +570,6 @@ begin
   rw this,
   exact measurable_set.Union (λ y, (hf y hs).prod (measurable_set_singleton y))
 end
-
-omit m
 
 end prod
 
@@ -864,8 +860,6 @@ begin
     by rwa [(right_inverse_range_splitting hg.injective).comp_eq_id] at this,
   exact hg.measurable_range_splitting.comp H.subtype_mk
 end
-
-omit mα
 
 end measurable_embedding
 

--- a/src/measure_theory/measurable_space.lean
+++ b/src/measure_theory/measurable_space.lean
@@ -804,7 +804,8 @@ structure measurable_embedding {α β : Type*} [measurable_space α] [measurable
 
 namespace measurable_embedding
 
-variables {mα : measurable_space α} [measurable_space β] [measurable_space γ] {f : α → β} {g : β → γ}
+variables {mα : measurable_space α} [measurable_space β] [measurable_space γ]
+  {f : α → β} {g : β → γ}
 
 include mα
 

--- a/src/measure_theory/measurable_space_def.lean
+++ b/src/measure_theory/measurable_space_def.lean
@@ -421,7 +421,8 @@ lemma measurable_id : measurable (@id α) := λ t, id
 
 lemma measurable_id' : measurable (λ a : α, a) := measurable_id
 
-lemma measurable.comp {g : β → γ} {f : α → β} (hg : measurable g) (hf : measurable f) :
+lemma measurable.comp {α β γ} {mα : measurable_space α} {mβ : measurable_space β}
+  {mγ : measurable_space γ} {g : β → γ} {f : α → β} (hg : measurable g) (hf : measurable f) :
   measurable (g ∘ f) :=
 λ t ht, hf (hg ht)
 

--- a/src/measure_theory/measurable_space_def.lean
+++ b/src/measure_theory/measurable_space_def.lean
@@ -217,8 +217,6 @@ by { by_cases p; simp [h, measurable_set.empty]; apply measurable_set.univ }
 lemma nonempty_measurable_superset (s : set α) : nonempty { t // s ⊆ t ∧ measurable_set t} :=
 ⟨⟨univ, subset_univ s, measurable_set.univ⟩⟩
 
-omit m
-
 end
 
 @[ext] lemma measurable_space.ext : ∀ {m₁ m₂ : measurable_space α},

--- a/src/measure_theory/measurable_space_def.lean
+++ b/src/measure_theory/measurable_space_def.lean
@@ -58,15 +58,18 @@ attribute [class] measurable_space
 instance [h : measurable_space α] : measurable_space (order_dual α) := h
 
 section
-variable [measurable_space α]
 
 /-- `measurable_set s` means that `s` is measurable (in the ambient measure space on `α`) -/
-def measurable_set : set α → Prop := ‹measurable_space α›.measurable_set'
+def measurable_set [measurable_space α] : set α → Prop := ‹measurable_space α›.measurable_set'
 
 localized "notation `measurable_set[` m `]` := @measurable_set _ m" in measure_theory
 
-@[simp] lemma measurable_set.empty : measurable_set (∅ : set α) :=
+@[simp] lemma measurable_set.empty [measurable_space α] : measurable_set (∅ : set α) :=
 ‹measurable_space α›.measurable_set_empty
+
+variable {m : measurable_space α}
+
+include m
 
 lemma measurable_set.compl : measurable_set s → measurable_set sᶜ :=
 ‹measurable_space α›.measurable_set_compl s
@@ -213,6 +216,8 @@ by { by_cases p; simp [h, measurable_set.empty]; apply measurable_set.univ }
 /-- Every set has a measurable superset. Declare this as local instance as needed. -/
 lemma nonempty_measurable_superset (s : set α) : nonempty { t // s ⊆ t ∧ measurable_set t} :=
 ⟨⟨univ, subset_univ s, measurable_set.univ⟩⟩
+
+omit m
 
 end
 

--- a/src/probability_theory/stopping.lean
+++ b/src/probability_theory/stopping.lean
@@ -85,7 +85,7 @@ def adapted (f : filtration ι m) (u : ι → α → β) : Prop :=
 namespace adapted
 
 lemma add [has_add β] [has_measurable_add₂ β] {u v : ι → α → β} {f : filtration ι m}
-  (hu : adapted f u) (hv : adapted f v) : adapted f (u + v):=
+  (hu : adapted f u) (hv : adapted f v) : adapted f (u + v) :=
 λ i, @measurable.add _ _ _ _ (f i) _ _ _ (hu i) (hv i)
 
 lemma neg [has_neg β] [has_measurable_neg β] {u : ι → α → β} {f : filtration ι m}
@@ -143,8 +143,7 @@ begin
   { convert (hτ 0),
     simp only [set.set_of_eq_eq_singleton, le_zero_iff] },
   { rw (_ : {x | τ x = i + 1} = {x | τ x ≤ i + 1} \ {x | τ x ≤ i}),
-    { exact @measurable_set.diff _ (f (i + 1)) _ _ (hτ (i + 1))
-        (f.mono (nat.le_succ _) _ (hτ i)) },
+    { exact (hτ (i + 1)).diff (f.mono (nat.le_succ _) _ (hτ i)) },
     { ext, simp only [set.mem_diff, not_le, set.mem_set_of_eq],
       split,
       { intro h, simp [h] },
@@ -164,8 +163,7 @@ begin
     { simp [h], },
     { simp only [h, ne.symm h, or_false, or_iff_left_iff_imp], }, },
   rw this,
-  refine @measurable_set.union _ (f.seq i) _ _ _ (hτ.measurable_set_eq i),
-  exact @measurable_set.diff _ (f.seq i) _ _ (@measurable_set.univ _ (f.seq i)) (hτ i),
+  exact (measurable_set.univ.diff (hτ i)).union (hτ.measurable_set_eq i),
 end
 
 lemma is_stopping_time.measurable_set_eq_le
@@ -179,7 +177,7 @@ lemma is_stopping_time_of_measurable_set_eq
 begin
   intro i,
   rw show {x | τ x ≤ i} = ⋃ k ≤ i, {x | τ x = k}, by { ext, simp },
-  refine @measurable_set.bUnion _ _ (f i) _ _ (set.countable_encodable _) (λ k hk, _),
+  refine measurable_set.bUnion (set.countable_encodable _) (λ k hk, _),
   exact f.mono hk _ (hτ k),
 end
 
@@ -197,7 +195,7 @@ lemma max [linear_order ι] {f : filtration ι m} {τ π : α → ι}
 begin
   intro i,
   simp_rw [max_le_iff, set.set_of_and],
-  exact @measurable_set.inter _ (f i) _ _ (hτ i) (hπ i),
+  exact (hτ i).inter (hπ i),
 end
 
 lemma min [linear_order ι] {f : filtration ι m} {τ π : α → ι}
@@ -206,7 +204,7 @@ lemma min [linear_order ι] {f : filtration ι m} {τ π : α → ι}
 begin
   intro i,
   simp_rw [min_le_iff, set.set_of_or],
-  exact @measurable_set.union _ (f i) _ _ (hτ i) (hπ i),
+  exact (hτ i).union (hπ i),
 end
 
 lemma add_const
@@ -233,9 +231,9 @@ protected def measurable_space
   measurable_set_compl := λ s hs i,
     begin
       rw (_ : sᶜ ∩ {x | τ x ≤ i} = (sᶜ ∪ {x | τ x ≤ i}ᶜ) ∩ {x | τ x ≤ i}),
-      { refine @measurable_set.inter _ (f i) _ _ _ _,
+      { refine measurable_set.inter _ _,
         { rw ← set.compl_inter,
-          exact @measurable_set.compl _ _ (f i) (hs i) },
+          exact (hs i).compl },
         { exact hτ i} },
       { rw set.union_inter_distrib_right,
         simp only [set.compl_inter_self, set.union_empty] }
@@ -244,7 +242,7 @@ protected def measurable_space
     begin
       rw forall_swap at hs,
       rw set.Union_inter,
-      exact @measurable_set.Union _ _ (f i) _ _ (hs i),
+      exact measurable_set.Union (hs i),
     end }
 
 @[protected]
@@ -259,7 +257,7 @@ lemma measurable_space_mono
 begin
   intros s hs i,
   rw (_ : s ∩ {x | π x ≤ i} = s ∩ {x | τ x ≤ i} ∩ {x | π x ≤ i}),
-  { exact @measurable_set.inter _ (f i) _ _ (hs i) (hπ i) },
+  { exact (hs i).inter (hπ i) },
   { ext,
     simp only [set.mem_inter_eq, iff_self_and, and.congr_left_iff, set.mem_set_of_eq],
     intros hle' _,
@@ -393,14 +391,13 @@ begin
   intro i,
   rw stopped_process_eq,
   refine @measurable.add _ _ _ _ (f i) _ _ _ _ _,
-  { refine @measurable.indicator _ _ (f i) _ _ _ _ (hu i) _,
-    convert @measurable_set.union _ (f i) _ _
-      (@measurable_set.compl _ _ (f i) (hτ i)) (hτ.measurable_set_eq i),
+  { refine (hu i).indicator _,
+    convert measurable_set.union (hτ i).compl (hτ.measurable_set_eq i),
     ext x,
     change i ≤ τ x ↔ ¬ τ x ≤ i ∨ τ x = i,
     rw [not_le, le_iff_lt_or_eq, eq_comm] },
   { refine @finset.measurable_sum' _ _ _ _ _ _ (f i) _ _ _,
-    refine λ j hij, @measurable.indicator _ _ (f i) _ _ _ _ _ _,
+    refine λ j hij, measurable.indicator _ _,
     { rw finset.mem_range at hij,
       exact measurable.le (f.mono hij.le) (hu j) },
     { rw finset.mem_range at hij,

--- a/src/probability_theory/stopping.lean
+++ b/src/probability_theory/stopping.lean
@@ -98,7 +98,7 @@ end adapted
 variable (β)
 
 lemma adapted_zero [has_zero β] (f : filtration ι m) : adapted f (0 : ι → α → β) :=
-λ i, @measurable_zero β α _ (f i) _
+λ i, @measurable_zero β α (f i) _ _
 
 variable {β}
 


### PR DESCRIPTION
The `measurable_space` argument is inferred from other arguments (like `measurable f` or a measure for example) instead of being a type class. This ensures that the lemmas are usable without `@` when several measurable space structures are used for the same type.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
