### PR TITLE
[Merged by Bors] - refactor(data/{sigma,psigma}/order): Use `lex` synonym and new notation

### DIFF
--- a/src/data/psigma/order.lean
+++ b/src/data/psigma/order.lean
@@ -4,39 +4,50 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Scott Morrison, Minchao Wu
 -/
 import data.sigma.lex
-import order.basic
+import order.lexicographic
 
 /-!
 # Lexicographic order on a sigma type
 
-This file defines the lexicographic order on `Σ' i, α i` as the default order.
+This file defines the lexicographic order on `Σₗ' i, α i`. `a` is less than `b` if its summand is
+strictly less than the summand of `b` or they are in the same summand and `a` is less than `b`
+there.
 
-We mark these as instances because the 'pointwise' partial order `prod.has_le` doesn't make sense
-for dependent pairs. However in the future we will want to make the disjoint order the default
-instead, where `x ≤ y` only if `x.fst = y.fst`.
+## Notation
+
+* `Σₗ' i, α i`: Sigma type equipped with the lexicographic order. A type synonym of `Σ' i, α i`.
 
 ## See also
 
 Related files are:
 * `data.finset.colex`: Colexicographic order on finite sets.
 * `data.list.lex`: Lexicographic order on lists.
-* `data.sigma.order`: Lexicographic order on `Σ i, α i`. Basically a twin of this file.
+* `data.sigma.order`: Lexicographic order on `Σₗ i, α i`. Basically a twin of this file.
 * `order.lexicographic`: Lexicographic order on `α × β`.
+
+## TODO
+
+Define the disjoint order on `Σ' i, α i`, where `x ≤ y` only if `x.fst = y.fst`.
+
+Prove that a sigma type is a `no_top_order`, `no_bot_order`, `densely_ordered` when its summands
+are.
 -/
 
 variables {ι : Type*} {α : ι → Type*}
 
 namespace psigma
 
+notation `Σₗ'` binders `, ` r:(scoped p, _root_.lex (psigma p)) := r
+
 /-- The lexicographical `≤` on a sigma type. -/
-instance lex.has_le [has_lt ι] [Π i, has_le (α i)] : has_le (Σ' i, α i) :=
+instance lex.has_le [has_lt ι] [Π i, has_le (α i)] : has_le (Σₗ' i, α i) :=
 { le := lex (<) (λ i, (≤)) }
 
 /-- The lexicographical `<` on a sigma type. -/
-instance lex.has_lt [has_lt ι] [Π i, has_lt (α i)] : has_lt (Σ' i, α i) :=
+instance lex.has_lt [has_lt ι] [Π i, has_lt (α i)] : has_lt (Σₗ' i, α i) :=
 { lt := lex (<) (λ i, (<)) }
 
-instance lex.preorder [preorder ι] [Π i, preorder (α i)] : preorder (Σ' i, α i) :=
+instance lex.preorder [preorder ι] [Π i, preorder (α i)] : preorder (Σₗ' i, α i) :=
 { le_refl := λ ⟨i, a⟩, lex.right _ le_rfl,
   le_trans :=
   begin
@@ -64,7 +75,7 @@ instance lex.preorder [preorder ι] [Π i, preorder (α i)] : preorder (Σ' i, �
 
 /-- Dictionary / lexicographic partial_order for dependent pairs. -/
 instance lex.partial_order [partial_order ι] [Π i, partial_order (α i)] :
-  partial_order (Σ' i, α i) :=
+  partial_order (Σₗ' i, α i) :=
 { le_antisymm :=
   begin
     rintro ⟨a₁, b₁⟩ ⟨a₂, b₂⟩
@@ -77,7 +88,7 @@ instance lex.partial_order [partial_order ι] [Π i, partial_order (α i)] :
   .. lex.preorder }
 
 /-- Dictionary / lexicographic linear_order for pairs. -/
-instance lex.linear_order [linear_order ι] [Π i, linear_order (α i)] : linear_order (Σ' i, α i) :=
+instance lex.linear_order [linear_order ι] [Π i, linear_order (α i)] : linear_order (Σₗ' i, α i) :=
 { le_total :=
   begin
   rintro ⟨i, a⟩ ⟨j, b⟩,

--- a/src/data/sigma/order.lean
+++ b/src/data/sigma/order.lean
@@ -5,6 +5,7 @@ Authors: Yaël Dillies
 -/
 import data.sigma.lex
 import order.bounded_order
+import order.lexicographic
 
 /-!
 # Orders on a sigma type
@@ -15,10 +16,28 @@ This file defines two orders on a sigma type:
 * The lexicographical order. `a` is less than `b` if its summand is strictly less than the summand
   of `b` or they are in the same summand and `a` is less than `b` there.
 
-## Implementation notes
+We make the disjoint sum of orders the default set of instances. The lexicographic order goes on a
+type synonym.
 
-We declare the disjoint sum of orders as the default instances. The lexicographical order can
-override it in local by opening locale `lex`.
+## Notation
+
+* `Σₗ i, α i`: Sigma type equipped with the lexicographic order. Type synonym of `Σ i, α i`.
+
+## See also
+
+Related files are:
+* `data.finset.colex`: Colexicographic order on finite sets.
+* `data.list.lex`: Lexicographic order on lists.
+* `data.psigma.order`: Lexicographic order on `Σₗ' i, α i`. Basically a twin of this file.
+* `order.lexicographic`: Lexicographic order on `α × β`.
+
+## TODO
+
+Prove that a sigma type is a `no_top_order`, `no_bot_order`, `densely_ordered` when its summands
+are.
+
+Upgrade `equiv.sigma_congr_left`, `equiv.sigma_congr`, `equiv.sigma_assoc`,
+`equiv.sigma_prod_of_equiv`, `equiv.sigma_equiv_prod`, ... to order isomorphisms.
 -/
 
 namespace sigma
@@ -51,23 +70,18 @@ instance [Π i, partial_order (α i)] : partial_order (Σ i, α i) :=
 
 namespace lex
 
-localized "attribute [-instance] sigma.has_le" in lex
-localized "attribute [-instance] sigma.preorder" in lex
-localized "attribute [-instance] sigma.partial_order" in lex
+notation `Σₗ` binders `, ` r:(scoped p, _root_.lex (sigma p)) := r
 
-/-- The lexicographical `≤` on a sigma type. Turn this on by opening locale `lex`. -/
-protected def has_le [has_lt ι] [Π i, has_le (α i)] : has_le (Σ i, α i) := ⟨lex (<) (λ i, (≤))⟩
+/-- The lexicographical `≤` on a sigma type. -/
+instance has_le [has_lt ι] [Π i, has_le (α i)] : has_le (Σₗ i, α i) := ⟨lex (<) (λ i, (≤))⟩
 
-/-- The lexicographical `<` on a sigma type. Turn this on by opening locale `lex`. -/
-protected def has_lt [has_lt ι] [Π i, has_lt (α i)] : has_lt (Σ i, α i) := ⟨lex (<) (λ i, (<))⟩
+/-- The lexicographical `<` on a sigma type. -/
+instance has_lt [has_lt ι] [Π i, has_lt (α i)] : has_lt (Σₗ i, α i) := ⟨lex (<) (λ i, (<))⟩
 
-localized "attribute [instance] sigma.lex.has_le" in lex
-localized "attribute [instance] sigma.lex.has_lt" in lex
-
-/-- The lexicographical preorder on a sigma type. Turn this on by opening locale `lex`. -/
-protected def preorder [preorder ι] [Π i, preorder (α i)] : preorder (Σ i, α i) :=
+/-- The lexicographical preorder on a sigma type. -/
+instance preorder [preorder ι] [Π i, preorder (α i)] : preorder (Σₗ i, α i) :=
 { le_refl := λ ⟨i, a⟩, lex.right a a le_rfl,
-  le_trans := λ _ _ _, trans,
+  le_trans := λ _ _ _, trans_of (lex (<) $ λ _, (≤)),
   lt_iff_le_not_le := begin
     refine λ a b, ⟨λ hab, ⟨hab.mono_right (λ i a b, le_of_lt), _⟩, _⟩,
     { rintro (⟨j, i, b, a, hji⟩ | ⟨i, b, a, hba⟩);
@@ -83,29 +97,23 @@ protected def preorder [preorder ι] [Π i, preorder (α i)] : preorder (Σ i, �
   .. lex.has_le,
   .. lex.has_lt }
 
-localized "attribute [instance] sigma.lex.preorder" in lex
-
-/-- The lexicographical partial order on a sigma type. Turn this on by opening locale `lex`. -/
-protected def partial_order [preorder ι] [Π i, partial_order (α i)] :
-  partial_order (Σ i, α i) :=
-{ le_antisymm := λ _ _, antisymm,
+/-- The lexicographical partial order on a sigma type. -/
+instance partial_order [preorder ι] [Π i, partial_order (α i)] :
+  partial_order (Σₗ i, α i) :=
+{ le_antisymm := λ _ _, antisymm_of (lex (<) $ λ _, (≤)),
   .. lex.preorder }
 
-localized "attribute [instance] sigma.lex.partial_order" in lex
-
-/-- The lexicographical linear order on a sigma type. Turn this on by opening locale `lex`. -/
-protected def linear_order [linear_order ι] [Π i, linear_order (α i)] :
-  linear_order (Σ i, α i) :=
-{ le_total := total_of _,
+/-- The lexicographical linear order on a sigma type. -/
+instance linear_order [linear_order ι] [Π i, linear_order (α i)] :
+  linear_order (Σₗ i, α i) :=
+{ le_total := total_of (lex (<) $ λ _, (≤)),
   decidable_eq := sigma.decidable_eq,
   decidable_le := lex.decidable _ _,
   .. lex.partial_order }
 
-localized "attribute [instance] sigma.lex.linear_order" in lex
-
-/-- The lexicographical linear order on a sigma type. Turn this on by opening locale `lex`. -/
-protected def order_bot [partial_order ι] [order_bot ι] [Π i, preorder (α i)] [order_bot (α ⊥)] :
-  order_bot (Σ i, α i) :=
+/-- The lexicographical linear order on a sigma type. -/
+instance order_bot [partial_order ι] [order_bot ι] [Π i, preorder (α i)] [order_bot (α ⊥)] :
+  order_bot (Σₗ i, α i) :=
 { bot := ⟨⊥, ⊥⟩,
   bot_le := λ ⟨a, b⟩, begin
     obtain rfl | ha := eq_bot_or_bot_lt a,
@@ -113,11 +121,9 @@ protected def order_bot [partial_order ι] [order_bot ι] [Π i, preorder (α i)
     { exact lex.left _ _ ha }
   end }
 
-localized "attribute [instance] sigma.lex.order_bot" in lex
-
-/-- The lexicographical linear order on a sigma type. Turn this on by opening locale `lex`. -/
-protected def order_top [partial_order ι] [order_top ι] [Π i, preorder (α i)] [order_top (α ⊤)] :
-  order_top (Σ i, α i) :=
+/-- The lexicographical linear order on a sigma type. -/
+instance order_top [partial_order ι] [order_top ι] [Π i, preorder (α i)] [order_top (α ⊤)] :
+  order_top (Σₗ i, α i) :=
 { top := ⟨⊤, ⊤⟩,
   le_top := λ ⟨a, b⟩, begin
     obtain rfl | ha := eq_top_or_lt_top a,
@@ -125,15 +131,11 @@ protected def order_top [partial_order ι] [order_top ι] [Π i, preorder (α i)
     { exact lex.left _ _ ha }
   end }
 
-localized "attribute [instance] sigma.lex.order_top" in lex
-
-/-- The lexicographical linear order on a sigma type. Turn this on by opening locale `lex`. -/
-protected def bounded_order [partial_order ι] [bounded_order ι] [Π i, preorder (α i)]
+/-- The lexicographical linear order on a sigma type. -/
+instance bounded_order [partial_order ι] [bounded_order ι] [Π i, preorder (α i)]
   [order_bot (α ⊥)] [order_top (α ⊤)] :
-  bounded_order (Σ i, α i) :=
+  bounded_order (Σₗ i, α i) :=
 { .. lex.order_bot, .. lex.order_top }
-
-localized "attribute [instance] sigma.lex.bounded_order" in lex
 
 end lex
 end sigma

--- a/src/order/rel_classes.lean
+++ b/src/order/rel_classes.lean
@@ -19,6 +19,9 @@ universes u v
 
 variables {α : Type u} {β : Type v} {r : α → α → Prop} {s : β → β → Prop}
 
+@[elab_simple]
+lemma antisymm_of (r : α → α → Prop) [is_antisymm α r] {a b : α} : r a b → r b a → a = b := antisymm
+
 open function
 
 theorem is_refl.swap (r) [is_refl α r] : is_refl α (swap r) := ⟨refl_of r⟩

--- a/src/order/rel_classes.lean
+++ b/src/order/rel_classes.lean
@@ -19,10 +19,11 @@ universes u v
 
 variables {α : Type u} {β : Type v} {r : α → α → Prop} {s : β → β → Prop}
 
+open function
+
+/-- A version of `antisymm` with `r` explicit. -/
 @[elab_simple]
 lemma antisymm_of (r : α → α → Prop) [is_antisymm α r] {a b : α} : r a b → r b a → a = b := antisymm
-
-open function
 
 theorem is_refl.swap (r) [is_refl α r] : is_refl α (swap r) := ⟨refl_of r⟩
 theorem is_irrefl.swap (r) [is_irrefl α r] : is_irrefl α (swap r) := ⟨irrefl_of r⟩

--- a/src/order/rel_classes.lean
+++ b/src/order/rel_classes.lean
@@ -21,7 +21,9 @@ variables {α : Type u} {β : Type v} {r : α → α → Prop} {s : β → β �
 
 open function
 
-/-- A version of `antisymm` with `r` explicit. -/
+/-- A version of `antisymm` with `r` explicit.
+
+This lemma matches the lemmas from lean core in `init.algebra.classes`, but is missing there.  -/
 @[elab_simple]
 lemma antisymm_of (r : α → α → Prop) [is_antisymm α r] {a b : α} : r a b → r b a → a = b := antisymm
 


### PR DESCRIPTION
This introduces notations `Σₗ i, α i` and `Σₗ' i, α i` for `lex (Σ i, α i)` and `lex (Σ' i, α i)` and use them instead of the instance switch with locale `lex`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
