### PR TITLE
[Merged by Bors] - chore(.github): include co-author attributions in PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -13,6 +13,11 @@ If this PR depends on other PRs, please list them below this comment,
 using the following format:
 - [ ] depends on: #abc [optional extra text]
 - [ ] depends on: #xyz [optional extra text]
+
+To indicate co-authors, include lines at the bottom of the commit message 
+using the format:
+
+Co-authored-by: Author Name <author@email.com>
 -->
 
 [![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -15,7 +15,7 @@ using the following format:
 - [ ] depends on: #xyz [optional extra text]
 
 To indicate co-authors, include lines at the bottom of the commit message 
-using the format:
+(that is, before the `---`) using the format:
 
 Co-authored-by: Author Name <author@email.com>
 -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,6 +5,11 @@
 PR is merged. Please leave a blank newline before the `---`, otherwise
 GitHub will format the text above it as a title.
 
+To indicate co-authors, include lines at the bottom of the commit message 
+(that is, before the `---`) using the following format:
+
+Co-authored-by: Author Name <author@email.com>
+
 Any other comments you want to keep out of the PR commit should go
 below the `---`, and placed outside this HTML comment, or else they
 will be invisible to reviewers.
@@ -13,11 +18,6 @@ If this PR depends on other PRs, please list them below this comment,
 using the following format:
 - [ ] depends on: #abc [optional extra text]
 - [ ] depends on: #xyz [optional extra text]
-
-To indicate co-authors, include lines at the bottom of the commit message 
-(that is, before the `---`) using the format:
-
-Co-authored-by: Author Name <author@email.com>
 -->
 
 [![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

I often forget the exact syntax for this and it's wrong in various ways in our commit history. Not a big deal, but doesn't hurt to mention it here.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
