### PR TITLE
[Merged by Bors] - fix(algebra/group/type_tags): resolve an instance diamond caused by over-eager unfolding

### DIFF
--- a/src/algebra/group/type_tags.lean
+++ b/src/algebra/group/type_tags.lean
@@ -174,22 +174,22 @@ instance [h : add_monoid α] : monoid (multiplicative α) :=
   ..multiplicative.semigroup }
 
 instance [left_cancel_monoid α] : add_left_cancel_monoid (additive α) :=
-{ .. additive.add_monoid, .. additive.add_left_cancel_semigroup }
+{ zero := 0, add := (+), .. additive.add_monoid, .. additive.add_left_cancel_semigroup }
 
 instance [add_left_cancel_monoid α] : left_cancel_monoid (multiplicative α) :=
-{ .. multiplicative.monoid, .. multiplicative.left_cancel_semigroup }
+{ one := 1, mul := (*), .. multiplicative.monoid, .. multiplicative.left_cancel_semigroup }
 
 instance [right_cancel_monoid α] : add_right_cancel_monoid (additive α) :=
-{ .. additive.add_monoid, .. additive.add_right_cancel_semigroup }
+{ zero := 0, add := (+), .. additive.add_monoid, .. additive.add_right_cancel_semigroup }
 
 instance [add_right_cancel_monoid α] : right_cancel_monoid (multiplicative α) :=
-{ .. multiplicative.monoid, .. multiplicative.right_cancel_semigroup }
+{ one := 1, mul := (*), .. multiplicative.monoid, .. multiplicative.right_cancel_semigroup }
 
 instance [comm_monoid α] : add_comm_monoid (additive α) :=
-{ .. additive.add_monoid, .. additive.add_comm_semigroup }
+{ zero := 0, add := (+), .. additive.add_monoid, .. additive.add_comm_semigroup }
 
 instance [add_comm_monoid α] : comm_monoid (multiplicative α) :=
-{ ..multiplicative.monoid, .. multiplicative.comm_semigroup }
+{ one := 1, mul := (*), ..multiplicative.monoid, .. multiplicative.comm_semigroup }
 
 instance [has_inv α] : has_neg (additive α) := ⟨λ x, multiplicative.of_add x.to_mul⁻¹⟩
 

--- a/test/instance_diamonds.lean
+++ b/test/instance_diamonds.lean
@@ -74,3 +74,23 @@ example (R : Type*) [h : ordered_semiring R] :
 rfl
 
 end with_top
+
+/-! ## `multiplicative` instances -/
+section multiplicative
+
+-- `dunfold` should ideally not break or fix definitional equality
+
+example :
+  @monoid.to_mul_one_class (multiplicative ℕ) (comm_monoid.to_monoid _) =
+    multiplicative.mul_one_class :=
+rfl
+
+example :
+  @monoid.to_mul_one_class (multiplicative ℕ) (comm_monoid.to_monoid _) =
+    multiplicative.mul_one_class :=
+begin
+  dunfold has_one.one multiplicative.mul_one_class,
+  refl,
+end
+
+end multiplicative

--- a/test/instance_diamonds.lean
+++ b/test/instance_diamonds.lean
@@ -78,19 +78,20 @@ end with_top
 /-! ## `multiplicative` instances -/
 section multiplicative
 
--- `dunfold` should ideally not break or fix definitional equality
-
 example :
   @monoid.to_mul_one_class (multiplicative ℕ) (comm_monoid.to_monoid _) =
     multiplicative.mul_one_class :=
 rfl
 
+-- `dunfold` can still cbreak unification, but it's better to have `dunfold` break it than have the
+-- above example fail.
 example :
   @monoid.to_mul_one_class (multiplicative ℕ) (comm_monoid.to_monoid _) =
     multiplicative.mul_one_class :=
 begin
   dunfold has_one.one multiplicative.mul_one_class,
-  refl,
+  success_if_fail { refl, },
+  sorry
 end
 
 end multiplicative

--- a/test/instance_diamonds.lean
+++ b/test/instance_diamonds.lean
@@ -83,7 +83,7 @@ example :
     multiplicative.mul_one_class :=
 rfl
 
--- `dunfold` can still cbreak unification, but it's better to have `dunfold` break it than have the
+-- `dunfold` can still break unification, but it's better to have `dunfold` break it than have the
 -- above example fail.
 example :
   @monoid.to_mul_one_class (multiplicative ℕ) (comm_monoid.to_monoid _) =
@@ -91,7 +91,8 @@ example :
 begin
   dunfold has_one.one multiplicative.mul_one_class,
   success_if_fail { refl, },
-  sorry
+  ext,
+  refl
 end
 
 end multiplicative


### PR DESCRIPTION
By setting the `one` and `zero` fields manually, we ensure that they are syntactically equal to the ones found via `has_one` and `has_zero`, rather than potentially having typeclass arguments resolved in a different way.
This seems to fix the failing test.

[Zulip thread](https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/Diamond.20in.20multiplicative.20nat/near/266824443)



---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
