### PR TITLE
[Merged by Bors] - feat(data/{fin/vec_notation, matrix/notation}): `cons_{add,sub,dot_product}_cons`

### DIFF
--- a/src/data/fin/vec_notation.lean
+++ b/src/data/fin/vec_notation.lean
@@ -300,6 +300,10 @@ by { ext i, refine fin.cases _ _ i; simp [vec_head, vec_tail] }
   v + vec_cons y w = vec_cons (vec_head v + y) (vec_tail v + w) :=
 by { ext i, refine fin.cases _ _ i; simp [vec_head, vec_tail] }
 
+@[simp] lemma cons_add_cons (x : α) (v : fin n → α) (y : α) (w : fin n → α) :
+  vec_cons x v + vec_cons y w = vec_cons (x + y) (v + w) :=
+by simp
+
 @[simp] lemma head_add (a b : fin n.succ → α) : vec_head (a + b) = vec_head a + vec_head b := rfl
 
 @[simp] lemma tail_add (a b : fin n.succ → α) : vec_tail (a + b) = vec_tail a + vec_tail b := rfl
@@ -319,6 +323,10 @@ by { ext i, refine fin.cases _ _ i; simp [vec_head, vec_tail] }
 @[simp] lemma sub_cons (v : fin n.succ → α) (y : α) (w : fin n → α) :
   v - vec_cons y w = vec_cons (vec_head v - y) (vec_tail v - w) :=
 by { ext i, refine fin.cases _ _ i; simp [vec_head, vec_tail] }
+
+@[simp] lemma cons_sub_cons (x : α) (v : fin n → α) (y : α) (w : fin n → α) :
+  vec_cons x v - vec_cons y w = vec_cons (x - y) (v - w) :=
+by simp
 
 @[simp] lemma head_sub (a b : fin n.succ → α) : vec_head (a - b) = vec_head a - vec_head b := rfl
 

--- a/src/data/matrix/notation.lean
+++ b/src/data/matrix/notation.lean
@@ -71,6 +71,10 @@ by simp [dot_product, fin.sum_univ_succ, vec_head, vec_tail]
   dot_product v (vec_cons x w) = vec_head v * x + dot_product (vec_tail v) w :=
 by simp [dot_product, fin.sum_univ_succ, vec_head, vec_tail]
 
+@[simp] lemma cons_dot_product_cons (x : α) (v : fin n → α) (y : α) (w : fin n → α) :
+  dot_product (vec_cons x v) (vec_cons y w) = x * y + dot_product v w :=
+by simp
+
 end dot_product
 
 section col_row


### PR DESCRIPTION
While these can be proved by `simp`, they are not rejected by the simp linter.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

(at least, when I ran #lint locally!)

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
