### PR TITLE
[Merged by Bors] - chore(ring_theory/localization): fix typo in module docstring

### DIFF
--- a/src/ring_theory/localization.lean
+++ b/src/ring_theory/localization.lean
@@ -63,7 +63,7 @@ variables [algebra R S] [algebra P Q] (M : submonoid R) (T : submonoid P)
    complement of a prime ideal is a local ring
  * `is_fraction_ring.field`: a definition (not an instance) stating the localization of an integral
    domain `R` at `R \ {0}` is a field
- * `rat.is_fraction_ring_int` is an instance stating `ℚ` is the field of fractions of `ℤ`
+ * `rat.is_fraction_ring` is an instance stating `ℚ` is the field of fractions of `ℤ`
 
 ## Implementation notes
 
@@ -814,7 +814,7 @@ end away
 
 section inv_submonoid
 
-variables (M S) 
+variables (M S)
 
 /-- The submonoid of `S = M⁻¹R` consisting of `{ 1 / x | x ∈ M }`. -/
 def inv_submonoid : submonoid S := (M.map (algebra_map R S : R →* S)).left_inv


### PR DESCRIPTION
There was a mismatch in the module docstring to the decl name later.



---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
