### PR TITLE
refactor(algebra/homology/homotopy): a more convenient structure homotopy

### DIFF
--- a/src/algebra/homology/homotopy.lean
+++ b/src/algebra/homology/homotopy.lean
@@ -25,14 +25,23 @@ variables {V : Type u} [category.{v} V] [preadditive V]
 variables {c : complex_shape ι} {C D E : homological_complex V c}
 variables (f g : C ⟶ D) (h k : D ⟶ E) (i : ι)
 
-section
+section 
 
-/-- The composition of `C.d i i' ≫ f i' i` if there is some `i'` coming after `i`,
+/-- The subset of ι × ι consisting of those (i,j) such that c.rel j i) -/
+def homotopy.set_of_cs (c : complex_shape ι) : set (ι × ι) := λ (x : ι × ι), c.rel x.2 x.1
+
+/-- A prehomotopy C D consists of morphisms C.X i ⟶ C.X j when c.rel j i -/
+abbreviation prehomotopy (C D : homological_complex V c) :=
+Π (ij : homotopy.set_of_cs c), C.X ij.val.1 ⟶ D.X ij.val.2
+
+namespace homotopy
+
+/-- The composition of `C.d i i' ≫ f ⟨⟨i',i⟩,_⟩` if there is some `i'` coming after `i`,
 and `0` otherwise. -/
-def d_next (i : ι) : (Π i j, C.X i ⟶ D.X j) →+ (C.X i ⟶ D.X i) :=
+def d_next (i : ι) : prehomotopy C D →+ (C.X i ⟶ D.X i) :=
 add_monoid_hom.mk' (λ f, match c.next i with
 | none := 0
-| some ⟨i',w⟩ := C.d i i' ≫ f i' i
+| some ⟨i',w⟩ := C.d i i' ≫ f ⟨⟨i',i⟩,w⟩
 end)
 begin
   intros f g,
@@ -41,13 +50,13 @@ begin
   exact preadditive.comp_add _ _ _ _ _ _,
 end
 
-/-- `f i' i` if `i'` comes after `i`, and 0 if there's no such `i'`.
+/-- `f ⟨⟨i',i⟩,_⟩` if `i'` comes after `i`, and 0 if there's no such `i'`.
 Hopefully there won't be much need for this, except in `d_next_eq_d_from_from_next`
 to see that `d_next` factors through `C.d_from i`. -/
-def from_next [has_zero_object V] (i : ι) : (Π i j, C.X i ⟶ D.X j) →+ (C.X_next i ⟶ D.X i) :=
+def from_next [has_zero_object V] (i : ι) : prehomotopy C D →+ (C.X_next i ⟶ D.X i) :=
 add_monoid_hom.mk' (λ f, match c.next i with
 | none := 0
-| some ⟨i',w⟩ := (C.X_next_iso w).hom ≫ f i' i
+| some ⟨i',w⟩ := (C.X_next_iso w).hom ≫ f ⟨⟨i',i⟩,w⟩
 end)
 begin
   intros f g,
@@ -56,7 +65,7 @@ begin
   exact preadditive.comp_add _ _ _ _ _ _,
 end
 
-lemma d_next_eq_d_from_from_next [has_zero_object V] (f : Π i j, C.X i ⟶ D.X j) (i : ι) :
+lemma d_next_eq_d_from_from_next [has_zero_object V] (f : prehomotopy C D) (i : ι) :
   d_next i f = C.d_from i ≫ from_next i f :=
 begin
   dsimp [d_next, from_next],
@@ -64,16 +73,16 @@ begin
   { dsimp [d_next, from_next], simp },
 end
 
-lemma d_next_eq (f : Π i j, C.X i ⟶ D.X j) {i i' : ι} (w : c.rel i i') :
-  d_next i f = C.d i i' ≫ f i' i :=
+lemma d_next_eq (f : prehomotopy C D) {i i' : ι} (w : c.rel i i') :
+  d_next i f = C.d i i' ≫ f ⟨⟨i',i⟩,w⟩ :=
 begin
   dsimp [d_next],
   rw c.next_eq_some w,
   refl,
 end
 
-@[simp] lemma d_next_comp_left (f : C ⟶ D) (g : Π i j, D.X i ⟶ E.X j) (i : ι) :
-  d_next i (λ i j, f.f i ≫ g i j) = f.f i ≫ d_next i g :=
+@[simp] lemma d_next_comp_left (f : C ⟶ D) (g : prehomotopy D E) (i : ι) :
+  d_next i (λ ij, f.f ij.val.1 ≫ g ij) = f.f i ≫ d_next i g :=
 begin
   dsimp [d_next],
   rcases c.next i with _|⟨i',w⟩,
@@ -82,8 +91,8 @@ begin
     simp, },
 end
 
-@[simp] lemma d_next_comp_right (f : Π i j, C.X i ⟶ D.X j) (g : D ⟶ E) (i : ι) :
-  d_next i (λ i j, f i j ≫ g.f j) = d_next i f ≫ g.f i :=
+@[simp] lemma d_next_comp_right (f : prehomotopy C D) (g : D ⟶ E) (i : ι) :
+  d_next i (λ ij, f ij ≫ g.f ij.val.2) = d_next i f ≫ g.f i :=
 begin
   dsimp [d_next],
   rcases c.next i with _|⟨i',w⟩,
@@ -92,12 +101,12 @@ begin
     simp, },
 end
 
-/-- The composition of `f j j' ≫ D.d j' j` if there is some `j'` coming before `j`,
+/-- The composition of `f ⟨⟨j,j'⟩,_⟩ ≫ D.d j' j` if there is some `j'` coming before `j`,
 and `0` otherwise. -/
-def prev_d (j : ι) : (Π i j, C.X i ⟶ D.X j) →+ (C.X j ⟶ D.X j) :=
+def prev_d (j : ι) : prehomotopy C D →+ (C.X j ⟶ D.X j) :=
 add_monoid_hom.mk' (λ f, match c.prev j with
 | none := 0
-| some ⟨j',w⟩ := f j j' ≫ D.d j' j
+| some ⟨j',w⟩ := f ⟨⟨j,j'⟩,w⟩ ≫ D.d j' j
 end)
 begin
   intros f g,
@@ -106,13 +115,13 @@ begin
   exact preadditive.add_comp _ _ _ _ _ _,
 end
 
-/-- `f j j'` if `j'` comes after `j`, and 0 if there's no such `j'`.
+/-- `f ⟨⟨j,j⟩,_⟩'` if `j'` comes after `j`, and 0 if there's no such `j'`.
 Hopefully there won't be much need for this, except in `d_next_eq_d_from_from_next`
 to see that `d_next` factors through `C.d_from i`. -/
-def to_prev [has_zero_object V] (j : ι) : (Π i j, C.X i ⟶ D.X j) →+ (C.X j ⟶ D.X_prev j) :=
+def to_prev [has_zero_object V] (j : ι) : prehomotopy C D →+ (C.X j ⟶ D.X_prev j) :=
 add_monoid_hom.mk' (λ f, match c.prev j with
 | none := 0
-| some ⟨j',w⟩ := f j j' ≫ (D.X_prev_iso w).inv
+| some ⟨j',w⟩ := f ⟨⟨j,j'⟩,w⟩ ≫ (D.X_prev_iso w).inv
 end)
 begin
   intros f g,
@@ -121,7 +130,7 @@ begin
   exact preadditive.add_comp _ _ _ _ _ _,
 end
 
-lemma prev_d_eq_to_prev_d_to [has_zero_object V] (f : Π i j, C.X i ⟶ D.X j) (j : ι) :
+lemma prev_d_eq_to_prev_d_to [has_zero_object V] (f : prehomotopy C D) (j : ι) :
   prev_d j f = to_prev j f ≫ D.d_to j :=
 begin
   dsimp [prev_d, to_prev],
@@ -129,16 +138,16 @@ begin
   { dsimp [prev_d, to_prev], simp },
 end
 
-lemma prev_d_eq (f : Π i j, C.X i ⟶ D.X j) {j j' : ι} (w : c.rel j' j) :
-  prev_d j f = f j j' ≫ D.d j' j :=
+lemma prev_d_eq (f : prehomotopy C D) {j j' : ι} (w : c.rel j' j) :
+  prev_d j f = f ⟨⟨j,j'⟩,w⟩ ≫ D.d j' j :=
 begin
   dsimp [prev_d],
   rw c.prev_eq_some w,
   refl,
 end
 
-@[simp] lemma prev_d_comp_left (f : C ⟶ D) (g : Π i j, D.X i ⟶ E.X j) (j : ι) :
-  prev_d j (λ i j, f.f i ≫ g i j) = f.f j ≫ prev_d j g :=
+@[simp] lemma prev_d_comp_left (f : C ⟶ D) (g : prehomotopy D E) (j : ι) :
+  prev_d j (λ ij, f.f ij.val.1 ≫ g ij) = f.f j ≫ prev_d j g :=
 begin
   dsimp [prev_d],
   rcases c.prev j with _|⟨j',w⟩,
@@ -147,8 +156,8 @@ begin
     simp, },
 end
 
-@[simp] lemma to_prev'_comp_right (f : Π i j, C.X i ⟶ D.X j) (g : D ⟶ E) (j : ι) :
-  prev_d j (λ i j, f i j ≫ g.f j) = prev_d j f ≫ g.f j :=
+@[simp] lemma to_prev'_comp_right (f : prehomotopy C D) (g : D ⟶ E) (j : ι) :
+  prev_d j (λ ij, f ij ≫ g.f ij.val.2) = prev_d j f ≫ g.f j :=
 begin
   dsimp [prev_d],
   rcases c.prev j with _|⟨j',w⟩,
@@ -157,66 +166,174 @@ begin
     simp, },
 end
 
-lemma d_next_nat (C D : chain_complex V ℕ) (i : ℕ) (f : Π i j, C.X i ⟶ D.X j) :
-  d_next i f = C.d i (i-1) ≫ f (i-1) i :=
+/-!
+Null homotopic maps can be constructed using the formula `hd+dh`. We provide some
+convenient simplification lemmas that give a degreewise description of `hd+dh`,
+depending on whether we have two differentials going to and from a certain degree,
+only one, or none.
+-/
+
+/-- The null homotopic map associated to a family `hom` of morphisms `C_i ⟶ D_j`
+when `c.rel j i`. This is the same datum as for the field `hom` in the structure
+`homotopy`. -/
+def null_homotopic_map (hom : prehomotopy C D) : C ⟶ D :=
+{ f      := λ i, d_next i hom + prev_d i hom,
+  comm'  := λ i j hij,
+  begin
+    have eq1 : prev_d i hom ≫ D.d i j = 0,
+    { rcases h : c.prev i with _|⟨i',w⟩,
+      { dsimp [prev_d], rw h, erw zero_comp, },
+      { rw [prev_d_eq hom w, category.assoc, D.d_comp_d' i' i j w hij, comp_zero], }, },
+    have eq2 : C.d i j ≫ d_next j hom = 0,
+    { rcases h : c.next j with _|⟨j',w⟩,
+      { dsimp [d_next], rw h, erw comp_zero, },
+      { rw [d_next_eq hom w, ← category.assoc, C.d_comp_d' i j j' hij w, zero_comp], }, },
+    rw [d_next_eq hom hij, prev_d_eq hom hij, preadditive.comp_add, preadditive.add_comp,
+      eq1, eq2, add_zero, zero_add, category.assoc], 
+  end }
+
+/-- make `null_homotopic_map` into an additive map of monoids -/
+def add_monoid_hom_null_homotopic_map : prehomotopy C D →+ (C ⟶ D) :=
+add_monoid_hom.mk' null_homotopic_map
 begin
-  cases i,
-  { dsimp [d_next],
-    rcases (complex_shape.down ℕ).next 0 with _|⟨j,hj⟩;
-    dsimp [d_next],
-    { rw [C.shape, zero_comp], dsimp, dec_trivial },
-    { dsimp at hj, exact (nat.succ_ne_zero _ hj).elim } },
-  rw d_next_eq, dsimp, refl
+  intros hom₁ hom₂,
+  unfold null_homotopic_map,
+  ext,
+  dsimp,
+  simp only [map_add, add_f_apply],
+  abel, 
 end
 
-lemma prev_d_nat (C D : cochain_complex V ℕ) (i : ℕ) (f : Π i j, C.X i ⟶ D.X j) :
-  prev_d i f = f i (i-1) ≫ D.d (i-1) i :=
+/-- Use this lemma when you need the additivity of `null_homotopic_map` -/
+lemma additive_null_homotopic_map (hom : prehomotopy C D) :
+   null_homotopic_map hom = add_monoid_hom_null_homotopic_map hom :=
+by { dsimp [add_monoid_hom_null_homotopic_map], refl, }
+
+/-- null homotopies can be postcomposed with a morphism of complexes,
+and the corresponding null homotopic maps are computed by `null_homotopic_map_comp` -/
+@[simp]
+def prehomotopy_comp (hom : prehomotopy C D) (g : D ⟶ E) : prehomotopy C E :=
+λ ij, hom ij ≫ g.f ij.val.2 
+
+/-- null homotopies can be precomposed with a morphism of complexes,
+and the corresponding null homotopic maps are computed by `comp_null_homotopic_map` -/
+@[simp]
+def comp_prehomotopy (g : C ⟶ D) (hom : prehomotopy D E) : prehomotopy C E :=
+λ ij, g.f ij.val.1 ≫ hom ij
+
+@[simp]
+lemma null_homotopic_map_comp (hom : prehomotopy C D) (g : D ⟶ E) :
+  null_homotopic_map hom ≫ g = null_homotopic_map (prehomotopy_comp hom g) :=
 begin
-  cases i,
-  { dsimp [prev_d],
-    rcases (complex_shape.up ℕ).prev 0 with _|⟨j,hj⟩;
-    dsimp [prev_d],
-    { rw [D.shape, comp_zero], dsimp, dec_trivial },
-    { dsimp at hj, exact (nat.succ_ne_zero _ hj).elim } },
-  rw prev_d_eq, dsimp, refl
+  ext,
+  simp only [null_homotopic_map, prehomotopy_comp, d_next_comp_right, preadditive.add_comp,
+    to_prev'_comp_right, comp_f],
 end
+
+@[simp]
+lemma comp_null_homotopic_map (g : C ⟶ D) (hom : prehomotopy D E)  :
+   g ≫ null_homotopic_map hom = null_homotopic_map (comp_prehomotopy g hom) :=
+begin
+  ext,
+  simp only [null_homotopic_map, d_next_comp_left, prev_d_comp_left, preadditive.comp_add,
+    comp_prehomotopy, comp_f],
+end
+
+/-! This lemma and the following ones can be used in order to compute
+the degreewise morphisms induced by the null homotopic maps constructed
+with `null_homotopic_map` -/
+@[simp]
+lemma null_homotopic_map_f {k₂ k₁ k₀ : ι} (r₂₁ : c.rel k₂ k₁) (r₁₀ : c.rel k₁ k₀)
+  (hom : prehomotopy C D) :
+  (null_homotopic_map hom).f k₁ = C.d k₁ k₀ ≫ hom ⟨⟨k₀,k₁⟩,r₁₀⟩ + hom ⟨⟨k₁,k₂⟩,r₂₁⟩ ≫ D.d k₂ k₁ :=
+by { dsimp [null_homotopic_map], rw [d_next_eq hom r₁₀, prev_d_eq hom r₂₁], }
+
+@[simp]
+lemma null_homotopic_map_f_of_not_rel_left {k₁ k₀ : ι} (r₁₀ : c.rel k₁ k₀)
+  (hk₀ : ∀ l : ι, ¬c.rel k₀ l) (hom : prehomotopy C D) :
+  (null_homotopic_map hom).f k₀ = hom ⟨⟨k₀,k₁⟩,r₁₀⟩ ≫ D.d k₁ k₀ :=
+begin
+  dsimp [null_homotopic_map],
+  rw prev_d_eq hom r₁₀,
+  rcases h : c.next k₀ with _|⟨l,w⟩, swap, exfalso, exact hk₀ l w,
+  dsimp [d_next], rw h, erw zero_add,
+end
+
+@[simp]
+lemma null_homotopic_map_f_of_not_rel_right {k₁ k₀ : ι} (r₁₀ : c.rel k₁ k₀)
+  (hk₁ : ∀ l : ι, ¬c.rel l k₁)
+  (hom : prehomotopy C D) :
+  (null_homotopic_map hom).f k₁ = C.d k₁ k₀ ≫ hom ⟨⟨k₀,k₁⟩,r₁₀⟩ :=
+begin
+  dsimp [null_homotopic_map],
+  rw d_next_eq hom r₁₀,
+  rcases h : c.prev k₁ with _|⟨l,w⟩, swap, exfalso, exact hk₁ l w,
+  dsimp [prev_d], rw h, erw add_zero,
+end
+
+@[simp]
+lemma null_homotopic_map_f_eq_zero {k₀ : ι} 
+  (hk₀ : ∀ l : ι, ¬c.rel k₀ l) (hk₀' : ∀ l : ι, ¬c.rel l k₀)
+  (hom : prehomotopy C D) :
+  (null_homotopic_map hom).f k₀ = 0 :=
+begin
+  dsimp [null_homotopic_map],
+  rcases h1 : c.next k₀ with _|⟨l,w⟩, swap, exfalso, exact hk₀ l w,
+  rcases h2 : c.prev k₀ with _|⟨l,w⟩, swap, exfalso, exact hk₀' l w,
+  dsimp [d_next, prev_d],
+  rw [h1, h2],
+  erw zero_add,
+  refl,
+end
+
+end homotopy
 
 /--
-A homotopy `h` between chain maps `f` and `g` consists of components `h i j : C.X i ⟶ D.X j`
-which are zero unless `c.rel j i`, satisfying the homotopy condition.
--/
+A homotopy `h` between chain maps `f` and `g` consists of a prehomotopy `hom`
+such the difference between `f` and `g` is the `null_homotopic_map`
+attached to hom. -/
 @[ext, nolint has_inhabited_instance]
 structure homotopy (f g : C ⟶ D) :=
-(hom : Π i j, C.X i ⟶ D.X j)
-(zero' : ∀ i j, ¬ c.rel j i → hom i j = 0 . obviously)
-(comm : ∀ i, f.f i = d_next i hom + prev_d i hom + g.f i . obviously')
+(hom : prehomotopy C D)
+(comm : f = homotopy.null_homotopic_map hom + g)
 
 variables {f g}
 namespace homotopy
 
-restate_axiom homotopy.zero'
+lemma comm_ext (e : homotopy f g) (i : ι) :
+  f.f i = (null_homotopic_map e.hom).f i + g.f i :=
+begin
+  have H := congr_arg (λ φ, φ.f i : (C ⟶ D) → (C.X i ⟶ D.X i)) e.comm,
+  simp only [add_f_apply] at H,
+  exact H,
+end
+
+/-- Tautological construction of the `homotopy` to zero for maps constructed by
+`null_homotopic_map` -/
+@[simps]
+def null_homotopy (hom : prehomotopy C D) :
+  homotopy (null_homotopic_map hom) 0 :=
+{ hom := hom,
+  comm := by simp only [add_zero], }
 
 /--
 `f` is homotopic to `g` iff `f - g` is homotopic to `0`.
 -/
 def equiv_sub_zero : homotopy f g ≃ homotopy (f - g) 0 :=
 { to_fun := λ h,
-  { hom := λ i j, h.hom i j,
-    zero' := λ i j w, h.zero _ _ w,
-    comm := λ i, by simp [h.comm] },
+  { hom := h.hom,
+    comm := by { simpa only [add_zero] using sub_eq_of_eq_add h.comm, }, },
   inv_fun := λ h,
-  { hom := λ i j, h.hom i j,
-    zero' := λ i j w, h.zero _ _ w,
-    comm := λ i, by simpa [sub_eq_iff_eq_add] using h.comm i },
-  left_inv := by tidy,
-  right_inv := by tidy, }
+  { hom := h.hom,
+    comm := by { simpa only [add_zero] using eq_add_of_sub_eq h.comm, }, },
+  left_inv  := by { intro, dsimp, ext, refl, },
+  right_inv := by { intro, dsimp, ext, refl, }, }
 
 /-- Equal chain maps are homotopic. -/
 @[simps]
 def of_eq (h : f = g) : homotopy f g :=
 { hom := 0,
-  zero' := λ _ _ _, rfl,
-  comm := λ _, by simp only [add_monoid_hom.map_zero, zero_add, h] }
+  comm := by { simpa only [additive_null_homotopic_map, zero_add, map_zero], }, }
 
 /-- Every chain map is homotopic to itself. -/
 @[simps, refl]
@@ -227,44 +344,72 @@ of_eq (rfl : f = f)
 @[simps, symm]
 def symm {f g : C ⟶ D} (h : homotopy f g) : homotopy g f :=
 { hom := -h.hom,
-  zero' := λ i j w, by rw [pi.neg_apply, pi.neg_apply, h.zero i j w, neg_zero],
-  comm := λ i, by rw [add_monoid_hom.map_neg, add_monoid_hom.map_neg, h.comm, ← neg_add,
-      ← add_assoc, neg_add_self, zero_add] }
+  comm :=
+  begin
+    have H := h.comm,
+    simp only [additive_null_homotopic_map, map_neg] at H ⊢,
+    exact eq_neg_add_of_add_eq (eq.symm H),
+  end }
 
 /-- homotopy is a transitive relation. -/
 @[simps, trans]
 def trans {e f g : C ⟶ D} (h : homotopy e f) (k : homotopy f g) : homotopy e g :=
 { hom := h.hom + k.hom,
-  zero' := λ i j w, by rw [pi.add_apply, pi.add_apply, h.zero i j w, k.zero i j w, zero_add],
-  comm := λ i, by { rw [add_monoid_hom.map_add, add_monoid_hom.map_add, h.comm, k.comm], abel }, }
+  comm :=
+  begin
+    have H := eq.trans h.comm (congr_arg (has_add.add _) k.comm),
+    simpa only [additive_null_homotopic_map, map_add, add_assoc] using H,
+  end }
 
 /-- the sum of two homotopies is a homotopy between the sum of the respective morphisms. -/
 @[simps]
 def add {f₁ g₁ f₂ g₂: C ⟶ D}
   (h₁ : homotopy f₁ g₁) (h₂ : homotopy f₂ g₂) : homotopy (f₁+f₂) (g₁+g₂) :=
 { hom := h₁.hom + h₂.hom,
-  zero' := λ i j hij, by
-    rw [pi.add_apply, pi.add_apply, h₁.zero' i j hij, h₂.zero' i j hij, add_zero],
-  comm := λ i, by
-    { simp only [homological_complex.add_f_apply, h₁.comm, h₂.comm,
-        add_monoid_hom.map_add],
-      abel, }, }
+  comm := 
+  begin
+    have H1 := h₁.comm,
+    have H2 := h₂.comm,
+    simp only [additive_null_homotopic_map, map_add] at H1 H2 ⊢,
+    simp only [congr (congr_arg has_add.add H1) H2],
+    abel,
+  end }
+
+/-- the difference of two homotopies is a homotopy between the differences of the respective morphisms. -/
+@[simps]
+def sub {f₁ g₁ f₂ g₂: C ⟶ D}
+  (h₁ : homotopy f₁ g₁) (h₂ : homotopy f₂ g₂) : homotopy (f₁-f₂) (g₁-g₂) :=
+{ hom := h₁.hom - h₂.hom,
+  comm := 
+  begin
+    have H1 := h₁.comm,
+    have H2 := h₂.comm,
+    simp only [additive_null_homotopic_map, map_sub] at H1 H2 ⊢,
+    simp only [congr (congr_arg has_sub.sub H1) H2],
+    abel,
+  end }
 
 /-- homotopy is closed under composition (on the right) -/
 @[simps]
 def comp_right {e f : C ⟶ D} (h : homotopy e f) (g : D ⟶ E) : homotopy (e ≫ g) (f ≫ g) :=
-{ hom := λ i j, h.hom i j ≫ g.f j,
-  zero' := λ i j w, by rw [h.zero i j w, zero_comp],
-  comm := λ i, by simp only [h.comm i, d_next_comp_right, preadditive.add_comp,
-    to_prev'_comp_right, comp_f], }
+{ hom := prehomotopy_comp h.hom g,
+  comm :=
+  begin
+    simp only [← null_homotopic_map_comp, ← preadditive.add_comp],
+    congr',
+    exact h.comm,
+  end}
 
 /-- homotopy is closed under composition (on the left) -/
 @[simps]
 def comp_left {f g : D ⟶ E} (h : homotopy f g) (e : C ⟶ D) : homotopy (e ≫ f) (e ≫ g) :=
-{ hom := λ i j, e.f i ≫ h.hom i j,
-  zero' := λ i j w, by rw [h.zero i j w, comp_zero],
-  comm := λ i, by simp only [h.comm i, d_next_comp_left, preadditive.comp_add,
-    prev_d_comp_left, comp_f], }
+{ hom := comp_prehomotopy e h.hom,
+  comm :=
+  begin
+    simp only [← comp_null_homotopic_map, ← preadditive.comp_add],
+    congr',
+    exact h.comm,
+  end}
 
 /-- homotopy is closed under composition -/
 @[simps]
@@ -283,158 +428,6 @@ def comp_left_id {f : D ⟶ D} (h : homotopy f (𝟙 D)) (g : C ⟶ D) : homotop
 (h.comp_left g).trans (of_eq $ category.comp_id _)
 
 /-!
-Null homotopic maps can be constructed using the formula `hd+dh`. We show that
-these morphisms are homotopic to `0` and provide some convenient simplification
-lemmas that give a degreewise description of `hd+dh`, depending on whether we have 
-two differentials going to and from a certain degree, only one, or none.
--/
-
-/-- The null homotopic map associated to a family `hom` of morphisms `C_i ⟶ D_j`.
-This is the same datum as for the field `hom` in the structure `homotopy`. For
-this definition, we do not need the field `zero` of that structure 
-as this definition uses only the maps `C_i ⟶ C_j` when `c.rel j i`. -/
-def null_homotopic_map (hom : Π i j, C.X i ⟶ D.X j) : C ⟶ D :=
-{ f      := λ i, d_next i hom + prev_d i hom,
-  comm'  := λ i j hij,
-  begin
-    have eq1 : prev_d i hom ≫ D.d i j = 0,
-    { rcases h : c.prev i with _|⟨i',w⟩,
-      { dsimp [prev_d], rw h, erw zero_comp, },
-      { rw [prev_d_eq hom w, category.assoc, D.d_comp_d' i' i j w hij, comp_zero], }, },
-    have eq2 : C.d i j ≫ d_next j hom = 0,
-    { rcases h : c.next j with _|⟨j',w⟩,
-      { dsimp [d_next], rw h, erw comp_zero, },
-      { rw [d_next_eq hom w, ← category.assoc, C.d_comp_d' i j j' hij w, zero_comp], }, },
-    rw [d_next_eq hom hij, prev_d_eq hom hij, preadditive.comp_add, preadditive.add_comp,
-      eq1, eq2, add_zero, zero_add, category.assoc], 
-  end }
-
-/-- Variant of `null_homotopic_map` where the input consists only of the
-relevant maps `C_i ⟶ D_j` such that `c.rel j i`. -/
-def null_homotopic_map' (h : Π i j, c.rel j i → (C.X i ⟶ D.X j)) : C ⟶ D :=
-null_homotopic_map (λ i j, dite (c.rel j i) (h i j) (λ _, 0))
-
-/-- Tautological construction of the `homotopy` to zero for maps constructed by
-`null_homotopic_map`, at least when we have the `zero'` condition. -/
-@[simps]
-def null_homotopy (hom : Π i j, C.X i ⟶ D.X j) (zero' : ∀ i j, ¬ c.rel j i → hom i j = 0) :
-  homotopy (null_homotopic_map hom) 0 :=
-{ hom := hom,
-  zero' := zero',
-  comm := by { intro i, rw [homological_complex.zero_f_apply, add_zero], refl, }, }
-
-/-- Homotopy to zero for maps constructed with `null_homotopic_map'` -/
-@[simps]
-def null_homotopy' (h : Π i j, c.rel j i → (C.X i ⟶ D.X j)) :
-  homotopy (null_homotopic_map' h) 0 :=
-begin
-  apply null_homotopy (λ i j, dite (c.rel j i) (h i j) (λ _, 0)),
-  intros i j hij,
-  dsimp,
-  rw [dite_eq_right_iff],
-  intro hij',
-  exfalso,
-  exact hij hij',
-end
-
-/-! This lemma and the following ones can be used in order to compute
-the degreewise morphisms induced by the null homotopic maps constructed
-with `null_homotopic_map` or `null_homotopic_map'` -/
-@[simp]
-lemma null_homotopic_map_f {k₂ k₁ k₀ : ι} (r₂₁ : c.rel k₂ k₁) (r₁₀ : c.rel k₁ k₀)
-  (hom : Π i j, C.X i ⟶ D.X j) :
-  (null_homotopic_map hom).f k₁ = C.d k₁ k₀ ≫ hom k₀ k₁ + hom k₁ k₂ ≫ D.d k₂ k₁ :=
-by { dsimp [null_homotopic_map], rw [d_next_eq hom r₁₀, prev_d_eq hom r₂₁], }
-
-@[simp]
-lemma null_homotopic_map'_f {k₂ k₁ k₀  : ι} (r₂₁ : c.rel k₂ k₁) (r₁₀ : c.rel k₁ k₀)
-  (h : Π i j, c.rel j i → (C.X i ⟶ D.X j)) :
-  (null_homotopic_map' h).f k₁ = C.d k₁ k₀ ≫ h k₀ k₁ r₁₀ + h k₁ k₂ r₂₁ ≫ D.d k₂ k₁ :=
-begin
-  simp only [← null_homotopic_map'],
-  rw null_homotopic_map_f r₂₁ r₁₀ (λ i j, dite (c.rel j i) (h i j) (λ _, 0)),
-  dsimp,
-  split_ifs,
-  refl,
-end
-
-@[simp]
-lemma null_homotopic_map_f_of_not_rel_left {k₁ k₀ : ι} (r₁₀ : c.rel k₁ k₀)
-  (hk₀ : ∀ l : ι, ¬c.rel k₀ l)
-  (hom : Π i j, C.X i ⟶ D.X j) :
-  (null_homotopic_map hom).f k₀ = hom k₀ k₁ ≫ D.d k₁ k₀ :=
-begin
-  dsimp [null_homotopic_map],
-  rw prev_d_eq hom r₁₀,
-  rcases h : c.next k₀ with _|⟨l,w⟩, swap, exfalso, exact hk₀ l w,
-  dsimp [d_next], rw h, erw zero_add,
-end
-
-@[simp]
-lemma null_homotopic_map'_f_of_not_rel_left {k₁ k₀ : ι} (r₁₀ : c.rel k₁ k₀)
-  (hk₀ : ∀ l : ι, ¬c.rel k₀ l)
-  (h : Π i j, c.rel j i → (C.X i ⟶ D.X j)) :
-  (null_homotopic_map' h).f k₀ = h k₀ k₁ r₁₀ ≫ D.d k₁ k₀ :=
-begin
-  simp only [← null_homotopic_map'],
-  rw null_homotopic_map_f_of_not_rel_left r₁₀ hk₀ (λ i j, dite (c.rel j i) (h i j) (λ _, 0)),
-  dsimp,
-  split_ifs,
-  refl,
-end
-
-@[simp]
-lemma null_homotopic_map_f_of_not_rel_right {k₁ k₀ : ι} (r₁₀ : c.rel k₁ k₀)
-  (hk₁ : ∀ l : ι, ¬c.rel l k₁)
-  (hom : Π i j, C.X i ⟶ D.X j) :
-  (null_homotopic_map hom).f k₁ = C.d k₁ k₀ ≫ hom k₀ k₁ :=
-begin
-  dsimp [null_homotopic_map],
-  rw d_next_eq hom r₁₀,
-  rcases h : c.prev k₁ with _|⟨l,w⟩, swap, exfalso, exact hk₁ l w,
-  dsimp [prev_d], rw h, erw add_zero,
-end
-
-@[simp]
-lemma null_homotopic_map'_f_of_not_rel_right {k₁ k₀ : ι} (r₁₀ : c.rel k₁ k₀)
-  (hk₁ : ∀ l : ι, ¬c.rel l k₁)
-  (h : Π i j, c.rel j i → (C.X i ⟶ D.X j)) :
-  (null_homotopic_map' h).f k₁ = C.d k₁ k₀ ≫ h k₀ k₁ r₁₀ :=
-begin
-  simp only [← null_homotopic_map'],
-  rw null_homotopic_map_f_of_not_rel_right r₁₀ hk₁ (λ i j, dite (c.rel j i) (h i j) (λ _, 0)),
-  dsimp,
-  split_ifs,
-  refl,
-end
-
-@[simp]
-lemma null_homotopic_map_f_eq_zero {k₀ : ι} 
-  (hk₀ : ∀ l : ι, ¬c.rel k₀ l) (hk₀' : ∀ l : ι, ¬c.rel l k₀)
-  (hom : Π i j, C.X i ⟶ D.X j) :
-  (null_homotopic_map hom).f k₀ = 0 :=
-begin
-  dsimp [null_homotopic_map],
-  rcases h1 : c.next k₀ with _|⟨l,w⟩, swap, exfalso, exact hk₀ l w,
-  rcases h2 : c.prev k₀ with _|⟨l,w⟩, swap, exfalso, exact hk₀' l w,
-  dsimp [d_next, prev_d],
-  rw [h1, h2],
-  erw zero_add,
-  refl,
-end
-
-@[simp]
-lemma null_homotopic_map'_f_eq_zero {k₀ : ι} 
-  (hk₀ : ∀ l : ι, ¬c.rel k₀ l) (hk₀' : ∀ l : ι, ¬c.rel l k₀)
-  (h : Π i j, c.rel j i → (C.X i ⟶ D.X j)) :
-  (null_homotopic_map' h).f k₀ = 0 :=
-begin
-  simp only [← null_homotopic_map'],
-  exact null_homotopic_map_f_eq_zero hk₀ hk₀'
-    (λ i j, dite (c.rel j i) (h i j) (λ _, 0)),
-end
-
-/-!
 `homotopy.mk_inductive` allows us to build a homotopy inductively,
 so that as we construct each component, we have available the previous two components,
 and the fact that they satisfy the homotopy condition.
@@ -451,23 +444,34 @@ section mk_inductive
 
 variables {P Q : chain_complex V ℕ}
 
-@[simp] lemma prev_d_chain_complex (f : Π i j, P.X i ⟶ Q.X j) (j : ℕ) :
-  prev_d j f = f j (j+1) ≫ Q.d _ _ :=
+lemma cs_down_succ (j : ℕ) : (complex_shape.down ℕ).rel (j+1) j :=
+by { have eq : j+1 = j+1 := rfl, assumption, }
+
+lemma cs_down_0_not_rel_left (j : ℕ) : ¬(complex_shape.down ℕ).rel 0 j :=
+begin
+  intro h,
+  dsimp at h,
+  apply nat.not_succ_le_zero j,
+  rw [show j.succ=j+1, by refl, h],
+end
+
+@[simp] lemma prev_d_chain_complex (f : prehomotopy P Q) (j : ℕ) :
+  prev_d j f = f ⟨⟨j,j+1⟩,cs_down_succ j⟩ ≫ Q.d _ _ :=
 begin
   dsimp [prev_d],
   simp only [chain_complex.prev],
   refl,
 end
 
-@[simp] lemma d_next_succ_chain_complex (f : Π i j, P.X i ⟶ Q.X j) (i : ℕ) :
-  d_next (i+1) f = P.d _ _ ≫ f i (i+1) :=
+@[simp] lemma d_next_succ_chain_complex (f : prehomotopy P Q) (i : ℕ) :
+  d_next (i+1) f = P.d _ _ ≫ f ⟨⟨i,i+1⟩,cs_down_succ i⟩ :=
 begin
   dsimp [d_next],
   simp only [chain_complex.next_nat_succ],
   refl,
 end
 
-@[simp] lemma d_next_zero_chain_complex (f : Π i j, P.X i ⟶ Q.X j) :
+@[simp] lemma d_next_zero_chain_complex (f : prehomotopy P Q) :
   d_next 0 f = 0 :=
 begin
   dsimp [d_next],
@@ -513,7 +517,6 @@ def mk_inductive_aux₁ :
 section
 
 variable [has_zero_object V]
-
 /--
 An auxiliary construction for `mk_inductive`.
 -/
@@ -540,30 +543,33 @@ and the fact that it satisfies the homotopy condition,
 using as an inductive hypothesis the data and homotopy condition for the previous two components.
 -/
 def mk_inductive : homotopy e 0 :=
-{ hom := λ i j, if h : i + 1 = j then
-    (mk_inductive_aux₂ e zero comm_zero one comm_one succ i).2.1 ≫ (Q.X_prev_iso h).hom
-  else
-    0,
-  zero' := λ i j w, by rwa dif_neg,
-  comm := λ i, begin
+{ hom := λ ij, (mk_inductive_aux₂ e zero comm_zero one comm_one succ ij.val.1).2.1 ≫
+    (Q.X_prev_iso ij.property).hom,
+  comm := begin
+    ext i,
     dsimp, simp only [add_zero],
     convert (mk_inductive_aux₂ e zero comm_zero one comm_one succ i).2.2,
     { rcases i with (_|_|_|i),
+      { simp only [null_homotopic_map_f_of_not_rel_left
+          (cs_down_succ 0) cs_down_0_not_rel_left],
+        dsimp,
+        simp only [zero_add, comp_zero],
+        slice_rhs 2 3 { erw X_prev_iso_comp_d_to, },
+        slice_lhs 2 3 { erw iso.inv_hom_id, },
+        simp only [category.id_comp], },
+      simp only [null_homotopic_map_f (cs_down_succ 1) (cs_down_succ 0)], rotate,
+      simp only [null_homotopic_map_f (cs_down_succ 2) (cs_down_succ 1)], rotate,
+      simp only [null_homotopic_map_f (cs_down_succ (i.succ.succ.succ))
+        (cs_down_succ (i.succ.succ))],
+      all_goals
       { dsimp,
-        simp only [d_next_zero_chain_complex, d_from_eq_zero, limits.comp_zero], },
-      all_goals
-      { simp only [d_next_succ_chain_complex],
-        dsimp,
-        simp only [category.comp_id, category.assoc, iso.inv_hom_id, d_from_comp_X_next_iso_assoc,
-          dite_eq_ite, if_true, eq_self_iff_true]}, },
-    { cases i,
-      all_goals
-      { simp only [prev_d_chain_complex],
-        dsimp,
-        simp only [category.comp_id, category.assoc, iso.inv_hom_id, X_prev_iso_comp_d_to,
-          dite_eq_ite, if_true, eq_self_iff_true], }, },
-  end, }
-
+        simp only [d_from_comp_X_next_iso_assoc, category.assoc],
+        erw iso.inv_hom_id,
+        simp only [X_prev_iso_comp_d_to, category.comp_id],
+        simp only [add_right_inj],
+        slice_lhs 2 3 { erw iso.inv_hom_id, },
+        simp only [category.id_comp], }, },
+  end }
 end
 
 end mk_inductive
@@ -621,25 +627,33 @@ variables [has_equalizers V] [has_cokernels V] [has_images V] [has_image_maps V]
 variable [has_zero_object V]
 
 /--
+Null homotopic maps induce the zero map on homology.
+-/
+theorem homology_map_eq_zero (hom : prehomotopy C D) (i : ι) :
+  (homology_functor V c i).map (homotopy.null_homotopic_map hom) = 0 :=
+begin
+  dsimp [homology_functor, kernel_subobject_map, homotopy.null_homotopic_map],
+  ext,
+  simp only [homology.π_map, comp_zero],
+  dsimp [kernel_subobject_map],
+  simp only [preadditive.comp_add, homotopy.d_next_eq_d_from_from_next,
+    kernel_subobject_arrow_comp_assoc, zero_comp,zero_add],
+  erw [subobject.factor_thru_of_le (D.boundaries_le_cycles i)],
+  { simp only [comp_zero, image_to_kernel_as_boundaries_to_cycles,
+    homology.condition, category.assoc], },
+  { rw [homotopy.prev_d_eq_to_prev_d_to, ← category.assoc],
+    apply image_subobject_factors_comp_self, },
+end
+
+/--
 Homotopic maps induce the same map on homology.
 -/
 theorem homology_map_eq_of_homotopy (h : homotopy f g) (i : ι) :
   (homology_functor V c i).map f = (homology_functor V c i).map g :=
 begin
-  dsimp [homology_functor],
-  apply eq_of_sub_eq_zero,
-  ext,
-  simp only [homology.π_map, comp_zero, preadditive.comp_sub],
-  dsimp [kernel_subobject_map],
-  simp_rw [h.comm i],
-  simp only [zero_add, zero_comp, d_next_eq_d_from_from_next, kernel_subobject_arrow_comp_assoc,
-    preadditive.comp_add],
-  rw [←preadditive.sub_comp],
-  simp only [category_theory.subobject.factor_thru_add_sub_factor_thru_right],
-  erw [subobject.factor_thru_of_le (D.boundaries_le_cycles i)],
-  { simp, },
-  { rw [prev_d_eq_to_prev_d_to, ←category.assoc],
-    apply image_subobject_factors_comp_self, },
+  rw h.comm,
+  simp only [add_left_eq_self, functor.map_add],
+  exact homology_map_eq_zero h.hom i,
 end
 
 /-- Homotopy equivalent complexes have isomorphic homologies. -/
@@ -666,16 +680,15 @@ variables {W : Type*} [category W] [preadditive W]
 @[simps]
 def functor.map_homotopy (F : V ⥤ W) [F.additive] {f g : C ⟶ D} (h : homotopy f g) :
   homotopy ((F.map_homological_complex c).map f) ((F.map_homological_complex c).map g) :=
-{ hom := λ i j, F.map (h.hom i j),
-  zero' := λ i j w, by { rw [h.zero i j w, F.map_zero], },
-  comm := λ i, begin
-    have := h.comm i,
-    dsimp [d_next, prev_d] at *,
+{ hom := λ ij, F.map (h.hom ij),
+  comm := begin
+    ext i,
+    have := homotopy.comm_ext h i,
+    dsimp [homotopy.null_homotopic_map, homotopy.d_next, homotopy.prev_d] at *,
     rcases c.next i with _|⟨inext,wn⟩;
     rcases c.prev i with _|⟨iprev,wp⟩;
-    dsimp [d_next, prev_d] at *;
-    { intro h,
-      simp [h] },
+    dsimp [homotopy.d_next, homotopy.prev_d] at *;
+    { intro h, simp only [h, functor.map_add, zero_add, functor.map_comp, functor.map_zero], },
   end, }
 
 /-- An additive functor preserves homotopy equivalences. -/

--- a/src/algebra/homology/homotopy.lean
+++ b/src/algebra/homology/homotopy.lean
@@ -375,7 +375,8 @@ def add {f₁ g₁ f₂ g₂: C ⟶ D}
     abel,
   end }
 
-/-- the difference of two homotopies is a homotopy between the differences of the respective morphisms. -/
+/-- the difference of two homotopies is a homotopy between the differences
+of the respective morphisms. -/
 @[simps]
 def sub {f₁ g₁ f₂ g₂: C ⟶ D}
   (h₁ : homotopy f₁ g₁) (h₂ : homotopy f₂ g₂) : homotopy (f₁-f₂) (g₁-g₂) :=


### PR DESCRIPTION
Homotopies between morphisms `C ⟶ D` of homological_complex V c were based on families of morphisms `(hom : Π i j, C.X i ⟶ D.X j)` with the condition that `hom i j` = 0 when `¬c.rel j i` (e.g. `j≠i+1` in the case
of chain_complexes). It was quite unpractical when one had to construct such homotopies because any definition would unnecessarily use a syntax like `if c.rel j i then ... else 0`. 

My first idea was to use the type `Π i j, c.rel j i → (C.X i ⟶ D.X j)` instead of `Π i j, C.X i ⟶ D.X j`, which was good, but then, the additive group structure on this set had to be redefined.

Then, in order to get the additive group structure automatically from the Π construction, I suggest using Π over the type of the subset of ι × ι consisting of tuples ⟨i,j⟩ such that c.rel j i. If we define this as a `prehomotopy C D`, one may define the associated null_homotopic_map C ⟶ D, and redefine `homotopy
f g` can be defined as a prehomotopy hom such that `f = null_homotopic_map hom + g`.

Changing this definition did not break anything else in the mathlib itself. The adaptation should be very easy for any code that constructed homotopies based on the previous definition.


---

Zulip discussion: https://leanprover.zulipchat.com/#narrow/stream/144837-PR-reviews/topic/.2311256.20refactor.28algebra.2Fhomology.2Fhomotopy.29

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
