### PR TITLE
[Merged by Bors] - [Merged by Bors] - feat(algebra/polynomial/big_operators): lemmas about polynomial degree of products

### DIFF
--- a/src/algebra/polynomial/big_operators.lean
+++ b/src/algebra/polynomial/big_operators.lean
@@ -76,6 +76,14 @@ begin
   { simpa using nat_degree_mul_le.trans (add_le_add_left IH _) }
 end
 
+lemma degree_list_prod_le (l : list (polynomial α)) :
+  degree l.prod ≤ (l.map degree).sum :=
+begin
+  induction l with hd tl IH,
+  { simp },
+  { simpa using (degree_mul_le _ _).trans (add_le_add_left IH _) }
+end
+
 lemma coeff_list_prod_of_nat_degree_le (l : list (polynomial α)) (n : ℕ)
   (hl : ∀ p ∈ l, nat_degree p ≤ n) :
   coeff (list.prod l) (l.length * n) = (l.map (λ p, coeff p n)).prod :=
@@ -111,6 +119,17 @@ quotient.induction_on t (by simpa using nat_degree_list_prod_le)
 
 lemma nat_degree_prod_le : (∏ i in s, f i).nat_degree ≤ ∑ i in s, (f i).nat_degree :=
 by simpa using nat_degree_multiset_prod_le (s.1.map f)
+
+/--
+The degree of a product of polynomials is at most the sum of the degrees,
+where the degree of the zero polynomial is ⊥.
+-/
+lemma degree_multiset_prod_le :
+  t.prod.degree ≤ (t.map polynomial.degree).sum :=
+quotient.induction_on t (by simpa using degree_list_prod_le)
+
+lemma degree_prod_le : (∏ i in s, f i).degree ≤ ∑ i in s, (f i).degree :=
+by simpa using degree_multiset_prod_le (s.1.map f)
 
 /--
 The leading coefficient of a product of polynomials is equal to

--- a/src/algebra/polynomial/big_operators.lean
+++ b/src/algebra/polynomial/big_operators.lean
@@ -129,7 +129,7 @@ lemma degree_multiset_prod_le :
 quotient.induction_on t (by simpa using degree_list_prod_le)
 
 lemma degree_prod_le : (∏ i in s, f i).degree ≤ ∑ i in s, (f i).degree :=
-by simpa using degree_multiset_prod_le (s.1.map f)
+by simpa only [multiset.map_map] using degree_multiset_prod_le (s.1.map f)
 
 /--
 The leading coefficient of a product of polynomials is equal to


### PR DESCRIPTION
These already existed for `nat_degree` but `degree` versions seemed missing.

from flt-regular



---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
