### PR TITLE
[Merged by Bors] - feat(data/polynomial/monic): add two lemmas on degrees of monic polynomials

### DIFF
--- a/src/data/polynomial/monic.lean
+++ b/src/data/polynomial/monic.lean
@@ -188,9 +188,9 @@ begin
     ring }
 end
 
-lemma nat_degree_pow_X_add_C [nontrivial R] (n : ℕ) (r : R) :
+@[simp] lemma nat_degree_pow_X_add_C [nontrivial R] (n : ℕ) (r : R) :
   ((X + C r) ^ n).nat_degree = n :=
-by rw [monic.nat_degree_pow (monic_X_add_C r), nat_degree_X_add_C, mul_one]
+by rw [(monic_X_add_C r).nat_degree_pow, nat_degree_X_add_C, mul_one]
 
 end monic
 

--- a/src/data/polynomial/monic.lean
+++ b/src/data/polynomial/monic.lean
@@ -179,6 +179,19 @@ begin
   rw [← hndeg, ← polynomial.leading_coeff, hp.leading_coeff, C.map_one]
 end
 
+lemma nat_degree_pow (hp : p.monic) (n : ℕ) :
+  (p ^ n).nat_degree = n * p.nat_degree :=
+begin
+  induction n with n hn,
+  { simp },
+  { rw [pow_succ, hp.nat_degree_mul (monic_pow hp n), hn],
+    ring }
+end
+
+lemma nat_degree_pow_X_add_C [nontrivial R] (n : ℕ) (r : R) :
+  ((X + C r) ^ n).nat_degree = n :=
+by rw [monic.nat_degree_pow (monic_X_add_C r), nat_degree_X_add_C, mul_one]
+
 end monic
 
 end semiring

--- a/src/data/polynomial/monic.lean
+++ b/src/data/polynomial/monic.lean
@@ -188,11 +188,11 @@ begin
     ring }
 end
 
+end monic
+
 @[simp] lemma nat_degree_pow_X_add_C [nontrivial R] (n : ℕ) (r : R) :
   ((X + C r) ^ n).nat_degree = n :=
 by rw [(monic_X_add_C r).nat_degree_pow, nat_degree_X_add_C, mul_one]
-
-end monic
 
 end semiring
 

--- a/src/data/polynomial/monic.lean
+++ b/src/data/polynomial/monic.lean
@@ -190,7 +190,7 @@ end
 
 lemma nat_degree_pow_X_add_C [nontrivial R] (n : ℕ) (r : R) :
   ((X + C r) ^ n).nat_degree = n :=
-by rw [monic.nat_degree_pow (monic_X_add_C r), nat_degree_X_add_C, mul_one]
+by rw [(monic_X_add_C r).nat_degree_pow, nat_degree_X_add_C, mul_one]
 
 end monic
 


### PR DESCRIPTION
This PR is a step in the direction of simplifying #11139.

The two lemmas involve computing the degree of a power of monic polynomials.

[Zulip](https://leanprover.zulipchat.com/#narrow/stream/144837-PR-reviews/topic/.2311139.20taylor.20sum.20and.20nat_degree_taylor)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
