### PR TITLE
[Merged by Bors] - feat(analysis/inner_product_space/orientation): orientations of real inner product spaces

### DIFF
--- a/src/analysis/inner_product_space/orientation.lean
+++ b/src/analysis/inner_product_space/orientation.lean
@@ -25,7 +25,7 @@ variables {ι : Type*} [fintype ι] [decidable_eq ι]
 
 open finite_dimensional
 
-/-- `adjust_to_orientation`, applied to an orthonormal basis, produces an orthonormal basis. -/
+/-- `basis.adjust_to_orientation`, applied to an orthonormal basis, produces an orthonormal basis. -/
 lemma orthonormal.orthonormal_adjust_to_orientation [nonempty ι] {e : basis ι ℝ E}
   (h : orthonormal ℝ e) (x : orientation ℝ E ι) : orthonormal ℝ (e.adjust_to_orientation x) :=
 h.orthonormal_of_forall_eq_or_eq_neg (e.adjust_to_orientation_apply_eq_or_eq_neg x)

--- a/src/analysis/inner_product_space/orientation.lean
+++ b/src/analysis/inner_product_space/orientation.lean
@@ -1,0 +1,59 @@
+/-
+Copyright (c) 2022 Joseph Myers. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Joseph Myers
+-/
+import analysis.inner_product_space.projection
+import linear_algebra.orientation
+
+/-!
+# Orientations of real inner product spaces.
+
+This file provides definitions and proves lemmas about orientations of real inner product spaces.
+
+## Main definitions
+
+* `orientation.fin_orthonormal_basis` is an orthonormal basis, indexed by `fin n`, with the given
+orientation.
+
+-/
+
+noncomputable theory
+
+variables {E : Type*} [inner_product_space ℝ E]
+variables {ι : Type*} [fintype ι] [decidable_eq ι]
+
+open finite_dimensional
+
+/-- `adjust_to_orientation`, applied to an orthonormal basis, produces an orthonormal basis. -/
+lemma orthonormal.orthonormal_adjust_to_orientation [nonempty ι] {e : basis ι ℝ E}
+  (h : orthonormal ℝ e) (x : orientation ℝ E ι) : orthonormal ℝ (e.adjust_to_orientation x) :=
+h.orthonormal_of_forall_eq_or_eq_neg (e.adjust_to_orientation_apply_eq_or_eq_neg x)
+
+/-- An orthonormal basis, indexed by `fin n`, with the given orientation. -/
+protected def orientation.fin_orthonormal_basis {n : ℕ} (hn : 0 < n) (h : finrank ℝ E = n)
+  (x : orientation ℝ E (fin n)) : basis (fin n) ℝ E :=
+begin
+  haveI := fin.pos_iff_nonempty.1 hn,
+  haveI := finite_dimensional_of_finrank (h.symm ▸ hn : 0 < finrank ℝ E),
+  exact (fin_orthonormal_basis h).adjust_to_orientation x
+end
+
+/-- `orientation.fin_orthonormal_basis` is orthonormal. -/
+protected lemma orientation.fin_orthonormal_basis_orthonormal {n : ℕ} (hn : 0 < n)
+  (h : finrank ℝ E = n) (x : orientation ℝ E (fin n)) :
+  orthonormal ℝ (x.fin_orthonormal_basis hn h) :=
+begin
+  haveI := fin.pos_iff_nonempty.1 hn,
+  haveI := finite_dimensional_of_finrank (h.symm ▸ hn : 0 < finrank ℝ E),
+  exact (fin_orthonormal_basis_orthonormal h).orthonormal_adjust_to_orientation _
+end
+
+/-- `orientation.fin_orthonormal_basis` gives a basis with the required orientation. -/
+@[simp] lemma orientation.fin_orthonormal_basis_orientation {n : ℕ} (hn : 0 < n)
+  (h : finrank ℝ E = n) (x : orientation ℝ E (fin n)) :
+  (x.fin_orthonormal_basis hn h).orientation = x :=
+begin
+  haveI := fin.pos_iff_nonempty.1 hn,
+  exact basis.orientation_adjust_to_orientation _ _
+end

--- a/src/analysis/inner_product_space/orientation.lean
+++ b/src/analysis/inner_product_space/orientation.lean
@@ -25,7 +25,8 @@ variables {ι : Type*} [fintype ι] [decidable_eq ι]
 
 open finite_dimensional
 
-/-- `basis.adjust_to_orientation`, applied to an orthonormal basis, produces an orthonormal basis. -/
+/-- `basis.adjust_to_orientation`, applied to an orthonormal basis, produces an orthonormal
+basis. -/
 lemma orthonormal.orthonormal_adjust_to_orientation [nonempty ι] {e : basis ι ℝ E}
   (h : orthonormal ℝ e) (x : orientation ℝ E ι) : orthonormal ℝ (e.adjust_to_orientation x) :=
 h.orthonormal_of_forall_eq_or_eq_neg (e.adjust_to_orientation_apply_eq_or_eq_neg x)


### PR DESCRIPTION
Add definitions and lemmas relating to orientations of real inner
product spaces, in particular constructing an orthonormal basis with a
given orientation in finite positive dimension.

This is in a new file since nothing else about inner product spaces
needs to depend on orientations.



---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
