### PR TITLE
[Merged by Bors] - chore(ci): update some workflows to use custom bot token

### DIFF
--- a/.github/workflows/add_label_from_review.yml
+++ b/.github/workflows/add_label_from_review.yml
@@ -18,7 +18,7 @@ jobs:
           repository: ${{ github.repository }}
           pull_number: ${{ github.event.pull_request.number }}
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.TRIAGE_TOKEN }}
 
       # Parse steps.get_pr_head.outputs.data, since it is a string
       - id: parse_pr_head
@@ -39,7 +39,7 @@ jobs:
           repository: ${{ github.repository }}
           username: ${{ github.event.review.user.login }}
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.TRIAGE_TOKEN }}
 
       # Parse steps.get_user.outputs.data, since it is a string
       - if: steps.parse_pr_head.outputs.head_user == 'leanprover-community'
@@ -60,7 +60,7 @@ jobs:
           issue_number: ${{ github.event.pull_request.number }}
           labels: '["ready-to-merge"]'
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.TRIAGE_TOKEN }}
 
       - if: (steps.parse_pr_head.outputs.head_user == 'leanprover-community') && (steps.parse_user.outputs.permission == 'admin')
         id: remove_labels
@@ -70,11 +70,11 @@ jobs:
         run: |
           curl --request DELETE \
             --url https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/labels/awaiting-review \
-            --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}'
+            --header 'authorization: Bearer ${{ secrets.TRIAGE_TOKEN }}'
           curl --request DELETE \
             --url https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/labels/awaiting-author \
-            --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}'
-            
+            --header 'authorization: Bearer ${{ secrets.TRIAGE_TOKEN }}'
+
   add_delegated_label:
     name: Add delegated label
     if: (startsWith(github.event.review.body, 'bors d') || contains(toJSON(github.event.review.body), '\r\nbors d'))
@@ -88,7 +88,7 @@ jobs:
           repository: ${{ github.repository }}
           pull_number: ${{ github.event.pull_request.number }}
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.TRIAGE_TOKEN }}
 
       # Parse steps.get_pr_head.outputs.data, since it is a string
       - id: parse_pr_head
@@ -109,7 +109,7 @@ jobs:
           repository: ${{ github.repository }}
           username: ${{ github.event.review.user.login }}
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.TRIAGE_TOKEN }}
 
       # Parse steps.get_user.outputs.data, since it is a string
       - if: steps.parse_pr_head.outputs.head_user == 'leanprover-community'
@@ -130,7 +130,7 @@ jobs:
           issue_number: ${{ github.event.pull_request.number }}
           labels: '["delegated"]'
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.TRIAGE_TOKEN }}
 
       - if: (steps.parse_pr_head.outputs.head_user == 'leanprover-community') && (steps.parse_user.outputs.permission == 'admin')
         id: remove_labels
@@ -140,4 +140,4 @@ jobs:
         run: |
           curl --request DELETE \
             --url https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/labels/awaiting-review \
-            --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}'
+            --header 'authorization: Bearer ${{ secrets.TRIAGE_TOKEN }}'

--- a/.github/workflows/dependent-issues.yml
+++ b/.github/workflows/dependent-issues.yml
@@ -32,7 +32,7 @@ jobs:
       - uses: z0al/dependent-issues@v1
         env:
           # (Required) The token to use to make API calls to GitHub.
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.TRIAGE_TOKEN }}
         with:
           # (Optional) The label to use to mark dependent issues
           label: blocked-by-other-PR

--- a/.github/workflows/merge_conflicts.yml
+++ b/.github/workflows/merge_conflicts.yml
@@ -17,4 +17,4 @@ jobs:
         uses: eps1lon/actions-label-merge-conflict@releases/2.x
         with:
           dirtyLabel: "merge-conflict"
-          repoToken: "${{ secrets.GITHUB_TOKEN }}"
+          repoToken: "${{ secrets.TRIAGE_TOKEN }}"


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)

`TRIAGE_TOKEN` comes from a bot with [triage access](https://docs.github.com/en/organizations/managing-access-to-your-organizations-repositories/repository-roles-for-an-organization) to mathlib only. I think all the locations I've changed only need this access.

This is an attempt to fix some of the CI failures we're seeing due to GitHub rate limits on the default Actions token.