### PR TITLE
feat(group_theory/perm/cycle_types.lean) : add sign_of_cycle_type'

### DIFF
--- a/src/group_theory/_acl/sign.lean
+++ b/src/group_theory/_acl/sign.lean
@@ -1,0 +1,12 @@
+import algebra.gcd_monoid.multiset
+import combinatorics.partition
+import group_theory.perm.cycles
+import ring_theory.int.basic
+import tactic.linarith
+
+
+lemma sign (h : is_three_cycle σ) : sign σ = 1 :=
+begin
+  rw [sign_of_cycle_type', h.cycle_type],
+  refl,
+end

--- a/src/group_theory/perm/cycle_type.lean
+++ b/src/group_theory/perm/cycle_type.lean
@@ -10,6 +10,77 @@ import group_theory.perm.cycles
 import ring_theory.int.basic
 import tactic.linarith
 
+/- To be put in the relevant mathlib files :
+algebra.big_operators.multiset
+algebra.group_power.lemmas
+algebra.big_operators.basic
+-/
+-- for zpow
+import algebra.group_power.lemmas
+-- for finset
+import data.finset.basic
+import algebra.big_operators.basic
+
+namespace multiset
+variables {ι α : Type*}
+
+section comm_monoid
+
+variable [comm_monoid α]
+
+@[simp]
+lemma prod_map_pow {m : multiset ι} {f : ι → ℕ} {a : α} :
+  (multiset.map (λ i, a ^ (f i)) m).prod = a ^ ((multiset.map f m).sum) :=
+  multiset.induction_on m (by simp) (λ n m ih, by simp [ih, pow_add])
+
+end comm_monoid
+
+section comm_group
+
+variable [comm_group α]
+
+@[simp]
+lemma prod_map_zpow {m : multiset ι} {f : ι → ℤ} {a : α} :
+  (multiset.map (λ i, a ^ (f i)) m).prod = a ^ ((multiset.map f m).sum) :=
+  multiset.induction_on m (by simp) (λ n m ih, by simp [ih, zpow_add])
+
+end comm_group
+end multiset
+
+namespace finset
+variables {ι α : Type*}
+
+section comm_monoid
+open_locale big_operators
+
+variable [comm_monoid α]
+
+@[simp]
+lemma prod_map_pow {s : finset ι} {f : ι → ℕ} {a : α} :
+  finset.prod s (λ (i : ι), a ^ (f i)) = a ^ (finset.sum s f) :=
+begin
+  unfold finset.prod, unfold finset.sum,
+  rw multiset.prod_map_pow,
+end
+
+end comm_monoid
+
+section comm_group
+
+variable [comm_group α]
+
+@[simp]
+lemma prod_map_zpow {s : finset ι} {f : ι → ℤ} {a : α} :
+  finset.prod s (λ (i : ι), a ^ (f i)) = a ^ (finset.sum s f) :=
+begin
+  unfold finset.prod, unfold finset.sum,
+  rw multiset.prod_map_zpow,
+end
+
+end comm_group
+end finset
+
+/- End of stuff to be put elsewhere -/
 /-!
 # Cycle Types
 
@@ -26,6 +97,7 @@ In this file we define the cycle type of a permutation.
 - `lcm_cycle_type` : The lcm of `σ.cycle_type` equals `order_of σ`
 - `is_conj_iff_cycle_type_eq` : Two permutations are conjugate if and only if they have the same
   cycle type.
+- `sign_of_cycle_type` : Expresses the signature of a permutation from its cycle type.
 * `exists_prime_order_of_dvd_card`: For every prime `p` dividing the order of a finite group `G`
   there exists an element of order `p` in `G`. This is known as Cauchy`s theorem.
 -/
@@ -152,6 +224,17 @@ cycle_induction_on (λ τ : perm α, sign τ = (τ.cycle_type.map (λ n, -(-1 : 
   (λ σ hσ, by rw [hσ.sign, hσ.cycle_type, coe_map, coe_prod,
     list.map_singleton, list.prod_singleton])
   (λ σ τ hστ hc hσ hτ, by rw [sign_mul, hσ, hτ, hστ.cycle_type, multiset.map_add, prod_add])
+
+/-- Expresses signature from cycle type -/
+lemma sign_of_cycle_type' (σ : perm α) :
+  σ.sign = (-1)^(σ.cycle_type.sum + σ.cycle_type.card) :=
+begin
+  have aux : ∀ n : ℕ, n ∈ σ.cycle_type → -(-1 : units ℤ) ^ n = (-1) * (-1) ^ n :=
+    λ n h, units.neg_eq_neg_one_mul _,
+  rw [sign_of_cycle_type, multiset.map_congr aux, multiset.prod_map_mul,
+  add_comm, pow_add, multiset.map_const, multiset.prod_repeat, mul_right_inj,
+  multiset.prod_map_pow, multiset.map_id'],
+end
 
 lemma lcm_cycle_type (σ : perm α) : σ.cycle_type.lcm = order_of σ :=
 cycle_induction_on (λ τ : perm α, τ.cycle_type.lcm = order_of τ) σ
@@ -560,7 +643,7 @@ by rw [←card_cycle_type_eq_one, h.cycle_type, card_singleton]
 
 lemma sign (h : is_three_cycle σ) : sign σ = 1 :=
 begin
-  rw [sign_of_cycle_type, h.cycle_type],
+  rw [sign_of_cycle_type', h.cycle_type],
   refl,
 end
 

--- a/src/group_theory/specific_groups/alternating.lean
+++ b/src/group_theory/specific_groups/alternating.lean
@@ -262,10 +262,19 @@ begin
   rw [← multiset.eq_repeat'] at h2,
   have h56 : 5 ≤ 3 * 2 := nat.le_succ 5,
   have h := le_of_mul_le_mul_right (le_trans h h56) dec_trivial,
-  rw [mem_alternating_group, sign_of_cycle_type, h2, multiset.map_repeat, multiset.prod_repeat,
+  have ha' : even (multiset.card g.cycle_type),
+  { /-
+    rw [mem_alternating_group, sign_of_cycle_type, h2] at ha,
+    rw [multiset.map_repeat, multiset.prod_repeat,
     int.units_pow_two, units.ext_iff, units.coe_one, units.coe_pow, units.coe_neg_one,
       nat.neg_one_pow_eq_one_iff_even _] at ha,
+    swap, { dec_trivial }, -/
+  rw [mem_alternating_group, sign_of_cycle_type', h2, units.ext_iff, units.coe_one,
+    units.coe_pow, units.coe_neg_one, nat.neg_one_pow_eq_one_iff_even _] at ha,
   swap, { dec_trivial },
+  rw [multiset.sum_repeat, algebra.id.smul_eq_mul, multiset.card_repeat] at ha,
+  refine (nat.even_add.mp ha).mp _,
+  apply nat.even.mul_right _, dec_trivial },
   rw [is_conj_iff_cycle_type_eq, h2],
   interval_cases multiset.card g.cycle_type,
   { exact (h1 (card_cycle_type_eq_zero.1 h_1)).elim },
@@ -322,10 +331,12 @@ instance is_simple_group_five : is_simple_group (alternating_group (fin 5)) :=
   { -- The case `n = 4` leads to contradiction, as no element of $A_5$ includes a 4-cycle.
     have con := mem_alternating_group.1 gA,
     contrapose! con,
+    /-
     rw [sign_of_cycle_type, cycle_type_of_card_le_mem_cycle_type_add_two dec_trivial ng,
-      multiset.map_singleton, multiset.prod_singleton],
+      multiset.map_singleton, multiset.prod_singleton], -/
+    rw [sign_of_cycle_type', cycle_type_of_card_le_mem_cycle_type_add_two dec_trivial ng],
     dec_trivial },
-  { -- If `n = 5`, then `g` is itself a 5-cycle, conjugate to `fin_rotate 5`.
+   { -- If `n = 5`, then `g` is itself a 5-cycle, conjugate to `fin_rotate 5`.
     refine (is_conj_iff_cycle_type_eq.2 _).normal_closure_eq_top_of
       normal_closure_fin_rotate_five,
     rw [cycle_type_of_card_le_mem_cycle_type_add_two dec_trivial ng, cycle_type_fin_rotate] }


### PR DESCRIPTION
Add sign_of_cycle_type'

It gives a simpler formula than sign_of_cycle_type
Modifications are made to alternating_group.lean so that it uses this new formula.
Four lemmas of the form pow_map_pow, for finsets and multisets,  to be displaced elsewhere.

This PR cancels another one #11233 because Lean went out of control on that branch on my computer.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
