### PR TITLE
[Merged by Bors] - feat(set_theory/ordinal): `ordinal` is a successor order

### DIFF
--- a/src/set_theory/ordinal.lean
+++ b/src/set_theory/ordinal.lean
@@ -5,6 +5,7 @@ Authors: Mario Carneiro, Floris van Doorn
 -/
 import set_theory.cardinal
 import order.conditionally_complete_lattice
+import order.succ_pred
 
 /-!
 # Ordinals
@@ -1029,6 +1030,8 @@ instance : linear_order ordinal :=
   ..ordinal.partial_order }
 
 instance : is_well_order ordinal (<) := ⟨wf⟩
+
+instance : succ_order ordinal := succ_order.of_succ_le_iff succ (λ _ _, succ_le)
 
 @[simp] lemma typein_le_typein (r : α → α → Prop) [is_well_order α r] {x x' : α} :
   typein r x ≤ typein r x' ↔ ¬r x' x :=


### PR DESCRIPTION
This provides the `succ_order` instance for `ordinal`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

Requested by @alexjbest 

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
