### PR TITLE
[Merged by Bors] - feat(ring_theory/power_series): teach simp to simplify more coercions of polynomials  to power series

### DIFF
--- a/src/ring_theory/power_series/basic.lean
+++ b/src/ring_theory/power_series/basic.lean
@@ -780,9 +780,21 @@ by simp only [coeff_coe, mv_power_series.coeff_mul, coeff_mul]
   ((C a : mv_polynomial σ R) : mv_power_series σ R) = mv_power_series.C σ R a :=
 coe_monomial _ _
 
+@[simp, norm_cast] lemma coe_bit0 :
+  ((bit0 φ : mv_polynomial σ R) : mv_power_series σ R) = bit0 (φ : mv_power_series σ R) :=
+coe_add _ _
+
+@[simp, norm_cast] lemma coe_bit1 :
+  ((bit1 φ : mv_polynomial σ R) : mv_power_series σ R) = bit1 (φ : mv_power_series σ R) :=
+by rw [bit1, bit1, coe_add, coe_one, coe_bit0]
+
 @[simp, norm_cast] lemma coe_X (s : σ) :
   ((X s : mv_polynomial σ R) : mv_power_series σ R) = mv_power_series.X s :=
 coe_monomial _ _
+
+@[simp, norm_cast] lemma coe_X_pow (n : ℕ) (i : σ) :
+  ((X i ^ n : mv_polynomial σ R) : mv_power_series σ R) = mv_power_series.X i ^ n :=
+by { rw [X_pow_eq_monomial, mv_power_series.X_pow_eq], exact coe_monomial _ 1 }
 
 variables (σ R)
 
@@ -1811,9 +1823,21 @@ begin
   rwa power_series.monomial_zero_eq_C_apply at this,
 end
 
+@[simp, norm_cast] lemma coe_bit0 :
+  ((bit0 φ : polynomial R) : power_series R) = bit0 (φ : power_series R) :=
+coe_add φ φ
+
+@[simp, norm_cast] lemma coe_bit1 :
+  ((bit1 φ : polynomial R) : power_series R) = bit1 (φ : power_series R) :=
+by rw [bit1, bit1, coe_add, coe_one, coe_bit0]
+
 @[simp, norm_cast] lemma coe_X :
   ((X : polynomial R) : power_series R) = power_series.X :=
 coe_monomial _ _
+
+@[simp, norm_cast] lemma coe_X_pow (n : ℕ) :
+  ((X ^ n : polynomial R) : power_series R) = power_series.X ^ n :=
+by { rw [X_pow_eq_monomial, power_series.X_pow_eq], exact coe_monomial n 1 }
 
 variables (R)
 

--- a/src/ring_theory/power_series/basic.lean
+++ b/src/ring_theory/power_series/basic.lean
@@ -792,10 +792,6 @@ by rw [bit1, bit1, coe_add, coe_one, coe_bit0]
   ((X s : mv_polynomial σ R) : mv_power_series σ R) = mv_power_series.X s :=
 coe_monomial _ _
 
-@[simp, norm_cast] lemma coe_X_pow (n : ℕ) (i : σ) :
-  ((X i ^ n : mv_polynomial σ R) : mv_power_series σ R) = mv_power_series.X i ^ n :=
-by { rw [X_pow_eq_monomial, mv_power_series.X_pow_eq], exact coe_monomial _ 1 }
-
 variables (σ R)
 
 lemma coe_injective : function.injective (coe : mv_polynomial σ R → mv_power_series σ R) :=
@@ -822,6 +818,10 @@ def coe_to_mv_power_series.ring_hom : mv_polynomial σ R →+* mv_power_series �
   map_one' := coe_one,
   map_add' := coe_add,
   map_mul' := coe_mul }
+
+@[simp, norm_cast] lemma coe_pow (n : ℕ) :
+  ((φ ^ n : mv_polynomial σ R) : mv_power_series σ R) = (φ : mv_power_series σ R) ^ n :=
+coe_to_mv_power_series.ring_hom.map_pow _ _
 
 variables (φ ψ)
 
@@ -1835,10 +1835,6 @@ by rw [bit1, bit1, coe_add, coe_one, coe_bit0]
   ((X : polynomial R) : power_series R) = power_series.X :=
 coe_monomial _ _
 
-@[simp, norm_cast] lemma coe_X_pow (n : ℕ) :
-  ((X ^ n : polynomial R) : power_series R) = power_series.X ^ n :=
-by { rw [X_pow_eq_monomial, power_series.X_pow_eq], exact coe_monomial n 1 }
-
 variables (R)
 
 lemma coe_injective : function.injective (coe : polynomial R → power_series R) :=
@@ -1869,6 +1865,10 @@ def coe_to_power_series.ring_hom : polynomial R →+* power_series R :=
   map_mul' := coe_mul }
 
 @[simp] lemma coe_to_power_series.ring_hom_apply : coe_to_power_series.ring_hom φ = φ := rfl
+
+@[simp, norm_cast] lemma coe_pow (n : ℕ):
+  ((φ ^ n : polynomial R) : power_series R) = (φ : power_series R) ^ n :=
+coe_to_power_series.ring_hom.map_pow _ _
 
 variables (A : Type*) [semiring A] [algebra R A]
 


### PR DESCRIPTION
So that simp can prove that the polynomial `5 * X^2 + X + 1` coerced to a power series is the same thing with the power series generator `X`. Likewise for `mv_power_series`.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
