### PR TITLE
[Merged by Bors] - feat(data/matrix/basic): infix notation for matrix.dot_product in locale matrix

### DIFF
--- a/src/data/matrix/basic.lean
+++ b/src/data/matrix/basic.lean
@@ -17,6 +17,15 @@ import data.fintype.card
 
 This file defines basic properties of matrices.
 
+## Notation
+
+The locale `matrix` gives the following notation:
+
+* `⬝ᵥ` for `matrix.dot_product`
+* `⬝` for `matrix.mul`
+* `ᵀ` for `matrix.transpose`
+* `ᴴ` for `matrix.conj_transpose`
+
 ## TODO
 
 Under various conditions, multiplication of infinite matrices makes sense.

--- a/src/data/matrix/basic.lean
+++ b/src/data/matrix/basic.lean
@@ -303,8 +303,8 @@ variable [fintype m]
 def dot_product [has_mul α] [add_comm_monoid α] (v w : m → α) : α :=
 ∑ i, v i * w i
 
-/- the precedence of ` ⬝ᵥ ` for `matrix.dot_product` is set as to come
-   immediately after ` • ` for `has_scalar.smul` -/
+/- The precedence of 72 comes immediately after ` • ` for `has_scalar.smul`,
+   so that `r₁ • a ⬝ᵥ r₂ • b` is parsed as `(r₁ • a) ⬝ᵥ (r₂ • b)` here. -/
 localized "infix  ` ⬝ᵥ `:72 := matrix.dot_product" in matrix
 
 lemma dot_product_assoc [fintype n] [non_unital_semiring α] (u : m → α) (w : n → α)
@@ -371,7 +371,7 @@ variables [ring α] (u v w : m → α)
 
 @[simp] lemma dot_product_neg : v ⬝ᵥ (-w) = - (v ⬝ᵥ w) := by simp [dot_product]
 
-@[simp] lemma sub_dot_product : (u - v) ⬝ᵥ w = u ⬝ᵥ w - (v ⬝ᵥ w) :=
+@[simp] lemma sub_dot_product : (u - v) ⬝ᵥ w = u ⬝ᵥ w - v ⬝ᵥ w :=
 by simp [sub_eq_add_neg]
 
 @[simp] lemma dot_product_sub : u ⬝ᵥ (v - w) = u ⬝ᵥ v - u ⬝ᵥ w :=
@@ -398,10 +398,10 @@ variables [semiring α] [star_ring α] (v w : m → α)
 lemma star_dot_product_star : star v ⬝ᵥ star w = star (w ⬝ᵥ v) :=
 by simp [dot_product]
 
-lemma star_dot_product : (star v) ⬝ᵥ w = star ((star w) ⬝ᵥ v) :=
+lemma star_dot_product : star v ⬝ᵥ w = star (star w ⬝ᵥ v) :=
 by simp [dot_product]
 
-lemma dot_product_star : v ⬝ᵥ (star w) = star (w ⬝ᵥ (star v)) :=
+lemma dot_product_star : v ⬝ᵥ star w = star (w ⬝ᵥ star v) :=
 by simp [dot_product]
 
 end star_ring

--- a/src/data/matrix/basic.lean
+++ b/src/data/matrix/basic.lean
@@ -395,7 +395,7 @@ end distrib_mul_action
 section star_ring
 variables [semiring α] [star_ring α] (v w : m → α)
 
-lemma star_dot_product_star : (star v) ⬝ᵥ (star w) = star (w ⬝ᵥ v) :=
+lemma star_dot_product_star : star v ⬝ᵥ star w = star (w ⬝ᵥ v) :=
 by simp [dot_product]
 
 lemma star_dot_product : (star v) ⬝ᵥ w = star ((star w) ⬝ᵥ v) :=

--- a/src/data/matrix/basic.lean
+++ b/src/data/matrix/basic.lean
@@ -303,34 +303,36 @@ variable [fintype m]
 def dot_product [has_mul α] [add_comm_monoid α] (v w : m → α) : α :=
 ∑ i, v i * w i
 
+localized "infix  ` ⬝ᵥ `:67 := matrix.dot_product" in matrix
+
 lemma dot_product_assoc [fintype n] [non_unital_semiring α] (u : m → α) (w : n → α)
   (v : matrix m n α) :
-  dot_product (λ j, dot_product u (λ i, v i j)) w = dot_product u (λ i, dot_product (v i) w) :=
+  (λ j, u ⬝ᵥ (λ i, v i j)) ⬝ᵥ w = u ⬝ᵥ (λ i, (v i) ⬝ᵥ w) :=
 by simpa [dot_product, finset.mul_sum, finset.sum_mul, mul_assoc] using finset.sum_comm
 
 lemma dot_product_comm [comm_semiring α] (v w : m → α) :
-  dot_product v w = dot_product w v :=
+  v ⬝ᵥ w = w ⬝ᵥ v :=
 by simp_rw [dot_product, mul_comm]
 
 @[simp] lemma dot_product_punit [add_comm_monoid α] [has_mul α] (v w : punit → α) :
-  dot_product v w = v ⟨⟩ * w ⟨⟩ :=
+  v ⬝ᵥ w = v ⟨⟩ * w ⟨⟩ :=
 by simp [dot_product]
 
 section non_unital_non_assoc_semiring
 variables [non_unital_non_assoc_semiring α] (u v w : m → α)
 
-@[simp] lemma dot_product_zero : dot_product v 0 = 0 := by simp [dot_product]
+@[simp] lemma dot_product_zero : v ⬝ᵥ 0 = 0 := by simp [dot_product]
 
-@[simp] lemma dot_product_zero' : dot_product v (λ _, 0) = 0 := dot_product_zero v
+@[simp] lemma dot_product_zero' : v ⬝ᵥ (λ _, 0) = 0 := dot_product_zero v
 
-@[simp] lemma zero_dot_product : dot_product 0 v = 0 := by simp [dot_product]
+@[simp] lemma zero_dot_product : 0 ⬝ᵥ v = 0 := by simp [dot_product]
 
-@[simp] lemma zero_dot_product' : dot_product (λ _, (0 : α)) v = 0 := zero_dot_product v
+@[simp] lemma zero_dot_product' : (λ _, (0 : α)) ⬝ᵥ v = 0 := zero_dot_product v
 
-@[simp] lemma add_dot_product : dot_product (u + v) w = dot_product u w + dot_product v w :=
+@[simp] lemma add_dot_product : (u + v) ⬝ᵥ w = u ⬝ᵥ w + v ⬝ᵥ w :=
 by simp [dot_product, add_mul, finset.sum_add_distrib]
 
-@[simp] lemma dot_product_add : dot_product u (v + w) = dot_product u v + dot_product u w :=
+@[simp] lemma dot_product_add : u ⬝ᵥ (v + w) = u ⬝ᵥ v + u ⬝ᵥ w :=
 by simp [dot_product, mul_add, finset.sum_add_distrib]
 
 end non_unital_non_assoc_semiring
@@ -338,23 +340,23 @@ end non_unital_non_assoc_semiring
 section non_unital_non_assoc_semiring_decidable
 variables [decidable_eq m] [non_unital_non_assoc_semiring α] (u v w : m → α)
 
-@[simp] lemma diagonal_dot_product (i : m) : dot_product (diagonal v i) w = v i * w i :=
+@[simp] lemma diagonal_dot_product (i : m) : (diagonal v i) ⬝ᵥ w = v i * w i :=
 have ∀ j ≠ i, diagonal v i j * w j = 0 := λ j hij, by simp [diagonal_apply_ne' hij],
 by convert finset.sum_eq_single i (λ j _, this j) _ using 1; simp
 
-@[simp] lemma dot_product_diagonal (i : m) : dot_product v (diagonal w i) = v i * w i :=
+@[simp] lemma dot_product_diagonal (i : m) : v ⬝ᵥ (diagonal w i) = v i * w i :=
 have ∀ j ≠ i, v j * diagonal w i j = 0 := λ j hij, by simp [diagonal_apply_ne' hij],
 by convert finset.sum_eq_single i (λ j _, this j) _ using 1; simp
 
-@[simp] lemma dot_product_diagonal' (i : m) : dot_product v (λ j, diagonal w j i) = v i * w i :=
+@[simp] lemma dot_product_diagonal' (i : m) : v ⬝ᵥ (λ j, diagonal w j i) = v i * w i :=
 have ∀ j ≠ i, v j * diagonal w j i = 0 := λ j hij, by simp [diagonal_apply_ne hij],
 by convert finset.sum_eq_single i (λ j _, this j) _ using 1; simp
 
-@[simp] lemma single_dot_product (x : α) (i : m) : dot_product (pi.single i x) v = x * v i :=
+@[simp] lemma single_dot_product (x : α) (i : m) : (pi.single i x) ⬝ᵥ v = x * v i :=
 have ∀ j ≠ i, pi.single i x j * v j = 0 := λ j hij, by simp [pi.single_eq_of_ne hij],
 by convert finset.sum_eq_single i (λ j _, this j) _ using 1; simp
 
-@[simp] lemma dot_product_single (x : α) (i : m) : dot_product v (pi.single i x) = v i * x :=
+@[simp] lemma dot_product_single (x : α) (i : m) : v ⬝ᵥ (pi.single i x) = v i * x :=
 have ∀ j ≠ i, v j * pi.single i x j = 0 := λ j hij, by simp [pi.single_eq_of_ne hij],
 by convert finset.sum_eq_single i (λ j _, this j) _ using 1; simp
 
@@ -363,14 +365,14 @@ end non_unital_non_assoc_semiring_decidable
 section ring
 variables [ring α] (u v w : m → α)
 
-@[simp] lemma neg_dot_product : dot_product (-v) w = - dot_product v w := by simp [dot_product]
+@[simp] lemma neg_dot_product : (-v) ⬝ᵥ w = - (v ⬝ᵥ w) := by simp [dot_product]
 
-@[simp] lemma dot_product_neg : dot_product v (-w) = - dot_product v w := by simp [dot_product]
+@[simp] lemma dot_product_neg : v ⬝ᵥ (-w) = - (v ⬝ᵥ w) := by simp [dot_product]
 
-@[simp] lemma sub_dot_product : dot_product (u - v) w = dot_product u w - dot_product v w :=
+@[simp] lemma sub_dot_product : (u - v) ⬝ᵥ w = u ⬝ᵥ w - (v ⬝ᵥ w) :=
 by simp [sub_eq_add_neg]
 
-@[simp] lemma dot_product_sub : dot_product u (v - w) = dot_product u v - dot_product u w :=
+@[simp] lemma dot_product_sub : u ⬝ᵥ (v - w) = u ⬝ᵥ v - u ⬝ᵥ w :=
 by simp [sub_eq_add_neg]
 
 end ring
@@ -379,11 +381,11 @@ section distrib_mul_action
 variables [monoid R] [has_mul α] [add_comm_monoid α] [distrib_mul_action R α]
 
 @[simp] lemma smul_dot_product [is_scalar_tower R α α] (x : R) (v w : m → α) :
-  dot_product (x • v) w = x • dot_product v w :=
+  (x • v) ⬝ᵥ w = x • (v ⬝ᵥ w) :=
 by simp [dot_product, finset.smul_sum, smul_mul_assoc]
 
 @[simp] lemma dot_product_smul [smul_comm_class R α α] (x : R) (v w : m → α)  :
-  dot_product v (x • w) = x • dot_product v w :=
+  v ⬝ᵥ (x • w) = x • (v ⬝ᵥ w) :=
 by simp [dot_product, finset.smul_sum, mul_smul_comm]
 
 end distrib_mul_action
@@ -391,25 +393,27 @@ end distrib_mul_action
 section star_ring
 variables [semiring α] [star_ring α] (v w : m → α)
 
-lemma star_dot_product_star : dot_product (star v) (star w) = star (dot_product w v) :=
+lemma star_dot_product_star : (star v) ⬝ᵥ (star w) = star (w ⬝ᵥ v) :=
 by simp [dot_product]
 
-lemma star_dot_product : dot_product (star v) w = star (dot_product (star w) v) :=
+lemma star_dot_product : (star v) ⬝ᵥ w = star ((star w) ⬝ᵥ v) :=
 by simp [dot_product]
 
-lemma dot_product_star : dot_product v (star w) = star (dot_product w (star v)) :=
+lemma dot_product_star : v ⬝ᵥ (star w) = star (w ⬝ᵥ (star v)) :=
 by simp [dot_product]
 
 end star_ring
 
 end dot_product
 
+open_locale matrix
+
 /-- `M ⬝ N` is the usual product of matrices `M` and `N`, i.e. we have that
 `(M ⬝ N) i k` is the dot product of the `i`-th row of `M` by the `k`-th column of `N`.
 This is currently only defined when `m` is finite. -/
 protected def mul [fintype m] [has_mul α] [add_comm_monoid α]
   (M : matrix l m α) (N : matrix m n α) : matrix l n α :=
-λ i k, dot_product (λ j, M i j) (λ j, N j k)
+λ i k, (λ j, M i j) ⬝ᵥ (λ j, N j k)
 
 localized "infixl ` ⬝ `:75 := matrix.mul" in matrix
 
@@ -422,7 +426,7 @@ instance [fintype n] [has_mul α] [add_comm_monoid α] : has_mul (matrix n n α)
   M * N = M ⬝ N := rfl
 
 theorem mul_apply' [fintype m] [has_mul α] [add_comm_monoid α]
-  {M : matrix l m α} {N : matrix m n α} {i k} : (M ⬝ N) i k = dot_product (λ j, M i j) (λ j, N j k)
+  {M : matrix l m α} {N : matrix m n α} {i k} : (M ⬝ N) i k = (λ j, M i j) ⬝ᵥ (λ j, N j k)
   := rfl
 
 @[simp] theorem diagonal_neg [decidable_eq n] [add_group α] (d : n → α) :
@@ -946,13 +950,13 @@ variables [non_unital_non_assoc_semiring α]
     Put another way, `mul_vec M v` is the vector whose entries
     are those of `M ⬝ col v` (see `col_mul_vec`). -/
 def mul_vec [fintype n] (M : matrix m n α) (v : n → α) : m → α
-| i := dot_product (λ j, M i j) v
+| i := (λ j, M i j) ⬝ᵥ v
 
 /-- `vec_mul v M` is the vector-matrix product of `v` and `M`, where `v` is seen as a row matrix.
     Put another way, `vec_mul v M` is the vector whose entries
     are those of `row v ⬝ M` (see `row_vec_mul`). -/
 def vec_mul [fintype m] (v : m → α) (M : matrix m n α) : n → α
-| j := dot_product v (λ i, M i j)
+| j := v ⬝ᵥ (λ i, M i j)
 
 /-- Left multiplication by a matrix, as an `add_monoid_hom` from vectors to vectors. -/
 @[simps] def mul_vec.add_monoid_hom_left [fintype n] (v : n → α) : matrix m n α →+ m → α :=
@@ -971,7 +975,7 @@ dot_product_diagonal' v w x
 /-- Associate the dot product of `mul_vec` to the left. -/
 lemma dot_product_mul_vec [fintype n] [fintype m] [non_unital_semiring R]
   (v : m → R) (A : matrix m n R) (w : n → R) :
-  dot_product v (mul_vec A w) = dot_product (vec_mul v A) w :=
+  v ⬝ᵥ (mul_vec A w) = (vec_mul v A) ⬝ᵥ w :=
 by simp only [dot_product, vec_mul, mul_vec, finset.mul_sum, finset.sum_mul, mul_assoc];
    exact finset.sum_comm
 
@@ -1534,7 +1538,7 @@ lemma row_mul_vec [fintype n] [semiring α] (M : matrix m n α) (v : n → α) :
 
 @[simp]
 lemma row_mul_col_apply [fintype m] [has_mul α] [add_comm_monoid α] (v w : m → α) (i j) :
-  (row v ⬝ col w) i j = dot_product v w :=
+  (row v ⬝ col w) i j = v ⬝ᵥ w :=
 rfl
 
 end row_col
@@ -1663,7 +1667,7 @@ lemma map_matrix_mul (M : matrix m n α) (N : matrix n o α) (i : m) (j : o) (f 
 by simp [matrix.mul_apply, ring_hom.map_sum]
 
 lemma map_dot_product [semiring R] [semiring S] (f : R →+* S) (v w : n → R) :
-  f (matrix.dot_product v w) = matrix.dot_product (f ∘ v) (f ∘ w) :=
+  f (v ⬝ᵥ w) = (f ∘ v) ⬝ᵥ (f ∘ w) :=
 by simp only [matrix.dot_product, f.map_sum, f.map_mul]
 
 lemma map_vec_mul [semiring R] [semiring S]

--- a/src/data/matrix/basic.lean
+++ b/src/data/matrix/basic.lean
@@ -303,8 +303,8 @@ variable [fintype m]
 def dot_product [has_mul α] [add_comm_monoid α] (v w : m → α) : α :=
 ∑ i, v i * w i
 
-/- the precedence of ` ⬝ᵥ ` for `matrix.dot_product` is set to come immediately after
-    ` • ` for `has_scalar.smul` -/
+/- the precedence of ` ⬝ᵥ ` for `matrix.dot_product` is set as to come
+   immediately after ` • ` for `has_scalar.smul` -/
 localized "infix  ` ⬝ᵥ `:72 := matrix.dot_product" in matrix
 
 lemma dot_product_assoc [fintype n] [non_unital_semiring α] (u : m → α) (w : n → α)

--- a/src/data/matrix/basic.lean
+++ b/src/data/matrix/basic.lean
@@ -303,7 +303,9 @@ variable [fintype m]
 def dot_product [has_mul α] [add_comm_monoid α] (v w : m → α) : α :=
 ∑ i, v i * w i
 
-localized "infix  ` ⬝ᵥ `:67 := matrix.dot_product" in matrix
+/- the precedence of ` ⬝ᵥ ` for `matrix.dot_product` is set to come immediately after
+    ` • ` for `has_scalar.smul` -/
+localized "infix  ` ⬝ᵥ `:72 := matrix.dot_product" in matrix
 
 lemma dot_product_assoc [fintype n] [non_unital_semiring α] (u : m → α) (w : n → α)
   (v : matrix m n α) :

--- a/src/data/matrix/basic.lean
+++ b/src/data/matrix/basic.lean
@@ -351,11 +351,11 @@ end non_unital_non_assoc_semiring
 section non_unital_non_assoc_semiring_decidable
 variables [decidable_eq m] [non_unital_non_assoc_semiring α] (u v w : m → α)
 
-@[simp] lemma diagonal_dot_product (i : m) : (diagonal v i) ⬝ᵥ w = v i * w i :=
+@[simp] lemma diagonal_dot_product (i : m) : diagonal v i ⬝ᵥ w = v i * w i :=
 have ∀ j ≠ i, diagonal v i j * w j = 0 := λ j hij, by simp [diagonal_apply_ne' hij],
 by convert finset.sum_eq_single i (λ j _, this j) _ using 1; simp
 
-@[simp] lemma dot_product_diagonal (i : m) : v ⬝ᵥ (diagonal w i) = v i * w i :=
+@[simp] lemma dot_product_diagonal (i : m) : v ⬝ᵥ diagonal w i = v i * w i :=
 have ∀ j ≠ i, v j * diagonal w i j = 0 := λ j hij, by simp [diagonal_apply_ne' hij],
 by convert finset.sum_eq_single i (λ j _, this j) _ using 1; simp
 
@@ -363,11 +363,11 @@ by convert finset.sum_eq_single i (λ j _, this j) _ using 1; simp
 have ∀ j ≠ i, v j * diagonal w j i = 0 := λ j hij, by simp [diagonal_apply_ne hij],
 by convert finset.sum_eq_single i (λ j _, this j) _ using 1; simp
 
-@[simp] lemma single_dot_product (x : α) (i : m) : (pi.single i x) ⬝ᵥ v = x * v i :=
+@[simp] lemma single_dot_product (x : α) (i : m) : pi.single i x ⬝ᵥ v = x * v i :=
 have ∀ j ≠ i, pi.single i x j * v j = 0 := λ j hij, by simp [pi.single_eq_of_ne hij],
 by convert finset.sum_eq_single i (λ j _, this j) _ using 1; simp
 
-@[simp] lemma dot_product_single (x : α) (i : m) : v ⬝ᵥ (pi.single i x) = v i * x :=
+@[simp] lemma dot_product_single (x : α) (i : m) : v ⬝ᵥ pi.single i x = v i * x :=
 have ∀ j ≠ i, v j * pi.single i x j = 0 := λ j hij, by simp [pi.single_eq_of_ne hij],
 by convert finset.sum_eq_single i (λ j _, this j) _ using 1; simp
 
@@ -376,9 +376,9 @@ end non_unital_non_assoc_semiring_decidable
 section ring
 variables [ring α] (u v w : m → α)
 
-@[simp] lemma neg_dot_product : (-v) ⬝ᵥ w = - (v ⬝ᵥ w) := by simp [dot_product]
+@[simp] lemma neg_dot_product : -v ⬝ᵥ w = - (v ⬝ᵥ w) := by simp [dot_product]
 
-@[simp] lemma dot_product_neg : v ⬝ᵥ (-w) = - (v ⬝ᵥ w) := by simp [dot_product]
+@[simp] lemma dot_product_neg : v ⬝ᵥ -w = - (v ⬝ᵥ w) := by simp [dot_product]
 
 @[simp] lemma sub_dot_product : (u - v) ⬝ᵥ w = u ⬝ᵥ w - v ⬝ᵥ w :=
 by simp [sub_eq_add_neg]
@@ -986,7 +986,7 @@ dot_product_diagonal' v w x
 /-- Associate the dot product of `mul_vec` to the left. -/
 lemma dot_product_mul_vec [fintype n] [fintype m] [non_unital_semiring R]
   (v : m → R) (A : matrix m n R) (w : n → R) :
-  v ⬝ᵥ (mul_vec A w) = (vec_mul v A) ⬝ᵥ w :=
+  v ⬝ᵥ mul_vec A w = vec_mul v A ⬝ᵥ w :=
 by simp only [dot_product, vec_mul, mul_vec, finset.mul_sum, finset.sum_mul, mul_assoc];
    exact finset.sum_comm
 


### PR DESCRIPTION
I created an infix notation for `matrix.dot_product` in locale `matrix`. The notation was consulted with @eric-wieser in #11181.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
