### PR TITLE
[Merged by Bors] - feat(linear_algebra/finite_dimensional): Define rank of set of vectors

### DIFF
--- a/docs/undergrad.yaml
+++ b/docs/undergrad.yaml
@@ -29,7 +29,7 @@ Linear algebra:
     finite-dimensionality : 'finite_dimensional'
     isomorphism with $K^n$: 'basis.equiv_fun'
     rank of a linear map: 'rank'
-    rank of a set of vectors: 'finite_dimensional.set.finrank'
+    rank of a set of vectors: 'set.finrank'
     rank of a system of linear equations: 'https://www.math.tamu.edu/~fnarc/psfiles/rank2005.pdf'
     isomorphism with bidual: 'module.eval_equiv'
   Multilinearity:

--- a/docs/undergrad.yaml
+++ b/docs/undergrad.yaml
@@ -29,7 +29,7 @@ Linear algebra:
     finite-dimensionality : 'finite_dimensional'
     isomorphism with $K^n$: 'basis.equiv_fun'
     rank of a linear map: 'rank'
-    rank of a set of vectors: 'https://encyclopediaofmath.org/wiki/Rank'
+    rank of a set of vectors: 'finite_dimensional.set.finrank'
     rank of a system of linear equations: 'https://www.math.tamu.edu/~fnarc/psfiles/rank2005.pdf'
     isomorphism with bidual: 'module.eval_equiv'
   Multilinearity:

--- a/src/linear_algebra/finite_dimensional.lean
+++ b/src/linear_algebra/finite_dimensional.lean
@@ -1143,6 +1143,8 @@ open submodule
 
 variable (K)
 
+
+/-- The rank of a set of vectors as a natural number. -/
 protected noncomputable def set.finrank (s : set V) : ℕ := finrank K (span K s)
 
 variable {K}

--- a/src/linear_algebra/finite_dimensional.lean
+++ b/src/linear_algebra/finite_dimensional.lean
@@ -1151,7 +1151,7 @@ lemma set.finrank_mono [finite_dimensional K V] {s t : set V} (h : s ⊆ t) :
   s.finrank K ≤ t.finrank K := finrank_mono (span_mono h)
 
 lemma finrank_span_le_card (s : set V) [fin : fintype s] :
-  s.finrank K ≤ s.to_finset.card :=
+  finrank K (span K s) ≤ s.to_finset.card :=
 begin
   haveI := span_of_finite K ⟨fin⟩,
   have : module.rank K (span K s) ≤ #s := dim_span_le s,
@@ -1176,7 +1176,7 @@ end
 
 lemma finrank_span_set_eq_card (s : set V) [fin : fintype s]
   (hs : linear_independent K (coe : s → V)) :
-  s.finrank K = s.to_finset.card :=
+  finrank K (span K s) = s.to_finset.card :=
 begin
   haveI := span_of_finite K ⟨fin⟩,
   have : module.rank K (span K s) = #s := dim_span_set hs,

--- a/src/linear_algebra/finite_dimensional.lean
+++ b/src/linear_algebra/finite_dimensional.lean
@@ -1166,7 +1166,7 @@ calc (s : set V).finrank K ≤ (s : set V).to_finset.card : finrank_span_le_card
 
 lemma finrank_span_eq_card {ι : Type*} [fintype ι] {b : ι → V}
   (hb : linear_independent K b) :
-  (set.range b).finrank K = fintype.card ι :=
+  finrank K (span K (set.range b)) = fintype.card ι :=
 begin
   haveI : finite_dimensional K (span K (set.range b)) := span_of_finite K (set.finite_range b),
   have : module.rank K (span K (set.range b)) = #(set.range b) := dim_span hb,
@@ -1186,7 +1186,7 @@ end
 
 lemma finrank_span_finset_eq_card (s : finset V)
   (hs : linear_independent K (coe : s → V)) :
-  (s : set V).finrank K = s.card :=
+  finrank K (span K (s : set V)) = s.card :=
 begin
   convert finrank_span_set_eq_card ↑s hs,
   ext,

--- a/src/linear_algebra/finite_dimensional.lean
+++ b/src/linear_algebra/finite_dimensional.lean
@@ -1143,7 +1143,7 @@ open submodule
 
 variable (K)
 
-noncomputable def set.finrank (s: set V) : ℕ := finrank K (span K s)
+protected noncomputable def set.finrank (s: set V) : ℕ := finrank K (span K s)
 
 variable {K}
 

--- a/src/linear_algebra/finite_dimensional.lean
+++ b/src/linear_algebra/finite_dimensional.lean
@@ -1143,7 +1143,7 @@ open submodule
 
 variable (K)
 
-protected noncomputable def set.finrank (s: set V) : ℕ := finrank K (span K s)
+protected noncomputable def set.finrank (s : set V) : ℕ := finrank K (span K s)
 
 variable {K}
 

--- a/src/linear_algebra/finite_dimensional.lean
+++ b/src/linear_algebra/finite_dimensional.lean
@@ -1156,7 +1156,7 @@ begin
   haveI := span_of_finite K ⟨fin⟩,
   have : module.rank K (span K s) ≤ #s := dim_span_le s,
   rw [←finrank_eq_dim, cardinal.mk_fintype, ←set.to_finset_card] at this,
-  exact_mod_cast this
+  exact_mod_cast this,
 end
 
 lemma finrank_span_finset_le_card (s : finset V)  :
@@ -1181,7 +1181,7 @@ begin
   haveI := span_of_finite K ⟨fin⟩,
   have : module.rank K (span K s) = #s := dim_span_set hs,
   rw [←finrank_eq_dim, cardinal.mk_fintype, ←set.to_finset_card] at this,
-  exact_mod_cast this
+  exact_mod_cast this,
 end
 
 lemma finrank_span_finset_eq_card (s : finset V)
@@ -1190,7 +1190,7 @@ lemma finrank_span_finset_eq_card (s : finset V)
 begin
   convert finrank_span_set_eq_card ↑s hs,
   ext,
-  simp
+  simp,
 end
 
 lemma span_lt_of_subset_of_card_lt_finrank {s : set V} [fintype s] {t : submodule K V}

--- a/src/linear_algebra/finite_dimensional.lean
+++ b/src/linear_algebra/finite_dimensional.lean
@@ -1147,11 +1147,8 @@ protected noncomputable def set.finrank (s: set V) : ℕ := finrank K (span K s)
 
 variable {K}
 
-lemma set.finrank_mono (s t: set V) [finite_dimensional K V] : s ⊆ t → s.finrank K ≤ t.finrank K :=
-begin
-  intro h,
-  exact finrank_mono (span_mono h),
-end
+lemma set.finrank_mono [finite_dimensional K V] {s t : set V} (h : s ⊆ t) : s.finrank K ≤ t.finrank K :=
+finrank_mono (span_mono h)
 
 lemma finrank_span_le_card (s : set V) [fin : fintype s] :
   s.finrank K ≤ s.to_finset.card :=

--- a/src/linear_algebra/finite_dimensional.lean
+++ b/src/linear_algebra/finite_dimensional.lean
@@ -1160,13 +1160,13 @@ begin
 end
 
 lemma finrank_span_finset_le_card (s : finset V)  :
-  finrank K (span K (s : set V)) ≤ s.card :=
-calc finrank K (span K (s : set V)) ≤ (s : set V).to_finset.card : finrank_span_le_card s
+  (s : set V).finrank K ≤ s.card :=
+calc (s : set V).finrank K ≤ (s : set V).to_finset.card : finrank_span_le_card s
                                 ... = s.card : by simp
 
 lemma finrank_span_eq_card {ι : Type*} [fintype ι] {b : ι → V}
   (hb : linear_independent K b) :
-  finrank K (span K (set.range b)) = fintype.card ι :=
+  (set.range b).finrank K = fintype.card ι :=
 begin
   haveI : finite_dimensional K (span K (set.range b)) := span_of_finite K (set.finite_range b),
   have : module.rank K (span K (set.range b)) = #(set.range b) := dim_span hb,
@@ -1186,7 +1186,7 @@ end
 
 lemma finrank_span_finset_eq_card (s : finset V)
   (hs : linear_independent K (coe : s → V)) :
-  finrank K (span K (s : set V)) = s.card :=
+  (s : set V).finrank K = s.card :=
 begin
   convert finrank_span_set_eq_card ↑s hs,
   ext,
@@ -1266,7 +1266,7 @@ end
 /-- A finite family of vectors is linearly independent if and only if
 its cardinality equals the dimension of its span. -/
 lemma linear_independent_iff_card_eq_finrank_span {ι : Type*} [fintype ι] {b : ι → V} :
-  linear_independent K b ↔ fintype.card ι = finrank K (span K (set.range b)) :=
+  linear_independent K b ↔ fintype.card ι = (set.range b).finrank K :=
 begin
   split,
   { intro h,

--- a/src/linear_algebra/finite_dimensional.lean
+++ b/src/linear_algebra/finite_dimensional.lean
@@ -1141,8 +1141,20 @@ section span
 
 open submodule
 
+variable (K)
+
+noncomputable def set.finrank (s: set V) : ℕ := finrank K (span K s)
+
+variable {K}
+
+lemma set.finrank_mono (s t: set V) [finite_dimensional K V] : s ⊆ t → s.finrank K ≤ t.finrank K :=
+begin
+  intro h,
+  exact finrank_mono (span_mono h),
+end
+
 lemma finrank_span_le_card (s : set V) [fin : fintype s] :
-  finrank K (span K s) ≤ s.to_finset.card :=
+  s.finrank K ≤ s.to_finset.card :=
 begin
   haveI := span_of_finite K ⟨fin⟩,
   have : module.rank K (span K s) ≤ #s := dim_span_le s,
@@ -1167,7 +1179,7 @@ end
 
 lemma finrank_span_set_eq_card (s : set V) [fin : fintype s]
   (hs : linear_independent K (coe : s → V)) :
-  finrank K (span K s) = s.to_finset.card :=
+  s.finrank K = s.to_finset.card :=
 begin
   haveI := span_of_finite K ⟨fin⟩,
   have : module.rank K (span K s) = #s := dim_span_set hs,

--- a/src/linear_algebra/finite_dimensional.lean
+++ b/src/linear_algebra/finite_dimensional.lean
@@ -1147,8 +1147,8 @@ protected noncomputable def set.finrank (s : set V) : ℕ := finrank K (span K s
 
 variable {K}
 
-lemma set.finrank_mono [finite_dimensional K V] {s t : set V} (h : s ⊆ t) : s.finrank K ≤ t.finrank K :=
-finrank_mono (span_mono h)
+lemma set.finrank_mono [finite_dimensional K V] {s t : set V} (h : s ⊆ t) :
+  s.finrank K ≤ t.finrank K := finrank_mono (span_mono h)
 
 lemma finrank_span_le_card (s : set V) [fin : fintype s] :
   s.finrank K ≤ s.to_finset.card :=


### PR DESCRIPTION
Added in the definition of "rank of a set of vectors" and a useful lemma about the rank when one set is a subset of the other.

Read the zulip stream here: https://leanprover.zulipchat.com/#narrow/stream/113489-new-members/topic/First.20Time.20Contributing

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
