### PR TITLE
[Merged by Bors] - feat(algebra,linear_algebra,ring_theory): more is_central_scalar instances

### DIFF
--- a/src/algebra/direct_sum/module.lean
+++ b/src/algebra/direct_sum/module.lean
@@ -38,6 +38,8 @@ instance {S : Type*} [semiring S] [Π i, module S (M i)] [Π i, smul_comm_class 
 instance {S : Type*} [semiring S] [has_scalar R S] [Π i, module S (M i)]
   [Π i, is_scalar_tower R S (M i)] :
   is_scalar_tower R S (⨁ i, M i) := dfinsupp.is_scalar_tower
+instance [Π i, module Rᵐᵒᵖ (M i)] [Π i, is_central_scalar R (M i)] :
+  is_central_scalar R (⨁ i, M i) := dfinsupp.is_central_scalar
 
 lemma smul_apply (b : R) (v : ⨁ i, M i) (i : ι) :
   (b • v) i = b • (v i) := dfinsupp.smul_apply _ _ _

--- a/src/algebra/lie/quotient.lean
+++ b/src/algebra/lie/quotient.lean
@@ -44,7 +44,14 @@ namespace quotient
 variables {N I}
 
 instance add_comm_group : add_comm_group (M ⧸ N) := submodule.quotient.add_comm_group _
+instance module' {S : Type*} [semiring S] [has_scalar S R] [module S M] [is_scalar_tower S R M] :
+  module S (M ⧸ N) := submodule.quotient.module' _
 instance module : module R (M ⧸ N) := submodule.quotient.module _
+instance is_central_scalar {S : Type*} [semiring S]
+  [has_scalar S R] [module S M] [is_scalar_tower S R M]
+  [has_scalar Sᵐᵒᵖ R] [module Sᵐᵒᵖ M] [is_scalar_tower Sᵐᵒᵖ R M]
+  [is_central_scalar S M] : is_central_scalar S (M ⧸ N) :=
+submodule.quotient.is_central_scalar _
 instance inhabited : inhabited (M ⧸ N) := ⟨0⟩
 
 /-- Map sending an element of `M` to the corresponding element of `M/N`, when `N` is a

--- a/src/algebra/lie/subalgebra.lean
+++ b/src/algebra/lie/subalgebra.lean
@@ -51,19 +51,39 @@ instance : inhabited (lie_subalgebra R L) := ⟨0⟩
 instance : has_coe (lie_subalgebra R L) (submodule R L) := ⟨lie_subalgebra.to_submodule⟩
 instance : has_mem L (lie_subalgebra R L) := ⟨λ x L', x ∈ (L' : set L)⟩
 
+namespace lie_subalgebra
+
 /-- A Lie subalgebra forms a new Lie ring. -/
-instance lie_subalgebra_lie_ring (L' : lie_subalgebra R L) : lie_ring L' :=
+instance (L' : lie_subalgebra R L) : lie_ring L' :=
 { bracket      := λ x y, ⟨⁅x.val, y.val⁆, L'.lie_mem' x.property y.property⟩,
   lie_add      := by { intros, apply set_coe.ext, apply lie_add, },
   add_lie      := by { intros, apply set_coe.ext, apply add_lie, },
   lie_self     := by { intros, apply set_coe.ext, apply lie_self, },
   leibniz_lie  := by { intros, apply set_coe.ext, apply leibniz_lie, } }
 
-/-- A Lie subalgebra forms a new Lie algebra. -/
-instance lie_subalgebra_lie_algebra (L' : lie_subalgebra R L) : lie_algebra R L' :=
-{ lie_smul := by { intros, apply set_coe.ext, apply lie_smul } }
+section
 
-namespace lie_subalgebra
+variables {R₁ : Type*} [semiring R₁]
+
+/-- A Lie subalgebra inherits module structures from `L`. -/
+instance [has_scalar R₁ R] [module R₁ L] [is_scalar_tower R₁ R L]
+  (L' : lie_subalgebra R L) : module R₁ L' :=
+L'.to_submodule.module'
+
+instance [has_scalar R₁ R] [has_scalar R₁ᵐᵒᵖ R] [module R₁ L] [module R₁ᵐᵒᵖ L]
+  [is_scalar_tower R₁ R L] [is_scalar_tower R₁ᵐᵒᵖ R L] [is_central_scalar R₁ L]
+  (L' : lie_subalgebra R L) : is_central_scalar R₁ L' :=
+L'.to_submodule.is_central_scalar
+
+instance [has_scalar R₁ R] [module R₁ L] [is_scalar_tower R₁ R L]
+  (L' : lie_subalgebra R L) : is_scalar_tower R₁ R L' :=
+L'.to_submodule.is_scalar_tower
+
+end
+
+/-- A Lie subalgebra forms a new Lie algebra. -/
+instance (L' : lie_subalgebra R L) : lie_algebra R L' :=
+{ lie_smul := by { intros, apply set_coe.ext, apply lie_smul } }
 
 variables {R L} (L' : lie_subalgebra R L)
 

--- a/src/algebra/lie/submodule.lean
+++ b/src/algebra/lie/submodule.lean
@@ -115,6 +115,17 @@ instance : lie_ring_module L N :=
   lie_add     := by { intros x m n, apply set_coe.ext, apply lie_add, },
   leibniz_lie := by { intros x y m, apply set_coe.ext, apply leibniz_lie, }, }
 
+instance module' {S : Type*} [semiring S] [has_scalar S R] [module S M] [is_scalar_tower S R M] :
+  module S N :=
+N.to_submodule.module'
+
+instance : module R N := N.to_submodule.module
+
+instance {S : Type*} [semiring S] [has_scalar S R] [has_scalar Sᵐᵒᵖ R] [module S M] [module Sᵐᵒᵖ M]
+  [is_scalar_tower S R M] [is_scalar_tower Sᵐᵒᵖ R M] [is_central_scalar S M] :
+  is_central_scalar S N :=
+N.to_submodule.is_central_scalar
+
 instance : lie_module R L N :=
 { lie_smul := by { intros t x y, apply set_coe.ext, apply lie_smul, },
   smul_lie := by { intros t x y, apply set_coe.ext, apply smul_lie, }, }

--- a/src/linear_algebra/quotient.lean
+++ b/src/linear_algebra/quotient.lean
@@ -113,13 +113,17 @@ quotient.has_scalar' P
 
 @[simp] theorem mk_smul (r : S) (x : M) : (mk (r • x) : M ⧸ p) = r • mk x := rfl
 
-instance (T : Type*) [has_scalar T R] [has_scalar T M] [is_scalar_tower T R M]
+instance smul_comm_class (T : Type*) [has_scalar T R] [has_scalar T M] [is_scalar_tower T R M]
   [smul_comm_class S T M] : smul_comm_class S T (M ⧸ P) :=
 { smul_comm := λ x y, quotient.ind' $ by exact λ z, congr_arg mk (smul_comm _ _ _) }
 
-instance (T : Type*) [has_scalar T R] [has_scalar T M] [is_scalar_tower T R M] [has_scalar S T]
-  [is_scalar_tower S T M] : is_scalar_tower S T (M ⧸ P) :=
+instance is_scalar_tower (T : Type*) [has_scalar T R] [has_scalar T M] [is_scalar_tower T R M]
+  [has_scalar S T] [is_scalar_tower S T M] : is_scalar_tower S T (M ⧸ P) :=
 { smul_assoc := λ x y, quotient.ind' $ by exact λ z, congr_arg mk (smul_assoc _ _ _) }
+
+instance is_central_scalar [has_scalar Sᵐᵒᵖ R] [has_scalar Sᵐᵒᵖ M] [is_scalar_tower Sᵐᵒᵖ R M]
+  [is_central_scalar S M] : is_central_scalar S (M ⧸ P) :=
+{ op_smul_eq_smul := λ x, quotient.ind' $ by exact λ z, congr_arg mk $ op_smul_eq_smul _ _ }
 
 end has_scalar
 

--- a/src/linear_algebra/tensor_product.lean
+++ b/src/linear_algebra/tensor_product.lean
@@ -274,6 +274,13 @@ instance left_module : module R'' (M ⊗[R] N) :=
 
 instance : module R (M ⊗[R] N) := tensor_product.left_module
 
+instance [module R''ᵐᵒᵖ M] [is_central_scalar R'' M] : is_central_scalar R'' (M ⊗[R] N) :=
+{ op_smul_eq_smul := λ r x,
+  tensor_product.induction_on x
+    (by rw [smul_zero, smul_zero])
+    (λ x y, by rw [smul_tmul', smul_tmul', op_smul_eq_smul])
+    (λ x y hx hy, by rw [smul_add, smul_add, hx, hy]) }
+
 section
 
 -- Like `R'`, `R'₂` provides a `distrib_mul_action R'₂ (M ⊗[R] N)`

--- a/src/ring_theory/adjoin_root.lean
+++ b/src/ring_theory/adjoin_root.lean
@@ -79,11 +79,11 @@ ideal.quotient.algebra S
 instance [comm_semiring S] [comm_semiring K] [has_scalar S K] [algebra S R] [algebra K R]
   [is_scalar_tower S K R] :
   is_scalar_tower S K (adjoin_root f) :=
-submodule.quotient.has_quotient.quotient.is_scalar_tower _ _
+submodule.quotient.is_scalar_tower _ _
 
 instance [comm_semiring S] [comm_semiring K] [algebra S R] [algebra K R] [smul_comm_class S K R] :
   smul_comm_class S K (adjoin_root f) :=
-submodule.quotient.has_quotient.quotient.smul_comm_class _ _
+submodule.quotient.smul_comm_class _ _
 
 @[simp] lemma algebra_map_eq : algebra_map R (adjoin_root f) = of f := rfl
 

--- a/src/ring_theory/derivation.lean
+++ b/src/ring_theory/derivation.lean
@@ -176,6 +176,10 @@ lemma smul_apply (r : S) (D : derivation R A M) : (r • D) a = r • D a := rfl
 instance : distrib_mul_action S (derivation R A M) :=
 function.injective.distrib_mul_action coe_fn_add_monoid_hom coe_injective coe_smul
 
+instance [distrib_mul_action Sᵐᵒᵖ M] [is_central_scalar S M] :
+  is_central_scalar S (derivation R A M) :=
+{ op_smul_eq_smul := λ _ _, ext $ λ _, op_smul_eq_smul _ _}
+
 end scalar
 
 @[priority 100]


### PR DESCRIPTION
This provides new transitive scalar actions:
* on `lie_submodule R L M` that match the actions on `submodule R M`
* on quotients by `lie_submodule R L M` that match the actions on quotients by `submodule R M`

The rest of the instances in this PR live in `Prop` so do not define any further actions.

This also fixes some overly verbose instance names.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
