### PR TITLE
[Merged by Bors] - feat(algebra/associated): generalize nat.prime.pow_dvd_of_dvd_mul_{left,right}

### DIFF
--- a/src/algebra/associated.lean
+++ b/src/algebra/associated.lean
@@ -110,12 +110,11 @@ end
 
 lemma prime.pow_dvd_of_dvd_mul_left
   [cancel_comm_monoid_with_zero α]
-  {p a b : α} (hp : prime p) (n : ℕ) (h : ¬(p ∣ a)) (h' : p ^ n ∣ a * b) : p ^ n ∣ b :=
+  {p a b : α} (hp : prime p) (n : ℕ) (h : ¬p ∣ a) (h' : p ^ n ∣ a * b) : p ^ n ∣ b :=
 begin
   induction n with n ih,
   { rw pow_zero, exact one_dvd b },
-  { specialize ih (dvd_trans (pow_dvd_pow p n.le_succ) h'),
-    obtain ⟨c, rfl⟩ := ih,
+  { obtain ⟨c, rfl⟩ := ih (dvd_trans (pow_dvd_pow p n.le_succ) h'),
     rw pow_succ',
     apply mul_dvd_mul_left _ ((hp.dvd_or_dvd _).resolve_left h),
     rwa [←mul_dvd_mul_iff_left (pow_ne_zero n hp.ne_zero), ←pow_succ', mul_left_comm] }
@@ -123,10 +122,8 @@ end
 
 lemma prime.pow_dvd_of_dvd_mul_right
   [cancel_comm_monoid_with_zero α]
-  {p a b : α} (hp : prime p) (n : ℕ) (h : ¬(p ∣ b)) (h' : p ^ n ∣ a * b) : p ^ n ∣ a :=
-begin
-  rw [mul_comm] at h', exact hp.pow_dvd_of_dvd_mul_left n h h',
-end
+  {p a b : α} (hp : prime p) (n : ℕ) (h : ¬p ∣ b) (h' : p ^ n ∣ a * b) : p ^ n ∣ a :=
+by { rw [mul_comm] at h', exact hp.pow_dvd_of_dvd_mul_left n h h' }
 
 /-- `irreducible p` states that `p` is non-unit and only factors into units.
 

--- a/src/algebra/associated.lean
+++ b/src/algebra/associated.lean
@@ -108,6 +108,26 @@ begin
     exact or.inr (hc.symm ▸ dvd_mul_right _ _) }
 end
 
+lemma prime.pow_dvd_of_dvd_mul_left
+  [cancel_comm_monoid_with_zero α]
+  {p a b : α} (hp : prime p) (n : ℕ) (h : ¬(p ∣ a)) (h' : p ^ n ∣ a * b) : p ^ n ∣ b :=
+begin
+  induction n with n ih,
+  { rw pow_zero, exact one_dvd b },
+  { specialize ih (dvd_trans (pow_dvd_pow p n.le_succ) h'),
+    obtain ⟨c, rfl⟩ := ih,
+    rw pow_succ',
+    apply mul_dvd_mul_left _ ((hp.dvd_or_dvd _).resolve_left h),
+    rwa [←mul_dvd_mul_iff_left (pow_ne_zero n hp.ne_zero), ←pow_succ', mul_left_comm] }
+end
+
+lemma prime.pow_dvd_of_dvd_mul_right
+  [cancel_comm_monoid_with_zero α]
+  {p a b : α} (hp : prime p) (n : ℕ) (h : ¬(p ∣ b)) (h' : p ^ n ∣ a * b) : p ^ n ∣ a :=
+begin
+  rw [mul_comm] at h', exact hp.pow_dvd_of_dvd_mul_left n h h',
+end
+
 /-- `irreducible p` states that `p` is non-unit and only factors into units.
 
 We explicitly avoid stating that `p` is non-zero, this would require a semiring. Assuming only a

--- a/src/data/nat/prime.lean
+++ b/src/data/nat/prime.lean
@@ -545,25 +545,6 @@ begin
   { rw pow_succ at h, exact (pp.dvd_mul.1 h).elim id IH }
 end
 
-lemma prime.pow_dvd_of_dvd_mul_right {p n a b : ℕ} (hp : p.prime) (h : p ^ n ∣ a * b)
-  (hpb : ¬ p ∣ b) : p ^ n ∣ a :=
-begin
-  induction n with n ih,
-  { simp only [one_dvd, pow_zero] },
-  { rw [pow_succ'] at *,
-    rcases ih ((dvd_mul_right _ _).trans h) with ⟨c, rfl⟩,
-    rw [mul_assoc] at h,
-    rcases hp.dvd_mul.1 (nat.dvd_of_mul_dvd_mul_left (pow_pos hp.pos _) h)
-      with ⟨d, rfl⟩|⟨d, rfl⟩,
-    { rw [← mul_assoc],
-      exact dvd_mul_right _ _ },
-    { exact (hpb (dvd_mul_right _ _)).elim } }
-end
-
-lemma prime.pow_dvd_of_dvd_mul_left {p n a b : ℕ} (hp : p.prime) (h : p ^ n ∣ a * b)
-  (hpb : ¬ p ∣ a) : p ^ n ∣ b :=
-by rw [mul_comm] at h; exact hp.pow_dvd_of_dvd_mul_right h hpb
-
 lemma prime.pow_not_prime {x n : ℕ} (hn : 2 ≤ n) : ¬ (x ^ n).prime :=
 λ hp, (hp.eq_one_or_self_of_dvd x $ dvd_trans ⟨x, sq _⟩ (pow_dvd_pow _ hn)).elim
   (λ hx1, hp.ne_one $ hx1.symm ▸ one_pow _)


### PR DESCRIPTION

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

@ChrisHughes24 added these in  #8483, but they seem to be unused in mathlib. I dropped the specialized results since they're just an application of `nat.prime_iff` away.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
