### PR TITLE
feat(combinatorics/hales_jewett): extended HJ theorem

### DIFF
--- a/src/combinatorics/hales_jewett.lean
+++ b/src/combinatorics/hales_jewett.lean
@@ -319,7 +319,7 @@ structure subspace (η α ι : Type*) :=
 
 namespace subspace
 
-/-- The combinatorial subspace corresponding to the indentity embedding `(ι → α) → (ι → α)`. -/
+/-- The combinatorial subspace corresponding to the identity embedding `(ι → α) → (ι → α)`. -/
 instance {α ι} : inhabited (subspace ι α ι) := ⟨⟨sum.inr, λ i, ⟨i, rfl⟩⟩⟩
 
 instance (η α ι) : has_coe_to_fun (subspace η α ι) (λ _, (η → α) → ι → α) :=
@@ -367,12 +367,11 @@ end
 /-- A variant of the extended Hales-Jewett theorem `exists_mono_in_high_dimension` where the
 returned type is some `fin n` instead of a general fintype. -/
 theorem exists_mono_in_high_dimension_fin (α κ η) [fintype α] [fintype κ] [fintype η] :
-  ∃ n : ℕ, ∀ C : (fin n → α) → κ, ∃ l : subspace η α (fin n), l.is_mono C :=
+  ∃ n, ∀ C : (fin n → α) → κ, ∃ l : subspace η α (fin n), l.is_mono C :=
 begin
   obtain ⟨ι, ιfin, hι⟩ := exists_mono_in_high_dimension α κ η,
   resetI,
-  use fintype.card ι,
-  intro C,
+  refine ⟨fintype.card ι, λ C, _⟩,
   specialize hι (λ v, C (v ∘ (fintype.equiv_fin _).symm)),
   obtain ⟨l, c, cl⟩ := hι,
   refine ⟨⟨l.idx_fun ∘ (fintype.equiv_fin _).symm, _⟩, c, cl⟩,

--- a/src/combinatorics/hales_jewett.lean
+++ b/src/combinatorics/hales_jewett.lean
@@ -9,7 +9,8 @@ import algebra.big_operators.basic
 /-!
 # The Hales-Jewett theorem
 
-We prove the Hales-Jewett theorem and deduce Van der Waerden's theorem as a corollary.
+We prove the Hales-Jewett theorem. We deduce Van der Waerden's theorem and the extended Hales-Jewett
+theorm as corollaries.
 
 The Hales-Jewett theorem is a result in Ramsey theory dealing with *combinatorial lines*. Given
 an 'alphabet' `α : Type*` and `a b : α`, an example of a combinatorial line in `α^5` is
@@ -19,6 +20,10 @@ huge) finite type `ι` such that whenever `ι → α` is `κ`-colored (i.e. for 
 `C : (ι → α) → κ`), there exists a monochromatic line. We prove the Hales-Jewett theorem using
 the idea of *color focusing* and a *product argument*. See the proof of
 `combinatorics.line.exists_mono_in_high_dimension'` for details.
+
+*Combinatorial subspaces* are higher-dimensional analogues of combinatorial lines, defined in
+`combinatorics.subspace`. The extended Hales-Jewett theorem generalises the statement above from
+combinatorial lines to combinatorial subspaces of a fixed dimension.
 
 The version of Van der Waerden's theorem in this file states that whenever a commutative monoid `M`
 is finitely colored and `S` is a finite subset, there exists a monochromatic homothetic copy of `S`.
@@ -361,7 +366,7 @@ end
 
 /-- A variant of the extended Hales-Jewett theorem `exists_mono_in_high_dimension` where the
 returned type is some `fin n` instead of a general fintype. -/
-theorem exists_mono_in_high_dimension_fin (α) [fintype α] (κ) [fintype κ] (η) [fintype η] :
+theorem exists_mono_in_high_dimension_fin (α κ η) [fintype α] [fintype κ] [fintype η] :
   ∃ n : ℕ, ∀ C : (fin n → α) → κ, ∃ l : subspace η α (fin n), l.is_mono C :=
 begin
   obtain ⟨ι, ιfin, hι⟩ := exists_mono_in_high_dimension α κ η,


### PR DESCRIPTION
This PR extends the Hales-Jewett theorem from combinatorial lines to higher-dimensional combinatorial subspaces. It's an example of a theorem proving its own generalisation.

The plan is to eventually use this to prove existence of monochromatic (m,p,c)-sets.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
