### PR TITLE
[Merged by Bors] - feat(analysis/normed_space/lp_space): API for `lp.single`

### DIFF
--- a/src/analysis/normed_space/lp_space.lean
+++ b/src/analysis/normed_space/lp_space.lean
@@ -631,7 +631,7 @@ protected lemma single_apply_neg (p) (i : α) (a : E i) {j : α} (hij : j ≠ i)
   lp.single p i a j = 0 :=
 by rw [lp.single_apply, dif_neg hij]
 
-@[simp] protected lemma neg_single [decidable_eq α] (p) (i : α) (a : E i) :
+@[simp] protected lemma neg_single (p) (i : α) (a : E i) :
   lp.single p i (- a) = - lp.single p i a :=
 begin
   ext j,
@@ -641,7 +641,7 @@ begin
   { simp [lp.single_apply_neg p i _ hi] }
 end
 
-@[simp] protected lemma smul_single [decidable_eq α] (p) (i : α) (a : E i) (c : 𝕜) :
+@[simp] protected lemma smul_single (p) (i : α) (a : E i) (c : 𝕜) :
   lp.single p i (c • a) = c • lp.single p i a :=
 begin
   ext j,

--- a/src/analysis/normed_space/lp_space.lean
+++ b/src/analysis/normed_space/lp_space.lean
@@ -202,18 +202,6 @@ begin
       exact real.rpow_le_rpow_of_exponent_ge' (norm_nonneg _) hi.le hq.le hpq' } }
 end
 
-lemma _root_.mem_ℓp_single [decidable_eq α] (p) (i : α) (a : E i) :
-  @mem_ℓp α E _ (λ j, if h : j = i then eq.rec a h.symm else 0) p :=
-begin
-  refine (mem_ℓp_zero _).of_exponent_ge (zero_le p),
-  refine (set.finite_singleton i).subset _,
-  intros j,
-  simp only [forall_exists_index, set.mem_singleton_iff, ne.def, dite_eq_right_iff,
-    set.mem_set_of_eq, not_forall],
-  rintros rfl,
-  simp,
-end
-
 lemma add {f g : Π i, E i} (hf : mem_ℓp f p) (hg : mem_ℓp g p) : mem_ℓp (f + g) p :=
 begin
   rcases p.trichotomy with rfl | rfl | hp,
@@ -617,7 +605,16 @@ variables [decidable_eq α]
 
 /-- The element of `lp E p` which is `a : E i` at the index `i`, and zero elsewhere. -/
 protected def single (p) (i : α) (a : E i) : lp E p :=
-⟨_, mem_ℓp_single p i a⟩
+⟨ λ j, if h : j = i then eq.rec a h.symm else 0,
+  begin
+    refine (mem_ℓp_zero _).of_exponent_ge (zero_le p),
+    refine (set.finite_singleton i).subset _,
+    intros j,
+    simp only [forall_exists_index, set.mem_singleton_iff, ne.def, dite_eq_right_iff,
+      set.mem_set_of_eq, not_forall],
+    rintros rfl,
+    simp,
+  end ⟩
 
 protected lemma single_apply (p) (i : α) (a : E i) (j : α) :
   lp.single p i a j = if h : j = i then eq.rec a h.symm else 0 :=

--- a/src/analysis/normed_space/lp_space.lean
+++ b/src/analysis/normed_space/lp_space.lean
@@ -620,32 +620,32 @@ protected lemma single_apply (p) (i : α) (a : E i) (j : α) :
   lp.single p i a j = if h : j = i then eq.rec a h.symm else 0 :=
 rfl
 
-protected lemma single_apply_pos (p) (i : α) (a : E i) :
+protected lemma single_apply_self (p) (i : α) (a : E i) :
   lp.single p i a i = a :=
 by rw [lp.single_apply, dif_pos rfl]
 
-protected lemma single_apply_neg (p) (i : α) (a : E i) {j : α} (hij : j ≠ i) :
+protected lemma single_apply_ne (p) (i : α) (a : E i) {j : α} (hij : j ≠ i) :
   lp.single p i a j = 0 :=
 by rw [lp.single_apply, dif_neg hij]
 
-@[simp] protected lemma neg_single (p) (i : α) (a : E i) :
+@[simp] protected lemma single_neg (p) (i : α) (a : E i) :
   lp.single p i (- a) = - lp.single p i a :=
 begin
   ext j,
   by_cases hi : j = i,
   { subst hi,
-    simp [lp.single_apply_pos] },
-  { simp [lp.single_apply_neg p i _ hi] }
+    simp [lp.single_apply_self] },
+  { simp [lp.single_apply_ne p i _ hi] }
 end
 
-@[simp] protected lemma smul_single (p) (i : α) (a : E i) (c : 𝕜) :
+@[simp] protected lemma single_smul (p) (i : α) (a : E i) (c : 𝕜) :
   lp.single p i (c • a) = c • lp.single p i a :=
 begin
   ext j,
   by_cases hi : j = i,
   { subst hi,
-    simp [lp.single_apply_pos] },
-  { simp [lp.single_apply_neg p i _ hi] }
+    simp [lp.single_apply_self] },
+  { simp [lp.single_apply_ne p i _ hi] }
 end
 
 protected lemma norm_sum_single (hp : 0 < p.to_real) (f : Π i, E i) (s : finset α) :


### PR DESCRIPTION
Definition and basic properties for `lp.single`, an element of `lp` space supported at one point.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
