### PR TITLE
[Merged by Bors] - feat(analysis/mean_inequalities): Hölder's inequality for infinite sums

### DIFF
--- a/src/analysis/mean_inequalities.lean
+++ b/src/analysis/mean_inequalities.lean
@@ -340,6 +340,16 @@ begin
   exact ⟨H₂, tsum_le_of_sum_le H₂ H₁⟩,
 end
 
+theorem summable_mul_of_Lp_Lq {f g : ι → ℝ≥0} {p q : ℝ} (hpq : p.is_conjugate_exponent q)
+  (hf : summable (λ i, (f i) ^ p)) (hg : summable (λ i, (g i) ^ q)) :
+  summable (λ i, f i * g i) :=
+(inner_le_Lp_mul_Lq_tsum hpq hf hg).1
+
+theorem inner_le_Lp_mul_Lq_tsum' {f g : ι → ℝ≥0} {p q : ℝ} (hpq : p.is_conjugate_exponent q)
+  (hf : summable (λ i, (f i) ^ p)) (hg : summable (λ i, (g i) ^ q)) :
+  ∑' i, f i * g i ≤ (∑' i, (f i) ^ p) ^ (1 / p) * (∑' i, (g i) ^ q) ^ (1 / q)  :=
+(inner_le_Lp_mul_Lq_tsum hpq hf hg).2
+
 /-- Hölder inequality: the scalar product of two functions is bounded by the product of their
 `L^p` and `L^q` norms when `p` and `q` are conjugate exponents. A version for `nnreal`-valued
 functions. For an alternative version, convenient if the infinite sums are not already expressed as
@@ -449,6 +459,16 @@ begin
   refine tsum_le_of_sum_le H₂ H₁,
 end
 
+theorem summable_Lp_add {f g : ι → ℝ≥0} {p : ℝ} (hp : 1 ≤ p) (hf : summable (λ i, (f i) ^ p))
+  (hg : summable (λ i, (g i) ^ p)) :
+  summable (λ i, (f i + g i) ^ p) :=
+(Lp_add_le_tsum hp hf hg).1
+
+theorem Lp_add_le_tsum' {f g : ι → ℝ≥0} {p : ℝ} (hp : 1 ≤ p) (hf : summable (λ i, (f i) ^ p))
+  (hg : summable (λ i, (g i) ^ p)) :
+  (∑' i, (f i + g i) ^ p) ^ (1 / p) ≤ (∑' i, (f i) ^ p) ^ (1 / p) + (∑' i, (g i) ^ p) ^ (1 / p) :=
+(Lp_add_le_tsum hp hf hg).2
+
 /-- Minkowski inequality: the `L_p` seminorm of the infinite sum of two vectors is less than or
 equal to the infinite sum of the `L_p`-seminorms of the summands, if these infinite sums both
 exist. A version for `nnreal`-valued functions. For an alternative version, convenient if the
@@ -536,6 +556,16 @@ begin
   exact nnreal.inner_le_Lp_mul_Lq_tsum hpq hf_sum hg_sum,
 end
 
+theorem summable_mul_of_Lp_Lq_of_nonneg (hpq : p.is_conjugate_exponent q) (hf : ∀ i, 0 ≤ f i)
+  (hg : ∀ i, 0 ≤ g i) (hf_sum : summable (λ i, (f i) ^ p)) (hg_sum : summable (λ i, (g i) ^ q)) :
+  summable (λ i, f i * g i) :=
+(inner_le_Lp_mul_Lq_tsum_of_nonneg hpq hf hg hf_sum hg_sum).1
+
+theorem inner_le_Lp_mul_Lq_tsum_of_nonneg' (hpq : p.is_conjugate_exponent q) (hf : ∀ i, 0 ≤ f i)
+  (hg : ∀ i, 0 ≤ g i) (hf_sum : summable (λ i, (f i) ^ p)) (hg_sum : summable (λ i, (g i) ^ q)) :
+  ∑' i, f i * g i ≤ (∑' i, (f i) ^ p) ^ (1 / p) * (∑' i, (g i) ^ q) ^ (1 / q) :=
+(inner_le_Lp_mul_Lq_tsum_of_nonneg hpq hf hg hf_sum hg_sum).2
+
 /-- Hölder inequality: the scalar product of two functions is bounded by the product of their
 `L^p` and `L^q` norms when `p` and `q` are conjugate exponents. A version for `nnreal`-valued
 functions. For an alternative version, convenient if the infinite sums are not already expressed as
@@ -587,6 +617,16 @@ begin
   norm_cast at *,
   exact nnreal.Lp_add_le_tsum hp hf_sum hg_sum,
 end
+
+theorem summable_Lp_add_of_nonneg (hp : 1 ≤ p) (hf : ∀ i, 0 ≤ f i) (hg : ∀ i, 0 ≤ g i)
+  (hf_sum : summable (λ i, (f i) ^ p)) (hg_sum : summable (λ i, (g i) ^ p)) :
+  summable (λ i, (f i + g i) ^ p) :=
+(Lp_add_le_tsum_of_nonneg hp hf hg hf_sum hg_sum).1
+
+theorem Lp_add_le_tsum_of_nonneg' (hp : 1 ≤ p) (hf : ∀ i, 0 ≤ f i) (hg : ∀ i, 0 ≤ g i)
+  (hf_sum : summable (λ i, (f i) ^ p)) (hg_sum : summable (λ i, (g i) ^ p)) :
+  (∑' i, (f i + g i) ^ p) ^ (1 / p) ≤ (∑' i, (f i) ^ p) ^ (1 / p) + (∑' i, (g i) ^ p) ^ (1 / p) :=
+(Lp_add_le_tsum_of_nonneg hp hf hg hf_sum hg_sum).2
 
 /-- Minkowski inequality: the `L_p` seminorm of the infinite sum of two vectors is less than or
 equal to the infinite sum of the `L_p`-seminorms of the summands, if these infinite sums both

--- a/src/analysis/mean_inequalities.lean
+++ b/src/analysis/mean_inequalities.lean
@@ -315,6 +315,50 @@ begin
     rpow_one, div_self hG_zero], },
 end
 
+/-- Hölder inequality: the scalar product of two functions is bounded by the product of their
+`L^p` and `L^q` norms when `p` and `q` are conjugate exponents. A version for `nnreal`-valued
+functions. For an alternative version, convenient if the infinite sums are already expressed as
+`p`-th powers, see `inner_le_Lp_mul_Lq_has_sum`. -/
+theorem inner_le_Lp_mul_Lq_tsum {f g : ι → ℝ≥0} {p q : ℝ} (hpq : p.is_conjugate_exponent q)
+  (hf : summable (λ i, (f i) ^ p)) (hg : summable (λ i, (g i) ^ q)) :
+  summable (λ i, f i * g i) ∧
+  ∑' i, f i * g i ≤ (∑' i, (f i) ^ p) ^ (1 / p) * (∑' i, (g i) ^ q) ^ (1 / q) :=
+begin
+  have H₁ : ∀ s : finset ι, ∑ i in s, f i * g i
+    ≤ (∑' i, (f i) ^ p) ^ (1 / p) * (∑' i, (g i) ^ q) ^ (1 / q),
+  { intros s,
+    refine le_trans (inner_le_Lp_mul_Lq s f g hpq) (mul_le_mul _ _ bot_le bot_le),
+    { rw nnreal.rpow_le_rpow_iff (one_div_pos.mpr hpq.pos),
+      exact sum_le_tsum _ (λ _ _, zero_le _) hf },
+    { rw nnreal.rpow_le_rpow_iff (one_div_pos.mpr hpq.symm.pos),
+      exact sum_le_tsum _ (λ _ _, zero_le _) hg } },
+  have bdd : bdd_above (set.range (λ s, ∑ i in s, f i * g i)),
+  { refine ⟨(∑' i, (f i) ^ p) ^ (1 / p) * (∑' i, (g i) ^ q) ^ (1 / q), _⟩,
+    rintros a ⟨s, rfl⟩,
+    exact H₁ s },
+  have H₂ : summable _ := (has_sum_of_is_lub _ (is_lub_csupr bdd)).summable,
+  exact ⟨H₂, tsum_le_of_sum_le H₂ H₁⟩,
+end
+
+/-- Hölder inequality: the scalar product of two functions is bounded by the product of their
+`L^p` and `L^q` norms when `p` and `q` are conjugate exponents. A version for `nnreal`-valued
+functions. For an alternative version, convenient if the infinite sums are not already expressed as
+`p`-th powers, see `inner_le_Lp_mul_Lq_tsum`.  -/
+theorem inner_le_Lp_mul_Lq_has_sum {f g : ι → ℝ≥0} {A B : ℝ≥0} {p q : ℝ}
+  (hpq : p.is_conjugate_exponent q) (hf : has_sum (λ i, (f i) ^ p) (A ^ p))
+  (hg : has_sum (λ i, (g i) ^ q) (B ^ q)) :
+  ∃ C, C ≤ A * B ∧ has_sum (λ i, f i * g i) C :=
+begin
+  obtain ⟨H₁, H₂⟩ := inner_le_Lp_mul_Lq_tsum hpq hf.summable hg.summable,
+  have hA : A = (∑' (i : ι), f i ^ p) ^ (1 / p),
+  { rw [hf.tsum_eq, rpow_inv_rpow_self hpq.ne_zero] },
+  have hB : B = (∑' (i : ι), g i ^ q) ^ (1 / q),
+  { rw [hg.tsum_eq, rpow_inv_rpow_self hpq.symm.ne_zero] },
+  refine ⟨∑' i, f i * g i, _, _⟩,
+  { simpa [hA, hB] using H₂ },
+  { simpa only [rpow_self_rpow_inv hpq.ne_zero] using H₁.has_sum }
+end
+
 /-- For `1 ≤ p`, the `p`-th power of the sum of `f i` is bounded above by a constant times the
 sum of the `p`-th powers of `f i`. Version for sums over finite sets, with `ℝ≥0`-valued functions.
 -/
@@ -476,6 +520,41 @@ theorem inner_le_Lp_mul_Lq_of_nonneg (hpq : is_conjugate_exponent p q)
   ∑ i in s, f i * g i ≤ (∑ i in s, (f i)^p) ^ (1 / p) * (∑ i in s, (g i)^q) ^ (1 / q) :=
 by convert inner_le_Lp_mul_Lq s f g hpq using 3; apply sum_congr rfl; intros i hi;
   simp only [abs_of_nonneg, hf i hi, hg i hi]
+
+/-- Hölder inequality: the scalar product of two functions is bounded by the product of their
+`L^p` and `L^q` norms when `p` and `q` are conjugate exponents. A version for `ℝ`-valued functions.
+For an alternative version, convenient if the infinite sums are already expressed as `p`-th powers,
+see `inner_le_Lp_mul_Lq_has_sum_of_nonneg`. -/
+theorem inner_le_Lp_mul_Lq_tsum_of_nonneg (hpq : p.is_conjugate_exponent q) (hf : ∀ i, 0 ≤ f i)
+  (hg : ∀ i, 0 ≤ g i) (hf_sum : summable (λ i, (f i) ^ p)) (hg_sum : summable (λ i, (g i) ^ q)) :
+  summable (λ i, f i * g i) ∧
+  ∑' i, f i * g i ≤ (∑' i, (f i) ^ p) ^ (1 / p) * (∑' i, (g i) ^ q) ^ (1 / q) :=
+begin
+  lift f to (ι → ℝ≥0) using hf,
+  lift g to (ι → ℝ≥0) using hg,
+  norm_cast at *,
+  exact nnreal.inner_le_Lp_mul_Lq_tsum hpq hf_sum hg_sum,
+end
+
+/-- Hölder inequality: the scalar product of two functions is bounded by the product of their
+`L^p` and `L^q` norms when `p` and `q` are conjugate exponents. A version for `nnreal`-valued
+functions. For an alternative version, convenient if the infinite sums are not already expressed as
+`p`-th powers, see `inner_le_Lp_mul_Lq_tsum_of_nonneg`.  -/
+theorem inner_le_Lp_mul_Lq_has_sum_of_nonneg (hpq : p.is_conjugate_exponent q) {A B : ℝ}
+  (hA : 0 ≤ A) (hB : 0 ≤ B) (hf : ∀ i, 0 ≤ f i) (hg : ∀ i, 0 ≤ g i)
+  (hf_sum : has_sum (λ i, (f i) ^ p) (A ^ p)) (hg_sum : has_sum (λ i, (g i) ^ q) (B ^ q)) :
+  ∃ C : ℝ, 0 ≤ C ∧ C ≤ A * B ∧ has_sum (λ i, f i * g i) C :=
+begin
+  lift f to (ι → ℝ≥0) using hf,
+  lift g to (ι → ℝ≥0) using hg,
+  lift A to ℝ≥0 using hA,
+  lift B to ℝ≥0 using hB,
+  norm_cast at hf_sum hg_sum,
+  obtain ⟨C, hC, H⟩ := nnreal.inner_le_Lp_mul_Lq_has_sum hpq hf_sum hg_sum,
+  refine ⟨C, C.prop, hC, _⟩,
+  norm_cast,
+  exact H
+end
 
 /-- For `1 ≤ p`, the `p`-th power of the sum of `f i` is bounded above by a constant times the
 sum of the `p`-th powers of `f i`. Version for sums over finite sets, with nonnegative `ℝ`-valued

--- a/src/analysis/normed_space/lp_space.lean
+++ b/src/analysis/normed_space/lp_space.lean
@@ -37,6 +37,7 @@ The space `lp E p` is the subtype of elements of `Π i : α, E i` which satisfy 
   `p`
 * `lp.mem_ℓp_of_tendsto`, `lp.norm_le_of_tendsto`: A pointwise limit of functions in `lp`, all with
   `lp` norm `≤ C`, is itself in `lp` and has `lp` norm `≤ C`.
+* `lp.tsum_inner_mul_inner_le`: basic form of Hölder's inequality
 
 ## Implementation
 
@@ -45,7 +46,9 @@ say that `∥-f∥ = ∥f∥`, instead of the non-working `f.norm_neg`.
 
 ## TODO
 
-* Hölder's inequality
+* More versions of Hölder's inequality (for example: the case `p = 1`, `q = ∞`; a version for normed
+  rings which has `∥∑' i, f i * g i∥` rather than `∑' i, ∥f i∥ * g i∥` on the RHS; a version for three
+  exponents satisfying `1 / r = 1 / p + 1 / q`)
 * Equivalence with `pi_Lp`, for `α` finite
 * Equivalence with `measure_theory.Lp`, for `f : α → E` (i.e., functions rather than pi-types) and
   the counting measure on `α`
@@ -470,6 +473,23 @@ normed_group.of_core _
       exact real.rpow_le_rpow (norm_nonneg _) (norm_add_le _ _) hp''.le },
   end,
   norm_neg := norm_neg }
+
+-- TODO: define an `ennreal` version of `is_conjugate_exponent`, and then express this inequality
+-- in a better version which also covers the case `p = 1, q = ∞`.
+/-- Hölder inequality -/
+lemma tsum_inner_mul_inner_le {p q : ℝ≥0∞}
+  (hpq : p.to_real.is_conjugate_exponent q.to_real) (f : lp E p) (g : lp E q) :
+  summable (λ i, ∥f i∥ * ∥g i∥) ∧ ∑' i, ∥f i∥ * ∥g i∥ ≤ ∥f∥ * ∥g∥ :=
+begin
+  have hf₁ : ∀ i, 0 ≤ ∥f i∥ := λ i, norm_nonneg _,
+  have hg₁ : ∀ i, 0 ≤ ∥g i∥ := λ i, norm_nonneg _,
+  have hf₂ := lp.has_sum_norm hpq.pos f,
+  have hg₂ := lp.has_sum_norm hpq.symm.pos g,
+  obtain ⟨C, -, hC', hC⟩ :=
+    real.inner_le_Lp_mul_Lq_has_sum_of_nonneg hpq (norm_nonneg' _) (norm_nonneg' _) hf₁ hg₁ hf₂ hg₂,
+  rw ← hC.tsum_eq at hC',
+  exact ⟨hC.summable, hC'⟩
+end
 
 section compare_pointwise
 

--- a/src/analysis/normed_space/lp_space.lean
+++ b/src/analysis/normed_space/lp_space.lean
@@ -477,7 +477,7 @@ normed_group.of_core _
 -- TODO: define an `ennreal` version of `is_conjugate_exponent`, and then express this inequality
 -- in a better version which also covers the case `p = 1, q = ∞`.
 /-- Hölder inequality -/
-lemma tsum_inner_mul_inner_le {p q : ℝ≥0∞}
+protected lemma tsum_mul_le_mul_norm {p q : ℝ≥0∞}
   (hpq : p.to_real.is_conjugate_exponent q.to_real) (f : lp E p) (g : lp E q) :
   summable (λ i, ∥f i∥ * ∥g i∥) ∧ ∑' i, ∥f i∥ * ∥g i∥ ≤ ∥f∥ * ∥g∥ :=
 begin
@@ -490,6 +490,16 @@ begin
   rw ← hC.tsum_eq at hC',
   exact ⟨hC.summable, hC'⟩
 end
+
+protected lemma summable_mul {p q : ℝ≥0∞}
+  (hpq : p.to_real.is_conjugate_exponent q.to_real) (f : lp E p) (g : lp E q) :
+  summable (λ i, ∥f i∥ * ∥g i∥) :=
+(lp.tsum_mul_le_mul_norm hpq f g).1
+
+protected lemma tsum_mul_le_mul_norm' {p q : ℝ≥0∞}
+  (hpq : p.to_real.is_conjugate_exponent q.to_real) (f : lp E p) (g : lp E q) :
+  ∑' i, ∥f i∥ * ∥g i∥ ≤ ∥f∥ * ∥g∥ :=
+(lp.tsum_mul_le_mul_norm hpq f g).2
 
 section compare_pointwise
 

--- a/src/analysis/normed_space/lp_space.lean
+++ b/src/analysis/normed_space/lp_space.lean
@@ -47,8 +47,8 @@ say that `∥-f∥ = ∥f∥`, instead of the non-working `f.norm_neg`.
 ## TODO
 
 * More versions of Hölder's inequality (for example: the case `p = 1`, `q = ∞`; a version for normed
-  rings which has `∥∑' i, f i * g i∥` rather than `∑' i, ∥f i∥ * g i∥` on the RHS; a version for three
-  exponents satisfying `1 / r = 1 / p + 1 / q`)
+  rings which has `∥∑' i, f i * g i∥` rather than `∑' i, ∥f i∥ * g i∥` on the RHS; a version for
+  three exponents satisfying `1 / r = 1 / p + 1 / q`)
 * Equivalence with `pi_Lp`, for `α` finite
 * Equivalence with `measure_theory.Lp`, for `f : α → E` (i.e., functions rather than pi-types) and
   the counting measure on `α`


### PR DESCRIPTION
State a few versions of Hölder's inequality for infinite sums.

The specific forms of the inequality chosen are parallel to those for Minkowski's inequality in #10984.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
