### PR TITLE
[Merged by Bors] - feat(algebra/periodic): lifting to function on quotient group

### DIFF
--- a/src/algebra/periodic.lean
+++ b/src/algebra/periodic.lean
@@ -302,7 +302,7 @@ quot.lift f $ λ a b (h : ∃ k : ℤ, k • c = -a + b), begin
   exact (h.zsmul k _).symm
 end
 
-lemma periodic.lift_coe [add_group α] (h : periodic f c) (a : α) :
+@[simp] lemma periodic.lift_coe [add_group α] (h : periodic f c) (a : α) :
   h.lift (a : α ⧸ add_subgroup.zmultiples c) = f a :=
 rfl
 

--- a/src/algebra/periodic.lean
+++ b/src/algebra/periodic.lean
@@ -295,12 +295,9 @@ lemma periodic.map_vadd_multiples [add_comm_monoid α] (hf : periodic f c)
 by { rcases a with ⟨_, m, rfl⟩, simp [add_submonoid.vadd_def, add_comm _ x, hf.nsmul m x] }
 
 /-- Lift a periodic function to a function from the quotient group. -/
-def periodic.lift [add_group α] (h : periodic f c) : α ⧸ (add_subgroup.zmultiples c) → β :=
-quot.lift f $ λ a b (h : ∃ k : ℤ, k • c = -a + b), begin
-  cases h with k hk,
-  rw ←add_eq_of_eq_neg_add hk,
-  exact (h.zsmul k _).symm
-end
+def periodic.lift [add_group α] (h : periodic f c) (x : α ⧸ add_subgroup.zmultiples c) : β :=
+quotient.lift_on' x f $
+  λ a b ⟨k, hk⟩, (h.zsmul k _).symm.trans $ congr_arg f $ add_eq_of_eq_neg_add hk
 
 @[simp] lemma periodic.lift_coe [add_group α] (h : periodic f c) (a : α) :
   h.lift (a : α ⧸ add_subgroup.zmultiples c) = f a :=

--- a/src/algebra/periodic.lean
+++ b/src/algebra/periodic.lean
@@ -7,7 +7,7 @@ import algebra.field.opposite
 import algebra.module.basic
 import algebra.order.archimedean
 import data.int.parity
-import group_theory.subgroup.basic
+import group_theory.coset
 
 /-!
 # Periodicity
@@ -293,6 +293,18 @@ lemma periodic.map_vadd_multiples [add_comm_monoid α] (hf : periodic f c)
   (a : add_submonoid.multiples c) (x : α) :
   f (a +ᵥ x) = f x :=
 by { rcases a with ⟨_, m, rfl⟩, simp [add_submonoid.vadd_def, add_comm _ x, hf.nsmul m x] }
+
+/-- Lift a periodic function to a function from the quotient group. -/
+def periodic.lift [add_group α] (h : periodic f c) : α ⧸ (add_subgroup.zmultiples c) → β :=
+quot.lift f $ λ a b (h : ∃ k : ℤ, k • c = -a + b), begin
+  cases h with k hk,
+  rw ←add_eq_of_eq_neg_add hk,
+  exact (h.zsmul k _).symm
+end
+
+lemma periodic.lift_coe [add_group α] (h : periodic f c) (a : α) :
+  h.lift (a : α ⧸ add_subgroup.zmultiples c) = f a :=
+rfl
 
 /-! ### Antiperiodicity -/
 


### PR DESCRIPTION
I want to make more use of the type `real.angle` in
`analysis.special_functions.trigonometric.angle`, including defining
functions from this type in terms of periodic functions from `ℝ`.  To
support defining such functions, add a definition `periodic.lift` that
lifts a periodic function from `α` to a function from
`α ⧸ (add_subgroup.zmultiples c)`, along with a lemma
`periodic.lift_coe` about the values of the resulting function.



---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
