### PR TITLE
[Merged by Bors] - feat(analysis/inner_product_space/basic): inner products of linear combinations of orthonormal vectors

### DIFF
--- a/src/analysis/inner_product_space/basic.lean
+++ b/src/analysis/inner_product_space/basic.lean
@@ -729,10 +729,17 @@ by classical; simp [finsupp.total_apply, finsupp.inner_sum, orthonormal_iff_ite.
 
 /-- The inner product of a linear combination of a set of orthonormal vectors with one of those
 vectors picks out the coefficient of that vector. -/
+lemma orthonormal.inner_right_sum
+  {v : ι → E} (hv : orthonormal 𝕜 v) (l : ι → 𝕜) {s : finset ι} {i : ι} (hi : i ∈ s) :
+  ⟪v i, ∑ i in s, (l i) • (v i)⟫ = l i :=
+by classical; simp [inner_sum, inner_smul_right, orthonormal_iff_ite.mp hv, hi]
+
+/-- The inner product of a linear combination of a set of orthonormal vectors with one of those
+vectors picks out the coefficient of that vector. -/
 lemma orthonormal.inner_right_fintype [fintype ι]
   {v : ι → E} (hv : orthonormal 𝕜 v) (l : ι → 𝕜) (i : ι) :
   ⟪v i, ∑ i : ι, (l i) • (v i)⟫ = l i :=
-by classical; simp [inner_sum, inner_smul_right, orthonormal_iff_ite.mp hv]
+hv.inner_right_sum l (finset.mem_univ _)
 
 /-- The inner product of a linear combination of a set of orthonormal vectors with one of those
 vectors picks out the coefficient of that vector. -/
@@ -742,10 +749,17 @@ by rw [← inner_conj_sym, hv.inner_right_finsupp]
 
 /-- The inner product of a linear combination of a set of orthonormal vectors with one of those
 vectors picks out the coefficient of that vector. -/
+lemma orthonormal.inner_left_sum
+  {v : ι → E} (hv : orthonormal 𝕜 v) (l : ι → 𝕜) {s : finset ι} {i : ι} (hi : i ∈ s) :
+  ⟪∑ i in s, (l i) • (v i), v i⟫ = conj (l i) :=
+by classical; simp [sum_inner, inner_smul_left, orthonormal_iff_ite.mp hv, hi]
+
+/-- The inner product of a linear combination of a set of orthonormal vectors with one of those
+vectors picks out the coefficient of that vector. -/
 lemma orthonormal.inner_left_fintype [fintype ι]
   {v : ι → E} (hv : orthonormal 𝕜 v) (l : ι → 𝕜) (i : ι) :
   ⟪∑ i : ι, (l i) • (v i), v i⟫ = conj (l i) :=
-by classical; simp [sum_inner, inner_smul_left, orthonormal_iff_ite.mp hv]
+hv.inner_left_sum l (finset.mem_univ _)
 
 /-- The inner product of two linear combinations of a set of orthonormal vectors, expressed as
 a sum over the first `finsupp`. -/
@@ -763,10 +777,14 @@ by simp [finsupp.total_apply _ l₂, finsupp.inner_sum, hv.inner_left_finsupp, m
 
 /-- The inner product of two linear combinations of a set of orthonormal vectors, expressed as
 a sum. -/
-lemma orthonormal.inner_fintype [fintype ι]
-  {v : ι → E} (hv : orthonormal 𝕜 v) (l₁ l₂ : ι → 𝕜) :
-  ⟪∑ i, l₁ i • v i, ∑ i, l₂ i • v i⟫ = ∑ i, conj (l₁ i) * l₂ i :=
-by simp [sum_inner, inner_smul_left, hv.inner_right_fintype]
+lemma orthonormal.inner_sum
+  {v : ι → E} (hv : orthonormal 𝕜 v) (l₁ l₂ : ι → 𝕜) (s : finset ι) :
+  ⟪∑ i in s, l₁ i • v i, ∑ i in s, l₂ i • v i⟫ = ∑ i in s, conj (l₁ i) * l₂ i :=
+begin
+  simp_rw [sum_inner, inner_smul_left],
+  refine finset.sum_congr rfl (λ i hi, _),
+  rw hv.inner_right_sum l₂ hi
+end
 
 /--
 The double sum of weighted inner products of pairs of vectors from an orthonormal sequence is the

--- a/src/analysis/inner_product_space/basic.lean
+++ b/src/analysis/inner_product_space/basic.lean
@@ -747,6 +747,27 @@ lemma orthonormal.inner_left_fintype [fintype ι]
   ⟪∑ i : ι, (l i) • (v i), v i⟫ = conj (l i) :=
 by classical; simp [sum_inner, inner_smul_left, orthonormal_iff_ite.mp hv]
 
+/-- The inner product of two linear combinations of a set of orthonormal vectors, expressed as
+a sum over the first `finsupp`. -/
+lemma orthonormal.inner_finsupp_eq_sum_left
+  {v : ι → E} (hv : orthonormal 𝕜 v) (l₁ l₂ : ι →₀ 𝕜) :
+  ⟪finsupp.total ι E 𝕜 v l₁, finsupp.total ι E 𝕜 v l₂⟫ = l₁.sum (λ i y, conj y * l₂ i) :=
+by simp [finsupp.total_apply _ l₁, finsupp.sum_inner, hv.inner_right_finsupp]
+
+/-- The inner product of two linear combinations of a set of orthonormal vectors, expressed as
+a sum over the second `finsupp`. -/
+lemma orthonormal.inner_finsupp_eq_sum_right
+  {v : ι → E} (hv : orthonormal 𝕜 v) (l₁ l₂ : ι →₀ 𝕜) :
+  ⟪finsupp.total ι E 𝕜 v l₁, finsupp.total ι E 𝕜 v l₂⟫ = l₂.sum (λ i y, conj (l₁ i) * y) :=
+by simp [finsupp.total_apply _ l₂, finsupp.inner_sum, hv.inner_left_finsupp, mul_comm]
+
+/-- The inner product of two linear combinations of a set of orthonormal vectors, expressed as
+a sum. -/
+lemma orthonormal.inner_fintype [fintype ι]
+  {v : ι → E} (hv : orthonormal 𝕜 v) (l₁ l₂ : ι → 𝕜) :
+  ⟪∑ i, l₁ i • v i, ∑ i, l₂ i • v i⟫ = ∑ i, conj (l₁ i) * l₂ i :=
+by simp [sum_inner, inner_smul_left, hv.inner_right_fintype]
+
 /--
 The double sum of weighted inner products of pairs of vectors from an orthonormal sequence is the
 sum of the weights.


### PR DESCRIPTION
There are some lemmas about the inner product of a linear combination
of orthonormal vectors with one vector from that orthonormal family.
Add similar lemmas where both sides of the inner product are linear
combinations.



---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
