### PR TITLE
[Merged by Bors] - feat(analysis/seminorm): `semilattice_sup` on seminorms and lemmas about `ball`

### DIFF
--- a/src/analysis/seminorm.lean
+++ b/src/analysis/seminorm.lean
@@ -284,12 +284,8 @@ noncomputable instance : has_sup (seminorm 𝕜 E) :=
     triangle' := λ x y, sup_le
       ((p.triangle x y).trans $ add_le_add le_sup_left le_sup_left)
       ((q.triangle x y).trans $ add_le_add le_sup_right le_sup_right),
-    smul' := λ x v,
-    begin
-      simp,
-      rw [sup_eq_max, sup_eq_max, p.smul x v, q.smul x v,
-        (mul_max_of_nonneg (p v) (q v) (norm_nonneg x))],
-    end } }
+    smul' := λ x v, (congr_arg2 max (p.smul x v) (q.smul x v)).trans $
+      (mul_max_of_nonneg _ _ $ norm_nonneg x).symm } }
 
 @[simp] lemma coe_sup (p q : seminorm 𝕜 E) : ⇑(p ⊔ q) = p ⊔ q := rfl
 

--- a/src/analysis/seminorm.lean
+++ b/src/analysis/seminorm.lean
@@ -468,10 +468,7 @@ variables (ι' : finset ι)
 
 lemma seminorm_le_sup (p : ι → seminorm 𝕜 E) (ι' : finset ι) (i : ι) (hi : i ∈ ι') (x : E) :
   p i x ≤ ι'.sup p x :=
-begin
-  have h : p i ≤ ι'.sup p := @finset.le_sup _ _ _ _ _ p _ hi,
-  exact h x,
-end
+(finset.le_sup hi : p _ ≤ _) x
 
 lemma seminorm_sup_ball_int (p : ι → seminorm 𝕜 E) (ι' : finset ι) :
   ball (ι'.sup p) 0 1 = ⋂ (i ∈ ι'), ball (p i) (0 : E) 1 :=

--- a/src/analysis/seminorm.lean
+++ b/src/analysis/seminorm.lean
@@ -351,10 +351,6 @@ begin
         nnreal.coe_max, subtype.coe_mk, ih] }
 end
 
-lemma finset_le_sup (p : ι → seminorm 𝕜 E) (s : finset ι) (i : ι) (hi : i ∈ s) (x : E) :
-  p i x ≤ s.sup p x :=
-(finset.le_sup hi : p _ ≤ _) x
-
 end norm_one_class
 
 /-! ### Seminorm ball -/

--- a/src/analysis/seminorm.lean
+++ b/src/analysis/seminorm.lean
@@ -354,8 +354,8 @@ begin
         nnreal.coe_max, subtype.coe_mk, ih] }
 end
 
-lemma finset_le_sup (p : ι → seminorm 𝕜 E) (ι' : finset ι) (i : ι) (hi : i ∈ ι') (x : E) :
-  p i x ≤ ι'.sup p x :=
+lemma finset_le_sup (p : ι → seminorm 𝕜 E) (s : finset ι) (i : ι) (hi : i ∈ s) (x : E) :
+  p i x ≤ s.sup p x :=
 (finset.le_sup hi : p _ ≤ _) x
 
 end norm_one_class
@@ -394,21 +394,17 @@ begin
   ...    < r   : by rwa mem_ball_zero at hy,
 end
 
-lemma finset_sup_ball_inter (p : ι → seminorm 𝕜 E) (ι' : finset ι) (r : ℝ) (hr : 0 < r):
-  ball (ι'.sup p) 0 r = ⋂ (i ∈ ι'), ball (p i) (0 : E) r :=
+lemma finset_sup_ball_inter (p : ι → seminorm 𝕜 E) (s : finset ι) (r : ℝ) (hr : 0 < r):
+  ball (s.sup p) 0 r = ⋂ (i ∈ s), ball (p i) (0 : E) r :=
 begin
-  dunfold ball,
   ext,
-  simp,
-  split,
-  { intros hx i hi,
-    exact lt_of_le_of_lt (finset_le_sup p ι' i hi x) hx },
-  intros hx,
-  rw [finset_sup_apply, ←r.coe_to_nnreal (has_lt.lt.le hr), nnreal.coe_lt_coe, finset.sup_lt_iff],
+  simp_rw [mem_Inter, mem_ball_zero],
+  refine ⟨λ hx i hi, (finset_le_sup p s i hi x).trans_lt hx, λ hx, _⟩,
+  rw [finset_sup_apply, ←r.coe_to_nnreal (hr.le), nnreal.coe_lt_coe, finset.sup_lt_iff],
   { intros i hi,
-    rw [←nnreal.coe_lt_coe, r.coe_to_nnreal (has_lt.lt.le hr)],
+    rw [←nnreal.coe_lt_coe, r.coe_to_nnreal (hr.le)],
     exact (hx i hi) },
-  simp[hr],
+  simp [hr],
 end
 
 end module

--- a/src/analysis/seminorm.lean
+++ b/src/analysis/seminorm.lean
@@ -262,7 +262,7 @@ instance fun_like : fun_like (seminorm 𝕜 E) E (λ _, ℝ) :=
 /-- Helper instance for when there's too many metavariables to apply `fun_like`. -/
 instance : has_coe_to_fun (seminorm 𝕜 E) (λ _, E → ℝ) := ⟨λ p, p.to_fun⟩
 
-@[ext] lemma ext {p q : seminorm 𝕜 E} (h : (p : E → ℝ) = q) : p = q := fun_like.ext p q h
+@[ext] lemma ext {p q : seminorm 𝕜 E} (h : ∀ x, (p : E → ℝ) x = q x) : p = q := fun_like.ext p q h
 
 instance : has_zero (seminorm 𝕜 E) :=
 ⟨{ to_fun    := λ _, 0,
@@ -743,9 +743,8 @@ end
   triangle' := gauge_add_le hs hs' }
 
 /-- Any seminorm arises a the gauge of its unit ball. -/
-lemma seminorm.gauge_ball (p : seminorm ℝ E) : gauge (p.ball 0 1) = p :=
+lemma seminorm.gauge_ball (p : seminorm ℝ E) (x : E): gauge (p.ball 0 1) x = p x :=
 begin
-  ext,
   obtain hp | hp := {r : ℝ | 0 < r ∧ x ∈ r • p.ball 0 1}.eq_empty_or_nonempty,
   { rw [gauge, hp, real.Inf_empty],
     by_contra,
@@ -769,8 +768,7 @@ end
 
 lemma seminorm.gauge_seminorm_ball (p : seminorm ℝ E) :
   gauge_seminorm (λ x, p.symmetric_ball_zero 1) (p.convex_ball 0 1)
-    (p.absorbent_ball_zero zero_lt_one) = p :=
-seminorm.ext p.gauge_ball
+    (p.absorbent_ball_zero zero_lt_one) = p := seminorm.ext p.gauge_ball
 
 end gauge
 

--- a/src/analysis/seminorm.lean
+++ b/src/analysis/seminorm.lean
@@ -329,13 +329,8 @@ instance : has_sup (seminorm 𝕜 E) :=
     triangle' := λ x y, sup_le
       ((p.triangle x y).trans $ add_le_add le_sup_left le_sup_left)
       ((q.triangle x y).trans $ add_le_add le_sup_right le_sup_right),
-    smul' :=
-      begin
-        intros x v,
-        simp,
-        rw mul_sup (norm_nonneg x),
-        rw [p.smul x v, q.smul x v],
-      end }}
+    smul' := λ x v, (congr_arg2 (⊔) (p.smul x v) (q.smul x v)).trans $
+      (mul_sup $ norm_nonneg x).symm } }
 
 @[simp] lemma coe_sup (p q : seminorm 𝕜 E) : ⇑(p ⊔ q) = p ⊔ q := rfl
 

--- a/src/analysis/seminorm.lean
+++ b/src/analysis/seminorm.lean
@@ -295,11 +295,14 @@ noncomputable instance : has_sup (seminorm 𝕜 E) :=
 
 @[simp] lemma coe_sup (p q : seminorm 𝕜 E) : ⇑(p ⊔ q) = p ⊔ q := rfl
 
-noncomputable instance : semilattice_sup (seminorm 𝕜 E) :=
-function.injective.semilattice_sup _ coe_injective coe_sup
+instance : partial_order (seminorm 𝕜 E) :=
+  partial_order.lift _ coe_injective
 
 lemma le_def (p q : seminorm 𝕜 E) : p ≤ q ↔ (p : E → ℝ) ≤ q := iff.rfl
 lemma lt_def (p q : seminorm 𝕜 E) : p < q ↔ (p : E → ℝ) < q := iff.rfl
+
+noncomputable instance : semilattice_sup (seminorm 𝕜 E) :=
+function.injective.semilattice_sup _ coe_injective coe_sup
 
 end has_scalar
 
@@ -400,9 +403,9 @@ begin
   ext,
   simp_rw [mem_Inter, mem_ball_zero],
   refine ⟨λ hx i hi, (finset_le_sup p s i hi x).trans_lt hx, λ hx, _⟩,
-  rw [finset_sup_apply, ←r.coe_to_nnreal (hr.le), nnreal.coe_lt_coe, finset.sup_lt_iff],
+  rw [finset_sup_apply, ←r.coe_to_nnreal hr.le, nnreal.coe_lt_coe, finset.sup_lt_iff],
   { intros i hi,
-    rw [←nnreal.coe_lt_coe, r.coe_to_nnreal (hr.le)],
+    rw [←nnreal.coe_lt_coe, r.coe_to_nnreal hr.le],
     exact (hx i hi) },
   simp [hr],
 end

--- a/src/analysis/seminorm.lean
+++ b/src/analysis/seminorm.lean
@@ -258,19 +258,21 @@ variables [add_monoid E]
 section has_scalar
 variables [has_scalar 𝕜 E]
 
-instance : has_zero (seminorm 𝕜 E) :=
-⟨{ to_fun    := λ _, 0,
-  smul'     := λ _ _, (mul_zero _).symm,
-  triangle' := λ _ _, by rw add_zero }⟩
-
-instance : inhabited (seminorm 𝕜 E) := ⟨0⟩
-
 instance : has_coe_to_fun (seminorm 𝕜 E) (λ _, E → ℝ) := ⟨λ p, p.to_fun⟩
 
 lemma coe_injective : @function.injective (seminorm 𝕜 E) (E → ℝ) coe_fn
 | ⟨x, _, _⟩ ⟨y, _, _⟩ rfl := rfl
 
 @[ext] lemma ext {p q : seminorm 𝕜 E} (h : (p : E → ℝ) = q) : p = q := coe_injective h
+
+instance : has_zero (seminorm 𝕜 E) :=
+⟨{ to_fun    := λ _, 0,
+  smul'     := λ _ _, (mul_zero _).symm,
+  triangle' := λ _ _, by rw add_zero }⟩
+
+@[simp] lemma coe_zero : coe_fn (0 : seminorm 𝕜 E) = 0 := rfl
+
+instance : inhabited (seminorm 𝕜 E) := ⟨0⟩
 
 variables (p : seminorm 𝕜 E) (c : 𝕜) (x y : E) (r : ℝ)
 

--- a/src/analysis/seminorm.lean
+++ b/src/analysis/seminorm.lean
@@ -326,16 +326,9 @@ end
 instance : has_sup (seminorm 𝕜 E) :=
 { sup := λ p q,
   { to_fun := p ⊔ q,
-    triangle' :=
-      begin
-        intros x y,
-        simp,
-        split,
-        { apply le_trans (p.triangle x y),
-          exact add_le_add (le_sup_left) (le_sup_left) },
-        apply le_trans (q.triangle x y),
-        exact add_le_add le_sup_right le_sup_right,
-      end,
+    triangle' := λ x y, sup_le
+      ((p.triangle x y).trans $ add_le_add le_sup_left le_sup_left)
+      ((q.triangle x y).trans $ add_le_add le_sup_right le_sup_right),
     smul' :=
       begin
         intros x v,

--- a/src/analysis/seminorm.lean
+++ b/src/analysis/seminorm.lean
@@ -263,6 +263,8 @@ instance : has_zero (seminorm 𝕜 E) :=
     smul'     := λ _ _, (mul_zero _).symm,
     triangle' := λ _ _, by rw add_zero }⟩
 
+@[simp] lemma coe_zero : (0 : seminorm 𝕜 E) = 0 := rfl
+
 instance : inhabited (seminorm 𝕜 E) := ⟨0⟩
 
 instance : has_coe_to_fun (seminorm 𝕜 E) (λ _, E → ℝ) := ⟨λ p, p.to_fun⟩
@@ -469,10 +471,11 @@ variables (p : ι → seminorm 𝕜 E)
 variables (ι' : finset ι)
 
 lemma seminorm_sup_finset_coe_to_fun (p : ι → seminorm 𝕜 E) (ι' : finset ι) :
-  coe_fn (ι'.sup p) = λ x, ↑(ι'.sup (λ i, (p i x).to_nnreal)) :=
+  coe_fn (ι'.sup p) = ↑(ι'.sup (λ i x, (p i x).to_nnreal)) :=
 begin
   sorry,
 end
+
 
 lemma seminorm_le_sup (p : ι → seminorm 𝕜 E) (ι' : finset ι) (i : ι) (hi : i ∈ ι') (x : E) :
   p i x ≤ ι'.sup p x :=

--- a/src/analysis/seminorm.lean
+++ b/src/analysis/seminorm.lean
@@ -337,9 +337,7 @@ nonneg_of_mul_nonneg_left h zero_lt_two
 
 lemma sub_rev : p (x - y) = p (y - x) := by rw [←neg_sub, p.neg]
 
-instance : order_bot (seminorm 𝕜 E) :=
-{ bot := 0,
-  bot_le := nonneg }
+instance : order_bot (seminorm 𝕜 E) := ⟨0, nonneg⟩
 
 @[simp] lemma coe_bot : ⇑(⊥ : seminorm 𝕜 E) = 0 := rfl
 
@@ -387,6 +385,8 @@ end has_scalar
 
 section module
 variables [norm_one_class 𝕜] [module 𝕜 E] (p : seminorm 𝕜 E)
+
+lemma ball_bot {r : ℝ} (x : E) (hr : 0 < r) : ball (⊥ : seminorm 𝕜 E) x r = set.univ := ball_zero' x hr
 
 /-- Seminorm-balls at the origin are balanced. -/
 lemma balanced_ball_zero (r : ℝ): balanced 𝕜 (ball p 0 r) :=

--- a/src/analysis/seminorm.lean
+++ b/src/analysis/seminorm.lean
@@ -316,9 +316,6 @@ nonneg_of_mul_nonneg_left h zero_lt_two
 
 lemma sub_rev : p (x - y) = p (y - x) := by rw [←neg_sub, p.neg]
 
-variables {α : Type*} [semilattice_sup α] {a b c d : α}
-variables (h₁ : a = b)
-
 lemma mul_sup {a b c : ℝ} (h₁ : 0 ≤ a) : a * (b ⊔ c) = (a * b) ⊔ (a * c) :=
 begin
   cases le_total b c with h h,
@@ -347,13 +344,13 @@ instance : has_sup (seminorm 𝕜 E) :=
         rw [p.smul x v, q.smul x v],
       end }}
 
-@[simp] lemma coe_sup (x y : seminorm 𝕜 E) : ⇑(x ⊔ y) = x ⊔ y := rfl
+@[simp] lemma coe_sup (p q : seminorm 𝕜 E) : ⇑(p ⊔ q) = p ⊔ q := rfl
 
 instance : semilattice_sup (seminorm 𝕜 E) :=
 function.injective.semilattice_sup _ coe_injective coe_sup
 
-lemma le_def (x y : seminorm 𝕜 E) : x ≤ y ↔ (x : E → ℝ) ≤ y := iff.rfl
-lemma lt_def (x y : seminorm 𝕜 E) : x < y ↔ (x : E → ℝ) < y := iff.rfl
+lemma le_def (p q : seminorm 𝕜 E) : p ≤ q ↔ (p : E → ℝ) ≤ q := iff.rfl
+lemma lt_def (p q : seminorm 𝕜 E) : p < q ↔ (p : E → ℝ) < q := iff.rfl
 
 instance : order_bot (seminorm 𝕜 E) :=
 { bot := 0,
@@ -481,13 +478,6 @@ variables {ι : Type*} [decidable_eq ι]
 variables (p : ι → seminorm 𝕜 E)
 variables (ι' : finset ι)
 
-lemma seminorm_sup_finset_coe_to_fun (p : ι → seminorm 𝕜 E) (ι' : finset ι) :
-  coe_fn (ι'.sup p) = ↑(ι'.sup (λ i x, (p i x).to_nnreal)) :=
-begin
-  sorry,
-end
-
-
 lemma seminorm_le_sup (p : ι → seminorm 𝕜 E) (ι' : finset ι) (i : ι) (hi : i ∈ ι') (x : E) :
   p i x ≤ ι'.sup p x :=
 begin
@@ -505,7 +495,13 @@ begin
   { intros hx i hi,
     exact lt_of_le_of_lt (seminorm_le_sup p ι' i hi x) hx },
   intros hx,
-  sorry,
+  rw [finset_sup_apply, ←nnreal.coe_one, nnreal.coe_lt_coe, finset.sup_lt_iff],
+  {
+    intros i hi,
+    have hp : p i x < 1 := hx i hi,
+    exact hp,
+  },
+  simp,
 end
 
 end seminorm_sup

--- a/src/analysis/seminorm.lean
+++ b/src/analysis/seminorm.lean
@@ -380,13 +380,18 @@ begin
   rw [set.eq_univ_iff_forall, ball],
   simp [hr],
 end
-
-lemma ball_sup (p : seminorm 𝕜 E) (q : seminorm 𝕜 E) (e : E) {r : ℝ} (hr : 0 ≤ r) :
+lemma ball_sup (p : seminorm 𝕜 E) (q : seminorm 𝕜 E) (e : E) (r : ℝ) :
   ball (p ⊔ q) e r = ball p e r ∩ ball q e r :=
+by simp_rw [ball, ←set.set_of_and, coe_sup, pi.sup_apply, sup_lt_iff]
+
+lemma ball_finset_sup' (p : ι → seminorm 𝕜 E) (s : finset ι) (H : s.nonempty) (e : E) (r : ℝ) :
+  ball (s.sup' H p) e r = s.inf' H (λ i, ball (p i) e r) :=
 begin
-  lift r to nnreal using hr,
-  simp_rw [ball, ←set.set_of_and],
-  simp,
+  induction s using finset.cons_induction_on with a s ha ih,
+  { exact false.elim (not_nonempty_empty H), },
+  { rcases s.eq_empty_or_nonempty with rfl | hs,
+    { classical, simp },
+    { rw [finset.sup'_cons hs, finset.inf'_cons hs, ball_sup, inf_eq_inter, ih] } },
 end
 
 end has_scalar

--- a/src/analysis/seminorm.lean
+++ b/src/analysis/seminorm.lean
@@ -259,9 +259,9 @@ section has_scalar
 variables [has_scalar 𝕜 E]
 
 instance : has_zero (seminorm 𝕜 E) :=
-  ⟨{ to_fun    := λ _, 0,
-    smul'     := λ _ _, (mul_zero _).symm,
-    triangle' := λ _ _, by rw add_zero }⟩
+⟨{ to_fun    := λ _, 0,
+  smul'     := λ _ _, (mul_zero _).symm,
+  triangle' := λ _ _, by rw add_zero }⟩
 
 instance : inhabited (seminorm 𝕜 E) := ⟨0⟩
 

--- a/src/analysis/seminorm.lean
+++ b/src/analysis/seminorm.lean
@@ -259,17 +259,17 @@ variables [has_scalar 𝕜 E]
 instance fun_like : fun_like (seminorm 𝕜 E) E (λ _, ℝ) :=
 { coe := seminorm.to_fun, coe_injective' := λ f g h, by cases f; cases g; congr' }
 
-/-- Helper instance for when there's too many metavariables to apply `fun_like`. -/
+/-- Helper instance for when there's too many metavariables to apply `to_fun.to_coe_fn`. -/
 instance : has_coe_to_fun (seminorm 𝕜 E) (λ _, E → ℝ) := ⟨λ p, p.to_fun⟩
 
 @[ext] lemma ext {p q : seminorm 𝕜 E} (h : ∀ x, (p : E → ℝ) x = q x) : p = q := fun_like.ext p q h
 
 instance : has_zero (seminorm 𝕜 E) :=
-⟨{ to_fun    := λ _, 0,
+⟨{ to_fun    := 0,
   smul'     := λ _ _, (mul_zero _).symm,
   triangle' := λ _ _, by rw add_zero }⟩
 
-@[simp] lemma coe_zero : coe_fn (0 : seminorm 𝕜 E) = 0 := rfl
+@[simp] lemma coe_zero : ⇑(0 : seminorm 𝕜 E) = 0 := rfl
 
 instance : inhabited (seminorm 𝕜 E) := ⟨0⟩
 

--- a/src/analysis/seminorm.lean
+++ b/src/analysis/seminorm.lean
@@ -375,7 +375,7 @@ lemma mem_ball_zero : y ∈ ball p 0 r ↔ p y < r := by rw [mem_ball, sub_zero]
 
 lemma ball_zero_eq : ball p 0 r = { y : E | p y < r } := set.ext $ λ x, p.mem_ball_zero
 
-lemma ball_zero' (x : E) (hr : 0 < r) : ball (0 : seminorm 𝕜 E) x r = set.univ :=
+@[simp] lemma ball_zero' (x : E) (hr : 0 < r) : ball (0 : seminorm 𝕜 E) x r = set.univ :=
 begin
   rw [set.eq_univ_iff_forall, ball],
   simp [hr],

--- a/src/analysis/seminorm.lean
+++ b/src/analysis/seminorm.lean
@@ -397,8 +397,8 @@ begin
     finset.sup_lt_iff (show ⊥ < r, from hr), ←nnreal.coe_lt_coe, subtype.coe_mk],
 end
 
-lemma ball_finset_sup_eq_finset_inf(p : ι → seminorm 𝕜 E) (s : finset ι) (e : E) (r : ℝ) (hr : 0 < r) :
-  ball (s.sup p) e r = s.inf (λ i, ball (p i) e r) :=
+lemma ball_finset_sup_eq_finset_inf (p : ι → seminorm 𝕜 E) (s : finset ι) (e : E) (r : ℝ)
+  (hr : 0 < r) : ball (s.sup p) e r = s.inf (λ i, ball (p i) e r) :=
 begin
   rw finset.inf_eq_infi,
   exact ball_finset_sup_eq_Inter _ _ _ _ hr,

--- a/src/analysis/seminorm.lean
+++ b/src/analysis/seminorm.lean
@@ -278,6 +278,8 @@ variables (p : seminorm 𝕜 E) (c : 𝕜) (x y : E) (r : ℝ)
 protected lemma smul : p (c • x) = ∥c∥ * p x := p.smul' _ _
 protected lemma triangle : p (x + y) ≤ p x + p y := p.triangle' _ _
 
+-- TODO: define `has_Sup` too, from the skeleton at
+-- https://github.com/leanprover-community/mathlib/pull/11329#issuecomment-1008915345
 noncomputable instance : has_sup (seminorm 𝕜 E) :=
 { sup := λ p q,
   { to_fun := p ⊔ q,
@@ -387,12 +389,19 @@ begin
   ...    < r   : by rwa mem_ball_zero at hy,
 end
 
-lemma finset_sup_ball_inter (p : ι → seminorm 𝕜 E) (s : finset ι) (e : E) (r : ℝ) (hr : 0 < r):
+lemma ball_finset_sup_eq_Inter (p : ι → seminorm 𝕜 E) (s : finset ι) (e : E) (r : ℝ) (hr : 0 < r) :
   ball (s.sup p) e r = ⋂ (i ∈ s), ball (p i) e r :=
 begin
   lift r to nnreal using hr.le,
   simp_rw [ball, Inter_set_of, finset_sup_apply, nnreal.coe_lt_coe,
     finset.sup_lt_iff (show ⊥ < r, from hr), ←nnreal.coe_lt_coe, subtype.coe_mk],
+end
+
+lemma ball_finset_sup_eq_finset_inf(p : ι → seminorm 𝕜 E) (s : finset ι) (e : E) (r : ℝ) (hr : 0 < r) :
+  ball (s.sup p) e r = s.inf (λ i, ball (p i) e r) :=
+begin
+  rw finset.inf_eq_infi,
+  exact ball_finset_sup_eq_Inter _ _ _ _ hr,
 end
 
 end module

--- a/src/analysis/seminorm.lean
+++ b/src/analysis/seminorm.lean
@@ -473,8 +473,6 @@ begin
 end
 
 
--- Show that this is a seminorm
--- Show that its unit ball is given by intersection
 lemma seminorm_sup_ball_int (p : ι → seminorm 𝕜 E) (ι' : finset ι) :
   ball (seminorm_sup_finset p ι') 0 1 = ⋂ (i ∈ ι'), ball (p i) (0 : E) 1 :=
 begin
@@ -483,16 +481,14 @@ begin
   rw seminorm_sup_finset_coe_to_fun,
   simp,
   split,
-  {
-    intros hx i hi,
+  { intros hx i hi,
     have hp : (p i x).to_nnreal < 1 := lt_of_le_of_lt (seminorm_sup_le_aux p ι' i hi x) hx,
     rw [←nnreal.coe_lt_coe, (p i x).coe_to_nnreal ((p i).nonneg x)] at hp,
     exact hp,
   },
   intros hx,
   rw [←nnreal.coe_one, nnreal.coe_lt_coe, finset.sup_lt_iff],
-  {
-    intros i' hi',
+  { intros i' hi',
     have hp : p i' x < 1 := hx i' hi',
     rw [←nnreal.coe_lt_coe, (p i' x).coe_to_nnreal ((p i').nonneg x)],
     exact hp,

--- a/src/analysis/seminorm.lean
+++ b/src/analysis/seminorm.lean
@@ -258,25 +258,19 @@ variables [add_monoid E]
 section has_scalar
 variables [has_scalar 𝕜 E]
 
-def zero_seminorm : seminorm 𝕜 E :=
-  { to_fun    := 0,
-    smul'     := by simp,
-    triangle' := by simp }
+instance : has_zero (seminorm 𝕜 E) :=
+  ⟨{ to_fun    := λ _, 0,
+    smul'     := λ _ _, (mul_zero _).symm,
+    triangle' := λ _ _, by rw add_zero }⟩
 
-instance : inhabited (seminorm 𝕜 E) := ⟨zero_seminorm⟩
+instance : inhabited (seminorm 𝕜 E) := ⟨0⟩
 
 instance : has_coe_to_fun (seminorm 𝕜 E) (λ _, E → ℝ) := ⟨λ p, p.to_fun⟩
 
 lemma coe_injective : @function.injective (seminorm 𝕜 E) (E → ℝ) coe_fn
 | ⟨x, _, _⟩ ⟨y, _, _⟩ rfl := rfl
 
-@[ext] lemma ext {p q : seminorm 𝕜 E} (h : (p : E → ℝ) = q) : p = q :=
-begin
-  cases p,
-  cases q,
-  have : p_to_fun = q_to_fun := h,
-  simp_rw this,
-end
+@[ext] lemma ext {p q : seminorm 𝕜 E} (h : (p : E → ℝ) = q) : p = q := coe_injective h
 
 variables (p : seminorm 𝕜 E) (c : 𝕜) (x y : E) (r : ℝ)
 
@@ -323,17 +317,12 @@ lemma sub_rev : p (x - y) = p (y - x) := by rw [←neg_sub, p.neg]
 variables {α : Type*} [semilattice_sup α] {a b c d : α}
 variables (h₁ : a = b)
 
-#check le_antisymm_iff.mp h₁
-
-#check sup_le_sup
 theorem sup_eq_sup (h₁ : a = b) (h₂ : c = d) : a ⊔ c = b ⊔ d :=
 begin
   refine le_antisymm _ _,
-  {
-    refine sup_le_sup _ _,
+  { refine sup_le_sup _ _,
     exact (le_antisymm_iff.mp h₁).1,
-    exact (le_antisymm_iff.mp h₂).1,
-  },
+    exact (le_antisymm_iff.mp h₂).1 },
   refine sup_le_sup _ _,
   exact (le_antisymm_iff.mp h₁).2,
   exact (le_antisymm_iff.mp h₂).2,
@@ -375,7 +364,7 @@ instance : semilattice_sup (seminorm 𝕜 E) :=
 function.injective.semilattice_sup _ coe_injective coe_sup
 
 instance : order_bot (seminorm 𝕜 E) :=
-{ bot := zero_seminorm,
+{ bot := 0,
   bot_le := nonneg }
 
 @[simp] lemma coe_bot : ⇑(⊥ : seminorm 𝕜 E) = 0 := rfl
@@ -485,8 +474,6 @@ end module
 end normed_linear_ordered_field
 
 section seminorm_sup
-
-noncomputable theory
 
 variables [normed_field 𝕜] [add_comm_group E] [module 𝕜 E] [semi_normed_space ℝ 𝕜]
 variables [module ℝ E]
@@ -823,7 +810,5 @@ lemma seminorm.gauge_seminorm_ball (p : seminorm ℝ E) :
 seminorm.ext p.gauge_ball
 
 end gauge
-
-
 
 -- TODO: topology induced by family of seminorms, local convexity.

--- a/src/analysis/seminorm.lean
+++ b/src/analysis/seminorm.lean
@@ -484,15 +484,13 @@ begin
   { intros hx i hi,
     have hp : (p i x).to_nnreal < 1 := lt_of_le_of_lt (seminorm_sup_le_aux p ι' i hi x) hx,
     rw [←nnreal.coe_lt_coe, (p i x).coe_to_nnreal ((p i).nonneg x)] at hp,
-    exact hp,
-  },
+    exact hp },
   intros hx,
   rw [←nnreal.coe_one, nnreal.coe_lt_coe, finset.sup_lt_iff],
   { intros i' hi',
     have hp : p i' x < 1 := hx i' hi',
     rw [←nnreal.coe_lt_coe, (p i' x).coe_to_nnreal ((p i').nonneg x)],
-    exact hp,
-  },
+    exact hp },
   simp,
 end
 

--- a/src/analysis/seminorm.lean
+++ b/src/analysis/seminorm.lean
@@ -256,13 +256,13 @@ variables [add_monoid E]
 section has_scalar
 variables [has_scalar 𝕜 E]
 
-instance : fun_like (seminorm 𝕜 E) E (λ _, ℝ) :=
+instance fun_like : fun_like (seminorm 𝕜 E) E (λ _, ℝ) :=
 { coe := seminorm.to_fun, coe_injective' := λ f g h, by cases f; cases g; congr' }
 
 /-- Helper instance for when there's too many metavariables to apply `fun_like`. -/
 instance : has_coe_to_fun (seminorm 𝕜 E) (λ _, E → ℝ) := ⟨λ p, p.to_fun⟩
 
-@[ext] lemma ext {p q : seminorm 𝕜 E} (h : (p : E → ℝ) = q) : p = q := fun_like.ext h
+@[ext] lemma ext {p q : seminorm 𝕜 E} (h : (p : E → ℝ) = q) : p = q := fun_like.ext p q h
 
 instance : has_zero (seminorm 𝕜 E) :=
 ⟨{ to_fun    := λ _, 0,
@@ -303,7 +303,7 @@ lemma le_def (p q : seminorm 𝕜 E) : p ≤ q ↔ (p : E → ℝ) ≤ q := iff.
 lemma lt_def (p q : seminorm 𝕜 E) : p < q ↔ (p : E → ℝ) < q := iff.rfl
 
 noncomputable instance : semilattice_sup (seminorm 𝕜 E) :=
-function.injective.semilattice_sup _ coe_injective coe_sup
+function.injective.semilattice_sup _ fun_like.coe_injective coe_sup
 
 end has_scalar
 

--- a/src/analysis/seminorm.lean
+++ b/src/analysis/seminorm.lean
@@ -293,7 +293,7 @@ noncomputable instance : has_sup (seminorm 𝕜 E) :=
 @[simp] lemma coe_sup (p q : seminorm 𝕜 E) : ⇑(p ⊔ q) = p ⊔ q := rfl
 
 instance : partial_order (seminorm 𝕜 E) :=
-  partial_order.lift _ coe_injective
+  partial_order.lift _ fun_like.coe_injective
 
 lemma le_def (p q : seminorm 𝕜 E) : p ≤ q ↔ (p : E → ℝ) ≤ q := iff.rfl
 lemma lt_def (p q : seminorm 𝕜 E) : p < q ↔ (p : E → ℝ) < q := iff.rfl

--- a/src/analysis/seminorm.lean
+++ b/src/analysis/seminorm.lean
@@ -263,8 +263,6 @@ instance : has_zero (seminorm 𝕜 E) :=
   smul'     := λ _ _, (mul_zero _).symm,
   triangle' := λ _ _, by rw add_zero }⟩
 
-@[simp] lemma coe_zero : (0 : seminorm 𝕜 E) = 0 := rfl
-
 instance : inhabited (seminorm 𝕜 E) := ⟨0⟩
 
 instance : has_coe_to_fun (seminorm 𝕜 E) (λ _, E → ℝ) := ⟨λ p, p.to_fun⟩
@@ -278,43 +276,6 @@ variables (p : seminorm 𝕜 E) (c : 𝕜) (x y : E) (r : ℝ)
 
 protected lemma smul : p (c • x) = ∥c∥ * p x := p.smul' _ _
 protected lemma triangle : p (x + y) ≤ p x + p y := p.triangle' _ _
-
-end has_scalar
-
-section smul_with_zero
-variables [smul_with_zero 𝕜 E] (p : seminorm 𝕜 E)
-
-@[simp]
-protected lemma zero : p 0 = 0 :=
-calc p 0 = p ((0 : 𝕜) • 0) : by rw zero_smul
-...      = 0 : by rw [p.smul, norm_zero, zero_mul]
-
-end smul_with_zero
-end add_monoid
-
-section norm_one_class
-variables [norm_one_class 𝕜] [add_comm_group E] [module 𝕜 E] (p : seminorm 𝕜 E) (x y : E) (r : ℝ)
-
-@[simp]
-protected lemma neg : p (-x) = p x :=
-calc p (-x) = p ((-1 : 𝕜) • x) : by rw neg_one_smul
-...         = p x : by rw [p.smul, norm_neg, norm_one, one_mul]
-
-protected lemma sub_le : p (x - y) ≤ p x + p y :=
-calc
-  p (x - y)
-      = p (x + -y) : by rw sub_eq_add_neg
-  ... ≤ p x + p (-y) : p.triangle x (-y)
-  ... = p x + p y : by rw p.neg
-
-lemma nonneg : 0 ≤ p x :=
-have h: 0 ≤ 2 * p x, from
-calc 0 = p (x + (- x)) : by rw [add_neg_self, p.zero]
-...    ≤ p x + p (-x)  : p.triangle _ _
-...    = 2 * p x : by rw [p.neg, two_mul],
-nonneg_of_mul_nonneg_left h zero_lt_two
-
-lemma sub_rev : p (x - y) = p (y - x) := by rw [←neg_sub, p.neg]
 
 lemma mul_sup {a b c : ℝ} (h₁ : 0 ≤ a) : a * (b ⊔ c) = (a * b) ⊔ (a * c) :=
 begin
@@ -340,13 +301,51 @@ function.injective.semilattice_sup _ coe_injective coe_sup
 lemma le_def (p q : seminorm 𝕜 E) : p ≤ q ↔ (p : E → ℝ) ≤ q := iff.rfl
 lemma lt_def (p q : seminorm 𝕜 E) : p < q ↔ (p : E → ℝ) < q := iff.rfl
 
+end has_scalar
+
+section smul_with_zero
+variables [smul_with_zero 𝕜 E] (p : seminorm 𝕜 E)
+
+@[simp]
+protected lemma zero : p 0 = 0 :=
+calc p 0 = p ((0 : 𝕜) • 0) : by rw zero_smul
+...      = 0 : by rw [p.smul, norm_zero, zero_mul]
+
+end smul_with_zero
+end add_monoid
+
+section norm_one_class
+variables [norm_one_class 𝕜] [add_comm_group E] [module 𝕜 E] (p : seminorm 𝕜 E) (x y : E) (r : ℝ)
+variables {ι : Type*}
+
+@[simp]
+protected lemma neg : p (-x) = p x :=
+calc p (-x) = p ((-1 : 𝕜) • x) : by rw neg_one_smul
+...         = p x : by rw [p.smul, norm_neg, norm_one, one_mul]
+
+protected lemma sub_le : p (x - y) ≤ p x + p y :=
+calc
+  p (x - y)
+      = p (x + -y) : by rw sub_eq_add_neg
+  ... ≤ p x + p (-y) : p.triangle x (-y)
+  ... = p x + p y : by rw p.neg
+
+lemma nonneg : 0 ≤ p x :=
+have h: 0 ≤ 2 * p x, from
+calc 0 = p (x + (- x)) : by rw [add_neg_self, p.zero]
+...    ≤ p x + p (-x)  : p.triangle _ _
+...    = 2 * p x : by rw [p.neg, two_mul],
+nonneg_of_mul_nonneg_left h zero_lt_two
+
+lemma sub_rev : p (x - y) = p (y - x) := by rw [←neg_sub, p.neg]
+
 instance : order_bot (seminorm 𝕜 E) :=
 { bot := 0,
   bot_le := nonneg }
 
 @[simp] lemma coe_bot : ⇑(⊥ : seminorm 𝕜 E) = 0 := rfl
 
-lemma finset_sup_apply {ι} (p : ι → seminorm 𝕜 E) (s : finset ι) (x : E) :
+lemma finset_sup_apply (p : ι → seminorm 𝕜 E) (s : finset ι) (x : E) :
   s.sup p x = ↑(s.sup (λ i, ⟨p i x, nonneg (p i) x⟩) : nnreal) :=
 begin
   induction s using finset.cons_induction_on with a s ha ih,
@@ -354,6 +353,11 @@ begin
   { rw [finset.sup_cons, finset.sup_cons, coe_sup, sup_eq_max, pi.sup_apply, sup_eq_max,
         nnreal.coe_max, subtype.coe_mk, ih] }
 end
+
+lemma finset_le_sup (p : ι → seminorm 𝕜 E) (ι' : finset ι) (i : ι) (hi : i ∈ ι') (x : E) :
+  p i x ≤ ι'.sup p x :=
+(finset.le_sup hi : p _ ≤ _) x
+
 end norm_one_class
 
 /-! ### Seminorm ball -/
@@ -379,7 +383,7 @@ lemma ball_zero_eq : ball p 0 r = { y : E | p y < r } := set.ext $ λ x, p.mem_b
 end has_scalar
 
 section module
-variables [norm_one_class 𝕜] [module 𝕜 E] (p : seminorm 𝕜 E)
+variables [norm_one_class 𝕜] [module 𝕜 E] (p : seminorm 𝕜 E) {ι : Type*}
 
 /-- Seminorm-balls at the origin are balanced. -/
 lemma balanced_ball_zero (r : ℝ): balanced 𝕜 (ball p 0 r) :=
@@ -388,6 +392,23 @@ begin
   rw [mem_ball_zero, ←hx, p.smul],
   calc _ ≤ p y : mul_le_of_le_one_left (p.nonneg _) ha
   ...    < r   : by rwa mem_ball_zero at hy,
+end
+
+lemma finset_sup_ball_inter (p : ι → seminorm 𝕜 E) (ι' : finset ι) (r : ℝ) (hr : 0 < r):
+  ball (ι'.sup p) 0 r = ⋂ (i ∈ ι'), ball (p i) (0 : E) r :=
+begin
+  dunfold ball,
+  ext,
+  simp,
+  split,
+  { intros hx i hi,
+    exact lt_of_le_of_lt (finset_le_sup p ι' i hi x) hx },
+  intros hx,
+  rw [finset_sup_apply, ←r.coe_to_nnreal (has_lt.lt.le hr), nnreal.coe_lt_coe, finset.sup_lt_iff],
+  { intros i hi,
+    rw [←nnreal.coe_lt_coe, r.coe_to_nnreal (has_lt.lt.le hr)],
+    exact (hx i hi) },
+  simp[hr],
 end
 
 end module
@@ -457,36 +478,6 @@ end
 
 end module
 end normed_linear_ordered_field
-
-section seminorm_sup
-
-variables [normed_field 𝕜] [add_comm_group E] [module 𝕜 E] [semi_normed_space ℝ 𝕜]
-variables [module ℝ E]
-variables {ι : Type*} [decidable_eq ι]
-variables (p : ι → seminorm 𝕜 E)
-variables (ι' : finset ι)
-
-lemma seminorm_le_sup (p : ι → seminorm 𝕜 E) (ι' : finset ι) (i : ι) (hi : i ∈ ι') (x : E) :
-  p i x ≤ ι'.sup p x :=
-(finset.le_sup hi : p _ ≤ _) x
-
-lemma seminorm_sup_ball_int (p : ι → seminorm 𝕜 E) (ι' : finset ι) :
-  ball (ι'.sup p) 0 1 = ⋂ (i ∈ ι'), ball (p i) (0 : E) 1 :=
-begin
-  dunfold ball,
-  ext,
-  simp,
-  split,
-  { intros hx i hi,
-    exact lt_of_le_of_lt (seminorm_le_sup p ι' i hi x) hx },
-  intros hx,
-  rw [finset_sup_apply, ←nnreal.coe_one, nnreal.coe_lt_coe, finset.sup_lt_iff],
-  { intros i hi,
-    exact (hx i hi) },
-  simp,
-end
-
-end seminorm_sup
 
 -- TODO: convexity and absorbent/balanced sets in vector spaces over ℝ
 

--- a/src/analysis/seminorm.lean
+++ b/src/analysis/seminorm.lean
@@ -317,17 +317,6 @@ lemma sub_rev : p (x - y) = p (y - x) := by rw [←neg_sub, p.neg]
 variables {α : Type*} [semilattice_sup α] {a b c d : α}
 variables (h₁ : a = b)
 
-theorem sup_eq_sup (h₁ : a = b) (h₂ : c = d) : a ⊔ c = b ⊔ d :=
-begin
-  refine le_antisymm _ _,
-  { refine sup_le_sup _ _,
-    exact (le_antisymm_iff.mp h₁).1,
-    exact (le_antisymm_iff.mp h₂).1 },
-  refine sup_le_sup _ _,
-  exact (le_antisymm_iff.mp h₁).2,
-  exact (le_antisymm_iff.mp h₂).2,
-end
-
 lemma mul_sup {a b c : ℝ} (h₁ : 0 ≤ a) : a * (b ⊔ c) = (a * b) ⊔ (a * c) :=
 begin
   cases le_total b c with h h,
@@ -353,9 +342,7 @@ instance : has_sup (seminorm 𝕜 E) :=
         intros x v,
         simp,
         rw mul_sup (norm_nonneg x),
-        rw sup_eq_sup,
-        exact p.smul x v,
-        exact q.smul x v,
+        rw [p.smul x v, q.smul x v],
       end }}
 
 @[simp] lemma coe_sup (x y : seminorm 𝕜 E) : ⇑(x ⊔ y) = x ⊔ y := rfl
@@ -480,13 +467,6 @@ variables [module ℝ E]
 variables {ι : Type*} [decidable_eq ι]
 variables (p : ι → seminorm 𝕜 E)
 variables (ι' : finset ι)
-
-@[simp]
-lemma seminorm_sup_singleton (p : ι → seminorm 𝕜 E) (i : ι):
-  ({i} : finset ι).sup p = p i :=
-begin
-  simp,
-end
 
 lemma seminorm_sup_finset_coe_to_fun (p : ι → seminorm 𝕜 E) (ι' : finset ι) :
   coe_fn (ι'.sup p) = λ x, ↑(ι'.sup (λ i, (p i x).to_nnreal)) :=

--- a/src/analysis/seminorm.lean
+++ b/src/analysis/seminorm.lean
@@ -483,8 +483,7 @@ begin
   rw [finset_sup_apply, ←nnreal.coe_one, nnreal.coe_lt_coe, finset.sup_lt_iff],
   {
     intros i hi,
-    have hp : p i x < 1 := hx i hi,
-    exact hp,
+    exact (hx i hi),
   },
   simp,
 end

--- a/src/analysis/seminorm.lean
+++ b/src/analysis/seminorm.lean
@@ -424,9 +424,6 @@ variables [normed_field 𝕜] [add_comm_group E] [module 𝕜 E] [semi_normed_sp
 variables [module ℝ E]
 variables {ι : Type*} [decidable_eq ι]
 
-lemma seminorm_sup_le_aux (p : ι → seminorm 𝕜 E) (ι' : finset ι) (i : ι) (hi : i ∈ ι') (x : E) :
-  (p i x).to_nnreal ≤ ι'.sup (λ (i : ι), (p i x).to_nnreal) := by exact finset.le_sup hi
-
 def seminorm_sup_finset (p : ι → seminorm 𝕜 E) (ι' : finset ι) : seminorm 𝕜 E :=
   { to_fun := λ x, ↑(ι'.sup (λ i, (p i x).to_nnreal)),
   smul' :=
@@ -454,9 +451,8 @@ def seminorm_sup_finset (p : ι → seminorm 𝕜 E) (ι' : finset ι) : seminor
         exact (p i).triangle x y,
       end,
       apply le_trans hpxy,
-      exact add_le_add (seminorm_sup_le_aux p ι' i hi x) (seminorm_sup_le_aux p ι' i hi y),
+      exact add_le_add (finset.le_sup hi) (finset.le_sup hi)
     end }
-
 
 lemma seminorm_sup_finset_coe_to_fun (p : ι → seminorm 𝕜 E) (ι' : finset ι) :
   coe_fn (seminorm_sup_finset p ι') =
@@ -472,7 +468,6 @@ begin
   exact (p i).nonneg x,
 end
 
-
 lemma seminorm_sup_ball_int (p : ι → seminorm 𝕜 E) (ι' : finset ι) :
   ball (seminorm_sup_finset p ι') 0 1 = ⋂ (i ∈ ι'), ball (p i) (0 : E) 1 :=
 begin
@@ -482,7 +477,7 @@ begin
   simp,
   split,
   { intros hx i hi,
-    have hp : (p i x).to_nnreal < 1 := lt_of_le_of_lt (seminorm_sup_le_aux p ι' i hi x) hx,
+    have hp : (p i x).to_nnreal < 1 := lt_of_le_of_lt (@finset.le_sup _ _ _ _ _ _ i hi) hx,
     rw [←nnreal.coe_lt_coe, (p i x).coe_to_nnreal ((p i).nonneg x)] at hp,
     exact hp },
   intros hx,

--- a/src/analysis/seminorm.lean
+++ b/src/analysis/seminorm.lean
@@ -278,21 +278,18 @@ variables (p : seminorm 𝕜 E) (c : 𝕜) (x y : E) (r : ℝ)
 protected lemma smul : p (c • x) = ∥c∥ * p x := p.smul' _ _
 protected lemma triangle : p (x + y) ≤ p x + p y := p.triangle' _ _
 
-lemma mul_sup {a b c : ℝ} (h₁ : 0 ≤ a) : a * (b ⊔ c) = (a * b) ⊔ (a * c) :=
-begin
-  cases le_total b c with h h,
-  { simp [sup_eq_max, max_eq_right h, max_eq_right (mul_le_mul_of_nonneg_left h h₁)] },
-  { simp [sup_eq_max, max_eq_left h, max_eq_left (mul_le_mul_of_nonneg_left h h₁)] },
-end
-
 noncomputable instance : has_sup (seminorm 𝕜 E) :=
 { sup := λ p q,
   { to_fun := p ⊔ q,
     triangle' := λ x y, sup_le
       ((p.triangle x y).trans $ add_le_add le_sup_left le_sup_left)
       ((q.triangle x y).trans $ add_le_add le_sup_right le_sup_right),
-    smul' := λ x v, (congr_arg2 (⊔) (p.smul x v) (q.smul x v)).trans $
-      (mul_sup $ norm_nonneg x).symm } }
+    smul' := λ x v,
+    begin
+      simp,
+      rw [sup_eq_max, sup_eq_max, p.smul x v, q.smul x v,
+        (mul_max_of_nonneg (p v) (q v) (norm_nonneg x))],
+    end } }
 
 @[simp] lemma coe_sup (p q : seminorm 𝕜 E) : ⇑(p ⊔ q) = p ⊔ q := rfl
 

--- a/src/analysis/seminorm.lean
+++ b/src/analysis/seminorm.lean
@@ -416,6 +416,92 @@ end
 end module
 end normed_linear_ordered_field
 
+section seminorm_sup
+
+noncomputable theory
+
+variables [normed_field 𝕜] [add_comm_group E] [module 𝕜 E] [semi_normed_space ℝ 𝕜]
+variables [module ℝ E]
+variables {ι : Type*} [decidable_eq ι]
+
+lemma seminorm_sup_le_aux (p : ι → seminorm 𝕜 E) (ι' : finset ι) (i : ι) (hi : i ∈ ι') (x : E) :
+  (p i x).to_nnreal ≤ ι'.sup (λ (i : ι), (p i x).to_nnreal) := by exact finset.le_sup hi
+
+def seminorm_sup_finset (p : ι → seminorm 𝕜 E) (ι' : finset ι) : seminorm 𝕜 E :=
+  { to_fun := λ x, ↑(ι'.sup (λ i, (p i x).to_nnreal)),
+  smul' :=
+    begin
+      intros x v,
+      rw [←∥x∥.coe_to_nnreal (norm_nonneg x), ←nnreal.coe_mul, nnreal.coe_eq],
+      rw (∥x∥.to_nnreal).mul_finset_sup,
+      refine finset.sup_congr _ _,
+      trivial,
+      intros i hi,
+      rw [←nnreal.coe_eq, nnreal.coe_mul, ∥x∥.coe_to_nnreal (norm_nonneg x),
+      (p i v).coe_to_nnreal (nonneg (p i) v), (p i (x • v)).coe_to_nnreal (nonneg (p i) (x • v))],
+      exact (p i).smul x v,
+    end,
+  triangle' :=
+    begin
+      intros x y,
+      rw [←nnreal.coe_add, nnreal.coe_le_coe],
+      refine finset.sup_le _,
+      intros i hi,
+      have hpxy : ((p i) (x + y)).to_nnreal ≤ (p i x).to_nnreal + (p i y).to_nnreal :=
+      begin
+        rw real.to_nnreal_add_to_nnreal (nonneg (p i) x) (nonneg (p i) y),
+        apply real.to_nnreal_le_to_nnreal,
+        exact (p i).triangle x y,
+      end,
+      apply le_trans hpxy,
+      exact add_le_add (seminorm_sup_le_aux p ι' i hi x) (seminorm_sup_le_aux p ι' i hi y),
+    end }
+
+
+lemma seminorm_sup_finset_coe_to_fun (p : ι → seminorm 𝕜 E) (ι' : finset ι) :
+  coe_fn (seminorm_sup_finset p ι') =
+  λ x, ↑(ι'.sup (λ i, (p i x).to_nnreal)) := rfl
+
+@[simp]
+lemma seminorm_sup_singleton (p : ι → seminorm 𝕜 E) (i : ι):
+  seminorm_sup_finset p {i} = p i :=
+begin
+  ext,
+  rw seminorm_sup_finset_coe_to_fun,
+  simp,
+  exact (p i).nonneg x,
+end
+
+
+-- Show that this is a seminorm
+-- Show that its unit ball is given by intersection
+lemma seminorm_sup_ball_int (p : ι → seminorm 𝕜 E) (ι' : finset ι) :
+  ball (seminorm_sup_finset p ι') 0 1 = ⋂ (i ∈ ι'), ball (p i) (0 : E) 1 :=
+begin
+  dunfold ball,
+  ext,
+  rw seminorm_sup_finset_coe_to_fun,
+  simp,
+  split,
+  {
+    intros hx i hi,
+    have hp : (p i x).to_nnreal < 1 := lt_of_le_of_lt (seminorm_sup_le_aux p ι' i hi x) hx,
+    rw [←nnreal.coe_lt_coe, (p i x).coe_to_nnreal ((p i).nonneg x)] at hp,
+    exact hp,
+  },
+  intros hx,
+  rw [←nnreal.coe_one, nnreal.coe_lt_coe, finset.sup_lt_iff],
+  {
+    intros i' hi',
+    have hp : p i' x < 1 := hx i' hi',
+    rw [←nnreal.coe_lt_coe, (p i' x).coe_to_nnreal ((p i').nonneg x)],
+    exact hp,
+  },
+  simp,
+end
+
+end seminorm_sup
+
 -- TODO: convexity and absorbent/balanced sets in vector spaces over ℝ
 
 end seminorm
@@ -710,5 +796,7 @@ lemma seminorm.gauge_seminorm_ball (p : seminorm ℝ E) :
 seminorm.ext p.gauge_ball
 
 end gauge
+
+
 
 -- TODO: topology induced by family of seminorms, local convexity.

--- a/src/analysis/seminorm.lean
+++ b/src/analysis/seminorm.lean
@@ -374,6 +374,12 @@ lemma mem_ball_zero : y ∈ ball p 0 r ↔ p y < r := by rw [mem_ball, sub_zero]
 
 lemma ball_zero_eq : ball p 0 r = { y : E | p y < r } := set.ext $ λ x, p.mem_ball_zero
 
+lemma zero_ball_eq_univ (hr : 0 < r) : ball (0 : seminorm 𝕜 E) x r = set.univ :=
+begin
+  rw [set.eq_univ_iff_forall, ball],
+  simp [hr],
+end
+
 end has_scalar
 
 section module

--- a/src/analysis/seminorm.lean
+++ b/src/analysis/seminorm.lean
@@ -386,7 +386,8 @@ end has_scalar
 section module
 variables [norm_one_class 𝕜] [module 𝕜 E] (p : seminorm 𝕜 E)
 
-lemma ball_bot {r : ℝ} (x : E) (hr : 0 < r) : ball (⊥ : seminorm 𝕜 E) x r = set.univ := ball_zero' x hr
+@[simp] lemma ball_bot {r : ℝ} (x : E) (hr : 0 < r) : ball (⊥ : seminorm 𝕜 E) x r = set.univ :=
+ball_zero' x hr
 
 /-- Seminorm-balls at the origin are balanced. -/
 lemma balanced_ball_zero (r : ℝ): balanced 𝕜 (ball p 0 r) :=

--- a/src/analysis/seminorm.lean
+++ b/src/analysis/seminorm.lean
@@ -345,12 +345,12 @@ instance : order_bot (seminorm 𝕜 E) :=
 
 lemma bot_eq_zero : (⊥ : seminorm 𝕜 E) = 0 := rfl
 
-
 lemma finset_sup_apply (p : ι → seminorm 𝕜 E) (s : finset ι) (x : E) :
   s.sup p x = ↑(s.sup (λ i, ⟨p i x, nonneg (p i) x⟩) : nnreal) :=
 begin
   induction s using finset.cons_induction_on with a s ha ih,
-  { rw [finset.sup_empty, finset.sup_empty, coe_bot, bot_eq_zero, pi.zero_apply, nonneg.coe_zero] },
+  { rw [finset.sup_empty, finset.sup_empty, coe_bot, _root_.bot_eq_zero, pi.zero_apply,
+        nonneg.coe_zero] },
   { rw [finset.sup_cons, finset.sup_cons, coe_sup, sup_eq_max, pi.sup_apply, sup_eq_max,
         nnreal.coe_max, subtype.coe_mk, ih] }
 end

--- a/src/analysis/seminorm.lean
+++ b/src/analysis/seminorm.lean
@@ -352,6 +352,9 @@ instance : has_sup (seminorm 𝕜 E) :=
 instance : semilattice_sup (seminorm 𝕜 E) :=
 function.injective.semilattice_sup _ coe_injective coe_sup
 
+lemma le_def (x y : seminorm 𝕜 E) : x ≤ y ↔ (x : E → ℝ) ≤ y := iff.rfl
+lemma lt_def (x y : seminorm 𝕜 E) : x < y ↔ (x : E → ℝ) < y := iff.rfl
+
 instance : order_bot (seminorm 𝕜 E) :=
 { bot := 0,
   bot_le := nonneg }

--- a/src/analysis/seminorm.lean
+++ b/src/analysis/seminorm.lean
@@ -481,10 +481,8 @@ begin
     exact lt_of_le_of_lt (seminorm_le_sup p ι' i hi x) hx },
   intros hx,
   rw [finset_sup_apply, ←nnreal.coe_one, nnreal.coe_lt_coe, finset.sup_lt_iff],
-  {
-    intros i hi,
-    exact (hx i hi),
-  },
+  { intros i hi,
+    exact (hx i hi) },
   simp,
 end
 

--- a/src/analysis/seminorm.lean
+++ b/src/analysis/seminorm.lean
@@ -68,7 +68,7 @@ Absorbent and balanced sets in a vector space over a normed field.
 open normed_field set
 open_locale pointwise topological_space
 
-variables {𝕜 E : Type*}
+variables {𝕜 E ι : Type*}
 
 section semi_normed_ring
 variables [semi_normed_ring 𝕜]
@@ -267,7 +267,7 @@ instance : has_coe_to_fun (seminorm 𝕜 E) (λ _, E → ℝ) := ⟨λ p, p.to_f
 instance : has_zero (seminorm 𝕜 E) :=
 ⟨{ to_fun    := 0,
   smul'     := λ _ _, (mul_zero _).symm,
-  triangle' := λ _ _, by rw add_zero }⟩
+  triangle' := λ _ _, eq.ge (zero_add _) }⟩
 
 @[simp] lemma coe_zero : ⇑(0 : seminorm 𝕜 E) = 0 := rfl
 
@@ -315,7 +315,6 @@ end add_monoid
 
 section norm_one_class
 variables [norm_one_class 𝕜] [add_comm_group E] [module 𝕜 E] (p : seminorm 𝕜 E) (x y : E) (r : ℝ)
-variables {ι : Type*}
 
 @[simp]
 protected lemma neg : p (-x) = p x :=
@@ -378,7 +377,7 @@ lemma ball_zero_eq : ball p 0 r = { y : E | p y < r } := set.ext $ λ x, p.mem_b
 end has_scalar
 
 section module
-variables [norm_one_class 𝕜] [module 𝕜 E] (p : seminorm 𝕜 E) {ι : Type*}
+variables [norm_one_class 𝕜] [module 𝕜 E] (p : seminorm 𝕜 E)
 
 /-- Seminorm-balls at the origin are balanced. -/
 lemma balanced_ball_zero (r : ℝ): balanced 𝕜 (ball p 0 r) :=
@@ -397,7 +396,15 @@ begin
     finset.sup_lt_iff (show ⊥ < r, from hr), ←nnreal.coe_lt_coe, subtype.coe_mk],
 end
 
-lemma ball_finset_sup_eq_finset_inf (p : ι → seminorm 𝕜 E) (s : finset ι) (e : E) {r : ℝ}
+lemma ball_sup (p : seminorm 𝕜 E) (q : seminorm 𝕜 E) (e : E) {r : ℝ} (hr : 0 < r) :
+  ball (p ⊔ q) e r = (ball p e r) ⊓ (ball q e r) :=
+begin
+  lift r to nnreal using hr.le,
+  simp_rw [set.inf_eq_inter, ball, ←set.set_of_and],
+  simp,
+end
+
+lemma ball_finset_sup (p : ι → seminorm 𝕜 E) (s : finset ι) (e : E) {r : ℝ}
   (hr : 0 < r) : ball (s.sup p) e r = s.inf (λ i, ball (p i) e r) :=
 begin
   rw finset.inf_eq_infi,

--- a/src/analysis/seminorm.lean
+++ b/src/analysis/seminorm.lean
@@ -765,7 +765,7 @@ end
 
 lemma seminorm.gauge_seminorm_ball (p : seminorm ℝ E) :
   gauge_seminorm (λ x, p.symmetric_ball_zero 1) (p.convex_ball 0 1)
-    (p.absorbent_ball_zero zero_lt_one) = p := seminorm.ext p.gauge_ball
+    (p.absorbent_ball_zero zero_lt_one) = p := fun_like.coe_injective p.gauge_ball
 
 end gauge
 

--- a/src/analysis/seminorm.lean
+++ b/src/analysis/seminorm.lean
@@ -381,10 +381,10 @@ begin
   simp [hr],
 end
 
-lemma ball_sup (p : seminorm 𝕜 E) (q : seminorm 𝕜 E) (e : E) {r : ℝ} (hr : 0 < r) :
+lemma ball_sup (p : seminorm 𝕜 E) (q : seminorm 𝕜 E) (e : E) {r : ℝ} (hr : 0 ≤ r) :
   ball (p ⊔ q) e r = ball p e r ∩ ball q e r :=
 begin
-  lift r to nnreal using hr.le,
+  lift r to nnreal using hr,
   simp_rw [ball, ←set.set_of_and],
   simp,
 end

--- a/src/analysis/seminorm.lean
+++ b/src/analysis/seminorm.lean
@@ -395,17 +395,12 @@ begin
   ...    < r   : by rwa mem_ball_zero at hy,
 end
 
-lemma finset_sup_ball_inter (p : ι → seminorm 𝕜 E) (s : finset ι) (r : ℝ) (hr : 0 < r):
-  ball (s.sup p) 0 r = ⋂ (i ∈ s), ball (p i) (0 : E) r :=
+lemma finset_sup_ball_inter (p : ι → seminorm 𝕜 E) (s : finset ι) (e : E) (r : ℝ) (hr : 0 < r):
+  ball (s.sup p) e r = ⋂ (i ∈ s), ball (p i) e r :=
 begin
-  ext,
-  simp_rw [mem_Inter, mem_ball_zero],
-  refine ⟨λ hx i hi, (finset_le_sup p s i hi x).trans_lt hx, λ hx, _⟩,
-  rw [finset_sup_apply, ←r.coe_to_nnreal hr.le, nnreal.coe_lt_coe, finset.sup_lt_iff],
-  { intros i hi,
-    rw [←nnreal.coe_lt_coe, r.coe_to_nnreal hr.le],
-    exact (hx i hi) },
-  simp [hr],
+  lift r to nnreal using hr.le,
+  simp_rw [ball, Inter_set_of, finset_sup_apply, nnreal.coe_lt_coe,
+    finset.sup_lt_iff (show ⊥ < r, from hr), ←nnreal.coe_lt_coe, subtype.coe_mk],
 end
 
 end module

--- a/src/analysis/seminorm.lean
+++ b/src/analysis/seminorm.lean
@@ -740,8 +740,9 @@ end
   triangle' := gauge_add_le hs hs' }
 
 /-- Any seminorm arises a the gauge of its unit ball. -/
-lemma seminorm.gauge_ball (p : seminorm ℝ E) (x : E): gauge (p.ball 0 1) x = p x :=
+lemma seminorm.gauge_ball (p : seminorm ℝ E) : gauge (p.ball 0 1) = p :=
 begin
+  ext,
   obtain hp | hp := {r : ℝ | 0 < r ∧ x ∈ r • p.ball 0 1}.eq_empty_or_nonempty,
   { rw [gauge, hp, real.Inf_empty],
     by_contra,

--- a/src/analysis/seminorm.lean
+++ b/src/analysis/seminorm.lean
@@ -403,10 +403,10 @@ begin
 end
 
 lemma ball_sup (p : seminorm 𝕜 E) (q : seminorm 𝕜 E) (e : E) {r : ℝ} (hr : 0 < r) :
-  ball (p ⊔ q) e r = (ball p e r) ⊓ (ball q e r) :=
+  ball (p ⊔ q) e r = ball p e r ∩ ball q e r :=
 begin
   lift r to nnreal using hr.le,
-  simp_rw [set.inf_eq_inter, ball, ←set.set_of_and],
+  simp_rw [ball, ←set.set_of_and],
   simp,
 end
 

--- a/src/analysis/seminorm.lean
+++ b/src/analysis/seminorm.lean
@@ -258,10 +258,7 @@ variables [has_scalar 𝕜 E]
 
 instance : has_coe_to_fun (seminorm 𝕜 E) (λ _, E → ℝ) := ⟨λ p, p.to_fun⟩
 
-lemma coe_injective : @function.injective (seminorm 𝕜 E) (E → ℝ) coe_fn
-| ⟨x, _, _⟩ ⟨y, _, _⟩ rfl := rfl
-
-@[ext] lemma ext {p q : seminorm 𝕜 E} (h : (p : E → ℝ) = q) : p = q := coe_injective h
+@[ext] lemma ext {p q : seminorm 𝕜 E} (h : (p : E → ℝ) = q) : p = q := fun_like.ext h
 
 instance : has_zero (seminorm 𝕜 E) :=
 ⟨{ to_fun    := λ _, 0,

--- a/src/analysis/seminorm.lean
+++ b/src/analysis/seminorm.lean
@@ -342,7 +342,7 @@ nonneg_of_mul_nonneg_left h zero_lt_two
 
 lemma sub_rev : p (x - y) = p (y - x) := by rw [←neg_sub, p.neg]
 
-noncomputable instance : order_bot (seminorm 𝕜 E) :=
+instance : order_bot (seminorm 𝕜 E) :=
 { bot := 0,
   bot_le := nonneg }
 

--- a/src/analysis/seminorm.lean
+++ b/src/analysis/seminorm.lean
@@ -381,6 +381,14 @@ begin
   simp [hr],
 end
 
+lemma ball_sup (p : seminorm 𝕜 E) (q : seminorm 𝕜 E) (e : E) {r : ℝ} (hr : 0 < r) :
+  ball (p ⊔ q) e r = ball p e r ∩ ball q e r :=
+begin
+  lift r to nnreal using hr.le,
+  simp_rw [ball, ←set.set_of_and],
+  simp,
+end
+
 end has_scalar
 
 section module
@@ -404,14 +412,6 @@ begin
   lift r to nnreal using hr.le,
   simp_rw [ball, Inter_set_of, finset_sup_apply, nnreal.coe_lt_coe,
     finset.sup_lt_iff (show ⊥ < r, from hr), ←nnreal.coe_lt_coe, subtype.coe_mk],
-end
-
-lemma ball_sup (p : seminorm 𝕜 E) (q : seminorm 𝕜 E) (e : E) {r : ℝ} (hr : 0 < r) :
-  ball (p ⊔ q) e r = ball p e r ∩ ball q e r :=
-begin
-  lift r to nnreal using hr.le,
-  simp_rw [ball, ←set.set_of_and],
-  simp,
 end
 
 lemma ball_finset_sup (p : ι → seminorm 𝕜 E) (s : finset ι) (e : E) {r : ℝ}

--- a/src/analysis/seminorm.lean
+++ b/src/analysis/seminorm.lean
@@ -389,7 +389,7 @@ begin
   ...    < r   : by rwa mem_ball_zero at hy,
 end
 
-lemma ball_finset_sup_eq_Inter (p : ι → seminorm 𝕜 E) (s : finset ι) (e : E) (r : ℝ) (hr : 0 < r) :
+lemma ball_finset_sup_eq_Inter (p : ι → seminorm 𝕜 E) (s : finset ι) (e : E) {r : ℝ} (hr : 0 < r) :
   ball (s.sup p) e r = ⋂ (i ∈ s), ball (p i) e r :=
 begin
   lift r to nnreal using hr.le,
@@ -397,11 +397,11 @@ begin
     finset.sup_lt_iff (show ⊥ < r, from hr), ←nnreal.coe_lt_coe, subtype.coe_mk],
 end
 
-lemma ball_finset_sup_eq_finset_inf (p : ι → seminorm 𝕜 E) (s : finset ι) (e : E) (r : ℝ)
+lemma ball_finset_sup_eq_finset_inf (p : ι → seminorm 𝕜 E) (s : finset ι) (e : E) {r : ℝ}
   (hr : 0 < r) : ball (s.sup p) e r = s.inf (λ i, ball (p i) e r) :=
 begin
   rw finset.inf_eq_infi,
-  exact ball_finset_sup_eq_Inter _ _ _ _ hr,
+  exact ball_finset_sup_eq_Inter _ _ _ hr,
 end
 
 end module

--- a/src/analysis/seminorm.lean
+++ b/src/analysis/seminorm.lean
@@ -247,8 +247,6 @@ structure seminorm (𝕜 : Type*) (E : Type*) [semi_normed_ring 𝕜] [add_monoi
 
 namespace seminorm
 
-noncomputable theory
-
 section semi_normed_ring
 variables [semi_normed_ring 𝕜]
 
@@ -286,7 +284,7 @@ begin
   { simp [sup_eq_max, max_eq_left h, max_eq_left (mul_le_mul_of_nonneg_left h h₁)] },
 end
 
-instance : has_sup (seminorm 𝕜 E) :=
+noncomputable instance : has_sup (seminorm 𝕜 E) :=
 { sup := λ p q,
   { to_fun := p ⊔ q,
     triangle' := λ x y, sup_le
@@ -297,7 +295,7 @@ instance : has_sup (seminorm 𝕜 E) :=
 
 @[simp] lemma coe_sup (p q : seminorm 𝕜 E) : ⇑(p ⊔ q) = p ⊔ q := rfl
 
-instance : semilattice_sup (seminorm 𝕜 E) :=
+noncomputable instance : semilattice_sup (seminorm 𝕜 E) :=
 function.injective.semilattice_sup _ coe_injective coe_sup
 
 lemma le_def (p q : seminorm 𝕜 E) : p ≤ q ↔ (p : E → ℝ) ≤ q := iff.rfl
@@ -341,7 +339,7 @@ nonneg_of_mul_nonneg_left h zero_lt_two
 
 lemma sub_rev : p (x - y) = p (y - x) := by rw [←neg_sub, p.neg]
 
-instance : order_bot (seminorm 𝕜 E) :=
+noncomputable instance : order_bot (seminorm 𝕜 E) :=
 { bot := 0,
   bot_le := nonneg }
 

--- a/src/analysis/seminorm.lean
+++ b/src/analysis/seminorm.lean
@@ -343,6 +343,9 @@ instance : order_bot (seminorm 𝕜 E) :=
 
 @[simp] lemma coe_bot : ⇑(⊥ : seminorm 𝕜 E) = 0 := rfl
 
+lemma bot_eq_zero : (⊥ : seminorm 𝕜 E) = 0 := rfl
+
+
 lemma finset_sup_apply (p : ι → seminorm 𝕜 E) (s : finset ι) (x : E) :
   s.sup p x = ↑(s.sup (λ i, ⟨p i x, nonneg (p i) x⟩) : nnreal) :=
 begin

--- a/src/analysis/seminorm.lean
+++ b/src/analysis/seminorm.lean
@@ -358,6 +358,14 @@ instance : order_bot (seminorm 𝕜 E) :=
 
 @[simp] lemma coe_bot : ⇑(⊥ : seminorm 𝕜 E) = 0 := rfl
 
+lemma finset_sup_apply {ι} (p : ι → seminorm 𝕜 E) (s : finset ι) (x : E) :
+  s.sup p x = ↑(s.sup (λ i, ⟨p i x, nonneg (p i) x⟩) : nnreal) :=
+begin
+  induction s using finset.cons_induction_on with a s ha ih,
+  { rw [finset.sup_empty, finset.sup_empty, coe_bot, bot_eq_zero, pi.zero_apply, nonneg.coe_zero] },
+  { rw [finset.sup_cons, finset.sup_cons, coe_sup, sup_eq_max, pi.sup_apply, sup_eq_max,
+        nnreal.coe_max, subtype.coe_mk, ih] }
+end
 end norm_one_class
 
 /-! ### Seminorm ball -/

--- a/src/analysis/seminorm.lean
+++ b/src/analysis/seminorm.lean
@@ -374,7 +374,7 @@ lemma mem_ball_zero : y ∈ ball p 0 r ↔ p y < r := by rw [mem_ball, sub_zero]
 
 lemma ball_zero_eq : ball p 0 r = { y : E | p y < r } := set.ext $ λ x, p.mem_ball_zero
 
-lemma zero_ball_eq_univ (hr : 0 < r) : ball (0 : seminorm 𝕜 E) x r = set.univ :=
+lemma ball_zero' (x : E) (hr : 0 < r) : ball (0 : seminorm 𝕜 E) x r = set.univ :=
 begin
   rw [set.eq_univ_iff_forall, ball],
   simp [hr],

--- a/src/analysis/seminorm.lean
+++ b/src/analysis/seminorm.lean
@@ -256,6 +256,10 @@ variables [add_monoid E]
 section has_scalar
 variables [has_scalar 𝕜 E]
 
+instance : fun_like (seminorm 𝕜 E) E (λ _, ℝ) :=
+{ coe := seminorm.to_fun, coe_injective' := λ f g h, by cases f; cases g; congr' }
+
+/-- Helper instance for when there's too many metavariables to apply `fun_like`. -/
 instance : has_coe_to_fun (seminorm 𝕜 E) (λ _, E → ℝ) := ⟨λ p, p.to_fun⟩
 
 @[ext] lemma ext {p q : seminorm 𝕜 E} (h : (p : E → ℝ) = q) : p = q := fun_like.ext h


### PR DESCRIPTION
Define `bot` and the the binary `sup` on seminorms, and some lemmas about the supremum of a finite number of seminorms.
Shows that the unit ball of the supremum is given by the intersection of the unit balls.


Co-authored-by: Eric Wieser <wieser.eric@gmail.com>

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
