### PR TITLE
[Merged by Bors] - feat(analysis/normed_space/linear_isometry): basis ext lemmas

### DIFF
--- a/src/analysis/normed_space/linear_isometry.lean
+++ b/src/analysis/normed_space/linear_isometry.lean
@@ -5,6 +5,7 @@ Authors: Yury Kudryashov, Frédéric Dupuis, Heather Macbeth
 -/
 import analysis.normed.group.basic
 import topology.algebra.module.basic
+import linear_algebra.basis
 
 /-!
 # (Semi-)linear isometries
@@ -457,3 +458,17 @@ rfl
 rfl
 
 end linear_isometry_equiv
+
+/-- Two linear isometries are equal if they are equal on basis vectors. -/
+lemma basis.ext_linear_isometry {ι : Type*} (b : basis ι R E) {f₁ f₂ : E →ₛₗᵢ[σ₁₂] E₂}
+  (h : ∀ i, f₁ (b i) = f₂ (b i)) : f₁ = f₂ :=
+linear_isometry.to_linear_map_injective $ b.ext h
+
+include σ₂₁
+
+/-- Two linear isometric equivalences are equal if they are equal on basis vectors. -/
+lemma basis.ext_linear_isometry_equiv {ι : Type*} (b : basis ι R E) {f₁ f₂ : E ≃ₛₗᵢ[σ₁₂] E₂}
+  (h : ∀ i, f₁ (b i) = f₂ (b i)) : f₁ = f₂ :=
+linear_isometry_equiv.to_linear_equiv_injective $ b.ext' h
+
+omit σ₂₁


### PR DESCRIPTION
Add lemmas that two linear isometries / linear isometric equivalences
are equal if they are equal on basis vectors, similar to such lemmas
for equality on basis vectors of other kinds of maps.



---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
