### PR TITLE
[Merged by Bors] - feat(linear_algebra/determinant): `linear_equiv.det_conj`

### DIFF
--- a/src/linear_algebra/determinant.lean
+++ b/src/linear_algebra/determinant.lean
@@ -332,6 +332,11 @@ protected def det : (M ≃ₗ[R] M) →* Rˣ :=
 
 @[simp] lemma det_symm (f : M ≃ₗ[R] M) : f.symm.det = f.det⁻¹ := map_inv _ f
 
+/-- Conjugating a linear equiv by a linear equiv does not change its determinant. -/
+@[simp] lemma det_conj (f : M ≃ₗ[R] M) (e : M ≃ₗ[R] M') :
+  ((e.symm.trans f).trans e).det = f.det :=
+by rw [←units.eq_iff, coe_det, coe_det, ←comp_coe, ←comp_coe, linear_map.det_conj]
+
 end linear_equiv
 
 /-- The determinants of a `linear_equiv` and its inverse multiply to 1. -/


### PR DESCRIPTION
Add a version of the `linear_map.det_conj` lemma for `linear_equiv.det`.



---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
