### PR TITLE
[Merged by Bors] - fix(docs/references.bib): syntax error

### DIFF
--- a/docs/references.bib
+++ b/docs/references.bib
@@ -816,7 +816,7 @@
   volume        = {25},
   year          = {1979},
   number        = {3-4},
-  pages         = {203--206}
+  pages         = {203--206},
   url           = {http://dx.doi.org/10.5169/seals-50379}
 }
 


### PR DESCRIPTION
This broke the docs build.



---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
