### PR TITLE
[Merged by Bors] - feat(algebra/big_operators/basic): Reindexing a product with a permutation

### DIFF
--- a/src/algebra/big_operators/basic.lean
+++ b/src/algebra/big_operators/basic.lean
@@ -259,6 +259,23 @@ by rw [finset.prod, ← multiset.coe_prod, ← multiset.coe_map, finset.coe_to_l
 
 end to_list
 
+@[to_additive]
+lemma prod_reindex (s : finset α) (f : α → β) {σ : equiv.perm α} (hs : {a | σ a ≠ a} ⊆ s) :
+  (∏ x in s, f (σ x)) = ∏ x in s, f x :=
+begin
+  convert (prod_map _ σ.to_embedding _).symm,
+  exact (map_perm hs).symm,
+end
+
+@[to_additive]
+lemma prod_reindex' (s : finset α) (f : α → α → β) {σ : equiv.perm α} (hs : {a | σ a ≠ a} ⊆ s) :
+  (∏ x in s, f (σ x) x) = ∏ x in s, f x (σ.symm x) :=
+begin
+  convert s.prod_reindex (λ x, f x (σ.symm x)) hs,
+  ext,
+  rw [equiv.symm_apply_apply],
+end
+
 end comm_monoid
 
 end finset

--- a/src/algebra/big_operators/basic.lean
+++ b/src/algebra/big_operators/basic.lean
@@ -260,21 +260,16 @@ by rw [finset.prod, ← multiset.coe_prod, ← multiset.coe_map, finset.coe_to_l
 end to_list
 
 @[to_additive]
-lemma prod_reindex (s : finset α) (f : α → β) {σ : equiv.perm α} (hs : {a | σ a ≠ a} ⊆ s) :
+lemma _root_.equiv.perm.prod_comp (σ : equiv.perm α) (s : finset α) (f : α → β)
+  (hs : {a | σ a ≠ a} ⊆ s) :
   (∏ x in s, f (σ x)) = ∏ x in s, f x :=
-begin
-  convert (prod_map _ σ.to_embedding _).symm,
-  exact (map_perm hs).symm,
-end
+by { convert (prod_map _ σ.to_embedding _).symm, exact (map_perm hs).symm }
 
 @[to_additive]
-lemma prod_reindex' (s : finset α) (f : α → α → β) {σ : equiv.perm α} (hs : {a | σ a ≠ a} ⊆ s) :
+lemma _root_.equiv.perm.prod_comp' (σ : equiv.perm α) (s : finset α) (f : α → α → β)
+  (hs : {a | σ a ≠ a} ⊆ s) :
   (∏ x in s, f (σ x) x) = ∏ x in s, f x (σ.symm x) :=
-begin
-  convert s.prod_reindex (λ x, f x (σ.symm x)) hs,
-  ext,
-  rw [equiv.symm_apply_apply],
-end
+by { convert σ.prod_comp s (λ x, f x (σ.symm x)) hs, ext, rw equiv.symm_apply_apply }
 
 end comm_monoid
 

--- a/src/data/finset/basic.lean
+++ b/src/data/finset/basic.lean
@@ -1886,6 +1886,18 @@ mem_map.trans $ by simp only [exists_prop]; refl
   b ∈ s.map f.to_embedding ↔ f.symm b ∈ s :=
 by { rw mem_map, exact ⟨by { rintro ⟨a, H, rfl⟩, simpa }, λ h, ⟨_, h, by simp⟩⟩ }
 
+lemma map_perm {σ : equiv.perm α} (hs : {a | σ a ≠ a} ⊆ s) : s.map (σ : α ↪ α) = s :=
+begin
+  ext i,
+  rw mem_map,
+  obtain hi | hi := eq_or_ne (σ i) i,
+  { refine ⟨_, λ h, ⟨i, h, hi⟩⟩,
+    rintro ⟨j, hj, h⟩,
+    rwa σ.injective (hi.trans h.symm) },
+  { refine iff_of_true ⟨σ.symm i, hs $ λ h, hi _, σ.apply_symm_apply _⟩ (hs hi),
+    convert congr_arg σ h; exact (σ.apply_symm_apply _).symm }
+end
+
 theorem mem_map' (f : α ↪ β) {a} {s : finset α} : f a ∈ s.map f ↔ a ∈ s :=
 mem_map_of_injective f.2
 

--- a/src/data/finset/basic.lean
+++ b/src/data/finset/basic.lean
@@ -1886,6 +1886,8 @@ mem_map.trans $ by simp only [exists_prop]; refl
   b ∈ s.map f.to_embedding ↔ f.symm b ∈ s :=
 by { rw mem_map, exact ⟨by { rintro ⟨a, H, rfl⟩, simpa }, λ h, ⟨_, h, by simp⟩⟩ }
 
+/-- If the only elements outside `s` are those left fixed by `σ`, then mapping by `σ` has no effect.
+-/
 lemma map_perm {σ : equiv.perm α} (hs : {a | σ a ≠ a} ⊆ s) : s.map (σ : α ↪ α) = s :=
 begin
   ext i,

--- a/src/data/finset/card.lean
+++ b/src/data/finset/card.lean
@@ -170,6 +170,8 @@ lemma fiber_card_ne_zero_iff_mem_image (s : finset α) (f : α → β) [decidabl
   (s.filter (λ x, f x = y)).card ≠ 0 ↔ y ∈ s.image f :=
 by { rw [←pos_iff_ne_zero, card_pos, fiber_nonempty_iff_mem_image] }
 
+@[simp] lemma card_map (f : α ↪ β) : (s.map f).card = s.card := multiset.card_map _ _
+
 @[simp] lemma card_subtype (p : α → Prop) [decidable_pred p] (s : finset α) :
   (s.subtype p).card = (s.filter p).card :=
 by simp [finset.subtype]
@@ -180,8 +182,6 @@ card_le_of_subset $ filter_subset _ _
 
 lemma eq_of_subset_of_card_le {s t : finset α} (h : s ⊆ t) (h₂ : t.card ≤ s.card) : s = t :=
 eq_of_veq $ multiset.eq_of_le_of_card_le (val_le_iff.mpr h) h₂
-
-@[simp] lemma card_map (f : α ↪ β) : (s.map f).card = s.card := multiset.card_map _ _
 
 lemma map_eq_of_subset {f : α ↪ α} (hs : s.map f ⊆ s) : s.map f = s :=
 eq_of_subset_of_card_le hs (card_map _).ge

--- a/src/data/finset/card.lean
+++ b/src/data/finset/card.lean
@@ -170,8 +170,6 @@ lemma fiber_card_ne_zero_iff_mem_image (s : finset α) (f : α → β) [decidabl
   (s.filter (λ x, f x = y)).card ≠ 0 ↔ y ∈ s.image f :=
 by { rw [←pos_iff_ne_zero, card_pos, fiber_nonempty_iff_mem_image] }
 
-@[simp] lemma card_map (f : α ↪ β) : (s.map f).card = s.card := multiset.card_map _ _
-
 @[simp] lemma card_subtype (p : α → Prop) [decidable_pred p] (s : finset α) :
   (s.subtype p).card = (s.filter p).card :=
 by simp [finset.subtype]
@@ -182,6 +180,11 @@ card_le_of_subset $ filter_subset _ _
 
 lemma eq_of_subset_of_card_le {s t : finset α} (h : s ⊆ t) (h₂ : t.card ≤ s.card) : s = t :=
 eq_of_veq $ multiset.eq_of_le_of_card_le (val_le_iff.mpr h) h₂
+
+@[simp] lemma card_map (f : α ↪ β) : (s.map f).card = s.card := multiset.card_map _ _
+
+lemma map_eq_of_subset {f : α ↪ α} (hs : s.map f ⊆ s) : s.map f = s :=
+eq_of_subset_of_card_le hs (card_map _).ge
 
 lemma filter_card_eq {p : α → Prop} [decidable_pred p] (h : (s.filter p).card = s.card) (x : α)
   (hx : x ∈ s) :

--- a/src/linear_algebra/matrix/determinant.lean
+++ b/src/linear_algebra/matrix/determinant.lean
@@ -156,7 +156,7 @@ calc det (M ⬝ N) = ∑ p : n → n, ∑ σ : perm n, ε σ * ∏ i, (M (σ i) 
   sum_congr rfl (λ σ _, fintype.sum_equiv (equiv.mul_right σ⁻¹) _ _
     (λ τ,
       have ∏ j, M (τ j) (σ j) = ∏ j, M ((τ * σ⁻¹) j) j,
-        by { rw ← σ⁻¹.prod_comp, simp only [equiv.perm.coe_mul, apply_inv_self] },
+        by { rw ← (σ⁻¹ : _ ≃ _).prod_comp, simp only [equiv.perm.coe_mul, apply_inv_self] },
       have h : ε σ * ε (τ * σ⁻¹) = ε τ :=
         calc ε σ * ε (τ * σ⁻¹) = ε ((τ * σ⁻¹) * σ) :
           by { rw [mul_comm, sign_mul (τ * σ⁻¹)], simp only [int.cast_mul, units.coe_mul] }

--- a/src/number_theory/sum_four_squares.lean
+++ b/src/number_theory/sum_four_squares.lean
@@ -99,7 +99,7 @@ let ⟨x, hx⟩ := h01 in let ⟨y, hy⟩ := h23 in
       ← int.sq_add_sq_of_two_mul_sq_add_sq hy.symm,
       ← mul_right_inj' (show (2 : ℤ) ≠ 0, from dec_trivial), ← h, mul_add, ← hx, ← hy],
     have : ∑ x, f (σ x)^2 = ∑ x, f x^2,
-    { conv_rhs { rw ← (σ : _ ≃ _).sum_comp } },
+    { conv_rhs { rw ←equiv.sum_comp σ } },
     have fin4univ : (univ : finset (fin 4)).1 = 0 ::ₘ 1 ::ₘ 2 ::ₘ 3 ::ₘ 0, from dec_trivial,
     simpa [finset.sum_eq_multiset_sum, fin4univ, multiset.sum_cons, f, add_assoc]
   end⟩

--- a/src/number_theory/sum_four_squares.lean
+++ b/src/number_theory/sum_four_squares.lean
@@ -99,7 +99,7 @@ let ⟨x, hx⟩ := h01 in let ⟨y, hy⟩ := h23 in
       ← int.sq_add_sq_of_two_mul_sq_add_sq hy.symm,
       ← mul_right_inj' (show (2 : ℤ) ≠ 0, from dec_trivial), ← h, mul_add, ← hx, ← hy],
     have : ∑ x, f (σ x)^2 = ∑ x, f x^2,
-    { conv_rhs { rw ← σ.sum_comp } },
+    { conv_rhs { rw ← (σ : _ ≃ _).sum_comp } },
     have fin4univ : (univ : finset (fin 4)).1 = 0 ::ₘ 1 ::ₘ 2 ::ₘ 3 ::ₘ 0, from dec_trivial,
     simpa [finset.sum_eq_multiset_sum, fin4univ, multiset.sum_cons, f, add_assoc]
   end⟩


### PR DESCRIPTION
This proves `(∏ x in s, f (σ x)) = ∏ x in s, f x` for a permutation `σ`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
