### PR TITLE
[Merged by Bors] - feat(category_theory): `Cat` is a strict bicategory

### DIFF
--- a/src/category_theory/bicategory/strict.lean
+++ b/src/category_theory/bicategory/strict.lean
@@ -23,7 +23,6 @@ identities.
 
 namespace category_theory
 
-open bicategory
 open_locale bicategory
 
 universes w v u
@@ -55,7 +54,7 @@ restate_axiom bicategory.strict.associator_eq_to_iso'
 attribute [simp]
   bicategory.strict.id_comp bicategory.strict.left_unitor_eq_to_iso
   bicategory.strict.comp_id bicategory.strict.right_unitor_eq_to_iso
-  bicategory.strict.assoc  bicategory.strict.associator_eq_to_iso
+  bicategory.strict.assoc bicategory.strict.associator_eq_to_iso
 
 /-- Category structure on a strict bicategory -/
 @[priority 100] -- see Note [lower instance priority]

--- a/src/category_theory/bicategory/strict.lean
+++ b/src/category_theory/bicategory/strict.lean
@@ -1,0 +1,102 @@
+/-
+Copyright (c) 2022 Yuma Mizuno. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Yuma Mizuno
+-/
+import category_theory.eq_to_hom
+import category_theory.bicategory.basic
+
+/-!
+# Strict bicategories
+
+A bicategory is called `strict` if the left unitors, the right unitors, and the associators are
+isomorphisms given by equalities.
+
+## Implementation notes
+
+In the literature of category theory, a strict bicategory is often defined as a bicategory whose
+left unitors, right unitors, and associators are the identities. We cannot use this definition
+directly in Lean since the types of 2-morphisms depend on 1-morphisms. For this reason, we use
+`eq_to_iso`, which gives isomorphisms from equalities, instead of identities.
+-/
+
+namespace category_theory
+
+open bicategory
+open_locale bicategory
+
+universes w v u
+
+variables (B : Type u) [bicategory.{w v} B]
+
+/--
+A bicategory is called `strict` if the left unitors, the right unitors, and the associators are
+isomorphisms given by equalities.
+-/
+class bicategory.strict : Prop :=
+(id_comp' : ∀ {a b : B} (f : a ⟶ b), 𝟙 a ≫ f = f . obviously)
+(comp_id' : ∀ {a b : B} (f : a ⟶ b), f ≫ 𝟙 b = f . obviously)
+(assoc' : ∀ {a b c d : B} (f : a ⟶ b) (g : b ⟶ c) (h : c ⟶ d),
+  (f ≫ g) ≫ h = f ≫ (g ≫ h) . obviously)
+(left_unitor_eq_to_iso' : ∀ {a b : B} (f : a ⟶ b),
+  λ_ f  = eq_to_iso (id_comp' f) . obviously)
+(right_unitor_eq_to_iso' : ∀ {a b : B} (f : a ⟶ b),
+  ρ_ f = eq_to_iso (comp_id' f) . obviously)
+(associator_eq_to_iso' : ∀ {a b c d : B} (f : a ⟶ b) (g : b ⟶ c) (h : c ⟶ d),
+  α_ f g h = eq_to_iso (assoc' f g h) . obviously)
+
+restate_axiom bicategory.strict.id_comp'
+restate_axiom bicategory.strict.comp_id'
+restate_axiom bicategory.strict.assoc'
+restate_axiom bicategory.strict.left_unitor_eq_to_iso'
+restate_axiom bicategory.strict.right_unitor_eq_to_iso'
+restate_axiom bicategory.strict.associator_eq_to_iso'
+attribute [simp]
+  bicategory.strict.id_comp bicategory.strict.left_unitor_eq_to_iso
+  bicategory.strict.comp_id bicategory.strict.right_unitor_eq_to_iso
+  bicategory.strict.assoc  bicategory.strict.associator_eq_to_iso
+
+/-- Category structure on a strict bicategory -/
+@[priority 100] -- see Note [lower instance priority]
+instance strict_bicategory.category [bicategory.strict B] : category B :=
+{ id_comp' := λ a b, bicategory.strict.id_comp,
+  comp_id' := λ a b, bicategory.strict.comp_id,
+  assoc' := λ a b c d, bicategory.strict.assoc }
+
+namespace bicategory
+
+variables {B}
+
+@[simp]
+lemma whisker_left_eq_to_hom {a b c : B} (f : a ⟶ b) {g h : b ⟶ c} (η : g = h) :
+  f ◁ eq_to_hom η = eq_to_hom (congr_arg2 (≫) rfl η) :=
+by { cases η, apply whisker_left_id }
+
+@[simp]
+lemma whisker_right_eq_to_hom {a b c : B} {f g : a ⟶ b} (η : f = g) (h : b ⟶ c) :
+  eq_to_hom η ▷ h = eq_to_hom (congr_arg2 (≫) η rfl) :=
+by { cases η, apply whisker_right_id }
+
+variables [strict B] {a b c d : B}
+
+@[reassoc, simp]
+lemma id_whisker_left {f g : a ⟶ b} (η : f ⟶ g) :
+  𝟙 a ◁ η = eq_to_hom (strict.id_comp f) ≫ η ≫ eq_to_hom (eq.symm (strict.id_comp g)) :=
+begin
+  slice_rhs 2 2 { rw ←left_unitor_conjugation η},
+  simp only [strict.left_unitor_eq_to_iso, eq_to_iso.inv, eq_to_hom_trans, category.id_comp,
+    eq_to_hom_refl, eq_to_hom_trans_assoc, eq_to_iso.hom, category.comp_id, category.assoc]
+end
+
+@[reassoc, simp]
+lemma id_whisker_right {f g : a ⟶ b} (η : f ⟶ g) :
+  η ▷ 𝟙 b = eq_to_hom (strict.comp_id f) ≫ η ≫ eq_to_hom (eq.symm (strict.comp_id g)) :=
+begin
+  slice_rhs 2 2 { rw ←right_unitor_conjugation η},
+  simp only [strict.right_unitor_eq_to_iso, eq_to_iso.inv, eq_to_hom_trans, category.id_comp,
+    eq_to_hom_refl, eq_to_hom_trans_assoc, eq_to_iso.hom, category.comp_id, category.assoc]
+end
+
+end bicategory
+
+end category_theory

--- a/src/category_theory/bicategory/strict.lean
+++ b/src/category_theory/bicategory/strict.lean
@@ -40,7 +40,7 @@ class bicategory.strict : Prop :=
 (assoc' : ∀ {a b c d : B} (f : a ⟶ b) (g : b ⟶ c) (h : c ⟶ d),
   (f ≫ g) ≫ h = f ≫ (g ≫ h) . obviously)
 (left_unitor_eq_to_iso' : ∀ {a b : B} (f : a ⟶ b),
-  λ_ f  = eq_to_iso (id_comp' f) . obviously)
+  λ_ f = eq_to_iso (id_comp' f) . obviously)
 (right_unitor_eq_to_iso' : ∀ {a b : B} (f : a ⟶ b),
   ρ_ f = eq_to_iso (comp_id' f) . obviously)
 (associator_eq_to_iso' : ∀ {a b c d : B} (f : a ⟶ b) (g : b ⟶ c) (h : c ⟶ d),

--- a/src/category_theory/bicategory/strict.lean
+++ b/src/category_theory/bicategory/strict.lean
@@ -14,10 +14,11 @@ isomorphisms given by equalities.
 
 ## Implementation notes
 
-In the literature of category theory, a strict bicategory is often defined as a bicategory whose
-left unitors, right unitors, and associators are the identities. We cannot use this definition
-directly in Lean since the types of 2-morphisms depend on 1-morphisms. For this reason, we use
-`eq_to_iso`, which gives isomorphisms from equalities, instead of identities.
+In the literature of category theory, a strict bicategory (usually called a strict 2-category) is
+often defined as a bicategory whose left unitors, right unitors, and associators are identities.
+We cannot use this definition directly here since the types of 2-morphisms depend on 1-morphisms.
+For this reason, we use `eq_to_iso`, which gives isomorphisms from equalities, instead of
+identities.
 -/
 
 namespace category_theory

--- a/src/category_theory/bicategory/strict.lean
+++ b/src/category_theory/bicategory/strict.lean
@@ -63,40 +63,4 @@ instance strict_bicategory.category [bicategory.strict B] : category B :=
   comp_id' := λ a b, bicategory.strict.comp_id,
   assoc' := λ a b c d, bicategory.strict.assoc }
 
-namespace bicategory
-
-variables {B}
-
-@[simp]
-lemma whisker_left_eq_to_hom {a b c : B} (f : a ⟶ b) {g h : b ⟶ c} (η : g = h) :
-  f ◁ eq_to_hom η = eq_to_hom (congr_arg2 (≫) rfl η) :=
-by { cases η, apply whisker_left_id }
-
-@[simp]
-lemma whisker_right_eq_to_hom {a b c : B} {f g : a ⟶ b} (η : f = g) (h : b ⟶ c) :
-  eq_to_hom η ▷ h = eq_to_hom (congr_arg2 (≫) η rfl) :=
-by { cases η, apply whisker_right_id }
-
-variables [strict B] {a b c d : B}
-
-@[reassoc, simp]
-lemma id_whisker_left {f g : a ⟶ b} (η : f ⟶ g) :
-  𝟙 a ◁ η = eq_to_hom (strict.id_comp f) ≫ η ≫ eq_to_hom (eq.symm (strict.id_comp g)) :=
-begin
-  slice_rhs 2 2 { rw ←left_unitor_conjugation η},
-  simp only [strict.left_unitor_eq_to_iso, eq_to_iso.inv, eq_to_hom_trans, category.id_comp,
-    eq_to_hom_refl, eq_to_hom_trans_assoc, eq_to_iso.hom, category.comp_id, category.assoc]
-end
-
-@[reassoc, simp]
-lemma id_whisker_right {f g : a ⟶ b} (η : f ⟶ g) :
-  η ▷ 𝟙 b = eq_to_hom (strict.comp_id f) ≫ η ≫ eq_to_hom (eq.symm (strict.comp_id g)) :=
-begin
-  slice_rhs 2 2 { rw ←right_unitor_conjugation η},
-  simp only [strict.right_unitor_eq_to_iso, eq_to_iso.inv, eq_to_hom_trans, category.id_comp,
-    eq_to_hom_refl, eq_to_hom_trans_assoc, eq_to_iso.hom, category.comp_id, category.assoc]
-end
-
-end bicategory
-
 end category_theory

--- a/src/category_theory/category/Cat.lean
+++ b/src/category_theory/category/Cat.lean
@@ -5,8 +5,8 @@ Authors: Yury Kudryashov
 -/
 import category_theory.concrete_category.bundled
 import category_theory.discrete_category
-import category_theory.eq_to_hom
 import category_theory.types
+import category_theory.bicategory.strict
 
 /-!
 # Category of categories
@@ -40,14 +40,28 @@ instance str (C : Cat.{v u}) : category.{v u} C := C.str
 /-- Construct a bundled `Cat` from the underlying type and the typeclass. -/
 def of (C : Type u) [category.{v} C] : Cat.{v u} := bundled.of C
 
-/-- Category structure on `Cat` -/
-instance category : large_category.{max v u} Cat.{v u} :=
+/-- Bicategory structure on `Cat` -/
+instance bicategory : bicategory.{(max v u) (max v u)} Cat.{v u} :=
 { hom := λ C D, C ⥤ D,
   id := λ C, 𝟭 C,
   comp := λ C D E F G, F ⋙ G,
-  id_comp' := λ C D F, by cases F; refl,
+  hom_category := λ C D, functor.category C D,
+  whisker_left := λ C D E F G H η, whisker_left F η,
+  whisker_right := λ C D E F G η H, whisker_right η H,
+  associator := λ A B C D, functor.associator,
+  left_unitor :=  λ A B, functor.left_unitor,
+  right_unitor := λ A B, functor.right_unitor,
+  pentagon' := by { intros, apply functor.pentagon },
+  triangle' := by { intros, apply functor.triangle } }
+
+/-- `Cat` is a strict bicategory. -/
+instance bicategory.strict : bicategory.strict Cat.{v u} :=
+{ id_comp' := λ C D F, by cases F; refl,
   comp_id' := λ C D F, by cases F; refl,
   assoc' := by intros; refl }
+
+/-- Category structure on `Cat` -/
+instance category : large_category.{max v u} Cat.{v u} := strict_bicategory.category Cat.{v u}
 
 /-- Functor that gets the set of objects of a category. It is not
 called `forget`, because it is not a faithful functor. -/

--- a/src/category_theory/category/Cat.lean
+++ b/src/category_theory/category/Cat.lean
@@ -51,8 +51,8 @@ instance bicategory : bicategory.{(max v u) (max v u)} Cat.{v u} :=
   associator := λ A B C D, functor.associator,
   left_unitor :=  λ A B, functor.left_unitor,
   right_unitor := λ A B, functor.right_unitor,
-  pentagon' := by { intros, apply functor.pentagon },
-  triangle' := by { intros, apply functor.triangle } }
+  pentagon' := λ A B C D E, functor.pentagon,
+  triangle' := λ A B C, functor.triangle }
 
 /-- `Cat` is a strict bicategory. -/
 instance bicategory.strict : bicategory.strict Cat.{v u} :=


### PR DESCRIPTION
This PR defines a bicategory structure on `Cat`. This also introduces the propositional type class `bicategory.strict`, and proves that `Cat` is an instance of this class.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
