### PR TITLE
[Merged by Bors] - feat(data/set/basic): add decidable instances for boolean operations

### DIFF
--- a/src/data/set/basic.lean
+++ b/src/data/set/basic.lean
@@ -2417,11 +2417,11 @@ instance decidable_union [decidable (a ∈ s)] [decidable (a ∈ t)] : decidable
 instance decidable_compl [decidable (a ∈ s)] : decidable (a ∈ sᶜ) :=
 (by apply_instance : decidable (a ∉ s))
 
-instance decidable_emptyset [decidable (a ∈ s)] : decidable (a ∈ (∅ : set α)) :=
-decidable.is_false (by simp)
+instance decidable_emptyset : decidable_pred (∈ (∅ : set α)) :=
+λ _, decidable.is_false (by simp)
 
-instance decidable_univ [decidable (a ∈ s)] : decidable (a ∈ (set.univ : set α)) :=
-decidable.is_true (by simp)
+instance decidable_univ : decidable_pred (∈ (set.univ : set α)) :=
+λ _, decidable.is_true (by simp)
 
 instance decidable_set_of (p : α → Prop) [decidable (p a)] : decidable (a ∈ {a | p a}) :=
 by assumption

--- a/src/data/set/basic.lean
+++ b/src/data/set/basic.lean
@@ -208,8 +208,6 @@ theorem mem_def {a : α} {s : set α} : a ∈ s ↔ s a := iff.rfl
 
 lemma set_of_bijective : bijective (set_of : (α → Prop) → set α) := bijective_id
 
-instance decidable_set_of (p : α → Prop) [H : decidable_pred p] : decidable_pred (∈ {a | p a}) := H
-
 @[simp] theorem set_of_subset_set_of {p q : α → Prop} :
   {a | p a} ⊆ {a | q a} ↔ (∀a, p a → q a) := iff.rfl
 
@@ -433,9 +431,6 @@ eq_univ_of_univ_subset $ hs ▸ h
 
 lemma exists_mem_of_nonempty (α) : ∀ [nonempty α], ∃x:α, x ∈ (univ : set α)
 | ⟨x⟩ := ⟨x, trivial⟩
-
-instance univ_decidable : decidable_pred (∈ @set.univ α) :=
-λ x, is_true trivial
 
 lemma ne_univ_iff_exists_not_mem {α : Type*} (s : set α) : s ≠ univ ↔ ∃ a, a ∉ s :=
 by rw [←not_forall, ←eq_univ_iff_forall]
@@ -2404,3 +2399,31 @@ lemma mem_iff_nonempty {α : Type*} [subsingleton α] {s : set α} {x : α} :
 ⟨λ hx, ⟨x, hx⟩, λ ⟨y, hy⟩, subsingleton.elim y x ▸ hy⟩
 
 end subsingleton
+
+/-! ### Decidability instances for sets -/
+
+namespace set
+variables {α : Type u} (s t : set α) (a : α)
+
+instance decidable_sdiff [decidable (a ∈ s)] [decidable (a ∈ t)] : decidable (a ∈ s \ t) :=
+(by apply_instance : decidable (a ∈ s ∧ a ∉ t))
+
+instance decidable_inter [decidable (a ∈ s)] [decidable (a ∈ t)] : decidable (a ∈ s ∩ t) :=
+(by apply_instance : decidable (a ∈ s ∧ a ∈ t))
+
+instance decidable_union [decidable (a ∈ s)] [decidable (a ∈ t)] : decidable (a ∈ s ∪ t) :=
+(by apply_instance : decidable (a ∈ s ∨ a ∈ t))
+
+instance decidable_compl [decidable (a ∈ s)] : decidable (a ∈ sᶜ) :=
+(by apply_instance : decidable (a ∉ s))
+
+instance decidable_emptyset [decidable (a ∈ s)] : decidable (a ∈ (∅ : set α)) :=
+decidable.is_false (by simp)
+
+instance decidable_univ [decidable (a ∈ s)] : decidable (a ∈ (set.univ : set α)) :=
+decidable.is_true (by simp)
+
+instance decidable_set_of (p : α → Prop) [decidable (p a)] : decidable (a ∈ {a | p a}) :=
+by assumption
+
+end set


### PR DESCRIPTION
Add decidability instances for `a ∈ s ∩ t`, etc.

---

I'm a bit surprised we didn't have these yet.

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
