### PR TITLE
[Merged by Bors] - chore(order/basic): Rename `no_bot_order`/`no_top_order` to `no_min_order`/`no_max_order`

### DIFF
--- a/src/algebra/order/group.lean
+++ b/src/algebra/order/group.lean
@@ -971,15 +971,15 @@ begin
 end
 
 @[priority 100, to_additive] -- see Note [lower instance priority]
-instance linear_ordered_comm_group.to_no_top_order [nontrivial α] :
-  no_top_order α :=
+instance linear_ordered_comm_group.to_no_max_order [nontrivial α] :
+  no_max_order α :=
 ⟨ begin
     obtain ⟨y, hy⟩ : ∃ (a:α), 1 < a := exists_one_lt',
     exact λ a, ⟨a * y, lt_mul_of_one_lt_right' a hy⟩
   end ⟩
 
 @[priority 100, to_additive] -- see Note [lower instance priority]
-instance linear_ordered_comm_group.to_no_bot_order [nontrivial α] : no_bot_order α :=
+instance linear_ordered_comm_group.to_no_min_order [nontrivial α] : no_min_order α :=
 ⟨ begin
     obtain ⟨y, hy⟩ : ∃ (a:α), 1 < a := exists_one_lt',
     exact λ a, ⟨a / y, (div_lt_self_iff a).mpr hy⟩

--- a/src/algebra/order/nonneg.lean
+++ b/src/algebra/order/nonneg.lean
@@ -49,8 +49,8 @@ instance order_bot [preorder α] {a : α} : order_bot {x : α // a ≤ x} :=
 
 lemma bot_eq [preorder α] {a : α} : (⊥ : {x : α // a ≤ x}) = ⟨a, le_rfl⟩ := rfl
 
-instance no_top_order [partial_order α] [no_top_order α] {a : α} : no_top_order {x : α // a ≤ x} :=
-set.Ici.no_top_order
+instance no_max_order [partial_order α] [no_max_order α] {a : α} : no_max_order {x : α // a ≤ x} :=
+set.Ici.no_max_order
 
 instance semilattice_inf [semilattice_inf α] {a : α} : semilattice_inf {x : α // a ≤ x} :=
 set.Ici.semilattice_inf

--- a/src/algebra/order/ring.lean
+++ b/src/algebra/order/ring.lean
@@ -744,8 +744,8 @@ lemma nonpos_of_mul_nonneg_right (h : 0 ≤ a * b) (ha : a < 0) : b ≤ 0 :=
 le_of_not_gt (λ hb, absurd h (mul_neg_of_neg_of_pos ha hb).not_le)
 
 @[priority 100] -- see Note [lower instance priority]
-instance linear_ordered_semiring.to_no_top_order {α : Type*} [linear_ordered_semiring α] :
-  no_top_order α :=
+instance linear_ordered_semiring.to_no_max_order {α : Type*} [linear_ordered_semiring α] :
+  no_max_order α :=
 ⟨assume a, ⟨a + 1, lt_add_of_pos_right _ zero_lt_one⟩⟩
 
 /-- Pullback a `linear_ordered_semiring` under an injective map.

--- a/src/analysis/calculus/fderiv.lean
+++ b/src/analysis/calculus/fderiv.lean
@@ -379,7 +379,7 @@ neighborhood of `x`. See also `has_strict_fderiv_at.exists_lipschitz_on_with_of_
 more precise statement. -/
 lemma has_strict_fderiv_at.exists_lipschitz_on_with (hf : has_strict_fderiv_at f f' x) :
   ∃ K (s ∈ 𝓝 x), lipschitz_on_with K f s :=
-(no_max _).imp hf.exists_lipschitz_on_with_of_nnnorm_lt
+(exists_gt _).imp hf.exists_lipschitz_on_with_of_nnnorm_lt
 
 /-- Directional derivative agrees with `has_fderiv`. -/
 lemma has_fderiv_at.lim (hf : has_fderiv_at f f' x) (v : E) {α : Type*} {c : α → 𝕜}

--- a/src/analysis/calculus/fderiv.lean
+++ b/src/analysis/calculus/fderiv.lean
@@ -379,7 +379,7 @@ neighborhood of `x`. See also `has_strict_fderiv_at.exists_lipschitz_on_with_of_
 more precise statement. -/
 lemma has_strict_fderiv_at.exists_lipschitz_on_with (hf : has_strict_fderiv_at f f' x) :
   ∃ K (s ∈ 𝓝 x), lipschitz_on_with K f s :=
-(no_top _).imp hf.exists_lipschitz_on_with_of_nnnorm_lt
+(no_max _).imp hf.exists_lipschitz_on_with_of_nnnorm_lt
 
 /-- Directional derivative agrees with `has_fderiv`. -/
 lemma has_fderiv_at.lim (hf : has_fderiv_at f f' x) (v : E) {α : Type*} {c : α → 𝕜}

--- a/src/analysis/calculus/mean_value.lean
+++ b/src/analysis/calculus/mean_value.lean
@@ -554,7 +554,7 @@ lemma exists_nhds_within_lipschitz_on_with_of_has_fderiv_within_at
   (hs : convex ℝ s) {f : E → G} (hder : ∀ᶠ y in 𝓝[s] x, has_fderiv_within_at f (f' y) s y)
   (hcont : continuous_within_at f' s x) :
   ∃ K (t ∈ 𝓝[s] x), lipschitz_on_with K f t :=
-(no_max _).imp $
+(exists_gt _).imp $
   hs.exists_nhds_within_lipschitz_on_with_of_has_fderiv_within_at_of_nnnorm_lt hder hcont
 
 /-- The mean value theorem on a convex set: if the derivative of a function within this set is

--- a/src/analysis/calculus/mean_value.lean
+++ b/src/analysis/calculus/mean_value.lean
@@ -554,7 +554,7 @@ lemma exists_nhds_within_lipschitz_on_with_of_has_fderiv_within_at
   (hs : convex ℝ s) {f : E → G} (hder : ∀ᶠ y in 𝓝[s] x, has_fderiv_within_at f (f' y) s y)
   (hcont : continuous_within_at f' s x) :
   ∃ K (t ∈ 𝓝[s] x), lipschitz_on_with K f t :=
-(no_top _).imp $
+(no_max _).imp $
   hs.exists_nhds_within_lipschitz_on_with_of_has_fderiv_within_at_of_nnnorm_lt hder hcont
 
 /-- The mean value theorem on a convex set: if the derivative of a function within this set is

--- a/src/analysis/calculus/times_cont_diff.lean
+++ b/src/analysis/calculus/times_cont_diff.lean
@@ -2764,7 +2764,7 @@ lemma has_ftaylor_series_up_to_on.exists_lipschitz_on_with {E F : Type*}
   {p : E → formal_multilinear_series ℝ E F} {s : set E} {x : E}
   (hf : has_ftaylor_series_up_to_on 1 f p (insert x s)) (hs : convex ℝ s) :
   ∃ K (t ∈ 𝓝[s] x), lipschitz_on_with K f t :=
-(no_top _).imp $ hf.exists_lipschitz_on_with_of_nnnorm_lt hs
+(no_max _).imp $ hf.exists_lipschitz_on_with_of_nnnorm_lt hs
 
 /-- If `f` is `C^1` within a conves set `s` at `x`, then it is Lipschitz on a neighborhood of `x`
 within `s`. -/

--- a/src/analysis/calculus/times_cont_diff.lean
+++ b/src/analysis/calculus/times_cont_diff.lean
@@ -2764,7 +2764,7 @@ lemma has_ftaylor_series_up_to_on.exists_lipschitz_on_with {E F : Type*}
   {p : E → formal_multilinear_series ℝ E F} {s : set E} {x : E}
   (hf : has_ftaylor_series_up_to_on 1 f p (insert x s)) (hs : convex ℝ s) :
   ∃ K (t ∈ 𝓝[s] x), lipschitz_on_with K f t :=
-(no_max _).imp $ hf.exists_lipschitz_on_with_of_nnnorm_lt hs
+(exists_gt _).imp $ hf.exists_lipschitz_on_with_of_nnnorm_lt hs
 
 /-- If `f` is `C^1` within a conves set `s` at `x`, then it is Lipschitz on a neighborhood of `x`
 within `s`. -/

--- a/src/analysis/normed_space/basic.lean
+++ b/src/analysis/normed_space/basic.lean
@@ -449,7 +449,7 @@ lemma normed_group.tendsto_at_top [nonempty α] [semilattice_sup α] {β : Type*
 A variant of `normed_group.tendsto_at_top` that
 uses `∃ N, ∀ n > N, ...` rather than `∃ N, ∀ n ≥ N, ...`
 -/
-lemma normed_group.tendsto_at_top' [nonempty α] [semilattice_sup α] [no_top_order α]
+lemma normed_group.tendsto_at_top' [nonempty α] [semilattice_sup α] [no_max_order α]
   {β : Type*} [semi_normed_group β]
   {f : α → β} {b : β} :
   tendsto f at_top (𝓝 b) ↔ ∀ ε, 0 < ε → ∃ N, ∀ n, N < n → ∥f n - b∥ < ε :=

--- a/src/data/psigma/order.lean
+++ b/src/data/psigma/order.lean
@@ -29,7 +29,7 @@ Related files are:
 
 Define the disjoint order on `Σ' i, α i`, where `x ≤ y` only if `x.fst = y.fst`.
 
-Prove that a sigma type is a `no_top_order`, `no_bot_order`, `densely_ordered` when its summands
+Prove that a sigma type is a `no_max_order`, `no_min_order`, `densely_ordered` when its summands
 are.
 -/
 

--- a/src/data/real/nnreal.lean
+++ b/src/data/real/nnreal.lean
@@ -280,7 +280,7 @@ noncomputable example : linear_ordered_comm_monoid_with_zero ℝ≥0 := by apply
 noncomputable example : linear_ordered_comm_group_with_zero ℝ≥0 := by apply_instance
 example : canonically_ordered_comm_semiring ℝ≥0 := by apply_instance
 example : densely_ordered ℝ≥0 := by apply_instance
-example : no_top_order ℝ≥0 := by apply_instance
+example : no_max_order ℝ≥0 := by apply_instance
 
 lemma bdd_above_coe {s : set ℝ≥0} : bdd_above ((coe : ℝ≥0 → ℝ) '' s) ↔ bdd_above s :=
 iff.intro

--- a/src/data/set/intervals/basic.lean
+++ b/src/data/set/intervals/basic.lean
@@ -125,8 +125,8 @@ set.ext $ λ x, and_comm _ _
 @[simp] lemma nonempty_Ioo [densely_ordered α] : (Ioo a b).nonempty ↔ a < b :=
 ⟨λ ⟨x, ha, hb⟩, ha.trans hb, exists_between⟩
 
-@[simp] lemma nonempty_Ioi [no_max_order α] : (Ioi a).nonempty := no_max a
-@[simp] lemma nonempty_Iio [no_min_order α] : (Iio a).nonempty := no_min a
+@[simp] lemma nonempty_Ioi [no_max_order α] : (Ioi a).nonempty := exists_gt a
+@[simp] lemma nonempty_Iio [no_min_order α] : (Iio a).nonempty := exists_lt a
 
 lemma nonempty_Icc_subtype (h : a ≤ b) : nonempty (Icc a b) :=
 nonempty.to_subtype (nonempty_Icc.mpr h)

--- a/src/data/set/intervals/basic.lean
+++ b/src/data/set/intervals/basic.lean
@@ -125,9 +125,8 @@ set.ext $ λ x, and_comm _ _
 @[simp] lemma nonempty_Ioo [densely_ordered α] : (Ioo a b).nonempty ↔ a < b :=
 ⟨λ ⟨x, ha, hb⟩, ha.trans hb, exists_between⟩
 
-@[simp] lemma nonempty_Ioi [no_top_order α] : (Ioi a).nonempty := no_top a
-
-@[simp] lemma nonempty_Iio [no_bot_order α] : (Iio a).nonempty := no_bot a
+@[simp] lemma nonempty_Ioi [no_max_order α] : (Ioi a).nonempty := no_max a
+@[simp] lemma nonempty_Iio [no_min_order α] : (Iio a).nonempty := no_min a
 
 lemma nonempty_Icc_subtype (h : a ≤ b) : nonempty (Icc a b) :=
 nonempty.to_subtype (nonempty_Icc.mpr h)
@@ -149,12 +148,12 @@ nonempty.to_subtype nonempty_Iic
 lemma nonempty_Ioo_subtype [densely_ordered α] (h : a < b) : nonempty (Ioo a b) :=
 nonempty.to_subtype (nonempty_Ioo.mpr h)
 
-/-- In a `no_top_order`, the intervals `Ioi` are nonempty. -/
-instance nonempty_Ioi_subtype [no_top_order α] : nonempty (Ioi a) :=
+/-- In an order without maximal elements, the intervals `Ioi` are nonempty. -/
+instance nonempty_Ioi_subtype [no_max_order α] : nonempty (Ioi a) :=
 nonempty.to_subtype nonempty_Ioi
 
-/-- In a `no_bot_order`, the intervals `Iio` are nonempty. -/
-instance nonempty_Iio_subtype [no_bot_order α] : nonempty (Iio a) :=
+/-- In an order without minimal elements, the intervals `Iio` are nonempty. -/
+instance nonempty_Iio_subtype [no_min_order α] : nonempty (Iio a) :=
 nonempty.to_subtype nonempty_Iio
 
 @[simp] lemma Icc_eq_empty (h : ¬a ≤ b) : Icc a b = ∅ :=

--- a/src/data/set/intervals/infinite.lean
+++ b/src/data/set/intervals/infinite.lean
@@ -49,7 +49,7 @@ begin
   rintro (f : finite (Iio b)),
   obtain ⟨m, hm₁, hm₂⟩ : ∃ m < b, ∀ x < b, ¬x < m,
   { simpa using finset.exists_minimal f.to_finset },
-  obtain ⟨z, hz⟩ : ∃ z, z < m := no_min _,
+  obtain ⟨z, hz⟩ : ∃ z, z < m := exists_lt _,
   exact hm₂ z (lt_trans hz hm₁) hz
 end
 

--- a/src/data/set/intervals/infinite.lean
+++ b/src/data/set/intervals/infinite.lean
@@ -42,14 +42,14 @@ end bounded
 
 section unbounded_below
 
-variables [no_bot_order α]
+variables [no_min_order α]
 
 lemma Iio.infinite {b : α} : infinite (Iio b) :=
 begin
   rintro (f : finite (Iio b)),
   obtain ⟨m, hm₁, hm₂⟩ : ∃ m < b, ∀ x < b, ¬x < m,
   { simpa using finset.exists_minimal f.to_finset },
-  obtain ⟨z, hz⟩ : ∃ z, z < m := no_bot _,
+  obtain ⟨z, hz⟩ : ∃ z, z < m := no_min _,
   exact hm₂ z (lt_trans hz hm₁) hz
 end
 
@@ -60,7 +60,7 @@ end unbounded_below
 
 section unbounded_above
 
-variables [no_top_order α]
+variables [no_max_order α]
 
 lemma Ioi.infinite {a : α} : infinite (Ioi a) :=
 by apply @Iio.infinite (order_dual α)

--- a/src/data/sigma/order.lean
+++ b/src/data/sigma/order.lean
@@ -33,7 +33,7 @@ Related files are:
 
 ## TODO
 
-Prove that a sigma type is a `no_top_order`, `no_bot_order`, `densely_ordered` when its summands
+Prove that a sigma type is a `no_max_order`, `no_min_order`, `densely_ordered` when its summands
 are.
 
 Upgrade `equiv.sigma_congr_left`, `equiv.sigma_congr`, `equiv.sigma_assoc`,

--- a/src/data/sum/order.lean
+++ b/src/data/sum/order.lean
@@ -154,43 +154,43 @@ instance [partial_order α] [partial_order β] : partial_order (α ⊕ β) :=
 { le_antisymm := λ _ _, antisymm,
   .. sum.preorder }
 
-instance no_bot_order [has_lt α] [has_lt β] [no_bot_order α] [no_bot_order β] :
-  no_bot_order (α ⊕ β) :=
+instance no_min_order [has_lt α] [has_lt β] [no_min_order α] [no_min_order β] :
+  no_min_order (α ⊕ β) :=
 ⟨λ a, match a with
-| inl a := let ⟨b, h⟩ := no_bot a in ⟨inl b, inl_lt_inl_iff.2 h⟩
-| inr a := let ⟨b, h⟩ := no_bot a in ⟨inr b, inr_lt_inr_iff.2 h⟩
+| inl a := let ⟨b, h⟩ := no_min a in ⟨inl b, inl_lt_inl_iff.2 h⟩
+| inr a := let ⟨b, h⟩ := no_min a in ⟨inr b, inr_lt_inr_iff.2 h⟩
 end⟩
 
-instance no_top_order [has_lt α] [has_lt β] [no_top_order α] [no_top_order β] :
-  no_top_order (α ⊕ β) :=
+instance no_max_order [has_lt α] [has_lt β] [no_max_order α] [no_max_order β] :
+  no_max_order (α ⊕ β) :=
 ⟨λ a, match a with
-| inl a := let ⟨b, h⟩ := no_top a in ⟨inl b, inl_lt_inl_iff.2 h⟩
-| inr a := let ⟨b, h⟩ := no_top a in ⟨inr b, inr_lt_inr_iff.2 h⟩
+| inl a := let ⟨b, h⟩ := no_max a in ⟨inl b, inl_lt_inl_iff.2 h⟩
+| inr a := let ⟨b, h⟩ := no_max a in ⟨inr b, inr_lt_inr_iff.2 h⟩
 end⟩
 
-@[simp] lemma no_bot_order_iff [has_lt α] [has_lt β] :
-  no_bot_order (α ⊕ β) ↔ no_bot_order α ∧ no_bot_order β :=
+@[simp] lemma no_min_order_iff [has_lt α] [has_lt β] :
+  no_min_order (α ⊕ β) ↔ no_min_order α ∧ no_min_order β :=
 ⟨λ _, by exactI ⟨⟨λ a, begin
-  obtain ⟨b | b, h⟩ := no_bot (inl a : α ⊕ β),
+  obtain ⟨b | b, h⟩ := no_min (inl a : α ⊕ β),
   { exact ⟨b, inl_lt_inl_iff.1 h⟩ },
   { exact (not_inr_lt_inl h).elim }
 end⟩, ⟨λ a, begin
-  obtain ⟨b | b, h⟩ := no_bot (inr a : α ⊕ β),
+  obtain ⟨b | b, h⟩ := no_min (inr a : α ⊕ β),
   { exact (not_inl_lt_inr h).elim },
   { exact ⟨b, inr_lt_inr_iff.1 h⟩ }
-end⟩⟩, λ h, @sum.no_bot_order _ _ _ _ h.1 h.2⟩
+end⟩⟩, λ h, @sum.no_min_order _ _ _ _ h.1 h.2⟩
 
-@[simp] lemma no_top_order_iff [has_lt α] [has_lt β] :
-  no_top_order (α ⊕ β) ↔ no_top_order α ∧ no_top_order β :=
+@[simp] lemma no_max_order_iff [has_lt α] [has_lt β] :
+  no_max_order (α ⊕ β) ↔ no_max_order α ∧ no_max_order β :=
 ⟨λ _, by exactI ⟨⟨λ a, begin
-  obtain ⟨b | b, h⟩ := no_top (inl a : α ⊕ β),
+  obtain ⟨b | b, h⟩ := no_max (inl a : α ⊕ β),
   { exact ⟨b, inl_lt_inl_iff.1 h⟩ },
   { exact (not_inl_lt_inr h).elim }
 end⟩, ⟨λ a, begin
-  obtain ⟨b | b, h⟩ := no_top (inr a : α ⊕ β),
+  obtain ⟨b | b, h⟩ := no_max (inr a : α ⊕ β),
   { exact (not_inr_lt_inl h).elim },
   { exact ⟨b, inr_lt_inr_iff.1 h⟩ }
-end⟩⟩, λ h, @sum.no_top_order _ _ _ _ h.1 h.2⟩
+end⟩⟩, λ h, @sum.no_max_order _ _ _ _ h.1 h.2⟩
 
 instance densely_ordered [has_lt α] [has_lt β] [densely_ordered α] [densely_ordered β] :
   densely_ordered (α ⊕ β) :=
@@ -354,53 +354,53 @@ instance bounded_order [has_le α] [has_le β] [order_bot α] [order_top β] :
   bounded_order (α ⊕ₗ β) :=
 { .. lex.order_bot, .. lex.order_top }
 
-instance no_bot_order [has_lt α] [has_lt β] [no_bot_order α] [no_bot_order β] :
-  no_bot_order (α ⊕ₗ β) :=
+instance no_min_order [has_lt α] [has_lt β] [no_min_order α] [no_min_order β] :
+  no_min_order (α ⊕ₗ β) :=
 ⟨λ a, match a with
-| inl a := let ⟨b, h⟩ := no_bot a in ⟨to_lex (inl b), inl_lt_inl_iff.2 h⟩
-| inr a := let ⟨b, h⟩ := no_bot a in ⟨to_lex (inr b), inr_lt_inr_iff.2 h⟩
+| inl a := let ⟨b, h⟩ := no_min a in ⟨to_lex (inl b), inl_lt_inl_iff.2 h⟩
+| inr a := let ⟨b, h⟩ := no_min a in ⟨to_lex (inr b), inr_lt_inr_iff.2 h⟩
 end⟩
 
-instance no_top_order [has_lt α] [has_lt β] [no_top_order α] [no_top_order β] :
-  no_top_order (α ⊕ₗ β) :=
+instance no_max_order [has_lt α] [has_lt β] [no_max_order α] [no_max_order β] :
+  no_max_order (α ⊕ₗ β) :=
 ⟨λ a, match a with
-| inl a := let ⟨b, h⟩ := no_top a in ⟨to_lex (inl b), inl_lt_inl_iff.2 h⟩
-| inr a := let ⟨b, h⟩ := no_top a in ⟨to_lex (inr b), inr_lt_inr_iff.2 h⟩
+| inl a := let ⟨b, h⟩ := no_max a in ⟨to_lex (inl b), inl_lt_inl_iff.2 h⟩
+| inr a := let ⟨b, h⟩ := no_max a in ⟨to_lex (inr b), inr_lt_inr_iff.2 h⟩
 end⟩
 
-instance no_bot_order_of_nonempty [has_lt α] [has_lt β] [no_bot_order α] [nonempty α] :
-  no_bot_order (α ⊕ₗ β) :=
+instance no_min_order_of_nonempty [has_lt α] [has_lt β] [no_min_order α] [nonempty α] :
+  no_min_order (α ⊕ₗ β) :=
 ⟨λ a, match a with
-| inl a := let ⟨b, h⟩ := no_bot a in ⟨to_lex (inl b), inl_lt_inl_iff.2 h⟩
+| inl a := let ⟨b, h⟩ := no_min a in ⟨to_lex (inl b), inl_lt_inl_iff.2 h⟩
 | inr a := ⟨to_lex (inl $ classical.arbitrary α), inl_lt_inr _ _⟩
 end⟩
 
-instance no_top_order_of_nonempty [has_lt α] [has_lt β] [no_top_order β] [nonempty β] :
-  no_top_order (α ⊕ₗ β) :=
+instance no_max_order_of_nonempty [has_lt α] [has_lt β] [no_max_order β] [nonempty β] :
+  no_max_order (α ⊕ₗ β) :=
 ⟨λ a, match a with
 | inl a := ⟨to_lex (inr $ classical.arbitrary β), inl_lt_inr _ _⟩
-| inr a := let ⟨b, h⟩ := no_top a in ⟨to_lex (inr b), inr_lt_inr_iff.2 h⟩
+| inr a := let ⟨b, h⟩ := no_max a in ⟨to_lex (inr b), inr_lt_inr_iff.2 h⟩
 end⟩
 
-instance densely_ordered_of_no_top_order [has_lt α] [has_lt β] [densely_ordered α]
-  [densely_ordered β] [no_top_order α] :
+instance densely_ordered_of_no_max_order [has_lt α] [has_lt β] [densely_ordered α]
+  [densely_ordered β] [no_max_order α] :
   densely_ordered (α ⊕ₗ β) :=
 ⟨λ a b h, match a, b, h with
 | inl a, inl b, lex.inl h := let ⟨c, ha, hb⟩ := exists_between h in
                     ⟨to_lex (inl c), inl_lt_inl_iff.2 ha, inl_lt_inl_iff.2 hb⟩
-| inl a, inr b, lex.sep _ _ := let ⟨c, h⟩ := no_top a in
+| inl a, inr b, lex.sep _ _ := let ⟨c, h⟩ := no_max a in
                     ⟨to_lex (inl c), inl_lt_inl_iff.2 h, inl_lt_inr _ _⟩
 | inr a, inr b, lex.inr h := let ⟨c, ha, hb⟩ := exists_between h in
                     ⟨to_lex (inr c), inr_lt_inr_iff.2 ha, inr_lt_inr_iff.2 hb⟩
 end⟩
 
-instance densely_ordered_of_no_bot_order [has_lt α] [has_lt β] [densely_ordered α]
-  [densely_ordered β] [no_bot_order β] :
+instance densely_ordered_of_no_min_order [has_lt α] [has_lt β] [densely_ordered α]
+  [densely_ordered β] [no_min_order β] :
   densely_ordered (α ⊕ₗ β) :=
 ⟨λ a b h, match a, b, h with
 | inl a, inl b, lex.inl h := let ⟨c, ha, hb⟩ := exists_between h in
                     ⟨to_lex (inl c), inl_lt_inl_iff.2 ha, inl_lt_inl_iff.2 hb⟩
-| inl a, inr b, lex.sep _ _ := let ⟨c, h⟩ := no_bot b in
+| inl a, inr b, lex.sep _ _ := let ⟨c, h⟩ := no_min b in
                     ⟨to_lex (inr c), inl_lt_inr _ _, inr_lt_inr_iff.2 h⟩
 | inr a, inr b, lex.inr h := let ⟨c, ha, hb⟩ := exists_between h in
                     ⟨to_lex (inr c), inr_lt_inr_iff.2 ha, inr_lt_inr_iff.2 hb⟩

--- a/src/data/sum/order.lean
+++ b/src/data/sum/order.lean
@@ -157,25 +157,25 @@ instance [partial_order α] [partial_order β] : partial_order (α ⊕ β) :=
 instance no_min_order [has_lt α] [has_lt β] [no_min_order α] [no_min_order β] :
   no_min_order (α ⊕ β) :=
 ⟨λ a, match a with
-| inl a := let ⟨b, h⟩ := no_min a in ⟨inl b, inl_lt_inl_iff.2 h⟩
-| inr a := let ⟨b, h⟩ := no_min a in ⟨inr b, inr_lt_inr_iff.2 h⟩
+| inl a := let ⟨b, h⟩ := exists_lt a in ⟨inl b, inl_lt_inl_iff.2 h⟩
+| inr a := let ⟨b, h⟩ := exists_lt a in ⟨inr b, inr_lt_inr_iff.2 h⟩
 end⟩
 
 instance no_max_order [has_lt α] [has_lt β] [no_max_order α] [no_max_order β] :
   no_max_order (α ⊕ β) :=
 ⟨λ a, match a with
-| inl a := let ⟨b, h⟩ := no_max a in ⟨inl b, inl_lt_inl_iff.2 h⟩
-| inr a := let ⟨b, h⟩ := no_max a in ⟨inr b, inr_lt_inr_iff.2 h⟩
+| inl a := let ⟨b, h⟩ := exists_gt a in ⟨inl b, inl_lt_inl_iff.2 h⟩
+| inr a := let ⟨b, h⟩ := exists_gt a in ⟨inr b, inr_lt_inr_iff.2 h⟩
 end⟩
 
 @[simp] lemma no_min_order_iff [has_lt α] [has_lt β] :
   no_min_order (α ⊕ β) ↔ no_min_order α ∧ no_min_order β :=
 ⟨λ _, by exactI ⟨⟨λ a, begin
-  obtain ⟨b | b, h⟩ := no_min (inl a : α ⊕ β),
+  obtain ⟨b | b, h⟩ := exists_lt (inl a : α ⊕ β),
   { exact ⟨b, inl_lt_inl_iff.1 h⟩ },
   { exact (not_inr_lt_inl h).elim }
 end⟩, ⟨λ a, begin
-  obtain ⟨b | b, h⟩ := no_min (inr a : α ⊕ β),
+  obtain ⟨b | b, h⟩ := exists_lt (inr a : α ⊕ β),
   { exact (not_inl_lt_inr h).elim },
   { exact ⟨b, inr_lt_inr_iff.1 h⟩ }
 end⟩⟩, λ h, @sum.no_min_order _ _ _ _ h.1 h.2⟩
@@ -183,11 +183,11 @@ end⟩⟩, λ h, @sum.no_min_order _ _ _ _ h.1 h.2⟩
 @[simp] lemma no_max_order_iff [has_lt α] [has_lt β] :
   no_max_order (α ⊕ β) ↔ no_max_order α ∧ no_max_order β :=
 ⟨λ _, by exactI ⟨⟨λ a, begin
-  obtain ⟨b | b, h⟩ := no_max (inl a : α ⊕ β),
+  obtain ⟨b | b, h⟩ := exists_gt (inl a : α ⊕ β),
   { exact ⟨b, inl_lt_inl_iff.1 h⟩ },
   { exact (not_inl_lt_inr h).elim }
 end⟩, ⟨λ a, begin
-  obtain ⟨b | b, h⟩ := no_max (inr a : α ⊕ β),
+  obtain ⟨b | b, h⟩ := exists_gt (inr a : α ⊕ β),
   { exact (not_inr_lt_inl h).elim },
   { exact ⟨b, inr_lt_inr_iff.1 h⟩ }
 end⟩⟩, λ h, @sum.no_max_order _ _ _ _ h.1 h.2⟩
@@ -357,21 +357,21 @@ instance bounded_order [has_le α] [has_le β] [order_bot α] [order_top β] :
 instance no_min_order [has_lt α] [has_lt β] [no_min_order α] [no_min_order β] :
   no_min_order (α ⊕ₗ β) :=
 ⟨λ a, match a with
-| inl a := let ⟨b, h⟩ := no_min a in ⟨to_lex (inl b), inl_lt_inl_iff.2 h⟩
-| inr a := let ⟨b, h⟩ := no_min a in ⟨to_lex (inr b), inr_lt_inr_iff.2 h⟩
+| inl a := let ⟨b, h⟩ := exists_lt a in ⟨to_lex (inl b), inl_lt_inl_iff.2 h⟩
+| inr a := let ⟨b, h⟩ := exists_lt a in ⟨to_lex (inr b), inr_lt_inr_iff.2 h⟩
 end⟩
 
 instance no_max_order [has_lt α] [has_lt β] [no_max_order α] [no_max_order β] :
   no_max_order (α ⊕ₗ β) :=
 ⟨λ a, match a with
-| inl a := let ⟨b, h⟩ := no_max a in ⟨to_lex (inl b), inl_lt_inl_iff.2 h⟩
-| inr a := let ⟨b, h⟩ := no_max a in ⟨to_lex (inr b), inr_lt_inr_iff.2 h⟩
+| inl a := let ⟨b, h⟩ := exists_gt a in ⟨to_lex (inl b), inl_lt_inl_iff.2 h⟩
+| inr a := let ⟨b, h⟩ := exists_gt a in ⟨to_lex (inr b), inr_lt_inr_iff.2 h⟩
 end⟩
 
 instance no_min_order_of_nonempty [has_lt α] [has_lt β] [no_min_order α] [nonempty α] :
   no_min_order (α ⊕ₗ β) :=
 ⟨λ a, match a with
-| inl a := let ⟨b, h⟩ := no_min a in ⟨to_lex (inl b), inl_lt_inl_iff.2 h⟩
+| inl a := let ⟨b, h⟩ := exists_lt a in ⟨to_lex (inl b), inl_lt_inl_iff.2 h⟩
 | inr a := ⟨to_lex (inl $ classical.arbitrary α), inl_lt_inr _ _⟩
 end⟩
 
@@ -379,7 +379,7 @@ instance no_max_order_of_nonempty [has_lt α] [has_lt β] [no_max_order β] [non
   no_max_order (α ⊕ₗ β) :=
 ⟨λ a, match a with
 | inl a := ⟨to_lex (inr $ classical.arbitrary β), inl_lt_inr _ _⟩
-| inr a := let ⟨b, h⟩ := no_max a in ⟨to_lex (inr b), inr_lt_inr_iff.2 h⟩
+| inr a := let ⟨b, h⟩ := exists_gt a in ⟨to_lex (inr b), inr_lt_inr_iff.2 h⟩
 end⟩
 
 instance densely_ordered_of_no_max_order [has_lt α] [has_lt β] [densely_ordered α]
@@ -388,7 +388,7 @@ instance densely_ordered_of_no_max_order [has_lt α] [has_lt β] [densely_ordere
 ⟨λ a b h, match a, b, h with
 | inl a, inl b, lex.inl h := let ⟨c, ha, hb⟩ := exists_between h in
                     ⟨to_lex (inl c), inl_lt_inl_iff.2 ha, inl_lt_inl_iff.2 hb⟩
-| inl a, inr b, lex.sep _ _ := let ⟨c, h⟩ := no_max a in
+| inl a, inr b, lex.sep _ _ := let ⟨c, h⟩ := exists_gt a in
                     ⟨to_lex (inl c), inl_lt_inl_iff.2 h, inl_lt_inr _ _⟩
 | inr a, inr b, lex.inr h := let ⟨c, ha, hb⟩ := exists_between h in
                     ⟨to_lex (inr c), inr_lt_inr_iff.2 ha, inr_lt_inr_iff.2 hb⟩
@@ -400,7 +400,7 @@ instance densely_ordered_of_no_min_order [has_lt α] [has_lt β] [densely_ordere
 ⟨λ a b h, match a, b, h with
 | inl a, inl b, lex.inl h := let ⟨c, ha, hb⟩ := exists_between h in
                     ⟨to_lex (inl c), inl_lt_inl_iff.2 ha, inl_lt_inl_iff.2 hb⟩
-| inl a, inr b, lex.sep _ _ := let ⟨c, h⟩ := no_min b in
+| inl a, inr b, lex.sep _ _ := let ⟨c, h⟩ := exists_lt b in
                     ⟨to_lex (inr c), inl_lt_inr _ _, inr_lt_inr_iff.2 h⟩
 | inr a, inr b, lex.inr h := let ⟨c, ha, hb⟩ := exists_between h in
                     ⟨to_lex (inr c), inr_lt_inr_iff.2 ha, inr_lt_inr_iff.2 hb⟩

--- a/src/measure_theory/constructions/borel_space.lean
+++ b/src/measure_theory/constructions/borel_space.lean
@@ -489,7 +489,7 @@ begin
 end
 
 lemma dense.borel_eq_generate_from_Ico_mem {α : Type*} [topological_space α] [linear_order α]
-  [order_topology α] [second_countable_topology α] [densely_ordered α] [no_bot_order α]
+  [order_topology α] [second_countable_topology α] [densely_ordered α] [no_min_order α]
   {s : set α} (hd : dense s) :
   borel α = generate_from {S : set α | ∃ (l ∈ s) (u ∈ s) (h : l < u), Ico l u = S} :=
 hd.borel_eq_generate_from_Ico_mem_aux (by simp) $
@@ -516,7 +516,7 @@ begin
 end
 
 lemma dense.borel_eq_generate_from_Ioc_mem {α : Type*} [topological_space α] [linear_order α]
-  [order_topology α] [second_countable_topology α] [densely_ordered α] [no_top_order α]
+  [order_topology α] [second_countable_topology α] [densely_ordered α] [no_max_order α]
   {s : set α} (hd : dense s) :
   borel α = generate_from {S : set α | ∃ (l ∈ s) (u ∈ s) (h : l < u), Ioc l u = S} :=
 hd.borel_eq_generate_from_Ioc_mem_aux (by simp) $
@@ -565,7 +565,7 @@ end
 closed-open intervals. -/
 lemma ext_of_Ico' {α : Type*} [topological_space α] {m : measurable_space α}
   [second_countable_topology α] [linear_order α] [order_topology α] [borel_space α]
-  [no_top_order α] (μ ν : measure α) (hμ : ∀ ⦃a b⦄, a < b → μ (Ico a b) ≠ ∞)
+  [no_max_order α] (μ ν : measure α) (hμ : ∀ ⦃a b⦄, a < b → μ (Ico a b) ≠ ∞)
   (h : ∀ ⦃a b⦄, a < b → μ (Ico a b) = ν (Ico a b)) : μ = ν :=
 begin
   rcases exists_countable_dense_bot_top α with ⟨s, hsc, hsd, hsb, hst⟩,
@@ -589,7 +589,7 @@ end
 open-closed intervals. -/
 lemma ext_of_Ioc' {α : Type*} [topological_space α] {m : measurable_space α}
   [second_countable_topology α] [linear_order α] [order_topology α] [borel_space α]
-  [no_bot_order α] (μ ν : measure α) (hμ : ∀ ⦃a b⦄, a < b → μ (Ioc a b) ≠ ∞)
+  [no_min_order α] (μ ν : measure α) (hμ : ∀ ⦃a b⦄, a < b → μ (Ioc a b) ≠ ∞)
   (h : ∀ ⦃a b⦄, a < b → μ (Ioc a b) = ν (Ioc a b)) : μ = ν :=
 begin
   refine @ext_of_Ico' (order_dual α) _ _ _ _ _ ‹_› _ μ ν _ _;
@@ -601,7 +601,7 @@ end
 closed-open intervals. -/
 lemma ext_of_Ico {α : Type*} [topological_space α] {m : measurable_space α}
   [second_countable_topology α] [conditionally_complete_linear_order α] [order_topology α]
-  [borel_space α] [no_top_order α] (μ ν : measure α) [is_locally_finite_measure μ]
+  [borel_space α] [no_max_order α] (μ ν : measure α) [is_locally_finite_measure μ]
   (h : ∀ ⦃a b⦄, a < b → μ (Ico a b) = ν (Ico a b)) : μ = ν :=
 μ.ext_of_Ico' ν (λ a b hab, measure_Ico_lt_top.ne) h
 
@@ -609,7 +609,7 @@ lemma ext_of_Ico {α : Type*} [topological_space α] {m : measurable_space α}
 open-closed intervals. -/
 lemma ext_of_Ioc {α : Type*} [topological_space α] {m : measurable_space α}
   [second_countable_topology α] [conditionally_complete_linear_order α] [order_topology α]
-  [borel_space α] [no_bot_order α] (μ ν : measure α) [is_locally_finite_measure μ]
+  [borel_space α] [no_min_order α] (μ ν : measure α) [is_locally_finite_measure μ]
   (h : ∀ ⦃a b⦄, a < b → μ (Ioc a b) = ν (Ioc a b)) : μ = ν :=
 μ.ext_of_Ioc' ν (λ a b hab, measure_Ioc_lt_top.ne) h
 

--- a/src/measure_theory/integral/integral_eq_improper.lean
+++ b/src/measure_theory/integral/integral_eq_improper.lean
@@ -113,7 +113,7 @@ variables [linear_order α] [topological_space α] [order_closed_topology α]
   [opens_measurable_space α] {a b : ι → α}
   (ha : tendsto a l at_bot) (hb : tendsto b l at_top)
 
-lemma ae_cover_Ioo [no_bot_order α] [no_top_order α] :
+lemma ae_cover_Ioo [no_min_order α] [no_max_order α] :
   ae_cover μ l (λ i, Ioo (a i) (b i)) :=
 { ae_eventually_mem := ae_of_all μ (λ x,
     (ha.eventually $ eventually_lt_at_bot x).mp $
@@ -121,28 +121,28 @@ lemma ae_cover_Ioo [no_bot_order α] [no_top_order α] :
     λ i hbi hai, ⟨hai, hbi⟩ ),
   measurable := λ i, measurable_set_Ioo }
 
-lemma ae_cover_Ioc [no_bot_order α] : ae_cover μ l (λ i, Ioc (a i) (b i)) :=
+lemma ae_cover_Ioc [no_min_order α] : ae_cover μ l (λ i, Ioc (a i) (b i)) :=
 { ae_eventually_mem := ae_of_all μ (λ x,
     (ha.eventually $ eventually_lt_at_bot x).mp $
     (hb.eventually $ eventually_ge_at_top x).mono $
     λ i hbi hai, ⟨hai, hbi⟩ ),
   measurable := λ i, measurable_set_Ioc }
 
-lemma ae_cover_Ico [no_top_order α] : ae_cover μ l (λ i, Ico (a i) (b i)) :=
+lemma ae_cover_Ico [no_max_order α] : ae_cover μ l (λ i, Ico (a i) (b i)) :=
 { ae_eventually_mem := ae_of_all μ (λ x,
     (ha.eventually $ eventually_le_at_bot x).mp $
     (hb.eventually $ eventually_gt_at_top x).mono $
     λ i hbi hai, ⟨hai, hbi⟩ ),
   measurable := λ i, measurable_set_Ico }
 
-lemma ae_cover_Ioi [no_bot_order α] :
+lemma ae_cover_Ioi [no_min_order α] :
   ae_cover μ l (λ i, Ioi $ a i) :=
 { ae_eventually_mem := ae_of_all μ (λ x,
     (ha.eventually $ eventually_lt_at_bot x).mono $
     λ i hai, hai ),
   measurable := λ i, measurable_set_Ioi }
 
-lemma ae_cover_Iio [no_top_order α] :
+lemma ae_cover_Iio [no_max_order α] :
   ae_cover μ l (λ i, Iio $ b i) :=
 { ae_eventually_mem := ae_of_all μ (λ x,
     (hb.eventually $ eventually_gt_at_top x).mono $
@@ -374,7 +374,7 @@ variables {α ι E : Type*}
           [measurable_space E] [normed_group E] [borel_space E]
           {a b : ι → α} {f : α → E}
 
-lemma integrable_of_interval_integral_norm_tendsto [no_bot_order α] [nonempty α]
+lemma integrable_of_interval_integral_norm_tendsto [no_min_order α] [nonempty α]
   (I : ℝ) (hfi : ∀ i, integrable_on f (Ioc (a i) (b i)) μ)
   (ha : tendsto a l at_bot) (hb : tendsto b l at_top)
   (h : tendsto (λ i, ∫ x in a i .. b i, ∥f x∥ ∂μ) l (𝓝 $ I)) :
@@ -389,7 +389,7 @@ begin
   exact interval_integral.integral_of_le (hai.trans hbi)
 end
 
-lemma integrable_on_Iic_of_interval_integral_norm_tendsto [no_bot_order α] (I : ℝ) (b : α)
+lemma integrable_on_Iic_of_interval_integral_norm_tendsto [no_min_order α] (I : ℝ) (b : α)
   (hfi : ∀ i, integrable_on f (Ioc (a i) b) μ) (ha : tendsto a l at_bot)
   (h : tendsto (λ i, ∫ x in a i .. b, ∥f x∥ ∂μ) l (𝓝 $ I)) :
   integrable_on f (Iic b) μ :=
@@ -438,7 +438,7 @@ variables {α ι E : Type*}
           [complete_space E] [second_countable_topology E]
           {a b : ι → α} {f : α → E}
 
-lemma interval_integral_tendsto_integral [no_bot_order α] [nonempty α]
+lemma interval_integral_tendsto_integral [no_min_order α] [nonempty α]
   (hfi : integrable f μ) (ha : tendsto a l at_bot) (hb : tendsto b l at_top) :
   tendsto (λ i, ∫ x in a i .. b i, f x ∂μ) l (𝓝 $ ∫ x, f x ∂μ) :=
 begin
@@ -451,7 +451,7 @@ begin
   exact (interval_integral.integral_of_le (hai.trans hbi)).symm
 end
 
-lemma interval_integral_tendsto_integral_Iic [no_bot_order α] (b : α)
+lemma interval_integral_tendsto_integral_Iic [no_min_order α] (b : α)
   (hfi : integrable_on f (Iic b) μ) (ha : tendsto a l at_bot) :
   tendsto (λ i, ∫ x in a i .. b, f x ∂μ) l (𝓝 $ ∫ x in Iic b, f x ∂μ) :=
 begin

--- a/src/measure_theory/integral/interval_integral.lean
+++ b/src/measure_theory/integral/interval_integral.lean
@@ -1110,15 +1110,15 @@ begin
   exact (continuous_on_primitive_interval h_int).neg,
 end
 
-variables [no_bot_order α] [no_top_order α] [has_no_atoms μ]
+variables [no_min_order α] [no_max_order α] [has_no_atoms μ]
 
 lemma continuous_primitive {f : α → E} (h_int : ∀ a b : α, interval_integrable f μ a b) (a : α) :
   continuous (λ b, ∫ x in a..b, f x ∂ μ) :=
 begin
   rw continuous_iff_continuous_at,
   intro b₀,
-  cases no_bot b₀ with b₁ hb₁,
-  cases no_top b₀ with b₂ hb₂,
+  cases no_min b₀ with b₁ hb₁,
+  cases no_max b₀ with b₂ hb₂,
   apply continuous_within_at.continuous_at _ (Icc_mem_nhds hb₁ hb₂),
   exact continuous_within_at_primitive (measure_singleton b₀) (h_int _ _)
 end

--- a/src/measure_theory/integral/interval_integral.lean
+++ b/src/measure_theory/integral/interval_integral.lean
@@ -1117,8 +1117,8 @@ lemma continuous_primitive {f : α → E} (h_int : ∀ a b : α, interval_integr
 begin
   rw continuous_iff_continuous_at,
   intro b₀,
-  cases no_min b₀ with b₁ hb₁,
-  cases no_max b₀ with b₂ hb₂,
+  cases exists_lt b₀ with b₁ hb₁,
+  cases exists_gt b₀ with b₂ hb₂,
   apply continuous_within_at.continuous_at _ (Icc_mem_nhds hb₁ hb₂),
   exact continuous_within_at_primitive (measure_singleton b₀) (h_int _ _)
 end

--- a/src/order/basic.lean
+++ b/src/order/basic.lean
@@ -550,7 +550,7 @@ end prod
 
 /-- Order without a maximal element. Sometimes called cofinal. -/
 class no_max_order (α : Type u) [has_lt α] : Prop :=
-(no_max : ∀ a : α, ∃ a', a < a')
+(no_max (a : α) : ∃ b, a < b)
 
 lemma no_max [has_lt α] [no_max_order α] : ∀ a : α, ∃ a', a < a' :=
 no_max_order.no_max
@@ -573,7 +573,7 @@ le_antisymm hb (ha b)
 
 /-- Order without a minimal element. Sometimes called coinitial or dense. -/
 class no_min_order (α : Type u) [has_lt α] : Prop :=
-(no_min : ∀ a : α, ∃ a', a' < a)
+(no_min (a : α) : ∃ b, b < a)
 
 lemma no_min [has_lt α] [no_min_order α] : ∀ a : α, ∃ a', a' < a :=
 no_min_order.no_min

--- a/src/order/basic.lean
+++ b/src/order/basic.lean
@@ -550,13 +550,13 @@ end prod
 
 /-- Order without a maximal element. Sometimes called cofinal. -/
 class no_max_order (α : Type u) [has_lt α] : Prop :=
-(no_max (a : α) : ∃ b, a < b)
+(exists_gt (a : α) : ∃ b, a < b)
 
-lemma no_max [has_lt α] [no_max_order α] : ∀ a : α, ∃ a', a < a' :=
-no_max_order.no_max
+lemma exists_gt [has_lt α] [no_max_order α] : ∀ a : α, ∃ a', a < a' :=
+no_max_order.exists_gt
 
 instance nonempty_gt [has_lt α] [no_max_order α] (a : α) : nonempty {x // a < x} :=
-nonempty_subtype.2 (no_max a)
+nonempty_subtype.2 (exists_gt a)
 
 /-- `a : α` is a top element of `α` if it is greater than or equal to any other element of `α`.
 This predicate is roughly an unbundled version of `order_bot`, except that a preorder may have
@@ -565,7 +565,7 @@ several top elements. When `α` is linear, this is useful to make a case disjunc
 def is_top {α : Type u} [has_le α] (a : α) : Prop := ∀ b, b ≤ a
 
 @[simp] lemma not_is_top [preorder α] [no_max_order α] (a : α) : ¬is_top a :=
-λ h, let ⟨b, hb⟩ := no_max a in hb.not_le (h b)
+λ h, let ⟨b, hb⟩ := exists_gt a in hb.not_le (h b)
 
 lemma is_top.unique {α : Type u} [partial_order α] {a b : α} (ha : is_top a) (hb : a ≤ b) :
   a = b :=
@@ -573,10 +573,10 @@ le_antisymm hb (ha b)
 
 /-- Order without a minimal element. Sometimes called coinitial or dense. -/
 class no_min_order (α : Type u) [has_lt α] : Prop :=
-(no_min (a : α) : ∃ b, b < a)
+(exists_lt (a : α) : ∃ b, b < a)
 
-lemma no_min [has_lt α] [no_min_order α] : ∀ a : α, ∃ a', a' < a :=
-no_min_order.no_min
+lemma exists_lt [has_lt α] [no_min_order α] : ∀ a : α, ∃ a', a' < a :=
+no_min_order.exists_lt
 
 /-- `a : α` is a bottom element of `α` if it is less than or equal to any other element of `α`.
 This predicate is roughly an unbundled version of `order_bot`, except that a preorder may have
@@ -585,7 +585,7 @@ several bottom elements. When `α` is linear, this is useful to make a case disj
 def is_bot {α : Type u} [has_le α] (a : α) : Prop := ∀ b, a ≤ b
 
 @[simp] lemma not_is_bot [preorder α] [no_min_order α] (a : α) : ¬is_bot a :=
-λ h, let ⟨b, hb⟩ := no_min a in hb.not_le (h b)
+λ h, let ⟨b, hb⟩ := exists_lt a in hb.not_le (h b)
 
 lemma is_bot.unique {α : Type u} [partial_order α] {a b : α} (ha : is_bot a) (hb : b ≤ a) :
   a = b :=
@@ -593,14 +593,14 @@ le_antisymm (ha b) hb
 
 instance order_dual.no_max_order (α : Type u) [has_lt α] [no_min_order α] :
   no_max_order (order_dual α) :=
-⟨λ a, @no_min α _ _ a⟩
+⟨λ a, @exists_lt α _ _ a⟩
 
 instance order_dual.no_min_order (α : Type u) [has_lt α] [no_max_order α] :
   no_min_order (order_dual α) :=
-⟨λ a, @no_max α _ _ a⟩
+⟨λ a, @exists_gt α _ _ a⟩
 
 instance nonempty_lt [has_lt α] [no_min_order α] (a : α) : nonempty {x // x < a} :=
-nonempty_subtype.2 (no_min a)
+nonempty_subtype.2 (exists_lt a)
 
 /-- An order is dense if there is an element between any pair of distinct elements. -/
 class densely_ordered (α : Type u) [has_lt α] : Prop :=

--- a/src/order/basic.lean
+++ b/src/order/basic.lean
@@ -27,7 +27,7 @@ classes and allows to transfer order instances.
 
 ### Extra classes
 
-- `no_top_order`, `no_bot_order`: An order without a maximal/minimal element.
+- `no_max_order`, `no_min_order`: An order without a maximal/minimal element.
 - `densely_ordered`: An order with no gap, i.e. for any two elements `a < b` there exists `c` such
   that `a < c < b`.
 
@@ -549,58 +549,58 @@ end prod
 /-! ### Additional order classes -/
 
 /-- Order without a maximal element. Sometimes called cofinal. -/
-class no_top_order (α : Type u) [has_lt α] : Prop :=
-(no_top : ∀ a : α, ∃ a', a < a')
+class no_max_order (α : Type u) [has_lt α] : Prop :=
+(no_max : ∀ a : α, ∃ a', a < a')
 
-lemma no_top [has_lt α] [no_top_order α] : ∀ a : α, ∃ a', a < a' :=
-no_top_order.no_top
+lemma no_max [has_lt α] [no_max_order α] : ∀ a : α, ∃ a', a < a' :=
+no_max_order.no_max
 
-instance nonempty_gt {α : Type u} [has_lt α] [no_top_order α] (a : α) :
-  nonempty {x // a < x} :=
-nonempty_subtype.2 (no_top a)
+instance nonempty_gt [has_lt α] [no_max_order α] (a : α) : nonempty {x // a < x} :=
+nonempty_subtype.2 (no_max a)
 
 /-- `a : α` is a top element of `α` if it is greater than or equal to any other element of `α`.
-This predicate is useful, e.g., to make some statements and proofs work in both cases
-`[order_top α]` and `[no_top_order α]`. -/
+This predicate is roughly an unbundled version of `order_bot`, except that a preorder may have
+several top elements. When `α` is linear, this is useful to make a case disjunction on
+`no_max_order α` within a proof. -/
 def is_top {α : Type u} [has_le α] (a : α) : Prop := ∀ b, b ≤ a
 
-@[simp] lemma not_is_top {α : Type u} [preorder α] [no_top_order α] (a : α) : ¬is_top a :=
-λ h, let ⟨b, hb⟩ := no_top a in hb.not_le (h b)
+@[simp] lemma not_is_top [preorder α] [no_max_order α] (a : α) : ¬is_top a :=
+λ h, let ⟨b, hb⟩ := no_max a in hb.not_le (h b)
 
 lemma is_top.unique {α : Type u} [partial_order α] {a b : α} (ha : is_top a) (hb : a ≤ b) :
   a = b :=
 le_antisymm hb (ha b)
 
 /-- Order without a minimal element. Sometimes called coinitial or dense. -/
-class no_bot_order (α : Type u) [has_lt α] : Prop :=
-(no_bot : ∀ a : α, ∃ a', a' < a)
+class no_min_order (α : Type u) [has_lt α] : Prop :=
+(no_min : ∀ a : α, ∃ a', a' < a)
 
-lemma no_bot [has_lt α] [no_bot_order α] : ∀ a : α, ∃ a', a' < a :=
-no_bot_order.no_bot
+lemma no_min [has_lt α] [no_min_order α] : ∀ a : α, ∃ a', a' < a :=
+no_min_order.no_min
 
 /-- `a : α` is a bottom element of `α` if it is less than or equal to any other element of `α`.
-This predicate is useful, e.g., to make some statements and proofs work in both cases
-`[order_bot α]` and `[no_bot_order α]`. -/
+This predicate is roughly an unbundled version of `order_bot`, except that a preorder may have
+several bottom elements. When `α` is linear, this is useful to make a case disjunction on
+`no_min_order α` within a proof. -/
 def is_bot {α : Type u} [has_le α] (a : α) : Prop := ∀ b, a ≤ b
 
-@[simp] lemma not_is_bot {α : Type u} [preorder α] [no_bot_order α] (a : α) : ¬is_bot a :=
-λ h, let ⟨b, hb⟩ := no_bot a in hb.not_le (h b)
+@[simp] lemma not_is_bot [preorder α] [no_min_order α] (a : α) : ¬is_bot a :=
+λ h, let ⟨b, hb⟩ := no_min a in hb.not_le (h b)
 
 lemma is_bot.unique {α : Type u} [partial_order α] {a b : α} (ha : is_bot a) (hb : b ≤ a) :
   a = b :=
 le_antisymm (ha b) hb
 
-instance order_dual.no_top_order (α : Type u) [has_lt α] [no_bot_order α] :
-  no_top_order (order_dual α) :=
-⟨λ a, @no_bot α _ _ a⟩
+instance order_dual.no_max_order (α : Type u) [has_lt α] [no_min_order α] :
+  no_max_order (order_dual α) :=
+⟨λ a, @no_min α _ _ a⟩
 
-instance order_dual.no_bot_order (α : Type u) [has_lt α] [no_top_order α] :
-  no_bot_order (order_dual α) :=
-⟨λ a, @no_top α _ _ a⟩
+instance order_dual.no_min_order (α : Type u) [has_lt α] [no_max_order α] :
+  no_min_order (order_dual α) :=
+⟨λ a, @no_max α _ _ a⟩
 
-instance nonempty_lt {α : Type u} [has_lt α] [no_bot_order α] (a : α) :
-  nonempty {x // x < a} :=
-nonempty_subtype.2 (no_bot a)
+instance nonempty_lt [has_lt α] [no_min_order α] (a : α) : nonempty {x // x < a} :=
+nonempty_subtype.2 (no_min a)
 
 /-- An order is dense if there is an element between any pair of distinct elements. -/
 class densely_ordered (α : Type u) [has_lt α] : Prop :=

--- a/src/order/bounded_order.lean
+++ b/src/order/bounded_order.lean
@@ -619,23 +619,23 @@ have acc_bot : acc ((<) : with_bot α → with_bot α → Prop) ⊥ :=
   from λ b ih hba, acc.intro _ (λ c, option.rec_on c (λ _, acc_bot)
     (λ c hc, ih _ (some_lt_some.1 hc) (lt_trans hc hba)))))))⟩
 
-instance densely_ordered [has_lt α] [densely_ordered α] [no_bot_order α] :
+instance densely_ordered [has_lt α] [densely_ordered α] [no_min_order α] :
   densely_ordered (with_bot α) :=
 ⟨ λ a b,
   match a, b with
   | a,      none   := λ h : a < ⊥, (not_lt_none _ h).elim
-  | none,   some b := λ h, let ⟨a, ha⟩ := no_bot b in ⟨a, bot_lt_coe a, coe_lt_coe.2 ha⟩
+  | none,   some b := λ h, let ⟨a, ha⟩ := no_min b in ⟨a, bot_lt_coe a, coe_lt_coe.2 ha⟩
   | some a, some b := λ h, let ⟨a, ha₁, ha₂⟩ := exists_between (coe_lt_coe.1 h) in
     ⟨a, coe_lt_coe.2 ha₁, coe_lt_coe.2 ha₂⟩
   end⟩
 
-instance {α : Type*} [has_lt α] [no_top_order α] [nonempty α] : no_top_order (with_bot α) :=
+instance {α : Type*} [has_lt α] [no_max_order α] [nonempty α] : no_max_order (with_bot α) :=
 ⟨begin
   apply with_bot.rec_bot_coe,
   { apply ‹nonempty α›.elim,
     exact λ a, ⟨a, with_bot.bot_lt_coe a⟩, },
   { intro a,
-    obtain ⟨b, ha⟩ := no_top a,
+    obtain ⟨b, ha⟩ := no_max a,
     exact ⟨b, with_bot.coe_lt_coe.mpr ha⟩, }
 end⟩
 
@@ -866,29 +866,29 @@ have acc_some : ∀ a : α, acc ((<) : with_top α → with_top α → Prop) (so
 ⟨λ a, option.rec_on a (acc.intro _ (λ y, option.rec_on y (λ h, (lt_irrefl _ h).elim)
   (λ _ _, acc_some _))) acc_some⟩
 
-instance densely_ordered [has_lt α] [densely_ordered α] [no_top_order α] :
+instance densely_ordered [has_lt α] [densely_ordered α] [no_max_order α] :
   densely_ordered (with_top α) :=
 ⟨ λ a b,
   match a, b with
   | none,   a   := λ h : ⊤ < a, (not_none_lt _ h).elim
-  | some a, none := λ h, let ⟨b, hb⟩ := no_top a in ⟨b, coe_lt_coe.2 hb, coe_lt_top b⟩
+  | some a, none := λ h, let ⟨b, hb⟩ := no_max a in ⟨b, coe_lt_coe.2 hb, coe_lt_top b⟩
   | some a, some b := λ h, let ⟨a, ha₁, ha₂⟩ := exists_between (coe_lt_coe.1 h) in
     ⟨a, coe_lt_coe.2 ha₁, coe_lt_coe.2 ha₂⟩
   end⟩
 
-lemma lt_iff_exists_coe_btwn [partial_order α] [densely_ordered α] [no_top_order α]
+lemma lt_iff_exists_coe_btwn [partial_order α] [densely_ordered α] [no_max_order α]
   {a b : with_top α} :
   (a < b) ↔ (∃ x : α, a < ↑x ∧ ↑x < b) :=
 ⟨λ h, let ⟨y, hy⟩ := exists_between h, ⟨x, hx⟩ := lt_iff_exists_coe.1 hy.2 in ⟨x, hx.1 ▸ hy⟩,
  λ ⟨x, hx⟩, lt_trans hx.1 hx.2⟩
 
-instance {α : Type*} [has_lt α] [no_bot_order α] [nonempty α] : no_bot_order (with_top α) :=
+instance {α : Type*} [has_lt α] [no_min_order α] [nonempty α] : no_min_order (with_top α) :=
 ⟨begin
   apply with_top.rec_top_coe,
   { apply ‹nonempty α›.elim,
     exact λ a, ⟨a, with_top.coe_lt_top a⟩, },
   { intro a,
-    obtain ⟨b, ha⟩ := no_bot a,
+    obtain ⟨b, ha⟩ := no_min a,
     exact ⟨b, with_top.coe_lt_coe.mpr ha⟩, }
 end⟩
 

--- a/src/order/bounded_order.lean
+++ b/src/order/bounded_order.lean
@@ -624,7 +624,7 @@ instance densely_ordered [has_lt α] [densely_ordered α] [no_min_order α] :
 ⟨ λ a b,
   match a, b with
   | a,      none   := λ h : a < ⊥, (not_lt_none _ h).elim
-  | none,   some b := λ h, let ⟨a, ha⟩ := no_min b in ⟨a, bot_lt_coe a, coe_lt_coe.2 ha⟩
+  | none,   some b := λ h, let ⟨a, ha⟩ := exists_lt b in ⟨a, bot_lt_coe a, coe_lt_coe.2 ha⟩
   | some a, some b := λ h, let ⟨a, ha₁, ha₂⟩ := exists_between (coe_lt_coe.1 h) in
     ⟨a, coe_lt_coe.2 ha₁, coe_lt_coe.2 ha₂⟩
   end⟩
@@ -635,7 +635,7 @@ instance [has_lt α] [no_max_order α] [nonempty α] : no_max_order (with_bot α
   { apply ‹nonempty α›.elim,
     exact λ a, ⟨a, with_bot.bot_lt_coe a⟩, },
   { intro a,
-    obtain ⟨b, ha⟩ := no_max a,
+    obtain ⟨b, ha⟩ := exists_gt a,
     exact ⟨b, with_bot.coe_lt_coe.mpr ha⟩, }
 end⟩
 
@@ -871,7 +871,7 @@ instance densely_ordered [has_lt α] [densely_ordered α] [no_max_order α] :
 ⟨ λ a b,
   match a, b with
   | none,   a   := λ h : ⊤ < a, (not_none_lt _ h).elim
-  | some a, none := λ h, let ⟨b, hb⟩ := no_max a in ⟨b, coe_lt_coe.2 hb, coe_lt_top b⟩
+  | some a, none := λ h, let ⟨b, hb⟩ := exists_gt a in ⟨b, coe_lt_coe.2 hb, coe_lt_top b⟩
   | some a, some b := λ h, let ⟨a, ha₁, ha₂⟩ := exists_between (coe_lt_coe.1 h) in
     ⟨a, coe_lt_coe.2 ha₁, coe_lt_coe.2 ha₂⟩
   end⟩
@@ -888,7 +888,7 @@ instance [has_lt α] [no_min_order α] [nonempty α] : no_min_order (with_top α
   { apply ‹nonempty α›.elim,
     exact λ a, ⟨a, with_top.coe_lt_top a⟩, },
   { intro a,
-    obtain ⟨b, ha⟩ := no_min a,
+    obtain ⟨b, ha⟩ := exists_lt a,
     exact ⟨b, with_top.coe_lt_coe.mpr ha⟩, }
 end⟩
 

--- a/src/order/bounded_order.lean
+++ b/src/order/bounded_order.lean
@@ -629,7 +629,7 @@ instance densely_ordered [has_lt α] [densely_ordered α] [no_min_order α] :
     ⟨a, coe_lt_coe.2 ha₁, coe_lt_coe.2 ha₂⟩
   end⟩
 
-instance {α : Type*} [has_lt α] [no_max_order α] [nonempty α] : no_max_order (with_bot α) :=
+instance [has_lt α] [no_max_order α] [nonempty α] : no_max_order (with_bot α) :=
 ⟨begin
   apply with_bot.rec_bot_coe,
   { apply ‹nonempty α›.elim,
@@ -882,7 +882,7 @@ lemma lt_iff_exists_coe_btwn [partial_order α] [densely_ordered α] [no_max_ord
 ⟨λ h, let ⟨y, hy⟩ := exists_between h, ⟨x, hx⟩ := lt_iff_exists_coe.1 hy.2 in ⟨x, hx.1 ▸ hy⟩,
  λ ⟨x, hx⟩, lt_trans hx.1 hx.2⟩
 
-instance {α : Type*} [has_lt α] [no_min_order α] [nonempty α] : no_min_order (with_top α) :=
+instance [has_lt α] [no_min_order α] [nonempty α] : no_min_order (with_top α) :=
 ⟨begin
   apply with_top.rec_top_coe,
   { apply ‹nonempty α›.elim,

--- a/src/order/bounds.lean
+++ b/src/order/bounds.lean
@@ -518,7 +518,7 @@ lemma is_glb_univ [preorder γ] [order_bot γ] : is_glb (univ : set γ) ⊥ :=
 is_least_univ.is_glb
 
 @[simp] lemma no_max_order.upper_bounds_univ [no_max_order α] : upper_bounds (univ : set α) = ∅ :=
-eq_empty_of_subset_empty $ λ b hb, let ⟨x, hx⟩ := no_max b in
+eq_empty_of_subset_empty $ λ b hb, let ⟨x, hx⟩ := exists_gt b in
 not_le_of_lt hx (hb trivial)
 
 @[simp] lemma no_min_order.lower_bounds_univ [no_min_order α] : lower_bounds (univ : set α) = ∅ :=
@@ -553,7 +553,7 @@ lemma is_lub_empty [preorder γ] [order_bot γ] : is_lub ∅ (⊥:γ) :=
 @is_glb_empty (order_dual γ) _ _
 
 lemma is_lub.nonempty [no_min_order α] (hs : is_lub s a) : s.nonempty :=
-let ⟨a', ha'⟩ := no_min a in
+let ⟨a', ha'⟩ := exists_lt a in
 ne_empty_iff_nonempty.1 $ assume h,
 have a ≤ a', from hs.right $ by simp only [h, upper_bounds_empty],
 not_le_of_lt ha' this

--- a/src/order/bounds.lean
+++ b/src/order/bounds.lean
@@ -517,17 +517,17 @@ lemma is_least_univ [preorder γ] [order_bot γ] : is_least (univ : set γ) ⊥ 
 lemma is_glb_univ [preorder γ] [order_bot γ] : is_glb (univ : set γ) ⊥ :=
 is_least_univ.is_glb
 
-@[simp] lemma no_top_order.upper_bounds_univ [no_top_order α] : upper_bounds (univ : set α) = ∅ :=
-eq_empty_of_subset_empty $ λ b hb, let ⟨x, hx⟩ := no_top b in
+@[simp] lemma no_max_order.upper_bounds_univ [no_max_order α] : upper_bounds (univ : set α) = ∅ :=
+eq_empty_of_subset_empty $ λ b hb, let ⟨x, hx⟩ := no_max b in
 not_le_of_lt hx (hb trivial)
 
-@[simp] lemma no_bot_order.lower_bounds_univ [no_bot_order α] : lower_bounds (univ : set α) = ∅ :=
-@no_top_order.upper_bounds_univ (order_dual α) _ _
+@[simp] lemma no_min_order.lower_bounds_univ [no_min_order α] : lower_bounds (univ : set α) = ∅ :=
+@no_max_order.upper_bounds_univ (order_dual α) _ _
 
-@[simp] lemma not_bdd_above_univ [no_top_order α] : ¬bdd_above (univ : set α) :=
+@[simp] lemma not_bdd_above_univ [no_max_order α] : ¬bdd_above (univ : set α) :=
 by simp [bdd_above]
 
-@[simp] lemma not_bdd_below_univ [no_bot_order α] : ¬bdd_below (univ : set α) :=
+@[simp] lemma not_bdd_below_univ [no_min_order α] : ¬bdd_below (univ : set α) :=
 @not_bdd_above_univ (order_dual α) _ _
 
 /-!
@@ -552,13 +552,13 @@ by simp only [is_glb, lower_bounds_empty, is_greatest_univ]
 lemma is_lub_empty [preorder γ] [order_bot γ] : is_lub ∅ (⊥:γ) :=
 @is_glb_empty (order_dual γ) _ _
 
-lemma is_lub.nonempty [no_bot_order α] (hs : is_lub s a) : s.nonempty :=
-let ⟨a', ha'⟩ := no_bot a in
+lemma is_lub.nonempty [no_min_order α] (hs : is_lub s a) : s.nonempty :=
+let ⟨a', ha'⟩ := no_min a in
 ne_empty_iff_nonempty.1 $ assume h,
 have a ≤ a', from hs.right $ by simp only [h, upper_bounds_empty],
 not_le_of_lt ha' this
 
-lemma is_glb.nonempty [no_top_order α] (hs : is_glb s a) : s.nonempty := hs.dual.nonempty
+lemma is_glb.nonempty [no_max_order α] (hs : is_glb s a) : s.nonempty := hs.dual.nonempty
 
 lemma nonempty_of_not_bdd_above [ha : nonempty α] (h : ¬bdd_above s) : s.nonempty :=
 nonempty.elim ha $ λ x, (not_bdd_above_iff'.1 h x).imp $ λ a ha, ha.fst

--- a/src/order/conditionally_complete_lattice.lean
+++ b/src/order/conditionally_complete_lattice.lean
@@ -407,7 +407,7 @@ theorem cInf_insert (hs : bdd_below s) (sne : s.nonempty) : Inf (insert a s) = a
 @[simp] lemma cInf_Ioc [densely_ordered α] (h : a < b) : Inf (Ioc a b) = a :=
 (is_glb_Ioc h).cInf_eq (nonempty_Ioc.2 h)
 
-@[simp] lemma cInf_Ioi [no_top_order α] [densely_ordered α] : Inf (Ioi a) = a :=
+@[simp] lemma cInf_Ioi [no_max_order α] [densely_ordered α] : Inf (Ioi a) = a :=
 cInf_eq_of_forall_ge_of_forall_gt_exists_lt nonempty_Ioi (λ _, le_of_lt)
   (λ w hw, by simpa using exists_between hw)
 
@@ -422,7 +422,7 @@ cInf_eq_of_forall_ge_of_forall_gt_exists_lt nonempty_Ioi (λ _, le_of_lt)
 
 @[simp] lemma cSup_Iic : Sup (Iic a) = a := is_greatest_Iic.cSup_eq
 
-@[simp] lemma cSup_Iio [no_bot_order α] [densely_ordered α] : Sup (Iio a) = a :=
+@[simp] lemma cSup_Iio [no_min_order α] [densely_ordered α] : Sup (Iio a) = a :=
 cSup_eq_of_forall_le_of_forall_lt_exists_gt nonempty_Iio (λ _, le_of_lt)
   (λ w hw, by simpa [and_comm] using exists_between hw)
 

--- a/src/order/countable_dense_linear_order.lean
+++ b/src/order/countable_dense_linear_order.lean
@@ -48,12 +48,12 @@ if nlo : lo.nonempty then
       (λ m hm, ⟨m, λ x hx, lt_of_le_of_lt (finset.le_max' lo x hx) hm.1,
                    λ y hy, lt_of_lt_of_le hm.2 (finset.min'_le hi y hy)⟩)
   else -- upper set is empty, use `no_max_order`
-    exists.elim (no_max (finset.max' lo nlo)) (λ m hm,
+    exists.elim (exists_gt (finset.max' lo nlo)) (λ m hm,
     ⟨m, λ x hx, lt_of_le_of_lt (finset.le_max' lo x hx) hm,
         λ y hy, (nhi ⟨y, hy⟩).elim⟩)
 else
   if nhi : hi.nonempty then -- lower set is empty, use `no_min_order`
-    exists.elim (no_min (finset.min' hi nhi)) (λ m hm,
+    exists.elim (exists_lt (finset.min' hi nhi)) (λ m hm,
     ⟨m, λ x hx, (nlo ⟨x, hx⟩).elim,
         λ y hy, lt_of_lt_of_le hm (finset.min'_le hi y hy)⟩)
   else -- both sets are empty, use nonempty

--- a/src/order/countable_dense_linear_order.lean
+++ b/src/order/countable_dense_linear_order.lean
@@ -39,7 +39,7 @@ namespace order
     before `hi`. Then there is an element of `α` strictly between `lo`
     and `hi`. -/
 lemma exists_between_finsets {α : Type*} [linear_order α]
-  [densely_ordered α] [no_bot_order α] [no_top_order α] [nonem : nonempty α]
+  [densely_ordered α] [no_min_order α] [no_max_order α] [nonem : nonempty α]
   (lo hi : finset α) (lo_lt_hi : ∀ (x ∈ lo) (y ∈ hi), x < y) :
   ∃ m : α, (∀ x ∈ lo, x < m) ∧ (∀ y ∈ hi, m < y) :=
 if nlo : lo.nonempty then
@@ -47,13 +47,13 @@ if nlo : lo.nonempty then
     exists.elim (exists_between (lo_lt_hi _ (finset.max'_mem _ nlo) _ (finset.min'_mem _ nhi)))
       (λ m hm, ⟨m, λ x hx, lt_of_le_of_lt (finset.le_max' lo x hx) hm.1,
                    λ y hy, lt_of_lt_of_le hm.2 (finset.min'_le hi y hy)⟩)
-  else -- upper set is empty, use no_top_order
-    exists.elim (no_top (finset.max' lo nlo)) (λ m hm,
+  else -- upper set is empty, use `no_max_order`
+    exists.elim (no_max (finset.max' lo nlo)) (λ m hm,
     ⟨m, λ x hx, lt_of_le_of_lt (finset.le_max' lo x hx) hm,
         λ y hy, (nhi ⟨y, hy⟩).elim⟩)
 else
-  if nhi : hi.nonempty then -- lower set is empty, use no_bot_order
-    exists.elim (no_bot (finset.min' hi nhi)) (λ m hm,
+  if nhi : hi.nonempty then -- lower set is empty, use `no_min_order`
+    exists.elim (no_min (finset.min' hi nhi)) (λ m hm,
     ⟨m, λ x hx, (nlo ⟨x, hx⟩).elim,
         λ y hy, lt_of_lt_of_le hm (finset.min'_le hi y hy)⟩)
   else -- both sets are empty, use nonempty
@@ -82,7 +82,7 @@ the domain of `f` is `b`'s relation to the image of `f`.
 
 Thus, if `a` is not already in `f`, then we can extend `f` by sending `a` to `b`.
 -/
-lemma exists_across [densely_ordered β] [no_bot_order β] [no_top_order β] [nonempty β]
+lemma exists_across [densely_ordered β] [no_min_order β] [no_max_order β] [nonempty β]
   (f : partial_iso α β) (a : α) :
   ∃ b : β, ∀ (p ∈ f.val), cmp (prod.fst p) a = cmp (prod.snd p) b :=
 begin
@@ -122,7 +122,7 @@ subtype.map (finset.image (equiv.prod_comm _ _)) $ λ f hf p hp q hq,
 variable (β)
 /-- The set of partial isomorphisms defined at `a : α`, together with a proof that any
     partial isomorphism can be extended to one defined at `a`. -/
-def defined_at_left [densely_ordered β] [no_bot_order β] [no_top_order β] [nonempty β]
+def defined_at_left [densely_ordered β] [no_min_order β] [no_max_order β] [nonempty β]
   (a : α) : cofinal (partial_iso α β) :=
 { carrier := λ f, ∃ b : β, (a, b) ∈ f.val,
   mem_gt :=
@@ -143,7 +143,7 @@ def defined_at_left [densely_ordered β] [no_bot_order β] [no_top_order β] [no
 variables (α) {β}
 /-- The set of partial isomorphisms defined at `b : β`, together with a proof that any
     partial isomorphism can be extended to include `b`. We prove this by symmetry. -/
-def defined_at_right [densely_ordered α] [no_bot_order α] [no_top_order α] [nonempty α]
+def defined_at_right [densely_ordered α] [no_min_order α] [no_max_order α] [nonempty α]
   (b : β) : cofinal (partial_iso α β) :=
 { carrier := λ f, ∃ a, (a, b) ∈ f.val,
   mem_gt :=
@@ -165,14 +165,14 @@ variable {α}
 
 /-- Given an ideal which intersects `defined_at_left β a`, pick `b : β` such that
     some partial function in the ideal maps `a` to `b`. -/
-def fun_of_ideal [densely_ordered β] [no_bot_order β] [no_top_order β] [nonempty β]
+def fun_of_ideal [densely_ordered β] [no_min_order β] [no_max_order β] [nonempty β]
   (a : α) (I : ideal (partial_iso α β)) :
   (∃ f, f ∈ defined_at_left β a ∧ f ∈ I) → { b // ∃ f ∈ I, (a, b) ∈ subtype.val f } :=
 classical.indefinite_description _ ∘ (λ ⟨f, ⟨b, hb⟩, hf⟩, ⟨b, f, hf, hb⟩)
 
 /-- Given an ideal which intersects `defined_at_right α b`, pick `a : α` such that
     some partial function in the ideal maps `a` to `b`. -/
-def inv_of_ideal [densely_ordered α] [no_bot_order α] [no_top_order α] [nonempty α]
+def inv_of_ideal [densely_ordered α] [no_min_order α] [no_max_order α] [nonempty α]
   (b : β) (I : ideal (partial_iso α β)) :
   (∃ f, f ∈ defined_at_right α b ∧ f ∈ I) → { a // ∃ f ∈ I, (a, b) ∈ subtype.val f } :=
 classical.indefinite_description _ ∘ (λ ⟨f, ⟨a, ha⟩, hf⟩, ⟨a, f, hf, ha⟩)
@@ -184,7 +184,7 @@ variables (α β)
 
 /-- Any countable linear order embeds in any nonempty dense linear order without endpoints. -/
 def embedding_from_countable_to_dense
-  [encodable α] [densely_ordered β] [no_bot_order β] [no_top_order β] [nonempty β] :
+  [encodable α] [densely_ordered β] [no_min_order β] [no_max_order β] [nonempty β] :
   α ↪o β :=
 let our_ideal : ideal (partial_iso α β) := ideal_of_cofinals default $ defined_at_left β in
 let F := λ a, fun_of_ideal a our_ideal (cofinal_meets_ideal_of_cofinals _ _ a) in
@@ -199,8 +199,8 @@ end
 
 /-- Any two countable dense, nonempty linear orders without endpoints are order isomorphic. -/
 def iso_of_countable_dense
-  [encodable α] [densely_ordered α] [no_bot_order α] [no_top_order α] [nonempty α]
-  [encodable β] [densely_ordered β] [no_bot_order β] [no_top_order β] [nonempty β] :
+  [encodable α] [densely_ordered α] [no_min_order α] [no_max_order α] [nonempty α]
+  [encodable β] [densely_ordered β] [no_min_order β] [no_max_order β] [nonempty β] :
   α ≃o β :=
 let to_cofinal : α ⊕ β → cofinal (partial_iso α β) :=
   λ p, sum.rec_on p (defined_at_left β) (defined_at_right α) in

--- a/src/order/filter/at_top_bot.lean
+++ b/src/order/filter/at_top_bot.lean
@@ -1043,7 +1043,7 @@ map_coe_at_top_of_Ici_subset (subset.refl _)
 /-- The image of the filter `at_top` on `Ioi a` under the coercion equals `at_top`. -/
 @[simp] lemma map_coe_Ioi_at_top [semilattice_sup α] [no_max_order α] (a : α) :
   map (coe : Ioi a → α) at_top = at_top :=
-map_coe_at_top_of_Ici_subset $ Ici_subset_Ioi.2 (no_max a).snd
+let ⟨b, hb⟩ := no_max a in map_coe_at_top_of_Ici_subset $ Ici_subset_Ioi.2 hb
 
 /-- The `at_top` filter for an open interval `Ioi a` comes from the `at_top` filter in the ambient
 order. -/

--- a/src/order/filter/at_top_bot.lean
+++ b/src/order/filter/at_top_bot.lean
@@ -1043,10 +1043,7 @@ map_coe_at_top_of_Ici_subset (subset.refl _)
 /-- The image of the filter `at_top` on `Ioi a` under the coercion equals `at_top`. -/
 @[simp] lemma map_coe_Ioi_at_top [semilattice_sup α] [no_max_order α] (a : α) :
   map (coe : Ioi a → α) at_top = at_top :=
-begin
-  rcases no_max a with ⟨b, hb⟩,
-  exact map_coe_at_top_of_Ici_subset (Ici_subset_Ioi.2 hb)
-end
+map_coe_at_top_of_Ici_subset $ Ici_subset_Ioi.2 (no_max a).snd
 
 /-- The `at_top` filter for an open interval `Ioi a` comes from the `at_top` filter in the ambient
 order. -/

--- a/src/order/filter/at_top_bot.lean
+++ b/src/order/filter/at_top_bot.lean
@@ -39,13 +39,13 @@ lemma mem_at_top [preorder α] (a : α) : {b : α | a ≤ b} ∈ @at_top α _ :=
 mem_infi_of_mem a $ subset.refl _
 
 lemma Ioi_mem_at_top [preorder α] [no_max_order α] (x : α) : Ioi x ∈ (at_top : filter α) :=
-let ⟨z, hz⟩ := no_max x in mem_of_superset (mem_at_top z) $ λ y h,  lt_of_lt_of_le hz h
+let ⟨z, hz⟩ := exists_gt x in mem_of_superset (mem_at_top z) $ λ y h,  lt_of_lt_of_le hz h
 
 lemma mem_at_bot [preorder α] (a : α) : {b : α | b ≤ a} ∈ @at_bot α _ :=
 mem_infi_of_mem a $ subset.refl _
 
 lemma Iio_mem_at_bot [preorder α] [no_min_order α] (x : α) : Iio x ∈ (at_bot : filter α) :=
-let ⟨z, hz⟩ := no_min x in mem_of_superset (mem_at_bot z) $ λ y h, lt_of_le_of_lt h hz
+let ⟨z, hz⟩ := exists_lt x in mem_of_superset (mem_at_bot z) $ λ y h, lt_of_le_of_lt h hz
 
 lemma at_top_basis [nonempty α] [semilattice_sup α] :
   (@at_top α _).has_basis (λ _, true) Ici :=
@@ -108,7 +108,7 @@ Iio_mem_at_bot a
 lemma at_top_basis_Ioi [nonempty α] [semilattice_sup α] [no_max_order α] :
   (@at_top α _).has_basis (λ _, true) Ioi :=
 at_top_basis.to_has_basis (λ a ha, ⟨a, ha, Ioi_subset_Ici_self⟩) $
-  λ a ha, (no_max a).imp $ λ b hb, ⟨ha, Ici_subset_Ioi.2 hb⟩
+  λ a ha, (exists_gt a).imp $ λ b hb, ⟨ha, Ici_subset_Ioi.2 hb⟩
 
 lemma at_top_countable_basis [nonempty α] [semilattice_sup α] [encodable α] :
   has_countable_basis (at_top : filter α) (λ _, true) Ici :=
@@ -294,7 +294,7 @@ lemma exists_le_of_tendsto_at_bot [semilattice_sup α] [preorder β] {u : α →
 lemma exists_lt_of_tendsto_at_top [semilattice_sup α] [preorder β] [no_max_order β]
   {u : α → β} (h : tendsto u at_top at_top) (a : α) (b : β) : ∃ a' ≥ a, b < u a' :=
 begin
-  cases no_max b with b' hb',
+  cases exists_gt b with b' hb',
   rcases exists_le_of_tendsto_at_top h a b' with ⟨a', ha', ha''⟩,
   exact ⟨a', ha', lt_of_lt_of_le hb' ha''⟩
 end
@@ -1043,7 +1043,7 @@ map_coe_at_top_of_Ici_subset (subset.refl _)
 /-- The image of the filter `at_top` on `Ioi a` under the coercion equals `at_top`. -/
 @[simp] lemma map_coe_Ioi_at_top [semilattice_sup α] [no_max_order α] (a : α) :
   map (coe : Ioi a → α) at_top = at_top :=
-let ⟨b, hb⟩ := no_max a in map_coe_at_top_of_Ici_subset $ Ici_subset_Ioi.2 hb
+let ⟨b, hb⟩ := exists_gt a in map_coe_at_top_of_Ici_subset $ Ici_subset_Ioi.2 hb
 
 /-- The `at_top` filter for an open interval `Ioi a` comes from the `at_top` filter in the ambient
 order. -/

--- a/src/order/filter/at_top_bot.lean
+++ b/src/order/filter/at_top_bot.lean
@@ -38,14 +38,14 @@ def at_bot [preorder α] : filter α := ⨅ a, 𝓟 (Iic a)
 lemma mem_at_top [preorder α] (a : α) : {b : α | a ≤ b} ∈ @at_top α _ :=
 mem_infi_of_mem a $ subset.refl _
 
-lemma Ioi_mem_at_top [preorder α] [no_top_order α] (x : α) : Ioi x ∈ (at_top : filter α) :=
-let ⟨z, hz⟩ := no_top x in mem_of_superset (mem_at_top z) $ λ y h,  lt_of_lt_of_le hz h
+lemma Ioi_mem_at_top [preorder α] [no_max_order α] (x : α) : Ioi x ∈ (at_top : filter α) :=
+let ⟨z, hz⟩ := no_max x in mem_of_superset (mem_at_top z) $ λ y h,  lt_of_lt_of_le hz h
 
 lemma mem_at_bot [preorder α] (a : α) : {b : α | b ≤ a} ∈ @at_bot α _ :=
 mem_infi_of_mem a $ subset.refl _
 
-lemma Iio_mem_at_bot [preorder α] [no_bot_order α] (x : α) : Iio x ∈ (at_bot : filter α) :=
-let ⟨z, hz⟩ := no_bot x in mem_of_superset (mem_at_bot z) $ λ y h, lt_of_le_of_lt h hz
+lemma Iio_mem_at_bot [preorder α] [no_min_order α] (x : α) : Iio x ∈ (at_bot : filter α) :=
+let ⟨z, hz⟩ := no_min x in mem_of_superset (mem_at_bot z) $ λ y h, lt_of_le_of_lt h hz
 
 lemma at_top_basis [nonempty α] [semilattice_sup α] :
   (@at_top α _).has_basis (λ _, true) Ici :=
@@ -97,18 +97,18 @@ lemma eventually_ge_at_top [preorder α] (a : α) : ∀ᶠ x in at_top, a ≤ x 
 
 lemma eventually_le_at_bot [preorder α] (a : α) : ∀ᶠ x in at_bot, x ≤ a := mem_at_bot a
 
-lemma eventually_gt_at_top [preorder α] [no_top_order α] (a : α) :
+lemma eventually_gt_at_top [preorder α] [no_max_order α] (a : α) :
   ∀ᶠ x in at_top, a < x :=
 Ioi_mem_at_top a
 
-lemma eventually_lt_at_bot [preorder α] [no_bot_order α] (a : α) :
+lemma eventually_lt_at_bot [preorder α] [no_min_order α] (a : α) :
   ∀ᶠ x in at_bot, x < a :=
 Iio_mem_at_bot a
 
-lemma at_top_basis_Ioi [nonempty α] [semilattice_sup α] [no_top_order α] :
+lemma at_top_basis_Ioi [nonempty α] [semilattice_sup α] [no_max_order α] :
   (@at_top α _).has_basis (λ _, true) Ioi :=
 at_top_basis.to_has_basis (λ a ha, ⟨a, ha, Ioi_subset_Ici_self⟩) $
-  λ a ha, (no_top a).imp $ λ b hb, ⟨ha, Ici_subset_Ioi.2 hb⟩
+  λ a ha, (no_max a).imp $ λ b hb, ⟨ha, Ici_subset_Ioi.2 hb⟩
 
 lemma at_top_countable_basis [nonempty α] [semilattice_sup α] [encodable α] :
   has_countable_basis (at_top : filter α) (λ _, true) Ici :=
@@ -174,11 +174,11 @@ lemma frequently_at_bot [semilattice_inf α] [nonempty α] {p : α → Prop} :
   (∃ᶠ x in at_bot, p x) ↔ (∀ a, ∃ b ≤ a, p b) :=
 @frequently_at_top (order_dual α) _ _ _
 
-lemma frequently_at_top' [semilattice_sup α] [nonempty α] [no_top_order α] {p : α → Prop} :
+lemma frequently_at_top' [semilattice_sup α] [nonempty α] [no_max_order α] {p : α → Prop} :
   (∃ᶠ x in at_top, p x) ↔ (∀ a, ∃ b > a, p b) :=
 by simp [at_top_basis_Ioi.frequently_iff]
 
-lemma frequently_at_bot' [semilattice_inf α] [nonempty α] [no_bot_order α] {p : α → Prop} :
+lemma frequently_at_bot' [semilattice_inf α] [nonempty α] [no_min_order α] {p : α → Prop} :
   (∃ᶠ x in at_bot, p x) ↔ (∀ a, ∃ b < a, p b) :=
 @frequently_at_top' (order_dual α) _ _ _ _
 
@@ -291,16 +291,16 @@ lemma exists_le_of_tendsto_at_bot [semilattice_sup α] [preorder β] {u : α →
   (h : tendsto u at_top at_bot) : ∀ a b, ∃ a' ≥ a, u a' ≤ b :=
 @exists_le_of_tendsto_at_top _ (order_dual β) _ _ _ h
 
-lemma exists_lt_of_tendsto_at_top [semilattice_sup α] [preorder β] [no_top_order β]
+lemma exists_lt_of_tendsto_at_top [semilattice_sup α] [preorder β] [no_max_order β]
   {u : α → β} (h : tendsto u at_top at_top) (a : α) (b : β) : ∃ a' ≥ a, b < u a' :=
 begin
-  cases no_top b with b' hb',
+  cases no_max b with b' hb',
   rcases exists_le_of_tendsto_at_top h a b' with ⟨a', ha', ha''⟩,
   exact ⟨a', ha', lt_of_lt_of_le hb' ha''⟩
 end
 
 @[nolint ge_or_gt] -- see Note [nolint_ge]
-lemma exists_lt_of_tendsto_at_bot [semilattice_sup α] [preorder β] [no_bot_order β]
+lemma exists_lt_of_tendsto_at_bot [semilattice_sup α] [preorder β] [no_min_order β]
   {u : α → β} (h : tendsto u at_top at_bot) : ∀ a b, ∃ a' ≥ a, u a' < b :=
 @exists_lt_of_tendsto_at_top _ (order_dual β) _ _ _ _ h
 
@@ -308,7 +308,7 @@ lemma exists_lt_of_tendsto_at_bot [semilattice_sup α] [preorder β] [no_bot_ord
 If `u` is a sequence which is unbounded above,
 then after any point, it reaches a value strictly greater than all previous values.
 -/
-lemma high_scores [linear_order β] [no_top_order β] {u : ℕ → β}
+lemma high_scores [linear_order β] [no_max_order β] {u : ℕ → β}
   (hu : tendsto u at_top at_top) : ∀ N, ∃ n ≥ N, ∀ k < n, u k < u n :=
 begin
   intros N,
@@ -336,7 +336,7 @@ If `u` is a sequence which is unbounded below,
 then after any point, it reaches a value strictly smaller than all previous values.
 -/
 @[nolint ge_or_gt] -- see Note [nolint_ge]
-lemma low_scores [linear_order β] [no_bot_order β] {u : ℕ → β}
+lemma low_scores [linear_order β] [no_min_order β] {u : ℕ → β}
   (hu : tendsto u at_top at_bot) : ∀ N, ∃ n ≥ N, ∀ k < n, u n < u k :=
 @high_scores (order_dual β) _ _ _ hu
 
@@ -344,7 +344,7 @@ lemma low_scores [linear_order β] [no_bot_order β] {u : ℕ → β}
 If `u` is a sequence which is unbounded above,
 then it `frequently` reaches a value strictly greater than all previous values.
 -/
-lemma frequently_high_scores [linear_order β] [no_top_order β] {u : ℕ → β}
+lemma frequently_high_scores [linear_order β] [no_max_order β] {u : ℕ → β}
   (hu : tendsto u at_top at_top) : ∃ᶠ n in at_top, ∀ k < n, u k < u n :=
 by simpa [frequently_at_top] using high_scores hu
 
@@ -352,12 +352,12 @@ by simpa [frequently_at_top] using high_scores hu
 If `u` is a sequence which is unbounded below,
 then it `frequently` reaches a value strictly smaller than all previous values.
 -/
-lemma frequently_low_scores [linear_order β] [no_bot_order β] {u : ℕ → β}
+lemma frequently_low_scores [linear_order β] [no_min_order β] {u : ℕ → β}
   (hu : tendsto u at_top at_bot) : ∃ᶠ n in at_top, ∀ k < n, u n < u k :=
 @frequently_high_scores (order_dual β) _ _ _ hu
 
 lemma strict_mono_subseq_of_tendsto_at_top
-  {β : Type*} [linear_order β] [no_top_order β]
+  {β : Type*} [linear_order β] [no_max_order β]
   {u : ℕ → β} (hu : tendsto u at_top at_top) :
   ∃ φ : ℕ → ℕ, strict_mono φ ∧ strict_mono (u ∘ φ) :=
 let ⟨φ, h, h'⟩ := extraction_of_frequently_at_top (frequently_high_scores hu) in
@@ -1041,10 +1041,10 @@ end
 map_coe_at_top_of_Ici_subset (subset.refl _)
 
 /-- The image of the filter `at_top` on `Ioi a` under the coercion equals `at_top`. -/
-@[simp] lemma map_coe_Ioi_at_top [semilattice_sup α] [no_top_order α] (a : α) :
+@[simp] lemma map_coe_Ioi_at_top [semilattice_sup α] [no_max_order α] (a : α) :
   map (coe : Ioi a → α) at_top = at_top :=
 begin
-  rcases no_top a with ⟨b, hb⟩,
+  rcases no_max a with ⟨b, hb⟩,
   exact map_coe_at_top_of_Ici_subset (Ici_subset_Ioi.2 hb)
 end
 
@@ -1066,7 +1066,7 @@ by rw [← map_coe_Ici_at_top a, comap_map subtype.coe_injective]
 
 /-- The `at_bot` filter for an open interval `Iio a` comes from the `at_bot` filter in the ambient
 order. -/
-@[simp] lemma map_coe_Iio_at_bot [semilattice_inf α] [no_bot_order α] (a : α) :
+@[simp] lemma map_coe_Iio_at_bot [semilattice_inf α] [no_min_order α] (a : α) :
   map (coe : Iio a → α) at_bot = at_bot :=
 @map_coe_Ioi_at_top (order_dual α) _ _ _
 
@@ -1106,7 +1106,7 @@ lemma tendsto_Iic_at_bot [semilattice_inf α] {a : α} {f : β → Iic a} {l : f
   tendsto f l at_bot ↔ tendsto (λ x, (f x : α)) l at_bot :=
 by rw [at_bot_Iic_eq, tendsto_comap_iff]
 
-@[simp] lemma tendsto_comp_coe_Ioi_at_top [semilattice_sup α] [no_top_order α] {a : α}
+@[simp] lemma tendsto_comp_coe_Ioi_at_top [semilattice_sup α] [no_max_order α] {a : α}
   {f : α → β} {l : filter β} :
   tendsto (λ x : Ioi a, f x) at_top l ↔ tendsto f at_top l :=
 by rw [← map_coe_Ioi_at_top a, tendsto_map'_iff]
@@ -1116,7 +1116,7 @@ by rw [← map_coe_Ioi_at_top a, tendsto_map'_iff]
   tendsto (λ x : Ici a, f x) at_top l ↔ tendsto f at_top l :=
 by rw [← map_coe_Ici_at_top a, tendsto_map'_iff]
 
-@[simp] lemma tendsto_comp_coe_Iio_at_bot [semilattice_inf α] [no_bot_order α] {a : α}
+@[simp] lemma tendsto_comp_coe_Iio_at_bot [semilattice_inf α] [no_min_order α] {a : α}
   {f : α → β} {l : filter β} :
   tendsto (λ x : Iio a, f x) at_bot l ↔ tendsto f at_bot l :=
 by rw [← map_coe_Iio_at_bot a, tendsto_map'_iff]
@@ -1185,7 +1185,7 @@ lemma tendsto_at_bot_at_bot_of_monotone' [preorder ι] [linear_order α]
   tendsto u at_bot at_bot :=
 @tendsto_at_top_at_top_of_monotone' (order_dual ι) (order_dual α) _ _ _ h.dual H
 
-lemma unbounded_of_tendsto_at_top [nonempty α] [semilattice_sup α] [preorder β] [no_top_order β]
+lemma unbounded_of_tendsto_at_top [nonempty α] [semilattice_sup α] [preorder β] [no_max_order β]
   {f : α → β} (h : tendsto f at_top at_top) :
   ¬ bdd_above (range f) :=
 begin
@@ -1197,17 +1197,17 @@ begin
   ... ≤ M : hM (set.mem_range_self a)
 end
 
-lemma unbounded_of_tendsto_at_bot [nonempty α] [semilattice_sup α] [preorder β] [no_bot_order β]
+lemma unbounded_of_tendsto_at_bot [nonempty α] [semilattice_sup α] [preorder β] [no_min_order β]
   {f : α → β} (h : tendsto f at_top at_bot) :
   ¬ bdd_below (range f) :=
 @unbounded_of_tendsto_at_top _ (order_dual β) _ _ _ _ _ h
 
-lemma unbounded_of_tendsto_at_top' [nonempty α] [semilattice_inf α] [preorder β] [no_top_order β]
+lemma unbounded_of_tendsto_at_top' [nonempty α] [semilattice_inf α] [preorder β] [no_max_order β]
   {f : α → β} (h : tendsto f at_bot at_top) :
   ¬ bdd_above (range f) :=
 @unbounded_of_tendsto_at_top (order_dual α) _ _ _ _ _ _ h
 
-lemma unbounded_of_tendsto_at_bot' [nonempty α] [semilattice_inf α] [preorder β] [no_bot_order β]
+lemma unbounded_of_tendsto_at_bot' [nonempty α] [semilattice_inf α] [preorder β] [no_min_order β]
   {f : α → β} (h : tendsto f at_bot at_bot) :
   ¬ bdd_below (range f) :=
 @unbounded_of_tendsto_at_top (order_dual α) (order_dual β) _ _ _ _ _ h

--- a/src/order/lattice_intervals.lean
+++ b/src/order/lattice_intervals.lean
@@ -100,7 +100,7 @@ instance [preorder α] [order_bot α] : order_bot (Iic a) :=
 @[simp] lemma coe_bot [preorder α] [order_bot α] {a : α} : ↑(⊥ : Iic a) = (⊥ : α) := rfl
 
 instance [partial_order α] [no_min_order α] {a : α} : no_min_order (Iic a) :=
-⟨λ x, let ⟨y, hy⟩ := no_min x.1 in ⟨⟨y, le_trans hy.le x.2⟩, hy⟩ ⟩
+⟨λ x, let ⟨y, hy⟩ := exists_lt x.1 in ⟨⟨y, le_trans hy.le x.2⟩, hy⟩ ⟩
 
 instance [preorder α] [bounded_order α] : bounded_order (Iic a) :=
 { .. Iic.order_top,
@@ -135,7 +135,7 @@ instance [preorder α] [order_top α] : order_top (Ici a) :=
 @[simp] lemma coe_top [preorder α] [order_top α] {a : α} : ↑(⊤ : Ici a) = (⊤ : α) := rfl
 
 instance [partial_order α] [no_max_order α] {a : α} : no_max_order (Ici a) :=
-⟨λ x, let ⟨y, hy⟩ := no_max x.1 in ⟨⟨y, le_trans x.2 hy.le⟩, hy⟩ ⟩
+⟨λ x, let ⟨y, hy⟩ := exists_gt x.1 in ⟨⟨y, le_trans x.2 hy.le⟩, hy⟩ ⟩
 
 instance [preorder α] [bounded_order α] : bounded_order (Ici a) :=
 { .. Ici.order_top,

--- a/src/order/lattice_intervals.lean
+++ b/src/order/lattice_intervals.lean
@@ -99,8 +99,8 @@ instance [preorder α] [order_bot α] : order_bot (Iic a) :=
 
 @[simp] lemma coe_bot [preorder α] [order_bot α] {a : α} : ↑(⊥ : Iic a) = (⊥ : α) := rfl
 
-instance [partial_order α] [no_bot_order α] {a : α} : no_bot_order (Iic a) :=
-⟨λ x, let ⟨y, hy⟩ := no_bot x.1 in ⟨⟨y, le_trans hy.le x.2⟩, hy⟩ ⟩
+instance [partial_order α] [no_min_order α] {a : α} : no_min_order (Iic a) :=
+⟨λ x, let ⟨y, hy⟩ := no_min x.1 in ⟨⟨y, le_trans hy.le x.2⟩, hy⟩ ⟩
 
 instance [preorder α] [bounded_order α] : bounded_order (Iic a) :=
 { .. Iic.order_top,
@@ -134,8 +134,8 @@ instance [preorder α] [order_top α] : order_top (Ici a) :=
 
 @[simp] lemma coe_top [preorder α] [order_top α] {a : α} : ↑(⊤ : Ici a) = (⊤ : α) := rfl
 
-instance [partial_order α] [no_top_order α] {a : α} : no_top_order (Ici a) :=
-⟨λ x, let ⟨y, hy⟩ := no_top x.1 in ⟨⟨y, le_trans x.2 hy.le⟩, hy⟩ ⟩
+instance [partial_order α] [no_max_order α] {a : α} : no_max_order (Ici a) :=
+⟨λ x, let ⟨y, hy⟩ := no_max x.1 in ⟨⟨y, le_trans x.2 hy.le⟩, hy⟩ ⟩
 
 instance [preorder α] [bounded_order α] : bounded_order (Ici a) :=
 { .. Ici.order_top,

--- a/src/order/liminf_limsup.lean
+++ b/src/order/liminf_limsup.lean
@@ -95,7 +95,7 @@ lemma not_is_bounded_under_of_tendsto_at_top [preorder β] [no_max_order β] {f 
 begin
   rintro ⟨b, hb⟩,
   rw eventually_map at hb,
-  obtain ⟨b', h⟩ := no_max b,
+  obtain ⟨b', h⟩ := exists_gt b,
   have hb' := (tendsto_at_top.mp hf) b',
   have : {x : α | f x ≤ b} ∩ {x : α | b' ≤ f x} = ∅ :=
     eq_empty_of_subset_empty (λ x hx, (not_le_of_lt h) (le_trans hx.2 hx.1)),

--- a/src/order/liminf_limsup.lean
+++ b/src/order/liminf_limsup.lean
@@ -89,20 +89,20 @@ lemma is_bounded.is_bounded_under {q : β → β → Prop} {u : α → β}
   (hf : ∀a₀ a₁, r a₀ a₁ → q (u a₀) (u a₁)) : f.is_bounded r → f.is_bounded_under q u
 | ⟨b, h⟩ := ⟨u b, show ∀ᶠ x in f, q (u x) (u b), from h.mono (λ x, hf x b)⟩
 
-lemma not_is_bounded_under_of_tendsto_at_top [preorder β] [no_top_order β] {f : α → β}
+lemma not_is_bounded_under_of_tendsto_at_top [preorder β] [no_max_order β] {f : α → β}
   {l : filter α} [l.ne_bot] (hf : tendsto f l at_top) :
   ¬ is_bounded_under (≤) l f :=
 begin
   rintro ⟨b, hb⟩,
   rw eventually_map at hb,
-  obtain ⟨b', h⟩ := no_top b,
+  obtain ⟨b', h⟩ := no_max b,
   have hb' := (tendsto_at_top.mp hf) b',
   have : {x : α | f x ≤ b} ∩ {x : α | b' ≤ f x} = ∅ :=
     eq_empty_of_subset_empty (λ x hx, (not_le_of_lt h) (le_trans hx.2 hx.1)),
   exact (nonempty_of_mem (hb.and hb')).ne_empty this
 end
 
-lemma not_is_bounded_under_of_tendsto_at_bot [preorder β] [no_bot_order β] {f : α → β}
+lemma not_is_bounded_under_of_tendsto_at_bot [preorder β] [no_min_order β] {f : α → β}
   {l : filter α} [l.ne_bot](hf : tendsto f l at_bot) :
   ¬ is_bounded_under (≥) l f :=
 @not_is_bounded_under_of_tendsto_at_top α (order_dual β) _ _ _ _ _ hf

--- a/src/order/locally_finite.lean
+++ b/src/order/locally_finite.lean
@@ -70,9 +70,9 @@ Provide the `locally_finite_order` instance for `α ×ₗ β` where `locally_fin
 Provide the `locally_finite_order` instance for `α →₀ β` where `β` is locally finite. Provide the
 `locally_finite_order` instance for `Π₀ i, β i` where all the `β i` are locally finite.
 
-From `linear_order α`, `no_top_order α`, `locally_finite_order α`, we can also define an
+From `linear_order α`, `no_max_order α`, `locally_finite_order α`, we can also define an
 order isomorphism `α ≃ ℕ` or `α ≃ ℤ`, depending on whether we have `order_bot α` or
-`no_bot_order α` and `nonempty α`. When `order_bot α`, we can match `a : α` to `(Iio a).card`.
+`no_min_order α` and `nonempty α`. When `order_bot α`, we can match `a : α` to `(Iio a).card`.
 
 We can provide `succ_order α` from `linear_order α` and `locally_finite_order α` using
 

--- a/src/order/succ_pred.lean
+++ b/src/order/succ_pred.lean
@@ -41,7 +41,7 @@ The solution taken here is to remove the implications `≤ → <` and instead re
 for all non maximal elements (enforced by the combination of `le_succ` and the contrapositive of
 `maximal_of_succ_le`).
 The stricter condition of every element having a sensible successor can be obtained through the
-combination of `succ_order α` and `no_top_order α`.
+combination of `succ_order α` and `no_max_order α`.
 
 ## TODO
 
@@ -111,11 +111,11 @@ protected lemma _root_.has_lt.lt.covers_succ {a b : α} (h : a < b) : a ⋖ succ
 @[simp] lemma covers_succ_of_nonempty_Ioi {a : α} (h : (set.Ioi a).nonempty) : a ⋖ succ a :=
 has_lt.lt.covers_succ h.some_mem
 
-section no_top_order
-variables [no_top_order α] {a b : α}
+section no_max_order
+variables [no_max_order α] {a b : α}
 
 lemma lt_succ (a : α) : a < succ a :=
-(le_succ a).lt_of_not_le (λ h, not_exists.2 (maximal_of_succ_le h) (no_top a))
+(le_succ a).lt_of_not_le $ λ h, not_exists.2 (maximal_of_succ_le h) (no_max a)
 
 lemma lt_succ_iff : a < succ b ↔ a ≤ b :=
 ⟨le_of_lt_succ, λ h, h.trans_lt $ lt_succ b⟩
@@ -137,7 +137,7 @@ lemma succ_strict_mono : strict_mono (succ : α → α) := λ a b, succ_lt_succ
 
 lemma covers_succ (a : α) : a ⋖ succ a := ⟨lt_succ a, λ c hc, (succ_le_of_lt hc).not_lt⟩
 
-end no_top_order
+end no_max_order
 
 end preorder
 
@@ -175,8 +175,8 @@ end
 lemma _root_.covers.succ_eq {a b : α} (h : a ⋖ b) : succ a = b :=
 (succ_le_of_lt h.lt).eq_of_not_lt $ λ h', h.2 (lt_succ_of_not_maximal h.lt) h'
 
-section no_top_order
-variables [no_top_order α] {a b : α}
+section no_max_order
+variables [no_max_order α] {a b : α}
 
 lemma succ_injective : injective (succ : α → α) :=
 begin
@@ -202,7 +202,7 @@ by rw [←lt_succ_iff, ←lt_succ_iff, lt_succ_iff_lt_or_eq]
 lemma _root_.covers_iff_succ_eq : a ⋖ b ↔ succ a = b :=
 ⟨covers.succ_eq, by { rintro rfl, exact covers_succ _ }⟩
 
-end no_top_order
+end no_max_order
 
 end partial_order
 
@@ -323,11 +323,11 @@ protected lemma _root_.has_lt.lt.pred_covers {a b : α} (h : b < a) : pred a ⋖
 @[simp] lemma pred_covers_of_nonempty_Iio {a : α} (h : (set.Iio a).nonempty) : pred a ⋖ a :=
 has_lt.lt.pred_covers h.some_mem
 
-section no_bot_order
-variables [no_bot_order α] {a b : α}
+section no_min_order
+variables [no_min_order α] {a b : α}
 
 lemma pred_lt (a : α) : pred a < a :=
-(pred_le a).lt_of_not_le (λ h, not_exists.2 (minimal_of_le_pred h) (no_bot a))
+(pred_le a).lt_of_not_le $ λ h, not_exists.2 (minimal_of_le_pred h) (no_min a)
 
 lemma pred_lt_iff : pred a < b ↔ a ≤ b :=
 ⟨le_of_pred_lt, (pred_lt a).trans_le⟩
@@ -349,7 +349,7 @@ lemma pred_strict_mono : strict_mono (pred : α → α) := λ a b, pred_lt_pred
 
 lemma pred_covers (a : α) : pred a ⋖ a := ⟨pred_lt a, λ c hc, (le_of_pred_lt hc).not_lt⟩
 
-end no_bot_order
+end no_min_order
 
 end preorder
 
@@ -387,8 +387,8 @@ end
 lemma _root_.covers.pred_eq {a b : α} (h : a ⋖ b) : pred b = a :=
 (le_pred_of_lt h.lt).eq_of_not_gt $ λ h', h.2 h' $ pred_lt_of_not_minimal h.lt
 
-section no_bot_order
-variables [no_bot_order α] {a b : α}
+section no_min_order
+variables [no_min_order α] {a b : α}
 
 lemma pred_injective : injective (pred : α → α) :=
 begin
@@ -412,7 +412,7 @@ by rw [←pred_lt_iff, ←pred_lt_iff, pred_lt_iff_lt_or_eq]
 lemma _root_.covers_iff_pred_eq : a ⋖ b ↔ pred b = a :=
 ⟨covers.pred_eq, by { rintro rfl, exact pred_covers _ }⟩
 
-end no_bot_order
+end no_min_order
 
 end partial_order
 
@@ -495,8 +495,8 @@ has_lt.lt.succ_pred h.some_mem
 @[simp] lemma pred_succ_of_nonempty_Ioi {a : α} (h : (set.Ioi a).nonempty) : pred (succ a) = a :=
 has_lt.lt.pred_succ h.some_mem
 
-@[simp] lemma succ_pred [no_bot_order α] (a : α) : succ (pred a) = a := (pred_covers _).succ_eq
-@[simp] lemma pred_succ [no_top_order α] (a : α) : pred (succ a) = a := (covers_succ _).pred_eq
+@[simp] lemma succ_pred [no_min_order α] (a : α) : succ (pred a) = a := (pred_covers _).succ_eq
+@[simp] lemma pred_succ [no_max_order α] (a : α) : pred (succ a) = a := (covers_succ _).pred_eq
 
 end succ_pred_order
 
@@ -527,9 +527,9 @@ Adding a greatest/least element to a `succ_order` or to a `pred_order`.
 As far as successors and predecessors are concerned, there are four ways to add a bottom or top
 element to an order:
 * Adding a `⊤` to an `order_top`: Preserves `succ` and `pred`.
-* Adding a `⊤` to a `no_top_order`: Preserves `succ`. Never preserves `pred`.
+* Adding a `⊤` to a `no_max_order`: Preserves `succ`. Never preserves `pred`.
 * Adding a `⊥` to an `order_bot`: Preserves `succ` and `pred`.
-* Adding a `⊥` to a `no_bot_order`: Preserves `pred`. Never preserves `succ`.
+* Adding a `⊥` to a `no_min_order`: Preserves `pred`. Never preserves `succ`.
 where "preserves `(succ/pred)`" means
 `(succ/pred)_order α → (succ/pred)_order ((with_top/with_bot) α)`.
 -/
@@ -618,9 +618,9 @@ instance [partial_order α] [order_top α] [pred_order α] : pred_order (with_to
     { exact some_le_some.2 (le_of_pred_lt $ some_lt_some.1 h) }
   end }
 
-/-! #### Adding a `⊤` to a `no_top_order` -/
+/-! #### Adding a `⊤` to a `no_max_order` -/
 
-instance of_no_top [partial_order α] [no_top_order α] [succ_order α] :
+instance with_top.succ_order_of_no_max_order [partial_order α] [no_max_order α] [succ_order α] :
   succ_order (with_top α) :=
 { succ := λ a, match a with
     | ⊤        := ⊤
@@ -634,7 +634,7 @@ instance of_no_top [partial_order α] [no_top_order α] [succ_order α] :
   maximal_of_succ_le := λ a ha b h, begin
     cases a,
     { exact not_top_lt h },
-    { exact not_exists.2 (maximal_of_succ_le (some_le_some.1 ha)) (no_top a) }
+    { exact not_exists.2 (maximal_of_succ_le (some_le_some.1 ha)) (no_max a) }
   end,
   succ_le_of_lt := λ a b h, begin
     cases a,
@@ -651,14 +651,14 @@ instance of_no_top [partial_order α] [no_top_order α] [succ_order α] :
     { exact some_le_some.2 (le_of_lt_succ $ some_lt_some.1 h) }
   end }
 
-instance [partial_order α] [no_top_order α] [hα : nonempty α] :
+instance [partial_order α] [no_max_order α] [hα : nonempty α] :
   is_empty (pred_order (with_top α)) :=
 ⟨begin
   introI,
   set b := pred (⊤ : with_top α) with h,
   cases pred (⊤ : with_top α) with a ha; change b with pred ⊤ at h,
   { exact hα.elim (λ a, minimal_of_le_pred h.ge (coe_lt_top a)) },
-  { obtain ⟨c, hc⟩ := no_top a,
+  { obtain ⟨c, hc⟩ := no_max a,
     rw [←some_lt_some, ←h] at hc,
     exact (le_of_pred_lt hc).not_lt (some_lt_none _) }
 end⟩
@@ -749,21 +749,21 @@ instance [decidable_eq α] [partial_order α] [order_bot α] [pred_order α] :
     { exact le_of_pred_lt (some_lt_some.1 h) }
   end }
 
-/-! #### Adding a `⊥` to a `no_bot_order` -/
+/-! #### Adding a `⊥` to a `no_min_order` -/
 
-instance [partial_order α] [no_bot_order α] [hα : nonempty α] :
+instance [partial_order α] [no_min_order α] [hα : nonempty α] :
   is_empty (succ_order (with_bot α)) :=
 ⟨begin
   introI,
   set b : with_bot α := succ ⊥ with h,
   cases succ (⊥ : with_bot α) with a ha; change b with succ ⊥ at h,
   { exact hα.elim (λ a, maximal_of_succ_le h.le (bot_lt_coe a)) },
-  { obtain ⟨c, hc⟩ := no_bot a,
+  { obtain ⟨c, hc⟩ := no_min a,
     rw [←some_lt_some, ←h] at hc,
     exact (le_of_lt_succ hc).not_lt (none_lt_some _) }
 end⟩
 
-instance of_no_bot [partial_order α] [no_bot_order α] [pred_order α] :
+instance with_bot.pred_order_of_no_min_order [partial_order α] [no_min_order α] [pred_order α] :
   pred_order (with_bot α) :=
 { pred := λ a, match a with
     | ⊥        := ⊥
@@ -777,7 +777,7 @@ instance of_no_bot [partial_order α] [no_bot_order α] [pred_order α] :
   minimal_of_le_pred := λ a ha b h, begin
     cases a,
     { exact not_lt_bot h },
-    { exact not_exists.2 (minimal_of_le_pred (some_le_some.1 ha)) (no_bot a) }
+    { exact not_exists.2 (minimal_of_le_pred (some_le_some.1 ha)) (no_min a) }
   end,
   le_pred_of_lt := λ a b h, begin
     cases b,

--- a/src/order/succ_pred.lean
+++ b/src/order/succ_pred.lean
@@ -115,7 +115,7 @@ section no_max_order
 variables [no_max_order α] {a b : α}
 
 lemma lt_succ (a : α) : a < succ a :=
-(le_succ a).lt_of_not_le $ λ h, not_exists.2 (maximal_of_succ_le h) (no_max a)
+(le_succ a).lt_of_not_le $ λ h, not_exists.2 (maximal_of_succ_le h) (exists_gt a)
 
 lemma lt_succ_iff : a < succ b ↔ a ≤ b :=
 ⟨le_of_lt_succ, λ h, h.trans_lt $ lt_succ b⟩
@@ -327,7 +327,7 @@ section no_min_order
 variables [no_min_order α] {a b : α}
 
 lemma pred_lt (a : α) : pred a < a :=
-(pred_le a).lt_of_not_le $ λ h, not_exists.2 (minimal_of_le_pred h) (no_min a)
+(pred_le a).lt_of_not_le $ λ h, not_exists.2 (minimal_of_le_pred h) (exists_lt a)
 
 lemma pred_lt_iff : pred a < b ↔ a ≤ b :=
 ⟨le_of_pred_lt, (pred_lt a).trans_le⟩
@@ -634,7 +634,7 @@ instance with_top.succ_order_of_no_max_order [partial_order α] [no_max_order α
   maximal_of_succ_le := λ a ha b h, begin
     cases a,
     { exact not_top_lt h },
-    { exact not_exists.2 (maximal_of_succ_le (some_le_some.1 ha)) (no_max a) }
+    { exact not_exists.2 (maximal_of_succ_le (some_le_some.1 ha)) (exists_gt a) }
   end,
   succ_le_of_lt := λ a b h, begin
     cases a,
@@ -658,7 +658,7 @@ instance [partial_order α] [no_max_order α] [hα : nonempty α] :
   set b := pred (⊤ : with_top α) with h,
   cases pred (⊤ : with_top α) with a ha; change b with pred ⊤ at h,
   { exact hα.elim (λ a, minimal_of_le_pred h.ge (coe_lt_top a)) },
-  { obtain ⟨c, hc⟩ := no_max a,
+  { obtain ⟨c, hc⟩ := exists_gt a,
     rw [←some_lt_some, ←h] at hc,
     exact (le_of_pred_lt hc).not_lt (some_lt_none _) }
 end⟩
@@ -758,7 +758,7 @@ instance [partial_order α] [no_min_order α] [hα : nonempty α] :
   set b : with_bot α := succ ⊥ with h,
   cases succ (⊥ : with_bot α) with a ha; change b with succ ⊥ at h,
   { exact hα.elim (λ a, maximal_of_succ_le h.le (bot_lt_coe a)) },
-  { obtain ⟨c, hc⟩ := no_min a,
+  { obtain ⟨c, hc⟩ := exists_lt a,
     rw [←some_lt_some, ←h] at hc,
     exact (le_of_lt_succ hc).not_lt (none_lt_some _) }
 end⟩
@@ -777,7 +777,7 @@ instance with_bot.pred_order_of_no_min_order [partial_order α] [no_min_order α
   minimal_of_le_pred := λ a ha b h, begin
     cases a,
     { exact not_lt_bot h },
-    { exact not_exists.2 (minimal_of_le_pred (some_le_some.1 ha)) (no_min a) }
+    { exact not_exists.2 (minimal_of_le_pred (some_le_some.1 ha)) (exists_lt a) }
   end,
   le_pred_of_lt := λ a b h, begin
     cases b,

--- a/src/set_theory/cardinal.lean
+++ b/src/set_theory/cardinal.lean
@@ -472,8 +472,8 @@ begin
   exact cantor_injective f hf
 end
 
-instance : no_top_order cardinal.{u} :=
-{ no_top := λ a, ⟨_, cantor a⟩, ..cardinal.partial_order }
+instance : no_max_order cardinal.{u} :=
+{ no_max := λ a, ⟨_, cantor a⟩, ..cardinal.partial_order }
 
 noncomputable instance : linear_order cardinal.{u} :=
 { le_total    := by rintros ⟨α⟩ ⟨β⟩; exact embedding.total,

--- a/src/set_theory/cardinal.lean
+++ b/src/set_theory/cardinal.lean
@@ -473,7 +473,7 @@ begin
 end
 
 instance : no_max_order cardinal.{u} :=
-{ no_max := λ a, ⟨_, cantor a⟩, ..cardinal.partial_order }
+{ exists_gt := λ a, ⟨_, cantor a⟩, ..cardinal.partial_order }
 
 noncomputable instance : linear_order cardinal.{u} :=
 { le_total    := by rintros ⟨α⟩ ⟨β⟩; exact embedding.total,

--- a/src/set_theory/ordinal.lean
+++ b/src/set_theory/ordinal.lean
@@ -1141,7 +1141,7 @@ lemma Inf_mem {s : set ordinal} (hs : s.nonempty) :
   Inf s ∈ s :=
 by { rw Inf_eq_omin hs, exact omin_mem _ hs }
 
-instance : no_top_order ordinal :=
+instance : no_max_order ordinal :=
 ⟨λ a, ⟨a.succ, lt_succ_self a⟩⟩
 
 end ordinal

--- a/src/topology/algebra/ordered/basic.lean
+++ b/src/topology/algebra/ordered/basic.lean
@@ -562,16 +562,16 @@ lemma filter.tendsto.min {b : filter β} {a₁ a₂ : α} (hf : tendsto f b (�
   tendsto (λb, min (f b) (g b)) b (𝓝 (min a₁ a₂)) :=
 (continuous_min.tendsto (a₁, a₂)).comp (hf.prod_mk_nhds hg)
 
-lemma dense.exists_lt [no_bot_order α] {s : set α} (hs : dense s) (x : α) : ∃ y ∈ s, y < x :=
-hs.exists_mem_open is_open_Iio (no_bot x)
+lemma dense.exists_lt [no_min_order α] {s : set α} (hs : dense s) (x : α) : ∃ y ∈ s, y < x :=
+hs.exists_mem_open is_open_Iio (no_min x)
 
-lemma dense.exists_gt [no_top_order α] {s : set α} (hs : dense s) (x : α) : ∃ y ∈ s, x < y :=
+lemma dense.exists_gt [no_max_order α] {s : set α} (hs : dense s) (x : α) : ∃ y ∈ s, x < y :=
 hs.order_dual.exists_lt x
 
-lemma dense.exists_le [no_bot_order α] {s : set α} (hs : dense s) (x : α) : ∃ y ∈ s, y ≤ x :=
+lemma dense.exists_le [no_min_order α] {s : set α} (hs : dense s) (x : α) : ∃ y ∈ s, y ≤ x :=
 (hs.exists_lt x).imp $ λ y hy, ⟨hy.fst, hy.snd.le⟩
 
-lemma dense.exists_ge [no_top_order α] {s : set α} (hs : dense s) (x : α) : ∃ y ∈ s, x ≤ y :=
+lemma dense.exists_ge [no_max_order α] {s : set α} (hs : dense s) (x : α) : ∃ y ∈ s, x ≤ y :=
 hs.order_dual.exists_le x
 
 lemma dense.exists_le' {s : set α} (hs : dense s) (hbot : ∀ x, is_bot x → x ∈ s) (x : α) :
@@ -1047,19 +1047,19 @@ end
 
 /-- A set is a neighborhood of `a` if and only if it contains an interval `(l, u)` containing `a`.
 -/
-lemma mem_nhds_iff_exists_Ioo_subset [no_top_order α] [no_bot_order α] {a : α} {s : set α} :
+lemma mem_nhds_iff_exists_Ioo_subset [no_max_order α] [no_min_order α] {a : α} {s : set α} :
   s ∈ 𝓝 a ↔ ∃l u, a ∈ Ioo l u ∧ Ioo l u ⊆ s :=
-mem_nhds_iff_exists_Ioo_subset' (no_bot a) (no_top a)
+mem_nhds_iff_exists_Ioo_subset' (no_min a) (no_max a)
 
 lemma nhds_basis_Ioo' {a : α} (hl : ∃ l, l < a) (hu : ∃ u, a < u) :
   (𝓝 a).has_basis (λ b : α × α, b.1 < a ∧ a < b.2) (λ b, Ioo b.1 b.2) :=
 ⟨λ s, (mem_nhds_iff_exists_Ioo_subset' hl hu).trans $ by simp⟩
 
-lemma nhds_basis_Ioo [no_top_order α] [no_bot_order α] (a : α) :
+lemma nhds_basis_Ioo [no_max_order α] [no_min_order α] (a : α) :
   (𝓝 a).has_basis (λ b : α × α, b.1 < a ∧ a < b.2) (λ b, Ioo b.1 b.2) :=
-nhds_basis_Ioo' (no_bot a) (no_top a)
+nhds_basis_Ioo' (no_min a) (no_max a)
 
-lemma filter.eventually.exists_Ioo_subset [no_top_order α] [no_bot_order α] {a : α} {p : α → Prop}
+lemma filter.eventually.exists_Ioo_subset [no_max_order α] [no_min_order α] {a : α} {p : α → Prop}
   (hp : ∀ᶠ x in 𝓝 a, p x) :
   ∃ l u, a ∈ Ioo l u ∧ Ioo l u ⊆ {x | p x} :=
 mem_nhds_iff_exists_Ioo_subset.1 hp
@@ -1145,43 +1145,43 @@ pi_Ioo_mem_nhds ha hb
 
 end pi
 
-lemma disjoint_nhds_at_top [no_top_order α] (x : α) :
+lemma disjoint_nhds_at_top [no_max_order α] (x : α) :
   disjoint (𝓝 x) at_top :=
 begin
   rw filter.disjoint_iff,
-  cases no_top x with a ha,
+  cases no_max x with a ha,
   use [Iio a, Iio_mem_nhds ha, Ici a, mem_at_top a],
   rw [inter_comm, Ici_inter_Iio, Ico_self]
 end
 
-@[simp] lemma inf_nhds_at_top [no_top_order α] (x : α) :
+@[simp] lemma inf_nhds_at_top [no_max_order α] (x : α) :
   𝓝 x ⊓ at_top = ⊥ :=
 disjoint_iff.1 (disjoint_nhds_at_top x)
 
-lemma disjoint_nhds_at_bot [no_bot_order α] (x : α) :
+lemma disjoint_nhds_at_bot [no_min_order α] (x : α) :
   disjoint (𝓝 x) at_bot :=
 @disjoint_nhds_at_top (order_dual α) _ _ _ _ x
 
-@[simp] lemma inf_nhds_at_bot [no_bot_order α] (x : α) :
+@[simp] lemma inf_nhds_at_bot [no_min_order α] (x : α) :
   𝓝 x ⊓ at_bot = ⊥ :=
 @inf_nhds_at_top (order_dual α) _ _ _ _ x
 
-lemma not_tendsto_nhds_of_tendsto_at_top [no_top_order α]
+lemma not_tendsto_nhds_of_tendsto_at_top [no_max_order α]
   {F : filter β} [ne_bot F] {f : β → α} (hf : tendsto f F at_top) (x : α) :
   ¬ tendsto f F (𝓝 x) :=
 hf.not_tendsto (disjoint_nhds_at_top x).symm
 
-lemma not_tendsto_at_top_of_tendsto_nhds [no_top_order α]
+lemma not_tendsto_at_top_of_tendsto_nhds [no_max_order α]
   {F : filter β} [ne_bot F] {f : β → α} {x : α} (hf : tendsto f F (𝓝 x)) :
   ¬  tendsto f F at_top :=
 hf.not_tendsto (disjoint_nhds_at_top x)
 
-lemma not_tendsto_nhds_of_tendsto_at_bot [no_bot_order α]
+lemma not_tendsto_nhds_of_tendsto_at_bot [no_min_order α]
   {F : filter β} [ne_bot F] {f : β → α} (hf : tendsto f F at_bot) (x : α) :
   ¬ tendsto f F (𝓝 x) :=
 hf.not_tendsto (disjoint_nhds_at_bot x).symm
 
-lemma not_tendsto_at_bot_of_tendsto_nhds [no_bot_order α]
+lemma not_tendsto_at_bot_of_tendsto_nhds [no_min_order α]
   {F : filter β} [ne_bot F] {f : β → α} {x : α} (hf : tendsto f F (𝓝 x)) :
   ¬  tendsto f F at_bot :=
 hf.not_tendsto (disjoint_nhds_at_bot x)
@@ -1236,13 +1236,13 @@ lemma mem_nhds_within_Ioi_iff_exists_Ioo_subset' {a u' : α} {s : set α} (hu' :
 
 /-- A set is a neighborhood of `a` within `(a, +∞)` if and only if it contains an interval `(a, u)`
 with `a < u`. -/
-lemma mem_nhds_within_Ioi_iff_exists_Ioo_subset [no_top_order α] {a : α} {s : set α} :
+lemma mem_nhds_within_Ioi_iff_exists_Ioo_subset [no_max_order α] {a : α} {s : set α} :
   s ∈ 𝓝[>] a ↔ ∃u ∈ Ioi a, Ioo a u ⊆ s :=
-let ⟨u', hu'⟩ := no_top a in mem_nhds_within_Ioi_iff_exists_Ioo_subset' hu'
+let ⟨u', hu'⟩ := no_max a in mem_nhds_within_Ioi_iff_exists_Ioo_subset' hu'
 
 /-- A set is a neighborhood of `a` within `(a, +∞)` if and only if it contains an interval `(a, u]`
 with `a < u`. -/
-lemma mem_nhds_within_Ioi_iff_exists_Ioc_subset [no_top_order α] [densely_ordered α]
+lemma mem_nhds_within_Ioi_iff_exists_Ioc_subset [no_max_order α] [densely_ordered α]
   {a : α} {s : set α} : s ∈ 𝓝[>] a ↔ ∃u ∈ Ioi a, Ioc a u ⊆ s :=
 begin
   rw mem_nhds_within_Ioi_iff_exists_Ioo_subset,
@@ -1282,13 +1282,13 @@ lemma mem_nhds_within_Iio_iff_exists_Ioo_subset' {a l' : α} {s : set α} (hl' :
 
 /-- A set is a neighborhood of `a` within `(-∞, a)` if and only if it contains an interval `(l, a)`
 with `l < a`. -/
-lemma mem_nhds_within_Iio_iff_exists_Ioo_subset [no_bot_order α] {a : α} {s : set α} :
+lemma mem_nhds_within_Iio_iff_exists_Ioo_subset [no_min_order α] {a : α} {s : set α} :
   s ∈ 𝓝[<] a ↔ ∃l ∈ Iio a, Ioo l a ⊆ s :=
-let ⟨l', hl'⟩ := no_bot a in mem_nhds_within_Iio_iff_exists_Ioo_subset' hl'
+let ⟨l', hl'⟩ := no_min a in mem_nhds_within_Iio_iff_exists_Ioo_subset' hl'
 
 /-- A set is a neighborhood of `a` within `(-∞, a)` if and only if it contains an interval `[l, a)`
 with `l < a`. -/
-lemma mem_nhds_within_Iio_iff_exists_Ico_subset [no_bot_order α] [densely_ordered α]
+lemma mem_nhds_within_Iio_iff_exists_Ico_subset [no_min_order α] [densely_ordered α]
   {a : α} {s : set α} : s ∈ 𝓝[<] a ↔ ∃l ∈ Iio a, Ico l a ⊆ s :=
 begin
   have : of_dual ⁻¹' s ∈ 𝓝[>] (to_dual a) ↔ _ :=
@@ -1338,13 +1338,13 @@ lemma mem_nhds_within_Ici_iff_exists_Ico_subset' {a u' : α} {s : set α} (hu' :
 
 /-- A set is a neighborhood of `a` within `[a, +∞)` if and only if it contains an interval `[a, u)`
 with `a < u`. -/
-lemma mem_nhds_within_Ici_iff_exists_Ico_subset [no_top_order α] {a : α} {s : set α} :
+lemma mem_nhds_within_Ici_iff_exists_Ico_subset [no_max_order α] {a : α} {s : set α} :
   s ∈ 𝓝[≥] a ↔ ∃u ∈ Ioi a, Ico a u ⊆ s :=
-let ⟨u', hu'⟩ := no_top a in mem_nhds_within_Ici_iff_exists_Ico_subset' hu'
+let ⟨u', hu'⟩ := no_max a in mem_nhds_within_Ici_iff_exists_Ico_subset' hu'
 
 /-- A set is a neighborhood of `a` within `[a, +∞)` if and only if it contains an interval `[a, u]`
 with `a < u`. -/
-lemma mem_nhds_within_Ici_iff_exists_Icc_subset' [no_top_order α] [densely_ordered α]
+lemma mem_nhds_within_Ici_iff_exists_Icc_subset' [no_max_order α] [densely_ordered α]
   {a : α} {s : set α} : s ∈ 𝓝[≥] a ↔ ∃u ∈ Ioi a, Icc a u ⊆ s :=
 begin
   rw mem_nhds_within_Ici_iff_exists_Ico_subset,
@@ -1384,13 +1384,13 @@ lemma mem_nhds_within_Iic_iff_exists_Ioc_subset' {a l' : α} {s : set α} (hl' :
 
 /-- A set is a neighborhood of `a` within `(-∞, a]` if and only if it contains an interval `(l, a]`
 with `l < a`. -/
-lemma mem_nhds_within_Iic_iff_exists_Ioc_subset [no_bot_order α] {a : α} {s : set α} :
+lemma mem_nhds_within_Iic_iff_exists_Ioc_subset [no_min_order α] {a : α} {s : set α} :
   s ∈ 𝓝[≤] a ↔ ∃l ∈ Iio a, Ioc l a ⊆ s :=
-let ⟨l', hl'⟩ := no_bot a in mem_nhds_within_Iic_iff_exists_Ioc_subset' hl'
+let ⟨l', hl'⟩ := no_min a in mem_nhds_within_Iic_iff_exists_Ioc_subset' hl'
 
 /-- A set is a neighborhood of `a` within `(-∞, a]` if and only if it contains an interval `[l, a]`
 with `l < a`. -/
-lemma mem_nhds_within_Iic_iff_exists_Icc_subset' [no_bot_order α] [densely_ordered α]
+lemma mem_nhds_within_Iic_iff_exists_Icc_subset' [no_min_order α] [densely_ordered α]
   {a : α} {s : set α} : s ∈ 𝓝[≤] a ↔ ∃l ∈ Iio a, Icc l a ⊆ s :=
 begin
   convert @mem_nhds_within_Ici_iff_exists_Icc_subset' (order_dual α) _ _ _ _ _ _ _,
@@ -1400,7 +1400,7 @@ end
 
 /-- A set is a neighborhood of `a` within `[a, +∞)` if and only if it contains an interval `[a, u]`
 with `a < u`. -/
-lemma mem_nhds_within_Ici_iff_exists_Icc_subset [no_top_order α] [densely_ordered α]
+lemma mem_nhds_within_Ici_iff_exists_Icc_subset [no_max_order α] [densely_ordered α]
   {a : α} {s : set α} : s ∈ 𝓝[≥] a ↔ ∃u, a < u ∧ Icc a u ⊆ s :=
 begin
   rw mem_nhds_within_Ici_iff_exists_Ico_subset,
@@ -1414,7 +1414,7 @@ end
 
 /-- A set is a neighborhood of `a` within `(-∞, a]` if and only if it contains an interval `[l, a]`
 with `l < a`. -/
-lemma mem_nhds_within_Iic_iff_exists_Icc_subset [no_bot_order α] [densely_ordered α]
+lemma mem_nhds_within_Iic_iff_exists_Icc_subset [no_min_order α] [densely_ordered α]
   {a : α} {s : set α} : s ∈ 𝓝[≤] a ↔ ∃l, l < a ∧ Icc l a ⊆ s :=
 begin
   rw mem_nhds_within_Iic_iff_exists_Ioc_subset,
@@ -1509,7 +1509,7 @@ begin
     (λ x, neg_abs_le_self $ f x) (λ x, le_abs_self $ f x),
 end
 
-lemma nhds_basis_Ioo_pos [no_bot_order α] [no_top_order α] (a : α) :
+lemma nhds_basis_Ioo_pos [no_min_order α] [no_max_order α] (a : α) :
   (𝓝 a).has_basis (λ ε : α, (0 : α) < ε) (λ ε, Ioo (a-ε) (a+ε)) :=
 ⟨begin
   refine λ t, (nhds_basis_Ioo a).mem_iff.trans ⟨_, _⟩,
@@ -1524,7 +1524,7 @@ lemma nhds_basis_Ioo_pos [no_bot_order α] [no_top_order α] (a : α) :
     exact ⟨(a-ε, a+ε), by simp [ε_pos], h⟩ },
 end⟩
 
-lemma nhds_basis_abs_sub_lt [no_bot_order α] [no_top_order α] (a : α) :
+lemma nhds_basis_abs_sub_lt [no_min_order α] [no_max_order α] (a : α) :
   (𝓝 a).has_basis (λ ε : α, (0 : α) < ε) (λ ε, {b | |b - a| < ε}) :=
 begin
   convert nhds_basis_Ioo_pos a,
@@ -1535,14 +1535,14 @@ end
 
 variable (α)
 
-lemma nhds_basis_zero_abs_sub_lt [no_bot_order α] [no_top_order α] :
+lemma nhds_basis_zero_abs_sub_lt [no_min_order α] [no_max_order α] :
   (𝓝 (0 : α)).has_basis (λ ε : α, (0 : α) < ε) (λ ε, {b | |b| < ε}) :=
 by simpa using nhds_basis_abs_sub_lt (0 : α)
 
 variable {α}
 
 /-- If `a` is positive we can form a basis from only nonnegative `Ioo` intervals -/
-lemma nhds_basis_Ioo_pos_of_pos [no_bot_order α] [no_top_order α]
+lemma nhds_basis_Ioo_pos_of_pos [no_min_order α] [no_max_order α]
   {a : α} (ha : 0 < a) :
   (𝓝 a).has_basis (λ ε : α, (0 : α) < ε ∧ ε ≤ a) (λ ε, Ioo (a-ε) (a+ε)) :=
 ⟨ λ t, (nhds_basis_Ioo_pos a).mem_iff.trans
@@ -1576,7 +1576,7 @@ lemma filter.tendsto.add_at_top {C : α} (hf : tendsto f l (𝓝 C)) (hg : tends
   tendsto (λ x, f x + g x) l at_top :=
 begin
   nontriviality α,
-  obtain ⟨C', hC'⟩ : ∃ C', C' < C := no_bot C,
+  obtain ⟨C', hC'⟩ : ∃ C', C' < C := no_min C,
   refine tendsto_at_top_add_left_of_le' _ C' _ hg,
   exact (hf.eventually (lt_mem_nhds hC')).mono (λ x, le_of_lt)
 end
@@ -2093,11 +2093,11 @@ begin
   exact ⟨u, hu.1, hu.2.2.symm⟩
 end
 
-lemma exists_seq_strict_mono_tendsto [densely_ordered α] [no_bot_order α]
+lemma exists_seq_strict_mono_tendsto [densely_ordered α] [no_min_order α]
   [first_countable_topology α] (x : α) :
   ∃ u : ℕ → α, strict_mono u ∧ (∀ n, u n < x) ∧ tendsto u at_top (𝓝 x) :=
 begin
-  obtain ⟨y, hy⟩ : ∃ y, y < x := no_bot x,
+  obtain ⟨y, hy⟩ : ∃ y, y < x := no_min x,
   rcases exists_seq_strict_mono_tendsto' hy with ⟨u, hu_mono, hu_mem, hux⟩,
   exact ⟨u, hu_mono, λ n, (hu_mem n).2, hux⟩
 end
@@ -2128,7 +2128,7 @@ lemma exists_seq_strict_anti_tendsto' [densely_ordered α]
   ∃ u : ℕ → α, strict_anti u ∧ (∀ n, u n ∈ Ioo x y) ∧ tendsto u at_top (𝓝 x) :=
 by simpa only [dual_Ioo] using exists_seq_strict_mono_tendsto' (order_dual.to_dual_lt_to_dual.2 hy)
 
-lemma exists_seq_strict_anti_tendsto [densely_ordered α] [no_top_order α]
+lemma exists_seq_strict_anti_tendsto [densely_ordered α] [no_max_order α]
   [first_countable_topology α] (x : α) :
   ∃ u : ℕ → α, strict_anti u ∧ (∀ n, x < u n) ∧ tendsto u at_top (𝓝 x) :=
 @exists_seq_strict_mono_tendsto (order_dual α) _ _ _ _ _ _ x
@@ -2188,7 +2188,7 @@ begin
 end
 
 /-- The closure of the interval `(a, +∞)` is the closed interval `[a, +∞)`. -/
-@[simp] lemma closure_Ioi (a : α) [no_top_order α] :
+@[simp] lemma closure_Ioi (a : α) [no_max_order α] :
   closure (Ioi a) = Ici a :=
 closure_Ioi' nonempty_Ioi
 
@@ -2199,7 +2199,7 @@ lemma closure_Iio' {a : α} (h : (Iio a).nonempty) :
 @closure_Ioi' (order_dual α) _ _ _ _ _ h
 
 /-- The closure of the interval `(-∞, a)` is the interval `(-∞, a]`. -/
-@[simp] lemma closure_Iio (a : α) [no_bot_order α] :
+@[simp] lemma closure_Iio (a : α) [no_min_order α] :
   closure (Iio a) = Iic a :=
 closure_Iio' nonempty_Iio
 
@@ -2238,67 +2238,67 @@ end
 @[simp] lemma interior_Ici' {a : α} (ha : (Iio a).nonempty) : interior (Ici a) = Ioi a :=
 by rw [← compl_Iio, interior_compl, closure_Iio' ha, compl_Iic]
 
-lemma interior_Ici [no_bot_order α] {a : α} : interior (Ici a) = Ioi a :=
+lemma interior_Ici [no_min_order α] {a : α} : interior (Ici a) = Ioi a :=
 interior_Ici' nonempty_Iio
 
 @[simp] lemma interior_Iic' {a : α} (ha : (Ioi a).nonempty) : interior (Iic a) = Iio a :=
 @interior_Ici' (order_dual α) _ _ _ _ _ ha
 
-lemma interior_Iic [no_top_order α] {a : α} : interior (Iic a) = Iio a :=
+lemma interior_Iic [no_max_order α] {a : α} : interior (Iic a) = Iio a :=
 interior_Iic' nonempty_Ioi
 
-@[simp] lemma interior_Icc [no_bot_order α] [no_top_order α] {a b : α}:
+@[simp] lemma interior_Icc [no_min_order α] [no_max_order α] {a b : α}:
   interior (Icc a b) = Ioo a b :=
 by rw [← Ici_inter_Iic, interior_inter, interior_Ici, interior_Iic, Ioi_inter_Iio]
 
-@[simp] lemma interior_Ico [no_bot_order α] {a b : α} : interior (Ico a b) = Ioo a b :=
+@[simp] lemma interior_Ico [no_min_order α] {a b : α} : interior (Ico a b) = Ioo a b :=
 by rw [← Ici_inter_Iio, interior_inter, interior_Ici, interior_Iio, Ioi_inter_Iio]
 
-@[simp] lemma interior_Ioc [no_top_order α] {a b : α} : interior (Ioc a b) = Ioo a b :=
+@[simp] lemma interior_Ioc [no_max_order α] {a b : α} : interior (Ioc a b) = Ioo a b :=
 by rw [← Ioi_inter_Iic, interior_inter, interior_Ioi, interior_Iic, Ioi_inter_Iio]
 
 @[simp] lemma frontier_Ici' {a : α} (ha : (Iio a).nonempty) : frontier (Ici a) = {a} :=
 by simp [frontier, ha]
 
-lemma frontier_Ici [no_bot_order α] {a : α} : frontier (Ici a) = {a} :=
+lemma frontier_Ici [no_min_order α] {a : α} : frontier (Ici a) = {a} :=
 frontier_Ici' nonempty_Iio
 
 @[simp] lemma frontier_Iic' {a : α} (ha : (Ioi a).nonempty) : frontier (Iic a) = {a} :=
 by simp [frontier, ha]
 
-lemma frontier_Iic [no_top_order α] {a : α} : frontier (Iic a) = {a} :=
+lemma frontier_Iic [no_max_order α] {a : α} : frontier (Iic a) = {a} :=
 frontier_Iic' nonempty_Ioi
 
 @[simp] lemma frontier_Ioi' {a : α} (ha : (Ioi a).nonempty) : frontier (Ioi a) = {a} :=
 by simp [frontier, closure_Ioi' ha, Iic_diff_Iio, Icc_self]
 
-lemma frontier_Ioi [no_top_order α] {a : α} : frontier (Ioi a) = {a} :=
+lemma frontier_Ioi [no_max_order α] {a : α} : frontier (Ioi a) = {a} :=
 frontier_Ioi' nonempty_Ioi
 
 @[simp] lemma frontier_Iio' {a : α} (ha : (Iio a).nonempty) : frontier (Iio a) = {a} :=
 by simp [frontier, closure_Iio' ha, Iic_diff_Iio, Icc_self]
 
-lemma frontier_Iio [no_bot_order α] {a : α} : frontier (Iio a) = {a} :=
+lemma frontier_Iio [no_min_order α] {a : α} : frontier (Iio a) = {a} :=
 frontier_Iio' nonempty_Iio
 
-@[simp] lemma frontier_Icc [no_bot_order α] [no_top_order α] {a b : α} (h : a < b) :
+@[simp] lemma frontier_Icc [no_min_order α] [no_max_order α] {a b : α} (h : a < b) :
   frontier (Icc a b) = {a, b} :=
 by simp [frontier, le_of_lt h, Icc_diff_Ioo_same]
 
 @[simp] lemma frontier_Ioo {a b : α} (h : a < b) : frontier (Ioo a b) = {a, b} :=
 by simp [frontier, h, le_of_lt h, Icc_diff_Ioo_same]
 
-@[simp] lemma frontier_Ico [no_bot_order α] {a b : α} (h : a < b) : frontier (Ico a b) = {a, b} :=
+@[simp] lemma frontier_Ico [no_min_order α] {a b : α} (h : a < b) : frontier (Ico a b) = {a, b} :=
 by simp [frontier, h, le_of_lt h, Icc_diff_Ioo_same]
 
-@[simp] lemma frontier_Ioc [no_top_order α] {a b : α} (h : a < b) : frontier (Ioc a b) = {a, b} :=
+@[simp] lemma frontier_Ioc [no_max_order α] {a b : α} (h : a < b) : frontier (Ioc a b) = {a, b} :=
 by simp [frontier, h, le_of_lt h, Icc_diff_Ioo_same]
 
 lemma nhds_within_Ioi_ne_bot' {a b : α} (H₁ : (Ioi a).nonempty) (H₂ : a ≤ b) :
   ne_bot (𝓝[Ioi a] b) :=
 mem_closure_iff_nhds_within_ne_bot.1 $ by rwa [closure_Ioi' H₁]
 
-lemma nhds_within_Ioi_ne_bot [no_top_order α] {a b : α} (H : a ≤ b) :
+lemma nhds_within_Ioi_ne_bot [no_max_order α] {a b : α} (H : a ≤ b) :
   ne_bot (𝓝[Ioi a] b) :=
 nhds_within_Ioi_ne_bot' nonempty_Ioi H
 
@@ -2307,11 +2307,11 @@ lemma nhds_within_Ioi_self_ne_bot' {a : α} (H : (Ioi a).nonempty) :
 nhds_within_Ioi_ne_bot' H (le_refl a)
 
 @[instance]
-lemma nhds_within_Ioi_self_ne_bot [no_top_order α] (a : α) :
+lemma nhds_within_Ioi_self_ne_bot [no_max_order α] (a : α) :
   ne_bot (𝓝[>] a) :=
 nhds_within_Ioi_ne_bot (le_refl a)
 
-lemma filter.eventually.exists_gt [no_top_order α] {a : α} {p : α → Prop} (h : ∀ᶠ x in 𝓝 a, p x) :
+lemma filter.eventually.exists_gt [no_max_order α] {a : α} {p : α → Prop} (h : ∀ᶠ x in 𝓝 a, p x) :
   ∃ b > a, p b :=
 by simpa only [exists_prop, gt_iff_lt, and_comm]
   using ((h.filter_mono (@nhds_within_le_nhds _ _ a (Ioi a))).and self_mem_nhds_within).exists
@@ -2320,7 +2320,7 @@ lemma nhds_within_Iio_ne_bot' {b c : α} (H₁ : (Iio c).nonempty) (H₂ : b ≤
   ne_bot (𝓝[Iio c] b) :=
 mem_closure_iff_nhds_within_ne_bot.1 $ by rwa closure_Iio' H₁
 
-lemma nhds_within_Iio_ne_bot [no_bot_order α] {a b : α} (H : a ≤ b) :
+lemma nhds_within_Iio_ne_bot [no_min_order α] {a b : α} (H : a ≤ b) :
   ne_bot (𝓝[Iio b] a) :=
 nhds_within_Iio_ne_bot' nonempty_Iio H
 
@@ -2329,11 +2329,11 @@ lemma nhds_within_Iio_self_ne_bot' {b : α} (H : (Iio b).nonempty) :
 nhds_within_Iio_ne_bot' H (le_refl b)
 
 @[instance]
-lemma nhds_within_Iio_self_ne_bot [no_bot_order α] (a : α) :
+lemma nhds_within_Iio_self_ne_bot [no_min_order α] (a : α) :
   ne_bot (𝓝[<] a) :=
 nhds_within_Iio_ne_bot (le_refl a)
 
-lemma filter.eventually.exists_lt [no_bot_order α] {a : α} {p : α → Prop} (h : ∀ᶠ x in 𝓝 a, p x) :
+lemma filter.eventually.exists_lt [no_min_order α] {a : α} {p : α → Prop} (h : ∀ᶠ x in 𝓝 a, p x) :
   ∃ b < a, p b :=
 @filter.eventually.exists_gt (order_dual α) _ _ _ _ _ _ _ h
 

--- a/src/topology/algebra/ordered/basic.lean
+++ b/src/topology/algebra/ordered/basic.lean
@@ -563,7 +563,7 @@ lemma filter.tendsto.min {b : filter β} {a₁ a₂ : α} (hf : tendsto f b (�
 (continuous_min.tendsto (a₁, a₂)).comp (hf.prod_mk_nhds hg)
 
 lemma dense.exists_lt [no_min_order α] {s : set α} (hs : dense s) (x : α) : ∃ y ∈ s, y < x :=
-hs.exists_mem_open is_open_Iio (no_min x)
+hs.exists_mem_open is_open_Iio (exists_lt x)
 
 lemma dense.exists_gt [no_max_order α] {s : set α} (hs : dense s) (x : α) : ∃ y ∈ s, x < y :=
 hs.order_dual.exists_lt x
@@ -1049,7 +1049,7 @@ end
 -/
 lemma mem_nhds_iff_exists_Ioo_subset [no_max_order α] [no_min_order α] {a : α} {s : set α} :
   s ∈ 𝓝 a ↔ ∃l u, a ∈ Ioo l u ∧ Ioo l u ⊆ s :=
-mem_nhds_iff_exists_Ioo_subset' (no_min a) (no_max a)
+mem_nhds_iff_exists_Ioo_subset' (exists_lt a) (exists_gt a)
 
 lemma nhds_basis_Ioo' {a : α} (hl : ∃ l, l < a) (hu : ∃ u, a < u) :
   (𝓝 a).has_basis (λ b : α × α, b.1 < a ∧ a < b.2) (λ b, Ioo b.1 b.2) :=
@@ -1057,7 +1057,7 @@ lemma nhds_basis_Ioo' {a : α} (hl : ∃ l, l < a) (hu : ∃ u, a < u) :
 
 lemma nhds_basis_Ioo [no_max_order α] [no_min_order α] (a : α) :
   (𝓝 a).has_basis (λ b : α × α, b.1 < a ∧ a < b.2) (λ b, Ioo b.1 b.2) :=
-nhds_basis_Ioo' (no_min a) (no_max a)
+nhds_basis_Ioo' (exists_lt a) (exists_gt a)
 
 lemma filter.eventually.exists_Ioo_subset [no_max_order α] [no_min_order α] {a : α} {p : α → Prop}
   (hp : ∀ᶠ x in 𝓝 a, p x) :
@@ -1149,7 +1149,7 @@ lemma disjoint_nhds_at_top [no_max_order α] (x : α) :
   disjoint (𝓝 x) at_top :=
 begin
   rw filter.disjoint_iff,
-  cases no_max x with a ha,
+  cases exists_gt x with a ha,
   use [Iio a, Iio_mem_nhds ha, Ici a, mem_at_top a],
   rw [inter_comm, Ici_inter_Iio, Ico_self]
 end
@@ -1238,7 +1238,7 @@ lemma mem_nhds_within_Ioi_iff_exists_Ioo_subset' {a u' : α} {s : set α} (hu' :
 with `a < u`. -/
 lemma mem_nhds_within_Ioi_iff_exists_Ioo_subset [no_max_order α] {a : α} {s : set α} :
   s ∈ 𝓝[>] a ↔ ∃u ∈ Ioi a, Ioo a u ⊆ s :=
-let ⟨u', hu'⟩ := no_max a in mem_nhds_within_Ioi_iff_exists_Ioo_subset' hu'
+let ⟨u', hu'⟩ := exists_gt a in mem_nhds_within_Ioi_iff_exists_Ioo_subset' hu'
 
 /-- A set is a neighborhood of `a` within `(a, +∞)` if and only if it contains an interval `(a, u]`
 with `a < u`. -/
@@ -1284,7 +1284,7 @@ lemma mem_nhds_within_Iio_iff_exists_Ioo_subset' {a l' : α} {s : set α} (hl' :
 with `l < a`. -/
 lemma mem_nhds_within_Iio_iff_exists_Ioo_subset [no_min_order α] {a : α} {s : set α} :
   s ∈ 𝓝[<] a ↔ ∃l ∈ Iio a, Ioo l a ⊆ s :=
-let ⟨l', hl'⟩ := no_min a in mem_nhds_within_Iio_iff_exists_Ioo_subset' hl'
+let ⟨l', hl'⟩ := exists_lt a in mem_nhds_within_Iio_iff_exists_Ioo_subset' hl'
 
 /-- A set is a neighborhood of `a` within `(-∞, a)` if and only if it contains an interval `[l, a)`
 with `l < a`. -/
@@ -1340,7 +1340,7 @@ lemma mem_nhds_within_Ici_iff_exists_Ico_subset' {a u' : α} {s : set α} (hu' :
 with `a < u`. -/
 lemma mem_nhds_within_Ici_iff_exists_Ico_subset [no_max_order α] {a : α} {s : set α} :
   s ∈ 𝓝[≥] a ↔ ∃u ∈ Ioi a, Ico a u ⊆ s :=
-let ⟨u', hu'⟩ := no_max a in mem_nhds_within_Ici_iff_exists_Ico_subset' hu'
+let ⟨u', hu'⟩ := exists_gt a in mem_nhds_within_Ici_iff_exists_Ico_subset' hu'
 
 /-- A set is a neighborhood of `a` within `[a, +∞)` if and only if it contains an interval `[a, u]`
 with `a < u`. -/
@@ -1386,7 +1386,7 @@ lemma mem_nhds_within_Iic_iff_exists_Ioc_subset' {a l' : α} {s : set α} (hl' :
 with `l < a`. -/
 lemma mem_nhds_within_Iic_iff_exists_Ioc_subset [no_min_order α] {a : α} {s : set α} :
   s ∈ 𝓝[≤] a ↔ ∃l ∈ Iio a, Ioc l a ⊆ s :=
-let ⟨l', hl'⟩ := no_min a in mem_nhds_within_Iic_iff_exists_Ioc_subset' hl'
+let ⟨l', hl'⟩ := exists_lt a in mem_nhds_within_Iic_iff_exists_Ioc_subset' hl'
 
 /-- A set is a neighborhood of `a` within `(-∞, a]` if and only if it contains an interval `[l, a]`
 with `l < a`. -/
@@ -1576,7 +1576,7 @@ lemma filter.tendsto.add_at_top {C : α} (hf : tendsto f l (𝓝 C)) (hg : tends
   tendsto (λ x, f x + g x) l at_top :=
 begin
   nontriviality α,
-  obtain ⟨C', hC'⟩ : ∃ C', C' < C := no_min C,
+  obtain ⟨C', hC'⟩ : ∃ C', C' < C := exists_lt C,
   refine tendsto_at_top_add_left_of_le' _ C' _ hg,
   exact (hf.eventually (lt_mem_nhds hC')).mono (λ x, le_of_lt)
 end
@@ -2097,7 +2097,7 @@ lemma exists_seq_strict_mono_tendsto [densely_ordered α] [no_min_order α]
   [first_countable_topology α] (x : α) :
   ∃ u : ℕ → α, strict_mono u ∧ (∀ n, u n < x) ∧ tendsto u at_top (𝓝 x) :=
 begin
-  obtain ⟨y, hy⟩ : ∃ y, y < x := no_min x,
+  obtain ⟨y, hy⟩ : ∃ y, y < x := exists_lt x,
   rcases exists_seq_strict_mono_tendsto' hy with ⟨u, hu_mono, hu_mem, hux⟩,
   exact ⟨u, hu_mono, λ n, (hu_mem n).2, hux⟩
 end

--- a/src/topology/algebra/ordered/monotone_convergence.lean
+++ b/src/topology/algebra/ordered/monotone_convergence.lean
@@ -218,7 +218,7 @@ else or.inl $ tendsto_at_top_at_top_of_monotone' h_mono H
 
 lemma tendsto_iff_tendsto_subseq_of_monotone {ι₁ ι₂ α : Type*} [semilattice_sup ι₁] [preorder ι₂]
   [nonempty ι₁] [topological_space α] [conditionally_complete_linear_order α] [order_topology α]
-  [no_top_order α] {f : ι₂ → α} {φ : ι₁ → ι₂} {l : α} (hf : monotone f)
+  [no_max_order α] {f : ι₂ → α} {φ : ι₁ → ι₂} {l : α} (hf : monotone f)
   (hg : tendsto φ at_top at_top) :
   tendsto f at_top (𝓝 l) ↔ tendsto (f ∘ φ) at_top (𝓝 l) :=
 begin

--- a/src/topology/bases.lean
+++ b/src/topology/bases.lean
@@ -394,7 +394,7 @@ in ⟨coe '' t, image_subset_iff.2 $ λ x _, mem_preimage.2 $ subtype.coe_prop _
 separable space (e.g., if `α` has a second countable topology), then there exists a countable
 dense subset `t ⊆ s` such that `t` contains bottom/top element of `α` when they exist and belong
 to `s`. For a dense subset containing neither bot nor top elements, see
-`dense.exists_countable_dense_subset_no_min_max`. -/
+`dense.exists_countable_dense_subset_no_bot_top`. -/
 lemma dense.exists_countable_dense_subset_bot_top {α : Type*} [topological_space α]
   [partial_order α] {s : set α} [separable_space s] (hs : dense s) :
   ∃ t ⊆ s, countable t ∧ dense t ∧ (∀ x, is_bot x → x ∈ s → x ∈ t) ∧

--- a/src/topology/bases.lean
+++ b/src/topology/bases.lean
@@ -394,7 +394,7 @@ in ⟨coe '' t, image_subset_iff.2 $ λ x _, mem_preimage.2 $ subtype.coe_prop _
 separable space (e.g., if `α` has a second countable topology), then there exists a countable
 dense subset `t ⊆ s` such that `t` contains bottom/top element of `α` when they exist and belong
 to `s`. For a dense subset containing neither bot nor top elements, see
-`dense.exists_countable_dense_subset_no_bot_top`. -/
+`dense.exists_countable_dense_subset_no_min_max`. -/
 lemma dense.exists_countable_dense_subset_bot_top {α : Type*} [topological_space α]
   [partial_order α] {s : set α} [separable_space s] (hs : dense s) :
   ∃ t ⊆ s, countable t ∧ dense t ∧ (∀ x, is_bot x → x ∈ s → x ∈ t) ∧

--- a/src/topology/instances/irrational.lean
+++ b/src/topology/instances/irrational.lean
@@ -19,7 +19,7 @@ In this file we prove the following theorems:
   `irrational.eventually_forall_le_dist_cast_rat_of_denom_le`: a sufficiently small neighborhood of
   an irrational number is disjoint with the set of rational numbers with bounded denominator.
 
-We also provide `order_topology`, `no_bot_order`, `no_top_order`, and `densely_ordered`
+We also provide `order_topology`, `no_min_order`, `no_max_order`, and `densely_ordered`
 instances for `{x // irrational x}`.
 
 ## Tags
@@ -52,10 +52,10 @@ instance : order_topology {x // irrational x} :=
 induced_order_topology _ (λ x y, iff.rfl) $ λ x y hlt,
   let ⟨a, ha, hxa, hay⟩ := exists_irrational_btwn hlt in ⟨⟨a, ha⟩, hxa, hay⟩
 
-instance : no_top_order {x // irrational x} :=
+instance : no_max_order {x // irrational x} :=
 ⟨λ ⟨x, hx⟩, ⟨⟨x + (1 : ℕ), hx.add_nat 1⟩, by simp⟩⟩
 
-instance : no_bot_order {x // irrational x} :=
+instance : no_min_order {x // irrational x} :=
 ⟨λ ⟨x, hx⟩, ⟨⟨x - (1 : ℕ), hx.sub_nat 1⟩, by simp⟩⟩
 
 instance : densely_ordered {x // irrational x} :=

--- a/src/topology/instances/real.lean
+++ b/src/topology/instances/real.lean
@@ -207,7 +207,7 @@ show continuous ((has_inv.inv ∘ @subtype.val ℝ (λr, r ≠ 0)) ∘ λa, ⟨f
 
 lemma real.uniform_continuous_mul_const {x : ℝ} : uniform_continuous ((*) x) :=
 metric.uniform_continuous_iff.2 $ λ ε ε0, begin
-  cases no_max (|x|) with y xy,
+  cases exists_gt (|x|) with y xy,
   have y0 := lt_of_le_of_lt (abs_nonneg _) xy,
   refine ⟨_, div_pos ε0 y0, λ a b h, _⟩,
   rw [real.dist_eq, ← mul_sub, abs_mul, ← mul_div_cancel' ε (ne_of_gt y0)],

--- a/src/topology/instances/real.lean
+++ b/src/topology/instances/real.lean
@@ -207,7 +207,7 @@ show continuous ((has_inv.inv ∘ @subtype.val ℝ (λr, r ≠ 0)) ∘ λa, ⟨f
 
 lemma real.uniform_continuous_mul_const {x : ℝ} : uniform_continuous ((*) x) :=
 metric.uniform_continuous_iff.2 $ λ ε ε0, begin
-  cases no_top (|x|) with y xy,
+  cases no_max (|x|) with y xy,
   have y0 := lt_of_le_of_lt (abs_nonneg _) xy,
   refine ⟨_, div_pos ε0 y0, λ a b h, _⟩,
   rw [real.dist_eq, ← mul_sub, abs_mul, ← mul_div_cancel' ε (ne_of_gt y0)],

--- a/src/topology/metric_space/basic.lean
+++ b/src/topology/metric_space/basic.lean
@@ -814,7 +814,7 @@ theorem tendsto_at_top [nonempty β] [semilattice_sup β] {u : β → α} {a : �
 A variant of `tendsto_at_top` that
 uses `∃ N, ∀ n > N, ...` rather than `∃ N, ∀ n ≥ N, ...`
 -/
-theorem tendsto_at_top' [nonempty β] [semilattice_sup β] [no_top_order β] {u : β → α} {a : α} :
+theorem tendsto_at_top' [nonempty β] [semilattice_sup β] [no_max_order β] {u : β → α} {a : α} :
   tendsto u at_top (𝓝 a) ↔ ∀ε>0, ∃N, ∀n>N, dist (u n) a < ε :=
 (at_top_basis_Ioi.tendsto_iff nhds_basis_ball).trans $
   by { simp only [exists_prop, true_and], refl }
@@ -1652,7 +1652,7 @@ lemma exists_lt_subset_ball (hs : is_closed s) (h : s ⊆ ball x r) :
 begin
   cases le_or_lt r 0 with hr hr,
   { rw [ball_eq_empty.2 hr, subset_empty_iff] at h, unfreezingI { subst s },
-    exact (no_bot r).imp (λ r' hr', ⟨hr', empty_subset _⟩) },
+    exact (no_min r).imp (λ r' hr', ⟨hr', empty_subset _⟩) },
   { exact (exists_pos_lt_subset_ball hr hs h).imp (λ r' hr', ⟨hr'.fst.2, hr'.snd⟩) }
 end
 

--- a/src/topology/metric_space/basic.lean
+++ b/src/topology/metric_space/basic.lean
@@ -1652,7 +1652,7 @@ lemma exists_lt_subset_ball (hs : is_closed s) (h : s ⊆ ball x r) :
 begin
   cases le_or_lt r 0 with hr hr,
   { rw [ball_eq_empty.2 hr, subset_empty_iff] at h, unfreezingI { subst s },
-    exact (no_min r).imp (λ r' hr', ⟨hr', empty_subset _⟩) },
+    exact (exists_lt r).imp (λ r' hr', ⟨hr', empty_subset _⟩) },
   { exact (exists_pos_lt_subset_ball hr hs h).imp (λ r' hr', ⟨hr'.fst.2, hr'.snd⟩) }
 end
 


### PR DESCRIPTION
because that's really what they are.

`∀ a, ∃ b, b < a` precisely means that every `a` is not a minimal element. The correct statement for an order without bottom elements is `∀ a, ∃ b, ¬ a ≤ b`, which is a weaker condition in general. Both conditions are equivalent over a linear order.

Renames
* `no_bot_order` -> `no_min_order`
* `no_top_order` -> `no_max_order`
* `no_bot` -> `exists_lt`
* `no_top` -> `exists_gt`

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
This change matches #11268 and the incoming PR introducing `is_min`/`is_max`.

Due to the naming confusion, I suspect `no_min_order` (formerly `no_bot_order` ) might have been misused and could be weakened to `no_bot_order` (which does not exist yet).

Somehow requested by @RemyDegenne

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
