### PR TITLE
[Merged by Bors] - feat(ring_theory/discriminant): remove an assumption

### DIFF
--- a/src/ring_theory/discriminant.lean
+++ b/src/ring_theory/discriminant.lean
@@ -108,15 +108,18 @@ variables [module.finite K L] [is_separable K L] [is_alg_closed E]
 variables (b : ι → L) (pb : power_basis K L)
 
 /-- Over a field, if `b` is linear independent, then `algebra.discr K b ≠ 0`. -/
-lemma discr_not_zero_of_linear_independent [nonempty ι]
+lemma discr_not_zero_of_linear_independent
   (hcard : fintype.card ι = finrank K L) (hli : linear_independent K b) : discr K b ≠ 0 :=
 begin
-  classical,
-  have := span_eq_top_of_linear_independent_of_card_eq_finrank hli hcard,
-  rw [discr_def, trace_matrix_def],
-  simp_rw [← basis.mk_apply hli this],
-  rw [← trace_matrix_def, trace_matrix_of_basis, ← bilin_form.nondegenerate_iff_det_ne_zero],
-  exact trace_form_nondegenerate _ _
+  by_cases h : nonempty ι,
+  { classical,
+    have := span_eq_top_of_linear_independent_of_card_eq_finrank hli hcard,
+    rw [discr_def, trace_matrix_def],
+    simp_rw [← basis.mk_apply hli this],
+    rw [← trace_matrix_def, trace_matrix_of_basis, ← bilin_form.nondegenerate_iff_det_ne_zero],
+    exact trace_form_nondegenerate _ _  },
+  letI := not_nonempty_iff.1 h,
+  simp [discr],
 end
 
 /-- If `L/K` is a field extension and `b : ι → L`, then `discr K b` is the square of the


### PR DESCRIPTION
We remove a `nonempty` assumption.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
