### PR TITLE
[Merged by Bors] - refactor(analysis/complex/circle): The circle group is commutative

### DIFF
--- a/src/analysis/complex/circle.lean
+++ b/src/analysis/complex/circle.lean
@@ -59,11 +59,11 @@ by rw [mem_circle_iff_abs, complex.abs, real.sqrt_eq_one]
 
 lemma nonzero_of_mem_circle (z : circle) : (z:ℂ) ≠ 0 := nonzero_of_mem_unit_sphere z
 
-instance : group circle :=
+instance : comm_group circle :=
 { inv := λ z, ⟨conj (z : ℂ), by simp⟩,
   mul_left_inv := λ z, subtype.ext $ by { simp [has_inv.inv, ← norm_sq_eq_conj_mul_self,
     ← mul_self_abs] },
-  .. circle.to_monoid }
+  .. circle.to_comm_monoid }
 
 lemma coe_inv_circle_eq_conj (z : circle) : ↑(z⁻¹) = (conj : ring_aut ℂ) z := rfl
 


### PR DESCRIPTION
This PR upgrades the `group circle` instance to a `comm_group circle` instance.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
