### PR TITLE
[Merged by Bors] - fix(algebra/tropical/basic): provide explicit min and max

### DIFF
--- a/src/algebra/tropical/basic.lean
+++ b/src/algebra/tropical/basic.lean
@@ -107,6 +107,9 @@ as a term of `tropical R` via `trop x`. -/
 def trop_rec {F : Π (X : tropical R), Sort v} (h : Π X, F (trop X)) : Π X, F X :=
 λ X, h (untrop X)
 
+instance [decidable_eq R] : decidable_eq (tropical R) :=
+λ x y, decidable_of_iff _ injective_untrop.eq_iff
+
 section order
 
 instance [has_le R] : has_le (tropical R) :=
@@ -115,11 +118,19 @@ instance [has_le R] : has_le (tropical R) :=
 @[simp] lemma untrop_le_iff [has_le R] {x y : tropical R} :
   untrop x ≤ untrop y ↔ x ≤ y := iff.rfl
 
+instance decidable_le [has_le R] [decidable_rel ((≤) : R → R → Prop)] :
+  decidable_rel ((≤) : tropical R → tropical R → Prop) :=
+λ x y, ‹decidable_rel (≤)› (untrop x) (untrop y)
+
 instance [has_lt R] : has_lt (tropical R) :=
 { lt := λ x y, untrop x < untrop y }
 
 @[simp] lemma untrop_lt_iff [has_lt R] {x y : tropical R} :
   untrop x < untrop y ↔ x < y := iff.rfl
+
+instance decidable_lt [has_lt R] [decidable_rel ((<) : R → R → Prop)] :
+  decidable_rel ((<) : tropical R → tropical R → Prop) :=
+λ x y, ‹decidable_rel (<)› (untrop x) (untrop y)
 
 instance [preorder R] : preorder (tropical R) :=
 { le_refl := λ _, le_refl _,
@@ -164,24 +175,45 @@ instance [has_le R] [order_top R] : order_top (tropical R) :=
 variable [linear_order R]
 
 /-- Tropical addition is the minimum of two underlying elements of `R`. -/
-protected def add (x y : tropical R) : tropical R :=
-trop (min (untrop x) (untrop y))
+instance : has_add (tropical R) :=
+⟨λ x y, trop (min (untrop x) (untrop y))⟩
 
 instance : add_comm_semigroup (tropical R) :=
-{ add := tropical.add,
+{ add := (+),
   add_assoc := λ _ _ _, untrop_injective (min_assoc _ _ _),
   add_comm := λ _ _, untrop_injective (min_comm _ _) }
 
 instance : linear_order (tropical R) :=
 { le_total := λ a b, le_total (untrop a) (untrop b),
-  decidable_le := λ x y, if h : (untrop x) ≤ (untrop y) then is_true h else is_false h,
+  decidable_le := tropical.decidable_le,
+  decidable_lt := tropical.decidable_lt,
+  decidable_eq := tropical.decidable_eq,
+  max := λ a b, trop (max (untrop a) (untrop b)),
+  max_def := begin
+    ext x y,
+    rw [max_default, max_def, apply_ite trop, trop_untrop, trop_untrop],
+    refl,
+  end,
+  min := (+),
+  min_def := begin
+    ext x y,
+    dsimp only [has_add.add],
+    rw [min_default, min_def, apply_ite trop, trop_untrop, trop_untrop],
+    refl,
+  end,
   ..tropical.partial_order }
 
 @[simp] lemma untrop_add (x y : tropical R) : untrop (x + y) = min (untrop x) (untrop y) := rfl
+@[simp] lemma untrop_sup (x y : tropical R) : untrop (x ⊔ y) = untrop x ⊔ untrop y := rfl
+@[simp] lemma untrop_max (x y : tropical R) : untrop (max x y) = max (untrop x) (untrop y) := rfl
 @[simp] lemma trop_min (x y : R) : trop (min x y) = trop x + trop y := rfl
 @[simp] lemma trop_inf (x y : R) : trop (x ⊓ y) = trop x + trop y := rfl
+@[simp] lemma min_eq_add : (min : tropical R → tropical R → tropical R) = (+) := rfl
+@[simp] lemma inf_eq_add : ((⊓) : tropical R → tropical R → tropical R) = (+) := rfl
 
 lemma trop_add_def (x y : tropical R) : x + y = trop (min (untrop x) (untrop y)) := rfl
+lemma trop_max_def (x y : tropical R) : max x y = trop (max (untrop x) (untrop y)) := rfl
+lemma trop_sup_def (x y : tropical R) : x ⊔ y = trop (untrop x ⊔ untrop y) := rfl
 
 @[simp] lemma add_eq_left ⦃x y : tropical R⦄ (h : x ≤ y) :
   x + y = x := untrop_injective (by simpa using h)
@@ -226,9 +258,8 @@ end order
 section monoid
 
 /-- Tropical multiplication is the addition in the underlying `R`. -/
-protected def mul [has_add R] (x y : tropical R) : tropical R := trop (untrop x + untrop y)
-
-instance [has_add R] : has_mul (tropical R) := ⟨tropical.mul⟩
+instance [has_add R] : has_mul (tropical R) :=
+⟨λ x y, trop (untrop x + untrop y)⟩
 
 @[simp] lemma trop_add [has_add R] (x y : R) :
   trop (x + y) = trop x * trop y := rfl
@@ -256,7 +287,7 @@ instance [has_sub R] : has_div (tropical R) := ⟨λ x y, trop (untrop x - untro
   untrop (x / y) = untrop x - untrop y := rfl
 
 instance [add_semigroup R] : semigroup (tropical R) :=
-{ mul := tropical.mul,
+{ mul := (*),
   mul_assoc := λ _ _ _, untrop_injective (add_assoc _ _ _) }
 
 instance [add_comm_semigroup R] : comm_semigroup (tropical R) :=
@@ -362,8 +393,8 @@ instance covariant_swap_add_lt [linear_order R] :
 instance [linear_order R] [has_add R]
   [covariant_class R R (+) (≤)] [covariant_class R R (function.swap (+)) (≤)] :
   distrib (tropical R) :=
-{ mul := tropical.mul,
-  add := tropical.add,
+{ mul := (*),
+  add := (+),
   left_distrib := λ _ _ _, untrop_injective (min_add_add_left _ _ _).symm,
   right_distrib := λ _ _ _, untrop_injective (min_add_add_right _ _ _).symm }
 

--- a/src/algebra/tropical/basic.lean
+++ b/src/algebra/tropical/basic.lean
@@ -191,15 +191,15 @@ instance : linear_order (tropical R) :=
   max := λ a b, trop (max (untrop a) (untrop b)),
   max_def := begin
     ext x y,
-    rw [max_default, max_def, apply_ite trop, trop_untrop, trop_untrop],
-    refl,
+    rw [max_default, max_def, apply_ite trop, trop_untrop, trop_untrop,
+      if_congr untrop_le_iff rfl rfl],
   end,
   min := (+),
   min_def := begin
     ext x y,
     dsimp only [has_add.add],
-    rw [min_default, min_def, apply_ite trop, trop_untrop, trop_untrop],
-    refl,
+    rw [min_default, min_def, apply_ite trop, trop_untrop, trop_untrop,
+      if_congr untrop_le_iff rfl rfl],
   end,
   ..tropical.partial_order }
 

--- a/src/algebra/tropical/basic.lean
+++ b/src/algebra/tropical/basic.lean
@@ -183,6 +183,11 @@ instance : add_comm_semigroup (tropical R) :=
   add_assoc := λ _ _ _, untrop_injective (min_assoc _ _ _),
   add_comm := λ _ _, untrop_injective (min_comm _ _) }
 
+@[simp] lemma untrop_add (x y : tropical R) : untrop (x + y) = min (untrop x) (untrop y) := rfl
+@[simp] lemma trop_min (x y : R) : trop (min x y) = trop x + trop y := rfl
+@[simp] lemma trop_inf (x y : R) : trop (x ⊓ y) = trop x + trop y := rfl
+lemma trop_add_def (x y : tropical R) : x + y = trop (min (untrop x) (untrop y)) := rfl
+
 instance : linear_order (tropical R) :=
 { le_total := λ a b, le_total (untrop a) (untrop b),
   decidable_le := tropical.decidable_le,
@@ -197,23 +202,15 @@ instance : linear_order (tropical R) :=
   min := (+),
   min_def := begin
     ext x y,
-    dsimp only [has_add.add],
-    rw [min_default, min_def, apply_ite trop, trop_untrop, trop_untrop,
+    rw [trop_add_def, min_default, min_def, apply_ite trop, trop_untrop, trop_untrop,
       if_congr untrop_le_iff rfl rfl],
   end,
   ..tropical.partial_order }
 
-@[simp] lemma untrop_add (x y : tropical R) : untrop (x + y) = min (untrop x) (untrop y) := rfl
 @[simp] lemma untrop_sup (x y : tropical R) : untrop (x ⊔ y) = untrop x ⊔ untrop y := rfl
 @[simp] lemma untrop_max (x y : tropical R) : untrop (max x y) = max (untrop x) (untrop y) := rfl
-@[simp] lemma trop_min (x y : R) : trop (min x y) = trop x + trop y := rfl
-@[simp] lemma trop_inf (x y : R) : trop (x ⊓ y) = trop x + trop y := rfl
 @[simp] lemma min_eq_add : (min : tropical R → tropical R → tropical R) = (+) := rfl
 @[simp] lemma inf_eq_add : ((⊓) : tropical R → tropical R → tropical R) = (+) := rfl
-
-lemma trop_add_def (x y : tropical R) : x + y = trop (min (untrop x) (untrop y)) := rfl
-lemma trop_max_def (x y : tropical R) : max x y = trop (max (untrop x) (untrop y)) := rfl
-lemma trop_sup_def (x y : tropical R) : x ⊔ y = trop (untrop x ⊔ untrop y) := rfl
 
 @[simp] lemma add_eq_left ⦃x y : tropical R⦄ (h : x ≤ y) :
   x + y = x := untrop_injective (by simpa using h)

--- a/src/algebra/tropical/basic.lean
+++ b/src/algebra/tropical/basic.lean
@@ -186,6 +186,7 @@ instance : add_comm_semigroup (tropical R) :=
 @[simp] lemma untrop_add (x y : tropical R) : untrop (x + y) = min (untrop x) (untrop y) := rfl
 @[simp] lemma trop_min (x y : R) : trop (min x y) = trop x + trop y := rfl
 @[simp] lemma trop_inf (x y : R) : trop (x ⊓ y) = trop x + trop y := rfl
+
 lemma trop_add_def (x y : tropical R) : x + y = trop (min (untrop x) (untrop y)) := rfl
 
 instance : linear_order (tropical R) :=
@@ -211,6 +212,9 @@ instance : linear_order (tropical R) :=
 @[simp] lemma untrop_max (x y : tropical R) : untrop (max x y) = max (untrop x) (untrop y) := rfl
 @[simp] lemma min_eq_add : (min : tropical R → tropical R → tropical R) = (+) := rfl
 @[simp] lemma inf_eq_add : ((⊓) : tropical R → tropical R → tropical R) = (+) := rfl
+
+lemma trop_max_def (x y : tropical R) : max x y = trop (max (untrop x) (untrop y)) := rfl
+lemma trop_sup_def (x y : tropical R) : x ⊔ y = trop (untrop x ⊔ untrop y) := rfl
 
 @[simp] lemma add_eq_left ⦃x y : tropical R⦄ (h : x ≤ y) :
   x + y = x := untrop_injective (by simpa using h)


### PR DESCRIPTION
This also renames `tropical.add` to `tropical.has_add`, since this matches how we normally do this, and it makes unfolding easier.

Without this change, we have a diamond where `linear_order.min` is not defeq to `lattice.inf`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
