### PR TITLE
[Merged by Bors] - feat(topology/algebra/uniform_group): Condition for uniform convergence

### DIFF
--- a/src/topology/algebra/uniform_group.lean
+++ b/src/topology/algebra/uniform_group.lean
@@ -203,7 +203,7 @@ def topological_group.to_uniform_space : uniform_space G :=
 
 variables {G}
 
-@[to_additive] lemma topological_group.tendsto_uniformly_on
+@[to_additive] lemma topological_group.tendsto_uniformly_on_iff
   {ι α : Type*} (F : ι → α → G) (f : α → G) (p : filter ι) (s : set α) :
   @tendsto_uniformly_on α G ι (topological_group.to_uniform_space G) F f p s
     ↔ ∀ u ∈ nhds (1 : G), {i : ι | ∀ a ∈ s, F i a / f a ∈ u} ∈ p :=

--- a/src/topology/algebra/uniform_group.lean
+++ b/src/topology/algebra/uniform_group.lean
@@ -3,10 +3,12 @@ Copyright (c) 2018 Patrick Massot. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Patrick Massot, Johannes Hölzl
 -/
-import topology.uniform_space.uniform_embedding
-import topology.uniform_space.complete_separated
-import topology.algebra.group
+
 import tactic.abel
+import topology.algebra.group
+import topology.uniform_space.complete_separated
+import topology.uniform_space.uniform_convergence
+import topology.uniform_space.uniform_embedding
 
 /-!
 # Uniform structure on topological groups
@@ -198,6 +200,15 @@ def topological_group.to_uniform_space : uniform_space G :=
     { rintros h ⟨x, y⟩ hx rfl, exact h hx },
     { rintros h x hx, exact @h (a, x) hx rfl }
   end }
+
+variables {G}
+
+@[to_additive] lemma topological_group.tends_uniformly_to
+  {ι α : Type*} (F : ι → α → G) (f : α → G) (p : filter ι) (s : set α) :
+  @tendsto_uniformly_on α G ι (topological_group.to_uniform_space G) F f p s
+    ↔ ∀ u ∈ nhds (1 : G), {i : ι | ∀ a ∈ s, F i a / f a ∈ u} ∈ p :=
+⟨λ h u hu, h _ ⟨u, hu, set.subset.rfl⟩, λ h v ⟨u, hu, hv⟩,
+  p.sets_of_superset (h u hu) (λ i hi a ha, hv (by exact hi a ha))⟩
 
 end topological_comm_group
 

--- a/src/topology/algebra/uniform_group.lean
+++ b/src/topology/algebra/uniform_group.lean
@@ -205,16 +205,30 @@ variables {G}
 @[to_additive] lemma topological_group.tendsto_uniformly_iff
   {ι α : Type*} (F : ι → α → G) (f : α → G) (p : filter ι) :
   @tendsto_uniformly α G ι (topological_group.to_uniform_space G) F f p
-    ↔ ∀ u ∈ 𝓝 (1 : G), {i : ι | ∀ a, F i a / f a ∈ u} ∈ p :=
-⟨λ h u hu, h _ ⟨u, hu, set.subset.rfl⟩, λ h v ⟨u, hu, hv⟩,
-  p.sets_of_superset (h u hu) (λ i hi a, hv (by exact hi a))⟩
+    ↔ ∀ u ∈ 𝓝 (1 : G), ∀ᶠ i in p, ∀ a, F i a / f a ∈ u :=
+⟨λ h u hu, h _ ⟨u, hu, λ _, id⟩, λ h v ⟨u, hu, hv⟩,
+  mem_of_superset (h u hu) (λ i hi a, hv (by exact hi a))⟩
 
 @[to_additive] lemma topological_group.tendsto_uniformly_on_iff
   {ι α : Type*} (F : ι → α → G) (f : α → G) (p : filter ι) (s : set α) :
   @tendsto_uniformly_on α G ι (topological_group.to_uniform_space G) F f p s
     ↔ ∀ u ∈ 𝓝 (1 : G), {i : ι | ∀ a ∈ s, F i a / f a ∈ u} ∈ p :=
-⟨λ h u hu, h _ ⟨u, hu, set.subset.rfl⟩, λ h v ⟨u, hu, hv⟩,
-  p.sets_of_superset (h u hu) (λ i hi a ha, hv (by exact hi a ha))⟩
+⟨λ h u hu, h _ ⟨u, hu, λ _, id⟩, λ h v ⟨u, hu, hv⟩,
+  mem_of_superset (h u hu) (λ i hi a ha, hv (by exact hi a ha))⟩
+
+@[to_additive] lemma topological_group.tendsto_locally_uniformly_iff
+  {ι α : Type*} [topological_space α] (F : ι → α → G) (f : α → G) (p : filter ι) :
+  @tendsto_locally_uniformly α G ι (topological_group.to_uniform_space G) _ F f p
+    ↔ ∀ (u ∈ 𝓝 (1 : G)) (x : α), ∃ (t ∈ 𝓝 x), ∀ᶠ i in p, ∀ a ∈ t, F i a / f a ∈ u :=
+⟨λ h u hu, h _ ⟨u, hu, λ _, id⟩, λ h v ⟨u, hu, hv⟩ x, exists_imp_exists (by exact λ a,
+  exists_imp_exists (λ ha hp, mem_of_superset hp (λ i hi a ha, hv (by exact hi a ha)))) (h u hu x)⟩
+
+@[to_additive] lemma topological_group.tendsto_locally_uniformly_on_iff
+  {ι α : Type*} [topological_space α] (F : ι → α → G) (f : α → G) (p : filter ι) (s : set α) :
+  @tendsto_locally_uniformly_on α G ι (topological_group.to_uniform_space G) _ F f p s
+    ↔ ∀ (u ∈ 𝓝 (1 : G)) (x ∈ s), ∃ (t ∈ 𝓝[s] x), ∀ᶠ i in p, ∀ a ∈ t, F i a / f a ∈ u :=
+⟨λ h u hu, h _ ⟨u, hu, λ _, id⟩, λ h v ⟨u, hu, hv⟩ x, exists_imp_exists (by exact λ a,
+  exists_imp_exists (λ ha hp, mem_of_superset hp (λ i hi a ha, hv (by exact hi a ha)))) ∘ h u hu x⟩
 
 end topological_comm_group
 

--- a/src/topology/algebra/uniform_group.lean
+++ b/src/topology/algebra/uniform_group.lean
@@ -3,12 +3,11 @@ Copyright (c) 2018 Patrick Massot. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Patrick Massot, Johannes Hölzl
 -/
-
-import tactic.abel
-import topology.algebra.group
-import topology.uniform_space.complete_separated
 import topology.uniform_space.uniform_convergence
 import topology.uniform_space.uniform_embedding
+import topology.uniform_space.complete_separated
+import topology.algebra.group
+import tactic.abel
 
 /-!
 # Uniform structure on topological groups
@@ -203,10 +202,17 @@ def topological_group.to_uniform_space : uniform_space G :=
 
 variables {G}
 
+@[to_additive] lemma topological_group.tendsto_uniformly_iff
+  {ι α : Type*} (F : ι → α → G) (f : α → G) (p : filter ι) :
+  @tendsto_uniformly α G ι (topological_group.to_uniform_space G) F f p
+    ↔ ∀ u ∈ 𝓝 (1 : G), {i : ι | ∀ a, F i a / f a ∈ u} ∈ p :=
+⟨λ h u hu, h _ ⟨u, hu, set.subset.rfl⟩, λ h v ⟨u, hu, hv⟩,
+  p.sets_of_superset (h u hu) (λ i hi a, hv (by exact hi a))⟩
+
 @[to_additive] lemma topological_group.tendsto_uniformly_on_iff
   {ι α : Type*} (F : ι → α → G) (f : α → G) (p : filter ι) (s : set α) :
   @tendsto_uniformly_on α G ι (topological_group.to_uniform_space G) F f p s
-    ↔ ∀ u ∈ nhds (1 : G), {i : ι | ∀ a ∈ s, F i a / f a ∈ u} ∈ p :=
+    ↔ ∀ u ∈ 𝓝 (1 : G), {i : ι | ∀ a ∈ s, F i a / f a ∈ u} ∈ p :=
 ⟨λ h u hu, h _ ⟨u, hu, set.subset.rfl⟩, λ h v ⟨u, hu, hv⟩,
   p.sets_of_superset (h u hu) (λ i hi a ha, hv (by exact hi a ha))⟩
 

--- a/src/topology/algebra/uniform_group.lean
+++ b/src/topology/algebra/uniform_group.lean
@@ -203,7 +203,7 @@ def topological_group.to_uniform_space : uniform_space G :=
 
 variables {G}
 
-@[to_additive] lemma topological_group.tends_uniformly_to
+@[to_additive] lemma topological_group.tendsto_uniformly_on
   {ι α : Type*} (F : ι → α → G) (f : α → G) (p : filter ι) (s : set α) :
   @tendsto_uniformly_on α G ι (topological_group.to_uniform_space G) F f p s
     ↔ ∀ u ∈ nhds (1 : G), {i : ι | ∀ a ∈ s, F i a / f a ∈ u} ∈ p :=

--- a/src/topology/algebra/uniform_group.lean
+++ b/src/topology/algebra/uniform_group.lean
@@ -212,7 +212,7 @@ variables {G}
 @[to_additive] lemma topological_group.tendsto_uniformly_on_iff
   {ι α : Type*} (F : ι → α → G) (f : α → G) (p : filter ι) (s : set α) :
   @tendsto_uniformly_on α G ι (topological_group.to_uniform_space G) F f p s
-    ↔ ∀ u ∈ 𝓝 (1 : G), {i : ι | ∀ a ∈ s, F i a / f a ∈ u} ∈ p :=
+    ↔ ∀ u ∈ 𝓝 (1 : G), ∀ᶠ i in p, ∀ a ∈ s, F i a / f a ∈ u :=
 ⟨λ h u hu, h _ ⟨u, hu, λ _, id⟩, λ h v ⟨u, hu, hv⟩,
   mem_of_superset (h u hu) (λ i hi a ha, hv (by exact hi a ha))⟩
 


### PR DESCRIPTION
This PR adds a lemma regarding uniform convergence on a topological group `G`, placed right after the construction of the `uniform_space` structure on `G`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
