### PR TITLE
[Merged by Bors] - fix(tactic/ring_exp): fix normalization proof of unchanged subexpressions

### DIFF
--- a/src/tactic/ring_exp.lean
+++ b/src/tactic/ring_exp.lean
@@ -1194,6 +1194,8 @@ Normalized expressions might have the form `a^1 * 1 + 0`,
 since the dummy operations reduce special cases in pattern-matching.
 Humans prefer to read `a` instead.
 This tactic gets rid of the dummy additions, multiplications and exponentiations.
+
+Returns a normalized expression `e'` and a proof that `e.pretty = e'`.
 -/
 meta def ex.simple : Π {et : ex_type}, ex et → ring_exp_m (expr × expr)
 | sum pps@(ex.sum pps_i p (ex.zero _)) := do
@@ -1211,7 +1213,7 @@ meta def ex.simple : Π {et : ex_type}, ex et → ring_exp_m (expr × expr)
 | prod pps@(ex.prod pps_i p (ex.coeff _ ⟨⟨-1, 1, _, _⟩⟩)) := do
   ctx ← get_context,
   match ctx.info_b.ring_instance with
-  | none := prod.mk pps.pretty <$> pps.proof_term
+  | none := prod.mk pps.pretty <$> lift (mk_eq_refl pps.pretty)
   | (some ringi) := do
     (p_p, p_pf) ← p.simple,
     prod.mk
@@ -1234,7 +1236,7 @@ meta def ex.simple : Π {et : ex_type}, ex et → ring_exp_m (expr × expr)
   prod.mk
     <$> mk_pow [p_p, ps_p]
     <*> mk_app_csr ``exp_congr [p.pretty, p_p, ps.pretty, ps_p, p_pf, ps_pf]
-| et ps := prod.mk ps.pretty <$> ps.proof_term
+| et ps := prod.mk ps.pretty <$> lift (mk_eq_refl ps.pretty)
 
 /--
 Performs a lookup of the atom `a` in the list of known atoms,

--- a/test/ring_exp.lean
+++ b/test/ring_exp.lean
@@ -147,6 +147,21 @@ begin
   ring_exp,
 end
 
+-- Simplified instance of a bug reported by Patrick Massot:
+-- https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/ring_exp.20bug
+example (l : ℤ) : l - l = 0 :=
+begin
+  tactic.replace_at (tactic.ring_exp.normalize tactic.transparency.reducible) [] tt >> pure (),
+  refl
+end
+
+-- Normalizing also works on more complicated expressions:
+example (a b : ℤ) : (a^2 - b - b) + (2 * id b - a^2) = 0 :=
+begin
+  tactic.replace_at (tactic.ring_exp.normalize tactic.transparency.semireducible) [] tt >> pure (),
+  refl
+end
+
 section conv
 /-!
   ### `conv` section


### PR DESCRIPTION
When trying to simplify a goal (instead of proving equalities), `ring_exp` will rewrite subexpressions to a normal form, then simplify this normal form by removing extraneous `+ 0`s and `* 1`s. Both steps return a new expression and a proof that the *step*'s input expression equals the output expression.

In some cases where the normal form and simplified form coincide, `ex.simplify` would instead output a proof that *ring_exp*'s input expression equals the output expression, so we'd get a type error in trying to compose a proof that `a = b` with a proof that `a = b`.

This PR fixes that bug by returning instead a proof that `b = b`, as expected.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
