### PR TITLE
[Merged by Bors] - feat(data/nat/factorization): add lemma `factorization_prod`

### DIFF
--- a/src/data/nat/factorization.lean
+++ b/src/data/nat/factorization.lean
@@ -96,7 +96,7 @@ by simp [factorization_pow, hp.factorization]
 /-- For any `p : ℕ` and any function `g : α → ℕ` that's non-zero on `S : finset α`,
 the power of `p` in `S.prod g` equals the sum over `x ∈ S` of the powers of `p` in `g x`.
 Generalises `factorization_mul`, which is the special case where `S.card = 2` and `g = id` -/
-lemma factorization_prod {α : Type*} {S : finset α} {p : ℕ} {g : α → ℕ} (hS: ∀ x ∈ S, g x ≠ 0) :
+lemma factorization_prod {α : Type*} {S : finset α} {g : α → ℕ} (hS: ∀ x ∈ S, g x ≠ 0) :
   (S.prod g).factorization = S.sum (λ x, (g x).factorization) :=
 begin
   classical,

--- a/src/data/nat/factorization.lean
+++ b/src/data/nat/factorization.lean
@@ -95,8 +95,8 @@ by simp [factorization_pow, hp.factorization]
 
 /-- For any `p : ℕ` and any function `g : α → ℕ` that's non-zero on `S : finset α`,
 the power of `p` in `S.prod g` equals the sum over `x ∈ S` of the powers of `p` in `g x`.
-Generalises `factorization_mul`, which is the special case where `S.card = 2` and `g = id` -/
-lemma factorization_prod {α : Type*} {S : finset α} {g : α → ℕ} (hS: ∀ x ∈ S, g x ≠ 0) :
+Generalises `factorization_mul`, which is the special case where `S.card = 2` and `g = id`. -/
+lemma factorization_prod {α : Type*} {S : finset α} {g : α → ℕ} (hS : ∀ x ∈ S, g x ≠ 0) :
   (S.prod g).factorization = S.sum (λ x, (g x).factorization) :=
 begin
   classical,

--- a/src/data/nat/factorization.lean
+++ b/src/data/nat/factorization.lean
@@ -93,9 +93,9 @@ end
   factorization (p^k) = single p k :=
 by simp [factorization_pow, hp.factorization]
 
-/-- For any `p : ℕ` and any function `g : α → ℕ` that's positive on `S : finset α`,
+/-- For any `p : ℕ` and any function `g : α → ℕ` that's non-zero on `S : finset α`,
 the power of `p` in `S.prod g` equals the sum over `x ∈ S` of the powers of `p` in `g x`.
-Generalises `factorization_mul`, which is the special case where `S.card = 2`. -/
+Generalises `factorization_mul`, which is the special case where `S.card = 2` and `g = id` -/
 lemma factorization_prod {α : Type*} {S : finset α} {p : ℕ} {g : α → ℕ} (hS: ∀ x ∈ S, g x ≠ 0) :
   (S.prod g).factorization = S.sum (λ x, (g x).factorization) :=
 begin

--- a/src/data/nat/factorization.lean
+++ b/src/data/nat/factorization.lean
@@ -187,6 +187,4 @@ begin
   { rintro ⟨c, rfl⟩, rw factorization_mul hd (right_ne_zero_of_mul hn), simp },
 end
 
-
-
 end nat

--- a/src/data/nat/factorization.lean
+++ b/src/data/nat/factorization.lean
@@ -173,4 +173,20 @@ begin
   { rintro ⟨c, rfl⟩, rw factorization_mul hd (right_ne_zero_of_mul hn), simp },
 end
 
+/-- For any `p : ℕ` and any function `g : α → ℕ` that's positive on `S : finset α`,
+the power of `p` in `S.prod g` equals the sum over `x ∈ S` of the powers of `p` in `g x`.
+Generalises `count_factors_mul_of_pos`, which is the special case where `S.card = 2`. -/
+
+lemma count_factors_prod {α : Type*} {S : finset α} {p : ℕ} {g : α → ℕ} (hS: ∀ x ∈ S, 0 < g x) :
+  (S.prod g).factorization p = S.sum (λ x, (g x).factorization p) :=
+begin
+  simp only [factorization_eq_count],
+  classical,
+  apply finset.induction_on' S, { simp },
+  { intros x T hxS hTS hxT IH,
+    rw [prod_insert hxT, sum_insert hxT, ←IH],
+    exact count_factors_mul_of_pos (hS x hxS) (finset.prod_pos (λ a ha, hS a (hTS ha))) },
+end
+
+
 end nat

--- a/src/data/nat/factorization.lean
+++ b/src/data/nat/factorization.lean
@@ -175,9 +175,9 @@ end
 
 /-- For any `p : ℕ` and any function `g : α → ℕ` that's positive on `S : finset α`,
 the power of `p` in `S.prod g` equals the sum over `x ∈ S` of the powers of `p` in `g x`.
-Generalises `count_factors_mul_of_pos`, which is the special case where `S.card = 2`. -/
+Generalises `factorization_mul`, which is the special case where `S.card = 2`. -/
 
-lemma count_factors_prod {α : Type*} {S : finset α} {p : ℕ} {g : α → ℕ} (hS: ∀ x ∈ S, 0 < g x) :
+lemma factorization_prod {α : Type*} {S : finset α} {p : ℕ} {g : α → ℕ} (hS: ∀ x ∈ S, 0 < g x) :
   (S.prod g).factorization p = S.sum (λ x, (g x).factorization p) :=
 begin
   simp only [factorization_eq_count],

--- a/src/data/nat/factorization.lean
+++ b/src/data/nat/factorization.lean
@@ -93,6 +93,20 @@ end
   factorization (p^k) = single p k :=
 by simp [factorization_pow, hp.factorization]
 
+/-- For any `p : ℕ` and any function `g : α → ℕ` that's positive on `S : finset α`,
+the power of `p` in `S.prod g` equals the sum over `x ∈ S` of the powers of `p` in `g x`.
+Generalises `factorization_mul`, which is the special case where `S.card = 2`. -/
+lemma factorization_prod {α : Type*} {S : finset α} {p : ℕ} {g : α → ℕ} (hS: ∀ x ∈ S, g x ≠ 0) :
+  (S.prod g).factorization = S.sum (λ x, (g x).factorization) :=
+begin
+  classical,
+  ext p,
+  apply finset.induction_on' S, { simp },
+  { intros x T hxS hTS hxT IH,
+    have hT : T.prod g ≠ 0 := prod_ne_zero_iff.mpr (λ x hx, hS x (hTS hx)),
+    simp [prod_insert hxT, sum_insert hxT, ←IH, factorization_mul (hS x hxS) hT] }
+end
+
 /-! ### Factorizations of pairs of coprime numbers -/
 
 /-- The prime factorizations of coprime `a` and `b` are disjoint -/
@@ -173,20 +187,6 @@ begin
   { rintro ⟨c, rfl⟩, rw factorization_mul hd (right_ne_zero_of_mul hn), simp },
 end
 
-/-- For any `p : ℕ` and any function `g : α → ℕ` that's positive on `S : finset α`,
-the power of `p` in `S.prod g` equals the sum over `x ∈ S` of the powers of `p` in `g x`.
-Generalises `factorization_mul`, which is the special case where `S.card = 2`. -/
-
-lemma factorization_prod {α : Type*} {S : finset α} {p : ℕ} {g : α → ℕ} (hS: ∀ x ∈ S, 0 < g x) :
-  (S.prod g).factorization p = S.sum (λ x, (g x).factorization p) :=
-begin
-  simp only [factorization_eq_count],
-  classical,
-  apply finset.induction_on' S, { simp },
-  { intros x T hxS hTS hxT IH,
-    rw [prod_insert hxT, sum_insert hxT, ←IH],
-    exact count_factors_mul_of_pos (hS x hxS) (finset.prod_pos (λ a ha, hS a (hTS ha))) },
-end
 
 
 end nat


### PR DESCRIPTION
For any `p : ℕ` and any function `g : α → ℕ` that's non-zero on `S : finset α`, the power of `p` in `S.prod g` equals the sum over `x ∈ S` of the powers of `p` in `g x`.

Generalises `factorization_mul`, which is the special case where `S.card = 2` and `g = id`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
