### PR TITLE
chore(analysis/normed_space/basic): make `normed_space` extend `seminormed_space`

### DIFF
--- a/src/analysis/calculus/tangent_cone.lean
+++ b/src/analysis/calculus/tangent_cone.lean
@@ -182,6 +182,12 @@ begin
     exact tendsto_pow_at_top_nhds_0_of_lt_1 one_half_pos.le one_half_lt_one }
 end
 
+/-- This instance is just `pi.module`, but lean can't find it when it needs it. -/
+instance pi.module_of_normed_group_of_semi_normed_space {ι : Type*} {E : ι → Type*}
+  [Π i, normed_group (E i)] [Π i, semi_normed_space 𝕜 (E i)] :
+  module 𝕜 (Π i, E i) :=
+@pi.module ι E 𝕜 (by apply_instance) (λ _, by apply_instance) (λ _, by apply_instance)
+
 /-- The tangent cone of a product contains the tangent cone of each factor. -/
 lemma maps_to_tangent_cone_pi {ι : Type*} [decidable_eq ι] {E : ι → Type*}
   [Π i, normed_group (E i)] [Π i, normed_space 𝕜 (E i)]

--- a/src/analysis/normed_space/basic.lean
+++ b/src/analysis/normed_space/basic.lean
@@ -535,21 +535,14 @@ class semi_normed_space (α : Type*) (β : Type*) [normed_field α] [semi_normed
   extends module α β :=
 (norm_smul_le : ∀ (a:α) (b:β), ∥a • b∥ ≤ ∥a∥ * ∥b∥)
 
-set_option extends_priority 920
--- Here, we set a rather high priority for the instance `[normed_space α β] : module α β`
--- to take precedence over `semiring.to_module` as this leads to instance paths with better
--- unification properties.
 /-- A normed space over a normed field is a vector space endowed with a norm which satisfies the
 equality `∥c • x∥ = ∥c∥ ∥x∥`. We require only `∥c • x∥ ≤ ∥c∥ ∥x∥` in the definition, then prove
 `∥c • x∥ = ∥c∥ ∥x∥` in `norm_smul`. -/
 class normed_space (α : Type*) (β : Type*) [normed_field α] [normed_group β]
-  extends module α β :=
-(norm_smul_le : ∀ (a:α) (b:β), ∥a • b∥ ≤ ∥a∥ * ∥b∥)
+  extends semi_normed_space α β.
 
 /-- A normed space is a seminormed space. -/
-@[priority 100] -- see Note [lower instance priority]
-instance normed_space.to_semi_normed_space [normed_field α] [normed_group β]
-  [γ : normed_space α β] : semi_normed_space α β := { ..γ }
+add_decl_doc normed_space.to_semi_normed_space
 
 end prio
 

--- a/src/analysis/normed_space/operator_norm.lean
+++ b/src/analysis/normed_space/operator_norm.lean
@@ -1129,7 +1129,7 @@ normed_group.of_core _ ⟨op_norm_zero_iff, op_norm_add_le, op_norm_neg⟩
 
 instance to_normed_space {𝕜' : Type*} [normed_field 𝕜'] [normed_space 𝕜' F]
   [smul_comm_class 𝕜₂ 𝕜' F] : normed_space 𝕜' (E →SL[σ₁₂] F) :=
-⟨op_norm_smul_le⟩
+{ norm_smul_le := op_norm_smul_le }
 
 /-- Continuous linear maps form a normed ring with respect to the operator norm. -/
 instance to_normed_ring : normed_ring (E →L[𝕜] E) :=


### PR DESCRIPTION
This saves a few lines, and is one step closer to eliminating the distinction between these two classes entirely



---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
