### PR TITLE
[Merged by Bors] - feat(combinatorics/configuration): Cardinality results for projective plane.

### DIFF
--- a/src/combinatorics/configuration.lean
+++ b/src/combinatorics/configuration.lean
@@ -309,7 +309,7 @@ class projective_plane extends nondegenerate P L : Type u :=
 (mk_point_ax : ∀ {l₁ l₂ : L} (h : l₁ ≠ l₂), mk_point h ∈ l₁ ∧ mk_point h ∈ l₂)
 (mk_line : ∀ {p₁ p₂ : P} (h : p₁ ≠ p₂), L)
 (mk_line_ax : ∀ {p₁ p₂ : P} (h : p₁ ≠ p₂), p₁ ∈ mk_line h ∧ p₂ ∈ mk_line h)
-(exists_config : ∃ (p₁ p₂ p₃ : P) (l₁ l₂ l₃ : L), p₁ ∈ l₁ ∧ p₁ ∉ l₂ ∧ p₁ ∉ l₃ ∧
+(exists_config : ∃ (p₁ p₂ p₃ : P) (l₁ l₂ l₃ : L), p₁ ∉ l₂ ∧ p₁ ∉ l₃ ∧
   p₂ ∉ l₁ ∧ p₂ ∈ l₂ ∧ p₂ ∈ l₃ ∧ p₃ ∉ l₁ ∧ p₃ ∈ l₂ ∧ p₃ ∉ l₃)
 
 namespace projective_plane
@@ -326,10 +326,48 @@ instance [projective_plane P L] : projective_plane (dual L) (dual P) :=
   mk_point := @mk_line P L _ _,
   mk_point_ax := λ _ _, mk_line_ax,
   exists_config := by
-  { obtain ⟨p₁, p₂, p₃, l₁, l₂, l₃, h₁₁, h₁₂, h₁₃, h₂₁, h₂₂, h₂₃, h₃₁, h₃₂, h₃₃⟩ :=
+  { obtain ⟨p₁, p₂, p₃, l₁, l₂, l₃, h₁₂, h₁₃, h₂₁, h₂₂, h₂₃, h₃₁, h₃₂, h₃₃⟩ :=
     @exists_config P L _ _,
-    exact ⟨l₁, l₂, l₃, p₁, p₂, p₃, h₁₁, h₂₁, h₃₁, h₁₂, h₂₂, h₃₂, h₁₃, h₂₃, h₃₃⟩ },
+    exact ⟨l₁, l₂, l₃, p₁, p₂, p₃, h₂₁, h₃₁, h₁₂, h₂₂, h₃₂, h₁₃, h₂₃, h₃₃⟩ },
   .. dual.nondegenerate P L }
+
+variables [fintype P] [fintype L]
+
+lemma card_points_eq_card_lines [projective_plane P L] : fintype.card P = fintype.card L :=
+le_antisymm (has_lines.card_le P L) (has_points.card_le P L)
+
+variables {P} (L)
+
+lemma line_count_eq_line_count [projective_plane P L] (p q : P) :
+  line_count L p = line_count L q :=
+begin
+  obtain ⟨p₁, p₂, p₃, l₁, l₂, l₃, h₁₂, h₁₃, h₂₁, h₂₂, h₂₃, h₃₁, h₃₂, h₃₃⟩ := exists_config,
+  have h := card_points_eq_card_lines P L,
+  let n := line_count L p₂,
+  have hp₂ : line_count L p₂ = n := rfl,
+  have hl₁ : point_count P l₁ = n := (has_lines.line_count_eq_point_count h h₂₁).symm.trans hp₂,
+  have hp₃ : line_count L p₃ = n := (has_lines.line_count_eq_point_count h h₃₁).trans hl₁,
+  have hl₃ : point_count P l₃ = n := (has_lines.line_count_eq_point_count h h₃₃).symm.trans hp₃,
+  have hp₁ : line_count L p₁ = n := (has_lines.line_count_eq_point_count h h₁₃).trans hl₃,
+  have hl₂ : point_count P l₂ = n := (has_lines.line_count_eq_point_count h h₁₂).symm.trans hp₁,
+  suffices : ∀ p : P, line_count L p = n, { exact (this p).trans (this q).symm },
+  refine λ p, or_not.elim (λ h₂, _) (λ h₂, (has_lines.line_count_eq_point_count h h₂).trans hl₂),
+  refine or_not.elim (λ h₃, _) (λ h₃, (has_lines.line_count_eq_point_count h h₃).trans hl₃),
+  rwa (eq_or_eq h₂ h₂₂ h₃ h₂₃).resolve_right (λ h, h₃₃ ((congr_arg (has_mem.mem p₃) h).mp h₃₂)),
+end
+
+variables (P) {L}
+
+lemma point_count_eq_point_count [projective_plane P L] (l m : L) :
+  point_count P l = point_count P m :=
+line_count_eq_line_count (dual P) l m
+
+variables {P L}
+
+lemma line_count_eq_point_count [projective_plane P L] (p : P) (l : L) :
+  line_count L p = point_count P l :=
+exists.elim (exists_point l) (λ q hq, (line_count_eq_line_count L p q).trans
+  (has_lines.line_count_eq_point_count (card_points_eq_card_lines P L) hq))
 
 end projective_plane
 


### PR DESCRIPTION
This PR proves several cardinality results for projective planes (e.g., number of points = number of lines, number of points on given line = number of lines on given point).

It looks like the `exists_config` (whose sole purpose is to rule out [the 7th example here](https://en.wikipedia.org/wiki/Projective_plane#Degenerate_planes)) can be weakened slightly.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
