### PR TITLE
[Merged by Bors] - feat(tactic/lint): include linter name in github output

### DIFF
--- a/src/tactic/lint/frontend.lean
+++ b/src/tactic/lint/frontend.lean
@@ -132,8 +132,8 @@ meta def print_workflow_command (env : environment) (linter_name decl_name : nam
  (warning : string) : option string := do
   po ← env.decl_pos decl_name,
   ol ← env.decl_olean decl_name,
-  return $ sformat!"\n::error file={ol},line={po.line},col={po.column}::" ++
-    sformat!"The {linter_name} linter has flagged this declaration:%0A" ++
+  return $ sformat!"\n::error file={ol},line={po.line},col={po.column},title=" ++
+    sformat!"Warning from {linter_name} linter::" ++
     sformat!"{escape_workflow_command $ to_string decl_name} - {escape_workflow_command warning}"
 
 /-- Formats a map of linter warnings using `print_warning`, sorted by line number. -/

--- a/src/tactic/lint/frontend.lean
+++ b/src/tactic/lint/frontend.lean
@@ -120,8 +120,6 @@ https://github.com/actions/toolkit/blob/7257597d731b34d14090db516d9ea53439300e98
 def escape_workflow_command (s : string) : string :=
 "".intercalate $ s.to_list.map workflow_command_replacements
 
-def test (n : ℕ) := 4
-
 /--
 Prints a workflow command to emit an error understood by github in an actions workflow.
 This enables CI to tag the parts of the file where linting failed with annotations, and makes it

--- a/src/tactic/lint/frontend.lean
+++ b/src/tactic/lint/frontend.lean
@@ -120,6 +120,8 @@ https://github.com/actions/toolkit/blob/7257597d731b34d14090db516d9ea53439300e98
 def escape_workflow_command (s : string) : string :=
 "".intercalate $ s.to_list.map workflow_command_replacements
 
+def test (n : ℕ) := 4
+
 /--
 Prints a workflow command to emit an error understood by github in an actions workflow.
 This enables CI to tag the parts of the file where linting failed with annotations, and makes it

--- a/src/tactic/lint/frontend.lean
+++ b/src/tactic/lint/frontend.lean
@@ -126,21 +126,21 @@ This enables CI to tag the parts of the file where linting failed with annotatio
 easier for mathlib contributors to see what needs fixing.
 See https://docs.github.com/en/actions/learn-github-actions/workflow-commands-for-github-actions#setting-an-error-message
 -/
-meta def print_workflow_command (env : environment) (decl_name : name) (warning : string) :
-  option string :=
-do
+meta def print_workflow_command (env : environment) (linter_name decl_name : name)
+ (warning : string) : option string := do
   po ← env.decl_pos decl_name,
   ol ← env.decl_olean decl_name,
   return $ sformat!"\n::error file={ol},line={po.line},col={po.column}::" ++
+    sformat!"The {linter_name} linter has flagged this declaration:%0A" ++
     sformat!"{escape_workflow_command $ to_string decl_name} - {escape_workflow_command warning}"
 
 /-- Formats a map of linter warnings using `print_warning`, sorted by line number. -/
-meta def print_warnings (env : environment) (emit_workflow_commands : bool)
+meta def print_warnings (env : environment) (emit_workflow_commands : bool) (linter_name : name)
   (results : rb_map name string) : format :=
 format.intercalate format.line $ (sort_results env results).map $
   λ ⟨decl_name, warning⟩, let form := print_warning decl_name warning in
     if emit_workflow_commands then
-      form ++ (print_workflow_command env decl_name warning).get_or_else ""
+      form ++ (print_workflow_command env linter_name decl_name warning).get_or_else ""
     else form
 
 /--
@@ -174,9 +174,10 @@ let formatted_results := results.map $ λ ⟨linter_name, linter, results⟩,
   let report_str : format := to_fmt "/- The `" ++ to_fmt linter_name ++ "` linter reports: -/\n" in
   if ¬ results.empty then
     let warnings := match group_by_filename with
-      | none := print_warnings env emit_workflow_commands results
+      | none := print_warnings env emit_workflow_commands linter_name results
       | some dropped :=
-        grouped_by_filename env results dropped (print_warnings env emit_workflow_commands)
+        grouped_by_filename env results dropped
+          (print_warnings env emit_workflow_commands linter_name)
       end in
     report_str ++ "/- " ++ linter.errors_found ++ " -/\n" ++ warnings ++ "\n"
   else if verbose = lint_verbosity.high then


### PR DESCRIPTION

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

https://github.com/leanprover-community/mathlib/pull/11396/files has the somewhat unclear line:

![image](https://user-images.githubusercontent.com/4967469/149244604-adb81e59-9321-4711-ade1-8cc761dd640c.png)

This will print the linter name in the output. Test included so CI should fail.

cc @alexjbest if you know of a better way to format this on GitHub.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)

