### PR TITLE
[Merged by Bors] - chore(ring_theory/roots_of_unity): change argument order

### DIFF
--- a/src/ring_theory/roots_of_unity.lean
+++ b/src/ring_theory/roots_of_unity.lean
@@ -494,7 +494,7 @@ variables [comm_semiring R] [comm_semiring S] {f : R →+* S} {ζ : R}
 
 open function
 
-lemma map_of_injective (hf : injective f) (h : is_primitive_root ζ k) : is_primitive_root (f ζ) k :=
+lemma map_of_injective (h : is_primitive_root ζ k) (hf : injective f) : is_primitive_root (f ζ) k :=
 { pow_eq_one := by rw [←map_pow, h.pow_eq_one, _root_.map_one],
   dvd_of_pow_eq_one := begin
     rw h.eq_order_of,
@@ -503,7 +503,7 @@ lemma map_of_injective (hf : injective f) (h : is_primitive_root ζ k) : is_prim
     exact order_of_dvd_of_pow_eq_one (hf hl)
   end }
 
-lemma of_map_of_injective (hf : injective f) (h : is_primitive_root (f ζ) k) :
+lemma of_map_of_injective (h : is_primitive_root (f ζ) k) (hf : injective f) :
   is_primitive_root ζ k :=
 { pow_eq_one := by { apply_fun f, rw [map_pow, _root_.map_one, h.pow_eq_one] },
   dvd_of_pow_eq_one := begin


### PR DESCRIPTION
this is for easier dot notation in situations such as `refine`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
