### PR TITLE
[Merged by Bors] - feat(algebra/star/basic): change `star_ring_aut` (notably, complex conjugation) from `ring_equiv` to `ring_hom` and make type argument explicit

### DIFF
--- a/src/algebra/module/linear_map.lean
+++ b/src/algebra/module/linear_map.lean
@@ -94,7 +94,7 @@ add_decl_doc linear_map.to_add_hom
 
 notation M ` →ₛₗ[`:25 σ:25 `] `:0 M₂:0 := linear_map σ M M₂
 notation M ` →ₗ[`:25 R:25 `] `:0 M₂:0 := linear_map (ring_hom.id R) M M₂
-notation M ` →ₗ⋆[`:25 R:25 `] `:0 M₂:0 := linear_map (@star_ring_aut R _ _ : R →+* R) M M₂
+notation M ` →ₗ⋆[`:25 R:25 `] `:0 M₂:0 := linear_map (star_ring_aut R : R →+* R) M M₂
 
 namespace linear_map
 

--- a/src/algebra/module/linear_map.lean
+++ b/src/algebra/module/linear_map.lean
@@ -94,7 +94,7 @@ add_decl_doc linear_map.to_add_hom
 
 notation M ` →ₛₗ[`:25 σ:25 `] `:0 M₂:0 := linear_map σ M M₂
 notation M ` →ₗ[`:25 R:25 `] `:0 M₂:0 := linear_map (ring_hom.id R) M M₂
-notation M ` →ₗ⋆[`:25 R:25 `] `:0 M₂:0 := linear_map (star_ring_end R : R →+* R) M M₂
+notation M ` →ₗ⋆[`:25 R:25 `] `:0 M₂:0 := linear_map (star_ring_end R) M M₂
 
 namespace linear_map
 

--- a/src/algebra/module/linear_map.lean
+++ b/src/algebra/module/linear_map.lean
@@ -94,7 +94,7 @@ add_decl_doc linear_map.to_add_hom
 
 notation M ` →ₛₗ[`:25 σ:25 `] `:0 M₂:0 := linear_map σ M M₂
 notation M ` →ₗ[`:25 R:25 `] `:0 M₂:0 := linear_map (ring_hom.id R) M M₂
-notation M ` →ₗ⋆[`:25 R:25 `] `:0 M₂:0 := linear_map (star_ring_aut R : R →+* R) M M₂
+notation M ` →ₗ⋆[`:25 R:25 `] `:0 M₂:0 := linear_map (star_ring_end R : R →+* R) M M₂
 
 namespace linear_map
 

--- a/src/algebra/star/basic.lean
+++ b/src/algebra/star/basic.lean
@@ -213,23 +213,25 @@ def star_ring_equiv [semiring R] [star_ring R] : R ≃+* Rᵐᵒᵖ :=
   ..star_add_equiv.trans (mul_opposite.op_add_equiv : R ≃+ Rᵐᵒᵖ),
   ..star_mul_equiv}
 
+variables (R)
 /-- `star` as a `ring_aut` for commutative `R`. This is used to denote complex
 conjugation, and is available under the notation `conj` in the locale `complex_conjugate` -/
 def star_ring_aut [comm_semiring R] [star_ring R] : ring_aut R :=
 { to_fun := star,
   ..star_add_equiv,
   ..star_mul_aut }
+variables {R}
 
-localized "notation `conj` := star_ring_aut" in complex_conjugate
+localized "notation `conj` := star_ring_aut _" in complex_conjugate
 
 /-- This is not a simp lemma, since we usually want simp to keep `star_ring_aut` bundled.
  For example, for complex conjugation, we don't want simp to turn `conj x`
  into the bare function `star x` automatically since most lemmas are about `conj x`. -/
 lemma star_ring_aut_apply [comm_semiring R] [star_ring R] {x : R} :
-  star_ring_aut x = star x := rfl
+  star_ring_aut R x = star x := rfl
 
 @[simp] lemma star_ring_aut_self_apply [comm_semiring R] [star_ring R] (x : R) :
-  star_ring_aut (star_ring_aut x) = x := star_star x
+  star_ring_aut R (star_ring_aut R x) = x := star_star x
 
 -- A more convenient name for complex conjugation
 alias star_ring_aut_self_apply ← complex.conj_conj
@@ -246,7 +248,7 @@ op_injective $
 
 /-- When multiplication is commutative, `star` preserves division. -/
 @[simp] lemma star_div' [field R] [star_ring R] (x y : R) : star (x / y) = star x / star y :=
-(star_ring_aut : R ≃+* R).to_ring_hom.map_div _ _
+(star_ring_aut R : R ≃+* R).to_ring_hom.map_div _ _
 
 @[simp] lemma star_bit0 [ring R] [star_ring R] (r : R) : star (bit0 r) = bit0 (star r) :=
 by simp [bit0]
@@ -306,8 +308,7 @@ namespace ring_hom_inv_pair
 /-- Instance needed to define star-linear maps over a commutative star ring
 (ex: conjugate-linear maps when R = ℂ).  -/
 instance [comm_semiring R] [star_ring R] :
-  ring_hom_inv_pair ((star_ring_aut : ring_aut R) : R →+* R)
-    ((star_ring_aut : ring_aut R) : R →+* R) :=
+  ring_hom_inv_pair (star_ring_aut R : R →+* R) (star_ring_aut R: R →+* R) :=
 ⟨ring_hom.ext star_star, ring_hom.ext star_star⟩
 
 end ring_hom_inv_pair

--- a/src/algebra/star/basic.lean
+++ b/src/algebra/star/basic.lean
@@ -214,6 +214,7 @@ def star_ring_equiv [semiring R] [star_ring R] : R ≃+* Rᵐᵒᵖ :=
   ..star_mul_equiv }
 
 /-- `star` as a ring automorphism, for commutative `R`. -/
+@[simps apply]
 def star_ring_aut [comm_semiring R] [star_ring R] : ring_aut R :=
 { to_fun := star,
   ..star_add_equiv,

--- a/src/algebra/star/basic.lean
+++ b/src/algebra/star/basic.lean
@@ -227,12 +227,7 @@ Note that this is the preferred form (over `star_ring_aut`, available under the 
 because the notation `E →ₗ⋆[R] F` for an `R`-conjugate-linear map (short for
 `E →ₛₗ[star_ring_end R] F`) does not pretty-print if there is a coercion involved, as would be the
 case for `(↑star_ring_aut : R →* R)`. -/
-def star_ring_end [comm_semiring R] [star_ring R] : R →+* R :=
-{ to_fun := star,
-  map_one' := star_one R,
-  map_mul' := star_mul',
-  map_zero' := star_zero R,
-  map_add' := star_add }
+def star_ring_end [comm_semiring R] [star_ring R] : R →+* R := @star_ring_aut R _ _
 variables {R}
 
 localized "notation `conj` := star_ring_end _" in complex_conjugate

--- a/src/algebra/star/basic.lean
+++ b/src/algebra/star/basic.lean
@@ -310,7 +310,7 @@ namespace ring_hom_inv_pair
 /-- Instance needed to define star-linear maps over a commutative star ring
 (ex: conjugate-linear maps when R = ℂ).  -/
 instance [comm_semiring R] [star_ring R] :
-  ring_hom_inv_pair (star_ring_end R : R →+* R) (star_ring_end R: R →+* R) :=
+  ring_hom_inv_pair (star_ring_end R) (star_ring_end R) :=
 ⟨ring_hom.ext star_star, ring_hom.ext star_star⟩
 
 end ring_hom_inv_pair

--- a/src/algebra/star/basic.lean
+++ b/src/algebra/star/basic.lean
@@ -211,31 +211,33 @@ instance star_ring.to_star_add_monoid [semiring R] [star_ring R] : star_add_mono
 def star_ring_equiv [semiring R] [star_ring R] : R ≃+* Rᵐᵒᵖ :=
 { to_fun := λ x, mul_opposite.op (star x),
   ..star_add_equiv.trans (mul_opposite.op_add_equiv : R ≃+ Rᵐᵒᵖ),
-  ..star_mul_equiv}
+  ..star_mul_equiv }
 
 variables (R)
-/-- `star` as a `ring_aut` for commutative `R`. This is used to denote complex
+/-- `star` as a ring endomorphism, for commutative `R`. This is used to denote complex
 conjugation, and is available under the notation `conj` in the locale `complex_conjugate` -/
-def star_ring_aut [comm_semiring R] [star_ring R] : ring_aut R :=
+def star_ring_end [comm_semiring R] [star_ring R] : R →+* R :=
 { to_fun := star,
-  ..star_add_equiv,
-  ..star_mul_aut }
+  map_one' := star_one R,
+  map_mul' := star_mul',
+  map_zero' := star_zero R,
+  map_add' := star_add }
 variables {R}
 
-localized "notation `conj` := star_ring_aut _" in complex_conjugate
+localized "notation `conj` := star_ring_end _" in complex_conjugate
 
-/-- This is not a simp lemma, since we usually want simp to keep `star_ring_aut` bundled.
+/-- This is not a simp lemma, since we usually want simp to keep `star_ring_end` bundled.
  For example, for complex conjugation, we don't want simp to turn `conj x`
  into the bare function `star x` automatically since most lemmas are about `conj x`. -/
-lemma star_ring_aut_apply [comm_semiring R] [star_ring R] {x : R} :
-  star_ring_aut R x = star x := rfl
+lemma star_ring_end_apply [comm_semiring R] [star_ring R] {x : R} :
+  star_ring_end R x = star x := rfl
 
-@[simp] lemma star_ring_aut_self_apply [comm_semiring R] [star_ring R] (x : R) :
-  star_ring_aut R (star_ring_aut R x) = x := star_star x
+@[simp] lemma star_ring_end_self_apply [comm_semiring R] [star_ring R] (x : R) :
+  star_ring_end R (star_ring_end R x) = x := star_star x
 
 -- A more convenient name for complex conjugation
-alias star_ring_aut_self_apply ← complex.conj_conj
-alias star_ring_aut_self_apply ← is_R_or_C.conj_conj
+alias star_ring_end_self_apply ← complex.conj_conj
+alias star_ring_end_self_apply ← is_R_or_C.conj_conj
 
 @[simp] lemma star_inv' [division_ring R] [star_ring R] (x : R) : star (x⁻¹) = (star x)⁻¹ :=
 op_injective $
@@ -248,7 +250,7 @@ op_injective $
 
 /-- When multiplication is commutative, `star` preserves division. -/
 @[simp] lemma star_div' [field R] [star_ring R] (x y : R) : star (x / y) = star x / star y :=
-(star_ring_aut R : R ≃+* R).to_ring_hom.map_div _ _
+(star_ring_end R).map_div _ _
 
 @[simp] lemma star_bit0 [ring R] [star_ring R] (r : R) : star (bit0 r) = bit0 (star r) :=
 by simp [bit0]
@@ -308,7 +310,7 @@ namespace ring_hom_inv_pair
 /-- Instance needed to define star-linear maps over a commutative star ring
 (ex: conjugate-linear maps when R = ℂ).  -/
 instance [comm_semiring R] [star_ring R] :
-  ring_hom_inv_pair (star_ring_aut R : R →+* R) (star_ring_aut R: R →+* R) :=
+  ring_hom_inv_pair (star_ring_end R : R →+* R) (star_ring_end R: R →+* R) :=
 ⟨ring_hom.ext star_star, ring_hom.ext star_star⟩
 
 end ring_hom_inv_pair

--- a/src/algebra/star/basic.lean
+++ b/src/algebra/star/basic.lean
@@ -213,9 +213,20 @@ def star_ring_equiv [semiring R] [star_ring R] : R ≃+* Rᵐᵒᵖ :=
   ..star_add_equiv.trans (mul_opposite.op_add_equiv : R ≃+ Rᵐᵒᵖ),
   ..star_mul_equiv }
 
+/-- `star` as a ring automorphism, for commutative `R`. -/
+def star_ring_aut [comm_semiring R] [star_ring R] : ring_aut R :=
+{ to_fun := star,
+  ..star_add_equiv,
+  ..star_mul_aut }
+
 variables (R)
 /-- `star` as a ring endomorphism, for commutative `R`. This is used to denote complex
-conjugation, and is available under the notation `conj` in the locale `complex_conjugate` -/
+conjugation, and is available under the notation `conj` in the locale `complex_conjugate`.
+
+Note that this is the preferred form (over `star_ring_aut`, available under the same hypotheses)
+because the notation `E →ₗ⋆[R] F` for an `R`-conjugate-linear map (short for
+`E →ₛₗ[star_ring_end R] F`) does not pretty-print if there is a coercion involved, as would be the
+case for `(↑star_ring_aut : R →* R)`. -/
 def star_ring_end [comm_semiring R] [star_ring R] : R →+* R :=
 { to_fun := star,
   map_one' := star_one R,

--- a/src/analysis/complex/circle.lean
+++ b/src/analysis/complex/circle.lean
@@ -65,7 +65,7 @@ instance : comm_group circle :=
     ← mul_self_abs] },
   .. circle.to_comm_monoid }
 
-lemma coe_inv_circle_eq_conj (z : circle) : ↑(z⁻¹) = conj (z:ℂ) := rfl
+lemma coe_inv_circle_eq_conj (z : circle) : ↑(z⁻¹) = conj (z : ℂ) := rfl
 
 @[simp] lemma coe_inv_circle (z : circle) : ↑(z⁻¹) = (z : ℂ)⁻¹ :=
 begin

--- a/src/analysis/complex/circle.lean
+++ b/src/analysis/complex/circle.lean
@@ -65,7 +65,7 @@ instance : comm_group circle :=
     ← mul_self_abs] },
   .. circle.to_comm_monoid }
 
-lemma coe_inv_circle_eq_conj (z : circle) : ↑(z⁻¹) = (conj : ring_aut ℂ) z := rfl
+lemma coe_inv_circle_eq_conj (z : circle) : ↑(z⁻¹) = conj (z:ℂ) := rfl
 
 @[simp] lemma coe_inv_circle (z : circle) : ↑(z⁻¹) = (z : ℂ)⁻¹ :=
 begin

--- a/src/analysis/complex/isometry.lean
+++ b/src/analysis/complex/isometry.lean
@@ -62,7 +62,7 @@ begin
   intro h,
   have h1 : rotation a 1 = conj 1 := linear_isometry_equiv.congr_fun h 1,
   have hI : rotation a I = conj I := linear_isometry_equiv.congr_fun h I,
-  rw [rotation_apply, ring_equiv.map_one, mul_one] at h1,
+  rw [rotation_apply, ring_hom.map_one, mul_one] at h1,
   rw [rotation_apply, conj_I, ← neg_one_mul, mul_left_inj' I_ne_zero, h1, eq_neg_self_iff] at hI,
   exact one_ne_zero hI,
 end
@@ -102,11 +102,11 @@ begin
   apply_fun λ x, x ^ 2 at this,
   simp only [norm_eq_abs, ←norm_sq_eq_abs] at this,
   rw [←of_real_inj, ←mul_conj, ←mul_conj] at this,
-  rw [ring_equiv.map_sub, ring_equiv.map_sub] at this,
+  rw [ring_hom.map_sub, ring_hom.map_sub] at this,
   simp only [sub_mul, mul_sub, one_mul, mul_one] at this,
   rw [mul_conj, norm_sq_eq_abs, ←norm_eq_abs, linear_isometry.norm_map] at this,
   rw [mul_conj, norm_sq_eq_abs, ←norm_eq_abs] at this,
-  simp only [sub_sub, sub_right_inj, mul_one, of_real_pow, ring_equiv.map_one, norm_eq_abs] at this,
+  simp only [sub_sub, sub_right_inj, mul_one, of_real_pow, ring_hom.map_one, norm_eq_abs] at this,
   simp only [add_sub, sub_left_inj] at this,
   rw [add_comm, ←this, add_comm],
 end

--- a/src/analysis/inner_product_space/basic.lean
+++ b/src/analysis/inner_product_space/basic.lean
@@ -177,7 +177,7 @@ lemma inner_add_left {x y z : F} : ⟪x + y, z⟫ = ⟪x, z⟫ + ⟪y, z⟫ :=
 c.add_left _ _ _
 
 lemma inner_add_right {x y z : F} : ⟪x, y + z⟫ = ⟪x, y⟫ + ⟪x, z⟫ :=
-by rw [←inner_conj_sym, inner_add_left, ring_equiv.map_add]; simp only [inner_conj_sym]
+by rw [←inner_conj_sym, inner_add_left, ring_hom.map_add]; simp only [inner_conj_sym]
 
 lemma inner_norm_sq_eq_inner_self (x : F) : (norm_sqF x : 𝕜) = ⟪x, x⟫ :=
 begin
@@ -195,13 +195,13 @@ lemma inner_smul_left {x y : F} {r : 𝕜} : ⟪r • x, y⟫ = r† * ⟪x, y�
 c.smul_left _ _ _
 
 lemma inner_smul_right {x y : F} {r : 𝕜} : ⟪x, r • y⟫ = r * ⟪x, y⟫ :=
-by rw [←inner_conj_sym, inner_smul_left]; simp only [conj_conj, inner_conj_sym, ring_equiv.map_mul]
+by rw [←inner_conj_sym, inner_smul_left]; simp only [conj_conj, inner_conj_sym, ring_hom.map_mul]
 
 lemma inner_zero_left {x : F} : ⟪0, x⟫ = 0 :=
-by rw [←zero_smul 𝕜 (0 : F), inner_smul_left]; simp only [zero_mul, ring_equiv.map_zero]
+by rw [←zero_smul 𝕜 (0 : F), inner_smul_left]; simp only [zero_mul, ring_hom.map_zero]
 
 lemma inner_zero_right {x : F} : ⟪x, 0⟫ = 0 :=
-by rw [←inner_conj_sym, inner_zero_left]; simp only [ring_equiv.map_zero]
+by rw [←inner_conj_sym, inner_zero_left]; simp only [ring_hom.map_zero]
 
 lemma inner_self_eq_zero {x : F} : ⟪x, x⟫ = 0 ↔ x = 0 :=
 iff.intro (c.definite _) (by { rintro rfl, exact inner_zero_left })
@@ -216,7 +216,7 @@ lemma inner_neg_left {x y : F} : ⟪-x, y⟫ = -⟪x, y⟫ :=
 by { rw [← neg_one_smul 𝕜 x, inner_smul_left], simp }
 
 lemma inner_neg_right {x y : F} : ⟪x, -y⟫ = -⟪x, y⟫ :=
-by rw [←inner_conj_sym, inner_neg_left]; simp only [ring_equiv.map_neg, inner_conj_sym]
+by rw [←inner_conj_sym, inner_neg_left]; simp only [ring_hom.map_neg, inner_conj_sym]
 
 lemma inner_sub_left {x y z : F} : ⟪x - y, z⟫ = ⟪x, z⟫ - ⟪y, z⟫ :=
 by { simp [sub_eq_add_neg, inner_add_left, inner_neg_left] }
@@ -273,7 +273,7 @@ begin
       ... = re ⟪x, x⟫ - re (T† * ⟪y, x⟫) - re (T * ⟪x, y⟫) + re (T * T† * ⟪y, y⟫)
                   : by simp only [inner_smul_left, inner_smul_right, mul_assoc]
       ... = re ⟪x, x⟫ - re (⟪x, y⟫ / ⟪y, y⟫ * ⟪y, x⟫)
-                  : by field_simp [-mul_re, inner_conj_sym, hT, ring_equiv.map_div, h₁, h₃]
+                  : by field_simp [-mul_re, inner_conj_sym, hT, ring_hom.map_div, h₁, h₃]
       ... = re ⟪x, x⟫ - re (⟪x, y⟫ * ⟪y, x⟫ / ⟪y, y⟫)
                   : by rw [div_mul_eq_mul_div_comm, ←mul_div_assoc]
       ... = re ⟪x, x⟫ - re (⟪x, y⟫ * ⟪y, x⟫ / re ⟪y, y⟫)
@@ -407,7 +407,7 @@ lemma inner_add_left {x y z : E} : ⟪x + y, z⟫ = ⟪x, z⟫ + ⟪y, z⟫ :=
 inner_product_space.add_left _ _ _
 
 lemma inner_add_right {x y z : E} : ⟪x, y + z⟫ = ⟪x, y⟫ + ⟪x, z⟫ :=
-by { rw [←inner_conj_sym, inner_add_left, ring_equiv.map_add], simp only [inner_conj_sym] }
+by { rw [←inner_conj_sym, inner_add_left, ring_hom.map_add], simp only [inner_conj_sym] }
 
 lemma inner_re_symm {x y : E} : re ⟪x, y⟫ = re ⟪y, x⟫ :=
 by rw [←inner_conj_sym, conj_re]
@@ -423,7 +423,7 @@ lemma inner_smul_real_left {x y : E} {r : ℝ} : ⟪(r : 𝕜) • x, y⟫ = r �
 by { rw [inner_smul_left, conj_of_real, algebra.smul_def], refl }
 
 lemma inner_smul_right {x y : E} {r : 𝕜} : ⟪x, r • y⟫ = r * ⟪x, y⟫ :=
-by rw [←inner_conj_sym, inner_smul_left, ring_equiv.map_mul, conj_conj, inner_conj_sym]
+by rw [←inner_conj_sym, inner_smul_left, ring_hom.map_mul, conj_conj, inner_conj_sym]
 lemma real_inner_smul_right {x y : F} {r : ℝ} : ⟪x, r • y⟫_ℝ = r * ⟪x, y⟫_ℝ := inner_smul_right
 
 lemma inner_smul_real_right {x y : E} {r : ℝ} : ⟪x, (r : 𝕜) • y⟫ = r • ⟪x, y⟫ :=
@@ -468,13 +468,13 @@ lemma finsupp.inner_sum {ι : Type*} (l : ι →₀ 𝕜) (v : ι → E) (x : E)
 by { convert inner_sum l.support (λ a, l a • v a) x, simp [inner_smul_right, finsupp.sum] }
 
 @[simp] lemma inner_zero_left {x : E} : ⟪0, x⟫ = 0 :=
-by rw [← zero_smul 𝕜 (0:E), inner_smul_left, ring_equiv.map_zero, zero_mul]
+by rw [← zero_smul 𝕜 (0:E), inner_smul_left, ring_hom.map_zero, zero_mul]
 
 lemma inner_re_zero_left {x : E} : re ⟪0, x⟫ = 0 :=
 by simp only [inner_zero_left, add_monoid_hom.map_zero]
 
 @[simp] lemma inner_zero_right {x : E} : ⟪x, 0⟫ = 0 :=
-by rw [←inner_conj_sym, inner_zero_left, ring_equiv.map_zero]
+by rw [←inner_conj_sym, inner_zero_left, ring_hom.map_zero]
 
 lemma inner_re_zero_right {x : E} : re ⟪x, 0⟫ = 0 :=
 by simp only [inner_zero_right, add_monoid_hom.map_zero]
@@ -541,7 +541,7 @@ by rw [←inner_conj_sym, abs_conj]
 by { rw [← neg_one_smul 𝕜 x, inner_smul_left], simp }
 
 @[simp] lemma inner_neg_right {x y : E} : ⟪x, -y⟫ = -⟪x, y⟫ :=
-by rw [←inner_conj_sym, inner_neg_left]; simp only [ring_equiv.map_neg, inner_conj_sym]
+by rw [←inner_conj_sym, inner_neg_left]; simp only [ring_hom.map_neg, inner_conj_sym]
 
 lemma inner_neg_neg {x y : E} : ⟪-x, -y⟫ = ⟪x, y⟫ := by simp
 
@@ -620,7 +620,7 @@ begin
       ... = re ⟪x, x⟫ - re (T† * ⟪y, x⟫) - re (T * ⟪x, y⟫) + re (T * T† * ⟪y, y⟫)
                   : by simp only [inner_smul_left, inner_smul_right, mul_assoc]
       ... = re ⟪x, x⟫ - re (⟪x, y⟫ / ⟪y, y⟫ * ⟪y, x⟫)
-                  : by field_simp [-mul_re, hT, ring_equiv.map_div, h₁, h₃, inner_conj_sym]
+                  : by field_simp [-mul_re, hT, ring_hom.map_div, h₁, h₃, inner_conj_sym]
       ... = re ⟪x, x⟫ - re (⟪x, y⟫ * ⟪y, x⟫ / ⟪y, y⟫)
                   : by rw [div_mul_eq_mul_div_comm, ←mul_div_assoc]
       ... = re ⟪x, x⟫ - re (⟪x, y⟫ * ⟪y, x⟫ / re ⟪y, y⟫)
@@ -1481,7 +1481,8 @@ end
 
 /-- The inner product as a continuous sesquilinear map, with the two arguments flipped. -/
 def innerSL_flip : E →L[𝕜] E →L⋆[𝕜] 𝕜 :=
-continuous_linear_map.flipₗᵢ' E E 𝕜 (ring_hom.id 𝕜) (star_ring_end 𝕜) innerSL
+@continuous_linear_map.flipₗᵢ' 𝕜 𝕜 𝕜 E E 𝕜 _ _ _ _ _ _ _ _ _ (ring_hom.id 𝕜) (star_ring_end 𝕜) _ _
+  innerSL
 
 @[simp] lemma innerSL_flip_apply {x y : E} : innerSL_flip x y = ⟪y, x⟫ := rfl
 

--- a/src/analysis/inner_product_space/basic.lean
+++ b/src/analysis/inner_product_space/basic.lean
@@ -432,7 +432,7 @@ by { rw [inner_smul_right, algebra.smul_def], refl }
 /-- The inner product as a sesquilinear form. -/
 @[simps]
 def sesq_form_of_inner : E →ₗ[𝕜] E →ₗ⋆[𝕜] 𝕜 :=
-linear_map.mk₂'ₛₗ (ring_hom.id 𝕜) ((star_ring_end _).to_ring_hom)
+linear_map.mk₂'ₛₗ (ring_hom.id 𝕜) (star_ring_end _)
   (λ x y, ⟪y, x⟫)
   (λ x y z, inner_add_right)
   (λ r x y, inner_smul_right)
@@ -1481,7 +1481,7 @@ end
 
 /-- The inner product as a continuous sesquilinear map, with the two arguments flipped. -/
 def innerSL_flip : E →L[𝕜] E →L⋆[𝕜] 𝕜 :=
-continuous_linear_map.flipₗᵢ' E E 𝕜 (ring_hom.id 𝕜) (star_ring_end 𝕜 : 𝕜 →+* 𝕜) innerSL
+continuous_linear_map.flipₗᵢ' E E 𝕜 (ring_hom.id 𝕜) (star_ring_end 𝕜) innerSL
 
 @[simp] lemma innerSL_flip_apply {x y : E} : innerSL_flip x y = ⟪y, x⟫ := rfl
 
@@ -1493,7 +1493,7 @@ variables  {E' : Type*} [inner_product_space 𝕜 E']
 as a continuous linear map. -/
 def to_sesq_form : (E →L[𝕜] E') →L[𝕜] E' →L⋆[𝕜] E →L[𝕜] 𝕜 :=
 ↑((continuous_linear_map.flipₗᵢ' E E' 𝕜
-  (↑(star_ring_end 𝕜 : 𝕜 ≃+* 𝕜) : 𝕜 →+* 𝕜) (ring_hom.id 𝕜)).to_continuous_linear_equiv) ∘L
+  (star_ring_end 𝕜) (ring_hom.id 𝕜)).to_continuous_linear_equiv) ∘L
 (continuous_linear_map.compSL E E' (E' →L⋆[𝕜] 𝕜) (ring_hom.id 𝕜) (ring_hom.id 𝕜) innerSL_flip)
 
 @[simp] lemma to_sesq_form_apply_coe (f : E →L[𝕜] E') (x : E') :

--- a/src/analysis/inner_product_space/basic.lean
+++ b/src/analysis/inner_product_space/basic.lean
@@ -152,7 +152,7 @@ local notation `norm_sqK` := @is_R_or_C.norm_sq 𝕜 _
 local notation `reK` := @is_R_or_C.re 𝕜 _
 local notation `absK` := @is_R_or_C.abs 𝕜 _
 local notation `ext_iff` := @is_R_or_C.ext_iff 𝕜 _
-local postfix `†`:90 := star_ring_aut _
+local postfix `†`:90 := star_ring_end _
 
 /-- Inner product defined by the `inner_product_space.core` structure. -/
 def to_has_inner : has_inner 𝕜 F := { inner := c.inner }
@@ -386,7 +386,7 @@ local notation `⟪`x`, `y`⟫` := @inner 𝕜 _ _ x y
 local notation `IK` := @is_R_or_C.I 𝕜 _
 local notation `absR` := has_abs.abs
 local notation `absK` := @is_R_or_C.abs 𝕜 _
-local postfix `†`:90 := star_ring_aut _
+local postfix `†`:90 := star_ring_end _
 
 export inner_product_space (norm_sq_eq_inner)
 
@@ -432,7 +432,7 @@ by { rw [inner_smul_right, algebra.smul_def], refl }
 /-- The inner product as a sesquilinear form. -/
 @[simps]
 def sesq_form_of_inner : E →ₗ[𝕜] E →ₗ⋆[𝕜] 𝕜 :=
-linear_map.mk₂'ₛₗ (ring_hom.id 𝕜) ((star_ring_aut _).to_ring_hom)
+linear_map.mk₂'ₛₗ (ring_hom.id 𝕜) ((star_ring_end _).to_ring_hom)
   (λ x y, ⟪y, x⟫)
   (λ x y z, inner_add_right)
   (λ r x y, inner_smul_right)
@@ -1481,7 +1481,7 @@ end
 
 /-- The inner product as a continuous sesquilinear map, with the two arguments flipped. -/
 def innerSL_flip : E →L[𝕜] E →L⋆[𝕜] 𝕜 :=
-continuous_linear_map.flipₗᵢ' E E 𝕜 (ring_hom.id 𝕜) (star_ring_aut 𝕜 : 𝕜 →+* 𝕜) innerSL
+continuous_linear_map.flipₗᵢ' E E 𝕜 (ring_hom.id 𝕜) (star_ring_end 𝕜 : 𝕜 →+* 𝕜) innerSL
 
 @[simp] lemma innerSL_flip_apply {x y : E} : innerSL_flip x y = ⟪y, x⟫ := rfl
 
@@ -1493,7 +1493,7 @@ variables  {E' : Type*} [inner_product_space 𝕜 E']
 as a continuous linear map. -/
 def to_sesq_form : (E →L[𝕜] E') →L[𝕜] E' →L⋆[𝕜] E →L[𝕜] 𝕜 :=
 ↑((continuous_linear_map.flipₗᵢ' E E' 𝕜
-  (↑(star_ring_aut 𝕜 : 𝕜 ≃+* 𝕜) : 𝕜 →+* 𝕜) (ring_hom.id 𝕜)).to_continuous_linear_equiv) ∘L
+  (↑(star_ring_end 𝕜 : 𝕜 ≃+* 𝕜) : 𝕜 →+* 𝕜) (ring_hom.id 𝕜)).to_continuous_linear_equiv) ∘L
 (continuous_linear_map.compSL E E' (E' →L⋆[𝕜] 𝕜) (ring_hom.id 𝕜) (ring_hom.id 𝕜) innerSL_flip)
 
 @[simp] lemma to_sesq_form_apply_coe (f : E →L[𝕜] E') (x : E') :

--- a/src/analysis/inner_product_space/basic.lean
+++ b/src/analysis/inner_product_space/basic.lean
@@ -152,7 +152,7 @@ local notation `norm_sqK` := @is_R_or_C.norm_sq 𝕜 _
 local notation `reK` := @is_R_or_C.re 𝕜 _
 local notation `absK` := @is_R_or_C.abs 𝕜 _
 local notation `ext_iff` := @is_R_or_C.ext_iff 𝕜 _
-local postfix `†`:90 := star_ring_aut
+local postfix `†`:90 := star_ring_aut _
 
 /-- Inner product defined by the `inner_product_space.core` structure. -/
 def to_has_inner : has_inner 𝕜 F := { inner := c.inner }
@@ -386,7 +386,7 @@ local notation `⟪`x`, `y`⟫` := @inner 𝕜 _ _ x y
 local notation `IK` := @is_R_or_C.I 𝕜 _
 local notation `absR` := has_abs.abs
 local notation `absK` := @is_R_or_C.abs 𝕜 _
-local postfix `†`:90 := star_ring_aut
+local postfix `†`:90 := star_ring_aut _
 
 export inner_product_space (norm_sq_eq_inner)
 
@@ -432,7 +432,7 @@ by { rw [inner_smul_right, algebra.smul_def], refl }
 /-- The inner product as a sesquilinear form. -/
 @[simps]
 def sesq_form_of_inner : E →ₗ[𝕜] E →ₗ⋆[𝕜] 𝕜 :=
-linear_map.mk₂'ₛₗ (ring_hom.id 𝕜) (star_ring_aut.to_ring_hom)
+linear_map.mk₂'ₛₗ (ring_hom.id 𝕜) ((star_ring_aut _).to_ring_hom)
   (λ x y, ⟪y, x⟫)
   (λ x y z, inner_add_right)
   (λ r x y, inner_smul_right)
@@ -1481,7 +1481,7 @@ end
 
 /-- The inner product as a continuous sesquilinear map, with the two arguments flipped. -/
 def innerSL_flip : E →L[𝕜] E →L⋆[𝕜] 𝕜 :=
-continuous_linear_map.flipₗᵢ' E E 𝕜 (ring_hom.id 𝕜) (↑star_ring_aut : 𝕜 →+* 𝕜) innerSL
+continuous_linear_map.flipₗᵢ' E E 𝕜 (ring_hom.id 𝕜) (star_ring_aut 𝕜 : 𝕜 →+* 𝕜) innerSL
 
 @[simp] lemma innerSL_flip_apply {x y : E} : innerSL_flip x y = ⟪y, x⟫ := rfl
 
@@ -1493,7 +1493,7 @@ variables  {E' : Type*} [inner_product_space 𝕜 E']
 as a continuous linear map. -/
 def to_sesq_form : (E →L[𝕜] E') →L[𝕜] E' →L⋆[𝕜] E →L[𝕜] 𝕜 :=
 ↑((continuous_linear_map.flipₗᵢ' E E' 𝕜
-  (↑(star_ring_aut : 𝕜 ≃+* 𝕜) : 𝕜 →+* 𝕜) (ring_hom.id 𝕜)).to_continuous_linear_equiv) ∘L
+  (↑(star_ring_aut 𝕜 : 𝕜 ≃+* 𝕜) : 𝕜 →+* 𝕜) (ring_hom.id 𝕜)).to_continuous_linear_equiv) ∘L
 (continuous_linear_map.compSL E E' (E' →L⋆[𝕜] 𝕜) (ring_hom.id 𝕜) (ring_hom.id 𝕜) innerSL_flip)
 
 @[simp] lemma to_sesq_form_apply_coe (f : E →L[𝕜] E') (x : E') :

--- a/src/analysis/inner_product_space/dual.lean
+++ b/src/analysis/inner_product_space/dual.lean
@@ -39,7 +39,7 @@ open is_R_or_C continuous_linear_map
 variables (𝕜 : Type*)
 variables (E : Type*) [is_R_or_C 𝕜] [inner_product_space 𝕜 E]
 local notation `⟪`x`, `y`⟫` := @inner 𝕜 E _ x y
-local postfix `†`:90 := star_ring_aut
+local postfix `†`:90 := star_ring_aut _
 
 /--
 An element `x` of an inner product space `E` induces an element of the dual space `dual 𝕜 E`,

--- a/src/analysis/inner_product_space/dual.lean
+++ b/src/analysis/inner_product_space/dual.lean
@@ -39,7 +39,7 @@ open is_R_or_C continuous_linear_map
 variables (𝕜 : Type*)
 variables (E : Type*) [is_R_or_C 𝕜] [inner_product_space 𝕜 E]
 local notation `⟪`x`, `y`⟫` := @inner 𝕜 E _ x y
-local postfix `†`:90 := star_ring_aut _
+local postfix `†`:90 := star_ring_end _
 
 /--
 An element `x` of an inner product space `E` induces an element of the dual space `dual 𝕜 E`,

--- a/src/analysis/inner_product_space/dual.lean
+++ b/src/analysis/inner_product_space/dual.lean
@@ -96,7 +96,7 @@ begin
       exact sub_eq_zero.mp (eq.symm h₃) },
     have h₄ := calc
       ⟪((ℓ z)† / ⟪z, z⟫) • z, x⟫ = (ℓ z) / ⟪z, z⟫ * ⟪z, x⟫
-            : by simp [inner_smul_left, ring_equiv.map_div, conj_conj]
+            : by simp [inner_smul_left, ring_hom.map_div, conj_conj]
                             ... = (ℓ z) * ⟪z, x⟫ / ⟪z, z⟫
             : by rw [←div_mul_eq_mul_div]
                             ... = (ℓ x) * ⟪z, z⟫ / ⟪z, z⟫

--- a/src/analysis/inner_product_space/pi_L2.lean
+++ b/src/analysis/inner_product_space/pi_L2.lean
@@ -71,7 +71,7 @@ instance pi_Lp.inner_product_space {ι : Type*} [fintype ι] (f : ι → Type*)
   begin
     intros x y,
     unfold inner,
-    rw ring_equiv.map_sum,
+    rw ring_hom.map_sum,
     apply finset.sum_congr rfl,
     rintros z -,
     apply inner_conj_sym,

--- a/src/analysis/normed_space/linear_isometry.lean
+++ b/src/analysis/normed_space/linear_isometry.lean
@@ -48,7 +48,7 @@ structure linear_isometry (σ₁₂ : R →+* R₂) (E E₂ : Type*) [semi_norme
 
 notation E ` →ₛₗᵢ[`:25 σ₁₂:25 `] `:0 E₂:0 := linear_isometry σ₁₂ E E₂
 notation E ` →ₗᵢ[`:25 R:25 `] `:0 E₂:0 := linear_isometry (ring_hom.id R) E E₂
-notation E ` →ₗᵢ⋆[`:25 R:25 `] `:0 E₂:0 := linear_isometry (star_ring_aut R : R →+* R) E E₂
+notation E ` →ₗᵢ⋆[`:25 R:25 `] `:0 E₂:0 := linear_isometry (star_ring_end R : R →+* R) E E₂
 
 namespace linear_isometry
 
@@ -216,7 +216,7 @@ structure linear_isometry_equiv (σ₁₂ : R →+* R₂) {σ₂₁ : R₂ →+*
 notation E ` ≃ₛₗᵢ[`:25 σ₁₂:25 `] `:0 E₂:0 := linear_isometry_equiv σ₁₂ E E₂
 notation E ` ≃ₗᵢ[`:25 R:25 `] `:0 E₂:0 := linear_isometry_equiv (ring_hom.id R) E E₂
 notation E ` ≃ₗᵢ⋆[`:25 R:25 `] `:0 E₂:0 :=
-  linear_isometry_equiv (star_ring_aut R : R →+* R) E E₂
+  linear_isometry_equiv (star_ring_end R : R →+* R) E E₂
 
 namespace linear_isometry_equiv
 

--- a/src/analysis/normed_space/linear_isometry.lean
+++ b/src/analysis/normed_space/linear_isometry.lean
@@ -48,7 +48,7 @@ structure linear_isometry (σ₁₂ : R →+* R₂) (E E₂ : Type*) [semi_norme
 
 notation E ` →ₛₗᵢ[`:25 σ₁₂:25 `] `:0 E₂:0 := linear_isometry σ₁₂ E E₂
 notation E ` →ₗᵢ[`:25 R:25 `] `:0 E₂:0 := linear_isometry (ring_hom.id R) E E₂
-notation E ` →ₗᵢ⋆[`:25 R:25 `] `:0 E₂:0 := linear_isometry (star_ring_end R : R →+* R) E E₂
+notation E ` →ₗᵢ⋆[`:25 R:25 `] `:0 E₂:0 := linear_isometry (star_ring_end R) E E₂
 
 namespace linear_isometry
 
@@ -216,7 +216,7 @@ structure linear_isometry_equiv (σ₁₂ : R →+* R₂) {σ₂₁ : R₂ →+*
 notation E ` ≃ₛₗᵢ[`:25 σ₁₂:25 `] `:0 E₂:0 := linear_isometry_equiv σ₁₂ E E₂
 notation E ` ≃ₗᵢ[`:25 R:25 `] `:0 E₂:0 := linear_isometry_equiv (ring_hom.id R) E E₂
 notation E ` ≃ₗᵢ⋆[`:25 R:25 `] `:0 E₂:0 :=
-  linear_isometry_equiv (star_ring_end R : R →+* R) E E₂
+  linear_isometry_equiv (star_ring_end R) E E₂
 
 namespace linear_isometry_equiv
 

--- a/src/analysis/normed_space/linear_isometry.lean
+++ b/src/analysis/normed_space/linear_isometry.lean
@@ -48,7 +48,7 @@ structure linear_isometry (σ₁₂ : R →+* R₂) (E E₂ : Type*) [semi_norme
 
 notation E ` →ₛₗᵢ[`:25 σ₁₂:25 `] `:0 E₂:0 := linear_isometry σ₁₂ E E₂
 notation E ` →ₗᵢ[`:25 R:25 `] `:0 E₂:0 := linear_isometry (ring_hom.id R) E E₂
-notation E ` →ₗᵢ⋆[`:25 R:25 `] `:0 E₂:0 := linear_isometry (@star_ring_aut R _ _ : R →+* R) E E₂
+notation E ` →ₗᵢ⋆[`:25 R:25 `] `:0 E₂:0 := linear_isometry (star_ring_aut R : R →+* R) E E₂
 
 namespace linear_isometry
 
@@ -216,7 +216,7 @@ structure linear_isometry_equiv (σ₁₂ : R →+* R₂) {σ₂₁ : R₂ →+*
 notation E ` ≃ₛₗᵢ[`:25 σ₁₂:25 `] `:0 E₂:0 := linear_isometry_equiv σ₁₂ E E₂
 notation E ` ≃ₗᵢ[`:25 R:25 `] `:0 E₂:0 := linear_isometry_equiv (ring_hom.id R) E E₂
 notation E ` ≃ₗᵢ⋆[`:25 R:25 `] `:0 E₂:0 :=
-  linear_isometry_equiv (@star_ring_aut R _ _ : R →+* R) E E₂
+  linear_isometry_equiv (star_ring_aut R : R →+* R) E E₂
 
 namespace linear_isometry_equiv
 

--- a/src/analysis/normed_space/star.lean
+++ b/src/analysis/normed_space/star.lean
@@ -95,8 +95,8 @@ lemma continuous_within_at.star {f : α → E} {s : set α} {x : α}
 
 end normed_star_monoid
 
-instance ring_hom_isometric.star_ring_aut [normed_comm_ring E] [star_ring E]
-   [normed_star_monoid E] : ring_hom_isometric (star_ring_aut E : E →+* E) :=
+instance ring_hom_isometric.star_ring_end [normed_comm_ring E] [star_ring E]
+   [normed_star_monoid E] : ring_hom_isometric (star_ring_end E : E →+* E) :=
 ⟨λ _, norm_star⟩
 
 namespace cstar_ring

--- a/src/analysis/normed_space/star.lean
+++ b/src/analysis/normed_space/star.lean
@@ -96,7 +96,7 @@ lemma continuous_within_at.star {f : α → E} {s : set α} {x : α}
 end normed_star_monoid
 
 instance ring_hom_isometric.star_ring_aut [normed_comm_ring E] [star_ring E]
-   [normed_star_monoid E] : ring_hom_isometric ((star_ring_aut : ring_aut E) : E →+* E) :=
+   [normed_star_monoid E] : ring_hom_isometric (star_ring_aut E : E →+* E) :=
 ⟨λ _, norm_star⟩
 
 namespace cstar_ring

--- a/src/analysis/normed_space/star.lean
+++ b/src/analysis/normed_space/star.lean
@@ -96,7 +96,7 @@ lemma continuous_within_at.star {f : α → E} {s : set α} {x : α}
 end normed_star_monoid
 
 instance ring_hom_isometric.star_ring_end [normed_comm_ring E] [star_ring E]
-   [normed_star_monoid E] : ring_hom_isometric (star_ring_end E : E →+* E) :=
+   [normed_star_monoid E] : ring_hom_isometric (star_ring_end E) :=
 ⟨λ _, norm_star⟩
 
 namespace cstar_ring

--- a/src/data/complex/basic.lean
+++ b/src/data/complex/basic.lean
@@ -186,7 +186,7 @@ by rw [pow_bit1', I_mul_I]
 /-! ### Complex conjugation -/
 
 /-- This defines the complex conjugate as the `star` operation of the `star_ring ℂ`. It
-is recommended to use the ring automorphism version `star_ring_end`, available under the
+is recommended to use the ring endomorphism version `star_ring_end`, available under the
 notation `conj` in the locale `complex_conjugate`. -/
 instance : star_ring ℂ :=
 { star := λ z, ⟨z.re, -z.im⟩,
@@ -301,7 +301,7 @@ ext_iff.2 $ by simp [two_mul, sub_eq_add_neg]
 lemma norm_sq_sub (z w : ℂ) : norm_sq (z - w) =
   norm_sq z + norm_sq w - 2 * (z * conj w).re :=
 by { rw [sub_eq_add_neg, norm_sq_add],
-     simp only [ring_equiv.map_neg, mul_neg_eq_neg_mul_symm, neg_re,
+     simp only [ring_hom.map_neg, mul_neg_eq_neg_mul_symm, neg_re,
                 tactic.ring.add_neg_eq_sub, norm_sq_neg] }
 
 /-! ### Inversion -/
@@ -650,7 +650,7 @@ by rw [lim_eq_lim_im_add_lim_re]; simp
 
 lemma is_cau_seq_conj (f : cau_seq ℂ abs) : is_cau_seq abs (λ n, conj (f n)) :=
 λ ε ε0, let ⟨i, hi⟩ := f.2 ε ε0 in
-⟨i, λ j hj, by rw [← ring_equiv.map_sub, abs_conj]; exact hi j hj⟩
+⟨i, λ j hj, by rw [← ring_hom.map_sub, abs_conj]; exact hi j hj⟩
 
 /-- The complex conjugate of a complex Cauchy sequence, as a complex Cauchy sequence. -/
 noncomputable def cau_seq_conj (f : cau_seq ℂ abs) : cau_seq ℂ abs :=

--- a/src/data/complex/basic.lean
+++ b/src/data/complex/basic.lean
@@ -186,7 +186,7 @@ by rw [pow_bit1', I_mul_I]
 /-! ### Complex conjugation -/
 
 /-- This defines the complex conjugate as the `star` operation of the `star_ring ℂ`. It
-is recommended to use the ring automorphism version `star_ring_aut`, available under the
+is recommended to use the ring automorphism version `star_ring_end`, available under the
 notation `conj` in the locale `complex_conjugate`. -/
 instance : star_ring ℂ :=
 { star := λ z, ⟨z.re, -z.im⟩,

--- a/src/data/complex/exponential.lean
+++ b/src/data/complex/exponential.lean
@@ -477,7 +477,7 @@ begin
   dsimp [exp', function.comp, cau_seq_conj],
   rw (star_ring_end _).map_sum,
   refine sum_congr rfl (λ n hn, _),
-  rw [ring_equiv.map_div, ring_equiv.map_pow, ← of_real_nat_cast, conj_of_real]
+  rw [ring_hom.map_div, ring_hom.map_pow, ← of_real_nat_cast, conj_of_real]
 end
 
 @[simp] lemma of_real_exp_of_real_re (x : ℝ) : ((exp x).re : ℂ) = exp x :=

--- a/src/data/complex/exponential.lean
+++ b/src/data/complex/exponential.lean
@@ -475,7 +475,7 @@ begin
   rw [← lim_conj],
   refine congr_arg lim (cau_seq.ext (λ _, _)),
   dsimp [exp', function.comp, cau_seq_conj],
-  rw (star_ring_aut _).map_sum,
+  rw (star_ring_end _).map_sum,
   refine sum_congr rfl (λ n hn, _),
   rw [ring_equiv.map_div, ring_equiv.map_pow, ← of_real_nat_cast, conj_of_real]
 end

--- a/src/data/complex/exponential.lean
+++ b/src/data/complex/exponential.lean
@@ -540,8 +540,8 @@ lemma cosh_sub : cosh (x - y) = cosh x * cosh y - sinh x * sinh y :=
 by simp [sub_eq_add_neg, cosh_add, sinh_neg, cosh_neg]
 
 lemma sinh_conj : sinh (conj x) = conj (sinh x) :=
-by rw [sinh, ← ring_equiv.map_neg, exp_conj, exp_conj, ← ring_equiv.map_sub, sinh,
-  ring_equiv.map_div, conj_bit0, ring_equiv.map_one]
+by rw [sinh, ← ring_hom.map_neg, exp_conj, exp_conj, ← ring_hom.map_sub, sinh,
+  ring_hom.map_div, conj_bit0, ring_hom.map_one]
 
 @[simp] lemma of_real_sinh_of_real_re (x : ℝ) : ((sinh x).re : ℂ) = sinh x :=
 eq_conj_iff_re.1 $ by rw [← sinh_conj, conj_of_real]
@@ -556,8 +556,8 @@ lemma sinh_of_real_re (x : ℝ) : (sinh x).re = real.sinh x := rfl
 
 lemma cosh_conj : cosh (conj x) = conj (cosh x) :=
 begin
-  rw [cosh, ← ring_equiv.map_neg, exp_conj, exp_conj, ← ring_equiv.map_add, cosh,
-      ring_equiv.map_div, conj_bit0, ring_equiv.map_one]
+  rw [cosh, ← ring_hom.map_neg, exp_conj, exp_conj, ← ring_hom.map_add, cosh,
+      ring_hom.map_div, conj_bit0, ring_hom.map_one]
 end
 
 @[simp] lemma of_real_cosh_of_real_re (x : ℝ) : ((cosh x).re : ℂ) = cosh x :=
@@ -578,7 +578,7 @@ lemma tanh_eq_sinh_div_cosh : tanh x = sinh x / cosh x := rfl
 @[simp] lemma tanh_neg : tanh (-x) = -tanh x := by simp [tanh, neg_div]
 
 lemma tanh_conj : tanh (conj x) = conj (tanh x) :=
-by rw [tanh, sinh_conj, cosh_conj, ← ring_equiv.map_div, tanh]
+by rw [tanh, sinh_conj, cosh_conj, ← ring_hom.map_div, tanh]
 
 @[simp] lemma of_real_tanh_of_real_re (x : ℝ) : ((tanh x).re : ℂ) = tanh x :=
 eq_conj_iff_re.1 $ by rw [← tanh_conj, conj_of_real]
@@ -751,7 +751,7 @@ end
 
 lemma sin_conj : sin (conj x) = conj (sin x) :=
 by rw [← mul_left_inj' I_ne_zero, ← sinh_mul_I,
-       ← conj_neg_I, ← ring_equiv.map_mul, ← ring_equiv.map_mul, sinh_conj,
+       ← conj_neg_I, ← ring_hom.map_mul, ← ring_hom.map_mul, sinh_conj,
        mul_neg_eq_neg_mul_symm, sinh_neg, sinh_mul_I, mul_neg_eq_neg_mul_symm]
 
 @[simp] lemma of_real_sin_of_real_re (x : ℝ) : ((sin x).re : ℂ) = sin x :=
@@ -766,7 +766,7 @@ by rw [← of_real_sin_of_real_re, of_real_im]
 lemma sin_of_real_re (x : ℝ) : (sin x).re = real.sin x := rfl
 
 lemma cos_conj : cos (conj x) = conj (cos x) :=
-by rw [← cosh_mul_I, ← conj_neg_I, ← ring_equiv.map_mul, ← cosh_mul_I,
+by rw [← cosh_mul_I, ← conj_neg_I, ← ring_hom.map_mul, ← cosh_mul_I,
        cosh_conj, mul_neg_eq_neg_mul_symm, cosh_neg]
 
 @[simp] lemma of_real_cos_of_real_re (x : ℝ) : ((cos x).re : ℂ) = cos x :=
@@ -790,7 +790,7 @@ by rw [tan_eq_sin_div_cos, div_mul_cancel _ hx]
 @[simp] lemma tan_neg : tan (-x) = -tan x := by simp [tan, neg_div]
 
 lemma tan_conj : tan (conj x) = conj (tan x) :=
-by rw [tan, sin_conj, cos_conj, ← ring_equiv.map_div, tan]
+by rw [tan, sin_conj, cos_conj, ← ring_hom.map_div, tan]
 
 @[simp] lemma of_real_tan_of_real_re (x : ℝ) : ((tan x).re : ℂ) = tan x :=
 eq_conj_iff_re.1 $ by rw [← tan_conj, conj_of_real]

--- a/src/data/complex/exponential.lean
+++ b/src/data/complex/exponential.lean
@@ -475,7 +475,7 @@ begin
   rw [← lim_conj],
   refine congr_arg lim (cau_seq.ext (λ _, _)),
   dsimp [exp', function.comp, cau_seq_conj],
-  rw star_ring_aut.map_sum,
+  rw (star_ring_aut _).map_sum,
   refine sum_congr rfl (λ n hn, _),
   rw [ring_equiv.map_div, ring_equiv.map_pow, ← of_real_nat_cast, conj_of_real]
 end

--- a/src/data/complex/is_R_or_C.lean
+++ b/src/data/complex/is_R_or_C.lean
@@ -204,7 +204,7 @@ begin
       convert (re_add_im z).symm, simp [this] },
     contrapose! h,
     rw ← re_add_im z,
-    simp only [conj_of_real, ring_equiv.map_add, ring_equiv.map_mul, conj_I_ax],
+    simp only [conj_of_real, ring_hom.map_add, ring_hom.map_mul, conj_I_ax],
     rw [add_left_cancel_iff, ext_iff],
     simpa [neg_eq_iff_add_eq_zero, add_self_eq_zero] },
   { rintros ⟨r, rfl⟩, apply conj_of_real }
@@ -666,7 +666,7 @@ noncomputable instance real.is_R_or_C : is_R_or_C ℝ :=
   mul_im_ax := λ z w, by simp only [add_zero, zero_mul, mul_zero, add_monoid_hom.zero_apply],
   conj_re_ax := λ z, by simp only [star_ring_end_apply, star_id_of_comm],
   conj_im_ax := λ z, by simp only [neg_zero, add_monoid_hom.zero_apply],
-  conj_I_ax := by simp only [ring_equiv.map_zero, neg_zero],
+  conj_I_ax := by simp only [ring_hom.map_zero, neg_zero],
   norm_sq_eq_def_ax := λ z, by simp only [sq, norm, ←abs_mul, abs_mul_self z, add_zero,
     mul_zero, add_monoid_hom.zero_apply, add_monoid_hom.id_apply],
   mul_im_I_ax := λ z, by simp only [mul_zero, add_monoid_hom.zero_apply],
@@ -749,8 +749,11 @@ linear_map.mk_continuous im_lm 1 $ by
 
 /-- Conjugate as an `ℝ`-algebra equivalence -/
 noncomputable def conj_ae : K ≃ₐ[ℝ] K :=
-{ commutes' := conj_of_real,
-  .. star_ring_end K }
+{ inv_fun := conj,
+  left_inv := conj_conj,
+  right_inv := conj_conj,
+  commutes' := conj_of_real,
+  .. conj }
 
 @[simp] lemma conj_ae_coe : (conj_ae : K → K) = conj := rfl
 

--- a/src/data/complex/is_R_or_C.lean
+++ b/src/data/complex/is_R_or_C.lean
@@ -664,13 +664,13 @@ noncomputable instance real.is_R_or_C : is_R_or_C ℝ :=
   mul_re_ax := λ z w,
     by simp only [sub_zero, mul_zero, add_monoid_hom.zero_apply, add_monoid_hom.id_apply],
   mul_im_ax := λ z w, by simp only [add_zero, zero_mul, mul_zero, add_monoid_hom.zero_apply],
-  conj_re_ax := λ z, by simp only [star_ring_aut_apply, star_id_of_comm],
+  conj_re_ax := λ z, by simp only [star_ring_end_apply, star_id_of_comm],
   conj_im_ax := λ z, by simp only [neg_zero, add_monoid_hom.zero_apply],
   conj_I_ax := by simp only [ring_equiv.map_zero, neg_zero],
   norm_sq_eq_def_ax := λ z, by simp only [sq, norm, ←abs_mul, abs_mul_self z, add_zero,
     mul_zero, add_monoid_hom.zero_apply, add_monoid_hom.id_apply],
   mul_im_I_ax := λ z, by simp only [mul_zero, add_monoid_hom.zero_apply],
-  inv_def_ax := λ z, by simp only [star_ring_aut_apply, star, sq, real.norm_eq_abs,
+  inv_def_ax := λ z, by simp only [star_ring_end_apply, star, sq, real.norm_eq_abs,
     abs_mul_abs_self, ←div_eq_mul_inv, algebra.id.map_eq_id, id.def, ring_hom.id_apply,
     div_self_mul_self'],
   div_I_ax := λ z, by simp only [div_zero, mul_zero, neg_zero]}
@@ -750,7 +750,7 @@ linear_map.mk_continuous im_lm 1 $ by
 /-- Conjugate as an `ℝ`-algebra equivalence -/
 noncomputable def conj_ae : K ≃ₐ[ℝ] K :=
 { commutes' := conj_of_real,
-  .. star_ring_aut K }
+  .. star_ring_end K }
 
 @[simp] lemma conj_ae_coe : (conj_ae : K → K) = conj := rfl
 

--- a/src/data/complex/is_R_or_C.lean
+++ b/src/data/complex/is_R_or_C.lean
@@ -750,7 +750,7 @@ linear_map.mk_continuous im_lm 1 $ by
 /-- Conjugate as an `ℝ`-algebra equivalence -/
 noncomputable def conj_ae : K ≃ₐ[ℝ] K :=
 { commutes' := conj_of_real,
-  .. star_ring_aut }
+  .. star_ring_aut K }
 
 @[simp] lemma conj_ae_coe : (conj_ae : K → K) = conj := rfl
 

--- a/src/data/equiv/module.lean
+++ b/src/data/equiv/module.lean
@@ -58,7 +58,7 @@ attribute [nolint doc_blame] linear_equiv.to_add_equiv
 
 notation M ` ≃ₛₗ[`:50 σ `] ` M₂ := linear_equiv σ M M₂
 notation M ` ≃ₗ[`:50 R `] ` M₂ := linear_equiv (ring_hom.id R) M M₂
-notation M ` ≃ₗ⋆[`:50 R `] ` M₂ := linear_equiv (@star_ring_aut R _ _ : R →+* R) M M₂
+notation M ` ≃ₗ⋆[`:50 R `] ` M₂ := linear_equiv (star_ring_aut R : R →+* R) M M₂
 
 namespace linear_equiv
 

--- a/src/data/equiv/module.lean
+++ b/src/data/equiv/module.lean
@@ -14,7 +14,7 @@ In this file we define
 * `linear_equiv σ M M₂`, `M ≃ₛₗ[σ] M₂`: an invertible semilinear map. Here, `σ` is a `ring_hom`
   from `R` to `R₂` and an `e : M ≃ₛₗ[σ] M₂` satisfies `e (c • x) = (σ c) • (e x)`. The plain
   linear version, with `σ` being `ring_hom.id R`, is denoted by `M ≃ₗ[R] M₂`, and the
-  star-linear version (with `σ` begin `star_ring_end`) is denoted by `M ≃ₗ⋆[R] M₂`.
+  star-linear version (with `σ` being `star_ring_end`) is denoted by `M ≃ₗ⋆[R] M₂`.
 
 ## Implementation notes
 

--- a/src/data/equiv/module.lean
+++ b/src/data/equiv/module.lean
@@ -14,7 +14,7 @@ In this file we define
 * `linear_equiv σ M M₂`, `M ≃ₛₗ[σ] M₂`: an invertible semilinear map. Here, `σ` is a `ring_hom`
   from `R` to `R₂` and an `e : M ≃ₛₗ[σ] M₂` satisfies `e (c • x) = (σ c) • (e x)`. The plain
   linear version, with `σ` being `ring_hom.id R`, is denoted by `M ≃ₗ[R] M₂`, and the
-  star-linear version (with `σ` begin `star_ring_aut`) is denoted by `M ≃ₗ⋆[R] M₂`.
+  star-linear version (with `σ` begin `star_ring_end`) is denoted by `M ≃ₗ⋆[R] M₂`.
 
 ## Implementation notes
 
@@ -58,7 +58,7 @@ attribute [nolint doc_blame] linear_equiv.to_add_equiv
 
 notation M ` ≃ₛₗ[`:50 σ `] ` M₂ := linear_equiv σ M M₂
 notation M ` ≃ₗ[`:50 R `] ` M₂ := linear_equiv (ring_hom.id R) M M₂
-notation M ` ≃ₗ⋆[`:50 R `] ` M₂ := linear_equiv (star_ring_aut R : R →+* R) M M₂
+notation M ` ≃ₗ⋆[`:50 R `] ` M₂ := linear_equiv (star_ring_end R) M M₂
 
 namespace linear_equiv
 

--- a/src/linear_algebra/matrix/adjugate.lean
+++ b/src/linear_algebra/matrix/adjugate.lean
@@ -346,7 +346,7 @@ lemma adjugate_conj_transpose [star_ring α] (A : matrix n n α) : A.adjugateᴴ
 begin
   dsimp only [conj_transpose],
   have : Aᵀ.adjugate.map star = adjugate (Aᵀ.map star) :=
-    ((star_ring_aut α).to_ring_hom.map_adjugate Aᵀ),
+    ((star_ring_end α).to_ring_hom.map_adjugate Aᵀ),
   rw [A.adjugate_transpose, this],
 end
 

--- a/src/linear_algebra/matrix/adjugate.lean
+++ b/src/linear_algebra/matrix/adjugate.lean
@@ -346,7 +346,7 @@ lemma adjugate_conj_transpose [star_ring α] (A : matrix n n α) : A.adjugateᴴ
 begin
   dsimp only [conj_transpose],
   have : Aᵀ.adjugate.map star = adjugate (Aᵀ.map star) :=
-    ((star_ring_aut : α ≃+* α).to_ring_hom.map_adjugate Aᵀ),
+    ((star_ring_aut α).to_ring_hom.map_adjugate Aᵀ),
   rw [A.adjugate_transpose, this],
 end
 

--- a/src/linear_algebra/matrix/adjugate.lean
+++ b/src/linear_algebra/matrix/adjugate.lean
@@ -345,8 +345,7 @@ adjugate_fin_two _
 lemma adjugate_conj_transpose [star_ring α] (A : matrix n n α) : A.adjugateᴴ = adjugate (Aᴴ) :=
 begin
   dsimp only [conj_transpose],
-  have : Aᵀ.adjugate.map star = adjugate (Aᵀ.map star) :=
-    ((star_ring_end α).to_ring_hom.map_adjugate Aᵀ),
+  have : Aᵀ.adjugate.map star = adjugate (Aᵀ.map star) := ((star_ring_end α).map_adjugate Aᵀ),
   rw [A.adjugate_transpose, this],
 end
 

--- a/src/linear_algebra/matrix/determinant.lean
+++ b/src/linear_algebra/matrix/determinant.lean
@@ -286,7 +286,7 @@ f.to_alg_hom.map_det _
 end hom_map
 
 @[simp] lemma det_conj_transpose [star_ring R] (M : matrix m m R) : det (Mᴴ) = star (det M) :=
-((star_ring_aut : ring_aut R).map_det _).symm.trans $ congr_arg star M.det_transpose
+((star_ring_aut R).map_det _).symm.trans $ congr_arg star M.det_transpose
 
 section det_zero
 /-!

--- a/src/linear_algebra/matrix/determinant.lean
+++ b/src/linear_algebra/matrix/determinant.lean
@@ -286,7 +286,7 @@ f.to_alg_hom.map_det _
 end hom_map
 
 @[simp] lemma det_conj_transpose [star_ring R] (M : matrix m m R) : det (Mᴴ) = star (det M) :=
-((star_ring_aut R).map_det _).symm.trans $ congr_arg star M.det_transpose
+((star_ring_end R).map_det _).symm.trans $ congr_arg star M.det_transpose
 
 section det_zero
 /-!

--- a/src/number_theory/modular.lean
+++ b/src/number_theory/modular.lean
@@ -144,7 +144,7 @@ begin
       rw [f_def, add_im, of_real_mul_im, of_real_im, add_zero, mul_left_comm,
         inv_mul_cancel hz, mul_one], },
     { show ((z : ℂ).im)⁻¹ * ((z : ℂ) * conj (f c)).im = c 1,
-      rw [f_def, ring_equiv.map_add, ring_equiv.map_mul, mul_add, mul_left_comm, mul_conj,
+      rw [f_def, ring_hom.map_add, ring_hom.map_mul, mul_add, mul_left_comm, mul_conj,
         conj_of_real, conj_of_real, ← of_real_mul, add_im, of_real_im, zero_add,
         inv_mul_eq_iff_eq_mul₀ hz],
       simp only [of_real_im, of_real_re, mul_im, zero_add, mul_zero] } },

--- a/src/topology/algebra/module/basic.lean
+++ b/src/topology/algebra/module/basic.lean
@@ -231,7 +231,7 @@ structure continuous_linear_map
 
 notation M ` →SL[`:25 σ `] ` M₂ := continuous_linear_map σ M M₂
 notation M ` →L[`:25 R `] ` M₂ := continuous_linear_map (ring_hom.id R) M M₂
-notation M ` →L⋆[`:25 R `] ` M₂ := continuous_linear_map (star_ring_aut R : R →+* R) M M₂
+notation M ` →L⋆[`:25 R `] ` M₂ := continuous_linear_map (star_ring_end R : R →+* R) M M₂
 
 /-- Continuous linear equivalences between modules. We only put the type classes that are necessary
 for the definition, although in applications `M` and `M₂` will be topological modules over the
@@ -249,7 +249,7 @@ structure continuous_linear_equiv
 
 notation M ` ≃SL[`:50 σ `] ` M₂ := continuous_linear_equiv σ M M₂
 notation M ` ≃L[`:50 R `] ` M₂ := continuous_linear_equiv (ring_hom.id R) M M₂
-notation M ` ≃L⋆[`:50 R `] ` M₂ := continuous_linear_equiv (star_ring_aut R : R →+* R) M M₂
+notation M ` ≃L⋆[`:50 R `] ` M₂ := continuous_linear_equiv (star_ring_end R : R →+* R) M M₂
 
 section pointwise_limits
 

--- a/src/topology/algebra/module/basic.lean
+++ b/src/topology/algebra/module/basic.lean
@@ -231,7 +231,7 @@ structure continuous_linear_map
 
 notation M ` →SL[`:25 σ `] ` M₂ := continuous_linear_map σ M M₂
 notation M ` →L[`:25 R `] ` M₂ := continuous_linear_map (ring_hom.id R) M M₂
-notation M ` →L⋆[`:25 R `] ` M₂ := continuous_linear_map (star_ring_end R : R →+* R) M M₂
+notation M ` →L⋆[`:25 R `] ` M₂ := continuous_linear_map (star_ring_end R) M M₂
 
 /-- Continuous linear equivalences between modules. We only put the type classes that are necessary
 for the definition, although in applications `M` and `M₂` will be topological modules over the
@@ -249,7 +249,7 @@ structure continuous_linear_equiv
 
 notation M ` ≃SL[`:50 σ `] ` M₂ := continuous_linear_equiv σ M M₂
 notation M ` ≃L[`:50 R `] ` M₂ := continuous_linear_equiv (ring_hom.id R) M M₂
-notation M ` ≃L⋆[`:50 R `] ` M₂ := continuous_linear_equiv (star_ring_end R : R →+* R) M M₂
+notation M ` ≃L⋆[`:50 R `] ` M₂ := continuous_linear_equiv (star_ring_end R) M M₂
 
 section pointwise_limits
 

--- a/src/topology/algebra/module/basic.lean
+++ b/src/topology/algebra/module/basic.lean
@@ -231,7 +231,7 @@ structure continuous_linear_map
 
 notation M ` →SL[`:25 σ `] ` M₂ := continuous_linear_map σ M M₂
 notation M ` →L[`:25 R `] ` M₂ := continuous_linear_map (ring_hom.id R) M M₂
-notation M ` →L⋆[`:25 R `] ` M₂ := continuous_linear_map (@star_ring_aut R _ _ : R →+* R) M M₂
+notation M ` →L⋆[`:25 R `] ` M₂ := continuous_linear_map (star_ring_aut R : R →+* R) M M₂
 
 /-- Continuous linear equivalences between modules. We only put the type classes that are necessary
 for the definition, although in applications `M` and `M₂` will be topological modules over the
@@ -249,7 +249,7 @@ structure continuous_linear_equiv
 
 notation M ` ≃SL[`:50 σ `] ` M₂ := continuous_linear_equiv σ M M₂
 notation M ` ≃L[`:50 R `] ` M₂ := continuous_linear_equiv (ring_hom.id R) M M₂
-notation M ` ≃L⋆[`:50 R `] ` M₂ := continuous_linear_equiv (@star_ring_aut R _ _ : R →+* R) M M₂
+notation M ` ≃L⋆[`:50 R `] ` M₂ := continuous_linear_equiv (star_ring_aut R : R →+* R) M M₂
 
 section pointwise_limits
 


### PR DESCRIPTION
Change the underlying object notated by `conj` from
```lean
def star_ring_aut [comm_semiring R] [star_ring R] : ring_aut R :=
```
to
```lean
def star_ring_end [comm_semiring R] [star_ring R] : R →+* R :=
```
and also make the `R` argument explicit.  These two changes allow the notation for conjugate-linear maps, `E →ₗ⋆[R] F` and variants, to pretty-print, see
https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/Pretty.20printer.20omits.20notation

This is a partial reversion of #9640, in which complex conjugation was upgraded from `ring_hom` to `ring_equiv`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
