### PR TITLE
[Merged by Bors] - feat(ring_theory/{trace,norm}): add trace_gen_eq_next_coeff_minpoly and norm_gen_eq_coeff_zero_minpoly 

### DIFF
--- a/src/field_theory/splitting_field.lean
+++ b/src/field_theory/splitting_field.lean
@@ -505,6 +505,19 @@ begin
   rw [eval_multiset_prod_X_sub_C_derivative hr]
 end
 
+/-- If `P` is a monic polynomial that splits, than `coeff P 0` equals the product of the roots. -/
+lemma prod_roots_eq_coeff_zero_of_monic_of_split {P : polynomial K} (hmo : P.monic)
+  (hP : P.splits (ring_hom.id K)) : coeff P 0 = (-1) ^ P.nat_degree * P.roots.prod :=
+begin
+  nth_rewrite 0 [eq_prod_roots_of_monic_of_splits_id hmo hP],
+  rw [coeff_zero_eq_eval_zero, eval_multiset_prod, multiset.map_map],
+  simp_rw [function.comp_app, eval_sub, eval_X, zero_sub, eval_C],
+  conv_lhs { congr, congr, funext,
+    rw [neg_eq_neg_one_mul] },
+  rw [multiset.prod_map_mul, multiset.map_const, multiset.prod_repeat, multiset.map_id',
+    splits_iff_card_roots.1 hP]
+end
+
 end splits
 
 end polynomial

--- a/src/field_theory/splitting_field.lean
+++ b/src/field_theory/splitting_field.lean
@@ -505,7 +505,7 @@ begin
   rw [eval_multiset_prod_X_sub_C_derivative hr]
 end
 
-/-- If `P` is a monic polynomial that splits, than `coeff P 0` equals the product of the roots. -/
+/-- If `P` is a monic polynomial that splits, then `coeff P 0` equals the product of the roots. -/
 lemma prod_roots_eq_coeff_zero_of_monic_of_split {P : polynomial K} (hmo : P.monic)
   (hP : P.splits (ring_hom.id K)) : coeff P 0 = (-1) ^ P.nat_degree * P.roots.prod :=
 begin

--- a/src/field_theory/splitting_field.lean
+++ b/src/field_theory/splitting_field.lean
@@ -518,6 +518,16 @@ begin
     splits_iff_card_roots.1 hP]
 end
 
+/-- If `P` is a monic polynomial that splits, then `P.next_coeff` equals the sum of the roots. -/
+lemma sum_roots_eq_next_coeff_of_monic_of_split {P : polynomial K} (hmo : P.monic)
+  (hP : P.splits (ring_hom.id K)) : P.next_coeff = - P.roots.sum :=
+begin
+  nth_rewrite 0 [eq_prod_roots_of_monic_of_splits_id hmo hP],
+  rw [monic.next_coeff_multiset_prod _ _ (λ a ha, _)],
+  { simp_rw [next_coeff_X_sub_C, multiset.sum_map_neg] },
+  { exact monic_X_sub_C a }
+end
+
 end splits
 
 end polynomial

--- a/src/ring_theory/norm.lean
+++ b/src/ring_theory/norm.lean
@@ -108,8 +108,7 @@ lemma norm_gen_eq_coeff_zero_minpoly [algebra K S] (pb : power_basis K S)
   (-1) ^ pb.dim * coeff ((minpoly K pb.gen).map (algebra_map K F)) 0 :=
 begin
   rw [norm_eq_matrix_det pb.basis, det_eq_sign_charpoly_coeff, charpoly_left_mul_matrix,
-      ring_hom.map_mul, ring_hom.map_pow, ring_hom.map_neg, ring_hom.map_one,
-      ← coeff_map, fintype.card_fin],
+      map_mul, map_pow, map_neg, map_one, ← coeff_map, fintype.card_fin],
 end
 
 /-- Given `pb : power_basis K S`, then the norm of `pb.gen` is

--- a/src/ring_theory/norm.lean
+++ b/src/ring_theory/norm.lean
@@ -102,7 +102,7 @@ section eq_prod_roots
 
 /-- Given `pb : power_basis K S`, then the norm of `pb.gen` is
 `(-1) ^ pb.dim * coeff ((minpoly K pb.gen).map (algebra_map K F)) 0`. -/
-lemma norm_gen_eq_coeff_zero_minpoly [algebra K S] (pb : power_basis K S)
+lemma power_basis.norm_gen_eq_coeff_zero_minpoly [algebra K S] (pb : power_basis K S)
   (hf : (minpoly K pb.gen).splits (algebra_map K F)) :
   (algebra_map K F) (norm K pb.gen) =
   (-1) ^ pb.dim * coeff ((minpoly K pb.gen).map (algebra_map K F)) 0 :=
@@ -114,12 +114,12 @@ end
 
 /-- Given `pb : power_basis K S`, then the norm of `pb.gen` is
 `((minpoly K pb.gen).map (algebra_map K F)).roots.prod`. -/
-lemma norm_gen_eq_prod_roots [algebra K S] (pb : power_basis K S)
+lemma power_basis.norm_gen_eq_prod_roots [algebra K S] (pb : power_basis K S)
   (hf : (minpoly K pb.gen).splits (algebra_map K F)) :
   algebra_map K F (norm K pb.gen) =
     ((minpoly K pb.gen).map (algebra_map K F)).roots.prod :=
 begin
-  rw [norm_gen_eq_coeff_zero_minpoly _ hf, ← pb.nat_degree_minpoly,
+  rw [power_basis.norm_gen_eq_coeff_zero_minpoly _ hf, ← pb.nat_degree_minpoly,
     prod_roots_eq_coeff_zero_of_monic_of_split
       (monic_map _ (minpoly.monic (power_basis.is_integral_gen _)))
       ((splits_id_iff_splits _).2 hf)],
@@ -202,8 +202,8 @@ lemma norm_eq_prod_embeddings_gen
     (@@finset.univ (power_basis.alg_hom.fintype pb)).prod (λ σ, σ pb.gen) :=
 begin
   letI := classical.dec_eq E,
-  rw [norm_gen_eq_prod_roots pb hE, fintype.prod_equiv pb.lift_equiv', finset.prod_mem_multiset,
-    finset.prod_eq_multiset_prod, multiset.to_finset_val,
+  rw [power_basis.norm_gen_eq_prod_roots pb hE, fintype.prod_equiv pb.lift_equiv',
+    finset.prod_mem_multiset, finset.prod_eq_multiset_prod, multiset.to_finset_val,
     multiset.erase_dup_eq_self.mpr, multiset.map_id],
   { exact nodup_roots ((separable_map _).mpr hfx) },
   { intro x, refl },

--- a/src/ring_theory/norm.lean
+++ b/src/ring_theory/norm.lean
@@ -121,7 +121,8 @@ lemma norm_gen_eq_prod_roots [algebra K S] (pb : power_basis K S)
 begin
   rw [norm_gen_eq_coeff_zero_minpoly _ hf, ← pb.nat_degree_minpoly,
     prod_roots_eq_coeff_zero_of_monic_of_split
-      (monic_map _ (minpoly.monic (power_basis.is_integral_gen _))) ((splits_id_iff_splits _).2 hf)],
+      (monic_map _ (minpoly.monic (power_basis.is_integral_gen _)))
+      ((splits_id_iff_splits _).2 hf)],
   simp only [power_basis.nat_degree_minpoly, nat_degree_map],
   rw [← mul_assoc, ← mul_pow],
   simp

--- a/src/ring_theory/norm.lean
+++ b/src/ring_theory/norm.lean
@@ -121,7 +121,7 @@ lemma norm_gen_eq_prod_roots [algebra K S] (pb : power_basis K S)
 begin
   rw [norm_gen_eq_coeff_zero_minpoly _ hf, ← pb.nat_degree_minpoly,
     prod_roots_eq_coeff_zero_of_monic_of_split
-    (monic_map _ (minpoly.monic (power_basis.is_integral_gen _))) ((splits_id_iff_splits _).2 hf)],
+      (monic_map _ (minpoly.monic (power_basis.is_integral_gen _))) ((splits_id_iff_splits _).2 hf)],
   simp only [power_basis.nat_degree_minpoly, nat_degree_map],
   rw [← mul_assoc, ← mul_pow],
   simp

--- a/src/ring_theory/norm.lean
+++ b/src/ring_theory/norm.lean
@@ -102,8 +102,7 @@ section eq_prod_roots
 
 /-- Given `pb : power_basis K S`, then the norm of `pb.gen` is
 `(-1) ^ pb.dim * coeff ((minpoly K pb.gen).map (algebra_map K F)) 0`. -/
-lemma power_basis.norm_gen_eq_coeff_zero_minpoly [algebra K S] (pb : power_basis K S)
-  (hf : (minpoly K pb.gen).splits (algebra_map K F)) :
+lemma power_basis.norm_gen_eq_coeff_zero_minpoly [algebra K S] (pb : power_basis K S) :
   (algebra_map K F) (norm K pb.gen) =
   (-1) ^ pb.dim * coeff ((minpoly K pb.gen).map (algebra_map K F)) 0 :=
 begin
@@ -119,7 +118,7 @@ lemma power_basis.norm_gen_eq_prod_roots [algebra K S] (pb : power_basis K S)
   algebra_map K F (norm K pb.gen) =
     ((minpoly K pb.gen).map (algebra_map K F)).roots.prod :=
 begin
-  rw [power_basis.norm_gen_eq_coeff_zero_minpoly _ hf, ← pb.nat_degree_minpoly,
+  rw [power_basis.norm_gen_eq_coeff_zero_minpoly, ← pb.nat_degree_minpoly,
     prod_roots_eq_coeff_zero_of_monic_of_split
       (monic_map _ (minpoly.monic (power_basis.is_integral_gen _)))
       ((splits_id_iff_splits _).2 hf)],

--- a/src/ring_theory/norm.lean
+++ b/src/ring_theory/norm.lean
@@ -108,7 +108,8 @@ lemma norm_gen_eq_coeff_zero_minpoly [algebra K S] (pb : power_basis K S)
   (-1) ^ pb.dim * coeff ((minpoly K pb.gen).map (algebra_map K F)) 0 :=
 begin
   rw [norm_eq_matrix_det pb.basis, det_eq_sign_charpoly_coeff, charpoly_left_mul_matrix,
-      map_mul, map_pow, map_neg, map_one, ← coeff_map, fintype.card_fin],
+      ring_hom.map_mul, map_pow, ring_hom.map_neg, ring_hom.map_one, ← coeff_map,
+      fintype.card_fin],
 end
 
 /-- Given `pb : power_basis K S`, then the norm of `pb.gen` is

--- a/src/ring_theory/trace.lean
+++ b/src/ring_theory/trace.lean
@@ -195,19 +195,30 @@ open algebra polynomial
 variables {F : Type*} [field F]
 variables [algebra K S] [algebra K F]
 
+/-- Given `pb : power_basis K S`, then the trace of `pb.gen` is
+`-((minpoly K pb.gen).map (algebra_map K F)).next_coeff`. -/
+lemma power_basis.trace_gen_eq_coeff_minpoly [nontrivial S] (pb : power_basis K S)
+  (hf : (minpoly K pb.gen).splits (algebra_map K F)) :
+  algebra_map K F (trace K S pb.gen) =
+    -((minpoly K pb.gen).map (algebra_map K F)).next_coeff :=
+begin
+  have d_pos : 0 < pb.dim := power_basis.dim_pos pb,
+  have d_pos' : 0 < (minpoly K pb.gen).nat_degree, { simpa },
+  haveI : nonempty (fin pb.dim) := ⟨⟨0, d_pos⟩⟩,
+  rw [trace_eq_matrix_trace pb.basis, trace_eq_neg_charpoly_coeff, charpoly_left_mul_matrix,
+      ring_hom.map_neg, ← pb.nat_degree_minpoly, fintype.card_fin,
+      ← next_coeff_of_pos_nat_degree _ d_pos',
+      ← next_coeff_map (algebra_map K F).injective]
+end
+
+/-- Given `pb : power_basis K S`, then the trace of `pb.gen` is
+`((minpoly K pb.gen).map (algebra_map K F)).roots.sum`. -/
 lemma power_basis.trace_gen_eq_sum_roots [nontrivial S] (pb : power_basis K S)
   (hf : (minpoly K pb.gen).splits (algebra_map K F)) :
   algebra_map K F (trace K S pb.gen) =
     ((minpoly K pb.gen).map (algebra_map K F)).roots.sum :=
 begin
-  have d_pos : 0 < pb.dim := power_basis.dim_pos pb,
-  have d_pos' : 0 < (minpoly K pb.gen).nat_degree, { simpa },
-  haveI : nonempty (fin pb.dim) := ⟨⟨0, d_pos⟩⟩,
-  -- Write the LHS as the `d-1`'th coefficient of `minpoly K pb.gen`
-  rw [trace_eq_matrix_trace pb.basis, trace_eq_neg_charpoly_coeff, charpoly_left_mul_matrix,
-      ring_hom.map_neg, ← pb.nat_degree_minpoly, fintype.card_fin,
-      ← next_coeff_of_pos_nat_degree _ d_pos',
-      ← next_coeff_map (algebra_map K F).injective],
+  rw [power_basis.trace_gen_eq_coeff_minpoly _ hf],
   -- Rewrite `minpoly K pb.gen` as a product over the roots.
   conv_lhs { rw eq_prod_roots_of_splits hf },
   rw [monic.next_coeff_mul, next_coeff_C_eq_zero, zero_add, monic.next_coeff_multiset_prod],

--- a/src/ring_theory/trace.lean
+++ b/src/ring_theory/trace.lean
@@ -197,7 +197,7 @@ variables [algebra K S] [algebra K F]
 
 /-- Given `pb : power_basis K S`, then the trace of `pb.gen` is
 `-((minpoly K pb.gen).map (algebra_map K F)).next_coeff`. -/
-lemma power_basis.trace_gen_eq_coeff_minpoly [nontrivial S] (pb : power_basis K S)
+lemma power_basis.trace_gen_eq_next_coeff_minpoly [nontrivial S] (pb : power_basis K S)
   (hf : (minpoly K pb.gen).splits (algebra_map K F)) :
   algebra_map K F (trace K S pb.gen) =
     -((minpoly K pb.gen).map (algebra_map K F)).next_coeff :=

--- a/src/ring_theory/trace.lean
+++ b/src/ring_theory/trace.lean
@@ -197,8 +197,7 @@ variables [algebra K S] [algebra K F]
 
 /-- Given `pb : power_basis K S`, then the trace of `pb.gen` is
 `-((minpoly K pb.gen).map (algebra_map K F)).next_coeff`. -/
-lemma power_basis.trace_gen_eq_next_coeff_minpoly [nontrivial S] (pb : power_basis K S)
-  (hf : (minpoly K pb.gen).splits (algebra_map K F)) :
+lemma power_basis.trace_gen_eq_next_coeff_minpoly [nontrivial S] (pb : power_basis K S) :
   algebra_map K F (trace K S pb.gen) =
     -((minpoly K pb.gen).map (algebra_map K F)).next_coeff :=
 begin
@@ -218,7 +217,7 @@ lemma power_basis.trace_gen_eq_sum_roots [nontrivial S] (pb : power_basis K S)
   algebra_map K F (trace K S pb.gen) =
     ((minpoly K pb.gen).map (algebra_map K F)).roots.sum :=
 begin
-  rw [power_basis.trace_gen_eq_next_coeff_minpoly _ hf, sum_roots_eq_next_coeff_of_monic_of_split
+  rw [power_basis.trace_gen_eq_next_coeff_minpoly, sum_roots_eq_next_coeff_of_monic_of_split
     (monic_map _ (minpoly.monic (power_basis.is_integral_gen _)))
     ((splits_id_iff_splits _).2 hf), neg_neg]
 end

--- a/src/ring_theory/trace.lean
+++ b/src/ring_theory/trace.lean
@@ -218,17 +218,9 @@ lemma power_basis.trace_gen_eq_sum_roots [nontrivial S] (pb : power_basis K S)
   algebra_map K F (trace K S pb.gen) =
     ((minpoly K pb.gen).map (algebra_map K F)).roots.sum :=
 begin
-  rw [power_basis.trace_gen_eq_coeff_minpoly _ hf],
-  -- Rewrite `minpoly K pb.gen` as a product over the roots.
-  conv_lhs { rw eq_prod_roots_of_splits hf },
-  rw [monic.next_coeff_mul, next_coeff_C_eq_zero, zero_add, monic.next_coeff_multiset_prod],
-  -- And conclude both sides are the same.
-  simp_rw [next_coeff_X_sub_C, multiset.sum_map_neg, neg_neg],
-  -- Now we deal with the side conditions.
-  { intros, apply monic_X_sub_C },
-  { convert monic_one, simp [(minpoly.monic pb.is_integral_gen).leading_coeff] },
-  { apply monic_multiset_prod_of_monic,
-    intros, apply monic_X_sub_C },
+  rw [power_basis.trace_gen_eq_next_coeff_minpoly _ hf, sum_roots_eq_next_coeff_of_monic_of_split
+    (monic_map _ (minpoly.monic (power_basis.is_integral_gen _)))
+    ((splits_id_iff_splits _).2 hf), neg_neg]
 end
 
 namespace intermediate_field.adjoin_simple


### PR DESCRIPTION
We add `trace_gen_eq_next_coeff_minpoly` and `norm_gen_eq_coeff_zero_minpoly`.

From flt-regular.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
