### PR TITLE
[Merged by Bors] - refactor(order/ideal): Generalize definition and lemmas

### DIFF
--- a/src/order/atoms.lean
+++ b/src/order/atoms.lean
@@ -54,11 +54,11 @@ section atoms
 
 section is_atom
 
-variables [partial_order α] [order_bot α] {a b x : α}
-
 /-- An atom of an `order_bot` is an element with no other element between it and `⊥`,
   which is not `⊥`. -/
-def is_atom (a : α) : Prop := a ≠ ⊥ ∧ (∀ b, b < a → b = ⊥)
+def is_atom [preorder α] [order_bot α] (a : α) : Prop := a ≠ ⊥ ∧ (∀ b, b < a → b = ⊥)
+
+variables [partial_order α] [order_bot α] {a b x : α}
 
 lemma eq_bot_or_eq_of_le_atom (ha : is_atom a) (hab : b ≤ a) : b = ⊥ ∨ b = a :=
 hab.lt_or_eq.imp_left (ha.2 b)
@@ -79,11 +79,11 @@ end is_atom
 
 section is_coatom
 
-variables [partial_order α] [order_top α] {a b x : α}
-
 /-- A coatom of an `order_top` is an element with no other element between it and `⊤`,
   which is not `⊤`. -/
-def is_coatom (a : α) : Prop := a ≠ ⊤ ∧ (∀ b, a < b → b = ⊤)
+def is_coatom [preorder α] [order_top α] (a : α) : Prop := a ≠ ⊤ ∧ (∀ b, a < b → b = ⊤)
+
+variables [partial_order α] [order_top α] {a b x : α}
 
 lemma eq_top_or_eq_of_coatom_le (ha : is_coatom a) (hab : a ≤ b) : b = ⊤ ∨ b = a :=
 hab.lt_or_eq.imp (ha.2 b) eq_comm.2

--- a/src/order/directed.lean
+++ b/src/order/directed.lean
@@ -3,7 +3,6 @@ Copyright (c) 2017 Johannes Hölzl. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl
 -/
-import order.lattice
 import data.set.basic
 
 /-!
@@ -86,7 +85,13 @@ lemma directed_of (r : α → α → Prop) [is_directed α r] (a b : α) : ∃ c
 is_directed.directed _ _
 
 lemma directed_id [is_directed α r] : directed r id := by convert directed_of r
-lemma directed_id_iff_is_directed : directed r id ↔ is_directed α r := ⟨λ h, ⟨h⟩, @directed_id _ _⟩
+lemma directed_id_iff : directed r id ↔ is_directed α r := ⟨λ h, ⟨h⟩, @directed_id _ _⟩
+
+lemma directed_on_univ [is_directed α r] : directed_on r set.univ :=
+λ a _ b _, let ⟨c, hc⟩ := directed_of r a b in ⟨c, trivial, hc⟩
+
+lemma directed_on_univ_iff : directed_on r set.univ ↔ is_directed α r :=
+⟨λ h, ⟨λ a b, let ⟨c, _, hc⟩ := h a trivial b trivial in ⟨c, hc⟩⟩, @directed_on_univ _ _⟩
 
 @[priority 100]  -- see Note [lower instance priority]
 instance is_total.to_is_directed [is_total α r] : is_directed α r :=
@@ -116,3 +121,11 @@ instance semilattice_sup.to_is_directed_le [semilattice_sup α] : is_directed α
 @[priority 100]  -- see Note [lower instance priority]
 instance semilattice_inf.to_is_directed_ge [semilattice_inf α] : is_directed α (swap (≤)) :=
 ⟨λ a b, ⟨a ⊓ b, inf_le_left, inf_le_right⟩⟩
+
+@[priority 100]  -- see Note [lower instance priority]
+instance order_top.to_is_directed_le [has_le α] [order_top α] : is_directed α (≤) :=
+⟨λ a b, ⟨⊤, le_top, le_top⟩⟩
+
+@[priority 100]  -- see Note [lower instance priority]
+instance order_bot.to_is_directed_ge [has_le α] [order_bot α] : is_directed α (swap (≤)) :=
+⟨λ a b, ⟨⊥, bot_le, bot_le⟩⟩

--- a/src/order/ideal.lean
+++ b/src/order/ideal.lean
@@ -163,6 +163,14 @@ lemma ideal_Inter_nonempty_iff :
   ideal_Inter_nonempty P ↔ ∃ a : P, ∀ I : ideal P, a ∈ I :=
 ⟨λ _, by exactI ideal_Inter_nonempty.exists_all_mem, ideal_Inter_nonempty_of_exists_all_mem⟩
 
+lemma inter_nonempty [is_directed P (swap (≤))] (I J : ideal P) : (I ∩ J : set P).nonempty :=
+begin
+  obtain ⟨a, ha⟩ := I.nonempty,
+  obtain ⟨b, hb⟩ := J.nonempty,
+  obtain ⟨c, hac, hbc⟩ := directed_of (swap (≤)) a b,
+  exact ⟨c, I.mem_of_le hac ha, J.mem_of_le hbc hb⟩,
+end
+
 end has_le
 
 section preorder
@@ -185,14 +193,6 @@ instance [inhabited P] : inhabited (ideal P) := ⟨ideal.principal default⟩
 
 lemma mem_compl_of_ge {x y : P} : x ≤ y → x ∈ (I : set P)ᶜ → y ∈ (I : set P)ᶜ :=
 λ h, mt (I.mem_of_le h)
-
-lemma inter_nonempty [is_directed P (swap (≤))] (I J : ideal P) : (I ∩ J : set P).nonempty :=
-begin
-  obtain ⟨a, ha⟩ := I.nonempty,
-  obtain ⟨b, hb⟩ := J.nonempty,
-  obtain ⟨c, hac, hbc⟩ := directed_of (swap (≤)) a b,
-  exact ⟨c, I.mem_of_le hac ha, J.mem_of_le hbc hb⟩,
-end
 
 end preorder
 
@@ -218,7 +218,7 @@ end order_bot
 section directed
 variables [has_le P] [is_directed P (≤)] [nonempty P] {I : ideal P}
 
-/-- The top ideal is `set.univ`. -/
+/-- In a directed and nonempty order, the top ideal of a is `set.univ`. -/
 instance : order_top (ideal P) :=
 { top := { carrier := set.univ,
            nonempty := set.univ_nonempty,
@@ -283,15 +283,15 @@ end semilattice_sup
 section semilattice_sup_directed
 variables [semilattice_sup P] [is_directed P (swap (≤))] {x : P} {I J K : ideal P}
 
-/-- The infimum of two ideals is their intersection. -/
+/-- The infimum of two ideals of a co-directed order is their intersection. -/
 instance : has_inf (ideal P) :=
 ⟨λ I J, { carrier   := I ∩ J,
   nonempty  := inter_nonempty I J,
   directed  := λ x ⟨_, _⟩ y ⟨_, _⟩, ⟨x ⊔ y, ⟨sup_mem x ‹_› y ‹_›, sup_mem x ‹_› y ‹_›⟩, by simp⟩,
   mem_of_le := λ x y h ⟨_, _⟩, ⟨mem_of_le I h ‹_›, mem_of_le J h ‹_›⟩ }⟩
 
-/-- The supremum of two ideals is the union of the down sets of the pointwise supremum of `I` and
-`J`. -/
+/-- The supremum of two ideals of a co-directed order is the union of the down sets of the pointwise
+supremum of `I` and `J`. -/
 instance : has_sup (ideal P) :=
 ⟨λ I J, { carrier   := {x | ∃ (i ∈ I) (j ∈ J), x ≤ i ⊔ j},
   nonempty  := by { cases inter_nonempty I J, exact ⟨w, w, h.1, w, h.2, le_sup_left⟩ },
@@ -323,11 +323,7 @@ instance : lattice (ideal P) :=
 @[simp] lemma mem_sup : x ∈ I ⊔ J ↔ ∃ (i ∈ I) (j ∈ J), x ≤ i ⊔ j := iff.rfl
 
 lemma lt_sup_principal_of_not_mem (hx : x ∉ I) : I < I ⊔ principal x :=
-begin
-  refine le_sup_left.lt_of_ne (λ h, hx _),
-  simp only [left_eq_sup, principal_le_iff] at h,
-  exact h
-end
+le_sup_left.lt_of_ne $ λ h, hx $ by simpa only [left_eq_sup, principal_le_iff] using h
 
 end semilattice_sup_directed
 

--- a/src/order/ideal.lean
+++ b/src/order/ideal.lean
@@ -132,7 +132,8 @@ and nonempty. -/
 
 variable (P)
 
-/-- An order `P` has the `ideal_Inter_nonempty` property if the intersection of all ideals is nonempty. Most importantly, the ideals of a `semilattice_sup` with this property form a complete
+/-- An order `P` has the `ideal_Inter_nonempty` property if the intersection of all ideals is
+nonempty. Most importantly, the ideals of a `semilattice_sup` with this property form a complete
 lattice.
 
 TODO: This is equivalent to the existence of a bottom element and shouldn't be specialized to

--- a/src/order/ideal.lean
+++ b/src/order/ideal.lean
@@ -21,8 +21,6 @@ structure, such as a bottom element, a top element, or a join-semilattice struct
   Dual to the notion of a proper filter.
 - `order.ideal.is_maximal`: a predicate for maximal ideals.
   Dual to the notion of an ultrafilter.
-- `ideal_inter_nonempty P`: a predicate for when the intersection of any two ideals of
-  `P` is nonempty.
 - `ideal_Inter_nonempty P`: a predicate for when the intersection of all ideals of
   `P` is nonempty.
 - `order.cofinal P`: the type of subsets of `P` containing arbitrarily large elements.
@@ -40,21 +38,29 @@ structure, such as a bottom element, a top element, or a join-semilattice struct
 Note that for the Rasiowa–Sikorski lemma, Wikipedia uses the opposite ordering on `P`,
 in line with most presentations of forcing.
 
+## TODO
+
+`order.ideal.ideal_Inter_nonempty` is a complicated way to say that `P` has a bottom element. It
+should be replaced by this clearer condition, which could be called strong directedness and which
+is a Prop version of `order_bot`.
+
 ## Tags
 
 ideal, cofinal, dense, countable, generic
 
 -/
 
+open function
+
 namespace order
 
 variables {P : Type*}
 
-/-- An ideal on a preorder `P` is a subset of `P` that is
+/-- An ideal on an order `P` is a subset of `P` that is
   - nonempty
   - upward directed (any pair of elements in the ideal has an upper bound in the ideal)
   - downward closed (any element less than an element of the ideal is in the ideal). -/
-structure ideal (P) [preorder P] :=
+structure ideal (P) [has_le P] :=
 (carrier   : set P)
 (nonempty  : carrier.nonempty)
 (directed  : directed_on (≤) carrier)
@@ -64,30 +70,21 @@ structure ideal (P) [preorder P] :=
   - nonempty
   - upward directed (any pair of elements in the ideal has an upper bound in the ideal)
   - downward closed (any element less than an element of the ideal is in the ideal). -/
-@[mk_iff] structure is_ideal {P} [preorder P] (I : set P) : Prop :=
+@[mk_iff] structure is_ideal {P} [has_le P] (I : set P) : Prop :=
 (nonempty : I.nonempty)
 (directed : directed_on (≤) I)
 (mem_of_le : ∀ {x y : P}, x ≤ y → y ∈ I → x ∈ I)
 
+attribute [protected] ideal.nonempty ideal.directed is_ideal.nonempty is_ideal.directed
+
 /-- Create an element of type `order.ideal` from a set satisfying the predicate
 `order.is_ideal`. -/
-def is_ideal.to_ideal [preorder P] {I : set P} (h : is_ideal I) : ideal P :=
+def is_ideal.to_ideal [has_le P] {I : set P} (h : is_ideal I) : ideal P :=
 ⟨I, h.1, h.2, h.3⟩
 
 namespace ideal
-
-section preorder
-variables [preorder P] {x y : P} {I J : ideal P}
-
-/-- The smallest ideal containing a given element. -/
-def principal (p : P) : ideal P :=
-{ carrier   := { x | x ≤ p },
-  nonempty  := ⟨p, le_refl _⟩,
-  directed  := λ x hx y hy, ⟨p, le_refl _, hx, hy⟩,
-  mem_of_le := λ x y hxy hy, le_trans hxy hy, }
-
-instance [inhabited P] : inhabited (ideal P) :=
-⟨ideal.principal default⟩
+section has_le
+variables [has_le P] {I J : ideal P} {x y : P}
 
 /-- An ideal of `P` can be viewed as a subset of `P`. -/
 instance : has_coe (ideal P) (set P) := ⟨carrier⟩
@@ -97,31 +94,23 @@ instance : has_mem P (ideal P) := ⟨λ x I, x ∈ (I : set P)⟩
 
 @[simp] lemma mem_coe : x ∈ (I : set P) ↔ x ∈ I := iff_of_eq rfl
 
-@[simp] lemma mem_principal : x ∈ principal y ↔ x ≤ y := by refl
-
 /-- Two ideals are equal when their underlying sets are equal. -/
-@[ext] lemma ext : ∀ (I J : ideal P), (I : set P) = J → I = J
+@[ext] lemma ext : ∀ {I J : ideal P}, (I : set P) = J → I = J
 | ⟨_, _, _, _⟩ ⟨_, _, _, _⟩ rfl := rfl
 
-@[simp, norm_cast] lemma ext_set_eq {I J : ideal P} : (I : set P) = J ↔ I = J :=
-⟨by ext, congr_arg _⟩
+lemma coe_injective : injective (coe : ideal P → set P) := λ _ _, ext
 
-lemma ext'_iff {I J : ideal P} : I = J ↔ (I : set P) = J := ext_set_eq.symm
+@[simp, norm_cast] lemma coe_inj : (I : set P) = J ↔ I = J := ⟨by ext, congr_arg _⟩
 
-lemma is_ideal (I : ideal P) : is_ideal (I : set P) := ⟨I.2, I.3, I.4⟩
+lemma ext_iff : I = J ↔ (I : set P) = J := coe_inj.symm
+
+protected lemma is_ideal (I : ideal P) : is_ideal (I : set P) := ⟨I.2, I.3, I.4⟩
 
 /-- The partial ordering by subset inclusion, inherited from `set P`. -/
-instance : partial_order (ideal P) := partial_order.lift coe ext
+instance : partial_order (ideal P) := partial_order.lift coe coe_injective
 
 @[trans] lemma mem_of_mem_of_le : x ∈ I → I ≤ J → x ∈ J :=
 @set.mem_of_mem_of_subset P x I J
-
-@[simp] lemma principal_le_iff : principal x ≤ I ↔ x ∈ I :=
-⟨λ (h : ∀ {y}, y ≤ x → y ∈ I), h (le_refl x),
- λ h_mem y (h_le : y ≤ x), I.mem_of_le h_le h_mem⟩
-
-lemma mem_compl_of_ge {x y : P} : x ≤ y → x ∈ (I : set P)ᶜ → y ∈ (I : set P)ᶜ :=
-λ h, mt (I.mem_of_le h)
 
 /-- A proper ideal is one that is not the whole set.
     Note that the whole set might not be an ideal. -/
@@ -135,34 +124,23 @@ lemma is_proper_of_not_mem {I : ideal P} {p : P} (nmem : p ∉ I) : is_proper I 
 end⟩
 
 /-- An ideal is maximal if it is maximal in the collection of proper ideals.
-  Note that we cannot use the `is_coatom` class because `P` might not have a `top` element.
--/
+
+Note that `is_coatom` is less general because ideals only have a top element when `P` is directed
+and nonempty. -/
 @[mk_iff] class is_maximal (I : ideal P) extends is_proper I : Prop :=
 (maximal_proper : ∀ ⦃J : ideal P⦄, I < J → (J : set P) = set.univ)
 
 variable (P)
 
-/-- A preorder `P` has the `ideal_inter_nonempty` property if the
-    intersection of any two ideals is nonempty.
-    Most importantly, a `semilattice_sup` preorder with this property
-    satisfies that its ideal poset is a lattice.
--/
-class ideal_inter_nonempty : Prop :=
-(inter_nonempty : ∀ (I J : ideal P), ((I : set P) ∩ (J : set P)).nonempty)
+/-- An order `P` has the `ideal_Inter_nonempty` property if the intersection of all ideals is nonempty. Most importantly, the ideals of a `semilattice_sup` with this property form a complete
+lattice.
 
-/-- A preorder `P` has the `ideal_Inter_nonempty` property if the
-    intersection of all ideals is nonempty.
-    Most importantly, a `semilattice_sup` preorder with this property
-    satisfies that its ideal poset is a complete lattice.
--/
+TODO: This is equivalent to the existence of a bottom element and shouldn't be specialized to
+ideals. -/
 class ideal_Inter_nonempty : Prop :=
 (Inter_nonempty : (⋂ (I : ideal P), (I : set P)).nonempty)
 
 variable {P}
-
-lemma inter_nonempty [ideal_inter_nonempty P] :
-  ∀ (I J : ideal P), ((I : set P) ∩ (J : set P)).nonempty :=
-ideal_inter_nonempty.inter_nonempty
 
 lemma Inter_nonempty [ideal_Inter_nonempty P] :
   (⋂ (I : ideal P), (I : set P)).nonempty :=
@@ -184,14 +162,46 @@ lemma ideal_Inter_nonempty_iff :
   ideal_Inter_nonempty P ↔ ∃ a : P, ∀ I : ideal P, a ∈ I :=
 ⟨λ _, by exactI ideal_Inter_nonempty.exists_all_mem, ideal_Inter_nonempty_of_exists_all_mem⟩
 
+end has_le
+
+section preorder
+variables [preorder P] {I J : ideal P} {x y : P}
+
+/-- The smallest ideal containing a given element. -/
+def principal (p : P) : ideal P :=
+{ carrier   := { x | x ≤ p },
+  nonempty  := ⟨p, le_rfl⟩,
+  directed  := λ x hx y hy, ⟨p, le_rfl, hx, hy⟩,
+  mem_of_le := λ x y hxy hy, le_trans hxy hy, }
+
+instance [inhabited P] : inhabited (ideal P) := ⟨ideal.principal default⟩
+
+@[simp] lemma principal_le_iff : principal x ≤ I ↔ x ∈ I :=
+⟨λ (h : ∀ {y}, y ≤ x → y ∈ I), h (le_refl x),
+ λ h_mem y (h_le : y ≤ x), I.mem_of_le h_le h_mem⟩
+
+@[simp] lemma mem_principal : x ∈ principal y ↔ x ≤ y := iff.rfl
+
+lemma mem_compl_of_ge {x y : P} : x ≤ y → x ∈ (I : set P)ᶜ → y ∈ (I : set P)ᶜ :=
+λ h, mt (I.mem_of_le h)
+
+lemma inter_nonempty [is_directed P (swap (≤))] (I J : ideal P) : (I ∩ J : set P).nonempty :=
+begin
+  obtain ⟨a, ha⟩ := I.nonempty,
+  obtain ⟨b, hb⟩ := J.nonempty,
+  obtain ⟨c, hac, hbc⟩ := directed_of (swap (≤)) a b,
+  exact ⟨c, I.mem_of_le hac ha, J.mem_of_le hbc hb⟩,
+end
+
 end preorder
 
 section order_bot
-variables [preorder P] [order_bot P] {I : ideal P}
 
 /-- A specific witness of `I.nonempty` when `P` has a bottom element. -/
-@[simp] lemma bot_mem : ⊥ ∈ I :=
+@[simp] lemma bot_mem [has_le P] [order_bot P] {I : ideal P} : ⊥ ∈ I :=
 I.mem_of_le bot_le I.nonempty.some_mem
+
+variables [preorder P] [order_bot P] {I : ideal P}
 
 /-- There is a bottom ideal when `P` has a bottom element. -/
 instance : order_bot (ideal P) :=
@@ -204,60 +214,54 @@ by { rw ideal_Inter_nonempty_iff, exact ⟨⊥, λ I, bot_mem⟩ }
 
 end order_bot
 
-section order_top
+section directed
+variables [has_le P] [is_directed P (≤)] [nonempty P] {I : ideal P}
 
-variables [preorder P] [order_top P]
-
-/-- There is a top ideal when `P` has a top element. -/
+/-- The top ideal is `set.univ`. -/
 instance : order_top (ideal P) :=
-{ top := principal ⊤,
-  le_top := λ I x h, le_top }
+{ top := { carrier := set.univ,
+           nonempty := set.univ_nonempty,
+           directed := directed_on_univ,
+           mem_of_le := λ _ _ _ _, trivial },
+  le_top := λ I, le_top }
 
-@[simp] lemma coe_top : ((⊤ : ideal P) : set P) = set.univ :=
-set.univ_subset_iff.1 (λ p _, le_top)
+@[simp] lemma coe_top : ((⊤ : ideal P) : set P) = set.univ := rfl
 
-lemma top_of_mem_top {I : ideal P} (mem_top : ⊤ ∈ I) : I = ⊤ :=
-begin
-  ext,
-  change x ∈ I ↔ x ∈ ((⊤ : ideal P) : set P),
-  split,
-  { simp [coe_top] },
-  { exact λ _, I.mem_of_le le_top mem_top }
-end
+lemma is_proper_of_ne_top (ne_top : I ≠ ⊤) : is_proper I := ⟨λ h, ne_top $ ext h⟩
 
-lemma is_proper_of_ne_top {I : ideal P} (ne_top : I ≠ ⊤) : is_proper I :=
-is_proper_of_not_mem (λ h, ne_top (top_of_mem_top h))
-
-lemma is_proper.ne_top {I : ideal P} (hI : is_proper I) : I ≠ ⊤ :=
+lemma is_proper.ne_top (hI : is_proper I) : I ≠ ⊤ :=
 begin
   intro h,
-  rw [ext'_iff, coe_top] at h,
+  rw [ext_iff, coe_top] at h,
   apply hI.ne_univ,
   assumption,
 end
 
-lemma is_proper.top_not_mem {I : ideal P} (hI : is_proper I) : ⊤ ∉ I :=
-by { by_contra, exact hI.ne_top (top_of_mem_top h) }
+lemma _root_.is_coatom.is_proper (hI : is_coatom I) : is_proper I := is_proper_of_ne_top hI.1
 
-lemma _root_.is_coatom.is_proper {I : ideal P} (hI : is_coatom I) : is_proper I :=
-is_proper_of_ne_top hI.1
+lemma is_proper_iff_ne_top : is_proper I ↔ I ≠ ⊤ := ⟨λ h, h.ne_top, λ h, is_proper_of_ne_top h⟩
 
-lemma is_proper_iff_ne_top {I : ideal P} : is_proper I ↔ I ≠ ⊤ :=
-⟨λ h, h.ne_top, λ h, is_proper_of_ne_top h⟩
-
-lemma is_maximal.is_coatom {I : ideal P} (h : is_maximal I) : is_coatom I :=
+lemma is_maximal.is_coatom (h : is_maximal I) : is_coatom I :=
 ⟨is_maximal.to_is_proper.ne_top,
- λ _ _, by { rw [ext'_iff, coe_top], exact is_maximal.maximal_proper ‹_› }⟩
+  λ _ _, by { rw [ext_iff, coe_top], exact is_maximal.maximal_proper ‹_› }⟩
 
-lemma is_maximal.is_coatom' {I : ideal P} [is_maximal I] : is_coatom I :=
-is_maximal.is_coatom ‹_›
+lemma is_maximal.is_coatom' [is_maximal I] : is_coatom I := is_maximal.is_coatom ‹_›
 
-lemma _root_.is_coatom.is_maximal {I : ideal P} (hI : is_coatom I) : is_maximal I :=
+lemma _root_.is_coatom.is_maximal (hI : is_coatom I) : is_maximal I :=
 { maximal_proper := λ _ _, by simp [hI.2 _ ‹_›],
   ..is_coatom.is_proper ‹_› }
 
-lemma is_maximal_iff_is_coatom {I : ideal P} : is_maximal I ↔ is_coatom I :=
-⟨λ h, h.is_coatom, λ h, h.is_maximal⟩
+lemma is_maximal_iff_is_coatom : is_maximal I ↔ is_coatom I := ⟨λ h, h.is_coatom, λ h, h.is_maximal⟩
+
+end directed
+
+section order_top
+variables [has_le P] [order_top P] {I : ideal P}
+
+lemma top_of_top_mem (hI : ⊤ ∈ I) : I = ⊤ :=
+by { ext, exact iff_of_true (I.mem_of_le le_top hI) trivial }
+
+lemma is_proper.top_not_mem (hI : is_proper I) : ⊤ ∉ I := λ h, hI.ne_top $ top_of_top_mem h
 
 end order_top
 
@@ -275,21 +279,20 @@ I.mem_of_le (sup_le hx hy) h_mem
 
 end semilattice_sup
 
-section semilattice_sup_ideal_inter_nonempty
+section semilattice_sup_directed
+variables [semilattice_sup P] [is_directed P (swap (≤))] {x : P} {I J K : ideal P}
 
-variables [semilattice_sup P] [ideal_inter_nonempty P] {x : P} {I J K : ideal P}
-
-/-- The intersection of two ideals is an ideal, when it is nonempty and `P` has joins. -/
-def inf (I J : ideal P) : ideal P :=
-{ carrier   := I ∩ J,
+/-- The infimum of two ideals is their intersection. -/
+instance : has_inf (ideal P) :=
+⟨λ I J, { carrier   := I ∩ J,
   nonempty  := inter_nonempty I J,
   directed  := λ x ⟨_, _⟩ y ⟨_, _⟩, ⟨x ⊔ y, ⟨sup_mem x ‹_› y ‹_›, sup_mem x ‹_› y ‹_›⟩, by simp⟩,
-  mem_of_le := λ x y h ⟨_, _⟩, ⟨mem_of_le I h ‹_›, mem_of_le J h ‹_›⟩ }
+  mem_of_le := λ x y h ⟨_, _⟩, ⟨mem_of_le I h ‹_›, mem_of_le J h ‹_›⟩ }⟩
 
-/-- There is a smallest ideal containing two ideals, when their intersection is nonempty and
-    `P` has joins. -/
-def sup (I J : ideal P) : ideal P :=
-{ carrier   := {x | ∃ (i ∈ I) (j ∈ J), x ≤ i ⊔ j},
+/-- The supremum of two ideals is the union of the down sets of the pointwise supremum of `I` and
+`J`. -/
+instance : has_sup (ideal P) :=
+⟨λ I J, { carrier   := {x | ∃ (i ∈ I) (j ∈ J), x ≤ i ⊔ j},
   nonempty  := by { cases inter_nonempty I J, exact ⟨w, w, h.1, w, h.2, le_sup_left⟩ },
   directed  := λ x ⟨xi, _, xj, _, _⟩ y ⟨yi, _, yj, _, _⟩,
     ⟨x ⊔ y,
@@ -301,47 +304,42 @@ def sup (I J : ideal P) : ideal P :=
         (calc y ≤ yi ⊔ yj               : ‹_›
          ...    ≤ (xi ⊔ yi) ⊔ (xj ⊔ yj) : sup_le_sup le_sup_right le_sup_right)⟩,
      le_sup_left, le_sup_right⟩,
-  mem_of_le := λ x y _ ⟨yi, _, yj, _, _⟩, ⟨yi, ‹_›, yj, ‹_›, le_trans ‹x ≤ y› ‹_›⟩ }
-
-lemma sup_le : I ≤ K → J ≤ K → sup I J ≤ K :=
-λ hIK hJK x ⟨i, hiI, j, hjJ, hxij⟩,
-K.mem_of_le hxij $ sup_mem i (mem_of_mem_of_le hiI hIK) j (mem_of_mem_of_le hjJ hJK)
+  mem_of_le := λ x y _ ⟨yi, _, yj, _, _⟩, ⟨yi, ‹_›, yj, ‹_›, le_trans ‹x ≤ y› ‹_›⟩ }⟩
 
 instance : lattice (ideal P) :=
-{ sup          := sup,
-  le_sup_left  := λ I J (i ∈ I), by { cases nonempty J, exact ⟨i, ‹_›, w, ‹_›, le_sup_left⟩ },
-  le_sup_right := λ I J (j ∈ J), by { cases nonempty I, exact ⟨w, ‹_›, j, ‹_›, le_sup_right⟩ },
-  sup_le       := @sup_le _ _ _,
-  inf          := inf,
+{ sup          := (⊔),
+  le_sup_left  := λ I J (i ∈ I), by { cases J.nonempty, exact ⟨i, ‹_›, w, ‹_›, le_sup_left⟩ },
+  le_sup_right := λ I J (j ∈ J), by { cases I.nonempty, exact ⟨w, ‹_›, j, ‹_›, le_sup_right⟩ },
+  sup_le       := λ I J K hIK hJK a ⟨i, hi, j, hj, ha⟩,
+    K.mem_of_le ha $ sup_mem i (mem_of_mem_of_le hi hIK) j (mem_of_mem_of_le hj hJK),
+  inf          := (⊓),
   inf_le_left  := λ I J, set.inter_subset_left I J,
   inf_le_right := λ I J, set.inter_subset_right I J,
   le_inf       := λ I J K, set.subset_inter,
   .. ideal.partial_order }
 
-@[simp] lemma mem_inf : x ∈ I ⊓ J ↔ x ∈ I ∧ x ∈ J := iff_of_eq rfl
-
-@[simp] lemma mem_sup : x ∈ I ⊔ J ↔ ∃ (i ∈ I) (j ∈ J), x ≤ i ⊔ j := iff_of_eq rfl
+@[simp] lemma mem_inf : x ∈ I ⊓ J ↔ x ∈ I ∧ x ∈ J := iff.rfl
+@[simp] lemma mem_sup : x ∈ I ⊔ J ↔ ∃ (i ∈ I) (j ∈ J), x ≤ i ⊔ j := iff.rfl
 
 lemma lt_sup_principal_of_not_mem (hx : x ∉ I) : I < I ⊔ principal x :=
 begin
-  apply lt_of_le_of_ne le_sup_left,
-  intro h,
-  simp at h,
-  exact hx h
+  refine le_sup_left.lt_of_ne (λ h, hx _),
+  simp only [left_eq_sup, principal_le_iff] at h,
+  exact h
 end
 
-end semilattice_sup_ideal_inter_nonempty
+end semilattice_sup_directed
 
 section ideal_Inter_nonempty
 
 variables [preorder P] [ideal_Inter_nonempty P]
 
 @[priority 100]
-instance ideal_Inter_nonempty.ideal_inter_nonempty : ideal_inter_nonempty P :=
-{ inter_nonempty := λ _ _, begin
-    obtain ⟨a, ha⟩ : ∃ a : P, ∀ I : ideal P, a ∈ I := ideal_Inter_nonempty.exists_all_mem,
-    exact ⟨a, ha _, ha _⟩
-  end }
+instance ideal_Inter_nonempty.to_directed_ge : is_directed P (swap (≤)) :=
+⟨λ a b, begin
+    obtain ⟨c, hc⟩ : ∃ a, ∀ I : ideal P, a ∈ I := ideal_Inter_nonempty.exists_all_mem,
+    exact ⟨c, hc (principal a), hc (principal b)⟩,
+  end⟩
 
 variables {α β γ : Type*} {ι : Sort*}
 
@@ -403,27 +401,13 @@ instance : complete_lattice (ideal P) :=
 
 end semilattice_sup_ideal_Inter_nonempty
 
-section semilattice_inf
-
-variable [semilattice_inf P]
-
-@[priority 100]
-instance semilattice_inf.ideal_inter_nonempty : ideal_inter_nonempty P :=
-{ inter_nonempty := λ I J, begin
-    cases I.nonempty with i _,
-    cases J.nonempty with j _,
-    exact ⟨i ⊓ j, I.mem_of_le inf_le_left ‹_›, J.mem_of_le inf_le_right ‹_›⟩
-  end }
-
-end semilattice_inf
-
 section distrib_lattice
 
 variables [distrib_lattice P]
 variables {I J : ideal P}
 
-lemma eq_sup_of_le_sup {x i j: P} (hi : i ∈ I) (hj : j ∈ J) (hx : x ≤ i ⊔ j):
-∃ (i' ∈ I) (j' ∈ J), x = i' ⊔ j' :=
+lemma eq_sup_of_le_sup {x i j: P} (hi : i ∈ I) (hj : j ∈ J) (hx : x ≤ i ⊔ j) :
+  ∃ (i' ∈ I) (j' ∈ J), x = i' ⊔ j' :=
 begin
   refine ⟨x ⊓ i, I.mem_of_le inf_le_right hi, x ⊓ j, J.mem_of_le inf_le_right hj, _⟩,
   calc
@@ -472,7 +456,7 @@ namespace cofinal
 variables [preorder P]
 
 instance : inhabited (cofinal P) :=
-⟨{ carrier := set.univ, mem_gt := λ x, ⟨x, trivial, le_refl _⟩ }⟩
+⟨{ carrier := set.univ, mem_gt := λ x, ⟨x, trivial, le_rfl⟩ }⟩
 
 instance : has_mem P (cofinal P) := ⟨λ x D, x ∈ D.carrier⟩
 
@@ -517,18 +501,18 @@ by { dunfold sequence_of_cofinals, rw encodable.encodek, apply cofinal.above_mem
   This proves the Rasiowa–Sikorski lemma. -/
 def ideal_of_cofinals : ideal P :=
 { carrier   := { x : P | ∃ n, x ≤ sequence_of_cofinals p 𝒟 n },
-  nonempty  := ⟨p, 0, le_refl _⟩,
+  nonempty  := ⟨p, 0, le_rfl⟩,
   directed  := λ x ⟨n, hn⟩ y ⟨m, hm⟩,
-               ⟨_, ⟨max n m, le_refl _⟩,
+               ⟨_, ⟨max n m, le_rfl⟩,
                le_trans hn $ sequence_of_cofinals.monotone p 𝒟 (le_max_left _ _),
                le_trans hm $ sequence_of_cofinals.monotone p 𝒟 (le_max_right _ _) ⟩,
   mem_of_le := λ x y hxy ⟨n, hn⟩, ⟨n, le_trans hxy hn⟩, }
 
-lemma mem_ideal_of_cofinals : p ∈ ideal_of_cofinals p 𝒟 := ⟨0, le_refl _⟩
+lemma mem_ideal_of_cofinals : p ∈ ideal_of_cofinals p 𝒟 := ⟨0, le_rfl⟩
 
 /-- `ideal_of_cofinals p 𝒟` is `𝒟`-generic. -/
 lemma cofinal_meets_ideal_of_cofinals (i : ι) : ∃ x : P, x ∈ 𝒟 i ∧ x ∈ ideal_of_cofinals p 𝒟 :=
-⟨_, sequence_of_cofinals.encode_mem p 𝒟 i, _, le_refl _⟩
+⟨_, sequence_of_cofinals.encode_mem p 𝒟 i, _, le_rfl⟩
 
 end ideal_of_cofinals
 


### PR DESCRIPTION
* Generalize the `order_top` instance to `[nonempty P] [is_directed P (≤)]`.
* Delete `order.ideal.ideal_inter_nonempty` in favor of the equivalent condition `is_directed P (swap (≤))`.
* Delete `order.ideal.sup`/`order.ideal.inf` in favor of a direct instance declaration.
* Generalize defs/lemmas from `preorder` to `has_le` or `partial_order` to `preorder`.
* Two more `is_directed` lemmas and instances for `order_bot` and `order_top`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
