### PR TITLE
[Merged by Bors] - feat(data/finsupp/basic): add `finset_sum_apply` and `coe_fn_add_hom`

### DIFF
--- a/src/data/finsupp/basic.lean
+++ b/src/data/finsupp/basic.lean
@@ -870,6 +870,13 @@ See `finsupp.lapply` for the stronger version as a linear map. -/
 @[simps apply]
 def apply_add_hom (a : α) : (α →₀ M) →+ M := ⟨λ g, g a, zero_apply, λ _ _, add_apply _ _ _⟩
 
+/-- Coercion from a `finsupp` to a function type is an `add_monoid_hom`. -/
+noncomputable
+def coe_fn_add_monoid_hom {α M : Type*} [add_zero_class M] : (α →₀ M) →+ (α → M) :=
+{ to_fun := λ f, f,
+  map_zero' := by simp,
+  map_add' := by simp }
+
 lemma update_eq_single_add_erase (f : α →₀ M) (a : α) (b : M) :
   f.update a b = single a b + f.erase a :=
 begin
@@ -1003,13 +1010,6 @@ ext $ λ a, by simp only [hf', add_apply, map_range_apply]
 @[simp] lemma emb_domain_add (f : α ↪ β) (v w : α →₀ M) :
   emb_domain f (v + w) = emb_domain f v + emb_domain f w :=
 (emb_domain.add_monoid_hom f).map_add v w
-
-/-- Coercion from a `finsupp` to a function type is an `add_monoid_hom`. -/
-noncomputable
-def coe_fn_add_monoid_hom {α M : Type*} [add_zero_class M] : (α →₀ M) →+ (α → M) :=
-{ to_fun := λ f, f,
-  map_zero' := by simp,
-  map_add' := by simp }
 
 end add_zero_class
 

--- a/src/data/finsupp/basic.lean
+++ b/src/data/finsupp/basic.lean
@@ -1156,8 +1156,8 @@ lemma coe_finset_sum [add_comm_monoid N] (S : finset ι) (f : ι → α →₀ N
   ⇑(∑ i in S, f i) = ∑ i in S, f i :=
 (coe_fn_add_monoid_hom : (α →₀ N) →+ _).map_sum _ _
 
-lemma coe_finsupp_sum [has_zero M] [add_comm_monoid N] (f : α →₀ M) (g : α → M →₀ N) :
-  ⇑(∑ i in f.support, g i) = ∑ i in f.support, g i :=
+lemma coe_sum [has_zero M] [add_comm_monoid N] (f : α →₀ M) (g : α → M → β →₀ N) :
+  ⇑(f.sum g) = f.sum (λ a₁ b, g a₁ b) :=
 coe_finset_sum _ _
 
 lemma support_sum [decidable_eq β] [has_zero M] [add_comm_monoid N]

--- a/src/data/finsupp/basic.lean
+++ b/src/data/finsupp/basic.lean
@@ -1154,7 +1154,7 @@ finset_sum_apply _ _ _
 
 lemma coe_finset_sum [add_comm_monoid N] (S : finset ι) (f : ι → α →₀ N) :
   ⇑(∑ i in S, f i) = ∑ i in S, f i :=
-(coe_fn_add_monoid_hom : (α →₀ N) →+ _).map_sum _ _
+(coe_fn_add_hom : (α →₀ N) →+ _).map_sum _ _
 
 lemma coe_sum [has_zero M] [add_comm_monoid N] (f : α →₀ M) (g : α → M → β →₀ N) :
   ⇑(f.sum g) = f.sum (λ a₁ b, g a₁ b) :=

--- a/src/data/finsupp/basic.lean
+++ b/src/data/finsupp/basic.lean
@@ -1020,6 +1020,13 @@ instance : add_monoid (α →₀ M) :=
   nsmul_succ' := λ n v, by { ext i, simp [nat.succ_eq_one_add, add_nsmul] },
   .. finsupp.add_zero_class }
 
+/-- Coercion from a `finsupp` to a function type is an `add_monoid_hom`. -/
+noncomputable
+def coe_fn_add_monoid_hom {α M : Type*} [add_zero_class M] : (α →₀ M) →+ (α → M) :=
+{ to_fun := λ f, f,
+  map_zero' := by simp,
+  map_add' := by simp }
+
 end add_monoid
 
 end finsupp

--- a/src/data/finsupp/basic.lean
+++ b/src/data/finsupp/basic.lean
@@ -1134,6 +1134,16 @@ lemma update_eq_sub_add_single [add_group G] (f : α →₀ G) (a : α) (b : G) 
   f.update a b = f - single a (f a) + single a b :=
 by rw [update_eq_erase_add_single, erase_eq_sub_single]
 
+/-- Given a family of functions `f i : α → ℕ` indexed over `S : finset ι`, the sum of this family
+  over `S` is a function `α → ℕ` whose value at `p : α` is `∑ (i : ι) in S, (f i) p` -/
+lemma finset_sum_apply {ι α : Type*} {S : finset ι} {p : α} {f : ι → α → ℕ} :
+  (S.sum f) p = ∑ (i : ι) in S, (f i) p :=
+begin
+  classical,
+  apply finset.induction_on' S, { simp },
+  { intros i T hi hST hiT h, simp [finset.sum_insert hiT, h] }
+end
+
 @[simp] lemma sum_apply [has_zero M] [add_comm_monoid N]
   {f : α →₀ M} {g : α → M → β →₀ N} {a₂ : β} :
   (f.sum g) a₂ = f.sum (λa₁ b, g a₁ b a₂) :=

--- a/src/data/finsupp/basic.lean
+++ b/src/data/finsupp/basic.lean
@@ -1141,8 +1141,6 @@ lemma update_eq_sub_add_single [add_group G] (f : α →₀ G) (a : α) (b : G) 
   f.update a b = f - single a (f a) + single a b :=
 by rw [update_eq_erase_add_single, erase_eq_sub_single]
 
-/-- Given a family of functions `f i : α → N` indexed over `S : finset ι`, the sum of this family
-  over `S` is a function `α → N` whose value at `p : α` is `∑ (i : ι) in S, (f i) p` -/
 lemma finset_sum_apply [add_comm_monoid N] (S : finset ι) (f : ι → α →₀ N) (a : α) :
   (∑ i in S, f i) a = ∑ i in S, f i a :=
 (apply_add_hom a : (α →₀ N) →+ _).map_sum _ _

--- a/src/data/finsupp/basic.lean
+++ b/src/data/finsupp/basic.lean
@@ -1144,7 +1144,7 @@ by rw [update_eq_erase_add_single, erase_eq_sub_single]
 /-- Given a family of functions `f i : α → N` indexed over `S : finset ι`, the sum of this family
   over `S` is a function `α → N` whose value at `p : α` is `∑ (i : ι) in S, (f i) p` -/
 lemma finset_sum_apply [add_comm_monoid N] (S : finset ι) (a : α) (f : ι → α →₀ N) :
-  (S.sum f) a = ∑ (i : ι) in S, (f i) a :=
+  (∑ i in S, f i) a = ∑ i in S, f i a :=
 (apply_add_hom a : (α →₀ N) →+ _).map_sum _ _
 
 @[simp] lemma sum_apply [has_zero M] [add_comm_monoid N]

--- a/src/data/finsupp/basic.lean
+++ b/src/data/finsupp/basic.lean
@@ -1156,7 +1156,9 @@ lemma coe_finset_sum [add_comm_monoid N] (S : finset ι) (f : ι → α →₀ N
   ⇑(∑ i in S, f i) = ∑ i in S, f i :=
 (coe_fn_add_monoid_hom : (α →₀ N) →+ _).map_sum _ _
 
-#exit
+lemma coe_finsupp_sum [has_zero M] [add_comm_monoid N] (f : α →₀ M) (g : α → M →₀ N) :
+  ⇑(∑ i in f.support, g i) = ∑ i in f.support, g i :=
+coe_finset_sum _ _
 
 lemma support_sum [decidable_eq β] [has_zero M] [add_comm_monoid N]
   {f : α →₀ M} {g : α → M → (β →₀ N)} :

--- a/src/data/finsupp/basic.lean
+++ b/src/data/finsupp/basic.lean
@@ -1143,7 +1143,7 @@ by rw [update_eq_erase_add_single, erase_eq_sub_single]
 
 /-- Given a family of functions `f i : α → N` indexed over `S : finset ι`, the sum of this family
   over `S` is a function `α → N` whose value at `p : α` is `∑ (i : ι) in S, (f i) p` -/
-lemma finset_sum_apply [add_comm_monoid N] (S : finset ι) (a : α) (f : ι → α →₀ N) :
+lemma finset_sum_apply [add_comm_monoid N] (S : finset ι) (f : ι → α →₀ N) (a : α) :
   (∑ i in S, f i) a = ∑ i in S, f i a :=
 (apply_add_hom a : (α →₀ N) →+ _).map_sum _ _
 

--- a/src/data/finsupp/basic.lean
+++ b/src/data/finsupp/basic.lean
@@ -1004,6 +1004,13 @@ ext $ λ a, by simp only [hf', add_apply, map_range_apply]
   emb_domain f (v + w) = emb_domain f v + emb_domain f w :=
 (emb_domain.add_monoid_hom f).map_add v w
 
+/-- Coercion from a `finsupp` to a function type is an `add_monoid_hom`. -/
+noncomputable
+def coe_fn_add_monoid_hom {α M : Type*} [add_zero_class M] : (α →₀ M) →+ (α → M) :=
+{ to_fun := λ f, f,
+  map_zero' := by simp,
+  map_add' := by simp }
+
 end add_zero_class
 
 section add_monoid
@@ -1019,13 +1026,6 @@ instance : add_monoid (α →₀ M) :=
   nsmul_zero' := λ v, by { ext i, simp },
   nsmul_succ' := λ n v, by { ext i, simp [nat.succ_eq_one_add, add_nsmul] },
   .. finsupp.add_zero_class }
-
-/-- Coercion from a `finsupp` to a function type is an `add_monoid_hom`. -/
-noncomputable
-def coe_fn_add_monoid_hom {α M : Type*} [add_zero_class M] : (α →₀ M) →+ (α → M) :=
-{ to_fun := λ f, f,
-  map_zero' := by simp,
-  map_add' := by simp }
 
 end add_monoid
 

--- a/src/data/finsupp/basic.lean
+++ b/src/data/finsupp/basic.lean
@@ -1134,9 +1134,9 @@ lemma update_eq_sub_add_single [add_group G] (f : α →₀ G) (a : α) (b : G) 
   f.update a b = f - single a (f a) + single a b :=
 by rw [update_eq_erase_add_single, erase_eq_sub_single]
 
-/-- Given a family of functions `f i : α → ℕ` indexed over `S : finset ι`, the sum of this family
-  over `S` is a function `α → ℕ` whose value at `p : α` is `∑ (i : ι) in S, (f i) p` -/
-lemma finset_sum_apply {ι α : Type*} {S : finset ι} {p : α} {f : ι → α → ℕ} :
+/-- Given a family of functions `f i : α → N` indexed over `S : finset ι`, the sum of this family
+  over `S` is a function `α → N` whose value at `p : α` is `∑ (i : ι) in S, (f i) p` -/
+lemma finset_sum_apply [add_comm_monoid N] {S : finset ι} {p : α} {f : ι → α → N} :
   (S.sum f) p = ∑ (i : ι) in S, (f i) p :=
 begin
   classical,

--- a/src/data/finsupp/basic.lean
+++ b/src/data/finsupp/basic.lean
@@ -871,11 +871,11 @@ See `finsupp.lapply` for the stronger version as a linear map. -/
 def apply_add_hom (a : α) : (α →₀ M) →+ M := ⟨λ g, g a, zero_apply, λ _ _, add_apply _ _ _⟩
 
 /-- Coercion from a `finsupp` to a function type is an `add_monoid_hom`. -/
-noncomputable
-def coe_fn_add_monoid_hom {α M : Type*} [add_zero_class M] : (α →₀ M) →+ (α → M) :=
-{ to_fun := λ f, f,
-  map_zero' := by simp,
-  map_add' := by simp }
+@[simps]
+noncomputable def coe_fn_add_monoid_hom : (α →₀ M) →+ (α → M) :=
+{ to_fun := coe_fn,
+  map_zero' := coe_zero,
+  map_add' := coe_add }
 
 lemma update_eq_single_add_erase (f : α →₀ M) (a : α) (b : M) :
   f.update a b = single a b + f.erase a :=

--- a/src/data/finsupp/basic.lean
+++ b/src/data/finsupp/basic.lean
@@ -1152,6 +1152,12 @@ lemma finset_sum_apply [add_comm_monoid N] (S : finset ι) (a : α) (f : ι → 
   (f.sum g) a₂ = f.sum (λa₁ b, g a₁ b a₂) :=
 finset_sum_apply _ _ _
 
+lemma coe_finset_sum [add_comm_monoid N] (S : finset ι) (f : ι → α →₀ N) :
+  ⇑(∑ i in S, f i) = ∑ i in S, f i :=
+(coe_fn_add_monoid_hom : (α →₀ N) →+ _).map_sum _ _
+
+#exit
+
 lemma support_sum [decidable_eq β] [has_zero M] [add_comm_monoid N]
   {f : α →₀ M} {g : α → M → (β →₀ N)} :
   (f.sum g).support ⊆ f.support.bUnion (λa, (g a (f a)).support) :=

--- a/src/data/finsupp/basic.lean
+++ b/src/data/finsupp/basic.lean
@@ -1143,18 +1143,14 @@ by rw [update_eq_erase_add_single, erase_eq_sub_single]
 
 /-- Given a family of functions `f i : α → N` indexed over `S : finset ι`, the sum of this family
   over `S` is a function `α → N` whose value at `p : α` is `∑ (i : ι) in S, (f i) p` -/
-lemma finset_sum_apply [add_comm_monoid N] {S : finset ι} {p : α} {f : ι → α → N} :
-  (S.sum f) p = ∑ (i : ι) in S, (f i) p :=
-begin
-  classical,
-  apply finset.induction_on' S, { simp },
-  { intros i T hi hST hiT h, simp [finset.sum_insert hiT, h] }
-end
+lemma finset_sum_apply [add_comm_monoid N] (S : finset ι) (a : α) (f : ι → α →₀ N) :
+  (S.sum f) a = ∑ (i : ι) in S, (f i) a :=
+(apply_add_hom a : (α →₀ N) →+ _).map_sum _ _
 
 @[simp] lemma sum_apply [has_zero M] [add_comm_monoid N]
   {f : α →₀ M} {g : α → M → β →₀ N} {a₂ : β} :
   (f.sum g) a₂ = f.sum (λa₁ b, g a₁ b a₂) :=
-(apply_add_hom a₂ : (β →₀ N) →+ _).map_sum _ _
+finset_sum_apply _ _ _
 
 lemma support_sum [decidable_eq β] [has_zero M] [add_comm_monoid N]
   {f : α →₀ M} {g : α → M → (β →₀ N)} :

--- a/src/data/finsupp/basic.lean
+++ b/src/data/finsupp/basic.lean
@@ -872,7 +872,7 @@ def apply_add_hom (a : α) : (α →₀ M) →+ M := ⟨λ g, g a, zero_apply, �
 
 /-- Coercion from a `finsupp` to a function type is an `add_monoid_hom`. -/
 @[simps]
-noncomputable def coe_fn_add_monoid_hom : (α →₀ M) →+ (α → M) :=
+noncomputable def coe_fn_add_hom : (α →₀ M) →+ (α → M) :=
 { to_fun := coe_fn,
   map_zero' := coe_zero,
   map_add' := coe_add }


### PR DESCRIPTION
`finset_sum_apply`: Given a family of functions `f i : α → ℕ` indexed over `S : finset ι`, the sum of this family over `S` is a function `α → ℕ` whose value at `p : α` is `∑ (i : ι) in S, (f i) p`

`coe_fn_add_monoid_hom`: Coercion from a `finsupp` to a function type is an `add_monoid_hom`. Proved by Alex J. Best

Co-authored-by: Alex J. Best <alex.j.best@gmail.com>
Co-authored-by: Eric Wieser <wieser.eric@gmail.com>

---

Discussed here: https://leanprover.zulipchat.com/#narrow/stream/113489-new-members/topic/Applying.20a.20sum.20of.20finsupps

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
