### PR TITLE
[Merged by Bors] - fix(analysis/calculus/fderiv_symmetric): speed up tactic block from 3.6s to 180ms

### DIFF
--- a/src/analysis/calculus/fderiv_symmetric.lean
+++ b/src/analysis/calculus/fderiv_symmetric.lean
@@ -157,10 +157,7 @@ begin
       { refine ⟨_, xt_mem t ⟨ht.1, ht.2.le⟩⟩,
         rw [add_assoc, add_mem_ball_iff_norm],
         exact I.trans_lt hδ },
-      have := sδ H,
-      simp only [mem_set_of_eq] at this,
-      convert this;
-      abel
+      simpa only [mem_set_of_eq, add_assoc x, add_sub_cancel'] using sδ H,
     end
     ... ≤ (ε * (∥h • v∥ + ∥h • w∥)) * (∥h • w∥) :
     begin


### PR DESCRIPTION
The timings are measured for the single small begin/end block. The proof as a whole is still around 7.6s, down from 11s.

The fault here was likely the `convert`, which presumably spent a lot of time trying to unify typeclass arguments.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
