### PR TITLE
[Merged by Bors] - feat(algebra/field/basic): `div_neg_self`, `neg_div_self`

### DIFF
--- a/src/algebra/field/basic.lean
+++ b/src/algebra/field/basic.lean
@@ -97,6 +97,12 @@ by simp [neg_div]
 lemma neg_div_neg_eq (a b : K) : (-a) / (-b) = a / b :=
 by rw [div_neg_eq_neg_div, neg_div, neg_neg]
 
+@[simp] lemma div_neg_self {a : K} (h : a ≠ 0) : a / -a = -1 :=
+by rw [div_neg_eq_neg_div, div_self h]
+
+@[simp] lemma neg_div_self {a : K} (h : a ≠ 0) : (-a) / a = -1 :=
+by rw [neg_div, div_self h]
+
 @[field_simps] lemma div_add_div_same (a b c : K) : a / c + b / c = (a + b) / c :=
 by simpa only [div_eq_mul_inv] using (right_distrib a b (c⁻¹)).symm
 


### PR DESCRIPTION
I think these two lemmas are useful as `simp` lemmas, but they don't
seem to be there already.



---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
