### PR TITLE
[Merged by Bors] - chore(algebra/char_p): ring_char.eq is better in the other direction, with instances, and explicit arguments

### DIFF
--- a/src/algebra/char_p/basic.lean
+++ b/src/algebra/char_p/basic.lean
@@ -92,8 +92,8 @@ theorem spec : ∀ x:ℕ, (x:R) = 0 ↔ ring_char R ∣ x :=
 by letI := (classical.some_spec (char_p.exists_unique R)).1;
 unfold ring_char; exact char_p.cast_eq_zero_iff R (ring_char R)
 
-theorem eq {p : ℕ} (C : char_p R p) : p = ring_char R :=
-(classical.some_spec (char_p.exists_unique R)).2 p C
+theorem eq (p : ℕ) [C : char_p R p] : ring_char R = p :=
+((classical.some_spec (char_p.exists_unique R)).2 p C).symm
 
 instance char_p : char_p R (ring_char R) :=
 ⟨spec R⟩
@@ -104,13 +104,13 @@ theorem of_eq {p : ℕ} (h : ring_char R = p) : char_p R p :=
 char_p.congr (ring_char R) h
 
 theorem eq_iff {p : ℕ} : ring_char R = p ↔ char_p R p :=
-⟨of_eq, eq.symm ∘ eq R⟩
+⟨of_eq, @eq R _ p⟩
 
 theorem dvd {x : ℕ} (hx : (x : R) = 0) : ring_char R ∣ x :=
 (spec R x).1 hx
 
 @[simp]
-lemma eq_zero [char_zero R] : ring_char R = 0 := (eq R (char_p.of_char_zero R)).symm
+lemma eq_zero [char_zero R] : ring_char R = 0 := eq R 0
 
 end ring_char
 


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)