### PR TITLE
[Merged by Bors] - feat(algebra/star/unitary): (re)define unitary elements of a star monoid

### DIFF
--- a/src/algebra/star/self_adjoint.lean
+++ b/src/algebra/star/self_adjoint.lean
@@ -52,6 +52,8 @@ by { rw [←add_subgroup.mem_carrier], exact iff.rfl }
 
 @[simp, norm_cast] lemma star_coe_eq {x : self_adjoint R} : star (x : R) = x := x.prop
 
+instance : inhabited (self_adjoint R) := ⟨0⟩
+
 end add_group
 
 instance [add_comm_group R] [star_add_monoid R] : add_comm_group (self_adjoint R) :=
@@ -64,6 +66,8 @@ variables [ring R] [star_ring R]
 instance : has_one (self_adjoint R) := ⟨⟨1, by rw [mem_iff, star_one]⟩⟩
 
 @[simp, norm_cast] lemma coe_one : (coe : self_adjoint R → R) (1 : self_adjoint R) = (1 : R) := rfl
+
+instance [nontrivial R] : nontrivial (self_adjoint R) := ⟨⟨0, 1, subtype.ne_of_val_ne zero_ne_one⟩⟩
 
 lemma one_mem : (1 : R) ∈ self_adjoint R := by simp only [mem_iff, star_one]
 

--- a/src/algebra/star/unitary.lean
+++ b/src/algebra/star/unitary.lean
@@ -75,6 +75,6 @@ instance : inhabited (unitary R) := ⟨1⟩
 
 lemma star_eq_inv (U : unitary R) : star U = U⁻¹ := rfl
 
-lemma star_eq_inv' : (star : unitary R → unitary R) = star := rfl
+lemma star_eq_inv' : (star : unitary R → unitary R) = has_inv.inv := rfl
 
 end unitary

--- a/src/algebra/star/unitary.lean
+++ b/src/algebra/star/unitary.lean
@@ -9,9 +9,9 @@ import group_theory.submonoid.operations
 /-!
 # Unitary elements of a star monoid
 
-
-## Main Definitions
-
+This file defines `unitary R`, where `R` is a star monoid, as the submonoid containing the elements
+that satisfy `star U * U = 1` and `U * star U = 1`, and these form a group.
+This includes, for instance, unitary operators on Hilbert spaces.
 
 ## Tags
 

--- a/src/algebra/star/unitary.lean
+++ b/src/algebra/star/unitary.lean
@@ -41,28 +41,25 @@ variables {R : Type*}
 namespace unitary
 variables [monoid R] [star_monoid R]
 
-@[simp] lemma mem_star_mul_self {U : R} (hU : U ∈ unitary R) : star U * U = 1 := hU.1
-@[simp] lemma mem_mul_star_self {U : R} (hU : U ∈ unitary R) : U * star U = 1 := hU.2
+@[simp] lemma star_mul_self_of_mem {U : R} (hU : U ∈ unitary R) : star U * U = 1 := hU.1
+@[simp] lemma mul_star_self_of_mem {U : R} (hU : U ∈ unitary R) : U * star U = 1 := hU.2
 
-instance : has_star (unitary R) :=
-⟨λ U, ⟨star U, ⟨by rw [star_star, mem_mul_star_self (subtype.mem U)],
-               by rw [star_star, mem_star_mul_self (subtype.mem U)]⟩⟩⟩
+lemma star_mem {U : R} (hU : U ∈ unitary R) : star U ∈ unitary R :=
+⟨by rw [star_star, mul_star_self_of_mem hU], by rw [star_star, star_mul_self_of_mem hU]⟩
 
-@[simp, norm_cast] lemma coe_star {U : unitary R} : (coe : unitary R → R) (star U) = star U := rfl
+@[simp] lemma star_mem_iff {U : R} : star U ∈ unitary R ↔ U ∈ unitary R :=
+⟨λ h, star_star U ▸ star_mem h, star_mem⟩
 
-@[simp] lemma star_mul_self (U : unitary R) : star U * U = 1 :=
-by { ext, simp only [coe_star, set_like.coe_mem, submonoid.coe_one, mem_star_mul_self,
-                      submonoid.coe_mul] }
+instance : has_star (unitary R) := ⟨λ U, ⟨star U, star_mem U.prop⟩⟩
 
-@[simp] lemma mul_star_self (U : unitary R) : U * star U = 1 :=
-by { ext, simp only [coe_star, set_like.coe_mem, mem_mul_star_self,
-                     submonoid.coe_one, submonoid.coe_mul], }
+@[simp, norm_cast] lemma coe_star {U : unitary R} : ↑(star U) = (star U : R) := rfl
 
-lemma coe_star_mul_self (U : unitary R) : (star U : R) * U = 1 :=
-by simp only [set_like.coe_mem, mem_star_mul_self]
+lemma coe_star_mul_self (U : unitary R) : (star U : R) * U = 1 := star_mul_self_of_mem U.prop
+lemma coe_mul_star_self (U : unitary R) :  (U : R) * star U = 1 := mul_star_self_of_mem U.prop
 
-lemma coe_mul_star_self (U : unitary R) :  (U : R) * star U = 1 :=
-by simp only [set_like.coe_mem, mem_mul_star_self]
+@[simp] lemma star_mul_self (U : unitary R) : star U * U = 1 := subtype.ext $ coe_star_mul_self U
+@[simp] lemma mul_star_self (U : unitary R) : U * star U = 1 := subtype.ext $ coe_mul_star_self U
+
 
 instance : group (unitary R) :=
 { inv := λ U, star U,
@@ -78,11 +75,5 @@ instance : star_monoid (unitary R) :=
 instance : inhabited (unitary R) := ⟨1⟩
 
 lemma star_eq_inv (U : unitary R) : star U = U⁻¹ := rfl
-
-lemma star_mem {U : R} (hU : U ∈ unitary R) : star U ∈ unitary R :=
-⟨by simp only [mem_mul_star_self hU, star_star], by simp only [mem_star_mul_self hU, star_star]⟩
-
-lemma star_mem_iff {U : R} : star U ∈ unitary R ↔ U ∈ unitary R :=
-⟨λ h, by { rw [←star_star U], exact star_mem h }, star_mem⟩
 
 end unitary

--- a/src/algebra/star/unitary.lean
+++ b/src/algebra/star/unitary.lean
@@ -75,6 +75,8 @@ instance : has_involutive_star (unitary R) :=
 instance : star_monoid (unitary R) :=
 ⟨λ _ _, by { ext, simp only [coe_star, submonoid.coe_mul, star_mul] }⟩
 
+instance : inhabited (unitary R) := ⟨1⟩
+
 lemma star_eq_inv (U : unitary R) : star U = U⁻¹ := rfl
 
 lemma star_mem {U : R} (hU : U ∈ unitary R) : star U ∈ unitary R :=

--- a/src/algebra/star/unitary.lean
+++ b/src/algebra/star/unitary.lean
@@ -60,9 +60,8 @@ lemma coe_mul_star_self (U : unitary R) :  (U : R) * star U = 1 := mul_star_self
 @[simp] lemma star_mul_self (U : unitary R) : star U * U = 1 := subtype.ext $ coe_star_mul_self U
 @[simp] lemma mul_star_self (U : unitary R) : U * star U = 1 := subtype.ext $ coe_mul_star_self U
 
-
 instance : group (unitary R) :=
-{ inv := λ U, star U,
+{ inv := star,
   mul_left_inv := star_mul_self,
   ..submonoid.to_monoid _ }
 
@@ -75,5 +74,7 @@ instance : star_monoid (unitary R) :=
 instance : inhabited (unitary R) := ⟨1⟩
 
 lemma star_eq_inv (U : unitary R) : star U = U⁻¹ := rfl
+
+lemma star_eq_inv' : (star : unitary R → unitary R) = star := rfl
 
 end unitary

--- a/src/algebra/star/unitary.lean
+++ b/src/algebra/star/unitary.lean
@@ -1,0 +1,86 @@
+/-
+Copyright (c) 2022 Frédéric Dupuis. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Shing Tak Lam, Frédéric Dupuis
+-/
+import algebra.star.basic
+import group_theory.submonoid.operations
+
+/-!
+# Unitary elements of a star monoid
+
+
+## Main Definitions
+
+
+## Tags
+
+unitary
+-/
+
+/--
+In a `star_monoid R`, `unitary R` is the submonoid consisting of all the elements `U` of
+`R` such that `star U * U = 1` and `U * star U = 1`.
+-/
+def unitary (R : Type*) [monoid R] [star_monoid R] : submonoid R :=
+{ carrier := {U | star U * U = 1 ∧ U * star U = 1},
+  one_mem' := by simp only [mul_one, and_self, set.mem_set_of_eq, star_one],
+  mul_mem' := λ U B ⟨hA₁, hA₂⟩ ⟨hB₁, hB₂⟩,
+  begin
+    refine ⟨_, _⟩,
+    { calc star (U * B) * (U * B) = star B * star U * U * B     : by simp only [mul_assoc, star_mul]
+                            ...   = star B * (star U * U) * B   : by rw [←mul_assoc]
+                            ...   = 1                           : by rw [hA₁, mul_one, hB₁] },
+    { calc U * B * star (U * B) = U * B * (star B * star U)     : by rw [star_mul]
+                            ... = U * (B * star B) * star U     : by simp_rw [←mul_assoc]
+                            ... = 1                             : by rw [hB₂, mul_one, hA₂] }
+  end }
+
+variables {R : Type*}
+
+namespace unitary
+variables [monoid R] [star_monoid R]
+
+@[simp] lemma mem_star_mul_self {U : R} (hU : U ∈ unitary R) : star U * U = 1 := hU.1
+@[simp] lemma mem_mul_star_self {U : R} (hU : U ∈ unitary R) : U * star U = 1 := hU.2
+
+instance : has_star (unitary R) :=
+⟨λ U, ⟨star U, ⟨by rw [star_star, mem_mul_star_self (subtype.mem U)],
+               by rw [star_star, mem_star_mul_self (subtype.mem U)]⟩⟩⟩
+
+@[simp, norm_cast] lemma coe_star {U : unitary R} : (coe : unitary R → R) (star U) = star U := rfl
+
+@[simp] lemma star_mul_self (U : unitary R) : star U * U = 1 :=
+by { ext, simp only [coe_star, set_like.coe_mem, submonoid.coe_one, mem_star_mul_self,
+                      submonoid.coe_mul] }
+
+@[simp] lemma mul_star_self (U : unitary R) : U * star U = 1 :=
+by { ext, simp only [coe_star, set_like.coe_mem, mem_mul_star_self,
+                     submonoid.coe_one, submonoid.coe_mul], }
+
+lemma coe_star_mul_self (U : unitary R) : (star U : R) * U = 1 :=
+by simp only [set_like.coe_mem, mem_star_mul_self]
+
+lemma coe_mul_star_self (U : unitary R) :  (U : R) * star U = 1 :=
+by simp only [set_like.coe_mem, mem_mul_star_self]
+
+instance : group (unitary R) :=
+{ inv := λ U, star U,
+  mul_left_inv := star_mul_self,
+  ..submonoid.to_monoid _ }
+
+instance : has_involutive_star (unitary R) :=
+⟨λ _, by { ext, simp only [coe_star, star_star] }⟩
+
+instance : star_monoid (unitary R) :=
+⟨λ _ _, by { ext, simp only [coe_star, submonoid.coe_mul, star_mul] }⟩
+
+lemma star_eq_inv (U : unitary R) : star U = U⁻¹ := rfl
+
+lemma star_mem {U : R} (hU : U ∈ unitary R) : star U ∈ unitary R :=
+⟨by simp only [mem_mul_star_self hU, star_star], by simp only [mem_star_mul_self hU, star_star]⟩
+
+lemma star_mem_iff {U : R} : star U ∈ unitary R ↔ U ∈ unitary R :=
+⟨λ h, by { rw [←star_star U], exact star_mem h }, star_mem⟩
+
+end unitary

--- a/src/algebra/star/unitary.lean
+++ b/src/algebra/star/unitary.lean
@@ -9,7 +9,7 @@ import group_theory.submonoid.operations
 /-!
 # Unitary elements of a star monoid
 
-This file defines `unitary R`, where `R` is a star monoid, as the submonoid containing the elements
+This file defines `unitary R`, where `R` is a star monoid, as the submonoid made of the elements
 that satisfy `star U * U = 1` and `U * star U = 1`, and these form a group.
 This includes, for instance, unitary operators on Hilbert spaces.
 

--- a/src/algebra/star/unitary.lean
+++ b/src/algebra/star/unitary.lean
@@ -13,6 +13,8 @@ This file defines `unitary R`, where `R` is a star monoid, as the submonoid cont
 that satisfy `star U * U = 1` and `U * star U = 1`, and these form a group.
 This includes, for instance, unitary operators on Hilbert spaces.
 
+See also `matrix.unitary_group` for specializations to `unitary (matrix n n R)`.
+
 ## Tags
 
 unitary

--- a/src/analysis/normed_space/star.lean
+++ b/src/analysis/normed_space/star.lean
@@ -7,6 +7,7 @@ Authors: Frédéric Dupuis
 import analysis.normed.group.hom
 import analysis.normed_space.basic
 import analysis.normed_space.linear_isometry
+import algebra.star.unitary
 
 /-!
 # Normed star rings and algebras
@@ -136,6 +137,28 @@ begin
   { exact h.symm },
   { exfalso,
     exact one_ne_zero (norm_eq_zero.mp h) }
+end
+
+@[simp] lemma norm_coe_unitary [nontrivial E] (U : unitary E) : ∥(U : E)∥ = 1 :=
+begin
+  have := calc
+    ∥(U : E)∥^2 = ∥(U : E)∥ * ∥(U : E)∥ : pow_two _
+           ...  = ∥(U⋆ * U : E)∥        : cstar_ring.norm_star_mul_self.symm
+           ...  = ∥(1 : E)∥             : by simp only [set_like.coe_mem, unitary.mem_star_mul_self]
+           ...  = 1                     : cstar_ring.norm_one,
+  refine (sq_eq_sq (norm_nonneg _) zero_le_one).mp _,
+  rw [one_pow 2, this],
+end
+
+@[simp] lemma norm_coe_unitary_mul [nontrivial E] (U : unitary E) (A : E) : ∥(U : E) * A∥ = ∥A∥ :=
+begin
+  refine le_antisymm _ _,
+  { calc _  ≤ ∥(U : E)∥ * ∥A∥     : norm_mul_le _ _
+        ... = ∥A∥                 : by rw [norm_coe_unitary, one_mul] },
+  { calc ∥A∥ = ∥(U : E)⋆ * U * A∥  : by { nth_rewrite_lhs 0 [←one_mul A],
+                                         rw [←unitary.coe_star_mul_self U, mul_assoc] }
+        ... ≤ ∥(U : E)⋆∥ * ∥(U : E) * A∥   : by { rw [mul_assoc], exact norm_mul_le _ _ }
+        ... = ∥(U : E) * A∥   : by simp only [one_mul, norm_coe_unitary, norm_star] }
 end
 
 end cstar_ring

--- a/src/analysis/normed_space/star.lean
+++ b/src/analysis/normed_space/star.lean
@@ -139,6 +139,7 @@ begin
     exact one_ne_zero (norm_eq_zero.mp h) }
 end
 
+@[priority 100] -- see Note [lower instance priority]
 instance [nontrivial E] : norm_one_class E := ⟨norm_one⟩
 
 lemma norm_coe_unitary [nontrivial E] (U : unitary E) : ∥(U : E)∥ = 1 :=

--- a/src/analysis/normed_space/star.lean
+++ b/src/analysis/normed_space/star.lean
@@ -144,7 +144,7 @@ begin
   have := calc
     ∥(U : E)∥^2 = ∥(U : E)∥ * ∥(U : E)∥ : pow_two _
            ...  = ∥(U⋆ * U : E)∥        : cstar_ring.norm_star_mul_self.symm
-           ...  = ∥(1 : E)∥             : by simp only [set_like.coe_mem, unitary.mem_star_mul_self]
+           ...  = ∥(1 : E)∥             : by rw unitary.coe_star_mul_self
            ...  = 1                     : cstar_ring.norm_one,
   refine (sq_eq_sq (norm_nonneg _) zero_le_one).mp _,
   rw [one_pow 2, this],

--- a/src/analysis/normed_space/star.lean
+++ b/src/analysis/normed_space/star.lean
@@ -139,6 +139,8 @@ begin
     exact one_ne_zero (norm_eq_zero.mp h) }
 end
 
+instance [nontrivial E] : norm_one_class E := ⟨norm_one⟩
+
 lemma norm_coe_unitary [nontrivial E] (U : unitary E) : ∥(U : E)∥ = 1 :=
 begin
   have := calc

--- a/src/analysis/normed_space/star.lean
+++ b/src/analysis/normed_space/star.lean
@@ -139,7 +139,7 @@ begin
     exact one_ne_zero (norm_eq_zero.mp h) }
 end
 
-@[simp] lemma norm_coe_unitary [nontrivial E] (U : unitary E) : ∥(U : E)∥ = 1 :=
+lemma norm_coe_unitary [nontrivial E] (U : unitary E) : ∥(U : E)∥ = 1 :=
 begin
   have := calc
     ∥(U : E)∥^2 = ∥(U : E)∥ * ∥(U : E)∥ : pow_two _
@@ -168,7 +168,7 @@ begin
     rw [h_nontriv (U * A)] }
 end
 
-@[simp] lemma norm_mem_unitary_mul {U : E} (A : E) (hU : U ∈ unitary E) : ∥U * A∥ = ∥A∥ :=
+lemma norm_mem_unitary_mul {U : E} (A : E) (hU : U ∈ unitary E) : ∥U * A∥ = ∥A∥ :=
 norm_coe_unitary_mul ⟨U, hU⟩ A
 
 @[simp] lemma norm_mul_coe_unitary (A : E) (U : unitary E) : ∥A * U∥ = ∥A∥ :=
@@ -177,7 +177,7 @@ calc _ = ∥star (star (U : E) * star A)∥   : by simp only [star_star, star_mu
   ...  = ∥star A∥                         : norm_mem_unitary_mul (star A) (unitary.star_mem U.prop)
   ...  = ∥A∥                              : norm_star
 
-@[simp] lemma norm_mul_mem_unitary (A : E) {U : E} (hU : U ∈ unitary E) : ∥A * U∥ = ∥A∥ :=
+lemma norm_mul_mem_unitary (A : E) {U : E} (hU : U ∈ unitary E) : ∥A * U∥ = ∥A∥ :=
 norm_mul_coe_unitary A ⟨U, hU⟩
 
 end cstar_ring

--- a/src/analysis/normed_space/star.lean
+++ b/src/analysis/normed_space/star.lean
@@ -171,6 +171,9 @@ begin
     rw [h_nontriv (U * A)] }
 end
 
+@[simp] lemma norm_unitary_smul (U : unitary E) (A : E) : ∥U • A∥ = ∥A∥ :=
+norm_coe_unitary_mul U A
+
 lemma norm_mem_unitary_mul {U : E} (A : E) (hU : U ∈ unitary E) : ∥U * A∥ = ∥A∥ :=
 norm_coe_unitary_mul ⟨U, hU⟩ A
 

--- a/src/analysis/normed_space/star.lean
+++ b/src/analysis/normed_space/star.lean
@@ -153,7 +153,7 @@ begin
   rw [one_pow 2, this],
 end
 
-@[simp] lemma norm_mem_unitary [nontrivial E] {U : E} (hU : U ∈ unitary E) : ∥U∥ = 1 :=
+@[simp] lemma norm_of_mem_unitary [nontrivial E] {U : E} (hU : U ∈ unitary E) : ∥U∥ = 1 :=
 norm_coe_unitary ⟨U, hU⟩
 
 @[simp] lemma norm_coe_unitary_mul (U : unitary E) (A : E) : ∥(U : E) * A∥ = ∥A∥ :=

--- a/src/analysis/normed_space/star.lean
+++ b/src/analysis/normed_space/star.lean
@@ -150,16 +150,35 @@ begin
   rw [one_pow 2, this],
 end
 
-@[simp] lemma norm_coe_unitary_mul [nontrivial E] (U : unitary E) (A : E) : ∥(U : E) * A∥ = ∥A∥ :=
+@[simp] lemma norm_mem_unitary [nontrivial E] {U : E} (hU : U ∈ unitary E) : ∥U∥ = 1 :=
+norm_coe_unitary ⟨U, hU⟩
+
+@[simp] lemma norm_coe_unitary_mul (U : unitary E) (A : E) : ∥(U : E) * A∥ = ∥A∥ :=
 begin
-  refine le_antisymm _ _,
-  { calc _  ≤ ∥(U : E)∥ * ∥A∥     : norm_mul_le _ _
-        ... = ∥A∥                 : by rw [norm_coe_unitary, one_mul] },
-  { calc ∥A∥ = ∥(U : E)⋆ * U * A∥  : by { nth_rewrite_lhs 0 [←one_mul A],
-                                         rw [←unitary.coe_star_mul_self U, mul_assoc] }
-        ... ≤ ∥(U : E)⋆∥ * ∥(U : E) * A∥   : by { rw [mul_assoc], exact norm_mul_le _ _ }
-        ... = ∥(U : E) * A∥   : by simp only [one_mul, norm_coe_unitary, norm_star] }
+  by_cases h_nontriv : ∃ (x y : E), x ≠ y,
+  { haveI : nontrivial E := ⟨h_nontriv⟩,
+    refine le_antisymm _ _,
+    { calc _  ≤ ∥(U : E)∥ * ∥A∥     : norm_mul_le _ _
+          ... = ∥A∥                 : by rw [norm_coe_unitary, one_mul] },
+    { calc ∥A∥ = ∥(U : E)⋆ * U * A∥  : by { nth_rewrite_lhs 0 [←one_mul A],
+                                           rw [←unitary.coe_star_mul_self U, mul_assoc] }
+          ... ≤ ∥(U : E)⋆∥ * ∥(U : E) * A∥   : by { rw [mul_assoc], exact norm_mul_le _ _ }
+          ... = ∥(U : E) * A∥   : by simp only [one_mul, norm_coe_unitary, norm_star] } },
+  { push_neg at h_nontriv,
+    rw [h_nontriv (U * A)] }
 end
+
+@[simp] lemma norm_mem_unitary_mul {U : E} (A : E) (hU : U ∈ unitary E) : ∥U * A∥ = ∥A∥ :=
+norm_coe_unitary_mul ⟨U, hU⟩ A
+
+@[simp] lemma norm_mul_coe_unitary (A : E) (U : unitary E) : ∥A * U∥ = ∥A∥ :=
+calc _ = ∥star (star (U : E) * star A)∥   : by simp only [star_star, star_mul]
+  ...  = ∥star (U : E) * star A∥          : by rw [norm_star]
+  ...  = ∥star A∥                         : norm_mem_unitary_mul (star A) (unitary.star_mem U.prop)
+  ...  = ∥A∥                              : norm_star
+
+@[simp] lemma norm_mul_mem_unitary (A : E) {U : E} (hU : U ∈ unitary E) : ∥A * U∥ = ∥A∥ :=
+norm_mul_coe_unitary A ⟨U, hU⟩
 
 end cstar_ring
 

--- a/src/linear_algebra/unitary_group.lean
+++ b/src/linear_algebra/unitary_group.lean
@@ -5,6 +5,7 @@ Authors: Shing Tak Lam
 -/
 import linear_algebra.matrix.to_lin
 import linear_algebra.matrix.nonsingular_inverse
+import algebra.star.unitary
 
 /-!
 # The Unitary Group
@@ -35,22 +36,6 @@ matrix group, group, unitary group, orthogonal group
 
 universes u v
 
-section
-
-variables (M : Type v) [monoid M] [star_monoid M]
-
-/--
-In a `star_monoid M`, `unitary_submonoid M` is the submonoid consisting of all the elements of
-`M` such that `star A * A = 1`.
--/
-def unitary_submonoid : submonoid M :=
-{ carrier := {A | star A * A = 1},
-  one_mem' := by simp,
-  mul_mem' := λ A B (hA : star A * A = 1) (hB : star B * B = 1), show star (A * B) * (A * B) = 1,
-  by rwa [star_mul, ←mul_assoc, mul_assoc _ _ A, hA, mul_one] }
-
-end
-
 namespace matrix
 open linear_map
 open_locale matrix
@@ -63,26 +48,12 @@ variables (α : Type v) [comm_ring α] [star_ring α]
 /--
 `unitary_group n` is the group of `n` by `n` matrices where the star-transpose is the inverse.
 -/
-@[derive monoid]
-def unitary_group : Type* := unitary_submonoid (matrix n n α)
+abbreviation unitary_group := unitary (matrix n n α)
 
 end
 
 variables {n : Type u} [decidable_eq n] [fintype n]
 variables {α : Type v} [comm_ring α] [star_ring α]
-
-namespace unitary_submonoid
-
-lemma star_mem {A : matrix n n α} (h : A ∈ unitary_submonoid (matrix n n α)) :
-  star A ∈ unitary_submonoid (matrix n n α) :=
-mul_eq_one_comm.mp $ (star_star A).symm ▸ h
-
-@[simp]
-lemma star_mem_iff {A : matrix n n α} :
-  star A ∈ unitary_submonoid (matrix n n α) ↔ A ∈ unitary_submonoid (matrix n n α) :=
-⟨λ ha, star_star A ▸ star_mem ha, star_mem⟩
-
-end unitary_submonoid
 
 namespace unitary_group
 
@@ -105,18 +76,8 @@ subtype.ext_iff_val.trans ⟨(λ h i j, congr_fun (congr_fun h i) j), matrix.ext
 @[ext] lemma ext (A B : unitary_group n α) : (∀ i j, A i j = B i j) → A = B :=
 (unitary_group.ext_iff A B).mpr
 
-instance : has_inv (unitary_group n α) :=
-⟨λ A, ⟨star A.1, unitary_submonoid.star_mem_iff.mpr A.2⟩⟩
-
-instance : star_monoid (unitary_group n α) :=
-{ star := λ A, ⟨star A.1, unitary_submonoid.star_mem A.2⟩,
-  star_involutive := λ A, subtype.ext $ star_star A.1,
-  star_mul := λ A B, subtype.ext $ star_mul A.1 B.1 }
-
 @[simp]
-lemma star_mul_self (A : unitary_group n α) : star A ⬝ A = 1 := A.2
-
-instance : inhabited (unitary_group n α) := ⟨1⟩
+lemma star_mul_self (A : unitary_group n α) : star A ⬝ A = 1 := A.2.1
 
 section coe_lemmas
 
@@ -144,21 +105,16 @@ matrix.to_lin'_one
 
 end coe_lemmas
 
-instance : group (unitary_group n α) :=
-{ mul_left_inv := λ A, subtype.eq A.2,
-  ..unitary_group.has_inv,
-  ..unitary_group.monoid n α }
-
 /-- `to_linear_equiv A` is matrix multiplication of vectors by `A`, as a linear equivalence. -/
 def to_linear_equiv (A : unitary_group n α) : (n → α) ≃ₗ[α] (n → α) :=
-{ inv_fun := A⁻¹.to_lin',
+{ inv_fun := to_lin' A⁻¹,
   left_inv := λ x, calc
-    A⁻¹.to_lin'.comp A.to_lin' x
-        = (A⁻¹ * A).to_lin' x : by rw [←to_lin'_mul]
+    (to_lin' A⁻¹).comp (to_lin' A) x
+        = (to_lin' (A⁻¹ * A)) x : by rw [←to_lin'_mul]
     ... = x : by rw [mul_left_inv, to_lin'_one, id_apply],
   right_inv := λ x, calc
-    A.to_lin'.comp A⁻¹.to_lin' x
-        = (A * A⁻¹).to_lin' x : by rw [←to_lin'_mul]
+    (to_lin' A).comp (to_lin' A⁻¹) x
+        = to_lin' (A * A⁻¹) x : by rw [←to_lin'_mul]
     ... = x : by rw [mul_right_inv, to_lin'_one, id_apply],
   ..matrix.to_lin' A }
 
@@ -167,7 +123,7 @@ def to_GL (A : unitary_group n α) : general_linear_group α (n → α) :=
 general_linear_group.of_linear_equiv (to_linear_equiv A)
 
 lemma coe_to_GL (A : unitary_group n α) :
-  ↑(to_GL A) = A.to_lin' :=
+  ↑(to_GL A) = to_lin' A :=
 rfl
 
 @[simp]


### PR DESCRIPTION
This PR defines `unitary R` for a star monoid `R` as the submonoid containing the elements that satisfy both `star U * U = 1` and `U * star U = 1`. We show basic properties (i.e. that this forms a group) and show that they
preserve the norm when `R` is a C* ring.

Note that this replaces `unitary_submonoid`, which only included the condition `star U * U = 1` -- see [the discussion](https://leanprover.zulipchat.com/#narrow/stream/116395-maths/topic/unitary.20submonoid) on Zulip.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
