### PR TITLE
[Merged by Bors] - feat(analysis/special_functions/trigonometric/angle): `neg_coe_pi`

### DIFF
--- a/src/analysis/special_functions/trigonometric/angle.lean
+++ b/src/analysis/special_functions/trigonometric/angle.lean
@@ -56,6 +56,13 @@ by simp only [quotient_add_group.eq, add_subgroup.zmultiples_eq_closure,
 @[simp] lemma coe_two_pi : ↑(2 * π : ℝ) = (0 : angle) :=
 angle_eq_iff_two_pi_dvd_sub.2 ⟨1, by rw [sub_zero, int.cast_one, mul_one]⟩
 
+@[simp] lemma neg_coe_pi : -(π : angle) = π :=
+begin
+  rw [←coe_neg, angle_eq_iff_two_pi_dvd_sub],
+  use -1,
+  simp [two_mul, sub_eq_add_neg]
+end
+
 theorem cos_eq_iff_eq_or_eq_neg {θ ψ : ℝ} : cos θ = cos ψ ↔ (θ : angle) = ψ ∨ (θ : angle) = -ψ :=
 begin
   split,


### PR DESCRIPTION
Add the lemma that `-π` and `π` are the same `real.angle` (angle mod 2π).



---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
