### PR TITLE
[Merged by Bors] - feat(analysis/seminorm): add composition with linear maps

### DIFF
--- a/src/analysis/seminorm.lean
+++ b/src/analysis/seminorm.lean
@@ -383,6 +383,7 @@ end add_monoid
 section module
 variables [add_comm_group E] [add_comm_group F] [add_comm_group G]
 variables [module 𝕜 E] [module 𝕜 F] [module 𝕜 G]
+variables [semiring R] [module R ℝ] [has_scalar R ℝ≥0] [is_scalar_tower R ℝ≥0 ℝ]
 
 /-- Composition of a seminorm with a linear map is a seminorm. -/
 def comp (p : seminorm 𝕜 F) (f : E →ₗ[𝕜] F) : seminorm 𝕜 E :=
@@ -419,7 +420,7 @@ begin
   exact p.triangle _ _,
 end
 
-lemma smul_comp (p : seminorm 𝕜 F) (f : E →ₗ[𝕜] F) (c : ℝ≥0) : (c • p).comp f = c • (p.comp f) :=
+lemma smul_comp (p : seminorm 𝕜 F) (f : E →ₗ[𝕜] F) (c : R) : (c • p).comp f = c • (p.comp f) :=
 ext $ λ _, rfl
 
 lemma comp_mono {p : seminorm 𝕜 F} {q : seminorm 𝕜 F} (f : E →ₗ[𝕜] F) (hp : p ≤ q) :

--- a/src/analysis/seminorm.lean
+++ b/src/analysis/seminorm.lean
@@ -68,7 +68,7 @@ Absorbent and balanced sets in a vector space over a normed field.
 open normed_field set
 open_locale pointwise topological_space
 
-variables {𝕜 E ι : Type*}
+variables {𝕜 E E' ι : Type*}
 
 section semi_normed_ring
 variables [semi_normed_ring 𝕜]
@@ -313,8 +313,29 @@ calc p 0 = p ((0 : 𝕜) • 0) : by rw zero_smul
 end smul_with_zero
 end add_monoid
 
+section module
+variables [add_comm_group E] [add_comm_group E'] [module 𝕜 E] [module 𝕜 E']
+
+/-- Composition of a seminorm with a linear map is a seminorm. -/
+def comp (p : seminorm 𝕜 E') (f : E →ₗ[𝕜] E') : seminorm 𝕜 E :=
+  { to_fun := λ x, p(f x),
+    smul' := λ _ _, (congr_arg p (f.map_smul _ _)).trans (p.smul _ _),
+    triangle' := λ _ _, eq.trans_le (congr_arg p (f.map_add _ _)) (p.triangle _ _) }
+
+lemma coe_comp (p : seminorm 𝕜 E') (f : E →ₗ[𝕜] E') : ⇑(p.comp f) = p ∘ f := rfl
+
+lemma comp_apply (p : seminorm 𝕜 E') (f : E →ₗ[𝕜] E') (x : E) : (p.comp f) x = p(f x) := rfl
+
+lemma comp_mono {p : seminorm 𝕜 E'} {q : seminorm 𝕜 E'} (f : E →ₗ[𝕜] E') (hp : p ≤ q) :
+  p.comp f ≤ q.comp f :=
+begin
+  intros x,
+  simp_rw comp_apply,
+  exact hp (f x),
+end
+
 section norm_one_class
-variables [norm_one_class 𝕜] [add_comm_group E] [module 𝕜 E] (p : seminorm 𝕜 E) (x y : E) (r : ℝ)
+variables [norm_one_class 𝕜] (p : seminorm 𝕜 E) (x y : E) (r : ℝ)
 
 @[simp]
 protected lemma neg : p (-x) = p x :=
@@ -354,6 +375,7 @@ begin
 end
 
 end norm_one_class
+end module
 
 /-! ### Seminorm ball -/
 
@@ -395,7 +417,19 @@ end
 end has_scalar
 
 section module
-variables [norm_one_class 𝕜] [module 𝕜 E] (p : seminorm 𝕜 E)
+
+variables [module 𝕜 E]
+variables [add_comm_group E'] [module 𝕜 E']
+
+lemma comp_ball (p : seminorm 𝕜 E') (f : E →ₗ[𝕜] E') (x : E) (r : ℝ) :
+  (p.comp f).ball x r = f ⁻¹' (p.ball (f x) r) :=
+begin
+  ext,
+  simp_rw [ball, mem_preimage, comp_apply, set.mem_set_of_eq, map_sub],
+end
+
+section norm_one_class
+variables [norm_one_class 𝕜] (p : seminorm 𝕜 E)
 
 @[simp] lemma ball_bot {r : ℝ} (x : E) (hr : 0 < r) : ball (⊥ : seminorm 𝕜 E) x r = set.univ :=
 ball_zero' x hr
@@ -424,6 +458,7 @@ begin
   exact ball_finset_sup_eq_Inter _ _ _ hr,
 end
 
+end norm_one_class
 end module
 end add_comm_group
 end semi_normed_ring

--- a/src/analysis/seminorm.lean
+++ b/src/analysis/seminorm.lean
@@ -468,9 +468,9 @@ section normed_field
 variables [normed_field 𝕜] [add_comm_group E] [add_comm_group F] [module 𝕜 E] [module 𝕜 F]
 
 lemma comp_smul (p : seminorm 𝕜 F) (f : E →ₗ[𝕜] F) (c : 𝕜) :
-  p.comp (c • f) = (∥c∥.to_nnreal) • (p.comp f) :=
+  p.comp (c • f) = ∥c∥₊ • p.comp f :=
 ext $ λ _, by rw [comp_apply, smul_apply, linear_map.smul_apply, p.smul, nnreal.smul_def,
-  real.coe_to_nnreal _ (norm_nonneg c), smul_eq_mul, comp_apply]
+  coe_nnnorm, smul_eq_mul, comp_apply]
 
 lemma comp_smul_apply (p : seminorm 𝕜 F) (f : E →ₗ[𝕜] F) (c : 𝕜) (x : E) :
   p.comp (c • f) x = ∥c∥ * p (f x) := p.smul _ _

--- a/src/analysis/seminorm.lean
+++ b/src/analysis/seminorm.lean
@@ -473,8 +473,25 @@ end
 
 end norm_one_class
 end module
+end semi_normed_ring
+
+section normed_field
+variables [normed_field 𝕜] [add_comm_group E] [add_comm_group F] [module 𝕜 E] [module 𝕜 F]
+
+lemma comp_smul (p : seminorm 𝕜 F) (f : E →ₗ[𝕜] F) (c : 𝕜) :
+  p.comp (c • f) = (∥c∥.to_nnreal) • (p.comp f) :=
+ext $ λ _, by rw [comp_apply, smul_apply, linear_map.smul_apply, p.smul, nnreal.smul_def,
+  real.coe_to_nnreal _ (norm_nonneg c), smul_eq_mul, comp_apply]
+
+lemma comp_smul_apply (p : seminorm 𝕜 F) (f : E →ₗ[𝕜] F) (c : 𝕜) (x : E) :
+  p.comp (c • f) x = ∥c∥ * p (f x) := p.smul _ _
+
+end normed_field
 
 /-! ### Seminorm ball -/
+
+section semi_normed_ring
+variables [semi_normed_ring 𝕜]
 
 section add_comm_group
 variables [add_comm_group E]

--- a/src/analysis/seminorm.lean
+++ b/src/analysis/seminorm.lean
@@ -271,6 +271,8 @@ instance : has_zero (seminorm 𝕜 E) :=
 
 @[simp] lemma coe_zero : ⇑(0 : seminorm 𝕜 E) = 0 := rfl
 
+@[simp] lemma zero_apply (x : E) : (0 : seminorm 𝕜 E) x = 0 := rfl
+
 instance : inhabited (seminorm 𝕜 E) := ⟨0⟩
 
 variables (p : seminorm 𝕜 E) (c : 𝕜) (x y : E) (r : ℝ)
@@ -329,6 +331,12 @@ lemma comp_apply (p : seminorm 𝕜 F) (f : E →ₗ[𝕜] F) (x : E) : (p.comp 
 
 @[simp] lemma comp_id (p : seminorm 𝕜 E) : p.comp linear_map.id = p :=
 ext $ λ _, rfl
+
+@[simp] lemma comp_zero (p : seminorm 𝕜 F) : p.comp (0 : E →ₗ[𝕜] F) = 0 :=
+ext $ λ _, by rw [comp_apply, linear_map.zero_apply, seminorm.zero, seminorm.zero_apply]
+
+@[simp] lemma zero_comp (f : E →ₗ[𝕜] F) : (0 : seminorm 𝕜 F).comp f = 0 :=
+ext $ λ _, by simp_rw [comp_apply, seminorm.zero_apply]
 
 lemma comp_comp (p : seminorm 𝕜 G) (g : F →ₗ[𝕜] G) (f : E →ₗ[𝕜] F) :
   p.comp (g.comp f) = (p.comp g).comp f :=

--- a/src/analysis/seminorm.lean
+++ b/src/analysis/seminorm.lean
@@ -464,8 +464,8 @@ end norm_one_class
 end module
 end semi_normed_ring
 
-section normed_field
-variables [normed_field 𝕜] [add_comm_group E] [add_comm_group F] [module 𝕜 E] [module 𝕜 F]
+section semi_normed_comm_ring
+variables [semi_normed_comm_ring 𝕜] [add_comm_group E] [add_comm_group F] [module 𝕜 E] [module 𝕜 F]
 
 lemma comp_smul (p : seminorm 𝕜 F) (f : E →ₗ[𝕜] F) (c : 𝕜) :
   p.comp (c • f) = ∥c∥₊ • p.comp f :=
@@ -475,7 +475,7 @@ ext $ λ _, by rw [comp_apply, smul_apply, linear_map.smul_apply, p.smul, nnreal
 lemma comp_smul_apply (p : seminorm 𝕜 F) (f : E →ₗ[𝕜] F) (c : 𝕜) (x : E) :
   p.comp (c • f) x = ∥c∥ * p (f x) := p.smul _ _
 
-end normed_field
+end semi_normed_comm_ring
 
 /-! ### Seminorm ball -/
 

--- a/src/analysis/seminorm.lean
+++ b/src/analysis/seminorm.lean
@@ -383,7 +383,7 @@ end add_monoid
 section module
 variables [add_comm_group E] [add_comm_group F] [add_comm_group G]
 variables [module 𝕜 E] [module 𝕜 F] [module 𝕜 G]
-variables [semiring R] [module R ℝ] [has_scalar R ℝ≥0] [is_scalar_tower R ℝ≥0 ℝ]
+variables [has_scalar R ℝ] [has_scalar R ℝ≥0] [is_scalar_tower R ℝ≥0 ℝ]
 
 /-- Composition of a seminorm with a linear map is a seminorm. -/
 def comp (p : seminorm 𝕜 F) (f : E →ₗ[𝕜] F) : seminorm 𝕜 E :=

--- a/src/analysis/seminorm.lean
+++ b/src/analysis/seminorm.lean
@@ -418,7 +418,7 @@ lemma smul_comp (p : seminorm 𝕜 F) (f : E →ₗ[𝕜] F) (c : R) : (c • p)
 ext $ λ _, rfl
 
 lemma comp_mono {p : seminorm 𝕜 F} {q : seminorm 𝕜 F} (f : E →ₗ[𝕜] F) (hp : p ≤ q) :
-  p.comp f ≤ q.comp f := λ x, hp (f x)
+  p.comp f ≤ q.comp f := λ _, hp _
 
 section norm_one_class
 variables [norm_one_class 𝕜] (p : seminorm 𝕜 E) (x y : E) (r : ℝ)

--- a/src/analysis/seminorm.lean
+++ b/src/analysis/seminorm.lean
@@ -325,7 +325,7 @@ def comp (p : seminorm 𝕜 F) (f : E →ₗ[𝕜] F) : seminorm 𝕜 E :=
 
 lemma coe_comp (p : seminorm 𝕜 F) (f : E →ₗ[𝕜] F) : ⇑(p.comp f) = p ∘ f := rfl
 
-lemma comp_apply (p : seminorm 𝕜 F) (f : E →ₗ[𝕜] F) (x : E) : (p.comp f) x = p(f x) := rfl
+@[simp] lemma comp_apply (p : seminorm 𝕜 F) (f : E →ₗ[𝕜] F) (x : E) : (p.comp f) x = p (f x) := rfl
 
 @[simp] lemma comp_id (p : seminorm 𝕜 E) : p.comp linear_map.id = p :=
 ext $ λ _, rfl

--- a/src/analysis/seminorm.lean
+++ b/src/analysis/seminorm.lean
@@ -70,7 +70,6 @@ open_locale pointwise topological_space nnreal
 
 variables {R 𝕜 E F G ι : Type*}
 
-
 section semi_normed_ring
 variables [semi_normed_ring 𝕜]
 
@@ -399,14 +398,29 @@ lemma coe_comp (p : seminorm 𝕜 F) (f : E →ₗ[𝕜] F) : ⇑(p.comp f) = p 
 ext $ λ _, rfl
 
 @[simp] lemma comp_zero (p : seminorm 𝕜 F) : p.comp (0 : E →ₗ[𝕜] F) = 0 :=
-ext $ λ _, by rw [comp_apply, linear_map.zero_apply, seminorm.zero, seminorm.zero_apply]
+ext $ λ _, seminorm.zero _
 
 @[simp] lemma zero_comp (f : E →ₗ[𝕜] F) : (0 : seminorm 𝕜 F).comp f = 0 :=
-ext $ λ _, by simp_rw [comp_apply, seminorm.zero_apply]
+ext $ λ _, rfl
 
 lemma comp_comp (p : seminorm 𝕜 G) (g : F →ₗ[𝕜] G) (f : E →ₗ[𝕜] F) :
   p.comp (g.comp f) = (p.comp g).comp f :=
 ext $ λ _, by simp_rw [comp_apply, linear_map.comp_apply]
+
+lemma add_comp (p q : seminorm 𝕜 F) (f : E →ₗ[𝕜] F) : (p + q).comp f = p.comp f + q.comp f :=
+ext $ λ _, rfl
+
+lemma comp_triangle (p : seminorm 𝕜 F) (f g : E →ₗ[𝕜] F) : p.comp (f + g) ≤ p.comp f + p.comp g :=
+begin
+  simp_rw [le_def, coe_add, coe_comp],
+  refine pi.le_def.mpr _,
+  intros x,
+  simp,
+  exact p.triangle _ _,
+end
+
+lemma smul_comp (p : seminorm 𝕜 F) (f : E →ₗ[𝕜] F) (c : ℝ≥0) : (c • p).comp f = c • (p.comp f) :=
+ext $ λ _, rfl
 
 lemma comp_mono {p : seminorm 𝕜 F} {q : seminorm 𝕜 F} (f : E →ₗ[𝕜] F) (hp : p ≤ q) :
   p.comp f ≤ q.comp f :=

--- a/src/analysis/seminorm.lean
+++ b/src/analysis/seminorm.lean
@@ -406,7 +406,7 @@ ext $ λ _, rfl
 
 lemma comp_comp (p : seminorm 𝕜 G) (g : F →ₗ[𝕜] G) (f : E →ₗ[𝕜] F) :
   p.comp (g.comp f) = (p.comp g).comp f :=
-ext $ λ _, by simp_rw [comp_apply, linear_map.comp_apply]
+ext $ λ _, rfl
 
 lemma add_comp (p q : seminorm 𝕜 F) (f : E →ₗ[𝕜] F) : (p + q).comp f = p.comp f + q.comp f :=
 ext $ λ _, rfl
@@ -416,7 +416,6 @@ begin
   simp_rw [le_def, coe_add, coe_comp],
   refine pi.le_def.mpr _,
   intros x,
-  simp,
   exact p.triangle _ _,
 end
 
@@ -424,12 +423,7 @@ lemma smul_comp (p : seminorm 𝕜 F) (f : E →ₗ[𝕜] F) (c : R) : (c • p)
 ext $ λ _, rfl
 
 lemma comp_mono {p : seminorm 𝕜 F} {q : seminorm 𝕜 F} (f : E →ₗ[𝕜] F) (hp : p ≤ q) :
-  p.comp f ≤ q.comp f :=
-begin
-  intros x,
-  simp_rw comp_apply,
-  exact hp (f x),
-end
+  p.comp f ≤ q.comp f := λ x, hp (f x)
 
 section norm_one_class
 variables [norm_one_class 𝕜] (p : seminorm 𝕜 E) (x y : E) (r : ℝ)

--- a/src/analysis/seminorm.lean
+++ b/src/analysis/seminorm.lean
@@ -412,12 +412,7 @@ lemma add_comp (p q : seminorm 𝕜 F) (f : E →ₗ[𝕜] F) : (p + q).comp f =
 ext $ λ _, rfl
 
 lemma comp_triangle (p : seminorm 𝕜 F) (f g : E →ₗ[𝕜] F) : p.comp (f + g) ≤ p.comp f + p.comp g :=
-begin
-  simp_rw [le_def, coe_add, coe_comp],
-  refine pi.le_def.mpr _,
-  intros x,
-  exact p.triangle _ _,
-end
+λ _, p.triangle _ _
 
 lemma smul_comp (p : seminorm 𝕜 F) (f : E →ₗ[𝕜] F) (c : R) : (c • p).comp f = c • (p.comp f) :=
 ext $ λ _, rfl

--- a/src/analysis/seminorm.lean
+++ b/src/analysis/seminorm.lean
@@ -68,7 +68,7 @@ Absorbent and balanced sets in a vector space over a normed field.
 open normed_field set
 open_locale pointwise topological_space
 
-variables {𝕜 E E' ι : Type*}
+variables {𝕜 E F G ι : Type*}
 
 section semi_normed_ring
 variables [semi_normed_ring 𝕜]
@@ -314,19 +314,27 @@ end smul_with_zero
 end add_monoid
 
 section module
-variables [add_comm_group E] [add_comm_group E'] [module 𝕜 E] [module 𝕜 E']
+variables [add_comm_group E] [add_comm_group F] [add_comm_group G]
+variables [module 𝕜 E] [module 𝕜 F] [module 𝕜 G]
 
 /-- Composition of a seminorm with a linear map is a seminorm. -/
-def comp (p : seminorm 𝕜 E') (f : E →ₗ[𝕜] E') : seminorm 𝕜 E :=
-  { to_fun := λ x, p(f x),
-    smul' := λ _ _, (congr_arg p (f.map_smul _ _)).trans (p.smul _ _),
-    triangle' := λ _ _, eq.trans_le (congr_arg p (f.map_add _ _)) (p.triangle _ _) }
+def comp (p : seminorm 𝕜 F) (f : E →ₗ[𝕜] F) : seminorm 𝕜 E :=
+{ to_fun := λ x, p(f x),
+  smul' := λ _ _, (congr_arg p (f.map_smul _ _)).trans (p.smul _ _),
+  triangle' := λ _ _, eq.trans_le (congr_arg p (f.map_add _ _)) (p.triangle _ _) }
 
-lemma coe_comp (p : seminorm 𝕜 E') (f : E →ₗ[𝕜] E') : ⇑(p.comp f) = p ∘ f := rfl
+lemma coe_comp (p : seminorm 𝕜 F) (f : E →ₗ[𝕜] F) : ⇑(p.comp f) = p ∘ f := rfl
 
-lemma comp_apply (p : seminorm 𝕜 E') (f : E →ₗ[𝕜] E') (x : E) : (p.comp f) x = p(f x) := rfl
+lemma comp_apply (p : seminorm 𝕜 F) (f : E →ₗ[𝕜] F) (x : E) : (p.comp f) x = p(f x) := rfl
 
-lemma comp_mono {p : seminorm 𝕜 E'} {q : seminorm 𝕜 E'} (f : E →ₗ[𝕜] E') (hp : p ≤ q) :
+@[simp] lemma comp_id (p : seminorm 𝕜 E) : p.comp linear_map.id = p :=
+ext $ λ _, rfl
+
+lemma comp_comp (p : seminorm 𝕜 G) (g : F →ₗ[𝕜] G) (f : E →ₗ[𝕜] F) :
+  p.comp (g.comp f) = (p.comp g).comp f :=
+ext $ λ _, by simp_rw [comp_apply, linear_map.comp_apply]
+
+lemma comp_mono {p : seminorm 𝕜 F} {q : seminorm 𝕜 F} (f : E →ₗ[𝕜] F) (hp : p ≤ q) :
   p.comp f ≤ q.comp f :=
 begin
   intros x,
@@ -419,9 +427,9 @@ end has_scalar
 section module
 
 variables [module 𝕜 E]
-variables [add_comm_group E'] [module 𝕜 E']
+variables [add_comm_group F] [module 𝕜 F]
 
-lemma comp_ball (p : seminorm 𝕜 E') (f : E →ₗ[𝕜] E') (x : E) (r : ℝ) :
+lemma ball_comp (p : seminorm 𝕜 F) (f : E →ₗ[𝕜] F) (x : E) (r : ℝ) :
   (p.comp f).ball x r = f ⁻¹' (p.ball (f x) r) :=
 begin
   ext,


### PR DESCRIPTION
This PR defines the composition of seminorms with linear maps and shows that composition is monotone and calculates the seminorm ball of the composition.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
