### PR TITLE
[Merged by Bors] - chore(analysis/normed/group/basic): merge `norm` and `semi_norm` lemmas on `prod` and `pi`

### DIFF
--- a/src/analysis/analytic/basic.lean
+++ b/src/analysis/analytic/basic.lean
@@ -531,8 +531,8 @@ begin
       (C * (a / r') ^ 2) * (∥y - (x, x)∥ * ∥y.1 - y.2∥) * ((n + 2) * a ^ n),
     have hAB : ∀ n, ∥A (n + 2)∥ ≤ B n := λ n,
     calc ∥A (n + 2)∥ ≤ ∥p (n + 2)∥ * ↑(n + 2) * ∥y - (x, x)∥ ^ (n + 1) * ∥y.1 - y.2∥ :
-      by simpa only [fintype.card_fin, pi_norm_const, prod.norm_def, pi.sub_def, prod.fst_sub,
-        prod.snd_sub, sub_sub_sub_cancel_right]
+      by simpa only [fintype.card_fin, pi_norm_const (_ : E), prod.norm_def, pi.sub_def,
+        prod.fst_sub, prod.snd_sub, sub_sub_sub_cancel_right]
         using (p $ n + 2).norm_image_sub_le (λ _, y.1 - x) (λ _, y.2 - x)
     ... = ∥p (n + 2)∥ * ∥y - (x, x)∥ ^ n * (↑(n + 2) * ∥y - (x, x)∥ * ∥y.1 - y.2∥) :
       by { rw [pow_succ ∥y - (x, x)∥], ac_refl }

--- a/src/analysis/normed/group/basic.lean
+++ b/src/analysis/normed/group/basic.lean
@@ -693,18 +693,18 @@ noncomputable instance prod.semi_normed_group : semi_normed_group (E × F) :=
   dist_eq := assume (x y : E × F),
     show max (dist x.1 y.1) (dist x.2 y.2) = (max ∥(x - y).1∥ ∥(x - y).2∥), by simp [dist_eq_norm] }
 
-lemma prod.semi_norm_def (x : E × F) : ∥x∥ = (max ∥x.1∥ ∥x.2∥) := rfl
+lemma prod.norm_def (x : E × F) : ∥x∥ = (max ∥x.1∥ ∥x.2∥) := rfl
 
-lemma prod.nnsemi_norm_def (x : E × F) : ∥x∥₊ = max (∥x.1∥₊) (∥x.2∥₊) :=
-by { have := x.semi_norm_def, simp only [← coe_nnnorm] at this, exact_mod_cast this }
+lemma prod.nnnorm_def (x : E × F) : ∥x∥₊ = max (∥x.1∥₊) (∥x.2∥₊) :=
+by { have := x.norm_def, simp only [← coe_nnnorm] at this, exact_mod_cast this }
 
-lemma semi_norm_fst_le (x : E × F) : ∥x.1∥ ≤ ∥x∥ :=
+lemma norm_fst_le (x : E × F) : ∥x.1∥ ≤ ∥x∥ :=
 le_max_left _ _
 
-lemma semi_norm_snd_le (x : E × F) : ∥x.2∥ ≤ ∥x∥ :=
+lemma norm_snd_le (x : E × F) : ∥x.2∥ ≤ ∥x∥ :=
 le_max_right _ _
 
-lemma semi_norm_prod_le_iff {x : E × F} {r : ℝ} :
+lemma norm_prod_le_iff {x : E × F} {r : ℝ} :
   ∥x∥ ≤ r ↔ ∥x.1∥ ≤ r ∧ ∥x.2∥ ≤ r :=
 max_le_iff
 
@@ -719,26 +719,26 @@ noncomputable instance pi.semi_normed_group {π : ι → Type*} [fintype ι]
 
 /-- The seminorm of an element in a product space is `≤ r` if and only if the norm of each
 component is. -/
-lemma pi_semi_norm_le_iff {π : ι → Type*} [fintype ι] [∀i, semi_normed_group (π i)] {r : ℝ}
+lemma pi_norm_le_iff {π : ι → Type*} [fintype ι] [∀i, semi_normed_group (π i)] {r : ℝ}
   (hr : 0 ≤ r) {x : Πi, π i} : ∥x∥ ≤ r ↔ ∀i, ∥x i∥ ≤ r :=
 by simp only [← dist_zero_right, dist_pi_le_iff hr, pi.zero_apply]
 
 /-- The seminorm of an element in a product space is `< r` if and only if the norm of each
 component is. -/
-lemma pi_semi_norm_lt_iff {π : ι → Type*} [fintype ι] [∀i, semi_normed_group (π i)] {r : ℝ}
+lemma pi_norm_lt_iff {π : ι → Type*} [fintype ι] [∀i, semi_normed_group (π i)] {r : ℝ}
   (hr : 0 < r) {x : Πi, π i} : ∥x∥ < r ↔ ∀i, ∥x i∥ < r :=
 by simp only [← dist_zero_right, dist_pi_lt_iff hr, pi.zero_apply]
 
-lemma semi_norm_le_pi_norm {π : ι → Type*} [fintype ι] [∀i, semi_normed_group (π i)] (x : Πi, π i)
+lemma norm_le_pi_norm {π : ι → Type*} [fintype ι] [∀i, semi_normed_group (π i)] (x : Πi, π i)
   (i : ι) : ∥x i∥ ≤ ∥x∥ :=
-(pi_semi_norm_le_iff (norm_nonneg x)).1 (le_refl _) i
+(pi_norm_le_iff (norm_nonneg x)).1 (le_refl _) i
 
-@[simp] lemma pi_semi_norm_const [nonempty ι] [fintype ι] (a : E) : ∥(λ i : ι, a)∥ = ∥a∥ :=
+@[simp] lemma pi_norm_const [nonempty ι] [fintype ι] (a : E) : ∥(λ i : ι, a)∥ = ∥a∥ :=
 by simpa only [← dist_zero_right] using dist_pi_const a 0
 
-@[simp] lemma pi_nnsemi_norm_const [nonempty ι] [fintype ι] (a : E) :
+@[simp] lemma pi_nnnorm_const [nonempty ι] [fintype ι] (a : E) :
   ∥(λ i : ι, a)∥₊ = ∥a∥₊ :=
-nnreal.eq $ pi_semi_norm_const a
+nnreal.eq $ pi_norm_const a
 
 lemma tendsto_iff_norm_tendsto_zero {f : α → E} {a : filter α} {b : E} :
   tendsto f a (𝓝 b) ↔ tendsto (λ e, ∥f e - b∥) a (𝓝 0) :=
@@ -986,47 +986,9 @@ instance submodule.normed_group {𝕜 : Type*} {_ : ring 𝕜}
 /-- normed group instance on the product of two normed groups, using the sup norm. -/
 noncomputable instance prod.normed_group : normed_group (E × F) := { ..prod.semi_normed_group }
 
-lemma prod.norm_def (x : E × F) : ∥x∥ = (max ∥x.1∥ ∥x.2∥) := rfl
-
-lemma prod.nnnorm_def (x : E × F) : ∥x∥₊ = max (∥x.1∥₊) (∥x.2∥₊) :=
-by { have := x.norm_def, simp only [← coe_nnnorm] at this, exact_mod_cast this }
-
-lemma norm_fst_le (x : E × F) : ∥x.1∥ ≤ ∥x∥ :=
-le_max_left _ _
-
-lemma norm_snd_le (x : E × F) : ∥x.2∥ ≤ ∥x∥ :=
-le_max_right _ _
-
-lemma norm_prod_le_iff {x : E × F} {r : ℝ} :
-  ∥x∥ ≤ r ↔ ∥x.1∥ ≤ r ∧ ∥x.2∥ ≤ r :=
-max_le_iff
-
 /-- normed group instance on the product of finitely many normed groups, using the sup norm. -/
 noncomputable instance pi.normed_group {π : ι → Type*} [fintype ι] [∀i, normed_group (π i)] :
   normed_group (Πi, π i) := { ..pi.semi_normed_group }
-
-/-- The norm of an element in a product space is `≤ r` if and only if the norm of each
-component is. -/
-lemma pi_norm_le_iff {π : ι → Type*} [fintype ι] [∀i, normed_group (π i)] {r : ℝ} (hr : 0 ≤ r)
-  {x : Πi, π i} : ∥x∥ ≤ r ↔ ∀i, ∥x i∥ ≤ r :=
-by simp only [← dist_zero_right, dist_pi_le_iff hr, pi.zero_apply]
-
-/-- The norm of an element in a product space is `< r` if and only if the norm of each
-component is. -/
-lemma pi_norm_lt_iff {π : ι → Type*} [fintype ι] [∀i, normed_group (π i)] {r : ℝ} (hr : 0 < r)
-  {x : Πi, π i} : ∥x∥ < r ↔ ∀i, ∥x i∥ < r :=
-by simp only [← dist_zero_right, dist_pi_lt_iff hr, pi.zero_apply]
-
-lemma norm_le_pi_norm {π : ι → Type*} [fintype ι] [∀i, normed_group (π i)] (x : Πi, π i) (i : ι) :
-  ∥x i∥ ≤ ∥x∥ :=
-(pi_norm_le_iff (norm_nonneg x)).1 (le_refl _) i
-
-@[simp] lemma pi_norm_const [nonempty ι] [fintype ι] (a : E) : ∥(λ i : ι, a)∥ = ∥a∥ :=
-by simpa only [← dist_zero_right] using dist_pi_const a 0
-
-@[simp] lemma pi_nnnorm_const [nonempty ι] [fintype ι] (a : E) :
-  ∥(λ i : ι, a)∥₊ = ∥a∥₊ :=
-nnreal.eq $ pi_norm_const a
 
 lemma tendsto_norm_nhds_within_zero : tendsto (norm : E → ℝ) (𝓝[≠] 0) (𝓝[>] 0) :=
 (continuous_norm.tendsto' (0 : E) 0 norm_zero).inf $ tendsto_principal_principal.2 $

--- a/src/analysis/normed_space/basic.lean
+++ b/src/analysis/normed_space/basic.lean
@@ -190,10 +190,10 @@ pi.semi_normed_group
 
 local attribute [instance] matrix.semi_normed_group
 
-lemma semi_norm_matrix_le_iff {n m : Type*} [fintype n] [fintype m] {r : ℝ} (hr : 0 ≤ r)
+lemma norm_matrix_le_iff {n m : Type*} [fintype n] [fintype m] {r : ℝ} (hr : 0 ≤ r)
   {A : matrix n m α} :
   ∥A∥ ≤ r ↔ ∀ i j, ∥A i j∥ ≤ r :=
-by simp [pi_semi_norm_le_iff hr]
+by simp [pi_norm_le_iff hr]
 
 end semi_normed_ring
 
@@ -680,7 +680,7 @@ open normed_field
 
 /-- The product of two normed spaces is a normed space, with the sup norm. -/
 instance prod.normed_space : normed_space α (E × F) :=
-{ norm_smul_le := λ s x, le_of_eq $ by simp [prod.semi_norm_def, norm_smul, mul_max_of_nonneg],
+{ norm_smul_le := λ s x, le_of_eq $ by simp [prod.norm_def, norm_smul, mul_max_of_nonneg],
   ..prod.normed_group,
   ..prod.module }
 

--- a/src/analysis/normed_space/basic.lean
+++ b/src/analysis/normed_space/basic.lean
@@ -84,8 +84,8 @@ instance normed_ring.to_normed_group [β : normed_ring α] : normed_group α := 
 instance semi_normed_ring.to_semi_normed_group [β : semi_normed_ring α] :
   semi_normed_group α := { ..β }
 
-instance prod.norm_one_class [normed_group α] [has_one α] [norm_one_class α]
-  [normed_group β] [has_one β] [norm_one_class β] :
+instance prod.norm_one_class [semi_normed_group α] [has_one α] [norm_one_class α]
+  [semi_normed_group β] [has_one β] [norm_one_class β] :
   norm_one_class (α × β) :=
 ⟨by simp [prod.norm_def]⟩
 

--- a/src/analysis/normed_space/finite_dimension.lean
+++ b/src/analysis/normed_space/finite_dimension.lean
@@ -211,7 +211,7 @@ begin
     have C0_le : ∀i, C0 i ≤ C :=
       λi, finset.single_le_sum (λj hj, (hC0 j).1) (finset.mem_univ _),
     apply ξ.equiv_fun.to_linear_map.continuous_of_bound C (λx, _),
-    rw pi_semi_norm_le_iff,
+    rw pi_norm_le_iff,
     { exact λi, le_trans ((hC0 i).2 x) (mul_le_mul_of_nonneg_right (C0_le i) (norm_nonneg _)) },
     { exact mul_nonneg C_nonneg (norm_nonneg _) } }
 end

--- a/src/analysis/normed_space/linear_isometry.lean
+++ b/src/analysis/normed_space/linear_isometry.lean
@@ -531,7 +531,7 @@ noncomputable def prod_assoc [module R E₂] [module R E₃] : (E × E₂) × E�
   norm_map' :=
     begin
       rintros ⟨⟨e, f⟩, g⟩,
-      simp only [linear_equiv.coe_mk, equiv.prod_assoc_apply, prod.semi_norm_def, max_assoc],
+      simp only [linear_equiv.coe_mk, equiv.prod_assoc_apply, prod.norm_def, max_assoc],
     end,
   .. equiv.prod_assoc E E₂ E₃, }
 

--- a/src/analysis/normed_space/multilinear.lean
+++ b/src/analysis/normed_space/multilinear.lean
@@ -196,7 +196,7 @@ begin
         { assume j hj,
           by_cases h : j = i,
           { rw h, simp, exact norm_le_pi_norm (m₁ - m₂) i },
-          { simp [h, max_le_max, norm_le_pi_norm] } }
+          { simp [h, max_le_max, norm_le_pi_norm (_ : Π i, E i)] } }
       end
     ... = ∥m₁ - m₂∥ * (max ∥m₁∥ ∥m₂∥) ^ (fintype.card ι - 1) :
       by { rw prod_update_of_mem (finset.mem_univ _), simp [card_univ_diff] } },
@@ -328,7 +328,7 @@ calc
   ∥f m∥ ≤ ∥f∥ * ∏ i, ∥m i∥ : f.le_op_norm m
   ... ≤ ∥f∥ * ∏ i : ι, 1 :
     mul_le_mul_of_nonneg_left (prod_le_prod (λi hi, norm_nonneg _)
-      (λi hi, le_trans (norm_le_pi_norm _ _) h)) (op_norm_nonneg f)
+      (λi hi, le_trans (norm_le_pi_norm (_ : Π i, E i) _) h)) (op_norm_nonneg f)
   ... = ∥f∥ : by simp
 
 /-- If one controls the norm of every `f x`, then one controls the norm of `f`. -/

--- a/src/analysis/normed_space/operator_norm.lean
+++ b/src/analysis/normed_space/operator_norm.lean
@@ -438,7 +438,7 @@ end
 @[simp] lemma op_norm_prod (f : E →L[𝕜] Fₗ) (g : E →L[𝕜] Gₗ) : ∥f.prod g∥ = ∥(f, g)∥ :=
 le_antisymm
   (op_norm_le_bound _ (norm_nonneg _) $ λ x,
-    by simpa only [prod_apply, prod.semi_norm_def, max_mul_of_nonneg, norm_nonneg]
+    by simpa only [prod_apply, prod.norm_def, max_mul_of_nonneg, norm_nonneg]
       using max_le_max (le_op_norm f x) (le_op_norm g x)) $
   max_le
     (op_norm_le_bound _ (norm_nonneg _) $ λ x, (le_max_left _ _).trans ((f.prod g).le_op_norm x))


### PR DESCRIPTION
`norm` and `semi_norm` are the same operator, so there is no need to have two sets of lemmas.

As a result the elaborator needs a few hints for some applications of the `pi` lemmas, but this is par for the course for pi typeclass instances anyway.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
