### PR TITLE
[Merged by Bors] - feat(measure_theory/measure): define `ae_disjoint`

### DIFF
--- a/src/measure_theory/measure/ae_disjoint.lean
+++ b/src/measure_theory/measure/ae_disjoint.lean
@@ -1,0 +1,101 @@
+/-
+Copyright (c) 2022 Yury Kudryashov. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Yury Kudryashov
+-/
+import measure_theory.measure.measure_space_def
+
+/-!
+# Almost everywhere disjoint sets
+
+We say that sets `s` and `t` are `μ`-a.e. disjoint (see `measure_theory.ae_disjoint`) if their
+intersection has measure zero. This assumption can be used instead of `disjoint` in most theorems in
+measure theory.
+-/
+
+open set function
+
+namespace measure_theory
+
+variables {ι α : Type*} {m : measurable_space α} (μ : measure α)
+
+/-- Two sets are said to be `μ`-a.e. disjoint if their intersection has measure zero. -/
+def ae_disjoint (s t : set α) := μ (s ∩ t) = 0
+
+variables {μ} {s t u v : set α}
+
+/-- If `s : ι → set α` is a countable family of pairwise a.e. disjoint sets, then there exists a
+family of measurable null sets `t i` such that `s i \ t i` are pairwise disjoint. -/
+lemma exists_null_pairwise_disjoint_diff [encodable ι] {s : ι → set α}
+  (hd : pairwise (ae_disjoint μ on s)) :
+  ∃ t : ι → set α, (∀ i, measurable_set (t i)) ∧ (∀ i, μ (t i) = 0) ∧ 
+    pairwise (disjoint on (λ i, s i \ t i)) :=
+begin
+  refine ⟨λ i, to_measurable μ (s i ∩ ⋃ j ∈ ({i}ᶜ : set ι), s j),
+    λ i, measurable_set_to_measurable _ _, λ i, _, _⟩,
+  { simp only [measure_to_measurable, inter_Union, measure_bUnion_null_iff (countable_encodable _)],
+    exact λ j hj, hd _ _ (ne.symm hj) },
+  { simp only [pairwise, disjoint_left, on_fun, mem_diff, not_and, and_imp, not_not],
+    intros i j hne x hi hU hj,
+    replace hU : x ∉ s i ∩ ⋃ j ≠ i, s j := λ h, hU (subset_to_measurable _ _ h),
+    simp only [mem_inter_eq, mem_Union, not_and, not_exists] at hU,
+    exact (hU hi j hne.symm hj).elim }
+end
+
+namespace ae_disjoint
+
+protected lemma eq (h : ae_disjoint μ s t) : μ (s ∩ t) = 0 := h
+
+@[symm] protected lemma symm (h : ae_disjoint μ s t) : ae_disjoint μ t s :=
+by rwa [ae_disjoint, inter_comm]
+
+protected lemma symmetric : symmetric (ae_disjoint μ) := λ s t h, h.symm
+
+protected lemma comm : ae_disjoint μ s t ↔ ae_disjoint μ t s := ⟨λ h, h.symm, λ h, h.symm⟩
+
+lemma _root_.disjoint.ae_disjoint (h : disjoint s t) : ae_disjoint μ s t :=
+by rw [ae_disjoint, disjoint_iff_inter_eq_empty.1 h, measure_empty]
+
+lemma mono_ae (h : ae_disjoint μ s t) (hu : u ≤ᵐ[μ] s) (hv : v ≤ᵐ[μ] t) : ae_disjoint μ u v :=
+measure_mono_null_ae (hu.inter hv) h
+
+lemma mono (h : ae_disjoint μ s t) (hu : u ⊆ s) (hv : v ⊆ t) : ae_disjoint μ u v :=
+h.mono_ae hu.eventually_le hv.eventually_le
+
+@[simp] lemma Union_left_iff [encodable ι] {s : ι → set α} :
+  ae_disjoint μ (⋃ i, s i) t ↔ ∀ i, ae_disjoint μ (s i) t :=
+by simp only [ae_disjoint, Union_inter, measure_Union_null_iff]
+
+@[simp] lemma Union_right_iff [encodable ι] {t : ι → set α} :
+  ae_disjoint μ s (⋃ i, t i) ↔ ∀ i, ae_disjoint μ s (t i) :=
+by simp only [ae_disjoint, inter_Union, measure_Union_null_iff]
+
+@[simp] lemma union_left_iff : ae_disjoint μ (s ∪ t) u ↔ ae_disjoint μ s u ∧ ae_disjoint μ t u :=
+by simp [union_eq_Union, and.comm]
+
+@[simp] lemma union_right_iff : ae_disjoint μ s (t ∪ u) ↔ ae_disjoint μ s t ∧ ae_disjoint μ s u :=
+by simp [union_eq_Union, and.comm]
+
+lemma union_left (hs : ae_disjoint μ s u) (ht : ae_disjoint μ t u) : ae_disjoint μ (s ∪ t) u :=
+union_left_iff.mpr ⟨hs, ht⟩
+
+lemma union_right (ht : ae_disjoint μ s t) (hu : ae_disjoint μ s u) : ae_disjoint μ s (t ∪ u) :=
+union_right_iff.2 ⟨ht, hu⟩
+
+lemma disjoint_diff (h : ae_disjoint μ s t) : disjoint (s \ to_measurable μ (s ∩ t)) t :=
+disjoint_left.2 $ λ x ⟨hxs, hx⟩ hxt, hx $ subset_to_measurable _ _ ⟨hxs, hxt⟩
+
+/-- If `s` and `t` are `μ`-a.e. disjoint, then `s \ u` and `t` are disjoint for some measurable null
+set `u`. See also `measure_theory.ae_disjoint.disjoint_diff`. -/
+lemma exists_disjoint_diff (h : ae_disjoint μ s t) :
+  ∃ u, measurable_set u ∧ μ u = 0 ∧ disjoint (s \ u) t :=
+⟨_, measurable_set_to_measurable _ _, (measure_to_measurable _).trans h, h.disjoint_diff⟩
+
+lemma of_null_right (h : μ t = 0) : ae_disjoint μ s t :=
+measure_mono_null (inter_subset_right _ _) h
+
+lemma of_null_left (h : μ s = 0) : ae_disjoint μ s t := (of_null_right h).symm
+
+end ae_disjoint
+
+end measure_theory

--- a/src/measure_theory/measure/ae_disjoint.lean
+++ b/src/measure_theory/measure/ae_disjoint.lean
@@ -83,7 +83,7 @@ lemma union_right (ht : ae_disjoint μ s t) (hu : ae_disjoint μ s u) : ae_disjo
 union_right_iff.2 ⟨ht, hu⟩
 
 /-- If `s` and `t` are `μ`-a.e. disjoint, then `s \ u` and `t` are disjoint for some measurable null
-set `u`. See also `measure_theory.ae_disjoint.disjoint_diff`. -/
+set `u`. -/
 lemma exists_disjoint_diff (h : ae_disjoint μ s t) :
   ∃ u, measurable_set u ∧ μ u = 0 ∧ disjoint (s \ u) t :=
 ⟨to_measurable μ (s ∩ t), measurable_set_to_measurable _ _, (measure_to_measurable _).trans h,

--- a/src/measure_theory/measure/ae_disjoint.lean
+++ b/src/measure_theory/measure/ae_disjoint.lean
@@ -82,14 +82,12 @@ union_left_iff.mpr ⟨hs, ht⟩
 lemma union_right (ht : ae_disjoint μ s t) (hu : ae_disjoint μ s u) : ae_disjoint μ s (t ∪ u) :=
 union_right_iff.2 ⟨ht, hu⟩
 
-lemma disjoint_diff (h : ae_disjoint μ s t) : disjoint (s \ to_measurable μ (s ∩ t)) t :=
-disjoint_left.2 $ λ x ⟨hxs, hx⟩ hxt, hx $ subset_to_measurable _ _ ⟨hxs, hxt⟩
-
 /-- If `s` and `t` are `μ`-a.e. disjoint, then `s \ u` and `t` are disjoint for some measurable null
 set `u`. See also `measure_theory.ae_disjoint.disjoint_diff`. -/
 lemma exists_disjoint_diff (h : ae_disjoint μ s t) :
   ∃ u, measurable_set u ∧ μ u = 0 ∧ disjoint (s \ u) t :=
-⟨_, measurable_set_to_measurable _ _, (measure_to_measurable _).trans h, h.disjoint_diff⟩
+⟨to_measurable μ (s ∩ t), measurable_set_to_measurable _ _, (measure_to_measurable _).trans h,
+  disjoint_diff.symm.mono_left (λ x hx, ⟨hx.1, λ hxt, hx.2 $ subset_to_measurable _ _ ⟨hx.1, hxt⟩⟩)⟩
 
 lemma of_null_right (h : μ t = 0) : ae_disjoint μ s t :=
 measure_mono_null (inter_subset_right _ _) h

--- a/src/measure_theory/measure/measure_space_def.lean
+++ b/src/measure_theory/measure/measure_space_def.lean
@@ -392,6 +392,11 @@ alias measure_mono_ae ← filter.eventually_le.measure_le
 lemma measure_congr (H : s =ᵐ[μ] t) : μ s = μ t :=
 le_antisymm H.le.measure_le H.symm.le.measure_le
 
+alias measure_congr ← filter.eventually_eq.measure_eq
+
+lemma measure_mono_null_ae (H : s ≤ᵐ[μ] t) (ht : μ t = 0) : μ s = 0 :=
+nonpos_iff_eq_zero.1 $ ht ▸ H.measure_le
+
 /-- A measurable set `t ⊇ s` such that `μ t = μ s`. It even satisifies `μ (t ∩ u) = μ (s ∩ u)` for
 any measurable set `u`, see `measure_to_measurable_inter`. If `s` is a null measurable set, then
 we also have `t =ᵐ[μ] s`, see `null_measurable_set.to_measurable_ae_eq`. -/


### PR DESCRIPTION
I am going to migrate most `disjoint` assumptions to `ae_disjoint`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
