### PR TITLE
[Merged by Bors] - doc(tactic/interactive): mention triv uses contradiction

### DIFF
--- a/src/tactic/interactive.lean
+++ b/src/tactic/interactive.lean
@@ -630,8 +630,9 @@ add_tactic_doc
   tags       := ["testing"] }
 
 /--
-A weaker version of `trivial` that tries to solve the goal using a canonical proof of `true` or the `reflexivity` tactic
-(unfolding only `reducible` constants, so can fail faster than `trivial`), and otherwise tries the `contradiction` tactic. -/
+A weaker version of `trivial` that tries to solve the goal using a canonical proof of `true` or the
+`reflexivity` tactic (unfolding only `reducible` constants, so can fail faster than `trivial`),
+and otherwise tries the `contradiction` tactic. -/
 meta def triv : tactic unit :=
 tactic.triv' <|> tactic.reflexivity reducible <|> tactic.contradiction <|> fail "triv tactic failed"
 

--- a/src/tactic/interactive.lean
+++ b/src/tactic/interactive.lean
@@ -630,8 +630,8 @@ add_tactic_doc
   tags       := ["testing"] }
 
 /--
-a weaker version of `trivial` that tries to solve the goal by reflexivity, finding
-contradictory hypotheses, or by reducing it to true, unfolding only `reducible` constants. -/
+A weaker version of `trivial` that tries to solve the goal using a canonical proof of `true` or the `reflexivity` tactic
+(unfolding only `reducible` constants, so can fail faster than `trivial`), and otherwise tries the `contradiction` tactic. -/
 meta def triv : tactic unit :=
 tactic.triv' <|> tactic.reflexivity reducible <|> tactic.contradiction <|> fail "triv tactic failed"
 

--- a/src/tactic/interactive.lean
+++ b/src/tactic/interactive.lean
@@ -630,8 +630,8 @@ add_tactic_doc
   tags       := ["testing"] }
 
 /--
-a weaker version of `trivial` that tries to solve the goal by reflexivity or by reducing it to true,
-unfolding only `reducible` constants. -/
+a weaker version of `trivial` that tries to solve the goal by reflexivity, finding
+contradictory hypotheses, or by reducing it to true, unfolding only `reducible` constants. -/
 meta def triv : tactic unit :=
 tactic.triv' <|> tactic.reflexivity reducible <|> tactic.contradiction <|> fail "triv tactic failed"
 


### PR DESCRIPTION
Adding the fact that `triv` tries `contradiction` to the docstring for `triv`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

I switched from telling UGs to use `trivial` to telling them to use `triv` when faced with a goal of `true`, because I want a simple tactic which proves `true` and does essentially nothing else, and `trivial` tries `contradiction` (which can sometimes work for basic logic goals). UGs still insist on using it in other situations, but today one had two contradictory hypotheses and closed the goal with `triv` and then asked why it worked, and according to the docs it shouldn't have. But `triv` does indeed try `contradiction`. In fact I am not sure I could find a goal for which one of `triv` and `trivial` works and the other does not.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
