### PR TITLE
[Merged by Bors] - feat(analysis/special_functions/complex/arg): `arg_neg` lemmas

### DIFF
--- a/src/analysis/special_functions/complex/arg.lean
+++ b/src/analysis/special_functions/complex/arg.lean
@@ -164,16 +164,6 @@ begin
   exact div_pos (abs_pos.2 hy) (abs_pos.2 hx)
 end
 
-lemma arg_eq_arg_neg_add_pi_of_im_nonneg_of_re_neg {x : ℂ} (hxr : x.re < 0) (hxi : 0 ≤ x.im) :
-  arg x = arg (-x) + π :=
-have 0 ≤ (-x).re, from le_of_lt $ by simpa [neg_pos],
-by rw [arg, arg, if_neg (not_le.2 hxr), if_pos this, if_pos hxi, abs_neg]
-
-lemma arg_eq_arg_neg_sub_pi_of_im_neg_of_re_neg {x : ℂ} (hxr : x.re < 0) (hxi : x.im < 0) :
-  arg x = arg (-x) - π :=
-have 0 ≤ (-x).re, from le_of_lt $ by simpa [neg_pos],
-by rw [arg, arg, if_neg (not_le.2 hxr), if_neg (not_le.2 hxi), if_pos this, abs_neg]
-
 @[simp] lemma arg_one : arg 1 = 0 :=
 by simp [arg, zero_le_one]
 
@@ -288,6 +278,65 @@ end
 begin
   by_cases h : arg x = π;
     simp [arg_inv, h]
+end
+
+lemma arg_neg_eq_arg_sub_pi_of_im_pos {x : ℂ} (hi : 0 < x.im) : arg (-x) = arg x - π :=
+begin
+  rw [arg_of_im_pos hi, arg_of_im_neg (show (-x).im < 0, from left.neg_neg_iff.2 hi)],
+  simp [neg_div, real.arccos_neg]
+end
+
+lemma arg_neg_eq_arg_add_pi_of_im_neg {x : ℂ} (hi : x.im < 0) : arg (-x) = arg x + π :=
+begin
+  rw [arg_of_im_neg hi, arg_of_im_pos (show 0 < (-x).im, from left.neg_pos_iff.2 hi)],
+  simp [neg_div, real.arccos_neg, add_comm, ←sub_eq_add_neg]
+end
+
+lemma arg_neg_eq_arg_sub_pi_iff {x : ℂ} :
+  arg (-x) = arg x - π ↔ (0 < x.im ∨ x.im = 0 ∧ x.re < 0) :=
+begin
+  rcases lt_trichotomy x.im 0 with (hi|hi|hi),
+  { simp [hi, hi.ne, hi.not_lt, arg_neg_eq_arg_add_pi_of_im_neg, sub_eq_add_neg,
+          ←add_eq_zero_iff_eq_neg, real.pi_ne_zero] },
+  { rw (ext rfl hi : x = x.re),
+    rcases lt_trichotomy x.re 0 with (hr|hr|hr),
+    { rw [arg_of_real_of_neg hr, ←of_real_neg, arg_of_real_of_nonneg (left.neg_pos_iff.2 hr).le],
+      simp [hr] },
+    { simp [hr, hi, real.pi_ne_zero] },
+    { rw [arg_of_real_of_nonneg hr.le, ←of_real_neg, arg_of_real_of_neg (left.neg_neg_iff.2 hr)],
+      simp [hr.not_lt, ←add_eq_zero_iff_eq_neg, real.pi_ne_zero] } },
+  { simp [hi, arg_neg_eq_arg_sub_pi_of_im_pos] }
+end
+
+lemma arg_neg_eq_arg_add_pi_iff {x : ℂ} :
+  arg (-x) = arg x + π ↔ (x.im < 0 ∨ x.im = 0 ∧ 0 < x.re) :=
+begin
+  rcases lt_trichotomy x.im 0 with (hi|hi|hi),
+  { simp [hi, arg_neg_eq_arg_add_pi_of_im_neg] },
+  { rw (ext rfl hi : x = x.re),
+    rcases lt_trichotomy x.re 0 with (hr|hr|hr),
+    { rw [arg_of_real_of_neg hr, ←of_real_neg, arg_of_real_of_nonneg (left.neg_pos_iff.2 hr).le],
+      simp [hr.not_lt, ←two_mul, real.pi_ne_zero] },
+    { simp [hr, hi, real.pi_ne_zero.symm] },
+    { rw [arg_of_real_of_nonneg hr.le, ←of_real_neg, arg_of_real_of_neg (left.neg_neg_iff.2 hr)],
+      simp [hr] } },
+  { simp [hi, hi.ne.symm, hi.not_lt, arg_neg_eq_arg_sub_pi_of_im_pos, sub_eq_add_neg,
+          ←add_eq_zero_iff_neg_eq, real.pi_ne_zero] }
+end
+
+lemma arg_neg_coe_angle {x : ℂ} (hx : x ≠ 0) : (arg (-x) : real.angle) = arg x + π :=
+begin
+  rcases lt_trichotomy x.im 0 with (hi|hi|hi),
+  { rw [arg_neg_eq_arg_add_pi_of_im_neg hi, real.angle.coe_add] },
+  { rw (ext rfl hi : x = x.re),
+    rcases lt_trichotomy x.re 0 with (hr|hr|hr),
+    { rw [arg_of_real_of_neg hr, ←of_real_neg, arg_of_real_of_nonneg (left.neg_pos_iff.2 hr).le,
+          ←real.angle.coe_add, ←two_mul, real.angle.coe_two_pi, real.angle.coe_zero] },
+    { exact false.elim (hx (ext hr hi)) },
+    { rw [arg_of_real_of_nonneg hr.le, ←of_real_neg, arg_of_real_of_neg (left.neg_neg_iff.2 hr),
+          real.angle.coe_zero, zero_add] } },
+  { rw [arg_neg_eq_arg_sub_pi_of_im_pos hi, real.angle.coe_sub,
+        real.angle.sub_coe_pi_eq_add_coe_pi] }
 end
 
 section continuity


### PR DESCRIPTION
Add lemmas about the value of `arg (-x)`: one each for positive and
negative sign of `x.im`, two `iff` lemmas saying exactly when it's
equal to `arg x - π` or `arg x + π`, and a simpler lemma giving the
value of `(arg (-x) : real.angle)` for any nonzero `x`.

These replace the previous lemmas
`arg_eq_arg_neg_add_pi_of_im_nonneg_of_re_neg` and
`arg_eq_arg_neg_sub_pi_of_im_neg_of_re_neg`, which are strictly less
general (they have a hypothesis `x.re < 0` that's not needed unless
the imaginary part is 0).  Those two lemmas are unused in current
mathlib (they were used in the proof of `cos_arg` before the golfing
in #10365) and it seems reasonable to me to replace them with the more
general lemmas.



---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
