### PR TITLE
[Merged by Bors] - feat(order/succ_pred/relation): `succ`/`pred` inductions on relations

### DIFF
--- a/src/data/int/succ_pred.lean
+++ b/src/data/int/succ_pred.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yaël Dillies
 -/
 import data.int.basic
-import order.succ_pred
+import order.succ_pred.basic
 
 /-!
 # Successors and predecessors of integers

--- a/src/data/nat/succ_pred.lean
+++ b/src/data/nat/succ_pred.lean
@@ -3,7 +3,7 @@ Copyright (c) 2021 Yaël Dillies. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yaël Dillies
 -/
-import order.succ_pred
+import order.succ_pred.basic
 
 /-!
 # Successors and predecessors of naturals

--- a/src/logic/relation.lean
+++ b/src/logic/relation.lean
@@ -37,6 +37,8 @@ the bundled version, see `rel`.
   terms of rewriting systems, this means that `a` and `b` can be rewritten to the same term.
 -/
 
+open function
+
 variables {α β γ δ : Type*}
 
 section ne_imp
@@ -402,6 +404,14 @@ lemma trans_gen.mono {p : α → α → Prop} :
   (∀ a b, r a b → p a b) → trans_gen r a b → trans_gen p a b :=
 trans_gen.lift id
 
+lemma trans_gen_swap : trans_gen (swap r) a b ↔ trans_gen r b a :=
+begin
+  have : ∀{r} {a b : α}, trans_gen (swap r) a b → trans_gen r b a,
+  { intros r a b h, induction h with b h b c hab hbc ih, { exact trans_gen.single h },
+    exact ih.head hbc },
+  exact ⟨this, this⟩
+end
+
 end trans_gen
 
 section refl_trans_gen
@@ -455,6 +465,13 @@ by simpa [refl_trans_gen_idem] using hab.lift f h
 lemma refl_trans_gen_closed {p : α → α → Prop} :
   (∀ a b, r a b → refl_trans_gen p a b) → refl_trans_gen r a b → refl_trans_gen p a b :=
 refl_trans_gen.lift' id
+
+lemma refl_trans_gen_swap : refl_trans_gen (swap r) a b ↔ refl_trans_gen r b a :=
+begin
+  have : ∀{r} {a b : α}, refl_trans_gen (swap r) a b → refl_trans_gen r b a,
+  { intros r a b h, induction h with b c hab hbc ih, { refl }, exact ih.head hbc },
+  exact ⟨this, this⟩
+end
 
 end refl_trans_gen
 

--- a/src/logic/relation.lean
+++ b/src/logic/relation.lean
@@ -390,6 +390,10 @@ lemma trans_gen.closed {p : α → α → Prop} :
   (∀ a b, r a b → trans_gen p a b) → trans_gen r a b → trans_gen p a b :=
 trans_gen.lift' id
 
+lemma trans_gen.mono {p : α → α → Prop} :
+  (∀ a b, r a b → p a b) → trans_gen r a b → trans_gen p a b :=
+trans_gen.lift id
+
 end trans_gen
 
 section refl_trans_gen

--- a/src/logic/relation.lean
+++ b/src/logic/relation.lean
@@ -170,9 +170,17 @@ attribute [refl] refl_trans_gen.refl
 
 attribute [refl] refl_gen.refl
 
-lemma refl_gen.to_refl_trans_gen : ∀ {a b}, refl_gen r a b → refl_trans_gen r a b
+namespace refl_gen
+
+lemma to_refl_trans_gen : ∀ {a b}, refl_gen r a b → refl_trans_gen r a b
+| a _ refl := by refl
+| a b (single h) := refl_trans_gen.tail refl_trans_gen.refl h
+
+lemma mono {p : α → α → Prop} (hp : ∀ a b, r a b → p a b) : ∀ {a b}, refl_gen r a b → refl_gen p a b
 | a _ refl_gen.refl := by refl
-| a b (refl_gen.single h) := refl_trans_gen.tail refl_trans_gen.refl h
+| a b (single h) := single (hp a b h)
+
+end refl_gen
 
 namespace refl_trans_gen
 

--- a/src/logic/relation.lean
+++ b/src/logic/relation.lean
@@ -404,13 +404,11 @@ lemma trans_gen.mono {p : α → α → Prop} :
   (∀ a b, r a b → p a b) → trans_gen r a b → trans_gen p a b :=
 trans_gen.lift id
 
+lemma trans_gen.swap (h : trans_gen r b a) : trans_gen (swap r) a b :=
+by { induction h with b h b c hab hbc ih, { exact trans_gen.single h }, exact ih.head hbc }
+
 lemma trans_gen_swap : trans_gen (swap r) a b ↔ trans_gen r b a :=
-begin
-  have : ∀{r} {a b : α}, trans_gen (swap r) a b → trans_gen r b a,
-  { intros r a b h, induction h with b h b c hab hbc ih, { exact trans_gen.single h },
-    exact ih.head hbc },
-  exact ⟨this, this⟩
-end
+⟨trans_gen.swap, trans_gen.swap⟩
 
 end trans_gen
 
@@ -466,12 +464,11 @@ lemma refl_trans_gen_closed {p : α → α → Prop} :
   (∀ a b, r a b → refl_trans_gen p a b) → refl_trans_gen r a b → refl_trans_gen p a b :=
 refl_trans_gen.lift' id
 
+lemma refl_trans_gen.swap (h : refl_trans_gen r b a) : refl_trans_gen (swap r) a b :=
+by { induction h with b c hab hbc ih, { refl }, exact ih.head hbc }
+
 lemma refl_trans_gen_swap : refl_trans_gen (swap r) a b ↔ refl_trans_gen r b a :=
-begin
-  have : ∀{r} {a b : α}, refl_trans_gen (swap r) a b → refl_trans_gen r b a,
-  { intros r a b h, induction h with b c hab hbc ih, { refl }, exact ih.head hbc },
-  exact ⟨this, this⟩
-end
+⟨refl_trans_gen.swap, refl_trans_gen.swap⟩
 
 end refl_trans_gen
 

--- a/src/order/succ_pred/basic.lean
+++ b/src/order/succ_pred/basic.lean
@@ -830,11 +830,14 @@ begin
   exact id_le_iterate_of_id_le le_succ n a,
 end
 
-lemma succ.rec {p : α → Prop} (hsucc : ∀ a, p a → p (succ a)) {a b : α} (h : a ≤ b) (ha : p a) :
-  p b :=
+/-- Induction principle on a type with a `succ_order` for all elements above a given element `m`. -/
+@[elab_as_eliminator] lemma succ.rec {P : α → Prop} {m : α}
+  (h0 : P m) (h1 : ∀ n, m ≤ n → P n → P (succ n)) ⦃n : α⦄ (hmn : m ≤ n) : P n :=
 begin
-  obtain ⟨n, rfl⟩ := h.exists_succ_iterate,
-  exact iterate.rec _ hsucc ha n,
+  obtain ⟨n, rfl⟩ := hmn.exists_succ_iterate, clear hmn,
+  induction n with n ih,
+  { exact h0 },
+  { rw [function.iterate_succ_apply'], exact h1 _ (id_le_iterate_of_id_le le_succ n m) ih }
 end
 
 lemma succ.rec_iff {p : α → Prop} (hsucc : ∀ a, p a ↔ p (succ a)) {a b : α} (h : a ≤ b) :
@@ -858,9 +861,10 @@ exists_pred_iterate_of_le h
 lemma exists_pred_iterate_iff_le : (∃ n, pred^[n] b = a) ↔ a ≤ b :=
 @exists_succ_iterate_iff_le (order_dual α) _ _ _ _ _
 
-lemma pred.rec {p : α → Prop} (hsucc : ∀ a, p a → p (pred a)) {a b : α} (h : b ≤ a) (ha : p a) :
-  p b :=
-@succ.rec (order_dual α) _ _ _ _ hsucc _ _ h ha
+/-- Induction principle on a type with a `succ_order` for all elements above a given element `m`. -/
+@[elab_as_eliminator] lemma pred.rec {P : α → Prop} {m : α}
+  (h0 : P m) (h1 : ∀ n, n ≤ m → P n → P (pred n)) ⦃n : α⦄ (hmn : n ≤ m) : P n :=
+@succ.rec (order_dual α) _ _ _ _ _ h0 h1 _ hmn
 
 lemma pred.rec_iff {p : α → Prop} (hsucc : ∀ a, p a ↔ p (pred a)) {a b : α} (h : a ≤ b) :
   p a ↔ p b :=
@@ -899,7 +903,7 @@ section order_bot
 variables [preorder α] [order_bot α] [succ_order α] [is_succ_archimedean α]
 
 lemma succ.rec_bot (p : α → Prop) (hbot : p ⊥) (hsucc : ∀ a, p a → p (succ a)) (a : α) : p a :=
-succ.rec hsucc bot_le hbot
+succ.rec hbot (λ x _ h, hsucc x h) (bot_le : ⊥ ≤ a)
 
 end order_bot
 
@@ -907,6 +911,6 @@ section order_top
 variables [preorder α] [order_top α] [pred_order α] [is_pred_archimedean α]
 
 lemma pred.rec_top (p : α → Prop) (htop : p ⊤) (hpred : ∀ a, p a → p (pred a)) (a : α) : p a :=
-pred.rec hpred le_top htop
+pred.rec htop (λ x _ h, hpred x h) (le_top : a ≤ ⊤)
 
 end order_top

--- a/src/order/succ_pred/basic.lean
+++ b/src/order/succ_pred/basic.lean
@@ -861,7 +861,7 @@ exists_pred_iterate_of_le h
 lemma exists_pred_iterate_iff_le : (∃ n, pred^[n] b = a) ↔ a ≤ b :=
 @exists_succ_iterate_iff_le (order_dual α) _ _ _ _ _
 
-/-- Induction principle on a type with a `succ_order` for all elements above a given element `m`. -/
+/-- Induction principle on a type with a `pred_order` for all elements below a given element `m`. -/
 @[elab_as_eliminator] lemma pred.rec {P : α → Prop} {m : α}
   (h0 : P m) (h1 : ∀ n, n ≤ m → P n → P (pred n)) ⦃n : α⦄ (hmn : n ≤ m) : P n :=
 @succ.rec (order_dual α) _ _ _ _ _ h0 h1 _ hmn

--- a/src/order/succ_pred/relation.lean
+++ b/src/order/succ_pred/relation.lean
@@ -11,45 +11,113 @@ This file contains properties about relations on types with a `succ_order`
 and their closure operations (like the transitive closure).
 -/
 
-open set relation succ_order function
+open set relation succ_order pred_order function
 
-variables {α : Type*} [linear_order α] [succ_order α] [is_succ_archimedean α] [no_max_order α]
-/-- `(n, m)` is in the reflexive-transitive closure of `~` if `i ~ i+1` and `i+1 ~ i`
+section succ
+variables {α : Type*} [linear_order α] [succ_order α] [is_succ_archimedean α]
+
+/-- For `n ≤ m`, `(n, m)` is in the reflexive-transitive closure of `~` if `i ~ succ i`
+  for all `i` between `n` and `m`. -/
+lemma refl_trans_gen_of_succ_of_le (r : α → α → Prop) {n m : α}
+  (h : ∀ i ∈ Ico n m, r i (succ i)) (hnm : n ≤ m) : refl_trans_gen r n m :=
+begin
+  revert h, refine succ.rec _ _ hnm,
+  { intros h, exact refl_trans_gen.refl },
+  { intros m hnm ih h,
+    have : refl_trans_gen r n m := ih (λ i hi, h i ⟨hi.1, hi.2.trans_le $ le_succ m⟩),
+    cases (le_succ m).eq_or_lt with hm hm, { rwa [← hm] },
+    exact this.tail (h m ⟨hnm, hm⟩) }
+end
+
+/-- For `m ≤ n`, `(n, m)` is in the reflexive-transitive closure of `~` if `succ i ~ i`
+  for all `i` between `n` and `m`. -/
+lemma refl_trans_gen_of_succ_of_ge (r : α → α → Prop) {n m : α}
+  (h : ∀ i ∈ Ico m n, r (succ i) i) (hmn : m ≤ n) : refl_trans_gen r n m :=
+by { rw [← refl_trans_gen_swap], exact refl_trans_gen_of_succ_of_le (swap r) h hmn }
+
+/-- `(n, m)` is in the reflexive-transitive closure of `~` if `i ~ succ i` and `succ i ~ i`
   for all `i` between `n` and `m`. -/
 lemma refl_trans_gen_of_succ (r : α → α → Prop) {n m : α}
   (h1 : ∀ i ∈ Ico n m, r i (succ i)) (h2 : ∀ i ∈ Ico m n, r (succ i) i) : refl_trans_gen r n m :=
-begin
-  cases le_total n m with hnm hmn,
-  { revert h1 h2,
-    refine le_succ_rec _ _ hnm,
-    { intros h1 h2, exact refl_trans_gen.refl },
-    { intros m hnm ih h1 h2,
-      refine refl_trans_gen.tail (ih _ _) (h1 m _),
-      { intros i hi, exact h1 i ⟨hi.1, hi.2.trans $ lt_succ m⟩ },
-      { simp [Ico_eq_empty_of_le (show n ≤ m, from hnm)] },
-      { refine ⟨hnm, lt_succ m⟩ } }, },
-  { revert h1 h2,
-    refine le_succ_rec _ _ hmn,
-    { intros h1 h2, exact refl_trans_gen.refl },
-    { intros n hmn ih h1 h2,
-      refine refl_trans_gen.head (h2 n _) (ih _ _),
-      { refine ⟨hmn, lt_succ n⟩ },
-      { simp [Ico_eq_empty_of_le (show m ≤ n, from hmn)] },
-      { intros i hi, exact h2 i ⟨hi.1, hi.2.trans $ lt_succ n⟩ } } }
-end
+(le_total n m).elim (refl_trans_gen_of_succ_of_le r h1) $ refl_trans_gen_of_succ_of_ge r h2
 
-/-- `(n, m)` is in the transitive closure of a relation `~` for `n ≠ m` if `i ~ i+1` and `i+1 ~ i`
-  for all `i` between `n` and `m`. -/
+/-- For `n ≠ m`,`(n, m)` is in the transitive closure of a relation `~` if `i ~ succ i` and
+  `succ i ~ i` for all `i` between `n` and `m`. -/
 lemma trans_gen_of_succ_of_ne (r : α → α → Prop) {n m : α}
   (h1 : ∀ i ∈ Ico n m, r i (succ i)) (h2 : ∀ i ∈ Ico m n, r (succ i) i)
   (hnm : n ≠ m) : trans_gen r n m :=
 (refl_trans_gen_iff_eq_or_trans_gen.mp (refl_trans_gen_of_succ r h1 h2)).resolve_left hnm.symm
 
-/-- `(n, m)` is in the transitive closure of a reflexive relation `~` if `i ~ i+1` and `i+1 ~ i`
+/-- For `n < m`, `(n, m)` is in the transitive closure of a relation `~` if `i ~ succ i`
   for all `i` between `n` and `m`. -/
+lemma trans_gen_of_succ_of_lt (r : α → α → Prop) {n m : α}
+  (h : ∀ i ∈ Ico n m, r i (succ i)) (hnm : n < m) : trans_gen r n m :=
+trans_gen_of_succ_of_ne r h (by simp [Ico_eq_empty_of_le hnm.le]) hnm.ne
+
+/-- For `m < n`, `(n, m)` is in the transitive closure of a relation `~` if `succ i ~ i`
+  for all `i` between `n` and `m`. -/
+lemma trans_gen_of_succ_of_gt (r : α → α → Prop) {n m : α}
+  (h : ∀ i ∈ Ico m n, r (succ i) i) (hmn : m < n) : trans_gen r n m :=
+trans_gen_of_succ_of_ne r (by simp [Ico_eq_empty_of_le hmn.le]) h hmn.ne.symm
+
+/-- `(n, m)` is in the transitive closure of a reflexive relation `~` if `i ~ succ i` and
+  `succ i ~ i` for all `i` between `n` and `m`. -/
 lemma trans_gen_of_succ_of_reflexive (r : α → α → Prop) {n m : α} (hr : reflexive r)
   (h1 : ∀ i ∈ Ico n m, r i (succ i)) (h2 : ∀ i ∈ Ico m n, r (succ i) i) : trans_gen r n m :=
 begin
   rcases eq_or_ne m n with rfl|hmn, { exact trans_gen.single (hr m) },
   exact trans_gen_of_succ_of_ne r h1 h2 hmn.symm
 end
+
+end succ
+
+section pred
+variables {α : Type*} [linear_order α] [pred_order α] [is_pred_archimedean α]
+
+/-- For `m ≤ n`, `(n, m)` is in the reflexive-transitive closure of `~` if `i ~ pred i`
+  for all `i` between `n` and `m`. -/
+lemma refl_trans_gen_of_pred_of_ge (r : α → α → Prop) {n m : α}
+  (h : ∀ i ∈ Ioc m n, r i (pred i)) (hnm : m ≤ n) : refl_trans_gen r n m :=
+@refl_trans_gen_of_succ_of_le (order_dual α) _ _ _ r n m (λ x hx, h x ⟨hx.2, hx.1⟩) hnm
+
+/-- For `n ≤ m`, `(n, m)` is in the reflexive-transitive closure of `~` if `pred i ~ i`
+  for all `i` between `n` and `m`. -/
+lemma refl_trans_gen_of_pred_of_le (r : α → α → Prop) {n m : α}
+  (h : ∀ i ∈ Ioc n m, r (pred i) i) (hmn : n ≤ m) : refl_trans_gen r n m :=
+@refl_trans_gen_of_succ_of_ge (order_dual α) _ _ _ r n m (λ x hx, h x ⟨hx.2, hx.1⟩) hmn
+
+/-- `(n, m)` is in the reflexive-transitive closure of `~` if `i ~ pred i` and `pred i ~ i`
+  for all `i` between `n` and `m`. -/
+lemma refl_trans_gen_of_pred (r : α → α → Prop) {n m : α}
+  (h1 : ∀ i ∈ Ioc m n, r i (pred i)) (h2 : ∀ i ∈ Ioc n m, r (pred i) i) : refl_trans_gen r n m :=
+@refl_trans_gen_of_succ (order_dual α) _ _ _ r n m (λ x hx, h1 x ⟨hx.2, hx.1⟩)
+  (λ x hx, h2 x ⟨hx.2, hx.1⟩)
+
+/-- For `n ≠ m`, `(n, m)` is in the transitive closure of a relation `~` if `i ~ pred i` and
+  `pred i ~ i` for all `i` between `n` and `m`. -/
+lemma trans_gen_of_pred_of_ne (r : α → α → Prop) {n m : α}
+  (h1 : ∀ i ∈ Ioc m n, r i (pred i)) (h2 : ∀ i ∈ Ioc n m, r (pred i) i)
+  (hnm : n ≠ m) : trans_gen r n m :=
+@trans_gen_of_succ_of_ne (order_dual α) _ _ _ r n m (λ x hx, h1 x ⟨hx.2, hx.1⟩)
+  (λ x hx, h2 x ⟨hx.2, hx.1⟩) hnm
+
+/-- For `m < n`, `(n, m)` is in the transitive closure of a relation `~` for `n ≠ m` if `i ~ pred i`
+  for all `i` between `n` and `m`. -/
+lemma trans_gen_of_pred_of_gt (r : α → α → Prop) {n m : α}
+  (h : ∀ i ∈ Ioc m n, r i (pred i)) (hnm : m < n) : trans_gen r n m :=
+trans_gen_of_pred_of_ne r h (by simp [Ioc_eq_empty_of_le hnm.le]) hnm.ne.symm
+
+/-- For `n < m`, `(n, m)` is in the transitive closure of a relation `~` for `n ≠ m` if `pred i ~ i`
+  for all `i` between `n` and `m`. -/
+lemma trans_gen_of_pred_of_lt (r : α → α → Prop) {n m : α}
+  (h : ∀ i ∈ Ioc n m, r (pred i) i) (hmn : n < m) : trans_gen r n m :=
+trans_gen_of_pred_of_ne r (by simp [Ioc_eq_empty_of_le hmn.le]) h hmn.ne
+
+/-- `(n, m)` is in the transitive closure of a reflexive relation `~` if `i ~ pred i` and
+  `pred i ~ i` for all `i` between `n` and `m`. -/
+lemma trans_gen_of_pred_of_reflexive (r : α → α → Prop) {n m : α} (hr : reflexive r)
+  (h1 : ∀ i ∈ Ioc m n, r i (pred i)) (h2 : ∀ i ∈ Ioc n m, r (pred i) i) : trans_gen r n m :=
+@trans_gen_of_succ_of_reflexive (order_dual α) _ _ _ r n m hr (λ x hx, h1 x ⟨hx.2, hx.1⟩)
+  (λ x hx, h2 x ⟨hx.2, hx.1⟩)
+
+end pred

--- a/src/order/succ_pred/relation.lean
+++ b/src/order/succ_pred/relation.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Floris van Doorn
 -/
 import order.succ_pred.basic
-import logic.relation
 /-!
 # Relations on types with a `succ_order`
 

--- a/src/order/succ_pred/relation.lean
+++ b/src/order/succ_pred/relation.lean
@@ -1,0 +1,56 @@
+/-
+Copyright (c) 2022 Floris van Doorn. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Floris van Doorn
+-/
+import order.succ_pred.basic
+import logic.relation
+/-!
+# Relations on types with a `succ_order`
+
+This file contains properties about relations on types with a `succ_order`
+and their closure operations (like the transitive closure).
+-/
+
+open set relation succ_order function
+
+variables {α : Type*} [linear_order α] [succ_order α] [is_succ_archimedean α] [no_max_order α]
+/-- `(n, m)` is in the reflexive-transitive closure of `~` if `i ~ i+1` and `i+1 ~ i`
+  for all `i` between `n` and `m`. -/
+lemma refl_trans_gen_of_succ (r : α → α → Prop) {n m : α}
+  (h1 : ∀ i ∈ Ico n m, r i (succ i)) (h2 : ∀ i ∈ Ico m n, r (succ i) i) : refl_trans_gen r n m :=
+begin
+  cases le_total n m with hnm hmn,
+  { revert h1 h2,
+    refine le_succ_rec _ _ hnm,
+    { intros h1 h2, exact refl_trans_gen.refl },
+    { intros m hnm ih h1 h2,
+      refine refl_trans_gen.tail (ih _ _) (h1 m _),
+      { intros i hi, exact h1 i ⟨hi.1, hi.2.trans $ lt_succ m⟩ },
+      { simp [Ico_eq_empty_of_le (show n ≤ m, from hnm)] },
+      { refine ⟨hnm, lt_succ m⟩ } }, },
+  { revert h1 h2,
+    refine le_succ_rec _ _ hmn,
+    { intros h1 h2, exact refl_trans_gen.refl },
+    { intros n hmn ih h1 h2,
+      refine refl_trans_gen.head (h2 n _) (ih _ _),
+      { refine ⟨hmn, lt_succ n⟩ },
+      { simp [Ico_eq_empty_of_le (show m ≤ n, from hmn)] },
+      { intros i hi, exact h2 i ⟨hi.1, hi.2.trans $ lt_succ n⟩ } } }
+end
+
+/-- `(n, m)` is in the transitive closure of a relation `~` for `n ≠ m` if `i ~ i+1` and `i+1 ~ i`
+  for all `i` between `n` and `m`. -/
+lemma trans_gen_of_succ_of_ne (r : α → α → Prop) {n m : α}
+  (h1 : ∀ i ∈ Ico n m, r i (succ i)) (h2 : ∀ i ∈ Ico m n, r (succ i) i)
+  (hnm : n ≠ m) : trans_gen r n m :=
+(refl_trans_gen_iff_eq_or_trans_gen.mp (refl_trans_gen_of_succ r h1 h2)).resolve_left hnm.symm
+
+/-- `(n, m)` is in the transitive closure of a reflexive relation `~` if `i ~ i+1` and `i+1 ~ i`
+  for all `i` between `n` and `m`. -/
+lemma trans_gen_of_succ_of_reflexive (r : α → α → Prop) {n m : α} (hr : reflexive r)
+  (h1 : ∀ i ∈ Ico n m, r i (succ i)) (h2 : ∀ i ∈ Ico m n, r (succ i) i) : trans_gen r n m :=
+begin
+  rcases eq_or_ne m n with rfl|hmn, { exact trans_gen.single (hr m) },
+  exact trans_gen_of_succ_of_ne r h1 h2 hmn.symm
+end

--- a/src/order/succ_pred/relation.lean
+++ b/src/order/succ_pred/relation.lean
@@ -13,8 +13,8 @@ and their closure operations (like the transitive closure).
 
 open set relation succ_order pred_order function
 
-section succ
-variables {α : Type*} [linear_order α] [succ_order α] [is_succ_archimedean α]
+section partial_succ
+variables {α : Type*} [partial_order α] [succ_order α] [is_succ_archimedean α]
 
 /-- For `n ≤ m`, `(n, m)` is in the reflexive-transitive closure of `~` if `i ~ succ i`
   for all `i` between `n` and `m`. -/
@@ -35,6 +35,25 @@ lemma refl_trans_gen_of_succ_of_ge (r : α → α → Prop) {n m : α}
   (h : ∀ i ∈ Ico m n, r (succ i) i) (hmn : m ≤ n) : refl_trans_gen r n m :=
 by { rw [← refl_trans_gen_swap], exact refl_trans_gen_of_succ_of_le (swap r) h hmn }
 
+/-- For `n < m`, `(n, m)` is in the transitive closure of a relation `~` if `i ~ succ i`
+  for all `i` between `n` and `m`. -/
+lemma trans_gen_of_succ_of_lt (r : α → α → Prop) {n m : α}
+  (h : ∀ i ∈ Ico n m, r i (succ i)) (hnm : n < m) : trans_gen r n m :=
+(refl_trans_gen_iff_eq_or_trans_gen.mp $ refl_trans_gen_of_succ_of_le r h hnm.le).resolve_left
+  hnm.ne'
+
+/-- For `m < n`, `(n, m)` is in the transitive closure of a relation `~` if `succ i ~ i`
+  for all `i` between `n` and `m`. -/
+lemma trans_gen_of_succ_of_gt (r : α → α → Prop) {n m : α}
+  (h : ∀ i ∈ Ico m n, r (succ i) i) (hmn : m < n) : trans_gen r n m :=
+(refl_trans_gen_iff_eq_or_trans_gen.mp $ refl_trans_gen_of_succ_of_ge r h hmn.le).resolve_left
+  hmn.ne
+
+end partial_succ
+
+section linear_succ
+variables {α : Type*} [linear_order α] [succ_order α] [is_succ_archimedean α]
+
 /-- `(n, m)` is in the reflexive-transitive closure of `~` if `i ~ succ i` and `succ i ~ i`
   for all `i` between `n` and `m`. -/
 lemma refl_trans_gen_of_succ (r : α → α → Prop) {n m : α}
@@ -48,17 +67,6 @@ lemma trans_gen_of_succ_of_ne (r : α → α → Prop) {n m : α}
   (hnm : n ≠ m) : trans_gen r n m :=
 (refl_trans_gen_iff_eq_or_trans_gen.mp (refl_trans_gen_of_succ r h1 h2)).resolve_left hnm.symm
 
-/-- For `n < m`, `(n, m)` is in the transitive closure of a relation `~` if `i ~ succ i`
-  for all `i` between `n` and `m`. -/
-lemma trans_gen_of_succ_of_lt (r : α → α → Prop) {n m : α}
-  (h : ∀ i ∈ Ico n m, r i (succ i)) (hnm : n < m) : trans_gen r n m :=
-trans_gen_of_succ_of_ne r h (by simp [Ico_eq_empty_of_le hnm.le]) hnm.ne
-
-/-- For `m < n`, `(n, m)` is in the transitive closure of a relation `~` if `succ i ~ i`
-  for all `i` between `n` and `m`. -/
-lemma trans_gen_of_succ_of_gt (r : α → α → Prop) {n m : α}
-  (h : ∀ i ∈ Ico m n, r (succ i) i) (hmn : m < n) : trans_gen r n m :=
-trans_gen_of_succ_of_ne r (by simp [Ico_eq_empty_of_le hmn.le]) h hmn.ne.symm
 
 /-- `(n, m)` is in the transitive closure of a reflexive relation `~` if `i ~ succ i` and
   `succ i ~ i` for all `i` between `n` and `m`. -/
@@ -69,10 +77,10 @@ begin
   exact trans_gen_of_succ_of_ne r h1 h2 hmn.symm
 end
 
-end succ
+end linear_succ
 
-section pred
-variables {α : Type*} [linear_order α] [pred_order α] [is_pred_archimedean α]
+section partial_pred
+variables {α : Type*} [partial_order α] [pred_order α] [is_pred_archimedean α]
 
 /-- For `m ≤ n`, `(n, m)` is in the reflexive-transitive closure of `~` if `i ~ pred i`
   for all `i` between `n` and `m`. -/
@@ -85,6 +93,23 @@ lemma refl_trans_gen_of_pred_of_ge (r : α → α → Prop) {n m : α}
 lemma refl_trans_gen_of_pred_of_le (r : α → α → Prop) {n m : α}
   (h : ∀ i ∈ Ioc n m, r (pred i) i) (hmn : n ≤ m) : refl_trans_gen r n m :=
 @refl_trans_gen_of_succ_of_ge (order_dual α) _ _ _ r n m (λ x hx, h x ⟨hx.2, hx.1⟩) hmn
+
+/-- For `m < n`, `(n, m)` is in the transitive closure of a relation `~` for `n ≠ m` if `i ~ pred i`
+  for all `i` between `n` and `m`. -/
+lemma trans_gen_of_pred_of_gt (r : α → α → Prop) {n m : α}
+  (h : ∀ i ∈ Ioc m n, r i (pred i)) (hnm : m < n) : trans_gen r n m :=
+@trans_gen_of_succ_of_lt (order_dual α) _ _ _ r _ _ (λ x hx, h x ⟨hx.2, hx.1⟩) hnm
+
+/-- For `n < m`, `(n, m)` is in the transitive closure of a relation `~` for `n ≠ m` if `pred i ~ i`
+  for all `i` between `n` and `m`. -/
+lemma trans_gen_of_pred_of_lt (r : α → α → Prop) {n m : α}
+  (h : ∀ i ∈ Ioc n m, r (pred i) i) (hmn : n < m) : trans_gen r n m :=
+@trans_gen_of_succ_of_gt (order_dual α) _ _ _ r _ _ (λ x hx, h x ⟨hx.2, hx.1⟩) hmn
+
+end partial_pred
+
+section linear_pred
+variables {α : Type*} [linear_order α] [pred_order α] [is_pred_archimedean α]
 
 /-- `(n, m)` is in the reflexive-transitive closure of `~` if `i ~ pred i` and `pred i ~ i`
   for all `i` between `n` and `m`. -/
@@ -101,18 +126,6 @@ lemma trans_gen_of_pred_of_ne (r : α → α → Prop) {n m : α}
 @trans_gen_of_succ_of_ne (order_dual α) _ _ _ r n m (λ x hx, h1 x ⟨hx.2, hx.1⟩)
   (λ x hx, h2 x ⟨hx.2, hx.1⟩) hnm
 
-/-- For `m < n`, `(n, m)` is in the transitive closure of a relation `~` for `n ≠ m` if `i ~ pred i`
-  for all `i` between `n` and `m`. -/
-lemma trans_gen_of_pred_of_gt (r : α → α → Prop) {n m : α}
-  (h : ∀ i ∈ Ioc m n, r i (pred i)) (hnm : m < n) : trans_gen r n m :=
-trans_gen_of_pred_of_ne r h (by simp [Ioc_eq_empty_of_le hnm.le]) hnm.ne.symm
-
-/-- For `n < m`, `(n, m)` is in the transitive closure of a relation `~` for `n ≠ m` if `pred i ~ i`
-  for all `i` between `n` and `m`. -/
-lemma trans_gen_of_pred_of_lt (r : α → α → Prop) {n m : α}
-  (h : ∀ i ∈ Ioc n m, r (pred i) i) (hmn : n < m) : trans_gen r n m :=
-trans_gen_of_pred_of_ne r (by simp [Ioc_eq_empty_of_le hmn.le]) h hmn.ne
-
 /-- `(n, m)` is in the transitive closure of a reflexive relation `~` if `i ~ pred i` and
   `pred i ~ i` for all `i` between `n` and `m`. -/
 lemma trans_gen_of_pred_of_reflexive (r : α → α → Prop) {n m : α} (hr : reflexive r)
@@ -120,4 +133,4 @@ lemma trans_gen_of_pred_of_reflexive (r : α → α → Prop) {n m : α} (hr : r
 @trans_gen_of_succ_of_reflexive (order_dual α) _ _ _ r n m hr (λ x hx, h1 x ⟨hx.2, hx.1⟩)
   (λ x hx, h2 x ⟨hx.2, hx.1⟩)
 
-end pred
+end linear_pred

--- a/src/set_theory/ordinal.lean
+++ b/src/set_theory/ordinal.lean
@@ -5,7 +5,7 @@ Authors: Mario Carneiro, Floris van Doorn
 -/
 import data.sum.order
 import order.conditionally_complete_lattice
-import order.succ_pred
+import order.succ_pred.basic
 import set_theory.cardinal
 
 /-!


### PR DESCRIPTION
* Rename file `order.succ_pred` -> `order.succ_pred.basic`
* Generalize induction principles `succ.rec` and `pred.rec`, make the argument order more "induction-like" and add the attribute `@[elab_as_eliminator]`
* Proof properties about `refl_trans_gen` and `trans_gen` in a `is_succ_archimedean` order.
* Proof some monotonicity properties of closure operations.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
