### PR TITLE
[Merged by Bors] - feat(group_theory/nilpotent): Add equality theorems for nilpotency class

### DIFF
--- a/src/group_theory/nilpotent.lean
+++ b/src/group_theory/nilpotent.lean
@@ -351,8 +351,8 @@ nat.find (is_nilpotent.nilpotent G)
 
 variable {G}
 
-/-- Equivalently, the nilpotency class is the smallest `n` for which any ascending
-central series reaches `G` in its `n`'th term -/
+/-- The nilpotency class of a nilpotent `G` is equal to the smallest `n` for which an ascending
+central series reaches `G` in its `n`'th term. -/
 lemma least_ascending_central_series_length_eq_nilpotency_class :
   nat.find ((nilpotent_iff_finite_ascending_central_series G).mp hG) = group.nilpotency_class G :=
 begin
@@ -365,6 +365,8 @@ begin
     exact (ascending_central_series_le_upper H hH n), }
 end
 
+/-- The nilpotency class of a nilpotent `G` is equal to the smallest `n` for which a descending
+central series reaches `⊥` in its `n`'th term. -/
 lemma least_descending_central_series_length_eq_nilpotency_class :
   nat.find ((nilpotent_iff_finite_descending_central_series G).mp hG) = group.nilpotency_class G :=
 begin
@@ -382,6 +384,7 @@ begin
     { simp, exact hH.1 } },
 end
 
+/-- The nilpotency class of a nilpotent `G` is equal to the length of the lower central series. -/
 lemma lower_central_series_length_eq_nilpotency_class :
   nat.find (nilpotent_iff_lower_central_series.mp hG) = @group.nilpotency_class G _ _ :=
 begin

--- a/src/group_theory/nilpotent.lean
+++ b/src/group_theory/nilpotent.lean
@@ -49,7 +49,12 @@ subgroup `G` of `G`, and `⊥` denotes the trivial subgroup `{1}`.
 * `nilpotent_iff_finite_descending_central_series` : `G` is nilpotent iff some descending central
     series reaches `⊥`.
 * `nilpotent_iff_lower` : `G` is nilpotent iff the lower central series reaches `⊥`.
+* The `nilpotency_class` can likeways be obtained from these equivalent
+  definitions, see `least_ascending_central_series_length_eq_nilpotency_class`,
+  `least_descending_central_series_length_eq_nilpotency_class` and
+  `lower_central_series_length_eq_nilpotency_class`.
 * `is_nilpotent.to_is_solvable`: If `G` is nilpotent, it is solvable.
+
 
 ## Warning
 
@@ -139,17 +144,6 @@ class group.is_nilpotent (G : Type*) [group G] : Prop :=
 
 open group
 
-section classical
-
-open_locale classical
-
-/-- The nilpotency class of a nilpotent group is the small natural `n` such that
-the `n`'th term of the upper central series is `G`. -/
-noncomputable def group.nilpotency_class (G : Type*) [group G] [is_nilpotent G] : ℕ :=
-nat.find (is_nilpotent.nilpotent G)
-
-end classical
-
 variable {G}
 
 /-- A sequence of subgroups of `G` is an ascending central series if `H 0` is trivial and
@@ -208,6 +202,45 @@ begin
     exact eq_top_iff.mpr this }
 end
 
+lemma is_decending_rev_series_of_is_ascending
+  {H: ℕ → subgroup G} {n : ℕ} (hn : H n = ⊤) (hasc : is_ascending_central_series H) :
+  is_descending_central_series (λ (m : ℕ), H (n - m)) :=
+begin
+  cases hasc with h0 hH,
+  refine ⟨hn, λ x m hx g, _⟩,
+  dsimp at hx,
+  by_cases hm : n ≤ m,
+  { have hnm : n - m = 0 := tsub_eq_zero_iff_le.mpr hm,
+    rw [hnm, h0, subgroup.mem_bot] at hx,
+    subst hx,
+    convert subgroup.one_mem _,
+    group },
+  { push_neg at hm,
+    apply hH,
+    convert hx,
+    rw nat.sub_succ,
+    exact nat.succ_pred_eq_of_pos (tsub_pos_of_lt hm) },
+end
+
+lemma is_ascending_rev_series_of_is_descending
+  {H: ℕ → subgroup G} {n : ℕ} (hn : H n = ⊥) (hdesc : is_descending_central_series H) :
+  is_ascending_central_series (λ (m : ℕ), H (n - m)) :=
+begin
+  cases hdesc with h0 hH,
+  refine ⟨hn, λ x m hx g, _⟩,
+  dsimp only at hx,
+  by_cases hm : n ≤ m,
+  { have hnm : n - m = 0 := tsub_eq_zero_iff_le.mpr hm,
+    dsimp only,
+    rw [hnm, h0],
+    exact mem_top _ },
+  { push_neg at hm,
+    dsimp only,
+    convert hH x _ hx g,
+    rw nat.sub_succ,
+    exact (nat.succ_pred_eq_of_pos (tsub_pos_of_lt hm)).symm }
+end
+
 /-- A group `G` is nilpotent iff there exists a descending central series which reaches the
   trivial group in a finite time. -/
 theorem nilpotent_iff_finite_descending_central_series :
@@ -215,41 +248,16 @@ theorem nilpotent_iff_finite_descending_central_series :
 begin
   rw nilpotent_iff_finite_ascending_central_series,
   split,
-  { rintro ⟨H, ⟨h0, hH⟩, n, hn⟩,
+  { rintro ⟨H, hasc, n, hn⟩,
     use (λ m, H (n - m)),
     split,
-    { refine ⟨hn, λ x m hx g, _⟩,
-      dsimp at hx,
-      by_cases hm : n ≤ m,
-      { have hnm : n - m = 0 := tsub_eq_zero_iff_le.mpr hm,
-        rw [hnm, h0, subgroup.mem_bot] at hx,
-        subst hx,
-        convert subgroup.one_mem _,
-        group },
-      { push_neg at hm,
-        apply hH,
-        convert hx,
-        rw nat.sub_succ,
-        exact nat.succ_pred_eq_of_pos (tsub_pos_of_lt hm) } },
-    { use n,
-      rwa tsub_self } },
-  { rintro ⟨H, ⟨h0, hH⟩, n, hn⟩,
+    { apply (is_decending_rev_series_of_is_ascending G hn hasc) },
+    { use n, simp, exact hasc.1 } },
+  { rintro ⟨H, hdesc, n, hn⟩,
     use (λ m, H (n - m)),
     split,
-    { refine ⟨hn, λ x m hx g, _⟩,
-      dsimp only at hx,
-      by_cases hm : n ≤ m,
-      { have hnm : n - m = 0 := tsub_eq_zero_iff_le.mpr hm,
-        dsimp only,
-        rw [hnm, h0],
-        exact mem_top _ },
-      { push_neg at hm,
-        dsimp only,
-        convert hH x _ hx g,
-        rw nat.sub_succ,
-        exact (nat.succ_pred_eq_of_pos (tsub_pos_of_lt hm)).symm } },
-    { use n,
-      rwa tsub_self } },
+    { apply (is_ascending_rev_series_of_is_descending G hn hdesc) },
+    { use n, simp, exact hdesc.1 } },
 end
 
 /-- The lower central series of a group `G` is a sequence `H n` of subgroups of `G`, defined
@@ -327,6 +335,78 @@ begin
   { intro h,
     use [lower_central_series G, lower_central_series_is_descending_central_series, h] },
 end
+
+section classical
+
+open_locale classical
+
+variables [hG : is_nilpotent G]
+include hG
+
+/-- The nilpotency class of a nilpotent group is the small natural `n` such that
+the `n`'th term of the upper central series is `G`. -/
+noncomputable def group.nilpotency_class : ℕ :=
+nat.find (is_nilpotent.nilpotent G)
+
+/-- Equivalently, the nilpotency class is the smallest `n` for which any ascending
+central series reaches `G` in its `n`'th term -/
+lemma least_ascending_central_series_length_eq_nilpotency_class
+  (h : ∃ n : ℕ, ∃ H : ℕ → subgroup G, (is_ascending_central_series H ∧ H n = ⊤)) :
+  nat.find h = @group.nilpotency_class G _ _ :=
+begin
+  refine le_antisymm (nat.find_mono _) (nat.find_mono _); clear h,
+  { rintros n h,
+    refine ⟨upper_central_series G, ⟨upper_central_series_is_ascending_central_series G, h⟩⟩ },
+  { rintros n ⟨H, ⟨hasc, hn⟩⟩,
+    apply top_le_iff.mp,
+    rw ← hn,
+    exact (ascending_central_series_le_upper H hasc n), }
+end
+
+lemma least_descending_central_series_length_eq_nilpotency_class
+  (h : ∃ n : ℕ, ∃ H : ℕ → subgroup G, (is_descending_central_series H ∧ H n = ⊥)) :
+  nat.find h = @group.nilpotency_class G _ _ :=
+begin
+  have h₂ : ∃ n : ℕ, ∃ H : ℕ → subgroup G, (is_ascending_central_series H ∧ H n = ⊤) :=
+  begin
+    obtain ⟨H, ⟨hH, ⟨n, hn⟩⟩⟩ := (nilpotent_iff_finite_ascending_central_series G).mp hG,
+    refine ⟨n, H, hH, hn⟩,
+  end,
+  rw ← least_ascending_central_series_length_eq_nilpotency_class h₂,
+  refine le_antisymm (nat.find_mono _) (nat.find_mono _); clear h h₂,
+  { rintros n ⟨H, ⟨hH, hn⟩⟩,
+    use (λ m, H (n - m)),
+    split,
+    { apply is_decending_rev_series_of_is_ascending G hn hH },
+    { simp, exact hH.1 } },
+  { rintros n ⟨H, ⟨hH, hn⟩⟩,
+    use (λ m, H (n - m)),
+    split,
+    { apply is_ascending_rev_series_of_is_descending G hn hH },
+    { simp, exact hH.1 } },
+end
+
+lemma lower_central_series_length_eq_nilpotency_class
+  (h : ∃ n : ℕ, lower_central_series G n = ⊥) :
+  nat.find h = @group.nilpotency_class G _ _ :=
+begin
+  have h₂ : ∃ n : ℕ, ∃ H : ℕ → subgroup G, (is_descending_central_series H ∧ H n = ⊥) :=
+  begin
+    obtain ⟨H, ⟨hH, ⟨n, hn⟩⟩⟩ := (nilpotent_iff_finite_descending_central_series G).mp hG,
+    refine ⟨n, H, hH, hn⟩,
+  end,
+  rw ← least_descending_central_series_length_eq_nilpotency_class h₂,
+  refine le_antisymm (nat.find_mono _) (nat.find_mono _); clear h h₂,
+  { rintros n ⟨H, ⟨hH, hn⟩⟩,
+    apply le_bot_iff.mp,
+    rw ← hn,
+    exact (descending_central_series_ge_lower H hH n), },
+  { rintros n h,
+    refine ⟨lower_central_series G, ⟨lower_central_series_is_descending_central_series, h⟩⟩ },
+end
+
+
+end classical
 
 lemma lower_central_series_map_subtype_le (H : subgroup G) (n : ℕ) :
   (lower_central_series H n).map H.subtype ≤ lower_central_series G n :=

--- a/src/group_theory/nilpotent.lean
+++ b/src/group_theory/nilpotent.lean
@@ -344,7 +344,7 @@ include hG
 
 variable (G)
 
-/-- The nilpotency class of a nilpotent group is the small natural `n` such that
+/-- The nilpotency class of a nilpotent group is the smallest natural `n` such that
 the `n`'th term of the upper central series is `G`. -/
 noncomputable def group.nilpotency_class : ℕ :=
 nat.find (is_nilpotent.nilpotent G)
@@ -365,7 +365,7 @@ begin
     exact (ascending_central_series_le_upper H hH n), }
 end
 
-/-- The nilpotency class of a nilpotent `G` is equal to the smallest `n` for which a descending
+/-- The nilpotency class of a nilpotent `G` is equal to the smallest `n` for which the descending
 central series reaches `⊥` in its `n`'th term. -/
 lemma least_descending_central_series_length_eq_nilpotency_class :
   nat.find ((nilpotent_iff_finite_descending_central_series G).mp hG) = group.nilpotency_class G :=


### PR DESCRIPTION
the nilpotency class can be defined as the length of the
upper central series, the lower central series, or as the shortest
length across all ascending or descending series.

In order to use the equivalence proofs between the various definition
of nilpotency in these lemmas, I had to reorder them to put the `∃n` in
front.

---

I’m still new here, so happy to learn through these reviews :-). I left a few questions via a self-review below.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
