### PR TITLE
[Merged by Bors] - feat(data/nat/prime): factors of non-prime powers

### DIFF
--- a/src/data/finset/basic.lean
+++ b/src/data/finset/basic.lean
@@ -1828,10 +1828,10 @@ lemma to_finset_eq_iff_perm_erase_dup {l l' : list α} :
   l.to_finset = l'.to_finset ↔ l.erase_dup ~ l'.erase_dup :=
 by simp [finset.ext_iff, perm_ext (nodup_erase_dup _) (nodup_erase_dup _)]
 
-lemma to_finset.ext_iff {a b : list ℕ} : a.to_finset = b.to_finset ↔ ∀ x, x ∈ a ↔ x ∈ b :=
+lemma to_finset.ext_iff {a b : list α} : a.to_finset = b.to_finset ↔ ∀ x, x ∈ a ↔ x ∈ b :=
 by simp only [finset.ext_iff, mem_to_finset]
 
-lemma to_finset.ext {a b : list ℕ} : (∀ x, x ∈ a ↔ x ∈ b) → a.to_finset = b.to_finset :=
+lemma to_finset.ext {a b : list α} : (∀ x, x ∈ a ↔ x ∈ b) → a.to_finset = b.to_finset :=
 to_finset.ext_iff.mpr
 
 lemma to_finset_eq_of_perm (l l' : list α) (h : l ~ l') :

--- a/src/data/finset/basic.lean
+++ b/src/data/finset/basic.lean
@@ -1828,6 +1828,12 @@ lemma to_finset_eq_iff_perm_erase_dup {l l' : list α} :
   l.to_finset = l'.to_finset ↔ l.erase_dup ~ l'.erase_dup :=
 by simp [finset.ext_iff, perm_ext (nodup_erase_dup _) (nodup_erase_dup _)]
 
+lemma to_finset.ext_iff {a b : list ℕ} : a.to_finset = b.to_finset ↔ ∀ x, x ∈ a ↔ x ∈ b :=
+by simp only [to_finset_eq_iff_perm_erase_dup, perm_ext, nodup_erase_dup, mem_erase_dup]
+
+lemma to_finset.ext {a b : list ℕ} : (∀ x, x ∈ a ↔ x ∈ b) → a.to_finset = b.to_finset :=
+to_finset.ext_iff.mpr
+
 lemma to_finset_eq_of_perm (l l' : list α) (h : l ~ l') :
   l.to_finset = l'.to_finset :=
 to_finset_eq_iff_perm_erase_dup.mpr h.erase_dup

--- a/src/data/finset/basic.lean
+++ b/src/data/finset/basic.lean
@@ -1829,7 +1829,7 @@ lemma to_finset_eq_iff_perm_erase_dup {l l' : list α} :
 by simp [finset.ext_iff, perm_ext (nodup_erase_dup _) (nodup_erase_dup _)]
 
 lemma to_finset.ext_iff {a b : list ℕ} : a.to_finset = b.to_finset ↔ ∀ x, x ∈ a ↔ x ∈ b :=
-by simp only [to_finset_eq_iff_perm_erase_dup, perm_ext, nodup_erase_dup, mem_erase_dup]
+by simp only [finset.ext_iff, mem_to_finset]
 
 lemma to_finset.ext {a b : list ℕ} : (∀ x, x ∈ a ↔ x ∈ b) → a.to_finset = b.to_finset :=
 to_finset.ext_iff.mpr

--- a/src/data/nat/factorization.lean
+++ b/src/data/nat/factorization.lean
@@ -131,12 +131,12 @@ begin
   exact support_add_eq (factorization_disjoint_of_coprime hab),
 end
 
-lemma factorization_mul_support_of_pos {a b : ℕ} (ha : a ≠ 0) (hb : b ≠ 0) :
+lemma factorization_mul_support {a b : ℕ} (ha : a ≠ 0) (hb : b ≠ 0) :
   (a * b).factorization.support = a.factorization.support ∪ b.factorization.support :=
 begin
   ext q,
   simp only [finset.mem_union, factor_iff_mem_factorization],
-  rw mem_factors_mul_of_pos ha.bot_lt hb.bot_lt,
+  rw mem_factors_mul ha hb,
 end
 
 /-- For any multiplicative function `f` with `f 1 = 1` and any `n > 0`,

--- a/src/data/nat/prime.lean
+++ b/src/data/nat/prime.lean
@@ -1101,17 +1101,18 @@ end nat
 
 namespace nat
 
-lemma mem_factors_mul {a b : ℕ} (ha : a ≠ 0) (hb : b ≠ 0) (p : ℕ) :
+lemma mem_factors_mul {a b : ℕ} (ha : a ≠ 0) (hb : b ≠ 0) {p : ℕ} :
   p ∈ (a * b).factors ↔ p ∈ a.factors ∨ p ∈ b.factors :=
 begin
   rw [mem_factors (mul_ne_zero ha hb), mem_factors ha, mem_factors hb, ←and_or_distrib_left],
   simpa only [and.congr_right_iff] using prime.dvd_mul
 end
 
-/-- If `a`,`b` are positive the prime divisors of `(a * b)` are the union of those of `a` and `b` -/
+/-- If `a`, `b` are positive, the prime divisors of `a * b` are the union of those of `a` and `b` -/
 lemma factors_mul_to_finset {a b : ℕ} (ha : a ≠ 0) (hb : b ≠ 0) :
   (a * b).factors.to_finset = a.factors.to_finset ∪ b.factors.to_finset :=
-by { ext p, simp only [finset.mem_union, list.mem_to_finset, mem_factors_mul ha hb p] }
+(list.to_finset.ext $ λ x, (mem_factors_mul ha hb).trans list.mem_union.symm).trans $
+  list.to_finset_union _ _
 
 lemma pow_succ_factors_to_finset (n k : ℕ) :
   (n^(k+1)).factors.to_finset = n.factors.to_finset :=
@@ -1152,16 +1153,16 @@ begin
   { simp [(coprime_zero_left _).mp hab] },
   rcases b.eq_zero_or_pos with rfl | hb,
   { simp [(coprime_zero_right _).mp hab] },
-  rw [mem_factors_mul ha.ne' hb.ne' p, list.mem_union]
+  rw [mem_factors_mul ha.ne' hb.ne', list.mem_union]
 end
 
 lemma factors_mul_to_finset_of_coprime {a b : ℕ} (hab : coprime a b) :
   (a * b).factors.to_finset = a.factors.to_finset ∪ b.factors.to_finset :=
-by { ext p, simp [mem_factors_mul_of_coprime hab] }
+(list.to_finset.ext $ mem_factors_mul_of_coprime hab).trans $ list.to_finset_union _ _
 
 open list
 
-/-- For `b > 0`, the power of `p` in `a * b` is at least that in `a` -/
+/-- For `0 < b`, the power of `p` in `a * b` is at least that in `a` -/
 lemma le_factors_count_mul_left {p a b : ℕ} (hb : 0 < b) :
   list.count p a.factors ≤ list.count p (a * b).factors :=
 begin

--- a/src/data/nat/prime.lean
+++ b/src/data/nat/prime.lean
@@ -1102,21 +1102,40 @@ end nat
 namespace nat
 
 /-- The only prime divisor of positive prime power `p^k` is `p` itself -/
-lemma prime_pow_prime_divisor {p k : ℕ} (hk : 0 < k) (hp: prime p) :
+lemma prime_pow_prime_divisor {p k : ℕ} (hk : k ≠ 0) (hp : prime p) :
   (p^k).factors.to_finset = {p} :=
-by rw [hp.factors_pow, list.to_finset_repeat_of_ne_zero hk.ne']
+by rw [hp.factors_pow, list.to_finset_repeat_of_ne_zero hk]
 
-lemma mem_factors_mul_of_pos {a b : ℕ} (ha : 0 < a) (hb : 0 < b) (p : ℕ) :
+lemma mem_factors_mul_of_ne_zero {a b : ℕ} (ha : a ≠ 0) (hb : b ≠ 0) (p : ℕ) :
   p ∈ (a * b).factors ↔ p ∈ a.factors ∨ p ∈ b.factors :=
 begin
-  rw [mem_factors (mul_pos ha hb), mem_factors ha, mem_factors hb, ←and_or_distrib_left],
+  rw [mem_factors (mul_ne_zero ha hb).bot_lt, mem_factors ha.bot_lt, mem_factors hb.bot_lt,
+    ←and_or_distrib_left],
   simpa only [and.congr_right_iff] using prime.dvd_mul
 end
 
 /-- If `a`,`b` are positive the prime divisors of `(a * b)` are the union of those of `a` and `b` -/
-lemma factors_mul_of_pos {a b : ℕ} (ha : 0 < a) (hb : 0 < b) :
+lemma factors_mul_to_finset_of_ne_zero {a b : ℕ} (ha : a ≠ 0) (hb : b ≠ 0) :
   (a * b).factors.to_finset = a.factors.to_finset ∪ b.factors.to_finset :=
-by { ext p, simp only [finset.mem_union, list.mem_to_finset, mem_factors_mul_of_pos ha hb p] }
+by { ext p, simp only [finset.mem_union, list.mem_to_finset, mem_factors_mul_of_ne_zero ha hb p] }
+
+lemma pow_succ_factors_to_finset (n k : ℕ) :
+  (n^(k+1)).factors.to_finset = n.factors.to_finset :=
+begin
+  rcases eq_or_ne n 0 with rfl | hn,
+  { simp },
+  induction k with k ih,
+  { simp },
+  rw [pow_succ, factors_mul_to_finset_of_ne_zero hn (pow_ne_zero _ hn), ih, finset.union_idempotent]
+end
+
+lemma pow_factors_to_finset (n : ℕ) {k : ℕ} (hk : k ≠ 0) :
+  (n^k).factors.to_finset = n.factors.to_finset :=
+begin
+  cases k,
+  { simpa using hk },
+  rw pow_succ_factors_to_finset
+end
 
 /-- The sets of factors of coprime `a` and `b` are disjoint -/
 lemma coprime_factors_disjoint {a b : ℕ} (hab: a.coprime b) : list.disjoint a.factors b.factors :=
@@ -1127,16 +1146,19 @@ begin
   exact prime_of_mem_factors hqa
 end
 
-lemma factors_mul_of_coprime {a b : ℕ} (hab : coprime a b) (p:ℕ):
+lemma mem_factors_mul_of_coprime {a b : ℕ} (hab : coprime a b) (p : ℕ) :
   p ∈ (a * b).factors ↔ p ∈ a.factors ∪ b.factors :=
 begin
   rcases a.eq_zero_or_pos with rfl | ha,
   { simp [(coprime_zero_left _).mp hab] },
   rcases b.eq_zero_or_pos with rfl | hb,
   { simp [(coprime_zero_right _).mp hab] },
-  rw [mem_factors_mul_of_pos ha hb p, list.mem_union]
+  rw [mem_factors_mul_of_ne_zero ha.ne' hb.ne' p, list.mem_union]
 end
 
+lemma factors_mul_to_finset_of_coprime {a b : ℕ} (hab : coprime a b) :
+  (a * b).factors.to_finset = a.factors.to_finset ∪ b.factors.to_finset :=
+by { ext p, simp [mem_factors_mul_of_coprime hab] }
 
 open list
 

--- a/src/data/nat/prime.lean
+++ b/src/data/nat/prime.lean
@@ -1106,7 +1106,7 @@ lemma prime_pow_prime_divisor {p k : ℕ} (hk : k ≠ 0) (hp : prime p) :
   (p^k).factors.to_finset = {p} :=
 by rw [hp.factors_pow, list.to_finset_repeat_of_ne_zero hk]
 
-lemma mem_factors_mul_of_ne_zero {a b : ℕ} (ha : a ≠ 0) (hb : b ≠ 0) (p : ℕ) :
+lemma mem_factors_mul {a b : ℕ} (ha : a ≠ 0) (hb : b ≠ 0) (p : ℕ) :
   p ∈ (a * b).factors ↔ p ∈ a.factors ∨ p ∈ b.factors :=
 begin
   rw [mem_factors (mul_ne_zero ha hb).bot_lt, mem_factors ha.bot_lt, mem_factors hb.bot_lt,
@@ -1115,9 +1115,9 @@ begin
 end
 
 /-- If `a`,`b` are positive the prime divisors of `(a * b)` are the union of those of `a` and `b` -/
-lemma factors_mul_to_finset_of_ne_zero {a b : ℕ} (ha : a ≠ 0) (hb : b ≠ 0) :
+lemma factors_mul_to_finset {a b : ℕ} (ha : a ≠ 0) (hb : b ≠ 0) :
   (a * b).factors.to_finset = a.factors.to_finset ∪ b.factors.to_finset :=
-by { ext p, simp only [finset.mem_union, list.mem_to_finset, mem_factors_mul_of_ne_zero ha hb p] }
+by { ext p, simp only [finset.mem_union, list.mem_to_finset, mem_factors_mul ha hb p] }
 
 lemma pow_succ_factors_to_finset (n k : ℕ) :
   (n^(k+1)).factors.to_finset = n.factors.to_finset :=
@@ -1126,7 +1126,7 @@ begin
   { simp },
   induction k with k ih,
   { simp },
-  rw [pow_succ, factors_mul_to_finset_of_ne_zero hn (pow_ne_zero _ hn), ih, finset.union_idempotent]
+  rw [pow_succ, factors_mul_to_finset hn (pow_ne_zero _ hn), ih, finset.union_idempotent]
 end
 
 lemma pow_factors_to_finset (n : ℕ) {k : ℕ} (hk : k ≠ 0) :
@@ -1138,7 +1138,7 @@ begin
 end
 
 /-- The sets of factors of coprime `a` and `b` are disjoint -/
-lemma coprime_factors_disjoint {a b : ℕ} (hab: a.coprime b) : list.disjoint a.factors b.factors :=
+lemma coprime_factors_disjoint {a b : ℕ} (hab : a.coprime b) : list.disjoint a.factors b.factors :=
 begin
   intros q hqa hqb,
   apply not_prime_one,
@@ -1153,7 +1153,7 @@ begin
   { simp [(coprime_zero_left _).mp hab] },
   rcases b.eq_zero_or_pos with rfl | hb,
   { simp [(coprime_zero_right _).mp hab] },
-  rw [mem_factors_mul_of_ne_zero ha.ne' hb.ne' p, list.mem_union]
+  rw [mem_factors_mul ha.ne' hb.ne' p, list.mem_union]
 end
 
 lemma factors_mul_to_finset_of_coprime {a b : ℕ} (hab : coprime a b) :

--- a/src/data/nat/prime.lean
+++ b/src/data/nat/prime.lean
@@ -696,9 +696,9 @@ begin
   { rwa ←mem_factors_iff_dvd hn (prime_of_mem_factors h) }
 end
 
-lemma mem_factors {n p} (hn : 0 < n) : p ∈ factors n ↔ prime p ∧ p ∣ n :=
-⟨λ h, ⟨prime_of_mem_factors h, (mem_factors_iff_dvd hn $ prime_of_mem_factors h).mp h⟩,
- λ ⟨hprime, hdvd⟩, (mem_factors_iff_dvd hn hprime).mpr hdvd⟩
+lemma mem_factors {n p} (hn : n ≠ 0) : p ∈ factors n ↔ prime p ∧ p ∣ n :=
+⟨λ h, ⟨prime_of_mem_factors h, (mem_factors_iff_dvd hn.bot_lt $ prime_of_mem_factors h).mp h⟩,
+ λ ⟨hprime, hdvd⟩, (mem_factors_iff_dvd hn.bot_lt hprime).mpr hdvd⟩
 
 /-- **Fundamental theorem of arithmetic**-/
 lemma factors_unique {n : ℕ} {l : list ℕ} (h₁ : prod l = n) (h₂ : ∀ p ∈ l, prime p) :
@@ -1101,16 +1101,10 @@ end nat
 
 namespace nat
 
-/-- The only prime divisor of positive prime power `p^k` is `p` itself -/
-lemma prime_pow_prime_divisor {p k : ℕ} (hk : k ≠ 0) (hp : prime p) :
-  (p^k).factors.to_finset = {p} :=
-by rw [hp.factors_pow, list.to_finset_repeat_of_ne_zero hk]
-
 lemma mem_factors_mul {a b : ℕ} (ha : a ≠ 0) (hb : b ≠ 0) (p : ℕ) :
   p ∈ (a * b).factors ↔ p ∈ a.factors ∨ p ∈ b.factors :=
 begin
-  rw [mem_factors (mul_ne_zero ha hb).bot_lt, mem_factors ha.bot_lt, mem_factors hb.bot_lt,
-    ←and_or_distrib_left],
+  rw [mem_factors (mul_ne_zero ha hb), mem_factors ha, mem_factors hb, ←and_or_distrib_left],
   simpa only [and.congr_right_iff] using prime.dvd_mul
 end
 
@@ -1136,6 +1130,11 @@ begin
   { simpa using hk },
   rw pow_succ_factors_to_finset
 end
+
+/-- The only prime divisor of positive prime power `p^k` is `p` itself -/
+lemma prime_pow_prime_divisor {p k : ℕ} (hk : k ≠ 0) (hp : prime p) :
+  (p^k).factors.to_finset = {p} :=
+by simp [pow_factors_to_finset p hk, factors_prime hp]
 
 /-- The sets of factors of coprime `a` and `b` are disjoint -/
 lemma coprime_factors_disjoint {a b : ℕ} (hab : a.coprime b) : list.disjoint a.factors b.factors :=

--- a/src/group_theory/p_group.lean
+++ b/src/group_theory/p_group.lean
@@ -52,7 +52,7 @@ begin
   { use (card G).factors.length,
     rw [←list.prod_repeat, ←list.eq_repeat_of_mem this, nat.prod_factors hG] },
   intros q hq,
-  obtain ⟨hq1, hq2⟩ := (nat.mem_factors hG).mp hq,
+  obtain ⟨hq1, hq2⟩ := (nat.mem_factors hG).mp hq.ne',
   haveI : fact q.prime := ⟨hq1⟩,
   obtain ⟨g, hg⟩ := equiv.perm.exists_prime_order_of_dvd_card q hq2,
   obtain ⟨k, hk⟩ := (iff_order_of.mp h) g,

--- a/src/group_theory/p_group.lean
+++ b/src/group_theory/p_group.lean
@@ -52,7 +52,7 @@ begin
   { use (card G).factors.length,
     rw [←list.prod_repeat, ←list.eq_repeat_of_mem this, nat.prod_factors hG] },
   intros q hq,
-  obtain ⟨hq1, hq2⟩ := (nat.mem_factors hG).mp hq.ne',
+  obtain ⟨hq1, hq2⟩ := (nat.mem_factors hG.ne').mp hq,
   haveI : fact q.prime := ⟨hq1⟩,
   obtain ⟨g, hg⟩ := equiv.perm.exists_prime_order_of_dvd_card q hq2,
   obtain ⟨k, hk⟩ := (iff_order_of.mp h) g,


### PR DESCRIPTION
Adds the result `pow_factors_to_finset`, fills in `factors_mul_to_finset_of_coprime` for the sake of completion, and adjusts statements to take `ne_zero` rather than pos assumptions.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
