### PR TITLE
[Merged by Bors] - feat(combinatorics/simple_graph/coloring): add inequalities from embeddings

### DIFF
--- a/src/combinatorics/simple_graph/coloring.lean
+++ b/src/combinatorics/simple_graph/coloring.lean
@@ -184,7 +184,7 @@ G.recolor_of_embedding $ (function.embedding.nonempty_of_card_le hn).some
 
 variables {G}
 
-lemma colorable.of_le {n m : ℕ} (h : n ≤ m) (hc : G.colorable n) : G.colorable m :=
+lemma colorable.mono {n m : ℕ} (h : n ≤ m) (hc : G.colorable n) : G.colorable m :=
 ⟨G.recolor_of_card_le (by simp [h]) hc.some⟩
 
 lemma coloring.to_colorable [fintype α] (C : G.coloring α) :
@@ -307,7 +307,7 @@ begin
   exact colorable_chromatic_number hn,
 end
 
-lemma colorable.of_le_colorable {G' : simple_graph V} (h : G ≤ G') {n : ℕ}
+lemma colorable.mono_left {G' : simple_graph V} (h : G ≤ G') {n : ℕ}
   (hc : G'.colorable n) : G.colorable n :=
 ⟨hc.some.comp (hom.map_spanning_subgraphs h)⟩
 
@@ -324,7 +324,7 @@ end
 lemma colorable.chromatic_number_mono (G' : simple_graph V)
   {m : ℕ} (hc : G'.colorable m) (h : G ≤ G') :
   G.chromatic_number ≤ G'.chromatic_number :=
-hc.chromatic_number_le_of_forall_imp (λ n, colorable.of_le_colorable h)
+hc.chromatic_number_le_of_forall_imp (λ n, colorable.mono_left h)
 
 lemma colorable.chromatic_number_mono_of_embedding {V' : Type*} {G' : simple_graph V'}
   {n : ℕ} (h : G'.colorable n) (f : G ↪g G') :

--- a/src/combinatorics/simple_graph/coloring.lean
+++ b/src/combinatorics/simple_graph/coloring.lean
@@ -288,7 +288,7 @@ begin
   exact G.is_empty_of_colorable_zero h',
 end
 
-lemma zero_lt_chromatic_number [nonempty V] {n : ℕ} (hc : G.colorable n) :
+lemma chromatic_number_pos [nonempty V] {n : ℕ} (hc : G.colorable n) :
   0 < G.chromatic_number :=
 begin
   apply le_cInf (colorable_set_nonempty_of_colorable hc),
@@ -300,7 +300,7 @@ begin
   exact nat.not_lt_zero _ hi,
 end
 
-lemma colorable_chromatic_number_of_zero_lt (h : 0 < G.chromatic_number) :
+lemma colorable_of_chromatic_number_pos (h : 0 < G.chromatic_number) :
   G.colorable G.chromatic_number :=
 begin
   obtain ⟨h, hn⟩ := nat.nonempty_of_pos_Inf h,
@@ -321,12 +321,12 @@ begin
   apply colorable_chromatic_number hc,
 end
 
-lemma colorable.chromatic_number_le_of_le (G' : simple_graph V)
+lemma colorable.chromatic_number_mono (G' : simple_graph V)
   {m : ℕ} (hc : G'.colorable m) (h : G ≤ G') :
   G.chromatic_number ≤ G'.chromatic_number :=
 hc.chromatic_number_le_of_forall_imp (λ n, colorable.of_le_colorable h)
 
-lemma colorable.chromatic_number_le_of_embedding {V' : Type*} {G' : simple_graph V'}
+lemma colorable.chromatic_number_mono_of_embedding {V' : Type*} {G' : simple_graph V'}
   {n : ℕ} (h : G'.colorable n) (f : G ↪g G') :
   G.chromatic_number ≤ G'.chromatic_number :=
 h.chromatic_number_le_of_forall_imp (λ _, colorable.of_embedding f)
@@ -358,7 +358,7 @@ begin
     coloring.mk (λ _, 0) (λ v w h, false.elim h),
   apply le_antisymm,
   { exact chromatic_number_le_card C, },
-  { exact zero_lt_chromatic_number C.to_colorable, },
+  { exact chromatic_number_pos C.to_colorable, },
 end
 
 @[simp] lemma chromatic_number_top [fintype V] :
@@ -382,7 +382,7 @@ begin
   apply nat.not_succ_le_self n,
   convert_to (⊤ : simple_graph {m | m < n + 1}).chromatic_number ≤ _,
   { simp, },
-  refine (colorable_chromatic_number_of_zero_lt hc).chromatic_number_le_of_embedding _,
+  refine (colorable_of_chromatic_number_pos hc).chromatic_number_mono_of_embedding _,
   apply embedding.complete_graph.of_embedding,
   exact (function.embedding.subtype _).trans (infinite.nat_embedding V),
 end

--- a/src/combinatorics/simple_graph/coloring.lean
+++ b/src/combinatorics/simple_graph/coloring.lean
@@ -184,7 +184,7 @@ G.recolor_of_embedding $ (function.embedding.nonempty_of_card_le hn).some
 
 variables {G}
 
-lemma colorable.of_le {n m : ℕ} (hc : G.colorable n) (h : n ≤ m) : G.colorable m :=
+lemma colorable.of_le {n m : ℕ} (h : n ≤ m) (hc : G.colorable n) : G.colorable m :=
 ⟨G.recolor_of_card_le (by simp [h]) hc.some⟩
 
 lemma coloring.to_colorable [fintype α] (C : G.coloring α) :
@@ -204,6 +204,10 @@ begin
   exact G.recolor_of_card_le hn hc.some,
 end
 
+lemma colorable.of_embedding {V' : Type*} {G' : simple_graph V'}
+  (f : G ↪g G') {n : ℕ} (h : G'.colorable n) : G.colorable n :=
+⟨(h.to_coloring (by simp)).comp f⟩
+
 lemma colorable_iff_exists_bdd_nat_coloring (n : ℕ) :
   G.colorable n ↔ ∃ (C : G.coloring ℕ), ∀ v, C v < n :=
 begin
@@ -219,7 +223,7 @@ begin
     refine ⟨coloring.mk _ _⟩,
     { exact λ v, ⟨C v, Cf v⟩, },
     { rintro v w hvw,
-      simp only [complete_graph_eq_top, top_adj, subtype.mk_eq_mk, ne.def],
+      simp only [subtype.mk_eq_mk, ne.def],
       exact C.valid hvw, } }
 end
 
@@ -296,11 +300,18 @@ begin
   exact nat.not_lt_zero _ hi,
 end
 
-lemma colorable_of_le_colorable {G' : simple_graph V} (h : G ≤ G') (n : ℕ)
+lemma colorable_chromatic_number_of_zero_lt (h : 0 < G.chromatic_number) :
+  G.colorable G.chromatic_number :=
+begin
+  obtain ⟨h, hn⟩ := nat.nonempty_of_pos_Inf h,
+  exact colorable_chromatic_number hn,
+end
+
+lemma colorable.of_le_colorable {G' : simple_graph V} (h : G ≤ G') {n : ℕ}
   (hc : G'.colorable n) : G.colorable n :=
 ⟨hc.some.comp (hom.map_spanning_subgraphs h)⟩
 
-lemma chromatic_number_le_of_forall_imp {G' : simple_graph V}
+lemma colorable.chromatic_number_le_of_forall_imp {V' : Type*} {G' : simple_graph V'}
   {m : ℕ} (hc : G'.colorable m)
   (h : ∀ n, G'.colorable n → G.colorable n) :
   G.chromatic_number ≤ G'.chromatic_number :=
@@ -310,13 +321,15 @@ begin
   apply colorable_chromatic_number hc,
 end
 
-lemma chromatic_number_le_of_le_colorable (G' : simple_graph V)
+lemma colorable.chromatic_number_le_of_le (G' : simple_graph V)
   {m : ℕ} (hc : G'.colorable m) (h : G ≤ G') :
   G.chromatic_number ≤ G'.chromatic_number :=
-begin
-  apply chromatic_number_le_of_forall_imp hc,
-  exact colorable_of_le_colorable h,
-end
+hc.chromatic_number_le_of_forall_imp (λ n, colorable.of_le_colorable h)
+
+lemma colorable.chromatic_number_le_of_embedding {V' : Type*} {G' : simple_graph V'}
+  {n : ℕ} (h : G'.colorable n) (f : G ↪g G') :
+  G.chromatic_number ≤ G'.chromatic_number :=
+h.chromatic_number_le_of_forall_imp (λ _, colorable.of_embedding f)
 
 lemma chromatic_number_eq_card_of_forall_surj [fintype α] (C : G.coloring α)
   (h : ∀ (C' : G.coloring α), function.surjective C') :
@@ -348,7 +361,7 @@ begin
   { exact zero_lt_chromatic_number C.to_colorable, },
 end
 
-lemma chromatic_number_complete_graph [fintype V] :
+@[simp] lemma chromatic_number_top [fintype V] :
   (⊤ : simple_graph V).chromatic_number = fintype.card V :=
 begin
   apply chromatic_number_eq_card_of_forall_surj (self_coloring _),
@@ -358,6 +371,20 @@ begin
   contrapose,
   intro h,
   exact C.valid h,
+end
+
+lemma chromatic_number_top_eq_zero_of_infinite (V : Type*) [infinite V] :
+  (⊤ : simple_graph V).chromatic_number = 0 :=
+begin
+  let n := (⊤ : simple_graph V).chromatic_number,
+  by_contra hc,
+  replace hc := pos_iff_ne_zero.mpr hc,
+  apply nat.not_succ_le_self n,
+  convert_to (⊤ : simple_graph {m | m < n + 1}).chromatic_number ≤ _,
+  { simp, },
+  refine (colorable_chromatic_number_of_zero_lt hc).chromatic_number_le_of_embedding _,
+  apply embedding.complete_graph.of_embedding,
+  exact (function.embedding.subtype _).trans (infinite.nat_embedding V),
 end
 
 /-- The bicoloring of a complete bipartite graph using whether a vertex

--- a/src/combinatorics/simple_graph/partition.lean
+++ b/src/combinatorics/simple_graph/partition.lean
@@ -127,7 +127,7 @@ begin
   { rintro ⟨P, hf, h⟩,
     haveI : fintype P.parts := hf.fintype,
     rw set.finite.card_to_finset at h,
-    apply P.to_colorable.of_le h, },
+    apply P.to_colorable.mono h, },
   { rintro ⟨C⟩,
     refine ⟨C.to_partition, C.color_classes_finite_of_fintype, le_trans _ (fintype.card_fin n).le⟩,
     generalize_proofs h,


### PR DESCRIPTION
Also add a lemma that the chromatic number of an infinite complete graph is zero (i.e., it needs infinitely many colors), as suggested by @arthurpaulino.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)

I snuck in some mild refactorings to permit some more dot notation, too.