### PR TITLE
[Merged by Bors] - chore(*): clean up comment strings in docstrings

### DIFF
--- a/src/algebra/category/Mon/filtered_colimits.lean
+++ b/src/algebra/category/Mon/filtered_colimits.lean
@@ -205,7 +205,7 @@ lemma cocone_naturality {j j' : J} (f : j ⟶ j') :
 monoid_hom.coe_inj ((types.colimit_cocone (F ⋙ forget Mon)).ι.naturality f)
 
 /-- The cocone over the proposed colimit monoid. -/
-@[to_additive "/-- The cocone over the proposed colimit additive monoid. -/"]
+@[to_additive "The cocone over the proposed colimit additive monoid."]
 def colimit_cocone : cocone F :=
 { X := colimit,
   ι := { app := cocone_morphism } }.

--- a/src/algebra/group/opposite.lean
+++ b/src/algebra/group/opposite.lean
@@ -220,16 +220,16 @@ open mul_opposite
 
 /-- Inversion on a group is a `mul_equiv` to the opposite group. When `G` is commutative, there is
 `mul_equiv.inv`. -/
-@[to_additive "/-- Negation on an additive group is an `add_equiv` to the opposite group. When `G`
-is commutative, there is `add_equiv.inv`. -/", simps { fully_applied := ff, simp_rhs := tt }]
+@[to_additive "Negation on an additive group is an `add_equiv` to the opposite group. When `G`
+is commutative, there is `add_equiv.inv`.", simps { fully_applied := ff, simp_rhs := tt }]
 def mul_equiv.inv' (G : Type*) [group G] : G ≃* Gᵐᵒᵖ :=
 { map_mul' := λ x y, unop_injective $ mul_inv_rev x y,
   .. (equiv.inv G).trans op_equiv }
 
 /-- A monoid homomorphism `f : M →* N` such that `f x` commutes with `f y` for all `x, y` defines
 a monoid homomorphism to `Nᵐᵒᵖ`. -/
-@[to_additive "/-- An additive monoid homomorphism `f : M →+ N` such that `f x` additively commutes
-with `f y` for all `x, y` defines an additive monoid homomorphism to `Sᵃᵒᵖ`. -/",
+@[to_additive "An additive monoid homomorphism `f : M →+ N` such that `f x` additively commutes
+with `f y` for all `x, y` defines an additive monoid homomorphism to `Sᵃᵒᵖ`.",
   simps {fully_applied := ff}]
 def monoid_hom.to_opposite {M N : Type*} [mul_one_class M] [mul_one_class N] (f : M →* N)
   (hf : ∀ x y, commute (f x) (f y)) : M →* Nᵐᵒᵖ :=
@@ -239,8 +239,8 @@ def monoid_hom.to_opposite {M N : Type*} [mul_one_class M] [mul_one_class N] (f 
 
 /-- A monoid homomorphism `f : M →* N` such that `f x` commutes with `f y` for all `x, y` defines
 a monoid homomorphism from `Mᵐᵒᵖ`. -/
-@[to_additive "/-- An additive monoid homomorphism `f : M →+ N` such that `f x` additively commutes
-with `f y` for all `x`, `y` defines an additive monoid homomorphism from `Mᵃᵒᵖ`. -/",
+@[to_additive "An additive monoid homomorphism `f : M →+ N` such that `f x` additively commutes
+with `f y` for all `x`, `y` defines an additive monoid homomorphism from `Mᵃᵒᵖ`.",
   simps {fully_applied := ff}]
 def monoid_hom.from_opposite {M N : Type*} [mul_one_class M] [mul_one_class N] (f : M →* N)
   (hf : ∀ x y, commute (f x) (f y)) : Mᵐᵒᵖ →* N :=
@@ -270,9 +270,9 @@ rfl
 
 /-- A monoid homomorphism `M →* N` can equivalently be viewed as a monoid homomorphism
 `Mᵐᵒᵖ →* Nᵐᵒᵖ`. This is the action of the (fully faithful) `ᵐᵒᵖ`-functor on morphisms. -/
-@[to_additive "/-- An additive monoid homomorphism `M →+ N` can equivalently be viewed as an
+@[to_additive "An additive monoid homomorphism `M →+ N` can equivalently be viewed as an
 additive monoid homomorphism `Mᵃᵒᵖ →+ Nᵃᵒᵖ`. This is the action of the (fully faithful)
-`ᵃᵒᵖ`-functor on morphisms. -/", simps]
+`ᵃᵒᵖ`-functor on morphisms.", simps]
 def monoid_hom.op {M N} [mul_one_class M] [mul_one_class N] :
   (M →* N) ≃ (Mᵐᵒᵖ →* Nᵐᵒᵖ) :=
 { to_fun    := λ f, { to_fun   := op ∘ f ∘ unop,

--- a/src/algebra/group/opposite.lean
+++ b/src/algebra/group/opposite.lean
@@ -323,7 +323,7 @@ def add_equiv.mul_op {α β} [has_add α] [has_add β] :
   (αᵐᵒᵖ ≃+ βᵐᵒᵖ) ≃ (α ≃+ β) := add_equiv.mul_op.symm
 
 /-- A iso `α ≃* β` can equivalently be viewed as an iso `αᵐᵒᵖ ≃* βᵐᵒᵖ`. -/
-@[to_additive "A iso `α ≃+ β` can equivalently be viewed as an iso `αᵃᵒᵖ ≃+ βᵃᵒᵖ`. -/", simps]
+@[to_additive "A iso `α ≃+ β` can equivalently be viewed as an iso `αᵃᵒᵖ ≃+ βᵃᵒᵖ`.", simps]
 def mul_equiv.op {α β} [has_mul α] [has_mul β] :
   (α ≃* β) ≃ (αᵐᵒᵖ ≃* βᵐᵒᵖ) :=
 { to_fun    := λ f, { to_fun   := op ∘ f ∘ unop,

--- a/src/algebra/opposites.lean
+++ b/src/algebra/opposites.lean
@@ -35,8 +35,8 @@ open function
 
 /-- Multiplicative opposite of a type. This type inherits all additive structures on `α` and
 reverses left and right in multiplication.-/
-@[to_additive "/-- Additive opposite of a type. This type inherits all multiplicative structures on
-`α` and reverses left and right in addition. -/"]
+@[to_additive "Additive opposite of a type. This type inherits all multiplicative structures on
+`α` and reverses left and right in addition."]
 def mul_opposite (α : Type u) : Type u := α
 
 postfix `ᵐᵒᵖ`:std.prec.max_plus := mul_opposite

--- a/src/group_theory/order_of_element.lean
+++ b/src/group_theory/order_of_element.lean
@@ -673,7 +673,7 @@ def subgroup_of_idempotent {G : Type*} [group G] [fintype G] (S : set G)
 
 /-- If `S` is a nonempty subset of a finite group `G`, then `S ^ |G|` is a subgroup -/
 @[to_additive smul_card_add_subgroup "If `S` is a nonempty subset of a finite add group `G`,
-  then `|G| • S` is a subgroup -/", simps]
+  then `|G| • S` is a subgroup", simps]
 def pow_card_subgroup {G : Type*} [group G] [fintype G] (S : set G) (hS : S.nonempty) :
   subgroup G :=
 have one_mem : (1 : G) ∈ (S ^ fintype.card G) := by

--- a/src/measure_theory/group/fundamental_domain.lean
+++ b/src/measure_theory/group/fundamental_domain.lean
@@ -58,8 +58,8 @@ variables {G α E : Type*} [group G] [mul_action G α] [measurable_space α]
 
 /-- If for each `x : α`, exactly one of `g • x`, `g : G`, belongs to a measurable set `s`, then `s`
 is a fundamental domain for the action of `G` on `α`. -/
-@[to_additive "/- If for each `x : α`, exactly one of `g +ᵥ x`, `g : G`, belongs to a measurable set
-`s`, then `s` is a fundamental domain for the additive action of `G` on `α`. -/"]
+@[to_additive "If for each `x : α`, exactly one of `g +ᵥ x`, `g : G`, belongs to a measurable set
+`s`, then `s` is a fundamental domain for the additive action of `G` on `α`."]
 lemma mk' (h_meas : measurable_set s) (h_exists : ∀ x : α, ∃! g : G, g • x ∈ s) :
   is_fundamental_domain G s μ :=
 { measurable_set := h_meas,

--- a/src/topology/algebra/monoid.lean
+++ b/src/topology/algebra/monoid.lean
@@ -182,9 +182,9 @@ variables {M₁ M₂} [mul_one_class M₁] [mul_one_class M₂] [has_continuous_
 /-- Construct a bundled monoid homomorphism `M₁ →* M₂` from a function `f` and a proof that it
 belongs to the closure of the range of the coercion from `M₁ →* M₂` (or another type of bundled
 homomorphisms that has a `monoid_hom_class` instance) to `M₁ → M₂`. -/
-@[to_additive "/-- Construct a bundled additive monoid homomorphism `M₁ →+ M₂` from a function `f`
+@[to_additive "Construct a bundled additive monoid homomorphism `M₁ →+ M₂` from a function `f`
 and a proof that it belongs to the closure of the range of the coercion from `M₁ →+ M₂` (or another
-type of bundled homomorphisms that has a `add_monoid_hom_class` instance) to `M₁ → M₂`. -/",
+type of bundled homomorphisms that has a `add_monoid_hom_class` instance) to `M₁ → M₂`.",
   simps { fully_applied := ff }]
 def monoid_hom_of_mem_closure_range_coe (f : M₁ → M₂)
   (hf : f ∈ closure (range (λ (f : F) (x : M₁), f x))) : M₁ →* M₂ :=


### PR DESCRIPTION
The syntax for these was wrong and showed up in doc-gen output unintentionally e.g.
https://leanprover-community.github.io/mathlib_docs/algebra/group/opposite.html#add_monoid_hom.op

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
