### PR TITLE
[Merged by Bors] - feat(algebra/lie/{nilpotent,of_associative}): a representation of an associative algebra gives a representation of a Lie algebra

### DIFF
--- a/src/algebra/algebra/basic.lean
+++ b/src/algebra/algebra/basic.lean
@@ -463,8 +463,6 @@ variables (R : Type u) (M : Type v) [comm_semiring R] [add_comm_monoid M] [modul
 instance : algebra R (module.End R M) :=
 algebra.of_module smul_mul_assoc (λ r f g, (smul_comm r f g).symm)
 
-instance : is_scalar_tower R (module.End R M) M := ⟨λ t f m, rfl⟩
-
 lemma algebra_map_End_eq_smul_id (a : R) :
   (algebra_map R (End R M)) a = a • linear_map.id := rfl
 

--- a/src/algebra/algebra/basic.lean
+++ b/src/algebra/algebra/basic.lean
@@ -463,6 +463,8 @@ variables (R : Type u) (M : Type v) [comm_semiring R] [add_comm_monoid M] [modul
 instance : algebra R (module.End R M) :=
 algebra.of_module smul_mul_assoc (λ r f g, (smul_comm r f g).symm)
 
+instance : is_scalar_tower R (module.End R M) M := ⟨λ t f m, rfl⟩
+
 lemma algebra_map_End_eq_smul_id (a : R) :
   (algebra_map R (End R M)) a = a • linear_map.id := rfl
 

--- a/src/algebra/lie/nilpotent.lean
+++ b/src/algebra/lie/nilpotent.lean
@@ -300,6 +300,10 @@ begin
   simp [← lie_submodule.coe_to_submodule_eq_iff, coe_lower_central_series_ideal_quot_eq, hk],
 end
 
+lemma lie_algebra.non_trivial_center_of_is_nilpotent [nontrivial L] [is_nilpotent R L] :
+  nontrivial $ center R L :=
+lie_module.nontrivial_max_triv_of_is_nilpotent R L L
+
 lemma lie_ideal.map_lower_central_series_le (k : ℕ) {f : L →ₗ⁅R⁆ L'} :
   lie_ideal.map f (lower_central_series R L L k) ≤ lower_central_series R L' L' k :=
 begin

--- a/src/algebra/lie/of_associative.lean
+++ b/src/algebra/lie/of_associative.lean
@@ -66,17 +66,30 @@ lemma of_associative_ring_bracket (x y : A) : ⁅x, y⁆ = x*y - y*x := rfl
 
 end lie_ring
 
-instance lie_ring_module.of_associative_module {M : Type w} [add_comm_group M] [module A M] :
-  lie_ring_module A M :=
+section associative_module
+
+variables {M : Type w} [add_comm_group M] [module A M]
+
+/-- We can regard a module over an associative ring `A` as a Lie ring module over `A` with Lie
+bracket equal to its ring commutator.
+
+Note that this cannot be a global instance because it would create a diamond when `M = A`,
+specifically we can build two mathematically-different `has_bracket A A`s:
+ 1. `@ring.has_bracket A _` which says `⁅a, b⁆ = a * b - b * a`
+ 2. `(@lie_ring_module.of_associative_module A _ A _ _).to_has_bracket` which says `⁅a, b⁆ = a • b`
+    (and thus `⁅a, b⁆ = a * b`) -/
+def lie_ring_module.of_associative_module : lie_ring_module A M :=
 { bracket     := (•),
   add_lie     := add_smul,
   lie_add     := smul_add,
   leibniz_lie :=
     by simp [lie_ring.of_associative_ring_bracket, sub_smul, mul_smul, sub_add_cancel], }
 
-lemma lie_ring_module.of_associative_module_apply {M : Type w} [add_comm_group M] [module A M]
-  (a : A) (m : M) : ⁅a, m⁆ = a • m :=
-rfl
+local attribute [instance] lie_ring_module.of_associative_module
+
+lemma lie_eq_smul (a : A) (m : M) : ⁅a, m⁆ = a • m := rfl
+
+end associative_module
 
 section lie_algebra
 
@@ -90,13 +103,28 @@ instance lie_algebra.of_associative_algebra : lie_algebra R A :=
     by rw [lie_ring.of_associative_ring_bracket, lie_ring.of_associative_ring_bracket,
            algebra.mul_smul_comm, algebra.smul_mul_assoc, smul_sub], }
 
+local attribute [instance] lie_ring_module.of_associative_module
+
+section associative_representation
+
+variables {M : Type w} [add_comm_group M] [module R M] [module A M] [is_scalar_tower R A M]
+
 /-- A representation of an associative algebra `A` is also a representation of `A`, regarded as a
-Lie algebra via the ring commutator. -/
-instance lie_module.of_associative_module
-  {M : Type w} [add_comm_group M] [module R M] [module A M] [is_scalar_tower R A M] :
-  lie_module R A M :=
+Lie algebra via the ring commutator.
+
+See the comment at `lie_ring_module.of_associative_module` for why the possibility `M = A` means
+this cannot be a global instance. -/
+def lie_module.of_associative_module : lie_module R A M :=
 { smul_lie := smul_assoc,
   lie_smul := smul_algebra_smul_comm }
+
+instance module.End.lie_ring_module : lie_ring_module (module.End R M) M :=
+lie_ring_module.of_associative_module
+
+instance module.End.lie_module : lie_module R (module.End R M) M :=
+lie_module.of_associative_module
+
+end associative_representation
 
 namespace alg_hom
 
@@ -157,7 +185,7 @@ def lie_algebra.ad : L →ₗ⁅R⁆ module.End R L := lie_module.to_endomorphis
 
 @[simp] lemma lie_module.to_endomorphism_module_End :
   lie_module.to_endomorphism R (module.End R M) M = lie_hom.id :=
-by { ext g m, simp [lie_ring_module.of_associative_module_apply], }
+by { ext g m, simp [lie_eq_smul], }
 
 open lie_algebra
 

--- a/src/algebra/lie/of_associative.lean
+++ b/src/algebra/lie/of_associative.lean
@@ -77,7 +77,10 @@ Note that this cannot be a global instance because it would create a diamond whe
 specifically we can build two mathematically-different `has_bracket A A`s:
  1. `@ring.has_bracket A _` which says `⁅a, b⁆ = a * b - b * a`
  2. `(@lie_ring_module.of_associative_module A _ A _ _).to_has_bracket` which says `⁅a, b⁆ = a • b`
-    (and thus `⁅a, b⁆ = a * b`) -/
+    (and thus `⁅a, b⁆ = a * b`)
+
+See note [reducible non-instances] -/
+@[reducible]
 def lie_ring_module.of_associative_module : lie_ring_module A M :=
 { bracket     := (•),
   add_lie     := add_smul,

--- a/src/algebra/lie/of_associative.lean
+++ b/src/algebra/lie/of_associative.lean
@@ -66,6 +66,18 @@ lemma of_associative_ring_bracket (x y : A) : ⁅x, y⁆ = x*y - y*x := rfl
 
 end lie_ring
 
+instance lie_ring_module.of_associative_module {M : Type w} [add_comm_group M] [module A M] :
+  lie_ring_module A M :=
+{ bracket     := (•),
+  add_lie     := add_smul,
+  lie_add     := smul_add,
+  leibniz_lie :=
+    by simp [lie_ring.of_associative_ring_bracket, sub_smul, mul_smul, sub_add_cancel], }
+
+lemma lie_ring_module.of_associative_module_apply {M : Type w} [add_comm_group M] [module A M]
+  (a : A) (m : M) : ⁅a, m⁆ = a • m :=
+rfl
+
 section lie_algebra
 
 variables {R : Type u} [comm_ring R] [algebra R A]
@@ -77,6 +89,14 @@ instance lie_algebra.of_associative_algebra : lie_algebra R A :=
 { lie_smul := λ t x y,
     by rw [lie_ring.of_associative_ring_bracket, lie_ring.of_associative_ring_bracket,
            algebra.mul_smul_comm, algebra.smul_mul_assoc, smul_sub], }
+
+/-- A representation of an associative algebra `A` is also a representation of `A`, regarded as a
+Lie algebra via the ring commutator. -/
+instance lie_module.of_associative_module
+  {M : Type w} [add_comm_group M] [module R M] [module A M] [is_scalar_tower R A M] :
+  lie_module R A M :=
+{ smul_lie := smul_assoc,
+  lie_smul := smul_algebra_smul_comm }
 
 namespace alg_hom
 
@@ -134,6 +154,10 @@ See also `lie_module.to_module_hom`. -/
 def lie_algebra.ad : L →ₗ⁅R⁆ module.End R L := lie_module.to_endomorphism R L L
 
 @[simp] lemma lie_algebra.ad_apply (x y : L) : lie_algebra.ad R L x y = ⁅x, y⁆ := rfl
+
+@[simp] lemma lie_module.to_endomorphism_module_End :
+  lie_module.to_endomorphism R (module.End R M) M = lie_hom.id :=
+by { ext g m, simp [lie_ring_module.of_associative_module_apply], }
 
 open lie_algebra
 

--- a/src/algebra/module/linear_map.lean
+++ b/src/algebra/module/linear_map.lean
@@ -794,6 +794,10 @@ instance apply_smul_comm_class : smul_comm_class R (module.End R M) M :=
 instance apply_smul_comm_class' : smul_comm_class (module.End R M) R M :=
 { smul_comm := linear_map.map_smul }
 
+instance _root_.module.End.is_scalar_tower
+  {R M : Type*} [comm_semiring R] [add_comm_monoid M] [module R M] :
+is_scalar_tower R (module.End R M) M := ⟨λ t f m, rfl⟩
+
 end endomorphisms
 
 end linear_map

--- a/src/algebra/module/linear_map.lean
+++ b/src/algebra/module/linear_map.lean
@@ -755,7 +755,7 @@ instance _root_.module.End.ring : ring (module.End R N₁) :=
 section
 variables [monoid S] [distrib_mul_action S M] [smul_comm_class R S M]
 
-instance _root_.module.End.is_scalar_tower' :
+instance _root_.module.End.is_scalar_tower :
   is_scalar_tower S (module.End R M) (module.End R M) := ⟨smul_comp⟩
 
 instance _root_.module.End.smul_comm_class [has_scalar S R] [is_scalar_tower S R M] :
@@ -794,9 +794,9 @@ instance apply_smul_comm_class : smul_comm_class R (module.End R M) M :=
 instance apply_smul_comm_class' : smul_comm_class (module.End R M) R M :=
 { smul_comm := linear_map.map_smul }
 
-instance _root_.module.End.is_scalar_tower
-  {R M : Type*} [comm_semiring R] [add_comm_monoid M] [module R M] :
-is_scalar_tower R (module.End R M) M := ⟨λ t f m, rfl⟩
+instance apply_is_scalar_tower {R M : Type*} [comm_semiring R] [add_comm_monoid M] [module R M] :
+  is_scalar_tower R (module.End R M) M :=
+⟨λ t f m, rfl⟩
 
 end endomorphisms
 

--- a/src/algebra/module/linear_map.lean
+++ b/src/algebra/module/linear_map.lean
@@ -755,7 +755,7 @@ instance _root_.module.End.ring : ring (module.End R N₁) :=
 section
 variables [monoid S] [distrib_mul_action S M] [smul_comm_class R S M]
 
-instance _root_.module.End.is_scalar_tower :
+instance _root_.module.End.is_scalar_tower' :
   is_scalar_tower S (module.End R M) (module.End R M) := ⟨smul_comp⟩
 
 instance _root_.module.End.smul_comm_class [has_scalar S R] [is_scalar_tower S R M] :


### PR DESCRIPTION
The lemma `lie_algebra.non_trivial_center_of_is_nilpotent` is unrelated.

---

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
