### PR TITLE
[Merged by Bors] - feat(topology/uniform_space/uniform_convergence): Product of `tendsto_uniformly`

### DIFF
--- a/src/topology/uniform_space/uniform_convergence.lean
+++ b/src/topology/uniform_space/uniform_convergence.lean
@@ -139,13 +139,12 @@ begin
     λ i hi a ha, hvw (show (_, _) ∈ v ×ˢ w, from ⟨hi.1 a.1 ha.1, hi.2 a.2 ha.2⟩)⟩,
 end
 
-lemma tendsto_uniformly.prod' {ι' α' β' : Type*} [uniform_space β'] {F' : ι' → α' → β'}
+lemma tendsto_uniformly.prod_map {ι' α' β' : Type*} [uniform_space β'] {F' : ι' → α' → β'}
   {f' : α' → β'} {p' : filter ι'} (h : tendsto_uniformly F f p) (h' : tendsto_uniformly F' f' p') :
-  tendsto_uniformly (λ (i : ι × ι') (a : α × α'), (F i.1 a.1, F' i.2 a.2))
-    (λ a, (f a.1, f' a.2)) (p.prod p') :=
+  tendsto_uniformly (λ (i : ι × ι'), prod.map (F i.1) (F' i.2)) (prod.map f f') (p.prod p') :=
 begin
   rw [←tendsto_uniformly_on_univ, ←univ_prod_univ] at *,
-  exact h.prod' h',
+  exact h.prod_map h',
 end
 
 lemma tendsto_uniformly_on.prod {ι' β' : Type*} [uniform_space β'] {F' : ι' → α → β'} {f' : α → β'}

--- a/src/topology/uniform_space/uniform_convergence.lean
+++ b/src/topology/uniform_space/uniform_convergence.lean
@@ -151,7 +151,7 @@ end
 lemma tendsto_uniformly_on.prod {ι' β' : Type*} [uniform_space β'] {F' : ι' → α → β'} {f' : α → β'}
   {p' : filter ι'} (h : tendsto_uniformly_on F f p s) (h' : tendsto_uniformly_on F' f' p' s) :
   tendsto_uniformly_on (λ (i : ι × ι') a, (F i.1 a, F' i.2 a)) (λ a, (f a, f' a)) (p.prod p') s :=
-(congr_arg _ s.inter_self).mp ((h.prod' h').comp (λ a, (a, a)))
+(congr_arg _ s.inter_self).mp ((h.prod_map h').comp (λ a, (a, a)))
 
 lemma tendsto_uniformly.prod {ι' β' : Type*} [uniform_space β'] {F' : ι' → α → β'} {f' : α → β'}
   {p' : filter ι'} (h : tendsto_uniformly F f p) (h' : tendsto_uniformly F' f' p') :

--- a/src/topology/uniform_space/uniform_convergence.lean
+++ b/src/topology/uniform_space/uniform_convergence.lean
@@ -108,6 +108,28 @@ protected lemma tendsto_uniformly.tendsto_uniformly_on
   (h : tendsto_uniformly F f p) : tendsto_uniformly_on F f p s :=
 (tendsto_uniformly_on_univ.2 h).mono (subset_univ s)
 
+lemma tendsto_uniformly_on.prod {ι₁ ι₂ : Type*} {F₁ : ι₁ → α → β} {F₂ : ι₂ → α → β}
+  {f₁ : α → β} {f₂ : α → β} {p₁ : filter ι₁} {p₂ : filter ι₂}
+  (h₁ : tendsto_uniformly_on F₁ f₁ p₁ s) (h₂ : tendsto_uniformly_on F₂ f₂ p₂ s) :
+  tendsto_uniformly_on (λ (i : ι₁ × ι₂) a, (F₁ i.1 a, F₂ i.2 a))
+    (λ a, (f₁ a, f₂ a)) (p₁.prod p₂) s :=
+begin
+  intros u hu,
+  rw [uniformity_prod_eq_prod, mem_map, mem_prod_iff] at hu,
+  obtain ⟨v, hv, w, hw, h⟩ := hu,
+  exact mem_prod_iff.mpr ⟨_, h₁ v hv, _, h₂ w hw, λ i hi a ha,
+    h (show ((f₁ a, F₁ i.1 a), (f₂ a, F₂ i.2 a)) ∈ v ×ˢ w, from ⟨hi.1 a ha, hi.2 a ha⟩)⟩,
+end
+
+lemma tendsto_uniformly.prod {ι₁ ι₂ : Type*} {F₁ : ι₁ → α → β} {F₂ : ι₂ → α → β}
+  {f₁ : α → β} {f₂ : α → β} {p₁ : filter ι₁} {p₂ : filter ι₂}
+  (h₁ : tendsto_uniformly F₁ f₁ p₁) (h₂ : tendsto_uniformly F₂ f₂ p₂) :
+  tendsto_uniformly (λ (i : ι₁ × ι₂) a, (F₁ i.1 a, F₂ i.2 a)) (λ a, (f₁ a, f₂ a)) (p₁.prod p₂) :=
+begin
+  rw ← tendsto_uniformly_on_univ at *,
+  exact tendsto_uniformly_on.prod h₁ h₂,
+end
+
 /-- Composing on the right by a function preserves uniform convergence on a set -/
 lemma tendsto_uniformly_on.comp (h : tendsto_uniformly_on F f p s) (g : γ → α) :
   tendsto_uniformly_on (λ n, F n ∘ g) (f ∘ g) p (g ⁻¹' s) :=

--- a/src/topology/uniform_space/uniform_convergence.lean
+++ b/src/topology/uniform_space/uniform_convergence.lean
@@ -156,7 +156,7 @@ lemma tendsto_uniformly_on.prod {ι' β' : Type*} [uniform_space β'] {F' : ι' 
 lemma tendsto_uniformly.prod {ι' β' : Type*} [uniform_space β'] {F' : ι' → α → β'} {f' : α → β'}
   {p' : filter ι'} (h : tendsto_uniformly F f p) (h' : tendsto_uniformly F' f' p') :
   tendsto_uniformly (λ (i : ι × ι') a, (F i.1 a, F' i.2 a)) (λ a, (f a, f' a)) (p.prod p') :=
-(h.prod' h').comp (λ a, (a, a))
+(h.prod_map h').comp (λ a, (a, a))
 
 /-- Uniform convergence to a constant function is equivalent to convergence in `p ×ᶠ ⊤`. -/
 lemma tendsto_prod_top_iff {c : β} : tendsto ↿F (p ×ᶠ ⊤) (𝓝 c) ↔ tendsto_uniformly F (λ _, c) p :=

--- a/src/topology/uniform_space/uniform_convergence.lean
+++ b/src/topology/uniform_space/uniform_convergence.lean
@@ -153,8 +153,8 @@ lemma tendsto_uniformly_on.prod {ι' β' : Type*} [uniform_space β'] {F' : ι' 
   tendsto_uniformly_on (λ (i : ι × ι') a, (F i.1 a, F' i.2 a)) (λ a, (f a, f' a)) (p.prod p') s :=
 (congr_arg _ s.inter_self).mp ((h.prod' h').comp (λ a, (a, a)))
 
-lemma tendsto_uniformly.prod {ι' : Type*} {F' : ι' → α → β} {f' : α → β} {p' : filter ι'}
-  (h : tendsto_uniformly F f p) (h' : tendsto_uniformly F' f' p') :
+lemma tendsto_uniformly.prod {ι' β' : Type*} [uniform_space β'] {F' : ι' → α → β'} {f' : α → β'}
+  {p' : filter ι'} (h : tendsto_uniformly F f p) (h' : tendsto_uniformly F' f' p') :
   tendsto_uniformly (λ (i : ι × ι') a, (F i.1 a, F' i.2 a)) (λ a, (f a, f' a)) (p.prod p') :=
 (h.prod' h').comp (λ a, (a, a))
 

--- a/src/topology/uniform_space/uniform_convergence.lean
+++ b/src/topology/uniform_space/uniform_convergence.lean
@@ -108,28 +108,6 @@ protected lemma tendsto_uniformly.tendsto_uniformly_on
   (h : tendsto_uniformly F f p) : tendsto_uniformly_on F f p s :=
 (tendsto_uniformly_on_univ.2 h).mono (subset_univ s)
 
-lemma tendsto_uniformly_on.prod {ι₁ ι₂ : Type*} {F₁ : ι₁ → α → β} {F₂ : ι₂ → α → β}
-  {f₁ : α → β} {f₂ : α → β} {p₁ : filter ι₁} {p₂ : filter ι₂}
-  (h₁ : tendsto_uniformly_on F₁ f₁ p₁ s) (h₂ : tendsto_uniformly_on F₂ f₂ p₂ s) :
-  tendsto_uniformly_on (λ (i : ι₁ × ι₂) a, (F₁ i.1 a, F₂ i.2 a))
-    (λ a, (f₁ a, f₂ a)) (p₁.prod p₂) s :=
-begin
-  intros u hu,
-  rw [uniformity_prod_eq_prod, mem_map, mem_prod_iff] at hu,
-  obtain ⟨v, hv, w, hw, h⟩ := hu,
-  exact mem_prod_iff.mpr ⟨_, h₁ v hv, _, h₂ w hw, λ i hi a ha,
-    h (show ((f₁ a, F₁ i.1 a), (f₂ a, F₂ i.2 a)) ∈ v ×ˢ w, from ⟨hi.1 a ha, hi.2 a ha⟩)⟩,
-end
-
-lemma tendsto_uniformly.prod {ι₁ ι₂ : Type*} {F₁ : ι₁ → α → β} {F₂ : ι₂ → α → β}
-  {f₁ : α → β} {f₂ : α → β} {p₁ : filter ι₁} {p₂ : filter ι₂}
-  (h₁ : tendsto_uniformly F₁ f₁ p₁) (h₂ : tendsto_uniformly F₂ f₂ p₂) :
-  tendsto_uniformly (λ (i : ι₁ × ι₂) a, (F₁ i.1 a, F₂ i.2 a)) (λ a, (f₁ a, f₂ a)) (p₁.prod p₂) :=
-begin
-  rw ← tendsto_uniformly_on_univ at *,
-  exact tendsto_uniformly_on.prod h₁ h₂,
-end
-
 /-- Composing on the right by a function preserves uniform convergence on a set -/
 lemma tendsto_uniformly_on.comp (h : tendsto_uniformly_on F f p s) (g : γ → α) :
   tendsto_uniformly_on (λ n, F n ∘ g) (f ∘ g) p (g ⁻¹' s) :=
@@ -147,6 +125,38 @@ begin
   apply (h u hu).mono (λ n hn, _),
   exact λ x, hn _
 end
+
+lemma tendsto_uniformly_on.prod' {ι' α' β' : Type*} [uniform_space β']
+  {F' : ι' → α' → β'} {f' : α' → β'} {p' : filter ι'} {s' : set α'}
+  (h : tendsto_uniformly_on F f p s) (h' : tendsto_uniformly_on F' f' p' s') :
+  tendsto_uniformly_on (λ (i : ι × ι') (a : α × α'), (F i.1 a.1, F' i.2 a.2))
+    (λ a, (f a.1, f' a.2)) (p.prod p') (s ×ˢ s') :=
+begin
+  intros u hu,
+  rw [uniformity_prod_eq_prod, mem_map, mem_prod_iff] at hu,
+  obtain ⟨v, hv, w, hw, hvw⟩ := hu,
+  exact mem_prod_iff.mpr ⟨_, h v hv, _, h' w hw,
+    λ i hi a ha, hvw (show (_, _) ∈ v ×ˢ w, from ⟨hi.1 a.1 ha.1, hi.2 a.2 ha.2⟩)⟩,
+end
+
+lemma tendsto_uniformly.prod' {ι' α' β' : Type*} [uniform_space β'] {F' : ι' → α' → β'}
+  {f' : α' → β'} {p' : filter ι'} (h : tendsto_uniformly F f p) (h' : tendsto_uniformly F' f' p') :
+  tendsto_uniformly (λ (i : ι × ι') (a : α × α'), (F i.1 a.1, F' i.2 a.2))
+    (λ a, (f a.1, f' a.2)) (p.prod p') :=
+begin
+  rw [←tendsto_uniformly_on_univ, ←univ_prod_univ] at *,
+  exact h.prod' h',
+end
+
+lemma tendsto_uniformly_on.prod {ι' β' : Type*} [uniform_space β'] {F' : ι' → α → β'} {f' : α → β'}
+  {p' : filter ι'} (h : tendsto_uniformly_on F f p s) (h' : tendsto_uniformly_on F' f' p' s) :
+  tendsto_uniformly_on (λ (i : ι × ι') a, (F i.1 a, F' i.2 a)) (λ a, (f a, f' a)) (p.prod p') s :=
+(congr_arg _ s.inter_self).mp ((h.prod' h').comp (λ a, (a, a)))
+
+lemma tendsto_uniformly.prod {ι' : Type*} {F' : ι' → α → β} {f' : α → β} {p' : filter ι'}
+  (h : tendsto_uniformly F f p) (h' : tendsto_uniformly F' f' p') :
+  tendsto_uniformly (λ (i : ι × ι') a, (F i.1 a, F' i.2 a)) (λ a, (f a, f' a)) (p.prod p') :=
+(h.prod' h').comp (λ a, (a, a))
 
 /-- Uniform convergence to a constant function is equivalent to convergence in `p ×ᶠ ⊤`. -/
 lemma tendsto_prod_top_iff {c : β} : tendsto ↿F (p ×ᶠ ⊤) (𝓝 c) ↔ tendsto_uniformly F (λ _, c) p :=

--- a/src/topology/uniform_space/uniform_convergence.lean
+++ b/src/topology/uniform_space/uniform_convergence.lean
@@ -126,11 +126,11 @@ begin
   exact λ x, hn _
 end
 
-lemma tendsto_uniformly_on.prod' {ι' α' β' : Type*} [uniform_space β']
+lemma tendsto_uniformly_on.prod_map {ι' α' β' : Type*} [uniform_space β']
   {F' : ι' → α' → β'} {f' : α' → β'} {p' : filter ι'} {s' : set α'}
   (h : tendsto_uniformly_on F f p s) (h' : tendsto_uniformly_on F' f' p' s') :
-  tendsto_uniformly_on (λ (i : ι × ι') (a : α × α'), (F i.1 a.1, F' i.2 a.2))
-    (λ a, (f a.1, f' a.2)) (p.prod p') (s ×ˢ s') :=
+  tendsto_uniformly_on (λ (i : ι × ι'), prod.map (F i.1) (F' i.2))
+    (prod.map f f') (p.prod p') (s ×ˢ s') :=
 begin
   intros u hu,
   rw [uniformity_prod_eq_prod, mem_map, mem_prod_iff] at hu,


### PR DESCRIPTION
This PR adds lemmas `tendsto_uniformly_on.prod` and `tendsto_uniformly.prod`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
