### PR TITLE
[Merged by Bors] - feat(group_theory/nilpotent): add nilpotency_class inequalities

### DIFF
--- a/src/group_theory/nilpotent.lean
+++ b/src/group_theory/nilpotent.lean
@@ -520,8 +520,8 @@ end
 end classical
 
 /-- The range of a surejctive homomorphism from a nilpotent group is nilpotent -/
-lemma nilpotent_of_surjective
-  {G' : Type*} [group G'] {f : G →* G'} (hf : function.surjective f) [h : is_nilpotent G] :
+lemma nilpotent_of_surjective {G' : Type*} [group G'] [h : is_nilpotent G]
+  (f : G →* G') (hf : function.surjective f) :
   is_nilpotent G' :=
 begin
   unfreezingI { rcases h with ⟨n, hn⟩ },
@@ -536,7 +536,7 @@ end
 /-- The nilpotency class of the range of a surejctive homomorphism from a
 nilpotent group is less or equal the nilpotency class of the domain -/
 lemma nilpotency_class_le_of_surjective
-  {G' : Type*} [group G'] {f : G →* G'} (hf : function.surjective f) [h : is_nilpotent G] :
+  {G' : Type*} [group G'] (f : G →* G') (hf : function.surjective f) [h : is_nilpotent G] :
   @group.nilpotency_class G' _ (nilpotent_of_surjective hf) ≤
     group.nilpotency_class G :=
 begin

--- a/src/group_theory/nilpotent.lean
+++ b/src/group_theory/nilpotent.lean
@@ -353,6 +353,11 @@ nat.find (is_nilpotent.nilpotent G)
 
 variable {G}
 
+@[simp]
+lemma upper_central_series_nilpotency_class :
+  upper_central_series G (group.nilpotency_class G) = ⊤ :=
+nat.find_spec (is_nilpotent.nilpotent G)
+
 /-- The nilpotency class of a nilpotent `G` is equal to the smallest `n` for which an ascending
 central series reaches `G` in its `n`'th term. -/
 lemma least_ascending_central_series_length_eq_nilpotency_class :
@@ -398,6 +403,14 @@ begin
     exact (descending_central_series_ge_lower H hH n), },
   { rintros n h,
     refine ⟨lower_central_series G, ⟨lower_central_series_is_descending_central_series, h⟩⟩ },
+end
+
+@[simp]
+lemma lower_central_series_nilpotency_class [is_nilpotent G] :
+  lower_central_series G (group.nilpotency_class G) = ⊥ :=
+begin
+  rw ← lower_central_series_length_eq_nilpotency_class,
+  exact (nat.find_spec (nilpotent_iff_lower_central_series.mp _))
 end
 
 end classical
@@ -496,14 +509,12 @@ lemma nilpotency_class_le_of_ker_le_center {H : Type*} [group H] {f : G →* H}
   @group.nilpotency_class G _ (is_nilpotent_of_ker_le_center hf1 hH) ≤
     group.nilpotency_class H + 1 :=
 begin
-  repeat { rw ← lower_central_series_length_eq_nilpotency_class },
+  nth_rewrite 0 ← lower_central_series_length_eq_nilpotency_class,
   apply nat.find_min',
-  have hn := nat.find_spec (nilpotent_iff_lower_central_series.mp hH),
   refine lower_central_series_succ_eq_bot (le_trans ((map_eq_bot_iff _).mp _) hf1),
   apply eq_bot_iff.mpr,
   apply (le_trans (lower_central_series.map f _)),
-  rw hn,
-  exact (le_refl _),
+  simp only [lower_central_series_nilpotency_class, le_bot_iff],
 end
 
 end classical

--- a/src/group_theory/nilpotent.lean
+++ b/src/group_theory/nilpotent.lean
@@ -509,7 +509,7 @@ lemma nilpotency_class_le_of_ker_le_center {H : Type*} [group H] {f : G →* H}
   @group.nilpotency_class G _ (is_nilpotent_of_ker_le_center hf1 hH) ≤
     group.nilpotency_class H + 1 :=
 begin
-  nth_rewrite 0 ← lower_central_series_length_eq_nilpotency_class,
+  rw ← lower_central_series_length_eq_nilpotency_class,
   apply nat.find_min',
   refine lower_central_series_succ_eq_bot (le_trans ((map_eq_bot_iff _).mp _) hf1),
   apply eq_bot_iff.mpr,

--- a/src/group_theory/nilpotent.lean
+++ b/src/group_theory/nilpotent.lean
@@ -537,7 +537,7 @@ end
 nilpotent group is less or equal the nilpotency class of the domain -/
 lemma nilpotency_class_le_of_surjective
   {G' : Type*} [group G'] (f : G →* G') (hf : function.surjective f) [h : is_nilpotent G] :
-  @group.nilpotency_class G' _ (nilpotent_of_surjective hf) ≤
+  @group.nilpotency_class G' _ (nilpotent_of_surjective _ hf) ≤
     group.nilpotency_class G :=
 begin
   apply nat.find_mono,
@@ -552,11 +552,11 @@ end
 /-- A quotient of a nilpotent group is nilpotent -/
 instance nilpotent_quotient_of_nilpotent (H : subgroup G) [H.normal] [h : is_nilpotent G] :
   is_nilpotent (G ⧸ H) :=
- nilpotent_of_surjective (show function.surjective (quotient_group.mk' H), by tidy)
+ nilpotent_of_surjective _ (show function.surjective (quotient_group.mk' H), by tidy)
 
 /-- The nilpotency class of a quotient of `G` is less or equal the nilpotency class of `G` -/
 lemma nilpotency_class_quotient_le (H : subgroup G) [H.normal] [h : is_nilpotent G] :
-  group.nilpotency_class (G ⧸ H) ≤ group.nilpotency_class G := nilpotency_class_le_of_surjective _
+  group.nilpotency_class (G ⧸ H) ≤ group.nilpotency_class G := nilpotency_class_le_of_surjective _ _
 
 lemma derived_le_lower_central (n : ℕ) : derived_series G n ≤ lower_central_series G n :=
 by { induction n with i ih, { simp }, { apply general_commutator_mono ih, simp } }

--- a/src/group_theory/nilpotent.lean
+++ b/src/group_theory/nilpotent.lean
@@ -406,7 +406,7 @@ begin
 end
 
 @[simp]
-lemma lower_central_series_nilpotency_class [is_nilpotent G] :
+lemma lower_central_series_nilpotency_class :
   lower_central_series G (group.nilpotency_class G) = ⊥ :=
 begin
   rw ← lower_central_series_length_eq_nilpotency_class,

--- a/src/group_theory/nilpotent.lean
+++ b/src/group_theory/nilpotent.lean
@@ -490,7 +490,7 @@ end
 
 /-- The preimage of a nilpotent group is nilpotent if the kernel of the homomorphism is contained
 in the center -/
-lemma is_nilpotent_of_ker_le_center {H : Type*} [group H] {f : G →* H}
+lemma is_nilpotent_of_ker_le_center {H : Type*} [group H] (f : G →* H)
   (hf1 : f.ker ≤ center G) (hH : is_nilpotent H) : is_nilpotent G :=
 begin
   rw nilpotent_iff_lower_central_series at *,
@@ -504,9 +504,9 @@ section classical
 
 open_locale classical
 
-lemma nilpotency_class_le_of_ker_le_center {H : Type*} [group H] {f : G →* H}
+lemma nilpotency_class_le_of_ker_le_center {H : Type*} [group H] (f : G →* H)
   (hf1 : f.ker ≤ center G) (hH : is_nilpotent H) :
-  @group.nilpotency_class G _ (is_nilpotent_of_ker_le_center hf1 hH) ≤
+  @group.nilpotency_class G _ (is_nilpotent_of_ker_le_center f hf1 hH) ≤
     group.nilpotency_class H + 1 :=
 begin
   rw ← lower_central_series_length_eq_nilpotency_class,

--- a/src/group_theory/nilpotent.lean
+++ b/src/group_theory/nilpotent.lean
@@ -516,7 +516,7 @@ begin
   unfreezingI { rcases h with ⟨n, hn⟩ },
   use n,
   apply eq_top_iff.mpr,
-  calc ⊤ = f.range : symm (monoid_hom.range_eq_top_of_surjective hf)
+  calc ⊤ = f.range : symm (f.range_top_of_surjective hf)
     ... = subgroup.map f ⊤ : monoid_hom.range_eq_map _
     ... = subgroup.map f (upper_central_series G n) : by rw hn
     ... ≤ upper_central_series G' n : upper_central_series.map hf n,
@@ -532,7 +532,7 @@ begin
   apply nat.find_mono,
   intros n hn,
   apply eq_top_iff.mpr,
-  calc ⊤ = f.range : symm (monoid_hom.range_eq_top_of_surjective hf)
+  calc ⊤ = f.range : symm (f.range_top_of_surjective hf)
     ... = subgroup.map f ⊤ : monoid_hom.range_eq_map _
     ... = subgroup.map f (upper_central_series G n) : by rw hn
     ... ≤ upper_central_series G' n : upper_central_series.map hf n,

--- a/src/group_theory/nilpotent.lean
+++ b/src/group_theory/nilpotent.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2021 Kevin Buzzard. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Kevin Buzzard, Ines Wright
+Authors: Kevin Buzzard, Ines Wright, Joachim Breitner
 -/
 
 import group_theory.general_commutator
@@ -53,6 +53,8 @@ subgroup `G` of `G`, and `⊥` denotes the trivial subgroup `{1}`.
   definitions, see `least_ascending_central_series_length_eq_nilpotency_class`,
   `least_descending_central_series_length_eq_nilpotency_class` and
   `lower_central_series_length_eq_nilpotency_class`.
+* If `G` is nilpotent, then so are its subgroups, images, quotients and preimages.
+  Corresponding lemmas about the `nilpotency_class` are provided.
 * `is_nilpotent.to_is_solvable`: If `G` is nilpotent, it is solvable.
 
 
@@ -506,7 +508,7 @@ end
 
 end classical
 
-
+/-- The range of a surejctive homomorphism from a nilpotent group is nilpotent -/
 lemma nilpotent_of_surjective
   {G' : Type*} [group G'] {f : G →* G'} (hf : function.surjective f) [h : is_nilpotent G] :
   is_nilpotent G' :=
@@ -520,6 +522,8 @@ begin
     ... ≤ upper_central_series G' n : upper_central_series.map hf n,
 end
 
+/-- The nilpotency class of the range of a surejctive homomorphism from a
+nilpotent group is less or equal the nilpotency class of the domain -/
 lemma nilpotency_class_le_of_surjective
   {G' : Type*} [group G'] {f : G →* G'} (hf : function.surjective f) [h : is_nilpotent G] :
   @group.nilpotency_class G' _ (nilpotent_of_surjective hf) ≤
@@ -534,10 +538,12 @@ begin
     ... ≤ upper_central_series G' n : upper_central_series.map hf n,
 end
 
+/-- A quotient of a nilpotent group is nilpotent -/
 instance nilpotent_quotient_of_nilpotent (H : subgroup G) [H.normal] [h : is_nilpotent G] :
   is_nilpotent (G ⧸ H) :=
  nilpotent_of_surjective (show function.surjective (quotient_group.mk' H), by tidy)
 
+/-- The nilpotency class of a quotient of `G` is less or equal the nilpotency class of `G` -/
 lemma nilpotency_class_quotient_le (H : subgroup G) [H.normal] [h : is_nilpotent G] :
   group.nilpotency_class (G ⧸ H) ≤ group.nilpotency_class G := nilpotency_class_le_of_surjective _
 

--- a/src/group_theory/subgroup/basic.lean
+++ b/src/group_theory/subgroup/basic.lean
@@ -1476,10 +1476,6 @@ iff.rfl
 @[to_additive] lemma range_eq_map (f : G →* N) : f.range = (⊤ : subgroup G).map f :=
 by ext; simp
 
-@[to_additive]
-lemma range_eq_top_of_surjective {f : G →* N} (hf : function.surjective f) :
-  f.range = ⊤ := by { ext, simp, apply hf }
-
 /-- The canonical surjective group homomorphism `G →* f(G)` induced by a group
 homomorphism `G →* N`. -/
 @[to_additive "The canonical surjective `add_group` homomorphism `G →+ f(G)` induced by a group

--- a/src/group_theory/subgroup/basic.lean
+++ b/src/group_theory/subgroup/basic.lean
@@ -1476,6 +1476,10 @@ iff.rfl
 @[to_additive] lemma range_eq_map (f : G →* N) : f.range = (⊤ : subgroup G).map f :=
 by ext; simp
 
+@[to_additive]
+lemma range_eq_top_of_surjective {f : G →* N} (hf : function.surjective f) :
+  f.range = ⊤ := by { ext, simp, apply hf }
+
 /-- The canonical surjective group homomorphism `G →* f(G)` induced by a group
 homomorphism `G →* N`. -/
 @[to_additive "The canonical surjective `add_group` homomorphism `G →+ f(G)` induced by a group


### PR DESCRIPTION
Every theorem that proves `nilpotency G'` (e.g. for subgroups, images,
preimages) should be accompanied by a lemma relating their
`nilpotency_class`, so add thse lmmeas for subgroups and preimages.

Also add nilpotency lemmas for surjective homomorphisms and quotions,
including nilpotency_class lemmas.



---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
-->

- [x] depends on: #11583

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
