### PR TITLE
[Merged by Bors] - feat(group_theory/subgroup/basic): add normalizer_condition definition

### DIFF
--- a/src/group_theory/nilpotent.lean
+++ b/src/group_theory/nilpotent.lean
@@ -482,3 +482,21 @@ begin
   calc derived_series G n ≤ lower_central_series G n : derived_le_lower_central n
     ... = ⊥ : hn
 end
+
+section normalizer_condition
+
+/-- Every proper subgroup `H` of `G` is a proper normal subgroup of the normalizer of `H` in `G`. -/
+def normalizer_condition (G : Type*) [group G] :=
+  ∀ (H : subgroup G), H < ⊤ → H < normalizer H
+
+/-- Alternative phrasing of the normalizer condition: Only the full group is self-normalizing.
+This may be easier to work with, as it avoids inequalities or negations.  -/
+lemma normalizer_condition_iff_only_full_group_self_normalizing :
+  normalizer_condition G ↔ ∀ (H : subgroup G), H.normalizer = H → H = ⊤ :=
+begin
+  apply forall_congr, intro H,
+  simp [normalizer_condition, lt_top_iff_ne_top, lt_iff_le_and_ne, le_normalizer],
+  tauto!,
+end
+
+end normalizer_condition

--- a/src/group_theory/nilpotent.lean
+++ b/src/group_theory/nilpotent.lean
@@ -482,21 +482,3 @@ begin
   calc derived_series G n ≤ lower_central_series G n : derived_le_lower_central n
     ... = ⊥ : hn
 end
-
-section normalizer_condition
-
-/-- Every proper subgroup `H` of `G` is a proper normal subgroup of the normalizer of `H` in `G`. -/
-def normalizer_condition (G : Type*) [group G] :=
-  ∀ (H : subgroup G), H < ⊤ → H < normalizer H
-
-/-- Alternative phrasing of the normalizer condition: Only the full group is self-normalizing.
-This may be easier to work with, as it avoids inequalities or negations.  -/
-lemma normalizer_condition_iff_only_full_group_self_normalizing :
-  normalizer_condition G ↔ ∀ (H : subgroup G), H.normalizer = H → H = ⊤ :=
-begin
-  apply forall_congr, intro H,
-  simp [normalizer_condition, lt_top_iff_ne_top, lt_iff_le_and_ne, le_normalizer],
-  tauto!,
-end
-
-end normalizer_condition

--- a/src/group_theory/subgroup/basic.lean
+++ b/src/group_theory/subgroup/basic.lean
@@ -1287,13 +1287,13 @@ end
 variable (G)
 
 /-- Every proper subgroup `H` of `G` is a proper normal subgroup of the normalizer of `H` in `G`. -/
-def normalizer_condition := ∀ (H : subgroup G), H < ⊤ → H < normalizer H
+def _root_.normalizer_condition := ∀ (H : subgroup G), H < ⊤ → H < normalizer H
 
 variable {G}
 
 /-- Alternative phrasing of the normalizer condition: Only the full group is self-normalizing.
 This may be easier to work with, as it avoids inequalities and negations.  -/
-lemma normalizer_condition_iff_only_full_group_self_normalizing :
+lemma _root_.normalizer_condition_iff_only_full_group_self_normalizing :
   normalizer_condition G ↔ ∀ (H : subgroup G), H.normalizer = H → H = ⊤ :=
 begin
   apply forall_congr, intro H,

--- a/src/group_theory/subgroup/basic.lean
+++ b/src/group_theory/subgroup/basic.lean
@@ -1284,6 +1284,23 @@ lemma le_normalizer_map (f : G →* N) :
     simp [hy, hyH, mul_assoc] }
 end
 
+variable (G)
+
+/-- Every proper subgroup `H` of `G` is a proper normal subgroup of the normalizer of `H` in `G`. -/
+def normalizer_condition := ∀ (H : subgroup G), H < ⊤ → H < normalizer H
+
+variable {G}
+
+/-- Alternative phrasing of the normalizer condition: Only the full group is self-normalizing.
+This may be easier to work with, as it avoids inequalities and negations.  -/
+lemma normalizer_condition_iff_only_full_group_self_normalizing :
+  normalizer_condition G ↔ ∀ (H : subgroup G), H.normalizer = H → H = ⊤ :=
+begin
+  apply forall_congr, intro H,
+  simp only [lt_iff_le_and_ne, le_normalizer, true_and, le_top, ne.def],
+  tauto!,
+end
+
 variable (H)
 
 /-- Commutivity of a subgroup -/


### PR DESCRIPTION
and an equivalent formula that is a bit easier to work with.

---

Main question: Should this definition live in `group_theory.nilpotent.lean`, in `group_theory.subgroup.basic` (where the normalizer is defined), or maybe it’s own module?

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
