### PR TITLE
[Merged by Bors] - refactor(order/{bounded, rel_classes}): Moved `bounded` into the `set` namespace

### DIFF
--- a/src/order/bounded.lean
+++ b/src/order/bounded.lean
@@ -15,6 +15,7 @@ the same ideas, or similar results with a few minor differences. The file is div
 different general ideas.
 -/
 
+namespace set
 variables {α : Type*} {r : α → α → Prop} {s t : set α}
 
 /-! ### Subsets of bounded and unbounded sets -/
@@ -328,3 +329,5 @@ theorem bounded_gt_inter_gt [linear_order α] [no_min_order α] (a : α) :
 theorem unbounded_gt_inter_gt [linear_order α] [no_min_order α] (a : α) :
   unbounded (>) (s ∩ {b | b < a}) ↔ unbounded (>) s :=
 @unbounded_lt_inter_lt (order_dual α) s _ _ a
+
+end set

--- a/src/order/rel_classes.lean
+++ b/src/order/rel_classes.lean
@@ -281,9 +281,11 @@ instance prod.lex.is_well_order [is_well_order α r] [is_well_order β s] :
   end,
   wf := prod.lex_wf is_well_order.wf is_well_order.wf }
 
-/-- An unbounded or cofinal set -/
+namespace set
+
+/-- An unbounded or cofinal set. -/
 def unbounded (r : α → α → Prop) (s : set α) : Prop := ∀ a, ∃ b ∈ s, ¬ r b a
-/-- A bounded or final set -/
+/-- A bounded or final set. Not to be confused with [`metric.bounded`]. -/
 def bounded (r : α → α → Prop) (s : set α) : Prop := ∃ a, ∀ b ∈ s, r b a
 
 @[simp] lemma not_bounded_iff {r : α → α → Prop} (s : set α) : ¬bounded r s ↔ unbounded r s :=
@@ -291,6 +293,8 @@ by simp only [bounded, unbounded, not_forall, not_exists, exists_prop, not_and, 
 
 @[simp] lemma not_unbounded_iff {r : α → α → Prop} (s : set α) : ¬unbounded r s ↔ bounded r s :=
 by rw [not_iff_comm, not_bounded_iff]
+
+end set
 
 namespace prod
 

--- a/src/order/rel_classes.lean
+++ b/src/order/rel_classes.lean
@@ -285,7 +285,7 @@ namespace set
 
 /-- An unbounded or cofinal set. -/
 def unbounded (r : α → α → Prop) (s : set α) : Prop := ∀ a, ∃ b ∈ s, ¬ r b a
-/-- A bounded or final set. Not to be confused with [`metric.bounded`]. -/
+/-- A bounded or final set. Not to be confused with `metric.bounded`. -/
 def bounded (r : α → α → Prop) (s : set α) : Prop := ∃ a, ∀ b ∈ s, r b a
 
 @[simp] lemma not_bounded_iff {r : α → α → Prop} (s : set α) : ¬bounded r s ↔ unbounded r s :=


### PR DESCRIPTION
As per the [Zulip discussion](https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/bounded.2Emono). Closes #11589.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
