### PR TITLE
[Merged by Bors] - fix(category_theory/triangulated): Fix definition of pretriangulated

### DIFF
--- a/src/category_theory/triangulated/pretriangulated.lean
+++ b/src/category_theory/triangulated/pretriangulated.lean
@@ -62,7 +62,7 @@ See https://stacks.math.columbia.edu/tag/0145
 -/
 class pretriangulated :=
 (distinguished_triangles [] : set (triangle C))
-(isomorphic_distinguished : Π (T₁ ∈ distinguished_triangles) (T₂ : triangle C) (T₁ ≅ T₂),
+(isomorphic_distinguished : Π (T₁ ∈ distinguished_triangles) (T₂ ≅ T₁),
   T₂ ∈ distinguished_triangles)
 (contractible_distinguished : Π (X : C), (contractible_triangle C X) ∈ distinguished_triangles)
 (distinguished_cocone_triangle : Π (X Y : C) (f : X ⟶ Y), (∃ (Z : C) (g : Y ⟶ Z)
@@ -90,7 +90,7 @@ Given any distinguished triangle `T`, then we know `T.inv_rotate` is also distin
 -/
 lemma inv_rot_of_dist_triangle (T ∈ dist_triang C) : (T.inv_rotate ∈ dist_triang C) :=
 (rotate_distinguished_triangle (T.inv_rotate)).mpr
-  (isomorphic_distinguished T H (T.inv_rotate.rotate) T (inv_rot_comp_rot.symm.app T))
+  (isomorphic_distinguished T H T.inv_rotate.rotate (inv_rot_comp_rot.app T))
 
 /--
 Given any distinguished triangle


### PR DESCRIPTION
The original definition unfolds to `(T₁ : triangle C) (T₁ ∈ distinguished_triangles) (T₂ : triangle C) (T₁ : triangle C) (e : T₁ ≅ T₂)`, where the two `T₁` are referring to different triangles.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
