### PR TITLE
feat(bors.toml): let bors wait for PRs to be green before merging

### DIFF
--- a/bors.toml
+++ b/bors.toml
@@ -5,6 +5,7 @@ pr_status = ["Build mathlib", "Lint mathlib", "Run tests", "Lint style"]
 # status = ["Build mathlib (fork)", "Lint mathlib (fork)", "Run tests (fork)", "Lint style (fork)"]
 use_squash_merge = true
 timeout_sec = 28800
+prerun_timeout_sec = 28800
 block_labels = ["not-ready-to-merge", "WIP", "blocked-by-other-PR", "merge-conflict", "awaiting-CI"]
 delete_merged_branches = true
 cut_body_after = "---"

--- a/bors.toml
+++ b/bors.toml
@@ -1,4 +1,5 @@
 status = ["Build mathlib", "Lint mathlib", "Run tests", "Lint style"]
+pr_status = ["Build mathlib", "Lint mathlib", "Run tests", "Lint style"]
 # if you want to use bors in an external fork of mathlib,
 # comment out the first line and uncomment the line below
 # status = ["Build mathlib (fork)", "Lint mathlib (fork)", "Run tests (fork)", "Lint style (fork)"]


### PR DESCRIPTION
This makes it reasonable to type `bors r+` even while CI is running.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)


See discussion on Zulip: https://leanprover.zulipchat.com/#narrow/stream/113489-new-members/topic/bors.20and.20pr_status/near/268977363