### PR TITLE
[Merged by Bors] - feat(analysis/special_functions/pow): add nnreal variant of rpow_pos

### DIFF
--- a/src/analysis/special_functions/pow.lean
+++ b/src/analysis/special_functions/pow.lean
@@ -965,15 +965,14 @@ real.rpow_le_rpow_of_exponent_ge hx0 hx1 hyz
 
 lemma rpow_pos {p : ℝ} {x : ℝ≥0} (hx_pos : 0 < x) : 0 < x^p :=
 begin
-  have rpow_pos_of_nonneg : ∀ {p : ℝ}, 0 ≤ p → 0 < x^p,
-  { intros p hp_nonneg,
-    obtain rfl|hp_pos := hp_nonneg.eq_or_lt,
-    { simp only [zero_lt_one, rpow_zero], },
-    { rw ←zero_rpow hp_pos.ne', exact rpow_lt_rpow hx_pos hp_pos, } },
-  cases lt_or_le 0 p with hp_pos hp_nonpos,
-  { exact rpow_pos_of_nonneg hp_pos.le },
+  have rpow_pos_of_nonneg : ∀ {p : ℝ}, 0 < p → 0 < x^p,
+  { intros p hp_pos,
+    rw ←zero_rpow hp_pos.ne', exact rpow_lt_rpow hx_pos hp_pos },
+  rcases lt_trichotomy 0 p with hp_pos|rfl|hp_neg,
+  { exact rpow_pos_of_nonneg hp_pos },
+  { simp only [zero_lt_one, rpow_zero] },
   { rw [←neg_neg p, rpow_neg, inv_pos],
-    exact rpow_pos_of_nonneg (neg_nonneg.mpr hp_nonpos) },
+    exact rpow_pos_of_nonneg (neg_pos.mpr hp_neg) },
 end
 
 lemma rpow_lt_one {x : ℝ≥0} {z : ℝ} (hx : 0 ≤ x) (hx1 : x < 1) (hz : 0 < z) : x^z < 1 :=

--- a/src/analysis/special_functions/pow.lean
+++ b/src/analysis/special_functions/pow.lean
@@ -967,7 +967,8 @@ lemma rpow_pos {p : ℝ} {x : ℝ≥0} (hx_pos : 0 < x) : 0 < x^p :=
 begin
   have rpow_pos_of_nonneg : ∀ {p : ℝ}, 0 < p → 0 < x^p,
   { intros p hp_pos,
-    rw ←zero_rpow hp_pos.ne', exact rpow_lt_rpow hx_pos hp_pos },
+    rw ←zero_rpow hp_pos.ne',
+    exact rpow_lt_rpow hx_pos hp_pos },
   rcases lt_trichotomy 0 p with hp_pos|rfl|hp_neg,
   { exact rpow_pos_of_nonneg hp_pos },
   { simp only [zero_lt_one, rpow_zero] },

--- a/src/analysis/special_functions/pow.lean
+++ b/src/analysis/special_functions/pow.lean
@@ -963,6 +963,21 @@ lemma rpow_le_rpow_of_exponent_ge {x : ℝ≥0} {y z : ℝ} (hx0 : 0 < x) (hx1 :
   x^y ≤ x^z :=
 real.rpow_le_rpow_of_exponent_ge hx0 hx1 hyz
 
+lemma rpow_pos_of_nonneg {p : ℝ} {x : ℝ≥0} (hx_pos : 0 < x) (hp_nonneg : 0 ≤ p) : 0 < x^p :=
+begin
+  obtain rfl|hp_pos := hp_nonneg.eq_or_lt,
+  { simp only [zero_lt_one, rpow_zero], },
+  { rw ←zero_rpow hp_pos.ne', exact rpow_lt_rpow hx_pos hp_pos, },
+end
+
+lemma rpow_pos {p : ℝ} {x : ℝ≥0} (hx_pos : 0 < x) : 0 < x^p :=
+begin
+  cases lt_or_le 0 p with hp_pos hp_nonpos,
+  { exact rpow_pos_of_nonneg hx_pos hp_pos.le },
+  { rw [←neg_neg p, rpow_neg, inv_pos],
+    exact rpow_pos_of_nonneg hx_pos (neg_nonneg.mpr hp_nonpos) },
+end
+
 lemma rpow_lt_one {x : ℝ≥0} {z : ℝ} (hx : 0 ≤ x) (hx1 : x < 1) (hz : 0 < z) : x^z < 1 :=
 real.rpow_lt_one hx hx1 hz
 

--- a/src/analysis/special_functions/pow.lean
+++ b/src/analysis/special_functions/pow.lean
@@ -963,19 +963,17 @@ lemma rpow_le_rpow_of_exponent_ge {x : ℝ≥0} {y z : ℝ} (hx0 : 0 < x) (hx1 :
   x^y ≤ x^z :=
 real.rpow_le_rpow_of_exponent_ge hx0 hx1 hyz
 
-lemma rpow_pos_of_nonneg {p : ℝ} {x : ℝ≥0} (hx_pos : 0 < x) (hp_nonneg : 0 ≤ p) : 0 < x^p :=
-begin
-  obtain rfl|hp_pos := hp_nonneg.eq_or_lt,
-  { simp only [zero_lt_one, rpow_zero], },
-  { rw ←zero_rpow hp_pos.ne', exact rpow_lt_rpow hx_pos hp_pos, },
-end
-
 lemma rpow_pos {p : ℝ} {x : ℝ≥0} (hx_pos : 0 < x) : 0 < x^p :=
 begin
+  have rpow_pos_of_nonneg : ∀ {p : ℝ}, 0 ≤ p → 0 < x^p,
+  { intros p hp_nonneg,
+    obtain rfl|hp_pos := hp_nonneg.eq_or_lt,
+    { simp only [zero_lt_one, rpow_zero], },
+    { rw ←zero_rpow hp_pos.ne', exact rpow_lt_rpow hx_pos hp_pos, } },
   cases lt_or_le 0 p with hp_pos hp_nonpos,
-  { exact rpow_pos_of_nonneg hx_pos hp_pos.le },
+  { exact rpow_pos_of_nonneg hp_pos.le },
   { rw [←neg_neg p, rpow_neg, inv_pos],
-    exact rpow_pos_of_nonneg hx_pos (neg_nonneg.mpr hp_nonpos) },
+    exact rpow_pos_of_nonneg (neg_nonneg.mpr hp_nonpos) },
 end
 
 lemma rpow_lt_one {x : ℝ≥0} {z : ℝ} (hx : 0 ≤ x) (hx1 : x < 1) (hz : 0 < z) : x^z < 1 :=


### PR DESCRIPTION
This matches the lemma for ennreal.



---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
