### PR TITLE
[Merged by Bors] - feat(algebra/group/hom): Notation for `monoid_with_zero_hom`

### DIFF
--- a/src/algebra/gcd_monoid/basic.lean
+++ b/src/algebra/gcd_monoid/basic.lean
@@ -86,7 +86,7 @@ variables [cancel_comm_monoid_with_zero α] [normalization_monoid α]
 norm_unit_coe_units 1
 
 /-- Chooses an element of each associate class, by multiplying by `norm_unit` -/
-def normalize : monoid_with_zero_hom α α :=
+def normalize : α →*₀ α :=
 { to_fun := λ x, x * norm_unit x,
   map_zero' := by simp,
   map_one' := by rw [norm_unit_one, units.coe_one, mul_one],

--- a/src/algebra/group/hom.lean
+++ b/src/algebra/group/hom.lean
@@ -9,7 +9,7 @@ import algebra.group_with_zero.defs
 import data.fun_like
 
 /-!
-# monoid and group homomorphisms
+# Monoid and group homomorphisms
 
 This file defines the bundled structures for monoid and group homomorphisms. Namely, we define
 `monoid_hom` (resp., `add_monoid_hom`) to be bundled homomorphisms between multiplicative (resp.,
@@ -29,10 +29,11 @@ building blocks for other homomorphisms:
 
 ## Notations
 
-* `→*` for bundled monoid homs (also use for group homs)
-* `→+` for bundled add_monoid homs (also use for add_group homs)
+* `→+`: Bundled `add_monoid` homs. Also use for `add_group` homs.
+* `→*`: Bundled `monoid` homs. Also use for `group` homs.
+* `→*₀`: Bundled `monoid_with_zero` homs. Also use for `group_with_zero` homs.
 
-## implementation notes
+## Implementation notes
 
 There's a coercion from bundled homs to fun, and the canonical
 notation is to use the bundled hom as a function via this coercion.
@@ -310,7 +311,7 @@ section mul_zero_one
 
 variables [mul_zero_one_class M] [mul_zero_one_class N]
 
-/-- `monoid_with_zero_hom M N` is the type of functions `M → N` that preserve
+/-- `M →*₀ N` is the type of functions `M → N` that preserve
 the `monoid_with_zero` structure.
 
 `monoid_with_zero_hom` is also used for group homomorphisms.
@@ -327,6 +328,8 @@ structure monoid_with_zero_hom (M : Type*) (N : Type*) [mul_zero_one_class M] [m
 attribute [nolint doc_blame] monoid_with_zero_hom.to_monoid_hom
 attribute [nolint doc_blame] monoid_with_zero_hom.to_zero_hom
 
+infixr ` →*₀ `:25 := monoid_with_zero_hom
+
 /-- `monoid_with_zero_hom_class F M N` states that `F` is a type of
 `monoid_with_zero`-preserving homomorphisms.
 
@@ -337,7 +340,7 @@ class monoid_with_zero_hom_class (F : Type*) (M N : out_param $ Type*)
   extends monoid_hom_class F M N, zero_hom_class F M N
 
 instance monoid_with_zero_hom.monoid_with_zero_hom_class :
-  monoid_with_zero_hom_class (monoid_with_zero_hom M N) M N :=
+  monoid_with_zero_hom_class (M →*₀ N) M N :=
 { coe := monoid_with_zero_hom.to_fun,
   coe_injective' := λ f g h, by cases f; cases g; congr',
   map_mul := monoid_with_zero_hom.map_mul',
@@ -358,10 +361,10 @@ instance monoid_hom.has_coe_to_mul_hom {mM : mul_one_class M} {mN : mul_one_clas
   has_coe (M →* N) (mul_hom M N) := ⟨monoid_hom.to_mul_hom⟩
 instance monoid_with_zero_hom.has_coe_to_monoid_hom
   {mM : mul_zero_one_class M} {mN : mul_zero_one_class N} :
-  has_coe (monoid_with_zero_hom M N) (M →* N) := ⟨monoid_with_zero_hom.to_monoid_hom⟩
+  has_coe (M →*₀ N) (M →* N) := ⟨monoid_with_zero_hom.to_monoid_hom⟩
 instance monoid_with_zero_hom.has_coe_to_zero_hom
   {mM : mul_zero_one_class M} {mN : mul_zero_one_class N} :
-  has_coe (monoid_with_zero_hom M N) (zero_hom M N) := ⟨monoid_with_zero_hom.to_zero_hom⟩
+  has_coe (M →*₀ N) (zero_hom M N) := ⟨monoid_with_zero_hom.to_zero_hom⟩
 
 /-! The simp-normal form of morphism coercion is `f.to_..._hom`. This choice is primarily because
 this is the way things were before the above coercions were introduced. Bundled morphisms defined
@@ -374,11 +377,11 @@ lemma monoid_hom.coe_eq_to_mul_hom {mM : mul_one_class M} {mN : mul_one_class N}
   (f : mul_hom M N) = f.to_mul_hom := rfl
 @[simp]
 lemma monoid_with_zero_hom.coe_eq_to_monoid_hom
-  {mM : mul_zero_one_class M} {mN : mul_zero_one_class N} (f : monoid_with_zero_hom M N) :
+  {mM : mul_zero_one_class M} {mN : mul_zero_one_class N} (f : M →*₀ N) :
   (f : M →* N) = f.to_monoid_hom := rfl
 @[simp]
 lemma monoid_with_zero_hom.coe_eq_to_zero_hom
-  {mM : mul_zero_one_class M} {mN : mul_zero_one_class N} (f : monoid_with_zero_hom M N) :
+  {mM : mul_zero_one_class M} {mN : mul_zero_one_class N} (f : M →*₀ N) :
   (f : zero_hom M N) = f.to_zero_hom := rfl
 
 -- Fallback `has_coe_to_fun` instances to help the elaborator
@@ -392,7 +395,7 @@ instance {mM : has_mul M} {mN : has_mul N} : has_coe_to_fun (mul_hom M N) (λ _,
 instance {mM : mul_one_class M} {mN : mul_one_class N} : has_coe_to_fun (M →* N) (λ _, M → N) :=
 ⟨monoid_hom.to_fun⟩
 instance {mM : mul_zero_one_class M} {mN : mul_zero_one_class N} :
-  has_coe_to_fun (monoid_with_zero_hom M N) (λ _, M → N) :=
+  has_coe_to_fun (M →*₀ N) (λ _, M → N) :=
 ⟨monoid_with_zero_hom.to_fun⟩
 
 -- these must come after the coe_to_fun definitions
@@ -414,7 +417,7 @@ lemma monoid_hom.to_fun_eq_coe [mul_one_class M] [mul_one_class N]
   (f : M →* N) : f.to_fun = f := rfl
 @[simp]
 lemma monoid_with_zero_hom.to_fun_eq_coe [mul_zero_one_class M] [mul_zero_one_class N]
-  (f : monoid_with_zero_hom M N) : f.to_fun = f := rfl
+  (f : M →*₀ N) : f.to_fun = f := rfl
 
 @[simp, to_additive]
 lemma one_hom.coe_mk [has_one M] [has_one N]
@@ -437,11 +440,11 @@ lemma monoid_hom.to_mul_hom_coe [mul_one_class M] [mul_one_class N] (f : M →* 
   (f.to_mul_hom : M → N) = f := rfl
 @[simp]
 lemma monoid_with_zero_hom.to_zero_hom_coe [mul_zero_one_class M] [mul_zero_one_class N]
-  (f : monoid_with_zero_hom M N) :
+  (f : M →*₀ N) :
   (f.to_zero_hom : M → N) = f := rfl
 @[simp]
 lemma monoid_with_zero_hom.to_monoid_hom_coe [mul_zero_one_class M] [mul_zero_one_class N]
-  (f : monoid_with_zero_hom M N) :
+  (f : M →*₀ N) :
   (f.to_monoid_hom : M → N) = f := rfl
 
 @[to_additive]
@@ -456,9 +459,9 @@ congr_arg (λ h : mul_hom M N, h x) h
 theorem monoid_hom.congr_fun [mul_one_class M] [mul_one_class N]
   {f g : M →* N} (h : f = g) (x : M) : f x = g x :=
 congr_arg (λ h : M →* N, h x) h
-theorem monoid_with_zero_hom.congr_fun [mul_zero_one_class M] [mul_zero_one_class N]
-  {f g : monoid_with_zero_hom M N} (h : f = g) (x : M) : f x = g x :=
-congr_arg (λ h : monoid_with_zero_hom M N, h x) h
+theorem monoid_with_zero_hom.congr_fun [mul_zero_one_class M] [mul_zero_one_class N] {f g : M →*₀ N}
+  (h : f = g) (x : M) : f x = g x :=
+congr_arg (λ h : M →*₀ N, h x) h
 
 @[to_additive]
 theorem one_hom.congr_arg [has_one M] [has_one N]
@@ -472,8 +475,8 @@ congr_arg (λ x : M, f x) h
 theorem monoid_hom.congr_arg [mul_one_class M] [mul_one_class N]
   (f : M →* N) {x y : M} (h : x = y) : f x = f y :=
 congr_arg (λ x : M, f x) h
-theorem monoid_with_zero_hom.congr_arg [mul_zero_one_class M] [mul_zero_one_class N]
-  (f : monoid_with_zero_hom M N) {x y : M} (h : x = y) : f x = f y :=
+theorem monoid_with_zero_hom.congr_arg [mul_zero_one_class M] [mul_zero_one_class N] (f : M →*₀ N)
+  {x y : M} (h : x = y) : f x = f y :=
 congr_arg (λ x : M, f x) h
 
 @[to_additive]
@@ -487,7 +490,7 @@ lemma monoid_hom.coe_inj [mul_one_class M] [mul_one_class N]
   ⦃f g : M →* N⦄ (h : (f : M → N) = g) : f = g :=
 by cases f; cases g; cases h; refl
 lemma monoid_with_zero_hom.coe_inj [mul_zero_one_class M] [mul_zero_one_class N]
-  ⦃f g : monoid_with_zero_hom M N⦄ (h : (f : M → N) = g) : f = g :=
+  ⦃f g : M →*₀ N⦄ (h : (f : M → N) = g) : f = g :=
 by cases f; cases g; cases h; refl
 
 @[ext, to_additive]
@@ -501,8 +504,8 @@ lemma monoid_hom.ext [mul_one_class M] [mul_one_class N]
   ⦃f g : M →* N⦄ (h : ∀ x, f x = g x) : f = g :=
 monoid_hom.coe_inj (funext h)
 @[ext]
-lemma monoid_with_zero_hom.ext [mul_zero_one_class M] [mul_zero_one_class N]
-  ⦃f g : monoid_with_zero_hom M N⦄ (h : ∀ x, f x = g x) : f = g :=
+lemma monoid_with_zero_hom.ext [mul_zero_one_class M] [mul_zero_one_class N] ⦃f g : M →*₀ N⦄
+  (h : ∀ x, f x = g x) : f = g :=
 monoid_with_zero_hom.coe_inj (funext h)
 
 @[to_additive]
@@ -515,8 +518,8 @@ lemma mul_hom.ext_iff [has_mul M] [has_mul N] {f g : mul_hom M N} : f = g ↔ �
 lemma monoid_hom.ext_iff [mul_one_class M] [mul_one_class N]
   {f g : M →* N} : f = g ↔ ∀ x, f x = g x :=
 ⟨λ h x, h ▸ rfl, λ h, monoid_hom.ext h⟩
-lemma monoid_with_zero_hom.ext_iff [mul_zero_one_class M] [mul_zero_one_class N]
-  {f g : monoid_with_zero_hom M N} : f = g ↔ ∀ x, f x = g x :=
+lemma monoid_with_zero_hom.ext_iff [mul_zero_one_class M] [mul_zero_one_class N] {f g : M →*₀ N} :
+  f = g ↔ ∀ x, f x = g x :=
 ⟨λ h x, h ▸ rfl, λ h, monoid_with_zero_hom.ext h⟩
 
 @[simp, to_additive]
@@ -532,8 +535,8 @@ lemma monoid_hom.mk_coe [mul_one_class M] [mul_one_class N]
   (f : M →* N) (h1 hmul) : monoid_hom.mk f h1 hmul = f :=
 monoid_hom.ext $ λ _, rfl
 @[simp]
-lemma monoid_with_zero_hom.mk_coe [mul_zero_one_class M] [mul_zero_one_class N]
-  (f : monoid_with_zero_hom M N) (h0 h1 hmul) : monoid_with_zero_hom.mk f h0 h1 hmul = f :=
+lemma monoid_with_zero_hom.mk_coe [mul_zero_one_class M] [mul_zero_one_class N] (f : M →*₀ N)
+  (h0 h1 hmul) : monoid_with_zero_hom.mk f h0 h1 hmul = f :=
 monoid_with_zero_hom.ext $ λ _, rfl
 
 end coes
@@ -545,12 +548,12 @@ protected lemma one_hom.map_one [has_one M] [has_one N] (f : one_hom M N) : f 1 
 protected lemma monoid_hom.map_one [mul_one_class M] [mul_one_class N] (f : M →* N) :
   f 1 = 1 := f.map_one'
 protected lemma monoid_with_zero_hom.map_one [mul_zero_one_class M] [mul_zero_one_class N]
-  (f : monoid_with_zero_hom M N) : f 1 = 1 := f.map_one'
+  (f : M →*₀ N) : f 1 = 1 := f.map_one'
 
 /-- If `f` is an additive monoid homomorphism then `f 0 = 0`. -/
 add_decl_doc add_monoid_hom.map_zero
 protected lemma monoid_with_zero_hom.map_zero [mul_zero_one_class M] [mul_zero_one_class N]
-  (f : monoid_with_zero_hom M N) : f 0 = 0 := f.map_zero'
+  (f : M →*₀ N) : f 0 = 0 := f.map_zero'
 
 @[to_additive]
 protected lemma mul_hom.map_mul [has_mul M] [has_mul N]
@@ -560,7 +563,7 @@ protected lemma mul_hom.map_mul [has_mul M] [has_mul N]
 protected lemma monoid_hom.map_mul [mul_one_class M] [mul_one_class N]
   (f : M →* N) (a b : M) : f (a * b) = f a * f b := f.map_mul' a b
 protected lemma monoid_with_zero_hom.map_mul [mul_zero_one_class M] [mul_zero_one_class N]
-  (f :  monoid_with_zero_hom M N) (a b : M) : f (a * b) = f a * f b := f.map_mul' a b
+  (f :  M →*₀ N) (a b : M) : f (a * b) = f a * f b := f.map_mul' a b
 
 /-- If `f` is an additive monoid homomorphism then `f (a + b) = f a + f b`. -/
 add_decl_doc add_monoid_hom.map_add
@@ -616,7 +619,7 @@ def monoid_hom.id (M : Type*) [mul_one_class M] : M →* M :=
 { to_fun := λ x, x, map_one' := rfl, map_mul' := λ _ _, rfl, }
 /-- The identity map from a monoid_with_zero to itself. -/
 @[simps]
-def monoid_with_zero_hom.id (M : Type*) [mul_zero_one_class M] : monoid_with_zero_hom M M :=
+def monoid_with_zero_hom.id (M : Type*) [mul_zero_one_class M] : M →*₀ M :=
 { to_fun := λ x, x, map_zero' := rfl, map_one' := rfl, map_mul' := λ _ _, rfl, }
 
 /-- The identity map from an type with zero to itself. -/
@@ -645,7 +648,7 @@ def monoid_hom.comp [mul_one_class M] [mul_one_class N] [mul_one_class P]
 
 /-- Composition of `monoid_with_zero_hom`s as a `monoid_with_zero_hom`. -/
 def monoid_with_zero_hom.comp [mul_zero_one_class M] [mul_zero_one_class N] [mul_zero_one_class P]
-  (hnp : monoid_with_zero_hom N P) (hmn : monoid_with_zero_hom M N) : monoid_with_zero_hom M P :=
+  (hnp : N →*₀ P) (hmn : M →*₀ N) : M →*₀ P :=
 { to_fun := hnp ∘ hmn, map_zero' := by simp, map_one' := by simp, map_mul' := by simp, }
 
 /-- Composition of `zero_hom`s as a `zero_hom`. -/
@@ -665,8 +668,7 @@ add_decl_doc add_monoid_hom.comp
   (g : N →* P) (f : M →* N) :
   ⇑(g.comp f) = g ∘ f := rfl
 @[simp] lemma monoid_with_zero_hom.coe_comp [mul_zero_one_class M] [mul_zero_one_class N]
-  [mul_zero_one_class P]
-  (g : monoid_with_zero_hom N P) (f : monoid_with_zero_hom M N) :
+  [mul_zero_one_class P] (g : N →*₀ P) (f : M →*₀ N) :
   ⇑(g.comp f) = g ∘ f := rfl
 
 @[to_additive] lemma one_hom.comp_apply [has_one M] [has_one N] [has_one P]
@@ -678,9 +680,8 @@ add_decl_doc add_monoid_hom.comp
 @[to_additive] lemma monoid_hom.comp_apply [mul_one_class M] [mul_one_class N] [mul_one_class P]
   (g : N →* P) (f : M →* N) (x : M) :
   g.comp f x = g (f x) := rfl
-lemma monoid_with_zero_hom.comp_apply
-  [mul_zero_one_class M] [mul_zero_one_class N] [mul_zero_one_class P]
-  (g : monoid_with_zero_hom N P) (f : monoid_with_zero_hom M N) (x : M) :
+lemma monoid_with_zero_hom.comp_apply [mul_zero_one_class M] [mul_zero_one_class N]
+  [mul_zero_one_class P] (g : N →*₀ P) (f : M →*₀ N) (x : M) :
   g.comp f x = g (f x) := rfl
 
 /-- Composition of monoid homomorphisms is associative. -/
@@ -696,7 +697,7 @@ lemma monoid_with_zero_hom.comp_apply
   (h.comp g).comp f = h.comp (g.comp f) := rfl
 lemma monoid_with_zero_hom.comp_assoc {Q : Type*}
   [mul_zero_one_class M] [mul_zero_one_class N] [mul_zero_one_class P] [mul_zero_one_class Q]
-  (f : monoid_with_zero_hom M N) (g : monoid_with_zero_hom N P) (h : monoid_with_zero_hom P Q) :
+  (f : M →*₀ N) (g : N →*₀ P) (h : P →*₀ Q) :
   (h.comp g).comp f = h.comp (g.comp f) := rfl
 
 @[to_additive]
@@ -715,9 +716,8 @@ lemma monoid_hom.cancel_right
   {g₁ g₂ : N →* P} {f : M →* N} (hf : function.surjective f) :
   g₁.comp f = g₂.comp f ↔ g₁ = g₂ :=
 ⟨λ h, monoid_hom.ext $ hf.forall.2 (monoid_hom.ext_iff.1 h), λ h, h ▸ rfl⟩
-lemma monoid_with_zero_hom.cancel_right
-  [mul_zero_one_class M] [mul_zero_one_class N] [mul_zero_one_class P]
-  {g₁ g₂ : monoid_with_zero_hom N P} {f : monoid_with_zero_hom M N} (hf : function.surjective f) :
+lemma monoid_with_zero_hom.cancel_right [mul_zero_one_class M] [mul_zero_one_class N]
+  [mul_zero_one_class P] {g₁ g₂ : N →*₀ P} {f : M →*₀ N} (hf : function.surjective f) :
   g₁.comp f = g₂.comp f ↔ g₁ = g₂ :=
 ⟨λ h, monoid_with_zero_hom.ext $ hf.forall.2 (monoid_with_zero_hom.ext_iff.1 h),
  λ h, h ▸ rfl⟩
@@ -740,9 +740,8 @@ lemma monoid_hom.cancel_left [mul_one_class M] [mul_one_class N] [mul_one_class 
   g.comp f₁ = g.comp f₂ ↔ f₁ = f₂ :=
 ⟨λ h, monoid_hom.ext $ λ x, hg $ by rw [← monoid_hom.comp_apply, h, monoid_hom.comp_apply],
  λ h, h ▸ rfl⟩
-lemma monoid_with_zero_hom.cancel_left
-  [mul_zero_one_class M] [mul_zero_one_class N] [mul_zero_one_class P]
-  {g : monoid_with_zero_hom N P} {f₁ f₂ : monoid_with_zero_hom M N} (hg : function.injective g) :
+lemma monoid_with_zero_hom.cancel_left [mul_zero_one_class M] [mul_zero_one_class N]
+  [mul_zero_one_class P] {g : N →*₀ P} {f₁ f₂ : M →*₀ N} (hg : function.injective g) :
   g.comp f₁ = g.comp f₂ ↔ f₁ = f₂ :=
 ⟨λ h, monoid_with_zero_hom.ext $ λ x, hg $ by rw [
         ← monoid_with_zero_hom.comp_apply, h, monoid_with_zero_hom.comp_apply],
@@ -757,10 +756,10 @@ lemma monoid_hom.to_mul_hom_injective [mul_one_class M] [mul_one_class N] :
   function.injective (monoid_hom.to_mul_hom : (M →* N) → mul_hom M N) :=
 λ f g h, monoid_hom.ext $ mul_hom.ext_iff.mp h
 lemma monoid_with_zero_hom.to_monoid_hom_injective [monoid_with_zero M] [monoid_with_zero N] :
-  function.injective (monoid_with_zero_hom.to_monoid_hom : monoid_with_zero_hom M N → M →* N) :=
+  function.injective (monoid_with_zero_hom.to_monoid_hom : (M →*₀ N) → M →* N) :=
 λ f g h, monoid_with_zero_hom.ext $ monoid_hom.ext_iff.mp h
 lemma monoid_with_zero_hom.to_zero_hom_injective [monoid_with_zero M] [monoid_with_zero N] :
-  function.injective (monoid_with_zero_hom.to_zero_hom : monoid_with_zero_hom M N → zero_hom M N) :=
+  function.injective (monoid_with_zero_hom.to_zero_hom : (M →*₀ N) → zero_hom M N) :=
 λ f g h, monoid_with_zero_hom.ext $ zero_hom.ext_iff.mp h
 
 @[simp, to_additive] lemma one_hom.comp_id [has_one M] [has_one N]
@@ -770,7 +769,7 @@ lemma monoid_with_zero_hom.to_zero_hom_injective [monoid_with_zero M] [monoid_wi
 @[simp, to_additive] lemma monoid_hom.comp_id [mul_one_class M] [mul_one_class N]
   (f : M →* N) : f.comp (monoid_hom.id M) = f := monoid_hom.ext $ λ x, rfl
 @[simp] lemma monoid_with_zero_hom.comp_id [mul_zero_one_class M] [mul_zero_one_class N]
-  (f : monoid_with_zero_hom M N) : f.comp (monoid_with_zero_hom.id M) = f :=
+  (f : M →*₀ N) : f.comp (monoid_with_zero_hom.id M) = f :=
 monoid_with_zero_hom.ext $ λ x, rfl
 
 @[simp, to_additive] lemma one_hom.id_comp [has_one M] [has_one N]
@@ -780,7 +779,7 @@ monoid_with_zero_hom.ext $ λ x, rfl
 @[simp, to_additive] lemma monoid_hom.id_comp [mul_one_class M] [mul_one_class N]
   (f : M →* N) : (monoid_hom.id N).comp f = f := monoid_hom.ext $ λ x, rfl
 @[simp] lemma monoid_with_zero_hom.id_comp [mul_zero_one_class M] [mul_zero_one_class N]
-  (f : monoid_with_zero_hom M N) : (monoid_with_zero_hom.id N).comp f = f :=
+  (f : M →*₀ N) : (monoid_with_zero_hom.id N).comp f = f :=
 monoid_with_zero_hom.ext $ λ x, rfl
 
 @[to_additive add_monoid_hom.map_nsmul]
@@ -894,8 +893,7 @@ instance [has_mul M] [mul_one_class N] : inhabited (mul_hom M N) := ⟨1⟩
 @[to_additive]
 instance [mul_one_class M] [mul_one_class N] : inhabited (M →* N) := ⟨1⟩
 -- unlike the other homs, `monoid_with_zero_hom` does not have a `1` or `0`
-instance [mul_zero_one_class M] : inhabited (monoid_with_zero_hom M M) :=
-⟨monoid_with_zero_hom.id M⟩
+instance [mul_zero_one_class M] : inhabited (M →*₀ M) := ⟨monoid_with_zero_hom.id M⟩
 
 namespace monoid_hom
 variables [mM : mul_one_class M] [mN : mul_one_class N] [mP : mul_one_class P]

--- a/src/algebra/group/prod.lean
+++ b/src/algebra/group/prod.lean
@@ -375,7 +375,7 @@ def mul_monoid_hom [comm_monoid α] : α × α →* α :=
 
 /-- Multiplication as a multiplicative homomorphism with zero. -/
 @[simps]
-def mul_monoid_with_zero_hom [comm_monoid_with_zero α] : monoid_with_zero_hom (α × α) α :=
+def mul_monoid_with_zero_hom [comm_monoid_with_zero α] : α × α →*₀ α :=
 { map_zero' := mul_zero _,
   .. mul_monoid_hom }
 
@@ -388,7 +388,7 @@ def div_monoid_hom [comm_group α] : α × α →* α :=
 
 /-- Division as a multiplicative homomorphism with zero. -/
 @[simps]
-def div_monoid_with_zero_hom [comm_group_with_zero α] : monoid_with_zero_hom (α × α) α :=
+def div_monoid_with_zero_hom [comm_group_with_zero α] : α × α →*₀ α :=
 { to_fun := λ a, a.1 / a.2,
   map_zero' := zero_div _,
   map_one' := div_one _,

--- a/src/algebra/group_with_zero/basic.lean
+++ b/src/algebra/group_with_zero/basic.lean
@@ -1129,7 +1129,7 @@ variables [group_with_zero G₀] [group_with_zero G₀'] [monoid_with_zero M₀]
 
 section monoid_with_zero
 
-variables (f : monoid_with_zero_hom G₀ M₀) {a : G₀}
+variables (f : G₀ →*₀ M₀) {a : G₀}
 
 lemma map_ne_zero : f a ≠ 0 ↔ a ≠ 0 :=
 ⟨λ hfa ha, hfa $ ha.symm ▸ f.map_zero, λ ha, ((is_unit.mk0 a ha).map f.to_monoid_hom).ne_zero⟩
@@ -1141,7 +1141,7 @@ end monoid_with_zero
 
 section group_with_zero
 
-variables (f : monoid_with_zero_hom G₀ G₀') (a b : G₀)
+variables (f : G₀ →*₀ G₀') (a b : G₀)
 
 /-- A monoid homomorphism between groups with zeros sending `0` to `0` sends `a⁻¹` to `(f a)⁻¹`. -/
 @[simp] lemma map_inv : f a⁻¹ = (f a)⁻¹ :=
@@ -1159,7 +1159,7 @@ end group_with_zero
 end monoid_with_zero_hom
 
 /-- Inversion on a commutative group with zero, considered as a monoid with zero homomorphism. -/
-def inv_monoid_with_zero_hom {G₀ : Type*} [comm_group_with_zero G₀] : monoid_with_zero_hom G₀ G₀ :=
+def inv_monoid_with_zero_hom {G₀ : Type*} [comm_group_with_zero G₀] : G₀ →*₀ G₀ :=
 { to_fun := has_inv.inv,
   map_zero' := inv_zero,
   map_one' := inv_one,
@@ -1170,7 +1170,7 @@ def inv_monoid_with_zero_hom {G₀ : Type*} [comm_group_with_zero G₀] : monoid
 by rw [← units.coe_map, ← units.coe_map, ← units.coe_inv', monoid_hom.map_inv]
 
 @[simp] lemma monoid_with_zero_hom.map_units_inv {M G₀ : Type*} [monoid_with_zero M]
-  [group_with_zero G₀] (f : monoid_with_zero_hom M G₀) (u : Mˣ) : f ↑u⁻¹ = (f u)⁻¹ :=
+  [group_with_zero G₀] (f : M →*₀ G₀) (u : Mˣ) : f ↑u⁻¹ = (f u)⁻¹ :=
 f.to_monoid_hom.map_units_inv u
 
 section noncomputable_defs

--- a/src/algebra/group_with_zero/power.lean
+++ b/src/algebra/group_with_zero/power.lean
@@ -274,7 +274,7 @@ end
 /-- If a monoid homomorphism `f` between two `group_with_zero`s maps `0` to `0`, then it maps `x^n`,
 `n : ℤ`, to `(f x)^n`. -/
 lemma monoid_with_zero_hom.map_zpow {G₀ G₀' : Type*} [group_with_zero G₀] [group_with_zero G₀']
-  (f : monoid_with_zero_hom G₀ G₀') (x : G₀) :
+  (f : G₀ →*₀ G₀') (x : G₀) :
   ∀ n : ℤ, f (x ^ n) = f x ^ n
 | (n : ℕ) := by { rw [zpow_coe_nat, zpow_coe_nat], exact f.to_monoid_hom.map_pow x n }
 | -[1+n] := begin

--- a/src/algebra/order/absolute_value.lean
+++ b/src/algebra/order/absolute_value.lean
@@ -95,7 +95,7 @@ variables [nontrivial R]
 by rw [← abv.map_mul, mul_one, mul_one]
 
 /-- Absolute values from a nontrivial `R` to a linear ordered ring preserve `*`, `0` and `1`. -/
-def to_monoid_with_zero_hom : monoid_with_zero_hom R S :=
+def to_monoid_with_zero_hom : R →*₀ S :=
 { to_fun := abv,
   map_zero' := abv.map_zero,
   map_one' := abv.map_one,
@@ -231,8 +231,7 @@ theorem abv_one [nontrivial R] : abv 1 = 1 :=
 by rw [← abv_mul abv, mul_one, mul_one]
 
 /-- `abv` as a `monoid_with_zero_hom`. -/
-def abv_hom [nontrivial R] : monoid_with_zero_hom R S :=
-⟨abv, abv_zero abv, abv_one abv, abv_mul abv⟩
+def abv_hom [nontrivial R] : R →*₀ S := ⟨abv, abv_zero abv, abv_one abv, abv_mul abv⟩
 
 lemma abv_pow [nontrivial R] (abv : R → S) [is_absolute_value abv]
   (a : R) (n : ℕ) : abv (a ^ n) = abv a ^ n :=

--- a/src/algebra/order/field.lean
+++ b/src/algebra/order/field.lean
@@ -706,14 +706,12 @@ lemma max_div_div_right_of_nonpos {c : α} (hc : c ≤ 0) (a b : α) :
   max (a / c) (b / c) = (min a b) / c :=
 eq.symm $ @monotone.map_min α (order_dual α) _ _ _ _ _ (λ x y, div_le_div_of_nonpos_of_le hc)
 
-lemma abs_div (a b : α) : |a / b| = |a| / |b| :=
-(abs_hom : monoid_with_zero_hom α α).map_div a b
+lemma abs_div (a b : α) : |a / b| = |a| / |b| := (abs_hom : α →*₀ α).map_div a b
 
 lemma abs_one_div (a : α) : |1 / a| = 1 / |a| :=
 by rw [abs_div, abs_one]
 
-lemma abs_inv (a : α) : |a⁻¹| = (|a|)⁻¹ :=
-(abs_hom : monoid_with_zero_hom α α).map_inv a
+lemma abs_inv (a : α) : |a⁻¹| = (|a|)⁻¹ := (abs_hom : α →*₀ α).map_inv a
 
 -- TODO: add lemmas with `a⁻¹`.
 lemma one_div_strict_anti_on : strict_anti_on (λ x : α, 1 / x) (set.Ioi 0) :=

--- a/src/algebra/order/ring.lean
+++ b/src/algebra/order/ring.lean
@@ -1032,7 +1032,7 @@ begin
 end
 
 /-- `abs` as a `monoid_with_zero_hom`. -/
-def abs_hom : monoid_with_zero_hom α α := ⟨abs, abs_zero, abs_one, abs_mul⟩
+def abs_hom : α →*₀ α := ⟨abs, abs_zero, abs_one, abs_mul⟩
 
 @[simp] lemma abs_mul_abs_self (a : α) : |a| * |a| = a * a :=
 abs_by_cases (λ x, x * x = a * a) rfl (neg_mul_neg a a)

--- a/src/algebra/quaternion.lean
+++ b/src/algebra/quaternion.lean
@@ -486,7 +486,7 @@ def conj_ae : ℍ[R] ≃ₐ[R] (ℍ[R]ᵐᵒᵖ) := quaternion_algebra.conj_ae
 @[simp] lemma coe_conj_ae : ⇑(conj_ae : ℍ[R] ≃ₐ[R] ℍ[R]ᵐᵒᵖ) = op ∘ conj := rfl
 
 /-- Square of the norm. -/
-def norm_sq : monoid_with_zero_hom ℍ[R] R :=
+def norm_sq : ℍ[R] →*₀ R :=
 { to_fun := λ a, (a * a.conj).re,
   map_zero' := by rw [conj_zero, zero_mul, zero_re],
   map_one' := by rw [conj_one, one_mul, one_re],

--- a/src/algebra/ring/basic.lean
+++ b/src/algebra/ring/basic.lean
@@ -327,12 +327,12 @@ end add_monoid_hom
 This extends from both `monoid_hom` and `monoid_with_zero_hom` in order to put the fields in a
 sensible order, even though `monoid_with_zero_hom` already extends `monoid_hom`. -/
 structure ring_hom (α : Type*) (β : Type*) [non_assoc_semiring α] [non_assoc_semiring β]
-  extends monoid_hom α β, add_monoid_hom α β, monoid_with_zero_hom α β
+  extends α →* β, α →+ β, α →*₀ β
 
 infixr ` →+* `:25 := ring_hom
 
-/-- Reinterpret a ring homomorphism `f : R →+* S` as a `monoid_with_zero_hom R S`.
-The `simp`-normal form is `(f : monoid_with_zero_hom R S)`. -/
+/-- Reinterpret a ring homomorphism `f : R →+* S` as a monoid with zero homomorphism `R →*₀ S`.
+The `simp`-normal form is `(f : R →*₀ S)`. -/
 add_decl_doc ring_hom.to_monoid_with_zero_hom
 
 /-- Reinterpret a ring homomorphism `f : R →+* S` as a monoid homomorphism `R →* S`.

--- a/src/algebra/smul_with_zero.lean
+++ b/src/algebra/smul_with_zero.lean
@@ -151,8 +151,7 @@ protected def function.surjective.mul_action_with_zero
 variables (M)
 
 /-- Compose a `mul_action_with_zero` with a `monoid_with_zero_hom`, with action `f r' • m` -/
-def mul_action_with_zero.comp_hom (f : monoid_with_zero_hom R' R) :
-  mul_action_with_zero R' M :=
+def mul_action_with_zero.comp_hom (f : R' →*₀ R) : mul_action_with_zero R' M :=
 { smul := (•) ∘ f,
   mul_smul := λ r s m, by simp [mul_smul],
   one_smul := λ m, by simp,
@@ -164,6 +163,6 @@ end monoid_with_zero
 @[simps]
 def smul_monoid_with_zero_hom {α β : Type*} [monoid_with_zero α] [mul_zero_one_class β]
   [mul_action_with_zero α β] [is_scalar_tower α β β] [smul_comm_class α β β] :
-  monoid_with_zero_hom (α × β) β :=
+  α × β →*₀ β :=
 { map_zero' := smul_zero' _ _,
   .. smul_monoid_hom }

--- a/src/analysis/normed_space/basic.lean
+++ b/src/analysis/normed_space/basic.lean
@@ -271,12 +271,11 @@ instance to_norm_one_class : norm_one_class α :=
 @[simp] lemma nnnorm_mul (a b : α) : ∥a * b∥₊ = ∥a∥₊ * ∥b∥₊ :=
 nnreal.eq $ norm_mul a b
 
-/-- `norm` as a `monoid_hom`. -/
-@[simps] def norm_hom : monoid_with_zero_hom α ℝ := ⟨norm, norm_zero, norm_one, norm_mul⟩
+/-- `norm` as a `monoid_with_zero_hom`. -/
+@[simps] def norm_hom : α →*₀ ℝ := ⟨norm, norm_zero, norm_one, norm_mul⟩
 
-/-- `nnnorm` as a `monoid_hom`. -/
-@[simps] def nnnorm_hom : monoid_with_zero_hom α ℝ≥0 :=
-⟨nnnorm, nnnorm_zero, nnnorm_one, nnnorm_mul⟩
+/-- `nnnorm` as a `monoid_with_zero_hom`. -/
+@[simps] def nnnorm_hom : α →*₀ ℝ≥0 := ⟨nnnorm, nnnorm_zero, nnnorm_one, nnnorm_mul⟩
 
 @[simp] lemma norm_pow (a : α) : ∀ (n : ℕ), ∥a ^ n∥ = ∥a∥ ^ n :=
 (norm_hom.to_monoid_hom : α →* ℝ).map_pow a
@@ -292,23 +291,19 @@ nnreal.eq $ norm_mul a b
   ∥∏ b in s, f b∥₊ = ∏ b in s, ∥f b∥₊ :=
 (nnnorm_hom.to_monoid_hom : α →* ℝ≥0).map_prod f s
 
-@[simp] lemma norm_div (a b : α) : ∥a / b∥ = ∥a∥ / ∥b∥ :=
-(norm_hom : monoid_with_zero_hom α ℝ).map_div a b
+@[simp] lemma norm_div (a b : α) : ∥a / b∥ = ∥a∥ / ∥b∥ := (norm_hom : α →*₀ ℝ).map_div a b
 
-@[simp] lemma nnnorm_div (a b : α) : ∥a / b∥₊ = ∥a∥₊ / ∥b∥₊ :=
-(nnnorm_hom : monoid_with_zero_hom α ℝ≥0).map_div a b
+@[simp] lemma nnnorm_div (a b : α) : ∥a / b∥₊ = ∥a∥₊ / ∥b∥₊ := (nnnorm_hom : α →*₀ ℝ≥0).map_div a b
 
-@[simp] lemma norm_inv (a : α) : ∥a⁻¹∥ = ∥a∥⁻¹ :=
-(norm_hom : monoid_with_zero_hom α ℝ).map_inv a
+@[simp] lemma norm_inv (a : α) : ∥a⁻¹∥ = ∥a∥⁻¹ := (norm_hom : α →*₀ ℝ).map_inv a
 
 @[simp] lemma nnnorm_inv (a : α) : ∥a⁻¹∥₊ = ∥a∥₊⁻¹ :=
 nnreal.eq $ by simp
 
-@[simp] lemma norm_zpow : ∀ (a : α) (n : ℤ), ∥a^n∥ = ∥a∥^n :=
-(norm_hom : monoid_with_zero_hom α ℝ).map_zpow
+@[simp] lemma norm_zpow : ∀ (a : α) (n : ℤ), ∥a^n∥ = ∥a∥^n := (norm_hom : α →*₀ ℝ).map_zpow
 
 @[simp] lemma nnnorm_zpow : ∀ (a : α) (n : ℤ), ∥a ^ n∥₊ = ∥a∥₊ ^ n :=
-(nnnorm_hom : monoid_with_zero_hom α ℝ≥0).map_zpow
+(nnnorm_hom : α →*₀ ℝ≥0).map_zpow
 
 @[priority 100] -- see Note [lower instance priority]
 instance : has_continuous_inv₀ α :=

--- a/src/data/complex/basic.lean
+++ b/src/data/complex/basic.lean
@@ -225,7 +225,7 @@ lemma eq_conj_iff_im {z : ℂ} : conj z = z ↔ z.im = 0 :=
 /-! ### Norm squared -/
 
 /-- The norm squared function. -/
-@[pp_nodot] def norm_sq : monoid_with_zero_hom ℂ ℝ :=
+@[pp_nodot] def norm_sq : ℂ →*₀ ℝ :=
 { to_fun := λ z, z.re * z.re + z.im * z.im,
   map_zero' := by simp,
   map_one' := by simp,

--- a/src/data/complex/is_R_or_C.lean
+++ b/src/data/complex/is_R_or_C.lean
@@ -245,7 +245,7 @@ lemma eq_conj_iff_re {z : K} : conj z = z ↔ ((re z) : K) = z :=
 eq_conj_iff_real.trans ⟨by rintro ⟨r, rfl⟩; simp, λ h, ⟨_, h.symm⟩⟩
 
 /-- The norm squared function. -/
-def norm_sq : monoid_with_zero_hom K ℝ :=
+def norm_sq : K →*₀ ℝ :=
 { to_fun := λ z, re z * re z + im z * im z,
   map_zero' := by simp only [add_zero, mul_zero, map_zero],
   map_one' := by simp only [one_im, add_zero, mul_one, one_re, mul_zero],

--- a/src/data/fintype/basic.lean
+++ b/src/data/fintype/basic.lean
@@ -273,8 +273,8 @@ instance decidable_eq_monoid_hom_fintype [decidable_eq β] [fintype α]
 λ a b, decidable_of_iff ((a : α → β) = b) (injective.eq_iff monoid_hom.coe_inj)
 
 instance decidable_eq_monoid_with_zero_hom_fintype [decidable_eq β] [fintype α]
-  [mul_zero_one_class α] [mul_zero_one_class β]:
-  decidable_eq (monoid_with_zero_hom α β) :=
+  [mul_zero_one_class α] [mul_zero_one_class β] :
+  decidable_eq (α →*₀ β) :=
 λ a b, decidable_of_iff ((a : α → β) = b) (injective.eq_iff monoid_with_zero_hom.coe_inj)
 
 instance decidable_eq_ring_hom_fintype [decidable_eq β] [fintype α]

--- a/src/data/int/cast.lean
+++ b/src/data/int/cast.lean
@@ -266,16 +266,15 @@ namespace monoid_with_zero_hom
 variables {M : Type*} [monoid_with_zero M]
 
 /-- If two `monoid_with_zero_hom`s agree on `-1` and the naturals then they are equal. -/
-@[ext] theorem ext_int {f g : monoid_with_zero_hom ℤ M}
-  (h_neg_one : f (-1) = g (-1))
+@[ext] lemma ext_int {f g : ℤ →*₀ M} (h_neg_one : f (-1) = g (-1))
   (h_nat : f.comp int.of_nat_hom.to_monoid_with_zero_hom =
            g.comp int.of_nat_hom.to_monoid_with_zero_hom) :
   f = g :=
 to_monoid_hom_injective $ monoid_hom.ext_int h_neg_one $ monoid_hom.ext (congr_fun h_nat : _)
 
 /-- If two `monoid_with_zero_hom`s agree on `-1` and the _positive_ naturals then they are equal. -/
-theorem ext_int' {φ₁ φ₂ : monoid_with_zero_hom ℤ M}
-  (h_neg_one : φ₁ (-1) = φ₂ (-1)) (h_pos : ∀ n : ℕ, 0 < n → φ₁ n = φ₂ n) : φ₁ = φ₂ :=
+lemma ext_int' {φ₁ φ₂ : ℤ →*₀ M} (h_neg_one : φ₁ (-1) = φ₂ (-1))
+  (h_pos : ∀ n : ℕ, 0 < n → φ₁ n = φ₂ n) : φ₁ = φ₂ :=
 ext_int h_neg_one $ ext_nat h_pos
 
 end monoid_with_zero_hom

--- a/src/data/nat/cast.lean
+++ b/src/data/nat/cast.lean
@@ -304,7 +304,7 @@ begin
 end
 
 @[ext] theorem monoid_with_zero_hom.ext_nat :
-∀ {f g : monoid_with_zero_hom ℕ A}, (∀ {n : ℕ}, 0 < n → f n = g n) → f = g := ext_nat''
+  ∀ {f g : ℕ →*₀ A}, (∀ {n : ℕ}, 0 < n → f n = g n) → f = g := ext_nat''
 
 end monoid_with_zero_hom_class
 

--- a/src/data/rat/cast.lean
+++ b/src/data/rat/cast.lean
@@ -302,7 +302,7 @@ variables {M : Type*} [group_with_zero M]
 
 See note [partially-applied ext lemmas] for why `comp` is used here. -/
 @[ext]
-theorem ext_rat {f g : monoid_with_zero_hom ℚ M}
+theorem ext_rat {f g : ℚ →*₀ M}
   (same_on_int : f.comp (int.cast_ring_hom ℚ).to_monoid_with_zero_hom =
     g.comp (int.cast_ring_hom ℚ).to_monoid_with_zero_hom) : f = g :=
 begin
@@ -313,7 +313,7 @@ begin
 end
 
 /-- Positive integer values of a morphism `φ` and its value on `-1` completely determine `φ`. -/
-theorem ext_rat_on_pnat {f g : monoid_with_zero_hom ℚ M}
+theorem ext_rat_on_pnat {f g : ℚ →*₀ M}
   (same_on_neg_one : f (-1) = g (-1)) (same_on_pnat : ∀ n : ℕ, 0 < n → f n = g n) : f = g :=
 ext_rat $ ext_int' (by simpa) ‹_›
 

--- a/src/data/real/nnreal.lean
+++ b/src/data/real/nnreal.lean
@@ -714,7 +714,7 @@ end nnreal
 namespace real
 
 /-- The absolute value on `ℝ` as a map to `ℝ≥0`. -/
-@[pp_nodot] noncomputable def nnabs : monoid_with_zero_hom ℝ ℝ≥0 :=
+@[pp_nodot] noncomputable def nnabs : ℝ →*₀ ℝ≥0 :=
 { to_fun := λ x, ⟨|x|, abs_nonneg x⟩,
   map_zero' := by { ext, simp },
   map_one' := by { ext, simp },

--- a/src/data/real/sqrt.lean
+++ b/src/data/real/sqrt.lean
@@ -83,7 +83,7 @@ lemma sqrt_mul (x y : ℝ≥0) : sqrt (x * y) = sqrt x * sqrt y :=
 by rw [sqrt_eq_iff_sq_eq, mul_mul_mul_comm, mul_self_sqrt, mul_self_sqrt]
 
 /-- `nnreal.sqrt` as a `monoid_with_zero_hom`. -/
-noncomputable def sqrt_hom : monoid_with_zero_hom ℝ≥0 ℝ≥0 := ⟨sqrt, sqrt_zero, sqrt_one, sqrt_mul⟩
+noncomputable def sqrt_hom : ℝ≥0 →*₀ ℝ≥0 := ⟨sqrt, sqrt_zero, sqrt_one, sqrt_mul⟩
 
 lemma sqrt_inv (x : ℝ≥0) : sqrt (x⁻¹) = (sqrt x)⁻¹ := sqrt_hom.map_inv x
 

--- a/src/ring_theory/non_zero_divisors.lean
+++ b/src/ring_theory/non_zero_divisors.lean
@@ -109,20 +109,17 @@ lemma mem_non_zero_divisors_iff_ne_zero [no_zero_divisors M] [nontrivial M] {x :
   x ∈ M⁰ ↔ x ≠ 0 :=
 ⟨non_zero_divisors.ne_zero, λ hnx z, eq_zero_of_ne_zero_of_mul_right_eq_zero hnx⟩
 
-lemma monoid_with_zero_hom.map_ne_zero_of_mem_non_zero_divisors [nontrivial M]
-  (g : monoid_with_zero_hom M M') (hg : function.injective g)
-  {x : M} (h : x ∈ M⁰) : g x ≠ 0 :=
+lemma monoid_with_zero_hom.map_ne_zero_of_mem_non_zero_divisors [nontrivial M] (g : M →*₀ M')
+  (hg : function.injective g) {x : M} (h : x ∈ M⁰) : g x ≠ 0 :=
 λ h0, one_ne_zero (h 1 ((one_mul x).symm ▸ (hg (trans h0 g.map_zero.symm))))
 
 lemma ring_hom.map_ne_zero_of_mem_non_zero_divisors {R R' : Type*} [semiring R] [semiring R']
-  [nontrivial R]
-  (g : R →+* R') (hg : function.injective g)
+  [nontrivial R] (g : R →+* R') (hg : function.injective g)
   {x : R} (h : x ∈ R⁰) : g x ≠ 0 :=
 g.to_monoid_with_zero_hom.map_ne_zero_of_mem_non_zero_divisors hg h
 
 lemma monoid_with_zero_hom.map_mem_non_zero_divisors [nontrivial M] [no_zero_divisors M']
-  (g : monoid_with_zero_hom M M') (hg : function.injective g)
-  {x : M} (h : x ∈ M⁰) : g x ∈ M'⁰ :=
+  (g : M →*₀ M') (hg : function.injective g) {x : M} (h : x ∈ M⁰) : g x ∈ M'⁰ :=
 λ z hz, eq_zero_of_ne_zero_of_mul_right_eq_zero
   (g.map_ne_zero_of_mem_non_zero_divisors hg h) hz
 
@@ -141,10 +138,9 @@ lemma powers_le_non_zero_divisors_of_no_zero_divisors [no_zero_divisors M]
   {a : M} (ha : a ≠ 0) : submonoid.powers a ≤ M⁰ :=
 le_non_zero_divisors_of_no_zero_divisors (λ h, absurd (h.rec_on (λ _ hn, pow_eq_zero hn)) ha)
 
-lemma monoid_with_zero_hom.map_le_non_zero_divisors_of_injective
-  [nontrivial M] [no_zero_divisors M']
-  (f : monoid_with_zero_hom M M') (hf : function.injective f)
-  {S : submonoid M} (hS : S ≤ M⁰) : S.map ↑f ≤ M'⁰ :=
+lemma monoid_with_zero_hom.map_le_non_zero_divisors_of_injective [nontrivial M]
+  [no_zero_divisors M'] (f : M →*₀ M') (hf : function.injective f) {S : submonoid M} (hS : S ≤ M⁰) :
+  S.map ↑f ≤ M'⁰ :=
 le_non_zero_divisors_of_no_zero_divisors (λ h, let ⟨x, hx, hx0⟩ := h in
   zero_ne_one (hS (hf (trans hx0 (f.map_zero.symm)) ▸ hx : 0 ∈ S) 1 (mul_zero 1)).symm)
 

--- a/src/ring_theory/valuation/basic.lean
+++ b/src/ring_theory/valuation/basic.lean
@@ -62,7 +62,7 @@ variables (R) (Γ₀ : Type*) [linear_ordered_comm_monoid_with_zero Γ₀] [ring
 
 /-- The type of `Γ₀`-valued valuations on `R`. -/
 @[nolint has_inhabited_instance]
-structure valuation extends monoid_with_zero_hom R Γ₀ :=
+structure valuation extends R →*₀ Γ₀ :=
 (map_add' : ∀ x y, to_fun (x + y) ≤ max (to_fun x) (to_fun y))
 
 /-- The `monoid_with_zero_hom` underlying a valuation. -/
@@ -88,12 +88,12 @@ instance : has_coe_to_fun (valuation R Γ₀) (λ _, R → Γ₀) :=
 { coe := λ v, v.to_monoid_with_zero_hom.to_fun }
 
 /-- A valuation is coerced to a monoid morphism R → Γ₀. -/
-instance : has_coe (valuation R Γ₀) (monoid_with_zero_hom R Γ₀) :=
+instance : has_coe (valuation R Γ₀) (R →*₀ Γ₀) :=
 ⟨valuation.to_monoid_with_zero_hom⟩
 
 variables {R} {Γ₀} (v : valuation R Γ₀) {x y z : R}
 
-@[simp, norm_cast] lemma coe_coe : ((v : monoid_with_zero_hom R Γ₀) : R → Γ₀) = v := rfl
+@[simp, norm_cast] lemma coe_coe : ((v : R →*₀ Γ₀) : R → Γ₀) = v := rfl
 
 @[simp] lemma map_zero : v 0 = 0 := v.map_zero'
 @[simp] lemma map_one  : v 1 = 1 := v.map_one'
@@ -170,7 +170,7 @@ ext $ λ r, rfl
 
 /-- A `≤`-preserving group homomorphism `Γ₀ → Γ'₀` induces a map `valuation R Γ₀ → valuation R Γ'₀`.
 -/
-def map (f : monoid_with_zero_hom Γ₀ Γ'₀) (hf : monotone f) (v : valuation R Γ₀) :
+def map (f : Γ₀ →*₀ Γ'₀) (hf : monotone f) (v : valuation R Γ₀) :
   valuation R Γ'₀ :=
 { to_fun := f ∘ v,
   map_add' := λ r s,
@@ -266,7 +266,7 @@ variables {v₁ : valuation R Γ₀} {v₂ : valuation R Γ'₀} {v₃ : valuati
 lemma of_eq {v' : valuation R Γ₀} (h : v = v') : v.is_equiv v' :=
 by { subst h }
 
-lemma map {v' : valuation R Γ₀} (f : monoid_with_zero_hom Γ₀ Γ'₀) (hf : monotone f)
+lemma map {v' : valuation R Γ₀} (f : Γ₀ →*₀ Γ'₀) (hf : monotone f)
   (inf : injective f) (h : v.is_equiv v') :
   (v.map f hf).is_equiv (v'.map f hf) :=
 let H : strict_mono f := hf.strict_mono_of_injective inf in
@@ -296,9 +296,8 @@ end is_equiv -- end of namespace
 section
 
 lemma is_equiv_of_map_strict_mono [linear_ordered_comm_monoid_with_zero Γ₀]
-  [linear_ordered_comm_monoid_with_zero Γ'₀]
-  [ring R] {v : valuation R Γ₀}
-  (f : monoid_with_zero_hom Γ₀ Γ'₀) (H : strict_mono f) :
+  [linear_ordered_comm_monoid_with_zero Γ'₀] [ring R] {v : valuation R Γ₀} (f : Γ₀ →*₀ Γ'₀)
+  (H : strict_mono f) :
   is_equiv (v.map f (H.monotone)) v :=
 λ x y, ⟨H.le_iff_le.mp, λ h, H.monotone h⟩
 


### PR DESCRIPTION
Introduce notation `→*₀` for `monoid_with_zero_hom` and use it everywhere.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

I think this is a cute notation, but I made it up! So please suggest anything you would prefer (in particular because `₀` is usually used for finitely supported stuff).

Just noted along the way that `valuation` hasn't gone through the hom refactor.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
