### PR TITLE
[Merged by Bors] - feat(data/finset/finsupp): Finitely supported product of finsets

### DIFF
--- a/src/data/finset/finsupp.lean
+++ b/src/data/finset/finsupp.lean
@@ -6,9 +6,9 @@ Authors: Yaël Dillies
 import data.finsupp.basic
 
 /-!
-# Finitely supported produvy of finsets
+# Finitely supported product of finsets
 
-This file defines the finitely supported product of finsets as `finset (ι →₀ α)`.
+This file defines the finitely supported product of finsets as a `finset (ι →₀ α)`.
 
 ## Main declarations
 
@@ -26,7 +26,7 @@ noncomputable theory
 open finsupp
 open_locale big_operators classical pointwise
 
-variables {ι α β : Type*} [has_zero α] {s : finset ι} {f : ι →₀ α}
+variables {ι α : Type*} [has_zero α] {s : finset ι} {f : ι →₀ α}
 
 namespace finset
 

--- a/src/data/finset/finsupp.lean
+++ b/src/data/finset/finsupp.lean
@@ -12,10 +12,8 @@ This file defines the finitely supported product of finsets as `finset (ι →�
 
 ## Main declarations
 
-* `finset.finsupp`: The finitely supported product of finset. `s.sym n` is all the multisets of cardinality `n`
-  whose elements are in `s`.
-* `finset.sym2`: The symmetric square of a finset. `s.sym2` is all the pairs whose elements are in
-  `s`.
+* `finset.finsupp`: The finitely supported product of finsets.
+* `finsupp.pi`: `f.pi` is the finset of `finsupp`s whose `i`-th value lies in `f i`.
 
 ## Implementation notes
 
@@ -67,3 +65,22 @@ end
 (card_map _).trans $ card_pi _ _
 
 end finset
+
+open finset
+
+namespace finsupp
+
+/-- Given a finitely supported function `f : ι →₀ finset α`, one can define the finset
+`f.pi` of all finitely supported functions whose value at `i` is in `f i` for all `i`. -/
+def pi (f : ι →₀ finset α) : finset (ι →₀ α) := f.support.finsupp f
+
+@[simp] lemma mem_pi {f : ι →₀ finset α} {g : ι →₀ α} : g ∈ f.pi ↔ ∀ i, g i ∈ f i :=
+mem_finsupp_iff_of_support_subset $ subset.refl _
+
+@[simp] lemma card_pi (f : ι →₀ finset α) : f.pi.card = f.prod (λ i, (f i).card) :=
+begin
+  rw [pi, card_finsupp],
+  exact finset.prod_congr rfl (λ i _, by simp only [pi.nat_apply, nat.cast_id]),
+end
+
+end finsupp

--- a/src/data/finset/finsupp.lean
+++ b/src/data/finset/finsupp.lean
@@ -3,7 +3,7 @@ Copyright (c) 2022 Yaël Dillies. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yaël Dillies
 -/
-import data.finsupp.basic
+import data.finsupp.indicator
 
 /-!
 # Finitely supported product of finsets
@@ -45,7 +45,6 @@ begin
     exact indicator_of_mem hi _ },
   { refine λ h, ⟨λ i _, f i, mem_pi.2 h.2, _⟩,
     ext i,
-    dsimp,
     exact ite_eq_left_iff.2 (λ hi, (not_mem_support_iff.1 $ λ H, hi $ h.1 H).symm) }
 end
 

--- a/src/data/finset/finsupp.lean
+++ b/src/data/finset/finsupp.lean
@@ -1,0 +1,69 @@
+/-
+Copyright (c) 2022 Yaël Dillies. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Yaël Dillies
+-/
+import data.finsupp.basic
+
+/-!
+# Finitely supported produvy of finsets
+
+This file defines the finitely supported product of finsets as `finset (ι →₀ α)`.
+
+## Main declarations
+
+* `finset.finsupp`: The finitely supported product of finset. `s.sym n` is all the multisets of cardinality `n`
+  whose elements are in `s`.
+* `finset.sym2`: The symmetric square of a finset. `s.sym2` is all the pairs whose elements are in
+  `s`.
+
+## Implementation notes
+
+We make heavy use of the fact that `0 : finset α` is `{0}`. This scalar actions convention turns out
+to be precisely what we want here too.
+-/
+
+noncomputable theory
+
+open finsupp
+open_locale big_operators classical pointwise
+
+variables {ι α β : Type*} [has_zero α] {s : finset ι} {f : ι →₀ α}
+
+namespace finset
+
+/-- Finitely supported product of finsets. -/
+def finsupp (s : finset ι) (t : ι → finset α) : finset (ι →₀ α) :=
+(s.pi t).map ⟨indicator s, indicator_injective s⟩
+
+lemma mem_finsupp_iff {t : ι → finset α} : f ∈ s.finsupp t ↔ f.support ⊆ s ∧ ∀ i ∈ s, f i ∈ t i :=
+begin
+  refine mem_map.trans ⟨_, _⟩,
+  { rintro ⟨f, hf, rfl⟩,
+    refine ⟨support_indicator_subset _ _, λ i hi, _⟩,
+    convert mem_pi.1 hf i hi,
+    exact indicator_of_mem hi _ },
+  { refine λ h, ⟨λ i _, f i, mem_pi.2 h.2, _⟩,
+    ext i,
+    dsimp,
+    exact ite_eq_left_iff.2 (λ hi, (not_mem_support_iff.1 $ λ H, hi $ h.1 H).symm) }
+end
+
+/-- When `t` is supported on `s`, `f ∈ s.finsupp t` precisely means that `f` is pointwise in `t`. -/
+@[simp] lemma mem_finsupp_iff_of_support_subset {t : ι →₀ finset α} (ht : t.support ⊆ s) :
+  f ∈ s.finsupp t ↔ ∀ i, f i ∈ t i :=
+begin
+  refine mem_finsupp_iff.trans (forall_and_distrib.symm.trans $ forall_congr $ λ i, ⟨λ h, _,
+    λ h, ⟨λ hi, ht $ mem_support_iff.2 $ λ H, mem_support_iff.1 hi _, λ _, h⟩⟩),
+  { by_cases hi : i ∈ s,
+    { exact h.2 hi },
+    { rw [not_mem_support_iff.1 (mt h.1 hi), not_mem_support_iff.1 (λ H, hi $ ht H)],
+      exact zero_mem_zero } },
+  { rwa [H, mem_zero] at h }
+end
+
+@[simp] lemma card_finsupp (s : finset ι) (t : ι → finset α) :
+  (s.finsupp t).card = ∏ i in s, (t i).card :=
+(card_map _).trans $ card_pi _ _
+
+end finset

--- a/src/data/finset/finsupp.lean
+++ b/src/data/finset/finsupp.lean
@@ -12,8 +12,10 @@ This file defines the finitely supported product of finsets as a `finset (ι →
 
 ## Main declarations
 
-* `finset.finsupp`: The finitely supported product of finsets.
-* `finsupp.pi`: `f.pi` is the finset of `finsupp`s whose `i`-th value lies in `f i`.
+* `finset.finsupp`: Finitely supported product of finsets. `s.finset t` is the product of the `t i`
+  over all `i ∈ s`.
+* `finsupp.pi`: `f.pi` is the finset of `finsupp`s whose `i`-th value lies in `f i`. This is the
+  special case of `finset.finsupp` where we take the product of the `f i` over the support of `f`.
 
 ## Implementation notes
 
@@ -31,7 +33,7 @@ variables {ι α : Type*} [has_zero α] {s : finset ι} {f : ι →₀ α}
 namespace finset
 
 /-- Finitely supported product of finsets. -/
-def finsupp (s : finset ι) (t : ι → finset α) : finset (ι →₀ α) :=
+protected def finsupp (s : finset ι) (t : ι → finset α) : finset (ι →₀ α) :=
 (s.pi t).map ⟨indicator s, indicator_injective s⟩
 
 lemma mem_finsupp_iff {t : ι → finset α} : f ∈ s.finsupp t ↔ f.support ⊆ s ∧ ∀ i ∈ s, f i ∈ t i :=

--- a/src/data/finsupp/basic.lean
+++ b/src/data/finsupp/basic.lean
@@ -45,7 +45,6 @@ non-pointwise multiplication.
 * `finsupp.update`: Changes one value of a `finsupp`.
 * `finsupp.erase`: Replaces one value of a `finsupp` by `0`.
 * `finsupp.on_finset`: The restriction of a function to a `finset` as a `finsupp`.
-* `finsupp.indicator`: Turns a map from a `finset` into a `finsupp` from the entire type.
 * `finsupp.map_range`: Composition of a `zero_hom` with a`finsupp`.
 * `finsupp.emb_domain`: Maps the domain of a `finsupp` by an embedding.
 * `finsupp.map_domain`: Maps the domain of a `finsupp` by a function and by summing.
@@ -426,46 +425,6 @@ lemma support_update_ne_zero [decidable_eq α] (h : b ≠ 0) :
   support (f.update a b) = insert a f.support := by convert if_neg h
 
 end update
-
-/-! ### `indicator` -/
-
-section indicator
-variables [has_zero α] {s : finset ι} (f : Π i ∈ s, α) {i : ι}
-
-/-- Create an element of `ι →₀ α` from a finset `s` and a function `f` defined on this finset. -/
-def indicator (s : finset ι) (f : Π i ∈ s, α) : ι →₀ α :=
-{ to_fun := λ i, if H : i ∈ s then f i H else 0,
-  support := (s.attach.filter $ λ i : s, f i.1 i.2 ≠ 0).map $ embedding.subtype _,
-  mem_support_to_fun := λ i, begin
-    rw [mem_map, dite_ne_right_iff],
-    exact ⟨λ ⟨⟨j, hj⟩, hf, rfl⟩, ⟨hj, (mem_filter.1 hf).2⟩,
-      λ ⟨hi, hf⟩, ⟨⟨i, hi⟩, mem_filter.2 $ ⟨mem_attach _ _, hf⟩, rfl⟩⟩,
-  end }
-
-lemma indicator_of_mem (hi : i ∈ s) (f : Π i ∈ s, α) : indicator s f i = f i hi := dif_pos hi
-lemma indicator_of_not_mem (hi : i ∉ s) (f : Π i ∈ s, α) : indicator s f i = 0 := dif_neg hi
-
-variables (s i)
-
-@[simp] lemma indicator_apply : indicator s f i = if hi : i ∈ s then f i hi else 0 := rfl
-
-lemma indicator_injective : injective (λ f : Π i ∈ s, α, indicator s f) :=
-begin
-  intros a b h,
-  ext i hi,
-  rw [←indicator_of_mem hi a, ←indicator_of_mem hi b],
-  exact congr_fun h i,
-end
-
-lemma support_indicator_subset : ((indicator s f).support : set ι) ⊆ s :=
-begin
-  intros i hi,
-  rw [mem_coe, mem_support_iff] at hi,
-  by_contra,
-  exact hi (indicator_of_not_mem h _),
-end
-
-end indicator
 
 /-! ### Declarations about `on_finset` -/
 

--- a/src/data/finsupp/basic.lean
+++ b/src/data/finsupp/basic.lean
@@ -48,7 +48,7 @@ non-pointwise multiplication.
 * `finsupp.indicator`: Turns a map from a `finset` into a `finsupp` from the entire type.
 * `finsupp.map_range`: Composition of a `zero_hom` with a`finsupp`.
 * `finsupp.emb_domain`: Maps the domain of a `finsupp` by an embedding.
-* `finsupp.map_domain`: Maps the domain of a `finsupp` by a function and by summing .
+* `finsupp.map_domain`: Maps the domain of a `finsupp` by a function and by summing.
 * `finsupp.comap_domain`: Postcomposition of a `finsupp` with a function injective on the preimage
   of its support.
 * `finsupp.zip_with`: Postcomposition of two `finsupp`s with a function `f` such that `f 0 0 = 0`.

--- a/src/data/finsupp/indicator.lean
+++ b/src/data/finsupp/indicator.lean
@@ -1,0 +1,61 @@
+/-
+Copyright (c) 2022 Yaël Dillies. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Yaël Dillies
+-/
+import data.finsupp.basic
+
+/-!
+# Building finitely supported functions off finsets
+
+This file defines `finsupp.indicator` to help create finsupps from finsets.
+
+## Main declarations
+
+* `finsupp.indicator`: Turns a map from a `finset` into a `finsupp` from the entire type.
+-/
+
+noncomputable theory
+
+open finset function
+open_locale classical
+
+variables {ι α : Type*}
+
+namespace finsupp
+variables [has_zero α] {s : finset ι} (f : Π i ∈ s, α) {i : ι}
+
+/-- Create an element of `ι →₀ α` from a finset `s` and a function `f` defined on this finset. -/
+def indicator (s : finset ι) (f : Π i ∈ s, α) : ι →₀ α :=
+{ to_fun := λ i, if H : i ∈ s then f i H else 0,
+  support := (s.attach.filter $ λ i : s, f i.1 i.2 ≠ 0).map $ embedding.subtype _,
+  mem_support_to_fun := λ i, begin
+    rw [mem_map, dite_ne_right_iff],
+    exact ⟨λ ⟨⟨j, hj⟩, hf, rfl⟩, ⟨hj, (mem_filter.1 hf).2⟩,
+      λ ⟨hi, hf⟩, ⟨⟨i, hi⟩, mem_filter.2 $ ⟨mem_attach _ _, hf⟩, rfl⟩⟩,
+  end }
+
+lemma indicator_of_mem (hi : i ∈ s) (f : Π i ∈ s, α) : indicator s f i = f i hi := dif_pos hi
+lemma indicator_of_not_mem (hi : i ∉ s) (f : Π i ∈ s, α) : indicator s f i = 0 := dif_neg hi
+
+variables (s i)
+
+@[simp] lemma indicator_apply : indicator s f i = if hi : i ∈ s then f i hi else 0 := rfl
+
+lemma indicator_injective : injective (λ f : Π i ∈ s, α, indicator s f) :=
+begin
+  intros a b h,
+  ext i hi,
+  rw [←indicator_of_mem hi a, ←indicator_of_mem hi b],
+  exact congr_fun h i,
+end
+
+lemma support_indicator_subset : ((indicator s f).support : set ι) ⊆ s :=
+begin
+  intros i hi,
+  rw [mem_coe, mem_support_iff] at hi,
+  by_contra,
+  exact hi (indicator_of_not_mem h _),
+end
+
+end finsupp


### PR DESCRIPTION
Define
* `finsupp.indicator`: Similar to `finsupp.on_finset` except that it only requires a partially defined function. This is more compatible with `finset.pi`.
* `finset.finsupp : finset ι → (ι → finset α) → finset (ι →₀ α)`: Finitely supported product of finsets.
* `finsupp.pi : (ι →₀ finset α) → finset (ι →₀ α)`: The set of finitely supported functions whose `i`-th value lies in the `i`-th of a given `finset`-valued `finsupp`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

This is categorically pleasing.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
