### PR TITLE
[Merged by Bors] - doc(algebra,data/fun_like): small morphism documentation improvements

### DIFF
--- a/src/algebra/group/hom.lean
+++ b/src/algebra/group/hom.lean
@@ -458,52 +458,6 @@ lemma monoid_with_zero_hom.to_monoid_hom_coe [mul_zero_one_class M] [mul_zero_on
   (f : M →*₀ N) :
   (f.to_monoid_hom : M → N) = f := rfl
 
-@[to_additive]
-theorem one_hom.congr_fun [has_one M] [has_one N]
-  {f g : one_hom M N} (h : f = g) (x : M) : f x = g x :=
-congr_arg (λ h : one_hom M N, h x) h
-@[to_additive]
-theorem mul_hom.congr_fun [has_mul M] [has_mul N]
-  {f g : mul_hom M N} (h : f = g) (x : M) : f x = g x :=
-congr_arg (λ h : mul_hom M N, h x) h
-@[to_additive]
-theorem monoid_hom.congr_fun [mul_one_class M] [mul_one_class N]
-  {f g : M →* N} (h : f = g) (x : M) : f x = g x :=
-congr_arg (λ h : M →* N, h x) h
-theorem monoid_with_zero_hom.congr_fun [mul_zero_one_class M] [mul_zero_one_class N] {f g : M →*₀ N}
-  (h : f = g) (x : M) : f x = g x :=
-congr_arg (λ h : M →*₀ N, h x) h
-
-@[to_additive]
-theorem one_hom.congr_arg [has_one M] [has_one N]
-  (f : one_hom M N) {x y : M} (h : x = y) : f x = f y :=
-congr_arg (λ x : M, f x) h
-@[to_additive]
-theorem mul_hom.congr_arg [has_mul M] [has_mul N]
-  (f : mul_hom M N) {x y : M} (h : x = y) : f x = f y :=
-congr_arg (λ x : M, f x) h
-@[to_additive]
-theorem monoid_hom.congr_arg [mul_one_class M] [mul_one_class N]
-  (f : M →* N) {x y : M} (h : x = y) : f x = f y :=
-congr_arg (λ x : M, f x) h
-theorem monoid_with_zero_hom.congr_arg [mul_zero_one_class M] [mul_zero_one_class N] (f : M →*₀ N)
-  {x y : M} (h : x = y) : f x = f y :=
-congr_arg (λ x : M, f x) h
-
-@[to_additive]
-lemma one_hom.coe_inj [has_one M] [has_one N] ⦃f g : one_hom M N⦄ (h : (f : M → N) = g) : f = g :=
-by cases f; cases g; cases h; refl
-@[to_additive]
-lemma mul_hom.coe_inj [has_mul M] [has_mul N] ⦃f g : mul_hom M N⦄ (h : (f : M → N) = g) : f = g :=
-by cases f; cases g; cases h; refl
-@[to_additive]
-lemma monoid_hom.coe_inj [mul_one_class M] [mul_one_class N]
-  ⦃f g : M →* N⦄ (h : (f : M → N) = g) : f = g :=
-by cases f; cases g; cases h; refl
-lemma monoid_with_zero_hom.coe_inj [mul_zero_one_class M] [mul_zero_one_class N]
-  ⦃f g : M →*₀ N⦄ (h : (f : M → N) = g) : f = g :=
-by cases f; cases g; cases h; refl
-
 @[ext, to_additive]
 lemma one_hom.ext [has_one M] [has_one N] ⦃f g : one_hom M N⦄ (h : ∀ x, f x = g x) : f = g :=
 one_hom.coe_inj (funext h)
@@ -519,19 +473,84 @@ lemma monoid_with_zero_hom.ext [mul_zero_one_class M] [mul_zero_one_class N] ⦃
   (h : ∀ x, f x = g x) : f = g :=
 monoid_with_zero_hom.coe_inj (funext h)
 
+section deprecated
+
+/-- Deprecated: use `fun_like.congr_fun` instead. -/
+@[to_additive]
+theorem one_hom.congr_fun [has_one M] [has_one N]
+  {f g : one_hom M N} (h : f = g) (x : M) : f x = g x :=
+congr_arg (λ h : one_hom M N, h x) h
+/-- Deprecated: use `fun_like.congr_fun` instead. -/
+@[to_additive]
+theorem mul_hom.congr_fun [has_mul M] [has_mul N]
+  {f g : mul_hom M N} (h : f = g) (x : M) : f x = g x :=
+congr_arg (λ h : mul_hom M N, h x) h
+/-- Deprecated: use `fun_like.congr_fun` instead. -/
+@[to_additive]
+theorem monoid_hom.congr_fun [mul_one_class M] [mul_one_class N]
+  {f g : M →* N} (h : f = g) (x : M) : f x = g x :=
+congr_arg (λ h : M →* N, h x) h
+/-- Deprecated: use `fun_like.congr_fun` instead. -/
+theorem monoid_with_zero_hom.congr_fun [mul_zero_one_class M] [mul_zero_one_class N] {f g : M →*₀ N}
+  (h : f = g) (x : M) : f x = g x :=
+congr_arg (λ h : M →*₀ N, h x) h
+
+/-- Deprecated: use `fun_like.congr_arg` instead. -/
+@[to_additive]
+theorem one_hom.congr_arg [has_one M] [has_one N]
+  (f : one_hom M N) {x y : M} (h : x = y) : f x = f y :=
+congr_arg (λ x : M, f x) h
+/-- Deprecated: use `fun_like.congr_arg` instead. -/
+@[to_additive]
+theorem mul_hom.congr_arg [has_mul M] [has_mul N]
+  (f : mul_hom M N) {x y : M} (h : x = y) : f x = f y :=
+congr_arg (λ x : M, f x) h
+/-- Deprecated: use `fun_like.congr_arg` instead. -/
+@[to_additive]
+theorem monoid_hom.congr_arg [mul_one_class M] [mul_one_class N]
+  (f : M →* N) {x y : M} (h : x = y) : f x = f y :=
+congr_arg (λ x : M, f x) h
+/-- Deprecated: use `fun_like.congr_arg` instead. -/
+theorem monoid_with_zero_hom.congr_arg [mul_zero_one_class M] [mul_zero_one_class N] (f : M →*₀ N)
+  {x y : M} (h : x = y) : f x = f y :=
+congr_arg (λ x : M, f x) h
+
+/-- Deprecated: use `fun_like.coe_injective` instead. -/
+@[to_additive]
+lemma one_hom.coe_inj [has_one M] [has_one N] ⦃f g : one_hom M N⦄ (h : (f : M → N) = g) : f = g :=
+by cases f; cases g; cases h; refl
+/-- Deprecated: use `fun_like.coe_injective` instead. -/
+@[to_additive]
+lemma mul_hom.coe_inj [has_mul M] [has_mul N] ⦃f g : mul_hom M N⦄ (h : (f : M → N) = g) : f = g :=
+by cases f; cases g; cases h; refl
+/-- Deprecated: use `fun_like.coe_injective` instead. -/
+@[to_additive]
+lemma monoid_hom.coe_inj [mul_one_class M] [mul_one_class N]
+  ⦃f g : M →* N⦄ (h : (f : M → N) = g) : f = g :=
+by cases f; cases g; cases h; refl
+/-- Deprecated: use `fun_like.coe_injective` instead. -/
+lemma monoid_with_zero_hom.coe_inj [mul_zero_one_class M] [mul_zero_one_class N]
+  ⦃f g : M →*₀ N⦄ (h : (f : M → N) = g) : f = g :=
+by cases f; cases g; cases h; refl
+
+/-- Deprecated: use `fun_like.ext_iff` instead. -/
 @[to_additive]
 lemma one_hom.ext_iff [has_one M] [has_one N] {f g : one_hom M N} : f = g ↔ ∀ x, f x = g x :=
 ⟨λ h x, h ▸ rfl, λ h, one_hom.ext h⟩
+/-- Deprecated: use `fun_like.ext_iff` instead. -/
 @[to_additive]
 lemma mul_hom.ext_iff [has_mul M] [has_mul N] {f g : mul_hom M N} : f = g ↔ ∀ x, f x = g x :=
 ⟨λ h x, h ▸ rfl, λ h, mul_hom.ext h⟩
 @[to_additive]
+/-- Deprecated: use `fun_like.ext_iff` instead. -/
 lemma monoid_hom.ext_iff [mul_one_class M] [mul_one_class N]
   {f g : M →* N} : f = g ↔ ∀ x, f x = g x :=
 ⟨λ h x, h ▸ rfl, λ h, monoid_hom.ext h⟩
+/-- Deprecated: use `fun_like.ext_iff` instead. -/
 lemma monoid_with_zero_hom.ext_iff [mul_zero_one_class M] [mul_zero_one_class N] {f g : M →*₀ N} :
   f = g ↔ ∀ x, f x = g x :=
 ⟨λ h x, h ▸ rfl, λ h, monoid_with_zero_hom.ext h⟩
+end deprecated
 
 @[simp, to_additive]
 lemma one_hom.mk_coe [has_one M] [has_one N]

--- a/src/algebra/group/hom.lean
+++ b/src/algebra/group/hom.lean
@@ -460,18 +460,18 @@ lemma monoid_with_zero_hom.to_monoid_hom_coe [mul_zero_one_class M] [mul_zero_on
 
 @[ext, to_additive]
 lemma one_hom.ext [has_one M] [has_one N] ⦃f g : one_hom M N⦄ (h : ∀ x, f x = g x) : f = g :=
-one_hom.coe_inj (funext h)
+fun_like.ext _ _ h
 @[ext, to_additive]
 lemma mul_hom.ext [has_mul M] [has_mul N] ⦃f g : mul_hom M N⦄ (h : ∀ x, f x = g x) : f = g :=
-mul_hom.coe_inj (funext h)
+fun_like.ext _ _ h
 @[ext, to_additive]
 lemma monoid_hom.ext [mul_one_class M] [mul_one_class N]
   ⦃f g : M →* N⦄ (h : ∀ x, f x = g x) : f = g :=
-monoid_hom.coe_inj (funext h)
+fun_like.ext _ _ h
 @[ext]
 lemma monoid_with_zero_hom.ext [mul_zero_one_class M] [mul_zero_one_class N] ⦃f g : M →*₀ N⦄
   (h : ∀ x, f x = g x) : f = g :=
-monoid_with_zero_hom.coe_inj (funext h)
+fun_like.ext _ _ h
 
 section deprecated
 
@@ -479,77 +479,77 @@ section deprecated
 @[to_additive]
 theorem one_hom.congr_fun [has_one M] [has_one N]
   {f g : one_hom M N} (h : f = g) (x : M) : f x = g x :=
-congr_arg (λ h : one_hom M N, h x) h
+fun_like.congr_fun h x
 /-- Deprecated: use `fun_like.congr_fun` instead. -/
 @[to_additive]
 theorem mul_hom.congr_fun [has_mul M] [has_mul N]
   {f g : mul_hom M N} (h : f = g) (x : M) : f x = g x :=
-congr_arg (λ h : mul_hom M N, h x) h
+fun_like.congr_fun h x
 /-- Deprecated: use `fun_like.congr_fun` instead. -/
 @[to_additive]
 theorem monoid_hom.congr_fun [mul_one_class M] [mul_one_class N]
   {f g : M →* N} (h : f = g) (x : M) : f x = g x :=
-congr_arg (λ h : M →* N, h x) h
+fun_like.congr_fun h x
 /-- Deprecated: use `fun_like.congr_fun` instead. -/
 theorem monoid_with_zero_hom.congr_fun [mul_zero_one_class M] [mul_zero_one_class N] {f g : M →*₀ N}
   (h : f = g) (x : M) : f x = g x :=
-congr_arg (λ h : M →*₀ N, h x) h
+fun_like.congr_fun h x
 
 /-- Deprecated: use `fun_like.congr_arg` instead. -/
 @[to_additive]
 theorem one_hom.congr_arg [has_one M] [has_one N]
   (f : one_hom M N) {x y : M} (h : x = y) : f x = f y :=
-congr_arg (λ x : M, f x) h
+fun_like.congr_arg f h
 /-- Deprecated: use `fun_like.congr_arg` instead. -/
 @[to_additive]
 theorem mul_hom.congr_arg [has_mul M] [has_mul N]
   (f : mul_hom M N) {x y : M} (h : x = y) : f x = f y :=
-congr_arg (λ x : M, f x) h
+fun_like.congr_arg f h
 /-- Deprecated: use `fun_like.congr_arg` instead. -/
 @[to_additive]
 theorem monoid_hom.congr_arg [mul_one_class M] [mul_one_class N]
   (f : M →* N) {x y : M} (h : x = y) : f x = f y :=
-congr_arg (λ x : M, f x) h
+fun_like.congr_arg f h
 /-- Deprecated: use `fun_like.congr_arg` instead. -/
 theorem monoid_with_zero_hom.congr_arg [mul_zero_one_class M] [mul_zero_one_class N] (f : M →*₀ N)
   {x y : M} (h : x = y) : f x = f y :=
-congr_arg (λ x : M, f x) h
+fun_like.congr_arg f h
 
 /-- Deprecated: use `fun_like.coe_injective` instead. -/
 @[to_additive]
 lemma one_hom.coe_inj [has_one M] [has_one N] ⦃f g : one_hom M N⦄ (h : (f : M → N) = g) : f = g :=
-by cases f; cases g; cases h; refl
+fun_like.coe_injective h
 /-- Deprecated: use `fun_like.coe_injective` instead. -/
 @[to_additive]
 lemma mul_hom.coe_inj [has_mul M] [has_mul N] ⦃f g : mul_hom M N⦄ (h : (f : M → N) = g) : f = g :=
-by cases f; cases g; cases h; refl
+fun_like.coe_injective h
 /-- Deprecated: use `fun_like.coe_injective` instead. -/
 @[to_additive]
 lemma monoid_hom.coe_inj [mul_one_class M] [mul_one_class N]
   ⦃f g : M →* N⦄ (h : (f : M → N) = g) : f = g :=
-by cases f; cases g; cases h; refl
+fun_like.coe_injective h
 /-- Deprecated: use `fun_like.coe_injective` instead. -/
 lemma monoid_with_zero_hom.coe_inj [mul_zero_one_class M] [mul_zero_one_class N]
   ⦃f g : M →*₀ N⦄ (h : (f : M → N) = g) : f = g :=
-by cases f; cases g; cases h; refl
+fun_like.coe_injective h
 
 /-- Deprecated: use `fun_like.ext_iff` instead. -/
 @[to_additive]
 lemma one_hom.ext_iff [has_one M] [has_one N] {f g : one_hom M N} : f = g ↔ ∀ x, f x = g x :=
-⟨λ h x, h ▸ rfl, λ h, one_hom.ext h⟩
+fun_like.ext_iff
 /-- Deprecated: use `fun_like.ext_iff` instead. -/
 @[to_additive]
 lemma mul_hom.ext_iff [has_mul M] [has_mul N] {f g : mul_hom M N} : f = g ↔ ∀ x, f x = g x :=
-⟨λ h x, h ▸ rfl, λ h, mul_hom.ext h⟩
-@[to_additive]
+fun_like.ext_iff
 /-- Deprecated: use `fun_like.ext_iff` instead. -/
+@[to_additive]
 lemma monoid_hom.ext_iff [mul_one_class M] [mul_one_class N]
   {f g : M →* N} : f = g ↔ ∀ x, f x = g x :=
-⟨λ h x, h ▸ rfl, λ h, monoid_hom.ext h⟩
+fun_like.ext_iff
 /-- Deprecated: use `fun_like.ext_iff` instead. -/
 lemma monoid_with_zero_hom.ext_iff [mul_zero_one_class M] [mul_zero_one_class N] {f g : M →*₀ N} :
   f = g ↔ ∀ x, f x = g x :=
-⟨λ h x, h ▸ rfl, λ h, monoid_with_zero_hom.ext h⟩
+fun_like.ext_iff
 end deprecated
 
 @[simp, to_additive]

--- a/src/algebra/module/linear_map.lean
+++ b/src/algebra/module/linear_map.lean
@@ -118,7 +118,8 @@ instance : add_monoid_hom_class (M →ₛₗ[σ] M₃) M M₃ :=
 def to_distrib_mul_action_hom (f : M →ₗ[R] M₂) : distrib_mul_action_hom R M M₂ :=
 { map_zero' := show f 0 = 0, from map_zero f, ..f }
 
-/-- Helper instance for when there's too many metavariables to apply `to_fun.to_coe_fn` directly.
+/-- Helper instance for when there's too many metavariables to apply `fun_like.has_coe_to_fun`
+directly.
 -/
 instance : has_coe_to_fun (M →ₛₗ[σ] M₃) (λ _, M → M₃) := ⟨linear_map.to_fun⟩
 

--- a/src/algebra/ring/basic.lean
+++ b/src/algebra/ring/basic.lean
@@ -394,7 +394,8 @@ instance : ring_hom_class (α →+* β) α β :=
   map_mul := ring_hom.map_mul',
   map_one := ring_hom.map_one' }
 
-/-- Helper instance for when there's too many metavariables to apply `to_fun.to_coe_fn` directly.
+/-- Helper instance for when there's too many metavariables to apply `fun_like.has_coe_to_fun`
+directly.
 -/
 instance : has_coe_to_fun (α →+* β) (λ _, α → β) := ⟨ring_hom.to_fun⟩
 

--- a/src/analysis/normed_space/linear_isometry.lean
+++ b/src/analysis/normed_space/linear_isometry.lean
@@ -67,7 +67,8 @@ instance : add_monoid_hom_class (E →ₛₗᵢ[σ₁₂] E₂) E E₂ :=
   map_add := λ f, map_add f.to_linear_map,
   map_zero := λ f, map_zero f.to_linear_map }
 
-/-- Helper instance for when there's too many metavariables to apply `to_fun.to_coe_fn` directly.
+/-- Helper instance for when there's too many metavariables to apply `fun_like.has_coe_to_fun`
+directly.
 -/
 instance : has_coe_to_fun (E →ₛₗᵢ[σ₁₂] E₂) (λ _, E → E₂) := ⟨λ f, f.to_fun⟩
 
@@ -266,7 +267,8 @@ instance : add_monoid_hom_class (E ≃ₛₗᵢ[σ₁₂] E₂) E E₂ :=
   map_add := λ f, map_add f.to_linear_equiv,
   map_zero := λ f, map_zero f.to_linear_equiv }
 
-/-- Helper instance for when there's too many metavariables to apply `to_fun.to_coe_fn` directly.
+/-- Helper instance for when there's too many metavariables to apply `fun_like.has_coe_to_fun`
+directly.
 -/
 instance : has_coe_to_fun (E ≃ₛₗᵢ[σ₁₂] E₂) (λ _, E → E₂) := ⟨λ f, f.to_fun⟩
 

--- a/src/analysis/seminorm.lean
+++ b/src/analysis/seminorm.lean
@@ -333,7 +333,7 @@ variables [has_scalar 𝕜 E]
 instance fun_like : fun_like (seminorm 𝕜 E) E (λ _, ℝ) :=
 { coe := seminorm.to_fun, coe_injective' := λ f g h, by cases f; cases g; congr' }
 
-/-- Helper instance for when there's too many metavariables to apply `to_fun.to_coe_fn`. -/
+/-- Helper instance for when there's too many metavariables to apply `fun_like.has_coe_to_fun`. -/
 instance : has_coe_to_fun (seminorm 𝕜 E) (λ _, E → ℝ) := ⟨λ p, p.to_fun⟩
 
 @[ext] lemma ext {p q : seminorm 𝕜 E} (h : ∀ x, (p : E → ℝ) x = q x) : p = q := fun_like.ext p q h

--- a/src/data/fun_like/basic.lean
+++ b/src/data/fun_like/basic.lean
@@ -29,8 +29,9 @@ variables (A B : Type*) [my_class A] [my_class B]
 instance : fun_like (my_hom A B) A (λ _, B) :=
 { coe := my_hom.to_fun, coe_injective' := λ f g h, by cases f; cases g; congr' }
 
-/-- Helper instance for when there's too many metavariables to apply `to_fun.to_coe_fn` directly. -/
-instance : has_coe_to_fun (my_hom A B) (λ _, A → B) := to_fun.to_coe_fn
+/-- Helper instance for when there's too many metavariables to apply
+`fun_like.has_coe_to_fun` directly. -/
+instance : has_coe_to_fun (my_hom A B) (λ _, A → B) := fun_like.has_coe_to_fun
 
 @[simp] lemma to_fun_eq_coe {f : my_hom A B} : f.to_fun = (f : A → B) := rfl
 

--- a/src/ring_theory/derivation.lean
+++ b/src/ring_theory/derivation.lean
@@ -57,7 +57,8 @@ instance : add_monoid_hom_class (derivation R A M) A M :=
   map_add := λ D, D.to_linear_map.map_add',
   map_zero := λ D, D.to_linear_map.map_zero }
 
-/-- Helper instance for when there's too many metavariables to apply `to_fun.to_coe_fn` directly. -/
+/-- Helper instance for when there's too many metavariables to apply `fun_like.has_coe_to_fun`
+directly. -/
 instance : has_coe_to_fun (derivation R A M) (λ _, A → M) := ⟨λ D, D.to_linear_map.to_fun⟩
 
 -- Not a simp lemma because it can be proved via `coe_fn_coe` + `to_linear_map_eq_coe`


### PR DESCRIPTION
 * The `fun_like` docs talked about a `to_fun` class, this doesn't exist (anymore).
 * Warn that `{one,mul,monoid,monoid_with_zero}_hom.{congr_fun,congr_arg,coe_inj,ext_iff}` has been superseded by `fun_like`.

Thanks to @YaelDillies for pointing out these issues.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
