### PR TITLE
[Merged by Bors] - chore(probability_theory/stopping): fix names in documentation

### DIFF
--- a/src/probability_theory/stopping.lean
+++ b/src/probability_theory/stopping.lean
@@ -20,10 +20,10 @@ at a specific time and is the first step in formalizing stochastic processes.
   filtration `f` if at each point in time `i`, `u i` is `f i`-measurable
 * `measure_theory.filtration.natural`: the natural filtration with respect to a sequence of
   measurable functions is the smallest filtration to which it is adapted to
-* `measure_theory.stopping_time`: a stopping time with respect to some filtration `f` is a
+* `measure_theory.is_stopping_time`: a stopping time with respect to some filtration `f` is a
   function `τ` such that for all `i`, the preimage of `{j | j ≤ i}` along `τ` is
   `f i`-measurable
-* `measure_theory.stopping_time.measurable_space`: the σ-algebra associated with a stopping time
+* `measure_theory.is_stopping_time.measurable_space`: the σ-algebra associated with a stopping time
 
 ## Tags
 


### PR DESCRIPTION
---
https://leanprover-community.github.io/mathlib_docs/probability_theory/stopping.html
does not link to `is_stopping_time` and `is_stopping_time.measurable_space` correctly. 

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
