### PR TITLE
[Merged by Bors] - feat(tactic/linear_combination): add tactic for combining equations

### DIFF
--- a/src/tactic/linear_combination.lean
+++ b/src/tactic/linear_combination.lean
@@ -346,13 +346,12 @@ meta def parse_name_pexpr_pair : lean.parser (name × pexpr) :=
 
 Note: The left and right sides of all the equalities should have the same
   type, and the coefficients should also have this type.  There must be
-  instances of `has_mul` and `add_group` for this type.  Also note that the
-  target must involve at least one variable.
+  instances of `has_mul` and `add_group` for this type.
 
 * Input:
-  * `input` : the pairs of hypotheses and their corresponding coefficients
-      if no coefficient is given with a hypothesis, then the coefficient for
-      that hypothesis will be set to 1
+  * `input` : the pairs of hypotheses and their corresponding coefficients.
+      If no coefficient is given with a hypothesis, then the coefficient for
+      that hypothesis will be set to 1.
   * `config` : a linear_combination_config, which determines the tactic used
       for normalization; by default, this value is the standard configuration
       for a linear_combination_config.  In the standard configuration,

--- a/src/tactic/linear_combination.lean
+++ b/src/tactic/linear_combination.lean
@@ -5,7 +5,6 @@ Authors: Abby J. Goldberg
 -/
 
 import tactic.ring
-open tactic
 
 /-!
 
@@ -35,6 +34,7 @@ to the target.
 -/
 
 namespace linear_combo
+open tactic
 
 /-! ### Lemmas -/
 

--- a/src/tactic/linear_combination.lean
+++ b/src/tactic/linear_combination.lean
@@ -68,7 +68,7 @@ A configuration object for `linear_combination`.
 `normalize` describes whether or not the normalization step should be used.
 
 `normalization_tactic` describes the tactic used for normalization when
-checking if the weighted sum is equivalent to the goal (when `normalize` is tt).
+checking if the weighted sum is equivalent to the goal (when `normalize` is `tt`).
 -/
 meta structure linear_combination_config : Type :=
 (normalize : bool := tt)
@@ -79,15 +79,15 @@ meta structure linear_combination_config : Type :=
 
 
 /--
-Given that lhs = rhs, this tactic returns an expr proving that
-  coeff * lhs = coeff * rhs.
+Given that `lhs = rhs`, this tactic returns an `expr` proving that
+  `coeff * lhs = coeff * rhs`.
 
 * Input:
-  * `h_equality` : an expr, whose type should be an equality between terms of
-      type α, where there is an instance of `has_mul α`
-  * `coeff` : a pexpr, which should be a value of type α
+  * `h_equality` : an `expr`, whose type should be an equality between terms of
+      type `α`, where there is an instance of `has_mul α`
+  * `coeff` : a `pexpr`, which should be a value of type `α`
 
-* Output: a tactic expr, which proves that the result of multiplying both sides
+* Output: an `expr`, which proves that the result of multiplying both sides
     of `h_equality` by the `coeff` holds
 -/
 meta def mul_equality_expr (h_equality : expr) (coeff : pexpr) : tactic expr :=
@@ -100,33 +100,33 @@ do
   mk_app ``left_mul_both_sides [coeff_expr, h_equality]
 
 /--
-Given two hypotheses that a = b and c = d, this tactic returns an expr proving
-  that a + c = b + d.
+Given two hypotheses that `a = b` and `c = d`, this tactic returns an `expr` proving
+  that `a + c = b + d`.
 
 * Input:
-  * `h_equality1` : an expr, whose type should be an equality between terms of
-      type α, where there is an instance of `has_add α`
-  * `h_equality2` : an expr, whose type should be an equality between terms of
-      type α
+  * `h_equality1` : an `expr`, whose type should be an equality between terms of
+      type `α`, where there is an instance of `has_add α`
+  * `h_equality2` : an `expr`, whose type should be an equality between terms of
+      type `α`
 
-* Output: a tactic expr, which proves that the result of adding the two
+* Output: an `expr`, which proves that the result of adding the two
     equalities holds
 -/
 meta def sum_equalities (h_equality1 h_equality2 : expr) : tactic expr :=
 mk_app ``sum_two_equations [h_equality1, h_equality2]
 
 /--
-Given that a = b and c = d, along with a coefficient, this tactic returns an
-  expr proving that a + coeff * c = b + coeff * d.
+Given that `a = b` and `c = d`, along with a coefficient, this tactic returns an
+  `expr` proving that `a + coeff * c = b + coeff * d`.
 
 * Input:
-  * `h_equality1` : an expr, whose type should be an equality between terms of
-      type α, where there are instances of `has_add α` and `has_mul α`
-  * `h_equality2` : an expr, whose type should be an equality between terms of
-      type α
-  * `coeff_for_eq2` : a pexpr, which should be a value of type α
+  * `h_equality1` : an `expr`, whose type should be an equality between terms of
+      type `α`, where there are instances of `has_add α` and `has_mul α`
+  * `h_equality2` : an `expr`, whose type should be an equality between terms of
+      type `α`
+  * `coeff_for_eq2` : a `pexpr`, which should be a value of type `α`
 
-* Output: a tactic expr, which proves that the result of adding the first
+* Output: an `expr`, which proves that the result of adding the first
   equality to the result of multiplying `coeff_for_eq2` by the second equality
   holds
 -/
@@ -135,19 +135,19 @@ meta def sum_two_hyps_one_mul_helper (h_equality1 h_equality2 : expr)
 mul_equality_expr h_equality2 coeff_for_eq2 >>= sum_equalities h_equality1
 
 /--
-Given that l_sum1 = r_sum1, l_h1 = r_h1, ..., l_hn = r_hn, and given
-  coefficients c_1, ..., c_n, this tactic returns an expr proving that
-    l_sum1 + (c_1 * l_h1) + ... + (c_n * l_hn)
-  = r_sum1 + (c_1 * r_h1) + ... + (c_n * r_hn)
+Given that `l_sum1 = r_sum1`, `l_h1 = r_h1`, ..., `l_hn = r_hn`, and given
+  coefficients `c_1`, ..., `c_n`, this tactic returns an `expr` proving that
+    `l_sum1 + (c_1 * l_h1) + ... + (c_n * l_hn)`
+  `= r_sum1 + (c_1 * r_h1) + ... + (c_n * r_hn)`
 
 * Input:
-  * an option (tactic expr) : `none`, if there is no sum to add to yet, or
+  * an `option (tactic expr)` : `none`, if there is no sum to add to yet, or
       `some` containing the base summation equation
-  * a list name : a list of names, referring to equalities in the local context
-  * a list pexpr : a list of coefficients to be multiplied with the
+  * a `list name` : a list of names, referring to equalities in the local context
+  * a `list pexpr` : a list of coefficients to be multiplied with the
       corresponding equalities in the list of names
 
-* Output: a tactic expr, which proves that the weighted sum of the given
+* Output: an `expr`, which proves that the weighted sum of the given
     equalities added to the base equation holds
 -/
 meta def make_sum_of_hyps_helper :
@@ -189,7 +189,7 @@ Given a list of names referencing equalities and a list of pexprs representing
   * `coeffs` : a list of coefficients to be multiplied with the corresponding
       equalities in the list of names
 
-* Output: a `tactic expr`, which proves that the weighted sum of the equalities
+* Output: an `expr`, which proves that the weighted sum of the equalities
     holds
 -/
 meta def make_sum_of_hyps (h_eqs_names : list name) (coeffs : list pexpr) :
@@ -203,14 +203,14 @@ make_sum_of_hyps_helper none h_eqs_names coeffs
 /--
 This tactic proves that the result of moving all the terms in an equality to
   the left side of the equals sign by subtracting the right side of the
-  equation from the left side holds.  In other words, given lhs = rhs,
-  this tactic proves that lhs - rhs = 0.
+  equation from the left side holds.  In other words, given `lhs = rhs`,
+  this tactic proves that `lhs - rhs = 0`.
 
 * Input:
-  * `h_equality` : an expr, whose type should be an equality between terms of
-      type α, where there is an instance of `add_group α`
+  * `h_equality` : an `expr`, whose type should be an equality between terms of
+      type `α`, where there is an instance of `add_group α`
 
-* Output: tactic expr, which proves that lhs - rhs = 0, where lhs and rhs are
+* Output: an `expr`, which proves that `lhs - rhs = 0`, where `lhs` and `rhs` are
    the left and right sides of `h_equality` respectively
 -/
 meta def move_to_left_side (h_equality : expr) : tactic expr :=
@@ -220,10 +220,10 @@ mk_app ``left_minus_right [h_equality]
 This tactic replaces the target with the result of moving all the terms in the
   target to the left side of the equals sign by subtracting the right side of
   the equation from the left side.  In other words, when the target is
-  lhs = rhs, this tactic proves that lhs - rhs = 0 and replaces the target
+  lhs = rhs, this tactic proves that `lhs - rhs = 0` and replaces the target
   with this new equality.
 Note: The target must be an equality when this tactic is called, and the
-  equality must have some type α on each side, where there is an instance of
+  equality must have some type `α` on each side, where there is an instance of
   `add_group α`.
 
 * Input: N/A
@@ -245,8 +245,8 @@ do
 /--
 This tactic changes the goal to be that the lefthand side of the target is
   equal to the lefthand side of the given expression.  For example,
-  if `hsum_on_left` is 5*x - 5*y = 0, and the target is -5*y + 5*x = 0, this
-  tactic will change the target to be -5*y + 5*x = 5*x - 5*y.
+  if `hsum_on_left` is `5*x - 5*y = 0`, and the target is `-5*y + 5*x = 0`, this
+  tactic will change the target to be `-5*y + 5*x = 5*x - 5*y`.
 
 This tactic only should be used when the target's type an equality whose
   right side is 0.
@@ -265,7 +265,7 @@ This tactic attempts to prove the goal by normalizing the target if the
 `normalize` field of the given configuration is true.
 
 * Input:
-  * `config` : a linear_combination_config, which determines the tactic used
+  * `config` : a `linear_combination_config`, which determines the tactic used
       for normalization if normalization is done
 
 * Output: N/A
@@ -294,9 +294,9 @@ Note: The left and right sides of all the equalities should have the same
       context
   * `coeffs` : a list of coefficients to be multiplied with the corresponding
     equations in the list of names
-  * `config` : a linear_combination_config, which determines the tactic used
+  * `config` : a `linear_combination_config`, which determines the tactic used
       for normalization; by default, this value is the standard configuration
-      for a linear_combination_config
+      for a `linear_combination_config`
 
 * Output: N/A
 -/
@@ -315,11 +315,11 @@ setup_tactic_parser
 
 /--
 A parser that matches a pair in parentheses, where the first item in the pair
-is an identifier and the second item in the pair is a pexpr.
+is an identifier and the second item in the pair is a `pexpr`.
 
 * Input: None
 
-* Output: a lean.parser (name × pexpr)
+* Output: a `lean.parser (name × pexpr)`
 -/
 meta def parse_name_pexpr_pair : lean.parser (name × pexpr) :=
 do

--- a/src/tactic/linear_combination.lean
+++ b/src/tactic/linear_combination.lean
@@ -1,0 +1,390 @@
+/-
+Copyright (c) 2022 Abby J. Goldberg. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Abby J. Goldberg
+-/
+
+import tactic.ring
+
+/-!
+
+# linear_combination Tactic
+
+In this file, the `linear_combination` tactic is created.  This tactic attempts
+to prove the target by creating and applying a linear combination of a list of
+equalities.  This file also includes a definition for
+`linear_combination_config`.  A `linear_combination_config` object can be 
+passed into the tactic, allowing the user to specify a normalization tactic.
+
+## Implementation Notes
+
+This tactic works by creating a weighted sum of the given equations with the
+given coefficients.  Then, it subtracts the right side of the weighted sum
+from the left side so that the right side equals 0, and it does the same with
+the target.  Afterwards, it sets the goal to be the equality between the
+lefthand side of the new goal and the lefthand side of the new weighted sum.
+Lastly, it uses a normalization tactic to see if the weighted sum is equal
+to the target.
+
+## References
+
+* <https://leanprover.zulipchat.com/#narrow/stream/239415-metaprogramming-.2F.20tactics/topic/Linear.20algebra.20tactic/near/213928196>
+
+-/
+
+namespace linear_combination
+
+/-! ### Lemmas -/
+
+lemma left_mul_both_sides {α} [h : has_mul α] {x y : α} (z : α) (h1 : x = y) :
+  z * x = z * y :=
+congr_arg (has_mul.mul z) h1
+
+lemma sum_two_equations {α} [h : has_add α] {x1 y1 x2 y2 : α} (h1 : x1 = y1)
+  (h2: x2 = y2) : x1 + x2 = y1 + y2 :=
+congr (congr_arg has_add.add h1) h2
+
+lemma left_minus_right {α} [h : add_group α] {x y : α} (h1 : x = y) :
+  x - y = 0 :=
+sub_eq_zero.mpr h1
+
+lemma all_on_left_equiv {α} [h : add_group α] (x y : α) :
+  (x = y) = (x - y = 0) :=
+propext (⟨left_minus_right, sub_eq_zero.mp⟩)
+
+lemma replace_eq_expr {α} [h : has_zero α] {x y : α} (h1 : x = 0) (h2 : y = x) :
+  y = 0 :=
+by rwa h2
+
+
+/-! ### Configuration -/
+
+
+/-- 
+A configuration object for `linear_combination`. 
+
+`normalize` describes whether or not the normalization step should be used.
+
+`normalization_tactic` describes the tactic used for normalization when
+checking if the weighted sum is equivalent to the goal (when `normalize` is tt).
+-/
+meta structure linear_combination_config : Type :=
+(normalize : bool := tt)
+(normalization_tactic : tactic unit := `[ring1])
+
+
+/-! ### Part 1: Multiplying Equations by Constants and Adding Them Together -/
+
+
+/--
+Given that lhs = rhs, this tactic returns an expr stating that
+  coeff * lhs = coeff * rhs.
+
+* Input:
+  * `heq` : an expr, which should be an equality with some type α on each side,
+      where `has_mul α` is true
+  * `coeff` : a pexpr, which should be a value of type α
+
+* Output: a tactic expr that is the result of multiplying both sides of `heq` by
+    the `coeff`
+-/
+meta def mul_equality_expr (heq : expr) (coeff : pexpr) : tactic expr :=
+do
+  `(%%lhs = %%rhs) ← tactic.infer_type heq,
+  -- Explicitly mark the coefficient as having the same type as the sides of
+  --   heq - this is necessary in order to use the left_mul_both_sides lemma
+  left_type ← tactic.infer_type lhs,
+  coeff_expr ← tactic.to_expr ``(%%coeff : %%left_type),
+  tactic.mk_app ``left_mul_both_sides [coeff_expr, heq]
+  <|> tactic.fail ("The type of the left and right sides of each equality " ++
+    "must fulfill the 'has_mul' condition in order to multiply the " ++
+    "equalities by the given factors.")
+
+/--
+Given two hypotheses stating that a = b and c = d, this tactic returns an
+  expr stating that a + c = b + d.
+
+* Input:
+  * `heq1` : an expr, which should be an equality with some type α on each side,
+      where `has_add α` is true
+  * `heq2` : an expr, which should be an equality with type α on each side
+
+* Output: a tactic expr that is the result of adding the two equalities
+-/
+meta def sum_equalities (heq1 heq2 : expr) : tactic expr :=
+do
+  tactic.mk_app ``sum_two_equations [heq1, heq2]
+  <|> tactic.fail ("The type of the left and right sides of each equality " ++
+    "must fulfill the 'has_add' condition in order to add the " ++
+    "equalities together.")
+
+/--
+Given that a = b and c = d, along with a coefficient, this tactic returns an
+  expr stating that a + coeff * c = b + coeff * d.
+
+* Input:
+  * `heq1` : an expr, which should be an equality with some type α on each side,
+    where `has_add α` and `has_mul α` are true
+  * `heq2` : an expr, which should be an equality with type α on each side
+  * `coeff_for_eq2` : a pexpr, which should be a value of type α
+    
+* Output: a tactic expr that is the result of adding the first equality to the
+  result of multiplying `coeff_for_eq2` by the second equality
+-/
+meta def sum_two_hyps_one_mul_helper (heq1 heq2 : expr) (coeff_for_eq2 : pexpr) :
+  tactic expr :=
+do
+  -- Multiply the second equation by the coefficient
+  hmul2 ← mul_equality_expr heq2 coeff_for_eq2,
+  -- Add the first equation and the newly computed equation together
+  sum_equalities heq1 hmul2
+
+/--
+This tactic builds on the given summed equation by multiplying each equation in
+  the given list by its associated coefficient and summing the equations
+  together
+
+* Input:
+  * an option (tactic expr) : `none`, if there is no sum to add to yet, or
+      `some` containing the base summation equation
+  * a list name : a list of names, referring to equations in the local context
+  * a list pexpr : a list of coefficients to be multiplied with the
+      corresponding equations in the list of names
+  
+* Output: a tactic expr expressing the weighted sum of the given equations
+    added to the base equation
+-/
+meta def make_sum_of_hyps_helper :
+  option (tactic expr) → list name → list pexpr → tactic expr
+| none [] []                                               :=
+  do tactic.fail "There are no hypotheses to add"
+| (some tactic_hcombo) [] []                               :=
+  do tactic_hcombo
+| none (heq_nam :: heqs) (coeff :: coeffs)                 :=
+ do
+    -- This is the first equation, and we do not have anything to add to it
+    heq ← tactic.get_local heq_nam,
+    let eq1_times_coeff1 := mul_equality_expr heq coeff,
+    make_sum_of_hyps_helper (some eq1_times_coeff1) heqs coeffs
+| (some tactic_hcombo) (heq_nam :: heqs) (coeff :: coeffs) :=
+  do
+    heq ← tactic.get_local heq_nam,
+    hcombo ← tactic_hcombo,
+    -- We want to add this weighted equation to
+    --   the current equation in the hypothesis
+    let hcombo_updated := sum_two_hyps_one_mul_helper hcombo heq coeff,
+    make_sum_of_hyps_helper (some hcombo_updated) heqs coeffs
+| _ _ _                                             :=
+  do tactic.fail ("The length of the input list of equalities should be the " ++
+    "same as the length of the input list of coefficients")
+
+/--
+Given a list of names referencing equalities and a list of pexprs representing
+  coefficients, this tactic creates a weighted sum of the equalities, where each
+  equation is multiplied by the corresponding coefficient.
+
+* Input:
+  * `heqs` : a list of names, referring to equations in the local context
+  * `coeffs` : a list of coefficients to be multiplied with the corresponding
+      equations in the list of names
+  
+* Output: a `tactic expr` that is the weighted sum of the equations
+-/
+meta def make_sum_of_hyps (heqs : list name) (coeffs : list pexpr) :
+  tactic expr :=
+make_sum_of_hyps_helper none heqs coeffs
+
+
+/-! ### Part 2: Simplifying -/
+
+
+/--
+This tactic moves all the terms in an equality to the left side of the equals
+  sign by subtracting the right side of the equation from the left side.  In
+  other words, given lhs = rhs, this tactic returns lhs - rhs = 0.
+
+* Input:
+  * `heq` : an expr, which should be an equality with some type α on each side,
+      where `add_group α` is true
+  
+* Output: tactic expr that is lhs - rhs = 0, where lhs and rhs are the left and 
+  right sides of heq respectively
+-/
+meta def move_to_left_side (heq : expr) : tactic expr :=
+do
+  tactic.mk_app ``left_minus_right [heq]
+  <|> tactic.fail ("The type of the left and right sides of each equality " ++
+    "must fulfill the 'add_group' condition in order to match the linear " ++
+    "combination to the target.")
+
+/--
+Moves all the terms in the target to the left side of the equals sign by
+  subtracting the right side of the equation from the left side.  In other
+  words, given a target of lhs = rhs, this tactic returns lhs - rhs = 0.
+Note: The target must be an equality when this tactic is called, and the
+  equality must have some type α on each side, where `add_group α` is true.
+
+* Input: N/A
+  
+* Output: tactic unit
+-/
+meta def move_target_to_left_side : tactic unit :=
+do
+  -- Move all the terms in the target equality to the left side
+  target ← tactic.target,
+  (targ_lhs, targ_rhs) ← tactic.match_eq target,
+  target_left_eq ← tactic.to_expr ``(%%targ_lhs - %%targ_rhs = 0),
+  do {
+    can_replace_proof ← tactic.mk_app ``all_on_left_equiv [targ_lhs, targ_rhs],
+    tactic.replace_target target_left_eq can_replace_proof
+  }
+  <|> tactic.fail ("The type of the left and right sides of the goal " ++
+    "must fulfill the 'add_group' condition in order to match the linear " ++
+    "combination to the target.")
+
+
+
+/-! ### Part 3: Matching the Linear Combination to the Target -/
+
+
+/--
+This tactic changes the goal to be that the lefthand side of the target is
+  equal to the lefthand side of the given expression.  For example,
+  if `hsum_on_left` is 5*x - 5*y = 0, and the target is -5*y + 5*x = 0, this
+  tactic will change the target to be -5*y + 5*x = 5*x - 5*y.
+
+This tactic only should be used when the target is an equality whose right side
+  is 0.
+
+* Input:
+  * `hsum_on_left` : expr, which should be an equality whose right side is 0
+  
+* Output: tactic unit
+-/
+meta def set_goal_to_hleft_eq_tleft (hsum_on_left : expr) : tactic unit :=
+do
+  { change_goal ← tactic.to_expr ``(replace_eq_expr %%hsum_on_left),
+    tactic.apply change_goal,
+    pure () }
+  <|> tactic.fail ("The type of the left and right sides of each equality " ++
+    "must fulfill the 'has_zero' condition.")
+
+/--
+This tactic attempts to prove the goal by normalizing the target if the
+`normalize` field of the given configuration is true.
+
+* Input:
+  * `config` : a linear_combination_config, which determines the tactic used
+      for normalization if normalization is done
+
+* Outout: tactic unit
+-/
+meta def prove_equal_if_desired (config : linear_combination_config) :
+  tactic unit :=
+when config.normalize config.normalization_tactic
+
+/-! ### Part 4: Completed Tactic -/
+
+
+/--
+This is a tactic that attempts to prove the target by creating and applying a
+  linear combination of a list of equalities.  (If the `normalize` field of the
+  configuration is set to ff, then the tactic will simply set the user up to 
+  prove their target using the linear combination instead of attempting to
+  finish the proof.)
+
+Note: The left and right sides of all the equations should have the same
+  ring type, and the coefficients should also have this type.  This type must
+  have the has_mul and add_group properties.  Also note that the target must
+  involve at least one variable.
+
+* Input:
+  * `heqs` : a list of names, referring to equations in the local context
+  * `coeffs` : a list of coefficients to be multiplied with the corresponding
+    equations in the list of names
+  * `config` : a linear_combination_config, which determines the tactic used
+      for normalization; by default, this value is the standard configuration
+      for a linear_combination_config
+  
+* Output: tactic unit
+-/
+meta def linear_combination (heqs : list name) (coeffs : list pexpr)
+  (config : linear_combination_config := {}) : tactic unit :=
+do
+  hsum ← make_sum_of_hyps heqs coeffs,
+  hsum_on_left ← move_to_left_side hsum,
+  move_target_to_left_side,
+  set_goal_to_hleft_eq_tleft hsum_on_left,
+  prove_equal_if_desired config
+
+
+section interactive_mode
+setup_tactic_parser
+
+/--
+A parser that matches a pair in parentheses, where the first item in the pair
+is an identifier and the second item in the pair is a pexpr.
+
+* Input: None
+
+* Output: a lean.parser (name × pexpr)
+-/
+meta def parse_name_pexpr_pair : lean.parser (name × pexpr) :=
+do 
+  tk "(",
+  id ← ident,
+  tk ",",
+  coeff ← parser.pexpr 0,
+  tk ")",
+  pure (id, coeff)
+
+/--
+`linear_combination` attempts to prove the target by creating and applying a
+  linear combination of a list of equalities.  The tactic will create a linear
+  combination by adding the equalities together from left to right, so the order
+  of the input hypotheses does matter.  If the `normalize` field of the
+  configuration is set to ff, then the tactic will simply set the user up to
+  prove their target using the linear combination instead of attempting to
+  finish the proof.
+
+Note: The left and right sides of all the equations should have the same
+  type, and the coefficients should also have this type.  This type must
+  have the has_mul and add_group properties.  Also note that the target must
+  involve at least one variable.
+
+* Input:
+  * `heqs` : a list of identifiers, referring to equations in the local context
+  * `coeffs` : a list of coefficients to be multiplied with the corresponding
+      equations in the list of names
+
+  * `input` : a sequence of name and pexpr pairs, which represents the pairs
+      of hypotheses and their corresponding coefficients
+  * `config` : a linear_combination_config, which determines the tactic used
+      for normalization; by default, this value is the standard configuration
+      for a linear_combination_config
+  
+* Output: tactic unit
+
+Example Usage:
+  Given that `h1` and `h2` are equalities in the local context,
+  `linear_combination (h1, 2) (h2, -3)`
+  will attempt to solve the goal by computing `2 * h1 + -3 * h2`
+  and matching that to the goal.
+-/
+add_tactic_doc
+{ name := "linear_combination",
+  category := doc_category.tactic,
+  decl_names := [`tactic.interactive.linear_combination],
+  tags := [] }
+
+meta def _root_.tactic.interactive.linear_combination
+  (input : parse parse_name_pexpr_pair*)
+  (config : linear_combination_config := {}) : tactic unit :=
+let (heqs, coeffs) := list.unzip input in
+linear_combination heqs coeffs config
+
+
+
+end interactive_mode 
+
+end linear_combination

--- a/src/tactic/linear_combination.lean
+++ b/src/tactic/linear_combination.lean
@@ -370,19 +370,17 @@ Example Usage:
   will attempt to solve the goal by computing `2 * h1 + -3 * h2`
   and matching that to the goal.
 -/
-add_tactic_doc
-{ name := "linear_combination",
-  category := doc_category.tactic,
-  decl_names := [`tactic.interactive.linear_combination],
-  tags := [] }
 meta def _root_.tactic.interactive.linear_combination
   (input : parse parse_name_pexpr_pair*)
   (config : linear_combination_config := {}) : tactic unit :=
 let (heqs, coeffs) := list.unzip input in
 linear_combination heqs coeffs config
 
-
+add_tactic_doc
+{ name := "linear_combination",
+  category := doc_category.tactic,
+  decl_names := [`tactic.interactive.linear_combination],
+  tags := [] }
 
 end interactive_mode
-
 end linear_combo

--- a/src/tactic/linear_combination.lean
+++ b/src/tactic/linear_combination.lean
@@ -13,7 +13,7 @@ import tactic.ring
 In this file, the `linear_combination` tactic is created.  This tactic attempts
 to prove the target by creating and applying a linear combination of a list of
 equalities.  This file also includes a definition for
-`linear_combination_config`.  A `linear_combination_config` object can be 
+`linear_combination_config`.  A `linear_combination_config` object can be
 passed into the tactic, allowing the user to specify a normalization tactic.
 
 ## Implementation Notes
@@ -32,7 +32,7 @@ to the target.
 
 -/
 
-namespace linear_combination
+namespace linear_combo
 
 /-! ### Lemmas -/
 
@@ -60,8 +60,8 @@ by rwa h2
 /-! ### Configuration -/
 
 
-/-- 
-A configuration object for `linear_combination`. 
+/--
+A configuration object for `linear_combination`.
 
 `normalize` describes whether or not the normalization step should be used.
 
@@ -127,7 +127,7 @@ Given that a = b and c = d, along with a coefficient, this tactic returns an
     where `has_add α` and `has_mul α` are true
   * `heq2` : an expr, which should be an equality with type α on each side
   * `coeff_for_eq2` : a pexpr, which should be a value of type α
-    
+
 * Output: a tactic expr that is the result of adding the first equality to the
   result of multiplying `coeff_for_eq2` by the second equality
 -/
@@ -150,7 +150,7 @@ This tactic builds on the given summed equation by multiplying each equation in
   * a list name : a list of names, referring to equations in the local context
   * a list pexpr : a list of coefficients to be multiplied with the
       corresponding equations in the list of names
-  
+
 * Output: a tactic expr expressing the weighted sum of the given equations
     added to the base equation
 -/
@@ -187,7 +187,7 @@ Given a list of names referencing equalities and a list of pexprs representing
   * `heqs` : a list of names, referring to equations in the local context
   * `coeffs` : a list of coefficients to be multiplied with the corresponding
       equations in the list of names
-  
+
 * Output: a `tactic expr` that is the weighted sum of the equations
 -/
 meta def make_sum_of_hyps (heqs : list name) (coeffs : list pexpr) :
@@ -206,8 +206,8 @@ This tactic moves all the terms in an equality to the left side of the equals
 * Input:
   * `heq` : an expr, which should be an equality with some type α on each side,
       where `add_group α` is true
-  
-* Output: tactic expr that is lhs - rhs = 0, where lhs and rhs are the left and 
+
+* Output: tactic expr that is lhs - rhs = 0, where lhs and rhs are the left and
   right sides of heq respectively
 -/
 meta def move_to_left_side (heq : expr) : tactic expr :=
@@ -225,7 +225,7 @@ Note: The target must be an equality when this tactic is called, and the
   equality must have some type α on each side, where `add_group α` is true.
 
 * Input: N/A
-  
+
 * Output: tactic unit
 -/
 meta def move_target_to_left_side : tactic unit :=
@@ -234,10 +234,9 @@ do
   target ← tactic.target,
   (targ_lhs, targ_rhs) ← tactic.match_eq target,
   target_left_eq ← tactic.to_expr ``(%%targ_lhs - %%targ_rhs = 0),
-  do {
-    can_replace_proof ← tactic.mk_app ``all_on_left_equiv [targ_lhs, targ_rhs],
-    tactic.replace_target target_left_eq can_replace_proof
-  }
+  do
+    { can_replace_proof ← tactic.mk_app ``all_on_left_equiv [targ_lhs, targ_rhs],
+      tactic.replace_target target_left_eq can_replace_proof }
   <|> tactic.fail ("The type of the left and right sides of the goal " ++
     "must fulfill the 'add_group' condition in order to match the linear " ++
     "combination to the target.")
@@ -258,7 +257,7 @@ This tactic only should be used when the target is an equality whose right side
 
 * Input:
   * `hsum_on_left` : expr, which should be an equality whose right side is 0
-  
+
 * Output: tactic unit
 -/
 meta def set_goal_to_hleft_eq_tleft (hsum_on_left : expr) : tactic unit :=
@@ -289,7 +288,7 @@ when config.normalize config.normalization_tactic
 /--
 This is a tactic that attempts to prove the target by creating and applying a
   linear combination of a list of equalities.  (If the `normalize` field of the
-  configuration is set to ff, then the tactic will simply set the user up to 
+  configuration is set to ff, then the tactic will simply set the user up to
   prove their target using the linear combination instead of attempting to
   finish the proof.)
 
@@ -305,7 +304,7 @@ Note: The left and right sides of all the equations should have the same
   * `config` : a linear_combination_config, which determines the tactic used
       for normalization; by default, this value is the standard configuration
       for a linear_combination_config
-  
+
 * Output: tactic unit
 -/
 meta def linear_combination (heqs : list name) (coeffs : list pexpr)
@@ -330,7 +329,7 @@ is an identifier and the second item in the pair is a pexpr.
 * Output: a lean.parser (name × pexpr)
 -/
 meta def parse_name_pexpr_pair : lean.parser (name × pexpr) :=
-do 
+do
   tk "(",
   id ← ident,
   tk ",",
@@ -362,7 +361,7 @@ Note: The left and right sides of all the equations should have the same
   * `config` : a linear_combination_config, which determines the tactic used
       for normalization; by default, this value is the standard configuration
       for a linear_combination_config
-  
+
 * Output: tactic unit
 
 Example Usage:
@@ -376,7 +375,6 @@ add_tactic_doc
   category := doc_category.tactic,
   decl_names := [`tactic.interactive.linear_combination],
   tags := [] }
-
 meta def _root_.tactic.interactive.linear_combination
   (input : parse parse_name_pexpr_pair*)
   (config : linear_combination_config := {}) : tactic unit :=
@@ -385,6 +383,6 @@ linear_combination heqs coeffs config
 
 
 
-end interactive_mode 
+end interactive_mode
 
-end linear_combination
+end linear_combo

--- a/src/tactic/linear_combination.lean
+++ b/src/tactic/linear_combination.lean
@@ -352,8 +352,6 @@ Note: The left and right sides of all the equalities should have the same
       `normalize` is set to tt (meaning this tactic is set to use
       normalization), and `normalization_tactic` is set to  `ring1`.
 
-* Output: N/A
-
 Example Usage:
 ```
 example (x y : ℤ) (h1 : x*y + 2*x = 1) (h2 : x = y) :
@@ -364,6 +362,18 @@ example (x y z : ℝ) (ha : x + 2*y - z = 4) (hb : 2*x + y + z = -2)
     (hc : x + 2*y + z = 2) :
   -3*x - 3*y - 4*z = 2 :=
 by linear_combination (ha, 1) (hb, -1) (hc, -2)
+
+example (x y : ℚ) (h1 : x + y = 3) (h2 : 3*x = 7) :
+  x*x*y + y*x*y + 6*x = 3*x*y + 14 :=
+by linear_combination (h1, x*y) (h2, 2)
+
+example (x y : ℤ) (h1 : x = -3) (h2 : y = 10) :
+  2*x = -6 :=
+begin
+  linear_combination (h1, 2) {normalize := ff},
+  simp,
+  norm_cast
+end
 ```
 -/
 meta def _root_.tactic.interactive.linear_combination

--- a/test/linear_combination.lean
+++ b/test/linear_combination.lean
@@ -8,6 +8,10 @@ example (x y : ℤ) (h1 : 3*x + 2*y = 10):
   3*x + 2*y = 10 :=
 by linear_combination (h1, 1)
 
+example (x y : ℤ) (h1 : 3*x + 2*y = 10):
+  3*x + 2*y = 10 :=
+by linear_combination h1
+
 example (x y : ℤ) (h1 : x + 2 = -3) (h2 : y = 10) :
   2*x + 4 = -6 :=
 by linear_combination (h1, 2)
@@ -15,6 +19,10 @@ by linear_combination (h1, 2)
 example (x y : ℤ) (h1 : x*y + 2*x = 1) (h2 : x = y) :
   x*y = -2*y + 1 :=
 by linear_combination (h1, 1) (h2, -2)
+
+example (x y : ℤ) (h1 : x*y + 2*x = 1) (h2 : x = y) :
+  x*y = -2*y + 1 :=
+by linear_combination (h2, -2) h1
 
 example (x y : ℤ) (h1 : x + 2 = -3) (h2 : y = 10) :
   2*x + 4 - y = -16 :=
@@ -81,6 +89,11 @@ example (w x y z : ℝ) (h1 : x + 2.1*y + 2*z = 2) (h2 : x + 8*z + 5*w = -6.5)
     (h3 : x + y + 5*z + 5*w = 3) :
   x + 2.2*y + 2*z - 5*w = -8.5 :=
 by linear_combination (h1, 2) (h2, 1) (h3, -2)
+
+example (w x y z : ℝ) (h1 : x + 2.1*y + 2*z = 2) (h2 : x + 8*z + 5*w = -6.5)
+    (h3 : x + y + 5*z + 5*w = 3) :
+  x + 2.2*y + 2*z - 5*w = -8.5 :=
+by linear_combination (h1, 2) h2 (h3, -2)
 
 example (a b c d : ℚ) (h1 : a = 4) (h2 : 3 = b) (h3 : c*3 = d) (h4 : -d = a) :
   2*a - 3 + 9*c + 3*d = 8 - b + 3*d - 3*a :=

--- a/test/linear_combination.lean
+++ b/test/linear_combination.lean
@@ -1,0 +1,204 @@
+import tactic.linear_combination
+import data.real.basic
+
+
+/-! ### Simple Cases with ℤ and two or less equations -/
+
+example (x y : ℤ) (h1 : 3*x + 2*y = 10):
+  3*x + 2*y = 10 :=
+by linear_combination (h1, 1)
+
+example (x y : ℤ) (h1 : x + 2 = -3) (h2 : y = 10) :
+  2*x + 4 = -6 :=
+by linear_combination (h1, 2)
+
+example (x y : ℤ) (h1 : x*y + 2*x = 1) (h2 : x = y) :
+  x*y = -2*y + 1 :=
+by linear_combination (h1, 1) (h2, -2)
+
+example (x y : ℤ) (h1 : x + 2 = -3) (h2 : y = 10) :
+  2*x + 4 - y = -16 :=
+by linear_combination (h1, 2) (h2, -1)
+
+example (x y : ℤ) (h1 : x + 2 = -3) (h2 : y = 10) :
+  -y + 2*x + 4 = -16 :=
+by linear_combination (h2, -1) (h1, 2)
+
+example (x y : ℤ) (h1 : 3*x + 2*y = 10) (h2 : 2*x + 5*y = 3) :
+  11*y = -11 :=
+by linear_combination (h1, -2) (h2, 3)
+
+example (x y : ℤ) (h1 : 3*x + 2*y = 10) (h2 : 2*x + 5*y = 3) :
+  -11*y = 11 :=
+by linear_combination (h1, 2) (h2, -3)
+
+example (x y : ℤ) (h1 : 3*x + 2*y = 10) (h2 : 2*x + 5*y = 3) :
+  -11*y = 11 + 1 - 1 :=
+by linear_combination (h1, 2) (h2, -3)
+
+example (x y : ℤ) (h1 : 10 = 3*x + 2*y) (h2 : 3 = 2*x + 5*y) :
+  11 + 1 - 1 = -11*y :=
+by linear_combination (h1, 2) (h2, -3)
+
+
+/-! ### More complicated cases with two equations -/
+
+example (x y : ℤ) (h1 : x + 2 = -3) (h2 : y = 10) :
+  -y + 2*x + 4 = -16 :=
+by linear_combination (h1, 2) (h2, -1)
+
+example (x y : ℚ) (h1 : 3*x + 2*y = 10) (h2 : 2*x + 5*y = 3) :
+  -11*y + 1 = 11 + 1 :=
+by linear_combination (h1, 2) (h2, -3)
+
+example (a b : ℝ) (ha : 2*a = 4) (hab : 2*b = a - b) :
+  b = 2 / 3 :=
+by linear_combination (ha, 1/6) (hab, 1/3)
+
+
+/-! ### Cases with more than 2 equations -/
+
+example (a b : ℝ) (ha : 2*a = 4) (hab : 2*b = a - b) (hignore : 3 = a + b) :
+  b = 2 / 3 :=
+by linear_combination (ha, 1/6) (hab, 1/3) (hignore, 0)
+
+example (x y z : ℝ) (ha : x + 2*y - z = 4) (hb : 2*x + y + z = -2)
+    (hc : x + 2*y + z = 2) :
+  -3*x - 3*y - 4*z = 2 :=
+by linear_combination (ha, 1) (hb, -1) (hc, -2)
+
+example (x y z : ℝ) (ha : x + 2*y - z = 4) (hb : 2*x + y + z = -2)
+    (hc : x + 2*y + z = 2) :
+  6*x = -10 :=
+by linear_combination (ha, 1) (hb, 4) (hc, -3)
+
+example (x y z : ℝ) (ha : x + 2*y - z = 4) (hb : 2*x + y + z = -2)
+    (hc : x + 2*y + z = 2) :
+  10 = 6*-x :=
+by linear_combination (ha, 1) (hb, 4) (hc, -3)
+
+example (w x y z : ℝ) (h1 : x + 2.1*y + 2*z = 2) (h2 : x + 8*z + 5*w = -6.5)
+    (h3 : x + y + 5*z + 5*w = 3) :
+  x + 2.2*y + 2*z - 5*w = -8.5 :=
+by linear_combination (h1, 2) (h2, 1) (h3, -2)
+
+example (a b c d : ℚ) (h1 : a = 4) (h2 : 3 = b) (h3 : c*3 = d) (h4 : -d = a) :
+  2*a - 3 + 9*c + 3*d = 8 - b + 3*d - 3*a :=
+by linear_combination (h1, 2) (h2, -1) (h3, 3) (h4, -3)
+
+example (a b c d : ℚ) (h1 : a = 4) (h2 : 3 = b) (h3 : c*3 = d) (h4 : -d = a) :
+  6 - 3*c + 3*a + 3*d = 2*b - d + 12 - 3*a :=
+by linear_combination (h2, 2) (h3, -1) (h1, 3) (h4, -3)
+
+
+/-! ### Cases with arbitrary coefficients -/
+
+example (a b : ℤ) (h : a = b) :
+  a * a = a * b :=
+by linear_combination (h, a)
+
+example (a b c : ℤ) (h : a = b) :
+  a * c = b * c :=
+by linear_combination (h, c)
+
+example (a b c : ℤ) (h1 : a = b) (h2 : b = 1) :
+  c * a + b = c * b + 1 :=
+by linear_combination (h1, c) (h2, 1)
+
+example (x y : ℚ) (h1 : x + y = 3) (h2 : 3*x = 7) :
+  x*x*y + y*x*y + 6*x = 3*x*y + 14 :=
+by linear_combination (h1, x*y) (h2, 2)
+
+example {α} [h : comm_ring α] {a b c d e f : α} (h1 : a*d = b*c) (h2 : c*f = e*d) :
+  c * (a*f - b*e) = 0 :=
+by linear_combination (h1, e) (h2, a)
+
+
+/-! ### Cases that explicitly use a linear_combination_config -/
+
+example (x y : ℚ) (h1 : 3*x + 2*y = 10) (h2 : 2*x + 5*y = 3) :
+  -11*y + 1 = 11 + 1 :=
+by linear_combination (h1, 2) (h2, -3) {normalization_tactic := `[ring]}
+
+example (x y : ℚ) (h1 : 3*x + 2*y = 10) (h2 : 2*x + 5*y = 3) :
+  -11*y + 1 = 11 + 1 :=
+by linear_combination (h1, 2) (h2, -3) {normalization_tactic := `[ring1]}
+
+example (a b : ℝ) (ha : 2*a = 4) (hab : 2*b = a - b) :
+  b = 2 / 3 :=
+by linear_combination (ha, 1/6) (hab, 1/3) {normalization_tactic := `[ring_nf]}
+
+example (x y : ℤ) (h1 : 3*x + 2*y = 10):
+  3*x + 2*y = 10 :=
+by linear_combination (h1, 1) {normalization_tactic := `[simp]}
+
+
+/-! ### Cases that have linear_combination skip normalization -/
+
+
+example (a b : ℝ) (ha : 2*a = 4) (hab : 2*b = a - b) :
+  b = 2 / 3 :=
+begin
+  linear_combination (ha, 1/6) (hab, 1/3) {normalize := ff},
+  linarith
+end
+
+example (x y : ℤ) (h1 : x = -3) (h2 : y = 10) :
+  2*x = -6 :=
+begin
+  linear_combination (h1, 2) {normalize := ff},
+  simp,
+  norm_cast
+end
+
+
+/-! ### Cases that should fail -/
+
+-- This should fail because there are no hypotheses given
+example (x y : ℤ) (h1 : x*y + 2*x = 1) (h2 : x = y) :
+  x*y = -2*y + 1 :=
+begin
+  success_if_fail {linear_combination},
+  linear_combination (h1, 1) (h2, -2)
+end
+
+-- This should fail because the second coefficient has a different type than
+--   the equations it is being combined with.  This was a design choice for the
+--   sake of simplicity, but the tactic could potentially be modified to allow
+--   this behavior.
+example (x y : ℤ) (h1 : x*y + 2*x = 1) (h2 : x = y) :
+  x*y + 2*x = 1 :=
+begin
+  success_if_fail {linear_combination (h1, 1) (h2, (0 : ℝ))},
+  linear_combination (h1, 1)
+end
+
+-- This should fail because the second coefficient has a different type than
+--   the equations it is being combined with.  This was a design choice for the
+--   sake of simplicity, but the tactic could potentially be modified to allow
+--   this behavior.
+example (x y : ℤ) (h1 : x*y + 2*x = 1) (h2 : x = y) :
+  x*y + 2*x = 1 :=
+begin
+  success_if_fail {linear_combination (h1, 1) (h2, (0 : ℕ))},
+  linear_combination (h1, 1)
+end
+
+-- This should fail because the coefficients are incorrect.  They should instead
+--   be -2 and 3, respectively.
+example (x y : ℤ) (h1 : 3*x + 2*y = 10) (h2 : 2*x + 5*y = 3) :
+  11*y = -11 :=
+begin
+  success_if_fail {linear_combination (h1, 2) (h2, -3)},
+  linear_combination (h1, -2) (h2, 3)
+end
+
+-- This fails because the linear_combination tactic requires the equations
+--   and coefficients to use a type that fulfills the add_group condition,
+--   and ℕ does not.
+example (a b : ℕ) (h1 : a = 3) :
+  a = 3 :=
+begin
+  success_if_fail {linear_combination (h1, (1 : ℕ))},
+  exact h1
+end


### PR DESCRIPTION
This new tactic attempts to prove a target equation by creating a linear combination of a list of equalities.  The name of this tactic is currently `linear_combination`, but I am open to other possible names.

An example of how to use this tactic is shown below:

```
example (x y : ℤ) (h1 : x*y + 2*x = 1) (h2 : x = y) :
  x*y = -2*y + 1 :=
by linear_combination (h1, 1) (h2, -2)
```

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
