### PR TITLE
[Merged by Bors] - feat(algebra/big_operators/order): The size of a finset of disjoint finsets is less than the size of its union

### DIFF
--- a/src/algebra/big_operators/order.lean
+++ b/src/algebra/big_operators/order.lean
@@ -304,6 +304,18 @@ lemma sum_card [fintype α] (h : ∀ a, (B.filter $ (∈) a).card = n) :
   ∑ s in B, s.card = fintype.card α * n :=
 by simp_rw [fintype.card, ←sum_card_inter (λ a _, h a), univ_inter]
 
+lemma card_le_card_bUnion {s : finset ι} {f : ι → finset α} (h₀ : ∀ i ∈ s, (f i).nonempty)
+  (h₁ : (s : set ι).pairwise_disjoint f) :
+  s.card ≤ (s.bUnion f).card :=
+by { rw [card_bUnion h₁, card_eq_sum_ones], exact sum_le_sum (λ i hi, (h₀ i hi).card_pos) }
+
+lemma card_le_card_bUnion_add_one {s : finset (finset α)}
+  (hs : (s : set (finset α)).pairwise_disjoint id) :
+  s.card ≤ (s.bUnion id).card + 1 :=
+(tsub_le_iff_right.1 pred_card_le_card_erase).trans $ add_le_add_right ((card_le_card_bUnion
+  (λ i hi, nonempty_iff_ne_empty.2 $ ne_of_mem_erase hi) $ hs.subset $ erase_subset ∅ _).trans $
+  card_le_of_subset $ bUnion_subset_bUnion_of_subset_left _ $ erase_subset ∅ _) _
+
 end double_counting
 
 section canonically_ordered_monoid

--- a/src/algebra/big_operators/order.lean
+++ b/src/algebra/big_operators/order.lean
@@ -14,6 +14,7 @@ Mostly monotonicity results for the `∏` and `∑` operations.
 
 -/
 
+open function
 open_locale big_operators
 
 variables {ι α β M N G k R : Type*}
@@ -304,17 +305,26 @@ lemma sum_card [fintype α] (h : ∀ a, (B.filter $ (∈) a).card = n) :
   ∑ s in B, s.card = fintype.card α * n :=
 by simp_rw [fintype.card, ←sum_card_inter (λ a _, h a), univ_inter]
 
-lemma card_le_card_bUnion {s : finset ι} {f : ι → finset α} (h₀ : ∀ i ∈ s, (f i).nonempty)
-  (h₁ : (s : set ι).pairwise_disjoint f) :
+lemma card_le_card_bUnion {s : finset ι} {f : ι → finset α} (hs : (s : set ι).pairwise_disjoint f)
+  (hf : ∀ i ∈ s, (f i).nonempty) :
   s.card ≤ (s.bUnion f).card :=
-by { rw [card_bUnion h₁, card_eq_sum_ones], exact sum_le_sum (λ i hi, (h₀ i hi).card_pos) }
+by { rw [card_bUnion hs, card_eq_sum_ones], exact sum_le_sum (λ i hi, (hf i hi).card_pos) }
 
-lemma card_le_card_bUnion_add_one {s : finset (finset α)}
-  (hs : (s : set (finset α)).pairwise_disjoint id) :
-  s.card ≤ (s.bUnion id).card + 1 :=
-(tsub_le_iff_right.1 pred_card_le_card_erase).trans $ add_le_add_right ((card_le_card_bUnion
-  (λ i hi, nonempty_iff_ne_empty.2 $ ne_of_mem_erase hi) $ hs.subset $ erase_subset ∅ _).trans $
-  card_le_of_subset $ bUnion_subset_bUnion_of_subset_left _ $ erase_subset ∅ _) _
+lemma card_le_card_bUnion_add_card_fiber {s : finset ι} {f : ι → finset α}
+  (hs : (s : set ι).pairwise_disjoint f) :
+  s.card ≤ (s.bUnion f).card + (s.filter $ λ i, f i = ∅).card :=
+begin
+  rw [←finset.filter_card_add_filter_neg_card_eq_card (λ i, f i = ∅), add_comm],
+  exact add_le_add_right ((card_le_card_bUnion (hs.subset $ filter_subset _ _) $ λ i hi,
+    nonempty_of_ne_empty $ (mem_filter.1 hi).2).trans $ card_le_of_subset $
+    bUnion_subset_bUnion_of_subset_left _ $ filter_subset _ _) _,
+end
+
+lemma card_le_card_bUnion_add_one {s : finset ι} {f : ι → finset α} (hf : injective f)
+  (hs : (s : set ι).pairwise_disjoint f) :
+  s.card ≤ (s.bUnion f).card + 1 :=
+(card_le_card_bUnion_add_card_fiber hs).trans $ add_le_add_left (card_le_one.2 $ λ i hi j hj, hf $
+  (mem_filter.1 hi).2.trans (mem_filter.1 hj).2.symm) _
 
 end double_counting
 


### PR DESCRIPTION
Prove `card_le_card_bUnion`, its corollary `card_le_card_bUnion_add_card_fiber` where we drop the nonemptiness condition in exchange of a `+` card of the fiber of `∅` on the RHS, and its useful special case `card_le_card_bUnion_add_one`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
