### PR TITLE
[Merged by Bors] - refactor(topology/algebra/uniform_group): Use `to_additive`.

### DIFF
--- a/src/topology/algebra/group_completion.lean
+++ b/src/topology/algebra/group_completion.lean
@@ -130,7 +130,7 @@ open uniform_space uniform_space.completion
 /-- Extension to the completion of a continuous group hom. -/
 def add_monoid_hom.extension [complete_space β] [separated_space β] (f : α →+ β)
   (hf : continuous f) : completion α →+ β :=
-have hf : uniform_continuous f, from uniform_continuous_of_continuous hf,
+have hf : uniform_continuous f, from uniform_continuous_add_monoid_hom_of_continuous hf,
 { to_fun := completion.extension f,
   map_zero' := by rw [← coe_zero, extension_coe hf, f.map_zero],
   map_add' := assume a b, completion.induction_on₂ a b
@@ -142,7 +142,7 @@ have hf : uniform_continuous f, from uniform_continuous_of_continuous hf,
 
 lemma add_monoid_hom.extension_coe [complete_space β] [separated_space β] (f : α →+ β)
   (hf : continuous f) (a : α) : f.extension hf a = f a :=
-extension_coe (uniform_continuous_of_continuous hf) a
+extension_coe (uniform_continuous_add_monoid_hom_of_continuous hf) a
 
 @[continuity]
 lemma add_monoid_hom.continuous_extension [complete_space β] [separated_space β] (f : α →+ β)
@@ -160,7 +160,7 @@ continuous_map
 
 lemma add_monoid_hom.completion_coe (f : α →+ β)
   (hf : continuous f) (a : α) : f.completion hf a = f a :=
-map_coe (uniform_continuous_of_continuous hf) a
+map_coe (uniform_continuous_add_monoid_hom_of_continuous hf) a
 
 lemma add_monoid_hom.completion_zero : (0 : α →+ β).completion continuous_const = 0 :=
 begin

--- a/src/topology/algebra/uniform_group.lean
+++ b/src/topology/algebra/uniform_group.lean
@@ -21,132 +21,141 @@ import tactic.abel
 noncomputable theory
 open_locale classical uniformity topological_space filter
 
-section uniform_add_group
+section uniform_group
 open filter set
 
 variables {α : Type*} {β : Type*}
 
-/-- A uniform (additive) group is a group in which the addition and negation are
-  uniformly continuous. -/
+/-- A uniform group is a group in which multiplication and inversion are uniformly continuous. -/
+
+class uniform_group (α : Type*) [uniform_space α] [group α] : Prop :=
+(uniform_continuous_div : uniform_continuous (λp:α×α, p.1 / p.2))
+
+/-- A uniform additive group is an additive group in which addition
+  and negation are uniformly continuous.-/
 class uniform_add_group (α : Type*) [uniform_space α] [add_group α] : Prop :=
 (uniform_continuous_sub : uniform_continuous (λp:α×α, p.1 - p.2))
 
-theorem uniform_add_group.mk' {α} [uniform_space α] [add_group α]
-  (h₁ : uniform_continuous (λp:α×α, p.1 + p.2))
-  (h₂ : uniform_continuous (λp:α, -p)) : uniform_add_group α :=
-⟨by simpa only [sub_eq_add_neg] using
+attribute [to_additive] uniform_group
+
+@[to_additive] theorem uniform_group.mk' {α} [uniform_space α] [group α]
+  (h₁ : uniform_continuous (λp:α×α, p.1 * p.2))
+  (h₂ : uniform_continuous (λp:α, p⁻¹)) : uniform_group α :=
+⟨by simpa only [div_eq_mul_inv] using
   h₁.comp (uniform_continuous_fst.prod_mk (h₂.comp uniform_continuous_snd))⟩
 
-variables [uniform_space α] [add_group α] [uniform_add_group α]
+variables [uniform_space α] [group α] [uniform_group α]
 
-lemma uniform_continuous_sub : uniform_continuous (λp:α×α, p.1 - p.2) :=
-uniform_add_group.uniform_continuous_sub
+@[to_additive] lemma uniform_continuous_div : uniform_continuous (λp:α×α, p.1 / p.2) :=
+uniform_group.uniform_continuous_div
 
-lemma uniform_continuous.sub [uniform_space β] {f : β → α} {g : β → α}
-  (hf : uniform_continuous f) (hg : uniform_continuous g) : uniform_continuous (λx, f x - g x) :=
-uniform_continuous_sub.comp (hf.prod_mk hg)
+@[to_additive] lemma uniform_continuous.div [uniform_space β] {f : β → α} {g : β → α}
+  (hf : uniform_continuous f) (hg : uniform_continuous g) : uniform_continuous (λx, f x / g x) :=
+uniform_continuous_div.comp (hf.prod_mk hg)
 
-lemma uniform_continuous.neg [uniform_space β] {f : β → α}
-  (hf : uniform_continuous f) : uniform_continuous (λx, - f x) :=
-have uniform_continuous (λx, 0 - f x),
-  from uniform_continuous_const.sub hf,
+@[to_additive] lemma uniform_continuous.inv [uniform_space β] {f : β → α}
+  (hf : uniform_continuous f) : uniform_continuous (λx, (f x)⁻¹) :=
+have uniform_continuous (λx, 1 / f x),
+  from uniform_continuous_const.div hf,
 by simp * at *
 
-lemma uniform_continuous_neg : uniform_continuous (λx:α, - x) :=
-uniform_continuous_id.neg
+@[to_additive] lemma uniform_continuous_inv : uniform_continuous (λx:α, x⁻¹) :=
+uniform_continuous_id.inv
 
-lemma uniform_continuous.add [uniform_space β] {f : β → α} {g : β → α}
-  (hf : uniform_continuous f) (hg : uniform_continuous g) : uniform_continuous (λx, f x + g x) :=
-have uniform_continuous (λx, f x - - g x), from hf.sub hg.neg,
-by simp [*, sub_eq_add_neg] at *
+@[to_additive] lemma uniform_continuous.mul [uniform_space β] {f : β → α} {g : β → α}
+  (hf : uniform_continuous f) (hg : uniform_continuous g) : uniform_continuous (λx, f x * g x) :=
+have uniform_continuous (λx, f x / (g x)⁻¹), from hf.div hg.inv,
+by simp * at *
 
-lemma uniform_continuous_add : uniform_continuous (λp:α×α, p.1 + p.2) :=
-uniform_continuous_fst.add uniform_continuous_snd
+@[to_additive] lemma uniform_continuous_mul : uniform_continuous (λp:α×α, p.1 * p.2) :=
+uniform_continuous_fst.mul uniform_continuous_snd
 
-@[priority 10]
-instance uniform_add_group.to_topological_add_group : topological_add_group α :=
-{ continuous_add := uniform_continuous_add.continuous,
-  continuous_neg := uniform_continuous_neg.continuous }
+@[priority 10, to_additive]
+instance uniform_group.to_topological_group : topological_group α :=
+{ continuous_mul := uniform_continuous_mul.continuous,
+  continuous_inv := uniform_continuous_inv.continuous }
 
-instance [uniform_space β] [add_group β] [uniform_add_group β] : uniform_add_group (α × β) :=
-⟨((uniform_continuous_fst.comp uniform_continuous_fst).sub
+@[to_additive] instance [uniform_space β] [group β] [uniform_group β] : uniform_group (α × β) :=
+⟨((uniform_continuous_fst.comp uniform_continuous_fst).div
   (uniform_continuous_fst.comp uniform_continuous_snd)).prod_mk
- ((uniform_continuous_snd.comp uniform_continuous_fst).sub
+ ((uniform_continuous_snd.comp uniform_continuous_fst).div
   (uniform_continuous_snd.comp uniform_continuous_snd))⟩
 
-lemma uniformity_translate (a : α) : (𝓤 α).map (λx:α×α, (x.1 + a, x.2 + a)) = 𝓤 α :=
+@[to_additive] lemma uniformity_translate_mul (a : α) :
+  (𝓤 α).map (λx:α×α, (x.1 * a, x.2 * a)) = 𝓤 α :=
 le_antisymm
-  (uniform_continuous_id.add uniform_continuous_const)
+  (uniform_continuous_id.mul uniform_continuous_const)
   (calc 𝓤 α =
-    ((𝓤 α).map (λx:α×α, (x.1 + -a, x.2 + -a))).map (λx:α×α, (x.1 + a, x.2 + a)) :
+    ((𝓤 α).map (λx:α×α, (x.1 * a⁻¹, x.2 * a⁻¹))).map (λx:α×α, (x.1 * a, x.2 * a)) :
       by simp [filter.map_map, (∘)]; exact filter.map_id.symm
-    ... ≤ (𝓤 α).map (λx:α×α, (x.1 + a, x.2 + a)) :
-      filter.map_mono (uniform_continuous_id.add uniform_continuous_const))
+    ... ≤ (𝓤 α).map (λx:α×α, (x.1 * a, x.2 * a)) :
+      filter.map_mono (uniform_continuous_id.mul uniform_continuous_const))
 
-lemma uniform_embedding_translate (a : α) : uniform_embedding (λx:α, x + a) :=
+@[to_additive] lemma uniform_embedding_translate_mul (a : α) : uniform_embedding (λx:α, x * a) :=
 { comap_uniformity := begin
-    rw [← uniformity_translate a, comap_map] {occs := occurrences.pos [1]},
+    rw [← uniformity_translate_mul a, comap_map] {occs := occurrences.pos [1]},
     rintros ⟨p₁, p₂⟩ ⟨q₁, q₂⟩,
     simp [prod.eq_iff_fst_eq_snd_eq] {contextual := tt}
   end,
-  inj := add_left_injective a }
+  inj := mul_left_injective a }
 
 section
 variables (α)
-lemma uniformity_eq_comap_nhds_zero : 𝓤 α = comap (λx:α×α, x.2 - x.1) (𝓝 (0:α)) :=
+@[to_additive] lemma uniformity_eq_comap_nhds_one : 𝓤 α = comap (λx:α×α, x.2 / x.1) (𝓝 (1:α)) :=
 begin
   rw [nhds_eq_comap_uniformity, filter.comap_comap],
   refine le_antisymm (filter.map_le_iff_le_comap.1 _) _,
   { assume s hs,
-    rcases mem_uniformity_of_uniform_continuous_invariant uniform_continuous_sub hs
+    rcases mem_uniformity_of_uniform_continuous_invariant uniform_continuous_div hs
       with ⟨t, ht, hts⟩,
     refine mem_map.2 (mem_of_superset ht _),
     rintros ⟨a, b⟩,
     simpa [subset_def] using hts a b a },
   { assume s hs,
-    rcases mem_uniformity_of_uniform_continuous_invariant uniform_continuous_add hs
+    rcases mem_uniformity_of_uniform_continuous_invariant uniform_continuous_mul hs
       with ⟨t, ht, hts⟩,
     refine ⟨_, ht, _⟩,
-    rintros ⟨a, b⟩, simpa [subset_def] using hts 0 (b - a) a }
+    rintros ⟨a, b⟩, simpa [subset_def] using hts 1 (b / a) a }
 end
 end
 
-lemma group_separation_rel (x y : α) : (x, y) ∈ separation_rel α ↔ x - y ∈ closure ({0} : set α) :=
-have embedding (λa, a + (y - x)), from (uniform_embedding_translate (y - x)).embedding,
-show (x, y) ∈ ⋂₀ (𝓤 α).sets ↔ x - y ∈ closure ({0} : set α),
+@[to_additive] lemma group_separation_rel (x y : α) :
+  (x, y) ∈ separation_rel α ↔ x / y ∈ closure ({1} : set α) :=
+have embedding (λa, a * (y / x)), from (uniform_embedding_translate_mul (y / x)).embedding,
+show (x, y) ∈ ⋂₀ (𝓤 α).sets ↔ x / y ∈ closure ({1} : set α),
 begin
-  rw [this.closure_eq_preimage_closure_image, uniformity_eq_comap_nhds_zero α, sInter_comap_sets],
+  rw [this.closure_eq_preimage_closure_image, uniformity_eq_comap_nhds_one α, sInter_comap_sets],
   simp [mem_closure_iff_nhds, inter_singleton_nonempty, sub_eq_add_neg, add_assoc]
 end
 
-lemma uniform_continuous_of_tendsto_zero [uniform_space β] [add_group β] [uniform_add_group β]
-  {f : α →+ β} (h : tendsto f (𝓝 0) (𝓝 0)) :
+@[to_additive] lemma uniform_continuous_of_tendsto_one
+  [uniform_space β] [group β] [uniform_group β] {f : α →* β} (h : tendsto f (𝓝 1) (𝓝 1)) :
   uniform_continuous f :=
 begin
-  have : ((λx:β×β, x.2 - x.1) ∘ (λx:α×α, (f x.1, f x.2))) = (λx:α×α, f (x.2 - x.1)),
-  { simp only [f.map_sub] },
-  rw [uniform_continuous, uniformity_eq_comap_nhds_zero α, uniformity_eq_comap_nhds_zero β,
+  have : ((λx:β×β, x.2 / x.1) ∘ (λx:α×α, (f x.1, f x.2))) = (λx:α×α, f (x.2 / x.1)),
+  { simp only [f.map_div] },
+  rw [uniform_continuous, uniformity_eq_comap_nhds_one α, uniformity_eq_comap_nhds_one β,
     tendsto_comap_iff, this],
   exact tendsto.comp h tendsto_comap
 end
 
-lemma add_monoid_hom.uniform_continuous_of_continuous_at_zero
-  [uniform_space β] [add_group β] [uniform_add_group β]
-  (f : α →+ β) (hf : continuous_at f 0) :
+@[to_additive] lemma monoid_hom.uniform_continuous_of_continuous_at_one
+  [uniform_space β] [group β] [uniform_group β]
+  (f : α →* β) (hf : continuous_at f 1) :
   uniform_continuous f :=
-uniform_continuous_of_tendsto_zero (by simpa using hf.tendsto)
+uniform_continuous_of_tendsto_one (by simpa using hf.tendsto)
 
-lemma uniform_continuous_of_continuous [uniform_space β] [add_group β] [uniform_add_group β]
-  {f : α →+ β} (h : continuous f) : uniform_continuous f :=
-uniform_continuous_of_tendsto_zero $
-  suffices tendsto f (𝓝 0) (𝓝 (f 0)), by rwa f.map_zero at this,
-  h.tendsto 0
+@[to_additive] lemma uniform_continuous_monoid_hom_of_continuous [uniform_space β]
+  [group β] [uniform_group β] {f : α →* β} (h : continuous f) : uniform_continuous f :=
+uniform_continuous_of_tendsto_one $
+  suffices tendsto f (𝓝 1) (𝓝 (f 1)), by rwa f.map_one at this,
+  h.tendsto 1
 
-lemma cauchy_seq.add {ι : Type*} [semilattice_sup ι] {u v : ι → α} (hu : cauchy_seq u)
-  (hv : cauchy_seq v) : cauchy_seq (u + v) :=
-uniform_continuous_add.comp_cauchy_seq (hu.prod hv)
+@[to_additive] lemma cauchy_seq.mul {ι : Type*} [semilattice_sup ι] {u v : ι → α}
+  (hu : cauchy_seq u) (hv : cauchy_seq v) : cauchy_seq (u * v) :=
+uniform_continuous_mul.comp_cauchy_seq (hu.prod hv)
 
-end uniform_add_group
+end uniform_group
 
 section topological_comm_group
 open filter
@@ -232,103 +241,103 @@ variables {G}
 
 end topological_comm_group
 
-section topological_add_comm_group
+section topological_comm_group
 universes u v w x
 open filter
 
-variables (G : Type*) [add_comm_group G] [topological_space G] [topological_add_group G]
+variables (G : Type*) [comm_group G] [topological_space G] [topological_group G]
 
 section
-local attribute [instance] topological_add_group.to_uniform_space
+local attribute [instance] topological_group.to_uniform_space
 
-lemma uniformity_eq_comap_nhds_zero' : 𝓤 G = comap (λp:G×G, p.2 - p.1) (𝓝 (0 : G)) := rfl
+@[to_additive] lemma uniformity_eq_comap_nhds_one' :
+  𝓤 G = comap (λp:G×G, p.2 / p.1) (𝓝 (1 : G)) := rfl
 
 variable {G}
-lemma topological_add_group_is_uniform : uniform_add_group G :=
+@[to_additive] lemma topological_group_is_uniform : uniform_group G :=
 have tendsto
-    ((λp:(G×G), p.1 - p.2) ∘ (λp:(G×G)×(G×G), (p.1.2 - p.1.1, p.2.2 - p.2.1)))
-    (comap (λp:(G×G)×(G×G), (p.1.2 - p.1.1, p.2.2 - p.2.1)) ((𝓝 0).prod (𝓝 0)))
-    (𝓝 (0 - 0)) :=
-  (tendsto_fst.sub tendsto_snd).comp tendsto_comap,
+    ((λp:(G×G), p.1 / p.2) ∘ (λp:(G×G)×(G×G), (p.1.2 / p.1.1, p.2.2 / p.2.1)))
+    (comap (λp:(G×G)×(G×G), (p.1.2 / p.1.1, p.2.2 / p.2.1)) ((𝓝 1).prod (𝓝 1)))
+    (𝓝 (1 / 1)) :=
+  (tendsto_fst.div' tendsto_snd).comp tendsto_comap,
 begin
   constructor,
   rw [uniform_continuous, uniformity_prod_eq_prod, tendsto_map'_iff,
-    uniformity_eq_comap_nhds_zero' G, tendsto_comap_iff, prod_comap_comap_eq],
-  simpa [(∘), sub_eq_add_neg, add_comm, add_left_comm] using this
+    uniformity_eq_comap_nhds_one' G, tendsto_comap_iff, prod_comap_comap_eq],
+  simpa [(∘), div_eq_mul_inv, mul_comm, mul_left_comm] using this
 end
 
-local attribute [instance] topological_add_group_is_uniform
+local attribute [instance] topological_group_is_uniform
 
 open set
 
-lemma topological_add_group.separated_iff_zero_closed :
-  separated_space G ↔ is_closed ({0} : set G) :=
+@[to_additive] lemma topological_group.separated_iff_one_closed :
+  separated_space G ↔ is_closed ({1} : set G) :=
 begin
   rw [separated_space_iff, ← closure_eq_iff_is_closed],
   split; intro h,
   { apply subset.antisymm,
     { intros x x_in,
-      have := group_separation_rel x 0,
-      rw sub_zero at this,
+      have := group_separation_rel x 1,
+      rw div_one' at this,
       rw [← this, h] at x_in,
-      change x = 0 at x_in,
+      change x = 1 at x_in,
       simp [x_in] },
     { exact subset_closure } },
   { ext p,
     cases p with x y,
-    rw [group_separation_rel x, h, mem_singleton_iff, sub_eq_zero],
+    rw [group_separation_rel x, h, mem_singleton_iff, div_eq_one],
     refl }
 end
 
-lemma topological_add_group.separated_of_zero_sep (H : ∀ x : G, x ≠ 0 → ∃ U ∈ nhds (0 : G), x ∉ U) :
-  separated_space G:=
+@[to_additive] lemma topological_group.separated_of_one_sep
+  (H : ∀ x : G, x ≠ 1 → ∃ U ∈ nhds (1 : G), x ∉ U) : separated_space G:=
 begin
-  rw [topological_add_group.separated_iff_zero_closed, ← is_open_compl_iff, is_open_iff_mem_nhds],
+  rw [topological_group.separated_iff_one_closed, ← is_open_compl_iff, is_open_iff_mem_nhds],
   intros x x_not,
-  have : x ≠ 0, from mem_compl_singleton_iff.mp x_not,
+  have : x ≠ 1, from mem_compl_singleton_iff.mp x_not,
   rcases H x this with ⟨U, U_in, xU⟩,
-  rw ← nhds_zero_symm G at U_in,
+  rw ← nhds_one_symm G at U_in,
   rcases U_in with ⟨W, W_in, UW⟩,
-  rw ← nhds_translation_add_neg,
+  rw ← nhds_translation_mul_inv,
   use [W, W_in],
   rw subset_compl_comm,
-  suffices : -x ∉ W, by simpa,
+  suffices : x⁻¹ ∉ W, by simpa,
   exact λ h, xU (UW h)
 end
 
 end
 
-lemma to_uniform_space_eq {G : Type*} [u : uniform_space G] [add_comm_group G]
-  [uniform_add_group G] :
-  topological_add_group.to_uniform_space G = u :=
+@[to_additive] lemma uniform_group.to_uniform_space_eq {G : Type*} [u : uniform_space G]
+  [comm_group G] [uniform_group G] : topological_group.to_uniform_space G = u :=
 begin
   ext : 1,
-  show @uniformity G (topological_add_group.to_uniform_space G) = 𝓤 G,
-  rw [uniformity_eq_comap_nhds_zero' G, uniformity_eq_comap_nhds_zero G]
+  show @uniformity G (topological_group.to_uniform_space G) = 𝓤 G,
+  rw [uniformity_eq_comap_nhds_one' G, uniformity_eq_comap_nhds_one G]
 end
 
-end topological_add_comm_group
+end topological_comm_group
 
-open add_comm_group filter set function
+open comm_group filter set function
 
 section
 variables {α : Type*} {β : Type*}
-variables [topological_space α] [add_comm_group α] [topological_add_group α]
+variables [topological_space α] [comm_group α] [topological_group α]
 
 -- β is a dense subgroup of α, inclusion is denoted by e
-variables [topological_space β] [add_comm_group β]
-variables {e : β →+ α} (de : dense_inducing e)
+variables [topological_space β] [comm_group β]
+variables {e : β →* α} (de : dense_inducing e)
 include de
 
-lemma tendsto_sub_comap_self (x₀ : α) :
-  tendsto (λt:β×β, t.2 - t.1) (comap (λp:β×β, (e p.1, e p.2)) $ 𝓝 (x₀, x₀)) (𝓝 0) :=
+@[to_additive] lemma tendsto_div_comap_self (x₀ : α) :
+  tendsto (λt:β×β, t.2 / t.1) (comap (λp:β×β, (e p.1, e p.2)) $ 𝓝 (x₀, x₀)) (𝓝 1) :=
 begin
-  have comm : (λx:α×α, x.2-x.1) ∘ (λt:β×β, (e t.1, e t.2)) = e ∘ (λt:β×β, t.2 - t.1),
+  have comm : (λx:α×α, x.2/x.1) ∘ (λt:β×β, (e t.1, e t.2)) = e ∘ (λt:β×β, t.2 / t.1),
   { ext t,
-    change e t.2 - e t.1 = e (t.2 - t.1),
-    rwa ← e.map_sub t.2 t.1 },
-  have lim : tendsto (λ x : α × α, x.2-x.1) (𝓝 (x₀, x₀)) (𝓝 (e 0)),
-  { simpa using (continuous_sub.comp (@continuous_swap α α _ _)).tendsto (x₀, x₀) },
+    change e t.2 / e t.1 = e (t.2 / t.1),
+    rwa ← e.map_div t.2 t.1 },
+  have lim : tendsto (λ x : α × α, x.2/x.1) (𝓝 (x₀, x₀)) (𝓝 (e 1)),
+  { simpa using (continuous_div'.comp (@continuous_swap α α _ _)).tendsto (x₀, x₀) },
   simpa using de.tendsto_comap_nhds_nhds lim comm
 end
 end

--- a/src/topology/algebra/uniform_ring.lean
+++ b/src/topology/algebra/uniform_ring.lean
@@ -114,7 +114,7 @@ variables {β : Type u} [uniform_space β] [ring β] [uniform_add_group β] [top
 def extension_hom [complete_space β] [separated_space β] :
   completion α →+* β :=
 have hf' : continuous (f : α →+ β), from hf, -- helping the elaborator
-have hf : uniform_continuous f, from uniform_continuous_of_continuous hf',
+have hf : uniform_continuous f, from uniform_continuous_add_monoid_hom_of_continuous hf',
 { to_fun := completion.extension f,
   map_zero' := by rw [← coe_zero, extension_coe hf, f.map_zero],
   map_add' := assume a b, completion.induction_on₂ a b
@@ -157,7 +157,7 @@ namespace uniform_space
 variables {α : Type*}
 lemma ring_sep_rel (α) [comm_ring α] [uniform_space α] [uniform_add_group α] [topological_ring α] :
   separation_setoid α = submodule.quotient_rel (ideal.closure ⊥) :=
-setoid.ext $ assume x y, group_separation_rel x y
+setoid.ext $ assume x y, add_group_separation_rel x y
 
 lemma ring_sep_quot
   (α : Type u) [r : comm_ring α] [uniform_space α] [uniform_add_group α] [topological_ring α] :
@@ -170,7 +170,7 @@ corresponding to the closure of zero. -/
 def sep_quot_equiv_ring_quot (α)
   [r : comm_ring α] [uniform_space α] [uniform_add_group α] [topological_ring α] :
   quotient (separation_setoid α) ≃ (α ⧸ (⊥ : ideal α).closure) :=
-quotient.congr_right $ assume x y, group_separation_rel x y
+quotient.congr_right $ assume x y, add_group_separation_rel x y
 
 /- TODO: use a form of transport a.k.a. lift definition a.k.a. transfer -/
 instance comm_ring [comm_ring α] [uniform_space α] [uniform_add_group α] [topological_ring α] :


### PR DESCRIPTION
This PR refactors `topology/algebra/uniform_group` to use `to_additive`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
