### PR TITLE
[Merged by Bors] - feat(group_theory/nilpotent): add upper_central_series_eq_top_iff_nilpotency_class_le

### DIFF
--- a/src/group_theory/nilpotent.lean
+++ b/src/group_theory/nilpotent.lean
@@ -423,7 +423,7 @@ begin
   split,
   { intro h,
     rw ← lower_central_series_length_eq_nilpotency_class,
-    exact (nat.find_le h),
+    exact (nat.find_le h), },
   { intro h,
     apply eq_bot_iff.mpr,
     rw ← lower_central_series_nilpotency_class,

--- a/src/group_theory/nilpotent.lean
+++ b/src/group_theory/nilpotent.lean
@@ -354,6 +354,18 @@ lemma upper_central_series_nilpotency_class :
   upper_central_series G (group.nilpotency_class G) = ⊤ :=
 nat.find_spec (is_nilpotent.nilpotent G)
 
+lemma upper_central_series_eq_top_iff_nilpotency_class_le {n : ℕ} :
+  (upper_central_series G n = ⊤) ↔ (group.nilpotency_class G ≤ n) :=
+begin
+  split,
+  { intro h,
+    exact (nat.find_le h), },
+  { intro h,
+    apply eq_top_iff.mpr,
+    rw ← upper_central_series_nilpotency_class,
+    exact (upper_central_series_mono _ h), }
+end
+
 /-- The nilpotency class of a nilpotent `G` is equal to the smallest `n` for which an ascending
 central series reaches `G` in its `n`'th term. -/
 lemma least_ascending_central_series_length_eq_nilpotency_class :
@@ -403,6 +415,19 @@ lemma lower_central_series_nilpotency_class :
 begin
   rw ← lower_central_series_length_eq_nilpotency_class,
   exact (nat.find_spec (nilpotent_iff_lower_central_series.mp _))
+end
+
+lemma lower_central_series_eq_bot_iff_nilpotency_class_le {n : ℕ} :
+  (lower_central_series G n = ⊥) ↔ (group.nilpotency_class G ≤ n) :=
+begin
+  split,
+  { intro h,
+    rw ← lower_central_series_length_eq_nilpotency_class,
+    exact (nat.find_le h),
+  { intro h,
+    apply eq_bot_iff.mpr,
+    rw ← lower_central_series_nilpotency_class,
+    exact (lower_central_series_antitone h), }
 end
 
 end classical


### PR DESCRIPTION
and the analogue for the lower central series.



---
extracted from https://github.com/leanprover-community/mathlib/pull/11592

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
