### PR TITLE
[Merged by Bors] - chore(topology/algebra/uniform_group): Remove newline after docstring

### DIFF
--- a/src/topology/algebra/uniform_group.lean
+++ b/src/topology/algebra/uniform_group.lean
@@ -27,7 +27,6 @@ open filter set
 variables {α : Type*} {β : Type*}
 
 /-- A uniform group is a group in which multiplication and inversion are uniformly continuous. -/
-
 class uniform_group (α : Type*) [uniform_space α] [group α] : Prop :=
 (uniform_continuous_div : uniform_continuous (λp:α×α, p.1 / p.2))
 


### PR DESCRIPTION
Yael pointed out that #11662 added an erroneous newline after a docstring. This PR removes that newline.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
