### PR TITLE
[Merged by Bors] - refactor(set_theory/ordinal): Add `covariant_class` instances for ordinal addition and multiplication

### DIFF
--- a/src/set_theory/cardinal_ordinal.lean
+++ b/src/set_theory/cardinal_ordinal.lean
@@ -190,7 +190,7 @@ end
 def aleph (o : ordinal) : cardinal := aleph' (ordinal.omega + o)
 
 @[simp] theorem aleph_lt {o₁ o₂ : ordinal.{u}} : aleph o₁ < aleph o₂ ↔ o₁ < o₂ :=
-aleph'_lt.trans (ordinal.add_lt_add_iff_left _)
+aleph'_lt.trans (add_lt_add_iff_left _)
 
 @[simp] theorem aleph_le {o₁ o₂ : ordinal.{u}} : aleph o₁ ≤ aleph o₂ ↔ o₁ ≤ o₂ :=
 le_iff_le_iff_lt_iff_lt.2 aleph_lt

--- a/src/set_theory/ordinal.lean
+++ b/src/set_theory/ordinal.lean
@@ -966,7 +966,7 @@ instance : add_monoid ordinal.{u} :=
       simp only [sum_assoc_apply_inl_inl, sum_assoc_apply_inl_inr, sum_assoc_apply_inr,
         sum.lex_inl_inl, sum.lex_inr_inr, sum.lex.sep, sum.lex_inr_inl] end⟩⟩ }
 
-instance : covariant_class ordinal.{u} ordinal.{u} (+) (≤) :=
+instance has_le.le.add_covariant_class : covariant_class ordinal.{u} ordinal.{u} (+) (≤) :=
 ⟨λ c a b h, begin
   revert h c, exact (
   induction_on a $ λ α₁ r₁ _, induction_on b $ λ α₂ r₂ _ ⟨⟨⟨f, fo⟩, fi⟩⟩ c,
@@ -986,19 +986,23 @@ instance : covariant_class ordinal.{u} ordinal.{u} (+) (≤) :=
     end⟩⟩)
 end⟩
 
+instance has_le.le.add_swap_covariant_class :
+  covariant_class ordinal.{u} ordinal.{u} (function.swap (+)) (≤) :=
+⟨λ c a b h, begin
+  revert h c, exact (
+  induction_on a $ λ α₁ r₁ hr₁, induction_on b $ λ α₂ r₂ hr₂ ⟨⟨⟨f, fo⟩, fi⟩⟩ c,
+  induction_on c $ λ β s hs, (@type_le' _ _ _ _
+    (@sum.lex.is_well_order _ _ _ _ hr₁ hs)
+    (@sum.lex.is_well_order _ _ _ _ hr₂ hs)).2
+  ⟨⟨f.sum_map (embedding.refl _), λ a b, begin
+    split; intro H,
+    { cases a with a a; cases b with b b; cases H; constructor; [rwa ← fo, assumption] },
+    { cases H; constructor; [rwa fo, assumption] }
+  end⟩⟩)
+end⟩
+
 theorem le_add_right (a b : ordinal) : a ≤ a + b :=
 by simpa only [add_zero] using add_le_add_left (ordinal.zero_le b) a
-
-theorem add_le_add_right {a b : ordinal} : a ≤ b → ∀ c, a + c ≤ b + c :=
-induction_on a $ λ α₁ r₁ hr₁, induction_on b $ λ α₂ r₂ hr₂ ⟨⟨⟨f, fo⟩, fi⟩⟩ c,
-induction_on c $ λ β s hs, (@type_le' _ _ _ _
-  (@sum.lex.is_well_order _ _ _ _ hr₁ hs)
-  (@sum.lex.is_well_order _ _ _ _ hr₂ hs)).2
-⟨⟨f.sum_map (embedding.refl _), λ a b, begin
-  split; intro H,
-  { cases a with a a; cases b with b b; cases H; constructor; [rwa ← fo, assumption] },
-  { cases H; constructor; [rwa fo, assumption] }
-end⟩⟩
 
 theorem le_add_left (a b : ordinal) : a ≤ b + a :=
 by simpa only [zero_add] using add_le_add_right (ordinal.zero_le b) a

--- a/src/set_theory/ordinal.lean
+++ b/src/set_theory/ordinal.lean
@@ -966,22 +966,25 @@ instance : add_monoid ordinal.{u} :=
       simp only [sum_assoc_apply_inl_inl, sum_assoc_apply_inl_inr, sum_assoc_apply_inr,
         sum.lex_inl_inl, sum.lex_inr_inr, sum.lex.sep, sum.lex_inr_inl] end⟩⟩ }
 
-theorem add_le_add_left {a b : ordinal} : a ≤ b → ∀ c, c + a ≤ c + b :=
-induction_on a $ λ α₁ r₁ _, induction_on b $ λ α₂ r₂ _ ⟨⟨⟨f, fo⟩, fi⟩⟩ c,
-induction_on c $ λ β s _,
-⟨⟨⟨(embedding.refl _).sum_map f,
-  λ a b, match a, b with
-    | sum.inl a, sum.inl b := sum.lex_inl_inl.trans sum.lex_inl_inl.symm
-    | sum.inl a, sum.inr b := by apply iff_of_true; apply sum.lex.sep
-    | sum.inr a, sum.inl b := by apply iff_of_false; exact sum.lex_inr_inl
-    | sum.inr a, sum.inr b := sum.lex_inr_inr.trans $ fo.trans sum.lex_inr_inr.symm
-    end⟩,
-  λ a b H, match a, b, H with
-    | _,         sum.inl b, _ := ⟨sum.inl b, rfl⟩
-    | sum.inl a, sum.inr b, H := (sum.lex_inr_inl H).elim
-    | sum.inr a, sum.inr b, H := let ⟨w, h⟩ := fi _ _ (sum.lex_inr_inr.1 H) in
-        ⟨sum.inr w, congr_arg sum.inr h⟩
-  end⟩⟩
+instance : covariant_class ordinal.{u} ordinal.{u} (+) (≤) :=
+⟨λ c a b h, begin
+  revert h c, exact (
+  induction_on a $ λ α₁ r₁ _, induction_on b $ λ α₂ r₂ _ ⟨⟨⟨f, fo⟩, fi⟩⟩ c,
+  induction_on c $ λ β s _,
+  ⟨⟨⟨(embedding.refl _).sum_map f,
+    λ a b, match a, b with
+      | sum.inl a, sum.inl b := sum.lex_inl_inl.trans sum.lex_inl_inl.symm
+      | sum.inl a, sum.inr b := by apply iff_of_true; apply sum.lex.sep
+      | sum.inr a, sum.inl b := by apply iff_of_false; exact sum.lex_inr_inl
+      | sum.inr a, sum.inr b := sum.lex_inr_inr.trans $ fo.trans sum.lex_inr_inr.symm
+      end⟩,
+    λ a b H, match a, b, H with
+      | _,         sum.inl b, _ := ⟨sum.inl b, rfl⟩
+      | sum.inl a, sum.inr b, H := (sum.lex_inr_inl H).elim
+      | sum.inr a, sum.inr b, H := let ⟨w, h⟩ := fi _ _ (sum.lex_inr_inr.1 H) in
+          ⟨sum.inr w, congr_arg sum.inr h⟩
+    end⟩⟩)
+end⟩
 
 theorem le_add_right (a b : ordinal) : a ≤ a + b :=
 by simpa only [add_zero] using add_le_add_left (ordinal.zero_le b) a

--- a/src/set_theory/ordinal.lean
+++ b/src/set_theory/ordinal.lean
@@ -1000,9 +1000,6 @@ induction_on c $ λ β s hs, (@type_le' _ _ _ _
   { cases H; constructor; [rwa fo, assumption] }
 end⟩⟩
 
-protected theorem add_le_add {a b c d : ordinal} (hab : a ≤ b) (hcd : c ≤ d) : a + c ≤ b + d :=
-(add_le_add_right hab c).trans (add_le_add_left hcd b)
-
 theorem le_add_left (a b : ordinal) : a ≤ b + a :=
 by simpa only [zero_add] using add_le_add_right (ordinal.zero_le b) a
 

--- a/src/set_theory/ordinal.lean
+++ b/src/set_theory/ordinal.lean
@@ -997,6 +997,9 @@ induction_on c $ λ β s hs, (@type_le' _ _ _ _
   { cases H; constructor; [rwa fo, assumption] }
 end⟩⟩
 
+protected theorem add_le_add {a b c d : ordinal} (hab : a ≤ b) (hcd : c ≤ d) : a + c ≤ b + d :=
+(add_le_add_right hab c).trans (add_le_add_left hcd b)
+
 theorem le_add_left (a b : ordinal) : a ≤ b + a :=
 by simpa only [zero_add] using add_le_add_right (ordinal.zero_le b) a
 

--- a/src/set_theory/ordinal_arithmetic.lean
+++ b/src/set_theory/ordinal_arithmetic.lean
@@ -130,6 +130,9 @@ by rw [←succ_zero, lt_succ, ordinal.le_zero]
 theorem add_lt_add_iff_left (a) {b c : ordinal} : a + b < a + c ↔ b < c :=
 by rw [← not_le, ← not_le, add_le_add_iff_left]
 
+instance : covariant_class ordinal.{u} ordinal.{u} (+) (<) :=
+⟨λ a b c, (add_lt_add_iff_left a).2⟩
+
 instance : contravariant_class ordinal.{u} ordinal.{u} (+) (<) :=
 ⟨λ a b c, (add_lt_add_iff_left a).1⟩
 

--- a/src/set_theory/ordinal_arithmetic.lean
+++ b/src/set_theory/ordinal_arithmetic.lean
@@ -604,9 +604,6 @@ by { convert mul_le_mul_left' (one_le_iff_pos.2 hb) a, rw mul_one a }
 theorem le_mul_right (a : ordinal) {b : ordinal} (hb : 0 < b) : a ≤ b * a :=
 by { convert mul_le_mul_right' (one_le_iff_pos.2 hb) a, rw one_mul a }
 
-theorem mul_le_mul {a b c d : ordinal} (h₁ : a ≤ c) (h₂ : b ≤ d) : a * b ≤ c * d :=
-(mul_le_mul_left' h₂ _).trans (mul_le_mul_right' h₁ _)
-
 private lemma mul_le_of_limit_aux {α β r s} [is_well_order α r] [is_well_order β s]
   {c} (h : is_limit (type s)) (H : ∀ b' < type s, type r * b' ≤ c)
   (l : c < type r * type s) : false :=
@@ -1425,7 +1422,7 @@ begin
     { simp only [zero_opow c0, ordinal.zero_le] } },
   { apply limit_rec_on c,
     { simp only [opow_zero] },
-    { intros c IH, simpa only [opow_succ] using mul_le_mul IH ab },
+    { intros c IH, simpa only [opow_succ] using mul_le_mul' IH ab },
     { exact λ c l IH, (opow_le_of_limit a0 l).2
         (λ b' h, le_trans (IH _ h) (opow_le_opow_right
           (lt_of_lt_of_le (ordinal.pos_iff_ne_zero.2 a0) ab) (le_of_lt h))) } }
@@ -1620,7 +1617,7 @@ theorem add_log_le_log_mul {x y : ordinal} (b : ordinal) (x0 : 0 < x) (y0 : 0 < 
 begin
   by_cases hb : 1 < b,
   { rw [le_log hb (mul_pos x0 y0), opow_add],
-    exact mul_le_mul (opow_log_le b x0) (opow_log_le b y0) },
+    exact mul_le_mul' (opow_log_le b x0) (opow_log_le b y0) },
   simp only [log_not_one_lt hb, zero_add]
 end
 
@@ -1996,7 +1993,7 @@ begin
     rw [opow_succ, mul_assoc, mul_lt_mul_iff_left (opow_pos _ omega_pos)],
     exact mul_lt_omega hn hb },
   { rcases ((opow_is_normal one_lt_omega).limit_lt l).1 ha with ⟨x, hx, ax⟩,
-    refine (mul_le_mul (le_of_lt ax) (le_of_lt hb)).trans_lt _,
+    refine (mul_le_mul' (le_of_lt ax) (le_of_lt hb)).trans_lt _,
     rw [← opow_succ, opow_lt_opow_iff_right one_lt_omega],
     exact l.2 _ hx }
 end

--- a/src/set_theory/ordinal_arithmetic.lean
+++ b/src/set_theory/ordinal_arithmetic.lean
@@ -130,6 +130,9 @@ by rw [←succ_zero, lt_succ, ordinal.le_zero]
 theorem add_lt_add_iff_left (a) {b c : ordinal} : a + b < a + c ↔ b < c :=
 by rw [← not_le, ← not_le, add_le_add_iff_left]
 
+instance : contravariant_class ordinal.{u} ordinal.{u} (+) (<) :=
+⟨λ a b c, (add_lt_add_iff_left a).1⟩
+
 theorem lt_of_add_lt_add_right {a b c : ordinal} : a + b < c + b → a < c :=
 lt_imp_lt_of_le_imp_le (λ h, add_le_add_right h _)
 

--- a/src/set_theory/ordinal_arithmetic.lean
+++ b/src/set_theory/ordinal_arithmetic.lean
@@ -127,14 +127,14 @@ by rw [← not_le, succ_le, not_lt]
 theorem lt_one_iff_zero {a : ordinal} : a < 1 ↔ a = 0 :=
 by rw [←succ_zero, lt_succ, ordinal.le_zero]
 
-theorem add_lt_add_iff_left (a) {b c : ordinal} : a + b < a + c ↔ b < c :=
+private theorem add_lt_add_iff_left' (a) {b c : ordinal} : a + b < a + c ↔ b < c :=
 by rw [← not_le, ← not_le, add_le_add_iff_left]
 
 instance : covariant_class ordinal.{u} ordinal.{u} (+) (<) :=
-⟨λ a b c, (add_lt_add_iff_left a).2⟩
+⟨λ a b c, (add_lt_add_iff_left' a).2⟩
 
 instance : contravariant_class ordinal.{u} ordinal.{u} (+) (<) :=
-⟨λ a b c, (add_lt_add_iff_left a).1⟩
+⟨λ a b c, (add_lt_add_iff_left' a).1⟩
 
 theorem lt_of_add_lt_add_right {a b c : ordinal} : a + b < c + b → a < c :=
 lt_imp_lt_of_le_imp_le (λ h, add_le_add_right h _)

--- a/src/set_theory/ordinal_arithmetic.lean
+++ b/src/set_theory/ordinal_arithmetic.lean
@@ -1955,6 +1955,7 @@ le_antisymm
     rw IH _ h,
     apply le_trans (add_le_add_left _ _),
     { rw ← mul_succ, exact mul_le_mul_left _ (succ_le.2 $ l.2 _ h) },
+    { apply_instance },
     { rw ← ba, exact le_add_right _ _ }
   end)
   (mul_le_mul_right _ (le_add_right _ _))

--- a/src/set_theory/ordinal_arithmetic.lean
+++ b/src/set_theory/ordinal_arithmetic.lean
@@ -1958,7 +1958,6 @@ le_antisymm
     rw IH _ h,
     apply le_trans (add_le_add_left _ _),
     { rw ← mul_succ, exact mul_le_mul_left' (succ_le.2 $ l.2 _ h) _ },
-    { apply_instance },
     { rw ← ba, exact le_add_right _ _ }
   end)
   (mul_le_mul_right' (le_add_right _ _) _)

--- a/src/set_theory/ordinal_arithmetic.lean
+++ b/src/set_theory/ordinal_arithmetic.lean
@@ -71,9 +71,9 @@ quotient.sound ⟨(rel_iso.preimage equiv.ulift _).trans
 @[simp] theorem lift_succ (a) : lift (succ a) = succ (lift a) :=
 by unfold succ; simp only [lift_add, lift_one]
 
-theorem add_le_add_iff_left (a) {b c : ordinal} : a + b ≤ a + c ↔ b ≤ c :=
-⟨induction_on a $ λ α r hr, induction_on b $ λ β₁ s₁ hs₁, induction_on c $ λ β₂ s₂ hs₂ ⟨f⟩, ⟨
-  have fl : ∀ a, f (sum.inl a) = sum.inl a := λ a,
+instance has_le.le.add_contravariant_class : contravariant_class ordinal.{u} ordinal.{u} (+) (≤) :=
+⟨λ a b c, induction_on a $ λ α r hr, induction_on b $ λ β₁ s₁ hs₁, induction_on c $ λ β₂ s₂ hs₂ ⟨f⟩,
+  ⟨have fl : ∀ a, f (sum.inl a) = sum.inl a := λ a,
     by simpa only [initial_seg.trans_apply, initial_seg.le_add_apply]
       using @initial_seg.eq _ _ _ _ (@sum.lex.is_well_order _ _ _ _ hr hs₂)
         ((initial_seg.le_add r s₁).trans f) (initial_seg.le_add r s₂) a,
@@ -93,8 +93,7 @@ theorem add_le_add_iff_left (a) {b c : ordinal} : a + b ≤ a + c ↔ b ≤ c :=
       rcases f.init' (by rw fr; exact sum.lex_inr_inr.2 H) with ⟨a'|a', h⟩,
       { rw fl at h, cases h },
       { rw fr at h, exact ⟨a', sum.inr.inj h⟩ }
-    end⟩⟩,
-λ h, add_le_add_left h _⟩
+    end⟩⟩⟩
 
 theorem add_succ (o₁ o₂ : ordinal) : o₁ + succ o₂ = succ (o₁ + o₂) :=
 (add_assoc _ _ _).symm
@@ -1958,6 +1957,7 @@ le_antisymm
     rw IH _ h,
     apply le_trans (add_le_add_left _ _),
     { rw ← mul_succ, exact mul_le_mul_left' (succ_le.2 $ l.2 _ h) _ },
+    { apply_instance },
     { rw ← ba, exact le_add_right _ _ }
   end)
   (mul_le_mul_right' (le_add_right _ _) _)

--- a/src/set_theory/ordinal_notation.lean
+++ b/src/set_theory/ordinal_notation.lean
@@ -196,9 +196,9 @@ begin
   induction h with _ e n a eb b h₁ h₂ h₃ _ IH,
   { exact opow_pos _ omega_pos },
   { rw repr,
-    refine lt_of_lt_of_le ((ordinal.add_lt_add_iff_left _).2 IH) _,
+    apply ((ordinal.add_lt_add_iff_left _).2 IH).trans_le,
     rw ← mul_succ,
-    refine le_trans (mul_le_mul_left _ $ ordinal.succ_le.2 $ nat_lt_omega _) _,
+    apply (mul_le_mul_left' (ordinal.succ_le.2 (nat_lt_omega _)) _).trans,
     rw ← opow_succ,
     exact opow_le_opow_right omega_pos (ordinal.succ_le.2 h₃) }
 end
@@ -437,7 +437,7 @@ instance sub_NF (o₁ o₂) : ∀ [NF o₁] [NF o₂], NF (o₁ - o₂)
           add_comm, nat.cast_add, ordinal.mul_add, add_assoc, add_sub_add_cancel],
       refine (ordinal.sub_eq_of_add_eq $ add_absorp h₂.snd'.repr_lt $
         le_trans _ (le_add_right _ _)).symm,
-      simpa using mul_le_mul_left _ (nat_cast_le.2 $ nat.succ_pos _) } },
+      simpa using mul_le_mul_left' (nat_cast_le.2 $ nat.succ_pos _) _ } },
   { exact (ordinal.sub_eq_of_add_eq $ add_absorp (h₂.below_of_lt ee).repr_lt $
       omega_le_oadd _ _ _).symm }
 end
@@ -684,12 +684,12 @@ begin
   rw [← opow_mul, ← opow_mul],
   apply opow_le_opow_right omega_pos,
   cases le_or_lt ω (repr e) with h h,
-  { apply le_trans (mul_le_mul_left _ $ le_of_lt $ lt_succ_self _),
+  { apply le_trans (mul_le_mul_left' (le_of_lt (lt_succ_self _)) _),
     rw [succ, add_mul_succ _ (one_add_of_omega_le h), ← succ,
         succ_le, mul_lt_mul_iff_left (ordinal.pos_iff_ne_zero.2 e0)],
     exact omega_is_limit.2 _ l },
   { refine le_trans (le_of_lt $ mul_lt_omega (omega_is_limit.2 _ h) l) _,
-    simpa using mul_le_mul_right ω (one_le_iff_ne_zero.2 e0) }
+    simpa using mul_le_mul_right' (one_le_iff_ne_zero.2 e0) ω }
 end
 
 section

--- a/src/set_theory/ordinal_notation.lean
+++ b/src/set_theory/ordinal_notation.lean
@@ -733,7 +733,7 @@ begin
       refine mul_lt_omega_opow rr0 this (nat_lt_omega _),
       simpa using (add_lt_add_iff_left (repr a0)).2 e0 },
     { refine lt_of_lt_of_le Rl (opow_le_opow_right omega_pos $
-        mul_le_mul_left _ $ succ_le_succ.2 $ nat_cast_le.2 $ le_of_lt k.lt_succ_self) } },
+        mul_le_mul_left' (succ_le_succ.2 (nat_cast_le.2 (le_of_lt k.lt_succ_self))) _) } },
   calc
         ω0 ^ k.succ * α' + R'
       = ω0 ^ succ k * α' + (ω0 ^ k * α' * m + R) : by rw [nat_cast_succ, RR, ← mul_assoc]
@@ -749,14 +749,14 @@ begin
     { refine add_lt_omega_opow _ Rl,
       rw [opow_mul, opow_succ, mul_lt_mul_iff_left ω00],
       exact No.snd'.repr_lt },
-    { have := mul_le_mul_left (ω0 ^ succ k) (one_le_iff_pos.2 $ nat_cast_pos.2 n.pos),
+    { have := mul_le_mul_left' (one_le_iff_pos.2 $ nat_cast_pos.2 n.pos) (ω0 ^ succ k),
       rw opow_mul, simpa [-opow_succ] } },
   { cases m,
     { have : R = 0, {cases k; simp [R, opow_aux]}, simp [this] },
     { rw [← nat_cast_succ, add_mul_succ],
       apply add_absorp Rl,
       rw [opow_mul, opow_succ],
-      apply ordinal.mul_le_mul_left,
+      apply mul_le_mul_left',
       simpa [α', repr] using omega_le_oadd a0 n a' } }
 end
 

--- a/src/set_theory/ordinal_notation.lean
+++ b/src/set_theory/ordinal_notation.lean
@@ -196,7 +196,7 @@ begin
   induction h with _ e n a eb b h₁ h₂ h₃ _ IH,
   { exact opow_pos _ omega_pos },
   { rw repr,
-    apply ((ordinal.add_lt_add_iff_left _).2 IH).trans_le,
+    apply ((add_lt_add_iff_left _).2 IH).trans_le,
     rw ← mul_succ,
     apply (mul_le_mul_left' (ordinal.succ_le.2 (nat_lt_omega _)) _).trans,
     rw ← opow_succ,
@@ -234,7 +234,7 @@ theorem oadd_lt_oadd_2 {e o₁ o₂ : onote} {n₁ n₂ : ℕ+}
   (h₁ : NF (oadd e n₁ o₁)) (h : (n₁:ℕ) < n₂) : oadd e n₁ o₁ < oadd e n₂ o₂ :=
 begin
   simp [lt_def],
-  refine lt_of_lt_of_le ((ordinal.add_lt_add_iff_left _).2 h₁.snd'.repr_lt)
+  refine lt_of_lt_of_le ((add_lt_add_iff_left _).2 h₁.snd'.repr_lt)
     (le_trans _ (le_add_right _ _)),
   rwa [← mul_succ, mul_le_mul_iff_left (opow_pos _ omega_pos),
        ordinal.succ_le, nat_cast_lt]
@@ -244,7 +244,7 @@ theorem oadd_lt_oadd_3 {e n a₁ a₂} (h : a₁ < a₂) :
   oadd e n a₁ < oadd e n a₂ :=
 begin
   rw lt_def, unfold repr,
-  exact (ordinal.add_lt_add_iff_left _).2 h
+  exact add_lt_add_left h _
 end
 
 theorem cmp_compares : ∀ (a b : onote) [NF a] [NF b], (cmp a b).compares a b
@@ -471,7 +471,7 @@ theorem oadd_mul_NF_below {e₁ n₁ a₁ b₁} (h₁ : NF_below (oadd e₁ n₁
   { haveI := h₁.fst, haveI := h₂.fst,
     apply NF_below.oadd, apply_instance,
     { rwa repr_add },
-    { rw [repr_add, ordinal.add_lt_add_iff_left], exact h₂.lt } }
+    { rw [repr_add, add_lt_add_iff_left], exact h₂.lt } }
 end
 
 instance mul_NF : ∀ o₁ o₂ [NF o₁] [NF o₂], NF (o₁ * o₂)


### PR DESCRIPTION
This replaces the old `add_le_add_left`, `add_le_add_right`, `mul_le_mul_left`, `mul_le_mul_right` theorems.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->


[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
