### PR TITLE
[Merged by Bors] - feat(set_theory/ordinal_arithmetic): Normal functions evaluated at `ω`

### DIFF
--- a/src/set_theory/ordinal.lean
+++ b/src/set_theory/ordinal.lean
@@ -1151,6 +1151,9 @@ wf.conditionally_complete_linear_order_with_bot 0 $ le_antisymm (ordinal.zero_le
 protected theorem not_lt_zero (o : ordinal) : ¬ o < 0 :=
 not_lt_bot
 
+theorem eq_zero_or_pos : ∀ a : ordinal, a = 0 ∨ 0 < a :=
+eq_bot_or_bot_lt
+
 lemma Inf_eq_omin {s : set ordinal} (hs : s.nonempty) :
   Inf s = omin s hs :=
 begin

--- a/src/set_theory/ordinal_arithmetic.lean
+++ b/src/set_theory/ordinal_arithmetic.lean
@@ -1861,8 +1861,8 @@ theorem omega_le {o : ordinal.{u}} : omega ≤ o ↔ ∀ n : ℕ, (n : ordinal) 
    let ⟨n, e⟩ := lt_omega.1 h in
    by rw [e, ← succ_le]; exact H (n+1)⟩
 
-theorem omega_eq_sup_nat_cast : omega = sup nat.cast :=
-(omega_le.2 $ le_sup _).antisymm $ sup_le.2 $ λ n, (nat_lt_omega n).le
+theorem sup_nat_cast : sup nat.cast = omega :=
+(sup_le.2 $ λ n, (nat_lt_omega n).le).antisymm $ omega_le.2 $ le_sup _
 
 theorem nat_lt_limit {o} (h : is_limit o) : ∀ n : ℕ, (n : ordinal) < o
 | 0     := lt_of_le_of_ne (ordinal.zero_le o) h.1.symm
@@ -2031,26 +2031,26 @@ le_antisymm
   (le_opow_self _ a1)
 
 theorem is_normal.apply_omega {f : ordinal.{u} → ordinal.{u}} (hf : is_normal f) :
-  f omega = sup.{0 u} (f ∘ nat.cast) :=
-by rw [omega_eq_sup_nat_cast, is_normal.sup.{0 u u} hf ⟨0⟩]
+  sup.{0 u} (f ∘ nat.cast) = f omega :=
+by rw [←sup_nat_cast, is_normal.sup.{0 u u} hf ⟨0⟩]
 
-theorem add_omega_eq_sup_add_nat (o : ordinal.{u}) : o + omega = sup (λ n : ℕ, o + n) :=
+theorem sup_add_nat (o : ordinal.{u}) : sup (λ n : ℕ, o + n) = o + omega :=
 (add_is_normal o).apply_omega
 
-theorem mul_omega_eq_sup_mul_nat (o : ordinal) : o * omega = sup (λ n : ℕ, o * n) :=
+theorem sup_mul_nat (o : ordinal) : sup (λ n : ℕ, o * n) = o * omega :=
 begin
   rcases eq_zero_or_pos o with rfl | ho,
-  { rw zero_mul, exact eq.symm (sup_eq_zero_iff.2 $ λ n, zero_mul _) },
+  { rw zero_mul, exact sup_eq_zero_iff.2 (λ n, zero_mul n) },
   { exact (mul_is_normal ho).apply_omega }
 end
 
-theorem opow_omega_eq_sup_power_nat {o : ordinal.{u}} (ho : 0 < o) :
-  o ^ omega = sup (λ n : ℕ, o ^ n) :=
+theorem sup_opow_nat {o : ordinal.{u}} (ho : 0 < o) :
+  sup (λ n : ℕ, o ^ n) = o ^ omega :=
 begin
   rcases lt_or_eq_of_le (one_le_iff_pos.2 ho) with ho₁ | rfl,
   { exact (opow_is_normal ho₁).apply_omega },
   { rw one_opow,
-    refine le_antisymm _ (sup_le.2 (λ n, by rw one_opow)),
+    refine le_antisymm (sup_le.2 (λ n, by rw one_opow)) _,
     convert le_sup _ 0,
     rw [nat.cast_zero, opow_zero] }
 end

--- a/src/set_theory/ordinal_arithmetic.lean
+++ b/src/set_theory/ordinal_arithmetic.lean
@@ -2042,11 +2042,8 @@ by rwa [add_omega_eq_sup_add_nat o, lt_sup] at h
 
 theorem mul_omega_eq_sup_mul_nat (o : ordinal) : o * omega = sup (λ n : ℕ, o * n) :=
 begin
-  cases eq_zero_or_pos o with ho ho,
-  { rw [ho, zero_mul],
-    apply eq.symm,
-    rw sup_eq_zero_iff,
-    exact λ n, zero_mul _ },
+  rcases eq_zero_or_pos o with rfl | ho,
+  { rw zero_mul, exact eq.symm (sup_eq_zero_iff.2 $ λ n, zero_mul _) },
   { exact (mul_is_normal ho).apply_omega }
 end
 
@@ -2056,9 +2053,9 @@ by rwa [mul_omega_eq_sup_mul_nat o, lt_sup] at h
 theorem opow_omega_eq_sup_power_nat {o : ordinal.{u}} (ho : 0 < o) :
   o ^ omega = sup (λ n : ℕ, o ^ n) :=
 begin
-  cases lt_or_eq_of_le (one_le_iff_pos.2 ho) with ho₁ ho₁,
+  rcases lt_or_eq_of_le (one_le_iff_pos.2 ho) with ho₁ | rfl,
   { exact (opow_is_normal ho₁).apply_omega },
-  { rw [←ho₁, one_opow],
+  { rw one_opow,
     refine le_antisymm _ (sup_le.2 (λ n, by rw one_opow)),
     convert le_sup _ 0,
     rw [nat.cast_zero, opow_zero] }
@@ -2066,8 +2063,8 @@ end
 
 lemma lt_opow_omega {a o : ordinal.{u}} (h : a < o ^ omega.{u}) : ∃ n : ℕ, a < o ^ n :=
 begin
-  cases eq_zero_or_pos o with ho ho,
-  { rw [ho, zero_opow omega_ne_zero] at h,
+  rcases eq_zero_or_pos o with rfl | ho,
+  { rw zero_opow omega_ne_zero at h,
     exact (ordinal.not_lt_zero a h).elim },
   { rwa [opow_omega_eq_sup_power_nat ho, lt_sup] at h }
 end

--- a/src/set_theory/ordinal_arithmetic.lean
+++ b/src/set_theory/ordinal_arithmetic.lean
@@ -2047,7 +2047,7 @@ begin
     apply eq.symm,
     rw sup_eq_zero_iff,
     exact λ n, zero_mul _ },
-  exact (mul_is_normal ho).apply_omega
+  { exact (mul_is_normal ho).apply_omega }
 end
 
 lemma lt_mul_omega {a o : ordinal} (h : a < o * omega) : ∃ n : ℕ, a < o * n :=
@@ -2056,17 +2056,12 @@ by rwa [mul_omega_eq_sup_mul_nat o, lt_sup] at h
 theorem opow_omega_eq_sup_power_nat {o : ordinal.{u}} (ho : 0 < o) :
   o ^ omega = sup (λ n : ℕ, o ^ n) :=
 begin
-  rw ←one_le_iff_pos at ho,
-  cases lt_or_eq_of_le ho with ho₁ ho₁,
+  cases lt_or_eq_of_le (one_le_iff_pos.2 ho) with ho₁ ho₁,
   { exact (opow_is_normal ho₁).apply_omega },
-  rw [←ho₁, one_opow],
-  apply le_antisymm,
-  { nth_rewrite 0 ←opow_zero 1,
-    rw ←nat.cast_zero,
-    exact le_sup _ 0 },
-  rw sup_le,
-  intro n,
-  rw one_opow
+  { rw [←ho₁, one_opow],
+    refine le_antisymm _ (sup_le.2 (λ n, by rw one_opow)),
+    convert le_sup _ 0,
+    rw [nat.cast_zero, opow_zero] }
 end
 
 lemma lt_opow_omega {a o : ordinal.{u}} (h : a < o ^ omega.{u}) : ∃ n : ℕ, a < o ^ n :=
@@ -2074,7 +2069,7 @@ begin
   cases eq_zero_or_pos o with ho ho,
   { rw [ho, zero_opow omega_ne_zero] at h,
     exact (ordinal.not_lt_zero a h).elim },
-  rwa [opow_omega_eq_sup_power_nat ho, lt_sup] at h
+  { rwa [opow_omega_eq_sup_power_nat ho, lt_sup] at h }
 end
 
 /-! ### Fixed points of normal functions -/

--- a/src/set_theory/ordinal_arithmetic.lean
+++ b/src/set_theory/ordinal_arithmetic.lean
@@ -1861,6 +1861,9 @@ theorem omega_le {o : ordinal.{u}} : omega ≤ o ↔ ∀ n : ℕ, (n : ordinal) 
    let ⟨n, e⟩ := lt_omega.1 h in
    by rw [e, ← succ_le]; exact H (n+1)⟩
 
+theorem omega_eq_sup_nat_cast : omega = sup nat.cast :=
+(omega_le.2 $ le_sup _).antisymm $ sup_le.2 $ λ n, (nat_lt_omega n).le
+
 theorem nat_lt_limit {o} (h : is_limit o) : ∀ n : ℕ, (n : ordinal) < o
 | 0     := lt_of_le_of_ne (ordinal.zero_le o) h.1.symm
 | (n+1) := h.2 _ (nat_lt_limit n)
@@ -2026,6 +2029,53 @@ le_antisymm
   ((opow_le_of_limit (one_le_iff_ne_zero.1 $ le_of_lt a1) omega_is_limit).2
     (λ b hb, le_of_lt (opow_lt_omega h hb)))
   (le_opow_self _ a1)
+
+theorem is_normal.apply_omega {f : ordinal.{u} → ordinal.{u}} (hf : is_normal f) :
+  f omega = sup.{0 u} (f ∘ nat.cast) :=
+by rw [omega_eq_sup_nat_cast, is_normal.sup.{0 u u} hf ⟨0⟩]
+
+theorem add_omega_eq_sup_add_nat (o : ordinal.{u}) : o + omega = sup (λ n : ℕ, o + n) :=
+(add_is_normal o).apply_omega
+
+lemma lt_add_omega {a o : ordinal.{u}} (h : a < o + omega) : ∃ n : ℕ, a < o + n :=
+by rwa [add_omega_eq_sup_add_nat o, lt_sup] at h
+
+theorem mul_omega_eq_sup_mul_nat (o : ordinal) : o * omega = sup (λ n : ℕ, o * n) :=
+begin
+  cases eq_zero_or_pos o with ho ho,
+  { rw [ho, zero_mul],
+    apply eq.symm,
+    rw sup_eq_zero_iff,
+    exact λ n, zero_mul _ },
+  exact (mul_is_normal ho).apply_omega
+end
+
+lemma lt_mul_omega {a o : ordinal} (h : a < o * omega) : ∃ n : ℕ, a < o * n :=
+by rwa [mul_omega_eq_sup_mul_nat o, lt_sup] at h
+
+theorem opow_omega_eq_sup_power_nat {o : ordinal.{u}} (ho : 0 < o) :
+  o ^ omega = sup (λ n : ℕ, o ^ n) :=
+begin
+  rw ←one_le_iff_pos at ho,
+  cases lt_or_eq_of_le ho with ho₁ ho₁,
+  { exact (opow_is_normal ho₁).apply_omega },
+  rw [←ho₁, one_opow],
+  apply le_antisymm,
+  { nth_rewrite 0 ←opow_zero 1,
+    rw ←nat.cast_zero,
+    exact le_sup _ 0 },
+  rw sup_le,
+  intro n,
+  rw one_opow
+end
+
+lemma lt_opow_omega {a o : ordinal.{u}} (h : a < o ^ omega.{u}) : ∃ n : ℕ, a < o ^ n :=
+begin
+  cases eq_zero_or_pos o with ho ho,
+  { rw [ho, zero_opow omega_ne_zero] at h,
+    exact (ordinal.not_lt_zero a h).elim },
+  rwa [opow_omega_eq_sup_power_nat ho, lt_sup] at h
+end
 
 /-! ### Fixed points of normal functions -/
 

--- a/src/set_theory/ordinal_arithmetic.lean
+++ b/src/set_theory/ordinal_arithmetic.lean
@@ -2037,18 +2037,12 @@ by rw [omega_eq_sup_nat_cast, is_normal.sup.{0 u u} hf ⟨0⟩]
 theorem add_omega_eq_sup_add_nat (o : ordinal.{u}) : o + omega = sup (λ n : ℕ, o + n) :=
 (add_is_normal o).apply_omega
 
-lemma lt_add_omega {a o : ordinal.{u}} (h : a < o + omega) : ∃ n : ℕ, a < o + n :=
-by rwa [add_omega_eq_sup_add_nat o, lt_sup] at h
-
 theorem mul_omega_eq_sup_mul_nat (o : ordinal) : o * omega = sup (λ n : ℕ, o * n) :=
 begin
   rcases eq_zero_or_pos o with rfl | ho,
   { rw zero_mul, exact eq.symm (sup_eq_zero_iff.2 $ λ n, zero_mul _) },
   { exact (mul_is_normal ho).apply_omega }
 end
-
-lemma lt_mul_omega {a o : ordinal} (h : a < o * omega) : ∃ n : ℕ, a < o * n :=
-by rwa [mul_omega_eq_sup_mul_nat o, lt_sup] at h
 
 theorem opow_omega_eq_sup_power_nat {o : ordinal.{u}} (ho : 0 < o) :
   o ^ omega = sup (λ n : ℕ, o ^ n) :=
@@ -2059,14 +2053,6 @@ begin
     refine le_antisymm _ (sup_le.2 (λ n, by rw one_opow)),
     convert le_sup _ 0,
     rw [nat.cast_zero, opow_zero] }
-end
-
-lemma lt_opow_omega {a o : ordinal.{u}} (h : a < o ^ omega.{u}) : ∃ n : ℕ, a < o ^ n :=
-begin
-  rcases eq_zero_or_pos o with rfl | ho,
-  { rw zero_opow omega_ne_zero at h,
-    exact (ordinal.not_lt_zero a h).elim },
-  { rwa [opow_omega_eq_sup_power_nat ho, lt_sup] at h }
 end
 
 /-! ### Fixed points of normal functions -/


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

Somewhat branched off of #11270. I might use these lemmas on a future PR on ordinal derivatives.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
