### PR TITLE
[Merged by Bors] - feat(algebra/big_operators/{basic,multiset}): two `multiset.prod` lemmas

### DIFF
--- a/src/algebra/big_operators/basic.lean
+++ b/src/algebra/big_operators/basic.lean
@@ -1549,8 +1549,7 @@ begin
   rw [← finset.sum_nsmul, h₂, to_finset_sum_count_nsmul_eq]
 end
 
-lemma to_finset_prod_dvd_prod [comm_monoid α] [decidable_eq α] {S : multiset α} :
-  S.to_finset.prod id ∣ S.prod :=
+lemma to_finset_prod_dvd_prod [comm_monoid α] {S : multiset α} : S.to_finset.prod id ∣ S.prod :=
 begin
   rw finset.prod_eq_multiset_prod,
   refine multiset.prod_dvd_prod _,

--- a/src/algebra/big_operators/basic.lean
+++ b/src/algebra/big_operators/basic.lean
@@ -1549,6 +1549,14 @@ begin
   rw [← finset.sum_nsmul, h₂, to_finset_sum_count_nsmul_eq]
 end
 
+lemma to_finset_prod_dvd_prod [comm_monoid α] [decidable_eq α] {S : multiset α} :
+  S.to_finset.prod id ∣ S.prod :=
+begin
+  rw finset.prod_eq_multiset_prod,
+  refine multiset.prod_dvd_prod _,
+  simp [multiset.erase_dup_le S],
+end
+
 end multiset
 
 @[simp, norm_cast] lemma nat.cast_sum [add_comm_monoid β] [has_one β] (s : finset α) (f : α → ℕ) :

--- a/src/algebra/big_operators/multiset.lean
+++ b/src/algebra/big_operators/multiset.lean
@@ -113,6 +113,14 @@ lemma prod_map_prod_map (m : multiset β) (n : multiset γ) {f : β → γ → �
   prod (m.map $ λ a, prod $ n.map $ λ b, f a b) = prod (n.map $ λ b, prod $ m.map $ λ a, f a b) :=
 multiset.induction_on m (by simp) (λ a m ih, by simp [ih])
 
+lemma prod_insert [comm_monoid α] (S : multiset α) (a : α) :
+  (insert a S).prod = a * S.prod :=
+begin
+  apply multiset.strong_induction_on S,
+  apply multiset.induction_on' S, { simp },
+  exact λ _ _ _ _, id,
+end
+
 @[to_additive]
 lemma prod_induction (p : α → Prop) (s : multiset α) (p_mul : ∀ a b, p a → p b → p (a * b))
   (p_one : p 1) (p_s : ∀ a ∈ s, p a) :
@@ -147,6 +155,16 @@ lemma prod_dvd_prod (h : s ≤ t) : s.prod ∣ t.prod :=
 begin
   obtain ⟨z, rfl⟩ := multiset.le_iff_exists_add.1 h,
   simp only [prod_add, dvd_mul_right],
+end
+
+lemma prod_dvd_prod' [comm_monoid β] {S : multiset α} (g1 g2 : α → β)
+  (h : ∀ a ∈ S, g1 a ∣ g2 a) :
+  (multiset.map g1 S).prod ∣ (multiset.map g2 S).prod :=
+begin
+  apply multiset.induction_on' S, { simp },
+  intros a T haS _ IH,
+  simp only [multiset.map_insert, multiset.prod_insert],
+  exact mul_dvd_mul (h a haS) IH,
 end
 
 end comm_monoid

--- a/src/algebra/big_operators/multiset.lean
+++ b/src/algebra/big_operators/multiset.lean
@@ -113,10 +113,6 @@ lemma prod_map_prod_map (m : multiset β) (n : multiset γ) {f : β → γ → �
   prod (m.map $ λ a, prod $ n.map $ λ b, f a b) = prod (n.map $ λ b, prod $ m.map $ λ a, f a b) :=
 multiset.induction_on m (by simp) (λ a m ih, by simp [ih])
 
-@[simp] lemma prod_insert [comm_monoid α] (S : multiset α) (a : α) :
-  (insert a S).prod = a * S.prod :=
-by { apply multiset.strong_induction_on S, apply multiset.induction_on' S; simp }
-
 @[to_additive]
 lemma prod_induction (p : α → Prop) (s : multiset α) (p_mul : ∀ a b, p a → p b → p (a * b))
   (p_one : p 1) (p_s : ∀ a ∈ s, p a) :

--- a/src/algebra/big_operators/multiset.lean
+++ b/src/algebra/big_operators/multiset.lean
@@ -115,11 +115,7 @@ multiset.induction_on m (by simp) (λ a m ih, by simp [ih])
 
 lemma prod_insert [comm_monoid α] (S : multiset α) (a : α) :
   (insert a S).prod = a * S.prod :=
-begin
-  apply multiset.strong_induction_on S,
-  apply multiset.induction_on' S, { simp },
-  exact λ _ _ _ _, id,
-end
+by { apply multiset.strong_induction_on S, apply multiset.induction_on' S; simp }
 
 @[to_additive]
 lemma prod_induction (p : α → Prop) (s : multiset α) (p_mul : ∀ a b, p a → p b → p (a * b))

--- a/src/algebra/big_operators/multiset.lean
+++ b/src/algebra/big_operators/multiset.lean
@@ -151,7 +151,7 @@ end
 
 end comm_monoid
 
-lemma prod_dvd_prod' [comm_monoid β] {S : multiset α} (g1 g2 : α → β) (h : ∀ a ∈ S, g1 a ∣ g2 a) :
+lemma prod_dvd_prod_of_dvd [comm_monoid β] {S : multiset α} (g1 g2 : α → β) (h : ∀ a ∈ S, g1 a ∣ g2 a) :
   (multiset.map g1 S).prod ∣ (multiset.map g2 S).prod :=
 begin
   apply multiset.induction_on' S, { simp },

--- a/src/algebra/big_operators/multiset.lean
+++ b/src/algebra/big_operators/multiset.lean
@@ -153,14 +153,12 @@ begin
   simp only [prod_add, dvd_mul_right],
 end
 
-lemma prod_dvd_prod' [comm_monoid β] {S : multiset α} (g1 g2 : α → β)
-  (h : ∀ a ∈ S, g1 a ∣ g2 a) :
+lemma prod_dvd_prod' [comm_monoid β] {S : multiset α} (g1 g2 : α → β) (h : ∀ a ∈ S, g1 a ∣ g2 a) :
   (multiset.map g1 S).prod ∣ (multiset.map g2 S).prod :=
 begin
   apply multiset.induction_on' S, { simp },
   intros a T haS _ IH,
-  simp only [multiset.map_insert, multiset.prod_insert],
-  exact mul_dvd_mul (h a haS) IH,
+  simp only [multiset.map_insert, multiset.prod_insert, mul_dvd_mul (h a haS) IH]
 end
 
 end comm_monoid

--- a/src/algebra/big_operators/multiset.lean
+++ b/src/algebra/big_operators/multiset.lean
@@ -113,7 +113,7 @@ lemma prod_map_prod_map (m : multiset β) (n : multiset γ) {f : β → γ → �
   prod (m.map $ λ a, prod $ n.map $ λ b, f a b) = prod (n.map $ λ b, prod $ m.map $ λ a, f a b) :=
 multiset.induction_on m (by simp) (λ a m ih, by simp [ih])
 
-lemma prod_insert [comm_monoid α] (S : multiset α) (a : α) :
+@[simp] lemma prod_insert [comm_monoid α] (S : multiset α) (a : α) :
   (insert a S).prod = a * S.prod :=
 by { apply multiset.strong_induction_on S, apply multiset.induction_on' S; simp }
 
@@ -158,7 +158,7 @@ lemma prod_dvd_prod' [comm_monoid β] {S : multiset α} (g1 g2 : α → β) (h :
 begin
   apply multiset.induction_on' S, { simp },
   intros a T haS _ IH,
-  simp only [multiset.map_insert, multiset.prod_insert, mul_dvd_mul (h a haS) IH]
+  simp [mul_dvd_mul (h a haS) IH]
 end
 
 end comm_monoid

--- a/src/algebra/big_operators/multiset.lean
+++ b/src/algebra/big_operators/multiset.lean
@@ -149,6 +149,8 @@ begin
   simp only [prod_add, dvd_mul_right],
 end
 
+end comm_monoid
+
 lemma prod_dvd_prod' [comm_monoid β] {S : multiset α} (g1 g2 : α → β) (h : ∀ a ∈ S, g1 a ∣ g2 a) :
   (multiset.map g1 S).prod ∣ (multiset.map g2 S).prod :=
 begin
@@ -157,7 +159,6 @@ begin
   simp [mul_dvd_mul (h a haS) IH]
 end
 
-end comm_monoid
 
 section add_comm_monoid
 variables [add_comm_monoid α]

--- a/src/algebra/big_operators/multiset.lean
+++ b/src/algebra/big_operators/multiset.lean
@@ -151,7 +151,8 @@ end
 
 end comm_monoid
 
-lemma prod_dvd_prod_of_dvd [comm_monoid β] {S : multiset α} (g1 g2 : α → β) (h : ∀ a ∈ S, g1 a ∣ g2 a) :
+lemma prod_dvd_prod_of_dvd [comm_monoid β] {S : multiset α} (g1 g2 : α → β)
+  (h : ∀ a ∈ S, g1 a ∣ g2 a) :
   (multiset.map g1 S).prod ∣ (multiset.map g2 S).prod :=
 begin
   apply multiset.induction_on' S, { simp },

--- a/src/data/multiset/basic.lean
+++ b/src/data/multiset/basic.lean
@@ -864,6 +864,14 @@ lemma map_strict_mono (f : α → β) : strict_mono (map f) := λ _ _, map_lt_ma
 @[simp] theorem map_subset_map {f : α → β} {s t : multiset α} (H : s ⊆ t) : map f s ⊆ map f t :=
 λ b m, let ⟨a, h, e⟩ := mem_map.1 m in mem_map.2 ⟨a, H h, e⟩
 
+lemma map_insert (S : multiset α) (a : α) (g : α → β) :
+  multiset.map g (insert a S) = insert (g a) (multiset.map g S) :=
+begin
+  apply multiset.strong_induction_on S,
+  apply multiset.induction_on' S, { simp },
+  exact λ _ _ _ _, id,
+end
+
 lemma map_erase [decidable_eq α] [decidable_eq β]
   (f : α → β) (hf : function.injective f) (x : α) (s : multiset α) :
   (s.erase x).map f = (s.map f).erase (f x) :=

--- a/src/data/multiset/basic.lean
+++ b/src/data/multiset/basic.lean
@@ -864,7 +864,7 @@ lemma map_strict_mono (f : α → β) : strict_mono (map f) := λ _ _, map_lt_ma
 @[simp] theorem map_subset_map {f : α → β} {s t : multiset α} (H : s ⊆ t) : map f s ⊆ map f t :=
 λ b m, let ⟨a, h, e⟩ := mem_map.1 m in mem_map.2 ⟨a, H h, e⟩
 
-lemma map_insert (S : multiset α) (a : α) (g : α → β) :
+@[simp] lemma map_insert (S : multiset α) (a : α) (g : α → β) :
   multiset.map g (insert a S) = insert (g a) (multiset.map g S) :=
 by { apply multiset.strong_induction_on S, apply multiset.induction_on' S; simp }
 

--- a/src/data/multiset/basic.lean
+++ b/src/data/multiset/basic.lean
@@ -2128,4 +2128,3 @@ lemma coe_subsingleton_equiv [subsingleton α] :
 rfl
 
 end multiset
--- #lint

--- a/src/data/multiset/basic.lean
+++ b/src/data/multiset/basic.lean
@@ -866,11 +866,7 @@ lemma map_strict_mono (f : α → β) : strict_mono (map f) := λ _ _, map_lt_ma
 
 lemma map_insert (S : multiset α) (a : α) (g : α → β) :
   multiset.map g (insert a S) = insert (g a) (multiset.map g S) :=
-begin
-  apply multiset.strong_induction_on S,
-  apply multiset.induction_on' S, { simp },
-  exact λ _ _ _ _, id,
-end
+by { apply multiset.strong_induction_on S, apply multiset.induction_on' S; simp }
 
 lemma map_erase [decidable_eq α] [decidable_eq β]
   (f : α → β) (hf : function.injective f) (x : α) (s : multiset α) :

--- a/src/data/multiset/basic.lean
+++ b/src/data/multiset/basic.lean
@@ -864,10 +864,6 @@ lemma map_strict_mono (f : α → β) : strict_mono (map f) := λ _ _, map_lt_ma
 @[simp] theorem map_subset_map {f : α → β} {s t : multiset α} (H : s ⊆ t) : map f s ⊆ map f t :=
 λ b m, let ⟨a, h, e⟩ := mem_map.1 m in mem_map.2 ⟨a, H h, e⟩
 
-@[simp] lemma map_insert (S : multiset α) (a : α) (g : α → β) :
-  multiset.map g (insert a S) = insert (g a) (multiset.map g S) :=
-by { apply multiset.strong_induction_on S, apply multiset.induction_on' S; simp }
-
 lemma map_erase [decidable_eq α] [decidable_eq β]
   (f : α → β) (hf : function.injective f) (x : α) (s : multiset α) :
   (s.erase x).map f = (s.map f).erase (f x) :=
@@ -2132,3 +2128,4 @@ lemma coe_subsingleton_equiv [subsingleton α] :
 rfl
 
 end multiset
+-- #lint


### PR DESCRIPTION
Two lemmas suggested by Riccardo Brasca on #11572:

`to_finset_prod_dvd_prod`: `S.to_finset.prod id ∣ S.prod`

`prod_dvd_prod_of_dvd`: For any `S : multiset α`, if `∀ a ∈ S, g1 a ∣ g2 a` then `S.prod g1 ∣ S.prod g2` (a counterpart to `finset.prod_dvd_prod`)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
