### PR TITLE
[Merged by Bors] - feat(algebra/ne_zero): add `coe_trans` instance

### DIFF
--- a/src/algebra/ne_zero.lean
+++ b/src/algebra/ne_zero.lean
@@ -33,7 +33,7 @@ by simp [ne_zero_iff]
 
 namespace ne_zero
 
-variables {R M F : Type*} {r : R} {x y : M} {n p : ℕ} {a : ℕ+}
+variables {R S M F : Type*} {r : R} {x y : M} {n p : ℕ} {a : ℕ+}
 
 instance pnat : ne_zero (a : ℕ) := ⟨a.ne_zero⟩
 instance succ : ne_zero (n + 1) := ⟨n.succ_ne_zero⟩
@@ -46,6 +46,9 @@ instance char_zero [ne_zero n] [add_monoid M] [has_one M] [char_zero M] : ne_zer
 
 @[priority 100] instance invertible [monoid_with_zero M] [nontrivial M] [invertible x] :
   ne_zero x := ⟨nonzero_of_invertible x⟩
+
+instance coe_trans {r : R} [has_zero M] [has_coe R S] [has_coe_t S M] [h : ne_zero (r : M)] :
+  ne_zero ((r : S) : M) := ⟨h.out⟩
 
 lemma of_map [has_zero R] [has_zero M] [zero_hom_class F R M] (f : F) [ne_zero (f r)] :
   ne_zero r := ⟨λ h, ne (f r) $ by convert map_zero f⟩

--- a/src/number_theory/cyclotomic/basic.lean
+++ b/src/number_theory/cyclotomic/basic.lean
@@ -282,9 +282,9 @@ end
 
 section field
 
-variable [ne_zero ((n : ℕ) : K)]
+variable [ne_zero (n : K)]
 
-/-- If `ne_zero ((n : ℕ) : K)`, a cyclotomic extension splits `X ^ n - 1` if `n ∈ S`.-/
+/-- A cyclotomic extension splits `X ^ n - 1` if `n ∈ S` and `ne_zero (n : K)`.-/
 lemma splits_X_pow_sub_one [H : is_cyclotomic_extension S K L] (hS : n ∈ S) :
   splits (algebra_map K L) (X ^ (n : ℕ) - 1) :=
 begin
@@ -296,7 +296,7 @@ begin
   exact X_pow_sub_one_splits (is_root_cyclotomic_iff.1 hz),
 end
 
-/-- If `ne_zero ((n : ℕ) : K)`, a cyclotomic extension splits `cyclotomic n K` if `n ∈ S`.-/
+/-- A cyclotomic extension splits `cyclotomic n K` if `n ∈ S` and `ne_zero (n : K)`.-/
 lemma splits_cyclotomic [is_cyclotomic_extension S K L] (hS : n ∈ S) :
   splits (algebra_map K L) (cyclotomic n K) :=
 begin


### PR DESCRIPTION
This is super-useful for `flt_regular`, meaning we don't have to write all of our lemmata as `ne_zero ((n : ℕ) : R)`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)

This _seems_ to work (the reason I modified number_theory/cyclotomic/basic was to test whether it was fine, and it led me to modify things to `has_coe_t` instead of `has_coe`). However, I'm not sure if it's the most general possible version, and I'm also not sure whether this will cause loops or not.

cc: @riccardobrasca
