### PR TITLE
[Merged by Bors] - feat(data/fintype/order): More and better instances

### DIFF
--- a/src/data/finset/lattice.lean
+++ b/src/data/finset/lattice.lean
@@ -13,7 +13,7 @@ import order.lexicographic
 # Lattice operations on finsets
 -/
 
-variables {α β γ : Type*}
+variables {α β γ ι : Type*}
 
 namespace finset
 open multiset order_dual
@@ -414,6 +414,31 @@ lemma inf_eq_top_iff (f : β → α)
 @finset.sup_eq_bot_iff (order_dual α) _ _ _ _ _
 
 end inf
+
+section distrib_lattice
+variables [distrib_lattice α]
+
+lemma sup_inf_distrib_left [order_bot α] (s : finset ι) (f : ι → α) (a : α) :
+  a ⊓ s.sup f = s.sup (λ i, a ⊓ f i) :=
+begin
+  induction s using finset.cons_induction with i s hi h,
+  { simp_rw [finset.sup_empty, inf_bot_eq] },
+  { rw [sup_cons, sup_cons, inf_sup_left, h] }
+end
+
+lemma sup_inf_distrib_right [order_bot α] (s : finset ι) (f : ι → α) (a : α) :
+  s.sup f ⊓ a = s.sup (λ i, f i ⊓ a) :=
+by { rw [_root_.inf_comm, s.sup_inf_distrib_left], simp_rw _root_.inf_comm }
+
+lemma inf_sup_distrib_left [order_top α] (s : finset ι) (f : ι → α) (a : α) :
+  a ⊔ s.inf f = s.inf (λ i, a ⊔ f i) :=
+@sup_inf_distrib_left _ (order_dual α) _ _ _ _ _
+
+lemma inf_sup_distrib_right [order_top α] (s : finset ι) (f : ι → α) (a : α) :
+  s.inf f ⊔ a = s.inf (λ i, f i ⊔ a) :=
+@sup_inf_distrib_right _ (order_dual α) _ _ _ _ _
+
+end distrib_lattice
 
 lemma inf_eq_infi [complete_lattice β] (s : finset α) (f : α → β) : s.inf f = (⨅a∈s, f a) :=
 @sup_eq_supr _ (order_dual β) _ _ _
@@ -966,7 +991,7 @@ end max_min
 
 section max_min_induction_value
 
-variables {ι : Type*} [linear_order α] [linear_order β]
+variables [linear_order α] [linear_order β]
 
 /-- Induction principle for `finset`s in any type from which a given function `f` maps to a linearly
 ordered type : a predicate is true on all `s : finset α` provided that:
@@ -1091,7 +1116,7 @@ by { ext a, rw [mem_sup, mem_image], simp only [mem_singleton, eq_comm] }
 end finset
 
 section lattice
-variables {ι : Type*} {ι' : Sort*} [complete_lattice α]
+variables {ι' : Sort*} [complete_lattice α]
 
 /-- Supremum of `s i`, `i : ι`, is equal to the supremum over `t : finset ι` of suprema
 `⨆ i ∈ t, s i`. This version assumes `ι` is a `Type*`. See `supr_eq_supr_finset'` for a version
@@ -1130,7 +1155,7 @@ lemma infi_eq_infi_finset' (s : ι' → α) :
 end lattice
 
 namespace set
-variables {ι : Type*} {ι' : Sort*}
+variables {ι' : Sort*}
 
 /-- Union of an indexed family of sets `s : ι → set α` is equal to the union of the unions
 of finite subfamilies. This version assumes `ι : Type*`. See also `Union_eq_Union_finset'` for

--- a/src/data/finset/lattice.lean
+++ b/src/data/finset/lattice.lean
@@ -432,11 +432,11 @@ by { rw [_root_.inf_comm, s.sup_inf_distrib_left], simp_rw _root_.inf_comm }
 
 lemma inf_sup_distrib_left [order_top α] (s : finset ι) (f : ι → α) (a : α) :
   a ⊔ s.inf f = s.inf (λ i, a ⊔ f i) :=
-@sup_inf_distrib_left _ (order_dual α) _ _ _ _ _
+@sup_inf_distrib_left (order_dual α) _ _ _ _ _ _
 
 lemma inf_sup_distrib_right [order_top α] (s : finset ι) (f : ι → α) (a : α) :
   s.inf f ⊔ a = s.inf (λ i, f i ⊔ a) :=
-@sup_inf_distrib_right _ (order_dual α) _ _ _ _ _
+@sup_inf_distrib_right (order_dual α) _ _ _ _ _ _
 
 end distrib_lattice
 

--- a/src/data/fintype/order.lean
+++ b/src/data/fintype/order.lean
@@ -1,54 +1,70 @@
 /-
 Copyright (c) 2021 Peter Nelson. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Peter Nelson
+Authors: Peter Nelson, Yaël Dillies
 -/
 import data.fintype.basic
+import order.conditionally_complete_lattice
 
 /-!
 # Order structures on finite types
 
-This file provides order instances on fintypes:
-* A `semilattice_inf` instance on a `fintype` allows constructing an `order_bot`.
-* A `semilattice_sup` instance on a `fintype` allows constructing an `order_top`.
-* A `lattice` instance on a `fintype` allows constructing a `bounded_order`.
-* A `lattice` instance on a `fintype` can be promoted to a `complete_lattice`.
-* A `linear_order` instance on a `fintype` can be promoted to a `complete_linear_order`.
+This file provides order instances on fintypes.
 
-Getting to a `bounded_order` from a `lattice` is computable, but the
-subsequent definitions are not, since the definitions of `Sup` and `Inf` use `set.to_finset`, which
-implicitly requires a `decidable_pred` instance for every `s : set α`.
+## Computable instances
 
-The `complete_linear_order` instance for `fin (n + 1)` is the only proper instance in this file. The
-rest are `def`s to avoid loops in typeclass inference.
+On a `fintype`, we can construct
+* an `order_bot` from `semilattice_inf`.
+* an `order_top` from `semilattice_sup`.
+* a `bounded_order` from `lattice`.
+
+Those are marked as `def` to avoid defeqness issues.
+
+## Completion instances
+
+Those instances are noncomputable because the definitions of `Sup` and `Inf` use `set.to_finset` and
+set membership is undecidable in general.
+
+On a `fintype`, we can promote:
+* a `lattice` to a `complete_lattice`.
+* a `distrib_lattice` to a `complete_distrib_lattice`.
+* a `linear_order`  to a `complete_linear_order`.
+* a `boolean_algebra` to a `complete_boolean_algebra`.
+
+Those are marked as `def` to avoid typeclass loops.
+
+## Concrete instances
+
+We provide a few instances for concrete types:
+* `fin.complete_linear_order`
+* `bool.complete_linear_order`
 -/
 
+open finset
+
+namespace fintype
 variables {ι α : Type*} [fintype ι] [fintype α]
 
-section inhabited
-variables (α) [inhabited α]
+section nonempty
+variables (α) [nonempty α]
 
-/-- Constructs the `⊥` of a finite inhabited `semilattice_inf`. -/
+/-- Constructs the `⊥` of a finite nonempty `semilattice_inf`. -/
 @[reducible] -- See note [reducible non-instances]
-def fintype.to_order_bot [semilattice_inf α] : order_bot α :=
-{ bot := finset.fold (⊓) (arbitrary α) id finset.univ,
-  bot_le := λ a, ((finset.fold_op_rel_iff_and (@le_inf_iff α _)).1 le_rfl).2 a (finset.mem_univ _) }
+def to_order_bot [semilattice_inf α] : order_bot α :=
+{ bot := univ.inf' univ_nonempty id,
+  bot_le := λ a, inf'_le _ $ mem_univ a }
 
-/-- Constructs the `⊤` of a finite inhabited `semilattice_sup` -/
+/-- Constructs the `⊤` of a finite nonempty `semilattice_sup` -/
 @[reducible] -- See note [reducible non-instances]
-def fintype.to_order_top [semilattice_sup α] : order_top α :=
-{ top := finset.fold (⊔) (arbitrary α) id finset.univ,
-  le_top := λ a,
-    ((finset.fold_op_rel_iff_and (λ x y z, show x ≥ y ⊔ z ↔ _, from sup_le_iff)).mp le_rfl).2
-      a (finset.mem_univ a) }
+def to_order_top [semilattice_sup α] : order_top α :=
+{ top := univ.sup' univ_nonempty id,
+  le_top := λ a, le_sup' _ $ mem_univ a }
 
-/-- Constructs the `⊤` and `⊥` of a finite inhabited `lattice`. -/
+/-- Constructs the `⊤` and `⊥` of a finite nonempty `lattice`. -/
 @[reducible] -- See note [reducible non-instances]
-def fintype.to_bounded_order [lattice α] : bounded_order α :=
-{ .. fintype.to_order_bot α,
-  .. fintype.to_order_top α }
+def to_bounded_order [lattice α] : bounded_order α := { ..to_order_bot α, ..to_order_top α }
 
-end inhabited
+end nonempty
 
 section bounded_order
 variables (α)
@@ -57,7 +73,7 @@ open_locale classical
 
 /-- A finite bounded lattice is complete. -/
 @[reducible] -- See note [reducible non-instances]
-noncomputable def fintype.to_complete_lattice [hl : lattice α] [hb : bounded_order α] :
+noncomputable def to_complete_lattice [lattice α] [bounded_order α] :
   complete_lattice α :=
 { Sup := λ s, s.to_finset.sup id,
   Inf := λ s, s.to_finset.inf id,
@@ -65,13 +81,37 @@ noncomputable def fintype.to_complete_lattice [hl : lattice α] [hb : bounded_or
   Sup_le := λ s _ ha, finset.sup_le (λ b hb, ha _ $ set.mem_to_finset.mp hb),
   Inf_le := λ _ _ ha, finset.inf_le (set.mem_to_finset.mpr ha),
   le_Inf := λ s _ ha, finset.le_inf (λ b hb, ha _ $ set.mem_to_finset.mp hb),
-  .. hl, .. hb }
+  .. ‹lattice α›, .. ‹bounded_order α› }
+
+/-- A finite bounded distributive lattice is completely distributive. -/
+@[reducible] -- See note [reducible non-instances]
+noncomputable def to_complete_distrib_lattice [distrib_lattice α] [bounded_order α] :
+  complete_distrib_lattice α :=
+{ infi_sup_le_sup_Inf := λ a s, begin
+    convert (finset.inf_sup_distrib_left _ _ _).ge,
+    convert (finset.inf_eq_infi _ _).symm,
+    simp_rw set.mem_to_finset,
+    refl,
+  end,
+  inf_Sup_le_supr_inf := λ a s, begin
+    convert (finset.sup_inf_distrib_left _ _ _).le,
+    convert (finset.sup_eq_supr _ _).symm,
+    simp_rw set.mem_to_finset,
+    refl,
+  end,
+  ..to_complete_lattice α }
 
 /-- A finite bounded linear order is complete. -/
 @[reducible] -- See note [reducible non-instances]
-noncomputable def fintype.to_complete_linear_order [h : linear_order α] [bounded_order α] :
+noncomputable def to_complete_linear_order [linear_order α] [bounded_order α] :
   complete_linear_order α :=
-{ .. fintype.to_complete_lattice α, .. h }
+{ ..to_complete_lattice α, .. ‹linear_order α› }
+
+/-- A finite boolean algebra is complete. -/
+@[reducible] -- See note [reducible non-instances]
+noncomputable def to_complete_boolean_algebra [boolean_algebra α] :
+  complete_boolean_algebra α :=
+{ ..fintype.to_complete_distrib_lattice α, .. ‹boolean_algebra α› }
 
 end bounded_order
 
@@ -81,21 +121,23 @@ variables (α) [nonempty α]
 /-- A nonempty finite lattice is complete. If the lattice is already a `bounded_order`, then use
 `fintype.to_complete_lattice` instead, as this gives definitional equality for `⊥` and `⊤`. -/
 @[reducible] -- See note [reducible non-instances]
-noncomputable def fintype.to_complete_lattice_of_lattice [lattice α] : complete_lattice α :=
-@fintype.to_complete_lattice _ _ _ $ @fintype.to_bounded_order α _ ⟨classical.arbitrary α⟩ _
+noncomputable def to_complete_lattice_of_nonempty [lattice α] : complete_lattice α :=
+@to_complete_lattice _ _ _ $ @to_bounded_order α _ ⟨classical.arbitrary α⟩ _
 
 /-- A nonempty finite linear order is complete. If the linear order is already a `bounded_order`,
 then use `fintype.to_complete_linear_order` instead, as this gives definitional equality for `⊥` and
 `⊤`. -/
 @[reducible] -- See note [reducible non-instances]
-noncomputable def fintype.to_complete_linear_order_of_linear_order [h : linear_order α] :
+noncomputable def to_complete_linear_order_of_nonempty [linear_order α] :
   complete_linear_order α :=
-{ .. fintype.to_complete_lattice_of_lattice α,
-  .. h }
+{ ..to_complete_lattice_of_nonempty α, .. ‹linear_order α› }
 
 end nonempty
+end fintype
 
-/-! ### `fin` -/
+/-! ### Concrete instances -/
 
-noncomputable instance fin.complete_linear_order {n : ℕ} : complete_linear_order (fin (n + 1)) :=
+noncomputable instance {n : ℕ} : complete_linear_order (fin (n + 1)) :=
 fintype.to_complete_linear_order _
+
+noncomputable instance : complete_linear_order bool := fintype.to_complete_linear_order _

--- a/src/order/conditionally_complete_lattice.lean
+++ b/src/order/conditionally_complete_lattice.lean
@@ -111,7 +111,7 @@ instance conditionally_complete_linear_order_bot.to_order_bot
 /-- A complete lattice is a conditionally complete lattice, as there are no restrictions
 on the properties of Inf and Sup in a complete lattice.-/
 @[priority 100] -- see Note [lower instance priority]
-instance conditionally_complete_lattice_of_complete_lattice [complete_lattice α]:
+instance complete_lattice.to_conditionally_complete_lattice [complete_lattice α] :
   conditionally_complete_lattice α :=
 { le_cSup := by intros; apply le_Sup; assumption,
   cSup_le := by intros; apply Sup_le; assumption,
@@ -120,9 +120,11 @@ instance conditionally_complete_lattice_of_complete_lattice [complete_lattice α
   ..‹complete_lattice α› }
 
 @[priority 100] -- see Note [lower instance priority]
-instance conditionally_complete_linear_order_of_complete_linear_order [complete_linear_order α]:
-  conditionally_complete_linear_order α :=
-{ ..conditionally_complete_lattice_of_complete_lattice, .. ‹complete_linear_order α› }
+instance complete_linear_order.to_conditionally_complete_linear_order_bot {α : Type*}
+  [complete_linear_order α] :
+  conditionally_complete_linear_order_bot α :=
+{ cSup_empty := Sup_empty,
+  ..complete_lattice.to_conditionally_complete_lattice, .. ‹complete_linear_order α› }
 
 section
 open_locale classical


### PR DESCRIPTION
In a fintype, this allows to promote 
* `distrib_lattice` to `complete_distrib_lattice`
* `boolean_algebra` to `complete_boolean_algebra`

Also strengthen
* `fintype.to_order_bot`
* `fintype.to_order_top`
* `fintype.to_bounded_order`
* `complete_linear_order.to_conditionally_complete_linear_order_bot`

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
