### PR TITLE
[Merged by Bors] - feat(order/complete_boolean_algebra): Frames

### DIFF
--- a/docs/references.bib
+++ b/docs/references.bib
@@ -180,6 +180,15 @@
   publisher     = {Cambridge University Press}
 }
 
+@Book{            borceux-vol3,
+  title         = {Handbook of Categorical Algebra: Volume 3, Sheaf Theory},
+  author        = {Borceux, Francis},
+  series        = {Encyclopedia of Mathematics},
+  volume        = {52},
+  year          = {1994},
+  publisher     = {Cambridge University Press}
+}
+
 @Book{            bourbaki1966,
   author        = {Bourbaki, Nicolas},
   title         = {Elements of mathematics. {G}eneral topology. {P}art 1},

--- a/src/data/set/prod.lean
+++ b/src/data/set/prod.lean
@@ -186,6 +186,12 @@ lemma prod_sub_preimage_iff {W : set γ} {f : α × β → γ} :
   s ×ˢ t ⊆ f ⁻¹' W ↔ ∀ a b, a ∈ s → b ∈ t → f (a, b) ∈ W :=
 by simp [subset_def]
 
+lemma image_prod_mk_subset_prod_left (hb : b ∈ t) : (λ a, (a, b)) '' s ⊆ s ×ˢ t :=
+by { rintro _ ⟨a, ha, rfl⟩, exact ⟨ha, hb⟩ }
+
+lemma image_prod_mk_subset_prod_right (ha : a ∈ s) : prod.mk a '' t ⊆ s ×ˢ t :=
+by { rintro _ ⟨b, hb, rfl⟩, exact ⟨ha, hb⟩ }
+
 lemma fst_image_prod_subset (s : set α) (t : set β) : prod.fst '' (s ×ˢ t) ⊆ s :=
 λ _ h, let ⟨_, ⟨h₂, _⟩, h₁⟩ := (set.mem_image _ _ _).1 h in h₁ ▸ h₂
 

--- a/src/order/complete_boolean_algebra.lean
+++ b/src/order/complete_boolean_algebra.lean
@@ -18,6 +18,10 @@ distributive Boolean algebras.
   distribute over `⨆` and `⨅` respectively.
 * `complete_boolean_algebra`: Completely distributive Boolean algebra: A Boolean algebra whose `⊓`
   and `⊔` distribute over `⨆` and `⨅` respectively.
+
+## References
+
+* [Wikipedia, *Complete Heyting algebra*][https://en.wikipedia.org/wiki/Complete_Heyting_algebra]
 -/
 
 set_option old_structure_cmd true

--- a/src/order/complete_boolean_algebra.lean
+++ b/src/order/complete_boolean_algebra.lean
@@ -1,18 +1,19 @@
 /-
 Copyright (c) 2017 Johannes Hölzl. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Johannes Hölzl
+Authors: Johannes Hölzl, Yaël Dillies
 -/
 import order.complete_lattice
 
 /-!
-# Completely distributive lattices and Boolean algebras
+# Frames, completely distributive lattices and Boolean algebras
 
-In this file there are definitions and an API for completely distributive lattices and completely
+In this file we define and provide API for frames, completely distributive lattices and completely
 distributive Boolean algebras.
 
 ## Typeclasses
 
+* `frame`: Frame: A complete lattice whose `⊓` distributes over `⨆`.
 * `complete_distrib_lattice`: Completely distributive lattices: A complete lattice whose `⊓` and `⊔`
   distribute over `⨆` and `⨅` respectively.
 * `complete_boolean_algebra`: Completely distributive Boolean algebra: A Boolean algebra whose `⊓`
@@ -22,15 +23,65 @@ distributive Boolean algebras.
 set_option old_structure_cmd true
 
 universes u v w
-variables {α : Type u} {β : Type v} {ι : Sort w}
+variables {α : Type u} {β : Type v} {ι : Sort w} {κ : ι → Sort*}
+
+/-- A frame, aka complete Heyting algebra, is a complete lattice whose `⊓` distributes over `⨆`. -/
+class frame (α : Type*) extends complete_lattice α :=
+(inf_Sup_le_supr_inf (a : α) (s : set α) : a ⊓ Sup s ≤ ⨆ b ∈ s, a ⊓ b)
+
+section frame
+variables [frame α] {s t : set α} {a b : α}
+
+lemma inf_Sup_eq : a ⊓ Sup s = (⨆ b ∈ s, a ⊓ b) :=
+(frame.inf_Sup_le_supr_inf _ _).antisymm supr_inf_le_inf_Sup
+
+lemma Sup_inf_eq : Sup s ⊓ b = (⨆ a ∈ s, a ⊓ b) :=
+by simpa only [inf_comm] using @inf_Sup_eq α _ s b
+
+lemma supr_inf_eq (f : ι → α) (a : α) : (⨆ i, f i) ⊓ a = ⨆ i, f i ⊓ a :=
+by rw [supr, Sup_inf_eq, supr_range]
+
+lemma inf_supr_eq (a : α) (f : ι → α) : a ⊓ (⨆ i, f i) = ⨆ i, a ⊓ f i :=
+by simpa only [inf_comm] using supr_inf_eq f a
+
+lemma bsupr_inf_eq {f : Π i, κ i → α} (a : α) : (⨆ i j, f i j) ⊓ a = ⨆ i j, f i j ⊓ a :=
+by simp only [supr_inf_eq]
+
+lemma inf_bsupr_eq {f : Π i, κ i → α} (a : α) : a ⊓ (⨆ i j, f i j) = ⨆ i j, a ⊓ f i j :=
+by simp only [inf_supr_eq]
+
+instance pi.frame {ι : Type*} {π : ι → Type*} [Π i, frame (π i)] : frame (Π i, π i) :=
+{ inf_Sup_le_supr_inf := λ a s i,
+    by simp only [complete_lattice.Sup, Sup_apply, supr_apply, pi.inf_apply, inf_supr_eq,
+      ← supr_subtype''],
+  .. pi.complete_lattice }
+
+lemma Sup_inf_Sup : Sup s ⊓ Sup t = ⨆ p ∈ s ×ˢ t, (p : α × α).1 ⊓ p.2 :=
+begin
+  refine le_antisymm _ _,
+  { simp_rw [Sup_inf_eq, supr_le_iff, inf_Sup_eq],
+    rintro a ha,
+    have : (⨆ p ∈ prod.mk a '' t, (p : α × α).1 ⊓ p.2) ≤ ⨆ p ∈ s ×ˢ t, ((p : α × α).1 : α) ⊓ p.2,
+    { exact supr_le_supr_of_subset (set.image_prod_mk_subset_prod_right ha) },
+    rwa supr_image at this },
+  { simp_rw [supr_le_iff, set.mem_prod],
+    exact λ a ha, inf_le_inf (le_Sup ha.1) (le_Sup ha.2) }
+end
+
+lemma supr_disjoint_iff {f : ι → α} : disjoint (⨆ i, f i) a ↔ ∀ i, disjoint (f i) a :=
+by simp only [disjoint_iff, supr_inf_eq, supr_eq_bot]
+
+lemma disjoint_supr_iff {f : ι → α} : disjoint a (⨆ i, f i) ↔ ∀ i, disjoint a (f i) :=
+by simpa only [disjoint.comm] using @supr_disjoint_iff _ _ _ a f
+
+end frame
 
 /-- A complete distributive lattice is a bit stronger than the name might
   suggest; perhaps completely distributive lattice is more descriptive,
   as this class includes a requirement that the lattice join
   distribute over *arbitrary* infima, and similarly for the dual. -/
-class complete_distrib_lattice α extends complete_lattice α :=
+class complete_distrib_lattice α extends frame α :=
 (infi_sup_le_sup_Inf : ∀ a s, (⨅ b ∈ s, a ⊔ b) ≤ a ⊔ Inf s)
-(inf_Sup_le_supr_inf : ∀ a s, a ⊓ Sup s ≤ (⨆ b ∈ s, a ⊓ b))
 
 section complete_distrib_lattice
 variables [complete_distrib_lattice α] {a b : α} {s t : set α}
@@ -46,82 +97,32 @@ sup_Inf_le_infi_sup.antisymm (complete_distrib_lattice.infi_sup_le_sup_Inf _ _)
 theorem Inf_sup_eq : Inf s ⊔ b = (⨅ a ∈ s, a ⊔ b) :=
 by simpa only [sup_comm] using @sup_Inf_eq α _ b s
 
-theorem inf_Sup_eq : a ⊓ Sup s = (⨆ b ∈ s, a ⊓ b) :=
-(complete_distrib_lattice.inf_Sup_le_supr_inf _ _).antisymm supr_inf_le_inf_Sup
-
-theorem Sup_inf_eq : Sup s ⊓ b = (⨆ a ∈ s, a ⊓ b) :=
-by simpa only [inf_comm] using @inf_Sup_eq α _ b s
-
-theorem supr_inf_eq (f : ι → α) (a : α) : (⨆ i, f i) ⊓ a = ⨆ i, f i ⊓ a :=
-by rw [supr, Sup_inf_eq, supr_range]
-
-theorem inf_supr_eq (a : α) (f : ι → α) : a ⊓ (⨆ i, f i) = ⨆ i, a ⊓ f i :=
-by simpa only [inf_comm] using supr_inf_eq f a
-
 theorem infi_sup_eq (f : ι → α) (a : α) : (⨅ i, f i) ⊔ a = ⨅ i, f i ⊔ a :=
 @supr_inf_eq (order_dual α) _ _ _ _
 
 theorem sup_infi_eq (a : α) (f : ι → α) : a ⊔ (⨅ i, f i) = ⨅ i, a ⊔ f i :=
 @inf_supr_eq (order_dual α) _ _ _ _
 
-theorem bsupr_inf_eq {p : α → Prop} {f : Π i (hi : p i), α} (a : α) :
-  (⨆ i hi, f i hi) ⊓ a = ⨆ i hi, f i hi ⊓ a :=
-by simp only [supr_inf_eq]
-
-theorem inf_bsupr_eq (a : α) {p : α → Prop} {f : Π i (hi : p i), α} :
-  a ⊓ (⨆ i hi, f i hi) = ⨆ i hi, a ⊓ f i hi :=
-by simp only [inf_supr_eq]
-
 theorem binfi_sup_eq {p : α → Prop} {f : Π i (hi : p i), α} (a : α) :
   (⨅ i hi, f i hi) ⊔ a = ⨅ i hi, f i hi ⊔ a :=
-@bsupr_inf_eq (order_dual α) _ _ _ _
+@bsupr_inf_eq (order_dual α) _ _ _ _ _
 
 theorem sup_binfi_eq (a : α) {p : α → Prop} {f : Π i (hi : p i), α} :
   a ⊔ (⨅ i hi, f i hi) = ⨅ i hi, a ⊔ f i hi :=
-@inf_bsupr_eq (order_dual α) _ _ _ _
+@inf_bsupr_eq (order_dual α) _ _ _ _ _
 
 instance pi.complete_distrib_lattice {ι : Type*} {π : ι → Type*}
   [∀ i, complete_distrib_lattice (π i)] : complete_distrib_lattice (Π i, π i) :=
-{ infi_sup_le_sup_Inf := λ a s i,
-    by simp only [← sup_infi_eq, complete_lattice.Inf, Inf_apply, ←infi_subtype'', infi_apply,
-      pi.sup_apply],
+{ Sup := Sup,
+  Inf := Inf,
+  infi_sup_le_sup_Inf := λ a s i,
+    by simp only [←sup_infi_eq, Inf_apply, ←infi_subtype'', infi_apply, pi.sup_apply],
   inf_Sup_le_supr_inf := λ a s i,
-    by simp only [complete_lattice.Sup, Sup_apply, supr_apply, pi.inf_apply, inf_supr_eq,
-      ← supr_subtype''],
-  .. pi.complete_lattice }
+    by simp only [Sup_apply, supr_apply, pi.inf_apply, inf_supr_eq, ←supr_subtype''],
+  .. pi.frame }
 
 theorem Inf_sup_Inf : Inf s ⊔ Inf t = (⨅ p ∈ s ×ˢ t, (p : α × α).1 ⊔ p.2) :=
-begin
-  apply le_antisymm,
-  { simp only [and_imp, prod.forall, le_infi_iff, set.mem_prod],
-    intros a b ha hb,
-    exact sup_le_sup (Inf_le ha) (Inf_le hb) },
-  { have : ∀ a ∈ s, (⨅ p ∈ s ×ˢ t, (p : α × α).1 ⊔ p.2) ≤ a ⊔ Inf t,
-    { rintro a ha,
-      have : (⨅ p ∈ s ×ˢ t, ((p : α × α).1 : α) ⊔ p.2) ≤
-             (⨅ p ∈ prod.mk a '' t, (p : α × α).1 ⊔ p.2),
-      { apply infi_le_infi_of_subset,
-        rintro ⟨x, y⟩,
-        simp only [and_imp, set.mem_image, prod.mk.inj_iff, set.prod_mk_mem_set_prod_eq,
-                   exists_imp_distrib],
-        rintro x' x't ax x'y,
-        rw [← x'y, ← ax],
-        simp [ha, x't] },
-      rw [infi_image] at this,
-      simp only at this,
-      rwa ← sup_Inf_eq at this },
-    calc (⨅ p ∈ s ×ˢ t, (p : α × α).1 ⊔ p.2) ≤ (⨅ a ∈ s, a ⊔ Inf t) : by simp; exact this
-       ... = Inf s ⊔ Inf t : Inf_sup_eq.symm }
-end
-
-theorem Sup_inf_Sup : Sup s ⊓ Sup t = (⨆ p ∈ s ×ˢ t, (p : α × α).1 ⊓ p.2) :=
-@Inf_sup_Inf (order_dual α) _ _ _
-
-lemma supr_disjoint_iff {f : ι → α} : disjoint (⨆ i, f i) a ↔ ∀ i, disjoint (f i) a :=
-by simp only [disjoint_iff, supr_inf_eq, supr_eq_bot]
-
-lemma disjoint_supr_iff {f : ι → α} : disjoint a (⨆ i, f i) ↔ ∀ i, disjoint a (f i) :=
-by simpa only [disjoint.comm] using @supr_disjoint_iff _ _ _ a f
+@Sup_inf_Sup (order_dual α) _ _ _
 
 end complete_distrib_lattice
 

--- a/src/order/complete_boolean_algebra.lean
+++ b/src/order/complete_boolean_algebra.lean
@@ -131,6 +131,14 @@ instance pi.complete_distrib_lattice {ι : Type*} {π : ι → Type*}
     by simp only [Sup_apply, supr_apply, pi.inf_apply, inf_supr_eq, ←supr_subtype''],
   .. pi.frame }
 
+lemma infi_sup_infi {ι ι' : Type*} {f : ι → α} {g : ι' → α} :
+  (⨅ i, f i) ⊔ (⨅ i, g i) = ⨅ i : ι × ι', f i.1 ⊔ g i.2 :=
+@supr_inf_supr (order_dual α) _ _ _ _ _
+
+lemma binfi_sup_binfi {ι ι' : Type*} {f : ι → α} {g : ι' → α} {s : set ι} {t : set ι'} :
+  (⨅ i ∈ s, f i) ⊔ (⨅ j ∈ t, g j) = ⨅ p ∈ s ×ˢ t, f (p : ι × ι').1 ⊔ g p.2 :=
+@bsupr_inf_bsupr (order_dual α) _ _ _ _ _ _ _
+
 theorem Inf_sup_Inf : Inf s ⊔ Inf t = (⨅ p ∈ s ×ˢ t, (p : α × α).1 ⊔ p.2) :=
 @Sup_inf_Sup (order_dual α) _ _ _
 

--- a/src/order/complete_boolean_algebra.lean
+++ b/src/order/complete_boolean_algebra.lean
@@ -36,10 +36,10 @@ class frame (α : Type*) extends complete_lattice α :=
 section frame
 variables [frame α] {s t : set α} {a b : α}
 
-lemma inf_Sup_eq : a ⊓ Sup s = (⨆ b ∈ s, a ⊓ b) :=
+lemma inf_Sup_eq : a ⊓ Sup s = ⨆ b ∈ s, a ⊓ b :=
 (frame.inf_Sup_le_supr_inf _ _).antisymm supr_inf_le_inf_Sup
 
-lemma Sup_inf_eq : Sup s ⊓ b = (⨆ a ∈ s, a ⊓ b) :=
+lemma Sup_inf_eq : Sup s ⊓ b = ⨆ a ∈ s, a ⊓ b :=
 by simpa only [inf_comm] using @inf_Sup_eq α _ s b
 
 lemma supr_inf_eq (f : ι → α) (a : α) : (⨆ i, f i) ⊓ a = ⨆ i, f i ⊓ a :=

--- a/src/order/complete_boolean_algebra.lean
+++ b/src/order/complete_boolean_algebra.lean
@@ -54,12 +54,6 @@ by simp only [supr_inf_eq]
 lemma inf_bsupr_eq {f : Π i, κ i → α} (a : α) : a ⊓ (⨆ i j, f i j) = ⨆ i j, a ⊓ f i j :=
 by simp only [inf_supr_eq]
 
-instance pi.frame {ι : Type*} {π : ι → Type*} [Π i, frame (π i)] : frame (Π i, π i) :=
-{ inf_Sup_le_supr_inf := λ a s i,
-    by simp only [complete_lattice.Sup, Sup_apply, supr_apply, pi.inf_apply, inf_supr_eq,
-      ← supr_subtype''],
-  .. pi.complete_lattice }
-
 lemma Sup_inf_Sup : Sup s ⊓ Sup t = ⨆ p ∈ s ×ˢ t, (p : α × α).1 ⊓ p.2 :=
 begin
   refine le_antisymm _ _,
@@ -77,6 +71,12 @@ by simp only [disjoint_iff, supr_inf_eq, supr_eq_bot]
 
 lemma disjoint_supr_iff {f : ι → α} : disjoint a (⨆ i, f i) ↔ ∀ i, disjoint a (f i) :=
 by simpa only [disjoint.comm] using @supr_disjoint_iff _ _ _ a f
+
+instance pi.frame {ι : Type*} {π : ι → Type*} [Π i, frame (π i)] : frame (Π i, π i) :=
+{ inf_Sup_le_supr_inf := λ a s i,
+    by simp only [complete_lattice.Sup, Sup_apply, supr_apply, pi.inf_apply, inf_supr_eq,
+      ← supr_subtype''],
+  .. pi.complete_lattice }
 
 end frame
 

--- a/src/order/complete_boolean_algebra.lean
+++ b/src/order/complete_boolean_algebra.lean
@@ -19,6 +19,10 @@ distributive Boolean algebras.
 * `complete_boolean_algebra`: Completely distributive Boolean algebra: A Boolean algebra whose `⊓`
   and `⊔` distribute over `⨆` and `⨅` respectively.
 
+## TODO
+
+Add instances for `prod`
+
 ## References
 
 * [Wikipedia, *Complete Heyting algebra*][https://en.wikipedia.org/wiki/Complete_Heyting_algebra]
@@ -54,17 +58,19 @@ by simp only [supr_inf_eq]
 lemma inf_bsupr_eq {f : Π i, κ i → α} (a : α) : a ⊓ (⨆ i j, f i j) = ⨆ i j, a ⊓ f i j :=
 by simp only [inf_supr_eq]
 
-lemma Sup_inf_Sup : Sup s ⊓ Sup t = ⨆ p ∈ s ×ˢ t, (p : α × α).1 ⊓ p.2 :=
+lemma supr_inf_supr {ι ι' : Type*} {f : ι → α} {g : ι' → α} :
+  (⨆ i, f i) ⊓ (⨆ j, g j) = ⨆ i : ι × ι', f i.1 ⊓ g i.2 :=
+by simp only [inf_supr_eq, supr_inf_eq, supr_prod]
+
+lemma bsupr_inf_bsupr {ι ι' : Type*} {f : ι → α} {g : ι' → α} {s : set ι} {t : set ι'} :
+  (⨆ i ∈ s, f i) ⊓ (⨆ j ∈ t, g j) = ⨆ p ∈ s ×ˢ t, f (p : ι × ι').1 ⊓ g p.2 :=
 begin
-  refine le_antisymm _ _,
-  { simp_rw [Sup_inf_eq, supr_le_iff, inf_Sup_eq],
-    rintro a ha,
-    have : (⨆ p ∈ prod.mk a '' t, (p : α × α).1 ⊓ p.2) ≤ ⨆ p ∈ s ×ˢ t, ((p : α × α).1 : α) ⊓ p.2,
-    { exact supr_le_supr_of_subset (set.image_prod_mk_subset_prod_right ha) },
-    rwa supr_image at this },
-  { simp_rw [supr_le_iff, set.mem_prod],
-    exact λ a ha, inf_le_inf (le_Sup ha.1) (le_Sup ha.2) }
+  simp only [supr_subtype', supr_inf_supr],
+  exact supr_congr (equiv.set.prod s t).symm (equiv.surjective _) (λ x, rfl)
 end
+
+lemma Sup_inf_Sup : Sup s ⊓ Sup t = ⨆ p ∈ s ×ˢ t, (p : α × α).1 ⊓ p.2 :=
+by simp only [Sup_eq_supr, bsupr_inf_bsupr]
 
 lemma supr_disjoint_iff {f : ι → α} : disjoint (⨆ i, f i) a ↔ ∀ i, disjoint (f i) a :=
 by simp only [disjoint_iff, supr_inf_eq, supr_eq_bot]

--- a/src/order/complete_boolean_algebra.lean
+++ b/src/order/complete_boolean_algebra.lean
@@ -19,6 +19,9 @@ distributive Boolean algebras.
 * `complete_boolean_algebra`: Completely distributive Boolean algebra: A Boolean algebra whose `⊓`
   and `⊔` distribute over `⨆` and `⨅` respectively.
 
+A set of opens gives rise to a topological space precisely if it forms a frame. Such a frame is also
+completely distributive, but not all frames are.
+
 ## TODO
 
 Add instances for `prod`
@@ -26,6 +29,7 @@ Add instances for `prod`
 ## References
 
 * [Wikipedia, *Complete Heyting algebra*][https://en.wikipedia.org/wiki/Complete_Heyting_algebra]
+* [Francis Borceux, *Handbook of Categorical Algebra III*][borceux-vol3]
 -/
 
 set_option old_structure_cmd true

--- a/src/order/copy.lean
+++ b/src/order/copy.lean
@@ -72,6 +72,25 @@ begin
   all_goals { abstract { subst_vars, casesI c, assumption } }
 end
 
+/-- A function to create a provable equal copy of a frame with possibly different definitional
+equalities. -/
+def frame.copy (c : frame α)
+  (le : α → α → Prop) (eq_le : le = @frame.le α c)
+  (top : α) (eq_top : top = @frame.top α c)
+  (bot : α) (eq_bot : bot = @frame.bot α c)
+  (sup : α → α → α) (eq_sup : sup = @frame.sup α c)
+  (inf : α → α → α) (eq_inf : inf = @frame.inf α c)
+  (Sup : set α → α) (eq_Sup : Sup = @frame.Sup α c)
+  (Inf : set α → α) (eq_Inf : Inf = @frame.Inf α c) :
+  frame α :=
+begin
+  refine { le := le, top := top, bot := bot, sup := sup, inf := inf, Sup := Sup, Inf := Inf,
+    .. complete_lattice.copy (@frame.to_complete_lattice α c)
+      le eq_le top eq_top bot eq_bot sup eq_sup inf eq_inf Sup eq_Sup Inf eq_Inf,
+    .. },
+  all_goals { abstract { subst_vars, casesI c, assumption } }
+end
+
 /-- A function to create a provable equal copy of a complete distributive lattice
 with possibly different definitional equalities. -/
 def complete_distrib_lattice.copy (c : complete_distrib_lattice α)
@@ -85,7 +104,7 @@ def complete_distrib_lattice.copy (c : complete_distrib_lattice α)
   complete_distrib_lattice α :=
 begin
   refine { le := le, top := top, bot := bot, sup := sup, inf := inf, Sup := Sup, Inf := Inf,
-    .. complete_lattice.copy (@complete_distrib_lattice.to_complete_lattice α c)
+    .. frame.copy (@complete_distrib_lattice.to_frame α c)
       le eq_le top eq_top bot eq_bot sup eq_sup inf eq_inf Sup eq_Sup Inf eq_Inf,
     .. },
   all_goals { abstract { subst_vars, casesI c, assumption } }

--- a/src/order/copy.lean
+++ b/src/order/copy.lean
@@ -13,6 +13,8 @@ where one replaces the data parts with provably equal definitions
 that have better definitional properties.
 -/
 
+open order
+
 universe u
 
 variables {α : Type u}
@@ -91,6 +93,25 @@ begin
   all_goals { abstract { subst_vars, casesI c, assumption } }
 end
 
+/-- A function to create a provable equal copy of a coframe with possibly different definitional
+equalities. -/
+def coframe.copy (c : coframe α)
+  (le : α → α → Prop) (eq_le : le = @coframe.le α c)
+  (top : α) (eq_top : top = @coframe.top α c)
+  (bot : α) (eq_bot : bot = @coframe.bot α c)
+  (sup : α → α → α) (eq_sup : sup = @coframe.sup α c)
+  (inf : α → α → α) (eq_inf : inf = @coframe.inf α c)
+  (Sup : set α → α) (eq_Sup : Sup = @coframe.Sup α c)
+  (Inf : set α → α) (eq_Inf : Inf = @coframe.Inf α c) :
+  coframe α :=
+begin
+  refine { le := le, top := top, bot := bot, sup := sup, inf := inf, Sup := Sup, Inf := Inf,
+    .. complete_lattice.copy (@coframe.to_complete_lattice α c)
+      le eq_le top eq_top bot eq_bot sup eq_sup inf eq_inf Sup eq_Sup Inf eq_Inf,
+    .. },
+  all_goals { abstract { subst_vars, casesI c, assumption } }
+end
+
 /-- A function to create a provable equal copy of a complete distributive lattice
 with possibly different definitional equalities. -/
 def complete_distrib_lattice.copy (c : complete_distrib_lattice α)
@@ -102,13 +123,10 @@ def complete_distrib_lattice.copy (c : complete_distrib_lattice α)
   (Sup : set α → α) (eq_Sup : Sup = @complete_distrib_lattice.Sup α c)
   (Inf : set α → α) (eq_Inf : Inf = @complete_distrib_lattice.Inf α c) :
   complete_distrib_lattice α :=
-begin
-  refine { le := le, top := top, bot := bot, sup := sup, inf := inf, Sup := Sup, Inf := Inf,
-    .. frame.copy (@complete_distrib_lattice.to_frame α c)
+{ .. frame.copy (@complete_distrib_lattice.to_frame α c)
       le eq_le top eq_top bot eq_bot sup eq_sup inf eq_inf Sup eq_Sup Inf eq_Inf,
-    .. },
-  all_goals { abstract { subst_vars, casesI c, assumption } }
-end
+  .. coframe.copy (@complete_distrib_lattice.to_coframe α c)
+      le eq_le top eq_top bot eq_bot sup eq_sup inf eq_inf Sup eq_Sup Inf eq_Inf}
 
 /-- A function to create a provable equal copy of a conditionally complete lattice
 with possibly different definitional equalities. -/


### PR DESCRIPTION
Define the order theoretic `order.frame` and `order.coframe` and insert them between `complete_lattice` and `complete_distrib_lattice`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

~~Do we want the order dual of this? I could not find it in the literature.~~ Added

The design will slightly change once we have Heyting algebras. We will take the Heyting implication as redundant data.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
