### PR TITLE
[Merged by Bors] - feat(measure_theory/integral/lebesgue): weaken assumptions for with_density lemmas

### DIFF
--- a/src/measure_theory/constructions/borel_space.lean
+++ b/src/measure_theory/constructions/borel_space.lean
@@ -1810,6 +1810,23 @@ begin
   { exact tendsto_const_nhds, },
 end
 
+lemma ae_measurable_of_unif_approx {μ : measure α} {g : α → β}
+  (hf : ∀ ε > (0 : ℝ), ∃ (f : α → β), ae_measurable f μ ∧ ∀ᵐ x ∂μ, dist (f x) (g x) ≤ ε) :
+  ae_measurable g μ :=
+begin
+  obtain ⟨u, u_anti, u_pos, u_lim⟩ :
+    ∃ (u : ℕ → ℝ), strict_anti u ∧ (∀ (n : ℕ), 0 < u n) ∧ tendsto u at_top (𝓝 0) :=
+      exists_seq_strict_anti_tendsto (0 : ℝ),
+  choose f Hf using λ (n : ℕ), hf (u n) (u_pos n),
+  have : ∀ᵐ x ∂μ, tendsto (λ n, f n x) at_top (𝓝 (g x)),
+  { have : ∀ᵐ x ∂ μ, ∀ n, dist (f n x) (g x) ≤ u n := ae_all_iff.2 (λ n, (Hf n).2),
+    filter_upwards [this],
+    assume x hx,
+    rw tendsto_iff_dist_tendsto_zero,
+    exact squeeze_zero (λ n, dist_nonneg) hx u_lim },
+  exact ae_measurable_of_tendsto_metric_ae (λ n, (Hf n).1) this,
+end
+
 lemma measurable_of_tendsto_metric_ae {μ : measure α} [μ.is_complete] {f : ℕ → α → β} {g : α → β}
   (hf : ∀ n, measurable (f n))
   (h_ae_tendsto : ∀ᵐ x ∂μ, filter.at_top.tendsto (λ n, f n x) (𝓝 (g x))) :

--- a/src/measure_theory/function/ae_eq_of_integral.lean
+++ b/src/measure_theory/function/ae_eq_of_integral.lean
@@ -307,7 +307,7 @@ lemma ae_fin_strongly_measurable.ae_nonneg_of_forall_set_integral_nonneg {f : α
 begin
   let t := hf.sigma_finite_set,
   suffices : 0 ≤ᵐ[μ.restrict t] f,
-    from ae_of_ae_restrict_of_ae_restrict_compl this hf.ae_eq_zero_compl.symm.le,
+    from ae_of_ae_restrict_of_ae_restrict_compl _ this hf.ae_eq_zero_compl.symm.le,
   haveI : sigma_finite (μ.restrict t) := hf.sigma_finite_restrict,
   refine ae_nonneg_of_forall_set_integral_nonneg_of_sigma_finite (λ s hs hμts, _)
     (λ s hs hμts, _),
@@ -432,7 +432,7 @@ lemma ae_fin_strongly_measurable.ae_eq_zero_of_forall_set_integral_eq_zero {f : 
 begin
   let t := hf.sigma_finite_set,
   suffices : f =ᵐ[μ.restrict t] 0,
-    from ae_of_ae_restrict_of_ae_restrict_compl this hf.ae_eq_zero_compl,
+    from ae_of_ae_restrict_of_ae_restrict_compl _ this hf.ae_eq_zero_compl,
   haveI : sigma_finite (μ.restrict t) := hf.sigma_finite_restrict,
   refine ae_eq_zero_of_forall_set_integral_eq_of_sigma_finite _ _,
   { intros s hs hμs,
@@ -492,7 +492,7 @@ begin
     exact eventually_of_forall htf_zero, },
   have hf_meas_m : @measurable _ _ m _ f, from hf.measurable,
   suffices : f =ᵐ[μ.restrict t] 0,
-    from ae_of_ae_restrict_of_ae_restrict_compl this htf_zero,
+    from ae_of_ae_restrict_of_ae_restrict_compl _ this htf_zero,
   refine measure_eq_zero_of_trim_eq_zero hm _,
   refine ae_eq_zero_of_forall_set_integral_eq_of_sigma_finite _ _,
   { intros s hs hμs,

--- a/src/measure_theory/function/l1_space.lean
+++ b/src/measure_theory/function/l1_space.lean
@@ -592,34 +592,57 @@ end
 lemma of_real_to_real_ae_eq {f : α → ℝ≥0∞} (hf : ∀ᵐ x ∂μ, f x < ∞) :
   (λ x, ennreal.of_real (f x).to_real) =ᵐ[μ] f :=
 begin
-  rw ae_iff at hf,
-  rw [filter.eventually_eq, ae_iff],
-  have : {x | ¬ ennreal.of_real (f x).to_real = f x} = {x | f x = ∞},
-  { ext x,
-    simp only [ne.def, set.mem_set_of_eq],
-    split; intro hx,
-    { by_contra hntop,
-      exact hx (ennreal.of_real_to_real hntop) },
-    { rw hx, simp } },
-  rw this,
-  simpa using hf,
+  filter_upwards [hf],
+  assume x hx,
+  simp only [hx.ne, of_real_to_real, ne.def, not_false_iff],
+end
+
+lemma coe_to_nnreal_ae_eq {f : α → ℝ≥0∞} (hf : ∀ᵐ x ∂μ, f x < ∞) :
+  (λ x, ((f x).to_nnreal : ℝ≥0∞)) =ᵐ[μ] f :=
+begin
+  filter_upwards [hf],
+  assume x hx,
+  simp only [hx.ne, ne.def, not_false_iff, coe_to_nnreal],
+end
+
+lemma integrable_with_density_iff_integrable_smul
+  {E : Type*} [normed_group E] [normed_space ℝ E] [second_countable_topology E]
+  [measurable_space E] [borel_space E]
+  {f : α → ℝ≥0} (hf : measurable f) {g : α → E} :
+  integrable g (μ.with_density (λ x, (f x : ℝ≥0∞))) ↔ integrable (λ x, (f x : ℝ) • g x) μ :=
+begin
+  by_cases H : ae_measurable (λ (x : α), (f x : ℝ) • g x) μ,
+  { simp only [integrable, ae_measurable_with_density_iff hf, has_finite_integral, H, true_and],
+    rw lintegral_with_density_eq_lintegral_mul₀' hf.coe_nnreal_ennreal.ae_measurable,
+    { congr',
+      ext1 x,
+      simp only [nnnorm_smul, nnreal.nnnorm_eq, coe_mul, pi.mul_apply] },
+    { rw ae_measurable_with_density_ennreal_iff hf,
+      convert H.nnnorm.coe_nnreal_ennreal,
+      ext1 x,
+      simp only [nnnorm_smul, nnreal.nnnorm_eq, coe_mul] } },
+  { simp only [integrable, ae_measurable_with_density_iff hf, H, false_and] }
+end
+
+lemma integrable_with_density_iff_integrable_smul'
+  {E : Type*} [normed_group E] [normed_space ℝ E] [second_countable_topology E]
+  [measurable_space E] [borel_space E]
+  {f : α → ℝ≥0∞} (hf : measurable f) (hflt : ∀ᵐ x ∂μ, f x < ∞) {g : α → E} :
+  integrable g (μ.with_density f) ↔ integrable (λ x, (f x).to_real • g x) μ :=
+begin
+  rw [← with_density_congr_ae (coe_to_nnreal_ae_eq hflt),
+      integrable_with_density_iff_integrable_smul],
+  { refl },
+  { exact hf.ennreal_to_nnreal },
 end
 
 lemma integrable_with_density_iff {f : α → ℝ≥0∞} (hf : measurable f)
-  (hflt : ∀ᵐ x ∂μ, f x < ∞) {g : α → ℝ} (hg : measurable g) :
+  (hflt : ∀ᵐ x ∂μ, f x < ∞) {g : α → ℝ} :
   integrable g (μ.with_density f) ↔ integrable (λ x, g x * (f x).to_real) μ :=
 begin
-  simp only [integrable, has_finite_integral, hg.ae_measurable.mul hf.ae_measurable.ennreal_to_real,
-    hg.ae_measurable, true_and, coe_mul, normed_field.nnnorm_mul],
-  suffices h_int_eq : ∫⁻ a, ∥g a∥₊ ∂μ.with_density f = ∫⁻ a, ∥g a∥₊ * ∥(f a).to_real∥₊ ∂μ,
-    by rw h_int_eq,
-  rw lintegral_with_density_eq_lintegral_mul _ hf hg.nnnorm.coe_nnreal_ennreal,
-  refine lintegral_congr_ae _,
-  rw mul_comm,
-  refine filter.eventually_eq.mul (ae_eq_refl _) ((of_real_to_real_ae_eq hflt).symm.trans _),
-  convert ae_eq_refl _,
-  ext1 x,
-  exact real.ennnorm_eq_of_real ennreal.to_real_nonneg,
+  have : (λ x, g x * (f x).to_real) = (λ x, (f x).to_real • g x), by simp [mul_comm],
+  rw this,
+  exact integrable_with_density_iff_integrable_smul' hf hflt,
 end
 
 lemma mem_ℒ1_to_real_of_lintegral_ne_top

--- a/src/measure_theory/integral/lebesgue.lean
+++ b/src/measure_theory/integral/lebesgue.lean
@@ -962,7 +962,7 @@ open simple_func
 variables {m : measurable_space α} {μ ν : measure α}
 
 /-- The **lower Lebesgue integral** of a function `f` with respect to a measure `μ`. -/
-def lintegral {m : measurable_space α} (μ : measure α) (f : α → ℝ≥0∞) : ℝ≥0∞ :=
+@[irreducible] def lintegral {m : measurable_space α} (μ : measure α) (f : α → ℝ≥0∞) : ℝ≥0∞ :=
 ⨆ (g : α →ₛ ℝ≥0∞) (hf : ⇑g ≤ f), g.lintegral μ
 
 /-! In the notation for integrals, an expression like `∫⁻ x, g ∥x∥ ∂μ` will not be parsed correctly,
@@ -977,14 +977,20 @@ notation `∫⁻` binders ` in ` s `, ` r:(scoped:60 f, lintegral (measure.restr
 theorem simple_func.lintegral_eq_lintegral {m : measurable_space α} (f : α →ₛ ℝ≥0∞)
   (μ : measure α) :
   ∫⁻ a, f a ∂ μ = f.lintegral μ :=
-le_antisymm
-  (bsupr_le $ λ g hg, lintegral_mono hg $ le_refl _)
-  (le_supr_of_le f $ le_supr_of_le (le_refl _) (le_refl _))
+begin
+  rw lintegral,
+  exact le_antisymm
+    (bsupr_le $ λ g hg, lintegral_mono hg $ le_refl _)
+    (le_supr_of_le f $ le_supr_of_le (le_refl _) (le_refl _))
+end
 
 @[mono] lemma lintegral_mono' {m : measurable_space α} ⦃μ ν : measure α⦄ (hμν : μ ≤ ν)
   ⦃f g : α → ℝ≥0∞⦄ (hfg : f ≤ g) :
   ∫⁻ a, f a ∂μ ≤ ∫⁻ a, g a ∂ν :=
-supr_le_supr $ λ φ, supr_le_supr2 $ λ hφ, ⟨le_trans hφ hfg, lintegral_mono (le_refl φ) hμν⟩
+begin
+  rw [lintegral, lintegral],
+  exact supr_le_supr (λ φ, supr_le_supr2 $ λ hφ, ⟨le_trans hφ hfg, lintegral_mono (le_refl φ) hμν⟩)
+end
 
 lemma lintegral_mono ⦃f g : α → ℝ≥0∞⦄ (hfg : f ≤ g) :
   ∫⁻ a, f a ∂μ ≤ ∫⁻ a, g a ∂μ :=
@@ -997,6 +1003,16 @@ begin
   intro a,
   rw ennreal.coe_le_coe,
   exact h a,
+end
+
+lemma supr_lintegral_measurable_le_eq_lintegral (f : α → ℝ≥0∞) :
+  (⨆ (g : α → ℝ≥0∞) (g_meas : measurable g) (hg : g ≤ f), ∫⁻ a, g a ∂μ) = ∫⁻ a, f a ∂μ :=
+begin
+  apply le_antisymm,
+  { exact supr_le (λ i, supr_le (λ hi, supr_le (λ h'i, lintegral_mono h'i))) },
+  { rw lintegral,
+    refine bsupr_le (λ i hi, le_supr_of_le i (le_supr_of_le i.measurable (le_supr_of_le hi _))),
+    exact le_of_eq (i.lintegral_eq_lintegral _).symm },
 end
 
 lemma lintegral_mono_set {m : measurable_space α} ⦃μ : measure α⦄
@@ -1031,6 +1047,7 @@ lemma lintegral_eq_nnreal {m : measurable_space α} (f : α → ℝ≥0∞) (μ 
   (∫⁻ a, f a ∂μ) = (⨆ (φ : α →ₛ ℝ≥0) (hf : ∀ x, ↑(φ x) ≤ f x),
       (φ.map (coe : ℝ≥0 → ℝ≥0∞)).lintegral μ) :=
 begin
+  rw lintegral,
   refine le_antisymm
     (bsupr_le $ assume φ hφ, _)
     (supr_le_supr2 $ λ φ, ⟨φ.map (coe : ℝ≥0 → ℝ≥0∞), le_refl _⟩),
@@ -1095,6 +1112,7 @@ lemma lintegral_mono_ae {f g : α → ℝ≥0∞} (h : ∀ᵐ a ∂μ, f a ≤ g
 begin
   rcases exists_measurable_superset_of_null h with ⟨t, hts, ht, ht0⟩,
   have : ∀ᵐ x ∂μ, x ∉ t := measure_zero_iff_ae_nmem.1 ht0,
+  rw [lintegral, lintegral],
   refine (supr_le $ assume s, supr_le $ assume hfs,
     le_supr_of_le (s.restrict tᶜ) $ le_supr_of_le _ _),
   { assume a,
@@ -1433,7 +1451,7 @@ begin
   rw [ennreal.mul_supr],
   simp only [supr_le_iff, ge_iff_le],
   assume hs,
-  rw ← simple_func.const_mul_lintegral,
+  rw [← simple_func.const_mul_lintegral, lintegral],
   refine le_supr_of_le (const α r * s) (le_supr_of_le (λx, _) (le_refl _)),
   exact mul_le_mul_left' (hs x) _
 end
@@ -1505,8 +1523,9 @@ lemma set_lintegral_eq_const {f : α → ℝ≥0∞} (hf : measurable f) (r : �
   ∫⁻ x in {x | f x = r}, f x ∂μ = r * μ {x | f x = r} :=
 begin
   have : ∀ᵐ x ∂μ, x ∈ {x | f x = r} → f x = r := ae_of_all μ (λ _ hx, hx),
-  erw [set_lintegral_congr_fun _ this, lintegral_const,
-       measure.restrict_apply measurable_set.univ, set.univ_inter],
+  rw [set_lintegral_congr_fun _ this],
+  dsimp,
+  rw [lintegral_const, measure.restrict_apply measurable_set.univ, set.univ_inter],
   exact hf (measurable_set_singleton r)
 end
 
@@ -1864,7 +1883,7 @@ lemma lintegral_add_compl (f : α → ℝ≥0∞) {A : set α} (hA : measurable_
   ∫⁻ x in A, f x ∂μ + ∫⁻ x in Aᶜ, f x ∂μ = ∫⁻ x, f x ∂μ :=
 by rw [← lintegral_add_measure, measure.restrict_add_restrict_compl hA]
 
-lemma lintegral_map [measurable_space β] {f : β → ℝ≥0∞} {g : α → β}
+lemma lintegral_map {mβ : measurable_space β} {f : β → ℝ≥0∞} {g : α → β}
   (hf : measurable f) (hg : measurable g) : ∫⁻ a, f a ∂(map g μ) = ∫⁻ a, f (g a) ∂μ :=
 begin
   simp only [lintegral_eq_supr_eapprox_lintegral, hf, hf.comp hg],
@@ -1873,13 +1892,22 @@ begin
   ext1 x, simp only [eapprox_comp hf hg, coe_comp]
 end
 
-lemma lintegral_map' [measurable_space β] {f : β → ℝ≥0∞} {g : α → β}
+lemma lintegral_map' {mβ : measurable_space β} {f : β → ℝ≥0∞} {g : α → β}
   (hf : ae_measurable f (measure.map g μ)) (hg : measurable g) :
   ∫⁻ a, f a ∂(measure.map g μ) = ∫⁻ a, f (g a) ∂μ :=
 calc ∫⁻ a, f a ∂(measure.map g μ) = ∫⁻ a, hf.mk f a ∂(measure.map g μ) :
   lintegral_congr_ae hf.ae_eq_mk
 ... = ∫⁻ a, hf.mk f (g a) ∂μ : lintegral_map hf.measurable_mk hg
 ... = ∫⁻ a, f (g a) ∂μ : lintegral_congr_ae (ae_eq_comp hg hf.ae_eq_mk.symm)
+
+lemma lintegral_map_le {mβ : measurable_space β} (f : β → ℝ≥0∞) {g : α → β} (hg : measurable g) :
+  ∫⁻ a, f a ∂(measure.map g μ) ≤ ∫⁻ a, f (g a) ∂μ :=
+begin
+  rw [← supr_lintegral_measurable_le_eq_lintegral, ← supr_lintegral_measurable_le_eq_lintegral],
+  refine bsupr_le (λ i hi, supr_le (λ h'i, _)),
+  refine le_supr_of_le (i ∘ g) (le_supr_of_le (hi.comp hg) _),
+  exact le_supr_of_le (λ x, h'i (g x)) (le_of_eq (lintegral_map hi hg))
+end
 
 lemma lintegral_comp [measurable_space β] {f : β → ℝ≥0∞} {g : α → β}
   (hf : measurable f) (hg : measurable g) : lintegral μ (f ∘ g) = ∫⁻ a, f a ∂(map g μ) :=
@@ -1897,12 +1925,13 @@ lemma _root_.measurable_embedding.lintegral_map [measurable_space β] {g : α �
   (hg : measurable_embedding g) (f : β → ℝ≥0∞) :
   ∫⁻ a, f a ∂(map g μ) = ∫⁻ a, f (g a) ∂μ :=
 begin
+  rw [lintegral, lintegral],
   refine le_antisymm (bsupr_le $ λ f₀ hf₀, _) (bsupr_le $ λ f₀ hf₀, _),
-  { rw [simple_func.lintegral_map _ hg.measurable, lintegral],
+  { rw [simple_func.lintegral_map _ hg.measurable],
     have : (f₀.comp g hg.measurable : α → ℝ≥0∞) ≤ f ∘ g, from λ x, hf₀ (g x),
     exact le_supr_of_le (comp f₀ g hg.measurable) (le_supr _ this) },
   { rw [← f₀.extend_comp_eq hg (const _ 0), ← simple_func.lintegral_map,
-      ← simple_func.lintegral_eq_lintegral],
+      ← simple_func.lintegral_eq_lintegral, ← lintegral],
     refine lintegral_mono_ae (hg.ae_map_iff.2 $ eventually_of_forall $ λ x, _),
     exact (extend_apply _ _ _ _).trans_le (hf₀ _) }
 end
@@ -2035,6 +2064,14 @@ measure.of_measurable (λs hs, ∫⁻ a in s, f a ∂μ) (by simp) (λ s hs hd, 
   μ.with_density f s = ∫⁻ a in s, f a ∂μ :=
 measure.of_measurable_apply s hs
 
+lemma with_density_congr_ae {f g : α → ℝ≥0∞} (h : f =ᵐ[μ] g) :
+  μ.with_density f = μ.with_density g :=
+begin
+  apply measure.ext (λ s hs, _),
+  rw [with_density_apply _ hs, with_density_apply _ hs],
+  exact lintegral_congr_ae (ae_restrict_of_ae h)
+end
+
 lemma with_density_add {f g : α → ℝ≥0∞} (hf : measurable f) (hg : measurable g) :
   μ.with_density (f + g) = μ.with_density f + μ.with_density g :=
 begin
@@ -2138,6 +2175,115 @@ lemma with_density_eq_zero {f : α → ℝ≥0∞}
 by rw [← lintegral_eq_zero_iff' hf, ← set_lintegral_univ,
        ← with_density_apply _ measurable_set.univ, h, measure.coe_zero, pi.zero_apply]
 
+lemma with_density_apply_eq_zero {f : α → ℝ≥0∞} {s : set α} (hf : measurable f) :
+  μ.with_density f s = 0 ↔ μ ({x | f x ≠ 0} ∩ s) = 0 :=
+begin
+  split,
+  { assume hs,
+    let t := to_measurable (μ.with_density f) s,
+    apply measure_mono_null
+      (inter_subset_inter_right _ (subset_to_measurable (μ.with_density f) s)),
+    have A : μ.with_density f t = 0, by rw [measure_to_measurable, hs],
+    rw [with_density_apply f (measurable_set_to_measurable _ s), lintegral_eq_zero_iff hf,
+        eventually_eq, ae_restrict_iff, ae_iff] at A,
+    swap, { exact hf (measurable_set_singleton 0) },
+    simp only [pi.zero_apply, mem_set_of_eq, filter.mem_mk] at A,
+    convert A,
+    ext x,
+    simp only [and_comm, exists_prop, mem_inter_eq, iff_self, mem_set_of_eq, mem_compl_eq,
+               not_forall] },
+  { assume hs,
+    let t := to_measurable μ ({x | f x ≠ 0} ∩ s),
+    have A : s ⊆ t ∪ {x | f x = 0},
+    { assume x hx,
+      rcases eq_or_ne (f x) 0 with fx|fx,
+      { simp only [fx, mem_union_eq, mem_set_of_eq, eq_self_iff_true, or_true] },
+      { left,
+        apply subset_to_measurable _ _,
+        exact ⟨fx, hx⟩ } },
+    apply measure_mono_null A (measure_union_null _ _),
+    { apply with_density_absolutely_continuous,
+      rwa measure_to_measurable },
+    { have M : measurable_set {x : α | f x = 0} := hf (measurable_set_singleton _),
+      rw [with_density_apply _ M, (lintegral_eq_zero_iff hf)],
+      filter_upwards [ae_restrict_mem M],
+      simp only [imp_self, pi.zero_apply, implies_true_iff] } }
+end
+
+lemma ae_with_density_iff {p : α → Prop} {f : α → ℝ≥0∞} (hf : measurable f) :
+  (∀ᵐ x ∂(μ.with_density f), p x) ↔ ∀ᵐ x ∂μ, f x ≠ 0 → p x :=
+begin
+  rw [ae_iff, ae_iff, with_density_apply_eq_zero hf],
+  congr',
+  ext x,
+  simp only [exists_prop, mem_inter_eq, iff_self, mem_set_of_eq, not_forall],
+end
+
+lemma ae_with_density_iff_ae_restrict {p : α → Prop} {f : α → ℝ≥0∞} (hf : measurable f) :
+  (∀ᵐ x ∂(μ.with_density f), p x) ↔ (∀ᵐ x ∂(μ.restrict {x | f x ≠ 0}), p x) :=
+begin
+  rw [ae_with_density_iff hf, ae_restrict_iff'],
+  { refl },
+  { exact hf (measurable_set_singleton 0).compl },
+end
+
+lemma ae_measurable_with_density_iff {E : Type*} [normed_group E] [normed_space ℝ E]
+  [topological_space.second_countable_topology E] [measurable_space E] [borel_space E]
+  {f : α → ℝ≥0} (hf : measurable f) {g : α → E} :
+  ae_measurable g (μ.with_density (λ x, (f x : ℝ≥0∞))) ↔ ae_measurable (λ x, (f x : ℝ) • g x) μ :=
+begin
+  split,
+  { rintros ⟨g', g'meas, hg'⟩,
+    have A : measurable_set {x : α | f x ≠ 0} := (hf (measurable_set_singleton 0)).compl,
+    refine ⟨λ x, (f x : ℝ) • g' x, hf.coe_nnreal_real.smul g'meas, _⟩,
+    apply @ae_of_ae_restrict_of_ae_restrict_compl _ _ _ {x | f x ≠ 0},
+    { rw [eventually_eq, ae_with_density_iff hf.coe_nnreal_ennreal] at hg',
+      rw ae_restrict_iff' A,
+      filter_upwards [hg'],
+      assume a ha h'a,
+      have : (f a : ℝ≥0∞) ≠ 0, by simpa only [ne.def, coe_eq_zero] using h'a,
+      rw ha this },
+    { filter_upwards [ae_restrict_mem A.compl],
+      assume x hx,
+      simp only [not_not, mem_set_of_eq, mem_compl_eq] at hx,
+      simp [hx] } },
+  { rintros ⟨g', g'meas, hg'⟩,
+    refine ⟨λ x, (f x : ℝ)⁻¹ • g' x, hf.coe_nnreal_real.inv.smul g'meas, _⟩,
+    rw [eventually_eq, ae_with_density_iff hf.coe_nnreal_ennreal],
+    filter_upwards [hg'],
+    assume x hx h'x,
+    rw [← hx, smul_smul, _root_.inv_mul_cancel, one_smul],
+    simp only [ne.def, coe_eq_zero] at h'x,
+    simpa only [nnreal.coe_eq_zero, ne.def] using h'x }
+end
+
+lemma ae_measurable_with_density_ennreal_iff {f : α → ℝ≥0} (hf : measurable f) {g : α → ℝ≥0∞} :
+  ae_measurable g (μ.with_density (λ x, (f x : ℝ≥0∞))) ↔
+    ae_measurable (λ x, (f x : ℝ≥0∞) * g x) μ :=
+begin
+  split,
+  { rintros ⟨g', g'meas, hg'⟩,
+    have A : measurable_set {x : α | f x ≠ 0} := (hf (measurable_set_singleton 0)).compl,
+    refine ⟨λ x, f x * g' x, hf.coe_nnreal_ennreal.smul g'meas, _⟩,
+    apply ae_of_ae_restrict_of_ae_restrict_compl {x | f x ≠ 0},
+    { rw [eventually_eq, ae_with_density_iff hf.coe_nnreal_ennreal] at hg',
+      rw ae_restrict_iff' A,
+      filter_upwards [hg'],
+      assume a ha h'a,
+      have : (f a : ℝ≥0∞) ≠ 0, by simpa only [ne.def, coe_eq_zero] using h'a,
+      rw ha this },
+    { filter_upwards [ae_restrict_mem A.compl],
+      assume x hx,
+      simp only [not_not, mem_set_of_eq, mem_compl_eq] at hx,
+      simp [hx] } },
+  { rintros ⟨g', g'meas, hg'⟩,
+    refine ⟨λ x, (f x)⁻¹ * g' x, hf.coe_nnreal_ennreal.inv.smul g'meas, _⟩,
+    rw [eventually_eq, ae_with_density_iff hf.coe_nnreal_ennreal],
+    filter_upwards [hg'],
+    assume x hx h'x,
+    rw [← hx, ← mul_assoc, ennreal.inv_mul_cancel h'x ennreal.coe_ne_top, one_mul] }
+end
+
 end lintegral
 
 end measure_theory
@@ -2195,6 +2341,131 @@ begin
     simp [lintegral_supr, ennreal.mul_supr, h_mf.mul (h_mea_g _), *] }
 end
 
+lemma set_lintegral_with_density_eq_set_lintegral_mul (μ : measure α) {f g : α → ℝ≥0∞}
+  (hf : measurable f) (hg : measurable g) {s : set α} (hs : measurable_set s) :
+  ∫⁻ x in s, g x ∂μ.with_density f = ∫⁻ x in s, (f * g) x ∂μ :=
+by rw [restrict_with_density hs, lintegral_with_density_eq_lintegral_mul _ hf hg]
+
+/-- The Lebesgue integral of `g` with respect to the measure `μ.with_density f` coincides with
+the integral of `f * g`. This version assumes that `g` is almost everywhere measurable. For a
+version without conditions on `g` but requiring that `f` is almost everywhere finite, see
+`lintegral_with_density_eq_lintegral_mul_non_measurable` -/
+lemma lintegral_with_density_eq_lintegral_mul₀' {μ : measure α} {f : α → ℝ≥0∞}
+  (hf : ae_measurable f μ) {g : α → ℝ≥0∞} (hg : ae_measurable g (μ.with_density f)) :
+  ∫⁻ a, g a ∂(μ.with_density f) = ∫⁻ a, (f * g) a ∂μ :=
+begin
+  let f' := hf.mk f,
+  have : μ.with_density f = μ.with_density f' := with_density_congr_ae hf.ae_eq_mk,
+  rw this at ⊢ hg,
+  let g' := hg.mk g,
+  calc ∫⁻ a, g a ∂(μ.with_density f') = ∫⁻ a, g' a ∂(μ.with_density f') :
+    lintegral_congr_ae hg.ae_eq_mk
+  ... = ∫⁻ a, (f' * g') a ∂μ :
+    lintegral_with_density_eq_lintegral_mul _ hf.measurable_mk hg.measurable_mk
+  ... = ∫⁻ a, (f' * g) a ∂μ :
+    begin
+      apply lintegral_congr_ae,
+      apply ae_of_ae_restrict_of_ae_restrict_compl {x | f' x ≠ 0},
+      { have Z := hg.ae_eq_mk,
+        rw [eventually_eq, ae_with_density_iff_ae_restrict hf.measurable_mk] at Z,
+        filter_upwards [Z],
+        assume x hx,
+        simp only [hx, pi.mul_apply] },
+      { have M : measurable_set {x : α | f' x ≠ 0}ᶜ :=
+          (hf.measurable_mk (measurable_set_singleton 0).compl).compl,
+        filter_upwards [ae_restrict_mem M],
+        assume x hx,
+        simp only [not_not, mem_set_of_eq, mem_compl_eq] at hx,
+        simp only [hx, zero_mul, pi.mul_apply] }
+    end
+  ... = ∫⁻ (a : α), (f * g) a ∂μ :
+    begin
+      apply lintegral_congr_ae,
+      filter_upwards [hf.ae_eq_mk],
+      assume x hx,
+      simp only [hx, pi.mul_apply],
+    end
+end
+
+lemma lintegral_with_density_eq_lintegral_mul₀ {μ : measure α} {f : α → ℝ≥0∞}
+  (hf : ae_measurable f μ) {g : α → ℝ≥0∞} (hg : ae_measurable g μ) :
+  ∫⁻ a, g a ∂(μ.with_density f) = ∫⁻ a, (f * g) a ∂μ :=
+lintegral_with_density_eq_lintegral_mul₀' hf (hg.mono' (with_density_absolutely_continuous μ f))
+
+lemma lintegral_with_density_le_lintegral_mul (μ : measure α)
+  {f : α → ℝ≥0∞} (f_meas : measurable f) (g : α → ℝ≥0∞) :
+  ∫⁻ a, g a ∂(μ.with_density f) ≤ ∫⁻ a, (f * g) a ∂μ :=
+begin
+  rw [← supr_lintegral_measurable_le_eq_lintegral, ← supr_lintegral_measurable_le_eq_lintegral],
+  refine bsupr_le (λ i i_meas, supr_le (λ hi, _)),
+  have A : f * i ≤ f * g := λ x, ennreal.mul_le_mul le_rfl (hi x),
+  refine le_supr_of_le (f * i) (le_supr_of_le (f_meas.mul i_meas) _),
+  exact le_supr_of_le A (le_of_eq (lintegral_with_density_eq_lintegral_mul _ f_meas i_meas))
+end
+
+lemma lintegral_with_density_eq_lintegral_mul_non_measurable (μ : measure α)
+  {f : α → ℝ≥0∞} (f_meas : measurable f) (hf : ∀ᵐ x ∂μ, f x < ∞) (g : α → ℝ≥0∞) :
+  ∫⁻ a, g a ∂(μ.with_density f) = ∫⁻ a, (f * g) a ∂μ :=
+begin
+  refine le_antisymm (lintegral_with_density_le_lintegral_mul μ f_meas g) _,
+  rw [← supr_lintegral_measurable_le_eq_lintegral, ← supr_lintegral_measurable_le_eq_lintegral],
+  refine bsupr_le (λ i i_meas, supr_le (λ hi, _)),
+  have A : (λ x, (f x)⁻¹ * i x) ≤ g,
+  { assume x,
+    dsimp,
+    rw [mul_comm, ← div_eq_mul_inv],
+    exact div_le_of_le_mul' (hi x), },
+  refine le_supr_of_le (λ x, (f x)⁻¹ * i x) (le_supr_of_le (f_meas.inv.mul i_meas) _),
+  refine le_supr_of_le A _,
+  rw lintegral_with_density_eq_lintegral_mul _ f_meas (f_meas.inv.mul i_meas),
+  apply lintegral_mono_ae,
+  filter_upwards [hf],
+  assume x h'x,
+  rcases eq_or_ne (f x) 0 with hx|hx,
+  { have := hi x,
+    simp only [hx, zero_mul, pi.mul_apply, nonpos_iff_eq_zero] at this,
+    simp [this] },
+  { apply le_of_eq _,
+    dsimp,
+    rw [← mul_assoc, ennreal.mul_inv_cancel hx h'x.ne, one_mul] }
+end
+
+lemma set_lintegral_with_density_eq_set_lintegral_mul_non_measurable (μ : measure α)
+  {f : α → ℝ≥0∞} (f_meas : measurable f) (g : α → ℝ≥0∞)
+  {s : set α} (hs : measurable_set s) (hf : ∀ᵐ x ∂(μ.restrict s), f x < ∞) :
+  ∫⁻ a in s, g a ∂(μ.with_density f) = ∫⁻ a in s, (f * g) a ∂μ :=
+by rw [restrict_with_density hs, lintegral_with_density_eq_lintegral_mul_non_measurable _ f_meas hf]
+
+lemma lintegral_with_density_eq_lintegral_mul_non_measurable₀ (μ : measure α)
+  {f : α → ℝ≥0∞} (hf : ae_measurable f μ) (h'f : ∀ᵐ x ∂μ, f x < ∞) (g : α → ℝ≥0∞) :
+  ∫⁻ a, g a ∂(μ.with_density f) = ∫⁻ a, (f * g) a ∂μ :=
+begin
+  let f' := hf.mk f,
+  calc
+  ∫⁻ a, g a ∂(μ.with_density f)
+      = ∫⁻ a, g a ∂(μ.with_density f') : by rw with_density_congr_ae hf.ae_eq_mk
+  ... = ∫⁻ a, (f' * g) a ∂μ :
+    begin
+      apply lintegral_with_density_eq_lintegral_mul_non_measurable _ hf.measurable_mk,
+      filter_upwards [h'f, hf.ae_eq_mk],
+      assume x hx h'x,
+      rwa ← h'x,
+    end
+  ... = ∫⁻ a, (f * g) a ∂μ :
+    begin
+      apply lintegral_congr_ae,
+      filter_upwards [hf.ae_eq_mk],
+      assume x hx,
+      simp only [hx, pi.mul_apply],
+    end
+end
+
+lemma set_lintegral_with_density_eq_set_lintegral_mul_non_measurable₀ (μ : measure α)
+  {f : α → ℝ≥0∞} {s : set α} (hf : ae_measurable f (μ.restrict s)) (g : α → ℝ≥0∞)
+  (hs : measurable_set s) (h'f : ∀ᵐ x ∂(μ.restrict s), f x < ∞) :
+  ∫⁻ a in s, g a ∂(μ.with_density f) = ∫⁻ a in s, (f * g) a ∂μ :=
+by rw [restrict_with_density hs, lintegral_with_density_eq_lintegral_mul_non_measurable₀ _ hf h'f]
+
 lemma with_density_mul (μ : measure α) {f g : α → ℝ≥0∞} (hf : measurable f) (hg : measurable g) :
   μ.with_density (f * g) = (μ.with_density f).with_density g :=
 begin
@@ -2202,11 +2473,6 @@ begin
   simp [with_density_apply _ hs, restrict_with_density hs,
         lintegral_with_density_eq_lintegral_mul _ hf hg],
 end
-
-lemma set_lintegral_with_density_eq_set_lintegral_mul (μ : measure α) {f g : α → ℝ≥0∞}
-  (hf : measurable f) (hg : measurable g) {s : set α} (hs : measurable_set s) :
-  ∫⁻ x in s, g x ∂μ.with_density f = ∫⁻ x in s, (f * g) x ∂μ :=
-by rw [restrict_with_density hs, lintegral_with_density_eq_lintegral_mul _ hf hg]
 
 /-- In a sigma-finite measure space, there exists an integrable function which is
 positive everywhere (and with an arbitrarily small integral). -/

--- a/src/measure_theory/measure/measure_space.lean
+++ b/src/measure_theory/measure/measure_space.lean
@@ -1658,7 +1658,7 @@ lemma ae_restrict_of_ae_restrict_of_subset {s t : set α} {p : α → Prop} (hst
   (∀ᵐ x ∂(μ.restrict s), p x) :=
 h.filter_mono (ae_mono $ measure.restrict_mono hst (le_refl μ))
 
-lemma ae_of_ae_restrict_of_ae_restrict_compl {t : set α} {p : α → Prop}
+lemma ae_of_ae_restrict_of_ae_restrict_compl (t : set α) {p : α → Prop}
   (ht : ∀ᵐ x ∂(μ.restrict t), p x) (htc : ∀ᵐ x ∂(μ.restrict tᶜ), p x) :
   ∀ᵐ x ∂μ, p x :=
 nonpos_iff_eq_zero.1 $
@@ -3263,7 +3263,7 @@ begin
       (indicator_ae_eq_restrict hs).trans (h.ae_eq_mk.trans $ (indicator_ae_eq_restrict hs).symm),
     have B : s.indicator f =ᵐ[μ.restrict sᶜ] s.indicator (ae_measurable.mk f h) :=
       (indicator_ae_eq_restrict_compl hs).trans (indicator_ae_eq_restrict_compl hs).symm,
-    exact ae_of_ae_restrict_of_ae_restrict_compl A B },
+    exact ae_of_ae_restrict_of_ae_restrict_compl _ A B },
 end
 
 @[measurability]

--- a/src/probability_theory/density.lean
+++ b/src/probability_theory/density.lean
@@ -158,7 +158,7 @@ lemma integrable_iff_integrable_mul_pdf [is_finite_measure ℙ] {X : α → E} [
 begin
   rw [← integrable_map_measure hf.ae_measurable (has_pdf.measurable X ℙ μ),
       map_eq_with_density_pdf X ℙ μ,
-      integrable_with_density_iff (measurable_pdf _ _ _) ae_lt_top hf],
+      integrable_with_density_iff (measurable_pdf _ _ _) ae_lt_top],
   apply_instance
 end
 


### PR DESCRIPTION
We state more precise versions of some lemmas about the measure `μ.with_density f`, making it possible to remove some assumptions down the road. For instance, the lemma
```lean
  integrable g (μ.with_density f) ↔ integrable (λ x, g x * (f x).to_real) μ
```
currently requires the measurability of `g`, while we can completely remove it with the new lemmas.

We also make `lintegral` irreducible.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
