### PR TITLE
[Merged by Bors] - feat(data/nat/mul_ind): generalise rec_on_prime to assume positivity

### DIFF
--- a/src/data/nat/factorization.lean
+++ b/src/data/nat/factorization.lean
@@ -164,7 +164,7 @@ begin
   { intros p k hp hk hpk, simp [prime.factorization_pow hp, finsupp.prod_single_index _, hf] },
   { simp },
   { rintros -, rw [factorization_one, hf], simp },
-  { intros a b hab ha hb hab_pos,
+  { intros a b _ _ hab ha hb hab_pos,
     rw [h_mult a b hab, ha (left_ne_zero_of_mul hab_pos), hb (right_ne_zero_of_mul hab_pos),
         factorization_mul_of_coprime hab, ←prod_add_index_of_disjoint],
     convert (factorization_disjoint_of_coprime hab) },
@@ -180,7 +180,7 @@ begin
   { intros p k hp hk, simp only [hp.factorization_pow], rw prod_single_index _, simp [hf1] },
   { simp [hf0] },
   { rw [factorization_one, hf1], simp },
-  { intros a b hab ha hb,
+  { intros a b _ _ hab ha hb,
     rw [h_mult a b hab, ha, hb, factorization_mul_of_coprime hab, ←prod_add_index_of_disjoint],
     convert (factorization_disjoint_of_coprime hab) },
 end

--- a/src/data/nat/mul_ind.lean
+++ b/src/data/nat/mul_ind.lean
@@ -68,16 +68,18 @@ def rec_on_prime_pow {P : ℕ → Sort*} (h0 : P 0) (h1 : P 1)
 `P b` to `P (a * b)` when `a, b` are coprime, you can define `P` for all natural numbers. -/
 @[elab_as_eliminator]
 def rec_on_pos_prime_coprime {P : ℕ → Sort*} (hp : ∀ p n : ℕ, prime p → 0 < n → P (p ^ n))
-  (h0 : P 0) (h1 : P 1) (h : ∀ a b, coprime a b → P a → P b → P (a * b)) : ∀ a, P a :=
+  (h0 : P 0) (h1 : P 1) (h : ∀ a b, 0 < a → 0 < b → coprime a b → P a → P b → P (a * b)) :
+  ∀ a, P a :=
 rec_on_prime_pow h0 h1 $ λ a p n hp' hpa ha,
-  h (p ^ n) a ((prime.coprime_pow_of_not_dvd hp' hpa).symm)
-  (if h : n = 0 then eq.rec h1 h.symm else hp p n hp' $ nat.pos_of_ne_zero h) ha
+  (h (p ^ n) a (pow_pos hp'.pos _) (nat.pos_of_ne_zero (λ t, by simpa [t] using hpa))
+  (prime.coprime_pow_of_not_dvd hp' hpa).symm
+  (if h : n = 0 then eq.rec h1 h.symm else hp p n hp' $ nat.pos_of_ne_zero h) ha)
 
 /-- Given `P 0`, `P (p ^ k)` for all prime powers, and a way to extend `P a` and `P b` to
 `P (a * b)` when `a, b` are coprime, you can define `P` for all natural numbers. -/
 @[elab_as_eliminator]
 def rec_on_prime_coprime {P : ℕ → Sort*} (h0 : P 0) (hp : ∀ p n : ℕ, prime p → P (p ^ n))
-  (h : ∀ a b, coprime a b → P a → P b → P (a * b)) : ∀ a, P a :=
+  (h : ∀ a b, 0 < a → 0 < b → coprime a b → P a → P b → P (a * b)) : ∀ a, P a :=
 rec_on_pos_prime_coprime (λ p n h _, hp p n h) h0 (hp 2 0 prime_two) h
 
 /-- Given `P 0`, `P 1`, `P p` for all primes, and a proof that you can extend
@@ -90,6 +92,6 @@ let hp : ∀ p n : ℕ, prime p → P (p ^ n) :=
   | 0     := h1
   | (n+1) := by exact h _ _ (hp p hp') (_match _)
   end in
-rec_on_prime_coprime h0 hp $ λ a b _, h a b
+rec_on_prime_coprime h0 hp $ λ a b _ _ _, h a b
 
 end nat


### PR DESCRIPTION
This makes the multiplicative induction principles slightly stronger, as the coprimality part can assume the given values are positive.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
