### PR TITLE
[Merged by Bors] - chore(*): Rename `prod_dvd_prod`

### DIFF
--- a/src/algebra/big_operators/basic.lean
+++ b/src/algebra/big_operators/basic.lean
@@ -1220,7 +1220,7 @@ lemma prod_pow_boole [decidable_eq α] (s : finset α) (f : α → β) (a : α) 
   (∏ x in s, (f x)^(ite (a = x) 1 0)) = ite (a ∈ s) (f a) 1 :=
 by simp
 
-lemma prod_dvd_prod {S : finset α} (g1 g2 : α → β) (h : ∀ a ∈ S, g1 a ∣ g2 a) :
+lemma prod_dvd_prod_of_dvd {S : finset α} (g1 g2 : α → β) (h : ∀ a ∈ S, g1 a ∣ g2 a) :
   S.prod g1 ∣ S.prod g2 :=
 begin
   classical,
@@ -1552,7 +1552,7 @@ end
 lemma to_finset_prod_dvd_prod [comm_monoid α] {S : multiset α} : S.to_finset.prod id ∣ S.prod :=
 begin
   rw finset.prod_eq_multiset_prod,
-  refine multiset.prod_dvd_prod _,
+  refine multiset.prod_dvd_prod_of_le _,
   simp [multiset.erase_dup_le S],
 end
 

--- a/src/algebra/big_operators/multiset.lean
+++ b/src/algebra/big_operators/multiset.lean
@@ -143,7 +143,7 @@ end
 lemma dvd_prod : a ∈ s → a ∣ s.prod :=
 quotient.induction_on s (λ l a h, by simpa using list.dvd_prod h) a
 
-lemma prod_dvd_prod (h : s ≤ t) : s.prod ∣ t.prod :=
+lemma prod_dvd_prod_of_le (h : s ≤ t) : s.prod ∣ t.prod :=
 begin
   obtain ⟨z, rfl⟩ := multiset.le_iff_exists_add.1 h,
   simp only [prod_add, dvd_mul_right],

--- a/src/algebra/squarefree.lean
+++ b/src/algebra/squarefree.lean
@@ -216,7 +216,7 @@ begin
         apply not_irreducible_zero (irreducible_of_normalized_factor 0
             (multiset.mem_erase_dup.1 (multiset.mem_of_le hs con))) },
       rw (normalized_factors_prod h0).symm.dvd_iff_dvd_right,
-      refine ⟨⟨multiset.prod_dvd_prod (le_trans hs (multiset.erase_dup_le _)), h0⟩, _⟩,
+      refine ⟨⟨multiset.prod_dvd_prod_of_le (le_trans hs (multiset.erase_dup_le _)), h0⟩, _⟩,
       have h := unique_factorization_monoid.factors_unique irreducible_of_normalized_factor
         (λ x hx, irreducible_of_normalized_factor x (multiset.mem_of_le
           (le_trans hs (multiset.erase_dup_le _)) hx)) (normalized_factors_prod hs0),

--- a/src/ring_theory/unique_factorization_domain.lean
+++ b/src/ring_theory/unique_factorization_domain.lean
@@ -531,7 +531,7 @@ begin
     simp [hx, right_ne_zero_of_mul hy] },
   { rw [← (normalized_factors_prod hx).dvd_iff_dvd_left,
       ← (normalized_factors_prod hy).dvd_iff_dvd_right],
-    apply multiset.prod_dvd_prod }
+    apply multiset.prod_dvd_prod_of_le }
 end
 
 lemma zero_not_mem_normalized_factors (x : α) : (0 : α) ∉ normalized_factors x :=
@@ -1412,7 +1412,7 @@ begin
     show (s.snd : M) * s.fst.prod ∣ y,
     rw [(unit_associated_one.mul_right s.fst.prod).dvd_iff_dvd_left, one_mul,
         ← (normalized_factors_prod hy).dvd_iff_dvd_right],
-    exact multiset.prod_dvd_prod hs },
+    exact multiset.prod_dvd_prod_of_le hs },
   { rintro (h : x ∣ y),
     have hx : x ≠ 0, { refine mt (λ hx, _) hy, rwa [hx, zero_dvd_iff] at h },
     obtain ⟨u, hu⟩ := normalized_factors_prod hx,


### PR DESCRIPTION
In #11693 I introduced the counterpart for `multiset` of `finset.prod_dvd_prod`.  It makes sense for these to have the same name, but there's already a different lemma called `multiset.prod_dvd_prod`, so the new lemma was named `multiset.prod_dvd_prod_of_dvd` instead.  As discussed with @riccardobrasca and @ericrbg at #11693, this PR brings the names of the two counterpart lemmas into alignment, and also renames `multiset.prod_dvd_prod` to something more informative.

Renaming as follows:
`multiset.prod_dvd_prod` to `multiset.prod_dvd_prod_of_le`
`finset.prod_dvd_prod` to `finset.prod_dvd_prod_of_dvd`

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
