### PR TITLE
[Merged by Bors] - fix(tactic/suggest): make `library_search` aware of definition of `ne`

### DIFF
--- a/src/tactic/suggest.lean
+++ b/src/tactic/suggest.lean
@@ -62,10 +62,13 @@ meta def allowed_head_symbols : expr → list name
 | `(@has_le.le ℕ _ 1 _) := [`has_le.le, `has_lt.lt]
 | `(@ge ℕ _ _ 1) := [`has_le.le, `has_lt.lt]
 
--- And then the generic cases:
-| (expr.pi _ _ _ t) := allowed_head_symbols t
+-- These allow `library_search` to search for lemmas of type `¬ a = b` when proving `a ≠ b`
+--   and vice-versa.
 | `(_ ≠ _) := [`false]
 | `(¬ _ = _) := [`ne]
+
+-- And then the generic cases:
+| (expr.pi _ _ _ t) := allowed_head_symbols t
 | (expr.app f _) := allowed_head_symbols f
 | (expr.const n _) := [normalize_synonym n]
 | _ := [`_]

--- a/src/tactic/suggest.lean
+++ b/src/tactic/suggest.lean
@@ -64,6 +64,8 @@ meta def allowed_head_symbols : expr → list name
 
 -- And then the generic cases:
 | (expr.pi _ _ _ t) := allowed_head_symbols t
+| `(_ ≠ _) := [`false]
+| `(¬ _ = _) := [`ne]
 | (expr.app f _) := allowed_head_symbols f
 | (expr.const n _) := [normalize_synonym n]
 | _ := [`_]

--- a/test/library_search/basic.lean
+++ b/test/library_search/basic.lean
@@ -150,4 +150,11 @@ begin
   exact []
 end
 
+-- Tests for #3428
+constants (x y w z : ℕ)
+axiom not_axiom : ¬ x = y
+axiom ne_axiom : w ≠ z
+example : x ≠ y := by library_search
+example : ¬ w = z := by library_search
+
 end test.library_search


### PR DESCRIPTION
`library_search` wasn't including results like `¬ a = b` to solve goals like `a ≠ b` and vice-versa.

Closes #3428

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
