### PR TITLE
[Merged by Bors] - feat(order/category/*): `order_dual` as an equivalence of categories

### DIFF
--- a/src/data/fin/basic.lean
+++ b/src/data/fin/basic.lean
@@ -196,6 +196,8 @@ instance {n : ℕ} : linear_order (fin n) :=
   decidable_eq := fin.decidable_eq _,
  ..linear_order.lift (coe : fin n → ℕ) (@fin.eq_of_veq _) }
 
+instance {n : ℕ}  : partial_order (fin n) := linear_order.to_partial_order (fin n)
+
 /-- The inclusion map `fin n → ℕ` is a relation embedding. -/
 def coe_embedding (n) : (fin n) ↪o ℕ :=
 ⟨⟨coe, @fin.eq_of_veq _⟩, λ a b, iff.rfl⟩

--- a/src/data/fintype/basic.lean
+++ b/src/data/fintype/basic.lean
@@ -871,6 +871,8 @@ fintype.of_equiv _ equiv.plift.symm
   fintype.card (plift α) = fintype.card α :=
 fintype.of_equiv_card _
 
+instance (α : Type*) [fintype α] : fintype (order_dual α) := ‹fintype α›
+
 lemma univ_sum_type {α β : Type*} [fintype α] [fintype β] [fintype (α ⊕ β)] [decidable_eq (α ⊕ β)] :
   (univ : finset (α ⊕ β)) = map function.embedding.inl univ ∪ map function.embedding.inr univ :=
 begin

--- a/src/data/fintype/basic.lean
+++ b/src/data/fintype/basic.lean
@@ -873,6 +873,14 @@ fintype.of_equiv_card _
 
 instance (α : Type*) [fintype α] : fintype (order_dual α) := ‹fintype α›
 
+@[simp] lemma fintype.card_order_dual (α : Type*) [fintype α] :
+  fintype.card (order_dual α) = fintype.card α := rfl
+
+instance (α : Type*) [fintype α] : fintype (lex α) := ‹fintype α›
+
+@[simp] lemma fintype.card_lex (α : Type*) [fintype α] :
+  fintype.card (lex α) = fintype.card α := rfl
+
 lemma univ_sum_type {α β : Type*} [fintype α] [fintype β] [fintype (α ⊕ β)] [decidable_eq (α ⊕ β)] :
   (univ : finset (α ⊕ β)) = map function.embedding.inl univ ∪ map function.embedding.inr univ :=
 begin

--- a/src/data/fintype/order.lean
+++ b/src/data/fintype/order.lean
@@ -138,6 +138,7 @@ end fintype
 
 /-! ### Concrete instances -/
 
+@[priority 900] -- to avoid noncomputability poisoning
 noncomputable instance {n : ℕ} : complete_linear_order (fin (n + 1)) :=
 fintype.to_complete_linear_order _
 

--- a/src/data/fintype/order.lean
+++ b/src/data/fintype/order.lean
@@ -138,7 +138,6 @@ end fintype
 
 /-! ### Concrete instances -/
 
-@[priority 900] -- to avoid noncomputability poisoning
 noncomputable instance {n : ℕ} : complete_linear_order (fin (n + 1)) :=
 fintype.to_complete_linear_order _
 

--- a/src/order/category/LinearOrder.lean
+++ b/src/order/category/LinearOrder.lean
@@ -16,7 +16,7 @@ open category_theory
 
 universe u
 
-/-- The category of linearly ordered types. -/
+/-- The category of linear orders. -/
 def LinearOrder := bundled linear_order
 
 namespace LinearOrder
@@ -49,13 +49,10 @@ bundled_hom.forget₂ _ _
 { obj := λ X, of (order_dual X), map := λ X Y, order_hom.dual }
 
 /-- The equivalence between `PartialOrder` and itself induced by `order_dual` both ways. -/
-def dual_equiv : LinearOrder ≌ LinearOrder :=
+@[simps functor inverse] def dual_equiv : LinearOrder ≌ LinearOrder :=
 equivalence.mk to_dual to_dual
   (nat_iso.of_components (λ X, iso.mk $ order_iso.dual_dual X) $ λ X Y f, rfl)
   (nat_iso.of_components (λ X, iso.mk $ order_iso.dual_dual X) $ λ X Y f, rfl)
-
-@[simp] lemma dual_equiv_functor : dual_equiv.functor = to_dual := rfl
-@[simp] lemma dual_equiv_inverse : dual_equiv.inverse = to_dual := rfl
 
 end LinearOrder
 

--- a/src/order/category/LinearOrder.lean
+++ b/src/order/category/LinearOrder.lean
@@ -6,9 +6,15 @@ Authors: Johan Commelin
 
 import order.category.PartialOrder
 
-/-! # Category of linearly ordered types -/
+/-!
+# Category of linear orders
+
+This defines `LinearOrder`, the category of linear orders with monotone maps.
+-/
 
 open category_theory
+
+universe u
 
 /-- The category of linearly ordered types. -/
 def LinearOrder := bundled linear_order
@@ -21,11 +27,38 @@ attribute [derive [large_category, concrete_category]] LinearOrder
 
 instance : has_coe_to_sort LinearOrder Type* := bundled.has_coe_to_sort
 
-/-- Construct a bundled LinearOrder from the underlying type and typeclass. -/
+/-- Construct a bundled `LinearOrder` from the underlying type and typeclass. -/
 def of (α : Type*) [linear_order α] : LinearOrder := bundled.of α
 
 instance : inhabited LinearOrder := ⟨of punit⟩
 
 instance (α : LinearOrder) : linear_order α := α.str
 
+instance has_forget_to_PartialOrder : has_forget₂ LinearOrder PartialOrder :=
+bundled_hom.forget₂ _ _
+
+/-- `order_dual` as a functor. -/
+@[simps] def to_dual : LinearOrder ⥤ LinearOrder :=
+{ obj := λ X, of (order_dual X), map := λ X Y, order_hom.dual }
+
+/-- Constructs an equivalence between linear orders from an order isomorphism between them. -/
+@[simps] def iso_of_order_iso {α β : LinearOrder.{u}} (e : α ≃o β) : α ≅ β :=
+{ hom := e,
+  inv := e.symm,
+  hom_inv_id' := by { ext, exact e.symm_apply_apply x },
+  inv_hom_id' := by { ext, exact e.apply_symm_apply x } }
+
+/-- The equivalence between `PartialOrder` and itself induced by `order_dual` both ways. -/
+def dual_equiv : LinearOrder ≌ LinearOrder :=
+equivalence.mk to_dual to_dual
+  (nat_iso.of_components (λ X, iso_of_order_iso $ order_iso.dual_dual X) $ λ X Y f, rfl)
+  (nat_iso.of_components (λ X, iso_of_order_iso $ order_iso.dual_dual X) $ λ X Y f, rfl)
+
+@[simp] lemma dual_equiv_functor : dual_equiv.functor = to_dual := rfl
+@[simp] lemma dual_equiv_inverse : dual_equiv.inverse = to_dual := rfl
+
 end LinearOrder
+
+lemma LinearOrder_dual_equiv_comp_forget_to_PartialOrder :
+  LinearOrder.dual_equiv.functor ⋙ forget₂ LinearOrder PartialOrder
+  = forget₂ LinearOrder PartialOrder ⋙ PartialOrder.dual_equiv.functor := rfl

--- a/src/order/category/LinearOrder.lean
+++ b/src/order/category/LinearOrder.lean
@@ -38,7 +38,7 @@ instance has_forget_to_PartialOrder : has_forget₂ LinearOrder PartialOrder :=
 bundled_hom.forget₂ _ _
 
 /-- Constructs an equivalence between linear orders from an order isomorphism between them. -/
-@[simps] def iso_of_order_iso {α β : LinearOrder.{u}} (e : α ≃o β) : α ≅ β :=
+@[simps] def iso.mk {α β : LinearOrder.{u}} (e : α ≃o β) : α ≅ β :=
 { hom := e,
   inv := e.symm,
   hom_inv_id' := by { ext, exact e.symm_apply_apply x },
@@ -51,8 +51,8 @@ bundled_hom.forget₂ _ _
 /-- The equivalence between `PartialOrder` and itself induced by `order_dual` both ways. -/
 def dual_equiv : LinearOrder ≌ LinearOrder :=
 equivalence.mk to_dual to_dual
-  (nat_iso.of_components (λ X, iso_of_order_iso $ order_iso.dual_dual X) $ λ X Y f, rfl)
-  (nat_iso.of_components (λ X, iso_of_order_iso $ order_iso.dual_dual X) $ λ X Y f, rfl)
+  (nat_iso.of_components (λ X, iso.mk $ order_iso.dual_dual X) $ λ X Y f, rfl)
+  (nat_iso.of_components (λ X, iso.mk $ order_iso.dual_dual X) $ λ X Y f, rfl)
 
 @[simp] lemma dual_equiv_functor : dual_equiv.functor = to_dual := rfl
 @[simp] lemma dual_equiv_inverse : dual_equiv.inverse = to_dual := rfl

--- a/src/order/category/LinearOrder.lean
+++ b/src/order/category/LinearOrder.lean
@@ -37,16 +37,16 @@ instance (α : LinearOrder) : linear_order α := α.str
 instance has_forget_to_PartialOrder : has_forget₂ LinearOrder PartialOrder :=
 bundled_hom.forget₂ _ _
 
-/-- `order_dual` as a functor. -/
-@[simps] def to_dual : LinearOrder ⥤ LinearOrder :=
-{ obj := λ X, of (order_dual X), map := λ X Y, order_hom.dual }
-
 /-- Constructs an equivalence between linear orders from an order isomorphism between them. -/
 @[simps] def iso_of_order_iso {α β : LinearOrder.{u}} (e : α ≃o β) : α ≅ β :=
 { hom := e,
   inv := e.symm,
   hom_inv_id' := by { ext, exact e.symm_apply_apply x },
   inv_hom_id' := by { ext, exact e.apply_symm_apply x } }
+
+/-- `order_dual` as a functor. -/
+@[simps] def to_dual : LinearOrder ⥤ LinearOrder :=
+{ obj := λ X, of (order_dual X), map := λ X Y, order_hom.dual }
 
 /-- The equivalence between `PartialOrder` and itself induced by `order_dual` both ways. -/
 def dual_equiv : LinearOrder ≌ LinearOrder :=

--- a/src/order/category/NonemptyFinLinOrd.lean
+++ b/src/order/category/NonemptyFinLinOrd.lean
@@ -66,10 +66,6 @@ instance (α : NonemptyFinLinOrd) : nonempty_fin_lin_ord α := α.str
 instance has_forget_to_LinearOrder : has_forget₂ NonemptyFinLinOrd LinearOrder :=
 bundled_hom.forget₂ _ _
 
-/-- `order_dual` as a functor. -/
-@[simps] def to_dual : NonemptyFinLinOrd ⥤ NonemptyFinLinOrd :=
-{ obj := λ X, of (order_dual X), map := λ X Y, order_hom.dual }
-
 /-- Constructs an equivalence between nonempty finite linear orders from an order isomorphism
 between them. -/
 @[simps] def iso_of_order_iso {α β : NonemptyFinLinOrd.{u}} (e : α ≃o β) : α ≅ β :=
@@ -77,6 +73,10 @@ between them. -/
   inv := e.symm,
   hom_inv_id' := by { ext, exact e.symm_apply_apply x },
   inv_hom_id' := by { ext, exact e.apply_symm_apply x } }
+
+/-- `order_dual` as a functor. -/
+@[simps] def to_dual : NonemptyFinLinOrd ⥤ NonemptyFinLinOrd :=
+{ obj := λ X, of (order_dual X), map := λ X Y, order_hom.dual }
 
 /-- The equivalence between `FinPartialOrder` and itself induced by `order_dual` both ways. -/
 def dual_equiv : NonemptyFinLinOrd ≌ NonemptyFinLinOrd :=

--- a/src/order/category/NonemptyFinLinOrd.lean
+++ b/src/order/category/NonemptyFinLinOrd.lean
@@ -3,12 +3,14 @@ Copyright (c) 2020 Johan Commelin. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johan Commelin
 -/
-import data.fin.basic
+import data.fintype.order
 import order.category.LinearOrder
 
-/-! # Nonempty finite linear orders
+/-!
+# Nonempty finite linear orders
 
-Nonempty finite linear orders form the index category for simplicial objects.
+This defines `NonemptyFinLinOrd`, the category of nonempty finite linear orders with monotone maps.
+This is the index category for simplicial objects.
 -/
 
 universes u v
@@ -22,14 +24,9 @@ class nonempty_fin_lin_ord (α : Type*) extends fintype α, linear_order α :=
 attribute [instance] nonempty_fin_lin_ord.nonempty
 
 @[priority 100]
-instance nonempty_fin_lin_ord.order_bot (α : Type*) [nonempty_fin_lin_ord α] : order_bot α :=
-{ bot := finset.min' finset.univ ⟨classical.arbitrary α, by simp⟩,
-  bot_le := λ a, finset.min'_le _ a (by simp) }
-
-@[priority 100]
-instance nonempty_fin_lin_ord.order_top (α : Type*) [nonempty_fin_lin_ord α] : order_top α :=
-{ top := finset.max' finset.univ ⟨classical.arbitrary α, by simp⟩,
-  le_top := λ a, finset.le_max' _ a (by simp) }
+instance nonempty_fin_lin_ord.to_bounded_order (α : Type*) [nonempty_fin_lin_ord α] :
+  bounded_order α :=
+fintype.to_bounded_order α
 
 instance punit.nonempty_fin_lin_ord : nonempty_fin_lin_ord punit :=
 { .. punit.linear_ordered_cancel_add_comm_monoid,
@@ -45,6 +42,9 @@ instance ulift.nonempty_fin_lin_ord (α : Type u) [nonempty_fin_lin_ord α] :
   .. linear_order.lift equiv.ulift (equiv.injective _),
   .. ulift.fintype _ }
 
+instance (α : Type*) [nonempty_fin_lin_ord α] : nonempty_fin_lin_ord (order_dual α) :=
+{ ..order_dual.fintype α }
+
 /-- The category of nonempty finite linear orders. -/
 def NonemptyFinLinOrd := bundled nonempty_fin_lin_ord
 
@@ -56,11 +56,39 @@ attribute [derive [large_category, concrete_category]] NonemptyFinLinOrd
 
 instance : has_coe_to_sort NonemptyFinLinOrd Type* := bundled.has_coe_to_sort
 
-/-- Construct a bundled NonemptyFinLinOrd from the underlying type and typeclass. -/
+/-- Construct a bundled `NonemptyFinLinOrd` from the underlying type and typeclass. -/
 def of (α : Type*) [nonempty_fin_lin_ord α] : NonemptyFinLinOrd := bundled.of α
 
 instance : inhabited NonemptyFinLinOrd := ⟨of punit⟩
 
 instance (α : NonemptyFinLinOrd) : nonempty_fin_lin_ord α := α.str
 
+instance has_forget_to_LinearOrder : has_forget₂ NonemptyFinLinOrd LinearOrder :=
+bundled_hom.forget₂ _ _
+
+/-- `order_dual` as a functor. -/
+@[simps] def to_dual : NonemptyFinLinOrd ⥤ NonemptyFinLinOrd :=
+{ obj := λ X, of (order_dual X), map := λ X Y, order_hom.dual }
+
+/-- Constructs an equivalence between nonempty finite linear orders from an order isomorphism
+between them. -/
+@[simps] def iso_of_order_iso {α β : NonemptyFinLinOrd.{u}} (e : α ≃o β) : α ≅ β :=
+{ hom := e,
+  inv := e.symm,
+  hom_inv_id' := by { ext, exact e.symm_apply_apply x },
+  inv_hom_id' := by { ext, exact e.apply_symm_apply x } }
+
+/-- The equivalence between `FinPartialOrder` and itself induced by `order_dual` both ways. -/
+def dual_equiv : NonemptyFinLinOrd ≌ NonemptyFinLinOrd :=
+equivalence.mk to_dual to_dual
+  (nat_iso.of_components (λ X, iso_of_order_iso $ order_iso.dual_dual X) $ λ X Y f, rfl)
+  (nat_iso.of_components (λ X, iso_of_order_iso $ order_iso.dual_dual X) $ λ X Y f, rfl)
+
+@[simp] lemma dual_equiv_functor : dual_equiv.functor = to_dual := rfl
+@[simp] lemma dual_equiv_inverse : dual_equiv.inverse = to_dual := rfl
+
 end NonemptyFinLinOrd
+
+lemma NonemptyFinLinOrd_dual_equiv_comp_forget_to_LinearOrder :
+  NonemptyFinLinOrd.dual_equiv.functor ⋙ forget₂ NonemptyFinLinOrd LinearOrder
+  = forget₂ NonemptyFinLinOrd LinearOrder ⋙ LinearOrder.dual_equiv.functor := rfl

--- a/src/order/category/NonemptyFinLinOrd.lean
+++ b/src/order/category/NonemptyFinLinOrd.lean
@@ -79,13 +79,10 @@ between them. -/
 { obj := λ X, of (order_dual X), map := λ X Y, order_hom.dual }
 
 /-- The equivalence between `FinPartialOrder` and itself induced by `order_dual` both ways. -/
-def dual_equiv : NonemptyFinLinOrd ≌ NonemptyFinLinOrd :=
+@[simps functor inverse] def dual_equiv : NonemptyFinLinOrd ≌ NonemptyFinLinOrd :=
 equivalence.mk to_dual to_dual
   (nat_iso.of_components (λ X, iso.mk $ order_iso.dual_dual X) $ λ X Y f, rfl)
   (nat_iso.of_components (λ X, iso.mk $ order_iso.dual_dual X) $ λ X Y f, rfl)
-
-@[simp] lemma dual_equiv_functor : dual_equiv.functor = to_dual := rfl
-@[simp] lemma dual_equiv_inverse : dual_equiv.inverse = to_dual := rfl
 
 end NonemptyFinLinOrd
 

--- a/src/order/category/NonemptyFinLinOrd.lean
+++ b/src/order/category/NonemptyFinLinOrd.lean
@@ -68,7 +68,7 @@ bundled_hom.forget₂ _ _
 
 /-- Constructs an equivalence between nonempty finite linear orders from an order isomorphism
 between them. -/
-@[simps] def iso_of_order_iso {α β : NonemptyFinLinOrd.{u}} (e : α ≃o β) : α ≅ β :=
+@[simps] def iso.mk {α β : NonemptyFinLinOrd.{u}} (e : α ≃o β) : α ≅ β :=
 { hom := e,
   inv := e.symm,
   hom_inv_id' := by { ext, exact e.symm_apply_apply x },
@@ -81,8 +81,8 @@ between them. -/
 /-- The equivalence between `FinPartialOrder` and itself induced by `order_dual` both ways. -/
 def dual_equiv : NonemptyFinLinOrd ≌ NonemptyFinLinOrd :=
 equivalence.mk to_dual to_dual
-  (nat_iso.of_components (λ X, iso_of_order_iso $ order_iso.dual_dual X) $ λ X Y f, rfl)
-  (nat_iso.of_components (λ X, iso_of_order_iso $ order_iso.dual_dual X) $ λ X Y f, rfl)
+  (nat_iso.of_components (λ X, iso.mk $ order_iso.dual_dual X) $ λ X Y f, rfl)
+  (nat_iso.of_components (λ X, iso.mk $ order_iso.dual_dual X) $ λ X Y f, rfl)
 
 @[simp] lemma dual_equiv_functor : dual_equiv.functor = to_dual := rfl
 @[simp] lemma dual_equiv_inverse : dual_equiv.inverse = to_dual := rfl

--- a/src/order/category/PartialOrder.lean
+++ b/src/order/category/PartialOrder.lean
@@ -6,9 +6,15 @@ Authors: Johan Commelin
 
 import order.category.Preorder
 
-/-! # Category of partially ordered types -/
+/-!
+# Category of partial orders
+
+This defines `PartialOrder`, the category of partial orders with monotone maps.
+-/
 
 open category_theory
+
+universe u
 
 /-- The category of partially ordered types. -/
 def PartialOrder := bundled partial_order
@@ -28,4 +34,30 @@ instance : inhabited PartialOrder := ⟨of punit⟩
 
 instance (α : PartialOrder) : partial_order α := α.str
 
+instance has_forget_to_Preorder : has_forget₂ PartialOrder Preorder := bundled_hom.forget₂ _ _
+
+/-- `order_dual` as a functor. -/
+@[simps] def to_dual : PartialOrder ⥤ PartialOrder :=
+{ obj := λ X, of (order_dual X), map := λ X Y, order_hom.dual }
+
+/-- Constructs an equivalence between partial orders from an order isomorphism between them. -/
+@[simps] def iso_of_order_iso {α β : PartialOrder.{u}} (e : α ≃o β) : α ≅ β :=
+{ hom := e,
+  inv := e.symm,
+  hom_inv_id' := by { ext, exact e.symm_apply_apply x },
+  inv_hom_id' := by { ext, exact e.apply_symm_apply x } }
+
+/-- The equivalence between `PartialOrder` and itself induced by `order_dual` both ways. -/
+def dual_equiv : PartialOrder ≌ PartialOrder :=
+equivalence.mk to_dual to_dual
+  (nat_iso.of_components (λ X, iso_of_order_iso $ order_iso.dual_dual X) $ λ X Y f, rfl)
+  (nat_iso.of_components (λ X, iso_of_order_iso $ order_iso.dual_dual X) $ λ X Y f, rfl)
+
+@[simp] lemma dual_equiv_functor : dual_equiv.functor = to_dual := rfl
+@[simp] lemma dual_equiv_inverse : dual_equiv.inverse = to_dual := rfl
+
 end PartialOrder
+
+lemma PartialOrder_dual_equiv_comp_forget_to_Preorder :
+  PartialOrder.dual_equiv.functor ⋙ forget₂ PartialOrder Preorder
+  = forget₂ PartialOrder Preorder ⋙ Preorder.dual_equiv.functor := rfl

--- a/src/order/category/PartialOrder.lean
+++ b/src/order/category/PartialOrder.lean
@@ -37,7 +37,7 @@ instance (α : PartialOrder) : partial_order α := α.str
 instance has_forget_to_Preorder : has_forget₂ PartialOrder Preorder := bundled_hom.forget₂ _ _
 
 /-- Constructs an equivalence between partial orders from an order isomorphism between them. -/
-@[simps] def iso_of_order_iso {α β : PartialOrder.{u}} (e : α ≃o β) : α ≅ β :=
+@[simps] def iso.mk {α β : PartialOrder.{u}} (e : α ≃o β) : α ≅ β :=
 { hom := e,
   inv := e.symm,
   hom_inv_id' := by { ext, exact e.symm_apply_apply x },
@@ -50,8 +50,8 @@ instance has_forget_to_Preorder : has_forget₂ PartialOrder Preorder := bundled
 /-- The equivalence between `PartialOrder` and itself induced by `order_dual` both ways. -/
 def dual_equiv : PartialOrder ≌ PartialOrder :=
 equivalence.mk to_dual to_dual
-  (nat_iso.of_components (λ X, iso_of_order_iso $ order_iso.dual_dual X) $ λ X Y f, rfl)
-  (nat_iso.of_components (λ X, iso_of_order_iso $ order_iso.dual_dual X) $ λ X Y f, rfl)
+  (nat_iso.of_components (λ X, iso.mk $ order_iso.dual_dual X) $ λ X Y f, rfl)
+  (nat_iso.of_components (λ X, iso.mk $ order_iso.dual_dual X) $ λ X Y f, rfl)
 
 @[simp] lemma dual_equiv_functor : dual_equiv.functor = to_dual := rfl
 @[simp] lemma dual_equiv_inverse : dual_equiv.inverse = to_dual := rfl

--- a/src/order/category/PartialOrder.lean
+++ b/src/order/category/PartialOrder.lean
@@ -48,13 +48,10 @@ instance has_forget_to_Preorder : has_forget₂ PartialOrder Preorder := bundled
 { obj := λ X, of (order_dual X), map := λ X Y, order_hom.dual }
 
 /-- The equivalence between `PartialOrder` and itself induced by `order_dual` both ways. -/
-def dual_equiv : PartialOrder ≌ PartialOrder :=
+@[simps functor inverse] def dual_equiv : PartialOrder ≌ PartialOrder :=
 equivalence.mk to_dual to_dual
   (nat_iso.of_components (λ X, iso.mk $ order_iso.dual_dual X) $ λ X Y f, rfl)
   (nat_iso.of_components (λ X, iso.mk $ order_iso.dual_dual X) $ λ X Y f, rfl)
-
-@[simp] lemma dual_equiv_functor : dual_equiv.functor = to_dual := rfl
-@[simp] lemma dual_equiv_inverse : dual_equiv.inverse = to_dual := rfl
 
 end PartialOrder
 

--- a/src/order/category/PartialOrder.lean
+++ b/src/order/category/PartialOrder.lean
@@ -36,16 +36,16 @@ instance (α : PartialOrder) : partial_order α := α.str
 
 instance has_forget_to_Preorder : has_forget₂ PartialOrder Preorder := bundled_hom.forget₂ _ _
 
-/-- `order_dual` as a functor. -/
-@[simps] def to_dual : PartialOrder ⥤ PartialOrder :=
-{ obj := λ X, of (order_dual X), map := λ X Y, order_hom.dual }
-
 /-- Constructs an equivalence between partial orders from an order isomorphism between them. -/
 @[simps] def iso_of_order_iso {α β : PartialOrder.{u}} (e : α ≃o β) : α ≅ β :=
 { hom := e,
   inv := e.symm,
   hom_inv_id' := by { ext, exact e.symm_apply_apply x },
   inv_hom_id' := by { ext, exact e.apply_symm_apply x } }
+
+/-- `order_dual` as a functor. -/
+@[simps] def to_dual : PartialOrder ⥤ PartialOrder :=
+{ obj := λ X, of (order_dual X), map := λ X Y, order_hom.dual }
 
 /-- The equivalence between `PartialOrder` and itself induced by `order_dual` both ways. -/
 def dual_equiv : PartialOrder ≌ PartialOrder :=

--- a/src/order/category/Preorder.lean
+++ b/src/order/category/Preorder.lean
@@ -7,7 +7,13 @@ import category_theory.concrete_category.bundled_hom
 import algebra.punit_instances
 import order.hom.basic
 
-/-! # Category of preorders -/
+/-!
+# Category of preorders
+
+This defines `Preorder`, the category of preorders with monotone maps.
+-/
+
+universe u
 
 open category_theory
 
@@ -32,5 +38,25 @@ def of (α : Type*) [preorder α] : Preorder := bundled.of α
 instance : inhabited Preorder := ⟨of punit⟩
 
 instance (α : Preorder) : preorder α := α.str
+
+/-- `order_dual` as a functor. -/
+@[simps] def to_dual : Preorder ⥤ Preorder :=
+{ obj := λ X, of (order_dual X), map := λ X Y, order_hom.dual }
+
+/-- Constructs an equivalence between preorders from an order isomorphism between them. -/
+@[simps] def iso_of_order_iso {α β : Preorder.{u}} (e : α ≃o β) : α ≅ β :=
+{ hom := e,
+  inv := e.symm,
+  hom_inv_id' := by { ext, exact e.symm_apply_apply x },
+  inv_hom_id' := by { ext, exact e.apply_symm_apply x } }
+
+/-- The equivalence between `Preorder` and itself induced by `order_dual` both ways. -/
+def dual_equiv : Preorder ≌ Preorder :=
+equivalence.mk to_dual to_dual
+  (nat_iso.of_components (λ X, iso_of_order_iso $ order_iso.dual_dual X) $ λ X Y f, rfl)
+  (nat_iso.of_components (λ X, iso_of_order_iso $ order_iso.dual_dual X) $ λ X Y f, rfl)
+
+@[simp] lemma dual_equiv_functor : dual_equiv.functor = to_dual := rfl
+@[simp] lemma dual_equiv_inverse : dual_equiv.inverse = to_dual := rfl
 
 end Preorder

--- a/src/order/category/Preorder.lean
+++ b/src/order/category/Preorder.lean
@@ -40,7 +40,7 @@ instance : inhabited Preorder := ⟨of punit⟩
 instance (α : Preorder) : preorder α := α.str
 
 /-- Constructs an equivalence between preorders from an order isomorphism between them. -/
-@[simps] def iso_of_order_iso {α β : Preorder.{u}} (e : α ≃o β) : α ≅ β :=
+@[simps] def iso.mk {α β : Preorder.{u}} (e : α ≃o β) : α ≅ β :=
 { hom := e,
   inv := e.symm,
   hom_inv_id' := by { ext, exact e.symm_apply_apply x },
@@ -53,8 +53,8 @@ instance (α : Preorder) : preorder α := α.str
 /-- The equivalence between `Preorder` and itself induced by `order_dual` both ways. -/
 def dual_equiv : Preorder ≌ Preorder :=
 equivalence.mk to_dual to_dual
-  (nat_iso.of_components (λ X, iso_of_order_iso $ order_iso.dual_dual X) $ λ X Y f, rfl)
-  (nat_iso.of_components (λ X, iso_of_order_iso $ order_iso.dual_dual X) $ λ X Y f, rfl)
+  (nat_iso.of_components (λ X, iso.mk $ order_iso.dual_dual X) $ λ X Y f, rfl)
+  (nat_iso.of_components (λ X, iso.mk $ order_iso.dual_dual X) $ λ X Y f, rfl)
 
 @[simp] lemma dual_equiv_functor : dual_equiv.functor = to_dual := rfl
 @[simp] lemma dual_equiv_inverse : dual_equiv.inverse = to_dual := rfl

--- a/src/order/category/Preorder.lean
+++ b/src/order/category/Preorder.lean
@@ -39,16 +39,16 @@ instance : inhabited Preorder := ⟨of punit⟩
 
 instance (α : Preorder) : preorder α := α.str
 
-/-- `order_dual` as a functor. -/
-@[simps] def to_dual : Preorder ⥤ Preorder :=
-{ obj := λ X, of (order_dual X), map := λ X Y, order_hom.dual }
-
 /-- Constructs an equivalence between preorders from an order isomorphism between them. -/
 @[simps] def iso_of_order_iso {α β : Preorder.{u}} (e : α ≃o β) : α ≅ β :=
 { hom := e,
   inv := e.symm,
   hom_inv_id' := by { ext, exact e.symm_apply_apply x },
   inv_hom_id' := by { ext, exact e.apply_symm_apply x } }
+
+/-- `order_dual` as a functor. -/
+@[simps] def to_dual : Preorder ⥤ Preorder :=
+{ obj := λ X, of (order_dual X), map := λ X Y, order_hom.dual }
 
 /-- The equivalence between `Preorder` and itself induced by `order_dual` both ways. -/
 def dual_equiv : Preorder ≌ Preorder :=

--- a/src/order/category/Preorder.lean
+++ b/src/order/category/Preorder.lean
@@ -51,12 +51,9 @@ instance (α : Preorder) : preorder α := α.str
 { obj := λ X, of (order_dual X), map := λ X Y, order_hom.dual }
 
 /-- The equivalence between `Preorder` and itself induced by `order_dual` both ways. -/
-def dual_equiv : Preorder ≌ Preorder :=
+@[simps functor inverse] def dual_equiv : Preorder ≌ Preorder :=
 equivalence.mk to_dual to_dual
   (nat_iso.of_components (λ X, iso.mk $ order_iso.dual_dual X) $ λ X Y f, rfl)
   (nat_iso.of_components (λ X, iso.mk $ order_iso.dual_dual X) $ λ X Y f, rfl)
-
-@[simp] lemma dual_equiv_functor : dual_equiv.functor = to_dual := rfl
-@[simp] lemma dual_equiv_inverse : dual_equiv.inverse = to_dual := rfl
 
 end Preorder

--- a/src/order/hom/basic.lean
+++ b/src/order/hom/basic.lean
@@ -67,6 +67,8 @@ We also define two functions to convert other bundled maps to `α →o β`:
 monotone map, bundled morphism
 -/
 
+open order_dual
+
 /-- Bundled monotone (aka, increasing) function -/
 structure order_hom (α β : Type*) [preorder α] [preorder β] :=
 (to_fun   : α → β)
@@ -495,6 +497,21 @@ lemma trans_apply (e : α ≃o β) (e' : β ≃o γ) (x : α) : e.trans e' x = e
 @[simp] lemma refl_trans (e : α ≃o β) : (refl α).trans e = e := by { ext x, refl }
 
 @[simp] lemma trans_refl (e : α ≃o β) : e.trans (refl β) = e := by { ext x, refl }
+
+variables (α)
+
+/-- The order isomorphism between a type and its double dual. -/
+def dual_dual : α ≃o order_dual (order_dual α) := refl α
+
+@[simp] lemma coe_dual_dual : ⇑(dual_dual α) = to_dual ∘ to_dual := rfl
+@[simp] lemma coe_dual_dual_symm : ⇑(dual_dual α).symm = of_dual ∘ of_dual := rfl
+
+variables {α}
+
+@[simp] lemma dual_dual_apply (a : α) : dual_dual α a = to_dual (to_dual a) := rfl
+
+@[simp] lemma dual_dual_symm_apply (a : order_dual (order_dual α)) :
+  (dual_dual α).symm a = of_dual (of_dual a) := rfl
 
 end has_le
 


### PR DESCRIPTION
For `whatever` a category of orders, define
* `whatever.iso.mk`: Turns an order isomorphism into an equivalence of objects inside `whatever`
* `whatever.to_dual`: `order_dual` as a functor from `whatever` to itself
* `whatever.dual_equiv`: The equivalence of categories between `whatever` and itself induced by `order_dual` both ways
* `order_iso.dual_dual`: The order isomorphism between `α` and `order_dual (order_dual α)`

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
