### PR TITLE
[Merged by Bors] - chore(*): register global fact instances

### DIFF
--- a/src/algebra/char_p/two.lean
+++ b/src/algebra/char_p/two.lean
@@ -16,8 +16,6 @@ elsewhere, with a shorter name for ease of discovery, and no need for a `[fact (
 
 variables {R ι : Type*}
 
-local attribute [instance] nat.fact_prime_two
-
 namespace char_two
 
 section semiring

--- a/src/analysis/fourier.lean
+++ b/src/analysis/fourier.lean
@@ -55,8 +55,6 @@ noncomputable theory
 open_locale ennreal complex_conjugate classical
 open topological_space continuous_map measure_theory measure_theory.measure algebra submodule set
 
-local attribute [instance] fact_one_le_two_ennreal
-
 /-! ### Choice of measure on the circle -/
 
 section haar_circle

--- a/src/analysis/inner_product_space/l2_space.lean
+++ b/src/analysis/inner_product_space/l2_space.lean
@@ -74,8 +74,6 @@ Hilbert space, Hilbert sum, l2, Hilbert basis, unitary equivalence, isometric is
 open is_R_or_C submodule filter
 open_locale big_operators nnreal ennreal classical complex_conjugate
 
-local attribute [instance] fact_one_le_two_ennreal
-
 noncomputable theory
 
 variables {ι : Type*}

--- a/src/analysis/inner_product_space/pi_L2.lean
+++ b/src/analysis/inner_product_space/pi_L2.lean
@@ -34,10 +34,6 @@ This is recorded in this file as an inner product space instance on `pi_Lp 2`.
 open real set filter is_R_or_C
 open_locale big_operators uniformity topological_space nnreal ennreal complex_conjugate direct_sum
 
-local attribute [instance] fact_one_le_two_real
-
-local attribute [instance] fact_one_le_two_real
-
 noncomputable theory
 
 variables {ι : Type*}

--- a/src/analysis/inner_product_space/spectrum.lean
+++ b/src/analysis/inner_product_space/spectrum.lean
@@ -48,8 +48,6 @@ variables {E : Type*} [inner_product_space 𝕜 E]
 
 local notation `⟪`x`, `y`⟫` := @inner 𝕜 E _ x y
 
-local attribute [instance] fact_one_le_two_real
-
 open_locale big_operators complex_conjugate
 open module.End
 

--- a/src/analysis/normed_space/pi_Lp.lean
+++ b/src/analysis/normed_space/pi_Lp.lean
@@ -71,8 +71,8 @@ def pi_Lp {ι : Type*} (p : ℝ) (α : ι → Type*) : Type* := Π (i : ι), α 
 instance {ι : Type*} (p : ℝ) (α : ι → Type*) [∀ i, inhabited (α i)] : inhabited (pi_Lp p α) :=
 ⟨λ i, default⟩
 
-lemma fact_one_le_one_real : fact ((1:ℝ) ≤ 1) := ⟨rfl.le⟩
-lemma fact_one_le_two_real : fact ((1:ℝ) ≤ 2) := ⟨one_le_two⟩
+instance fact_one_le_one_real : fact ((1:ℝ) ≤ 1) := ⟨rfl.le⟩
+instance fact_one_le_two_real : fact ((1:ℝ) ≤ 2) := ⟨one_le_two⟩
 
 namespace pi_Lp
 

--- a/src/data/nat/prime.lean
+++ b/src/data/nat/prime.lean
@@ -1090,11 +1090,9 @@ namespace nat
 
 theorem prime_three : prime 3 := by norm_num
 
-/-- See note [fact non-instances].-/
-lemma fact_prime_two : fact (prime 2) := ⟨prime_two⟩
+instance fact_prime_two : fact (prime 2) := ⟨prime_two⟩
 
-/-- See note [fact non-instances].-/
-lemma fact_prime_three : fact (prime 3) := ⟨prime_three⟩
+instance fact_prime_three : fact (prime 3) := ⟨prime_three⟩
 
 end nat
 

--- a/src/data/real/ennreal.lean
+++ b/src/data/real/ennreal.lean
@@ -228,18 +228,15 @@ coe_one ▸ coe_two ▸ by exact_mod_cast (@one_lt_two ℕ _ _)
 lemma two_ne_zero : (2:ℝ≥0∞) ≠ 0 := (ne_of_lt zero_lt_two).symm
 lemma two_ne_top : (2:ℝ≥0∞) ≠ ∞ := coe_two ▸ coe_ne_top
 
-/-- `(1 : ℝ≥0∞) ≤ 1`, recorded as a `fact` for use with `Lp` spaces, see note [fact non-instances].
--/
-lemma _root_.fact_one_le_one_ennreal : fact ((1 : ℝ≥0∞) ≤ 1) := ⟨le_refl _⟩
+/-- `(1 : ℝ≥0∞) ≤ 1`, recorded as a `fact` for use with `Lp` spaces. -/
+instance _root_.fact_one_le_one_ennreal : fact ((1 : ℝ≥0∞) ≤ 1) := ⟨le_refl _⟩
 
-/-- `(1 : ℝ≥0∞) ≤ 2`, recorded as a `fact` for use with `Lp` spaces, see note [fact non-instances].
--/
-lemma _root_.fact_one_le_two_ennreal : fact ((1 : ℝ≥0∞) ≤ 2) :=
+/-- `(1 : ℝ≥0∞) ≤ 2`, recorded as a `fact` for use with `Lp` spaces. -/
+instance _root_.fact_one_le_two_ennreal : fact ((1 : ℝ≥0∞) ≤ 2) :=
 ⟨ennreal.coe_le_coe.2 (show (1 : ℝ≥0) ≤ 2, by norm_num)⟩
 
-/-- `(1 : ℝ≥0∞) ≤ ∞`, recorded as a `fact` for use with `Lp` spaces, see note [fact non-instances].
--/
-lemma _root_.fact_one_le_top_ennreal : fact ((1 : ℝ≥0∞) ≤ ∞) := ⟨le_top⟩
+/-- `(1 : ℝ≥0∞) ≤ ∞`, recorded as a `fact` for use with `Lp` spaces. -/
+instance _root_.fact_one_le_top_ennreal : fact ((1 : ℝ≥0∞) ≤ ∞) := ⟨le_top⟩
 
 /-- The set of numbers in `ℝ≥0∞` that are not equal to `∞` is equivalent to `ℝ≥0`. -/
 def ne_top_equiv_nnreal : {a | a ≠ ∞} ≃ ℝ≥0 :=

--- a/src/geometry/manifold/instances/real.lean
+++ b/src/geometry/manifold/instances/real.lean
@@ -40,7 +40,6 @@ typeclass. We provide it as `[fact (x < y)]`.
 noncomputable theory
 open set function
 open_locale manifold
-local attribute [instance] fact_one_le_two_real
 
 /--
 The half-space in `ℝ^n`, used to model manifolds with boundary. We only define it when

--- a/src/group_theory/order_of_element.lean
+++ b/src/group_theory/order_of_element.lean
@@ -258,10 +258,7 @@ end
 omit hp
 -- An example on how to determine the order of an element of a finite group.
 example : order_of (-1 : ℤˣ) = 2 :=
-begin
-  haveI := fact_prime_two,
-  exact order_of_eq_prime (int.units_sq _) dec_trivial,
-end
+order_of_eq_prime (int.units_sq _) dec_trivial
 
 end p_prime
 

--- a/src/measure_theory/function/conditional_expectation.lean
+++ b/src/measure_theory/function/conditional_expectation.lean
@@ -688,8 +688,6 @@ We define a conditional expectation in `L2`: it is the orthogonal projection on 
 
 section condexp_L2
 
-local attribute [instance] fact_one_le_two_ennreal
-
 variables [complete_space E] {m m0 : measurable_space α} {μ : measure α}
   {s t : set α}
 
@@ -1125,8 +1123,6 @@ takes `x : G` to the conditional expectation of the indicator of the set `s` wit
 seen as an element of `α →₁[μ] G`.
 -/
 
-local attribute [instance] fact_one_le_two_ennreal
-
 variables {m m0 : measurable_space α} {μ : measure α} {s t : set α} [normed_space ℝ G]
 
 section condexp_ind_L1_fin
@@ -1409,8 +1405,6 @@ end condexp_ind
 
 section condexp_L1
 
-local attribute [instance] fact_one_le_one_ennreal
-
 variables {m m0 : measurable_space α} {μ : measure α}
   {hm : m ≤ m0} [sigma_finite (μ.trim hm)] {f g : α → F'} {s : set α}
 
@@ -1628,8 +1622,6 @@ section condexp
 /-! ### Conditional expectation of a function -/
 
 open_locale classical
-
-local attribute [instance] fact_one_le_one_ennreal
 
 variables {𝕜} {m m0 : measurable_space α} {μ : measure α}
   {hm : m ≤ m0} [sigma_finite (μ.trim hm)] {f g : α → F'} {s : set α}

--- a/src/measure_theory/function/l2_space.lean
+++ b/src/measure_theory/function/l2_space.lean
@@ -196,8 +196,6 @@ variables (μ : measure α) [is_finite_measure μ]
 
 open_locale bounded_continuous_function complex_conjugate
 
-local attribute [instance] fact_one_le_two_ennreal
-
 local notation `⟪`x`, `y`⟫` := @inner 𝕜 (α →₂[μ] 𝕜) _ x y
 
 /-- For bounded continuous functions `f`, `g` on a finite-measure topological space `α`, the L^2

--- a/src/measure_theory/function/lp_space.lean
+++ b/src/measure_theory/function/lp_space.lean
@@ -77,8 +77,6 @@ noncomputable theory
 open topological_space measure_theory filter
 open_locale nnreal ennreal big_operators topological_space measure_theory
 
-local attribute [instance] fact_one_le_one_ennreal fact_one_le_two_ennreal fact_one_le_top_ennreal
-
 variables {α E F G : Type*} {m m0 : measurable_space α} {p : ℝ≥0∞} {q : ℝ} {μ ν : measure α}
   [measurable_space E] [normed_group E]
   [normed_group F] [normed_group G]

--- a/src/measure_theory/function/simple_func_dense.lean
+++ b/src/measure_theory/function/simple_func_dense.lean
@@ -985,8 +985,6 @@ end
 
 section integrable
 
-local attribute [instance] fact_one_le_one_ennreal
-
 notation α ` →₁ₛ[`:25 μ `] ` E := @measure_theory.Lp.simple_func α E _ _ _ _ _ 1 μ
 
 lemma L1.simple_func.to_Lp_one_eq_to_L1 (f : α →ₛ E) (hf : integrable f μ) :

--- a/src/measure_theory/integral/bochner.lean
+++ b/src/measure_theory/integral/bochner.lean
@@ -146,8 +146,6 @@ noncomputable theory
 open_locale classical topological_space big_operators nnreal ennreal measure_theory
 open set filter topological_space ennreal emetric
 
-local attribute [instance] fact_one_le_one_ennreal
-
 namespace measure_theory
 
 variables {α E F 𝕜 : Type*}
@@ -659,8 +657,6 @@ lemma continuous_integral : continuous (λ (f : α →₁[μ] E), integral f) :=
 L1.integral_clm.continuous
 
 section pos_part
-
-local attribute [instance] fact_one_le_one_ennreal
 
 lemma integral_eq_norm_pos_part_sub (f : α →₁[μ] ℝ) :
   integral f = ∥Lp.pos_part f∥ - ∥Lp.neg_part f∥ :=

--- a/src/measure_theory/integral/set_integral.lean
+++ b/src/measure_theory/integral/set_integral.lean
@@ -740,8 +740,6 @@ variables {μ : measure α} {𝕜 : Type*} [is_R_or_C 𝕜] [normed_space 𝕜 E
   [normed_group F] [normed_space 𝕜 F]
   {p : ennreal}
 
-local attribute [instance] fact_one_le_one_ennreal
-
 namespace continuous_linear_map
 
 variables [measurable_space F] [borel_space F]

--- a/src/measure_theory/integral/set_to_l1.lean
+++ b/src/measure_theory/integral/set_to_l1.lean
@@ -76,8 +76,6 @@ noncomputable theory
 open_locale classical topological_space big_operators nnreal ennreal measure_theory pointwise
 open set filter topological_space ennreal emetric
 
-local attribute [instance] fact_one_le_one_ennreal
-
 namespace measure_theory
 
 variables {α E F F' G 𝕜 : Type*} {p : ℝ≥0∞}

--- a/src/number_theory/quadratic_reciprocity.lean
+++ b/src/number_theory/quadratic_reciprocity.lean
@@ -434,8 +434,6 @@ have hqp0 : (q : zmod p) ≠ 0, from prime_ne_zero p q hpq,
 by rw [eisenstein_lemma q hp1.1 hpq0, eisenstein_lemma p hq1.1 hqp0,
   ← pow_add, sum_mul_div_add_sum_mul_div_eq_mul q p hpq0, mul_comm]
 
-local attribute [instance] nat.fact_prime_two
-
 lemma legendre_sym_two [hp1 : fact (p % 2 = 1)] : legendre_sym 2 p = (-1) ^ (p / 4 + p / 2) :=
 have hp2 : p ≠ 2, from mt (congr_arg (% 2)) (by simpa using hp1.1),
 have hp22 : p / 2 / 2 = _ := div_eq_filter_card (show 0 < 2, from dec_trivial)

--- a/src/topology/metric_space/gromov_hausdorff.lean
+++ b/src/topology/metric_space/gromov_hausdorff.lean
@@ -43,7 +43,6 @@ noncomputable theory
 open_locale classical topological_space ennreal
 
 local notation `ℓ_infty_ℝ`:= lp (λ n : ℕ, ℝ) ∞
-local attribute [instance] fact_one_le_top_ennreal
 
 universes u v w
 

--- a/src/topology/metric_space/kuratowski.lean
+++ b/src/topology/metric_space/kuratowski.lean
@@ -18,8 +18,6 @@ open set metric topological_space
 open_locale ennreal
 local notation `ℓ_infty_ℝ`:= lp (λ n : ℕ, ℝ) ∞
 
-local attribute [instance] fact_one_le_top_ennreal
-
 universes u v w
 variables {α : Type u} {β : Type v} {γ : Type w}
 


### PR DESCRIPTION
We register globally some fact instances which are necessary for integration or euclidean spaces. And also the fact that 2 and 3 are prime. See https://leanprover.zulipchat.com/#narrow/stream/113489-new-members/topic/euclidean_space.20error/near/269992165

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
