### PR TITLE
[Merged by Bors] - feat(*): define subobject classes from submonoid up to subfield

### DIFF
--- a/src/algebra/algebra/subalgebra/basic.lean
+++ b/src/algebra/algebra/subalgebra/basic.lean
@@ -37,7 +37,14 @@ variables [semiring A] [algebra R A] [semiring B] [algebra R B] [semiring C] [al
 include R
 
 instance : set_like (subalgebra R A) A :=
-⟨subalgebra.carrier, λ p q h, by cases p; cases q; congr'⟩
+{ coe := subalgebra.carrier,
+  coe_injective' := λ p q h, by cases p; cases q; congr' }
+
+instance : subsemiring_class (subalgebra R A) A :=
+{ add_mem := add_mem',
+  mul_mem := mul_mem',
+  one_mem := one_mem',
+  zero_mem := zero_mem' }
 
 @[simp]
 lemma mem_carrier {s : subalgebra R A} {x : A} : x ∈ s.carrier ↔ x ∈ s := iff.rfl
@@ -100,6 +107,10 @@ S.to_subsemiring.zero_mem
 
 theorem add_mem {x y : A} (hx : x ∈ S) (hy : y ∈ S) : x + y ∈ S :=
 S.to_subsemiring.add_mem hx hy
+
+instance {R A : Type*} [comm_ring R] [ring A] [algebra R A] : subring_class (subalgebra R A) A :=
+{ neg_mem := λ S x hx, neg_one_smul R x ▸ S.smul_mem hx _,
+  .. subalgebra.subsemiring_class }
 
 theorem neg_mem {R : Type u} {A : Type v} [comm_ring R] [ring A]
   [algebra R A] (S : subalgebra R A) {x : A} (hx : x ∈ S) : -x ∈ S :=

--- a/src/algebra/lie/subalgebra.lean
+++ b/src/algebra/lie/subalgebra.lean
@@ -49,9 +49,19 @@ instance : has_zero (lie_subalgebra R L) :=
 
 instance : inhabited (lie_subalgebra R L) := ⟨0⟩
 instance : has_coe (lie_subalgebra R L) (submodule R L) := ⟨lie_subalgebra.to_submodule⟩
-instance : has_mem L (lie_subalgebra R L) := ⟨λ x L', x ∈ (L' : set L)⟩
 
 namespace lie_subalgebra
+
+open neg_mem_class
+
+instance : set_like (lie_subalgebra R L) L :=
+{ coe := λ L', L',
+  coe_injective' := λ L' L'' h, by { rcases L' with ⟨⟨⟩⟩, rcases L'' with ⟨⟨⟩⟩, congr' } }
+
+instance : add_subgroup_class (lie_subalgebra R L) L :=
+{ add_mem := λ L', L'.add_mem',
+  zero_mem := λ L', L'.zero_mem',
+  neg_mem := λ L' x hx, show -x ∈ (L' : submodule R L), from neg_mem hx }
 
 /-- A Lie subalgebra forms a new Lie ring. -/
 instance (L' : lie_subalgebra R L) : lie_ring L' :=
@@ -119,10 +129,10 @@ lemma coe_zero_iff_zero (x : L') : (x : L) = 0 ↔ x = 0 := (ext_iff L' x 0).sym
 
 @[ext] lemma ext (L₁' L₂' : lie_subalgebra R L) (h : ∀ x, x ∈ L₁' ↔ x ∈ L₂') :
   L₁' = L₂' :=
-by { cases L₁', cases L₂', simp only [], ext x, exact h x, }
+set_like.ext h
 
 lemma ext_iff' (L₁' L₂' : lie_subalgebra R L) : L₁' = L₂' ↔ ∀ x, x ∈ L₁' ↔ x ∈ L₂' :=
-⟨λ h x, by rw h, ext L₁' L₂'⟩
+set_like.ext_iff
 
 @[simp] lemma mk_coe (S : set L) (h₁ h₂ h₃ h₄) :
   ((⟨⟨S, h₁, h₂, h₃⟩, h₄⟩ : lie_subalgebra R L) : set L) = S := rfl
@@ -132,12 +142,12 @@ lemma ext_iff' (L₁' L₂' : lie_subalgebra R L) : L₁' = L₂' ↔ ∀ x, x �
 by { cases p, refl, }
 
 lemma coe_injective : function.injective (coe : lie_subalgebra R L → set L) :=
-by { rintro ⟨⟨⟩⟩ ⟨⟨⟩⟩ h, congr' }
+set_like.coe_injective
 
 instance : set_like (lie_subalgebra R L) L := ⟨coe, coe_injective⟩
 
 @[norm_cast] theorem coe_set_eq (L₁' L₂' : lie_subalgebra R L) :
-  (L₁' : set L) = L₂' ↔ L₁' = L₂' := coe_injective.eq_iff
+  (L₁' : set L) = L₂' ↔ L₁' = L₂' := set_like.coe_set_eq
 
 lemma to_submodule_injective :
   function.injective (coe : lie_subalgebra R L → submodule R L) :=
@@ -542,8 +552,8 @@ variables [comm_ring R] [lie_ring L₁] [lie_ring L₂] [lie_algebra R L₁] [li
 /-- An injective Lie algebra morphism is an equivalence onto its range. -/
 noncomputable def of_injective (f : L₁ →ₗ⁅R⁆ L₂) (h : function.injective f) :
   L₁ ≃ₗ⁅R⁆ f.range :=
-{ map_lie' := λ x y, by { apply set_coe.ext, simpa, },
-..(linear_equiv.of_injective ↑f $ by rwa [lie_hom.coe_to_linear_map])}
+{ map_lie' := λ x y, by { apply set_coe.ext, simpa },
+  .. linear_equiv.of_injective (f : L₁ →ₗ[R] L₂) $ by rwa [lie_hom.coe_to_linear_map] }
 
 @[simp] lemma of_injective_apply (f : L₁ →ₗ⁅R⁆ L₂) (h : function.injective f) (x : L₁) :
   ↑(of_injective f h x) = f x := rfl

--- a/src/algebra/lie/subalgebra.lean
+++ b/src/algebra/lie/subalgebra.lean
@@ -144,8 +144,6 @@ by { cases p, refl, }
 lemma coe_injective : function.injective (coe : lie_subalgebra R L → set L) :=
 set_like.coe_injective
 
-instance : set_like (lie_subalgebra R L) L := ⟨coe, coe_injective⟩
-
 @[norm_cast] theorem coe_set_eq (L₁' L₂' : lie_subalgebra R L) :
   (L₁' : set L) = L₂' ↔ L₁' = L₂' := set_like.coe_set_eq
 

--- a/src/algebra/lie/submodule.lean
+++ b/src/algebra/lie/submodule.lean
@@ -49,9 +49,16 @@ namespace lie_submodule
 
 variables {R L M} (N N' : lie_submodule R L M)
 
+open neg_mem_class
+
 instance : set_like (lie_submodule R L M) M :=
 { coe := carrier,
   coe_injective' := λ N O h, by cases N; cases O; congr' }
+
+instance : add_subgroup_class (lie_submodule R L M) M :=
+{ add_mem := λ N, N.add_mem',
+  zero_mem := λ N, N.zero_mem',
+  neg_mem := λ N x hx, show -x ∈ N.to_submodule, from neg_mem hx }
 
 /-- The zero module is a Lie submodule of any Lie module. -/
 instance : has_zero (lie_submodule R L M) :=

--- a/src/algebra/module/submodule.lean
+++ b/src/algebra/module/submodule.lean
@@ -47,7 +47,12 @@ namespace submodule
 variables [semiring R] [add_comm_monoid M] [module R M]
 
 instance : set_like (submodule R M) M :=
-⟨submodule.carrier, λ p q h, by cases p; cases q; congr'⟩
+{ coe := submodule.carrier,
+  coe_injective' := λ p q h, by cases p; cases q; congr' }
+
+instance : add_submonoid_class (submodule R M) M :=
+{ zero_mem := zero_mem',
+  add_mem := add_mem' }
 
 @[simp] theorem mem_to_add_submonoid (p : submodule R M) (x : M) : x ∈ p.to_add_submonoid ↔ x ∈ p :=
 iff.rfl
@@ -282,7 +287,11 @@ variables {module_M : module R M}
 variables (p p' : submodule R M)
 variables {r : R} {x y : M}
 
-lemma neg_mem (hx : x ∈ p) : -x ∈ p := p.to_sub_mul_action.neg_mem hx
+instance [module R M] : add_subgroup_class (submodule R M) M :=
+{ neg_mem := λ p x, p.to_sub_mul_action.neg_mem,
+  .. submodule.add_submonoid_class }
+
+lemma neg_mem (hx : x ∈ p) : -x ∈ p := neg_mem_class.neg_mem hx
 
 /-- Reinterpret a submodule as an additive subgroup. -/
 def to_add_subgroup : add_subgroup M :=

--- a/src/analysis/inner_product_space/l2_space.lean
+++ b/src/analysis/inner_product_space/l2_space.lean
@@ -224,7 +224,6 @@ end
 protected lemma range_linear_isometry [Π i, complete_space (G i)] :
   hV.linear_isometry.to_linear_map.range = (⨆ i, (V i).to_linear_map.range).topological_closure :=
 begin
-  classical,
   refine le_antisymm _ _,
   { rintros x ⟨f, rfl⟩,
     refine mem_closure_of_tendsto (hV.has_sum_linear_isometry f) (eventually_of_forall _),
@@ -237,7 +236,7 @@ begin
     { refine supr_le _,
       rintros i x ⟨x, rfl⟩,
       use lp.single 2 i x,
-      convert hV.linear_isometry_apply_single _ },
+      exact hV.linear_isometry_apply_single x },
     exact hV.linear_isometry.isometry.uniform_inducing.is_complete_range.is_closed }
 end
 

--- a/src/field_theory/galois.lean
+++ b/src/field_theory/galois.lean
@@ -150,7 +150,7 @@ lemma alg_equiv.transfer_galois (f : E ≃ₐ[F] E') : is_galois F E ↔ is_galo
 ⟨λ h, by exactI is_galois.of_alg_equiv f, λ h, by exactI is_galois.of_alg_equiv f.symm⟩
 
 lemma is_galois_iff_is_galois_top : is_galois F (⊤ : intermediate_field F E) ↔ is_galois F E :=
-(intermediate_field.top_equiv).transfer_galois
+(intermediate_field.top_equiv : (⊤ : intermediate_field F E) ≃ₐ[F] E).transfer_galois
 
 instance is_galois_bot : is_galois F (⊥ : intermediate_field F E) :=
 (intermediate_field.bot_equiv F E).transfer_galois.mpr (is_galois.self F)
@@ -401,7 +401,8 @@ begin
   simp only [P] at *,
   rw [of_separable_splitting_field_aux hp K (multiset.mem_to_finset.mp hx),
     hK, finrank_mul_finrank],
-  exact (linear_equiv.finrank_eq (intermediate_field.lift2_alg_equiv K⟮x⟯).to_linear_equiv).symm,
+  symmetry,
+  exact linear_equiv.finrank_eq (alg_equiv.to_linear_equiv (intermediate_field.lift2_alg_equiv _))
 end
 
 /--Equivalent characterizations of a Galois extension of finite degree-/

--- a/src/field_theory/intermediate_field.lean
+++ b/src/field_theory/intermediate_field.lean
@@ -61,6 +61,14 @@ def to_subfield : subfield L := { ..S.to_subalgebra, ..S }
 instance : set_like (intermediate_field K L) L :=
 ⟨λ S, S.to_subalgebra.carrier, by { rintros ⟨⟨⟩⟩ ⟨⟨⟩⟩ ⟨h⟩, congr, }⟩
 
+instance : subfield_class (intermediate_field K L) L :=
+{ add_mem := λ s, s.add_mem',
+  zero_mem := λ s, s.zero_mem',
+  neg_mem := neg_mem',
+  mul_mem := λ s, s.mul_mem',
+  one_mem := λ s, s.one_mem',
+  inv_mem := inv_mem' }
+
 @[simp]
 lemma mem_carrier {s : intermediate_field K L} {x : L} : x ∈ s.carrier ↔ x ∈ s := iff.rfl
 

--- a/src/field_theory/subfield.lean
+++ b/src/field_theory/subfield.lean
@@ -72,6 +72,11 @@ namespace subfield_class
 variables (S : Type*) [set_like S K] [h : subfield_class S K]
 include h
 
+/-- A subfield contains `1`, products and inverses.
+
+Be assured that we're not actually proving that subfields are subgroups:
+`subgroup_class` is really an abbreviation of `subgroup_with_or_without_zero_class`.
+ -/
 @[priority 100] -- See note [lower instance priority]
 instance subfield_class.to_subgroup_class : subgroup_class S K := { .. h }
 

--- a/src/field_theory/subfield.lean
+++ b/src/field_theory/subfield.lean
@@ -81,6 +81,7 @@ Be assured that we're not actually proving that subfields are subgroups:
 instance subfield_class.to_subgroup_class : subgroup_class S K := { .. h }
 
 /-- A subfield inherits a field structure -/
+@[priority 75] -- Prefer subclasses of `field` over subclasses of `subfield_class`.
 instance to_field (s : S) : field s :=
 subtype.coe_injective.field (coe : s → K)
   rfl rfl (λ _ _, rfl) (λ _ _, rfl) (λ _, rfl) (λ _ _, rfl) (λ _, rfl) (λ _ _, rfl)
@@ -88,6 +89,7 @@ subtype.coe_injective.field (coe : s → K)
 omit h
 
 /-- A subfield of a `linear_ordered_field` is a `linear_ordered_field`. -/
+@[priority 75] -- Prefer subclasses of `field` over subclasses of `subfield_class`.
 instance to_linear_ordered_field {K} [linear_ordered_field K] [set_like S K]
   [subfield_class S K] (s : S) :
   linear_ordered_field s :=

--- a/src/field_theory/subfield.lean
+++ b/src/field_theory/subfield.lean
@@ -63,6 +63,34 @@ universes u v w
 
 variables {K : Type u} {L : Type v} {M : Type w} [field K] [field L] [field M]
 
+/-- `subfield_class S K` states `S` is a type of subsets `s ⊆ K` closed under field operations. -/
+class subfield_class (S : Type*) (K : out_param $ Type*) [field K] [set_like S K]
+  extends subring_class S K, inv_mem_class S K.
+
+namespace subfield_class
+
+variables (S : Type*) [set_like S K] [h : subfield_class S K]
+include h
+
+@[priority 100] -- See note [lower instance priority]
+instance subfield_class.to_subgroup_class : subgroup_class S K := { .. h }
+
+/-- A subfield inherits a field structure -/
+instance to_field (s : S) : field s :=
+subtype.coe_injective.field (coe : s → K)
+  rfl rfl (λ _ _, rfl) (λ _ _, rfl) (λ _, rfl) (λ _ _, rfl) (λ _, rfl) (λ _ _, rfl)
+
+omit h
+
+/-- A subfield of a `linear_ordered_field` is a `linear_ordered_field`. -/
+instance to_linear_ordered_field {K} [linear_ordered_field K] [set_like S K]
+  [subfield_class S K] (s : S) :
+  linear_ordered_field s :=
+subtype.coe_injective.linear_ordered_field coe
+  rfl rfl (λ _ _, rfl) (λ _ _, rfl) (λ _, rfl) (λ _ _, rfl) (λ _, rfl) (λ _ _, rfl)
+
+end subfield_class
+
 set_option old_structure_cmd true
 
 /-- `subfield R` is the type of subfields of `R`. A subfield of `R` is a subset `s` that is a
@@ -84,9 +112,16 @@ def to_add_subgroup (s : subfield K) : add_subgroup K :=
 def to_submonoid (s : subfield K) : submonoid K :=
 { ..s.to_subring.to_submonoid }
 
-
 instance : set_like (subfield K) K :=
 ⟨subfield.carrier, λ p q h, by cases p; cases q; congr'⟩
+
+instance : subfield_class (subfield K) K :=
+{ add_mem := add_mem',
+  zero_mem := zero_mem',
+  neg_mem := neg_mem',
+  mul_mem := mul_mem',
+  one_mem := one_mem',
+  inv_mem := inv_mem' }
 
 @[simp]
 lemma mem_carrier {s : subfield K} {x : K} : x ∈ s.carrier ↔ x ∈ s := iff.rfl

--- a/src/field_theory/subfield.lean
+++ b/src/field_theory/subfield.lean
@@ -84,7 +84,8 @@ instance subfield_class.to_subgroup_class : subgroup_class S K := { .. h }
 @[priority 75] -- Prefer subclasses of `field` over subclasses of `subfield_class`.
 instance to_field (s : S) : field s :=
 subtype.coe_injective.field (coe : s → K)
-  rfl rfl (λ _ _, rfl) (λ _ _, rfl) (λ _, rfl) (λ _ _, rfl) (λ _, rfl) (λ _ _, rfl)
+  rfl rfl (λ _ _, rfl) (λ _ _, rfl) (λ _, rfl) (λ _ _, rfl) (λ _, rfl) (λ _ _, rfl) (λ _ _, rfl)
+  (λ _ _, rfl) (λ _ _, rfl) (λ _ _, rfl)
 
 omit h
 
@@ -94,7 +95,8 @@ instance to_linear_ordered_field {K} [linear_ordered_field K] [set_like S K]
   [subfield_class S K] (s : S) :
   linear_ordered_field s :=
 subtype.coe_injective.linear_ordered_field coe
-  rfl rfl (λ _ _, rfl) (λ _ _, rfl) (λ _, rfl) (λ _ _, rfl) (λ _, rfl) (λ _ _, rfl)
+  rfl rfl (λ _ _, rfl) (λ _ _, rfl) (λ _, rfl) (λ _ _, rfl) (λ _, rfl) (λ _ _, rfl) (λ _ _, rfl)
+  (λ _ _, rfl) (λ _ _, rfl) (λ _ _, rfl)
 
 end subfield_class
 

--- a/src/group_theory/subgroup/basic.lean
+++ b/src/group_theory/subgroup/basic.lean
@@ -128,7 +128,7 @@ open mul_mem_class inv_mem_class submonoid_class
 /-- A subgroup is closed under division. -/
 @[to_additive "An additive subgroup is closed under subtraction."]
 theorem div_mem {x y : M} (hx : x ∈ H) (hy : y ∈ H) : x / y ∈ H :=
-by simpa only [div_eq_mul_inv] using mul_mem hx (inv_mem hy)
+by rw [div_eq_mul_inv]; exact mul_mem hx (inv_mem hy)
 
 @[to_additive]
 lemma zpow_mem {x : M} (hx : x ∈ K) : ∀ n : ℤ, x ^ n ∈ K

--- a/src/group_theory/subgroup/basic.lean
+++ b/src/group_theory/subgroup/basic.lean
@@ -89,6 +89,158 @@ open_locale big_operators pointwise
 variables {G : Type*} [group G]
 variables {A : Type*} [add_group A]
 
+section subgroup_class
+
+/-- `inv_mem_class S G` states `S` is a type of subsets `s ⊆ G` closed under inverses. -/
+class inv_mem_class (S G : Type*) [has_inv G] [set_like S G] :=
+(inv_mem : ∀ {s : S} {x}, x ∈ s → x⁻¹ ∈ s)
+
+/-- `neg_mem_class S G` states `S` is a type of subsets `s ⊆ G` closed under negation. -/
+class neg_mem_class (S G : Type*) [has_neg G] [set_like S G] :=
+(neg_mem : ∀ {s : S} {x}, x ∈ s → -x ∈ s)
+
+/-- `subgroup_class S G` states `S` is a type of subsets `s ⊆ G` that are subgroups of `G`. -/
+class subgroup_class (S G : Type*) [div_inv_monoid G] [set_like S G]
+  extends submonoid_class S G :=
+(inv_mem : ∀ {s : S} {x}, x ∈ s → x⁻¹ ∈ s)
+
+/-- `add_subgroup_class S G` states `S` is a type of subsets `s ⊆ G` that are
+additive subgroups of `G`. -/
+class add_subgroup_class (S G : Type*) [sub_neg_monoid G] [set_like S G]
+  extends add_submonoid_class S G :=
+(neg_mem : ∀ {s : S} {x}, x ∈ s → -x ∈ s)
+
+attribute [to_additive] inv_mem_class subgroup_class
+
+namespace subgroup_class
+
+variables (M S : Type*) [div_inv_monoid M] [set_like S M] [hSM : subgroup_class S M]
+include hSM
+
+@[to_additive, priority 100] -- See note [lower instance priority]
+instance to_inv_mem_class : inv_mem_class S M :=
+{ .. hSM }
+
+variables {S M} {H K : S}
+
+open mul_mem_class inv_mem_class submonoid_class
+
+/-- A subgroup is closed under division. -/
+@[to_additive "An `add_subgroup` is closed under subtraction."]
+theorem div_mem {x y : M} (hx : x ∈ H) (hy : y ∈ H) : x / y ∈ H :=
+by simpa only [div_eq_mul_inv] using mul_mem hx (inv_mem hy)
+
+@[to_additive]
+lemma zpow_mem {x : M} (hx : x ∈ K) : ∀ n : ℤ, x ^ n ∈ K
+| (n : ℕ) := by { rw [zpow_coe_nat], exact pow_mem hx n }
+| -[1+ n] := by { rw [zpow_neg_succ_of_nat], exact inv_mem (pow_mem hx n.succ) }
+
+omit hSM
+variables [set_like S G] [hSG : subgroup_class S G]
+include hSG
+
+@[simp, to_additive] theorem inv_mem_iff {x : G} : x⁻¹ ∈ H ↔ x ∈ H :=
+⟨λ h, inv_inv x ▸ inv_mem h, inv_mem⟩
+
+@[to_additive] lemma div_mem_comm_iff {a b : G} : a / b ∈ H ↔ b / a ∈ H :=
+by rw [← inv_mem_iff, div_eq_mul_inv, div_eq_mul_inv, mul_inv_rev, inv_inv]
+
+@[simp, to_additive]
+theorem inv_coe_set : (H : set G)⁻¹ = H :=
+by { ext, simp }
+
+@[simp, to_additive]
+lemma exists_inv_mem_iff_exists_mem {P : G → Prop} :
+  (∃ (x : G), x ∈ H ∧ P x⁻¹) ↔ ∃ x ∈ H, P x :=
+by split; { rintros ⟨x, x_in, hx⟩, exact ⟨x⁻¹, inv_mem x_in, by simp [hx]⟩ }
+
+@[to_additive]
+lemma mul_mem_cancel_right {x y : G} (h : x ∈ H) : y * x ∈ H ↔ y ∈ H :=
+⟨λ hba, by simpa using mul_mem hba (inv_mem h), λ hb, mul_mem hb h⟩
+
+@[to_additive]
+lemma mul_mem_cancel_left {x y : G} (h : x ∈ H) : x * y ∈ H ↔ y ∈ H :=
+⟨λ hab, by simpa using mul_mem (inv_mem h) hab, mul_mem h⟩
+
+omit hSG
+include hSM
+
+/-- A subgroup of a group inherits an inverse. -/
+@[to_additive "A `add_subgroup` of a `add_group` inherits an inverse."]
+instance has_inv : has_inv H := ⟨λ a, ⟨a⁻¹, inv_mem a.2⟩⟩
+
+/-- A subgroup of a group inherits a division -/
+@[to_additive "An `add_subgroup` of an `add_group` inherits a subtraction."]
+instance has_div : has_div H := ⟨λ a b, ⟨a / b, div_mem a.2 b.2⟩⟩
+
+@[simp, norm_cast, to_additive] lemma coe_inv (x : H) : ↑(x⁻¹ : H) = (x⁻¹ : M) := rfl
+@[simp, norm_cast, to_additive] lemma coe_div (x y : H) : (↑(x / y) : M) = ↑x / ↑y := rfl
+
+omit hSM
+variables (H)
+include hSG
+
+/-- A subgroup of a group inherits a group structure. -/
+@[to_additive "An `add_subgroup` of an `add_group` inherits an `add_group` structure."]
+instance to_group : group H :=
+subtype.coe_injective.group _ rfl (λ _ _, rfl) (λ _, rfl) (λ _ _, rfl)
+
+omit hSG
+
+/-- A subgroup of a `comm_group` is a `comm_group`. -/
+@[to_additive "An `add_subgroup` of an `add_comm_group` is an `add_comm_group`."]
+instance to_comm_group {G : Type*} [comm_group G] [set_like S G] [subgroup_class S G] :
+  comm_group H :=
+subtype.coe_injective.comm_group _ rfl (λ _ _, rfl) (λ _, rfl) (λ _ _, rfl)
+
+/-- A subgroup of an `ordered_comm_group` is an `ordered_comm_group`. -/
+@[to_additive "An `add_subgroup` of an `add_ordered_comm_group` is an `add_ordered_comm_group`."]
+instance to_ordered_comm_group {G : Type*} [ordered_comm_group G] [set_like S G]
+  [subgroup_class S G] : ordered_comm_group H :=
+subtype.coe_injective.ordered_comm_group _ rfl (λ _ _, rfl) (λ _, rfl) (λ _ _, rfl)
+
+/-- A subgroup of a `linear_ordered_comm_group` is a `linear_ordered_comm_group`. -/
+@[to_additive "An `add_subgroup` of a `linear_ordered_add_comm_group` is a
+  `linear_ordered_add_comm_group`."]
+instance to_linear_ordered_comm_group {G : Type*} [linear_ordered_comm_group G] [set_like S G]
+  [subgroup_class S G] : linear_ordered_comm_group H :=
+subtype.coe_injective.linear_ordered_comm_group _ rfl (λ _ _, rfl) (λ _, rfl) (λ _ _, rfl)
+
+include hSG
+
+/-- The natural group hom from a subgroup of group `G` to `G`. -/
+@[to_additive "The natural group hom from an `add_subgroup` of `add_group` `G` to `G`."]
+def subtype : H →* G := ⟨coe, rfl, λ _ _, rfl⟩
+
+@[simp, to_additive] theorem coe_subtype : (subtype H : H → G) = coe := rfl
+
+variables {H}
+
+@[simp, norm_cast, to_additive coe_smul]
+lemma coe_pow (x : H) (n : ℕ) : ((x ^ n : H) : G) = x ^ n :=
+(subtype H : H →* G).map_pow _ _
+
+@[simp, norm_cast, to_additive] lemma coe_zpow (x : H) (n : ℤ) : ((x ^ n : H) : G) = x ^ n :=
+(subtype H : H →* G).map_zpow _ _
+
+/-- The inclusion homomorphism from a subgroup `H` contained in `K` to `K`. -/
+@[to_additive "The inclusion homomorphism from a additive subgroup `H` contained in `K` to `K`."]
+def inclusion {H K : S} (h : H ≤ K) : H →* K :=
+monoid_hom.mk' (λ x, ⟨x, h x.prop⟩) (λ ⟨a, ha⟩  ⟨b, hb⟩, rfl)
+
+@[simp, to_additive]
+lemma coe_inclusion {H K : S} {h : H ≤ K} (a : H) : (inclusion h a : G) = a :=
+by { cases a, simp only [inclusion, set_like.coe_mk, monoid_hom.mk'_apply] }
+
+@[simp, to_additive]
+lemma subtype_comp_inclusion {H K : S} (hH : H ≤ K) :
+  (subtype K).comp (inclusion hH) = subtype H :=
+by { ext, simp only [monoid_hom.comp_apply, coe_subtype, coe_inclusion] }
+
+end subgroup_class
+
+end subgroup_class
+
 set_option old_structure_cmd true
 
 /-- A subgroup of a group `G` is a subset containing 1, closed under multiplication
@@ -114,7 +266,14 @@ namespace subgroup
 
 @[to_additive]
 instance : set_like (subgroup G) G :=
-⟨subgroup.carrier, λ p q h, by cases p; cases q; congr'⟩
+{ coe := subgroup.carrier,
+  coe_injective' := λ p q h, by cases p; cases q; congr' }
+
+@[to_additive]
+instance : subgroup_class (subgroup G) G :=
+{ mul_mem := subgroup.mul_mem',
+  one_mem := subgroup.one_mem',
+  inv_mem := subgroup.inv_mem' }
 
 @[simp, to_additive]
 lemma mem_carrier {s : subgroup G} {x : G} : x ∈ s.carrier ↔ x ∈ s := iff.rfl

--- a/src/group_theory/subgroup/basic.lean
+++ b/src/group_theory/subgroup/basic.lean
@@ -194,7 +194,7 @@ include hSG
 @[to_additive "An additive subgroup of an `add_group` inherits an `add_group` structure.",
 priority 75] -- Prefer subclasses of `group` over subclasses of `subgroup_class`.
 instance to_group : group H :=
-subtype.coe_injective.group _ rfl (λ _ _, rfl) (λ _, rfl) (λ _ _, rfl)
+subtype.coe_injective.group _ rfl (λ _ _, rfl) (λ _, rfl) (λ _ _, rfl) (λ _ _, rfl) (λ _ _, rfl)
 
 omit hSG
 
@@ -203,14 +203,16 @@ omit hSG
 priority 75] -- Prefer subclasses of `comm_group` over subclasses of `subgroup_class`.
 instance to_comm_group {G : Type*} [comm_group G] [set_like S G] [subgroup_class S G] :
   comm_group H :=
-subtype.coe_injective.comm_group _ rfl (λ _ _, rfl) (λ _, rfl) (λ _ _, rfl)
+subtype.coe_injective.comm_group _ rfl (λ _ _, rfl) (λ _, rfl) (λ _ _, rfl) (λ _ _, rfl)
+  (λ _ _, rfl)
 
 /-- A subgroup of an `ordered_comm_group` is an `ordered_comm_group`. -/
 @[to_additive "An additive subgroup of an `add_ordered_comm_group` is an `add_ordered_comm_group`.",
 priority 75] -- Prefer subclasses of `group` over subclasses of `subgroup_class`.
 instance to_ordered_comm_group {G : Type*} [ordered_comm_group G] [set_like S G]
   [subgroup_class S G] : ordered_comm_group H :=
-subtype.coe_injective.ordered_comm_group _ rfl (λ _ _, rfl) (λ _, rfl) (λ _ _, rfl)
+subtype.coe_injective.ordered_comm_group _ rfl (λ _ _, rfl) (λ _, rfl) (λ _ _, rfl) (λ _ _, rfl)
+  (λ _ _, rfl)
 
 /-- A subgroup of a `linear_ordered_comm_group` is a `linear_ordered_comm_group`. -/
 @[to_additive "An additive subgroup of a `linear_ordered_add_comm_group` is a
@@ -219,6 +221,7 @@ subtype.coe_injective.ordered_comm_group _ rfl (λ _ _, rfl) (λ _, rfl) (λ _ _
 instance to_linear_ordered_comm_group {G : Type*} [linear_ordered_comm_group G] [set_like S G]
   [subgroup_class S G] : linear_ordered_comm_group H :=
 subtype.coe_injective.linear_ordered_comm_group _ rfl (λ _ _, rfl) (λ _, rfl) (λ _ _, rfl)
+  (λ _ _, rfl) (λ _ _, rfl)
 
 include hSG
 

--- a/src/group_theory/subgroup/basic.lean
+++ b/src/group_theory/subgroup/basic.lean
@@ -181,27 +181,31 @@ variables (H)
 include hSG
 
 /-- A subgroup of a group inherits a group structure. -/
-@[to_additive "An `add_subgroup` of an `add_group` inherits an `add_group` structure."]
+@[to_additive "An `add_subgroup` of an `add_group` inherits an `add_group` structure.",
+priority 75] -- Prefer subclasses of `group` over subclasses of `subgroup_class`.
 instance to_group : group H :=
 subtype.coe_injective.group _ rfl (λ _ _, rfl) (λ _, rfl) (λ _ _, rfl)
 
 omit hSG
 
 /-- A subgroup of a `comm_group` is a `comm_group`. -/
-@[to_additive "An `add_subgroup` of an `add_comm_group` is an `add_comm_group`."]
+@[to_additive "An `add_subgroup` of an `add_comm_group` is an `add_comm_group`.",
+priority 75] -- Prefer subclasses of `comm_group` over subclasses of `subgroup_class`.
 instance to_comm_group {G : Type*} [comm_group G] [set_like S G] [subgroup_class S G] :
   comm_group H :=
 subtype.coe_injective.comm_group _ rfl (λ _ _, rfl) (λ _, rfl) (λ _ _, rfl)
 
 /-- A subgroup of an `ordered_comm_group` is an `ordered_comm_group`. -/
-@[to_additive "An `add_subgroup` of an `add_ordered_comm_group` is an `add_ordered_comm_group`."]
+@[to_additive "An `add_subgroup` of an `add_ordered_comm_group` is an `add_ordered_comm_group`.",
+priority 75] -- Prefer subclasses of `group` over subclasses of `subgroup_class`.
 instance to_ordered_comm_group {G : Type*} [ordered_comm_group G] [set_like S G]
   [subgroup_class S G] : ordered_comm_group H :=
 subtype.coe_injective.ordered_comm_group _ rfl (λ _ _, rfl) (λ _, rfl) (λ _ _, rfl)
 
 /-- A subgroup of a `linear_ordered_comm_group` is a `linear_ordered_comm_group`. -/
 @[to_additive "An `add_subgroup` of a `linear_ordered_add_comm_group` is a
-  `linear_ordered_add_comm_group`."]
+  `linear_ordered_add_comm_group`.",
+  priority 75] -- Prefer subclasses of `group` over subclasses of `subgroup_class`.
 instance to_linear_ordered_comm_group {G : Type*} [linear_ordered_comm_group G] [set_like S G]
   [subgroup_class S G] : linear_ordered_comm_group H :=
 subtype.coe_injective.linear_ordered_comm_group _ rfl (λ _ _, rfl) (λ _, rfl) (λ _ _, rfl)

--- a/src/group_theory/subgroup/basic.lean
+++ b/src/group_theory/subgroup/basic.lean
@@ -126,7 +126,7 @@ variables {S M} {H K : S}
 open mul_mem_class inv_mem_class submonoid_class
 
 /-- A subgroup is closed under division. -/
-@[to_additive "An `add_subgroup` is closed under subtraction."]
+@[to_additive "An additive subgroup is closed under subtraction."]
 theorem div_mem {x y : M} (hx : x ∈ H) (hy : y ∈ H) : x / y ∈ H :=
 by simpa only [div_eq_mul_inv] using mul_mem hx (inv_mem hy)
 
@@ -166,13 +166,23 @@ omit hSG
 include hSM
 
 /-- A subgroup of a group inherits an inverse. -/
-@[to_additive "A `add_subgroup` of a `add_group` inherits an inverse."]
+@[to_additive "An additive subgroup of a `add_group` inherits an inverse."]
 instance has_inv : has_inv H := ⟨λ a, ⟨a⁻¹, inv_mem a.2⟩⟩
 
 /-- A subgroup of a group inherits a division -/
-@[to_additive "An `add_subgroup` of an `add_group` inherits a subtraction."]
+@[to_additive "An additive subgroup of an `add_group` inherits a subtraction."]
 instance has_div : has_div H := ⟨λ a b, ⟨a / b, div_mem a.2 b.2⟩⟩
 
+omit hSM
+/-- An additive subgroup of an `add_group` inherits an integer scaling. -/
+instance _root_.add_subgroup_class.has_zsmul {M S} [sub_neg_monoid M] [set_like S M]
+  [add_subgroup_class S M] {H : S} : has_scalar ℤ H :=
+⟨λ n a, ⟨n • a, add_subgroup_class.zsmul_mem a.2 n⟩⟩
+include hSM
+
+/-- A subgroup of a group inherits an integer power. -/
+@[to_additive]
+instance has_zpow : has_pow H ℤ := ⟨λ a n, ⟨a ^ n, zpow_mem a.2 n⟩⟩
 @[simp, norm_cast, to_additive] lemma coe_inv (x : H) : ↑(x⁻¹ : H) = (x⁻¹ : M) := rfl
 @[simp, norm_cast, to_additive] lemma coe_div (x y : H) : (↑(x / y) : M) = ↑x / ↑y := rfl
 
@@ -181,7 +191,7 @@ variables (H)
 include hSG
 
 /-- A subgroup of a group inherits a group structure. -/
-@[to_additive "An `add_subgroup` of an `add_group` inherits an `add_group` structure.",
+@[to_additive "An additive subgroup of an `add_group` inherits an `add_group` structure.",
 priority 75] -- Prefer subclasses of `group` over subclasses of `subgroup_class`.
 instance to_group : group H :=
 subtype.coe_injective.group _ rfl (λ _ _, rfl) (λ _, rfl) (λ _ _, rfl)
@@ -189,21 +199,21 @@ subtype.coe_injective.group _ rfl (λ _ _, rfl) (λ _, rfl) (λ _ _, rfl)
 omit hSG
 
 /-- A subgroup of a `comm_group` is a `comm_group`. -/
-@[to_additive "An `add_subgroup` of an `add_comm_group` is an `add_comm_group`.",
+@[to_additive "An additive subgroup of an `add_comm_group` is an `add_comm_group`.",
 priority 75] -- Prefer subclasses of `comm_group` over subclasses of `subgroup_class`.
 instance to_comm_group {G : Type*} [comm_group G] [set_like S G] [subgroup_class S G] :
   comm_group H :=
 subtype.coe_injective.comm_group _ rfl (λ _ _, rfl) (λ _, rfl) (λ _ _, rfl)
 
 /-- A subgroup of an `ordered_comm_group` is an `ordered_comm_group`. -/
-@[to_additive "An `add_subgroup` of an `add_ordered_comm_group` is an `add_ordered_comm_group`.",
+@[to_additive "An additive subgroup of an `add_ordered_comm_group` is an `add_ordered_comm_group`.",
 priority 75] -- Prefer subclasses of `group` over subclasses of `subgroup_class`.
 instance to_ordered_comm_group {G : Type*} [ordered_comm_group G] [set_like S G]
   [subgroup_class S G] : ordered_comm_group H :=
 subtype.coe_injective.ordered_comm_group _ rfl (λ _ _, rfl) (λ _, rfl) (λ _ _, rfl)
 
 /-- A subgroup of a `linear_ordered_comm_group` is a `linear_ordered_comm_group`. -/
-@[to_additive "An `add_subgroup` of a `linear_ordered_add_comm_group` is a
+@[to_additive "An additive subgroup of a `linear_ordered_add_comm_group` is a
   `linear_ordered_add_comm_group`.",
   priority 75] -- Prefer subclasses of `group` over subclasses of `subgroup_class`.
 instance to_linear_ordered_comm_group {G : Type*} [linear_ordered_comm_group G] [set_like S G]
@@ -213,7 +223,7 @@ subtype.coe_injective.linear_ordered_comm_group _ rfl (λ _ _, rfl) (λ _, rfl) 
 include hSG
 
 /-- The natural group hom from a subgroup of group `G` to `G`. -/
-@[to_additive "The natural group hom from an `add_subgroup` of `add_group` `G` to `G`."]
+@[to_additive "The natural group hom from an additive subgroup of `add_group` `G` to `G`."]
 def subtype : H →* G := ⟨coe, rfl, λ _ _, rfl⟩
 
 @[simp, to_additive] theorem coe_subtype : (subtype H : H → G) = coe := rfl

--- a/src/group_theory/submonoid/basic.lean
+++ b/src/group_theory/submonoid/basic.lean
@@ -77,11 +77,15 @@ export add_mem_class (add_mem)
 
 attribute [to_additive] one_mem_class mul_mem_class
 
+section
+
 set_option old_structure_cmd true
 
 /-- A submonoid of a monoid `M` is a subset containing 1 and closed under multiplication. -/
 structure submonoid (M : Type*) [mul_one_class M] extends subsemigroup M :=
 (one_mem' : (1 : M) ∈ carrier)
+
+end
 
 /-- A submonoid of a monoid `M` can be considered as a subsemigroup of that monoid. -/
 add_decl_doc submonoid.to_subsemigroup
@@ -92,10 +96,16 @@ class submonoid_class (S : Type*) (M : out_param $ Type*) [mul_one_class M] [set
   extends mul_mem_class S M :=
 (one_mem : ∀ (s : S), (1 : M) ∈ s)
 
+section
+
+set_option old_structure_cmd true
+
 /-- An additive submonoid of an additive monoid `M` is a subset containing 0 and
   closed under addition. -/
 structure add_submonoid (M : Type*) [add_zero_class M] extends add_subsemigroup M :=
 (zero_mem' : (0 : M) ∈ carrier)
+
+end
 
 /-- An additive submonoid of an additive monoid `M` can be considered as an
 additive subsemigroup of that additive monoid. -/

--- a/src/group_theory/submonoid/basic.lean
+++ b/src/group_theory/submonoid/basic.lean
@@ -114,6 +114,12 @@ instance submonoid_class.to_one_mem_class (S : Type*) (M : out_param $ Type*) [m
   [set_like S M] [h : submonoid_class S M] : one_mem_class S M :=
 { ..h }
 
+@[to_additive]
+lemma pow_mem {M} [monoid M] {A : Type*} [set_like A M] [submonoid_class A M] {S : A} {x : M}
+  (hx : x ∈ S) : ∀ (n : ℕ), x ^ n ∈ S
+| 0 := by { rw pow_zero, exact one_mem_class.one_mem S }
+| (n + 1) := by { rw pow_succ, exact mul_mem_class.mul_mem hx (pow_mem n) }
+
 namespace submonoid
 
 @[to_additive]

--- a/src/group_theory/submonoid/basic.lean
+++ b/src/group_theory/submonoid/basic.lean
@@ -57,6 +57,26 @@ section non_assoc
 variables [mul_one_class M] {s : set M}
 variables [add_zero_class A] {t : set A}
 
+/-- `one_mem_class S M` says `S` is a type of subsets `s ≤ M`, such that `1 ∈ s` for all `s`. -/
+class one_mem_class (S : Type*) (M : out_param $ Type*) [has_one M] [set_like S M] :=
+(one_mem : ∀ (s : S), (1 : M) ∈ s)
+
+/-- `zero_mem_class S M` says `S` is a type of subsets `s ≤ M`, such that `0 ∈ s` for all `s`. -/
+class zero_mem_class (S : Type*) (M : out_param $ Type*) [has_zero M] [set_like S M] :=
+(zero_mem : ∀ (s : S), (0 : M) ∈ s)
+
+/-- `mul_mem_class S M` says `S` is a type of subsets `s ≤ M` that are closed under `(*)` -/
+class mul_mem_class (S : Type*) (M : out_param $ Type*) [has_mul M] [set_like S M] :=
+(mul_mem : ∀ {s : S} {a b : M}, a ∈ s → b ∈ s → a * b ∈ s)
+
+/-- `add_mem_class S M` says `S` is a type of subsets `s ≤ M` that are closed under `(+)` -/
+class add_mem_class (S : Type*) (M : out_param $ Type*) [has_add M] [set_like S M] :=
+(add_mem : ∀ {s : S} {a b : M}, a ∈ s → b ∈ s → a + b ∈ s)
+
+export add_mem_class (add_mem)
+
+attribute [to_additive] one_mem_class mul_mem_class
+
 set_option old_structure_cmd true
 
 /-- A submonoid of a monoid `M` is a subset containing 1 and closed under multiplication. -/
@@ -65,6 +85,12 @@ structure submonoid (M : Type*) [mul_one_class M] extends subsemigroup M :=
 
 /-- A submonoid of a monoid `M` can be considered as a subsemigroup of that monoid. -/
 add_decl_doc submonoid.to_subsemigroup
+
+/-- `submonoid_class S M` says `S` is a type of subsets `s ≤ M` that contain `1`
+and are closed under `(*)` -/
+class submonoid_class (S : Type*) (M : out_param $ Type*) [mul_one_class M] [set_like S M]
+  extends mul_mem_class S M :=
+(one_mem : ∀ (s : S), (1 : M) ∈ s)
 
 /-- An additive submonoid of an additive monoid `M` is a subset containing 0 and
   closed under addition. -/
@@ -75,13 +101,30 @@ structure add_submonoid (M : Type*) [add_zero_class M] extends add_subsemigroup 
 additive subsemigroup of that additive monoid. -/
 add_decl_doc add_submonoid.to_add_subsemigroup
 
-attribute [to_additive] submonoid
+/-- `add_submonoid_class S M` says `S` is a type of subsets `s ≤ M` that contain `0`
+and are closed under `(+)` -/
+class add_submonoid_class (S : Type*) (M : out_param $ Type*) [add_zero_class M] [set_like S M]
+  extends add_mem_class S M :=
+(zero_mem : ∀ (s : S), (0 : M) ∈ s)
+
+attribute [to_additive] submonoid submonoid_class
+
+@[to_additive, priority 100] -- See note [lower instance priority]
+instance submonoid_class.to_one_mem_class (S : Type*) (M : out_param $ Type*) [mul_one_class M]
+  [set_like S M] [h : submonoid_class S M] : one_mem_class S M :=
+{ ..h }
 
 namespace submonoid
 
 @[to_additive]
 instance : set_like (submonoid M) M :=
-⟨submonoid.carrier, λ p q h, by cases p; cases q; congr'⟩
+{ coe := submonoid.carrier,
+  coe_injective' := λ p q h, by cases p; cases q; congr' }
+
+@[to_additive]
+instance : submonoid_class (submonoid M) M :=
+{ one_mem := submonoid.one_mem',
+  mul_mem := submonoid.mul_mem' }
 
 /-- See Note [custom simps projection] -/
 @[to_additive " See Note [custom simps projection]"]

--- a/src/group_theory/submonoid/membership.lean
+++ b/src/group_theory/submonoid/membership.lean
@@ -41,10 +41,6 @@ variables [monoid M] [set_like B M] [submonoid_class B M] {S : B}
 
 namespace submonoid_class
 
-@[simp, norm_cast, to_additive coe_nsmul] theorem coe_pow (x : S) (n : ℕ) :
-  ↑(x ^ n) = (x ^ n : M) :=
-(submonoid_class.subtype S : _ →* M).map_pow x n
-
 @[simp, norm_cast, to_additive] theorem coe_list_prod (l : list S) :
   (l.prod : M) = (l.map coe).prod :=
 (submonoid_class.subtype S : _ →* M).map_list_prod l
@@ -79,18 +75,11 @@ lemma prod_mem {M : Type*} [comm_monoid M] [set_like B M] [submonoid_class B M]
   ∏ c in t, f c ∈ S :=
 multiset_prod_mem (t.1.map f) $ λ x hx, let ⟨i, hi, hix⟩ := multiset.mem_map.1 hx in hix ▸ h i hi
 
-@[to_additive nsmul_mem] lemma pow_mem {x : M} (hx : x ∈ S) (n : ℕ) : x ^ n ∈ S :=
-by simpa only [coe_pow] using ((⟨x, hx⟩ : S) ^ n).coe_prop
-
 end submonoid_class
 
 namespace submonoid
 
 variables [monoid M] (s : submonoid M)
-
-@[simp, norm_cast, to_additive coe_nsmul] theorem coe_pow (x : s) (n : ℕ) :
-  ↑(x ^ n) = (x ^ n : M) :=
-s.subtype.map_pow x n
 
 @[simp, norm_cast, to_additive] theorem coe_list_prod (l : list s) :
   (l.prod : M) = (l.map coe).prod :=
@@ -136,7 +125,6 @@ lemma prod_mem {M : Type*} [comm_monoid M] (S : submonoid M)
   ∏ c in t, f c ∈ S :=
 S.multiset_prod_mem (t.1.map f) $ λ x hx, let ⟨i, hi, hix⟩ := multiset.mem_map.1 hx in hix ▸ h i hi
 
-<<<<<<< HEAD
 @[to_additive]
 lemma noncomm_prod_mem (S : submonoid M) {ι : Type*} (t : finset ι) (f : ι → M)
   (comm : ∀ (x ∈ t) (y ∈ t), commute (f x) (f y)) (h : ∀ c ∈ t, f c ∈ S) :
@@ -148,12 +136,8 @@ begin
   rintros ⟨x, ⟨hx, rfl⟩⟩,
   exact h x hx,
 end
-=======
-@[to_additive nsmul_mem] lemma pow_mem {x : M} (hx : x ∈ s) (n : ℕ) : x ^ n ∈ s :=
-by simpa only [coe_pow] using ((⟨x, hx⟩ : s) ^ n).coe_prop
 
 end submonoid
->>>>>>> 7d76acc0c0 (feat(*): define subobject classes from `submonoid` up to `subfield`)
 
 end assoc
 

--- a/src/group_theory/submonoid/membership.lean
+++ b/src/group_theory/submonoid/membership.lean
@@ -34,17 +34,67 @@ submonoid, submonoids
 
 open_locale big_operators
 
-variables {M : Type*}
-variables {A : Type*}
-
-namespace submonoid
+variables {M A B : Type*}
 
 section assoc
-variables [monoid M] (S : submonoid M)
+variables [monoid M] [set_like B M] [submonoid_class B M] {S : B}
+
+namespace submonoid_class
+
+@[simp, norm_cast, to_additive coe_nsmul] theorem coe_pow (x : S) (n : ℕ) :
+  ↑(x ^ n) = (x ^ n : M) :=
+(submonoid_class.subtype S : _ →* M).map_pow x n
 
 @[simp, norm_cast, to_additive] theorem coe_list_prod (l : list S) :
   (l.prod : M) = (l.map coe).prod :=
-S.subtype.map_list_prod l
+(submonoid_class.subtype S : _ →* M).map_list_prod l
+
+@[simp, norm_cast, to_additive] theorem coe_multiset_prod {M} [comm_monoid M] [set_like B M]
+  [submonoid_class B M] (m : multiset S) : (m.prod : M) = (m.map coe).prod :=
+(submonoid_class.subtype S : _ →* M).map_multiset_prod m
+
+@[simp, norm_cast, to_additive] theorem coe_finset_prod {ι M} [comm_monoid M] [set_like B M]
+  [submonoid_class B M] (f : ι → S) (s : finset ι) :
+  ↑(∏ i in s, f i) = (∏ i in s, f i : M) :=
+(submonoid_class.subtype S : _ →* M).map_prod f s
+
+/-- Product of a list of elements in a submonoid is in the submonoid. -/
+@[to_additive "Sum of a list of elements in an `add_submonoid` is in the `add_submonoid`."]
+lemma list_prod_mem {l : list M} (hl : ∀ x ∈ l, x ∈ S) : l.prod ∈ S :=
+by { lift l to list S using hl, rw ← coe_list_prod, exact l.prod.coe_prop }
+
+/-- Product of a multiset of elements in a submonoid of a `comm_monoid` is in the submonoid. -/
+@[to_additive "Sum of a multiset of elements in an `add_submonoid` of an `add_comm_monoid` is
+in the `add_submonoid`."]
+lemma multiset_prod_mem {M} [comm_monoid M] [set_like B M] [submonoid_class B M] (m : multiset M)
+  (hm : ∀ a ∈ m, a ∈ S) : m.prod ∈ S :=
+by { lift m to multiset S using hm, rw ← coe_multiset_prod, exact m.prod.coe_prop }
+
+/-- Product of elements of a submonoid of a `comm_monoid` indexed by a `finset` is in the
+    submonoid. -/
+@[to_additive "Sum of elements in an `add_submonoid` of an `add_comm_monoid` indexed by a `finset`
+is in the `add_submonoid`."]
+lemma prod_mem {M : Type*} [comm_monoid M] [set_like B M] [submonoid_class B M]
+  {ι : Type*} {t : finset ι} {f : ι → M} (h : ∀c ∈ t, f c ∈ S) :
+  ∏ c in t, f c ∈ S :=
+multiset_prod_mem (t.1.map f) $ λ x hx, let ⟨i, hi, hix⟩ := multiset.mem_map.1 hx in hix ▸ h i hi
+
+@[to_additive nsmul_mem] lemma pow_mem {x : M} (hx : x ∈ S) (n : ℕ) : x ^ n ∈ S :=
+by simpa only [coe_pow] using ((⟨x, hx⟩ : S) ^ n).coe_prop
+
+end submonoid_class
+
+namespace submonoid
+
+variables [monoid M] (s : submonoid M)
+
+@[simp, norm_cast, to_additive coe_nsmul] theorem coe_pow (x : s) (n : ℕ) :
+  ↑(x ^ n) = (x ^ n : M) :=
+s.subtype.map_pow x n
+
+@[simp, norm_cast, to_additive] theorem coe_list_prod (l : list s) :
+  (l.prod : M) = (l.map coe).prod :=
+s.subtype.map_list_prod l
 
 @[simp, norm_cast, to_additive] theorem coe_multiset_prod {M} [comm_monoid M] (S : submonoid M)
   (m : multiset S) : (m.prod : M) = (m.map coe).prod :=
@@ -57,8 +107,8 @@ S.subtype.map_prod f s
 
 /-- Product of a list of elements in a submonoid is in the submonoid. -/
 @[to_additive "Sum of a list of elements in an `add_submonoid` is in the `add_submonoid`."]
-lemma list_prod_mem {l : list M} (hl : ∀ x ∈ l, x ∈ S) : l.prod ∈ S :=
-by { lift l to list S using hl, rw ← coe_list_prod, exact l.prod.coe_prop }
+lemma list_prod_mem {l : list M} (hl : ∀ x ∈ l, x ∈ s) : l.prod ∈ s :=
+by { lift l to list s using hl, rw ← coe_list_prod, exact l.prod.coe_prop }
 
 /-- Product of a multiset of elements in a submonoid of a `comm_monoid` is in the submonoid. -/
 @[to_additive "Sum of a multiset of elements in an `add_submonoid` of an `add_comm_monoid` is
@@ -86,6 +136,7 @@ lemma prod_mem {M : Type*} [comm_monoid M] (S : submonoid M)
   ∏ c in t, f c ∈ S :=
 S.multiset_prod_mem (t.1.map f) $ λ x hx, let ⟨i, hi, hix⟩ := multiset.mem_map.1 hx in hix ▸ h i hi
 
+<<<<<<< HEAD
 @[to_additive]
 lemma noncomm_prod_mem (S : submonoid M) {ι : Type*} (t : finset ι) (f : ι → M)
   (comm : ∀ (x ∈ t) (y ∈ t), commute (f x) (f y)) (h : ∀ c ∈ t, f c ∈ S) :
@@ -97,13 +148,24 @@ begin
   rintros ⟨x, ⟨hx, rfl⟩⟩,
   exact h x hx,
 end
+=======
+@[to_additive nsmul_mem] lemma pow_mem {x : M} (hx : x ∈ s) (n : ℕ) : x ^ n ∈ s :=
+by simpa only [coe_pow] using ((⟨x, hx⟩ : s) ^ n).coe_prop
+
+end submonoid
+>>>>>>> 7d76acc0c0 (feat(*): define subobject classes from `submonoid` up to `subfield`)
 
 end assoc
 
 section non_assoc
-variables [mul_one_class M] (S : submonoid M)
+variables [mul_one_class M]
 
 open set
+
+namespace submonoid
+
+-- TODO: this section can be generalized to `[submonoid_class B M] [complete_lattice B]`
+-- such that `complete_lattice.le` coincides with `set_like.le`
 
 @[to_additive]
 lemma mem_supr_of_directed {ι} [hι : nonempty ι] {S : ι → submonoid M} (hS : directed (≤) S)
@@ -194,9 +256,9 @@ begin
     refine ⟨_, hmul _ _ _ _ Cx Cy⟩ },
 end
 
-end non_assoc
-
 end submonoid
+
+end non_assoc
 
 namespace free_monoid
 
@@ -219,7 +281,7 @@ open monoid_hom
 
 lemma closure_singleton_eq (x : M) : closure ({x} : set M) = (powers_hom M x).mrange :=
 closure_eq_of_le (set.singleton_subset_iff.2 ⟨multiplicative.of_add 1, pow_one x⟩) $
-  λ x ⟨n, hn⟩, hn ▸ pow_mem _ (subset_closure $ set.mem_singleton _) _
+  λ x ⟨n, hn⟩, hn ▸ submonoid.pow_mem _ (subset_closure $ set.mem_singleton _) _
 
 /-- The submonoid generated by an element of a monoid equals the set of natural number powers of
     the element. -/

--- a/src/group_theory/submonoid/membership.lean
+++ b/src/group_theory/submonoid/membership.lean
@@ -79,7 +79,7 @@ end submonoid_class
 
 namespace submonoid
 
-variables [monoid M] (s : submonoid M)
+variables (s : submonoid M)
 
 @[simp, norm_cast, to_additive] theorem coe_list_prod (l : list s) :
   (l.prod : M) = (l.map coe).prod :=

--- a/src/group_theory/submonoid/operations.lean
+++ b/src/group_theory/submonoid/operations.lean
@@ -436,35 +436,40 @@ rfl
 
 /-- A submonoid of a unital magma inherits a unital magma structure. -/
 @[to_additive "An `add_submonoid` of an unital additive magma inherits an unital additive magma
-structure."]
+structure.",
+priority 75] -- Prefer subclasses of `monoid` over subclasses of `submonoid_class`.
 instance to_mul_one_class {M : Type*} [mul_one_class M] {A : Type*} [set_like A M]
   [submonoid_class A M] (S : A) : mul_one_class S :=
 subtype.coe_injective.mul_one_class _ rfl (λ _ _, rfl)
 
 /-- A submonoid of a monoid inherits a monoid structure. -/
 @[to_additive "An `add_submonoid` of an `add_monoid` inherits an `add_monoid`
-structure."]
+structure.",
+priority 75] -- Prefer subclasses of `monoid` over subclasses of `submonoid_class`.
 instance to_monoid {M : Type*} [monoid M] {A : Type*} [set_like A M] [submonoid_class A M]
   (S : A) : monoid S :=
 subtype.coe_injective.monoid coe rfl (λ _ _, rfl) (λ _ _, rfl)
 
 /-- A submonoid of a `comm_monoid` is a `comm_monoid`. -/
 @[to_additive "An `add_submonoid` of an `add_comm_monoid` is
-an `add_comm_monoid`."]
+an `add_comm_monoid`.",
+priority 75] -- Prefer subclasses of `monoid` over subclasses of `submonoid_class`.
 instance to_comm_monoid {M} [comm_monoid M] {A : Type*} [set_like A M] [submonoid_class A M]
   (S : A) : comm_monoid S :=
 subtype.coe_injective.comm_monoid coe rfl (λ _ _, rfl) (λ _ _, rfl)
 
 /-- A submonoid of an `ordered_comm_monoid` is an `ordered_comm_monoid`. -/
 @[to_additive "An `add_submonoid` of an `ordered_add_comm_monoid` is
-an `ordered_add_comm_monoid`."]
+an `ordered_add_comm_monoid`.",
+priority 75] -- Prefer subclasses of `monoid` over subclasses of `submonoid_class`.
 instance to_ordered_comm_monoid {M} [ordered_comm_monoid M] {A : Type*} [set_like A M]
   [submonoid_class A M] (S : A) : ordered_comm_monoid S :=
 subtype.coe_injective.ordered_comm_monoid coe rfl (λ _ _, rfl) (λ _ _, rfl)
 
 /-- A submonoid of a `linear_ordered_comm_monoid` is a `linear_ordered_comm_monoid`. -/
 @[to_additive "An `add_submonoid` of a `linear_ordered_add_comm_monoid` is
-a `linear_ordered_add_comm_monoid`."]
+a `linear_ordered_add_comm_monoid`.",
+priority 75] -- Prefer subclasses of `monoid` over subclasses of `submonoid_class`.
 instance to_linear_ordered_comm_monoid {M} [linear_ordered_comm_monoid M] {A : Type*}
   [set_like A M] [submonoid_class A M] (S : A) :
   linear_ordered_comm_monoid S :=
@@ -472,7 +477,8 @@ subtype.coe_injective.linear_ordered_comm_monoid coe rfl (λ _ _, rfl) (λ _ _, 
 
 /-- A submonoid of an `ordered_cancel_comm_monoid` is an `ordered_cancel_comm_monoid`. -/
 @[to_additive "An `add_submonoid` of an `ordered_cancel_add_comm_monoid` is
-an `ordered_cancel_add_comm_monoid`."]
+an `ordered_cancel_add_comm_monoid`.",
+priority 75] -- Prefer subclasses of `monoid` over subclasses of `submonoid_class`.
 instance to_ordered_cancel_comm_monoid {M} [ordered_cancel_comm_monoid M] {A : Type*}
   [set_like A M] [submonoid_class A M] (S : A) :
   ordered_cancel_comm_monoid S :=
@@ -481,7 +487,8 @@ subtype.coe_injective.ordered_cancel_comm_monoid coe rfl (λ _ _, rfl) (λ _ _, 
 /-- A submonoid of a `linear_ordered_cancel_comm_monoid` is a `linear_ordered_cancel_comm_monoid`.
 -/
 @[to_additive "An `add_submonoid` of a `linear_ordered_cancel_add_comm_monoid` is
-a `linear_ordered_cancel_add_comm_monoid`."]
+a `linear_ordered_cancel_add_comm_monoid`.",
+priority 75] -- Prefer subclasses of `monoid` over subclasses of `submonoid_class`.
 instance to_linear_ordered_cancel_comm_monoid {M} [linear_ordered_cancel_comm_monoid M]
   {A : Type*} [set_like A M] [submonoid_class A M] (S : A) : linear_ordered_cancel_comm_monoid S :=
 subtype.coe_injective.linear_ordered_cancel_comm_monoid coe rfl (λ _ _, rfl) (λ _ _, rfl)

--- a/src/group_theory/submonoid/operations.lean
+++ b/src/group_theory/submonoid/operations.lean
@@ -411,6 +411,29 @@ variables (S')
 
 omit hA
 
+/-- An `add_submonoid` of an `add_monoid` inherits a scalar multiplication. -/
+instance _root_.add_submonoid_class.has_nsmul {M} [add_monoid M] {A : Type*} [set_like A M]
+  [add_submonoid_class A M] (S : A) :
+  has_scalar ℕ S :=
+⟨λ n a, ⟨n • a.1, nsmul_mem a.2 n⟩⟩
+
+/-- A submonoid of a monoid inherits a power operator. -/
+instance has_pow {M} [monoid M] {A : Type*} [set_like A M] [submonoid_class A M] (S : A) :
+  has_pow S ℕ :=
+⟨λ a n, ⟨a.1 ^ n, pow_mem a.2 n⟩⟩
+
+attribute [to_additive] submonoid_class.has_pow
+
+@[simp, norm_cast, to_additive] lemma coe_pow {M} [monoid M] {A : Type*} [set_like A M]
+  [submonoid_class A M] {S : A} (x : S) (n : ℕ) :
+  (↑(x ^ n) : M) = ↑x ^ n :=
+rfl
+
+@[simp, to_additive] lemma mk_pow {M} [monoid M] {A : Type*} [set_like A M]
+  [submonoid_class A M] {S : A} (x : M) (hx : x ∈ S) (n : ℕ) :
+  (⟨x, hx⟩ : S) ^ n = ⟨x ^ n, pow_mem hx n⟩ :=
+rfl
+
 /-- A submonoid of a unital magma inherits a unital magma structure. -/
 @[to_additive "An `add_submonoid` of an unital additive magma inherits an unital additive magma
 structure."]
@@ -423,21 +446,21 @@ subtype.coe_injective.mul_one_class _ rfl (λ _ _, rfl)
 structure."]
 instance to_monoid {M : Type*} [monoid M] {A : Type*} [set_like A M] [submonoid_class A M]
   (S : A) : monoid S :=
-subtype.coe_injective.monoid coe rfl (λ _ _, rfl)
+subtype.coe_injective.monoid coe rfl (λ _ _, rfl) (λ _ _, rfl)
 
 /-- A submonoid of a `comm_monoid` is a `comm_monoid`. -/
 @[to_additive "An `add_submonoid` of an `add_comm_monoid` is
 an `add_comm_monoid`."]
 instance to_comm_monoid {M} [comm_monoid M] {A : Type*} [set_like A M] [submonoid_class A M]
   (S : A) : comm_monoid S :=
-subtype.coe_injective.comm_monoid coe rfl (λ _ _, rfl)
+subtype.coe_injective.comm_monoid coe rfl (λ _ _, rfl) (λ _ _, rfl)
 
 /-- A submonoid of an `ordered_comm_monoid` is an `ordered_comm_monoid`. -/
 @[to_additive "An `add_submonoid` of an `ordered_add_comm_monoid` is
 an `ordered_add_comm_monoid`."]
 instance to_ordered_comm_monoid {M} [ordered_comm_monoid M] {A : Type*} [set_like A M]
   [submonoid_class A M] (S : A) : ordered_comm_monoid S :=
-subtype.coe_injective.ordered_comm_monoid coe rfl (λ _ _, rfl)
+subtype.coe_injective.ordered_comm_monoid coe rfl (λ _ _, rfl) (λ _ _, rfl)
 
 /-- A submonoid of a `linear_ordered_comm_monoid` is a `linear_ordered_comm_monoid`. -/
 @[to_additive "An `add_submonoid` of a `linear_ordered_add_comm_monoid` is
@@ -445,7 +468,7 @@ a `linear_ordered_add_comm_monoid`."]
 instance to_linear_ordered_comm_monoid {M} [linear_ordered_comm_monoid M] {A : Type*}
   [set_like A M] [submonoid_class A M] (S : A) :
   linear_ordered_comm_monoid S :=
-subtype.coe_injective.linear_ordered_comm_monoid coe rfl (λ _ _, rfl)
+subtype.coe_injective.linear_ordered_comm_monoid coe rfl (λ _ _, rfl) (λ _ _, rfl)
 
 /-- A submonoid of an `ordered_cancel_comm_monoid` is an `ordered_cancel_comm_monoid`. -/
 @[to_additive "An `add_submonoid` of an `ordered_cancel_add_comm_monoid` is
@@ -453,7 +476,7 @@ an `ordered_cancel_add_comm_monoid`."]
 instance to_ordered_cancel_comm_monoid {M} [ordered_cancel_comm_monoid M] {A : Type*}
   [set_like A M] [submonoid_class A M] (S : A) :
   ordered_cancel_comm_monoid S :=
-subtype.coe_injective.ordered_cancel_comm_monoid coe rfl (λ _ _, rfl)
+subtype.coe_injective.ordered_cancel_comm_monoid coe rfl (λ _ _, rfl) (λ _ _, rfl)
 
 /-- A submonoid of a `linear_ordered_cancel_comm_monoid` is a `linear_ordered_cancel_comm_monoid`.
 -/
@@ -461,7 +484,7 @@ subtype.coe_injective.ordered_cancel_comm_monoid coe rfl (λ _ _, rfl)
 a `linear_ordered_cancel_add_comm_monoid`."]
 instance to_linear_ordered_cancel_comm_monoid {M} [linear_ordered_cancel_comm_monoid M]
   {A : Type*} [set_like A M] [submonoid_class A M] (S : A) : linear_ordered_cancel_comm_monoid S :=
-subtype.coe_injective.linear_ordered_cancel_comm_monoid coe rfl (λ _ _, rfl)
+subtype.coe_injective.linear_ordered_cancel_comm_monoid coe rfl (λ _ _, rfl) (λ _ _, rfl)
 
 include hA
 
@@ -500,11 +523,7 @@ subtype.coe_injective.mul_one_class coe rfl (λ _ _, rfl)
 
 @[to_additive] lemma pow_mem {M : Type*} [monoid M] (S : submonoid M) {x : M}
   (hx : x ∈ S) (n : ℕ) : x ^ n ∈ S :=
-begin
-  induction n with n ih,
-  { simpa only [pow_zero] using S.one_mem },
-  { simpa only [pow_succ] using S.mul_mem hx ih }
-end
+pow_mem hx n
 
 instance _root_.add_submonoid.has_nsmul {M : Type*} [add_monoid M] (S : add_submonoid M) :
   has_scalar ℕ S :=

--- a/src/group_theory/submonoid/operations.lean
+++ b/src/group_theory/submonoid/operations.lean
@@ -378,6 +378,103 @@ lemma comap_strict_mono_of_surjective : strict_mono (comap f) :=
 
 end galois_insertion
 
+end submonoid
+
+namespace submonoid_class
+
+variables {A : Type*} [set_like A M] [hA : submonoid_class A M] (S' : A)
+include hA
+
+open mul_mem_class
+
+/-- A submonoid of a monoid inherits a multiplication. -/
+@[to_additive "An `add_submonoid` of an `add_monoid` inherits an addition."]
+instance has_mul : has_mul S' := ⟨λ a b, ⟨a.1 * b.1, mul_mem a.2 b.2⟩⟩
+
+/-- A submonoid of a monoid inherits a 1. -/
+@[to_additive "An `add_submonoid` of an `add_monoid` inherits a zero."]
+instance has_one : has_one S' := ⟨⟨_, one_mem S'⟩⟩
+
+@[simp, norm_cast, to_additive] lemma coe_mul (x y : S') : (↑(x * y) : M) = ↑x * ↑y := rfl
+@[simp, norm_cast, to_additive] lemma coe_one : ((1 : S') : M) = 1 := rfl
+
+variables {S'}
+@[simp, norm_cast, to_additive] lemma coe_eq_one {x : S'} : (↑x : M) = 1 ↔ x = 1 :=
+(subtype.ext_iff.symm : (x : M) = (1 : S') ↔ x = 1)
+variables (S')
+
+@[simp, to_additive] lemma mk_mul_mk (x y : M) (hx : x ∈ S') (hy : y ∈ S') :
+  (⟨x, hx⟩ : S') * ⟨y, hy⟩ = ⟨x * y, mul_mem hx hy⟩ := rfl
+
+@[to_additive] lemma mul_def (x y : S') : x * y = ⟨x * y, mul_mem x.2 y.2⟩ := rfl
+@[to_additive] lemma one_def : (1 : S') = ⟨1, one_mem S'⟩ := rfl
+
+omit hA
+
+/-- A submonoid of a unital magma inherits a unital magma structure. -/
+@[to_additive "An `add_submonoid` of an unital additive magma inherits an unital additive magma
+structure."]
+instance to_mul_one_class {M : Type*} [mul_one_class M] {A : Type*} [set_like A M]
+  [submonoid_class A M] (S : A) : mul_one_class S :=
+subtype.coe_injective.mul_one_class _ rfl (λ _ _, rfl)
+
+/-- A submonoid of a monoid inherits a monoid structure. -/
+@[to_additive "An `add_submonoid` of an `add_monoid` inherits an `add_monoid`
+structure."]
+instance to_monoid {M : Type*} [monoid M] {A : Type*} [set_like A M] [submonoid_class A M]
+  (S : A) : monoid S :=
+subtype.coe_injective.monoid coe rfl (λ _ _, rfl)
+
+/-- A submonoid of a `comm_monoid` is a `comm_monoid`. -/
+@[to_additive "An `add_submonoid` of an `add_comm_monoid` is
+an `add_comm_monoid`."]
+instance to_comm_monoid {M} [comm_monoid M] {A : Type*} [set_like A M] [submonoid_class A M]
+  (S : A) : comm_monoid S :=
+subtype.coe_injective.comm_monoid coe rfl (λ _ _, rfl)
+
+/-- A submonoid of an `ordered_comm_monoid` is an `ordered_comm_monoid`. -/
+@[to_additive "An `add_submonoid` of an `ordered_add_comm_monoid` is
+an `ordered_add_comm_monoid`."]
+instance to_ordered_comm_monoid {M} [ordered_comm_monoid M] {A : Type*} [set_like A M]
+  [submonoid_class A M] (S : A) : ordered_comm_monoid S :=
+subtype.coe_injective.ordered_comm_monoid coe rfl (λ _ _, rfl)
+
+/-- A submonoid of a `linear_ordered_comm_monoid` is a `linear_ordered_comm_monoid`. -/
+@[to_additive "An `add_submonoid` of a `linear_ordered_add_comm_monoid` is
+a `linear_ordered_add_comm_monoid`."]
+instance to_linear_ordered_comm_monoid {M} [linear_ordered_comm_monoid M] {A : Type*}
+  [set_like A M] [submonoid_class A M] (S : A) :
+  linear_ordered_comm_monoid S :=
+subtype.coe_injective.linear_ordered_comm_monoid coe rfl (λ _ _, rfl)
+
+/-- A submonoid of an `ordered_cancel_comm_monoid` is an `ordered_cancel_comm_monoid`. -/
+@[to_additive "An `add_submonoid` of an `ordered_cancel_add_comm_monoid` is
+an `ordered_cancel_add_comm_monoid`."]
+instance to_ordered_cancel_comm_monoid {M} [ordered_cancel_comm_monoid M] {A : Type*}
+  [set_like A M] [submonoid_class A M] (S : A) :
+  ordered_cancel_comm_monoid S :=
+subtype.coe_injective.ordered_cancel_comm_monoid coe rfl (λ _ _, rfl)
+
+/-- A submonoid of a `linear_ordered_cancel_comm_monoid` is a `linear_ordered_cancel_comm_monoid`.
+-/
+@[to_additive "An `add_submonoid` of a `linear_ordered_cancel_add_comm_monoid` is
+a `linear_ordered_cancel_add_comm_monoid`."]
+instance to_linear_ordered_cancel_comm_monoid {M} [linear_ordered_cancel_comm_monoid M]
+  {A : Type*} [set_like A M] [submonoid_class A M] (S : A) : linear_ordered_cancel_comm_monoid S :=
+subtype.coe_injective.linear_ordered_cancel_comm_monoid coe rfl (λ _ _, rfl)
+
+include hA
+
+/-- The natural monoid hom from a submonoid of monoid `M` to `M`. -/
+@[to_additive "The natural monoid hom from an `add_submonoid` of `add_monoid` `M` to `M`."]
+def subtype : S' →* M := ⟨coe, rfl, λ _ _, rfl⟩
+
+@[simp, to_additive] theorem coe_subtype : (submonoid_class.subtype S' : S' → M) = coe := rfl
+
+end submonoid_class
+
+namespace submonoid
+
 /-- A submonoid of a monoid inherits a multiplication. -/
 @[to_additive "An `add_submonoid` of an `add_monoid` inherits an addition."]
 instance has_mul : has_mul S := ⟨λ a b, ⟨a.1 * b.1, S.mul_mem a.2 b.2⟩⟩

--- a/src/group_theory/sylow.lean
+++ b/src/group_theory/sylow.lean
@@ -67,6 +67,11 @@ instance : set_like (sylow p G) G :=
 { coe := coe,
   coe_injective' := λ P Q h, ext (set_like.coe_injective h) }
 
+instance : subgroup_class (sylow p G) G :=
+{ mul_mem := λ s, s.mul_mem',
+  one_mem := λ s, s.one_mem',
+  inv_mem := λ s, s.inv_mem' }
+
 end sylow
 
 /-- A generalization of **Sylow's first theorem**.

--- a/src/measure_theory/function/lp_space.lean
+++ b/src/measure_theory/function/lp_space.lean
@@ -2598,7 +2598,7 @@ linear_map.mk_continuous
 variables {𝕜}
 
 lemma range_to_Lp [normed_field 𝕜] [normed_space 𝕜 E] [fact (1 ≤ p)] :
-  ((to_Lp p μ 𝕜).range.to_add_subgroup : add_subgroup (Lp E p μ))
+  (((to_Lp p μ 𝕜).range : submodule 𝕜 (Lp E p μ)).to_add_subgroup)
     = measure_theory.Lp.bounded_continuous_function E p μ :=
 range_to_Lp_hom p μ
 
@@ -2631,7 +2631,7 @@ def to_Lp [normed_field 𝕜] [normed_space 𝕜 E] :
 variables {𝕜}
 
 lemma range_to_Lp [normed_field 𝕜] [normed_space 𝕜 E] :
-  ((to_Lp p μ 𝕜).range.to_add_subgroup : add_subgroup (Lp E p μ))
+  ((to_Lp p μ 𝕜).range : submodule 𝕜 (Lp E p μ)).to_add_subgroup
     = measure_theory.Lp.bounded_continuous_function E p μ :=
 begin
   refine set_like.ext' _,

--- a/src/measure_theory/function/lp_space.lean
+++ b/src/measure_theory/function/lp_space.lean
@@ -1315,14 +1315,6 @@ def Lp {α} (E : Type*) {m : measurable_space α} [normed_group E]
 localized "notation α ` →₁[`:25 μ `] ` E := measure_theory.Lp E 1 μ" in measure_theory
 localized "notation α ` →₂[`:25 μ `] ` E := measure_theory.Lp E 2 μ" in measure_theory
 
-/-- Prefer to inherit `add_comm_group → add_comm_monoid` over `add_submonoid_class → _`.
-
-This speeds up some unifications, especially with the `normed_group` instance a whole lot,
-since those problems involve huge terms due to all the parameters.
--/
-instance [borel_space E] [second_countable_topology E] : add_comm_monoid (Lp E p μ) :=
-add_comm_group.to_add_comm_monoid _
-
 namespace mem_ℒp
 
 /-- make an element of Lp from a function verifying `mem_ℒp` -/

--- a/src/measure_theory/function/lp_space.lean
+++ b/src/measure_theory/function/lp_space.lean
@@ -1315,6 +1315,14 @@ def Lp {α} (E : Type*) {m : measurable_space α} [normed_group E]
 localized "notation α ` →₁[`:25 μ `] ` E := measure_theory.Lp E 1 μ" in measure_theory
 localized "notation α ` →₂[`:25 μ `] ` E := measure_theory.Lp E 2 μ" in measure_theory
 
+/-- Prefer to inherit `add_comm_group → add_comm_monoid` over `add_submonoid_class → _`.
+
+This speeds up some unifications, especially with the `normed_group` instance a whole lot,
+since those problems involve huge terms due to all the parameters.
+-/
+instance [borel_space E] [second_countable_topology E] : add_comm_monoid (Lp E p μ) :=
+add_comm_group.to_add_comm_monoid _
+
 namespace mem_ℒp
 
 /-- make an element of Lp from a function verifying `mem_ℒp` -/

--- a/src/measure_theory/integral/bochner.lean
+++ b/src/measure_theory/integral/bochner.lean
@@ -627,10 +627,10 @@ lemma integral_add (f g : α →₁[μ] E) : integral (f + g) = integral f + int
 map_add integral_clm f g
 
 lemma integral_neg (f : α →₁[μ] E) : integral (-f) = - integral f :=
-integral_clm.map_neg f
+map_neg integral_clm f
 
 lemma integral_sub (f g : α →₁[μ] E) : integral (f - g) = integral f - integral g :=
-integral_clm.map_sub f g
+map_sub integral_clm f g
 
 lemma integral_smul (c : 𝕜) (f : α →₁[μ] E) : integral (c • f) = c • integral f :=
 map_smul (integral_clm' 𝕜) c f

--- a/src/ring_theory/jacobson.lean
+++ b/src/ring_theory/jacobson.lean
@@ -409,8 +409,8 @@ begin
     change (polynomial.map ((quotient.mk I).comp C).range_restrict f).coeff n = 0 at hf,
     rw [coeff_map, subtype.ext_iff] at hf,
     rwa [mem_comap, ← quotient.eq_zero_iff_mem, ← ring_hom.comp_apply], },
-  haveI : (ideal.map (map_ring_hom i) I).is_prime :=
-    map_is_prime_of_surjective (map_surjective i hi) hi',
+  haveI := map_is_prime_of_surjective
+    (show function.surjective (map_ring_hom i), from map_surjective i hi) hi',
   suffices : (I.map (polynomial.map_ring_hom i)).jacobson = (I.map (polynomial.map_ring_hom i)),
   { replace this := congr_arg (comap (polynomial.map_ring_hom i)) this,
     rw [← map_jacobson_of_surjective _ hi',

--- a/src/ring_theory/norm.lean
+++ b/src/ring_theory/norm.lean
@@ -202,7 +202,7 @@ lemma _root_.intermediate_field.adjoin_simple.norm_gen_eq_prod_roots (x : L)
   (algebra_map K F) (norm K (adjoin_simple.gen K x)) =
     ((minpoly K x).map (algebra_map K F)).roots.prod :=
 begin
-  have injKxL : function.injective (algebra_map K⟮x⟯ L) := ring_hom.injective _,
+  have injKxL := (algebra_map K⟮x⟯ L).injective,
   by_cases hx : _root_.is_integral K x, swap,
   { simp [minpoly.eq_zero hx, intermediate_field.adjoin_simple.norm_gen_eq_one hx] },
   have hx' : _root_.is_integral K (adjoin_simple.gen K x),

--- a/src/ring_theory/polynomial/basic.lean
+++ b/src/ring_theory/polynomial/basic.lean
@@ -526,7 +526,8 @@ begin
   obtain ⟨x, hx'⟩ := x,
   obtain ⟨y, rfl⟩ := (ring_hom.mem_range).1 hx',
   refine subtype.eq _,
-  simp only [ring_hom.comp_apply, quotient.eq_zero_iff_mem, subring.coe_zero, subtype.val_eq_coe],
+  simp only [ring_hom.comp_apply, quotient.eq_zero_iff_mem, add_submonoid_class.coe_zero,
+    subtype.val_eq_coe],
   suffices : C (i y) ∈ (I.map (polynomial.map_ring_hom i)),
   { obtain ⟨f, hf⟩ := mem_image_of_mem_map_of_surjective (polynomial.map_ring_hom i)
       (polynomial.map_surjective _ (((quotient.mk I).comp C).range_restrict_surjective)) this,

--- a/src/ring_theory/roots_of_unity.lean
+++ b/src/ring_theory/roots_of_unity.lean
@@ -219,7 +219,7 @@ variables {k R}
 lemma map_root_of_unity_eq_pow_self [ring_hom_class F R R] (σ : F) (ζ : roots_of_unity k R) :
   ∃ m : ℕ, σ ζ = ζ ^ m :=
 begin
-  obtain ⟨m, hm⟩ := (restrict_roots_of_unity σ k).map_cyclic,
+  obtain ⟨m, hm⟩ := monoid_hom.map_cyclic (restrict_roots_of_unity σ k),
   rw [←restrict_roots_of_unity_coe_apply, hm, zpow_eq_mod_order_of, ←int.to_nat_of_nonneg
       (m.mod_nonneg (int.coe_nat_ne_zero.mpr (pos_iff_ne_zero.mp (order_of_pos ζ)))),
       zpow_coe_nat, roots_of_unity.coe_pow],

--- a/src/ring_theory/subring/basic.lean
+++ b/src/ring_theory/subring/basic.lean
@@ -91,6 +91,7 @@ lemma coe_int_mem (n : ℤ) : (n : R) ∈ s :=
 by simp only [← zsmul_one, zsmul_mem, one_mem]
 
 /-- A subring of a ring inherits a ring structure -/
+@[priority 75] -- Prefer subclasses of `ring` over subclasses of `subring_class`.
 instance to_ring : ring s :=
 { right_distrib := λ x y z, subtype.eq $ right_distrib x y z,
   left_distrib := λ x y z, subtype.eq $ left_distrib x y z,
@@ -98,31 +99,37 @@ instance to_ring : ring s :=
 
 omit hSR
 /-- A subring of a `comm_ring` is a `comm_ring`. -/
+@[priority 75] -- Prefer subclasses of `ring` over subclasses of `subring_class`.
 instance to_comm_ring {R} [comm_ring R] [set_like S R] [subring_class S R] : comm_ring s :=
 subtype.coe_injective.comm_ring coe rfl rfl (λ _ _, rfl) (λ _ _, rfl) (λ _, rfl) (λ _ _, rfl)
 
 /-- A subring of a domain is a domain. -/
+@[priority 75] -- Prefer subclasses of `ring` over subclasses of `subring_class`.
 instance {R} [ring R] [is_domain R] [set_like S R] [subring_class S R] : is_domain s :=
 { .. subsemiring_class.nontrivial s, .. subsemiring_class.no_zero_divisors s }
 
 /-- A subring of an `ordered_ring` is an `ordered_ring`. -/
+@[priority 75] -- Prefer subclasses of `ring` over subclasses of `subring_class`.
 instance to_ordered_ring {R} [ordered_ring R] [set_like S R] [subring_class S R] :
   ordered_ring s :=
 subtype.coe_injective.ordered_ring coe rfl rfl (λ _ _, rfl) (λ _ _, rfl) (λ _, rfl) (λ _ _, rfl)
 
 /-- A subring of an `ordered_comm_ring` is an `ordered_comm_ring`. -/
+@[priority 75] -- Prefer subclasses of `ring` over subclasses of `subring_class`.
 instance to_ordered_comm_ring {R} [ordered_comm_ring R] [set_like S R] [subring_class S R] :
   ordered_comm_ring s :=
 subtype.coe_injective.ordered_comm_ring coe rfl rfl
   (λ _ _, rfl) (λ _ _, rfl) (λ _, rfl) (λ _ _, rfl)
 
 /-- A subring of a `linear_ordered_ring` is a `linear_ordered_ring`. -/
+@[priority 75] -- Prefer subclasses of `ring` over subclasses of `subring_class`.
 instance to_linear_ordered_ring {R} [linear_ordered_ring R] [set_like S R] [subring_class S R] :
   linear_ordered_ring s :=
 subtype.coe_injective.linear_ordered_ring coe rfl rfl
   (λ _ _, rfl) (λ _ _, rfl) (λ _, rfl) (λ _ _, rfl)
 
 /-- A subring of a `linear_ordered_comm_ring` is a `linear_ordered_comm_ring`. -/
+@[priority 75] -- Prefer subclasses of `ring` over subclasses of `subring_class`.
 instance to_linear_ordered_comm_ring {R} [linear_ordered_comm_ring R] [set_like S R]
   [subring_class S R] : linear_ordered_comm_ring s :=
 subtype.coe_injective.linear_ordered_comm_ring coe rfl rfl

--- a/src/ring_theory/subring/basic.lean
+++ b/src/ring_theory/subring/basic.lean
@@ -99,7 +99,7 @@ instance to_ring : ring s :=
 omit hSR
 /-- A subring of a `comm_ring` is a `comm_ring`. -/
 instance to_comm_ring {R} [comm_ring R] [set_like S R] [subring_class S R] : comm_ring s :=
-{ mul_comm := λ _ _, subtype.eq $ mul_comm _ _, .. subring_class.to_ring s}
+subtype.coe_injective.comm_ring coe rfl rfl (λ _ _, rfl) (λ _ _, rfl) (λ _, rfl) (λ _ _, rfl)
 
 /-- A subring of a domain is a domain. -/
 instance {R} [ring R] [is_domain R] [set_like S R] [subring_class S R] : is_domain s :=

--- a/src/ring_theory/subring/basic.lean
+++ b/src/ring_theory/subring/basic.lean
@@ -102,6 +102,7 @@ omit hSR
 @[priority 75] -- Prefer subclasses of `ring` over subclasses of `subring_class`.
 instance to_comm_ring {R} [comm_ring R] [set_like S R] [subring_class S R] : comm_ring s :=
 subtype.coe_injective.comm_ring coe rfl rfl (λ _ _, rfl) (λ _ _, rfl) (λ _, rfl) (λ _ _, rfl)
+  (λ _ _, rfl) (λ _ _, rfl) (λ _ _, rfl)
 
 /-- A subring of a domain is a domain. -/
 @[priority 75] -- Prefer subclasses of `ring` over subclasses of `subring_class`.
@@ -113,27 +114,28 @@ instance {R} [ring R] [is_domain R] [set_like S R] [subring_class S R] : is_doma
 instance to_ordered_ring {R} [ordered_ring R] [set_like S R] [subring_class S R] :
   ordered_ring s :=
 subtype.coe_injective.ordered_ring coe rfl rfl (λ _ _, rfl) (λ _ _, rfl) (λ _, rfl) (λ _ _, rfl)
+  (λ _ _, rfl) (λ _ _, rfl) (λ _ _, rfl)
 
 /-- A subring of an `ordered_comm_ring` is an `ordered_comm_ring`. -/
 @[priority 75] -- Prefer subclasses of `ring` over subclasses of `subring_class`.
 instance to_ordered_comm_ring {R} [ordered_comm_ring R] [set_like S R] [subring_class S R] :
   ordered_comm_ring s :=
 subtype.coe_injective.ordered_comm_ring coe rfl rfl
-  (λ _ _, rfl) (λ _ _, rfl) (λ _, rfl) (λ _ _, rfl)
+  (λ _ _, rfl) (λ _ _, rfl) (λ _, rfl) (λ _ _, rfl) (λ _ _, rfl) (λ _ _, rfl) (λ _ _, rfl)
 
 /-- A subring of a `linear_ordered_ring` is a `linear_ordered_ring`. -/
 @[priority 75] -- Prefer subclasses of `ring` over subclasses of `subring_class`.
 instance to_linear_ordered_ring {R} [linear_ordered_ring R] [set_like S R] [subring_class S R] :
   linear_ordered_ring s :=
 subtype.coe_injective.linear_ordered_ring coe rfl rfl
-  (λ _ _, rfl) (λ _ _, rfl) (λ _, rfl) (λ _ _, rfl)
+  (λ _ _, rfl) (λ _ _, rfl) (λ _, rfl) (λ _ _, rfl) (λ _ _, rfl) (λ _ _, rfl) (λ _ _, rfl)
 
 /-- A subring of a `linear_ordered_comm_ring` is a `linear_ordered_comm_ring`. -/
 @[priority 75] -- Prefer subclasses of `ring` over subclasses of `subring_class`.
 instance to_linear_ordered_comm_ring {R} [linear_ordered_comm_ring R] [set_like S R]
   [subring_class S R] : linear_ordered_comm_ring s :=
 subtype.coe_injective.linear_ordered_comm_ring coe rfl rfl
-  (λ _ _, rfl) (λ _ _, rfl) (λ _, rfl) (λ _ _, rfl)
+  (λ _ _, rfl) (λ _ _, rfl) (λ _, rfl) (λ _ _, rfl) (λ _ _, rfl) (λ _ _, rfl) (λ _ _, rfl)
 
 include hSR
 

--- a/src/ring_theory/subsemiring/basic.lean
+++ b/src/ring_theory/subsemiring/basic.lean
@@ -52,12 +52,7 @@ by simp only [← nsmul_one, nsmul_mem, one_mem]
 
 /-- A subsemiring of a `non_assoc_semiring` inherits a `non_assoc_semiring` structure -/
 instance to_non_assoc_semiring : non_assoc_semiring s :=
-{ mul_zero := λ x, subtype.eq $ mul_zero x,
-  zero_mul := λ x, subtype.eq $ zero_mul x,
-  right_distrib := λ x y z, subtype.eq $ right_distrib x y z,
-  left_distrib := λ x y z, subtype.eq $ left_distrib x y z,
-  .. submonoid_class.to_mul_one_class s,
-  .. add_submonoid_class.to_add_comm_monoid s }
+subtype.coe_injective.non_assoc_semiring coe rfl rfl (λ _ _, rfl) (λ _ _, rfl)
 
 instance nontrivial [nontrivial R] : nontrivial s :=
 nontrivial_of_ne 0 1 $ λ H, zero_ne_one (congr_arg subtype.val H)
@@ -77,8 +72,7 @@ omit hSR
 
 /-- A subsemiring of a `semiring` is a `semiring`. -/
 instance to_semiring {R} [semiring R] [set_like S R] [subsemiring_class S R] : semiring s :=
-{ ..subsemiring_class.to_non_assoc_semiring s,
-  ..submonoid_class.to_monoid s }
+subtype.coe_injective.semiring coe rfl rfl (λ _ _, rfl) (λ _ _, rfl)
 
 @[simp, norm_cast] lemma coe_pow {R} [semiring R] [set_like S R] [subsemiring_class S R]
   (x : s) (n : ℕ) :
@@ -92,7 +86,7 @@ end
 /-- A subsemiring of a `comm_semiring` is a `comm_semiring`. -/
 instance to_comm_semiring {R} [comm_semiring R] [set_like S R] [subsemiring_class S R] :
   comm_semiring s :=
-{ mul_comm := λ _ _, subtype.eq $ mul_comm _ _, .. subsemiring_class.to_semiring s }
+subtype.coe_injective.comm_semiring coe rfl rfl (λ _ _, rfl) (λ _ _, rfl)
 
 /-- A subsemiring of an `ordered_semiring` is an `ordered_semiring`. -/
 instance to_ordered_semiring {R} [ordered_semiring R] [set_like S R] [subsemiring_class S R] :

--- a/src/ring_theory/subsemiring/basic.lean
+++ b/src/ring_theory/subsemiring/basic.lean
@@ -51,6 +51,7 @@ lemma coe_nat_mem (n : ℕ) : (n : R) ∈ s :=
 by simp only [← nsmul_one, nsmul_mem, one_mem]
 
 /-- A subsemiring of a `non_assoc_semiring` inherits a `non_assoc_semiring` structure -/
+@[priority 75] -- Prefer subclasses of `non_assoc_semiring` over subclasses of `subsemiring_class`.
 instance to_non_assoc_semiring : non_assoc_semiring s :=
 subtype.coe_injective.non_assoc_semiring coe rfl rfl (λ _ _, rfl) (λ _ _, rfl)
 
@@ -71,6 +72,7 @@ def subtype : s →+* R :=
 omit hSR
 
 /-- A subsemiring of a `semiring` is a `semiring`. -/
+@[priority 75] -- Prefer subclasses of `semiring` over subclasses of `subsemiring_class`.
 instance to_semiring {R} [semiring R] [set_like S R] [subsemiring_class S R] : semiring s :=
 subtype.coe_injective.semiring coe rfl rfl (λ _ _, rfl) (λ _ _, rfl)
 

--- a/src/ring_theory/subsemiring/basic.lean
+++ b/src/ring_theory/subsemiring/basic.lean
@@ -53,7 +53,7 @@ by simp only [← nsmul_one, nsmul_mem, one_mem]
 /-- A subsemiring of a `non_assoc_semiring` inherits a `non_assoc_semiring` structure -/
 @[priority 75] -- Prefer subclasses of `non_assoc_semiring` over subclasses of `subsemiring_class`.
 instance to_non_assoc_semiring : non_assoc_semiring s :=
-subtype.coe_injective.non_assoc_semiring coe rfl rfl (λ _ _, rfl) (λ _ _, rfl)
+subtype.coe_injective.non_assoc_semiring coe rfl rfl (λ _ _, rfl) (λ _ _, rfl) (λ _ _, rfl)
 
 instance nontrivial [nontrivial R] : nontrivial s :=
 nontrivial_of_ne 0 1 $ λ H, zero_ne_one (congr_arg subtype.val H)
@@ -74,7 +74,7 @@ omit hSR
 /-- A subsemiring of a `semiring` is a `semiring`. -/
 @[priority 75] -- Prefer subclasses of `semiring` over subclasses of `subsemiring_class`.
 instance to_semiring {R} [semiring R] [set_like S R] [subsemiring_class S R] : semiring s :=
-subtype.coe_injective.semiring coe rfl rfl (λ _ _, rfl) (λ _ _, rfl)
+subtype.coe_injective.semiring coe rfl rfl (λ _ _, rfl) (λ _ _, rfl) (λ _ _, rfl) (λ _ _, rfl)
 
 @[simp, norm_cast] lemma coe_pow {R} [semiring R] [set_like S R] [subsemiring_class S R]
   (x : s) (n : ℕ) :
@@ -88,22 +88,25 @@ end
 /-- A subsemiring of a `comm_semiring` is a `comm_semiring`. -/
 instance to_comm_semiring {R} [comm_semiring R] [set_like S R] [subsemiring_class S R] :
   comm_semiring s :=
-subtype.coe_injective.comm_semiring coe rfl rfl (λ _ _, rfl) (λ _ _, rfl)
+subtype.coe_injective.comm_semiring coe rfl rfl (λ _ _, rfl) (λ _ _, rfl) (λ _ _, rfl) (λ _ _, rfl)
 
 /-- A subsemiring of an `ordered_semiring` is an `ordered_semiring`. -/
 instance to_ordered_semiring {R} [ordered_semiring R] [set_like S R] [subsemiring_class S R] :
   ordered_semiring s :=
-subtype.coe_injective.ordered_semiring coe rfl rfl (λ _ _, rfl) (λ _ _, rfl)
+subtype.coe_injective.ordered_semiring coe rfl rfl (λ _ _, rfl) (λ _ _, rfl) (λ _ _, rfl)
+  (λ _ _, rfl)
 
 /-- A subsemiring of an `ordered_comm_semiring` is an `ordered_comm_semiring`. -/
 instance to_ordered_comm_semiring {R} [ordered_comm_semiring R] [set_like S R]
   [subsemiring_class S R] : ordered_comm_semiring s :=
-subtype.coe_injective.ordered_comm_semiring coe rfl rfl (λ _ _, rfl) (λ _ _, rfl)
+subtype.coe_injective.ordered_comm_semiring coe rfl rfl (λ _ _, rfl) (λ _ _, rfl) (λ _ _, rfl)
+  (λ _ _, rfl)
 
 /-- A subsemiring of a `linear_ordered_semiring` is a `linear_ordered_semiring`. -/
 instance to_linear_ordered_semiring {R} [linear_ordered_semiring R] [set_like S R]
   [subsemiring_class S R] : linear_ordered_semiring s :=
-subtype.coe_injective.linear_ordered_semiring coe rfl rfl (λ _ _, rfl) (λ _ _, rfl)
+subtype.coe_injective.linear_ordered_semiring coe rfl rfl (λ _ _, rfl) (λ _ _, rfl) (λ _ _, rfl)
+  (λ _ _, rfl)
 
 /-! Note: currently, there is no `linear_ordered_comm_semiring`. -/
 

--- a/src/ring_theory/trace.lean
+++ b/src/ring_theory/trace.lean
@@ -239,8 +239,7 @@ lemma trace_gen_eq_sum_roots (x : L)
   algebra_map K F (trace K K⟮x⟯ (adjoin_simple.gen K x)) =
     ((minpoly K x).map (algebra_map K F)).roots.sum :=
 begin
-  have injKKx : function.injective (algebra_map K K⟮x⟯) := ring_hom.injective _,
-  have injKxL : function.injective (algebra_map K⟮x⟯ L) := ring_hom.injective _,
+  have injKxL := (algebra_map K⟮x⟯ L).injective,
   by_cases hx : is_integral K x, swap,
   { simp [minpoly.eq_zero hx, trace_gen_eq_zero hx], },
   have hx' : is_integral K (adjoin_simple.gen K x),

--- a/src/tactic/lint/type_classes.lean
+++ b/src/tactic/lint/type_classes.lean
@@ -257,7 +257,7 @@ Some instances take quite some time to fail, and we seem to run against the cach
 https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/odd.20repeated.20type.20class.20search
 -/
 @[linter] meta def linter.fails_quickly : linter :=
-{ test := fails_quickly 15000,
+{ test := fails_quickly 20000,
   auto_decls := tt,
   no_errors_found := "No type-class searches timed out.",
   errors_found := "TYPE CLASS SEARCHES TIMED OUT.


### PR DESCRIPTION
The next part of my big refactoring plans: subobject classes in the same style as morphism classes.

This PR introduces the following subclasses of `set_like`:
 * `one_mem_class`, `zero_mem_class`, `mul_mem_class`, `add_mem_class`, `inv_mem_class`, `neg_mem_class`
 * `submonoid_class`, `add_submonoid_class`
 * `subgroup_class`, `add_subgroup_class`
 * `subsemiring_class`, `subring_class`, `subfield_class`

The main purpose of this refactor is that we can replace the wide variety of lemmas like `{add_submonoid,add_subgroup,subring,subfield,submodule,subwhatever}.{prod,sum}_mem` with a single `prod_mem` lemma that is generic over all types `B` that extend `submonoid`:

```lean
@[to_additive]
lemma prod_mem {M : Type*} [comm_monoid M] [set_like B M] [submonoid_class B M]
  {ι : Type*} {t : finset ι} {f : ι → M} (h : ∀c ∈ t, f c ∈ S) : ∏ c in t, f c ∈ S
```

## API changes

 * When you extend a `struct subobject`, make sure to create a corresponding `subobject_class` instance.

## Upcoming PRs
This PR splits out the first part of #11545, namely defining the subobject classes. I am planning these follow-up PRs for further parts of #11545:

 - [x] make the subobject consistently implicit in `{add,mul}_mem` #11758
 - [ ] remove duplicate instances like `subgroup.to_group` (replaced by the `subgroup_class.to_subgroup` instances that are added by this PR) #11759
 - [ ] further deduplication such as `finsupp_sum_mem`

## Subclassing `set_like`

Contrary to mathlib's typical subclass pattern, we don't extend `set_like`, but take a `set_like` instance parameter:
```lean
class one_mem_class (S : Type*) (M : out_param $ Type*) [has_one M] [set_like S M] :=
(one_mem : ∀ (s : S), (1 : M) ∈ s)
```
instead of:
```lean
class one_mem_class (S : Type*) (M : out_param $ Type*) [has_one M]
  extends set_like S M :=
(one_mem : ∀ (s : S), (1 : M) ∈ s)
```
The main reason is that this avoids some big defeq checks when typechecking e.g. `x * y : s`, where `s : S` and `[comm_group G] [subgroup_class S G]`. Namely, the type `coe_sort s` could be given by `subgroup_class → @@submonoid_class _ _ (comm_group.to_group.to_monoid) → set_like → has_coe_to_sort` or by `subgroup_class → @@submonoid_class _ _ (comm_group.to_comm_monoid.to_monoid) → set_like → has_coe_to_sort`. When checking that `has_mul` on the first type is the same as `has_mul` on the second type, those two inheritance paths are unified many times over ([sometimes exponentially many](https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/Why.20is.20.60int.2Ecast_abs.60.20so.20slow.3F/near/266945077)). So it's important to keep the size of types small, and therefore we avoid `extends`-based inheritance.

## Defeq fixes

Adding instances like `subgroup_class.to_group` means that there are now two (defeq) group instances for `subgroup`. This makes some code more fragile, until we can replace `subgroup.to_group` with its more generic form in a follow-up PR. Especially when taking subgroups of subgroups I needed to help the elaborator in a few places. These should be minimally invasive for other uses of the code.

## Timeout fixes

Some of the leaf files started timing out, so I made a couple of fixes. Generally these can be classed as:
 * `squeeze_simps`
 * Give inheritance `subX_class S M` → `X s` (where `s : S`) a lower prority than `Y s` → `X s` so that `subY_class S M` → `Y s` → `X s` is preferred over `subY_class S M` → `subX_class S M` → `X s`. This addresses slow unifications when `x : s`, `s` is a submonoid of `t`, which is itself a subgroup of `G`: existing code expects to go `subgroup → group → monoid`, which got changed to `subgroup_class → submonoid_class → monoid`; when this kind of unification issue appears in your type this results in slow unification. By tweaking the priorities, we help the elaborator find our preferred instance, avoiding the big defeq checks. (The real fix should of course be to fix the unifier so it doesn't become exponential in these kinds of cases.)
 * Split a long proof with duplication into smaller parts. This was basically my last resort.


I decided to bump the limit for the `fails_quickly` linter for `measure_theory.Lp_meas.complete_space`, which apparently just barely goes over this limit now. The time difference was about 10%-20% for that specific instance.

---

- [x] depends on: #11773
- [x] depends on: #12209 

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
