### PR TITLE
[Merged by Bors] - feat(topology/algebra/ordered/monotone_convergence): add `antitone.{ge,le}_of_tendsto`

### DIFF
--- a/src/topology/algebra/ordered/monotone_convergence.lean
+++ b/src/topology/algebra/ordered/monotone_convergence.lean
@@ -250,19 +250,19 @@ lemma monotone.le_of_tendsto [topological_space α] [preorder α] [order_closed_
   [semilattice_inf β] {f : β → α} {a : α} (hf : monotone f)
   (ha : tendsto f at_bot (𝓝 a)) (b : β) :
   a ≤ f b :=
-monotone.ge_of_tendsto hf.dual ha b
+hf.dual.ge_of_tendsto ha b
 
 lemma antitone.le_of_tendsto [topological_space α] [preorder α] [order_closed_topology α]
   [semilattice_sup β] {f : β → α} {a : α} (hf : antitone f)
   (ha : tendsto f at_top (𝓝 a)) (b : β) :
   a ≤ f b :=
-monotone.ge_of_tendsto hf.dual_right ha b
+hf.dual_right.ge_of_tendsto ha b
 
 lemma antitone.ge_of_tendsto [topological_space α] [preorder α] [order_closed_topology α]
   [semilattice_inf β] {f : β → α} {a : α} (hf : antitone f)
   (ha : tendsto f at_bot (𝓝 a)) (b : β) :
   f b ≤ a :=
-monotone.le_of_tendsto hf.dual_right ha b
+hf.dual_right.le_of_tendsto ha b
 
 lemma is_lub_of_tendsto_at_top [topological_space α] [preorder α] [order_closed_topology α]
   [nonempty β] [semilattice_sup β] {f : β → α} {a : α} (hf : monotone f)

--- a/src/topology/algebra/ordered/monotone_convergence.lean
+++ b/src/topology/algebra/ordered/monotone_convergence.lean
@@ -250,7 +250,7 @@ lemma monotone.le_of_tendsto [topological_space α] [preorder α] [order_closed_
   [semilattice_inf β] {f : β → α} {a : α} (hf : monotone f)
   (ha : tendsto f at_bot (𝓝 a)) (b : β) :
   a ≤ f b :=
-@monotone.ge_of_tendsto (order_dual α) (order_dual β) _ _ _ _ f _ hf.dual ha b
+monotone.ge_of_tendsto hf.dual ha b
 
 lemma antitone.le_of_tendsto [topological_space α] [preorder α] [order_closed_topology α]
   [semilattice_sup β] {f : β → α} {a : α} (hf : antitone f)

--- a/src/topology/algebra/ordered/monotone_convergence.lean
+++ b/src/topology/algebra/ordered/monotone_convergence.lean
@@ -252,6 +252,18 @@ lemma monotone.le_of_tendsto [topological_space α] [preorder α] [order_closed_
   a ≤ f b :=
 @monotone.ge_of_tendsto (order_dual α) (order_dual β) _ _ _ _ f _ hf.dual ha b
 
+lemma antitone.le_of_tendsto [topological_space α] [preorder α] [order_closed_topology α]
+  [semilattice_sup β] {f : β → α} {a : α} (hf : antitone f)
+  (ha : tendsto f at_top (𝓝 a)) (b : β) :
+  a ≤ f b :=
+monotone.ge_of_tendsto hf.dual_right ha b
+
+lemma antitone.ge_of_tendsto [topological_space α] [preorder α] [order_closed_topology α]
+  [semilattice_inf β] {f : β → α} {a : α} (hf : antitone f)
+  (ha : tendsto f at_bot (𝓝 a)) (b : β) :
+  f b ≤ a :=
+monotone.le_of_tendsto hf.dual_right ha b
+
 lemma is_lub_of_tendsto_at_top [topological_space α] [preorder α] [order_closed_topology α]
   [nonempty β] [semilattice_sup β] {f : β → α} {a : α} (hf : monotone f)
   (ha : tendsto f at_top (𝓝 a)) :


### PR DESCRIPTION

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

If merged, this will be used to remove a redundant `nonneg` requirement from the alternating series test in #11689. I wrote a short version using implicit parameters, and changed the existing proof term as well to be consistent. If there was a reason for `@monotone`, let me know and I'll change it back.

r? @YaelDillies 

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
