### PR TITLE
[Merged by Bors] - feat(set_theory/{ordinal_arithmetic, cardinal_ordinal}): Ordinals aren't a small type

### DIFF
--- a/src/set_theory/cardinal_ordinal.lean
+++ b/src/set_theory/cardinal_ordinal.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl, Mario Carneiro, Floris van Doorn
 -/
 
-import logic.small
 import set_theory.ordinal_arithmetic
 import tactic.linarith
 import order.bounded
@@ -912,25 +911,3 @@ le_refl _
 end bit
 
 end cardinal
-
-lemma not_injective_of_ordinal {α : Type u} (f : ordinal.{u} → α) :
-  ¬ function.injective f :=
-begin
-  let g : ordinal.{u} → ulift.{u+1} α := λ o, ulift.up (f o),
-  suffices : ¬ function.injective g,
-  { intro hf, exact this (equiv.ulift.symm.injective.comp hf) },
-  intro hg,
-  replace hg := cardinal.mk_le_of_injective hg,
-  rw cardinal.mk_ulift at hg,
-  have := hg.trans_lt (cardinal.lift_lt_univ _),
-  rw cardinal.univ_id at this,
-  exact lt_irrefl _ this
-end
-
-lemma not_injective_of_ordinal_of_small {α : Type v} [small.{u} α] (f : ordinal.{u} → α) :
-  ¬ function.injective f :=
-begin
-  intro hf,
-  apply not_injective_of_ordinal (equiv_shrink α ∘ f),
-  exact (equiv_shrink _).injective.comp hf,
-end

--- a/src/set_theory/ordinal_arithmetic.lean
+++ b/src/set_theory/ordinal_arithmetic.lean
@@ -1206,6 +1206,8 @@ begin
   exact (lt_blsub.{u u} (λ x _, x) _ h).false
 end
 
+end ordinal
+
 /-! ### Results about injectivity and surjectivity -/
 
 lemma not_surjective_of_ordinal {α : Type u} (f : α → ordinal.{u}) : ¬ function.surjective f :=
@@ -1222,10 +1224,14 @@ lemma not_injective_of_ordinal_of_small {α : Type v} [small.{u} α] (f : ordina
   ¬ function.injective f :=
 λ h, not_injective_of_ordinal _ ((equiv_shrink _).injective.comp h)
 
+/-- The type of ordinals in universe `u` is not `small.{u}`. This is the type-theoretic analog of
+the Burali-Forti paradox. -/
 theorem not_small_ordinal : ¬ small.{u} ordinal.{max u v} :=
-λ h, @not_injective_of_ordinal_of_small _ h _ (λ a b, lift_inj.1)
+λ h, @not_injective_of_ordinal_of_small _ h _ (λ a b, ordinal.lift_inj.1)
 
 /-! ### Enumerating unbounded sets of ordinals with ordinals -/
+
+namespace ordinal
 
 section
 variables {S : set ordinal.{u}} (hS : unbounded (<) S)

--- a/src/set_theory/ordinal_arithmetic.lean
+++ b/src/set_theory/ordinal_arithmetic.lean
@@ -1223,7 +1223,7 @@ lemma not_injective_of_ordinal_of_small {α : Type v} [small.{u} α] (f : ordina
 λ h, not_injective_of_ordinal _ ((equiv_shrink _).injective.comp h)
 
 theorem not_small_ordinal : ¬ small.{u} ordinal.{max u v} :=
-λ h, @not_injective_of_ordinal_of_small _ h ordinal.lift.{v u} (λ a b h, lift_inj.1 h)
+λ h, @not_injective_of_ordinal_of_small _ h ordinal.lift (λ a b, lift_inj.1)
 
 /-! ### Enumerating unbounded sets of ordinals with ordinals -/
 

--- a/src/set_theory/ordinal_arithmetic.lean
+++ b/src/set_theory/ordinal_arithmetic.lean
@@ -1231,7 +1231,7 @@ section
 variables {S : set ordinal.{u}} (hS : unbounded (<) S)
 
 -- A characterization of unboundedness that's more convenient to our purposes.
-private lemma unbounded_aux (hS : unbounded (<) S) (a) : ∃ b, b ∈ S ∧ a ≤ b :=
+private lemma unbounded_aux (a) : ∃ b, b ∈ S ∧ a ≤ b :=
 let ⟨b, hb, hb'⟩ := hS a in ⟨b, hb, le_of_not_gt hb'⟩
 
 /-- Enumerator function for an unbounded set of ordinals. -/

--- a/src/set_theory/ordinal_arithmetic.lean
+++ b/src/set_theory/ordinal_arithmetic.lean
@@ -3,6 +3,7 @@ Copyright (c) 2017 Johannes Hölzl. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro, Floris van Doorn, Violeta Hernández Palacios
 -/
+import logic.small
 import set_theory.ordinal
 import tactic.by_contra
 
@@ -1112,6 +1113,9 @@ begin
   exact this.false
 end
 
+theorem lsub_nmem_range {ι} (f : ι → ordinal) : lsub f ∉ set.range f :=
+λ ⟨i, h⟩, h.not_lt (lt_lsub f i)
+
 /-- The bounded least strict upper bound of a family of ordinals. -/
 def blsub (o : ordinal.{u}) (f : Π a < o, ordinal.{max u v}) : ordinal.{max u v} :=
 o.bsup (λ a ha, (f a ha).succ)
@@ -1201,6 +1205,22 @@ begin
   by_contra' h,
   exact (lt_blsub.{u u} (λ x _, x) _ h).false
 end
+
+/-! ### Lemmas about injectivity and surjectivity -/
+
+lemma not_surjective_of_ordinal {α : Type u} (f : α → ordinal.{u}) : ¬ function.surjective f :=
+λ h, ordinal.lsub_nmem_range.{u u} f (h _)
+
+lemma not_injective_of_ordinal {α : Type u} (f : ordinal.{u} → α) : ¬ function.injective f :=
+λ h, not_surjective_of_ordinal _ (inv_fun_surjective h)
+
+lemma not_surjective_of_ordinal_of_small {α : Type v} [small.{u} α] (f : α → ordinal.{u}) :
+  ¬ function.surjective f :=
+λ h, not_surjective_of_ordinal (f ∘ (equiv_shrink α).symm) (h.comp (equiv_shrink _).symm.surjective)
+
+lemma not_injective_of_ordinal_of_small {α : Type v} [small.{u} α] (f : ordinal.{u} → α) :
+  ¬ function.injective f :=
+λ h, not_injective_of_ordinal (equiv_shrink α ∘ f) ((equiv_shrink _).injective.comp h)
 
 /-! ### Enumerating unbounded sets of ordinals with ordinals -/
 

--- a/src/set_theory/ordinal_arithmetic.lean
+++ b/src/set_theory/ordinal_arithmetic.lean
@@ -1231,7 +1231,7 @@ section
 variables {S : set ordinal.{u}} (hS : unbounded (<) S)
 
 -- A characterization of unboundedness that's more convenient to our purposes.
-private lemma unbounded_aux (a) : ∃ b, b ∈ S ∧ a ≤ b :=
+private lemma unbounded_aux (hS : unbounded (<) S) (a) : ∃ b, b ∈ S ∧ a ≤ b :=
 let ⟨b, hb, hb'⟩ := hS a in ⟨b, hb, le_of_not_gt hb'⟩
 
 /-- Enumerator function for an unbounded set of ordinals. -/

--- a/src/set_theory/ordinal_arithmetic.lean
+++ b/src/set_theory/ordinal_arithmetic.lean
@@ -1206,7 +1206,7 @@ begin
   exact (lt_blsub.{u u} (λ x _, x) _ h).false
 end
 
-/-! ### Lemmas about injectivity and surjectivity -/
+/-! ### Results about injectivity and surjectivity -/
 
 lemma not_surjective_of_ordinal {α : Type u} (f : α → ordinal.{u}) : ¬ function.surjective f :=
 λ h, ordinal.lsub_nmem_range.{u u} f (h _)
@@ -1221,6 +1221,9 @@ lemma not_surjective_of_ordinal_of_small {α : Type v} [small.{u} α] (f : α �
 lemma not_injective_of_ordinal_of_small {α : Type v} [small.{u} α] (f : ordinal.{u} → α) :
   ¬ function.injective f :=
 λ h, not_injective_of_ordinal _ ((equiv_shrink _).injective.comp h)
+
+theorem not_small_ordinal : ¬ small.{u} ordinal.{max u v} :=
+λ h, @not_injective_of_ordinal_of_small _ h ordinal.lift.{v u} (λ a b h, lift_inj.1 h)
 
 /-! ### Enumerating unbounded sets of ordinals with ordinals -/
 

--- a/src/set_theory/ordinal_arithmetic.lean
+++ b/src/set_theory/ordinal_arithmetic.lean
@@ -1216,11 +1216,11 @@ lemma not_injective_of_ordinal {α : Type u} (f : ordinal.{u} → α) : ¬ funct
 
 lemma not_surjective_of_ordinal_of_small {α : Type v} [small.{u} α] (f : α → ordinal.{u}) :
   ¬ function.surjective f :=
-λ h, not_surjective_of_ordinal (f ∘ (equiv_shrink α).symm) (h.comp (equiv_shrink _).symm.surjective)
+λ h, not_surjective_of_ordinal _ (h.comp (equiv_shrink _).symm.surjective)
 
 lemma not_injective_of_ordinal_of_small {α : Type v} [small.{u} α] (f : ordinal.{u} → α) :
   ¬ function.injective f :=
-λ h, not_injective_of_ordinal (equiv_shrink α ∘ f) ((equiv_shrink _).injective.comp h)
+λ h, not_injective_of_ordinal _ ((equiv_shrink _).injective.comp h)
 
 /-! ### Enumerating unbounded sets of ordinals with ordinals -/
 

--- a/src/set_theory/ordinal_arithmetic.lean
+++ b/src/set_theory/ordinal_arithmetic.lean
@@ -1223,7 +1223,7 @@ lemma not_injective_of_ordinal_of_small {α : Type v} [small.{u} α] (f : ordina
 λ h, not_injective_of_ordinal _ ((equiv_shrink _).injective.comp h)
 
 theorem not_small_ordinal : ¬ small.{u} ordinal.{max u v} :=
-λ h, @not_injective_of_ordinal_of_small _ h ordinal.lift (λ a b, lift_inj.1)
+λ h, @not_injective_of_ordinal_of_small _ h lift (λ a b, lift_inj.1)
 
 /-! ### Enumerating unbounded sets of ordinals with ordinals -/
 

--- a/src/set_theory/ordinal_arithmetic.lean
+++ b/src/set_theory/ordinal_arithmetic.lean
@@ -1223,7 +1223,7 @@ lemma not_injective_of_ordinal_of_small {α : Type v} [small.{u} α] (f : ordina
 λ h, not_injective_of_ordinal _ ((equiv_shrink _).injective.comp h)
 
 theorem not_small_ordinal : ¬ small.{u} ordinal.{max u v} :=
-λ h, @not_injective_of_ordinal_of_small _ h lift (λ a b, lift_inj.1)
+λ h, @not_injective_of_ordinal_of_small _ h _ (λ a b, lift_inj.1)
 
 /-! ### Enumerating unbounded sets of ordinals with ordinals -/
 


### PR DESCRIPTION
We substantially golf and extend some results previously in `cardinal_ordinal.lean`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
