### PR TITLE
[Merged by Bors] - chore(algebra/ne_zero): revert transitivity changes

### DIFF
--- a/src/algebra/ne_zero.lean
+++ b/src/algebra/ne_zero.lean
@@ -33,7 +33,7 @@ by simp [ne_zero_iff]
 
 namespace ne_zero
 
-variables {R S M F : Type*} {r : R} {x y : M} {n p : ℕ} {a : ℕ+}
+variables {R M F : Type*} {r : R} {x y : M} {n p : ℕ} {a : ℕ+}
 
 instance pnat : ne_zero (a : ℕ) := ⟨a.ne_zero⟩
 instance succ : ne_zero (n + 1) := ⟨n.succ_ne_zero⟩
@@ -46,12 +46,6 @@ instance char_zero [ne_zero n] [add_monoid M] [has_one M] [char_zero M] : ne_zer
 
 @[priority 100] instance invertible [monoid_with_zero M] [nontrivial M] [invertible x] :
   ne_zero x := ⟨nonzero_of_invertible x⟩
-
-instance coe_trans {r : R} [has_zero M] [has_coe R S] [has_coe_t S M] [h : ne_zero (r : M)] :
-  ne_zero ((r : S) : M) := ⟨h.out⟩
-
-lemma trans {r : R} [has_zero M] [has_coe R S] [has_coe_t S M] (h : ne_zero ((r : S) : M)) :
-  ne_zero (r : M) := ⟨h.out⟩
 
 lemma of_map [has_zero R] [has_zero M] [zero_hom_class F R M] (f : F) [ne_zero (f r)] :
   ne_zero r := ⟨λ h, ne (f r) $ by convert map_zero f⟩

--- a/src/algebra/ne_zero.lean
+++ b/src/algebra/ne_zero.lean
@@ -33,7 +33,7 @@ by simp [ne_zero_iff]
 
 namespace ne_zero
 
-variables {R M F : Type*} {r : R} {x y : M} {n p : ℕ} {a : ℕ+}
+variables {R S M F : Type*} {r : R} {x y : M} {n p : ℕ} {a : ℕ+}
 
 instance pnat : ne_zero (a : ℕ) := ⟨a.ne_zero⟩
 instance succ : ne_zero (n + 1) := ⟨n.succ_ne_zero⟩
@@ -46,6 +46,12 @@ instance char_zero [ne_zero n] [add_monoid M] [has_one M] [char_zero M] : ne_zer
 
 @[priority 100] instance invertible [monoid_with_zero M] [nontrivial M] [invertible x] :
   ne_zero x := ⟨nonzero_of_invertible x⟩
+
+instance coe_trans {r : R} [has_zero M] [has_coe R S] [has_coe_t S M] [h : ne_zero (r : M)] :
+  ne_zero ((r : S) : M) := ⟨h.out⟩
+
+lemma trans {r : R} [has_zero M] [has_coe R S] [has_coe_t S M] (h : ne_zero ((r : S) : M)) :
+  ne_zero (r : M) := ⟨h.out⟩
 
 lemma of_map [has_zero R] [has_zero M] [zero_hom_class F R M] (f : F) [ne_zero (f r)] :
   ne_zero r := ⟨λ h, ne (f r) $ by convert map_zero f⟩

--- a/src/number_theory/cyclotomic/basic.lean
+++ b/src/number_theory/cyclotomic/basic.lean
@@ -41,9 +41,9 @@ primitive roots of unity, for all `n ∈ S`.
 * `is_cyclotomic_extension.number_field` : a finite cyclotomic extension of a number field is a
   number field.
 * `is_cyclotomic_extension.splitting_field_X_pow_sub_one` : if `is_cyclotomic_extension {n} K L`
-  and `ne_zero (n : K)`, then `L` is the splitting field of `X ^ n - 1`.
+  and `ne_zero ((n : ℕ) : K)`, then `L` is the splitting field of `X ^ n - 1`.
 * `is_cyclotomic_extension.splitting_field_cyclotomic` : if `is_cyclotomic_extension {n} K L`
-  and `ne_zero (n : K)`, then `L` is the splitting field of `cyclotomic n K`.
+  and `ne_zero ((n : ℕ) : K)`, then `L` is the splitting field of `cyclotomic n K`.
 
 ## Implementation details
 
@@ -282,7 +282,7 @@ end
 
 section field
 
-variable [ne_zero (n : K)]
+variable [ne_zero ((n : ℕ) : K)]
 
 /-- A cyclotomic extension splits `X ^ n - 1` if `n ∈ S` and `ne_zero (n : K)`.-/
 lemma splits_X_pow_sub_one [H : is_cyclotomic_extension S K L] (hS : n ∈ S) :
@@ -310,7 +310,7 @@ section singleton
 
 variables [is_cyclotomic_extension {n} K L]
 
-/-- If `is_cyclotomic_extension {n} K L` and `ne_zero (n : K)`, then `L` is the splitting
+/-- If `is_cyclotomic_extension {n} K L` and `ne_zero ((n : ℕ) : K)`, then `L` is the splitting
 field of `X ^ n - 1`. -/
 lemma splitting_field_X_pow_sub_one : is_splitting_field K L (X ^ (n : ℕ) - 1) :=
 { splits := splits_X_pow_sub_one n {n} K L (mem_singleton n),
@@ -334,7 +334,7 @@ begin
     (ne_zero.ne _ : ((n : ℕ) : K) ≠ 0)),
 end
 
-/-- If `is_cyclotomic_extension {n} K L` and `ne_zero (n : K)`, then `L` is the splitting
+/-- If `is_cyclotomic_extension {n} K L` and `ne_zero ((n : ℕ) : K)`, then `L` is the splitting
 field of `cyclotomic n K`. -/
 lemma splitting_field_cyclotomic : is_splitting_field K L (cyclotomic n K) :=
 { splits := splits_cyclotomic n {n} K L (mem_singleton n),
@@ -364,7 +364,7 @@ def cyclotomic_field : Type w := (cyclotomic n K).splitting_field
 
 namespace cyclotomic_field
 
-instance is_cyclotomic_extension [ne_zero (n : K)] :
+instance is_cyclotomic_extension [ne_zero ((n : ℕ) : K)] :
   is_cyclotomic_extension {n} K (cyclotomic_field n K) :=
 { exists_root := λ a han,
   begin
@@ -378,7 +378,7 @@ instance is_cyclotomic_extension [ne_zero (n : K)] :
     letI := classical.dec_eq (cyclotomic_field n K),
     obtain ⟨ζ, hζ⟩ := exists_root_of_splits _ (splitting_field.splits (cyclotomic n K))
       (degree_cyclotomic_pos n _ n.pos).ne',
-    haveI : ne_zero ((n : ℕ) : cyclotomic_field n K) :=
+    haveI : ne_zero ((n : ℕ) : (cyclotomic_field n K)) :=
       ne_zero.nat_of_injective (algebra_map K _).injective,
     rw [eval₂_eq_eval_map, map_cyclotomic, ← is_root.def, is_root_cyclotomic_iff] at hζ,
     exact is_cyclotomic_extension.adjoin_roots_cyclotomic_eq_adjoin_nth_roots n hζ,
@@ -438,15 +438,15 @@ no_zero_smul_divisors.of_algebra_map_injective (adjoin_algebra_injective n A K)
 instance : is_scalar_tower A (cyclotomic_ring n A K) (cyclotomic_field n K) :=
 is_scalar_tower.subalgebra' _ _ _ _
 
-instance is_cyclotomic_extension [ne_zero (n : A)] :
+instance is_cyclotomic_extension [ne_zero ((n : ℕ) : A)] :
   is_cyclotomic_extension {n} A (cyclotomic_ring n A K) :=
 { exists_root := λ a han,
   begin
     rw mem_singleton_iff at han,
     subst a,
-    haveI := (ne_zero.of_no_zero_smul_divisors A K n).trans,
-    haveI := (ne_zero.of_no_zero_smul_divisors A (cyclotomic_ring n A K) n).trans,
-    haveI := (ne_zero.of_no_zero_smul_divisors A (cyclotomic_field n K) n).trans,
+    haveI := ne_zero.of_no_zero_smul_divisors A K n,
+    haveI := ne_zero.of_no_zero_smul_divisors A (cyclotomic_ring n A K) n,
+    haveI := ne_zero.of_no_zero_smul_divisors A (cyclotomic_field n K) n,
     obtain ⟨μ, hμ⟩ := let h := (cyclotomic_field.is_cyclotomic_extension n K).exists_root
                       in h $ mem_singleton n,
     refine ⟨⟨μ, subset_adjoin _⟩, _⟩,
@@ -468,7 +468,8 @@ instance is_cyclotomic_extension [ne_zero (n : A)] :
     { exact subalgebra.mul_mem _ hy hz },
   end }
 
-instance [ne_zero (n : A)] : is_fraction_ring (cyclotomic_ring n A K) (cyclotomic_field n K) :=
+instance [ne_zero ((n : ℕ) : A)] :
+  is_fraction_ring (cyclotomic_ring n A K) (cyclotomic_field n K) :=
 { map_units := λ ⟨x, hx⟩, begin
     rw is_unit_iff_ne_zero,
     apply ring_hom.map_ne_zero_of_mem_non_zero_divisors,
@@ -477,7 +478,7 @@ instance [ne_zero (n : A)] : is_fraction_ring (cyclotomic_ring n A K) (cyclotomi
   end,
   surj := λ x,
   begin
-    letI : ne_zero (n : K) := (ne_zero.nat_of_injective (is_fraction_ring.injective A K)).trans,
+    letI : ne_zero ((n : ℕ) : K) := ne_zero.nat_of_injective (is_fraction_ring.injective A K),
     refine algebra.adjoin_induction (((is_cyclotomic_extension.iff_singleton n K _).1
       (cyclotomic_field.is_cyclotomic_extension n K)).2 x) (λ y hy, _) (λ k, _) _ _,
     { exact ⟨⟨⟨y, subset_adjoin hy⟩, 1⟩, by simpa⟩ },

--- a/src/number_theory/cyclotomic/zeta.lean
+++ b/src/number_theory/cyclotomic/zeta.lean
@@ -17,13 +17,13 @@ assumptions) a primitive `n`-root of unity in `B` and we study its properties.
 * `is_cyclotomic_extension.zeta n A B` : if `is_cyclotomic_extension {n} A B`, than `zeta n A B`
   is an element of `B` that plays the role of a primitive `n`-th root of unity.
 * `is_cyclotomic_extension.zeta.power_basis` : if `K` and `L` are fields such that
-  `is_cyclotomic_extension {n} K L` and `ne_zero (n : K)`, then `zeta.power_basis` is the
+  `is_cyclotomic_extension {n} K L` and `ne_zero (↑n : K)`, then `zeta.power_basis` is the
   power basis given by `zeta n K L`.
 * `is_cyclotomic_extension.zeta.embeddings_equiv_primitive_roots` : the equiv between `L →ₐ[K] A`
   and `primitive_roots n A` given by the choice of `zeta`.
 
 ## Main results
-* `is_cyclotomic_extension.zeta_primitive_root` : if `is_domain B` and `ne_zero (n : B)` then
+* `is_cyclotomic_extension.zeta_primitive_root` : if `is_domain B` and `ne_zero (↑n : B)` then
   `zeta n A B` is a primitive `n`-th root of unity.
 * `is_cyclotomic_extension.finrank` : if `irreducible (cyclotomic n K)` (in particular for
   `K = ℚ`), then the `finrank` of a cyclotomic extension is `n.totient`.
@@ -33,7 +33,7 @@ assumptions) a primitive `n`-root of unity in `B` and we study its properties.
 ## Implementation details
 `zeta n A B` is defined as any root of `cyclotomic n A` in `B`, that exists because of
 `is_cyclotomic_extension {n} A B`. It is not true in general that it is a primitive `n`-th root of
-unity, but this holds if `is_domain B` and `ne_zero (n : B)`.
+unity, but this holds if `is_domain B` and `ne_zero (↑n : B)`.
 
 -/
 
@@ -61,9 +61,9 @@ by { convert zeta_spec n A B, rw [is_root.def, aeval_def, eval₂_eq_eval_map, m
 lemma zeta_pow : (zeta n A B) ^ (n : ℕ) = 1 :=
 is_root_of_unity_of_root_cyclotomic (nat.mem_divisors_self _ n.pos.ne') (zeta_spec' _ _ _)
 
-/-- If `is_domain B` and `ne_zero (n : B)` then `zeta n A B` is a primitive `n`-th root of
+/-- If `is_domain B` and `ne_zero (↑n : B)` then `zeta n A B` is a primitive `n`-th root of
 unity. -/
-lemma zeta_primitive_root [is_domain B] [ne_zero (n : B)] :
+lemma zeta_primitive_root [is_domain B] [ne_zero ((n : ℕ) : B)] :
   is_primitive_root (zeta n A B) n :=
 by { rw ←is_root_cyclotomic_iff, exact zeta_spec' n A B }
 
@@ -71,7 +71,7 @@ section field
 
 variables {K : Type u} (L : Type v) (C : Type w)
 variables [field K] [field L] [comm_ring C] [algebra K L] [algebra K C]
-variables [is_cyclotomic_extension {n} K L] [ne_zero (n : K)]
+variables [is_cyclotomic_extension {n} K L] [ne_zero ((n : ℕ) : K)]
 
 /-- If `irreducible (cyclotomic n K)`, then the minimal polynomial of `zeta n K A` is
 `cyclotomic n K`. -/
@@ -86,8 +86,9 @@ variable (K)
 /-- The `power_basis` given by `zeta n K L`. -/
 @[simps] def zeta.power_basis : power_basis K L :=
 begin
-  haveI := (ne_zero.of_no_zero_smul_divisors K L n).trans,
-  refine power_basis.map (adjoin.power_basis $ integral {n} K L $ zeta n K L) _,
+  haveI := ne_zero.of_no_zero_smul_divisors K L n,
+  refine power_basis.map
+    (algebra.adjoin.power_basis $ integral {n} K L $ zeta n K L) _,
   exact (subalgebra.equiv_of_eq _ _
       (is_cyclotomic_extension.adjoin_primitive_root_eq_top n _ $ zeta_primitive_root n K L)).trans
       top_equiv
@@ -118,7 +119,7 @@ def zeta.embeddings_equiv_primitive_roots [is_domain C] (hirr : irreducible (cyc
 ((zeta.power_basis n K L).lift_equiv).trans
 { to_fun    := λ x,
   begin
-    haveI hn := (ne_zero.of_no_zero_smul_divisors K C n).trans,
+    haveI hn := ne_zero.of_no_zero_smul_divisors K C n,
     refine ⟨x.1, _⟩,
     cases x,
     rwa [mem_primitive_roots n.pos, ←is_root_cyclotomic_iff, is_root.def,
@@ -127,7 +128,7 @@ def zeta.embeddings_equiv_primitive_roots [is_domain C] (hirr : irreducible (cyc
   end,
   inv_fun   := λ x,
   begin
-    haveI hn := (ne_zero.of_no_zero_smul_divisors K C n).trans,
+    haveI hn := ne_zero.of_no_zero_smul_divisors K C n,
     refine ⟨x.1, _⟩,
     cases x,
     rwa [aeval_def, eval₂_eq_eval_map, zeta.power_basis_gen_minpoly L hirr, map_cyclotomic,
@@ -143,7 +144,7 @@ if `n` is odd. -/
 lemma norm_zeta_eq_one (K : Type u) [linear_ordered_field K] (L : Type v) [field L] [algebra K L]
   [is_cyclotomic_extension {n} K L] (hodd : odd (n : ℕ)) : norm K (zeta n K L) = 1 :=
 begin
-  haveI := (ne_zero.of_no_zero_smul_divisors K L n).trans,
+  haveI := ne_zero.of_no_zero_smul_divisors K L n,
   have hz := congr_arg (norm K) ((is_primitive_root.iff_def _ n).1 (zeta_primitive_root n K L)).1,
   rw [← ring_hom.map_one (algebra_map K L), norm_algebra_map, one_pow, monoid_hom.map_pow,
     ← one_pow ↑n] at hz,


### PR DESCRIPTION
The `trans` methods were a disaster for `flt-regular` - this reverts them unless a better solution can be found.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
