### PR TITLE
[Merged by Bors] - chore(linear_algebra): remove `bilinear_map` from imports in `pi`

### DIFF
--- a/src/linear_algebra/pi.lean
+++ b/src/linear_algebra/pi.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl, Mario Carneiro, Kevin Buzzard, Yury Kudryashov, Eric Wieser
 -/
 import linear_algebra.basic
-import linear_algebra.bilinear_map
 import data.equiv.fin
 
 /-!


### PR DESCRIPTION
Remove `bilinear_map` from imports in `pi`

---

I am sorry for a one-line PR, but I wanted to see whether CI complains about this.

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
