### PR TITLE
[Merged by Bors] - feat(category_theory/category/{Pointed,Bipointed}): The categories of pointed/bipointed types

### DIFF
--- a/src/category_theory/category/Bipointed.lean
+++ b/src/category_theory/category/Bipointed.lean
@@ -75,7 +75,7 @@ instance concrete_category : concrete_category Bipointed :=
 { obj := λ X, ⟨X, X.to_prod.swap⟩, map := λ X Y f, ⟨f.to_fun, f.map_snd, f.map_fst⟩ }
 
 /-- The equivalence between `Bipointed` and itself induced by `prod.swap` both ways. -/
-def swap_equiv : Bipointed ≌ Bipointed :=
+@[simps] def swap_equiv : Bipointed ≌ Bipointed :=
 equivalence.mk swap swap
   (nat_iso.of_components (λ X, { hom := ⟨id, rfl, rfl⟩, inv := ⟨id, rfl, rfl⟩ }) $ λ X Y f, rfl)
   (nat_iso.of_components (λ X, { hom := ⟨id, rfl, rfl⟩, inv := ⟨id, rfl, rfl⟩ }) $ λ X Y f, rfl)
@@ -123,3 +123,31 @@ def Pointed_to_Bipointed_snd : Pointed.{u} ⥤ Bipointed :=
 
 @[simp] lemma Pointed_to_Bipointed_snd_comp :
   Pointed_to_Bipointed_snd ⋙ Bipointed.swap = Pointed_to_Bipointed_fst := rfl
+
+/-- The free/forgetful adjunction between `Pointed_to_Bipointed_fst` and `Bipointed_to_Pointed_fst`.
+-/
+def Pointed_to_Bipointed_fst_Bipointed_to_Pointed_fst_adjunction :
+  Pointed_to_Bipointed_fst ⊣ Bipointed_to_Pointed_fst :=
+{ hom_equiv := λ X Y, { to_fun := λ f, ⟨f.to_fun ∘ option.some, f.map_fst⟩,
+                        inv_fun := λ f, ⟨λ o, o.elim Y.to_prod.2 f.to_fun, f.map_point, rfl⟩,
+                        left_inv := λ f, by { ext, cases x, exact f.map_snd.symm, refl },
+                        right_inv := λ f, Pointed.hom.ext _ _ rfl },
+  unit := { app := λ X, ⟨option.some, rfl⟩, naturality' := λ X Y f, rfl },
+  counit := { app := λ X, ⟨λ o, o.elim X.to_prod.2 id, rfl, rfl⟩,
+              naturality' := λ X Y f, by { ext, cases x, exact f.map_snd.symm, refl } },
+  hom_equiv_unit' := λ X Y f, rfl,
+  hom_equiv_counit' := λ X Y f, by { ext, cases x; refl } }
+
+/-- The free/forgetful adjunction between `Pointed_to_Bipointed_snd` and `Bipointed_to_Pointed_snd`.
+-/
+def Pointed_to_Bipointed_snd_Bipointed_to_Pointed_snd_adjunction :
+  Pointed_to_Bipointed_snd ⊣ Bipointed_to_Pointed_snd :=
+{ hom_equiv := λ X Y, { to_fun := λ f, ⟨f.to_fun ∘ option.some, f.map_snd⟩,
+                        inv_fun := λ f, ⟨λ o, o.elim Y.to_prod.1 f.to_fun, rfl, f.map_point⟩,
+                        left_inv := λ f, by { ext, cases x, exact f.map_fst.symm, refl },
+                        right_inv := λ f, Pointed.hom.ext _ _ rfl },
+  unit := { app := λ X, ⟨option.some, rfl⟩, naturality' := λ X Y f, rfl },
+  counit := { app := λ X, ⟨λ o, o.elim X.to_prod.1 id, rfl, rfl⟩,
+              naturality' := λ X Y f, by { ext, cases x, exact f.map_fst.symm, refl } },
+  hom_equiv_unit' := λ X Y f, rfl,
+  hom_equiv_counit' := λ X Y f, by { ext, cases x; refl } }

--- a/src/category_theory/category/Bipointed.lean
+++ b/src/category_theory/category/Bipointed.lean
@@ -68,4 +68,14 @@ instance concrete_category : concrete_category Bipointed :=
 { forget := { obj := Bipointed.X, map := @Bipointed.hom.to_fun },
   forget_faithful := ⟨@hom.ext⟩ }
 
+/-- Swaps the pointed elements of a bipointed type. `prod.swap` as a functor. -/
+@[simps] def swap : Bipointed ⥤ Bipointed :=
+{ obj := λ X, ⟨X, X.to_prod.swap⟩, map := λ X Y f, ⟨f.to_fun, f.map_snd, f.map_fst⟩ }
+
+/-- The equivalence between `Bipointed` and itself induced by `prod.swap` both ways. -/
+def swap_equiv : Bipointed ≌ Bipointed :=
+equivalence.mk swap swap
+  (nat_iso.of_components (λ X, { hom := ⟨id, rfl, rfl⟩, inv := ⟨id, rfl, rfl⟩ }) $ λ X Y f, rfl)
+  (nat_iso.of_components (λ X, { hom := ⟨id, rfl, rfl⟩, inv := ⟨id, rfl, rfl⟩ }) $ λ X Y f, rfl)
+
 end Bipointed

--- a/src/category_theory/category/Bipointed.lean
+++ b/src/category_theory/category/Bipointed.lean
@@ -103,3 +103,23 @@ def Bipointed_to_Pointed_snd : Bipointed ⥤ Pointed :=
 
 @[simp] lemma swap_comp_Bipointed_to_Pointed_snd :
   Bipointed.swap ⋙ Bipointed_to_Pointed_snd = Bipointed_to_Pointed_fst := rfl
+
+/-- The functor from `Pointed` to `Bipointed` which adds a second point. -/
+def Pointed_to_Bipointed_fst : Pointed.{u} ⥤ Bipointed :=
+{ obj := λ X, ⟨option X, X.point, none⟩,
+  map := λ X Y f, ⟨option.map f.to_fun, congr_arg _ f.map_point, rfl⟩,
+  map_id' := λ X, Bipointed.hom.ext _ _ option.map_id,
+  map_comp' := λ X Y Z f g, Bipointed.hom.ext _ _ (option.map_comp_map  _ _).symm }
+
+/-- The functor from `Pointed` to `Bipointed` which adds a first point. -/
+def Pointed_to_Bipointed_snd : Pointed.{u} ⥤ Bipointed :=
+{ obj := λ X, ⟨option X, none, X.point⟩,
+  map := λ X Y f, ⟨option.map f.to_fun, rfl, congr_arg _ f.map_point⟩,
+  map_id' := λ X, Bipointed.hom.ext _ _ option.map_id,
+  map_comp' := λ X Y Z f g, Bipointed.hom.ext _ _ (option.map_comp_map  _ _).symm }
+
+@[simp] lemma Pointed_to_Bipointed_fst_comp :
+  Pointed_to_Bipointed_fst ⋙ Bipointed.swap = Pointed_to_Bipointed_snd := rfl
+
+@[simp] lemma Pointed_to_Bipointed_snd_comp :
+  Pointed_to_Bipointed_snd ⋙ Bipointed.swap = Pointed_to_Bipointed_fst := rfl

--- a/src/category_theory/category/Bipointed.lean
+++ b/src/category_theory/category/Bipointed.lean
@@ -135,8 +135,7 @@ adjunction.mk_of_hom_equiv
                         inv_fun := λ f, ⟨λ o, o.elim Y.to_prod.2 f.to_fun, f.map_point, rfl⟩,
                         left_inv := λ f, by { ext, cases x, exact f.map_snd.symm, refl },
                         right_inv := λ f, Pointed.hom.ext _ _ rfl },
-  hom_equiv_naturality_left_symm' := λ X' X Y f g, by { ext, cases x; refl },
-  hom_equiv_naturality_right' := λ X' X Y f g, Pointed.hom.ext _ _ rfl }
+  hom_equiv_naturality_left_symm' := λ X' X Y f g, by { ext, cases x; refl } }
 
 /-- The free/forgetful adjunction between `Pointed_to_Bipointed_snd` and `Bipointed_to_Pointed_snd`.
 -/
@@ -147,5 +146,4 @@ adjunction.mk_of_hom_equiv
                         inv_fun := λ f, ⟨λ o, o.elim Y.to_prod.1 f.to_fun, rfl, f.map_point⟩,
                         left_inv := λ f, by { ext, cases x, exact f.map_fst.symm, refl },
                         right_inv := λ f, Pointed.hom.ext _ _ rfl },
-  hom_equiv_naturality_left_symm' := λ X' X Y f g, by { ext, cases x; refl },
-  hom_equiv_naturality_right' := λ X' X Y f g, Pointed.hom.ext _ _ rfl }
+  hom_equiv_naturality_left_symm' := λ X' X Y f g, by { ext, cases x; refl } }

--- a/src/category_theory/category/Bipointed.lean
+++ b/src/category_theory/category/Bipointed.lean
@@ -1,0 +1,71 @@
+/-
+Copyright (c) 2022 Yaël Dillies. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Yaël Dillies
+-/
+import category_theory.concrete_category.basic
+
+/-!
+# The category of bipointed types
+
+This defines `Bipointed` the category of bipointed types.
+
+## TODO
+
+Monoidal structure
+-/
+
+open category_theory
+
+universes u
+variables {α β : Type*}
+
+/-- The category of bipointed types. -/
+structure Bipointed : Type.{u + 1} :=
+(X : Type.{u})
+(to_prod : X × X)
+
+namespace Bipointed
+
+instance : has_coe_to_sort Bipointed Type* := ⟨Bipointed.X⟩
+
+/-- Turns a bipointing into a bipointed type. -/
+def of {X : Type*} (to_prod : X × X) : Bipointed := ⟨X, to_prod⟩
+
+alias of ← prod.Bipointed
+
+instance : inhabited Bipointed := ⟨of ((), ())⟩
+
+/-- Morphisms in `Bipointed`. -/
+@[nolint has_inhabited_instance, ext]
+protected structure hom (X Y : Bipointed.{u}) : Type u :=
+(to_fun : X → Y)
+(map_fst : to_fun X.to_prod.1 = Y.to_prod.1)
+(map_snd : to_fun X.to_prod.2 = Y.to_prod.2)
+
+namespace hom
+
+/-- The identity morphism of `X : Bipointed`. -/
+@[simps] def id (X : Bipointed) : Bipointed.hom X X := ⟨id, rfl, rfl⟩
+
+/-- Composition of morphisms of `Bipointed`. -/
+@[simps] def comp {X Y Z : Bipointed.{u}} (f : Bipointed.hom X Y) (g : Bipointed.hom Y Z) :
+  Bipointed.hom X Z :=
+⟨g.to_fun ∘ f.to_fun, by rw [function.comp_apply, f.map_fst, g.map_fst],
+  by rw [function.comp_apply, f.map_snd, g.map_snd]⟩
+
+end hom
+
+instance large_category : large_category Bipointed :=
+{ hom := hom,
+  id := hom.id,
+  comp := @hom.comp,
+  id_comp' := λ _ _ _, hom.ext _ _ rfl,
+  comp_id' := λ _ _ _, hom.ext _ _ rfl,
+  assoc' := λ _ _ _ _ _ _ _, hom.ext _ _ rfl }
+
+instance concrete_category : concrete_category Bipointed :=
+{ forget := { obj := Bipointed.X, map := @Bipointed.hom.to_fun },
+  forget_faithful := ⟨@hom.ext⟩ }
+
+end Bipointed

--- a/src/category_theory/category/Bipointed.lean
+++ b/src/category_theory/category/Bipointed.lean
@@ -3,12 +3,12 @@ Copyright (c) 2022 Yaël Dillies. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yaël Dillies
 -/
-import category_theory.concrete_category.basic
+import category_theory.category.Pointed
 
 /-!
 # The category of bipointed types
 
-This defines `Bipointed` the category of bipointed types.
+This defines `Bipointed`, the category of bipointed types.
 
 ## TODO
 
@@ -27,7 +27,9 @@ structure Bipointed : Type.{u + 1} :=
 
 namespace Bipointed
 
-instance : has_coe_to_sort Bipointed Type* := ⟨Bipointed.X⟩
+instance : has_coe_to_sort Bipointed Type* := ⟨X⟩
+
+attribute [protected] Bipointed.X
 
 /-- Turns a bipointing into a bipointed type. -/
 def of {X : Type*} (to_prod : X × X) : Bipointed := ⟨X, to_prod⟩
@@ -37,8 +39,7 @@ alias of ← prod.Bipointed
 instance : inhabited Bipointed := ⟨of ((), ())⟩
 
 /-- Morphisms in `Bipointed`. -/
-@[nolint has_inhabited_instance, ext]
-protected structure hom (X Y : Bipointed.{u}) : Type u :=
+@[ext] protected structure hom (X Y : Bipointed.{u}) : Type u :=
 (to_fun : X → Y)
 (map_fst : to_fun X.to_prod.1 = Y.to_prod.1)
 (map_snd : to_fun X.to_prod.2 = Y.to_prod.2)
@@ -46,11 +47,12 @@ protected structure hom (X Y : Bipointed.{u}) : Type u :=
 namespace hom
 
 /-- The identity morphism of `X : Bipointed`. -/
-@[simps] def id (X : Bipointed) : Bipointed.hom X X := ⟨id, rfl, rfl⟩
+@[simps] def id (X : Bipointed) : hom X X := ⟨id, rfl, rfl⟩
+
+instance (X : Bipointed) : inhabited (hom X X) := ⟨id X⟩
 
 /-- Composition of morphisms of `Bipointed`. -/
-@[simps] def comp {X Y Z : Bipointed.{u}} (f : Bipointed.hom X Y) (g : Bipointed.hom Y Z) :
-  Bipointed.hom X Z :=
+@[simps] def comp {X Y Z : Bipointed.{u}} (f : hom X Y) (g : hom Y Z) : hom X Z :=
 ⟨g.to_fun ∘ f.to_fun, by rw [function.comp_apply, f.map_fst, g.map_fst],
   by rw [function.comp_apply, f.map_snd, g.map_snd]⟩
 
@@ -65,7 +67,7 @@ instance large_category : large_category Bipointed :=
   assoc' := λ _ _ _ _ _ _ _, hom.ext _ _ rfl }
 
 instance concrete_category : concrete_category Bipointed :=
-{ forget := { obj := Bipointed.X, map := @Bipointed.hom.to_fun },
+{ forget := { obj := Bipointed.X, map := @hom.to_fun },
   forget_faithful := ⟨@hom.ext⟩ }
 
 /-- Swaps the pointed elements of a bipointed type. `prod.swap` as a functor. -/
@@ -78,4 +80,26 @@ equivalence.mk swap swap
   (nat_iso.of_components (λ X, { hom := ⟨id, rfl, rfl⟩, inv := ⟨id, rfl, rfl⟩ }) $ λ X Y f, rfl)
   (nat_iso.of_components (λ X, { hom := ⟨id, rfl, rfl⟩, inv := ⟨id, rfl, rfl⟩ }) $ λ X Y f, rfl)
 
+@[simp] lemma swap_equiv_symm : swap_equiv.symm = swap_equiv := rfl
+
 end Bipointed
+
+/-- The forgetful functor from `Bipointed` to `Pointed` which forgets about the second point. -/
+def Bipointed_to_Pointed_fst : Bipointed ⥤ Pointed :=
+{ obj := λ X, ⟨X, X.to_prod.1⟩, map := λ X Y f, ⟨f.to_fun, f.map_fst⟩ }
+
+/-- The forgetful functor from `Bipointed` to `Pointed` which forgets about the first point. -/
+def Bipointed_to_Pointed_snd : Bipointed ⥤ Pointed :=
+{ obj := λ X, ⟨X, X.to_prod.2⟩, map := λ X Y f, ⟨f.to_fun, f.map_snd⟩ }
+
+@[simp] lemma Bipointed_to_Pointed_fst_comp_forget :
+  Bipointed_to_Pointed_fst ⋙ forget Pointed = forget Bipointed := rfl
+
+@[simp] lemma Bipointed_to_Pointed_snd_comp_forget :
+  Bipointed_to_Pointed_snd ⋙ forget Pointed = forget Bipointed := rfl
+
+@[simp] lemma swap_comp_Bipointed_to_Pointed_fst :
+  Bipointed.swap ⋙ Bipointed_to_Pointed_fst = Bipointed_to_Pointed_snd := rfl
+
+@[simp] lemma swap_comp_Bipointed_to_Pointed_snd :
+  Bipointed.swap ⋙ Bipointed_to_Pointed_snd = Bipointed_to_Pointed_fst := rfl

--- a/src/category_theory/category/Bipointed.lean
+++ b/src/category_theory/category/Bipointed.lean
@@ -104,6 +104,7 @@ def Bipointed_to_Pointed_snd : Bipointed ⥤ Pointed :=
 @[simp] lemma swap_comp_Bipointed_to_Pointed_snd :
   Bipointed.swap ⋙ Bipointed_to_Pointed_snd = Bipointed_to_Pointed_fst := rfl
 
+--TODO: This is actually an equivalence
 /-- The functor from `Pointed` to `Bipointed` which adds a second point. -/
 def Pointed_to_Bipointed_fst : Pointed.{u} ⥤ Bipointed :=
 { obj := λ X, ⟨option X, X.point, none⟩,
@@ -111,6 +112,7 @@ def Pointed_to_Bipointed_fst : Pointed.{u} ⥤ Bipointed :=
   map_id' := λ X, Bipointed.hom.ext _ _ option.map_id,
   map_comp' := λ X Y Z f g, Bipointed.hom.ext _ _ (option.map_comp_map  _ _).symm }
 
+--TODO: This is actually an equivalence
 /-- The functor from `Pointed` to `Bipointed` which adds a first point. -/
 def Pointed_to_Bipointed_snd : Pointed.{u} ⥤ Bipointed :=
 { obj := λ X, ⟨option X, none, X.point⟩,
@@ -128,26 +130,22 @@ def Pointed_to_Bipointed_snd : Pointed.{u} ⥤ Bipointed :=
 -/
 def Pointed_to_Bipointed_fst_Bipointed_to_Pointed_fst_adjunction :
   Pointed_to_Bipointed_fst ⊣ Bipointed_to_Pointed_fst :=
+adjunction.mk_of_hom_equiv
 { hom_equiv := λ X Y, { to_fun := λ f, ⟨f.to_fun ∘ option.some, f.map_fst⟩,
                         inv_fun := λ f, ⟨λ o, o.elim Y.to_prod.2 f.to_fun, f.map_point, rfl⟩,
                         left_inv := λ f, by { ext, cases x, exact f.map_snd.symm, refl },
                         right_inv := λ f, Pointed.hom.ext _ _ rfl },
-  unit := { app := λ X, ⟨option.some, rfl⟩, naturality' := λ X Y f, rfl },
-  counit := { app := λ X, ⟨λ o, o.elim X.to_prod.2 id, rfl, rfl⟩,
-              naturality' := λ X Y f, by { ext, cases x, exact f.map_snd.symm, refl } },
-  hom_equiv_unit' := λ X Y f, rfl,
-  hom_equiv_counit' := λ X Y f, by { ext, cases x; refl } }
+  hom_equiv_naturality_left_symm' := λ X' X Y f g, by { ext, cases x; refl },
+  hom_equiv_naturality_right' := λ X' X Y f g, Pointed.hom.ext _ _ rfl }
 
 /-- The free/forgetful adjunction between `Pointed_to_Bipointed_snd` and `Bipointed_to_Pointed_snd`.
 -/
 def Pointed_to_Bipointed_snd_Bipointed_to_Pointed_snd_adjunction :
   Pointed_to_Bipointed_snd ⊣ Bipointed_to_Pointed_snd :=
+adjunction.mk_of_hom_equiv
 { hom_equiv := λ X Y, { to_fun := λ f, ⟨f.to_fun ∘ option.some, f.map_snd⟩,
                         inv_fun := λ f, ⟨λ o, o.elim Y.to_prod.1 f.to_fun, rfl, f.map_point⟩,
                         left_inv := λ f, by { ext, cases x, exact f.map_fst.symm, refl },
                         right_inv := λ f, Pointed.hom.ext _ _ rfl },
-  unit := { app := λ X, ⟨option.some, rfl⟩, naturality' := λ X Y f, rfl },
-  counit := { app := λ X, ⟨λ o, o.elim X.to_prod.1 id, rfl, rfl⟩,
-              naturality' := λ X Y f, by { ext, cases x, exact f.map_fst.symm, refl } },
-  hom_equiv_unit' := λ X Y f, rfl,
-  hom_equiv_counit' := λ X Y f, by { ext, cases x; refl } }
+  hom_equiv_naturality_left_symm' := λ X' X Y f g, by { ext, cases x; refl },
+  hom_equiv_naturality_right' := λ X' X Y f g, Pointed.hom.ext _ _ rfl }

--- a/src/category_theory/category/Pointed.lean
+++ b/src/category_theory/category/Pointed.lean
@@ -86,5 +86,4 @@ adjunction.mk_of_hom_equiv
                         inv_fun := λ f, ⟨λ o, o.elim Y.point f, rfl⟩,
                         left_inv := λ f, by { ext, cases x, exact f.map_point.symm, refl },
                         right_inv := λ f, funext $ λ _, rfl },
-  hom_equiv_naturality_left_symm' := λ X' X Y f g, by { ext, cases x; refl },
-  hom_equiv_naturality_right' := λ X' X Y f g, funext $ λ _, rfl }
+  hom_equiv_naturality_left_symm' := λ X' X Y f g, by { ext, cases x; refl }, }

--- a/src/category_theory/category/Pointed.lean
+++ b/src/category_theory/category/Pointed.lean
@@ -72,9 +72,19 @@ instance concrete_category : concrete_category Pointed :=
 end Pointed
 
 --TODO: This is actually an equivalence
-/-- `option` as a functor from types to pointed types. -/
+/-- `option` as a functor from types to pointed types. This is the free functor. -/
 @[simps] def Type_to_Pointed : Type.{u} ⥤ Pointed.{u} :=
 { obj := λ X, ⟨option X, none⟩,
   map := λ X Y f, ⟨option.map f, rfl⟩,
   map_id' := λ X, Pointed.hom.ext _ _ option.map_id,
   map_comp' := λ X Y Z f g, Pointed.hom.ext _ _ (option.map_comp_map _ _).symm }
+
+/-- `Type_to_Pointed` is the free functor. -/
+def Type_to_Pointed_forget_adjunction : Type_to_Pointed ⊣ forget Pointed :=
+adjunction.mk_of_hom_equiv
+{ hom_equiv := λ X Y, { to_fun := λ f, f.to_fun ∘ option.some,
+                        inv_fun := λ f, ⟨λ o, o.elim Y.point f, rfl⟩,
+                        left_inv := λ f, by { ext, cases x, exact f.map_point.symm, refl },
+                        right_inv := λ f, funext $ λ _, rfl },
+  hom_equiv_naturality_left_symm' := λ X' X Y f g, by { ext, cases x; refl },
+  hom_equiv_naturality_right' := λ X' X Y f g, funext $ λ _, rfl }

--- a/src/category_theory/category/Pointed.lean
+++ b/src/category_theory/category/Pointed.lean
@@ -1,0 +1,80 @@
+/-
+Copyright (c) 2022 Yaël Dillies. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Yaël Dillies
+-/
+import category_theory.concrete_category.basic
+
+/-!
+# The category of pointed types
+
+This defines `Pointed`, the category of pointed types.
+
+## TODO
+
+* Monoidal structure
+* Upgrade `Type_to_Pointed` to an equivalence
+-/
+
+open category_theory
+
+universes u
+variables {α β : Type*}
+
+/-- The category of pointed types. -/
+structure Pointed : Type.{u + 1} :=
+(X : Type.{u})
+(point : X)
+
+namespace Pointed
+
+instance : has_coe_to_sort Pointed Type* := ⟨X⟩
+
+attribute [protected] Pointed.X
+
+/-- Turns a point into a pointed type. -/
+def of {X : Type*} (point : X) : Pointed := ⟨X, point⟩
+
+alias of ← prod.Pointed
+
+instance : inhabited Pointed := ⟨of ((), ())⟩
+
+/-- Morphisms in `Pointed`. -/
+@[ext] protected structure hom (X Y : Pointed.{u}) : Type u :=
+(to_fun : X → Y)
+(map_point : to_fun X.point = Y.point)
+
+namespace hom
+
+/-- The identity morphism of `X : Pointed`. -/
+@[simps] def id (X : Pointed) : hom X X := ⟨id, rfl⟩
+
+instance (X : Pointed) : inhabited (hom X X) := ⟨id X⟩
+
+/-- Composition of morphisms of `Pointed`. -/
+@[simps] def comp {X Y Z : Pointed.{u}} (f : hom X Y) (g : hom Y Z) : hom X Z :=
+⟨g.to_fun ∘ f.to_fun, by rw [function.comp_apply, f.map_point, g.map_point]⟩
+
+end hom
+
+instance large_category : large_category Pointed :=
+{ hom := hom,
+  id := hom.id,
+  comp := @hom.comp,
+  id_comp' := λ _ _ _, hom.ext _ _ rfl,
+  comp_id' := λ _ _ _, hom.ext _ _ rfl,
+  assoc' := λ _ _ _ _ _ _ _, hom.ext _ _ rfl }
+
+instance concrete_category : concrete_category Pointed :=
+{ forget := { obj := Pointed.X, map := @hom.to_fun },
+  forget_faithful := ⟨@hom.ext⟩ }
+
+end Pointed
+
+--TODO: This is actually an equivalence
+/-- `option` as a functor from types to pointed types. -/
+@[simps] def Type_to_Pointed : Type.{u} ⥤ Pointed.{u} :=
+{ obj := λ X, ⟨option X, none⟩,
+  map := λ X Y f, ⟨option.map f, rfl⟩,
+  map_id' := λ X, Pointed.hom.ext _ _ option.map_id,
+  map_comp' := λ X Y Z f g, Pointed.hom.ext _ _ (option.map_comp_map _ _).symm }


### PR DESCRIPTION
Define
* `Pointed`, the category of pointed types
* `Bipointed`, the category of bipointed types
* the forgetful functors from `Bipointed` to `Pointed` and from `Pointed` to `Type*`
* `Type_to_Pointed`, the functor from `Type*` to `Pointed` induced by `option`
* `Bipointed.swap_equiv` the equivalence between `Bipointed` and itself induced by `prod.swap` both ways.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

Next, I'll define the monoidal structure on `Bipointed` given by the pointed sum.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
