### PR TITLE
feat(data/pnat/basic): add localized arrow for pnat coe

### DIFF
--- a/src/data/pnat/basic.lean
+++ b/src/data/pnat/basic.lean
@@ -18,6 +18,8 @@ def pnat := {n : ℕ // 0 < n}
 notation `ℕ+` := pnat
 
 instance coe_pnat_nat : has_coe ℕ+ ℕ := ⟨subtype.val⟩
+localized "prefix `⥉`:max := (coe : ℕ+ → ℕ)" in pnat
+
 instance : has_repr ℕ+ := ⟨λ n, repr n.1⟩
 
 /-- Predecessor of a `ℕ+`, as a `ℕ`. -/


### PR DESCRIPTION
This specific coercion is used a lot in `flt-regular`, and it would be nice to not have to cast explicitly all the time. I'm not attached to this arrow (or any symbol in particular) it's just one I happened to find and it fit the bill. Suggestions for that welcome.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
