### PR TITLE
[Merged by Bors] - feat(data/finset/sort): an order embedding from fin

### DIFF
--- a/src/data/finset/sort.lean
+++ b/src/data/finset/sort.lean
@@ -183,6 +183,16 @@ begin
   exact (s.order_emb_of_fin rfl).eq_iff_eq.trans (fin.ext_iff _ _)
 end
 
+/-- Given a finset `s` of size at least `k` in a linear order `α`, the map `order_emb_of_card_le`
+is an order embedding from `fin k` to `α` whose image is contained in `s`. Specifically, it maps
+`fin k` to an initial segment of `s`. -/
+def order_emb_of_card_le (s : finset α) {k : ℕ} (h : k ≤ s.card) : fin k ↪o α :=
+(fin.cast_le h).trans (s.order_emb_of_fin rfl)
+
+lemma order_emb_of_card_le_mem (s : finset α) {k : ℕ} (h : k ≤ s.card) (a) :
+  order_emb_of_card_le s h a ∈ s :=
+by simp only [order_emb_of_card_le, rel_embedding.coe_trans, finset.order_emb_of_fin_mem]
+
 lemma card_le_of_interleaved {s t : finset α} (h : ∀ x y ∈ s, x < y → ∃ z ∈ t, x < z ∧ z < y) :
   s.card ≤ t.card + 1 :=
 begin


### PR DESCRIPTION
Given a set `s` of at least `k` element in a linear order, there is an order embedding from `fin k` whose image is contained in `s`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
