### PR TITLE
[Merged by Bors] - feat(algebra/big_operators/intervals): summation by parts

### DIFF
--- a/src/algebra/big_operators/intervals.lean
+++ b/src/algebra/big_operators/intervals.lean
@@ -176,27 +176,36 @@ section nat
 variable {β : Type*}
 variables (f g : ℕ → β) {m n : ℕ}
 
+section group
+
+-- The partial products (starting from `0`) of `f` and `g` respectively.
+local notation `F` n:80 := ∏ i in range n, f i
+local notation `G` n:80 := ∏ i in range n, g i
+
+variable [comm_group β]
+
+@[to_additive]
+lemma prod_range_succ_div_prod : F (n+1) / F n = f n :=
+div_eq_iff_eq_mul'.mpr $ prod_range_succ f n
+
+@[to_additive]
+lemma prod_range_succ_div_top : F (n+1) / f n = F n :=
+div_eq_iff_eq_mul.mpr $ prod_range_succ f n
+
+@[to_additive]
+lemma prod_Ico_div_bot (hmn : m < n) : (∏ i in Ico m n, f i) / f m = ∏ i in Ico (m+1) n, f i :=
+div_eq_iff_eq_mul'.mpr $ prod_eq_prod_Ico_succ_bot hmn _
+
+@[to_additive]
+lemma prod_Ico_succ_div_top (hmn : m ≤ n) :
+  (∏ i in Ico m (n+1), f i) / f n = ∏ i in Ico m n, f i :=
+div_eq_iff_eq_mul.mpr $ prod_Ico_succ_top hmn _
+
+end group
+
 -- The partial sums (starting from `0`) of `f` and `g` respectively.
 local notation `F` n:80 := ∑ i in range n, f i
 local notation `G` n:80 := ∑ i in range n, g i
-
-section group
-variable [add_comm_group β]
-
-lemma sum_range_succ_sub_sum : F (n+1) - F n = f n :=
-sub_eq_iff_eq_add'.mpr $ sum_range_succ f n
-
-lemma sum_range_succ_sub_top : F (n+1) - f n = F n :=
-sub_eq_iff_eq_add.mpr $ sum_range_succ f n
-
-lemma sum_Ico_sub_bot (hmn : m < n) : ∑ i in Ico m n, f i - f m = ∑ i in Ico (m+1) n, f i :=
-sub_eq_iff_eq_add'.mpr $ sum_eq_sum_Ico_succ_bot hmn _
-
-lemma sum_Ico_succ_sub_top (hmn : m ≤ n) :
-  ∑ i in Ico m (n+1), f i - f n = ∑ i in Ico m n, f i :=
-sub_eq_iff_eq_add.mpr $ sum_Ico_succ_top hmn _
-
-end group
 
 variable [comm_ring β]
 
@@ -205,12 +214,9 @@ theorem sum_Ico_by_parts (hmn : m < n) :
   ∑ i in Ico m n, f i * g i =
     f (n-1) * G n - f m * G m - ∑ i in Ico m (n-1), G (i+1) * (f (i+1) - f i) :=
 begin
-  have h₁ : ∑ i in Ico (m+1) n, (f i * G i) = ∑ i in Ico m (n-1), (f (i+1) * G (i+1)) :=
-  begin
-    conv in n { rw ←nat.sub_add_cancel (nat.one_le_of_lt hmn) },
-    rw ←sum_Ico_add',
-  end,
-
+  have h₁ : ∑ i in Ico (m+1) n, (f i * G i) = ∑ i in Ico m (n-1), (f (i+1) * G (i+1)),
+  { conv in n { rw ←nat.sub_add_cancel (nat.one_le_of_lt hmn) },
+    rw ←sum_Ico_add' },
   have h₂ : ∑ i in Ico (m+1) n, (f i * G (i+1))
           = ∑ i in Ico m (n-1), (f i * G (i+1)) + f (n-1) * G n - f m * G (m+1) :=
   by rw [←sum_Ico_sub_bot _ hmn, ←sum_Ico_succ_sub_top _ (nat.le_pred_of_lt hmn),

--- a/src/algebra/big_operators/intervals.lean
+++ b/src/algebra/big_operators/intervals.lean
@@ -45,6 +45,14 @@ begin
   simp_rw add_comm,
 end
 
+@[to_additive]
+lemma prod_Ico_sub' {f : ℕ → β} {m n c: ℕ} (hm : c ≤ m) (hmn : m ≤ n) :
+  ∏ i in Ico (m - c) (n - c), f (i + c) = ∏ i in Ico m n, f i :=
+begin
+  rw [prod_Ico_add' f _ _],
+  simp only [nat.sub_add_cancel hm, nat.sub_add_cancel (le_trans hm hmn)],
+end
+
 lemma sum_Ico_succ_top {δ : Type*} [add_comm_monoid δ] {a b : ℕ}
   (hab : a ≤ b) (f : ℕ → δ) : (∑ k in Ico a (b + 1), f k) = (∑ k in Ico a b, f k) + f b :=
 by rw [nat.Ico_succ_right_eq_insert_Ico hab, sum_insert right_not_mem_Ico, add_comm]
@@ -180,19 +188,6 @@ variables (f g : ℕ → β) {m n : ℕ}
 local notation `F` n:80 := ∑ i in range n, f i
 local notation `G` n:80 := ∑ i in range n, g i
 
-section monoid
-variable [add_comm_monoid β]
-
-lemma sum_Ico_sub {c: ℕ} (hm : c ≤ m) (hmn : m ≤ n) :
-  ∑ (i : ℕ) in Ico (m-c) (n-c), f (i+c) = ∑ (i : ℕ) in Ico m n, f i :=
-begin
-  have hn : c ≤ n := le_trans hm hmn,
-  conv in (f (_+c)) { rw add_comm },
-  rw [sum_Ico_add f (m-c) (n-c), nat.sub_add_cancel hm, nat.sub_add_cancel hn],
-end
-
-end monoid
-
 section group
 variable [add_comm_group β]
 
@@ -219,7 +214,7 @@ theorem sum_Ico_by_parts (hmn : m < n) :
     f (n-1) * G n - f m * G m - ∑ i in Ico m (n-1), G (i+1) * (f (i+1) - f i) :=
 begin
   have h₁ : ∑ i in Ico (m+1) n, (f i * G i) = ∑ i in Ico m (n-1), (f (i+1) * G (i+1)) :=
-    (sum_Ico_sub _ m.succ_pos $ nat.succ_le_iff.mpr hmn).symm,
+    (sum_Ico_sub' m.succ_pos $ nat.succ_le_iff.mpr hmn).symm,
 
   have h₂ : ∑ i in Ico (m+1) n, (f i * G (i+1))
           = ∑ i in Ico m (n-1), (f i * G (i+1)) + f (n-1) * G n - f m * G (m+1) :=

--- a/src/algebra/big_operators/intervals.lean
+++ b/src/algebra/big_operators/intervals.lean
@@ -183,10 +183,10 @@ local notation `G` n:80 := ∑ i in range n, g i
 section group
 variable [add_comm_group β]
 
-lemma sum_range_succ_sub_sum_eq_top : F (n+1) - F n = f n :=
+lemma sum_range_succ_sub_sum : F (n+1) - F n = f n :=
 sub_eq_iff_eq_add'.mpr $ sum_range_succ f n
 
-lemma sum_range_succ_sub_top_eq_sum : F (n+1) - f n = F n :=
+lemma sum_range_succ_sub_top : F (n+1) - f n = F n :=
 sub_eq_iff_eq_add.mpr $ sum_range_succ f n
 
 lemma sum_Ico_sub_bot (hmn : m < n) : ∑ i in Ico m n, f i - f m = ∑ i in Ico (m+1) n, f i :=
@@ -217,12 +217,12 @@ begin
          nat.sub_add_cancel (pos_of_gt hmn), sub_add_cancel],
 
   rw sum_eq_sum_Ico_succ_bot hmn,
-  conv { for (f _ * g _) [2] { rw [←sum_range_succ_sub_sum_eq_top g, mul_sub_left_distrib] }},
+  conv { for (f _ * g _) [2] { rw [←sum_range_succ_sub_sum g, mul_sub_left_distrib] }},
   rw [sum_sub_distrib, h₂, h₁],
   conv_lhs { congr, skip, rw [←add_sub, add_comm, ←add_sub, ←sum_sub_distrib] },
   conv in (f _ * G (_+1) - _) { rw [←sub_mul, ←neg_sub, mul_comm, mul_neg] },
   rw [sum_neg_distrib, ←sub_eq_add_neg, add_sub, add_comm, sub_add, ←mul_sub,
-      sum_range_succ_sub_top_eq_sum]
+      sum_range_succ_sub_top]
 end
 
 /-- **Summation by parts** for ranges -/

--- a/src/algebra/big_operators/intervals.lean
+++ b/src/algebra/big_operators/intervals.lean
@@ -45,14 +45,6 @@ begin
   simp_rw add_comm,
 end
 
-@[to_additive]
-lemma prod_Ico_sub' {f : ℕ → β} {m n c: ℕ} (hm : c ≤ m) (hmn : m ≤ n) :
-  ∏ i in Ico (m - c) (n - c), f (i + c) = ∏ i in Ico m n, f i :=
-begin
-  rw [prod_Ico_add' f _ _],
-  simp only [nat.sub_add_cancel hm, nat.sub_add_cancel (le_trans hm hmn)],
-end
-
 lemma sum_Ico_succ_top {δ : Type*} [add_comm_monoid δ] {a b : ℕ}
   (hab : a ≤ b) (f : ℕ → δ) : (∑ k in Ico a (b + 1), f k) = (∑ k in Ico a b, f k) + f b :=
 by rw [nat.Ico_succ_right_eq_insert_Ico hab, sum_insert right_not_mem_Ico, add_comm]
@@ -214,7 +206,10 @@ theorem sum_Ico_by_parts (hmn : m < n) :
     f (n-1) * G n - f m * G m - ∑ i in Ico m (n-1), G (i+1) * (f (i+1) - f i) :=
 begin
   have h₁ : ∑ i in Ico (m+1) n, (f i * G i) = ∑ i in Ico m (n-1), (f (i+1) * G (i+1)) :=
-    (sum_Ico_sub' m.succ_pos $ nat.succ_le_iff.mpr hmn).symm,
+  begin
+    conv in n { rw ←nat.sub_add_cancel (nat.one_le_of_lt hmn) },
+    rw ←sum_Ico_add',
+  end,
 
   have h₂ : ∑ i in Ico (m+1) n, (f i * G (i+1))
           = ∑ i in Ico m (n-1), (f i * G (i+1)) + f (n-1) * G n - f m * G (m+1) :=

--- a/src/algebra/big_operators/intervals.lean
+++ b/src/algebra/big_operators/intervals.lean
@@ -25,22 +25,25 @@ section generic
 variables {α : Type u} {β : Type v} {γ : Type w} {s₂ s₁ s : finset α} {a : α}
   {g f : α → β}
 
-lemma sum_Ico_add [ordered_cancel_add_comm_monoid α] [has_exists_add_of_le α]
-  [locally_finite_order α] [add_comm_monoid β] (f : α → β) (a b c : α) :
-  (∑ x in Ico a b, f (c + x)) = (∑ x in Ico (a + c) (b + c), f x) :=
+variables [comm_monoid β]
+
+@[to_additive]
+lemma prod_Ico_add' [ordered_cancel_add_comm_monoid α] [has_exists_add_of_le α]
+  [locally_finite_order α] (f : α → β) (a b c : α) :
+  (∏ x in Ico a b, f (x + c)) = (∏ x in Ico (a + c) (b + c), f x) :=
 begin
   classical,
-  rw [←image_add_right_Ico, sum_image (λ x hx y hy h, add_right_cancel h)],
-  simp_rw add_comm,
+  rw [←image_add_right_Ico, prod_image (λ x hx y hy h, add_right_cancel h)],
 end
 
 @[to_additive]
 lemma prod_Ico_add [ordered_cancel_add_comm_monoid α] [has_exists_add_of_le α]
-  [locally_finite_order α] [comm_monoid β] (f : α → β) (a b c : α) :
+  [locally_finite_order α] (f : α → β) (a b c : α) :
   (∏ x in Ico a b, f (c + x)) = (∏ x in Ico (a + c) (b + c), f x) :=
-@sum_Ico_add _ (additive β) _ _ _ _ f a b c
-
-variables [comm_monoid β]
+begin
+  convert prod_Ico_add' f a b c,
+  simp_rw add_comm,
+end
 
 lemma sum_Ico_succ_top {δ : Type*} [add_comm_monoid δ] {a b : ℕ}
   (hab : a ≤ b) (f : ℕ → δ) : (∑ k in Ico a (b + 1), f k) = (∑ k in Ico a b, f k) + f b :=

--- a/src/algebra/big_operators/intervals.lean
+++ b/src/algebra/big_operators/intervals.lean
@@ -178,18 +178,14 @@ variables (f g : ℕ → β) {m n : ℕ}
 
 section group
 
--- The partial products (starting from `0`) of `f` and `g` respectively.
-local notation `F` n:80 := ∏ i in range n, f i
-local notation `G` n:80 := ∏ i in range n, g i
-
 variable [comm_group β]
 
 @[to_additive]
-lemma prod_range_succ_div_prod : F (n+1) / F n = f n :=
+lemma prod_range_succ_div_prod : (∏ i in range (n+1), f i) / ∏ i in range n, f i = f n :=
 div_eq_iff_eq_mul'.mpr $ prod_range_succ f n
 
 @[to_additive]
-lemma prod_range_succ_div_top : F (n+1) / f n = F n :=
+lemma prod_range_succ_div_top : (∏ i in range (n+1), f i) / f n = ∏ i in range n, f i :=
 div_eq_iff_eq_mul.mpr $ prod_range_succ f n
 
 @[to_additive]
@@ -197,14 +193,12 @@ lemma prod_Ico_div_bot (hmn : m < n) : (∏ i in Ico m n, f i) / f m = ∏ i in 
 div_eq_iff_eq_mul'.mpr $ prod_eq_prod_Ico_succ_bot hmn _
 
 @[to_additive]
-lemma prod_Ico_succ_div_top (hmn : m ≤ n) :
-  (∏ i in Ico m (n+1), f i) / f n = ∏ i in Ico m n, f i :=
+lemma prod_Ico_succ_div_top (hmn : m ≤ n) : (∏ i in Ico m (n+1), f i) / f n = ∏ i in Ico m n, f i :=
 div_eq_iff_eq_mul.mpr $ prod_Ico_succ_top hmn _
 
 end group
 
--- The partial sums (starting from `0`) of `f` and `g` respectively.
-local notation `F` n:80 := ∑ i in range n, f i
+-- The partial sum of `g`, starting from zero
 local notation `G` n:80 := ∑ i in range n, g i
 
 variable [comm_ring β]

--- a/src/algebra/big_operators/intervals.lean
+++ b/src/algebra/big_operators/intervals.lean
@@ -180,15 +180,6 @@ local notation `G` n:80 := ∑ i in range n, g i
 section monoid
 variable [add_comm_monoid β]
 
-lemma sum_Ico_empty : (∑ i in Ico n n, f i) = 0 :=
-begin
-  convert sum_empty,
-  exact Ico_self n,
-end
-
-lemma sum_Ico_single : (∑ i in Ico n (n+1), f i) = f n :=
-by rw [sum_eq_sum_Ico_succ_bot (lt_add_one n), sum_Ico_empty, add_zero]
-
 lemma sum_Ico_sub {c: ℕ} (hm : c ≤ m) (hmn : m ≤ n) :
   ∑ (i : ℕ) in Ico (m-c) (n-c), f (i+c) = ∑ (i : ℕ) in Ico m n, f i :=
 begin


### PR DESCRIPTION
Add the "summation by parts" identity over intervals of natural numbers, as well as some helper lemmas.

---

It's generally useful (I want it for Dirichlet's convergence test) but I couldn't find it anywhere. Hopefully I didn't miss it; that `calc` proof took a while to write :smile:. I've split the file into sections since the existing variable declarations weren't quite right and I needed some `local notation` to make things more manageable.

I haven't touched any of the existing lemmas for now. Some of them are also restricted to intervals of natural numbers, so presumably they could be moved next to the stuff from this PR. Alternatively I could generalize everything, but I don't have an intuitive understanding of the typeclass hierarchy yet. Let me know how it can be improved. This is only my second non-trivial PR.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
