### PR TITLE
[Merged by Bors] - feat(algebra/covariant_and_contravariant): covariance and monotonicity

### DIFF
--- a/src/algebra/covariant_and_contravariant.lean
+++ b/src/algebra/covariant_and_contravariant.lean
@@ -6,6 +6,7 @@ Authors: Damiano Testa
 
 import algebra.group.defs
 import order.basic
+import order.monotone
 
 /-!
 
@@ -195,6 +196,41 @@ trans (rel_of_act_rel_act m ab) rr
 end is_trans
 
 end contravariant
+
+section monotone
+
+variables {α : Type*} {M N μ} [preorder α] [preorder N]
+variable {f : N → α}
+
+/-- The partial application of a constant to a covariant operator is monotone. -/
+lemma covariant.monotone_of_const [covariant_class M N μ (≤)] (m : M) : monotone (μ m) :=
+  λ a b ha, covariant_class.elim m ha
+
+/-- A monotone function remains monotone when composed with the partial application
+of a covariant operator. E.g., `∀ (m : ℕ), monotone f → monotone (λ n, f (m + n))`. -/
+lemma monotone.covariant_of_const [covariant_class M N μ (≤)] (hf : monotone f) (m : M) :
+  monotone (f ∘ μ m) :=
+hf.comp $ covariant.monotone_of_const m
+
+/-- Same as `monotone.covariant_of_const`, but with the constant on the other side of
+the operator.  E.g., `∀ (m : ℕ), monotone f → monotone (λ n, f (n + m))`. -/
+lemma monotone.covariant_of_const' {μ : N → N → N} [covariant_class N N (swap μ) (≤)]
+  (hf : monotone f) (m : N) :
+  monotone (f ∘ (swap μ) m) :=
+hf.comp $ covariant.monotone_of_const m
+
+/-- Dual of `monotone.covariant_of_const` -/
+lemma antitone.covariant_of_const [covariant_class M N μ (≤)] (hf : antitone f) (m : M) :
+  antitone (f ∘ μ m) :=
+hf.comp_monotone $ covariant.monotone_of_const m
+
+/-- Dual of `monotone.covariant_of_const'` -/
+lemma antitone.covariant_of_const' {μ : N → N → N} [covariant_class N N (swap μ) (≤)]
+  (hf : antitone f) (m : N) :
+  antitone (f ∘ (swap μ) m) :=
+hf.comp_monotone $ covariant.monotone_of_const m
+
+end monotone
 
 lemma covariant_le_of_covariant_lt [partial_order N] :
   covariant M N μ (<) → covariant M N μ (≤) :=

--- a/src/algebra/covariant_and_contravariant.lean
+++ b/src/algebra/covariant_and_contravariant.lean
@@ -209,25 +209,25 @@ lemma covariant.monotone_of_const [covariant_class M N μ (≤)] (m : M) : monot
 /-- A monotone function remains monotone when composed with the partial application
 of a covariant operator. E.g., `∀ (m : ℕ), monotone f → monotone (λ n, f (m + n))`. -/
 lemma monotone.covariant_of_const [covariant_class M N μ (≤)] (hf : monotone f) (m : M) :
-  monotone (f ∘ μ m) :=
+  monotone (λ n, f (μ m n)) :=
 hf.comp $ covariant.monotone_of_const m
 
 /-- Same as `monotone.covariant_of_const`, but with the constant on the other side of
 the operator.  E.g., `∀ (m : ℕ), monotone f → monotone (λ n, f (n + m))`. -/
 lemma monotone.covariant_of_const' {μ : N → N → N} [covariant_class N N (swap μ) (≤)]
   (hf : monotone f) (m : N) :
-  monotone (f ∘ (swap μ) m) :=
+  monotone (λ n, f (μ n m)) :=
 hf.comp $ covariant.monotone_of_const m
 
 /-- Dual of `monotone.covariant_of_const` -/
 lemma antitone.covariant_of_const [covariant_class M N μ (≤)] (hf : antitone f) (m : M) :
-  antitone (f ∘ μ m) :=
+  antitone (λ n, f (μ m n)) :=
 hf.comp_monotone $ covariant.monotone_of_const m
 
 /-- Dual of `monotone.covariant_of_const'` -/
 lemma antitone.covariant_of_const' {μ : N → N → N} [covariant_class N N (swap μ) (≤)]
   (hf : antitone f) (m : N) :
-  antitone (f ∘ (swap μ) m) :=
+  antitone (λ n, f (μ n m)) :=
 hf.comp_monotone $ covariant.monotone_of_const m
 
 end monotone

--- a/src/algebra/covariant_and_contravariant.lean
+++ b/src/algebra/covariant_and_contravariant.lean
@@ -204,7 +204,7 @@ variable {f : N → α}
 
 /-- The partial application of a constant to a covariant operator is monotone. -/
 lemma covariant.monotone_of_const [covariant_class M N μ (≤)] (m : M) : monotone (μ m) :=
-  λ a b ha, covariant_class.elim m ha
+λ a b ha, covariant_class.elim m ha
 
 /-- A monotone function remains monotone when composed with the partial application
 of a covariant operator. E.g., `∀ (m : ℕ), monotone f → monotone (λ n, f (m + n))`. -/


### PR DESCRIPTION
Some simple lemmas about monotonicity and covariant operators. Proves things like `monotone f → monotone (λ n, f (3 + n))` by library search.

---

Arose from the discussion [here](https://github.com/leanprover-community/mathlib/pull/11689#discussion_r795897682).