### PR TITLE
[Merged by Bors] - feat(algebra/lie/ideal_operations): add lemma `lie_ideal_oper_eq_linear_span'`

### DIFF
--- a/src/algebra/lie/ideal_operations.lean
+++ b/src/algebra/lie/ideal_operations.lean
@@ -51,7 +51,8 @@ instance has_bracket : has_bracket (lie_ideal R L) (lie_submodule R L M) :=
 lemma lie_ideal_oper_eq_span :
   ⁅I, N⁆ = lie_span R L { m | ∃ (x : I) (n : N), ⁅(x : L), (n : M)⁆ = m } := rfl
 
-/-- See also `lie_submodule.lie_ideal_oper_eq_tensor_map_range`. -/
+/-- See also `lie_submodule.lie_ideal_oper_eq_linear_span'` and
+`lie_submodule.lie_ideal_oper_eq_tensor_map_range`. -/
 lemma lie_ideal_oper_eq_linear_span :
   (↑⁅I, N⁆ : submodule R M) = submodule.span R { m | ∃ (x : I) (n : N), ⁅(x : L), (n : M)⁆ = m } :=
 begin
@@ -70,6 +71,19 @@ begin
     rw [coe_submodule_le_coe_submodule, lie_ideal_oper_eq_span, lie_span_le],
     exact submodule.subset_span, },
   { rw lie_ideal_oper_eq_span, apply submodule_span_le_lie_span, },
+end
+
+lemma lie_ideal_oper_eq_linear_span' :
+  (↑⁅I, N⁆ : submodule R M) = submodule.span R { m | ∃ (x ∈ I) (n ∈ N), ⁅x, n⁆ = m } :=
+begin
+  rw lie_ideal_oper_eq_linear_span,
+  congr,
+  ext m,
+  split,
+  { rintros ⟨⟨x, hx⟩, ⟨n, hn⟩, rfl⟩,
+    exact ⟨x, hx, n, hn, rfl⟩, },
+  { rintros ⟨x, hx, n, hn, rfl⟩,
+    exact ⟨⟨x, hx⟩, ⟨n, hn⟩, rfl⟩, },
 end
 
 lemma lie_coe_mem_lie (x : I) (m : N) : ⁅(x : L), (m : M)⁆ ∈ ⁅I, N⁆ :=


### PR DESCRIPTION
It is useful to have this alternate form in situations where we have a hypothesis like `h : I = J` since we can then rewrite using `h` after applying this lemma.

An (admittedly brief) scan of the existing applications of `lie_ideal_oper_eq_linear_span` indicates that it's worth keeping both forms for convenience but I'm happy to dig deeper into this if requested.



---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
