### PR TITLE
[Merged by Bors] - refactor(data/quot): Make more `setoid` arguments implicit

### DIFF
--- a/src/data/quot.lean
+++ b/src/data/quot.lean
@@ -31,7 +31,7 @@ namespace quot
 variables {ra : α → α → Prop} {rb : β → β → Prop} {φ : quot ra → quot rb → Sort*}
 local notation `⟦`:max a `⟧` := quot.mk _ a
 
-instance [inhabited α] : inhabited (quot ra) := ⟨⟦default⟧⟩
+instance (r : α → α → Prop) [inhabited α] : inhabited (quot r) := ⟨⟦default⟧⟩
 
 instance [subsingleton α] : subsingleton (quot ra) :=
 ⟨λ x, quot.induction_on x (λ y, quot.ind (λ b, congr_arg _ (subsingleton.elim _ _)))⟩
@@ -139,7 +139,7 @@ namespace quotient
 variables [sa : setoid α] [sb : setoid β]
 variables {φ : quotient sa → quotient sb → Sort*}
 
-instance [inhabited α] : inhabited (quotient sa) := ⟨⟦default⟧⟩
+instance (s : setoid α) [inhabited α] : inhabited (quotient s) := ⟨⟦default⟧⟩
 
 instance (s : setoid α) [subsingleton α] : subsingleton (quotient s) :=
 quot.subsingleton
@@ -247,11 +247,11 @@ begin
   rw quotient.out_eq x,
 end
 
-@[simp] lemma quotient.out_equiv_out [s : setoid α] {x y : quotient s} :
+@[simp] lemma quotient.out_equiv_out {s : setoid α} {x y : quotient s} :
   x.out ≈ y.out ↔ x = y :=
 by rw [← quotient.eq_mk_iff_out, quotient.out_eq]
 
-@[simp] lemma quotient.out_inj [s : setoid α] {x y : quotient s} :
+@[simp] lemma quotient.out_inj {s : setoid α} {x y : quotient s} :
   x.out = y.out ↔ x = y :=
 ⟨λ h, quotient.out_equiv_out.1 $ h ▸ setoid.refl _, λ h, h ▸ rfl⟩
 
@@ -494,7 +494,7 @@ rfl
 
 /-- Map a function `f : α → β` that sends equivalent elements to equivalent elements
 to a function `quotient sa → quotient sb`. Useful to define unary operations on quotients. -/
-protected def map' (f : α → β) (h : ((≈) ⇒ (≈)) f f) :
+protected def map' (f : α → β) (h : (s₁.r ⇒ s₂.r) f f) :
   quotient s₁ → quotient s₂ :=
 quot.map f h
 
@@ -503,7 +503,7 @@ quot.map f h
 rfl
 
 /-- A version of `quotient.map₂` using curly braces and unification. -/
-protected def map₂' (f : α → β → γ) (h : ((≈) ⇒ (≈) ⇒ (≈)) f f) :
+protected def map₂' (f : α → β → γ) (h : (s₁.r ⇒ s₂.r ⇒ s₃.r) f f) :
   quotient s₁ → quotient s₂ → quotient s₃ :=
 quotient.map₂ f h
 

--- a/src/data/quot.lean
+++ b/src/data/quot.lean
@@ -31,7 +31,7 @@ namespace quot
 variables {ra : α → α → Prop} {rb : β → β → Prop} {φ : quot ra → quot rb → Sort*}
 local notation `⟦`:max a `⟧` := quot.mk _ a
 
-instance (r : α → α → Prop) [inhabited α] : inhabited (quot r) := ⟨⟦default⟧⟩
+instance [inhabited α] : inhabited (quot ra) := ⟨⟦default⟧⟩
 
 instance [subsingleton α] : subsingleton (quot ra) :=
 ⟨λ x, quot.induction_on x (λ y, quot.ind (λ b, congr_arg _ (subsingleton.elim _ _)))⟩

--- a/src/group_theory/schur_zassenhaus.lean
+++ b/src/group_theory/schur_zassenhaus.lean
@@ -114,8 +114,7 @@ setoid.mk (λ α β, diff α β = 1) ⟨λ α, diff_self α, λ α β h₁,
 def quotient_diff [H.normal] :=
 quotient H.setoid_diff
 
-instance [H.normal] : inhabited H.quotient_diff :=
-quotient.inhabited
+instance [H.normal] : inhabited H.quotient_diff := quotient.inhabited _
 
 variables {H}
 


### PR DESCRIPTION
Currently, not all of the `quotient` API can be used with non-instance setoids. This fixes it by making a few `setoid` arguments explicit rather than instances.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
