### PR TITLE
[Merged by Bors] - refactor(ring_theory/valuation/basic): `fun_like` design for `valuation`

### DIFF
--- a/src/ring_theory/perfection.lean
+++ b/src/ring_theory/perfection.lean
@@ -534,7 +534,7 @@ noncomputable def val : valuation (pre_tilt K v O hv p) ℝ≥0 :=
   map_one' := val_aux_one,
   map_mul' := val_aux_mul,
   map_zero' := val_aux_zero,
-  map_add' := val_aux_add }
+  map_add_le_max' := val_aux_add }
 
 variables {K v O hv p}
 lemma map_eq_zero {f : pre_tilt K v O hv p} : val K v O hv p f = 0 ↔ f = 0 :=

--- a/src/topology/algebra/valued_field.lean
+++ b/src/topology/algebra/valued_field.lean
@@ -309,7 +309,7 @@ noncomputable def valued.extension_valuation :
       norm_cast,
       exact valuation.map_mul _ _ _ },
   end,
-  map_add' := λ x y, begin
+  map_add_le_max' := λ x y, begin
     rw le_max_iff,
     apply completion.induction_on₂ x y,
     { have cont : continuous (valued.extension : hat K → Γ₀ K) := valued.continuous_extension,


### PR DESCRIPTION
Introduce `valuation_class`, the companion typeclass to `valuation`. Deprecate lemmas. Rename the field from `map_add'` to `map_add_le_max'` to avoid confusion with the eponymous field from `add_hom`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
