### PR TITLE
[Merged by Bors] - feat(algebra.group.hom_instances): Define left and right multiplication operators

### DIFF
--- a/src/algebra/group/hom_instances.lean
+++ b/src/algebra/group/hom_instances.lean
@@ -228,4 +228,11 @@ lemma add_monoid_hom.map_mul_iff (f : R →+ S) :
     (add_monoid_hom.mul : R →+ R →+ R).compr₂ f = (add_monoid_hom.mul.comp f).compl₂ f :=
 iff.symm add_monoid_hom.ext_iff₂
 
+/-- The left multiplicaiton map: `(a, b) ↦ a * b`. See also `add_monoid_hom.mul_left`. -/
+@[simps] def add_monoid.End.mul_left : R →+ add_monoid.End R := add_monoid_hom.mul
+
+/-- The right multiplicaiton map: `(a, b) ↦ b * a`. See also `add_monoid_hom.mul_right`. -/
+@[simps] def add_monoid.End.mul_right : R →+ add_monoid.End R := (add_monoid_hom.mul :
+  R →+ add_monoid.End R).flip
+
 end semiring

--- a/src/algebra/group/hom_instances.lean
+++ b/src/algebra/group/hom_instances.lean
@@ -232,7 +232,7 @@ iff.symm add_monoid_hom.ext_iff₂
 @[simps] def add_monoid.End.mul_left : R →+ add_monoid.End R := add_monoid_hom.mul
 
 /-- The right multiplicaiton map: `(a, b) ↦ b * a`. See also `add_monoid_hom.mul_right`. -/
-@[simps] def add_monoid.End.mul_right : R →+ add_monoid.End R := (add_monoid_hom.mul :
-  R →+ add_monoid.End R).flip
+@[simps] def add_monoid.End.mul_right : R →+ add_monoid.End R :=
+(add_monoid_hom.mul : R →+ add_monoid.End R).flip
 
 end semiring


### PR DESCRIPTION
Defines left and right multiplication operators on non unital, non associative semirings.

Suggested by @ocfnash for #11073

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
