### PR TITLE
[Merged by Bors] -  feat(group_theory/torsion): define torsion groups

### DIFF
--- a/src/group_theory/exponent.lean
+++ b/src/group_theory/exponent.lean
@@ -64,13 +64,17 @@ if h : exponent_exists G then nat.find h else 0
 variable {G}
 
 @[to_additive]
-lemma exponent_eq_zero_iff : exponent G = 0 ↔ ¬ exponent_exists G :=
+lemma exponent_exists_iff_ne_zero : exponent_exists G ↔ exponent G ≠ 0 :=
 begin
   rw [exponent],
   split_ifs,
   { simp [h, @not_lt_zero' ℕ] }, --if this isn't done this way, `to_additive` freaks
-  { tauto }
+  { tauto },
 end
+
+@[to_additive]
+lemma exponent_eq_zero_iff : exponent G = 0 ↔ ¬ exponent_exists G := 
+by simp only [exponent_exists_iff_ne_zero, not_not]
 
 @[to_additive]
 lemma exponent_eq_zero_of_order_zero {g : G} (hg : order_of g = 0) : exponent G = 0 :=

--- a/src/group_theory/order_of_element.lean
+++ b/src/group_theory/order_of_element.lean
@@ -8,6 +8,7 @@ import algebra.iterate_hom
 import algebra.pointwise
 import dynamics.periodic_pts
 import group_theory.coset
+import group_theory.quotient_group
 
 /-!
 # Order of an element
@@ -67,6 +68,23 @@ lemma is_of_fin_order_of_add_iff :
 lemma is_of_fin_order_iff_pow_eq_one (x : G) :
   is_of_fin_order x ↔ ∃ n, 0 < n ∧ x ^ n = 1 :=
 by { convert iff.rfl, simp [is_periodic_pt_mul_iff_pow_eq_one] }
+
+/-- Elements of finite order are of finite order in subgroups.-/
+@[to_additive is_of_fin_add_order_iff_coe]
+lemma is_of_fin_order_iff_coe {G : Type u} [group G] (H : subgroup G) (x : H) :
+  is_of_fin_order x ↔ is_of_fin_order (x : G) :=
+by { rw [is_of_fin_order_iff_pow_eq_one, is_of_fin_order_iff_pow_eq_one], norm_cast }
+
+variables 
+
+/-- Elements of finite order are of finite order in quotient groups.-/
+@[to_additive is_of_fin_add_order_iff_quotient]
+lemma is_of_fin_order.quotient {G : Type u} [group G] (N : subgroup G) [N.normal] (x : G) :
+  is_of_fin_order x → is_of_fin_order (x : G ⧸ N) := begin
+  rw [is_of_fin_order_iff_pow_eq_one, is_of_fin_order_iff_pow_eq_one],
+  rintros ⟨n, ⟨npos, hn⟩⟩,
+  exact ⟨n, ⟨npos, (quotient_group.con N).eq.mpr $ hn ▸ (quotient_group.con N).eq.mp rfl⟩⟩,
+end
 
 end is_of_fin_order
 

--- a/src/group_theory/torsion.lean
+++ b/src/group_theory/torsion.lean
@@ -56,6 +56,7 @@ lemma subgroup.is_torsion {tG : is_torsion G} (H : subgroup G) : is_torsion H :=
 end
 
 /--Quotient groups of torsion groups are torsion groups. -/
+@[to_additive "Quotient groups of additive torsion groups are additive torsion groups."]
 lemma quotient_group.is_torsion [nN : N.normal] (tG : is_torsion G) : is_torsion (G ⧸ N) :=
 λ g, quotient.induction_on' g $ λ a, begin
   rw is_of_fin_order_iff_pow_eq_one,
@@ -64,6 +65,7 @@ lemma quotient_group.is_torsion [nN : N.normal] (tG : is_torsion G) : is_torsion
 end
 
 /--If a group exponent exists, the group is torsion. -/
+@[to_additive exponent_exists.is_add_torsion]
 lemma exponent_exists.is_torsion (h : exponent_exists G) : is_torsion G := begin
   intro g,
   obtain ⟨n, npos, hn⟩ := h,
@@ -71,6 +73,7 @@ lemma exponent_exists.is_torsion (h : exponent_exists G) : is_torsion G := begin
 end
 
 /--The group exponent exists for any bounded torsion group. -/
+@[to_additive exponent_exists.of_is_add_torsion]
 lemma exponent_exists.of_is_torsion
   (tG : is_torsion G)
   (bounded : (set.range (λ g : G, order_of g)).finite) : exponent_exists G :=
@@ -78,5 +81,6 @@ exponent_exists_iff_ne_zero.mpr $
   (exponent_ne_zero_iff_range_order_of_finite (λ g, order_of_pos' (tG g))).mpr bounded
 
 /--Finite groups are torsion groups.-/
+@[to_additive is_add_torsion_of_fintype]
 lemma is_torsion_of_fintype [fintype G] : is_torsion G :=
 exponent_exists.is_torsion $ exponent_exists_iff_ne_zero.mpr exponent_ne_zero_of_fintype

--- a/src/group_theory/torsion.lean
+++ b/src/group_theory/torsion.lean
@@ -1,0 +1,63 @@
+/-
+Copyright (c) 2021 Julian Berman. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Julian Berman
+-/
+
+import group_theory.quotient_group
+
+/-!
+# Torsion groups
+
+This file defines torsion groups, i.e. groups where all elements have finite order.
+
+## Main definitions
+
+* `monoid.is_torsion` is a predicate asserting a monoid `G` is a torsion monoid, i.e. that for
+  each `g : G` there is some positive `n` such that `g ^ n = 1`. Torsion groups are also known as
+  periodic groups.
+* `add_monoid.is_torsion` the additive version of `monoid.is_torsion`.
+
+## Main results
+
+-/
+
+universe u
+
+variable {G : Type u}
+
+open_locale classical
+
+namespace monoid
+
+variables (G) [monoid G]
+
+/--A predicate on a monoid saying that there is a positive integer `n` such that `g ^ n = 1`
+  for all `g`.-/
+@[to_additive "A predicate on an additive monoid saying that for each `g` there is a positive
+  integer `n` such that `n • g = 0` for all `g`."]
+def is_torsion := ∀ g : G, ∃ n, 0 < n ∧ g ^ n = 1
+
+end monoid
+
+open monoid (is_torsion)
+
+variables [group G] {N : subgroup G}
+
+/--Subgroups of torsion groups are torsion groups. -/
+@[to_additive "Subgroups of additive torsion groups are additive torsion groups."]
+lemma subgroup.is_torsion {tG : is_torsion G} (H : subgroup G) : is_torsion H := begin
+  intro g,
+  obtain ⟨n, ⟨npos, hn⟩⟩ := tG g,
+  refine ⟨n, npos, subtype.coe_injective _⟩,
+  rw [subgroup.coe_pow, subgroup.coe_one, hn],
+end
+
+/--Quotient groups of torsion groups are torsion groups. -/
+lemma quotient_group.is_torsion [nN : N.normal] (tG : is_torsion G) : is_torsion (G ⧸ N) := begin
+  intro g,
+  refine quotient.induction_on' g _,
+  intro a,
+  obtain ⟨n, ⟨npos, hn⟩⟩ := tG a,
+  exact ⟨n, npos, (quotient_group.con N).eq.mpr $ hn ▸ (quotient_group.con N).eq.mp rfl⟩,
+end

--- a/src/group_theory/torsion.lean
+++ b/src/group_theory/torsion.lean
@@ -47,7 +47,7 @@ variables [group G] {N : subgroup G}
 
 /--Subgroups of torsion groups are torsion groups. -/
 @[to_additive "Subgroups of additive torsion groups are additive torsion groups."]
-lemma subgroup.is_torsion {tG : is_torsion G} (H : subgroup G) : is_torsion H := begin
+lemma is_torsion.subgroup (tG : is_torsion G) (H : subgroup G) : is_torsion H := begin
   intro g,
   obtain ⟨n, ⟨npos, hn⟩⟩ := (is_of_fin_order_iff_pow_eq_one ↑g).mp (tG _),
   rw is_of_fin_order_iff_pow_eq_one,
@@ -57,7 +57,7 @@ end
 
 /--Quotient groups of torsion groups are torsion groups. -/
 @[to_additive "Quotient groups of additive torsion groups are additive torsion groups."]
-lemma quotient_group.is_torsion [nN : N.normal] (tG : is_torsion G) : is_torsion (G ⧸ N) :=
+lemma is_torsion.quotient_group [nN : N.normal] (tG : is_torsion G) : is_torsion (G ⧸ N) :=
 λ g, quotient.induction_on' g $ λ a, begin
   rw is_of_fin_order_iff_pow_eq_one,
   obtain ⟨n, ⟨npos, hn⟩⟩ := (is_of_fin_order_iff_pow_eq_one _).mp (tG a),
@@ -74,9 +74,9 @@ end
 
 /--The group exponent exists for any bounded torsion group. -/
 @[to_additive exponent_exists.of_is_add_torsion]
-lemma exponent_exists.of_is_torsion
-  (tG : is_torsion G)
-  (bounded : (set.range (λ g : G, order_of g)).finite) : exponent_exists G :=
+lemma is_torsion.exponent_exists
+  (tG : is_torsion G)   (bounded : (set.range (λ g : G, order_of g)).finite) :
+  exponent_exists G :=
 exponent_exists_iff_ne_zero.mpr $
   (exponent_ne_zero_iff_range_order_of_finite (λ g, order_of_pos' (tG g))).mpr bounded
 

--- a/src/group_theory/torsion.lean
+++ b/src/group_theory/torsion.lean
@@ -19,8 +19,10 @@ This file defines torsion groups, i.e. groups where all elements have finite ord
   elements are of finite order. Torsion groups are also known as periodic groups.
 * `add_monoid.is_torsion` the additive version of `monoid.is_torsion`.
 
-## Main results
+## Future work
 
+* Define `tor G` for the torsion subgroup of a group
+* torsion-free groups
 -/
 
 universe u

--- a/src/group_theory/torsion.lean
+++ b/src/group_theory/torsion.lean
@@ -64,8 +64,8 @@ end
 /--If a group exponent exists, the group is torsion. -/
 lemma exponent_exists.is_torsion (h : exponent_exists G) : is_torsion G := begin
   intro g,
-  obtain ⟨n, ⟨npos, hn⟩⟩ := h,
-  exact ⟨n, npos, (is_periodic_pt_mul_iff_pow_eq_one _).mpr $ hn g⟩,
+  obtain ⟨n, npos, hn⟩ := h,
+  exact (is_of_fin_order_iff_pow_eq_one g).mpr ⟨n, npos, hn g⟩,
 end
 
 /--Finite groups are torsion groups.-/

--- a/src/group_theory/torsion.lean
+++ b/src/group_theory/torsion.lean
@@ -73,14 +73,14 @@ lemma exponent_exists.is_torsion (h : exponent_exists G) : is_torsion G := begin
 end
 
 /--The group exponent exists for any bounded torsion group. -/
-@[to_additive exponent_exists.of_is_add_torsion]
+@[to_additive is_add_torsion.exponent_exists]
 lemma is_torsion.exponent_exists
-  (tG : is_torsion G)   (bounded : (set.range (λ g : G, order_of g)).finite) :
+  (tG : is_torsion G) (bounded : (set.range (λ g : G, order_of g)).finite) :
   exponent_exists G :=
 exponent_exists_iff_ne_zero.mpr $
   (exponent_ne_zero_iff_range_order_of_finite (λ g, order_of_pos' (tG g))).mpr bounded
 
 /--Finite groups are torsion groups.-/
-@[to_additive is_add_torsion_of_fintype]
-lemma is_torsion_of_fintype [fintype G] : is_torsion G :=
+@[to_additive is_add_torsion.fintype]
+lemma is_torsion.fintype [fintype G] : is_torsion G :=
 exponent_exists.is_torsion $ exponent_exists_iff_ne_zero.mpr exponent_ne_zero_of_fintype

--- a/src/group_theory/torsion.lean
+++ b/src/group_theory/torsion.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Julian Berman
 -/
 
+import group_theory.exponent
 import group_theory.quotient_group
 
 /-!
@@ -40,7 +41,7 @@ def is_torsion := ∀ g : G, ∃ n, 0 < n ∧ g ^ n = 1
 
 end monoid
 
-open monoid (is_torsion)
+open monoid (exponent_exists is_torsion)
 
 variables [group G] {N : subgroup G}
 
@@ -60,4 +61,12 @@ lemma quotient_group.is_torsion [nN : N.normal] (tG : is_torsion G) : is_torsion
   intro a,
   obtain ⟨n, ⟨npos, hn⟩⟩ := tG a,
   exact ⟨n, npos, (quotient_group.con N).eq.mpr $ hn ▸ (quotient_group.con N).eq.mp rfl⟩,
+end
+
+/--If a group exponent exists, the group is torsion. -/
+lemma exponent_exists.is_torsion (h : exponent_exists G) : is_torsion G :=
+begin
+  intro g,
+  obtain ⟨n, ⟨npos, hn⟩⟩ := h,
+  exact ⟨n, npos, hn g⟩,
 end

--- a/src/group_theory/torsion.lean
+++ b/src/group_theory/torsion.lean
@@ -41,7 +41,7 @@ def is_torsion := ∀ g : G, ∃ n, 0 < n ∧ g ^ n = 1
 
 end monoid
 
-open monoid (exponent_exists is_torsion)
+open monoid
 
 variables [group G] {N : subgroup G}
 
@@ -64,9 +64,12 @@ lemma quotient_group.is_torsion [nN : N.normal] (tG : is_torsion G) : is_torsion
 end
 
 /--If a group exponent exists, the group is torsion. -/
-lemma exponent_exists.is_torsion (h : exponent_exists G) : is_torsion G :=
-begin
+lemma exponent_exists.is_torsion (h : exponent_exists G) : is_torsion G := begin
   intro g,
   obtain ⟨n, ⟨npos, hn⟩⟩ := h,
   exact ⟨n, npos, hn g⟩,
 end
+
+/--Finite groups are torsion groups.-/
+lemma is_torsion_of_fintype [fintype G] : is_torsion G :=
+exponent_exists.is_torsion $ exponent_exists_iff_ne_zero.mpr exponent_ne_zero_of_fintype

--- a/src/group_theory/torsion.lean
+++ b/src/group_theory/torsion.lean
@@ -47,19 +47,18 @@ variables [group G] {N : subgroup G}
 @[to_additive "Subgroups of additive torsion groups are additive torsion groups."]
 lemma subgroup.is_torsion {tG : is_torsion G} (H : subgroup G) : is_torsion H := begin
   intro g,
-  obtain ⟨n, ⟨npos, hn⟩⟩ := tG g,
+  obtain ⟨n, ⟨npos, hn⟩⟩ := (is_of_fin_order_iff_pow_eq_one ↑g).mp (tG _),
+  rw is_of_fin_order_iff_pow_eq_one,
   refine ⟨n, npos, subtype.coe_injective _⟩,
-  rw is_periodic_pt_mul_iff_pow_eq_one ↑g at hn,
-  simp only [hn, is_periodic_pt_mul_iff_pow_eq_one ↑g, mul_left_iterate, _root_.mul_one,
-             subgroup.coe_pow, subgroup.coe_one],
+  simp only [hn, subgroup.coe_pow, subgroup.coe_one],
 end
 
 /--Quotient groups of torsion groups are torsion groups. -/
 lemma quotient_group.is_torsion [nN : N.normal] (tG : is_torsion G) : is_torsion (G ⧸ N) :=
 λ g, quotient.induction_on' g $ λ a, begin
-  obtain ⟨n, ⟨npos, hn⟩⟩ := tG a,
-  refine ⟨n, npos, (is_periodic_pt_mul_iff_pow_eq_one _).mpr $ (quotient_group.con N).eq.mpr _⟩,
-  exact (is_periodic_pt_mul_iff_pow_eq_one a).mp hn ▸ (quotient_group.con N).eq.mp rfl,
+  rw is_of_fin_order_iff_pow_eq_one,
+  obtain ⟨n, ⟨npos, hn⟩⟩ := (is_of_fin_order_iff_pow_eq_one _).mp (tG a),
+  exact ⟨n, npos, (quotient_group.con N).eq.mpr (hn ▸ (quotient_group.con N).eq.mp rfl)⟩,
 end
 
 /--If a group exponent exists, the group is torsion. -/
@@ -68,7 +67,6 @@ lemma exponent_exists.is_torsion (h : exponent_exists G) : is_torsion G := begin
   obtain ⟨n, ⟨npos, hn⟩⟩ := h,
   exact ⟨n, npos, (is_periodic_pt_mul_iff_pow_eq_one _).mpr $ hn g⟩,
 end
-
 
 /--Finite groups are torsion groups.-/
 lemma is_torsion_of_fintype [fintype G] : is_torsion G :=

--- a/src/group_theory/torsion.lean
+++ b/src/group_theory/torsion.lean
@@ -47,28 +47,19 @@ variables [group G] {N : subgroup G}
 
 /--Subgroups of torsion groups are torsion groups. -/
 @[to_additive "Subgroups of additive torsion groups are additive torsion groups."]
-lemma is_torsion.subgroup (tG : is_torsion G) (H : subgroup G) : is_torsion H := begin
-  intro g,
-  obtain ⟨n, ⟨npos, hn⟩⟩ := (is_of_fin_order_iff_pow_eq_one ↑g).mp (tG _),
-  rw is_of_fin_order_iff_pow_eq_one,
-  refine ⟨n, npos, subtype.coe_injective _⟩,
-  simp only [hn, subgroup.coe_pow, subgroup.coe_one],
-end
+lemma is_torsion.subgroup (tG : is_torsion G) (H : subgroup G) : is_torsion H :=
+λ h, (is_of_fin_order_iff_coe _ h).mpr $ tG h
 
 /--Quotient groups of torsion groups are torsion groups. -/
 @[to_additive "Quotient groups of additive torsion groups are additive torsion groups."]
 lemma is_torsion.quotient_group [nN : N.normal] (tG : is_torsion G) : is_torsion (G ⧸ N) :=
-λ g, quotient.induction_on' g $ λ a, begin
-  rw is_of_fin_order_iff_pow_eq_one,
-  obtain ⟨n, ⟨npos, hn⟩⟩ := (is_of_fin_order_iff_pow_eq_one _).mp (tG a),
-  exact ⟨n, npos, (quotient_group.con N).eq.mpr (hn ▸ (quotient_group.con N).eq.mp rfl)⟩,
-end
+λ h, quotient_group.induction_on' h $ λ g, (tG g).quotient N g
 
 /--If a group exponent exists, the group is torsion. -/
 @[to_additive exponent_exists.is_add_torsion]
 lemma exponent_exists.is_torsion (h : exponent_exists G) : is_torsion G := begin
-  intro g,
   obtain ⟨n, npos, hn⟩ := h,
+  intro g,
   exact (is_of_fin_order_iff_pow_eq_one g).mpr ⟨n, npos, hn g⟩,
 end
 

--- a/src/group_theory/torsion.lean
+++ b/src/group_theory/torsion.lean
@@ -70,6 +70,13 @@ lemma exponent_exists.is_torsion (h : exponent_exists G) : is_torsion G := begin
   exact (is_of_fin_order_iff_pow_eq_one g).mpr ⟨n, npos, hn g⟩,
 end
 
+/--The group exponent exists for any bounded torsion group. -/
+lemma exponent_exists.of_is_torsion
+  (tG : is_torsion G)
+  (bounded : (set.range (λ g : G, order_of g)).finite) : exponent_exists G :=
+exponent_exists_iff_ne_zero.mpr $
+  (exponent_ne_zero_iff_range_order_of_finite (λ g, order_of_pos' (tG g))).mpr bounded
+
 /--Finite groups are torsion groups.-/
 lemma is_torsion_of_fintype [fintype G] : is_torsion G :=
 exponent_exists.is_torsion $ exponent_exists_iff_ne_zero.mpr exponent_ne_zero_of_fintype

--- a/src/group_theory/torsion.lean
+++ b/src/group_theory/torsion.lean
@@ -81,6 +81,6 @@ exponent_exists_iff_ne_zero.mpr $
   (exponent_ne_zero_iff_range_order_of_finite (λ g, order_of_pos' (tG g))).mpr bounded
 
 /--Finite groups are torsion groups.-/
-@[to_additive is_add_torsion.fintype]
-lemma is_torsion.fintype [fintype G] : is_torsion G :=
+@[to_additive is_add_torsion_of_fintype]
+lemma is_torsion_of_fintype [fintype G] : is_torsion G :=
 exponent_exists.is_torsion $ exponent_exists_iff_ne_zero.mpr exponent_ne_zero_of_fintype


### PR DESCRIPTION
I grepped for torsion group and didn't find anything -- hopefully adding this makes sense here.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
