### PR TITLE
[Merged by Bors] - feat(data/real/ennreal): `inv` is an `order_iso` to the order dual and lemmas for `supr, infi`

### DIFF
--- a/src/data/real/ennreal.lean
+++ b/src/data/real/ennreal.lean
@@ -1067,7 +1067,8 @@ def order_iso_inv_dual : ℝ≥0∞ ≃o order_dual ℝ≥0∞ :=
   right_inv := @ennreal.inv_inv,
   map_rel_iff' := λ a b, ennreal.inv_le_inv }
 
-lemma order_iso_inv_dual_symm_apply : ∀ x, order_iso_inv_dual.symm x = x⁻¹ := λ x, rfl
+@[simp]
+lemma order_iso_inv_dual_symm_apply : order_iso_inv_dual.symm a = a⁻¹ := rfl
 
 lemma pow_le_pow_of_le_one {n m : ℕ} (ha : a ≤ 1) (h : n ≤ m) : a ^ m ≤ a ^ n :=
 begin

--- a/src/data/real/ennreal.lean
+++ b/src/data/real/ennreal.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl, Yury Kudryashov
 -/
 import data.real.nnreal
+import order.liminf_limsup
 
 /-!
 # Extended non-negative reals
@@ -1057,6 +1058,17 @@ le_inv_iff_le_inv.trans $ by rw inv_one
 @[simp] lemma inv_lt_one : a⁻¹ < 1 ↔ 1 < a :=
 inv_lt_iff_inv_lt.trans $ by rw [inv_one]
 
+/-- The inverse map `λ x, x⁻¹` is an order isomorphism between `ℝ≥0∞` and its `order_dual` -/
+@[simps apply]
+def order_iso_inv_dual : ℝ≥0∞ ≃o order_dual ℝ≥0∞ :=
+{ to_fun := λ x, x⁻¹,
+  inv_fun := λ x, x⁻¹,
+  left_inv := @ennreal.inv_inv,
+  right_inv := @ennreal.inv_inv,
+  map_rel_iff' := λ a b, ennreal.inv_le_inv }
+
+lemma order_iso_inv_dual_symm_apply : ∀ x, order_iso_inv_dual.symm x = x⁻¹ := λ x, rfl
+
 lemma pow_le_pow_of_le_one {n m : ℕ} (ha : a ≤ 1) (h : n ≤ m) : a ^ m ≤ a ^ n :=
 begin
   rw [← @inv_inv a, ← ennreal.inv_pow, ← @ennreal.inv_pow a⁻¹, inv_le_inv],
@@ -1853,5 +1865,27 @@ lemma supr_coe_nat : (⨆n:ℕ, (n : ℝ≥0∞)) = ∞ :=
 (supr_eq_top _).2 $ assume b hb, ennreal.exists_nat_gt (lt_top_iff_ne_top.1 hb)
 
 end supr
+
+section inv_supr_infi
+
+open filter
+
+theorem inv_map_supr {ι : Sort*} {x : ι → ℝ≥0∞} :
+  (supr x)⁻¹ = (⨅ i, (x i)⁻¹) :=
+order_iso_inv_dual.map_supr x
+
+theorem inv_map_infi {ι : Sort*} {x : ι → ℝ≥0∞} :
+  (infi x)⁻¹ = (⨆ i, (x i)⁻¹) :=
+order_iso_inv_dual.map_infi x
+
+theorem inv_limsup {ι : Sort*} {x : ι → ℝ≥0∞} {l : filter ι} :
+  (l.limsup x)⁻¹ = l.liminf (λ i, (x i)⁻¹) :=
+by simp only [limsup_eq_infi_supr, inv_map_infi, inv_map_supr, liminf_eq_supr_infi]
+
+theorem inv_liminf {ι : Sort*} {x : ι → ℝ≥0∞} {l : filter ι} :
+  (l.liminf x)⁻¹ = l.limsup (λ i, (x i)⁻¹) :=
+by simp only [limsup_eq_infi_supr, inv_map_infi, inv_map_supr, liminf_eq_supr_infi]
+
+end inv_supr_infi
 
 end ennreal

--- a/src/data/real/ennreal.lean
+++ b/src/data/real/ennreal.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl, Yury Kudryashov
 -/
 import data.real.nnreal
-import order.liminf_limsup
 
 /-!
 # Extended non-negative reals
@@ -1060,7 +1059,7 @@ inv_lt_iff_inv_lt.trans $ by rw [inv_one]
 
 /-- The inverse map `λ x, x⁻¹` is an order isomorphism between `ℝ≥0∞` and its `order_dual` -/
 @[simps apply]
-def order_iso_inv_dual : ℝ≥0∞ ≃o order_dual ℝ≥0∞ :=
+def inv_order_iso : ℝ≥0∞ ≃o order_dual ℝ≥0∞ :=
 { to_fun := λ x, x⁻¹,
   inv_fun := λ x, x⁻¹,
   left_inv := @ennreal.inv_inv,
@@ -1068,7 +1067,7 @@ def order_iso_inv_dual : ℝ≥0∞ ≃o order_dual ℝ≥0∞ :=
   map_rel_iff' := λ a b, ennreal.inv_le_inv }
 
 @[simp]
-lemma order_iso_inv_dual_symm_apply : order_iso_inv_dual.symm a = a⁻¹ := rfl
+lemma inv_order_iso_symm_apply : inv_order_iso.symm a = a⁻¹ := rfl
 
 lemma pow_le_pow_of_le_one {n m : ℕ} (ha : a ≤ 1) (h : n ≤ m) : a ^ m ≤ a ^ n :=
 begin
@@ -1866,27 +1865,5 @@ lemma supr_coe_nat : (⨆n:ℕ, (n : ℝ≥0∞)) = ∞ :=
 (supr_eq_top _).2 $ assume b hb, ennreal.exists_nat_gt (lt_top_iff_ne_top.1 hb)
 
 end supr
-
-section inv_supr_infi
-
-open filter
-
-theorem inv_map_supr {ι : Sort*} {x : ι → ℝ≥0∞} :
-  (supr x)⁻¹ = (⨅ i, (x i)⁻¹) :=
-order_iso_inv_dual.map_supr x
-
-theorem inv_map_infi {ι : Sort*} {x : ι → ℝ≥0∞} :
-  (infi x)⁻¹ = (⨆ i, (x i)⁻¹) :=
-order_iso_inv_dual.map_infi x
-
-theorem inv_limsup {ι : Sort*} {x : ι → ℝ≥0∞} {l : filter ι} :
-  (l.limsup x)⁻¹ = l.liminf (λ i, (x i)⁻¹) :=
-by simp only [limsup_eq_infi_supr, inv_map_infi, inv_map_supr, liminf_eq_supr_infi]
-
-theorem inv_liminf {ι : Sort*} {x : ι → ℝ≥0∞} {l : filter ι} :
-  (l.liminf x)⁻¹ = l.limsup (λ i, (x i)⁻¹) :=
-by simp only [limsup_eq_infi_supr, inv_map_infi, inv_map_supr, liminf_eq_supr_infi]
-
-end inv_supr_infi
 
 end ennreal

--- a/src/topology/instances/ennreal.lean
+++ b/src/topology/instances/ennreal.lean
@@ -423,6 +423,22 @@ lemma infi_mul_right {ι} [nonempty ι] {f : ι → ℝ≥0∞} {a : ℝ≥0∞}
   (⨅ i, f i * a) = (⨅ i, f i) * a :=
 infi_mul_right' h (λ _, ‹nonempty ι›)
 
+lemma inv_map_infi {ι : Sort*} {x : ι → ℝ≥0∞} :
+  (infi x)⁻¹ = (⨆ i, (x i)⁻¹) :=
+inv_order_iso.map_infi x
+
+lemma inv_map_supr {ι : Sort*} {x : ι → ℝ≥0∞} :
+  (supr x)⁻¹ = (⨅ i, (x i)⁻¹) :=
+inv_order_iso.map_supr x
+
+lemma inv_limsup {ι : Sort*} {x : ι → ℝ≥0∞} {l : filter ι} :
+  (l.limsup x)⁻¹ = l.liminf (λ i, (x i)⁻¹) :=
+by simp only [limsup_eq_infi_supr, inv_map_infi, inv_map_supr, liminf_eq_supr_infi]
+
+lemma inv_liminf {ι : Sort*} {x : ι → ℝ≥0∞} {l : filter ι} :
+  (l.liminf x)⁻¹ = l.limsup (λ i, (x i)⁻¹) :=
+by simp only [limsup_eq_infi_supr, inv_map_infi, inv_map_supr, liminf_eq_supr_infi]
+
 protected lemma continuous_inv : continuous (has_inv.inv : ℝ≥0∞ → ℝ≥0∞) :=
 continuous_iff_continuous_at.2 $ λ a, tendsto_order.2
 ⟨begin


### PR DESCRIPTION
Establishes that `inv` is an order isomorphism to the order dual. We then provide some convenience lemmas which guarantee that `inv` switches `supr` and `infi` and hence also switches `limsup` and `liminf`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
