### PR TITLE
refactor(*): `bounded (≤)` → `bdd_above`

### DIFF
--- a/src/order/bounds.lean
+++ b/src/order/bounds.lean
@@ -91,6 +91,26 @@ lemma not_bdd_below_iff {α : Type*} [linear_order α] {s : set α} :
   ¬bdd_below s ↔ ∀ x, ∃ y ∈ s, y < x :=
 @not_bdd_above_iff (order_dual α) _ _
 
+/-- A set `s` is not bounded above if and only if for each `x` there exists `y ∈ s` that is greater
+or equal to `x`. -/
+lemma not_bdd_above_iff_le {α : Type*} [linear_order α] [no_max_order α] {s : set α} :
+  ¬bdd_above s ↔ ∀ x, ∃ y ∈ s, x ≤ y :=
+begin
+  rw not_bdd_above_iff,
+  refine ⟨λ h a, _, λ h a, _⟩,
+  { rcases h a with ⟨b, hb, hb'⟩,
+    exact ⟨b, hb, hb'.le⟩ },
+  { cases exists_gt a with b hb,
+    rcases h b with ⟨c, hc, hc'⟩,
+    exact ⟨c, hc, hb.trans_le hc'⟩ }
+end
+
+/-- A set `s` is not bounded below if and only if for each `x` there exists `y ∈ s` that is less
+or equal to `x`. -/
+lemma not_bdd_below_iff_le {α : Type*} [linear_order α] [no_min_order α] {s : set α} :
+  ¬bdd_below s ↔ ∀ x, ∃ y ∈ s, y ≤ x :=
+@not_bdd_above_iff_le (order_dual α) _ _ _
+
 lemma bdd_above.dual (h : bdd_above s) : bdd_below (of_dual ⁻¹' s) := h
 
 lemma bdd_below.dual (h : bdd_below s) : bdd_above (of_dual ⁻¹' s) := h

--- a/src/set_theory/cardinal_ordinal.lean
+++ b/src/set_theory/cardinal_ordinal.lean
@@ -236,7 +236,7 @@ lemma countable_iff_lt_aleph_one {α : Type*} (s : set α) : countable s ↔ #s 
 by rw [← succ_omega, lt_succ, mk_set_le_omega]
 
 /-- Ordinals that are cardinals are unbounded. -/
-theorem ord_card_unbounded : unbounded (<) {b : ordinal | b.card.ord = b} :=
+theorem ord_card_unbounded : ¬ bdd_above {b : ordinal | b.card.ord = b} :=
 unbounded_lt_iff.2 $ λ a, ⟨_, ⟨(by { dsimp, rw card_ord }), (lt_ord_succ_card a).le⟩⟩
 
 theorem eq_aleph'_of_eq_card_ord {o : ordinal} (ho : o.card.ord = o) : ∃ a, (aleph' a).ord = o :=
@@ -251,7 +251,7 @@ begin
 end
 
 /-- Infinite ordinals that are cardinals are unbounded. -/
-theorem ord_card_unbounded' : unbounded (<) {b : ordinal | b.card.ord = b ∧ ordinal.omega ≤ b} :=
+theorem ord_card_unbounded' : ¬ bdd_above {b : ordinal | b.card.ord = b ∧ ordinal.omega ≤ b} :=
 (unbounded_lt_inter_le ordinal.omega).2 ord_card_unbounded
 
 theorem eq_aleph_of_eq_card_ord {o : ordinal} (ho : o.card.ord = o) (ho' : ordinal.omega ≤ o) :

--- a/src/set_theory/cardinal_ordinal.lean
+++ b/src/set_theory/cardinal_ordinal.lean
@@ -237,7 +237,7 @@ by rw [← succ_omega, lt_succ, mk_set_le_omega]
 
 /-- Ordinals that are cardinals are unbounded. -/
 theorem ord_card_unbounded : ¬ bdd_above {b : ordinal | b.card.ord = b} :=
-unbounded_lt_iff.2 $ λ a, ⟨_, ⟨(by { dsimp, rw card_ord }), (lt_ord_succ_card a).le⟩⟩
+not_bdd_above_iff_le.2 $ λ a, ⟨_, ⟨(by { dsimp, rw card_ord }), (lt_ord_succ_card a).le⟩⟩
 
 theorem eq_aleph'_of_eq_card_ord {o : ordinal} (ho : o.card.ord = o) : ∃ a, (aleph' a).ord = o :=
 ⟨cardinal.aleph_idx.rel_iso o.card, by simpa using ho⟩
@@ -252,7 +252,11 @@ end
 
 /-- Infinite ordinals that are cardinals are unbounded. -/
 theorem ord_card_unbounded' : ¬ bdd_above {b : ordinal | b.card.ord = b ∧ ordinal.omega ≤ b} :=
-(unbounded_lt_inter_le ordinal.omega).2 ord_card_unbounded
+λ ⟨a, ha⟩, begin
+  rcases (not_bdd_above_iff.1 ord_card_unbounded) (max ordinal.omega a) with ⟨b, hb, hb'⟩,
+  simp [upper_bounds] at ha,
+  exact (ha hb ((le_max_left _ _).trans hb'.le)).not_lt ((le_max_right _ _).trans_lt hb')
+end
 
 theorem eq_aleph_of_eq_card_ord {o : ordinal} (ho : o.card.ord = o) (ho' : ordinal.omega ≤ o) :
   ∃ a, (aleph a).ord = o :=

--- a/src/set_theory/ordinal_arithmetic.lean
+++ b/src/set_theory/ordinal_arithmetic.lean
@@ -1252,7 +1252,7 @@ variables {S : set ordinal.{u}} (hS : ¬ bdd_above S)
 -- A characterization of unboundedness that's more convenient to our purposes.
 include hS
 private lemma unbounded_aux (a) : ∃ b, b ∈ S ∧ a ≤ b :=
-let ⟨b, hb, hb'⟩ := not_bdd_above_iff.1 hS a in ⟨b, hb, hb'.le⟩
+let ⟨b, hb, hb'⟩ := not_bdd_above_iff_le.1 hS a in ⟨b, hb, hb'⟩
 
 /-- Enumerator function for an unbounded set of ordinals. -/
 def enum_ord (S : set ordinal) (hS : ¬ bdd_above S) : ordinal → ordinal :=
@@ -2163,7 +2163,7 @@ le_antisymm (sup_le.mpr $ λ i, by rw [iterate_fixed h]) (le_nfp_self f a)
 
 /-- Fixed point lemma for normal functions: the fixed points of a normal function are unbounded. -/
 theorem is_normal.nfp_unbounded {f} (H : is_normal f) : ¬ bdd_above (fixed_points f) :=
-not_bdd_above_iff.2 $ λ a, ⟨_, H.nfp_fp a.succ, succ_le.1 (le_nfp_self f a.succ)⟩
+not_bdd_above_iff_le.2 $ λ a, ⟨_, H.nfp_fp a, (le_nfp_self f a)⟩
 
 /-- The derivative of a normal function `f` is the sequence of fixed points of `f`. -/
 def deriv (f : ordinal → ordinal) (o : ordinal) : ordinal :=

--- a/src/set_theory/ordinal_arithmetic.lean
+++ b/src/set_theory/ordinal_arithmetic.lean
@@ -1250,8 +1250,9 @@ section
 variables {S : set ordinal.{u}} (hS : ¬ bdd_above S)
 
 -- A characterization of unboundedness that's more convenient to our purposes.
+include hS
 private lemma unbounded_aux (a) : ∃ b, b ∈ S ∧ a ≤ b :=
-let ⟨b, hb, hb'⟩ := hS a in ⟨b, hb, le_of_not_gt hb'⟩
+let ⟨b, hb, hb'⟩ := not_bdd_above_iff.1 hS a in ⟨b, hb, hb'.le⟩
 
 /-- Enumerator function for an unbounded set of ordinals. -/
 def enum_ord (S : set ordinal) (hS : ¬ bdd_above S) : ordinal → ordinal :=
@@ -2162,7 +2163,7 @@ le_antisymm (sup_le.mpr $ λ i, by rw [iterate_fixed h]) (le_nfp_self f a)
 
 /-- Fixed point lemma for normal functions: the fixed points of a normal function are unbounded. -/
 theorem is_normal.nfp_unbounded {f} (H : is_normal f) : ¬ bdd_above (fixed_points f) :=
-λ a, ⟨_, H.nfp_fp a, not_lt_of_ge (le_nfp_self f a)⟩
+not_bdd_above_iff.2 $ λ a, ⟨_, H.nfp_fp a.succ, succ_le.1 (le_nfp_self f a.succ)⟩
 
 /-- The derivative of a normal function `f` is the sequence of fixed points of `f`. -/
 def deriv (f : ordinal → ordinal) (o : ordinal) : ordinal :=

--- a/src/set_theory/ordinal_arithmetic.lean
+++ b/src/set_theory/ordinal_arithmetic.lean
@@ -1247,18 +1247,18 @@ theorem not_small_ordinal : ¬ small.{u} ordinal.{max u v} :=
 namespace ordinal
 
 section
-variables {S : set ordinal.{u}} (hS : unbounded (<) S)
+variables {S : set ordinal.{u}} (hS : ¬ bdd_above S)
 
 -- A characterization of unboundedness that's more convenient to our purposes.
 private lemma unbounded_aux (a) : ∃ b, b ∈ S ∧ a ≤ b :=
 let ⟨b, hb, hb'⟩ := hS a in ⟨b, hb, le_of_not_gt hb'⟩
 
 /-- Enumerator function for an unbounded set of ordinals. -/
-def enum_ord (S : set ordinal) (hS : unbounded (<) S) : ordinal → ordinal :=
+def enum_ord (S : set ordinal) (hS : ¬ bdd_above S) : ordinal → ordinal :=
 wf.fix (λ o f, omin _ (unbounded_aux hS (blsub.{u u} o f)))
 
 /-- The hypothesis that asserts that the `omin` from `enum_ord_def'` exists. -/
-lemma enum_ord_def'_H {hS : unbounded (<) S} {o} :
+lemma enum_ord_def'_H {hS : ¬ bdd_above S} {o} :
   ∃ x, x ∈ S ∧ blsub.{u u} o (λ c _, enum_ord S hS c) ≤ x :=
 unbounded_aux hS _
 
@@ -1282,7 +1282,7 @@ theorem enum_ord.strict_mono : strict_mono (enum_ord S hS) :=
 λ _ _ h, (lt_blsub.{u u} _ _ h).trans_le (blsub_le_enum_ord hS _)
 
 /-- The hypothesis that asserts that the `omin` from `enum_ord_def` exists. -/
-lemma enum_ord_def_H {hS : unbounded (<) S} {o} :
+lemma enum_ord_def_H {hS : ¬ bdd_above S} {o} :
   ∃ x, x ∈ S ∧ ∀ c, c < o → enum_ord S hS c < x :=
 (⟨_, enum_ord_mem hS o, λ _ b, enum_ord.strict_mono hS b⟩)
 
@@ -2161,7 +2161,7 @@ theorem nfp_eq_self {f : ordinal → ordinal} {a} (h : f a = a) : nfp f a = a :=
 le_antisymm (sup_le.mpr $ λ i, by rw [iterate_fixed h]) (le_nfp_self f a)
 
 /-- Fixed point lemma for normal functions: the fixed points of a normal function are unbounded. -/
-theorem is_normal.nfp_unbounded {f} (H : is_normal f) : unbounded (<) (fixed_points f) :=
+theorem is_normal.nfp_unbounded {f} (H : is_normal f) : ¬ bdd_above (fixed_points f) :=
 λ a, ⟨_, H.nfp_fp a, not_lt_of_ge (le_nfp_self f a)⟩
 
 /-- The derivative of a normal function `f` is the sequence of fixed points of `f`. -/

--- a/src/set_theory/principal.lean
+++ b/src/set_theory/principal.lean
@@ -100,6 +100,6 @@ begin
 end
 
 theorem unbounded_principal (op : ordinal → ordinal → ordinal) : ¬ bdd_above {o | principal op o} :=
-λ o, ⟨_, principal_nfp_blsub₂ op o, (le_nfp_self _ o).not_lt⟩
+not_bdd_above_iff.2 $ λ o, ⟨_, principal_nfp_blsub₂ op o, (le_nfp_self _ o)⟩
 
 end ordinal

--- a/src/set_theory/principal.lean
+++ b/src/set_theory/principal.lean
@@ -99,8 +99,7 @@ begin
     exact lt_blsub₂ op hm (hn.trans_le h) },
 end
 
-theorem unbounded_principal (op : ordinal → ordinal → ordinal) :
-  set.unbounded (<) {o | principal op o} :=
+theorem unbounded_principal (op : ordinal → ordinal → ordinal) : ¬ bdd_above {o | principal op o} :=
 λ o, ⟨_, principal_nfp_blsub₂ op o, (le_nfp_self _ o).not_lt⟩
 
 end ordinal

--- a/src/set_theory/principal.lean
+++ b/src/set_theory/principal.lean
@@ -100,6 +100,6 @@ begin
 end
 
 theorem unbounded_principal (op : ordinal → ordinal → ordinal) : ¬ bdd_above {o | principal op o} :=
-not_bdd_above_iff.2 $ λ o, ⟨_, principal_nfp_blsub₂ op o, (le_nfp_self _ o)⟩
+not_bdd_above_iff_le.2 $ λ o, ⟨_, principal_nfp_blsub₂ op o, (le_nfp_self _ o)⟩
 
 end ordinal


### PR DESCRIPTION
`bdd_above` has quite more API for it, and it's what is used for `Sup`. Moreover, throughout the rest of mathlib, `bounded` and `unbounded` are only ever used with more general relations.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
