### PR TITLE
[Merged by Bors] - feat(analysis/inner_product_space/basic): `orthonormal.map_linear_isometry_equiv`

### DIFF
--- a/src/analysis/inner_product_space/basic.lean
+++ b/src/analysis/inner_product_space/basic.lean
@@ -1116,6 +1116,12 @@ lemma orthonormal.comp_linear_isometry_equiv {v : ι → E} (hv : orthonormal �
   orthonormal 𝕜 (f ∘ v) :=
 hv.comp_linear_isometry f.to_linear_isometry
 
+/-- A linear isometric equivalence, applied with `basis.map`, preserves the property of being
+orthonormal. --/
+lemma orthonormal.map_linear_isometry_equiv {v : basis ι 𝕜 E} (hv : orthonormal 𝕜 v)
+  (f : E ≃ₗᵢ[𝕜] E') : orthonormal 𝕜 (v.map f.to_linear_equiv) :=
+hv.comp_linear_isometry_equiv f
+
 /-- A linear map that sends an orthonormal basis to orthonormal vectors is a linear isometry. -/
 def linear_map.isometry_of_orthonormal (f : E →ₗ[𝕜] E') {v : basis ι 𝕜 E} (hv : orthonormal 𝕜 v)
   (hf : orthonormal 𝕜 (f ∘ v)) : E →ₗᵢ[𝕜] E' :=


### PR DESCRIPTION
Add a variant of `orthonormal.comp_linear_isometry_equiv` for the case
of an orthonormal basis mapped with `basis.map`.

If in future we get a bundled type of orthonormal bases with its own
`map` operation, this would no longer be a separate lemma, but until
then it's useful.



---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
