### PR TITLE
feat(order/extension): extending ordered groups to linear ordered groups

### DIFF
--- a/src/order/extension.lean
+++ b/src/order/extension.lean
@@ -9,6 +9,7 @@ import tactic.by_contra
 import algebra.group_power.basic
 import algebra.smul_with_zero
 import algebra.module
+import tactic.group
 
 /-!
 # Extend a partial order to a linear order
@@ -121,34 +122,38 @@ theorem extend_ordered_group {α : Type u} [o : ordered_comm_group α]
     (@linear_ordered_comm_group.to_ordered_comm_group α l) :=
 begin
   let S := { s | is_partial_order α s ∧
-                (∀ a b : α, s a b → ∀ c : α, s (c * a) (c * b)) ∧
+                (∀ a b c : α, s a b ↔ s (c * a) (c * b)) ∧
                 ∀ x y, (∃ (n : ℕ) (hn : n ≠ 0), s (y ^ n) (x ^ n)) → s y x },
-  have hS : ∀ c, c ⊆ S → zorn.chain (≤) c → ∀ y ∈ c, ∃ ub ∈ S, ∀ z ∈ c, z ≤ ub,
-  { rintro c hc₁ hc₂ s hs,
-    haveI := (hc₁ hs).1.1,
-    refine ⟨Sup c, _, λ z hz, le_Sup hz⟩,
+  have hS : ∀ C, C ⊆ S → zorn.chain (≤) C → ∀ y ∈ C, ∃ ub ∈ S, ∀ z ∈ C, z ≤ ub,
+  { rintro C hC₁ hC₂ s hs,
+    haveI := (hC₁ hs).1.1,
+    refine ⟨Sup C, _, λ z hz, le_Sup hz⟩,
     refine ⟨{ refl := _, trans := _, antisymm := _ }, _, _⟩,
     any_goals{ simp_rw binary_relation_Sup_iff},
     { intro x,
       exact ⟨s, hs, refl x⟩ },
     { rintro x y z ⟨s₁, h₁s₁, h₂s₁⟩ ⟨s₂, h₁s₂, h₂s₂⟩,
-      haveI : is_partial_order _ _ := (hc₁ h₁s₁).1,
-      haveI : is_partial_order _ _ := (hc₁ h₁s₂).1,
-      cases hc₂.total_of_refl h₁s₁ h₁s₂,
+      haveI : is_partial_order _ _ := (hC₁ h₁s₁).1,
+      haveI : is_partial_order _ _ := (hC₁ h₁s₂).1,
+      cases hC₂.total_of_refl h₁s₁ h₁s₂,
       { exact ⟨s₂, h₁s₂, trans (h _ _ h₂s₁) h₂s₂⟩ },
       { exact ⟨s₁, h₁s₁, trans h₂s₁ (h _ _ h₂s₂)⟩ } },
     { rintro x y ⟨s₁, h₁s₁, h₂s₁⟩ ⟨s₂, h₁s₂, h₂s₂⟩,
-      haveI : is_partial_order _ _ := (hc₁ h₁s₁).1,
-      haveI : is_partial_order _ _ := (hc₁ h₁s₂).1,
-      cases hc₂.total_of_refl h₁s₁ h₁s₂,
+      haveI : is_partial_order _ _ := (hC₁ h₁s₁).1,
+      haveI : is_partial_order _ _ := (hC₁ h₁s₂).1,
+      cases hC₂.total_of_refl h₁s₁ h₁s₂,
       { exact antisymm (h _ _ h₂s₁) h₂s₂ },
       { apply antisymm h₂s₁ (h _ _ h₂s₂) } },
-    { rintro x y ⟨s₁, h₁s₁, h₂s₁⟩ z, -- TODO is this junk removable?
-      use [s₁, h₁s₁, (hc₁ h₁s₁).2.1 _ _ h₂s₁ z], },
+    { intros x y z,
+      split;
+      rintros ⟨s₁, h₁s₁, h₂s₁⟩; -- TODO is this junk removable?
+      use [s₁, h₁s₁],
+      rwa ← (hC₁ h₁s₁).2.1,
+      rwa (hC₁ h₁s₁).2.1, },
     { rintro x y ⟨n, hn, r, hr₁, hr₂⟩,
-      use [r, hr₁, (hc₁ hr₁).2.2 _ _ ⟨n, hn, hr₂⟩], }, },
+      use [r, hr₁, (hC₁ hr₁).2.2 _ _ ⟨n, hn, hr₂⟩], }, },
   obtain ⟨s, ⟨hs₁, hs₁a, hs₁b⟩, rs, hs₂⟩ := zorn.zorn_nonempty_partial_order₀ S hS (≤)
-    ⟨is_partial_order.mk, o.mul_le_mul_left, h_norm⟩,
+    ⟨is_partial_order.mk, λ a b c, by rw mul_le_mul_iff_left, h_norm⟩,
   resetI,
   have inst_refl : is_refl α s := by apply_instance, -- probably dont need to be haveI's
   have inst_trans : is_trans α s := by apply_instance,
@@ -160,36 +165,33 @@ begin
       le_antisymm := inst_antisymm.antisymm,
       le_total := _,
       decidable_le := by apply_instance,
-      mul_le_mul_left := hs₁a,
+      mul_le_mul_left := λ a b hab c, (hs₁a a _ _).mp hab,
       ..(@ordered_comm_group.to_comm_group α o)},
   refine ⟨t, rs⟩,
   intros x y,
   change s x y ∨ s y x,
   by_contra h,
-  let s' := λ x' y', ∃ p q (hpq : p ≠ 0 ∨ q ≠ 0), s ((y / x) ^ q) ((y' / x') ^ p), -- s x' y' ∨ s x' x ∧ s y y',
+  let s' := λ x' y', ∃ p q (hpq : p ≠ 0 ∨ q ≠ 0), s (y ^ q * x' ^ p) (y' ^ p * x ^ q),
   have hfine : s ≤ s',
   { intros a b h, --finer
     use [1, 0],
-    simp only [ne.def, nat.one_ne_zero, not_false_iff, eq_self_iff_true, not_true,
-      or_false, zero_smul, one_nsmul, true_and],
-    convert hs₁a _ _ h a⁻¹,
-    { simp only [pow_zero, mul_left_inv], },
-    { simp only [pow_one, div_eq_inv_mul' b a], }, },
-  have hp : ∀ (x') (y') {p q} (hpq : p ≠ 0 ∨ q ≠ 0) (hs' : s ((y / x) ^ q) ((y' / x') ^ p)), p ≠ 0,
+    simpa, },
+  have hp : ∀ x' y' {p q} (hpq : p ≠ 0 ∨ q ≠ 0) (hs' : s (y ^ q * x' ^ p) (y' ^ p * x ^ q)), p ≠ 0,
   { rintro x' y' p q (hpq | hpq) hs',
     { assumption, },
     intro hp,
     apply h,
     right,
-    rw [hp, pow_zero, ← one_pow q] at hs',
-    simpa using hs₁a _ _ (hs₁b _ _ ⟨q, hpq, hs'⟩) x, },
+    simp only [hp, mul_one, pow_zero, one_mul] at hs',
+    simpa using hs₁b _ _ ⟨q, hpq, hs'⟩, },
   rw ← hs₂ s' _ hfine at h,
   { exact h (or.inl ⟨1, 1, by simp, refl _⟩) }, -- case α ????    v) in Nakada
   { have key : ∀ (a b c : α) (pab qab : ℕ) (habn : pab ≠ 0 ∨ qab ≠ 0)
-      (hab : s ((y / x) ^ qab) ((b / a) ^ pab)) (pbc qbc : ℕ) (hbcn : pbc ≠ 0 ∨ qbc ≠ 0)
-      (hbc : s ((y / x) ^ qbc) ((c / b) ^ pbc)),
+      (hab : s (y ^ qab * a ^ pab) (b ^ pab * x ^ qab)) (pbc qbc : ℕ) (hbcn : pbc ≠ 0 ∨ qbc ≠ 0)
+      (hbc : s (y ^ qbc * b ^ pbc) (c ^ pbc * x ^ qbc)),
       (pab * pbc ≠ 0 ∨ qab * pbc + qbc * pab ≠ 0) ∧
-      s ((y / x) ^ (qab * pbc + qbc * pab)) ((c / a) ^ (pab * pbc)),
+      s (y ^ (qab * pbc + qbc * pab) * a ^ (pab * pbc))
+        (c ^ (pab * pbc) * x ^ (qab * pbc + qbc * pab)),
     { intros a b c pab qab habn hab pbc qbc hbcn hbc,
       have habp : pab ≠ 0 := hp _ _ habn hab,
       have hbcp : pbc ≠ 0 := hp _ _ hbcn hbc,
@@ -198,7 +200,7 @@ begin
         intro hprod,
         rw [nat.mul_eq_zero] at hprod,
         tauto, },
-      rw [← div_mul_div_cancel'' b a c, pow_add, mul_pow],
+      rw [pow_add],
       have : ∀ (l k : α) (n : ℕ), s k l → s (k ^ n) (l ^ n),
       { intros l k n hlk,
         induction n,
@@ -206,22 +208,19 @@ begin
           exact refl _, },
         { simp only [nat.succ_eq_add_one, pow_add, pow_one],
           apply trans (_ : s (k ^ n_n * k) (l ^ n_n * k)),
-          apply hs₁a,
-          assumption,
-          rw [mul_comm _ k, mul_comm _ k],
-          apply hs₁a,
-          assumption, }, },
-      apply trans (_ : s ((y / x) ^ (qab * pbc) * (y / x) ^ (qbc * pab))
-                         ((y / x) ^ (qab * pbc) * (c / b) ^ (pab * pbc))),
-      { rw [mul_comm _ ((c / b) ^ (pab * pbc)), mul_comm _ ((c / b) ^ (pab * pbc))],
-        apply hs₁a,
+          rwa ← hs₁a,
+          rwa [mul_comm _ k, mul_comm _ k, ← hs₁a], }, },
+      apply trans _ (_ : s (y ^ (qbc * pab) * b ^ (pab * pbc) * x ^ (qab * pbc))
+                         (c ^ (pab * pbc) * x ^ (qab * pbc + qbc * pab))),
+      { rw [mul_comm (y ^ (qab * pbc)) (y ^ (qbc * pab)), mul_assoc, mul_assoc, ← hs₁a],
         convert this _ _ pbc hab using 1,
-        { rw [pow_mul], },
-        { rw [pow_mul], }, },
-      { apply hs₁a,
+        { simp [mul_pow, pow_mul], },
+        { simp [mul_pow, pow_mul, mul_comm], }, },
+      { rw [add_comm, pow_add, ← mul_assoc,
+          mul_comm _ (x ^ (qab * _)), mul_comm _ (x ^ (qab * _)), ← hs₁a],
         convert this _ _ pab hbc using 1,
-        { rw [pow_mul], },
-        { rw [pow_mul'], }, }, },
+        { simp [mul_pow, pow_mul' b, pow_mul y], },
+        { simp [mul_pow, pow_mul' c, pow_mul x], }, }, },
     have trans : ∀ (a b c : α), s' a b → s' b c → s' a c,
     { rintro a b c ⟨pab, qab, habn, hab⟩ ⟨pbc, qbc, hbcn, hbc⟩,
       use [pab * pbc, qab * pbc + qbc * pab],
@@ -235,43 +234,38 @@ begin
       have hpabn := hp _ _ habn hab,
       have hqabn := hp _ _ hban hba,
       obtain ⟨keyl, keyr⟩ := key a b a pab qab habn hab pba qba hban hba,
-      simp only [div_self', one_pow] at keyr,
-      have : s 1 ((x / y) ^ (qab * pba + qba * pab)),
-      { simpa [← mul_pow] using hs₁a _ _ keyr ((x / y) ^ (qab * pba + qba * pab)), },
+      have : s (y ^ (qab * pba + qba * pab)) (x ^ (qab * pba + qba * pab)),
+      -- this requires cancellation (strongness)
+      { rwa [mul_comm, ← hs₁a] at keyr, },
       by_cases hqs : qab = 0 ∧ qba = 0,
-      { simp only [hqs, pow_zero] at hab hba,
+      { simp only [hqs, pow_zero, one_mul, mul_one] at hab hba,
         apply antisymm (_ : s a b),
-        { rw ← one_pow pba at hba,
-          have := hs₁b _ _ ⟨_, _, hba⟩,
-          simpa using hs₁a _ _ this b,
+        { refine hs₁b _ _ ⟨_, _, hba⟩,
           tauto, },
-        { rw ← one_pow pab at hab,
-          have := hs₁b _ _ ⟨_, _, hab⟩,
-          simpa using hs₁a _ _ this a,
+        { refine hs₁b _ _ ⟨_, _, hab⟩,
           tauto, }, },
       exfalso,
-      rw ← one_pow (qab * pba + qba * pab) at this,
-      have : s 1 (x / y) := hs₁b _ _ ⟨_, _, this⟩,
-      have := hs₁a _ _ this y,
-      simp only [mul_one, mul_div_cancel'_right] at this,
+      have : s y x := hs₁b _ _ ⟨_, _, this⟩,
       tauto,
       intro hz,
       simp only [add_eq_zero_iff, nat.mul_eq_zero] at hz,
       tauto, },
-    { rintros a b ⟨pab, qab, habn, hab⟩ c, -- homog
-      use [pab, qab, habn],
-      simpa, },
+    { rintros a b c, -- homog
+      refine exists₂_congr _,
+      simp only [exists_prop, and.congr_right_iff],
+      intros pab qab habn,
+      rw [mul_pow, mul_pow, ← mul_assoc, mul_comm _ (c ^ _), mul_assoc, mul_assoc, ← hs₁a], },
     { rintros a b ⟨n, hnn, ⟨pn, qn, han, ha⟩⟩, -- normal
       use [pn * n, qn],
       split,
       { left,
         simp only [hnn, ne.def, nat.mul_eq_zero, or_false],
         exact hp _ _ han ha, },
-      have : (a / b) ^ n = a ^ n / b ^ n,
-      sorry,
-      simpa [pow_mul', this] using ha, }, },
+      simpa [pow_mul'] using ha, }, },
 end
 
+-- TODO this lemma missing for groups?
+-- have : (a / b) ^ n = a ^ n / b ^ n,
 
 def linear_group_extension (α : Type u) : Type u := α
 

--- a/src/order/extension.lean
+++ b/src/order/extension.lean
@@ -104,22 +104,22 @@ fin 2 → ℕ
 
 /- s is finer than r, more things are related -/
 @[to_additive]
-def ordered_comm_group.is_finer {α : Type u} (r s : ordered_comm_group α) : Prop :=
+def ordered_cancel_comm_monoid.is_finer {α : Type u} (r s : ordered_cancel_comm_monoid α) : Prop :=
   @has_le.le α (@preorder.to_has_le α
     (@partial_order.to_preorder α
-      (@ordered_comm_group.to_partial_order α r))) ≤
+      (@ordered_cancel_comm_monoid.to_partial_order α r))) ≤
   @has_le.le α (@preorder.to_has_le α
     (@partial_order.to_preorder α
-      (@ordered_comm_group.to_partial_order α s)))
+      (@ordered_cancel_comm_monoid.to_partial_order α s)))
 
 /--
 Any ordered group can be extended to a linear ordered group.
 -/
 @[to_additive]
-theorem extend_ordered_group {α : Type u} [o : ordered_comm_group α]
+theorem extend_ordered_group {α : Type u} [o : ordered_cancel_comm_monoid α]
   (h_norm : ∀ (x y : α), (∃ (n : ℕ) (hn : n ≠ 0), y ^ n ≤ x ^ n) → y ≤ x) : -- fuchs calls this normal
-  ∃ l : linear_ordered_comm_group α, ordered_comm_group.is_finer o
-    (@linear_ordered_comm_group.to_ordered_comm_group α l) :=
+  ∃ l : linear_ordered_cancel_comm_monoid α, ordered_cancel_comm_monoid.is_finer o
+    (@linear_ordered_cancel_comm_monoid.to_ordered_cancel_comm_monoid α l) :=
 begin
   let S := { s | is_partial_order α s ∧
                 (∀ a b c : α, s a b ↔ s (c * a) (c * b)) ∧
@@ -158,7 +158,7 @@ begin
   have inst_refl : is_refl α s := by apply_instance, -- probably dont need to be haveI's
   have inst_trans : is_trans α s := by apply_instance,
   have inst_antisymm : is_antisymm α s := by apply_instance,
-  let t : linear_ordered_comm_group α :=
+  let t : linear_ordered_cancel_comm_monoid α :=
     { le := s,
       le_refl := inst_refl.refl,
       le_trans := inst_trans.trans,
@@ -166,7 +166,8 @@ begin
       le_total := _,
       decidable_le := by apply_instance,
       mul_le_mul_left := λ a b hab c, (hs₁a a _ _).mp hab,
-      ..(@ordered_comm_group.to_comm_group α o)},
+      le_of_mul_le_mul_left := λ a b c, (hs₁a b c a).mpr,
+      ..(@ordered_cancel_comm_monoid.to_cancel_comm_monoid α o)},
   refine ⟨t, rs⟩,
   intros x y,
   change s x y ∨ s y x,

--- a/src/order/extension.lean
+++ b/src/order/extension.lean
@@ -6,6 +6,9 @@ Authors: Bhavik Mehta
 import data.set.lattice
 import order.zorn
 import tactic.by_contra
+import algebra.group_power.basic
+import algebra.smul_with_zero
+import algebra.module
 
 /-!
 # Extend a partial order to a linear order
@@ -69,6 +72,204 @@ begin
 end
 
 /-- A type alias for `α`, intended to extend a partial order on `α` to a linear order. -/
+def linear_extension (α : Type u) : Type u := α
+
+noncomputable instance {α : Type u} [partial_order α] : linear_order (linear_extension α) :=
+{ le := (extend_partial_order ((≤) : α → α → Prop)).some,
+  le_refl := (extend_partial_order ((≤) : α → α → Prop)).some_spec.some.1.1.1.1,
+  le_trans := (extend_partial_order ((≤) : α → α → Prop)).some_spec.some.1.1.2.1,
+  le_antisymm := (extend_partial_order ((≤) : α → α → Prop)).some_spec.some.1.2.1,
+  le_total := (extend_partial_order ((≤) : α → α → Prop)).some_spec.some.2.1,
+  decidable_le := classical.dec_rel _ }
+
+/-- The embedding of `α` into `linear_extension α` as a relation homomorphism. -/
+def to_linear_extension {α : Type u} [partial_order α] :
+  ((≤) : α → α → Prop) →r ((≤) : linear_extension α → linear_extension α → Prop) :=
+{ to_fun := λ x, x,
+  map_rel' := λ a b, (extend_partial_order ((≤) : α → α → Prop)).some_spec.some_spec _ _ }
+
+instance {α : Type u} [inhabited α] : inhabited (linear_extension α) :=
+⟨(default : α)⟩
+
+/-
+E.g.
+fin 2 → ℕ
+
+
+(a,b) ≤ (c,d) ↔ a ≤ c ∧ b ≤ d
+
+(1,0) (0,1)
+-/
+
+/- s is finer than r, more things are related -/
+def is_finer {α : Type u} (r s : ordered_add_comm_group α) : Prop :=
+  @has_le.le α (@preorder.to_has_le α
+    (@partial_order.to_preorder α
+      (@ordered_add_comm_group.to_partial_order α r))) ≤
+  @has_le.le α (@preorder.to_has_le α
+    (@partial_order.to_preorder α
+      (@ordered_add_comm_group.to_partial_order α s)))
+
+/--
+Any ordered group can be extended to a linear ordered group.
+-/
+theorem extend_ordered_group {α : Type u} [o : ordered_add_comm_group α]
+  (h_norm : ∀ (x : α), (∃ (n : ℕ) (hn : n ≠ 0), 0 ≤ n • x) → 0 ≤ x) : -- fuchs calls this normal
+  ∃ l : linear_ordered_add_comm_group α, is_finer o
+    (@linear_ordered_add_comm_group.to_ordered_add_comm_group α l)
+ :=
+begin
+  let S := {s | is_partial_order α s ∧
+                (∀ a b : α, s a b → ∀ c : α, s (c + a) (c + b)) ∧
+                ∀ x, (∃ (n : ℕ) (hn : n ≠ 0), s 0 (n • x)) → s 0 x },
+  have hS : ∀ c, c ⊆ S → zorn.chain (≤) c → ∀ y ∈ c, (∃ ub ∈ S, ∀ z ∈ c, z ≤ ub),
+  { rintro c hc₁ hc₂ s hs,
+    -- haveI := (hc₁ hs).1,
+  -- let S := (univ : set (ordered_add_comm_group α)),
+  -- have hS : ∀ c, c ⊆ S → zorn.chain is_finer c → ∀ y ∈ c, ∃ ub ∈ S, ∀ z ∈ c, is_finer z ub,
+  -- { rintro c hc₁ hc₂ s hs,
+    haveI := (hc₁ hs).1.1,
+    refine ⟨Sup c, _, λ z hz, le_Sup hz⟩,
+    refine ⟨{ refl := _, trans := _, antisymm := _ }, _, _⟩,
+    any_goals{ simp_rw binary_relation_Sup_iff},
+    { intro x,
+      exact ⟨s, hs, refl x⟩ },
+    { rintro x y z ⟨s₁, h₁s₁, h₂s₁⟩ ⟨s₂, h₁s₂, h₂s₂⟩,
+      haveI : is_partial_order _ _ := (hc₁ h₁s₁).1,
+      haveI : is_partial_order _ _ := (hc₁ h₁s₂).1,
+      cases hc₂.total_of_refl h₁s₁ h₁s₂,
+      { exact ⟨s₂, h₁s₂, trans (h _ _ h₂s₁) h₂s₂⟩ },
+      { exact ⟨s₁, h₁s₁, trans h₂s₁ (h _ _ h₂s₂)⟩ } },
+    { rintro x y ⟨s₁, h₁s₁, h₂s₁⟩ ⟨s₂, h₁s₂, h₂s₂⟩,
+      haveI : is_partial_order _ _ := (hc₁ h₁s₁).1,
+      haveI : is_partial_order _ _ := (hc₁ h₁s₂).1,
+      cases hc₂.total_of_refl h₁s₁ h₁s₂,
+      { exact antisymm (h _ _ h₂s₁) h₂s₂ },
+      { apply antisymm h₂s₁ (h _ _ h₂s₂) } },
+    { rintro x y ⟨s₁, h₁s₁, h₂s₁⟩ z, -- TODO is this junk removable?
+      use [s₁, h₁s₁, (hc₁ h₁s₁).2.1 _ _ h₂s₁ z], },
+    { rintro x ⟨n, hn, r, hr₁, hr₂⟩,
+      use [r, hr₁, (hc₁ hr₁).2.2 _ ⟨n, hn, hr₂⟩], }, },
+  obtain ⟨s, ⟨hs₁, hs₁a, hs₁b⟩, rs, hs₂⟩ := zorn.zorn_nonempty_partial_order₀ S hS (≤)
+    ⟨is_partial_order.mk, o.add_le_add_left, h_norm⟩,
+  resetI,
+  haveI inst_refl : is_refl α s := by apply_instance, -- probably dont need to be haveI's
+  haveI inst_trans : is_trans α s := by apply_instance,
+  haveI inst_antisymm : is_antisymm α s := by apply_instance,
+  let t : linear_ordered_add_comm_group α :=
+    { le := s,
+      le_refl := inst_refl.refl,
+      le_trans := inst_trans.trans,
+      le_antisymm := inst_antisymm.antisymm,
+      le_total := _,
+      decidable_le := by apply_instance,
+      add_le_add_left := hs₁a,
+      ..(@ordered_add_comm_group.to_add_comm_group α o)},
+  refine ⟨t, rs⟩,
+  intros x y,
+  change s x y ∨ s y x,
+  by_contra h,
+  let s' := λ x' y', ∃ p q (hpq : p ≠ 0 ∨ q ≠ 0), s (q • (y - x)) (p • (y' - x')), -- s x' y' ∨ s x' x ∧ s y y',
+  have hp : ∀ (x') (y') {p q} (hpq : p ≠ 0 ∨ q ≠ 0) (hs' : s (q • (y - x)) (p • (y' - x'))), p ≠ 0,
+  { rintro x' y' p q hpq hs',
+    cases hpq, assumption,
+    intro hp,
+    rw not_or_distrib at h,
+    apply h.2,
+    simp only [hp, zero_smul] at hs',
+    have : s 0 (q • (x - y)),
+    { have : s (q • (x - y) + q • (y - x)) (q • (x - y) + 0),
+      exact hs₁a _ _ hs' _,
+      simpa [← smul_add], },
+    have : s (y + 0) (y + (x - y)) := hs₁a _ _ (hs₁b _ ⟨_, hpq, this⟩) y,
+    simpa, },
+  have hh := h,
+  rw ← hs₂ s' _ _ at h,
+  { -- case α ????
+    exact h (or.inl ⟨1, 1, by simp, refl _⟩) },
+  { have trans : ∀ (a b c : α), s' a b → s' b c → s' a c,
+    { rintro a b c ⟨pab, qab, habn, hab⟩ ⟨pbc, qbc, hbcn, hbc⟩,
+      use [pab * pbc, qab * pbc + qbc * pab],
+      have habp : pab ≠ 0 := hp _ _ habn hab,
+      have hbcp : pbc ≠ 0 := hp _ _ hbcn hbc,
+      split,
+      { left,
+        intro hprod,
+        rw [nat.mul_eq_zero] at hprod,
+        tauto, },
+      rw [← sub_add_sub_cancel' b a c],
+      rw smul_add,
+      rw add_smul,
+      have : ∀ (l k : α) (n : ℕ), s k l → s (n • k) (n • l),
+      { intros l k n hlk,
+        induction n,
+        { simp,
+          exact refl _, },
+        { simp [nat.succ_eq_add_one, add_smul],
+          apply trans (_ : s (n_n • k + k) (n_n • l + k)),
+          apply hs₁a,
+          assumption,
+          rw [add_comm _ k, add_comm _ k],
+          apply hs₁a,
+          assumption, }, },
+      apply trans (_ : s ((qab * pbc) • (y - x) + (qbc * pab) • (y - x))
+                         ((qab * pbc) • (y - x) + (pab * pbc) • (c - b))),
+      { rw [add_comm _ ((pab * pbc) • (c - b))],
+        rw [add_comm _ ((pab * pbc) • (c - b))],
+        apply hs₁a,
+        convert this _ _ pbc hab using 1,
+        { rw [mul_smul, smul_comm], },
+        { rw [mul_smul, smul_comm], }, },
+      { apply hs₁a,
+        convert this _ _ pab hbc using 1,
+        { rw [mul_smul, smul_comm], },
+        { rw [mul_smul, smul_comm], }, }, },
+    repeat {split},
+    refine
+      { refl := _,
+        trans := _,
+        antisymm := _ },
+    { intro x,
+      use [1,0],
+      simp only [ne.def, nat.one_ne_zero, not_false_iff, eq_self_iff_true, not_true,
+        or_false, zero_smul, sub_self, smul_zero', true_and],
+      exact refl _, },
+    { exact trans },
+    { rintros a b ⟨pab, qab, habn, hab⟩ ⟨pba, qba, hban, hba⟩,
+      apply antisymm (_ : s a b),
+      { suffices : s 0 (a - b),
+        { convert hs₁a _ _ this b,
+          { rw add_zero, },
+          { rw add_sub_cancel'_right, }, },
+        sorry, },
+      sorry,
+      -- apply hs₁b,
+      -- obtain ⟨p, q, hpq, haa⟩ := trans a b a hab hba,
+      -- have : q = 0,
+      -- sorry,
+      -- simp [this] at haa,
+      -- simp at haa,
+       },
+    { rintros a b ⟨pab, qab, habn, hab⟩ c, -- homog
+      use [pab, qab, habn],
+      simpa, },
+    { rintros a ⟨n, hnn, ⟨pn, qn, han, ha⟩⟩, -- normal
+      use [pn * n, qn],
+      split,
+      { left,
+        simp only [hnn, ne.def, nat.mul_eq_zero, or_false],
+        exact hp _ _ han ha, },
+      simpa [mul_smul] using ha, }, },
+  { intros a b h, --finer
+    use [1, 0],
+    simp only [ne.def, nat.one_ne_zero, not_false_iff, eq_self_iff_true, not_true,
+      or_false, zero_smul, one_nsmul, true_and],
+    convert hs₁a _ _ h (-a),
+    simp only [add_left_neg],
+    exact sub_eq_neg_add b a, },
+end
+
+
 def linear_extension (α : Type u) : Type u := α
 
 noncomputable instance {α : Type u} [partial_order α] : linear_order (linear_extension α) :=


### PR DESCRIPTION
This is a theorem of Fuchs based on the existing extension of partial orders to linear orders.

The hope is to extend some results about Hahn series that assume linear ordered group by invoking this result to produce nice linear ordered group structures when needed in the proof, rather than as an assumption.

I would love to know if there are other results that rely on an ordered group structure for the proof but the final result either doesn't involve the order or is preserved by extending the order, as those could possibly also be generalized.


---
TODO
- [ ] cleanup
- [ ] probably split file
- [ ] add doc and also for Szpilrajn
- [ ] make a version which only assumes add_comm_group and starts with the trivial order
- [x] add cancel monoid version (either follow Nakada https://eprints.lib.hokudai.ac.jp/dspace/bitstream/2115/55970/1/JFSHIU_11_N4_181-189.pdf or just try and move minus signs across the relation everywhere)


<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
