### PR TITLE
[Merged by Bors] - chore(data/finsupp/basic): generalize comap_mul_action

### DIFF
--- a/src/algebra/monoid_algebra/basic.lean
+++ b/src/algebra/monoid_algebra/basic.lean
@@ -267,7 +267,7 @@ finsupp.is_central_scalar G k
 
 instance comap_distrib_mul_action_self [group G] [semiring k] :
   distrib_mul_action G (monoid_algebra k G) :=
-finsupp.comap_distrib_mul_action_self
+finsupp.comap_distrib_mul_action
 
 end derived_instances
 

--- a/src/data/finsupp/basic.lean
+++ b/src/data/finsupp/basic.lean
@@ -2276,61 +2276,51 @@ rfl
 end sum
 
 section
-variables [group G] [mul_action G α] [add_comm_monoid M]
+variables [monoid G] [mul_action G α] [add_comm_monoid M]
 
-/--
-Scalar multiplication by a group element g,
-given by precomposition with the action of g⁻¹ on the domain.
--/
+/-- Scalar multiplication acting on the domain.
+
+This is not an instance as it would conflict with the action on the range. -/
 def comap_has_scalar : has_scalar G (α →₀ M) :=
-{ smul := λ g f, f.comap_domain (λ a, g⁻¹ • a)
-  (λ a a' m m' h, by simpa [←mul_smul] using (congr_arg (λ a, g • a) h)) }
+{ smul := λ g, map_domain ((•) g) }
 
 local attribute [instance] comap_has_scalar
 
-/--
-Scalar multiplication by a group element,
-given by precomposition with the action of g⁻¹ on the domain,
-is multiplicative in g.
--/
+lemma comap_smul_def (g : G) (f : α →₀ M) : g • f = map_domain ((•) g) f := rfl
+
+@[simp] lemma comap_smul_single (g : G) (a : α) (b : M) :
+  g • single a b = single (g • a) b :=
+map_domain_single
+
+/-- `finsupp.comap_has_scalar` is multiplicative -/
 def comap_mul_action : mul_action G (α →₀ M) :=
-{ one_smul := λ f, by { ext, dsimp [(•)], simp, },
-  mul_smul := λ g g' f, by { ext, dsimp [(•)], simp [mul_smul], }, }
+{ one_smul := λ f, by  rw [comap_smul_def, one_smul_eq_id, map_domain_id],
+  mul_smul := λ g g' f, by rw [comap_smul_def, comap_smul_def, comap_smul_def, ←comp_smul_left,
+    map_domain_comp], }
 
 local attribute [instance] comap_mul_action
 
-/--
-Scalar multiplication by a group element,
-given by precomposition with the action of g⁻¹ on the domain,
-is additive in the second argument.
--/
+/-- `finsupp.comap_has_scalar` is distributive -/
 def comap_distrib_mul_action :
   distrib_mul_action G (α →₀ M) :=
 { smul_zero := λ g, by { ext, dsimp [(•)], simp, },
-  smul_add := λ g f f', by { ext, dsimp [(•)], simp, }, }
+  smul_add := λ g f f', by { ext, dsimp [(•)], simp [map_domain_add], }, }
 
-/--
-Scalar multiplication by a group element on finitely supported functions on a group,
-given by precomposition with the action of g⁻¹. -/
-def comap_distrib_mul_action_self :
-  distrib_mul_action G (G →₀ M) :=
-@finsupp.comap_distrib_mul_action G M G _ (monoid.to_mul_action G) _
-
-@[simp]
-lemma comap_smul_single (g : G) (a : α) (b : M) :
-  g • single a b = single (g • a) b :=
-begin
-  ext a',
-  dsimp [(•)],
-  by_cases h : g • a = a',
-  { subst h, simp [←mul_smul], },
-  { simp [single_eq_of_ne h], rw [single_eq_of_ne],
-    rintro rfl, simpa [←mul_smul] using h, }
 end
 
-@[simp]
-lemma comap_smul_apply (g : G) (f : α →₀ M) (a : α) :
-  (g • f) a = f (g⁻¹ • a) := rfl
+section
+variables [group G] [mul_action G α] [add_comm_monoid M]
+
+local attribute [instance] comap_has_scalar comap_mul_action comap_distrib_mul_action
+
+/-- When `G` is a group, `finsupp.comap_has_scalar` acts by precomposition with the action of `g⁻¹`.
+-/
+@[simp] lemma comap_smul_apply (g : G) (f : α →₀ M) (a : α) :
+  (g • f) a = f (g⁻¹ • a) :=
+begin
+  conv_lhs { rw ←smul_inv_smul g a },
+  exact map_domain_apply (mul_action.injective g) _ (g⁻¹ • a),
+end
 
 end
 

--- a/src/group_theory/group_action/defs.lean
+++ b/src/group_theory/group_action/defs.lean
@@ -296,6 +296,15 @@ variables [monoid M] [mul_action M α]
 variable (M)
 @[simp, to_additive] theorem one_smul (b : α) : (1 : M) • b = b := mul_action.one_smul _
 
+/-- `has_scalar` version of `one_mul_eq_id` -/
+@[to_additive]
+lemma one_smul_eq_id : ((•) (1 : M) : α → α) = id := funext $ one_smul _
+
+/-- `has_scalar` version of `comp_mul_left` -/
+@[to_additive]
+lemma comp_smul_left (a₁ a₂ : M) : (•) a₁ ∘ (•) a₂ = ((•) (a₁ * a₂) : α → α) :=
+funext $ λ _, (mul_smul _ _ _).symm
+
 variables {M}
 
 /-- Pullback a multiplicative action along an injective map respecting `•`.


### PR DESCRIPTION
This new definition is propoitionally equal to the old one in the presence of `[group G]` (all the previous `lemma`s continue to apply), but generalizes to `[monoid G]`.

This also removes `finsupp.comap_distrib_mul_action_self` as there is no need to have this as a separate definition.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
