### PR TITLE
[Merged by Bors] - style(analysis/special_functions/trigonometric/angle): make types of `sin` and `cos` explicit

### DIFF
--- a/src/analysis/special_functions/trigonometric/angle.lean
+++ b/src/analysis/special_functions/trigonometric/angle.lean
@@ -141,13 +141,13 @@ begin
 end
 
 /-- The sine of a `real.angle`. -/
-def sin (θ : angle) := sin_periodic.lift θ
+def sin (θ : angle) : ℝ := sin_periodic.lift θ
 
 @[simp] lemma sin_coe (x : ℝ) : sin (x : angle) = real.sin x :=
 rfl
 
 /-- The cosine of a `real.angle`. -/
-def cos (θ : angle) := cos_periodic.lift θ
+def cos (θ : angle) : ℝ := cos_periodic.lift θ
 
 @[simp] lemma cos_coe (x : ℝ) : cos (x : angle) = real.cos x :=
 rfl


### PR DESCRIPTION
Give the types of the results of `real.angle.sin` and `real.angle.cos`
explicitly, as requested by @eric-wieser in #11887.



---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
