### PR TITLE
[Merged by Bors] - chore(algebra/order/ring): add a few aliases

### DIFF
--- a/src/algebra/order/ring.lean
+++ b/src/algebra/order/ring.lean
@@ -138,6 +138,11 @@ lemma zero_lt_three : 0 < (3:α) := add_pos zero_lt_two zero_lt_one
 
 lemma zero_lt_four : 0 < (4:α) := add_pos zero_lt_two zero_lt_two
 
+alias zero_lt_one ← one_pos
+alias zero_lt_two ← two_pos
+alias zero_lt_three ← three_pos
+alias zero_lt_four ← four_pos
+
 end nontrivial
 
 lemma mul_lt_mul_of_pos_left (h₁ : a < b) (h₂ : 0 < c) : c * a < c * b :=

--- a/src/data/list/basic.lean
+++ b/src/data/list/basic.lean
@@ -9,7 +9,7 @@ import data.nat.basic
 # Basic properties of lists
 -/
 
-open function nat
+open function nat (hiding one_pos)
 
 namespace list
 universes u v w x


### PR DESCRIPTION
Add aliases `one_pos`, `two_pos`, `three_pos`, and `four_pos`.

We used to have (some of) these lemmas. They were removed during one of cleanups but it doesn't hurt to have aliases.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
