### PR TITLE
[Merged by Bors] - feat(topology/algebra/uniform_group): `cauchy_seq.const_mul` and friends

### DIFF
--- a/src/topology/algebra/uniform_group.lean
+++ b/src/topology/algebra/uniform_group.lean
@@ -162,11 +162,16 @@ uniform_continuous_mul.comp_cauchy_seq (hu.prod $ cauchy_seq_const x)
   {u : ι → α} {x : α} (hu : cauchy_seq u) : cauchy_seq (λ n, x * u n) :=
 uniform_continuous_mul.comp_cauchy_seq ((cauchy_seq_const x).prod hu)
 
-lemma cauchy_seq.neg {ι : Type*} [add_group α] [uniform_add_group α] [semilattice_sup ι]
+end uniform_group
+
+section uniform_add_group
+variables {α : Type*} [uniform_space α] [add_group α] [uniform_add_group α]
+
+lemma cauchy_seq.neg {ι : Type*} [semilattice_sup ι]
   {u : ι → α} (h : cauchy_seq u) : cauchy_seq (-u) :=
 uniform_continuous_neg.comp_cauchy_seq h
 
-end uniform_group
+end uniform_add_group
 
 section topological_comm_group
 open filter

--- a/src/topology/algebra/uniform_group.lean
+++ b/src/topology/algebra/uniform_group.lean
@@ -162,16 +162,11 @@ uniform_continuous_mul.comp_cauchy_seq (hu.prod hv)
   {u : ι → α} {x : α} (hu : cauchy_seq u) : cauchy_seq (λ n, x * u n) :=
 (uniform_continuous_const.mul uniform_continuous_id).comp_cauchy_seq hu
 
-end uniform_group
-
-section uniform_add_group
-variables {α : Type*} [uniform_space α] [add_group α] [uniform_add_group α]
-
 @[to_additive] lemma cauchy_seq.inv {ι : Type*} [semilattice_sup ι]
-  {u : ι → α} (h : cauchy_seq u) : cauchy_seq (-u) :=
-uniform_continuous_neg.comp_cauchy_seq h
+  {u : ι → α} (h : cauchy_seq u) : cauchy_seq (u⁻¹) :=
+uniform_continuous_inv.comp_cauchy_seq h
 
-end uniform_add_group
+end uniform_group
 
 section topological_comm_group
 open filter

--- a/src/topology/algebra/uniform_group.lean
+++ b/src/topology/algebra/uniform_group.lean
@@ -154,20 +154,20 @@ uniform_continuous_of_tendsto_one $
   (hu : cauchy_seq u) (hv : cauchy_seq v) : cauchy_seq (u * v) :=
 uniform_continuous_mul.comp_cauchy_seq (hu.prod hv)
 
-@[to_additive] lemma cauchy_seq.mul_const {ι : Type*} [semilattice_sup ι] [nonempty ι]
+@[to_additive] lemma cauchy_seq.mul_const {ι : Type*} [semilattice_sup ι]
   {u : ι → α} {x : α} (hu : cauchy_seq u) : cauchy_seq (λ n, u n * x) :=
-uniform_continuous_mul.comp_cauchy_seq (hu.prod $ cauchy_seq_const x)
+(uniform_continuous_id.mul uniform_continuous_const).comp_cauchy_seq hu
 
-@[to_additive] lemma cauchy_seq.const_mul {ι : Type*} [semilattice_sup ι] [nonempty ι]
+@[to_additive] lemma cauchy_seq.const_mul {ι : Type*} [semilattice_sup ι]
   {u : ι → α} {x : α} (hu : cauchy_seq u) : cauchy_seq (λ n, x * u n) :=
-uniform_continuous_mul.comp_cauchy_seq ((cauchy_seq_const x).prod hu)
+(uniform_continuous_const.mul uniform_continuous_id).comp_cauchy_seq hu
 
 end uniform_group
 
 section uniform_add_group
 variables {α : Type*} [uniform_space α] [add_group α] [uniform_add_group α]
 
-lemma cauchy_seq.neg {ι : Type*} [semilattice_sup ι]
+@[to_additive] lemma cauchy_seq.inv {ι : Type*} [semilattice_sup ι]
   {u : ι → α} (h : cauchy_seq u) : cauchy_seq (-u) :=
 uniform_continuous_neg.comp_cauchy_seq h
 

--- a/src/topology/algebra/uniform_group.lean
+++ b/src/topology/algebra/uniform_group.lean
@@ -154,6 +154,14 @@ uniform_continuous_of_tendsto_one $
   (hu : cauchy_seq u) (hv : cauchy_seq v) : cauchy_seq (u * v) :=
 uniform_continuous_mul.comp_cauchy_seq (hu.prod hv)
 
+@[to_additive] lemma cauchy_seq.mul_const {ι : Type*} [semilattice_sup ι] [nonempty ι]
+  {u : ι → α} {x : α} (hu : cauchy_seq u) : cauchy_seq (λ n, u n * x) :=
+uniform_continuous_mul.comp_cauchy_seq (hu.prod $ cauchy_seq_const x)
+
+@[to_additive] lemma cauchy_seq.const_mul {ι : Type*} [semilattice_sup ι] [nonempty ι]
+  {u : ι → α} {x : α} (hu : cauchy_seq u) : cauchy_seq (λ n, x * u n) :=
+uniform_continuous_mul.comp_cauchy_seq ((cauchy_seq_const x).prod hu)
+
 lemma cauchy_seq.neg {ι : Type*} [add_group α] [uniform_add_group α] [semilattice_sup ι]
   {u : ι → α} (h : cauchy_seq u) : cauchy_seq (-u) :=
 uniform_continuous_neg.comp_cauchy_seq h

--- a/src/topology/algebra/uniform_group.lean
+++ b/src/topology/algebra/uniform_group.lean
@@ -154,6 +154,10 @@ uniform_continuous_of_tendsto_one $
   (hu : cauchy_seq u) (hv : cauchy_seq v) : cauchy_seq (u * v) :=
 uniform_continuous_mul.comp_cauchy_seq (hu.prod hv)
 
+lemma cauchy_seq.neg {ι : Type*} [add_group α] [uniform_add_group α] [semilattice_sup ι]
+  {u : ι → α} (h : cauchy_seq u) : cauchy_seq (-u) :=
+uniform_continuous_neg.comp_cauchy_seq h
+
 end uniform_group
 
 section topological_comm_group

--- a/src/topology/uniform_space/cauchy.lean
+++ b/src/topology/uniform_space/cauchy.lean
@@ -156,7 +156,7 @@ lemma filter.tendsto.cauchy_seq [semilattice_sup β] [nonempty β] {f : β → �
   cauchy_seq f :=
 hx.cauchy_map
 
-lemma cauchy_seq_const (x : α) : cauchy_seq (λ n : ℕ, x) :=
+lemma cauchy_seq_const [semilattice_sup β] [nonempty β] (x : α) : cauchy_seq (λ n : β, x) :=
 tendsto_const_nhds.cauchy_seq
 
 lemma cauchy_seq_iff_tendsto [nonempty β] [semilattice_sup β] {u : β → α} :


### PR DESCRIPTION
A Cauchy sequence multiplied by a constant (including `-1`) remains a Cauchy sequence.

---

This was suggested by @PatrickMassot [here](https://github.com/leanprover-community/mathlib/pull/11689#discussion_r795886954). As Patrick pointed out, the lemma that prompted the comment is superfluous, but these helpers will be useful in #11908 anyways.


<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
 
[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
