### PR TITLE
[Merged by Bors] - chore(algebra/tropical/basic): remove 3 instances

### DIFF
--- a/src/algebra/tropical/basic.lean
+++ b/src/algebra/tropical/basic.lean
@@ -364,10 +364,6 @@ instance covariant_add [linear_order R] : covariant_class (tropical R) (tropical
     { rwa [add_eq_right hx] } }
 end⟩
 
-instance covariant_swap_add [linear_order R] :
-  covariant_class (tropical R) (tropical R) (function.swap (+)) (≤) :=
-⟨λ x y z h, by { convert add_le_add_left h x using 1; rw [add_comm] }⟩
-
 instance covariant_mul_lt [has_lt R] [has_add R] [covariant_class R R (+) (<)] :
   covariant_class (tropical R) (tropical R) (*) (<) :=
 ⟨λ x y z h, add_lt_add_left h _⟩
@@ -376,20 +372,6 @@ instance covariant_swap_mul_lt [preorder R] [has_add R]
   [covariant_class R R (function.swap (+)) (<)] :
   covariant_class (tropical R) (tropical R) (function.swap (*)) (<) :=
 ⟨λ x y z h, add_lt_add_right h _⟩
-
-instance covariant_add_lt [linear_order R] : covariant_class (tropical R) (tropical R) (+) (≤) :=
-⟨λ x y z h, begin
-  cases le_total x y with hx hy,
-  { rw [add_eq_left hx, add_eq_left (hx.trans h)] },
-  { rw [add_eq_right hy],
-    cases le_total x z with hx hx,
-    { rwa [add_eq_left hx] },
-    { rwa [add_eq_right hx] } }
-end⟩
-
-instance covariant_swap_add_lt [linear_order R] :
-  covariant_class (tropical R) (tropical R) (function.swap (+)) (≤) :=
-⟨λ x y z h, by { convert add_le_add_left h x using 1; rw [add_comm] }⟩
 
 instance [linear_order R] [has_add R]
   [covariant_class R R (+) (≤)] [covariant_class R R (function.swap (+)) (≤)] :


### PR DESCRIPTION
The three removed instances are

* `covariant_swap_add` (exists since addition is commutative and the non-swapped version is proved);
* `covariant_add_lt` (as is, this is a copy of `covariant_add` -- judging from the name, it could have been intended to have a `(<)`, but with `(<)` it is false, see below);
* `covariant_swap_add_lt` (exists since addition is commutative and the non-swapped version is proved).

Here is a proof that the second instance with `(<)` is false:

```lean
lemma not_cov_lt : ¬ covariant_class (tropical ℕ) (tropical ℕ) (+) (<) :=
begin
  refine λ h, (lt_irrefl (trop 0) _),
  cases h,
  have : trop 0 < trop 1 := show 0 < 1, from zero_lt_one,
  calc trop 0 = trop 0 + trop 0 : (trop 0).add_self.symm
          ... < trop 0 + trop 1 : h _ this
          ... = trop 0          : add_eq_left this.le,
end
```

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
