### PR TITLE
[Merged by Bors] - feat(algebra/module/basic): turn implications into iffs

### DIFF
--- a/src/algebra/module/basic.lean
+++ b/src/algebra/module/basic.lean
@@ -526,11 +526,8 @@ include R
 lemma nat.no_zero_smul_divisors : no_zero_smul_divisors ℕ M :=
 ⟨by { intros c x, rw [nsmul_eq_smul_cast R, smul_eq_zero], simp }⟩
 
-variables {M}
-
-lemma eq_zero_of_two_nsmul_eq_zero {v : M} (hv : 2 • v = 0) : v = 0 :=
-by haveI := nat.no_zero_smul_divisors R M;
-exact (smul_eq_zero.mp hv).resolve_left (by norm_num)
+@[simp] lemma two_nsmul_eq_zero {v : M} : 2 • v = 0 ↔ v = 0 :=
+by { haveI := nat.no_zero_smul_divisors R M, norm_num [smul_eq_zero] }
 
 end nat
 
@@ -564,15 +561,20 @@ end smul_injective
 
 section nat
 
-variables (R) [no_zero_smul_divisors R M] [char_zero R]
+variables (R M) [no_zero_smul_divisors R M] [char_zero R]
 include R
 
-lemma eq_zero_of_eq_neg {v : M} (hv : v = - v) : v = 0 :=
-begin
-  refine eq_zero_of_two_nsmul_eq_zero R _,
-  rw two_smul,
-  exact add_eq_zero_iff_eq_neg.mpr hv
-end
+lemma eq_neg_iff_eq_zero {v : M} : v = - v ↔ v = 0 :=
+by rw [← two_nsmul_eq_zero R M, two_smul, add_eq_zero_iff_eq_neg]
+
+lemma neg_eq_iff_eq_zero {v : M} : - v = v ↔ v = 0 :=
+by rw [eq_comm, eq_neg_iff_eq_zero R M]
+
+lemma ne_neg_iff_ne_zero {v : M} : v ≠ -v ↔ v ≠ 0 :=
+(eq_neg_iff_eq_zero R M).not
+
+lemma neg_ne_iff_ne_zero {v : M} : -v ≠ v ↔ v ≠ 0 :=
+(neg_eq_iff_eq_zero R M).not
 
 end nat
 
@@ -593,15 +595,6 @@ lemma smul_left_injective {x : M} (hx : x ≠ 0) :
                 ... = 0 : sub_eq_zero.mpr h)).resolve_right hx)
 
 end smul_injective
-
-section nat
-
-variables [char_zero R]
-
-lemma ne_neg_of_ne_zero [no_zero_divisors R] {v : R} (hv : v ≠ 0) : v ≠ -v :=
-λ h, hv (eq_zero_of_eq_neg R h)
-
-end nat
 
 end module
 

--- a/src/algebra/module/basic.lean
+++ b/src/algebra/module/basic.lean
@@ -564,17 +564,17 @@ section nat
 variables (R M) [no_zero_smul_divisors R M] [char_zero R]
 include R
 
-lemma eq_neg_iff_eq_zero {v : M} : v = - v ↔ v = 0 :=
+lemma self_eq_neg {v : M} : v = - v ↔ v = 0 :=
 by rw [← two_nsmul_eq_zero R M, two_smul, add_eq_zero_iff_eq_neg]
 
-lemma neg_eq_iff_eq_zero {v : M} : - v = v ↔ v = 0 :=
-by rw [eq_comm, eq_neg_iff_eq_zero R M]
+lemma neg_eq_self {v : M} : - v = v ↔ v = 0 :=
+by rw [eq_comm, self_eq_neg R M]
 
-lemma ne_neg_iff_ne_zero {v : M} : v ≠ -v ↔ v ≠ 0 :=
-(eq_neg_iff_eq_zero R M).not
+lemma self_ne_neg {v : M} : v ≠ -v ↔ v ≠ 0 :=
+(self_eq_neg R M).not
 
-lemma neg_ne_iff_ne_zero {v : M} : -v ≠ v ↔ v ≠ 0 :=
-(neg_eq_iff_eq_zero R M).not
+lemma neg_ne_self {v : M} : -v ≠ v ↔ v ≠ 0 :=
+(neg_eq_self R M).not
 
 end nat
 

--- a/src/analysis/normed_space/basic.lean
+++ b/src/analysis/normed_space/basic.lean
@@ -674,7 +674,7 @@ def homeomorph_unit_ball {E : Type*} [semi_normed_group E] [normed_space ℝ E] 
 variables (α)
 
 lemma ne_neg_of_mem_sphere [char_zero α] {r : ℝ} (hr : r ≠ 0) (x : sphere (0:E) r) : x ≠ - x :=
-λ h, ne_zero_of_mem_sphere hr x ((eq_neg_iff_eq_zero α _).mp (by { conv_lhs {rw h}, simp }))
+λ h, ne_zero_of_mem_sphere hr x ((self_eq_neg α _).mp (by { conv_lhs {rw h}, simp }))
 
 lemma ne_neg_of_mem_unit_sphere [char_zero α] (x : sphere (0:E) 1) : x ≠ - x :=
 ne_neg_of_mem_sphere α one_ne_zero x

--- a/src/analysis/normed_space/basic.lean
+++ b/src/analysis/normed_space/basic.lean
@@ -674,7 +674,7 @@ def homeomorph_unit_ball {E : Type*} [semi_normed_group E] [normed_space ℝ E] 
 variables (α)
 
 lemma ne_neg_of_mem_sphere [char_zero α] {r : ℝ} (hr : r ≠ 0) (x : sphere (0:E) r) : x ≠ - x :=
-λ h, ne_zero_of_mem_sphere hr x (eq_zero_of_eq_neg α (by { conv_lhs {rw h}, simp }))
+λ h, ne_zero_of_mem_sphere hr x ((eq_neg_iff_eq_zero α _).mp (by { conv_lhs {rw h}, simp }))
 
 lemma ne_neg_of_mem_unit_sphere [char_zero α] (x : sphere (0:E) 1) : x ≠ - x :=
 ne_neg_of_mem_sphere α one_ne_zero x

--- a/src/measure_theory/integral/bochner.lean
+++ b/src/measure_theory/integral/bochner.lean
@@ -1331,7 +1331,7 @@ to a left-invariant measure is 0. -/
 lemma integral_zero_of_mul_left_eq_neg [is_mul_left_invariant μ] {f : G → E} {g : G}
   (hf' : ∀ x, f (g * x) = - f x) :
   ∫ x, f x ∂μ = 0 :=
-by { refine eq_zero_of_eq_neg ℝ _, simp_rw [← integral_neg, ← hf', integral_mul_left_eq_self] }
+by simp_rw [eq_neg_iff_eq_zero ℝ E, ← integral_neg, ← hf', integral_mul_left_eq_self]
 
 /-- If some right-translate of a function negates it, then the integral of the function with respect
 to a right-invariant measure is 0. -/
@@ -1339,7 +1339,7 @@ to a right-invariant measure is 0. -/
 lemma integral_zero_of_mul_right_eq_neg [is_mul_right_invariant μ] {f : G → E} {g : G}
   (hf' : ∀ x, f (x * g) = - f x) :
   ∫ x, f x ∂μ = 0 :=
-by { refine eq_zero_of_eq_neg ℝ _, simp_rw [← integral_neg, ← hf', integral_mul_right_eq_self] }
+by simp_rw [eq_neg_iff_eq_zero ℝ E, ← integral_neg, ← hf', integral_mul_right_eq_self]
 
 end group
 

--- a/src/measure_theory/integral/bochner.lean
+++ b/src/measure_theory/integral/bochner.lean
@@ -1331,7 +1331,7 @@ to a left-invariant measure is 0. -/
 lemma integral_zero_of_mul_left_eq_neg [is_mul_left_invariant μ] {f : G → E} {g : G}
   (hf' : ∀ x, f (g * x) = - f x) :
   ∫ x, f x ∂μ = 0 :=
-by simp_rw [← eq_neg_iff_eq_zero ℝ E, ← integral_neg, ← hf', integral_mul_left_eq_self]
+by simp_rw [← self_eq_neg ℝ E, ← integral_neg, ← hf', integral_mul_left_eq_self]
 
 /-- If some right-translate of a function negates it, then the integral of the function with respect
 to a right-invariant measure is 0. -/
@@ -1339,7 +1339,7 @@ to a right-invariant measure is 0. -/
 lemma integral_zero_of_mul_right_eq_neg [is_mul_right_invariant μ] {f : G → E} {g : G}
   (hf' : ∀ x, f (x * g) = - f x) :
   ∫ x, f x ∂μ = 0 :=
-by simp_rw [← eq_neg_iff_eq_zero ℝ E, ← integral_neg, ← hf', integral_mul_right_eq_self]
+by simp_rw [← self_eq_neg ℝ E, ← integral_neg, ← hf', integral_mul_right_eq_self]
 
 end group
 

--- a/src/measure_theory/integral/bochner.lean
+++ b/src/measure_theory/integral/bochner.lean
@@ -1331,7 +1331,7 @@ to a left-invariant measure is 0. -/
 lemma integral_zero_of_mul_left_eq_neg [is_mul_left_invariant μ] {f : G → E} {g : G}
   (hf' : ∀ x, f (g * x) = - f x) :
   ∫ x, f x ∂μ = 0 :=
-by simp_rw [eq_neg_iff_eq_zero ℝ E, ← integral_neg, ← hf', integral_mul_left_eq_self]
+by simp_rw [← eq_neg_iff_eq_zero ℝ E, ← integral_neg, ← hf', integral_mul_left_eq_self]
 
 /-- If some right-translate of a function negates it, then the integral of the function with respect
 to a right-invariant measure is 0. -/
@@ -1339,7 +1339,7 @@ to a right-invariant measure is 0. -/
 lemma integral_zero_of_mul_right_eq_neg [is_mul_right_invariant μ] {f : G → E} {g : G}
   (hf' : ∀ x, f (x * g) = - f x) :
   ∫ x, f x ∂μ = 0 :=
-by simp_rw [eq_neg_iff_eq_zero ℝ E, ← integral_neg, ← hf', integral_mul_right_eq_self]
+by simp_rw [← eq_neg_iff_eq_zero ℝ E, ← integral_neg, ← hf', integral_mul_right_eq_self]
 
 end group
 


### PR DESCRIPTION
* Turn the following implications into `iff`, rename them accordingly, and make the type arguments explicit (`M` has to be explicit when using it in `rw`, otherwise one will have unsolved type-class arguments)
```
eq_zero_of_two_nsmul_eq_zero -> two_nsmul_eq_zero
eq_zero_of_eq_neg -> self_eq_neg
ne_neg_of_ne_zero -> self_ne_neg
```
* Also add two variants
* Generalize `ne_neg_iff_ne_zero` to work in modules over a ring
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
