### PR TITLE
[Merged by Bors] - doc(algebra/group/hom_instances): Fix spellings

### DIFF
--- a/src/algebra/group/hom_instances.lean
+++ b/src/algebra/group/hom_instances.lean
@@ -228,10 +228,10 @@ lemma add_monoid_hom.map_mul_iff (f : R →+ S) :
     (add_monoid_hom.mul : R →+ R →+ R).compr₂ f = (add_monoid_hom.mul.comp f).compl₂ f :=
 iff.symm add_monoid_hom.ext_iff₂
 
-/-- The left multiplicaiton map: `(a, b) ↦ a * b`. See also `add_monoid_hom.mul_left`. -/
+/-- The left multiplication map: `(a, b) ↦ a * b`. See also `add_monoid_hom.mul_left`. -/
 @[simps] def add_monoid.End.mul_left : R →+ add_monoid.End R := add_monoid_hom.mul
 
-/-- The right multiplicaiton map: `(a, b) ↦ b * a`. See also `add_monoid_hom.mul_right`. -/
+/-- The right multiplication map: `(a, b) ↦ b * a`. See also `add_monoid_hom.mul_right`. -/
 @[simps] def add_monoid.End.mul_right : R →+ add_monoid.End R :=
 (add_monoid_hom.mul : R →+ add_monoid.End R).flip
 


### PR DESCRIPTION
Fixes spelling mistakes introduced by #11843

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
