### PR TITLE
`import number_theory.divisors` to `is_prime_pow`

### DIFF
--- a/src/algebra/is_prime_pow.lean
+++ b/src/algebra/is_prime_pow.lean
@@ -5,6 +5,7 @@ Authors: Bhavik Mehta
 -/
 import algebra.associated
 import data.nat.factorization
+import number_theory.divisors
 
 /-!
 # Prime powers


### PR DESCRIPTION
This is proposed to fix the CI failure on #11384, as I noted in a comment there.  I think previously `is_prime_pow` was getting the definition of `nat.divisors` via the import of `data.nat.mul_ind` in `data/nat/factorization`, which is gone in the changes made in #11384.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
