### PR TITLE
[Merged by Bors] - feat(order/category/BoundedOrder): The category of bounded orders

### DIFF
--- a/src/order/category/BoundedOrder.lean
+++ b/src/order/category/BoundedOrder.lean
@@ -1,0 +1,82 @@
+/-
+Copyright (c) 2022 Yaël Dillies. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Yaël Dillies
+-/
+import category_theory.category.Bipointed
+import order.category.PartialOrder
+import order.hom.bounded
+
+/-!
+# The category of bounded orders
+
+This defines `BoundedOrder`, the category of bounded orders.
+-/
+
+universes u v
+
+open category_theory
+
+/-- The category of bounded orders with monotone functions. -/
+structure BoundedOrder :=
+(to_PartialOrder : PartialOrder)
+[is_bounded_order : bounded_order to_PartialOrder]
+
+namespace BoundedOrder
+
+instance : has_coe_to_sort BoundedOrder Type* := induced_category.has_coe_to_sort to_PartialOrder
+instance (X : BoundedOrder) : partial_order X := X.to_PartialOrder.str
+
+attribute [instance]  BoundedOrder.is_bounded_order
+
+/-- Construct a bundled `BoundedOrder` from a `fintype` `partial_order`. -/
+def of (α : Type*) [partial_order α] [bounded_order α] : BoundedOrder := ⟨⟨α⟩⟩
+
+instance : inhabited BoundedOrder := ⟨of punit⟩
+
+instance large_category : large_category.{u} BoundedOrder :=
+{ hom := λ X Y, bounded_order_hom X Y,
+  id := λ X, bounded_order_hom.id X,
+  comp := λ X Y Z f g, g.comp f,
+  id_comp' := λ X Y, bounded_order_hom.comp_id,
+  comp_id' := λ X Y, bounded_order_hom.id_comp,
+  assoc' := λ W X Y Z _ _ _, bounded_order_hom.comp_assoc _ _ _ }
+
+instance concrete_category : concrete_category BoundedOrder :=
+{ forget := ⟨coe_sort, λ X Y, coe_fn, λ X, rfl, λ X Y Z f g, rfl⟩,
+  forget_faithful := ⟨λ X Y, by convert fun_like.coe_injective⟩ }
+
+instance has_forget_to_PartialOrder : has_forget₂ BoundedOrder PartialOrder :=
+{ forget₂ := { obj := λ X, PartialOrder.of X, map := λ X Y, bounded_order_hom.to_order_hom },
+  forget_comp := rfl }
+
+instance has_forget_to_Bipointed : has_forget₂ BoundedOrder Bipointed :=
+{ forget₂ := { obj := λ X, ⟨X, ⊥, ⊤⟩, map := λ X Y f, ⟨f, map_bot f, map_top f⟩ },
+  forget_comp := rfl }
+
+/-- `order_dual` as a functor. -/
+@[simps] def dual : BoundedOrder ⥤ BoundedOrder :=
+{ obj := λ X, of (order_dual X), map := λ X Y, bounded_order_hom.dual }
+
+/-- Constructs an equivalence between bounded orders from an order isomorphism between them. -/
+@[simps] def iso.mk {α β : BoundedOrder.{u}} (e : α ≃o β) : α ≅ β :=
+{ hom := e,
+  inv := e.symm,
+  hom_inv_id' := by { ext, exact e.symm_apply_apply _ },
+  inv_hom_id' := by { ext, exact e.apply_symm_apply _ } }
+
+/-- The equivalence between `BoundedOrder` and itself induced by `order_dual` both ways. -/
+@[simps functor inverse] def dual_equiv : BoundedOrder ≌ BoundedOrder :=
+equivalence.mk dual dual
+  (nat_iso.of_components (λ X, iso.mk $ order_iso.dual_dual X) $ λ X Y f, rfl)
+  (nat_iso.of_components (λ X, iso.mk $ order_iso.dual_dual X) $ λ X Y f, rfl)
+
+end BoundedOrder
+
+lemma BoundedOrder_dual_comp_forget_to_PartialOrder :
+  BoundedOrder.dual ⋙ forget₂ BoundedOrder PartialOrder =
+    forget₂ BoundedOrder PartialOrder ⋙ PartialOrder.to_dual := rfl
+
+lemma BoundedOrder_dual_comp_forget_to_Bipointed :
+  BoundedOrder.dual ⋙ forget₂ BoundedOrder Bipointed =
+    forget₂ BoundedOrder Bipointed ⋙ Bipointed.swap := rfl

--- a/src/order/category/BoundedOrder.lean
+++ b/src/order/category/BoundedOrder.lean
@@ -47,8 +47,7 @@ instance concrete_category : concrete_category BoundedOrder :=
   forget_faithful := ⟨λ X Y, by convert fun_like.coe_injective⟩ }
 
 instance has_forget_to_PartialOrder : has_forget₂ BoundedOrder PartialOrder :=
-{ forget₂ := { obj := λ X, PartialOrder.of X, map := λ X Y, bounded_order_hom.to_order_hom },
-  forget_comp := rfl }
+{ forget₂ := { obj := λ X, X.to_PartialOrder, map := λ X Y, bounded_order_hom.to_order_hom } }
 
 instance has_forget_to_Bipointed : has_forget₂ BoundedOrder Bipointed :=
 { forget₂ := { obj := λ X, ⟨X, ⊥, ⊤⟩, map := λ X Y f, ⟨f, map_bot f, map_top f⟩ },

--- a/src/order/category/PartialOrder.lean
+++ b/src/order/category/PartialOrder.lean
@@ -55,6 +55,6 @@ equivalence.mk to_dual to_dual
 
 end PartialOrder
 
-lemma PartialOrder_dual_equiv_comp_forget_to_Preorder :
-  PartialOrder.dual_equiv.functor ⋙ forget₂ PartialOrder Preorder
-  = forget₂ PartialOrder Preorder ⋙ Preorder.dual_equiv.functor := rfl
+lemma PartialOrder_to_dual_comp_forget_to_Preorder :
+  PartialOrder.to_dual ⋙ forget₂ PartialOrder Preorder =
+    forget₂ PartialOrder Preorder ⋙ Preorder.to_dual := rfl

--- a/src/order/hom/bounded.lean
+++ b/src/order/hom/bounded.lean
@@ -426,8 +426,8 @@ orders. -/
                    map_top' := congr_arg to_dual (map_bot f),
                    map_bot' := congr_arg to_dual (map_top f) },
   inv_fun := λ f, { to_order_hom := order_hom.dual.symm f.to_order_hom,
-                   map_top' := map_bot f,
-                   map_bot' := map_top f },
+                    map_top' := map_bot f,
+                    map_bot' := map_top f },
   left_inv := λ f, ext $ λ a, rfl,
   right_inv := λ f, ext $ λ a, rfl }
 

--- a/src/order/hom/bounded.lean
+++ b/src/order/hom/bounded.lean
@@ -27,7 +27,7 @@ be satisfied by itself and all stricter types.
 * `bounded_order_hom_class`
 -/
 
-open function
+open function order_dual
 
 variables {F α β γ δ : Type*}
 
@@ -86,6 +86,22 @@ instance bounded_order_hom_class.to_bot_hom_class [preorder α] [preorder β]
   [bounded_order α] [bounded_order β] [bounded_order_hom_class F α β] :
   bot_hom_class F α β :=
 { .. ‹bounded_order_hom_class F α β› }
+
+@[priority 100] -- See note [lower instance priority]
+instance order_iso.top_hom_class [partial_order α] [partial_order β] [order_top α] [order_top β] :
+  top_hom_class (α ≃o β) α β :=
+{ map_top := λ f, f.map_top, ..rel_iso.rel_hom_class }
+
+@[priority 100] -- See note [lower instance priority]
+instance order_iso.bot_hom_class [partial_order α] [partial_order β] [order_bot α] [order_bot β] :
+  bot_hom_class (α ≃o β) α β :=
+{ map_bot := λ f, f.map_bot, ..rel_iso.rel_hom_class }
+
+@[priority 100] -- See note [lower instance priority]
+instance order_iso.bounded_order_hom_class [partial_order α] [partial_order β]
+  [bounded_order α] [bounded_order β] :
+  bounded_order_hom_class (α ≃o β) α β :=
+{ ..order_iso.top_hom_class, ..order_iso.bot_hom_class }
 
 instance [has_top α] [has_top β] [top_hom_class F α β] : has_coe_t F (top_hom α β) :=
 ⟨λ f, ⟨f, map_top f⟩⟩
@@ -401,5 +417,18 @@ lemma cancel_left {g : bounded_order_hom β γ} {f₁ f₂ : bounded_order_hom �
   g.comp f₁ = g.comp f₂ ↔ f₁ = f₂ :=
 ⟨λ h, bounded_order_hom.ext $ λ a, hg $
   by rw [←bounded_order_hom.comp_apply, h, bounded_order_hom.comp_apply], congr_arg _⟩
+
+/-- Reinterpret a bounded order homomorphism as a bounded order homomorphism between the dual
+orders. -/
+@[simps] protected def dual :
+   bounded_order_hom α β ≃ bounded_order_hom (order_dual α) (order_dual β) :=
+{ to_fun := λ f, { to_order_hom := f.to_order_hom.dual,
+                   map_top' := congr_arg to_dual (map_bot f),
+                   map_bot' := congr_arg to_dual (map_top f) },
+  inv_fun := λ f, { to_order_hom := order_hom.dual.symm f.to_order_hom,
+                   map_top' := map_bot f,
+                   map_bot' := map_top f },
+  left_inv := λ f, ext $ λ a, rfl,
+  right_inv := λ f, ext $ λ a, rfl }
 
 end bounded_order_hom


### PR DESCRIPTION
Define `BoundedOrder`, the category of bounded orders with bounded order homs along with its forgetful functors to `PartialOrder` and `Bipointed`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
