### PR TITLE
[Merged by Bors] - feat(analysis/inner_product_space/pi_L2): `complex.isometry_of_orthonormal`

### DIFF
--- a/src/analysis/inner_product_space/pi_L2.lean
+++ b/src/analysis/inner_product_space/pi_L2.lean
@@ -232,6 +232,16 @@ complex.isometry_euclidean.trans (v.isometry_euclidean_of_orthonormal hv).symm
     (complex.isometry_of_orthonormal hv).trans f :=
 by simp [complex.isometry_of_orthonormal, linear_isometry_equiv.trans_assoc]
 
+lemma complex.isometry_of_orthonormal_symm_apply
+  {v : basis (fin 2) ℝ F} (hv : orthonormal ℝ v) (f : F) :
+  (complex.isometry_of_orthonormal hv).symm f = (v.coord 0 f : ℂ) + (v.coord 1 f : ℂ) * I :=
+by simp [complex.isometry_of_orthonormal]
+
+lemma complex.isometry_of_orthonormal_apply
+  {v : basis (fin 2) ℝ F} (hv : orthonormal ℝ v) (z : ℂ) :
+  complex.isometry_of_orthonormal hv z = z.re • v 0 + z.im • v 1 :=
+by simp [complex.isometry_of_orthonormal, (dec_trivial : (finset.univ : finset (fin 2)) = {0, 1})]
+
 open finite_dimensional
 
 /-- Given a natural number `n` equal to the `finrank` of a finite-dimensional inner product space,

--- a/src/analysis/inner_product_space/pi_L2.lean
+++ b/src/analysis/inner_product_space/pi_L2.lean
@@ -39,6 +39,8 @@ noncomputable theory
 variables {ι : Type*}
 variables {𝕜 : Type*} [is_R_or_C 𝕜] {E : Type*} [inner_product_space 𝕜 E]
 variables {E' : Type*} [inner_product_space 𝕜 E']
+variables {F : Type*} [inner_product_space ℝ F]
+variables {F' : Type*} [inner_product_space ℝ F']
 local notation `⟪`x`, `y`⟫` := @inner 𝕜 _ _ x y
 
 /-
@@ -219,6 +221,16 @@ by { conv_rhs { rw ← complex.isometry_euclidean_proj_eq_self z }, simp }
 @[simp] lemma complex.isometry_euclidean_apply_one (z : ℂ) :
   complex.isometry_euclidean z 1 = z.im :=
 by { conv_rhs { rw ← complex.isometry_euclidean_proj_eq_self z }, simp }
+
+/-- The isometry between `ℂ` and a two-dimensional real inner product space given by a basis. -/
+def complex.isometry_of_orthonormal {v : basis (fin 2) ℝ F} (hv : orthonormal ℝ v) : ℂ ≃ₗᵢ[ℝ] F :=
+complex.isometry_euclidean.trans (v.isometry_euclidean_of_orthonormal hv).symm
+
+@[simp] lemma complex.map_isometry_of_orthonormal {v : basis (fin 2) ℝ F} (hv : orthonormal ℝ v)
+  (f : F ≃ₗᵢ[ℝ] F') :
+  complex.isometry_of_orthonormal (hv.map_linear_isometry_equiv f) =
+    (complex.isometry_of_orthonormal hv).trans f :=
+by simp [complex.isometry_of_orthonormal, linear_isometry_equiv.trans_assoc]
 
 open finite_dimensional
 


### PR DESCRIPTION
Add a definition for the isometry between `ℂ` and a two-dimensional
real inner product space given by a basis, and an associated `simp`
lemma for how this relates to `basis.map`.

This definition is just the composition of two existing definitions,
`complex.isometry_euclidean` and (the inverse of)
`basis.isometry_euclidean_of_orthonormal`.  However, it's still useful
to have it as a single definition when using it to define and prove
basic properties of oriented angles (in an oriented two-dimensional
real inner product space), to keep definitions and terms in proofs
simpler and to avoid tactics such as `simp` or `rw` rearranging things
inside this definition when not wanted (almost everything just needs
to use some isometry between these two spaces without caring about the
details of how it's defined, so it seems best to use a single `def`
for this isometry, and on the rare occasions where the details of how
it's defined matter, prove specific lemmas about the required
properties).



---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
