### PR TITLE
[Merged by Bors] - feat(data/equiv): define `ring_equiv_class`

### DIFF
--- a/src/algebra/algebra/basic.lean
+++ b/src/algebra/algebra/basic.lean
@@ -772,31 +772,30 @@ variables [comm_semiring R] [semiring A₁] [semiring A₂] [semiring A₃]
 variables [algebra R A₁] [algebra R A₂] [algebra R A₃]
 variables (e : A₁ ≃ₐ[R] A₂)
 
+instance : ring_equiv_class (A₁ ≃ₐ[R] A₂) A₁ A₂ :=
+{ coe := to_fun,
+  inv := inv_fun,
+  coe_injective' := λ f g h₁ h₂, by { cases f, cases g, congr' },
+  map_add := map_add',
+  map_mul := map_mul',
+  left_inv := left_inv,
+  right_inv := right_inv }
+
 instance : has_coe_to_fun (A₁ ≃ₐ[R] A₂) (λ _, A₁ → A₂) := ⟨alg_equiv.to_fun⟩
 
 @[ext]
-lemma ext {f g : A₁ ≃ₐ[R] A₂} (h : ∀ a, f a = g a) : f = g :=
-begin
-  have h₁ : f.to_equiv = g.to_equiv := equiv.ext h,
-  cases f, cases g, congr,
-  { exact (funext h) },
-  { exact congr_arg equiv.inv_fun h₁ }
-end
+lemma ext {f g : A₁ ≃ₐ[R] A₂} (h : ∀ a, f a = g a) : f = g := fun_like.ext f g h
 
-protected lemma congr_arg {f : A₁ ≃ₐ[R] A₂} : Π {x x' : A₁}, x = x' → f x = f x'
-| _ _ rfl := rfl
+protected lemma congr_arg {f : A₁ ≃ₐ[R] A₂} {x x' : A₁} : x = x' → f x = f x' :=
+fun_like.congr_arg f
 
-protected lemma congr_fun {f g : A₁ ≃ₐ[R] A₂} (h : f = g) (x : A₁) : f x = g x := h ▸ rfl
+protected lemma congr_fun {f g : A₁ ≃ₐ[R] A₂} (h : f = g) (x : A₁) : f x = g x :=
+fun_like.congr_fun h x
 
-lemma ext_iff {f g : A₁ ≃ₐ[R] A₂} : f = g ↔ ∀ x, f x = g x :=
-⟨λ h x, h ▸ rfl, ext⟩
+protected lemma ext_iff {f g : A₁ ≃ₐ[R] A₂} : f = g ↔ ∀ x, f x = g x := fun_like.ext_iff
 
 lemma coe_fun_injective : @function.injective (A₁ ≃ₐ[R] A₂) (A₁ → A₂) (λ e, (e : A₁ → A₂)) :=
-begin
-  intros f g w,
-  ext,
-  exact congr_fun w a,
-end
+fun_like.coe_injective
 
 instance has_coe_to_ring_equiv : has_coe (A₁ ≃ₐ[R] A₂) (A₁ ≃+* A₂) := ⟨alg_equiv.to_ring_equiv⟩
 
@@ -817,13 +816,10 @@ lemma coe_ring_equiv' : (e.to_ring_equiv : A₁ → A₂) = e := rfl
 lemma coe_ring_equiv_injective : function.injective (coe : (A₁ ≃ₐ[R] A₂) → (A₁ ≃+* A₂)) :=
 λ e₁ e₂ h, ext $ ring_equiv.congr_fun h
 
-@[simp] lemma map_add : ∀ x y, e (x + y) = e x + e y := e.to_add_equiv.map_add
-
-@[simp] lemma map_zero : e 0 = 0 := e.to_add_equiv.map_zero
-
-@[simp] lemma map_mul : ∀ x y, e (x * y) = (e x) * (e y) := e.to_mul_equiv.map_mul
-
-@[simp] lemma map_one : e 1 = 1 := e.to_mul_equiv.map_one
+protected lemma map_add : ∀ x y, e (x + y) = e x + e y := map_add e
+protected lemma map_zero : e 0 = 0 := map_zero e
+protected lemma map_mul : ∀ x y, e (x * y) = (e x) * (e y) := map_mul e
+protected lemma map_one : e 1 = 1 := map_one e
 
 @[simp] lemma commutes : ∀ (r : R), e (algebra_map R A₁ r) = algebra_map R A₂ r :=
   e.commutes'
@@ -861,13 +857,10 @@ lemma coe_alg_hom_injective : function.injective (coe : (A₁ ≃ₐ[R] A₂) �
 lemma coe_ring_hom_commutes : ((e : A₁ →ₐ[R] A₂) : A₁ →+* A₂) = ((e : A₁ ≃+* A₂) : A₁ →+* A₂) :=
 rfl
 
-@[simp] lemma map_pow : ∀ (x : A₁) (n : ℕ), e (x ^ n) = (e x) ^ n := e.to_alg_hom.map_pow
-
-lemma injective : function.injective e := e.to_equiv.injective
-
-lemma surjective : function.surjective e := e.to_equiv.surjective
-
-lemma bijective : function.bijective e := e.to_equiv.bijective
+protected lemma map_pow : ∀ (x : A₁) (n : ℕ), e (x ^ n) = (e x) ^ n := e.to_alg_hom.map_pow
+protected lemma injective : function.injective e := equiv_like.injective e
+protected lemma surjective : function.surjective e := equiv_like.surjective e
+protected lemma bijective : function.bijective e := equiv_like.bijective e
 
 /-- Algebra equivalences are reflexive. -/
 @[refl] def refl : A₁ ≃ₐ[R] A₁ := {commutes' := λ r, rfl, ..(1 : A₁ ≃+* A₁)}
@@ -1154,11 +1147,8 @@ section ring
 variables [comm_ring R] [ring A₁] [ring A₂]
 variables [algebra R A₁] [algebra R A₂] (e : A₁ ≃ₐ[R] A₂)
 
-@[simp] lemma map_neg (x) : e (-x) = -e x :=
-e.to_alg_hom.map_neg x
-
-@[simp] lemma map_sub (x y) : e (x - y) = e x - e y :=
-e.to_alg_hom.map_sub x y
+protected lemma map_neg (x) : e (-x) = -e x := map_neg e x
+protected lemma map_sub (x y) : e (x - y) = e x - e y := map_sub e x y
 
 end ring
 

--- a/src/algebra/algebra/basic.lean
+++ b/src/algebra/algebra/basic.lean
@@ -781,6 +781,8 @@ instance : ring_equiv_class (A₁ ≃ₐ[R] A₂) A₁ A₂ :=
   left_inv := left_inv,
   right_inv := right_inv }
 
+/--  Helper instance for when there's too many metavariables to apply
+`fun_like.has_coe_to_fun` directly. -/
 instance : has_coe_to_fun (A₁ ≃ₐ[R] A₂) (λ _, A₁ → A₂) := ⟨alg_equiv.to_fun⟩
 
 @[ext]

--- a/src/algebra/ring/basic.lean
+++ b/src/algebra/ring/basic.lean
@@ -401,6 +401,9 @@ initialize_simps_projections ring_hom (to_fun → apply)
 
 @[simp] lemma coe_mk (f : α → β) (h₁ h₂ h₃ h₄) : ⇑(⟨f, h₁, h₂, h₃, h₄⟩ : α →+* β) = f := rfl
 
+@[simp] lemma coe_coe {F : Type*} [ring_hom_class F α β] (f : F) : ((f : α →+* β) : α → β) = f :=
+rfl
+
 instance has_coe_monoid_hom : has_coe (α →+* β) (α →* β) := ⟨ring_hom.to_monoid_hom⟩
 
 @[simp, norm_cast] lemma coe_monoid_hom (f : α →+* β) : ⇑(f : α →* β) = f := rfl

--- a/src/data/equiv/ring.lean
+++ b/src/data/equiv/ring.lean
@@ -253,9 +253,9 @@ protected lemma map_zero : f 0 = 0 := map_zero f
 
 variable {x}
 
-protected lemma map_eq_zero_iff : f x = 0 ↔ x = 0 := map_eq_zero_iff f (equiv_like.injective f)
+protected lemma map_eq_zero_iff : f x = 0 ↔ x = 0 := add_equiv_class.map_eq_zero_iff f
 
-lemma map_ne_zero_iff : f x ≠ 0 ↔ x ≠ 0 := (f : R ≃+ S).map_ne_zero_iff
+lemma map_ne_zero_iff : f x ≠ 0 ↔ x ≠ 0 := add_equiv_class.map_ne_zero_iff f
 
 end non_unital_semiring
 
@@ -268,9 +268,9 @@ protected lemma map_one : f 1 = 1 := map_one f
 
 variable {x}
 
-protected lemma map_eq_one_iff : f x = 1 ↔ x = 1 := map_eq_one_iff f (equiv_like.injective f)
+protected lemma map_eq_one_iff : f x = 1 ↔ x = 1 := mul_equiv_class.map_eq_one_iff f
 
-lemma map_ne_one_iff : f x ≠ 1 ↔ x ≠ 1 := (f : R ≃* S).map_ne_one_iff
+lemma map_ne_one_iff : f x ≠ 1 ↔ x ≠ 1 := mul_equiv_class.map_ne_one_iff f
 
 /-- Produce a ring isomorphism from a bijective ring homomorphism. -/
 noncomputable def of_bijective (f : R →+* S) (hf : function.bijective f) : R ≃+* S :=

--- a/src/data/equiv/ring.lean
+++ b/src/data/equiv/ring.lean
@@ -74,7 +74,7 @@ instance to_add_equiv_class (F R S : Type*)
   .. h }
 
 @[priority 100] -- See note [lower instance priority]
-instance to_ring_hom_class(F R S : Type*)
+instance to_ring_hom_class (F R S : Type*)
   [non_assoc_semiring R] [non_assoc_semiring S] [h : ring_equiv_class F R S] :
   ring_hom_class F R S :=
 { coe := coe_fn,

--- a/src/data/equiv/ring.lean
+++ b/src/data/equiv/ring.lean
@@ -57,31 +57,62 @@ add_decl_doc ring_equiv.to_add_equiv
 /-- The equivalence of multiplicative monoids underlying an equivalence of (semi)rings. -/
 add_decl_doc ring_equiv.to_mul_equiv
 
+/-- `ring_equiv_class F R S` states that `F` is a type of ring structure preserving equivalences.
+You should extend this class when you extend `ring_equiv`. -/
+class ring_equiv_class (F : Type*) (R S : out_param Type*)
+  [has_mul R] [has_add R] [has_mul S] [has_add S]
+  extends mul_equiv_class F R S :=
+(map_add : ∀ (f : F) a b, f (a + b) = f a + f b)
+
+namespace ring_equiv_class
+
+@[priority 100] -- See note [lower instance priority]
+instance to_add_equiv_class (F R S : Type*)
+  [has_mul R] [has_add R] [has_mul S] [has_add S] [h : ring_equiv_class F R S] :
+  add_equiv_class F R S :=
+{ coe := coe_fn,
+  .. h }
+
+@[priority 100] -- See note [lower instance priority]
+instance to_ring_hom_class(F R S : Type*)
+  [non_assoc_semiring R] [non_assoc_semiring S] [h : ring_equiv_class F R S] :
+  ring_hom_class F R S :=
+{ coe := coe_fn,
+  coe_injective' := fun_like.coe_injective,
+  map_zero := map_zero,
+  map_one := map_one,
+  .. h }
+
+end ring_equiv_class
+
 namespace ring_equiv
 
 section basic
 
 variables [has_mul R] [has_add R] [has_mul S] [has_add S] [has_mul S'] [has_add S']
 
+instance : ring_equiv_class (R ≃+* S) R S :=
+{ coe := to_fun,
+  inv := inv_fun,
+  coe_injective' := λ e f h₁ h₂, by { cases e, cases f, congr' },
+  map_add := map_add',
+  map_mul := map_mul',
+  left_inv := ring_equiv.left_inv,
+  right_inv := ring_equiv.right_inv }
+
 instance : has_coe_to_fun (R ≃+* S) (λ _, R → S) := ⟨ring_equiv.to_fun⟩
 
 @[simp] lemma to_fun_eq_coe (f : R ≃+* S) : f.to_fun = f := rfl
 
 /-- A ring isomorphism preserves multiplication. -/
-@[simp] lemma map_mul (e : R ≃+* S) (x y : R) : e (x * y) = e x * e y := e.map_mul' x y
+protected lemma map_mul (e : R ≃+* S) (x y : R) : e (x * y) = e x * e y := map_mul e x y
 
 /-- A ring isomorphism preserves addition. -/
-@[simp] lemma map_add (e : R ≃+* S) (x y : R) : e (x + y) = e x + e y := e.map_add' x y
+protected lemma map_add (e : R ≃+* S) (x y : R) : e (x + y) = e x + e y := map_add e x y
 
 /-- Two ring isomorphisms agree if they are defined by the
     same underlying function. -/
-@[ext] lemma ext {f g : R ≃+* S} (h : ∀ x, f x = g x) : f = g :=
-begin
-  have h₁ : f.to_equiv = g.to_equiv := equiv.ext h,
-  cases f, cases g, congr,
-  { exact (funext h) },
-  { exact congr_arg equiv.inv_fun h₁ }
-end
+@[ext] lemma ext {f g : R ≃+* S} (h : ∀ x, f x = g x) : f = g := fun_like.ext f g h
 
 @[simp] theorem coe_mk (e e' h₁ h₂ h₃ h₄) :
   ⇑(⟨e, e', h₁, h₂, h₃, h₄⟩ : R ≃+* S) = e := rfl
@@ -89,13 +120,11 @@ end
 @[simp] theorem mk_coe (e : R ≃+* S) (e' h₁ h₂ h₃ h₄) :
   (⟨e, e', h₁, h₂, h₃, h₄⟩ : R ≃+* S) = e := ext $ λ _, rfl
 
-protected lemma congr_arg {f : R ≃+* S} : Π {x x' : R}, x = x' → f x = f x'
-| _ _ rfl := rfl
+protected lemma congr_arg {f : R ≃+* S} {x x' : R} : x = x' → f x = f x' := fun_like.congr_arg f
 
-protected lemma congr_fun {f g : R ≃+* S} (h : f = g) (x : R) : f x = g x := h ▸ rfl
+protected lemma congr_fun {f g : R ≃+* S} (h : f = g) (x : R) : f x = g x := fun_like.congr_fun h x
 
-lemma ext_iff {f g : R ≃+* S} : f = g ↔ ∀ x, f x = g x :=
-⟨λ h x, h ▸ rfl, ext⟩
+protected lemma ext_iff {f g : R ≃+* S} : f = g ↔ ∀ x, f x = g x := fun_like.ext_iff
 
 instance has_coe_to_mul_equiv : has_coe (R ≃+* S) (R ≃* S) := ⟨ring_equiv.to_mul_equiv⟩
 
@@ -166,9 +195,9 @@ symm_bijective.injective $ ext $ λ x, rfl
 @[simp] lemma trans_apply (e₁ : R ≃+* S) (e₂ : S ≃+* S') (a : R) :
   e₁.trans e₂ a = e₂ (e₁ a) := rfl
 
-protected lemma bijective (e : R ≃+* S) : function.bijective e := e.to_equiv.bijective
-protected lemma injective (e : R ≃+* S) : function.injective e := e.to_equiv.injective
-protected lemma surjective (e : R ≃+* S) : function.surjective e := e.to_equiv.surjective
+protected lemma bijective (e : R ≃+* S) : function.bijective e := equiv_like.bijective e
+protected lemma injective (e : R ≃+* S) : function.injective e := equiv_like.injective e
+protected lemma surjective (e : R ≃+* S) : function.surjective e := equiv_like.surjective e
 
 @[simp] lemma apply_symm_apply (e : R ≃+* S) : ∀ x, e (e.symm x) = x := e.to_equiv.apply_symm_apply
 @[simp] lemma symm_apply_apply (e : R ≃+* S) : ∀ x, e.symm (e x) = x := e.to_equiv.symm_apply_apply
@@ -220,11 +249,11 @@ variables [non_unital_non_assoc_semiring R] [non_unital_non_assoc_semiring S]
   (f : R ≃+* S) (x y : R)
 
 /-- A ring isomorphism sends zero to zero. -/
-@[simp] lemma map_zero : f 0 = 0 := (f : R ≃+ S).map_zero
+protected lemma map_zero : f 0 = 0 := map_zero f
 
 variable {x}
 
-@[simp] lemma map_eq_zero_iff : f x = 0 ↔ x = 0 := (f : R ≃+ S).map_eq_zero_iff
+protected lemma map_eq_zero_iff : f x = 0 ↔ x = 0 := map_eq_zero_iff f (equiv_like.injective f)
 
 lemma map_ne_zero_iff : f x ≠ 0 ↔ x ≠ 0 := (f : R ≃+ S).map_ne_zero_iff
 
@@ -235,11 +264,11 @@ section semiring
 variables [non_assoc_semiring R] [non_assoc_semiring S] (f : R ≃+* S) (x y : R)
 
 /-- A ring isomorphism sends one to one. -/
-@[simp] lemma map_one : f 1 = 1 := (f : R ≃* S).map_one
+protected lemma map_one : f 1 = 1 := map_one f
 
 variable {x}
 
-@[simp] lemma map_eq_one_iff : f x = 1 ↔ x = 1 := (f : R ≃* S).map_eq_one_iff
+protected lemma map_eq_one_iff : f x = 1 ↔ x = 1 := map_eq_one_iff f (equiv_like.injective f)
 
 lemma map_ne_one_iff : f x ≠ 1 ↔ x ≠ 1 := (f : R ≃* S).map_ne_one_iff
 
@@ -259,9 +288,9 @@ section
 
 variables [ring R] [ring S] (f : R ≃+* S) (x y : R)
 
-@[simp] lemma map_neg : f (-x) = -f x := (f : R ≃+ S).map_neg x
+protected lemma map_neg : f (-x) = -f x := map_neg f x
 
-@[simp] lemma map_sub : f (x - y) = f x - f y := (f : R ≃+ S).map_sub x y
+protected lemma map_sub : f (x - y) = f x - f y := map_sub f x y
 
 @[simp] lemma map_neg_one : f (-1) = -1 := f.map_one ▸ f.map_neg 1
 
@@ -408,9 +437,7 @@ section group_power
 
 variables [semiring R] [semiring S]
 
-@[simp] lemma map_pow (f : R ≃+* S) (a) :
-  ∀ n : ℕ, f (a ^ n) = (f a) ^ n :=
-f.to_ring_hom.map_pow a
+protected lemma map_pow (f : R ≃+* S) (a) : ∀ n : ℕ, f (a ^ n) = (f a) ^ n := map_pow f a
 
 end group_power
 

--- a/src/data/mv_polynomial/equiv.lean
+++ b/src/data/mv_polynomial/equiv.lean
@@ -293,8 +293,8 @@ lemma fin_succ_equiv_eq (n : ℕ) :
 begin
   ext : 2,
   { simp only [fin_succ_equiv, option_equiv_left_apply, aeval_C, alg_equiv.coe_trans,
-      alg_equiv.coe_alg_hom, coe_eval₂_hom, alg_hom.coe_to_ring_hom, comp_app, rename_equiv_apply,
-      eval₂_C, ring_hom.coe_comp, coe_coe, rename_C],
+      ring_hom.coe_coe, coe_eval₂_hom, comp_app, rename_equiv_apply, eval₂_C, ring_hom.coe_comp,
+      rename_C],
     refl },
   { intro i,
     refine fin.cases _ _ i;

--- a/src/ring_theory/algebraic_independent.lean
+++ b/src/ring_theory/algebraic_independent.lean
@@ -417,7 +417,7 @@ begin
     @polynomial.is_scalar_tower (mv_polynomial ι R) _ R _ _ _ _ _ _ _,
   rw [algebraic_independent.mv_polynomial_option_equiv_polynomial_adjoin_apply, aeval_C,
     @is_scalar_tower.algebra_map_apply _ _ _ _ _ _ _ _ _ h, ← polynomial.C_eq_algebra_map,
-    polynomial.map_C, coe_coe, alg_hom.coe_to_ring_hom, alg_equiv.coe_alg_hom, alg_equiv.commutes]
+    polynomial.map_C, ring_hom.coe_coe, alg_equiv.commutes]
 end
 
 @[simp]
@@ -433,7 +433,7 @@ lemma algebraic_independent.mv_polynomial_option_equiv_polynomial_adjoin_X_some
   hx.mv_polynomial_option_equiv_polynomial_adjoin (X (some i)) =
     polynomial.C (hx.aeval_equiv (X i)) :=
 by rw [algebraic_independent.mv_polynomial_option_equiv_polynomial_adjoin_apply, aeval_X,
-      option.elim, polynomial.map_C, coe_coe, alg_hom.coe_to_ring_hom, alg_equiv.coe_alg_hom]
+      option.elim, polynomial.map_C, ring_hom.coe_coe]
 
 lemma algebraic_independent.aeval_comp_mv_polynomial_option_equiv_polynomial_adjoin
   (hx : algebraic_independent R x) (a : A) :

--- a/src/ring_theory/finiteness.lean
+++ b/src/ring_theory/finiteness.lean
@@ -382,7 +382,7 @@ begin
     (mv_polynomial.map_surjective f.to_ring_hom hf_surj).comp (alg_equiv.surjective _),
     ideal.fg_ker_comp _ _ _ _ (alg_equiv.surjective _)⟩,
   { convert submodule.fg_bot,
-    exact ring_hom.ker_coe_equiv _, },
+    exact ring_hom.ker_coe_equiv (mv_polynomial.sum_alg_equiv R ι ι').to_ring_equiv },
   { rw [alg_hom.to_ring_hom_eq_coe, mv_polynomial.map_alg_hom_coe_ring_hom, mv_polynomial.ker_map],
     exact hf_ker.map mv_polynomial.C, }
 end


### PR DESCRIPTION
This PR applies the morphism class pattern to `ring_equiv`, producing a new `ring_equiv_class` extending `mul_equiv_class` and `add_equiv_class`. It also provides a `ring_equiv_class` instance for `alg_equiv`s.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
