### PR TITLE
[Merged by Bors] - chore(category_theory/linear/yoneda): Removing some slow uses of `obviously`

### DIFF
--- a/src/category_theory/linear/yoneda.lean
+++ b/src/category_theory/linear/yoneda.lean
@@ -38,7 +38,7 @@ def linear_yoneda : C ⥤ Cᵒᵖ ⥤ Module R :=
     map_comp' := λ _ _ _ f g, begin ext, dsimp, erw [category.assoc] end,
     map_id' := λ Y, begin ext, dsimp, erw [category.id_comp] end },
   map := λ X X' f, { app := λ Y, linear.right_comp R _ f },
-  map_id' := λ X, by { ext, simp },
+  map_id' := λ X, by { ext, simp }, -- `obviously` provides these, but slowly
   map_comp' := λ _ _ _ f g, by { ext, simp } }
 
 /-- The Yoneda embedding for `R`-linear categories `C`,
@@ -52,7 +52,7 @@ def linear_coyoneda : Cᵒᵖ ⥤ C ⥤ Module R :=
     map_id' := λ Y, by { ext, exact category.comp_id _ },
     map_comp' := λ _ _ _ f g, by { ext, exact eq.symm (category.assoc _ _ _) } },
   map := λ Y Y' f, { app := λ X, linear.left_comp _ _ f.unop },
-  map_id' := λ X, by { ext, simp },
+  map_id' := λ X, by { ext, simp }, -- `obviously` provides these, but slowly
   map_comp' := λ _ _ _ f g, by { ext, simp } }
 
 instance linear_yoneda_obj_additive (X : C) : ((linear_yoneda R C).obj X).additive := {}

--- a/src/category_theory/linear/yoneda.lean
+++ b/src/category_theory/linear/yoneda.lean
@@ -37,7 +37,9 @@ def linear_yoneda : C ⥤ Cᵒᵖ ⥤ Module R :=
     map := λ Y Y' f, linear.left_comp R _ f.unop,
     map_comp' := λ _ _ _ f g, begin ext, dsimp, erw [category.assoc] end,
     map_id' := λ Y, begin ext, dsimp, erw [category.id_comp] end },
-  map := λ X X' f, { app := λ Y, linear.right_comp R _ f } }.
+  map := λ X X' f, { app := λ Y, linear.right_comp R _ f },
+  map_id' := λ X, by { ext, simp },
+  map_comp' := λ _ _ _ f g, by { ext, simp } }
 
 /-- The Yoneda embedding for `R`-linear categories `C`,
 sending an object `Y : Cᵒᵖ` to the `Module R`-valued copresheaf on `C`,
@@ -49,7 +51,9 @@ def linear_coyoneda : Cᵒᵖ ⥤ C ⥤ Module R :=
     map := λ Y Y', linear.right_comp _ _,
     map_id' := λ Y, by { ext, exact category.comp_id _ },
     map_comp' := λ _ _ _ f g, by { ext, exact eq.symm (category.assoc _ _ _) } },
-  map := λ Y Y' f, { app := λ X, linear.left_comp _ _ f.unop } }
+  map := λ Y Y' f, { app := λ X, linear.left_comp _ _ f.unop },
+  map_id' := λ X, by { ext, simp },
+  map_comp' := λ _ _ _ f g, by { ext, simp } }
 
 instance linear_yoneda_obj_additive (X : C) : ((linear_yoneda R C).obj X).additive := {}
 instance linear_coyoneda_obj_additive (Y : Cᵒᵖ) : ((linear_coyoneda R C).obj Y).additive := {}


### PR DESCRIPTION
Providing explicit proofs for `map_id'` and `map_comp'` rather than leaving them for `obviously` (and hence `tidy`) to fill in.
Suggested by Kevin Buzzard in [this Zulip comment](https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/.60tidy.60.20in.20mathlib.20proofs/near/271474418).

Co-authored-by: Kevin Buzzard <k.buzzard@imperial.ac.uk>

(These are temporary changes until `obviously` can be tweaked to do this more quickly)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
