### PR TITLE
[Merged by Bors] - chore(category_theory/monad/equiv_mon): Removing some slow uses of `obviously`

### DIFF
--- a/src/category_theory/monad/equiv_mon.lean
+++ b/src/category_theory/monad/equiv_mon.lean
@@ -38,6 +38,8 @@ def to_Mon : monad C → Mon_ (C ⥤ C) := λ M,
 { X := (M : C ⥤ C),
   one := M.η,
   mul := M.μ,
+  one_mul' := by { ext, simp },
+  mul_one' := by { ext, simp },
   mul_assoc' := by { ext, dsimp, simp [M.assoc] } }
 
 variable (C)

--- a/src/category_theory/monad/equiv_mon.lean
+++ b/src/category_theory/monad/equiv_mon.lean
@@ -87,7 +87,9 @@ variable {C}
 @[simps {rhs_md := semireducible}]
 def counit_iso : Mon_to_Monad C ⋙ Monad_to_Mon C ≅ 𝟭 _ :=
 { hom := { app := λ _, { hom := 𝟙 _ } },
-  inv := { app := λ _, { hom := 𝟙 _ } } }
+  inv := { app := λ _, { hom := 𝟙 _ } },
+  hom_inv_id' := by { ext, simp },
+  inv_hom_id' := by { ext, simp } }
 
 /-- Auxiliary definition for `Monad_Mon_equiv` -/
 @[simps]

--- a/src/category_theory/monad/equiv_mon.lean
+++ b/src/category_theory/monad/equiv_mon.lean
@@ -119,7 +119,8 @@ def Monad_Mon_equiv : (monad C) ≌ (Mon_ (C ⥤ C)) :=
 { functor := Monad_to_Mon _,
   inverse := Mon_to_Monad _,
   unit_iso := unit_iso,
-  counit_iso := counit_iso }
+  counit_iso := counit_iso,
+  functor_unit_iso_comp' := by { intros X, ext, dsimp, simp } }
 
 -- Sanity check
 example (A : monad C) {X : C} : ((Monad_Mon_equiv C).unit_iso.app A).hom.app X = 𝟙 _ := rfl

--- a/src/category_theory/monad/equiv_mon.lean
+++ b/src/category_theory/monad/equiv_mon.lean
@@ -38,8 +38,8 @@ def to_Mon : monad C → Mon_ (C ⥤ C) := λ M,
 { X := (M : C ⥤ C),
   one := M.η,
   mul := M.μ,
-  one_mul' := by { ext, simp },
-  mul_one' := by { ext, simp },
+  one_mul' := by { ext, simp }, -- `obviously` provides this, but slowly
+  mul_one' := by { ext, simp }, -- `obviously` provides this, but slowly
   mul_assoc' := by { ext, dsimp, simp [M.assoc] } }
 
 variable (C)
@@ -48,7 +48,7 @@ variable (C)
 def Monad_to_Mon : monad C ⥤ Mon_ (C ⥤ C) :=
 { obj := to_Mon,
   map := λ _ _ f, { hom := f.to_nat_trans },
-  map_id' := by { intros X, refl },
+  map_id' := by { intros X, refl }, -- `obviously` provides this, but slowly
   map_comp' := by { intros X Y Z f g, refl, } }
 variable {C}
 
@@ -88,7 +88,7 @@ variable {C}
 def counit_iso : Mon_to_Monad C ⋙ Monad_to_Mon C ≅ 𝟭 _ :=
 { hom := { app := λ _, { hom := 𝟙 _ } },
   inv := { app := λ _, { hom := 𝟙 _ } },
-  hom_inv_id' := by { ext, simp },
+  hom_inv_id' := by { ext, simp }, -- `obviously` provides these, but slowly
   inv_hom_id' := by { ext, simp } }
 
 /-- Auxiliary definition for `Monad_Mon_equiv` -/
@@ -106,7 +106,7 @@ def unit_iso_inv : Monad_to_Mon C ⋙ Mon_to_Monad C ⟶ 𝟭 _ :=
 def unit_iso : 𝟭 _ ≅ Monad_to_Mon C ⋙ Mon_to_Monad C :=
 { hom := unit_iso_hom,
   inv := unit_iso_inv,
-  hom_inv_id' := by { ext, simp },
+  hom_inv_id' := by { ext, simp }, -- `obviously` provides these, but slowly
   inv_hom_id' := by { ext, simp } }
 
 end Monad_Mon_equiv
@@ -120,7 +120,7 @@ def Monad_Mon_equiv : (monad C) ≌ (Mon_ (C ⥤ C)) :=
   inverse := Mon_to_Monad _,
   unit_iso := unit_iso,
   counit_iso := counit_iso,
-  functor_unit_iso_comp' := by { intros X, ext, dsimp, simp } }
+  functor_unit_iso_comp' := by { intros X, ext, dsimp, simp } } -- `obviously`, slowly
 
 -- Sanity check
 example (A : monad C) {X : C} : ((Monad_Mon_equiv C).unit_iso.app A).hom.app X = 𝟙 _ := rfl

--- a/src/category_theory/monad/equiv_mon.lean
+++ b/src/category_theory/monad/equiv_mon.lean
@@ -47,7 +47,9 @@ variable (C)
 @[simps]
 def Monad_to_Mon : monad C ⥤ Mon_ (C ⥤ C) :=
 { obj := to_Mon,
-  map := λ _ _ f, { hom := f.to_nat_trans } }
+  map := λ _ _ f, { hom := f.to_nat_trans },
+  map_id' := by { intros X, refl },
+  map_comp' := by { intros X Y Z f g, refl, } }
 variable {C}
 
 /-- To every monoid object in `C ⥤ C` we associate a `Monad C`. -/

--- a/src/category_theory/monad/equiv_mon.lean
+++ b/src/category_theory/monad/equiv_mon.lean
@@ -105,7 +105,9 @@ def unit_iso_inv : Monad_to_Mon C ⋙ Mon_to_Monad C ⟶ 𝟭 _ :=
 @[simps]
 def unit_iso : 𝟭 _ ≅ Monad_to_Mon C ⋙ Mon_to_Monad C :=
 { hom := unit_iso_hom,
-  inv := unit_iso_inv }
+  inv := unit_iso_inv,
+  hom_inv_id' := by { ext, simp },
+  inv_hom_id' := by { ext, simp } }
 
 end Monad_Mon_equiv
 


### PR DESCRIPTION
Providing explicit proofs for various fields rather than leaving them for `obviously` (and hence `tidy`) to fill in.
Follow-up to this suggestion by Kevin Buzzard in [this Zulip comment](https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/.60tidy.60.20in.20mathlib.20proofs/near/271474418).

(These are temporary changes until `obviously` can be tweaked to do this more quickly)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
