### PR TITLE
[Merged by Bors] - chore(order/cover): Rename `covers` to `covby`

### DIFF
--- a/src/order/atoms.lean
+++ b/src/order/atoms.lean
@@ -71,11 +71,11 @@ lemma is_atom.Iic (ha : is_atom a) (hax : a ≤ x) : is_atom (⟨a, hax⟩ : set
 lemma is_atom.of_is_atom_coe_Iic {a : set.Iic x} (ha : is_atom a) : is_atom (a : α) :=
 ⟨λ con, ha.1 (subtype.ext con), λ b hba, subtype.mk_eq_mk.1 (ha.2 ⟨b, hba.le.trans a.prop⟩ hba)⟩
 
-@[simp] lemma bot_covers_iff : ⊥ ⋖ a ↔ is_atom a :=
+@[simp] lemma bot_covby_iff : ⊥ ⋖ a ↔ is_atom a :=
 ⟨λ h, ⟨h.lt.ne', λ b hba, not_not.1 $ λ hb, h.2 (ne.bot_lt hb) hba⟩,
   λ h, ⟨h.1.bot_lt, λ b hb hba, hb.ne' $ h.2 _ hba⟩⟩
 
-alias bot_covers_iff ↔ covers.is_atom is_atom.bot_covers
+alias bot_covby_iff ↔ covby.is_atom is_atom.bot_covby
 
 end is_atom
 
@@ -97,11 +97,11 @@ lemma is_coatom.of_is_coatom_coe_Ici {a : set.Ici x} (ha : is_coatom a) :
   is_coatom (a : α) :=
 ⟨λ con, ha.1 (subtype.ext con), λ b hba, subtype.mk_eq_mk.1 (ha.2 ⟨b, le_trans a.prop hba.le⟩ hba)⟩
 
-@[simp] lemma covers_top_iff : a ⋖ ⊤ ↔ is_coatom a :=
+@[simp] lemma covby_top_iff : a ⋖ ⊤ ↔ is_coatom a :=
 ⟨λ h, ⟨h.ne, λ b hab, not_not.1 $ λ hb, h.2 hab $ ne.lt_top hb⟩,
   λ h, ⟨h.1.lt_top, λ b hab hb, hb.ne $ h.2 _ hab⟩⟩
 
-alias covers_top_iff ↔ covers.is_coatom is_coatom.covers_top
+alias covby_top_iff ↔ covby.is_coatom is_coatom.covby_top
 
 end is_coatom
 
@@ -346,7 +346,7 @@ protected def is_simple_order.linear_order [decidable_eq α] : linear_order α :
 
 @[simp] lemma is_coatom_bot : is_coatom (⊥ : α) := is_atom_dual_iff_is_coatom.1 is_atom_top
 
-lemma bot_covers_top : (⊥ : α) ⋖ ⊤ := is_atom_top.bot_covers
+lemma bot_covby_top : (⊥ : α) ⋖ ⊤ := is_atom_top.bot_covby
 
 end is_simple_order
 

--- a/src/order/cover.lean
+++ b/src/order/cover.lean
@@ -37,7 +37,7 @@ by { simp_rw [covby, not_and, not_forall, exists_prop, not_not], exact imp_iff_r
 alias not_covby_iff ↔ exists_lt_lt_of_not_covby _
 alias exists_lt_lt_of_not_covby ← has_lt.lt.exists_lt_lt
 
-/-- In a dense order, nothing covby anything. -/
+/-- In a dense order, nothing covers anything. -/
 lemma not_covby [densely_ordered α] : ¬ a ⋖ b :=
 λ h, let ⟨c, hc⟩ := exists_between h.1 in h.2 hc.1 hc.2
 

--- a/src/order/cover.lean
+++ b/src/order/cover.lean
@@ -23,54 +23,54 @@ variables {α β : Type*}
 section has_lt
 variables [has_lt α] {a b : α}
 
-/-- `covers a b` means that `b` covers `a`: `a < b` and there is no element in between. -/
-def covers (a b : α) : Prop := a < b ∧ ∀ ⦃c⦄, a < c → ¬ c < b
+/-- `covby a b` means that `b` covers `a`: `a < b` and there is no element in between. -/
+def covby (a b : α) : Prop := a < b ∧ ∀ ⦃c⦄, a < c → ¬ c < b
 
-infix ` ⋖ `:50 := covers
+infix ` ⋖ `:50 := covby
 
-lemma covers.lt (h : a ⋖ b) : a < b := h.1
+lemma covby.lt (h : a ⋖ b) : a < b := h.1
 
 /-- If `a < b`, then `b` does not cover `a` iff there's an element in between. -/
-lemma not_covers_iff (h : a < b) : ¬a ⋖ b ↔ ∃ c, a < c ∧ c < b :=
-by { simp_rw [covers, not_and, not_forall, exists_prop, not_not], exact imp_iff_right h }
+lemma not_covby_iff (h : a < b) : ¬a ⋖ b ↔ ∃ c, a < c ∧ c < b :=
+by { simp_rw [covby, not_and, not_forall, exists_prop, not_not], exact imp_iff_right h }
 
-alias not_covers_iff ↔ exists_lt_lt_of_not_covers _
-alias exists_lt_lt_of_not_covers ← has_lt.lt.exists_lt_lt
+alias not_covby_iff ↔ exists_lt_lt_of_not_covby _
+alias exists_lt_lt_of_not_covby ← has_lt.lt.exists_lt_lt
 
-/-- In a dense order, nothing covers anything. -/
-lemma not_covers [densely_ordered α] : ¬ a ⋖ b :=
+/-- In a dense order, nothing covby anything. -/
+lemma not_covby [densely_ordered α] : ¬ a ⋖ b :=
 λ h, let ⟨c, hc⟩ := exists_between h.1 in h.2 hc.1 hc.2
 
-lemma densely_ordered_iff_forall_not_covers : densely_ordered α ↔ ∀ a b : α, ¬ a ⋖ b :=
-⟨λ h a b, @not_covers _ _ _ _ h, λ h, ⟨λ a b hab, exists_lt_lt_of_not_covers hab $ h _ _⟩⟩
+lemma densely_ordered_iff_forall_not_covby : densely_ordered α ↔ ∀ a b : α, ¬ a ⋖ b :=
+⟨λ h a b, @not_covby _ _ _ _ h, λ h, ⟨λ a b hab, exists_lt_lt_of_not_covby hab $ h _ _⟩⟩
 
 open order_dual
 
-@[simp] lemma to_dual_covers_to_dual_iff : to_dual b ⋖ to_dual a ↔ a ⋖ b :=
+@[simp] lemma to_dual_covby_to_dual_iff : to_dual b ⋖ to_dual a ↔ a ⋖ b :=
 and_congr_right' $ forall_congr $ λ c, forall_swap
 
-@[simp] lemma of_dual_covers_of_dual_iff {a b : order_dual α} :
+@[simp] lemma of_dual_covby_of_dual_iff {a b : order_dual α} :
   of_dual a ⋖ of_dual b ↔ b ⋖ a :=
 and_congr_right' $ forall_congr $ λ c, forall_swap
 
-alias to_dual_covers_to_dual_iff ↔ _ covers.to_dual
-alias of_dual_covers_of_dual_iff ↔ _ covers.of_dual
+alias to_dual_covby_to_dual_iff ↔ _ covby.to_dual
+alias of_dual_covby_of_dual_iff ↔ _ covby.of_dual
 
 end has_lt
 
 section preorder
 variables [preorder α] [preorder β] {a b : α} {f : α ↪o β} {e : α ≃o β}
 
-lemma covers.le (h : a ⋖ b) : a ≤ b := h.1.le
-protected lemma covers.ne (h : a ⋖ b) : a ≠ b := h.lt.ne
-lemma covers.ne' (h : a ⋖ b) : b ≠ a := h.lt.ne'
+lemma covby.le (h : a ⋖ b) : a ≤ b := h.1.le
+protected lemma covby.ne (h : a ⋖ b) : a ≠ b := h.lt.ne
+lemma covby.ne' (h : a ⋖ b) : b ≠ a := h.lt.ne'
 
-instance covers.is_irrefl : is_irrefl α (⋖) := ⟨λ a ha, ha.ne rfl⟩
+instance covby.is_irrefl : is_irrefl α (⋖) := ⟨λ a ha, ha.ne rfl⟩
 
-lemma covers.Ioo_eq (h : a ⋖ b) : Ioo a b = ∅ :=
+lemma covby.Ioo_eq (h : a ⋖ b) : Ioo a b = ∅ :=
 eq_empty_iff_forall_not_mem.2 $ λ x hx, h.2 hx.1 hx.2
 
-lemma covers.of_image (h : f a ⋖ f b) : a ⋖ b :=
+lemma covby.of_image (h : f a ⋖ f b) : a ⋖ b :=
 begin
   refine ⟨_, λ c hac hcb, _⟩,
   { rw ←order_embedding.lt_iff_lt f,
@@ -79,7 +79,7 @@ begin
   exact h.2 hac hcb,
 end
 
-lemma covers.image (hab : a ⋖ b) (h : (set.range f).ord_connected) : f a ⋖ f b :=
+lemma covby.image (hab : a ⋖ b) (h : (set.range f).ord_connected) : f a ⋖ f b :=
 begin
   refine ⟨f.strict_mono hab.1, λ c ha hb, _⟩,
   obtain ⟨c, rfl⟩ := h.out (mem_range_self _) (mem_range_self _) ⟨ha.le, hb.le⟩,
@@ -87,12 +87,12 @@ begin
   exact hab.2 ha hb,
 end
 
-protected lemma set.ord_connected.image_covers_image_iff (h : (set.range f).ord_connected) :
+protected lemma set.ord_connected.image_covby_image_iff (h : (set.range f).ord_connected) :
   f a ⋖ f b ↔ a ⋖ b :=
-⟨covers.of_image, λ hab, hab.image h⟩
+⟨covby.of_image, λ hab, hab.image h⟩
 
-@[simp] lemma apply_covers_apply_iff : e a ⋖ e b ↔ a ⋖ b :=
-⟨covers.of_image, λ hab, begin
+@[simp] lemma apply_covby_apply_iff : e a ⋖ e b ↔ a ⋖ b :=
+⟨covby.of_image, λ hab, begin
   refine ⟨e.strict_mono hab.1, λ c ha hb, _⟩,
   rw [←e.symm.lt_iff_lt, order_iso.symm_apply_apply] at ha hb,
   exact hab.2 ha hb,
@@ -103,13 +103,13 @@ end preorder
 section partial_order
 variables [partial_order α] {a b : α}
 
-lemma covers.Ico_eq (h : a ⋖ b) : Ico a b = {a} :=
+lemma covby.Ico_eq (h : a ⋖ b) : Ico a b = {a} :=
 by rw [←set.Ioo_union_left h.lt, h.Ioo_eq, empty_union]
 
-lemma covers.Ioc_eq (h : a ⋖ b) : Ioc a b = {b} :=
+lemma covby.Ioc_eq (h : a ⋖ b) : Ioc a b = {b} :=
 by rw [←set.Ioo_union_right h.lt, h.Ioo_eq, empty_union]
 
-lemma covers.Icc_eq (h : a ⋖ b) : Icc a b = {a, b} :=
+lemma covby.Icc_eq (h : a ⋖ b) : Icc a b = {a, b} :=
 by { rw [←set.Ico_union_right h.le, h.Ico_eq], refl }
 
 end partial_order

--- a/src/order/succ_pred/basic.lean
+++ b/src/order/succ_pred/basic.lean
@@ -50,7 +50,7 @@ Is `galois_connection pred succ` always true? If not, we should introduce
 class succ_pred_order (α : Type*) [preorder α] extends succ_order α, pred_order α :=
 (pred_succ_gc : galois_connection (pred : α → α) succ)
 ```
-`covers` should help here.
+`covby` should help here.
 -/
 
 open function
@@ -105,11 +105,11 @@ lemma lt_succ_of_not_maximal {a b : α} (h : a < b) : a < succ a :=
 
 alias lt_succ_of_not_maximal ← has_lt.lt.lt_succ
 
-protected lemma _root_.has_lt.lt.covers_succ {a b : α} (h : a < b) : a ⋖ succ a :=
+protected lemma _root_.has_lt.lt.covby_succ {a b : α} (h : a < b) : a ⋖ succ a :=
 ⟨h.lt_succ, λ c hc, (succ_le_of_lt hc).not_lt⟩
 
-@[simp] lemma covers_succ_of_nonempty_Ioi {a : α} (h : (set.Ioi a).nonempty) : a ⋖ succ a :=
-has_lt.lt.covers_succ h.some_mem
+@[simp] lemma covby_succ_of_nonempty_Ioi {a : α} (h : (set.Ioi a).nonempty) : a ⋖ succ a :=
+has_lt.lt.covby_succ h.some_mem
 
 section no_max_order
 variables [no_max_order α] {a b : α}
@@ -135,7 +135,7 @@ alias succ_lt_succ_iff ↔ lt_of_succ_lt_succ succ_lt_succ
 
 lemma succ_strict_mono : strict_mono (succ : α → α) := λ a b, succ_lt_succ
 
-lemma covers_succ (a : α) : a ⋖ succ a := ⟨lt_succ a, λ c hc, (succ_le_of_lt hc).not_lt⟩
+lemma covby_succ (a : α) : a ⋖ succ a := ⟨lt_succ a, λ c hc, (succ_le_of_lt hc).not_lt⟩
 
 end no_max_order
 
@@ -172,7 +172,7 @@ begin
   { exact ⟨le_succ a, le_rfl⟩ }
 end
 
-lemma _root_.covers.succ_eq {a b : α} (h : a ⋖ b) : succ a = b :=
+lemma _root_.covby.succ_eq {a b : α} (h : a ⋖ b) : succ a = b :=
 (succ_le_of_lt h.lt).eq_of_not_lt $ λ h', h.2 (lt_succ_of_not_maximal h.lt) h'
 
 section no_max_order
@@ -199,8 +199,8 @@ lt_succ_iff.trans le_iff_lt_or_eq
 lemma le_succ_iff_lt_or_eq : a ≤ succ b ↔ (a ≤ b ∨ a = succ b) :=
 by rw [←lt_succ_iff, ←lt_succ_iff, lt_succ_iff_lt_or_eq]
 
-lemma _root_.covers_iff_succ_eq : a ⋖ b ↔ succ a = b :=
-⟨covers.succ_eq, by { rintro rfl, exact covers_succ _ }⟩
+lemma _root_.covby_iff_succ_eq : a ⋖ b ↔ succ a = b :=
+⟨covby.succ_eq, by { rintro rfl, exact covby_succ _ }⟩
 
 end no_max_order
 
@@ -317,11 +317,11 @@ lemma pred_lt_of_not_minimal {a b : α} (h : b < a) : pred a < a :=
 
 alias pred_lt_of_not_minimal ← has_lt.lt.pred_lt
 
-protected lemma _root_.has_lt.lt.pred_covers {a b : α} (h : b < a) : pred a ⋖ a :=
+protected lemma _root_.has_lt.lt.pred_covby {a b : α} (h : b < a) : pred a ⋖ a :=
 ⟨h.pred_lt, λ c hc, (le_of_pred_lt hc).not_lt⟩
 
-@[simp] lemma pred_covers_of_nonempty_Iio {a : α} (h : (set.Iio a).nonempty) : pred a ⋖ a :=
-has_lt.lt.pred_covers h.some_mem
+@[simp] lemma pred_covby_of_nonempty_Iio {a : α} (h : (set.Iio a).nonempty) : pred a ⋖ a :=
+has_lt.lt.pred_covby h.some_mem
 
 section no_min_order
 variables [no_min_order α] {a b : α}
@@ -347,7 +347,7 @@ alias pred_lt_pred_iff ↔ lt_of_pred_lt_pred pred_lt_pred
 
 lemma pred_strict_mono : strict_mono (pred : α → α) := λ a b, pred_lt_pred
 
-lemma pred_covers (a : α) : pred a ⋖ a := ⟨pred_lt a, λ c hc, (le_of_pred_lt hc).not_lt⟩
+lemma pred_covby (a : α) : pred a ⋖ a := ⟨pred_lt a, λ c hc, (le_of_pred_lt hc).not_lt⟩
 
 end no_min_order
 
@@ -384,7 +384,7 @@ begin
   { exact ⟨le_rfl, pred_le a⟩ }
 end
 
-lemma _root_.covers.pred_eq {a b : α} (h : a ⋖ b) : pred b = a :=
+lemma _root_.covby.pred_eq {a b : α} (h : a ⋖ b) : pred b = a :=
 (le_pred_of_lt h.lt).eq_of_not_gt $ λ h', h.2 h' $ pred_lt_of_not_minimal h.lt
 
 section no_min_order
@@ -409,8 +409,8 @@ pred_lt_iff.trans le_iff_lt_or_eq
 lemma le_pred_iff_lt_or_eq : pred a ≤ b ↔ (a ≤ b ∨ pred a = b) :=
 by rw [←pred_lt_iff, ←pred_lt_iff, pred_lt_iff_lt_or_eq]
 
-lemma _root_.covers_iff_pred_eq : a ⋖ b ↔ pred b = a :=
-⟨covers.pred_eq, by { rintro rfl, exact pred_covers _ }⟩
+lemma _root_.covby_iff_pred_eq : a ⋖ b ↔ pred b = a :=
+⟨covby.pred_eq, by { rintro rfl, exact pred_covby _ }⟩
 
 end no_min_order
 
@@ -486,8 +486,8 @@ open succ_order pred_order
 section succ_pred_order
 variables [partial_order α] [succ_order α] [pred_order α] {a b : α}
 
-protected lemma _root_.has_lt.lt.succ_pred (h : b < a) : succ (pred a) = a := h.pred_covers.succ_eq
-protected lemma _root_.has_lt.lt.pred_succ (h : a < b) : pred (succ a) = a := h.covers_succ.pred_eq
+protected lemma _root_.has_lt.lt.succ_pred (h : b < a) : succ (pred a) = a := h.pred_covby.succ_eq
+protected lemma _root_.has_lt.lt.pred_succ (h : a < b) : pred (succ a) = a := h.covby_succ.pred_eq
 
 @[simp] lemma succ_pred_of_nonempty_Iio {a : α} (h : (set.Iio a).nonempty) : succ (pred a) = a :=
 has_lt.lt.succ_pred h.some_mem
@@ -495,8 +495,8 @@ has_lt.lt.succ_pred h.some_mem
 @[simp] lemma pred_succ_of_nonempty_Ioi {a : α} (h : (set.Ioi a).nonempty) : pred (succ a) = a :=
 has_lt.lt.pred_succ h.some_mem
 
-@[simp] lemma succ_pred [no_min_order α] (a : α) : succ (pred a) = a := (pred_covers _).succ_eq
-@[simp] lemma pred_succ [no_max_order α] (a : α) : pred (succ a) = a := (covers_succ _).pred_eq
+@[simp] lemma succ_pred [no_min_order α] (a : α) : succ (pred a) = a := (pred_covby _).succ_eq
+@[simp] lemma pred_succ [no_max_order α] (a : α) : pred (succ a) = a := (covby_succ _).pred_eq
 
 end succ_pred_order
 


### PR DESCRIPTION
This matches the way it is written. `a ⋖ b` means that `b` covers `a`, that is `a` is covered by `b`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
