### PR TITLE
[Merged by Bors] - feal(category_theory/bicategory/functor): define pseudofunctors

### DIFF
--- a/src/category_theory/bicategory/functor.lean
+++ b/src/category_theory/bicategory/functor.lean
@@ -237,7 +237,7 @@ def comp (F : oplax_functor B C) (G : oplax_functor C D) : oplax_functor B D :=
   .. (F : prelax_functor B C).comp ↑G }
 
 /--
-A structure on an oplax functor that promotes an oplax functors to a pseudofunctor.
+A structure on an oplax functor that promotes an oplax functor to a pseudofunctor.
 See `pseudofunctor.mk_of_oplax`.
 -/
 @[nolint has_inhabited_instance]

--- a/src/category_theory/bicategory/functor.lean
+++ b/src/category_theory/bicategory/functor.lean
@@ -23,7 +23,7 @@ The former uses `iso` for the same type, and the latter uses` is_iso` for the sa
   `map₂_whisker_right` instead of naturality of `map_comp`.
 * `pseudofunctor.mk_of_oplax` : construct a pseudofunctor from an oplax functor whose
   `map_id` and `map_comp` are isomorphisms. This constructor uses `iso` to describe isomorphisms.
-* `pseudofunctor.mk_of_oplax'` : similar to `mk_of_oplax`, but uses` is_iso` to describe
+* `pseudofunctor.mk_of_oplax'` : similar to `mk_of_oplax`, but uses `is_iso` to describe
   isomorphisms.
 
 ## Main definitions
@@ -347,10 +347,10 @@ open iso
 /-- The prelax functor between the underlying quivers. -/
 add_decl_doc pseudofunctor.to_prelax_functor
 
-instance has_coe_to_prelax : has_coe (pseudofunctor B C) (prelax_functor B C) :=
+instance has_coe_to_prelax_functor : has_coe (pseudofunctor B C) (prelax_functor B C) :=
 ⟨to_prelax_functor⟩
 
-@[simp] lemma to_prelax_eq_coe : F.to_prelax_functor = F := rfl
+@[simp] lemma to_prelax_functor_eq_coe : F.to_prelax_functor = F := rfl
 @[simp] lemma to_prelax_functor_obj : (F : prelax_functor B C).obj = F.obj := rfl
 @[simp] lemma to_prelax_functor_map : (F : prelax_functor B C).map = F.map := rfl
 @[simp] lemma to_prelax_functor_map₂ : (F : prelax_functor B C).map₂ = F.map₂ := rfl

--- a/src/category_theory/bicategory/functor.lean
+++ b/src/category_theory/bicategory/functor.lean
@@ -220,7 +220,7 @@ def comp (F : oplax_functor B C) (G : oplax_functor C D) : oplax_functor B D :=
   .. (F : prelax_functor B C).comp ↑G }
 
 /--
-A structure on an oplax functor that promotes an oprax functors to a pseudofunctor.
+A structure on an oplax functor that promotes an oplax functors to a pseudofunctor.
 See `pseudofunctor.mk_of_oplax`.
 -/
 @[nolint has_inhabited_instance]

--- a/src/category_theory/bicategory/functor.lean
+++ b/src/category_theory/bicategory/functor.lean
@@ -49,14 +49,17 @@ open_locale bicategory
 universes w₁ w₂ w₃ v₁ v₂ v₃ u₁ u₂ u₃
 
 section
-variables (B : Type u₁) [quiver.{v₁+1} B] [∀ a b : B, quiver.{w₁+1} (a ⟶ b)]
-variables (C : Type u₂) [quiver.{v₂+1} C] [∀ a b : C, quiver.{w₂+1} (a ⟶ b)]
+variables {B : Type u₁} [quiver.{v₁+1} B] [∀ a b : B, quiver.{w₁+1} (a ⟶ b)]
+variables {C : Type u₂} [quiver.{v₂+1} C] [∀ a b : C, quiver.{w₂+1} (a ⟶ b)]
+variables {D : Type u₃} [quiver.{v₃+1} D] [∀ a b : D, quiver.{w₃+1} (a ⟶ b)]
 
 /--
 A prelax functor between bicategories consists of functions between objects,
 1-morphisms, and 2-morphisms. This structure will be extended to define `oplax_functor`.
 -/
-structure prelax_functor extends prefunctor B C :=
+structure prelax_functor
+  (B : Type u₁) [quiver.{v₁+1} B] [∀ a b : B, quiver.{w₁+1} (a ⟶ b)]
+  (C : Type u₂) [quiver.{v₂+1} C] [∀ a b : C, quiver.{w₂+1} (a ⟶ b)] extends prefunctor B C :=
 (map₂ {a b : B} {f g : a ⟶ b} : (f ⟶ g) → (map f ⟶ map g))
 
 /-- The prefunctor between the underlying quivers. -/
@@ -64,29 +67,24 @@ add_decl_doc prelax_functor.to_prefunctor
 
 namespace prelax_functor
 
-variables {B C} {D : Type u₃} [quiver.{v₃+1} D] [∀ a b : D, quiver.{w₃+1} (a ⟶ b)]
-variables (F : prelax_functor B C) (G : prelax_functor C D)
-
 instance has_coe_to_prefunctor : has_coe (prelax_functor B C) (prefunctor B C) := ⟨to_prefunctor⟩
+
+variables (F : prelax_functor B C)
 
 @[simp] lemma to_prefunctor_eq_coe : F.to_prefunctor = F := rfl
 @[simp] lemma to_prefunctor_obj : (F : prefunctor B C).obj = F.obj := rfl
 @[simp] lemma to_prefunctor_map : (F : prefunctor B C).map = F.map := rfl
 
-variables (B)
-
 /-- The identity prelax functor. -/
 @[simps]
-def id : prelax_functor B B :=
+def id (B : Type u₁) [quiver.{v₁+1} B] [∀ a b : B, quiver.{w₁+1} (a ⟶ b)] : prelax_functor B B :=
 { map₂ := λ a b f g η, η, .. prefunctor.id B }
 
 instance : inhabited (prelax_functor B B) := ⟨prelax_functor.id B⟩
 
-variables {B}
-
 /-- Composition of prelax functors. -/
 @[simps]
-def comp : prelax_functor B D :=
+def comp (F : prelax_functor B C) (G : prelax_functor C D) : prelax_functor B D :=
 { map₂ := λ a b f g η, G.map₂ (F.map₂ η), .. (F : prefunctor B C).comp ↑G }
 
 end prelax_functor
@@ -114,8 +112,6 @@ def oplax_functor.map₂_associator_aux
 map₂ (α_ f g h).hom ≫ map_comp f (g ≫ h) ≫ (map f ◁ map_comp g h) =
   map_comp (f ≫ g) h ≫ (map_comp f g ▷ map h) ≫ (α_ (map f) (map g) (map h)).hom
 
-variables (B C)
-
 /--
 An oplax functor `F` between bicategories `B` and `C` consists of functions between objects,
 1-morphisms, and 2-morphisms.
@@ -128,7 +124,8 @@ Functions between 2-morphisms strictly commute with compositions and preserve th
 They also preserve the associator, the left unitor, and the right unitor modulo some adjustments
 of domains and codomains of 2-morphisms.
 -/
-structure oplax_functor extends prelax_functor B C :=
+structure oplax_functor (B : Type u₁) [bicategory.{w₁ v₁} B] (C : Type u₂) [bicategory.{w₂ v₂} C]
+  extends prelax_functor B C :=
 (map_id (a : B) : map (𝟙 a) ⟶ 𝟙 (obj a))
 (map_comp {a b c : B} (f : a ⟶ b) (g : b ⟶ c) : map (f ≫ g) ⟶ map f ≫ map g)
 (map_comp_naturality_left' : ∀ {a b c : B} {f f' : a ⟶ b} (η : f ⟶ f') (g : b ⟶ c),
@@ -146,8 +143,6 @@ structure oplax_functor extends prelax_functor B C :=
 (map₂_right_unitor' : ∀ {a b : B} (f : a ⟶ b),
   map₂ (ρ_ f).hom = map_comp f (𝟙 b) ≫ (map f ◁ map_id b) ≫ (ρ_ (map f)).hom . obviously)
 
-variables {B C}
-
 namespace oplax_functor
 
 restate_axiom map_comp_naturality_left'
@@ -164,13 +159,14 @@ attribute [reassoc]
 attribute [simp] map₂_comp map₂_left_unitor map₂_right_unitor
 
 section
-variables (F : oplax_functor B C) (G : oplax_functor C D)
 
 /-- The prelax functor between the underlying quivers. -/
 add_decl_doc oplax_functor.to_prelax_functor
 
 instance has_coe_to_prelax : has_coe (oplax_functor B C) (prelax_functor B C) :=
 ⟨to_prelax_functor⟩
+
+variables (F : oplax_functor B C)
 
 @[simp] lemma to_prelax_eq_coe : F.to_prelax_functor = F := rfl
 @[simp] lemma to_prelax_functor_obj : (F : prelax_functor B C).obj = F.obj := rfl
@@ -183,22 +179,18 @@ def map_functor (a b : B) : (a ⟶ b) ⥤ (F.obj a ⟶ F.obj b) :=
 { obj := λ f, F.map f,
   map := λ f g η, F.map₂ η }
 
-variables (B)
-
 /-- The identity oplax functor. -/
 @[simps]
-def id : oplax_functor B B :=
+def id (B : Type u₁) [bicategory.{w₁ v₁} B] : oplax_functor B B :=
 { map_id := λ a, 𝟙 (𝟙 a),
   map_comp := λ a b c f g, 𝟙 (f ≫ g),
   .. prelax_functor.id B }
 
 instance : inhabited (oplax_functor B B) := ⟨id B⟩
 
-variables {B}
-
 /-- Composition of oplax functors. -/
 @[simps]
-def comp : oplax_functor B D :=
+def comp (F : oplax_functor B C) (G : oplax_functor C D) : oplax_functor B D :=
 { map_id := λ a,
     (G.map_functor _ _).map (F.map_id a) ≫ G.map_id (F.obj a),
   map_comp := λ a b c f g,
@@ -232,7 +224,7 @@ A structure on an oplax functor that promotes an oprax functors to a pseudofunct
 See `pseudofunctor.mk_of_oplax`.
 -/
 @[nolint has_inhabited_instance]
-structure pseudo_core :=
+structure pseudo_core (F : oplax_functor B C) :=
 (map_id_iso (a : B) : F.map (𝟙 a) ≅ 𝟙 (F.obj a))
 (map_comp_iso {a b c : B} (f : a ⟶ b) (g : b ⟶ c) : F.map (f ≫ g) ≅ F.map f ≫ F.map g)
 (map_id_iso_hom' : ∀ {a : B}, (map_id_iso a).hom = F.map_id a . obviously)
@@ -263,8 +255,6 @@ def pseudofunctor.map₂_associator_aux
 map₂ (α_ f g h).hom = (map_comp (f ≫ g) h).hom ≫ ((map_comp f g).hom ▷ map h) ≫
   (α_ (map f) (map g) (map h)).hom ≫ (map f ◁ (map_comp g h).inv) ≫ (map_comp f (g ≫ h)).inv
 
-variables (B C)
-
 /--
 A pseudofunctors `F` between bicategories `B` and `C` consists of functions between objects,
 1-morphisms, and 2-morphisms.
@@ -277,7 +267,8 @@ Functions between 2-morphisms strictly commute with compositions and preserve th
 They also preserve the associator, the left unitor, and the right unitor modulo some adjustments
 of domains and codomains of 2-morphisms.
 -/
-structure pseudofunctor extends prelax_functor B C :=
+structure pseudofunctor (B : Type u₁) [bicategory.{w₁ v₁} B] (C : Type u₂) [bicategory.{w₂ v₂} C]
+  extends prelax_functor B C :=
 (map_id (a : B) : map (𝟙 a) ≅ 𝟙 (obj a))
 (map_comp {a b c : B} (f : a ⟶ b) (g : b ⟶ c) : map (f ≫ g) ≅ map f ≫ map g)
 (map₂_id' : ∀ {a b : B} (f : a ⟶ b), map₂ (𝟙 f) = 𝟙 (map f) . obviously)
@@ -297,8 +288,6 @@ structure pseudofunctor extends prelax_functor B C :=
   map₂ (ρ_ f).hom = (map_comp f (𝟙 b)).hom ≫ (map f ◁ (map_id b).hom) ≫ (ρ_ (map f)).hom
     . obviously)
 
-variables {B C}
-
 namespace pseudofunctor
 
 restate_axiom map₂_id'
@@ -315,8 +304,6 @@ attribute [simp]
   map₂_associator map₂_left_unitor map₂_right_unitor
 
 section
-variables (F : pseudofunctor B C) (G : pseudofunctor C D)
-
 open iso
 
 /-- The prelax functor between the underlying quivers. -/
@@ -324,6 +311,8 @@ add_decl_doc pseudofunctor.to_prelax_functor
 
 instance has_coe_to_prelax_functor : has_coe (pseudofunctor B C) (prelax_functor B C) :=
 ⟨to_prelax_functor⟩
+
+variables (F : pseudofunctor B C)
 
 @[simp] lemma to_prelax_functor_eq_coe : F.to_prelax_functor = F := rfl
 @[simp] lemma to_prelax_functor_obj : (F : prelax_functor B C).obj = F.obj := rfl
@@ -351,22 +340,18 @@ instance has_coe_to_oplax : has_coe (pseudofunctor B C) (oplax_functor B C) := �
 def map_functor (a b : B) : (a ⟶ b) ⥤ (F.obj a ⟶ F.obj b) :=
 (F : oplax_functor B C).map_functor a b
 
-variables (B)
-
 /-- The identity pseudofunctor. -/
 @[simps]
-def id : pseudofunctor B B :=
+def id (B : Type u₁) [bicategory.{w₁ v₁} B] : pseudofunctor B B :=
 { map_id := λ a, iso.refl (𝟙 a),
   map_comp := λ a b c f g, iso.refl (f ≫ g),
   .. prelax_functor.id B }
 
 instance : inhabited (pseudofunctor B B) := ⟨id B⟩
 
-variables {B}
-
 /-- Composition of pseudofunctors. -/
 @[simps]
-def comp : pseudofunctor B D :=
+def comp (F : pseudofunctor B C) (G : pseudofunctor C D) : pseudofunctor B D :=
 { map_id := λ a, (G.map_functor _ _).map_iso (F.map_id a) ≪≫ G.map_id (F.obj a),
   map_comp := λ a b c f g,
     (G.map_functor _ _).map_iso (F.map_comp f g) ≪≫ G.map_comp (F.map f) (F.map g),
@@ -399,7 +384,7 @@ Construct a pseudofunctor from an oplax functor whose `map_id` and `map_comp` ar
 -/
 @[simps]
 noncomputable
-def mk_of_oplax' {F : oplax_functor B C}
+def mk_of_oplax' (F : oplax_functor B C)
   [∀ a, is_iso (F.map_id a)] [∀ {a b c} (f : a ⟶ b) (g : b ⟶ c), is_iso (F.map_comp f g)] :
   pseudofunctor B C :=
 { map_id := λ a, as_iso (F.map_id a),

--- a/src/category_theory/bicategory/functor.lean
+++ b/src/category_theory/bicategory/functor.lean
@@ -67,13 +67,10 @@ add_decl_doc prelax_functor.to_prefunctor
 
 namespace prelax_functor
 
-instance has_coe_to_prefunctor : has_coe (prelax_functor B C) (prefunctor B C) := ⟨to_prefunctor⟩
-
 variables (F : prelax_functor B C)
 
-@[simp] lemma to_prefunctor_eq_coe : F.to_prefunctor = F := rfl
-@[simp] lemma to_prefunctor_obj : (F : prefunctor B C).obj = F.obj := rfl
-@[simp] lemma to_prefunctor_map : (F : prefunctor B C).map = F.map := rfl
+@[simp] lemma to_prefunctor_obj : F.to_prefunctor.obj = F.obj := rfl
+@[simp] lemma to_prefunctor_map : F.to_prefunctor.map = F.map := rfl
 
 /-- The identity prelax functor. -/
 @[simps]
@@ -85,7 +82,7 @@ instance : inhabited (prelax_functor B B) := ⟨prelax_functor.id B⟩
 /-- Composition of prelax functors. -/
 @[simps]
 def comp (F : prelax_functor B C) (G : prelax_functor C D) : prelax_functor B D :=
-{ map₂ := λ a b f g η, G.map₂ (F.map₂ η), .. (F : prefunctor B C).comp ↑G }
+{ map₂ := λ a b f g η, G.map₂ (F.map₂ η), .. F.to_prefunctor.comp G.to_prefunctor }
 
 end prelax_functor
 
@@ -163,15 +160,11 @@ section
 /-- The prelax functor between the underlying quivers. -/
 add_decl_doc oplax_functor.to_prelax_functor
 
-instance has_coe_to_prelax : has_coe (oplax_functor B C) (prelax_functor B C) :=
-⟨to_prelax_functor⟩
-
 variables (F : oplax_functor B C)
 
-@[simp] lemma to_prelax_eq_coe : F.to_prelax_functor = F := rfl
-@[simp] lemma to_prelax_functor_obj : (F : prelax_functor B C).obj = F.obj := rfl
-@[simp] lemma to_prelax_functor_map : (F : prelax_functor B C).map = F.map := rfl
-@[simp] lemma to_prelax_functor_map₂ : (F : prelax_functor B C).map₂ = F.map₂ := rfl
+@[simp] lemma to_prelax_functor_obj : F.to_prelax_functor.obj = F.obj := rfl
+@[simp] lemma to_prelax_functor_map : F.to_prelax_functor.map = F.map := rfl
+@[simp] lemma to_prelax_functor_map₂ : F.to_prelax_functor.map₂ = F.map₂ := rfl
 
 /-- Function between 1-morphisms as a functor. -/
 @[simps]
@@ -217,7 +210,7 @@ def comp (F : oplax_functor B C) (G : oplax_functor C D) : oplax_functor B D :=
   { dsimp,
     simp only [map₂_right_unitor, map₂_comp, map_comp_naturality_right_assoc,
       whisker_left_comp, assoc] },
-  .. (F : prelax_functor B C).comp ↑G }
+  .. F.to_prelax_functor.comp G.to_prelax_functor }
 
 /--
 A structure on an oplax functor that promotes an oplax functors to a pseudofunctor.
@@ -310,36 +303,29 @@ open iso
 /-- The prelax functor between the underlying quivers. -/
 add_decl_doc pseudofunctor.to_prelax_functor
 
-instance has_coe_to_prelax_functor : has_coe (pseudofunctor B C) (prelax_functor B C) :=
-⟨to_prelax_functor⟩
-
 variables (F : pseudofunctor B C)
 
-@[simp] lemma to_prelax_functor_eq_coe : F.to_prelax_functor = F := rfl
-@[simp] lemma to_prelax_functor_obj : (F : prelax_functor B C).obj = F.obj := rfl
-@[simp] lemma to_prelax_functor_map : (F : prelax_functor B C).map = F.map := rfl
-@[simp] lemma to_prelax_functor_map₂ : (F : prelax_functor B C).map₂ = F.map₂ := rfl
+@[simp] lemma to_prelax_functor_obj : F.to_prelax_functor.obj = F.obj := rfl
+@[simp] lemma to_prelax_functor_map : F.to_prelax_functor.map = F.map := rfl
+@[simp] lemma to_prelax_functor_map₂ : F.to_prelax_functor.map₂ = F.map₂ := rfl
 
 /-- The oplax functor associated with a pseudofunctor. -/
 def to_oplax : oplax_functor B C :=
 { map_id := λ a, (F.map_id a).hom,
   map_comp := λ a b c f g, (F.map_comp f g).hom,
-  .. (F : prelax_functor B C) }
+  .. F.to_prelax_functor }
 
-instance has_coe_to_oplax : has_coe (pseudofunctor B C) (oplax_functor B C) := ⟨to_oplax⟩
-
-@[simp] lemma to_oplax_eq_coe : F.to_oplax = F := rfl
-@[simp] lemma to_oplax_obj : (F : oplax_functor B C).obj = F.obj := rfl
-@[simp] lemma to_oplax_map : (F : oplax_functor B C).map = F.map := rfl
-@[simp] lemma to_oplax_map₂ : (F : oplax_functor B C).map₂ = F.map₂ := rfl
-@[simp] lemma to_oplax_map_id (a : B) : (F : oplax_functor B C).map_id a = (F.map_id a).hom := rfl
+@[simp] lemma to_oplax_obj : F.to_oplax.obj = F.obj := rfl
+@[simp] lemma to_oplax_map : F.to_oplax.map = F.map := rfl
+@[simp] lemma to_oplax_map₂ : F.to_oplax.map₂ = F.map₂ := rfl
+@[simp] lemma to_oplax_map_id (a : B) : F.to_oplax.map_id a = (F.map_id a).hom := rfl
 @[simp] lemma to_oplax_map_comp {a b c : B} (f : a ⟶ b) (g : b ⟶ c) :
-  (F : oplax_functor B C).map_comp f g = (F.map_comp f g).hom := rfl
+  F.to_oplax.map_comp f g = (F.map_comp f g).hom := rfl
 
 /-- Function on 1-morphisms as a functor. -/
 @[simps]
 def map_functor (a b : B) : (a ⟶ b) ⥤ (F.obj a ⟶ F.obj b) :=
-(F : oplax_functor B C).map_functor a b
+F.to_oplax.map_functor a b
 
 /-- The identity pseudofunctor. -/
 @[simps]
@@ -356,7 +342,7 @@ def comp (F : pseudofunctor B C) (G : pseudofunctor C D) : pseudofunctor B D :=
 { map_id := λ a, (G.map_functor _ _).map_iso (F.map_id a) ≪≫ G.map_id (F.obj a),
   map_comp := λ a b c f g,
     (G.map_functor _ _).map_iso (F.map_comp f g) ≪≫ G.map_comp (F.map f) (F.map g),
-  .. (F : prelax_functor B C).comp ↑G }
+  .. F.to_prelax_functor.comp G.to_prelax_functor }
 
 /--
 Construct a pseudofunctor from an oplax functor whose `map_id` and `map_comp` are isomorphisms.
@@ -378,7 +364,7 @@ def mk_of_oplax (F : oplax_functor B C) (F' : F.pseudo_core) : pseudofunctor B C
     rw [F'.map_comp_iso_hom (f ≫ g) h, F'.map_comp_iso_hom f g, ←F.map₂_associator_assoc,
       ←F'.map_comp_iso_hom f (g ≫ h), ←F'.map_comp_iso_hom g h,
       hom_inv_whisker_left_assoc, hom_inv_id, comp_id] },
-  .. (F : prelax_functor B C) }
+  .. F.to_prelax_functor }
 
 /--
 Construct a pseudofunctor from an oplax functor whose `map_id` and `map_comp` are isomorphisms.
@@ -401,7 +387,7 @@ def mk_of_oplax' (F : oplax_functor B C)
     simp only [←assoc],
     rw [is_iso.eq_comp_inv, ←inv_whisker_left, is_iso.eq_comp_inv],
     simp only [assoc, F.map₂_associator] },
-  .. (F : prelax_functor B C) }
+  .. F.to_prelax_functor }
 
 end
 

--- a/src/category_theory/bicategory/functor.lean
+++ b/src/category_theory/bicategory/functor.lean
@@ -44,10 +44,10 @@ to forget the definitions of the inverses. On the other hand, the latter constru
 
 ## Main definitions
 
-* `oplax_functor B C` : an oplax functor between bicategories `B` and `C`
-* `oplax_functor.comp F G` : the composition of oplax functors
-* `pseudofunctor B C` : a pseudofunctor between bicategories `B` and `C`
-* `pseudofunctor.comp F G` : the composition of pseudofunctors
+* `category_theory.oplax_functor B C` : an oplax functor between bicategories `B` and `C`
+* `category_theory.oplax_functor.comp F G` : the composition of oplax functors
+* `category_theory.pseudofunctor B C` : a pseudofunctor between bicategories `B` and `C`
+* `category_theory.pseudofunctor.comp F G` : the composition of pseudofunctors
 
 ## Future work
 

--- a/src/category_theory/bicategory/functor.lean
+++ b/src/category_theory/bicategory/functor.lean
@@ -240,11 +240,12 @@ end
 end oplax_functor
 
 /--
-The auxiliary definition that claims that pseudofunctors preserve the associators
-modulo some adjustments of domains and codomains of 2-morphisms. -/
+This auxiliary definition states that pseudofunctors preserve the associators
+modulo some adjustments of domains and codomains of 2-morphisms.
+-/
 /-
-The reason for using this auxiliary definition instead of writing it directly in the definition
-of pseudofunctors is that doing so will cause a timeout.
+We use this auxiliary definition instead of writing it directly in the definition
+of pseudofunctors because doing so will cause a timeout.
 -/
 @[simp]
 def pseudofunctor.map₂_associator_aux

--- a/src/category_theory/bicategory/functor.lean
+++ b/src/category_theory/bicategory/functor.lean
@@ -239,19 +239,6 @@ restate_axiom pseudo_core.map_id_iso_hom'
 restate_axiom pseudo_core.map_comp_iso_hom'
 attribute [simp] pseudo_core.map_id_iso_hom pseudo_core.map_comp_iso_hom
 
-/--
-A predicate on an oplax functor that promotes an oprax functors to a pseudofunctor.
-See `pseudofunctor.mk_of_oplax'`.
--/
-class is_pseudo : Prop :=
-(map_id_is_iso' : ∀ (a : B), is_iso (F.map_id a) . tactic.apply_instance)
-(map_comp_is_iso' : ∀ {a b c : B} (f : a ⟶ b) (g : b ⟶ c),
-  is_iso (F.map_comp f g) . tactic.apply_instance)
-
-restate_axiom is_pseudo.map_id_is_iso'
-restate_axiom is_pseudo.map_comp_is_iso'
-attribute [instance] is_pseudo.map_id_is_iso is_pseudo.map_comp_is_iso
-
 end
 
 end oplax_functor
@@ -408,7 +395,9 @@ def mk_of_oplax {F : oplax_functor B C} (F' : oplax_functor.pseudo_core F) : pse
 Construct a pseudofunctor from an oplax functor whose `map_id` and `map_comp` are isomorphisms.
 -/
 noncomputable
-def mk_of_oplax' {F : oplax_functor B C} [oplax_functor.is_pseudo F] : pseudofunctor B C :=
+def mk_of_oplax' {F : oplax_functor B C}
+  [∀ a, is_iso (F.map_id a)] [∀ {a b c} (f : a ⟶ b) (g : b ⟶ c), is_iso (F.map_comp f g)] :
+  pseudofunctor B C :=
 { map_id := λ a, as_iso (F.map_id a),
   map_comp := λ a b c f g, as_iso (F.map_comp f g),
   map₂_whisker_right' := λ a b c f g η h, by

--- a/src/category_theory/bicategory/functor.lean
+++ b/src/category_theory/bicategory/functor.lean
@@ -162,12 +162,6 @@ namespace oplax_functor
 section
 variables (F : oplax_functor B C) (G : oplax_functor C D)
 
-/-- Function between 1-morphisms as a functor. -/
-@[simps]
-def map_functor (a b : B) : (a ⟶ b) ⥤ (F.obj a ⟶ F.obj b) :=
-{ obj := λ f, F.map f,
-  map := λ f g η, F.map₂ η }
-
 /-- The prelax functor between the underlying quivers. -/
 add_decl_doc oplax_functor.to_prelax_functor
 
@@ -178,6 +172,12 @@ instance has_coe_to_prelax : has_coe (oplax_functor B C) (prelax_functor B C) :=
 @[simp] lemma to_prelax_functor_obj : (F : prelax_functor B C).obj = F.obj := rfl
 @[simp] lemma to_prelax_functor_map : (F : prelax_functor B C).map = F.map := rfl
 @[simp] lemma to_prelax_functor_map₂ : (F : prelax_functor B C).map₂ = F.map₂ := rfl
+
+/-- Function between 1-morphisms as a functor. -/
+@[simps]
+def map_functor (a b : B) : (a ⟶ b) ⥤ (F.obj a ⟶ F.obj b) :=
+{ obj := λ f, F.map f,
+  map := λ f g η, F.map₂ η }
 
 variables (B)
 
@@ -223,7 +223,12 @@ def comp : oplax_functor B D :=
       whisker_left_comp, assoc] },
   .. (F : prelax_functor B C).comp ↑G }
 
-structure pseudo_core (F : oplax_functor B C) :=
+/--
+A structure on an oplax functor that promotes an oprax functors to a pseudofunctor.
+See `pseudofunctor.mk_of_oplax`.
+-/
+@[nolint has_inhabited_instance]
+structure pseudo_core :=
 (map_id_iso (a : B) : F.map (𝟙 a) ≅ 𝟙 (F.obj a))
 (map_comp_iso {a b c : B} (f : a ⟶ b) (g : b ⟶ c) : F.map (f ≫ g) ≅ F.map f ≫ F.map g)
 (map_id_iso_hom' : ∀ {a : B}, (map_id_iso a).hom = F.map_id a . obviously)
@@ -234,6 +239,10 @@ restate_axiom pseudo_core.map_id_iso_hom'
 restate_axiom pseudo_core.map_comp_iso_hom'
 attribute [simp] pseudo_core.map_id_iso_hom pseudo_core.map_comp_iso_hom
 
+/--
+A predicate on an oplax functor that promotes an oprax functors to a pseudofunctor.
+See `pseudofunctor.mk_of_oplax'`.
+-/
 class is_pseudo : Prop :=
 (map_id_is_iso' : ∀ (a : B), is_iso (F.map_id a) . tactic.apply_instance)
 (map_comp_is_iso' : ∀ {a b c : B} (f : a ⟶ b) (g : b ⟶ c),
@@ -304,15 +313,14 @@ restate_axiom pseudofunctor.map₂_comp'
 restate_axiom pseudofunctor.map₂_associator'
 restate_axiom pseudofunctor.map₂_left_unitor'
 restate_axiom pseudofunctor.map₂_right_unitor'
-attribute [simp]
-  pseudofunctor.map₂_whisker_right pseudofunctor.map₂_whisker_left
-  pseudofunctor.map₂_id pseudofunctor.map₂_associator
 attribute [reassoc]
   pseudofunctor.map₂_whisker_right pseudofunctor.map₂_whisker_left
   pseudofunctor.map₂_comp pseudofunctor.map₂_associator
   pseudofunctor.map₂_left_unitor pseudofunctor.map₂_right_unitor
 attribute [simp]
-  pseudofunctor.map₂_comp pseudofunctor.map₂_left_unitor pseudofunctor.map₂_right_unitor
+  pseudofunctor.map₂_whisker_right pseudofunctor.map₂_whisker_left
+  pseudofunctor.map₂_id pseudofunctor.map₂_associator pseudofunctor.map₂_comp
+  pseudofunctor.map₂_left_unitor pseudofunctor.map₂_right_unitor
 
 variables {B C}
 
@@ -321,12 +329,6 @@ namespace pseudofunctor
 section
 open iso
 variables (F : pseudofunctor B C) (G : pseudofunctor C D)
-
-/-- Function on 1-morphisms as a functor. -/
-@[simps]
-def map_functor {a b : B} : (a ⟶ b) ⥤ (F.obj a ⟶ F.obj b) :=
-{ obj := λ f, F.map f,
-  map := λ f g η, F.map₂ η }
 
 /-- The prelax functor between the underlying quivers. -/
 add_decl_doc pseudofunctor.to_prelax_functor
@@ -354,6 +356,11 @@ instance has_coe_to_oplax : has_coe (pseudofunctor B C) (oplax_functor B C) := �
 @[simp] lemma to_oplax_map_id (a : B) : (F : oplax_functor B C).map_id a = (F.map_id a).hom := rfl
 @[simp] lemma to_oplax_map_comp {a b c : B} (f : a ⟶ b) (g : b ⟶ c) :
   (F : oplax_functor B C).map_comp f g = (F.map_comp f g).hom := rfl
+
+/-- Function on 1-morphisms as a functor. -/
+@[simps]
+def map_functor {a b : B} : (a ⟶ b) ⥤ (F.obj a ⟶ F.obj b) :=
+(F : oplax_functor B C).map_functor a b
 
 variables (B)
 

--- a/src/category_theory/bicategory/functor.lean
+++ b/src/category_theory/bicategory/functor.lean
@@ -68,18 +68,25 @@ instance has_coe_to_prefunctor : has_coe (prelax_functor B C) (prefunctor B C) :
 variables (B)
 
 /-- The identity prelax functor. -/
-@[simps]
 def id : prelax_functor B B :=
 { map₂ := λ a b f g η, η, .. prefunctor.id B }
+
+@[simp] lemma id_obj (a : B) : (id B).obj a = a := rfl
+@[simp] lemma id_map {a b : B} (f : a ⟶ b) : (id B).map f = f := rfl
+@[simp] lemma id_map₂ {a b : B} {f g : a ⟶ b} (η : f ⟶ g) : (id B).map₂ η = η := rfl
 
 instance : inhabited (prelax_functor B B) := ⟨prelax_functor.id B⟩
 
 variables {B}
 
 /-- Composition of prelax functors. -/
-@[simps]
 def comp : prelax_functor B D :=
 { map₂ := λ a b f g η, G.map₂ (F.map₂ η), .. (F : prefunctor B C).comp ↑G }
+
+@[simp] lemma comp_obj (a : B) : (F.comp G).obj a = G.obj (F.obj a) := rfl
+@[simp] lemma comp_map {a b : B} (f : a ⟶ b) : (F.comp G).map f = G.map (F.map f) := rfl
+@[simp] lemma comp_map₂ {a b : B} {f g : a ⟶ b} (η : f ⟶ g) :
+  (F.comp G).map₂ η = G.map₂ (F.map₂ η) := rfl
 
 end prelax_functor
 
@@ -182,18 +189,23 @@ def map_functor (a b : B) : (a ⟶ b) ⥤ (F.obj a ⟶ F.obj b) :=
 variables (B)
 
 /-- The identity oplax functor. -/
-@[simps]
 def id : oplax_functor B B :=
 { map_id := λ a, 𝟙 (𝟙 a),
   map_comp := λ a b c f g, 𝟙 (f ≫ g),
   .. prelax_functor.id B }
+
+@[simp] lemma id_obj (a : B) : (id B).obj a = a := rfl
+@[simp] lemma id_map {a b : B} (f : a ⟶ b) : (id B).map f = f := rfl
+@[simp] lemma id_map₂ {a b : B} {f g : a ⟶ b} (η : f ⟶ g) : (id B).map₂ η = η := rfl
+@[simp] lemma id_map_id (a : B) : (id B).map_id a = 𝟙 (𝟙 a) := rfl
+@[simp] lemma id_map_comp {a b c : B} (f : a ⟶ b) (g : b ⟶ c) :
+  (id B).map_comp f g = 𝟙 (f ≫ g) := rfl
 
 instance : inhabited (oplax_functor B B) := ⟨id B⟩
 
 variables {B}
 
 /-- Composition of oplax functors. -/
-@[simps]
 def comp : oplax_functor B D :=
 { map_id := λ a,
     (G.map_functor _ _).map (F.map_id a) ≫ G.map_id (F.obj a),
@@ -222,6 +234,18 @@ def comp : oplax_functor B D :=
     simp only [map₂_right_unitor, map₂_comp, map_comp_naturality_right_assoc,
       whisker_left_comp, assoc] },
   .. (F : prelax_functor B C).comp ↑G }
+
+@[simp] lemma comp_obj (a : B) : (F.comp G).obj a = G.obj (F.obj a) := rfl
+@[simp] lemma comp_map {a b : B} (f : a ⟶ b) : (F.comp G).map f = G.map (F.map f) := rfl
+@[simp] lemma comp_map₂ {a b : B} {f g : a ⟶ b} (η : f ⟶ g) :
+  (F.comp G).map₂ η = G.map₂ (F.map₂ η) := rfl
+@[simp] lemma comp_map_id (a : B) :
+  (F.comp G).map_id a =
+    (G.map_functor (F.obj a) (F.obj a)).map (F.map_id a) ≫ G.map_id (F.obj a) := rfl
+@[simp] lemma comp_map_comp {a b c : B} (f : a ⟶ b) (g : b ⟶ c) :
+  (F.comp G).map_comp f g =
+    (G.map_functor (F.obj a) (F.obj c)).map (F.map_comp f g) ≫
+      G.map_comp (F.map f) (F.map g) := rfl
 
 /--
 A structure on an oplax functor that promotes an oprax functors to a pseudofunctor.
@@ -345,35 +369,56 @@ instance has_coe_to_oplax : has_coe (pseudofunctor B C) (oplax_functor B C) := �
   (F : oplax_functor B C).map_comp f g = (F.map_comp f g).hom := rfl
 
 /-- Function on 1-morphisms as a functor. -/
-@[simps]
-def map_functor {a b : B} : (a ⟶ b) ⥤ (F.obj a ⟶ F.obj b) :=
+def map_functor (a b : B) : (a ⟶ b) ⥤ (F.obj a ⟶ F.obj b) :=
 (F : oplax_functor B C).map_functor a b
+
+@[simp] lemma map_functor_obj {a b : B} (f : a ⟶ b) : (F.map_functor a b).obj f = F.map f := rfl
+@[simp] lemma map_functor_map {a b : B} {f g : a ⟶ b} (η : f ⟶ g) :
+  (F.map_functor a b).map η = F.map₂ η := rfl
 
 variables (B)
 
 /-- The identity pseudofunctor. -/
-@[simps]
 def id : pseudofunctor B B :=
 { map_id := λ a, iso.refl (𝟙 a),
   map_comp := λ a b c f g, iso.refl (f ≫ g),
   .. prelax_functor.id B }
+
+@[simp] lemma id_obj (a : B) : (id B).obj a = a := rfl
+@[simp] lemma id_map {a b : B} (f : a ⟶ b) : (id B).map f = f := rfl
+@[simp] lemma id_map₂ {a b : B} {f g : a ⟶ b} (η : f ⟶ g) : (id B).map₂ η = η := rfl
+@[simp] lemma id_map_id (a : B) : (id B).map_id a = iso.refl (𝟙 a) := rfl
+@[simp] lemma id_map_comp {a b c : B} (f : a ⟶ b) (g : b ⟶ c) :
+  (id B).map_comp f g = iso.refl (f ≫ g) := rfl
 
 instance : inhabited (pseudofunctor B B) := ⟨id B⟩
 
 variables {B}
 
 /-- Composition of pseudofunctors. -/
-@[simps]
 def comp : pseudofunctor B D :=
-{ map_id := λ a, G.map_functor.map_iso (F.map_id a) ≪≫ G.map_id (F.obj a),
+{ map_id := λ a, (G.map_functor _ _).map_iso (F.map_id a) ≪≫ G.map_id (F.obj a),
   map_comp := λ a b c f g,
-    G.map_functor.map_iso (F.map_comp f g) ≪≫ G.map_comp (F.map f) (F.map g),
+    (G.map_functor _ _).map_iso (F.map_comp f g) ≪≫ G.map_comp (F.map f) (F.map g),
   .. (F : prelax_functor B C).comp ↑G }
+
+@[simp] lemma comp_obj (a : B) : (F.comp G).obj a = G.obj (F.obj a) := rfl
+@[simp] lemma comp_map {a b : B} (f : a ⟶ b) : (F.comp G).map f = G.map (F.map f) := rfl
+@[simp] lemma comp_map₂ {a b : B} {f g : a ⟶ b} (η : f ⟶ g) :
+  (F.comp G).map₂ η = G.map₂ (F.map₂ η) := rfl
+@[simp] lemma comp_map_id (a : B) :
+  (F.comp G).map_id a =
+    (G.map_functor (F.obj a) (F.obj a)).map_iso (F.map_id a) ≪≫ G.map_id (F.obj a) := rfl
+@[simp] lemma comp_map_comp {a b c : B} (f : a ⟶ b) (g : b ⟶ c) :
+  (F.comp G).map_comp f g =
+    (G.map_functor (F.obj a) (F.obj c)).map_iso (F.map_comp f g) ≪≫
+      G.map_comp (F.map f) (F.map g) := rfl
 
 /--
 Construct a pseudofunctor from an oplax functor whose `map_id` and `map_comp` are isomorphisms.
 -/
-def mk_of_oplax {F : oplax_functor B C} (F' : oplax_functor.pseudo_core F) : pseudofunctor B C :=
+@[simps]
+def mk_of_oplax (F : oplax_functor B C) (F' : F.pseudo_core) : pseudofunctor B C :=
 { map_id := F'.map_id_iso,
   map_comp := F'.map_comp_iso,
   map₂_whisker_right' := λ a b c f g η h, by
@@ -394,6 +439,7 @@ def mk_of_oplax {F : oplax_functor B C} (F' : oplax_functor.pseudo_core F) : pse
 /--
 Construct a pseudofunctor from an oplax functor whose `map_id` and `map_comp` are isomorphisms.
 -/
+@[simps]
 noncomputable
 def mk_of_oplax' {F : oplax_functor B C}
   [∀ a, is_iso (F.map_id a)] [∀ {a b c} (f : a ⟶ b) (g : b ⟶ c), is_iso (F.map_comp f g)] :

--- a/src/category_theory/bicategory/functor.lean
+++ b/src/category_theory/bicategory/functor.lean
@@ -18,7 +18,6 @@ An oplax functor `F` between bicategories `B` and `C` consists of
 
 A pseudofunctor is an oplax functor whose `map_id` and `map_comp` are isomorphisms. We provide
 several constructors for pseudofunctors:
-The former uses `iso` for the same type, and the latter uses` is_iso` for the same type.
 * `pseudofunctor.mk` : the default constructor, which requires `map₂_whisker_left` and
   `map₂_whisker_right` instead of naturality of `map_comp`.
 * `pseudofunctor.mk_of_oplax` : construct a pseudofunctor from an oplax functor whose

--- a/src/category_theory/bicategory/functor.lean
+++ b/src/category_theory/bicategory/functor.lean
@@ -10,8 +10,8 @@ import category_theory.bicategory.basic
 
 An oplax functor `F` between bicategories `B` and `C` consists of
 * a function between objects `F.obj : B ⟶ C`,
-* a family of functions between 1-morphisms `F.map : (a ⟶ b) → (obj a ⟶ obj b)`,
-* a family of functions between 2-morphisms `F.map₂ : (f ⟶ g) → (map f ⟶ map g)`,
+* a family of functions between 1-morphisms `F.map : (a ⟶ b) → (F.obj a ⟶ F.obj b)`,
+* a family of functions between 2-morphisms `F.map₂ : (f ⟶ g) → (F.map f ⟶ F.map g)`,
 * a family of 2-morphisms `F.map_id a : F.map (𝟙 a) ⟶ 𝟙 (F.obj a)`,
 * a family of 2-morphisms `F.map_comp f g : F.map (f ≫ g) ⟶ F.map f ≫ F.map g`, and
 * certain consistency conditions on them.
@@ -130,16 +130,16 @@ map₂ (α_ f g h).hom ≫ map_comp f (g ≫ h) ≫ (map f ◁ map_comp g h) =
   map_comp (f ≫ g) h ≫ (map_comp f g ▷ map h) ≫ (α_ (map f) (map g) (map h)).hom
 
 /--
-An oplax functor `F` between bicategories `B` and `C` consists of functions between objects,
-1-morphisms, and 2-morphisms.
+An oplax functor `F` between bicategories `B` and `C` consists of a function between objects
+`F.obj`, a function between 1-morphisms `F.map`, and a function between 2-morphisms `F.map₂`.
 
-Unlike functors between categories, functions between 1-morphisms do not need to strictly commute
-with compositions, and do not need to strictly preserve the identity. Instead, there are
-specified 2-morphisms `F.map (𝟙 a) ⟶ 𝟙 (F.obj a)` and `F.map (f ≫ g) ⟶ F.map f ≫ F.map g`.
+Unlike functors between categories, `F.map` do not need to strictly commute with the composition,
+and do not need to strictly preserve the identity. Instead, there are specified 2-morphisms
+`F.map (𝟙 a) ⟶ 𝟙 (F.obj a)` and `F.map (f ≫ g) ⟶ F.map f ≫ F.map g`.
 
-Functions between 2-morphisms strictly commute with compositions and preserve the identity.
-They also preserve the associator, the left unitor, and the right unitor modulo some adjustments
-of domains and codomains of 2-morphisms.
+`F.map₂` strictly commute with compositions and preserve the identity. They also preserve the
+associator, the left unitor, and the right unitor modulo some adjustments of domains and codomains
+of 2-morphisms.
 -/
 structure oplax_functor (B : Type u₁) [bicategory.{w₁ v₁} B] (C : Type u₂) [bicategory.{w₂ v₂} C]
   extends prelax_functor B C :=
@@ -274,16 +274,16 @@ map₂ (α_ f g h).hom = (map_comp (f ≫ g) h).hom ≫ ((map_comp f g).hom ▷ 
   (α_ (map f) (map g) (map h)).hom ≫ (map f ◁ (map_comp g h).inv) ≫ (map_comp f (g ≫ h)).inv
 
 /--
-A pseudofunctor `F` between bicategories `B` and `C` consists of functions between objects,
-1-morphisms, and 2-morphisms.
+A pseudofunctor `F` between bicategories `B` and `C` consists of a function between objects
+`F.obj`, a function between 1-morphisms `F.map`, and a function between 2-morphisms `F.map₂`.
 
-Unlike functors between categories, functions between 1-morphisms do not need to strictly commute
-with compositions, and do not need to strictly preserve the identity. Instead, there are
-specified 2-isomorphisms `F.map (𝟙 a) ≅ 𝟙 (F.obj a)` and `F.map (f ≫ g) ≅ F.map f ≫ F.map g`.
+Unlike functors between categories, `F.map` do not need to strictly commute with the compositions,
+and do not need to strictly preserve the identity. Instead, there are specified 2-isomorphisms
+`F.map (𝟙 a) ≅ 𝟙 (F.obj a)` and `F.map (f ≫ g) ≅ F.map f ≫ F.map g`.
 
-Functions between 2-morphisms strictly commute with compositions and preserve the identity.
-They also preserve the associator, the left unitor, and the right unitor modulo some adjustments
-of domains and codomains of 2-morphisms.
+`F.map₂` strictly commute with compositions and preserve the identity. They also preserve the
+associator, the left unitor, and the right unitor modulo some adjustments of domains and codomains
+of 2-morphisms.
 -/
 structure pseudofunctor (B : Type u₁) [bicategory.{w₁ v₁} B] (C : Type u₂) [bicategory.{w₂ v₂} C]
   extends prelax_functor B C :=

--- a/src/category_theory/bicategory/functor.lean
+++ b/src/category_theory/bicategory/functor.lean
@@ -67,10 +67,13 @@ add_decl_doc prelax_functor.to_prefunctor
 
 namespace prelax_functor
 
+instance has_coe_to_prefunctor : has_coe (prelax_functor B C) (prefunctor B C) := ⟨to_prefunctor⟩
+
 variables (F : prelax_functor B C)
 
-@[simp] lemma to_prefunctor_obj : F.to_prefunctor.obj = F.obj := rfl
-@[simp] lemma to_prefunctor_map : F.to_prefunctor.map = F.map := rfl
+@[simp] lemma to_prefunctor_eq_coe : F.to_prefunctor = F := rfl
+@[simp] lemma to_prefunctor_obj : (F : prefunctor B C).obj = F.obj := rfl
+@[simp] lemma to_prefunctor_map : (F : prefunctor B C).map = F.map := rfl
 
 /-- The identity prelax functor. -/
 @[simps]
@@ -82,7 +85,7 @@ instance : inhabited (prelax_functor B B) := ⟨prelax_functor.id B⟩
 /-- Composition of prelax functors. -/
 @[simps]
 def comp (F : prelax_functor B C) (G : prelax_functor C D) : prelax_functor B D :=
-{ map₂ := λ a b f g η, G.map₂ (F.map₂ η), .. F.to_prefunctor.comp G.to_prefunctor }
+{ map₂ := λ a b f g η, G.map₂ (F.map₂ η), .. (F : prefunctor B C).comp ↑G }
 
 end prelax_functor
 
@@ -160,11 +163,15 @@ section
 /-- The prelax functor between the underlying quivers. -/
 add_decl_doc oplax_functor.to_prelax_functor
 
+instance has_coe_to_prelax : has_coe (oplax_functor B C) (prelax_functor B C) :=
+⟨to_prelax_functor⟩
+
 variables (F : oplax_functor B C)
 
-@[simp] lemma to_prelax_functor_obj : F.to_prelax_functor.obj = F.obj := rfl
-@[simp] lemma to_prelax_functor_map : F.to_prelax_functor.map = F.map := rfl
-@[simp] lemma to_prelax_functor_map₂ : F.to_prelax_functor.map₂ = F.map₂ := rfl
+@[simp] lemma to_prelax_eq_coe : F.to_prelax_functor = F := rfl
+@[simp] lemma to_prelax_functor_obj : (F : prelax_functor B C).obj = F.obj := rfl
+@[simp] lemma to_prelax_functor_map : (F : prelax_functor B C).map = F.map := rfl
+@[simp] lemma to_prelax_functor_map₂ : (F : prelax_functor B C).map₂ = F.map₂ := rfl
 
 /-- Function between 1-morphisms as a functor. -/
 @[simps]
@@ -210,7 +217,7 @@ def comp (F : oplax_functor B C) (G : oplax_functor C D) : oplax_functor B D :=
   { dsimp,
     simp only [map₂_right_unitor, map₂_comp, map_comp_naturality_right_assoc,
       whisker_left_comp, assoc] },
-  .. F.to_prelax_functor.comp G.to_prelax_functor }
+  .. (F : prelax_functor B C).comp ↑G }
 
 /--
 A structure on an oplax functor that promotes an oplax functors to a pseudofunctor.
@@ -303,29 +310,36 @@ open iso
 /-- The prelax functor between the underlying quivers. -/
 add_decl_doc pseudofunctor.to_prelax_functor
 
+instance has_coe_to_prelax_functor : has_coe (pseudofunctor B C) (prelax_functor B C) :=
+⟨to_prelax_functor⟩
+
 variables (F : pseudofunctor B C)
 
-@[simp] lemma to_prelax_functor_obj : F.to_prelax_functor.obj = F.obj := rfl
-@[simp] lemma to_prelax_functor_map : F.to_prelax_functor.map = F.map := rfl
-@[simp] lemma to_prelax_functor_map₂ : F.to_prelax_functor.map₂ = F.map₂ := rfl
+@[simp] lemma to_prelax_functor_eq_coe : F.to_prelax_functor = F := rfl
+@[simp] lemma to_prelax_functor_obj : (F : prelax_functor B C).obj = F.obj := rfl
+@[simp] lemma to_prelax_functor_map : (F : prelax_functor B C).map = F.map := rfl
+@[simp] lemma to_prelax_functor_map₂ : (F : prelax_functor B C).map₂ = F.map₂ := rfl
 
 /-- The oplax functor associated with a pseudofunctor. -/
 def to_oplax : oplax_functor B C :=
 { map_id := λ a, (F.map_id a).hom,
   map_comp := λ a b c f g, (F.map_comp f g).hom,
-  .. F.to_prelax_functor }
+  .. (F : prelax_functor B C) }
 
-@[simp] lemma to_oplax_obj : F.to_oplax.obj = F.obj := rfl
-@[simp] lemma to_oplax_map : F.to_oplax.map = F.map := rfl
-@[simp] lemma to_oplax_map₂ : F.to_oplax.map₂ = F.map₂ := rfl
-@[simp] lemma to_oplax_map_id (a : B) : F.to_oplax.map_id a = (F.map_id a).hom := rfl
+instance has_coe_to_oplax : has_coe (pseudofunctor B C) (oplax_functor B C) := ⟨to_oplax⟩
+
+@[simp] lemma to_oplax_eq_coe : F.to_oplax = F := rfl
+@[simp] lemma to_oplax_obj : (F : oplax_functor B C).obj = F.obj := rfl
+@[simp] lemma to_oplax_map : (F : oplax_functor B C).map = F.map := rfl
+@[simp] lemma to_oplax_map₂ : (F : oplax_functor B C).map₂ = F.map₂ := rfl
+@[simp] lemma to_oplax_map_id (a : B) : (F : oplax_functor B C).map_id a = (F.map_id a).hom := rfl
 @[simp] lemma to_oplax_map_comp {a b c : B} (f : a ⟶ b) (g : b ⟶ c) :
-  F.to_oplax.map_comp f g = (F.map_comp f g).hom := rfl
+  (F : oplax_functor B C).map_comp f g = (F.map_comp f g).hom := rfl
 
 /-- Function on 1-morphisms as a functor. -/
 @[simps]
 def map_functor (a b : B) : (a ⟶ b) ⥤ (F.obj a ⟶ F.obj b) :=
-F.to_oplax.map_functor a b
+(F : oplax_functor B C).map_functor a b
 
 /-- The identity pseudofunctor. -/
 @[simps]
@@ -342,7 +356,7 @@ def comp (F : pseudofunctor B C) (G : pseudofunctor C D) : pseudofunctor B D :=
 { map_id := λ a, (G.map_functor _ _).map_iso (F.map_id a) ≪≫ G.map_id (F.obj a),
   map_comp := λ a b c f g,
     (G.map_functor _ _).map_iso (F.map_comp f g) ≪≫ G.map_comp (F.map f) (F.map g),
-  .. F.to_prelax_functor.comp G.to_prelax_functor }
+  .. (F : prelax_functor B C).comp ↑G }
 
 /--
 Construct a pseudofunctor from an oplax functor whose `map_id` and `map_comp` are isomorphisms.
@@ -364,7 +378,7 @@ def mk_of_oplax (F : oplax_functor B C) (F' : F.pseudo_core) : pseudofunctor B C
     rw [F'.map_comp_iso_hom (f ≫ g) h, F'.map_comp_iso_hom f g, ←F.map₂_associator_assoc,
       ←F'.map_comp_iso_hom f (g ≫ h), ←F'.map_comp_iso_hom g h,
       hom_inv_whisker_left_assoc, hom_inv_id, comp_id] },
-  .. F.to_prelax_functor }
+  .. (F : prelax_functor B C) }
 
 /--
 Construct a pseudofunctor from an oplax functor whose `map_id` and `map_comp` are isomorphisms.
@@ -387,7 +401,7 @@ def mk_of_oplax' (F : oplax_functor B C)
     simp only [←assoc],
     rw [is_iso.eq_comp_inv, ←inv_whisker_left, is_iso.eq_comp_inv],
     simp only [assoc, F.map₂_associator] },
-  .. F.to_prelax_functor }
+  .. (F : prelax_functor B C) }
 
 end
 

--- a/src/category_theory/bicategory/functor.lean
+++ b/src/category_theory/bicategory/functor.lean
@@ -15,7 +15,16 @@ An oplax functor `F` between bicategories `B` and `C` consists of
 * a family of 2-morphisms `F.map_id a : F.map (𝟙 a) ⟶ 𝟙 (F.obj a)`,
 * a family of 2-morphisms `F.map_comp f g : F.map (f ≫ g) ⟶ F.map f ≫ F.map g`, and
 * certain consistency conditions on them.
-A pseudofunctor is an oplax functor whose `map_id` and `map_comp` are isomorphisms.
+
+A pseudofunctor is an oplax functor whose `map_id` and `map_comp` are isomorphisms. We provide
+several constructors for pseudofunctors:
+The former uses `iso` for the same type, and the latter uses` is_iso` for the same type.
+* `pseudofunctor.mk` : the default constructor, which requires `map₂_whisker_left` and
+  `map₂_whisker_right` instead of naturality of `map_comp`.
+* `pseudofunctor.mk_of_oplax` : construct a pseudofunctor from an oplax functor whose
+  `map_id` and `map_comp` are isomorphisms. This constructor uses `iso` to describe isomorphisms.
+* `pseudofunctor.mk_of_oplax'` : similar to `mk_of_oplax`, but uses` is_iso` to describe
+  isomorphisms.
 
 ## Main definitions
 
@@ -145,26 +154,22 @@ structure oplax_functor extends prelax_functor B C :=
 (map₂_right_unitor' : ∀ {a b : B} (f : a ⟶ b),
   map₂ (ρ_ f).hom = map_comp f (𝟙 b) ≫ (map f ◁ map_id b) ≫ (ρ_ (map f)).hom . obviously)
 
-restate_axiom oplax_functor.map_comp_naturality_left'
-restate_axiom oplax_functor.map_comp_naturality_right'
-restate_axiom oplax_functor.map₂_id'
-restate_axiom oplax_functor.map₂_comp'
-restate_axiom oplax_functor.map₂_associator'
-restate_axiom oplax_functor.map₂_left_unitor'
-restate_axiom oplax_functor.map₂_right_unitor'
-attribute [simp]
-  oplax_functor.map_comp_naturality_left oplax_functor.map_comp_naturality_right
-  oplax_functor.map₂_id oplax_functor.map₂_associator
-attribute [reassoc]
-  oplax_functor.map_comp_naturality_left oplax_functor.map_comp_naturality_right
-  oplax_functor.map₂_comp oplax_functor.map₂_associator
-  oplax_functor.map₂_left_unitor oplax_functor.map₂_right_unitor
-attribute [simp]
-  oplax_functor.map₂_comp oplax_functor.map₂_left_unitor oplax_functor.map₂_right_unitor
-
 variables {B C}
 
 namespace oplax_functor
+
+restate_axiom map_comp_naturality_left'
+restate_axiom map_comp_naturality_right'
+restate_axiom map₂_id'
+restate_axiom map₂_comp'
+restate_axiom map₂_associator'
+restate_axiom map₂_left_unitor'
+restate_axiom map₂_right_unitor'
+attribute [simp] map_comp_naturality_left map_comp_naturality_right map₂_id map₂_associator
+attribute [reassoc]
+  map_comp_naturality_left map_comp_naturality_right map₂_comp
+  map₂_associator map₂_left_unitor map₂_right_unitor
+attribute [simp] map₂_comp map₂_left_unitor map₂_right_unitor
 
 section
 variables (F : oplax_functor B C) (G : oplax_functor C D)
@@ -300,13 +305,13 @@ of domains and codomains of 2-morphisms.
 structure pseudofunctor extends prelax_functor B C :=
 (map_id (a : B) : map (𝟙 a) ≅ 𝟙 (obj a))
 (map_comp {a b c : B} (f : a ⟶ b) (g : b ⟶ c) : map (f ≫ g) ≅ map f ≫ map g)
-(map₂_whisker_right' : ∀ {a b c : B} {f g : a ⟶ b} (η : f ⟶ g) (h : b ⟶ c),
-  map₂ (η ▷ h) = (map_comp f h).hom ≫ (map₂ η ▷ map h) ≫ (map_comp g h).inv . obviously)
-(map₂_whisker_left' : ∀ {a b c : B} (f : a ⟶ b) {g h : b ⟶ c} (η : g ⟶ h),
-  map₂ (f ◁ η) = (map_comp f g).hom ≫ (map f ◁ map₂ η) ≫ (map_comp f h).inv . obviously)
 (map₂_id' : ∀ {a b : B} (f : a ⟶ b), map₂ (𝟙 f) = 𝟙 (map f) . obviously)
 (map₂_comp' : ∀ {a b : B} {f g h : a ⟶ b} (η : f ⟶ g) (θ : g ⟶ h),
   map₂ (η ≫ θ) = map₂ η ≫ map₂ θ . obviously)
+(map₂_whisker_left' : ∀ {a b c : B} (f : a ⟶ b) {g h : b ⟶ c} (η : g ⟶ h),
+  map₂ (f ◁ η) = (map_comp f g).hom ≫ (map f ◁ map₂ η) ≫ (map_comp f h).inv . obviously)
+(map₂_whisker_right' : ∀ {a b c : B} {f g : a ⟶ b} (η : f ⟶ g) (h : b ⟶ c),
+  map₂ (η ▷ h) = (map_comp f h).hom ≫ (map₂ η ▷ map h) ≫ (map_comp g h).inv . obviously)
 (map₂_associator' : ∀ {a b c d : B} (f : a ⟶ b) (g : b ⟶ c) (h : c ⟶ d),
   pseudofunctor.map₂_associator_aux obj (λ a b, map) (λ a b f g, map₂) (λ a b c, map_comp) f g h
     . obviously)
@@ -317,29 +322,27 @@ structure pseudofunctor extends prelax_functor B C :=
   map₂ (ρ_ f).hom = (map_comp f (𝟙 b)).hom ≫ (map f ◁ (map_id b).hom) ≫ (ρ_ (map f)).hom
     . obviously)
 
-restate_axiom pseudofunctor.map₂_whisker_right'
-restate_axiom pseudofunctor.map₂_whisker_left'
-restate_axiom pseudofunctor.map₂_id'
-restate_axiom pseudofunctor.map₂_comp'
-restate_axiom pseudofunctor.map₂_associator'
-restate_axiom pseudofunctor.map₂_left_unitor'
-restate_axiom pseudofunctor.map₂_right_unitor'
-attribute [reassoc]
-  pseudofunctor.map₂_whisker_right pseudofunctor.map₂_whisker_left
-  pseudofunctor.map₂_comp pseudofunctor.map₂_associator
-  pseudofunctor.map₂_left_unitor pseudofunctor.map₂_right_unitor
-attribute [simp]
-  pseudofunctor.map₂_whisker_right pseudofunctor.map₂_whisker_left
-  pseudofunctor.map₂_id pseudofunctor.map₂_associator pseudofunctor.map₂_comp
-  pseudofunctor.map₂_left_unitor pseudofunctor.map₂_right_unitor
-
 variables {B C}
 
 namespace pseudofunctor
 
+restate_axiom map₂_id'
+restate_axiom map₂_comp'
+restate_axiom map₂_whisker_left'
+restate_axiom map₂_whisker_right'
+restate_axiom map₂_associator'
+restate_axiom map₂_left_unitor'
+restate_axiom map₂_right_unitor'
+attribute [reassoc]
+  map₂_comp map₂_whisker_left map₂_whisker_right map₂_associator map₂_left_unitor map₂_right_unitor
+attribute [simp]
+  map₂_id map₂_comp map₂_whisker_left map₂_whisker_right
+  map₂_associator map₂_left_unitor map₂_right_unitor
+
 section
-open iso
 variables (F : pseudofunctor B C) (G : pseudofunctor C D)
+
+open iso
 
 /-- The prelax functor between the underlying quivers. -/
 add_decl_doc pseudofunctor.to_prelax_functor
@@ -462,6 +465,11 @@ def mk_of_oplax' {F : oplax_functor B C}
 end
 
 end pseudofunctor
+
+#check @pseudofunctor.mk
+
+#check @pseudofunctor.mk_of_oplax
+
 
 end
 

--- a/src/category_theory/bicategory/functor.lean
+++ b/src/category_theory/bicategory/functor.lean
@@ -76,25 +76,18 @@ instance has_coe_to_prefunctor : has_coe (prelax_functor B C) (prefunctor B C) :
 variables (B)
 
 /-- The identity prelax functor. -/
+@[simps]
 def id : prelax_functor B B :=
 { map₂ := λ a b f g η, η, .. prefunctor.id B }
-
-@[simp] lemma id_obj (a : B) : (id B).obj a = a := rfl
-@[simp] lemma id_map {a b : B} (f : a ⟶ b) : (id B).map f = f := rfl
-@[simp] lemma id_map₂ {a b : B} {f g : a ⟶ b} (η : f ⟶ g) : (id B).map₂ η = η := rfl
 
 instance : inhabited (prelax_functor B B) := ⟨prelax_functor.id B⟩
 
 variables {B}
 
 /-- Composition of prelax functors. -/
+@[simps]
 def comp : prelax_functor B D :=
 { map₂ := λ a b f g η, G.map₂ (F.map₂ η), .. (F : prefunctor B C).comp ↑G }
-
-@[simp] lemma comp_obj (a : B) : (F.comp G).obj a = G.obj (F.obj a) := rfl
-@[simp] lemma comp_map {a b : B} (f : a ⟶ b) : (F.comp G).map f = G.map (F.map f) := rfl
-@[simp] lemma comp_map₂ {a b : B} {f g : a ⟶ b} (η : f ⟶ g) :
-  (F.comp G).map₂ η = G.map₂ (F.map₂ η) := rfl
 
 end prelax_functor
 
@@ -193,23 +186,18 @@ def map_functor (a b : B) : (a ⟶ b) ⥤ (F.obj a ⟶ F.obj b) :=
 variables (B)
 
 /-- The identity oplax functor. -/
+@[simps]
 def id : oplax_functor B B :=
 { map_id := λ a, 𝟙 (𝟙 a),
   map_comp := λ a b c f g, 𝟙 (f ≫ g),
   .. prelax_functor.id B }
-
-@[simp] lemma id_obj (a : B) : (id B).obj a = a := rfl
-@[simp] lemma id_map {a b : B} (f : a ⟶ b) : (id B).map f = f := rfl
-@[simp] lemma id_map₂ {a b : B} {f g : a ⟶ b} (η : f ⟶ g) : (id B).map₂ η = η := rfl
-@[simp] lemma id_map_id (a : B) : (id B).map_id a = 𝟙 (𝟙 a) := rfl
-@[simp] lemma id_map_comp {a b c : B} (f : a ⟶ b) (g : b ⟶ c) :
-  (id B).map_comp f g = 𝟙 (f ≫ g) := rfl
 
 instance : inhabited (oplax_functor B B) := ⟨id B⟩
 
 variables {B}
 
 /-- Composition of oplax functors. -/
+@[simps]
 def comp : oplax_functor B D :=
 { map_id := λ a,
     (G.map_functor _ _).map (F.map_id a) ≫ G.map_id (F.obj a),
@@ -238,18 +226,6 @@ def comp : oplax_functor B D :=
     simp only [map₂_right_unitor, map₂_comp, map_comp_naturality_right_assoc,
       whisker_left_comp, assoc] },
   .. (F : prelax_functor B C).comp ↑G }
-
-@[simp] lemma comp_obj (a : B) : (F.comp G).obj a = G.obj (F.obj a) := rfl
-@[simp] lemma comp_map {a b : B} (f : a ⟶ b) : (F.comp G).map f = G.map (F.map f) := rfl
-@[simp] lemma comp_map₂ {a b : B} {f g : a ⟶ b} (η : f ⟶ g) :
-  (F.comp G).map₂ η = G.map₂ (F.map₂ η) := rfl
-@[simp] lemma comp_map_id (a : B) :
-  (F.comp G).map_id a =
-    (G.map_functor (F.obj a) (F.obj a)).map (F.map_id a) ≫ G.map_id (F.obj a) := rfl
-@[simp] lemma comp_map_comp {a b c : B} (f : a ⟶ b) (g : b ⟶ c) :
-  (F.comp G).map_comp f g =
-    (G.map_functor (F.obj a) (F.obj c)).map (F.map_comp f g) ≫
-      G.map_comp (F.map f) (F.map g) := rfl
 
 /--
 A structure on an oplax functor that promotes an oprax functors to a pseudofunctor.
@@ -371,50 +347,30 @@ instance has_coe_to_oplax : has_coe (pseudofunctor B C) (oplax_functor B C) := �
   (F : oplax_functor B C).map_comp f g = (F.map_comp f g).hom := rfl
 
 /-- Function on 1-morphisms as a functor. -/
+@[simps]
 def map_functor (a b : B) : (a ⟶ b) ⥤ (F.obj a ⟶ F.obj b) :=
 (F : oplax_functor B C).map_functor a b
-
-@[simp] lemma map_functor_obj {a b : B} (f : a ⟶ b) : (F.map_functor a b).obj f = F.map f := rfl
-@[simp] lemma map_functor_map {a b : B} {f g : a ⟶ b} (η : f ⟶ g) :
-  (F.map_functor a b).map η = F.map₂ η := rfl
 
 variables (B)
 
 /-- The identity pseudofunctor. -/
+@[simps]
 def id : pseudofunctor B B :=
 { map_id := λ a, iso.refl (𝟙 a),
   map_comp := λ a b c f g, iso.refl (f ≫ g),
   .. prelax_functor.id B }
-
-@[simp] lemma id_obj (a : B) : (id B).obj a = a := rfl
-@[simp] lemma id_map {a b : B} (f : a ⟶ b) : (id B).map f = f := rfl
-@[simp] lemma id_map₂ {a b : B} {f g : a ⟶ b} (η : f ⟶ g) : (id B).map₂ η = η := rfl
-@[simp] lemma id_map_id (a : B) : (id B).map_id a = iso.refl (𝟙 a) := rfl
-@[simp] lemma id_map_comp {a b c : B} (f : a ⟶ b) (g : b ⟶ c) :
-  (id B).map_comp f g = iso.refl (f ≫ g) := rfl
 
 instance : inhabited (pseudofunctor B B) := ⟨id B⟩
 
 variables {B}
 
 /-- Composition of pseudofunctors. -/
+@[simps]
 def comp : pseudofunctor B D :=
 { map_id := λ a, (G.map_functor _ _).map_iso (F.map_id a) ≪≫ G.map_id (F.obj a),
   map_comp := λ a b c f g,
     (G.map_functor _ _).map_iso (F.map_comp f g) ≪≫ G.map_comp (F.map f) (F.map g),
   .. (F : prelax_functor B C).comp ↑G }
-
-@[simp] lemma comp_obj (a : B) : (F.comp G).obj a = G.obj (F.obj a) := rfl
-@[simp] lemma comp_map {a b : B} (f : a ⟶ b) : (F.comp G).map f = G.map (F.map f) := rfl
-@[simp] lemma comp_map₂ {a b : B} {f g : a ⟶ b} (η : f ⟶ g) :
-  (F.comp G).map₂ η = G.map₂ (F.map₂ η) := rfl
-@[simp] lemma comp_map_id (a : B) :
-  (F.comp G).map_id a =
-    (G.map_functor (F.obj a) (F.obj a)).map_iso (F.map_id a) ≪≫ G.map_id (F.obj a) := rfl
-@[simp] lemma comp_map_comp {a b c : B} (f : a ⟶ b) (g : b ⟶ c) :
-  (F.comp G).map_comp f g =
-    (G.map_functor (F.obj a) (F.obj c)).map_iso (F.map_comp f g) ≪≫
-      G.map_comp (F.map f) (F.map g) := rfl
 
 /--
 Construct a pseudofunctor from an oplax functor whose `map_id` and `map_comp` are isomorphisms.

--- a/src/category_theory/bicategory/functor.lean
+++ b/src/category_theory/bicategory/functor.lean
@@ -6,7 +6,7 @@ Authors: Yuma Mizuno
 import category_theory.bicategory.basic
 
 /-!
-# Oplax functors
+# Oplax functors and pseudofunctors
 
 An oplax functor `F` between bicategories `B` and `C` consists of
 * a function between objects `F.obj : B ⟶ C`,
@@ -15,21 +15,20 @@ An oplax functor `F` between bicategories `B` and `C` consists of
 * a family of 2-morphisms `F.map_id a : F.map (𝟙 a) ⟶ 𝟙 (F.obj a)`,
 * a family of 2-morphisms `F.map_comp f g : F.map (f ≫ g) ⟶ F.map f ≫ F.map g`, and
 * certain consistency conditions on them.
+A pseudofunctor is an oplax functor whose `map_id` and `map_comp` are isomorphisms.
 
 ## Main definitions
 
 * `oplax_functor B C` : an oplax functor between bicategories `B` and `C`
 * `oplax_functor.comp F G` : the composition of oplax functors
+* `pseudofunctor B C` : a pseudofunctor between bicategories `B` and `C`
+* `pseudofunctor.comp F G` : the composition of pseudofunctors
 
 ## Future work
 
 There are two types of functors between bicategories, called lax and oplax functors, depending on
 the directions of `map_id` and `map_comp`. We may need both in mathlib in the future, but for
 now we only define oplax functors.
-
-In addition, if we require `map_id` and `map_comp` to be isomorphisms, we obtain the definition
-of pseudofunctors. There are several possible design choices to implement pseudofunctors,
-but the choice is left to future development.
 -/
 
 set_option old_structure_cmd true
@@ -49,7 +48,7 @@ variables (C : Type u₂) [quiver.{v₂+1} C] [∀ a b : C, quiver.{w₂+1} (a �
 A prelax functor between bicategories consists of functions between objects,
 1-morphisms, and 2-morphisms. This structure will be extended to define `oplax_functor`.
 -/
-structure prelax_functor extends prefunctor B C : Type (max w₁ w₂ v₁ v₂ u₁ u₂) :=
+structure prelax_functor extends prefunctor B C :=
 (map₂ {a b : B} {f g : a ⟶ b} : (f ⟶ g) → (map f ⟶ map g))
 
 /-- The prefunctor between the underlying quivers. -/
@@ -60,8 +59,11 @@ namespace prelax_functor
 variables {B C} {D : Type u₃} [quiver.{v₃+1} D] [∀ a b : D, quiver.{w₃+1} (a ⟶ b)]
 variables (F : prelax_functor B C) (G : prelax_functor C D)
 
-@[simp] lemma to_prefunctor_obj : F.to_prefunctor.obj = F.obj := rfl
-@[simp] lemma to_prefunctor_map : F.to_prefunctor.map = F.map := rfl
+instance has_coe_to_prefunctor : has_coe (prelax_functor B C) (prefunctor B C) := ⟨to_prefunctor⟩
+
+@[simp] lemma to_prefunctor_eq_coe : F.to_prefunctor = F := rfl
+@[simp] lemma to_prefunctor_obj : (F : prefunctor B C).obj = F.obj := rfl
+@[simp] lemma to_prefunctor_map : (F : prefunctor B C).map = F.map := rfl
 
 variables (B)
 
@@ -77,7 +79,7 @@ variables {B}
 /-- Composition of prelax functors. -/
 @[simps]
 def comp : prelax_functor B D :=
-{ map₂ := λ a b f g η, G.map₂ (F.map₂ η), .. F.to_prefunctor.comp G.to_prefunctor }
+{ map₂ := λ a b f g η, G.map₂ (F.map₂ η), .. (F : prefunctor B C).comp ↑G }
 
 end prelax_functor
 
@@ -85,6 +87,7 @@ end
 
 section
 variables {B : Type u₁} [bicategory.{w₁ v₁} B] {C : Type u₂} [bicategory.{w₂ v₂} C]
+variables {D : Type u₃} [bicategory.{w₃ v₃} D]
 
 /--
 This auxiliary definition states that oplax functors preserve the associators
@@ -117,7 +120,7 @@ Functions between 2-morphisms strictly commute with compositions and preserve th
 They also preserve the associator, the left unitor, and the right unitor modulo some adjustments
 of domains and codomains of 2-morphisms.
 -/
-structure oplax_functor extends prelax_functor B C : Type (max w₁ w₂ v₁ v₂ u₁ u₂) :=
+structure oplax_functor extends prelax_functor B C :=
 (map_id (a : B) : map (𝟙 a) ⟶ 𝟙 (obj a))
 (map_comp {a b c : B} (f : a ⟶ b) (g : b ⟶ c) : map (f ≫ g) ⟶ map f ≫ map g)
 (map_comp_naturality_left' : ∀ {a b c : B} {f f' : a ⟶ b} (η : f ⟶ f') (g : b ⟶ c),
@@ -152,9 +155,11 @@ attribute [reassoc]
 attribute [simp]
   oplax_functor.map₂_comp oplax_functor.map₂_left_unitor oplax_functor.map₂_right_unitor
 
+variables {B C}
+
 namespace oplax_functor
 
-variables {B} {C} {D : Type u₃} [bicategory.{w₃ v₃} D]
+section
 variables (F : oplax_functor B C) (G : oplax_functor C D)
 
 /-- Function between 1-morphisms as a functor. -/
@@ -166,9 +171,13 @@ def map_functor (a b : B) : (a ⟶ b) ⥤ (F.obj a ⟶ F.obj b) :=
 /-- The prelax functor between the underlying quivers. -/
 add_decl_doc oplax_functor.to_prelax_functor
 
-@[simp] lemma to_prelax_functor_obj : F.to_prelax_functor.obj = F.obj := rfl
-@[simp] lemma to_prelax_functor_map : F.to_prelax_functor.map = F.map := rfl
-@[simp] lemma to_prelax_functor_map₂ : F.to_prelax_functor.map₂ = F.map₂ := rfl
+instance has_coe_to_prelax : has_coe (oplax_functor B C) (prelax_functor B C) :=
+⟨to_prelax_functor⟩
+
+@[simp] lemma to_prelax_eq_coe : F.to_prelax_functor = F := rfl
+@[simp] lemma to_prelax_functor_obj : (F : prelax_functor B C).obj = F.obj := rfl
+@[simp] lemma to_prelax_functor_map : (F : prelax_functor B C).map = F.map := rfl
+@[simp] lemma to_prelax_functor_map₂ : (F : prelax_functor B C).map₂ = F.map₂ := rfl
 
 variables (B)
 
@@ -212,9 +221,204 @@ def comp : oplax_functor B D :=
   { dsimp,
     simp only [map₂_right_unitor, map₂_comp, map_comp_naturality_right_assoc,
       whisker_left_comp, assoc] },
-  .. F.to_prelax_functor.comp G.to_prelax_functor }
+  .. (F : prelax_functor B C).comp ↑G }
+
+structure pseudo_core (F : oplax_functor B C) :=
+(map_id_iso (a : B) : F.map (𝟙 a) ≅ 𝟙 (F.obj a))
+(map_comp_iso {a b c : B} (f : a ⟶ b) (g : b ⟶ c) : F.map (f ≫ g) ≅ F.map f ≫ F.map g)
+(map_id_iso_hom' : ∀ {a : B}, (map_id_iso a).hom = F.map_id a . obviously)
+(map_comp_iso_hom' : ∀ {a b c : B} (f : a ⟶ b) (g : b ⟶ c),
+  (map_comp_iso f g).hom = F.map_comp f g . obviously)
+
+restate_axiom pseudo_core.map_id_iso_hom'
+restate_axiom pseudo_core.map_comp_iso_hom'
+attribute [simp] pseudo_core.map_id_iso_hom pseudo_core.map_comp_iso_hom
+
+class is_pseudo : Prop :=
+(map_id_is_iso' : ∀ (a : B), is_iso (F.map_id a) . tactic.apply_instance)
+(map_comp_is_iso' : ∀ {a b c : B} (f : a ⟶ b) (g : b ⟶ c),
+  is_iso (F.map_comp f g) . tactic.apply_instance)
+
+restate_axiom is_pseudo.map_id_is_iso'
+restate_axiom is_pseudo.map_comp_is_iso'
+attribute [instance] is_pseudo.map_id_is_iso is_pseudo.map_comp_is_iso
+
+end
 
 end oplax_functor
+
+/--
+The auxiliary definition that claims that pseudofunctors preserve the associators
+modulo some adjustments of domains and codomains of 2-morphisms. -/
+/-
+The reason for using this auxiliary definition instead of writing it directly in the definition
+of pseudofunctors is that doing so will cause a timeout.
+-/
+@[simp]
+def pseudofunctor.map₂_associator_aux
+  (obj : B → C) (map : Π {X Y : B}, (X ⟶ Y) → (obj X ⟶ obj Y))
+  (map₂ : Π {a b : B} {f g : a ⟶ b}, (f ⟶ g) → (map f ⟶ map g))
+  (map_comp : Π {a b c : B} (f : a ⟶ b) (g : b ⟶ c), map (f ≫ g) ≅ map f ≫ map g)
+  {a b c d : B} (f : a ⟶ b) (g : b ⟶ c) (h : c ⟶ d) : Prop :=
+map₂ (α_ f g h).hom = (map_comp (f ≫ g) h).hom ≫ ((map_comp f g).hom ▷ map h) ≫
+  (α_ (map f) (map g) (map h)).hom ≫ (map f ◁ (map_comp g h).inv) ≫ (map_comp f (g ≫ h)).inv
+
+variables (B C)
+
+/--
+A pseudofunctors `F` between bicategories `B` and `C` consists of functions between objects,
+1-morphisms, and 2-morphisms.
+
+Unlike functors between categories, functions between 1-morphisms do not need to strictly commute
+with compositions, and do not need to strictly preserve the identity. Instead, there are
+specified 2-isomorphisms `F.map (𝟙 a) ≅ 𝟙 (F.obj a)` and `F.map (f ≫ g) ≅ F.map f ≫ F.map g`.
+
+Functions between 2-morphisms strictly commute with compositions and preserve the identity.
+They also preserve the associator, the left unitor, and the right unitor modulo some adjustments
+of domains and codomains of 2-morphisms.
+-/
+structure pseudofunctor (B : Type u₁) [bicategory.{w₁ v₁} B] (C : Type u₂) [bicategory.{w₂ v₂} C]
+  extends prelax_functor B C :=
+(map_id (a : B) : map (𝟙 a) ≅ 𝟙 (obj a))
+(map_comp {a b c : B} (f : a ⟶ b) (g : b ⟶ c) : map (f ≫ g) ≅ map f ≫ map g)
+(map₂_whisker_right' : ∀ {a b c : B} {f g : a ⟶ b} (η : f ⟶ g) (h : b ⟶ c),
+  map₂ (η ▷ h) = (map_comp f h).hom ≫ (map₂ η ▷ map h) ≫ (map_comp g h).inv . obviously)
+(map₂_whisker_left' : ∀ {a b c : B} (f : a ⟶ b) {g h : b ⟶ c} (η : g ⟶ h),
+  map₂ (f ◁ η) = (map_comp f g).hom ≫ (map f ◁ map₂ η) ≫ (map_comp f h).inv . obviously)
+(map₂_id' : ∀ {a b : B} (f : a ⟶ b), map₂ (𝟙 f) = 𝟙 (map f) . obviously)
+(map₂_comp' : ∀ {a b : B} {f g h : a ⟶ b} (η : f ⟶ g) (θ : g ⟶ h),
+  map₂ (η ≫ θ) = map₂ η ≫ map₂ θ . obviously)
+(map₂_associator' : ∀ {a b c d : B} (f : a ⟶ b) (g : b ⟶ c) (h : c ⟶ d),
+  pseudofunctor.map₂_associator_aux obj (λ a b, map) (λ a b f g, map₂) (λ a b c, map_comp) f g h
+    . obviously)
+(map₂_left_unitor' : ∀ {a b : B} (f : a ⟶ b),
+  map₂ (λ_ f).hom = (map_comp (𝟙 a) f).hom ≫ ((map_id a).hom ▷ map f) ≫ (λ_ (map f)).hom
+    . obviously)
+(map₂_right_unitor' : ∀ {a b : B} (f : a ⟶ b),
+  map₂ (ρ_ f).hom = (map_comp f (𝟙 b)).hom ≫ (map f ◁ (map_id b).hom) ≫ (ρ_ (map f)).hom
+    . obviously)
+
+restate_axiom pseudofunctor.map₂_whisker_right'
+restate_axiom pseudofunctor.map₂_whisker_left'
+restate_axiom pseudofunctor.map₂_id'
+restate_axiom pseudofunctor.map₂_comp'
+restate_axiom pseudofunctor.map₂_associator'
+restate_axiom pseudofunctor.map₂_left_unitor'
+restate_axiom pseudofunctor.map₂_right_unitor'
+attribute [simp]
+  pseudofunctor.map₂_whisker_right pseudofunctor.map₂_whisker_left
+  pseudofunctor.map₂_id pseudofunctor.map₂_associator
+attribute [reassoc]
+  pseudofunctor.map₂_whisker_right pseudofunctor.map₂_whisker_left
+  pseudofunctor.map₂_comp pseudofunctor.map₂_associator
+  pseudofunctor.map₂_left_unitor pseudofunctor.map₂_right_unitor
+attribute [simp]
+  pseudofunctor.map₂_comp pseudofunctor.map₂_left_unitor pseudofunctor.map₂_right_unitor
+
+namespace pseudofunctor
+
+section
+open iso
+variables (F : pseudofunctor B C) (G : pseudofunctor C D)
+
+/-- Function on 1-morphisms as a functor. -/
+@[simps]
+def map_functor {a b : B} : (a ⟶ b) ⥤ (F.obj a ⟶ F.obj b) :=
+{ obj := λ f, F.map f,
+  map := λ f g η, F.map₂ η }
+
+/-- The prelax functor between the underlying quivers. -/
+add_decl_doc pseudofunctor.to_prelax_functor
+
+instance has_coe_to_prelax : has_coe (pseudofunctor B C) (prelax_functor B C) :=
+⟨to_prelax_functor⟩
+
+@[simp] lemma to_prelax_eq_coe : F.to_prelax_functor = F := rfl
+@[simp] lemma to_prelax_functor_obj : (F : prelax_functor B C).obj = F.obj := rfl
+@[simp] lemma to_prelax_functor_map : (F : prelax_functor B C).map = F.map := rfl
+@[simp] lemma to_prelax_functor_map₂ : (F : prelax_functor B C).map₂ = F.map₂ := rfl
+
+/-- The oplax functor associated with a pseudofunctor. -/
+def to_oplax : oplax_functor B C :=
+{ map_id := λ a, (F.map_id a).hom,
+  map_comp := λ a b c f g, (F.map_comp f g).hom,
+  .. (F : prelax_functor B C) }
+
+instance has_coe_to_oplax : has_coe (pseudofunctor B C) (oplax_functor B C) := ⟨to_oplax⟩
+
+@[simp] lemma to_oplax_eq_coe : F.to_oplax = F := rfl
+@[simp] lemma to_oplax_obj : (F : oplax_functor B C).obj = F.obj := rfl
+@[simp] lemma to_oplax_map : (F : oplax_functor B C).map = F.map := rfl
+@[simp] lemma to_oplax_map₂ : (F : oplax_functor B C).map₂ = F.map₂ := rfl
+@[simp] lemma to_oplax_map_id (a : B) : (F : oplax_functor B C).map_id a = (F.map_id a).hom := rfl
+@[simp] lemma to_oplax_map_comp {a b c : B} (f : a ⟶ b) (g : b ⟶ c) :
+  (F : oplax_functor B C).map_comp f g = (F.map_comp f g).hom := rfl
+
+variables (B)
+
+/-- The identity pseudofunctor. -/
+@[simps]
+def id : pseudofunctor B B :=
+{ map_id := λ a, iso.refl (𝟙 a),
+  map_comp := λ a b c f g, iso.refl (f ≫ g),
+  .. prelax_functor.id B }
+
+instance : inhabited (pseudofunctor B B) := ⟨id B⟩
+
+variables {B}
+
+/-- Composition of pseudofunctors. -/
+@[simps]
+def comp : pseudofunctor B D :=
+{ map_id := λ a, G.map_functor.map_iso (F.map_id a) ≪≫ G.map_id (F.obj a),
+  map_comp := λ a b c f g,
+    G.map_functor.map_iso (F.map_comp f g) ≪≫ G.map_comp (F.map f) (F.map g),
+  .. (F : prelax_functor B C).comp ↑G }
+
+/--
+Construct a pseudofunctor from an oplax functor whose `map_id` and `map_comp` are isomorphisms.
+-/
+def mk_of_oplax {F : oplax_functor B C} (F' : oplax_functor.pseudo_core F) : pseudofunctor B C :=
+{ map_id := F'.map_id_iso,
+  map_comp := F'.map_comp_iso,
+  map₂_whisker_right' := λ a b c f g η h, by
+  { dsimp,
+    rw [F'.map_comp_iso_hom f h, ←F.map_comp_naturality_left_assoc,
+      ←F'.map_comp_iso_hom g h, hom_inv_id, comp_id] },
+  map₂_whisker_left' := λ a b c f g h η, by
+  { dsimp,
+    rw [F'.map_comp_iso_hom f g, ←F.map_comp_naturality_right_assoc,
+      ←F'.map_comp_iso_hom f h, hom_inv_id, comp_id] },
+  map₂_associator' := λ a b c d f g h, by
+  { dsimp,
+    rw [F'.map_comp_iso_hom (f ≫ g) h, F'.map_comp_iso_hom f g, ←F.map₂_associator_assoc,
+      ←F'.map_comp_iso_hom f (g ≫ h), ←F'.map_comp_iso_hom g h,
+      hom_inv_whisker_left_assoc, hom_inv_id, comp_id] },
+  .. (F : prelax_functor B C) }
+
+/--
+Construct a pseudofunctor from an oplax functor whose `map_id` and `map_comp` are isomorphisms.
+-/
+noncomputable
+def mk_of_oplax' {F : oplax_functor B C} [oplax_functor.is_pseudo F] : pseudofunctor B C :=
+{ map_id := λ a, as_iso (F.map_id a),
+  map_comp := λ a b c f g, as_iso (F.map_comp f g),
+  map₂_whisker_right' := λ a b c f g η h, by
+  { dsimp,
+    rw [←assoc, is_iso.eq_comp_inv, F.map_comp_naturality_left] },
+  map₂_whisker_left' := λ a b c f g h η, by
+  { dsimp,
+    rw [←assoc, is_iso.eq_comp_inv, F.map_comp_naturality_right] },
+  map₂_associator' := λ a b c d f g h, by
+  { dsimp,
+    simp only [←assoc],
+    rw [is_iso.eq_comp_inv, ←inv_whisker_left, is_iso.eq_comp_inv],
+    simp only [assoc, F.map₂_associator] },
+  .. (F : prelax_functor B C) }
+
+end
+
+end pseudofunctor
 
 end
 

--- a/src/category_theory/bicategory/functor.lean
+++ b/src/category_theory/bicategory/functor.lean
@@ -219,6 +219,18 @@ def comp (F : oplax_functor B C) (G : oplax_functor C D) : oplax_functor B D :=
       whisker_left_comp, assoc] },
   .. (F : prelax_functor B C).comp ↑G }
 
+instance
+  (F : oplax_functor B C) [∀ {a b c : B} (f : a ⟶ b) (g : b ⟶ c), is_iso (F.map_comp f g)]
+  (G : oplax_functor C D) [∀ {a b c : C} (f : a ⟶ b) (g : b ⟶ c), is_iso (G.map_comp f g)]
+  {a b c : B} (f : a ⟶ b) (g : b ⟶ c) :
+  is_iso ((F.comp G).map_comp f g) := is_iso.comp_is_iso
+
+instance
+  (F : oplax_functor B C) [∀ a, is_iso (F.map_id a)]
+  (G : oplax_functor C D) [∀ a, is_iso (G.map_id a)]
+  (a : B) :
+  is_iso ((F.comp G).map_id a) := is_iso.comp_is_iso
+
 /--
 A structure on an oplax functor that promotes an oplax functors to a pseudofunctor.
 See `pseudofunctor.mk_of_oplax`.
@@ -402,6 +414,23 @@ def mk_of_oplax' (F : oplax_functor B C)
     rw [is_iso.eq_comp_inv, ←inv_whisker_left, is_iso.eq_comp_inv],
     simp only [assoc, F.map₂_associator] },
   .. (F : prelax_functor B C) }
+
+/-- Composition of pseudofunctors. -/
+@[simps]
+def comp' (F : pseudofunctor B C) (G : pseudofunctor C D) : pseudofunctor B D :=
+mk_of_oplax ((F : oplax_functor B C).comp G)
+{ map_id_iso := λ a, (G.map_functor _ _).map_iso (F.map_id a) ≪≫ G.map_id (F.obj a),
+  map_comp_iso := λ a b c f g,
+    (G.map_functor _ _).map_iso (F.map_comp f g) ≪≫ G.map_comp (F.map f) (F.map g) }
+
+instance (a : B) : is_iso ((F : oplax_functor B C).map_id a) := is_iso.of_iso (F.map_id a)
+instance {a b c : B} (f : a ⟶ b) (g : b ⟶ c) :
+  is_iso ((F : oplax_functor B C).map_comp f g) := is_iso.of_iso (F.map_comp f g)
+
+/-- Composition of pseudofunctors. -/
+@[simps] noncomputable
+def comp'' (F : pseudofunctor B C) (G : pseudofunctor C D) : pseudofunctor B D :=
+mk_of_oplax' ((F : oplax_functor B C).comp ↑G)
 
 end
 

--- a/src/category_theory/bicategory/functor.lean
+++ b/src/category_theory/bicategory/functor.lean
@@ -219,18 +219,6 @@ def comp (F : oplax_functor B C) (G : oplax_functor C D) : oplax_functor B D :=
       whisker_left_comp, assoc] },
   .. (F : prelax_functor B C).comp ↑G }
 
-instance
-  (F : oplax_functor B C) [∀ {a b c : B} (f : a ⟶ b) (g : b ⟶ c), is_iso (F.map_comp f g)]
-  (G : oplax_functor C D) [∀ {a b c : C} (f : a ⟶ b) (g : b ⟶ c), is_iso (G.map_comp f g)]
-  {a b c : B} (f : a ⟶ b) (g : b ⟶ c) :
-  is_iso ((F.comp G).map_comp f g) := is_iso.comp_is_iso
-
-instance
-  (F : oplax_functor B C) [∀ a, is_iso (F.map_id a)]
-  (G : oplax_functor C D) [∀ a, is_iso (G.map_id a)]
-  (a : B) :
-  is_iso ((F.comp G).map_id a) := is_iso.comp_is_iso
-
 /--
 A structure on an oplax functor that promotes an oplax functors to a pseudofunctor.
 See `pseudofunctor.mk_of_oplax`.
@@ -414,23 +402,6 @@ def mk_of_oplax' (F : oplax_functor B C)
     rw [is_iso.eq_comp_inv, ←inv_whisker_left, is_iso.eq_comp_inv],
     simp only [assoc, F.map₂_associator] },
   .. (F : prelax_functor B C) }
-
-/-- Composition of pseudofunctors. -/
-@[simps]
-def comp' (F : pseudofunctor B C) (G : pseudofunctor C D) : pseudofunctor B D :=
-mk_of_oplax ((F : oplax_functor B C).comp G)
-{ map_id_iso := λ a, (G.map_functor _ _).map_iso (F.map_id a) ≪≫ G.map_id (F.obj a),
-  map_comp_iso := λ a b c f g,
-    (G.map_functor _ _).map_iso (F.map_comp f g) ≪≫ G.map_comp (F.map f) (F.map g) }
-
-instance (a : B) : is_iso ((F : oplax_functor B C).map_id a) := is_iso.of_iso (F.map_id a)
-instance {a b c : B} (f : a ⟶ b) (g : b ⟶ c) :
-  is_iso ((F : oplax_functor B C).map_comp f g) := is_iso.of_iso (F.map_comp f g)
-
-/-- Composition of pseudofunctors. -/
-@[simps] noncomputable
-def comp'' (F : pseudofunctor B C) (G : pseudofunctor C D) : pseudofunctor B D :=
-mk_of_oplax' ((F : oplax_functor B C).comp ↑G)
 
 end
 

--- a/src/category_theory/bicategory/functor.lean
+++ b/src/category_theory/bicategory/functor.lean
@@ -466,11 +466,6 @@ end
 
 end pseudofunctor
 
-#check @pseudofunctor.mk
-
-#check @pseudofunctor.mk_of_oplax
-
-
 end
 
 end category_theory

--- a/src/category_theory/bicategory/functor.lean
+++ b/src/category_theory/bicategory/functor.lean
@@ -25,6 +25,23 @@ several constructors for pseudofunctors:
 * `pseudofunctor.mk_of_oplax'` : similar to `mk_of_oplax`, but uses `is_iso` to describe
   isomorphisms.
 
+The additional constructors are useful when constructing a pseudofunctor where the construction
+of the oplax functor associated with it is already done. For example, the composition of
+pseudofunctors can be defined by using the composition of oplax functors as follows:
+```lean
+def pseudofunctor.comp (F : pseudofunctor B C) (G : pseudofunctor C D) : pseudofunctor B D :=
+mk_of_oplax ((F : oplax_functor B C).comp G)
+{ map_id_iso := λ a, (G.map_functor _ _).map_iso (F.map_id a) ≪≫ G.map_id (F.obj a),
+  map_comp_iso := λ a b c f g,
+    (G.map_functor _ _).map_iso (F.map_comp f g) ≪≫ G.map_comp (F.map f) (F.map g) }
+```
+although the composition of pseudofunctors in this file is defined by using the default constructor
+because `obviously` is smart enough. Similarly, the composition is also defined by using
+`mk_of_oplax'` after giving appropriate instances for `is_iso`. The former constructor
+`mk_of_oplax` requires isomorphisms as data type `iso`, and so it is useful if you don't want
+to forget the definitions of the inverses. On the other hand, the latter constructor
+`mk_of_oplax'` is useful if you want to use propositional type class `is_iso`.
+
 ## Main definitions
 
 * `oplax_functor B C` : an oplax functor between bicategories `B` and `C`

--- a/src/category_theory/bicategory/functor.lean
+++ b/src/category_theory/bicategory/functor.lean
@@ -277,8 +277,7 @@ Functions between 2-morphisms strictly commute with compositions and preserve th
 They also preserve the associator, the left unitor, and the right unitor modulo some adjustments
 of domains and codomains of 2-morphisms.
 -/
-structure pseudofunctor (B : Type u₁) [bicategory.{w₁ v₁} B] (C : Type u₂) [bicategory.{w₂ v₂} C]
-  extends prelax_functor B C :=
+structure pseudofunctor extends prelax_functor B C :=
 (map_id (a : B) : map (𝟙 a) ≅ 𝟙 (obj a))
 (map_comp {a b c : B} (f : a ⟶ b) (g : b ⟶ c) : map (f ≫ g) ≅ map f ≫ map g)
 (map₂_whisker_right' : ∀ {a b c : B} {f g : a ⟶ b} (η : f ⟶ g) (h : b ⟶ c),
@@ -314,6 +313,8 @@ attribute [reassoc]
   pseudofunctor.map₂_left_unitor pseudofunctor.map₂_right_unitor
 attribute [simp]
   pseudofunctor.map₂_comp pseudofunctor.map₂_left_unitor pseudofunctor.map₂_right_unitor
+
+variables {B C}
 
 namespace pseudofunctor
 

--- a/src/category_theory/bicategory/functor.lean
+++ b/src/category_theory/bicategory/functor.lean
@@ -382,14 +382,14 @@ Construct a pseudofunctor from an oplax functor whose `map_id` and `map_comp` ar
 def mk_of_oplax (F : oplax_functor B C) (F' : F.pseudo_core) : pseudofunctor B C :=
 { map_id := F'.map_id_iso,
   map_comp := F'.map_comp_iso,
-  map₂_whisker_right' := λ a b c f g η h, by
-  { dsimp,
-    rw [F'.map_comp_iso_hom f h, ←F.map_comp_naturality_left_assoc,
-      ←F'.map_comp_iso_hom g h, hom_inv_id, comp_id] },
   map₂_whisker_left' := λ a b c f g h η, by
   { dsimp,
     rw [F'.map_comp_iso_hom f g, ←F.map_comp_naturality_right_assoc,
       ←F'.map_comp_iso_hom f h, hom_inv_id, comp_id] },
+  map₂_whisker_right' := λ a b c f g η h, by
+  { dsimp,
+    rw [F'.map_comp_iso_hom f h, ←F.map_comp_naturality_left_assoc,
+      ←F'.map_comp_iso_hom g h, hom_inv_id, comp_id] },
   map₂_associator' := λ a b c d f g h, by
   { dsimp,
     rw [F'.map_comp_iso_hom (f ≫ g) h, F'.map_comp_iso_hom f g, ←F.map₂_associator_assoc,
@@ -407,12 +407,12 @@ def mk_of_oplax' (F : oplax_functor B C)
   pseudofunctor B C :=
 { map_id := λ a, as_iso (F.map_id a),
   map_comp := λ a b c f g, as_iso (F.map_comp f g),
-  map₂_whisker_right' := λ a b c f g η h, by
-  { dsimp,
-    rw [←assoc, is_iso.eq_comp_inv, F.map_comp_naturality_left] },
   map₂_whisker_left' := λ a b c f g h η, by
   { dsimp,
     rw [←assoc, is_iso.eq_comp_inv, F.map_comp_naturality_right] },
+  map₂_whisker_right' := λ a b c f g η h, by
+  { dsimp,
+    rw [←assoc, is_iso.eq_comp_inv, F.map_comp_naturality_left] },
   map₂_associator' := λ a b c d f g h, by
   { dsimp,
     simp only [←assoc],

--- a/src/category_theory/bicategory/functor.lean
+++ b/src/category_theory/bicategory/functor.lean
@@ -274,7 +274,7 @@ map₂ (α_ f g h).hom = (map_comp (f ≫ g) h).hom ≫ ((map_comp f g).hom ▷ 
   (α_ (map f) (map g) (map h)).hom ≫ (map f ◁ (map_comp g h).inv) ≫ (map_comp f (g ≫ h)).inv
 
 /--
-A pseudofunctors `F` between bicategories `B` and `C` consists of functions between objects,
+A pseudofunctor `F` between bicategories `B` and `C` consists of functions between objects,
 1-morphisms, and 2-morphisms.
 
 Unlike functors between categories, functions between 1-morphisms do not need to strictly commute


### PR DESCRIPTION
This PR defines pseudofunctors between bicategories. 

We provide two constructors (`mk_of_oplax` and `mk_of_oplax'`) that construct pseudofunctors from oplax functors whose `map_id` and `map_comp` are isomorphisms. The constructor `mk_of_oplax` uses `iso` to describe isomorphisms, while `mk_of_oplax'` uses `is_iso`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
