### PR TITLE
[Merged by Bors] - feat(topology/order/lattice): add a consequence of the continuity of sup/inf

### DIFF
--- a/src/order/filter/basic.lean
+++ b/src/order/filter/basic.lean
@@ -2666,6 +2666,11 @@ lemma tendsto_prod_iff {f : α × β → γ} {x : filter α} {y : filter β} {z 
   ∀ W ∈ z, ∃ U ∈ x,  ∃ V ∈ y, ∀ x y, x ∈ U → y ∈ V → f (x, y) ∈ W :=
 by simp only [tendsto_def, mem_prod_iff, prod_sub_preimage_iff, exists_prop, iff_self]
 
+lemma tendsto_prod_iff' {f : filter α} {g : filter β} {g' : filter γ}
+  {s : α → β × γ} :
+  tendsto s f (g ×ᶠ g') ↔ tendsto (λ n, (s n).1) f g ∧ tendsto (λ n, (s n).2) f g' :=
+by { unfold filter.prod, simp only [tendsto_inf, tendsto_comap_iff, iff_self] }
+
 end prod
 
 /-! ### Coproducts of filters -/

--- a/src/topology/constructions.lean
+++ b/src/topology/constructions.lean
@@ -279,6 +279,11 @@ begin
     exact ⟨u, u_open.mem_nhds au, v, v_open.mem_nhds bv, huv⟩ }
 end
 
+lemma _root_.prod.tendsto_iff (seq : α → β × γ) {f : filter α} (x : β × γ) :
+  tendsto seq f (𝓝 x)
+    ↔ tendsto (λ n, (seq n).fst) f (𝓝 x.fst) ∧ tendsto (λ n, (seq n).snd) f (𝓝 x.snd) :=
+by { cases x, rw [nhds_prod_eq, filter.tendsto_prod_iff'], }
+
 lemma filter.has_basis.prod_nhds {ιa ιb : Type*} {pa : ιa → Prop} {pb : ιb → Prop}
   {sa : ιa → set α} {sb : ιb → set β} {a : α} {b : β} (ha : (𝓝 a).has_basis pa sa)
   (hb : (𝓝 b).has_basis pb sb) :

--- a/src/topology/constructions.lean
+++ b/src/topology/constructions.lean
@@ -279,7 +279,7 @@ begin
     exact ⟨u, u_open.mem_nhds au, v, v_open.mem_nhds bv, huv⟩ }
 end
 
-lemma _root_.prod.tendsto_iff (seq : α → β × γ) {f : filter α} (x : β × γ) :
+lemma _root_.prod.tendsto_iff {α} (seq : α → β × γ) {f : filter α} (x : β × γ) :
   tendsto seq f (𝓝 x)
     ↔ tendsto (λ n, (seq n).fst) f (𝓝 x.fst) ∧ tendsto (λ n, (seq n).snd) f (𝓝 x.snd) :=
 by { cases x, rw [nhds_prod_eq, filter.tendsto_prod_iff'], }

--- a/src/topology/order/lattice.lean
+++ b/src/topology/order/lattice.lean
@@ -82,3 +82,32 @@ has_continuous_sup.continuous_sup
   {f g : X → L} (hf : continuous f) (hg : continuous g) :
   continuous (λx, f x ⊔ g x) :=
 continuous_sup.comp (hf.prod_mk hg : _)
+
+open filter
+open_locale filter topological_space
+
+lemma filter.tendsto.sup_right {ι β} [preorder ι] [topological_space β] [has_sup β]
+  [has_continuous_sup β] {l : filter ι} {f g : ι → β} {x y : β}
+  (hf : tendsto f l (𝓝 x)) (hg : tendsto g l (𝓝 y)) :
+  tendsto (f ⊔ g) l (𝓝 (x ⊔ y)) :=
+begin
+  have h_prod_left : f ⊔ g = (λ p : β × β, (p.fst ⊔ p.snd : β)) ∘ (λ i, (f i, g i)) := rfl,
+  have h_prod_right : x ⊔ y = (λ p : β × β, p.fst ⊔ p.snd) (x, y) := rfl,
+  rw [h_prod_left, h_prod_right],
+  refine (continuous_sup.tendsto (x,y)).comp _,
+  rw prod.tendsto_iff,
+  exact ⟨hf, hg⟩,
+end
+
+lemma filter.tendsto.inf_right {ι β} [preorder ι] [topological_space β] [has_inf β]
+  [has_continuous_inf β] {l : filter ι} {f g : ι → β} {x y : β}
+  (hf : tendsto f l (𝓝 x)) (hg : tendsto g l (𝓝 y)) :
+  tendsto (f ⊓ g) l (𝓝 (x ⊓ y)) :=
+begin
+  have h_prod_left : f ⊓ g = (λ p : β × β, (p.fst ⊓ p.snd : β)) ∘ (λ i, (f i, g i)) := rfl,
+  have h_prod_right : x ⊓ y = (λ p : β × β, p.fst ⊓ p.snd) (x, y) := rfl,
+  rw [h_prod_left, h_prod_right],
+  refine (continuous_inf.tendsto (x,y)).comp _,
+  rw prod.tendsto_iff,
+  exact ⟨hf, hg⟩,
+end

--- a/src/topology/order/lattice.lean
+++ b/src/topology/order/lattice.lean
@@ -86,14 +86,26 @@ has_continuous_sup.continuous_sup
   continuous (λx, f x ⊔ g x) :=
 continuous_sup.comp (hf.prod_mk hg : _)
 
-lemma filter.tendsto.sup_right {ι β} [topological_space β] [has_sup β] [has_continuous_sup β]
+lemma filter.tendsto.sup_right_nhds' {ι β} [topological_space β] [has_sup β] [has_continuous_sup β]
   {l : filter ι} {f g : ι → β} {x y : β}
   (hf : tendsto f l (𝓝 x)) (hg : tendsto g l (𝓝 y)) :
   tendsto (f ⊔ g) l (𝓝 (x ⊔ y)) :=
 (continuous_sup.tendsto _).comp (tendsto.prod_mk_nhds hf hg)
 
-lemma filter.tendsto.inf_right {ι β} [topological_space β] [has_inf β] [has_continuous_inf β]
+lemma filter.tendsto.sup_right_nhds {ι β} [topological_space β] [has_sup β] [has_continuous_sup β]
+  {l : filter ι} {f g : ι → β} {x y : β}
+  (hf : tendsto f l (𝓝 x)) (hg : tendsto g l (𝓝 y)) :
+  tendsto (λ i, f i ⊔ g i) l (𝓝 (x ⊔ y)) :=
+hf.sup_right_nhds' hg
+
+lemma filter.tendsto.inf_right_nhds' {ι β} [topological_space β] [has_inf β] [has_continuous_inf β]
   {l : filter ι} {f g : ι → β} {x y : β}
   (hf : tendsto f l (𝓝 x)) (hg : tendsto g l (𝓝 y)) :
   tendsto (f ⊓ g) l (𝓝 (x ⊓ y)) :=
 (continuous_inf.tendsto _).comp (tendsto.prod_mk_nhds hf hg)
+
+lemma filter.tendsto.inf_right_nhds {ι β} [topological_space β] [has_inf β] [has_continuous_inf β]
+  {l : filter ι} {f g : ι → β} {x y : β}
+  (hf : tendsto f l (𝓝 x)) (hg : tendsto g l (𝓝 y)) :
+  tendsto (λ i, f i ⊓ g i) l (𝓝 (x ⊓ y)) :=
+hf.inf_right_nhds' hg

--- a/src/topology/order/lattice.lean
+++ b/src/topology/order/lattice.lean
@@ -22,6 +22,9 @@ and `has_continuous_sup`.
 topological, lattice
 -/
 
+open filter
+open_locale topological_space
+
 /--
 Let `L` be a topological space and let `L×L` be equipped with the product topology and let
 `⊓:L×L → L` be an infimum. Then `L` is said to have *(jointly) continuous infimum* if the map
@@ -83,11 +86,8 @@ has_continuous_sup.continuous_sup
   continuous (λx, f x ⊔ g x) :=
 continuous_sup.comp (hf.prod_mk hg : _)
 
-open filter
-open_locale filter topological_space
-
-lemma filter.tendsto.sup_right {ι β} [preorder ι] [topological_space β] [has_sup β]
-  [has_continuous_sup β] {l : filter ι} {f g : ι → β} {x y : β}
+lemma filter.tendsto.sup_right {ι β} [topological_space β] [has_sup β] [has_continuous_sup β]
+  {l : filter ι} {f g : ι → β} {x y : β}
   (hf : tendsto f l (𝓝 x)) (hg : tendsto g l (𝓝 y)) :
   tendsto (f ⊔ g) l (𝓝 (x ⊔ y)) :=
 begin
@@ -99,8 +99,8 @@ begin
   exact ⟨hf, hg⟩,
 end
 
-lemma filter.tendsto.inf_right {ι β} [preorder ι] [topological_space β] [has_inf β]
-  [has_continuous_inf β] {l : filter ι} {f g : ι → β} {x y : β}
+lemma filter.tendsto.inf_right {ι β} [topological_space β] [has_inf β] [has_continuous_inf β]
+  {l : filter ι} {f g : ι → β} {x y : β}
   (hf : tendsto f l (𝓝 x)) (hg : tendsto g l (𝓝 y)) :
   tendsto (f ⊓ g) l (𝓝 (x ⊓ y)) :=
 begin

--- a/src/topology/order/lattice.lean
+++ b/src/topology/order/lattice.lean
@@ -90,14 +90,7 @@ lemma filter.tendsto.sup_right {ι β} [topological_space β] [has_sup β] [has_
   {l : filter ι} {f g : ι → β} {x y : β}
   (hf : tendsto f l (𝓝 x)) (hg : tendsto g l (𝓝 y)) :
   tendsto (f ⊔ g) l (𝓝 (x ⊔ y)) :=
-begin
-  have h_prod_left : f ⊔ g = (λ p : β × β, (p.fst ⊔ p.snd : β)) ∘ (λ i, (f i, g i)) := rfl,
-  have h_prod_right : x ⊔ y = (λ p : β × β, p.fst ⊔ p.snd) (x, y) := rfl,
-  rw [h_prod_left, h_prod_right],
-  refine (continuous_sup.tendsto (x,y)).comp _,
-  rw prod.tendsto_iff,
-  exact ⟨hf, hg⟩,
-end
+(continuous_sup.tendsto _).comp (tendsto.prod_mk_nhds hf hg)
 
 lemma filter.tendsto.inf_right {ι β} [topological_space β] [has_inf β] [has_continuous_inf β]
   {l : filter ι} {f g : ι → β} {x y : β}

--- a/src/topology/order/lattice.lean
+++ b/src/topology/order/lattice.lean
@@ -103,11 +103,4 @@ lemma filter.tendsto.inf_right {ι β} [topological_space β] [has_inf β] [has_
   {l : filter ι} {f g : ι → β} {x y : β}
   (hf : tendsto f l (𝓝 x)) (hg : tendsto g l (𝓝 y)) :
   tendsto (f ⊓ g) l (𝓝 (x ⊓ y)) :=
-begin
-  have h_prod_left : f ⊓ g = (λ p : β × β, (p.fst ⊓ p.snd : β)) ∘ (λ i, (f i, g i)) := rfl,
-  have h_prod_right : x ⊓ y = (λ p : β × β, p.fst ⊓ p.snd) (x, y) := rfl,
-  rw [h_prod_left, h_prod_right],
-  refine (continuous_inf.tendsto (x,y)).comp _,
-  rw prod.tendsto_iff,
-  exact ⟨hf, hg⟩,
-end
+(continuous_inf.tendsto _).comp (tendsto.prod_mk_nhds hf hg)


### PR DESCRIPTION
Prove this lemma and its `inf` counterpart:
```lean
lemma filter.tendsto.sup_right_nhds {ι β} [topological_space β] [has_sup β] [has_continuous_sup β]
  {l : filter ι} {f g : ι → β} {x y : β} (hf : tendsto f l (𝓝 x)) (hg : tendsto g l (𝓝 y)) :
  tendsto (f ⊔ g) l (𝓝 (x ⊔ y))
```
The name is `sup_right_nhds` because `sup` already exists, and is about a supremum over the filters on the left in the tendsto.

The proofs of `tendsto_prod_iff'` and `prod.tendsto_iff` were written by  Patrick Massot.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
