### PR TITLE
[Merged by Bors] - chore(data/equiv/set): more lemmas about prod

### DIFF
--- a/src/data/equiv/set.lean
+++ b/src/data/equiv/set.lean
@@ -100,9 +100,29 @@ set.preimage_eq_iff_eq_image e.bijective
 lemma eq_preimage_iff_image_eq {α β} (e : α ≃ β) (s t) : s = e ⁻¹' t ↔ e '' s = t :=
 set.eq_preimage_iff_image_eq e.bijective
 
+lemma prod_comm_preimage {α β} {s : set α} {t : set β} :
+  equiv.prod_comm α β ⁻¹' (t ×ˢ s) = (s ×ˢ t) :=
+by { ext, simp [and_comm] }
+
+lemma prod_comm_image {α β γ} {s : set α} {t : set β} {u : set γ} :
+  equiv.prod_comm α β '' (s ×ˢ t) = (t ×ˢ s) :=
+by simpa only [equiv.image_eq_preimage] using prod_comm_preimage
+
 lemma prod_assoc_preimage {α β γ} {s : set α} {t : set β} {u : set γ} :
   equiv.prod_assoc α β γ ⁻¹' (s ×ˢ (t ×ˢ u)) = (s ×ˢ t) ×ˢ u :=
 by { ext, simp [and_assoc] }
+
+lemma prod_assoc_symm_preimage {α β γ} {s : set α} {t : set β} {u : set γ} :
+  (equiv.prod_assoc α β γ).symm ⁻¹' ((s ×ˢ t) ×ˢ u) = s ×ˢ (t ×ˢ u) :=
+by { ext, simp [and_assoc] }
+
+lemma prod_assoc_image {α β γ} {s : set α} {t : set β} {u : set γ} :
+  equiv.prod_assoc α β γ '' ((s ×ˢ t) ×ˢ u) = s ×ˢ (t ×ˢ u) :=
+by simpa only [equiv.image_eq_preimage] using prod_assoc_symm_preimage
+
+lemma prod_assoc_symm_image {α β γ} {s : set α} {t : set β} {u : set γ} :
+  (equiv.prod_assoc α β γ).symm '' (s ×ˢ (t ×ˢ u)) = (s ×ˢ t) ×ˢ u :=
+by simpa only [equiv.image_eq_preimage] using prod_assoc_preimage
 
 /-- A set `s` in `α × β` is equivalent to the sigma-type `Σ x, {y | (x, y) ∈ s}`. -/
 def set_prod_equiv_sigma {α β : Type*} (s : set (α × β)) :

--- a/src/data/equiv/set.lean
+++ b/src/data/equiv/set.lean
@@ -100,21 +100,26 @@ set.preimage_eq_iff_eq_image e.bijective
 lemma eq_preimage_iff_image_eq {α β} (e : α ≃ β) (s t) : s = e ⁻¹' t ↔ e '' s = t :=
 set.eq_preimage_iff_image_eq e.bijective
 
-lemma prod_comm_preimage {α β} {s : set α} {t : set β} :
+@[simp] lemma prod_comm_preimage {α β} {s : set α} {t : set β} :
   equiv.prod_comm α β ⁻¹' (t ×ˢ s) = (s ×ˢ t) :=
 set.preimage_swap_prod
 
-lemma prod_comm_image {α β γ} {s : set α} {t : set β} {u : set γ} :
+lemma prod_comm_image {α β} {s : set α} {t : set β} :
   equiv.prod_comm α β '' (s ×ˢ t) = (t ×ˢ s) :=
 set.image_swap_prod
 
+@[simp]
 lemma prod_assoc_preimage {α β γ} {s : set α} {t : set β} {u : set γ} :
   equiv.prod_assoc α β γ ⁻¹' (s ×ˢ (t ×ˢ u)) = (s ×ˢ t) ×ˢ u :=
 by { ext, simp [and_assoc] }
 
+@[simp]
 lemma prod_assoc_symm_preimage {α β γ} {s : set α} {t : set β} {u : set γ} :
   (equiv.prod_assoc α β γ).symm ⁻¹' ((s ×ˢ t) ×ˢ u) = s ×ˢ (t ×ˢ u) :=
 by { ext, simp [and_assoc] }
+
+-- `@[simp]` doesn't like these lemmas, as it uses `set.image_congr'` to turn `equiv.prod_assoc`
+-- into a lambda expression and then unfold it.
 
 lemma prod_assoc_image {α β γ} {s : set α} {t : set β} {u : set γ} :
   equiv.prod_assoc α β γ '' ((s ×ˢ t) ×ˢ u) = s ×ˢ (t ×ˢ u) :=

--- a/src/data/equiv/set.lean
+++ b/src/data/equiv/set.lean
@@ -102,11 +102,11 @@ set.eq_preimage_iff_image_eq e.bijective
 
 lemma prod_comm_preimage {α β} {s : set α} {t : set β} :
   equiv.prod_comm α β ⁻¹' (t ×ˢ s) = (s ×ˢ t) :=
-by { ext, simp [and_comm] }
+set.preimage_swap_prod
 
 lemma prod_comm_image {α β γ} {s : set α} {t : set β} {u : set γ} :
   equiv.prod_comm α β '' (s ×ˢ t) = (t ×ˢ s) :=
-by simpa only [equiv.image_eq_preimage] using prod_comm_preimage
+set.image_swap_prod
 
 lemma prod_assoc_preimage {α β γ} {s : set α} {t : set β} {u : set γ} :
   equiv.prod_assoc α β γ ⁻¹' (s ×ˢ (t ×ˢ u)) = (s ×ˢ t) ×ˢ u :=


### PR DESCRIPTION
Note we don't need the `symm` lemmas for `prod.comm`, since `prod.comm` is involutive



---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
