### PR TITLE
[Merged by Bors] - refactor(category_theory/eq_to_hom): conjugation by eq_to_hom same as heq

### DIFF
--- a/src/category_theory/eq_to_hom.lean
+++ b/src/category_theory/eq_to_hom.lean
@@ -120,17 +120,19 @@ begin
   simpa using h_map X Y f
 end
 
+/-- Maps under functors are equal up to conjugation if and only if they are heterogeneously equal -/
+lemma map_conj_eq_to_hom_iff_map_heq {F G : C ⥤ D} {x y : C} (f : x ⟶ y)
+  (hx : F.obj x = G.obj x) (hy : F.obj y = G.obj y) :
+  F.map f = eq_to_hom hx ≫ G.map f ≫ eq_to_hom hy.symm ↔ F.map f == G.map f :=
+by { generalize : F.map f = Ff, generalize : G.map f = Gf, clear f,
+  generalize_hyp : F.obj x = F₁ at hx Ff ⊢,
+  generalize_hyp : F.obj y = F₂ at hy Ff ⊢, cases hx, cases hy, simp }
+
 /-- Proving equality between functors using heterogeneous equality. -/
 lemma hext {F G : C ⥤ D} (h_obj : ∀ X, F.obj X = G.obj X)
   (h_map : ∀ X Y (f : X ⟶ Y), F.map f == G.map f) : F = G :=
-begin
-  cases F with F_obj _ _ _, cases G with G_obj _ _ _,
-  have : F_obj = G_obj, by ext X; apply h_obj,
-  subst this,
-  congr,
-  funext X Y f,
-  exact eq_of_heq (h_map X Y f)
-end
+functor.ext h_obj (λ _ _ f,
+  (map_conj_eq_to_hom_iff_map_heq f (h_obj _) (h_obj _)).2 $ h_map _ _ f)
 
 -- Using equalities between functors.
 

--- a/src/category_theory/eq_to_hom.lean
+++ b/src/category_theory/eq_to_hom.lean
@@ -24,7 +24,8 @@ This file introduces various `simp` lemmas which in favourable circumstances
 result in the various `eq_to_hom` morphisms to drop out at the appropriate moment!
 -/
 
-universes v₁ v₂ v₃ u₁ u₂ u₃-- morphism levels before object levels. See note [category_theory universes].
+universes v₁ v₂ v₃ u₁ u₂ u₃
+-- morphism levels before object levels. See note [category_theory universes].
 
 namespace category_theory
 open opposite

--- a/src/category_theory/eq_to_hom.lean
+++ b/src/category_theory/eq_to_hom.lean
@@ -144,9 +144,7 @@ section heq
 
 /- Composition of functors and maps w.r.t. heq -/
 
-variables
-  {E : Type u₁} [category.{v₁} E]
-  {F G : C ⥤ D} {x y z : C} {f : x ⟶ y} {g : y ⟶ z}
+variables {E : Type u₃} [category.{v₃} E] {F G : C ⥤ D} {X Y Z : C} {f : X ⟶ Y} {g : Y ⟶ Z}
 
 lemma map_comp_heq (hx : F.obj x = G.obj x) (hy : F.obj y = G.obj y) (hz : F.obj z = G.obj z)
   (hf : F.map f == G.map f) (hg : F.map g == G.map g) : F.map (f ≫ g) == G.map (f ≫ g) :=

--- a/src/category_theory/eq_to_hom.lean
+++ b/src/category_theory/eq_to_hom.lean
@@ -143,6 +143,43 @@ lemma congr_hom {F G : C ⥤ D} (h : F = G) {X Y} (f : X ⟶ Y) :
   F.map f = eq_to_hom (congr_obj h X) ≫ G.map f ≫ eq_to_hom (congr_obj h Y).symm :=
 by subst h; simp
 
+
+section heq
+
+/- Composition of functors and maps w.r.t. heq -/
+
+variables
+  {E : Type u₁} [category.{v₁} E]
+  {F G : C ⥤ D} {x y z : C} {f : x ⟶ y} {g : y ⟶ z}
+
+lemma map_comp_heq (hx : F.obj x = G.obj x) (hy : F.obj y = G.obj y) (hz : F.obj z = G.obj z)
+  (hf : F.map f == G.map f) (hg : F.map g == G.map g) : F.map (f ≫ g) == G.map (f ≫ g) :=
+by { rw [F.map_comp, G.map_comp], congr' }
+
+lemma map_comp_heq' (hobj : ∀ x : C, F.obj x = G.obj x)
+  (hmap : ∀ {x y} (f : x ⟶ y), F.map f == G.map f) :
+  F.map (f ≫ g) == G.map (f ≫ g) :=
+by rw functor.hext hobj (λ _ _, hmap)
+
+lemma precomp_map_heq (H : E ⥤ C)
+  (hmap : ∀ {x y} (f : x ⟶ y), F.map f == G.map f) {x y : E} (f : x ⟶ y) :
+  (H ⋙ F).map f == (H ⋙ G).map f := hmap _
+
+lemma comp_map_heq (H : D ⥤ E) (hx : F.obj x = G.obj x) (hy : F.obj y = G.obj y)
+  (hmap : F.map f == G.map f) : (F ⋙ H).map f == (G ⋙ H).map f :=
+by { dsimp, congr' }
+
+lemma comp_map_heq' (H : D ⥤ E) (hobj : ∀ x : C, F.obj x = G.obj x)
+  (hmap : ∀ {x y} (f : x ⟶ y), F.map f == G.map f) :
+  (F ⋙ H).map f == (G ⋙ H).map f :=
+by rw functor.hext hobj (λ _ _, hmap)
+
+lemma hcongr_hom {F G : C ⥤ D} (h : F = G) {X Y} (f : X ⟶ Y) :
+  F.map f == G.map f :=
+by subst h; simp
+
+end heq
+
 end functor
 
 @[simp] lemma eq_to_hom_map (F : C ⥤ D) {X Y : C} (p : X = Y) :

--- a/src/category_theory/eq_to_hom.lean
+++ b/src/category_theory/eq_to_hom.lean
@@ -170,8 +170,7 @@ lemma comp_map_heq' (H : D ⥤ E) (hobj : ∀ x : C, F.obj x = G.obj x)
   (F ⋙ H).map f == (G ⋙ H).map f :=
 by rw functor.hext hobj (λ _ _, hmap)
 
-lemma hcongr_hom {F G : C ⥤ D} (h : F = G) {X Y} (f : X ⟶ Y) :
-  F.map f == G.map f :=
+lemma hcongr_hom {F G : C ⥤ D} (h : F = G) {X Y} (f : X ⟶ Y) : F.map f == G.map f :=
 by subst h; simp
 
 end heq

--- a/src/category_theory/eq_to_hom.lean
+++ b/src/category_theory/eq_to_hom.lean
@@ -129,7 +129,7 @@ by { cases h, cases h', simp }
 lemma hext {F G : C ⥤ D} (h_obj : ∀ X, F.obj X = G.obj X)
   (h_map : ∀ X Y (f : X ⟶ Y), F.map f == G.map f) : F = G :=
 functor.ext h_obj (λ _ _ f,
-  (map_conj_eq_to_hom_iff_map_heq f (h_obj _) (h_obj _)).2 $ h_map _ _ f)
+  (conj_eq_to_hom_iff_heq _ _ (h_obj _) (h_obj _)).2 $ h_map _ _ f)
 
 -- Using equalities between functors.
 

--- a/src/category_theory/eq_to_hom.lean
+++ b/src/category_theory/eq_to_hom.lean
@@ -165,7 +165,7 @@ lemma postcomp_map_heq (H : D ⥤ E) (hx : F.obj x = G.obj x) (hy : F.obj y = G.
   (hmap : F.map f == G.map f) : (F ⋙ H).map f == (G ⋙ H).map f :=
 by { dsimp, congr' }
 
-lemma comp_map_heq' (H : D ⥤ E) (hobj : ∀ x : C, F.obj x = G.obj x)
+lemma postcomp_map_heq' (H : D ⥤ E) (hobj : ∀ x : C, F.obj x = G.obj x)
   (hmap : ∀ {x y} (f : x ⟶ y), F.map f == G.map f) :
   (F ⋙ H).map f == (G ⋙ H).map f :=
 by rw functor.hext hobj (λ _ _, hmap)

--- a/src/category_theory/eq_to_hom.lean
+++ b/src/category_theory/eq_to_hom.lean
@@ -24,7 +24,7 @@ This file introduces various `simp` lemmas which in favourable circumstances
 result in the various `eq_to_hom` morphisms to drop out at the appropriate moment!
 -/
 
-universes v₁ v₂ u₁ u₂ -- morphism levels before object levels. See note [category_theory universes].
+universes v₁ v₂ v₃ u₁ u₂ u₃-- morphism levels before object levels. See note [category_theory universes].
 
 namespace category_theory
 open opposite

--- a/src/category_theory/eq_to_hom.lean
+++ b/src/category_theory/eq_to_hom.lean
@@ -161,7 +161,7 @@ lemma precomp_map_heq (H : E ⥤ C)
   (hmap : ∀ {x y} (f : x ⟶ y), F.map f == G.map f) {x y : E} (f : x ⟶ y) :
   (H ⋙ F).map f == (H ⋙ G).map f := hmap _
 
-lemma comp_map_heq (H : D ⥤ E) (hx : F.obj x = G.obj x) (hy : F.obj y = G.obj y)
+lemma postcomp_map_heq (H : D ⥤ E) (hx : F.obj x = G.obj x) (hy : F.obj y = G.obj y)
   (hmap : F.map f == G.map f) : (F ⋙ H).map f == (G ⋙ H).map f :=
 by { dsimp, congr' }
 

--- a/src/category_theory/eq_to_hom.lean
+++ b/src/category_theory/eq_to_hom.lean
@@ -146,25 +146,25 @@ section heq
 
 variables {E : Type u₃} [category.{v₃} E] {F G : C ⥤ D} {X Y Z : C} {f : X ⟶ Y} {g : Y ⟶ Z}
 
-lemma map_comp_heq (hx : F.obj x = G.obj x) (hy : F.obj y = G.obj y) (hz : F.obj z = G.obj z)
+lemma map_comp_heq (hx : F.obj X = G.obj X) (hy : F.obj Y = G.obj Y) (hz : F.obj Z = G.obj Z)
   (hf : F.map f == G.map f) (hg : F.map g == G.map g) : F.map (f ≫ g) == G.map (f ≫ g) :=
 by { rw [F.map_comp, G.map_comp], congr' }
 
-lemma map_comp_heq' (hobj : ∀ x : C, F.obj x = G.obj x)
-  (hmap : ∀ {x y} (f : x ⟶ y), F.map f == G.map f) :
+lemma map_comp_heq' (hobj : ∀ X : C, F.obj X = G.obj X)
+  (hmap : ∀ {X Y} (f : X ⟶ Y), F.map f == G.map f) :
   F.map (f ≫ g) == G.map (f ≫ g) :=
 by rw functor.hext hobj (λ _ _, hmap)
 
 lemma precomp_map_heq (H : E ⥤ C)
-  (hmap : ∀ {x y} (f : x ⟶ y), F.map f == G.map f) {x y : E} (f : x ⟶ y) :
+  (hmap : ∀ {X Y} (f : X ⟶ Y), F.map f == G.map f) {X Y : E} (f : X ⟶ Y) :
   (H ⋙ F).map f == (H ⋙ G).map f := hmap _
 
-lemma postcomp_map_heq (H : D ⥤ E) (hx : F.obj x = G.obj x) (hy : F.obj y = G.obj y)
+lemma postcomp_map_heq (H : D ⥤ E) (hx : F.obj X = G.obj X) (hy : F.obj Y = G.obj Y)
   (hmap : F.map f == G.map f) : (F ⋙ H).map f == (G ⋙ H).map f :=
 by { dsimp, congr' }
 
-lemma postcomp_map_heq' (H : D ⥤ E) (hobj : ∀ x : C, F.obj x = G.obj x)
-  (hmap : ∀ {x y} (f : x ⟶ y), F.map f == G.map f) :
+lemma postcomp_map_heq' (H : D ⥤ E) (hobj : ∀ X : C, F.obj X = G.obj X)
+  (hmap : ∀ {X Y} (f : X ⟶ Y), F.map f == G.map f) :
   (F ⋙ H).map f == (G ⋙ H).map f :=
 by rw functor.hext hobj (λ _ _, hmap)
 

--- a/src/category_theory/eq_to_hom.lean
+++ b/src/category_theory/eq_to_hom.lean
@@ -120,13 +120,10 @@ begin
   simpa using h_map X Y f
 end
 
-/-- Maps under functors are equal up to conjugation if and only if they are heterogeneously equal -/
-lemma map_conj_eq_to_hom_iff_map_heq {F G : C ⥤ D} {x y : C} (f : x ⟶ y)
-  (hx : F.obj x = G.obj x) (hy : F.obj y = G.obj y) :
-  F.map f = eq_to_hom hx ≫ G.map f ≫ eq_to_hom hy.symm ↔ F.map f == G.map f :=
-by { generalize : F.map f = Ff, generalize : G.map f = Gf, clear f,
-  generalize_hyp : F.obj x = F₁ at hx Ff ⊢,
-  generalize_hyp : F.obj y = F₂ at hy Ff ⊢, cases hx, cases hy, simp }
+/-- Two morphisms are conjugate via eq_to_hom if and only if they are heterogeneously equal. --/
+lemma conj_eq_to_hom_iff_heq {W X Y Z : C} (f : W ⟶ X) (g : Y ⟶ Z) (h : W = Y) (h' : X = Z) :
+  f = eq_to_hom h ≫ g ≫ eq_to_hom h'.symm ↔ f == g :=
+by { cases h, cases h', simp }
 
 /-- Proving equality between functors using heterogeneous equality. -/
 lemma hext {F G : C ⥤ D} (h_obj : ∀ X, F.obj X = G.obj X)

--- a/src/category_theory/eq_to_hom.lean
+++ b/src/category_theory/eq_to_hom.lean
@@ -140,7 +140,6 @@ lemma congr_hom {F G : C ⥤ D} (h : F = G) {X Y} (f : X ⟶ Y) :
   F.map f = eq_to_hom (congr_obj h X) ≫ G.map f ≫ eq_to_hom (congr_obj h Y).symm :=
 by subst h; simp
 
-
 section heq
 
 /- Composition of functors and maps w.r.t. heq -/

--- a/src/category_theory/eq_to_hom.lean
+++ b/src/category_theory/eq_to_hom.lean
@@ -171,7 +171,7 @@ lemma postcomp_map_heq' (H : D ⥤ E) (hobj : ∀ x : C, F.obj x = G.obj x)
 by rw functor.hext hobj (λ _ _, hmap)
 
 lemma hcongr_hom {F G : C ⥤ D} (h : F = G) {X Y} (f : X ⟶ Y) : F.map f == G.map f :=
-by subst h; simp
+by subst h
 
 end heq
 

--- a/src/category_theory/functor.lean
+++ b/src/category_theory/functor.lean
@@ -106,6 +106,12 @@ by { split_ifs; refl, }
 
 end
 
+section heq
+
+
+
+end heq
+
 end functor
 
 end category_theory

--- a/src/category_theory/functor.lean
+++ b/src/category_theory/functor.lean
@@ -106,12 +106,6 @@ by { split_ifs; refl, }
 
 end
 
-section heq
-
-
-
-end heq
-
 end functor
 
 end category_theory


### PR DESCRIPTION
Xu Junyan provided this lemma for showing that `heq` gives the same as conjugation by `eq_to_hom` for equality of functor maps. I refactored `hext` using this result.

Then I added a bunch of lemmas for how `heq` interacts with composition of functors and `functor.map` applied to composition of morphisms