### PR TITLE
[Merged by Bors] - feat(data/list/big_operators): add `list.prod_map_mul`

### DIFF
--- a/src/data/list/big_operators.lean
+++ b/src/data/list/big_operators.lean
@@ -68,6 +68,11 @@ begin
   { exact hf _ _ _ _ }
 end
 
+@[simp, to_additive]
+lemma prod_map_mul {α : Type*} [comm_monoid α] {l : list ι} {f g : ι → α} :
+  (l.map $ λ i, f i * g i).prod = (l.map f).prod * (l.map g).prod :=
+l.prod_hom₂ (*) mul_mul_mul_comm (mul_one _) _ _
+
 @[to_additive]
 lemma prod_map_hom (L : list ι) (f : ι → M) (g : M →* N) :
   (L.map (g ∘ f)).prod = g ((L.map f).prod) :=


### PR DESCRIPTION
This is an analogue of the corresponding lemma `multiset.prod_map_mul`.



---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
