### PR TITLE
[Merged by Bors] - refactor(topology/compacts): Turn into structures, use `set_like`, cleanup

### DIFF
--- a/src/analysis/fourier.lean
+++ b/src/analysis/fourier.lean
@@ -67,7 +67,7 @@ instance : borel_space circle := ⟨rfl⟩
 
 /-- Haar measure on the circle, normalized to have total measure 1. -/
 @[derive is_haar_measure]
-def haar_circle : measure circle := haar_measure positive_compacts_univ
+def haar_circle : measure circle := haar_measure ⊤
 
 instance : is_probability_measure haar_circle := ⟨haar_measure_self⟩
 

--- a/src/measure_theory/measure/content.lean
+++ b/src/measure_theory/measure/content.lean
@@ -158,13 +158,13 @@ begin
     { intros n s hn ih, rw [finset.sup_insert, finset.sum_insert hn],
       exact le_trans (μ.sup_le _ _) (add_le_add_left ih _) }},
   refine bsupr_le (λ K hK, _),
-  rcases is_compact.elim_finite_subcover K.2 _ (λ i, (U i).prop) _ with ⟨t, ht⟩, swap,
+  obtain ⟨t, ht⟩ := K.compact.elim_finite_subcover  _ (λ i, (U i).prop) _, swap,
   { convert hK, rw [opens.supr_def, subtype.coe_mk] },
-  rcases K.2.finite_compact_cover t (coe ∘ U) (λ i _, (U _).prop) (by simp only [ht])
+  rcases K.compact.finite_compact_cover t (coe ∘ U) (λ i _, (U _).prop) (by simp only [ht])
     with ⟨K', h1K', h2K', h3K'⟩,
   let L : ℕ → compacts G := λ n, ⟨K' n, h1K' n⟩,
   convert le_trans (h3 t L) _,
-  { ext1, simp only [h3K', compacts.coe_finset_sup, finset.sup_eq_supr, set.supr_eq_Union] },
+  { ext1, rw [compacts.coe_finset_sup, finset.sup_eq_supr], exact h3K' },
   refine le_trans (finset.sum_le_sum _) (ennreal.sum_le_tsum t),
   intros i hi, refine le_trans _ (le_supr _ (L i)),
   refine le_trans _ (le_supr _ (h2K' i)), refl'

--- a/src/measure_theory/measure/content.lean
+++ b/src/measure_theory/measure/content.lean
@@ -62,8 +62,8 @@ variables {G : Type w} [topological_space G]
 from which one can define a measure. -/
 structure content (G : Type w) [topological_space G] :=
 (to_fun : compacts G → ℝ≥0)
-(mono' : ∀ (K₁ K₂ : compacts G), K₁.1 ⊆ K₂.1 → to_fun K₁ ≤ to_fun K₂)
-(sup_disjoint' : ∀ (K₁ K₂ : compacts G), disjoint K₁.1 K₂.1 →
+(mono' : ∀ (K₁ K₂ : compacts G), (K₁ : set G) ⊆ K₂ → to_fun K₁ ≤ to_fun K₂)
+(sup_disjoint' : ∀ (K₁ K₂ : compacts G), disjoint (K₁ : set G) K₂ →
    to_fun (K₁ ⊔ K₂) = to_fun K₁ + to_fun K₂)
 (sup_le' : ∀ (K₁ K₂ : compacts G), to_fun (K₁ ⊔ K₂) ≤ to_fun K₁ + to_fun K₂)
 
@@ -84,10 +84,11 @@ variable (μ : content G)
 
 lemma apply_eq_coe_to_fun (K : compacts G) : μ K = μ.to_fun K := rfl
 
-lemma mono (K₁ K₂ : compacts G) (h : K₁.1 ⊆ K₂.1) : μ K₁ ≤ μ K₂ :=
+lemma mono (K₁ K₂ : compacts G) (h : (K₁ : set G) ⊆ K₂) : μ K₁ ≤ μ K₂ :=
 by simp [apply_eq_coe_to_fun, μ.mono' _ _ h]
 
-lemma sup_disjoint (K₁ K₂ : compacts G) (h : disjoint K₁.1 K₂.1) : μ (K₁ ⊔ K₂) = μ K₁ + μ K₂ :=
+lemma sup_disjoint (K₁ K₂ : compacts G) (h : disjoint (K₁ : set G) K₂) :
+  μ (K₁ ⊔ K₂) = μ K₁ + μ K₂ :=
 by simp [apply_eq_coe_to_fun, μ.sup_disjoint' _ _ h]
 
 lemma sup_le (K₁ K₂ : compacts G) : μ (K₁ ⊔ K₂) ≤ μ K₁ + μ K₂ :=
@@ -105,14 +106,13 @@ end
 /-- Constructing the inner content of a content. From a content defined on the compact sets, we
   obtain a function defined on all open sets, by taking the supremum of the content of all compact
   subsets. -/
-def inner_content (U : opens G) : ℝ≥0∞ :=
-⨆ (K : compacts G) (h : K.1 ⊆ U), μ K
+def inner_content (U : opens G) : ℝ≥0∞ := ⨆ (K : compacts G) (h : (K : set G) ⊆ U), μ K
 
-lemma le_inner_content (K : compacts G) (U : opens G)
-  (h2 : K.1 ⊆ U) : μ K ≤ μ.inner_content U :=
+lemma le_inner_content (K : compacts G) (U : opens G) (h2 : (K : set G) ⊆ U) :
+  μ K ≤ μ.inner_content U :=
 le_supr_of_le K $ le_supr _ h2
 
-lemma inner_content_le (U : opens G) (K : compacts G) (h2 : (U : set G) ⊆ K.1) :
+lemma inner_content_le (U : opens G) (K : compacts G) (h2 : (U : set G) ⊆ K) :
   μ.inner_content U ≤ μ K :=
 bsupr_le $ λ K' hK', μ.mono _ _ (subset.trans hK' h2)
 
@@ -126,7 +126,7 @@ lemma inner_content_empty :
 begin
   refine le_antisymm _ (zero_le _), rw ←μ.empty,
   refine bsupr_le (λ K hK, _),
-  have : K = ⊥, { ext1, rw [subset_empty_iff.mp hK, compacts.bot_val] }, rw this, refl'
+  have : K = ⊥, { ext1, rw [subset_empty_iff.mp hK, compacts.coe_bot] }, rw this, refl'
 end
 
 /-- This is "unbundled", because that it required for the API of `induced_outer_measure`. -/
@@ -136,7 +136,7 @@ supr_le_supr $ λ K, supr_le_supr_const $ λ hK, subset.trans hK h2
 
 lemma inner_content_exists_compact {U : opens G}
   (hU : μ.inner_content U ≠ ∞) {ε : ℝ≥0} (hε : ε ≠ 0) :
-  ∃ K : compacts G, K.1 ⊆ U ∧ μ.inner_content U ≤ μ K + ε :=
+  ∃ K : compacts G, (K : set G) ⊆ U ∧ μ.inner_content U ≤ μ K + ε :=
 begin
   have h'ε := ennreal.coe_ne_zero.2 hε,
   cases le_or_lt (μ.inner_content U) ε,
@@ -164,7 +164,7 @@ begin
     with ⟨K', h1K', h2K', h3K'⟩,
   let L : ℕ → compacts G := λ n, ⟨K' n, h1K' n⟩,
   convert le_trans (h3 t L) _,
-  { ext1, simp only [h3K', compacts.finset_sup_val, finset.sup_eq_supr, set.supr_eq_Union] },
+  { ext1, simp only [h3K', compacts.coe_finset_sup, finset.sup_eq_supr, set.supr_eq_Union] },
   refine le_trans (finset.sum_le_sum _) (ennreal.sum_le_tsum t),
   intros i hi, refine le_trans _ (le_supr _ (L i)),
   refine le_trans _ (le_supr _ (h2K' i)), refl'
@@ -204,7 +204,7 @@ begin
   rcases compact_covered_by_mul_left_translates K.2 this with ⟨s, hs⟩,
   suffices : μ K ≤ s.card * μ.inner_content U,
   { exact (ennreal.mul_pos_iff.mp $ hK.bot_lt.trans_le this).2 },
-  have : K.1 ⊆ ↑⨆ (g ∈ s), opens.comap (homeomorph.mul_left g).to_continuous_map U,
+  have : (K : set G) ⊆ ↑⨆ (g ∈ s), opens.comap (homeomorph.mul_left g).to_continuous_map U,
   { simpa only [opens.supr_def, opens.coe_comap, subtype.coe_mk] },
   refine (μ.le_inner_content _ _ this).trans _,
   refine (rel_supr_sum (μ.inner_content) (μ.inner_content_empty) (≤)
@@ -231,10 +231,10 @@ lemma outer_measure_of_is_open (U : set G) (hU : is_open U) :
 μ.outer_measure_opens ⟨U, hU⟩
 
 lemma outer_measure_le
-  (U : opens G) (K : compacts G) (hUK : (U : set G) ⊆ K.1) : μ.outer_measure U ≤ μ K :=
+  (U : opens G) (K : compacts G) (hUK : (U : set G) ⊆ K) : μ.outer_measure U ≤ μ K :=
 (μ.outer_measure_opens U).le.trans $ μ.inner_content_le U K hUK
 
-lemma le_outer_measure_compacts (K : compacts G) : μ K ≤ μ.outer_measure K.1 :=
+lemma le_outer_measure_compacts (K : compacts G) : μ K ≤ μ.outer_measure K :=
 begin
   rw [content.outer_measure, induced_outer_measure_eq_infi],
   { exact le_infi (λ U, le_infi $ λ hU, le_infi $ μ.le_inner_content K ⟨U, hU⟩) },
@@ -246,12 +246,11 @@ lemma outer_measure_eq_infi (A : set G) :
   μ.outer_measure A = ⨅ (U : set G) (hU : is_open U) (h : A ⊆ U), μ.inner_content ⟨U, hU⟩ :=
 induced_outer_measure_eq_infi _ μ.inner_content_Union_nat μ.inner_content_mono A
 
-lemma outer_measure_interior_compacts (K : compacts G) : μ.outer_measure (interior K.1) ≤ μ K :=
-le_trans (le_of_eq $ μ.outer_measure_opens (opens.interior K.1))
-         (μ.inner_content_le _ _ interior_subset)
+lemma outer_measure_interior_compacts (K : compacts G) : μ.outer_measure (interior K) ≤ μ K :=
+(μ.outer_measure_opens $ opens.interior K).le.trans $ μ.inner_content_le _ _ interior_subset
 
 lemma outer_measure_exists_compact {U : opens G} (hU : μ.outer_measure U ≠ ∞) {ε : ℝ≥0}
-  (hε : ε ≠ 0) : ∃ K : compacts G, K.1 ⊆ U ∧ μ.outer_measure U ≤ μ.outer_measure K.1 + ε :=
+  (hε : ε ≠ 0) : ∃ K : compacts G, (K : set G) ⊆ U ∧ μ.outer_measure U ≤ μ.outer_measure K + ε :=
 begin
   rw [μ.outer_measure_opens] at hU ⊢,
   rcases μ.inner_content_exists_compact hU hε with ⟨K, h1K, h2K⟩,
@@ -322,17 +321,17 @@ begin
   intro U',
   rw μ.outer_measure_of_is_open ((U' : set G) ∩ U) (is_open.inter U'.prop hU),
   simp only [inner_content, supr_subtype'], rw [opens.coe_mk],
-  haveI : nonempty {L : compacts G // L.1 ⊆ U' ∩ U} := ⟨⟨⊥, empty_subset _⟩⟩,
+  haveI : nonempty {L : compacts G // (L : set G) ⊆ U' ∩ U} := ⟨⟨⊥, empty_subset _⟩⟩,
   rw [ennreal.supr_add],
   refine supr_le _, rintro ⟨L, hL⟩, simp only [subset_inter_iff] at hL,
-  have : ↑U' \ U ⊆ U' \ L.1 := diff_subset_diff_right hL.2,
+  have : ↑U' \ U ⊆ U' \ L := diff_subset_diff_right hL.2,
   refine le_trans (add_le_add_left (μ.outer_measure.mono' this) _) _,
-  rw μ.outer_measure_of_is_open (↑U' \ L.1) (is_open.sdiff U'.2 L.2.is_closed),
+  rw μ.outer_measure_of_is_open (↑U' \ L) (is_open.sdiff U'.2 L.2.is_closed),
   simp only [inner_content, supr_subtype'], rw [opens.coe_mk],
-  haveI : nonempty {M : compacts G // M.1 ⊆ ↑U' \ L.1} := ⟨⟨⊥, empty_subset _⟩⟩,
+  haveI : nonempty {M : compacts G // (M : set G) ⊆ ↑U' \ L} := ⟨⟨⊥, empty_subset _⟩⟩,
   rw [ennreal.add_supr], refine supr_le _, rintro ⟨M, hM⟩, simp only [subset_diff] at hM,
-  have : (L ⊔ M).1 ⊆ U',
-  { simp only [union_subset_iff, compacts.sup_val, hM, hL, and_self] },
+  have : (↑(L ⊔ M) : set G) ⊆ U',
+  { simp only [union_subset_iff, compacts.coe_sup, hM, hL, and_self] },
   rw μ.outer_measure_of_is_open ↑U' U'.2,
   refine le_trans (ge_of_eq _) (μ.le_inner_content _ _ this),
   exact μ.sup_disjoint _ _ hM.2.symm,
@@ -362,7 +361,7 @@ begin
   rw [measure_apply _ hU.measurable_set, μ.outer_measure_of_is_open U hU] at hr,
   simp only [inner_content, lt_supr_iff] at hr,
   rcases hr with ⟨K, hKU, hr⟩,
-  refine ⟨K.1, hKU, K.2, hr.trans_le _⟩,
+  refine ⟨K, hKU, K.2, hr.trans_le _⟩,
   exact (μ.le_outer_measure_compacts K).trans (le_to_measure_apply _ _ _)
 end
 

--- a/src/measure_theory/measure/haar.lean
+++ b/src/measure_theory/measure/haar.lean
@@ -93,26 +93,26 @@ variables [topological_space G]
   The argument `K` is a (bundled) compact set, so that we can consider `prehaar K₀ U` as an
   element of `haar_product` (below). -/
 @[to_additive "additive version of `measure_theory.measure.haar.prehaar`"]
-def prehaar (K₀ U : set G) (K : compacts G) : ℝ := (index K U : ℝ) / index K₀ U
+def prehaar (K₀ U : set G) (K : compacts G) : ℝ := (index (K : set G) U : ℝ) / index K₀ U
 
 @[to_additive]
-lemma prehaar_empty (K₀ : positive_compacts G) {U : set G} : prehaar K₀ U ⊥ = 0 :=
-by { simp only [prehaar, compacts.bot_val, index_empty, nat.cast_zero, zero_div] }
+lemma prehaar_empty (K₀ : positive_compacts G) {U : set G} : prehaar (K₀ : set G) U ⊥ = 0 :=
+by rw [prehaar, compacts.coe_bot, index_empty, nat.cast_zero, zero_div]
 
 @[to_additive]
 lemma prehaar_nonneg (K₀ : positive_compacts G) {U : set G} (K : compacts G) :
-  0 ≤ prehaar K₀ U K :=
+  0 ≤ prehaar (K₀ : set G) U K :=
 by apply div_nonneg; norm_cast; apply zero_le
 
 /-- `haar_product K₀` is the product of intervals `[0, (K : K₀)]`, for all compact sets `K`.
   For all `U`, we can show that `prehaar K₀ U ∈ haar_product K₀`. -/
 @[to_additive "additive version of `measure_theory.measure.haar.haar_product`"]
 def haar_product (K₀ : set G) : set (compacts G → ℝ) :=
-pi univ (λ K, Icc 0 $ index K K₀)
+pi univ (λ K, Icc 0 $ index (K : set G) K₀)
 
 @[simp, to_additive]
 lemma mem_prehaar_empty {K₀ : set G} {f : compacts G → ℝ} :
-  f ∈ haar_product K₀ ↔ ∀ K : compacts G, f K ∈ Icc (0 : ℝ) (index K K₀) :=
+  f ∈ haar_product K₀ ↔ ∀ K : compacts G, f K ∈ Icc (0 : ℝ) (index (K : set G) K₀) :=
 by simp only [haar_product, pi, forall_prop_of_true, mem_univ, mem_set_of_eq]
 
 /-- The closure of the collection of elements of the form `prehaar K₀ U`,
@@ -144,7 +144,8 @@ by { have := nat.Inf_mem (index_defined hK hV), rwa [mem_image] at this }
 
 @[to_additive le_add_index_mul]
 lemma le_index_mul (K₀ : positive_compacts G) (K : compacts G) {V : set G}
-  (hV : (interior V).nonempty) : index K V ≤ index K K₀.1 * index K₀ V :=
+  (hV : (interior V).nonempty) :
+  index (K : set G) V ≤ index (K : set G) K₀ * index (K₀ : set G) V :=
 begin
   obtain ⟨s, h1s, h2s⟩ := index_elim K.compact K₀.interior_nonempty,
   obtain ⟨t, h1t, h2t⟩ := index_elim K₀.compact hV,
@@ -159,11 +160,11 @@ end
 
 @[to_additive add_index_pos]
 lemma index_pos (K : positive_compacts G) {V : set G} (hV : (interior V).nonempty) :
-  0 < index K V :=
+  0 < index (K : set G) V :=
 begin
   unfold index, rw [nat.Inf_def, nat.find_pos, mem_image],
   { rintro ⟨t, h1t, h2t⟩, rw [finset.card_eq_zero] at h2t, subst h2t,
-    obtain ⟨g, hg⟩ := K.nonempty_interior,
+    obtain ⟨g, hg⟩ := K.interior_nonempty,
     show g ∈ (∅ : set G), convert h1t (interior_subset hg), symmetry, apply bUnion_empty },
   { exact index_defined K.compact hV }
 end
@@ -250,7 +251,7 @@ end
 
 @[to_additive add_prehaar_le_add_index]
 lemma prehaar_le_index (K₀ : positive_compacts G) {U : set G} (K : compacts G)
-  (hU : (interior U).nonempty) : prehaar K₀ U K ≤ index K K₀ :=
+  (hU : (interior U).nonempty) : prehaar (K₀ : set G) U K ≤ index (K : set G) K₀ :=
 begin
   unfold prehaar, rw [div_le_iff]; norm_cast,
   { apply le_index_mul K₀ K hU },
@@ -259,12 +260,14 @@ end
 
 @[to_additive]
 lemma prehaar_pos (K₀ : positive_compacts G) {U : set G} (hU : (interior U).nonempty)
-  {K : set G} (h1K : is_compact K) (h2K : (interior K).nonempty) : 0 < prehaar K₀.1 U ⟨K, h1K⟩ :=
-by { apply div_pos; norm_cast, apply index_pos ⟨K, h1K, h2K⟩ hU, exact index_pos K₀ hU }
+  {K : set G} (h1K : is_compact K) (h2K : (interior K).nonempty) :
+  0 < prehaar (K₀ : set G) U ⟨K, h1K⟩ :=
+by { apply div_pos; norm_cast, apply index_pos ⟨⟨K, h1K⟩, h2K⟩ hU, exact index_pos K₀ hU }
 
 @[to_additive]
 lemma prehaar_mono {K₀ : positive_compacts G} {U : set G} (hU : (interior U).nonempty)
-  {K₁ K₂ : compacts G} (h : K₁.1 ⊆ K₂.1) : prehaar K₀.1 U K₁ ≤ prehaar K₀.1 U K₂ :=
+  {K₁ K₂ : compacts G} (h : (K₁ : set G) ⊆ K₂.1) :
+  prehaar (K₀ : set G) U K₁ ≤ prehaar (K₀ : set G) U K₂ :=
 begin
   simp only [prehaar], rw [div_le_div_right], exact_mod_cast index_mono K₂.2 h hU,
   exact_mod_cast index_pos K₀ hU
@@ -272,12 +275,13 @@ end
 
 @[to_additive]
 lemma prehaar_self {K₀ : positive_compacts G} {U : set G} (hU : (interior U).nonempty) :
-  prehaar K₀.1 U ⟨K₀.1, K₀.2.1⟩ = 1 :=
-by { simp only [prehaar], rw [div_self], apply ne_of_gt, exact_mod_cast index_pos K₀ hU }
+  prehaar (K₀ : set G) U K₀.to_compacts = 1 :=
+div_self $ ne_of_gt $ by exact_mod_cast index_pos K₀ hU
 
 @[to_additive]
 lemma prehaar_sup_le {K₀ : positive_compacts G} {U : set G} (K₁ K₂ : compacts G)
-  (hU : (interior U).nonempty) : prehaar K₀.1 U (K₁ ⊔ K₂) ≤ prehaar K₀.1 U K₁ + prehaar K₀.1 U K₂ :=
+  (hU : (interior U).nonempty) :
+  prehaar (K₀ : set G) U (K₁ ⊔ K₂) ≤ prehaar (K₀ : set G) U K₁ + prehaar (K₀ : set G) U K₂ :=
 begin
   simp only [prehaar], rw [div_add_div_same, div_le_div_right],
   exact_mod_cast index_union_le K₁ K₂ hU, exact_mod_cast index_pos K₀ hU
@@ -286,35 +290,36 @@ end
 @[to_additive]
 lemma prehaar_sup_eq {K₀ : positive_compacts G} {U : set G} {K₁ K₂ : compacts G}
   (hU : (interior U).nonempty) (h : disjoint (K₁.1 * U⁻¹) (K₂.1 * U⁻¹)) :
-  prehaar K₀.1 U (K₁ ⊔ K₂) = prehaar K₀.1 U K₁ + prehaar K₀.1 U K₂ :=
+  prehaar (K₀ : set G) U (K₁ ⊔ K₂) = prehaar (K₀ : set G) U K₁ + prehaar (K₀ : set G) U K₂ :=
 by { simp only [prehaar], rw [div_add_div_same], congr', exact_mod_cast index_union_eq K₁ K₂ hU h }
 
 @[to_additive]
 lemma is_left_invariant_prehaar {K₀ : positive_compacts G} {U : set G} (hU : (interior U).nonempty)
-  (g : G) (K : compacts G) : prehaar K₀.1 U (K.map _ $ continuous_mul_left g) = prehaar K₀.1 U K :=
-by simp only [prehaar, compacts.map_val, is_left_invariant_index K.compact _ hU]
+  (g : G) (K : compacts G) :
+  prehaar (K₀ : set G) U (K.map _ $ continuous_mul_left g) = prehaar (K₀ : set G) U K :=
+by simp only [prehaar, compacts.coe_map, is_left_invariant_index K.compact _ hU]
 
 /-!
 ### Lemmas about `haar_product`
 -/
 
 @[to_additive]
-lemma prehaar_mem_haar_product (K₀ : positive_compacts G) {U : set G}
-  (hU : (interior U).nonempty) : prehaar K₀.1 U ∈ haar_product K₀.1 :=
+lemma prehaar_mem_haar_product (K₀ : positive_compacts G) {U : set G} (hU : (interior U).nonempty) :
+  prehaar (K₀ : set G) U ∈ haar_product (K₀ : set G) :=
 by { rintro ⟨K, hK⟩ h2K, rw [mem_Icc], exact ⟨prehaar_nonneg K₀ _, prehaar_le_index K₀ _ hU⟩ }
 
 @[to_additive]
 lemma nonempty_Inter_cl_prehaar (K₀ : positive_compacts G) :
-  (haar_product K₀.1 ∩ ⋂ (V : open_nhds_of (1 : G)), cl_prehaar K₀.1 V).nonempty :=
+  (haar_product (K₀ : set G) ∩ ⋂ (V : open_nhds_of (1 : G)), cl_prehaar K₀ V).nonempty :=
 begin
-  have : is_compact (haar_product K₀.1),
+  have : is_compact (haar_product (K₀ : set G)),
   { apply is_compact_univ_pi, intro K, apply is_compact_Icc },
-  refine this.inter_Inter_nonempty (cl_prehaar K₀.1) (λ s, is_closed_closure) (λ t, _),
+  refine this.inter_Inter_nonempty (cl_prehaar K₀) (λ s, is_closed_closure) (λ t, _),
   let V₀ := ⋂ (V ∈ t), (V : open_nhds_of 1).1,
   have h1V₀ : is_open V₀,
   { apply is_open_bInter, apply finite_mem_finset, rintro ⟨V, hV⟩ h2V, exact hV.1 },
   have h2V₀ : (1 : G) ∈ V₀, { simp only [mem_Inter], rintro ⟨V, hV⟩ h2V, exact hV.2 },
-  refine ⟨prehaar K₀.1 V₀, _⟩,
+  refine ⟨prehaar K₀ V₀, _⟩,
   split,
   { apply prehaar_mem_haar_product K₀, use 1, rwa h1V₀.interior_eq },
   { simp only [mem_Inter], rintro ⟨V, hV⟩ h2V, apply subset_closure,
@@ -326,7 +331,7 @@ end
 ### Lemmas about `chaar`
 -/
 
-/-- This is the "limit" of `prehaar K₀.1 U K` as `U` becomes a smaller and smaller open
+/-- This is the "limit" of `prehaar K₀ U K` as `U` becomes a smaller and smaller open
   neighborhood of `(1 : G)`. More precisely, it is defined to be an arbitrary element
   in the intersection of all the sets `cl_prehaar K₀ V` in `haar_product K₀`.
   This is roughly equal to the Haar measure on compact sets,
@@ -337,12 +342,12 @@ def chaar (K₀ : positive_compacts G) (K : compacts G) : ℝ :=
 classical.some (nonempty_Inter_cl_prehaar K₀) K
 
 @[to_additive add_chaar_mem_add_haar_product]
-lemma chaar_mem_haar_product (K₀ : positive_compacts G) : chaar K₀ ∈ haar_product K₀.1 :=
+lemma chaar_mem_haar_product (K₀ : positive_compacts G) : chaar K₀ ∈ haar_product (K₀ : set G) :=
 (classical.some_spec (nonempty_Inter_cl_prehaar K₀)).1
 
 @[to_additive add_chaar_mem_cl_add_prehaar]
 lemma chaar_mem_cl_prehaar (K₀ : positive_compacts G) (V : open_nhds_of (1 : G)) :
-  chaar K₀ ∈ cl_prehaar K₀.1 V :=
+  chaar K₀ ∈ cl_prehaar (K₀ : set G) V :=
 by { have := (classical.some_spec (nonempty_Inter_cl_prehaar K₀)).2, rw [mem_Inter] at this,
      exact this V }
 
@@ -363,9 +368,9 @@ begin
 end
 
 @[to_additive add_chaar_self]
-lemma chaar_self (K₀ : positive_compacts G) : chaar K₀ ⟨K₀.1, K₀.2.1⟩ = 1 :=
+lemma chaar_self (K₀ : positive_compacts G) : chaar K₀ K₀.to_compacts = 1 :=
 begin
-  let eval : (compacts G → ℝ) → ℝ := λ f, f ⟨K₀.1, K₀.2.1⟩,
+  let eval : (compacts G → ℝ) → ℝ := λ f, f K₀.to_compacts,
   have : continuous eval := continuous_apply _,
   show chaar K₀ ∈ eval ⁻¹' {(1 : ℝ)},
   apply mem_of_subset_of_mem _ (chaar_mem_cl_prehaar K₀ ⟨set.univ, is_open_univ, mem_univ _⟩),
@@ -376,7 +381,7 @@ begin
 end
 
 @[to_additive add_chaar_mono]
-lemma chaar_mono {K₀ : positive_compacts G} {K₁ K₂ : compacts G} (h : K₁.1 ⊆ K₂.1) :
+lemma chaar_mono {K₀ : positive_compacts G} {K₁ K₂ : compacts G} (h : (K₁ : set G) ⊆ K₂) :
   chaar K₀ K₁ ≤ chaar K₀ K₂ :=
 begin
   let eval : (compacts G → ℝ) → ℝ := λ f, f K₂ - f K₁,
@@ -470,7 +475,7 @@ lemma haar_content_apply (K₀ : positive_compacts G) (K : compacts G) :
 
 /-- The variant of `chaar_self` for `haar_content` -/
 @[to_additive]
-lemma haar_content_self {K₀ : positive_compacts G} : haar_content K₀ ⟨K₀.1, K₀.2.1⟩ = 1 :=
+lemma haar_content_self {K₀ : positive_compacts G} : haar_content K₀ K₀.to_compacts = 1 :=
 by { simp_rw [← ennreal.coe_one, haar_content_apply, ennreal.coe_eq_coe, chaar_self], refl }
 
 /-- The variant of `is_left_invariant_chaar` for `haar_content` -/
@@ -482,7 +487,7 @@ by simpa only [ennreal.coe_eq_coe, ←nnreal.coe_eq, haar_content_apply]
 
 @[to_additive]
 lemma haar_content_outer_measure_self_pos {K₀ : positive_compacts G} :
-  0 < (haar_content K₀).outer_measure K₀.1 :=
+  0 < (haar_content K₀).outer_measure K₀ :=
 begin
   apply ennreal.zero_lt_one.trans_le,
   rw [content.outer_measure_eq_infi],
@@ -490,7 +495,7 @@ begin
   intros U hU,
   refine le_infi _,
   intros h2U,
-  refine le_trans (le_of_eq _) (le_bsupr ⟨K₀.1, K₀.2.1⟩ h2U),
+  refine le_trans (le_of_eq _) (le_bsupr K₀.to_compacts h2U),
   exact haar_content_self.symm
 end
 
@@ -508,13 +513,13 @@ variables [topological_space G] [t2_space G] [topological_group G] [measurable_s
 @[to_additive "The Haar measure on the locally compact additive group `G`,
 scaled so that `add_haar_measure K₀ K₀ = 1`."]
 def haar_measure (K₀ : positive_compacts G) : measure G :=
-((haar_content K₀).outer_measure K₀.1)⁻¹ • (haar_content K₀).measure
+((haar_content K₀).outer_measure K₀)⁻¹ • (haar_content K₀).measure
 
 @[to_additive]
 lemma haar_measure_apply {K₀ : positive_compacts G} {s : set G} (hs : measurable_set s) :
-  haar_measure K₀ s = (haar_content K₀).outer_measure s / (haar_content K₀).outer_measure K₀.1 :=
+  haar_measure K₀ s = (haar_content K₀).outer_measure s / (haar_content K₀).outer_measure K₀ :=
 begin
-  change (((haar_content K₀).outer_measure) K₀.val)⁻¹ * (haar_content K₀).measure s = _,
+  change (((haar_content K₀).outer_measure) K₀)⁻¹ * (haar_content K₀).measure s = _,
   simp only [hs, div_eq_mul_inv, mul_comm, content.measure_apply],
 end
 
@@ -531,13 +536,12 @@ begin
 end
 
 @[to_additive]
-lemma haar_measure_self {K₀ : positive_compacts G} :
-  haar_measure K₀ K₀.1 = 1 :=
+lemma haar_measure_self {K₀ : positive_compacts G} : haar_measure K₀ K₀ = 1 :=
 begin
   haveI : locally_compact_space G := K₀.locally_compact_space_of_group,
-  rw [haar_measure_apply K₀.2.1.measurable_set, ennreal.div_self],
+  rw [haar_measure_apply K₀.compact.measurable_set, ennreal.div_self],
   { rw [← pos_iff_ne_zero], exact haar_content_outer_measure_self_pos },
-  { exact ne_of_lt (content.outer_measure_lt_top_of_is_compact _ K₀.2.1) }
+  { exact (content.outer_measure_lt_top_of_is_compact _ K₀.compact).ne }
 end
 
 /-- The Haar measure is regular. -/
@@ -563,7 +567,8 @@ sets and positive mass to nonempty open sets. -/
 instance is_haar_measure_haar_measure (K₀ : positive_compacts G) :
   is_haar_measure (haar_measure K₀) :=
 begin
-  apply is_haar_measure_of_is_compact_nonempty_interior (haar_measure K₀) K₀.1 K₀.2.1 K₀.2.2,
+  apply is_haar_measure_of_is_compact_nonempty_interior (haar_measure K₀) K₀ K₀.compact
+    K₀.interior_nonempty,
   { simp only [haar_measure_self], exact one_ne_zero },
   { simp only [haar_measure_self], exact ennreal.coe_ne_top },
 end
@@ -581,10 +586,10 @@ variables [second_countable_topology G]
   is a scalar multiple of the Haar measure. -/
 @[to_additive]
 theorem haar_measure_unique (μ : measure G) [sigma_finite μ] [is_mul_left_invariant μ]
-  (K₀ : positive_compacts G) : μ = μ K₀.1 • haar_measure K₀ :=
+  (K₀ : positive_compacts G) : μ = μ K₀ • haar_measure K₀ :=
 begin
   ext1 s hs,
-  have := measure_mul_measure_eq μ (haar_measure K₀) K₀.2.1 hs,
+  have := measure_mul_measure_eq μ (haar_measure K₀) K₀.compact hs,
   rw [haar_measure_self, one_mul] at this,
   rw [← this (by norm_num), smul_apply],
 end
@@ -593,7 +598,7 @@ end
 theorem regular_of_is_mul_left_invariant {μ : measure G} [sigma_finite μ] [is_mul_left_invariant μ]
   {K : set G} (hK : is_compact K) (h2K : (interior K).nonempty) (hμK : μ K ≠ ∞) :
   regular μ :=
-by { rw [haar_measure_unique μ ⟨K, hK, h2K⟩], exact regular.smul hμK }
+by { rw [haar_measure_unique μ ⟨⟨K, hK⟩, h2K⟩], exact regular.smul hμK }
 
 end unique
 
@@ -604,12 +609,12 @@ theorem is_haar_measure_eq_smul_is_haar_measure
   ∃ (c : ℝ≥0∞), (c ≠ 0) ∧ (c ≠ ∞) ∧ (μ = c • ν) :=
 begin
   have K : positive_compacts G := classical.arbitrary _,
-  have νpos : 0 < ν K := measure_pos_of_nonempty_interior _ K.nonempty_interior,
+  have νpos : 0 < ν K := measure_pos_of_nonempty_interior _ K.interior_nonempty,
   have νlt : ν K < ∞ := K.compact.measure_lt_top ,
   refine ⟨μ K / ν K, _, _, _⟩,
-  { simp only [νlt.ne, (μ.measure_pos_of_nonempty_interior K.property.right).ne', ne.def,
+  { simp only [νlt.ne, (μ.measure_pos_of_nonempty_interior K.interior_nonempty).ne', ne.def,
       ennreal.div_zero_iff, not_false_iff, or_self] },
-  { simp only [div_eq_mul_inv, νpos.ne', (is_compact.measure_lt_top K.property.left).ne, or_self,
+  { simp only [div_eq_mul_inv, νpos.ne', K.compact.measure_lt_top.ne, or_self,
       ennreal.inv_eq_top, with_top.mul_eq_top_iff, ne.def, not_false_iff, and_false, false_and] },
   { calc
     μ = μ K • haar_measure K : haar_measure_unique μ K

--- a/src/measure_theory/measure/haar.lean
+++ b/src/measure_theory/measure/haar.lean
@@ -93,26 +93,26 @@ variables [topological_space G]
   The argument `K` is a (bundled) compact set, so that we can consider `prehaar K₀ U` as an
   element of `haar_product` (below). -/
 @[to_additive "additive version of `measure_theory.measure.haar.prehaar`"]
-def prehaar (K₀ U : set G) (K : compacts G) : ℝ := (index K.1 U : ℝ) / index K₀ U
+def prehaar (K₀ U : set G) (K : compacts G) : ℝ := (index K U : ℝ) / index K₀ U
 
 @[to_additive]
-lemma prehaar_empty (K₀ : positive_compacts G) {U : set G} : prehaar K₀.1 U ⊥ = 0 :=
+lemma prehaar_empty (K₀ : positive_compacts G) {U : set G} : prehaar K₀ U ⊥ = 0 :=
 by { simp only [prehaar, compacts.bot_val, index_empty, nat.cast_zero, zero_div] }
 
 @[to_additive]
 lemma prehaar_nonneg (K₀ : positive_compacts G) {U : set G} (K : compacts G) :
-  0 ≤ prehaar K₀.1 U K :=
+  0 ≤ prehaar K₀ U K :=
 by apply div_nonneg; norm_cast; apply zero_le
 
 /-- `haar_product K₀` is the product of intervals `[0, (K : K₀)]`, for all compact sets `K`.
   For all `U`, we can show that `prehaar K₀ U ∈ haar_product K₀`. -/
 @[to_additive "additive version of `measure_theory.measure.haar.haar_product`"]
 def haar_product (K₀ : set G) : set (compacts G → ℝ) :=
-pi univ (λ K, Icc 0 $ index K.1 K₀)
+pi univ (λ K, Icc 0 $ index K K₀)
 
 @[simp, to_additive]
 lemma mem_prehaar_empty {K₀ : set G} {f : compacts G → ℝ} :
-  f ∈ haar_product K₀ ↔ ∀ K : compacts G, f K ∈ Icc (0 : ℝ) (index K.1 K₀) :=
+  f ∈ haar_product K₀ ↔ ∀ K : compacts G, f K ∈ Icc (0 : ℝ) (index K K₀) :=
 by simp only [haar_product, pi, forall_prop_of_true, mem_univ, mem_set_of_eq]
 
 /-- The closure of the collection of elements of the form `prehaar K₀ U`,
@@ -144,10 +144,10 @@ by { have := nat.Inf_mem (index_defined hK hV), rwa [mem_image] at this }
 
 @[to_additive le_add_index_mul]
 lemma le_index_mul (K₀ : positive_compacts G) (K : compacts G) {V : set G}
-  (hV : (interior V).nonempty) : index K.1 V ≤ index K.1 K₀.1 * index K₀.1 V :=
+  (hV : (interior V).nonempty) : index K V ≤ index K K₀.1 * index K₀ V :=
 begin
-  rcases index_elim K.2 K₀.2.2 with ⟨s, h1s, h2s⟩,
-  rcases index_elim K₀.2.1 hV with ⟨t, h1t, h2t⟩,
+  obtain ⟨s, h1s, h2s⟩ := index_elim K.compact K₀.interior_nonempty,
+  obtain ⟨t, h1t, h2t⟩ := index_elim K₀.compact hV,
   rw [← h2s, ← h2t, mul_comm],
   refine le_trans _ finset.mul_card_le,
   apply nat.Inf_le, refine ⟨_, _, rfl⟩, rw [mem_set_of_eq], refine subset.trans h1s _,
@@ -159,13 +159,13 @@ end
 
 @[to_additive add_index_pos]
 lemma index_pos (K : positive_compacts G) {V : set G} (hV : (interior V).nonempty) :
-  0 < index K.1 V :=
+  0 < index K V :=
 begin
   unfold index, rw [nat.Inf_def, nat.find_pos, mem_image],
   { rintro ⟨t, h1t, h2t⟩, rw [finset.card_eq_zero] at h2t, subst h2t,
-    cases K.2.2 with g hg,
+    obtain ⟨g, hg⟩ := K.nonempty_interior,
     show g ∈ (∅ : set G), convert h1t (interior_subset hg), symmetry, apply bUnion_empty },
-  { exact index_defined K.2.1 hV }
+  { exact index_defined K.compact hV }
 end
 
 @[to_additive add_index_mono]
@@ -250,7 +250,7 @@ end
 
 @[to_additive add_prehaar_le_add_index]
 lemma prehaar_le_index (K₀ : positive_compacts G) {U : set G} (K : compacts G)
-  (hU : (interior U).nonempty) : prehaar K₀.1 U K ≤ index K.1 K₀.1 :=
+  (hU : (interior U).nonempty) : prehaar K₀ U K ≤ index K K₀ :=
 begin
   unfold prehaar, rw [div_le_iff]; norm_cast,
   { apply le_index_mul K₀ K hU },
@@ -292,7 +292,7 @@ by { simp only [prehaar], rw [div_add_div_same], congr', exact_mod_cast index_un
 @[to_additive]
 lemma is_left_invariant_prehaar {K₀ : positive_compacts G} {U : set G} (hU : (interior U).nonempty)
   (g : G) (K : compacts G) : prehaar K₀.1 U (K.map _ $ continuous_mul_left g) = prehaar K₀.1 U K :=
-by simp only [prehaar, compacts.map_val, is_left_invariant_index K.2 _ hU]
+by simp only [prehaar, compacts.map_val, is_left_invariant_index K.compact _ hU]
 
 /-!
 ### Lemmas about `haar_product`
@@ -331,7 +331,7 @@ end
   in the intersection of all the sets `cl_prehaar K₀ V` in `haar_product K₀`.
   This is roughly equal to the Haar measure on compact sets,
   but it can differ slightly. We do know that
-  `haar_measure K₀ (interior K.1) ≤ chaar K₀ K ≤ haar_measure K₀ K.1`. -/
+  `haar_measure K₀ (interior K) ≤ chaar K₀ K ≤ haar_measure K₀ K`. -/
 @[to_additive add_chaar "additive version of `measure_theory.measure.haar.chaar`"]
 def chaar (K₀ : positive_compacts G) (K : compacts G) : ℝ :=
 classical.some (nonempty_Inter_cl_prehaar K₀) K
@@ -571,8 +571,7 @@ end
 /-- `haar` is some choice of a Haar measure, on a locally compact group. -/
 @[reducible, to_additive "`add_haar` is some choice of a Haar measure, on a locally compact
 additive group."]
-def haar [locally_compact_space G] : measure G :=
-haar_measure $ classical.choice (topological_space.nonempty_positive_compacts G)
+def haar [locally_compact_space G] : measure G := haar_measure $ classical.arbitrary _
 
 section unique
 
@@ -604,19 +603,19 @@ theorem is_haar_measure_eq_smul_is_haar_measure
   (μ ν : measure G) [is_haar_measure μ] [is_haar_measure ν] :
   ∃ (c : ℝ≥0∞), (c ≠ 0) ∧ (c ≠ ∞) ∧ (μ = c • ν) :=
 begin
-  have K : positive_compacts G := classical.choice (topological_space.nonempty_positive_compacts G),
-  have νpos : 0 < ν K.1 := measure_pos_of_nonempty_interior _ K.2.2,
-  have νlt : ν K.1 < ∞ := is_compact.measure_lt_top K.2.1,
-  refine ⟨μ K.1 / ν K.1, _, _, _⟩,
+  have K : positive_compacts G := classical.arbitrary _,
+  have νpos : 0 < ν K := measure_pos_of_nonempty_interior _ K.nonempty_interior,
+  have νlt : ν K < ∞ := K.compact.measure_lt_top ,
+  refine ⟨μ K / ν K, _, _, _⟩,
   { simp only [νlt.ne, (μ.measure_pos_of_nonempty_interior K.property.right).ne', ne.def,
       ennreal.div_zero_iff, not_false_iff, or_self] },
   { simp only [div_eq_mul_inv, νpos.ne', (is_compact.measure_lt_top K.property.left).ne, or_self,
       ennreal.inv_eq_top, with_top.mul_eq_top_iff, ne.def, not_false_iff, and_false, false_and] },
   { calc
-    μ = μ K.1 • haar_measure K : haar_measure_unique μ K
-    ... = (μ K.1 / ν K.1) • (ν K.1 • haar_measure K) :
+    μ = μ K • haar_measure K : haar_measure_unique μ K
+    ... = (μ K / ν K) • (ν K • haar_measure K) :
       by rw [smul_smul, div_eq_mul_inv, mul_assoc, ennreal.inv_mul_cancel νpos.ne' νlt.ne, mul_one]
-    ... = (μ K.1 / ν K.1) • ν : by rw ← haar_measure_unique ν K }
+    ... = (μ K / ν K) • ν : by rw ← haar_measure_unique ν K }
 end
 
 @[priority 90, to_additive] -- see Note [lower instance priority]]
@@ -624,7 +623,7 @@ instance regular_of_is_haar_measure
   [locally_compact_space G] [second_countable_topology G] (μ : measure G) [is_haar_measure μ] :
   regular μ :=
 begin
-  have K : positive_compacts G := classical.choice (topological_space.nonempty_positive_compacts G),
+  have K : positive_compacts G := classical.arbitrary _,
   obtain ⟨c, c0, ctop, hμ⟩ : ∃ (c : ℝ≥0∞), (c ≠ 0) ∧ (c ≠ ∞) ∧ (μ = c • haar_measure K) :=
     is_haar_measure_eq_smul_is_haar_measure μ _,
   rw hμ,
@@ -652,13 +651,13 @@ begin
   { rw [map_map continuous_inv.measurable continuous_inv.measurable] at this,
     { simpa only [inv_involutive, involutive.comp_self, map_id] },
     all_goals { apply_instance } },
-  have K : positive_compacts G := classical.choice (topological_space.nonempty_positive_compacts G),
-  have : c^2 * μ K.1 = 1^2 * μ K.1,
+  have K : positive_compacts G := classical.arbitrary _,
+  have : c^2 * μ K = 1^2 * μ K,
     by { conv_rhs { rw μeq },
          simp, },
   have : c^2 = 1^2 :=
-    (ennreal.mul_eq_mul_right (measure_pos_of_nonempty_interior _ K.2.2).ne'
-      (is_compact.measure_lt_top K.2.1).ne).1 this,
+    (ennreal.mul_eq_mul_right (measure_pos_of_nonempty_interior _ K.interior_nonempty).ne'
+      K.compact.measure_lt_top.ne).1 this,
   have : c = 1 := (ennreal.pow_strict_mono two_ne_zero).injective this,
   rw [hc, this, one_smul]
 end

--- a/src/measure_theory/measure/haar_lebesgue.lean
+++ b/src/measure_theory/measure/haar_lebesgue.lean
@@ -39,17 +39,20 @@ open topological_space set filter metric
 open_locale ennreal pointwise topological_space
 
 /-- The interval `[0,1]` as a compact set with non-empty interior. -/
-def topological_space.positive_compacts.Icc01 : positive_compacts ℝ :=
-⟨Icc 0 1, is_compact_Icc, by simp_rw [interior_Icc, nonempty_Ioo, zero_lt_one]⟩
+noncomputable def topological_space.positive_compacts.Icc01 : positive_compacts ℝ :=
+{ carrier := Icc 0 1,
+  compact' := is_compact_Icc,
+  interior_nonempty' := by simp_rw [interior_Icc, nonempty_Ioo, zero_lt_one] }
 
 universe u
 
 /-- The set `[0,1]^ι` as a compact set with non-empty interior. -/
-def topological_space.positive_compacts.pi_Icc01 (ι : Type*) [fintype ι] :
+noncomputable def topological_space.positive_compacts.pi_Icc01 (ι : Type*) [fintype ι] :
   positive_compacts (ι → ℝ) :=
-⟨set.pi set.univ (λ i, Icc 0 1), is_compact_univ_pi (λ i, is_compact_Icc),
-by simp only [interior_pi_set, finite.of_fintype, interior_Icc, univ_pi_nonempty_iff, nonempty_Ioo,
-  implies_true_iff, zero_lt_one]⟩
+{ carrier := pi univ (λ i, Icc 0 1),
+  compact' := is_compact_univ_pi (λ i, is_compact_Icc),
+  interior_nonempty' := by simp only [interior_pi_set, finite.of_fintype, interior_Icc,
+    univ_pi_nonempty_iff, nonempty_Ioo, implies_true_iff, zero_lt_one] }
 
 namespace measure_theory
 
@@ -75,8 +78,9 @@ lemma add_haar_measure_eq_volume_pi (ι : Type*) [fintype ι] :
   add_haar_measure (pi_Icc01 ι) = volume :=
 begin
   convert (add_haar_measure_unique volume (pi_Icc01 ι)).symm,
-  simp only [pi_Icc01, volume_pi_pi (λ i, Icc (0 : ℝ) 1),
-    finset.prod_const_one, ennreal.of_real_one, real.volume_Icc, one_smul, sub_zero]
+  simp only [pi_Icc01, volume_pi_pi (λ i, Icc (0 : ℝ) 1), positive_compacts.coe_mk,
+    compacts.coe_mk, finset.prod_const_one, ennreal.of_real_one, real.volume_Icc, one_smul,
+    sub_zero],
 end
 
 instance is_add_haar_measure_volume_pi (ι : Type*) [fintype ι] :

--- a/src/measure_theory/measure/haar_quotient.lean
+++ b/src/measure_theory/measure/haar_quotient.lean
@@ -166,7 +166,7 @@ variables [t2_space (G ⧸ Γ)] [second_countable_topology (G ⧸ Γ)] (K : posi
 lemma measure_theory.is_fundamental_domain.map_restrict_quotient [subgroup.normal Γ]
   [measure_theory.measure.is_haar_measure μ] [μ.is_mul_right_invariant]
   (h𝓕_finite : μ 𝓕 < ⊤) : measure.map (quotient_group.mk' Γ) (μ.restrict 𝓕)
-  = (μ (𝓕 ∩ (quotient_group.mk' Γ) ⁻¹' K.val)) • (measure_theory.measure.haar_measure K) :=
+  = (μ (𝓕 ∩ (quotient_group.mk' Γ) ⁻¹' K)) • (measure_theory.measure.haar_measure K) :=
 begin
   let π : G →* G ⧸ Γ := quotient_group.mk' Γ,
   have meas_π : measurable π := continuous_quotient_mk.measurable,
@@ -179,5 +179,5 @@ begin
     h𝓕.is_mul_left_invariant_map,
   rw [measure.haar_measure_unique (measure.map (quotient_group.mk' Γ) (μ.restrict 𝓕)) K,
     measure.map_apply meas_π, measure.restrict_apply' 𝓕meas, inter_comm],
-  exact K.prop.1.measurable_set,
+  exact K.compact.measurable_set,
 end

--- a/src/order/bounded_order.lean
+++ b/src/order/bounded_order.lean
@@ -430,6 +430,31 @@ lemma subsingleton_iff_bot_eq_top :
 
 end subsingleton
 
+section lift
+
+/-- Pullback an `order_top`. -/
+@[reducible] -- See note [reducible non-instances]
+def order_top.lift [has_le α] [has_top α] [has_le β] [order_top β] (f : α → β)
+  (map_le : ∀ a b, f a ≤ f b → a ≤ b) (map_top : f ⊤ = ⊤) :
+  order_top α :=
+⟨⊤, λ a, map_le _ _ $ by { rw map_top, exact le_top }⟩
+
+/-- Pullback an `order_bot`. -/
+@[reducible] -- See note [reducible non-instances]
+def order_bot.lift [has_le α] [has_bot α] [has_le β] [order_bot β] (f : α → β)
+  (map_le : ∀ a b, f a ≤ f b → a ≤ b) (map_bot : f ⊥ = ⊥) :
+  order_bot α :=
+⟨⊥, λ a, map_le _ _ $ by { rw map_bot, exact bot_le }⟩
+
+/-- Pullback a `bounded_order`. -/
+@[reducible] -- See note [reducible non-instances]
+def bounded_order.lift [has_le α] [has_top α] [has_bot α] [has_le β] [bounded_order β] (f : α → β)
+  (map_le : ∀ a b, f a ≤ f b → a ≤ b) (map_top : f ⊤ = ⊤) (map_bot : f ⊥ = ⊥) :
+  bounded_order α :=
+{ ..order_top.lift f map_le map_top, ..order_bot.lift f map_le map_bot }
+
+end lift
+
 /-! ### `with_bot`, `with_top` -/
 
 /-- Attach `⊥` to a type. -/

--- a/src/order/complete_lattice.lean
+++ b/src/order/complete_lattice.lean
@@ -1304,31 +1304,6 @@ lemma disjoint_Sup_right {a : set α} {b : α} (d : disjoint b (Sup a)) {i} (hi 
 
 end complete_lattice
 
-section lift
-
-/-- Pullback an `order_top`. -/
-@[reducible] -- See note [reducible non-instances]
-def order_top.lift [has_le α] [has_top α] [has_le β] [order_top β] (f : α → β)
-  (map_le : ∀ a b, f a ≤ f b → a ≤ b) (map_top : f ⊤ = ⊤) :
-  order_top α :=
-⟨⊤, λ a, map_le _ _ $ by { rw map_top, exact le_top }⟩
-
-/-- Pullback an `order_bot`. -/
-@[reducible] -- See note [reducible non-instances]
-def order_bot.lift [has_le α] [has_bot α] [has_le β] [order_bot β] (f : α → β)
-  (map_le : ∀ a b, f a ≤ f b → a ≤ b) (map_bot : f ⊥ = ⊥) :
-  order_bot α :=
-⟨⊥, λ a, map_le _ _ $ by { rw map_bot, exact bot_le }⟩
-
-/-- Pullback a `bounded_order`. -/
-@[reducible] -- See note [reducible non-instances]
-def bounded_order.lift [has_le α] [has_top α] [has_bot α] [has_le β] [bounded_order β] (f : α → β)
-  (map_le : ∀ a b, f a ≤ f b → a ≤ b) (map_top : f ⊤ = ⊤) (map_bot : f ⊥ = ⊥) :
-  bounded_order α :=
-{ ..order_top.lift f map_le map_top, ..order_bot.lift f map_le map_bot }
-
-end lift
-
 /-- Pullback a `complete_lattice` along an injection. -/
 @[reducible] -- See note [reducible non-instances]
 protected def function.injective.complete_lattice [has_sup α] [has_inf α] [has_Sup α]

--- a/src/topology/algebra/group.lean
+++ b/src/topology/algebra/group.lean
@@ -785,10 +785,10 @@ is locally compact. -/
   locally_compact_space G :=
 begin
   refine locally_compact_of_compact_nhds (λ x, _),
-  obtain ⟨y, hy⟩ : ∃ y, y ∈ interior K.1 := K.2.2,
+  obtain ⟨y, hy⟩ := K.interior_nonempty,
   let F := homeomorph.mul_left (x * y⁻¹),
-  refine ⟨F '' K.1, _, is_compact.image K.2.1 F.continuous⟩,
-  suffices : F.symm ⁻¹' K.1 ∈ 𝓝 x, by { convert this, apply equiv.image_eq_preimage },
+  refine ⟨F '' K, _, K.compact.image F.continuous⟩,
+  suffices : F.symm ⁻¹' K ∈ 𝓝 x, by { convert this, apply equiv.image_eq_preimage },
   apply continuous_at.preimage_mem_nhds F.symm.continuous.continuous_at,
   have : F.symm x = y, by simp [F, homeomorph.mul_left_symm],
   rw this,

--- a/src/topology/compacts.lean
+++ b/src/topology/compacts.lean
@@ -44,6 +44,8 @@ lemma closed (s : closeds α) : is_closed (s : set α) := s.closed'
 
 @[ext] protected lemma ext {s t : closeds α} (h : s.1 = t.1) : s = t := set_like.ext' h
 
+@[simp] lemma coe_mk (s : set α) (h) : (mk s h : set α) = s := rfl
+
 instance : has_sup (closeds α) := ⟨λ s t, ⟨s ∪ t, s.closed.union t.closed⟩⟩
 instance : has_inf (closeds α) := ⟨λ s t, ⟨s ∩ t, s.closed.inter t.closed⟩⟩
 instance : has_top (closeds α) := ⟨⟨univ, is_closed_univ⟩⟩
@@ -78,6 +80,8 @@ instance : set_like (compacts α) α :=
 lemma compact (s : compacts α) : is_compact (s : set α) := s.compact'
 
 @[ext] protected lemma ext {s t : compacts α} (h : (s : set α) = t) : s = t := set_like.ext' h
+
+@[simp] lemma coe_mk (s : set α) (h) : (mk s h : set α) = s := rfl
 
 instance : has_sup (compacts α) := ⟨λ s t, ⟨s ∪ t, s.compact.union t.compact⟩⟩
 instance [t2_space α] : has_inf (compacts α) := ⟨λ s t, ⟨s ∩ t, s.compact.inter t.compact⟩⟩
@@ -153,6 +157,8 @@ def to_closeds [t2_space α] (s : nonempty_compacts α) : closeds α := ⟨s, s.
 @[ext] protected lemma ext {s t : nonempty_compacts α} (h : (s : set α) = t) : s = t :=
 set_like.ext' h
 
+@[simp] lemma coe_mk (s : compacts α) (h) : (mk s h : set α) = s := rfl
+
 instance : has_sup (nonempty_compacts α) :=
 ⟨λ s t, ⟨s.to_compacts ⊔ t.to_compacts, s.nonempty.mono $ subset_union_left _ _⟩⟩
 instance [compact_space α] [nonempty α] : has_top (nonempty_compacts α) := ⟨⟨⊤, univ_nonempty⟩⟩
@@ -202,6 +208,8 @@ def to_nonempty_compacts (s : positive_compacts α) : nonempty_compacts α :=
 
 @[ext] protected lemma ext {s t : positive_compacts α} (h : (s : set α) = t) : s = t :=
 set_like.ext' h
+
+@[simp] lemma coe_mk (s : compacts α) (h) : (mk s h : set α) = s := rfl
 
 instance : has_sup (positive_compacts α) :=
 ⟨λ s t, ⟨s.to_compacts ⊔ t.to_compacts,

--- a/src/topology/compacts.lean
+++ b/src/topology/compacts.lean
@@ -1,105 +1,141 @@
 /-
 Copyright (c) 2020 Floris van Doorn. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Floris van Doorn
+Authors: Floris van Doorn, Yaël Dillies
 -/
+import data.set_like.basic
 import topology.homeomorph
+
 /-!
 # Compact sets
 
-## Summary
-
-We define the subtype of compact sets in a topological space.
+We define a few type of sets in a topological space.
 
 ## Main Definitions
 
-- `closeds α` is the type of closed subsets of a topological space `α`.
-- `compacts α` is the type of compact subsets of a topological space `α`.
-- `nonempty_compacts α` is the type of non-empty compact subsets.
-- `positive_compacts α` is the type of compact subsets with non-empty interior.
+For a topological space `α`,
+- `closeds α`: The type of closed sets.
+- `compacts α`: The type of compact sets.
+- `nonempty_compacts α`: The type of non-empty compact sets.
+- `positive_compacts α`: The type of compact sets with non-empty interior.
 -/
+
+/-- Pullback an `order_top`. -/
+@[reducible] -- See note [reducible non-instances]
+def order_top.lift {α β : Type*} [has_le α] [has_top α] [has_le β] [order_top β]
+  (f : α → β) (map_le : ∀ a b, f a ≤ f b → a ≤ b) (map_top : f ⊤ = ⊤) :
+  order_top α :=
+⟨⊤, λ a, map_le _ _ $ by { rw map_top, exact le_top }⟩
+
+/-- Pullback an `order_bot`. -/
+@[reducible] -- See note [reducible non-instances]
+def order_bot.lift {α β : Type*} [has_le α] [has_bot α] [has_le β] [order_bot β]
+  (f : α → β) (map_le : ∀ a b, f a ≤ f b → a ≤ b) (map_bot : f ⊥ = ⊥) :
+  order_bot α :=
+⟨⊥, λ a, map_le _ _ $ by { rw map_bot, exact bot_le }⟩
+
+/-- Pullback a `bounded_order`. -/
+@[reducible] -- See note [reducible non-instances]
+def bounded_order.lift {α β : Type*} [has_le α] [has_top α] [has_bot α] [has_le β] [bounded_order β]
+  (f : α → β) (map_le : ∀ a b, f a ≤ f b → a ≤ b) (map_top : f ⊤ = ⊤) (map_bot : f ⊥ = ⊥) :
+  bounded_order α :=
+{ ..order_top.lift f map_le map_top, ..order_bot.lift f map_le map_bot }
+
 open set
 
+variables {α β : Type*} [topological_space α] [topological_space β]
 
-variables (α : Type*) {β : Type*} [topological_space α] [topological_space β]
 namespace topological_space
 
+/-! ### Closed sets -/
+
 /-- The type of closed subsets of a topological space. -/
-def closeds := {s : set α // is_closed s}
+structure closeds (α : Type*) [topological_space α] :=
+(carrier : set α)
+(closed' : is_closed carrier)
 
-/-- The type of closed subsets is inhabited, with default element the empty set. -/
-instance : inhabited (closeds α) := ⟨⟨∅, is_closed_empty ⟩⟩
-
-/-- The compact sets of a topological space. See also `nonempty_compacts`. -/
-def compacts : Type* := { s : set α // is_compact s }
-
-/-- The type of non-empty compact subsets of a topological space. The
-non-emptiness will be useful in metric spaces, as we will be able to put
-a distance (and not merely an edistance) on this space. -/
-def nonempty_compacts := {s : set α // s.nonempty ∧ is_compact s}
-
-/-- In an inhabited space, the type of nonempty compact subsets is also inhabited, with
-default element the singleton set containing the default element. -/
-instance nonempty_compacts_inhabited [inhabited α] : inhabited (nonempty_compacts α) :=
-⟨⟨{default}, singleton_nonempty default, is_compact_singleton ⟩⟩
-
-/-- The compact sets with nonempty interior of a topological space. See also `compacts` and
-  `nonempty_compacts`. -/
-@[nolint has_inhabited_instance]
-def positive_compacts: Type* := { s : set α // is_compact s ∧ (interior s).nonempty }
-
-/-- In a nonempty compact space, `set.univ` is a member of `positive_compacts`, the compact sets
-with nonempty interior. -/
-def positive_compacts_univ {α : Type*} [topological_space α] [compact_space α] [nonempty α] :
-  positive_compacts α :=
-⟨set.univ, compact_univ, by simp⟩
-
-@[simp] lemma positive_compacts_univ_val (α : Type*) [topological_space α] [compact_space α]
-  [nonempty α] : (positive_compacts_univ : positive_compacts α).val = univ := rfl
-
+namespace closeds
 variables {α}
+
+instance : set_like (closeds α) α :=
+{ coe := closeds.carrier,
+  coe_injective' := λ s t h, by { cases s, cases t, congr' } }
+
+lemma closed (s : closeds α) : is_closed (s : set α) := s.closed'
+
+@[ext] protected lemma ext {s t : closeds α} (h : s.1 = t.1) : s = t := set_like.ext' h
+
+instance : has_sup (closeds α) := ⟨λ s t, ⟨s ∪ t, s.closed.union t.closed⟩⟩
+instance : has_inf (closeds α) := ⟨λ s t, ⟨s ∩ t, s.closed.inter t.closed⟩⟩
+instance : has_top (closeds α) := ⟨⟨univ, is_closed_univ⟩⟩
+instance : has_bot (closeds α) := ⟨⟨∅, is_closed_empty⟩⟩
+
+instance : lattice (closeds α) := set_like.coe_injective.lattice _ (λ _ _, rfl) (λ _ _, rfl)
+instance : bounded_order (closeds α) := bounded_order.lift (coe : _ → set α) (λ _ _, id) rfl rfl
+
+/-- The type of closed sets is inhabited, with default element the empty set. -/
+instance : inhabited (closeds α) := ⟨⊥⟩
+
+@[simp] lemma coe_sup (s t : closeds α) : (↑(s ⊔ t) : set α) = s ∪ t := rfl
+@[simp] lemma coe_inf (s t : closeds α) : (↑(s ⊓ t) : set α) = s ∩ t := rfl
+@[simp] lemma coe_top : (↑(⊤ : closeds α) : set α) = univ := rfl
+@[simp] lemma coe_bot : (↑(⊥ : closeds α) : set α) = ∅ := rfl
+
+end closeds
+
+/-! ### Compact sets -/
+
+/-- The type of compact sets of a topological space. -/
+structure compacts (α : Type*) [topological_space α] :=
+(carrier : set α)
+(compact' : is_compact carrier)
 
 namespace compacts
 
-instance : semilattice_sup (compacts α) :=
-subtype.semilattice_sup (λ K₁ K₂, is_compact.union)
+instance : set_like (compacts α) α :=
+{ coe := compacts.carrier,
+  coe_injective' := λ s t h, by { cases s, cases t, congr' } }
 
-instance : order_bot (compacts α) :=
-subtype.order_bot is_compact_empty
+lemma compact (s : compacts α) : is_compact (s : set α) := s.compact'
 
-instance [t2_space α]: semilattice_inf (compacts α) :=
-subtype.semilattice_inf (λ K₁ K₂, is_compact.inter)
+@[ext] protected lemma ext {s t : compacts α} (h : (s : set α) = t) : s = t := set_like.ext' h
+
+instance : has_sup (compacts α) := ⟨λ s t, ⟨s ∪ t, s.compact.union t.compact⟩⟩
+instance [t2_space α] : has_inf (compacts α) := ⟨λ s t, ⟨s ∩ t, s.compact.inter t.compact⟩⟩
+instance [compact_space α] : has_top (compacts α) := ⟨⟨univ, compact_univ⟩⟩
+instance : has_bot (compacts α) := ⟨⟨∅, is_compact_empty⟩⟩
+
+instance : semilattice_sup (compacts α) := set_like.coe_injective.semilattice_sup _ (λ _ _, rfl)
 
 instance [t2_space α] : lattice (compacts α) :=
-subtype.lattice (λ K₁ K₂, is_compact.union) (λ K₁ K₂, is_compact.inter)
+set_like.coe_injective.lattice _ (λ _ _, rfl) (λ _ _, rfl)
 
-@[simp] lemma bot_val : (⊥ : compacts α).1 = ∅ := rfl
+instance : order_bot (compacts α) := order_bot.lift (coe : _ → set α) (λ _ _, id) rfl
 
-@[simp] lemma sup_val {K₁ K₂ : compacts α} : (K₁ ⊔ K₂).1 = K₁.1 ∪ K₂.1 := rfl
+instance [compact_space α] : bounded_order (compacts α) :=
+bounded_order.lift (coe : _ → set α) (λ _ _, id) rfl rfl
 
-@[ext] protected lemma ext {K₁ K₂ : compacts α} (h : K₁.1 = K₂.1) : K₁ = K₂ :=
-subtype.eq h
-
-@[simp] lemma finset_sup_val {β} {K : β → compacts α} {s : finset β} :
-  (s.sup K).1 = s.sup (λ x, (K x).1) :=
-finset.sup_coe _ _
-
+/-- The type of compact sets is inhabited, with default element the empty set. -/
 instance : inhabited (compacts α) := ⟨⊥⟩
+
+@[simp] lemma coe_sup (s t : compacts α) : (↑(s ⊔ t) : set α) = s ∪ t := rfl
+@[simp] lemma coe_inf [t2_space α] (s t : compacts α) : (↑(s ⊓ t) : set α) = s ∩ t := rfl
+@[simp] lemma coe_top [compact_space α] : (↑(⊤ : compacts α) : set α) = univ := rfl
+@[simp] lemma coe_bot : (↑(⊥ : compacts α) : set α) = ∅ := rfl
 
 /-- The image of a compact set under a continuous function. -/
 protected def map (f : α → β) (hf : continuous f) (K : compacts α) : compacts β :=
 ⟨f '' K.1, K.2.image hf⟩
 
-@[simp] lemma map_val {f : α → β} (hf : continuous f) (K : compacts α) :
-  (K.map f hf).1 = f '' K.1 := rfl
+@[simp] lemma coe_map {f : α → β} (hf : continuous f) (s : compacts α) :
+  (s.map f hf : set β) = f '' s := rfl
 
 /-- A homeomorphism induces an equivalence on compact sets, by taking the image. -/
 @[simp] protected def equiv (f : α ≃ₜ β) : compacts α ≃ compacts β :=
 { to_fun := compacts.map f f.continuous,
   inv_fun := compacts.map _ f.symm.continuous,
-  left_inv := by { intro K, ext1, simp only [map_val, ← image_comp, f.symm_comp_self, image_id] },
-  right_inv := by { intro K, ext1,
-    simp only [map_val, ← image_comp, f.self_comp_symm, image_id] } }
+  left_inv := λ s, by { ext1, simp only [coe_map, ← image_comp, f.symm_comp_self, image_id] },
+  right_inv := λ s, by { ext1, simp only [coe_map, ← image_comp, f.self_comp_symm, image_id] } }
 
 /-- The image of a compact set under a homeomorphism can also be expressed as a preimage. -/
 lemma equiv_to_fun_val (f : α ≃ₜ β) (K : compacts α) :
@@ -108,30 +144,96 @@ congr_fun (image_eq_preimage_of_inverse f.left_inv f.right_inv) K.1
 
 end compacts
 
-section nonempty_compacts
-open topological_space set
-variable {α}
+/-! ### Nonempty compact sets -/
 
-instance nonempty_compacts.to_compact_space {p : nonempty_compacts α} : compact_space p.val :=
-⟨is_compact_iff_is_compact_univ.1 p.property.2⟩
+/-- The type of nonempty compact sets of a topological space. -/
+structure nonempty_compacts (α : Type*) [topological_space α] extends compacts α :=
+(nonempty' : carrier.nonempty)
 
-instance nonempty_compacts.to_nonempty {p : nonempty_compacts α} : nonempty p.val :=
-p.property.1.to_subtype
+namespace nonempty_compacts
 
-/-- Associate to a nonempty compact subset the corresponding closed subset -/
-def nonempty_compacts.to_closeds [t2_space α] : nonempty_compacts α → closeds α :=
-set.inclusion $ λ s hs, hs.2.is_closed
+instance : set_like (nonempty_compacts α) α :=
+{ coe := λ s, s.carrier,
+  coe_injective' := λ s t h, by { obtain ⟨⟨_, _⟩, _⟩ := s, obtain ⟨⟨_, _⟩, _⟩ := t, congr' } }
+
+lemma compact (s : nonempty_compacts α) : is_compact (s : set α) := s.compact'
+protected lemma nonempty (s : nonempty_compacts α) : (s : set α).nonempty := s.nonempty'
+
+@[ext] protected lemma ext {s t : nonempty_compacts α} (h : (s : set α) = t) : s = t :=
+set_like.ext' h
+
+instance : has_sup (nonempty_compacts α) :=
+⟨λ s t, ⟨s.to_compacts ⊔ t.to_compacts, s.nonempty.mono $ subset_union_left _ _⟩⟩
+instance [compact_space α] [nonempty α] : has_top (nonempty_compacts α) := ⟨⟨⊤, univ_nonempty⟩⟩
+
+instance : semilattice_sup (nonempty_compacts α) :=
+set_like.coe_injective.semilattice_sup _ (λ _ _, rfl)
+
+instance [compact_space α] [nonempty α] : order_top (nonempty_compacts α) :=
+order_top.lift (coe : _ → set α) (λ _ _, id) rfl
+
+@[simp] lemma coe_sup (s t : nonempty_compacts α) : (↑(s ⊔ t) : set α) = s ∪ t := rfl
+@[simp] lemma coe_top [compact_space α] [nonempty α] :
+  (↑(⊤ : nonempty_compacts α) : set α) = univ := rfl
+
+/-- In an inhabited space, the type of nonempty compact subsets is also inhabited, with
+default element the singleton set containing the default element. -/
+instance [inhabited α] : inhabited (nonempty_compacts α) :=
+⟨{ carrier := {default}, compact' := is_compact_singleton, nonempty' := singleton_nonempty _ }⟩
+
+instance to_compact_space {s : nonempty_compacts α} : compact_space s :=
+⟨is_compact_iff_is_compact_univ.1 s.compact⟩
+
+instance to_nonempty {s : nonempty_compacts α} : nonempty s := s.nonempty.to_subtype
 
 end nonempty_compacts
 
-section positive_compacts
+/-! ### Positive compact sets -/
 
-variable (α)
+/-- The type of compact sets nonempty interior of a topological space. See also `compacts` and
+`nonempty_compacts` -/
+structure positive_compacts (α : Type*) [topological_space α] extends compacts α :=
+(interior_nonempty' : (interior carrier).nonempty)
+
+namespace positive_compacts
+
+instance : set_like (positive_compacts α) α :=
+{ coe := λ s, s.carrier,
+  coe_injective' := λ s t h, by { obtain ⟨⟨_, _⟩, _⟩ := s, obtain ⟨⟨_, _⟩, _⟩ := t, congr' } }
+
+lemma compact (s : positive_compacts α) : is_compact (s : set α) := s.compact'
+lemma interior_nonempty (s : positive_compacts α) : (interior (s : set α)).nonempty :=
+s.interior_nonempty'
+
+/-- Reinterpret a positive compact as a nonempty compact. -/
+def to_nonempty_compacts (s : positive_compacts α) : nonempty_compacts α :=
+⟨s.to_compacts, s.interior_nonempty.mono interior_subset⟩
+
+@[ext] protected lemma ext {s t : positive_compacts α} (h : (s : set α) = t) : s = t :=
+set_like.ext' h
+
+instance : has_sup (positive_compacts α) :=
+⟨λ s t, ⟨s.to_compacts ⊔ t.to_compacts,
+  s.interior_nonempty.mono $ interior_mono $ subset_union_left _ _⟩⟩
+instance [compact_space α] [nonempty α] : has_top (positive_compacts α) :=
+⟨⟨⊤, interior_univ.symm.subst univ_nonempty⟩⟩
+
+instance : semilattice_sup (positive_compacts α) :=
+set_like.coe_injective.semilattice_sup _ (λ _ _, rfl)
+
+instance [compact_space α] [nonempty α] : order_top (positive_compacts α) :=
+order_top.lift (coe : _ → set α) (λ _ _, id) rfl
+
+@[simp] lemma coe_sup (s t : positive_compacts α) : (↑(s ⊔ t) : set α) = s ∪ t := rfl
+@[simp] lemma coe_top [compact_space α] [nonempty α] :
+  (↑(⊤ : positive_compacts α) : set α) = univ := rfl
+
+instance [compact_space α] [nonempty α] : inhabited (positive_compacts α) := ⟨⊤⟩
+
 /-- In a nonempty locally compact space, there exists a compact set with nonempty interior. -/
-instance nonempty_positive_compacts [locally_compact_space α] [h : nonempty α] :
-  nonempty (positive_compacts α) :=
-let ⟨K, hK⟩ := exists_compact_subset is_open_univ $ mem_univ h.some in ⟨⟨K, hK.1, ⟨_, hK.2.1⟩⟩⟩
+instance [locally_compact_space α] [nonempty α] : nonempty (positive_compacts α) :=
+let ⟨s, hs⟩ := exists_compact_subset is_open_univ $ mem_univ (classical.arbitrary α) in
+  ⟨{ carrier := s, compact' := hs.1, interior_nonempty' := ⟨_, hs.2.1⟩ }⟩
 
 end positive_compacts
-
 end topological_space

--- a/src/topology/compacts.lean
+++ b/src/topology/compacts.lean
@@ -138,6 +138,9 @@ instance : set_like (nonempty_compacts α) α :=
 lemma compact (s : nonempty_compacts α) : is_compact (s : set α) := s.compact'
 protected lemma nonempty (s : nonempty_compacts α) : (s : set α).nonempty := s.nonempty'
 
+/-- Reinterpret a nonempty compact as a closed set. -/
+def to_closeds (s : nonempty_compacts α) : closeds α := ⟨s, s.compact.is_closed⟩
+
 @[ext] protected lemma ext {s t : nonempty_compacts α} (h : (s : set α) = t) : s = t :=
 set_like.ext' h
 

--- a/src/topology/compacts.lean
+++ b/src/topology/compacts.lean
@@ -139,7 +139,7 @@ lemma compact (s : nonempty_compacts α) : is_compact (s : set α) := s.compact'
 protected lemma nonempty (s : nonempty_compacts α) : (s : set α).nonempty := s.nonempty'
 
 /-- Reinterpret a nonempty compact as a closed set. -/
-def to_closeds (s : nonempty_compacts α) : closeds α := ⟨s, s.compact.is_closed⟩
+def to_closeds [t2_space α] (s : nonempty_compacts α) : closeds α := ⟨s, s.compact.is_closed⟩
 
 @[ext] protected lemma ext {s t : nonempty_compacts α} (h : (s : set α) = t) : s = t :=
 set_like.ext' h

--- a/src/topology/compacts.lean
+++ b/src/topology/compacts.lean
@@ -3,13 +3,12 @@ Copyright (c) 2020 Floris van Doorn. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Floris van Doorn, Yaël Dillies
 -/
-import data.set_like.basic
 import topology.homeomorph
 
 /-!
 # Compact sets
 
-We define a few type of sets in a topological space.
+We define a few types of sets in a topological space.
 
 ## Main Definitions
 
@@ -42,7 +41,7 @@ instance : set_like (closeds α) α :=
 
 lemma closed (s : closeds α) : is_closed (s : set α) := s.closed'
 
-@[ext] protected lemma ext {s t : closeds α} (h : s.1 = t.1) : s = t := set_like.ext' h
+@[ext] protected lemma ext {s t : closeds α} (h : (s : set α) = t) : s = t := set_like.ext' h
 
 @[simp] lemma coe_mk (s : set α) (h) : (mk s h : set α) = s := rfl
 

--- a/src/topology/compacts.lean
+++ b/src/topology/compacts.lean
@@ -102,6 +102,15 @@ instance : inhabited (compacts α) := ⟨⊥⟩
 @[simp] lemma coe_top [compact_space α] : (↑(⊤ : compacts α) : set α) = univ := rfl
 @[simp] lemma coe_bot : (↑(⊥ : compacts α) : set α) = ∅ := rfl
 
+@[simp] lemma coe_finset_sup {ι : Type*} {s : finset ι} {f : ι → compacts α} :
+  (↑(s.sup f) : set α) = s.sup (λ i, f i) :=
+begin
+  classical,
+  refine finset.induction_on s rfl (λ a s _ h, _),
+  simp_rw [finset.sup_insert, coe_sup, sup_eq_union],
+  congr',
+end
+
 /-- The image of a compact set under a continuous function. -/
 protected def map (f : α → β) (hf : continuous f) (K : compacts α) : compacts β :=
 ⟨f '' K.1, K.2.image hf⟩

--- a/src/topology/compacts.lean
+++ b/src/topology/compacts.lean
@@ -20,27 +20,6 @@ For a topological space `α`,
 - `positive_compacts α`: The type of compact sets with non-empty interior.
 -/
 
-/-- Pullback an `order_top`. -/
-@[reducible] -- See note [reducible non-instances]
-def order_top.lift {α β : Type*} [has_le α] [has_top α] [has_le β] [order_top β]
-  (f : α → β) (map_le : ∀ a b, f a ≤ f b → a ≤ b) (map_top : f ⊤ = ⊤) :
-  order_top α :=
-⟨⊤, λ a, map_le _ _ $ by { rw map_top, exact le_top }⟩
-
-/-- Pullback an `order_bot`. -/
-@[reducible] -- See note [reducible non-instances]
-def order_bot.lift {α β : Type*} [has_le α] [has_bot α] [has_le β] [order_bot β]
-  (f : α → β) (map_le : ∀ a b, f a ≤ f b → a ≤ b) (map_bot : f ⊥ = ⊥) :
-  order_bot α :=
-⟨⊥, λ a, map_le _ _ $ by { rw map_bot, exact bot_le }⟩
-
-/-- Pullback a `bounded_order`. -/
-@[reducible] -- See note [reducible non-instances]
-def bounded_order.lift {α β : Type*} [has_le α] [has_top α] [has_bot α] [has_le β] [bounded_order β]
-  (f : α → β) (map_le : ∀ a b, f a ≤ f b → a ≤ b) (map_top : f ⊤ = ⊤) (map_bot : f ⊥ = ⊥) :
-  bounded_order α :=
-{ ..order_top.lift f map_le map_top, ..order_bot.lift f map_le map_bot }
-
 open set
 
 variables {α β : Type*} [topological_space α] [topological_space β]

--- a/src/topology/metric_space/closeds.lean
+++ b/src/topology/metric_space/closeds.lean
@@ -250,7 +250,10 @@ lemma nonempty_compacts.is_closed_in_closeds [complete_space α] :
 begin
   have : range nonempty_compacts.to_closeds =
     {s : closeds α | (s : set α).nonempty ∧ is_compact (s : set α) },
-    from range_inclusion _,
+  { ext s,
+    refine ⟨_, λ h, ⟨⟨⟨s, h.2⟩, h.1⟩, closeds.ext rfl⟩⟩,
+    rintro ⟨s, hs, rfl⟩,
+    exact ⟨s.nonempty, s.compact⟩ },
   rw this,
   refine is_closed_of_closure_subset (λs hs, ⟨_, _⟩),
   { -- take a set set t which is nonempty and at a finite distance of s
@@ -258,7 +261,7 @@ begin
     rw edist_comm at Dst,
     -- since `t` is nonempty, so is `s`
     exact nonempty_of_Hausdorff_edist_ne_top ht.1 (ne_of_lt Dst) },
-  { refine compact_iff_totally_bounded_complete.2 ⟨_, s.property.is_complete⟩,
+  { refine compact_iff_totally_bounded_complete.2 ⟨_, s.closed.is_complete⟩,
     refine totally_bounded_iff.2 (λε (εpos : 0 < ε), _),
     -- we have to show that s is covered by finitely many eballs of radius ε
     -- pick a nonempty compact set t at distance at most ε/2 of s

--- a/src/topology/metric_space/closeds.lean
+++ b/src/topology/metric_space/closeds.lean
@@ -35,51 +35,51 @@ variables {α : Type u} [emetric_space α] {s : set α}
 /-- In emetric spaces, the Hausdorff edistance defines an emetric space structure
 on the type of closed subsets -/
 instance closeds.emetric_space : emetric_space (closeds α) :=
-{ edist               := λs t, Hausdorff_edist s.val t.val,
+{ edist               := λs t, Hausdorff_edist (s : set α) t,
   edist_self          := λs, Hausdorff_edist_self,
   edist_comm          := λs t, Hausdorff_edist_comm,
   edist_triangle      := λs t u, Hausdorff_edist_triangle,
   eq_of_edist_eq_zero :=
-    λs t h, subtype.eq ((Hausdorff_edist_zero_iff_eq_of_closed s.property t.property).1 h) }
+    λ s t h, closeds.ext $ (Hausdorff_edist_zero_iff_eq_of_closed s.closed t.closed).1 h }
 
 /-- The edistance to a closed set depends continuously on the point and the set -/
 lemma continuous_inf_edist_Hausdorff_edist :
-  continuous (λp : α × (closeds α), inf_edist p.1 (p.2).val) :=
+  continuous (λ p : α × (closeds α), inf_edist p.1 p.2) :=
 begin
   refine continuous_of_le_add_edist 2 (by simp) _,
   rintros ⟨x, s⟩ ⟨y, t⟩,
-  calc inf_edist x (s.val) ≤ inf_edist x (t.val) + Hausdorff_edist (t.val) (s.val) :
+  calc inf_edist x s ≤ inf_edist x t + Hausdorff_edist (t : set α) s :
     inf_edist_le_inf_edist_add_Hausdorff_edist
-  ... ≤ (inf_edist y (t.val) + edist x y) + Hausdorff_edist (t.val) (s.val) :
+  ... ≤ inf_edist y t + edist x y + Hausdorff_edist (t : set α) s :
     add_le_add_right inf_edist_le_inf_edist_add_edist _
-  ... = inf_edist y (t.val) + (edist x y + Hausdorff_edist (s.val) (t.val)) :
-    by simp [add_comm, add_left_comm, Hausdorff_edist_comm, -subtype.val_eq_coe]
-  ... ≤ inf_edist y (t.val) + (edist (x, s) (y, t) + edist (x, s) (y, t)) :
+  ... = inf_edist y t + (edist x y + Hausdorff_edist (s : set α) t)
+      : by rw [add_assoc, Hausdorff_edist_comm]
+  ... ≤ inf_edist y t + (edist (x, s) (y, t) + edist (x, s) (y, t)) :
     add_le_add_left (add_le_add (le_max_left _ _) (le_max_right _ _)) _
-  ... = inf_edist y (t.val) + 2 * edist (x, s) (y, t) :
+  ... = inf_edist y t + 2 * edist (x, s) (y, t) :
     by rw [← mul_two, mul_comm]
 end
 
 /-- Subsets of a given closed subset form a closed set -/
 lemma is_closed_subsets_of_is_closed (hs : is_closed s) :
-  is_closed {t : closeds α | t.val ⊆ s} :=
+  is_closed {t : closeds α | (t : set α) ⊆ s} :=
 begin
   refine is_closed_of_closure_subset (λt ht x hx, _),
-  -- t : closeds α,  ht : t ∈ closure {t : closeds α | t.val ⊆ s},
-  -- x : α,  hx : x ∈ t.val
+  -- t : closeds α,  ht : t ∈ closure {t : closeds α | t ⊆ s},
+  -- x : α,  hx : x ∈ t
   -- goal : x ∈ s
   have : x ∈ closure s,
   { refine mem_closure_iff.2 (λε εpos, _),
     rcases mem_closure_iff.1 ht ε εpos with ⟨u, hu, Dtu⟩,
-    -- u : closeds α,  hu : u ∈ {t : closeds α | t.val ⊆ s},  hu' : edist t u < ε
+    -- u : closeds α,  hu : u ∈ {t : closeds α | t ⊆ s},  hu' : edist t u < ε
     rcases exists_edist_lt_of_Hausdorff_edist_lt hx Dtu with ⟨y, hy, Dxy⟩,
-    -- y : α,  hy : y ∈ u.val, Dxy : edist x y < ε
+    -- y : α,  hy : y ∈ u, Dxy : edist x y < ε
     exact ⟨y, hu hy, Dxy⟩ },
   rwa hs.closure_eq at this,
 end
 
 /-- By definition, the edistance on `closeds α` is given by the Hausdorff edistance -/
-lemma closeds.edist_eq {s t : closeds α} : edist s t = Hausdorff_edist s.val t.val := rfl
+lemma closeds.edist_eq {s t : closeds α} : edist s t = Hausdorff_edist (s : set α) t := rfl
 
 /-- In a complete space, the type of closed subsets is complete for the
 Hausdorff edistance. -/
@@ -100,11 +100,11 @@ begin
   in `t0` is close to a point in `s n`. The completeness then follows from a
   standard criterion. -/
   refine complete_of_convergent_controlled_sequences B B_pos (λs hs, _),
-  let t0 := ⋂n, closure (⋃m≥n, (s m).val),
+  let t0 := ⋂ n, closure (⋃ m ≥ n, s m : set α),
   let t : closeds α := ⟨t0, is_closed_Inter (λ_, is_closed_closure)⟩,
   use t,
   -- The inequality is written this way to agree with `edist_le_of_edist_le_geometric_of_tendsto₀`
-  have I1 : ∀n:ℕ, ∀x ∈ (s n).val, ∃y ∈ t0, edist x y ≤ 2 * B n,
+  have I1 : ∀ n, ∀ x ∈ s n, ∃ y ∈ t0, edist x y ≤ 2 * B n,
   { /- This is the main difficulty of the proof. Starting from `x ∈ s n`, we want
        to find a point in `t0` which is close to `x`. Define inductively a sequence of
        points `z m` with `z n = x` and `z m ∈ s m` and `edist (z m) (z (m+1)) ≤ B m`. This is
@@ -112,13 +112,15 @@ begin
        This sequence is a Cauchy sequence, therefore converging as the space is complete, to
        a limit which satisfies the required properties. -/
     assume n x hx,
-    obtain ⟨z, hz₀, hz⟩ : ∃ z : Π l, (s (n+l)).val, (z 0:α) = x ∧
+    obtain ⟨z, hz₀, hz⟩ : ∃ z : Π l, s (n + l), (z 0 : α) = x ∧
       ∀ k, edist (z k:α) (z (k+1):α) ≤ B n / 2^k,
     { -- We prove existence of the sequence by induction.
-      have : ∀ (l : ℕ) (z : (s (n+l)).val), ∃ z' : (s (n+l+1)).val, edist (z:α) z' ≤ B n / 2^l,
+      have : ∀ l (z : s (n + l)), ∃ z' : s (n + l + 1), edist (z : α) z' ≤ B n / 2^l,
       { assume l z,
-        obtain ⟨z', z'_mem, hz'⟩ : ∃ z' ∈ (s (n+l+1)).val, edist (z:α) z' < B n / 2^l,
-        { apply exists_edist_lt_of_Hausdorff_edist_lt z.2,
+        obtain ⟨z', z'_mem, hz'⟩ : ∃ z' ∈ s (n + l + 1), edist (z : α) z' < B n / 2^l,
+        { refine exists_edist_lt_of_Hausdorff_edist_lt _ _,
+          { exact s (n + l) },
+          { exact z.2 },
           simp only [B, ennreal.inv_pow, div_eq_mul_inv],
           rw [← pow_add],
           apply hs; simp },
@@ -144,7 +146,7 @@ begin
     -- is the limit of `z k`, and the distance between `z n` and `z k` has already been estimated.
     rw [← hz₀],
     exact edist_le_of_edist_le_geometric_two_of_tendsto₀ (B n) hz y_lim },
-  have I2 : ∀n:ℕ, ∀x ∈ t0, ∃y ∈ (s n).val, edist x y ≤ 2 * B n,
+  have I2 : ∀ n, ∀ x ∈ t0, ∃ y ∈ s n, edist x y ≤ 2 * B n,
   { /- For the (much easier) reverse inequality, we start from a point `x ∈ t0` and we want
         to find a point `y ∈ s n` which is close to `x`.
         `x` belongs to `t0`, the intersection of the closures. In particular, it is well
@@ -152,15 +154,15 @@ begin
         `s n` are close, this point is itself well approximated by a point `y` in `s n`,
         as required. -/
     assume n x xt0,
-    have : x ∈ closure (⋃m≥n, (s m).val), by apply mem_Inter.1 xt0 n,
+    have : x ∈ closure (⋃ m ≥ n, s m : set α), by apply mem_Inter.1 xt0 n,
     rcases mem_closure_iff.1 this (B n) (B_pos n) with ⟨z, hz, Dxz⟩,
     -- z : α,  Dxz : edist x z < B n,
     simp only [exists_prop, set.mem_Union] at hz,
     rcases hz with ⟨m, ⟨m_ge_n, hm⟩⟩,
-    -- m : ℕ, m_ge_n : m ≥ n, hm : z ∈ (s m).val
-    have : Hausdorff_edist (s m).val (s n).val < B n := hs n m n m_ge_n (le_refl n),
+    -- m : ℕ, m_ge_n : m ≥ n, hm : z ∈ s m
+    have : Hausdorff_edist (s m : set α) (s n) < B n := hs n m n m_ge_n (le_refl n),
     rcases exists_edist_lt_of_Hausdorff_edist_lt hm this with ⟨y, hy, Dzy⟩,
-    -- y : α,  hy : y ∈ (s n).val,  Dzy : edist z y < B n
+    -- y : α,  hy : y ∈ s n,  Dzy : edist z y < B n
     exact ⟨y, hy, calc
       edist x y ≤ edist x z + edist z y : edist_triangle _ _ _
             ... ≤ B n + B n : add_le_add (le_of_lt Dxz) (le_of_lt Dzy)
@@ -206,19 +208,17 @@ instance closeds.compact_space [compact_space α] : compact_space (closeds α) :
     { rintros x ⟨hx1, ⟨y, yu, hy⟩⟩,
       exact ⟨y, yu, le_of_lt hy⟩ }},
   -- introduce the set F of all subsets of `s` (seen as members of `closeds α`).
-  let F := {f : closeds α | f.val ⊆ s},
-  use F,
-  split,
+  let F := {f : closeds α | (f : set α) ⊆ s},
+  refine ⟨F, _, λ u _, _⟩,
   -- `F` is finite
-  { apply @finite_of_finite_image _ _ F (λf, f.val),
-    { exact subtype.val_injective.inj_on F },
+  { apply @finite_of_finite_image _ _ F coe,
+    { exact set_like.coe_injective.inj_on F },
     { refine fs.finite_subsets.subset (λb, _),
       simp only [and_imp, set.mem_image, set.mem_set_of_eq, exists_imp_distrib],
       assume x hx hx',
       rwa hx' at hx }},
   -- `F` is ε-dense
-  { assume u _,
-    rcases main u.val with ⟨t0, t0s, Dut0⟩,
+  { obtain ⟨t0, t0s, Dut0⟩ := main u,
     have : is_closed t0 := (fs.subset t0s).is_compact.is_closed,
     let t : closeds α := ⟨t0, this⟩,
     have : t ∈ F := t0s,
@@ -230,14 +230,13 @@ end⟩
 /-- In an emetric space, the type of non-empty compact subsets is an emetric space,
 where the edistance is the Hausdorff edistance -/
 instance nonempty_compacts.emetric_space : emetric_space (nonempty_compacts α) :=
-{ edist               := λs t, Hausdorff_edist s.val t.val,
+{ edist               := λ s t, Hausdorff_edist (s : set α) t,
   edist_self          := λs, Hausdorff_edist_self,
   edist_comm          := λs t, Hausdorff_edist_comm,
   edist_triangle      := λs t u, Hausdorff_edist_triangle,
-  eq_of_edist_eq_zero := λs t h, subtype.eq $ begin
-    have : closure (s.val) = closure (t.val) := Hausdorff_edist_zero_iff_closure_eq_closure.1 h,
-    rwa [s.property.2.is_closed.closure_eq,
-              t.property.2.is_closed.closure_eq] at this,
+  eq_of_edist_eq_zero := λ s t h, nonempty_compacts.ext $ begin
+    have : closure (s : set α) = closure t := Hausdorff_edist_zero_iff_closure_eq_closure.1 h,
+    rwa [s.compact.is_closed.closure_eq, t.compact.is_closed.closure_eq] at this,
   end }
 
 /-- `nonempty_compacts.to_closeds` is a uniform embedding (as it is an isometry) -/
@@ -249,7 +248,8 @@ isometry.uniform_embedding $ λx y, rfl
 lemma nonempty_compacts.is_closed_in_closeds [complete_space α] :
   is_closed (range $ @nonempty_compacts.to_closeds α _ _) :=
 begin
-  have : range nonempty_compacts.to_closeds = {s : closeds α | s.val.nonempty ∧ is_compact s.val},
+  have : range nonempty_compacts.to_closeds =
+    {s : closeds α | (s : set α).nonempty ∧ is_compact (s : set α) },
     from range_inclusion _,
   rw this,
   refine is_closed_of_closure_subset (λs hs, ⟨_, _⟩),
@@ -267,7 +267,7 @@ begin
     rcases totally_bounded_iff.1 (compact_iff_totally_bounded_complete.1 ht.2).1 (ε/2)
       (ennreal.half_pos εpos.ne') with ⟨u, fu, ut⟩,
     refine ⟨u, ⟨fu, λx hx, _⟩⟩,
-    -- u : set α,  fu : finite u,  ut : t.val ⊆ ⋃ (y : α) (H : y ∈ u), eball y (ε / 2)
+    -- u : set α,  fu : finite u,  ut : t ⊆ ⋃ (y : α) (H : y ∈ u), eball y (ε / 2)
     -- then s is covered by the union of the balls centered at u of radius ε
     rcases exists_edist_lt_of_Hausdorff_edist_lt hx Dst with ⟨z, hz, Dxz⟩,
     rcases mem_Union₂.1 (ut hz) with ⟨y, hy, Dzy⟩,
@@ -309,10 +309,10 @@ begin
     of `t`. -/
     rcases exists_countable_dense α with ⟨s, cs, s_dense⟩,
     let v0 := {t : set α | finite t ∧ t ⊆ s},
-    let v : set (nonempty_compacts α) := {t : nonempty_compacts α | t.val ∈ v0},
-    refine  ⟨⟨v, ⟨_, _⟩⟩⟩,
+    let v : set (nonempty_compacts α) := {t : nonempty_compacts α | (t : set α) ∈ v0},
+    refine  ⟨⟨v, _, _⟩⟩,
     { have : countable v0, from countable_set_of_finite_subset cs,
-      exact this.preimage subtype.coe_injective },
+      exact this.preimage set_like.coe_injective },
     { refine λt, mem_closure_iff.2 (λε εpos, _),
       -- t is a compact nonempty set, that we have to approximate uniformly by a a set in `v`.
       rcases exists_between εpos with ⟨δ, δpos, δlt⟩,
@@ -326,13 +326,13 @@ begin
       have Fspec : ∀x, F x ∈ s ∧ edist x (F x) < δ/2 := λx, some_spec (Exy x),
 
       -- cover `t` with finitely many balls. Their centers form a set `a`
-      have : totally_bounded t.val := t.property.2.totally_bounded,
+      have : totally_bounded (t : set α) := t.compact.totally_bounded,
       rcases totally_bounded_iff.1 this (δ/2) δpos' with ⟨a, af, ta⟩,
-      -- a : set α,  af : finite a,  ta : t.val ⊆ ⋃ (y : α) (H : y ∈ a), eball y (δ / 2)
+      -- a : set α,  af : finite a,  ta : t ⊆ ⋃ (y : α) (H : y ∈ a), eball y (δ / 2)
       -- replace each center by a nearby approximation in `s`, giving a new set `b`
       let b := F '' a,
       have : finite b := af.image _,
-      have tb : ∀x ∈ t.val, ∃y ∈ b, edist x y < δ,
+      have tb : ∀ x ∈ t, ∃ y ∈ b, edist x y < δ,
       { assume x hx,
         rcases mem_Union₂.1 (ta hx) with ⟨z, za, Dxz⟩,
         existsi [F z, mem_image_of_mem _ za],
@@ -340,30 +340,30 @@ begin
              ... < δ/2 + δ/2 : ennreal.add_lt_add Dxz (Fspec z).2
              ... = δ : ennreal.add_halves _ },
       -- keep only the points in `b` that are close to point in `t`, yielding a new set `c`
-      let c := {y ∈ b | ∃x∈t.val, edist x y < δ},
+      let c := {y ∈ b | ∃ x ∈ t, edist x y < δ},
       have : finite c := ‹finite b›.subset (λx hx, hx.1),
       -- points in `t` are well approximated by points in `c`
-      have tc : ∀x ∈ t.val, ∃y ∈ c, edist x y ≤ δ,
+      have tc : ∀ x ∈ t, ∃ y ∈ c, edist x y ≤ δ,
       { assume x hx,
         rcases tb x hx with ⟨y, yv, Dxy⟩,
         have : y ∈ c := by simp [c, -mem_image]; exact ⟨yv, ⟨x, hx, Dxy⟩⟩,
         exact ⟨y, this, le_of_lt Dxy⟩ },
       -- points in `c` are well approximated by points in `t`
-      have ct : ∀y ∈ c, ∃x ∈ t.val, edist y x ≤ δ,
-      { rintros y ⟨hy1, ⟨x, xt, Dyx⟩⟩,
+      have ct : ∀ y ∈ c, ∃ x ∈ t, edist y x ≤ δ,
+      { rintro y ⟨hy1, x, xt, Dyx⟩,
         have : edist y x ≤ δ := calc
           edist y x = edist x y : edist_comm _ _
           ... ≤ δ : le_of_lt Dyx,
         exact ⟨x, xt, this⟩ },
       -- it follows that their Hausdorff distance is small
-      have : Hausdorff_edist t.val c ≤ δ :=
+      have : Hausdorff_edist (t :set α) c ≤ δ :=
         Hausdorff_edist_le_of_mem_edist tc ct,
-      have Dtc : Hausdorff_edist t.val c < ε := lt_of_le_of_lt this δlt,
+      have Dtc : Hausdorff_edist (t : set α) c < ε := this.trans_lt δlt,
       -- the set `c` is not empty, as it is well approximated by a nonempty set
       have hc : c.nonempty,
-        from nonempty_of_Hausdorff_edist_ne_top t.property.1 (ne_top_of_lt Dtc),
+        from nonempty_of_Hausdorff_edist_ne_top t.nonempty (ne_top_of_lt Dtc),
       -- let `d` be the version of `c` in the type `nonempty_compacts α`
-      let d : nonempty_compacts α := ⟨c, ⟨hc, ‹finite c›.is_compact⟩⟩,
+      let d : nonempty_compacts α := ⟨⟨c, ‹finite c›.is_compact⟩, hc⟩,
       have : c ⊆ s,
       { assume x hx,
         rcases (mem_image _ _ _).1 hx.1 with ⟨y, ⟨ya, yx⟩⟩,
@@ -387,26 +387,24 @@ variables {α : Type u} [metric_space α]
 /-- `nonempty_compacts α` inherits a metric space structure, as the Hausdorff
 edistance between two such sets is finite. -/
 instance nonempty_compacts.metric_space : metric_space (nonempty_compacts α) :=
-emetric_space.to_metric_space $ λx y, Hausdorff_edist_ne_top_of_nonempty_of_bounded x.2.1 y.2.1
-  x.2.2.bounded y.2.2.bounded
+emetric_space.to_metric_space $ λ x y, Hausdorff_edist_ne_top_of_nonempty_of_bounded
+  x.nonempty y.nonempty x.compact.bounded y.compact.bounded
 
 /-- The distance on `nonempty_compacts α` is the Hausdorff distance, by construction -/
 lemma nonempty_compacts.dist_eq {x y : nonempty_compacts α} :
-  dist x y = Hausdorff_dist x.val y.val := rfl
+  dist x y = Hausdorff_dist (x : set α) y := rfl
 
-lemma lipschitz_inf_dist_set (x : α) :
-  lipschitz_with 1 (λ s : nonempty_compacts α, inf_dist x s.val) :=
+lemma lipschitz_inf_dist_set (x : α) : lipschitz_with 1 (λ s : nonempty_compacts α, inf_dist x s) :=
 lipschitz_with.of_le_add $ assume s t,
 by { rw dist_comm,
   exact inf_dist_le_inf_dist_add_Hausdorff_dist (edist_ne_top t s) }
 
-lemma lipschitz_inf_dist :
-  lipschitz_with 2 (λ p : α × (nonempty_compacts α), inf_dist p.1 p.2.val) :=
-@lipschitz_with.uncurry _ _ _ _ _ _ (λ (x : α) (s : nonempty_compacts α), inf_dist x s.val) 1 1
-  (λ s, lipschitz_inf_dist_pt s.val) lipschitz_inf_dist_set
+lemma lipschitz_inf_dist : lipschitz_with 2 (λ p : α × (nonempty_compacts α), inf_dist p.1 p.2) :=
+@lipschitz_with.uncurry _ _ _ _ _ _ (λ (x : α) (s : nonempty_compacts α), inf_dist x s) 1 1
+  (λ s, lipschitz_inf_dist_pt s) lipschitz_inf_dist_set
 
 lemma uniform_continuous_inf_dist_Hausdorff_dist :
-  uniform_continuous (λp : α × (nonempty_compacts α), inf_dist p.1 (p.2).val) :=
+  uniform_continuous (λ p : α × (nonempty_compacts α), inf_dist p.1 p.2) :=
 lipschitz_inf_dist.uniform_continuous
 
 end --section

--- a/src/topology/metric_space/gromov_hausdorff.lean
+++ b/src/topology/metric_space/gromov_hausdorff.lean
@@ -218,7 +218,6 @@ begin
   apply (mem_image _ _ _).2,
   existsi (⟨A, B⟩ : nonempty_compacts ℓ_infty_ℝ × nonempty_compacts ℓ_infty_ℝ),
   simp [AX, BY],
-  refl,
 end
 
 /-- The optimal coupling constructed above realizes exactly the Gromov-Hausdorff distance,

--- a/src/topology/metric_space/gromov_hausdorff.lean
+++ b/src/topology/metric_space/gromov_hausdorff.lean
@@ -62,9 +62,8 @@ Using the Kuratwoski embedding, we get a canonical map `to_GH_space` mapping any
 compact type to `GH_space`. -/
 
 /-- Equivalence relation identifying two nonempty compact sets which are isometric -/
-private definition isometry_rel :
-  nonempty_compacts ℓ_infty_ℝ → nonempty_compacts ℓ_infty_ℝ → Prop :=
-  λ x y, nonempty (x.val ≃ᵢ y.val)
+private def isometry_rel : nonempty_compacts ℓ_infty_ℝ → nonempty_compacts ℓ_infty_ℝ → Prop :=
+λ x y, nonempty (x ≃ᵢ y)
 
 /-- This is indeed an equivalence relation -/
 private lemma is_equivalence_isometry_rel : equivalence isometry_rel :=
@@ -81,50 +80,47 @@ definition GH_space : Type := quotient (isometry_rel.setoid)
 definition to_GH_space (X : Type u) [metric_space X] [compact_space X] [nonempty X] : GH_space :=
   ⟦nonempty_compacts.Kuratowski_embedding X⟧
 
-instance : inhabited GH_space := ⟨quot.mk _ ⟨{0}, by simp⟩⟩
+instance : inhabited GH_space := ⟨quot.mk _ ⟨⟨{0}, is_compact_singleton⟩, singleton_nonempty _⟩⟩
 
 /-- A metric space representative of any abstract point in `GH_space` -/
 @[nolint has_inhabited_instance]
-definition GH_space.rep (p : GH_space) : Type := (quot.out p).val
+def GH_space.rep (p : GH_space) : Type := (quotient.out p : nonempty_compacts ℓ_infty_ℝ)
 
 lemma eq_to_GH_space_iff {X : Type u} [metric_space X] [compact_space X] [nonempty X]
   {p : nonempty_compacts ℓ_infty_ℝ} :
-  ⟦p⟧ = to_GH_space X ↔ ∃ Ψ : X → ℓ_infty_ℝ, isometry Ψ ∧ range Ψ = p.val :=
+  ⟦p⟧ = to_GH_space X ↔ ∃ Ψ : X → ℓ_infty_ℝ, isometry Ψ ∧ range Ψ = p :=
 begin
   simp only [to_GH_space, quotient.eq],
   refine ⟨λ h, _, _⟩,
   { rcases setoid.symm h with ⟨e⟩,
     have f := (Kuratowski_embedding.isometry X).isometric_on_range.trans e,
     use [λ x, f x, isometry_subtype_coe.comp f.isometry],
-    rw [range_comp, f.range_eq_univ, set.image_univ, subtype.range_coe] },
+    rw [range_comp, f.range_eq_univ, set.image_univ, subtype.range_coe],
+    refl },
   { rintros ⟨Ψ, ⟨isomΨ, rangeΨ⟩⟩,
     have f := ((Kuratowski_embedding.isometry X).isometric_on_range.symm.trans
                isomΨ.isometric_on_range).symm,
-    have E : (range Ψ ≃ᵢ (nonempty_compacts.Kuratowski_embedding X).val) =
-        (p.val ≃ᵢ range (Kuratowski_embedding X)),
+    have E : (range Ψ ≃ᵢ nonempty_compacts.Kuratowski_embedding X) =
+        (p ≃ᵢ range (Kuratowski_embedding X)),
       by { dunfold nonempty_compacts.Kuratowski_embedding, rw [rangeΨ]; refl },
     exact ⟨cast E f⟩ }
 end
 
-lemma eq_to_GH_space {p : nonempty_compacts ℓ_infty_ℝ} : ⟦p⟧ = to_GH_space p.val :=
+lemma eq_to_GH_space {p : nonempty_compacts ℓ_infty_ℝ} : ⟦p⟧ = to_GH_space p :=
 eq_to_GH_space_iff.2 ⟨λ x, x, isometry_subtype_coe, subtype.range_coe⟩
 
 section
 local attribute [reducible] GH_space.rep
 
-instance rep_GH_space_metric_space {p : GH_space} : metric_space (p.rep) :=
-by apply_instance
+instance rep_GH_space_metric_space {p : GH_space} : metric_space p.rep := by apply_instance
+instance rep_GH_space_compact_space {p : GH_space} : compact_space p.rep := by apply_instance
+instance rep_GH_space_nonempty {p : GH_space} : nonempty p.rep := by apply_instance
 
-instance rep_GH_space_compact_space {p : GH_space} : compact_space (p.rep) :=
-by apply_instance
-
-instance rep_GH_space_nonempty {p : GH_space} : nonempty (p.rep) :=
-by apply_instance
 end
 
-lemma GH_space.to_GH_space_rep (p : GH_space) : to_GH_space (p.rep) = p :=
+lemma GH_space.to_GH_space_rep (p : GH_space) : to_GH_space p.rep = p :=
 begin
-  change to_GH_space (quot.out p).val = p,
+  change to_GH_space (quot.out p : nonempty_compacts ℓ_infty_ℝ) = p,
   rw ← eq_to_GH_space,
   exact quot.out_eq p
 end
@@ -137,8 +133,8 @@ lemma to_GH_space_eq_to_GH_space_iff_isometric {X : Type u} [metric_space X] [co
 ⟨begin
   simp only [to_GH_space, quotient.eq],
   rintro ⟨e⟩,
-  have I : ((nonempty_compacts.Kuratowski_embedding X).val ≃ᵢ
-             (nonempty_compacts.Kuratowski_embedding Y).val)
+  have I : ((nonempty_compacts.Kuratowski_embedding X) ≃ᵢ
+             (nonempty_compacts.Kuratowski_embedding Y))
           = ((range (Kuratowski_embedding X)) ≃ᵢ (range (Kuratowski_embedding Y))),
     by { dunfold nonempty_compacts.Kuratowski_embedding, refl },
   have f := (Kuratowski_embedding.isometry X).isometric_on_range,
@@ -151,8 +147,8 @@ begin
   have f := (Kuratowski_embedding.isometry X).isometric_on_range.symm,
   have g := (Kuratowski_embedding.isometry Y).isometric_on_range,
   have I : ((range (Kuratowski_embedding X)) ≃ᵢ (range (Kuratowski_embedding Y))) =
-    ((nonempty_compacts.Kuratowski_embedding X).val ≃ᵢ
-      (nonempty_compacts.Kuratowski_embedding Y).val),
+    ((nonempty_compacts.Kuratowski_embedding X) ≃ᵢ
+      (nonempty_compacts.Kuratowski_embedding Y)),
     by { dunfold nonempty_compacts.Kuratowski_embedding, refl },
   exact ⟨cast I ((f.trans e).trans g)⟩
 end⟩
@@ -163,14 +159,14 @@ we only consider embeddings in `ℓ^∞(ℝ)`, but we will prove below that it w
 instance : has_dist (GH_space) :=
 { dist := λ x y, Inf $
     (λ p : nonempty_compacts ℓ_infty_ℝ × nonempty_compacts ℓ_infty_ℝ,
-      Hausdorff_dist p.1.val p.2.val) '' ({a | ⟦a⟧ = x} ×ˢ {b | ⟦b⟧ = y}) }
+      Hausdorff_dist (p.1 : set ℓ_infty_ℝ) p.2) '' ({a | ⟦a⟧ = x} ×ˢ {b | ⟦b⟧ = y}) }
 
 /-- The Gromov-Hausdorff distance between two nonempty compact metric spaces, equal by definition to
 the distance of the equivalence classes of these spaces in the Gromov-Hausdorff space. -/
 def GH_dist (X : Type u) (Y : Type v) [metric_space X] [nonempty X] [compact_space X]
   [metric_space Y] [nonempty Y] [compact_space Y] : ℝ := dist (to_GH_space X) (to_GH_space Y)
 
-lemma dist_GH_dist (p q : GH_space) : dist p q = GH_dist (p.rep) (q.rep) :=
+lemma dist_GH_dist (p q : GH_space) : dist p q = GH_dist p.rep (q.rep) :=
 by rw [GH_dist, p.to_GH_space_rep, q.to_GH_space_rep]
 
 /-- The Gromov-Hausdorff distance between two spaces is bounded by the Hausdorff distance
@@ -207,21 +203,22 @@ begin
   rw ← this,
   -- Let `A` and `B` be the images of `X` and `Y` under this embedding. They are in `ℓ^∞(ℝ)`, and
   -- their Hausdorff distance is the same as in the original space.
-  let A : nonempty_compacts ℓ_infty_ℝ := ⟨F '' (range Φ'), ⟨(range_nonempty _).image _,
-      (is_compact_range IΦ'.continuous).image (Kuratowski_embedding.isometry _).continuous⟩⟩,
-  let B : nonempty_compacts ℓ_infty_ℝ := ⟨F '' (range Ψ'), ⟨(range_nonempty _).image _,
-      (is_compact_range IΨ'.continuous).image (Kuratowski_embedding.isometry _).continuous⟩⟩,
+  let A : nonempty_compacts ℓ_infty_ℝ := ⟨⟨F '' (range Φ'), (is_compact_range IΦ'.continuous).image
+    (Kuratowski_embedding.isometry _).continuous⟩, (range_nonempty _).image _⟩,
+  let B : nonempty_compacts ℓ_infty_ℝ := ⟨⟨F '' (range Ψ'), (is_compact_range IΨ'.continuous).image
+    (Kuratowski_embedding.isometry _).continuous⟩, (range_nonempty _).image _⟩,
   have AX : ⟦A⟧ = to_GH_space X,
   { rw eq_to_GH_space_iff,
-    exact ⟨λ x, F (Φ' x), ⟨(Kuratowski_embedding.isometry _).comp IΦ', by rw range_comp⟩⟩ },
+    exact ⟨λ x, F (Φ' x), (Kuratowski_embedding.isometry _).comp IΦ', range_comp _ _⟩ },
   have BY : ⟦B⟧ = to_GH_space Y,
   { rw eq_to_GH_space_iff,
-    exact ⟨λ x, F (Ψ' x), ⟨(Kuratowski_embedding.isometry _).comp IΨ', by rw range_comp⟩⟩ },
+    exact ⟨λ x, F (Ψ' x), (Kuratowski_embedding.isometry _).comp IΨ', range_comp _ _⟩ },
   refine cInf_le ⟨0,
     begin simp [lower_bounds], assume t _ _ _ _ ht, rw ← ht, exact Hausdorff_dist_nonneg end⟩ _,
   apply (mem_image _ _ _).2,
   existsi (⟨A, B⟩ : nonempty_compacts ℓ_infty_ℝ × nonempty_compacts ℓ_infty_ℝ),
-  simp [AX, BY]
+  simp [AX, BY],
+  refl,
 end
 
 /-- The optimal coupling constructed above realizes exactly the Gromov-Hausdorff distance,
@@ -239,10 +236,10 @@ begin
      definition of the optimal coupling, and the conclusion follows from the optimality
      of the optimal coupling within this family.
   -/
-  have A : ∀ p q : nonempty_compacts (ℓ_infty_ℝ), ⟦p⟧ = to_GH_space X → ⟦q⟧ = to_GH_space Y →
-        Hausdorff_dist (p.val) (q.val) < diam (univ : set X) + 1 + diam (univ : set Y) →
+  have A : ∀ p q : nonempty_compacts ℓ_infty_ℝ, ⟦p⟧ = to_GH_space X → ⟦q⟧ = to_GH_space Y →
+        Hausdorff_dist (p : set ℓ_infty_ℝ) q < diam (univ : set X) + 1 + diam (univ : set Y) →
         Hausdorff_dist (range (optimal_GH_injl X Y)) (range (optimal_GH_injr X Y)) ≤
-        Hausdorff_dist (p.val) (q.val),
+        Hausdorff_dist (p : set ℓ_infty_ℝ) q,
   { assume p q hp hq bound,
     rcases eq_to_GH_space_iff.1 hp with ⟨Φ, ⟨Φisom, Φrange⟩⟩,
     rcases eq_to_GH_space_iff.1 hq with ⟨Ψ, ⟨Ψisom, Ψrange⟩⟩,
@@ -250,9 +247,10 @@ begin
     { rcases exists_mem_of_nonempty X with ⟨xX, _⟩,
       have : ∃ y ∈ range Ψ, dist (Φ xX) y < diam (univ : set X) + 1 + diam (univ : set Y),
       { rw Ψrange,
-        have : Φ xX ∈ p.val := Φrange ▸ mem_range_self _,
+        have : Φ xX ∈ ↑p := Φrange.subst (mem_range_self _),
         exact exists_dist_lt_of_Hausdorff_dist_lt this bound
-          (Hausdorff_edist_ne_top_of_nonempty_of_bounded p.2.1 q.2.1 p.2.2.bounded q.2.2.bounded) },
+          (Hausdorff_edist_ne_top_of_nonempty_of_bounded p.nonempty q.nonempty
+            p.compact.bounded q.compact.bounded) },
       rcases this with ⟨y, hy, dy⟩,
       rcases mem_range.1 hy with ⟨z, hzy⟩,
       rw ← hzy at dy,
@@ -291,7 +289,7 @@ begin
             { apply mem_union_right, apply mem_range_self } },
           refine dist_le_diam_of_mem _ (A _) (A _),
           rw [Φrange, Ψrange],
-          exact (p.2.2.union q.2.2).bounded,
+          exact (p ⊔ q).compact.bounded,
         end
         ... ≤ 2 * diam (univ : set X) + 1 + 2 * diam (univ : set Y) : I } },
     let Fb := candidates_b_of_candidates F Fgood,
@@ -300,9 +298,10 @@ begin
     refine le_trans this (le_of_forall_le_of_dense (λ r hr, _)),
     have I1 : ∀ x : X, (⨅ y, Fb (inl x, inr y)) ≤ r,
     { assume x,
-      have : f (inl x) ∈ p.val, by { rw [← Φrange], apply mem_range_self },
+      have : f (inl x) ∈ ↑p := Φrange.subst (mem_range_self _),
       rcases exists_dist_lt_of_Hausdorff_dist_lt this hr
-        (Hausdorff_edist_ne_top_of_nonempty_of_bounded p.2.1 q.2.1 p.2.2.bounded q.2.2.bounded)
+        (Hausdorff_edist_ne_top_of_nonempty_of_bounded p.nonempty q.nonempty
+          p.compact.bounded q.compact.bounded)
         with ⟨z, zq, hz⟩,
       have : z ∈ range Ψ, by rwa [← Ψrange] at zq,
       rcases mem_range.1 this with ⟨y, hy⟩,
@@ -313,9 +312,10 @@ begin
         ... ≤ r : le_of_lt hz },
     have I2 : ∀ y : Y, (⨅ x, Fb (inl x, inr y)) ≤ r,
     { assume y,
-      have : f (inr y) ∈ q.val, by { rw [← Ψrange], apply mem_range_self },
+      have : f (inr y) ∈ ↑q := Ψrange.subst (mem_range_self _),
       rcases exists_dist_lt_of_Hausdorff_dist_lt' this hr
-        (Hausdorff_edist_ne_top_of_nonempty_of_bounded p.2.1 q.2.1 p.2.2.bounded q.2.2.bounded)
+        (Hausdorff_edist_ne_top_of_nonempty_of_bounded p.nonempty q.nonempty
+          p.compact.bounded q.compact.bounded)
         with ⟨z, zq, hz⟩,
       have : z ∈ range Φ, by rwa [← Φrange] at zq,
       rcases mem_range.1 this with ⟨x, hx⟩,
@@ -327,17 +327,18 @@ begin
     simp [HD, csupr_le I1, csupr_le I2] },
   /- Get the same inequality for any coupling. If the coupling is quite good, the desired
   inequality has been proved above. If it is bad, then the inequality is obvious. -/
-  have B : ∀ p q : nonempty_compacts (ℓ_infty_ℝ), ⟦p⟧ = to_GH_space X → ⟦q⟧ = to_GH_space Y →
+  have B : ∀ p q : nonempty_compacts ℓ_infty_ℝ, ⟦p⟧ = to_GH_space X → ⟦q⟧ = to_GH_space Y →
         Hausdorff_dist (range (optimal_GH_injl X Y)) (range (optimal_GH_injr X Y)) ≤
-        Hausdorff_dist (p.val) (q.val),
+        Hausdorff_dist (p : set ℓ_infty_ℝ) q,
   { assume p q hp hq,
-    by_cases h : Hausdorff_dist (p.val) (q.val) < diam (univ : set X) + 1 + diam (univ : set Y),
+    by_cases h :
+      Hausdorff_dist (p : set ℓ_infty_ℝ) q < diam (univ : set X) + 1 + diam (univ : set Y),
     { exact A p q hp hq h },
     { calc Hausdorff_dist (range (optimal_GH_injl X Y)) (range (optimal_GH_injr X Y))
                ≤ HD (candidates_b_dist X Y) :
              Hausdorff_dist_optimal_le_HD _ _ (candidates_b_dist_mem_candidates_b)
            ... ≤ diam (univ : set X) + 1 + diam (univ : set Y) : HD_candidates_b_dist_le
-           ... ≤ Hausdorff_dist (p.val) (q.val) : not_lt.1 h } },
+           ... ≤ Hausdorff_dist (p : set ℓ_infty_ℝ) q : not_lt.1 h } },
   refine le_antisymm _ _,
   { apply le_cInf,
     { refine (set.nonempty.prod _ _).image _; exact ⟨_, rfl⟩ },
@@ -378,10 +379,10 @@ instance : metric_space GH_space :=
   end,
   dist_comm := λ x y, begin
     have A : (λ (p : nonempty_compacts ℓ_infty_ℝ × nonempty_compacts ℓ_infty_ℝ),
-                 Hausdorff_dist ((p.fst).val) ((p.snd).val)) ''
+                 Hausdorff_dist (p.1 : set ℓ_infty_ℝ) p.2) ''
              ({a | ⟦a⟧ = x} ×ˢ {b | ⟦b⟧ = y})
            = ((λ (p : nonempty_compacts ℓ_infty_ℝ × nonempty_compacts ℓ_infty_ℝ),
-                 Hausdorff_dist ((p.fst).val) ((p.snd).val)) ∘ prod.swap) ''
+                 Hausdorff_dist (p.1 : set ℓ_infty_ℝ) p.2) ∘ prod.swap) ''
                  ({a | ⟦a⟧ = x} ×ˢ {b | ⟦b⟧ = y}) :=
       by { congr, funext, simp, rw Hausdorff_dist_comm },
     simp only [dist, A, image_comp, image_swap_prod],
@@ -467,7 +468,7 @@ end Gromov_Hausdorff
 /-- In particular, nonempty compacts of a metric space map to `GH_space`. We register this
 in the topological_space namespace to take advantage of the notation `p.to_GH_space`. -/
 definition topological_space.nonempty_compacts.to_GH_space {X : Type u} [metric_space X]
-  (p : nonempty_compacts X) : Gromov_Hausdorff.GH_space := Gromov_Hausdorff.to_GH_space p.val
+  (p : nonempty_compacts X) : Gromov_Hausdorff.GH_space := Gromov_Hausdorff.to_GH_space p
 
 open topological_space
 
@@ -479,13 +480,12 @@ variables {X : Type u} [metric_space X]
 theorem GH_dist_le_nonempty_compacts_dist (p q : nonempty_compacts X) :
   dist p.to_GH_space q.to_GH_space ≤ dist p q :=
 begin
-  have ha : isometry (coe : p.val → X) := isometry_subtype_coe,
-  have hb : isometry (coe : q.val → X) := isometry_subtype_coe,
-  have A : dist p q = Hausdorff_dist p.val q.val := rfl,
-  have I : p.val = range (coe : p.val → X), by simp,
-  have J : q.val = range (coe : q.val → X), by simp,
-  rw [I, J] at A,
-  rw A,
+  have ha : isometry (coe : p → X) := isometry_subtype_coe,
+  have hb : isometry (coe : q → X) := isometry_subtype_coe,
+  have A : dist p q = Hausdorff_dist (p : set X) q := rfl,
+  have I : ↑p = range (coe : p → X) := subtype.range_coe_subtype.symm,
+  have J : ↑q = range (coe : q → X) := subtype.range_coe_subtype.symm,
+  rw [A, I, J],
   exact GH_dist_le_Hausdorff_dist ha hb
 end
 
@@ -594,12 +594,12 @@ begin
   refine second_countable_of_countable_discretization (λ δ δpos, _),
   let ε := (2/5) * δ,
   have εpos : 0 < ε := mul_pos (by norm_num) δpos,
-  have : ∀ p:GH_space, ∃ s : set (p.rep), finite s ∧ (univ ⊆ (⋃x∈s, ball x ε)) :=
+  have : ∀ p:GH_space, ∃ s : set p.rep, finite s ∧ (univ ⊆ (⋃x∈s, ball x ε)) :=
     λ p, by simpa using finite_cover_balls_of_compact (@compact_univ p.rep _ _) εpos,
   -- for each `p`, `s p` is a finite `ε`-dense subset of `p` (or rather the metric space
   -- `p.rep` representing `p`)
   choose s hs using this,
-  have : ∀ p:GH_space, ∀ t:set (p.rep), finite t → ∃ n:ℕ, ∃ e:equiv t (fin n), true,
+  have : ∀ p:GH_space, ∀ t:set p.rep, finite t → ∃ n:ℕ, ∃ e:equiv t (fin n), true,
   { assume p t ht,
     letI : fintype t := finite.fintype ht,
     exact ⟨fintype.card t, fintype.equiv_fin t, trivial⟩ },
@@ -708,7 +708,7 @@ begin
           by rw [abs_of_nonneg (le_of_lt (inv_pos.2 εpos)), mul_assoc]
         ... ≤ ε * 1 : mul_le_mul_of_nonneg_left I (le_of_lt εpos)
         ... = ε : mul_one _ } },
-  calc dist p q = GH_dist (p.rep) (q.rep) : dist_GH_dist p q
+  calc dist p q = GH_dist p.rep (q.rep) : dist_GH_dist p q
     ... ≤ ε + ε/2 + ε : main
     ... = δ : by { simp [ε], ring }
 end
@@ -738,11 +738,11 @@ begin
     simp only [real.dist_eq, add_zero, sub_eq_add_neg, neg_zero] at this,
     exact le_of_lt (lt_of_le_of_lt (le_abs_self _) this) },
   -- construct a finite subset `s p` of `p` which is `ε`-dense and has cardinal `≤ K n`
-  have : ∀ p:GH_space, ∃ s : set (p.rep), ∃ N ≤ K n, ∃ E : equiv s (fin N),
+  have : ∀ p:GH_space, ∃ s : set p.rep, ∃ N ≤ K n, ∃ E : equiv s (fin N),
     p ∈ t → univ ⊆ ⋃x∈s, ball x (u n),
   { assume p,
     by_cases hp : p ∉ t,
-    { have : nonempty (equiv (∅ : set (p.rep)) (fin 0)),
+    { have : nonempty (equiv (∅ : set p.rep) (fin 0)),
       { rw ← fintype.card_eq, simp },
       use [∅, 0, bot_le, choice (this)] },
     { rcases hcov _ (set.not_not_mem.1 hp) n with ⟨s, ⟨scard, scover⟩⟩,
@@ -766,7 +766,7 @@ begin
   have Npq : N p = N q := (fin.ext_iff _ _).1 (sigma.mk.inj_iff.1 hpq).1,
   let Ψ : s p → s q := λ x, (E q).symm (fin.cast Npq ((E p) x)),
   let Φ : s p → q.rep := λ x, Ψ x,
-  have main : GH_dist (p.rep) (q.rep) ≤ ε + ε/2 + ε,
+  have main : GH_dist p.rep (q.rep) ≤ ε + ε/2 + ε,
   { -- to prove the main inequality, argue that `s p` is `ε`-dense in `p`, and `s q` is `ε`-dense
     -- in `q`, and `s p` and `s q` are almost isometric. Then closeness follows
     -- from `GH_dist_le_of_approx_subsets`
@@ -876,7 +876,7 @@ begin
           by rw [abs_of_nonneg (le_of_lt (inv_pos.2 εpos)), mul_assoc]
         ... ≤ ε * 1 : mul_le_mul_of_nonneg_left I (le_of_lt εpos)
         ... = ε : mul_one _ } },
-  calc dist p q = GH_dist (p.rep) (q.rep) : dist_GH_dist p q
+  calc dist p q = GH_dist p.rep (q.rep) : dist_GH_dist p q
     ... ≤ ε + ε/2 + ε : main
     ... = δ/2 : by { simp [ε], ring }
     ... < δ : half_lt_self δpos
@@ -990,8 +990,8 @@ begin
       exact (to_inductive_limit_isometry _ _).comp ((ic n).comp (to_glue_r_isometry _ _)) } },
   -- consider `X2 n` as a member `X3 n` of the type of nonempty compact subsets of `Z`, which
   -- is a metric space
-  let X3 : ℕ → nonempty_compacts Z := λ n, ⟨X2 n,
-    ⟨range_nonempty _, is_compact_range (isom n).continuous ⟩⟩,
+  let X3 : ℕ → nonempty_compacts Z := λ n,
+    ⟨⟨X2 n, is_compact_range (isom n).continuous⟩, range_nonempty _⟩,
   -- `X3 n` is a Cauchy sequence by construction, as the successive distances are
   -- bounded by `(1/2)^n`
   have : cauchy_seq X3,

--- a/src/topology/metric_space/kuratowski.lean
+++ b/src/topology/metric_space/kuratowski.lean
@@ -112,5 +112,6 @@ classical.some_spec (exists_isometric_embedding α)
 def nonempty_compacts.Kuratowski_embedding (α : Type u) [metric_space α] [compact_space α]
   [nonempty α] :
   nonempty_compacts ℓ_infty_ℝ :=
-⟨range (Kuratowski_embedding α), range_nonempty _,
-  is_compact_range (Kuratowski_embedding.isometry α).continuous⟩
+{ carrier := range (Kuratowski_embedding α),
+  compact' := is_compact_range (Kuratowski_embedding.isometry α).continuous,
+  nonempty' := range_nonempty _ }


### PR DESCRIPTION
* Change `closeds`, `compacts`, `nonempty_compacts`, `positive_compacts` from `subtype` to `structure`
* Use `set_like`
* Add missing instances
  * the `lattice` and `bounded_order` instances for `closeds`
  * the `bounded_order` instance for `compacts`
  * the `semilattice_sup` and `order_top` instances for `nonempty_compacts` 
  * the `inhabited`, `semilattice_sup` and `order_top` instances for `positive_compacts`
* kill `positive_compacts_univ` in favor of `⊤` using the new `order_top` instance
* rename `nonempty_positive_compacts` to `positive_compacts.nonempty`
* sectioning the file

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

Partly requested by @urkud 

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
