### PR TITLE
[Merged by Bors] - feat(topology/algebra): relax some `Type*` assumptions to `Sort*`

### DIFF
--- a/src/topology/algebra/group.lean
+++ b/src/topology/algebra/group.lean
@@ -869,7 +869,7 @@ end units
 
 section lattice_ops
 
-variables {ι : Type*} [group G] [group H] {ts : set (topological_space G)}
+variables {ι : Sort*} [group G] [group H] {ts : set (topological_space G)}
   (h : ∀ t ∈ ts, @topological_group G t _) {ts' : ι → topological_space G}
   (h' : ∀ i, @topological_group G (ts' i) _) {t₁ t₂ : topological_space G}
   (h₁ : @topological_group G t₁ _) (h₂ : @topological_group G t₂ _)

--- a/src/topology/algebra/monoid.lean
+++ b/src/topology/algebra/monoid.lean
@@ -498,8 +498,8 @@ instance multiplicative.has_continuous_mul {M} [h : topological_space M] [has_ad
 
 section lattice_ops
 
-variables [has_mul M] [has_mul N] {ts : set (topological_space M)}
-  (h : Π t ∈ ts, @has_continuous_mul M t _) {ts' : ι → topological_space M}
+variables {ι' : Sort*} [has_mul M] [has_mul N] {ts : set (topological_space M)}
+  (h : Π t ∈ ts, @has_continuous_mul M t _) {ts' : ι' → topological_space M}
   (h' : Π i, @has_continuous_mul M (ts' i) _) {t₁ t₂ : topological_space M}
   (h₁ : @has_continuous_mul M t₁ _) (h₂ : @has_continuous_mul M t₂ _)
   {t : topological_space N} [has_continuous_mul N] {F : Type*}

--- a/src/topology/algebra/mul_action.lean
+++ b/src/topology/algebra/mul_action.lean
@@ -144,7 +144,7 @@ instance {ι : Type*} {γ : ι → Type*}
 
 section lattice_ops
 
-variables {ι : Type*} [has_scalar M β]
+variables {ι : Sort*} [has_scalar M β]
   {ts : set (topological_space β)} (h : Π t ∈ ts, @has_continuous_smul M β _ _ t)
   {ts' : ι → topological_space β} (h' : Π i, @has_continuous_smul M β _ _ (ts' i))
   {t₁ t₂ : topological_space β} [h₁ : @has_continuous_smul M β _ _ t₁]


### PR DESCRIPTION
When working on #11720 I forgot that we have to deal with Prop-indexed infimums quite often, so this PR fixes that.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
