### PR TITLE
[Merged by Bors] - feat(tactic/linear_combination): improve error messages and degenerate case

### DIFF
--- a/src/tactic/linear_combination.lean
+++ b/src/tactic/linear_combination.lean
@@ -141,6 +141,7 @@ Given that `l_sum1 = r_sum1`, `l_h1 = r_h1`, ..., `l_hn = r_hn`, and given
   `= r_sum1 + (c_1 * r_h1) + ... + (c_n * r_hn)`
 
 * Input:
+  * `expected_tp`: the type of the terms being compared in the target equality
   * an `option (tactic expr)` : `none`, if there is no sum to add to yet, or
       `some` containing the base summation equation
   * a `list name` : a list of names, referring to equalities in the local context
@@ -153,7 +154,6 @@ Given that `l_sum1 = r_sum1`, `l_h1 = r_h1`, ..., `l_hn = r_hn`, and given
 meta def make_sum_of_hyps_helper (expected_tp : expr) :
   option (tactic expr) → list name → list pexpr → tactic expr
 | none [] []                                                             :=
-  -- do fail "There are no hypotheses to add"
   to_expr ``(rfl : (0 : %%expected_tp) = 0)
 | (some tactic_hcombo) [] []                                             :=
   do tactic_hcombo
@@ -190,6 +190,7 @@ Given a list of names referencing equalities and a list of pexprs representing
   (where each equation is multiplied by the corresponding coefficient) holds.
 
 * Input:
+  * `expected_tp`: the type of the terms being compared in the target equality
   * `h_eqs_names` : a list of names, referring to equalities in the local
       context
   * `coeffs` : a list of coefficients to be multiplied with the corresponding

--- a/test/linear_combination.lean
+++ b/test/linear_combination.lean
@@ -165,6 +165,23 @@ begin
 end
 
 
+/-! ### Cases without any arguments provided -/
+
+-- the corner case is "just apply the normalization procedure"
+example {x y z w : ℤ} (h₁ : 3 * x = 4 + y) (h₂ : x + 2 * y = 1) : z + w = w + z :=
+by linear_combination
+
+-- this interacts as expected with options
+example {x y z w : ℤ} (h₁ : 3 * x = 4 + y) (h₂ : x + 2 * y = 1) : z + w = w + z :=
+begin
+  linear_combination {normalize := ff},
+  guard_target' z + w - (w + z) = 0 - 0,
+  simp [add_comm]
+end
+
+example {x y z w : ℤ} (h₁ : 3 * x = 4 + y) (h₂ : x + 2 * y = 1) : z + w = w + z :=
+by linear_combination {normalization_tactic := `[simp [add_comm]]}
+
 /-! ### Cases that should fail -/
 
 -- This should fail because there are no hypotheses given
@@ -214,4 +231,11 @@ example (a b : ℕ) (h1 : a = 3) :
 begin
   success_if_fail {linear_combination (h1, (1 : ℕ))},
   exact h1
+end
+
+example (a b : ℤ) (x y : ℝ) (hab : a = b) (hxy : x = y) : 2*x = 2*y :=
+begin
+  success_if_fail_with_msg {linear_combination (hab, 2)}
+    "hab is an equality between terms of type ℤ, but is expected to be between terms of type ℝ",
+  linear_combination (hxy, 2)
 end


### PR DESCRIPTION
This threads the expected type of the combination from the target throughout the tactic call.
If no hypotheses are given to combine, the behavior is effectively to just call the normalization tactic.

closes #11990



---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
