### PR TITLE
[Merged by Bors] - feat(analysis/inner_product_space/basic) : `inner_map_self_eq_zero`

### DIFF
--- a/src/analysis/inner_product_space/basic.lean
+++ b/src/analysis/inner_product_space/basic.lean
@@ -1092,12 +1092,12 @@ lemma inner_map_self_eq_zero (T : V →ₗ[ℂ] V) :
   (∀ (x : V), ⟪T x, x⟫_ℂ = 0) ↔ T = 0 :=
 begin
   split,
-  intro hT,
-  ext x,
-  simp only [linear_map.zero_apply, ← inner_self_eq_zero, inner_map_polarization, hT],
-  norm_num,
-  intros hT x,
-  simp only [eq_self_iff_true, inner_zero_left, linear_map.zero_apply, hT],
+  { intro hT,
+    ext x,
+    simp only [linear_map.zero_apply, ← inner_self_eq_zero, inner_map_polarization, hT],
+    norm_num },
+  { rintro rfl x,
+    simp only [linear_map.zero_apply, inner_zero_left] }
 end
 
 end complex

--- a/src/analysis/inner_product_space/basic.lean
+++ b/src/analysis/inner_product_space/basic.lean
@@ -1091,10 +1091,8 @@ If `⟪T x, x⟫_ℂ = 0` for all x, then T = 0.
 lemma inner_map_self_eq_zero (T : V →ₗ[ℂ] V) (hT : ∀ (x : V), ⟪T x, x⟫_ℂ = 0) :
   T = 0 :=
 begin
-  apply linear_map.ext,
-  intro x,
-  rw [linear_map.zero_apply, ← inner_self_eq_zero, inner_map_polarization],
-  iterate {rw hT},
+  ext x,
+  simp only [linear_map.zero_apply, ← inner_self_eq_zero, inner_map_polarization, hT],
   norm_num,
 end
 

--- a/src/analysis/inner_product_space/basic.lean
+++ b/src/analysis/inner_product_space/basic.lean
@@ -1078,14 +1078,11 @@ lemma inner_map_polarization (T : V →ₗ[ℂ] V) (x y : V):
     complex.I * ⟪T (x + complex.I • y) , x + complex.I • y⟫_ℂ -
     complex.I * ⟪T (x - complex.I • y), x - complex.I • y ⟫_ℂ) / 4 :=
 begin
-  iterate {rw [map_add, inner_add_left, inner_add_right, inner_add_right]},
-  iterate {rw [map_sub,inner_sub_left, inner_sub_right, inner_sub_right]},
-  rw [linear_map.map_smul, inner_smul_left, inner_smul_right],
-  ring_nf,
-  rw complex.conj_I,
-  ring_nf,
-  rw complex.I_sq,
-  ring_nf,
+  simp only [map_add, map_sub, inner_add_left, inner_add_right, linear_map.map_smul,
+             inner_smul_left, inner_smul_right, complex.conj_I, ←pow_two, complex.I_sq,
+             inner_sub_left, inner_sub_right, mul_add, ←mul_assoc, mul_neg, neg_neg,
+             sub_neg_eq_add, one_mul, neg_one_mul, mul_sub, sub_sub],
+  ring,
 end
 
 /--

--- a/src/analysis/inner_product_space/basic.lean
+++ b/src/analysis/inner_product_space/basic.lean
@@ -1066,6 +1066,43 @@ begin
   simp only [sq, ← mul_div_right_comm, ← add_div]
 end
 
+section complex
+
+variables (V : Type*)
+[inner_product_space ℂ V]
+/--
+A complex polarization identity, with a linear map
+-/
+lemma inner_map_polarization (T : V →ₗ[ℂ] V) (x y : V):
+  ⟪ T y, x ⟫_ℂ = (⟪T (x + y) , x + y⟫_ℂ - ⟪T (x - y) , x - y⟫_ℂ +
+    complex.I * ⟪T (x + complex.I • y) , x + complex.I • y⟫_ℂ -
+    complex.I * ⟪T (x - complex.I • y), x - complex.I • y ⟫_ℂ) / 4 :=
+begin
+  iterate {rw [map_add, inner_add_left, inner_add_right, inner_add_right]},
+  iterate {rw [map_sub,inner_sub_left, inner_sub_right, inner_sub_right]},
+  rw [linear_map.map_smul, inner_smul_left, inner_smul_right],
+  ring_nf,
+  rw complex.conj_I,
+  ring_nf,
+  rw complex.I_sq,
+  ring_nf,
+end
+
+/--
+If `⟪T x, x⟫_ℂ = 0` for all x, then T = 0.
+-/
+lemma inner_map_self_eq_zero (T : V →ₗ[ℂ] V) (hT : ∀ (x : V), ⟪T x, x⟫_ℂ = 0) :
+  T = 0 :=
+begin
+  apply linear_map.ext,
+  intro x,
+  rw [linear_map.zero_apply, ← inner_self_eq_zero, inner_map_polarization],
+  iterate {rw hT},
+  norm_num,
+end
+
+end complex
+
 section
 
 variables {ι : Type*} {ι' : Type*} {ι'' : Type*}

--- a/src/analysis/inner_product_space/basic.lean
+++ b/src/analysis/inner_product_space/basic.lean
@@ -1068,7 +1068,7 @@ end
 
 section complex
 
-variables (V : Type*)
+variables {V : Type*}
 [inner_product_space ℂ V]
 /--
 A complex polarization identity, with a linear map

--- a/src/analysis/inner_product_space/basic.lean
+++ b/src/analysis/inner_product_space/basic.lean
@@ -1088,12 +1088,16 @@ end
 /--
 If `⟪T x, x⟫_ℂ = 0` for all x, then T = 0.
 -/
-lemma inner_map_self_eq_zero (T : V →ₗ[ℂ] V) (hT : ∀ (x : V), ⟪T x, x⟫_ℂ = 0) :
-  T = 0 :=
+lemma inner_map_self_eq_zero (T : V →ₗ[ℂ] V) :
+  (∀ (x : V), ⟪T x, x⟫_ℂ = 0) ↔ T = 0 :=
 begin
+  split,
+  intro hT,
   ext x,
   simp only [linear_map.zero_apply, ← inner_self_eq_zero, inner_map_polarization, hT],
   norm_num,
+  intros hT x,
+  simp only [eq_self_iff_true, inner_zero_left, linear_map.zero_apply, hT],
 end
 
 end complex


### PR DESCRIPTION
The main result here is:  If ⟪T x, x⟫_C = 0 for all x, then T = 0.
The proof uses a polarization identity.  Note that this is false
with R in place of C.  I am confident that my use of ring_nf is
not optimal, but I hope to learn from the cleanup process!

Co-authored-by: Daniel Packer

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
