### PR TITLE
[Merged by Bors] - chore(topology/uniform_space): use weaker TC assumptions

### DIFF
--- a/src/topology/uniform_space/abstract_completion.lean
+++ b/src/topology/uniform_space/abstract_completion.lean
@@ -84,11 +84,14 @@ lemma induction_on {p : hatα → Prop}
   (a : hatα) (hp : is_closed {a | p a}) (ih : ∀ a, p (ι a)) : p a :=
 is_closed_property pkg.dense hp ih a
 
-variables {β : Type*} [uniform_space β]
+variables {β : Type*}
 
-protected lemma funext [t2_space β] {f g : hatα → β} (hf : continuous f) (hg : continuous g)
+protected lemma funext [topological_space β] [t2_space β] {f g : hatα → β}
+  (hf : continuous f) (hg : continuous g)
   (h : ∀ a, f (ι a) = g (ι a)) : f = g :=
 funext $ assume a, pkg.induction_on a (is_closed_eq hf hg) h
+
+variables [uniform_space β]
 
 section extend
 /-- Extension of maps to completions -/
@@ -104,7 +107,7 @@ lemma extend_def (hf : uniform_continuous f) : pkg.extend f = pkg.dense_inducing
 if_pos hf
 
 lemma extend_coe [t2_space β] (hf : uniform_continuous f) (a : α) :
-(pkg.extend f) (ι a) = f a :=
+  (pkg.extend f) (ι a) = f a :=
 begin
   rw pkg.extend_def hf,
   exact pkg.dense_inducing.extend_eq hf.continuous a

--- a/src/topology/uniform_space/completion.lean
+++ b/src/topology/uniform_space/completion.lean
@@ -444,8 +444,8 @@ have ∀x : completion α × completion β × completion γ, p x.1 x.2.1 x.2.2, 
   is_closed_property dense_range_coe₃ hp $ assume ⟨a, b, c⟩, ih a b c,
 this (a, b, c)
 
-lemma ext [t2_space β] {f g : completion α → β} (hf : continuous f) (hg : continuous g)
-  (h : ∀a:α, f a = g a) : f = g :=
+lemma ext {Y : Type*} [topological_space Y] [t2_space Y] {f g : completion α → Y}
+  (hf : continuous f) (hg : continuous g) (h : ∀a:α, f a = g a) : f = g :=
 cpkg.funext hf hg h
 
 section extension


### PR DESCRIPTION
We don't need `[uniform_space β]` to prove
`uniform_space.completion.ext`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
