### PR TITLE
[Merged by Bors] - refactor(topology/metric_space/completion): change namespace

### DIFF
--- a/src/analysis/normed/group/completion.lean
+++ b/src/analysis/normed/group/completion.lean
@@ -40,10 +40,10 @@ instance [semi_normed_group E] : normed_group (completion E) :=
     { refine is_closed_eq (completion.uniform_continuous_extension₂ _).continuous _,
       exact continuous.comp completion.continuous_extension continuous_sub },
     { intros x y,
-      rw [← completion.coe_sub, norm_coe, metric.completion.dist_eq, dist_eq_norm] }
+      rw [← completion.coe_sub, norm_coe, completion.dist_eq, dist_eq_norm] }
   end,
-  .. uniform_space.completion.add_comm_group,
-  .. metric.completion.metric_space }
+  .. completion.add_comm_group,
+  .. completion.metric_space }
 
 end completion
 end uniform_space

--- a/src/topology/algebra/group_completion.lean
+++ b/src/topology/algebra/group_completion.lean
@@ -10,20 +10,20 @@ import topology.algebra.uniform_group
 /-!
 # Completion of topological groups:
 
-This files endows the completion of a uniform group with a group structure.  More precisely the
-instance `uniform_space.completion.group` builds a group structure on the completion of a group
-endowed with a compatible uniform structure.  Then the instance
-`uniform_space.completion.uniform_group` proves this group structure is compatible with the
-completed uniform structure. The compatibility condition is `uniform_group`.
+This files endows the completion of a topological abelian group with a group structure.
+More precisely the instance `uniform_space.completion.add_group` builds an abelian group structure
+on the completion of an abelian group endowed with a compatible uniform structure.
+Then the instance `uniform_space.completion.uniform_add_group` proves this group structure is
+compatible with the completed uniform structure. The compatibility condition is `uniform_add_group`.
 
 ## Main declarations:
 
-Beyond the instances explained above (that don't have to be explicitly invoked), the main
-constructions deal with continuous group morphisms.
+Beyond the instances explained above (that don't have to be explicitly invoked),
+the main constructions deal with continuous group morphisms.
 
-* `monoid_hom.extension`: extends a continuous group morphism from `G`
+* `add_monoid_hom.extension`: extends a continuous group morphism from `G`
   to a complete separated group `H` to `completion G`.
-* `monoid_hom.completion`: promotes a continuous group morphism
+* `add_monoid_hom.completion`: promotes a continuous group morphism
   from `G` to `H` into a continuous group morphism
   from `completion G` to `completion H`.
 -/
@@ -34,151 +34,155 @@ universes u v
 
 section group
 open uniform_space Cauchy filter set
-variables {G : Type u} [uniform_space G]
+variables {α : Type u} [uniform_space α]
 
-@[to_additive] instance [has_one G] : has_one (completion G) := ⟨(1 : G)⟩
-@[to_additive] instance [has_inv G] : has_inv (completion G) := ⟨completion.map (λ a, a⁻¹)⟩
-@[to_additive] instance [has_mul G] : has_mul (completion G) := ⟨completion.map₂ (*)⟩
-@[to_additive] instance [has_div G] : has_div (completion G) := ⟨completion.map₂ (/)⟩
+instance [has_zero α] : has_zero (completion α) := ⟨(0 : α)⟩
+instance [has_neg α] : has_neg (completion α) := ⟨completion.map (λa, -a : α → α)⟩
+instance [has_add α] : has_add (completion α) := ⟨completion.map₂ (+)⟩
+instance [has_sub α] : has_sub (completion α) := ⟨completion.map₂ has_sub.sub⟩
 
-@[norm_cast, to_additive]
-lemma uniform_space.completion.coe_one [has_one G] : ((1 : G) : completion G) = 1 := rfl
-
+@[norm_cast]
+lemma uniform_space.completion.coe_zero [has_zero α] : ((0 : α) : completion α) = 0 := rfl
 end group
 
-namespace uniform_space
-namespace completion
+namespace uniform_space.completion
+section uniform_add_group
+open uniform_space uniform_space.completion
+variables {α : Type*} [uniform_space α] [add_group α] [uniform_add_group α]
 
-variables {G : Type*} [uniform_space G] [group G] [uniform_group G]
+@[norm_cast]
+lemma coe_neg (a : α) : ((- a : α) : completion α) = - a :=
+(map_coe uniform_continuous_neg a).symm
 
-@[norm_cast, to_additive]
-lemma coe_inv (a : G) : ((a⁻¹ : G) : completion G) = a⁻¹ :=
-(map_coe uniform_continuous_inv a).symm
+@[norm_cast]
+lemma coe_sub (a b : α) : ((a - b : α) : completion α) = a - b :=
+(map₂_coe_coe a b has_sub.sub uniform_continuous_sub).symm
 
-@[norm_cast, to_additive]
-lemma coe_div (a b : G) : ((a / b : G) : completion G) = a / b :=
-(map₂_coe_coe a b has_div.div uniform_continuous_div).symm
+@[norm_cast]
+lemma coe_add (a b : α) : ((a + b : α) : completion α) = a + b :=
+(map₂_coe_coe a b (+) uniform_continuous_add).symm
 
-@[norm_cast, to_additive]
-lemma coe_mul (a b : G) : ((a * b : G) : completion G) = a * b :=
-(map₂_coe_coe a b (*) uniform_continuous_mul).symm
-
-@[to_additive] instance : monoid (completion G) :=
-{ one_mul := λ a, completion.induction_on a
-    (is_closed_eq (continuous_map₂ continuous_const continuous_id) continuous_id)
-    (λ a, by rw [← coe_one, ← coe_mul, one_mul]),
-  mul_one := λ a, completion.induction_on a
+instance : add_monoid (completion α) :=
+{ zero_add     := assume a, completion.induction_on a
+   (is_closed_eq (continuous_map₂ continuous_const continuous_id) continuous_id)
+    (assume a, show 0 + (a : completion α) = a, by rw_mod_cast zero_add),
+  add_zero     := assume a, completion.induction_on a
     (is_closed_eq (continuous_map₂ continuous_id continuous_const) continuous_id)
-    (λ a, by rw [← coe_one, ← coe_mul, mul_one]),
-  mul_assoc := λ a b c, completion.induction_on₃ a b c
+    (assume a, show (a : completion α) + 0 = a, by rw_mod_cast add_zero),
+  add_assoc    := assume a b c, completion.induction_on₃ a b c
     (is_closed_eq
-      (continuous_map₂ (continuous_map₂ continuous_fst continuous_snd.fst) continuous_snd.snd)
-      (continuous_map₂ continuous_fst (continuous_map₂ continuous_snd.fst continuous_snd.snd)))
-    (λ a b c, by simp only [← coe_mul, mul_assoc]),
-  .. completion.has_one, .. completion.has_mul }
+      (continuous_map₂
+        (continuous_map₂ continuous_fst (continuous_fst.comp continuous_snd))
+        (continuous_snd.comp continuous_snd))
+      (continuous_map₂ continuous_fst
+        (continuous_map₂
+          (continuous_fst.comp continuous_snd)
+          (continuous_snd.comp continuous_snd))))
+    (assume a b c, show (a : completion α) + b + c = a + (b + c),
+      by repeat { rw_mod_cast add_assoc }),
+  .. completion.has_zero, .. completion.has_neg, ..completion.has_add, .. completion.has_sub }
 
-@[to_additive] instance : div_inv_monoid (completion G) :=
-{ div_eq_mul_inv := λ a b, completion.induction_on₂ a b
+instance : sub_neg_monoid (completion α) :=
+{ sub_eq_add_neg := λ a b, completion.induction_on₂ a b
     (is_closed_eq (continuous_map₂ continuous_fst continuous_snd)
       (continuous_map₂ continuous_fst (completion.continuous_map.comp continuous_snd)))
-   (λ a b, by exact_mod_cast congr_arg coe (div_eq_mul_inv a b)),
-  .. completion.monoid, .. completion.has_inv, .. completion.has_div }
+   (λ a b, by exact_mod_cast congr_arg coe (sub_eq_add_neg a b)),
+  .. completion.add_monoid, .. completion.has_neg, .. completion.has_sub }
 
-@[to_additive] instance : group (completion G) :=
-{ mul_left_inv := λ a, completion.induction_on a
+instance : add_group (completion α) :=
+{ add_left_neg := assume a, completion.induction_on a
     (is_closed_eq (continuous_map₂ completion.continuous_map continuous_id) continuous_const)
-    (λ a, by rw [← coe_inv, ← coe_mul, mul_left_inv, coe_one]),
-  .. completion.div_inv_monoid }
+    (assume a, show - (a : completion α) + a = 0, by { rw_mod_cast add_left_neg, refl }),
+  .. completion.sub_neg_monoid }
 
-@[to_additive] instance : uniform_group (completion G) :=
-⟨uniform_continuous_map₂ has_div.div⟩
+instance : uniform_add_group (completion α) :=
+⟨uniform_continuous_map₂ has_sub.sub⟩
 
-/-- The map from a group to its completion as a group homomorphism. -/
-@[to_additive "The map from an additive group to its completion as a group homomorphism",
-  simps {fully_applied := ff}]
-def coe_monoid_hom : G →* completion G :=
+/-- The map from a group to its completion as a group hom. -/
+@[simps] def to_compl : α →+ completion α :=
 { to_fun := coe,
-  map_mul' := coe_mul,
-  map_one' := coe_one }
+  map_add' := coe_add,
+  map_zero' := coe_zero }
 
-@[to_additive] instance {G : Type u} [uniform_space G] [comm_group G] [uniform_group G] :
-  comm_group (completion G) :=
-{ mul_comm  := assume a b, completion.induction_on₂ a b
+lemma continuous_to_compl : continuous (to_compl : α → completion α) :=
+continuous_coe α
+
+variables {β : Type v} [uniform_space β] [add_group β] [uniform_add_group β]
+
+instance {α : Type u} [uniform_space α] [add_comm_group α] [uniform_add_group α] :
+  add_comm_group (completion α) :=
+{ add_comm  := assume a b, completion.induction_on₂ a b
     (is_closed_eq (continuous_map₂ continuous_fst continuous_snd)
       (continuous_map₂ continuous_snd continuous_fst))
-    (assume x y, by rw [← coe_mul, ← coe_mul, mul_comm]),
-  .. completion.group }
+    (assume x y, by { change ↑x + ↑y = ↑y + ↑x, rw [← coe_add, ← coe_add, add_comm]}),
+  .. completion.add_group }
 
-end completion
-end uniform_space
+end uniform_add_group
 
-namespace monoid_hom
-variables {G : Type u} [uniform_space G] [group G] [uniform_group G]
-          {H : Type v} [uniform_space H] [group H] [uniform_group H]
+end uniform_space.completion
+
+section add_monoid_hom
+variables {α β : Type*} [uniform_space α] [add_group α] [uniform_add_group α]
+                        [uniform_space β] [add_group β] [uniform_add_group β]
 
 open uniform_space uniform_space.completion
 
-section extension
-
-variables [complete_space H] [separated_space H]
-
-/-- Extension to the completion of a continuous group homomorphism. -/
-@[to_additive "Extension to the completion of a continuous group homomorphism."]
-def extension (f : G →* H) (hf : continuous f) : completion G →* H :=
-have hf : uniform_continuous f, from uniform_continuous_monoid_hom_of_continuous hf,
+/-- Extension to the completion of a continuous group hom. -/
+def add_monoid_hom.extension [complete_space β] [separated_space β] (f : α →+ β)
+  (hf : continuous f) : completion α →+ β :=
+have hf : uniform_continuous f, from uniform_continuous_add_monoid_hom_of_continuous hf,
 { to_fun := completion.extension f,
-  map_one' := by rw [← coe_one, extension_coe hf, map_one],
-  map_mul' := assume a b, completion.induction_on₂ a b
+  map_zero' := by rw [← coe_zero, extension_coe hf, f.map_zero],
+  map_add' := assume a b, completion.induction_on₂ a b
   (is_closed_eq
-    (continuous_extension.comp continuous_mul)
-    ((continuous_extension.comp continuous_fst).mul (continuous_extension.comp continuous_snd)))
-  (λ a b, by rw_mod_cast [extension_coe hf, extension_coe hf, extension_coe hf, map_mul]) }
+    (continuous_extension.comp continuous_add)
+    ((continuous_extension.comp continuous_fst).add (continuous_extension.comp continuous_snd)))
+  (λ a b, by rw_mod_cast [extension_coe hf, extension_coe hf, extension_coe hf,
+    f.map_add]) }
 
-@[to_additive] lemma extension_coe (f : G →* H) (hf : continuous f) (a : G) :
-  f.extension hf a = f a :=
-extension_coe (uniform_continuous_monoid_hom_of_continuous hf) a
+lemma add_monoid_hom.extension_coe [complete_space β] [separated_space β] (f : α →+ β)
+  (hf : continuous f) (a : α) : f.extension hf a = f a :=
+extension_coe (uniform_continuous_add_monoid_hom_of_continuous hf) a
 
 @[continuity]
-lemma continuous_extension (f : G →* H) (hf : continuous f) : continuous (f.extension hf) :=
+lemma add_monoid_hom.continuous_extension [complete_space β] [separated_space β] (f : α →+ β)
+  (hf : continuous f) : continuous (f.extension hf) :=
 continuous_extension
 
-end extension
-
 /-- Completion of a continuous group hom, as a group hom. -/
-@[to_additive "Completion of a continuous group hom, as a group hom."]
-protected def completion (f : G →* H) (hf : continuous f) : completion G →* completion H :=
-(coe_monoid_hom.comp f).extension ((continuous_coe _).comp hf)
+def add_monoid_hom.completion (f : α →+ β) (hf : continuous f) : completion α →+ completion β :=
+(to_compl.comp f).extension (continuous_to_compl.comp hf)
 
-@[continuity, to_additive]
-lemma continuous_completion (f : G →* H) (hf : continuous f) :
-  continuous (f.completion hf : completion G → completion H) :=
+@[continuity]
+lemma add_monoid_hom.continuous_completion (f : α →+ β)
+  (hf : continuous f) : continuous (f.completion hf : completion α → completion β) :=
 continuous_map
 
-@[simp, to_additive] lemma completion_coe (f : G →* H) (hf : continuous f) (a : G) :
-  f.completion hf a = f a :=
-map_coe (uniform_continuous_monoid_hom_of_continuous hf) a
+lemma add_monoid_hom.completion_coe (f : α →+ β)
+  (hf : continuous f) (a : α) : f.completion hf a = f a :=
+map_coe (uniform_continuous_add_monoid_hom_of_continuous hf) a
 
-@[simp, to_additive] lemma completion_one : (1 : G →* H).completion continuous_const = 1 :=
+lemma add_monoid_hom.completion_zero : (0 : α →+ β).completion continuous_const = 0 :=
 begin
   ext x,
   apply completion.induction_on x,
-  { apply is_closed_eq ((1 : G →* H).continuous_completion continuous_const),
+  { apply is_closed_eq ((0 : α →+ β).continuous_completion continuous_const),
     simp [continuous_const] },
   { intro a,
-    simp [(1 : G →* H).completion_coe continuous_const, coe_one] }
+    simp [(0 : α →+ β).completion_coe continuous_const, coe_zero] }
 end
 
-@[to_additive] lemma completion_mul {H : Type*} [comm_group H] [uniform_space H]
-  [uniform_group H] (f g : G →* H) (hf : continuous f) (hg : continuous g) :
-  (f * g).completion (hf.mul hg) = f.completion hf * g.completion hg :=
+lemma add_monoid_hom.completion_add {γ : Type*} [add_comm_group γ] [uniform_space γ]
+  [uniform_add_group γ] (f g : α →+ γ) (hf : continuous f) (hg : continuous g) :
+  (f + g).completion (hf.add hg) = f.completion hf + g.completion hg :=
 begin
-  have hfg := hf.mul hg,
+  have hfg := hf.add hg,
   ext x,
   apply completion.induction_on x,
-  { exact is_closed_eq ((f * g).continuous_completion hfg)
-    ((f.continuous_completion hf).mul (g.continuous_completion hg)) },
+  { exact is_closed_eq ((f+g).continuous_completion hfg)
+    ((f.continuous_completion hf).add (g.continuous_completion hg)) },
   { intro a,
-    simp [(f * g).completion_coe hfg, coe_mul, f.completion_coe hf, g.completion_coe hg] }
+    simp [(f+g).completion_coe hfg, coe_add, f.completion_coe hf, g.completion_coe hg] }
 end
 
-end monoid_hom
+end add_monoid_hom

--- a/src/topology/algebra/group_completion.lean
+++ b/src/topology/algebra/group_completion.lean
@@ -10,20 +10,20 @@ import topology.algebra.uniform_group
 /-!
 # Completion of topological groups:
 
-This files endows the completion of a topological abelian group with a group structure.
-More precisely the instance `uniform_space.completion.add_group` builds an abelian group structure
-on the completion of an abelian group endowed with a compatible uniform structure.
-Then the instance `uniform_space.completion.uniform_add_group` proves this group structure is
-compatible with the completed uniform structure. The compatibility condition is `uniform_add_group`.
+This files endows the completion of a uniform group with a group structure.  More precisely the
+instance `uniform_space.completion.group` builds a group structure on the completion of a group
+endowed with a compatible uniform structure.  Then the instance
+`uniform_space.completion.uniform_group` proves this group structure is compatible with the
+completed uniform structure. The compatibility condition is `uniform_group`.
 
 ## Main declarations:
 
-Beyond the instances explained above (that don't have to be explicitly invoked),
-the main constructions deal with continuous group morphisms.
+Beyond the instances explained above (that don't have to be explicitly invoked), the main
+constructions deal with continuous group morphisms.
 
-* `add_monoid_hom.extension`: extends a continuous group morphism from `G`
+* `monoid_hom.extension`: extends a continuous group morphism from `G`
   to a complete separated group `H` to `completion G`.
-* `add_monoid_hom.completion`: promotes a continuous group morphism
+* `monoid_hom.completion`: promotes a continuous group morphism
   from `G` to `H` into a continuous group morphism
   from `completion G` to `completion H`.
 -/
@@ -34,155 +34,151 @@ universes u v
 
 section group
 open uniform_space Cauchy filter set
-variables {α : Type u} [uniform_space α]
+variables {G : Type u} [uniform_space G]
 
-instance [has_zero α] : has_zero (completion α) := ⟨(0 : α)⟩
-instance [has_neg α] : has_neg (completion α) := ⟨completion.map (λa, -a : α → α)⟩
-instance [has_add α] : has_add (completion α) := ⟨completion.map₂ (+)⟩
-instance [has_sub α] : has_sub (completion α) := ⟨completion.map₂ has_sub.sub⟩
+@[to_additive] instance [has_one G] : has_one (completion G) := ⟨(1 : G)⟩
+@[to_additive] instance [has_inv G] : has_inv (completion G) := ⟨completion.map (λ a, a⁻¹)⟩
+@[to_additive] instance [has_mul G] : has_mul (completion G) := ⟨completion.map₂ (*)⟩
+@[to_additive] instance [has_div G] : has_div (completion G) := ⟨completion.map₂ (/)⟩
 
-@[norm_cast]
-lemma uniform_space.completion.coe_zero [has_zero α] : ((0 : α) : completion α) = 0 := rfl
+@[norm_cast, to_additive]
+lemma uniform_space.completion.coe_one [has_one G] : ((1 : G) : completion G) = 1 := rfl
+
 end group
 
-namespace uniform_space.completion
-section uniform_add_group
-open uniform_space uniform_space.completion
-variables {α : Type*} [uniform_space α] [add_group α] [uniform_add_group α]
+namespace uniform_space
+namespace completion
 
-@[norm_cast]
-lemma coe_neg (a : α) : ((- a : α) : completion α) = - a :=
-(map_coe uniform_continuous_neg a).symm
+variables {G : Type*} [uniform_space G] [group G] [uniform_group G]
 
-@[norm_cast]
-lemma coe_sub (a b : α) : ((a - b : α) : completion α) = a - b :=
-(map₂_coe_coe a b has_sub.sub uniform_continuous_sub).symm
+@[norm_cast, to_additive]
+lemma coe_inv (a : G) : ((a⁻¹ : G) : completion G) = a⁻¹ :=
+(map_coe uniform_continuous_inv a).symm
 
-@[norm_cast]
-lemma coe_add (a b : α) : ((a + b : α) : completion α) = a + b :=
-(map₂_coe_coe a b (+) uniform_continuous_add).symm
+@[norm_cast, to_additive]
+lemma coe_div (a b : G) : ((a / b : G) : completion G) = a / b :=
+(map₂_coe_coe a b has_div.div uniform_continuous_div).symm
 
-instance : add_monoid (completion α) :=
-{ zero_add     := assume a, completion.induction_on a
-   (is_closed_eq (continuous_map₂ continuous_const continuous_id) continuous_id)
-    (assume a, show 0 + (a : completion α) = a, by rw_mod_cast zero_add),
-  add_zero     := assume a, completion.induction_on a
+@[norm_cast, to_additive]
+lemma coe_mul (a b : G) : ((a * b : G) : completion G) = a * b :=
+(map₂_coe_coe a b (*) uniform_continuous_mul).symm
+
+@[to_additive] instance : monoid (completion G) :=
+{ one_mul := λ a, completion.induction_on a
+    (is_closed_eq (continuous_map₂ continuous_const continuous_id) continuous_id)
+    (λ a, by rw [← coe_one, ← coe_mul, one_mul]),
+  mul_one := λ a, completion.induction_on a
     (is_closed_eq (continuous_map₂ continuous_id continuous_const) continuous_id)
-    (assume a, show (a : completion α) + 0 = a, by rw_mod_cast add_zero),
-  add_assoc    := assume a b c, completion.induction_on₃ a b c
+    (λ a, by rw [← coe_one, ← coe_mul, mul_one]),
+  mul_assoc := λ a b c, completion.induction_on₃ a b c
     (is_closed_eq
-      (continuous_map₂
-        (continuous_map₂ continuous_fst (continuous_fst.comp continuous_snd))
-        (continuous_snd.comp continuous_snd))
-      (continuous_map₂ continuous_fst
-        (continuous_map₂
-          (continuous_fst.comp continuous_snd)
-          (continuous_snd.comp continuous_snd))))
-    (assume a b c, show (a : completion α) + b + c = a + (b + c),
-      by repeat { rw_mod_cast add_assoc }),
-  .. completion.has_zero, .. completion.has_neg, ..completion.has_add, .. completion.has_sub }
+      (continuous_map₂ (continuous_map₂ continuous_fst continuous_snd.fst) continuous_snd.snd)
+      (continuous_map₂ continuous_fst (continuous_map₂ continuous_snd.fst continuous_snd.snd)))
+    (λ a b c, by simp only [← coe_mul, mul_assoc]),
+  .. completion.has_one, .. completion.has_mul }
 
-instance : sub_neg_monoid (completion α) :=
-{ sub_eq_add_neg := λ a b, completion.induction_on₂ a b
+@[to_additive] instance : div_inv_monoid (completion G) :=
+{ div_eq_mul_inv := λ a b, completion.induction_on₂ a b
     (is_closed_eq (continuous_map₂ continuous_fst continuous_snd)
       (continuous_map₂ continuous_fst (completion.continuous_map.comp continuous_snd)))
-   (λ a b, by exact_mod_cast congr_arg coe (sub_eq_add_neg a b)),
-  .. completion.add_monoid, .. completion.has_neg, .. completion.has_sub }
+   (λ a b, by exact_mod_cast congr_arg coe (div_eq_mul_inv a b)),
+  .. completion.monoid, .. completion.has_inv, .. completion.has_div }
 
-instance : add_group (completion α) :=
-{ add_left_neg := assume a, completion.induction_on a
+@[to_additive] instance : group (completion G) :=
+{ mul_left_inv := λ a, completion.induction_on a
     (is_closed_eq (continuous_map₂ completion.continuous_map continuous_id) continuous_const)
-    (assume a, show - (a : completion α) + a = 0, by { rw_mod_cast add_left_neg, refl }),
-  .. completion.sub_neg_monoid }
+    (λ a, by rw [← coe_inv, ← coe_mul, mul_left_inv, coe_one]),
+  .. completion.div_inv_monoid }
 
-instance : uniform_add_group (completion α) :=
-⟨uniform_continuous_map₂ has_sub.sub⟩
+@[to_additive] instance : uniform_group (completion G) :=
+⟨uniform_continuous_map₂ has_div.div⟩
 
-/-- The map from a group to its completion as a group hom. -/
-@[simps] def to_compl : α →+ completion α :=
+/-- The map from a group to its completion as a group homomorphism. -/
+@[to_additive "The map from an additive group to its completion as a group homomorphism",
+  simps {fully_applied := ff}]
+def coe_monoid_hom : G →* completion G :=
 { to_fun := coe,
-  map_add' := coe_add,
-  map_zero' := coe_zero }
+  map_mul' := coe_mul,
+  map_one' := coe_one }
 
-lemma continuous_to_compl : continuous (to_compl : α → completion α) :=
-continuous_coe α
-
-variables {β : Type v} [uniform_space β] [add_group β] [uniform_add_group β]
-
-instance {α : Type u} [uniform_space α] [add_comm_group α] [uniform_add_group α] :
-  add_comm_group (completion α) :=
-{ add_comm  := assume a b, completion.induction_on₂ a b
+@[to_additive] instance {G : Type u} [uniform_space G] [comm_group G] [uniform_group G] :
+  comm_group (completion G) :=
+{ mul_comm  := assume a b, completion.induction_on₂ a b
     (is_closed_eq (continuous_map₂ continuous_fst continuous_snd)
       (continuous_map₂ continuous_snd continuous_fst))
-    (assume x y, by { change ↑x + ↑y = ↑y + ↑x, rw [← coe_add, ← coe_add, add_comm]}),
-  .. completion.add_group }
+    (assume x y, by rw [← coe_mul, ← coe_mul, mul_comm]),
+  .. completion.group }
 
-end uniform_add_group
+end completion
+end uniform_space
 
-end uniform_space.completion
-
-section add_monoid_hom
-variables {α β : Type*} [uniform_space α] [add_group α] [uniform_add_group α]
-                        [uniform_space β] [add_group β] [uniform_add_group β]
+namespace monoid_hom
+variables {G : Type u} [uniform_space G] [group G] [uniform_group G]
+          {H : Type v} [uniform_space H] [group H] [uniform_group H]
 
 open uniform_space uniform_space.completion
 
-/-- Extension to the completion of a continuous group hom. -/
-def add_monoid_hom.extension [complete_space β] [separated_space β] (f : α →+ β)
-  (hf : continuous f) : completion α →+ β :=
-have hf : uniform_continuous f, from uniform_continuous_add_monoid_hom_of_continuous hf,
-{ to_fun := completion.extension f,
-  map_zero' := by rw [← coe_zero, extension_coe hf, f.map_zero],
-  map_add' := assume a b, completion.induction_on₂ a b
-  (is_closed_eq
-    (continuous_extension.comp continuous_add)
-    ((continuous_extension.comp continuous_fst).add (continuous_extension.comp continuous_snd)))
-  (λ a b, by rw_mod_cast [extension_coe hf, extension_coe hf, extension_coe hf,
-    f.map_add]) }
+section extension
 
-lemma add_monoid_hom.extension_coe [complete_space β] [separated_space β] (f : α →+ β)
-  (hf : continuous f) (a : α) : f.extension hf a = f a :=
-extension_coe (uniform_continuous_add_monoid_hom_of_continuous hf) a
+variables [complete_space H] [separated_space H]
+
+/-- Extension to the completion of a continuous group homomorphism. -/
+@[to_additive "Extension to the completion of a continuous group homomorphism."]
+def extension (f : G →* H) (hf : continuous f) : completion G →* H :=
+have hf : uniform_continuous f, from uniform_continuous_monoid_hom_of_continuous hf,
+{ to_fun := completion.extension f,
+  map_one' := by rw [← coe_one, extension_coe hf, map_one],
+  map_mul' := assume a b, completion.induction_on₂ a b
+  (is_closed_eq
+    (continuous_extension.comp continuous_mul)
+    ((continuous_extension.comp continuous_fst).mul (continuous_extension.comp continuous_snd)))
+  (λ a b, by rw_mod_cast [extension_coe hf, extension_coe hf, extension_coe hf, map_mul]) }
+
+@[to_additive] lemma extension_coe (f : G →* H) (hf : continuous f) (a : G) :
+  f.extension hf a = f a :=
+extension_coe (uniform_continuous_monoid_hom_of_continuous hf) a
 
 @[continuity]
-lemma add_monoid_hom.continuous_extension [complete_space β] [separated_space β] (f : α →+ β)
-  (hf : continuous f) : continuous (f.extension hf) :=
+lemma continuous_extension (f : G →* H) (hf : continuous f) : continuous (f.extension hf) :=
 continuous_extension
 
-/-- Completion of a continuous group hom, as a group hom. -/
-def add_monoid_hom.completion (f : α →+ β) (hf : continuous f) : completion α →+ completion β :=
-(to_compl.comp f).extension (continuous_to_compl.comp hf)
+end extension
 
-@[continuity]
-lemma add_monoid_hom.continuous_completion (f : α →+ β)
-  (hf : continuous f) : continuous (f.completion hf : completion α → completion β) :=
+/-- Completion of a continuous group hom, as a group hom. -/
+@[to_additive "Completion of a continuous group hom, as a group hom."]
+protected def completion (f : G →* H) (hf : continuous f) : completion G →* completion H :=
+(coe_monoid_hom.comp f).extension ((continuous_coe _).comp hf)
+
+@[continuity, to_additive]
+lemma continuous_completion (f : G →* H) (hf : continuous f) :
+  continuous (f.completion hf : completion G → completion H) :=
 continuous_map
 
-lemma add_monoid_hom.completion_coe (f : α →+ β)
-  (hf : continuous f) (a : α) : f.completion hf a = f a :=
-map_coe (uniform_continuous_add_monoid_hom_of_continuous hf) a
+@[simp, to_additive] lemma completion_coe (f : G →* H) (hf : continuous f) (a : G) :
+  f.completion hf a = f a :=
+map_coe (uniform_continuous_monoid_hom_of_continuous hf) a
 
-lemma add_monoid_hom.completion_zero : (0 : α →+ β).completion continuous_const = 0 :=
+@[simp, to_additive] lemma completion_one : (1 : G →* H).completion continuous_const = 1 :=
 begin
   ext x,
   apply completion.induction_on x,
-  { apply is_closed_eq ((0 : α →+ β).continuous_completion continuous_const),
+  { apply is_closed_eq ((1 : G →* H).continuous_completion continuous_const),
     simp [continuous_const] },
   { intro a,
-    simp [(0 : α →+ β).completion_coe continuous_const, coe_zero] }
+    simp [(1 : G →* H).completion_coe continuous_const, coe_one] }
 end
 
-lemma add_monoid_hom.completion_add {γ : Type*} [add_comm_group γ] [uniform_space γ]
-  [uniform_add_group γ] (f g : α →+ γ) (hf : continuous f) (hg : continuous g) :
-  (f + g).completion (hf.add hg) = f.completion hf + g.completion hg :=
+@[to_additive] lemma completion_mul {H : Type*} [comm_group H] [uniform_space H]
+  [uniform_group H] (f g : G →* H) (hf : continuous f) (hg : continuous g) :
+  (f * g).completion (hf.mul hg) = f.completion hf * g.completion hg :=
 begin
-  have hfg := hf.add hg,
+  have hfg := hf.mul hg,
   ext x,
   apply completion.induction_on x,
-  { exact is_closed_eq ((f+g).continuous_completion hfg)
-    ((f.continuous_completion hf).add (g.continuous_completion hg)) },
+  { exact is_closed_eq ((f * g).continuous_completion hfg)
+    ((f.continuous_completion hf).mul (g.continuous_completion hg)) },
   { intro a,
-    simp [(f+g).completion_coe hfg, coe_add, f.completion_coe hf, g.completion_coe hg] }
+    simp [(f * g).completion_coe hfg, coe_mul, f.completion_coe hf, g.completion_coe hg] }
 end
 
-end add_monoid_hom
+end monoid_hom

--- a/src/topology/metric_space/completion.lean
+++ b/src/topology/metric_space/completion.lean
@@ -53,7 +53,7 @@ begin
   { refine is_closed_eq _ continuous_const,
     exact completion.continuous_dist continuous_id continuous_id },
   { assume a,
-    rw [dist_eq, dist_self] }
+    rw [completion.dist_eq, dist_self] }
 end
 
 protected lemma dist_comm (x y : completion α) : dist x y = dist y x :=
@@ -62,7 +62,7 @@ begin
   { exact is_closed_eq (completion.continuous_dist continuous_fst continuous_snd)
       (completion.continuous_dist continuous_snd continuous_fst) },
   { assume a b,
-    rw [dist_eq, dist_eq, dist_comm] }
+    rw [completion.dist_eq, completion.dist_eq, dist_comm] }
 end
 
 protected lemma dist_triangle (x y z : completion α) : dist x z ≤ dist x y + dist y z :=
@@ -71,7 +71,7 @@ begin
   { refine is_closed_le _ (continuous.add _ _);
       apply_rules [completion.continuous_dist, continuous.fst, continuous.snd, continuous_id] },
   { assume a b c,
-    rw [dist_eq, dist_eq, dist_eq],
+    rw [completion.dist_eq, completion.dist_eq, completion.dist_eq],
     exact dist_triangle a b c }
 end
 

--- a/src/topology/metric_space/completion.lean
+++ b/src/topology/metric_space/completion.lean
@@ -16,14 +16,14 @@ by extending the distance to the completion and checking that it is indeed a dis
 it defines the same uniformity as the already defined uniform structure on the completion
 -/
 
-open set filter uniform_space uniform_space.completion
-open_locale filter
+open set filter uniform_space metric
+open_locale filter topological_space uniformity
 noncomputable theory
 
-universes u
-variables {α : Type u} [pseudo_metric_space α]
+universes u v
+variables {α : Type u} {β : Type v} [pseudo_metric_space α]
 
-namespace metric
+namespace uniform_space.completion
 
 /-- The distance on the completion is obtained by extending the distance on the original space,
 by uniform continuity. -/
@@ -31,64 +31,59 @@ instance : has_dist (completion α) :=
 ⟨completion.extension₂ dist⟩
 
 /-- The new distance is uniformly continuous. -/
-protected lemma completion.uniform_continuous_dist :
+protected lemma uniform_continuous_dist :
   uniform_continuous (λp:completion α × completion α, dist p.1 p.2) :=
 uniform_continuous_extension₂ dist
 
+/-- The new distance is continuous. -/
+protected lemma continuous_dist [topological_space β] {f g : β → completion α} (hf : continuous f)
+  (hg : continuous g) :
+  continuous (λ x, dist (f x) (g x)) :=
+completion.uniform_continuous_dist.continuous.comp (hf.prod_mk hg : _)
+
 /-- The new distance is an extension of the original distance. -/
-protected lemma completion.dist_eq (x y : α) : dist (x : completion α) y = dist x y :=
+@[simp] protected lemma dist_eq (x y : α) : dist (x : completion α) y = dist x y :=
 completion.extension₂_coe_coe uniform_continuous_dist _ _
 
 /- Let us check that the new distance satisfies the axioms of a distance, by starting from the
 properties on α and extending them to `completion α` by continuity. -/
-protected lemma completion.dist_self (x : completion α) : dist x x = 0 :=
+protected lemma dist_self (x : completion α) : dist x x = 0 :=
 begin
   apply induction_on x,
   { refine is_closed_eq _ continuous_const,
-    exact (completion.uniform_continuous_dist.continuous.comp
-             (continuous.prod_mk continuous_id continuous_id : _) : _) },
+    exact completion.continuous_dist continuous_id continuous_id },
   { assume a,
-    rw [completion.dist_eq, dist_self] }
+    rw [dist_eq, dist_self] }
 end
 
-protected lemma completion.dist_comm (x y : completion α) : dist x y = dist y x :=
+protected lemma dist_comm (x y : completion α) : dist x y = dist y x :=
 begin
   apply induction_on₂ x y,
-  { refine is_closed_eq completion.uniform_continuous_dist.continuous _,
-    exact completion.uniform_continuous_dist.continuous.comp
-      (@continuous_swap (completion α) (completion α) _ _) },
+  { exact is_closed_eq (completion.continuous_dist continuous_fst continuous_snd)
+      (completion.continuous_dist continuous_snd continuous_fst) },
   { assume a b,
-    rw [completion.dist_eq, completion.dist_eq, dist_comm] }
+    rw [dist_eq, dist_eq, dist_comm] }
 end
 
-protected lemma completion.dist_triangle (x y z : completion α) : dist x z ≤ dist x y + dist y z :=
+protected lemma dist_triangle (x y z : completion α) : dist x z ≤ dist x y + dist y z :=
 begin
   apply induction_on₃ x y z,
-  { refine is_closed_le _ (continuous.add _ _),
-    { have : continuous (λp : completion α × completion α × completion α, (p.1, p.2.2)) :=
-        continuous.prod_mk continuous_fst (continuous.comp continuous_snd continuous_snd),
-      exact (completion.uniform_continuous_dist.continuous.comp this : _) },
-    { have : continuous (λp : completion α × completion α × completion α, (p.1, p.2.1)) :=
-        continuous.prod_mk continuous_fst (continuous_fst.comp continuous_snd),
-      exact (completion.uniform_continuous_dist.continuous.comp this : _) },
-    { have : continuous (λp : completion α × completion α × completion α, (p.2.1, p.2.2)) :=
-        continuous.prod_mk (continuous_fst.comp continuous_snd)
-                           (continuous.comp continuous_snd continuous_snd),
-      exact (continuous.comp completion.uniform_continuous_dist.continuous this : _) } },
+  { refine is_closed_le _ (continuous.add _ _);
+      apply_rules [completion.continuous_dist, continuous.fst, continuous.snd, continuous_id] },
   { assume a b c,
-    rw [completion.dist_eq, completion.dist_eq, completion.dist_eq],
+    rw [dist_eq, dist_eq, dist_eq],
     exact dist_triangle a b c }
 end
 
 /-- Elements of the uniformity (defined generally for completions) can be characterized in terms
 of the distance. -/
-protected lemma completion.mem_uniformity_dist (s : set (completion α × completion α)) :
-  s ∈ uniformity (completion α) ↔ (∃ε>0, ∀{a b}, dist a b < ε → (a, b) ∈ s) :=
+protected lemma mem_uniformity_dist (s : set (completion α × completion α)) :
+  s ∈ 𝓤 (completion α) ↔ (∃ε>0, ∀{a b}, dist a b < ε → (a, b) ∈ s) :=
 begin
   split,
-  { /- Start from an entourage `s`. It contains a closed entourage `t`. Its pullback in α is an
-    entourage, so it contains an ε-neighborhood of the diagonal by definition of the entourages
-    in metric spaces. Then `t` contains an ε-neighborhood of the diagonal in `completion α`, as
+  { /- Start from an entourage `s`. It contains a closed entourage `t`. Its pullback in `α` is an
+    entourage, so it contains an `ε`-neighborhood of the diagonal by definition of the entourages
+    in metric spaces. Then `t` contains an `ε`-neighborhood of the diagonal in `completion α`, as
     closed properties pass to the completion. -/
     assume hs,
     rcases mem_uniformity_is_closed hs with ⟨t, ht, ⟨tclosed, ts⟩⟩,
@@ -140,7 +135,7 @@ begin
 end
 
 /-- If two points are at distance 0, then they coincide. -/
-protected lemma completion.eq_of_dist_eq_zero (x y : completion α) (h : dist x y = 0) : x = y :=
+protected lemma eq_of_dist_eq_zero (x y : completion α) (h : dist x y = 0) : x = y :=
 begin
   /- This follows from the separation of `completion α` and from the description of
   entourages in terms of the distance. -/
@@ -153,8 +148,8 @@ end
 
 /-- Reformulate `completion.mem_uniformity_dist` in terms that are suitable for the definition
 of the metric space structure. -/
-protected lemma completion.uniformity_dist' :
-  uniformity (completion α) = (⨅ε:{ε : ℝ // 0 < ε}, 𝓟 {p | dist p.1 p.2 < ε.val}) :=
+protected lemma uniformity_dist' :
+  𝓤 (completion α) = (⨅ε:{ε : ℝ // 0 < ε}, 𝓟 {p | dist p.1 p.2 < ε.val}) :=
 begin
   ext s, rw mem_infi_of_directed,
   { simp [completion.mem_uniformity_dist, subset_def] },
@@ -162,12 +157,12 @@ begin
     simp [lt_min_iff, (≥)] {contextual := tt} }
 end
 
-protected lemma completion.uniformity_dist :
-  uniformity (completion α) = (⨅ ε>0, 𝓟 {p | dist p.1 p.2 < ε}) :=
+protected lemma uniformity_dist :
+  𝓤 (completion α) = (⨅ ε>0, 𝓟 {p | dist p.1 p.2 < ε}) :=
 by simpa [infi_subtype] using @completion.uniformity_dist' α _
 
 /-- Metric space structure on the completion of a pseudo_metric space. -/
-instance completion.metric_space : metric_space (completion α) :=
+instance : metric_space (completion α) :=
 { dist_self          := completion.dist_self,
   eq_of_dist_eq_zero := completion.eq_of_dist_eq_zero,
   dist_comm          := completion.dist_comm,
@@ -176,7 +171,10 @@ instance completion.metric_space : metric_space (completion α) :=
   uniformity_dist    := completion.uniformity_dist }
 
 /-- The embedding of a metric space in its completion is an isometry. -/
-lemma completion.coe_isometry : isometry (coe : α → completion α) :=
+lemma coe_isometry : isometry (coe : α → completion α) :=
 isometry_emetric_iff_metric.2 completion.dist_eq
 
-end metric
+@[simp] protected lemma edist_eq (x y : α) : edist (x : completion α) y = edist x y :=
+coe_isometry x y
+
+end uniform_space.completion

--- a/src/topology/metric_space/gromov_hausdorff.lean
+++ b/src/topology/metric_space/gromov_hausdorff.lean
@@ -963,9 +963,8 @@ begin
   let X2 := λ n, range (coeZ ∘ (Φ n) ∘ (Y n).embed),
   have isom : ∀ n, isometry (coeZ ∘ (Φ n) ∘ (Y n).embed),
   { assume n,
-    apply isometry.comp completion.coe_isometry _,
-    apply isometry.comp _ (Y n).isom,
-    apply to_inductive_limit_isometry },
+    refine uniform_space.completion.coe_isometry.comp _,
+    exact (to_inductive_limit_isometry _ _).comp (Y n).isom },
   -- The Hausdorff distance of `X2 n` and `X2 (n+1)` is by construction the distance between
   -- `u n` and `u (n+1)`, therefore bounded by `1/2^n`
   have D2 : ∀ n, Hausdorff_dist (X2 n) (X2 n.succ) < (1/2)^n,
@@ -987,9 +986,8 @@ begin
     rw range_comp at X2nsucc,
     rw [X2n, X2nsucc, Hausdorff_dist_image, Hausdorff_dist_optimal, ← dist_GH_dist],
     { exact hu n n n.succ (le_refl n) (le_succ n) },
-    { apply isometry.comp completion.coe_isometry _,
-      apply isometry.comp _ ((ic n).comp (to_glue_r_isometry _ _)),
-      apply to_inductive_limit_isometry } },
+    { apply uniform_space.completion.coe_isometry.comp _,
+      exact (to_inductive_limit_isometry _ _).comp ((ic n).comp (to_glue_r_isometry _ _)) } },
   -- consider `X2 n` as a member `X3 n` of the type of nonempty compact subsets of `Z`, which
   -- is a metric space
   let X3 : ℕ → nonempty_compacts Z := λ n, ⟨X2 n,


### PR DESCRIPTION
Move lemmas about metric on `uniform_space.completion` from `metric.completion` namespace to `uniform_space.completion`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
