### PR TITLE
[Merged by Bors] - feat(number_theory/divisors): add `prod_div_divisors` and `sum_div_divisors`

### DIFF
--- a/src/data/nat/basic.lean
+++ b/src/data/nat/basic.lean
@@ -876,6 +876,18 @@ begin
   exact nat.lt_succ_self _,
 end
 
+lemma div_eq_iff_eq_of_dvd_dvd {n x y : ℕ} (hn : n ≠ 0) (hx : x ∣ n) (hy : y ∣ n) :
+  n / x = n / y ↔ x = y :=
+begin
+  split,
+  { intros h,
+    rw ←mul_right_inj' hn,
+    apply nat.eq_mul_of_div_eq_left (dvd_mul_of_dvd_left hy x),
+    rw [eq_comm, mul_comm, nat.mul_div_assoc _ hy],
+    exact nat.eq_mul_of_div_eq_right hx h },
+  { intros h, rw h },
+end
+
 /-! ### `mod`, `dvd` -/
 
 lemma div_add_mod (m k : ℕ) : k * (m / k) + m % k = m :=

--- a/src/number_theory/divisors.lean
+++ b/src/number_theory/divisors.lean
@@ -453,13 +453,13 @@ begin
            nat.div_div_self h1 (pos_iff_ne_zero.mpr hn)⟩ },
 end
 
-@[simp]
-lemma sum_div_divisors {α : Type*} [add_comm_monoid α] (n : ℕ) (f : ℕ → α) :
-  ∑ d in n.divisors, f (n/d) = n.divisors.sum f :=
+@[simp, to_additive]
+lemma prod_div_divisors {α : Type*} [comm_monoid α] (n : ℕ) (f : ℕ → α) :
+  ∏ d in n.divisors, f (n/d) = n.divisors.prod f :=
 begin
-  by_cases hn : n = 0, { simp [hn, zero_nsmul (f 0)] },
-  rw ←sum_image,
-  { exact sum_congr (image_div_divisors_eq_divisors n) (by simp) },
+  by_cases hn : n = 0, { simp [hn] },
+  rw ←prod_image,
+  { exact prod_congr (image_div_divisors_eq_divisors n) (by simp) },
   { intros x hx y hy h,
     rw mem_divisors at hx hy,
     exact (div_eq_iff_eq_of_dvd_dvd hn hx.1 hy.1).mp h }

--- a/src/number_theory/divisors.lean
+++ b/src/number_theory/divisors.lean
@@ -435,4 +435,56 @@ begin
     simpa [hn, hn.ne', mem_factors] using and_comm (prime q) (q ∣ n) }
 end
 
+lemma div_eq_iff_eq_of_dvd_dvd {n x y : ℕ} (hn : n ≠ 0) (hx : x ∣ n) (hy : y ∣ n) :
+  n / x = n / y ↔ x = y :=
+begin
+  split,
+  { intros h,
+    rw ←mul_right_inj' hn,
+    apply nat.eq_mul_of_div_eq_left (dvd_mul_of_dvd_left hy x),
+    rw [eq_comm, mul_comm, nat.mul_div_assoc _ hy],
+    exact nat.eq_mul_of_div_eq_right hx h },
+  { intros h, rw h },
+end
+
+lemma image_div_divisors_eq_divisors (n : ℕ) : image (λ (x : ℕ), n / x) n.divisors = n.divisors :=
+begin
+  by_cases hn : n = 0, { simp [hn] },
+  ext,
+  rw mem_divisors,
+  rw mem_image,
+  split,
+  {
+    rintros ⟨x, hx1, hx2⟩,
+    split, swap, exact hn,
+    rw mem_divisors at hx1,
+    replace hx1 := hx1.1,
+    rw ←hx2,
+    exact div_dvd_of_dvd hx1,
+  },
+  {
+    rintros ⟨h1, -⟩,
+    use n/a,
+    split,
+    {
+      rw mem_divisors,
+      split, swap, exact hn,
+      exact div_dvd_of_dvd h1,
+    },
+    { exact nat.div_div_self h1 (pos_iff_ne_zero.mpr hn) },
+  },
+
+end
+
+@[simp]
+lemma sum_div_divisors (n : ℕ) (f : ℕ → ℕ) : ∑ d in n.divisors, f (n/d) = n.divisors.sum f :=
+begin
+  by_cases hn : n = 0, { simp [hn] },
+  rw ←sum_image,
+  { exact sum_congr (image_div_divisors_eq_divisors n) (by simp) },
+  { intros x hx y hy h,
+    rw mem_divisors at hx hy,
+    exact (div_eq_iff_eq_of_dvd_dvd hn hx.1 hy.1).mp h }
+end
+
 end nat

--- a/src/number_theory/divisors.lean
+++ b/src/number_theory/divisors.lean
@@ -453,7 +453,7 @@ begin
            nat.div_div_self h1 (pos_iff_ne_zero.mpr hn)⟩ },
 end
 
-@[simp, to_additive]
+@[simp, to_additive sum_div_divisors]
 lemma prod_div_divisors {α : Type*} [comm_monoid α] (n : ℕ) (f : ℕ → α) :
   ∏ d in n.divisors, f (n/d) = n.divisors.prod f :=
 begin

--- a/src/number_theory/divisors.lean
+++ b/src/number_theory/divisors.lean
@@ -435,18 +435,6 @@ begin
     simpa [hn, hn.ne', mem_factors] using and_comm (prime q) (q ∣ n) }
 end
 
-lemma div_eq_iff_eq_of_dvd_dvd {n x y : ℕ} (hn : n ≠ 0) (hx : x ∣ n) (hy : y ∣ n) :
-  n / x = n / y ↔ x = y :=
-begin
-  split,
-  { intros h,
-    rw ←mul_right_inj' hn,
-    apply nat.eq_mul_of_div_eq_left (dvd_mul_of_dvd_left hy x),
-    rw [eq_comm, mul_comm, nat.mul_div_assoc _ hy],
-    exact nat.eq_mul_of_div_eq_right hx h },
-  { intros h, rw h },
-end
-
 @[simp]
 lemma image_div_divisors_eq_divisors (n : ℕ) : image (λ (x : ℕ), n / x) n.divisors = n.divisors :=
 begin

--- a/src/number_theory/divisors.lean
+++ b/src/number_theory/divisors.lean
@@ -447,33 +447,22 @@ begin
   { intros h, rw h },
 end
 
+@[simp]
 lemma image_div_divisors_eq_divisors (n : ℕ) : image (λ (x : ℕ), n / x) n.divisors = n.divisors :=
 begin
   by_cases hn : n = 0, { simp [hn] },
   ext,
-  rw mem_divisors,
-  rw mem_image,
   split,
-  {
+  { rw mem_image,
     rintros ⟨x, hx1, hx2⟩,
-    split, swap, exact hn,
-    rw mem_divisors at hx1,
-    replace hx1 := hx1.1,
+    rw mem_divisors at *,
+    refine ⟨_,hn⟩,
     rw ←hx2,
-    exact div_dvd_of_dvd hx1,
-  },
-  {
+    exact div_dvd_of_dvd hx1.1 },
+  { rw [mem_divisors, mem_image],
     rintros ⟨h1, -⟩,
-    use n/a,
-    split,
-    {
-      rw mem_divisors,
-      split, swap, exact hn,
-      exact div_dvd_of_dvd h1,
-    },
-    { exact nat.div_div_self h1 (pos_iff_ne_zero.mpr hn) },
-  },
-
+    exact ⟨n/a, mem_divisors.mpr ⟨div_dvd_of_dvd h1, hn⟩,
+           nat.div_div_self h1 (pos_iff_ne_zero.mpr hn)⟩ },
 end
 
 @[simp]

--- a/src/number_theory/divisors.lean
+++ b/src/number_theory/divisors.lean
@@ -454,9 +454,10 @@ begin
 end
 
 @[simp]
-lemma sum_div_divisors (n : ℕ) (f : ℕ → ℕ) : ∑ d in n.divisors, f (n/d) = n.divisors.sum f :=
+lemma sum_div_divisors {α : Type*} [add_comm_monoid α] (n : ℕ) (f : ℕ → α) :
+  ∑ d in n.divisors, f (n/d) = n.divisors.sum f :=
 begin
-  by_cases hn : n = 0, { simp [hn] },
+  by_cases hn : n = 0, { simp [hn, zero_nsmul (f 0)] },
   rw ←sum_image,
   { exact sum_congr (image_div_divisors_eq_divisors n) (by simp) },
   { intros x hx y hy h,


### PR DESCRIPTION
Adds lemma `prod_div_divisors : ∏ d in n.divisors, f (n/d) = n.divisors.prod f` and `sum_div_divisors`.

Also proves `image_div_divisors_eq_divisors : image (λ (x : ℕ), n / x) n.divisors = n.divisors`
and `div_eq_iff_eq_of_dvd_dvd : n / x = n / y ↔ x = y` (where `n ≠ 0` and `x ∣ n` and `y ∣ n`)


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
