### PR TITLE
[Merged by Bors] - feat(data/matrix/notation): expansions of matrix multiplication for 2x2 and 3x3

### DIFF
--- a/src/data/matrix/notation.lean
+++ b/src/data/matrix/notation.lean
@@ -5,6 +5,7 @@ Authors: Anne Baanen
 -/
 import data.matrix.basic
 import data.fin.vec_notation
+import tactic.fin_cases
 
 /-!
 # Matrix and vector notation
@@ -232,6 +233,43 @@ by { ext i j, refine fin.cases _ _ i; simp [minor] }
 end minor
 
 section vec2_and_vec3
+
+section one
+
+variables [has_zero α] [has_one α]
+
+lemma one_fin_two : (1 : matrix (fin 2) (fin 2) α) = ![![1, 0], ![0, 1]] :=
+by { ext i j, fin_cases i; fin_cases j; refl }
+
+lemma one_fin_three : (1 : matrix (fin 3) (fin 3) α) = ![![1, 0, 0], ![0, 1, 0], ![0, 0, 1]] :=
+by { ext i j, fin_cases i; fin_cases j; refl }
+
+end one
+
+lemma mul_fin_two [add_comm_monoid α] [has_mul α] (a₁₁ a₁₂ a₂₁ a₂₂ b₁₁ b₁₂ b₂₁ b₂₂ : α) :
+  ![![a₁₁, a₁₂],
+    ![a₂₁, a₂₂]] ⬝ ![![b₁₁, b₁₂],
+                     ![b₂₁, b₂₂]] = ![![a₁₁ * b₁₁ + a₁₂ * b₂₁, a₁₁ * b₁₂ + a₁₂ * b₂₂],
+                                      ![a₂₁ * b₁₁ + a₂₂ * b₂₁, a₂₁ * b₁₂ + a₂₂ * b₂₂]] :=
+begin
+  ext i j,
+  fin_cases i; fin_cases j; simp [matrix.mul, dot_product, fin.sum_univ_succ]
+end
+
+lemma mul_fin_three [add_comm_monoid α] [has_mul α]
+  (a₁₁ a₁₂ a₁₃ a₂₁ a₂₂ a₂₃ a₃₁ a₃₂ a₃₃ b₁₁ b₁₂ b₁₃ b₂₁ b₂₂ b₂₃ b₃₁ b₃₂ b₃₃ : α) :
+  ![![a₁₁, a₁₂, a₁₃],
+    ![a₂₁, a₂₂, a₂₃],
+    ![a₃₁, a₃₂, a₃₃]] ⬝ ![![b₁₁, b₁₂, b₁₃],
+                          ![b₂₁, b₂₂, b₂₃],
+                          ![b₃₁, b₃₂, b₃₃]] =
+  ![![a₁₁*b₁₁ + a₁₂*b₂₁ + a₁₃*b₃₁, a₁₁*b₁₂ + a₁₂*b₂₂ + a₁₃*b₃₂, a₁₁*b₁₃ + a₁₂*b₂₃ + a₁₃*b₃₃],
+    ![a₂₁*b₁₁ + a₂₂*b₂₁ + a₂₃*b₃₁, a₂₁*b₁₂ + a₂₂*b₂₂ + a₂₃*b₃₂, a₂₁*b₁₃ + a₂₂*b₂₃ + a₂₃*b₃₃],
+    ![a₃₁*b₁₁ + a₃₂*b₂₁ + a₃₃*b₃₁, a₃₁*b₁₂ + a₃₂*b₂₂ + a₃₃*b₃₂, a₃₁*b₁₃ + a₃₂*b₂₃ + a₃₃*b₃₃]] :=
+begin
+  ext i j,
+  fin_cases i; fin_cases j; simp [matrix.mul, dot_product, fin.sum_univ_succ, ←add_assoc],
+end
 
 lemma vec2_eq {a₀ a₁ b₀ b₁ : α} (h₀ : a₀ = b₀) (h₁ : a₁ = b₁) :
   ![a₀, a₁] = ![b₀, b₁] :=


### PR DESCRIPTION
A clever way to generalize this would be to make a recursivedefinition of `mul` and `one` that's defeq to the desired `![...]` result and prove that's equal to the usual definition, but that doesn't help with actually writing the lemma statement, which is the tedious bit.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
