### PR TITLE
[Merged by Bors] - feat(algebra/group_power/basic): `two_zsmul`

### DIFF
--- a/src/algebra/group_power/basic.lean
+++ b/src/algebra/group_power/basic.lean
@@ -174,6 +174,7 @@ open int
 theorem zpow_one (a : G) : a ^ (1:ℤ) = a :=
 by { convert pow_one a using 1, exact zpow_coe_nat a 1 }
 
+@[to_additive two_zsmul]
 theorem zpow_two (a : G) : a ^ (2 : ℤ) = a * a :=
 by { convert pow_two a using 1, exact zpow_coe_nat a 2 }
 


### PR DESCRIPTION
Mark `zpow_two` with `@[to_additive two_zsmul]`.  I see no apparent
reason for this result not to use `to_additive`, and I found I had a
use for the additive version.



---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
