### PR TITLE
[Merged by Bors] - feat(data/finset/basic): add lemma `filter_eq_empty_iff`

### DIFF
--- a/src/data/finset/basic.lean
+++ b/src/data/finset/basic.lean
@@ -1416,7 +1416,7 @@ ext $ λ x, ⟨λ h, (mem_filter.1 h).1, λ hx, mem_filter.2 ⟨hx, h x hx⟩⟩
 lemma filter_false_of_mem {s : finset α} (h : ∀ x ∈ s, ¬ p x) : s.filter p = ∅ :=
 eq_empty_of_forall_not_mem (by simpa)
 
-lemma filter_false_iff (s : finset α) (p : α → Prop) [decidable_pred p] :
+lemma filter_eq_empty_iff (s : finset α) (p : α → Prop) [decidable_pred p] :
   (s.filter p = ∅) ↔ ∀ x ∈ s, ¬ p x :=
 begin
   refine ⟨_, filter_false_of_mem⟩,

--- a/src/data/finset/basic.lean
+++ b/src/data/finset/basic.lean
@@ -1416,6 +1416,15 @@ ext $ λ x, ⟨λ h, (mem_filter.1 h).1, λ hx, mem_filter.2 ⟨hx, h x hx⟩⟩
 lemma filter_false_of_mem {s : finset α} (h : ∀ x ∈ s, ¬ p x) : s.filter p = ∅ :=
 eq_empty_of_forall_not_mem (by simpa)
 
+lemma filter_empty_iff (s : finset ℕ) (p : ℕ → Prop) [decidable_pred p] :
+  (s.filter p = ∅) ↔ ∀ x ∈ s, ¬ p x :=
+begin
+  refine ⟨_, finset.filter_false_of_mem⟩,
+  intros hs,
+  injection hs with hs',
+  rwa filter_eq_nil at hs'
+end
+
 lemma filter_congr {s : finset α} (H : ∀ x ∈ s, p x ↔ q x) : filter p s = filter q s :=
 eq_of_veq $ filter_congr H
 
@@ -1506,15 +1515,6 @@ begin
   { simp [filter_union_right, em] },
   { intro x, simp },
   { intro x, simp, intros hx hx₂, refine ⟨or.resolve_left (h hx) hx₂, hx₂⟩ }
-end
-
-lemma filter_empty_iff (s : finset ℕ) (p : ℕ → Prop) [decidable_pred p] :
-  (s.filter p = ∅) ↔ ∀ x ∈ s, ¬ p x :=
-begin
-  refine ⟨_, finset.filter_false_of_mem⟩,
-  intros hs,
-  injection hs with hs',
-  rwa filter_eq_nil at hs'
 end
 
 /- We can simplify an application of filter where the decidability is inferred in "the wrong way" -/

--- a/src/data/finset/basic.lean
+++ b/src/data/finset/basic.lean
@@ -1416,7 +1416,7 @@ ext $ λ x, ⟨λ h, (mem_filter.1 h).1, λ hx, mem_filter.2 ⟨hx, h x hx⟩⟩
 lemma filter_false_of_mem {s : finset α} (h : ∀ x ∈ s, ¬ p x) : s.filter p = ∅ :=
 eq_empty_of_forall_not_mem (by simpa)
 
-lemma filter_empty_iff (s : finset ℕ) (p : ℕ → Prop) [decidable_pred p] :
+lemma filter_false_iff (s : finset α) (p : α → Prop) [decidable_pred p] :
   (s.filter p = ∅) ↔ ∀ x ∈ s, ¬ p x :=
 begin
   refine ⟨_, finset.filter_false_of_mem⟩,

--- a/src/data/finset/basic.lean
+++ b/src/data/finset/basic.lean
@@ -1419,7 +1419,7 @@ eq_empty_of_forall_not_mem (by simpa)
 lemma filter_false_iff (s : finset α) (p : α → Prop) [decidable_pred p] :
   (s.filter p = ∅) ↔ ∀ x ∈ s, ¬ p x :=
 begin
-  refine ⟨_, finset.filter_false_of_mem⟩,
+  refine ⟨_, filter_false_of_mem⟩,
   intros hs,
   injection hs with hs',
   rwa filter_eq_nil at hs'

--- a/src/data/finset/basic.lean
+++ b/src/data/finset/basic.lean
@@ -1512,19 +1512,9 @@ lemma filter_empty_iff (s : finset ℕ) (p : ℕ → Prop) [decidable_pred p] :
   (s.filter p = ∅) ↔ ∀ x ∈ s, ¬ p x :=
 begin
   refine ⟨_, finset.filter_false_of_mem⟩,
-  { induction s using finset.induction_on with a t hat IH, { intros hs, simp [hs] },
-    intros ht x hx,
-    have : filter p t = ∅,
-    { rw [←subset_empty, ←ht],
-      exact filter_subset_filter p (subset_insert a t) },
-    specialize IH this,
-    cases mem_insert.mp hx,
-    { rw h,
-      rw filter_insert p a t at ht,
-      intros H,
-      simp only [H, if_true, insert_ne_empty] at ht,
-      cases ht },
-    { exact IH x h } },
+  intros hs,
+  injection hs with hs',
+  rwa filter_eq_nil at hs'
 end
 
 /- We can simplify an application of filter where the decidability is inferred in "the wrong way" -/

--- a/src/data/finset/basic.lean
+++ b/src/data/finset/basic.lean
@@ -1508,6 +1508,25 @@ begin
   { intro x, simp, intros hx hx₂, refine ⟨or.resolve_left (h hx) hx₂, hx₂⟩ }
 end
 
+lemma filter_empty_iff (s : finset ℕ) (p : ℕ → Prop) [decidable_pred p] :
+  (s.filter p = ∅) ↔ ∀ x ∈ s, ¬ p x :=
+begin
+  refine ⟨_, finset.filter_false_of_mem⟩,
+  { induction s using finset.induction_on with a t hat IH, { intros hs, simp [hs] },
+    intros ht x hx,
+    have : filter p t = ∅,
+    { rw [←subset_empty, ←ht],
+      exact filter_subset_filter p (subset_insert a t) },
+    specialize IH this,
+    cases mem_insert.mp hx,
+    { rw h,
+      rw filter_insert p a t at ht,
+      intros H,
+      simp only [H, if_true, insert_ne_empty] at ht,
+      cases ht },
+    { exact IH x h } },
+end
+
 /- We can simplify an application of filter where the decidability is inferred in "the wrong way" -/
 @[simp] lemma filter_congr_decidable {α} (s : finset α) (p : α → Prop) (h : decidable_pred p)
   [decidable_pred p] : @filter α p h s = s.filter p :=


### PR DESCRIPTION
Add `filter_eq_empty_iff : (s.filter p = ∅) ↔ ∀ x ∈ s, ¬ p x`

We already have the right-to-left direction of this in `filter_false_of_mem`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
