### PR TITLE
[Merged by Bors] - feat(data/pfun): A new induction on pfun.fix

### DIFF
--- a/src/data/pfun.lean
+++ b/src/data/pfun.lean
@@ -253,17 +253,20 @@ end
 Another induction lemma for `b ∈ f.fix a` which allows one to prove a predicate `P` holds for
 `a` given that `f a` inherits `P` from `a` and `P` holds for preimages of `b`.
 -/
-lemma fix_induction'
-  {f : α →. β ⊕ α} {b : β} {P : α → Prop} {a : α} (h : b ∈ f.fix a)
-  (h_base : (∀ a_final : α, sum.inl b ∈ f a_final -> P a_final))
-  (h_ind : (∀ a_0 a_1 : α, sum.inr a_1 ∈ f a_0 -> P a_1 -> P a_0)) : P a :=
+@[elab_as_eliminator]
+def fix_induction'
+  (f : α →. β ⊕ α) (b : β) {C : α → Sort*} {a : α} (h : b ∈ f.fix a)
+  (hbase : (∀ a_final : α, sum.inl b ∈ f a_final → C a_final))
+  (hind : (∀ a_0 a_1 : α, b ∈ f.fix a_1 → sum.inr a_1 ∈ f a_0 → C a_1 → C a_0)) : C a :=
 begin
-  apply fix_induction h,
-  intros a' hba' H,
-  rw mem_fix_iff at hba',
-  rcases hba' with hba' | ⟨a'', f_a'_a'', f_fix_a_b⟩,
-  { exact h_base a' hba', },
-  { exact h_ind a' a'' f_a'_a'' (H a'' f_fix_a_b f_a'_a''), },
+  refine fix_induction h (λ a' h ih, _),
+  cases e : (f a').get (dom_of_mem_fix h) with b' a''; replace e : _ ∈ f a' := ⟨_, e⟩,
+  { have : b' = b,
+    { obtain h'' | ⟨a, h'', _⟩ := mem_fix_iff.1 h; cases part.mem_unique e h'', refl },
+    subst this, exact hbase _ e },
+  { have : b ∈ f.fix a'',
+    { obtain h'' | ⟨a, h'', e'⟩ := mem_fix_iff.1 h; cases part.mem_unique e h'', exact e' },
+    refine hind _ _ this e (ih _ this e) },
 end
 
 variables (f : α →. β)

--- a/src/data/pfun.lean
+++ b/src/data/pfun.lean
@@ -249,38 +249,21 @@ begin
   exact IH _ fa'' ⟨ha _ fa'', this⟩ this,
 end
 
-lemma inheriting_predicates
+/--
+Another induction lemma for `b ∈ f.fix a` which allows one to prove a predicate `P` holds for
+`a` given that `f a` inherits `P` from `a` and `P` holds for preimages of `b`.
+-/
+lemma fix_induction'
   {f : α →. β ⊕ α} {b : β} {P : α → Prop} {a : α} (h : b ∈ f.fix a)
-  (hbase : (∀ a_final : α, sum.inl b ∈ f a_final -> P a_final))
-  (hind : (∀ a_0 a_1 : α, sum.inr a_1 ∈ f a_0 -> P a_1 -> P a_0)) : P a :=
+  (h_base : (∀ a_final : α, sum.inl b ∈ f a_final -> P a_final))
+  (h_ind : (∀ a_0 a_1 : α, sum.inr a_1 ∈ f a_0 -> P a_1 -> P a_0)) : P a :=
 begin
   apply fix_induction h,
   intros a' hba' H,
   rw mem_fix_iff at hba',
   rcases hba' with hba' | ⟨a'', f_a'_a'', f_fix_a_b⟩,
-  { exact hbase a' hba', },
-  { exact hind a' a'' f_a'_a'' (H a'' f_fix_a_b f_a'_a''), },
-end
-
-def adjoin_succ (f : α →. β ⊕ α) : α × ℕ →. β ⊕ (α × ℕ) :=
-λ ⟨a, n⟩, (f a >>= λ x, by { cases x, exact pure (sum.inl x), exact pure (sum.inr ⟨x, n.succ⟩), } )
-
-lemma fix_eq_adjoin_succ_fix (f : α →. β ⊕ α) (a : α) : f.fix a = f.adjoin_succ.fix ⟨a, 0⟩ :=
-begin
-  sorry,
-end
-
-lemma fix_dom_iff_trace (f : α →. β ⊕ α) (a : α) :
-  (f.fix a).dom
-  ↔
-  (∃ (b : β) (n : ℕ) (it : fin (n.succ) → α),
-    it 0 = a
-    ∧
-    (∀ i : fin n, f (it i.succ) = part.some (sum.inr (it (i : fin n.succ))))
-    ∧
-    f (it n) = part.some (sum.inl b)) :=
-begin
-  sorry,
+  { exact h_base a' hba', },
+  { exact h_ind a' a'' f_a'_a'' (H a'' f_fix_a_b f_a'_a''), },
 end
 
 variables (f : α →. β)

--- a/src/data/pfun.lean
+++ b/src/data/pfun.lean
@@ -256,8 +256,8 @@ Another induction lemma for `b ∈ f.fix a` which allows one to prove a predicat
 @[elab_as_eliminator]
 def fix_induction'
   (f : α →. β ⊕ α) (b : β) {C : α → Sort*} {a : α} (h : b ∈ f.fix a)
-  (hbase : (∀ a_final : α, sum.inl b ∈ f a_final → C a_final))
-  (hind : (∀ a₀ a₁ : α, b ∈ f.fix a₁ → sum.inr a₁ ∈ f a₀ → C a₁ → C a₀)) : C a :=
+  (hbase : ∀ a_final : α, sum.inl b ∈ f a_final → C a_final)
+  (hind : ∀ a₀ a₁ : α, b ∈ f.fix a₁ → sum.inr a₁ ∈ f a₀ → C a₁ → C a₀) : C a :=
 begin
   refine fix_induction h (λ a' h ih, _),
   cases e : (f a').get (dom_of_mem_fix h) with b' a''; replace e : _ ∈ f a' := ⟨_, e⟩,

--- a/src/data/pfun.lean
+++ b/src/data/pfun.lean
@@ -5,7 +5,6 @@ Authors: Mario Carneiro, Jeremy Avigad, Simon Hudon
 -/
 import data.part
 import data.rel
-import data.fin.basic
 
 /-!
 # Partial functions

--- a/src/data/pfun.lean
+++ b/src/data/pfun.lean
@@ -257,7 +257,7 @@ Another induction lemma for `b ∈ f.fix a` which allows one to prove a predicat
 def fix_induction'
   (f : α →. β ⊕ α) (b : β) {C : α → Sort*} {a : α} (h : b ∈ f.fix a)
   (hbase : (∀ a_final : α, sum.inl b ∈ f a_final → C a_final))
-  (hind : (∀ a_0 a_1 : α, b ∈ f.fix a_1 → sum.inr a_1 ∈ f a_0 → C a_1 → C a_0)) : C a :=
+  (hind : (∀ a₀ a₁ : α, b ∈ f.fix a₁ → sum.inr a₁ ∈ f a₀ → C a₁ → C a₀)) : C a :=
 begin
   refine fix_induction h (λ a' h ih, _),
   cases e : (f a').get (dom_of_mem_fix h) with b' a''; replace e : _ ∈ f a' := ⟨_, e⟩,


### PR DESCRIPTION

A new lemma that lets you prove predicates given `b ∈ f.fix a` if `f` preserves the predicate, and it holds for values which `f` maps to `b`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
