### PR TITLE
chore(analysis/normed_space/star/basic): move `is_R_or_C` instance

### DIFF
--- a/src/analysis/inner_product_space/basic.lean
+++ b/src/analysis/inner_product_space/basic.lean
@@ -6,6 +6,7 @@ Authors: Zhouhang Zhou, Sébastien Gouëzel, Frédéric Dupuis
 import algebra.direct_sum.module
 import analysis.complex.basic
 import analysis.normed_space.bounded_linear_maps
+import analysis.normed_space.star.basic
 import linear_algebra.bilinear_form
 import linear_algebra.sesquilinear_form
 

--- a/src/analysis/normed_space/star/basic.lean
+++ b/src/analysis/normed_space/star/basic.lean
@@ -8,6 +8,7 @@ import analysis.normed.group.hom
 import analysis.normed_space.basic
 import analysis.normed_space.linear_isometry
 import algebra.star.unitary
+import data.complex.is_R_or_C
 
 /-!
 # Normed star rings and algebras
@@ -50,6 +51,10 @@ noncomputable instance : cstar_ring ℝ :=
 { norm_star_mul_self := λ x, by simp only [star, id.def, normed_field.norm_mul] }
 
 variables {𝕜 E α : Type*}
+
+@[priority 100] instance cstar_ring_R_or_C [is_R_or_C E] : cstar_ring E :=
+{ norm_star_mul_self :=
+  (λ x, (normed_field.norm_mul _ _).trans $ congr_arg (* ∥x∥) is_R_or_C.norm_conj) }
 
 section normed_star_monoid
 variables [normed_group E] [star_add_monoid E] [normed_star_monoid E]

--- a/src/data/complex/is_R_or_C.lean
+++ b/src/data/complex/is_R_or_C.lean
@@ -6,7 +6,6 @@ Authors: Frédéric Dupuis
 import data.real.sqrt
 import field_theory.tower
 import analysis.normed_space.finite_dimension
-import analysis.normed_space.star.basic
 
 /-!
 # `is_R_or_C`: a typeclass for ℝ or ℂ
@@ -406,9 +405,6 @@ by field_simp
 
 @[is_R_or_C_simps] lemma norm_conj {z : K} : ∥conj z∥ = ∥z∥ :=
 by simp only [←sqrt_norm_sq_eq_norm, norm_sq_conj]
-
-@[priority 100] instance : cstar_ring K :=
-{ norm_star_mul_self := λ x, (normed_field.norm_mul _ _).trans $ congr_arg (* ∥x∥) norm_conj }
 
 /-! ### Cast lemmas -/
 


### PR DESCRIPTION
Removes `data.complex.is_R_or_C`'s dependency on `analysis.normed_space.star.basic`. The latter now depends on the former.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

Prior to this PR, `analysis.complex.basic` depended on `analysis.specific_limits` transitively via `data.complex.is_R_or_C`. I want to add some stuff about complex numbers to `specific_limits`, but doing so would cause an import cycle due to that dependency chain. 

r? @j-loreaux (instance was added in #10555)

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
