### PR TITLE
[Merged by Bors] - feat(analysis/inner_product_space/spectrum): `pos_nonneg_eigenvalues`

### DIFF
--- a/src/analysis/inner_product_space/basic.lean
+++ b/src/analysis/inner_product_space/basic.lean
@@ -7,7 +7,6 @@ import algebra.direct_sum.module
 import analysis.complex.basic
 import analysis.normed_space.bounded_linear_maps
 import linear_algebra.bilinear_form
-import linear_algebra.eigenspace
 import linear_algebra.sesquilinear_form
 
 /-!
@@ -2275,25 +2274,3 @@ lemma is_self_adjoint.restrict_invariant {T : E →ₗ[𝕜] E} (hT : is_self_ad
 λ v w, hT v w
 
 end inner_product_space
-
-/-! ### Positive operators -/
-
-section nonneg
-
-lemma eigenvalue_nonneg_of_nonneg {μ : 𝕜} {T : E →ₗ[𝕜] E} (hμ : module.End.has_eigenvalue T μ)
-  (hnn : ∀ (x : E), 0 ≤ is_R_or_C.re ⟪T x, x⟫) : 0 ≤ is_R_or_C.re μ :=
-begin
-  let v := (module.End.has_eigenvalue.exists_has_eigenvector hμ).some,
-  let hv := (module.End.has_eigenvalue.exists_has_eigenvector hμ).some_spec,
-  have : is_R_or_C.re ⟪T v, v⟫ = is_R_or_C.re μ * ∥v∥^2,
-  { simp only [module.End.has_eigenvector.apply_eq_smul hv,inner_smul_left, neg_mul,
-    inner_self_eq_norm_sq, is_R_or_C.mul_re, sub_zero, is_R_or_C.conj_re, mul_zero,
-      inner_self_nonneg_im ]},
-  specialize hnn v,
-  rw this at hnn,
-  have : 0 < ∥v∥^2, {rw sq_pos_iff (∥v∥), rw norm_ne_zero_iff, exact hv.2},
-  rw ← zero_le_mul_right this,
-  exact hnn,
-end
-
-end nonneg

--- a/src/analysis/inner_product_space/basic.lean
+++ b/src/analysis/inner_product_space/basic.lean
@@ -7,6 +7,7 @@ import algebra.direct_sum.module
 import analysis.complex.basic
 import analysis.normed_space.bounded_linear_maps
 import linear_algebra.bilinear_form
+import linear_algebra.eigenspace
 import linear_algebra.sesquilinear_form
 
 /-!
@@ -2274,3 +2275,25 @@ lemma is_self_adjoint.restrict_invariant {T : E →ₗ[𝕜] E} (hT : is_self_ad
 λ v w, hT v w
 
 end inner_product_space
+
+/-! ### Positive operators -/
+
+section nonneg
+
+lemma eigenvalue_nonneg_of_nonneg {μ : 𝕜} {T : E →ₗ[𝕜] E} (hμ : module.End.has_eigenvalue T μ)
+  (hnn : ∀ (x : E), 0 ≤ is_R_or_C.re ⟪T x, x⟫) : 0 ≤ is_R_or_C.re μ :=
+begin
+  let v := (module.End.has_eigenvalue.exists_has_eigenvector hμ).some,
+  let hv := (module.End.has_eigenvalue.exists_has_eigenvector hμ).some_spec,
+  have : is_R_or_C.re ⟪T v, v⟫ = is_R_or_C.re μ * ∥v∥^2,
+  { simp only [module.End.has_eigenvector.apply_eq_smul hv,inner_smul_left, neg_mul,
+    inner_self_eq_norm_sq, is_R_or_C.mul_re, sub_zero, is_R_or_C.conj_re, mul_zero,
+      inner_self_nonneg_im ]},
+  specialize hnn v,
+  rw this at hnn,
+  have : 0 < ∥v∥^2, {rw sq_pos_iff (∥v∥), rw norm_ne_zero_iff, exact hv.2},
+  rw ← zero_le_mul_right this,
+  exact hnn,
+end
+
+end nonneg

--- a/src/analysis/inner_product_space/spectrum.lean
+++ b/src/analysis/inner_product_space/spectrum.lean
@@ -248,7 +248,7 @@ end inner_product_space
 section nonneg
 
 lemma eigenvalue_nonneg_of_nonneg {μ : ℝ} {T : E →ₗ[𝕜] E} (hμ : has_eigenvalue T μ)
-  (hnn : ∀ (x : E), 0 ≤ is_R_or_C.re ⟪T x, x⟫) : 0 ≤ is_R_or_C.re μ :=
+  (hnn : ∀ (x : E), 0 ≤ is_R_or_C.re ⟪x, T x⟫) : 0 ≤ μ :=
 begin
   obtain ⟨v, hv⟩ := hμ.exists_has_eigenvector,
   have hpos : 0 < ∥v∥ ^ 2, by simpa only [sq_pos_iff, norm_ne_zero_iff] using hv.2,

--- a/src/analysis/inner_product_space/spectrum.lean
+++ b/src/analysis/inner_product_space/spectrum.lean
@@ -242,25 +242,5 @@ end
 
 end version2
 
-section nonneg
-
-lemma eigenvalue_nonneg_of_nonneg {μ : 𝕜} (hμ : has_eigenvalue T μ)
-  (hnn : ∀ (x : E), 0 ≤ is_R_or_C.re ⟪T x, x⟫) : 0 ≤ is_R_or_C.re μ :=
-begin
-  let v := (module.End.has_eigenvalue.exists_has_eigenvector hμ).some,
-  let hv := (module.End.has_eigenvalue.exists_has_eigenvector hμ).some_spec,
-  have : is_R_or_C.re ⟪T v, v⟫ = is_R_or_C.re μ * ∥v∥^2,
-  { simp only [module.End.has_eigenvector.apply_eq_smul hv,inner_smul_left, neg_mul,
-    inner_self_eq_norm_sq, is_R_or_C.mul_re, sub_zero, is_R_or_C.conj_re, mul_zero,
-      inner_self_nonneg_im ]},
-  specialize hnn v,
-  rw this at hnn,
-  have : 0 < ∥v∥^2, {rw sq_pos_iff (∥v∥), rw norm_ne_zero_iff, exact hv.2},
-  rw ← zero_le_mul_right this,
-  exact hnn,
-end
-
-end nonneg
-
 end is_self_adjoint
 end inner_product_space

--- a/src/analysis/inner_product_space/spectrum.lean
+++ b/src/analysis/inner_product_space/spectrum.lean
@@ -256,5 +256,13 @@ begin
   { exact_mod_cast congr_arg is_R_or_C.re (inner_product_apply_eigenvector hv.1) },
   exact (zero_le_mul_right hpos).mp (this ▸ hnn v),
 end
-
+lemma eigenvalue_pos_of_pos {μ : ℝ} {T : E →ₗ[𝕜] E} (hμ : has_eigenvalue T μ)
+  (hnn : ∀ (x : E), 0 < is_R_or_C.re ⟪x, T x⟫) : 0 < μ :=
+begin
+  obtain ⟨v, hv⟩ := hμ.exists_has_eigenvector,
+  have hpos : 0 < ∥v∥ ^ 2, by simpa only [sq_pos_iff, norm_ne_zero_iff] using hv.2,
+  have : is_R_or_C.re ⟪v, T v⟫ = μ * ∥v∥ ^ 2,
+  { exact_mod_cast congr_arg is_R_or_C.re (inner_product_apply_eigenvector hv.1) },
+  exact (zero_lt_mul_right hpos).mp (this ▸ hnn v),
+end
 end nonneg

--- a/src/analysis/inner_product_space/spectrum.lean
+++ b/src/analysis/inner_product_space/spectrum.lean
@@ -244,3 +244,23 @@ end version2
 
 end is_self_adjoint
 end inner_product_space
+
+section nonneg
+
+lemma eigenvalue_nonneg_of_nonneg {μ : 𝕜} {T : E →ₗ[𝕜] E} (hμ : module.End.has_eigenvalue T μ)
+  (hnn : ∀ (x : E), 0 ≤ is_R_or_C.re ⟪T x, x⟫) : 0 ≤ is_R_or_C.re μ :=
+begin
+  let v := (module.End.has_eigenvalue.exists_has_eigenvector hμ).some,
+  let hv := (module.End.has_eigenvalue.exists_has_eigenvector hμ).some_spec,
+  have : is_R_or_C.re ⟪T v, v⟫ = is_R_or_C.re μ * ∥v∥^2,
+  { simp only [module.End.has_eigenvector.apply_eq_smul hv,inner_smul_left, neg_mul,
+    inner_self_eq_norm_sq, is_R_or_C.mul_re, sub_zero, is_R_or_C.conj_re, mul_zero,
+      inner_self_nonneg_im ]},
+  specialize hnn v,
+  rw this at hnn,
+  have : 0 < ∥v∥^2, {rw sq_pos_iff (∥v∥), rw norm_ne_zero_iff, exact hv.2},
+  rw ← zero_le_mul_right this,
+  exact hnn,
+end
+
+end nonneg

--- a/src/analysis/inner_product_space/spectrum.lean
+++ b/src/analysis/inner_product_space/spectrum.lean
@@ -247,7 +247,7 @@ end inner_product_space
 
 section nonneg
 
-lemma eigenvalue_nonneg_of_nonneg {μ : 𝕜} {T : E →ₗ[𝕜] E} (hμ : module.End.has_eigenvalue T μ)
+lemma eigenvalue_nonneg_of_nonneg {μ : ℝ} {T : E →ₗ[𝕜] E} (hμ : has_eigenvalue T μ)
   (hnn : ∀ (x : E), 0 ≤ is_R_or_C.re ⟪T x, x⟫) : 0 ≤ is_R_or_C.re μ :=
 begin
   let v := (module.End.has_eigenvalue.exists_has_eigenvector hμ).some,

--- a/src/analysis/inner_product_space/spectrum.lean
+++ b/src/analysis/inner_product_space/spectrum.lean
@@ -246,7 +246,10 @@ end is_self_adjoint
 end inner_product_space
 
 section nonneg
-
+@[simp]
+lemma inner_product_apply_eigenvector {μ : 𝕜} {v : E} {T : E →ₗ[𝕜] E}
+  (h : v ∈ module.End.eigenspace T μ) : ⟪v, T v⟫ = μ * ∥v∥ ^ 2 :=
+by simp only [mem_eigenspace_iff.mp h, inner_smul_right, inner_self_eq_norm_sq_to_K],
 lemma eigenvalue_nonneg_of_nonneg {μ : ℝ} {T : E →ₗ[𝕜] E} (hμ : has_eigenvalue T μ)
   (hnn : ∀ (x : E), 0 ≤ is_R_or_C.re ⟪x, T x⟫) : 0 ≤ μ :=
 begin

--- a/src/analysis/inner_product_space/spectrum.lean
+++ b/src/analysis/inner_product_space/spectrum.lean
@@ -262,7 +262,7 @@ begin
   exact (hpos (hT.eigenvector_basis hn i)),
 end
 
-end positive
+end nonneg
 
 end is_self_adjoint
 end inner_product_space

--- a/src/analysis/inner_product_space/spectrum.lean
+++ b/src/analysis/inner_product_space/spectrum.lean
@@ -245,8 +245,8 @@ end version2
 section positive
 variables {n : ℕ} (hn : finite_dimensional.finrank 𝕜 E = n)
 
-lemma pos_nonneg_eigenvalues (hpos : ∀ (x : E), (is_R_or_C.re ⟪T x, x⟫ ≥ 0)) :
-  ∀ (i : (fin n)), hT.eigenvalues hn i ≥ 0 :=
+lemma pos_nonneg_eigenvalues (hpos : ∀ (x : E), 0 ≤ is_R_or_C.re ⟪T x, x⟫) :
+  ∀ (i : (fin n)), 0 ≤ hT.eigenvalues hn i :=
 begin
   intro i,
   have : hT.eigenvalues hn i =

--- a/src/analysis/inner_product_space/spectrum.lean
+++ b/src/analysis/inner_product_space/spectrum.lean
@@ -250,17 +250,11 @@ section nonneg
 lemma eigenvalue_nonneg_of_nonneg {μ : ℝ} {T : E →ₗ[𝕜] E} (hμ : has_eigenvalue T μ)
   (hnn : ∀ (x : E), 0 ≤ is_R_or_C.re ⟪T x, x⟫) : 0 ≤ is_R_or_C.re μ :=
 begin
-  let v := (module.End.has_eigenvalue.exists_has_eigenvector hμ).some,
-  let hv := (module.End.has_eigenvalue.exists_has_eigenvector hμ).some_spec,
-  have : is_R_or_C.re ⟪T v, v⟫ = is_R_or_C.re μ * ∥v∥^2,
-  { simp only [module.End.has_eigenvector.apply_eq_smul hv,inner_smul_left, neg_mul,
-    inner_self_eq_norm_sq, is_R_or_C.mul_re, sub_zero, is_R_or_C.conj_re, mul_zero,
-      inner_self_nonneg_im ]},
-  specialize hnn v,
-  rw this at hnn,
-  have : 0 < ∥v∥^2, {rw sq_pos_iff (∥v∥), rw norm_ne_zero_iff, exact hv.2},
-  rw ← zero_le_mul_right this,
-  exact hnn,
+  obtain ⟨v, hv⟩ := hμ.exists_has_eigenvector,
+  have hpos : 0 < ∥v∥ ^ 2, by simpa only [sq_pos_iff, norm_ne_zero_iff] using hv.2,
+  have : is_R_or_C.re ⟪v, T v⟫ = μ * ∥v∥ ^ 2,
+  { exact_mod_cast congr_arg is_R_or_C.re (inner_product_apply_eigenvector hv.1) },
+  exact (zero_le_mul_right hpos).mp (this ▸ hnn v),
 end
 
 end nonneg

--- a/src/analysis/inner_product_space/spectrum.lean
+++ b/src/analysis/inner_product_space/spectrum.lean
@@ -245,7 +245,7 @@ end version2
 section positive
 variables {n : ℕ} (hn : finite_dimensional.finrank 𝕜 E = n)
 
-lemma pos_nonneg_eigenvalues (hpos : ∀ (x : E), 0 ≤ is_R_or_C.re ⟪T x, x⟫) :
+lemma nonneg_eigenvalues_of_nonneg (hpos : ∀ (x : E), 0 ≤ is_R_or_C.re ⟪T x, x⟫) :
   ∀ (i : (fin n)), 0 ≤ hT.eigenvalues hn i :=
 begin
   intro i,

--- a/src/analysis/inner_product_space/spectrum.lean
+++ b/src/analysis/inner_product_space/spectrum.lean
@@ -242,7 +242,7 @@ end
 
 end version2
 
-section positive
+section nonneg
 variables {n : ℕ} (hn : finite_dimensional.finrank 𝕜 E = n)
 
 lemma nonneg_eigenvalues_of_nonneg (hpos : ∀ (x : E), 0 ≤ is_R_or_C.re ⟪T x, x⟫) :

--- a/src/analysis/inner_product_space/spectrum.lean
+++ b/src/analysis/inner_product_space/spectrum.lean
@@ -243,16 +243,21 @@ end
 end version2
 
 section nonneg
-variables {n : ℕ} (hn : finite_dimensional.finrank 𝕜 E = n)
 
-lemma nonneg_eigenvalues_of_nonneg (hpos : ∀ (x : E), 0 ≤ is_R_or_C.re ⟪T x, x⟫) :
-  ∀ (i : (fin n)), 0 ≤ hT.eigenvalues hn i :=
+lemma eigenvalue_nonneg_of_nonneg {μ : 𝕜} (hμ : has_eigenvalue T μ)
+  (hnn : ∀ (x : E), 0 ≤ is_R_or_C.re ⟪T x, x⟫) : 0 ≤ is_R_or_C.re μ :=
 begin
-  intro i,
-  have : is_R_or_C.re ⟪ T (hT.eigenvector_basis hn i), hT.eigenvector_basis hn i ⟫ 
-    = hT.eigenvalues hn i,
-  { simp [inner_smul_left, inner_self_eq_norm_sq_to_K, (hT.eigenvector_basis_orthonormal hn).1] },
-  exact this ▸ hpos (hT.eigenvector_basis hn i),
+  let v := (module.End.has_eigenvalue.exists_has_eigenvector hμ).some,
+  let hv := (module.End.has_eigenvalue.exists_has_eigenvector hμ).some_spec,
+  have : is_R_or_C.re ⟪T v, v⟫ = is_R_or_C.re μ * ∥v∥^2,
+  { simp only [module.End.has_eigenvector.apply_eq_smul hv,inner_smul_left, neg_mul,
+    inner_self_eq_norm_sq, is_R_or_C.mul_re, sub_zero, is_R_or_C.conj_re, mul_zero,
+      inner_self_nonneg_im ]},
+  specialize hnn v,
+  rw this at hnn,
+  have : 0 < ∥v∥^2, {rw sq_pos_iff (∥v∥), rw norm_ne_zero_iff, exact hv.2},
+  rw ← zero_le_mul_right this,
+  exact hnn,
 end
 
 end nonneg

--- a/src/analysis/inner_product_space/spectrum.lean
+++ b/src/analysis/inner_product_space/spectrum.lean
@@ -242,5 +242,27 @@ end
 
 end version2
 
+section positive
+variables {n : ℕ} (hn : finite_dimensional.finrank 𝕜 E = n)
+
+lemma pos_nonneg_eigenvalues (hpos : ∀ (x : E), (is_R_or_C.re ⟪T x, x⟫ ≥ 0)) :
+  ∀ (i : (fin n)), hT.eigenvalues hn i ≥ 0 :=
+begin
+  intro i,
+  have : hT.eigenvalues hn i =
+    is_R_or_C.re ⟪ T (hT.eigenvector_basis hn i), hT.eigenvector_basis hn i ⟫ :=
+  begin
+    simp only [inner_smul_left, inner_product_space.is_self_adjoint.apply_eigenvector_basis,
+      is_R_or_C.conj_of_real, is_R_or_C.mul_re, is_R_or_C.of_real_re, sub_zero, mul_zero,
+      inner_self_nonneg_im, is_R_or_C.of_real_im, inner_self_eq_norm_sq_to_K],
+    rw (hT.eigenvector_basis_orthonormal hn).1,
+    norm_num,
+  end,
+  rw this,
+  exact (hpos (hT.eigenvector_basis hn i)),
+end
+
+end positive
+
 end is_self_adjoint
 end inner_product_space

--- a/src/analysis/inner_product_space/spectrum.lean
+++ b/src/analysis/inner_product_space/spectrum.lean
@@ -249,17 +249,10 @@ lemma nonneg_eigenvalues_of_nonneg (hpos : ∀ (x : E), 0 ≤ is_R_or_C.re ⟪T 
   ∀ (i : (fin n)), 0 ≤ hT.eigenvalues hn i :=
 begin
   intro i,
-  have : hT.eigenvalues hn i =
-    is_R_or_C.re ⟪ T (hT.eigenvector_basis hn i), hT.eigenvector_basis hn i ⟫ :=
-  begin
-    simp only [inner_smul_left, inner_product_space.is_self_adjoint.apply_eigenvector_basis,
-      is_R_or_C.conj_of_real, is_R_or_C.mul_re, is_R_or_C.of_real_re, sub_zero, mul_zero,
-      inner_self_nonneg_im, is_R_or_C.of_real_im, inner_self_eq_norm_sq_to_K],
-    rw (hT.eigenvector_basis_orthonormal hn).1,
-    norm_num,
-  end,
-  rw this,
-  exact (hpos (hT.eigenvector_basis hn i)),
+  have : is_R_or_C.re ⟪ T (hT.eigenvector_basis hn i), hT.eigenvector_basis hn i ⟫ 
+    = hT.eigenvalues hn i,
+  { simp [inner_smul_left, inner_self_eq_norm_sq_to_K, (hT.eigenvector_basis_orthonormal hn).1] },
+  exact this ▸ hpos (hT.eigenvector_basis hn i),
 end
 
 end nonneg

--- a/src/analysis/inner_product_space/spectrum.lean
+++ b/src/analysis/inner_product_space/spectrum.lean
@@ -246,10 +246,12 @@ end is_self_adjoint
 end inner_product_space
 
 section nonneg
+
 @[simp]
 lemma inner_product_apply_eigenvector {μ : 𝕜} {v : E} {T : E →ₗ[𝕜] E}
   (h : v ∈ module.End.eigenspace T μ) : ⟪v, T v⟫ = μ * ∥v∥ ^ 2 :=
-by simp only [mem_eigenspace_iff.mp h, inner_smul_right, inner_self_eq_norm_sq_to_K],
+by simp only [mem_eigenspace_iff.mp h, inner_smul_right, inner_self_eq_norm_sq_to_K]
+
 lemma eigenvalue_nonneg_of_nonneg {μ : ℝ} {T : E →ₗ[𝕜] E} (hμ : has_eigenvalue T μ)
   (hnn : ∀ (x : E), 0 ≤ is_R_or_C.re ⟪x, T x⟫) : 0 ≤ μ :=
 begin
@@ -259,6 +261,7 @@ begin
   { exact_mod_cast congr_arg is_R_or_C.re (inner_product_apply_eigenvector hv.1) },
   exact (zero_le_mul_right hpos).mp (this ▸ hnn v),
 end
+
 lemma eigenvalue_pos_of_pos {μ : ℝ} {T : E →ₗ[𝕜] E} (hμ : has_eigenvalue T μ)
   (hnn : ∀ (x : E), 0 < is_R_or_C.re ⟪x, T x⟫) : 0 < μ :=
 begin
@@ -268,4 +271,5 @@ begin
   { exact_mod_cast congr_arg is_R_or_C.re (inner_product_apply_eigenvector hv.1) },
   exact (zero_lt_mul_right hpos).mp (this ▸ hnn v),
 end
+
 end nonneg


### PR DESCRIPTION
If T is a positive self-adjoint operator, then its eigenvalues are
nonnegative.  Maybe there should be a definition of "positive operator",
and maybe this should be generalized.  Guidance appreciated!

Co-authored-by: Daniel Packer

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
