### PR TITLE
[Merged by Bors] - chore(topology/algebra/infinite_sum): reference Cauchy criterion in docs

### DIFF
--- a/src/topology/algebra/infinite_sum.lean
+++ b/src/topology/algebra/infinite_sum.lean
@@ -1022,6 +1022,7 @@ section uniform_group
 
 variables [add_comm_group α] [uniform_space α]
 
+/-- The **Cauchy criterion** for infinite sums, also known as the **Cauchy convergence test** -/
 lemma summable_iff_cauchy_seq_finset [complete_space α] {f : β → α} :
   summable f ↔ cauchy_seq (λ (s : finset β), ∑ b in s, f b) :=
 cauchy_map_iff_exists_tendsto.symm


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

Mathlib's online documentation now uses doc comments to provide search results. However, searching for ["Cauchy criterion"](https://mathworld.wolfram.com/CauchyCriterion.html) turns up nothing. Mention it as part of `summable_iff_cauchy_seq_finset` to fix this. Possibly it should be mentioned on [`cauchy_seq_tendsto_of_complete`](https://leanprover-community.github.io/mathlib_docs/topology/uniform_space/cauchy.html#cauchy_seq_tendsto_of_complete) as well, although that only goes in one direction.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
