### PR TITLE
feat(algebraic_geometry/*) : presheaf of modules

### DIFF
--- a/.github/workflows/bors.yml
+++ b/.github/workflows/bors.yml
@@ -80,8 +80,8 @@ jobs:
         run: |
           leanpkg configure
           echo "::set-output name=started::true"
-          lean --json -T100000 --make src | python3 scripts/detect_errors.py
-          lean --json -T100000 --make src | python3 scripts/detect_errors.py
+          lean --json -T400000 --make src | python3 scripts/detect_errors.py
+          lean --json -T400000 --make src | python3 scripts/detect_errors.py
 
       - name: push release to azure
         if: always() && github.repository == 'leanprover-community/mathlib' && steps.build.outputs.started == 'true'

--- a/.github/workflows/build_fork.yml
+++ b/.github/workflows/build_fork.yml
@@ -86,8 +86,8 @@ jobs:
         run: |
           leanpkg configure
           echo "::set-output name=started::true"
-          lean --json -T100000 --make src | python3 scripts/detect_errors.py
-          lean --json -T100000 --make src | python3 scripts/detect_errors.py
+          lean --json -T400000 --make src | python3 scripts/detect_errors.py
+          lean --json -T400000 --make src | python3 scripts/detect_errors.py
 
       - name: push release to azure
         if: always() && github.repository == 'leanprover-community/mathlib' && steps.build.outputs.started == 'true'

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,5 +7,6 @@
   "files.insertFinalNewline": true,
   "files.trimFinalNewlines": true,
   "files.trimTrailingWhitespace": true,
-  "search.usePCRE2": true
+  "search.usePCRE2": true,
+  "lean.timeLimit": 400000
 }

--- a/src/algebra/module/restriction_of_scalars.lean
+++ b/src/algebra/module/restriction_of_scalars.lean
@@ -16,201 +16,281 @@ namespace restriction_of_scalars
 universe u
 
 variables {R S : CommRing.{u}} -- [ring R] [ring S] -- (f : R →+* S)
-variables (N : Module S) -- [add_comm_monoid N] [module S N]
 variable (f : R ⟶ S)
+variables (N : Module S) -- [add_comm_monoid N] [module S N]
 include f
 
-/--Definition of scalar multiplication in restriction of scalars-/
-def has_scalar : has_scalar R N :=
-{ smul := λ r n,  f r • n}
+@[reducible] def module :
+  Module R :=
+{ carrier := N,
+  is_module := module.comp_hom _ f, }.
+localized "notation f `^*` N := restriction_of_scalars.module f N" in change_of_rings
 
--- #check (restriction_of_scalars.has_scalar N f).smul
-localized "attribute [instance] restriction_of_scalars.has_scalar" in change_of_rings
-
-@[simp] lemma smul_def (r : R) (n : N) :
-  @has_scalar.smul R N (restriction_of_scalars.has_scalar N f) r n = f r • n := rfl
-
-def is_module : module R N :=
-{ one_smul := by simp,
-  mul_smul := by simp [mul_smul],
-  smul_add := by simp [smul_add],
-  smul_zero := by simp,
-  add_smul := by simp [add_smul],
-  zero_smul := by simp,
-  ..(restriction_of_scalars.has_scalar N f) }.
+def is_module : _root_.module R N := (f ^* N).is_module
 
 localized "attribute [instance] restriction_of_scalars.is_module" in change_of_rings
 
-/--
-Given a ring homomorphism `f : R ⟶ S`, and an `S`-module `N`, we can turn `N` into an `R`-module.
-This is called restriction_of_scalar
--/
-def module :
-  Module R :=
-{ carrier := N,
-  is_add_comm_group := infer_instance,
-  is_module := is_module N f }.
-
-localized "notation f `^*` N := restriction_of_scalars.module N f" in change_of_rings
 
 instance has_scalar' : _root_.has_scalar S (f ^* N) :=
 { smul := λ s n, @has_scalar.smul S N _ s n }.
 
 @[simp] lemma smul_def' (r : R) (n : f ^* N) : r • n = f r • n := rfl
+@[simp] lemma smul_def (r : R) (n : N) :
+  @has_scalar.smul R N begin
+    haveI := is_module f N,
+    apply_instance,
+  end r n = f r • n := rfl
 
-/--restrictino of scalar is a functor from `S`-modules to `R`-modules.-/
+def compatible_smul (N₁ N₂ : Module S) :
+  let m1 := is_module f N₁,
+      m2 := is_module f N₂,
+      m3 := is_module f ⟨S⟩ in
+  begin
+    resetI,
+    exact linear_map.compatible_smul N₁ N₂ R S
+  end :=
+let m1 := is_module f N₁,
+    m2 := is_module f N₂,
+    m3 := is_module f ⟨S⟩ in
+begin
+  resetI,
+  fconstructor,
+  intros g r n,
+  calc  g (r • n)
+      = g (f r • n) : by congr' 1
+    ... = f r • g n : by { erw linear_map.map_smul, },
+end
+/--restriction of scalar is a functor from `S`-modules to `R`-modules.-/
 def functor : Module S ⥤ Module R :=
 { obj := λ N, f ^* N,
   map := λ N₁ N₂ l,
-    { to_fun := l,
-      map_add' := λ x y, by rw [linear_map.map_add],
-      map_smul' := λ r y, begin
-        simp only [smul_def', ring_hom.id_apply],
-        convert linear_map.map_smul l (f r) y,
-      end } }
+  let m1 := is_module f N₁,
+      m2 := is_module f N₂,
+      m3 := is_module f ⟨S⟩,
+      m4 := compatible_smul f N₁ N₂ in
+  begin
+    dsimp only at m4,
+    resetI,
+    exact linear_map.restrict_scalars R l,
+  end }.
+
+localized "notation f `⥤^*` M := (restriction_of_scalars.functor f).obj M" in change_of_rings
 
 end restriction_of_scalars
 
 namespace extension_of_scalars
+
+open category_theory tensor_product
 
 universe u
 
 variables {R S : CommRing.{u}} (f : R ⟶ S) (M : Module R)
 include f
 
-/--
-This action gives `S` an `R`-module strucutre
--/
-def is_R_mod_S : module R S := restriction_of_scalars.is_module ⟨S⟩ f
+-- /--
+-- This action gives `S` an `R`-module strucutre
+-- -/
+-- def is_R_mod_S : module R S := restriction_of_scalars.is_module ⟨S⟩ f
 
-localized "attribute [instance] extension_of_scalars.is_R_mod_S" in change_of_rings
+-- localized "attribute [instance] extension_of_scalars.is_R_mod_S" in change_of_rings
 
-@[simp] lemma smul_def (r : R) (s : S) :
-  @has_scalar.smul _ _ begin
-    haveI := is_R_mod_S f,
-    resetI,
-    apply_instance
-  end r s = f r * s := rfl
+-- @[simp] lemma smul_def (r : R) (s : S) :
+--   @has_scalar.smul _ _ begin
+--     haveI := is_R_mod_S f,
+--     resetI,
+--     apply_instance
+--   end r s = f r * s := rfl
 
 
 include M
 localized "notation M `⊗[` R `,` f `]` S := @tensor_product R _ M S _ _ _
-  (extension_of_scalars.is_R_mod_S f)" in change_of_rings
+  (restriction_of_scalars.is_module f ⟨S⟩)" in change_of_rings
+localized "notation m `⊗ₜ[` R `,` f `]` s := @tensor_product.tmul R _ _ _ _ _ _
+  (restriction_of_scalars.is_module f ⟨_⟩) m s" in change_of_rings
+
+def smul_by (s : S) : (M ⊗[R, f] S) ⟶ (M ⊗[R, f] S) :=
+let m : module R S := restriction_of_scalars.is_module f ⟨S⟩ in
+begin
+  resetI,
+  refine tensor_product.lift _,
+  refine ⟨_, _, _⟩,
+  { -- we define `m ↦ (s' ↦ m ⊗ (s * s'))`
+    refine λ m, ⟨λ s', m ⊗ₜ[R, f] (s * s'), _, _⟩,
+    { -- map_add
+      intros,
+      erw [mul_add, tmul_add], },
+    { -- map_smul
+      intros,
+      rw [ring_hom.id_apply, smul_tmul', smul_tmul],
+      congr' 1,
+      rw [restriction_of_scalars.smul_def f ⟨S⟩, smul_eq_mul, ← mul_assoc, mul_comm s,
+        mul_assoc, restriction_of_scalars.smul_def f ⟨S⟩, smul_eq_mul],
+    }, },
+  { intros,
+    ext,
+    simp only [linear_map.coe_mk, map_add, add_tmul],
+    refl, },
+  { intros,
+    ext,
+    simp only [linear_map.coe_mk, ring_hom.id_apply, linear_map.smul_apply],
+    rw [tensor_product.smul_tmul'], }
+end.
+
+lemma smul_by.pure_tensor (s s' : S) (m : M) :
+  (smul_by f M s (m ⊗ₜ[R, f] s')) =
+  m ⊗ₜ[R, f] (s * s') :=
+begin
+  simp only [smul_by, tensor_product.lift.tmul, linear_map.coe_mk],
+end
+
+lemma smul_by.one : smul_by f M 1 = 𝟙 _ :=
+begin
+  ext,
+  induction x using tensor_product.induction_on with _ _ _ _ ih1 ih2,
+  { simpa only [smul_by, map_zero], },
+  { simpa only [smul_by.pure_tensor, one_mul], },
+  { simp only [category_theory.types_id_apply] at ih1 ih2 ⊢,
+    conv_rhs { rw [← ih1, ← ih2] },
+    convert map_add _ _ _, },
+end.
+
+lemma smul_by.mul (s s' : S) : smul_by f M (s * s') = smul_by f M s' ≫ smul_by f M s :=
+begin
+  ext,
+  induction x using tensor_product.induction_on with _ _ x y ih1 ih2,
+  { simp only [smul_by, map_zero, types_comp_apply], },
+  { simp [smul_by, mul_assoc], },
+  { convert congr_arg2 (+) ih1 ih2 using 1,
+    { convert map_add _ _ _ },
+    { simp only [types_comp_apply],
+      calc  smul_by f M s (smul_by f M s' (x + y))
+          = smul_by f M s (smul_by f M s' x + smul_by f M s' y)
+          : by { congr' 1, convert map_add _ _ _}
+      ... = smul_by f M s (smul_by f M s' x) + smul_by f M s (smul_by f M s' y)
+          : by convert map_add _ _ _, }, }
+end.
+
+lemma smul_by.apply_zero (s : S) : smul_by f M s 0 = 0 :=
+by simp only [smul_by, map_zero]
+
+lemma smul_by.apply_add (s : S) (a b) : smul_by f M s (a + b) = smul_by f M s a + smul_by f M s b :=
+by simp [smul_by, map_add]
+
+
+lemma smul_by.add (s s') : smul_by f M (s + s') = smul_by f M s + smul_by f M s' :=
+begin
+  ext x,
+  induction x using tensor_product.induction_on with _ _ x y ih1 ih2,
+  { simp [smul_by], },
+  { simp [smul_by, add_mul, tmul_add], },
+  { simp only [pi.add_apply, smul_by.apply_add, ih1, ih2],
+    rw show ∀ (a b c d : M ⊗[R, f] S), a + b + (c + d) = a + c + (b + d), from _,
+    intros,
+    -- `ring` doesn't work here for some reason
+    rw calc a + b + (c + d) = a + (b + (c + d)) : by rw add_assoc
+      ... = a + (b + c + d) : by rw add_assoc
+      ... = a + (c + b + d) : by rw add_comm b c
+      ... = a + (c + (b + d)) : by rw add_assoc
+      ... = a + c + (b + d) : by rw add_assoc, }
+end.
+
+lemma smul_by.zero : smul_by f M 0 = 0 :=
+begin
+  ext,
+  induction x using tensor_product.induction_on with _ _ x y ih1 ih2,
+  { simp [smul_by], },
+  { simp [smul_by], },
+  { simp [smul_by.apply_add, ih1, ih2], }
+end.
 
 /--
 Since `S` has an `R`-module structure, `M ⊗[R] S` can be given an `S`-module structure.
 The scalar multiplication is defined by `s • (m ⊗ s') := m ⊗ (s * s')`
 -/
 @[reducible] def has_scalar_S_M_tensor_S : _root_.has_scalar S (M ⊗[R, f] S) :=
-{ smul := λ s', @tensor_product.lift R _ M S (M ⊗[R, f] S) _ _ _ _ (is_R_mod_S f) _
-  { to_fun := λ m,
-    { to_fun := λ s, @tensor_product.tmul R _ M S _ _ _ (is_R_mod_S f) m (s * s'),
-      map_add' := λ x y, by rw [add_mul, tensor_product.tmul_add],
-      map_smul' := λ x y, begin
-        rw [ring_hom.id_apply],
-        rw [smul_def f x, mul_assoc, ←smul_def],
-        erw tensor_product.tmul_smul,
-      end },
-    map_add' := λ _ _, begin
-      ext s, simp only [linear_map.coe_mk, linear_map.add_apply],
-      rw tensor_product.add_tmul
-    end,
-    map_smul' := λ _ _, begin
-      ext s, simp only [linear_map.smul_apply, ring_hom.id_apply, linear_map.coe_mk],
-      rw @tensor_product.smul_tmul R _ R _ M S _ _ _ (is_R_mod_S f) _ begin
-        haveI := is_R_mod_S f,
-        resetI,
-        apply_instance,
-      end _,
-      rw tensor_product.tmul_smul
-    end } }
+{ smul := λ s', smul_by f M s' }
 
 local attribute [instance] has_scalar_S_M_tensor_S
 
-lemma has_scalar_S_M_tensor_S.smul_pure_tensor (s s' : S) (m : M) :
-  s • (@tensor_product.tmul R _ M S _ _ _ (is_R_mod_S f) m s') =
-  @tensor_product.tmul R _ M S _ _ _ (is_R_mod_S f) m (s * s') :=
-begin
-  unfold has_scalar.smul, simp only [tensor_product.lift.tmul, linear_map.coe_mk],
-  rw mul_comm,
-end
+lemma smul_pure_tensor (s s' : S) (m : M) :
+  (s • (m ⊗ₜ[R, f] s')) =
+  m ⊗ₜ[R, f] (s * s') :=
+by simp only [smul_by, tensor_product.lift.tmul, linear_map.coe_mk]
+
+@[simp] lemma smul_zero (s : S) : s • (0 : M ⊗[R, f] S) = 0 :=
+by simp [smul_by]
 
 /--
 See above
 -/
 def mul_action_S_M_tensor_S : _root_.mul_action S (M ⊗[R, f] S) :=
 { one_smul := λ x, begin
-    apply @tensor_product.induction_on R _ M S _ _ _ (is_R_mod_S f) _ x;
-    unfold has_scalar.smul,
-    { simp only [map_zero] },
-    { intros m s, simp only [tensor_product.lift.tmul, linear_map.coe_mk, mul_one], },
-    { intros x y ihx ihy, simp only [map_add, ihx, ihy] },
+    change smul_by _ _ _ _ = _,
+    rw smul_by.one f M,
+    refl,
   end,
   mul_smul := λ s s' x, begin
-    apply @tensor_product.induction_on R _ M S _ _ _ (is_R_mod_S f) _ x;
-    unfold has_scalar.smul,
-    { simp only [map_zero] },
-    { intros m s'', simp only [tensor_product.lift.tmul, linear_map.coe_mk],
-      rw [mul_comm s s', mul_assoc], },
-    { intros x y ihx ihy,
-      conv_lhs { rw [map_add] },
-      conv_rhs { rw [map_add, map_add, ←ihx, ←ihy], } }
+    change smul_by _ _ _ _ = smul_by _ _ _ (smul_by _ _ _ _),
+    rw smul_by.mul f M,
+    refl,
   end,
-  ..(has_scalar_S_M_tensor_S f M) }
+  ..(has_scalar_S_M_tensor_S f M) }.
 
-local attribute [instance] mul_action_S_M_tensor_S
-
-@[simp] lemma distrib_mul_action_S_M_tensor_S.smul_zero (s : S) : s • (0 : M ⊗[R, f] S) = 0 :=
-begin
-  unfold has_scalar.smul,
-  simp only [map_zero],
-end
+localized "attribute [instance] extension_of_scalars.mul_action_S_M_tensor_S" in change_of_rings
 
 def distrib_mul_action_S_M_tensor_S : _root_.distrib_mul_action S (M ⊗[R, f] S) :=
-{ smul_zero := by simp,
-  smul_add := λ r x y, begin
-    apply @tensor_product.induction_on R _ M S _ _ _ (is_R_mod_S f) _ x,
-    { simp, },
-    { intros m s, unfold has_scalar.smul, simp only [map_add], },
-    { intros z z' ihz ihz',
-      unfold has_scalar.smul, simp only [map_add], }
+{ smul_zero := λ s, by { change smul_by f M s 0 = 0, apply smul_by.apply_zero, },
+  smul_add := λ s x y, begin
+    change smul_by f M s (x + y) = smul_by f M s x + smul_by f M s y,
+    apply smul_by.apply_add,
   end }
 
+def is_module : module S (M ⊗[R, f] S) :=
+{ add_smul := λ s s' x, begin
+    change smul_by _ _ _ _ = smul_by _ _ _ _ + smul_by _ _ _ _,
+    rw smul_by.add,
+    refl,
+  end,
+  zero_smul := λ x, begin
+    change smul_by _ _ _ _ = _,
+    rw smul_by.zero,
+    refl,
+  end,
+  ..(distrib_mul_action_S_M_tensor_S f M) }.
+
+def is_module' : module R (M ⊗[R, f] S) :=
+infer_instance
+
+-- def compatible_smul (M1 M2 : Module R) :
+--   linear_map.compatible_smul (M1 ⊗[R, f] S) (M2 ⊗[R, f] S) S R :=
+-- let im1 : module R S := restriction_of_scalars.is_module f ⟨S⟩,
+--     im2 : module S (M1 ⊗[R, f] S) := is_module f M1,
+--     im3 : module S (M2 ⊗[R, f] S) := is_module f M2 in
+-- ⟨λ g s x, begin
+--   resetI,
+--   induction x using tensor_product.induction_on with m1 s' z1 z2 ih1 ih2,
+--   { simp [smul_by.apply_zero], },
+--   { simp only [smul_by.pure_tensor],
+--     revert s,
+--     induction g (m1 ⊗ₜ[R, f] s') using tensor_product.induction_on,
+--     rw ← lift.equiv_symm_apply R M1 S (M2 ⊗[R, f] S) g m1 (s * s'),
+--     rw ← lift.equiv_symm_apply R M1 S (M2 ⊗[R, f] S) g m1 s',
+--     -- dsimp only,
+--     -- squeeze_dsimp,
+--     -- type_check (tensor_product.lift.equiv R M1 S (M2 ⊗[R, f] S)).symm g m1 s,
+--     sorry },
+--   { erw [map_add, smul_add s z1 z2, map_add, ih1, ih2, smul_add s (g z1) (g z2)],
+--     refl, },
+-- end⟩
+
+localized "attribute [instance] extension_of_scalars.is_module extension_of_scalars.is_module'"
+  in change_of_rings
 /--
 See above
 -/
-@[reducible] def module : Module S :=
+def module : Module S :=
 { carrier := M ⊗[R, f] S,
-  is_module :=
-    { add_smul := λ s s' x, begin
-        apply @tensor_product.induction_on R _ M S _ _ _ (is_R_mod_S f) _ x,
-        { rw [distrib_mul_action_S_M_tensor_S.smul_zero,
-              distrib_mul_action_S_M_tensor_S.smul_zero,
-              distrib_mul_action_S_M_tensor_S.smul_zero, zero_add] },
-        { rintros m s'',
-          rw [has_scalar_S_M_tensor_S.smul_pure_tensor,
-              has_scalar_S_M_tensor_S.smul_pure_tensor,
-              has_scalar_S_M_tensor_S.smul_pure_tensor, add_mul,
-              tensor_product.tmul_add] },
-        { rintros x y ihx ihy,
-          conv_lhs { rw [smul_add, ihx, ihy] },
-          have : s • x + s' • x + (s • y + s' • y) = s • x + s • y + (s' • x + s' • y),
-          { rw [add_assoc, add_assoc],
-            apply congr_arg2 (+), refl,
-            rw [←add_assoc, ←add_assoc],
-            apply congr_arg2 (+), rw add_comm, refl, },
-          erw this,
-          conv_rhs { rw [smul_add, smul_add] },
-          refl }
-      end,
-      zero_smul := λ x, begin
-        apply @tensor_product.induction_on R _ M S _ _ _ (is_R_mod_S f) _ x,
-        { rw smul_zero },
-        { rintros m s,
-          rw [has_scalar_S_M_tensor_S.smul_pure_tensor, zero_mul, tensor_product.tmul_zero], },
-        { rintros x y ihx ihy, rw [smul_add, ihx, ihy, zero_add] }
-      end,
-      ..(distrib_mul_action_S_M_tensor_S f M) } }
+  is_module := is_module f M }
 
 localized "notation f `_*` M := extension_of_scalars.module f M" in change_of_rings
 
@@ -219,40 +299,40 @@ omit M
 Extension of scalars is a functor where an `R`-module `M` is sent to `M ⊗ S` and
 `l : M1 ⟶ M2` is sent to `m ⊗ s ↦ l m ⊗ s`
 -/
-def map {M1 M2 : Module R} (l : M1 ⟶ M2) : (module f M1) ⟶ (module f M2) :=
-{ to_fun := @tensor_product.lift R _ M1 S (M2 ⊗[R, f] S) _ _ _ _ (is_R_mod_S f) _
-       {to_fun := λ m : M1,
-        { to_fun := λ (s : ↥S), @tensor_product.tmul R _ M2 S _ _ _ (is_R_mod_S f) (l m) s,
-          map_add' := λ s s', by rw tensor_product.tmul_add,
-          map_smul' := λ r s, by rw [ring_hom.id_apply, tensor_product.tmul_smul] },
-        map_add' := λ m m', begin
-          ext s, simp only [map_add, linear_map.coe_mk, linear_map.add_apply],
-          rw tensor_product.add_tmul
-        end,
-        map_smul' := λ s m, begin
-          ext s,
-          simp only [linear_map.smul_apply, ring_hom.id_apply,
-            linear_map.coe_mk, linear_map.map_smulₛₗ],
-          rw @tensor_product.smul_tmul R _ R _ M2 S _ _ _ (is_R_mod_S f) _
-            begin
-              haveI := is_R_mod_S f,
-              resetI,
-              apply_instance
-            end,
-          rw tensor_product.tmul_smul
-        end},
-  map_add' := λ x y, by rw map_add,
-  map_smul' := λ s x, begin
-    apply @tensor_product.induction_on R _ M1 S _ _ _ (is_R_mod_S f) _ x,
-    { rw [smul_zero, map_zero, smul_zero], },
-    { rintros m s',
-      rw [has_scalar_S_M_tensor_S.smul_pure_tensor, ring_hom.id_apply,
-        tensor_product.lift.tmul, tensor_product.lift.tmul, linear_map.coe_mk, linear_map.coe_mk,
-        has_scalar_S_M_tensor_S.smul_pure_tensor], },
-    { rintros x y ihx ihy,
-      rw [ring_hom.id_apply] at ihx ihy ⊢,
-      rw [smul_add, linear_map.map_add, ihx, ihy, linear_map.map_add, smul_add], }
-  end }
+def map {M1 M2 : Module R} (l : M1 ⟶ M2) : (f _* M1) ⟶ (f _* M2) :=
+let im1 : _root_.module R S := restriction_of_scalars.is_module f ⟨S⟩,
+    im2 : _root_.module R (f _* M2) := is_module' f M2 in
+begin
+  resetI,
+  refine
+    { to_fun := tensor_product.lift { to_fun := λ m1, _, map_add' := _, map_smul' := _ },
+      map_add' := _,
+      map_smul' := _ },
+  { -- `S ⟶ f _* M2` given by `s ↦ l m ⊗ s`
+    refine { to_fun := λ s, (l m1) ⊗ₜ[R, f] s, map_add' := _, map_smul' := _ },
+    { -- map_add
+      intros,
+      rw [tmul_add], },
+    { -- map_smul
+      intros,
+      rw [ring_hom.id_apply, restriction_of_scalars.smul_def f ⟨S⟩ r x, smul_tmul',
+        smul_tmul],
+      refl, } },
+  { intros m m',
+    ext s,
+    simp [add_tmul], },
+  { intros r m,
+    ext s,
+    simp [smul_tmul], },
+  { intros z1 z2,
+    simp, },
+  { intros s z,
+    induction z using tensor_product.induction_on with _ _ z1 z2 ih1 ih2,
+    { simp [smul_zero], },
+    { simp [smul_pure_tensor], },
+    { rw [smul_add, map_add, ring_hom.id_apply, ih1, ih2, map_add, smul_add,
+        ring_hom.id_apply], } }
+end.
 
 /--
 The functor extension of scalars
@@ -261,23 +341,25 @@ def functor : Module.{u} R ⥤ Module.{u} S :=
 { obj := λ M, f _* M,
   map := λ M1 M2 l, map f l,
   map_id' := λ M, begin
-    ext x, rw [map, Module.id_apply],
-    apply @tensor_product.induction_on R _ M S _ _ _ (is_R_mod_S f) _ x,
+    ext x,
+    rw [map, Module.id_apply],
+    induction x using tensor_product.induction_on with _ _ m s ihx ihy,
     { rw map_zero },
-    { intros m s, rw [linear_map.coe_mk, tensor_product.lift.tmul], refl, },
-    { intros x y ihx ihy, rw [linear_map.coe_mk] at ihx ihy ⊢,
+    { rw [linear_map.coe_mk, tensor_product.lift.tmul], refl, },
+    { rw [linear_map.coe_mk] at ihx ihy ⊢,
       rw [map_add, ihx, ihy], }
   end,
   map_comp' := λ M1 M2 M3 g h, begin
     ext x,
     rw [map, map, map, linear_map.coe_mk, category_theory.comp_apply,
       linear_map.coe_mk, linear_map.coe_mk],
-    apply @tensor_product.induction_on R _ _ S _ _ _ (is_R_mod_S f) _ x,
+    induction x using tensor_product.induction_on with _ _ m s ihx ihy,
     { rw [map_zero, map_zero, map_zero], },
-    { rintros m s, rw [tensor_product.lift.tmul, tensor_product.lift.tmul], refl, },
-    { rintros x y ihx ihy,
-      rw [map_add, ihx, ihy, map_add, map_add], }
+    { rw [tensor_product.lift.tmul, tensor_product.lift.tmul], refl, },
+    { rw [map_add, ihx, ihy, map_add, map_add], }
   end }.
+
+localized "notation f `⥤_*` M := (extension_of_scalars.functor f).obj M" in change_of_rings
 
 end extension_of_scalars
 
@@ -285,16 +367,17 @@ section adjunction
 
 universe u
 
-open category_theory
+open category_theory tensor_product
 open_locale change_of_rings
 
 variables {R S : CommRing.{u}} (f : R ⟶ S) (X : Module.{u} R) (Y : Module.{u} S)
 
-def backward (g : X ⟶ (restriction_of_scalars.functor f).obj Y) :
-  (extension_of_scalars.functor f).obj X ⟶ Y :=
+def backward (g : X ⟶ (f ⥤^* Y)) :
+  (f ⥤_* X) ⟶ Y :=
 { to_fun := λ z,
-  let m1 := extension_of_scalars.is_R_mod_S f,
-    m2 : module R Y := restriction_of_scalars.is_module _ f in
+  let m1 := restriction_of_scalars.is_module f ⟨S⟩,
+      m2 : module R Y := restriction_of_scalars.is_module f Y,
+      m3 : module S (f ⥤^* Y) := Y.is_module in
   begin
     resetI,
     refine tensor_product.lift
@@ -307,10 +390,11 @@ def backward (g : X ⟶ (restriction_of_scalars.functor f).obj Y) :
     { -- `x ⊗ s ↦ s • g x` in Y
       exact s • (g x : Y) },
     { intros, rw add_smul, },
-    { intros,
-      simp only [extension_of_scalars.smul_def, ring_hom.id_apply,
-        restriction_of_scalars.smul_def', mul_smul],
-      refl, },
+    { intros r s,
+      rw [ring_hom.id_apply],
+      calc  (r • s) • g x
+          = (f r * s) • g x : rfl
+      ... = f r • s • g x : by rw [mul_smul], },
     { intros x y,
       ext s,
       simp only [linear_map.coe_mk, smul_add, linear_map.add_apply, map_add], },
@@ -326,39 +410,29 @@ def backward (g : X ⟶ (restriction_of_scalars.functor f).obj Y) :
     rw [ring_hom.id_apply],
     induction z using tensor_product.induction_on with x y x y ih1 ih2,
     { simp only [smul_zero, map_zero], },
-    { rw extension_of_scalars.has_scalar_S_M_tensor_S.smul_pure_tensor,
-      simp [tensor_product.lift.tmul],
-      rw [mul_smul], },
+    { erw [extension_of_scalars.smul_pure_tensor],
+      simp [tensor_product.lift.tmul, mul_smul], },
     { simp only [smul_add, map_add],
       dsimp only at ih1 ih2,
       rw [ih1, ih2], },
   end }.
 
-def forward (g : (extension_of_scalars.functor f).obj X ⟶ Y) :
-  X ⟶ (restriction_of_scalars.functor f).obj Y :=
-{ to_fun := λ x, g begin
-    refine @tensor_product.tmul R _ X S _ _ _ (restriction_of_scalars.is_module ⟨S⟩ f) x 1,
-  end,
+def forward (g : (f ⥤_* X) ⟶ Y) :
+  X ⟶ (f ⥤^* Y) :=
+let m1 : module R S := restriction_of_scalars.is_module f ⟨S⟩,
+    m2 : module R Y := restriction_of_scalars.is_module f Y in
+{ to_fun := λ x, g (x ⊗ₜ[R, f] 1),
   map_add' := λ x x', by rw [tensor_product.add_tmul, map_add],
   map_smul' := λ r x, begin
+    resetI,
     rw [ring_hom.id_apply],
-    have eq0 :
-      -- (r • x) ⊗ₜ[R] 1 = x ⊗ₜ[R] (r • 1)
-      (@tensor_product.tmul R _ X S _ _ _ (restriction_of_scalars.is_module ⟨S⟩ f) (r • x) 1) =
-      @tensor_product.tmul R _ X S _ _ _ (restriction_of_scalars.is_module ⟨S⟩ f) x (f r • 1),
-    { erw @tensor_product.smul_tmul R _ R _ X S _ _ _
-        (restriction_of_scalars.is_module ⟨S⟩ f) _ begin
-          haveI := (restriction_of_scalars.is_module ⟨S⟩ f),
-          apply_instance
-        end _ r x 1,
-      congr', },
-    have eq1 := congr_arg g eq0,
-    erw ← linear_map.map_smul,
-    erw eq1,
-    congr' 1,
-    rw extension_of_scalars.has_scalar_S_M_tensor_S.smul_pure_tensor,
-    refl,
-  end }
+    calc  g ((r • x) ⊗ₜ[R, f] (1 : S))
+        = g (x ⊗ₜ[R, f] (r • 1)) : by rw smul_tmul
+    ... = g (x ⊗ₜ[R, f] (f r • 1)) : by rw restriction_of_scalars.smul_def f ⟨S⟩
+    ... = g (f r • (x ⊗ₜ[R, f] 1)) : by congr' 1
+    ... = f r • g (x ⊗ₜ[R, f] 1) : by rw linear_map.map_smul
+    ... = r • g (x ⊗ₜ[R, f] 1) : rfl,
+  end }.
 
 def equiv :
   ((extension_of_scalars.functor f).obj X ⟶ Y) ≃ (X ⟶ (restriction_of_scalars.functor f).obj Y) :=
@@ -371,26 +445,22 @@ def equiv :
     { erw tensor_product.lift.tmul,
       simp only [linear_map.coe_mk],
       change s • g _ = _,
-      rw [← linear_map.map_smul, extension_of_scalars.has_scalar_S_M_tensor_S.smul_pure_tensor,
-        mul_one], },
+      rw [← linear_map.map_smul, extension_of_scalars.smul_pure_tensor, mul_one], },
     { rw [map_add, map_add, ih1, ih2], }
   end,
   right_inv := λ g, begin
     ext,
     unfold forward backward,
     simp only [linear_map.coe_mk, tensor_product.lift.tmul, one_smul],
-  end }
+  end }.
 
 def unit.map : X ⟶ ((extension_of_scalars.functor f ⋙ restriction_of_scalars.functor f).obj X) :=
-{ to_fun := λ x, @tensor_product.tmul R _ X S _ _ _ (restriction_of_scalars.is_module ⟨S⟩ f) x 1,
+let m1 : module R S := restriction_of_scalars.is_module f ⟨S⟩ in
+{ to_fun := λ x, x ⊗ₜ[R, f] 1,
   map_add' := λ x x', by { rw tensor_product.add_tmul, },
   map_smul' := λ r x, begin
-    erw [@tensor_product.smul_tmul R _ R _ X S _ _ _
-        (restriction_of_scalars.is_module ⟨S⟩ f) _ begin
-          haveI := (restriction_of_scalars.is_module ⟨S⟩ f),
-          apply_instance
-        end _ r x 1, ring_hom.id_apply,
-        extension_of_scalars.has_scalar_S_M_tensor_S.smul_pure_tensor],
+    resetI,
+    erw [smul_tmul, extension_of_scalars.smul_pure_tensor],
     congr,
   end }.
 
@@ -400,18 +470,17 @@ def unit : 𝟭 (Module ↥R) ⟶ extension_of_scalars.functor f ⋙ restriction
     ext,
     simp only [unit.map, functor.id_map, Module.coe_comp, linear_map.coe_mk,
       function.comp_app, functor.comp_map],
-    have eq1 : (restriction_of_scalars.functor f).map ((extension_of_scalars.functor f).map g) =
-      { to_fun := (extension_of_scalars.functor f).map g, map_add' := _, map_smul' := _ } := rfl,
-    rw eq1,
+    rw show (restriction_of_scalars.functor f).map ((extension_of_scalars.functor f).map g) =
+      { to_fun := (extension_of_scalars.functor f).map g, map_add' := _, map_smul' := _ }, from rfl,
     simp only [linear_map.coe_mk],
     erw tensor_product.lift.tmul,
     simp only [linear_map.coe_mk],
   end }
 
 def counit.map : (restriction_of_scalars.functor f ⋙ extension_of_scalars.functor f).obj Y ⟶ Y :=
+let m1 : module R S := restriction_of_scalars.is_module f ⟨S⟩,
+    m2 : module R Y := restriction_of_scalars.is_module f Y in
 { to_fun :=
-    let m1 : module R S := restriction_of_scalars.is_module ⟨S⟩ f,
-        m2 : module R Y := restriction_of_scalars.is_module Y f in
     begin
       resetI,
       refine tensor_product.lift
@@ -425,7 +494,7 @@ def counit.map : (restriction_of_scalars.functor f ⋙ extension_of_scalars.func
       { intros s s', rw add_smul, },
       { intros r s,
         rw [ring_hom.id_apply, restriction_of_scalars.smul_def,
-          @restriction_of_scalars.smul_def R S ⟨S⟩ f, smul_eq_mul, mul_smul], },
+          restriction_of_scalars.smul_def f ⟨S⟩ r s, smul_eq_mul, mul_smul], },
       { intros y1 y2,
         ext,
         simp only [linear_map.coe_mk, smul_add, linear_map.add_apply], },
@@ -441,7 +510,7 @@ def counit.map : (restriction_of_scalars.functor f ⋙ extension_of_scalars.func
     simp only [ring_hom.id_apply],
     induction z using tensor_product.induction_on with x s' z1 z2 ih1 ih2,
     { simp only [smul_zero, map_zero], },
-    { erw extension_of_scalars.has_scalar_S_M_tensor_S.smul_pure_tensor,
+    { erw extension_of_scalars.smul_pure_tensor,
       simp only [linear_map.coe_mk, tensor_product.lift.tmul],
       rw mul_smul, },
     { rw [smul_add, map_add, map_add, ih1, ih2, smul_add], },
@@ -459,7 +528,7 @@ def counit : (restriction_of_scalars.functor f ⋙ extension_of_scalars.functor 
       simp only [linear_map.coe_mk, linear_map.map_smulₛₗ, ring_hom.id_apply],
       refl, },
     { rw [map_add, map_add, ih1, ih2, map_add, map_add], }
-  end }
+  end }.
 
 def adjunction : adjunction (extension_of_scalars.functor f) (restriction_of_scalars.functor f) :=
 { hom_equiv := equiv f,

--- a/src/algebra/module/restriction_of_scalars.lean
+++ b/src/algebra/module/restriction_of_scalars.lean
@@ -1,0 +1,310 @@
+/-
+Copyright (c) 2021 Jujian Zhang. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Jujian Zhang
+-/
+import algebra.category.CommRing
+import algebra.category.Module.basic
+import linear_algebra.tensor_product
+
+open_locale tensor_product
+
+namespace restriction_of_scalars
+
+universe u
+
+variables {R S : CommRing.{u}} -- [ring R] [ring S] -- (f : R →+* S)
+variables (N : Module S) -- [add_comm_monoid N] [module S N]
+variable (f : R ⟶ S)
+include f
+
+/--Definition of scalar multiplication in restriction of scalars-/
+def has_scalar : has_scalar R N :=
+{ smul := λ r n,  f r • n}
+
+-- #check (restriction_of_scalars.has_scalar N f).smul
+localized "attribute [instance] restriction_of_scalars.has_scalar" in change_of_rings
+localized "notation r `•[` N `,` f `]` m := (restriction_of_scalars.has_scalar N f).smul" in change_of_rings
+
+@[simp] lemma smul_def (r : R) (n : N) :
+  @has_scalar.smul R N (restriction_of_scalars.has_scalar N f) r n = f r • n := rfl
+
+def is_module : module R N :=
+{ one_smul := by simp,
+  mul_smul := by simp [mul_smul],
+  smul_add := by simp [smul_add],
+  smul_zero := by simp,
+  add_smul := by simp [add_smul],
+  zero_smul := by simp,
+  ..(restriction_of_scalars.has_scalar N f) }.
+
+localized "attribute [instance] restriction_of_scalars.is_module" in change_of_rings
+
+/--
+Given a ring homomorphism `f : R ⟶ S`, and an `S`-module `N`, we can turn `N` into an `R`-module.
+This is called restriction_of_scalar
+-/
+def module :
+  Module R :=
+{ carrier := N,
+  is_add_comm_group := infer_instance,
+  is_module := is_module N f }.
+
+localized "notation f `^*` N := restriction_of_scalars.module N f" in change_of_rings
+
+instance has_scalar' : _root_.has_scalar S (f ^* N) :=
+{ smul := λ s n, @has_scalar.smul S N _ s n }.
+
+@[simp] lemma smul_def' (r : R) (n : f ^* N) : r • n = f r • n := rfl
+
+/--restrictino of scalar is a functor from `S`-modules to `R`-modules.-/
+def restriction_of_scalar.functor : Module S ⥤ Module R :=
+{ obj := λ N, f ^* N,
+  map := λ N₁ N₂ l,
+    { to_fun := l,
+      map_add' := λ x y, by rw [linear_map.map_add],
+      map_smul' := λ r y, begin
+        simp only [smul_def', ring_hom.id_apply],
+        convert linear_map.map_smul l (f r) y,
+      end } }
+
+end restriction_of_scalars
+
+namespace extension_of_scalars
+
+universe u
+
+variables {R S : CommRing.{u}} (f : R ⟶ S) (M : Module R)
+include f
+
+-- /--
+-- `R` can act on `S` via `f : R ⟶ S` by `r • s := f r * s`
+-- -/
+-- def has_scalar : has_scalar R S := restriction_of_scalars.has_scalar ⟨S⟩ f
+-- local attribute [instance] has_scalar
+
+-- @[simp] lemma smul_def (r : R) (s : S) :
+--   @has_scalar.smul _ _ (has_scalar f) r s = f r * s := rfl
+
+-- /--
+-- See above
+-- -/
+-- def mul_action : mul_action R S :=
+-- { one_smul := λ s, by simp,
+--   mul_smul := λ r r' s, by simp [ring_hom.map_mul, mul_assoc],
+--   ..(has_scalar f)}.
+
+-- local attribute [instance] mul_action
+
+-- /--
+-- This action is distributive
+-- -/
+-- def distrib_mul_action : distrib_mul_action R S :=
+-- { smul_add := λ r s s', by simp [mul_add],
+--   smul_zero := λ r, by simp [mul_zero],
+--   ..(mul_action f)}.
+
+-- local attribute [instance] distrib_mul_action
+
+/--
+This action gives `S` an `R`-module strucutre
+-/
+def is_R_mod_S : module R S := restriction_of_scalars.is_module ⟨S⟩ f
+
+localized "attribute [instance] extension_of_scalars.is_R_mod_S" in change_of_rings
+
+@[simp] lemma smul_def (r : R) (s : S) :
+  @has_scalar.smul _ _ begin
+    haveI := is_R_mod_S f,
+    resetI,
+    apply_instance
+  end r s = f r * s := rfl
+
+
+include M
+localized "notation M `⊗[` R `,` f `]` S := @tensor_product R _ M S _ _ _
+  (extension_of_scalars.is_R_mod_S f)" in change_of_rings
+
+/--
+Since `S` has an `R`-module structure, `M ⊗[R] S` can be given an `S`-module structure.
+The scalar multiplication is defined by `s • (m ⊗ s') := m ⊗ (s * s')`
+-/
+@[reducible] def has_scalar_S_M_tensor_S : _root_.has_scalar S (M ⊗[R, f] S) :=
+{ smul := λ s', @tensor_product.lift R _ M S (M ⊗[R, f] S) _ _ _ _ (is_R_mod_S f) _
+  { to_fun := λ m,
+    { to_fun := λ s, @tensor_product.tmul R _ M S _ _ _ (is_R_mod_S f) m (s * s'),
+      map_add' := λ x y, by rw [add_mul, tensor_product.tmul_add],
+      map_smul' := λ x y, begin
+        rw [ring_hom.id_apply],
+        rw [smul_def f x, mul_assoc, ←smul_def],
+        erw tensor_product.tmul_smul,
+      end },
+    map_add' := λ _ _, begin
+      ext s, simp only [linear_map.coe_mk, linear_map.add_apply],
+      rw tensor_product.add_tmul
+    end,
+    map_smul' := λ _ _, begin
+      ext s, simp only [linear_map.smul_apply, ring_hom.id_apply, linear_map.coe_mk],
+      rw @tensor_product.smul_tmul R _ R _ M S _ _ _ (is_R_mod_S f) _ begin
+        haveI := is_R_mod_S f,
+        resetI,
+        apply_instance,
+      end _,
+      rw tensor_product.tmul_smul
+    end } }
+
+local attribute [instance] has_scalar_S_M_tensor_S
+
+lemma has_scalar_S_M_tensor_S.smul_pure_tensor (s s' : S) (m : M) :
+  s • (@tensor_product.tmul R _ M S _ _ _ (is_R_mod_S f) m s') =
+  @tensor_product.tmul R _ M S _ _ _ (is_R_mod_S f) m (s * s') :=
+begin
+  unfold has_scalar.smul, simp only [tensor_product.lift.tmul, linear_map.coe_mk],
+  rw mul_comm,
+end
+
+/--
+See above
+-/
+def mul_action_S_M_tensor_S : _root_.mul_action S (M ⊗[R, f] S) :=
+{ one_smul := λ x, begin
+    apply @tensor_product.induction_on R _ M S _ _ _ (is_R_mod_S f) _ x;
+    unfold has_scalar.smul,
+    { simp only [map_zero] },
+    { intros m s, simp only [tensor_product.lift.tmul, linear_map.coe_mk, mul_one], },
+    { intros x y ihx ihy, simp only [map_add, ihx, ihy] },
+  end,
+  mul_smul := λ s s' x, begin
+    apply @tensor_product.induction_on R _ M S _ _ _ (is_R_mod_S f) _ x;
+    unfold has_scalar.smul,
+    { simp only [map_zero] },
+    { intros m s'', simp only [tensor_product.lift.tmul, linear_map.coe_mk],
+      rw [mul_comm s s', mul_assoc], },
+    { intros x y ihx ihy,
+      conv_lhs { rw [map_add] },
+      conv_rhs { rw [map_add, map_add, ←ihx, ←ihy], } }
+  end,
+  ..(has_scalar_S_M_tensor_S f M) }
+
+local attribute [instance] mul_action_S_M_tensor_S
+
+@[simp] lemma distrib_mul_action_S_M_tensor_S.smul_zero (s : S) : s • (0 : M ⊗[R, f] S) = 0 :=
+begin
+  unfold has_scalar.smul,
+  simp only [map_zero],
+end
+
+def distrib_mul_action_S_M_tensor_S : _root_.distrib_mul_action S (M ⊗[R, f] S) :=
+{ smul_zero := by simp,
+  smul_add := λ r x y, begin
+    apply @tensor_product.induction_on R _ M S _ _ _ (is_R_mod_S f) _ x,
+    { simp, },
+    { intros m s, unfold has_scalar.smul, simp only [map_add], },
+    { intros z z' ihz ihz',
+      unfold has_scalar.smul, simp only [map_add], }
+  end }
+
+/--
+See above
+-/
+@[reducible] def module : Module S :=
+{ carrier := M ⊗[R, f] S,
+  is_module :=
+    { add_smul := λ s s' x, begin
+        apply @tensor_product.induction_on R _ M S _ _ _ (is_R_mod_S f) _ x,
+        { rw [distrib_mul_action_S_M_tensor_S.smul_zero,
+              distrib_mul_action_S_M_tensor_S.smul_zero,
+              distrib_mul_action_S_M_tensor_S.smul_zero, zero_add] },
+        { rintros m s'',
+          rw [has_scalar_S_M_tensor_S.smul_pure_tensor,
+              has_scalar_S_M_tensor_S.smul_pure_tensor,
+              has_scalar_S_M_tensor_S.smul_pure_tensor, add_mul,
+              tensor_product.tmul_add] },
+        { rintros x y ihx ihy,
+          conv_lhs { rw [smul_add, ihx, ihy] },
+          have : s • x + s' • x + (s • y + s' • y) = s • x + s • y + (s' • x + s' • y),
+          { rw [add_assoc, add_assoc],
+            apply congr_arg2 (+), refl,
+            rw [←add_assoc, ←add_assoc],
+            apply congr_arg2 (+), rw add_comm, refl, },
+          erw this,
+          conv_rhs { rw [smul_add, smul_add] },
+          refl }
+      end,
+      zero_smul := λ x, begin
+        apply @tensor_product.induction_on R _ M S _ _ _ (is_R_mod_S f) _ x,
+        { rw smul_zero },
+        { rintros m s,
+          rw [has_scalar_S_M_tensor_S.smul_pure_tensor, zero_mul, tensor_product.tmul_zero], },
+        { rintros x y ihx ihy, rw [smul_add, ihx, ihy, zero_add] }
+      end,
+      ..(distrib_mul_action_S_M_tensor_S f M) } }
+
+localized "notation f `_*` M := extension_of_scalars.module f M" in change_of_rings
+
+omit M
+/--
+Extension of scalars is a functor where an `R`-module `M` is sent to `M ⊗ S` and
+`l : M1 ⟶ M2` is sent to `m ⊗ s ↦ l m ⊗ s`
+-/
+def map {M1 M2 : Module R} (l : M1 ⟶ M2) : (module f M1) ⟶ (module f M2) :=
+{ to_fun := @tensor_product.lift R _ M1 S (M2 ⊗[R, f] S) _ _ _ _ (is_R_mod_S f) _
+       {to_fun := λ m : M1,
+        { to_fun := λ (s : ↥S), @tensor_product.tmul R _ M2 S _ _ _ (is_R_mod_S f) (l m) s,
+          map_add' := λ s s', by rw tensor_product.tmul_add,
+          map_smul' := λ r s, by rw [ring_hom.id_apply, tensor_product.tmul_smul] },
+        map_add' := λ m m', begin
+          ext s, simp only [map_add, linear_map.coe_mk, linear_map.add_apply],
+          rw tensor_product.add_tmul
+        end,
+        map_smul' := λ s m, begin
+          ext s,
+          simp only [linear_map.smul_apply, ring_hom.id_apply,
+            linear_map.coe_mk, linear_map.map_smulₛₗ],
+          rw @tensor_product.smul_tmul R _ R _ M2 S _ _ _ (is_R_mod_S f) _
+            begin
+              haveI := is_R_mod_S f,
+              resetI,
+              apply_instance
+            end,
+          rw tensor_product.tmul_smul
+        end},
+  map_add' := λ x y, by rw map_add,
+  map_smul' := λ s x, begin
+    apply @tensor_product.induction_on R _ M1 S _ _ _ (is_R_mod_S f) _ x,
+    { rw [smul_zero, map_zero, smul_zero], },
+    { rintros m s',
+      rw [has_scalar_S_M_tensor_S.smul_pure_tensor, ring_hom.id_apply,
+        tensor_product.lift.tmul, tensor_product.lift.tmul, linear_map.coe_mk, linear_map.coe_mk,
+        has_scalar_S_M_tensor_S.smul_pure_tensor], },
+    { rintros x y ihx ihy,
+      rw [ring_hom.id_apply] at ihx ihy ⊢,
+      rw [smul_add, linear_map.map_add, ihx, ihy, linear_map.map_add, smul_add], }
+  end }
+
+/--
+The functor extension of scalars
+-/
+def _root_.extension_of_scalars : Module.{u} R ⥤ Module.{u} S :=
+{ obj := λ M, f _* M,
+  map := λ M1 M2 l, map f l,
+  map_id' := λ M, begin
+    ext x, rw [map, Module.id_apply],
+    apply @tensor_product.induction_on R _ M S _ _ _ (is_R_mod_S f) _ x,
+    { rw map_zero },
+    { intros m s, rw [linear_map.coe_mk, tensor_product.lift.tmul], refl, },
+    { intros x y ihx ihy, rw [linear_map.coe_mk] at ihx ihy ⊢,
+      rw [map_add, ihx, ihy], }
+  end,
+  map_comp' := λ M1 M2 M3 g h, begin
+    ext x,
+    rw [map, map, map, linear_map.coe_mk, category_theory.comp_apply,
+      linear_map.coe_mk, linear_map.coe_mk],
+    apply @tensor_product.induction_on R _ _ S _ _ _ (is_R_mod_S f) _ x,
+    { rw [map_zero, map_zero, map_zero], },
+    { rintros m s, rw [tensor_product.lift.tmul, tensor_product.lift.tmul], refl, },
+    { rintros x y ihx ihy,
+      rw [map_add, ihx, ihy, map_add, map_add], }
+  end }
+
+end extension_of_scalars

--- a/src/algebra/module/restriction_of_scalars.lean
+++ b/src/algebra/module/restriction_of_scalars.lean
@@ -24,7 +24,6 @@ def has_scalar : has_scalar R N :=
 
 -- #check (restriction_of_scalars.has_scalar N f).smul
 localized "attribute [instance] restriction_of_scalars.has_scalar" in change_of_rings
-localized "notation r `•[` N `,` f `]` m := (restriction_of_scalars.has_scalar N f).smul" in change_of_rings
 
 @[simp] lemma smul_def (r : R) (n : N) :
   @has_scalar.smul R N (restriction_of_scalars.has_scalar N f) r n = f r • n := rfl

--- a/src/scratch.lean
+++ b/src/scratch.lean
@@ -176,8 +176,7 @@ as `f ^* 𝓕`.
 -/
 def restriction_by.obj (𝓕 : presheaf_of_module 𝓞2) : presheaf_of_module 𝓞1 :=
 { self := 𝓕.self,
-  is_module := λ U, @restriction_of_scalars.is_module (𝓞1.obj (op U)) (𝓞2.obj (op U))
-      ⟨𝓕.self.obj (op U)⟩ (f.app (op U)),
+  is_module := λ U, restriction_of_scalars.is_module (f.app (op U)) ⟨𝓕.self.obj (op U)⟩,
   compatible := λ U V inc r m, begin
     erw [𝓕.compatible inc, (ring_hom.congr_fun (f.naturality inc) r).symm],
     refl,
@@ -222,8 +221,16 @@ private def restrict.to_fun (U V : opens X) (inc : op U ⟶ op V) :
 let im1 : module (𝓞1.obj (op U)) (𝓕.self.obj (op U)) := 𝓕.is_module _,
     im2 : module (𝓞1.obj (op U)) (𝓞2.obj (op U)) := restriction_of_scalars.is_module
       (f.app (op U)) ⟨𝓞2.obj (op U)⟩,
+    im4 : module (𝓞1.obj (op U)) (𝓕.self.obj (op V)) := is_module_UV _ _ inc,
     im3 := restriction_of_scalars.is_module (f.app (op U) ≫ 𝓞2.map inc)
-      (f.app (op V)_* ⟨𝓕.to_core.self.obj (op V)⟩) in
+      (f.app (op V)_* ⟨𝓕.to_core.self.obj (op V)⟩),
+    im4 : module (𝓞1.obj (op V)) (𝓞2.obj (op V)) := restriction_of_scalars.is_module
+      (f.app (op V)) ⟨𝓞2.obj (op V)⟩,
+    im5 : module (𝓞1.obj (op U))
+      ((𝓕.self.obj (op V)) ⊗[𝓞1.obj (op V), f.app (op V)] (𝓞2.obj (op V))) :=
+      restriction_of_scalars.is_module (𝓞1.map inc)
+      { carrier := ((𝓕.self.obj (op V)) ⊗[𝓞1.obj (op V), f.app (op V)] (𝓞2.obj (op V))),
+        is_module := extension_of_scalars.is_module' (f.app (op V)) ⟨(𝓕.self.obj (op V))⟩ } in
 begin
   resetI,
   refine tensor_product.lift _,
@@ -232,53 +239,23 @@ begin
       map_add' := _,
       map_smul' := _ },
     { exact (𝓕.self.map inc m) ⊗ₜ[𝓞1.obj (op V), f.app (op V)] (𝓞2.map inc s), },
-    { fconstructor,
-      { intros m,
-        fconstructor,
-        { intros s,
-          refine @tensor_product.tmul (𝓞1.obj (op V)) _ (𝓕.self.obj (op V)) (𝓞2.obj (op V)) _ _ _
-            (restriction_of_scalars.is_module ⟨_⟩ (f.app (op V)))
-            (𝓕.self.map inc m) (𝓞2.map inc s),
-          },
-        { intros s1 s2,
-          rw [map_add, tensor_product.tmul_add], },
-        { intros r s,
-          rw [restriction_of_scalars.smul_def ⟨𝓞2.obj (op U)⟩ (f.app (op U)) r s, ring_hom.id_apply,
-            smul_eq_mul, ring_hom.map_mul, ←smul_eq_mul],
-          convert extension_of_scalars.has_scalar_S_M_tensor_S.smul_pure_tensor
-            (f.app (op V)) _ _ _ _, }, },
-      { intros m1 m2,
+    { intros s1 s2,
+      rw [map_add, tensor_product.tmul_add], },
+    { intros r s,
+      rw [restriction_of_scalars.smul_def (f.app (op U)) ⟨𝓞2.obj (op U)⟩ r s, ring_hom.id_apply,
+        smul_eq_mul, ring_hom.map_mul, ←smul_eq_mul],
+      convert extension_of_scalars.smul_pure_tensor (f.app (op V)) _ _ _ _, },
+    { intros m1 m2,
         ext z,
         simp only [map_add, tensor_product.add_tmul, linear_map.coe_mk, linear_map.add_apply], },
-      { intros r x,
-        ext z,
-        simp only [𝓕.compatible, ring_hom.id_apply, linear_map.coe_mk, linear_map.smul_apply],
-        rw @tensor_product.smul_tmul (𝓞1.obj (op V)) _ (𝓞1.obj (op V)) _
-          (𝓕.self.obj (op V)) (𝓞2.obj (op V)) _ _ _
-          (restriction_of_scalars.is_module ⟨_⟩ (f.app (op V)))
-          begin
-            haveI := 𝓕.is_module V,
-            apply_instance,
-          end begin
-            haveI := restriction_of_scalars.is_module ⟨𝓞2.obj (op V)⟩ (f.app (op V)),
-            apply_instance,
-          end _ (𝓞1.map inc r) (𝓕.self.map inc x) (𝓞2.map inc z),
-        rw [restriction_of_scalars.smul_def ⟨𝓞2.obj (op V)⟩ (f.app (op V)) (𝓞1.map inc r),
-          smul_eq_mul],
-        erw (extension_of_scalars.has_scalar_S_M_tensor_S.smul_pure_tensor (f.app (op V))
-          ⟨(𝓕.self.obj (op V))⟩ ((f.app (op V)) ((𝓞1.map inc) r)) ((𝓞2.map inc) z)
-          ((𝓕.to_core.self.map inc) x)).symm,
-        unfold has_scalar.smul,
-        rw tensor_product.lift.tmul,
-        dsimp,
-        erw [mul_comm, ← extension_of_scalars.has_scalar_S_M_tensor_S.smul_pure_tensor (f.app (op V))
-          ⟨(𝓕.self.obj (op V))⟩ ((f.app (op V)) ((𝓞1.map inc) r)) ((𝓞2.map inc) z)
-          ((𝓕.to_core.self.map inc) x)],
-        congr' 1,
-        rw ← f.naturality,
-        refl,
-        }, },
-      { exact x },
+    { intros r x,
+      ext z,
+      simp only [𝓕.compatible, ring_hom.id_apply, linear_map.coe_mk, linear_map.smul_apply],
+      rw tensor_product.smul_tmul,
+      erw extension_of_scalars.smul_pure_tensor,
+      congr' 1,
+      rwa ← f.naturality,
+      refl },
 end
 
 
@@ -290,20 +267,15 @@ of `𝓞2`.
 def restrict (U V : opens X) (inc : op U ⟶ op V) :
   linear_map (𝓞2.map inc) (extension_of_scalars.module (f.app (op U)) ⟨(𝓕.self.obj (op U))⟩)
     (extension_of_scalars.module (f.app (op V)) ⟨(𝓕.self.obj (op V))⟩) :=
--- let m1 : module (𝓞1.obj (op U)) (𝓞2.obj (op U)) :=
---   extension_of_scalars.is_R_mod_S (f.app (op U)),
--- m2 : module (𝓞1.obj (op U)) (f.app (op V) _* Module.mk (𝓕.to_core.self.obj (op V))) :=
---   restriction_of_scalars.is_module _ (f.app (op U) ≫ 𝓞2.map inc)
--- in
 { to_fun := restrict.to_fun f 𝓕 U V inc,
   map_add' := by simp [restrict.to_fun],
   map_smul' := λ r m, begin
     induction m using tensor_product.induction_on with m s x y ih1 ih2,
-    { simp only [restrict.to_fun, extension_of_scalars.distrib_mul_action_S_M_tensor_S.smul_zero,
+    { simp only [restrict.to_fun, extension_of_scalars.smul_zero,
         map_zero], },
     { simp only [restrict.to_fun, linear_map.coe_mk, tensor_product.lift.tmul,
-        extension_of_scalars.has_scalar_S_M_tensor_S.smul_pure_tensor, map_mul],
-      convert (extension_of_scalars.has_scalar_S_M_tensor_S.smul_pure_tensor _ _ _ _ _).symm, },
+        extension_of_scalars.smul_pure_tensor, map_mul],
+      convert (extension_of_scalars.smul_pure_tensor _ _ _ _ _).symm, },
     { simp only [restrict.to_fun] at ih1 ih2 ⊢,
       rw [smul_add, map_add, map_add, ih1, ih2],
       simp only [smul_add], }
@@ -361,12 +333,12 @@ def extension_by.obj : presheaf_of_module 𝓞2 :=
   compatible := λ U V inc r m, begin
     induction m using tensor_product.induction_on with x y x y ih1 ih2,
     { simp only [map_zero, smul_zero], },
-    { rw [extension_of_scalars.has_scalar_S_M_tensor_S.smul_pure_tensor],
+    { rw [extension_of_scalars.smul_pure_tensor],
       erw [tensor_product.lift.tmul],
       change tensor_product.tmul _ _ _ = _,
       erw [tensor_product.lift.tmul],
       change _ = _ • tensor_product.tmul _ _ _,
-      erw extension_of_scalars.has_scalar_S_M_tensor_S.smul_pure_tensor,
+      erw extension_of_scalars.smul_pure_tensor,
       rw map_mul,
       refl, },
     { rw [smul_add, map_add, ih1, ih2, map_add, smul_add], }
@@ -387,45 +359,42 @@ private def extension_by.map_app.to_fun {𝓕1 𝓕2 : presheaf_of_module 𝓞1}
 begin
   refine @tensor_product.lift (𝓞1.obj U) _ (𝓕1.self.obj U) (𝓞2.obj U)
     ((f _* 𝓕2).to_core.self.obj U) _ _ _ (𝓕1.is_module (unop U))
-    (restriction_of_scalars.is_module ⟨_⟩ (f.app U))
-    (restriction_of_scalars.is_module _ (f.app U)) _ x,
+    (restriction_of_scalars.is_module (f.app U) ⟨_⟩)
+    (restriction_of_scalars.is_module (f.app U) _) _ x,
   fconstructor,
   { intro m,
     fconstructor,
     { intro s,
       exact @tensor_product.tmul (𝓞1.obj U) _ (𝓕2.self.obj U) (𝓞2.obj U) _ _
         (𝓕2.is_module (unop U))
-        (restriction_of_scalars.is_module ⟨_⟩ (f.app U)) (φ.1.app U m) s },
+        (restriction_of_scalars.is_module (f.app U) ⟨_⟩) (φ.1.app U m) s },
     { intros x y,
       rw tensor_product.tmul_add, },
     { intros r x,
       rw ring_hom.id_apply,
-      rw @restriction_of_scalars.smul_def (𝓞1.obj U) (𝓞2.obj U) ⟨𝓞2.obj U⟩,
-      rw @restriction_of_scalars.smul_def (𝓞1.obj U) (𝓞2.obj U)
-        { carrier := ((f _* 𝓕2).self.obj U), is_module := _ } (f.app U) r,
-      erw extension_of_scalars.has_scalar_S_M_tensor_S.smul_pure_tensor,
+      rw @restriction_of_scalars.smul_def (𝓞1.obj U) (𝓞2.obj U) _ ⟨𝓞2.obj U⟩,
+      rw @restriction_of_scalars.smul_def (𝓞1.obj U) (𝓞2.obj U) (f.app U)
+        { carrier := ((f _* 𝓕2).self.obj U), is_module := _ } r,
+      erw extension_of_scalars.smul_pure_tensor,
       refl, }, },
-  { -- sorry,
-    intros, ext, simp [map_add, tensor_product.add_tmul],
-    },
-  { -- sorry,
-    intros r y,
+  { intros, ext, simp [map_add, tensor_product.add_tmul], },
+  { intros r y,
     ext s,
     simp only [ring_hom.id_apply, linear_map.coe_mk, linear_map.smul_apply],
     have eq1 : (φ.1.app U _) = _ • φ.1.app U _ := @morphism.compatible _ _ _ _ φ (unop U) r y,
     rw eq1,
     rw @restriction_of_scalars.smul_def (𝓞1.obj U) (𝓞2.obj U)
-      { carrier := (f _* 𝓕2).self.obj U, is_module := (f _* 𝓕2).is_module (unop U) }
-      (f.app U),
-    erw extension_of_scalars.has_scalar_S_M_tensor_S.smul_pure_tensor,
+      (f.app U)
+      { carrier := (f _* 𝓕2).self.obj U, is_module := (f _* 𝓕2).is_module (unop U) },
+    erw extension_of_scalars.smul_pure_tensor,
     rw @tensor_product.smul_tmul (𝓞1.obj U) _ (𝓞1.obj U) _ (𝓕2.self.obj U) (𝓞2.obj U)
-      _ _ (𝓕2.is_module (unop U)) (restriction_of_scalars.is_module ⟨_⟩ (f.app U)) begin
+      _ _ (𝓕2.is_module (unop U)) (restriction_of_scalars.is_module (f.app U) ⟨_⟩) begin
         haveI := 𝓕2.is_module (unop U),
         rw op_unop at _inst,
         resetI,
         apply_instance,
       end begin
-        haveI := restriction_of_scalars.is_module ⟨𝓞2.obj U⟩ (f.app U),
+        haveI := restriction_of_scalars.is_module (f.app U) ⟨𝓞2.obj U⟩,
         apply_instance,
       end _ r (φ.1.app U y) s,
     refl,
@@ -476,10 +445,10 @@ def extension_by.map {𝓕1 𝓕2 : presheaf_of_module 𝓞1} (φ : 𝓕1 ⟶ �
     change tensor_product.lift _ _ = r • tensor_product.lift _ _,
     induction m using tensor_product.induction_on with x y x y ih1 ih2,
     { simp only [map_zero, smul_zero], },
-    { rw [extension_of_scalars.has_scalar_S_M_tensor_S.smul_pure_tensor, tensor_product.lift.tmul,
+    { rw [extension_of_scalars.smul_pure_tensor, tensor_product.lift.tmul,
         tensor_product.lift.tmul],
       simp only [linear_map.coe_mk],
-      erw extension_of_scalars.has_scalar_S_M_tensor_S.smul_pure_tensor, },
+      erw extension_of_scalars.smul_pure_tensor, },
     { simp only [smul_add, ih1, ih2, map_add], }
   end }.
 

--- a/src/scratch.lean
+++ b/src/scratch.lean
@@ -355,50 +355,39 @@ lemma extension_by.obj_map' {U V : (opens X)ᵒᵖ} (inc : U ⟶ V) (x : (f _* �
 omit 𝓕
 
 private def extension_by.map_app.to_fun {𝓕1 𝓕2 : presheaf_of_module 𝓞1} (φ : 𝓕1 ⟶ 𝓕2)
-  (U : (opens X)ᵒᵖ) : (f _* 𝓕1).self.obj U → (f _*𝓕2).self.obj U := λ x,
+  (U : (opens X)ᵒᵖ) : (f _* 𝓕1).self.obj U → (f _*𝓕2).self.obj U := -- λ x,
+let im1 : module (𝓞1.obj U) (𝓞2.obj U) := restriction_of_scalars.is_module (f.app U) ⟨_⟩,
+    im2 : module (𝓞1.obj U) ((f _* 𝓕2).to_core.self.obj U) :=
+      restriction_of_scalars.is_module (f.app U) _,
+    im3 : module (𝓞1.obj U) (𝓕2.self.obj U) := 𝓕2.is_module (unop U) in
 begin
-  refine @tensor_product.lift (𝓞1.obj U) _ (𝓕1.self.obj U) (𝓞2.obj U)
-    ((f _* 𝓕2).to_core.self.obj U) _ _ _ (𝓕1.is_module (unop U))
-    (restriction_of_scalars.is_module (f.app U) ⟨_⟩)
-    (restriction_of_scalars.is_module (f.app U) _) _ x,
-  fconstructor,
-  { intro m,
-    fconstructor,
-    { intro s,
-      exact @tensor_product.tmul (𝓞1.obj U) _ (𝓕2.self.obj U) (𝓞2.obj U) _ _
-        (𝓕2.is_module (unop U))
-        (restriction_of_scalars.is_module (f.app U) ⟨_⟩) (φ.1.app U m) s },
-    { intros x y,
-      rw tensor_product.tmul_add, },
-    { intros r x,
-      rw ring_hom.id_apply,
-      rw @restriction_of_scalars.smul_def (𝓞1.obj U) (𝓞2.obj U) _ ⟨𝓞2.obj U⟩,
-      rw @restriction_of_scalars.smul_def (𝓞1.obj U) (𝓞2.obj U) (f.app U)
-        { carrier := ((f _* 𝓕2).self.obj U), is_module := _ } r,
-      erw extension_of_scalars.smul_pure_tensor,
-      refl, }, },
+  resetI,
+  refine tensor_product.lift _,
+  refine
+    { to_fun := λ m, { to_fun := λ s, _, map_add' := _, map_smul' := _ },
+      map_add' := _,
+      map_smul' := _ },
+    { exact (φ.1.app U m) ⊗ₜ[𝓞1.obj U, (f.app U)] s },
+  { intros x y,
+    rw tensor_product.tmul_add, },
+  { intros r x,
+    rw ring_hom.id_apply,
+    rw @restriction_of_scalars.smul_def (𝓞1.obj U) (𝓞2.obj U) _ ⟨𝓞2.obj U⟩,
+    rw @restriction_of_scalars.smul_def (𝓞1.obj U) (𝓞2.obj U) (f.app U)
+      { carrier := ((f _* 𝓕2).self.obj U), is_module := _ } r,
+    erw extension_of_scalars.smul_pure_tensor,
+    refl, },
   { intros, ext, simp [map_add, tensor_product.add_tmul], },
   { intros r y,
     ext s,
     simp only [ring_hom.id_apply, linear_map.coe_mk, linear_map.smul_apply],
-    have eq1 : (φ.1.app U _) = _ • φ.1.app U _ := @morphism.compatible _ _ _ _ φ (unop U) r y,
-    rw eq1,
-    rw @restriction_of_scalars.smul_def (𝓞1.obj U) (𝓞2.obj U)
-      (f.app U)
+    erw @morphism.compatible _ _ _ _ φ (unop U) r y,
+    rw @restriction_of_scalars.smul_def (𝓞1.obj U) (𝓞2.obj U) (f.app U)
       { carrier := (f _* 𝓕2).self.obj U, is_module := (f _* 𝓕2).is_module (unop U) },
     erw extension_of_scalars.smul_pure_tensor,
-    rw @tensor_product.smul_tmul (𝓞1.obj U) _ (𝓞1.obj U) _ (𝓕2.self.obj U) (𝓞2.obj U)
-      _ _ (𝓕2.is_module (unop U)) (restriction_of_scalars.is_module (f.app U) ⟨_⟩) begin
-        haveI := 𝓕2.is_module (unop U),
-        rw op_unop at _inst,
-        resetI,
-        apply_instance,
-      end begin
-        haveI := restriction_of_scalars.is_module (f.app U) ⟨𝓞2.obj U⟩,
-        apply_instance,
-      end _ r (φ.1.app U y) s,
-    refl,
-    },
+    erw @tensor_product.smul_tmul (𝓞1.obj U) _ (𝓞1.obj U) _ (𝓕2.self.obj U) (𝓞2.obj U)
+      _ _ _ _ _ _ _ r (φ.1.app U y) s,
+    refl, },
 end.
 
 private def extension_by.map_app.to_fun.map_zero' {𝓕1 𝓕2 : presheaf_of_module 𝓞1}
@@ -449,7 +438,7 @@ def extension_by.map {𝓕1 𝓕2 : presheaf_of_module 𝓞1} (φ : 𝓕1 ⟶ �
         tensor_product.lift.tmul],
       simp only [linear_map.coe_mk],
       erw extension_of_scalars.smul_pure_tensor, },
-    { simp only [smul_add, ih1, ih2, map_add], }
+    { rw [smul_add, map_add, ih1, ih2, map_add, smul_add] }
   end }.
 
 local notation f `_*→` φ := extension_by.map f φ
@@ -471,7 +460,7 @@ def extension_by.functor : presheaf_of_module 𝓞1 ⥤ presheaf_of_module 𝓞2
     { rw [tensor_product.lift.tmul],
       simp only [linear_map.coe_mk],
       refl, },
-    { simp only [map_add, ih1, ih2], },
+    { rw [map_add, ih1, ih2, map_add], },
   end,
   map_comp' := λ 𝓕1 𝓕2 𝓕3 φ12 φ23, begin
     ext U,
@@ -484,7 +473,7 @@ def extension_by.functor : presheaf_of_module 𝓞1 ⥤ presheaf_of_module 𝓞2
     { simp only [tensor_product.lift.tmul, linear_map.coe_mk],
       erw [comp_apply, comp_apply, tensor_product.lift.tmul],
       simp only [linear_map.coe_mk], },
-    { simp only [map_add, ih1, ih2], },
+    { rw [map_add, ih1, ih2, map_add], },
   end }.
 
 end extension
@@ -526,7 +515,23 @@ def forward.to_fun (g  : ((extension_by.functor f).obj X ⟶ Y)) :
     dsimp only,
     unfold unit.map,
     simp only [linear_map.coe_mk],
-    sorry,
+    change linear_map.restrict_scalars _ _ _ = _,
+    rw linear_map.restrict_scalars_apply,
+    simp only [linear_map.coe_mk],
+    have eq1 : (((extension_by.functor f).obj X).self.map inc) (x ⊗ₜ[𝓞1.obj U, f.app U] 1) =
+      (X.to_core.self.map inc) x ⊗ₜ[𝓞1.obj V, f.app V] 1,
+    { erw extension_by.obj_map' f X inc (x ⊗ₜ[𝓞1.obj U, f.app U] 1),
+      unfold restrict,
+      simp only [linear_map.coe_mk],
+      unfold restrict.to_fun,
+      simp only,
+      erw tensor_product.lift.tmul,
+      simp only [linear_map.coe_mk, map_one],
+      congr' 1, },
+    rw ← eq1,
+    change (((extension_by.functor f).obj X).self.map inc ≫ g.to_fun.app V) _ = _,
+    rw (g.1.naturality inc),
+    refl,
   end }.
 
 #exit

--- a/src/scratch.lean
+++ b/src/scratch.lean
@@ -9,6 +9,8 @@ import topology.sheaves.sheaf
 import algebra.category.CommRing.basic
 import algebra.module.restriction_of_scalars
 
+noncomputable theory
+
 open Top topological_space opposite category_theory
 open_locale tensor_product change_of_rings
 
@@ -213,16 +215,11 @@ include f
 variable (𝓕 : presheaf_of_module 𝓞1)
 include 𝓕
 
-/--
-For all opens `V ⊆ U`, there is a linear map `𝓕(U) ⊗[𝓞1(U)] 𝓞2(U) ⟶ 𝓕(V) ⊗[𝓞1(V)] 𝓞2(U)`
-given by `x ⊗ y ↦ ρₘ x ⊗ ρ₂ y` where `ρₘ` is restriction map of `𝓕` and `ρ₂` is restriction map
-of `𝓞2`.
--/
-def restrict (U V : opens X) (inc : op U ⟶ op V) :
-  linear_map (𝓞2.map inc) (extension_of_scalars.module (f.app (op U)) ⟨(𝓕.self.obj (op U))⟩)
-    (extension_of_scalars.module (f.app (op V)) ⟨(𝓕.self.obj (op V))⟩) :=
-{ to_fun := λ x, begin
-    refine @tensor_product.lift _ _ _ _
+private def restrict.to_fun (U V : opens X) (inc : op U ⟶ op V) :
+  (extension_of_scalars.module (f.app (op U)) ⟨(𝓕.self.obj (op U))⟩) →
+  (extension_of_scalars.module (f.app (op V)) ⟨(𝓕.self.obj (op V))⟩) :=
+λ x, begin
+  refine @tensor_product.lift _ _ _ _
       ((extension_of_scalars (f.app (op V))).obj ⟨𝓕.self.obj (op V)⟩) _ _ _ _ _ _ _ _,
     { exact 𝓞1.obj (op U) },
     { apply_instance },
@@ -270,7 +267,6 @@ def restrict (U V : opens X) (inc : op U ⟶ op V) :
         erw (extension_of_scalars.has_scalar_S_M_tensor_S.smul_pure_tensor (f.app (op V))
           ⟨(𝓕.self.obj (op V))⟩ ((f.app (op V)) ((𝓞1.map inc) r)) ((𝓞2.map inc) z)
           ((𝓕.to_core.self.map inc) x)).symm,
-
         unfold has_scalar.smul,
         rw tensor_product.lift.tmul,
         dsimp,
@@ -281,16 +277,34 @@ def restrict (U V : opens X) (inc : op U ⟶ op V) :
         rw ← f.naturality,
         refl,
         }, },
-    { exact x, },
-  end,
-  map_add' := by simp,
+      { exact x },
+end
+
+
+/--
+For all opens `V ⊆ U`, there is a linear map `𝓕(U) ⊗[𝓞1(U)] 𝓞2(U) ⟶ 𝓕(V) ⊗[𝓞1(V)] 𝓞2(U)`
+given by `x ⊗ y ↦ ρₘ x ⊗ ρ₂ y` where `ρₘ` is restriction map of `𝓕` and `ρ₂` is restriction map
+of `𝓞2`.
+-/
+def restrict (U V : opens X) (inc : op U ⟶ op V) :
+  linear_map (𝓞2.map inc) (extension_of_scalars.module (f.app (op U)) ⟨(𝓕.self.obj (op U))⟩)
+    (extension_of_scalars.module (f.app (op V)) ⟨(𝓕.self.obj (op V))⟩) :=
+-- let m1 : module (𝓞1.obj (op U)) (𝓞2.obj (op U)) :=
+--   extension_of_scalars.is_R_mod_S (f.app (op U)),
+-- m2 : module (𝓞1.obj (op U)) (f.app (op V) _* Module.mk (𝓕.to_core.self.obj (op V))) :=
+--   restriction_of_scalars.is_module _ (f.app (op U) ≫ 𝓞2.map inc)
+-- in
+{ to_fun := restrict.to_fun f 𝓕 U V inc,
+  map_add' := by simp [restrict.to_fun],
   map_smul' := λ r m, begin
     induction m using tensor_product.induction_on with m s x y ih1 ih2,
-    { simp only [extension_of_scalars.distrib_mul_action_S_M_tensor_S.smul_zero, map_zero], },
-    { simp only [linear_map.coe_mk, tensor_product.lift.tmul,
+    { simp only [restrict.to_fun, extension_of_scalars.distrib_mul_action_S_M_tensor_S.smul_zero,
+        map_zero], },
+    { simp only [restrict.to_fun, linear_map.coe_mk, tensor_product.lift.tmul,
         extension_of_scalars.has_scalar_S_M_tensor_S.smul_pure_tensor, map_mul],
       convert (extension_of_scalars.has_scalar_S_M_tensor_S.smul_pure_tensor _ _ _ _ _).symm, },
-    { rw [smul_add, map_add, map_add, ih1, ih2],
+    { simp only [restrict.to_fun] at ih1 ih2 ⊢,
+      rw [smul_add, map_add, map_add, ih1, ih2],
       simp only [smul_add], }
   end, }.
 
@@ -299,7 +313,7 @@ begin
   induction m using tensor_product.induction_on with x y x y ih1 ih2,
   { simp only [map_zero], },
   { unfold restrict,
-    simp only [category_theory.functor.map_id, id_apply, linear_map.coe_mk,
+    simp only [restrict.to_fun, category_theory.functor.map_id, id_apply, linear_map.coe_mk,
       tensor_product.lift.tmul], },
   { rw [map_add, ih1, ih2], },
 end.
@@ -329,10 +343,9 @@ def extension_by.obj_presheaf_Ab : presheaf Ab X :=
     dsimp,
     induction m using tensor_product.induction_on with x y x y ih1 ih2,
     { simp only [map_zero], },
-    { unfold restrict,
+    { unfold restrict restrict.to_fun,
       simp only [functor.map_comp, comp_apply, linear_map.coe_mk, add_monoid_hom.coe_mk],
-      dsimp,
-      simp only [tensor_product.lift.tmul, linear_map.coe_mk], },
+      erw [tensor_product.lift.tmul], },
     { simp only [map_add, ih1, ih2], }
   end }.
 
@@ -448,6 +461,7 @@ private def extension_by.map {𝓕1 𝓕2 : presheaf_of_module 𝓞1} (φ : 𝓕
     { simp only [map_zero], },
     { rw [extension_by.obj_map', extension_by.obj_map', restrict, tensor_product.lift.tmul,
         restrict],
+      unfold restrict.to_fun,
       simp only [linear_map.coe_mk],
       erw [tensor_product.lift.tmul, tensor_product.lift.tmul],
       dsimp,
@@ -511,5 +525,3 @@ def extension_by : presheaf_of_module 𝓞1 ⥤ presheaf_of_module 𝓞2 :=
 end extension
 
 end presheaf_of_module
-
-#lint

--- a/src/scratch.lean
+++ b/src/scratch.lean
@@ -13,7 +13,7 @@ noncomputable theory
 
 open Top topological_space opposite category_theory
 open_locale tensor_product change_of_rings
-
+set_option profiler true
 namespace presheaf_of_module
 
 section defs
@@ -308,16 +308,6 @@ def restrict (U V : opens X) (inc : op U ⟶ op V) :
       simp only [smul_add], }
   end, }.
 
-lemma restrict.aux1 (U : opens X) (m) : restrict f 𝓕 U U (𝟙 _) m = m :=
-begin
-  induction m using tensor_product.induction_on with x y x y ih1 ih2,
-  { simp only [map_zero], },
-  { unfold restrict,
-    simp only [restrict.to_fun, category_theory.functor.map_id, id_apply, linear_map.coe_mk,
-      tensor_product.lift.tmul], },
-  { rw [map_add, ih1, ih2], },
-end.
-
 /--
 For two presheaves of ring `𝓞1` and `𝓞2`m a morphism of presheaf of ring `f : 𝓞1 ⟶ 𝓞2` and a
 presheaf of module `𝓕` over `𝓞1`, there is a presheaf of modules over `𝓞2` given by
@@ -333,19 +323,24 @@ def extension_by.obj_presheaf_Ab : presheaf Ab X :=
       map_add' := by simp },
   map_id' := λ U, begin
     ext,
-    dsimp,
-    simp only [id_apply],
-    convert restrict.aux1 _ _ _ _,
-    all_goals { refl },
+    simp only [id_apply, linear_map.coe_mk, restrict, restrict.to_fun],
+    induction x using tensor_product.induction_on with x y x y ih1 ih2,
+    { simp only [map_zero], },
+    { simp only [add_monoid_hom.coe_mk],
+      erw [tensor_product.lift.tmul, linear_map.coe_mk],
+      congr';
+      erw [category_theory.functor.map_id, id_apply], },
+    { rw [map_add, ih1, ih2], },
   end,
   map_comp' := λ U V W incUV incVW, begin
     ext m,
-    dsimp,
+    simp only [add_monoid_hom.coe_mk, functor.map_comp, comp_apply, linear_map.coe_mk],
+    unfold restrict restrict.to_fun,
+    simp only [linear_map.coe_mk],
     induction m using tensor_product.induction_on with x y x y ih1 ih2,
     { simp only [map_zero], },
-    { unfold restrict restrict.to_fun,
-      simp only [functor.map_comp, comp_apply, linear_map.coe_mk, add_monoid_hom.coe_mk],
-      erw [tensor_product.lift.tmul], },
+    { erw [tensor_product.lift.tmul, tensor_product.lift.tmul, linear_map.coe_mk],
+      simp only [functor.map_comp, comp_apply, linear_map.coe_mk], },
     { simp only [map_add, ih1, ih2], }
   end }.
 

--- a/src/scratch.lean
+++ b/src/scratch.lean
@@ -13,7 +13,7 @@ noncomputable theory
 
 open Top topological_space opposite category_theory
 open_locale tensor_product change_of_rings
-set_option profiler true
+
 namespace presheaf_of_module
 
 section defs

--- a/src/scratch.lean
+++ b/src/scratch.lean
@@ -1,0 +1,515 @@
+/-
+Copyright (c) 2022 Jujian Zhang. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Jujian Zhang
+-/
+
+import topology.sheaves.presheaf
+import topology.sheaves.sheaf
+import algebra.category.CommRing.basic
+import algebra.module.restriction_of_scalars
+
+open Top topological_space opposite category_theory
+open_locale tensor_product change_of_rings
+
+namespace presheaf_of_module
+
+section defs
+variables {X : Top} (𝓞 : presheaf CommRing X)
+
+/--
+A presheaf of module over `𝓞 : presheaf CommRing X` is a presheaf of abelian group `𝓕` such that
+`𝓕(U)` is an `𝓞(U)`-module for all `U : opens X` and the restriction map is linear.
+
+We split the condition on restriction map to another definition because we want to use the module
+instances as early as possible.
+-/
+
+@[nolint has_inhabited_instance]
+structure core :=
+(self : presheaf Ab X)
+[is_module : ∀ (U : opens X), module (𝓞.obj (op U)) (self.obj (op U))]
+
+attribute [instance] core.is_module
+
+/--
+For presheaf of abelian group `𝓕`, `𝓕(U)` is an `𝓞(V)`-module for all `V ⊆ U : opens X` via
+restriction map of ring.
+-/
+def is_module_UV (𝓜 : presheaf_of_module.core 𝓞) {U V : opens X} (inc : op U ⟶ op V) :
+  module (𝓞.obj (op U)) (𝓜.self.obj (op V)) :=
+@restriction_of_scalars.is_module (𝓞.obj (op U)) (𝓞.obj (op V)) ⟨𝓜.self.obj (op V)⟩ (𝓞.map inc)
+local attribute [instance] is_module_UV
+
+/--
+For presheaf of abelian group `𝓕`, `𝓕(U)` is an `𝓞(V)`-module for all `V ⊆ U : opens X` via
+restriction map of ring. Explicitly, `r • m = ρ(r) • m` where `r : 𝓞(U)`, `m : 𝓕(V)` and `ρ` is
+the restriction map `𝓞(U) ⟶ 𝓞(V)`
+-/
+def has_scalar_UV (𝓜 : presheaf_of_module.core 𝓞) {U V : opens X} (inc : op U ⟶ op V) :
+  has_scalar (𝓞.obj (op U)) (𝓜.self.obj (op V)) :=
+@restriction_of_scalars.has_scalar (𝓞.obj (op U)) (𝓞.obj (op V)) ⟨𝓜.self.obj (op V)⟩ (𝓞.map inc)
+local attribute [instance] has_scalar_UV
+
+/--
+The compatibility of scalar multiplication states that `ρₘ (r • m) = ρᵣ r • ρₘ m` where `ρₘ` is
+restriction map of `𝓕` and `ρᵣ` is restriction map of `𝓞`.
+-/
+@[nolint has_inhabited_instance]
+structure _root_.presheaf_of_module extends presheaf_of_module.core 𝓞 :=
+(compatible : ∀ {U V : opens X} (inc : op U ⟶ op V) (r : 𝓞.obj (op U)) (m : self.obj (op U)),
+  self.map inc (r • m) = 𝓞.map inc r • self.map inc m)
+
+variable {𝓞}
+lemma is_linear_map (𝓕 : presheaf_of_module 𝓞) {U V : opens X} (inc : op U ⟶ op V) :
+  @@is_linear_map (𝓞.obj (op U)) _ _ _ _ (is_module_UV 𝓞 _ inc) (𝓕.self.map inc) :=
+{ map_add := map_add _,
+  map_smul := 𝓕.compatible inc }
+
+/--
+Since scalar multiplication is compatible with restriction, the restriction map of `𝓕` is actually
+a linear map.
+-/
+def to_linear_map (𝓕 : presheaf_of_module 𝓞) {U V : opens X} (inc : op U ⟶ op V) :
+  (⟨𝓕.self.obj (op U)⟩ : Module (𝓞.obj (op U))) ⟶
+  ({ carrier := 𝓕.self.obj (op V), is_module := is_module_UV 𝓞 _ inc } : Module (𝓞.obj (op U))) :=
+{ to_fun := 𝓕.self.map inc,
+  map_add' := by simp,
+  map_smul' := 𝓕.compatible inc }
+
+/--
+A morhpism `φ` between two presheaf of modules `𝓕1` and `𝓕2` is a morphism between presheaf of
+abelian groups such that `φ (r • m) = r • φ m`.
+-/
+@[nolint has_inhabited_instance, ext] structure morphism (𝓕1 𝓕2 : presheaf_of_module 𝓞) :=
+(to_fun : 𝓕1.self ⟶ 𝓕2.self)
+(compatible : ∀ {U : opens X} (r : 𝓞.obj (op U)) (m : 𝓕1.self.obj (op U)),
+  to_fun.app (op U) (r • m) = r • to_fun.app (op U) m )
+
+lemma morphism.is_linear {𝓕1 𝓕2 : presheaf_of_module 𝓞} (φ : morphism 𝓕1 𝓕2)
+  {U} :
+  _root_.is_linear_map (𝓞.obj (op U)) (φ.to_fun.app (op U)) :=
+{ map_add := map_add _,
+  map_smul := morphism.compatible _ }
+
+/--
+The composition of two morphisms between presheaf of modules is the composition of two morphisms as
+morphisms between presheaf of abelian group.
+-/
+def morphism.comp {𝓕1 𝓕2 𝓕3 : presheaf_of_module 𝓞}
+  (f12 : morphism 𝓕1 𝓕2) (f23 : morphism 𝓕2 𝓕3) : morphism 𝓕1 𝓕3 :=
+{ to_fun := f12.to_fun ≫ f23.to_fun,
+  compatible := λ U r m, begin
+    simp only [nat_trans.comp_app, comp_apply, f12.compatible, f23.compatible],
+  end }
+
+lemma morphism.comp_to_fun {𝓕1 𝓕2 𝓕3 : presheaf_of_module 𝓞}
+  (f12 : morphism 𝓕1 𝓕2) (f23 : morphism 𝓕2 𝓕3) :
+  (morphism.comp f12 f23).to_fun = f12.to_fun ≫ f23.to_fun := rfl
+
+/--
+The identity morphism of presheaf of module is identity morphism of presheaf of abelian group.
+-/
+def morphism.id (𝓕 : presheaf_of_module 𝓞) : morphism 𝓕 𝓕 :=
+{ to_fun := 𝟙 _,
+  compatible := λ U r m, begin
+    simp only [nat_trans.id_app, id_apply],
+  end }
+
+instance : category (presheaf_of_module 𝓞) :=
+{ hom := morphism,
+  id := morphism.id,
+  comp := λ _ _ _ f12 f23, morphism.comp f12 f23,
+  id_comp' := λ _ _ _, begin
+    ext U_op x,
+    simpa [morphism.comp_to_fun, comp_app],
+  end,
+  comp_id' := λ _ _ _, begin
+    ext U_op x,
+    simpa [morphism.comp_to_fun, comp_app],
+  end,
+  assoc' := λ _ _ _ _ _ _ _, begin
+    ext U_op x,
+    simp [morphism.comp_to_fun, comp_app],
+  end }.
+
+variable (𝓞)
+/--
+A sheaf of modules is a presheaf of module such that the underlying presheaf of abelian group is a
+sheaf.
+-/
+@[nolint has_inhabited_instance]
+structure _root_.sheaf_of_module extends _root_.presheaf_of_module 𝓞 :=
+(is_sheaf : presheaf.is_sheaf self)
+
+instance : category (sheaf_of_module 𝓞) :=
+{ hom := λ 𝓕1 𝓕2, morphism 𝓕1.1 𝓕2.1,
+  id := λ _, morphism.id _,
+  comp := λ _ _ _ f12 f23, morphism.comp f12 f23,
+  id_comp' := λ _ _ _, begin
+    ext U_op x,
+    simpa [morphism.comp_to_fun, comp_app],
+  end,
+  comp_id' := λ _ _ _, begin
+    ext U_op x,
+    simpa [morphism.comp_to_fun, comp_app],
+  end,
+  assoc' := λ _ _ _ _ _ _ _, begin
+    ext U_op x,
+    simp [morphism.comp_to_fun, comp_app],
+  end }
+
+end defs
+
+section restriction
+
+variables {X : Top} {𝓞1 𝓞2 : presheaf CommRing X} (f : 𝓞1 ⟶ 𝓞2)
+include f
+
+/--
+Given two presheaf of ring `𝓞1` and `𝓞2`, a morphsim `f : 𝓞1 ⟶ 𝓞2` and a presheaf of modules
+`𝓕` over `𝓞2`, there is a presheaf of modules over `𝓞1`. This is `𝓕` restricted by `f`, denoted
+as `f ^* 𝓕`.
+-/
+def restriction_by.obj (𝓕 : presheaf_of_module 𝓞2) : presheaf_of_module 𝓞1 :=
+{ self := 𝓕.self,
+  is_module := λ U, @restriction_of_scalars.is_module (𝓞1.obj (op U)) (𝓞2.obj (op U))
+      ⟨𝓕.self.obj (op U)⟩ (f.app (op U)),
+  compatible := λ U V inc r m, begin
+    erw [𝓕.compatible inc, (ring_hom.congr_fun (f.naturality inc) r).symm],
+    refl,
+  end }
+
+local notation f `^*` 𝓕 := restriction_by.obj f 𝓕
+
+/--
+Restricting presheaf of modules by `f` is functorial.
+-/
+def restriction_by.map {𝓕1 𝓕2 : presheaf_of_module 𝓞2} (φ : 𝓕1 ⟶ 𝓕2) :
+  (f^*𝓕1) ⟶ (f^*𝓕2) :=
+{ to_fun := φ.to_fun,
+  compatible := λ U r m, begin
+    erw [φ.compatible],
+    refl,
+  end }
+local notation f `^*→` φ := restriction_by.map f φ
+
+/--
+Restricting presheaf of modules by `f` is functorial.
+-/
+def restriction_by.functor : presheaf_of_module 𝓞2 ⥤ presheaf_of_module 𝓞1 :=
+{ obj := λ 𝓕, f ^* 𝓕,
+  map := λ _ _ φ, f ^*→ φ,
+  map_id' := λ _, rfl,
+  map_comp' := λ _ _ _ _ _, rfl }
+
+end restriction
+
+section extension
+
+variables {X : Top} {𝓞1 𝓞2 : presheaf CommRing X} (f : 𝓞1 ⟶ 𝓞2)
+include f
+
+variable (𝓕 : presheaf_of_module 𝓞1)
+include 𝓕
+
+/--
+For all opens `V ⊆ U`, there is a linear map `𝓕(U) ⊗[𝓞1(U)] 𝓞2(U) ⟶ 𝓕(V) ⊗[𝓞1(V)] 𝓞2(U)`
+given by `x ⊗ y ↦ ρₘ x ⊗ ρ₂ y` where `ρₘ` is restriction map of `𝓕` and `ρ₂` is restriction map
+of `𝓞2`.
+-/
+def restrict (U V : opens X) (inc : op U ⟶ op V) :
+  linear_map (𝓞2.map inc) (extension_of_scalars.module (f.app (op U)) ⟨(𝓕.self.obj (op U))⟩)
+    (extension_of_scalars.module (f.app (op V)) ⟨(𝓕.self.obj (op V))⟩) :=
+{ to_fun := λ x, begin
+    refine @tensor_product.lift _ _ _ _
+      ((extension_of_scalars (f.app (op V))).obj ⟨𝓕.self.obj (op V)⟩) _ _ _ _ _ _ _ _,
+    { exact 𝓞1.obj (op U) },
+    { apply_instance },
+    { exact 𝓕.self.obj (op U) },
+    { exact 𝓞2.obj (op U) },
+    { apply_instance },
+    { apply_instance },
+    { apply_instance },
+    { refine restriction_of_scalars.is_module ⟨_⟩ (f.app (op U)), },
+    { refine restriction_of_scalars.is_module _ _,
+      refine (f.app (op U)) ≫ (𝓞2.map inc), },
+    { fconstructor,
+      { intros m,
+        fconstructor,
+        { intros s,
+          refine @tensor_product.tmul (𝓞1.obj (op V)) _ (𝓕.self.obj (op V)) (𝓞2.obj (op V)) _ _ _
+            (restriction_of_scalars.is_module ⟨_⟩ (f.app (op V)))
+            (𝓕.self.map inc m) (𝓞2.map inc s),
+          },
+        { intros s1 s2,
+          rw [map_add, tensor_product.tmul_add], },
+        { intros r s,
+          rw [restriction_of_scalars.smul_def ⟨𝓞2.obj (op U)⟩ (f.app (op U)) r s, ring_hom.id_apply,
+            smul_eq_mul, ring_hom.map_mul, ←smul_eq_mul],
+          convert extension_of_scalars.has_scalar_S_M_tensor_S.smul_pure_tensor
+            (f.app (op V)) _ _ _ _, }, },
+      { intros m1 m2,
+        ext z,
+        simp only [map_add, tensor_product.add_tmul, linear_map.coe_mk, linear_map.add_apply], },
+      { intros r x,
+        ext z,
+        simp only [𝓕.compatible, ring_hom.id_apply, linear_map.coe_mk, linear_map.smul_apply],
+        rw @tensor_product.smul_tmul (𝓞1.obj (op V)) _ (𝓞1.obj (op V)) _
+          (𝓕.self.obj (op V)) (𝓞2.obj (op V)) _ _ _
+          (restriction_of_scalars.is_module ⟨_⟩ (f.app (op V)))
+          begin
+            haveI := 𝓕.is_module V,
+            apply_instance,
+          end begin
+            haveI := restriction_of_scalars.is_module ⟨𝓞2.obj (op V)⟩ (f.app (op V)),
+            apply_instance,
+          end _ (𝓞1.map inc r) (𝓕.self.map inc x) (𝓞2.map inc z),
+        rw [restriction_of_scalars.smul_def ⟨𝓞2.obj (op V)⟩ (f.app (op V)) (𝓞1.map inc r),
+          smul_eq_mul],
+        erw (extension_of_scalars.has_scalar_S_M_tensor_S.smul_pure_tensor (f.app (op V))
+          ⟨(𝓕.self.obj (op V))⟩ ((f.app (op V)) ((𝓞1.map inc) r)) ((𝓞2.map inc) z)
+          ((𝓕.to_core.self.map inc) x)).symm,
+
+        unfold has_scalar.smul,
+        rw tensor_product.lift.tmul,
+        dsimp,
+        erw [mul_comm, ← extension_of_scalars.has_scalar_S_M_tensor_S.smul_pure_tensor (f.app (op V))
+          ⟨(𝓕.self.obj (op V))⟩ ((f.app (op V)) ((𝓞1.map inc) r)) ((𝓞2.map inc) z)
+          ((𝓕.to_core.self.map inc) x)],
+        congr' 1,
+        rw ← f.naturality,
+        refl,
+        }, },
+    { exact x, },
+  end,
+  map_add' := by simp,
+  map_smul' := λ r m, begin
+    induction m using tensor_product.induction_on with m s x y ih1 ih2,
+    { simp only [extension_of_scalars.distrib_mul_action_S_M_tensor_S.smul_zero, map_zero], },
+    { simp only [linear_map.coe_mk, tensor_product.lift.tmul,
+        extension_of_scalars.has_scalar_S_M_tensor_S.smul_pure_tensor, map_mul],
+      convert (extension_of_scalars.has_scalar_S_M_tensor_S.smul_pure_tensor _ _ _ _ _).symm, },
+    { rw [smul_add, map_add, map_add, ih1, ih2],
+      simp only [smul_add], }
+  end, }.
+
+lemma restrict.aux1 (U : opens X) (m) : restrict f 𝓕 U U (𝟙 _) m = m :=
+begin
+  induction m using tensor_product.induction_on with x y x y ih1 ih2,
+  { simp only [map_zero], },
+  { unfold restrict,
+    simp only [category_theory.functor.map_id, id_apply, linear_map.coe_mk,
+      tensor_product.lift.tmul], },
+  { rw [map_add, ih1, ih2], },
+end.
+
+/--
+For two presheaves of ring `𝓞1` and `𝓞2`m a morphism of presheaf of ring `f : 𝓞1 ⟶ 𝓞2` and a
+presheaf of module `𝓕` over `𝓞1`, there is a presheaf of modules over `𝓞2` given by
+`U ↦ 𝓕(U) ⊗[𝓞1(U)] 𝓞2(U)`.
+-/
+def extension_by.obj_presheaf_Ab : presheaf Ab X :=
+{ obj := λ U,
+    ⟨(extension_of_scalars (f.app U)).obj
+      { carrier := (𝓕.self.obj U), is_module := 𝓕.is_module (unop U) }⟩,
+  map := λ U V inc,
+    { to_fun := restrict _ _ (unop U) (unop V) inc,
+      map_zero' := by simp,
+      map_add' := by simp },
+  map_id' := λ U, begin
+    ext,
+    dsimp,
+    simp only [id_apply],
+    convert restrict.aux1 _ _ _ _,
+    all_goals { refl },
+  end,
+  map_comp' := λ U V W incUV incVW, begin
+    ext m,
+    dsimp,
+    induction m using tensor_product.induction_on with x y x y ih1 ih2,
+    { simp only [map_zero], },
+    { unfold restrict,
+      simp only [functor.map_comp, comp_apply, linear_map.coe_mk, add_monoid_hom.coe_mk],
+      dsimp,
+      simp only [tensor_product.lift.tmul, linear_map.coe_mk], },
+    { simp only [map_add, ih1, ih2], }
+  end }.
+
+lemma extension_by.obj_presheaf_Ab_obj (U : (opens X)ᵒᵖ) :
+  (extension_by.obj_presheaf_Ab f 𝓕).obj U =
+  ⟨(extension_of_scalars (f.app U)).obj
+      { carrier := (𝓕.self.obj U), is_module := 𝓕.is_module (unop U) }⟩ := rfl
+
+/--
+For two presheaves of ring `𝓞1` and `𝓞2`m a morphism of presheaf of ring `f : 𝓞1 ⟶ 𝓞2` and a
+presheaf of module `𝓕` over `𝓞1`, there is a presheaf of modules over `𝓞2` given by
+`U ↦ 𝓕(U) ⊗[𝓞1(U)] 𝓞2(U)`.
+-/
+def extension_by.obj : presheaf_of_module 𝓞2 :=
+{ self := extension_by.obj_presheaf_Ab f 𝓕,
+  is_module := λ U, (extension_of_scalars.module (f.app (op U)) ⟨𝓕.self.obj (op U)⟩).is_module,
+  compatible := λ U V inc r m, begin
+    induction m using tensor_product.induction_on with x y x y ih1 ih2,
+    { simp only [map_zero, smul_zero], },
+    { rw [extension_of_scalars.has_scalar_S_M_tensor_S.smul_pure_tensor],
+      erw [tensor_product.lift.tmul],
+      change tensor_product.tmul _ _ _ = _,
+      erw [tensor_product.lift.tmul],
+      change _ = _ • tensor_product.tmul _ _ _,
+      erw extension_of_scalars.has_scalar_S_M_tensor_S.smul_pure_tensor,
+      rw map_mul,
+      refl, },
+    { rw [smul_add, map_add, ih1, ih2, map_add, smul_add], }
+  end }.
+
+local notation f `_*` 𝓕 := extension_by.obj f 𝓕
+
+lemma extension_by.obj_map {U V : opens X} (inc : op U ⟶ op V) (x : (f _* 𝓕).self.obj (op U)) :
+  (f _* 𝓕).self.map inc x = restrict _ _ _ _ inc x := rfl
+
+lemma extension_by.obj_map' {U V : (opens X)ᵒᵖ} (inc : U ⟶ V) (x : (f _* 𝓕).self.obj U) :
+  (f _* 𝓕).self.map inc x = restrict _ _ (unop U) (unop V) inc x := rfl
+
+omit 𝓕
+
+private def extension_by.map_app.to_fun {𝓕1 𝓕2 : presheaf_of_module 𝓞1} (φ : 𝓕1 ⟶ 𝓕2)
+  (U : (opens X)ᵒᵖ) : (f _* 𝓕1).self.obj U → (f _*𝓕2).self.obj U := λ x,
+begin
+  refine @tensor_product.lift (𝓞1.obj U) _ (𝓕1.self.obj U) (𝓞2.obj U)
+    ((f _* 𝓕2).to_core.self.obj U) _ _ _ (𝓕1.is_module (unop U))
+    (restriction_of_scalars.is_module ⟨_⟩ (f.app U))
+    (restriction_of_scalars.is_module _ (f.app U)) _ x,
+  fconstructor,
+  { intro m,
+    fconstructor,
+    { intro s,
+      exact @tensor_product.tmul (𝓞1.obj U) _ (𝓕2.self.obj U) (𝓞2.obj U) _ _
+        (𝓕2.is_module (unop U))
+        (restriction_of_scalars.is_module ⟨_⟩ (f.app U)) (φ.1.app U m) s },
+    { intros x y,
+      rw tensor_product.tmul_add, },
+    { intros r x,
+      rw ring_hom.id_apply,
+      rw @restriction_of_scalars.smul_def (𝓞1.obj U) (𝓞2.obj U) ⟨𝓞2.obj U⟩,
+      rw @restriction_of_scalars.smul_def (𝓞1.obj U) (𝓞2.obj U)
+        { carrier := ((f _* 𝓕2).self.obj U), is_module := _ } (f.app U) r,
+      erw extension_of_scalars.has_scalar_S_M_tensor_S.smul_pure_tensor,
+      refl, }, },
+  { -- sorry,
+    intros, ext, simp [map_add, tensor_product.add_tmul],
+    },
+  { -- sorry,
+    intros r y,
+    ext s,
+    simp only [ring_hom.id_apply, linear_map.coe_mk, linear_map.smul_apply],
+    have eq1 : (φ.1.app U _) = _ • φ.1.app U _ := @morphism.compatible _ _ _ _ φ (unop U) r y,
+    rw eq1,
+    rw @restriction_of_scalars.smul_def (𝓞1.obj U) (𝓞2.obj U)
+      { carrier := (f _* 𝓕2).self.obj U, is_module := (f _* 𝓕2).is_module (unop U) }
+      (f.app U),
+    erw extension_of_scalars.has_scalar_S_M_tensor_S.smul_pure_tensor,
+    rw @tensor_product.smul_tmul (𝓞1.obj U) _ (𝓞1.obj U) _ (𝓕2.self.obj U) (𝓞2.obj U)
+      _ _ (𝓕2.is_module (unop U)) (restriction_of_scalars.is_module ⟨_⟩ (f.app U)) begin
+        haveI := 𝓕2.is_module (unop U),
+        rw op_unop at _inst,
+        resetI,
+        apply_instance,
+      end begin
+        haveI := restriction_of_scalars.is_module ⟨𝓞2.obj U⟩ (f.app U),
+        apply_instance,
+      end _ r (φ.1.app U y) s,
+    refl,
+    },
+end.
+
+private def extension_by.map_app.to_fun.map_zero' {𝓕1 𝓕2 : presheaf_of_module 𝓞1}
+  (φ : 𝓕1 ⟶ 𝓕2)  (U : (opens X)ᵒᵖ) : extension_by.map_app.to_fun f φ U 0 = 0 :=
+by simp [extension_by.map_app.to_fun, map_zero]
+
+
+private def extension_by.map_app.to_fun.map_add' {𝓕1 𝓕2 : presheaf_of_module 𝓞1}
+  (φ : 𝓕1 ⟶ 𝓕2)  (U : (opens X)ᵒᵖ) (x y) :
+  extension_by.map_app.to_fun f φ U (x + y) =
+  extension_by.map_app.to_fun f φ U x + extension_by.map_app.to_fun f φ U y :=
+by simp [extension_by.map_app.to_fun, map_add]
+
+private def extension_by.map {𝓕1 𝓕2 : presheaf_of_module 𝓞1} (φ : 𝓕1 ⟶ 𝓕2) :
+  ((f _* 𝓕1).self ⟶ (f _* 𝓕2).self) :=
+{ app := λ U,
+  { to_fun := extension_by.map_app.to_fun f φ U,
+    map_zero' :=  extension_by.map_app.to_fun.map_zero' _ _ _,
+    map_add' := extension_by.map_app.to_fun.map_add' _ _ _, },
+  naturality' := λ U V inc, begin
+    unfold extension_by.map_app.to_fun,
+    ext,
+    simp only [comp_apply, add_monoid_hom.coe_mk],
+    induction x using tensor_product.induction_on with x y x y ih1 ih2,
+    { simp only [map_zero], },
+    { rw [extension_by.obj_map', extension_by.obj_map', restrict, tensor_product.lift.tmul,
+        restrict],
+      simp only [linear_map.coe_mk],
+      erw [tensor_product.lift.tmul, tensor_product.lift.tmul],
+      dsimp,
+      congr' 1,
+      convert add_monoid_hom.congr_fun (φ.1.naturality inc) x, },
+    { simp only [map_add, ih1, ih2], }
+  end }.
+
+/--The extension of presheaf of modules is functorial -/
+def extension_by.map {𝓕1 𝓕2 : presheaf_of_module 𝓞1} (φ : 𝓕1 ⟶ 𝓕2) :
+  (f _* 𝓕1) ⟶ (f _* 𝓕2) :=
+{ to_fun := extension_by.map f φ,
+  compatible := λ U r m, begin
+    unfold extension_by.map,
+    simp only [add_monoid_hom.coe_mk],
+    change tensor_product.lift _ _ = r • tensor_product.lift _ _,
+    induction m using tensor_product.induction_on with x y x y ih1 ih2,
+    { simp only [map_zero, smul_zero], },
+    { rw [extension_of_scalars.has_scalar_S_M_tensor_S.smul_pure_tensor, tensor_product.lift.tmul,
+        tensor_product.lift.tmul],
+      simp only [linear_map.coe_mk],
+      erw extension_of_scalars.has_scalar_S_M_tensor_S.smul_pure_tensor, },
+    { simp only [smul_add, ih1, ih2, map_add], }
+  end }.
+
+local notation f `_*→` φ := extension_by.map f φ
+/--
+The extension of presheaf of module is functorial given by
+`𝓕 ↦ 𝓕⊗[𝓞1] 𝓞2` and `φ : 𝓕1 ⟶ 𝓕2` to `(m ⊗ s) ↦ φ m ⊗ s`.
+-/
+def extension_by : presheaf_of_module 𝓞1 ⥤ presheaf_of_module 𝓞2 :=
+{ obj := λ 𝓕, f _* 𝓕,
+  map := λ _ _ φ, f _*→ φ,
+  map_id' := λ 𝓕, begin
+    ext U,
+    unfold extension_by.map,
+    dsimp only,
+    change extension_by.map_app.to_fun f _ _ _ = _,
+    change tensor_product.lift _ _ = _,
+    induction x using tensor_product.induction_on with x y x y ih1 ih2,
+    { simp only [map_zero], },
+    { rw [tensor_product.lift.tmul],
+      simp only [linear_map.coe_mk],
+      refl, },
+    { simp only [map_add, ih1, ih2], },
+  end,
+  map_comp' := λ 𝓕1 𝓕2 𝓕3 φ12 φ23, begin
+    ext U,
+    unfold extension_by.map,
+    dsimp only,
+    change extension_by.map_app.to_fun f _ _ _ = _,
+    change tensor_product.lift _ _ = _,
+    induction x using tensor_product.induction_on with x y x y ih1 ih2,
+    { simp only [map_zero] },
+    { simp only [tensor_product.lift.tmul, linear_map.coe_mk],
+      erw [comp_apply, comp_apply, tensor_product.lift.tmul],
+      simp only [linear_map.coe_mk], },
+    { simp only [map_add, ih1, ih2], },
+  end }.
+
+end extension
+
+end presheaf_of_module
+
+#lint

--- a/src/scratch.lean
+++ b/src/scratch.lean
@@ -11,7 +11,7 @@ import algebra.module.restriction_of_scalars
 
 noncomputable theory
 
-open Top topological_space opposite category_theory
+open Top topological_space opposite category_theory change_of_rings
 open_locale tensor_product change_of_rings
 
 namespace presheaf_of_module
@@ -220,7 +220,7 @@ private def restrict.to_fun (U V : opens X) (inc : op U ⟶ op V) :
   (extension_of_scalars.module (f.app (op V)) ⟨(𝓕.self.obj (op V))⟩) :=
 λ x, begin
   refine @tensor_product.lift _ _ _ _
-      ((extension_of_scalars (f.app (op V))).obj ⟨𝓕.self.obj (op V)⟩) _ _ _ _ _ _ _ _,
+      ((extension_of_scalars.functor (f.app (op V))).obj ⟨𝓕.self.obj (op V)⟩) _ _ _ _ _ _ _ _,
     { exact 𝓞1.obj (op U) },
     { apply_instance },
     { exact 𝓕.self.obj (op U) },
@@ -315,7 +315,7 @@ presheaf of module `𝓕` over `𝓞1`, there is a presheaf of modules over `�
 -/
 def extension_by.obj_presheaf_Ab : presheaf Ab X :=
 { obj := λ U,
-    ⟨(extension_of_scalars (f.app U)).obj
+    ⟨(extension_of_scalars.functor (f.app U)).obj
       { carrier := (𝓕.self.obj U), is_module := 𝓕.is_module (unop U) }⟩,
   map := λ U V inc,
     { to_fun := restrict _ _ (unop U) (unop V) inc,
@@ -346,7 +346,7 @@ def extension_by.obj_presheaf_Ab : presheaf Ab X :=
 
 lemma extension_by.obj_presheaf_Ab_obj (U : (opens X)ᵒᵖ) :
   (extension_by.obj_presheaf_Ab f 𝓕).obj U =
-  ⟨(extension_of_scalars (f.app U)).obj
+  ⟨(extension_of_scalars.functor (f.app U)).obj
       { carrier := (𝓕.self.obj U), is_module := 𝓕.is_module (unop U) }⟩ := rfl
 
 /--
@@ -487,7 +487,7 @@ local notation f `_*→` φ := extension_by.map f φ
 The extension of presheaf of module is functorial given by
 `𝓕 ↦ 𝓕⊗[𝓞1] 𝓞2` and `φ : 𝓕1 ⟶ 𝓕2` to `(m ⊗ s) ↦ φ m ⊗ s`.
 -/
-def extension_by : presheaf_of_module 𝓞1 ⥤ presheaf_of_module 𝓞2 :=
+def extension_by.functor : presheaf_of_module 𝓞1 ⥤ presheaf_of_module 𝓞2 :=
 { obj := λ 𝓕, f _* 𝓕,
   map := λ _ _ φ, f _*→ φ,
   map_id' := λ 𝓕, begin
@@ -518,5 +518,18 @@ def extension_by : presheaf_of_module 𝓞1 ⥤ presheaf_of_module 𝓞2 :=
   end }.
 
 end extension
+
+section
+
+variables {X : Top} {𝓞1 𝓞2 : presheaf CommRing X} (f : 𝓞1 ⟶ 𝓞2)
+
+-- example : adjunction (restriction_by.functor f) (extension_by.functor f) :=
+-- { hom_equiv := _,
+--   unit := _,
+--   counit := _,
+--   hom_equiv_unit' := _,
+--   hom_equiv_counit' := _ }
+
+end
 
 end presheaf_of_module


### PR DESCRIPTION
Presheaf of modules is defined along with two functors:

- restriction of presheaf of module by a morphism between presheaves of rings
- extension of presheaf of module by a morphism between presheaves of rings, i.e. `𝓕 ↦ 𝓕⊗[𝓞1] 𝓞2` and `φ : 𝓕1 ⟶ 𝓕2` to `(m ⊗ s) ↦ φ m ⊗ s`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
