### PR TITLE
[Merged by Bors] - perf(geometry/euclidean): speed up proof on the edge of timing out

### DIFF
--- a/src/geometry/euclidean/oriented_angle.lean
+++ b/src/geometry/euclidean/oriented_angle.lean
@@ -635,7 +635,10 @@ rfl
 /-- Applying `conj_lie` to both vectors negates the angle between those vectors. -/
 @[simp] lemma oangle_conj_lie (x y : V) :
   hb.oangle (hb.conj_lie x) (hb.conj_lie y) = -hb.oangle x y :=
-by simp [conj_lie, oangle, ←(star_ring_end ℂ).map_div]
+by simp only [orthonormal.conj_lie, linear_isometry_equiv.symm_apply_apply, orthonormal.oangle,
+  eq_self_iff_true, function.comp_app, complex.arg_coe_angle_eq_iff,
+  linear_isometry_equiv.coe_trans, neg_inj, complex.conj_lie_apply, complex.arg_conj_coe_angle,
+  ←(star_ring_end ℂ).map_div]
 
 /-- Any linear isometric equivalence in `V` is `rotation` or `conj_lie` composed with
 `rotation`. -/


### PR DESCRIPTION

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

This whole file is quite slow and could use some attention, it takes nearly a minute to build locally even with this change. This proof in particular was on the edge of timing out and causing some build trouble.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
