### PR TITLE
[Merged by Bors] - refactor(combinatorics/simple_graph/{basic,degree_sum}): move darts from degree_sum to basic

### DIFF
--- a/src/combinatorics/simple_graph/basic.lean
+++ b/src/combinatorics/simple_graph/basic.lean
@@ -344,8 +344,8 @@ d.is_adj
 def dart.rev (d : G.dart) : G.dart :=
 ⟨d.to_prod.swap, G.symm d.is_adj⟩
 
-@[simp] lemma dart.rev_edge (d : G.dart) : d.rev.edge = d.edge :=
-by { obtain ⟨⟨v,w⟩, _⟩ := d, exact sym2.eq_swap }
+@[simp] lemma dart.rev_edge : Π (d : G.dart), d.rev.edge = d.edge :=
+by { rintro ⟨⟨v,w⟩, _⟩, exact sym2.eq_swap }
 
 @[simp] lemma dart.rev_rev (d : G.dart) : d.rev.rev = d :=
 by ext; refl

--- a/src/combinatorics/simple_graph/basic.lean
+++ b/src/combinatorics/simple_graph/basic.lean
@@ -321,7 +321,7 @@ instance edges_fintype [decidable_eq V] [fintype V] [decidable_rel G.adj] :
 
 /-- A `dart` is an oriented edge, implemented as an ordered pair of adjacent vertices. -/
 @[ext, derive decidable_eq]
-structure dart extends prod V V :=
+structure dart extends V × V :=
 (is_adj : G.adj fst snd)
 
 section darts

--- a/src/combinatorics/simple_graph/basic.lean
+++ b/src/combinatorics/simple_graph/basic.lean
@@ -349,7 +349,7 @@ d.is_adj
 @[simps] def dart.symm (d : G.dart) : G.dart :=
 ⟨d.to_prod.swap, G.symm d.is_adj⟩
 
-@[simp] lemma dart.symm_mk (p : V × V) (h : G.adj p.1 p.2) :
+@[simp] lemma dart.symm_mk {p : V × V} (h : G.adj p.1 p.2) :
   (dart.mk p h).symm = dart.mk p.swap h.symm := rfl
 
 @[simp] lemma dart.edge_symm (d : G.dart) : d.symm.edge = d.edge :=

--- a/src/combinatorics/simple_graph/degree_sum.lean
+++ b/src/combinatorics/simple_graph/degree_sum.lean
@@ -72,7 +72,7 @@ end
 variables {G} [decidable_eq V]
 
 lemma dart.edge_fiber (d : G.dart) :
-  (univ.filter (λ (d' : G.dart), d'.edge = d.edge)) = {d, d.rev} :=
+  (univ.filter (λ (d' : G.dart), d'.edge = d.edge)) = {d, d.symm} :=
 finset.ext (λ d', by simpa using dart_edge_eq_iff d' d)
 
 variables (G)
@@ -85,7 +85,7 @@ begin
   convert congr_arg card d.edge_fiber,
   rw [card_insert_of_not_mem, card_singleton],
   rw [mem_singleton],
-  exact d.rev_ne.symm,
+  exact d.symm_ne.symm,
 end
 
 lemma dart_card_eq_twice_card_edges : fintype.card G.dart = 2 * G.edge_finset.card :=

--- a/src/combinatorics/simple_graph/degree_sum.lean
+++ b/src/combinatorics/simple_graph/degree_sum.lean
@@ -59,15 +59,12 @@ end
 
 lemma dart_fst_fiber_card_eq_degree [decidable_eq V] (v : V) :
   (univ.filter (λ d : G.dart, d.fst = v)).card = G.degree v :=
-begin
-  have hh := card_image_of_injective univ (G.dart_of_neighbor_set_injective v),
-  rw [finset.card_univ, card_neighbor_set_eq_degree] at hh,
-  rwa dart_fst_fiber,
-end
+by simpa only [dart_fst_fiber, finset.card_univ, card_neighbor_set_eq_degree]
+     using card_image_of_injective univ (G.dart_of_neighbor_set_injective v)
 
 lemma dart_card_eq_sum_degrees : fintype.card G.dart = ∑ v, G.degree v :=
 begin
-  haveI h : decidable_eq V, { classical, apply_instance },
+  haveI := classical.dec_eq V,
   simp only [←card_univ, ←dart_fst_fiber_card_eq_degree],
   exact card_eq_sum_card_fiberwise (by simp),
 end
@@ -83,8 +80,7 @@ variables (G)
 lemma dart_edge_fiber_card (e : sym2 V) (h : e ∈ G.edge_set) :
   (univ.filter (λ (d : G.dart), d.edge = e)).card = 2 :=
 begin
-  refine quotient.ind (λ p h, _) e h,
-  cases p with v w,
+  refine sym2.ind (λ v w h, _) e h,
   let d : G.dart := ⟨(v, w), h⟩,
   convert congr_arg card d.edge_fiber,
   rw [card_insert_of_not_mem, card_singleton],
@@ -159,7 +155,7 @@ lemma exists_ne_odd_degree_of_exists_odd_degree [fintype V] [decidable_rel G.adj
   (v : V) (h : odd (G.degree v)) :
   ∃ (w : V), w ≠ v ∧ odd (G.degree w) :=
 begin
-  haveI : decidable_eq V, { classical, apply_instance },
+  haveI := classical.dec_eq V,
   rcases G.odd_card_odd_degree_vertices_ne v h with ⟨k, hg⟩,
   have hg' : (filter (λ (w : V), w ≠ v ∧ odd (G.degree w)) univ).card > 0,
   { rw hg,

--- a/src/data/sym/sym2.lean
+++ b/src/data/sym/sym2.lean
@@ -100,6 +100,9 @@ protected lemma «forall» {α : Sort*} {f : sym2 α → Prop} :
 lemma eq_swap {a b : α} : ⟦(a, b)⟧ = ⟦(b, a)⟧ :=
 by { rw quotient.eq, apply rel.swap }
 
+@[simp] lemma mk_prod_swap_eq {p : α × α} : ⟦p.swap⟧ = ⟦p⟧ :=
+by { cases p, exact eq_swap }
+
 lemma congr_right {a b c : α} : ⟦(a, b)⟧ = ⟦(a, c)⟧ ↔ b = c :=
 by { split; intro h, { rw quotient.eq at h, cases h; refl }, rw h }
 
@@ -113,6 +116,10 @@ begin
   { rw quotient.eq at h, cases h; tidy },
   { cases h; rw [h.1, h.2], rw eq_swap }
 end
+
+lemma mk_eq_mk_iff {p q : α × α} :
+  ⟦p⟧ = ⟦q⟧ ↔ p = q ∨ p = q.swap :=
+by { cases p, cases q, simp only [eq_iff, prod.mk.inj_iff, prod.swap_prod_mk] }
 
 /-- The universal property of `sym2`; symmetric functions of two arguments are equivalent to
 functions from `sym2`. Note that when `β` is `Prop`, it can sometimes be more convenient to use


### PR DESCRIPTION
This also changes `simple_graph.dart` to extend `prod`, so that darts are even closer to being an ordered pair.

Since this touches the module docstrings, they are updated to use fully qualified names.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
