### PR TITLE
[Merged by Bors] - feat(analysis/normed_space/star/spectrum): prove the spectral radius of a selfadjoint element in a C*-algebra is its norm.

### DIFF
--- a/src/algebra/star/self_adjoint.lean
+++ b/src/algebra/star/self_adjoint.lean
@@ -91,6 +91,11 @@ by simp only [mem_iff, star_mul, star_star, mem_iff.mp hx, mul_assoc]
 lemma conjugate' {x : R} (hx : x ∈ self_adjoint R) (z : R) : star z * x * z ∈ self_adjoint R :=
 by simp only [mem_iff, star_mul, star_star, mem_iff.mp hx, mul_assoc]
 
+instance : has_pow (self_adjoint R) ℕ :=
+⟨λ x n, ⟨(x : R) ^ n, by simp only [mem_iff, star_pow, star_coe_eq]⟩⟩
+
+@[simp, norm_cast] lemma coe_pow (x : self_adjoint R) (n : ℕ) : ↑(x ^ n) = (x : R) ^ n := rfl
+
 end ring
 
 section comm_ring
@@ -100,11 +105,6 @@ instance : has_mul (self_adjoint R) :=
 ⟨λ x y, ⟨(x : R) * y, by simp only [mem_iff, star_mul', star_coe_eq]⟩⟩
 
 @[simp, norm_cast] lemma coe_mul (x y : self_adjoint R) : ↑(x * y) = (x : R) * y := rfl
-
-instance : has_pow (self_adjoint R) ℕ :=
-⟨λ x n, ⟨(x : R) ^ n, by simp only [mem_iff, star_pow, star_coe_eq]⟩⟩
-
-@[simp, norm_cast] lemma coe_pow (x : self_adjoint R) (n : ℕ) : ↑(x ^ n) = (x : R) ^ n := rfl
 
 instance : comm_ring (self_adjoint R) :=
 { npow := λ n x, x ^ n,

--- a/src/analysis/normed_space/star/basic.lean
+++ b/src/analysis/normed_space/star/basic.lean
@@ -7,6 +7,7 @@ Authors: Frédéric Dupuis
 import analysis.normed.group.hom
 import analysis.normed_space.basic
 import analysis.normed_space.linear_isometry
+import algebra.star.self_adjoint
 import algebra.star.unitary
 
 /-!
@@ -128,6 +129,13 @@ by { nth_rewrite 0 [←star_star x], simp only [norm_star_mul_self, norm_star] }
 lemma norm_star_mul_self' {x : E} : ∥x⋆ * x∥ = ∥x⋆∥ * ∥x∥ :=
 by rw [norm_star_mul_self, norm_star]
 
+lemma nnnorm_star_mul_self {x : E} : ∥x⋆ * x∥₊ = ∥x∥₊ * ∥x∥₊ :=
+begin
+  have : (∥x⋆ * x∥₊ : ℝ) = ∥x∥₊ * ∥x∥₊,
+    by simpa only [←coe_nnnorm] using @norm_star_mul_self _ _ _ _ x,
+  exact_mod_cast this,
+end
+
 @[simp] lemma norm_one [nontrivial E] : ∥(1 : E)∥ = 1 :=
 begin
   have : 0 < ∥(1 : E)∥ := norm_pos_iff.mpr one_ne_zero,
@@ -173,6 +181,18 @@ lemma norm_mul_mem_unitary (A : E) {U : E} (hU : U ∈ unitary E) : ∥A * U∥ 
 norm_mul_coe_unitary A ⟨U, hU⟩
 
 end cstar_ring
+
+lemma self_adjoint.nnnorm_pow_two_pow [normed_ring E] [star_ring E] [cstar_ring E]
+  {x : E} (hx : x ∈ self_adjoint E) (n : ℕ) : ∥x ^ 2 ^ n∥₊ = ∥x∥₊ ^ (2 ^ n) :=
+begin
+  induction n with k hk,
+  { simp only [pow_zero, pow_one] },
+  { rw [pow_succ, pow_mul', sq],
+    nth_rewrite 0 ←(self_adjoint.mem_iff.mp hx),
+    rw [←star_pow, nnnorm_star_mul_self, ←sq, hk, pow_mul'] },
+end
+
+end self_adjoint
 
 section starₗᵢ
 

--- a/src/analysis/normed_space/star/basic.lean
+++ b/src/analysis/normed_space/star/basic.lean
@@ -182,7 +182,7 @@ norm_mul_coe_unitary A ⟨U, hU⟩
 
 end cstar_ring
 
-lemma nnnorm_pow_two_pow_of_selfadjoint [normed_ring E] [star_ring E] [cstar_ring E]
+lemma nnnorm_pow_two_pow_of_self_adjoint [normed_ring E] [star_ring E] [cstar_ring E]
   {x : E} (hx : x ∈ self_adjoint E) (n : ℕ) : ∥x ^ 2 ^ n∥₊ = ∥x∥₊ ^ (2 ^ n) :=
 begin
   induction n with k hk,
@@ -194,7 +194,7 @@ end
 
 lemma self_adjoint.nnnorm_pow_two_pow [normed_ring E] [star_ring E] [cstar_ring E]
   (x : self_adjoint E) (n : ℕ) : ∥x ^ 2 ^ n∥₊ = ∥x∥₊ ^ (2 ^ n) :=
-nnnorm_pow_two_pow_of_selfadjoint x.property _
+nnnorm_pow_two_pow_of_self_adjoint x.property _
 
 section starₗᵢ
 

--- a/src/analysis/normed_space/star/basic.lean
+++ b/src/analysis/normed_space/star/basic.lean
@@ -182,7 +182,7 @@ norm_mul_coe_unitary A ⟨U, hU⟩
 
 end cstar_ring
 
-lemma self_adjoint.nnnorm_pow_two_pow [normed_ring E] [star_ring E] [cstar_ring E]
+lemma nnnorm_pow_two_pow_of_selfadjoint [normed_ring E] [star_ring E] [cstar_ring E]
   {x : E} (hx : x ∈ self_adjoint E) (n : ℕ) : ∥x ^ 2 ^ n∥₊ = ∥x∥₊ ^ (2 ^ n) :=
 begin
   induction n with k hk,
@@ -191,6 +191,10 @@ begin
     nth_rewrite 0 ←(self_adjoint.mem_iff.mp hx),
     rw [←star_pow, cstar_ring.nnnorm_star_mul_self, ←sq, hk, pow_mul'] },
 end
+
+lemma self_adjoint.nnnorm_pow_two_pow [normed_ring E] [star_ring E] [cstar_ring E]
+  (x : self_adjoint E) (n : ℕ) : ∥x ^ 2 ^ n∥₊ = ∥x∥₊ ^ (2 ^ n) :=
+nnnorm_pow_two_pow_of_selfadjoint x.property _
 
 section starₗᵢ
 

--- a/src/analysis/normed_space/star/basic.lean
+++ b/src/analysis/normed_space/star/basic.lean
@@ -189,10 +189,8 @@ begin
   { simp only [pow_zero, pow_one] },
   { rw [pow_succ, pow_mul', sq],
     nth_rewrite 0 ←(self_adjoint.mem_iff.mp hx),
-    rw [←star_pow, nnnorm_star_mul_self, ←sq, hk, pow_mul'] },
+    rw [←star_pow, cstar_ring.nnnorm_star_mul_self, ←sq, hk, pow_mul'] },
 end
-
-end self_adjoint
 
 section starₗᵢ
 

--- a/src/analysis/normed_space/star/spectrum.lean
+++ b/src/analysis/normed_space/star/spectrum.lean
@@ -26,7 +26,11 @@ begin
   convert (spectrum.pow_nnnorm_pow_one_div_tendsto_nhds_spectral_radius (a : A)).comp
       (nat.tendsto_pow_at_top_at_top_of_one_lt (by linarith : 1 < 2)),
   refine funext (λ n, _),
-  rw [function.comp_app, self_adjoint.nnnorm_pow_two_pow ha, ennreal.coe_pow, ←rpow_nat_cast,
+  rw [function.comp_app, nnnorm_pow_two_pow_of_self_adjoint ha, ennreal.coe_pow, ←rpow_nat_cast,
     ←rpow_mul],
   simp,
 end
+
+lemma self_adjoint.coe_spectral_radius_eq_nnnorm (a : self_adjoint A) :
+  spectral_radius ℂ (a : A) = ∥(a : A)∥₊ :=
+spectral_radius_eq_nnnorm_of_self_adjoint a.property

--- a/src/analysis/normed_space/star/spectrum.lean
+++ b/src/analysis/normed_space/star/spectrum.lean
@@ -1,0 +1,32 @@
+/-
+Copyright (c) 2022 Jireh Loreaux. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Jireh Loreaux
+-/
+import analysis.normed_space.star.basic
+import analysis.normed_space.spectrum
+
+/-!
+In this file, we establish various propreties related to the spectrum of elements in a
+C⋆-algebra over ℂ.
+-/
+
+variables {A : Type*}
+[normed_ring A] [normed_algebra ℂ A] [star_ring A] [cstar_ring A] [complete_space A]
+[measurable_space A] [borel_space A] [topological_space.second_countable_topology A]
+
+open_locale topological_space ennreal
+open filter ennreal
+
+lemma spectral_radius_eq_nnnorm_of_self_adjoint {a : A} (ha : a ∈ self_adjoint A) :
+  spectral_radius ℂ a = ∥a∥₊ :=
+begin
+  have hconst : tendsto (λ n : ℕ, (∥a∥₊ : ℝ≥0∞)) at_top _ := tendsto_const_nhds,
+  refine tendsto_nhds_unique _ hconst,
+  convert (spectrum.pow_nnnorm_pow_one_div_tendsto_nhds_spectral_radius (a : A)).comp
+      (nat.tendsto_pow_at_top_at_top_of_one_lt (by linarith : 1 < 2)),
+  refine funext (λ n, _),
+  rw [function.comp_app, self_adjoint.nnnorm_pow_two_pow ha, ennreal.coe_pow, ←rpow_nat_cast,
+    ←rpow_mul],
+  simp,
+end

--- a/src/analysis/normed_space/star/spectrum.lean
+++ b/src/analysis/normed_space/star/spectrum.lean
@@ -7,7 +7,7 @@ import analysis.normed_space.star.basic
 import analysis.normed_space.spectrum
 
 /-!
-In this file, we establish various propreties related to the spectrum of elements in a
+In this file, we establish various properties related to the spectrum of elements in a
 C⋆-algebra over ℂ.
 -/
 


### PR DESCRIPTION
This establishes that the spectral radius of a selfadjoint element in a C*-algebra is its (nn)norm using the Gelfand formula for the spectral radius. The same theorem for normal elements can be proven using this once normal elements are defined in mathlib.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
