### PR TITLE
[Merged by Bors] - feat(topology/algebra/continuous_monoid_hom): `to_continuous_map` is a `closed_embedding`

### DIFF
--- a/src/topology/algebra/continuous_monoid_hom.lean
+++ b/src/topology/algebra/continuous_monoid_hom.lean
@@ -17,6 +17,8 @@ This file defines the space of continuous homomorphisms between two topological 
 * `continuous_add_monoid_hom α β`: The continuous additive homomorphisms `α →+ β`.
 -/
 
+open_locale pointwise
+
 open function
 
 variables {F α β : Type*} (A B C D E : Type*)
@@ -196,6 +198,37 @@ lemma is_inducing : inducing (to_continuous_map : continuous_monoid_hom A B → 
 
 lemma is_embedding : embedding (to_continuous_map : continuous_monoid_hom A B → C(A, B)) :=
 ⟨is_inducing A B, to_continuous_map_injective⟩
+
+lemma is_closed_embedding [has_continuous_mul B] [t2_space B] :
+  closed_embedding (to_continuous_map : continuous_monoid_hom A B → C(A, B)) :=
+⟨is_embedding A B, ⟨begin
+  suffices : (set.range (to_continuous_map : continuous_monoid_hom A B → C(A, B))) =
+    ({f | f '' {1} ⊆ {1}ᶜ} ∪ ⋃ (x y) (U V W) (hU : is_open U) (hV : is_open V) (hW : is_open W)
+    (h : disjoint (U * V) W), {f | f '' {x} ⊆ U} ∩ {f | f '' {y} ⊆ V} ∩ {f | f '' {x * y} ⊆ W})ᶜ,
+  { rw [this, compl_compl],
+    refine (continuous_map.is_open_gen is_compact_singleton is_open_compl_singleton).union _,
+    repeat { apply is_open_Union, intro, },
+    repeat { apply is_open.inter },
+    all_goals { apply continuous_map.is_open_gen is_compact_singleton, assumption } },
+  simp_rw [set.compl_union, set.compl_Union, set.image_singleton, set.singleton_subset_iff,
+    set.ext_iff, set.mem_inter_iff, set.mem_Inter, set.mem_compl_iff],
+  refine λ f, ⟨_, _⟩,
+  { rintros ⟨f, rfl⟩,
+    exact ⟨λ h, h (map_one f), λ x y U V W hU hV hW h ⟨⟨hfU, hfV⟩, hfW⟩,
+      h ⟨set.mul_mem_mul hfU hfV, (congr_arg (∈ W) (map_mul f x y)).mp hfW⟩⟩ },
+  { rintros ⟨hf1, hf2⟩,
+    suffices : ∀ x y, f (x * y) = f x * f y,
+    { refine ⟨({ map_one' := of_not_not hf1, map_mul' := this, .. f } : continuous_monoid_hom A B),
+       continuous_map.ext (λ _, rfl)⟩, },
+    intros x y,
+    contrapose! hf2,
+    obtain ⟨UV, W, hUV, hW, hfUV, hfW, h⟩ := t2_separation hf2.symm,
+    have hB := @continuous_mul B _ _ _,
+    obtain ⟨U, V, hU, hV, hfU, hfV, h'⟩ := is_open_prod_iff.mp (hUV.preimage hB) (f x) (f y) hfUV,
+    refine ⟨x, y, U, V, W, hU, hV, hW, ((disjoint_iff.mpr h).mono_left _), ⟨hfU, hfV⟩, hfW⟩,
+    rintros _ ⟨x, y, hx : (x, y).1 ∈ U, hy : (x, y).2 ∈ V, rfl⟩,
+    exact h' ⟨hx, hy⟩ },
+end⟩⟩
 
 variables {A B C D E}
 


### PR DESCRIPTION
This PR proves that `to_continuous_map : continuous_monoid_hom A B → C(A, B)` is a `closed_embedding`. This will be useful for showing that the Pontryagin dual is locally compact.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
