### PR TITLE
[Merged by Bors] - feat(analysis/normed_space/linear_isometry): add lemmas to `linear_isometry_equiv`

### DIFF
--- a/src/analysis/normed_space/linear_isometry.lean
+++ b/src/analysis/normed_space/linear_isometry.lean
@@ -397,6 +397,13 @@ include σ₁₃ σ₂₁
 @[simp] lemma coe_trans (e₁ : E ≃ₛₗᵢ[σ₁₂] E₂) (e₂ : E₂ ≃ₛₗᵢ[σ₂₃] E₃) : ⇑(e₁.trans e₂) = e₂ ∘ e₁ :=
 rfl
 
+@[simp] lemma trans_apply (e₁ : E ≃ₛₗᵢ[σ₁₂] E₂) (e₂ : E₂ ≃ₛₗᵢ[σ₂₃] E₃) (c : E) :
+  (e₁.trans e₂ : E ≃ₛₗᵢ[σ₁₃] E₃) (c) = e₂ (e₁ (c)) :=
+rfl
+
+@[simp] lemma symm_trans_apply (e₁ : E ≃ₛₗᵢ[σ₁₂] E₂) (e₂ : E₂ ≃ₛₗᵢ[σ₂₃] E₃) (c : E₃) :
+  (e₁.trans e₂ : E ≃ₛₗᵢ[σ₁₃] E₃).symm c = e₁.symm(e₂.symm c) := rfl
+
 @[simp] lemma to_linear_equiv_trans (e' : E₂ ≃ₛₗᵢ[σ₂₃] E₃) :
   (e.trans e').to_linear_equiv = e.to_linear_equiv.trans e'.to_linear_equiv :=
 rfl

--- a/src/analysis/normed_space/linear_isometry.lean
+++ b/src/analysis/normed_space/linear_isometry.lean
@@ -402,7 +402,7 @@ rfl
 rfl
 
 @[simp] lemma symm_trans_apply (e₁ : E ≃ₛₗᵢ[σ₁₂] E₂) (e₂ : E₂ ≃ₛₗᵢ[σ₂₃] E₃) (c : E₃) :
-  (e₁.trans e₂ : E ≃ₛₗᵢ[σ₁₃] E₃).symm c = e₁.symm(e₂.symm c) := rfl
+  (e₁.trans e₂ : E ≃ₛₗᵢ[σ₁₃] E₃).symm c = e₁.symm (e₂.symm c) := rfl
 
 @[simp] lemma to_linear_equiv_trans (e' : E₂ ≃ₛₗᵢ[σ₂₃] E₃) :
   (e.trans e').to_linear_equiv = e.to_linear_equiv.trans e'.to_linear_equiv :=

--- a/src/analysis/normed_space/linear_isometry.lean
+++ b/src/analysis/normed_space/linear_isometry.lean
@@ -401,9 +401,6 @@ rfl
   (e₁.trans e₂ : E ≃ₛₗᵢ[σ₁₃] E₃) c = e₂ (e₁ c) :=
 rfl
 
-@[simp] lemma symm_trans_apply (e₁ : E ≃ₛₗᵢ[σ₁₂] E₂) (e₂ : E₂ ≃ₛₗᵢ[σ₂₃] E₃) (c : E₃) :
-  (e₁.trans e₂ : E ≃ₛₗᵢ[σ₁₃] E₃).symm c = e₁.symm (e₂.symm c) := rfl
-
 @[simp] lemma to_linear_equiv_trans (e' : E₂ ≃ₛₗᵢ[σ₂₃] E₃) :
   (e.trans e').to_linear_equiv = e.to_linear_equiv.trans e'.to_linear_equiv :=
 rfl

--- a/src/analysis/normed_space/linear_isometry.lean
+++ b/src/analysis/normed_space/linear_isometry.lean
@@ -398,7 +398,7 @@ include σ₁₃ σ₂₁
 rfl
 
 @[simp] lemma trans_apply (e₁ : E ≃ₛₗᵢ[σ₁₂] E₂) (e₂ : E₂ ≃ₛₗᵢ[σ₂₃] E₃) (c : E) :
-  (e₁.trans e₂ : E ≃ₛₗᵢ[σ₁₃] E₃) (c) = e₂ (e₁ (c)) :=
+  (e₁.trans e₂ : E ≃ₛₗᵢ[σ₁₃] E₃) c = e₂ (e₁ c) :=
 rfl
 
 @[simp] lemma symm_trans_apply (e₁ : E ≃ₛₗᵢ[σ₁₂] E₂) (e₂ : E₂ ≃ₛₗᵢ[σ₂₃] E₃) (c : E₃) :


### PR DESCRIPTION
Added two API lemmas to `linear_isometry_equiv` that I need elsewhere.

---
Maybe these aren't necessary, but we have them for `linear_equiv`, so this feels reasonable.

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
