### PR TITLE
[Merged by Bors] - feat(algebra/algebra/spectrum): add spectral mapping for inverses

### DIFF
--- a/src/algebra/algebra/spectrum.lean
+++ b/src/algebra/algebra/spectrum.lean
@@ -68,16 +68,6 @@ variable {R}
 noncomputable def resolvent (a : A) (r : R) : A :=
 ring.inverse (algebra_map R A r - a)
 
-/-- The unit `1 - r⁻¹ • a` constructed from `r • 1 - a` when the latter is a unit. -/
-@[simps]
-def units.sub_inv_smul {r : Rˣ} {a : A}
-  {u : Aˣ} (h : (u : A) = r • 1 - a) : Aˣ :=
-{ val := 1 - r⁻¹ • a,
-  inv := r • ↑u⁻¹,
-  val_inv := by { rw [mul_smul_comm, ←smul_mul_assoc, smul_sub, smul_inv_smul, ←h],
-                  exact u.val_inv },
-  inv_val := by { rw [smul_mul_assoc, ←mul_smul_comm, smul_sub, smul_inv_smul, ←h],
-                  exact u.inv_val } }
 
 end defs
 
@@ -125,26 +115,6 @@ iff.rfl
 lemma resolvent_eq {a : A} {r : R} (h : r ∈ resolvent_set R a) :
   resolvent a r = ↑h.unit⁻¹ :=
 ring.inverse_unit h.unit
-
-lemma smul_resolvent_self {r : Rˣ} {a : A} :
-  r • resolvent a (r : R) = resolvent (r⁻¹ • a) (1 : R) :=
-begin
-  by_cases h : (r : R) ∈ spectrum R a,
-  { rw [mem_iff] at h,
-    simp only [resolvent, algebra.algebra_map_eq_smul_one, ←units.smul_def, one_smul] at *,
-    have h' := (not_iff_not.mpr is_unit.smul_sub_iff_sub_inv_smul).mp h,
-    simp only [ring.inverse_non_unit _ h, ring.inverse_non_unit _ h', smul_zero] },
-  { rw not_mem_iff at h,
-    simp only [resolvent, algebra.algebra_map_eq_smul_one, ←units.smul_def, one_smul] at *,
-    rcases h with ⟨u, hu⟩,
-    rw [←hu, ←units.coe_sub_inv_smul hu, ring.inverse_unit, ←units.coe_inv_sub_inv_smul hu,
-      ring.inverse_unit] },
-end
-
-/-- The resolvent is a unit when the argument is in the resolvent set. -/
-lemma is_unit_resolvent {r : R} {a : A} (h : r ∈ resolvent_set R a) :
-  is_unit (resolvent a r) :=
-(resolvent_eq h).symm ▸ ⟨⟨(h.unit⁻¹ : Aˣ), h.unit, _, _⟩, rfl⟩
 
 lemma inv_mem_resolvent_set {r : Rˣ} {a : Aˣ} (h : (r : R) ∈ resolvent_set R (a : A)) :
   (↑r⁻¹ : R) ∈ resolvent_set R (↑a⁻¹ : A) :=

--- a/src/algebra/algebra/spectrum.lean
+++ b/src/algebra/algebra/spectrum.lean
@@ -129,18 +129,18 @@ begin
   exact (hcomm.is_unit_mul_iff.mp (h₁.symm ▸ h)).2,
 end
 
-lemma inv_mem_spectrum_iff {r : Rˣ} {a : Aˣ} :
+lemma inv_mem_iff {r : Rˣ} {a : Aˣ} :
   (r : R) ∈ σ (a : A) ↔ (↑r⁻¹ : R) ∈ σ (↑a⁻¹ : A) :=
 begin
   simp only [mem_iff, not_iff_not, ←mem_resolvent_set_iff],
   exact ⟨λ h, inv_mem_resolvent_set h, λ h, by simpa using inv_mem_resolvent_set h⟩,
 end
 
-lemma zero_not_mem_resolvent_set_of_unit (a : Aˣ) : 0 ∈ resolvent_set R (a : A) :=
+lemma zero_mem_resolvent_set_of_unit (a : Aˣ) : 0 ∈ resolvent_set R (a : A) :=
 by { rw [mem_resolvent_set_iff, is_unit.sub_iff], simp }
 
-lemma not_eq_zero_of_mem_of_unit {a : Aˣ} {r : R} (hr : r ∈ σ (a : A)) : r ≠ 0 :=
-λ hn, (hn ▸ hr) (zero_not_mem_resolvent_set_of_unit a)
+lemma ne_zero_of_mem_of_unit {a : Aˣ} {r : R} (hr : r ∈ σ (a : A)) : r ≠ 0 :=
+λ hn, (hn ▸ hr) (zero_mem_resolvent_set_of_unit a)
 
 lemma add_mem_iff {a : A} {r s : R} :
   r ∈ σ a ↔ r + s ∈ σ (↑ₐs + a) :=
@@ -270,17 +270,17 @@ begin
     exact ⟨unit_mem_mul_iff_mem_swap_mul.mp k_mem, k_neq⟩ },
 end
 
-lemma map_inv (a : Aˣ) : (σ (a : A))⁻¹ = σ (↑a⁻¹ : A) :=
+protected lemma map_inv (a : Aˣ) : (σ (a : A))⁻¹ = σ (↑a⁻¹ : A) :=
 begin
   refine set.eq_of_subset_of_subset (λ k hk, _) (λ k hk, _),
   { rw set.mem_inv at hk,
     have : k ≠ 0,
-    { simpa only [inv_inv] using inv_ne_zero (not_eq_zero_of_mem_of_unit hk), },
+    { simpa only [inv_inv] using inv_ne_zero (ne_zero_of_mem_of_unit hk), },
     lift k to 𝕜ˣ using is_unit_iff_ne_zero.mpr this,
     rw ←units.coe_inv' k at hk,
-    exact inv_mem_spectrum_iff.mp hk },
-  { lift k to 𝕜ˣ using is_unit_iff_ne_zero.mpr (not_eq_zero_of_mem_of_unit hk),
-    simpa only [units.coe_inv'] using inv_mem_spectrum_iff.mp hk, }
+    exact inv_mem_iff.mp hk },
+  { lift k to 𝕜ˣ using is_unit_iff_ne_zero.mpr (ne_zero_of_mem_of_unit hk),
+    simpa only [units.coe_inv'] using inv_mem_iff.mp hk, }
 end
 
 open polynomial

--- a/src/algebra/algebra/spectrum.lean
+++ b/src/algebra/algebra/spectrum.lean
@@ -146,6 +146,32 @@ lemma is_unit_resolvent {r : R} {a : A} (h : r ∈ resolvent_set R a) :
   is_unit (resolvent a r) :=
 (resolvent_eq h).symm ▸ ⟨⟨(h.unit⁻¹ : Aˣ), h.unit, _, _⟩, rfl⟩
 
+lemma inv_mem_resolvent_set {r : Rˣ} {a : Aˣ} (h : (r : R) ∈ resolvent_set R (a : A)) :
+  (↑r⁻¹ : R) ∈ resolvent_set R (↑a⁻¹ : A) :=
+begin
+  rw [mem_resolvent_set_iff, algebra.algebra_map_eq_smul_one, ←units.smul_def] at h ⊢,
+  rw [is_unit.smul_sub_iff_sub_inv_smul, inv_inv, is_unit.sub_iff],
+  have h₁ : (a : A) * (r • (↑a⁻¹ : A) - 1) = r • 1 - a,
+  { rw [mul_sub, mul_smul_comm, a.mul_inv, mul_one], },
+  have h₂ : (r • (↑a⁻¹ : A) - 1) * a = r • 1 - a,
+  { rw [sub_mul, smul_mul_assoc, a.inv_mul, one_mul], },
+  have hcomm : commute (a : A) (r • (↑a⁻¹ : A) - 1), { rwa ←h₂ at h₁ },
+  exact (hcomm.is_unit_mul_iff.mp (h₁.symm ▸ h)).2,
+end
+
+lemma inv_mem_spectrum_iff {r : Rˣ} {a : Aˣ} :
+  (r : R) ∈ σ (a : A) ↔ (↑r⁻¹ : R) ∈ σ (↑a⁻¹ : A) :=
+begin
+  simp only [mem_iff, not_iff_not, ←mem_resolvent_set_iff],
+  exact ⟨λ h, inv_mem_resolvent_set h, λ h, by simpa using inv_mem_resolvent_set h⟩,
+end
+
+lemma zero_not_mem_resolvent_set_of_unit (a : Aˣ) : 0 ∈ resolvent_set R (a : A) :=
+by { rw [mem_resolvent_set_iff, is_unit.sub_iff], simp }
+
+lemma not_eq_zero_of_mem_of_unit {a : Aˣ} {r : R} (hr : r ∈ σ (a : A)) : r ≠ 0 :=
+λ hn, (hn ▸ hr) (zero_not_mem_resolvent_set_of_unit a)
+
 lemma add_mem_iff {a : A} {r s : R} :
   r ∈ σ a ↔ r + s ∈ σ (↑ₐs + a) :=
 begin
@@ -272,6 +298,19 @@ begin
   { rintros _ _ k ⟨k_mem, k_neq⟩,
     change k with ↑(units.mk0 k k_neq) at k_mem,
     exact ⟨unit_mem_mul_iff_mem_swap_mul.mp k_mem, k_neq⟩ },
+end
+
+lemma map_inv (a : Aˣ) : (σ (a : A))⁻¹ = σ (↑a⁻¹ : A) :=
+begin
+  refine set.eq_of_subset_of_subset (λ k hk, _) (λ k hk, _),
+  { rw set.mem_inv at hk,
+    have : k ≠ 0,
+    { simpa only [inv_inv] using inv_ne_zero (not_eq_zero_of_mem_of_unit hk), },
+    lift k to 𝕜ˣ using is_unit_iff_ne_zero.mpr this,
+    rw ←units.coe_inv' k at hk,
+    exact inv_mem_spectrum_iff.mp hk },
+  { lift k to 𝕜ˣ using is_unit_iff_ne_zero.mpr (not_eq_zero_of_mem_of_unit hk),
+    simpa only [units.coe_inv'] using inv_mem_spectrum_iff.mp hk, }
 end
 
 open polynomial


### PR DESCRIPTION
Given a unit `a` in an algebra `A` over a field `𝕜`, the equality `(spectrum 𝕜 a)⁻¹ = spectrum 𝕜 a⁻¹` holds.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
