### PR TITLE
[Merged by Bors] - feat(set_theory/cardinal): add three_le

### DIFF
--- a/src/data/finset/card.lean
+++ b/src/data/finset/card.lean
@@ -308,7 +308,7 @@ lemma card_sdiff (h : s ⊆ t) : card (t \ s) = t.card - s.card :=
 suffices card (t \ s) = card ((t \ s) ∪ s) - s.card, by rwa sdiff_union_of_subset h at this,
 by rw [card_disjoint_union sdiff_disjoint, add_tsub_cancel_right]
 
-lemma card_sdiff_le (s t : finset α) : t.card - s.card ≤ card (t \ s) :=
+lemma le_card_sdiff (s t : finset α) : t.card - s.card ≤ card (t \ s) :=
 calc card t - card s
       ≤ card t - card (s ∩ t) : tsub_le_tsub_left (card_le_of_subset (inter_subset_left s t)) _
   ... = card (t \ (s ∩ t)) : (card_sdiff (inter_subset_right s t)).symm

--- a/src/data/finset/card.lean
+++ b/src/data/finset/card.lean
@@ -308,10 +308,11 @@ lemma card_sdiff (h : s ⊆ t) : card (t \ s) = t.card - s.card :=
 suffices card (t \ s) = card ((t \ s) ∪ s) - s.card, by rwa sdiff_union_of_subset h at this,
 by rw [card_disjoint_union sdiff_disjoint, add_tsub_cancel_right]
 
-lemma card_sdiff_ge (s t : finset α)  : card (t \ s) ≥ t.card - s.card :=
-calc card (t \ s) = card (t \ (s ∩ t)) : by rw sdiff_inter_self_right t s
-  ... = card t - card (s ∩ t) : card_sdiff (inter_subset_right s t)
-  ... ≥ card t - card s : tsub_le_tsub_left (card_le_of_subset (inter_subset_left s t)) _
+lemma card_sdiff_le (s t : finset α) : t.card - s.card ≤ card (t \ s) :=
+calc card t - card s
+      ≤ card t - card (s ∩ t) : tsub_le_tsub_left (card_le_of_subset (inter_subset_left s t)) _
+  ... = card (t \ (s ∩ t)) : (card_sdiff (inter_subset_right s t)).symm
+  ... ≤ card (t \ s) : by rw sdiff_inter_self_right t s
 
 lemma card_sdiff_add_card : (s \ t).card + t.card = (s ∪ t).card :=
 by rw [←card_disjoint_union sdiff_disjoint, sdiff_union_self_eq_union]

--- a/src/data/finset/card.lean
+++ b/src/data/finset/card.lean
@@ -308,6 +308,11 @@ lemma card_sdiff (h : s ⊆ t) : card (t \ s) = t.card - s.card :=
 suffices card (t \ s) = card ((t \ s) ∪ s) - s.card, by rwa sdiff_union_of_subset h at this,
 by rw [card_disjoint_union sdiff_disjoint, add_tsub_cancel_right]
 
+lemma card_sdiff_ge (s t : finset α)  : card (t \ s) ≥ t.card - s.card :=
+calc card (t \ s) = card (t \ (s ∩ t)) : by rw sdiff_inter_self_right t s
+  ... = card t - card (s ∩ t) : card_sdiff (inter_subset_right s t)
+  ... ≥ card t - card s : tsub_le_tsub_left (card_le_of_subset (inter_subset_left s t)) _
+
 lemma card_sdiff_add_card : (s \ t).card + t.card = (s ∪ t).card :=
 by rw [←card_disjoint_union sdiff_disjoint, sdiff_union_self_eq_union]
 

--- a/src/set_theory/cardinal.lean
+++ b/src/set_theory/cardinal.lean
@@ -1112,24 +1112,6 @@ lemma mk_int : #ℤ = ω := mk_denumerable ℤ
 
 lemma mk_pnat : #ℕ+ = ω := mk_denumerable ℕ+
 
-lemma two_le_iff : (2 : cardinal) ≤ #α ↔ ∃x y : α, x ≠ y :=
-begin
-  split,
-  { rintro ⟨f⟩, refine ⟨f $ sum.inl ⟨⟩, f $ sum.inr ⟨⟩, _⟩, intro h, cases f.2 h },
-  { rintro ⟨x, y, h⟩, by_contra h',
-    rw [not_le, ←nat.cast_two, nat_succ, lt_succ, nat.cast_one, le_one_iff_subsingleton] at h',
-    apply h, exactI subsingleton.elim _ _ }
-end
-
-lemma two_le_iff' (x : α) : (2 : cardinal) ≤ #α ↔ ∃y : α, x ≠ y :=
-begin
-  rw [two_le_iff],
-  split,
-  { rintro ⟨y, z, h⟩, refine classical.by_cases (λ(h' : x = y), _) (λ h', ⟨y, h'⟩),
-    rw [←h'] at h, exact ⟨z, h⟩ },
-  { rintro ⟨y, h⟩, exact ⟨x, y, h⟩ }
-end
-
 /-- **König's theorem** -/
 theorem sum_lt_prod {ι} (f g : ι → cardinal) (H : ∀ i, f i < g i) : sum f < prod g :=
 lt_of_not_ge $ λ ⟨F⟩, begin
@@ -1362,6 +1344,24 @@ theorem le_mk_iff_exists_subset {c : cardinal} {α : Type u} {s : set α} :
 begin
   rw [le_mk_iff_exists_set, ←subtype.exists_set_subtype],
   apply exists_congr, intro t, rw [mk_image_eq], apply subtype.val_injective
+end
+
+lemma two_le_iff : (2 : cardinal) ≤ #α ↔ ∃x y : α, x ≠ y :=
+begin
+  split,
+  { rintro ⟨f⟩, refine ⟨f $ sum.inl ⟨⟩, f $ sum.inr ⟨⟩, _⟩, intro h, cases f.2 h },
+  { rintro ⟨x, y, h⟩, by_contra h',
+    rw [not_le, ←nat.cast_two, nat_succ, lt_succ, nat.cast_one, le_one_iff_subsingleton] at h',
+    apply h, exactI subsingleton.elim _ _ }
+end
+
+lemma two_le_iff' (x : α) : (2 : cardinal) ≤ #α ↔ ∃y : α, x ≠ y :=
+begin
+  rw [two_le_iff],
+  split,
+  { rintro ⟨y, z, h⟩, refine classical.by_cases (λ(h' : x = y), _) (λ h', ⟨y, h'⟩),
+    rw [←h'] at h, exact ⟨z, h⟩ },
+  { rintro ⟨y, h⟩, exact ⟨x, y, h⟩ }
 end
 
 lemma three_le {α : Type*} (h : 3 ≤ # α) (x : α) (y : α) :

--- a/src/set_theory/cardinal.lean
+++ b/src/set_theory/cardinal.lean
@@ -1371,7 +1371,8 @@ begin
   obtain ⟨s, rfl, hs⟩ := mk_eq_nat_iff_finset.mp hs',
   have := calc
     0   < 1 : by simp
-    ... = s.card - l.length : by {rw hs, exact (norm_num.sub_nat_pos _ _ 1 rfl).symm}
+    ... = l.length.succ - l.length : (norm_num.sub_nat_pos _ _ 1 rfl).symm
+    ... = s.card - l.length : by rw hs
     ... ≤ s.card - l.to_finset.card : tsub_le_tsub_left (list.to_finset_card_le _) _
     ... ≤ (s \ l.to_finset).card : (finset.card_sdiff_ge _ _).le,
   obtain ⟨z, hz⟩ := finset.card_pos.mp this,

--- a/src/set_theory/cardinal.lean
+++ b/src/set_theory/cardinal.lean
@@ -1369,8 +1369,9 @@ lemma exists_not_mem_of_length_le {α : Type*} (l : list α) (h : ↑l.length < 
 begin
   contrapose! h,
   calc # α = # (set.univ : set α) : mk_univ.symm
-    ... ≤ # (l.to_finset : set α) : mk_le_mk_of_subset (λ x _, list.mem_to_finset.mpr (h x))
-    ... ≤ l.length : by simp [ list.to_finset_card_le ],
+    ... ≤ # l.to_finset           : mk_le_mk_of_subset (λ x _, list.mem_to_finset.mpr (h x))
+    ... = l.to_finset.card        : cardinal.mk_finset
+    ... ≤ l.length                : cardinal.nat_cast_le.mpr (list.to_finset_card_le l),
 end
 
 lemma three_le {α : Type*} (h : 3 ≤ # α) (x : α) (y : α) :

--- a/src/set_theory/cardinal.lean
+++ b/src/set_theory/cardinal.lean
@@ -1384,8 +1384,8 @@ lemma three_le {α : Type*} (h : 3 ≤ # α) (x : α) (y : α) :
   ∃ (z : α), z ≠ x ∧ z ≠ y :=
 begin
   have : ((3:nat) : cardinal) ≤ # α, simpa using h,
-  obtain ⟨z, hz⟩ := exists_not_mem_of_length_le [x, y] this,
-  use z, simpa [not_or_distrib] using hz,
+  have := exists_not_mem_of_length_le [x, y] this,
+  simpa [not_or_distrib] using this,
 end
 
 /-- The function α^{<β}, defined to be sup_{γ < β} α^γ.

--- a/src/set_theory/cardinal.lean
+++ b/src/set_theory/cardinal.lean
@@ -1364,6 +1364,23 @@ begin
   apply exists_congr, intro t, rw [mk_image_eq], apply subtype.val_injective
 end
 
+lemma three_le {α : Type*} (h : 3 ≤ # α) (x : α) (y : α) :
+  ∃ (z : α), z ≠ x ∧ z ≠ y :=
+begin
+  have : ((3:nat) : cardinal) ≤ # α, simpa using h,
+  obtain ⟨s', hs'⟩  := le_mk_iff_exists_set.mp this,
+  obtain ⟨s, rfl, hs⟩ := mk_eq_nat_iff_finset.mp hs',
+
+  have := calc
+    0   < 1 : by simp
+    ... = (s.card - 1) - 1 : by simp [ hs ]
+    ... ≤ (s.erase y).card - 1 : nat.sub_le_sub_right finset.pred_card_le_card_erase 1
+    ... ≤ ((s.erase y).erase x).card : finset.pred_card_le_card_erase,
+  obtain ⟨z, hz⟩ := finset.card_pos.mp this,
+  simp only [finset.mem_erase] at hz,
+  exact ⟨z, hz.1, hz.2.1⟩,
+end
+
 /-- The function α^{<β}, defined to be sup_{γ < β} α^γ.
   We index over {s : set β.out // #s < β } instead of {γ // γ < β}, because the latter lives in a
   higher universe -/

--- a/src/set_theory/cardinal.lean
+++ b/src/set_theory/cardinal.lean
@@ -1364,26 +1364,20 @@ begin
   { rintro ⟨y, h⟩, exact ⟨x, y, h⟩ }
 end
 
-lemma exists_not_mem_of_length_le {α : Type*} (l : list α) (h : ↑l.length.succ ≤ # α) :
+lemma exists_not_mem_of_length_le {α : Type*} (l : list α) (h : ↑l.length < # α) :
   ∃ (z : α), z ∉ l :=
 begin
-  obtain ⟨s', hs'⟩ := le_mk_iff_exists_set.mp h,
-  obtain ⟨s, rfl, hs⟩ := mk_eq_nat_iff_finset.mp hs',
-  have := calc
-    0   < 1 : by simp
-    ... = l.length.succ - l.length : (norm_num.sub_nat_pos _ _ 1 rfl).symm
-    ... = s.card - l.length : by rw hs
-    ... ≤ s.card - l.to_finset.card : tsub_le_tsub_left (list.to_finset_card_le _) _
-    ... ≤ (s \ l.to_finset).card : (finset.card_sdiff_ge _ _).le,
-  obtain ⟨z, hz⟩ := finset.card_pos.mp this,
-  simp only [finset.mem_sdiff, list.mem_to_finset] at hz,
-  exact ⟨z, hz.2⟩,
+  contrapose! h,
+  calc # α = # (set.univ : set α) : mk_univ.symm
+    ... ≤ # (l.to_finset : set α) : mk_le_mk_of_subset (λ x _, list.mem_to_finset.mpr (h x))
+    ... ≤ l.length : by simp [ list.to_finset_card_le ],
 end
 
 lemma three_le {α : Type*} (h : 3 ≤ # α) (x : α) (y : α) :
   ∃ (z : α), z ≠ x ∧ z ≠ y :=
 begin
   have : ((3:nat) : cardinal) ≤ # α, simpa using h,
+  have : ((2:nat) : cardinal) < # α, rwa [← cardinal.succ_le, ← cardinal.nat_succ],
   have := exists_not_mem_of_length_le [x, y] this,
   simpa [not_or_distrib] using this,
 end

--- a/src/set_theory/cardinal.lean
+++ b/src/set_theory/cardinal.lean
@@ -1364,21 +1364,27 @@ begin
   { rintro ⟨y, h⟩, exact ⟨x, y, h⟩ }
 end
 
+lemma exists_not_mem_of_length_le {α : Type*} (l : list α) (h : ↑l.length.succ ≤ # α) :
+  ∃ (z : α), z ∉ l :=
+begin
+  obtain ⟨s', hs'⟩ := le_mk_iff_exists_set.mp h,
+  obtain ⟨s, rfl, hs⟩ := mk_eq_nat_iff_finset.mp hs',
+  have := calc
+    0   < 1 : by simp
+    ... = s.card - l.length : by {rw hs, exact (norm_num.sub_nat_pos _ _ 1 rfl).symm}
+    ... ≤ s.card - l.to_finset.card : tsub_le_tsub_left (list.to_finset_card_le _) _
+    ... ≤ (s \ l.to_finset).card : (finset.card_sdiff_ge _ _).le,
+  obtain ⟨z, hz⟩ := finset.card_pos.mp this,
+  simp only [finset.mem_sdiff, list.mem_to_finset] at hz,
+  exact ⟨z, hz.2⟩,
+end
+
 lemma three_le {α : Type*} (h : 3 ≤ # α) (x : α) (y : α) :
   ∃ (z : α), z ≠ x ∧ z ≠ y :=
 begin
   have : ((3:nat) : cardinal) ≤ # α, simpa using h,
-  obtain ⟨s', hs'⟩  := le_mk_iff_exists_set.mp this,
-  obtain ⟨s, rfl, hs⟩ := mk_eq_nat_iff_finset.mp hs',
-
-  have := calc
-    0   < 1 : by simp
-    ... = (s.card - 1) - 1 : by simp [ hs ]
-    ... ≤ (s.erase y).card - 1 : nat.sub_le_sub_right finset.pred_card_le_card_erase 1
-    ... ≤ ((s.erase y).erase x).card : finset.pred_card_le_card_erase,
-  obtain ⟨z, hz⟩ := finset.card_pos.mp this,
-  simp only [finset.mem_erase] at hz,
-  exact ⟨z, hz.1, hz.2.1⟩,
+  obtain ⟨z, hz⟩ := exists_not_mem_of_length_le [x, y] this,
+  use z, simpa [not_or_distrib] using hz,
 end
 
 /-- The function α^{<β}, defined to be sup_{γ < β} α^γ.


### PR DESCRIPTION

---

I need this lemma in #12210. There was a discussion in zulip about generalizing this and  similar lemmas [cardinal.two_le_iff](https://leanprover-community.github.io/mathlib_docs/set_theory/cardinal.html#cardinal.two_le_iff), but for now having a non-generalized lemma is better than having none :-)

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
