### PR TITLE
[Merged by Bors] - feat(set_theory/ordinal): `Inf_empty`

### DIFF
--- a/src/set_theory/ordinal.lean
+++ b/src/set_theory/ordinal.lean
@@ -1146,6 +1146,12 @@ eq_bot_or_bot_lt
 instance : no_max_order ordinal :=
 ⟨λ a, ⟨a.succ, lt_succ_self a⟩⟩
 
+theorem Inf_empty : Inf (∅ : set ordinal) = 0 :=
+begin
+  change dite _ (wf.min ∅) (λ _, 0) = 0,
+  simp only [not_nonempty_empty, not_false_iff, dif_neg],
+end
+
 end ordinal
 
 /-! ### Representing a cardinal with an ordinal -/

--- a/src/set_theory/ordinal.lean
+++ b/src/set_theory/ordinal.lean
@@ -1149,7 +1149,7 @@ instance : no_max_order ordinal :=
 @[simp] theorem Inf_empty : Inf (∅ : set ordinal) = 0 :=
 begin
   change dite _ (wf.min ∅) (λ _, 0) = 0,
-  simp only [not_nonempty_empty, not_false_iff, dif_neg],
+  simp only [not_nonempty_empty, not_false_iff, dif_neg]
 end
 
 end ordinal

--- a/src/set_theory/ordinal.lean
+++ b/src/set_theory/ordinal.lean
@@ -1146,7 +1146,7 @@ eq_bot_or_bot_lt
 instance : no_max_order ordinal :=
 ⟨λ a, ⟨a.succ, lt_succ_self a⟩⟩
 
-theorem Inf_empty : Inf (∅ : set ordinal) = 0 :=
+@[simp] theorem Inf_empty : Inf (∅ : set ordinal) = 0 :=
 begin
   change dite _ (wf.min ∅) (λ _, 0) = 0,
   simp only [not_nonempty_empty, not_false_iff, dif_neg],


### PR DESCRIPTION
The docs mention that `Inf Ø` is defined as `0`. We prove that this is indeed the case.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
