### PR TITLE
[Merged by Bors] - feat(algebra/associated): add decidable instances

### DIFF
--- a/src/algebra/associated.lean
+++ b/src/algebra/associated.lean
@@ -635,7 +635,7 @@ iff.intro dvd_of_mk_le_mk mk_le_mk_of_dvd
 
 instance [decidable_rel ((∣) : α → α → Prop)] :
   decidable_rel ((∣) : associates α → associates α → Prop) :=
-λ a b, quotient.rec_on_subsingleton₂ a b (λ a b, decidable_of_iff _ mk_dvd_mk.symm)
+λ a b, quotient.rec_on_subsingleton₂ a b (λ a b, decidable_of_iff' _ mk_dvd_mk)
 
 lemma prime.le_or_le {p : associates α} (hp : prime p) {a b : associates α} (h : p ≤ a * b) :
   p ≤ a ∨ p ≤ b :=

--- a/src/algebra/associated.lean
+++ b/src/algebra/associated.lean
@@ -324,7 +324,7 @@ theorem dvd_dvd_iff_associated [cancel_monoid_with_zero α] {a b : α} : a ∣ b
 
 instance [cancel_monoid_with_zero α] [decidable_rel ((∣) : α → α → Prop)] :
   decidable_rel ((~ᵤ) : α → α → Prop) :=
-λ a b, decidable_of_iff _ (dvd_dvd_iff_associated)
+λ a b, decidable_of_iff _ dvd_dvd_iff_associated
 
 lemma associated.dvd_iff_dvd_left [monoid α] {a b c : α} (h : a ~ᵤ b) : a ∣ c ↔ b ∣ c :=
 let ⟨u, hu⟩ := h in hu ▸ units.mul_right_dvd.symm
@@ -445,9 +445,6 @@ open associated
 /-- The canonical quotient map from a monoid `α` into the `associates` of `α` -/
 protected def mk {α : Type*} [monoid α] (a : α) : associates α :=
 ⟦ a ⟧
-
-instance [cancel_monoid_with_zero α] [decidable_rel ((∣) : α → α → Prop)] :
-  decidable_eq (associates α) := quotient.decidable_eq
 
 instance [monoid α] : inhabited (associates α) := ⟨⟦1⟧⟩
 

--- a/src/algebra/associated.lean
+++ b/src/algebra/associated.lean
@@ -322,6 +322,10 @@ end
 theorem dvd_dvd_iff_associated [cancel_monoid_with_zero α] {a b : α} : a ∣ b ∧ b ∣ a ↔ a ~ᵤ b :=
 ⟨λ ⟨h1, h2⟩, associated_of_dvd_dvd h1 h2, associated.dvd_dvd⟩
 
+instance [cancel_monoid_with_zero α] [decidable_rel ((∣) : α → α → Prop)] :
+  decidable_rel ((~ᵤ) : α → α → Prop) :=
+λ a b, decidable_of_iff _ (dvd_dvd_iff_associated)
+
 lemma associated.dvd_iff_dvd_left [monoid α] {a b c : α} (h : a ~ᵤ b) : a ∣ c ↔ b ∣ c :=
 let ⟨u, hu⟩ := h in hu ▸ units.mul_right_dvd.symm
 
@@ -441,6 +445,9 @@ open associated
 /-- The canonical quotient map from a monoid `α` into the `associates` of `α` -/
 protected def mk {α : Type*} [monoid α] (a : α) : associates α :=
 ⟦ a ⟧
+
+instance [cancel_monoid_with_zero α] [decidable_rel ((∣) : α → α → Prop)] :
+  decidable_eq (associates α) := quotient.decidable_eq
 
 instance [monoid α] : inhabited (associates α) := ⟨⟦1⟧⟩
 
@@ -625,6 +632,10 @@ iff.intro dvd_of_mk_le_mk mk_le_mk_of_dvd
 
 theorem mk_dvd_mk {a b : α} : associates.mk a ∣ associates.mk b ↔ a ∣ b :=
 iff.intro dvd_of_mk_le_mk mk_le_mk_of_dvd
+
+instance [decidable_rel ((∣) : α → α → Prop)] :
+  decidable_rel ((∣) : associates α → associates α → Prop) :=
+λ a b, quotient.rec_on_subsingleton₂ a b (λ a b, decidable_of_iff _ mk_dvd_mk.symm)
 
 lemma prime.le_or_le {p : associates α} (hp : prime p) {a b : associates α} (h : p ≤ a * b) :
   p ≤ a ∨ p ≤ b :=


### PR DESCRIPTION
Makes equality and divisibility decidable in `associates`, given that divisibility is decidable in the general case.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)

The fact these were missing came up originally in #9345.
