### PR TITLE
[Merged by Bors] - refactor(topology/{separation,subset_properties}): use `set.subsingleton`

### DIFF
--- a/src/topology/separation.lean
+++ b/src/topology/separation.lean
@@ -1149,32 +1149,22 @@ begin
 end
 
 lemma is_preirreducible_iff_subsingleton [t2_space α] (S : set α) :
-  is_preirreducible S ↔ subsingleton S :=
+  is_preirreducible S ↔ set.subsingleton S :=
 begin
   split,
-  { intro h,
-    constructor,
-    intros x y,
-    ext,
+  { intros h x hx y hy,
     by_contradiction e,
     obtain ⟨U, V, hU, hV, hxU, hyV, h'⟩ := t2_separation e,
-    have := h U V hU hV ⟨x, x.prop, hxU⟩ ⟨y, y.prop, hyV⟩,
+    have := h U V hU hV ⟨x, hx, hxU⟩ ⟨y, hy, hyV⟩,
     rw [h', inter_empty] at this,
     exact this.some_spec },
-  { exact @@is_preirreducible_of_subsingleton _ _ }
+  { exact set.subsingleton.is_preirreducible }
 end
 
 lemma is_irreducible_iff_singleton [t2_space α] (S : set α) :
   is_irreducible S ↔ ∃ x, S = {x} :=
-begin
-  split,
-  { intro h,
-    rw exists_eq_singleton_iff_nonempty_subsingleton,
-    use h.1,
-    intros a ha b hb,
-    injection @@subsingleton.elim ((is_preirreducible_iff_subsingleton _).mp h.2) ⟨_, ha⟩ ⟨_, hb⟩ },
-  { rintro ⟨x, rfl⟩, exact is_irreducible_singleton }
-end
+by rw [is_irreducible, is_preirreducible_iff_subsingleton,
+  exists_eq_singleton_iff_nonempty_subsingleton]
 
 end separation
 

--- a/src/topology/sober.lean
+++ b/src/topology/sober.lean
@@ -311,7 +311,7 @@ begin
   constructor,
   rintro S h -,
   obtain ⟨x, rfl⟩ := (is_irreducible_iff_singleton S).mp h,
-  exact ⟨x, (t1_space.t1 x).closure_eq⟩
+  exact ⟨x, closure_singleton⟩
 end
 
 end sober

--- a/src/topology/subset_properties.lean
+++ b/src/topology/subset_properties.lean
@@ -1384,10 +1384,12 @@ lemma is_irreducible.is_preirreducible {s : set α} (h : is_irreducible s) :
 theorem is_preirreducible_empty : is_preirreducible (∅ : set α) :=
 λ _ _ _ _ _ ⟨x, h1, h2⟩, h1.elim
 
+lemma set.subsingleton.is_preirreducible {s : set α} (hs : s.subsingleton) :
+  is_preirreducible s :=
+λ u v hu hv ⟨x, hxs, hxu⟩ ⟨y, hys, hyv⟩, ⟨y, hys, hs hxs hys ▸ hxu, hyv⟩
+
 theorem is_irreducible_singleton {x} : is_irreducible ({x} : set α) :=
-⟨singleton_nonempty x,
- λ u v _ _ ⟨y, h1, h2⟩ ⟨z, h3, h4⟩, by rw mem_singleton_iff at h1 h3;
- substs y z; exact ⟨x, rfl, h2, h4⟩⟩
+⟨singleton_nonempty x, subsingleton_singleton.is_preirreducible⟩
 
 theorem is_preirreducible.closure {s : set α} (H : is_preirreducible s) :
   is_preirreducible (closure s) :=
@@ -1400,15 +1402,6 @@ let ⟨r, hrs, hruv⟩ := H u v hu hv ⟨p, hps, hpu⟩ ⟨q, hqs, hqv⟩ in
 lemma is_irreducible.closure {s : set α} (h : is_irreducible s) :
   is_irreducible (closure s) :=
 ⟨h.nonempty.closure, h.is_preirreducible.closure⟩
-
-lemma is_preirreducible_of_subsingleton (s : set α) [hs : subsingleton s] : is_preirreducible s :=
-begin
-  cases s.eq_empty_or_nonempty,
-  { exact h.symm ▸ is_preirreducible_empty },
-  { obtain ⟨x, e⟩ := exists_eq_singleton_iff_nonempty_subsingleton.mpr
-      ⟨h, λ _ ha _ hb, by injection @@subsingleton.elim hs ⟨_, ha⟩ ⟨_, hb⟩⟩,
-    exact e.symm ▸ is_irreducible_singleton.2 }
-end
 
 theorem exists_preirreducible (s : set α) (H : is_preirreducible s) :
   ∃ t : set α, is_preirreducible t ∧ s ⊆ t ∧ ∀ u, is_preirreducible u → t ⊆ u → u = t :=


### PR DESCRIPTION
Use `set.subsingleton s` instead of `_root_.subsingleton s` in `is_preirreducible_iff_subsingleton` and `is_preirreducible_of_subsingleton`, rename the latter to `set.subsingleton.is_preirreducible`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
