### PR TITLE
[Merged by Bors] - fix(analysis/normed_space/star/basic): make prop type classes props

### DIFF
--- a/src/analysis/normed_space/star/basic.lean
+++ b/src/analysis/normed_space/star/basic.lean
@@ -35,7 +35,7 @@ open_locale topological_space
 local postfix `⋆`:std.prec.max_plus := star
 
 /-- A normed star ring is a star ring endowed with a norm such that `star` is isometric. -/
-class normed_star_monoid (E : Type*) [normed_group E] [star_add_monoid E] :=
+class normed_star_monoid (E : Type*) [normed_group E] [star_add_monoid E] : Prop :=
 (norm_star : ∀ {x : E}, ∥x⋆∥ = ∥x∥)
 
 export normed_star_monoid (norm_star)
@@ -43,10 +43,10 @@ attribute [simp] norm_star
 
 /-- A C*-ring is a normed star ring that satifies the stronger condition `∥x⋆ * x∥ = ∥x∥^2`
 for every `x`. -/
-class cstar_ring (E : Type*) [normed_ring E] [star_ring E] :=
+class cstar_ring (E : Type*) [normed_ring E] [star_ring E] : Prop :=
 (norm_star_mul_self : ∀ {x : E}, ∥x⋆ * x∥ = ∥x∥ * ∥x∥)
 
-noncomputable instance : cstar_ring ℝ :=
+instance : cstar_ring ℝ :=
 { norm_star_mul_self := λ x, by simp only [star, id.def, norm_mul] }
 
 variables {𝕜 E α : Type*}


### PR DESCRIPTION
The type classes `normed_star_monoid` and `cstar_ring` are now properly declared as prop.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
