### PR TITLE
[Merged by Bors] - feat(probability/stopping): generalize `is_stopping_time.measurable_set_lt` and variants beyond `ℕ`

### DIFF
--- a/src/order/bounds.lean
+++ b/src/order/bounds.lean
@@ -386,9 +386,46 @@ lemma bdd_above_Iio : bdd_above (Iio a) := ⟨a, λ x hx, le_of_lt hx⟩
 
 lemma bdd_below_Ioi : bdd_below (Ioi a) := ⟨a, λ x hx, le_of_lt hx⟩
 
+lemma lub_Iio_le (a : α) (hb : is_lub (set.Iio a) b) : b ≤ a :=
+(is_lub_le_iff hb).mpr $ λ k hk, le_of_lt hk
+
+lemma le_glb_Ioi (a : α) (hb : is_glb (set.Ioi a) b) : a ≤ b :=
+@lub_Iio_le (order_dual α) _ _ a hb
+
+lemma lub_Iio_eq_self_or_Iio_eq_Iic [partial_order γ] {j : γ} (i : γ) (hj : is_lub (set.Iio i) j) :
+  j = i ∨ set.Iio i = set.Iic j :=
+begin
+  cases eq_or_lt_of_le (lub_Iio_le i hj) with hj_eq_i hj_lt_i,
+  { exact or.inl hj_eq_i, },
+  { right,
+    exact set.ext (λ k, ⟨λ hk_lt, hj.1 hk_lt, λ hk_le_j, lt_of_le_of_lt hk_le_j hj_lt_i⟩), },
+end
+
+lemma glb_Ioi_eq_self_or_Ioi_eq_Ici [partial_order γ] {j : γ} (i : γ) (hj : is_glb (set.Ioi i) j) :
+  j = i ∨ set.Ioi i = set.Ici j :=
+@lub_Iio_eq_self_or_Iio_eq_Iic (order_dual γ) _ j i hj
+
 section
 
-variables [linear_order γ] [densely_ordered γ]
+variables [linear_order γ]
+
+lemma exists_lub_Iio (i : γ) : ∃ j, is_lub (set.Iio i) j :=
+begin
+  by_cases h_exists_lt : ∃ j, j ∈ upper_bounds (set.Iio i) ∧ j < i,
+  { obtain ⟨j, hj_ub, hj_lt_i⟩ := h_exists_lt,
+    exact ⟨j, hj_ub, λ k hk_ub, hk_ub hj_lt_i⟩, },
+  { refine ⟨i, λ j hj, le_of_lt hj, _⟩,
+    rw mem_lower_bounds,
+    by_contra,
+    refine h_exists_lt _,
+    push_neg at h,
+    exact h, },
+end
+
+lemma exists_glb_Ioi (i : γ) : ∃ j, is_glb (set.Ioi i) j :=
+@exists_lub_Iio (order_dual γ) _ i
+
+variables [densely_ordered γ]
 
 lemma is_lub_Iio {a : γ} : is_lub (Iio a) a :=
 ⟨λ x hx, le_of_lt hx, λ y hy, le_of_forall_ge_of_dense hy⟩

--- a/src/probability/stopping.lean
+++ b/src/probability/stopping.lean
@@ -372,13 +372,11 @@ begin
   exact (hτ.measurable_set_le i).inter (hτ.measurable_set_ge i),
 end
 
-lemma is_stopping_time.measurable_set_eq_le
-  {f : filtration ℕ m} {τ : α → ℕ} (hτ : is_stopping_time f τ) {i j : ℕ} (hle : i ≤ j) :
+lemma is_stopping_time.measurable_set_eq_le (hτ : is_stopping_time f τ) {i j : ι} (hle : i ≤ j) :
   measurable_set[f j] {x | τ x = i} :=
 f.mono hle _ $ hτ.measurable_set_eq i
 
-lemma is_stopping_time.measurable_set_lt_le
-  (hτ : is_stopping_time f τ) {i j : ι} (hle : i ≤ j) :
+lemma is_stopping_time.measurable_set_lt_le (hτ : is_stopping_time f τ) {i j : ι} (hle : i ≤ j) :
   measurable_set[f j] {x | τ x < i} :=
 f.mono hle _ $ hτ.measurable_set_lt i
 

--- a/src/probability/stopping.lean
+++ b/src/probability/stopping.lean
@@ -5,6 +5,7 @@ Authors: Kexing Ying
 -/
 import measure_theory.constructions.borel_space
 import measure_theory.function.l1_space
+import topology.instances.discrete
 
 /-!
 # Filtration and stopping time
@@ -31,10 +32,12 @@ filtration, stopping time, stochastic process
 
 -/
 
-open topological_space
+open topological_space filter
 open_locale classical measure_theory nnreal ennreal topological_space big_operators
 
 namespace measure_theory
+
+/-! ### Filtrations -/
 
 /-- A `filtration` on measurable space `α` with σ-algebra `m` is a monotone
 sequence of sub-σ-algebras of `m`. -/
@@ -58,17 +61,22 @@ protected lemma le (f : filtration ι m) (i : ι) : f i ≤ m := f.le' i
 @[ext] protected lemma ext {f g : filtration ι m} (h : (f : ι → measurable_space α) = g) : f = g :=
 by { cases f, cases g, simp only, exact h, }
 
+variable (ι)
 /-- The constant filtration which is equal to `m` for all `i : ι`. -/
 def const (m' : measurable_space α) (hm' : m' ≤ m) : filtration ι m :=
 ⟨λ _, m', monotone_const, λ _, hm'⟩
+variable {ι}
 
-instance : inhabited (filtration ι m) := ⟨const m le_rfl⟩
+@[simp]
+lemma const_apply {m' : measurable_space α} {hm' : m' ≤ m} (i : ι) : const ι m' hm' i = m' := rfl
+
+instance : inhabited (filtration ι m) := ⟨const ι m le_rfl⟩
 
 instance : has_le (filtration ι m) := ⟨λ f g, ∀ i, f i ≤ g i⟩
 
-instance : has_bot (filtration ι m) := ⟨const ⊥ bot_le⟩
+instance : has_bot (filtration ι m) := ⟨const ι ⊥ bot_le⟩
 
-instance : has_top (filtration ι m) := ⟨const m le_rfl⟩
+instance : has_top (filtration ι m) := ⟨const ι m le_rfl⟩
 
 instance : has_sup (filtration ι m) := ⟨λ f g,
 { seq   := λ i, f i ⊔ g i,
@@ -179,24 +187,22 @@ instance : complete_lattice (filtration ι m) :=
 
 end filtration
 
-section preorder
-variables [preorder ι]
-
-lemma measurable_set_of_filtration {f : filtration ι m} {s : set α} {i : ι}
+lemma measurable_set_of_filtration [preorder ι] {f : filtration ι m} {s : set α} {i : ι}
   (hs : measurable_set[f i] s) : measurable_set[m] s :=
 f.le i s hs
 
 /-- A measure is σ-finite with respect to filtration if it is σ-finite with respect
 to all the sub-σ-algebra of the filtration. -/
-class sigma_finite_filtration (μ : measure α) (f : filtration ι m) : Prop :=
+class sigma_finite_filtration [preorder ι] (μ : measure α) (f : filtration ι m) : Prop :=
 (sigma_finite : ∀ i : ι, sigma_finite (μ.trim (f.le i)))
 
-instance sigma_finite_of_sigma_finite_filtration (μ : measure α) (f : filtration ι m)
+instance sigma_finite_of_sigma_finite_filtration [preorder ι] (μ : measure α) (f : filtration ι m)
   [hf : sigma_finite_filtration μ f] (i : ι) :
   sigma_finite (μ.trim (f.le i)) :=
 by apply hf.sigma_finite -- can't exact here
 
-variable [measurable_space β]
+section adapted
+variables [measurable_space β] [preorder ι]
 
 /-- A sequence of functions `u` is adapted to a filtration `f` if for all `i`,
 `u i` is `f i`-measurable. -/
@@ -224,9 +230,12 @@ variable (β)
 lemma adapted_zero [has_zero β] (f : filtration ι m) : adapted f (0 : ι → α → β) :=
 λ i, @measurable_zero β α (f i) _ _
 
-variable {β}
+end adapted
 
 namespace filtration
+variables {mβ : measurable_space β} [preorder ι]
+
+include mβ
 
 /-- Given a sequence of functions, the natural filtration is the smallest sequence
 of σ-algebras such that that sequence of functions is measurable with respect to
@@ -242,49 +251,125 @@ lemma adapted_natural {u : ι → α → β} (hum : ∀ i, measurable[m] (u i)) 
 
 end filtration
 
+/-! ### Stopping times -/
+
 /-- A stopping time with respect to some filtration `f` is a function
 `τ` such that for all `i`, the preimage of `{j | j ≤ i}` along `τ` is measurable
 with respect to `f i`.
 
 Intuitively, the stopping time `τ` describes some stopping rule such that at time
 `i`, we may determine it with the information we have at time `i`. -/
-def is_stopping_time (f : filtration ι m) (τ : α → ι) :=
+def is_stopping_time [preorder ι] (f : filtration ι m) (τ : α → ι) :=
 ∀ i : ι, measurable_set[f i] $ {x | τ x ≤ i}
 
-variables {f : filtration ℕ m} {τ : α → ℕ}
+lemma is_stopping_time_const [preorder ι] {f : filtration ι m} (i : ι) :
+  is_stopping_time f (λ x, i) :=
+λ j, by simp only [measurable_set.const]
 
-lemma is_stopping_time.measurable_set_le (hτ : is_stopping_time f τ) (i : ℕ) :
+section measurable_set
+
+section preorder
+variables [preorder ι] {f : filtration ι m} {τ : α → ι}
+
+lemma is_stopping_time.measurable_set_le (hτ : is_stopping_time f τ) (i : ι) :
   measurable_set[f i] {x | τ x ≤ i} :=
 hτ i
 
-lemma is_stopping_time.measurable_set_eq (hτ : is_stopping_time f τ) (i : ℕ) :
-  measurable_set[f i] {x | τ x = i} :=
+lemma is_stopping_time.measurable_set_lt_of_pred [pred_order ι]
+  (hτ : is_stopping_time f τ) (i : ι) :
+  measurable_set[f i] {x | τ x < i} :=
 begin
-  cases i,
-  { convert (hτ 0),
-    simp only [set.set_of_eq_eq_singleton, le_zero_iff] },
-  { rw (_ : {x | τ x = i + 1} = {x | τ x ≤ i + 1} \ {x | τ x ≤ i}),
-    { exact (hτ (i + 1)).diff (f.mono (nat.le_succ _) _ (hτ i)) },
-    { ext, simp only [set.mem_diff, not_le, set.mem_set_of_eq],
-      split,
-      { intro h, simp [h] },
-      { rintro ⟨h₁, h₂⟩,
-        linarith } } }
+  by_cases hi_min : is_min i,
+  { suffices : {x : α | τ x < i} = ∅, by { rw this, exact @measurable_set.empty _ (f i), },
+    ext1 x,
+    simp only [set.mem_set_of_eq, set.mem_empty_eq, iff_false],
+    rw is_min_iff_forall_not_lt at hi_min,
+    exact hi_min (τ x), },
+  have : {x : α | τ x < i} = τ ⁻¹' (set.Iio i),
+  { ext1 x, simp only [set.mem_set_of_eq, set.mem_preimage, set.mem_Iio], },
+  rw [this, pred_order.Iio_eq_Iic_pred' hi_min],
+  have : τ ⁻¹' set.Iic (pred_order.pred i) = {x : α | τ x ≤ pred_order.pred i},
+  { ext1 x, simp only [set.mem_preimage, set.mem_Iic, set.mem_set_of_eq], },
+  rw this,
+  exact f.mono (pred_order.pred_le i) _ (hτ.measurable_set_le (pred_order.pred i)),
 end
 
-lemma is_stopping_time.measurable_set_ge (hτ : is_stopping_time f τ) (i : ℕ) :
+end preorder
+
+section linear_order
+variables [linear_order ι] {f : filtration ι m} {τ : α → ι}
+
+lemma is_stopping_time.measurable_set_gt (hτ : is_stopping_time f τ) (i : ι) :
+  measurable_set[f i] {x | i < τ x} :=
+begin
+  have : {x | i < τ x} = {x | τ x ≤ i}ᶜ,
+  { ext1 x, simp only [set.mem_set_of_eq, set.mem_compl_eq, not_le], },
+  rw this,
+  exact (hτ.measurable_set_le i).compl,
+end
+
+variables [topological_space ι] [order_topology ι] [first_countable_topology ι]
+
+/-- Auxiliary lemma for `is_stopping_time.measurable_set_lt`. -/
+lemma is_stopping_time.measurable_set_lt_of_is_lub
+  (hτ : is_stopping_time f τ) (i : ι) (h_lub : is_lub (set.Iio i) i) :
+  measurable_set[f i] {x | τ x < i} :=
+begin
+  by_cases hi_min : is_min i,
+  { suffices : {x : α | τ x < i} = ∅, by { rw this, exact @measurable_set.empty _ (f i), },
+    ext1 x,
+    simp only [set.mem_set_of_eq, set.mem_empty_eq, iff_false],
+    exact is_min_iff_forall_not_lt.mp hi_min (τ x), },
+  obtain ⟨seq, -, -, h_tendsto, h_bound⟩ : ∃ seq : ℕ → ι,
+      monotone seq ∧ (∀ j, seq j ≤ i) ∧ tendsto seq at_top (𝓝 i) ∧ (∀ j, seq j < i),
+    from h_lub.exists_seq_monotone_tendsto (not_is_min_iff.mp hi_min),
+  have h_Ioi_eq_Union : set.Iio i = ⋃ j, { k | k ≤ seq j},
+  { ext1 k,
+    simp only [set.mem_Iio, set.mem_Union, set.mem_set_of_eq],
+    refine ⟨λ hk_lt_i, _, λ h_exists_k_le_seq, _⟩,
+    { rw tendsto_at_top' at h_tendsto,
+      have h_nhds : set.Ici k ∈ 𝓝 i,
+        from mem_nhds_iff.mpr ⟨set.Ioi k, set.Ioi_subset_Ici le_rfl, is_open_Ioi, hk_lt_i⟩,
+      obtain ⟨a, ha⟩ : ∃ (a : ℕ), ∀ (b : ℕ), b ≥ a → k ≤ seq b := h_tendsto (set.Ici k) h_nhds,
+      exact ⟨a, ha a le_rfl⟩, },
+    { obtain ⟨j, hk_seq_j⟩ := h_exists_k_le_seq,
+      exact hk_seq_j.trans_lt (h_bound j), }, },
+  have h_lt_eq_preimage : {x : α | τ x < i} = τ ⁻¹' (set.Iio i),
+  { ext1 x, simp only [set.mem_set_of_eq, set.mem_preimage, set.mem_Iio], },
+  rw [h_lt_eq_preimage, h_Ioi_eq_Union],
+  simp only [set.preimage_Union, set.preimage_set_of_eq],
+  exact measurable_set.Union
+    (λ n, f.mono (h_bound n).le _ (hτ.measurable_set_le (seq n))),
+end
+
+lemma is_stopping_time.measurable_set_lt (hτ : is_stopping_time f τ) (i : ι) :
+  measurable_set[f i] {x | τ x < i} :=
+begin
+  obtain ⟨i', hi'_lub⟩ : ∃ i', is_lub (set.Iio i) i', from exists_lub_Iio i,
+  cases lub_Iio_eq_self_or_Iio_eq_Iic i hi'_lub with hi'_eq_i h_Iio_eq_Iic,
+  { rw ← hi'_eq_i at hi'_lub ⊢,
+    exact hτ.measurable_set_lt_of_is_lub i' hi'_lub, },
+  { have h_lt_eq_preimage : {x : α | τ x < i} = τ ⁻¹' (set.Iio i) := rfl,
+    rw [h_lt_eq_preimage, h_Iio_eq_Iic],
+    exact f.mono (lub_Iio_le i hi'_lub) _ (hτ.measurable_set_le i'), },
+end
+
+lemma is_stopping_time.measurable_set_ge (hτ : is_stopping_time f τ) (i : ι) :
   measurable_set[f i] {x | i ≤ τ x} :=
 begin
-  have : {a : α | i ≤ τ a} = (set.univ \ {a | τ a ≤ i}) ∪ {a | τ a = i},
-  { ext1 a,
-    simp only [true_and, set.mem_univ, set.mem_diff, not_le, set.mem_union_eq,
-      set.mem_set_of_eq],
-    rw le_iff_lt_or_eq,
-    by_cases h : τ a = i,
-    { simp [h], },
-    { simp only [h, ne.symm h, or_false, or_iff_left_iff_imp], }, },
+  have : {x | i ≤ τ x} = {x | τ x < i}ᶜ,
+  { ext1 x, simp only [set.mem_set_of_eq, set.mem_compl_eq, not_lt], },
   rw this,
-  exact (measurable_set.univ.diff (hτ i)).union (hτ.measurable_set_eq i),
+  exact (hτ.measurable_set_lt i).compl,
+end
+
+lemma is_stopping_time.measurable_set_eq (hτ : is_stopping_time f τ) (i : ι) :
+  measurable_set[f i] {x | τ x = i} :=
+begin
+  have : {x | τ x = i} = {x | τ x ≤ i} ∩ {x | τ x ≥ i},
+  { ext1 x, simp only [set.mem_set_of_eq, ge_iff_le, set.mem_inter_eq, le_antisymm_iff], },
+  rw this,
+  exact (hτ.measurable_set_le i).inter (hτ.measurable_set_ge i),
 end
 
 lemma is_stopping_time.measurable_set_eq_le
@@ -292,22 +377,17 @@ lemma is_stopping_time.measurable_set_eq_le
   measurable_set[f j] {x | τ x = i} :=
 f.mono hle _ $ hτ.measurable_set_eq i
 
-lemma is_stopping_time.measurable_set_lt (hτ : is_stopping_time f τ) (i : ℕ) :
-  measurable_set[f i] {x | τ x < i} :=
-begin
-  convert (hτ i).diff (hτ.measurable_set_eq i),
-  ext,
-  change τ x < i ↔ τ x ≤ i ∧ τ x ≠ i,
-  rw lt_iff_le_and_ne,
-end
-
 lemma is_stopping_time.measurable_set_lt_le
-  (hτ : is_stopping_time f τ) {i j : ℕ} (hle : i ≤ j) :
+  (hτ : is_stopping_time f τ) {i j : ι} (hle : i ≤ j) :
   measurable_set[f j] {x | τ x < i} :=
 f.mono hle _ $ hτ.measurable_set_lt i
 
-lemma is_stopping_time_of_measurable_set_eq
-  {f : filtration ℕ m} {τ : α → ℕ} (hτ : ∀ i, measurable_set[f i] {x | τ x = i}) :
+end linear_order
+
+section encodable
+
+lemma is_stopping_time_of_measurable_set_eq [preorder ι] [encodable ι]
+  {f : filtration ι m} {τ : α → ι} (hτ : ∀ i, measurable_set[f i] {x | τ x = i}) :
   is_stopping_time f τ :=
 begin
   intro i,
@@ -316,11 +396,9 @@ begin
   exact f.mono hk _ (hτ k),
 end
 
-lemma is_stopping_time_const {f : filtration ι m} (i : ι) :
-  is_stopping_time f (λ x, i) :=
-λ j, by simp
+end encodable
 
-end preorder
+end measurable_set
 
 namespace is_stopping_time
 
@@ -342,8 +420,7 @@ begin
   exact (hτ i).union (hπ i),
 end
 
-lemma add_const
-  [add_group ι] [preorder ι] [covariant_class ι ι (function.swap (+)) (≤)]
+lemma add_const [add_group ι] [preorder ι] [covariant_class ι ι (function.swap (+)) (≤)]
   [covariant_class ι ι (+) (≤)]
   {f : filtration ι m} {τ : α → ι} (hτ : is_stopping_time f τ) {i : ι} (hi : 0 ≤ i) :
   is_stopping_time f (λ x, τ x + i) :=
@@ -462,6 +539,8 @@ end linear_order
 end is_stopping_time
 
 section linear_order
+
+/-! ## Stopped value and stopped process -/
 
 /-- Given a map `u : ι → α → E`, its stopped value with respect to the stopping
 time `τ` is the map `x ↦ u (τ x) x`. -/


### PR DESCRIPTION
The lemma `is_stopping_time.measurable_set_lt` and the similar results for gt, ge and eq were written for stopping times with value in nat. We generalize those results to linear orders with the order topology.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
