### PR TITLE
[Merged by Bors] - feat(analysis/normed_space/star/spectrum): prove the spectral radius of a star normal element is its norm

### DIFF
--- a/src/analysis/normed_space/star/spectrum.lean
+++ b/src/analysis/normed_space/star/spectrum.lean
@@ -59,10 +59,6 @@ begin
   simp,
 end
 
-lemma self_adjoint.coe_spectral_radius_eq_nnnorm (a : self_adjoint A) :
-  spectral_radius ℂ (a : A) = ∥(a : A)∥₊ :=
-spectral_radius_eq_nnnorm_of_self_adjoint a.property
-
 lemma spectral_radius_eq_nnnorm_of_star_normal (a : A) [is_star_normal a] :
   spectral_radius ℂ a = ∥a∥₊ :=
 begin

--- a/src/analysis/normed_space/star/spectrum.lean
+++ b/src/analysis/normed_space/star/spectrum.lean
@@ -10,8 +10,10 @@ import analysis.normed_space.spectrum
 In this file, we establish various propreties related to the spectrum of elements in C⋆-algebras.
 -/
 
+local postfix `⋆`:std.prec.max_plus := star
+
 open_locale topological_space ennreal
-open filter ennreal spectrum
+open filter ennreal spectrum cstar_ring
 
 section unitary_spectrum
 
@@ -60,5 +62,23 @@ end
 lemma self_adjoint.coe_spectral_radius_eq_nnnorm (a : self_adjoint A) :
   spectral_radius ℂ (a : A) = ∥(a : A)∥₊ :=
 spectral_radius_eq_nnnorm_of_self_adjoint a.property
+
+lemma spectral_radius_eq_nnnorm_of_star_normal (a : A) [is_star_normal a] :
+  spectral_radius ℂ a = ∥a∥₊ :=
+begin
+  refine (ennreal.pow_strict_mono (by linarith : 2 ≠ 0)).injective _,
+  have ha : a⋆ * a ∈ self_adjoint A,
+    from self_adjoint.mem_iff.mpr (by simpa only [star_star] using (star_mul a⋆ a)),
+  have heq : (λ n : ℕ, ((∥(a⋆ * a) ^ n∥₊ ^ (1 / n : ℝ)) : ℝ≥0∞))
+    = (λ x, x ^ 2) ∘ (λ n : ℕ, ((∥a ^ n∥₊ ^ (1 / n : ℝ)) : ℝ≥0∞)),
+  { funext,
+    rw [function.comp_apply, ←rpow_nat_cast, ←rpow_mul, mul_comm, rpow_mul, rpow_nat_cast,
+      ←coe_pow, sq, ←nnnorm_star_mul_self, (star_comm_self a).mul_pow, star_pow], },
+  have h₂ := ((ennreal.continuous_pow 2).tendsto (spectral_radius ℂ a)).comp
+    (spectrum.pow_nnnorm_pow_one_div_tendsto_nhds_spectral_radius a),
+  rw ←heq at h₂,
+  convert tendsto_nhds_unique h₂ (pow_nnnorm_pow_one_div_tendsto_nhds_spectral_radius (a⋆ * a)),
+  rw [spectral_radius_eq_nnnorm_of_self_adjoint ha, sq, nnnorm_star_mul_self, coe_mul],
+end
 
 end complex_scalars

--- a/src/analysis/normed_space/star/spectrum.lean
+++ b/src/analysis/normed_space/star/spectrum.lean
@@ -73,7 +73,7 @@ begin
     = (λ x, x ^ 2) ∘ (λ n : ℕ, ((∥a ^ n∥₊ ^ (1 / n : ℝ)) : ℝ≥0∞)),
   { funext,
     rw [function.comp_apply, ←rpow_nat_cast, ←rpow_mul, mul_comm, rpow_mul, rpow_nat_cast,
-      ←coe_pow, sq, ←nnnorm_star_mul_self, (star_comm_self a).mul_pow, star_pow], },
+      ←coe_pow, sq, ←nnnorm_star_mul_self, commute.mul_pow (star_comm_self' a), star_pow], },
   have h₂ := ((ennreal.continuous_pow 2).tendsto (spectral_radius ℂ a)).comp
     (spectrum.pow_nnnorm_pow_one_div_tendsto_nhds_spectral_radius a),
   rw ←heq at h₂,


### PR DESCRIPTION
In a C⋆-algebra over ℂ, the spectral radius of any star normal element is its norm. This extends the corresponding result for selfadjoint elements.

- [x] depends on: #12211 
- [x] depends on: #11991 

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
