### PR TITLE
[Merged by Bors] - chore(category_theory/adjunction/opposites): Forgotten `category_theory` namespace

### DIFF
--- a/src/category_theory/adjunction/opposites.lean
+++ b/src/category_theory/adjunction/opposites.lean
@@ -26,7 +26,7 @@ universes v₁ v₂ u₁ u₂ -- morphism levels before object levels. See note 
 
 variables {C : Type u₁} [category.{v₁} C] {D : Type u₂} [category.{v₂} D]
 
-namespace adjunction
+namespace category_theory.adjunction
 
 /-- If `G.op` is adjoint to `F.op` then `F` is adjoint to `G`. -/
 @[simps] def adjoint_of_op_adjoint_op (F : C ⥤ D) (G : D ⥤ C) (h : G.op ⊣ F.op) : F ⊣ G :=
@@ -265,4 +265,4 @@ def nat_iso_of_right_adjoint_nat_iso {F F' : C ⥤ D} {G G' : D ⥤ C}
   F ≅ F' :=
 left_adjoint_uniq adj1 (adj2.of_nat_iso_right r.symm)
 
-end adjunction
+end category_theory.adjunction


### PR DESCRIPTION
The forgotten `category_theory` namespace means that dot notation doesn't work on `category_theory.adjunction`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
