### PR TITLE
feat(topology/uniform_space/cauchy): `cauchy_seq` index shift

### DIFF
--- a/src/algebra/covariant_and_contravariant.lean
+++ b/src/algebra/covariant_and_contravariant.lean
@@ -203,32 +203,32 @@ variables {α : Type*} {M N μ} [preorder α] [preorder N]
 variable {f : N → α}
 
 /-- The partial application of a constant to a covariant operator is monotone. -/
-lemma covariant.monotone_of_const [covariant_class M N μ (≤)] (m : M) : monotone (μ m) :=
+lemma covariant.monotone_of_const (μ) [covariant_class M N μ (≤)] {m : M} : monotone (μ m) :=
 λ a b ha, covariant_class.elim m ha
 
 /-- A monotone function remains monotone when composed with the partial application
 of a covariant operator. E.g., `∀ (m : ℕ), monotone f → monotone (λ n, f (m + n))`. -/
 lemma monotone.covariant_of_const [covariant_class M N μ (≤)] (hf : monotone f) (m : M) :
   monotone (λ n, f (μ m n)) :=
-hf.comp $ covariant.monotone_of_const m
+hf.comp $ covariant.monotone_of_const μ
 
 /-- Same as `monotone.covariant_of_const`, but with the constant on the other side of
 the operator.  E.g., `∀ (m : ℕ), monotone f → monotone (λ n, f (n + m))`. -/
 lemma monotone.covariant_of_const' {μ : N → N → N} [covariant_class N N (swap μ) (≤)]
   (hf : monotone f) (m : N) :
   monotone (λ n, f (μ n m)) :=
-hf.comp $ covariant.monotone_of_const m
+hf.comp $ covariant.monotone_of_const (swap μ)
 
 /-- Dual of `monotone.covariant_of_const` -/
 lemma antitone.covariant_of_const [covariant_class M N μ (≤)] (hf : antitone f) (m : M) :
   antitone (λ n, f (μ m n)) :=
-hf.comp_monotone $ covariant.monotone_of_const m
+hf.comp_monotone $ covariant.monotone_of_const μ
 
 /-- Dual of `monotone.covariant_of_const'` -/
 lemma antitone.covariant_of_const' {μ : N → N → N} [covariant_class N N (swap μ) (≤)]
   (hf : antitone f) (m : N) :
   antitone (λ n, f (μ n m)) :=
-hf.comp_monotone $ covariant.monotone_of_const m
+hf.comp_monotone $ covariant.monotone_of_const (swap μ)
 
 end monotone
 

--- a/src/order/filter/at_top_bot.lean
+++ b/src/order/filter/at_top_bot.lean
@@ -1169,13 +1169,13 @@ map_at_top_eq_of_gc (λb, b * k + (k - 1)) 1
       ... ≤ (b * k + (k - 1)) / k : nat.div_le_div_right $ nat.le_add_right _ _)
 
 /-- A monotone sequence of natural numbers either tends to infinity *or* is eventually constant. -/
-lemma monotone.tendsto_at_top_at_top_or_eventually_const_nat
-  {f : ℕ → ℕ} (hf : monotone f) : tendsto f at_top at_top ∨ ∃ x, f =ᶠ[at_top] (λ _, x) :=
+lemma monotone.tendsto_at_top_at_top_or_eventually_const_nat [semilattice_sup ι] [nonempty ι]
+  {f : ι → ℕ} (hf : monotone f) : tendsto f at_top at_top ∨ ∃ x, f =ᶠ[at_top] (λ _, x) :=
 begin
   by_cases h : ∃ x, f =ᶠ[at_top] λ _, x,
   { right, assumption },
   left,
-  simp_rw [eventually_eq, eventually_at_top, not_exists, not_forall, exists_prop] at h,
+  simp_rw [eventually_eq, (@eventually_at_top ι), not_exists, not_forall, exists_prop] at h,
   apply tendsto_at_top_at_top_of_monotone hf,
   intro x,
   induction x with x hx,
@@ -1186,17 +1186,18 @@ begin
 end
 
 /-- A monotone sequence of integers either tends to infinity *or* is eventually constant. -/
-lemma monotone.tendsto_at_top_at_top_or_eventually_const_int
-  {f : ℤ → ℤ} (hf : monotone f) : tendsto f at_top at_top ∨ ∃ x, f =ᶠ[at_top] (λ _, x) :=
+lemma monotone.tendsto_at_top_at_top_or_eventually_const_int [semilattice_sup ι] [hne : nonempty ι]
+  {f : ι → ℤ} (hf : monotone f) : tendsto f at_top at_top ∨ ∃ x, f =ᶠ[at_top] (λ _, x) :=
 begin
   by_cases h : ∃ x, f =ᶠ[at_top] λ _, x,
   { right, assumption },
   left,
-  simp_rw [eventually_eq, eventually_at_top, not_exists, not_forall, exists_prop] at h,
+  simp_rw [eventually_eq, @eventually_at_top ι, not_exists, not_forall, exists_prop] at h,
   apply tendsto_at_top_at_top_of_monotone hf,
   intro x,
-  induction x using int.induction_on' with x _ hx x _ hx, use (f 37),
-  { use 37 },
+  let c := hne.some,
+  induction x using int.induction_on' with x _ hx x _ hx, use (f c),
+  { use c },
   { cases hx with a ha,
     rcases h x a with ⟨b, hb1, hb2⟩,
     exact ⟨b, (int.add_one_le_iff.mpr $ (ne.symm hb2).le_iff_lt.mp $ le_trans ha $ hf hb1)⟩ },

--- a/src/order/filter/at_top_bot.lean
+++ b/src/order/filter/at_top_bot.lean
@@ -1168,6 +1168,41 @@ map_at_top_eq_of_gc (λb, b * k + (k - 1)) 1
     calc b = (b * k) / k : by rw [nat.mul_div_cancel b hk]
       ... ≤ (b * k + (k - 1)) / k : nat.div_le_div_right $ nat.le_add_right _ _)
 
+/-- A monotone sequence of natural numbers either tends to infinity *or* is eventually constant. -/
+lemma monotone.tendsto_at_top_at_top_or_eventually_const_nat
+  {f : ℕ → ℕ} (hf : monotone f) : tendsto f at_top at_top ∨ ∃ x, f =ᶠ[at_top] (λ _, x) :=
+begin
+  by_cases h : ∃ x, f =ᶠ[at_top] λ _, x,
+  { right, assumption },
+  left,
+  simp_rw [eventually_eq, eventually_at_top, not_exists, not_forall, exists_prop] at h,
+  apply tendsto_at_top_at_top_of_monotone hf,
+  intro x,
+  induction x with x hx,
+  { simp only [exists_const, zero_le] },
+  cases hx with a ha,
+  rcases h x a with ⟨b, hb1, hb2⟩,
+  exact ⟨b, (nat.succ_le_iff.mpr $ (ne.symm hb2).le_iff_lt.mp $ le_trans ha $ hf hb1)⟩,
+end
+
+/-- A monotone sequence of integers either tends to infinity *or* is eventually constant. -/
+lemma monotone.tendsto_at_top_at_top_or_eventually_const_int
+  {f : ℤ → ℤ} (hf : monotone f) : tendsto f at_top at_top ∨ ∃ x, f =ᶠ[at_top] (λ _, x) :=
+begin
+  by_cases h : ∃ x, f =ᶠ[at_top] λ _, x,
+  { right, assumption },
+  left,
+  simp_rw [eventually_eq, eventually_at_top, not_exists, not_forall, exists_prop] at h,
+  apply tendsto_at_top_at_top_of_monotone hf,
+  intro x,
+  induction x using int.induction_on' with x _ hx x _ hx, use (f 37),
+  { use 37 },
+  { cases hx with a ha,
+    rcases h x a with ⟨b, hb1, hb2⟩,
+    exact ⟨b, (int.add_one_le_iff.mpr $ (ne.symm hb2).le_iff_lt.mp $ le_trans ha $ hf hb1)⟩ },
+  { exact hx.imp (λ _ ha, le_trans (le_of_lt $ sub_one_lt x) ha) }
+end
+
 /-- If `u` is a monotone function with linear ordered codomain and the range of `u` is not bounded
 above, then `tendsto u at_top at_top`. -/
 lemma tendsto_at_top_at_top_of_monotone' [preorder ι] [linear_order α]

--- a/src/topology/uniform_space/cauchy.lean
+++ b/src/topology/uniform_space/cauchy.lean
@@ -3,6 +3,7 @@ Copyright (c) 2017 Johannes Hölzl. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johannes Hölzl, Mario Carneiro
 -/
+import algebra.covariant_and_contravariant
 import topology.bases
 import topology.uniform_space.basic
 /-!
@@ -717,3 +718,35 @@ begin
 end
 
 end uniform_space
+
+section covariant
+
+/-- Proves things like `cauchy_seq f → cauchy_seq (λ (n : ℕ), f (1+n))` by `library_search`. -/
+lemma cauchy_seq.covariant_of_const_left_nat {f : ℕ → α} {μ : ℕ → ℕ → ℕ}
+  [covariant_class ℕ ℕ μ (≤)] (hf : cauchy_seq f) {m : ℕ} : cauchy_seq (λ n, f (μ m n)) :=
+begin
+  obtain h | ⟨N, hN⟩ := monotone.tendsto_at_top_at_top_or_eventually_const_nat
+    (covariant.monotone_of_const μ),
+  { exact hf.comp_tendsto h },
+  { exact cauchy_seq_of_eventually_const _ (hN.fun_comp f) },
+end
+
+lemma cauchy_seq.covariant_of_const_right_nat {f : ℕ → α} {μ : ℕ → ℕ → ℕ}
+  [covariant_class ℕ ℕ (swap μ) (≤)] (hf : cauchy_seq f) {m : ℕ} : cauchy_seq (λ n, f (μ n m)) :=
+@cauchy_seq.covariant_of_const_left_nat _ _ f (swap μ) _ hf m
+
+/-- Proves things like `cauchy_seq f → cauchy_seq (λ (n : ℤ), f (1+n))` by `library_search`. -/
+lemma cauchy_seq.covariant_of_const_left_int {f : ℤ → α} {μ : ℤ → ℤ → ℤ}
+  [covariant_class ℤ ℤ μ (≤)] (hf : cauchy_seq f) {m} : cauchy_seq (λ n, f (μ m n)) :=
+begin
+  obtain h | ⟨N, hN⟩ := monotone.tendsto_at_top_at_top_or_eventually_const_int
+    (covariant.monotone_of_const μ),
+  { exact hf.comp_tendsto h },
+  { exact cauchy_seq_of_eventually_const _ (hN.fun_comp f) },
+end
+
+lemma cauchy_seq.covariant_of_const_right_int {f : ℤ → α} {μ : ℤ → ℤ → ℤ}
+  [covariant_class ℤ ℤ (swap μ) (≤)] (hf : cauchy_seq f) {m} : cauchy_seq (λ n, f (μ n m)) :=
+@cauchy_seq.covariant_of_const_left_int _ _ f (swap μ) _ hf m
+
+end covariant

--- a/src/topology/uniform_space/cauchy.lean
+++ b/src/topology/uniform_space/cauchy.lean
@@ -167,6 +167,11 @@ hx.cauchy_map
 lemma cauchy_seq_const [semilattice_sup β] [nonempty β] (x : α) : cauchy_seq (λ n : β, x) :=
 tendsto_const_nhds.cauchy_seq
 
+lemma cauchy_seq_of_eventually_const [semilattice_sup β] [nonempty β]
+  {f : β → α} (x : α) (h : f =ᶠ[at_top] λ _, x) : cauchy_seq f :=
+let ⟨_, hN⟩ := eventually_at_top.mp h.eventually in
+  (tendsto_at_top_of_eventually_const hN).cauchy_seq
+
 lemma cauchy_seq_iff_tendsto [nonempty β] [semilattice_sup β] {u : β → α} :
   cauchy_seq u ↔ tendsto (prod.map u u) at_top (𝓤 α) :=
 cauchy_map_iff'.trans $ by simp only [prod_at_top_at_top_eq, prod.map_def]


### PR DESCRIPTION
Proves things like `cauchy_seq f → cauchy_seq (λ n, f (1+n))` by `library_search` where `n` is a natural number or an integer. Also adds `cauchy_seq_of_eventually_const`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

While working on #11908, I was often frustrated by the difficulty of proving that Cauchy sequences remain Cauchy after an index shift. Natural number index shifts are [relatively common](https://leanprover-community.github.io/mathlib_docs/analysis/specific_limits.html#antitone.tendsto_alternating_series_of_tendsto_zero) to avoid issues with subtraction in proofs. See #12215 for another example.

The solution is relatively simple: use the fact that the shifted function diverges along with `cauchy_seq.comp_tendsto_at_top`. However, this cannot be found by library search unless you happen to have the fact that `λ n, n + 1` diverges in scope. In #11815, which solved the same problem for `monotone`, Patrick recommended stating these lemmas in terms of `covariant_class`, which lets `library_search` find them without assistance. The `covariant_class` constraint can be solved by typeclass resolution.

This PR is more involved than #11815, since the invariance only holds for discrete, totally ordered domains.[^1] I wasn't sure how to express that constraint with typeclasses (or words TBH), so I've proved it for both the integers and the natural numbers. There's a lot of duplication as a result.

[^1]: I think it also works over continuous domains so long as `f` is smooth, but those aren't very common.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
