### PR TITLE
[Merged by Bors] - feat(algebra/{group/with_one,order/monoid}): equivs for `with_zero` and `with_one`

### DIFF
--- a/src/algebra/group/with_one.lean
+++ b/src/algebra/group/with_one.lean
@@ -146,6 +146,8 @@ theorem lift_unique (f : with_one α →* β) : f = lift (f.to_mul_hom.comp coe_
 
 end lift
 
+attribute [irreducible] with_one
+
 section map
 
 variables [has_mul α] [has_mul β] [has_mul γ]
@@ -157,17 +159,17 @@ variables [has_mul α] [has_mul β] [has_mul γ]
 def map (f : mul_hom α β) : with_one α →* with_one β :=
 lift (coe_mul_hom.comp f)
 
-@[simp] lemma map_coe (f : mul_hom α β) (a : α) : map f (a : with_one α) = f a :=
+@[simp, to_additive] lemma map_coe (f : mul_hom α β) (a : α) : map f (a : with_one α) = f a :=
 lift_coe _ _
 
 @[simp, to_additive]
 lemma map_id : map (mul_hom.id α) = monoid_hom.id (with_one α) :=
-by { ext, cases x; refl }
+by { ext, induction x using with_one.cases_on; refl }
 
 @[to_additive]
 lemma map_map (f : mul_hom α β) (g : mul_hom β γ) (x) :
   map g (map f x) = map (g.comp f) x :=
-by { cases x; refl }
+by { induction x using with_one.cases_on; refl }
 
 @[simp, to_additive]
 lemma map_comp (f : mul_hom α β) (g : mul_hom β γ) :
@@ -179,8 +181,8 @@ monoid_hom.ext $ λ x, (map_map f g x).symm
 def _root_.mul_equiv.with_one_congr (e : α ≃* β) : with_one α ≃* with_one β :=
 { to_fun := map e.to_mul_hom,
   inv_fun := map e.symm.to_mul_hom,
-  left_inv := λ x, (map_map _ _ _).trans $ by cases x; { simp [map, lift], refl },
-  right_inv := λ x, (map_map _ _ _).trans $ by cases x; { simp [map, lift], refl },
+  left_inv := λ x, (map_map _ _ _).trans $ by induction x using with_one.cases_on; { simp },
+  right_inv := λ x, (map_map _ _ _).trans $ by induction x using with_one.cases_on; { simp },
   .. map e.to_mul_hom }
 
 @[simp]
@@ -197,8 +199,6 @@ lemma _root_.mul_equiv.with_one_congr_trans (e₁ : α ≃* β) (e₂ : β ≃* 
 mul_equiv.to_monoid_hom_injective (map_comp _ _).symm
 
 end map
-
-attribute [irreducible] with_one
 
 @[simp, norm_cast, to_additive]
 lemma coe_mul [has_mul α] (a b : α) : ((a * b : α) : with_one α) = a * b := rfl

--- a/src/algebra/group/with_one.lean
+++ b/src/algebra/group/with_one.lean
@@ -5,6 +5,8 @@ Authors: Mario Carneiro, Johan Commelin
 -/
 import algebra.ring.basic
 import data.equiv.basic
+import data.equiv.mul_add
+import data.equiv.option
 
 /-!
 # Adjoining a zero/one to semigroups and related algebraic structures
@@ -19,7 +21,7 @@ information about these structures (which are not that standard in informal math
 -/
 
 universes u v w
-variable {α : Type u}
+variables {α : Type u} {β : Type v} {γ : Type w}
 
 /-- Add an extra element `1` to a type -/
 @[to_additive "Add an extra element `0` to a type"]
@@ -114,7 +116,7 @@ end
 
 section lift
 
-variables [has_mul α] {β : Type v} [mul_one_class β]
+variables [has_mul α] [mul_one_class β]
 
 /-- Lift a semigroup homomorphism `f` to a bundled monoid homorphism. -/
 @[to_additive "Lift an add_semigroup homomorphism `f` to a bundled add_monoid homorphism."]
@@ -146,7 +148,7 @@ end lift
 
 section map
 
-variables {β : Type v} [has_mul α] [has_mul β]
+variables [has_mul α] [has_mul β] [has_mul γ]
 
 /-- Given a multiplicative map from `α → β` returns a monoid homomorphism
   from `with_one α` to `with_one β` -/
@@ -155,14 +157,44 @@ variables {β : Type v} [has_mul α] [has_mul β]
 def map (f : mul_hom α β) : with_one α →* with_one β :=
 lift (coe_mul_hom.comp f)
 
+@[simp] lemma map_coe (f : mul_hom α β) (a : α) : map f (a : with_one α) = f a :=
+lift_coe _ _
+
 @[simp, to_additive]
 lemma map_id : map (mul_hom.id α) = monoid_hom.id (with_one α) :=
 by { ext, cases x; refl }
 
+@[to_additive]
+lemma map_map (f : mul_hom α β) (g : mul_hom β γ) (x) :
+  map g (map f x) = map (g.comp f) x :=
+by { cases x; refl }
+
 @[simp, to_additive]
-lemma map_comp {γ : Type w} [has_mul γ] (f : mul_hom α β) (g : mul_hom β γ) :
-map (g.comp f) = (map g).comp (map f) :=
-by { ext, cases x; refl }
+lemma map_comp (f : mul_hom α β) (g : mul_hom β γ) :
+  map (g.comp f) = (map g).comp (map f) :=
+monoid_hom.ext $ λ x, (map_map f g x).symm
+
+/-- A version of `equiv.option_congr` for `with_one`. -/
+@[to_additive "A version of `equiv.option_congr` for `with_zero`.", simps apply]
+def _root_.mul_equiv.with_one_congr (e : α ≃* β) : with_one α ≃* with_one β :=
+{ to_fun := map e.to_mul_hom,
+  inv_fun := map e.symm.to_mul_hom,
+  left_inv := λ x, (map_map _ _ _).trans $ by cases x; { simp [map, lift], refl },
+  right_inv := λ x, (map_map _ _ _).trans $ by cases x; { simp [map, lift], refl },
+  .. map e.to_mul_hom }
+
+@[simp]
+lemma _root_.mul_equiv.with_one_congr_refl : (mul_equiv.refl α).with_one_congr = mul_equiv.refl _ :=
+mul_equiv.to_monoid_hom_injective map_id
+
+@[simp]
+lemma _root_.mul_equiv.with_one_congr_symm (e : α ≃* β) :
+  e.with_one_congr.symm = e.symm.with_one_congr := rfl
+
+@[simp]
+lemma _root_.mul_equiv.with_one_congr_trans (e₁ : α ≃* β) (e₂ : β ≃* γ) :
+  e₁.with_one_congr.trans e₂.with_one_congr = (e₁.trans e₂).with_one_congr :=
+mul_equiv.to_monoid_hom_injective (map_comp _ _).symm
 
 end map
 

--- a/src/algebra/order/monoid.lean
+++ b/src/algebra/order/monoid.lean
@@ -7,6 +7,7 @@ import algebra.group.with_one
 import algebra.group.type_tags
 import algebra.group.prod
 import algebra.order.monoid_lemmas
+import data.equiv.mul_add
 import order.bounded_order
 import order.min_max
 import order.hom.basic
@@ -270,7 +271,7 @@ elements are ≤ 1 and then 1 is the top element.
 /--
 If `0` is the least element in `α`, then `with_zero α` is an `ordered_add_comm_monoid`.
 -/
-def ordered_add_comm_monoid [ordered_add_comm_monoid α]
+protected def ordered_add_comm_monoid [ordered_add_comm_monoid α]
   (zero_le : ∀ a : α, 0 ≤ a) : ordered_add_comm_monoid (with_zero α) :=
 begin
   suffices, refine
@@ -365,21 +366,26 @@ instance [add_comm_semigroup α] : add_comm_semigroup (with_top α) :=
   end,
   ..with_top.add_semigroup }
 
-instance [add_monoid α] : add_monoid (with_top α) :=
+instance [add_zero_class α] : add_zero_class (with_top α) :=
 { zero_add :=
   begin
     refine with_top.rec_top_coe _ _,
-    { simpa },
+    { simp },
     { intro,
       rw [←with_top.coe_zero, ←with_top.coe_add, zero_add] }
   end,
   add_zero :=
   begin
     refine with_top.rec_top_coe _ _,
-    { simpa },
+    { simp },
     { intro,
       rw [←with_top.coe_zero, ←with_top.coe_add, add_zero] }
   end,
+  ..with_top.has_zero,
+  ..with_top.has_add }
+
+instance [add_monoid α] : add_monoid (with_top α) :=
+{ ..with_top.add_zero_class,
   ..with_top.has_zero,
   ..with_top.add_semigroup }
 
@@ -424,8 +430,10 @@ namespace with_bot
 
 instance [has_zero α] : has_zero (with_bot α) := with_top.has_zero
 instance [has_one α] : has_one (with_bot α) := with_top.has_one
+instance [has_add α] : has_add (with_bot α) := with_top.has_add
 instance [add_semigroup α] : add_semigroup (with_bot α) := with_top.add_semigroup
 instance [add_comm_semigroup α] : add_comm_semigroup (with_bot α) := with_top.add_comm_semigroup
+instance [add_zero_class α] : add_zero_class (with_bot α) := with_top.add_zero_class
 instance [add_monoid α] : add_monoid (with_bot α) := with_top.add_monoid
 instance [add_comm_monoid α] : add_comm_monoid (with_bot α) :=  with_top.add_comm_monoid
 
@@ -478,6 +486,27 @@ by norm_cast
 with_top.add_eq_top
 
 end with_bot
+
+namespace with_zero
+
+local attribute [semireducible] with_zero
+variables [has_add α]
+
+/-- Making an additive monoid multiplicative then adding a zero is the same as adding a bottom
+element then making it multiplicative. -/
+def to_mul_bot : with_zero (multiplicative α) ≃* multiplicative (with_bot α) :=
+by exact mul_equiv.refl _
+
+@[simp] lemma to_mul_bot_zero :
+  to_mul_bot (0 : with_zero (multiplicative α)) = multiplicative.of_add ⊥ := rfl
+@[simp] lemma to_mul_bot_coe (x : multiplicative α) :
+  to_mul_bot ↑x = multiplicative.of_add (x.to_add : with_bot α) := rfl
+@[simp] lemma to_mul_bot_symm_bot :
+  to_mul_bot.symm (multiplicative.of_add (⊥ : with_bot α)) = 0 := rfl
+@[simp] lemma to_mul_bot_coe_of_add (x : α) :
+  to_mul_bot.symm (multiplicative.of_add (x : with_bot α)) = multiplicative.of_add x := rfl
+
+end with_zero
 
 /-- A canonically ordered additive monoid is an ordered commutative additive monoid
   in which the ordering coincides with the subtractibility relation,
@@ -1020,6 +1049,18 @@ instance [linear_ordered_add_comm_monoid α] : linear_ordered_comm_monoid (multi
 instance [linear_ordered_comm_monoid α] : linear_ordered_add_comm_monoid (additive α) :=
 { ..additive.linear_order,
   ..additive.ordered_add_comm_monoid }
+
+lemma with_zero.to_mul_bot_strict_mono [has_add α] [preorder α] :
+  strict_mono (@with_zero.to_mul_bot α _) :=
+λ x y, id
+
+@[simp] lemma with_zero.to_mul_bot_le [has_add α] [preorder α]
+  (a b : with_zero (multiplicative α)) :
+  with_zero.to_mul_bot a ≤ with_zero.to_mul_bot b ↔ a ≤ b := iff.rfl
+
+@[simp] lemma with_zero.to_mul_bot_lt [has_add α] [preorder α]
+  (a b : with_zero (multiplicative α)) :
+  with_zero.to_mul_bot a < with_zero.to_mul_bot b ↔ a < b := iff.rfl
 
 namespace additive
 


### PR DESCRIPTION
This provides:

* `add_equiv.with_zero_congr : α ≃+ β → with_zero α ≃+ with_zero β`
* `mul_equiv.with_one_congr : α ≃* β → with_one α ≃* with_one β`
* `with_zero.to_mul_bot : with_zero (multiplicative α) ≃* multiplicative (with_bot α)`

[Zulip thread](https://leanprover.zulipchat.com/#narrow/stream/217875-Is-there.20code.20for.20X.3F/topic/with_zero.20.28multiplicative.20A.29.20.E2.89.83*.20multiplicative.20.28with_bot.20A.29/near/272980650)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
