### PR TITLE
[Merged by Bors] - feat(algebra/algebra,data/equiv/ring): `{ring,alg}_equiv.Pi_congr_right`

### DIFF
--- a/src/algebra/algebra/basic.lean
+++ b/src/algebra/algebra/basic.lean
@@ -1362,6 +1362,13 @@ rfl
 @[simp] lemma const_alg_hom_eq_algebra_of_id : const_alg_hom R A R = algebra.of_id R (A → R) :=
 rfl
 
+@[simps]
+def Pi_congr_right {R ι : Type*} {A₁ A₂ : ι → Type*} [comm_semiring R]
+  [Π i, semiring (A₁ i)] [Π i, semiring (A₂ i)] [Π i, algebra R (A₁ i)] [Π i, algebra R (A₂ i)]
+  (e : ∀ i, A₁ i ≃ₐ[R] A₂ i) : (Π i, A₁ i) ≃ₐ[R] Π i, A₂ i :=
+{ commutes' := λ r, by { ext i, simp },
+  .. @ring_equiv.Pi_congr_right ι A₁ A₂ _ _ (λ i, (e i).to_ring_equiv) }
+
 end pi
 
 section is_scalar_tower

--- a/src/algebra/algebra/basic.lean
+++ b/src/algebra/algebra/basic.lean
@@ -1371,7 +1371,7 @@ This is the `alg_equiv` version of `equiv.Pi_congr_right`, and the dependent ver
 @[simps]
 def Pi_congr_right {R ι : Type*} {A₁ A₂ : ι → Type*} [comm_semiring R]
   [Π i, semiring (A₁ i)] [Π i, semiring (A₂ i)] [Π i, algebra R (A₁ i)] [Π i, algebra R (A₂ i)]
-  (e : ∀ i, A₁ i ≃ₐ[R] A₂ i) : (Π i, A₁ i) ≃ₐ[R] Π i, A₂ i :=
+  (e : Π i, A₁ i ≃ₐ[R] A₂ i) : (Π i, A₁ i) ≃ₐ[R] Π i, A₂ i :=
 { commutes' := λ r, by { ext i, simp },
   .. @ring_equiv.Pi_congr_right ι A₁ A₂ _ _ (λ i, (e i).to_ring_equiv) }
 
@@ -1383,13 +1383,13 @@ lemma Pi_congr_right_refl {R ι : Type*} {A : ι → Type*} [comm_semiring R]
 @[simp]
 lemma Pi_congr_right_symm {R ι : Type*} {A₁ A₂ : ι → Type*} [comm_semiring R]
   [Π i, semiring (A₁ i)] [Π i, semiring (A₂ i)] [Π i, algebra R (A₁ i)] [Π i, algebra R (A₂ i)]
-  (e : ∀ i, A₁ i ≃ₐ[R] A₂ i) : (Pi_congr_right e).symm = (Pi_congr_right $ λ i, (e i).symm) := rfl
+  (e : Π i, A₁ i ≃ₐ[R] A₂ i) : (Pi_congr_right e).symm = (Pi_congr_right $ λ i, (e i).symm) := rfl
 
 @[simp]
 lemma Pi_congr_right_trans {R ι : Type*} {A₁ A₂ A₃ : ι → Type*} [comm_semiring R]
   [Π i, semiring (A₁ i)] [Π i, semiring (A₂ i)] [Π i, semiring (A₃ i)]
   [Π i, algebra R (A₁ i)] [Π i, algebra R (A₂ i)] [Π i, algebra R (A₃ i)]
-  (e₁ : ∀ i, A₁ i ≃ₐ[R] A₂ i) (e₂ : ∀ i, A₂ i ≃ₐ[R] A₃ i) :
+  (e₁ : Π i, A₁ i ≃ₐ[R] A₂ i) (e₂ : Π i, A₂ i ≃ₐ[R] A₃ i) :
   (Pi_congr_right e₁).trans (Pi_congr_right e₂) = (Pi_congr_right $ λ i, (e₁ i).trans (e₂ i)) :=
 rfl
 

--- a/src/algebra/algebra/basic.lean
+++ b/src/algebra/algebra/basic.lean
@@ -1372,7 +1372,9 @@ This is the `alg_equiv` version of `equiv.Pi_congr_right`, and the dependent ver
 def Pi_congr_right {R ι : Type*} {A₁ A₂ : ι → Type*} [comm_semiring R]
   [Π i, semiring (A₁ i)] [Π i, semiring (A₂ i)] [Π i, algebra R (A₁ i)] [Π i, algebra R (A₂ i)]
   (e : Π i, A₁ i ≃ₐ[R] A₂ i) : (Π i, A₁ i) ≃ₐ[R] Π i, A₂ i :=
-{ commutes' := λ r, by { ext i, simp },
+{ to_fun := λ x j, e j (x j),
+  inv_fun := λ x j, (e j).symm (x j),
+  commutes' := λ r, by { ext i, simp },
   .. @ring_equiv.Pi_congr_right ι A₁ A₂ _ _ (λ i, (e i).to_ring_equiv) }
 
 @[simp]

--- a/src/algebra/algebra/basic.lean
+++ b/src/algebra/algebra/basic.lean
@@ -1375,6 +1375,24 @@ def Pi_congr_right {R ι : Type*} {A₁ A₂ : ι → Type*} [comm_semiring R]
 { commutes' := λ r, by { ext i, simp },
   .. @ring_equiv.Pi_congr_right ι A₁ A₂ _ _ (λ i, (e i).to_ring_equiv) }
 
+@[simp]
+lemma Pi_congr_right_refl {R ι : Type*} {A : ι → Type*} [comm_semiring R]
+  [Π i, semiring (A i)] [Π i, algebra R (A i)] :
+  Pi_congr_right (λ i, (alg_equiv.refl : A i ≃ₐ[R] A i)) = alg_equiv.refl := rfl
+
+@[simp]
+lemma Pi_congr_right_symm {R ι : Type*} {A₁ A₂ : ι → Type*} [comm_semiring R]
+  [Π i, semiring (A₁ i)] [Π i, semiring (A₂ i)] [Π i, algebra R (A₁ i)] [Π i, algebra R (A₂ i)]
+  (e : ∀ i, A₁ i ≃ₐ[R] A₂ i) : (Pi_congr_right e).symm = (Pi_congr_right $ λ i, (e i).symm) := rfl
+
+@[simp]
+lemma Pi_congr_right_trans {R ι : Type*} {A₁ A₂ A₃ : ι → Type*} [comm_semiring R]
+  [Π i, semiring (A₁ i)] [Π i, semiring (A₂ i)] [Π i, semiring (A₃ i)]
+  [Π i, algebra R (A₁ i)] [Π i, algebra R (A₂ i)] [Π i, algebra R (A₃ i)]
+  (e₁ : ∀ i, A₁ i ≃ₐ[R] A₂ i) (e₂ : ∀ i, A₂ i ≃ₐ[R] A₃ i) :
+  (Pi_congr_right e₁).trans (Pi_congr_right e₂) = (Pi_congr_right $ λ i, (e₁ i).trans (e₂ i)) :=
+rfl
+
 end pi
 
 section is_scalar_tower

--- a/src/algebra/algebra/basic.lean
+++ b/src/algebra/algebra/basic.lean
@@ -1362,6 +1362,12 @@ rfl
 @[simp] lemma const_alg_hom_eq_algebra_of_id : const_alg_hom R A R = algebra.of_id R (A → R) :=
 rfl
 
+/-- A family of algebra equivalences `Π j, (A₁ j ≃ₐ A₂ j)` generates a
+multiplicative equivalence between `Π j, A₁ j` and `Π j, A₂ j`.
+
+This is the `alg_equiv` version of `equiv.Pi_congr_right`, and the dependent version of
+`alg_equiv.arrow_congr`.
+-/
 @[simps]
 def Pi_congr_right {R ι : Type*} {A₁ A₂ : ι → Type*} [comm_semiring R]
   [Π i, semiring (A₁ i)] [Π i, semiring (A₂ i)] [Π i, algebra R (A₁ i)] [Π i, algebra R (A₂ i)]

--- a/src/algebra/algebra/basic.lean
+++ b/src/algebra/algebra/basic.lean
@@ -1362,13 +1362,17 @@ rfl
 @[simp] lemma const_alg_hom_eq_algebra_of_id : const_alg_hom R A R = algebra.of_id R (A → R) :=
 rfl
 
+end pi
+
+namespace alg_equiv
+
 /-- A family of algebra equivalences `Π j, (A₁ j ≃ₐ A₂ j)` generates a
 multiplicative equivalence between `Π j, A₁ j` and `Π j, A₂ j`.
 
 This is the `alg_equiv` version of `equiv.Pi_congr_right`, and the dependent version of
 `alg_equiv.arrow_congr`.
 -/
-@[simps]
+@[simps apply]
 def Pi_congr_right {R ι : Type*} {A₁ A₂ : ι → Type*} [comm_semiring R]
   [Π i, semiring (A₁ i)] [Π i, semiring (A₂ i)] [Π i, algebra R (A₁ i)] [Π i, algebra R (A₂ i)]
   (e : Π i, A₁ i ≃ₐ[R] A₂ i) : (Π i, A₁ i) ≃ₐ[R] Π i, A₂ i :=
@@ -1395,7 +1399,7 @@ lemma Pi_congr_right_trans {R ι : Type*} {A₁ A₂ A₃ : ι → Type*} [comm_
   (Pi_congr_right e₁).trans (Pi_congr_right e₂) = (Pi_congr_right $ λ i, (e₁ i).trans (e₂ i)) :=
 rfl
 
-end pi
+end alg_equiv
 
 section is_scalar_tower
 

--- a/src/data/equiv/ring.lean
+++ b/src/data/equiv/ring.lean
@@ -282,6 +282,12 @@ noncomputable def of_bijective (f : R →+* S) (hf : function.bijective f) : R �
 lemma of_bijective_apply (f : R →+* S) (hf : function.bijective f) (x : R) :
   of_bijective f hf x = f x := rfl
 
+/-- A family of ring isomorphisms `Π j, (R j ≃+* S j)` generates a
+ring isomorphisms between `Π j, R j` and `Π j, S j`.
+
+This is the `ring_equiv` version of `equiv.Pi_congr_right`, and the dependent version of
+`ring_equiv.arrow_congr`.
+-/
 @[simps]
 def Pi_congr_right {ι : Type*} {R S : ι → Type*}
   [Π i, semiring (R i)] [Π i, semiring (S i)]

--- a/src/data/equiv/ring.lean
+++ b/src/data/equiv/ring.lean
@@ -291,7 +291,7 @@ This is the `ring_equiv` version of `equiv.Pi_congr_right`, and the dependent ve
 @[simps apply]
 def Pi_congr_right {ι : Type*} {R S : ι → Type*}
   [Π i, semiring (R i)] [Π i, semiring (S i)]
-  (e : ∀ i, R i ≃+* S i) : (Π i, R i) ≃+* Π i, S i :=
+  (e : Π i, R i ≃+* S i) : (Π i, R i) ≃+* Π i, S i :=
 { to_fun := λ x j, es j (x j),
   inv_fun := λ x j, (es j).symm (x j),
   .. @mul_equiv.Pi_congr_right ι R S _ _ (λ i, (e i).to_mul_equiv),
@@ -304,12 +304,12 @@ lemma Pi_congr_right_refl {ι : Type*} {R : ι → Type*} [Π i, semiring (R i)]
 @[simp]
 lemma Pi_congr_right_symm {ι : Type*} {R S : ι → Type*}
   [Π i, semiring (R i)] [Π i, semiring (S i)]
-  (e : ∀ i, R i ≃+* S i) : (Pi_congr_right e).symm = (Pi_congr_right $ λ i, (e i).symm) := rfl
+  (e : Π i, R i ≃+* S i) : (Pi_congr_right e).symm = (Pi_congr_right $ λ i, (e i).symm) := rfl
 
 @[simp]
 lemma Pi_congr_right_trans {ι : Type*} {R S T : ι → Type*}
   [Π i, semiring (R i)] [Π i, semiring (S i)] [Π i, semiring (T i)]
-  (e : ∀ i, R i ≃+* S i) (f : ∀ i, S i ≃+* T i) :
+  (e : Π i, R i ≃+* S i) (f : Π i, S i ≃+* T i) :
   (Pi_congr_right e).trans (Pi_congr_right f) = (Pi_congr_right $ λ i, (e i).trans (f i)) := rfl
 
 end semiring

--- a/src/data/equiv/ring.lean
+++ b/src/data/equiv/ring.lean
@@ -292,8 +292,8 @@ This is the `ring_equiv` version of `equiv.Pi_congr_right`, and the dependent ve
 def Pi_congr_right {ι : Type*} {R S : ι → Type*}
   [Π i, semiring (R i)] [Π i, semiring (S i)]
   (e : Π i, R i ≃+* S i) : (Π i, R i) ≃+* Π i, S i :=
-{ to_fun := λ x j, es j (x j),
-  inv_fun := λ x j, (es j).symm (x j),
+{ to_fun := λ x j, e j (x j),
+  inv_fun := λ x j, (e j).symm (x j),
   .. @mul_equiv.Pi_congr_right ι R S _ _ (λ i, (e i).to_mul_equiv),
   .. @add_equiv.Pi_congr_right ι R S _ _ (λ i, (e i).to_add_equiv) }
 

--- a/src/data/equiv/ring.lean
+++ b/src/data/equiv/ring.lean
@@ -295,6 +295,21 @@ def Pi_congr_right {ι : Type*} {R S : ι → Type*}
 { .. @mul_equiv.Pi_congr_right ι R S _ _ (λ i, (e i).to_mul_equiv),
   .. @add_equiv.Pi_congr_right ι R S _ _ (λ i, (e i).to_add_equiv) }
 
+@[simp]
+lemma Pi_congr_right_refl {ι : Type*} {R : ι → Type*} [Π i, semiring (R i)] :
+  Pi_congr_right (λ i, ring_equiv.refl (R i)) = ring_equiv.refl _ := rfl
+
+@[simp]
+lemma Pi_congr_right_symm {ι : Type*} {R S : ι → Type*}
+  [Π i, semiring (R i)] [Π i, semiring (S i)]
+  (e : ∀ i, R i ≃+* S i) : (Pi_congr_right e).symm = (Pi_congr_right $ λ i, (e i).symm) := rfl
+
+@[simp]
+lemma Pi_congr_right_trans {ι : Type*} {R S T : ι → Type*}
+  [Π i, semiring (R i)] [Π i, semiring (S i)] [Π i, semiring (T i)]
+  (e : ∀ i, R i ≃+* S i) (f : ∀ i, S i ≃+* T i) :
+  (Pi_congr_right e).trans (Pi_congr_right f) = (Pi_congr_right $ λ i, (e i).trans (f i)) := rfl
+
 end semiring
 
 section

--- a/src/data/equiv/ring.lean
+++ b/src/data/equiv/ring.lean
@@ -282,6 +282,13 @@ noncomputable def of_bijective (f : R →+* S) (hf : function.bijective f) : R �
 lemma of_bijective_apply (f : R →+* S) (hf : function.bijective f) (x : R) :
   of_bijective f hf x = f x := rfl
 
+@[simps]
+def Pi_congr_right {ι : Type*} {R S : ι → Type*}
+  [Π i, semiring (R i)] [Π i, semiring (S i)]
+  (e : ∀ i, R i ≃+* S i) : (Π i, R i) ≃+* Π i, S i :=
+{ .. @mul_equiv.Pi_congr_right ι R S _ _ (λ i, (e i).to_mul_equiv),
+  .. @add_equiv.Pi_congr_right ι R S _ _ (λ i, (e i).to_add_equiv) }
+
 end semiring
 
 section

--- a/src/data/equiv/ring.lean
+++ b/src/data/equiv/ring.lean
@@ -288,11 +288,13 @@ ring isomorphisms between `Π j, R j` and `Π j, S j`.
 This is the `ring_equiv` version of `equiv.Pi_congr_right`, and the dependent version of
 `ring_equiv.arrow_congr`.
 -/
-@[simps]
+@[simps apply]
 def Pi_congr_right {ι : Type*} {R S : ι → Type*}
   [Π i, semiring (R i)] [Π i, semiring (S i)]
   (e : ∀ i, R i ≃+* S i) : (Π i, R i) ≃+* Π i, S i :=
-{ .. @mul_equiv.Pi_congr_right ι R S _ _ (λ i, (e i).to_mul_equiv),
+{ to_fun := λ x j, es j (x j),
+  inv_fun := λ x j, (es j).symm (x j),
+  .. @mul_equiv.Pi_congr_right ι R S _ _ (λ i, (e i).to_mul_equiv),
   .. @add_equiv.Pi_congr_right ι R S _ _ (λ i, (e i).to_add_equiv) }
 
 @[simp]


### PR DESCRIPTION
We extend `{add,mul}_equiv.Pi_congr_right` to rings and algebras.

Zulip thread: https://leanprover.zulipchat.com/#narrow/stream/217875-Is-there.20code.20for.20X.3F/topic/.60ring_equiv.2EPi_congr_right.60



---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
