### PR TITLE
[Merged by Bors] - refactor(group_theory/solvable): Delete duplicate lemma

### DIFF
--- a/src/group_theory/solvable.lean
+++ b/src/group_theory/solvable.lean
@@ -56,20 +56,9 @@ end derived_series
 
 section commutator_map
 
-lemma map_commutator_eq_commutator_map (H₁ H₂ : subgroup G) :
-  ⁅H₁, H₂⁆.map f = ⁅H₁.map f, H₂.map f⁆ :=
-begin
-  rw [general_commutator, general_commutator, monoid_hom.map_closure],
-  apply le_antisymm; apply closure_mono,
-  { rintros _ ⟨x, ⟨p, hp, q, hq, rfl⟩, rfl⟩,
-    refine ⟨f p, mem_map.mpr ⟨p, hp, rfl⟩, f q, mem_map.mpr ⟨q, hq, rfl⟩, by simp *⟩, },
-  { rintros x ⟨_, ⟨p, hp, rfl⟩, _, ⟨q, hq, rfl⟩, rfl⟩,
-    refine ⟨p * q * p⁻¹ * q⁻¹, ⟨p, hp, q, hq, rfl⟩, by simp *⟩, },
-end
-
 lemma commutator_le_map_commutator {H₁ H₂ : subgroup G} {K₁ K₂ : subgroup G'} (h₁ : K₁ ≤ H₁.map f)
   (h₂ : K₂ ≤ H₂.map f) : ⁅K₁, K₂⁆ ≤ ⁅H₁, H₂⁆.map f :=
-by { rw map_commutator_eq_commutator_map, exact general_commutator_mono h₁ h₂ }
+by { rw map_general_commutator, exact general_commutator_mono h₁ h₂ }
 
 section derived_series_map
 
@@ -80,7 +69,7 @@ lemma map_derived_series_le_derived_series (n : ℕ) :
 begin
   induction n with n ih,
   { simp only [derived_series_zero, le_top], },
-  { simp only [derived_series_succ, map_commutator_eq_commutator_map, general_commutator_mono, *], }
+  { simp only [derived_series_succ, map_general_commutator, general_commutator_mono, *], }
 end
 
 variables {f}


### PR DESCRIPTION
`map_commutator_eq_commutator_map` is a duplicate of `map_general_commutator`.

(This is one of the several orthogonal changes from #12134)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
