### PR TITLE
feat(analysis/inner_product_space/adjoint): `op_norm_of_unitary`

### DIFF
--- a/src/analysis/inner_product_space/adjoint.lean
+++ b/src/analysis/inner_product_space/adjoint.lean
@@ -186,14 +186,52 @@ lemma is_adjoint_pair (A : E' →L[ℝ] F') :
 
 end real
 
+def linear_equiv_of_unitary {U : (E →L[𝕜] E)} (hU : U ∈ unitary (E →L[𝕜] E)) :
+  (E ≃ₗ[𝕜] E) :=
+  { to_fun := U,
+    map_add' := map_add U,
+    map_smul' := map_smul U,
+    inv_fun := (star U : (E →L[𝕜] E)),
+    left_inv :=
+    begin
+      rw function.left_inverse_iff_comp,
+      ext,
+      simp only [id.def, function.comp_app, ← continuous_linear_map.mul_apply,
+        unitary.star_mul_self_of_mem hU, continuous_linear_map.one_apply],
+    end,
+    right_inv :=
+    begin
+      rw function.right_inverse_iff_comp,
+      ext,
+      simp only [id.def, function.comp_app, ← continuous_linear_map.mul_apply,
+        unitary.mul_star_self_of_mem hU, continuous_linear_map.one_apply],
+    end,
+  }
+
+def linear_isometry_equiv_of_unitary {U : (E →L[𝕜] E)} (hU : U ∈ unitary (E →L[𝕜] E)) :
+  (E ≃ₗᵢ[𝕜] E) :=
+{
+  to_linear_equiv := linear_equiv_of_unitary hU,
+  norm_map' :=
+  begin
+    intro x,
+    simp only [linear_equiv_of_unitary, linear_equiv.coe_mk],
+    rw [← sq_eq_sq (norm_nonneg (U x)) (norm_nonneg x), norm_sq_eq_inner,
+      ← continuous_linear_map.adjoint_inner_left, ← continuous_linear_map.mul_apply],
+    rw unitary.mem_iff at hU,
+    rw [← continuous_linear_map.star_eq_adjoint, hU.1, continuous_linear_map.one_apply,
+      inner_self_eq_norm_sq],
+  end
+}
+
 lemma norm_map_of_unitary {U : (E →L[𝕜] E)} (hU : U ∈ unitary (E →L[𝕜] E)) (x : E) :
   ∥U x∥ = ∥x∥ :=
 begin
-  rw [← sq_eq_sq (norm_nonneg (U x)) (norm_nonneg x), norm_sq_eq_inner,
-    ← continuous_linear_map.adjoint_inner_left, ← continuous_linear_map.mul_apply],
-  rw unitary.mem_iff at hU,
-  rw [← continuous_linear_map.star_eq_adjoint, hU.1, continuous_linear_map.one_apply,
-    inner_self_eq_norm_sq],
+  have := (linear_isometry_equiv_of_unitary hU).norm_map',
+  specialize this x,
+  simp only [linear_isometry_equiv_of_unitary, linear_equiv_of_unitary,
+    linear_equiv.coe_mk] at this,
+  exact this,
 end
 
 

--- a/src/analysis/inner_product_space/adjoint.lean
+++ b/src/analysis/inner_product_space/adjoint.lean
@@ -193,16 +193,14 @@ variables {U : (E →L[𝕜] E)}
 /-- Builds a linear isometric equivalence from `U ∈ unitary (E →L[𝕜] E)`. -/
 def linear_isometry_equiv_of_unitary (hU : U ∈ unitary (E →L[𝕜] E)) : (E ≃ₗᵢ[𝕜] E) :=
 { to_linear_equiv :=
-  { to_fun    := U,
-    map_add'  := map_add U,
-    map_smul' := map_smul U,
-    inv_fun   := (star U : (E →L[𝕜] E)),
-    left_inv  := λ x, by rw [←mul_apply, unitary.star_mul_self_of_mem hU, one_apply],
-    right_inv := λ x, by rw [←mul_apply, unitary.mul_star_self_of_mem hU, one_apply] },
-  norm_map' := λ x, by
-  { rw unitary.mem_iff at hU,
-    rw [linear_equiv.coe_mk, ←sq_eq_sq (norm_nonneg (U x)) (norm_nonneg x), norm_sq_eq_inner,
-      ←adjoint_inner_left, ←mul_apply, ←star_eq_adjoint, hU.1, one_apply, inner_self_eq_norm_sq] } }
+    linear_map.general_linear_group.to_linear_equiv $
+      units.map (continuous_linear_map.to_linear_map_hom : (E →L[𝕜] E) →* _)
+        (unitary.to_units ⟨U, hU⟩),
+  norm_map' := λ x,
+    show ∥U x∥ = ∥x∥,
+    by rw [←sq_eq_sq (norm_nonneg (U x)) (norm_nonneg x), norm_sq_eq_inner,
+      ←adjoint_inner_left, ←mul_apply, ←star_eq_adjoint, unitary.star_mul_self_of_mem hU, one_apply,
+      inner_self_eq_norm_sq] }
 
 lemma norm_map_of_unitary (hU : U ∈ unitary (E →L[𝕜] E)) (x : E) : ∥U x∥ = ∥x∥ :=
 (linear_isometry_equiv_of_unitary hU).norm_map' _

--- a/src/analysis/inner_product_space/adjoint.lean
+++ b/src/analysis/inner_product_space/adjoint.lean
@@ -313,6 +313,24 @@ instance : star_module 𝕜 (E →ₗ[𝕜] E) := ⟨linear_equiv.map_smulₛₗ
 
 lemma star_eq_adjoint (A : E →ₗ[𝕜] E) : star A = A.adjoint := rfl
 
+section unitary
+
+variables {U : (E →ₗ[𝕜] E)}
+
+lemma norm_map_of_unitary (hU : U ∈ unitary (E →ₗ[𝕜] E)) (x : E) : ∥U x∥ = ∥x∥ :=
+  by rw [←sq_eq_sq (norm_nonneg (U x)) (norm_nonneg x), norm_sq_eq_inner,
+    ←adjoint_inner_left, ←mul_apply, ←star_eq_adjoint, unitary.star_mul_self_of_mem hU, one_apply,
+    inner_self_eq_norm_sq]
+
+/-- Builds a linear isometric equivalence from `U ∈ unitary (E →ₗ[𝕜] E)`. -/
+def linear_isometry_equiv_of_unitary (hU : U ∈ unitary (E →ₗ[𝕜] E)) : (E ≃ₗᵢ[𝕜] E) :=
+{ to_linear_equiv :=
+    linear_map.general_linear_group.to_linear_equiv $
+      (unitary.to_units ⟨U, hU⟩),
+  norm_map' := norm_map_of_unitary hU }
+
+end unitary
+
 section real
 
 variables {E' : Type*} {F' : Type*} [inner_product_space ℝ E'] [inner_product_space ℝ F']

--- a/src/analysis/inner_product_space/adjoint.lean
+++ b/src/analysis/inner_product_space/adjoint.lean
@@ -192,26 +192,26 @@ variables {U : (E →L[𝕜] E)}
 
 /-- Builds a linear equivalence from `U ∈ unitary (E →L[𝕜] E)`. -/
 def linear_equiv_of_unitary (hU : U ∈ unitary (E →L[𝕜] E)) : (E ≃ₗ[𝕜] E) :=
-  { to_fun    := U,
-    map_add'  := map_add U,
-    map_smul' := map_smul U,
-    inv_fun   := (star U : (E →L[𝕜] E)),
-    left_inv  := by { rw function.left_inverse_iff_comp, ext, simp only [id.def, function.comp_app,
-      ← continuous_linear_map.mul_apply, unitary.star_mul_self_of_mem hU,
-      continuous_linear_map.one_apply] },
-    right_inv := by { rw function.right_inverse_iff_comp, ext, simp only [id.def, function.comp_app,
-      ← continuous_linear_map.mul_apply, unitary.mul_star_self_of_mem hU,
-      continuous_linear_map.one_apply] } }
+{ to_fun    := U,
+  map_add'  := map_add U,
+  map_smul' := map_smul U,
+  inv_fun   := (star U : (E →L[𝕜] E)),
+  left_inv  := by { rw function.left_inverse_iff_comp, ext, simp only [id.def, function.comp_app,
+    ← continuous_linear_map.mul_apply, unitary.star_mul_self_of_mem hU,
+    continuous_linear_map.one_apply] },
+  right_inv := by { rw function.right_inverse_iff_comp, ext, simp only [id.def, function.comp_app,
+    ← continuous_linear_map.mul_apply, unitary.mul_star_self_of_mem hU,
+    continuous_linear_map.one_apply] } }
 
 /-- Builds a linear isometric equivalence from `U ∈ unitary (E →L[𝕜] E)`. -/
 def linear_isometry_equiv_of_unitary (hU : U ∈ unitary (E →L[𝕜] E)) : (E ≃ₗᵢ[𝕜] E) :=
-  { to_linear_equiv := linear_equiv_of_unitary hU,
-    norm_map' := λ x : E, by { simp only [linear_equiv_of_unitary, linear_equiv.coe_mk],
-      rw [← sq_eq_sq (norm_nonneg (U x)) (norm_nonneg x), norm_sq_eq_inner,
-        ← continuous_linear_map.adjoint_inner_left, ← continuous_linear_map.mul_apply],
-      rw unitary.mem_iff at hU,
-      rw [← continuous_linear_map.star_eq_adjoint, hU.1, continuous_linear_map.one_apply,
-        inner_self_eq_norm_sq] } }
+{ to_linear_equiv := linear_equiv_of_unitary hU,
+  norm_map' := λ x : E, by { simp only [linear_equiv_of_unitary, linear_equiv.coe_mk],
+    rw [← sq_eq_sq (norm_nonneg (U x)) (norm_nonneg x), norm_sq_eq_inner,
+      ← continuous_linear_map.adjoint_inner_left, ← continuous_linear_map.mul_apply],
+    rw unitary.mem_iff at hU,
+    rw [← continuous_linear_map.star_eq_adjoint, hU.1, continuous_linear_map.one_apply,
+      inner_self_eq_norm_sq] } }
 
 lemma norm_map_of_unitary (hU : U ∈ unitary (E →L[𝕜] E)) (x : E) : ∥U x∥ = ∥x∥ :=
 begin

--- a/src/analysis/inner_product_space/adjoint.lean
+++ b/src/analysis/inner_product_space/adjoint.lean
@@ -214,12 +214,7 @@ def linear_isometry_equiv_of_unitary (hU : U ∈ unitary (E →L[𝕜] E)) : (E 
       inner_self_eq_norm_sq] } }
 
 lemma norm_map_of_unitary (hU : U ∈ unitary (E →L[𝕜] E)) (x : E) : ∥U x∥ = ∥x∥ :=
-begin
-  have := (linear_isometry_equiv_of_unitary hU).norm_map' x,
-  simp only [linear_isometry_equiv_of_unitary, linear_equiv_of_unitary, linear_equiv.coe_mk]
-    at this,
-  exact this,
-end
+(linear_isometry_equiv_of_unitary hU).norm_map' _ 
 
 end unitary
 

--- a/src/analysis/inner_product_space/adjoint.lean
+++ b/src/analysis/inner_product_space/adjoint.lean
@@ -205,13 +205,11 @@ def linear_equiv_of_unitary {U : (E →L[𝕜] E)} (hU : U ∈ unitary (E →L[�
       ext,
       simp only [id.def, function.comp_app, ← continuous_linear_map.mul_apply,
         unitary.mul_star_self_of_mem hU, continuous_linear_map.one_apply],
-    end,
-  }
+    end }
 
 def linear_isometry_equiv_of_unitary {U : (E →L[𝕜] E)} (hU : U ∈ unitary (E →L[𝕜] E)) :
   (E ≃ₗᵢ[𝕜] E) :=
-{
-  to_linear_equiv := linear_equiv_of_unitary hU,
+{ to_linear_equiv := linear_equiv_of_unitary hU,
   norm_map' :=
   begin
     intro x,
@@ -221,8 +219,7 @@ def linear_isometry_equiv_of_unitary {U : (E →L[𝕜] E)} (hU : U ∈ unitary 
     rw unitary.mem_iff at hU,
     rw [← continuous_linear_map.star_eq_adjoint, hU.1, continuous_linear_map.one_apply,
       inner_self_eq_norm_sq],
-  end
-}
+  end }
 
 lemma norm_map_of_unitary {U : (E →L[𝕜] E)} (hU : U ∈ unitary (E →L[𝕜] E)) (x : E) :
   ∥U x∥ = ∥x∥ :=

--- a/src/analysis/inner_product_space/adjoint.lean
+++ b/src/analysis/inner_product_space/adjoint.lean
@@ -190,6 +190,7 @@ section unitary
 
 variables {U : (E →L[𝕜] E)}
 
+/-- Builds a linear equivalence from `U ∈ unitary (E →L[𝕜] E)`. -/
 def linear_equiv_of_unitary (hU : U ∈ unitary (E →L[𝕜] E)) : (E ≃ₗ[𝕜] E) :=
   { to_fun    := U,
     map_add'  := map_add U,
@@ -202,6 +203,7 @@ def linear_equiv_of_unitary (hU : U ∈ unitary (E →L[𝕜] E)) : (E ≃ₗ[�
       ← continuous_linear_map.mul_apply, unitary.mul_star_self_of_mem hU,
       continuous_linear_map.one_apply] } }
 
+/-- Builds a linear isometric equivalence from `U ∈ unitary (E →L[𝕜] E)`. -/
 def linear_isometry_equiv_of_unitary (hU : U ∈ unitary (E →L[𝕜] E)) : (E ≃ₗᵢ[𝕜] E) :=
   { to_linear_equiv := linear_equiv_of_unitary hU,
     norm_map' := λ x : E, by { simp only [linear_equiv_of_unitary, linear_equiv.coe_mk],
@@ -213,10 +215,9 @@ def linear_isometry_equiv_of_unitary (hU : U ∈ unitary (E →L[𝕜] E)) : (E 
 
 lemma norm_map_of_unitary (hU : U ∈ unitary (E →L[𝕜] E)) (x : E) : ∥U x∥ = ∥x∥ :=
 begin
-  have := (linear_isometry_equiv_of_unitary hU).norm_map',
-  specialize this x,
-  simp only [linear_isometry_equiv_of_unitary, linear_equiv_of_unitary,
-    linear_equiv.coe_mk] at this,
+  have := (linear_isometry_equiv_of_unitary hU).norm_map' x,
+  simp only [linear_isometry_equiv_of_unitary, linear_equiv_of_unitary, linear_equiv.coe_mk]
+    at this,
   exact this,
 end
 

--- a/src/analysis/inner_product_space/adjoint.lean
+++ b/src/analysis/inner_product_space/adjoint.lean
@@ -190,28 +190,19 @@ section unitary
 
 variables {U : (E →L[𝕜] E)}
 
-/-- Builds a linear equivalence from `U ∈ unitary (E →L[𝕜] E)`. -/
-def linear_equiv_of_unitary (hU : U ∈ unitary (E →L[𝕜] E)) : (E ≃ₗ[𝕜] E) :=
-{ to_fun    := U,
-  map_add'  := map_add U,
-  map_smul' := map_smul U,
-  inv_fun   := (star U : (E →L[𝕜] E)),
-  left_inv  := by { rw function.left_inverse_iff_comp, ext, simp only [id.def, function.comp_app,
-    ← continuous_linear_map.mul_apply, unitary.star_mul_self_of_mem hU,
-    continuous_linear_map.one_apply] },
-  right_inv := by { rw function.right_inverse_iff_comp, ext, simp only [id.def, function.comp_app,
-    ← continuous_linear_map.mul_apply, unitary.mul_star_self_of_mem hU,
-    continuous_linear_map.one_apply] } }
-
 /-- Builds a linear isometric equivalence from `U ∈ unitary (E →L[𝕜] E)`. -/
 def linear_isometry_equiv_of_unitary (hU : U ∈ unitary (E →L[𝕜] E)) : (E ≃ₗᵢ[𝕜] E) :=
-{ to_linear_equiv := linear_equiv_of_unitary hU,
-  norm_map' := λ x : E, by { simp only [linear_equiv_of_unitary, linear_equiv.coe_mk],
-    rw [← sq_eq_sq (norm_nonneg (U x)) (norm_nonneg x), norm_sq_eq_inner,
-      ← continuous_linear_map.adjoint_inner_left, ← continuous_linear_map.mul_apply],
+{ to_linear_equiv :=
+  { to_fun    := U,
+    map_add'  := map_add U,
+    map_smul' := map_smul U,
+    inv_fun   := (star U : (E →L[𝕜] E)),
+    left_inv  := λ x, by rw [←mul_apply, unitary.star_mul_self_of_mem hU, one_apply],
+    right_inv := λ x, by rw [←mul_apply, unitary.mul_star_self_of_mem hU, one_apply] },
+  norm_map' := λ x, by {
     rw unitary.mem_iff at hU,
-    rw [← continuous_linear_map.star_eq_adjoint, hU.1, continuous_linear_map.one_apply,
-      inner_self_eq_norm_sq] } }
+    rw [linear_equiv.coe_mk, ←sq_eq_sq (norm_nonneg (U x)) (norm_nonneg x), norm_sq_eq_inner,
+      ←adjoint_inner_left, ←mul_apply, ←star_eq_adjoint, hU.1, one_apply, inner_self_eq_norm_sq] } }
 
 lemma norm_map_of_unitary (hU : U ∈ unitary (E →L[𝕜] E)) (x : E) : ∥U x∥ = ∥x∥ :=
 (linear_isometry_equiv_of_unitary hU).norm_map' _ 

--- a/src/analysis/inner_product_space/adjoint.lean
+++ b/src/analysis/inner_product_space/adjoint.lean
@@ -190,20 +190,26 @@ section unitary
 
 variables {U : (E →L[𝕜] E)}
 
+/-- forgetting continuity preserves composition -/
+@[simps]
+def _root_.continuous_linear_map.to_linear_map_hom :
+  (E →L[𝕜] E) →* (E →ₗ[𝕜] E) :=
+{ to_fun := continuous_linear_map.to_linear_map,
+  map_one' := rfl,
+  map_mul' := λ _ _, rfl }
+
+lemma norm_map_of_unitary (hU : U ∈ unitary (E →L[𝕜] E)) (x : E) : ∥U x∥ = ∥x∥ :=
+  by rw [←sq_eq_sq (norm_nonneg (U x)) (norm_nonneg x), norm_sq_eq_inner,
+    ←adjoint_inner_left, ←mul_apply, ←star_eq_adjoint, unitary.star_mul_self_of_mem hU, one_apply,
+    inner_self_eq_norm_sq]
+
 /-- Builds a linear isometric equivalence from `U ∈ unitary (E →L[𝕜] E)`. -/
 def linear_isometry_equiv_of_unitary (hU : U ∈ unitary (E →L[𝕜] E)) : (E ≃ₗᵢ[𝕜] E) :=
 { to_linear_equiv :=
     linear_map.general_linear_group.to_linear_equiv $
-      units.map (continuous_linear_map.to_linear_map_hom : (E →L[𝕜] E) →* _)
+      units.map (to_linear_map_hom : (E →L[𝕜] E) →* _)
         (unitary.to_units ⟨U, hU⟩),
-  norm_map' := λ x,
-    show ∥U x∥ = ∥x∥,
-    by rw [←sq_eq_sq (norm_nonneg (U x)) (norm_nonneg x), norm_sq_eq_inner,
-      ←adjoint_inner_left, ←mul_apply, ←star_eq_adjoint, unitary.star_mul_self_of_mem hU, one_apply,
-      inner_self_eq_norm_sq] }
-
-lemma norm_map_of_unitary (hU : U ∈ unitary (E →L[𝕜] E)) (x : E) : ∥U x∥ = ∥x∥ :=
-(linear_isometry_equiv_of_unitary hU).norm_map' _
+  norm_map' := norm_map_of_unitary hU }
 
 end unitary
 

--- a/src/analysis/inner_product_space/adjoint.lean
+++ b/src/analysis/inner_product_space/adjoint.lean
@@ -199,13 +199,13 @@ def linear_isometry_equiv_of_unitary (hU : U ∈ unitary (E →L[𝕜] E)) : (E 
     inv_fun   := (star U : (E →L[𝕜] E)),
     left_inv  := λ x, by rw [←mul_apply, unitary.star_mul_self_of_mem hU, one_apply],
     right_inv := λ x, by rw [←mul_apply, unitary.mul_star_self_of_mem hU, one_apply] },
-  norm_map' := λ x, by {
-    rw unitary.mem_iff at hU,
+  norm_map' := λ x, by
+  { rw unitary.mem_iff at hU,
     rw [linear_equiv.coe_mk, ←sq_eq_sq (norm_nonneg (U x)) (norm_nonneg x), norm_sq_eq_inner,
       ←adjoint_inner_left, ←mul_apply, ←star_eq_adjoint, hU.1, one_apply, inner_self_eq_norm_sq] } }
 
 lemma norm_map_of_unitary (hU : U ∈ unitary (E →L[𝕜] E)) (x : E) : ∥U x∥ = ∥x∥ :=
-(linear_isometry_equiv_of_unitary hU).norm_map' _ 
+(linear_isometry_equiv_of_unitary hU).norm_map' _
 
 end unitary
 

--- a/src/analysis/inner_product_space/adjoint.lean
+++ b/src/analysis/inner_product_space/adjoint.lean
@@ -186,43 +186,32 @@ lemma is_adjoint_pair (A : E' →L[ℝ] F') :
 
 end real
 
-def linear_equiv_of_unitary {U : (E →L[𝕜] E)} (hU : U ∈ unitary (E →L[𝕜] E)) :
-  (E ≃ₗ[𝕜] E) :=
-  { to_fun := U,
-    map_add' := map_add U,
+section unitary
+
+variables {U : (E →L[𝕜] E)}
+
+def linear_equiv_of_unitary (hU : U ∈ unitary (E →L[𝕜] E)) : (E ≃ₗ[𝕜] E) :=
+  { to_fun    := U,
+    map_add'  := map_add U,
     map_smul' := map_smul U,
-    inv_fun := (star U : (E →L[𝕜] E)),
-    left_inv :=
-    begin
-      rw function.left_inverse_iff_comp,
-      ext,
-      simp only [id.def, function.comp_app, ← continuous_linear_map.mul_apply,
-        unitary.star_mul_self_of_mem hU, continuous_linear_map.one_apply],
-    end,
-    right_inv :=
-    begin
-      rw function.right_inverse_iff_comp,
-      ext,
-      simp only [id.def, function.comp_app, ← continuous_linear_map.mul_apply,
-        unitary.mul_star_self_of_mem hU, continuous_linear_map.one_apply],
-    end }
+    inv_fun   := (star U : (E →L[𝕜] E)),
+    left_inv  := by { rw function.left_inverse_iff_comp, ext, simp only [id.def, function.comp_app,
+      ← continuous_linear_map.mul_apply, unitary.star_mul_self_of_mem hU,
+      continuous_linear_map.one_apply] },
+    right_inv := by { rw function.right_inverse_iff_comp, ext, simp only [id.def, function.comp_app,
+      ← continuous_linear_map.mul_apply, unitary.mul_star_self_of_mem hU,
+      continuous_linear_map.one_apply] } }
 
-def linear_isometry_equiv_of_unitary {U : (E →L[𝕜] E)} (hU : U ∈ unitary (E →L[𝕜] E)) :
-  (E ≃ₗᵢ[𝕜] E) :=
-{ to_linear_equiv := linear_equiv_of_unitary hU,
-  norm_map' :=
-  begin
-    intro x,
-    simp only [linear_equiv_of_unitary, linear_equiv.coe_mk],
-    rw [← sq_eq_sq (norm_nonneg (U x)) (norm_nonneg x), norm_sq_eq_inner,
-      ← continuous_linear_map.adjoint_inner_left, ← continuous_linear_map.mul_apply],
-    rw unitary.mem_iff at hU,
-    rw [← continuous_linear_map.star_eq_adjoint, hU.1, continuous_linear_map.one_apply,
-      inner_self_eq_norm_sq],
-  end }
+def linear_isometry_equiv_of_unitary (hU : U ∈ unitary (E →L[𝕜] E)) : (E ≃ₗᵢ[𝕜] E) :=
+  { to_linear_equiv := linear_equiv_of_unitary hU,
+    norm_map' := λ x : E, by { simp only [linear_equiv_of_unitary, linear_equiv.coe_mk],
+      rw [← sq_eq_sq (norm_nonneg (U x)) (norm_nonneg x), norm_sq_eq_inner,
+        ← continuous_linear_map.adjoint_inner_left, ← continuous_linear_map.mul_apply],
+      rw unitary.mem_iff at hU,
+      rw [← continuous_linear_map.star_eq_adjoint, hU.1, continuous_linear_map.one_apply,
+        inner_self_eq_norm_sq] } }
 
-lemma norm_map_of_unitary {U : (E →L[𝕜] E)} (hU : U ∈ unitary (E →L[𝕜] E)) (x : E) :
-  ∥U x∥ = ∥x∥ :=
+lemma norm_map_of_unitary (hU : U ∈ unitary (E →L[𝕜] E)) (x : E) : ∥U x∥ = ∥x∥ :=
 begin
   have := (linear_isometry_equiv_of_unitary hU).norm_map',
   specialize this x,
@@ -231,6 +220,7 @@ begin
   exact this,
 end
 
+end unitary
 
 end continuous_linear_map
 

--- a/src/analysis/inner_product_space/adjoint.lean
+++ b/src/analysis/inner_product_space/adjoint.lean
@@ -186,6 +186,37 @@ lemma is_adjoint_pair (A : E' →L[ℝ] F') :
 
 end real
 
+lemma norm_map_of_unitary {U : (E →L[𝕜] E)} (hU : U ∈ unitary (E →L[𝕜] E)) (x : E) :
+  ∥U x∥ = ∥x∥ :=
+begin
+  rw [← sq_eq_sq (norm_nonneg (U x)) (norm_nonneg x), norm_sq_eq_inner,
+    ← continuous_linear_map.adjoint_inner_left, ← continuous_linear_map.mul_apply],
+  rw unitary.mem_iff at hU,
+  rw [← continuous_linear_map.star_eq_adjoint, hU.1, continuous_linear_map.one_apply,
+    inner_self_eq_norm_sq],
+end
+
+lemma op_norm_of_unitary [nontrivial E] {U : (E →L[𝕜] E)} (hU : U ∈ unitary (E →L[𝕜] E)) :
+  ∥U∥ = 1 :=
+begin
+  have h_above : ∀ (x : E), ∥U x∥ ≤ 1 * ∥x∥,
+  { intro x,
+    rw norm_map_of_unitary hU,
+    norm_num },
+  have h_below : ∀ (N : ℝ), N ≥ 0 → (∀ (x : E), ∥U x∥ ≤ N * ∥x∥) → 1 ≤ N,
+  { intros N hN_zero,
+    contrapose!,
+    intro hN_one,
+    have hy_nonzero : ∃ (y : E), y ≠ 0 := exists_ne 0,
+    cases hy_nonzero with y hy,
+    use y,
+    rw norm_map_of_unitary hU,
+    have hy_pos : 0 < ∥y∥ := by {rw norm_pos_iff, exact hy},
+    rw mul_lt_iff_lt_one_left hy_pos,
+    exact hN_one },
+  apply continuous_linear_map.op_norm_eq_of_bounds zero_le_one h_above h_below,
+end
+
 end continuous_linear_map
 
 namespace linear_map

--- a/src/analysis/inner_product_space/adjoint.lean
+++ b/src/analysis/inner_product_space/adjoint.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Frédéric Dupuis, Heather Macbeth
 -/
 
-import logic.function.basic
 import analysis.inner_product_space.dual
 import analysis.inner_product_space.pi_L2
 

--- a/src/analysis/inner_product_space/adjoint.lean
+++ b/src/analysis/inner_product_space/adjoint.lean
@@ -197,19 +197,6 @@ begin
     inner_self_eq_norm_sq],
 end
 
-instance [hE : nontrivial E] : nontrivial (E →L[𝕜] E) :=
-begin
-  rw nontrivial_iff,
-  use (1 : (E →L[𝕜] E)),
-  use (0 : (E →L[𝕜] E)),
-  by_contra,
-  rw nontrivial_iff at hE,
-  cases hE with x hx,
-  cases hx with y hxy,
-  have heq : (1 : (E →L[𝕜] E)) x = (1 : (E →L[𝕜] E)) y :=
-    by simp only [h, continuous_linear_map.zero_apply],
-  tauto,
-end
 
 end continuous_linear_map
 

--- a/src/analysis/inner_product_space/adjoint.lean
+++ b/src/analysis/inner_product_space/adjoint.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Frédéric Dupuis, Heather Macbeth
 -/
 
+import logic.function.basic
 import analysis.inner_product_space.dual
 import analysis.inner_product_space.pi_L2
 
@@ -196,25 +197,18 @@ begin
     inner_self_eq_norm_sq],
 end
 
-lemma op_norm_of_unitary [nontrivial E] {U : (E →L[𝕜] E)} (hU : U ∈ unitary (E →L[𝕜] E)) :
-  ∥U∥ = 1 :=
+instance [hE : nontrivial E] : nontrivial (E →L[𝕜] E) :=
 begin
-  have h_above : ∀ (x : E), ∥U x∥ ≤ 1 * ∥x∥,
-  { intro x,
-    rw norm_map_of_unitary hU,
-    norm_num },
-  have h_below : ∀ (N : ℝ), N ≥ 0 → (∀ (x : E), ∥U x∥ ≤ N * ∥x∥) → 1 ≤ N,
-  { intros N hN_zero,
-    contrapose!,
-    intro hN_one,
-    have hy_nonzero : ∃ (y : E), y ≠ 0 := exists_ne 0,
-    cases hy_nonzero with y hy,
-    use y,
-    rw norm_map_of_unitary hU,
-    have hy_pos : 0 < ∥y∥ := by {rw norm_pos_iff, exact hy},
-    rw mul_lt_iff_lt_one_left hy_pos,
-    exact hN_one },
-  apply continuous_linear_map.op_norm_eq_of_bounds zero_le_one h_above h_below,
+  rw nontrivial_iff,
+  use (1 : (E →L[𝕜] E)),
+  use (0 : (E →L[𝕜] E)),
+  by_contra,
+  rw nontrivial_iff at hE,
+  cases hE with x hx,
+  cases hx with y hxy,
+  have heq : (1 : (E →L[𝕜] E)) x = (1 : (E →L[𝕜] E)) y :=
+    by simp only [h, continuous_linear_map.zero_apply],
+  tauto,
 end
 
 end continuous_linear_map

--- a/src/topology/algebra/module/basic.lean
+++ b/src/topology/algebra/module/basic.lean
@@ -490,12 +490,9 @@ by rw [← coe_id, coe_inj]
 
 instance [hE : nontrivial M₁] : nontrivial (M₁ →L[R₁] M₁) :=
 begin
-  rw nontrivial_iff,
-  refine ⟨1, 0, _⟩,
   obtain ⟨x, y, h⟩ := exists_pair_ne M₁,
-  contrapose! h,
-  show (1 : (M₁ →L[R₁] M₁)) x = (1 : (M₁ →L[R₁] M₁)) y,
-  simp only [h, continuous_linear_map.zero_apply],
+  exact nontrivial_iff.mpr
+    ⟨1, 0, λ heq, h (by rw [←one_apply x, ←one_apply y, heq, zero_apply, zero_apply])⟩
 end
 
 section add

--- a/src/topology/algebra/module/basic.lean
+++ b/src/topology/algebra/module/basic.lean
@@ -491,15 +491,11 @@ by rw [← coe_id, coe_inj]
 instance [hE : nontrivial M₁] : nontrivial (M₁ →L[R₁] M₁) :=
 begin
   rw nontrivial_iff,
-  use (1 : (M₁ →L[R₁] M₁)),
-  use (0 : (M₁ →L[R₁] M₁)),
-  by_contra,
-  rw nontrivial_iff at hE,
-  cases hE with x hx,
-  cases hx with y hxy,
-  have heq : (1 : (M₁ →L[R₁] M₁)) x = (1 : (M₁ →L[R₁] M₁)) y :=
-    by simp only [h, continuous_linear_map.zero_apply],
-  tauto,
+  refine ⟨1, 0, _⟩,
+  obtain ⟨x, y, h⟩ := exists_pair_ne M₁,
+  contrapose! h,
+  show (1 : (M₁ →L[R₁] M₁)) x = (1 : (M₁ →L[R₁] M₁)) y,
+  simp only [h, continuous_linear_map.zero_apply],
 end
 
 section add

--- a/src/topology/algebra/module/basic.lean
+++ b/src/topology/algebra/module/basic.lean
@@ -488,7 +488,7 @@ by rw [← coe_id, coe_inj]
 
 @[simp] lemma one_apply : (1 : M₁ →L[R₁] M₁) x = x := rfl
 
-instance [hE : nontrivial M₁] : nontrivial (M₁ →L[R₁] M₁) :=
+instance [nontrivial M₁] : nontrivial (M₁ →L[R₁] M₁) :=
 begin
   obtain ⟨x, y, h⟩ := exists_pair_ne M₁,
   exact nontrivial_iff.mpr

--- a/src/topology/algebra/module/basic.lean
+++ b/src/topology/algebra/module/basic.lean
@@ -488,6 +488,20 @@ by rw [← coe_id, coe_inj]
 
 @[simp] lemma one_apply : (1 : M₁ →L[R₁] M₁) x = x := rfl
 
+instance [hE : nontrivial M₁] : nontrivial (M₁ →L[R₁] M₁) :=
+begin
+  rw nontrivial_iff,
+  use (1 : (M₁ →L[R₁] M₁)),
+  use (0 : (M₁ →L[R₁] M₁)),
+  by_contra,
+  rw nontrivial_iff at hE,
+  cases hE with x hx,
+  cases hx with y hxy,
+  have heq : (1 : (M₁ →L[R₁] M₁)) x = (1 : (M₁ →L[R₁] M₁)) y :=
+    by simp only [h, continuous_linear_map.zero_apply],
+  tauto,
+end
+
 section add
 variables [has_continuous_add M₂]
 


### PR DESCRIPTION
We prove that `U` in `unitary (E →L[k] E)` is an isometry, and we prove
that its operator norm is equal to 1.



---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
