### PR TITLE
[Merged by Bors] - feat(category_theory/category/Groupoid): Add coercion to sort

### DIFF
--- a/src/category_theory/category/Groupoid.lean
+++ b/src/category_theory/category/Groupoid.lean
@@ -38,13 +38,17 @@ instance : inhabited Groupoid := ⟨bundled.of (single_obj punit)⟩
 
 instance str (C : Groupoid.{v u}) : groupoid.{v u} C.α := C.str
 
+instance : has_coe_to_sort Groupoid Type* := bundled.has_coe_to_sort
+
 /-- Construct a bundled `Groupoid` from the underlying type and the typeclass. -/
 def of (C : Type u) [groupoid.{v} C] : Groupoid.{v u} := bundled.of C
 
+@[simp] lemma coe_of (C : Type u) [groupoid C] : (of C : Type u) = C := rfl
+
 /-- Category structure on `Groupoid` -/
 instance category : large_category.{max v u} Groupoid.{v u} :=
-{ hom := λ C D, C.α ⥤ D.α,
-  id := λ C, 𝟭 C.α,
+{ hom := λ C D, C ⥤ D,
+  id := λ C, 𝟭 C,
   comp := λ C D E F G, F ⋙ G,
   id_comp' := λ C D F, by cases F; refl,
   comp_id' := λ C D F, by cases F; refl,
@@ -58,7 +62,7 @@ def objects : Groupoid.{v u} ⥤ Type u :=
 
 /-- Forgetting functor to `Cat` -/
 def forget_to_Cat : Groupoid.{v u} ⥤ Cat.{v u} :=
-{ obj := λ C, Cat.of C.α,
+{ obj := λ C, Cat.of C,
   map := λ C D, id }
 
 instance forget_to_Cat_full : full forget_to_Cat :=
@@ -77,7 +81,7 @@ section products
 def pi_limit_cone {J : Type u} (F : discrete J ⥤ Groupoid.{u u}) :
   limits.limit_cone F :=
 { cone :=
-    { X := @of (Π j : J, (F.obj j).α) _,
+    { X := @of (Π j : J, F.obj j) _,
       π := { app := λ j : J, category_theory.pi.eval _ j, } },
   is_limit :=
   { lift := λ s, functor.pi' s.π.app,
@@ -99,7 +103,7 @@ instance has_pi : limits.has_products Groupoid.{u u} :=
 
 /-- The product of a family of groupoids is isomorphic
 to the product object in the category of Groupoids -/
-noncomputable def pi_iso_pi (J : Type u) (f : J → Groupoid.{u u}) : @of (Π j, (f j).α) _ ≅ ∏ f :=
+noncomputable def pi_iso_pi (J : Type u) (f : J → Groupoid.{u u}) : @of (Π j, f j) _ ≅ ∏ f :=
 limits.is_limit.cone_point_unique_up_to_iso
   (pi_limit_cone (discrete.functor f)).is_limit
   (limits.limit.is_limit (discrete.functor f))

--- a/src/topology/homotopy/fundamental_groupoid.lean
+++ b/src/topology/homotopy/fundamental_groupoid.lean
@@ -333,17 +333,17 @@ localized "notation `πₘ` := fundamental_groupoid.fundamental_groupoid_functor
 /-- Help the typechecker by converting a point in a groupoid back to a point in
 the underlying topological space. -/
 @[reducible]
-def to_top {X : Top} (x : (πₓ X).α) : X := x
+def to_top {X : Top} (x : πₓ X) : X := x
 
 /-- Help the typechecker by converting a point in a topological space to a
 point in the fundamental groupoid of that space -/
 @[reducible]
-def from_top {X : Top} (x : X) : (πₓ X).α := x
+def from_top {X : Top} (x : X) : πₓ X := x
 
 /-- Help the typechecker by converting an arrow in the fundamental groupoid of
 a topological space back to a path in that space (i.e., `path.homotopic.quotient`). -/
 @[reducible]
-def to_path {X : Top} {x₀ x₁ : (πₓ X).α} (p : x₀ ⟶ x₁) :
+def to_path {X : Top} {x₀ x₁ : πₓ X} (p : x₀ ⟶ x₁) :
   path.homotopic.quotient x₀ x₁ := p
 
 /-- Help the typechecker by convering a path in a topological space to an arrow in the

--- a/src/topology/homotopy/product.lean
+++ b/src/topology/homotopy/product.lean
@@ -283,10 +283,10 @@ variables {I : Type u} (X : I → Top.{u})
 /--
 The projection map Π i, X i → X i induces a map π(Π i, X i) ⟶ π(X i).
 -/
-def proj (i : I) : (πₓ (Top.of (Π i, X i))).α ⥤ (πₓ (X i)).α := πₘ ⟨_, continuous_apply i⟩
+def proj (i : I) : πₓ (Top.of (Π i, X i)) ⥤ πₓ (X i) := πₘ ⟨_, continuous_apply i⟩
 
 /-- The projection map is precisely path.homotopic.proj interpreted as a functor -/
-@[simp] lemma proj_map (i : I) (x₀ x₁ : (πₓ (Top.of (Π i, X i))).α) (p : x₀ ⟶ x₁) :
+@[simp] lemma proj_map (i : I) (x₀ x₁ : πₓ (Top.of (Π i, X i))) (p : x₀ ⟶ x₁) :
   (proj X i).map p = (@path.homotopic.proj _ _ _ _ _ i p) := rfl
 
 /--
@@ -294,7 +294,7 @@ The map taking the pi product of a family of fundamental groupoids to the fundam
 groupoid of the pi product. This is actually an isomorphism (see `pi_iso`)
 -/
 @[simps]
-def pi_to_pi_Top : (Π i, (πₓ (X i)).α) ⥤ (πₓ (Top.of (Π i, X i))).α :=
+def pi_to_pi_Top : (Π i, πₓ (X i)) ⥤ πₓ (Top.of (Π i, X i)) :=
 { obj := λ g, g,
   map := λ v₁ v₂ p, path.homotopic.pi p,
   map_id' :=
@@ -311,7 +311,7 @@ Shows `pi_to_pi_Top` is an isomorphism, whose inverse is precisely the pi produc
 of the induced projections. This shows that `fundamental_groupoid_functor` preserves products.
 -/
 @[simps]
-def pi_iso : category_theory.Groupoid.of (Π i : I, (πₓ (X i)).α) ≅ (πₓ (Top.of (Π i, X i))) :=
+def pi_iso : category_theory.Groupoid.of (Π i : I, πₓ (X i)) ≅ πₓ (Top.of (Π i, X i)) :=
 { hom := pi_to_pi_Top X,
   inv := category_theory.functor.pi' (proj X),
   hom_inv_id' :=
@@ -371,15 +371,15 @@ section prod
 variables (A B : Top.{u})
 
 /-- The induced map of the left projection map X × Y → X -/
-def proj_left : (πₓ (Top.of (A × B))).α ⥤ (πₓ A).α := πₘ ⟨_, continuous_fst⟩
+def proj_left : πₓ (Top.of (A × B)) ⥤ πₓ A := πₘ ⟨_, continuous_fst⟩
 
 /-- The induced map of the right projection map X × Y → Y -/
-def proj_right : (πₓ (Top.of (A × B))).α ⥤ (πₓ B).α := πₘ ⟨_, continuous_snd⟩
+def proj_right : πₓ (Top.of (A × B)) ⥤ πₓ B := πₘ ⟨_, continuous_snd⟩
 
-@[simp] lemma proj_left_map (x₀ x₁ : (πₓ (Top.of (A × B))).α) (p : x₀ ⟶ x₁) :
+@[simp] lemma proj_left_map (x₀ x₁ : πₓ (Top.of (A × B))) (p : x₀ ⟶ x₁) :
   (proj_left A B).map p = path.homotopic.proj_left p := rfl
 
-@[simp] lemma proj_right_map (x₀ x₁ : (πₓ (Top.of (A × B))).α) (p : x₀ ⟶ x₁) :
+@[simp] lemma proj_right_map (x₀ x₁ : πₓ (Top.of (A × B))) (p : x₀ ⟶ x₁) :
   (proj_right A B).map p = path.homotopic.proj_right p := rfl
 
 
@@ -388,7 +388,7 @@ The map taking the product of two fundamental groupoids to the fundamental group
 of the two topological spaces. This is in fact an isomorphism (see `prod_iso`).
 -/
 @[simps]
-def prod_to_prod_Top : (πₓ A).α × (πₓ B).α ⥤ (πₓ (Top.of (A × B))).α :=
+def prod_to_prod_Top : (πₓ A) × (πₓ B) ⥤ πₓ (Top.of (A × B)) :=
 { obj := λ g, g,
   map := λ x y p, match x, y, p with
     | (x₀, x₁), (y₀, y₁), (p₀, p₁) := path.homotopic.prod p₀ p₁
@@ -409,7 +409,7 @@ Shows `prod_to_prod_Top` is an isomorphism, whose inverse is precisely the produ
 of the induced left and right projections.
 -/
 @[simps]
-def prod_iso : category_theory.Groupoid.of ((πₓ A).α × (πₓ B).α) ≅ (πₓ (Top.of (A × B))) :=
+def prod_iso : category_theory.Groupoid.of ((πₓ A) × (πₓ B)) ≅ (πₓ (Top.of (A × B))) :=
 { hom := prod_to_prod_Top A B,
   inv := (proj_left A B).prod' (proj_right A B),
   hom_inv_id' :=


### PR DESCRIPTION
Use coercion to type instead of `.α`
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
This should replace https://github.com/leanprover-community/mathlib/pull/12323
[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
