### PR TITLE
[Merged by Bors] - feat(category_theory/preadditive): the category of additive functors

### DIFF
--- a/src/category_theory/preadditive/additive_functor.lean
+++ b/src/category_theory/preadditive/additive_functor.lean
@@ -165,6 +165,7 @@ instance : preadditive (C ⥤+ D) :=
 preadditive.induced_category.category _
 
 /-- An additive functor is in particular a functor. -/
+@[derive full, derive faithful]
 def AdditiveFunctor.forget : (C ⥤+ D) ⥤ (C ⥤ D) :=
 full_subcategory_inclusion _
 

--- a/src/category_theory/preadditive/additive_functor.lean
+++ b/src/category_theory/preadditive/additive_functor.lean
@@ -3,7 +3,7 @@ Copyright (c) 2021 Adam Topaz. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Adam Topaz, Scott Morrison
 -/
-import category_theory.preadditive
+import category_theory.preadditive.functor_category
 import category_theory.limits.preserves.shapes.zero
 import category_theory.limits.shapes.biproducts
 
@@ -148,6 +148,50 @@ instance inverse_additive (e : C ≌ D) [e.functor.additive] : e.inverse.additiv
 { map_add' := λ X Y f g, by { apply e.functor.map_injective, simp, }, }
 
 end equivalence
+
+section
+variables (C D : Type*) [category C] [category D] [preadditive C] [preadditive D]
+
+/-- Bundled additive functors. -/
+@[derive category]
+def AdditiveFunctor :=
+{ F : C ⥤ D // functor.additive F }
+
+infixr ` ⥤+ `:26 := AdditiveFunctor
+
+instance : preadditive (C ⥤+ D) :=
+preadditive.induced_category.category _
+
+variables {C D}
+
+instance (F : C ⥤+ D) : functor.additive F.1 :=
+F.2
+
+@[simp] lemma AdditiveFunctor.hom_eq_hom {F G : C ⥤+ D} : (F ⟶ G) = (F.1 ⟶ G.1) :=
+rfl
+
+variables (C D)
+
+@[simps]
+def AdditiveFunctor.evaluation : C ⥤ (C ⥤ D) ⥤+ D :=
+{ obj := λ X,
+  { val :=
+    { obj := λ F, F.obj X,
+      map := λ F F' α, α.app X,
+      map_id' := λ F, rfl,
+      map_comp' := λ F G H α β, rfl },
+    property :=
+    { map_add' := λ X Y f g, rfl } },
+  map := λ X X' f,
+  { app := λ F, F.map f,
+    naturality' := λ F G α, (α.naturality f).symm },
+  map_id' := λ X, by { simp only [functor.map_id], refl },
+  map_comp' := λ X Y Z f g, by { simp only [functor.map_comp], refl } }
+
+instance : functor.additive (AdditiveFunctor.evaluation C D) :=
+{ map_add' := λ X Y f g, by { ext, simp } }
+
+end
 
 end preadditive
 

--- a/src/category_theory/preadditive/additive_functor.lean
+++ b/src/category_theory/preadditive/additive_functor.lean
@@ -155,7 +155,7 @@ section
 variables (C D : Type*) [category C] [category D] [preadditive C] [preadditive D]
 
 /-- Bundled additive functors. -/
-@[derive category]
+@[derive category, nolint has_inhabited_instance]
 def AdditiveFunctor :=
 { F : C ⥤ D // functor.additive F }
 

--- a/src/category_theory/preadditive/additive_functor.lean
+++ b/src/category_theory/preadditive/additive_functor.lean
@@ -171,7 +171,7 @@ full_subcategory_inclusion _
 
 variables {C D}
 
-/-- Turn an additive functor into an object of the catgory `AdditiveFunctor C D`. -/
+/-- Turn an additive functor into an object of the category `AdditiveFunctor C D`. -/
 def AdditiveFunctor.of (F : C ⥤ D) [F.additive] : C ⥤+ D :=
 ⟨F, infer_instance⟩
 

--- a/src/category_theory/preadditive/additive_functor.lean
+++ b/src/category_theory/preadditive/additive_functor.lean
@@ -16,6 +16,8 @@ groups.
 
 An additive functor between preadditive categories creates and preserves biproducts.
 
+We also define the category of bundled additive functors.
+
 # Implementation details
 
 `functor.additive` is a `Prop`-valued class, defined by saying that
@@ -162,34 +164,38 @@ infixr ` ⥤+ `:26 := AdditiveFunctor
 instance : preadditive (C ⥤+ D) :=
 preadditive.induced_category.category _
 
+/-- An additive functor is in particular a functor. -/
+def AdditiveFunctor.forget : (C ⥤+ D) ⥤ (C ⥤ D) :=
+full_subcategory_inclusion _
+
 variables {C D}
+
+/-- Turn an additive functor into an object of the catgory `AdditiveFunctor C D`. -/
+def AdditiveFunctor.of (F : C ⥤ D) [F.additive] : C ⥤+ D :=
+⟨F, infer_instance⟩
+
+@[simp]
+lemma AdditiveFunctor.of_fst (F : C ⥤ D) [F.additive] : (AdditiveFunctor.of F).1 = F :=
+rfl
+
+@[simp]
+lemma AdditiveFunctor.forget_obj (F : C ⥤+ D) : (AdditiveFunctor.forget C D).obj F = F.1 :=
+rfl
+
+lemma AdditiveFunctor.forget_obj_of (F : C ⥤ D) [F.additive] :
+  (AdditiveFunctor.forget C D).obj (AdditiveFunctor.of F) = F :=
+rfl
+
+@[simp]
+lemma AdditiveFunctor.forget_map (F G : C ⥤+ D) (α : F ⟶ G) :
+  (AdditiveFunctor.forget C D).map α = α :=
+rfl
+
+instance : functor.additive (AdditiveFunctor.forget C D) :=
+{ map_add' := λ F G α β, rfl }
 
 instance (F : C ⥤+ D) : functor.additive F.1 :=
 F.2
-
-@[simp] lemma AdditiveFunctor.hom_eq_hom {F G : C ⥤+ D} : (F ⟶ G) = (F.1 ⟶ G.1) :=
-rfl
-
-variables (C D)
-
-@[simps]
-def AdditiveFunctor.evaluation : C ⥤ (C ⥤ D) ⥤+ D :=
-{ obj := λ X,
-  { val :=
-    { obj := λ F, F.obj X,
-      map := λ F F' α, α.app X,
-      map_id' := λ F, rfl,
-      map_comp' := λ F G H α β, rfl },
-    property :=
-    { map_add' := λ X Y f g, rfl } },
-  map := λ X X' f,
-  { app := λ F, F.map f,
-    naturality' := λ F G α, (α.naturality f).symm },
-  map_id' := λ X, by { simp only [functor.map_id], refl },
-  map_comp' := λ X Y Z f g, by { simp only [functor.map_comp], refl } }
-
-instance : functor.additive (AdditiveFunctor.evaluation C D) :=
-{ map_add' := λ X Y f g, by { ext, simp } }
 
 end
 


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

Should the type be called `additive_functor` or `AdditiveFunctor`? Should it be inside some namespace?

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
