### PR TITLE
[Merged by Bors] - doc(data/set_like/basic): tidy up docstring

### DIFF
--- a/src/data/set_like/basic.lean
+++ b/src/data/set_like/basic.lean
@@ -27,16 +27,16 @@ boilerplate for every `set_like`: a `coe_sort`, a `coe` to set, a
 
 A typical subobject should be declared as:
 ```
-structure my_subobject (X : Type*) :=
+structure my_subobject (X : Type*) [object_typeclass X] :=
 (carrier : set X)
-(op_mem : ∀ {x : X}, x ∈ carrier → sorry ∈ carrier)
+(op_mem' : ∀ {x : X}, x ∈ carrier → sorry ∈ carrier)
 
 namespace my_subobject
 
-variables (X : Type*)
+variables {X : Type*} [object_typeclass X] {x : X}
 
 instance : set_like (my_subobject X) X :=
-⟨sub_mul_action.carrier, λ p q h, by cases p; cases q; congr'⟩
+⟨my_subobject.carrier, λ p q h, by cases p; cases q; congr'⟩
 
 @[simp] lemma mem_carrier {p : my_subobject X} : x ∈ p.carrier ↔ x ∈ (p : set X) := iff.rfl
 


### PR DESCRIPTION
Hopefully this makes the docstring slightly clearer.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)

I just tested out the code in this docstring, in an explicit example (because of a student project) and noticed (1) random reference to `sub_mul_action` (which is now fixed) (2) why not add the object typeclass to clarify the times where it's needed and (3) right now we refer to an `x` with no definition. I am not 100% sure about the binders; but I looked at subgroup and subfield and this was what they seem to have chosen. 