### PR TITLE
[Merged by Bors] - feat(analysis/special_functions/trigonometric): inequality `tan x  > x`

### DIFF
--- a/src/analysis/special_functions/trigonometric/arctan_deriv.lean
+++ b/src/analysis/special_functions/trigonometric/arctan_deriv.lean
@@ -7,10 +7,9 @@ import analysis.special_functions.trigonometric.arctan
 import analysis.special_functions.trigonometric.complex_deriv
 
 /-!
-# The `arctan` function.
+# Derivatives of the `tan` and `arctan` functions.
 
-Inequalities, derivatives,
-and `real.tan` as a `local_homeomorph` between `(-(π / 2), π / 2)` and the whole line.
+Continuity and derivatives of the tangent and arctangent functions.
 -/
 
 noncomputable theory

--- a/src/analysis/special_functions/trigonometric/basic.lean
+++ b/src/analysis/special_functions/trigonometric/basic.lean
@@ -486,39 +486,6 @@ by { rw real.range_cos, exact Icc.infinite (by norm_num) }
 lemma range_sin_infinite : (range real.sin).infinite :=
 by { rw real.range_sin, exact Icc.infinite (by norm_num) }
 
-lemma sin_lt {x : ℝ} (h : 0 < x) : sin x < x :=
-begin
-  cases le_or_gt x 1 with h' h',
-  { have hx : |x| = x := abs_of_nonneg (le_of_lt h),
-    have : |x| ≤ 1, rwa [hx],
-    have := sin_bound this, rw [abs_le] at this,
-    have := this.2, rw [sub_le_iff_le_add', hx] at this,
-    apply lt_of_le_of_lt this, rw [sub_add], apply lt_of_lt_of_le _ (le_of_eq (sub_zero x)),
-    apply sub_lt_sub_left, rw [sub_pos, div_eq_mul_inv (x ^ 3)], apply mul_lt_mul',
-    { rw [pow_succ x 3], refine le_trans _ (le_of_eq (one_mul _)),
-      rw mul_le_mul_right, exact h', apply pow_pos h },
-    norm_num, norm_num, apply pow_pos h },
-  exact lt_of_le_of_lt (sin_le_one x) h'
-end
-
-/- note 1: this inequality is not tight, the tighter inequality is sin x > x - x ^ 3 / 6.
-   note 2: this is also true for x > 1, but it's nontrivial for x just above 1. -/
-lemma sin_gt_sub_cube {x : ℝ} (h : 0 < x) (h' : x ≤ 1) : x - x ^ 3 / 4 < sin x :=
-begin
-  have hx : |x| = x := abs_of_nonneg (le_of_lt h),
-  have : |x| ≤ 1, rwa [hx],
-  have := sin_bound this, rw [abs_le] at this,
-  have := this.1, rw [le_sub_iff_add_le, hx] at this,
-  refine lt_of_lt_of_le _ this,
-  rw [add_comm, sub_add, sub_neg_eq_add], apply sub_lt_sub_left,
-  apply add_lt_of_lt_sub_left,
-  rw (show x ^ 3 / 4 - x ^ 3 / 6 = x ^ 3 * 12⁻¹,
-    by simp [div_eq_mul_inv, ← mul_sub]; norm_num),
-  apply mul_lt_mul',
-  { rw [pow_succ x 3], refine le_trans _ (le_of_eq (one_mul _)),
-    rw mul_le_mul_right, exact h', apply pow_pos h },
-  norm_num, norm_num, apply pow_pos h
-end
 
 section cos_div_sq
 

--- a/src/analysis/special_functions/trigonometric/bounds.lean
+++ b/src/analysis/special_functions/trigonometric/bounds.lean
@@ -35,7 +35,7 @@ open_locale real
 /-- For 0 < x, we have sin x < x. -/
 lemma sin_lt {x : ℝ} (h : 0 < x) : sin x < x :=
 begin
-  cases lt_or_ge 1 x with h' h',
+  cases lt_or_le 1 x with h' h',
   { exact (sin_le_one x).trans_lt h' },
   have hx : |x| = x := abs_of_nonneg h.le,
   have := le_of_abs_le (sin_bound $ show |x| ≤ 1, by rwa [hx]),
@@ -67,7 +67,7 @@ end
 
 
 /-- The derivative of `tan x - x` is `1/(cos x)^2 - 1` away from the zeroes of cos. -/
-lemma deriv_tan_sub_id (x : ℝ) (h: cos x ≠ 0) :
+lemma deriv_tan_sub_id (x : ℝ) (h : cos x ≠ 0) :
     deriv (λ y : ℝ, tan y - y) x = 1 / cos x ^ 2 - 1 :=
 has_deriv_at.deriv $ by simpa using (has_deriv_at_tan h).add (has_deriv_at_id x).neg
 
@@ -75,24 +75,22 @@ has_deriv_at.deriv $ by simpa using (has_deriv_at_tan h).add (has_deriv_at_id x)
 
 This is proved by checking that the function `tan x - x` vanishes
 at zero and has non-negative derivative. -/
-theorem lt_tan (x : ℝ) (h1 : 0 < x) (h2 : x < π / 2): x < tan x :=
+theorem lt_tan (x : ℝ) (h1 : 0 < x) (h2 : x < π / 2) : x < tan x :=
 begin
   let U := Ico 0 (π / 2),
 
   have intU : interior U = Ioo 0 (π / 2) := interior_Ico,
 
+  have half_pi_pos : 0 < π / 2 := div_pos pi_pos two_pos,
+
   have cos_pos : ∀ {y : ℝ}, y ∈ U → 0 < cos y,
   { intros y hy,
-    apply cos_pos_of_mem_Ioo,
-    cases hy,
-    split; linarith },
+    exact cos_pos_of_mem_Ioo (Ico_subset_Ioo_left (neg_lt_zero.mpr half_pi_pos) hy) },
 
   have sin_pos : ∀ {y : ℝ}, y ∈ interior U → 0 < sin y,
   { intros y hy,
     rw intU at hy,
-    apply sin_pos_of_mem_Ioo,
-    cases hy,
-    split; linarith },
+    exact sin_pos_of_mem_Ioo (Ioo_subset_Ioo_right (div_le_self pi_pos.le one_le_two) hy) },
 
   have tan_cts_U : continuous_on tan U,
   { apply continuous_on.mono continuous_on_tan,
@@ -118,9 +116,8 @@ begin
 
   have mono := convex.strict_mono_on_of_deriv_pos (convex_Ico 0 (π / 2)) tan_minus_id_cts deriv_pos,
   have zero_in_U : (0 : ℝ) ∈ U,
-  { split; linarith },
-  have x_in_U : x ∈ U,
-  { split; linarith },
+  { rwa left_mem_Ico },
+  have x_in_U : x ∈ U := ⟨h1.le, h2⟩,
   simpa only [tan_zero, sub_zero, sub_pos] using mono zero_in_U x_in_U h1
 end
 

--- a/src/analysis/special_functions/trigonometric/bounds.lean
+++ b/src/analysis/special_functions/trigonometric/bounds.lean
@@ -19,7 +19,7 @@ Here we prove the following:
 
 * `sin_lt`: for `x > 0` we have `sin x < x`.
 * `sin_gt_sub_cube`: For `0 < x ≤ 1` we have `sin x > x  - x^3 / 4`.
-* `tan_gt`: for `0 < x < π/2` we have `tan x > x`.
+* `lt_tan`: for `0 < x < π/2` we have `x < tan x`.
 
 ## Tags
 
@@ -71,7 +71,7 @@ begin
 end
 
 
-/- The next lemmas are building up to proving tan(x) ≥ x for x ∈ [0,π/2). -/
+/- The next lemmas are building up to proving tan(x) > x for x ∈ (0,π/2). -/
 
 private def tan_minus_id (x : ℝ) : ℝ := tan x - x
 
@@ -135,11 +135,11 @@ end
 
 private def U := Ico 0 (π/2 : ℝ)
 
-/-- For all `0 ≤ x < π/2` we have `tan x > x`.
+/-- For all `0 ≤ x < π/2` we have `x < tan x`.
 
 This is proved by checking that the function `tan x - x` vanishes
 at zero and has non-negative derivative. -/
-theorem tan_gt (x : ℝ) (h1: (0:ℝ) < x) (h2: x < π/2): tan x > x :=
+theorem lt_tan (x : ℝ) (h1: (0:ℝ) < x) (h2: x < π/2): x < tan x :=
 begin
   have intU : (interior U) = (Ioo (0:ℝ) (π/2:ℝ)) := by apply interior_Ico,
   have tan_cts_U : (continuous_on tan U),

--- a/src/analysis/special_functions/trigonometric/bounds.lean
+++ b/src/analysis/special_functions/trigonometric/bounds.lean
@@ -1,0 +1,201 @@
+/-
+Copyright (c) 2022 . All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: David Loeffler (also includes code by Chris Hughes and others
+relocated from basic.lean)
+-/
+import analysis.special_functions.trigonometric.basic
+import analysis.special_functions.trigonometric.deriv
+import analysis.special_functions.trigonometric.arctan_deriv
+/-!
+# Polynomial bounds for trigonometric functions
+
+## Main statements
+
+This file contains upper and lower bounds for real trigonometric functions in terms
+of polynomials. See `trigonometric.basic` for more elementary inequalities, establishing
+the ranges of these functions, and their monotonicity in suitable intervals.
+
+Here we prove the following:
+
+* `sin_lt`: for `x > 0` we have `sin x < x`.
+* `sin_gt_sub_cube`: For `0 < x ≤ 1` we have `sin x > x  - x^3 / 4`.
+* `tan_gt`: for `0 < x < π/2` we have `tan x > x`.
+
+## Tags
+
+sin, cos, tan, angle
+-/
+
+noncomputable theory
+open set
+
+namespace real
+notation `π` := real.pi
+
+/-- For 0 < x, we have sin x < x. -/
+lemma sin_lt {x : ℝ} (h : 0 < x) : sin x < x :=
+begin
+  cases le_or_gt x 1 with h' h',
+  { have hx : |x| = x := abs_of_nonneg (le_of_lt h),
+    have : |x| ≤ 1, rwa [hx],
+    have := sin_bound this, rw [abs_le] at this,
+    have := this.2, rw [sub_le_iff_le_add', hx] at this,
+    apply lt_of_le_of_lt this, rw [sub_add], apply lt_of_lt_of_le _ (le_of_eq (sub_zero x)),
+    apply sub_lt_sub_left, rw [sub_pos, div_eq_mul_inv (x ^ 3)], apply mul_lt_mul',
+    { rw [pow_succ x 3], refine le_trans _ (le_of_eq (one_mul _)),
+      rw mul_le_mul_right, exact h', apply pow_pos h },
+    norm_num, norm_num, apply pow_pos h },
+  exact lt_of_le_of_lt (sin_le_one x) h'
+end
+
+/-- For 0 < x ≤ 1 we have sin x ≥ x  - x^3 / 4.
+
+This is also true for x > 1, but it's nontrivial for x just above 1. This inequality is not
+tight; the tighter inequality is sin x > x - x ^ 3 / 6, but this inequality has a simpler
+proof. -/
+lemma sin_gt_sub_cube {x : ℝ} (h : 0 < x) (h' : x ≤ 1) : x - x ^ 3 / 4 < sin x :=
+begin
+  have hx : |x| = x := abs_of_nonneg (le_of_lt h),
+  have : |x| ≤ 1, rwa [hx],
+  have := sin_bound this, rw [abs_le] at this,
+  have := this.1, rw [le_sub_iff_add_le, hx] at this,
+  refine lt_of_lt_of_le _ this,
+  rw [add_comm, sub_add, sub_neg_eq_add], apply sub_lt_sub_left,
+  apply add_lt_of_lt_sub_left,
+  rw (show x ^ 3 / 4 - x ^ 3 / 6 = x ^ 3 * 12⁻¹,
+    by simp [div_eq_mul_inv, ← mul_sub]; norm_num),
+  apply mul_lt_mul',
+  { rw [pow_succ x 3], refine le_trans _ (le_of_eq (one_mul _)),
+    rw mul_le_mul_right, exact h', apply pow_pos h },
+  norm_num, norm_num, apply pow_pos h
+end
+
+
+/- The next lemmas are building up to proving tan(x) ≥ x for x ∈ [0,π/2). -/
+
+private def tan_minus_id (x : ℝ) : ℝ := tan x - x
+
+private def tansq (x : ℝ) (h : cos x ≠ 0) : ℝ := 1/(cos x)^2 - 1
+
+private lemma tan_minus_id_deriv (x : ℝ) (h: cos x ≠ 0) :
+    deriv tan_minus_id x = (tansq x h) :=
+begin
+  apply has_deriv_at.deriv,
+  simp only [tansq],
+  have uv := has_deriv_at.add (has_deriv_at_tan h) (has_deriv_at.neg (has_deriv_at_id x)),
+  simp at *,
+  exact uv,
+end
+
+/- tansq is positive away from the obvious bad points -/
+private lemma tansq_pos (x : ℝ) (h : cos x ≠ 0) (h2: sin x ≠ 0):
+  tansq x h > 0 :=
+begin
+  rw tansq,
+  simp,
+  have bd : cos x ^2 ≤ 1 := by
+  {
+    rw [sq_le,sqrt_one],
+    split, apply neg_one_le_cos,apply cos_le_one,
+    apply zero_le_one,
+  },
+  have bd2 : cos x ^2 < 1 := by
+  {
+    apply lt_of_le_of_ne bd,
+    rw cos_sq',
+    simp,exact h2,
+  },
+  rw [lt_inv,inv_one],
+  exact bd2,
+  apply zero_lt_one,
+  rwa [sq,mul_self_pos],
+end
+
+/- cos is nonzero on the Ico interval -/
+private lemma cos_nz (x : ℝ) (h1: 0 ≤ x) (h2: x < π/2): cos x ≠ 0 :=
+begin
+  intro coszero,
+  have : (x ∈ (Ioo (-(π / 2 : ℝ)) (π / 2 : ℝ))) := by
+  {
+    split,
+    apply (lt_of_lt_of_le _ h1),
+    rw [neg_lt,neg_zero],
+    exact pi_div_two_pos,
+    exact h2
+  },
+  have s : (cos x > 0) := cos_pos_of_mem_Ioo(this),
+  rw coszero at s,
+  exact (gt_irrefl (0:ℝ)) s,
+end
+
+/- sin is nonzero on the Ioo interval -/
+private lemma sin_nz (x: ℝ) (h1: 0 < x) (h2: x < π/2) : sin x ≠ 0 :=
+begin
+  apply ne_of_gt,
+  apply sin_pos_of_pos_of_lt_pi h1,
+  apply lt_trans h2,
+  rw ← lt_add_neg_iff_lt,
+  have : π + -(π / 2) = π/2 := by ring,
+  rw this, exact pi_div_two_pos,
+end
+
+private def U := Ico 0 (π/2 : ℝ)
+
+/-- For all `0 ≤ x < π/2` we have `tan x > x`.
+
+This is proved by checking that the function `tan x - x` vanishes
+at zero and has non-negative derivative. -/
+theorem tan_gt (x : ℝ) (h1: (0:ℝ) < x) (h2: x < π/2): tan x > x :=
+begin
+  have intU : (interior U) = (Ioo (0:ℝ) (π/2:ℝ)) := by apply interior_Ico,
+  have tan_cts_U : (continuous_on tan U) := by
+  {
+    apply continuous_on.mono continuous_on_tan,
+    intros z hz,
+    rw [U, Ico] at hz,
+    simp at *,
+    cases hz with zlo zhi,
+    exact cos_nz z zlo zhi,
+  },
+  have tan_minus_id_cts : (continuous_on tan_minus_id U) := by
+  {
+    have : continuous_on (id: ℝ → ℝ) U := continuous_on_id,
+    exact continuous_on.sub tan_cts_U this,
+  },
+
+  have deriv_pos : (∀ (y : ℝ), y ∈ interior U → 0 < deriv tan_minus_id y),
+  by {
+    intros y hy,
+    have t := interior_subset hy,
+    rw [intU,Ioo] at hy,
+    cases hy with ylo yhi,
+    rw tan_minus_id_deriv,
+    apply tansq_pos,
+    apply sin_nz y ylo yhi,
+    apply cos_nz y (le_of_lt ylo) yhi,
+  },
+
+  have mon:= (convex.strict_mono_on_of_deriv_pos
+    (convex_Ico 0 (π/2 : ℝ)) tan_minus_id_cts deriv_pos),
+
+  have zero_in_U: (0:ℝ) ∈ U := by
+  {
+    rw [U, Ico],
+    simp,
+    exact pi_div_two_pos,
+  },
+  have x_in_U : (x ∈ U) := by
+  {
+    rw [U,Ico],
+    simp,
+    split,
+    exact le_of_lt h1, exact h2,
+  },
+  have w := mon zero_in_U x_in_U h1,
+  rwa [tan_minus_id,tan_zero,
+    sub_zero,tan_minus_id,
+    lt_sub,sub_zero, ←gt_iff_lt] at w,
+end
+
+end real

--- a/src/analysis/special_functions/trigonometric/bounds.lean
+++ b/src/analysis/special_functions/trigonometric/bounds.lean
@@ -82,10 +82,7 @@ private lemma tan_minus_id_deriv (x : ℝ) (h: cos x ≠ 0) :
     deriv tan_minus_id x = (tansq x h) :=
 begin
   apply has_deriv_at.deriv,
-  simp only [tansq],
-  have uv := has_deriv_at.add (has_deriv_at_tan h) (has_deriv_at.neg (has_deriv_at_id x)),
-  simp at *,
-  exact uv,
+  simpa [tansq] using (has_deriv_at_tan h).add (has_deriv_at_id x).neg
 end
 
 /- tansq is positive away from the obvious bad points -/

--- a/src/analysis/special_functions/trigonometric/bounds.lean
+++ b/src/analysis/special_functions/trigonometric/bounds.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2022 . All rights reserved.
+Copyright (c) 2022 David Loeffler. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: David Loeffler
 -/
@@ -18,7 +18,7 @@ the ranges of these functions, and their monotonicity in suitable intervals.
 Here we prove the following:
 
 * `sin_lt`: for `x > 0` we have `sin x < x`.
-* `sin_gt_sub_cube`: For `0 < x ≤ 1` we have `sin x > x  - x^3 / 4`.
+* `sin_gt_sub_cube`: For `0 < x ≤ 1` we have `x - x ^ 3 / 4 < sin x`.
 * `lt_tan`: for `0 < x < π/2` we have `x < tan x`.
 
 ## Tags
@@ -30,7 +30,7 @@ noncomputable theory
 open set
 
 namespace real
-notation `π` := real.pi
+open_locale real
 
 /-- For 0 < x, we have sin x < x. -/
 lemma sin_lt {x : ℝ} (h : 0 < x) : sin x < x :=
@@ -50,11 +50,11 @@ begin
   norm_num
 end
 
-/-- For 0 < x ≤ 1 we have sin x ≥ x - x^3 / 4.
+/-- For 0 < x ≤ 1 we have x - x ^ 3 / 4 < sin x.
 
 This is also true for x > 1, but it's nontrivial for x just above 1. This inequality is not
-tight; the tighter inequality is sin x > x - x ^ 3 / 6, but this inequality has a simpler
-proof. -/
+tight; the tighter inequality is sin x > x - x ^ 3 / 6 for all x > 0, but this inequality has
+a simpler proof. -/
 lemma sin_gt_sub_cube {x : ℝ} (h : 0 < x) (h' : x ≤ 1) : x - x ^ 3 / 4 < sin x :=
 begin
   have hx : |x| = x := abs_of_nonneg h.le,
@@ -92,16 +92,12 @@ end
 private lemma tansq_pos (x : ℝ) (h : cos x ≠ 0) (h2: sin x ≠ 0):
   tansq x h > 0 :=
 begin
-  rw tansq,
-  simp,
-  have bd : cos x ^2 ≤ 1,
-  { rw [sq_le,sqrt_one],
-    split, apply neg_one_le_cos,apply cos_le_one,
-    apply zero_le_one,},
+  simp only [tansq, one_div, gt_iff_lt, sub_pos],
   have bd2 : cos x ^2 < 1,
-  { apply lt_of_le_of_ne bd,
+  { apply lt_of_le_of_ne x.cos_sq_le_one,
     rw cos_sq',
-    simp,exact h2,},
+    simp only [ne.def, sub_eq_self, pow_eq_zero_iff, nat.succ_pos'],
+    exact h2 },
   rw [lt_inv,inv_one],
   exact bd2,
   apply zero_lt_one,
@@ -118,7 +114,7 @@ begin
     rw [neg_lt,neg_zero],
     exact pi_div_two_pos,
     exact h2 },
-  have s : (cos x > 0) := cos_pos_of_mem_Ioo(this),
+  have s : (cos x > 0) := cos_pos_of_mem_Ioo this,
   rw coszero at s,
   exact (gt_irrefl (0:ℝ)) s,
 end
@@ -147,7 +143,7 @@ begin
   { apply continuous_on.mono continuous_on_tan,
     intros z hz,
     rw [U, Ico] at hz,
-    simp at *,
+    simp only [ne.def, mem_set_of_eq] at *,
     cases hz with zlo zhi,
     exact cos_nz z zlo zhi },
 
@@ -170,11 +166,11 @@ begin
 
   have zero_in_U: (0:ℝ) ∈ U,
   { rw [U, Ico],
-    simp,
+    simp only [mem_set_of_eq, le_refl, true_and],
     exact pi_div_two_pos },
   have x_in_U : (x ∈ U),
   { rw [U,Ico],
-    simp,
+    simp only [mem_set_of_eq],
     split,
     exact le_of_lt h1, exact h2 },
   have w := mon zero_in_U x_in_U h1,

--- a/src/analysis/special_functions/trigonometric/bounds.lean
+++ b/src/analysis/special_functions/trigonometric/bounds.lean
@@ -78,7 +78,7 @@ private def tan_minus_id (x : ℝ) : ℝ := tan x - x
 
 private def tansq (x : ℝ) (h : cos x ≠ 0) : ℝ := 1/(cos x)^2 - 1
 
-private lemma tan_minus_id_deriv (x : ℝ) (h: cos x ≠ 0) :
+lemma deriv_tan_sub_id (x : ℝ) (h: cos x ≠ 0) :
     deriv tan_minus_id x = (tansq x h) :=
 begin
   apply has_deriv_at.deriv,
@@ -90,30 +90,19 @@ private lemma tansq_pos (x : ℝ) (h : cos x ≠ 0) (h2: sin x ≠ 0):
   tansq x h > 0 :=
 begin
   simp only [tansq, one_div, gt_iff_lt, sub_pos],
-  have bd2 : cos x ^2 < 1,
+  have bd2 : cos x ^ 2 < 1,
   { apply lt_of_le_of_ne x.cos_sq_le_one,
-    rw cos_sq',
-    simp only [ne.def, sub_eq_self, pow_eq_zero_iff, nat.succ_pos'],
-    exact h2 },
-  rw [lt_inv,inv_one],
-  exact bd2,
-  apply zero_lt_one,
-  rwa [sq,mul_self_pos],
+    simpa only [cos_sq', ne.def, sub_eq_self, pow_eq_zero_iff, nat.succ_pos'] using h2 },
+  rwa [lt_inv, inv_one],
+  { exact zero_lt_one },
+  { rwa [sq,mul_self_pos] }
 end
 
 /- cos is nonzero on the Ico interval -/
-private lemma cos_nz (x : ℝ) (h1: 0 ≤ x) (h2: x < π/2): cos x ≠ 0 :=
+private lemma cos_pos (x : ℝ) (h1: 0 ≤ x) (h2: x < π/2): 0 < cos x :=
 begin
-  intro coszero,
-  have : (x ∈ (Ioo (-(π / 2 : ℝ)) (π / 2 : ℝ))),
-  { split,
-    apply (lt_of_lt_of_le _ h1),
-    rw [neg_lt,neg_zero],
-    exact pi_div_two_pos,
-    exact h2 },
-  have s : (cos x > 0) := cos_pos_of_mem_Ioo this,
-  rw coszero at s,
-  exact (gt_irrefl (0:ℝ)) s,
+  apply cos_pos_of_mem_Ioo,
+  split; linarith
 end
 
 /- sin is nonzero on the Ioo interval -/
@@ -135,7 +124,7 @@ This is proved by checking that the function `tan x - x` vanishes
 at zero and has non-negative derivative. -/
 theorem lt_tan (x : ℝ) (h1: (0:ℝ) < x) (h2: x < π/2): x < tan x :=
 begin
-  have intU : (interior U) = (Ioo (0:ℝ) (π/2:ℝ)) := by apply interior_Ico,
+  have intU : interior U = Ioo (0:ℝ) (π/2) := interior_Ico,
   have tan_cts_U : (continuous_on tan U),
   { apply continuous_on.mono continuous_on_tan,
     intros z hz,
@@ -144,14 +133,12 @@ begin
     cases hz with zlo zhi,
     exact cos_nz z zlo zhi },
 
-  have tan_minus_id_cts : (continuous_on tan_minus_id U),
-  { have : continuous_on (id: ℝ → ℝ) U := continuous_on_id,
-    exact continuous_on.sub tan_cts_U this},
+  have tan_minus_id_cts : continuous_on tan_minus_id U := tan_cts_U.sub continuous_on_id
 
   have deriv_pos : (∀ (y : ℝ), y ∈ interior U → 0 < deriv tan_minus_id y),
   { intros y hy,
     have t := interior_subset hy,
-    rw [intU,Ioo] at hy,
+    rw [intU, Ioo] at hy,
     cases hy with ylo yhi,
     rw tan_minus_id_deriv,
     apply tansq_pos,
@@ -162,14 +149,9 @@ begin
     (convex_Ico 0 (π/2 : ℝ)) tan_minus_id_cts deriv_pos),
 
   have zero_in_U: (0:ℝ) ∈ U,
-  { rw [U, Ico],
-    simp only [mem_set_of_eq, le_refl, true_and],
-    exact pi_div_two_pos },
+  { split; linarith },
   have x_in_U : (x ∈ U),
-  { rw [U,Ico],
-    simp only [mem_set_of_eq],
-    split,
-    exact le_of_lt h1, exact h2 },
+  { split; linarith },
   have w := mon zero_in_U x_in_U h1,
   rwa [tan_minus_id,tan_zero,
     sub_zero,tan_minus_id,

--- a/src/analysis/special_functions/trigonometric/bounds.lean
+++ b/src/analysis/special_functions/trigonometric/bounds.lean
@@ -71,58 +71,57 @@ lemma deriv_tan_sub_id (x : ℝ) (h: cos x ≠ 0) :
     deriv (λ y : ℝ, tan y - y) x = 1 / cos x ^ 2 - 1 :=
 has_deriv_at.deriv $ by simpa using (has_deriv_at_tan h).add (has_deriv_at_id x).neg
 
-private def U := Ico 0 (π/2)
-
 /-- For all `0 ≤ x < π/2` we have `x < tan x`.
 
 This is proved by checking that the function `tan x - x` vanishes
 at zero and has non-negative derivative. -/
 theorem lt_tan (x : ℝ) (h1 : 0 < x) (h2 : x < π / 2): x < tan x :=
 begin
-  have intU : interior U = Ioo 0 (π/2) := interior_Ico,
+  let U := Ico 0 (π / 2),
 
-  have cos_pos : ∀ y : ℝ, (0 ≤ y) → (y < π/2) → (0 < cos y),
-  { intros y y1 y2,
+  have intU : interior U = Ioo 0 (π / 2) := interior_Ico,
+
+  have cos_pos : ∀ {y : ℝ}, y ∈ U → 0 < cos y,
+  { intros y hy,
     apply cos_pos_of_mem_Ioo,
-    split; linarith, },
+    cases hy,
+    split; linarith },
 
-  have sin_pos : ∀ y : ℝ, 0 < y → y < π / 2 → 0 < sin y,
-  { intros y hy1 hy2,
-    apply sin_pos_of_pos_of_lt_pi hy1,
-    apply lt_trans hy2,
-    rw ← lt_add_neg_iff_lt,
-    have : π + -(π / 2) = π/2 := by ring,
-    rw this, exact pi_div_two_pos },
+  have sin_pos : ∀ {y : ℝ}, y ∈ interior U → 0 < sin y,
+  { intros y hy,
+    rw intU at hy,
+    apply sin_pos_of_mem_Ioo,
+    cases hy,
+    split; linarith },
 
   have tan_cts_U : continuous_on tan U,
   { apply continuous_on.mono continuous_on_tan,
     intros z hz,
-    rw [U, Ico] at hz,
-    simp only [ne.def, mem_set_of_eq] at *,
-    exact (cos_pos z hz.1 hz.2).ne' },
+    simp only [mem_set_of_eq],
+    exact (cos_pos hz).ne' },
 
   have tan_minus_id_cts : continuous_on (λ y : ℝ, tan y - y) U :=
     tan_cts_U.sub continuous_on_id,
 
   have deriv_pos : ∀ y : ℝ, y ∈ interior U → 0 < deriv (λ y' : ℝ, tan y' - y') y,
   { intros y hy,
-    rw [intU, Ioo] at hy,
-    have := (cos_pos y (le_of_lt hy.1) hy.2).ne',
-    simp only [deriv_tan_sub_id y this, one_div, gt_iff_lt, sub_pos],
+    have := cos_pos (interior_subset hy),
+    simp only [deriv_tan_sub_id y this.ne', one_div, gt_iff_lt, sub_pos],
     have bd2 : cos y ^ 2 < 1,
     { apply lt_of_le_of_ne y.cos_sq_le_one,
       rw cos_sq',
       simpa only [ne.def, sub_eq_self, pow_eq_zero_iff, nat.succ_pos']
-        using (sin_pos y hy.left hy.right).ne' },
+        using (sin_pos hy).ne' },
     rwa [lt_inv, inv_one],
     { exact zero_lt_one },
-    { rwa [sq, mul_self_pos] } },
+    simpa only [sq, mul_self_pos] using this.ne' },
+
   have mono := convex.strict_mono_on_of_deriv_pos (convex_Ico 0 (π / 2)) tan_minus_id_cts deriv_pos,
   have zero_in_U : (0 : ℝ) ∈ U,
   { split; linarith },
   have x_in_U : x ∈ U,
   { split; linarith },
-  simpa only [tan_zero, sub_zero, sub_pos] using mono zero_in_U x_in_U h1,
+  simpa only [tan_zero, sub_zero, sub_pos] using mono zero_in_U x_in_U h1
 end
 
 end real

--- a/src/analysis/special_functions/trigonometric/bounds.lean
+++ b/src/analysis/special_functions/trigonometric/bounds.lean
@@ -48,7 +48,7 @@ begin
   exact lt_of_le_of_lt (sin_le_one x) h'
 end
 
-/-- For 0 < x ≤ 1 we have sin x ≥ x  - x^3 / 4.
+/-- For 0 < x ≤ 1 we have sin x ≥ x - x^3 / 4.
 
 This is also true for x > 1, but it's nontrivial for x just above 1. This inequality is not
 tight; the tighter inequality is sin x > x - x ^ 3 / 6, but this inequality has a simpler

--- a/src/analysis/special_functions/trigonometric/bounds.lean
+++ b/src/analysis/special_functions/trigonometric/bounds.lean
@@ -55,19 +55,18 @@ tight; the tighter inequality is sin x > x - x ^ 3 / 6, but this inequality has 
 proof. -/
 lemma sin_gt_sub_cube {x : ℝ} (h : 0 < x) (h' : x ≤ 1) : x - x ^ 3 / 4 < sin x :=
 begin
-  have hx : |x| = x := abs_of_nonneg (le_of_lt h),
-  have : |x| ≤ 1, rwa [hx],
-  have := sin_bound this, rw [abs_le] at this,
-  have := this.1, rw [le_sub_iff_add_le, hx] at this,
+  have hx : |x| = x := abs_of_nonneg h.le,
+  have := neg_le_of_abs_le (sin_bound $ show |x| ≤ 1, by rwa [hx]),
+  rw [le_sub_iff_add_le, hx] at this,
   refine lt_of_lt_of_le _ this,
-  rw [add_comm, sub_add, sub_neg_eq_add], apply sub_lt_sub_left,
+  rw [add_comm, sub_add, sub_neg_eq_add],
+  apply sub_lt_sub_left,
   apply add_lt_of_lt_sub_left,
-  rw (show x ^ 3 / 4 - x ^ 3 / 6 = x ^ 3 * 12⁻¹,
-    by simp [div_eq_mul_inv, ← mul_sub]; norm_num),
-  apply mul_lt_mul',
-  { rw [pow_succ x 3], refine le_trans _ (le_of_eq (one_mul _)),
-    rw mul_le_mul_right, exact h', apply pow_pos h },
-  norm_num, norm_num, apply pow_pos h
+  have : x ^ 3 / 4 - x ^ 3 / 6 = x ^ 3 * 12⁻¹ := by norm_num [div_eq_mul_inv, ← mul_sub],
+  rw this,
+  refine mul_lt_mul' _ (by norm_num) (by norm_num) (pow_pos h 3),
+  apply pow_le_pow_of_le_one h.le h',
+  norm_num
 end
 
 

--- a/src/analysis/special_functions/trigonometric/bounds.lean
+++ b/src/analysis/special_functions/trigonometric/bounds.lean
@@ -35,17 +35,19 @@ notation `π` := real.pi
 /-- For 0 < x, we have sin x < x. -/
 lemma sin_lt {x : ℝ} (h : 0 < x) : sin x < x :=
 begin
-  cases le_or_gt x 1 with h' h',
-  { have hx : |x| = x := abs_of_nonneg (le_of_lt h),
-    have : |x| ≤ 1, rwa [hx],
-    have := sin_bound this, rw [abs_le] at this,
-    have := this.2, rw [sub_le_iff_le_add', hx] at this,
-    apply lt_of_le_of_lt this, rw [sub_add], apply lt_of_lt_of_le _ (le_of_eq (sub_zero x)),
-    apply sub_lt_sub_left, rw [sub_pos, div_eq_mul_inv (x ^ 3)], apply mul_lt_mul',
-    { rw [pow_succ x 3], refine le_trans _ (le_of_eq (one_mul _)),
-      rw mul_le_mul_right, exact h', apply pow_pos h },
-    norm_num, norm_num, apply pow_pos h },
-  exact lt_of_le_of_lt (sin_le_one x) h'
+  cases lt_or_ge 1 x with h' h',
+  { exact (sin_le_one x).trans_lt h' },
+  have hx : |x| = x := abs_of_nonneg h.le,
+  have := le_of_abs_le (sin_bound $ show |x| ≤ 1, by rwa [hx]),
+  rw [sub_le_iff_le_add', hx] at this,
+  apply this.trans_lt,
+  rw [sub_add],
+  apply lt_of_lt_of_le _ (sub_zero x).le,
+  apply sub_lt_sub_left,
+  rw [sub_pos, div_eq_mul_inv (x ^ 3)],
+  refine mul_lt_mul' _ (by norm_num) (by norm_num) (pow_pos h 3),
+  apply pow_le_pow_of_le_one h.le h',
+  norm_num
 end
 
 /-- For 0 < x ≤ 1 we have sin x ≥ x - x^3 / 4.

--- a/src/analysis/special_functions/trigonometric/bounds.lean
+++ b/src/analysis/special_functions/trigonometric/bounds.lean
@@ -1,8 +1,7 @@
 /-
 Copyright (c) 2022 . All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: David Loeffler (also includes code by Chris Hughes and others
-relocated from basic.lean)
+Authors: David Loeffler
 -/
 import analysis.special_functions.trigonometric.basic
 import analysis.special_functions.trigonometric.deriv
@@ -94,18 +93,14 @@ private lemma tansq_pos (x : ℝ) (h : cos x ≠ 0) (h2: sin x ≠ 0):
 begin
   rw tansq,
   simp,
-  have bd : cos x ^2 ≤ 1 := by
-  {
-    rw [sq_le,sqrt_one],
+  have bd : cos x ^2 ≤ 1,
+  { rw [sq_le,sqrt_one],
     split, apply neg_one_le_cos,apply cos_le_one,
-    apply zero_le_one,
-  },
-  have bd2 : cos x ^2 < 1 := by
-  {
-    apply lt_of_le_of_ne bd,
+    apply zero_le_one,},
+  have bd2 : cos x ^2 < 1,
+  { apply lt_of_le_of_ne bd,
     rw cos_sq',
-    simp,exact h2,
-  },
+    simp,exact h2,},
   rw [lt_inv,inv_one],
   exact bd2,
   apply zero_lt_one,
@@ -116,14 +111,12 @@ end
 private lemma cos_nz (x : ℝ) (h1: 0 ≤ x) (h2: x < π/2): cos x ≠ 0 :=
 begin
   intro coszero,
-  have : (x ∈ (Ioo (-(π / 2 : ℝ)) (π / 2 : ℝ))) := by
-  {
-    split,
+  have : (x ∈ (Ioo (-(π / 2 : ℝ)) (π / 2 : ℝ))),
+  { split,
     apply (lt_of_lt_of_le _ h1),
     rw [neg_lt,neg_zero],
     exact pi_div_two_pos,
-    exact h2
-  },
+    exact h2 },
   have s : (cos x > 0) := cos_pos_of_mem_Ioo(this),
   rw coszero at s,
   exact (gt_irrefl (0:ℝ)) s,
@@ -149,49 +142,40 @@ at zero and has non-negative derivative. -/
 theorem tan_gt (x : ℝ) (h1: (0:ℝ) < x) (h2: x < π/2): tan x > x :=
 begin
   have intU : (interior U) = (Ioo (0:ℝ) (π/2:ℝ)) := by apply interior_Ico,
-  have tan_cts_U : (continuous_on tan U) := by
-  {
-    apply continuous_on.mono continuous_on_tan,
+  have tan_cts_U : (continuous_on tan U),
+  { apply continuous_on.mono continuous_on_tan,
     intros z hz,
     rw [U, Ico] at hz,
     simp at *,
     cases hz with zlo zhi,
-    exact cos_nz z zlo zhi,
-  },
-  have tan_minus_id_cts : (continuous_on tan_minus_id U) := by
-  {
-    have : continuous_on (id: ℝ → ℝ) U := continuous_on_id,
-    exact continuous_on.sub tan_cts_U this,
-  },
+    exact cos_nz z zlo zhi },
+
+  have tan_minus_id_cts : (continuous_on tan_minus_id U),
+  { have : continuous_on (id: ℝ → ℝ) U := continuous_on_id,
+    exact continuous_on.sub tan_cts_U this},
 
   have deriv_pos : (∀ (y : ℝ), y ∈ interior U → 0 < deriv tan_minus_id y),
-  by {
-    intros y hy,
+  { intros y hy,
     have t := interior_subset hy,
     rw [intU,Ioo] at hy,
     cases hy with ylo yhi,
     rw tan_minus_id_deriv,
     apply tansq_pos,
     apply sin_nz y ylo yhi,
-    apply cos_nz y (le_of_lt ylo) yhi,
-  },
+    apply cos_nz y (le_of_lt ylo) yhi },
 
   have mon:= (convex.strict_mono_on_of_deriv_pos
     (convex_Ico 0 (π/2 : ℝ)) tan_minus_id_cts deriv_pos),
 
-  have zero_in_U: (0:ℝ) ∈ U := by
-  {
-    rw [U, Ico],
+  have zero_in_U: (0:ℝ) ∈ U,
+  { rw [U, Ico],
     simp,
-    exact pi_div_two_pos,
-  },
-  have x_in_U : (x ∈ U) := by
-  {
-    rw [U,Ico],
+    exact pi_div_two_pos },
+  have x_in_U : (x ∈ U),
+  { rw [U,Ico],
     simp,
     split,
-    exact le_of_lt h1, exact h2,
-  },
+    exact le_of_lt h1, exact h2 },
   have w := mon zero_in_U x_in_U h1,
   rwa [tan_minus_id,tan_zero,
     sub_zero,tan_minus_id,

--- a/src/analysis/special_functions/trigonometric/bounds.lean
+++ b/src/analysis/special_functions/trigonometric/bounds.lean
@@ -127,8 +127,7 @@ begin
         using (sin_pos y hy.left hy.right).ne' },
     rwa [lt_inv, inv_one],
     { exact zero_lt_one },
-    { rwa [sq,mul_self_pos] },
-  },
+    { rwa [sq,mul_self_pos] }, },
 
   have mon:= convex.strict_mono_on_of_deriv_pos
     (convex_Ico 0 (π/2)) tan_minus_id_cts deriv_pos,

--- a/src/data/complex/exponential.lean
+++ b/src/data/complex/exponential.lean
@@ -355,6 +355,15 @@ the complex exponential function -/
 /-- The complex tangent function, defined as `sin z / cos z` -/
 @[pp_nodot] def tan (z : ℂ) : ℂ := sin z / cos z
 
+/-- The complex secant function, defined as `1 / cos z` -/
+@[pp_nodot] def sec (z : ℂ) : ℂ := 1 / cos z
+
+/-- The complex cosecant function, defined as `1 / sin z` -/
+@[pp_nodot] def csc (z : ℂ) : ℂ := 1 / sin z
+
+/-- The complex cotangent function, defined as `cos z / sin z` -/
+@[pp_nodot] def cot (z : ℂ) : ℂ := cos z / sin z
+
 /-- The complex hyperbolic sine function, defined via `exp` -/
 @[pp_nodot] def sinh (z : ℂ) : ℂ := (exp z - exp (-z)) / 2
 
@@ -382,13 +391,22 @@ open complex
 /-- The real tangent function, defined as the real part of the complex tangent -/
 @[pp_nodot] def tan (x : ℝ) : ℝ := (tan x).re
 
-/-- The real hypebolic sine function, defined as the real part of the complex hyperbolic sine -/
+/-- The real secant function, defined as the real part of the complex secant -/
+@[pp_nodot] def sec (x : ℝ) : ℝ := (sec x).re
+
+/-- The real cosecant function, defined as the real part of the complex cosecant -/
+@[pp_nodot] def csc (x : ℝ) : ℝ := (csc x).re
+
+/-- The real cotangent function, defined as the real part of the complex cotangent -/
+@[pp_nodot] def cot (x : ℝ) : ℝ := (cot x).re
+
+/-- The real hyperbolic sine function, defined as the real part of the complex hyperbolic sine -/
 @[pp_nodot] def sinh (x : ℝ) : ℝ := (sinh x).re
 
-/-- The real hypebolic cosine function, defined as the real part of the complex hyperbolic cosine -/
+/-- The real hyperbolic cosine function, defined as the real part of the complex hyperbolic cosine -/
 @[pp_nodot] def cosh (x : ℝ) : ℝ := (cosh x).re
 
-/-- The real hypebolic tangent function, defined as the real part of
+/-- The real hyperbolic tangent function, defined as the real part of
 the complex hyperbolic tangent -/
 @[pp_nodot] def tanh (x : ℝ) : ℝ := (tanh x).re
 

--- a/src/data/complex/exponential.lean
+++ b/src/data/complex/exponential.lean
@@ -355,15 +355,6 @@ the complex exponential function -/
 /-- The complex tangent function, defined as `sin z / cos z` -/
 @[pp_nodot] def tan (z : ℂ) : ℂ := sin z / cos z
 
-/-- The complex secant function, defined as `1 / cos z` -/
-@[pp_nodot] def sec (z : ℂ) : ℂ := 1 / cos z
-
-/-- The complex cosecant function, defined as `1 / sin z` -/
-@[pp_nodot] def csc (z : ℂ) : ℂ := 1 / sin z
-
-/-- The complex cotangent function, defined as `cos z / sin z` -/
-@[pp_nodot] def cot (z : ℂ) : ℂ := cos z / sin z
-
 /-- The complex hyperbolic sine function, defined via `exp` -/
 @[pp_nodot] def sinh (z : ℂ) : ℂ := (exp z - exp (-z)) / 2
 
@@ -391,23 +382,13 @@ open complex
 /-- The real tangent function, defined as the real part of the complex tangent -/
 @[pp_nodot] def tan (x : ℝ) : ℝ := (tan x).re
 
-/-- The real secant function, defined as the real part of the complex secant -/
-@[pp_nodot] def sec (x : ℝ) : ℝ := (sec x).re
-
-/-- The real cosecant function, defined as the real part of the complex cosecant -/
-@[pp_nodot] def csc (x : ℝ) : ℝ := (csc x).re
-
-/-- The real cotangent function, defined as the real part of the complex cotangent -/
-@[pp_nodot] def cot (x : ℝ) : ℝ := (cot x).re
-
-/-- The real hyperbolic sine function, defined as the real part of the complex hyperbolic sine -/
+/-- The real hypebolic sine function, defined as the real part of the complex hyperbolic sine -/
 @[pp_nodot] def sinh (x : ℝ) : ℝ := (sinh x).re
 
-/-- The real hyperbolic cosine function, defined as the real part of the complex hyperbolic 
-cosine -/
+/-- The real hypebolic cosine function, defined as the real part of the complex hyperbolic cosine -/
 @[pp_nodot] def cosh (x : ℝ) : ℝ := (cosh x).re
 
-/-- The real hyperbolic tangent function, defined as the real part of
+/-- The real hypebolic tangent function, defined as the real part of
 the complex hyperbolic tangent -/
 @[pp_nodot] def tanh (x : ℝ) : ℝ := (tanh x).re
 

--- a/src/data/complex/exponential.lean
+++ b/src/data/complex/exponential.lean
@@ -403,7 +403,8 @@ open complex
 /-- The real hyperbolic sine function, defined as the real part of the complex hyperbolic sine -/
 @[pp_nodot] def sinh (x : ℝ) : ℝ := (sinh x).re
 
-/-- The real hyperbolic cosine function, defined as the real part of the complex hyperbolic cosine -/
+/-- The real hyperbolic cosine function, defined as the real part of the complex hyperbolic 
+cosine -/
 @[pp_nodot] def cosh (x : ℝ) : ℝ := (cosh x).re
 
 /-- The real hyperbolic tangent function, defined as the real part of

--- a/src/data/real/pi/bounds.lean
+++ b/src/data/real/pi/bounds.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Floris van Doorn, Mario Carneiro
 -/
 import analysis.special_functions.trigonometric.basic
+import analysis.special_functions.trigonometric.bounds
 
 /-!
 # Pi

--- a/src/data/real/pi/bounds.lean
+++ b/src/data/real/pi/bounds.lean
@@ -3,7 +3,6 @@ Copyright (c) 2019 Floris van Doorn. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Floris van Doorn, Mario Carneiro
 -/
-import analysis.special_functions.trigonometric.basic
 import analysis.special_functions.trigonometric.bounds
 
 /-!


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
This inequality for the tan function is a useful lemma in various proofs, including Cauchy's elementary proof for Euler's evaluation of zeta(2).

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
