### PR TITLE
[Merged by Bors] - feat(number_theory/cyclotomic/primitive_roots): add is_primitive_root.sub_one_power_basis

### DIFF
--- a/src/number_theory/cyclotomic/primitive_roots.lean
+++ b/src/number_theory/cyclotomic/primitive_roots.lean
@@ -109,6 +109,22 @@ power_basis.map (algebra.adjoin.power_basis $ integral {n} K L ζ) $
 (subalgebra.equiv_of_eq _ _ (is_cyclotomic_extension.adjoin_primitive_root_eq_top n _ hζ)).trans
 top_equiv
 
+lemma power_basis_gen_mem_adjoin_zeta_sub_one :
+  (power_basis K hζ).gen ∈ adjoin K ({ζ - 1} : set L) :=
+begin
+  rw [power_basis_gen, adjoin_singleton_eq_range_aeval, alg_hom.mem_range],
+  exact ⟨X + 1, by simp⟩
+end
+
+local attribute [instance] is_cyclotomic_extension.finite_dimensional
+
+/-- The `power_basis` given by `ζ - 1`. -/
+@[simps] noncomputable def sub_one_power_basis (hζ : is_primitive_root ζ n) :
+  _root_.power_basis K L :=
+  (hζ.power_basis K).of_gen_mem_adjoin
+    (is_integral_sub (is_integral_of_finite _ _ ζ) is_integral_one)
+    (hζ.power_basis_gen_mem_adjoin_zeta_sub_one _)
+
 variables {K}
 
 /-- The equivalence between `L →ₐ[K] A` and `primitive_roots n A` given by a primitive root `ζ`. -/

--- a/src/number_theory/cyclotomic/primitive_roots.lean
+++ b/src/number_theory/cyclotomic/primitive_roots.lean
@@ -116,13 +116,11 @@ begin
   exact ⟨X + 1, by simp⟩
 end
 
-local attribute [instance] is_cyclotomic_extension.finite_dimensional
-
 /-- The `power_basis` given by `ζ - 1`. -/
 @[simps] noncomputable def sub_one_power_basis (hζ : is_primitive_root ζ n) :
   _root_.power_basis K L :=
   (hζ.power_basis K).of_gen_mem_adjoin
-    (is_integral_sub (is_integral_of_finite _ _ ζ) is_integral_one)
+    (is_integral_sub (is_cyclotomic_extension.integral {n} K L ζ) is_integral_one)
     (hζ.power_basis_gen_mem_adjoin_zeta_sub_one _)
 
 variables {K}

--- a/src/ring_theory/adjoin/power_basis.lean
+++ b/src/ring_theory/adjoin/power_basis.lean
@@ -66,7 +66,7 @@ end algebra
 open algebra
 
 /-- The power basis given by `x` if `B.gen ∈ adjoin K {x}`. -/
-@[simps gen dim] noncomputable def power_basis.of_gen_mem_adjoin {x : S} (B : power_basis K S)
+@[simps] noncomputable def power_basis.of_gen_mem_adjoin {x : S} (B : power_basis K S)
   (hint : _root_.is_integral K x) (hx : B.gen ∈ adjoin K ({x} : set S)) : power_basis K S :=
 (algebra.adjoin.power_basis hint).map $
   (subalgebra.equiv_of_eq _ _ $ power_basis.adjoin_eq_top_of_gen_mem_adjoin hx).trans top_equiv

--- a/src/ring_theory/adjoin/power_basis.lean
+++ b/src/ring_theory/adjoin/power_basis.lean
@@ -62,3 +62,11 @@ where `d` is the degree of the minimal polynomial of `x`. -/
   basis_eq_pow := basis.mk_apply _ _ }
 
 end algebra
+
+open algebra
+
+/-- The power basis given by `x` if `B.gen ∈ adjoin K {x}`. -/
+@[simps gen dim] noncomputable def power_basis.of_gen_mem_adjoin {x : S} (B : power_basis K S)
+  (hint : _root_.is_integral K x) (hx : B.gen ∈ adjoin K ({x} : set S)) : power_basis K S :=
+(algebra.adjoin.power_basis hint).map $
+  (subalgebra.equiv_of_eq _ _ $ power_basis.adjoin_eq_top_of_gen_mem_adjoin hx).trans top_equiv

--- a/src/ring_theory/power_basis.lean
+++ b/src/ring_theory/power_basis.lean
@@ -533,4 +533,26 @@ pb.equiv_of_root_map _ _ _
 
 end map
 
+section adjoin
+
+open algebra
+
+lemma adjoin_gen_eq_top (B : power_basis R S) : adjoin R ({B.gen} : set S) = ⊤ :=
+begin
+  rw [← to_submodule_eq_top, _root_.eq_top_iff, ← B.basis.span_eq, submodule.span_le],
+  rintros x ⟨i, rfl⟩,
+  rw [B.basis_eq_pow i],
+  exact subalgebra.pow_mem _ (subset_adjoin (set.mem_singleton _)) _,
+end
+
+lemma adjoin_eq_top_of_gen_mem_adjoin {B : power_basis R S} {x : S}
+  (hx : B.gen ∈ adjoin R ({x} : set S)) : adjoin R ({x} : set S) = ⊤ :=
+begin
+  rw [_root_.eq_top_iff, ← B.adjoin_gen_eq_top],
+  refine adjoin_le _,
+  simp [hx],
+end
+
+end adjoin
+
 end power_basis


### PR DESCRIPTION
We add `is_primitive_root.sub_one_power_basis`,  the power basis of a cyclotomic extension given by `ζ - 1`, where `ζ ` is a primitive root of unity.

From flt-regular.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
