### PR TITLE
[Merged by Bors] - chore(data/polynomial/monic): remove useless lemma

### DIFF
--- a/src/data/polynomial/monic.lean
+++ b/src/data/polynomial/monic.lean
@@ -35,12 +35,10 @@ begin
   exact congr_arg C hp
 end
 
-lemma ne_zero_of_monic_of_zero_ne_one (hp : monic p) (h : (0 : R) ≠ 1) :
-  p ≠ 0 := mt (congr_arg leading_coeff) $ by rw [monic.def.1 hp, leading_coeff_zero]; cc
-
 lemma ne_zero_of_ne_zero_of_monic (hp : p ≠ 0) (hq : monic q) : q ≠ 0 :=
 begin
-  intro h, rw [h, monic.def, leading_coeff_zero] at hq,
+  rintro rfl,
+  rw [monic.def, leading_coeff_zero] at hq,
   rw [← mul_one p, ← C_1, ← hq, C_0, mul_zero] at hp,
   exact hp rfl
 end


### PR DESCRIPTION
There is a `nontrivial` version of this lemma (`ne_zero_of_monic`) which actually has uses in the library, unlike this deleted lemma. We also tidy the proof of the lemma below.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
