### PR TITLE
[Merged by Bors] - feat(data/int/basic): add three lemmas about ints, nats and int_nat_abs

### DIFF
--- a/src/data/int/basic.lean
+++ b/src/data/int/basic.lean
@@ -1151,6 +1151,10 @@ le_iff_le_iff_lt_iff_lt.1 to_nat_le
 @[simp]lemma le_to_nat_iff {n : ℕ} {z : ℤ} (h : 0 ≤ z) : n ≤ z.to_nat ↔ (n : ℤ) ≤ z :=
 by rw [←int.coe_nat_le_coe_nat_iff, int.to_nat_of_nonneg h]
 
+@[simp]
+lemma int.coe_nat_nonpos_iff {n : ℕ} : (n : ℤ) ≤ 0 ↔ n = 0 :=
+by exact_mod_cast nat.le_zero_iff
+
 theorem to_nat_le_to_nat {a b : ℤ} (h : a ≤ b) : to_nat a ≤ to_nat b :=
 by rw to_nat_le; exact le_trans h (le_to_nat b)
 
@@ -1209,6 +1213,14 @@ lemma to_nat_of_nonpos : ∀ {z : ℤ}, z ≤ 0 → z.to_nat = 0
 | (0 : ℕ)     := λ _, rfl
 | (n + 1 : ℕ) := λ h, (h.not_lt (by { exact_mod_cast nat.succ_pos n })).elim
 | (-[1+ n])  := λ _, rfl
+
+@[simp]
+lemma int.to_nat_eq_zero {n : ℤ} : n.to_nat = 0 ↔ n ≤ 0 :=
+begin
+  induction n,
+  { simp only [int.of_nat_eq_coe, int.to_nat_coe_nat, int.coe_nat_nonpos_iff] },
+  { simp [int.neg_succ_of_nat_coe'] }
+end
 
 /-! ### units -/
 

--- a/src/data/int/basic.lean
+++ b/src/data/int/basic.lean
@@ -1211,9 +1211,9 @@ theorem mem_to_nat' : ∀ (a : ℤ) (n : ℕ), n ∈ to_nat' a ↔ a = n
 | -[1+ m] n := by split; intro h; cases h
 
 lemma to_nat_of_nonpos : ∀ {z : ℤ}, z ≤ 0 → z.to_nat = 0
-| (0 : ℕ)     _ := rfl
+| 0           _ := rfl
 | (n + 1 : ℕ) h := (h.not_lt (by { exact_mod_cast nat.succ_pos n })).elim
-| (-[1+ n])   _ := rfl
+| -[1+ n]     _ := rfl
 
 @[simp]
 lemma to_nat_neg_nat : ∀ (n : ℕ),  (-(n : ℤ)).to_nat = 0
@@ -1225,7 +1225,7 @@ lemma to_nat_eq_zero : ∀ {n : ℤ}, n.to_nat = 0 ↔ n ≤ 0
 | (n : ℕ) := calc _ ↔ (n = 0) : ⟨(to_nat_coe_nat n).symm.trans, (to_nat_coe_nat n).trans⟩
                 ... ↔ _       : int.coe_nat_nonpos_iff.symm
 | -[1+ n] := show ((-((n : ℤ) + 1)).to_nat = 0) ↔ (-(n + 1) : ℤ) ≤ 0, from
-calc _ ↔ true : ⟨λ _, trivial, λ h, to_nat_neg_nat⟩
+calc _ ↔ true : ⟨λ _, trivial, λ h, to_nat_neg_nat _⟩
    ... ↔ _    : ⟨λ h, int.neg_nonpos_of_nonneg (int.coe_zero_le (n + 1)), λ _, trivial⟩
 
 /-! ### units -/

--- a/src/data/int/basic.lean
+++ b/src/data/int/basic.lean
@@ -1153,7 +1153,8 @@ by rw [←int.coe_nat_le_coe_nat_iff, int.to_nat_of_nonneg h]
 
 @[simp]
 lemma coe_nat_nonpos_iff {n : ℕ} : (n : ℤ) ≤ 0 ↔ n = 0 :=
-by exact_mod_cast nat.le_zero_iff
+⟨ λ h, le_antisymm (int.coe_nat_le.mp (h.trans int.coe_nat_zero.le)) n.zero_le,
+  λ h, (coe_nat_eq_zero.mpr h).le⟩
 
 theorem to_nat_le_to_nat {a b : ℤ} (h : a ≤ b) : to_nat a ≤ to_nat b :=
 by rw to_nat_le; exact le_trans h (le_to_nat b)
@@ -1210,17 +1211,21 @@ theorem mem_to_nat' : ∀ (a : ℤ) (n : ℕ), n ∈ to_nat' a ↔ a = n
 | -[1+ m] n := by split; intro h; cases h
 
 lemma to_nat_of_nonpos : ∀ {z : ℤ}, z ≤ 0 → z.to_nat = 0
-| (0 : ℕ)     := λ _, rfl
-| (n + 1 : ℕ) := λ h, (h.not_lt (by { exact_mod_cast nat.succ_pos n })).elim
-| (-[1+ n])  := λ _, rfl
+| (0 : ℕ)     _ := rfl
+| (n + 1 : ℕ) h := (h.not_lt (by { exact_mod_cast nat.succ_pos n })).elim
+| (-[1+ n])   _ := rfl
+
+lemma to_nat_neg_nat : ∀ {n : ℕ},  (-(n : ℤ)).to_nat = 0
+| 0       := rfl
+| (n + 1) := rfl
 
 @[simp]
-lemma to_nat_eq_zero {n : ℤ} : n.to_nat = 0 ↔ n ≤ 0 :=
-begin
-  induction n,
-  { simp only [of_nat_eq_coe, to_nat_coe_nat, coe_nat_nonpos_iff] },
-  { simp [int.neg_succ_of_nat_coe'] }
-end
+lemma to_nat_eq_zero : ∀ {n : ℤ}, n.to_nat = 0 ↔ n ≤ 0
+| (n : ℕ) := calc _ ↔ (n = 0) : ⟨(to_nat_coe_nat n).symm.trans, (to_nat_coe_nat n).trans⟩
+                ... ↔ _       : int.coe_nat_nonpos_iff.symm
+| -[1+ n] := show ((-((n : ℤ) + 1)).to_nat = 0) ↔ (-(n + 1) : ℤ) ≤ 0, from
+calc _ ↔ true : ⟨λ _, trivial, λ h, to_nat_neg_nat⟩
+   ... ↔ _    : ⟨λ h, int.neg_nonpos_of_nonneg (int.coe_zero_le (n + 1)), λ _, trivial⟩
 
 /-! ### units -/
 

--- a/src/data/int/basic.lean
+++ b/src/data/int/basic.lean
@@ -1212,7 +1212,7 @@ theorem mem_to_nat' : ∀ (a : ℤ) (n : ℕ), n ∈ to_nat' a ↔ a = n
 
 lemma to_nat_of_nonpos : ∀ {z : ℤ}, z ≤ 0 → z.to_nat = 0
 | 0           _ := rfl
-| (n + 1 : ℕ) h := (h.not_lt (by { exact_mod_cast nat.succ_pos n })).elim
+| (n + 1 : ℕ) h := (h.not_lt (coe_nat_succ_pos _)).elim
 | -[1+ n]     _ := rfl
 
 @[simp]

--- a/src/data/int/basic.lean
+++ b/src/data/int/basic.lean
@@ -1223,10 +1223,10 @@ lemma to_nat_neg_nat : ∀ (n : ℕ),  (-(n : ℤ)).to_nat = 0
 @[simp]
 lemma to_nat_eq_zero : ∀ {n : ℤ}, n.to_nat = 0 ↔ n ≤ 0
 | (n : ℕ) := calc _ ↔ (n = 0) : ⟨(to_nat_coe_nat n).symm.trans, (to_nat_coe_nat n).trans⟩
-                ... ↔ _       : int.coe_nat_nonpos_iff.symm
+                ... ↔ _       : coe_nat_nonpos_iff.symm
 | -[1+ n] := show ((-((n : ℤ) + 1)).to_nat = 0) ↔ (-(n + 1) : ℤ) ≤ 0, from
 calc _ ↔ true : ⟨λ _, trivial, λ h, to_nat_neg_nat _⟩
-   ... ↔ _    : ⟨λ h, int.neg_nonpos_of_nonneg (int.coe_zero_le (n + 1)), λ _, trivial⟩
+   ... ↔ _    : ⟨λ h, neg_nonpos_of_nonneg (coe_zero_le _), λ _, trivial⟩
 
 /-! ### units -/
 

--- a/src/data/int/basic.lean
+++ b/src/data/int/basic.lean
@@ -1215,7 +1215,8 @@ lemma to_nat_of_nonpos : ∀ {z : ℤ}, z ≤ 0 → z.to_nat = 0
 | (n + 1 : ℕ) h := (h.not_lt (by { exact_mod_cast nat.succ_pos n })).elim
 | (-[1+ n])   _ := rfl
 
-lemma to_nat_neg_nat : ∀ {n : ℕ},  (-(n : ℤ)).to_nat = 0
+@[simp]
+lemma to_nat_neg_nat : ∀ (n : ℕ),  (-(n : ℤ)).to_nat = 0
 | 0       := rfl
 | (n + 1) := rfl
 

--- a/src/data/int/basic.lean
+++ b/src/data/int/basic.lean
@@ -1152,7 +1152,7 @@ le_iff_le_iff_lt_iff_lt.1 to_nat_le
 by rw [←int.coe_nat_le_coe_nat_iff, int.to_nat_of_nonneg h]
 
 @[simp]
-lemma int.coe_nat_nonpos_iff {n : ℕ} : (n : ℤ) ≤ 0 ↔ n = 0 :=
+lemma coe_nat_nonpos_iff {n : ℕ} : (n : ℤ) ≤ 0 ↔ n = 0 :=
 by exact_mod_cast nat.le_zero_iff
 
 theorem to_nat_le_to_nat {a b : ℤ} (h : a ≤ b) : to_nat a ≤ to_nat b :=
@@ -1215,10 +1215,10 @@ lemma to_nat_of_nonpos : ∀ {z : ℤ}, z ≤ 0 → z.to_nat = 0
 | (-[1+ n])  := λ _, rfl
 
 @[simp]
-lemma int.to_nat_eq_zero {n : ℤ} : n.to_nat = 0 ↔ n ≤ 0 :=
+lemma to_nat_eq_zero {n : ℤ} : n.to_nat = 0 ↔ n ≤ 0 :=
 begin
   induction n,
-  { simp only [int.of_nat_eq_coe, int.to_nat_coe_nat, int.coe_nat_nonpos_iff] },
+  { simp only [of_nat_eq_coe, to_nat_coe_nat, coe_nat_nonpos_iff] },
   { simp [int.neg_succ_of_nat_coe'] }
 end
 

--- a/src/data/int/basic.lean
+++ b/src/data/int/basic.lean
@@ -1216,7 +1216,7 @@ lemma to_nat_of_nonpos : ∀ {z : ℤ}, z ≤ 0 → z.to_nat = 0
 | -[1+ n]     _ := rfl
 
 @[simp]
-lemma to_nat_neg_nat : ∀ (n : ℕ),  (-(n : ℤ)).to_nat = 0
+lemma to_nat_neg_nat : ∀ (n : ℕ), (-(n : ℤ)).to_nat = 0
 | 0       := rfl
 | (n + 1) := rfl
 


### PR DESCRIPTION
[Zulip discussion](https://leanprover.zulipchat.com/#narrow/stream/217875-Is-there.20code.20for.20X.3F/topic/int.2Eto_nat_eq_zero)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
