### PR TITLE
[Merged by Bors] - perf(data/fintype/basic): speed up mem_of_mem_perms_of_list

### DIFF
--- a/src/data/fintype/basic.lean
+++ b/src/data/fintype/basic.lean
@@ -1557,7 +1557,7 @@ lemma mem_of_mem_perms_of_list :
     else mem_cons_of_mem _ $
     mem_of_mem_perms_of_list hg₁ $
       by rw [eq_inv_mul_iff_mul_eq.2 hg₂, mul_apply, swap_inv, swap_apply_def];
-        split_ifs; cc)
+        split_ifs; [exact ne.symm hxy, exact ne.symm hxa, exact hx])
 
 lemma mem_perms_of_list_iff {l : list α} {f : perm α} :
   f ∈ perms_of_list l ↔ ∀ {x}, f x ≠ x → x ∈ l :=


### PR DESCRIPTION
This single theorem was taking twice as long as everything else in the file put together, and it was easy to fix.