### PR TITLE
[Merged by Bors] - chore(linear_algebra/general_linear_group): replace coe_fn with coe in lemma statements

### DIFF
--- a/src/linear_algebra/general_linear_group.lean
+++ b/src/linear_algebra/general_linear_group.lean
@@ -8,13 +8,18 @@ import linear_algebra.special_linear_group
 
 /-!
 # The General Linear group $GL(n, R)$
+
 This file defines the elements of the General Linear group `general_linear_group n R`,
 consisting of all invertible `n` by `n` `R`-matrices.
+
 ## Main definitions
+
 * `matrix.general_linear_group` is the type of matrices over R which are units in the matrix ring.
 * `matrix.GL_pos` gives the subgroup of matrices with
   positive determinant (over a linear ordered ring).
+
 ## Tags
+
 matrix group, group, matrix inverse
 -/
 
@@ -22,6 +27,9 @@ namespace matrix
 universes u v
 open_locale matrix
 open linear_map
+
+-- disable this instance so we do not accidentally use it in lemmas.
+local attribute [-instance] special_linear_group.has_coe_to_fun
 
 /-- `GL n R` is the group of `n` by `n` `R`-matrices with unit determinant.
 Defined as a subtype of matrices-/
@@ -62,9 +70,6 @@ def mk_of_det_ne_zero {K : Type*} [field K] (A : matrix n n K) (h : matrix.det A
   GL n K :=
 mk' A (invertible_of_nonzero h)
 
-instance coe_fun : has_coe_to_fun (GL n R) (λ _, n → n → R) :=
-{ coe := λ A, A.val }
-
 lemma ext_iff (A B : GL n R) : A = B ↔ (∀ i j, (A : matrix n n R) i j = (B : matrix n n R) i j) :=
 units.ext_iff.trans matrix.ext_iff.symm
 
@@ -77,7 +82,6 @@ section coe_lemmas
 
 variables (A B : GL n R)
 
-@[simp] lemma coe_fn_eq_coe : ⇑A = (↑A : matrix n n R) := rfl
 
 @[simp] lemma coe_mul : ↑(A * B) = (↑A : matrix n n R) ⬝ (↑B : matrix n n R) := rfl
 
@@ -103,7 +107,7 @@ units.map_equiv matrix.to_lin_alg_equiv'.to_ring_equiv.to_mul_equiv
 rfl
 
 @[simp] lemma to_linear_apply (v : n → R) :
-  (@to_linear n ‹_› ‹_› _ _ A) v = matrix.mul_vec_lin A v :=
+  (@to_linear n ‹_› ‹_› _ _ A) v = matrix.mul_vec_lin ↑A v :=
 rfl
 
 end coe_lemmas
@@ -155,13 +159,12 @@ instance : has_distrib_neg (GL_pos n R) :=
   neg_mul := λ x y, subtype.ext $ neg_mul _ _,
   mul_neg := λ x y, subtype.ext $ mul_neg _ _ }
 
-@[simp] lemma GL_pos_coe_neg (g : GL_pos n R) : ↑(- g) = - (↑g : matrix n n R) :=
+@[simp] lemma GL_pos.coe_neg (g : GL_pos n R) : ↑(- g) = - (↑g : matrix n n R) :=
 rfl
 
-@[simp]lemma GL_pos_neg_elt (g : GL_pos n R): ∀ i j, ( ↑(-g): matrix n n R) i j= - (g i j):=
-begin
-  simp [coe_fn_coe_base'],
-end
+@[simp] lemma GL_pos.coe_neg_apply (g : GL_pos n R) (i j : n) :
+  (↑(-g) : matrix n n R) i j = -((↑g : matrix n n R) i j) :=
+rfl
 
 end has_neg
 
@@ -201,5 +204,21 @@ general_linear_group.mk_of_det_ne_zero ![![a, -b], ![b, a]]
 -/
 
 end examples
+
+namespace general_linear_group
+variables {n : Type u} [decidable_eq n] [fintype n] {R : Type v} [comm_ring R]
+
+-- this section should be last to ensure we do not use it in lemmas
+section coe_fn_instance
+
+/-- This instance is here for convenience, but is not the simp-normal form. -/
+instance : has_coe_to_fun (GL n R) (λ _, n → n → R) :=
+{ coe := λ A, A.val }
+
+@[simp] lemma coe_fn_eq_coe (A : GL n R) : ⇑A = (↑A : matrix n n R) := rfl
+
+end coe_fn_instance
+
+end general_linear_group
 
 end matrix

--- a/src/linear_algebra/general_linear_group.lean
+++ b/src/linear_algebra/general_linear_group.lean
@@ -82,7 +82,6 @@ section coe_lemmas
 
 variables (A B : GL n R)
 
-
 @[simp] lemma coe_mul : ↑(A * B) = (↑A : matrix n n R) ⬝ (↑B : matrix n n R) := rfl
 
 @[simp] lemma coe_one : ↑(1 : GL n R) = (1 : matrix n n R) := rfl


### PR DESCRIPTION
This way, all the lemmas are expressed in terms of `↑` and not `⇑`.
This matches the approach used in `special_linear_group`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
-->
- [x] depends on: #12396

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)

