### PR TITLE
[Merged by Bors] - chore(probability/independence): change to set notation and `measurable_set`

### DIFF
--- a/src/measure_theory/measurable_space_def.lean
+++ b/src/measure_theory/measurable_space_def.lean
@@ -305,10 +305,6 @@ lemma measurable_set_generate_from {s : set (set α)} {t : set α} (ht : t ∈ s
   (generate_from s).measurable_set' t :=
 generate_measurable.basic t ht
 
-lemma measurable_set_generate_from' {s : set (set α)} {t : set α} (ht : t ∈ s) :
-  @measurable_set _ (generate_from s) t :=
-generate_measurable.basic t ht
-
 lemma generate_from_le {s : set (set α)} {m : measurable_space α}
   (h : ∀ t ∈ s, m.measurable_set' t) : generate_from s ≤ m :=
 assume t (ht : generate_measurable s t), ht.rec_on h

--- a/src/measure_theory/measurable_space_def.lean
+++ b/src/measure_theory/measurable_space_def.lean
@@ -305,6 +305,10 @@ lemma measurable_set_generate_from {s : set (set α)} {t : set α} (ht : t ∈ s
   (generate_from s).measurable_set' t :=
 generate_measurable.basic t ht
 
+lemma measurable_set_generate_from' {s : set (set α)} {t : set α} (ht : t ∈ s) :
+  @measurable_set _ (generate_from s) t :=
+measurable_set_generate_from ht
+
 lemma generate_from_le {s : set (set α)} {m : measurable_space α}
   (h : ∀ t ∈ s, m.measurable_set' t) : generate_from s ≤ m :=
 assume t (ht : generate_measurable s t), ht.rec_on h

--- a/src/measure_theory/measurable_space_def.lean
+++ b/src/measure_theory/measurable_space_def.lean
@@ -305,6 +305,10 @@ lemma measurable_set_generate_from {s : set (set α)} {t : set α} (ht : t ∈ s
   (generate_from s).measurable_set' t :=
 generate_measurable.basic t ht
 
+lemma measurable_set_generate_from' {s : set (set α)} {t : set α} (ht : t ∈ s) :
+  @measurable_set _ (generate_from s) t :=
+generate_measurable.basic t ht
+
 lemma generate_from_le {s : set (set α)} {m : measurable_space α}
   (h : ∀ t ∈ s, m.measurable_set' t) : generate_from s ≤ m :=
 assume t (ht : generate_measurable s t), ht.rec_on h

--- a/src/measure_theory/measurable_space_def.lean
+++ b/src/measure_theory/measurable_space_def.lean
@@ -302,12 +302,8 @@ def generate_from (s : set (set α)) : measurable_space α :=
   measurable_set_Union := generate_measurable.union }
 
 lemma measurable_set_generate_from {s : set (set α)} {t : set α} (ht : t ∈ s) :
-  (generate_from s).measurable_set' t :=
-generate_measurable.basic t ht
-
-lemma measurable_set_generate_from' {s : set (set α)} {t : set α} (ht : t ∈ s) :
   @measurable_set _ (generate_from s) t :=
-measurable_set_generate_from ht
+generate_measurable.basic t ht
 
 lemma generate_from_le {s : set (set α)} {m : measurable_space α}
   (h : ∀ t ∈ s, m.measurable_set' t) : generate_from s ≤ m :=

--- a/src/probability/independence.lean
+++ b/src/probability/independence.lean
@@ -254,7 +254,7 @@ lemma Indep.Indep_sets {α ι} [measurable_space α] {μ : measure α} {m : ι �
   (h_indep : Indep m μ) :
   Indep_sets s μ :=
 λ S f hfs, h_indep S $ λ x hxS,
-  ((hms x).symm ▸ measurable_set_generate_from (hfs x hxS) : (m x).measurable_set' (f x))
+  ((hms x).symm ▸ measurable_set_generate_from (hfs x hxS) : measurable_set[m x] (f x))
 
 lemma indep.indep_sets {α} [measurable_space α] {μ : measure α} {s1 s2 : set (set α)}
   (h_indep : indep (generate_from s1) (generate_from s2) μ) :

--- a/src/probability/independence.lean
+++ b/src/probability/independence.lean
@@ -64,7 +64,7 @@ Part A, Chapter 4.
 -/
 
 open measure_theory measurable_space
-open_locale big_operators classical
+open_locale big_operators classical measure_theory
 
 namespace probability_theory
 
@@ -90,7 +90,7 @@ for any finite set of indices `s = {i_1, ..., i_n}`, for any sets
 `f i_1 ∈ m i_1, ..., f i_n ∈ m i_n`, then `μ (⋂ i in s, f i) = ∏ i in s, μ (f i) `. -/
 def Indep {α ι} (m : ι → measurable_space α) [measurable_space α] (μ : measure α . volume_tac) :
   Prop :=
-Indep_sets (λ x, (m x).measurable_set') μ
+Indep_sets (λ x, {s | measurable_set[m x] s}) μ
 
 /-- Two measurable space structures (or σ-algebras) `m₁, m₂` are independent with respect to a
 measure `μ` (defined on a third σ-algebra) if for any sets `t₁ ∈ m₁, t₂ ∈ m₂`,
@@ -250,13 +250,13 @@ section from_measurable_spaces_to_sets_of_sets
 /-! ### Independence of measurable space structures implies independence of generating π-systems -/
 
 lemma Indep.Indep_sets {α ι} [measurable_space α] {μ : measure α} {m : ι → measurable_space α}
-  {s : ι → set (set α)} (hms : ∀ n, m n = measurable_space.generate_from (s n))
+  {s : ι → set (set α)} (hms : ∀ n, m n = generate_from (s n))
   (h_indep : Indep m μ) :
   Indep_sets s μ :=
 begin
   refine (λ S f hfs, h_indep S (λ x hxS, _)),
   simp_rw hms x,
-  exact measurable_set_generate_from (hfs x hxS),
+  exact measurable_set_generate_from' (hfs x hxS),
 end
 
 lemma indep.indep_sets {α} [measurable_space α] {μ : measure α} {s1 s2 : set (set α)}

--- a/src/probability/independence.lean
+++ b/src/probability/independence.lean
@@ -253,12 +253,8 @@ lemma Indep.Indep_sets {α ι} [measurable_space α] {μ : measure α} {m : ι �
   {s : ι → set (set α)} (hms : ∀ n, m n = generate_from (s n))
   (h_indep : Indep m μ) :
   Indep_sets s μ :=
-begin
-  refine (λ S f hfs, h_indep S (λ x hxS, _)),
-  change (m x).measurable_set' (f x),
-  simp_rw hms x,
-  exact measurable_set_generate_from (hfs x hxS),
-end
+λ S f hfs, h_indep S $ λ x hxS,
+  ((hms x).symm ▸ measurable_set_generate_from (hfs x hxS) : (m x).measurable_set' (f x))
 
 lemma indep.indep_sets {α} [measurable_space α] {μ : measure α} {s1 s2 : set (set α)}
   (h_indep : indep (generate_from s1) (generate_from s2) μ) :

--- a/src/probability/independence.lean
+++ b/src/probability/independence.lean
@@ -257,7 +257,7 @@ begin
   refine (λ S f hfs, h_indep S (λ x hxS, _)),
   change (m x).measurable_set' (f x),
   simp_rw hms x,
-  exact measurable_set_generate_from' (hfs x hxS),
+  exact measurable_set_generate_from (hfs x hxS),
 end
 
 lemma indep.indep_sets {α} [measurable_space α] {μ : measure α} {s1 s2 : set (set α)}

--- a/src/probability/independence.lean
+++ b/src/probability/independence.lean
@@ -97,7 +97,7 @@ measure `μ` (defined on a third σ-algebra) if for any sets `t₁ ∈ m₁, t�
 `μ (t₁ ∩ t₂) = μ (t₁) * μ (t₂)` -/
 def indep {α} (m₁ m₂ : measurable_space α) [measurable_space α] (μ : measure α . volume_tac) :
   Prop :=
-indep_sets (m₁.measurable_set') (m₂.measurable_set') μ
+indep_sets ({s | measurable_set[m₁] s}) ({s | measurable_set[m₂] s}) μ
 
 /-- A family of sets is independent if the family of measurable space structures they generate is
 independent. For a set `s`, the generated measurable space has measurable sets `∅, s, sᶜ, univ`. -/
@@ -255,6 +255,7 @@ lemma Indep.Indep_sets {α ι} [measurable_space α] {μ : measure α} {m : ι �
   Indep_sets s μ :=
 begin
   refine (λ S f hfs, h_indep S (λ x hxS, _)),
+  change (m x).measurable_set' (f x),
   simp_rw hms x,
   exact measurable_set_generate_from' (hfs x hxS),
 end


### PR DESCRIPTION
---
Currently when working with independence it sometimes generates goals such as 
```lean
s ∈ (measurable_space.generate_from {s}).measurable_set'
```
This PR should make the above goal into a nicer form.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
