### PR TITLE
[Merged by Bors] - chore(algebra/group/hom): more generic `f x ≠ 1` lemmas

### DIFF
--- a/src/algebra/group/hom.lean
+++ b/src/algebra/group/hom.lean
@@ -187,6 +187,17 @@ one_hom_class.map_one f
 hf.eq_iff' (map_one f)
 
 @[to_additive]
+lemma map_ne_one_iff {R S F : Type*} [has_one R] [has_one S] [one_hom_class F R S]
+  (f : F) (hf : function.injective f) {x : R} :
+  f x ≠ 1 ↔ x ≠ 1 :=
+not_congr (map_eq_one_iff f hf)
+
+@[to_additive]
+lemma ne_one_of_map {R S F : Type*} [has_one R] [has_one S] [one_hom_class F R S]
+  {f : F} {x : R} (hx : f x ≠ 1) : x ≠ 1 :=
+mt (λ h, show f x = 1, from h.symm ▸ map_one f) hx
+
+@[to_additive]
 instance [one_hom_class F M N] : has_coe_t F (one_hom M N) :=
 ⟨λ f, { to_fun := f, map_one' := map_one f }⟩
 

--- a/src/algebra/group/hom.lean
+++ b/src/algebra/group/hom.lean
@@ -190,12 +190,12 @@ hf.eq_iff' (map_one f)
 lemma map_ne_one_iff {R S F : Type*} [has_one R] [has_one S] [one_hom_class F R S]
   (f : F) (hf : function.injective f) {x : R} :
   f x ≠ 1 ↔ x ≠ 1 :=
-not_congr (map_eq_one_iff f hf)
+(map_eq_one_iff f hf).not
 
 @[to_additive]
 lemma ne_one_of_map {R S F : Type*} [has_one R] [has_one S] [one_hom_class F R S]
   {f : F} {x : R} (hx : f x ≠ 1) : x ≠ 1 :=
-mt (λ h, show f x = 1, from h.symm ▸ map_one f) hx
+ne_of_apply_ne f $ ne_of_ne_of_eq hx (map_one f).symm
 
 @[to_additive]
 instance [one_hom_class F M N] : has_coe_t F (one_hom M N) :=

--- a/src/data/equiv/mul_add.lean
+++ b/src/data/equiv/mul_add.lean
@@ -124,15 +124,14 @@ variables {F}
 
 @[simp, to_additive]
 lemma map_eq_one_iff {M N} [mul_one_class M] [mul_one_class N] [mul_equiv_class F M N]
-  (h : F) {x : M} :
-  h x = 1 ↔ x = 1 :=
-by rw [← map_one h, equiv_like.apply_eq_iff_eq h]
+  (h : F) {x : M} : h x = 1 ↔ x = 1 :=
+map_eq_one_iff h (equiv_like.injective h)
 
 @[to_additive]
 lemma map_ne_one_iff {M N} [mul_one_class M] [mul_one_class N] [mul_equiv_class F M N]
   (h : F) {x : M} :
   h x ≠ 1 ↔ x ≠ 1 :=
-not_congr (map_eq_one_iff h)
+map_ne_one_iff h (equiv_like.injective h)
 
 end mul_equiv_class
 


### PR DESCRIPTION
 * `map_ne_{one,zero}_iff` is the `not_congr` version of `map_eq_one_iff`, which was previously only available for `mul_equiv_class`

 * `ne_{one,zero}_of_map` is one direction of `map_ne_{one,zero}_iff` that doesn't assume injectivity

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
