### PR TITLE
[Merged by Bors] - feat(algebra/module/submodule_pointwise): pointwise negation

### DIFF
--- a/src/algebra/algebra/operations.lean
+++ b/src/algebra/algebra/operations.lean
@@ -196,7 +196,7 @@ end
 section
 open_locale pointwise
 
-/-- `submodule.has_neg` distributes over multiplication.
+/-- `submodule.has_pointwise_neg` distributes over multiplication.
 
 This is available as an instance in the `pointwise` locale. -/
 protected def has_distrib_pointwise_neg {A} [ring A] [algebra R A] :

--- a/src/algebra/algebra/operations.lean
+++ b/src/algebra/algebra/operations.lean
@@ -199,7 +199,8 @@ open_locale pointwise
 /-- `submodule.has_neg` distributes over multiplication.
 
 This is available as an instance in the `pointwise` locale. -/
-def has_distrib_pointwise_neg {A} [ring A] [algebra R A] : has_distrib_neg (submodule R A) :=
+protected def has_distrib_pointwise_neg {A} [ring A] [algebra R A] :
+  has_distrib_neg (submodule R A) :=
 { neg := has_neg.neg,
   neg_mul := λ x y, begin
     refine le_antisymm

--- a/src/algebra/algebra/operations.lean
+++ b/src/algebra/algebra/operations.lean
@@ -193,6 +193,36 @@ calc map f.to_linear_map (M * N)
       simp [fy_eq] }
 end
 
+section
+open_locale pointwise
+
+/-- `submodule.has_neg` distributes over multiplication.
+
+This is available as an instance in the `pointwise` locale. -/
+def has_distrib_pointwise_neg {A} [ring A] [algebra R A] : has_distrib_neg (submodule R A) :=
+{ neg := has_neg.neg,
+  neg_mul := λ x y, begin
+    refine le_antisymm
+      (mul_le.2 $ λ m hm n hn, _)
+      ((submodule.neg_le _ _).2 $ mul_le.2 $ λ m hm n hn, _);
+    simp only [submodule.mem_neg, ←neg_mul] at *,
+    { exact mul_mem_mul hm hn,},
+    { exact mul_mem_mul (neg_mem_neg.2 hm) hn },
+  end,
+  mul_neg := λ x y, begin
+    refine le_antisymm
+      (mul_le.2 $ λ m hm n hn, _)
+      ((submodule.neg_le _ _).2 $ mul_le.2 $ λ m hm n hn, _);
+    simp only [submodule.mem_neg, ←mul_neg] at *,
+    { exact mul_mem_mul hm hn,},
+    { exact mul_mem_mul hm (neg_mem_neg.2 hn) },
+  end,
+  ..submodule.has_involutive_pointwise_neg }
+
+localized "attribute [instance] submodule.has_distrib_pointwise_neg" in pointwise
+
+end
+
 section decidable_eq
 
 open_locale classical

--- a/src/algebra/module/submodule_pointwise.lean
+++ b/src/algebra/module/submodule_pointwise.lean
@@ -64,7 +64,7 @@ open_locale pointwise
 /-- `submodule.has_pointwise_neg` is involutive.
 
 This is available as an instance in the `pointwise` locale. -/
-def has_involutive_pointwise_neg : has_involutive_neg (submodule R M) :=
+protected def has_involutive_pointwise_neg : has_involutive_neg (submodule R M) :=
 { neg := has_neg.neg,
   neg_neg := λ S, set_like.coe_injective $ neg_neg _ }
 

--- a/src/algebra/module/submodule_pointwise.lean
+++ b/src/algebra/module/submodule_pointwise.lean
@@ -8,7 +8,11 @@ import linear_algebra.basic
 
 /-! # Pointwise instances on `submodule`s
 
-This file provides the actions
+This file provides:
+
+* `submodule.has_pointwise_neg`
+
+and the actions
 
 * `submodule.pointwise_distrib_mul_action`
 * `submodule.pointwise_mul_action_with_zero`
@@ -16,13 +20,100 @@ This file provides the actions
 which matches the action of `mul_action_set`.
 
 These actions are available in the `pointwise` locale.
+
+## Implementation notes
+
+Most of the lemmas in this file are direct copies of lemmas from
+`group_theory/submonoid/pointwise.lean`.
 -/
+
+variables {α : Type*} {R : Type*} {M : Type*}
+
+open_locale pointwise
 
 namespace submodule
 
-variables {α : Type*} {R : Type*} {M : Type*}
-variables [semiring R] [add_comm_monoid M] [module R M]
+section neg
 
+section semiring
+variables [semiring R] [add_comm_group M] [module R M]
+
+/-- The submodule with every element negated. Note if `R` is a ring and not just a semiring, this
+is a no-op, as shown by `submodule.neg_eq_self`.
+
+This is available as an instance in the `pointwise` locale. -/
+protected def has_pointwise_neg : has_neg (submodule R M):=
+{ neg := λ p,
+  { carrier := -(p : set M),
+    smul_mem' := λ r m hm, set.mem_neg.2 $ smul_neg r m ▸ p.smul_mem r $ set.mem_neg.1 hm,
+    ..(- p.to_add_submonoid) } }
+
+localized "attribute [instance] submodule.has_pointwise_neg" in pointwise
+open_locale pointwise
+
+@[simp] lemma coe_set_neg (S : submodule R M) : ↑(-S) = -(S : set M) := rfl
+
+@[simp] lemma neg_to_add_submonoid (S : submodule R M) :
+  (-S).to_add_submonoid = -S.to_add_submonoid := rfl
+
+@[simp] lemma mem_neg {g : M} {S : submodule R M} : g ∈ -S ↔ -g ∈ S := iff.rfl
+
+instance : has_involutive_neg (submodule R M) :=
+{ neg := has_neg.neg,
+  neg_neg := λ S, set_like.coe_injective $ neg_neg _ }
+
+@[simp] lemma neg_le_neg (S T : submodule R M) : -S ≤ -T ↔ S ≤ T :=
+set_like.coe_subset_coe.symm.trans set.neg_subset_neg
+
+lemma neg_le (S T : submodule R M) : -S ≤ T ↔ S ≤ -T :=
+set_like.coe_subset_coe.symm.trans set.neg_subset
+
+/-- `submodule.has_pointwise_neg` as an order isomorphism. -/
+def neg_order_iso : submodule R M ≃o submodule R M :=
+{ to_equiv := equiv.neg _,
+  map_rel_iff' := neg_le_neg }
+
+lemma closure_neg (s : set M) : span R (-s) = -(span R s) :=
+begin
+  apply le_antisymm,
+  { rw [span_le, coe_set_neg, ←set.neg_subset, neg_neg],
+    exact subset_span },
+  { rw [neg_le, span_le, coe_set_neg, ←set.neg_subset],
+    exact subset_span }
+end
+
+@[simp]
+lemma neg_inf (S T : submodule R M) : -(S ⊓ T) = (-S) ⊓ (-T) :=
+set_like.coe_injective set.inter_neg
+
+@[simp]
+lemma neg_sup (S T : submodule R M) : -(S ⊔ T) = (-S) ⊔ (-T) :=
+(neg_order_iso : submodule R M ≃o submodule R M).map_sup S T
+
+@[simp]
+lemma neg_bot : -(⊥ : submodule R M) = ⊥ :=
+set_like.coe_injective $ (set.neg_singleton 0).trans $ congr_arg _ neg_zero
+
+@[simp]
+lemma neg_top : -(⊤ : submodule R M) = ⊤ :=
+set_like.coe_injective $ set.neg_univ
+
+@[simp]
+lemma neg_infi {ι : Sort*} (S : ι → submodule R M) : -(⨅ i, S i) = ⨅ i, -S i :=
+(neg_order_iso : submodule R M ≃o submodule R M).map_infi _
+
+@[simp]
+lemma neg_supr {ι : Sort*} (S : ι → submodule R M) : -(⨆ i, S i) = ⨆ i, -(S i) :=
+(neg_order_iso : submodule R M ≃o submodule R M).map_supr _
+
+end semiring
+
+@[simp] lemma neg_eq_self [ring R] [add_comm_group M] [module R M] (p : submodule R M) : -p = p :=
+ext $ λ _, p.neg_mem_iff
+
+end neg
+
+variables [semiring R] [add_comm_monoid M] [module R M]
 
 instance pointwise_add_comm_monoid : add_comm_monoid (submodule R M) :=
 { add := (⊔),
@@ -34,7 +125,6 @@ instance pointwise_add_comm_monoid : add_comm_monoid (submodule R M) :=
 
 @[simp] lemma add_eq_sup (p q : submodule R M) : p + q = p ⊔ q := rfl
 @[simp] lemma zero_eq_bot : (0 : submodule R M) = ⊥ := rfl
-
 
 section
 variables [monoid α] [distrib_mul_action α M] [smul_comm_class α R M]

--- a/src/algebra/module/submodule_pointwise.lean
+++ b/src/algebra/module/submodule_pointwise.lean
@@ -41,8 +41,11 @@ variables [semiring R] [add_comm_group M] [module R M]
 /-- The submodule with every element negated. Note if `R` is a ring and not just a semiring, this
 is a no-op, as shown by `submodule.neg_eq_self`.
 
+Recall that When `R` is the semiring corresponding to the nonnegative elements of `R'`,
+`submodule R' M` is the type of cones of `M`. This instance reflects such cones about `0`.
+
 This is available as an instance in the `pointwise` locale. -/
-protected def has_pointwise_neg : has_neg (submodule R M):=
+protected def has_pointwise_neg : has_neg (submodule R M) :=
 { neg := λ p,
   { carrier := -(p : set M),
     smul_mem' := λ r m hm, set.mem_neg.2 $ smul_neg r m ▸ p.smul_mem r $ set.mem_neg.1 hm,
@@ -58,9 +61,14 @@ open_locale pointwise
 
 @[simp] lemma mem_neg {g : M} {S : submodule R M} : g ∈ -S ↔ -g ∈ S := iff.rfl
 
-instance : has_involutive_neg (submodule R M) :=
+/-- `submodule.has_pointwise_neg` is involutive.
+
+This is available as an instance in the `pointwise` locale. -/
+def has_involutive_pointwise_neg : has_involutive_neg (submodule R M) :=
 { neg := has_neg.neg,
   neg_neg := λ S, set_like.coe_injective $ neg_neg _ }
+
+localized "attribute [instance] submodule.has_involutive_pointwise_neg" in pointwise
 
 @[simp] lemma neg_le_neg (S T : submodule R M) : -S ≤ -T ↔ S ≤ T :=
 set_like.coe_subset_coe.symm.trans set.neg_subset_neg
@@ -107,6 +115,8 @@ lemma neg_supr {ι : Sort*} (S : ι → submodule R M) : -(⨆ i, S i) = ⨆ i, 
 (neg_order_iso : submodule R M ≃o submodule R M).map_supr _
 
 end semiring
+
+open_locale pointwise
 
 @[simp] lemma neg_eq_self [ring R] [add_comm_group M] [module R M] (p : submodule R M) : -p = p :=
 ext $ λ _, p.neg_mem_iff


### PR DESCRIPTION
We already have pointwise negation on `add_submonoid`s (from #10451), this extends it to `submodules`.
The lemmas are all copies of the add_submonoid lemmas, except for two new lemmas:

* `submodule.neg_to_add_submonoid`
* `submodule.neg_eq_self`, which isn't true for `add_submonoid`s

Finally, we provide a `has_distrib_neg` instance; even though the negation is not cancellative, it does distribute over multiplication as expected.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
