### PR TITLE
[Merged by Bors] - feat(data/pnat/find): port over `nat.find` API

### DIFF
--- a/src/data/pnat/basic.lean
+++ b/src/data/pnat/basic.lean
@@ -114,10 +114,7 @@ coe_injective.add_right_cancel_semigroup coe (λ _ _, rfl)
 
 @[priority 10]
 instance : covariant_class ℕ+ ℕ+ ((+)) (≤) :=
-⟨begin
-  rintro ⟨a, ha⟩ ⟨b, hb⟩ ⟨c, hc⟩,
-  simp [←pnat.coe_le_coe]
-end⟩
+⟨by { rintro ⟨a, ha⟩ ⟨b, hb⟩ ⟨c, hc⟩, simp [←pnat.coe_le_coe] }⟩
 
 @[simp] theorem ne_zero (n : ℕ+) : (n : ℕ) ≠ 0 := n.2.ne'
 
@@ -192,12 +189,15 @@ begin
   { simp [←pnat.coe_le_coe, subtype.ext_iff, nat.succ_le_succ_iff, nat.succ_inj'], }
 end
 
-lemma lt_add_right (n m : ℕ+) : n < n + m :=
+lemma lt_add_left (n m : ℕ+) : n < m + n :=
 begin
   rcases m with ⟨_|m, hm⟩,
   { exact absurd hm (lt_irrefl _) },
   { simp [←pnat.coe_lt_coe] }
 end
+
+lemma lt_add_right (n m : ℕ+) : n < n + m :=
+(lt_add_left n m).trans_le (add_comm _ _).le
 
 @[simp] lemma coe_bit0 (a : ℕ+) : ((bit0 a : ℕ+) : ℕ) = bit0 (a : ℕ) := rfl
 @[simp] lemma coe_bit1 (a : ℕ+) : ((bit1 a : ℕ+) : ℕ) = bit1 (a : ℕ) := rfl

--- a/src/data/pnat/basic.lean
+++ b/src/data/pnat/basic.lean
@@ -112,6 +112,13 @@ coe_injective.add_left_cancel_semigroup coe (λ _ _, rfl)
 instance : add_right_cancel_semigroup ℕ+ :=
 coe_injective.add_right_cancel_semigroup coe (λ _ _, rfl)
 
+@[priority 10]
+instance : covariant_class ℕ+ ℕ+ ((+)) (≤) :=
+⟨begin
+  rintro ⟨a, ha⟩ ⟨b, hb⟩ ⟨c, hc⟩,
+  simp [←pnat.coe_le_coe]
+end⟩
+
 @[simp] theorem ne_zero (n : ℕ+) : (n : ℕ) ≠ 0 := n.2.ne'
 
 theorem to_pnat'_coe {n : ℕ} : 0 < n → (n.to_pnat' : ℕ) = n := succ_pred_eq_of_pos
@@ -130,6 +137,8 @@ theorem add_one_le_iff : ∀ {a b : ℕ+}, a + 1 ≤ b ↔ a < b :=
 λ a b, nat.add_one_le_iff
 
 @[simp] lemma one_le (n : ℕ+) : (1 : ℕ+) ≤ n := n.2
+
+@[simp] lemma not_lt_one (n : ℕ+) : ¬ n < 1 := not_lt_of_le n.one_le
 
 instance : order_bot ℕ+ :=
 { bot := 1,
@@ -175,6 +184,20 @@ def coe_monoid_hom : ℕ+ →* ℕ :=
 lemma coe_eq_one_iff {m : ℕ+} :
 (m : ℕ) = 1 ↔ m = 1 := by { split; intro h; try { apply pnat.eq}; rw h; simp }
 
+@[simp] lemma le_one_iff {n : ℕ+} :
+  n ≤ 1 ↔ n = 1 :=
+begin
+  rcases n with ⟨_|n, hn⟩,
+  { exact absurd hn (lt_irrefl _) },
+  { simp [←pnat.coe_le_coe, subtype.ext_iff, nat.succ_le_succ_iff, nat.succ_inj'], }
+end
+
+lemma lt_add_right (n m : ℕ+) : n < n + m :=
+begin
+  rcases m with ⟨_|m, hm⟩,
+  { exact absurd hm (lt_irrefl _) },
+  { simp [←pnat.coe_lt_coe] }
+end
 
 @[simp] lemma coe_bit0 (a : ℕ+) : ((bit0 a : ℕ+) : ℕ) = bit0 (a : ℕ) := rfl
 @[simp] lemma coe_bit1 (a : ℕ+) : ((bit1 a : ℕ+) : ℕ) = bit1 (a : ℕ) := rfl

--- a/src/data/pnat/find.lean
+++ b/src/data/pnat/find.lean
@@ -101,10 +101,7 @@ lemma find_le {h : ∃ n, p n} (hn : p n) : pnat.find h ≤ n :=
 lemma find_comp_succ (h : ∃ n, p n) (h₂ : ∃ n, p (n + 1)) (h1 : ¬ p 1) :
   pnat.find h = pnat.find h₂ + 1 :=
 begin
-  refine (find_eq_iff _).2 ⟨pnat.find_spec h₂, λ n hn, _⟩,
-  revert n,
-  intro n,
-  refine pnat.rec_on n _ _,
+  refine (find_eq_iff _).2 ⟨pnat.find_spec h₂, λ n, pnat.rec_on n _ _⟩,
   { simp [h1] },
   intros m IH hm,
   simp only [add_lt_add_iff_right, lt_find_iff] at hm,

--- a/src/data/pnat/find.lean
+++ b/src/data/pnat/find.lean
@@ -17,18 +17,10 @@ namespace pnat
 variables {p q : ℕ+ → Prop} [decidable_pred p] [decidable_pred q] (h : ∃ n, p n)
 
 instance decidable_pred_exists_nat :
-  decidable_pred (λ n' : ℕ, ∃ (n : ℕ+) (hn : n' = n), p n)
-| 0       := is_false begin
-    push_neg,
-    rintro ⟨x, hx⟩,
-    simp [hx.ne]
-  end
-| (n' + 1) := if hp : p (n' + 1).to_pnat' then is_true ⟨(n' + 1).to_pnat', rfl, hp⟩
-  else is_false $ begin
-    contrapose! hp,
-    obtain ⟨n, hn, hp⟩ := hp,
-    simp [hn, hp]
-  end
+  decidable_pred (λ n' : ℕ, ∃ (n : ℕ+) (hn : n' = n), p n) := λ n',
+decidable_of_iff' (∃ (h : 0 < n'), p ⟨n', h⟩) $ subtype.exists.trans $
+  by simp_rw [subtype.coe_mk, @exists_comm (_ < _) (_ = _), exists_prop, exists_eq_left']
+
 
 include h
 
@@ -83,13 +75,7 @@ protected theorem find_min : ∀ {m : ℕ+}, m < pnat.find h → ¬p m :=
 begin
   simp only [pnat.find, ←pnat.coe_lt_coe, pnat.find_aux, mk_coe, nat.lt_find_iff, exists_prop,
              not_exists, not_and],
-  rintro ⟨m, hm⟩,
-  contrapose!,
-  intro h,
-  refine ⟨m, le_rfl, m.to_pnat', _, _⟩,
-  { simp [hm] },
-  { convert h,
-    simp [subtype.ext_iff, hm] }
+  exact λ m h, h m le_rfl m rfl
 end
 
 protected theorem find_min' {m : ℕ+} (hm : p m) : pnat.find h ≤ m :=

--- a/src/data/pnat/find.lean
+++ b/src/data/pnat/find.lean
@@ -117,8 +117,8 @@ pnat.find_min' _ (h _ (pnat.find_spec hq))
 lemma find_le {h : ∃ n, p n} (hn : p n) : pnat.find h ≤ n :=
 (pnat.find_le_iff _ _).2 ⟨n, le_rfl, hn⟩
 
-lemma find_comp_succ (h₁ : ∃ n, p n) (h₂ : ∃ n, p (n + 1)) (h1 : ¬ p 1) :
-  pnat.find h₁ = pnat.find h₂ + 1 :=
+lemma find_comp_succ (h : ∃ n, p n) (h₂ : ∃ n, p (n + 1)) (h1 : ¬ p 1) :
+  pnat.find h = pnat.find h₂ + 1 :=
 begin
   refine (find_eq_iff _).2 ⟨pnat.find_spec h₂, λ n hn, _⟩,
   revert n,

--- a/src/data/pnat/find.lean
+++ b/src/data/pnat/find.lean
@@ -1,0 +1,147 @@
+/-
+Copyright (c) 2022 Yakov Pechersky. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Yakov Pechersky, Floris van Doorn
+-/
+import data.pnat.basic
+
+/-!
+# Explicit least witnesses to existentials on positive natural numbers
+
+Implemented via calling out to `nat.find`.
+
+-/
+
+namespace pnat
+
+variables {p q : ℕ+ → Prop} [decidable_pred p] [decidable_pred q] (h : ∃ n, p n)
+
+instance decidable_pred_exists_nat :
+  decidable_pred (λ n' : ℕ, ∃ (n : ℕ+) (hn : n' = n), p n)
+| 0       := is_false begin
+    push_neg,
+    rintro ⟨x, hx⟩,
+    simp [hx.ne]
+  end
+| (n' + 1) := if hp : p (n' + 1).to_pnat' then is_true ⟨(n' + 1).to_pnat', rfl, hp⟩
+  else is_false $ begin
+    contrapose! hp,
+    obtain ⟨n, hn, hp⟩ := hp,
+    simp [hn, hp]
+  end
+
+include h
+
+/--
+If `p` is a (decidable) predicate on `ℕ+` and `hp : ∃ (n : ℕ+), p n` is a proof that
+there exists some positive natural number satisfying `p`, then `pnat.find hp` is the
+smallest positive natural number satisfying `p`. Note that `pnat.find` is protected,
+meaning that you can't just write `find`, even if the `pnat` namespace is open.
+
+The API for `pnat.find` is:
+
+* `pnat.find_spec` is the proof that `pnat.find hp` satisfies `p`.
+* `pnat.find_min` is the proof that if `m < pnat.find hp` then `m` does not satisfy `p`.
+* `pnat.find_min'` is the proof that if `m` does satisfy `p` then `pnat.find hp ≤ m`.
+-/
+protected def find_aux
+  (H' : ∃ (n' : ℕ) (n : ℕ+) (hn' : n' = n), p n := exists.elim h (λ n hn, ⟨n, n, rfl, hn⟩)) : ℕ :=
+nat.find H'
+
+protected theorem find_aux_spec
+  (H' : ∃ (n' : ℕ) (n : ℕ+) (hn' : n' = n), p n := exists.elim h (λ n hn, ⟨n, n, rfl, hn⟩)) :
+  ∃ (n : ℕ+) (hn' : pnat.find_aux h = n), p n :=
+nat.find_spec H'
+
+/--
+If `p` is a (decidable) predicate on `ℕ+` and `hp : ∃ (n : ℕ+), p n` is a proof that
+there exists some positive natural number satisfying `p`, then `pnat.find hp` is the
+smallest positive natural number satisfying `p`. Note that `pnat.find` is protected,
+meaning that you can't just write `find`, even if the `pnat` namespace is open.
+
+The API for `pnat.find` is:
+
+* `pnat.find_spec` is the proof that `pnat.find hp` satisfies `p`.
+* `pnat.find_min` is the proof that if `m < pnat.find hp` then `m` does not satisfy `p`.
+* `pnat.find_min'` is the proof that if `m` does satisfy `p` then `pnat.find hp ≤ m`.
+-/
+protected def find : ℕ+ :=
+⟨pnat.find_aux h, begin
+  obtain ⟨⟨n, hn⟩, h, -⟩ := pnat.find_aux_spec h,
+  rw h,
+  exact hn
+end⟩
+
+protected theorem find_spec : p (pnat.find h) :=
+begin
+  rw pnat.find,
+  obtain ⟨n, h, hp⟩ := pnat.find_aux_spec h,
+  simp [h, hp]
+end
+
+protected theorem find_min : ∀ {m : ℕ+}, m < pnat.find h → ¬p m :=
+begin
+  simp only [pnat.find, ←pnat.coe_lt_coe, pnat.find_aux, mk_coe, nat.lt_find_iff, exists_prop,
+             not_exists, not_and],
+  rintro ⟨m, hm⟩,
+  contrapose!,
+  intro h,
+  refine ⟨m, le_rfl, m.to_pnat', _, _⟩,
+  { simp [hm] },
+  { convert h,
+    simp [subtype.ext_iff, hm] }
+end
+
+protected theorem find_min' {m : ℕ+} (hm : p m) : pnat.find h ≤ m :=
+le_of_not_lt (λ l, pnat.find_min h l hm)
+
+variables {n m : ℕ+}
+
+lemma find_eq_iff : pnat.find h = m ↔ p m ∧ ∀ n < m, ¬ p n :=
+begin
+  split,
+  { rintro rfl, exact ⟨pnat.find_spec h, λ _, pnat.find_min h⟩ },
+  { rintro ⟨hm, hlt⟩,
+    exact le_antisymm (pnat.find_min' h hm) (not_lt.1 $ imp_not_comm.1 (hlt _) $ pnat.find_spec h) }
+end
+
+@[simp] lemma find_lt_iff (n : ℕ+) : pnat.find h < n ↔ ∃ m < n, p m :=
+⟨λ h2, ⟨pnat.find h, h2, pnat.find_spec h⟩, λ ⟨m, hmn, hm⟩, (pnat.find_min' h hm).trans_lt hmn⟩
+
+@[simp] lemma find_le_iff (n : ℕ+) : pnat.find h ≤ n ↔ ∃ m ≤ n, p m :=
+by simp only [exists_prop, ← lt_add_one_iff, find_lt_iff]
+
+@[simp] lemma le_find_iff (n : ℕ+) : n ≤ pnat.find h ↔ ∀ m < n, ¬ p m :=
+by simp_rw [← not_lt, find_lt_iff, not_exists]
+
+@[simp] lemma lt_find_iff (n : ℕ+) : n < pnat.find h ↔ ∀ m ≤ n, ¬ p m :=
+by simp only [← add_one_le_iff, le_find_iff, add_le_add_iff_right]
+
+@[simp] lemma find_eq_one : pnat.find h = 1 ↔ p 1 :=
+by simp [find_eq_iff]
+
+@[simp] lemma one_le_find : 1 < pnat.find h ↔ ¬ p 1 :=
+not_iff_not.mp $ by simp
+
+theorem find_mono (h : ∀ n, q n → p n)
+  {hp : ∃ n, p n} {hq : ∃ n, q n} :
+  pnat.find hp ≤ pnat.find hq :=
+pnat.find_min' _ (h _ (pnat.find_spec hq))
+
+lemma find_le {h : ∃ n, p n} (hn : p n) : pnat.find h ≤ n :=
+(pnat.find_le_iff _ _).2 ⟨n, le_rfl, hn⟩
+
+lemma find_comp_succ (h₁ : ∃ n, p n) (h₂ : ∃ n, p (n + 1)) (h1 : ¬ p 1) :
+  pnat.find h₁ = pnat.find h₂ + 1 :=
+begin
+  refine (find_eq_iff _).2 ⟨pnat.find_spec h₂, λ n hn, _⟩,
+  revert n,
+  intro n,
+  refine pnat.rec_on n _ _,
+  { simp [h1] },
+  intros m IH hm,
+  simp only [add_lt_add_iff_right, lt_find_iff] at hm,
+  exact hm _ le_rfl
+end
+
+end pnat


### PR DESCRIPTION
Didn't port `pnat.find_add` because I got lost in the proof.



---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
