### PR TITLE
[Merged by Bors] - feat(data/{nat,int,rat}/cast, algebra/star/basic): lemmas about `star` on casts

### DIFF
--- a/src/algebra/star/basic.lean
+++ b/src/algebra/star/basic.lean
@@ -247,20 +247,17 @@ def star_ring_equiv [non_unital_semiring R] [star_ring R] : R ≃+* Rᵐᵒᵖ :
   ..star_add_equiv.trans (mul_opposite.op_add_equiv : R ≃+ Rᵐᵒᵖ),
   ..star_mul_equiv }
 
-@[simp] lemma star_nat_cast [semiring R] [star_ring R] (n : ℕ) :
+@[simp, norm_cast] lemma star_nat_cast [semiring R] [star_ring R] (n : ℕ) :
   star (n : R) = n :=
-(congr_arg mul_opposite.unop (map_nat_cast (star_ring_equiv : R ≃+* Rᵐᵒᵖ) n)).trans
-  (mul_opposite.unop_nat_cast _)
+(congr_arg unop (map_nat_cast (star_ring_equiv : R ≃+* Rᵐᵒᵖ) n)).trans (unop_nat_cast _)
 
-@[simp] lemma star_int_cast [ring R] [star_ring R] (z : ℤ) :
+@[simp, norm_cast] lemma star_int_cast [ring R] [star_ring R] (z : ℤ) :
   star (z : R) = z :=
-(congr_arg mul_opposite.unop ((star_ring_equiv : R ≃+* Rᵐᵒᵖ).to_ring_hom.map_int_cast z)).trans
-  (mul_opposite.unop_int_cast _)
+(congr_arg unop ((star_ring_equiv : R ≃+* Rᵐᵒᵖ).to_ring_hom.map_int_cast z)).trans (unop_int_cast _)
 
-@[simp] lemma star_rat_cast [division_ring R] [char_zero R] [star_ring R] (r : ℚ) :
+@[simp, norm_cast] lemma star_rat_cast [division_ring R] [char_zero R] [star_ring R] (r : ℚ) :
   star (r : R) = r :=
-(congr_arg mul_opposite.unop ((star_ring_equiv : R ≃+* Rᵐᵒᵖ).to_ring_hom.map_rat_cast r)).trans
-  (mul_opposite.unop_rat_cast _)
+(congr_arg unop ((star_ring_equiv : R ≃+* Rᵐᵒᵖ).to_ring_hom.map_rat_cast r)).trans (unop_rat_cast _)
 
 /-- `star` as a ring automorphism, for commutative `R`. -/
 @[simps apply]

--- a/src/algebra/star/basic.lean
+++ b/src/algebra/star/basic.lean
@@ -146,7 +146,7 @@ op_injective $
   ((star_mul_equiv : R ≃* Rᵐᵒᵖ).to_monoid_hom.map_zpow x z).trans (op_zpow (star x) z).symm
 
 /-- When multiplication is commutative, `star` preserves division. -/
-@[simp] lemma star_div [comm_group R] [star_semigroup R] (x y : R) : 
+@[simp] lemma star_div [comm_group R] [star_semigroup R] (x y : R) :
   star (x / y) = star x / star y :=
 (star_mul_aut : R ≃* R).to_monoid_hom.map_div _ _
 
@@ -246,6 +246,21 @@ def star_ring_equiv [non_unital_semiring R] [star_ring R] : R ≃+* Rᵐᵒᵖ :
 { to_fun := λ x, mul_opposite.op (star x),
   ..star_add_equiv.trans (mul_opposite.op_add_equiv : R ≃+ Rᵐᵒᵖ),
   ..star_mul_equiv }
+
+@[simp] lemma star_nat_cast [semiring R] [star_ring R] (n : ℕ) :
+  star (n : R) = n :=
+(congr_arg mul_opposite.unop (map_nat_cast (star_ring_equiv : R ≃+* Rᵐᵒᵖ) n)).trans
+  (mul_opposite.unop_nat_cast _)
+
+@[simp] lemma star_int_cast [ring R] [star_ring R] (z : ℤ) :
+  star (z : R) = z :=
+(congr_arg mul_opposite.unop ((star_ring_equiv : R ≃+* Rᵐᵒᵖ).to_ring_hom.map_int_cast z)).trans
+  (mul_opposite.unop_int_cast _)
+
+@[simp] lemma star_rat_cast [division_ring R] [char_zero R] [star_ring R] (r : ℚ) :
+  star (r : R) = r :=
+(congr_arg mul_opposite.unop ((star_ring_equiv : R ≃+* Rᵐᵒᵖ).to_ring_hom.map_rat_cast r)).trans
+  (mul_opposite.unop_rat_cast _)
 
 /-- `star` as a ring automorphism, for commutative `R`. -/
 @[simps apply]

--- a/src/data/int/cast.lean
+++ b/src/data/int/cast.lean
@@ -323,11 +323,11 @@ namespace mul_opposite
 
 variables {α : Type*} [has_zero α] [has_one α] [has_add α] [has_neg α]
 
-@[simp] lemma op_int_cast : ∀ z : ℤ, mul_opposite.op (z : α) = z
+@[simp, norm_cast] lemma op_int_cast : ∀ z : ℤ, op (z : α) = z
 | (n:ℕ) := op_nat_cast n
 | -[1+n] := congr_arg (λ a : αᵐᵒᵖ, -(a + 1)) $ op_nat_cast n
 
-@[simp] lemma unop_int_cast : ∀ n : ℤ, mul_opposite.unop (n : αᵐᵒᵖ) = n
+@[simp, norm_cast] lemma unop_int_cast : ∀ n : ℤ, unop (n : αᵐᵒᵖ) = n
 | (n:ℕ) := unop_nat_cast n
 | -[1+n] := congr_arg (λ a : α, -(a + 1)) $ unop_nat_cast n
 

--- a/src/data/int/cast.lean
+++ b/src/data/int/cast.lean
@@ -318,3 +318,17 @@ by rw [cast_neg_succ_of_nat, cast_neg_succ_of_nat, neg_apply, add_apply, one_app
 by { ext, rw pi.int_apply }
 
 end pi
+
+namespace mul_opposite
+
+variables {α : Type*} [has_zero α] [has_one α] [has_add α] [has_neg α]
+
+@[simp] lemma op_int_cast : ∀ z : ℤ, mul_opposite.op (z : α) = z
+| (n:ℕ) := op_nat_cast n
+| -[1+n] := congr_arg (λ a : αᵐᵒᵖ, -(a + 1)) $ op_nat_cast n
+
+@[simp] lemma unop_int_cast : ∀ n : ℤ, mul_opposite.unop (n : αᵐᵒᵖ) = n
+| (n:ℕ) := unop_nat_cast n
+| -[1+n] := congr_arg (λ a : α, -(a + 1)) $ unop_nat_cast n
+
+end mul_opposite

--- a/src/data/nat/cast.lean
+++ b/src/data/nat/cast.lean
@@ -339,11 +339,11 @@ namespace mul_opposite
 
 variables {α : Type*} [has_zero α] [has_one α] [has_add α]
 
-@[simp] lemma op_nat_cast : ∀ n : ℕ, mul_opposite.op (n : α) = n
+@[simp, norm_cast] lemma op_nat_cast : ∀ n : ℕ, op (n : α) = n
 | 0 := rfl
 | (n + 1) := congr_arg (+ (1 : αᵐᵒᵖ)) $ op_nat_cast n
 
-@[simp] lemma unop_nat_cast : ∀ n : ℕ, mul_opposite.unop (n : αᵐᵒᵖ) = n
+@[simp, norm_cast] lemma unop_nat_cast : ∀ n : ℕ, unop (n : αᵐᵒᵖ) = n
 | 0 := rfl
 | (n + 1) := congr_arg (+ (1 : α)) $ unop_nat_cast n
 

--- a/src/data/nat/cast.lean
+++ b/src/data/nat/cast.lean
@@ -335,6 +335,20 @@ end ring_hom_class
 instance nat.subsingleton_ring_hom {R : Type*} [non_assoc_semiring R] : subsingleton (ℕ →+* R) :=
 ⟨ext_nat⟩
 
+namespace mul_opposite
+
+variables {α : Type*} [has_zero α] [has_one α] [has_add α]
+
+@[simp] lemma op_nat_cast : ∀ n : ℕ, mul_opposite.op (n : α) = n
+| 0 := rfl
+| (n + 1) := congr_arg (+ (1 : αᵐᵒᵖ)) $ op_nat_cast n
+
+@[simp] lemma unop_nat_cast : ∀ n : ℕ, mul_opposite.unop (n : αᵐᵒᵖ) = n
+| 0 := rfl
+| (n + 1) := congr_arg (+ (1 : α)) $ unop_nat_cast n
+
+end mul_opposite
+
 namespace with_top
 variables {α : Type*}
 

--- a/src/data/rat/cast.lean
+++ b/src/data/rat/cast.lean
@@ -324,11 +324,11 @@ namespace mul_opposite
 
 variables {α : Type*} [division_ring α]
 
-@[simp] lemma op_rat_cast (r : ℚ) : mul_opposite.op (r : α) = (↑r : αᵐᵒᵖ) :=
+@[simp, norm_cast] lemma op_rat_cast (r : ℚ) : op (r : α) = (↑r : αᵐᵒᵖ) :=
 by rw [cast_def, div_eq_mul_inv, op_mul, op_inv, op_nat_cast, op_int_cast,
     (commute.cast_int_right _ r.num).eq, cast_def, div_eq_mul_inv]
 
-@[simp] lemma unop_rat_cast (r : ℚ) : mul_opposite.unop (r : αᵐᵒᵖ) = r :=
+@[simp, norm_cast] lemma unop_rat_cast (r : ℚ) : unop (r : αᵐᵒᵖ) = r :=
 by rw [cast_def, div_eq_mul_inv, unop_mul, unop_inv, unop_nat_cast, unop_int_cast,
     (commute.cast_int_right _ r.num).eq, cast_def, div_eq_mul_inv]
 

--- a/src/data/rat/cast.lean
+++ b/src/data/rat/cast.lean
@@ -5,6 +5,7 @@ Authors: Johannes Hölzl, Mario Carneiro
 -/
 import data.rat.order
 import data.int.char_zero
+import algebra.field.opposite
 
 /-!
 # Casts for Rational Numbers
@@ -318,3 +319,17 @@ theorem ext_rat_on_pnat {f g : ℚ →*₀ M}
 ext_rat $ ext_int' (by simpa) ‹_›
 
 end monoid_with_zero_hom
+
+namespace mul_opposite
+
+variables {α : Type*} [division_ring α]
+
+@[simp] lemma op_rat_cast (r : ℚ) : mul_opposite.op (r : α) = (↑r : αᵐᵒᵖ) :=
+by rw [cast_def, div_eq_mul_inv, op_mul, op_inv, op_nat_cast, op_int_cast,
+    (commute.cast_int_right _ r.num).eq, cast_def, div_eq_mul_inv]
+
+@[simp] lemma unop_rat_cast (r : ℚ) : mul_opposite.unop (r : αᵐᵒᵖ) = r :=
+by rw [cast_def, div_eq_mul_inv, unop_mul, unop_inv, unop_nat_cast, unop_int_cast,
+    (commute.cast_int_right _ r.num).eq, cast_def, div_eq_mul_inv]
+
+end mul_opposite


### PR DESCRIPTION
This also includes lemmas about `mul_opposite` on casts which are used to prove the star lemmas. The new lemmas are:

* `star_nat_cast`
* `star_int_cast`
* `star_rat_cast`
* `op_nat_cast`
* `op_int_cast`
* `op_rat_cast`
* `unop_nat_cast`
* `unop_int_cast`
* `unop_rat_cast`

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
