### PR TITLE
[Merged by Bors] - feat(order/filter/archimedean): add lemmas about convergence to ±∞ for archimedean rings / groups.

### DIFF
--- a/src/order/filter/archimedean.lean
+++ b/src/order/filter/archimedean.lean
@@ -99,14 +99,19 @@ instance at_bot_countably_generated_of_archimedean [linear_ordered_ring R] [arch
   (at_bot : filter R).is_countably_generated :=
 at_bot_countable_basis_of_archimedean.is_countably_generated
 
-variables [linear_ordered_semiring R] [archimedean R]
+namespace filter
+
 variables {l : filter α} {f : α → R} {r : R}
+
+section linear_ordered_semiring
+
+variables [linear_ordered_semiring R] [archimedean R]
 
 /-- If a function tends to infinity along a filter, then this function multiplied by a positive
 constant (on the left) also tends to infinity. The archimedean assumption is convenient to get a
 statement that works on `ℕ`, `ℤ` and `ℝ`, although not necessary (a version in ordered fields is
 given in `filter.tendsto.const_mul_at_top`). -/
-lemma filter.tendsto.const_mul_at_top' (hr : 0 < r) (hf : tendsto f l at_top) :
+lemma tendsto.const_mul_at_top' (hr : 0 < r) (hf : tendsto f l at_top) :
   tendsto (λx, r * f x) l at_top :=
 begin
   apply tendsto_at_top.2 (λb, _),
@@ -123,7 +128,7 @@ end
 constant (on the right) also tends to infinity. The archimedean assumption is convenient to get a
 statement that works on `ℕ`, `ℤ` and `ℝ`, although not necessary (a version in ordered fields is
 given in `filter.tendsto.at_top_mul_const`). -/
-lemma filter.tendsto.at_top_mul_const' (hr : 0 < r) (hf : tendsto f l at_top) :
+lemma tendsto.at_top_mul_const' (hr : 0 < r) (hf : tendsto f l at_top) :
   tendsto (λx, f x * r) l at_top :=
 begin
   apply tendsto_at_top.2 (λb, _),
@@ -135,3 +140,106 @@ begin
   ... = (max b 0 * n) * r : by rw [mul_assoc]
   ... ≤ f x * r : mul_le_mul_of_nonneg_right hx (le_of_lt hr)
 end
+
+end linear_ordered_semiring
+
+section linear_ordered_ring
+
+variables [linear_ordered_ring R] [archimedean R]
+
+/-- See also `filter.tendsto.at_top_mul_neg_const` for a version of this lemma for
+`linear_ordered_field`s which does not require the `archimedean` assumption. -/
+lemma tendsto.at_top_mul_neg_const' (hr : r < 0) (hf : tendsto f l at_top) :
+  tendsto (λx, f x * r) l at_bot :=
+begin
+  have h : (λ x, f x * -r) = -λ x, f x * r, { ext, simp, },
+  rw tendsto_at_bot_iff_tends_to_neg_at_top,
+  exact h ▸ tendsto.at_top_mul_const' (neg_pos.mpr hr) hf,
+end
+
+/-- See also `filter.tendsto.at_bot_mul_const` for a version of this lemma for
+`linear_ordered_field`s which does not require the `archimedean` assumption. -/
+lemma tendsto.at_bot_mul_const' (hr : 0 < r) (hf : tendsto f l at_bot) :
+  tendsto (λx, f x * r) l at_bot :=
+begin
+  have h : (λ x, (-f) x * r) = -λ x, f x * r, { ext, simp, },
+  rw tendsto_at_bot_iff_tends_to_neg_at_top at hf ⊢,
+  exact h ▸  tendsto.at_top_mul_const' hr hf,
+end
+
+/-- See also `filter.tendsto.at_bot_mul_neg_const` for a version of this lemma for
+`linear_ordered_field`s which does not require the `archimedean` assumption. -/
+lemma tendsto.at_bot_mul_neg_const' (hr : r < 0) (hf : tendsto f l at_bot) :
+  tendsto (λx, f x * r) l at_top :=
+begin
+  have h : (λ x, (-f) x * r) = -λ x, f x * r, { ext, simp, },
+  rw tendsto_at_bot_iff_tends_to_neg_at_top at hf,
+  rw tendsto_at_top_iff_tends_to_neg_at_bot,
+  exact h ▸ tendsto.at_top_mul_neg_const' hr hf,
+end
+
+end linear_ordered_ring
+
+section linear_ordered_cancel_add_comm_monoid
+
+variables [linear_ordered_cancel_add_comm_monoid R] [archimedean R]
+
+lemma tendsto.at_top_nsmul_const {f : α → ℕ} (hr : 0 < r) (hf : tendsto f l at_top) :
+  tendsto (λ x, f x • r) l at_top :=
+begin
+  refine tendsto_at_top.mpr (λ s, _),
+  obtain ⟨n : ℕ, hn : s ≤ n • r⟩ := archimedean.arch s hr,
+  exact (tendsto_at_top.mp hf n).mono (λ a ha, hn.trans (nsmul_le_nsmul hr.le ha)),
+end
+
+end linear_ordered_cancel_add_comm_monoid
+
+section linear_ordered_add_comm_group
+
+variables [linear_ordered_add_comm_group R] [archimedean R]
+
+lemma tendsto.at_top_nsmul_neg_const {f : α → ℕ} (hr : r < 0) (hf : tendsto f l at_top) :
+  tendsto (λ x, f x • r) l at_bot :=
+begin
+  have h : (λ x, f x • -r) = -λ x, f x • r, { ext, simp, },
+  rw tendsto_at_bot_iff_tends_to_neg_at_top,
+  exact h ▸ tendsto.at_top_nsmul_const (neg_pos.mpr hr) hf,
+end
+
+lemma tendsto.at_top_zsmul_const {f : α → ℤ} (hr : 0 < r) (hf : tendsto f l at_top) :
+  tendsto (λ x, f x • r) l at_top :=
+begin
+  refine tendsto_at_top.mpr (λ s, _),
+  obtain ⟨n : ℕ, hn : s ≤ n • r⟩ := archimedean.arch s hr,
+  replace hn : s ≤ (n : ℤ) • r, { simpa, },
+  exact (tendsto_at_top.mp hf n).mono (λ a ha, hn.trans (zsmul_le_zsmul hr.le ha)),
+end
+
+lemma tendsto.at_top_zsmul_neg_const {f : α → ℤ} (hr : r < 0) (hf : tendsto f l at_top) :
+  tendsto (λ x, f x • r) l at_bot :=
+begin
+  have h : (λ x, f x • -r) = -λ x, f x • r, { ext, simp [zsmul_neg], },
+  rw tendsto_at_bot_iff_tends_to_neg_at_top,
+  exact h ▸ tendsto.at_top_zsmul_const (neg_pos.mpr hr) hf,
+end
+
+lemma tendsto.at_bot_zsmul_const {f : α → ℤ} (hr : 0 < r) (hf : tendsto f l at_bot) :
+  tendsto (λ x, f x • r) l at_bot :=
+begin
+  have h : (λ x, (-f) x • r) = -λ x, f x • r, { ext, simp, },
+  rw tendsto_at_bot_iff_tends_to_neg_at_top at hf ⊢,
+  exact h ▸ tendsto.at_top_zsmul_const hr hf,
+end
+
+lemma tendsto.at_bot_zsmul_neg_const {f : α → ℤ} (hr : r < 0) (hf : tendsto f l at_bot) :
+  tendsto (λ x, f x • r) l at_top :=
+begin
+  have h : (λ x, (-f) x • r) = -λ x, f x • r, { ext, simp, },
+  rw tendsto_at_bot_iff_tends_to_neg_at_top at hf,
+  rw tendsto_at_top_iff_tends_to_neg_at_bot,
+  exact h ▸ tendsto.at_top_zsmul_neg_const hr hf,
+end
+
+end linear_ordered_add_comm_group
+
+end filter

--- a/src/order/filter/at_top_bot.lean
+++ b/src/order/filter/at_top_bot.lean
@@ -563,6 +563,13 @@ end
 lemma tendsto_neg_at_bot_at_top : tendsto (has_neg.neg : β → β) at_bot at_top :=
 @tendsto_neg_at_top_at_bot (order_dual β) _
 
+lemma tendsto_at_top_iff_tends_to_neg_at_bot : tendsto f l at_top ↔ tendsto (-f) l at_bot :=
+have hf : f = has_neg.neg ∘ -f, { ext, simp, },
+⟨tendsto_neg_at_top_at_bot.comp, λ h, hf.symm ▸ tendsto_neg_at_bot_at_top.comp h⟩
+
+lemma tendsto_at_bot_iff_tends_to_neg_at_top : tendsto f l at_bot ↔ tendsto (-f) l at_top :=
+@tendsto_at_top_iff_tends_to_neg_at_bot α (order_dual β) _ l f
+
 end ordered_group
 
 section ordered_semiring


### PR DESCRIPTION
Formalized as part of the Sphere Eversion project.



---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
