### PR TITLE
[Merged by Bors] - fix(tactic/ring): `ring_nf` should descend into subexpressions

### DIFF
--- a/src/algebra/continued_fractions/computation/approximations.lean
+++ b/src/algebra/continued_fractions/computation/approximations.lean
@@ -515,8 +515,7 @@ begin
       simp only [stream_nth_fr_ne_zero, conts_eq.symm, pred_conts_eq.symm] at tmp,
       rw tmp,
       simp only [denom'],
-      ring_nf,
-      ac_refl },
+      ring_nf },
     rwa this },
   -- derive some tedious inequalities that we need to rewrite our goal
   have nextConts_b_ineq : (fib (n + 2) : K) ≤ (pred_conts.b + gp.b * conts.b), by

--- a/src/algebra/continued_fractions/computation/approximations.lean
+++ b/src/algebra/continued_fractions/computation/approximations.lean
@@ -515,7 +515,8 @@ begin
       simp only [stream_nth_fr_ne_zero, conts_eq.symm, pred_conts_eq.symm] at tmp,
       rw tmp,
       simp only [denom'],
-      ring_nf },
+      ring_nf,
+      ac_refl },
     rwa this },
   -- derive some tedious inequalities that we need to rewrite our goal
   have nextConts_b_ineq : (fib (n + 2) : K) ≤ (pred_conts.b + gp.b * conts.b), by

--- a/src/analysis/special_functions/pow.lean
+++ b/src/analysis/special_functions/pow.lean
@@ -887,11 +887,11 @@ end
 
 /-- The function `x ^ (1 / x)` tends to `1` at `+∞`. -/
 lemma tendsto_rpow_div : tendsto (λ x, x ^ ((1:ℝ) / x)) at_top (𝓝 1) :=
-by { convert tendsto_rpow_div_mul_add (1:ℝ) _ (0:ℝ) zero_ne_one, ring_nf }
+by { convert tendsto_rpow_div_mul_add (1:ℝ) _ (0:ℝ) zero_ne_one, funext, congr' 2, ring }
 
 /-- The function `x ^ (-1 / x)` tends to `1` at `+∞`. -/
 lemma tendsto_rpow_neg_div : tendsto (λ x, x ^ (-(1:ℝ) / x)) at_top (𝓝 1) :=
-by { convert tendsto_rpow_div_mul_add (-(1:ℝ)) _ (0:ℝ) zero_ne_one, ring_nf }
+by { convert tendsto_rpow_div_mul_add (-(1:ℝ)) _ (0:ℝ) zero_ne_one, funext, congr' 2, ring }
 
 end limits
 

--- a/src/data/zmod/basic.lean
+++ b/src/data/zmod/basic.lean
@@ -744,7 +744,7 @@ begin
   conv_lhs { congr, rw [← nat.mod_add_div n 2, int.coe_nat_add, int.coe_nat_mul,
     int.coe_nat_bit0, int.coe_nat_one] },
   suffices : ((n % 2 : ℕ) + (n / 2) : ℤ) ≤ (val x),
-  { rw ← sub_nonneg at this ⊢, apply le_trans this (le_of_eq _), ring_nf, ring },
+  { rw ← sub_nonneg at this ⊢, apply le_trans this (le_of_eq _), ring },
   norm_cast,
   calc (n : ℕ) % 2 + n / 2 ≤ 1 + n / 2 :
     nat.add_le_add_right (nat.le_of_lt_succ (nat.mod_lt _ dec_trivial)) _

--- a/src/tactic/ring.lean
+++ b/src/tactic/ring.lean
@@ -566,18 +566,19 @@ do
       (a, e', pr) ← ext_simplify_core a {}
         simp_lemmas.mk (λ _, failed) (λ a _ _ _ e, do
           write_ref atoms a,
+          (new_e, pr) ← eval' red atoms e,
           (new_e, pr) ← match mode with
-          | normalize_mode.raw := eval' red atoms
-          | normalize_mode.horner := trans_conv (eval' red atoms)
-                                      (λ e, do (e', prf, _) ← simplify lemmas [] e, pure (e', prf))
+          | normalize_mode.raw := λ _, pure (new_e, pr)
+          | normalize_mode.horner := trans_conv (λ _, pure (new_e, pr))
+            (λ e, do (e', prf, _) ← simplify lemmas [] e, pure (e', prf))
           | normalize_mode.SOP :=
-            trans_conv (eval' red atoms) $
+            trans_conv (λ _, pure (new_e, pr)) $
             trans_conv (λ e, do (e', prf, _) ← simplify lemmas [] e, pure (e', prf)) $
             simp_bottom_up' (λ e, norm_num.derive e <|> pow_lemma.rewrite e)
           end e,
           guard (¬ new_e =ₐ e),
           a ← read_ref atoms,
-          pure (a, new_e, some pr, tt))
+          pure (a, new_e, some pr, ff))
         (λ _ _ _ _ _, failed) `eq e,
       write_ref atoms a,
       pure (e', pr))

--- a/src/tactic/ring.lean
+++ b/src/tactic/ring.lean
@@ -577,7 +577,7 @@ do
           end e,
           guard (¬ new_e =ₐ e),
           a ← read_ref atoms,
-          pure (a, new_e, some pr, ff))
+          pure (a, new_e, some pr, tt))
         (λ _ _ _ _ _, failed) `eq e,
       write_ref atoms a,
       pure (e', pr))

--- a/test/ring.lean
+++ b/test/ring.lean
@@ -72,3 +72,6 @@ example {α} [field α] {x y : α}
   (h : 0 = (1 - x) ^ 2 * (x * (2 ^ 2 * y ^ 2 + 4 * (1 - x) ^ 2))) :
   0 = x * ((2 ^ 2 * y ^ 2 + 4 * (1 - x) ^ 2) * (1 - x) ^ 2) :=
 by transitivity; [exact h, ring]
+
+-- `ring_nf` should descend into the subexpressions `x * -a` and `-a * x`:
+example {a x : ℚ} : x * -a = - a * x := by ring_nf


### PR DESCRIPTION
Since the lambda passed to `ext_simp_core` was returning `ff`, this means the simplifier didn't descend into subexpressions, so `ring_nf` only tried to use the Horner normal form if the head symbol of the goal/hypothesis was `+`, `*`, `-` or `^`. In particular, since there are no such operations on `Sort`, `ring_nf` was exactly equivalent to `simp only [horner.equations._eqn_1, add_zero, one_mul, pow_one, neg_mul, add_neg_eq_sub]`. Toggling the return value means `ring_nf` will try to simplify all subexpressions, including the left hand side and right hand side of an equality.

@alexjbest discovered the MWE included in `test/ring.lean` while trying to use `ring_nf` to simplify a complicated expression.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
