### PR TITLE
[Merged by Bors] - chore(topology/algebra/uniform_mul_action): add `has_uniform_continuous_const_smul.op`

### DIFF
--- a/src/topology/algebra/uniform_mul_action.lean
+++ b/src/topology/algebra/uniform_mul_action.lean
@@ -47,6 +47,17 @@ lemma uniform_continuous.const_smul [has_uniform_continuous_const_smul M X]
   uniform_continuous (c • f) :=
 (uniform_continuous_const_smul c).comp hf
 
+/-- If a scalar is central, then its right action is uniform continuous when its left action is. -/
+@[priority 100]
+instance has_uniform_continuous_const_smul.op [has_scalar Mᵐᵒᵖ X] [is_central_scalar M X]
+  [has_uniform_continuous_const_smul M X] :
+  has_uniform_continuous_const_smul Mᵐᵒᵖ X :=
+⟨mul_opposite.rec $ λ c, begin
+  change uniform_continuous (λ m, mul_opposite.op c • m),
+  simp_rw op_smul_eq_smul,
+  exact uniform_continuous_const_smul c,
+end⟩
+
 end has_scalar
 
 @[to_additive] instance uniform_group.to_has_uniform_continuous_const_smul

--- a/src/topology/algebra/uniform_mul_action.lean
+++ b/src/topology/algebra/uniform_mul_action.lean
@@ -50,8 +50,7 @@ lemma uniform_continuous.const_smul [has_uniform_continuous_const_smul M X]
 /-- If a scalar is central, then its right action is uniform continuous when its left action is. -/
 @[priority 100]
 instance has_uniform_continuous_const_smul.op [has_scalar Mᵐᵒᵖ X] [is_central_scalar M X]
-  [has_uniform_continuous_const_smul M X] :
-  has_uniform_continuous_const_smul Mᵐᵒᵖ X :=
+  [has_uniform_continuous_const_smul M X] : has_uniform_continuous_const_smul Mᵐᵒᵖ X :=
 ⟨mul_opposite.rec $ λ c, begin
   change uniform_continuous (λ m, mul_opposite.op c • m),
   simp_rw op_smul_eq_smul,

--- a/src/topology/algebra/uniform_mul_action.lean
+++ b/src/topology/algebra/uniform_mul_action.lean
@@ -78,6 +78,9 @@ variable [has_scalar M X]
 @[to_additive] instance : has_uniform_continuous_const_smul M (completion X) :=
 ⟨λ c, uniform_continuous_map⟩
 
+instance [has_scalar Mᵐᵒᵖ X] [is_central_scalar M X] : is_central_scalar M (completion X) :=
+⟨λ c a, congr_arg (λ f, completion.map f a) $ by exact funext (op_smul_eq_smul c)⟩
+
 variables {M X} [has_uniform_continuous_const_smul M X]
 
 @[simp, norm_cast, to_additive]


### PR DESCRIPTION
This matches `has_continuous_const_smul.op` and other similar lemmas.

With this in place, we can state `is_central_scalar` on `completion`s.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
