### PR TITLE
[Merged by Bors] - feat(linear_algebra/projective_space/basic): The projectivization of a vector space.

### DIFF
--- a/src/linear_algebra/projective_space/basic.lean
+++ b/src/linear_algebra/projective_space/basic.lean
@@ -13,17 +13,20 @@ This file contains the definition of the projectivization of a vector space over
 as well as the bijection between said projectivization and the collection of all one
 dimensional subspaces of the vector space.
 
-## Constructing terms of `projectivization K V`.
-We have three ways to construct terms of `projectivization K V`:
+## Notation
+`ℙ K V` is notation for `projectivization K V`, the projectivization of a `K`-vector space `V`.
+
+## Constructing terms of `ℙ K V`.
+We have three ways to construct terms of `ℙ K V`:
 - `projectivization.mk K v hv` where `v : V` and `hv : v ≠ 0`.
 - `projectivization.mk' K v` where `v : { w : V // w ≠ 0 }`.
 - `projectivization.mk'' H h` where `H : submodule K V` and `h : finrank H = 1`.
 
 ## Other definitions
-- For `v : projectivization K V`, `v.submodule` gives the corresponding submodule of `V`.
-- `projectivization.equiv_submodule` is the equivalence between `projectivization K V`
+- For `v : ℙ K V`, `v.submodule` gives the corresponding submodule of `V`.
+- `projectivization.equiv_submodule` is the equivalence between `ℙ K V`
   and `{ H : submodule K V // finrank H = 1 }`.
-- For `v : projectivization K V`, `v.rep : V` is a representative of `v`.
+- For `v : ℙ K V`, `v.rep : V` is a representative of `v`.
 
 ## Projects
 Everything in this file can be done for `division_ring`s instead of `field`s, but
@@ -38,43 +41,46 @@ variables (K V : Type*) [field K] [add_comm_group V] [module K V]
 def projectivization_setoid : setoid { v : V // v ≠ 0 } :=
 (mul_action.orbit_rel Kˣ V).comap coe
 
-/-- The projectivization of the `K`-vector space `V`. -/
+/-- The projectivization of the `K`-vector space `V`.
+The notation `ℙ K V` is preferred. -/
 @[nolint has_inhabited_instance]
 def projectivization := quotient (projectivization_setoid K V)
+
+notation `ℙ` := projectivization
 
 namespace projectivization
 
 variables {V}
 
 /-- Construct an element of the projectivization from a nonzero vector. -/
-def mk (v : V) (hv : v ≠ 0) : projectivization K V := quotient.mk' ⟨v,hv⟩
+def mk (v : V) (hv : v ≠ 0) : ℙ K V := quotient.mk' ⟨v,hv⟩
 
 /-- A variant of `projectivization.mk` in terms of a subtype. `mk` is preferred. -/
-def mk' (v : { v : V // v ≠ 0 }) : projectivization K V := quotient.mk' v
+def mk' (v : { v : V // v ≠ 0 }) : ℙ K V := quotient.mk' v
 
 @[simp] lemma mk'_eq_mk (v : { v : V // v ≠ 0}) :
   mk' K v = mk K v v.2 :=
 by { dsimp [mk, mk'], congr' 1, simp }
 
-instance [nontrivial V] : nonempty (projectivization K V) :=
+instance [nontrivial V] : nonempty (ℙ K V) :=
 let ⟨v, hv⟩ := exists_ne (0 : V) in ⟨mk K v hv⟩
 
 variable {K}
 
 /-- Choose a representative of `v : projectivization K V` in `V`. -/
-protected noncomputable def rep (v : projectivization K V) : V := v.out'.1
+protected noncomputable def rep (v : ℙ K V) : V := v.out'
 
-lemma rep_nonzero (v : projectivization K V) : v.rep ≠ 0 := v.out'.2
+lemma rep_nonzero (v : ℙ K V) : v.rep ≠ 0 := v.out'.2
 
 @[simp]
-lemma mk_rep (v : projectivization K V) :
+lemma mk_rep (v : ℙ K V) :
   mk K v.rep v.rep_nonzero = v :=
 by { dsimp [mk, projectivization.rep], simp }
 
 open finite_dimensional
 
 /-- Consider an element of the projectivization as a submodule of `V`. -/
-protected def submodule (v : projectivization K V) : submodule K V :=
+protected def submodule (v : ℙ K V) : submodule K V :=
 quotient.lift_on' v (λ v, K ∙ (v : V)) $ begin
   rintro ⟨a, ha⟩ ⟨b, hb⟩ ⟨x, (rfl : x • b = a)⟩,
   exact (submodule.span_singleton_smul_eq _ x.ne_zero),
@@ -82,7 +88,7 @@ end
 
 variable (K)
 
-lemma mk_eq_mk_iff  (v w : V) (hv : v ≠ 0) (hw : w ≠ 0) :
+lemma mk_eq_mk_iff (v w : V) (hv : v ≠ 0) (hw : w ≠ 0) :
   mk K v hv = mk K w hw ↔ ∃ (a : Kˣ), a • w = v :=
 quotient.eq'
 
@@ -95,27 +101,27 @@ variable {K}
 /-- An induction principle for `projectivization`.
 Use as `induction v using projectivization.ind`. -/
 @[elab_as_eliminator]
-lemma ind {P : projectivization K V → Prop} (h : ∀ (v : V) (h : v ≠ 0), P (mk K v h)) :
+lemma ind {P : ℙ K V → Prop} (h : ∀ (v : V) (h : v ≠ 0), P (mk K v h)) :
   ∀ p, P p :=
 quotient.ind' $ subtype.rec $ by exact h
 
 @[simp]
 lemma submodule_mk (v : V) (hv : v ≠ 0) : (mk K v hv).submodule = K ∙ v := rfl
 
-lemma submodule_eq (v : projectivization K V) : v.submodule = K ∙ v.rep :=
+lemma submodule_eq (v : ℙ K V) : v.submodule = K ∙ v.rep :=
 by { conv_lhs { rw ← v.mk_rep }, refl }
 
-lemma finrank_submodule (v : projectivization K V) : finrank K v.submodule = 1 :=
+lemma finrank_submodule (v : ℙ K V) : finrank K v.submodule = 1 :=
 begin
   rw submodule_eq,
   exact finrank_span_singleton v.rep_nonzero,
 end
 
-instance (v : projectivization K V) : finite_dimensional K v.submodule :=
+instance (v : ℙ K V) : finite_dimensional K v.submodule :=
 by { rw ← v.mk_rep, change finite_dimensional K (K ∙ v.rep), apply_instance }
 
 lemma submodule_injective : function.injective
-  (projectivization.submodule : projectivization K V → submodule K V) :=
+  (projectivization.submodule : ℙ K V → submodule K V) :=
 begin
   intros u v h, replace h := le_of_eq h,
   simp only [submodule_eq] at h,
@@ -131,7 +137,7 @@ variables (K V)
 /-- The equivalence between the projectivization and the
 collection of subspaces of dimension 1. -/
 noncomputable
-def equiv_submodule : projectivization K V ≃ { H : submodule K V // finrank K H = 1 } :=
+def equiv_submodule : ℙ K V ≃ { H : submodule K V // finrank K H = 1 } :=
 equiv.of_bijective (λ v, ⟨v.submodule, v.finrank_submodule⟩)
 begin
   split,
@@ -156,7 +162,7 @@ variables {K V}
 
 /-- Construct an element of the projectivization from a subspace of dimension 1. -/
 noncomputable
-def mk'' (H : _root_.submodule K V) (h : finrank K H = 1) : projectivization K V :=
+def mk'' (H : _root_.submodule K V) (h : finrank K H = 1) : ℙ K V :=
 (equiv_submodule K V).symm ⟨H,h⟩
 
 @[simp]
@@ -169,16 +175,16 @@ begin
 end
 
 @[simp]
-lemma mk''_submodule (v : projectivization K V) : mk'' v.submodule v.finrank_submodule = v :=
+lemma mk''_submodule (v : ℙ K V) : mk'' v.submodule v.finrank_submodule = v :=
 show (equiv_submodule K V).symm (equiv_submodule K V _) = _, by simp
 
 section map
 
 variables {L W : Type*} [field L] [add_comm_group W] [module L W]
 
-/-- A semilinear map of vector spaces induces a map on projective spaces. -/
+/-- An injective semilinear map of vector spaces induces a map on projective spaces. -/
 def map {σ : K →+* L} (f : V →ₛₗ[σ] W) (hf : function.injective f) :
-  projectivization K V → projectivization L W :=
+  ℙ K V → ℙ L W :=
 quotient.map' (λ v, ⟨f v, λ c, v.2 (hf (by simp [c]))⟩)
 begin
   rintros ⟨u,hu⟩ ⟨v,hv⟩ ⟨a,ha⟩,

--- a/src/linear_algebra/projective_space/basic.lean
+++ b/src/linear_algebra/projective_space/basic.lean
@@ -81,13 +81,13 @@ end
 
 variable (K)
 
-lemma exists_of_mk_eq_mk  (v w : V) (hv : v ≠ 0) (hw : w ≠ 0) :
+lemma mk_eq_mk_iff  (v w : V) (hv : v ≠ 0) (hw : w ≠ 0) :
   mk K v hv = mk K w hw ↔ ∃ (a : Kˣ), a • w = v :=
 quotient.eq'
 
 lemma exists_smul_eq_mk_rep
   (v : V) (hv : v ≠ 0) : ∃ (a : Kˣ), a • v = (mk K v hv).rep :=
-(exists_of_mk_eq_mk _ _ _ (rep_nonzero _) hv).mp (by simp)
+show (projectivization_setoid K V).rel _ _, from quotient.mk_out' ⟨v, hv⟩
 
 variable {K}
 

--- a/src/linear_algebra/projective_space/basic.lean
+++ b/src/linear_algebra/projective_space/basic.lean
@@ -39,6 +39,7 @@ def projectivization_setoid : setoid { v : V // v ≠ 0 } :=
 (mul_action.orbit_rel Kˣ V).comap coe
 
 /-- The projectivization of the `K`-vector space `V`. -/
+@[nolint has_inhabited_instance]
 def projectivization := quotient (projectivization_setoid K V)
 
 namespace projectivization
@@ -55,8 +56,8 @@ def mk' (v : { v : V // v ≠ 0 }) : projectivization K V := quotient.mk' v
   mk' K v = mk K v v.2 :=
 by { dsimp [mk, mk'], congr' 1, simp }
 
-noncomputable instance [nontrivial V] : inhabited (projectivization K V) :=
-let e := exists_ne (0 : V) in ⟨mk K e.some e.some_spec⟩
+instance [nontrivial V] : nonempty (projectivization K V) :=
+let ⟨v, hv⟩ := exists_ne (0 : V) in ⟨mk K v hv⟩
 
 variable {K}
 

--- a/src/linear_algebra/projective_space/basic.lean
+++ b/src/linear_algebra/projective_space/basic.lean
@@ -25,9 +25,14 @@ We have three ways to construct terms of `projectivization K V`:
   and `{ H : submodule K V // finrank H = 1 }`.
 - For `v : projectivization K V`, `v.rep : V` is a representative of `v`.
 
+## Projects
+Everything in this file can be done for `division_ring`s instead of `field`s, but
+this would require a significant refactor of the results from
+`linear_algebra.finite_dimensional` and its imports.
+
 -/
 
-variables (K V : Type*) [division_ring K] [add_comm_group V] [module K V]
+variables (K V : Type*) [field K] [add_comm_group V] [module K V]
 
 /-- The setoid whose quotient is the projectivization of `V`. -/
 def projectivization_setoid : setoid { v : V // v ≠ 0 } :=
@@ -93,8 +98,10 @@ lemma submodule_eq (v : projectivization K V) : v.submodule = K ∙ v.rep :=
 by { conv_lhs { rw ← v.mk_rep }, refl }
 
 lemma finrank_submodule (v : projectivization K V) : finrank K v.submodule = 1 :=
-sorry
---finrank_span_singleton v.rep_nonzero
+begin
+  rw submodule_eq,
+  exact finrank_span_singleton v.rep_nonzero,
+end
 
 instance (v : projectivization K V) : finite_dimensional K v.submodule :=
 by { rw ← v.mk_rep, change finite_dimensional K (K ∙ v.rep), apply_instance }
@@ -123,8 +130,6 @@ begin
   { intros u v h, apply_fun (λ e, e.val) at h,
     apply submodule_injective h },
   { rintros ⟨H, h⟩,
-    sorry
-    /-
     rw finrank_eq_one_iff' at h,
     obtain ⟨v, hv, h⟩ := h,
     have : (v : V) ≠ 0 := λ c, hv (subtype.coe_injective c),
@@ -132,14 +137,12 @@ begin
     symmetry,
     ext x, revert x, erw ← set.ext_iff, ext x,
     dsimp,
-    rw [submodule_mk, submodule.span_singleton_eq_range],
+    rw [submodule.span_singleton_eq_range],
     refine ⟨λ hh, _, _⟩,
     { obtain ⟨c,hc⟩ := h ⟨x,hh⟩,
       exact ⟨c, congr_arg coe hc⟩ },
     { rintros ⟨c,rfl⟩,
-      refine submodule.smul_mem _ _ v.2 }
-    -/
-  }
+      refine submodule.smul_mem _ _ v.2 } }
 end
 variables {K V}
 
@@ -163,7 +166,7 @@ show (equiv_submodule K V).symm (equiv_submodule K V _) = _, by simp
 
 section map
 
-variables {L W : Type*} [division_ring L] [add_comm_group W] [module L W]
+variables {L W : Type*} [field L] [add_comm_group W] [module L W]
 
 /-- A semilinear map of vector spaces induces a map on projective spaces. -/
 def map {σ : K →+* L} (f : V →ₛₗ[σ] W) (hf : function.injective f) :

--- a/src/linear_algebra/projective_space/basic.lean
+++ b/src/linear_algebra/projective_space/basic.lean
@@ -81,15 +81,22 @@ end
 
 variable (K)
 
-lemma exists_of_mk_eq_mk  (v w : V) (hv : v ≠ 0) (hw : w ≠ 0) (h : mk K v hv = mk K w hw) :
-  ∃ (a : Kˣ), a • w = v :=
-quotient.exact' h
+lemma exists_of_mk_eq_mk  (v w : V) (hv : v ≠ 0) (hw : w ≠ 0) :
+  mk K v hv = mk K w hw ↔ ∃ (a : Kˣ), a • w = v :=
+quotient.eq'
 
 lemma exists_smul_eq_mk_rep
   (v : V) (hv : v ≠ 0) : ∃ (a : Kˣ), a • v = (mk K v hv).rep :=
-exists_of_mk_eq_mk _ _ _ (rep_nonzero _) hv (by simp)
+(exists_of_mk_eq_mk _ _ _ (rep_nonzero _) hv).mp (by simp)
 
 variable {K}
+
+/-- An induction principle for `projectivization`.
+Use as `induction v using projectivization.ind`. -/
+@[elab_as_eliminator]
+lemma ind {P : projectivization K V → Prop} (h : ∀ (v : V) (h : v ≠ 0), P (mk K v h)) :
+  ∀ p, P p :=
+quotient.ind' $ subtype.rec $ by exact h
 
 @[simp]
 lemma submodule_mk (v : V) (hv : v ≠ 0) : (mk K v hv).submodule = K ∙ v := rfl
@@ -203,7 +210,7 @@ end
 lemma map_id : map
   (linear_map.id : V →ₗ[K] V)
   (linear_equiv.refl K V).injective = id :=
-by { ext v, rw ← v.mk_rep, refl }
+by { ext v, induction v using projectivization.ind, refl }
 
 @[simp]
 lemma map_comp {F U : Type*} [field F] [add_comm_group U] [module F U]
@@ -211,7 +218,7 @@ lemma map_comp {F U : Type*} [field F] [add_comm_group U] [module F U]
   (f : V →ₛₗ[σ] W) (hf : function.injective f)
   (g : W →ₛₗ[τ] U) (hg : function.injective g) :
   map (g.comp f) (hg.comp hf) = map g hg ∘ map f hf :=
-by { ext v, rw ← v.mk_rep, refl }
+by { ext v, induction v using projectivization.ind, refl }
 
 end map
 

--- a/src/linear_algebra/projective_space/basic.lean
+++ b/src/linear_algebra/projective_space/basic.lean
@@ -27,7 +27,7 @@ We have three ways to construct terms of `projectivization K V`:
 
 -/
 
-variables (K V : Type*) [field K] [add_comm_group V] [module K V]
+variables (K V : Type*) [division_ring K] [add_comm_group V] [module K V]
 
 /-- The setoid whose quotient is the projectivization of `V`. -/
 def projectivization_setoid : setoid { v : V // v ≠ 0 } :=
@@ -106,7 +106,8 @@ begin
 end
 
 lemma finrank_submodule (v : projectivization K V) : finrank K v.submodule = 1 :=
-finrank_span_singleton v.rep_nonzero
+sorry
+--finrank_span_singleton v.rep_nonzero
 
 instance (v : projectivization K V) : finite_dimensional K v.submodule :=
 by { dsimp [projectivization.submodule], apply_instance }
@@ -132,6 +133,8 @@ begin
   { intros u v h, apply_fun (λ e, e.val) at h,
     apply submodule_injective h },
   { rintros ⟨H, h⟩,
+    sorry
+    /-
     rw finrank_eq_one_iff' at h,
     obtain ⟨v, hv, h⟩ := h,
     have : (v : V) ≠ 0 := λ c, hv (subtype.coe_injective c),
@@ -144,7 +147,9 @@ begin
     { obtain ⟨c,hc⟩ := h ⟨x,hh⟩,
       exact ⟨c, congr_arg coe hc⟩ },
     { rintros ⟨c,rfl⟩,
-      refine submodule.smul_mem _ _ v.2 } }
+      refine submodule.smul_mem _ _ v.2 }
+    -/
+  }
 end
 variables {K V}
 
@@ -168,7 +173,7 @@ show (equiv_submodule K V).symm (equiv_submodule K V _) = _, by simp
 
 section map
 
-variables {L W : Type*} [field L] [add_comm_group W] [module L W]
+variables {L W : Type*} [division_ring L] [add_comm_group W] [module L W]
 
 /-- A semilinear map of vector spaces induces a map on projective spaces. -/
 def map {σ : K →+* L} (f : V →ₛₗ[σ] W) (hf : function.injective f) :
@@ -183,7 +188,8 @@ end
 
 /-- Mapping with respect to a semilinear map over an isomorphism of fields yields
 an injective map on projective spaces. -/
-lemma map_injective {σ : K ≃+* L} (f : V →ₛₗ[σ.to_ring_hom] W) (hf : function.injective f) :
+lemma map_injective {σ : K →+* L} {τ : L →+* K} [ring_hom_inv_pair σ τ]
+  (f : V →ₛₗ[σ] W) (hf : function.injective f) :
   function.injective (map f hf) :=
 begin
   intros u v h,
@@ -192,9 +198,10 @@ begin
   dsimp [map, mk] at h,
   simp only [quotient.eq'] at h,
   obtain ⟨a,ha⟩ := h,
-  use σ.symm a,
+  use τ a,
   dsimp at ⊢ ha,
-  erw [← σ.apply_symm_apply a, ← f.map_smulₛₗ] at ha,
+  have : a = σ (τ a), by rw ring_hom_inv_pair.comp_apply_eq₂,
+  rw [this, ← f.map_smulₛₗ] at ha,
   exact hf ha,
 end
 
@@ -202,15 +209,7 @@ end
 lemma map_id : map
   (linear_map.id : V →ₗ[K] V)
   (linear_equiv.refl K V).injective = id :=
-begin
-  ext v,
-  rw ← v.mk_rep,
-  dsimp [mk, map],
-  simp only [quotient.eq'],
-  use 1,
-  rw one_smul,
-  refl,
-end
+by { ext v, rw ← v.mk_rep, refl }
 
 @[simp]
 lemma map_comp {F U : Type*} [field F] [add_comm_group U] [module F U]
@@ -218,14 +217,7 @@ lemma map_comp {F U : Type*} [field F] [add_comm_group U] [module F U]
   (f : V →ₛₗ[σ] W) (hf : function.injective f)
   (g : W →ₛₗ[τ] U) (hg : function.injective g) :
   map (g.comp f) (hg.comp hf) = map g hg ∘ map f hf :=
-begin
-  ext v,
-  rw ← v.mk_rep,
-  dsimp [mk, map],
-  simp only [quotient.eq'],
-  use 1,
-  simp,
-end
+by { ext v, rw ← v.mk_rep, refl }
 
 end map
 

--- a/src/linear_algebra/projective_space/basic.lean
+++ b/src/linear_algebra/projective_space/basic.lean
@@ -170,6 +170,7 @@ section map
 
 variables {L W : Type*} [field L] [add_comm_group W] [module L W]
 
+/-- A semilinear map of vector spaces induces a map on projective spaces. -/
 def map {σ : K →+* L} (f : V →ₛₗ[σ] W) (hf : function.injective f) :
   projectivization K V → projectivization L W :=
 quotient.map' (λ v, ⟨f v, λ c, v.2 (hf (by simp [c]))⟩)
@@ -229,3 +230,4 @@ end
 end map
 
 end projectivization
+#lint

--- a/src/linear_algebra/projective_space/basic.lean
+++ b/src/linear_algebra/projective_space/basic.lean
@@ -230,4 +230,3 @@ end
 end map
 
 end projectivization
-#lint

--- a/src/linear_algebra/projective_space/basic.lean
+++ b/src/linear_algebra/projective_space/basic.lean
@@ -1,0 +1,231 @@
+/-
+Copyright (c) 2022 Adam Topaz. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Adam Topaz
+-/
+import linear_algebra.finite_dimensional
+
+/-!
+
+# Projective Spaces
+
+This file contains the definition of the projectivization of a vector space over a field,
+as well as the bijection between said projectivization and the collection of all one
+dimensional subspaces of the vector space.
+
+## Constructing terms of `projectivization K V`.
+We have three ways to construct terms of `projectivization K V`:
+- `projectivization.mk K v hv` where `v : V` and `hv : v ≠ 0`.
+- `projectivization.mk' K v` where `v : { w : V // w ≠ 0 }`.
+- `projectivization.mk'' H h` where `H : submodule K V` and `h : finrank H = 1`.
+
+## Other definitions
+- For `v : projectivization K V`, `v.submodule` gives the corresponding submodule of `V`.
+- `projectivization.equiv_submodule` is the equivalence between `projectivization K V`
+  and `{ H : submodule K V // finrank H = 1 }`.
+- For `v : projectivization K V`, `v.rep : V` is a representative of `v`.
+
+-/
+
+variables (K V : Type*) [field K] [add_comm_group V] [module K V]
+
+/-- The setoid whose quotient is the projectivization of `V`. -/
+def projectivization_setoid : setoid { v : V // v ≠ 0 } :=
+{ r := λ u v, ∃ a : K, a • (u : V) = v,
+  iseqv := begin
+    refine ⟨λ u, ⟨1, by simp⟩, _, λ u v w ⟨a,ha⟩ ⟨b,hb⟩, ⟨b * a, by simp [ha, hb, mul_smul]⟩⟩,
+    rintros u v ⟨a,ha⟩,
+    use a⁻¹,
+    rw [← ha, ← mul_smul, inv_mul_cancel, one_smul],
+    intros c, apply v.2,
+    simpa [c] using ha.symm,
+  end }
+
+
+/-- The projectivization of the `K`-vector space `V`. -/
+def projectivization := quotient (projectivization_setoid K V)
+
+namespace projectivization
+
+variables {V}
+
+/-- Construct an element of the projectivization from a nonzero vector. -/
+def mk (v : V) (hv : v ≠ 0) : projectivization K V := quotient.mk' ⟨v,hv⟩
+
+/-- A variant of `projectivization.mk` in terms of a subtype. `mk` is preferred. -/
+def mk' (v : { v : V // v ≠ 0 }) : projectivization K V := quotient.mk' v
+
+@[simp] lemma mk'_eq_mk (v : { v : V // v ≠ 0}) :
+  mk' K v = mk K v v.2 :=
+by { dsimp [mk, mk'], congr' 1, simp }
+
+noncomputable instance [nontrivial V] : inhabited (projectivization K V) :=
+let e := exists_ne (0 : V) in ⟨mk K e.some e.some_spec⟩
+
+variable {K}
+
+/-- Choose a representative of `v : projectivization K V` in `V`. -/
+protected noncomputable def rep (v : projectivization K V) : V := v.out'.1
+
+lemma rep_nonzero (v : projectivization K V) : v.rep ≠ 0 := v.out'.2
+
+@[simp]
+lemma mk_rep (v : projectivization K V) :
+  mk K v.rep v.rep_nonzero = v :=
+by { dsimp [mk, projectivization.rep], simp }
+
+open finite_dimensional
+
+/-- Consider an element of the projectivization as a submodule of `V`. -/
+protected def submodule (v : projectivization K V) : submodule K V := K ∙ v.rep
+
+variable (K)
+
+lemma exists_of_mk_eq_mk  (v w : V) (hv : v ≠ 0) (hw : w ≠ 0) (h : mk K v hv = mk K w hw) :
+  ∃ (a : K) (ha : a ≠ 0), a • v = w :=
+begin
+  obtain ⟨a,h⟩ := quotient.exact' h,
+  refine ⟨a,_,h⟩,
+  intros c, refine hw _,
+  simpa [c] using h.symm,
+end
+
+lemma exists_smul_eq_mk_rep
+  (v : V) (hv : v ≠ 0) : ∃ (a : K) (ha : a ≠ 0), a • v = (mk K v hv).rep :=
+exists_of_mk_eq_mk _ _ _ hv (rep_nonzero _) (by simp)
+
+variable {K}
+
+@[simp]
+lemma submodule_mk (v : V) (hv : v ≠ 0) : (mk K v hv).submodule = K ∙ v :=
+begin
+  dsimp only [projectivization.submodule],
+  obtain ⟨a, ha, h⟩ := exists_smul_eq_mk_rep K v hv,
+  rw ← h,
+  apply submodule.span_singleton_smul_eq _ ha,
+end
+
+lemma finrank_submodule (v : projectivization K V) : finrank K v.submodule = 1 :=
+finrank_span_singleton v.rep_nonzero
+
+instance (v : projectivization K V) : finite_dimensional K v.submodule :=
+by { dsimp [projectivization.submodule], apply_instance }
+
+lemma submodule_injective : function.injective
+  (projectivization.submodule : projectivization K V → submodule K V) :=
+begin
+  intros u v h, replace h := le_of_eq h,
+  erw submodule.le_span_singleton_iff at h,
+  rw [← mk_rep v, ← mk_rep u],
+  symmetry,
+  exact quotient.sound' (h u.rep (submodule.mem_span_singleton_self _))
+end
+
+variables (K V)
+/-- The equivalence between the projectivization and the
+collection of subspaces of dimension 1. -/
+noncomputable
+def equiv_submodule : projectivization K V ≃ { H : submodule K V // finrank K H = 1 } :=
+equiv.of_bijective (λ v, ⟨v.submodule, v.finrank_submodule⟩)
+begin
+  split,
+  { intros u v h, apply_fun (λ e, e.val) at h,
+    apply submodule_injective h },
+  { rintros ⟨H, h⟩,
+    rw finrank_eq_one_iff' at h,
+    obtain ⟨v, hv, h⟩ := h,
+    have : (v : V) ≠ 0 := λ c, hv (subtype.coe_injective c),
+    use mk K v this,
+    symmetry,
+    ext x, revert x, erw ← set.ext_iff, ext x,
+    dsimp,
+    rw [submodule_mk, submodule.span_singleton_eq_range],
+    refine ⟨λ hh, _, _⟩,
+    { obtain ⟨c,hc⟩ := h ⟨x,hh⟩,
+      exact ⟨c, congr_arg coe hc⟩ },
+    { rintros ⟨c,rfl⟩,
+      refine submodule.smul_mem _ _ v.2 } }
+end
+variables {K V}
+
+/-- Construct an element of the projectivization from a subspace of dimension 1. -/
+noncomputable
+def mk'' (H : _root_.submodule K V) (h : finrank K H = 1) : projectivization K V :=
+(equiv_submodule K V).symm ⟨H,h⟩
+
+@[simp]
+lemma submodule_mk'' (H : _root_.submodule K V) (h : finrank K H = 1) :
+  (mk'' H h).submodule = H :=
+begin
+  suffices : (equiv_submodule K V) (mk'' H h) = ⟨H,h⟩, by exact congr_arg coe this,
+  dsimp [mk''],
+  simp
+end
+
+@[simp]
+lemma mk''_submodule (v : projectivization K V) : mk'' v.submodule v.finrank_submodule = v :=
+show (equiv_submodule K V).symm (equiv_submodule K V _) = _, by simp
+
+section map
+
+variables {L W : Type*} [field L] [add_comm_group W] [module L W]
+
+def map {σ : K →+* L} (f : V →ₛₗ[σ] W) (hf : function.injective f) :
+  projectivization K V → projectivization L W :=
+quotient.map' (λ v, ⟨f v, λ c, v.2 (hf (by simp [c]))⟩)
+begin
+  rintros ⟨u,hu⟩ ⟨v,hv⟩ ⟨a,ha⟩,
+  use σ a,
+  dsimp at ⊢ ha,
+  rw [← f.map_smulₛₗ, ha],
+end
+
+/-- Mapping with respect to a semilinear map over an isomorphism of fields yields
+an injective map on projective spaces. -/
+lemma map_injective {σ : K ≃+* L} (f : V →ₛₗ[σ.to_ring_hom] W) (hf : function.injective f) :
+  function.injective (map f hf) :=
+begin
+  intros u v h,
+  rw [← u.mk_rep, ← v.mk_rep] at *,
+  apply quotient.sound',
+  dsimp [map, mk] at h,
+  simp only [quotient.eq'] at h,
+  obtain ⟨a,ha⟩ := h,
+  use σ.symm a,
+  dsimp at ⊢ ha,
+  erw [← σ.apply_symm_apply a, ← f.map_smulₛₗ] at ha,
+  exact hf ha,
+end
+
+@[simp]
+lemma map_id : map
+  (linear_map.id : V →ₗ[K] V)
+  (linear_equiv.refl K V).injective = id :=
+begin
+  ext v,
+  rw ← v.mk_rep,
+  dsimp [mk, map],
+  simp only [quotient.eq'],
+  use 1,
+  rw one_smul,
+  refl,
+end
+
+@[simp]
+lemma map_comp {F U : Type*} [field F] [add_comm_group U] [module F U]
+  {σ : K →+* L} {τ : L →+* F} {γ : K →+* F} [ring_hom_comp_triple σ τ γ]
+  (f : V →ₛₗ[σ] W) (hf : function.injective f)
+  (g : W →ₛₗ[τ] U) (hg : function.injective g) :
+  map (g.comp f) (hg.comp hf) = map g hg ∘ map f hf :=
+begin
+  ext v,
+  rw ← v.mk_rep,
+  dsimp [mk, map],
+  simp only [quotient.eq'],
+  use 1,
+  simp,
+end
+
+end map
+
+end projectivization


### PR DESCRIPTION
This provides the initial definitions for the projective space associated to a vector space.

Future work:
- Linear subspaces of projective spaces, connection with subspaces of the vector space, etc.
- The incidence geometry structure of a projective space.
- The fundamental theorem of projective geometry.

I will tag this PR as RFC for now. If you see something missing from this *initial* PR, please let me know!

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
