### PR TITLE
[Merged by Bors] - chore(number_theory/number_field): golf `int.not_is_field`

### DIFF
--- a/src/number_theory/number_field.lean
+++ b/src/number_theory/number_field.lean
@@ -45,7 +45,7 @@ open_locale classical big_operators
 
 /-- `ℤ` with its usual ring structure is not a field. -/
 lemma int.not_is_field : ¬ is_field ℤ := 
-λ h, int.not_even_one $ (h.3 two_ne_zero).imp $ λ a, eq.symm
+λ h, int.not_even_one $ (h.mul_inv_cancel two_ne_zero).imp $ λ a, eq.symm
 
 namespace number_field
 

--- a/src/number_theory/number_field.lean
+++ b/src/number_theory/number_field.lean
@@ -44,17 +44,8 @@ open function
 open_locale classical big_operators
 
 /-- `ℤ` with its usual ring structure is not a field. -/
-lemma int.not_is_field : ¬ is_field ℤ :=
-begin
-  intro hf,
-  cases hf.mul_inv_cancel two_ne_zero with inv2 hinv2,
-  have not_even_2 : ¬ even (2 : ℤ),
-  { rw ← int.odd_iff_not_even,
-    apply int.odd.of_mul_left,
-    rw [hinv2, int.odd_iff_not_even],
-    exact int.not_even_one, },
-  exact not_even_2 (even_bit0 1),
-end
+lemma int.not_is_field : ¬ is_field ℤ := 
+λ h, int.not_even_one $ (h.3 two_ne_zero).imp $ λ a, eq.symm
 
 namespace number_field
 


### PR DESCRIPTION
Golfed proof of number_theory.number_field.int.not_is_field

Co-authored by: David Ang <dka31@cantab.ac.uk>
Co-authored by: Eric Rodriguez <ericrboidi@gmail.com>
Co-authored by: Violeta Hernández <vi.hdz.p@gmail.com>

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
