### PR TITLE
[Merged by Bors] - feat(measure_theory/group/arithmetic): actions by int and nat are measurable

### DIFF
--- a/src/measure_theory/group/arithmetic.lean
+++ b/src/measure_theory/group/arithmetic.lean
@@ -161,6 +161,7 @@ class has_measurable_pow (β γ : Type*) [measurable_space β] [measurable_space
 
 export has_measurable_pow (measurable_pow)
 
+/-- `monoid.has_pow` is measurable. -/
 instance monoid.has_measurable_pow (M : Type*) [monoid M] [measurable_space M]
   [has_measurable_mul₂ M] : has_measurable_pow M ℕ :=
 ⟨begin
@@ -402,6 +403,7 @@ measurable_inv hs
 
 end inv
 
+/-- `div_inv_monoid.has_pow` is measurable. -/
 instance div_inv_monoid.has_measurable_zpow (G : Type u) [div_inv_monoid G] [measurable_space G]
   [has_measurable_mul₂ G] [has_measurable_inv G] :
   has_measurable_pow G ℤ :=
@@ -543,6 +545,7 @@ instance pi.has_measurable_smul {ι : Type*} {α : ι → Type*} [∀ i, has_sca
 ⟨λ g, measurable_pi_iff.mpr $ λ i, (measurable_pi_apply i).const_smul _,
  λ g, measurable_pi_iff.mpr $ λ i, measurable_smul_const _⟩
 
+/-- `add_monoid.has_scalar_nat` is measurable. -/
 instance add_monoid.has_measurable_smul_nat₂ (M : Type*) [add_monoid M] [measurable_space M]
   [has_measurable_add₂ M] : has_measurable_smul₂ ℕ M :=
 ⟨begin
@@ -554,6 +557,7 @@ instance add_monoid.has_measurable_smul_nat₂ (M : Type*) [add_monoid M] [measu
   { simp only [succ_nsmul], exact measurable_id.add ih }
 end⟩
 
+/-- `sub_neg_monoid.has_scalar_int` is measurable. -/
 instance sub_neg_monoid.has_measurable_smul_int₂ (M : Type*) [sub_neg_monoid M] [measurable_space M]
   [has_measurable_add₂ M] [has_measurable_neg M] : has_measurable_smul₂ ℤ M :=
 ⟨begin

--- a/src/measure_theory/group/arithmetic.lean
+++ b/src/measure_theory/group/arithmetic.lean
@@ -164,8 +164,7 @@ export has_measurable_pow (measurable_pow)
 /-- `monoid.has_pow` is measurable. -/
 instance monoid.has_measurable_pow (M : Type*) [monoid M] [measurable_space M]
   [has_measurable_mul₂ M] : has_measurable_pow M ℕ :=
-⟨begin
-  refine measurable_from_prod_encodable (λ n, _),
+⟨measurable_from_prod_encodable $ λ n, begin
   induction n with n ih,
   { simp only [pow_zero, ←pi.one_def, measurable_one] },
   { simp only [pow_succ], exact measurable_id.mul ih }
@@ -407,9 +406,7 @@ end inv
 instance div_inv_monoid.has_measurable_zpow (G : Type u) [div_inv_monoid G] [measurable_space G]
   [has_measurable_mul₂ G] [has_measurable_inv G] :
   has_measurable_pow G ℤ :=
-⟨begin
-  refine measurable_from_prod_encodable (λ n, _),
-  dsimp,
+⟨measurable_from_prod_encodable $ λ n, begin
   cases n with n n,
   { simp_rw zpow_of_nat, exact measurable_id.pow_const _ },
   { simp_rw zpow_neg_succ_of_nat, exact (measurable_id.pow_const (n + 1)).inv }

--- a/src/measure_theory/group/arithmetic.lean
+++ b/src/measure_theory/group/arithmetic.lean
@@ -161,13 +161,12 @@ class has_measurable_pow (β γ : Type*) [measurable_space β] [measurable_space
 
 export has_measurable_pow (measurable_pow)
 
-instance has_measurable_mul.has_measurable_pow (M : Type*) [monoid M] [measurable_space M]
+instance monoid.has_measurable_pow (M : Type*) [monoid M] [measurable_space M]
   [has_measurable_mul₂ M] : has_measurable_pow M ℕ :=
 ⟨begin
-  haveI : measurable_singleton_class ℕ := ⟨λ _, trivial⟩,
   refine measurable_from_prod_encodable (λ n, _),
   induction n with n ih,
-  { simp [pow_zero, measurable_one] },
+  { simp only [pow_zero, ←pi.one_def, measurable_one] },
   { simp only [pow_succ], exact measurable_id.mul ih }
 end⟩
 
@@ -403,29 +402,16 @@ measurable_inv hs
 
 end inv
 
-/- There is something extremely strange here: copy-pasting the proof of this lemma in the proof
-of `has_measurable_zpow` fails, while `pp.all` does not show any difference in the goal.
-Keep it as a separate lemmas as a workaround. -/
-private lemma has_measurable_zpow_aux (G : Type u) [div_inv_monoid G] [measurable_space G]
-  [has_measurable_mul₂ G] [has_measurable_inv G] (k : ℕ) :
-  measurable (λ (x : G), x ^(-[1+ k])) :=
-begin
-  simp_rw [zpow_neg_succ_of_nat],
-  exact (measurable_id.pow_const (k + 1)).inv
-end
-
-instance has_measurable_zpow (G : Type u) [div_inv_monoid G] [measurable_space G]
+instance div_inv_monoid.has_measurable_zpow (G : Type u) [div_inv_monoid G] [measurable_space G]
   [has_measurable_mul₂ G] [has_measurable_inv G] :
   has_measurable_pow G ℤ :=
-begin
-  letI : measurable_singleton_class ℤ := ⟨λ _, trivial⟩,
-  constructor,
+⟨begin
   refine measurable_from_prod_encodable (λ n, _),
   dsimp,
-  apply int.cases_on n,
-  { simpa using measurable_id.pow_const },
-  { exact has_measurable_zpow_aux G }
-end
+  cases n with n n,
+  { simp_rw zpow_of_nat, exact measurable_id.pow_const _ },
+  { simp_rw zpow_neg_succ_of_nat, exact (measurable_id.pow_const (n + 1)).inv }
+end⟩
 
 @[priority 100, to_additive]
 instance has_measurable_div₂_of_mul_inv (G : Type*) [measurable_space G]
@@ -556,6 +542,28 @@ instance pi.has_measurable_smul {ι : Type*} {α : ι → Type*} [∀ i, has_sca
   has_measurable_smul M (Π i, α i) :=
 ⟨λ g, measurable_pi_iff.mpr $ λ i, (measurable_pi_apply i).const_smul _,
  λ g, measurable_pi_iff.mpr $ λ i, measurable_smul_const _⟩
+
+instance add_monoid.has_measurable_smul_nat₂ (M : Type*) [add_monoid M] [measurable_space M]
+  [has_measurable_add₂ M] : has_measurable_smul₂ ℕ M :=
+⟨begin
+  suffices : measurable (λ p : M × ℕ, p.2 • p.1),
+  { apply this.comp measurable_swap, },
+  refine measurable_from_prod_encodable (λ n, _),
+  induction n with n ih,
+  { simp only [zero_smul, ←pi.zero_def, measurable_zero] },
+  { simp only [succ_nsmul], exact measurable_id.add ih }
+end⟩
+
+instance sub_neg_monoid.has_measurable_smul_int₂ (M : Type*) [sub_neg_monoid M] [measurable_space M]
+  [has_measurable_add₂ M] [has_measurable_neg M] : has_measurable_smul₂ ℤ M :=
+⟨begin
+  suffices : measurable (λ p : M × ℤ, p.2 • p.1),
+  { apply this.comp measurable_swap, },
+  refine measurable_from_prod_encodable (λ n, _),
+  induction n with n n ih,
+  { simp only [of_nat_zsmul], exact measurable_const_smul _, },
+  { simp only [zsmul_neg_succ_of_nat], exact (measurable_const_smul _).neg }
+end⟩
 
 end smul
 


### PR DESCRIPTION
The `has_measurable_smul₂` proofs are essentially copied from the analogous proofs for `has_measurable_pow`, after golfing them.



---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
