### PR TITLE
chore(category_theory/closed): rename closed to right_closed

### DIFF
--- a/src/algebra/category/Module/monoidal.lean
+++ b/src/algebra/category/Module/monoidal.lean
@@ -263,11 +263,11 @@ end monoidal_category
 open opposite
 
 /--
-Auxiliary definition for the `monoidal_closed` instance on `Module R`.
+Auxiliary definition for the `right_monoidal_closed` instance on `Module R`.
 (This is only a separate definition in order to speed up typechecking. )
 -/
 @[simps]
-def monoidal_closed_hom_equiv (M N P : Module.{u} R) :
+def right_monoidal_closed_hom_equiv (M N P : Module.{u} R) :
   ((monoidal_category.tensor_left M).obj N ⟶ P) ≃
     (N ⟶ ((linear_coyoneda R (Module R)).obj (op M)).obj P) :=
 { to_fun := λ f, linear_map.compr₂ (tensor_product.mk R N M) ((β_ N M).hom ≫ f),
@@ -281,11 +281,11 @@ def monoidal_closed_hom_equiv (M N P : Module.{u} R) :
       symmetric_category.symmetry_assoc],
   end, }
 
-instance : monoidal_closed (Module.{u} R) :=
+instance : right_monoidal_closed (Module.{u} R) :=
 { closed' := λ M,
   { is_adj :=
     { right := (linear_coyoneda R (Module.{u} R)).obj (op M),
       adj := adjunction.mk_of_hom_equiv
-      { hom_equiv := λ N P, monoidal_closed_hom_equiv M N P, } } } }
+      { hom_equiv := λ N P, right_monoidal_closed_hom_equiv M N P, } } } }
 
 end Module

--- a/src/category_theory/closed/cartesian.lean
+++ b/src/category_theory/closed/cartesian.lean
@@ -45,7 +45,7 @@ An object `X` is *exponentiable* if `(X × -)` is a left adjoint.
 We define this as being `closed` in the cartesian monoidal structure.
 -/
 abbreviation exponentiable {C : Type u} [category.{v} C] [has_finite_products C] (X : C) :=
-closed X
+right_closed X
 
 /--
 If `X` and `Y` are exponentiable then `X ⨯ Y` is.
@@ -54,7 +54,7 @@ prove all objects are exponential uniformly.
 -/
 def binary_product_exponentiable {C : Type u} [category.{v} C] [has_finite_products C] {X Y : C}
   (hX : exponentiable X) (hY : exponentiable Y) : exponentiable (X ⨯ Y) :=
-tensor_closed hX hY
+tensor_right_closed hX hY
 
 /--
 The terminal object is always exponentiable.
@@ -63,14 +63,14 @@ at once, rather than just for this one.
 -/
 def terminal_exponentiable {C : Type u} [category.{v} C] [has_finite_products C] :
   exponentiable ⊤_ C :=
-unit_closed
+unit_right_closed
 
 /--
 A category `C` is cartesian closed if it has finite products and every object is exponentiable.
 We define this as `monoidal_closed` with respect to the cartesian monoidal structure.
 -/
 abbreviation cartesian_closed (C : Type u) [category.{v} C] [has_finite_products C] :=
-monoidal_closed C
+right_monoidal_closed C
 
 variables {C : Type u} [category.{v} C] (A B : C) {X X' Y Y' Z : C}
 
@@ -148,11 +148,11 @@ adjunction.hom_equiv_naturality_left_symm _ _ _
 
 @[simp]
 lemma uncurry_curry (f : A ⨯ X ⟶ Y) : uncurry (curry f) = f :=
-(closed.is_adj.adj.hom_equiv _ _).left_inv f
+(right_closed.is_adj.adj.hom_equiv _ _).left_inv f
 
 @[simp]
 lemma curry_uncurry (f : X ⟶ A⟹Y) : curry (uncurry f) = f :=
-(closed.is_adj.adj.hom_equiv _ _).right_inv f
+(right_closed.is_adj.adj.hom_equiv _ _).right_inv f
 
 lemma curry_eq_iff (f : A ⨯ Y ⟶ X) (g : Y ⟶ A ⟹ X) :
   curry f = g ↔ f = uncurry g :=
@@ -176,10 +176,10 @@ lemma curry_id_eq_coev (A X : C) [exponentiable A] : curry (𝟙 _) = (exp.coev 
 by { rw [curry_eq, (exp A).map_id (A ⨯ _)], apply comp_id }
 
 lemma curry_injective : function.injective (curry : (A ⨯ Y ⟶ X) → (Y ⟶ A ⟹ X)) :=
-(closed.is_adj.adj.hom_equiv _ _).injective
+(right_closed.is_adj.adj.hom_equiv _ _).injective
 
 lemma uncurry_injective : function.injective (uncurry : (Y ⟶ A ⟹ X) → (A ⨯ Y ⟶ X)) :=
-(closed.is_adj.adj.hom_equiv _ _).symm.injective
+(right_closed.is_adj.adj.hom_equiv _ _).symm.injective
 
 end cartesian_closed
 

--- a/src/category_theory/closed/monoidal.lean
+++ b/src/category_theory/closed/monoidal.lean
@@ -23,14 +23,14 @@ namespace category_theory
 open category monoidal_category
 
 /-- An object `X` is (right) closed if `(X ⊗ -)` is a left adjoint. -/
-class closed {C : Type u} [category.{v} C] [monoidal_category.{v} C] (X : C) :=
+class right_closed {C : Type u} [category.{v} C] [monoidal_category.{v} C] (X : C) :=
 (is_adj : is_left_adjoint (tensor_left X))
 
 /-- A monoidal category `C` is (right) monoidal closed if every object is (right) closed. -/
-class monoidal_closed (C : Type u) [category.{v} C] [monoidal_category.{v} C] :=
-(closed' : Π (X : C), closed X)
+class right_monoidal_closed (C : Type u) [category.{v} C] [monoidal_category.{v} C] :=
+(closed' : Π (X : C), right_closed X)
 
-attribute [instance, priority 100] monoidal_closed.closed'
+attribute [instance, priority 100] right_monoidal_closed.closed'
 
 variables {C : Type u} [category.{v} C] [monoidal_category.{v} C]
 
@@ -39,8 +39,8 @@ If `X` and `Y` are closed then `X ⊗ Y` is.
 This isn't an instance because it's not usually how we want to construct internal homs,
 we'll usually prove all objects are closed uniformly.
 -/
-def tensor_closed {X Y : C}
-  (hX : closed X) (hY : closed Y) : closed (X ⊗ Y) :=
+def tensor_right_closed {X Y : C}
+  (hX : right_closed X) (hY : right_closed Y) : right_closed (X ⊗ Y) :=
 { is_adj :=
   begin
     haveI := hX.is_adj,
@@ -53,7 +53,7 @@ The unit object is always closed.
 This isn't an instance because most of the time we'll prove closedness for all objects at once,
 rather than just for this one.
 -/
-def unit_closed : closed (𝟙_ C) :=
+def unit_right_closed : right_closed (𝟙_ C) :=
 { is_adj :=
   { right := 𝟭 C,
     adj := adjunction.mk_of_hom_equiv
@@ -67,7 +67,7 @@ def unit_closed : closed (𝟙_ C) :=
 
 variables (A B : C) {X X' Y Y' Z : C}
 
-variables [closed A]
+variables [right_closed A]
 
 /--
 This is the internal hom `A ⟶[C] -`.
@@ -79,13 +79,13 @@ that allows specifying a particular definition of the internal hom,
 and provide a low priority opaque instance.
 -/
 def ihom : C ⥤ C :=
-(@closed.is_adj _ _ _ A _).right
+(@right_closed.is_adj _ _ _ A _).right
 
 namespace ihom
 
 /-- The adjunction between `A ⊗ -` and `A ⟹ -`. -/
 def adjunction : tensor_left A ⊣ ihom A :=
-closed.is_adj.adj
+right_closed.is_adj.adj
 
 /-- The evaluation natural transformation. -/
 def ev : ihom A ⋙ tensor_left A ⟶ 𝟭 C :=
@@ -128,7 +128,7 @@ instance : preserves_colimits (tensor_left A) :=
 variables {A}
 
 -- Wrap these in a namespace so we don't clash with the core versions.
-namespace monoidal_closed
+namespace right_monoidal_closed
 
 /-- Currying in a monoidal closed category. -/
 def curry : (A ⊗ Y ⟶ X) → (Y ⟶ A ⟶[C] X) :=
@@ -164,11 +164,11 @@ adjunction.hom_equiv_naturality_left_symm _ _ _
 
 @[simp]
 lemma uncurry_curry (f : A ⊗ X ⟶ Y) : uncurry (curry f) = f :=
-(closed.is_adj.adj.hom_equiv _ _).left_inv f
+(right_closed.is_adj.adj.hom_equiv _ _).left_inv f
 
 @[simp]
 lemma curry_uncurry (f : X ⟶ A ⟶[C] Y) : curry (uncurry f) = f :=
-(closed.is_adj.adj.hom_equiv _ _).right_inv f
+(right_closed.is_adj.adj.hom_equiv _ _).right_inv f
 
 lemma curry_eq_iff (f : A ⊗ Y ⟶ X) (g : Y ⟶ A ⟶[C] X) :
   curry f = g ↔ f = uncurry g :=
@@ -186,10 +186,10 @@ lemma curry_eq (g : A ⊗ Y ⟶ X) : curry g = (ihom.coev A).app Y ≫ (ihom A).
 adjunction.hom_equiv_unit _
 
 lemma curry_injective : function.injective (curry : (A ⊗ Y ⟶ X) → (Y ⟶ A ⟶[C] X)) :=
-(closed.is_adj.adj.hom_equiv _ _).injective
+(right_closed.is_adj.adj.hom_equiv _ _).injective
 
 lemma uncurry_injective : function.injective (uncurry : (Y ⟶ A ⟶[C] X) → (A ⊗ Y ⟶ X)) :=
-(closed.is_adj.adj.hom_equiv _ _).symm.injective
+(right_closed.is_adj.adj.hom_equiv _ _).symm.injective
 
 variables (A X)
 
@@ -201,7 +201,7 @@ by { rw [curry_eq, (ihom A).map_id (A ⊗ _)], apply comp_id }
 
 section pre
 
-variables {A B} [closed B]
+variables {A B} [right_closed B]
 
 /-- Pre-compose an internal hom with an external hom. -/
 def pre (f : B ⟶ A) : ihom A ⟶ ihom B :=
@@ -213,7 +213,7 @@ lemma id_tensor_pre_app_comp_ev (f : B ⟶ A) (X : C) :
 transfer_nat_trans_self_counit _ _ ((tensoring_left C).map f) X
 
 lemma uncurry_pre (f : B ⟶ A) (X : C) :
-  monoidal_closed.uncurry ((pre f).app X) = (f ⊗ 𝟙 _) ≫ (ihom.ev A).app X :=
+  right_monoidal_closed.uncurry ((pre f).app X) = (f ⊗ 𝟙 _) ≫ (ihom.ev A).app X :=
 by rw [uncurry_eq, id_tensor_pre_app_comp_ev]
 
 lemma coev_app_comp_pre_app (f : B ⟶ A) :
@@ -222,11 +222,11 @@ lemma coev_app_comp_pre_app (f : B ⟶ A) :
 unit_transfer_nat_trans_self _ _ ((tensoring_left C).map f) X
 
 @[simp]
-lemma pre_id (A : C) [closed A] : pre (𝟙 A) = 𝟙 _ :=
+lemma pre_id (A : C) [right_closed A] : pre (𝟙 A) = 𝟙 _ :=
 by { simp only [pre, functor.map_id], dsimp, simp, }
 
 @[simp]
-lemma pre_map {A₁ A₂ A₃ : C} [closed A₁] [closed A₂] [closed A₃]
+lemma pre_map {A₁ A₂ A₃ : C} [right_closed A₁] [right_closed A₂] [right_closed A₃]
   (f : A₁ ⟶ A₂) (g : A₂ ⟶ A₃) :
   pre (f ≫ g) = pre g ≫ pre f :=
 by rw [pre, pre, pre, transfer_nat_trans_self_comp, (tensoring_left C).map_comp]
@@ -234,10 +234,10 @@ by rw [pre, pre, pre, transfer_nat_trans_self_comp, (tensoring_left C).map_comp]
 end pre
 
 /-- The internal hom functor given by the monoidal closed structure. -/
-def internal_hom [monoidal_closed C] : Cᵒᵖ ⥤ C ⥤ C :=
+def internal_hom [right_monoidal_closed C] : Cᵒᵖ ⥤ C ⥤ C :=
 { obj := λ X, ihom X.unop,
   map := λ X Y f, pre f.unop }
 
-end monoidal_closed
+end right_monoidal_closed
 
 end category_theory


### PR DESCRIPTION
I'm shortly going to introduce `left_closed` as well, and make `closed` mean "biclosed".

This is just a preliminary renaming PR.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
