### PR TITLE
feat(category_theory/closed): has_internal_hom class carrying data

### DIFF
--- a/src/algebra/category/Module/monoidal.lean
+++ b/src/algebra/category/Module/monoidal.lean
@@ -263,11 +263,11 @@ end monoidal_category
 open opposite
 
 /--
-Auxiliary definition for the `monoidal_closed` instance on `Module R`.
+Auxiliary definition for the `has_internal_homs` instance on `Module R`.
 (This is only a separate definition in order to speed up typechecking. )
 -/
 @[simps]
-def monoidal_closed_hom_equiv (M N P : Module.{u} R) :
+def has_internal_homs_hom_equiv (M N P : Module.{u} R) :
   ((monoidal_category.tensor_left M).obj N ⟶ P) ≃
     (N ⟶ ((linear_coyoneda R (Module R)).obj (op M)).obj P) :=
 { to_fun := λ f, linear_map.compr₂ (tensor_product.mk R N M) ((β_ N M).hom ≫ f),
@@ -281,11 +281,10 @@ def monoidal_closed_hom_equiv (M N P : Module.{u} R) :
       symmetric_category.symmetry_assoc],
   end, }
 
-instance : monoidal_closed (Module.{u} R) :=
-{ closed' := λ M,
-  { is_adj :=
-    { right := (linear_coyoneda R (Module.{u} R)).obj (op M),
-      adj := adjunction.mk_of_hom_equiv
-      { hom_equiv := λ N P, monoidal_closed_hom_equiv M N P, } } } }
+instance : has_internal_homs (Module.{u} R) :=
+{ has_internal_hom := λ M,
+  { ihom := (linear_coyoneda R (Module.{u} R)).obj (op M),
+    adj := adjunction.mk_of_hom_equiv
+    { hom_equiv := λ N P, has_internal_homs_hom_equiv M N P, } } }
 
 end Module

--- a/src/category_theory/closed/cartesian.lean
+++ b/src/category_theory/closed/cartesian.lean
@@ -76,6 +76,10 @@ variables {C : Type u} [category.{v} C] (A B : C) {X X' Y Y' Z : C}
 
 variables [has_finite_products C] [exponentiable A]
 
+section
+
+local attribute [instance] has_internal_hom_of_closed
+
 /-- This is (-)^A. -/
 abbreviation exp : C ⥤ C :=
 ihom A
@@ -238,10 +242,20 @@ by rw [pre, pre, pre, transfer_nat_trans_self_comp, prod.functor.map_comp]
 
 end pre
 
+end
+
+open cartesian_closed
+
 /-- The internal hom functor given by the cartesian closed structure. -/
 def internal_hom [cartesian_closed C] : Cᵒᵖ ⥤ C ⥤ C :=
 { obj := λ X, exp X.unop,
   map := λ X Y f, pre f.unop }
+
+variables {A B}
+
+section
+
+local attribute [instance] has_internal_hom_of_closed
 
 /-- If an initial object `I` exists in a CCC, then `A ⨯ I ≅ I`. -/
 @[simps]
@@ -257,6 +271,8 @@ def zero_mul {I : C} (t : is_initial I) : A ⨯ I ≅ I :=
     apply t.hom_ext,
   end,
   inv_hom_id' := t.hom_ext _ _ }
+
+end
 
 /-- If an initial object `0` exists in a CCC, then `0 ⨯ A ≅ 0`. -/
 def mul_zero {I : C} (t : is_initial I) : I ⨯ A ≅ I :=

--- a/src/category_theory/closed/monoidal.lean
+++ b/src/category_theory/closed/monoidal.lean
@@ -35,7 +35,7 @@ attribute [instance, priority 100] monoidal_closed.closed'
 /--
 A data-carrying typeclass giving a particular choice of internal hom for a single object.
 This is useful for concrete categories,
-where it is important that the internal has a particular definition.
+where it is important that the internal hom has a particular definition.
 -/
 class has_internal_hom {C : Type u} [category.{v} C] [monoidal_category.{v} C] (X : C) :=
 (ihom : C ⥤ C)
@@ -44,7 +44,7 @@ class has_internal_hom {C : Type u} [category.{v} C] [monoidal_category.{v} C] (
 /--
 A data-carrying typeclass giving a particular choice of internal hom for every object.
 This is useful for concrete categories,
-where it is important that the internal has a particular definition.
+where it is important that the internal homs have a particular definition.
 -/
 class has_internal_homs (C : Type u) [category.{v} C] [monoidal_category.{v} C] :=
 (has_internal_hom : Π (X : C), has_internal_hom X)

--- a/src/category_theory/closed/monoidal.lean
+++ b/src/category_theory/closed/monoidal.lean
@@ -39,7 +39,7 @@ where it is important that the internal has a particular definition.
 -/
 class has_internal_hom {C : Type u} [category.{v} C] [monoidal_category.{v} C] (X : C) :=
 (ihom : C ⥤ C)
-(adjunction : tensor_left X ⊣ ihom)
+(adj : tensor_left X ⊣ ihom)
 
 /--
 A data-carrying typeclass giving a particular choice of internal hom for every object.
@@ -57,7 +57,7 @@ variables {C : Type u} [category.{v} C] [monoidal_category.{v} C]
 def ihom (X : C) [has_internal_hom X] : C ⥤ C := has_internal_hom.ihom X
 
 instance closed_of_has_internal_hom (X : C) [has_internal_hom X] : closed X :=
-{ is_adj := { right := ihom X, adj := has_internal_hom.adjunction, }, }
+{ is_adj := { right := ihom X, adj := has_internal_hom.adj, }, }
 
 instance monoidal_closed_of_has_internal_homs [has_internal_homs C] : monoidal_closed C :=
 { closed' := λ X, by apply_instance, }
@@ -69,7 +69,7 @@ Construct a `has_internal_hom` instance using choice to pick an arbitrary right 
 -/
 def has_internal_hom_of_closed (X : C) [closed X] : has_internal_hom X :=
 { ihom := (@closed.is_adj _ _ _ X _).right,
-  adjunction := @adjunction.of_left_adjoint _ _ _ _ (tensor_left X) (@closed.is_adj _ _ _ X _) }
+  adj := @adjunction.of_left_adjoint _ _ _ _ (tensor_left X) (@closed.is_adj _ _ _ X _) }
 
 variables (C)
 

--- a/src/category_theory/closed/types.lean
+++ b/src/category_theory/closed/types.lean
@@ -7,6 +7,7 @@ import category_theory.limits.presheaf
 import category_theory.limits.preserves.functor_category
 import category_theory.limits.shapes.types
 import category_theory.closed.cartesian
+import category_theory.monoidal.types
 
 /-!
 # Cartesian closure of Type
@@ -27,6 +28,27 @@ variables {C : Type v₂} [category.{v₁} C]
 
 section cartesian_closed
 
+open opposite
+
+/--
+Auxiliary definition for the `has_internal_homs` instance on `Type v₁`.
+(This is only a separate definition in order to speed up typechecking. )
+-/
+@[simps]
+def has_internal_homs_hom_equiv (X Y Z : Type v₁) :
+  ((monoidal_category.tensor_left X).obj Y ⟶ Z) ≃
+    (Y ⟶ (coyoneda.obj (op X)).obj Z) :=
+{ to_fun := λ f y x, f (x, y),
+  inv_fun := λ f ⟨x,y⟩, f y x,
+  left_inv := λ f, by tidy,
+  right_inv := λ f, by tidy, }
+
+instance : has_internal_homs (Type v₁) :=
+{ has_internal_hom := λ X,
+  { ihom := coyoneda.obj (op X),
+    adj := adjunction.mk_of_hom_equiv
+    { hom_equiv := λ Y Z, has_internal_homs_hom_equiv X Y Z, } } }
+
 instance (X : Type v₁) : is_left_adjoint (types.binary_product_functor.obj X) :=
 { right :=
   { obj := λ Y, X ⟶ Y,
@@ -37,6 +59,16 @@ instance (X : Type v₁) : is_left_adjoint (types.binary_product_functor.obj X) 
 
 instance : has_finite_products (Type v₁) := has_finite_products_of_has_products _
 
+/-
+Note that we can't just use the `has_internal_homs` instance above,
+because it uses the `category_theory.types_monoidal` instance,
+which is not definitionally equal to the
+`category_theory.monoidal_of_has_finite_products` instance baked into `cartesian_closed`.
+
+As a consequence, while the internal hom `X ⟶[Type v₁] Y` will just be the usual
+function type `X → Y`, the `X ⟹ Y` type coming from the `cartesian_closed` instance
+will be "opaque".
+-/
 instance : cartesian_closed (Type v₁) :=
 { closed' := λ X,
   { is_adj := adjunction.left_adjoint_of_nat_iso (types.binary_product_iso_prod.app X) } }


### PR DESCRIPTION
Introduce a data-carrying analogue of `monoidal_closed` that allows us to specify a chosen internal hom object,
allowing us to ensure it is definitionally equal to the "obvious" one back in the real world.

This was suggested by @jcommelin on #12386.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
