### PR TITLE
feat(algebra/algebra/basic): Introduce non-unital, non-associative algebras

### DIFF
--- a/src/algebra/algebra/basic.lean
+++ b/src/algebra/algebra/basic.lean
@@ -115,6 +115,71 @@ class algebra (R : Type u) (A : Type v) [comm_semiring R] [semiring A]
   extends has_scalar R A, R →+* A :=
 (commutes' : ∀ r x, to_fun r * x = x * to_fun r)
 (smul_def' : ∀ r x, r • x = to_fun r * x)
+
+class non_unital_non_assoc_algebra (R : Type u) (A : Type v) [comm_semiring R] [non_unital_non_assoc_semiring A]
+  extends has_scalar R A, R →+* (add_monoid.End A) :=
+(commutes' : ∀ r a b, (to_ring_hom r a) * b = a * (to_ring_hom r b))
+(smul_def' : ∀ r a, r • a = to_ring_hom r  a)
+
+/- If R is a commutative semiring and A is a semiring and R →+* (add_monoid.End A) is a
+(non-unital, non-associative) algebra then  r → r•1 is a (unital, associative) algebra-/
+lemma to_algebra (R : Type u) (A : Type v) [comm_semiring R] [semiring A]
+  [non_unital_non_assoc_algebra R A] : algebra R A:= {
+    to_fun := λ r, _inst_3.to_fun r 1,
+    map_one' := by rw [ring_hom.to_fun_eq_coe, map_one, add_monoid.coe_one, id.def],
+    map_mul' := λ r₁ r₂, by rw [ring_hom.to_fun_eq_coe, map_mul, add_monoid.coe_mul,
+      function.comp_app, non_unital_non_assoc_algebra.commutes', one_mul],
+    map_zero' := by rw [ring_hom.to_fun_eq_coe, map_zero, add_monoid_hom.zero_apply],
+    map_add' := λ r₁ r₂, by rw [ring_hom.to_fun_eq_coe, map_add, add_monoid_hom.add_apply],
+    commutes' := λ r a, begin
+      simp only [ring_hom.to_fun_eq_coe],
+      rw [non_unital_non_assoc_algebra.commutes', one_mul, ← non_unital_non_assoc_algebra.commutes',
+        mul_one],
+    end,
+    smul_def' := λ r a, begin
+      simp only [ring_hom.to_fun_eq_coe],
+      rw [non_unital_non_assoc_algebra.smul_def', non_unital_non_assoc_algebra.commutes', one_mul],
+    end,
+  }
+
+/- A (unital associative) algebra is also a non-unital non-associative algebra -/
+lemma to_non_unital_non_assoc_algebra (R : Type u) (A : Type v) [comm_semiring R] [semiring A]
+  [algebra R A]  : non_unital_non_assoc_algebra R A := {
+  to_fun := λ r, {
+    to_fun := λ a, r • a,
+    map_zero' := by rw [algebra.smul_def', mul_zero],
+    map_add' := λ a b, by rw [algebra.smul_def', algebra.smul_def', algebra.smul_def', left_distrib],
+  }, -- for each r we have an element of add_monoid.End A
+  map_zero' := begin
+    ext,
+    simp only [add_monoid_hom.coe_mk, add_monoid_hom.zero_apply],
+    rw [algebra.smul_def', ring_hom.to_fun_eq_coe, map_zero, zero_mul],
+  end,
+  map_add' := λ r₁ r₂, begin
+    ext,
+    simp only [add_monoid_hom.coe_mk, add_monoid_hom.add_apply],
+    rw [algebra.smul_def', ring_hom.to_fun_eq_coe, map_add, right_distrib, algebra.smul_def',
+      algebra.smul_def', ring_hom.to_fun_eq_coe],
+  end,
+  map_one' := begin
+    ext,
+    simp only [add_monoid_hom.coe_mk, add_monoid.coe_one, id.def],
+    rw [algebra.smul_def', ring_hom.to_fun_eq_coe, map_one, one_mul],
+  end,
+  map_mul' := λ r₁ r₂, begin
+    ext,
+    simp only [add_monoid_hom.coe_mk, add_monoid.coe_mul, function.comp_app],
+    rw [algebra.smul_def', algebra.smul_def', algebra.smul_def', ring_hom.to_fun_eq_coe, map_mul,
+      mul_assoc],
+  end,
+  commutes' := λ r a b, begin
+    simp only [ring_hom.coe_mk, add_monoid_hom.coe_mk],
+    rw [algebra.smul_def', algebra.smul_def', algebra.commutes', ← mul_assoc],
+  end,
+  smul_def' := λ r a, by simp only [add_monoid_hom.coe_mk, ring_hom.coe_mk],
+}
+
+
 end prio
 
 /-- Embedding `R →+* A` given by `algebra` structure. -/

--- a/src/algebra/algebra/basic.lean
+++ b/src/algebra/algebra/basic.lean
@@ -145,41 +145,30 @@ def to_algebra (R : Type u) (A : Type v) [comm_semiring R] [semiring A]
       rw [non_unital_non_assoc_algebra.smul_def', non_unital_non_assoc_algebra.commutes', one_mul],
     end, }
 
-/-- A (unital associative) algebra is also a non-unital non-associative algebra -/
-def to_non_unital_non_assoc_algebra (R : Type u) (A : Type v) [comm_semiring R] [semiring A]
-  [algebra R A]  : non_unital_non_assoc_algebra R A :=
-{ to_fun := λ r,
-  { to_fun := λ a, r • a,
-    map_zero' := by rw [algebra.smul_def', mul_zero],
-    map_add' := λ a b, by rw [algebra.smul_def', algebra.smul_def', algebra.smul_def',
-      left_distrib], },
-  map_zero' := begin
-    ext,
-    simp only [add_monoid_hom.coe_mk, add_monoid_hom.zero_apply],
-    rw [algebra.smul_def', ring_hom.to_fun_eq_coe, map_zero, zero_mul],
-  end,
-  map_add' := λ r₁ r₂, begin
-    ext,
-    simp only [add_monoid_hom.coe_mk, add_monoid_hom.add_apply],
-    rw [algebra.smul_def', ring_hom.to_fun_eq_coe, map_add, right_distrib, algebra.smul_def',
-      algebra.smul_def', ring_hom.to_fun_eq_coe],
-  end,
-  map_one' := begin
-    ext,
-    simp only [add_monoid_hom.coe_mk, add_monoid.coe_one, id.def],
-    rw [algebra.smul_def', ring_hom.to_fun_eq_coe, map_one, one_mul],
-  end,
-  map_mul' := λ r₁ r₂, begin
-    ext,
-    simp only [add_monoid_hom.coe_mk, add_monoid.coe_mul, function.comp_app],
-    rw [algebra.smul_def', algebra.smul_def', algebra.smul_def', ring_hom.to_fun_eq_coe, map_mul,
-      mul_assoc],
-  end,
-  commutes' := λ r a b, begin
-    simp only [ring_hom.coe_mk, add_monoid_hom.coe_mk],
-    rw [algebra.smul_def', algebra.smul_def', algebra.commutes', ← mul_assoc],
-  end,
-  smul_def' := λ r a, by simp only [add_monoid_hom.coe_mk, ring_hom.coe_mk], }
+/-
+@[priority 200] -- see Note [lower instance priority]
+instance to_mul_action (R : Type u) (A : Type v) [comm_semiring R] [semiring A]
+  [algebra R A] : mul_action R A := {
+    one_smul := λ a, begin
+
+    end,
+    mul_smul := sorry,
+  }
+
+@[priority 200] -- see Note [lower instance priority]
+instance to_distrib_mul_action (R : Type u) (A : Type v) [comm_semiring R] [semiring A]
+  [algebra R A] : distrib_mul_action R A := {
+    smul_add := sorry,
+    smul_zero := sorry,
+  }
+
+@[priority 200] -- see Note [lower instance priority]
+instance to_module (R : Type u) (A : Type v) [comm_semiring R] [semiring A]
+  [algebra R A] : module R A := {
+    add_smul := sorry,
+    zero_smul := sorry,
+  }
+-/
 
 end prio
 
@@ -279,6 +268,19 @@ instance to_module : module R A :=
   smul_zero := by simp [smul_def''],
   add_smul := by simp [smul_def'', add_mul],
   zero_smul := by simp [smul_def''] }
+
+/-- A (unital associative) algebra is also a non-unital non-associative algebra -/
+def to_non_unital_non_assoc_algebra (R : Type u) (A : Type v) [comm_semiring R] [semiring A]
+  [algebra R A]  : non_unital_non_assoc_algebra R A :=
+{
+  commutes' := λ r a b, begin
+    simp only [ring_hom.to_fun_eq_coe, ring_hom.mk_coe, module.to_add_monoid_End_apply_apply],
+    rw [algebra.smul_def', algebra.smul_def', algebra.commutes', mul_assoc],
+  end,
+  smul_def' := λ r a, by simp only [ring_hom.to_fun_eq_coe, ring_hom.mk_coe,
+    module.to_add_monoid_End_apply_apply],
+  ..module.to_add_monoid_End R A
+   }
 
 -- From now on, we don't want to use the following instance anymore.
 -- Unfortunately, leaving it in place causes deterministic timeouts later in mathlib.

--- a/src/algebra/algebra/basic.lean
+++ b/src/algebra/algebra/basic.lean
@@ -116,16 +116,20 @@ class algebra (R : Type u) (A : Type v) [comm_semiring R] [semiring A]
 (commutes' : ∀ r x, to_fun r * x = x * to_fun r)
 (smul_def' : ∀ r x, r • x = to_fun r * x)
 
-class non_unital_non_assoc_algebra (R : Type u) (A : Type v) [comm_semiring R] [non_unital_non_assoc_semiring A]
-  extends has_scalar R A, R →+* (add_monoid.End A) :=
+/--
+A (non-unital, non-associative) `R`-algebra is a non-unital, non-associative, semiring `A` equipped
+with a map into its centroid `R → Z(A)`.
+-/
+class non_unital_non_assoc_algebra (R : Type u) (A : Type v) [comm_semiring R]
+  [non_unital_non_assoc_semiring A] extends has_scalar R A, R →+* (add_monoid.End A) :=
 (commutes' : ∀ r a b, (to_ring_hom r a) * b = a * (to_ring_hom r b))
 (smul_def' : ∀ r a, r • a = to_ring_hom r  a)
 
-/- If R is a commutative semiring and A is a semiring and R →+* (add_monoid.End A) is a
-(non-unital, non-associative) algebra then  r → r•1 is a (unital, associative) algebra-/
-lemma to_algebra (R : Type u) (A : Type v) [comm_semiring R] [semiring A]
-  [non_unital_non_assoc_algebra R A] : algebra R A:= {
-    to_fun := λ r, _inst_3.to_fun r 1,
+/-- If R is a commutative semiring, A is a semiring and R →+* (add_monoid.End A) is a
+(non-unital, non-associative) algebra then  r → r•1 is a (unital, associative) algebra -/
+def to_algebra (R : Type u) (A : Type v) [comm_semiring R] [semiring A]
+  [non_unital_non_assoc_algebra R A] : algebra R A:=
+  { to_fun := λ r, _inst_3.to_fun r 1,
     map_one' := by rw [ring_hom.to_fun_eq_coe, map_one, add_monoid.coe_one, id.def],
     map_mul' := λ r₁ r₂, by rw [ring_hom.to_fun_eq_coe, map_mul, add_monoid.coe_mul,
       function.comp_app, non_unital_non_assoc_algebra.commutes', one_mul],
@@ -139,17 +143,16 @@ lemma to_algebra (R : Type u) (A : Type v) [comm_semiring R] [semiring A]
     smul_def' := λ r a, begin
       simp only [ring_hom.to_fun_eq_coe],
       rw [non_unital_non_assoc_algebra.smul_def', non_unital_non_assoc_algebra.commutes', one_mul],
-    end,
-  }
+    end, }
 
-/- A (unital associative) algebra is also a non-unital non-associative algebra -/
-lemma to_non_unital_non_assoc_algebra (R : Type u) (A : Type v) [comm_semiring R] [semiring A]
-  [algebra R A]  : non_unital_non_assoc_algebra R A := {
-  to_fun := λ r, {
-    to_fun := λ a, r • a,
+/-- A (unital associative) algebra is also a non-unital non-associative algebra -/
+def to_non_unital_non_assoc_algebra (R : Type u) (A : Type v) [comm_semiring R] [semiring A]
+  [algebra R A]  : non_unital_non_assoc_algebra R A :=
+{ to_fun := λ r,
+  { to_fun := λ a, r • a,
     map_zero' := by rw [algebra.smul_def', mul_zero],
-    map_add' := λ a b, by rw [algebra.smul_def', algebra.smul_def', algebra.smul_def', left_distrib],
-  }, -- for each r we have an element of add_monoid.End A
+    map_add' := λ a b, by rw [algebra.smul_def', algebra.smul_def', algebra.smul_def',
+      left_distrib], },
   map_zero' := begin
     ext,
     simp only [add_monoid_hom.coe_mk, add_monoid_hom.zero_apply],
@@ -176,9 +179,7 @@ lemma to_non_unital_non_assoc_algebra (R : Type u) (A : Type v) [comm_semiring R
     simp only [ring_hom.coe_mk, add_monoid_hom.coe_mk],
     rw [algebra.smul_def', algebra.smul_def', algebra.commutes', ← mul_assoc],
   end,
-  smul_def' := λ r a, by simp only [add_monoid_hom.coe_mk, ring_hom.coe_mk],
-}
-
+  smul_def' := λ r a, by simp only [add_monoid_hom.coe_mk, ring_hom.coe_mk], }
 
 end prio
 

--- a/src/algebra/algebra/basic.lean
+++ b/src/algebra/algebra/basic.lean
@@ -145,31 +145,6 @@ def to_algebra (R : Type u) (A : Type v) [comm_semiring R] [semiring A]
       rw [non_unital_non_assoc_algebra.smul_def', non_unital_non_assoc_algebra.commutes', one_mul],
     end, }
 
-/-
-@[priority 200] -- see Note [lower instance priority]
-instance to_mul_action (R : Type u) (A : Type v) [comm_semiring R] [semiring A]
-  [algebra R A] : mul_action R A := {
-    one_smul := λ a, begin
-
-    end,
-    mul_smul := sorry,
-  }
-
-@[priority 200] -- see Note [lower instance priority]
-instance to_distrib_mul_action (R : Type u) (A : Type v) [comm_semiring R] [semiring A]
-  [algebra R A] : distrib_mul_action R A := {
-    smul_add := sorry,
-    smul_zero := sorry,
-  }
-
-@[priority 200] -- see Note [lower instance priority]
-instance to_module (R : Type u) (A : Type v) [comm_semiring R] [semiring A]
-  [algebra R A] : module R A := {
-    add_smul := sorry,
-    zero_smul := sorry,
-  }
--/
-
 end prio
 
 /-- Embedding `R →+* A` given by `algebra` structure. -/

--- a/src/algebra/algebra/basic.lean
+++ b/src/algebra/algebra/basic.lean
@@ -247,15 +247,13 @@ instance to_module : module R A :=
 /-- A (unital associative) algebra is also a non-unital non-associative algebra -/
 def to_non_unital_non_assoc_algebra (R : Type u) (A : Type v) [comm_semiring R] [semiring A]
   [algebra R A]  : non_unital_non_assoc_algebra R A :=
-{
-  commutes' := λ r a b, begin
+{ commutes' := λ r a b, begin
     simp only [ring_hom.to_fun_eq_coe, ring_hom.mk_coe, module.to_add_monoid_End_apply_apply],
     rw [algebra.smul_def', algebra.smul_def', algebra.commutes', mul_assoc],
   end,
   smul_def' := λ r a, by simp only [ring_hom.to_fun_eq_coe, ring_hom.mk_coe,
     module.to_add_monoid_End_apply_apply],
-  ..module.to_add_monoid_End R A
-   }
+  ..module.to_add_monoid_End R A }
 
 -- From now on, we don't want to use the following instance anymore.
 -- Unfortunately, leaving it in place causes deterministic timeouts later in mathlib.


### PR DESCRIPTION
Given a commutative semi-ring `R`, mathlib defines an `R`-algebra as a semiring `A` equipped with a map into its center `R → A`. This definition is restrictive as it forces the algebra to be unital and associative.

In the PR we start the work of introducing a more flexible notion of an algebra to mathlib, in the spirit of the original definition. We define a (non-unital, non-associative)  `R`-algebra via a map into the centroid of `A`. We show that when `A` is associative and unital, `A` is also an `R`-algebra in the original sense. We also show that every (unital, associative) `R`-algebra can be considered as a non-unital, non-associative algebra.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
