### PR TITLE
feat(topology/vector_bundle): direct sum of topological vector bundles

### DIFF
--- a/src/topology/constructions.lean
+++ b/src/topology/constructions.lean
@@ -536,6 +536,9 @@ lemma dense_range.prod_map {ι : Type*} {κ : Type*} {f : ι → β} {g : κ →
   (hf : dense_range f) (hg : dense_range g) : dense_range (prod.map f g) :=
 by simpa only [dense_range, prod_range_range_eq] using hf.prod hg
 
+lemma inducing_prod_mk (c : α) : inducing (prod.mk c : β → α × β) :=
+inducing_of_inducing_compose (continuous.prod.mk c) continuous_snd inducing_id
+
 lemma inducing.prod_mk {f : α → β} {g : γ → δ} (hf : inducing f) (hg : inducing g) :
   inducing (λx:α×γ, (f x.1, g x.2)) :=
 ⟨by rw [prod.topological_space, prod.topological_space, hf.induced, hg.induced,

--- a/src/topology/continuous_on.lean
+++ b/src/topology/continuous_on.lean
@@ -888,6 +888,11 @@ lemma continuous_on.prod {f : α → β} {g : α → γ} {s : set α}
   (hf : continuous_on f s) (hg : continuous_on g s) : continuous_on (λx, (f x, g x)) s :=
 λx hx, continuous_within_at.prod (hf x hx) (hg x hx)
 
+lemma continuous_on.prod' {f : α → β × γ} {s : set α}
+  (hf : continuous_on (prod.fst ∘ f) s) (hg : continuous_on (prod.snd ∘ f) s) :
+  continuous_on f s :=
+by simpa using hf.prod hg
+
 lemma inducing.continuous_within_at_iff {f : α → β} {g : β → γ} (hg : inducing g) {s : set α}
   {x : α} : continuous_within_at f s x ↔ continuous_within_at (g ∘ f) s x :=
 by simp_rw [continuous_within_at, inducing.tendsto_nhds_iff hg]

--- a/src/topology/fiber_bundle.lean
+++ b/src/topology/fiber_bundle.lean
@@ -1204,20 +1204,6 @@ lemma is_topological_fiber_bundle :
 lemma continuous_proj : @continuous _ _ a.total_space_topology _ proj :=
 by { letI := a.total_space_topology, exact a.is_topological_fiber_bundle.continuous_proj, }
 
--- lemma continuous_at_of_comp_dom {X : Type*} [topological_space X] {f : Z → X} {z : Z}
---   (hf : continuous_at (f ∘ (a.pretrivialization_at (proj z)).to_local_equiv.symm)
---     ((a.pretrivialization_at (proj z)) z)) :
---   @continuous_at _ _ a.total_space_topology _ f z :=
--- begin
---   letI := a.total_space_topology,
---   let e : trivialization F proj := a.trivialization_at (proj z),
---   have hez : z ∈ e.to_local_equiv.symm.target,
---   { rw [local_equiv.symm_target, e.source_eq],
---     exact a.mem_base_pretrivialization_at (proj z) },
---   rwa [e.to_local_homeomorph.symm.continuous_at_iff_continuous_at_comp_right hez,
---    local_homeomorph.symm_symm]
--- end
-
 /-- For a fiber bundle `Z` over `B` constructed using the `topological_fiber_prebundle` mechanism,
 continuity of a function `Z → X` on an open set `s` can be checked by precomposing at each point
 with the pretrivialization used for the construction at that point. -/
@@ -1240,37 +1226,5 @@ begin
   { rw e.mem_source,
     exact a.mem_base_pretrivialization_at (proj z) },
 end
-
--- lemma continuous_at_of_comp_rng {X : Type*} [topological_space X] {f : X → Z} {x : X}
---   -- (hf_proj : continuous_at (proj ∘ f) x)
---   (hf : continuous_at ((a.pretrivialization_at (proj (f x))) ∘ f) x) :
---   @continuous_at _ _ _ a.total_space_topology f x :=
--- begin
---   letI := a.total_space_topology,
---   let e : trivialization F proj := a.trivialization_at (proj (f x)),
---   rw e.to_local_homeomorph.continuous_at_iff_continuous_at_comp_left,
---   { exact hf },
---   have hf_proj : continuous_at (proj ∘ f) x,
---   { refine (continuous_fst.continuous_at.comp hf).congr _,
---     sorry,
---     -- ext x',
---     -- simp,
---     -- convert (e.coe_fst _).symm,
---     -- exact a.mem_base_pretrivialization_at (proj (f x)),
---   },
---   rw [e.source_eq, ← preimage_comp],
---   apply hf_proj.preimage_mem_nhds,
---   exact e.open_base_set.mem_nhds (a.mem_base_pretrivialization_at (proj (f x))),
--- end
-
-/-- For a fiber bundle `Z` over `B` constructed using the `topological_fiber_prebundle` mechanism,
-continuity of a function `f : X → Z` on an open set `s` can be checked by postcomposing at each
-point `f x : Z` with the pretrivialization used for the construction at that point. -/
-lemma continuous_at_of_comp_rng {X : Type*} [topological_space X] {f : X → Z}  {s : set B}
-  (hs : is_open s)
-  -- (hf_proj : continuous_at (proj ∘ f) x)
-  (hf : ∀ b, continuous_on ((a.pretrivialization_at b)) ∘ f) ((proj ∘ f) ⁻¹' s)) :
-  @continuous_on _ _ _ a.total_space_topology f x :=
-
 
 end topological_fiber_prebundle

--- a/src/topology/fiber_bundle.lean
+++ b/src/topology/fiber_bundle.lean
@@ -217,6 +217,9 @@ lemma apply_symm_apply' {b : B} {x : F} (hx : b ∈ e.base_set) :
   e (e.to_local_equiv.symm (b, x)) = (b, x) :=
 e.apply_symm_apply (e.mem_target.2 hx)
 
+lemma symm_apply_apply {x : Z} (hx : x ∈ e.source) : e.to_local_equiv.symm (e x) = x :=
+e.to_local_equiv.left_inv hx
+
 @[simp, mfld_simps] lemma symm_apply_mk_proj {x : Z} (ex : x ∈ e.source) :
   e.to_local_equiv.symm (proj x, (e x).2) = x :=
 by rw [← e.coe_fst ex, prod.mk.eta, ← e.coe_coe, e.to_local_equiv.left_inv ex]

--- a/src/topology/vector_bundle.lean
+++ b/src/topology/vector_bundle.lean
@@ -99,15 +99,6 @@ variables {R F E}
 def trivialization.to_pretrivialization (e : trivialization R F E) :
   topological_vector_bundle.pretrivialization R F E := { ..e }
 
--- lemma trivialization.to_pretrivialization_injective {e₁ e₂ : trivialization R F E}
---   (h : e₁.to_pretrivialization = e₂.to_pretrivialization) :
---   e₁ = e₂ :=
--- begin
---   rcases e₁ with ⟨⟨⟨e₁_pre_pre, _⟩, s₁, _⟩, _⟩,
---   rcases e₂ with ⟨⟨⟨e₂_pre_pre, _⟩, s₂, _⟩, _⟩,
---   simpa [trivialization.to_pretrivialization] using h,
--- end
-
 lemma trivialization.mem_source (e : trivialization R F E)
   {x : total_space E} : x ∈ e.source ↔ proj E x ∈ e.base_set :=
 topological_fiber_bundle.trivialization.mem_source e

--- a/src/topology/vector_bundle.lean
+++ b/src/topology/vector_bundle.lean
@@ -35,20 +35,20 @@ that the `topological_vector_bundle` class is `Prop`-valued.
 
 The point of this formalism is that it is unbundled in the sense that the total space of the bundle
 is a type with a topology, with which one can work or put further structure, and still one can
-perform operations on topological vector bundles (which are yet to be formalized). For instance,
-assume that `E₁ : B → Type*` and `E₂ : B → Type*` define two topological vector bundles over `R`
-with fiber models `F₁` and `F₂` which are normed spaces. Then one can construct the vector bundle of
+perform operations on topological vector bundles.  For instance, assume that `E₁ : B → Type*` and
+`E₂ : B → Type*` define two topological vector bundles over `R` with fiber models `F₁` and `F₂`
+which are normed spaces. Then we construct the vector bundle of direct sums, with fiber
+`E x := (E₁ x × E₂ x)`. We let `vector_bundle_prod R F₁ E₁ F₂ E₂ (x : B)` be a type
+synonym for `E₁ x × E₂ x`. Then one can endow `bundle.total_space (vector_prod R F₁ E₁ F₂ E₂)`
+with a topology `vector_bundle_prod.topological_space`, and a topological vector bundle structure,
+`vector_bundle_prod.topological_vector_bundle`.
+
+A similar construction (which is yet to be formalized) can be done for the vector bundle of
 continuous linear maps from `E₁ x` to `E₂ x` with fiber `E x := (E₁ x →L[R] E₂ x)` (and with the
 topology inherited from the norm-topology on `F₁ →L[R] F₂`, without the need to define the strong
-topology on continuous linear maps between general topological vector spaces). Let
-`vector_bundle_continuous_linear_map R F₁ E₁ F₂ E₂ (x : B)` be a type synonym for `E₁ x →L[R] E₂ x`.
-Then one can endow
-`bundle.total_space (vector_bundle_continuous_linear_map R F₁ E₁ F₂ E₂)`
-with a topology and a topological vector bundle structure.
-
-Similar constructions can be done for tensor products of topological vector bundles, exterior
-algebras, and so on, where the topology can be defined using a norm on the fiber model if this
-helps.
+topology on continuous linear maps between general topological vector spaces).  Likewise for tensor
+products of topological vector bundles, exterior algebras, and so on, where the topology can be
+defined using a norm on the fiber model if this helps.
 
 ## Tags
 Vector bundle
@@ -550,24 +550,33 @@ end
 
 namespace topological_vector_bundle
 
-variables (F₁ : Type*) (E₁ : B → Type*)
-  [∀ x, add_comm_monoid (E₁ x)] [∀ x, module R (E₁ x)]
-  [topological_space F₁] [add_comm_monoid F₁] [module R F₁]
-  [topological_space (total_space E₁)] [Π x : B, topological_space (E₁ x)]
-  [topological_vector_bundle R F₁ E₁]
+/-- The direct sum of the topological vector bundles `E₁` and `E₂`.  Type synonym for
+`λ x, E₁ x × E₂ x`. -/
+@[derive [topological_space, add_comm_monoid, module R], nolint unused_arguments]
+def vector_bundle_prod {B : Type*}
+  (F₁ : Type*) (E₁ : B → Type*) [Π x, add_comm_monoid (E₁ x)] [Π x, module R (E₁ x)]
+  [Π x : B, topological_space (E₁ x)]
+  (F₂ : Type*) (E₂ : B → Type*) [Π x, add_comm_monoid (E₂ x)] [∀ x, module R (E₂ x)]
+  [Π x : B, topological_space (E₂ x)]
+  (x : B) :=
+E₁ x × E₂ x
 
-variables (F₂ : Type*) (E₂ : B → Type*)
-  [∀ x, add_comm_monoid (E₂ x)] [∀ x, module R (E₂ x)]
-  [topological_space F₂] [add_comm_monoid F₂] [module R F₂]
-  [topological_space (total_space E₂)] [Π x : B, topological_space (E₂ x)]
-  [topological_vector_bundle R F₂ E₂]
+instance {B : Type*}
+  (F₁ : Type*) (E₁ : B → Type*) [Π x, add_comm_monoid (E₁ x)] [Π x, module R (E₁ x)]
+  [Π x : B, topological_space (E₁ x)]
+  (F₂ : Type*) (E₂ : B → Type*) [Π x, add_comm_monoid (E₂ x)] [∀ x, module R (E₂ x)]
+  [Π x : B, topological_space (E₂ x)]
+  (x : B) :
+  inhabited (vector_bundle_prod R F₁ E₁ F₂ E₂ x) :=
+⟨0⟩
 
--- move this
-lemma continuous_on.prod' {α : Type*} {β : Type*} {γ : Type*} [topological_space α]
-  [topological_space β] [topological_space γ] {f : α → β × γ} {s : set α}
-  (hf : continuous_on (prod.fst ∘ f) s) (hg : continuous_on (prod.snd ∘ f) s) :
-  continuous_on f s :=
-by simpa using hf.prod hg
+variables (F₁ : Type*) [topological_space F₁] [add_comm_monoid F₁] [module R F₁]
+  (E₁ : B → Type*) [Π x, add_comm_monoid (E₁ x)] [Π x, module R (E₁ x)]
+  [Π x : B, topological_space (E₁ x)] [topological_space (total_space E₁)]
+
+variables (F₂ : Type*) [topological_space F₂] [add_comm_monoid F₂] [module R F₂]
+  (E₂ : B → Type*) [Π x, add_comm_monoid (E₂ x)] [Π x, module R (E₂ x)]
+  [Π x : B, topological_space (E₂ x)] [topological_space (total_space E₂)]
 
 namespace pretrivialization
 variables (e₁ : trivialization R F₁ E₁) (e₂ : trivialization R F₂ E₂)
@@ -577,13 +586,15 @@ variables {R F₁ E₁ F₂ E₂}
 /-- Given trivializations `e₁`, `e₂` for vector bundles `E₁`, `E₂` over a base `B`, the forward
 function for the construction `topological_vector_bundle.pretrivialization.prod`, the induced
 pretrivialization for the direct sum of `E₁` and `E₂`. -/
-def prod.to_fun' : total_space (λ x, E₁ x × E₂ x) → B × (F₁ × F₂) :=
+def prod.to_fun' : total_space (vector_bundle_prod R F₁ E₁ F₂ E₂) → B × (F₁ × F₂) :=
 λ ⟨x, v₁, v₂⟩, ⟨x, (e₁ ⟨x, v₁⟩).2, (e₂ ⟨x, v₂⟩).2⟩
+
+variables [topological_vector_bundle R F₁ E₁] [topological_vector_bundle R F₂ E₂]
 
 /-- Given trivializations `e₁`, `e₂` for vector bundles `E₁`, `E₂` over a base `B`, the inverse
 function for the construction `topological_vector_bundle.pretrivialization.prod`, the induced
 pretrivialization for the direct sum of `E₁` and `E₂`. -/
-def prod.inv_fun' (p : B × (F₁ × F₂)) : total_space (λ x, E₁ x × E₂ x) :=
+def prod.inv_fun' (p : B × (F₁ × F₂)) : total_space (vector_bundle_prod R F₁ E₁ F₂ E₂) :=
 begin
   obtain ⟨x, w₁, w₂⟩ := p,
   refine ⟨x, _, _⟩,
@@ -599,7 +610,7 @@ end
 pretrivialization for the direct sum of `E₁` and `E₂`.  That is, the map which will later become
 a trivialization, after this direct sum is equipped with the right topological vector bundle
 structure. -/
-def prod : pretrivialization R (F₁ × F₂) (λ x, E₁ x × E₂ x) :=
+def prod : pretrivialization R (F₁ × F₂) (vector_bundle_prod R F₁ E₁ F₂ E₂) :=
 { to_fun := prod.to_fun' e₁ e₂,
   inv_fun := prod.inv_fun' e₁ e₂,
   source := (proj (λ x, E₁ x × E₂ x)) ⁻¹' (e₁.base_set.inter e₂.base_set),
@@ -714,17 +725,13 @@ end pretrivialization
 
 open pretrivialization
 
--- move this
-lemma inducing_prod_mk {X Y : Type*} [topological_space X] [topological_space Y] (c : X) :
-  inducing (prod.mk c : Y → X × Y) :=
-begin
-  refine inducing_of_inducing_compose (continuous.prod.mk c) continuous_snd _,
-  exact inducing_id,
-end
+variables [topological_vector_bundle R F₁ E₁] [topological_vector_bundle R F₂ E₂]
 
-/-- Auxiliary construction (`vector_prebundle`) for the direct sum of topological vector bundles. -/
-def _root_.topological_vector_prebundle.prod :
-  topological_vector_prebundle R (F₁ × F₂) (λ x, E₁ x × E₂ x) :=
+/-- The direct sum of topological vector bundles is a `topological_vector_prebundle` (this is an
+auxiliary construction for the `topological_vector_prebundle` instance, in which the
+pretrivializations are collated but no topology on the total space is yet provided). -/
+def _root_.vector_bundle_prod.topological_vector_prebundle :
+  topological_vector_prebundle R (F₁ × F₂) (vector_bundle_prod R F₁ E₁ F₂ E₂) :=
 { pretrivialization_at := λ x,
     pretrivialization.prod (trivialization_at R F₁ E₁ x) (trivialization_at R F₂ E₂ x),
   mem_base_pretrivialization_at := λ x,
@@ -751,33 +758,22 @@ def _root_.topological_vector_prebundle.prod :
   end }
 
 /-- The natural topology on the total space of the product of two vector bundles. -/
-instance prod.topological_space :
-  topological_space (total_space (λ (x : B), E₁ x × E₂ x)) :=
-(topological_vector_prebundle.prod R F₁ E₁ F₂ E₂).total_space_topology
+instance : topological_space (total_space (vector_bundle_prod R F₁ E₁ F₂ E₂)) :=
+(vector_bundle_prod.topological_vector_prebundle R F₁ E₁ F₂ E₂).total_space_topology
 
 /-- The product of two vector bundles is a vector bundle. -/
-instance prod.topological_vector_bundle :
-  topological_vector_bundle R (F₁ × F₂) (λ x, E₁ x × E₂ x) :=
-(topological_vector_prebundle.prod R F₁ E₁ F₂ E₂).to_topological_vector_bundle
+instance : topological_vector_bundle R (F₁ × F₂) (vector_bundle_prod R F₁ E₁ F₂ E₂) :=
+(vector_bundle_prod.topological_vector_prebundle R F₁ E₁ F₂ E₂).to_topological_vector_bundle
 
 variables {R F₁ E₁ F₂ E₂}
-
-lemma pretrivialization.is_open_source_prod
-  (e₁ : trivialization R F₁ E₁) (e₂ : trivialization R F₂ E₂) :
-  is_open (prod e₁ e₂).source :=
-(open_base_set_prod e₁ e₂).preimage (topological_vector_bundle.continuous_proj R B (F₁ × F₂))
-
-lemma pretrivialization.is_open_target_prod
-  (e₁ : trivialization R F₁ E₁) (e₂ : trivialization R F₂ E₂) :
-  is_open (prod e₁ e₂).target :=
-(open_base_set_prod e₁ e₂).prod is_open_univ
 
 /-- Given trivializations `e₁`, `e₂` for vector bundles `E₁`, `E₂` over a base `B`, the induced
 trivialization for the direct sum of `E₁` and `E₂`, whose base set is `e₁.base_set ∩ e₂.base_set`.
 -/
 def trivialization.prod (e₁ : trivialization R F₁ E₁) (e₂ : trivialization R F₂ E₂) :
-  trivialization R (F₁ × F₂) (λ x, E₁ x × E₂ x) :=
-{ open_source := pretrivialization.is_open_source_prod e₁ e₂,
+  trivialization R (F₁ × F₂) (vector_bundle_prod R F₁ E₁ F₂ E₂) :=
+{ open_source := (open_base_set_prod e₁ e₂).preimage
+    (topological_vector_bundle.continuous_proj R B (F₁ × F₂)),
   continuous_to_fun :=
   begin
     apply topological_fiber_prebundle.continuous_on_of_comp_right,
@@ -788,21 +784,22 @@ def trivialization.prod (e₁ : trivialization R F₁ E₁) (e₂ : trivializati
     rw topological_fiber_bundle.pretrivialization.target_inter_preimage_symm_source_eq,
     refl,
   end,
-  continuous_inv_fun :=
+  continuous_inv_fun := λ x hx, continuous_at.continuous_within_at
   begin
-    intros x hx,
-    apply continuous_at.continuous_within_at,
-    let f := topological_fiber_prebundle.trivialization_at
-      (topological_vector_prebundle.prod R F₁ E₁ F₂ E₂).to_topological_fiber_prebundle x.1,
     let f₁ := trivialization_at R F₁ E₁ x.1,
     let f₂ := trivialization_at R F₂ E₂ x.1,
-    have H : (prod e₁ e₂).to_local_equiv.symm ⁻¹' (prod f₁ f₂).to_local_equiv.source ∈ nhds x,
-    { sorry },
-    rw [f.to_local_homeomorph.continuous_at_iff_continuous_at_comp_left],
-    { refine (continuous_triv_change_prod f₁ e₁ f₂ e₂).continuous_at _,
-      refine filter.inter_mem _ H,
-      exact (pretrivialization.is_open_target_prod e₁ e₂).mem_nhds hx },
-    { exact H },
+    have H :
+      (prod e₁ e₂).target ∩ (prod e₁ e₂).to_local_equiv.symm ⁻¹' (prod f₁ f₂).source ∈ nhds x,
+    { rw topological_fiber_bundle.pretrivialization.target_inter_preimage_symm_source_eq,
+      refine is_open.mem_nhds _ ⟨⟨_, hx.1⟩, mem_univ _⟩,
+      { exact ((open_base_set_prod f₁ f₂).inter (open_base_set_prod e₁ e₂)).prod is_open_univ },
+      { exact ⟨mem_base_set_trivialization_at R F₁ E₁ x.1,
+          mem_base_set_trivialization_at R F₂ E₂ x.1⟩ } },
+    let a := (vector_bundle_prod.topological_vector_prebundle
+      R F₁ E₁ F₂ E₂).to_topological_fiber_prebundle,
+    rw (a.trivialization_at x.1).to_local_homeomorph.continuous_at_iff_continuous_at_comp_left,
+    { exact (continuous_triv_change_prod f₁ e₁ f₂ e₂).continuous_at H },
+    { exact filter.mem_of_superset H (inter_subset_right _ _) },
   end,
   .. pretrivialization.prod e₁ e₂ }
 

--- a/src/topology/vector_bundle.lean
+++ b/src/topology/vector_bundle.lean
@@ -99,6 +99,15 @@ variables {R F E}
 def trivialization.to_pretrivialization (e : trivialization R F E) :
   topological_vector_bundle.pretrivialization R F E := { ..e }
 
+-- lemma trivialization.to_pretrivialization_injective {e₁ e₂ : trivialization R F E}
+--   (h : e₁.to_pretrivialization = e₂.to_pretrivialization) :
+--   e₁ = e₂ :=
+-- begin
+--   rcases e₁ with ⟨⟨⟨e₁_pre_pre, _⟩, s₁, _⟩, _⟩,
+--   rcases e₂ with ⟨⟨⟨e₂_pre_pre, _⟩, s₂, _⟩, _⟩,
+--   simpa [trivialization.to_pretrivialization] using h,
+-- end
+
 lemma trivialization.mem_source (e : trivialization R F E)
   {x : total_space E} : x ∈ e.source ↔ proj E x ∈ e.base_set :=
 topological_fiber_bundle.trivialization.mem_source e
@@ -765,19 +774,11 @@ rfl
   (e₁.prod e₂).continuous_linear_equiv_at x ⟨hx₁, hx₂⟩
   = (e₁.continuous_linear_equiv_at x hx₁).prod (e₂.continuous_linear_equiv_at x hx₂) :=
 begin
-  sorry
+  ext1,
+  funext v,
+  obtain ⟨v₁, v₂⟩ := v,
+  rw [(e₁.prod e₂).continuous_linear_equiv_at_apply, trivialization.prod],
+  exact congr_arg prod.snd (prod_apply hx₁ hx₂ v₁ v₂),
 end
-
-@[simp] lemma trivialization_at_prod (x : B) :
-  trivialization_at R (F₁ × F₂) (λ x, E₁ x × E₂ x) x
-  = (trivialization_at R F₁ E₁ x).prod (trivialization_at R F₂ E₂ x) :=
-begin
-  sorry
-end
-
--- lemma trivialization.prod_apply (e₁ : trivialization R F₁ E₁) (e₂ : trivialization R F₂ E₂)
---   {p : total_space (λ (x : B), E₁ x × E₂ x)} (hp₁ : p.1 ∈ e₁.base_set) (hp₂ : p.1 ∈ e₂.base_set) :
---   (λ q : B × (F₁ × F₂), (q.1, q.2.1)) (e₁.prod e₂ p) = e₁ ⟨p.1, p.2.1⟩ :=
--- sorry
 
 end topological_vector_bundle

--- a/src/topology/vector_bundle.lean
+++ b/src/topology/vector_bundle.lean
@@ -211,10 +211,29 @@ def continuous_linear_equiv_at (e : trivialization R F E) (b : B)
   (x : total_space E) (hx : x ∈ e.source) :
   e.continuous_linear_equiv_at (proj E x) (e.mem_source.1 hx) x.2 = (e x).2 := by { cases x, refl }
 
+lemma apply_eq_prod_continuous_linear_equiv_at (e : trivialization R F E) (b : B)
+  (hb : b ∈ e.base_set) (z : E b) :
+  e.to_local_homeomorph ⟨b, z⟩ = ⟨b, e.continuous_linear_equiv_at b hb z⟩ :=
+begin
+  ext,
+  { convert e.coe_fst _,
+    rw e.source_eq,
+    exact hb },
+  { simp }
+end
+
 lemma symm_apply_eq_prod_continuous_linear_equiv_at_symm (e : trivialization R F E) (b : B)
   (hb : b ∈ e.base_set) (z : F) :
   e.to_local_homeomorph.symm ⟨b, z⟩ = ⟨b, (e.continuous_linear_equiv_at b hb).symm z⟩ :=
-sorry
+begin
+  have h : (b, z) ∈ e.to_local_homeomorph.target,
+  { rw e.target_eq,
+    exact ⟨hb, mem_univ _⟩ },
+  apply e.to_local_homeomorph.inj_on (e.to_local_homeomorph.map_target h),
+  { simp [e.source_eq, hb] },
+  simp [-continuous_linear_equiv_at_apply, e.apply_eq_prod_continuous_linear_equiv_at b hb,
+    e.to_local_homeomorph.right_inv h],
+end
 
 end trivialization
 
@@ -606,14 +625,12 @@ def prod : pretrivialization R (F₁ × F₂) (λ x, E₁ x × E₂ x) :=
   (prod e₁ e₂).base_set = e₁.base_set ∩ e₂.base_set :=
 rfl
 
-lemma prod_apply {e₁ : trivialization R F₁ E₁}
+@[simp] lemma prod_apply {e₁ : trivialization R F₁ E₁}
   {e₂ : trivialization R F₂ E₂} {x : B} (hx₁ : x ∈ e₁.base_set) (hx₂ : x ∈ e₂.base_set)
   (v₁ : E₁ x) (v₂ : E₂ x) :
   prod e₁ e₂ ⟨x, (v₁, v₂)⟩
   = ⟨x, e₁.continuous_linear_equiv_at x hx₁ v₁, e₂.continuous_linear_equiv_at x hx₂ v₂⟩ :=
-begin
-  sorry
-end
+rfl
 
 lemma prod_symm_apply {e₁ : trivialization R F₁ E₁}
   {e₂ : trivialization R F₂ E₂} {x : B} (hx₁ : x ∈ e₁.base_set) (hx₂ : x ∈ e₂.base_set)
@@ -622,7 +639,8 @@ lemma prod_symm_apply {e₁ : trivialization R F₁ E₁}
   = ⟨x, ((e₁.continuous_linear_equiv_at x hx₁).symm w₁,
       (e₂.continuous_linear_equiv_at x hx₂).symm w₂)⟩ :=
 begin
-  sorry
+  dsimp [prod, prod.inv_fun'],
+  rw [dif_pos, dif_pos]
 end
 
 lemma continuous_triv_change_prod
@@ -638,10 +656,8 @@ begin
   rw [(prod e₁ e₂).source_eq, (prod f₁ f₂).target_eq, inter_comm,
     topological_fiber_bundle.pretrivialization.preimage_symm_proj_inter,
     pretrivialization.base_set_prod, pretrivialization.base_set_prod],
-  let ψ₁ : local_homeomorph (B × F₁) (B × F₁) :=
-    f₁.to_local_homeomorph.symm.trans e₁.to_local_homeomorph,
-  let ψ₂ : local_homeomorph (B × F₂) (B × F₂) :=
-    f₂.to_local_homeomorph.symm.trans e₂.to_local_homeomorph,
+  let ψ₁ := f₁.to_local_homeomorph.symm.trans e₁.to_local_homeomorph,
+  let ψ₂ := f₂.to_local_homeomorph.symm.trans e₂.to_local_homeomorph,
   have hψ₁ : ψ₁.source = (e₁.base_set ∩ f₁.base_set) ×ˢ (univ : set F₁),
   { dsimp [ψ₁],
     rw [e₁.source_eq, f₁.target_eq, inter_comm],

--- a/src/topology/vector_bundle.lean
+++ b/src/topology/vector_bundle.lean
@@ -697,6 +697,14 @@ end pretrivialization
 
 open pretrivialization
 
+-- move this
+lemma inducing_prod_mk {X Y : Type*} [topological_space X] [topological_space Y] (c : X) :
+  inducing (prod.mk c : Y → X × Y) :=
+begin
+  refine inducing_of_inducing_compose (continuous.prod.mk c) continuous_snd _,
+  exact inducing_id,
+end
+
 /-- Auxiliary construction (`vector_prebundle`) for the direct sum of topological vector bundles. -/
 def _root_.topological_vector_prebundle.prod :
   topological_vector_prebundle R (F₁ × F₂) (λ x, E₁ x × E₂ x) :=
@@ -709,7 +717,21 @@ def _root_.topological_vector_prebundle.prod :
     (trivialization_at R F₁ E₁ q)
     (trivialization_at R F₂ E₂ p)
     (trivialization_at R F₂ E₂ q),
-  total_space_mk_inducing := _ }
+  total_space_mk_inducing := λ b,
+  begin
+    let e₁ := trivialization_at R F₁ E₁ b,
+    let e₂ := trivialization_at R F₂ E₂ b,
+    have hb₁ : b ∈ e₁.base_set := mem_base_set_trivialization_at R F₁ E₁ b,
+    have hb₂ : b ∈ e₂.base_set := mem_base_set_trivialization_at R F₂ E₂ b,
+    have key : inducing (λ w : E₁ b × E₂ b,
+      (b, e₁.continuous_linear_equiv_at b hb₁ w.1, e₂.continuous_linear_equiv_at b hb₂ w.2)),
+    { refine (inducing_prod_mk b).comp _,
+      exact ((e₁.continuous_linear_equiv_at b hb₁).to_homeomorph.inducing.prod_mk
+        (e₂.continuous_linear_equiv_at b hb₂).to_homeomorph.inducing) },
+    { convert key,
+      ext1 w,
+      simpa using prod_apply hb₁ hb₂ w.1 w.2 },
+  end }
 
 /-- The natural topology on the total space of the product of two vector bundles. -/
 instance prod.topological_space :


### PR DESCRIPTION
Define the direct sum of `R`-vector bundles `E₁`, modelled on fibre `F₁`, and `E₂`, which is modelled on `F₂`.  I define a type synonym `vector_bundle_prod R F₁ E₁ F₂ E₂` for `λ x, E₁ x × E₂ x`, which is necessary because the construction has a spurious dependence on `R`, `F₁`, `F₂`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
