### PR TITLE
[Merged by Bors] - fix(tactic/interactive): use non-interactive admit tactic

### DIFF
--- a/src/tactic/interactive.lean
+++ b/src/tactic/interactive.lean
@@ -28,7 +28,7 @@ meta def try_for (max : parse parser.pexpr) (tac : itactic) : tactic unit :=
 do max ← i_to_expr_strict max >>= tactic.eval_expr nat,
   λ s, match _root_.try_for max (tac s) with
   | some r := r
-  | none   := (tactic.trace "try_for timeout, using sorry" >> admit) s
+  | none   := (tactic.trace "try_for timeout, using sorry" >> tactic.admit) s
   end
 
 /-- Multiple `subst`. `substs x y z` is the same as `subst x, subst y, subst z`. -/


### PR DESCRIPTION
In a future release of Lean 3, the interactive admit tactic will take an additional argument.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
