### PR TITLE
[Merged by Bors] - feat(category_theory): cases in which (co)equalizers are split monos (epis)

### DIFF
--- a/src/category_theory/limits/shapes/equalizers.lean
+++ b/src/category_theory/limits/shapes/equalizers.lean
@@ -903,6 +903,13 @@ def split_mono_of_equalizer {X Y : C} {f : X ⟶ Y} {r : Y ⟶ X} (hr : f ≫ r 
   id' := fork.is_limit.hom_ext h
     ((category.assoc _ _ _).trans $ hr.trans (category.id_comp _).symm) }
 
+/-- The equalizer of an idempotent morphism and the identity is split mono. -/
+def split_mono_of_idempotent_equalizer {X : C} {f : X ⟶ X} (hf : f ≫ f = f)
+  [has_equalizer f (𝟙 X)] : split_mono (equalizer.ι f (𝟙 X)) :=
+{ retraction := equalizer.lift f (by simp [hf]),
+  id' := by { rw [← cancel_mono_id (equalizer.ι f (𝟙 X)), category.assoc, 
+    equalizer.lift_ι, equalizer.condition, category.comp_id] } }
+
 section
 -- In this section we show that a split epi `f` coequalizes `(f ≫ section_ f)` and `(𝟙 X)`.
 variables {C} [split_epi f]
@@ -935,5 +942,12 @@ def split_epi_of_coequalizer {X Y : C} {f : X ⟶ Y} {s : Y ⟶ X} (hs : f ≫ s
   split_epi f :=
 { section_ := s,
   id' := cofork.is_colimit.hom_ext h (hs.trans (category.comp_id _).symm) }
+
+/-- The coequalizer of an idempotent morphism and the identity is split epi. -/
+def split_epi_of_idempotent_coequalizer {X : C} {f : X ⟶ X} (hf : f ≫ f = f)
+  [has_coequalizer f (𝟙 X)] : split_epi (coequalizer.π f (𝟙 X)) :=
+{ section_ := coequalizer.desc f (by simp [hf]),
+  id' := by { rw [← cancel_epi_id (coequalizer.π f (𝟙 X)), 
+    ←category.assoc, coequalizer.π_desc, coequalizer.condition, category.id_comp] } }
 
 end category_theory.limits

--- a/src/category_theory/limits/shapes/equalizers.lean
+++ b/src/category_theory/limits/shapes/equalizers.lean
@@ -292,6 +292,14 @@ lemma cofork.is_colimit.hom_ext {s : cofork f g} (hs : is_colimit s) {W : C} {k 
   (h : cofork.π s ≫ k = cofork.π s ≫ l) : k = l :=
 hs.hom_ext $ cofork.coequalizer_ext _ h
 
+lemma fork.is_limit.lift_of_ι_ι {s : fork f g} (hs : is_limit s) {W : C} {k : W ⟶ X}
+  (hk : k ≫ f = k ≫ g) : hs.lift (fork.of_ι k hk) ≫ s.ι = k :=
+hs.fac _ _
+
+lemma cofork.is_colimit.π_desc_of_π {s : cofork f g} (hs : is_colimit s) {W : C} {k : Y ⟶ W}
+  (hk : f ≫ k = g ≫ k) : s.π ≫ hs.desc (cofork.of_π k hk) = k :=
+hs.fac _ _
+
 /-- If `s` is a limit fork over `f` and `g`, then a morphism `k : W ⟶ X` satisfying
     `k ≫ f = k ≫ g` induces a morphism `l : W ⟶ s.X` such that `l ≫ fork.ι s = k`. -/
 def fork.is_limit.lift' {s : fork f g} (hs : is_limit s) {W : C} (k : W ⟶ X) (h : k ≫ f = k ≫ g) :
@@ -903,12 +911,21 @@ def split_mono_of_equalizer {X Y : C} {f : X ⟶ Y} {r : Y ⟶ X} (hr : f ≫ r 
   id' := fork.is_limit.hom_ext h
     ((category.assoc _ _ _).trans $ hr.trans (category.id_comp _).symm) }
 
+/-- An equalizer of an idempotent morphism and the identity is split mono. -/
+def split_mono_of_is_limit_fork_of_idempotent {X : C} {f : X ⟶ X} (hf : f ≫ f = f)
+  {c : fork f (𝟙 X)} (i : is_limit c) : split_mono c.ι :=
+{ retraction := i.lift (fork.of_ι f (by simp [hf])),
+  id' :=
+  begin
+    letI := mono_of_is_limit_parallel_pair i,
+    rw [← cancel_mono_id c.ι, category.assoc, fork.is_limit.lift_of_ι, c.condition],
+    exact category.comp_id c.ι
+  end }
+
 /-- The equalizer of an idempotent morphism and the identity is split mono. -/
 def split_mono_of_idempotent_equalizer {X : C} {f : X ⟶ X} (hf : f ≫ f = f)
   [has_equalizer f (𝟙 X)] : split_mono (equalizer.ι f (𝟙 X)) :=
-{ retraction := equalizer.lift f (by simp [hf]),
-  id' := by { rw [← cancel_mono_id (equalizer.ι f (𝟙 X)), category.assoc, 
-    equalizer.lift_ι, equalizer.condition, category.comp_id] } }
+split_mono_of_is_limit_fork_of_idempotent _ hf (limit.is_limit _)
 
 section
 -- In this section we show that a split epi `f` coequalizes `(f ≫ section_ f)` and `(𝟙 X)`.
@@ -943,11 +960,20 @@ def split_epi_of_coequalizer {X Y : C} {f : X ⟶ Y} {s : Y ⟶ X} (hs : f ≫ s
 { section_ := s,
   id' := cofork.is_colimit.hom_ext h (hs.trans (category.comp_id _).symm) }
 
+/-- A coequalizer of an idempotent morphism and the identity is split epi. -/
+def split_epi_of_is_colimit_cofork_of_idempotent {X : C} {f : X ⟶ X} (hf : f ≫ f = f)
+  {c : cofork f (𝟙 X)} (i : is_colimit c) : split_epi c.π :=
+{ section_ := i.desc (cofork.of_π f (by simp [hf])),
+  id' :=
+  begin
+    letI := epi_of_is_colimit_parallel_pair i,
+    rw [← cancel_epi_id c.π, ← category.assoc, cofork.is_colimit.π_desc_of_π, c.condition],
+    exact category.id_comp _,
+  end }
+
 /-- The coequalizer of an idempotent morphism and the identity is split epi. -/
 def split_epi_of_idempotent_coequalizer {X : C} {f : X ⟶ X} (hf : f ≫ f = f)
   [has_coequalizer f (𝟙 X)] : split_epi (coequalizer.π f (𝟙 X)) :=
-{ section_ := coequalizer.desc f (by simp [hf]),
-  id' := by { rw [← cancel_epi_id (coequalizer.π f (𝟙 X)), 
-    ←category.assoc, coequalizer.π_desc, coequalizer.condition, category.id_comp] } }
+split_epi_of_is_colimit_cofork_of_idempotent _ hf (colimit.is_colimit _)
 
 end category_theory.limits

--- a/src/category_theory/limits/shapes/equalizers.lean
+++ b/src/category_theory/limits/shapes/equalizers.lean
@@ -292,12 +292,12 @@ lemma cofork.is_colimit.hom_ext {s : cofork f g} (hs : is_colimit s) {W : C} {k 
   (h : cofork.π s ≫ k = cofork.π s ≫ l) : k = l :=
 hs.hom_ext $ cofork.coequalizer_ext _ h
 
-lemma fork.is_limit.lift_of_ι_ι {s : fork f g} (hs : is_limit s) {W : C} {k : W ⟶ X}
-  (hk : k ≫ f = k ≫ g) : hs.lift (fork.of_ι k hk) ≫ s.ι = k :=
+@[simp] lemma fork.is_limit.lift_of_ι_ι {s : fork f g} (hs : is_limit s) {W : C}
+  {k : W ⟶ X} (hk : k ≫ f = k ≫ g) : hs.lift (fork.of_ι k hk) ≫ s.ι = k :=
 hs.fac _ _
 
-lemma cofork.is_colimit.π_desc_of_π {s : cofork f g} (hs : is_colimit s) {W : C} {k : Y ⟶ W}
-  (hk : f ≫ k = g ≫ k) : s.π ≫ hs.desc (cofork.of_π k hk) = k :=
+@[simp] lemma cofork.is_colimit.π_desc_of_π {s : cofork f g} (hs : is_colimit s) {W : C}
+  {k : Y ⟶ W} (hk : f ≫ k = g ≫ k) : s.π ≫ hs.desc (cofork.of_π k hk) = k :=
 hs.fac _ _
 
 /-- If `s` is a limit fork over `f` and `g`, then a morphism `k : W ⟶ X` satisfying
@@ -912,7 +912,7 @@ def split_mono_of_equalizer {X Y : C} {f : X ⟶ Y} {r : Y ⟶ X} (hr : f ≫ r 
     ((category.assoc _ _ _).trans $ hr.trans (category.id_comp _).symm) }
 
 /-- An equalizer of an idempotent morphism and the identity is split mono. -/
-def split_mono_of_is_limit_fork_of_idempotent {X : C} {f : X ⟶ X} (hf : f ≫ f = f)
+def split_mono_of_idempotent_of_is_limit_fork {X : C} {f : X ⟶ X} (hf : f ≫ f = f)
   {c : fork f (𝟙 X)} (i : is_limit c) : split_mono c.ι :=
 { retraction := i.lift (fork.of_ι f (by simp [hf])),
   id' :=
@@ -925,7 +925,7 @@ def split_mono_of_is_limit_fork_of_idempotent {X : C} {f : X ⟶ X} (hf : f ≫ 
 /-- The equalizer of an idempotent morphism and the identity is split mono. -/
 def split_mono_of_idempotent_equalizer {X : C} {f : X ⟶ X} (hf : f ≫ f = f)
   [has_equalizer f (𝟙 X)] : split_mono (equalizer.ι f (𝟙 X)) :=
-split_mono_of_is_limit_fork_of_idempotent _ hf (limit.is_limit _)
+split_mono_of_idempotent_of_is_limit_fork _ hf (limit.is_limit _)
 
 section
 -- In this section we show that a split epi `f` coequalizes `(f ≫ section_ f)` and `(𝟙 X)`.
@@ -961,7 +961,7 @@ def split_epi_of_coequalizer {X Y : C} {f : X ⟶ Y} {s : Y ⟶ X} (hs : f ≫ s
   id' := cofork.is_colimit.hom_ext h (hs.trans (category.comp_id _).symm) }
 
 /-- A coequalizer of an idempotent morphism and the identity is split epi. -/
-def split_epi_of_is_colimit_cofork_of_idempotent {X : C} {f : X ⟶ X} (hf : f ≫ f = f)
+def split_epi_of_idempotent_of_is_colimit_cofork {X : C} {f : X ⟶ X} (hf : f ≫ f = f)
   {c : cofork f (𝟙 X)} (i : is_colimit c) : split_epi c.π :=
 { section_ := i.desc (cofork.of_π f (by simp [hf])),
   id' :=
@@ -974,6 +974,6 @@ def split_epi_of_is_colimit_cofork_of_idempotent {X : C} {f : X ⟶ X} (hf : f �
 /-- The coequalizer of an idempotent morphism and the identity is split epi. -/
 def split_epi_of_idempotent_coequalizer {X : C} {f : X ⟶ X} (hf : f ≫ f = f)
   [has_coequalizer f (𝟙 X)] : split_epi (coequalizer.π f (𝟙 X)) :=
-split_epi_of_is_colimit_cofork_of_idempotent _ hf (colimit.is_colimit _)
+split_epi_of_idempotent_of_is_colimit_cofork _ hf (colimit.is_colimit _)
 
 end category_theory.limits

--- a/src/category_theory/limits/shapes/equalizers.lean
+++ b/src/category_theory/limits/shapes/equalizers.lean
@@ -918,7 +918,7 @@ def split_mono_of_is_limit_fork_of_idempotent {X : C} {f : X ⟶ X} (hf : f ≫ 
   id' :=
   begin
     letI := mono_of_is_limit_parallel_pair i,
-    rw [← cancel_mono_id c.ι, category.assoc, fork.is_limit.lift_of_ι, c.condition],
+    rw [← cancel_mono_id c.ι, category.assoc, fork.is_limit.lift_of_ι_ι, c.condition],
     exact category.comp_id c.ι
   end }
 

--- a/src/category_theory/limits/shapes/equalizers.lean
+++ b/src/category_theory/limits/shapes/equalizers.lean
@@ -895,12 +895,13 @@ fork.is_limit.mk' _ $ λ s,
 end
 
 /-- We show that the converse to `split_mono_equalizes` is true:
-Whenever `f` equalizes `(r ≫ f)` and `(𝟙 Y)`, `r` is the retraction of `f`. -/
-def split_mono_of_equalizer {X Y : C} (f : X ⟶ Y) (r : Y ⟶ X) (hr : f ≫ r ≫ f = f)
-  (h : is_limit (fork.of_ι f (eq.trans hr (eq.symm (category.comp_id _)) : f ≫ r ≫ f = f ≫ 𝟙 Y))) :
+Whenever `f` equalizes `(r ≫ f)` and `(𝟙 Y)`, then `r` is a retraction of `f`. -/
+def split_mono_of_equalizer {X Y : C} {f : X ⟶ Y} {r : Y ⟶ X} (hr : f ≫ r ≫ f = f)
+  (h : is_limit (fork.of_ι f (hr.trans (category.comp_id _).symm : f ≫ r ≫ f = f ≫ 𝟙 Y))) :
   split_mono f :=
 { retraction := r,
-  id' := fork.is_limit.hom_ext h (by { rw [category.assoc, category.id_comp], exact hr }) }
+  id' := fork.is_limit.hom_ext h
+    ((category.assoc _ _ _).trans $ hr.trans (category.id_comp _).symm) }
 
 section
 -- In this section we show that a split epi `f` coequalizes `(f ≫ section_ f)` and `(𝟙 X)`.
@@ -925,5 +926,14 @@ cofork.is_colimit.mk' _ $ λ s,
  λ m hm, by simp [← hm]⟩
 
 end
+
+/-- We show that the converse to `split_epi_equalizes` is true:
+Whenever `f` coequalizes `(f ≫ s)` and `(𝟙 X)`, then `s` is a section of `f`. -/
+def split_epi_of_coequalizer {X Y : C} {f : X ⟶ Y} {s : Y ⟶ X} (hs : f ≫ s ≫ f = f)
+  (h : is_colimit (cofork.of_π f ((category.assoc _ _ _).trans $
+    hs.trans (category.id_comp f).symm : (f ≫ s) ≫ f = 𝟙 X ≫ f))) :
+  split_epi f :=
+{ section_ := s,
+  id' := cofork.is_colimit.hom_ext h (hs.trans (category.comp_id _).symm) }
 
 end category_theory.limits

--- a/src/category_theory/limits/shapes/equalizers.lean
+++ b/src/category_theory/limits/shapes/equalizers.lean
@@ -883,7 +883,6 @@ Here we build the cone, and show in `split_mono_equalizes` that it is a limit co
 def cone_of_split_mono : cone (parallel_pair (𝟙 Y) (retraction f ≫ f)) :=
 fork.of_ι f (by simp)
 
-
 /--
 A split mono `f` equalizes `(retraction f ≫ f)` and `(𝟙 Y)`.
 -/
@@ -894,6 +893,14 @@ fork.is_limit.mk' _ $ λ s,
  λ m hm, by simp [←hm]⟩
 
 end
+
+/-- We show that the converse to `split_mono_equalizes` is true:
+Whenever `f` equalizes `(r ≫ f)` and `(𝟙 Y)`, `r` is the retraction of `f`. -/
+def split_mono_of_equalizer {X Y : C} (f : X ⟶ Y) (r : Y ⟶ X) (hr : f ≫ r ≫ f = f)
+  (h : is_limit (fork.of_ι f (eq.trans hr (eq.symm (category.comp_id _)) : f ≫ r ≫ f = f ≫ 𝟙 Y))) :
+  split_mono f :=
+{ retraction := r,
+  id' := fork.is_limit.hom_ext h (by { rw [category.assoc, category.id_comp], exact hr }) }
 
 section
 -- In this section we show that a split epi `f` coequalizes `(f ≫ section_ f)` and `(𝟙 X)`.


### PR DESCRIPTION

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
