### PR TITLE
[Merged by Bors] - chore(*): move `has_scalar` instances before `add_comm_monoid` instances

### DIFF
--- a/src/linear_algebra/multilinear/basic.lean
+++ b/src/linear_algebra/multilinear/basic.lean
@@ -151,6 +151,21 @@ instance : inhabited (multilinear_map R M₁ M₂) := ⟨0⟩
 
 @[simp] lemma zero_apply (m : Πi, M₁ i) : (0 : multilinear_map R M₁ M₂) m = 0 := rfl
 
+section has_scalar
+variables {R' A : Type*} [monoid R'] [semiring A]
+  [Π i, module A (M₁ i)] [distrib_mul_action R' M₂] [module A M₂] [smul_comm_class A R' M₂]
+
+instance : has_scalar R' (multilinear_map A M₁ M₂) := ⟨λ c f,
+  ⟨λ m, c • f m, λm i x y, by simp [smul_add], λl i x d, by simp [←smul_comm x c] ⟩⟩
+
+@[simp] lemma smul_apply (f : multilinear_map A M₁ M₂) (c : R') (m : Πi, M₁ i) :
+  (c • f) m = c • f m := rfl
+
+lemma coe_smul (c : R') (f : multilinear_map A M₁ M₂) : ⇑(c • f) = c • f :=
+rfl
+
+end has_scalar
+
 instance : add_comm_monoid (multilinear_map R M₁ M₂) :=
 { zero := (0 : multilinear_map R M₁ M₂),
   add := (+),
@@ -668,18 +683,8 @@ begin
 end
 
 section distrib_mul_action
-
 variables {R' A : Type*} [monoid R'] [semiring A]
   [Π i, module A (M₁ i)] [distrib_mul_action R' M₂] [module A M₂] [smul_comm_class A R' M₂]
-
-instance : has_scalar R' (multilinear_map A M₁ M₂) := ⟨λ c f,
-  ⟨λ m, c • f m, λm i x y, by simp [smul_add], λl i x d, by simp [←smul_comm x c] ⟩⟩
-
-@[simp] lemma smul_apply (f : multilinear_map A M₁ M₂) (c : R') (m : Πi, M₁ i) :
-  (c • f) m = c • f m := rfl
-
-lemma coe_smul (c : R') (f : multilinear_map A M₁ M₂) : ⇑(c • f) = c • f :=
-rfl
 
 instance : distrib_mul_action R' (multilinear_map A M₁ M₂) :=
 { one_smul := λ f, ext $ λ x, one_smul _ _,

--- a/src/measure_theory/measure/vector_measure.lean
+++ b/src/measure_theory/measure/vector_measure.lean
@@ -243,6 +243,28 @@ end
 
 end
 
+section has_scalar
+variables {M : Type*} [add_comm_monoid M] [topological_space M]
+variables {R : Type*} [semiring R] [distrib_mul_action R M] [has_continuous_const_smul R M]
+
+include m
+
+/-- Given a real number `r` and a signed measure `s`, `smul r s` is the signed
+measure corresponding to the function `r • s`. -/
+def smul (r : R) (v : vector_measure α M) : vector_measure α M :=
+{ measure_of' := r • v,
+  empty' := by rw [pi.smul_apply, empty, smul_zero],
+  not_measurable' := λ _ hi, by rw [pi.smul_apply, v.not_measurable hi, smul_zero],
+  m_Union' := λ _ hf₁ hf₂, has_sum.const_smul (v.m_Union hf₁ hf₂) }
+
+instance : has_scalar R (vector_measure α M) := ⟨smul⟩
+
+@[simp] lemma coe_smul (r : R) (v : vector_measure α M) : ⇑(r • v) = r • v := rfl
+lemma smul_apply (r : R) (v : vector_measure α M) (i : set α) :
+  (r • v) i = r • v i := rfl
+
+end has_scalar
+
 section add_comm_monoid
 
 variables {M : Type*} [add_comm_monoid M] [topological_space M]
@@ -322,25 +344,10 @@ function.injective.add_comm_group _ coe_injective coe_zero coe_add coe_neg coe_s
 end add_comm_group
 
 section distrib_mul_action
-
 variables {M : Type*} [add_comm_monoid M] [topological_space M]
 variables {R : Type*} [semiring R] [distrib_mul_action R M] [has_continuous_const_smul R M]
 
 include m
-
-/-- Given a real number `r` and a signed measure `s`, `smul r s` is the signed
-measure corresponding to the function `r • s`. -/
-def smul (r : R) (v : vector_measure α M) : vector_measure α M :=
-{ measure_of' := r • v,
-  empty' := by rw [pi.smul_apply, empty, smul_zero],
-  not_measurable' := λ _ hi, by rw [pi.smul_apply, v.not_measurable hi, smul_zero],
-  m_Union' := λ _ hf₁ hf₂, has_sum.const_smul (v.m_Union hf₁ hf₂) }
-
-instance : has_scalar R (vector_measure α M) := ⟨smul⟩
-
-@[simp] lemma coe_smul (r : R) (v : vector_measure α M) : ⇑(r • v) = r • v := rfl
-lemma smul_apply (r : R) (v : vector_measure α M) (i : set α) :
-  (r • v) i = r • v i := rfl
 
 instance [has_continuous_add M] : distrib_mul_action R (vector_measure α M) :=
 function.injective.distrib_mul_action coe_fn_add_monoid_hom coe_injective coe_smul

--- a/src/topology/algebra/module/multilinear.lean
+++ b/src/topology/algebra/module/multilinear.lean
@@ -102,6 +102,39 @@ instance : inhabited (continuous_multilinear_map R M₁ M₂) := ⟨0⟩
 @[simp] lemma to_multilinear_map_zero :
   (0 : continuous_multilinear_map R M₁ M₂).to_multilinear_map = 0 :=
 rfl
+section has_scalar
+
+variables {R' R'' A : Type*} [monoid R'] [monoid R''] [semiring A]
+  [Π i, module A (M₁ i)] [module A M₂]
+  [distrib_mul_action R' M₂] [has_continuous_const_smul R' M₂] [smul_comm_class A R' M₂]
+  [distrib_mul_action R'' M₂] [has_continuous_const_smul R'' M₂] [smul_comm_class A R'' M₂]
+
+instance : has_scalar R' (continuous_multilinear_map A M₁ M₂) :=
+⟨λ c f, { cont := f.cont.const_smul c, .. c • f.to_multilinear_map }⟩
+
+@[simp] lemma smul_apply (f : continuous_multilinear_map A M₁ M₂) (c : R') (m : Πi, M₁ i) :
+  (c • f) m = c • f m := rfl
+
+@[simp] lemma to_multilinear_map_smul (c : R') (f : continuous_multilinear_map A M₁ M₂) :
+  (c • f).to_multilinear_map = c • f.to_multilinear_map :=
+rfl
+
+instance [smul_comm_class R' R'' M₂] :
+  smul_comm_class R' R'' (continuous_multilinear_map A M₁ M₂) :=
+⟨λ c₁ c₂ f, ext $ λ x, smul_comm _ _ _⟩
+
+instance [has_scalar R' R''] [is_scalar_tower R' R'' M₂] :
+  is_scalar_tower R' R'' (continuous_multilinear_map A M₁ M₂) :=
+⟨λ c₁ c₂ f, ext $ λ x, smul_assoc _ _ _⟩
+
+instance [distrib_mul_action R'ᵐᵒᵖ M₂] [is_central_scalar R' M₂] :
+  is_central_scalar R' (continuous_multilinear_map A M₁ M₂) :=
+⟨λ c₁ f, ext $ λ x, op_smul_eq_smul _ _⟩
+
+instance : mul_action R' (continuous_multilinear_map A M₁ M₂) :=
+function.injective.mul_action to_multilinear_map to_multilinear_map_inj (λ _ _, rfl)
+
+end has_scalar
 
 section has_continuous_add
 variable [has_continuous_add M₂]
@@ -331,31 +364,6 @@ variables {R' R'' A : Type*} [monoid R'] [monoid R''] [semiring A]
   [Π i, module A (M₁ i)] [module A M₂]
   [distrib_mul_action R' M₂] [has_continuous_const_smul R' M₂] [smul_comm_class A R' M₂]
   [distrib_mul_action R'' M₂] [has_continuous_const_smul R'' M₂] [smul_comm_class A R'' M₂]
-
-instance : has_scalar R' (continuous_multilinear_map A M₁ M₂) :=
-⟨λ c f, { cont := f.cont.const_smul c, .. c • f.to_multilinear_map }⟩
-
-@[simp] lemma smul_apply (f : continuous_multilinear_map A M₁ M₂) (c : R') (m : Πi, M₁ i) :
-  (c • f) m = c • f m := rfl
-
-@[simp] lemma to_multilinear_map_smul (c : R') (f : continuous_multilinear_map A M₁ M₂) :
-  (c • f).to_multilinear_map = c • f.to_multilinear_map :=
-rfl
-
-instance [smul_comm_class R' R'' M₂] :
-  smul_comm_class R' R'' (continuous_multilinear_map A M₁ M₂) :=
-⟨λ c₁ c₂ f, ext $ λ x, smul_comm _ _ _⟩
-
-instance [has_scalar R' R''] [is_scalar_tower R' R'' M₂] :
-  is_scalar_tower R' R'' (continuous_multilinear_map A M₁ M₂) :=
-⟨λ c₁ c₂ f, ext $ λ x, smul_assoc _ _ _⟩
-
-instance [distrib_mul_action R'ᵐᵒᵖ M₂] [is_central_scalar R' M₂] :
-  is_central_scalar R' (continuous_multilinear_map A M₁ M₂) :=
-⟨λ c₁ f, ext $ λ x, op_smul_eq_smul _ _⟩
-
-instance : mul_action R' (continuous_multilinear_map A M₁ M₂) :=
-function.injective.mul_action to_multilinear_map to_multilinear_map_inj (λ _ _, rfl)
 
 instance [has_continuous_add M₂] : distrib_mul_action R' (continuous_multilinear_map A M₁ M₂) :=
 function.injective.distrib_mul_action


### PR DESCRIPTION
This makes it easier for us to set `nsmul` and `zsmul` in future.



---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
