### PR TITLE
[Merged by Bors] - feat(data/finset/noncomm_prod): add noncomm_prod_mul_distrib

### DIFF
--- a/src/data/finset/noncomm_prod.lean
+++ b/src/data/finset/noncomm_prod.lean
@@ -274,22 +274,29 @@ begin
         list.nodup_append_of_nodup sl' tl' h]
 end
 
+@[protected, to_additive]
+lemma noncomm_prod_mul_distrib_aux {s : finset α} {f : α → β} {g : α → β}
+  (comm_ff : ∀ (x ∈ s) (y ∈ s), commute (f x) (f y))
+  (comm_gg : ∀ (x ∈ s) (y ∈ s), commute (g x) (g y))
+  (comm_gf : ∀ (x ∈ s) (y ∈ s), x ≠ y → commute (g x) (f y)) :
+  (∀ (x ∈ s) (y ∈ s), commute ((f * g) x) ((f * g) y)) :=
+begin
+  intros x hx y hy,
+  by_cases h : x = y, { subst h },
+  apply commute.mul_left; apply commute.mul_right,
+  { exact comm_ff x hx y hy },
+  { exact (comm_gf y hy x hx (ne.symm h)).symm },
+  { exact comm_gf x hx y hy h },
+  { exact comm_gg x hx y hy },
+end
+
 /-- The non-commutative version of `finset.prod_mul_distrib` -/
 @[to_additive "The non-commutative version of `finset.sum_add_distrib`"]
 lemma noncomm_prod_mul_distrib {s : finset α} (f : α → β) (g : α → β)
   (comm_ff : ∀ (x ∈ s) (y ∈ s), commute (f x) (f y))
   (comm_gg : ∀ (x ∈ s) (y ∈ s), commute (g x) (g y))
   (comm_gf : ∀ (x ∈ s) (y ∈ s), x ≠ y → commute (g x) (f y)) :
-  noncomm_prod s (f * g)
-    begin
-      intros x hx y hy,
-      by_cases h : x = y, { subst h },
-      apply commute.mul_left; apply commute.mul_right,
-      { exact comm_ff x hx y hy },
-      { exact (comm_gf y hy x hx (ne.symm h)).symm },
-      { exact comm_gf x hx y hy h },
-      { exact comm_gg x hx y hy },
-    end
+  noncomm_prod s (f * g) (noncomm_prod_mul_distrib_aux comm_ff comm_gg comm_gf)
     = noncomm_prod s f comm_ff * noncomm_prod s g comm_gg :=
 begin
   classical,

--- a/src/data/finset/noncomm_prod.lean
+++ b/src/data/finset/noncomm_prod.lean
@@ -170,6 +170,16 @@ begin
   simp
 end
 
+@[to_additive]
+lemma noncomm_prod_commute (s : multiset α)
+  (comm : ∀ (x : α), x ∈ s → ∀ (y : α), y ∈ s → commute x y)
+  (y : α) (h : ∀ (x : α), x ∈ s → commute y x) : commute y (s.noncomm_prod comm) :=
+begin
+  induction s using quotient.induction_on,
+  simp only [quot_mk_to_coe, noncomm_prod_coe],
+  exact list.prod_commute _ _ h,
+end
+
 end multiset
 
 namespace finset
@@ -216,6 +226,18 @@ by simp [noncomm_prod, insert_val_of_not_mem ha, multiset.noncomm_prod_cons']
   noncomm_prod ({a} : finset α) f
     (λ x hx y hy, by rw [mem_singleton.mp hx, mem_singleton.mp hy]) = f a :=
 by simp [noncomm_prod, multiset.singleton_eq_cons]
+
+@[to_additive]
+lemma noncomm_prod_commute (s : finset α) (f : α → β)
+  (comm : ∀ (x : α), x ∈ s → ∀ (y : α), y ∈ s → commute (f x) (f y))
+  (y : β) (h : ∀ (x : α), x ∈ s → commute y (f x)) : commute y (s.noncomm_prod f comm) :=
+begin
+  apply multiset.noncomm_prod_commute,
+  intro y,
+  rw multiset.mem_map,
+  rintros ⟨x, ⟨hx, rfl⟩⟩,
+  exact h x hx,
+end
 
 @[to_additive] lemma noncomm_prod_eq_prod {β : Type*} [comm_monoid β] (s : finset α) (f : α → β) :
   noncomm_prod s f (λ _ _ _ _, commute.all _ _) = s.prod f :=

--- a/src/data/finset/noncomm_prod.lean
+++ b/src/data/finset/noncomm_prod.lean
@@ -276,8 +276,7 @@ end
 
 /- The non-commutative version of `finset.prod_mul_distrib` -/
 @[to_additive "The non-commutative version of `finset.sum_add_distrib`"]
-lemma noncomm_prod_mul_distrib [decidable_eq α] {s : finset α}
-  (f : α → β) (g : α → β)
+lemma noncomm_prod_mul_distrib {s : finset α} (f : α → β) (g : α → β)
   (comm_ff : ∀ (x ∈ s) (y ∈ s), commute (f x) (f y))
   (comm_gg : ∀ (x ∈ s) (y ∈ s), commute (g x) (g y))
   (comm_gf : ∀ (x ∈ s) (y ∈ s), x ≠ y → commute (g x) (f y)) :
@@ -293,14 +292,15 @@ lemma noncomm_prod_mul_distrib [decidable_eq α] {s : finset α}
     end
     = noncomm_prod s f comm_ff * noncomm_prod s g comm_gg :=
 begin
+  classical,
   induction s using finset.induction_on with x s hnmem ih,
   { simp, },
-  { simp only [finset.noncomm_prod_insert_of_not_mem _ _ _ _ hnmem, pi.mul_apply],
+  { simp only [finset.noncomm_prod_insert_of_not_mem _ _ _ _ hnmem],
     specialize ih
       (λ x hx y hy, comm_ff x (mem_insert_of_mem hx) y (mem_insert_of_mem hy))
       (λ x hx y hy, comm_gg x (mem_insert_of_mem hx) y (mem_insert_of_mem hy))
       (λ x hx y hy hne, comm_gf x (mem_insert_of_mem hx) y (mem_insert_of_mem hy) hne),
-    rw ih,
+    rw [ih, pi.mul_apply],
     simp only [mul_assoc],
     congr' 1,
     simp only [← mul_assoc],

--- a/src/data/finset/noncomm_prod.lean
+++ b/src/data/finset/noncomm_prod.lean
@@ -249,7 +249,7 @@ begin
 end
 
 /- The non-commutative version of `finset.prod_union` -/
-@[to_additive /-" The non-commutative version of `finset.sum_union` "-/]
+@[to_additive "The non-commutative version of `finset.sum_union`"]
 lemma noncomm_prod_union_of_disjoint [decidable_eq α] {s t : finset α}
   (h : disjoint s t) (f : α → β)
   (comm : ∀ (x ∈ s ∪ t) (y ∈ s ∪ t), commute (f x) (f y))
@@ -264,6 +264,43 @@ begin
   rw list.disjoint_to_finset_iff_disjoint at h,
   simp [sl', tl', noncomm_prod_to_finset, ←list.prod_append, ←list.to_finset_append,
         list.nodup_append_of_nodup sl' tl' h]
+end
+
+/- The non-commutative version of `finset.prod_mul_distrib` -/
+@[to_additive "The non-commutative version of `finset.sum_add_distrib`"]
+lemma noncomm_prod_mul_distrib [decidable_eq α] {s : finset α}
+  (f : α → β) (g : α → β)
+  (comm_ff : ∀ (x ∈ s) (y ∈ s), commute (f x) (f y))
+  (comm_gg : ∀ (x ∈ s) (y ∈ s), commute (g x) (g y))
+  (comm_gf : ∀ (x ∈ s) (y ∈ s), x ≠ y → commute (g x) (f y)) :
+  noncomm_prod s (f * g)
+    begin
+      intros x hx y hy,
+      by_cases h : x = y, { subst h },
+      apply commute.mul_left; apply commute.mul_right,
+      { exact comm_ff x hx y hy },
+      { exact (comm_gf y hy x hx (ne.symm h)).symm },
+      { exact comm_gf x hx y hy h },
+      { exact comm_gg x hx y hy },
+    end
+    = noncomm_prod s f comm_ff * noncomm_prod s g comm_gg :=
+begin
+  induction s using finset.induction_on with x s hnmem ih,
+  { simp, },
+  { simp only [finset.noncomm_prod_insert_of_not_mem _ _ _ _ hnmem, pi.mul_apply],
+    specialize ih
+      (λ x hx y hy, comm_ff x (mem_insert_of_mem hx) y (mem_insert_of_mem hy))
+      (λ x hx y hy, comm_gg x (mem_insert_of_mem hx) y (mem_insert_of_mem hy))
+      (λ x hx y hy hne, comm_gf x (mem_insert_of_mem hx) y (mem_insert_of_mem hy) hne),
+    rw ih,
+    simp only [mul_assoc],
+    congr' 1,
+    simp only [← mul_assoc],
+    congr' 1,
+    apply noncomm_prod_commute,
+    intros y hy,
+    have : x ≠ y, by {rintro rfl, contradiction},
+    exact comm_gf x (mem_insert_self x s) y (mem_insert_of_mem hy) this, }
 end
 
 end finset

--- a/src/data/finset/noncomm_prod.lean
+++ b/src/data/finset/noncomm_prod.lean
@@ -274,7 +274,7 @@ begin
         list.nodup_append_of_nodup sl' tl' h]
 end
 
-/- The non-commutative version of `finset.prod_mul_distrib` -/
+/-- The non-commutative version of `finset.prod_mul_distrib` -/
 @[to_additive "The non-commutative version of `finset.sum_add_distrib`"]
 lemma noncomm_prod_mul_distrib {s : finset α} (f : α → β) (g : α → β)
   (comm_ff : ∀ (x ∈ s) (y ∈ s), commute (f x) (f y))

--- a/src/data/list/prod_monoid.lean
+++ b/src/data/list/prod_monoid.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Alex J. Best
 -/
 import data.list.big_operators
+import algebra.group.commute
 
 /-!
 # Products / sums of lists of terms of a monoid
@@ -32,9 +33,18 @@ lemma prod_le_of_forall_le [ordered_comm_monoid α] (l : list α) (n : α) (h : 
 begin
   induction l with y l IH,
   { simp },
-  { specialize IH (λ x hx, h x (mem_cons_of_mem _ hx)),
-    have hy : y ≤ n := h y (mem_cons_self _ _),
-    simpa [pow_succ] using mul_le_mul' hy IH }
+  { rw list.ball_cons at h,
+    simpa [pow_succ] using mul_le_mul' h.1 (IH h.2) }
+end
+
+lemma prod_commute [monoid α] (l : list α)
+  (y : α) (h : ∀ (x ∈ l), commute y x) : commute y l.prod :=
+begin
+  induction l with y l IH,
+  { simp },
+  { rw list.ball_cons at h,
+    rw list.prod_cons,
+    exact commute.mul_right h.1 (IH h.2), }
 end
 
 end list

--- a/src/data/list/prod_monoid.lean
+++ b/src/data/list/prod_monoid.lean
@@ -37,6 +37,7 @@ begin
     simpa [pow_succ] using mul_le_mul' h.1 (IH h.2) }
 end
 
+@[to_additive]
 lemma prod_commute [monoid α] (l : list α)
   (y : α) (h : ∀ (x ∈ l), commute y x) : commute y l.prod :=
 begin


### PR DESCRIPTION
The non-commutative version of `finset.sum_union`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
-->

- [x] depends on: #12521

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
