### PR TITLE
[Merged by Bors] - chore(data/polynomial): use dot notation for monic lemmas

### DIFF
--- a/src/data/polynomial/div.lean
+++ b/src/data/polynomial/div.lean
@@ -305,7 +305,7 @@ begin
   nontriviality S,
   haveI : nontrivial R := f.domain_nontrivial,
   have : map f p /ₘ map f q = map f (p /ₘ q) ∧ map f p %ₘ map f q = map f (p %ₘ q),
-  { exact (div_mod_by_monic_unique ((p /ₘ q).map f) _ (monic_map f hq)
+  { exact (div_mod_by_monic_unique ((p /ₘ q).map f) _ (hq.map f)
       ⟨eq.symm $ by rw [← map_mul, ← map_add, mod_by_monic_add_div _ hq],
       calc _ ≤ degree (p %ₘ q) : degree_map_le _ _
       ... < degree q : degree_mod_by_monic_lt _ hq
@@ -346,7 +346,7 @@ end⟩
 theorem map_dvd_map [comm_ring S] (f : R →+* S) (hf : function.injective f) {x y : R[X]}
   (hx : x.monic) : x.map f ∣ y.map f ↔ x ∣ y :=
 begin
-  rw [← dvd_iff_mod_by_monic_eq_zero hx, ← dvd_iff_mod_by_monic_eq_zero (monic_map f hx),
+  rw [← dvd_iff_mod_by_monic_eq_zero hx, ← dvd_iff_mod_by_monic_eq_zero (hx.map f),
     ← map_mod_by_monic f hx],
   exact ⟨λ H, map_injective f hf $ by rw [H, map_zero],
   λ H, by rw [H, map_zero]⟩
@@ -438,7 +438,7 @@ This is computable via the divisibility algorithm `decidable_dvd_monic`. -/
 def root_multiplicity (a : R) (p : R[X]) : ℕ :=
 if h0 : p = 0 then 0
 else let I : decidable_pred (λ n : ℕ, ¬(X - C a) ^ (n + 1) ∣ p) :=
-  λ n, @not.decidable _ (decidable_dvd_monic p (monic_pow (monic_X_sub_C a) (n + 1))) in
+  λ n, @not.decidable _ (decidable_dvd_monic p ((monic_X_sub_C a).pow (n + 1))) in
 by exactI nat.find (multiplicity_X_sub_C_finite a h0)
 
 lemma root_multiplicity_eq_multiplicity (p : R[X]) (a : R) :
@@ -485,7 +485,7 @@ lemma div_by_monic_mul_pow_root_multiplicity_eq
   p /ₘ ((X - C a) ^ root_multiplicity a p) *
   (X - C a) ^ root_multiplicity a p = p :=
 have monic ((X - C a) ^ root_multiplicity a p),
-  from monic_pow (monic_X_sub_C _) _,
+  from (monic_X_sub_C _).pow _,
 by conv_rhs { rw [← mod_by_monic_add_div p this,
     (dvd_iff_mod_by_monic_eq_zero this).2 (pow_root_multiplicity_dvd _ _)] };
   simp [mul_comm]

--- a/src/data/polynomial/lifts.lean
+++ b/src/data/polynomial/lifts.lean
@@ -192,7 +192,6 @@ begin
   by_cases Rtrivial : nontrivial R,
   swap,
   { rw not_nontrivial_iff_subsingleton at Rtrivial,
-    resetI,
     obtain ⟨q, hq⟩ := mem_lifts_and_degree_eq hlifts,
     use q,
     exact ⟨hq.1, hq.2, monic_of_subsingleton _⟩ },

--- a/src/data/polynomial/lifts.lean
+++ b/src/data/polynomial/lifts.lean
@@ -186,37 +186,26 @@ section monic
 
 /-- A monic polynomial lifts if and only if it can be lifted to a monic polynomial
 of the same degree. -/
-lemma lifts_and_degree_eq_and_monic [nontrivial S] {p : S[X]} (hlifts :p ∈ lifts f)
-  (hmonic : p.monic) : ∃ (q : R[X]), map f q = p ∧ q.degree = p.degree ∧ q.monic :=
+lemma lifts_and_degree_eq_and_monic [nontrivial S] {p : S[X]} (hlifts : p ∈ lifts f)
+  (hp : p.monic) : ∃ (q : R[X]), map f q = p ∧ q.degree = p.degree ∧ q.monic :=
 begin
-  by_cases Rtrivial : nontrivial R,
-  swap,
-  { rw not_nontrivial_iff_subsingleton at Rtrivial,
-    obtain ⟨q, hq⟩ := mem_lifts_and_degree_eq hlifts,
-    use q,
-    exactI ⟨hq.1, hq.2, monic_of_subsingleton _⟩ },
-  resetI,
-  by_cases er_zero : p.erase_lead = 0,
-  { rw [← erase_lead_add_C_mul_X_pow p, er_zero, zero_add, monic.def.1 hmonic, C_1, one_mul],
-    use X ^ p.nat_degree,
-    repeat {split},
-    { simp only [polynomial.map_pow, map_X] },
-    { rw [degree_X_pow, degree_X_pow] },
-    { exact monic_X_pow p.nat_degree } },
+  casesI subsingleton_or_nontrivial R with hR hR,
+  { obtain ⟨q, hq⟩ := mem_lifts_and_degree_eq hlifts,
+    exact ⟨q, hq.1, hq.2, monic_of_subsingleton _⟩ },
+  have H : erase p.nat_degree p + X ^ p.nat_degree = p,
+  { simpa only [hp.leading_coeff, C_1, one_mul, erase_lead] using erase_lead_add_C_mul_X_pow p },
+  by_cases h0 : erase p.nat_degree p = 0,
+  { rw [← H, h0, zero_add],
+    refine ⟨X ^ p.nat_degree, _, _, monic_X_pow p.nat_degree⟩,
+    { rw [polynomial.map_pow, map_X] },
+    { rw [degree_X_pow, degree_X_pow] } },
   obtain ⟨q, hq⟩ := mem_lifts_and_degree_eq (erase_mem_lifts p.nat_degree hlifts),
-  have deg_er : p.erase_lead.nat_degree < p.nat_degree :=
-    or.resolve_right (erase_lead_nat_degree_lt_or_erase_lead_eq_zero p) er_zero,
-  replace deg_er := with_bot.coe_lt_coe.2 deg_er,
-  rw [← degree_eq_nat_degree er_zero, erase_lead, ← hq.2,
-    ← @degree_X_pow R _ Rtrivial p.nat_degree] at deg_er,
-  use q + X ^ p.nat_degree,
-  repeat {split},
-  { simp only [hq, map_add, polynomial.map_pow, map_X],
-    nth_rewrite 3 [← erase_lead_add_C_mul_X_pow p],
-    rw [erase_lead, monic.leading_coeff hmonic, C_1, one_mul] },
-  { rw [degree_add_eq_right_of_degree_lt deg_er, @degree_X_pow R _ Rtrivial p.nat_degree,
-    degree_eq_nat_degree (monic.ne_zero hmonic)] },
-  { exact (monic_X_pow _).add_of_right deg_er, },
+  have hdeg : q.degree < (X ^ p.nat_degree).degree,
+  { rw [@degree_X_pow R, hq.2, degree_eq_nat_degree h0, with_bot.coe_lt_coe],
+    exact or.resolve_right (erase_lead_nat_degree_lt_or_erase_lead_eq_zero p) h0, },
+  refine ⟨q + X ^ p.nat_degree, _, _, (monic_X_pow _).add_of_right hdeg⟩,
+  { rw [map_add, hq.1, polynomial.map_pow, map_X, H], },
+  { rw [degree_add_eq_right_of_degree_lt hdeg, degree_X_pow, degree_eq_nat_degree hp.ne_zero] }
 end
 
 end monic

--- a/src/data/polynomial/lifts.lean
+++ b/src/data/polynomial/lifts.lean
@@ -192,16 +192,18 @@ begin
   by_cases Rtrivial : nontrivial R,
   swap,
   { rw not_nontrivial_iff_subsingleton at Rtrivial,
+    resetI,
     obtain ⟨q, hq⟩ := mem_lifts_and_degree_eq hlifts,
     use q,
-    exact ⟨hq.1, hq.2, @monic_of_subsingleton _ _ Rtrivial q⟩ },
+    exact ⟨hq.1, hq.2, monic_of_subsingleton _⟩ },
+  resetI,
   by_cases er_zero : p.erase_lead = 0,
   { rw [← erase_lead_add_C_mul_X_pow p, er_zero, zero_add, monic.def.1 hmonic, C_1, one_mul],
     use X ^ p.nat_degree,
     repeat {split},
     { simp only [polynomial.map_pow, map_X] },
-    { rw [@degree_X_pow R _ Rtrivial, degree_X_pow] },
-    {exact monic_pow monic_X p.nat_degree } },
+    { rw [degree_X_pow, degree_X_pow] },
+    { exact monic_X_pow p.nat_degree } },
   obtain ⟨q, hq⟩ := mem_lifts_and_degree_eq (erase_mem_lifts p.nat_degree hlifts),
   have deg_er : p.erase_lead.nat_degree < p.nat_degree :=
     or.resolve_right (erase_lead_nat_degree_lt_or_erase_lead_eq_zero p) er_zero,
@@ -215,8 +217,7 @@ begin
     rw [erase_lead, monic.leading_coeff hmonic, C_1, one_mul] },
   { rw [degree_add_eq_right_of_degree_lt deg_er, @degree_X_pow R _ Rtrivial p.nat_degree,
     degree_eq_nat_degree (monic.ne_zero hmonic)] },
-  { rw [monic.def, leading_coeff_add_of_degree_lt deg_er],
-    exact monic_pow monic_X p.nat_degree }
+  { exact (monic_X_pow _).add_of_right deg_er, },
 end
 
 end monic

--- a/src/data/polynomial/lifts.lean
+++ b/src/data/polynomial/lifts.lean
@@ -194,7 +194,7 @@ begin
   { rw not_nontrivial_iff_subsingleton at Rtrivial,
     obtain ⟨q, hq⟩ := mem_lifts_and_degree_eq hlifts,
     use q,
-    exact ⟨hq.1, hq.2, monic_of_subsingleton _⟩ },
+    exactI ⟨hq.1, hq.2, monic_of_subsingleton _⟩ },
   resetI,
   by_cases er_zero : p.erase_lead = 0,
   { rw [← erase_lead_add_C_mul_X_pow p, er_zero, zero_add, monic.def.1 hmonic, C_1, one_mul],

--- a/src/data/polynomial/monic.lean
+++ b/src/data/polynomial/monic.lean
@@ -58,13 +58,13 @@ begin
   rwa nat_degree_eq_of_degree_eq (degree_map_eq_of_leading_coeff_ne_zero f _)
 end
 
-lemma monic_C_mul_of_mul_leading_coeff_eq_one [nontrivial R] {b : R}
-  (hp : b * p.leading_coeff = 1) : monic (C b * p) :=
-by rw [monic, leading_coeff_mul' _]; simp [leading_coeff_C b, hp]
+lemma monic_C_mul_of_mul_leading_coeff_eq_one {b : R} (hp : b * p.leading_coeff = 1) :
+  monic (C b * p) :=
+by { nontriviality, rw [monic, leading_coeff_mul' _]; simp [leading_coeff_C b, hp] }
 
-lemma monic_mul_C_of_leading_coeff_mul_eq_one [nontrivial R] {b : R}
-  (hp : p.leading_coeff * b = 1) : monic (p * C b) :=
-by rw [monic, leading_coeff_mul' _]; simp [leading_coeff_C b, hp]
+lemma monic_mul_C_of_leading_coeff_mul_eq_one {b : R} (hp : p.leading_coeff * b = 1) :
+  monic (p * C b) :=
+by { nontriviality, rw [monic, leading_coeff_mul' _]; simp [leading_coeff_C b, hp] }
 
 theorem monic_of_degree_le (n : ℕ) (H1 : degree p ≤ n) (H2 : coeff p n = 1) : monic p :=
 decidable.by_cases
@@ -219,8 +219,7 @@ begin
   refine t.induction_on _ _, { simp },
   intros a t ih ht,
   rw [multiset.map_cons, multiset.prod_cons],
-  exact (ht _ (multiset.mem_cons_self _ _)).mul
-    (ih (λ _ hi, ht _ (multiset.mem_cons_of_mem hi)))
+  exact (ht _ (multiset.mem_cons_self _ _)).mul (ih (λ _ hi, ht _ (multiset.mem_cons_of_mem hi)))
 end
 
 lemma monic_prod_of_monic (s : finset ι) (f : ι → R[X]) (hs : ∀ i ∈ s, monic (f i)) :
@@ -528,7 +527,6 @@ begin
     replace hp := congr_arg (* C ↑(h.unit)⁻¹) hp,
     simp only [zero_mul] at hp,
     rwa [mul_assoc, monic.mul_left_eq_zero_iff] at hp,
-    nontriviality,
     refine monic_mul_C_of_leading_coeff_mul_eq_one _,
     simp [units.mul_inv_eq_iff_eq_mul, is_unit.unit_spec] },
   { rintro rfl,

--- a/src/data/polynomial/monic.lean
+++ b/src/data/polynomial/monic.lean
@@ -11,7 +11,7 @@ import algebra.regular.smul
 # Theory of monic polynomials
 
 We give several tools for proving that polynomials are monic, e.g.
-`monic_mul`, `monic_map`.
+`monic.mul`, `monic.map`, `monic.pow`.
 -/
 
 noncomputable theory
@@ -43,7 +43,7 @@ begin
   exact hp rfl
 end
 
-lemma monic_map [semiring S] (f : R →+* S) (hp : monic p) : monic (p.map f) :=
+lemma monic.map [semiring S] (f : R →+* S) (hp : monic p) : monic (p.map f) :=
 if h : (0 : S) = 1 then
   by haveI := subsingleton_of_zero_eq_one h;
   exact subsingleton.elim _ _
@@ -82,22 +82,22 @@ monic_of_degree_le (n+1)
 theorem monic_X_add_C (x : R) : monic (X + C x) :=
 pow_one (X : R[X]) ▸ monic_X_pow_add degree_C_le
 
-lemma monic_mul (hp : monic p) (hq : monic q) : monic (p * q) :=
+lemma monic.mul (hp : monic p) (hq : monic q) : monic (p * q) :=
 if h0 : (0 : R) = 1 then by haveI := subsingleton_of_zero_eq_one h0;
   exact subsingleton.elim _ _
 else
   have leading_coeff p * leading_coeff q ≠ 0, by simp [monic.def.1 hp, monic.def.1 hq, ne.symm h0],
   by rw [monic.def, leading_coeff_mul' this, monic.def.1 hp, monic.def.1 hq, one_mul]
 
-lemma monic_pow (hp : monic p) : ∀ (n : ℕ), monic (p ^ n)
+lemma monic.pow (hp : monic p) : ∀ (n : ℕ), monic (p ^ n)
 | 0     := monic_one
-| (n+1) := by { rw pow_succ, exact monic_mul hp (monic_pow n) }
+| (n+1) := by { rw pow_succ, exact hp.mul (monic.pow n) }
 
-lemma monic_add_of_left (hp : monic p) (hpq : degree q < degree p) :
+lemma monic.add_of_left (hp : monic p) (hpq : degree q < degree p) :
   monic (p + q) :=
 by rwa [monic, add_comm, leading_coeff_add_of_degree_lt hpq]
 
-lemma monic_add_of_right (hq : monic q) (hpq : degree p < degree q) :
+lemma monic.add_of_right (hq : monic q) (hpq : degree p < degree q) :
   monic (p + q) :=
 by rwa [monic, leading_coeff_add_of_degree_lt hpq]
 
@@ -196,7 +196,7 @@ lemma nat_degree_pow (hp : p.monic) (n : ℕ) :
 begin
   induction n with n hn,
   { simp },
-  { rw [pow_succ, hp.nat_degree_mul (monic_pow hp n), hn],
+  { rw [pow_succ, hp.nat_degree_mul (hp.pow n), hn],
     ring }
 end
 
@@ -219,8 +219,7 @@ begin
   refine t.induction_on _ _, { simp },
   intros a t ih ht,
   rw [multiset.map_cons, multiset.prod_cons],
-  exact monic_mul
-    (ht _ (multiset.mem_cons_self _ _))
+  exact (ht _ (multiset.mem_cons_self _ _)).mul
     (ih (λ _ hi, ht _ (multiset.mem_cons_of_mem hi)))
 end
 
@@ -311,16 +310,16 @@ end
 
 lemma monic_sub_of_left {p q : R[X]} (hp : monic p) (hpq : degree q < degree p) :
   monic (p - q) :=
-by { rw sub_eq_add_neg, apply monic_add_of_left hp, rwa degree_neg }
+by { rw sub_eq_add_neg, apply hp.add_of_left, rwa degree_neg }
 
 lemma monic_sub_of_right {p q : R[X]}
   (hq : q.leading_coeff = -1) (hpq : degree p < degree q) : monic (p - q) :=
 have (-q).coeff (-q).nat_degree = 1 :=
 by rw [nat_degree_neg, coeff_neg, show q.coeff q.nat_degree = -1, from hq, neg_neg],
-by { rw sub_eq_add_neg, apply monic_add_of_right this, rwa degree_neg }
+by { rw sub_eq_add_neg, apply monic.add_of_right this, rwa degree_neg }
 
 @[simp]
-lemma nat_degree_map_of_monic [semiring S] [nontrivial S] {P : polynomial R} (hmo : P.monic)
+lemma monic.nat_degree_map [semiring S] [nontrivial S] {P : polynomial R} (hmo : P.monic)
   (f : R →+* S) : (P.map f).nat_degree = P.nat_degree :=
 begin
   refine le_antisymm (nat_degree_map_le _ _) (le_nat_degree_of_ne_zero _),
@@ -329,7 +328,7 @@ begin
 end
 
 @[simp]
-lemma degree_map_of_monic [semiring S] [nontrivial S] {P : polynomial R} (hmo : P.monic)
+lemma monic.degree_map [semiring S] [nontrivial S] {P : polynomial R} (hmo : P.monic)
   (f : R →+* S) : (P.map f).degree = P.degree :=
 begin
   by_cases hP : P = 0,
@@ -393,9 +392,6 @@ variables [semiring R] [nontrivial R] {p q : R[X]}
 
 @[simp] lemma not_monic_zero : ¬monic (0 : R[X]) :=
 by simpa only [monic, leading_coeff_zero] using (zero_ne_one : (0 : R) ≠ 1)
-
-lemma ne_zero_of_monic (h : monic p) : p ≠ 0 :=
-λ h₁, @not_monic_zero R _ _ (h₁ ▸ h)
 
 end nonzero_semiring
 

--- a/src/data/polynomial/ring_division.lean
+++ b/src/data/polynomial/ring_division.lean
@@ -234,7 +234,7 @@ begin
   induction n with n hn,
   { refine root_multiplicity_eq_zero _,
     simp only [eval_one, is_root.def, not_false_iff, one_ne_zero, pow_zero] },
-  have hzero :=  (ne_zero_of_monic (monic_pow (monic_X_sub_C a) n.succ)),
+  have hzero := pow_ne_zero n.succ (X_sub_C_ne_zero a),
   rw pow_succ (X - C a) n at hzero ⊢,
   simp only [root_multiplicity_mul hzero, root_multiplicity_X_sub_C_self, hn, nat.one_add]
 end

--- a/src/field_theory/minpoly.lean
+++ b/src/field_theory/minpoly.lean
@@ -54,7 +54,7 @@ by { delta minpoly, rw dif_pos hx, exact (well_founded.min_mem degree_lt_wf _ hx
 
 /-- A minimal polynomial is nonzero. -/
 lemma ne_zero [nontrivial A] (hx : is_integral A x) : minpoly A x ≠ 0 :=
-ne_zero_of_monic (monic hx)
+(monic hx).ne_zero
 
 lemma eq_zero (hx : ¬ is_integral A x) : minpoly A x = 0 :=
 dif_neg hx
@@ -396,7 +396,7 @@ begin
       (polynomial.monic.is_primitive (monic hx))).1 (irreducible hx) },
   { have htower := is_scalar_tower.aeval_apply A K R x (minpoly A x),
     rwa [aeval, eq_comm] at htower },
-  { exact monic_map _ (monic hx) }
+  { exact (monic hx).map _ }
 end
 
 /-- For GCD domains, the minimal polynomial divides any primitive polynomial that has the integral

--- a/src/field_theory/splitting_field.lean
+++ b/src/field_theory/splitting_field.lean
@@ -381,7 +381,7 @@ private lemma prod_multiset_X_sub_C_of_monic_of_roots_card_eq_of_field {p : K[X]
 begin
   have hprodmonic : (multiset.map (λ (a : K), X - C a) p.roots).prod.monic,
   { simp only [prod_multiset_root_eq_finset_root,
-      monic_prod_of_monic, monic_X_sub_C, monic_pow, forall_true_iff] },
+      monic_prod_of_monic, monic_X_sub_C, monic.pow, forall_true_iff] },
   have hdegree : (multiset.map (λ (a : K), X - C a) p.roots).prod.nat_degree = p.nat_degree,
   { rw [← hroots, nat_degree_multiset_prod _ (zero_nmem_multiset_map_X_sub_C _ (λ a : K, a))],
     simp only [eq_self_iff_true, mul_one, nat.cast_id, nsmul_eq_mul, multiset.sum_repeat,
@@ -392,7 +392,7 @@ begin
   have degp :
     p.nat_degree = (multiset.map (λ (a : K), X - C a) p.roots).prod.nat_degree + q.nat_degree,
   { nth_rewrite 0 [hq],
-    simp only [nat_degree_mul (ne_zero_of_monic hprodmonic) qzero] },
+    simp only [nat_degree_mul hprodmonic.ne_zero qzero] },
   have degq : q.nat_degree = 0,
   { rw hdegree at degp,
     rw [← add_right_inj p.nat_degree, ← degp, add_zero], },
@@ -414,7 +414,7 @@ begin
     roots_map_of_injective_card_eq_total_degree
       (is_fraction_ring.injective K (fraction_ring K)) hroots,
   rw ← prod_multiset_X_sub_C_of_monic_of_roots_card_eq_of_field
-    (monic_map (algebra_map K (fraction_ring K)) hmonic),
+    (hmonic.map (algebra_map K (fraction_ring K))),
   { simp only [map_C, function.comp_app, map_X, map_sub],
     congr' 1,
     rw ← this,
@@ -496,7 +496,7 @@ lemma aeval_root_derivative_of_splits [algebra K L] {P : K[X]} (hmo : P.monic)
   aeval r P.derivative =
   (multiset.map (λ a, r - a) ((P.map (algebra_map K L)).roots.erase r)).prod :=
 begin
-  replace hmo := monic_map (algebra_map K L) hmo,
+  replace hmo := hmo.map (algebra_map K L),
   replace hP := (splits_id_iff_splits (algebra_map K L)).2 hP,
   rw [aeval_def, ← eval_map, ← derivative_map],
   nth_rewrite 0 [eq_prod_roots_of_monic_of_splits_id hmo hP],

--- a/src/ring_theory/integral_closure.lean
+++ b/src/ring_theory/integral_closure.lean
@@ -123,7 +123,7 @@ theorem is_integral_alg_equiv (f : A ≃ₐ[R] B) {x : A} : is_integral R (f x) 
 theorem is_integral_of_is_scalar_tower [algebra A B] [is_scalar_tower R A B]
   (x : B) (hx : is_integral R x) : is_integral A x :=
 let ⟨p, hp, hpx⟩ := hx in
-⟨p.map $ algebra_map R A, monic_map _ hp,
+⟨p.map $ algebra_map R A, hp.map _,
   by rw [← aeval_def, ← is_scalar_tower.aeval_apply, aeval_def, hpx]⟩
 
 theorem is_integral_of_subring {x : A} (T : subring R)
@@ -708,7 +708,7 @@ begin
   { suffices h : (q.map (algebra_map (adjoin R S) B)).monic,
     { refine monic_of_injective _ h,
       exact subtype.val_injective },
-    { rw hq, exact monic_map _ pmonic } },
+    { rw hq, exact pmonic.map _ } },
   { convert hp using 1,
     replace hq := congr_arg (eval x) hq,
     convert hq using 1; symmetry; apply eval_map },
@@ -778,7 +778,7 @@ is_integral_tower_bot_of_is_integral (algebra_map A B).injective h
 
 lemma ring_hom.is_integral_elem_of_is_integral_elem_comp {x : T}
   (h : (g.comp f).is_integral_elem x) : g.is_integral_elem x :=
-let ⟨p, ⟨hp, hp'⟩⟩ := h in ⟨p.map f, monic_map f hp, by rwa ← eval₂_map at hp'⟩
+let ⟨p, ⟨hp, hp'⟩⟩ := h in ⟨p.map f, hp.map f, by rwa ← eval₂_map at hp'⟩
 
 lemma ring_hom.is_integral_tower_top_of_is_integral (h : (g.comp f).is_integral) : g.is_integral :=
 λ x, ring_hom.is_integral_elem_of_is_integral_elem_comp f g (h x)
@@ -788,7 +788,7 @@ then if the entire tower is an integral extension so is `A → B`. -/
 lemma is_integral_tower_top_of_is_integral {x : B} (h : is_integral R x) : is_integral A x :=
 begin
   rcases h with ⟨p, ⟨hp, hp'⟩⟩,
-  refine ⟨p.map (algebra_map R A), ⟨monic_map (algebra_map R A) hp, _⟩⟩,
+  refine ⟨p.map (algebra_map R A), ⟨hp.map (algebra_map R A), _⟩⟩,
   rw [is_scalar_tower.algebra_map_eq R A B, ← eval₂_map] at hp',
   exact hp',
 end
@@ -798,7 +798,7 @@ lemma ring_hom.is_integral_quotient_of_is_integral {I : ideal S} (hf : f.is_inte
 begin
   rintros ⟨x⟩,
   obtain ⟨p, ⟨p_monic, hpx⟩⟩ := hf x,
-  refine ⟨p.map (ideal.quotient.mk _), ⟨monic_map _ p_monic, _⟩⟩,
+  refine ⟨p.map (ideal.quotient.mk _), ⟨p_monic.map _, _⟩⟩,
   simpa only [hom_eval₂, eval₂_map] using congr_arg (ideal.quotient.mk I) hpx
 end
 

--- a/src/ring_theory/norm.lean
+++ b/src/ring_theory/norm.lean
@@ -118,7 +118,7 @@ lemma power_basis.norm_gen_eq_prod_roots [algebra K S] (pb : power_basis K S)
 begin
   rw [power_basis.norm_gen_eq_coeff_zero_minpoly, ← pb.nat_degree_minpoly, ring_hom.map_mul,
     ← coeff_map, prod_roots_eq_coeff_zero_of_monic_of_split
-      (monic_map _ (minpoly.monic (power_basis.is_integral_gen _)))
+      ((minpoly.monic (power_basis.is_integral_gen _)).map _)
       ((splits_id_iff_splits _).2 hf), nat_degree_map, map_pow, ← mul_assoc, ← mul_pow],
   simp
 end

--- a/src/ring_theory/polynomial/basic.lean
+++ b/src/ring_theory/polynomial/basic.lean
@@ -243,14 +243,14 @@ begin
   nontriviality R,
   cases n, { exact (hn rfl).elim },
   rw [geom_sum_succ', geom_sum_def],
-  refine monic_add_of_left (monic_pow hP _) _,
+  refine (hP.pow _).add_of_left _,
   refine lt_of_le_of_lt (degree_sum_le _ _) _,
   rw [finset.sup_lt_iff],
-  { simp only [finset.mem_range, degree_eq_nat_degree (monic_pow hP _).ne_zero,
+  { simp only [finset.mem_range, degree_eq_nat_degree (hP.pow _).ne_zero,
       with_bot.coe_lt_coe, hP.nat_degree_pow],
     intro k, exact nsmul_lt_nsmul hdeg },
   { rw [bot_lt_iff_ne_bot, ne.def, degree_eq_bot],
-    exact (monic_pow hP _).ne_zero }
+    exact (hP.pow _).ne_zero }
 end
 
 lemma monic.geom_sum' {R : Type*} [semiring R] {P : R[X]}

--- a/src/ring_theory/polynomial/cyclotomic/basic.lean
+++ b/src/ring_theory/polynomial/cyclotomic/basic.lean
@@ -344,8 +344,7 @@ end
 lemma cyclotomic.monic (n : ℕ) (R : Type*) [ring R] : (cyclotomic n R).monic :=
 begin
   rw ←map_cyclotomic_int,
-  apply monic_map,
-  exact (int_cyclotomic_spec n).2.2
+  exact (int_cyclotomic_spec n).2.2.map _,
 end
 
 /-- `cyclotomic n` is primitive. -/
@@ -354,7 +353,7 @@ lemma cyclotomic.is_primitive (n : ℕ) (R : Type*) [comm_ring R] : (cyclotomic 
 
 /-- `cyclotomic n R` is different from `0`. -/
 lemma cyclotomic_ne_zero (n : ℕ) (R : Type*) [ring R] [nontrivial R] : cyclotomic n R ≠ 0 :=
-monic.ne_zero (cyclotomic.monic n R)
+(cyclotomic.monic n R).ne_zero
 
 /-- The degree of `cyclotomic n` is `totient n`. -/
 lemma degree_cyclotomic (n : ℕ) (R : Type*) [ring R] [nontrivial R] :
@@ -895,7 +894,7 @@ begin
   haveI := ne_zero.of_pos hnpos,
   suffices : expand ℤ p (cyclotomic n ℤ) = (cyclotomic (n * p) ℤ) * (cyclotomic n ℤ),
   { rw [← map_cyclotomic_int, ← map_expand, this, map_mul, map_cyclotomic_int] },
-  refine eq_of_monic_of_dvd_of_nat_degree_le (monic_mul (cyclotomic.monic _ _)
+  refine eq_of_monic_of_dvd_of_nat_degree_le ((cyclotomic.monic _ _).mul
     (cyclotomic.monic _ _)) ((cyclotomic.monic n ℤ).expand hp.pos) _ _,
   { refine (is_primitive.int.dvd_iff_map_cast_dvd_map_cast _ _ (is_primitive.mul
       (cyclotomic.is_primitive (n * p) ℤ) (cyclotomic.is_primitive n ℤ))

--- a/src/ring_theory/polynomial/eisenstein.lean
+++ b/src/ring_theory/polynomial/eisenstein.lean
@@ -90,8 +90,8 @@ lemma exists_mem_adjoin_mul_eq_pow_nat_degree {x : S} (hx : aeval x f = 0)
   (algebra_map R S) p * y = x ^ (f.map (algebra_map R S)).nat_degree :=
 begin
   rw [aeval_def, polynomial.eval₂_eq_eval_map, eval_eq_finset_sum, range_add_one,
-    sum_insert not_mem_range_self, sum_range, (monic_map
-    (algebra_map R S) hmo).coeff_nat_degree, one_mul] at hx,
+    sum_insert not_mem_range_self, sum_range, (hmo.map
+    (algebra_map R S)).coeff_nat_degree, one_mul] at hx,
   replace hx := eq_neg_of_add_eq_zero hx,
   have : ∀ n < f.nat_degree, p ∣ f.coeff n,
   { intros n hn,
@@ -150,7 +150,7 @@ begin
     rw [hk, pow_add],
     refine mul_mem_right _ _ this },
   rw [aeval_def, eval₂_eq_eval_map, ← is_root.def] at hx,
-  refine pow_nat_degree_le_of_root_of_monic_mem (hf.map _) hx (monic_map _ hmo) _ rfl.le
+  refine pow_nat_degree_le_of_root_of_monic_mem (hf.map _) hx (hmo.map _) _ rfl.le
 end
 
 end comm_ring
@@ -221,10 +221,10 @@ begin
   have deg_K_P : (minpoly K B.gen).nat_degree = B.dim := B.nat_degree_minpoly,
   have deg_R_P : P.nat_degree = B.dim,
   { rw [← deg_K_P, minpoly.gcd_domain_eq_field_fractions K hBint,
-        nat_degree_map_of_monic (minpoly.monic hBint) (algebra_map R K)] },
+        (minpoly.monic hBint).nat_degree_map (algebra_map R K)] },
   choose! f hf using hei.is_weakly_eisenstein_at.exists_mem_adjoin_mul_eq_pow_nat_degree_le
     (minpoly.aeval R B.gen) (minpoly.monic hBint),
-  simp only [nat_degree_map_of_monic (minpoly.monic hBint), deg_R_P] at hf,
+  simp only [(minpoly.monic hBint).nat_degree_map, deg_R_P] at hf,
 
   -- The Eisenstein condition shows that `p` divides `Q.coeff 0`
   -- if `p^n.succ` divides the following multiple of `Q.coeff 0^n.succ`:
@@ -380,7 +380,7 @@ begin
       rw [smul_mul_assoc, ← pow_add, ← nat.add_sub_assoc H, ← add_assoc j 1 1,
         add_comm (j + 1) 1, add_assoc (j + 1), add_comm _ (k + P.nat_degree),
         nat.add_sub_add_right, ← (hf (k + P.nat_degree - 1) _).2, mul_smul_comm],
-      rw [nat_degree_map_of_monic (minpoly.monic hBint), add_comm, nat.add_sub_assoc,
+      rw [(minpoly.monic hBint).nat_degree_map, add_comm, nat.add_sub_assoc,
         le_add_iff_nonneg_right],
       { exact nat.zero_le _ },
       { refine one_le_iff_ne_zero.2 (λ h, _),
@@ -395,7 +395,7 @@ begin
   { convert this,
     rw [nat.succ_eq_add_one, add_assoc, ← nat.add_sub_assoc H, ← add_assoc, add_comm (j + 1),
       nat.add_sub_add_left, ← nat.add_sub_assoc, nat.add_sub_add_left, hP,
-      ← nat_degree_map_of_monic (minpoly.monic hBint) (algebra_map R K),
+      ← (minpoly.monic hBint).nat_degree_map  (algebra_map R K),
       ← minpoly.gcd_domain_eq_field_fractions K hBint, nat_degree_minpoly, hn, nat.sub_one,
       nat.pred_succ],
     linarith },
@@ -424,7 +424,7 @@ begin
         (is_integral.sum _ (λ k hk, is_integral_mul (is_integral_smul _ (is_integral.pow hBint _))
         ((is_integral.pow hBint _))))),
       refine adjoin_le_integral_closure hBint (hf _ _).1,
-      rw [nat_degree_map_of_monic (minpoly.monic hBint) (algebra_map R L)],
+      rw [(minpoly.monic hBint).nat_degree_map (algebra_map R L)],
       rw [add_comm, nat.add_sub_assoc, le_add_iff_nonneg_right],
       { exact zero_le _ },
       { refine one_le_iff_ne_zero.2 (λ h, _),

--- a/src/ring_theory/power_basis.lean
+++ b/src/ring_theory/power_basis.lean
@@ -209,7 +209,7 @@ nat_degree_eq_of_degree_eq_some pb.degree_minpoly_gen
 
 lemma minpoly_gen_monic (pb : power_basis A S) : monic (minpoly_gen pb) :=
 begin
-  apply monic_sub_of_left (monic_pow (monic_X) _),
+  apply monic_sub_of_left (monic_X_pow _) _,
   rw degree_X_pow,
   exact degree_sum_fin_lt _
 end

--- a/src/ring_theory/trace.lean
+++ b/src/ring_theory/trace.lean
@@ -215,7 +215,7 @@ lemma power_basis.trace_gen_eq_sum_roots [nontrivial S] (pb : power_basis K S)
 begin
   rw [power_basis.trace_gen_eq_next_coeff_minpoly, ring_hom.map_neg, ← next_coeff_map
     (algebra_map K F).injective, sum_roots_eq_next_coeff_of_monic_of_split
-      (monic_map _ (minpoly.monic (power_basis.is_integral_gen _)))
+      ((minpoly.monic (power_basis.is_integral_gen _)).map _)
       ((splits_id_iff_splits _).2 hf), neg_neg]
 end
 


### PR DESCRIPTION
As discussed in #12447
- Use the notation throughout the library
- Also deleted `ne_zero_of_monic` as it was a duplicate of `monic.ne_zero` it seems.
- Cleaned up a small proof here and there too.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] -->
- [x] depends on: #12447

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
