### PR TITLE
[Merged by Bors] - feat(model_theory/ultraproducts): Ultraproducts and the Compactness Theorem

### DIFF
--- a/docs/overview.yaml
+++ b/docs/overview.yaml
@@ -416,3 +416,4 @@ Logic and computation:
     substructure: 'first_order.language.substructure'
     definable set: 'first_order.language.definable_set'
     elementary embedding: 'first_order.language.elementary_embedding'
+    Compactness theorem: 'first_order.language.Theory.is_satisfiable_iff_is_finitely_satisfiable'

--- a/src/model_theory/quotients.lean
+++ b/src/model_theory/quotients.lean
@@ -55,10 +55,10 @@ begin
 end
 
 lemma rel_map_quotient_mk {n : ℕ} (r : L.relations n) (x : fin n → M) :
-  rel_map r (λ i, ⟦x i⟧) = @rel_map _ _ ps.to_structure _ r x :=
+  rel_map r (λ i, ⟦x i⟧) ↔ @rel_map _ _ ps.to_structure _ r x :=
 begin
   change quotient.lift (@rel_map L M ps.to_structure n r) prestructure.rel_equiv
-    (quotient.fin_choice _) = _,
+    (quotient.fin_choice _) ↔ _,
   rw [quotient.fin_choice_eq, quotient.lift_mk],
 end
 

--- a/src/model_theory/terms_and_formulas.lean
+++ b/src/model_theory/terms_and_formulas.lean
@@ -448,14 +448,14 @@ end formula
 variable (M)
 
 /-- A sentence can be evaluated as true or false in a structure. -/
-@[reducible] def realize_sentence (φ : L.sentence) : Prop :=
+def sentence.realize (φ : L.sentence) : Prop :=
 φ.realize (default : _ → M)
 
-infix ` ⊨ `:51 := realize_sentence -- input using \|= or \vDash, but not using \models
+infix ` ⊨ `:51 := sentence.realize -- input using \|= or \vDash, but not using \models
 
 /-- A model of a theory is a structure in which every sentence is realized as true. -/
 @[reducible] def Theory.model (T : L.Theory) : Prop :=
-∀ φ ∈ T, realize_sentence M φ
+∀ φ ∈ T, M ⊨ φ
 
 infix ` ⊨ `:51 := Theory.model -- input using \|= or \vDash, but not using \models
 
@@ -581,7 +581,7 @@ forall_congr (λ M, forall_congr (λ ne, forall_congr (λ str, forall_congr (λ 
 
 lemma models_sentence_iff {T : L.Theory} {φ : L.sentence} :
   T ⊨ φ ↔ ∀ (M : Type (max u v)) [nonempty M] [str : L.Structure M],
-    @Theory.model L M str T → @realize_sentence L M str φ :=
+    @Theory.model L M str T → @sentence.realize L M str φ :=
 begin
   rw [models_formula_iff],
   exact forall_congr (λ M, forall_congr (λ ne, forall_congr (λ str, unique.forall_iff)))

--- a/src/model_theory/ultraproducts.lean
+++ b/src/model_theory/ultraproducts.lean
@@ -7,13 +7,13 @@ import model_theory.quotients
 import order.filter.germ
 import order.filter.ultrafilter
 
-/-! # Ultraproducts, Łos's Theorem, and Compactness
+/-! # Ultraproducts, Łoś 's Theorem, and Compactness
 
 ## Main Definitions
 * `filter.ultraproduct` is a dependent version of `filter.germ`.
 
 ## Main Results
-* Łos's Theorem: `first_order.language.ultraproduct.sentence_realize`. An ultraproduct models a
+* Łoś 's Theorem: `first_order.language.ultraproduct.sentence_realize`. An ultraproduct models a
 sentence `φ` if and only if the set of structures in the product that model `φ` is in the
 ultrafilter.
 * The Compactness Theorem: `first_order.language.Theory.is_satisfiable_iff_is_finitely_satisfiable`.

--- a/src/model_theory/ultraproducts.lean
+++ b/src/model_theory/ultraproducts.lean
@@ -7,17 +7,20 @@ import model_theory.quotients
 import order.filter.germ
 import order.filter.ultrafilter
 
-/-! # Ultraproducts, Łoś 's Theorem, and Compactness
+/-! # Ultraproducts, Łoś's Theorem, and Compactness
 
 ## Main Definitions
 * `first_order.language.ultraproduct.Structure` is a structure on `filter.product`.
 
 ## Main Results
-* Łoś 's Theorem: `first_order.language.ultraproduct.sentence_realize`. An ultraproduct models a
+* Łoś's Theorem: `first_order.language.ultraproduct.sentence_realize`. An ultraproduct models a
 sentence `φ` if and only if the set of structures in the product that model `φ` is in the
 ultrafilter.
 * The Compactness Theorem: `first_order.language.Theory.is_satisfiable_iff_is_finitely_satisfiable`.
 A theory is satisfiable if and only if it is finitely satisfiable.
+
+## Tags
+ultraproduct, Los's theorem, compactness
 
 -/
 
@@ -39,12 +42,11 @@ namespace ultraproduct
 
 instance setoid_prestructure : L.prestructure ((u : filter α).product_setoid M) :=
 { to_structure := { fun_map := λ n f x a, fun_map f (λ i, x i a),
-             rel_map := λ n r x, ∀ᶠ (a : α) in ↑u, rel_map r (λ i, x i a) },
+             rel_map := λ n r x, ∀ᶠ (a : α) in u, rel_map r (λ i, x i a) },
   fun_equiv := λ n f x y xy, begin
     refine mem_of_superset (Inter_mem.2 xy) (λ a ha, _),
-    rw set.mem_Inter at ha,
-    simp only [set.mem_set_of_eq],
-    exact congr rfl (funext ha),
+    simp only [set.mem_Inter, set.mem_set_of_eq] at ha,
+    simp only [set.mem_set_of_eq, ha],
   end,
   rel_equiv := λ n r x y xy, begin
     rw ← iff_eq_eq,
@@ -87,7 +89,7 @@ variables [Π a : α, nonempty (M a)]
 theorem bounded_formula_realize_cast {β : Type*} {n : ℕ} (φ : L.bounded_formula β n)
   (x : β → (Π a, M a)) (v : fin n → (Π a, M a)) :
   φ.realize (λ (i : β), ((x i) : (u : filter α).product M)) (λ i, (v i)) ↔
-    ∀ᶠ (a : α) in ↑u, φ.realize (λ (i : β), x i a) (λ i, v i a) :=
+    ∀ᶠ (a : α) in u, φ.realize (λ (i : β), x i a) (λ i, v i a) :=
 begin
   letI := ((u : filter α).product_setoid M),
   induction φ with _ _ _ _ _ _ _ _ m _ _ ih ih' k φ ih,
@@ -153,27 +155,20 @@ theorem is_satisfiable_iff_is_finitely_satisfiable {T : L.Theory} :
   set M : Π (T0 : finset T), Type (max u v) :=
     λ T0, (h (T0.map (function.embedding.subtype (λ x, x ∈ T)))
       T0.map_subtype_subset).some_model with hM,
-  cases fintype_or_infinite T; resetI,
-  { refine (congr rfl _).mp (h (finset.univ.map (function.embedding.subtype (λ x, x ∈ T)))
-      finset.univ.map_subtype_subset),
-    rw [finset.coe_map, function.embedding.coe_subtype, finset.coe_univ, set.image_univ,
-      subtype.range_coe_subtype, set.set_of_mem_eq], },
-  { letI : Π (T0 : finset T), L.Structure (M T0) := λ T0, is_satisfiable.some_model_structure _,
-    haveI : (filter.at_top : filter (finset T)).ne_bot := at_top_ne_bot,
-    refine ⟨(↑(ultrafilter.of filter.at_top) : filter _).product M, _, ultraproduct.Structure, _⟩,
-    { haveI : Π (T0 : finset T), inhabited (M T0),
-      { exact λ T0, classical.inhabited_of_nonempty (is_satisfiable.nonempty_some_model _) },
-      exact nonempty_of_inhabited },
-    intros φ hφ,
-    rw ultraproduct.sentence_realize,
-    refine filter.eventually.filter_mono (ultrafilter.of_le _) (filter.eventually_at_top.2
-      ⟨{⟨φ, hφ⟩}, _⟩),
-    rintro ⟨s, hs⟩ h',
-    simp only [ge_iff_le, finset.le_eq_subset, finset.singleton_subset_iff, finset.mem_mk] at h',
-    refine is_satisfiable.some_model_models _ _ _,
-    simp only [finset.coe_map, function.embedding.coe_subtype, set.mem_image, finset.mem_coe,
-      finset.mem_mk, set_coe.exists, subtype.coe_mk, exists_and_distrib_right, exists_eq_right],
-    exact ⟨hφ, h'⟩, },
+  letI : Π (T0 : finset T), L.Structure (M T0) := λ T0, is_satisfiable.some_model_structure _,
+  haveI : (filter.at_top : filter (finset T)).ne_bot := at_top_ne_bot,
+  refine ⟨(↑(ultrafilter.of filter.at_top) : filter _).product M, infer_instance,
+    ultraproduct.Structure, _⟩,
+  intros φ hφ,
+  rw ultraproduct.sentence_realize,
+  refine filter.eventually.filter_mono (ultrafilter.of_le _) (filter.eventually_at_top.2
+    ⟨{⟨φ, hφ⟩}, _⟩),
+  rintro ⟨s, hs⟩ h',
+  simp only [ge_iff_le, finset.le_eq_subset, finset.singleton_subset_iff, finset.mem_mk] at h',
+  refine is_satisfiable.some_model_models _ _ _,
+  simp only [finset.coe_map, function.embedding.coe_subtype, set.mem_image, finset.mem_coe,
+    finset.mem_mk, set_coe.exists, subtype.coe_mk, exists_and_distrib_right, exists_eq_right],
+  exact ⟨hφ, h'⟩,
 end⟩
 
 end Theory

--- a/src/model_theory/ultraproducts.lean
+++ b/src/model_theory/ultraproducts.lean
@@ -10,7 +10,7 @@ import order.filter.ultrafilter
 /-! # Ultraproducts, Łoś 's Theorem, and Compactness
 
 ## Main Definitions
-* `filter.ultraproduct` is a dependent version of `filter.germ`.
+* `first_order.language.ultraproduct.Structure` is a structure on `filter.product`.
 
 ## Main Results
 * Łoś 's Theorem: `first_order.language.ultraproduct.sentence_realize`. An ultraproduct models a
@@ -167,7 +167,7 @@ theorem is_satisfiable_iff_is_finitely_satisfiable {T : L.Theory} :
       subtype.range_coe_subtype, set.set_of_mem_eq], },
   { letI : Π (T0 : finset T), L.Structure (M T0) := λ T0, is_satisfiable.some_model_structure _,
     haveI : (filter.at_top : filter (finset T)).ne_bot := at_top_ne_bot,
-    refine ⟨((ultrafilter.of filter.at_top) : filter _).product M, _, ultraproduct.Structure, _⟩,
+    refine ⟨(↑(ultrafilter.of filter.at_top) : filter _).product M, _, ultraproduct.Structure, _⟩,
     { haveI : Π (T0 : finset T), inhabited (M T0),
       { exact λ T0, classical.inhabited_of_nonempty (is_satisfiable.nonempty_some_model _) },
       exact nonempty_of_inhabited },

--- a/src/model_theory/ultraproducts.lean
+++ b/src/model_theory/ultraproducts.lean
@@ -1,0 +1,212 @@
+/-
+Copyright (c) 2022 Aaron Anderson. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Aaron Anderson
+-/
+import model_theory.quotients
+import order.filter.germ
+import order.filter.ultrafilter
+
+/-! # Ultraproducts, Łos's Theorem, and Compactness
+
+-/
+
+universes u v
+variables {α : Type*} (M : α → Type*) (u : ultrafilter α)
+
+open_locale first_order filter
+
+namespace filter
+
+variables (l : filter α) (β : α → Type*)
+
+/-- Setoid used to define the space of dependent germs. -/
+def ultraproduct_setoid : setoid (Π a, β a) :=
+{ r := λ f g, ∀ᶠ a in l, f a = g a,
+  iseqv := ⟨λ _, eventually_of_forall (λ _, rfl),
+    λ _ _ h, h.mono (λ _, eq.symm),
+    λ x y z h1 h2, h1.congr (h2.mono (λ x hx, hx ▸ iff.rfl))⟩ }
+
+/-- The space of germs of dependent functions `Π (a : α), β a` at a filter `l`. -/
+def ultraproduct : Type* := quotient (ultraproduct_setoid l β)
+
+variables {l} {β}
+
+instance : has_coe_t (Π a, β a) (ultraproduct l β) := ⟨quotient.mk'⟩
+
+instance [Π a, inhabited (β a)] : inhabited (ultraproduct l β) :=
+⟨(↑(λ a, (default : β a)) : ultraproduct l β)⟩
+
+end filter
+
+open filter
+
+namespace first_order
+namespace language
+
+open Structure
+
+variables {L : language.{u v}} [Π a, L.Structure (M a)]
+
+namespace ultraproduct
+
+instance setoid_prestructure : L.prestructure (ultraproduct_setoid ↑u M) :=
+{ to_structure := { fun_map := λ n f x a, fun_map f (λ i, x i a),
+             rel_map := λ n r x, ∀ᶠ (a : α) in ↑u, rel_map r (λ i, x i a) },
+  fun_equiv := λ n f x y xy, begin
+    refine mem_of_superset (Inter_mem.2 xy) (λ a ha, _),
+    rw set.mem_Inter at ha,
+    simp only [set.mem_set_of_eq],
+    exact congr rfl (funext ha),
+  end,
+  rel_equiv := λ n r x y xy, begin
+    rw ← iff_eq_eq,
+    refine ⟨λ hx, _, λ hy, _⟩,
+    { refine mem_of_superset (inter_mem hx (Inter_mem.2 xy)) _,
+      rintro a ⟨ha1, ha2⟩,
+      simp only [set.mem_Inter, set.mem_set_of_eq] at *,
+      rw ← funext ha2,
+      exact ha1 },
+    { refine mem_of_superset (inter_mem hy (Inter_mem.2 xy)) _,
+      rintro a ⟨ha1, ha2⟩,
+      simp only [set.mem_Inter, set.mem_set_of_eq] at *,
+      rw funext ha2,
+      exact ha1 },
+  end,
+  .. ultraproduct_setoid ↑u M }
+
+variables {M} {u}
+
+instance Structure : L.Structure (ultraproduct ↑u M) := language.quotient_structure
+
+lemma fun_map_cast {n : ℕ} (f : L.functions n) (x : fin n → (Π a, M a)) :
+  fun_map f (λ i, ((x i) : ultraproduct ↑u M)) = λ a, fun_map f (λ i, x i a) :=
+by apply fun_map_quotient_mk
+
+lemma term_realize_cast {β : Type*} (x : β → (Π a, M a)) (t : L.term β) :
+  t.realize (λ i, ((x i) : ultraproduct ↑u M)) = λ a, t.realize (λ i, x i a) :=
+begin
+  convert @term.realize_quotient_mk L _  (ultraproduct_setoid ↑u M)
+    (ultraproduct.setoid_prestructure M u) _ t x,
+  ext a,
+  induction t,
+  { refl },
+  { simp only [term.realize, t_ih],
+    refl }
+end
+
+variables [Π a : α, nonempty (M a)]
+
+theorem bounded_formula_realize_cast {β : Type*} {n : ℕ} (φ : L.bounded_formula β n)
+  (x : β → (Π a, M a)) (v : fin n → (Π a, M a)) :
+  φ.realize (λ (i : β), ((x i) : ultraproduct ↑u M)) (λ i, (v i)) ↔
+    ∀ᶠ (a : α) in ↑u, φ.realize (λ (i : β), x i a) (λ i, v i a) :=
+begin
+  induction φ with _ _ _ _ _ _ _ _ m a0 a1 a2 a3 a4 a5 a6 a7 a8 a9,
+  { simp only [bounded_formula.realize, eventually_const], },
+  { have h2 : ∀ a : α, sum.elim (λ (i : β), x i a) (λ i, v i a) = λ i, sum.elim x v i a,
+    { intro a,
+      ext i,
+      cases i;
+      simp, },
+    simp only [bounded_formula.realize, (sum.comp_elim coe x v).symm, h2, term_realize_cast],
+    exact quotient.eq' },
+  { have h2 : ∀ a : α, sum.elim (λ (i : β), x i a) (λ i, v i a) = λ i, sum.elim x v i a,
+    { intro a,
+      ext i,
+      cases i;
+      simp, },
+    simp only [bounded_formula.realize, (sum.comp_elim coe x v).symm, h2, term_realize_cast],
+    unfold rel_map,
+    rw quotient.lift,
+    change quotient.lift _ _ (quotient.fin_choice (λ _, ⟦_⟧)) ↔ _,
+    simp_rw [quotient.fin_choice_eq, quotient.lift_mk] },
+  { simp only [bounded_formula.realize, a2 v, a3 v],
+    rw ultrafilter.eventually_imp },
+  { simp only [bounded_formula.realize],
+    transitivity (∀ (m : Π (a : α), M a), a5.realize (λ (i : β), (x i : ultraproduct ↑u M))
+      (fin.snoc (coe ∘ v) (↑m : ultraproduct ↑u M))),
+    { exact (@forall_quotient_iff _ (ultraproduct_setoid ↑u M) _) },
+    have h' : ∀ (m : Π a, M a) (a : α), (λ (i : fin (a4 + 1)), (fin.snoc v m : _ → Π a, M a) i a) =
+      fin.snoc (λ (i : fin a4), v i a) (m a),
+    { intros m a,
+      ext i,
+      refine fin.reverse_induction _ _ i,
+      { simp only [fin.snoc_last] },
+      { intros i hi,
+        simp only [fin.snoc_cast_succ] } },
+    simp only [← fin.comp_snoc, a6, h'],
+    refine ⟨λ h, _, λ h m, _⟩,
+    { contrapose! h,
+      simp_rw [← ultrafilter.eventually_not, not_forall] at h,
+      refine ⟨λ a : α, classical.epsilon (λ m : M a, ¬ a5.realize (λ i, x i a)
+        (fin.snoc (λ i, v i a) m)), _⟩,
+      rw [← ultrafilter.eventually_not],
+      exact filter.mem_of_superset h (λ a ha, classical.epsilon_spec ha) },
+    { rw filter.eventually_iff at *,
+      exact filter.mem_of_superset h (λ a ha, ha (m a)) } }
+end
+
+theorem realize_formula_cast {β : Type*} (φ : L.formula β) (x : β → (Π a, M a)) :
+  φ.realize (λ i, ((x i) : ultraproduct ↑u M)) ↔
+    ∀ᶠ (a : α) in u, φ.realize (λ i, (x i a)) :=
+begin
+  simp_rw [formula.realize],
+  convert bounded_formula_realize_cast φ x default,
+  { simp },
+  ext,
+  rw iff_eq_eq,
+  refine congr rfl _,
+  simp,
+end
+
+/-- Łoś's Theorem : A sentence is true in an ultraproduct if and only if the set of structures it is
+  true in is in the ultrafilter. -/
+theorem sentence_realize (φ : L.sentence) :
+  (ultraproduct ↑u M) ⊨ φ ↔ ∀ᶠ (a : α) in u, (M a) ⊨ φ :=
+begin
+  simp_rw [sentence.realize, iff_eq_eq],
+  exact (congr rfl (subsingleton.elim _ _)).trans (iff_eq_eq.mp (realize_formula_cast φ _))
+end
+
+end ultraproduct
+
+namespace Theory
+
+/-- The Compactness Theorem of first-order logic: A theory is satisfiable if and only if it is
+finitely satisfiable. -/
+theorem is_satisfiable_iff_is_finitely_satisfiable {T : L.Theory} :
+  T.is_satisfiable ↔ T.is_finitely_satisfiable :=
+⟨Theory.is_satisfiable.is_finitely_satisfiable, λ h, begin
+  classical,
+  unfold is_finitely_satisfiable at h,
+  set M : Π (T0 : finset T), Type (max u v) :=
+    λ T0, (h (T0.map (function.embedding.subtype (λ x, x ∈ T)))
+      T0.map_subtype_subset).some_model with hM,
+  cases fintype_or_infinite T; resetI,
+  { refine (congr rfl _).mp (h (finset.univ.map (function.embedding.subtype (λ x, x ∈ T)))
+      finset.univ.map_subtype_subset),
+    rw [finset.coe_map, function.embedding.coe_subtype, finset.coe_univ, set.image_univ,
+      subtype.range_coe_subtype, set.set_of_mem_eq], },
+  { letI : Π (T0 : finset T), L.Structure (M T0) := λ T0, is_satisfiable.some_model_structure _,
+    haveI : (filter.at_top : filter (finset T)).ne_bot := at_top_ne_bot,
+    refine ⟨ultraproduct ↑(ultrafilter.of filter.at_top) M, _, ultraproduct.Structure, _⟩,
+    { haveI : Π (T0 : finset T), inhabited (M T0),
+      { exact λ T0, classical.inhabited_of_nonempty (is_satisfiable.nonempty_some_model _) },
+      exact nonempty_of_inhabited },
+    intros φ hφ,
+    rw ultraproduct.sentence_realize,
+    refine filter.eventually.filter_mono (ultrafilter.of_le _) (filter.eventually_at_top.2
+      ⟨{⟨φ, hφ⟩}, _⟩),
+    rintro ⟨s, hs⟩ h',
+    simp only [ge_iff_le, finset.le_eq_subset, finset.singleton_subset_iff, finset.mem_mk] at h',
+    refine is_satisfiable.some_model_models _ _ _,
+    simp only [finset.coe_map, function.embedding.coe_subtype, set.mem_image, finset.mem_coe,
+      finset.mem_mk, set_coe.exists, subtype.coe_mk, exists_and_distrib_right, exists_eq_right],
+    exact ⟨hφ, h'⟩, },
+end⟩
+
+end Theory
+
+end language
+end first_order

--- a/src/order/filter/germ.lean
+++ b/src/order/filter/germ.lean
@@ -92,7 +92,7 @@ variables {ε : α → Type*}
 
 instance : has_coe_t (Π a, ε a) (l.product ε) := ⟨quotient.mk'⟩
 
-instance [Π a, inhabited (ε  a)] : inhabited (l.product ε) :=
+instance [Π a, inhabited (ε a)] : inhabited (l.product ε) :=
 ⟨(↑(λ a, (default : ε a)) : l.product ε)⟩
 
 end product

--- a/src/order/filter/germ.lean
+++ b/src/order/filter/germ.lean
@@ -74,6 +74,29 @@ def germ_setoid (l : filter α) (β : Type*) : setoid (α → β) :=
 /-- The space of germs of functions `α → β` at a filter `l`. -/
 def germ (l : filter α) (β : Type*) : Type* := quotient (germ_setoid l β)
 
+/-- Setoid used to define the filter product. This is a dependent version of
+  `filter.germ_setoid`. -/
+def product_setoid (l : filter α) (ε : α → Type*) : setoid (Π a, ε a) :=
+{ r := λ f g, ∀ᶠ a in l, f a = g a,
+  iseqv := ⟨λ _, eventually_of_forall (λ _, rfl),
+    λ _ _ h, h.mono (λ _, eq.symm),
+    λ x y z h1 h2, h1.congr (h2.mono (λ x hx, hx ▸ iff.rfl))⟩ }
+
+/-- The filter product `Π (a : α), ε a` at a filter `l`. This is a dependent version of
+  `filter.germ`. -/
+@[protected] def product : Type* := quotient (product_setoid l ε)
+
+namespace product
+
+variables {ε : α → Type*}
+
+instance : has_coe_t (Π a, ε a) (l.product ε) := ⟨quotient.mk'⟩
+
+instance [Π a, inhabited (β a)] : inhabited (l.product β) :=
+⟨(↑(λ a, (default : β a)) : l.product β)⟩
+
+end product
+
 namespace germ
 
 instance : has_coe_t (α → β) (germ l β) := ⟨quotient.mk'⟩

--- a/src/order/filter/germ.lean
+++ b/src/order/filter/germ.lean
@@ -84,7 +84,7 @@ def product_setoid (l : filter α) (ε : α → Type*) : setoid (Π a, ε a) :=
 
 /-- The filter product `Π (a : α), ε a` at a filter `l`. This is a dependent version of
   `filter.germ`. -/
-@[protected] def product : Type* := quotient (product_setoid l ε)
+@[protected] def product (l : filter α) (ε : α → Type*) : Type* := quotient (product_setoid l ε)
 
 namespace product
 

--- a/src/order/filter/germ.lean
+++ b/src/order/filter/germ.lean
@@ -92,8 +92,8 @@ variables {ε : α → Type*}
 
 instance : has_coe_t (Π a, ε a) (l.product ε) := ⟨quotient.mk'⟩
 
-instance [Π a, inhabited (β a)] : inhabited (l.product β) :=
-⟨(↑(λ a, (default : β a)) : l.product β)⟩
+instance [Π a, inhabited (ε  a)] : inhabited (l.product ε) :=
+⟨(↑(λ a, (default : ε a)) : l.product ε)⟩
 
 end product
 


### PR DESCRIPTION
Defines `filter.product`, a dependent version of `filter.germ`.
Defines a structure on an ultraproduct (a `filter.product` with respect to an ultrafilter).
Proves Łoś's Theorem, characterizing when an ultraproduct realizes a formula.
Proves the Compactness theorem with ultraproducts.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
