### PR TITLE
[Merged by Bors] - chore(analysis/complex/upper_half_plane): use `coe` instead of `coe_fn`

### DIFF
--- a/src/analysis/complex/upper_half_plane.lean
+++ b/src/analysis/complex/upper_half_plane.lean
@@ -28,6 +28,12 @@ open_locale classical big_operators matrix_groups
 
 local attribute [instance] fintype.card_fin_even
 
+/- Disable this instances as it is not the simp-normal form, and having them disabled ensures
+we state lemmas in this file without spurious `coe_fn` terms. -/
+local attribute [-instance] matrix.special_linear_group.has_coe_to_fun
+
+local prefix `↑ₘ`:1024 := @coe _ (matrix (fin 2) (fin 2) _) _
+
 /-- The open upper half plane -/
 abbreviation upper_half_plane :=
 {point : ℂ // 0 < point.im}
@@ -59,10 +65,10 @@ by { rw complex.norm_sq_pos, exact z.ne_zero }
 lemma norm_sq_ne_zero (z : ℍ) : complex.norm_sq (z : ℂ) ≠ 0 := (norm_sq_pos z).ne'
 
 /-- Numerator of the formula for a fractional linear transformation -/
-@[simp] def num (g : SL(2, ℝ)) (z : ℍ) : ℂ := (g 0 0) * z + (g 0 1)
+@[simp] def num (g : SL(2, ℝ)) (z : ℍ) : ℂ := (↑ₘg 0 0 : ℝ) * z + (↑ₘg 0 1 : ℝ)
 
 /-- Denominator of the formula for a fractional linear transformation -/
-@[simp] def denom (g : SL(2, ℝ)) (z : ℍ) : ℂ := (g 1 0) * z + (g 1 1)
+@[simp] def denom (g : SL(2, ℝ)) (z : ℍ) : ℂ := (↑ₘg 1 0 : ℝ) * z + (↑ₘg 1 1 : ℝ)
 
 lemma linear_ne_zero (cd : fin 2 → ℝ) (z : ℍ) (h : cd ≠ 0) : (cd 0 : ℂ) * z + cd 1 ≠ 0 :=
 begin
@@ -77,7 +83,7 @@ begin
 end
 
 lemma denom_ne_zero (g : SL(2, ℝ)) (z : ℍ) : denom g z ≠ 0 :=
-linear_ne_zero (g 1) z (g.row_ne_zero 1)
+linear_ne_zero (↑ₘg 1) z (g.row_ne_zero 1)
 
 lemma norm_sq_denom_pos (g : SL(2, ℝ)) (z : ℍ) : 0 < complex.norm_sq (denom g z) :=
 complex.norm_sq_pos.mpr (denom_ne_zero g z)


### PR DESCRIPTION
This matches the approach used by other files working with `special_linear_group`.



---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
