### PR TITLE
[Merged by Bors] - feat(order/complete_lattice): add `complete_lattice.independent_pair`

### DIFF
--- a/counterexamples/direct_sum_is_internal.lean
+++ b/counterexamples/direct_sum_is_internal.lean
@@ -54,17 +54,10 @@ end
 
 def with_sign.independent : complete_lattice.independent with_sign :=
 begin
+  refine (complete_lattice.independent_pair units_int.one_ne_neg_one _).mpr
+    with_sign.is_compl.disjoint,
   intros i,
-  rw [←finset.sup_univ_eq_supr, units_int.univ, finset.sup_insert, finset.sup_singleton],
-  fin_cases i,
-  { convert with_sign.is_compl.disjoint,
-    convert bot_sup_eq,
-    { exact supr_neg (not_not_intro rfl), },
-    { rw supr_pos units_int.one_ne_neg_one.symm } },
-  { convert with_sign.is_compl.disjoint.symm,
-    convert sup_bot_eq,
-    { exact supr_neg (not_not_intro rfl), },
-    { rw supr_pos units_int.one_ne_neg_one } },
+  fin_cases i; simp,
 end
 
 lemma with_sign.supr : supr with_sign = ⊤ :=

--- a/src/data/set/basic.lean
+++ b/src/data/set/basic.lean
@@ -1060,6 +1060,16 @@ lemma insert_diff_self_of_not_mem {a : α} {s : set α} (h : a ∉ s) :
   insert a s \ {a} = s :=
 by { ext, simp [and_iff_left_of_imp (λ hx : x ∈ s, show x ≠ a, from λ hxa, h $ hxa ▸ hx)] }
 
+@[simp] lemma insert_diff_eq_singleton {a : α} {s : set α} (h : a ∉ s) :
+  insert a s \ s = {a} :=
+begin
+  ext,
+  rw [set.mem_diff, set.mem_insert_iff, set.mem_singleton_iff, or_and_distrib_right,
+    and_not_self, or_false, and_iff_left_iff_imp],
+  rintro rfl,
+  exact h,
+end
+
 lemma insert_inter_of_mem {s₁ s₂ : set α} {a : α} (h : a ∈ s₂) :
   insert a s₁ ∩ s₂ = insert a (s₁ ∩ s₂) :=
 by simp [set.insert_inter, h]

--- a/src/order/complete_lattice.lean
+++ b/src/order/complete_lattice.lean
@@ -1348,6 +1348,19 @@ theorem set_independent.mono {t : set α} (hst : t ⊆ s) :
 lemma set_independent.disjoint {x y : α} (hx : x ∈ s) (hy : y ∈ s) (h : x ≠ y) : disjoint x y :=
 disjoint_Sup_right (hs hx) ((mem_diff y).mpr ⟨hy, by simp [h.symm]⟩)
 
+lemma set_independent_pair {a b : α} (hab : a ≠ b) :
+  set_independent ({a, b} : set α) ↔ disjoint a b :=
+begin
+  split,
+  { intro h,
+    exact h.disjoint (mem_insert _ _) (mem_insert_of_mem _ (mem_singleton _)) hab, },
+  { rintros h c ((rfl : c = a) | (rfl : c = b)),
+    { convert h using 1,
+      simp [hab, Sup_singleton] },
+    { convert h.symm using 1,
+      simp [hab, Sup_singleton] }, },
+end
+
 include hs
 
 /-- If the elements of a set are independent, then any element is disjoint from the `Sup` of some
@@ -1420,6 +1433,20 @@ lemma independent.comp {ι ι' : Sort*} {α : Type*} [complete_lattice α]
 λ i, (hs (f i)).mono_right begin
   refine (supr_le_supr $ λ i, _).trans (supr_comp_le _ f),
   exact supr_le_supr_const hf.ne,
+end
+
+lemma independent_pair {i j : ι} (hij : i ≠ j) (huniv : ∀ k, k = i ∨ k = j):
+  independent t ↔ disjoint (t i) (t j) :=
+begin
+  split,
+  { intro h,
+    exact h.disjoint hij, },
+  { rintros h k,
+    obtain rfl | rfl := huniv k,
+    { refine h.mono_right (supr_le $ λ i, supr_le $ λ hi, eq.le _),
+      rw (huniv i).resolve_left hi },
+    { refine h.symm.mono_right (supr_le $ λ j, supr_le $ λ hj, eq.le _),
+      rw (huniv j).resolve_right hj } },
 end
 
 /-- Composing an indepedent indexed family with an order isomorphism on the elements results in


### PR DESCRIPTION
This makes `complete_lattice.independent` easier to work with in the degenerate case.



---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
