### PR TITLE
[Merged by Bors] - chore(*): clear up some excessive by statements

### DIFF
--- a/archive/100-theorems-list/82_cubing_a_cube.lean
+++ b/archive/100-theorems-list/82_cubing_a_cube.lean
@@ -476,7 +476,7 @@ begin
     have h2p' : p' ∈ (cs i'').to_set,
     { simp only [to_set, forall_fin_succ, p', cons_succ, cons_zero, mem_set_of_eq],
       refine ⟨_, by simpa [to_set, p] using hi''.2⟩,
-      have : (cs i).b 0 = (cs i'').b 0, { by rw [hi.1, h2i''.1] },
+      have : (cs i).b 0 = (cs i'').b 0, { rw [hi.1, h2i''.1] },
       simp [side, hw', xm, this, h3i''] },
     apply not_disjoint_iff.mpr ⟨p', hp', h2p'⟩,
     apply h.1, rintro rfl, apply (cs i).b_ne_xm, rw [←hi', ←hi''.1, hi.1], refl },

--- a/src/algebra/lie/nilpotent.lean
+++ b/src/algebra/lie/nilpotent.lean
@@ -161,7 +161,7 @@ begin
   induction k with k h,
   { rw [derived_series_def, derived_series_of_ideal_zero, lower_central_series_zero],
     exact le_rfl, },
-  { have h' : derived_series R L k ≤ ⊤, { by simp only [le_top], },
+  { have h' : derived_series R L k ≤ ⊤, { simp only [le_top], },
     rw [derived_series_def, derived_series_of_ideal_succ, lower_central_series_succ],
     exact lie_submodule.mono_lie _ _ _ _ h' h, },
 end
@@ -536,7 +536,7 @@ f.surjective_range_restrict.lie_algebra_is_nilpotent
   is_nilpotent R (ad R L).range ↔ is_nilpotent R L :=
 begin
   refine ⟨λ h, _, _⟩,
-  { have : (ad R L).ker = center R L, { by simp, },
+  { have : (ad R L).ker = center R L, { simp, },
     exact lie_algebra.nilpotent_of_nilpotent_quotient (le_of_eq this)
       ((ad R L).quot_ker_equiv_range.nilpotent_iff_equiv_nilpotent.mpr h), },
   { introsI h,

--- a/src/category_theory/adjunction/whiskering.lean
+++ b/src/category_theory/adjunction/whiskering.lean
@@ -53,7 +53,7 @@ mk_of_unit_counit
   counit :=
   { app := λ X, (functor.associator _ _ _).inv ≫
       whisker_right adj.counit X ≫ (functor.left_unitor _).hom,
-    naturality' := by by { intros, ext, dsimp, simp } },
+    naturality' := by { intros, ext, dsimp, simp } },
   left_triangle' := by { ext x, dsimp,
     simp only [category.id_comp, category.comp_id, ← x.map_comp], simp },
   right_triangle' :=  by { ext x, dsimp,

--- a/src/data/polynomial/div.lean
+++ b/src/data/polynomial/div.lean
@@ -256,11 +256,7 @@ end
 theorem nat_degree_div_by_monic {R : Type u} [comm_ring R] (f : R[X]) {g : R[X]}
   (hg : g.monic) : nat_degree (f /ₘ g) = nat_degree f - nat_degree g :=
 begin
-  by_cases h01 : (0 : R) = 1,
-  { haveI := subsingleton_of_zero_eq_one h01,
-    rw [subsingleton.elim (f /ₘ g) 0, subsingleton.elim f 0, subsingleton.elim g 0,
-        nat_degree_zero] },
-  haveI : nontrivial R := ⟨⟨0, 1, h01⟩⟩,
+  nontriviality R,
   by_cases hfg : f /ₘ g = 0,
   { rw [hfg, nat_degree_zero], rw div_by_monic_eq_zero_iff hg at hfg,
     rw tsub_eq_zero_iff_le.mpr (nat_degree_le_nat_degree $ le_of_lt hfg) },

--- a/src/data/polynomial/monic.lean
+++ b/src/data/polynomial/monic.lean
@@ -44,18 +44,15 @@ begin
 end
 
 lemma monic.map [semiring S] (f : R →+* S) (hp : monic p) : monic (p.map f) :=
-if h : (0 : S) = 1 then
-  by haveI := subsingleton_of_zero_eq_one h;
-  exact subsingleton.elim _ _
-else
-have f (leading_coeff p) ≠ 0,
-  by rwa [show _ = _, from hp, f.map_one, ne.def, eq_comm],
-by
 begin
+  nontriviality,
+  have : f (leading_coeff p) ≠ 0,
+  { rw [show _ = _, from hp, f.map_one],
+    exact one_ne_zero, },
   rw [monic, leading_coeff, coeff_map],
-  suffices : p.coeff (map f p).nat_degree = 1, simp [this],
-  suffices : (map f p).nat_degree = p.nat_degree, rw this, exact hp,
-  rwa nat_degree_eq_of_degree_eq (degree_map_eq_of_leading_coeff_ne_zero f _)
+  suffices : p.coeff (map f p).nat_degree = 1,
+  { simp [this], },
+  rwa nat_degree_eq_of_degree_eq (degree_map_eq_of_leading_coeff_ne_zero f this),
 end
 
 lemma monic_C_mul_of_mul_leading_coeff_eq_one {b : R} (hp : b * p.leading_coeff = 1) :

--- a/src/field_theory/separable.lean
+++ b/src/field_theory/separable.lean
@@ -540,7 +540,7 @@ begin
   rw or_iff_not_imp_right,
   rintro hn : n ≠ 0,
   have hf2 : (expand F (p ^ n) f).derivative = 0,
-  { by rw [derivative_expand, nat.cast_pow, char_p.cast_eq_zero,
+  { rw [derivative_expand, nat.cast_pow, char_p.cast_eq_zero,
       zero_pow hn.bot_lt, zero_mul, mul_zero] },
   rw [separable_def, hf2, is_coprime_zero_right, is_unit_iff] at hf,
   rcases hf with ⟨r, hr, hrf⟩,

--- a/src/group_theory/exponent.lean
+++ b/src/group_theory/exponent.lean
@@ -73,7 +73,7 @@ begin
 end
 
 @[to_additive]
-lemma exponent_eq_zero_iff : exponent G = 0 ↔ ¬ exponent_exists G := 
+lemma exponent_eq_zero_iff : exponent G = 0 ↔ ¬ exponent_exists G :=
 by simp only [exponent_exists_iff_ne_zero, not_not]
 
 @[to_additive]
@@ -175,7 +175,7 @@ begin
   rw ← finsupp.mem_support_iff at h,
   obtain ⟨g, hg⟩ : ∃ (g : G), g ^ (exponent G / p) ≠ 1,
   { suffices key : ¬ exponent G ∣ exponent G / p,
-    { by simpa using mt (exponent_dvd_of_forall_pow_eq_one G (exponent G / p)) key },
+    { simpa using mt (exponent_dvd_of_forall_pow_eq_one G (exponent G / p)) key },
     exact λ hd, hp.one_lt.not_le ((mul_le_iff_le_one_left he).mp $
                 nat.le_of_dvd he $ nat.mul_dvd_of_dvd_div (nat.dvd_of_mem_factorization h) hd) },
   obtain ⟨k, hk : exponent G = p ^ _ * k⟩ := nat.pow_factorization_dvd _ _,

--- a/src/linear_algebra/affine_space/affine_subspace.lean
+++ b/src/linear_algebra/affine_space/affine_subspace.lean
@@ -1217,7 +1217,7 @@ def map (s : affine_subspace k P₁) : affine_subspace k P₂ :=
     begin
       rintros t - - - ⟨p₁, h₁, rfl⟩ ⟨p₂, h₂, rfl⟩ ⟨p₃, h₃, rfl⟩,
       use t • (p₁ -ᵥ p₂) +ᵥ p₃,
-      suffices : t • (p₁ -ᵥ p₂) +ᵥ p₃ ∈ s, { by simp [this], },
+      suffices : t • (p₁ -ᵥ p₂) +ᵥ p₃ ∈ s, { simp [this], },
       exact s.smul_vsub_vadd_mem t h₁ h₂ h₃,
     end }
 

--- a/src/linear_algebra/affine_space/independent.lean
+++ b/src/linear_algebra/affine_space/independent.lean
@@ -519,7 +519,7 @@ begin
     rwa ← (equiv.vadd_const p).subset_image' b s, },
   { rw [equiv.coe_vadd_const_symm, ← vector_span_eq_span_vsub_set_right k hp] at hb₂,
     apply affine_subspace.ext_of_direction_eq,
-    { have : submodule.span k b = submodule.span k (insert 0 b), { by simp, },
+    { have : submodule.span k b = submodule.span k (insert 0 b), { simp, },
       simp only [direction_affine_span, ← hb₂, equiv.coe_vadd_const, set.singleton_union,
         vector_span_eq_span_vsub_set_right k (set.mem_insert p _), this],
       congr,

--- a/src/measure_theory/function/simple_func_dense.lean
+++ b/src/measure_theory/function/simple_func_dense.lean
@@ -625,7 +625,7 @@ protected lemma ae_measurable (f : Lp.simple_func E p μ) : ae_measurable (to_si
 (simple_func.measurable f).ae_measurable
 
 lemma to_simple_func_eq_to_fun (f : Lp.simple_func E p μ) : to_simple_func f =ᵐ[μ] f :=
-show ⇑(to_simple_func f) =ᵐ[μ] ⇑(f : α →ₘ[μ] E), by
+show ⇑(to_simple_func f) =ᵐ[μ] ⇑(f : α →ₘ[μ] E),
 begin
   convert (ae_eq_fun.coe_fn_mk (to_simple_func f) (simple_func.ae_measurable f)).symm using 2,
   exact (classical.some_spec f.2).symm,

--- a/src/number_theory/padics/padic_norm.lean
+++ b/src/number_theory/padics/padic_norm.lean
@@ -442,12 +442,12 @@ end
 lemma pow_succ_padic_val_nat_not_dvd {p n : ℕ} [hp : fact (nat.prime p)] (hn : 0 < n) :
   ¬ p ^ (padic_val_nat p n + 1) ∣ n :=
 begin
-  { rw multiplicity.pow_dvd_iff_le_multiplicity,
-    rw padic_val_nat_def (ne_of_gt hn),
-    { rw [nat.cast_add, enat.coe_get],
-      simp only [nat.cast_one, not_le],
-      apply enat.lt_add_one (ne_top_iff_finite.2 (finite_nat_iff.2 ⟨hp.elim.ne_one, hn⟩)) },
-    { apply_instance } }
+  rw multiplicity.pow_dvd_iff_le_multiplicity,
+  rw padic_val_nat_def (ne_of_gt hn),
+  { rw [nat.cast_add, enat.coe_get],
+    simp only [nat.cast_one, not_le],
+    apply enat.lt_add_one (ne_top_iff_finite.2 (finite_nat_iff.2 ⟨hp.elim.ne_one, hn⟩)) },
+  { apply_instance }
 end
 
 lemma padic_val_nat_primes {p q : ℕ} [p_prime : fact p.prime] [q_prime : fact q.prime]

--- a/src/order/filter/ennreal.lean
+++ b/src/order/filter/ennreal.lean
@@ -67,7 +67,7 @@ begin
       (λ _ _ _, by rwa mul_le_mul_left ha_zero ha_top) hg_bij.1,
   let g_iso := strict_mono.order_iso_of_surjective g hg_mono hg_bij.2,
   refine (order_iso.limsup_apply g_iso _ _ _ _).symm,
-  all_goals { by is_bounded_default },
+  all_goals { is_bounded_default },
 end
 
 lemma limsup_const_mul [countable_Inter_filter f] {u : α → ℝ≥0∞} {a : ℝ≥0∞} :

--- a/src/order/jordan_holder.lean
+++ b/src/order/jordan_holder.lean
@@ -375,15 +375,15 @@ by simp [erase_top, top, s.strict_mono.le_iff_le, fin.le_iff_coe_le_coe, tsub_le
 lemma mem_erase_top_of_ne_of_mem {s : composition_series X} {x : X}
   (hx : x ≠ s.top) (hxs : x ∈ s) : x ∈ s.erase_top :=
 begin
-  { rcases hxs with ⟨i, rfl⟩,
-    have hi : (i : ℕ) < (s.length - 1).succ,
-    { conv_rhs { rw [← nat.succ_sub (length_pos_of_mem_ne ⟨i, rfl⟩ s.top_mem hx),
-        nat.succ_sub_one] },
-      exact lt_of_le_of_ne
-        (nat.le_of_lt_succ i.2)
-        (by simpa [top, s.inj, fin.ext_iff] using hx) },
-    refine ⟨i.cast_succ, _⟩,
-    simp [fin.ext_iff, nat.mod_eq_of_lt hi] }
+  rcases hxs with ⟨i, rfl⟩,
+  have hi : (i : ℕ) < (s.length - 1).succ,
+  { conv_rhs { rw [← nat.succ_sub (length_pos_of_mem_ne ⟨i, rfl⟩ s.top_mem hx),
+      nat.succ_sub_one] },
+    exact lt_of_le_of_ne
+      (nat.le_of_lt_succ i.2)
+      (by simpa [top, s.inj, fin.ext_iff] using hx) },
+  refine ⟨i.cast_succ, _⟩,
+  simp [fin.ext_iff, nat.mod_eq_of_lt hi]
 end
 
 lemma mem_erase_top {s : composition_series X} {x : X}

--- a/src/topology/metric_space/gromov_hausdorff_realized.lean
+++ b/src/topology/metric_space/gromov_hausdorff_realized.lean
@@ -376,7 +376,7 @@ begin
   have E2 : (⨆ x, ⨅ y, g (inl x, inr y)) + dist f g = ⨆ x, (⨅ y, g (inl x, inr y)) + dist f g,
   { refine map_csupr_of_continuous_at_of_monotone (continuous_at_id.add continuous_at_const) _ _,
     { assume x y hx, simpa },
-    { by simpa using HD_bound_aux1 _ 0 } },
+    { simpa using HD_bound_aux1 _ 0 } },
   -- deduce the result from the above two steps
   simpa [E2, E1, function.comp]
 end
@@ -405,7 +405,7 @@ begin
   have E2 : (⨆ y, ⨅ x, g (inl x, inr y)) + dist f g = ⨆ y, (⨅ x, g (inl x, inr y)) + dist f g,
   { refine map_csupr_of_continuous_at_of_monotone (continuous_at_id.add continuous_at_const) _ _,
     { assume x y hx, simpa },
-    { by simpa using HD_bound_aux2 _ 0 } },
+    { simpa using HD_bound_aux2 _ 0 } },
   -- deduce the result from the above two steps
   simpa [E2, E1]
 end


### PR DESCRIPTION
Delete some `by` (and similar commands that do nothing, such as
- `by by blah`
- `by begin blah end`
- `{ by blah }`
- `begin { blah } end`

Also clean up the proof of `monic.map` and `nat_degree_div_by_monic` a bit.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
