### PR TITLE
[Merged by Bors] - docs(algebra/*): Add docstrings to additive lemmas

### DIFF
--- a/src/algebra/big_operators/basic.lean
+++ b/src/algebra/big_operators/basic.lean
@@ -766,13 +766,15 @@ end
   (∏ x in s, (ite (a = x) (b x) 1)) = ite (a ∈ s) (b a) 1 :=
 prod_dite_eq s a (λ x _, b x)
 
-/--
-  When a product is taken over a conditional whose condition is an equality test on the index
-  and whose alternative is 1, then the product's value is either the term at that index or `1`.
+/-- A product taken over a conditional whose condition is an equality test on the index and whose
+alternative is `1` has value either the term at that index or `1`.
 
-  The difference with `prod_ite_eq` is that the arguments to `eq` are swapped.
--/
-@[simp, to_additive] lemma prod_ite_eq' [decidable_eq α] (s : finset α) (a : α) (b : α → β) :
+The difference with `finset.prod_ite_eq` is that the arguments to `eq` are swapped. -/
+@[simp, to_additive "A sum taken over a conditional whose condition is an equality test on the index
+and whose alternative is `0` has value either the term at that index or `0`.
+
+The difference with `finset.sum_ite_eq` is that the arguments to `eq` are swapped."]
+lemma prod_ite_eq' [decidable_eq α] (s : finset α) (a : α) (b : α → β) :
   (∏ x in s, (ite (x = a) (b x) 1)) = ite (a ∈ s) (b a) 1 :=
 prod_dite_eq' s a (λ x _, b x)
 
@@ -991,7 +993,7 @@ lemma sum_range_induction {M : Type*} [add_comm_monoid M]
   ∑ k in finset.range n, f k = s n :=
 @prod_range_induction (multiplicative M) _ f s h0 h n
 
-/-- A telescoping sum along `{0, ..., n-1}` of an additive commutative group valued function
+/-- A telescoping sum along `{0, ..., n - 1}` of an additive commutative group valued function
 reduces to the difference of the last and first terms.-/
 lemma sum_range_sub {G : Type*} [add_comm_group G] (f : ℕ → G) (n : ℕ) :
   ∑ i in range n, (f (i+1) - f i) = f n - f 0 :=
@@ -1001,16 +1003,16 @@ lemma sum_range_sub' {G : Type*} [add_comm_group G] (f : ℕ → G) (n : ℕ) :
   ∑ i in range n, (f i - f (i+1)) = f 0 - f n :=
 by { apply sum_range_induction; simp }
 
-/-- A telescoping product along `{0, ..., n-1}` of a commutative group valued function
-reduces to the ratio of the last and first factors.-/
-@[to_additive]
+/-- A telescoping product along `{0, ..., n - 1}` of a commutative group valued function reduces to
+the ratio of the last and first factors. -/
+@[to_additiv]
 lemma prod_range_div {M : Type*} [comm_group M] (f : ℕ → M) (n : ℕ) :
   ∏ i in range n, (f (i+1) * (f i)⁻¹) = f n * (f 0)⁻¹ :=
 by simpa only [← div_eq_mul_inv] using @sum_range_sub (additive M) _ f n
 
 @[to_additive]
 lemma prod_range_div' {M : Type*} [comm_group M] (f : ℕ → M) (n : ℕ) :
-  ∏ i in range n, (f i * (f (i+1))⁻¹) = (f 0) * (f n)⁻¹ :=
+  ∏ i in range n, (f i * (f (i+1))⁻¹) = f 0 * (f n)⁻¹ :=
 by simpa only [← div_eq_mul_inv] using @sum_range_sub' (additive M) _ f n
 
 /--
@@ -1092,9 +1094,10 @@ finset.strong_induction_on s
         prod_insert (not_mem_erase _ _), ih', mul_one, h x hx]))
 
 
-/-- The product of the composition of functions `f` and `g`, is the product
-over `b ∈ s.image g` of `f b` to the power of the cardinality of the fibre of `b`. See also
-`finset.prod_image`. -/
+/-- The product of the composition of functions `f` and `g`, is the product over `b ∈ s.image g` of
+`f b` to the power of the cardinality of the fibre of `b`. See also `finset.prod_image`. -/
+@[to_additive "The sum of the composition of functions `f` and `g`, is the sum over `b ∈ s.image g`
+of `f b` times of the cardinality of the fibre of `b`. See also `finset.sum_image`."]
 lemma prod_comp [decidable_eq γ] (f : γ → β) (g : α → γ) :
   ∏ a in s, f (g a) = ∏ b in s.image g, f b ^ (s.filter (λ a, g a = b)).card  :=
 calc ∏ a in s, f (g a)
@@ -1290,13 +1293,6 @@ end
 lemma sum_boole {s : finset α} {p : α → Prop} [non_assoc_semiring β] {hp : decidable_pred p} :
   (∑ x in s, if p x then (1 : β) else (0 : β)) = (s.filter p).card :=
 by simp [sum_ite]
-
-lemma sum_comp [add_comm_monoid β] [decidable_eq γ] (f : γ → β) (g : α → γ) :
-  ∑ a in s, f (g a) = ∑ b in s.image g, (s.filter (λ a, g a = b)).card • (f b) :=
-@prod_comp (multiplicative β) _ _ _ _ _ _ _
-attribute [to_additive "The sum of the composition of functions `f` and `g`, is the sum
-over `b ∈ s.image g` of `f b` times of the cardinality of the fibre of `b`. See also
-`finset.sum_image`."] prod_comp
 
 lemma eq_sum_range_sub [add_comm_group β] (f : ℕ → β) (n : ℕ) :
   f n = f 0 + ∑ i in range n, (f (i+1) - f i) :=

--- a/src/algebra/big_operators/basic.lean
+++ b/src/algebra/big_operators/basic.lean
@@ -1005,7 +1005,7 @@ by { apply sum_range_induction; simp }
 
 /-- A telescoping product along `{0, ..., n - 1}` of a commutative group valued function reduces to
 the ratio of the last and first factors. -/
-@[to_additiv]
+@[to_additive]
 lemma prod_range_div {M : Type*} [comm_group M] (f : ℕ → M) (n : ℕ) :
   ∏ i in range n, (f (i+1) * (f i)⁻¹) = f n * (f 0)⁻¹ :=
 by simpa only [← div_eq_mul_inv] using @sum_range_sub (additive M) _ f n

--- a/src/algebra/big_operators/finprod.lean
+++ b/src/algebra/big_operators/finprod.lean
@@ -222,9 +222,9 @@ g.map_finprod_of_preimage_one (λ x, (hg.eq_iff' g.map_one).mp) f
   g (∏ᶠ i, f i) = ∏ᶠ i, g (f i) :=
 g.to_monoid_hom.map_finprod_of_injective g.injective f
 
-lemma finsum_smul {R M : Type*} [ring R] [add_comm_group M] [module R M]
-  [no_zero_smul_divisors R M] (f : ι → R) (x : M) :
-  (∑ᶠ i, f i) • x = (∑ᶠ i, (f i) • x) :=
+lemma finsum_smul {R M : Type*} [ring R] [add_comm_group M] [module R M] [no_zero_smul_divisors R M]
+  (f : ι → R) (x : M) :
+  (∑ᶠ i, f i) • x = ∑ᶠ i, f i • x :=
 begin
   rcases eq_or_ne x 0 with rfl|hx, { simp },
   exact ((smul_add_hom R M).flip x).map_finsum_of_injective (smul_left_injective R hx) _
@@ -414,9 +414,12 @@ by simp [h] {contextual := tt}
 ### Distributivity w.r.t. addition, subtraction, and (scalar) multiplication
 -/
 
-@[to_additive]
+/-- If the multiplicative supports of `f` and `g` are finite, then the product of `f i * g i` equals
+the product of `f i` multiplied by the product of `g i`. -/
+@[to_additive "If the additive supports of `f` and `g` are finite, then the sum of `f i + g i`
+equals the sum of `f i` plus the sum of `g i`."]
 lemma finprod_mul_distrib (hf : (mul_support f).finite) (hg : (mul_support g).finite) :
-  ∏ᶠ i, (f i * g i) = (∏ᶠ i, f i) * ∏ᶠ i, g i :=
+  ∏ᶠ i, f i * g i = (∏ᶠ i, f i) * ∏ᶠ i, g i :=
 begin
   classical,
   rw [finprod_eq_prod_of_mul_support_to_finset_subset _ hf (finset.subset_union_left _ _),
@@ -426,7 +429,10 @@ begin
   simp [mul_support_mul]
 end
 
-@[to_additive]
+/-- If the multiplicative supports of `f` and `g` are finite, then the product of `f i / g i`
+equals the product of `f i` divided by the product of `g i`. -/
+@[to_additive "If the additive supports of `f` and `g` are finite, then the sum of `f i - g i`
+equals the sum of `f i` minus the sum of `g i`."]
 lemma finprod_div_distrib {G : Type*} [comm_group G] {f g : α → G} (hf : (mul_support f).finite)
   (hg : (mul_support g).finite) :
   ∏ᶠ i, f i / g i = (∏ᶠ i, f i) / ∏ᶠ i, g i :=
@@ -444,25 +450,37 @@ by simp only [div_eq_mul_inv, finprod_mul_distrib hf ((mul_support_inv₀ g).sym
 @[to_additive "A more general version of `finsum_mem_add_distrib` that only requires `s ∩ support f`
 and `s ∩ support g` rather than `s` to be finite."]
 lemma finprod_mem_mul_distrib' (hf : (s ∩ mul_support f).finite) (hg : (s ∩ mul_support g).finite) :
-  ∏ᶠ i ∈ s, (f i * g i) = (∏ᶠ i ∈ s, f i) * ∏ᶠ i ∈ s, g i :=
+  ∏ᶠ i ∈ s, f i * g i = (∏ᶠ i ∈ s, f i) * ∏ᶠ i ∈ s, g i :=
 begin
   rw [← mul_support_mul_indicator] at hf hg,
   simp only [finprod_mem_def, mul_indicator_mul, finprod_mul_distrib hf hg]
 end
 
-@[to_additive] lemma finprod_mem_one (s : set α) : ∏ᶠ i ∈ s, (1 : M) = 1 := by simp
+/-- The product of the constant function `1` over any set equals `1`. -/
+@[to_additive "The product of the constant function `0` over any set equals `0`."]
+lemma finprod_mem_one (s : set α) : ∏ᶠ i ∈ s, (1 : M) = 1 := by simp
 
-@[to_additive] lemma finprod_mem_of_eq_on_one (hf : s.eq_on f 1) : ∏ᶠ i ∈ s, f i = 1 :=
+/-- If a function `f` equals `1` on a set `s`, then the product of `f i` over `i ∈ s` equals `1`. -/
+@[to_additive "If a function `f` equals `0` on a set `s`, then the product of `f i` over `i ∈ s`
+equals `0`."]
+lemma finprod_mem_of_eq_on_one (hf : s.eq_on f 1) : ∏ᶠ i ∈ s, f i = 1 :=
 by { rw ← finprod_mem_one s, exact finprod_mem_congr rfl hf }
 
-@[to_additive]
+/-- If the product of `f i` over `i ∈ s` is not equal to `1`, then there is some `x ∈ s` such that
+`f x ≠ 1`. -/
+@[to_additive "If the product of `f i` over `i ∈ s` is not equal to `0`, then there is some `x ∈ s`
+such that `f x ≠ 0`."]
 lemma exists_ne_one_of_finprod_mem_ne_one (h : ∏ᶠ i ∈ s, f i ≠ 1) : ∃ x ∈ s, f x ≠ 1 :=
 begin
   by_contra' h',
   exact h (finprod_mem_of_eq_on_one h')
 end
 
-@[to_additive] lemma finprod_mem_mul_distrib (hs : s.finite) :
+/-- Given a finite set `s`, the product of `f i * g i` over `i ∈ s` equals the product of `f i`
+over `i ∈ s` times the product of `g i` over `i ∈ s`. -/
+@[to_additive "Given a finite set `s`, the sum of `f i + g i` over `i ∈ s` equals the sum of `f i`
+over `i ∈ s` plus the sum of `g i` over `i ∈ s`."]
+lemma finprod_mem_mul_distrib (hs : s.finite) :
   ∏ᶠ i ∈ s, f i * g i = (∏ᶠ i ∈ s, f i) * ∏ᶠ i ∈ s, g i :=
 finprod_mem_mul_distrib' (hs.inter_of_left _) (hs.inter_of_left _)
 
@@ -474,16 +492,19 @@ g.map_finprod_plift f $ hf.preimage $ equiv.plift.injective.inj_on _
 than `s` to be finite. -/
 @[to_additive "A more general version of `add_monoid_hom.map_finsum_mem` that requires
 `s ∩ support f` rather than `s` to be finite."]
-lemma monoid_hom.map_finprod_mem' {f : α → M} (g : M →* N)
-  (h₀ : (s ∩ mul_support f).finite) :
-  g (∏ᶠ j ∈ s, f j) = ∏ᶠ i ∈ s, (g (f i)) :=
+lemma monoid_hom.map_finprod_mem' {f : α → M} (g : M →* N) (h₀ : (s ∩ mul_support f).finite) :
+  g (∏ᶠ j ∈ s, f j) = ∏ᶠ i ∈ s, g (f i) :=
 begin
   rw [g.map_finprod],
   { simp only [g.map_finprod_Prop] },
   { simpa only [finprod_eq_mul_indicator_apply, mul_support_mul_indicator] }
 end
 
-@[to_additive] lemma monoid_hom.map_finprod_mem (f : α → M) (g : M →* N) (hs : s.finite) :
+/-- Given a monoid homomorphism `g : M →* N` and a function `f : α → M`, the value of `g` at the
+product of `f i` over `i ∈ s` equals the product of `g (f i)` over `s`. -/
+@[to_additive "Given an additive monoid homomorphism `g : M →* N` and a function `f : α → M`, the
+value of `g` at the sum of `f i` over `i ∈ s` equals the sum of `g (f i)` over `s`."]
+lemma monoid_hom.map_finprod_mem (f : α → M) (g : M →* N) (hs : s.finite) :
   g (∏ᶠ j ∈ s, f j) = ∏ᶠ i ∈ s, g (f i) :=
 g.map_finprod_mem' (hs.inter_of_left _)
 
@@ -499,7 +520,10 @@ lemma finprod_mem_inv_distrib₀ {G : Type*} [comm_group_with_zero G] (f : α �
   (hs : s.finite) : ∏ᶠ x ∈ s, (f x)⁻¹ = (∏ᶠ x ∈ s, f x)⁻¹ :=
 ((mul_equiv.inv₀ G).map_finprod_mem f hs).symm
 
-@[to_additive]
+/-- Given a finite set `s`, the product of `f i / g i` over `i ∈ s` equals the product of `f i`
+over `i ∈ s` divided by the product of `g i` over `i ∈ s`. -/
+@[to_additive "Given a finite set `s`, the sum of `f i / g i` over `i ∈ s` equals the sum of `f i`
+over `i ∈ s` minus the sum of `g i` over `i ∈ s`."]
 lemma finprod_mem_div_distrib {G : Type*} [comm_group G] (f g : α → G) (hs : s.finite) :
   ∏ᶠ i ∈ s, f i / g i = (∏ᶠ i ∈ s, f i) / ∏ᶠ i ∈ s, g i :=
 by simp only [div_eq_mul_inv, finprod_mem_mul_distrib hs, finprod_mem_inv_distrib g hs]
@@ -512,14 +536,21 @@ by simp only [div_eq_mul_inv, finprod_mem_mul_distrib hs, finprod_mem_inv_distri
 ### `∏ᶠ x ∈ s, f x` and set operations
 -/
 
-@[to_additive] lemma finprod_mem_empty : ∏ᶠ i ∈ (∅ : set α), f i = 1 := by simp
+/-- The product of any function over an empty set is `1`. -/
+@[to_additive "The sum of any function over an empty set is `0`."]
+lemma finprod_mem_empty : ∏ᶠ i ∈ (∅ : set α), f i = 1 := by simp
 
 /-- A set `s` is nonempty if the product of some function over `s` is not equal to `1`. -/
 @[to_additive "A set `s` is nonempty if the sum of some function over `s` is not equal to `0`."]
 lemma nonempty_of_finprod_mem_ne_one (h : ∏ᶠ i ∈ s, f i ≠ 1) : s.nonempty :=
 ne_empty_iff_nonempty.1 $ λ h', h $ h'.symm ▸ finprod_mem_empty
 
-@[to_additive] lemma finprod_mem_union_inter (hs : s.finite) (ht : t.finite) :
+/-- Given finite sets `s` and `t`, the product of `f i` over `i ∈ s ∪ t` times the product of
+`f i` over `i ∈ s ∩ t` equals the product of `f i` over `i ∈ s` times the product of `f i`
+over `i ∈ t`. -/
+@[to_additive "Given finite sets `s` and `t`, the sum of `f i` over `i ∈ s ∪ t` plus the sum of
+`f i` over `i ∈ s ∩ t` equals the sum of `f i` over `i ∈ s` plus the sum of `f i` over `i ∈ t`."]
+lemma finprod_mem_union_inter (hs : s.finite) (ht : t.finite) :
   (∏ᶠ i ∈ s ∪ t, f i) * ∏ᶠ i ∈ s ∩ t, f i = (∏ᶠ i ∈ s, f i) * ∏ᶠ i ∈ t, f i :=
 begin
   lift s to finset α using hs, lift t to finset α using ht,
@@ -552,7 +583,11 @@ lemma finprod_mem_union' (hst : disjoint s t) (hs : (s ∩ mul_support f).finite
 by rw [← finprod_mem_union_inter' hs ht, disjoint_iff_inter_eq_empty.1 hst, finprod_mem_empty,
   mul_one]
 
-@[to_additive] lemma finprod_mem_union (hst : disjoint s t) (hs : s.finite) (ht : t.finite) :
+/-- Given two finite disjoint sets `s` and `t`, the product of `f i` over `i ∈ s ∪ t` equals the
+product of `f i` over `i ∈ s` times the product of `f i` over `i ∈ t`. -/
+@[to_additive "Given two finite disjoint sets `s` and `t`, the sum of `f i` over `i ∈ s ∪ t` equals
+the sum of `f i` over `i ∈ s` plus the sum of `f i` over `i ∈ t`."]
+lemma finprod_mem_union (hst : disjoint s t) (hs : s.finite) (ht : t.finite) :
   ∏ᶠ i ∈ s ∪ t, f i = (∏ᶠ i ∈ s, f i) * ∏ᶠ i ∈ t, f i :=
 finprod_mem_union' hst (hs.inter_of_left _) (ht.inter_of_left _)
 
@@ -566,7 +601,9 @@ lemma finprod_mem_union'' (hst : disjoint (s ∩ mul_support f) (t ∩ mul_suppo
 by rw [← finprod_mem_inter_mul_support f s, ← finprod_mem_inter_mul_support f t,
   ← finprod_mem_union hst hs ht, ← union_inter_distrib_right, finprod_mem_inter_mul_support]
 
-@[to_additive] lemma finprod_mem_singleton : ∏ᶠ i ∈ ({a} : set α), f i = f a :=
+/-- The product of `f i` over `i ∈ {a}` equals `f a`. -/
+@[to_additive "The sum of `f i` over `i ∈ {a}` equals `f a`."]
+lemma finprod_mem_singleton : ∏ᶠ i ∈ ({a} : set α), f i = f a :=
 by rw [← finset.coe_singleton, finprod_mem_coe_finset, finset.prod_singleton]
 
 @[simp, to_additive] lemma finprod_cond_eq_left : ∏ᶠ i = a, f i = f a :=
@@ -587,22 +624,35 @@ begin
   { exact (finite_singleton a).inter_of_left _ }
 end
 
-@[to_additive] lemma finprod_mem_insert (f : α → M) (h : a ∉ s) (hs : s.finite) :
+/-- Given a finite set `s` and an element `a ∉ s`, the product of `f i` over `i ∈ insert a s` equals
+`f a` times the product of `f i` over `i ∈ s`. -/
+@[to_additive "Given a finite set `s` and an element `a ∉ s`, the sum of `f i` over `i ∈ insert a s`
+equals `f a` plus the sum of `f i` over `i ∈ s`."]
+lemma finprod_mem_insert (f : α → M) (h : a ∉ s) (hs : s.finite) :
   ∏ᶠ i ∈ insert a s, f i = f a * ∏ᶠ i ∈ s, f i :=
 finprod_mem_insert' f h $ hs.inter_of_left _
 
-@[to_additive] lemma finprod_mem_insert_of_eq_one_if_not_mem (h : a ∉ s → f a = 1) :
-  ∏ᶠ i ∈ (insert a s), f i = ∏ᶠ i ∈ s, f i :=
+/-- If `f a = 1` when `a ∉ s`, then the product of `f i` over `i ∈ insert a s` equals the product of
+`f i` over `i ∈ s`. -/
+@[to_additive "If `f a = 0` when `a ∉ s`, then the sum of `f i` over `i ∈ insert a s` equals the sum
+of `f i` over `i ∈ s`."]
+lemma finprod_mem_insert_of_eq_one_if_not_mem (h : a ∉ s → f a = 1) :
+  ∏ᶠ i ∈ insert a s, f i = ∏ᶠ i ∈ s, f i :=
 begin
   refine finprod_mem_inter_mul_support_eq' _ _ _ (λ x hx, ⟨_, or.inr⟩),
   rintro (rfl|hxs),
   exacts [not_imp_comm.1 h hx, hxs]
 end
 
-@[to_additive] lemma finprod_mem_insert_one (h : f a = 1) :
-  ∏ᶠ i ∈ (insert a s), f i = ∏ᶠ i ∈ s, f i :=
+/-- If `f a = 1`, then the product of `f i` over `i ∈ insert a s` equals the product of `f i` over
+`i ∈ s`. -/
+@[to_additive "If `f a = 0`, then the sum of `f i` over `i ∈ insert a s` equals the sum of `f i`
+over `i ∈ s`."]
+lemma finprod_mem_insert_one (h : f a = 1) : ∏ᶠ i ∈ insert a s, f i = ∏ᶠ i ∈ s, f i :=
 finprod_mem_insert_of_eq_one_if_not_mem (λ _, h)
 
+/-- If the multiplicative support of `f` is finite, then for every `x` in the domain of `f`, `f x`
+divides `finprod f`.  -/
 lemma finprod_mem_dvd {f : α → N} (a : α) (hf : (mul_support f).finite) : f a ∣ finprod f :=
 begin
   by_cases ha : a ∈ mul_support f,
@@ -612,10 +662,15 @@ begin
     exact one_dvd (finprod f) }
 end
 
-@[to_additive] lemma finprod_mem_pair (h : a ≠ b) : ∏ᶠ i ∈ ({a, b} : set α), f i = f a * f b :=
+/-- The product of `f i` over `i ∈ {a, b}`, `a ≠ b`, is equal to `f a * f b`. -/
+@[to_additive "The sum of `f i` over `i ∈ {a, b}`, `a ≠ b`, is equal to `f a + f b`."]
+lemma finprod_mem_pair (h : a ≠ b) : ∏ᶠ i ∈ ({a, b} : set α), f i = f a * f b :=
 by { rw [finprod_mem_insert, finprod_mem_singleton], exacts [h, finite_singleton b] }
 
-@[to_additive]
+/-- The product of `f y` over `y ∈ g '' s` equals the product of `f (g i)` over `s`
+provided that `g` is injective on `s ∩ mul_support (f ∘ g)`. -/
+@[to_additive "The sum of `f y` over `y ∈ g '' s` equals the sum of `f (g i)` over `s` provided that
+`g` is injective on `s ∩ support (f ∘ g)`."]
 lemma finprod_mem_image' {s : set β} {g : β → α} (hg : (s ∩ mul_support (f ∘ g)).inj_on g) :
   ∏ᶠ i ∈ g '' s, f i = ∏ᶠ j ∈ s, f (g j) :=
 begin
@@ -631,25 +686,36 @@ begin
     rwa [image_inter_mul_support_eq, infinite_image_iff hg] }
 end
 
-@[to_additive] lemma finprod_mem_image {s : set β} {g : β → α} (hg : s.inj_on g) :
+/-- The product of `f y` over `y ∈ g '' s` equals the product of `f (g i)` over `s` provided that
+`g` is injective on `s`. -/
+@[to_additive "The sum of `f y` over `y ∈ g '' s` equals the sum of `f (g i)` over `s` provided that
+`g` is injective on `s`."]
+lemma finprod_mem_image {s : set β} {g : β → α} (hg : s.inj_on g) :
   ∏ᶠ i ∈ g '' s, f i = ∏ᶠ j ∈ s, f (g j) :=
 finprod_mem_image' $ hg.mono $ inter_subset_left _ _
 
-@[to_additive] lemma finprod_mem_range' {g : β → α} (hg : (mul_support (f ∘ g)).inj_on g) :
+/-- The product of `f y` over `y ∈ set.range g` equals the product of `f (g i)` over all `i`
+provided that `g` is injective on `mul_support (f ∘ g)`. -/
+@[to_additive "The sum of `f y` over `y ∈ set.range g` equals the sum of `f (g i)` over all `i`
+provided that `g` is injective on `support (f ∘ g)`."]
+lemma finprod_mem_range' {g : β → α} (hg : (mul_support (f ∘ g)).inj_on g) :
   ∏ᶠ i ∈ range g, f i = ∏ᶠ j, f (g j) :=
 begin
   rw [← image_univ, finprod_mem_image', finprod_mem_univ],
   rwa univ_inter
 end
 
-@[to_additive] lemma finprod_mem_range {g : β → α} (hg : injective g) :
-  ∏ᶠ i ∈ range g, f i = ∏ᶠ j, f (g j) :=
+/-- The product of `f y` over `y ∈ set.range g` equals the product of `f (g i)` over all `i`
+provided that `g` is injective. -/
+@[to_additive "The sum of `f y` over `y ∈ set.range g` equals the sum of `f (g i)` over all `i`
+provided that `g` is injective."]
+lemma finprod_mem_range {g : β → α} (hg : injective g) : ∏ᶠ i ∈ range g, f i = ∏ᶠ j, f (g j) :=
 finprod_mem_range' (hg.inj_on _)
 
 /-- See also `finset.prod_bij`. -/
 @[to_additive "See also `finset.sum_bij`."]
-lemma finprod_mem_eq_of_bij_on {s : set α} {t : set β} {f : α → M} {g : β → M}
-  (e : α → β) (he₀ : set.bij_on e s t) (he₁ : ∀ x ∈ s, f x = g (e x)) :
+lemma finprod_mem_eq_of_bij_on {s : set α} {t : set β} {f : α → M} {g : β → M} (e : α → β)
+  (he₀ : s.bij_on e t) (he₁ : ∀ x ∈ s, f x = g (e x)) :
   ∏ᶠ i ∈ s, f i = ∏ᶠ j ∈ t, g j :=
 begin
   rw [← set.bij_on.image_eq he₀, finprod_mem_image he₀.2.1],
@@ -701,11 +767,20 @@ lemma finprod_mem_mul_diff' (hst : s ⊆ t) (ht : (t ∩ mul_support f).finite) 
   (∏ᶠ i ∈ s, f i) * ∏ᶠ i ∈ t \ s, f i = ∏ᶠ i ∈ t, f i :=
 by rw [← finprod_mem_inter_mul_diff' _ ht, inter_eq_self_of_subset_right hst]
 
-@[to_additive] lemma finprod_mem_mul_diff (hst : s ⊆ t) (ht : t.finite) :
+/-- Given a finite set `t` and a subset `s` of `t`, the product of `f i` over `i ∈ s`
+times the product of `f i` over `t \ s` equals the product of `f i` over `i ∈ t`. -/
+@[to_additive "Given a finite set `t` and a subset `s` of `t`, the sum of `f i` over `i ∈ s` plus
+the sum of `f i` over `t \\ s` equals the sum of `f i` over `i ∈ t`."]
+lemma finprod_mem_mul_diff (hst : s ⊆ t) (ht : t.finite) :
   (∏ᶠ i ∈ s, f i) * ∏ᶠ i ∈ t \ s, f i = ∏ᶠ i ∈ t, f i :=
 finprod_mem_mul_diff' hst (ht.inter_of_left _)
 
-@[to_additive]
+/-- Given a family of pairwise disjoint finite sets `t i` indexed by a finite type, the product of
+`f a` over the union `⋃ i, t i` is equal to the product over all indexes `i` of the products of
+`f a` over `a ∈ t i`. -/
+@[to_additive "Given a family of pairwise disjoint finite sets `t i` indexed by a finite type, the
+sum of `f a` over the union `⋃ i, t i` is equal to the sum over all indexes `i` of the sums of `f a`
+over `a ∈ t i`."]
 lemma finprod_mem_Union [fintype ι] {t : ι → set α} (h : pairwise (disjoint on t))
   (ht : ∀ i, (t i).finite) :
   ∏ᶠ a ∈ (⋃ i : ι, t i), f a = ∏ᶠ i, ∏ᶠ a ∈ t i, f a :=
@@ -718,8 +793,16 @@ begin
   { exact λ x _ y _ hxy, finset.disjoint_iff_disjoint_coe.2 (h x y hxy) }
 end
 
-@[to_additive] lemma finprod_mem_bUnion {I : set ι} {t : ι → set α} (h : I.pairwise_disjoint t)
-  (hI : I.finite) (ht : ∀ i ∈ I, (t i).finite) :
+/-- Given a family of sets `t : ι → set α`, a finite set `I` in the index type such that all sets
+`t i`, `i ∈ I`, are finite, if all `t i`, `i ∈ I`, are pairwise disjoint, then the product of `f a`
+over `a ∈ ⋃ i ∈ I, t i` is equal to the product over `i ∈ I` of the products of `f a` over
+`a ∈ t i`. -/
+@[to_additive "Given a family of sets `t : ι → set α`, a finite set `I` in the index type such that
+all sets `t i`, `i ∈ I`, are finite, if all `t i`, `i ∈ I`, are pairwise disjoint, then the sum of
+`f a` over `a ∈ ⋃ i ∈ I, t i` is equal to the sum over `i ∈ I` of the sums of `f a` over
+`a ∈ t i`."]
+lemma finprod_mem_bUnion {I : set ι} {t : ι → set α} (h : I.pairwise_disjoint t) (hI : I.finite)
+  (ht : ∀ i ∈ I, (t i).finite) :
   ∏ᶠ a ∈ ⋃ x ∈ I, t x, f a = ∏ᶠ i ∈ I, ∏ᶠ j ∈ t i, f j :=
 begin
   haveI := hI.fintype,
@@ -727,8 +810,12 @@ begin
   exacts [λ x y hxy, h x.2 y.2 (subtype.coe_injective.ne hxy), λ b, ht b b.2]
 end
 
-@[to_additive] lemma finprod_mem_sUnion {t : set (set α)} (h : t.pairwise_disjoint id)
-  (ht₀ : t.finite) (ht₁ : ∀ x ∈ t, set.finite x) :
+/-- If `t` is a finite set of pairwise disjoint finite sets, then the product of `f a`
+over `a ∈ ⋃₀ t` is the product over `s ∈ t` of the products of `f a` over `a ∈ s`. -/
+@[to_additive "If `t` is a finite set of pairwise disjoint finite sets, then the sum of `f a` over
+`a ∈ ⋃₀ t` is the sum over `s ∈ t` of the sums of `f a` over `a ∈ s`."]
+lemma finprod_mem_sUnion {t : set (set α)} (h : t.pairwise_disjoint id) (ht₀ : t.finite)
+  (ht₁ : ∀ x ∈ t, set.finite x) :
   ∏ᶠ a ∈ ⋃₀ t, f a = ∏ᶠ s ∈ t, ∏ᶠ a ∈ s, f a :=
 by { rw set.sUnion_eq_bUnion, exact finprod_mem_bUnion h ht₀ ht₁ }
 
@@ -749,7 +836,10 @@ begin
     apply finset.prod_erase _ ha, }
 end
 
-@[to_additive]
+/-- If `s : set α` and `t : set β` are finite sets, then taking the product over `s` commutes with
+taking the product over `t`. -/
+@[to_additive "If `s : set α` and `t : set β` are finite sets, then summing over `s` commutes with
+summing over `t`."]
 lemma finprod_mem_comm {s : set α} {t : set β} (f : α → β → M) (hs : s.finite) (ht : t.finite) :
   ∏ᶠ i ∈ s, ∏ᶠ j ∈ t, f i j = ∏ᶠ j ∈ t, ∏ᶠ i ∈ s, f i j :=
 begin

--- a/src/algebra/big_operators/finprod.lean
+++ b/src/algebra/big_operators/finprod.lean
@@ -181,10 +181,6 @@ begin
   exacts [finset.prod_induction _ _ hp₁ hp₀ (λ i hi, hp₂ _), hp₀]
 end
 
-/-- To prove a property of a finite sum, it suffices to prove that the property is
-additive and holds on summands. -/
-add_decl_doc finsum_induction
-
 lemma finprod_nonneg {R : Type*} [ordered_comm_semiring R] {f : α → R} (hf : ∀ x, 0 ≤ f x) :
   0 ≤ ∏ᶠ x, f x :=
 finprod_induction (λ x, 0 ≤ x) zero_le_one (λ x y, mul_nonneg) hf
@@ -418,10 +414,7 @@ by simp [h] {contextual := tt}
 ### Distributivity w.r.t. addition, subtraction, and (scalar) multiplication
 -/
 
-/-- If the multiplicative supports of `f` and `g` are finite, then the product of `f i * g i` equals
-the product of `f i` multiplied by the product of `g i`. -/
-@[to_additive "If the additive supports of `f` and `g` are finite, then the sum of `f i * g i`
-equals the sum of `f i` plus the sum of `g i`."]
+@[to_additive]
 lemma finprod_mul_distrib (hf : (mul_support f).finite) (hg : (mul_support g).finite) :
   ∏ᶠ i, (f i * g i) = (∏ᶠ i, f i) * ∏ᶠ i, g i :=
 begin
@@ -433,10 +426,7 @@ begin
   simp [mul_support_mul]
 end
 
-/-- If the multiplicative supports of `f` and `g` are finite, then the product of `f i / g i`
-equals the product of `f i` divided by the product of `g i`. -/
-@[to_additive "If the additive supports of `f` and `g` are finite, then the sum of `f i - g i`
-equals the sum of `f i` minus the sum of `g i`."]
+@[to_additive]
 lemma finprod_div_distrib {G : Type*} [comm_group G] {f g : α → G} (hf : (mul_support f).finite)
   (hg : (mul_support g).finite) :
   ∏ᶠ i, f i / g i = (∏ᶠ i, f i) / ∏ᶠ i, g i :=
@@ -460,31 +450,19 @@ begin
   simp only [finprod_mem_def, mul_indicator_mul, finprod_mul_distrib hf hg]
 end
 
-/-- The product of the constant function `1` over any set equals `1`. -/
-@[to_additive "The product of the constant function `0` over any set equals `0`."]
-lemma finprod_mem_one (s : set α) : ∏ᶠ i ∈ s, (1 : M) = 1 := by simp
+@[to_additive] lemma finprod_mem_one (s : set α) : ∏ᶠ i ∈ s, (1 : M) = 1 := by simp
 
-/-- If a function `f` equals `1` on a set `s`, then the product of `f i` over `i ∈ s` equals `1`. -/
-@[to_additive "If a function `f` equals `0` on a set `s`, then the product of `f i` over `i ∈ s` equals `0`."]
-lemma finprod_mem_of_eq_on_one (hf : eq_on f 1 s) : ∏ᶠ i ∈ s, f i = 1 :=
+@[to_additive] lemma finprod_mem_of_eq_on_one (hf : s.eq_on f 1) : ∏ᶠ i ∈ s, f i = 1 :=
 by { rw ← finprod_mem_one s, exact finprod_mem_congr rfl hf }
 
-/-- If the product of `f i` over `i ∈ s` is not equal to `1`, then there is some `x ∈ s` such that
-`f x ≠ 1`. -/
-@[to_additive "If the product of `f i` over `i ∈ s` is not equal to `0`, then there is some `x ∈ s`
-such that `f x ≠ 0`."]
-lemma exists_ne_one_of_finprod_mem_ne_one (h : ∏ᶠ i ∈ s, f i ≠ 1) :
-  ∃ x ∈ s, f x ≠ 1 :=
+@[to_additive]
+lemma exists_ne_one_of_finprod_mem_ne_one (h : ∏ᶠ i ∈ s, f i ≠ 1) : ∃ x ∈ s, f x ≠ 1 :=
 begin
   by_contra' h',
   exact h (finprod_mem_of_eq_on_one h')
 end
 
-/-- Given a finite set `s`, the product of `f i * g i` over `i ∈ s` equals the product of `f i`
-over `i ∈ s` times the product of `g i` over `i ∈ s`. -/
-@[to_additive "Given a finite set `s`, the product of `f i * g i` over `i ∈ s` equals the product of
-`f i` over `i ∈ s` times the product of `g i` over `i ∈ s`."]
-lemma finprod_mem_mul_distrib (hs : s.finite) :
+@[to_additive] lemma finprod_mem_mul_distrib (hs : s.finite) :
   ∏ᶠ i ∈ s, f i * g i = (∏ᶠ i ∈ s, f i) * ∏ᶠ i ∈ s, g i :=
 finprod_mem_mul_distrib' (hs.inter_of_left _) (hs.inter_of_left _)
 
@@ -505,11 +483,7 @@ begin
   { simpa only [finprod_eq_mul_indicator_apply, mul_support_mul_indicator] }
 end
 
-/-- Given a monoid homomorphism `g : M →* N` and a function `f : α → M`, the value of `g` at the
-product of `f i` over `i ∈ s` equals the product of `(g ∘ f) i` over `s`. -/
-@[to_additive "Given an additive monoid homomorphism `g : M →* N` and a function `f : α → M`, the
-value of `g` at the sum of `f i` over `i ∈ s` equals the sum of `(g ∘ f) i` over `s`."]
-lemma monoid_hom.map_finprod_mem (f : α → M) (g : M →* N) (hs : s.finite) :
+@[to_additive] lemma monoid_hom.map_finprod_mem (f : α → M) (g : M →* N) (hs : s.finite) :
   g (∏ᶠ j ∈ s, f j) = ∏ᶠ i ∈ s, g (f i) :=
 g.map_finprod_mem' (hs.inter_of_left _)
 
@@ -525,10 +499,7 @@ lemma finprod_mem_inv_distrib₀ {G : Type*} [comm_group_with_zero G] (f : α �
   (hs : s.finite) : ∏ᶠ x ∈ s, (f x)⁻¹ = (∏ᶠ x ∈ s, f x)⁻¹ :=
 ((mul_equiv.inv₀ G).map_finprod_mem f hs).symm
 
-/-- Given a finite set `s`, the product of `f i / g i` over `i ∈ s` equals the product of `f i`
-over `i ∈ s` divided by the product of `g i` over `i ∈ s`. -/
-@[to_additive "Given a finite set `s`, the sum of `f i / g i` over `i ∈ s` equals the sum of `f i`
-over `i ∈ s` minus by the sum of `g i` over `i ∈ s`."]
+@[to_additive]
 lemma finprod_mem_div_distrib {G : Type*} [comm_group G] (f g : α → G) (hs : s.finite) :
   ∏ᶠ i ∈ s, f i / g i = (∏ᶠ i ∈ s, f i) / ∏ᶠ i ∈ s, g i :=
 by simp only [div_eq_mul_inv, finprod_mem_mul_distrib hs, finprod_mem_inv_distrib g hs]
@@ -541,21 +512,14 @@ by simp only [div_eq_mul_inv, finprod_mem_mul_distrib hs, finprod_mem_inv_distri
 ### `∏ᶠ x ∈ s, f x` and set operations
 -/
 
-/-- The product of any function over an empty set is `1`. -/
-@[to_additive "The sum of any function over an empty set is `0`."]
-lemma finprod_mem_empty : ∏ᶠ i ∈ (∅ : set α), f i = 1 := by simp
+@[to_additive] lemma finprod_mem_empty : ∏ᶠ i ∈ (∅ : set α), f i = 1 := by simp
 
 /-- A set `s` is nonempty if the product of some function over `s` is not equal to `1`. -/
 @[to_additive "A set `s` is nonempty if the sum of some function over `s` is not equal to `0`."]
 lemma nonempty_of_finprod_mem_ne_one (h : ∏ᶠ i ∈ s, f i ≠ 1) : s.nonempty :=
 ne_empty_iff_nonempty.1 $ λ h', h $ h'.symm ▸ finprod_mem_empty
 
-/-- Given finite sets `s` and `t`, the product of `f i` over `i ∈ s ∪ t` times the product of
-`f i` over `i ∈ s ∩ t` equals the product of `f i` over `i ∈ s` times the product of `f i`
-over `i ∈ t`. -/
-@[to_additive "Given finite sets `s` and `t`, the sum of `f i` over `i ∈ s ∪ t` plus the sum of
-`f i` over `i ∈ s ∩ t` equals the sum of `f i` over `i ∈ s` plus the sum of `f i` over `i ∈ t`."]
-lemma finprod_mem_union_inter (hs : s.finite) (ht : t.finite) :
+@[to_additive] lemma finprod_mem_union_inter (hs : s.finite) (ht : t.finite) :
   (∏ᶠ i ∈ s ∪ t, f i) * ∏ᶠ i ∈ s ∩ t, f i = (∏ᶠ i ∈ s, f i) * ∏ᶠ i ∈ t, f i :=
 begin
   lift s to finset α using hs, lift t to finset α using ht,
@@ -588,11 +552,7 @@ lemma finprod_mem_union' (hst : disjoint s t) (hs : (s ∩ mul_support f).finite
 by rw [← finprod_mem_union_inter' hs ht, disjoint_iff_inter_eq_empty.1 hst, finprod_mem_empty,
   mul_one]
 
-/-- Given two finite disjoint sets `s` and `t`, the product of `f i` over `i ∈ s ∪ t` equals the
-product of `f i` over `i ∈ s` times the product of `f i` over `i ∈ t`. -/
-@[to_additive "Given two finite disjoint sets `s` and `t`, the sum of `f i` over `i ∈ s ∪ t` equals
-the sum of `f i` over `i ∈ s` plus the sum of `f i` over `i ∈ t`."]
-lemma finprod_mem_union (hst : disjoint s t) (hs : s.finite) (ht : t.finite) :
+@[to_additive] lemma finprod_mem_union (hst : disjoint s t) (hs : s.finite) (ht : t.finite) :
   ∏ᶠ i ∈ s ∪ t, f i = (∏ᶠ i ∈ s, f i) * ∏ᶠ i ∈ t, f i :=
 finprod_mem_union' hst (hs.inter_of_left _) (ht.inter_of_left _)
 
@@ -606,9 +566,7 @@ lemma finprod_mem_union'' (hst : disjoint (s ∩ mul_support f) (t ∩ mul_suppo
 by rw [← finprod_mem_inter_mul_support f s, ← finprod_mem_inter_mul_support f t,
   ← finprod_mem_union hst hs ht, ← union_inter_distrib_right, finprod_mem_inter_mul_support]
 
-/-- The product of `f i` over `i ∈ {a}` equals `f a`. -/
-@[to_additive "The sum of `f i` over `i ∈ {a}` equals `f a`."]
-lemma finprod_mem_singleton : ∏ᶠ i ∈ ({a} : set α), f i = f a :=
+@[to_additive] lemma finprod_mem_singleton : ∏ᶠ i ∈ ({a} : set α), f i = f a :=
 by rw [← finset.coe_singleton, finprod_mem_coe_finset, finset.prod_singleton]
 
 @[simp, to_additive] lemma finprod_cond_eq_left : ∏ᶠ i = a, f i = f a :=
@@ -629,18 +587,11 @@ begin
   { exact (finite_singleton a).inter_of_left _ }
 end
 
-/-- Given a finite set `s` and an element `a ∉ s`, the product of `f i` over `i ∈ insert a s` equals
-`f a` times the product of `f i` over `i ∈ s`. -/
-@[to_additive "Given a finite set `s` and an element `a ∉ s`, the sum of `f i` over `i ∈ insert a s`
-equals `f a` plus the sum of `f i` over `i ∈ s`."]
-lemma finprod_mem_insert (f : α → M) (h : a ∉ s) (hs : s.finite) :
+@[to_additive] lemma finprod_mem_insert (f : α → M) (h : a ∉ s) (hs : s.finite) :
   ∏ᶠ i ∈ insert a s, f i = f a * ∏ᶠ i ∈ s, f i :=
 finprod_mem_insert' f h $ hs.inter_of_left _
 
-/-- If `f a = 1` for all `a ∉ s`, then the product of `f i` over `i ∈ insert a s` equals the
-product of `f i` over `i ∈ s`. -/
-@[to_additive "If `f a = 0` for all `a ∉ s`, then the sum of `f i` over `i ∈ insert a s` equals the
-sum of `f i` over `i ∈ s`."] lemma finprod_mem_insert_of_eq_one_if_not_mem (h : a ∉ s → f a = 1) :
+@[to_additive] lemma finprod_mem_insert_of_eq_one_if_not_mem (h : a ∉ s → f a = 1) :
   ∏ᶠ i ∈ (insert a s), f i = ∏ᶠ i ∈ s, f i :=
 begin
   refine finprod_mem_inter_mul_support_eq' _ _ _ (λ x hx, ⟨_, or.inr⟩),
@@ -648,17 +599,11 @@ begin
   exacts [not_imp_comm.1 h hx, hxs]
 end
 
-/-- If `f a = 1`, then the product of `f i` over `i ∈ insert a s` equals the product of `f i` over
-`i ∈ s`. -/
-@[to_additive "If `f a = 0`, then the sum of `f i` over `i ∈ insert a s` equals the sum of `f i`
-over `i ∈ s`."] lemma finprod_mem_insert_one (h : f a = 1) :
+@[to_additive] lemma finprod_mem_insert_one (h : f a = 1) :
   ∏ᶠ i ∈ (insert a s), f i = ∏ᶠ i ∈ s, f i :=
 finprod_mem_insert_of_eq_one_if_not_mem (λ _, h)
 
-/-- If the multiplicative support of `f` is finite, then for every `x` in the domain of `f`,
-`f x` divides `finprod f`.  -/
-lemma finprod_mem_dvd {f : α → N} (a : α) (hf : finite (mul_support f)) :
-  f a ∣ finprod f :=
+lemma finprod_mem_dvd {f : α → N} (a : α) (hf : (mul_support f).finite) : f a ∣ finprod f :=
 begin
   by_cases ha : a ∈ mul_support f,
   { rw finprod_eq_prod_of_mul_support_to_finset_subset f hf (set.subset.refl _),
@@ -667,16 +612,10 @@ begin
     exact one_dvd (finprod f) }
 end
 
-/-- The product of `f i` over `i ∈ {a, b}`, `a ≠ b`, is equal to `f a * f b`. -/
-@[to_additive "The sum of `f y` over `y ∈ g '' s` equals the sum of `f (g i)` over `s` provided that
-`g` is injective on `s ∩ support (f ∘ g)`."]
-lemma finprod_mem_pair (h : a ≠ b) : ∏ᶠ i ∈ ({a, b} : set α), f i = f a * f b :=
+@[to_additive] lemma finprod_mem_pair (h : a ≠ b) : ∏ᶠ i ∈ ({a, b} : set α), f i = f a * f b :=
 by { rw [finprod_mem_insert, finprod_mem_singleton], exacts [h, finite_singleton b] }
 
-/-- The product of `f y` over `y ∈ g '' s` equals the product of `f (g i)` over `s`
-provided that `g` is injective on `s ∩ mul_support (f ∘ g)`. -/
-@[to_additive "The sum of `f y` over `y ∈ g '' s` equals the sum of `f (g i)` over `s` provided that
-`g` is injective on `s ∩ support (f ∘ g)`."]
+@[to_additive]
 lemma finprod_mem_image' {s : set β} {g : β → α} (hg : (s ∩ mul_support (f ∘ g)).inj_on g) :
   ∏ᶠ i ∈ g '' s, f i = ∏ᶠ j ∈ s, f (g j) :=
 begin
@@ -692,38 +631,23 @@ begin
     rwa [image_inter_mul_support_eq, infinite_image_iff hg] }
 end
 
-/-- The product of `f y` over `y ∈ g '' s` equals the product of `f (g i)` over `s`
-provided that `g` is injective on `s`. -/
-@[to_additive "The sum of `f y` over `y ∈ g '' s` equals the sum of `f (g i)` over `s` provided that
-`g` is injective on `s`."] lemma finprod_mem_image {s : set β} {g : β → α} (hg : s.inj_on g) :
+@[to_additive] lemma finprod_mem_image {s : set β} {g : β → α} (hg : s.inj_on g) :
   ∏ᶠ i ∈ g '' s, f i = ∏ᶠ j ∈ s, f (g j) :=
 finprod_mem_image' $ hg.mono $ inter_subset_left _ _
 
-/-- The product of `f y` over `y ∈ set.range g` equals the product of `f (g i)` over all `i`
-provided that `g` is injective on `mul_support (f ∘ g)`. -/
-@[to_additive "The sum of `f y` over `y ∈ set.range g` equals the sum of `f (g i)` over all `i`
-provided that `g` is injective on `support (f ∘ g)`."]
-lemma finprod_mem_range' {g : β → α} (hg : (mul_support (f ∘ g)).inj_on g) :
+@[to_additive] lemma finprod_mem_range' {g : β → α} (hg : (mul_support (f ∘ g)).inj_on g) :
   ∏ᶠ i ∈ range g, f i = ∏ᶠ j, f (g j) :=
 begin
   rw [← image_univ, finprod_mem_image', finprod_mem_univ],
   rwa univ_inter
 end
 
-/-- The product of `f y` over `y ∈ set.range g` equals the product of `f (g i)` over all `i`
-provided that `g` is injective. -/
-@[to_additive "The sum of `f y` over `y ∈ set.range g` equals the sum of `f (g i)` over all `i`
-provided that `g` is injective."] lemma finprod_mem_range {g : β → α} (hg : injective g) :
+@[to_additive] lemma finprod_mem_range {g : β → α} (hg : injective g) :
   ∏ᶠ i ∈ range g, f i = ∏ᶠ j, f (g j) :=
 finprod_mem_range' (hg.inj_on _)
 
-/-- The product of `f i` over `s : set α` is equal to the product of `g j` over `t : set β`
-if there exists a function `e : α → β` such that `e` is bijective from `s` to `t` and for all
-`x` in `s` we have `f x = g (e x)`.
-See also `finset.prod_bij`. -/
-@[to_additive "The sum of `f i` over `s : set α` is equal to the sum of `g j` over `t : set β` if
-there exists a function `e : α → β` such that `e` is bijective from `s` to `t` and for all `x` in
-`s` we have `f x = g (e x)`. See also `finset.sum_bij`."]
+/-- See also `finset.prod_bij`. -/
+@[to_additive "See also `finset.sum_bij`."]
 lemma finprod_mem_eq_of_bij_on {s : set α} {t : set β} {f : α → M} {g : β → M}
   (e : α → β) (he₀ : set.bij_on e s t) (he₁ : ∀ x ∈ s, f x = g (e x)) :
   ∏ᶠ i ∈ s, f i = ∏ᶠ j ∈ t, g j :=
@@ -732,12 +656,8 @@ begin
   exact finprod_mem_congr rfl he₁
 end
 
-/-- The product of `f i` is equal to the product of `g j` if there exists a bijective function
-`e : α → β` such that for all `x` we have `f x = g (e x)`.
-See `finprod_comp`, `fintype.prod_bijective` and `finset.prod_bij`. -/
-@[to_additive "The sum of `f i` is equal to the sum of `g j` if there exists a bijective function
-`e : α → β` such that for all `x` we have `f x = g (e x)`.
-See `finsum_comp`, `fintype.sum_bijective` and `finset.sum_bij`."]
+/-- See `finprod_comp`, `fintype.prod_bijective` and `finset.prod_bij`. -/
+@[to_additive "See `finsum_comp`, `fintype.sum_bijective` and `finset.sum_bij`."]
 lemma finprod_eq_of_bijective {f : α → M} {g : β → M} (e : α → β) (he₀ : bijective e)
   (he₁ : ∀ x, f x = g (e x)) :
   ∏ᶠ i, f i = ∏ᶠ j, g j :=
@@ -746,10 +666,8 @@ begin
   exact finprod_mem_eq_of_bij_on _ (bijective_iff_bij_on_univ.mp he₀) (λ x _, he₁ x),
 end
 
-/-- Given a bijective function `e` the product of `g i` is equal to the product of `g (e i)`.
-See also `finprod_eq_of_bijective`, `fintype.prod_bijective` and `finset.prod_bij`. -/
-@[to_additive "Given a bijective function `e` the sum of `g i` is equal to the sum of `g (e i)`.
-See also `finsum_eq_of_bijective`, `fintype.sum_bijective` and `finset.sum_bij`."]
+/-- See also `finprod_eq_of_bijective`, `fintype.prod_bijective` and `finset.prod_bij`. -/
+@[to_additive "See also `finsum_eq_of_bijective`, `fintype.sum_bijective` and `finset.sum_bij`."]
 lemma finprod_comp {g : β → M} (e : α → β) (he₀ : function.bijective e) :
   ∏ᶠ i, g (e i) = ∏ᶠ j, g j := finprod_eq_of_bijective e he₀ (λ x, rfl)
 
@@ -783,23 +701,14 @@ lemma finprod_mem_mul_diff' (hst : s ⊆ t) (ht : (t ∩ mul_support f).finite) 
   (∏ᶠ i ∈ s, f i) * ∏ᶠ i ∈ t \ s, f i = ∏ᶠ i ∈ t, f i :=
 by rw [← finprod_mem_inter_mul_diff' _ ht, inter_eq_self_of_subset_right hst]
 
-/-- Given a finite set `t` and a subset `s` of `t`, the product of `f i` over `i ∈ s`
-times the product of `f i` over `t \ s` equals the product of `f i` over `i ∈ t`. -/
-@[to_additive "Given a finite set `t` and a subset `s` of `t`, the sum of `f i` over `i ∈ s` plus
-the sum of `f i` over `t \ s` equals the sum of `f i` over `i ∈ t`."]
-lemma finprod_mem_mul_diff (hst : s ⊆ t) (ht : t.finite) :
+@[to_additive] lemma finprod_mem_mul_diff (hst : s ⊆ t) (ht : t.finite) :
   (∏ᶠ i ∈ s, f i) * ∏ᶠ i ∈ t \ s, f i = ∏ᶠ i ∈ t, f i :=
 finprod_mem_mul_diff' hst (ht.inter_of_left _)
 
-/-- Given a family of pairwise disjoint finite sets `t i` indexed by a finite type, the product of
-`f a` over the union `⋃ i, t i` is equal to the product over all indexes `i` of the products of
-`f a` over `a ∈ t i`. -/
-@[to_additive "Given a family of pairwise disjoint finite sets `t i` indexed by a finite type, the
-sum of `f a` over the union `⋃ i, t i` is equal to the sum over all indexes `i` of the sums of `f a`
-over `a ∈ t i`."]
+@[to_additive]
 lemma finprod_mem_Union [fintype ι] {t : ι → set α} (h : pairwise (disjoint on t))
   (ht : ∀ i, (t i).finite) :
-  ∏ᶠ a ∈ (⋃ i : ι, t i), f a = ∏ᶠ i, (∏ᶠ a ∈ t i, f a) :=
+  ∏ᶠ a ∈ (⋃ i : ι, t i), f a = ∏ᶠ i, ∏ᶠ a ∈ t i, f a :=
 begin
   lift t to ι → finset α using ht,
   classical,
@@ -809,15 +718,8 @@ begin
   { exact λ x _ y _ hxy, finset.disjoint_iff_disjoint_coe.2 (h x y hxy) }
 end
 
-/-- Given a family of sets `t : ι → set α`, a finite set `I` in the index type such that all sets
-`t i`, `i ∈ I`, are finite, if all `t i`, `i ∈ I`, are pairwise disjoint, then the product of `f a`
-over `a ∈ ⋃ i ∈ I, t i` is equal to the product over `i ∈ I` of the products of `f a` over
-`a ∈ t i`. -/
-@[to_additive "Given a family of sets `t : ι → set α`, a finite set `I` in the index type such that
-all sets `t i`, `i ∈ I`, are finite, if all `t i`, `i ∈ I`, are pairwise disjoint, then the sum of
-`f a` over `a ∈ ⋃ i ∈ I, t i` is equal to the sum over `i ∈ I` of the sums of `f a` over
-`a ∈ t i`."] lemma finprod_mem_bUnion {I : set ι} {t : ι → set α}
-  (h : I.pairwise_disjoint t) (hI : I.finite) (ht : ∀ i ∈ I, (t i).finite) :
+@[to_additive] lemma finprod_mem_bUnion {I : set ι} {t : ι → set α} (h : I.pairwise_disjoint t)
+  (hI : I.finite) (ht : ∀ i ∈ I, (t i).finite) :
   ∏ᶠ a ∈ ⋃ x ∈ I, t x, f a = ∏ᶠ i ∈ I, ∏ᶠ j ∈ t i, f j :=
 begin
   haveI := hI.fintype,
@@ -825,11 +727,7 @@ begin
   exacts [λ x y hxy, h x.2 y.2 (subtype.coe_injective.ne hxy), λ b, ht b b.2]
 end
 
-/-- If `t` is a finite set of pairwise disjoint finite sets, then the product of `f a`
-over `a ∈ ⋃₀ t` is the product over `s ∈ t` of the products of `f a` over `a ∈ s`. -/
-@[to_additive "If `t` is a finite set of pairwise disjoint finite sets, then the sum of `f a` over
-`a ∈ ⋃₀ t` is the sum over `s ∈ t` of the sums of `f a` over `a ∈ s`."]
-lemma finprod_mem_sUnion {t : set (set α)} (h : t.pairwise_disjoint id)
+@[to_additive] lemma finprod_mem_sUnion {t : set (set α)} (h : t.pairwise_disjoint id)
   (ht₀ : t.finite) (ht₁ : ∀ x ∈ t, set.finite x) :
   ∏ᶠ a ∈ ⋃₀ t, f a = ∏ᶠ s ∈ t, ∏ᶠ a ∈ s, f a :=
 by { rw set.sUnion_eq_bUnion, exact finprod_mem_bUnion h ht₀ ht₁ }
@@ -851,12 +749,8 @@ begin
     apply finset.prod_erase _ ha, }
 end
 
-/-- If `s : set α` and `t : set β` are finite sets, then the product over `s` commutes
-with the product over `t`. -/
-@[to_additive "If `s : set α` and `t : set β` are finite sets, then the sum over `s` commutes with
-the sum over `t`."]
-lemma finprod_mem_comm {s : set α} {t : set β}
-  (f : α → β → M) (hs : s.finite) (ht : t.finite) :
+@[to_additive]
+lemma finprod_mem_comm {s : set α} {t : set β} (f : α → β → M) (hs : s.finite) (ht : t.finite) :
   ∏ᶠ i ∈ s, ∏ᶠ j ∈ t, f i j = ∏ᶠ j ∈ t, ∏ᶠ i ∈ s, f i j :=
 begin
   lift s to finset α using hs, lift t to finset β using ht,

--- a/src/algebra/big_operators/finprod.lean
+++ b/src/algebra/big_operators/finprod.lean
@@ -169,9 +169,11 @@ by { subst q, exact finprod_congr hfg }
 attribute [congr] finsum_congr_Prop
 
 /-- To prove a property of a finite product, it suffices to prove that the property is
-multiplicative and holds on multipliers. -/
-@[to_additive] lemma finprod_induction {f : α → M} (p : M → Prop) (hp₀ : p 1)
-  (hp₁ : ∀ x y, p x → p y → p (x * y)) (hp₂ : ∀ i, p (f i)) :
+multiplicative and holds on the factors. -/
+@[to_additive "To prove a property of a finite sum, it suffices to prove that the property is
+additive and holds on the summands."]
+lemma finprod_induction {f : α → M} (p : M → Prop) (hp₀ : p 1) (hp₁ : ∀ x y, p x → p y → p (x * y))
+  (hp₂ : ∀ i, p (f i)) :
   p (∏ᶠ i, f i) :=
 begin
   rw finprod,
@@ -417,9 +419,10 @@ by simp [h] {contextual := tt}
 -/
 
 /-- If the multiplicative supports of `f` and `g` are finite, then the product of `f i * g i` equals
-the product of `f i` multiplied by the product over `g i`. -/
-@[to_additive] lemma finprod_mul_distrib (hf : (mul_support f).finite)
-  (hg : (mul_support g).finite) :
+the product of `f i` multiplied by the product of `g i`. -/
+@[to_additive "If the additive supports of `f` and `g` are finite, then the sum of `f i * g i`
+equals the sum of `f i` plus the sum of `g i`."]
+lemma finprod_mul_distrib (hf : (mul_support f).finite) (hg : (mul_support g).finite) :
   ∏ᶠ i, (f i * g i) = (∏ᶠ i, f i) * ∏ᶠ i, g i :=
 begin
   classical,
@@ -431,9 +434,11 @@ begin
 end
 
 /-- If the multiplicative supports of `f` and `g` are finite, then the product of `f i / g i`
-equals the product of `f i` divided by the product over `g i`. -/
-@[to_additive] lemma finprod_div_distrib {G : Type*} [comm_group G] {f g : α → G}
-  (hf : (mul_support f).finite) (hg : (mul_support g).finite) :
+equals the product of `f i` divided by the product of `g i`. -/
+@[to_additive "If the additive supports of `f` and `g` are finite, then the sum of `f i - g i`
+equals the sum of `f i` minus the sum of `g i`."]
+lemma finprod_div_distrib {G : Type*} [comm_group G] {f g : α → G} (hf : (mul_support f).finite)
+  (hg : (mul_support g).finite) :
   ∏ᶠ i, f i / g i = (∏ᶠ i, f i) / ∏ᶠ i, g i :=
 by simp only [div_eq_mul_inv, finprod_mul_distrib hf ((mul_support_inv g).symm.rec hg),
               finprod_inv_distrib]
@@ -444,26 +449,31 @@ lemma finprod_div_distrib₀ {G : Type*} [comm_group_with_zero G] {f g : α → 
 by simp only [div_eq_mul_inv, finprod_mul_distrib hf ((mul_support_inv₀ g).symm.rec hg),
               finprod_inv_distrib₀]
 
-/-- A more general version of `finprod_mem_mul_distrib` that requires `s ∩ mul_support f` and
-`s ∩ mul_support g` instead of `s` to be finite. -/
-@[to_additive] lemma finprod_mem_mul_distrib' (hf : (s ∩ mul_support f).finite)
-  (hg : (s ∩ mul_support g).finite) :
+/-- A more general version of `finprod_mem_mul_distrib` that only requires `s ∩ mul_support f` and
+`s ∩ mul_support g` rather than `s` to be finite. -/
+@[to_additive "A more general version of `finsum_mem_add_distrib` that only requires `s ∩ support f`
+and `s ∩ support g` rather than `s` to be finite."]
+lemma finprod_mem_mul_distrib' (hf : (s ∩ mul_support f).finite) (hg : (s ∩ mul_support g).finite) :
   ∏ᶠ i ∈ s, (f i * g i) = (∏ᶠ i ∈ s, f i) * ∏ᶠ i ∈ s, g i :=
 begin
   rw [← mul_support_mul_indicator] at hf hg,
   simp only [finprod_mem_def, mul_indicator_mul, finprod_mul_distrib hf hg]
 end
 
-/-- The product of constant one over any set equals one. -/
-@[to_additive] lemma finprod_mem_one (s : set α) : ∏ᶠ i ∈ s, (1 : M) = 1 := by simp
+/-- The product of the constant function `1` over any set equals `1`. -/
+@[to_additive "The product of the constant function `0` over any set equals `0`."]
+lemma finprod_mem_one (s : set α) : ∏ᶠ i ∈ s, (1 : M) = 1 := by simp
 
-/-- If a function `f` equals one on a set `s`, then the product of `f i` over `i ∈ s` equals one. -/
-@[to_additive] lemma finprod_mem_of_eq_on_one (hf : eq_on f 1 s) : ∏ᶠ i ∈ s, f i = 1 :=
+/-- If a function `f` equals `1` on a set `s`, then the product of `f i` over `i ∈ s` equals `1`. -/
+@[to_additive "If a function `f` equals `0` on a set `s`, then the product of `f i` over `i ∈ s` equals `0`."]
+lemma finprod_mem_of_eq_on_one (hf : eq_on f 1 s) : ∏ᶠ i ∈ s, f i = 1 :=
 by { rw ← finprod_mem_one s, exact finprod_mem_congr rfl hf }
 
-/-- If the product of `f i` over `i ∈ s` is not equal to one, then there is some `x ∈ s`
-such that `f x ≠ 1`. -/
-@[to_additive] lemma exists_ne_one_of_finprod_mem_ne_one (h : ∏ᶠ i ∈ s, f i ≠ 1) :
+/-- If the product of `f i` over `i ∈ s` is not equal to `1`, then there is some `x ∈ s` such that
+`f x ≠ 1`. -/
+@[to_additive "If the product of `f i` over `i ∈ s` is not equal to `0`, then there is some `x ∈ s`
+such that `f x ≠ 0`."]
+lemma exists_ne_one_of_finprod_mem_ne_one (h : ∏ᶠ i ∈ s, f i ≠ 1) :
   ∃ x ∈ s, f x ≠ 1 :=
 begin
   by_contra' h',
@@ -472,17 +482,21 @@ end
 
 /-- Given a finite set `s`, the product of `f i * g i` over `i ∈ s` equals the product of `f i`
 over `i ∈ s` times the product of `g i` over `i ∈ s`. -/
-@[to_additive] lemma finprod_mem_mul_distrib (hs : s.finite) :
-  ∏ᶠ i ∈ s, (f i * g i) = (∏ᶠ i ∈ s, f i) * ∏ᶠ i ∈ s, g i :=
+@[to_additive "Given a finite set `s`, the product of `f i * g i` over `i ∈ s` equals the product of
+`f i` over `i ∈ s` times the product of `g i` over `i ∈ s`."]
+lemma finprod_mem_mul_distrib (hs : s.finite) :
+  ∏ᶠ i ∈ s, f i * g i = (∏ᶠ i ∈ s, f i) * ∏ᶠ i ∈ s, g i :=
 finprod_mem_mul_distrib' (hs.inter_of_left _) (hs.inter_of_left _)
 
 @[to_additive] lemma monoid_hom.map_finprod {f : α → M} (g : M →* N) (hf : (mul_support f).finite) :
   g (∏ᶠ i, f i) = ∏ᶠ i, g (f i) :=
 g.map_finprod_plift f $ hf.preimage $ equiv.plift.injective.inj_on _
 
-/-- A more general version of `monoid_hom.map_finprod_mem` that requires `s ∩ mul_support f` and
-  instead of `s` to be finite. -/
-@[to_additive] lemma monoid_hom.map_finprod_mem' {f : α → M} (g : M →* N)
+/-- A more general version of `monoid_hom.map_finprod_mem` that requires `s ∩ mul_support f` rather
+than `s` to be finite. -/
+@[to_additive "A more general version of `add_monoid_hom.map_finsum_mem` that requires
+`s ∩ support f` rather than `s` to be finite."]
+lemma monoid_hom.map_finprod_mem' {f : α → M} (g : M →* N)
   (h₀ : (s ∩ mul_support f).finite) :
   g (∏ᶠ j ∈ s, f j) = ∏ᶠ i ∈ s, (g (f i)) :=
 begin
@@ -491,9 +505,11 @@ begin
   { simpa only [finprod_eq_mul_indicator_apply, mul_support_mul_indicator] }
 end
 
-/-- Given a monoid homomorphism `g : M →* N`, and a function `f : α → M`, the value of `g` at the
+/-- Given a monoid homomorphism `g : M →* N` and a function `f : α → M`, the value of `g` at the
 product of `f i` over `i ∈ s` equals the product of `(g ∘ f) i` over `s`. -/
-@[to_additive] lemma monoid_hom.map_finprod_mem (f : α → M) (g : M →* N) (hs : s.finite) :
+@[to_additive "Given an additive monoid homomorphism `g : M →* N` and a function `f : α → M`, the
+value of `g` at the sum of `f i` over `i ∈ s` equals the sum of `(g ∘ f) i` over `s`."]
+lemma monoid_hom.map_finprod_mem (f : α → M) (g : M →* N) (hs : s.finite) :
   g (∏ᶠ j ∈ s, f j) = ∏ᶠ i ∈ s, g (f i) :=
 g.map_finprod_mem' (hs.inter_of_left _)
 
@@ -511,8 +527,10 @@ lemma finprod_mem_inv_distrib₀ {G : Type*} [comm_group_with_zero G] (f : α �
 
 /-- Given a finite set `s`, the product of `f i / g i` over `i ∈ s` equals the product of `f i`
 over `i ∈ s` divided by the product of `g i` over `i ∈ s`. -/
-@[to_additive] lemma finprod_mem_div_distrib {G : Type*} [comm_group G] (f g : α → G)
-  (hs : s.finite) : ∏ᶠ i ∈ s, f i / g i = (∏ᶠ i ∈ s, f i) / ∏ᶠ i ∈ s, g i :=
+@[to_additive "Given a finite set `s`, the sum of `f i / g i` over `i ∈ s` equals the sum of `f i`
+over `i ∈ s` minus by the sum of `g i` over `i ∈ s`."]
+lemma finprod_mem_div_distrib {G : Type*} [comm_group G] (f g : α → G) (hs : s.finite) :
+  ∏ᶠ i ∈ s, f i / g i = (∏ᶠ i ∈ s, f i) / ∏ᶠ i ∈ s, g i :=
 by simp only [div_eq_mul_inv, finprod_mem_mul_distrib hs, finprod_mem_inv_distrib g hs]
 
 lemma finprod_mem_div_distrib₀ {G : Type*} [comm_group_with_zero G] (f g : α → G)
@@ -523,17 +541,21 @@ by simp only [div_eq_mul_inv, finprod_mem_mul_distrib hs, finprod_mem_inv_distri
 ### `∏ᶠ x ∈ s, f x` and set operations
 -/
 
-/-- The product of any function over an empty set is one. -/
-@[to_additive] lemma finprod_mem_empty : ∏ᶠ i ∈ (∅ : set α), f i = 1 := by simp
+/-- The product of any function over an empty set is `1`. -/
+@[to_additive "The sum of any function over an empty set is `0`."]
+lemma finprod_mem_empty : ∏ᶠ i ∈ (∅ : set α), f i = 1 := by simp
 
-/-- A set `s` is not empty if the product of some function over `s` is not equal to one. -/
-@[to_additive] lemma nonempty_of_finprod_mem_ne_one (h : ∏ᶠ i ∈ s, f i ≠ 1) : s.nonempty :=
+/-- A set `s` is nonempty if the product of some function over `s` is not equal to `1`. -/
+@[to_additive "A set `s` is nonempty if the sum of some function over `s` is not equal to `0`."]
+lemma nonempty_of_finprod_mem_ne_one (h : ∏ᶠ i ∈ s, f i ≠ 1) : s.nonempty :=
 ne_empty_iff_nonempty.1 $ λ h', h $ h'.symm ▸ finprod_mem_empty
 
 /-- Given finite sets `s` and `t`, the product of `f i` over `i ∈ s ∪ t` times the product of
 `f i` over `i ∈ s ∩ t` equals the product of `f i` over `i ∈ s` times the product of `f i`
 over `i ∈ t`. -/
-@[to_additive] lemma finprod_mem_union_inter (hs : s.finite) (ht : t.finite) :
+@[to_additive "Given finite sets `s` and `t`, the sum of `f i` over `i ∈ s ∪ t` plus the sum of
+`f i` over `i ∈ s ∩ t` equals the sum of `f i` over `i ∈ s` plus the sum of `f i` over `i ∈ t`."]
+lemma finprod_mem_union_inter (hs : s.finite) (ht : t.finite) :
   (∏ᶠ i ∈ s ∪ t, f i) * ∏ᶠ i ∈ s ∩ t, f i = (∏ᶠ i ∈ s, f i) * ∏ᶠ i ∈ t, f i :=
 begin
   lift s to finset α using hs, lift t to finset α using ht,
@@ -543,8 +565,9 @@ begin
 end
 
 /-- A more general version of `finprod_mem_union_inter` that requires `s ∩ mul_support f` and
-`t ∩ mul_support f` instead of `s` and `t` to be finite. -/
-@[to_additive] lemma finprod_mem_union_inter'
+`t ∩ mul_support f` rather than `s` and `t` to be finite. -/
+@[to_additive "A more general version of `finsum_mem_union_inter` that requires `s ∩ support f` and
+`t ∩ support f` rather than `s` and `t` to be finite."] lemma finprod_mem_union_inter'
   (hs : (s ∩ mul_support f).finite) (ht : (t ∩ mul_support f).finite) :
   (∏ᶠ i ∈ s ∪ t, f i) * ∏ᶠ i ∈ s ∩ t, f i = (∏ᶠ i ∈ s, f i) * ∏ᶠ i ∈ t, f i :=
 begin
@@ -556,8 +579,10 @@ begin
 end
 
 /-- A more general version of `finprod_mem_union` that requires `s ∩ mul_support f` and
-`t ∩ mul_support f` instead of `s` and `t` to be finite. -/
-@[to_additive] lemma finprod_mem_union' (hst : disjoint s t) (hs : (s ∩ mul_support f).finite)
+`t ∩ mul_support f` rather than `s` and `t` to be finite. -/
+@[to_additive "A more general version of `finsum_mem_union` that requires `s ∩ support f` and
+`t ∩ support f` rather than `s` and `t` to be finite."]
+lemma finprod_mem_union' (hst : disjoint s t) (hs : (s ∩ mul_support f).finite)
   (ht : (t ∩ mul_support f).finite) :
   ∏ᶠ i ∈ s ∪ t, f i = (∏ᶠ i ∈ s, f i) * ∏ᶠ i ∈ t, f i :=
 by rw [← finprod_mem_union_inter' hs ht, disjoint_iff_inter_eq_empty.1 hst, finprod_mem_empty,
@@ -565,20 +590,25 @@ by rw [← finprod_mem_union_inter' hs ht, disjoint_iff_inter_eq_empty.1 hst, fi
 
 /-- Given two finite disjoint sets `s` and `t`, the product of `f i` over `i ∈ s ∪ t` equals the
 product of `f i` over `i ∈ s` times the product of `f i` over `i ∈ t`. -/
-@[to_additive] lemma finprod_mem_union (hst : disjoint s t) (hs : s.finite) (ht : t.finite) :
+@[to_additive "Given two finite disjoint sets `s` and `t`, the sum of `f i` over `i ∈ s ∪ t` equals
+the sum of `f i` over `i ∈ s` plus the sum of `f i` over `i ∈ t`."]
+lemma finprod_mem_union (hst : disjoint s t) (hs : s.finite) (ht : t.finite) :
   ∏ᶠ i ∈ s ∪ t, f i = (∏ᶠ i ∈ s, f i) * ∏ᶠ i ∈ t, f i :=
 finprod_mem_union' hst (hs.inter_of_left _) (ht.inter_of_left _)
 
 /-- A more general version of `finprod_mem_union'` that requires `s ∩ mul_support f` and
-`t ∩ mul_support f` instead of `s` and `t` to be disjoint -/
-@[to_additive] lemma finprod_mem_union'' (hst : disjoint (s ∩ mul_support f) (t ∩ mul_support f))
+`t ∩ mul_support f` rather than `s` and `t` to be disjoint -/
+@[to_additive "A more general version of `finsum_mem_union'` that requires `s ∩ support f` and
+`t ∩ support f` rather than `s` and `t` to be disjoint"]
+lemma finprod_mem_union'' (hst : disjoint (s ∩ mul_support f) (t ∩ mul_support f))
   (hs : (s ∩ mul_support f).finite) (ht : (t ∩ mul_support f).finite) :
   ∏ᶠ i ∈ s ∪ t, f i = (∏ᶠ i ∈ s, f i) * ∏ᶠ i ∈ t, f i :=
 by rw [← finprod_mem_inter_mul_support f s, ← finprod_mem_inter_mul_support f t,
   ← finprod_mem_union hst hs ht, ← union_inter_distrib_right, finprod_mem_inter_mul_support]
 
 /-- The product of `f i` over `i ∈ {a}` equals `f a`. -/
-@[to_additive] lemma finprod_mem_singleton : ∏ᶠ i ∈ ({a} : set α), f i = f a :=
+@[to_additive "The sum of `f i` over `i ∈ {a}` equals `f a`."]
+lemma finprod_mem_singleton : ∏ᶠ i ∈ ({a} : set α), f i = f a :=
 by rw [← finset.coe_singleton, finprod_mem_coe_finset, finset.prod_singleton]
 
 @[simp, to_additive] lemma finprod_cond_eq_left : ∏ᶠ i = a, f i = f a :=
@@ -587,10 +617,11 @@ finprod_mem_singleton
 @[simp, to_additive] lemma finprod_cond_eq_right : ∏ᶠ i (hi : a = i), f i = f a :=
 by simp [@eq_comm _ a]
 
-/-- A more general version of `finprod_mem_insert` that requires `s ∩ mul_support f` instead of
-`s` to be finite. -/
-@[to_additive] lemma finprod_mem_insert' (f : α → M) (h : a ∉ s)
-  (hs : (s ∩ mul_support f).finite) :
+/-- A more general version of `finprod_mem_insert` that requires `s ∩ mul_support f` rather than `s`
+to be finite. -/
+@[to_additive "A more general version of `finsum_mem_insert` that requires `s ∩ support f` rather
+than `s` to be finite."]
+lemma finprod_mem_insert' (f : α → M) (h : a ∉ s) (hs : (s ∩ mul_support f).finite) :
   ∏ᶠ i ∈ insert a s, f i = f a * ∏ᶠ i ∈ s, f i :=
 begin
   rw [insert_eq, finprod_mem_union' _ _ hs, finprod_mem_singleton],
@@ -600,13 +631,16 @@ end
 
 /-- Given a finite set `s` and an element `a ∉ s`, the product of `f i` over `i ∈ insert a s` equals
 `f a` times the product of `f i` over `i ∈ s`. -/
-@[to_additive] lemma finprod_mem_insert (f : α → M) (h : a ∉ s) (hs : s.finite) :
+@[to_additive "Given a finite set `s` and an element `a ∉ s`, the sum of `f i` over `i ∈ insert a s`
+equals `f a` plus the sum of `f i` over `i ∈ s`."]
+lemma finprod_mem_insert (f : α → M) (h : a ∉ s) (hs : s.finite) :
   ∏ᶠ i ∈ insert a s, f i = f a * ∏ᶠ i ∈ s, f i :=
 finprod_mem_insert' f h $ hs.inter_of_left _
 
 /-- If `f a = 1` for all `a ∉ s`, then the product of `f i` over `i ∈ insert a s` equals the
 product of `f i` over `i ∈ s`. -/
-@[to_additive] lemma finprod_mem_insert_of_eq_one_if_not_mem (h : a ∉ s → f a = 1) :
+@[to_additive "If `f a = 0` for all `a ∉ s`, then the sum of `f i` over `i ∈ insert a s` equals the
+sum of `f i` over `i ∈ s`."] lemma finprod_mem_insert_of_eq_one_if_not_mem (h : a ∉ s → f a = 1) :
   ∏ᶠ i ∈ (insert a s), f i = ∏ᶠ i ∈ s, f i :=
 begin
   refine finprod_mem_inter_mul_support_eq' _ _ _ (λ x hx, ⟨_, or.inr⟩),
@@ -616,7 +650,8 @@ end
 
 /-- If `f a = 1`, then the product of `f i` over `i ∈ insert a s` equals the product of `f i` over
 `i ∈ s`. -/
-@[to_additive] lemma finprod_mem_insert_one (h : f a = 1) :
+@[to_additive "If `f a = 0`, then the sum of `f i` over `i ∈ insert a s` equals the sum of `f i`
+over `i ∈ s`."] lemma finprod_mem_insert_one (h : f a = 1) :
   ∏ᶠ i ∈ (insert a s), f i = ∏ᶠ i ∈ s, f i :=
 finprod_mem_insert_of_eq_one_if_not_mem (λ _, h)
 
@@ -633,14 +668,17 @@ begin
 end
 
 /-- The product of `f i` over `i ∈ {a, b}`, `a ≠ b`, is equal to `f a * f b`. -/
-@[to_additive] lemma finprod_mem_pair (h : a ≠ b) : ∏ᶠ i ∈ ({a, b} : set α), f i = f a * f b :=
+@[to_additive "The sum of `f y` over `y ∈ g '' s` equals the sum of `f (g i)` over `s` provided that
+`g` is injective on `s ∩ support (f ∘ g)`."]
+lemma finprod_mem_pair (h : a ≠ b) : ∏ᶠ i ∈ ({a, b} : set α), f i = f a * f b :=
 by { rw [finprod_mem_insert, finprod_mem_singleton], exacts [h, finite_singleton b] }
 
 /-- The product of `f y` over `y ∈ g '' s` equals the product of `f (g i)` over `s`
 provided that `g` is injective on `s ∩ mul_support (f ∘ g)`. -/
-@[to_additive] lemma finprod_mem_image' {s : set β} {g : β → α}
-  (hg : set.inj_on g (s ∩ mul_support (f ∘ g))) :
-  ∏ᶠ i ∈ (g '' s), f i = ∏ᶠ j ∈ s, f (g j) :=
+@[to_additive "The sum of `f y` over `y ∈ g '' s` equals the sum of `f (g i)` over `s` provided that
+`g` is injective on `s ∩ support (f ∘ g)`."]
+lemma finprod_mem_image' {s : set β} {g : β → α} (hg : (s ∩ mul_support (f ∘ g)).inj_on g) :
+  ∏ᶠ i ∈ g '' s, f i = ∏ᶠ j ∈ s, f (g j) :=
 begin
   classical,
   by_cases hs : finite (s ∩ mul_support (f ∘ g)),
@@ -656,13 +694,16 @@ end
 
 /-- The product of `f y` over `y ∈ g '' s` equals the product of `f (g i)` over `s`
 provided that `g` is injective on `s`. -/
-@[to_additive] lemma finprod_mem_image {β} {s : set β} {g : β → α} (hg : set.inj_on g s) :
-  ∏ᶠ i ∈ (g '' s), f i = ∏ᶠ j ∈ s, f (g j) :=
+@[to_additive "The sum of `f y` over `y ∈ g '' s` equals the sum of `f (g i)` over `s` provided that
+`g` is injective on `s`."] lemma finprod_mem_image {s : set β} {g : β → α} (hg : s.inj_on g) :
+  ∏ᶠ i ∈ g '' s, f i = ∏ᶠ j ∈ s, f (g j) :=
 finprod_mem_image' $ hg.mono $ inter_subset_left _ _
 
 /-- The product of `f y` over `y ∈ set.range g` equals the product of `f (g i)` over all `i`
 provided that `g` is injective on `mul_support (f ∘ g)`. -/
-@[to_additive] lemma finprod_mem_range' {g : β → α} (hg : set.inj_on g (mul_support (f ∘ g))) :
+@[to_additive "The sum of `f y` over `y ∈ set.range g` equals the sum of `f (g i)` over all `i`
+provided that `g` is injective on `support (f ∘ g)`."]
+lemma finprod_mem_range' {g : β → α} (hg : (mul_support (f ∘ g)).inj_on g) :
   ∏ᶠ i ∈ range g, f i = ∏ᶠ j, f (g j) :=
 begin
   rw [← image_univ, finprod_mem_image', finprod_mem_univ],
@@ -671,7 +712,8 @@ end
 
 /-- The product of `f y` over `y ∈ set.range g` equals the product of `f (g i)` over all `i`
 provided that `g` is injective. -/
-@[to_additive] lemma finprod_mem_range {g : β → α} (hg : injective g) :
+@[to_additive "The sum of `f y` over `y ∈ set.range g` equals the sum of `f (g i)` over all `i`
+provided that `g` is injective."] lemma finprod_mem_range {g : β → α} (hg : injective g) :
   ∏ᶠ i ∈ range g, f i = ∏ᶠ j, f (g j) :=
 finprod_mem_range' (hg.inj_on _)
 
@@ -679,7 +721,10 @@ finprod_mem_range' (hg.inj_on _)
 if there exists a function `e : α → β` such that `e` is bijective from `s` to `t` and for all
 `x` in `s` we have `f x = g (e x)`.
 See also `finset.prod_bij`. -/
-@[to_additive] lemma finprod_mem_eq_of_bij_on {s : set α} {t : set β} {f : α → M} {g : β → M}
+@[to_additive "The sum of `f i` over `s : set α` is equal to the sum of `g j` over `t : set β` if
+there exists a function `e : α → β` such that `e` is bijective from `s` to `t` and for all `x` in
+`s` we have `f x = g (e x)`. See also `finset.sum_bij`."]
+lemma finprod_mem_eq_of_bij_on {s : set α} {t : set β} {f : α → M} {g : β → M}
   (e : α → β) (he₀ : set.bij_on e s t) (he₁ : ∀ x ∈ s, f x = g (e x)) :
   ∏ᶠ i ∈ s, f i = ∏ᶠ j ∈ t, g j :=
 begin
@@ -689,9 +734,12 @@ end
 
 /-- The product of `f i` is equal to the product of `g j` if there exists a bijective function
 `e : α → β` such that for all `x` we have `f x = g (e x)`.
-See `finprod_comp`, `fintype.prod_bijective` and `finset.prod_bij` -/
-@[to_additive] lemma finprod_eq_of_bijective {f : α → M} {g : β → M}
-  (e : α → β) (he₀ : function.bijective e) (he₁ : ∀ x, f x = g (e x)) :
+See `finprod_comp`, `fintype.prod_bijective` and `finset.prod_bij`. -/
+@[to_additive "The sum of `f i` is equal to the sum of `g j` if there exists a bijective function
+`e : α → β` such that for all `x` we have `f x = g (e x)`.
+See `finsum_comp`, `fintype.sum_bijective` and `finset.sum_bij`."]
+lemma finprod_eq_of_bijective {f : α → M} {g : β → M} (e : α → β) (he₀ : bijective e)
+  (he₁ : ∀ x, f x = g (e x)) :
   ∏ᶠ i, f i = ∏ᶠ j, g j :=
 begin
   rw [← finprod_mem_univ f, ← finprod_mem_univ g],
@@ -699,8 +747,10 @@ begin
 end
 
 /-- Given a bijective function `e` the product of `g i` is equal to the product of `g (e i)`.
-See also `finprod_eq_of_bijective`, `fintype.prod_bijective` and `finset.prod_bij` -/
-@[to_additive] lemma finprod_comp {g : β → M} (e : α → β) (he₀ : function.bijective e) :
+See also `finprod_eq_of_bijective`, `fintype.prod_bijective` and `finset.prod_bij`. -/
+@[to_additive "Given a bijective function `e` the sum of `g i` is equal to the sum of `g (e i)`.
+See also `finsum_eq_of_bijective`, `fintype.sum_bijective` and `finset.sum_bij`."]
+lemma finprod_comp {g : β → M} (e : α → β) (he₀ : function.bijective e) :
   ∏ᶠ i, g (e i) = ∏ᶠ j, g j := finprod_eq_of_bijective e he₀ (λ x, rfl)
 
 @[to_additive] lemma finprod_set_coe_eq_finprod_mem (s : set α) : ∏ᶠ j : s, f j = ∏ᶠ i ∈ s, f i :=
@@ -725,23 +775,30 @@ end
   (∏ᶠ i ∈ s ∩ t, f i) * ∏ᶠ i ∈ s \ t, f i = ∏ᶠ i ∈ s, f i :=
 finprod_mem_inter_mul_diff' _ $ h.inter_of_left _
 
-/-- A more general version of `finprod_mem_mul_diff` that requires `t ∩ mul_support f` instead of
-  `t` to be finite. -/
-@[to_additive] lemma finprod_mem_mul_diff' (hst : s ⊆ t) (ht : (t ∩ mul_support f).finite) :
+/-- A more general version of `finprod_mem_mul_diff` that requires `t ∩ mul_support f` rather than
+`t` to be finite. -/
+@[to_additive "A more general version of `finsum_mem_add_diff` that requires `t ∩ support f` rather
+than `t` to be finite."]
+lemma finprod_mem_mul_diff' (hst : s ⊆ t) (ht : (t ∩ mul_support f).finite) :
   (∏ᶠ i ∈ s, f i) * ∏ᶠ i ∈ t \ s, f i = ∏ᶠ i ∈ t, f i :=
 by rw [← finprod_mem_inter_mul_diff' _ ht, inter_eq_self_of_subset_right hst]
 
 /-- Given a finite set `t` and a subset `s` of `t`, the product of `f i` over `i ∈ s`
 times the product of `f i` over `t \ s` equals the product of `f i` over `i ∈ t`. -/
-@[to_additive] lemma finprod_mem_mul_diff (hst : s ⊆ t) (ht : t.finite) :
+@[to_additive "Given a finite set `t` and a subset `s` of `t`, the sum of `f i` over `i ∈ s` plus
+the sum of `f i` over `t \ s` equals the sum of `f i` over `i ∈ t`."]
+lemma finprod_mem_mul_diff (hst : s ⊆ t) (ht : t.finite) :
   (∏ᶠ i ∈ s, f i) * ∏ᶠ i ∈ t \ s, f i = ∏ᶠ i ∈ t, f i :=
 finprod_mem_mul_diff' hst (ht.inter_of_left _)
 
-/-- Given a family of pairwise disjoint finite sets `t i` indexed by a finite type,
-the product of `f a` over the union `⋃ i, t i` is equal to the product over all indexes `i`
-of the products of `f a` over `a ∈ t i`. -/
-@[to_additive] lemma finprod_mem_Union [fintype ι] {t : ι → set α}
-  (h : pairwise (disjoint on t)) (ht : ∀ i, (t i).finite) :
+/-- Given a family of pairwise disjoint finite sets `t i` indexed by a finite type, the product of
+`f a` over the union `⋃ i, t i` is equal to the product over all indexes `i` of the products of
+`f a` over `a ∈ t i`. -/
+@[to_additive "Given a family of pairwise disjoint finite sets `t i` indexed by a finite type, the
+sum of `f a` over the union `⋃ i, t i` is equal to the sum over all indexes `i` of the sums of `f a`
+over `a ∈ t i`."]
+lemma finprod_mem_Union [fintype ι] {t : ι → set α} (h : pairwise (disjoint on t))
+  (ht : ∀ i, (t i).finite) :
   ∏ᶠ a ∈ (⋃ i : ι, t i), f a = ∏ᶠ i, (∏ᶠ a ∈ t i, f a) :=
 begin
   lift t to ι → finset α using ht,
@@ -752,11 +809,14 @@ begin
   { exact λ x _ y _ hxy, finset.disjoint_iff_disjoint_coe.2 (h x y hxy) }
 end
 
-/-- Given a family of sets `t : ι → set α`, a finite set `I` in the index type such that all
-sets `t i`, `i ∈ I`, are finite, if all `t i`, `i ∈ I`, are pairwise disjoint, then
-the product of `f a` over `a ∈ ⋃ i ∈ I, t i` is equal to the product over `i ∈ I`
-of the products of `f a` over `a ∈ t i`. -/
-@[to_additive] lemma finprod_mem_bUnion {I : set ι} {t : ι → set α}
+/-- Given a family of sets `t : ι → set α`, a finite set `I` in the index type such that all sets
+`t i`, `i ∈ I`, are finite, if all `t i`, `i ∈ I`, are pairwise disjoint, then the product of `f a`
+over `a ∈ ⋃ i ∈ I, t i` is equal to the product over `i ∈ I` of the products of `f a` over
+`a ∈ t i`. -/
+@[to_additive "Given a family of sets `t : ι → set α`, a finite set `I` in the index type such that
+all sets `t i`, `i ∈ I`, are finite, if all `t i`, `i ∈ I`, are pairwise disjoint, then the sum of
+`f a` over `a ∈ ⋃ i ∈ I, t i` is equal to the sum over `i ∈ I` of the sums of `f a` over
+`a ∈ t i`."] lemma finprod_mem_bUnion {I : set ι} {t : ι → set α}
   (h : I.pairwise_disjoint t) (hI : I.finite) (ht : ∀ i ∈ I, (t i).finite) :
   ∏ᶠ a ∈ ⋃ x ∈ I, t x, f a = ∏ᶠ i ∈ I, ∏ᶠ j ∈ t i, f j :=
 begin
@@ -767,7 +827,9 @@ end
 
 /-- If `t` is a finite set of pairwise disjoint finite sets, then the product of `f a`
 over `a ∈ ⋃₀ t` is the product over `s ∈ t` of the products of `f a` over `a ∈ s`. -/
-@[to_additive] lemma finprod_mem_sUnion {t : set (set α)} (h : t.pairwise_disjoint id)
+@[to_additive "If `t` is a finite set of pairwise disjoint finite sets, then the sum of `f a` over
+`a ∈ ⋃₀ t` is the sum over `s ∈ t` of the sums of `f a` over `a ∈ s`."]
+lemma finprod_mem_sUnion {t : set (set α)} (h : t.pairwise_disjoint id)
   (ht₀ : t.finite) (ht₁ : ∀ x ∈ t, set.finite x) :
   ∏ᶠ a ∈ ⋃₀ t, f a = ∏ᶠ s ∈ t, ∏ᶠ a ∈ s, f a :=
 by { rw set.sUnion_eq_bUnion, exact finprod_mem_bUnion h ht₀ ht₁ }
@@ -791,7 +853,9 @@ end
 
 /-- If `s : set α` and `t : set β` are finite sets, then the product over `s` commutes
 with the product over `t`. -/
-@[to_additive] lemma finprod_mem_comm {s : set α} {t : set β}
+@[to_additive "If `s : set α` and `t : set β` are finite sets, then the sum over `s` commutes with
+the sum over `t`."]
+lemma finprod_mem_comm {s : set α} {t : set β}
   (f : α → β → M) (hs : s.finite) (ht : t.finite) :
   ∏ᶠ i ∈ s, ∏ᶠ j ∈ t, f i j = ∏ᶠ j ∈ t, ∏ᶠ i ∈ s, f i j :=
 begin
@@ -801,8 +865,9 @@ begin
 end
 
 /-- To prove a property of a finite product, it suffices to prove that the property is
-multiplicative and holds on multipliers. -/
-@[to_additive] lemma finprod_mem_induction (p : M → Prop) (hp₀ : p 1)
+multiplicative and holds on factors. -/
+@[to_additive "To prove a property of a finite sum, it suffices to prove that the property is
+additive and holds on summands."] lemma finprod_mem_induction (p : M → Prop) (hp₀ : p 1)
   (hp₁ : ∀ x y, p x → p y → p (x * y)) (hp₂ : ∀ x ∈ s, p $ f x) :
   p (∏ᶠ i ∈ s, f i) :=
 finprod_induction _ hp₀ hp₁ $ λ x, finprod_induction _ hp₀ hp₁ $ hp₂ x
@@ -855,13 +920,11 @@ end
   ∏ a in s, ∏ᶠ b : β, f a b = ∏ᶠ b : β, ∏ a in s, f a b :=
 (finprod_prod_comm s (λ b a, f a b) h).symm
 
-lemma mul_finsum {R : Type*} [semiring R] (f : α → R) (r : R)
-  (h : (function.support f).finite) :
+lemma mul_finsum {R : Type*} [semiring R] (f : α → R) (r : R) (h : (support f).finite) :
   r * ∑ᶠ a : α, f a = ∑ᶠ a : α, r * f a :=
 (add_monoid_hom.mul_left r).map_finsum h
 
-lemma finsum_mul {R : Type*} [semiring R] (f : α → R) (r : R)
-  (h : (function.support f).finite) :
+lemma finsum_mul {R : Type*} [semiring R] (f : α → R) (r : R) (h : (support f).finite) :
   (∑ᶠ a : α, f a) * r = ∑ᶠ a : α, f a * r :=
 (add_monoid_hom.mul_right r).map_finsum h
 
@@ -879,7 +942,10 @@ end
 /-- Note that `b ∈ (s.filter (λ ab, prod.fst ab = a)).image prod.snd` iff `(a, b) ∈ s` so we can
 simplify the right hand side of this lemma. However the form stated here is more useful for
 iterating this lemma, e.g., if we have `f : α × β × γ → M`. -/
-@[to_additive] lemma finprod_mem_finset_product' [decidable_eq α] [decidable_eq β]
+@[to_additive "Note that `b ∈ (s.filter (λ ab, prod.fst ab = a)).image prod.snd` iff `(a, b) ∈ s` so
+we can simplify the right hand side of this lemma. However the form stated here is more useful for
+iterating this lemma, e.g., if we have `f : α × β × γ → M`."]
+lemma finprod_mem_finset_product' [decidable_eq α] [decidable_eq β]
   (s : finset (α × β)) (f : α × β → M) :
   ∏ᶠ ab (h : ab ∈ s), f ab =
   ∏ᶠ a b (h : b ∈ (s.filter (λ ab, prod.fst ab = a)).image prod.snd), f (a, b) :=
@@ -901,7 +967,8 @@ begin
 end
 
 /-- See also `finprod_mem_finset_product'`. -/
-@[to_additive] lemma finprod_mem_finset_product (s : finset (α × β)) (f : α × β → M) :
+@[to_additive "See also `finsum_mem_finset_product'`."]
+lemma finprod_mem_finset_product (s : finset (α × β)) (f : α × β → M) :
   ∏ᶠ ab (h : ab ∈ s), f ab = ∏ᶠ a b (h : (a, b) ∈ s), f (a, b) :=
 by { classical, rw finprod_mem_finset_product', simp, }
 
@@ -928,8 +995,8 @@ lemma finprod_dmem {s : set α} [decidable_pred (∈ s)] (f : (Π (a : α), a �
 finprod_congr (λ a, finprod_congr (λ ha, (dif_pos ha).symm))
 
 @[to_additive]
-lemma finprod_emb_domain' {f : α → β} (hf : function.injective f)
-  [decidable_pred (∈ set.range f)] (g : α → M) :
+lemma finprod_emb_domain' {f : α → β} (hf : injective f) [decidable_pred (∈ set.range f)]
+  (g : α → M) :
   ∏ᶠ (b : β), (if h : b ∈ set.range f then g (classical.some h) else 1) = ∏ᶠ (a : α), g a :=
 begin
   simp_rw [← finprod_eq_dif],

--- a/src/algebra/big_operators/nat_antidiagonal.lean
+++ b/src/algebra/big_operators/nat_antidiagonal.lean
@@ -64,7 +64,8 @@ end
 
 /-- This lemma matches more generally than `finset.nat.prod_antidiagonal_eq_prod_range_succ_mk` when
 using `rw ←`. -/
-@[to_additive]
+@[to_additive "This lemma matches more generally than
+`finset.nat.sum_antidiagonal_eq_sum_range_succ_mk` when using `rw ←`."]
 lemma prod_antidiagonal_eq_prod_range_succ {M : Type*} [comm_monoid M] (f : ℕ → ℕ → M) (n : ℕ) :
   ∏ ij in finset.nat.antidiagonal n, f ij.1 ij.2 = ∏ k in range n.succ, f k (n - k) :=
 prod_antidiagonal_eq_prod_range_succ_mk _ _

--- a/src/algebra/big_operators/ring.lean
+++ b/src/algebra/big_operators/ring.lean
@@ -218,7 +218,8 @@ end comm_ring
 
 /-- A product over all subsets of `s ∪ {x}` is obtained by multiplying the product over all subsets
 of `s`, and over all subsets of `s` to which one adds `x`. -/
-@[to_additive]
+@[to_additive "A sum over all subsets of `s ∪ {x}` is obtained by summing the sum over all subsets
+of `s`, and over all subsets of `s` to which one adds `x`."]
 lemma prod_powerset_insert [decidable_eq α] [comm_monoid β] {s : finset α} {x : α} (h : x ∉ s)
   (f : finset α → β) :
   (∏ a in (insert x s).powerset, f a) =
@@ -235,9 +236,10 @@ begin
     exact ne_insert_of_not_mem _ _ (not_mem_of_mem_powerset_of_not_mem h₁ h) }
 end
 
-/-- A product over `powerset s` is equal to the double product over
-sets of subsets of `s` with `card s = k`, for `k = 1, ... , card s`. -/
-@[to_additive]
+/-- A product over `powerset s` is equal to the double product over sets of subsets of `s` with
+`card s = k`, for `k = 1, ..., card s`. -/
+@[to_additive "A sum over `powerset s` is equal to the double sum over sets of subsets of `s` with
+`card s = k`, for `k = 1, ..., card s`"]
 lemma prod_powerset [comm_monoid β] (s : finset α) (f : finset α → β) :
   ∏ t in powerset s, f t = ∏ j in range (card s + 1), ∏ t in powerset_len j s, f t :=
 begin

--- a/src/algebra/category/Group/limits.lean
+++ b/src/algebra/category/Group/limits.lean
@@ -58,13 +58,14 @@ begin
   apply_instance,
 end
 
-/--
-We show that the forgetful functor `Group ⥤ Mon` creates limits.
+/-- We show that the forgetful functor `Group ⥤ Mon` creates limits.
 
-All we need to do is notice that the limit point has a `group` instance available,
-and then reuse the existing limit.
--/
-@[to_additive]
+All we need to do is notice that the limit point has a `group` instance available, and then reuse
+the existing limit. -/
+@[to_additive "We show that the forgetful functor `AddGroup ⥤ AddMon` creates limits.
+
+All we need to do is notice that the limit point has an `add_group` instance available, and then
+reuse the existing limit."]
 instance (F : J ⥤ Group) : creates_limit F (forget₂ Group Mon.{u}) :=
 creates_limit_of_reflects_iso (λ c' t,
 { lifted_cone :=
@@ -95,26 +96,30 @@ def limit_cone_is_limit (F : J ⥤ Group) : is_limit (limit_cone F) :=
 lifted_limit_is_limit _
 
 /-- The category of groups has all limits. -/
-@[to_additive]
+@[to_additive "The category of additive groups has all limits."]
 instance has_limits : has_limits Group :=
 { has_limits_of_shape := λ J 𝒥, by exactI
   { has_limit := λ F, has_limit_of_created F (forget₂ Group Mon) } } -- TODO use the above instead?
 
-/--
-The forgetful functor from groups to monoids preserves all limits.
-(That is, the underlying monoid could have been computed instead as limits in the category
-of monoids.)
+/-- The forgetful functor from groups to monoids preserves all limits.
+
+This means the underlying monoid of a limit can be computed as a limit in the category of monoids.
 -/
-@[to_additive AddGroup.forget₂_AddMon_preserves_limits]
+@[to_additive AddGroup.forget₂_AddMon_preserves_limits "The forgetful functor from additive groups
+to additive monoids preserves all limits.
+
+This means the underlying additive monoid of a limit can be computed as a limit in the category of
+additive monoids."]
 instance forget₂_Mon_preserves_limits : preserves_limits (forget₂ Group Mon) :=
 { preserves_limits_of_shape := λ J 𝒥,
   { preserves_limit := λ F, by apply_instance } }
 
-/--
-The forgetful functor from groups to types preserves all limits. (That is, the underlying
-types could have been computed instead as limits in the category of types.)
--/
-@[to_additive]
+/-- The forgetful functor from groups to types preserves all limits.
+
+This means the underlying type of a limit can be computed as a limit in the category of types. -/
+@[to_additive "The forgetful functor from additive groups to types preserves all limits.
+
+This means the underlying type of a limit can be computed as a limit in the category of types."]
 instance forget_preserves_limits : preserves_limits (forget Group) :=
 { preserves_limits_of_shape := λ J 𝒥, by exactI
   { preserves_limit := λ F, limits.comp_preserves_limit (forget₂ Group Mon) (forget Mon) } }

--- a/src/algebra/category/Mon/limits.lean
+++ b/src/algebra/category/Mon/limits.lean
@@ -96,18 +96,19 @@ end has_limits
 open has_limits
 
 /-- The category of monoids has all limits. -/
-@[to_additive]
+@[to_additive "The category of additive monoids has all limits."]
 instance has_limits : has_limits Mon :=
 { has_limits_of_shape := λ J 𝒥, by exactI
   { has_limit := λ F, has_limit.mk
     { cone     := limit_cone F,
       is_limit := limit_cone_is_limit F } } }
 
-/--
-The forgetful functor from monoids to types preserves all limits. (That is, the underlying
-types could have been computed instead as limits in the category of types.)
--/
-@[to_additive]
+/-- The forgetful functor from monoids to types preserves all limits.
+
+This means the underlying type of a limit can be computed as a limit in the category of types. -/
+@[to_additive "The forgetful functor from additive monoids to types preserves all limits.
+
+This means the underlying type of a limit can be computed as a limit in the category of types."]
 instance forget_preserves_limits : preserves_limits (forget Mon) :=
 { preserves_limits_of_shape := λ J 𝒥, by exactI
   { preserves_limit := λ F, preserves_limit_of_preserves_limit_cone
@@ -130,13 +131,14 @@ instance limit_comm_monoid (F : J ⥤ CommMon) :
 @submonoid.to_comm_monoid (Π j, F.obj j) _
   (Mon.sections_submonoid (F ⋙ forget₂ CommMon Mon.{u}))
 
-/--
-We show that the forgetful functor `CommMon ⥤ Mon` creates limits.
+/-- We show that the forgetful functor `CommMon ⥤ Mon` creates limits.
 
 All we need to do is notice that the limit point has a `comm_monoid` instance available,
-and then reuse the existing limit.
--/
-@[to_additive]
+and then reuse the existing limit. -/
+@[to_additive "We show that the forgetful functor `AddCommMon ⥤ AddMon` creates limits.
+
+All we need to do is notice that the limit point has an `add_comm_monoid` instance available,
+and then reuse the existing limit."]
 instance (F : J ⥤ CommMon) : creates_limit F (forget₂ CommMon Mon.{u}) :=
 creates_limit_of_reflects_iso (λ c' t,
 { lifted_cone :=
@@ -167,26 +169,30 @@ def limit_cone_is_limit (F : J ⥤ CommMon) : is_limit (limit_cone F) :=
 lifted_limit_is_limit _
 
 /-- The category of commutative monoids has all limits. -/
-@[to_additive]
+@[to_additive "The category of commutative monoids has all limits."]
 instance has_limits : has_limits CommMon :=
 { has_limits_of_shape := λ J 𝒥, by exactI
   { has_limit := λ F, has_limit_of_created F (forget₂ CommMon Mon) } }
 
-/--
-The forgetful functor from commutative monoids to monoids preserves all limits.
-(That is, the underlying monoid could have been computed instead as limits in the category
-of monoids.)
--/
-@[to_additive AddCommMon.forget₂_AddMon_preserves_limits]
+/-- The forgetful functor from commutative monoids to monoids preserves all limits.
+
+This means the underlying type of a limit can be computed as a limit in the category of monoids. -/
+@[to_additive AddCommMon.forget₂_AddMon_preserves_limits "The forgetful functor from additive
+commutative monoids to additive monoids preserves all limits.
+
+This means the underlying type of a limit can be computed as a limit in the category of additive
+monoids."]
 instance forget₂_Mon_preserves_limits : preserves_limits (forget₂ CommMon Mon) :=
 { preserves_limits_of_shape := λ J 𝒥,
   { preserves_limit := λ F, by apply_instance } }
 
-/--
-The forgetful functor from commutative monoids to types preserves all limits. (That is, the
-underlying types could have been computed instead as limits in the category of types.)
--/
-@[to_additive]
+/-- The forgetful functor from commutative monoids to types preserves all limits.
+
+This means the underlying type of a limit can be computed as a limit in the category of types. -/
+@[to_additive "The forgetful functor from additive commutative monoids to types preserves all
+limits.
+
+This means the underlying type of a limit can be computed as a limit in the category of types."]
 instance forget_preserves_limits : preserves_limits (forget CommMon) :=
 { preserves_limits_of_shape := λ J 𝒥, by exactI
   { preserves_limit := λ F, limits.comp_preserves_limit (forget₂ CommMon Mon) (forget Mon) } }

--- a/src/algebra/group/commute.lean
+++ b/src/algebra/group/commute.lean
@@ -35,14 +35,16 @@ section has_mul
 variables {S : Type*} [has_mul S]
 
 /-- Equality behind `commute a b`; useful for rewriting. -/
-@[to_additive] protected theorem eq {a b : S} (h : commute a b) : a * b = b * a := h
+@[to_additive "Equality behind `add_commute a b`; useful for rewriting."]
+protected lemma eq {a b : S} (h : commute a b) : a * b = b * a := h
 
 /-- Any element commutes with itself. -/
-@[refl, simp, to_additive] protected theorem refl (a : S) : commute a a := eq.refl (a * a)
+@[refl, simp, to_additive "Any element commutes with itself."]
+protected lemma refl (a : S) : commute a a := eq.refl (a * a)
 
 /-- If `a` commutes with `b`, then `b` commutes with `a`. -/
-@[symm, to_additive] protected theorem symm {a b : S} (h : commute a b) : commute b a :=
-eq.symm h
+@[symm, to_additive "If `a` commutes with `b`, then `b` commutes with `a`."]
+protected lemma symm {a b : S} (h : commute a b) : commute b a := eq.symm h
 
 @[to_additive] protected theorem semiconj_by {a b : S} (h : commute a b) : semiconj_by a b b := h
 
@@ -57,14 +59,12 @@ section semigroup
 variables {S : Type*} [semigroup S] {a b c : S}
 
 /-- If `a` commutes with both `b` and `c`, then it commutes with their product. -/
-@[simp, to_additive] theorem mul_right (hab : commute a b) (hac : commute a c) :
-  commute a (b * c) :=
-hab.mul_right hac
+@[simp, to_additive "If `a` commutes with both `b` and `c`, then it commutes with their sum."]
+lemma mul_right (hab : commute a b) (hac : commute a c) : commute a (b * c) := hab.mul_right hac
 
 /-- If both `a` and `b` commute with `c`, then their product commutes with `c`. -/
-@[simp, to_additive] theorem mul_left (hac : commute a c) (hbc : commute b c) :
-  commute (a * b) c :=
-hac.mul_left hbc
+@[simp, to_additive "If both `a` and `b` commute with `c`, then their product commutes with `c`."]
+lemma mul_left (hac : commute a c) (hbc : commute b c) : commute (a * b) c := hac.mul_left hbc
 
 @[to_additive] protected lemma right_comm (h : commute b c) (a : S) :
   a * b * c = a * c * b :=

--- a/src/algebra/group/freiman.lean
+++ b/src/algebra/group/freiman.lean
@@ -79,7 +79,9 @@ class add_freiman_hom_class (F : Type*) (A : out_param $ set α) (β : out_param
 
 /-- `freiman_hom_class F A β n` states that `F` is a type of `n`-ary products-preserving morphisms.
 You should extend this class when you extend `freiman_hom`. -/
-@[to_additive add_freiman_hom_class]
+@[to_additive add_freiman_hom_class
+"`add_freiman_hom_class F A β n` states that `F` is a type of `n`-ary sums-preserving morphisms.
+You should extend this class when you extend `add_freiman_hom`."]
 class freiman_hom_class (F : Type*) (A : out_param $ set α) (β : out_param $ Type*) [comm_monoid α]
   [comm_monoid β] (n : ℕ) [fun_like F α (λ _, β)] :=
 (map_prod_eq_map_prod' (f : F) {s t : multiset α} (hsA : ∀ ⦃x⦄, x ∈ s → x ∈ A)
@@ -216,7 +218,8 @@ instance : has_mul (A →*[n] β) :=
 
 /-- If `f` is a Freiman homomorphism to a commutative group, then `f⁻¹` is the Freiman homomorphism
 sending `x` to `(f x)⁻¹`. -/
-@[to_additive]
+@[to_additive "If `f` is a Freiman homomorphism to an additive commutative group, then `-f` is the
+Freiman homomorphism sending `x` to `-f x`."]
 instance : has_inv (A →*[n] G) :=
 ⟨λ f, { to_fun := λ x, (f x)⁻¹,
   map_prod_eq_map_prod' := λ s t hsA htA hs ht h,
@@ -288,7 +291,11 @@ end freiman_hom
 
 We can't leave the domain `A : set α` of the `freiman_hom` a free variable, since it wouldn't be
 inferrable. -/
-@[to_additive]
+@[to_additive " An additive monoid homomorphism is naturally an `add_freiman_hom` on its entire
+domain.
+
+We can't leave the domain `A : set α` of the `freiman_hom` a free variable, since it wouldn't be
+inferrable."]
 instance monoid_hom.freiman_hom_class : freiman_hom_class (α →* β) set.univ β n :=
 { map_prod_eq_map_prod' := λ f s t _ _ _ _ h, by rw [←f.map_multiset_prod, h, f.map_multiset_prod] }
 

--- a/src/algebra/group/hom.lean
+++ b/src/algebra/group/hom.lean
@@ -265,9 +265,10 @@ attribute [nolint doc_blame] monoid_hom.to_one_hom
 infixr ` →* `:25 := monoid_hom
 
 /-- `monoid_hom_class F M N` states that `F` is a type of `monoid`-preserving homomorphisms.
-You should also extend this typeclass when you extend `monoid_hom`.
--/
-@[ancestor mul_hom_class one_hom_class, to_additive]
+You should also extend this typeclass when you extend `monoid_hom`. -/
+@[ancestor mul_hom_class one_hom_class, to_additive
+"`add_monoid_hom_class F M N` states that `F` is a type of `add_monoid`-preserving homomorphisms.
+You should also extend this typeclass when you extend `add_monoid_hom`."]
 class monoid_hom_class (F : Type*) (M N : out_param $ Type*)
   [mul_one_class M] [mul_one_class N]
   extends mul_hom_class F M N, one_hom_class F M N
@@ -289,19 +290,20 @@ lemma map_mul_eq_one [monoid_hom_class F M N] (f : F) {a b : M} (h : a * b = 1) 
 by rw [← map_mul, h, map_one]
 
 /-- Group homomorphisms preserve inverse. -/
-@[simp, to_additive]
+@[simp, to_additive "Additive group homomorphisms preserve negation."]
 theorem map_inv [group G] [group H] [monoid_hom_class F G H]
   (f : F) (g : G) : f g⁻¹ = (f g)⁻¹ :=
 eq_inv_of_mul_eq_one $ map_mul_eq_one f $ inv_mul_self g
 
 /-- Group homomorphisms preserve division. -/
-@[simp, to_additive]
+@[simp, to_additive "Additive group homomorphisms preserve subtraction."]
 theorem map_mul_inv [group G] [group H] [monoid_hom_class F G H]
   (f : F) (g h : G) : f (g * h⁻¹) = f g * (f h)⁻¹ :=
 by rw [map_mul, map_inv]
 
 /-- Group homomorphisms preserve division. -/
-@[simp, to_additive] lemma map_div [group G] [group H] [monoid_hom_class F G H]
+@[simp, to_additive "Additive group homomorphisms preserve subtraction."]
+lemma map_div [group G] [group H] [monoid_hom_class F G H]
   (f : F) (x y : G) : f (x / y) = f x / f y :=
 by rw [div_eq_mul_inv, div_eq_mul_inv, map_mul_inv]
 
@@ -319,7 +321,7 @@ theorem map_zpow' [div_inv_monoid G] [div_inv_monoid H] [monoid_hom_class F G H]
 | -[1+n]  := by rw [zpow_neg_succ_of_nat, hf, map_pow, ← zpow_neg_succ_of_nat]
 
 /-- Group homomorphisms preserve integer power. -/
-@[simp, to_additive /-" Additive group homomorphisms preserve integer scaling. "-/]
+@[simp, to_additive "Additive group homomorphisms preserve integer scaling."]
 theorem map_zpow [group G] [group H] [monoid_hom_class F G H] (f : F) (g : G) (n : ℤ) :
   f (g ^ n) = (f g) ^ n :=
 map_zpow' f (map_inv f) g n
@@ -487,17 +489,17 @@ fun_like.ext _ _ h
 section deprecated
 
 /-- Deprecated: use `fun_like.congr_fun` instead. -/
-@[to_additive]
+@[to_additive "Deprecated: use `fun_like.congr_fun` instead."]
 theorem one_hom.congr_fun [has_one M] [has_one N]
   {f g : one_hom M N} (h : f = g) (x : M) : f x = g x :=
 fun_like.congr_fun h x
 /-- Deprecated: use `fun_like.congr_fun` instead. -/
-@[to_additive]
+@[to_additive "Deprecated: use `fun_like.congr_fun` instead."]
 theorem mul_hom.congr_fun [has_mul M] [has_mul N]
   {f g : mul_hom M N} (h : f = g) (x : M) : f x = g x :=
 fun_like.congr_fun h x
 /-- Deprecated: use `fun_like.congr_fun` instead. -/
-@[to_additive]
+@[to_additive "Deprecated: use `fun_like.congr_fun` instead."]
 theorem monoid_hom.congr_fun [mul_one_class M] [mul_one_class N]
   {f g : M →* N} (h : f = g) (x : M) : f x = g x :=
 fun_like.congr_fun h x
@@ -507,17 +509,17 @@ theorem monoid_with_zero_hom.congr_fun [mul_zero_one_class M] [mul_zero_one_clas
 fun_like.congr_fun h x
 
 /-- Deprecated: use `fun_like.congr_arg` instead. -/
-@[to_additive]
+@[to_additive "Deprecated: use `fun_like.congr_arg` instead."]
 theorem one_hom.congr_arg [has_one M] [has_one N]
   (f : one_hom M N) {x y : M} (h : x = y) : f x = f y :=
 fun_like.congr_arg f h
 /-- Deprecated: use `fun_like.congr_arg` instead. -/
-@[to_additive]
+@[to_additive "Deprecated: use `fun_like.congr_arg` instead."]
 theorem mul_hom.congr_arg [has_mul M] [has_mul N]
   (f : mul_hom M N) {x y : M} (h : x = y) : f x = f y :=
 fun_like.congr_arg f h
 /-- Deprecated: use `fun_like.congr_arg` instead. -/
-@[to_additive]
+@[to_additive "Deprecated: use `fun_like.congr_arg` instead."]
 theorem monoid_hom.congr_arg [mul_one_class M] [mul_one_class N]
   (f : M →* N) {x y : M} (h : x = y) : f x = f y :=
 fun_like.congr_arg f h
@@ -527,15 +529,15 @@ theorem monoid_with_zero_hom.congr_arg [mul_zero_one_class M] [mul_zero_one_clas
 fun_like.congr_arg f h
 
 /-- Deprecated: use `fun_like.coe_injective` instead. -/
-@[to_additive]
+@[to_additive "Deprecated: use `fun_like.coe_injective` instead."]
 lemma one_hom.coe_inj [has_one M] [has_one N] ⦃f g : one_hom M N⦄ (h : (f : M → N) = g) : f = g :=
 fun_like.coe_injective h
 /-- Deprecated: use `fun_like.coe_injective` instead. -/
-@[to_additive]
+@[to_additive "Deprecated: use `fun_like.coe_injective` instead."]
 lemma mul_hom.coe_inj [has_mul M] [has_mul N] ⦃f g : mul_hom M N⦄ (h : (f : M → N) = g) : f = g :=
 fun_like.coe_injective h
 /-- Deprecated: use `fun_like.coe_injective` instead. -/
-@[to_additive]
+@[to_additive "Deprecated: use `fun_like.coe_injective` instead."]
 lemma monoid_hom.coe_inj [mul_one_class M] [mul_one_class N]
   ⦃f g : M →* N⦄ (h : (f : M → N) = g) : f = g :=
 fun_like.coe_injective h
@@ -545,7 +547,7 @@ lemma monoid_with_zero_hom.coe_inj [mul_zero_one_class M] [mul_zero_one_class N]
 fun_like.coe_injective h
 
 /-- Deprecated: use `fun_like.ext_iff` instead. -/
-@[to_additive]
+@[to_additive "Deprecated: use `fun_like.ext_iff` instead."]
 lemma one_hom.ext_iff [has_one M] [has_one N] {f g : one_hom M N} : f = g ↔ ∀ x, f x = g x :=
 fun_like.ext_iff
 /-- Deprecated: use `fun_like.ext_iff` instead. -/
@@ -1047,13 +1049,13 @@ protected theorem map_inv {G H} [group G] [group H] (f : G →* H) (g : G) : f g
 map_inv f g
 
 /-- Group homomorphisms preserve integer power. -/
-@[to_additive /-" Additive group homomorphisms preserve integer scaling. "-/]
+@[to_additive "Additive group homomorphisms preserve integer scaling."]
 protected theorem map_zpow {G H} [group G] [group H] (f : G →* H) (g : G) (n : ℤ) :
   f (g ^ n) = (f g) ^ n :=
 map_zpow f g n
 
 /-- Group homomorphisms preserve division. -/
-@[to_additive /-" Additive group homomorphisms preserve subtraction. "-/]
+@[to_additive "Additive group homomorphisms preserve subtraction."]
 protected theorem map_div {G H} [group G] [group H] (f : G →* H) (g h : G) :
   f (g / h) = f g / f h :=
 map_div f g h
@@ -1066,9 +1068,9 @@ map_mul_inv f g h
 
 /-- A homomorphism from a group to a monoid is injective iff its kernel is trivial.
 For the iff statement on the triviality of the kernel, see `monoid_hom.injective_iff'`.  -/
-@[to_additive /-" A homomorphism from an additive group to an additive monoid is injective iff
+@[to_additive "A homomorphism from an additive group to an additive monoid is injective iff
 its kernel is trivial. For the iff statement on the triviality of the kernel,
-see `add_monoid_hom.injective_iff'`. "-/]
+see `add_monoid_hom.injective_iff'`."]
 lemma injective_iff {G H} [group G] [mul_one_class H] (f : G →* H) :
   function.injective f ↔ (∀ a, f a = 1 → a = 1) :=
 ⟨λ h x, (map_eq_one_iff f h).mp,
@@ -1077,9 +1079,9 @@ lemma injective_iff {G H} [group G] [mul_one_class H] (f : G →* H) :
 /-- A homomorphism from a group to a monoid is injective iff its kernel is trivial,
 stated as an iff on the triviality of the kernel.
 For the implication, see `monoid_hom.injective_iff`. -/
-@[to_additive /-" A homomorphism from an additive group to an additive monoid is injective iff
-its kernel is trivial, stated as an iff on the triviality of the kernel. For the implication, see
-`add_monoid_hom.injective_iff`. "-/]
+@[to_additive "A homomorphism from an additive group to an additive monoid is injective iff its
+kernel is trivial, stated as an iff on the triviality of the kernel. For the implication, see
+`add_monoid_hom.injective_iff`."]
 lemma injective_iff' {G H} [group G] [mul_one_class H] (f : G →* H) :
   function.injective f ↔ (∀ a, f a = 1 ↔ a = 1) :=
 f.injective_iff.trans $ forall_congr $ λ a, ⟨λ h, ⟨h, λ H, H.symm ▸ f.map_one⟩, iff.mp⟩

--- a/src/algebra/group/semiconj.lean
+++ b/src/algebra/group/semiconj.lean
@@ -35,7 +35,7 @@ def semiconj_by {M : Type u} [has_mul M] (a x y : M) : Prop := a * x = y * a
 namespace semiconj_by
 
 /-- Equality behind `semiconj_by a x y`; useful for rewriting. -/
-@[to_additive]
+@[to_additive "Equality behind `add_semiconj_by a x y`; useful for rewriting."]
 protected lemma eq {S : Type u} [has_mul S] {a x y : S} (h : semiconj_by a x y) :
   a * x = y * a := h
 
@@ -45,14 +45,15 @@ variables {S : Type u} [semigroup S] {a b x y z x' y' : S}
 
 /-- If `a` semiconjugates `x` to `y` and `x'` to `y'`,
 then it semiconjugates `x * x'` to `y * y'`. -/
-@[simp, to_additive] lemma mul_right (h : semiconj_by a x y) (h' : semiconj_by a x' y') :
+@[simp, to_additive "If `a` semiconjugates `x` to `y` and `x'` to `y'`, then it semiconjugates
+`x + x'` to `y + y'`."]
+lemma mul_right (h : semiconj_by a x y) (h' : semiconj_by a x' y') :
   semiconj_by a (x * x') (y * y') :=
 by unfold semiconj_by; assoc_rw [h.eq, h'.eq]
 
 /-- If both `a` and `b` semiconjugate `x` to `y`, then so does `a * b`. -/
-@[to_additive]
-lemma mul_left (ha : semiconj_by a y z) (hb : semiconj_by b x y) :
-  semiconj_by (a * b) x z :=
+@[to_additive "If both `a` and `b` semiconjugate `x` to `y`, then so does `a + b`."]
+lemma mul_left (ha : semiconj_by a y z) (hb : semiconj_by b x y) : semiconj_by (a * b) x z :=
 by unfold semiconj_by; assoc_rw [hb.eq, ha.eq, mul_assoc]
 
 /-- The relation “there exists an element that semiconjugates `a` to `b`” on a semigroup
@@ -90,8 +91,9 @@ section monoid
 variables {M : Type u} [monoid M]
 
 /-- If `a` semiconjugates a unit `x` to a unit `y`, then it semiconjugates `x⁻¹` to `y⁻¹`. -/
-@[to_additive] lemma units_inv_right {a : M} {x y : Mˣ} (h : semiconj_by a x y) :
-  semiconj_by a ↑x⁻¹ ↑y⁻¹ :=
+@[to_additive "If `a` semiconjugates an additive unit `x` to an additive unit `y`, then it
+semiconjugates `-x` to `-y`."]
+lemma units_inv_right {a : M} {x y : Mˣ} (h : semiconj_by a x y) : semiconj_by a ↑x⁻¹ ↑y⁻¹ :=
 calc a * ↑x⁻¹ = ↑y⁻¹ * (y * a) * ↑x⁻¹ : by rw [units.inv_mul_cancel_left]
           ... = ↑y⁻¹ * a              : by rw [← h.eq, mul_assoc, units.mul_inv_cancel_right]
 
@@ -100,7 +102,9 @@ calc a * ↑x⁻¹ = ↑y⁻¹ * (y * a) * ↑x⁻¹ : by rw [units.inv_mul_canc
 ⟨units_inv_right, units_inv_right⟩
 
 /-- If a unit `a` semiconjugates `x` to `y`, then `a⁻¹` semiconjugates `y` to `x`. -/
-@[to_additive] lemma units_inv_symm_left {a : Mˣ} {x y : M} (h : semiconj_by ↑a x y) :
+@[to_additive "If an additive unit `a` semiconjugates `x` to `y`, then `-a` semiconjugates `y` to
+`x`."]
+lemma units_inv_symm_left {a : Mˣ} {x y : M} (h : semiconj_by ↑a x y) :
   semiconj_by ↑a⁻¹ y x :=
 calc ↑a⁻¹ * y = ↑a⁻¹ * (y * a * ↑a⁻¹) : by rw [units.mul_inv_cancel_right]
           ... = x * ↑a⁻¹              : by rw [← h.eq, ← mul_assoc, units.inv_mul_cancel_left]
@@ -157,7 +161,8 @@ h.inv_right.inv_symm_left
 inv_right_iff.trans inv_symm_left_iff
 
 /-- `a` semiconjugates `x` to `a * x * a⁻¹`. -/
-@[to_additive] lemma conj_mk (a x : G) : semiconj_by a x (a * x * a⁻¹) :=
+@[to_additive "`a` semiconjugates `x` to `a + x + -a`."]
+lemma conj_mk (a x : G) : semiconj_by a x (a * x * a⁻¹) :=
 by unfold semiconj_by; rw [mul_assoc, inv_mul_self, mul_one]
 
 end group
@@ -170,7 +175,7 @@ lemma semiconj_by_iff_eq {M : Type u} [cancel_comm_monoid M] {a x y : M} :
 ⟨λ h, mul_left_cancel (h.trans (mul_comm _ _)), λ h, by rw [h, semiconj_by, mul_comm] ⟩
 
 /-- `a` semiconjugates `x` to `a * x * a⁻¹`. -/
-@[to_additive]
+@[to_additive "`a` semiconjugates `x` to `a + x + -a`."]
 lemma units.mk_semiconj_by {M : Type u} [monoid M] (u : Mˣ) (x : M) :
   semiconj_by ↑u x (u * x * ↑u⁻¹) :=
 by unfold semiconj_by; rw [units.inv_mul_cancel_right]

--- a/src/algebra/group/units.lean
+++ b/src/algebra/group/units.lean
@@ -115,7 +115,7 @@ lemma copy_eq (u : αˣ) (val hv inv hi) :
 ext hv
 
 /-- Units of a monoid form a group. -/
-@[to_additive] instance : group αˣ :=
+@[to_additive "Additive units of an additive monoid form an additive group."] instance : group αˣ :=
 { mul := λ u₁ u₂, ⟨u₁.val * u₂.val, u₂.inv * u₁.inv,
     by rw [mul_assoc, ← mul_assoc u₂.val, val_inv, one_mul, val_inv],
     by rw [mul_assoc, ← mul_assoc u₁.inv, inv_val, one_mul, inv_val]⟩,

--- a/src/algebra/group_power/basic.lean
+++ b/src/algebra/group_power/basic.lean
@@ -49,7 +49,7 @@ theorem pow_one (a : M) : a^1 = a :=
 by rw [pow_succ, pow_zero, mul_one]
 
 /-- Note that most of the lemmas about powers of two refer to it as `sq`. -/
-@[to_additive two_nsmul]
+@[to_additive two_nsmul, nolint to_additive_doc]
 theorem pow_two (a : M) : a^2 = a * a :=
 by rw [pow_succ, pow_one]
 

--- a/src/algebra/indicator_function.lean
+++ b/src/algebra/indicator_function.lean
@@ -101,9 +101,11 @@ end
   function.mul_support (s.mul_indicator f) = s ∩ function.mul_support f :=
 ext $ λ x, by simp [function.mem_mul_support, mul_indicator_apply_eq_one]
 
-/-- If a multiplicative indicator function is not equal to one at a point, then that
-point is in the set. -/
-@[to_additive] lemma mem_of_mul_indicator_ne_one (h : mul_indicator s f a ≠ 1) : a ∈ s :=
+/-- If a multiplicative indicator function is not equal to `1` at a point, then that point is in the
+set. -/
+@[to_additive "If an additive indicator function is not equal to `0` at a point, then that point is
+in the set."]
+lemma mem_of_mul_indicator_ne_one (h : mul_indicator s f a ≠ 1) : a ∈ s :=
 not_imp_comm.1 (λ hn, mul_indicator_of_not_mem hn f) h
 
 @[to_additive] lemma eq_on_mul_indicator : eq_on (mul_indicator s f) f s :=
@@ -352,7 +354,7 @@ begin
     exact mul_indicator_of_not_mem hn _ }
 end
 
-/-- Consider a sum of `g i (f i)` over a `finset`.  Suppose `g` is a
+/-- Consider a sum of `g i (f i)` over a `finset`. Suppose `g` is a
 function such as multiplication, which maps a second argument of 0 to
 0.  (A typical use case would be a weighted sum of `f i * h i` or `f i
 • h i`, where `f` gives the weights that are multiplied by some other
@@ -361,14 +363,13 @@ function, the `finset` may be replaced by a possibly larger `finset`
 without changing the value of the sum. -/
 add_decl_doc set.sum_indicator_subset_of_eq_zero
 
-@[to_additive] lemma prod_mul_indicator_subset (f : α → M) {s t : finset α} (h : s ⊆ t) :
+/-- Taking the product of an indicator function over a possibly larger `finset` is the same as
+taking the original function over the original `finset`. -/
+@[to_additive "Summing an indicator function over a possibly larger `finset` is the same as summing
+the original function over the original `finset`."]
+lemma prod_mul_indicator_subset (f : α → M) {s t : finset α} (h : s ⊆ t) :
   ∏ i in s, f i = ∏ i in t, mul_indicator ↑s f i :=
 prod_mul_indicator_subset_of_eq_one _ (λ a b, b) h (λ _, rfl)
-
-/-- Summing an indicator function over a possibly larger `finset` is
-the same as summing the original function over the original
-`finset`. -/
-add_decl_doc sum_indicator_subset
 
 @[to_additive] lemma _root_.finset.prod_mul_indicator_eq_prod_filter
   (s : finset ι) (f : ι → α → M) (t : ι → set α) (g : ι → α) :

--- a/src/algebra/order/group.lean
+++ b/src/algebra/order/group.lean
@@ -70,7 +70,8 @@ instance ordered_comm_group.to_covariant_class_left_le (α : Type u) [ordered_co
 { elim := λ a b c bc, ordered_comm_group.mul_le_mul_left b c bc a }
 
 /--The units of an ordered commutative monoid form an ordered commutative group. -/
-@[to_additive]
+@[to_additive "The units of an ordered commutative additive monoid form an ordered commutative
+additive group."]
 instance units.ordered_comm_group [ordered_comm_monoid α] : ordered_comm_group αˣ :=
 { mul_le_mul_left := λ a b h c, (mul_le_mul_left' (h : (a : α) ≤ b) _ :  (c : α) * a ≤ c * b),
   .. units.partial_order,
@@ -232,14 +233,14 @@ end typeclasses_right_le
 section typeclasses_right_lt
 variables [has_lt α] [covariant_class α α (swap (*)) (<)] {a b c : α}
 
-/--  Uses `right` co(ntra)variant. -/
-@[simp, to_additive right.neg_neg_iff]
+/-- Uses `right` co(ntra)variant. -/
+@[simp, to_additive right.neg_neg_iff "Uses `right` co(ntra)variant."]
 lemma right.inv_lt_one_iff :
   a⁻¹ < 1 ↔ 1 < a :=
 by rw [← mul_lt_mul_iff_right a, inv_mul_self, one_mul]
 
-/--  Uses `right` co(ntra)variant. -/
-@[simp, to_additive right.neg_pos_iff]
+/-- Uses `right` co(ntra)variant. -/
+@[simp, to_additive right.neg_pos_iff "Uses `right` co(ntra)variant."]
 lemma right.one_lt_inv_iff :
   1 < a⁻¹ ↔ a < 1 :=
 by rw [← mul_lt_mul_iff_right a, inv_mul_self, one_mul]
@@ -996,12 +997,11 @@ section covariant_add_le
 section has_neg
 
 /-- `abs a` is the absolute value of `a`. -/
-@[to_additive, priority 100] -- see Note [lower instance priority]
-instance has_inv_lattice_has_abs [has_inv α] [lattice α] : has_abs (α)  := ⟨λa, a ⊔ (a⁻¹)⟩
+@[to_additive "`abs a` is the absolute value of `a`",
+  priority 100] -- see Note [lower instance priority]
+instance has_inv.to_has_abs [has_inv α] [has_sup α] : has_abs α := ⟨λ a, a ⊔ a⁻¹⟩
 
-@[to_additive]
-lemma abs_eq_sup_inv [has_inv α] [lattice α] (a : α) : |a| = a ⊔ a⁻¹ :=
-rfl
+@[to_additive] lemma abs_eq_sup_inv [has_inv α] [has_sup α] (a : α) : |a| = a ⊔ a⁻¹ := rfl
 
 variables [has_neg α] [linear_order α] {a b: α}
 

--- a/src/algebra/order/hom/monoid.lean
+++ b/src/algebra/order/hom/monoid.lean
@@ -176,7 +176,9 @@ instance : order_monoid_hom_class (α →*o β) α β :=
 
 /-- Helper instance for when there's too many metavariables to apply `fun_like.has_coe_to_fun`
 directly. -/
-@[to_additive] instance : has_coe_to_fun (α →*o β) (λ _, α → β) := fun_like.has_coe_to_fun
+@[to_additive "Helper instance for when there's too many metavariables to apply
+`fun_like.has_coe_to_fun` directly."]
+instance : has_coe_to_fun (α →*o β) (λ _, α → β) := fun_like.has_coe_to_fun
 
 -- Other lemmas should be accessed through the `fun_like` API
 @[ext, to_additive] lemma ext (h : ∀ a, f a = g a) : f = g := fun_like.ext f g h

--- a/src/algebra/order/lattice_group.lean
+++ b/src/algebra/order/lattice_group.lean
@@ -390,8 +390,8 @@ begin
   ... = |a / b|           : by rw sup_div_inf_eq_abs_div
 end
 
-/-- If `a` is positive, then it is equal to its positive component `a⁺`. -/
-@[to_additive "If `a` is positive, then it is equal to its positive component `a⁺`."] -- pos_of_nonneg
+/-- If `a` is positive, then it is equal to its positive component `a⁺`. -/ -- pos_of_nonneg
+@[to_additive "If `a` is positive, then it is equal to its positive component `a⁺`."]
 lemma pos_of_one_le (a : α) (h : 1 ≤ a) : a⁺ = a :=
 by { rw m_pos_part_def, exact sup_of_le_left h, }
 

--- a/src/algebra/order/lattice_group.lean
+++ b/src/algebra/order/lattice_group.lean
@@ -390,11 +390,8 @@ begin
   ... = |a / b|           : by rw sup_div_inf_eq_abs_div
 end
 
-/--
-Let `α` be a lattice ordered commutative group and let `a` be a positive element in `α`. Then `a` is
-equal to its positive component `a⁺`.
--/
-@[to_additive] -- pos_of_nonneg
+/-- If `a` is positive, then it is equal to its positive component `a⁺`. -/
+@[to_additive "If `a` is positive, then it is equal to its positive component `a⁺`."] -- pos_of_nonneg
 lemma pos_of_one_le (a : α) (h : 1 ≤ a) : a⁺ = a :=
 by { rw m_pos_part_def, exact sup_of_le_left h, }
 
@@ -430,11 +427,9 @@ begin
   apply one_le_mul h h,
 end
 
-/--
-The unary operation of taking the absolute value is idempotent.
--/
-@[simp, to_additive abs_abs]
-lemma m_abs_abs [covariant_class α α (*) (≤)] (a : α) : | |a| | = |a| :=
+/-- The unary operation of taking the absolute value is idempotent. -/
+@[simp, to_additive abs_abs "The unary operation of taking the absolute value is idempotent."]
+lemma mabs_mabs [covariant_class α α (*) (≤)] (a : α) : | |a| | = |a| :=
 mabs_of_one_le _ (one_le_abs _)
 
 @[to_additive abs_sup_sub_sup_le_abs]

--- a/src/algebra/order/monoid_lemmas.lean
+++ b/src/algebra/order/monoid_lemmas.lean
@@ -266,18 +266,16 @@ calc  b ≤ c     : hbc
     ... = 1 * c : (one_mul c).symm
     ... ≤ a * c : mul_le_mul_right' ha c
 
-/--
-Assume monotonicity on the `left`. The lemma assuming `right` is `right.mul_lt_one`. -/
-@[to_additive]
+/-- Assumes left covariance. The lemma assuming right covariance is `right.mul_lt_one`. -/
+@[to_additive "Assumes left covariance. The lemma assuming right covariance is `right.add_neg`."]
 lemma left.mul_lt_one [covariant_class α α (*) (<)]
   {a b : α} (ha : a < 1) (hb : b < 1) : a * b < 1 :=
 calc  a * b < a * 1 : mul_lt_mul_left' hb a
         ... = a     : mul_one a
         ... < 1     : ha
 
-/--
-Assume monotonicity on the `right`. The lemma assuming `left` is `left.mul_lt_one`. -/
-@[to_additive]
+/-- Assumes right covariance. The lemma assuming left covariance is `left.mul_lt_one`. -/
+@[to_additive "Assumes right covariance. The lemma assuming left covariance is `left.add_neg`"]
 lemma right.mul_lt_one [covariant_class α α (swap (*)) (<)]
   {a b : α} (ha : a < 1) (hb : b < 1) : a * b < 1 :=
 calc  a * b < 1 * b : mul_lt_mul_right' ha b
@@ -307,7 +305,7 @@ calc  b ≤ c     : hbc
     ... < a * c : mul_lt_mul_right' ha c
 
 /-- Assumes left covariance. -/
-@[to_additive]
+@[to_additive "Assumes left covariance."]
 lemma le_mul_of_le_of_le_one [covariant_class α α (*) (≤)]
   {a b c : α} (ha : c ≤ a) (hb : 1 ≤ b) : c ≤ a * b :=
 calc  c ≤ a     : ha
@@ -321,7 +319,7 @@ lemma one_le_mul [covariant_class α α (*) (≤)]
 le_mul_of_le_of_le_one ha hb
 
 /-- Assumes left covariance. -/
-@[to_additive]
+@[to_additive "Assumes left covariance."]
 lemma lt_mul_of_lt_of_one_lt [covariant_class α α (*) (<)]
   {a b c : α} (ha : c < a) (hb : 1 < b) : c < a * b :=
 calc  c < a     : ha
@@ -329,7 +327,7 @@ calc  c < a     : ha
     ... < a * b : mul_lt_mul_left' hb a
 
 /-- Assumes left covariance. -/
-@[to_additive]
+@[to_additive "Assumes left covariance."]
 lemma left.mul_lt_one_of_lt_of_lt_one [covariant_class α α (*) (<)]
   {a b c : α} (ha : a < c) (hb : b < 1) : a * b < c :=
 calc  a * b < a * 1 : mul_lt_mul_left' hb a
@@ -337,7 +335,7 @@ calc  a * b < a * 1 : mul_lt_mul_left' hb a
         ... < c     : ha
 
 /-- Assumes right covariance. -/
-@[to_additive]
+@[to_additive "Assumes right covariance."]
 lemma right.mul_lt_one_of_lt_of_lt_one [covariant_class α α (swap (*)) (<)]
   {a b c : α} (ha : a < 1) (hb : b < c) : a * b < c :=
 calc  a * b < 1 * b : mul_lt_mul_right' ha b
@@ -345,7 +343,7 @@ calc  a * b < 1 * b : mul_lt_mul_right' ha b
         ... < c     : hb
 
 /-- Assumes right covariance. -/
-@[to_additive right.add_nonneg]
+@[to_additive right.add_nonneg "Assumes right covariance."]
 lemma right.one_le_mul [covariant_class α α (swap (*)) (≤)]
   {a b : α} (ha : 1 ≤ a) (hb : 1 ≤ b) : 1 ≤ a * b :=
 calc  1 ≤ b     : hb
@@ -353,7 +351,7 @@ calc  1 ≤ b     : hb
     ... ≤ a * b : mul_le_mul_right' ha b
 
 /-- Assumes right covariance. -/
-@[to_additive right.add_pos]
+@[to_additive right.add_pos "Assumes right covariance."]
 lemma right.one_lt_mul [covariant_class α α (swap (*)) (<)]
   {b : α} (hb : 1 < b) {a: α} (ha : 1 < a) : 1 < a * b :=
 calc  1 < b     : hb

--- a/src/algebra/pointwise.lean
+++ b/src/algebra/pointwise.lean
@@ -1280,9 +1280,10 @@ localized "attribute [instance] finset.mul_one_class finset.add_zero_class finse
 
 open_locale classical
 
-/-- A finite set `U` contained in the product of two sets `S * S'` is also contained in the product
-of two finite sets `T * T' ⊆ S * S'`. -/
-@[to_additive]
+/-- If a finset `U` contained in the product of two sets `S * S'`, we can find two finsets `T`, `T'`
+such that `U ⊆ T * T'` and `T * T' ⊆ S * S'`. -/
+@[to_additive "If a finset `U` contained in the product of two sets `S * S'`, we can find two
+finsets `T`, `T'` such that `U ⊆ T * T'` and `T * T' ⊆ S * S'`."]
 lemma subset_mul {M : Type*} [monoid M] {S : set M} {S' : set M} {U : finset M} (f : ↑U ⊆ S * S') :
   ∃ (T T' : finset M), ↑T ⊆ S ∧ ↑T' ⊆ S' ∧ U ⊆ T * T' :=
 begin


### PR DESCRIPTION
Many additive lemmas had no docstrings while their multiplicative counterparts had. This adds them in all files under `algebra`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
