### PR TITLE
[Merged by Bors] - fix(probability): remove unused argument from `cond_cond_eq_cond_inter`

### DIFF
--- a/src/probability/conditional.lean
+++ b/src/probability/conditional.lean
@@ -112,14 +112,15 @@ end
 /-- Conditioning first on `s` and then on `t` results in the same measure as conditioning
 on `s ∩ t`. -/
 @[simp] lemma cond_cond_eq_cond_inter
-  (hms : measurable_set s) (hmt : measurable_set t) (hcs : μ s ≠ 0) (hci : μ (s ∩ t) ≠ 0) :
+  (hms : measurable_set s) (hmt : measurable_set t) (hci : μ (s ∩ t) ≠ 0) :
   μ[|s][|t] = μ[|s ∩ t] :=
 begin
   have := hms.inter hmt,
   have := measure_ne_top μ s,
+  have hcs : μ s ≠ 0 := (μ.to_outer_measure.pos_of_subset_ne_zero
+    (set.inter_subset_left _ _) hci).ne',
   ext1,
-  haveI := cond_is_probability_measure μ
-    (μ.to_outer_measure.pos_of_subset_ne_zero (set.inter_subset_left _ _) hci).ne',
+  haveI := cond_is_probability_measure μ hcs,
   simp only [*, cond_apply, ←mul_assoc, ←set.inter_assoc],
   congr,
   simp [*, ennreal.mul_inv, mul_comm, ←mul_assoc, ennreal.inv_mul_cancel]


### PR DESCRIPTION
This was a property that we already derived within the proof itself from conditionable intersection (I think I forgot to remove this when I made the PR).

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
