### PR TITLE
[Merged by Bors] - refactor(group_theory/commutator): Golf proof of `commutator_mem_commutator`

### DIFF
--- a/src/group_theory/commutator.lean
+++ b/src/group_theory/commutator.lean
@@ -41,6 +41,10 @@ instance commutator : has_bracket (subgroup G) (subgroup G) :=
 lemma commutator_def (H₁ H₂ : subgroup G) :
   ⁅H₁, H₂⁆ = closure {g | ∃ (g₁ ∈ H₁) (g₂ ∈ H₂), ⁅g₁, g₂⁆ = g} := rfl
 
+lemma commutator_mem_commutator {H₁ H₂ : subgroup G} {g₁ g₂ : G} (hp : g₁ ∈ H₁) (hq : g₂ ∈ H₂) :
+  ⁅g₁, g₂⁆ ∈ ⁅H₁, H₂⁆ :=
+subset_closure ⟨g₁, h₁, g₂, h₂, rfl⟩
+
 instance commutator_normal (H₁ H₂ : subgroup G) [h₁ : H₁.normal]
   [h₂ : H₂.normal] : normal ⁅H₁, H₂⁆ :=
 begin
@@ -77,10 +81,6 @@ begin
   { rintros h x ⟨p, hp, q, hq, rfl⟩,
     exact h p hp q hq, }
 end
-
-lemma commutator_mem_commutator {H₁ H₂ : subgroup G} {p q : G} (hp : p ∈ H₁) (hq : q ∈ H₂) :
-  ⁅p, q⁆ ∈ ⁅H₁, H₂⁆ :=
-(commutator_le H₁ H₂ ⁅H₁, H₂⁆).mp (le_refl ⁅H₁, H₂⁆) p hp q hq
 
 lemma commutator_comm (H₁ H₂ : subgroup G) : ⁅H₁, H₂⁆ = ⁅H₂, H₁⁆ :=
 begin

--- a/src/group_theory/commutator.lean
+++ b/src/group_theory/commutator.lean
@@ -41,7 +41,7 @@ instance commutator : has_bracket (subgroup G) (subgroup G) :=
 lemma commutator_def (H₁ H₂ : subgroup G) :
   ⁅H₁, H₂⁆ = closure {g | ∃ (g₁ ∈ H₁) (g₂ ∈ H₂), ⁅g₁, g₂⁆ = g} := rfl
 
-lemma commutator_mem_commutator {H₁ H₂ : subgroup G} {g₁ g₂ : G} (hp : g₁ ∈ H₁) (hq : g₂ ∈ H₂) :
+lemma commutator_mem_commutator {H₁ H₂ : subgroup G} {g₁ g₂ : G} (h₁ : g₁ ∈ H₁) (h₂ : g₂ ∈ H₂) :
   ⁅g₁, g₂⁆ ∈ ⁅H₁, H₂⁆ :=
 subset_closure ⟨g₁, h₁, g₂, h₂, rfl⟩
 


### PR DESCRIPTION
This PR golfs the proof of `commutator_mem_commutator`, and moves it earlier in the file so that it can be used earlier.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
