### PR TITLE
feat(algebra/ring/basic): lemmas about oddness of add/sub 1

### DIFF
--- a/src/algebra/ring/basic.lean
+++ b/src/algebra/ring/basic.lean
@@ -294,6 +294,12 @@ by { ext x, simp [odd, eq_comm] }
 theorem dvd_add {a b c : α} (h₁ : a ∣ b) (h₂ : a ∣ c) : a ∣ b + c :=
 dvd.elim h₁ (λ d hd, dvd.elim h₂ (λ e he, dvd.intro (d + e) (by simp [left_distrib, hd, he])))
 
+lemma even_iff_bit0 (a : α) : even a ↔ ∃ x, bit0 x = a :=
+by simp only [even, bit0, add_mul, eq_comm, one_mul]
+
+lemma odd_iff_bit1 (a : α) : odd a ↔ ∃ x, bit1 x = a :=
+by simp only [odd, bit1, bit0, add_mul, eq_comm, one_mul]
+
 end semiring
 
 namespace add_hom
@@ -922,6 +928,24 @@ protected def function.surjective.ring
   ring β :=
 { .. hf.add_comm_group f zero add neg sub nsmul zsmul,
   .. hf.monoid f one mul npow, .. hf.distrib f add mul }
+
+@[simp]
+lemma odd_add_one_iff_even {R : Type*} [ring R] (a : R) : odd (a + 1) ↔ even a :=
+by simp [even_iff_bit0, odd_iff_bit1, bit0, bit1]
+
+@[simp]
+lemma odd_sub_one_iff_even {R : Type*} [ring R] (a : R) : odd (a - 1) ↔ even a :=
+begin
+  refine ⟨_, _⟩,
+  { rintro ⟨w, hw⟩,
+    refine ⟨w + 1, _⟩,
+    rw [sub_eq_iff_eq_add.mp hw, mul_add, add_assoc, mul_one],
+    refl },
+  { rintro ⟨w, rfl⟩,
+    refine ⟨w - 1, _⟩,
+    rw [mul_sub, sub_add, sub_right_inj, mul_one, sub_eq_iff_eq_add.mpr],
+    refl }
+end
 
 end ring
 

--- a/src/data/int/parity.lean
+++ b/src/data/int/parity.lean
@@ -182,12 +182,12 @@ theorem even.sub_odd (hm : even m) (hn : odd n) : odd (m - n) :=
 odd_sub'.2 $ iff_of_true hn hm
 
 @[simp]
-lemma int.odd_add_one_iff_even (z : ℤ) : odd (z + 1) ↔ even z :=
-int.odd_add'.trans (by simp)
+lemma odd_add_one_iff_even (z : ℤ) : odd (z + 1) ↔ even z :=
+odd_add'.trans (by simp)
 
 @[simp]
-lemma int.odd_sub_one_iff_even (z : ℤ) : odd (z - 1) ↔ even z :=
-int.odd_sub'.trans (by simp)
+lemma odd_sub_one_iff_even (z : ℤ) : odd (z - 1) ↔ even z :=
+odd_sub'.trans (by simp)
 
 lemma even_mul_succ_self (n : ℤ) : even (n * (n + 1)) :=
 begin

--- a/src/data/int/parity.lean
+++ b/src/data/int/parity.lean
@@ -181,6 +181,14 @@ by rw [odd_iff_not_even, even_sub, not_iff, not_iff_comm, odd_iff_not_even]
 theorem even.sub_odd (hm : even m) (hn : odd n) : odd (m - n) :=
 odd_sub'.2 $ iff_of_true hn hm
 
+@[simp]
+lemma int.odd_add_one_iff_even (z : ℤ) : odd (z + 1) ↔ even z :=
+int.odd_add'.trans (by simp)
+
+@[simp]
+lemma int.odd_sub_one_iff_even (z : ℤ) : odd (z - 1) ↔ even z :=
+int.odd_sub'.trans (by simp)
+
 lemma even_mul_succ_self (n : ℤ) : even (n * (n + 1)) :=
 begin
   rw even_mul,

--- a/src/data/int/parity.lean
+++ b/src/data/int/parity.lean
@@ -181,14 +181,6 @@ by rw [odd_iff_not_even, even_sub, not_iff, not_iff_comm, odd_iff_not_even]
 theorem even.sub_odd (hm : even m) (hn : odd n) : odd (m - n) :=
 odd_sub'.2 $ iff_of_true hn hm
 
-@[simp]
-lemma odd_add_one_iff_even (z : ℤ) : odd (z + 1) ↔ even z :=
-odd_add'.trans (by simp)
-
-@[simp]
-lemma odd_sub_one_iff_even (z : ℤ) : odd (z - 1) ↔ even z :=
-odd_sub'.trans (by simp)
-
 lemma even_mul_succ_self (n : ℤ) : even (n * (n + 1)) :=
 begin
   rw even_mul,


### PR DESCRIPTION
I could not find these lemmas, so I added them.

Two lemmas show that `even` means "in the image of `bit0`" and `odd` means "in the image of `bit0`".

The other two lemmas show that `odd (a ± 1)` is equivalent to `even a`.

I tagged the last two lemmas with the `simp` attribute, since it seems that there is a confluence towards `even`, instead of `odd`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
