### PR TITLE
[Merged by Bors] - chore({category_theory,order}/category/*): Missing `dsimp` lemmas

### DIFF
--- a/src/category_theory/category/Bipointed.lean
+++ b/src/category_theory/category/Bipointed.lean
@@ -34,6 +34,8 @@ attribute [protected] Bipointed.X
 /-- Turns a bipointing into a bipointed type. -/
 def of {X : Type*} (to_prod : X × X) : Bipointed := ⟨X, to_prod⟩
 
+@[simp] lemma coe_of {X : Type*} (to_prod : X × X) : ↥(of to_prod) = X := rfl
+
 alias of ← prod.Bipointed
 
 instance : inhabited Bipointed := ⟨of ((), ())⟩

--- a/src/category_theory/category/PartialFun.lean
+++ b/src/category_theory/category/PartialFun.lean
@@ -41,6 +41,8 @@ instance : has_coe_to_sort PartialFun Type* := ⟨id⟩
 /-- Turns a type into a `PartialFun`. -/
 @[nolint has_inhabited_instance] def of : Type* → PartialFun := id
 
+@[simp] lemma coe_of (X : Type*) : ↥(of X) = X := rfl
+
 instance : inhabited PartialFun := ⟨Type*⟩
 
 instance large_category : large_category.{u} PartialFun :=

--- a/src/category_theory/category/Pointed.lean
+++ b/src/category_theory/category/Pointed.lean
@@ -35,6 +35,8 @@ attribute [protected] Pointed.X
 /-- Turns a point into a pointed type. -/
 def of {X : Type*} (point : X) : Pointed := ⟨X, point⟩
 
+@[simp] lemma coe_of {X : Type*} (point : X) : ↥(of point) = X := rfl
+
 alias of ← prod.Pointed
 
 instance : inhabited Pointed := ⟨of ((), ())⟩

--- a/src/category_theory/category/Twop.lean
+++ b/src/category_theory/category/Twop.lean
@@ -36,6 +36,9 @@ attribute [protected] Twop.X
 /-- Turns a two-pointing into a two-pointed type. -/
 def of {X : Type*} (to_two_pointing : two_pointing X) : Twop := ⟨X, to_two_pointing⟩
 
+@[simp] lemma coe_of {X : Type*} (to_two_pointing : two_pointing X) :
+  ↥(of to_two_pointing) = X := rfl
+
 alias of ← two_pointing.Twop
 
 instance : inhabited Twop := ⟨of two_pointing.bool⟩
@@ -43,6 +46,8 @@ instance : inhabited Twop := ⟨of two_pointing.bool⟩
 /-- Turns a two-pointed type into a bipointed type, by forgetting that the pointed elements are
 distinct. -/
 def to_Bipointed (X : Twop) : Bipointed := X.to_two_pointing.to_prod.Bipointed
+
+@[simp] lemma coe_to_Bipointed (X : Twop) : ↥X.to_Bipointed = ↥X := rfl
 
 instance large_category : large_category Twop := induced_category.category to_Bipointed
 

--- a/src/order/category/BoolAlg.lean
+++ b/src/order/category/BoolAlg.lean
@@ -28,6 +28,8 @@ instance (X : BoolAlg) : boolean_algebra X := X.str
 /-- Construct a bundled `BoolAlg` from a `boolean_algebra`. -/
 def of (α : Type*) [boolean_algebra α] : BoolAlg := bundled.of α
 
+@[simp] lemma coe_of (α : Type*) [boolean_algebra α] : ↥(of α) = α := rfl
+
 instance : inhabited BoolAlg := ⟨of punit⟩
 
 /-- Turn a `BoolAlg` into a `BoundedDistribLattice` by forgetting its complement operation. -/

--- a/src/order/category/BoundedLattice.lean
+++ b/src/order/category/BoundedLattice.lean
@@ -34,6 +34,8 @@ attribute [instance] BoundedLattice.is_bounded_order
 /-- Construct a bundled `BoundedLattice` from `lattice` + `bounded_order`. -/
 def of (α : Type*) [lattice α] [bounded_order α] : BoundedLattice := ⟨⟨α⟩⟩
 
+@[simp] lemma coe_of (α : Type*) [lattice α] [bounded_order α] : ↥(of α) = α := rfl
+
 instance : inhabited BoundedLattice := ⟨of punit⟩
 
 instance : large_category.{u} BoundedLattice :=

--- a/src/order/category/BoundedOrder.lean
+++ b/src/order/category/BoundedOrder.lean
@@ -32,6 +32,8 @@ attribute [instance]  BoundedOrder.is_bounded_order
 /-- Construct a bundled `BoundedOrder` from a `fintype` `partial_order`. -/
 def of (α : Type*) [partial_order α] [bounded_order α] : BoundedOrder := ⟨⟨α⟩⟩
 
+@[simp] lemma coe_of (α : Type*) [partial_order α] [bounded_order α] : ↥(of α) = α := rfl
+
 instance : inhabited BoundedOrder := ⟨of punit⟩
 
 instance large_category : large_category.{u} BoundedOrder :=
@@ -74,7 +76,7 @@ end BoundedOrder
 
 lemma BoundedOrder_dual_comp_forget_to_PartialOrder :
   BoundedOrder.dual ⋙ forget₂ BoundedOrder PartialOrder =
-    forget₂ BoundedOrder PartialOrder ⋙ PartialOrder.to_dual := rfl
+    forget₂ BoundedOrder PartialOrder ⋙ PartialOrder.dual := rfl
 
 lemma BoundedOrder_dual_comp_forget_to_Bipointed :
   BoundedOrder.dual ⋙ forget₂ BoundedOrder Bipointed =

--- a/src/order/category/CompleteLattice.lean
+++ b/src/order/category/CompleteLattice.lean
@@ -27,6 +27,8 @@ instance (X : CompleteLattice) : complete_lattice X := X.str
 /-- Construct a bundled `CompleteLattice` from a `complete_lattice`. -/
 def of (α : Type*) [complete_lattice α] : CompleteLattice := bundled.of α
 
+@[simp] lemma coe_of (α : Type*) [complete_lattice α] : ↥(of α) = α := rfl
+
 instance : inhabited CompleteLattice := ⟨of punit⟩
 
 instance : bundled_hom @complete_lattice_hom :=

--- a/src/order/category/DistribLattice.lean
+++ b/src/order/category/DistribLattice.lean
@@ -30,6 +30,8 @@ instance (X : DistribLattice) : distrib_lattice X := X.str
 /-- Construct a bundled `DistribLattice` from a `distrib_lattice` underlying type and typeclass. -/
 def of (α : Type*) [distrib_lattice α] : DistribLattice := bundled.of α
 
+@[simp] lemma coe_of (α : Type*) [distrib_lattice α] : ↥(of α) = α := rfl
+
 instance : inhabited DistribLattice := ⟨of punit⟩
 
 instance : bundled_hom.parent_projection @distrib_lattice.to_lattice := ⟨⟩

--- a/src/order/category/FinPartialOrder.lean
+++ b/src/order/category/FinPartialOrder.lean
@@ -38,6 +38,8 @@ attribute [instance]  FinPartialOrder.is_fintype
 /-- Construct a bundled `FinPartialOrder` from `fintype` + `partial_order`. -/
 def of (α : Type*) [partial_order α] [fintype α] : FinPartialOrder := ⟨⟨α⟩⟩
 
+@[simp] lemma coe_of (α : Type*) [partial_order α] [fintype α] : ↥(of α) = α := rfl
+
 instance : inhabited FinPartialOrder := ⟨of punit⟩
 
 instance large_category : large_category FinPartialOrder :=
@@ -73,4 +75,4 @@ end FinPartialOrder
 
 lemma FinPartialOrder_dual_comp_forget_to_PartialOrder :
   FinPartialOrder.dual ⋙ forget₂ FinPartialOrder PartialOrder =
-    forget₂ FinPartialOrder PartialOrder ⋙ PartialOrder.to_dual := rfl
+    forget₂ FinPartialOrder PartialOrder ⋙ PartialOrder.dual := rfl

--- a/src/order/category/Frame.lean
+++ b/src/order/category/Frame.lean
@@ -31,6 +31,8 @@ instance (X : Frame) : frame X := X.str
 /-- Construct a bundled `Frame` from a `frame`. -/
 def of (α : Type*) [frame α] : Frame := bundled.of α
 
+@[simp] lemma coe_of (α : Type*) [frame α] : ↥(of α) = α := rfl
+
 instance : inhabited Frame := ⟨of punit⟩
 
 /-- An abbreviation of `frame_hom` that assumes `frame` instead of the weaker `complete_lattice`.

--- a/src/order/category/Lattice.lean
+++ b/src/order/category/Lattice.lean
@@ -35,6 +35,8 @@ instance (X : Lattice) : lattice X := X.str
 /-- Construct a bundled `Lattice` from a `lattice`. -/
 def of (α : Type*) [lattice α] : Lattice := bundled.of α
 
+@[simp] lemma coe_of (α : Type*) [lattice α] : ↥(of α) = α := rfl
+
 instance : inhabited Lattice := ⟨of bool⟩
 
 instance : bundled_hom @lattice_hom :=
@@ -71,4 +73,4 @@ end Lattice
 
 lemma Lattice_dual_comp_forget_to_PartialOrder :
   Lattice.dual ⋙ forget₂ Lattice PartialOrder =
-    forget₂ Lattice PartialOrder ⋙ PartialOrder.to_dual := rfl
+    forget₂ Lattice PartialOrder ⋙ PartialOrder.dual := rfl

--- a/src/order/category/LinearOrder.lean
+++ b/src/order/category/LinearOrder.lean
@@ -30,6 +30,8 @@ instance : has_coe_to_sort LinearOrder Type* := bundled.has_coe_to_sort
 /-- Construct a bundled `LinearOrder` from the underlying type and typeclass. -/
 def of (α : Type*) [linear_order α] : LinearOrder := bundled.of α
 
+@[simp] lemma coe_of (α : Type*) [linear_order α] : ↥(of α) = α := rfl
+
 instance : inhabited LinearOrder := ⟨of punit⟩
 
 instance (α : LinearOrder) : linear_order α := α.str

--- a/src/order/category/NonemptyFinLinOrd.lean
+++ b/src/order/category/NonemptyFinLinOrd.lean
@@ -59,6 +59,8 @@ instance : has_coe_to_sort NonemptyFinLinOrd Type* := bundled.has_coe_to_sort
 /-- Construct a bundled `NonemptyFinLinOrd` from the underlying type and typeclass. -/
 def of (α : Type*) [nonempty_fin_lin_ord α] : NonemptyFinLinOrd := bundled.of α
 
+@[simp] lemma coe_of (α : Type*) [nonempty_fin_lin_ord α] : ↥(of α) = α := rfl
+
 instance : inhabited NonemptyFinLinOrd := ⟨of punit⟩
 
 instance (α : NonemptyFinLinOrd) : nonempty_fin_lin_ord α := α.str
@@ -75,17 +77,17 @@ between them. -/
   inv_hom_id' := by { ext, exact e.apply_symm_apply x } }
 
 /-- `order_dual` as a functor. -/
-@[simps] def to_dual : NonemptyFinLinOrd ⥤ NonemptyFinLinOrd :=
+@[simps] def dual : NonemptyFinLinOrd ⥤ NonemptyFinLinOrd :=
 { obj := λ X, of (order_dual X), map := λ X Y, order_hom.dual }
 
 /-- The equivalence between `FinPartialOrder` and itself induced by `order_dual` both ways. -/
 @[simps functor inverse] def dual_equiv : NonemptyFinLinOrd ≌ NonemptyFinLinOrd :=
-equivalence.mk to_dual to_dual
+equivalence.mk dual dual
   (nat_iso.of_components (λ X, iso.mk $ order_iso.dual_dual X) $ λ X Y f, rfl)
   (nat_iso.of_components (λ X, iso.mk $ order_iso.dual_dual X) $ λ X Y f, rfl)
 
 end NonemptyFinLinOrd
 
-lemma NonemptyFinLinOrd_dual_equiv_comp_forget_to_LinearOrder :
-  NonemptyFinLinOrd.dual_equiv.functor ⋙ forget₂ NonemptyFinLinOrd LinearOrder
-  = forget₂ NonemptyFinLinOrd LinearOrder ⋙ LinearOrder.dual_equiv.functor := rfl
+lemma NonemptyFinLinOrd_dual_comp_forget_to_LinearOrder :
+  NonemptyFinLinOrd.dual ⋙ forget₂ NonemptyFinLinOrd LinearOrder =
+    forget₂ NonemptyFinLinOrd LinearOrder ⋙ LinearOrder.dual := rfl

--- a/src/order/category/PartialOrder.lean
+++ b/src/order/category/PartialOrder.lean
@@ -30,6 +30,8 @@ instance : has_coe_to_sort PartialOrder Type* := bundled.has_coe_to_sort
 /-- Construct a bundled PartialOrder from the underlying type and typeclass. -/
 def of (α : Type*) [partial_order α] : PartialOrder := bundled.of α
 
+@[simp] lemma coe_of (α : Type*) [partial_order α] : ↥(of α) = α := rfl
+
 instance : inhabited PartialOrder := ⟨of punit⟩
 
 instance (α : PartialOrder) : partial_order α := α.str
@@ -44,20 +46,20 @@ instance has_forget_to_Preorder : has_forget₂ PartialOrder Preorder := bundled
   inv_hom_id' := by { ext, exact e.apply_symm_apply x } }
 
 /-- `order_dual` as a functor. -/
-@[simps] def to_dual : PartialOrder ⥤ PartialOrder :=
+@[simps] def dual : PartialOrder ⥤ PartialOrder :=
 { obj := λ X, of (order_dual X), map := λ X Y, order_hom.dual }
 
 /-- The equivalence between `PartialOrder` and itself induced by `order_dual` both ways. -/
 @[simps functor inverse] def dual_equiv : PartialOrder ≌ PartialOrder :=
-equivalence.mk to_dual to_dual
+equivalence.mk dual dual
   (nat_iso.of_components (λ X, iso.mk $ order_iso.dual_dual X) $ λ X Y f, rfl)
   (nat_iso.of_components (λ X, iso.mk $ order_iso.dual_dual X) $ λ X Y f, rfl)
 
 end PartialOrder
 
-lemma PartialOrder_to_dual_comp_forget_to_Preorder :
-  PartialOrder.to_dual ⋙ forget₂ PartialOrder Preorder =
-    forget₂ PartialOrder Preorder ⋙ Preorder.to_dual := rfl
+lemma PartialOrder_dual_comp_forget_to_Preorder :
+  PartialOrder.dual ⋙ forget₂ PartialOrder Preorder =
+    forget₂ PartialOrder Preorder ⋙ Preorder.dual := rfl
 
 /-- `antisymmetrization` as a functor. It is the free functor. -/
 def Preorder_to_PartialOrder : Preorder.{u} ⥤ PartialOrder :=
@@ -85,7 +87,7 @@ adjunction.mk_of_hom_equiv
 
 /-- `Preorder_to_PartialOrder` and `order_dual` commute. -/
 @[simps] def Preorder_to_PartialOrder_comp_to_dual_iso_to_dual_comp_Preorder_to_PartialOrder :
- (Preorder_to_PartialOrder.{u} ⋙ PartialOrder.to_dual) ≅
-    (Preorder.to_dual ⋙ Preorder_to_PartialOrder) :=
+ (Preorder_to_PartialOrder.{u} ⋙ PartialOrder.dual) ≅
+    (Preorder.dual ⋙ Preorder_to_PartialOrder) :=
 nat_iso.of_components (λ X, PartialOrder.iso.mk $ order_iso.dual_antisymmetrization _) $
   λ X Y f, order_hom.ext _ _ $ funext $ λ x, quotient.induction_on' x $ λ x, rfl

--- a/src/order/category/Preorder.lean
+++ b/src/order/category/Preorder.lean
@@ -35,6 +35,8 @@ instance : has_coe_to_sort Preorder Type* := bundled.has_coe_to_sort
 /-- Construct a bundled Preorder from the underlying type and typeclass. -/
 def of (α : Type*) [preorder α] : Preorder := bundled.of α
 
+@[simp] lemma coe_of (α : Type*) [preorder α] : ↥(of α) = α := rfl
+
 instance : inhabited Preorder := ⟨of punit⟩
 
 instance (α : Preorder) : preorder α := α.str
@@ -47,12 +49,12 @@ instance (α : Preorder) : preorder α := α.str
   inv_hom_id' := by { ext, exact e.apply_symm_apply x } }
 
 /-- `order_dual` as a functor. -/
-@[simps] def to_dual : Preorder ⥤ Preorder :=
+@[simps] def dual : Preorder ⥤ Preorder :=
 { obj := λ X, of (order_dual X), map := λ X Y, order_hom.dual }
 
 /-- The equivalence between `Preorder` and itself induced by `order_dual` both ways. -/
 @[simps functor inverse] def dual_equiv : Preorder ≌ Preorder :=
-equivalence.mk to_dual to_dual
+equivalence.mk dual dual
   (nat_iso.of_components (λ X, iso.mk $ order_iso.dual_dual X) $ λ X Y f, rfl)
   (nat_iso.of_components (λ X, iso.mk $ order_iso.dual_dual X) $ λ X Y f, rfl)
 

--- a/src/order/category/omega_complete_partial_order.lean
+++ b/src/order/category/omega_complete_partial_order.lean
@@ -48,6 +48,8 @@ instance : has_coe_to_sort ωCPO Type* := bundled.has_coe_to_sort
 /-- Construct a bundled ωCPO from the underlying type and typeclass. -/
 def of (α : Type*) [omega_complete_partial_order α] : ωCPO := bundled.of α
 
+@[simp] lemma coe_of (α : Type*) [omega_complete_partial_order α] : ↥(of α) = α := rfl
+
 instance : inhabited ωCPO := ⟨of punit⟩
 
 instance (α : ωCPO) : omega_complete_partial_order α := α.str


### PR DESCRIPTION
Add the `dsimp` lemmas stating `↥(of α) = α `. Also rename the few `to_dual` functors to `dual` to match the other files.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

Requested by @b-mehta

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
