### PR TITLE
[Merged by Bors] - feat(topology/algebra/continuous_monoid_hom): Define the Pontryagin dual

### DIFF
--- a/src/topology/algebra/continuous_monoid_hom.lean
+++ b/src/topology/algebra/continuous_monoid_hom.lean
@@ -243,25 +243,6 @@ let hi := is_inducing A E, hc := hi.continuous in
 
 end continuous_monoid_hom
 
-section pontryagin_dual
-
-variables (G : Type*) [monoid G] [topological_space G]
-
 /-- The Pontryagin dual of `G` is the group of continuous homomorphism `G → circle`. -/
-def pontryagin_dual := continuous_monoid_hom G circle
-
-variables {G}
-
-noncomputable instance : topological_space (pontryagin_dual G) :=
-continuous_monoid_hom.topological_space
-
-instance : t2_space (pontryagin_dual G) :=
-continuous_monoid_hom.t2_space
-
-noncomputable instance : comm_group (pontryagin_dual G) :=
-continuous_monoid_hom.comm_group
-
-instance : topological_group (pontryagin_dual G) :=
-continuous_monoid_hom.topological_group
-
-end pontryagin_dual
+@[derive [topological_space, t2_space, comm_group, topological_group]]
+def pontryagin_dual (G : Type*) [monoid G] [topological_space G] := continuous_monoid_hom G circle

--- a/src/topology/algebra/continuous_monoid_hom.lean
+++ b/src/topology/algebra/continuous_monoid_hom.lean
@@ -244,5 +244,5 @@ let hi := is_inducing A E, hc := hi.continuous in
 end continuous_monoid_hom
 
 /-- The Pontryagin dual of `G` is the group of continuous homomorphism `G → circle`. -/
-@[derive [topological_space, t2_space, comm_group, topological_group]]
+@[derive [topological_space, t2_space, comm_group, topological_group, inhabited]]
 def pontryagin_dual (G : Type*) [monoid G] [topological_space G] := continuous_monoid_hom G circle

--- a/src/topology/algebra/continuous_monoid_hom.lean
+++ b/src/topology/algebra/continuous_monoid_hom.lean
@@ -3,6 +3,7 @@ Copyright (c) 2022 Thomas Browning. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Thomas Browning
 -/
+import analysis.complex.circle
 import topology.continuous_function.algebra
 
 /-!
@@ -241,3 +242,26 @@ let hi := is_inducing A E, hc := hi.continuous in
   continuous_inv := hi.continuous_iff.mpr (continuous_inv.comp hc) }
 
 end continuous_monoid_hom
+
+section pontryagin_dual
+
+variables (G : Type*) [monoid G] [topological_space G]
+
+/-- The Pontryagin dual of `G` is the group of continuous homomorphism `G → circle`. -/
+def pontryagin_dual := continuous_monoid_hom G circle
+
+variables {G}
+
+noncomputable instance : topological_space (pontryagin_dual G) :=
+continuous_monoid_hom.topological_space
+
+instance : t2_space (pontryagin_dual G) :=
+continuous_monoid_hom.t2_space
+
+noncomputable instance : comm_group (pontryagin_dual G) :=
+continuous_monoid_hom.comm_group
+
+instance : topological_group (pontryagin_dual G) :=
+continuous_monoid_hom.topological_group
+
+end pontryagin_dual


### PR DESCRIPTION
This PR adds the definition of the Pontryagin dual.

We're still missing the locally compact instance. I thought I could get it from `closed_embedding (to_continuous_map : continuous_monoid_hom A B → C(A, B))`, but actually `C(A, B)` is almost never locally compact.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
