### PR TITLE
[Merged by Bors] - feat(measure_theory/group/fundamental_domain): ess_sup_measure_restrict

### DIFF
--- a/src/measure_theory/function/ess_sup.lean
+++ b/src/measure_theory/function/ess_sup.lean
@@ -50,6 +50,20 @@ lemma ess_inf_congr_ae {f g : α → β} (hfg : f =ᵐ[μ] g) :  ess_inf f μ = 
 
 end conditionally_complete_lattice
 
+section conditionally_complete_linear_order
+variable [conditionally_complete_linear_order β]
+
+lemma ess_sup_eq_Inf {m : measurable_space α} (μ : measure α) (f : α → β) :
+  ess_sup f μ = Inf {a | μ {x | a < f x} = 0} :=
+begin
+  dsimp [ess_sup, limsup, Limsup],
+  congr,
+  ext a,
+  simp [eventually_map, ae_iff],
+end
+
+end conditionally_complete_linear_order
+
 section complete_lattice
 variable [complete_lattice β]
 
@@ -111,6 +125,10 @@ begin
   refine limsup_le_limsup_of_le (measure.ae_le_iff_absolutely_continuous.mpr hμν) _ _,
   all_goals { is_bounded_default, },
 end
+
+lemma ess_sup_mono_measure' {α : Type*} {β : Type*} {m : measurable_space α}
+  {μ ν : measure_theory.measure α} [complete_lattice β] {f : α → β} (hμν : ν ≤ μ) :
+  ess_sup f ν ≤ ess_sup f μ := ess_sup_mono_measure (measure.absolutely_continuous_of_le hμν)
 
 lemma ess_inf_antitone_measure {f : α → β} (hμν : μ ≪ ν) : ess_inf f ν ≤ ess_inf f μ :=
 begin

--- a/src/measure_theory/group/fundamental_domain.lean
+++ b/src/measure_theory/group/fundamental_domain.lean
@@ -181,7 +181,9 @@ begin
 end
 
 /-- If `s` and `t` are two fundamental domains of the same action, then their measures are equal. -/
-@[to_additive] protected lemma measure_eq (hs : is_fundamental_domain G s μ)
+@[to_additive "If `s` and `t` are two fundamental domains of the same action, then their measures
+are equal."]
+protected lemma measure_eq (hs : is_fundamental_domain G s μ)
   (ht : is_fundamental_domain G t μ) : μ s = μ t :=
 by simpa only [set_lintegral_one] using hs.set_lintegral_eq ht (λ _, 1) (λ _ _, rfl)
 
@@ -261,7 +263,10 @@ end
 /-- If `f` is invariant under the action of a countable group `G`, and `μ` is a `G`-invariant
   measure with a fundamental domain `s`, then the `ess_sup` of `f` restricted to `s` is the same as
   that of `f` on all of its domain. -/
-@[to_additive] lemma ess_sup_measure_restrict (hs : is_fundamental_domain G s μ)
+@[to_additive "If `f` is invariant under the action of a countable additive group `G`, and `μ` is a
+`G`-invariant measure with a fundamental domain `s`, then the `ess_sup` of `f` restricted to `s` is
+the same as that of `f` on all of its domain."]
+lemma ess_sup_measure_restrict (hs : is_fundamental_domain G s μ)
   {f : α → ℝ≥0∞} (hf : ∀ γ : G, ∀ x: α, f (γ • x) =  f x) :
   ess_sup f (μ.restrict s) = ess_sup f μ :=
 begin

--- a/src/measure_theory/group/fundamental_domain.lean
+++ b/src/measure_theory/group/fundamental_domain.lean
@@ -152,6 +152,11 @@ h.measure_eq_tsum_of_ac absolutely_continuous.rfl t
   μ t = ∑' g : G, μ (g • t ∩ s) :=
 by simpa only [set_lintegral_one] using h.set_lintegral_eq_tsum (λ _, 1) t
 
+@[to_additive] lemma measure_zero_of_invariant (h : is_fundamental_domain G s μ) (t : set α)
+  (ht : ∀ g : G, g • t = t) (hts : μ (t ∩ s) = 0) :
+  μ t = 0 :=
+by simp [measure_eq_tsum h, ht, hts]
+
 @[to_additive] protected lemma set_lintegral_eq (hs : is_fundamental_domain G s μ)
   (ht : is_fundamental_domain G t μ) (f : α → ℝ≥0∞) (hf : ∀ (g : G) x, f (g • x) = f x) :
   ∫⁻ x in s, f x ∂μ = ∫⁻ x in t, f x ∂μ :=
@@ -251,6 +256,28 @@ begin
       by rw [restrict_congr_set (hac hs.Union_smul_ae_eq), restrict_univ] },
   { rw [integral_undef hfs, integral_undef],
     rwa [hs.integrable_on_iff ht hf] at hfs }
+end
+
+/-- If `f` is invariant under the action of a countable group `G`, and `μ` is a `G`-invariant
+  measure with a fundamental domain `s`, then the `ess_sup` of `f` restricted to `s` is the same as
+  that of `f` on all of its domain. -/
+@[to_additive] lemma ess_sup_measure_restrict (hs : is_fundamental_domain G s μ)
+  {f : α → ℝ≥0∞} (hf : ∀ γ : G, ∀ x: α, f (γ • x) =  f x) :
+  ess_sup f (μ.restrict s) = ess_sup f μ :=
+begin
+  refine le_antisymm (ess_sup_mono_measure' measure.restrict_le_self) _,
+  rw [ess_sup_eq_Inf (μ.restrict s) f, ess_sup_eq_Inf μ f],
+  refine Inf_le_Inf _,
+  intros a,
+  dsimp,
+  intros ha,
+  refine measure_zero_of_invariant hs _ _ _,
+  { intros γ,
+    ext x,
+    rw mem_smul_set_iff_inv_smul_mem,
+    simp only [mem_set_of_eq, hf (γ⁻¹) x], },
+  rwa measure.restrict_apply' at ha,
+  exact hs.measurable_set,
 end
 
 end is_fundamental_domain

--- a/src/measure_theory/group/fundamental_domain.lean
+++ b/src/measure_theory/group/fundamental_domain.lean
@@ -273,16 +273,13 @@ begin
   refine le_antisymm (ess_sup_mono_measure' measure.restrict_le_self) _,
   rw [ess_sup_eq_Inf (μ.restrict s) f, ess_sup_eq_Inf μ f],
   refine Inf_le_Inf _,
-  intros a,
-  dsimp,
-  intros ha,
-  refine measure_zero_of_invariant hs _ _ _,
-  { intros γ,
-    ext x,
-    rw mem_smul_set_iff_inv_smul_mem,
-    simp only [mem_set_of_eq, hf (γ⁻¹) x], },
-  rwa measure.restrict_apply' at ha,
-  exact hs.measurable_set,
+  rintro a (ha : (μ.restrict s) {x : α | a < f x} = 0),
+  rw measure.restrict_apply' hs.measurable_set at ha,
+  refine measure_zero_of_invariant hs _ _ ha,
+  intros γ,
+  ext x,
+  rw mem_smul_set_iff_inv_smul_mem,
+  simp only [mem_set_of_eq, hf (γ⁻¹) x],
 end
 
 end is_fundamental_domain


### PR DESCRIPTION
If `f` is invariant under the action of a countable group `G`, and `μ` is a `G`-invariant measure with a fundamental domain `s`, then the `ess_sup` of `f` restricted to `s` is the same as that of `f` on all of its domain.

Co-authored-by: Heather Macbeth <25316162+hrmacbeth@users.noreply.github.com>

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
