### PR TITLE
[Merged by Bors] - feat(combinatorics/simple_graph/connectivity): API for get_vert

### DIFF
--- a/src/combinatorics/simple_graph/connectivity.lean
+++ b/src/combinatorics/simple_graph/connectivity.lean
@@ -100,12 +100,21 @@ def get_vert : Π {u v : V} (p : G.walk u v) (n : ℕ), V
 @[simp] lemma get_vert_zero {u v} (w : G.walk u v) : w.get_vert 0 = u :=
 by { cases w; refl }
 
-@[simp] lemma get_vert_last {u v} (w : G.walk u v) : w.get_vert w.length = v :=
+@[simp] lemma get_vert_length {u v} (w : G.walk u v) : w.get_vert w.length = v :=
 begin
   induction w with _ x y z hxy wyz IH,
   { refl },
   { simp [length, get_vert, IH] }
 end
+
+lemma get_vert_of_length_le {u v} (w : G.walk u v) {i : ℕ} (hi : w.length ≤ i) :
+  w.get_vert w.length = v :=
+begin
+  induction w with _ x y z hxy wyz IH,
+  { refl },
+  { simp [length, get_vert, IH] }
+end
+
 
 lemma adj_get_vert_succ {u v} (w : G.walk u v) {i : ℕ} (hi : i < w.length) :
   G.adj (w.get_vert i) (w.get_vert (i+1)) :=

--- a/src/combinatorics/simple_graph/connectivity.lean
+++ b/src/combinatorics/simple_graph/connectivity.lean
@@ -117,7 +117,6 @@ begin
     { exact IH (nat.succ_le_succ_iff.1 hi) } }
 end
 
-
 lemma adj_get_vert_succ {u v} (w : G.walk u v) {i : ℕ} (hi : i < w.length) :
   G.adj (w.get_vert i) (w.get_vert (i+1)) :=
 begin
@@ -127,7 +126,6 @@ begin
     { simp [get_vert, hxy] },
     { exact IH (nat.succ_lt_succ_iff.1 hi) } },
 end
-
 
 @[simp] lemma cons_append {u v w x : V} (h : G.adj u v) (p : G.walk v w) (q : G.walk w x) :
   (cons h p).append q = cons h (p.append q) := rfl

--- a/src/combinatorics/simple_graph/connectivity.lean
+++ b/src/combinatorics/simple_graph/connectivity.lean
@@ -100,13 +100,6 @@ def get_vert : Π {u v : V} (p : G.walk u v) (n : ℕ), V
 @[simp] lemma get_vert_zero {u v} (w : G.walk u v) : w.get_vert 0 = u :=
 by { cases w; refl }
 
-@[simp] lemma get_vert_length {u v} (w : G.walk u v) : w.get_vert w.length = v :=
-begin
-  induction w with _ x y z hxy wyz IH,
-  { refl },
-  { simp [length, get_vert, IH] }
-end
-
 lemma get_vert_of_length_le {u v} (w : G.walk u v) {i : ℕ} (hi : w.length ≤ i) :
   w.get_vert i = v :=
 begin
@@ -116,6 +109,9 @@ begin
     { cases hi, },
     { exact IH (nat.succ_le_succ_iff.1 hi) } }
 end
+
+@[simp] lemma get_vert_length {u v} (w : G.walk u v) : w.get_vert w.length = v :=
+w.get_vert_of_length_le rfl.le
 
 lemma adj_get_vert_succ {u v} (w : G.walk u v) {i : ℕ} (hi : i < w.length) :
   G.adj (w.get_vert i) (w.get_vert (i+1)) :=

--- a/src/combinatorics/simple_graph/connectivity.lean
+++ b/src/combinatorics/simple_graph/connectivity.lean
@@ -108,11 +108,13 @@ begin
 end
 
 lemma get_vert_of_length_le {u v} (w : G.walk u v) {i : ℕ} (hi : w.length ≤ i) :
-  w.get_vert w.length = v :=
+  w.get_vert i = v :=
 begin
-  induction w with _ x y z hxy wyz IH,
+  induction w with _ x y z hxy wyz IH generalizing i,
   { refl },
-  { simp [length, get_vert, IH] }
+  { cases i,
+    { cases hi, },
+    { exact IH (nat.succ_le_succ_iff.1 hi) } }
 end
 
 

--- a/src/combinatorics/simple_graph/connectivity.lean
+++ b/src/combinatorics/simple_graph/connectivity.lean
@@ -97,6 +97,27 @@ def get_vert : Π {u v : V} (p : G.walk u v) (n : ℕ), V
 | u v (cons _ _) 0 := u
 | u v (cons _ q) (n+1) := q.get_vert n
 
+@[simp] lemma get_vert_zero {u v} (w : G.walk u v) : w.get_vert 0 = u :=
+by { cases w; refl }
+
+@[simp] lemma get_vert_last {u v} (w : G.walk u v) : w.get_vert w.length = v :=
+begin
+  induction w with _ x y z hxy wyz IH,
+  { refl },
+  { simp [length, get_vert, IH] }
+end
+
+lemma adj_get_vert_succ {u v} (w : G.walk u v) {i : ℕ} (hi : i < w.length) :
+  G.adj (w.get_vert i) (w.get_vert (i+1)) :=
+begin
+  induction w with _ x y z hxy wyz IH generalizing i,
+  { cases hi, },
+  { cases i,
+    { simp [get_vert, hxy] },
+    { exact IH (nat.succ_lt_succ_iff.1 hi) } },
+end
+
+
 @[simp] lemma cons_append {u v w x : V} (h : G.adj u v) (p : G.walk v w) (q : G.walk w x) :
   (cons h p).append q = cons h (p.append q) := rfl
 


### PR DESCRIPTION
From my Formalising Mathematics 2022 course.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

`get_vert` has no API and is used nowhere else. This is the bare minumum.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
