### PR TITLE
[Merged by Bors] - chore(algebra/category/Module): simp lemmas for monoidal closed

### DIFF
--- a/src/algebra/category/Module/monoidal.lean
+++ b/src/algebra/category/Module/monoidal.lean
@@ -16,6 +16,10 @@ Mostly this uses existing machinery in `linear_algebra.tensor_product`.
 We just need to provide a few small missing pieces to build the
 `monoidal_category` instance and then the `symmetric_category` instance.
 
+Note the universe level of the modules must be at least the universe level of the ring,
+so that we have a monoidal unit.
+For now, we simplify by insisting both universe levels are the same.
+
 We then construct the monoidal closed structure on `Module R`.
 
 If you're happy using the bundled `Module R`, it may be possible to mostly
@@ -287,5 +291,18 @@ instance : monoidal_closed (Module.{u} R) :=
     { right := (linear_coyoneda R (Module.{u} R)).obj (op M),
       adj := adjunction.mk_of_hom_equiv
       { hom_equiv := λ N P, monoidal_closed_hom_equiv M N P, } } } }
+
+-- I can't seem to express the function coercion here without writing `@coe_fn`.
+@[simp]
+lemma monoidal_closed_curry {M N P : Module.{u} R} (f : M ⊗ N ⟶ P) (x : M) (y : N) :
+  @coe_fn _ _ linear_map.has_coe_to_fun ((monoidal_closed.curry f : N →ₗ[R] (M →ₗ[R] P)) y) x =
+    f (x ⊗ₜ[R] y) :=
+rfl
+
+@[simp]
+lemma monoidal_closed_uncurry {M N P : Module.{u} R}
+  (f : N ⟶ (M ⟶[Module.{u} R] P)) (x : M) (y : N) :
+  monoidal_closed.uncurry f (x ⊗ₜ[R] y) = (@coe_fn _ _ linear_map.has_coe_to_fun (f y)) x :=
+by { simp only [monoidal_closed.uncurry, ihom.adjunction, is_left_adjoint.adj], simp, }
 
 end Module

--- a/src/category_theory/closed/monoidal.lean
+++ b/src/category_theory/closed/monoidal.lean
@@ -108,7 +108,7 @@ lemma coev_naturality {X Y : C} (f : X ⟶ Y) :
   f ≫ (coev A).app Y = (coev A).app X ≫ (ihom A).map ((𝟙 A) ⊗ f) :=
 (coev A).naturality f
 
-notation A ` ⟶[C] `:20 B:19 := (ihom A).obj B
+notation A ` ⟶[`C`] ` B:10 := (@ihom C _ _ A _).obj B
 
 @[simp, reassoc] lemma ev_coev :
   ((𝟙 A) ⊗ ((coev A).app B)) ≫ (ev A).app (A ⊗ B) = 𝟙 (A ⊗ B) :=
@@ -131,15 +131,15 @@ variables {A}
 namespace monoidal_closed
 
 /-- Currying in a monoidal closed category. -/
-def curry : (A ⊗ Y ⟶ X) → (Y ⟶ A ⟶[C] X) :=
+def curry : (A ⊗ Y ⟶ X) → (Y ⟶ (A ⟶[C] X)) :=
 (ihom.adjunction A).hom_equiv _ _
 /-- Uncurrying in a monoidal closed category. -/
-def uncurry : (Y ⟶ A ⟶[C] X) → (A ⊗ Y ⟶ X) :=
+def uncurry : (Y ⟶ (A ⟶[C] X)) → (A ⊗ Y ⟶ X) :=
 ((ihom.adjunction A).hom_equiv _ _).symm
 
 @[simp] lemma hom_equiv_apply_eq (f : A ⊗ Y ⟶ X) :
   (ihom.adjunction A).hom_equiv _ _ f = curry f := rfl
-@[simp] lemma hom_equiv_symm_apply_eq (f : Y ⟶ A ⟶[C] X) :
+@[simp] lemma hom_equiv_symm_apply_eq (f : Y ⟶ (A ⟶[C] X)) :
   ((ihom.adjunction A).hom_equiv _ _).symm f = uncurry f := rfl
 
 @[reassoc]
@@ -153,12 +153,12 @@ lemma curry_natural_right (f : A ⊗ X ⟶ Y) (g : Y ⟶ Y') :
 adjunction.hom_equiv_naturality_right _ _ _
 
 @[reassoc]
-lemma uncurry_natural_right  (f : X ⟶ A ⟶[C] Y) (g : Y ⟶ Y') :
+lemma uncurry_natural_right  (f : X ⟶ (A ⟶[C] Y)) (g : Y ⟶ Y') :
   uncurry (f ≫ (ihom _).map g) = uncurry f ≫ g :=
 adjunction.hom_equiv_naturality_right_symm _ _ _
 
 @[reassoc]
-lemma uncurry_natural_left  (f : X ⟶ X') (g : X' ⟶ A ⟶[C] Y) :
+lemma uncurry_natural_left  (f : X ⟶ X') (g : X' ⟶ (A ⟶[C] Y)) :
   uncurry (f ≫ g) = ((𝟙 _) ⊗ f) ≫ uncurry g :=
 adjunction.hom_equiv_naturality_left_symm _ _ _
 
@@ -167,28 +167,28 @@ lemma uncurry_curry (f : A ⊗ X ⟶ Y) : uncurry (curry f) = f :=
 (closed.is_adj.adj.hom_equiv _ _).left_inv f
 
 @[simp]
-lemma curry_uncurry (f : X ⟶ A ⟶[C] Y) : curry (uncurry f) = f :=
+lemma curry_uncurry (f : X ⟶ (A ⟶[C] Y)) : curry (uncurry f) = f :=
 (closed.is_adj.adj.hom_equiv _ _).right_inv f
 
-lemma curry_eq_iff (f : A ⊗ Y ⟶ X) (g : Y ⟶ A ⟶[C] X) :
+lemma curry_eq_iff (f : A ⊗ Y ⟶ X) (g : Y ⟶ (A ⟶[C] X)) :
   curry f = g ↔ f = uncurry g :=
 adjunction.hom_equiv_apply_eq _ f g
 
-lemma eq_curry_iff (f : A ⊗ Y ⟶ X) (g : Y ⟶ A ⟶[C] X) :
+lemma eq_curry_iff (f : A ⊗ Y ⟶ X) (g : Y ⟶ (A ⟶[C] X)) :
   g = curry f ↔ uncurry g = f :=
 adjunction.eq_hom_equiv_apply _ f g
 
 -- I don't think these two should be simp.
-lemma uncurry_eq (g : Y ⟶ A ⟶[C] X) : uncurry g = ((𝟙 A) ⊗ g) ≫ (ihom.ev A).app X :=
+lemma uncurry_eq (g : Y ⟶ (A ⟶[C] X)) : uncurry g = ((𝟙 A) ⊗ g) ≫ (ihom.ev A).app X :=
 adjunction.hom_equiv_counit _
 
 lemma curry_eq (g : A ⊗ Y ⟶ X) : curry g = (ihom.coev A).app Y ≫ (ihom A).map g :=
 adjunction.hom_equiv_unit _
 
-lemma curry_injective : function.injective (curry : (A ⊗ Y ⟶ X) → (Y ⟶ A ⟶[C] X)) :=
+lemma curry_injective : function.injective (curry : (A ⊗ Y ⟶ X) → (Y ⟶ (A ⟶[C] X))) :=
 (closed.is_adj.adj.hom_equiv _ _).injective
 
-lemma uncurry_injective : function.injective (uncurry : (Y ⟶ A ⟶[C] X) → (A ⊗ Y ⟶ X)) :=
+lemma uncurry_injective : function.injective (uncurry : (Y ⟶ (A ⟶[C] X)) → (A ⊗ Y ⟶ X)) :=
 (closed.is_adj.adj.hom_equiv _ _).symm.injective
 
 variables (A X)


### PR DESCRIPTION
I'm worried by the fact that I can't express the coercions here without using `@`. They do turn up in the wild, however!

---

- [x] depends on: #12612 

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
