### PR TITLE
[Merged by Bors] - chore(category_theory/closed/monoidal): fix notation

### DIFF
--- a/src/category_theory/closed/monoidal.lean
+++ b/src/category_theory/closed/monoidal.lean
@@ -108,7 +108,7 @@ lemma coev_naturality {X Y : C} (f : X ⟶ Y) :
   f ≫ (coev A).app Y = (coev A).app X ≫ (ihom A).map ((𝟙 A) ⊗ f) :=
 (coev A).naturality f
 
-notation A ` ⟶[C] `:20 B:19 := (ihom A).obj B
+notation A ` ⟶[`C`] ` B:10 := (@ihom C _ _ A _).obj B
 
 @[simp, reassoc] lemma ev_coev :
   ((𝟙 A) ⊗ ((coev A).app B)) ≫ (ev A).app (A ⊗ B) = 𝟙 (A ⊗ B) :=
@@ -131,15 +131,15 @@ variables {A}
 namespace monoidal_closed
 
 /-- Currying in a monoidal closed category. -/
-def curry : (A ⊗ Y ⟶ X) → (Y ⟶ A ⟶[C] X) :=
+def curry : (A ⊗ Y ⟶ X) → (Y ⟶ (A ⟶[C] X)) :=
 (ihom.adjunction A).hom_equiv _ _
 /-- Uncurrying in a monoidal closed category. -/
-def uncurry : (Y ⟶ A ⟶[C] X) → (A ⊗ Y ⟶ X) :=
+def uncurry : (Y ⟶ (A ⟶[C] X)) → (A ⊗ Y ⟶ X) :=
 ((ihom.adjunction A).hom_equiv _ _).symm
 
 @[simp] lemma hom_equiv_apply_eq (f : A ⊗ Y ⟶ X) :
   (ihom.adjunction A).hom_equiv _ _ f = curry f := rfl
-@[simp] lemma hom_equiv_symm_apply_eq (f : Y ⟶ A ⟶[C] X) :
+@[simp] lemma hom_equiv_symm_apply_eq (f : Y ⟶ (A ⟶[C] X)) :
   ((ihom.adjunction A).hom_equiv _ _).symm f = uncurry f := rfl
 
 @[reassoc]
@@ -153,12 +153,12 @@ lemma curry_natural_right (f : A ⊗ X ⟶ Y) (g : Y ⟶ Y') :
 adjunction.hom_equiv_naturality_right _ _ _
 
 @[reassoc]
-lemma uncurry_natural_right  (f : X ⟶ A ⟶[C] Y) (g : Y ⟶ Y') :
+lemma uncurry_natural_right  (f : X ⟶ (A ⟶[C] Y)) (g : Y ⟶ Y') :
   uncurry (f ≫ (ihom _).map g) = uncurry f ≫ g :=
 adjunction.hom_equiv_naturality_right_symm _ _ _
 
 @[reassoc]
-lemma uncurry_natural_left  (f : X ⟶ X') (g : X' ⟶ A ⟶[C] Y) :
+lemma uncurry_natural_left  (f : X ⟶ X') (g : X' ⟶ (A ⟶[C] Y)) :
   uncurry (f ≫ g) = ((𝟙 _) ⊗ f) ≫ uncurry g :=
 adjunction.hom_equiv_naturality_left_symm _ _ _
 
@@ -167,28 +167,28 @@ lemma uncurry_curry (f : A ⊗ X ⟶ Y) : uncurry (curry f) = f :=
 (closed.is_adj.adj.hom_equiv _ _).left_inv f
 
 @[simp]
-lemma curry_uncurry (f : X ⟶ A ⟶[C] Y) : curry (uncurry f) = f :=
+lemma curry_uncurry (f : X ⟶ (A ⟶[C] Y)) : curry (uncurry f) = f :=
 (closed.is_adj.adj.hom_equiv _ _).right_inv f
 
-lemma curry_eq_iff (f : A ⊗ Y ⟶ X) (g : Y ⟶ A ⟶[C] X) :
+lemma curry_eq_iff (f : A ⊗ Y ⟶ X) (g : Y ⟶ (A ⟶[C] X)) :
   curry f = g ↔ f = uncurry g :=
 adjunction.hom_equiv_apply_eq _ f g
 
-lemma eq_curry_iff (f : A ⊗ Y ⟶ X) (g : Y ⟶ A ⟶[C] X) :
+lemma eq_curry_iff (f : A ⊗ Y ⟶ X) (g : Y ⟶ (A ⟶[C] X)) :
   g = curry f ↔ uncurry g = f :=
 adjunction.eq_hom_equiv_apply _ f g
 
 -- I don't think these two should be simp.
-lemma uncurry_eq (g : Y ⟶ A ⟶[C] X) : uncurry g = ((𝟙 A) ⊗ g) ≫ (ihom.ev A).app X :=
+lemma uncurry_eq (g : Y ⟶ (A ⟶[C] X)) : uncurry g = ((𝟙 A) ⊗ g) ≫ (ihom.ev A).app X :=
 adjunction.hom_equiv_counit _
 
 lemma curry_eq (g : A ⊗ Y ⟶ X) : curry g = (ihom.coev A).app Y ≫ (ihom A).map g :=
 adjunction.hom_equiv_unit _
 
-lemma curry_injective : function.injective (curry : (A ⊗ Y ⟶ X) → (Y ⟶ A ⟶[C] X)) :=
+lemma curry_injective : function.injective (curry : (A ⊗ Y ⟶ X) → (Y ⟶ (A ⟶[C] X))) :=
 (closed.is_adj.adj.hom_equiv _ _).injective
 
-lemma uncurry_injective : function.injective (uncurry : (Y ⟶ A ⟶[C] X) → (A ⊗ Y ⟶ X)) :=
+lemma uncurry_injective : function.injective (uncurry : (Y ⟶ (A ⟶[C] X)) → (A ⊗ Y ⟶ X)) :=
 (closed.is_adj.adj.hom_equiv _ _).symm.injective
 
 variables (A X)


### PR DESCRIPTION
Previously the `C` in the internal hom arrow ` ⟶[C] ` was hardcoded, which wasn't very useful!

I've also reduced the precedence slightly, so we now require more parentheses, but I think these are less confusing rather than more so it is a good side effect?

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
