### PR TITLE
[Merged by Bors] - fix(tactic/suggest): fixing `library_search`

### DIFF
--- a/src/tactic/suggest.lean
+++ b/src/tactic/suggest.lean
@@ -64,8 +64,8 @@ meta def allowed_head_symbols : expr → list name
 
 -- These allow `library_search` to search for lemmas of type `¬ a = b` when proving `a ≠ b`
 --   and vice-versa.
-| `(_ ≠ _) := [`false]
-| `(¬ _ = _) := [`ne]
+| `(_ ≠ _) := [`false, `ne]
+| `(¬ _ = _) := [`ne, `false]
 
 -- And then the generic cases:
 | (expr.pi _ _ _ t) := allowed_head_symbols t

--- a/test/library_search/basic.lean
+++ b/test/library_search/basic.lean
@@ -157,4 +157,11 @@ axiom ne_axiom : w ≠ z
 example : x ≠ y := by library_search
 example : ¬ w = z := by library_search
 
+structure foo := (a : nat) (b : nat)
+constants (k l : foo)
+axiom ne_axiom' (h : k.a ≠ 0) : k.b ≠ 0
+axiom not_axiom' (h : l.a ≠ 0) : ¬ l.b = 0
+example (hq : k.a ≠ 0) : k.b ≠ 0 := by library_search
+example (hq : l.a ≠ 0) : ¬ l.b = 0 := by library_search
+
 end test.library_search


### PR DESCRIPTION
Further enhancing `library_search` search possibilities for 'ne' and 'not eq'

Related: https://github.com/leanprover-community/mathlib/pull/11742

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
