### PR TITLE
[Merged by Bors] - feat(category_theory/monoidal): distribute tensor over direct sum

### DIFF
--- a/src/category_theory/limits/shapes/biproducts.lean
+++ b/src/category_theory/limits/shapes/biproducts.lean
@@ -1210,6 +1210,10 @@ def is_bilimit_of_total {f : J → C} (b : bicone f) (total : ∑ j : J, b.π j 
       dsimp, simp,
     end } }
 
+lemma is_bilimit.total {f : J → C} {b : bicone f} (i : b.is_bilimit) :
+  ∑ j : J, b.π j ≫ b.ι j = 𝟙 b.X :=
+i.is_limit.hom_ext (λ j, by simp [sum_comp, b.ι_π, comp_dite])
+
 /--
 In a preadditive category, we can construct a biproduct for `f : J → C` from
 any bicone `b` for `f` satisfying `total : ∑ j : J, b.π j ≫ b.ι j = 𝟙 b.X`.
@@ -1276,10 +1280,7 @@ In any preadditive category, any biproduct satsifies
 `∑ j : J, biproduct.π f j ≫ biproduct.ι f j = 𝟙 (⨁ f)`
 -/
 @[simp] lemma biproduct.total : ∑ j : J, biproduct.π f j ≫ biproduct.ι f j = 𝟙 (⨁ f) :=
-begin
-  ext j j',
-  simp [comp_sum, sum_comp, biproduct.ι_π, comp_dite, dite_comp],
-end
+is_bilimit.total (biproduct.is_bilimit _)
 
 lemma biproduct.lift_eq {T : C} {g : Π j, T ⟶ f j} :
   biproduct.lift g = ∑ j, g j ≫ biproduct.ι f j :=
@@ -1357,6 +1358,10 @@ def is_binary_bilimit_of_total {X Y : C} (b : binary_bicone X Y)
     uniq' := λ s m h, by erw [←category.id_comp m, ←total,
       add_comp, category.assoc, category.assoc, h walking_pair.left, h walking_pair.right],
     fac' := λ s j, by cases j; simp, } }
+
+lemma is_bilimit.binary_total {X Y : C} {b : binary_bicone X Y} (i : b.is_bilimit) :
+  b.fst ≫ b.inl + b.snd ≫ b.inr = 𝟙 b.X :=
+i.is_limit.hom_ext (λ j, by { cases j; simp, })
 
 /--
 In a preadditive category, we can construct a binary biproduct for `X Y : C` from

--- a/src/category_theory/monoidal/category.lean
+++ b/src/category_theory/monoidal/category.lean
@@ -176,6 +176,16 @@ variables {U V W X Y Z : C}
 -- left_unitor_inv_naturality
 -- right_unitor_inv_naturality
 
+lemma tensor_dite {P : Prop} [decidable P]
+  {W X Y Z : C} (f : W ⟶ X) (g : P → (Y ⟶ Z)) (g' : ¬P → (Y ⟶ Z)) :
+  f ⊗ (if h : P then g h else g' h) = if h : P then f ⊗ g h else f ⊗ g' h :=
+by { split_ifs; refl }
+
+lemma dite_tensor {P : Prop} [decidable P]
+  {W X Y Z : C} (f : W ⟶ X) (g : P → (Y ⟶ Z)) (g' : ¬P → (Y ⟶ Z)) :
+  (if h : P then g h else g' h) ⊗ f  = if h : P then g h ⊗ f else g' h ⊗ f :=
+by { split_ifs; refl }
+
 @[reassoc, simp] lemma comp_tensor_id (f : W ⟶ X) (g : X ⟶ Y) :
   (f ≫ g) ⊗ (𝟙 Z) = (f ⊗ (𝟙 Z)) ≫ (g ⊗ (𝟙 Z)) :=
 by { rw ←tensor_comp, simp }

--- a/src/category_theory/monoidal/preadditive.lean
+++ b/src/category_theory/monoidal/preadditive.lean
@@ -47,4 +47,82 @@ local attribute [simp] monoidal_preadditive.tensor_add monoidal_preadditive.add_
 instance tensoring_left_additive (X : C) : ((tensoring_left C).obj X).additive := {}
 instance tensoring_right_additive (X : C) : ((tensoring_right C).obj X).additive := {}
 
+open_locale big_operators
+
+lemma tensor_sum {P Q R S : C} {J : Type*} (s : finset J) (f : P ⟶ Q) (g : J → (R ⟶ S)) :
+  f ⊗ ∑ j in s, g j = ∑ j in s, f ⊗ g j :=
+begin
+  rw ←tensor_id_comp_id_tensor,
+  let tQ := (((tensoring_left C).obj Q).map_add_hom : (R ⟶ S) →+ _),
+  change _ ≫ tQ _ = _,
+  rw [tQ.map_sum, preadditive.comp_sum],
+  dsimp [tQ],
+  simp only [tensor_id_comp_id_tensor],
+end
+
+lemma sum_tensor {P Q R S : C} {J : Type*} (s : finset J) (f : P ⟶ Q) (g : J → (R ⟶ S)) :
+  (∑ j in s, g j) ⊗ f = ∑ j in s, g j ⊗ f :=
+begin
+  rw ←tensor_id_comp_id_tensor,
+  let tQ := (((tensoring_right C).obj P).map_add_hom : (R ⟶ S) →+ _),
+  change tQ _ ≫ _ = _,
+  rw [tQ.map_sum, preadditive.sum_comp],
+  dsimp [tQ],
+  simp only [tensor_id_comp_id_tensor],
+end
+
+variables {C} [has_finite_biproducts C]
+
+def left_distributor {J : Type*} [decidable_eq J] [fintype J] (X : C) (f : J → C) :
+  X ⊗ (⨁ f) ≅ ⨁ (λ j, X ⊗ f j) :=
+{ hom := ∑ j : J, (𝟙 X ⊗ biproduct.π f j) ≫ biproduct.ι _ j,
+  inv := ∑ j : J, biproduct.π _ j ≫ (𝟙 X ⊗ biproduct.ι f j),
+  hom_inv_id' := begin
+    simp only [if_true, dif_ctx_congr,
+      finset.mem_univ, finset.sum_congr, finset.sum_dite_eq',
+      preadditive.sum_comp, preadditive.comp_sum,
+      category.id_comp, category.assoc, eq_to_hom_refl,
+      biproduct.ι_π_assoc, comp_zero, zero_comp, dite_comp, comp_dite],
+    simp only [←id_tensor_comp, ←tensor_sum, biproduct.total, tensor_id],
+  end,
+  inv_hom_id' := begin
+    ext j j',
+    simp only [preadditive.sum_comp, preadditive.comp_sum,
+      category.assoc, category.comp_id, category.id_comp, dite_comp, comp_dite,
+      ←id_tensor_comp_assoc, biproduct.ι_π, biproduct.ι_π_assoc],
+    simp only [category.comp_id, category.id_comp, eq_to_hom_refl, tensor_dite,
+      finset.sum_dite_eq, finset.mem_univ, finset.sum_congr, finset.sum_dite_eq',
+      dite_eq_ite, if_t_t, if_true, dif_ctx_congr,
+      comp_zero, zero_comp, monoidal_preadditive.tensor_zero],
+    split_ifs with h,
+    { cases h, simp, },
+    { refl, },
+  end, }
+
+def right_distributor {J : Type*} [decidable_eq J] [fintype J] (X : C) (f : J → C) :
+  (⨁ f) ⊗ X ≅ ⨁ (λ j, f j ⊗ X) :=
+{ hom := ∑ j : J, (biproduct.π f j ⊗ 𝟙 X) ≫ biproduct.ι _ j,
+  inv := ∑ j : J, biproduct.π _ j ≫ (biproduct.ι f j ⊗ 𝟙 X),
+  hom_inv_id' := begin
+    simp only [if_true, dif_ctx_congr,
+      finset.mem_univ, finset.sum_congr, finset.sum_dite_eq',
+      preadditive.sum_comp, preadditive.comp_sum,
+      category.id_comp, category.assoc, eq_to_hom_refl,
+      biproduct.ι_π_assoc, comp_zero, zero_comp, dite_comp, comp_dite],
+    simp only [←comp_tensor_id, ←sum_tensor, biproduct.total, tensor_id],
+  end,
+  inv_hom_id' := begin
+    ext j j',
+    simp only [preadditive.sum_comp, preadditive.comp_sum,
+      category.assoc, category.comp_id, category.id_comp, dite_comp, comp_dite,
+      ←comp_tensor_id_assoc, biproduct.ι_π, biproduct.ι_π_assoc],
+    simp only [category.comp_id, category.id_comp, eq_to_hom_refl, tensor_dite,
+      finset.sum_dite_eq, finset.mem_univ, finset.sum_congr, finset.sum_dite_eq',
+      dite_eq_ite, if_t_t, if_true, dif_ctx_congr,
+      comp_zero, zero_comp, monoidal_preadditive.tensor_zero],
+    split_ifs with h,
+    { cases h, simp, },
+    { simp, },
+  end, }
+
 end category_theory

--- a/src/category_theory/monoidal/preadditive.lean
+++ b/src/category_theory/monoidal/preadditive.lean
@@ -44,6 +44,8 @@ variables [monoidal_preadditive C]
 
 local attribute [simp] monoidal_preadditive.tensor_add monoidal_preadditive.add_tensor
 
+instance tensor_left_additive (X : C) : (tensor_left X).additive := {}
+instance tensor_right_additive (X : C) : (tensor_right X).additive := {}
 instance tensoring_left_additive (X : C) : ((tensoring_left C).obj X).additive := {}
 instance tensoring_right_additive (X : C) : ((tensoring_right C).obj X).additive := {}
 
@@ -73,33 +75,37 @@ end
 
 variables {C} [has_finite_biproducts C]
 
+-- In a closed monoidal category, this would hold because
+-- `tensor_left X` is a left adjoint and hence preserves all colimits.
+-- In any case it is true in any preadditive category.
+instance (X : C) : preserves_finite_biproducts (tensor_left X) :=
+{ preserves := λ J _ _, by exactI
+  { preserves := λ f,
+    { preserves := λ b i, is_bilimit_of_total _ begin
+      dsimp,
+      simp only [←tensor_comp, category.comp_id, ←tensor_sum, ←tensor_id, is_bilimit.total i],
+    end } } }
+
 /-- The isomorphism showing how tensor product on the left distributes over direct sums. -/
-@[simps]
 def left_distributor {J : Type*} [decidable_eq J] [fintype J] (X : C) (f : J → C) :
   X ⊗ (⨁ f) ≅ ⨁ (λ j, X ⊗ f j) :=
-{ hom := ∑ j : J, (𝟙 X ⊗ biproduct.π f j) ≫ biproduct.ι _ j,
-  inv := ∑ j : J, biproduct.π _ j ≫ (𝟙 X ⊗ biproduct.ι f j),
-  hom_inv_id' := begin
-    simp only [if_true, dif_ctx_congr,
-      finset.mem_univ, finset.sum_congr, finset.sum_dite_eq',
-      preadditive.sum_comp, preadditive.comp_sum,
-      category.id_comp, category.assoc, eq_to_hom_refl,
-      biproduct.ι_π_assoc, comp_zero, zero_comp, dite_comp, comp_dite],
-    simp only [←id_tensor_comp, ←tensor_sum, biproduct.total, tensor_id],
-  end,
-  inv_hom_id' := begin
-    ext j j',
-    simp only [preadditive.sum_comp, preadditive.comp_sum,
-      category.assoc, category.comp_id, category.id_comp, dite_comp, comp_dite,
-      ←id_tensor_comp_assoc, biproduct.ι_π, biproduct.ι_π_assoc],
-    simp only [category.comp_id, category.id_comp, eq_to_hom_refl, tensor_dite,
-      finset.sum_dite_eq, finset.mem_univ, finset.sum_congr, finset.sum_dite_eq',
-      dite_eq_ite, if_t_t, if_true, dif_ctx_congr,
-      comp_zero, zero_comp, monoidal_preadditive.tensor_zero],
-    split_ifs with h,
-    { cases h, simp, },
-    { refl, },
-  end, }
+(tensor_left X).map_biproduct f
+
+@[simp]
+lemma left_distributor_hom {J : Type*} [decidable_eq J] [fintype J] (X : C) (f : J → C) :
+  (left_distributor X f).hom = ∑ j : J, (𝟙 X ⊗ biproduct.π f j) ≫ biproduct.ι _ j :=
+begin
+  ext, dsimp [tensor_left, left_distributor],
+  simp [preadditive.sum_comp, biproduct.ι_π, comp_dite],
+end
+
+@[simp]
+lemma left_distributor_inv {J : Type*} [decidable_eq J] [fintype J] (X : C) (f : J → C) :
+  (left_distributor X f).inv = ∑ j : J, biproduct.π _ j ≫ (𝟙 X ⊗ biproduct.ι f j) :=
+begin
+  ext, dsimp [tensor_left, left_distributor],
+  simp [preadditive.comp_sum, biproduct.ι_π_assoc, dite_comp],
+end
 
 lemma left_distributor_assoc {J : Type*} [decidable_eq J] [fintype J] (X Y : C) (f : J → C) :
    (as_iso (𝟙 X) ⊗ left_distributor Y f) ≪≫ left_distributor X _ =
@@ -119,33 +125,34 @@ begin
   simp only [←tensor_id, associator_naturality, iso.inv_hom_id_assoc],
 end
 
+instance (X : C) : preserves_finite_biproducts (tensor_right X) :=
+{ preserves := λ J _ _, by exactI
+  { preserves := λ f,
+    { preserves := λ b i, is_bilimit_of_total _ begin
+      dsimp,
+      simp only [←tensor_comp, category.comp_id, ←sum_tensor, ←tensor_id, is_bilimit.total i],
+    end } } }
+
 /-- The isomorphism showing how tensor product on the right distributes over direct sums. -/
-@[simps]
 def right_distributor {J : Type*} [decidable_eq J] [fintype J] (X : C) (f : J → C) :
-  (⨁ f) ⊗ X ≅ ⨁ (λ j, f j ⊗ X) :=
-{ hom := ∑ j : J, (biproduct.π f j ⊗ 𝟙 X) ≫ biproduct.ι _ j,
-  inv := ∑ j : J, biproduct.π _ j ≫ (biproduct.ι f j ⊗ 𝟙 X),
-  hom_inv_id' := begin
-    simp only [if_true, dif_ctx_congr,
-      finset.mem_univ, finset.sum_congr, finset.sum_dite_eq',
-      preadditive.sum_comp, preadditive.comp_sum,
-      category.id_comp, category.assoc, eq_to_hom_refl,
-      biproduct.ι_π_assoc, comp_zero, zero_comp, dite_comp, comp_dite],
-    simp only [←comp_tensor_id, ←sum_tensor, biproduct.total, tensor_id],
-  end,
-  inv_hom_id' := begin
-    ext j j',
-    simp only [preadditive.sum_comp, preadditive.comp_sum,
-      category.assoc, category.comp_id, category.id_comp, dite_comp, comp_dite,
-      ←comp_tensor_id_assoc, biproduct.ι_π, biproduct.ι_π_assoc],
-    simp only [category.comp_id, category.id_comp, eq_to_hom_refl, tensor_dite,
-      finset.sum_dite_eq, finset.mem_univ, finset.sum_congr, finset.sum_dite_eq',
-      dite_eq_ite, if_t_t, if_true, dif_ctx_congr,
-      comp_zero, zero_comp, monoidal_preadditive.tensor_zero],
-    split_ifs with h,
-    { cases h, simp, },
-    { simp, },
-  end, }
+  (⨁ f) ⊗ X ≅ ⨁ (λ j, f j ⊗ X)  :=
+(tensor_right X).map_biproduct f
+
+@[simp]
+lemma right_distributor_hom {J : Type*} [decidable_eq J] [fintype J] (X : C) (f : J → C) :
+  (right_distributor X f).hom = ∑ j : J, (biproduct.π f j ⊗ 𝟙 X) ≫ biproduct.ι _ j :=
+begin
+  ext, dsimp [tensor_right, right_distributor],
+  simp [preadditive.sum_comp, biproduct.ι_π, comp_dite],
+end
+
+@[simp]
+lemma right_distributor_inv {J : Type*} [decidable_eq J] [fintype J] (X : C) (f : J → C) :
+  (right_distributor X f).inv = ∑ j : J, biproduct.π _ j ≫ (biproduct.ι f j ⊗ 𝟙 X) :=
+begin
+  ext, dsimp [tensor_right, right_distributor],
+  simp [preadditive.comp_sum, biproduct.ι_π_assoc, dite_comp],
+end
 
 lemma right_distributor_assoc {J : Type*} [decidable_eq J] [fintype J] (X Y : C) (f : J → C) :
    (right_distributor X f ⊗ as_iso (𝟙 Y)) ≪≫ right_distributor Y _ =

--- a/src/category_theory/monoidal/preadditive.lean
+++ b/src/category_theory/monoidal/preadditive.lean
@@ -73,6 +73,8 @@ end
 
 variables {C} [has_finite_biproducts C]
 
+/-- The isomorphism showing how tensor product on the left distributes over direct sums. -/
+@[simps]
 def left_distributor {J : Type*} [decidable_eq J] [fintype J] (X : C) (f : J → C) :
   X ⊗ (⨁ f) ≅ ⨁ (λ j, X ⊗ f j) :=
 { hom := ∑ j : J, (𝟙 X ⊗ biproduct.π f j) ≫ biproduct.ι _ j,
@@ -99,6 +101,26 @@ def left_distributor {J : Type*} [decidable_eq J] [fintype J] (X : C) (f : J →
     { refl, },
   end, }
 
+lemma left_distributor_assoc {J : Type*} [decidable_eq J] [fintype J] (X Y : C) (f : J → C) :
+   (as_iso (𝟙 X) ⊗ left_distributor Y f) ≪≫ left_distributor X _ =
+     (α_ X Y (⨁ f)).symm ≪≫ left_distributor (X ⊗ Y) f ≪≫ biproduct.map_iso (λ j, α_ X Y _) :=
+begin
+  ext,
+  simp only [category.comp_id,  category.assoc, eq_to_hom_refl,
+    iso.trans_hom, iso.symm_hom, as_iso_hom, comp_zero, comp_dite,
+    preadditive.sum_comp, preadditive.comp_sum,
+    tensor_sum, id_tensor_comp, tensor_iso_hom, left_distributor_hom,
+    biproduct.map_iso_hom, biproduct.ι_map, biproduct.ι_π,
+    finset.sum_dite_irrel, finset.sum_dite_eq', finset.sum_const_zero],
+  simp only [←id_tensor_comp, biproduct.ι_π],
+  simp only [id_tensor_comp, tensor_dite, comp_dite],
+  simp only [category.comp_id, comp_zero, monoidal_preadditive.tensor_zero, eq_to_hom_refl, tensor_id,
+    if_true, dif_ctx_congr, finset.sum_congr, finset.mem_univ, finset.sum_dite_eq'],
+  simp only [←tensor_id, associator_naturality, iso.inv_hom_id_assoc],
+end
+
+/-- The isomorphism showing how tensor product on the right distributes over direct sums. -/
+@[simps]
 def right_distributor {J : Type*} [decidable_eq J] [fintype J] (X : C) (f : J → C) :
   (⨁ f) ⊗ X ≅ ⨁ (λ j, f j ⊗ X) :=
 { hom := ∑ j : J, (biproduct.π f j ⊗ 𝟙 X) ≫ biproduct.ι _ j,
@@ -124,5 +146,44 @@ def right_distributor {J : Type*} [decidable_eq J] [fintype J] (X : C) (f : J �
     { cases h, simp, },
     { simp, },
   end, }
+
+lemma right_distributor_assoc {J : Type*} [decidable_eq J] [fintype J] (X Y : C) (f : J → C) :
+   (right_distributor X f ⊗ as_iso (𝟙 Y)) ≪≫ right_distributor Y _ =
+     α_ (⨁ f) X Y ≪≫ right_distributor (X ⊗ Y) f ≪≫ biproduct.map_iso (λ j, (α_ _ X Y).symm) :=
+begin
+  ext,
+  simp only [category.comp_id, category.assoc, eq_to_hom_refl, iso.symm_hom,
+    iso.trans_hom, as_iso_hom, comp_zero, comp_dite, preadditive.sum_comp, preadditive.comp_sum,
+    sum_tensor, comp_tensor_id, tensor_iso_hom, right_distributor_hom,
+    biproduct.map_iso_hom, biproduct.ι_map, biproduct.ι_π,
+    finset.sum_dite_irrel, finset.sum_dite_eq', finset.sum_const_zero, finset.mem_univ, if_true],
+  simp only [←comp_tensor_id, biproduct.ι_π, dite_tensor, comp_dite],
+  simp only [category.comp_id, comp_tensor_id, eq_to_hom_refl, tensor_id, comp_zero,
+    monoidal_preadditive.zero_tensor,
+    if_true, dif_ctx_congr, finset.mem_univ, finset.sum_congr, finset.sum_dite_eq'],
+  simp only [←tensor_id, associator_inv_naturality, iso.hom_inv_id_assoc]
+end
+
+lemma left_distributor_right_distributor_assoc
+  {J : Type*} [decidable_eq J] [fintype J] (X Y : C) (f : J → C) :
+  (left_distributor X f ⊗ as_iso (𝟙 Y)) ≪≫ right_distributor Y _ =
+    α_ X (⨁ f) Y ≪≫ (as_iso (𝟙 X) ⊗ right_distributor Y _) ≪≫ left_distributor X _ ≪≫
+      biproduct.map_iso (λ j, (α_ _ _ _).symm) :=
+begin
+  ext,
+  simp only [category.comp_id, category.assoc, eq_to_hom_refl, iso.symm_hom,
+    iso.trans_hom, as_iso_hom, comp_zero, comp_dite, preadditive.sum_comp, preadditive.comp_sum,
+    sum_tensor, tensor_sum, comp_tensor_id, tensor_iso_hom,
+    left_distributor_hom, right_distributor_hom,
+    biproduct.map_iso_hom, biproduct.ι_map, biproduct.ι_π,
+    finset.sum_dite_irrel, finset.sum_dite_eq', finset.sum_const_zero, finset.mem_univ, if_true],
+  simp only [←comp_tensor_id, ←id_tensor_comp_assoc, category.assoc, biproduct.ι_π,
+    comp_dite, dite_comp, tensor_dite, dite_tensor],
+  simp only [category.comp_id, category.id_comp, category.assoc, id_tensor_comp,
+    comp_zero, zero_comp, monoidal_preadditive.tensor_zero, monoidal_preadditive.zero_tensor,
+    comp_tensor_id, eq_to_hom_refl, tensor_id,
+    if_true, dif_ctx_congr, finset.sum_congr, finset.mem_univ, finset.sum_dite_eq'],
+  simp only [associator_inv_naturality, iso.hom_inv_id_assoc]
+end
 
 end category_theory

--- a/src/category_theory/monoidal/preadditive.lean
+++ b/src/category_theory/monoidal/preadditive.lean
@@ -114,8 +114,8 @@ begin
     finset.sum_dite_irrel, finset.sum_dite_eq', finset.sum_const_zero],
   simp only [←id_tensor_comp, biproduct.ι_π],
   simp only [id_tensor_comp, tensor_dite, comp_dite],
-  simp only [category.comp_id, comp_zero, monoidal_preadditive.tensor_zero, eq_to_hom_refl, tensor_id,
-    if_true, dif_ctx_congr, finset.sum_congr, finset.mem_univ, finset.sum_dite_eq'],
+  simp only [category.comp_id, comp_zero, monoidal_preadditive.tensor_zero, eq_to_hom_refl,
+    tensor_id, if_true, dif_ctx_congr, finset.sum_congr, finset.mem_univ, finset.sum_dite_eq'],
   simp only [←tensor_id, associator_naturality, iso.inv_hom_id_assoc],
 end
 

--- a/src/category_theory/monoidal/preadditive.lean
+++ b/src/category_theory/monoidal/preadditive.lean
@@ -73,7 +73,7 @@ begin
   simp only [tensor_id_comp_id_tensor],
 end
 
-variables {C} [has_finite_biproducts C]
+variables {C}
 
 -- In a closed monoidal category, this would hold because
 -- `tensor_left X` is a left adjoint and hence preserves all colimits.
@@ -85,6 +85,16 @@ instance (X : C) : preserves_finite_biproducts (tensor_left X) :=
       dsimp,
       simp only [←tensor_comp, category.comp_id, ←tensor_sum, ←tensor_id, is_bilimit.total i],
     end } } }
+
+instance (X : C) : preserves_finite_biproducts (tensor_right X) :=
+{ preserves := λ J _ _, by exactI
+  { preserves := λ f,
+    { preserves := λ b i, is_bilimit_of_total _ begin
+      dsimp,
+      simp only [←tensor_comp, category.comp_id, ←sum_tensor, ←tensor_id, is_bilimit.total i],
+    end } } }
+
+variables [has_finite_biproducts C]
 
 /-- The isomorphism showing how tensor product on the left distributes over direct sums. -/
 def left_distributor {J : Type*} [decidable_eq J] [fintype J] (X : C) (f : J → C) :
@@ -124,14 +134,6 @@ begin
     tensor_id, if_true, dif_ctx_congr, finset.sum_congr, finset.mem_univ, finset.sum_dite_eq'],
   simp only [←tensor_id, associator_naturality, iso.inv_hom_id_assoc],
 end
-
-instance (X : C) : preserves_finite_biproducts (tensor_right X) :=
-{ preserves := λ J _ _, by exactI
-  { preserves := λ f,
-    { preserves := λ b i, is_bilimit_of_total _ begin
-      dsimp,
-      simp only [←tensor_comp, category.comp_id, ←sum_tensor, ←tensor_id, is_bilimit.total i],
-    end } } }
 
 /-- The isomorphism showing how tensor product on the right distributes over direct sums. -/
 def right_distributor {J : Type*} [decidable_eq J] [fintype J] (X : C) (f : J → C) :


### PR DESCRIPTION
This is preliminary to the monoidal structure on chain complexes.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
