### PR TITLE
[Merged by Bors] - feat(group_theory/commutator): The three subgroups lemma

### DIFF
--- a/src/group_theory/commutator.lean
+++ b/src/group_theory/commutator.lean
@@ -103,6 +103,19 @@ begin
   rw [mem_bot, commutator_element_eq_one_iff_mul_comm, eq_comm],
 end
 
+lemma general_commutator_general_commutator_eq_bot_of_rotate {H₁ H₂ H₃ : subgroup G}
+  (h1 : ⁅⁅H₂, H₃⁆, H₁⁆ = ⊥) (h2 : ⁅⁅H₃, H₁⁆, H₂⁆ = ⊥) : ⁅⁅H₁, H₂⁆, H₃⁆ = ⊥ :=
+begin
+  simp_rw [commutator_eq_bot_iff_le_centralizer, commutator_le,
+    mem_centralizer_iff_commutator_eq_one] at h1 h2 ⊢,
+  intros x hx y hy z hz,
+  have : ⁅z, ⁅x, y⁆⁆ = x * z * ⁅y, ⁅z⁻¹, x⁻¹⁆⁆⁻¹ * z⁻¹ * y * ⁅x⁻¹, ⁅y⁻¹, z⁆⁆⁻¹ * y⁻¹ * x⁻¹ :=
+  by group,
+  simp only [commutator_element_def] at *,
+  rw [this, h1 _ (H₂.inv_mem hy) z hz _ (H₁.inv_mem hx), h2 _ (H₃.inv_mem hz) _ (H₁.inv_mem hx) y hy,
+    one_inv, mul_one, mul_one, mul_inv_cancel_right, mul_inv_cancel_right, mul_inv_self],
+end
+
 lemma commutator_le_right (H₁ H₂ : subgroup G) [h : normal H₂] : ⁅H₁, H₂⁆ ≤ H₂ :=
 commutator_le.mpr (λ g₁ h₁ g₂ h₂, H₂.mul_mem (h.conj_mem g₂ h₂ g₁) (H₂.inv_mem h₂))
 

--- a/src/group_theory/commutator.lean
+++ b/src/group_theory/commutator.lean
@@ -76,7 +76,8 @@ begin
   rw [mem_bot, commutator_element_eq_one_iff_mul_comm, eq_comm],
 end
 
-lemma general_commutator_general_commutator_eq_bot_of_rotate
+/-- **The Three Subgroups Lemma** -/
+lemma commutator_commutator_eq_bot_of_rotate
   (h1 : ⁅⁅H₂, H₃⁆, H₁⁆ = ⊥) (h2 : ⁅⁅H₃, H₁⁆, H₂⁆ = ⊥) : ⁅⁅H₁, H₂⁆, H₃⁆ = ⊥ :=
 begin
   simp_rw [commutator_eq_bot_iff_le_centralizer, commutator_le,

--- a/src/group_theory/commutator.lean
+++ b/src/group_theory/commutator.lean
@@ -76,7 +76,7 @@ begin
   rw [mem_bot, commutator_element_eq_one_iff_mul_comm, eq_comm],
 end
 
-/-- **The Three Subgroups Lemma** -/
+/-- **The Three Subgroups Lemma** (via the Hall-Witt identity) -/
 lemma commutator_commutator_eq_bot_of_rotate
   (h1 : ⁅⁅H₂, H₃⁆, H₁⁆ = ⊥) (h2 : ⁅⁅H₃, H₁⁆, H₂⁆ = ⊥) : ⁅⁅H₁, H₂⁆, H₃⁆ = ⊥ :=
 begin

--- a/src/group_theory/commutator.lean
+++ b/src/group_theory/commutator.lean
@@ -107,13 +107,12 @@ lemma general_commutator_general_commutator_eq_bot_of_rotate {H₁ H₂ H₃ : s
   (h1 : ⁅⁅H₂, H₃⁆, H₁⁆ = ⊥) (h2 : ⁅⁅H₃, H₁⁆, H₂⁆ = ⊥) : ⁅⁅H₁, H₂⁆, H₃⁆ = ⊥ :=
 begin
   simp_rw [commutator_eq_bot_iff_le_centralizer, commutator_le,
-    mem_centralizer_iff_commutator_eq_one] at h1 h2 ⊢,
+    mem_centralizer_iff_commutator_eq_one, ←commutator_element_def] at h1 h2 ⊢,
   intros x hx y hy z hz,
-  have : ⁅z, ⁅x, y⁆⁆ = x * z * ⁅y, ⁅z⁻¹, x⁻¹⁆⁆⁻¹ * z⁻¹ * y * ⁅x⁻¹, ⁅y⁻¹, z⁆⁆⁻¹ * y⁻¹ * x⁻¹ :=
-  by group,
-  simp only [commutator_element_def] at *,
-  rw [this, h1 _ (H₂.inv_mem hy) z hz _ (H₁.inv_mem hx), h2 _ (H₃.inv_mem hz) _ (H₁.inv_mem hx) y hy,
-    one_inv, mul_one, mul_one, mul_inv_cancel_right, mul_inv_cancel_right, mul_inv_self],
+  transitivity x * z * ⁅y, ⁅z⁻¹, x⁻¹⁆⁆⁻¹ * z⁻¹ * y * ⁅x⁻¹, ⁅y⁻¹, z⁆⁆⁻¹ * y⁻¹ * x⁻¹,
+  { group },
+  { rw [h1 _ (H₂.inv_mem hy) _ hz _ (H₁.inv_mem hx), h2 _ (H₃.inv_mem hz) _ (H₁.inv_mem hx) _ hy],
+    group },
 end
 
 lemma commutator_le_right (H₁ H₂ : subgroup G) [h : normal H₂] : ⁅H₁, H₂⁆ ≤ H₂ :=


### PR DESCRIPTION
This PR proves the three subgroups lemma: If `⁅⁅H₂, H₃⁆, H₁⁆ = ⊥` and `⁅⁅H₃, H₁⁆, H₂⁆ = ⊥`, then `⁅⁅H₁, H₂⁆, H₃⁆ = ⊥`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
