### PR TITLE
feat(linear_algebra/affine_space/independent): There exists a nontrivial affine relation on an affine dependent family

### DIFF
--- a/src/linear_algebra/affine_space/independent.lean
+++ b/src/linear_algebra/affine_space/independent.lean
@@ -464,6 +464,18 @@ begin
   { simp only [finset.sum_dite_of_true (λx h, h), subtype.val_eq_coe, finset.mk_coe, f, hwt, hw], },
 end
 
+lemma exists_nontrivial_relation_sum_zero_of_not_affine_ind'
+  {ι} {p : ι → V} (h : ¬ affine_independent k p) : ∃ t : finset ι,
+  (∃ f : ι → k, ∑ e in t, f e • p e = 0 ∧ ∑ e in t, f e = 0 ∧ ∃ x ∈ t, f x ≠ 0) :=
+begin
+  rw affine_independent_def at h,
+  simp only [exists_prop, not_forall] at h,
+  obtain ⟨t, w, hw, hwt, i, hi, hi'⟩ := h,
+  simp only [finset.weighted_vsub_eq_weighted_vsub_of_point_of_sum_eq_zero _ w p hw 0,
+    vsub_eq_sub, finset.weighted_vsub_of_point_apply, sub_zero] at hwt,
+  exact ⟨t, w, hwt, hw, i, hi, hi'⟩
+end
+
 end affine_independent
 
 section division_ring


### PR DESCRIPTION
This generalizes `exists_nontrivial_relation_sum_zero_of_not_affine_ind` to families that aren't necessarily indexed by a `finset`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

I'm unsure on the name I should use for this theorem. Suggestions welcome.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
