### PR TITLE
[Merged by Bors] - feat(analysis/seminorm): add lemmas for inequalities and `finset.sup`

### DIFF
--- a/src/analysis/seminorm.lean
+++ b/src/analysis/seminorm.lean
@@ -310,6 +310,26 @@ begin
   exact bot_le,
 end
 
+lemma sup_le_apply (p : ι → seminorm 𝕜 E) (s : finset ι) (x : E) {a : ℝ} (ha : 0 < a):
+  (∀ (i : ι), i ∈ s → p i x ≤ a) → s.sup p x ≤ a :=
+begin
+  intro h,
+  rw [finset_sup_apply, ←a.coe_to_nnreal ha.le, nnreal.coe_le_coe],
+  refine finset.sup_le (λ i hi, _),
+  rw [←nnreal.coe_le_coe, subtype.coe_mk, a.coe_to_nnreal ha.le],
+  exact h i hi,
+end
+
+lemma sup_lt_apply {p : ι → seminorm 𝕜 E} {s : finset ι} {x : E} {a : ℝ} (ha : 0 < a):
+  (∀ (i : ι), i ∈ s → p i x < a) → s.sup p x < a :=
+begin
+  intro h,
+  rw [finset_sup_apply, ←a.coe_to_nnreal ha.le, nnreal.coe_lt_coe],
+  refine (finset.sup_lt_iff (real.to_nnreal_pos.mpr ha)).mpr (λ i hi, _),
+  rw [←nnreal.coe_lt_coe, subtype.coe_mk, a.coe_to_nnreal ha.le],
+  exact h i hi,
+end
+
 end norm_one_class
 end module
 end semi_normed_ring

--- a/src/analysis/seminorm.lean
+++ b/src/analysis/seminorm.lean
@@ -310,7 +310,7 @@ begin
   exact bot_le,
 end
 
-lemma finset_sup_le_apply (p : ι → seminorm 𝕜 E) (s : finset ι) (x : E) {a : ℝ} (ha : 0 < a)
+lemma finset_sup_apply_le (p : ι → seminorm 𝕜 E) (s : finset ι) (x : E) {a : ℝ} (ha : 0 < a)
   (h: ∀ (i : ι), i ∈ s → p i x ≤ a) : s.sup p x ≤ a :=
 begin
   rw [finset_sup_apply, ←a.coe_to_nnreal ha.le, nnreal.coe_le_coe],

--- a/src/analysis/seminorm.lean
+++ b/src/analysis/seminorm.lean
@@ -318,13 +318,13 @@ begin
   exact finset.sup_le h,
 end
 
-lemma finset_sup_lt_apply {p : ι → seminorm 𝕜 E} {s : finset ι} {x : E} {a : ℝ} (ha : 0 < a)
-  (h : ∀ (i : ι), i ∈ s → p i x < a) : s.sup p x < a :=
+lemma finset_sup_apply_lt {p : ι → seminorm 𝕜 E} {s : finset ι} {x : E} {a : ℝ} (ha : 0 < a)
+  (h : ∀ i, i ∈ s → p i x < a) : s.sup p x < a :=
 begin
-  rw [finset_sup_apply, ←a.coe_to_nnreal ha.le, nnreal.coe_lt_coe],
-  refine (finset.sup_lt_iff (real.to_nnreal_pos.mpr ha)).mpr (λ i hi, _),
-  rw [←nnreal.coe_lt_coe, subtype.coe_mk, a.coe_to_nnreal ha.le],
-  exact h i hi,
+  lift a to ℝ≥0 using ha.le,
+  rw [finset_sup_apply, nnreal.coe_lt_coe, finset.sup_lt_iff],
+  { exact h },
+  { exact nnreal.coe_pos.mpr ha },
 end
 
 end norm_one_class

--- a/src/analysis/seminorm.lean
+++ b/src/analysis/seminorm.lean
@@ -310,13 +310,12 @@ begin
   exact bot_le,
 end
 
-lemma finset_sup_le_apply {p : ι → seminorm 𝕜 E} {s : finset ι} {x : E} {a : ℝ} (ha : 0 < a)
-  (h: ∀ (i : ι), i ∈ s → p i x ≤ a) : s.sup p x ≤ a :=
+lemma finset_sup_apply_le {p : ι → seminorm 𝕜 E} {s : finset ι} {x : E} {a : ℝ} (ha : 0 ≤ a)
+  (h : ∀ i, i ∈ s → p i x ≤ a) : s.sup p x ≤ a :=
 begin
-  rw [finset_sup_apply, ←a.coe_to_nnreal ha.le, nnreal.coe_le_coe],
-  refine finset.sup_le (λ i hi, _),
-  rw [←nnreal.coe_le_coe, subtype.coe_mk, a.coe_to_nnreal ha.le],
-  exact h i hi,
+  lift a to ℝ≥0 using ha,
+  rw [finset_sup_apply, nnreal.coe_le_coe],
+  exact finset.sup_le h,
 end
 
 lemma finset_sup_lt_apply {p : ι → seminorm 𝕜 E} {s : finset ι} {x : E} {a : ℝ} (ha : 0 < a)

--- a/src/analysis/seminorm.lean
+++ b/src/analysis/seminorm.lean
@@ -310,7 +310,7 @@ begin
   exact bot_le,
 end
 
-lemma finset_sup_apply_le (p : ι → seminorm 𝕜 E) (s : finset ι) (x : E) {a : ℝ} (ha : 0 < a)
+lemma finset_sup_le_apply {p : ι → seminorm 𝕜 E} {s : finset ι} {x : E} {a : ℝ} (ha : 0 < a)
   (h: ∀ (i : ι), i ∈ s → p i x ≤ a) : s.sup p x ≤ a :=
 begin
   rw [finset_sup_apply, ←a.coe_to_nnreal ha.le, nnreal.coe_le_coe],

--- a/src/analysis/seminorm.lean
+++ b/src/analysis/seminorm.lean
@@ -310,20 +310,18 @@ begin
   exact bot_le,
 end
 
-lemma sup_le_apply (p : ι → seminorm 𝕜 E) (s : finset ι) (x : E) {a : ℝ} (ha : 0 < a):
-  (∀ (i : ι), i ∈ s → p i x ≤ a) → s.sup p x ≤ a :=
+lemma finset_sup_le_apply (p : ι → seminorm 𝕜 E) (s : finset ι) (x : E) {a : ℝ} (ha : 0 < a)
+  (h: ∀ (i : ι), i ∈ s → p i x ≤ a) : s.sup p x ≤ a :=
 begin
-  intro h,
   rw [finset_sup_apply, ←a.coe_to_nnreal ha.le, nnreal.coe_le_coe],
   refine finset.sup_le (λ i hi, _),
   rw [←nnreal.coe_le_coe, subtype.coe_mk, a.coe_to_nnreal ha.le],
   exact h i hi,
 end
 
-lemma sup_lt_apply {p : ι → seminorm 𝕜 E} {s : finset ι} {x : E} {a : ℝ} (ha : 0 < a):
-  (∀ (i : ι), i ∈ s → p i x < a) → s.sup p x < a :=
+lemma finset_sup_lt_apply {p : ι → seminorm 𝕜 E} {s : finset ι} {x : E} {a : ℝ} (ha : 0 < a)
+  (h : ∀ (i : ι), i ∈ s → p i x < a) : s.sup p x < a :=
 begin
-  intro h,
   rw [finset_sup_apply, ←a.coe_to_nnreal ha.le, nnreal.coe_lt_coe],
   refine (finset.sup_lt_iff (real.to_nnreal_pos.mpr ha)).mpr (λ i hi, _),
   rw [←nnreal.coe_lt_coe, subtype.coe_mk, a.coe_to_nnreal ha.le],


### PR DESCRIPTION
These lemmas are not lean-trivial since seminorms map to the `real` and not to `nnreal`.

Co-authored-by: Eric Wieser <wieser.eric@gmail.com>

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
