### PR TITLE
[Merged by Bors] - fix(tactic/norm_num): make norm_num user command match norm_num better

### DIFF
--- a/src/tactic/norm_num.lean
+++ b/src/tactic/norm_num.lean
@@ -1425,16 +1425,21 @@ interactive.simp_core {} (tactic.norm_num1 step (interactive.loc.ns [none]))
   ff (simp_arg_type.except ``one_div :: hs) [] l >> skip
 
 /-- Carry out similar operations as `tactic.norm_num` but on an `expr` rather than a location.
+Given an expression `e`, returns `(e', ⊢ e = e')`.
 The `no_dflt`, `hs`, and `attr_names` are passed on to `simp`.
 Unlike `norm_num`, this tactic does not fail. -/
 meta def tactic.expr_norm_num (step : expr → tactic (expr × expr))
   (no_dflt : bool := ff) (hs : list simp_arg_type := []) (attr_names : list name := []) :
-  expr → tactic expr :=
-λ e,
-(do e' ← (prod.fst <$> norm_num.derive' step e) <|>
-         (prod.fst <$> e.simp {} (tactic.norm_num1 step (interactive.loc.ns [none]))
-                       no_dflt attr_names (simp_arg_type.except ``one_div :: hs)),
-  tactic.expr_norm_num e') <|> pure e
+  expr → tactic (expr × expr) :=
+let simp_step (e : expr) := do
+      (e', p, _) ← e.simp {} (tactic.norm_num1 step (interactive.loc.ns [none]))
+                   no_dflt attr_names (simp_arg_type.except ``one_div :: hs),
+      return (e', p)
+in or_refl_conv $ λ e, do
+  (e', p') ← norm_num.derive' step e <|> simp_step e,
+  (e'', p'') ← tactic.expr_norm_num e',
+  p ← mk_eq_trans p' p'',
+  return (e'', p)
 
 namespace tactic.interactive
 open norm_num interactive interactive.types
@@ -1597,7 +1602,7 @@ do
 
     /- Try simplifying the expression. -/
     step ← norm_num.get_step,
-    tactic.expr_norm_num step no_dflt hs attr_names e } ts,
+    prod.fst <$> tactic.expr_norm_num step no_dflt hs attr_names e } ts,
 
   /- Trace the result. -/
   when (¬ is_trace_enabled_for `silence_norm_num_if_true ∨ result ≠ expr.const `true [])

--- a/src/tactic/norm_num.lean
+++ b/src/tactic/norm_num.lean
@@ -1428,7 +1428,7 @@ interactive.simp_core {} (tactic.norm_num1 step (interactive.loc.ns [none]))
 Given an expression `e`, returns `(e', ⊢ e = e')`.
 The `no_dflt`, `hs`, and `attr_names` are passed on to `simp`.
 Unlike `norm_num`, this tactic does not fail. -/
-meta def tactic.expr_norm_num (step : expr → tactic (expr × expr))
+meta def _root_.expr.norm_num (step : expr → tactic (expr × expr))
   (no_dflt : bool := ff) (hs : list simp_arg_type := []) (attr_names : list name := []) :
   expr → tactic (expr × expr) :=
 let simp_step (e : expr) := do
@@ -1437,7 +1437,7 @@ let simp_step (e : expr) := do
       return (e', p)
 in or_refl_conv $ λ e, do
   (e', p') ← norm_num.derive' step e <|> simp_step e,
-  (e'', p'') ← tactic.expr_norm_num e',
+  (e'', p'') ← _root_.expr.norm_num e',
   p ← mk_eq_trans p' p'',
   return (e'', p)
 
@@ -1602,7 +1602,7 @@ do
 
     /- Try simplifying the expression. -/
     step ← norm_num.get_step,
-    prod.fst <$> tactic.expr_norm_num step no_dflt hs attr_names e } ts,
+    prod.fst <$> e.norm_num step no_dflt hs attr_names } ts,
 
   /- Trace the result. -/
   when (¬ is_trace_enabled_for `silence_norm_num_if_true ∨ result ≠ expr.const `true [])

--- a/src/tactic/norm_num.lean
+++ b/src/tactic/norm_num.lean
@@ -1536,6 +1536,9 @@ namespace tactic
 
 setup_tactic_parser
 
+/- With this option, turn off the messages if the result is exactly `true` -/
+declare_trace silence_norm_num_if_true
+
 /--
 The basic usage is `#norm_num e`, where `e` is an expression,
 which will print the `norm_num` form of `e`.
@@ -1570,7 +1573,7 @@ do
   (ts, mappings) ← synthesize_tactic_state_with_variables_as_hyps (e :: hs_es),
 
   /- Enter the `tactic` monad, *critically* using the synthesized tactic state `ts`. -/
-  simp_result ← lean.parser.of_tactic $ λ _, do
+  result ← lean.parser.of_tactic $ λ _, do
   { /- Resolve the local variables added by the parser to `e` (when it was parsed) against the local
        hypotheses added to the `ts : tactic_state` which we are using. -/
     e ← to_expr e,
@@ -1597,8 +1600,8 @@ do
     tactic.expr_norm_num step no_dflt hs attr_names e } ts,
 
   /- Trace the result. -/
-  when (¬ is_trace_enabled_for `silence_simp_if_true ∨ simp_result ≠ expr.const `true [])
-    (trace simp_result)
+  when (¬ is_trace_enabled_for `silence_norm_num_if_true ∨ result ≠ expr.const `true [])
+    (trace result)
 
 add_tactic_doc
 { name                     := "#norm_num",

--- a/test/norm_num.lean
+++ b/test/norm_num.lean
@@ -184,6 +184,28 @@ example : (9 * 9 * 9) * (12 : α) / 27 = 81 * (2 + 2) := by norm_num
 example : (-2 : α) * 4 / 3 = -8 / 3 := by norm_num
 example : - (-4 / 3) = 1 / (3 / (4 : α)) := by norm_num
 
+-- user command
+
+set_option trace.silence_norm_num_if_true true
+#norm_num 1 = 1
+example : 1 = 1 := by norm_num
+#norm_num 2^4-1 ∣ 2^16-1
+example : 2^4-1 ∣ 2^16-1 := by norm_num
+#norm_num (3 : real) ^ (-2 : ℤ) = 1/9
+example : (3 : real) ^ (-2 : ℤ) = 1/9 := by norm_num
+
+section norm_num_cmd_variable
+variables (x y : ℕ)
+
+#norm_num bit0 x < bit0 (y + x) ↔ 0 < y
+example : bit0 x < bit0 (y + x) ↔ 0 < y := by norm_num
+#norm_num bit0 x < bit0 (y + (2^10%11 - 1) + x) ↔ 0 < y
+example : bit0 x < bit0 (y + (2^10%11 - 1) + x) ↔ 0 < y := by norm_num
+#norm_num bit0 x < bit0 (y + (2^10%11 - 1) + x) + 3*2-6 ↔ 0 < y
+example : bit0 x < bit0 (y + (2^10%11 - 1) + x) + 3*2-6 ↔ 0 < y := by norm_num
+
+end norm_num_cmd_variable
+
 -- auto gen tests
 example : ((25 * (1 / 1)) + (30 - 16)) = (39 : α) := by norm_num
 example : ((19 * (- 2 - 3)) / 6) = (-95/6 : α) := by norm_num


### PR DESCRIPTION
Corrects some issues with the `#norm_num` user command that prevented it from fully normalizing expressions. Also, adds `expr.norm_num`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
