### PR TITLE
[Merged by Bors] - feat(tactic/interactive): guard_{hyp,target}_mod_implicit

### DIFF
--- a/src/tactic/interactive.lean
+++ b/src/tactic/interactive.lean
@@ -413,6 +413,28 @@ meta def guard_hyp_nums (n : ℕ) : tactic unit :=
 do k ← local_context,
    guard (n = k.length) <|> fail format!"{k.length} hypotheses found"
 
+/--
+`guard_hyp_mod_implicit h : t` fails if the type of the hypothesis `h`
+is not definitionally equal to `t` modulo none transparency
+(i.e., unifying the implicit arguments modulo semireducible transparency).
+We use this tactic for writing tests.
+-/
+meta def guard_hyp_mod_implicit (n : parse ident) (p : parse $ tk ":" *> texpr) : tactic unit := do
+h ← get_local n >>= infer_type >>= instantiate_mvars,
+e ← to_expr p,
+is_def_eq h e transparency.none
+
+/--
+`guard_target_mod_implicit t` fails if the target of the main goal
+is not definitionally equal to `t` modulo none transparency
+(i.e., unifying the implicit arguments modulo semireducible transparency).
+We use this tactic for writing tests.
+-/
+meta def guard_target_mod_implicit (p : parse texpr) : tactic unit := do
+tgt ← target,
+e ← to_expr p,
+is_def_eq tgt e transparency.none
+
 /-- Test that `t` is the tag of the main goal. -/
 meta def guard_tags (tags : parse ident*) : tactic unit :=
 do (t : list name) ← get_main_tag,

--- a/test/mod_implicit.lean
+++ b/test/mod_implicit.lean
@@ -1,0 +1,22 @@
+import tactic.interactive
+import data.nat.basic
+
+variables (p : ℕ → Prop) (a b : ℕ)
+
+example (h : p (a + b)) : p (b + a) :=
+begin
+  rw add_comm,
+  -- `guard_target` fails because the instances don't match
+  success_if_fail { guard_target p (a + b) },
+  guard_target_mod_implicit p (a + b),
+  assumption
+end
+
+example (h : p (b + a)) : p (a + b) :=
+begin
+  rw add_comm at h,
+  -- `guard_hyp` fails because the instances don't match
+  success_if_fail { guard_hyp h : p (a + b) },
+  guard_hyp_mod_implicit h : p (a + b),
+  assumption
+end


### PR DESCRIPTION
This adds two new tactics `guard_hyp_mod_implicit` and `guard_target_mod_implicit`, with the same syntax as `guard_hyp` and `guard_target`.  While the `guard_*` tactics check for syntax equality, the `guard_*_mod_implicit` tactics check for definitional equality with the `none` transparency---meaning that only implicit arguments are unfolded.

This is useful when writing tests and expect a certain goal, but the tactic produces a term with different (but defeq) type class instances.

---

(split from #12182)

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
