### PR TITLE
[Merged by Bors] - feat(linear_algebra/clifford_algebra/conjugation): add lemmas showing interaction between `involute` and `even_odd`

### DIFF
--- a/src/algebra/direct_sum/internal.lean
+++ b/src/algebra/direct_sum/internal.lean
@@ -44,6 +44,14 @@ open_locale direct_sum big_operators
 
 variables {ι : Type*} {S R : Type*}
 
+lemma set_like.has_graded_one.algebra_map_mem [has_zero ι]
+  [comm_semiring S] [semiring R] [algebra S R]
+  (A : ι → submodule S R) [set_like.has_graded_one A] (s : S) : algebra_map S R s ∈ A 0 :=
+begin
+  rw algebra.algebra_map_eq_smul_one,
+  exact ((A 0).smul_mem s set_like.has_graded_one.one_mem),
+end
+
 section direct_sum
 variables [decidable_eq ι]
 
@@ -160,10 +168,8 @@ instance galgebra [add_monoid ι]
   [comm_semiring S] [semiring R] [algebra S R]
   (A : ι → submodule S R) [h : set_like.graded_monoid A] :
   direct_sum.galgebra S (λ i, A i) :=
-{ to_fun := begin
-    refine ((algebra.linear_map S R).cod_restrict (A 0) $ λ r, _).to_add_monoid_hom,
-    exact submodule.one_le.mpr set_like.has_graded_one.one_mem (submodule.algebra_map_mem _),
-  end,
+{ to_fun := ((algebra.linear_map S R).cod_restrict (A 0) $
+    set_like.has_graded_one.algebra_map_mem A).to_add_monoid_hom,
   map_one := subtype.ext $ by exact (algebra_map S R).map_one,
   map_mul := λ x y, sigma.subtype_ext (add_zero 0).symm $ (algebra_map S R).map_mul _ _,
   commutes := λ r ⟨i, xi⟩,

--- a/src/linear_algebra/clifford_algebra/conjugation.lean
+++ b/src/linear_algebra/clifford_algebra/conjugation.lean
@@ -235,4 +235,30 @@ set_like.ext_iff.mp (even_odd_comap_reverse Q n) x
 
 end submodule
 
+/-!
+### Related properties of the even and odd submodules
+
+TODO: show that these are `iff`s when `invertible (2 : R)`.
+-/
+
+lemma involute_eq_of_mem_even {x : clifford_algebra Q} (h : x ∈ even_odd Q 0) :
+  involute x = x :=
+begin
+  refine even_induction Q (alg_hom.commutes _) _ _ x h,
+  { rintros x y hx hy ihx ihy,
+    rw [map_add, ihx, ihy]},
+  { intros m₁ m₂ x hx ihx,
+    rw [map_mul, map_mul, involute_ι, involute_ι, ihx, neg_mul_neg], },
+end
+
+lemma involute_eq_of_mem_odd {x : clifford_algebra Q} (h : x ∈ even_odd Q 1) :
+  involute x = -x :=
+begin
+  refine odd_induction Q involute_ι _ _ x h,
+  { rintros x y hx hy ihx ihy,
+    rw [map_add, ihx, ihy, neg_add] },
+  { intros m₁ m₂ x hx ihx,
+    rw [map_mul, map_mul, involute_ι, involute_ι, ihx, neg_mul_neg, mul_neg] },
+end
+
 end clifford_algebra

--- a/src/linear_algebra/clifford_algebra/grading.lean
+++ b/src/linear_algebra/clifford_algebra/grading.lean
@@ -39,9 +39,6 @@ begin
   exact (pow_one _).ge,
 end
 
-lemma algebra_map_mem_even_odd_zero (r : R) : algebra_map R _ r ∈ even_odd Q 0 :=
-one_le_even_odd_zero _ $ submodule.algebra_map_mem _
-
 lemma ι_mem_even_odd_one (m : M) : ι Q m ∈ even_odd Q 1 :=
 range_ι_le_even_odd_one Q $ linear_map.mem_range_self _ m
 
@@ -173,7 +170,7 @@ end
 scalars, closed under addition, and under left-multiplication by a pair of vectors. -/
 @[elab_as_eliminator]
 lemma even_induction  {P : Π x, x ∈ even_odd Q 0 → Prop}
-  (hr : ∀ r : R, P (algebra_map _ _ r) (algebra_map_mem_even_odd_zero _ _))
+  (hr : ∀ r : R, P (algebra_map _ _ r) (set_like.has_graded_one.algebra_map_mem _ _))
   (hadd : ∀ {x y hx hy}, P x hx → P y hy → P (x + y) (submodule.add_mem _ hx hy))
   (hιι_mul : ∀ m₁ m₂ {x hx}, P x hx → P (ι Q m₁ * ι Q m₂ * x)
     (zero_add 0 ▸ set_like.graded_monoid.mul_mem (ι_mul_ι_mem_even_odd_zero Q m₁ m₂) hx))

--- a/src/linear_algebra/clifford_algebra/grading.lean
+++ b/src/linear_algebra/clifford_algebra/grading.lean
@@ -39,8 +39,18 @@ begin
   exact (pow_one _).ge,
 end
 
+lemma algebra_map_mem_even_odd_zero (r : R) : algebra_map R _ r ∈ even_odd Q 0 :=
+one_le_even_odd_zero _ $ submodule.algebra_map_mem _
+
 lemma ι_mem_even_odd_one (m : M) : ι Q m ∈ even_odd Q 1 :=
 range_ι_le_even_odd_one Q $ linear_map.mem_range_self _ m
+
+lemma ι_mul_ι_mem_even_odd_zero (m₁ m₂ : M) :
+  ι Q m₁ * ι Q m₂ ∈ even_odd Q 0 :=
+submodule.mem_supr_of_mem ⟨2, rfl⟩ begin
+  rw [subtype.coe_mk, pow_two],
+  exact submodule.mul_mem_mul ((ι Q).mem_range_self m₁) ((ι Q).mem_range_self m₂),
+end
 
 lemma even_odd_mul_le (i j : zmod 2) : even_odd Q i * even_odd Q j ≤ even_odd Q (i + j) :=
 begin
@@ -116,6 +126,79 @@ begin
   calc    (⨆ (i : zmod 2) (j : {n // ↑n = i}), (ι Q).range ^ ↑j)
         = (⨆ (i : Σ i : zmod 2, {n : ℕ // ↑n = i}), (ι Q).range ^ (i.2 : ℕ)) : by rw supr_sigma
     ... = (⨆ (i : ℕ), (ι Q).range ^ i) : supr_congr (λ i, i.2) (λ i, ⟨⟨_, i, rfl⟩, rfl⟩) (λ _, rfl),
+end
+
+/-- To show a property is true on the even or odd part, it suffices to show it is true on the
+scalars or vectors (respectively), closed under addition, and under left-multiplication by a pair
+of vectors. -/
+@[elab_as_eliminator]
+lemma even_odd_induction (n : zmod 2) {P : Π x, x ∈ even_odd Q n → Prop}
+  (hr : ∀ v (h : v ∈ (ι Q).range ^ n.val),
+    P v (submodule.mem_supr_of_mem ⟨n.val, n.nat_cast_zmod_val⟩ h))
+  (hadd : ∀ {x y hx hy}, P x hx → P y hy → P (x + y) (submodule.add_mem _ hx hy))
+  (hιι_mul : ∀ m₁ m₂ {x hx}, P x hx → P (ι Q m₁ * ι Q m₂ * x)
+    (zero_add n ▸ set_like.graded_monoid.mul_mem (ι_mul_ι_mem_even_odd_zero Q m₁ m₂) hx))
+  (x : clifford_algebra Q) (hx : x ∈ even_odd Q n) : P x hx :=
+begin
+  apply submodule.supr_induction' _ _ (hr 0 (submodule.zero_mem _)) @hadd,
+  refine subtype.rec _,
+  simp_rw [subtype.coe_mk, zmod.nat_coe_zmod_eq_iff, add_comm n.val],
+  rintros n' ⟨k, rfl⟩ xv,
+  simp_rw [pow_add, pow_mul],
+  refine submodule.mul_induction_on' _ _,
+  { intros a ha b hb,
+    refine submodule.pow_induction_on' ((ι Q).range ^ 2) _ _ _ ha,
+    { intro r,
+      simp_rw ←algebra.smul_def,
+      exact hr _ (submodule.smul_mem _ _ hb), },
+    { intros x y n hx hy,
+      simp_rw add_mul,
+      apply hadd, },
+    { intros x hx n y hy ihy,
+      revert hx,
+      simp_rw pow_two,
+      refine submodule.mul_induction_on' _ _,
+      { simp_rw linear_map.mem_range,
+        rintros _ ⟨m₁, rfl⟩ _ ⟨m₂, rfl⟩,
+        simp_rw mul_assoc _ y b,
+        refine hιι_mul _ _ ihy, },
+      { intros x hx y hy ihx ihy,
+        simp_rw add_mul,
+        apply hadd ihx ihy } } },
+  { intros x y hx hy,
+    apply hadd }
+end
+
+/-- To show a property is true on the even parts, it suffices to show it is true on the
+scalars, closed under addition, and under left-multiplication by a pair of vectors. -/
+@[elab_as_eliminator]
+lemma even_induction  {P : Π x, x ∈ even_odd Q 0 → Prop}
+  (hr : ∀ r : R, P (algebra_map _ _ r) (algebra_map_mem_even_odd_zero _ _))
+  (hadd : ∀ {x y hx hy}, P x hx → P y hy → P (x + y) (submodule.add_mem _ hx hy))
+  (hιι_mul : ∀ m₁ m₂ {x hx}, P x hx → P (ι Q m₁ * ι Q m₂ * x)
+    (zero_add 0 ▸ set_like.graded_monoid.mul_mem (ι_mul_ι_mem_even_odd_zero Q m₁ m₂) hx))
+  (x : clifford_algebra Q) (hx : x ∈ even_odd Q 0) : P x hx :=
+begin
+  refine even_odd_induction Q 0 (λ rx, _) @hadd hιι_mul x hx,
+  simp_rw [zmod.val_zero, pow_zero],
+  rintro ⟨r, rfl⟩,
+  exact hr r,
+end
+
+/-- To show a property is true on the odd parts, it suffices to show it is true on the
+vectors, closed under addition, and under left-multiplication by a pair of vectors. -/
+@[elab_as_eliminator]
+lemma odd_induction {P : Π x, x ∈ even_odd Q 1 → Prop}
+  (hι : ∀ v, P (ι Q v) (ι_mem_even_odd_one _ _))
+  (hadd : ∀ {x y hx hy}, P x hx → P y hy → P (x + y) (submodule.add_mem _ hx hy))
+  (hιι_mul : ∀ m₁ m₂ {x hx}, P x hx → P (ι Q m₁ * ι Q m₂ * x)
+    (zero_add (1 : zmod 2) ▸ set_like.graded_monoid.mul_mem (ι_mul_ι_mem_even_odd_zero Q m₁ m₂) hx))
+  (x : clifford_algebra Q) (hx : x ∈ even_odd Q 1) : P x hx :=
+begin
+  refine even_odd_induction Q 1 (λ ιv, _) @hadd hιι_mul x hx,
+  simp_rw [zmod.val_one, pow_one],
+  rintro ⟨v, rfl⟩,
+  exact hι v,
 end
 
 end clifford_algebra


### PR DESCRIPTION
Often the even and odd submodules are defined in terms of involution, but this strategy doesn't actually work in characteristic two.



---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
