### PR TITLE
[Merged by Bors] - feat(ring_theory/graded_algebra/homogeneous_ideal): refactor `homogeneous_ideal` as a structure extending ideals

### DIFF
--- a/src/ring_theory/graded_algebra/homogeneous_ideal.lean
+++ b/src/ring_theory/graded_algebra/homogeneous_ideal.lean
@@ -61,6 +61,18 @@ abbreviation homogeneous_ideal : Type* := { I : ideal A // I.is_homogeneous 𝒜
 instance : has_mem A (homogeneous_ideal 𝒜) :=
 { mem := λ r I, r ∈ (I : ideal A) }
 
+lemma homogeneous_ideal.mem_iff {I : homogeneous_ideal 𝒜} {x : A} : x ∈ I ↔ x ∈ (↑I : ideal A) :=
+iff.rfl
+
+instance homogeneous_ideal.set_like : set_like (homogeneous_ideal 𝒜) A :=
+{ coe := λ I, I.1.carrier,
+  coe_injective' := λ ⟨I, hI⟩ ⟨J, hJ⟩ (h : I.carrier = J.carrier), begin
+    rw subtype.ext_iff_val,
+    ext,
+    change x ∈ I.carrier ↔ x ∈ J.carrier,
+    rw h
+  end }
+
 end homogeneous_def
 
 section homogeneous_core

--- a/src/ring_theory/graded_algebra/homogeneous_ideal.lean
+++ b/src/ring_theory/graded_algebra/homogeneous_ideal.lean
@@ -65,8 +65,9 @@ def homogeneous_ideal.to_ideal (I : homogeneous_ideal 𝒜) : ideal A := I.to_su
 lemma homogeneous_ideal.is_homogeneous (I : homogeneous_ideal 𝒜) :
   I.to_ideal.is_homogeneous 𝒜 := I.is_homogeneous'
 
-@[ext] lemma homogeneous_ideal.ext {I J : homogeneous_ideal 𝒜} (h : I.to_ideal = J.to_ideal) :
-  I = J := by cases I; cases J; simpa [homogeneous_ideal.to_ideal] using h
+lemma homogeneous_ideal.to_ideal_injective :
+  function.injective (homogeneous_ideal.to_ideal : homogeneous_ideal 𝒜 → ideal A) :=
+sorry
 
 instance homogeneous_ideal.set_like : set_like (homogeneous_ideal 𝒜) A :=
 { coe := λ I, I.to_ideal,

--- a/src/ring_theory/graded_algebra/homogeneous_ideal.lean
+++ b/src/ring_theory/graded_algebra/homogeneous_ideal.lean
@@ -59,11 +59,8 @@ def ideal.is_homogeneous : Prop :=
 abbreviation homogeneous_ideal : Type* := { I : ideal A // I.is_homogeneous 𝒜 }
 
 instance homogeneous_ideal.set_like : set_like (homogeneous_ideal 𝒜) A :=
-{ coe := λ I, ((I : ideal A) : set A),
-  coe_injective' := λ ⟨I, hI⟩ ⟨J, hJ⟩ h, begin
-    congr,
-    exact set_like.coe_injective h,
-  end }
+{ coe := λ I, I.1.carrier,
+  coe_injective' := λ ⟨I, hI⟩ ⟨J, hJ⟩ h, by congr; exact set_like.coe_injective h }
 
 lemma homogeneous_ideal.mem_iff {I : homogeneous_ideal 𝒜} {x : A} : x ∈ I ↔ x ∈ (↑I : ideal A) :=
 iff.rfl
@@ -251,6 +248,8 @@ end ideal.is_homogeneous
 variables {𝒜}
 
 namespace homogeneous_ideal
+
+instance : partial_order (homogeneous_ideal 𝒜) := set_like.partial_order
 
 instance : has_bot (homogeneous_ideal 𝒜) :=
 ⟨⟨⊥, ideal.is_homogeneous.bot 𝒜⟩⟩

--- a/src/ring_theory/graded_algebra/homogeneous_ideal.lean
+++ b/src/ring_theory/graded_algebra/homogeneous_ideal.lean
@@ -285,14 +285,14 @@ to_ideal_injective.eq_iff.symm
 instance : has_inf (homogeneous_ideal 𝒜) :=
 { inf := λ I J, ⟨I.to_ideal ⊓ J.to_ideal, I.is_homogeneous.inf J.is_homogeneous⟩ }
 
-@[simp] lemma to_ideal_inf (I J : homogeneous_ideal 𝒜) : (I ⊓ J).to_ideal = I.to_ideal ⊓ J.to_ideal :=
-rfl
+@[simp] lemma to_ideal_inf (I J : homogeneous_ideal 𝒜) :
+  (I ⊓ J).to_ideal = I.to_ideal ⊓ J.to_ideal := rfl
 
 instance : has_Inf (homogeneous_ideal 𝒜) :=
 ⟨λ ℐ, ⟨Inf (to_ideal '' ℐ), ideal.is_homogeneous.Inf $ λ _ ⟨I, _, hI⟩, hI ▸ I.is_homogeneous⟩⟩
 
-@[simp] lemma to_ideal_Inf (ℐ : set (homogeneous_ideal 𝒜)) : (Inf ℐ).to_ideal = Inf (to_ideal '' ℐ) :=
-rfl
+@[simp] lemma to_ideal_Inf (ℐ : set (homogeneous_ideal 𝒜)) :
+  (Inf ℐ).to_ideal = Inf (to_ideal '' ℐ) := rfl
 
 @[simp] lemma to_ideal_infi {ι' : Sort*} (s : ι' → homogeneous_ideal 𝒜) :
   (⨅ i, s i).to_ideal = ⨅ i, (s i).to_ideal :=
@@ -301,8 +301,8 @@ by rw [infi, infi, to_ideal_Inf, ←set.range_comp]
 instance : has_sup (homogeneous_ideal 𝒜) :=
 { sup := λ I J, ⟨I.to_ideal ⊔ J.to_ideal, I.is_homogeneous.sup J.is_homogeneous⟩ }
 
-@[simp] lemma to_ideal_sup (I J : homogeneous_ideal 𝒜) : (I ⊔ J).to_ideal = I.to_ideal ⊔ J.to_ideal :=
-rfl
+@[simp] lemma to_ideal_sup (I J : homogeneous_ideal 𝒜) :
+  (I ⊔ J).to_ideal = I.to_ideal ⊔ J.to_ideal := rfl
 
 instance : has_Sup (homogeneous_ideal 𝒜) :=
 ⟨λ ℐ, ⟨Sup (to_ideal '' ℐ), ideal.is_homogeneous.Sup $ λ _ ⟨I, _, hI⟩, hI ▸ I.is_homogeneous⟩⟩
@@ -320,8 +320,8 @@ to_ideal_injective.complete_lattice _ to_ideal_sup to_ideal_inf to_ideal_Sup to_
 
 instance : has_add (homogeneous_ideal 𝒜) := ⟨(⊔)⟩
 
-@[simp] lemma to_ideal_add (I J : homogeneous_ideal 𝒜) : (I + J).to_ideal = I.to_ideal + J.to_ideal :=
-rfl
+@[simp] lemma to_ideal_add (I J : homogeneous_ideal 𝒜) :
+  (I + J).to_ideal = I.to_ideal + J.to_ideal := rfl
 
 instance : inhabited (homogeneous_ideal 𝒜) := { default := ⊥ }
 

--- a/src/ring_theory/graded_algebra/homogeneous_ideal.lean
+++ b/src/ring_theory/graded_algebra/homogeneous_ideal.lean
@@ -56,13 +56,30 @@ def ideal.is_homogeneous : Prop :=
 ∀ (i : ι) ⦃r : A⦄, r ∈ I → (graded_algebra.decompose 𝒜 r i : A) ∈ I
 
 /-- For any `semiring A`, we collect the homogeneous ideals of `A` into a type. -/
-abbreviation homogeneous_ideal : Type* := { I : ideal A // I.is_homogeneous 𝒜 }
+structure homogeneous_ideal extends submodule A A :=
+(is_homogeneous' : ideal.is_homogeneous 𝒜 to_submodule)
+
+variable {𝒜}
+def homogeneous_ideal.to_ideal (I : homogeneous_ideal 𝒜) : ideal A := I.to_submodule
+
+lemma homogeneous_ideal.is_homogeneous (I : homogeneous_ideal 𝒜) :
+  I.to_ideal.is_homogeneous 𝒜 := I.is_homogeneous'
+
+@[ext] lemma homogeneous_ideal.ext {I J : homogeneous_ideal 𝒜} (h : I.to_ideal = J.to_ideal) :
+  I = J := by cases I; cases J; simpa [homogeneous_ideal.to_ideal] using h
 
 instance homogeneous_ideal.set_like : set_like (homogeneous_ideal 𝒜) A :=
-{ coe := λ I, I.1.carrier,
-  coe_injective' := λ ⟨I, hI⟩ ⟨J, hJ⟩ h, by congr; exact set_like.coe_injective h }
+{ coe := λ I, I.to_ideal,
+  coe_injective' := λ I J h, by ext1; exact set_like.coe_injective h }
 
-lemma homogeneous_ideal.mem_iff {I : homogeneous_ideal 𝒜} {x : A} : x ∈ I ↔ x ∈ (↑I : ideal A) :=
+instance homogeneous_ideal.coe : has_coe (homogeneous_ideal 𝒜) (ideal A) :=
+{ coe := λ I, I.to_ideal }
+
+lemma homogeneous_ideal.ext_iff_coe {I J : homogeneous_ideal 𝒜} :
+  I = J ↔ (↑I : ideal A) = ↑J :=
+⟨λ h, h ▸ rfl, λ h, by ext1; exact h⟩
+
+lemma homogeneous_ideal.mem_iff {I : homogeneous_ideal 𝒜} {x : A} : x ∈ I ↔ x ∈ I.to_ideal :=
 iff.rfl
 
 end homogeneous_def
@@ -166,7 +183,7 @@ end
 
 @[simp] lemma homogeneous_ideal.homogeneous_core_coe_eq_self (I : homogeneous_ideal 𝒜) :
   (I : ideal A).homogeneous_core 𝒜 = I :=
-subtype.coe_injective $ ideal.is_homogeneous.coe_homogeneous_core_eq_self I.prop
+by ext1; convert ideal.is_homogeneous.coe_homogeneous_core_eq_self I.is_homogeneous
 
 variables (𝒜 I)
 
@@ -257,7 +274,10 @@ instance : has_bot (homogeneous_ideal 𝒜) :=
 @[simp] lemma coe_bot : ↑(⊥ : homogeneous_ideal 𝒜) = (⊥ : ideal A) := rfl
 
 @[simp] lemma eq_bot_iff (I : homogeneous_ideal 𝒜) : I = ⊥ ↔ (I : ideal A) = ⊥ :=
-subtype.ext_iff
+begin
+  rw show I = ⊥ ↔ I.to_ideal = ⊥, from ⟨λ hI, by rw hI; refl, λ hI, by ext1; exact hI⟩,
+  refl
+end
 
 instance : has_top (homogeneous_ideal 𝒜) :=
 ⟨⟨⊤, ideal.is_homogeneous.top 𝒜⟩⟩
@@ -265,15 +285,18 @@ instance : has_top (homogeneous_ideal 𝒜) :=
 @[simp] lemma coe_top : ↑(⊤ : homogeneous_ideal 𝒜) = (⊤ : ideal A) := rfl
 
 @[simp] lemma eq_top_iff (I : homogeneous_ideal 𝒜) : I = ⊤ ↔ (I : ideal A) = ⊤ :=
-subtype.ext_iff
+begin
+  rw show I = ⊤ ↔ I.to_ideal = ⊤, from ⟨λ hI, by rw hI; refl, λ hI, by ext1; exact hI⟩,
+  refl
+end
 
 instance : has_inf (homogeneous_ideal 𝒜) :=
-{ inf := λ I J, ⟨I ⊓ J, I.prop.inf J.prop⟩ }
+{ inf := λ I J, ⟨I ⊓ J, I.is_homogeneous.inf J.is_homogeneous⟩ }
 
 @[simp] lemma coe_inf (I J : homogeneous_ideal 𝒜) : ↑(I ⊓ J) = (I ⊓ J : ideal A) := rfl
 
 instance : has_Inf (homogeneous_ideal 𝒜) :=
-{ Inf := λ ℐ, ⟨Inf (coe '' ℐ), ideal.is_homogeneous.Inf $ λ _ ⟨I, _, hI⟩, hI ▸ I.prop⟩ }
+{ Inf := λ ℐ, ⟨Inf (coe '' ℐ), ideal.is_homogeneous.Inf $ λ _ ⟨I, _, hI⟩, hI ▸ I.is_homogeneous⟩ }
 
 @[simp] lemma coe_Inf (ℐ : set (homogeneous_ideal 𝒜)) : ↑(Inf ℐ) = (Inf (coe '' ℐ) : ideal A) :=
 rfl
@@ -283,12 +306,12 @@ rfl
 by rw [infi, infi, coe_Inf, ←set.range_comp]
 
 instance : has_sup (homogeneous_ideal 𝒜) :=
-{ sup := λ I J, ⟨I ⊔ J, I.prop.sup J.prop⟩ }
+{ sup := λ I J, ⟨I ⊔ J, I.is_homogeneous.sup J.is_homogeneous⟩ }
 
 @[simp] lemma coe_sup (I J : homogeneous_ideal 𝒜) : ↑(I ⊔ J) = (I ⊔ J : ideal A) := rfl
 
 instance : has_Sup (homogeneous_ideal 𝒜) :=
-{ Sup := λ ℐ, ⟨Sup (coe '' ℐ), ideal.is_homogeneous.Sup $ λ _ ⟨I, _, hI⟩, hI ▸ I.prop⟩ }
+{ Sup := λ ℐ, ⟨Sup (coe '' ℐ), ideal.is_homogeneous.Sup $ λ _ ⟨I, _, hI⟩, hI ▸ I.is_homogeneous⟩ }
 
 @[simp] lemma coe_Sup (ℐ : set (homogeneous_ideal 𝒜)) : ↑(Sup ℐ) = (Sup (coe '' ℐ) : ideal A) :=
 rfl
@@ -298,7 +321,8 @@ rfl
 by rw [supr, supr, coe_Sup, ←set.range_comp]
 
 instance : complete_lattice (homogeneous_ideal 𝒜) :=
-subtype.coe_injective.complete_lattice _ coe_sup coe_inf coe_Sup coe_Inf coe_top coe_bot
+function.injective.complete_lattice (coe : homogeneous_ideal 𝒜 → ideal A)
+  (λ x y h, by ext1; exact h ) coe_sup coe_inf coe_Sup coe_Inf coe_top coe_bot
 
 instance : has_add (homogeneous_ideal 𝒜) := ⟨(⊔)⟩
 
@@ -329,7 +353,7 @@ end
 variables {𝒜}
 
 instance : has_mul (homogeneous_ideal 𝒜) :=
-{ mul := λ I J, ⟨I * J, I.prop.mul J.prop⟩ }
+{ mul := λ I J, ⟨I * J, I.is_homogeneous.mul J.is_homogeneous⟩ }
 
 @[simp] lemma homogeneous_ideal.coe_mul (I J : homogeneous_ideal 𝒜) :
   ↑(I * J) = (I * J : ideal A) := rfl
@@ -358,7 +382,8 @@ lemma ideal.homogeneous_core.gc : galois_connection coe (ideal.homogeneous_core 
 /--`coe : homogeneous_ideal 𝒜 → ideal A` and `ideal.homogeneous_core 𝒜` forms a galois
 coinsertion-/
 def ideal.homogeneous_core.gi : galois_coinsertion coe (ideal.homogeneous_core 𝒜) :=
-{ choice := λ I HI, ⟨I, le_antisymm (I.coe_homogeneous_core_le 𝒜) HI ▸ subtype.prop _⟩,
+{ choice := λ I HI,
+    ⟨I, le_antisymm (I.coe_homogeneous_core_le 𝒜) HI ▸ homogeneous_ideal.is_homogeneous _⟩,
   gc := ideal.homogeneous_core.gc 𝒜,
   u_l_le := λ I, ideal.homogeneous_core'_le _ _,
   choice_eq := λ I H, le_antisymm H (I.coe_homogeneous_core_le _) }
@@ -372,9 +397,11 @@ lemma ideal.homogeneous_core'_eq_Sup :
 begin
   refine (is_lub.Sup_eq _).symm,
   apply is_greatest.is_lub,
-  have coe_mono : monotone (coe : {I : ideal A // I.is_homogeneous 𝒜} → ideal A) := λ _ _, id,
+  have coe_mono : monotone (coe : homogeneous_ideal 𝒜 → ideal A) := λ _ _, id,
   convert coe_mono.map_is_greatest (ideal.homogeneous_core.gc 𝒜).is_greatest_u using 1,
-  simp only [subtype.coe_image, exists_prop, mem_set_of_eq, subtype.coe_mk],
+  ext,
+  rw [mem_image, mem_set_of_eq],
+  refine ⟨λ hI, ⟨⟨x, hI.1⟩, ⟨hI.2, rfl⟩⟩, by rintro ⟨x, ⟨hx, rfl⟩⟩; exact ⟨x.is_homogeneous, hx⟩⟩,
 end
 
 end homogeneous_core
@@ -382,6 +409,8 @@ end homogeneous_core
 /-! ### Homogeneous hulls -/
 
 section homogeneous_hull
+
+open homogeneous_ideal
 
 variables [comm_semiring R] [semiring A]
 variables [algebra R A] [decidable_eq ι] [add_monoid ι]
@@ -427,7 +456,7 @@ end
 
 @[simp] lemma homogeneous_ideal.homogeneous_hull_coe_eq_self (I : homogeneous_ideal 𝒜) :
   (I : ideal A).homogeneous_hull 𝒜 = I :=
-subtype.coe_injective $ ideal.is_homogeneous.homogeneous_hull_eq_self I.prop
+by ext1; convert ideal.is_homogeneous.homogeneous_hull_eq_self I.is_homogeneous
 
 variables (I 𝒜)
 
@@ -445,11 +474,13 @@ lemma ideal.homogeneous_hull_eq_supr :
   (I.homogeneous_hull 𝒜) =
   ⨆ i, ⟨ideal.span (graded_algebra.proj 𝒜 i '' I), ideal.is_homogeneous_span 𝒜 _
     (by {rintros _ ⟨x, -, rfl⟩, apply set_like.is_homogeneous_coe})⟩ :=
-by { ext1, rw [ideal.coe_homogeneous_hull_eq_supr, homogeneous_ideal.coe_supr], refl, }
+by rw [ext_iff_coe, ideal.coe_homogeneous_hull_eq_supr, coe_supr]; refl
 
 end homogeneous_hull
 
 section galois_connection
+
+open homogeneous_ideal
 
 variables [comm_semiring R] [semiring A]
 variables [algebra R A] [decidable_eq ι] [add_monoid ι]
@@ -462,7 +493,7 @@ lemma ideal.homogeneous_hull.gc : galois_connection (ideal.homogeneous_hull 𝒜
 
 /-- `ideal.homogeneous_hull 𝒜` and `coe : homogeneous_ideal 𝒜 → ideal A` forms a galois insertion-/
 def ideal.homogeneous_hull.gi : galois_insertion (ideal.homogeneous_hull 𝒜) coe :=
-{ choice := λ I H, ⟨I, le_antisymm H (I.le_coe_homogeneous_hull 𝒜) ▸ subtype.prop _⟩,
+{ choice := λ I H, ⟨I, le_antisymm H (I.le_coe_homogeneous_hull 𝒜) ▸ is_homogeneous _⟩,
   gc := ideal.homogeneous_hull.gc 𝒜,
   le_l_u := λ I, ideal.le_coe_homogeneous_hull _ _,
   choice_eq := λ I H, le_antisymm (I.le_coe_homogeneous_hull 𝒜) H}

--- a/src/ring_theory/graded_algebra/homogeneous_ideal.lean
+++ b/src/ring_theory/graded_algebra/homogeneous_ideal.lean
@@ -17,7 +17,7 @@ operations on them.
 
 For any `I : ideal A`:
 * `ideal.is_homogeneous 𝒜 I`: The property that an ideal is closed under `graded_algebra.proj`.
-* `homogeneous_ideal 𝒜`: The subtype of ideals which satisfy `ideal.is_homogeneous`
+* `homogeneous_ideal 𝒜`: The structure extending ideals which satisfy `ideal.is_homogeneous`
 * `ideal.homogeneous_core I 𝒜`: The largest homogeneous ideal smaller than `I`.
 * `ideal.homogeneous_hull I 𝒜`: The smallest homogeneous ideal larger than `I`.
 
@@ -60,6 +60,7 @@ structure homogeneous_ideal extends submodule A A :=
 (is_homogeneous' : ideal.is_homogeneous 𝒜 to_submodule)
 
 variable {𝒜}
+/--Converting a homogeneous ideal to an ideal-/
 def homogeneous_ideal.to_ideal (I : homogeneous_ideal 𝒜) : ideal A := I.to_submodule
 
 lemma homogeneous_ideal.is_homogeneous (I : homogeneous_ideal 𝒜) :

--- a/src/ring_theory/graded_algebra/homogeneous_ideal.lean
+++ b/src/ring_theory/graded_algebra/homogeneous_ideal.lean
@@ -67,18 +67,18 @@ lemma homogeneous_ideal.is_homogeneous (I : homogeneous_ideal 𝒜) :
 
 lemma homogeneous_ideal.to_ideal_injective :
   function.injective (homogeneous_ideal.to_ideal : homogeneous_ideal 𝒜 → ideal A) :=
-sorry
+λ ⟨x, hx⟩ ⟨y, hy⟩ (h : x = y), by simp [h]
 
 instance homogeneous_ideal.set_like : set_like (homogeneous_ideal 𝒜) A :=
 { coe := λ I, I.to_ideal,
-  coe_injective' := λ I J h, by ext1; exact set_like.coe_injective h }
+  coe_injective' := λ I J h, begin
+    apply_fun homogeneous_ideal.to_ideal,
+    exact set_like.coe_injective h,
+    exact homogeneous_ideal.to_ideal_injective,
+  end }
 
-instance homogeneous_ideal.coe : has_coe (homogeneous_ideal 𝒜) (ideal A) :=
-{ coe := λ I, I.to_ideal }
-
-lemma homogeneous_ideal.ext_iff_coe {I J : homogeneous_ideal 𝒜} :
-  I = J ↔ (↑I : ideal A) = ↑J :=
-⟨λ h, h ▸ rfl, λ h, by ext1; exact h⟩
+@[ext] lemma homogeneous_ideal.ext {I J : homogeneous_ideal 𝒜}
+  (h : I.to_ideal = J.to_ideal) : I = J := homogeneous_ideal.to_ideal_injective h
 
 lemma homogeneous_ideal.mem_iff {I : homogeneous_ideal 𝒜} {x : A} : x ∈ I ↔ x ∈ I.to_ideal :=
 iff.rfl
@@ -163,7 +163,7 @@ def ideal.homogeneous_core : homogeneous_ideal 𝒜 :=
 lemma ideal.homogeneous_core_mono : monotone (ideal.homogeneous_core 𝒜) :=
 ideal.homogeneous_core'_mono 𝒜
 
-lemma ideal.coe_homogeneous_core_le : ↑(I.homogeneous_core 𝒜) ≤ I :=
+lemma ideal.coe_homogeneous_core_le : (I.homogeneous_core 𝒜).to_ideal ≤ I :=
 ideal.homogeneous_core'_le 𝒜 I
 
 variables {𝒜 I}
@@ -173,7 +173,7 @@ lemma ideal.mem_homogeneous_core_of_is_homogeneous_of_mem {x : A}
 ideal.subset_span ⟨⟨x, h⟩, hmem, rfl⟩
 
 lemma ideal.is_homogeneous.coe_homogeneous_core_eq_self (h : I.is_homogeneous 𝒜) :
-  ↑(I.homogeneous_core 𝒜) = I :=
+  (I.homogeneous_core 𝒜).to_ideal = I :=
 begin
   apply le_antisymm (I.homogeneous_core'_le 𝒜) _,
   intros x hx,
@@ -183,12 +183,12 @@ begin
 end
 
 @[simp] lemma homogeneous_ideal.homogeneous_core_coe_eq_self (I : homogeneous_ideal 𝒜) :
-  (I : ideal A).homogeneous_core 𝒜 = I :=
+  I.to_ideal.homogeneous_core 𝒜 = I :=
 by ext1; convert ideal.is_homogeneous.coe_homogeneous_core_eq_self I.is_homogeneous
 
 variables (𝒜 I)
 
-lemma ideal.is_homogeneous.iff_eq : I.is_homogeneous 𝒜 ↔ ↑(I.homogeneous_core 𝒜) = I :=
+lemma ideal.is_homogeneous.iff_eq : I.is_homogeneous 𝒜 ↔ (I.homogeneous_core 𝒜).to_ideal = I :=
 ⟨ λ hI, hI.coe_homogeneous_core_eq_self,
   λ hI, hI ▸ (ideal.homogeneous_core 𝒜 I).2 ⟩
 
@@ -272,62 +272,58 @@ instance : partial_order (homogeneous_ideal 𝒜) := set_like.partial_order
 instance : has_bot (homogeneous_ideal 𝒜) :=
 ⟨⟨⊥, ideal.is_homogeneous.bot 𝒜⟩⟩
 
-@[simp] lemma coe_bot : ↑(⊥ : homogeneous_ideal 𝒜) = (⊥ : ideal A) := rfl
+@[simp] lemma coe_bot : (⊥ : homogeneous_ideal 𝒜).to_ideal = (⊥ : ideal A) := rfl
 
-@[simp] lemma eq_bot_iff (I : homogeneous_ideal 𝒜) : I = ⊥ ↔ (I : ideal A) = ⊥ :=
-begin
-  rw show I = ⊥ ↔ I.to_ideal = ⊥, from ⟨λ hI, by rw hI; refl, λ hI, by ext1; exact hI⟩,
-  refl
-end
+@[simp] lemma eq_bot_iff (I : homogeneous_ideal 𝒜) : I = ⊥ ↔ I.to_ideal = ⊥ :=
+to_ideal_injective.eq_iff.symm
 
 instance : has_top (homogeneous_ideal 𝒜) :=
 ⟨⟨⊤, ideal.is_homogeneous.top 𝒜⟩⟩
 
-@[simp] lemma coe_top : ↑(⊤ : homogeneous_ideal 𝒜) = (⊤ : ideal A) := rfl
+@[simp] lemma coe_top : (⊤ : homogeneous_ideal 𝒜).to_ideal = (⊤ : ideal A) := rfl
 
-@[simp] lemma eq_top_iff (I : homogeneous_ideal 𝒜) : I = ⊤ ↔ (I : ideal A) = ⊤ :=
-begin
-  rw show I = ⊤ ↔ I.to_ideal = ⊤, from ⟨λ hI, by rw hI; refl, λ hI, by ext1; exact hI⟩,
-  refl
-end
+@[simp] lemma eq_top_iff (I : homogeneous_ideal 𝒜) : I = ⊤ ↔ I.to_ideal = ⊤ :=
+to_ideal_injective.eq_iff.symm
 
 instance : has_inf (homogeneous_ideal 𝒜) :=
-{ inf := λ I J, ⟨I ⊓ J, I.is_homogeneous.inf J.is_homogeneous⟩ }
+{ inf := λ I J, ⟨I.to_ideal ⊓ J.to_ideal, I.is_homogeneous.inf J.is_homogeneous⟩ }
 
-@[simp] lemma coe_inf (I J : homogeneous_ideal 𝒜) : ↑(I ⊓ J) = (I ⊓ J : ideal A) := rfl
+@[simp] lemma coe_inf (I J : homogeneous_ideal 𝒜) : (I ⊓ J).to_ideal = I.to_ideal ⊓ J.to_ideal :=
+rfl
 
 instance : has_Inf (homogeneous_ideal 𝒜) :=
-{ Inf := λ ℐ, ⟨Inf (coe '' ℐ), ideal.is_homogeneous.Inf $ λ _ ⟨I, _, hI⟩, hI ▸ I.is_homogeneous⟩ }
+⟨λ ℐ, ⟨Inf (to_ideal '' ℐ), ideal.is_homogeneous.Inf $ λ _ ⟨I, _, hI⟩, hI ▸ I.is_homogeneous⟩⟩
 
-@[simp] lemma coe_Inf (ℐ : set (homogeneous_ideal 𝒜)) : ↑(Inf ℐ) = (Inf (coe '' ℐ) : ideal A) :=
+@[simp] lemma coe_Inf (ℐ : set (homogeneous_ideal 𝒜)) : (Inf ℐ).to_ideal = Inf (to_ideal '' ℐ) :=
 rfl
 
 @[simp] lemma coe_infi {ι' : Sort*} (s : ι' → homogeneous_ideal 𝒜) :
-  ↑(⨅ i, s i) = ⨅ i, (s i : ideal A) :=
+  (⨅ i, s i).to_ideal = ⨅ i, (s i).to_ideal :=
 by rw [infi, infi, coe_Inf, ←set.range_comp]
 
 instance : has_sup (homogeneous_ideal 𝒜) :=
-{ sup := λ I J, ⟨I ⊔ J, I.is_homogeneous.sup J.is_homogeneous⟩ }
+{ sup := λ I J, ⟨I.to_ideal ⊔ J.to_ideal, I.is_homogeneous.sup J.is_homogeneous⟩ }
 
-@[simp] lemma coe_sup (I J : homogeneous_ideal 𝒜) : ↑(I ⊔ J) = (I ⊔ J : ideal A) := rfl
-
-instance : has_Sup (homogeneous_ideal 𝒜) :=
-{ Sup := λ ℐ, ⟨Sup (coe '' ℐ), ideal.is_homogeneous.Sup $ λ _ ⟨I, _, hI⟩, hI ▸ I.is_homogeneous⟩ }
-
-@[simp] lemma coe_Sup (ℐ : set (homogeneous_ideal 𝒜)) : ↑(Sup ℐ) = (Sup (coe '' ℐ) : ideal A) :=
+@[simp] lemma coe_sup (I J : homogeneous_ideal 𝒜) : (I ⊔ J).to_ideal = I.to_ideal ⊔ J.to_ideal :=
 rfl
 
+instance : has_Sup (homogeneous_ideal 𝒜) :=
+⟨λ ℐ, ⟨Sup (to_ideal '' ℐ), ideal.is_homogeneous.Sup $ λ _ ⟨I, _, hI⟩, hI ▸ I.is_homogeneous⟩⟩
+
+@[simp] lemma coe_Sup (ℐ : set (homogeneous_ideal 𝒜)) :
+  (Sup ℐ).to_ideal = (Sup (to_ideal '' ℐ) : ideal A) := rfl
+
 @[simp] lemma coe_supr {ι' : Sort*} (s : ι' → homogeneous_ideal 𝒜) :
-  ↑(⨆ i, s i) = ⨆ i, (s i : ideal A) :=
+  (⨆ i, s i).to_ideal = ⨆ i, (s i).to_ideal :=
 by rw [supr, supr, coe_Sup, ←set.range_comp]
 
 instance : complete_lattice (homogeneous_ideal 𝒜) :=
-function.injective.complete_lattice (coe : homogeneous_ideal 𝒜 → ideal A)
-  (λ x y h, by ext1; exact h ) coe_sup coe_inf coe_Sup coe_Inf coe_top coe_bot
+to_ideal_injective.complete_lattice _ coe_sup coe_inf coe_Sup coe_Inf coe_top coe_bot
 
 instance : has_add (homogeneous_ideal 𝒜) := ⟨(⊔)⟩
 
-@[simp] lemma coe_add (I J : homogeneous_ideal 𝒜) : ↑(I + J) = (I + J : ideal A) := rfl
+@[simp] lemma coe_add (I J : homogeneous_ideal 𝒜) : (I + J).to_ideal = I.to_ideal + J.to_ideal :=
+rfl
 
 instance : inhabited (homogeneous_ideal 𝒜) := { default := ⊥ }
 
@@ -354,10 +350,10 @@ end
 variables {𝒜}
 
 instance : has_mul (homogeneous_ideal 𝒜) :=
-{ mul := λ I J, ⟨I * J, I.is_homogeneous.mul J.is_homogeneous⟩ }
+{ mul := λ I J, ⟨I.to_ideal * J.to_ideal, I.is_homogeneous.mul J.is_homogeneous⟩ }
 
 @[simp] lemma homogeneous_ideal.coe_mul (I J : homogeneous_ideal 𝒜) :
-  ↑(I * J) = (I * J : ideal A) := rfl
+  (I * J).to_ideal = I.to_ideal * J.to_ideal := rfl
 
 end comm_semiring
 
@@ -370,19 +366,21 @@ for building the lattice structure. -/
 
 section homogeneous_core
 
+open homogeneous_ideal
+
 variables [comm_semiring R] [semiring A]
 variables [algebra R A] [decidable_eq ι] [add_monoid ι]
 variables (𝒜 : ι → submodule R A) [graded_algebra 𝒜]
 variable (I : ideal A)
 
-lemma ideal.homogeneous_core.gc : galois_connection coe (ideal.homogeneous_core 𝒜) :=
+lemma ideal.homogeneous_core.gc : galois_connection to_ideal (ideal.homogeneous_core 𝒜) :=
 λ I J, ⟨
   λ H, I.homogeneous_core_coe_eq_self ▸ ideal.homogeneous_core_mono 𝒜 H,
   λ H, le_trans H (ideal.homogeneous_core'_le _ _)⟩
 
 /--`coe : homogeneous_ideal 𝒜 → ideal A` and `ideal.homogeneous_core 𝒜` forms a galois
 coinsertion-/
-def ideal.homogeneous_core.gi : galois_coinsertion coe (ideal.homogeneous_core 𝒜) :=
+def ideal.homogeneous_core.gi : galois_coinsertion to_ideal (ideal.homogeneous_core 𝒜) :=
 { choice := λ I HI,
     ⟨I, le_antisymm (I.coe_homogeneous_core_le 𝒜) HI ▸ homogeneous_ideal.is_homogeneous _⟩,
   gc := ideal.homogeneous_core.gc 𝒜,
@@ -390,7 +388,7 @@ def ideal.homogeneous_core.gi : galois_coinsertion coe (ideal.homogeneous_core �
   choice_eq := λ I H, le_antisymm H (I.coe_homogeneous_core_le _) }
 
 lemma ideal.homogeneous_core_eq_Sup :
-  I.homogeneous_core 𝒜 = Sup {J : homogeneous_ideal 𝒜 | ↑J ≤ I} :=
+  I.homogeneous_core 𝒜 = Sup {J : homogeneous_ideal 𝒜 | J.to_ideal ≤ I} :=
 eq.symm $ is_lub.Sup_eq $ (ideal.homogeneous_core.gc 𝒜).is_greatest_u.is_lub
 
 lemma ideal.homogeneous_core'_eq_Sup :
@@ -398,7 +396,7 @@ lemma ideal.homogeneous_core'_eq_Sup :
 begin
   refine (is_lub.Sup_eq _).symm,
   apply is_greatest.is_lub,
-  have coe_mono : monotone (coe : homogeneous_ideal 𝒜 → ideal A) := λ _ _, id,
+  have coe_mono : monotone (to_ideal : homogeneous_ideal 𝒜 → ideal A) := λ x y, id,
   convert coe_mono.map_is_greatest (ideal.homogeneous_core.gc 𝒜).is_greatest_u using 1,
   ext,
   rw [mem_image, mem_set_of_eq],
@@ -428,7 +426,7 @@ def ideal.homogeneous_hull : homogeneous_ideal 𝒜 :=
 end⟩
 
 lemma ideal.le_coe_homogeneous_hull :
-  I ≤ ideal.homogeneous_hull 𝒜 I :=
+  I ≤ (ideal.homogeneous_hull 𝒜 I).to_ideal :=
 begin
   intros r hr,
   letI : Π (i : ι) (x : 𝒜 i), decidable (x ≠ 0) := λ _ _, classical.dec _,
@@ -447,7 +445,7 @@ end
 variables {I 𝒜}
 
 lemma ideal.is_homogeneous.homogeneous_hull_eq_self (h : I.is_homogeneous 𝒜) :
-  ↑(ideal.homogeneous_hull 𝒜 I) = I :=
+  (ideal.homogeneous_hull 𝒜 I).to_ideal = I :=
 begin
   apply le_antisymm _ (ideal.le_coe_homogeneous_hull _ _),
   apply (ideal.span_le).2,
@@ -456,13 +454,13 @@ begin
 end
 
 @[simp] lemma homogeneous_ideal.homogeneous_hull_coe_eq_self (I : homogeneous_ideal 𝒜) :
-  (I : ideal A).homogeneous_hull 𝒜 = I :=
+  I.to_ideal.homogeneous_hull 𝒜 = I :=
 by ext1; convert ideal.is_homogeneous.homogeneous_hull_eq_self I.is_homogeneous
 
 variables (I 𝒜)
 
 lemma ideal.coe_homogeneous_hull_eq_supr :
-  ↑(I.homogeneous_hull 𝒜) = ⨆ i, ideal.span (graded_algebra.proj 𝒜 i '' I) :=
+  (I.homogeneous_hull 𝒜).to_ideal = ⨆ i, ideal.span (graded_algebra.proj 𝒜 i '' I) :=
 begin
   rw ←ideal.span_Union,
   apply congr_arg ideal.span _,
@@ -475,7 +473,7 @@ lemma ideal.homogeneous_hull_eq_supr :
   (I.homogeneous_hull 𝒜) =
   ⨆ i, ⟨ideal.span (graded_algebra.proj 𝒜 i '' I), ideal.is_homogeneous_span 𝒜 _
     (by {rintros _ ⟨x, -, rfl⟩, apply set_like.is_homogeneous_coe})⟩ :=
-by rw [ext_iff_coe, ideal.coe_homogeneous_hull_eq_supr, coe_supr]; refl
+by ext1; rw [ideal.coe_homogeneous_hull_eq_supr, coe_supr]; refl
 
 end homogeneous_hull
 
@@ -487,20 +485,20 @@ variables [comm_semiring R] [semiring A]
 variables [algebra R A] [decidable_eq ι] [add_monoid ι]
 variables (𝒜 : ι → submodule R A) [graded_algebra 𝒜]
 
-lemma ideal.homogeneous_hull.gc : galois_connection (ideal.homogeneous_hull 𝒜) coe :=
+lemma ideal.homogeneous_hull.gc : galois_connection (ideal.homogeneous_hull 𝒜) to_ideal :=
 λ I J, ⟨
   le_trans (ideal.le_coe_homogeneous_hull _ _),
   λ H, J.homogeneous_hull_coe_eq_self ▸ ideal.homogeneous_hull_mono 𝒜 H⟩
 
 /-- `ideal.homogeneous_hull 𝒜` and `coe : homogeneous_ideal 𝒜 → ideal A` forms a galois insertion-/
-def ideal.homogeneous_hull.gi : galois_insertion (ideal.homogeneous_hull 𝒜) coe :=
+def ideal.homogeneous_hull.gi : galois_insertion (ideal.homogeneous_hull 𝒜) to_ideal :=
 { choice := λ I H, ⟨I, le_antisymm H (I.le_coe_homogeneous_hull 𝒜) ▸ is_homogeneous _⟩,
   gc := ideal.homogeneous_hull.gc 𝒜,
   le_l_u := λ I, ideal.le_coe_homogeneous_hull _ _,
   choice_eq := λ I H, le_antisymm (I.le_coe_homogeneous_hull 𝒜) H}
 
 lemma ideal.homogeneous_hull_eq_Inf (I : ideal A) :
-  ideal.homogeneous_hull 𝒜 I = Inf { J : homogeneous_ideal 𝒜 | I ≤ J } :=
+  ideal.homogeneous_hull 𝒜 I = Inf { J : homogeneous_ideal 𝒜 | I ≤ J.to_ideal } :=
 eq.symm $ is_glb.Inf_eq $ (ideal.homogeneous_hull.gc 𝒜).is_least_l.is_glb
 
 end galois_connection
@@ -536,7 +534,7 @@ end⟩
 @[simp] lemma homogeneous_ideal.mem_irrelevant_iff (a : A) :
   a ∈ homogeneous_ideal.irrelevant 𝒜 ↔ proj 𝒜 0 a = 0 := iff.rfl
 
-@[simp, norm_cast] lemma homogeneous_ideal.coe_irrelevant :
-  ↑(homogeneous_ideal.irrelevant 𝒜) = (graded_algebra.proj_zero_ring_hom 𝒜).ker := rfl
+@[simp] lemma homogeneous_ideal.coe_irrelevant :
+  (homogeneous_ideal.irrelevant 𝒜).to_ideal = (graded_algebra.proj_zero_ring_hom 𝒜).ker := rfl
 
 end irrelevant_ideal

--- a/src/ring_theory/graded_algebra/homogeneous_ideal.lean
+++ b/src/ring_theory/graded_algebra/homogeneous_ideal.lean
@@ -71,11 +71,7 @@ lemma homogeneous_ideal.to_ideal_injective :
 
 instance homogeneous_ideal.set_like : set_like (homogeneous_ideal 𝒜) A :=
 { coe := λ I, I.to_ideal,
-  coe_injective' := λ I J h, begin
-    apply_fun homogeneous_ideal.to_ideal,
-    exact set_like.coe_injective h,
-    exact homogeneous_ideal.to_ideal_injective,
-  end }
+  coe_injective' := λ I J h, homogeneous_ideal.to_ideal_injective $ set_like.coe_injective h }
 
 @[ext] lemma homogeneous_ideal.ext {I J : homogeneous_ideal 𝒜}
   (h : I.to_ideal = J.to_ideal) : I = J := homogeneous_ideal.to_ideal_injective h

--- a/src/ring_theory/graded_algebra/homogeneous_ideal.lean
+++ b/src/ring_theory/graded_algebra/homogeneous_ideal.lean
@@ -59,12 +59,10 @@ def ideal.is_homogeneous : Prop :=
 abbreviation homogeneous_ideal : Type* := { I : ideal A // I.is_homogeneous 𝒜 }
 
 instance homogeneous_ideal.set_like : set_like (homogeneous_ideal 𝒜) A :=
-{ coe := λ I, I.1.carrier,
-  coe_injective' := λ ⟨I, hI⟩ ⟨J, hJ⟩ (h : I.carrier = J.carrier), begin
-    rw subtype.ext_iff_val,
-    ext,
-    change x ∈ I.carrier ↔ x ∈ J.carrier,
-    rw h
+{ coe := λ I, ((I : ideal A) : set A),
+  coe_injective' := λ ⟨I, hI⟩ ⟨J, hJ⟩ h, begin
+    congr,
+    exact set_like.coe_injective h,
   end }
 
 lemma homogeneous_ideal.mem_iff {I : homogeneous_ideal 𝒜} {x : A} : x ∈ I ↔ x ∈ (↑I : ideal A) :=

--- a/src/ring_theory/graded_algebra/homogeneous_ideal.lean
+++ b/src/ring_theory/graded_algebra/homogeneous_ideal.lean
@@ -160,7 +160,7 @@ def ideal.homogeneous_core : homogeneous_ideal 𝒜 :=
 lemma ideal.homogeneous_core_mono : monotone (ideal.homogeneous_core 𝒜) :=
 ideal.homogeneous_core'_mono 𝒜
 
-lemma ideal.coe_homogeneous_core_le : (I.homogeneous_core 𝒜).to_ideal ≤ I :=
+lemma ideal.to_ideal_homogeneous_core_le : (I.homogeneous_core 𝒜).to_ideal ≤ I :=
 ideal.homogeneous_core'_le 𝒜 I
 
 variables {𝒜 I}
@@ -169,7 +169,7 @@ lemma ideal.mem_homogeneous_core_of_is_homogeneous_of_mem {x : A}
   (h : set_like.is_homogeneous 𝒜 x) (hmem : x ∈ I) : x ∈ I.homogeneous_core 𝒜 :=
 ideal.subset_span ⟨⟨x, h⟩, hmem, rfl⟩
 
-lemma ideal.is_homogeneous.coe_homogeneous_core_eq_self (h : I.is_homogeneous 𝒜) :
+lemma ideal.is_homogeneous.to_ideal_homogeneous_core_eq_self (h : I.is_homogeneous 𝒜) :
   (I.homogeneous_core 𝒜).to_ideal = I :=
 begin
   apply le_antisymm (I.homogeneous_core'_le 𝒜) _,
@@ -179,14 +179,14 @@ begin
   exact ideal.sum_mem _ (λ j hj, ideal.subset_span ⟨⟨_, is_homogeneous_coe _⟩, h _ hx, rfl⟩)
 end
 
-@[simp] lemma homogeneous_ideal.homogeneous_core_coe_eq_self (I : homogeneous_ideal 𝒜) :
+@[simp] lemma homogeneous_ideal.to_ideal_homogeneous_core_eq_self (I : homogeneous_ideal 𝒜) :
   I.to_ideal.homogeneous_core 𝒜 = I :=
-by ext1; convert ideal.is_homogeneous.coe_homogeneous_core_eq_self I.is_homogeneous
+by ext1; convert ideal.is_homogeneous.to_ideal_homogeneous_core_eq_self I.is_homogeneous
 
 variables (𝒜 I)
 
 lemma ideal.is_homogeneous.iff_eq : I.is_homogeneous 𝒜 ↔ (I.homogeneous_core 𝒜).to_ideal = I :=
-⟨ λ hI, hI.coe_homogeneous_core_eq_self,
+⟨ λ hI, hI.to_ideal_homogeneous_core_eq_self,
   λ hI, hI ▸ (ideal.homogeneous_core 𝒜 I).2 ⟩
 
 lemma ideal.is_homogeneous.iff_exists :
@@ -269,7 +269,7 @@ instance : partial_order (homogeneous_ideal 𝒜) := set_like.partial_order
 instance : has_bot (homogeneous_ideal 𝒜) :=
 ⟨⟨⊥, ideal.is_homogeneous.bot 𝒜⟩⟩
 
-@[simp] lemma coe_bot : (⊥ : homogeneous_ideal 𝒜).to_ideal = (⊥ : ideal A) := rfl
+@[simp] lemma to_ideal_bot : (⊥ : homogeneous_ideal 𝒜).to_ideal = (⊥ : ideal A) := rfl
 
 @[simp] lemma eq_bot_iff (I : homogeneous_ideal 𝒜) : I = ⊥ ↔ I.to_ideal = ⊥ :=
 to_ideal_injective.eq_iff.symm
@@ -277,7 +277,7 @@ to_ideal_injective.eq_iff.symm
 instance : has_top (homogeneous_ideal 𝒜) :=
 ⟨⟨⊤, ideal.is_homogeneous.top 𝒜⟩⟩
 
-@[simp] lemma coe_top : (⊤ : homogeneous_ideal 𝒜).to_ideal = (⊤ : ideal A) := rfl
+@[simp] lemma to_ideal_top : (⊤ : homogeneous_ideal 𝒜).to_ideal = (⊤ : ideal A) := rfl
 
 @[simp] lemma eq_top_iff (I : homogeneous_ideal 𝒜) : I = ⊤ ↔ I.to_ideal = ⊤ :=
 to_ideal_injective.eq_iff.symm
@@ -285,41 +285,42 @@ to_ideal_injective.eq_iff.symm
 instance : has_inf (homogeneous_ideal 𝒜) :=
 { inf := λ I J, ⟨I.to_ideal ⊓ J.to_ideal, I.is_homogeneous.inf J.is_homogeneous⟩ }
 
-@[simp] lemma coe_inf (I J : homogeneous_ideal 𝒜) : (I ⊓ J).to_ideal = I.to_ideal ⊓ J.to_ideal :=
+@[simp] lemma to_ideal_inf (I J : homogeneous_ideal 𝒜) : (I ⊓ J).to_ideal = I.to_ideal ⊓ J.to_ideal :=
 rfl
 
 instance : has_Inf (homogeneous_ideal 𝒜) :=
 ⟨λ ℐ, ⟨Inf (to_ideal '' ℐ), ideal.is_homogeneous.Inf $ λ _ ⟨I, _, hI⟩, hI ▸ I.is_homogeneous⟩⟩
 
-@[simp] lemma coe_Inf (ℐ : set (homogeneous_ideal 𝒜)) : (Inf ℐ).to_ideal = Inf (to_ideal '' ℐ) :=
+@[simp] lemma to_ideal_Inf (ℐ : set (homogeneous_ideal 𝒜)) : (Inf ℐ).to_ideal = Inf (to_ideal '' ℐ) :=
 rfl
 
-@[simp] lemma coe_infi {ι' : Sort*} (s : ι' → homogeneous_ideal 𝒜) :
+@[simp] lemma to_ideal_infi {ι' : Sort*} (s : ι' → homogeneous_ideal 𝒜) :
   (⨅ i, s i).to_ideal = ⨅ i, (s i).to_ideal :=
-by rw [infi, infi, coe_Inf, ←set.range_comp]
+by rw [infi, infi, to_ideal_Inf, ←set.range_comp]
 
 instance : has_sup (homogeneous_ideal 𝒜) :=
 { sup := λ I J, ⟨I.to_ideal ⊔ J.to_ideal, I.is_homogeneous.sup J.is_homogeneous⟩ }
 
-@[simp] lemma coe_sup (I J : homogeneous_ideal 𝒜) : (I ⊔ J).to_ideal = I.to_ideal ⊔ J.to_ideal :=
+@[simp] lemma to_ideal_sup (I J : homogeneous_ideal 𝒜) : (I ⊔ J).to_ideal = I.to_ideal ⊔ J.to_ideal :=
 rfl
 
 instance : has_Sup (homogeneous_ideal 𝒜) :=
 ⟨λ ℐ, ⟨Sup (to_ideal '' ℐ), ideal.is_homogeneous.Sup $ λ _ ⟨I, _, hI⟩, hI ▸ I.is_homogeneous⟩⟩
 
-@[simp] lemma coe_Sup (ℐ : set (homogeneous_ideal 𝒜)) :
+@[simp] lemma to_ideal_Sup (ℐ : set (homogeneous_ideal 𝒜)) :
   (Sup ℐ).to_ideal = (Sup (to_ideal '' ℐ) : ideal A) := rfl
 
 @[simp] lemma coe_supr {ι' : Sort*} (s : ι' → homogeneous_ideal 𝒜) :
   (⨆ i, s i).to_ideal = ⨆ i, (s i).to_ideal :=
-by rw [supr, supr, coe_Sup, ←set.range_comp]
+by rw [supr, supr, to_ideal_Sup, ←set.range_comp]
 
 instance : complete_lattice (homogeneous_ideal 𝒜) :=
-to_ideal_injective.complete_lattice _ coe_sup coe_inf coe_Sup coe_Inf coe_top coe_bot
+to_ideal_injective.complete_lattice _ to_ideal_sup to_ideal_inf to_ideal_Sup to_ideal_Inf
+  to_ideal_top to_ideal_bot
 
 instance : has_add (homogeneous_ideal 𝒜) := ⟨(⊔)⟩
 
-@[simp] lemma coe_add (I J : homogeneous_ideal 𝒜) : (I + J).to_ideal = I.to_ideal + J.to_ideal :=
+@[simp] lemma to_ideal_add (I J : homogeneous_ideal 𝒜) : (I + J).to_ideal = I.to_ideal + J.to_ideal :=
 rfl
 
 instance : inhabited (homogeneous_ideal 𝒜) := { default := ⊥ }
@@ -349,7 +350,7 @@ variables {𝒜}
 instance : has_mul (homogeneous_ideal 𝒜) :=
 { mul := λ I J, ⟨I.to_ideal * J.to_ideal, I.is_homogeneous.mul J.is_homogeneous⟩ }
 
-@[simp] lemma homogeneous_ideal.coe_mul (I J : homogeneous_ideal 𝒜) :
+@[simp] lemma homogeneous_ideal.to_ideal_mul (I J : homogeneous_ideal 𝒜) :
   (I * J).to_ideal = I.to_ideal * J.to_ideal := rfl
 
 end comm_semiring
@@ -372,17 +373,17 @@ variable (I : ideal A)
 
 lemma ideal.homogeneous_core.gc : galois_connection to_ideal (ideal.homogeneous_core 𝒜) :=
 λ I J, ⟨
-  λ H, I.homogeneous_core_coe_eq_self ▸ ideal.homogeneous_core_mono 𝒜 H,
+  λ H, I.to_ideal_homogeneous_core_eq_self ▸ ideal.homogeneous_core_mono 𝒜 H,
   λ H, le_trans H (ideal.homogeneous_core'_le _ _)⟩
 
 /--`to_ideal : homogeneous_ideal 𝒜 → ideal A` and `ideal.homogeneous_core 𝒜` forms a galois
 coinsertion-/
 def ideal.homogeneous_core.gi : galois_coinsertion to_ideal (ideal.homogeneous_core 𝒜) :=
 { choice := λ I HI,
-    ⟨I, le_antisymm (I.coe_homogeneous_core_le 𝒜) HI ▸ homogeneous_ideal.is_homogeneous _⟩,
+    ⟨I, le_antisymm (I.to_ideal_homogeneous_core_le 𝒜) HI ▸ homogeneous_ideal.is_homogeneous _⟩,
   gc := ideal.homogeneous_core.gc 𝒜,
   u_l_le := λ I, ideal.homogeneous_core'_le _ _,
-  choice_eq := λ I H, le_antisymm H (I.coe_homogeneous_core_le _) }
+  choice_eq := λ I H, le_antisymm H (I.to_ideal_homogeneous_core_le _) }
 
 lemma ideal.homogeneous_core_eq_Sup :
   I.homogeneous_core 𝒜 = Sup {J : homogeneous_ideal 𝒜 | J.to_ideal ≤ I} :=
@@ -422,7 +423,7 @@ def ideal.homogeneous_hull : homogeneous_ideal 𝒜 :=
   apply set_like.is_homogeneous_coe
 end⟩
 
-lemma ideal.le_coe_homogeneous_hull :
+lemma ideal.le_to_ideal_homogeneous_hull :
   I ≤ (ideal.homogeneous_hull 𝒜 I).to_ideal :=
 begin
   intros r hr,
@@ -441,22 +442,22 @@ end
 
 variables {I 𝒜}
 
-lemma ideal.is_homogeneous.homogeneous_hull_eq_self (h : I.is_homogeneous 𝒜) :
+lemma ideal.is_homogeneous.to_ideal_homogeneous_hull_eq_self (h : I.is_homogeneous 𝒜) :
   (ideal.homogeneous_hull 𝒜 I).to_ideal = I :=
 begin
-  apply le_antisymm _ (ideal.le_coe_homogeneous_hull _ _),
+  apply le_antisymm _ (ideal.le_to_ideal_homogeneous_hull _ _),
   apply (ideal.span_le).2,
   rintros _ ⟨i, x, rfl⟩,
   exact h _ x.prop,
 end
 
-@[simp] lemma homogeneous_ideal.homogeneous_hull_coe_eq_self (I : homogeneous_ideal 𝒜) :
+@[simp] lemma homogeneous_ideal.homogeneous_hull_to_ideal_eq_self (I : homogeneous_ideal 𝒜) :
   I.to_ideal.homogeneous_hull 𝒜 = I :=
-by ext1; convert ideal.is_homogeneous.homogeneous_hull_eq_self I.is_homogeneous
+homogeneous_ideal.to_ideal_injective $ I.is_homogeneous.to_ideal_homogeneous_hull_eq_self
 
 variables (I 𝒜)
 
-lemma ideal.coe_homogeneous_hull_eq_supr :
+lemma ideal.to_ideal_homogeneous_hull_eq_supr :
   (I.homogeneous_hull 𝒜).to_ideal = ⨆ i, ideal.span (graded_algebra.proj 𝒜 i '' I) :=
 begin
   rw ←ideal.span_Union,
@@ -470,7 +471,7 @@ lemma ideal.homogeneous_hull_eq_supr :
   (I.homogeneous_hull 𝒜) =
   ⨆ i, ⟨ideal.span (graded_algebra.proj 𝒜 i '' I), ideal.is_homogeneous_span 𝒜 _
     (by {rintros _ ⟨x, -, rfl⟩, apply set_like.is_homogeneous_coe})⟩ :=
-by ext1; rw [ideal.coe_homogeneous_hull_eq_supr, coe_supr]; refl
+by ext1; rw [ideal.to_ideal_homogeneous_hull_eq_supr, coe_supr]; refl
 
 end homogeneous_hull
 
@@ -484,16 +485,16 @@ variables (𝒜 : ι → submodule R A) [graded_algebra 𝒜]
 
 lemma ideal.homogeneous_hull.gc : galois_connection (ideal.homogeneous_hull 𝒜) to_ideal :=
 λ I J, ⟨
-  le_trans (ideal.le_coe_homogeneous_hull _ _),
-  λ H, J.homogeneous_hull_coe_eq_self ▸ ideal.homogeneous_hull_mono 𝒜 H⟩
+  le_trans (ideal.le_to_ideal_homogeneous_hull _ _),
+  λ H, J.homogeneous_hull_to_ideal_eq_self ▸ ideal.homogeneous_hull_mono 𝒜 H⟩
 
 /-- `ideal.homogeneous_hull 𝒜` and `to_ideal : homogeneous_ideal 𝒜 → ideal A` forms a galois
 insertion-/
 def ideal.homogeneous_hull.gi : galois_insertion (ideal.homogeneous_hull 𝒜) to_ideal :=
-{ choice := λ I H, ⟨I, le_antisymm H (I.le_coe_homogeneous_hull 𝒜) ▸ is_homogeneous _⟩,
+{ choice := λ I H, ⟨I, le_antisymm H (I.le_to_ideal_homogeneous_hull 𝒜) ▸ is_homogeneous _⟩,
   gc := ideal.homogeneous_hull.gc 𝒜,
-  le_l_u := λ I, ideal.le_coe_homogeneous_hull _ _,
-  choice_eq := λ I H, le_antisymm (I.le_coe_homogeneous_hull 𝒜) H}
+  le_l_u := λ I, ideal.le_to_ideal_homogeneous_hull _ _,
+  choice_eq := λ I H, le_antisymm (I.le_to_ideal_homogeneous_hull 𝒜) H}
 
 lemma ideal.homogeneous_hull_eq_Inf (I : ideal A) :
   ideal.homogeneous_hull 𝒜 I = Inf { J : homogeneous_ideal 𝒜 | I ≤ J.to_ideal } :=

--- a/src/ring_theory/graded_algebra/homogeneous_ideal.lean
+++ b/src/ring_theory/graded_algebra/homogeneous_ideal.lean
@@ -58,12 +58,6 @@ def ideal.is_homogeneous : Prop :=
 /-- For any `semiring A`, we collect the homogeneous ideals of `A` into a type. -/
 abbreviation homogeneous_ideal : Type* := { I : ideal A // I.is_homogeneous 𝒜 }
 
-instance : has_mem A (homogeneous_ideal 𝒜) :=
-{ mem := λ r I, r ∈ (I : ideal A) }
-
-lemma homogeneous_ideal.mem_iff {I : homogeneous_ideal 𝒜} {x : A} : x ∈ I ↔ x ∈ (↑I : ideal A) :=
-iff.rfl
-
 instance homogeneous_ideal.set_like : set_like (homogeneous_ideal 𝒜) A :=
 { coe := λ I, I.1.carrier,
   coe_injective' := λ ⟨I, hI⟩ ⟨J, hJ⟩ (h : I.carrier = J.carrier), begin
@@ -72,6 +66,9 @@ instance homogeneous_ideal.set_like : set_like (homogeneous_ideal 𝒜) A :=
     change x ∈ I.carrier ↔ x ∈ J.carrier,
     rw h
   end }
+
+lemma homogeneous_ideal.mem_iff {I : homogeneous_ideal 𝒜} {x : A} : x ∈ I ↔ x ∈ (↑I : ideal A) :=
+iff.rfl
 
 end homogeneous_def
 

--- a/src/ring_theory/graded_algebra/homogeneous_ideal.lean
+++ b/src/ring_theory/graded_algebra/homogeneous_ideal.lean
@@ -533,7 +533,7 @@ end⟩
 @[simp] lemma homogeneous_ideal.mem_irrelevant_iff (a : A) :
   a ∈ homogeneous_ideal.irrelevant 𝒜 ↔ proj 𝒜 0 a = 0 := iff.rfl
 
-@[simp] lemma homogeneous_ideal.coe_irrelevant :
+@[simp] lemma homogeneous_ideal.to_ideal_irrelevant :
   (homogeneous_ideal.irrelevant 𝒜).to_ideal = (graded_algebra.proj_zero_ring_hom 𝒜).ker := rfl
 
 end irrelevant_ideal

--- a/src/ring_theory/graded_algebra/homogeneous_ideal.lean
+++ b/src/ring_theory/graded_algebra/homogeneous_ideal.lean
@@ -252,9 +252,6 @@ variables {𝒜}
 
 namespace homogeneous_ideal
 
-instance : partial_order (homogeneous_ideal 𝒜) :=
-partial_order.lift _ subtype.coe_injective
-
 instance : has_bot (homogeneous_ideal 𝒜) :=
 ⟨⟨⊥, ideal.is_homogeneous.bot 𝒜⟩⟩
 

--- a/src/ring_theory/graded_algebra/homogeneous_ideal.lean
+++ b/src/ring_theory/graded_algebra/homogeneous_ideal.lean
@@ -375,7 +375,7 @@ lemma ideal.homogeneous_core.gc : galois_connection to_ideal (ideal.homogeneous_
   λ H, I.homogeneous_core_coe_eq_self ▸ ideal.homogeneous_core_mono 𝒜 H,
   λ H, le_trans H (ideal.homogeneous_core'_le _ _)⟩
 
-/--`coe : homogeneous_ideal 𝒜 → ideal A` and `ideal.homogeneous_core 𝒜` forms a galois
+/--`to_ideal : homogeneous_ideal 𝒜 → ideal A` and `ideal.homogeneous_core 𝒜` forms a galois
 coinsertion-/
 def ideal.homogeneous_core.gi : galois_coinsertion to_ideal (ideal.homogeneous_core 𝒜) :=
 { choice := λ I HI,
@@ -487,7 +487,8 @@ lemma ideal.homogeneous_hull.gc : galois_connection (ideal.homogeneous_hull 𝒜
   le_trans (ideal.le_coe_homogeneous_hull _ _),
   λ H, J.homogeneous_hull_coe_eq_self ▸ ideal.homogeneous_hull_mono 𝒜 H⟩
 
-/-- `ideal.homogeneous_hull 𝒜` and `coe : homogeneous_ideal 𝒜 → ideal A` forms a galois insertion-/
+/-- `ideal.homogeneous_hull 𝒜` and `to_linear_map : homogeneous_ideal 𝒜 → ideal A` forms a galois
+insertion-/
 def ideal.homogeneous_hull.gi : galois_insertion (ideal.homogeneous_hull 𝒜) to_ideal :=
 { choice := λ I H, ⟨I, le_antisymm H (I.le_coe_homogeneous_hull 𝒜) ▸ is_homogeneous _⟩,
   gc := ideal.homogeneous_hull.gc 𝒜,

--- a/src/ring_theory/graded_algebra/homogeneous_ideal.lean
+++ b/src/ring_theory/graded_algebra/homogeneous_ideal.lean
@@ -488,7 +488,7 @@ lemma ideal.homogeneous_hull.gc : galois_connection (ideal.homogeneous_hull 𝒜
   le_trans (ideal.le_to_ideal_homogeneous_hull _ _),
   λ H, J.homogeneous_hull_to_ideal_eq_self ▸ ideal.homogeneous_hull_mono 𝒜 H⟩
 
-/-- `ideal.homogeneous_hull 𝒜` and `to_ideal : homogeneous_ideal 𝒜 → ideal A` forms a galois
+/-- `ideal.homogeneous_hull 𝒜` and `to_ideal : homogeneous_ideal 𝒜 → ideal A` form a galois
 insertion-/
 def ideal.homogeneous_hull.gi : galois_insertion (ideal.homogeneous_hull 𝒜) to_ideal :=
 { choice := λ I H, ⟨I, le_antisymm H (I.le_to_ideal_homogeneous_hull 𝒜) ▸ is_homogeneous _⟩,

--- a/src/ring_theory/graded_algebra/homogeneous_ideal.lean
+++ b/src/ring_theory/graded_algebra/homogeneous_ideal.lean
@@ -487,7 +487,7 @@ lemma ideal.homogeneous_hull.gc : galois_connection (ideal.homogeneous_hull 𝒜
   le_trans (ideal.le_coe_homogeneous_hull _ _),
   λ H, J.homogeneous_hull_coe_eq_self ▸ ideal.homogeneous_hull_mono 𝒜 H⟩
 
-/-- `ideal.homogeneous_hull 𝒜` and `to_linear_map : homogeneous_ideal 𝒜 → ideal A` forms a galois
+/-- `ideal.homogeneous_hull 𝒜` and `to_ideal : homogeneous_ideal 𝒜 → ideal A` forms a galois
 insertion-/
 def ideal.homogeneous_hull.gi : galois_insertion (ideal.homogeneous_hull 𝒜) to_ideal :=
 { choice := λ I H, ⟨I, le_antisymm H (I.le_coe_homogeneous_hull 𝒜) ▸ is_homogeneous _⟩,

--- a/src/ring_theory/graded_algebra/homogeneous_ideal.lean
+++ b/src/ring_theory/graded_algebra/homogeneous_ideal.lean
@@ -77,8 +77,8 @@ instance homogeneous_ideal.set_like : set_like (homogeneous_ideal 𝒜) A :=
 @[ext] lemma homogeneous_ideal.ext {I J : homogeneous_ideal 𝒜}
   (h : I.to_ideal = J.to_ideal) : I = J := homogeneous_ideal.to_ideal_injective h
 
-lemma homogeneous_ideal.mem_iff {I : homogeneous_ideal 𝒜} {x : A} : x ∈ I ↔ x ∈ I.to_ideal :=
-iff.rfl
+@[simp] lemma homogeneous_ideal.mem_iff {I : homogeneous_ideal 𝒜} {x : A} :
+  x ∈ I.to_ideal ↔ x ∈ I := iff.rfl
 
 end homogeneous_def
 

--- a/src/ring_theory/graded_algebra/radical.lean
+++ b/src/ring_theory/graded_algebra/radical.lean
@@ -174,11 +174,11 @@ lemma ideal.is_homogeneous.radical {I : ideal A} (h : I.is_homogeneous 𝒜)  :
 begin
   convert (Inf {J : homogeneous_ideal 𝒜 | I ≤ J.to_ideal ∧ J.to_ideal.is_prime}).is_homogeneous
     using 2,
-  simp_rw [h.radical_eq, homogeneous_ideal.to_ideal_Inf],
+  rw [h.radical_eq, homogeneous_ideal.to_ideal_Inf],
   congr' 1,
   ext1,
   rw [set.mem_image, set.mem_set_of_eq],
-  exact ⟨λ h, ⟨⟨x, h.1⟩, h.2, rfl⟩, by { rintro ⟨x, ⟨h1, h2⟩, rfl⟩, exact ⟨x.2, h1, h2⟩ }⟩
+  exact ⟨λ h, ⟨⟨x, h.1⟩, h.2, rfl⟩, by rintro ⟨x, ⟨h1, h2⟩, rfl⟩; exact ⟨x.2, h1, h2⟩⟩
 end
 
 /-- The radical of a homogenous ideal, as another homogenous ideal. -/

--- a/src/ring_theory/graded_algebra/radical.lean
+++ b/src/ring_theory/graded_algebra/radical.lean
@@ -148,9 +148,9 @@ lemma ideal.is_prime.homogeneous_core {I : ideal A} (h : I.is_prime) :
   (I.homogeneous_core 𝒜).to_ideal.is_prime :=
 begin
   apply (ideal.homogeneous_core 𝒜 I).is_homogeneous.is_prime_of_homogeneous_mem_or_mem,
-  { exact ne_top_of_le_ne_top h.ne_top (ideal.coe_homogeneous_core_le 𝒜 I) },
+  { exact ne_top_of_le_ne_top h.ne_top (ideal.to_ideal_homogeneous_core_le 𝒜 I) },
   rintros x y hx hy hxy,
-  have H := h.mem_or_mem (ideal.coe_homogeneous_core_le 𝒜 I hxy),
+  have H := h.mem_or_mem (ideal.to_ideal_homogeneous_core_le 𝒜 I hxy),
   refine H.imp _ _,
   { exact ideal.mem_homogeneous_core_of_is_homogeneous_of_mem hx, },
   { exact ideal.mem_homogeneous_core_of_is_homogeneous_of_mem hy, },
@@ -164,9 +164,9 @@ begin
   { exact Inf_le_Inf (λ J, and.right), },
   { refine Inf_le_Inf_of_forall_exists_le _,
     rintros J ⟨HJ₁, HJ₂⟩,
-    refine ⟨(J.homogeneous_core 𝒜).to_ideal, _, J.coe_homogeneous_core_le _⟩,
+    refine ⟨(J.homogeneous_core 𝒜).to_ideal, _, J.to_ideal_homogeneous_core_le _⟩,
     refine ⟨homogeneous_ideal.is_homogeneous _, _, HJ₂.homogeneous_core⟩,
-    refine hI.coe_homogeneous_core_eq_self.symm.trans_le (ideal.homogeneous_core_mono _ HJ₁), }
+    refine hI.to_ideal_homogeneous_core_eq_self.symm.trans_le (ideal.homogeneous_core_mono _ HJ₁), }
 end
 
 lemma ideal.is_homogeneous.radical {I : ideal A} (h : I.is_homogeneous 𝒜)  :
@@ -174,7 +174,7 @@ lemma ideal.is_homogeneous.radical {I : ideal A} (h : I.is_homogeneous 𝒜)  :
 begin
   convert (Inf {J : homogeneous_ideal 𝒜 | I ≤ J.to_ideal ∧ J.to_ideal.is_prime}).is_homogeneous
     using 2,
-  simp_rw [h.radical_eq, homogeneous_ideal.coe_Inf],
+  simp_rw [h.radical_eq, homogeneous_ideal.to_ideal_Inf],
   congr' 1,
   ext1,
   rw [set.mem_image, set.mem_set_of_eq],

--- a/src/ring_theory/graded_algebra/radical.lean
+++ b/src/ring_theory/graded_algebra/radical.lean
@@ -145,9 +145,9 @@ lemma ideal.is_homogeneous.is_prime_iff {I : ideal A} (h : I.is_homogeneous 𝒜
     h.is_prime_of_homogeneous_mem_or_mem I_ne_top @homogeneous_mem_or_mem⟩
 
 lemma ideal.is_prime.homogeneous_core {I : ideal A} (h : I.is_prime) :
-  (I.homogeneous_core 𝒜 : ideal A).is_prime :=
+  (I.homogeneous_core 𝒜).to_ideal.is_prime :=
 begin
-  apply (ideal.homogeneous_core 𝒜 I).prop.is_prime_of_homogeneous_mem_or_mem,
+  apply (ideal.homogeneous_core 𝒜 I).is_homogeneous.is_prime_of_homogeneous_mem_or_mem,
   { exact ne_top_of_le_ne_top h.ne_top (ideal.coe_homogeneous_core_le 𝒜 I) },
   rintros x y hx hy hxy,
   have H := h.mem_or_mem (ideal.coe_homogeneous_core_le 𝒜 I hxy),
@@ -164,23 +164,27 @@ begin
   { exact Inf_le_Inf (λ J, and.right), },
   { refine Inf_le_Inf_of_forall_exists_le _,
     rintros J ⟨HJ₁, HJ₂⟩,
-    refine ⟨J.homogeneous_core 𝒜, _, J.coe_homogeneous_core_le _⟩,
-    refine ⟨subtype.prop _, _, HJ₂.homogeneous_core⟩,
+    refine ⟨(J.homogeneous_core 𝒜).to_ideal, _, J.coe_homogeneous_core_le _⟩,
+    refine ⟨homogeneous_ideal.is_homogeneous _, _, HJ₂.homogeneous_core⟩,
     refine hI.coe_homogeneous_core_eq_self.symm.trans_le (ideal.homogeneous_core_mono _ HJ₁), }
 end
 
 lemma ideal.is_homogeneous.radical {I : ideal A} (h : I.is_homogeneous 𝒜)  :
   I.radical.is_homogeneous 𝒜 :=
 begin
-  convert (Inf {J : homogeneous_ideal 𝒜 | I ≤ J.val ∧ J.val.is_prime}).prop using 2,
-  simp_rw [h.radical_eq, homogeneous_ideal.coe_Inf, subtype.coe_image, set.mem_set_of_eq,
-    exists_prop]
+  convert (Inf {J : homogeneous_ideal 𝒜 | I ≤ J.to_ideal ∧ J.to_ideal.is_prime}).is_homogeneous
+    using 2,
+  simp_rw [h.radical_eq, homogeneous_ideal.coe_Inf],
+  congr' 1,
+  ext1,
+  rw [set.mem_image, set.mem_set_of_eq],
+  exact ⟨λ h, ⟨⟨x, h.1⟩, h.2, rfl⟩, by { rintro ⟨x, ⟨h1, h2⟩, rfl⟩, exact ⟨x.2, h1, h2⟩ }⟩
 end
 
 /-- The radical of a homogenous ideal, as another homogenous ideal. -/
 def homogeneous_ideal.radical (I : homogeneous_ideal 𝒜) : homogeneous_ideal 𝒜 :=
-⟨(I : ideal A).radical, I.prop.radical⟩
+⟨I.to_ideal.radical, I.is_homogeneous.radical⟩
 
 @[simp]
 lemma homogeneous_ideal.coe_radical (I : homogeneous_ideal 𝒜) :
-  (I.radical : ideal A) = (I : ideal A).radical := rfl
+  I.radical.to_ideal = I.to_ideal.radical := rfl


### PR DESCRIPTION
We refactored `homogeneous_ideal` as a structure extending ideals so that we can define a `set_like (homogeneous_ideal \McA) A` instance.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
