### PR TITLE
[Merged by Bors] - perf(analysis/convec/topology): remove topological_add_group.path_connected instance

### DIFF
--- a/src/analysis/convex/topology.lean
+++ b/src/analysis/convex/topology.lean
@@ -283,6 +283,10 @@ by simp only [metric.diam, convex_hull_ediam]
 by simp only [metric.bounded_iff_ediam_ne_top, convex_hull_ediam]
 
 @[priority 100]
+instance normed_space.path_connected : path_connected_space E :=
+topological_add_group.path_connected
+
+@[priority 100]
 instance normed_space.loc_path_connected : loc_path_connected_space E :=
 loc_path_connected_of_bases (λ x, metric.nhds_basis_ball)
   (λ x r r_pos, (convex_ball x r).is_path_connected $ by simp [r_pos])

--- a/src/analysis/convex/topology.lean
+++ b/src/analysis/convex/topology.lean
@@ -206,8 +206,12 @@ begin
     (line_map_apply_one _ _) H
 end
 
-@[priority 100]
-instance topological_add_group.path_connected : path_connected_space E :=
+/--
+Every topological vector space over ℝ is path connected.
+
+Not an instance, because it creates enormous TC subproblems (turn on `pp.all`).
+-/
+lemma topological_add_group.path_connected : path_connected_space E :=
 path_connected_space_iff_univ.mpr $ convex_univ.is_path_connected ⟨(0 : E), trivial⟩
 
 end has_continuous_smul

--- a/src/tactic/lint/type_classes.lean
+++ b/src/tactic/lint/type_classes.lean
@@ -257,7 +257,7 @@ Some instances take quite some time to fail, and we seem to run against the cach
 https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/odd.20repeated.20type.20class.20search
 -/
 @[linter] meta def linter.fails_quickly : linter :=
-{ test := fails_quickly 10000,
+{ test := fails_quickly 15000,
   auto_decls := tt,
   no_errors_found := "No type-class searches timed out.",
   errors_found := "TYPE CLASS SEARCHES TIMED OUT.

--- a/src/tactic/lint/type_classes.lean
+++ b/src/tactic/lint/type_classes.lean
@@ -257,7 +257,7 @@ Some instances take quite some time to fail, and we seem to run against the cach
 https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/odd.20repeated.20type.20class.20search
 -/
 @[linter] meta def linter.fails_quickly : linter :=
-{ test := fails_quickly 15000,
+{ test := fails_quickly 10000,
   auto_decls := tt,
   no_errors_found := "No type-class searches timed out.",
   errors_found := "TYPE CLASS SEARCHES TIMED OUT.


### PR DESCRIPTION
The linter was right in #10011 and `topological_add_group.path_connected` should not be an instance, because it creates enormous TC subproblems (turn on `pp.all` to get an idea of what's going on).

Apparently the instance isn't even used in mathlib.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
