### PR TITLE
[Merged by Bors] - feat(group_theory/abelianization): An application of the three subgroups lemma

### DIFF
--- a/src/group_theory/abelianization.lean
+++ b/src/group_theory/abelianization.lean
@@ -43,7 +43,7 @@ lemma commutator_eq_normal_closure :
   commutator G = subgroup.normal_closure {g | ∃ g₁ g₂ : G, ⁅g₁, g₂⁆ = g} :=
 by simp_rw [commutator, subgroup.commutator_def', subgroup.mem_top, exists_true_left]
 
-lemma commutator_centralizer_commutator_le_center (G : Type*) [group G] :
+lemma commutator_centralizer_commutator_le_center :
   ⁅(commutator G).centralizer, (commutator G).centralizer⁆ ≤ subgroup.center G :=
 begin
   rw [←subgroup.centralizer_top, ←subgroup.commutator_eq_bot_iff_le_centralizer],

--- a/src/group_theory/abelianization.lean
+++ b/src/group_theory/abelianization.lean
@@ -43,6 +43,17 @@ lemma commutator_eq_normal_closure :
   commutator G = subgroup.normal_closure {g | ∃ g₁ g₂ : G, ⁅g₁, g₂⁆ = g} :=
 by simp_rw [commutator, subgroup.commutator_def', subgroup.mem_top, exists_true_left]
 
+lemma commutator_centralizer_commutator_le_center (G : Type*) [group G] :
+  ⁅(commutator G).centralizer, (commutator G).centralizer⁆ ≤ subgroup.center G :=
+begin
+  rw [←subgroup.centralizer_top, ←subgroup.commutator_eq_bot_iff_le_centralizer],
+  suffices : ⁅⁅⊤, (commutator G).centralizer⁆, (commutator G).centralizer⁆ = ⊥,
+  { refine subgroup.commutator_commutator_eq_bot_of_rotate _ this,
+    rwa subgroup.commutator_comm (commutator G).centralizer },
+  rw [subgroup.commutator_comm, subgroup.commutator_eq_bot_iff_le_centralizer],
+  exact set.centralizer_subset (subgroup.commutator_mono le_top le_top),
+end
+
 /-- The abelianization of G is the quotient of G by its commutator subgroup. -/
 def abelianization : Type u :=
 G ⧸ (commutator G)


### PR DESCRIPTION
This PR uses the three subgroups lemma to prove that `⁅(commutator G).centralizer, (commutator G).centralizer⁆ ≤ subgroup.center G`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
