### PR TITLE
[Merged by Bors] - chore(analysis/complex/upper_half_plane): don't use `abbreviation`

### DIFF
--- a/src/analysis/complex/upper_half_plane.lean
+++ b/src/analysis/complex/upper_half_plane.lean
@@ -35,8 +35,8 @@ local attribute [-instance] matrix.special_linear_group.has_coe_to_fun
 local prefix `↑ₘ`:1024 := @coe _ (matrix (fin 2) (fin 2) _) _
 
 /-- The open upper half plane -/
-abbreviation upper_half_plane :=
-{point : ℂ // 0 < point.im}
+@[derive [topological_space, λ α, has_coe α ℂ]]
+def upper_half_plane := {point : ℂ // 0 < point.im}
 
 localized "notation `ℍ` := upper_half_plane" in upper_half_plane
 

--- a/src/analysis/complex/upper_half_plane.lean
+++ b/src/analysis/complex/upper_half_plane.lean
@@ -42,6 +42,8 @@ localized "notation `ℍ` := upper_half_plane" in upper_half_plane
 
 namespace upper_half_plane
 
+instance : inhabited ℍ := ⟨⟨complex.I, by simp⟩⟩
+
 /-- Imaginary part -/
 def im (z : ℍ) := (z : ℂ).im
 


### PR DESCRIPTION
Some day we should add Poincaré metric as a `metric_space` instance on `upper_half_plane`.
In the meantime, make sure that Lean doesn't use `subtype` instances for `uniform_space` and/or `metric_space`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
