### PR TITLE
[Merged by Bors] - feat(linear_algebra/matrix/determinant): special case of the matrix determinant lemma

### DIFF
--- a/src/linear_algebra/matrix/determinant.lean
+++ b/src/linear_algebra/matrix/determinant.lean
@@ -574,7 +574,7 @@ end
 /-- The determinant of a 2x2 block matrix with the lower-left block equal to zero is the product of
 the determinants of the diagonal blocks. For the generalization to any number of blocks, see
 `matrix.det_of_upper_triangular`. -/
-lemma upper_two_block_triangular_det
+@[simp] lemma upper_two_block_triangular_det
   (A : matrix m m R) (B : matrix m n R) (D : matrix n n R) :
   (matrix.from_blocks A B 0 D).det = A.det * D.det :=
 begin
@@ -631,7 +631,7 @@ end
 /-- The determinant of a 2x2 block matrix with the upper-right block equal to zero is the product of
 the determinants of the diagonal blocks. For the generalization to any number of blocks, see
 `matrix.det_of_lower_triangular`. -/
-lemma lower_two_block_triangular_det
+@[simp] lemma lower_two_block_triangular_det
   (A : matrix m m R) (C : matrix n m R) (D : matrix n n R) :
   (matrix.from_blocks A 0 C D).det = A.det * D.det :=
 by rw [←det_transpose, from_blocks_transpose, transpose_zero, upper_two_block_triangular_det,
@@ -640,18 +640,16 @@ by rw [←det_transpose, from_blocks_transpose, transpose_zero, upper_two_block_
 /-- A special case of the **Matrix determinant lemma** for when `A = I`.
 
 TODO: show this more generally. -/
-lemma det_one_add_col_mul_row {u v : m → R} :
-  det (1 + col u ⬝ row v) = 1 + v ⬝ᵥ u :=
+lemma det_one_add_col_mul_row (u v : m → R) : det (1 + col u ⬝ row v) = 1 + v ⬝ᵥ u :=
 calc  det (1 + col u ⬝ row v)
     = det (from_blocks 1 0 (row v) 1
-      ⬝ from_blocks (1 + col u ⬝ row v) (col u) 0 (1 : matrix unit unit R)
-      ⬝ from_blocks 1 0 (-row v) 1) :
+         ⬝ from_blocks (1 + col u ⬝ row v) (col u) 0 (1 : matrix unit unit R)
+         ⬝ from_blocks 1 0 (-row v) 1) :
   by simp only [matrix.det_mul, upper_two_block_triangular_det, lower_two_block_triangular_det,
-                      det_one, one_mul, mul_one]
+                det_one, one_mul, mul_one]
 ... = det (from_blocks 1 (col u) 0 (1 + row v ⬝ col u)) :
-        congr_arg _ $
-  by simp [from_blocks_multiply, matrix.mul_add, matrix.add_mul, ←matrix.mul_assoc, ←neg_add_rev,
-    add_comm]
+  congr_arg _ $ by simp [from_blocks_multiply, matrix.mul_add, matrix.add_mul, ←matrix.mul_assoc,
+                         ←neg_add_rev, add_comm]
 ... = det (1 + row v ⬝ col u) : by rw [upper_two_block_triangular_det, det_one, one_mul]
 ... = 1 + v ⬝ᵥ u : by simp
 

--- a/src/linear_algebra/matrix/determinant.lean
+++ b/src/linear_algebra/matrix/determinant.lean
@@ -573,7 +573,7 @@ end
 
 /-- The determinant of a 2x2 block matrix with the lower-left block equal to zero is the product of
 the determinants of the diagonal blocks. For the generalization to any number of blocks, see
-`matrix.upper_block_triangular_det`. -/
+`matrix.det_of_upper_triangular`. -/
 lemma upper_two_block_triangular_det
   (A : matrix m m R) (B : matrix m n R) (D : matrix n n R) :
   (matrix.from_blocks A B 0 D).det = A.det * D.det :=
@@ -627,6 +627,33 @@ begin
     { rw [finset.prod_eq_zero (finset.mem_univ (sum.inl a)), mul_zero],
       rw [hx, from_blocks_apply₂₁], refl }}
 end
+
+/-- The determinant of a 2x2 block matrix with the upper-right block equal to zero is the product of
+the determinants of the diagonal blocks. For the generalization to any number of blocks, see
+`matrix.det_of_lower_triangular`. -/
+lemma lower_two_block_triangular_det
+  (A : matrix m m R) (C : matrix n m R) (D : matrix n n R) :
+  (matrix.from_blocks A 0 C D).det = A.det * D.det :=
+by rw [←det_transpose, from_blocks_transpose, transpose_zero, upper_two_block_triangular_det,
+  det_transpose, det_transpose]
+
+/-- A special case of the **Matrix determinant lemma** for when `A = I`.
+
+TODO: show this more generally. -/
+lemma det_one_add_col_mul_row {u v : m → R} :
+  det (1 + col u ⬝ row v) = 1 + v ⬝ᵥ u :=
+calc  det (1 + col u ⬝ row v)
+    = det (from_blocks 1 0 (row v) 1
+      ⬝ from_blocks (1 + col u ⬝ row v) (col u) 0 (1 : matrix unit unit R)
+      ⬝ from_blocks 1 0 (-row v) 1) :
+  by simp only [matrix.det_mul, upper_two_block_triangular_det, lower_two_block_triangular_det,
+                      det_one, one_mul, mul_one]
+... = det (from_blocks 1 (col u) 0 (1 + row v ⬝ col u)) :
+        congr_arg _ $
+  by simp [from_blocks_multiply, matrix.mul_add, matrix.add_mul, ←matrix.mul_assoc, ←neg_add_rev,
+    add_comm]
+... = det (1 + row v ⬝ col u) : by rw [upper_two_block_triangular_det, det_one, one_mul]
+... = 1 + v ⬝ᵥ u : by simp
 
 /-- Laplacian expansion of the determinant of an `n+1 × n+1` matrix along column 0. -/
 lemma det_succ_column_zero {n : ℕ} (A : matrix (fin n.succ) (fin n.succ) R) :


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)

I've not had much practice formatting calc proofs, comments appreciated.

The more general case, `det (A + col u ⬝ row v) = det A + det (row v ⬝ A.adjugate ⬝ col u)`, requires a lot of messy polynomial manipulation to avoid invertibility issues, it seems. Either we prove it via:

* "Proof of Theorem 7.262" from https://github.com/darijgr/detnotes/releases/download/2019-01-10/sols.pdf, which is lots of annoying combinatorics
* The polynomial trick shown in https://math.stackexchange.com/a/1639020/1896