### PR TITLE
[Merged by Bors] - feat(topology/continuous_function/units): basic results about units in `C(α, β)`

### DIFF
--- a/src/topology/continuous_function/units.lean
+++ b/src/topology/continuous_function/units.lean
@@ -14,38 +14,41 @@ This file concerns itself with `C(α, β)ˣ` and `C(α, βˣ)` when `α` is a to
 and `β` is a normed ring.
 -/
 
+variables {α β : Type*} [topological_space α]
+
 namespace continuous_map
 
-section units
+section monoid
 
-section normed_ring
-
-variables {α : Type*} [topological_space α] {β : Type*} [normed_ring β]
+variables [monoid β] [topological_space β] [has_continuous_mul β]
 
 /-- Equivalence between continuous maps into the units of a normed ring the
 the units of the ring of continuous functions. -/
-@[simps]
+@[to_additive add_units_lift, simps]
 def units_lift : C(α, βˣ) ≃ C(α, β)ˣ :=
 { to_fun := λ f,
-  { val := ⟨coe ∘ f, units.continuous_coe.comp f.continuous⟩,
+  { val := ⟨λ x, f x, units.continuous_coe.comp f.continuous⟩,
     inv := ⟨λ x, ↑(f x)⁻¹, units.continuous_coe.comp (continuous_inv.comp f.continuous)⟩,
-    val_inv := by { ext, simp only [coe_mul, coe_mk, pi.mul_apply, units.mul_inv, coe_one,
-      pi.one_apply] },
-    inv_val := by { ext, simp only [coe_mul, coe_mk, pi.mul_apply, units.inv_mul, coe_one,
-      pi.one_apply]} },
+    val_inv := ext $ λ x, units.mul_inv _,
+    inv_val := ext $ λ x, units.inv_mul _ },
   inv_fun := λ f,
-  { to_fun := λ x, ⟨f x, f⁻¹ x, (f.val.coe_mul f.inv ▸ continuous_map.congr_fun f.val_inv x),
-                                (f.inv.coe_mul f.val ▸ continuous_map.congr_fun f.inv_val x)⟩,
-    continuous_to_fun := continuous_induced_rng (continuous.prod_mk (f : C(α, β)).continuous
-      $ mul_opposite.continuous_op.comp (continuous_map.continuous (f⁻¹ : C(α, β)ˣ))) },
+  { to_fun := λ x, ⟨f x, f⁻¹ x, continuous_map.congr_fun f.mul_inv x,
+                                continuous_map.congr_fun f.inv_mul x⟩,
+    continuous_to_fun := continuous_induced_rng $ continuous.prod_mk (f : C(α, β)).continuous
+      $ mul_opposite.continuous_op.comp (↑f⁻¹ : C(α, β)).continuous },
   left_inv := λ f, by { ext, refl },
   right_inv := λ f, by { ext, refl } }
+
+end monoid
+
+section normed_ring
+
+variables [normed_ring β] [complete_space β]
 
 /-- Construct a continuous map into the group of units of a normed ring from a function into the
 normed ring and a proof that every element of the range is a unit. -/
 @[simps]
-noncomputable def units_of_forall_is_unit [complete_space β] {f : C(α, β)}
-  (h : ∀ x, is_unit (f x)) : C(α, βˣ) :=
+noncomputable def units_of_forall_is_unit {f : C(α, β)} (h : ∀ x, is_unit (f x)) : C(α, βˣ) :=
 { to_fun := λ x, (h x).unit,
   continuous_to_fun :=
   begin
@@ -56,26 +59,21 @@ noncomputable def units_of_forall_is_unit [complete_space β] {f : C(α, β)}
     exact this.comp (f.continuous_at x),
   end }
 
-instance [complete_space β] : can_lift C(α, β) C(α, βˣ) :=
-{ coe := λ f, ⟨coe ∘ f, units.continuous_coe.comp f.continuous⟩,
+instance : can_lift C(α, β) C(α, βˣ) :=
+{ coe := λ f, ⟨λ x, f x, units.continuous_coe.comp f.continuous⟩,
   cond := λ f, ∀ x, is_unit (f x),
   prf := λ f h, ⟨units_of_forall_is_unit h, by { ext, refl }⟩ }
 
-lemma is_unit_iff_forall_is_unit [complete_space β] (f : C(α, β)) :
+lemma is_unit_iff_forall_is_unit (f : C(α, β)) :
   is_unit f ↔ ∀ x, is_unit (f x) :=
-begin
-  refine iff.intro (λ h, _) (λ h, _),
-  { lift f to C(α, β)ˣ using h,
-    exact λ x, ⟨⟨f x, f⁻¹ x, (f.val.coe_mul f.inv ▸ continuous_map.congr_fun f.val_inv x),
-                             (f.inv.coe_mul f.val ▸ continuous_map.congr_fun f.inv_val x)⟩, rfl⟩ },
-  { refine ⟨(units_of_forall_is_unit h).units_lift, by { ext, refl }⟩ }
-end
+iff.intro (λ h, λ x, ⟨units_lift.symm h.unit x, rfl⟩)
+  (λ h, ⟨(units_of_forall_is_unit h).units_lift, by { ext, refl }⟩)
 
 end normed_ring
 
 section normed_field
 
-variables {α : Type*} [topological_space α] {𝕜 : Type*} [normed_field 𝕜] [complete_space 𝕜]
+variables {𝕜 : Type*} [normed_field 𝕜] [complete_space 𝕜]
 
 lemma is_unit_iff_forall_ne_zero (f : C(α, 𝕜)) :
   is_unit f ↔ ∀ x, f x ≠ 0 :=
@@ -88,7 +86,5 @@ by { ext, simp only [spectrum.mem_iff, is_unit_iff_forall_ne_zero, not_forall, c
        sub_eq_zero, @eq_comm _ x _] }
 
 end normed_field
-
-end units
 
 end continuous_map

--- a/src/topology/continuous_function/units.lean
+++ b/src/topology/continuous_function/units.lean
@@ -24,7 +24,7 @@ variables [monoid β] [topological_space β] [has_continuous_mul β]
 
 /-- Equivalence between continuous maps into the units of a monoid with continuous multiplication
 and the units of the monoid of continuous maps. -/
-@[to_additive add_units_lift, simps]
+@[to_additive, simps]
 def units_lift : C(α, βˣ) ≃ C(α, β)ˣ :=
 { to_fun := λ f,
   { val := ⟨λ x, f x, units.continuous_coe.comp f.continuous⟩,

--- a/src/topology/continuous_function/units.lean
+++ b/src/topology/continuous_function/units.lean
@@ -11,7 +11,7 @@ import algebra.algebra.spectrum
 # Units of continuous functions
 
 This file concerns itself with `C(α, β)ˣ` and `C(α, βˣ)` when `α` is a topological space
-and `β` is a normed ring.
+and `β` has an appropriate algebraic and topological structure.
 -/
 
 variables {α β : Type*} [topological_space α]
@@ -22,8 +22,8 @@ section monoid
 
 variables [monoid β] [topological_space β] [has_continuous_mul β]
 
-/-- Equivalence between continuous maps into the units of a normed ring the
-the units of the ring of continuous functions. -/
+/-- Equivalence between continuous maps into the units of a monoid with continuous multiplication
+and the units of the monoid of continuous maps. -/
 @[to_additive add_units_lift, simps]
 def units_lift : C(α, βˣ) ≃ C(α, β)ˣ :=
 { to_fun := λ f,

--- a/src/topology/continuous_function/units.lean
+++ b/src/topology/continuous_function/units.lean
@@ -24,7 +24,8 @@ variables [monoid β] [topological_space β] [has_continuous_mul β]
 
 /-- Equivalence between continuous maps into the units of a monoid with continuous multiplication
 and the units of the monoid of continuous maps. -/
-@[to_additive, simps]
+@[to_additive "Equivalence between continuous maps into the additive units of an additive monoid
+with continuous addition and the additive units of the additive monoid of continuous maps.", simps]
 def units_lift : C(α, βˣ) ≃ C(α, β)ˣ :=
 { to_fun := λ f,
   { val := ⟨λ x, f x, units.continuous_coe.comp f.continuous⟩,

--- a/src/topology/continuous_function/units.lean
+++ b/src/topology/continuous_function/units.lean
@@ -1,0 +1,90 @@
+/-
+Copyright (c) 2022 Jireh Loreaux. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Jireh Loreaux
+-/
+import topology.continuous_function.compact
+import analysis.normed_space.units
+import algebra.algebra.spectrum
+
+/-!
+# Units of continuous functions
+
+This file concerns itself with `C(α, β)ˣ` and `C(α, βˣ)` when `α` is a topological space
+and `β` is a normed ring.
+-/
+
+section units
+
+section normed_ring
+
+variables {α : Type*} [topological_space α] {β : Type*} [normed_ring β]
+
+/-- Equivalence between continuous maps into the units of a normed ring the
+the units of the ring of continuous functions. -/
+@[simps]
+def continuous_map.units_lift : C(α, βˣ) ≃ C(α, β)ˣ :=
+{ to_fun := λ f,
+  { val := ⟨coe ∘ f, units.continuous_coe.comp f.continuous⟩,
+    inv := ⟨λ x, ↑(f x)⁻¹, units.continuous_coe.comp (continuous_inv.comp f.continuous)⟩,
+    val_inv := by { ext, simp only [continuous_map.coe_mul, continuous_map.coe_mk, pi.mul_apply,
+      units.mul_inv, continuous_map.coe_one, pi.one_apply] },
+    inv_val := by { ext, simp only [continuous_map.coe_mul, continuous_map.coe_mk, pi.mul_apply,
+      units.inv_mul, continuous_map.coe_one, pi.one_apply]} },
+  inv_fun := λ f,
+  { to_fun := λ x, ⟨f x, f⁻¹ x, (f.val.coe_mul f.inv ▸ continuous_map.congr_fun f.val_inv x),
+                                (f.inv.coe_mul f.val ▸ continuous_map.congr_fun f.inv_val x)⟩,
+    continuous_to_fun := continuous_induced_rng (continuous.prod_mk (f : C(α, β)).continuous
+      $ mul_opposite.continuous_op.comp (continuous_map.continuous (f⁻¹ : C(α, β)ˣ))) },
+  left_inv := λ f, by { ext, refl },
+  right_inv := λ f, by { ext, refl } }
+
+/-- Construct a continuous map into the group of units of a normed ring from a function into the
+normed ring and a proof that every element of the range is a unit. -/
+@[simps]
+noncomputable def continuous_map.units_of_forall_is_unit [complete_space β] {f : C(α, β)}
+  (h : ∀ x, is_unit (f x)) : C(α, βˣ) :=
+{ to_fun := λ x, (h x).unit,
+  continuous_to_fun :=
+  begin
+    refine continuous_induced_rng (continuous.prod_mk f.continuous
+      (mul_opposite.continuous_op.comp (continuous_iff_continuous_at.mpr (λ x, _)))),
+    have := normed_ring.inverse_continuous_at (h x).unit,
+    simp only [←ring.inverse_unit, is_unit.unit_spec, ←function.comp_apply] at this ⊢,
+    exact this.comp (f.continuous_at x),
+  end }
+
+instance [complete_space β] : can_lift C(α, β) C(α, βˣ) :=
+{ coe := λ f, ⟨coe ∘ f, units.continuous_coe.comp f.continuous⟩,
+  cond := λ f, ∀ x, is_unit (f x),
+  prf := λ f h, ⟨continuous_map.units_of_forall_is_unit h, by { ext, refl }⟩ }
+
+lemma continuous_map.is_unit_iff_forall_is_unit [complete_space β] (f : C(α, β)) :
+  is_unit f ↔ ∀ x, is_unit (f x) :=
+begin
+  refine iff.intro (λ h, _) (λ h, _),
+  { lift f to C(α, β)ˣ using h,
+    exact λ x, ⟨⟨f x, f⁻¹ x, (f.val.coe_mul f.inv ▸ continuous_map.congr_fun f.val_inv x),
+                             (f.inv.coe_mul f.val ▸ continuous_map.congr_fun f.inv_val x)⟩, rfl⟩ },
+  { refine ⟨(continuous_map.units_of_forall_is_unit h).units_lift, by { ext, refl }⟩ }
+end
+
+end normed_ring
+
+section normed_field
+
+variables {α : Type*} [topological_space α] {𝕜 : Type*} [normed_field 𝕜] [complete_space 𝕜]
+
+lemma continuous_map.is_unit_iff_forall_ne_zero (f : C(α, 𝕜)) :
+  is_unit f ↔ ∀ x, f x ≠ 0 :=
+by simp_rw [f.is_unit_iff_forall_is_unit, is_unit_iff_ne_zero]
+
+lemma continuous_map.spectrum_eq_range (f : C(α, 𝕜)) :
+  spectrum 𝕜 f = set.range f :=
+by { ext, simp only [spectrum.mem_iff, continuous_map.is_unit_iff_forall_ne_zero, not_forall,
+       continuous_map.coe_sub, pi.sub_apply, algebra_map_apply, algebra.id.smul_eq_mul,
+       mul_one, not_not, set.mem_range, sub_eq_zero, @eq_comm _ x _] }
+
+end normed_field
+
+end units

--- a/src/topology/continuous_function/units.lean
+++ b/src/topology/continuous_function/units.lean
@@ -82,9 +82,12 @@ by simp_rw [f.is_unit_iff_forall_is_unit, is_unit_iff_ne_zero]
 
 lemma spectrum_eq_range (f : C(α, 𝕜)) :
   spectrum 𝕜 f = set.range f :=
-by { ext, simp only [spectrum.mem_iff, is_unit_iff_forall_ne_zero, not_forall, coe_sub,
-       pi.sub_apply, algebra_map_apply, algebra.id.smul_eq_mul, mul_one, not_not, set.mem_range,
-       sub_eq_zero, @eq_comm _ x _] }
+begin
+  ext,
+  simp only [spectrum.mem_iff, is_unit_iff_forall_ne_zero, not_forall, coe_sub,
+    pi.sub_apply, algebra_map_apply, algebra.id.smul_eq_mul, mul_one, not_not, set.mem_range,
+    sub_eq_zero, @eq_comm _ x _]
+end
 
 end normed_field
 

--- a/src/topology/continuous_function/units.lean
+++ b/src/topology/continuous_function/units.lean
@@ -46,19 +46,22 @@ section normed_ring
 
 variables [normed_ring β] [complete_space β]
 
+lemma _root_.normed_ring.is_unit_unit_continuous {f : C(α, β)} (h : ∀ x, is_unit (f x)) :
+  continuous (λ x, (h x).unit) :=
+begin
+  refine continuous_induced_rng (continuous.prod_mk f.continuous
+    (mul_opposite.continuous_op.comp (continuous_iff_continuous_at.mpr (λ x, _)))),
+  have := normed_ring.inverse_continuous_at (h x).unit,
+  simp only [←ring.inverse_unit, is_unit.unit_spec, ←function.comp_apply] at this ⊢,
+  exact this.comp (f.continuous_at x),
+end
+
 /-- Construct a continuous map into the group of units of a normed ring from a function into the
 normed ring and a proof that every element of the range is a unit. -/
 @[simps]
 noncomputable def units_of_forall_is_unit {f : C(α, β)} (h : ∀ x, is_unit (f x)) : C(α, βˣ) :=
 { to_fun := λ x, (h x).unit,
-  continuous_to_fun :=
-  begin
-    refine continuous_induced_rng (continuous.prod_mk f.continuous
-      (mul_opposite.continuous_op.comp (continuous_iff_continuous_at.mpr (λ x, _)))),
-    have := normed_ring.inverse_continuous_at (h x).unit,
-    simp only [←ring.inverse_unit, is_unit.unit_spec, ←function.comp_apply] at this ⊢,
-    exact this.comp (f.continuous_at x),
-  end }
+  continuous_to_fun :=  normed_ring.is_unit_unit_continuous h }
 
 instance : can_lift C(α, β) C(α, βˣ) :=
 { coe := λ f, ⟨λ x, f x, units.continuous_coe.comp f.continuous⟩,

--- a/src/topology/continuous_function/units.lean
+++ b/src/topology/continuous_function/units.lean
@@ -10,23 +10,23 @@ import algebra.algebra.spectrum
 /-!
 # Units of continuous functions
 
-This file concerns itself with `C(α, β)ˣ` and `C(α, βˣ)` when `α` is a topological space
-and `β` has an appropriate algebraic and topological structure.
+This file concerns itself with `C(X, M)ˣ` and `C(X, Mˣ)` when `X` is a topological space
+and `M` has some monoid structure compatible with its topology.
 -/
 
-variables {α β : Type*} [topological_space α]
+variables {X M R 𝕜 : Type*} [topological_space X]
 
 namespace continuous_map
 
 section monoid
 
-variables [monoid β] [topological_space β] [has_continuous_mul β]
+variables [monoid M] [topological_space M] [has_continuous_mul M]
 
 /-- Equivalence between continuous maps into the units of a monoid with continuous multiplication
 and the units of the monoid of continuous maps. -/
 @[to_additive "Equivalence between continuous maps into the additive units of an additive monoid
 with continuous addition and the additive units of the additive monoid of continuous maps.", simps]
-def units_lift : C(α, βˣ) ≃ C(α, β)ˣ :=
+def units_lift : C(X, Mˣ) ≃ C(X, M)ˣ :=
 { to_fun := λ f,
   { val := ⟨λ x, f x, units.continuous_coe.comp f.continuous⟩,
     inv := ⟨λ x, ↑(f x)⁻¹, units.continuous_coe.comp (continuous_inv.comp f.continuous)⟩,
@@ -35,8 +35,8 @@ def units_lift : C(α, βˣ) ≃ C(α, β)ˣ :=
   inv_fun := λ f,
   { to_fun := λ x, ⟨f x, f⁻¹ x, continuous_map.congr_fun f.mul_inv x,
                                 continuous_map.congr_fun f.inv_mul x⟩,
-    continuous_to_fun := continuous_induced_rng $ continuous.prod_mk (f : C(α, β)).continuous
-      $ mul_opposite.continuous_op.comp (↑f⁻¹ : C(α, β)).continuous },
+    continuous_to_fun := continuous_induced_rng $ continuous.prod_mk (f : C(X, M)).continuous
+      $ mul_opposite.continuous_op.comp (↑f⁻¹ : C(X, M)).continuous },
   left_inv := λ f, by { ext, refl },
   right_inv := λ f, by { ext, refl } }
 
@@ -44,9 +44,9 @@ end monoid
 
 section normed_ring
 
-variables [normed_ring β] [complete_space β]
+variables [normed_ring R] [complete_space R]
 
-lemma _root_.normed_ring.is_unit_unit_continuous {f : C(α, β)} (h : ∀ x, is_unit (f x)) :
+lemma _root_.normed_ring.is_unit_unit_continuous {f : C(X, R)} (h : ∀ x, is_unit (f x)) :
   continuous (λ x, (h x).unit) :=
 begin
   refine continuous_induced_rng (continuous.prod_mk f.continuous
@@ -59,16 +59,16 @@ end
 /-- Construct a continuous map into the group of units of a normed ring from a function into the
 normed ring and a proof that every element of the range is a unit. -/
 @[simps]
-noncomputable def units_of_forall_is_unit {f : C(α, β)} (h : ∀ x, is_unit (f x)) : C(α, βˣ) :=
+noncomputable def units_of_forall_is_unit {f : C(X, R)} (h : ∀ x, is_unit (f x)) : C(X, Rˣ) :=
 { to_fun := λ x, (h x).unit,
   continuous_to_fun :=  normed_ring.is_unit_unit_continuous h }
 
-instance : can_lift C(α, β) C(α, βˣ) :=
+instance : can_lift C(X, R) C(X, Rˣ) :=
 { coe := λ f, ⟨λ x, f x, units.continuous_coe.comp f.continuous⟩,
   cond := λ f, ∀ x, is_unit (f x),
   prf := λ f h, ⟨units_of_forall_is_unit h, by { ext, refl }⟩ }
 
-lemma is_unit_iff_forall_is_unit (f : C(α, β)) :
+lemma is_unit_iff_forall_is_unit (f : C(X, R)) :
   is_unit f ↔ ∀ x, is_unit (f x) :=
 iff.intro (λ h, λ x, ⟨units_lift.symm h.unit x, rfl⟩)
   (λ h, ⟨(units_of_forall_is_unit h).units_lift, by { ext, refl }⟩)
@@ -77,13 +77,13 @@ end normed_ring
 
 section normed_field
 
-variables {𝕜 : Type*} [normed_field 𝕜] [complete_space 𝕜]
+variables [normed_field 𝕜] [complete_space 𝕜]
 
-lemma is_unit_iff_forall_ne_zero (f : C(α, 𝕜)) :
+lemma is_unit_iff_forall_ne_zero (f : C(X, 𝕜)) :
   is_unit f ↔ ∀ x, f x ≠ 0 :=
 by simp_rw [f.is_unit_iff_forall_is_unit, is_unit_iff_ne_zero]
 
-lemma spectrum_eq_range (f : C(α, 𝕜)) :
+lemma spectrum_eq_range (f : C(X, 𝕜)) :
   spectrum 𝕜 f = set.range f :=
 begin
   ext,

--- a/src/topology/continuous_function/units.lean
+++ b/src/topology/continuous_function/units.lean
@@ -14,6 +14,8 @@ This file concerns itself with `C(α, β)ˣ` and `C(α, βˣ)` when `α` is a to
 and `β` is a normed ring.
 -/
 
+namespace continuous_map
+
 section units
 
 section normed_ring
@@ -23,14 +25,14 @@ variables {α : Type*} [topological_space α] {β : Type*} [normed_ring β]
 /-- Equivalence between continuous maps into the units of a normed ring the
 the units of the ring of continuous functions. -/
 @[simps]
-def continuous_map.units_lift : C(α, βˣ) ≃ C(α, β)ˣ :=
+def units_lift : C(α, βˣ) ≃ C(α, β)ˣ :=
 { to_fun := λ f,
   { val := ⟨coe ∘ f, units.continuous_coe.comp f.continuous⟩,
     inv := ⟨λ x, ↑(f x)⁻¹, units.continuous_coe.comp (continuous_inv.comp f.continuous)⟩,
-    val_inv := by { ext, simp only [continuous_map.coe_mul, continuous_map.coe_mk, pi.mul_apply,
-      units.mul_inv, continuous_map.coe_one, pi.one_apply] },
-    inv_val := by { ext, simp only [continuous_map.coe_mul, continuous_map.coe_mk, pi.mul_apply,
-      units.inv_mul, continuous_map.coe_one, pi.one_apply]} },
+    val_inv := by { ext, simp only [coe_mul, coe_mk, pi.mul_apply, units.mul_inv, coe_one,
+      pi.one_apply] },
+    inv_val := by { ext, simp only [coe_mul, coe_mk, pi.mul_apply, units.inv_mul, coe_one,
+      pi.one_apply]} },
   inv_fun := λ f,
   { to_fun := λ x, ⟨f x, f⁻¹ x, (f.val.coe_mul f.inv ▸ continuous_map.congr_fun f.val_inv x),
                                 (f.inv.coe_mul f.val ▸ continuous_map.congr_fun f.inv_val x)⟩,
@@ -42,7 +44,7 @@ def continuous_map.units_lift : C(α, βˣ) ≃ C(α, β)ˣ :=
 /-- Construct a continuous map into the group of units of a normed ring from a function into the
 normed ring and a proof that every element of the range is a unit. -/
 @[simps]
-noncomputable def continuous_map.units_of_forall_is_unit [complete_space β] {f : C(α, β)}
+noncomputable def units_of_forall_is_unit [complete_space β] {f : C(α, β)}
   (h : ∀ x, is_unit (f x)) : C(α, βˣ) :=
 { to_fun := λ x, (h x).unit,
   continuous_to_fun :=
@@ -57,16 +59,16 @@ noncomputable def continuous_map.units_of_forall_is_unit [complete_space β] {f 
 instance [complete_space β] : can_lift C(α, β) C(α, βˣ) :=
 { coe := λ f, ⟨coe ∘ f, units.continuous_coe.comp f.continuous⟩,
   cond := λ f, ∀ x, is_unit (f x),
-  prf := λ f h, ⟨continuous_map.units_of_forall_is_unit h, by { ext, refl }⟩ }
+  prf := λ f h, ⟨units_of_forall_is_unit h, by { ext, refl }⟩ }
 
-lemma continuous_map.is_unit_iff_forall_is_unit [complete_space β] (f : C(α, β)) :
+lemma is_unit_iff_forall_is_unit [complete_space β] (f : C(α, β)) :
   is_unit f ↔ ∀ x, is_unit (f x) :=
 begin
   refine iff.intro (λ h, _) (λ h, _),
   { lift f to C(α, β)ˣ using h,
     exact λ x, ⟨⟨f x, f⁻¹ x, (f.val.coe_mul f.inv ▸ continuous_map.congr_fun f.val_inv x),
                              (f.inv.coe_mul f.val ▸ continuous_map.congr_fun f.inv_val x)⟩, rfl⟩ },
-  { refine ⟨(continuous_map.units_of_forall_is_unit h).units_lift, by { ext, refl }⟩ }
+  { refine ⟨(units_of_forall_is_unit h).units_lift, by { ext, refl }⟩ }
 end
 
 end normed_ring
@@ -75,16 +77,18 @@ section normed_field
 
 variables {α : Type*} [topological_space α] {𝕜 : Type*} [normed_field 𝕜] [complete_space 𝕜]
 
-lemma continuous_map.is_unit_iff_forall_ne_zero (f : C(α, 𝕜)) :
+lemma is_unit_iff_forall_ne_zero (f : C(α, 𝕜)) :
   is_unit f ↔ ∀ x, f x ≠ 0 :=
 by simp_rw [f.is_unit_iff_forall_is_unit, is_unit_iff_ne_zero]
 
-lemma continuous_map.spectrum_eq_range (f : C(α, 𝕜)) :
+lemma spectrum_eq_range (f : C(α, 𝕜)) :
   spectrum 𝕜 f = set.range f :=
-by { ext, simp only [spectrum.mem_iff, continuous_map.is_unit_iff_forall_ne_zero, not_forall,
-       continuous_map.coe_sub, pi.sub_apply, algebra_map_apply, algebra.id.smul_eq_mul,
-       mul_one, not_not, set.mem_range, sub_eq_zero, @eq_comm _ x _] }
+by { ext, simp only [spectrum.mem_iff, is_unit_iff_forall_ne_zero, not_forall, coe_sub,
+       pi.sub_apply, algebra_map_apply, algebra.id.smul_eq_mul, mul_one, not_not, set.mem_range,
+       sub_eq_zero, @eq_comm _ x _] }
 
 end normed_field
 
 end units
+
+end continuous_map


### PR DESCRIPTION
This establishes a few facts about units in `C(α, β)` including the equivalence `C(α, βˣ) ≃ C(α, β)ˣ`. Moreover, when `β` is a complete normed field, we show that the spectrum of `f : C(α, β)` is precisely `set.range f`.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
