### PR TITLE
[Merged by Bors] - feat(number_theory/arithmetic_function): add eq of multiplicative functions

### DIFF
--- a/src/number_theory/arithmetic_function.lean
+++ b/src/number_theory/arithmetic_function.lean
@@ -569,28 +569,19 @@ they agree on prime powers -/
 lemma eq_iff_eq_on_prime_powers [comm_monoid_with_zero R]
   (f : arithmetic_function R) (hf : f.is_multiplicative)
   (g : arithmetic_function R) (hg : g.is_multiplicative) :
-  f = g ↔ ∀ (p i : ℕ), nat.prime p → f(p ^ i) = g(p ^ i) :=
+  f = g ↔ ∀ (p i : ℕ), nat.prime p → f (p ^ i) = g (p ^ i) :=
 begin
   split,
-  intros h p i _,
-  simp only [h],
+  { intros h p i _, rw [h] },
   intros h,
   ext n,
   by_cases hn : n = 0,
-  rw [hn, arithmetic_function.map_zero, arithmetic_function.map_zero],
-  rw nat.multiplicative_factorization f (λ x y, (λ hxy, hf.map_mul_of_coprime hxy)) hf.map_one hn,
-  rw nat.multiplicative_factorization g (λ x y, (λ hxy, hg.map_mul_of_coprime hxy)) hg.map_one hn,
-
-  have : n.factorization.support ⊆ n.factors.to_finset, simp,
-  rw finsupp.prod_of_support_subset n.factorization this,
-  rw finsupp.prod_of_support_subset n.factorization this,
-  apply prod_congr rfl,
+  { rw [hn, arithmetic_function.map_zero, arithmetic_function.map_zero] },
+  rw [multiplicative_factorization f hf hn, multiplicative_factorization g hg hn],
+  refine finset.prod_congr rfl _,
+  simp only [support_factorization, list.mem_to_finset],
   intros p hp,
-  rw list.mem_to_finset at hp,
-  exact h p (n.factorization p) (nat.prime_of_mem_factors hp),
-
-  intros i hi, rw pow_zero, exact hg.map_one,
-  intros i hi, rw pow_zero, exact hf.map_one,
+  exact h p _ (nat.prime_of_mem_factors hp),
 end
 
 end is_multiplicative

--- a/src/number_theory/arithmetic_function.lean
+++ b/src/number_theory/arithmetic_function.lean
@@ -564,6 +564,35 @@ lemma multiplicative_factorization [comm_monoid_with_zero R] (f : arithmetic_fun
   ∀ {n : ℕ}, n ≠ 0 → f n = n.factorization.prod (λ p k, f (p ^ k)) :=
 λ n hn, multiplicative_factorization f hf.2 hf.1 hn
 
+/-- Two multiplicative functions `f` and `g` are equal if and only if
+they agree on prime powers -/
+lemma eq_iff_eq_on_prime_powers [comm_monoid_with_zero R]
+  (f : arithmetic_function R) (hf : f.is_multiplicative)
+  (g : arithmetic_function R) (hg : g.is_multiplicative) :
+  f = g ↔ ∀ (p i : ℕ), nat.prime p → f(p ^ i) = g(p ^ i) :=
+begin
+  split,
+  intros h p i _,
+  simp only [h],
+  intros h,
+  ext n,
+  by_cases hn : n = 0,
+  rw [hn, arithmetic_function.map_zero, arithmetic_function.map_zero],
+  rw nat.multiplicative_factorization f (λ x y, (λ hxy, hf.map_mul_of_coprime hxy)) hf.map_one hn,
+  rw nat.multiplicative_factorization g (λ x y, (λ hxy, hg.map_mul_of_coprime hxy)) hg.map_one hn,
+
+  have : n.factorization.support ⊆ n.factors.to_finset, simp,
+  rw finsupp.prod_of_support_subset n.factorization this,
+  rw finsupp.prod_of_support_subset n.factorization this,
+  apply prod_congr rfl,
+  intros p hp,
+  rw list.mem_to_finset at hp,
+  exact h p (n.factorization p) (nat.prime_of_mem_factors hp),
+
+  intros i hi, rw pow_zero, exact hg.map_one,
+  intros i hi, rw pow_zero, exact hf.map_one,
+end
+
 end is_multiplicative
 
 section special_functions


### PR DESCRIPTION
To show that two multiplicative functions are equal, it suffices to show
that they are equal on prime powers. This is a commonly used strategy
when two functions are known to be multiplicative (e.g., they're both
Dirichlet convolutions of simpler multiplicative functions).

This will be used in several ongoing commits to prove asymptotics for
squarefree numbers.



---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
