### PR TITLE
[Merged by Bors] - chore(category_theory/preadditive/projective_resolution): typo

### DIFF
--- a/src/category_theory/preadditive/projective_resolution.lean
+++ b/src/category_theory/preadditive/projective_resolution.lean
@@ -165,7 +165,7 @@ begin
   exact lift_f_succ P Q n g g' w,
 end
 
-/-- The resolution maps interwine the lift of a morphism and that morphism. -/
+/-- The resolution maps intertwine the lift of a morphism and that morphism. -/
 @[simp, reassoc]
 lemma lift_commutes
   {Y Z : C} (f : Y ⟶ Z) (P : ProjectiveResolution Y) (Q : ProjectiveResolution Z) :


### PR DESCRIPTION

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
