### PR TITLE
chore(data/nat/prime): redefine `nat.prime` as `prime`

### DIFF
--- a/src/algebra/char_p/basic.lean
+++ b/src/algebra/char_p/basic.lean
@@ -131,7 +131,7 @@ begin
   { intro h1,
     contrapose! h1,
     rw finset.mem_range,
-    exact nat.prime.pos (fact.out _) }
+    exact prime.pos (fact.out _) }
 end
 
 theorem add_pow_char_pow_of_commute [semiring R] {p : ℕ} [fact p.prime]

--- a/src/algebra/char_p/exp_char.lean
+++ b/src/algebra/char_p/exp_char.lean
@@ -57,7 +57,7 @@ begin
       exact false.elim (one_ne_zero (hp.eq R (char_p.of_char_zero R))) },
     { intro pprime,
       rw (char_p.eq R hp infer_instance : p = 0) at pprime,
-      exact false.elim (nat.not_prime_zero pprime) } },
+      exact false.elim (not_prime_zero pprime) } },
   { split,
     { intro hpq, rw hpq, exact hq_prime, },
     { intro _,

--- a/src/algebra/is_prime_pow.lean
+++ b/src/algebra/is_prime_pow.lean
@@ -78,10 +78,10 @@ section nat
 
 lemma is_prime_pow_nat_iff (n : ℕ) :
   is_prime_pow n ↔ ∃ (p k : ℕ), nat.prime p ∧ 0 < k ∧ p ^ k = n :=
-by simp only [is_prime_pow_def, nat.prime_iff]
+iff.rfl
 
 lemma nat.prime.is_prime_pow {p : ℕ} (hp : p.prime) : is_prime_pow p :=
-(nat.prime_iff.mp hp).is_prime_pow
+hp.is_prime_pow
 
 lemma is_prime_pow_nat_iff_bounded (n : ℕ) :
   is_prime_pow n ↔ ∃ (p : ℕ), p ≤ n ∧ ∃ (k : ℕ), k ≤ n ∧ p.prime ∧ 0 < k ∧ p ^ k = n :=
@@ -100,7 +100,6 @@ lemma is_prime_pow.min_fac_pow_factorization_eq {n : ℕ} (hn : is_prime_pow n) 
   n.min_fac ^ n.factorization n.min_fac = n :=
 begin
   obtain ⟨p, k, hp, hk, rfl⟩ := hn,
-  rw ←nat.prime_iff at hp,
   rw [hp.pow_min_fac hk.ne', hp.factorization_pow, finsupp.single_eq_same],
 end
 
@@ -110,7 +109,7 @@ lemma is_prime_pow_of_min_fac_pow_factorization_eq {n : ℕ}
 begin
   rcases eq_or_ne n 0 with rfl | hn',
   { simpa using h },
-  refine ⟨_, _, nat.prime_iff.1 (nat.min_fac_prime hn), _, h⟩,
+  refine ⟨_, _, nat.min_fac_prime hn, _, h⟩,
   rw [pos_iff_ne_zero, ←finsupp.mem_support_iff, nat.factor_iff_mem_factorization,
     nat.mem_factors_iff_dvd hn' (nat.min_fac_prime hn)],
   apply nat.min_fac_dvd

--- a/src/data/int/gcd.lean
+++ b/src/data/int/gcd.lean
@@ -178,10 +178,10 @@ dvd.elim H (λl H1, by rw mul_assoc at H1; exact ⟨_, mul_left_cancel₀ k_non_
 theorem dvd_of_mul_dvd_mul_right {i j k : ℤ} (k_non_zero : k ≠ 0) (H : i * k ∣ j * k) : i ∣ j :=
 by rw [mul_comm i k, mul_comm j k] at H; exact dvd_of_mul_dvd_mul_left k_non_zero H
 
-lemma prime.dvd_nat_abs_of_coe_dvd_sq {p : ℕ} (hp : p.prime) (k : ℤ) (h : ↑p ∣ k ^ 2) :
+lemma prime.dvd_nat_abs_of_coe_dvd_sq {p : ℕ} (hp : prime p) (k : ℤ) (h : ↑p ∣ k ^ 2) :
   p ∣ k.nat_abs :=
 begin
-  apply @nat.prime.dvd_of_dvd_pow _ _ 2 hp,
+  apply hp.dvd_of_dvd_pow,
   rwa [sq, ← nat_abs_mul, ← coe_nat_dvd_left, ← sq]
 end
 

--- a/src/data/nat/factorization.lean
+++ b/src/data/nat/factorization.lean
@@ -133,7 +133,7 @@ begin
 end
 
 /-- For prime `p` the only prime factor of `p^k` is `p` with multiplicity `k` -/
-lemma prime.factorization_pow {p k : ℕ} (hp : prime p) :
+lemma _root_.prime.factorization_pow {p k : ℕ} (hp : prime p) :
   factorization (p ^ k) = single p k :=
 by simp [hp]
 

--- a/src/data/nat/prime.lean
+++ b/src/data/nat/prime.lean
@@ -181,6 +181,9 @@ theorem _root_.irreducible.dvd_mul {p m n : ℕ} (pp : irreducible p) : p ∣ m 
 ⟨λ H, or_iff_not_imp_left.2 $ λ h, (pp.coprime_iff_not_dvd.2 h).dvd_of_dvd_mul_left H,
  or.rec (λ h : p ∣ m, h.mul_right _) (λ h : p ∣ n, h.mul_left _)⟩
 
+theorem _root_.prime.dvd_mul {p m n : ℕ} (pp : prime p) : p ∣ m * n ↔ p ∣ m ∨ p ∣ n :=
+pp.irreducible.dvd_mul
+
 theorem _root_.irreducible_iff_nat_prime (a : ℕ) : irreducible a ↔ prime a :=
 ⟨λ h, ⟨h.ne_zero, h.not_unit, λ a b, h.dvd_mul.mp⟩, prime.irreducible⟩
 
@@ -1230,17 +1233,6 @@ lemma eq_two_pow_or_exists_odd_prime_and_dvd (n : ℕ) :
 end nat
 
 abbreviation nat.prime := @prime ℕ
-
-theorem prime.dvd_mul {p m n : ℕ} (pp : prime p) :
-p ∣ m * n ↔ p ∣ m ∨ p ∣ n :=
-begin
-  split,
-  apply pp.dvd_or_dvd,
-  rintro (h|h),
-  exact dvd_mul_of_dvd_left h n,
-  exact dvd_mul_of_dvd_right h m,
-end
-
 
 namespace int
 lemma prime_two : prime (2 : ℤ) := nat.prime_iff_prime_int.mp nat.prime_two

--- a/src/data/num/prime.lean
+++ b/src/data/num/prime.lean
@@ -73,7 +73,7 @@ end
 @[simp] def prime (n : pos_num) : Prop := nat.prime n
 
 instance decidable_prime : decidable_pred pos_num.prime
-| 1 := decidable.is_false nat.not_prime_one
+| 1 := decidable.is_false not_prime_one
 | (bit0 n) := decidable_of_iff' (n = 1) begin
     refine nat.prime_def_min_fac.trans ((and_iff_right _).trans $ eq_comm.trans _),
     { exact bit0_le_bit0.2 (to_nat_pos _) },
@@ -103,7 +103,7 @@ def min_fac : num → pos_num
 @[simp] def prime (n : num) : Prop := nat.prime n
 
 instance decidable_prime : decidable_pred num.prime
-| 0 := decidable.is_false nat.not_prime_zero
+| 0 := decidable.is_false not_prime_zero
 | (pos n) := pos_num.decidable_prime n
 
 end num

--- a/src/data/pnat/prime.lean
+++ b/src/data/pnat/prime.lean
@@ -77,7 +77,7 @@ section prime
 /-- Primality predicate for `ℕ+`, defined in terms of `nat.prime`. -/
 def prime (p : ℕ+) : Prop := (p : ℕ).prime
 
-lemma prime.one_lt {p : ℕ+} : p.prime → 1 < p := nat.prime.one_lt
+lemma prime.one_lt {p : ℕ+} : p.prime → 1 < p := prime.one_lt
 
 lemma prime_two : (2 : ℕ+).prime := nat.prime_two
 
@@ -85,10 +85,10 @@ lemma dvd_prime {p m : ℕ+} (pp : p.prime) :
 (m ∣ p ↔ m = 1 ∨ m = p) := by { rw pnat.dvd_iff, rw nat.dvd_prime pp, simp }
 
 lemma prime.ne_one {p : ℕ+} : p.prime → p ≠ 1 :=
-by { intro pp, intro contra, apply nat.prime.ne_one pp, rw pnat.coe_eq_one_iff, apply contra }
+by { rw [ne.def, ←pnat.coe_eq_one_iff], exact prime.ne_one }
 
 @[simp]
-lemma not_prime_one : ¬ (1: ℕ+).prime :=  nat.not_prime_one
+lemma not_prime_one : ¬ (1: ℕ+).prime := not_prime_one
 
 lemma prime.not_dvd_one {p : ℕ+} :
 p.prime →  ¬ p ∣ 1 := λ pp : p.prime, by {rw dvd_iff, apply nat.prime.not_dvd_one pp}
@@ -96,7 +96,7 @@ p.prime →  ¬ p ∣ 1 := λ pp : p.prime, by {rw dvd_iff, apply nat.prime.not_
 lemma exists_prime_and_dvd {n : ℕ+} (hn : n ≠ 1) : (∃ (p : ℕ+), p.prime ∧ p ∣ n) :=
 begin
   obtain ⟨p, hp⟩ := nat.exists_prime_and_dvd (mt coe_eq_one_iff.mp hn),
-  existsi (⟨p, nat.prime.pos hp.left⟩ : ℕ+), rw dvd_iff, apply hp
+  existsi (⟨p, hp.left.pos⟩ : ℕ+), rw dvd_iff, apply hp
 end
 
 end prime

--- a/src/group_theory/perm/cycles.lean
+++ b/src/group_theory/perm/cycles.lean
@@ -531,7 +531,7 @@ begin
   classical,
   have : n.coprime (order_of f),
   { refine nat.coprime.symm _,
-    rw nat.prime.coprime_iff_not_dvd hf',
+    rw hf'.irreducible.coprime_iff_not_dvd,
     exact nat.not_dvd_of_pos_of_lt hn hn' },
   obtain ⟨m, hm⟩ := exists_pow_eq_self_of_coprime this,
   have hf'' := hf,
@@ -1279,7 +1279,7 @@ begin
     (mem_support.mp ((finset.ext_iff.mp h2 y).mpr (finset.mem_univ y))),
   rw [h5, ←hi],
   refine closure_cycle_coprime_swap (nat.coprime.symm
-    (h0.coprime_iff_not_dvd.mpr (λ h, h4 _))) h1 h2 x,
+    (h0.irreducible.coprime_iff_not_dvd.mpr (λ h, h4 _))) h1 h2 x,
   cases h with m hm,
   rwa [hm, pow_mul, ←finset.card_univ, ←h2, ←order_of_is_cycle h1,
     pow_order_of_eq_one, one_pow, one_apply] at hi,

--- a/src/number_theory/divisors.lean
+++ b/src/number_theory/divisors.lean
@@ -262,7 +262,8 @@ lemma prime.divisors {p : ℕ} (pp : p.prime) :
   divisors p = {1, p} :=
 begin
   ext,
-  rw [mem_divisors, dvd_prime pp, and_iff_left pp.ne_zero, finset.mem_insert, finset.mem_singleton]
+  rw [mem_divisors, dvd_prime pp.irreducible, and_iff_left pp.ne_zero, finset.mem_insert,
+    finset.mem_singleton]
 end
 
 lemma prime.proper_divisors {p : ℕ} (pp : p.prime) :
@@ -340,9 +341,11 @@ lemma sum_proper_divisors_eq_one_iff_prime :
   ∑ x in n.proper_divisors, x = 1 ↔ n.prime :=
 begin
   cases n,
-  { simp [nat.not_prime_zero] },
+  { refine iff_of_false _ not_prime_zero,
+    simp },
   cases n,
-  { simp [nat.not_prime_one] },
+  { refine iff_of_false _ not_prime_one,
+    simp },
   rw [← proper_divisors_eq_singleton_one_iff_prime],
   refine ⟨λ h, _, λ h, h.symm ▸ sum_singleton⟩,
   rw [@eq_comm (finset ℕ) _ _],

--- a/src/number_theory/divisors.lean
+++ b/src/number_theory/divisors.lean
@@ -262,8 +262,7 @@ lemma prime.divisors {p : ℕ} (pp : p.prime) :
   divisors p = {1, p} :=
 begin
   ext,
-  rw [mem_divisors, dvd_prime pp.irreducible, and_iff_left pp.ne_zero, finset.mem_insert,
-    finset.mem_singleton]
+  rw [mem_divisors, dvd_prime pp, and_iff_left pp.ne_zero, finset.mem_insert, finset.mem_singleton]
 end
 
 lemma prime.proper_divisors {p : ℕ} (pp : p.prime) :

--- a/src/number_theory/primorial.lean
+++ b/src/number_theory/primorial.lean
@@ -153,7 +153,11 @@ lemma primorial_le_4_pow : ∀ (n : ℕ), n# ≤ 4 ^ n
               ≤ 4 ^ n.succ : primorial_le_4_pow (n + 1)
           ... ≤ 4 ^ (n + 2) : pow_le_pow (by norm_num) (nat.le_succ _), },
       { have n_zero : n = 0 := eq_bot_iff.2 (succ_le_succ_iff.1 n_le_one),
-        norm_num [n_zero, primorial, range_succ, prod_filter, nat.not_prime_zero, nat.prime_two] },
+        simp only [n_zero, primorial, range_succ, prod_filter, is_lawful_singleton.insert_emptyc_eq,
+          finset.prod_singleton, mul_one, prod_insert, range_zero, ite_mul, zero_add,
+          prod_insert_one, mul_ite, prod_congr, mul_zero] { discharger := `[norm_num] },
+        rw [if_neg not_prime_zero, if_pos nat.prime_two],
+        norm_num },
     end
 
 end

--- a/src/set_theory/cardinal_divisibility.lean
+++ b/src/set_theory/cardinal_divisibility.lean
@@ -94,7 +94,7 @@ end
 
 @[simp] lemma nat_is_prime_iff : prime (n : cardinal) ↔ n.prime :=
 begin
-  simp only [prime, nat.prime_iff],
+  simp only [prime],
   refine and_congr (by simp) (and_congr _ ⟨λ h b c hbc, _, λ h b c hbc, _⟩),
   { simp only [is_unit_iff, nat.is_unit_iff],
     exact_mod_cast iff.rfl },


### PR DESCRIPTION

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

This is a WIP that shows this definition in feasible without too deep changes. Still needs a bunch of tidying up and propagating changes further into the tree, but I'd like to get some feedback before spending too much more time on it.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
