### PR TITLE
[Merged by Bors] - feat(algebra/parity + data/{int, nat}/parity): parity lemmas for general semirings

### DIFF
--- a/src/algebra/parity.lean
+++ b/src/algebra/parity.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Damiano Testa
 -/
 
-/--  This file proves some general facts about even and odd elements of semirings. -/
+/-!  This file proves some general facts about even and odd elements of semirings. -/
 import algebra.ring.basic
 
 variables {α : Type*}

--- a/src/algebra/parity.lean
+++ b/src/algebra/parity.lean
@@ -4,8 +4,9 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Damiano Testa
 -/
 
-/-!  This file proves some general facts about even and odd elements of semirings. -/
 import algebra.ring.basic
+
+/-!  This file proves some general facts about even and odd elements of semirings. -/
 
 variables {α : Type*}
 

--- a/src/algebra/parity.lean
+++ b/src/algebra/parity.lean
@@ -1,3 +1,10 @@
+/-
+Copyright (c) 2022 Damiano Testa. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Damiano Testa
+-/
+
+/--  This file proves some general facts about even and odd elements of semirings. -/
 import algebra.ring.basic
 
 variables {α : Type*}

--- a/src/algebra/parity.lean
+++ b/src/algebra/parity.lean
@@ -1,0 +1,38 @@
+import algebra.ring.basic
+
+variables {α : Type*}
+
+section semiring
+variable [semiring α]
+
+theorem even.add_even {m n : α} (hm : even m) (hn : even n) :
+  even (m + n) :=
+begin
+  rcases hm with ⟨m, rfl⟩,
+  rcases hn with ⟨n, rfl⟩,
+  exact ⟨m + n, (mul_add _ _ _).symm⟩
+end
+
+theorem even.add_odd {m n : α} (hm : even m) (hn : odd n) :
+  odd (m + n) :=
+begin
+  rcases hm with ⟨m, rfl⟩,
+  rcases hn with ⟨n, rfl⟩,
+  exact ⟨m + n, by rw [mul_add, add_assoc]⟩
+end
+
+theorem odd.add_even {m n : α} (hm : odd m) (hn : even n) :
+  odd (m + n) :=
+by { rw add_comm, exact hn.add_odd hm }
+
+theorem odd.add_odd {m n : α} (hm : odd m) (hn : odd n) :
+  even (m + n) :=
+begin
+  rcases hm with ⟨m, rfl⟩,
+  rcases hn with ⟨n, rfl⟩,
+  refine ⟨n + m + 1, _⟩,
+  rw [←add_assoc, add_comm _ (2 * n), ←add_assoc, ←mul_add, add_assoc, mul_add _ (n + m), mul_one],
+  refl
+end
+
+end semiring

--- a/src/data/int/parity.lean
+++ b/src/data/int/parity.lean
@@ -94,14 +94,8 @@ by cases mod_two_eq_zero_or_one m with h₁ h₁;
    simp [even_iff, h₁, h₂, int.add_mod];
    norm_num
 
-theorem even.add_even (hm : even m) (hn : even n) : even (m + n) :=
-even_add.2 $ iff_of_true hm hn
-
 theorem even_add' : even (m + n) ↔ (odd m ↔ odd n) :=
 by rw [even_add, even_iff_not_odd, even_iff_not_odd, not_iff_not]
-
-theorem odd.add_odd (hm : odd m) (hn : odd n) : even (m + n) :=
-even_add'.2 $ iff_of_true hm hn
 
 @[simp] theorem not_even_bit1 (n : ℤ) : ¬ even (bit1 n) :=
 by simp [bit1] with parity_simps
@@ -157,14 +151,8 @@ even_pow.trans $ and_iff_left h
 @[parity_simps] theorem odd_add : odd (m + n) ↔ (odd m ↔ even n) :=
 by rw [odd_iff_not_even, even_add, not_iff, odd_iff_not_even]
 
-theorem odd.add_even (hm : odd m) (hn : even n) : odd (m + n) :=
-odd_add.2 $ iff_of_true hm hn
-
 theorem odd_add' : odd (m + n) ↔ (odd n ↔ even m) :=
 by rw [add_comm, odd_add]
-
-theorem even.add_odd (hm : even m) (hn : odd n) : odd (m + n) :=
-odd_add'.2 $ iff_of_true hn hm
 
 lemma ne_of_odd_add (h : odd (m + n)) : m ≠ n :=
 λ hnot, by simpa [hnot] with parity_simps using h

--- a/src/data/nat/parity.lean
+++ b/src/data/nat/parity.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jeremy Avigad, Benjamin Davidson
 -/
 import data.nat.modeq
-import algebra.parity
 
 /-!
 # Parity of natural numbers

--- a/src/data/nat/parity.lean
+++ b/src/data/nat/parity.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jeremy Avigad, Benjamin Davidson
 -/
 import data.nat.modeq
+import algebra.parity
 
 /-!
 # Parity of natural numbers
@@ -98,14 +99,8 @@ by cases mod_two_eq_zero_or_one m with h₁ h₁;
    simp [even_iff, h₁, h₂, nat.add_mod];
    norm_num
 
-theorem even.add_even (hm : even m) (hn : even n) : even (m + n) :=
-even_add.2 $ iff_of_true hm hn
-
 theorem even_add' : even (m + n) ↔ (odd m ↔ odd n) :=
 by rw [even_add, even_iff_not_odd, even_iff_not_odd, not_iff_not]
-
-theorem odd.add_odd (hm : odd m) (hn : odd n) : even (m + n) :=
-even_add'.2 $ iff_of_true hm hn
 
 @[simp] theorem not_even_bit1 (n : ℕ) : ¬ even (bit1 n) :=
 by simp [bit1] with parity_simps
@@ -176,14 +171,8 @@ by rw [even_iff_two_dvd, dvd_iff_mod_eq_zero, nat.div_mod_eq_mod_mul_div, mul_co
 @[parity_simps] theorem odd_add : odd (m + n) ↔ (odd m ↔ even n) :=
 by rw [odd_iff_not_even, even_add, not_iff, odd_iff_not_even]
 
-theorem odd.add_even (hm : odd m) (hn : even n) : odd (m + n) :=
-odd_add.2 $ iff_of_true hm hn
-
 theorem odd_add' : odd (m + n) ↔ (odd n ↔ even m) :=
 by rw [add_comm, odd_add]
-
-theorem even.add_odd (hm : even m) (hn : odd n) : odd (m + n) :=
-odd_add'.2 $ iff_of_true hn hm
 
 lemma ne_of_odd_add (h : odd (m + n)) : m ≠ n :=
 λ hnot, by simpa [hnot] with parity_simps using h


### PR DESCRIPTION
This PR proves some general facts about adding even/odd elements in a semiring, thus removing the need to proving the same results for `nat` and `int`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
