### PR TITLE
[Merged by Bors] - feat(model_theory/basic, terms_and_formulas): Helper functions for constant symbols

### DIFF
--- a/src/model_theory/basic.lean
+++ b/src/model_theory/basic.lean
@@ -572,7 +572,7 @@ def Lhom_with_constants : L →ᴸ L[[α]] := Lhom.sum_inl
 
 variable {L}
 
-instance : has_coe α (L[[α]].constants) := ⟨sum.inr⟩
+instance : has_coe_t α (L[[α]].constants) := ⟨sum.inr⟩
 
 /-- Adds constants to a language map.  -/
 def Lhom.add_constants {L' : language} (φ : L →ᴸ L') :

--- a/src/model_theory/basic.lean
+++ b/src/model_theory/basic.lean
@@ -572,6 +572,8 @@ def Lhom_with_constants : L →ᴸ L[[α]] := Lhom.sum_inl
 
 variable {L}
 
+instance : has_coe α (L[[α]].constants) := ⟨sum.inr⟩
+
 /-- Adds constants to a language map.  -/
 def Lhom.add_constants {L' : language} (φ : L →ᴸ L') :
   L[[α]] →ᴸ L'[[α]] := φ.sum_map (Lhom.id _)
@@ -613,6 +615,8 @@ instance add_constants_expansion {L' : language} [L'.Structure M] (φ : L →ᴸ
   [φ.is_expansion_on M] :
   (φ.add_constants A).is_expansion_on M :=
 Lhom.sum_map_is_expansion_on _ _ M
+
+@[simp] lemma coe_coe_param {a : A} : ((a : L[[A]].constants) : M) = a := rfl
 
 variables {A} {B : set M} (h : A ⊆ B)
 

--- a/src/model_theory/basic.lean
+++ b/src/model_theory/basic.lean
@@ -570,9 +570,11 @@ localized "notation L`[[`:95 α`]]`:90 := L.with_constants α" in first_order
 /-- The language map adding constants.  -/
 def Lhom_with_constants : L →ᴸ L[[α]] := Lhom.sum_inl
 
-variable {L}
+variables {α}
 
-instance : has_coe_t α (L[[α]].constants) := ⟨sum.inr⟩
+protected def con (a : α) : L[[α]].constants := sum.inr a
+
+variables {L} (α)
 
 /-- Adds constants to a language map.  -/
 def Lhom.add_constants {L' : language} (φ : L →ᴸ L') :
@@ -616,7 +618,7 @@ instance add_constants_expansion {L' : language} [L'.Structure M] (φ : L →ᴸ
   (φ.add_constants A).is_expansion_on M :=
 Lhom.sum_map_is_expansion_on _ _ M
 
-@[simp] lemma coe_coe_param {a : A} : ((a : L[[A]].constants) : M) = a := rfl
+@[simp] lemma coe_con {a : A} : ((L.con a) : M) = a := rfl
 
 variables {A} {B : set M} (h : A ⊆ B)
 

--- a/src/model_theory/basic.lean
+++ b/src/model_theory/basic.lean
@@ -572,6 +572,7 @@ def Lhom_with_constants : L →ᴸ L[[α]] := Lhom.sum_inl
 
 variables {α}
 
+/-- The constant symbol indexed by a particular element. -/
 protected def con (a : α) : L[[α]].constants := sum.inr a
 
 variables {L} (α)

--- a/src/model_theory/terms_and_formulas.lean
+++ b/src/model_theory/terms_and_formulas.lean
@@ -146,12 +146,16 @@ encodable.of_left_injection list_encode (λ l, (list_decode l).head')
 instance inhabited_of_var [inhabited α] : inhabited (L.term α) :=
 ⟨var default⟩
 
+end term
+
 /-- The representation of a constant symbol as a term. -/
-def con (c : L.constants) : (L.term α) :=
+def constants.term (c : L.constants) : (L.term α) :=
 func c default
 
+namespace term
+
 instance inhabited_of_constant [inhabited L.constants] : inhabited (L.term α) :=
-⟨con default⟩
+⟨(default : L.constants).term⟩
 
 /-- A term `t` with variables indexed by `α` can be evaluated by giving a value to each variable. -/
 @[simp] def realize (v : α → M) :
@@ -167,9 +171,12 @@ begin
   { simp [ih] }
 end
 
-@[simp] lemma realize_con {c : L.constants} {v : α → M} :
-  (con c).realize v = c :=
+@[simp] lemma realize_constants {c : L.constants} {v : α → M} :
+  c.term.realize v = c :=
 fun_map_eq_coe_constants
+
+lemma realize_con {A : set M} {a : A} {v : α → M} :
+  (L.con a).term.realize v = a := rfl
 
 end term
 

--- a/src/model_theory/terms_and_formulas.lean
+++ b/src/model_theory/terms_and_formulas.lean
@@ -146,11 +146,12 @@ encodable.of_left_injection list_encode (λ l, (list_decode l).head')
 instance inhabited_of_var [inhabited α] : inhabited (L.term α) :=
 ⟨var default⟩
 
-instance : has_coe L.constants (L.term α) :=
-⟨λ c, func c default⟩
+/-- The representation of a constant symbol as a term. -/
+def con (c : L.constants) : (L.term α) :=
+func c default
 
 instance inhabited_of_constant [inhabited L.constants] : inhabited (L.term α) :=
-⟨↑(default : L.constants)⟩
+⟨con default⟩
 
 /-- A term `t` with variables indexed by `α` can be evaluated by giving a value to each variable. -/
 @[simp] def realize (v : α → M) :
@@ -166,8 +167,8 @@ begin
   { simp [ih] }
 end
 
-@[simp] lemma realize_coe_constant {c : L.constants} {v : α → M} :
-  (↑c : L.term α).realize v = c :=
+@[simp] lemma realize_con {c : L.constants} {v : α → M} :
+  (con c).realize v = c :=
 fun_map_eq_coe_constants
 
 end term

--- a/src/model_theory/terms_and_formulas.lean
+++ b/src/model_theory/terms_and_formulas.lean
@@ -547,7 +547,7 @@ def is_satisfiable : Prop :=
 
 /-- A theory is finitely satisfiable if all of its finite subtheories are satisfiable. -/
 def is_finitely_satisfiable : Prop :=
-∀ (T0 : finset L.sentence), (↑T0 : L.Theory) ⊆ T → (↑T0 : L.Theory).is_satisfiable
+∀ (T0 : finset L.sentence), (T0 : L.Theory) ⊆ T → (T0 : L.Theory).is_satisfiable
 
 variables {T} {T' : L.Theory}
 

--- a/src/model_theory/terms_and_formulas.lean
+++ b/src/model_theory/terms_and_formulas.lean
@@ -146,11 +146,11 @@ encodable.of_left_injection list_encode (λ l, (list_decode l).head')
 instance inhabited_of_var [inhabited α] : inhabited (L.term α) :=
 ⟨var default⟩
 
-instance inhabited_of_constant [inhabited L.constants] : inhabited (L.term α) :=
-⟨func (default : L.constants) default⟩
-
 instance : has_coe L.constants (L.term α) :=
 ⟨λ c, func c default⟩
+
+instance inhabited_of_constant [inhabited L.constants] : inhabited (L.term α) :=
+⟨↑(default : L.constants)⟩
 
 /-- A term `t` with variables indexed by `α` can be evaluated by giving a value to each variable. -/
 @[simp] def realize (v : α → M) :
@@ -165,6 +165,10 @@ begin
   { refl, },
   { simp [ih] }
 end
+
+@[simp] lemma realize_coe_constant {c : L.constants} {v : α → M} :
+  (↑c : L.term α).realize v = c :=
+fun_map_eq_coe_constants
 
 end term
 
@@ -543,7 +547,7 @@ def is_satisfiable : Prop :=
 
 /-- A theory is finitely satisfiable if all of its finite subtheories are satisfiable. -/
 def is_finitely_satisfiable : Prop :=
-∀ (T0 : finset L.sentence), (T0 : L.Theory) ⊆ T → (T0 : L.Theory).is_satisfiable
+∀ (T0 : finset L.sentence), (↑T0 : L.Theory) ⊆ T → (↑T0 : L.Theory).is_satisfiable
 
 variables {T} {T' : L.Theory}
 


### PR DESCRIPTION
Defines a function `language.con` from `A` to constants of the language `L[[A]]`.
Changes the coercion of a constant to a term to a function `language.constants.term`.
Proves `simp` lemmas for interpretation of constant symbols and realization of constant terms.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
