### PR TITLE
[Merged by Bors] - feat(category_theory/punit): A groupoid is equivalent to punit iff it has a unique arrow between any two objects

### DIFF
--- a/src/category_theory/groupoid.lean
+++ b/src/category_theory/groupoid.lean
@@ -88,27 +88,6 @@ def groupoid.of_is_iso (all_is_iso : ∀ {X Y : C} (f : X ⟶ Y), is_iso f) : gr
 def groupoid.of_all_unique (all_unique : ∀ {X Y : C}, unique (X ⟶ Y)) :
   groupoid.{v} C := { inv := λ X Y f, all_unique.default }
 
-/-- A category being equivalent to `punit` is equivalent to it having a unique morphism between
-  any two objects. (In fact, such a category is also a groupoid; see `groupoid.of_all_unique`) -/
-theorem equiv_punit_iff_unique :
-  nonempty (C ≌ discrete punit) ↔ (nonempty C) ∧ (∀ x y : C, nonempty $ unique (x ⟶ y)) :=
-begin
-  split,
-  { rintro ⟨h⟩, refine ⟨⟨h.inverse.obj punit.star⟩, λ x y, nonempty.intro _⟩,
-    apply (unique_of_subsingleton _), swap,
-    { have hx : x ⟶ h.inverse.obj punit.star := by convert h.unit.app x,
-      have hy : h.inverse.obj punit.star ⟶ y := by convert h.unit_inv.app y,
-      exact hx ≫ hy, },
-    suffices : ∀ z, z = h.unit.app x ≫ (h.functor ⋙ h.inverse).map z ≫ h.unit_inv.app y,
-    { apply subsingleton.intro, intros a b, rw [this a, this b],
-      simp only [functor.comp_map], congr, },
-    intro z, have := congr_arg (≫ (h.unit_inv.app y)) (h.unit.naturality z), simpa, },
-  { rintro ⟨⟨p⟩, h⟩, haveI := λ x y, (h x y).some,
-    refine nonempty.intro (category_theory.equivalence.mk
-      ((functor.const _).obj punit.star) ((functor.const _).obj p) _ (by apply functor.punit_ext)),
-    exact nat_iso.of_components (λ _, iso_of_both_ways default default) (λ _ _ _, by tidy), },
-end
-
 end
 
 instance induced_category.groupoid {C : Type u} (D : Type u₂) [groupoid.{v} D] (F : C → D) :

--- a/src/category_theory/groupoid.lean
+++ b/src/category_theory/groupoid.lean
@@ -6,9 +6,6 @@ Authors: Reid Barton, Scott Morrison, David Wärn
 import category_theory.full_subcategory
 import category_theory.products.basic
 import category_theory.pi.basic
-import category_theory.discrete_category
-import category_theory.punit
-import category_theory.thin
 
 /-!
 # Groupoids
@@ -85,8 +82,8 @@ def groupoid.of_is_iso (all_is_iso : ∀ {X Y : C} (f : X ⟶ Y), is_iso f) : gr
 { inv := λ X Y f, inv f }
 
 /-- A category with a unique morphism between any two objects is a groupoid -/
-def groupoid.of_all_unique (all_unique : ∀ {X Y : C}, unique (X ⟶ Y)) :
-  groupoid.{v} C := { inv := λ X Y f, all_unique.default }
+def groupoid.of_hom_unique (all_unique : ∀ {X Y : C}, unique (X ⟶ Y)) : groupoid.{v} C :=
+{ inv := λ X Y f, all_unique.default }
 
 end
 

--- a/src/category_theory/punit.lean
+++ b/src/category_theory/punit.lean
@@ -5,7 +5,6 @@ Authors: Scott Morrison, Bhavik Mehta
 -/
 import category_theory.functor.const
 import category_theory.discrete_category
-import category_theory.thin
 
 /-!
 # The category `discrete punit`
@@ -72,24 +71,28 @@ def equiv : (discrete punit ⥤ C) ≌ C :=
 end functor
 
 /-- A category being equivalent to `punit` is equivalent to it having a unique morphism between
-  any two objects. (In fact, such a category is also a groupoid; see `groupoid.of_all_unique`) -/
+  any two objects. (In fact, such a category is also a groupoid; see `groupoid.of_hom_unique`) -/
 theorem equiv_punit_iff_unique :
   nonempty (C ≌ discrete punit) ↔ (nonempty C) ∧ (∀ x y : C, nonempty $ unique (x ⟶ y)) :=
 begin
   split,
-  { rintro ⟨h⟩, refine ⟨⟨h.inverse.obj punit.star⟩, λ x y, nonempty.intro _⟩,
+  { rintro ⟨h⟩,
+    refine ⟨⟨h.inverse.obj punit.star⟩, λ x y, nonempty.intro _⟩,
     apply (unique_of_subsingleton _), swap,
     { have hx : x ⟶ h.inverse.obj punit.star := by convert h.unit.app x,
       have hy : h.inverse.obj punit.star ⟶ y := by convert h.unit_inv.app y,
       exact hx ≫ hy, },
-    suffices : ∀ z, z = h.unit.app x ≫ (h.functor ⋙ h.inverse).map z ≫ h.unit_inv.app y,
-    { apply subsingleton.intro, intros a b, rw [this a, this b],
-      simp only [functor.comp_map], congr, },
-    intro z, have := congr_arg (≫ (h.unit_inv.app y)) (h.unit.naturality z), simpa, },
-  { rintro ⟨⟨p⟩, h⟩, haveI := λ x y, (h x y).some,
+    have : ∀ z, z = h.unit.app x ≫ (h.functor ⋙ h.inverse).map z ≫ h.unit_inv.app y,
+    { intro z, simpa using congr_arg (≫ (h.unit_inv.app y)) (h.unit.naturality z), },
+    apply subsingleton.intro,
+    intros a b,
+    rw [this a, this b],
+    simp only [functor.comp_map], congr, },
+  { rintro ⟨⟨p⟩, h⟩,
+    haveI := λ x y, (h x y).some,
     refine nonempty.intro (category_theory.equivalence.mk
       ((functor.const _).obj punit.star) ((functor.const _).obj p) _ (by apply functor.punit_ext)),
-    exact nat_iso.of_components (λ _, iso_of_both_ways default default) (λ _ _ _, by tidy), },
+    exact nat_iso.of_components (λ _, { hom := default, inv := default }) (λ _ _ _, by tidy), },
 end
 
 end category_theory

--- a/src/category_theory/punit.lean
+++ b/src/category_theory/punit.lean
@@ -5,6 +5,7 @@ Authors: Scott Morrison, Bhavik Mehta
 -/
 import category_theory.functor.const
 import category_theory.discrete_category
+import category_theory.thin
 
 /-!
 # The category `discrete punit`
@@ -17,9 +18,9 @@ and construct the equivalence `(discrete punit ⥤ C) ≌ C`.
 universes v u -- morphism levels before object levels. See note [category_theory universes].
 
 namespace category_theory
+variables (C : Type u) [category.{v} C]
 
 namespace functor
-variables (C : Type u) [category.{v} C]
 
 /-- The constant functor sending everything to `punit.star`. -/
 @[simps]
@@ -69,5 +70,26 @@ def equiv : (discrete punit ⥤ C) ≌ C :=
   end }
 
 end functor
+
+/-- A category being equivalent to `punit` is equivalent to it having a unique morphism between
+  any two objects. (In fact, such a category is also a groupoid; see `groupoid.of_all_unique`) -/
+theorem equiv_punit_iff_unique :
+  nonempty (C ≌ discrete punit) ↔ (nonempty C) ∧ (∀ x y : C, nonempty $ unique (x ⟶ y)) :=
+begin
+  split,
+  { rintro ⟨h⟩, refine ⟨⟨h.inverse.obj punit.star⟩, λ x y, nonempty.intro _⟩,
+    apply (unique_of_subsingleton _), swap,
+    { have hx : x ⟶ h.inverse.obj punit.star := by convert h.unit.app x,
+      have hy : h.inverse.obj punit.star ⟶ y := by convert h.unit_inv.app y,
+      exact hx ≫ hy, },
+    suffices : ∀ z, z = h.unit.app x ≫ (h.functor ⋙ h.inverse).map z ≫ h.unit_inv.app y,
+    { apply subsingleton.intro, intros a b, rw [this a, this b],
+      simp only [functor.comp_map], congr, },
+    intro z, have := congr_arg (≫ (h.unit_inv.app y)) (h.unit.naturality z), simpa, },
+  { rintro ⟨⟨p⟩, h⟩, haveI := λ x y, (h x y).some,
+    refine nonempty.intro (category_theory.equivalence.mk
+      ((functor.const _).obj punit.star) ((functor.const _).obj p) _ (by apply functor.punit_ext)),
+    exact nat_iso.of_components (λ _, iso_of_both_ways default default) (λ _ _ _, by tidy), },
+end
 
 end category_theory


### PR DESCRIPTION
In terms of topology, when this is used with the fundamental groupoid, it means that a space is simply connected (we still need to define this) if and only if any two paths between the same points are homotopic, and contractible spaces are simply connected.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
