### PR TITLE
[Merged by Bors] - feat(topology/algebra/order/basic): f ≤ᶠ[l] g implies limit of f ≤ limit of g

### DIFF
--- a/src/topology/algebra/order/basic.lean
+++ b/src/topology/algebra/order/basic.lean
@@ -163,10 +163,7 @@ have tendsto (λb, (f b, g b)) b (𝓝 (a₁, a₂)),
 show (a₁, a₂) ∈ {p:α×α | p.1 ≤ p.2},
   from t.is_closed_le'.mem_of_tendsto this h
 
-/-- Alias of `le_of_tendsto_of_tendsto` for ease of discovery when focusing on `eventually_le` -/
-lemma tendsto_le_of_eventually_le {f g : β → α} {b : filter β} {a₁ a₂ : α} [ne_bot b]
-  (hf : tendsto f b (𝓝 a₁)) (hg : tendsto g b (𝓝 a₂)) (h : f ≤ᶠ[b] g) :
-  a₁ ≤ a₂ := le_of_tendsto_of_tendsto hf hg h
+alias le_of_tendsto_of_tendsto ← tendsto_le_of_eventually_le
 
 lemma le_of_tendsto_of_tendsto' {f g : β → α} {b : filter β} {a₁ a₂ : α} [ne_bot b]
   (hf : tendsto f b (𝓝 a₁)) (hg : tendsto g b (𝓝 a₂)) (h : ∀ x, f x ≤ g x) :

--- a/src/topology/algebra/order/basic.lean
+++ b/src/topology/algebra/order/basic.lean
@@ -163,6 +163,11 @@ have tendsto (λb, (f b, g b)) b (𝓝 (a₁, a₂)),
 show (a₁, a₂) ∈ {p:α×α | p.1 ≤ p.2},
   from t.is_closed_le'.mem_of_tendsto this h
 
+/-- Alias of `le_of_tendsto_of_tendsto` for ease of discovery when focusing on `eventually_le` -/
+lemma tendsto_le_of_eventually_le {f g : β → α} {b : filter β} {a₁ a₂ : α} [ne_bot b]
+  (hf : tendsto f b (𝓝 a₁)) (hg : tendsto g b (𝓝 a₂)) (h : f ≤ᶠ[b] g) :
+  a₁ ≤ a₂ := le_of_tendsto_of_tendsto hf hg h
+
 lemma le_of_tendsto_of_tendsto' {f g : β → α} {b : filter β} {a₁ a₂ : α} [ne_bot b]
   (hf : tendsto f b (𝓝 a₁)) (hg : tendsto g b (𝓝 a₂)) (h : ∀ x, f x ≤ g x) :
   a₁ ≤ a₂ :=
@@ -333,46 +338,6 @@ lemma eventually_le_of_tendsto_lt {l : filter γ} {f : γ → α} {u v : α} (hv
 lemma eventually_ge_of_tendsto_gt {l : filter γ} {f : γ → α} {u v : α} (hv : u < v)
   (h : tendsto f l (𝓝 v)) : ∀ᶠ a in l, u ≤ f a :=
 (eventually_gt_of_tendsto_gt hv h).mono (λ v, le_of_lt)
-
-lemma tendsto_le_of_eventually_le {l : filter γ} [ne_bot l] {f g : γ → α} {u v : α}
-  (hf : filter.tendsto f l (𝓝 u)) (hg : filter.tendsto g l (𝓝 v)) (hfg : f ≤ᶠ[l] g) :
-  u ≤ v :=
-begin
-  by_contradiction H,
-  push_neg at H,
-
-  by_cases h_sep : ∃ x, v < x ∧ x < u,
-  { rcases h_sep with ⟨x, hxl, hxr⟩,
-    cases filter.nonempty_of_mem (
-      l.inter_sets (hf $ Ioi_mem_nhds hxr) (l.inter_sets (hg $ Iio_mem_nhds hxl) hfg)) with c hc,
-    simp at hc,
-    exact ne_of_lt (
-      calc f c ≤ g c : hc.right.right
-        ... < x : hc.right.left
-        ... < f c : hc.left
-    ) rfl, },
-  { cases filter.nonempty_of_mem (
-      l.inter_sets (hf $ Ioi_mem_nhds H) (l.inter_sets (hg $ Iio_mem_nhds H) hfg)) with c hc,
-    simp at hc,
-
-    push_neg at h_sep,
-    by_cases hf_lt : f c < u,
-      specialize h_sep (f c) hc.left,
-      exact not_le_of_lt hf_lt h_sep,
-
-    by_cases hg_lt : v < g c,
-      specialize h_sep (g c) hg_lt,
-      exact ne_of_lt (calc u ≤ g c : h_sep ... < u : hc.right.left) rfl,
-
-    push_neg at hf_lt,
-    push_neg at hg_lt,
-    have : u < u,
-      calc u ≤ f c : hf_lt
-        ... ≤ g c : hc.right.right
-        ... ≤ v : hg_lt
-        ... < u : H,
-   exact ne_of_lt this rfl, },
-end
 
 variables [topological_space γ]
 /-!

--- a/src/topology/algebra/order/basic.lean
+++ b/src/topology/algebra/order/basic.lean
@@ -334,6 +334,46 @@ lemma eventually_ge_of_tendsto_gt {l : filter γ} {f : γ → α} {u v : α} (hv
   (h : tendsto f l (𝓝 v)) : ∀ᶠ a in l, u ≤ f a :=
 (eventually_gt_of_tendsto_gt hv h).mono (λ v, le_of_lt)
 
+lemma tendsto_le_of_eventually_le {l : filter γ} [ne_bot l] {f g : γ → α} {u v : α}
+  (hf : filter.tendsto f l (𝓝 u)) (hg : filter.tendsto g l (𝓝 v)) (hfg : f ≤ᶠ[l] g) :
+  u ≤ v :=
+begin
+  by_contradiction H,
+  push_neg at H,
+
+  by_cases h_sep : ∃ x, v < x ∧ x < u,
+  { cases h_sep with x hx,
+    cases filter.nonempty_of_mem (l.inter_sets (hf (Ioi_mem_nhds hx.right)) (l.inter_sets (hg (Iio_mem_nhds hx.left)) hfg)) with c hc,
+    simp at hc,
+    exact ne_of_lt (
+      calc f c ≤ g c : hc.right.right
+        ... < x : hc.right.left
+        ... < f c : hc.left
+    ) rfl,
+  },
+  { cases filter.nonempty_of_mem (l.inter_sets (hf (Ioi_mem_nhds H)) (l.inter_sets (hg (Iio_mem_nhds H)) hfg)) with c hc,
+    simp at hc,
+
+    push_neg at h_sep,
+    by_cases hf_lt : f c < u,
+      specialize h_sep (f c) hc.left,
+      exact not_le_of_lt hf_lt h_sep,
+
+    by_cases hg_lt : v < g c,
+      specialize h_sep (g c) hg_lt,
+      exact ne_of_lt (calc u ≤ g c : h_sep ... < u : hc.right.left) rfl,
+
+    push_neg at hf_lt,
+    push_neg at hg_lt,
+    have : u < u,
+      calc u ≤ f c : hf_lt
+        ... ≤ g c : hc.right.right
+        ... ≤ v : hg_lt
+        ... < u : H,
+   exact ne_of_lt this rfl,
+  },
+end
+
 variables [topological_space γ]
 /-!
 ### Neighborhoods to the left and to the right on an `order_closed_topology`

--- a/src/topology/algebra/order/basic.lean
+++ b/src/topology/algebra/order/basic.lean
@@ -342,9 +342,9 @@ begin
   push_neg at H,
 
   by_cases h_sep : ∃ x, v < x ∧ x < u,
-  { cases h_sep with x hx,
+  { rcases h_sep with ⟨x, hxl, hxr⟩,
     cases filter.nonempty_of_mem (
-      l.inter_sets (hf $ Ioi_mem_nhds hx.right) (l.inter_sets (hg $ Iio_mem_nhds hx.left) hfg)) with c hc,
+      l.inter_sets (hf $ Ioi_mem_nhds hxr) (l.inter_sets (hg $ Iio_mem_nhds hxl) hfg)) with c hc,
     simp at hc,
     exact ne_of_lt (
       calc f c ≤ g c : hc.right.right
@@ -352,7 +352,7 @@ begin
         ... < f c : hc.left
     ) rfl, },
   { cases filter.nonempty_of_mem (
-      l.inter_sets (hf (Ioi_mem_nhds H)) (l.inter_sets (hg (Iio_mem_nhds H)) hfg)) with c hc,
+      l.inter_sets (hf $ Ioi_mem_nhds H) (l.inter_sets (hg $ Iio_mem_nhds H) hfg)) with c hc,
     simp at hc,
 
     push_neg at h_sep,

--- a/src/topology/algebra/order/basic.lean
+++ b/src/topology/algebra/order/basic.lean
@@ -343,15 +343,16 @@ begin
 
   by_cases h_sep : ∃ x, v < x ∧ x < u,
   { cases h_sep with x hx,
-    cases filter.nonempty_of_mem (l.inter_sets (hf (Ioi_mem_nhds hx.right)) (l.inter_sets (hg (Iio_mem_nhds hx.left)) hfg)) with c hc,
+    cases filter.nonempty_of_mem (
+      l.inter_sets (hf $ Ioi_mem_nhds hx.right) (l.inter_sets (hg $ Iio_mem_nhds hx.left) hfg)) with c hc,
     simp at hc,
     exact ne_of_lt (
       calc f c ≤ g c : hc.right.right
         ... < x : hc.right.left
         ... < f c : hc.left
-    ) rfl,
-  },
-  { cases filter.nonempty_of_mem (l.inter_sets (hf (Ioi_mem_nhds H)) (l.inter_sets (hg (Iio_mem_nhds H)) hfg)) with c hc,
+    ) rfl, },
+  { cases filter.nonempty_of_mem (
+      l.inter_sets (hf (Ioi_mem_nhds H)) (l.inter_sets (hg (Iio_mem_nhds H)) hfg)) with c hc,
     simp at hc,
 
     push_neg at h_sep,
@@ -370,8 +371,7 @@ begin
         ... ≤ g c : hc.right.right
         ... ≤ v : hg_lt
         ... < u : H,
-   exact ne_of_lt this rfl,
-  },
+   exact ne_of_lt this rfl, },
 end
 
 variables [topological_space γ]


### PR DESCRIPTION
There are several implications of the form `eventually_*_of_tendsto_*`,
which involve the order relationships between the limit of a function
and other constants. What appears to be missing are reverse
implications: If two functions are eventually ordered, then their limits
respect the order.

This is lemma will be used in further work on the asymptotics of
squarefree numbers



---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
