### PR TITLE
[Merged by Bors] - feat(group_theory/complement): Transversals as functions

### DIFF
--- a/src/group_theory/complement.lean
+++ b/src/group_theory/complement.lean
@@ -201,24 +201,27 @@ mem_right_transversals_iff_exists_unique_quotient_mk'_eq.trans
 namespace mem_left_transversals
 
 /-- A left transversal is in bijection with left cosets. -/
+@[to_additive "A left transversal is in bijection with left cosets."]
 noncomputable def to_equiv (hS : S ∈ subgroup.left_transversals (H : set G)) : G ⧸ H ≃ S :=
 (equiv.of_bijective _ (subgroup.mem_left_transversals_iff_bijective.mp hS)).symm
 
-lemma mk'_to_equiv (hS : S ∈ subgroup.left_transversals (H : set G)) (q : G ⧸ H) :
+@[to_additive] lemma mk'_to_equiv (hS : S ∈ subgroup.left_transversals (H : set G)) (q : G ⧸ H) :
   quotient.mk' (to_equiv hS q : G) = q :=
 (to_equiv hS).symm_apply_apply q
 
-/-- A left transversal can be viewed as a function mapping each element of the group to the
-  chosen representative from that left coset. -/
+/-- A left transversal can be viewed as a function mapping each element of the group
+  to the chosen representative from that left coset. -/
+@[to_additive "A left transversal can be viewed as a function mapping each element of the group
+  to the chosen representative from that left coset."]
 noncomputable def to_fun (hS : S ∈ subgroup.left_transversals (H : set G)) : G → S :=
 to_equiv hS ∘ quotient.mk'
 
-lemma inv_to_fun_mul_mem (hS : S ∈ subgroup.left_transversals (H : set G)) (g : G) :
-  (to_fun hS g : G)⁻¹ * g ∈ H :=
+@[to_additive] lemma inv_to_fun_mul_mem (hS : S ∈ subgroup.left_transversals (H : set G))
+  (g : G) : (to_fun hS g : G)⁻¹ * g ∈ H :=
 quotient.exact' (mk'_to_equiv hS g)
 
-lemma inv_mul_to_fun_mem (hS : S ∈ subgroup.left_transversals (H : set G)) (g : G) :
-  g⁻¹ * to_fun hS g ∈ H :=
+@[to_additive] lemma inv_mul_to_fun_mem (hS : S ∈ subgroup.left_transversals (H : set G))
+  (g : G) : g⁻¹ * to_fun hS g ∈ H :=
 (congr_arg (∈ H) (by rw [mul_inv_rev, inv_inv])).mp (H.inv_mem (inv_to_fun_mul_mem hS g))
 
 end mem_left_transversals
@@ -226,25 +229,28 @@ end mem_left_transversals
 namespace mem_right_transversals
 
 /-- A right transversal is in bijection with right cosets. -/
+@[to_additive "A right transversal is in bijection with right cosets."]
 noncomputable def to_equiv (hS : S ∈ subgroup.right_transversals (H : set G)) :
   quotient (quotient_group.right_rel H) ≃ S :=
 (equiv.of_bijective _ (subgroup.mem_right_transversals_iff_bijective.mp hS)).symm
 
-lemma mk'_to_equiv (hS : S ∈ subgroup.right_transversals (H : set G))
+@[to_additive] lemma mk'_to_equiv (hS : S ∈ subgroup.right_transversals (H : set G))
   (q : quotient (quotient_group.right_rel H)) : quotient.mk' (to_equiv hS q : G) = q :=
 (to_equiv hS).symm_apply_apply q
 
-/-- A right transversal can be viewed as a function mapping each element of the group to the
-  chosen representative from that right coset. -/
+/-- A right transversal can be viewed as a function mapping each element of the group
+  to the chosen representative from that right coset. -/
+@[to_additive "A right transversal can be viewed as a function mapping each element of the group
+  to the chosen representative from that right coset."]
 noncomputable def to_fun (hS : S ∈ subgroup.right_transversals (H : set G)) : G → S :=
 to_equiv hS ∘ quotient.mk'
 
-lemma mul_inv_to_fun_mem (hS : S ∈ subgroup.right_transversals (H : set G)) (g : G) :
-  g * (to_fun hS g : G)⁻¹ ∈ H :=
+@[to_additive] lemma mul_inv_to_fun_mem (hS : S ∈ subgroup.right_transversals (H : set G))
+  (g : G) : g * (to_fun hS g : G)⁻¹ ∈ H :=
 quotient.exact' (mk'_to_equiv hS _)
 
-lemma to_fun_mul_inv_mem (hS : S ∈ subgroup.right_transversals (H : set G)) (g : G) :
-  (to_fun hS g : G) * g⁻¹ ∈ H :=
+@[to_additive] lemma to_fun_mul_inv_mem (hS : S ∈ subgroup.right_transversals (H : set G))
+  (g : G) : (to_fun hS g : G) * g⁻¹ ∈ H :=
 (congr_arg (∈ H) (by rw [mul_inv_rev, inv_inv])).mp (H.inv_mem (mul_inv_to_fun_mem hS g))
 
 end mem_right_transversals

--- a/src/group_theory/complement.lean
+++ b/src/group_theory/complement.lean
@@ -306,5 +306,3 @@ lemma is_complement'_of_coprime [fintype G] [fintype H] [fintype K]
 is_complement'_of_card_mul_and_disjoint h1 (disjoint_iff.mpr (inf_eq_bot_of_coprime h2))
 
 end subgroup
-
-#lint

--- a/src/group_theory/complement.lean
+++ b/src/group_theory/complement.lean
@@ -198,6 +198,51 @@ mem_left_transversals_iff_exists_unique_quotient_mk'_eq.trans
 mem_right_transversals_iff_exists_unique_quotient_mk'_eq.trans
   (function.bijective_iff_exists_unique (S.restrict quotient.mk')).symm
 
+namespace mem_left_transversals
+
+noncomputable def to_equiv (hS : S ∈ subgroup.left_transversals (H : set G)) : G ⧸ H ≃ S :=
+(equiv.of_bijective _ (subgroup.mem_left_transversals_iff_bijective.mp hS)).symm
+
+lemma mk'_to_equiv (hS : S ∈ subgroup.left_transversals (H : set G)) (q : G ⧸ H) :
+  quotient.mk' (to_equiv hS q : G) = q :=
+(to_equiv hS).symm_apply_apply q
+
+noncomputable def to_fun (hS : S ∈ subgroup.left_transversals (H : set G)) : G → S :=
+to_equiv hS ∘ quotient.mk'
+
+lemma inv_to_fun_mul_mem (hS : S ∈ subgroup.left_transversals (H : set G)) (g : G) :
+  (to_fun hS g : G)⁻¹ * g ∈ H :=
+quotient.exact' (mk'_to_equiv hS g)
+
+lemma inv_mul_to_fun_mem (hS : S ∈ subgroup.left_transversals (H : set G)) (g : G) :
+  g⁻¹ * to_fun hS g ∈ H :=
+(congr_arg (∈ H) (by rw [mul_inv_rev, inv_inv])).mp (H.inv_mem (inv_to_fun_mul_mem hS g))
+
+end mem_left_transversals
+
+namespace mem_right_transversals
+
+noncomputable def to_equiv (hS : S ∈ subgroup.right_transversals (H : set G)) :
+  quotient (quotient_group.right_rel H) ≃ S :=
+(equiv.of_bijective _ (subgroup.mem_right_transversals_iff_bijective.mp hS)).symm
+
+lemma mk'_to_equiv (hS : S ∈ subgroup.right_transversals (H : set G))
+  (q : quotient (quotient_group.right_rel H)) : quotient.mk' (to_equiv hS q : G) = q :=
+(to_equiv hS).symm_apply_apply q
+
+noncomputable def to_fun (hS : S ∈ subgroup.right_transversals (H : set G)) : G → S :=
+to_equiv hS ∘ quotient.mk'
+
+lemma mul_inv_to_fun_mem (hS : S ∈ subgroup.right_transversals (H : set G)) (g : G) :
+  g * (to_fun hS g : G)⁻¹ ∈ H :=
+quotient.exact' (mk'_to_equiv hS _)
+
+lemma to_fun_mul_inv_mem (hS : S ∈ subgroup.right_transversals (H : set G)) (g : G) :
+  (to_fun hS g : G) * g⁻¹ ∈ H :=
+(congr_arg (∈ H) (by rw [mul_inv_rev, inv_inv])).mp (H.inv_mem (mul_inv_to_fun_mem hS g))
+
+end mem_right_transversals
+
 @[to_additive] instance : inhabited (left_transversals (H : set G)) :=
 ⟨⟨set.range quotient.out', mem_left_transversals_iff_bijective.mpr ⟨by
 { rintros ⟨_, q₁, rfl⟩ ⟨_, q₂, rfl⟩ hg,

--- a/src/group_theory/complement.lean
+++ b/src/group_theory/complement.lean
@@ -200,6 +200,7 @@ mem_right_transversals_iff_exists_unique_quotient_mk'_eq.trans
 
 namespace mem_left_transversals
 
+/-- A left transversal is in bijection with left cosets. -/
 noncomputable def to_equiv (hS : S ∈ subgroup.left_transversals (H : set G)) : G ⧸ H ≃ S :=
 (equiv.of_bijective _ (subgroup.mem_left_transversals_iff_bijective.mp hS)).symm
 
@@ -207,6 +208,8 @@ lemma mk'_to_equiv (hS : S ∈ subgroup.left_transversals (H : set G)) (q : G �
   quotient.mk' (to_equiv hS q : G) = q :=
 (to_equiv hS).symm_apply_apply q
 
+/-- A left transversal can be viewed as a function mapping each element of the group to the
+  chosen representative from that left coset. -/
 noncomputable def to_fun (hS : S ∈ subgroup.left_transversals (H : set G)) : G → S :=
 to_equiv hS ∘ quotient.mk'
 
@@ -222,6 +225,7 @@ end mem_left_transversals
 
 namespace mem_right_transversals
 
+/-- A right transversal is in bijection with right cosets. -/
 noncomputable def to_equiv (hS : S ∈ subgroup.right_transversals (H : set G)) :
   quotient (quotient_group.right_rel H) ≃ S :=
 (equiv.of_bijective _ (subgroup.mem_right_transversals_iff_bijective.mp hS)).symm
@@ -230,6 +234,8 @@ lemma mk'_to_equiv (hS : S ∈ subgroup.right_transversals (H : set G))
   (q : quotient (quotient_group.right_rel H)) : quotient.mk' (to_equiv hS q : G) = q :=
 (to_equiv hS).symm_apply_apply q
 
+/-- A right transversal can be viewed as a function mapping each element of the group to the
+  chosen representative from that right coset. -/
 noncomputable def to_fun (hS : S ∈ subgroup.right_transversals (H : set G)) : G → S :=
 to_equiv hS ∘ quotient.mk'
 
@@ -300,3 +306,5 @@ lemma is_complement'_of_coprime [fintype G] [fintype H] [fintype K]
 is_complement'_of_card_mul_and_disjoint h1 (disjoint_iff.mpr (inf_eq_bot_of_coprime h2))
 
 end subgroup
+
+#lint


### PR DESCRIPTION
This PR adds interpretations of transversals as functions mapping elements of `G` to the chosen coset representative.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
