### PR TITLE
[Merged by Bors] - feat(data/nat/sqrt_norm_num): norm_num extension for sqrt

### DIFF
--- a/src/data/nat/prime.lean
+++ b/src/data/nat/prime.lean
@@ -6,9 +6,8 @@ Authors: Leonardo de Moura, Jeremy Avigad, Mario Carneiro
 import data.list.prime
 import data.list.sort
 import data.nat.gcd
-import data.nat.sqrt
+import data.nat.sqrt_norm_num
 import data.set.finite
-import tactic.norm_num
 import tactic.wlog
 
 /-!

--- a/src/data/nat/sqrt_norm_num.lean
+++ b/src/data/nat/sqrt_norm_num.lean
@@ -18,7 +18,7 @@ lemma is_sqrt {n a a2 b : ℕ}
   (ha2 : a * a = a2) (hb : a2 + b = n) (hle : b ≤ bit0 a) : sqrt n = a :=
 by { rw [← hb, ← ha2, ← pow_two], exact sqrt_add_eq' _ hle }
 
-/-- Given `n` proves `(a, ⊢ nat.sqrt n = a)`. -/
+/-- Given `n` provides `(a, ⊢ nat.sqrt n = a)`. -/
 meta def prove_sqrt (ic : instance_cache) (n : expr) : tactic (instance_cache × expr × expr) := do
   nn ← n.to_nat,
   let na := nn.sqrt,
@@ -26,7 +26,6 @@ meta def prove_sqrt (ic : instance_cache) (n : expr) : tactic (instance_cache ×
   (ic, a2, ha2) ← prove_mul_nat ic a a,
   (ic, b) ← ic.of_nat (nn - na*na),
   (ic, hb) ← prove_add_nat ic a2 b n,
-  (ic, b2, hb2) ← prove_mul_nat ic b b,
   (ic, hle) ← prove_le_nat ic b (`(bit0:ℕ→ℕ).mk_app [a]),
   pure (ic, a, `(@is_sqrt).mk_app [n, a, a2, b, ha2, hb, hle])
 

--- a/src/data/nat/sqrt_norm_num.lean
+++ b/src/data/nat/sqrt_norm_num.lean
@@ -16,10 +16,7 @@ open tactic nat
 
 lemma is_sqrt {n a a2 b : ℕ}
   (ha2 : a * a = a2) (hb : a2 + b = n) (hle : b ≤ bit0 a) : sqrt n = a :=
-begin
-  refine (eq_sqrt.2 ⟨by rw [ha2, ← hb]; apply nat.le_add_right, _⟩).symm,
-  rwa [succ_mul, mul_succ, add_succ, lt_succ_iff, ha2, ← hb, add_assoc, add_le_add_iff_left],
-end
+by { rw [← hb, ← ha2, ← pow_two], exact sqrt_add_eq' _ hle }
 
 /-- Given `n` proves `(a, ⊢ nat.sqrt n = a)`. -/
 meta def prove_sqrt (ic : instance_cache) (n : expr) : tactic (instance_cache × expr × expr) := do

--- a/src/data/nat/sqrt_norm_num.lean
+++ b/src/data/nat/sqrt_norm_num.lean
@@ -1,0 +1,48 @@
+/-
+Copyright (c) 2022 Mario Carneiro. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Mario Carneiro
+-/
+import tactic.norm_num
+import data.nat.sqrt
+
+/-! ### `norm_num` plugin for `sqrt`
+
+The `norm_num` plugin evaluates `sqrt` by bounding it between consecutive integers.
+-/
+
+namespace norm_num
+open tactic nat
+
+lemma is_sqrt {n a a2 b : ℕ}
+  (ha2 : a * a = a2) (hb : a2 + b = n) (hle : b ≤ bit0 a) : sqrt n = a :=
+begin
+  refine (eq_sqrt.2 ⟨by rw [ha2, ← hb]; apply nat.le_add_right, _⟩).symm,
+  rwa [succ_mul, mul_succ, add_succ, lt_succ_iff, ha2, ← hb, add_assoc, add_le_add_iff_left],
+end
+
+/-- Given `n` proves `(a, ⊢ nat.sqrt n = a)`. -/
+meta def prove_sqrt (ic : instance_cache) (n : expr) : tactic (instance_cache × expr × expr) := do
+  nn ← n.to_nat,
+  let na := nn.sqrt,
+  (ic, a) ← ic.of_nat na,
+  (ic, a2, ha2) ← prove_mul_nat ic a a,
+  (ic, b) ← ic.of_nat (nn - na*na),
+  (ic, hb) ← prove_add_nat ic a2 b n,
+  (ic, b2, hb2) ← prove_mul_nat ic b b,
+  (ic, hle) ← prove_le_nat ic b (`(bit0:ℕ→ℕ).mk_app [a]),
+  pure (ic, a, `(@is_sqrt).mk_app [n, a, a2, b, ha2, hb, hle])
+
+/-- A `norm_num` plugin for `sqrt n` when `n` is a numeral. -/
+@[norm_num] meta def eval_sqrt : expr → tactic (expr × expr)
+| `(sqrt %%en) := do
+    n ← en.to_nat,
+    match n with
+    | 0 := pure (`(0:ℕ), `(sqrt_zero))
+    | _ := do
+      c ← mk_instance_cache `(ℕ),
+      prod.snd <$> prove_sqrt c en
+    end
+| _ := failed
+
+end norm_num

--- a/test/norm_num_ext.lean
+++ b/test/norm_num_ext.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro
 -/
 import data.int.gcd
+import data.nat.sqrt_norm_num
 import data.nat.prime
 import algebra.squarefree
 
@@ -12,6 +13,17 @@ import algebra.squarefree
 -/
 
 -- coverage tests
+example : nat.sqrt 0 = 0 := by norm_num
+example : nat.sqrt 1 = 1 := by norm_num
+example : nat.sqrt 2 = 1 := by norm_num
+example : nat.sqrt 3 = 1 := by norm_num
+example : nat.sqrt 4 = 2 := by norm_num
+example : nat.sqrt 9 = 3 := by norm_num
+example : nat.sqrt 10 = 3 := by norm_num
+example : nat.sqrt 100 = 10 := by norm_num
+example : nat.sqrt 120 = 10 := by norm_num
+example : nat.sqrt 121 = 11 := by norm_num
+
 example : nat.coprime 1 2 := by norm_num
 example : nat.coprime 2 1 := by norm_num
 example : ¬ nat.coprime 0 0 := by norm_num


### PR DESCRIPTION
Inspired by https://leanprover.zulipchat.com/#narrow/stream/217875-Is-there-code-for-X.3F/topic/2.20is.20not.20a.20square . The norm_num extension has to go in a separate file from `data.nat.sqrt` because `data.nat.sqrt` is a dependency of `norm_num`.