### PR TITLE
[Merged by Bors] - docs(algebra/order/floor): Update floor_semiring docs to reflect it's just an ordered_semiring

### DIFF
--- a/src/algebra/order/floor.lean
+++ b/src/algebra/order/floor.lean
@@ -15,7 +15,7 @@ We define the natural- and integer-valued floor and ceil functions on linearly o
 
 ## Main Definitions
 
-* `floor_semiring`: A linearly ordered semiring with natural-valued floor and ceil.
+* `floor_semiring`: An ordered semiring with natural-valued floor and ceil.
 * `nat.floor a`: Greatest natural `n` such that `n ≤ a`. Equal to `0` if `a < 0`.
 * `nat.ceil a`: Least natural `n` such that `a ≤ n`.
 
@@ -51,8 +51,9 @@ variables {α : Type*}
 
 /-! ### Floor semiring -/
 
-/-- A `floor_semiring` is a linear ordered semiring over `α` with a function
-`floor : α → ℕ` satisfying `∀ (n : ℕ) (x : α), n ≤ ⌊x⌋ ↔ (n : α) ≤ x)`. -/
+/-- A `floor_semiring` is an ordered semiring over `α` with a function
+`floor : α → ℕ` satisfying `∀ (n : ℕ) (x : α), n ≤ ⌊x⌋ ↔ (n : α) ≤ x)`.
+Note that many lemmas require a `linear_order`. Please see the above `TODO`. -/
 class floor_semiring (α) [linear_ordered_semiring α] :=
 (floor : α → ℕ)
 (ceil : α → ℕ)
@@ -70,7 +71,7 @@ instance : floor_semiring ℕ :=
 namespace nat
 
 section ordered_semiring
-variables [linear_ordered_semiring α] [floor_semiring α] {a : α} {n : ℕ}
+variables [ordered_semiring α] [floor_semiring α] {a : α} {n : ℕ}
 
 /-- `⌊a⌋₊` is the greatest natural `n` such that `n ≤ a`. If `a` is negative, then `⌊a⌋₊ = 0`. -/
 def floor : α → ℕ := floor_semiring.floor

--- a/src/algebra/order/floor.lean
+++ b/src/algebra/order/floor.lean
@@ -54,7 +54,7 @@ variables {α : Type*}
 /-- A `floor_semiring` is an ordered semiring over `α` with a function
 `floor : α → ℕ` satisfying `∀ (n : ℕ) (x : α), n ≤ ⌊x⌋ ↔ (n : α) ≤ x)`.
 Note that many lemmas require a `linear_order`. Please see the above `TODO`. -/
-class floor_semiring (α) [linear_ordered_semiring α] :=
+class floor_semiring (α) [ordered_semiring α] :=
 (floor : α → ℕ)
 (ceil : α → ℕ)
 (floor_of_neg {a : α} (ha : a < 0) : floor a = 0)

--- a/src/algebra/order/floor.lean
+++ b/src/algebra/order/floor.lean
@@ -53,7 +53,7 @@ variables {α : Type*}
 
 /-- A `floor_semiring` is a linear ordered semiring over `α` with a function
 `floor : α → ℕ` satisfying `∀ (n : ℕ) (x : α), n ≤ ⌊x⌋ ↔ (n : α) ≤ x)`. -/
-class floor_semiring (α) [ordered_semiring α] :=
+class floor_semiring (α) [linear_ordered_semiring α] :=
 (floor : α → ℕ)
 (ceil : α → ℕ)
 (floor_of_neg {a : α} (ha : a < 0) : floor a = 0)
@@ -70,7 +70,7 @@ instance : floor_semiring ℕ :=
 namespace nat
 
 section ordered_semiring
-variables [ordered_semiring α] [floor_semiring α] {a : α} {n : ℕ}
+variables [linear_ordered_semiring α] [floor_semiring α] {a : α} {n : ℕ}
 
 /-- `⌊a⌋₊` is the greatest natural `n` such that `n ≤ a`. If `a` is negative, then `⌊a⌋₊ = 0`. -/
 def floor : α → ℕ := floor_semiring.floor

--- a/src/algebra/order/nonneg.lean
+++ b/src/algebra/order/nonneg.lean
@@ -266,7 +266,7 @@ instance canonically_linear_ordered_add_monoid [linear_ordered_ring α] :
   canonically_linear_ordered_add_monoid {x : α // 0 ≤ x} :=
 { ..subtype.linear_order _, ..nonneg.canonically_ordered_add_monoid }
 
-instance floor_semiring [ordered_semiring α] [floor_semiring α] : floor_semiring {r : α // 0 ≤ r} :=
+instance floor_semiring [linear_ordered_semiring α] [floor_semiring α] : floor_semiring {r : α // 0 ≤ r} :=
 { floor := λ a, ⌊(a : α)⌋₊,
   ceil := λ a, ⌈(a : α)⌉₊,
   floor_of_neg := λ a ha, floor_semiring.floor_of_neg ha,
@@ -279,10 +279,10 @@ instance floor_semiring [ordered_semiring α] [floor_semiring α] : floor_semiri
     rw [←subtype.coe_le_coe, nonneg.coe_nat_cast]
   end}
 
-@[norm_cast] lemma nat_floor_coe [ordered_semiring α] [floor_semiring α] (a : {r : α // 0 ≤ r}) :
+@[norm_cast] lemma nat_floor_coe [linear_ordered_semiring α] [floor_semiring α] (a : {r : α // 0 ≤ r}) :
   ⌊(a : α)⌋₊ = ⌊a⌋₊ := rfl
 
-@[norm_cast] lemma nat_ceil_coe [ordered_semiring α] [floor_semiring α] (a : {r : α // 0 ≤ r}) :
+@[norm_cast] lemma nat_ceil_coe [linear_ordered_semiring α] [floor_semiring α] (a : {r : α // 0 ≤ r}) :
   ⌈(a : α)⌉₊ = ⌈a⌉₊  := rfl
 
 section linear_order

--- a/src/algebra/order/nonneg.lean
+++ b/src/algebra/order/nonneg.lean
@@ -266,7 +266,7 @@ instance canonically_linear_ordered_add_monoid [linear_ordered_ring α] :
   canonically_linear_ordered_add_monoid {x : α // 0 ≤ x} :=
 { ..subtype.linear_order _, ..nonneg.canonically_ordered_add_monoid }
 
-instance floor_semiring [linear_ordered_semiring α] [floor_semiring α] : floor_semiring {r : α // 0 ≤ r} :=
+instance floor_semiring [ordered_semiring α] [floor_semiring α] : floor_semiring {r : α // 0 ≤ r} :=
 { floor := λ a, ⌊(a : α)⌋₊,
   ceil := λ a, ⌈(a : α)⌉₊,
   floor_of_neg := λ a ha, floor_semiring.floor_of_neg ha,
@@ -279,10 +279,10 @@ instance floor_semiring [linear_ordered_semiring α] [floor_semiring α] : floor
     rw [←subtype.coe_le_coe, nonneg.coe_nat_cast]
   end}
 
-@[norm_cast] lemma nat_floor_coe [linear_ordered_semiring α] [floor_semiring α] (a : {r : α // 0 ≤ r}) :
+@[norm_cast] lemma nat_floor_coe [ordered_semiring α] [floor_semiring α] (a : {r : α // 0 ≤ r}) :
   ⌊(a : α)⌋₊ = ⌊a⌋₊ := rfl
 
-@[norm_cast] lemma nat_ceil_coe [linear_ordered_semiring α] [floor_semiring α] (a : {r : α // 0 ≤ r}) :
+@[norm_cast] lemma nat_ceil_coe [ordered_semiring α] [floor_semiring α] (a : {r : α // 0 ≤ r}) :
   ⌈(a : α)⌉₊ = ⌈a⌉₊  := rfl
 
 section linear_order


### PR DESCRIPTION
The docs say that `floor_semiring` is a linear ordered semiring, but it is only an `ordered_semiring` in the code. Change the docs to reflect this fact.



---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
