### PR TITLE
feat(group_theory/index): Intersection of finite index subgroups

### DIFF
--- a/src/group_theory/index.lean
+++ b/src/group_theory/index.lean
@@ -219,4 +219,22 @@ by { rw index_eq_card, exact fintype.card_ne_zero }
 lemma one_lt_index_of_ne_top [fintype (G ⧸ H)] (hH : H ≠ ⊤) : 1 < H.index :=
 nat.one_lt_iff_ne_zero_and_ne_one.mpr ⟨index_ne_zero_of_fintype, mt index_eq_one.mp hH⟩
 
+variables (H K)
+
+class finite_index : Prop :=
+(finite_index : H.index ≠ 0)
+
+instance : finite_index (⊤ : subgroup G) :=
+⟨by rw index_top; exact one_ne_zero⟩
+
+instance [hH : finite_index H] [hK : finite_index K] : finite_index (H ⊓ K) :=
+⟨begin
+  replace hH : H.relindex ⊤ ≠ 0 := by rw relindex_top_right; exact hH.1,
+  replace hK : K.relindex ⊤ ≠ 0 := by rw relindex_top_right; exact hK.1,
+  have hHK : H.relindex K ≠ 0 := mt (relindex_eq_zero_of_le_right le_top) hH,
+  rw ← inf_relindex_right at hHK,
+  rw ← relindex_top_right,
+  exact relindex_ne_zero_trans hHK hK,
+end⟩
+
 end subgroup

--- a/src/group_theory/index.lean
+++ b/src/group_theory/index.lean
@@ -221,6 +221,7 @@ nat.one_lt_iff_ne_zero_and_ne_one.mpr ⟨index_ne_zero_of_fintype, mt index_eq_o
 
 variables (H K)
 
+/-- Typeclass for finite index subgroups. -/
 class finite_index : Prop :=
 (finite_index : H.index ≠ 0)
 


### PR DESCRIPTION
This PR adds a typeclass for finite index subgroups, and proves that finite index subgroups are closed under intersection.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
