### PR TITLE
[Merged by Bors] - feat(set_theory/cardinal): `cardinal.to_nat` is order-preserving on finite cardinals

### DIFF
--- a/src/set_theory/cardinal.lean
+++ b/src/set_theory/cardinal.lean
@@ -1023,9 +1023,21 @@ lemma cast_to_nat_of_omega_le {c : cardinal} (h : ω ≤ c) :
   ↑c.to_nat = (0 : cardinal) :=
 by rw [to_nat_apply_of_omega_le h, nat.cast_zero]
 
-lemma to_nat_mono_of_lt_omega {c d : cardinal} (hd : d < ω) (hcd : c ≤ d) :
+lemma to_nat_le_to_nat_iff_of_lt_omega {c d : cardinal} (hc : c < ω) (hd : d < ω) :
+  c.to_nat ≤ d.to_nat ↔ c ≤ d :=
+by rw [←nat_cast_le, cast_to_nat_of_lt_omega hc, cast_to_nat_of_lt_omega hd]
+
+lemma to_nat_lt_to_nat_iff_of_lt_omega {c d : cardinal} (hc : c < ω) (hd : d < ω) :
+  c.to_nat < d.to_nat ↔ c < d :=
+by rw [←nat_cast_lt, cast_to_nat_of_lt_omega hc, cast_to_nat_of_lt_omega hd]
+
+lemma to_nat_le_to_nat_of_lt_omega {c d : cardinal} (hd : d < ω) (hcd : c ≤ d) :
   c.to_nat ≤ d.to_nat :=
-by rwa [←nat_cast_le, cast_to_nat_of_lt_omega (lt_of_le_of_lt hcd hd), cast_to_nat_of_lt_omega hd]
+(to_nat_le_to_nat_iff_of_lt_omega (lt_of_le_of_lt hcd hd) hd).mpr hcd
+
+lemma to_nat_lt_to_nat_of_lt_omega {c d : cardinal} (hd : d < ω) (hcd : c < d) :
+  c.to_nat < d.to_nat :=
+(to_nat_lt_to_nat_iff_of_lt_omega (hcd.trans hd) hd).mpr hcd
 
 @[simp]
 lemma to_nat_cast (n : ℕ) : cardinal.to_nat n = n :=

--- a/src/set_theory/cardinal.lean
+++ b/src/set_theory/cardinal.lean
@@ -1023,21 +1023,21 @@ lemma cast_to_nat_of_omega_le {c : cardinal} (h : ω ≤ c) :
   ↑c.to_nat = (0 : cardinal) :=
 by rw [to_nat_apply_of_omega_le h, nat.cast_zero]
 
-lemma to_nat_le_to_nat_iff_of_lt_omega {c d : cardinal} (hc : c < ω) (hd : d < ω) :
+lemma to_nat_le_iff_le_of_lt_omega {c d : cardinal} (hc : c < ω) (hd : d < ω) :
   c.to_nat ≤ d.to_nat ↔ c ≤ d :=
 by rw [←nat_cast_le, cast_to_nat_of_lt_omega hc, cast_to_nat_of_lt_omega hd]
 
-lemma to_nat_lt_to_nat_iff_of_lt_omega {c d : cardinal} (hc : c < ω) (hd : d < ω) :
+lemma to_nat_lt_iff_lt_of_lt_omega {c d : cardinal} (hc : c < ω) (hd : d < ω) :
   c.to_nat < d.to_nat ↔ c < d :=
 by rw [←nat_cast_lt, cast_to_nat_of_lt_omega hc, cast_to_nat_of_lt_omega hd]
 
-lemma to_nat_le_to_nat_of_lt_omega {c d : cardinal} (hd : d < ω) (hcd : c ≤ d) :
+lemma to_nat_le_of_le_of_lt_omega {c d : cardinal} (hd : d < ω) (hcd : c ≤ d) :
   c.to_nat ≤ d.to_nat :=
-(to_nat_le_to_nat_iff_of_lt_omega (lt_of_le_of_lt hcd hd) hd).mpr hcd
+(to_nat_le_iff_le_of_lt_omega (lt_of_le_of_lt hcd hd) hd).mpr hcd
 
-lemma to_nat_lt_to_nat_of_lt_omega {c d : cardinal} (hd : d < ω) (hcd : c < d) :
+lemma to_nat_lt_of_lt_of_lt_omega {c d : cardinal} (hd : d < ω) (hcd : c < d) :
   c.to_nat < d.to_nat :=
-(to_nat_lt_to_nat_iff_of_lt_omega (hcd.trans hd) hd).mpr hcd
+(to_nat_lt_iff_lt_of_lt_omega (hcd.trans hd) hd).mpr hcd
 
 @[simp]
 lemma to_nat_cast (n : ℕ) : cardinal.to_nat n = n :=

--- a/src/set_theory/cardinal.lean
+++ b/src/set_theory/cardinal.lean
@@ -1023,6 +1023,10 @@ lemma cast_to_nat_of_omega_le {c : cardinal} (h : ω ≤ c) :
   ↑c.to_nat = (0 : cardinal) :=
 by rw [to_nat_apply_of_omega_le h, nat.cast_zero]
 
+lemma to_nat_mono_of_lt_omega {c d : cardinal} (hd : d < ω) (hcd : c ≤ d) :
+  c.to_nat ≤ d.to_nat :=
+by rwa [←nat_cast_le, cast_to_nat_of_lt_omega (lt_of_le_of_lt hcd hd), cast_to_nat_of_lt_omega hd]
+
 @[simp]
 lemma to_nat_cast (n : ℕ) : cardinal.to_nat n = n :=
 begin


### PR DESCRIPTION
This PR proves that `cardinal.to_nat` is order-preserving on finite cardinals.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
