### PR TITLE
[Merged by Bors] - refactor(topology/algebra/field): make `topological_division_ring` extend `has_continuous_inv₀`

### DIFF
--- a/src/topology/algebra/field.lean
+++ b/src/topology/algebra/field.lean
@@ -67,8 +67,7 @@ variables (K : Type*) [division_ring K] [topological_space K]
 
 /-- A topological division ring is a division ring with a topology where all operations are
     continuous, including inversion. -/
-class topological_division_ring extends topological_ring K : Prop :=
-(continuous_inv : ∀ x : K, x ≠ 0 → continuous_at (λ x : K, x⁻¹ : K → K) x)
+class topological_division_ring extends topological_ring K, has_continuous_inv₀ K : Prop
 
 namespace topological_division_ring
 open filter set
@@ -98,7 +97,7 @@ lemma units_top_group : topological_group Kˣ :=
      rw [continuous_at, nhds_induced, nhds_induced, tendsto_iff_comap, comap_comm this],
      apply comap_mono,
      rw [← tendsto_iff_comap, units.coe_inv'],
-     exact topological_division_ring.continuous_inv (x : K) x.ne_zero
+     exact continuous_at_inv₀ x.ne_zero
    end ,
   ..topological_ring.top_monoid_units K}
 

--- a/src/topology/algebra/group_with_zero.lean
+++ b/src/topology/algebra/group_with_zero.lean
@@ -73,7 +73,7 @@ end div_const
 
 /-- A type with `0` and `has_inv` such that `λ x, x⁻¹` is continuous at all nonzero points. Any
 normed (semi)field has this property. -/
-class has_continuous_inv₀ (G₀ : Type*) [has_zero G₀] [has_inv G₀] [topological_space G₀] :=
+class has_continuous_inv₀ (G₀ : Type*) [has_zero G₀] [has_inv G₀] [topological_space G₀] : Prop :=
 (continuous_at_inv₀ : ∀ ⦃x : G₀⦄, x ≠ 0 → continuous_at has_inv.inv x)
 
 export has_continuous_inv₀ (continuous_at_inv₀)

--- a/src/topology/algebra/uniform_field.lean
+++ b/src/topology/algebra/uniform_field.lean
@@ -93,7 +93,7 @@ variables [topological_division_ring K]
 
 lemma hat_inv_extends {x : K} (h : x ≠ 0) : hat_inv (x : hat K) = coe (x⁻¹ : K) :=
 dense_inducing_coe.extend_eq_at
-    ((continuous_coe K).continuous_at.comp (topological_division_ring.continuous_inv x h))
+    ((continuous_coe K).continuous_at.comp (continuous_at_inv₀ h))
 
 variables [completable_top_field K]
 
@@ -155,7 +155,7 @@ instance field_completion : field (hat K) :=
   ..(by apply_instance : comm_ring (hat K)) }
 
 instance topological_division_ring_completion : topological_division_ring (hat K) :=
-{ continuous_inv := begin
+{ continuous_at_inv₀ := begin
     intros x x_ne,
     have : {y | hat_inv y = y⁻¹ } ∈ 𝓝 x,
     { have : {(0 : hat K)}ᶜ ⊆ {y : hat K | hat_inv y = y⁻¹ },

--- a/src/topology/algebra/valued_field.lean
+++ b/src/topology/algebra/valued_field.lean
@@ -83,7 +83,7 @@ open valued
     [BouAC, VI.5.1 middle of Proposition 1] -/
 @[priority 100]
 instance valued.topological_division_ring [valued K Γ₀] : topological_division_ring K :=
-{ continuous_inv :=
+{ continuous_at_inv₀ :=
     begin
       intros x x_ne s s_in,
       cases valued.mem_nhds.mp s_in with γ hs, clear s_in,
@@ -231,7 +231,7 @@ lemma valued.continuous_extension : continuous (valued.extension : hat K → Γ�
         conv {congr, skip, skip, rw ← (one_mul (1 : hat K))},
         refine tendsto.mul continuous_fst.continuous_at
                            (tendsto.comp _ continuous_snd.continuous_at),
-        convert topological_division_ring.continuous_inv (1 : hat K) zero_ne_one.symm,
+        convert @continuous_at_inv₀ (hat K) _ _ _ _ _ zero_ne_one.symm,
         exact inv_one.symm },
       rcases tendsto_prod_self_iff.mp this V V_in with ⟨U, U_in, hU⟩,
       let hatKstar := ({0}ᶜ : set $ hat K),

--- a/src/topology/algebra/valued_field.lean
+++ b/src/topology/algebra/valued_field.lean
@@ -231,7 +231,7 @@ lemma valued.continuous_extension : continuous (valued.extension : hat K → Γ�
         conv {congr, skip, skip, rw ← (one_mul (1 : hat K))},
         refine tendsto.mul continuous_fst.continuous_at
                            (tendsto.comp _ continuous_snd.continuous_at),
-        convert @continuous_at_inv₀ (hat K) _ _ _ _ _ zero_ne_one.symm,
+        convert continuous_at_inv₀ (zero_ne_one.symm : 1 ≠ (0 : hat K)),
         exact inv_one.symm },
       rcases tendsto_prod_self_iff.mp this V V_in with ⟨U, U_in, hU⟩,
       let hatKstar := ({0}ᶜ : set $ hat K),


### PR DESCRIPTION
Topological division ring had been rolling its own `continuous_inv` field which was almost identical to the `continuous_at_inv₀` field of `has_continuous_inv₀`. Here we refactor so that `topological_division_ring` extends `has_continuous_inv₀` instead.

- [x] depends on: #12770 

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
