### PR TITLE
[Merged by Bors] - feat(analysis/*): generalize `set_smul_mem_nhds_zero` to topological vector spaces

### DIFF
--- a/src/analysis/locally_convex/basic.lean
+++ b/src/analysis/locally_convex/basic.lean
@@ -218,6 +218,24 @@ end
 
 variables [topological_space E] [has_continuous_smul 𝕜 E]
 
+/-- Scalar multiplication preserves neighborhoods of zero. -/
+lemma set_smul_mem_nhds_zero {c : 𝕜} {s : set E} (hs : s ∈ 𝓝 (0 : E)) (hc : c ≠ 0) :
+  c • s ∈ 𝓝 (0 : E) :=
+begin
+  rcases mem_nhds_iff.mp hs with ⟨U, hs', hU, hU'⟩,
+  refine mem_nhds_iff.mpr ⟨c • U, set.smul_set_mono hs', is_open.smul₀ hU hc, _⟩,
+  convert set.smul_mem_smul_set hU',
+  exact (smul_zero c).symm,
+end
+
+lemma set_smul_mem_nhds_zero_iff (s : set E) {c : 𝕜} (hc : c ≠ 0) :
+  c • s ∈ 𝓝 (0 : E) ↔ s ∈ 𝓝 (0 : E) :=
+begin
+  refine ⟨λ h, _, λ h, set_smul_mem_nhds_zero h hc⟩,
+  convert set_smul_mem_nhds_zero h (inv_ne_zero hc),
+  rw [smul_smul, inv_mul_cancel hc, one_smul],
+end
+
 /-- Every neighbourhood of the origin is absorbent. -/
 lemma absorbent_nhds_zero (hA : A ∈ 𝓝 (0 : E)) : absorbent 𝕜 A :=
 begin

--- a/src/analysis/locally_convex/basic.lean
+++ b/src/analysis/locally_convex/basic.lean
@@ -218,24 +218,6 @@ end
 
 variables [topological_space E] [has_continuous_smul 𝕜 E]
 
-/-- Scalar multiplication preserves neighborhoods of zero. -/
-lemma set_smul_mem_nhds_zero {c : 𝕜} {s : set E} (hs : s ∈ 𝓝 (0 : E)) (hc : c ≠ 0) :
-  c • s ∈ 𝓝 (0 : E) :=
-begin
-  rcases mem_nhds_iff.mp hs with ⟨U, hs', hU, hU'⟩,
-  refine mem_nhds_iff.mpr ⟨c • U, set.smul_set_mono hs', is_open.smul₀ hU hc, _⟩,
-  convert set.smul_mem_smul_set hU',
-  exact (smul_zero c).symm,
-end
-
-lemma set_smul_mem_nhds_zero_iff (s : set E) {c : 𝕜} (hc : c ≠ 0) :
-  c • s ∈ 𝓝 (0 : E) ↔ s ∈ 𝓝 (0 : E) :=
-begin
-  refine ⟨λ h, _, λ h, set_smul_mem_nhds_zero h hc⟩,
-  convert set_smul_mem_nhds_zero h (inv_ne_zero hc),
-  rw [smul_smul, inv_mul_cancel hc, one_smul],
-end
-
 /-- Every neighbourhood of the origin is absorbent. -/
 lemma absorbent_nhds_zero (hA : A ∈ 𝓝 (0 : E)) : absorbent 𝕜 A :=
 begin

--- a/src/analysis/normed_space/pointwise.lean
+++ b/src/analysis/normed_space/pointwise.lean
@@ -7,7 +7,6 @@ import analysis.normed.group.pointwise
 import analysis.normed.group.add_torsor
 import analysis.normed_space.basic
 import topology.metric_space.hausdorff_distance
-import analysis.locally_convex.basic
 
 /-!
 # Properties of pointwise scalar multiplication of sets in normed spaces.

--- a/src/analysis/normed_space/pointwise.lean
+++ b/src/analysis/normed_space/pointwise.lean
@@ -7,6 +7,7 @@ import analysis.normed.group.pointwise
 import analysis.normed.group.add_torsor
 import analysis.normed_space.basic
 import topology.metric_space.hausdorff_distance
+import analysis.locally_convex.basic
 
 /-!
 # Properties of pointwise scalar multiplication of sets in normed spaces.
@@ -85,24 +86,6 @@ begin
   have : y = x + r • z, by simp only [hz, add_neg_cancel_left],
   apply hε,
   simpa only [this, dist_eq_norm, add_sub_cancel', mem_closed_ball] using I,
-end
-
-lemma set_smul_mem_nhds_zero {s : set E} (hs : s ∈ 𝓝 (0 : E)) {c : 𝕜} (hc : c ≠ 0) :
-  c • s ∈ 𝓝 (0 : E) :=
-begin
-  obtain ⟨ε, εpos, hε⟩ : ∃ (ε : ℝ) (H : 0 < ε), ball 0 ε ⊆ s := metric.mem_nhds_iff.1 hs,
-  have : c • ball (0 : E) ε ∈ 𝓝 (0 : E),
-  { rw [smul_ball hc, smul_zero],
-    exact ball_mem_nhds _ (mul_pos (by simpa using hc) εpos) },
-  exact filter.mem_of_superset this ((set_smul_subset_set_smul_iff₀ hc).2 hε)
-end
-
-lemma set_smul_mem_nhds_zero_iff (s : set E) {c : 𝕜} (hc : c ≠ 0) :
-  c • s ∈ 𝓝 (0 : E) ↔ s ∈ 𝓝(0 : E) :=
-begin
-  refine ⟨λ h, _, λ h, set_smul_mem_nhds_zero h hc⟩,
-  convert set_smul_mem_nhds_zero h (inv_ne_zero hc),
-  rw [smul_smul, inv_mul_cancel hc, one_smul],
 end
 
 /-- Any ball is the image of a ball centered at the origin under a shift. -/

--- a/src/topology/algebra/const_mul_action.lean
+++ b/src/topology/algebra/const_mul_action.lean
@@ -378,25 +378,42 @@ end
 
 section nhds
 
-variables {G₀ : Type*} [add_comm_group α] [topological_space α] [group_with_zero G₀]
-  [distrib_mul_action G₀ α] [has_continuous_const_smul G₀ α]
+section mul_action
 
-/-- Scalar multiplication preserves neighborhoods of zero. -/
-lemma set_smul_mem_nhds_zero {c : G₀} {s : set α} (hs : s ∈ 𝓝 (0 : α)) (hc : c ≠ 0) :
-  c • s ∈ 𝓝 (0 : α) :=
+variables {G₀ : Type*} [group_with_zero G₀] [mul_action G₀ α]
+  [topological_space α] [has_continuous_const_smul G₀ α]
+
+/-- Scalar multiplication preserves neighborhoods. -/
+lemma set_smul_mem_nhds_smul {c : G₀} {s : set α} {x : α} (hs : s ∈ 𝓝 x) (hc : c ≠ 0) :
+  c • s ∈ 𝓝 (c • x : α) :=
 begin
-  rcases mem_nhds_iff.mp hs with ⟨U, hs', hU, hU'⟩,
-  refine mem_nhds_iff.mpr ⟨c • U, set.smul_set_mono hs', is_open.smul₀ hU hc, _⟩,
-  convert set.smul_mem_smul_set hU',
-  exact (smul_zero c).symm,
+  rw mem_nhds_iff at hs ⊢,
+  obtain ⟨U, hs', hU, hU'⟩ := hs,
+  exact ⟨c • U, set.smul_set_mono hs', hU.smul₀ hc, set.smul_mem_smul_set hU'⟩,
 end
 
-lemma set_smul_mem_nhds_zero_iff (s : set α) {c : G₀} (hc : c ≠ 0) :
+lemma set_smul_mem_nhds_smul_iff {c : G₀} {s : set α} {x : α} (hc : c ≠ 0) :
+  c • s ∈ 𝓝 (c • x : α) ↔ s ∈ 𝓝 x :=
+begin
+  refine ⟨λ h, _, λ h, set_smul_mem_nhds_smul h hc⟩,
+  rw [←inv_smul_smul₀ hc x, ←inv_smul_smul₀ hc s],
+  exact set_smul_mem_nhds_smul h (inv_ne_zero hc),
+end
+
+end mul_action
+
+section distrib_mul_action
+
+variables {G₀ : Type*} [group_with_zero G₀] [add_monoid α] [distrib_mul_action G₀ α]
+  [topological_space α] [has_continuous_const_smul G₀ α]
+
+lemma set_smul_mem_nhds_zero_iff {s : set α} {c : G₀} (hc : c ≠ 0) :
   c • s ∈ 𝓝 (0 : α) ↔ s ∈ 𝓝 (0 : α) :=
 begin
-  refine ⟨λ h, _, λ h, set_smul_mem_nhds_zero h hc⟩,
-  convert set_smul_mem_nhds_zero h (inv_ne_zero hc),
-  rw [smul_smul, inv_mul_cancel hc, one_smul],
+  refine iff.trans _ (set_smul_mem_nhds_smul_iff hc),
+  rw smul_zero,
 end
+
+end distrib_mul_action
 
 end nhds

--- a/src/topology/algebra/const_mul_action.lean
+++ b/src/topology/algebra/const_mul_action.lean
@@ -375,3 +375,28 @@ begin
     simp only [image_smul, not_not, mem_set_of_eq, ne.def] at H,
     exact eq_empty_iff_forall_not_mem.mp H (γ • x) ⟨mem_image_of_mem _ x_in_K₀, h'⟩ },
 end
+
+section nhds
+
+variables {G₀ : Type*} [add_comm_group α] [topological_space α] [group_with_zero G₀]
+  [distrib_mul_action G₀ α] [has_continuous_const_smul G₀ α]
+
+/-- Scalar multiplication preserves neighborhoods of zero. -/
+lemma set_smul_mem_nhds_zero {c : G₀} {s : set α} (hs : s ∈ 𝓝 (0 : α)) (hc : c ≠ 0) :
+  c • s ∈ 𝓝 (0 : α) :=
+begin
+  rcases mem_nhds_iff.mp hs with ⟨U, hs', hU, hU'⟩,
+  refine mem_nhds_iff.mpr ⟨c • U, set.smul_set_mono hs', is_open.smul₀ hU hc, _⟩,
+  convert set.smul_mem_smul_set hU',
+  exact (smul_zero c).symm,
+end
+
+lemma set_smul_mem_nhds_zero_iff (s : set α) {c : G₀} (hc : c ≠ 0) :
+  c • s ∈ 𝓝 (0 : α) ↔ s ∈ 𝓝 (0 : α) :=
+begin
+  refine ⟨λ h, _, λ h, set_smul_mem_nhds_zero h hc⟩,
+  convert set_smul_mem_nhds_zero h (inv_ne_zero hc),
+  rw [smul_smul, inv_mul_cancel hc, one_smul],
+end
+
+end nhds


### PR DESCRIPTION
The lemma holds for arbitrary topological vector spaces and has nothing to do with normed spaces.

Co-authored-by: Eric Wieser <wieser.eric@gmail.com>

---

Fun fact: the proof is simpler.

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
