### PR TITLE
[Merged by Bors] - feat(algebra/char_p/two): add `simp` attribute to some lemmas involving characteristic two identities

### DIFF
--- a/src/algebra/char_p/two.lean
+++ b/src/algebra/char_p/two.lean
@@ -33,6 +33,9 @@ add_self_eq_zero x
 lemma bit1_eq_one (x : R) : (bit1 x : R) = 1 :=
 by rw [bit1, bit0_eq_zero, zero_add]
 
+lemma two_mul_eq_zero (x : R) : (2 : R) * x = 0 :=
+(two_mul _).trans (char_two.add_self_eq_zero _)
+
 end semiring
 
 section ring

--- a/src/algebra/char_p/two.lean
+++ b/src/algebra/char_p/two.lean
@@ -27,11 +27,17 @@ by rw [← nat.cast_two, char_p.cast_eq_zero]
 @[simp] lemma add_self_eq_zero (x : R) : x + x = 0 :=
 by rw [←two_smul R x, two_eq_zero, zero_smul]
 
-@[simp] lemma bit0_eq_zero (x : R) : (bit0 x : R) = 0 :=
-add_self_eq_zero x
+@[simp] lemma bit0_eq_zero : (bit0 : R → R) = 0 :=
+by { funext, exact add_self_eq_zero _ }
 
-@[simp] lemma bit1_eq_one (x : R) : (bit1 x : R) = 1 :=
-by rw [bit1, bit0_eq_zero, zero_add]
+lemma bit0_eq_zero_apply (x : R) : (bit0 x : R) = 0 :=
+by simp
+
+@[simp] lemma bit1_eq_one : (bit1 : R → R) = 1 :=
+by { funext, simp [bit1] }
+
+lemma bit1_eq_one_apply (x : R) : (bit1 x : R) = 1 :=
+by simp
 
 end semiring
 

--- a/src/algebra/char_p/two.lean
+++ b/src/algebra/char_p/two.lean
@@ -21,7 +21,7 @@ namespace char_two
 section semiring
 variables [semiring R] [char_p R 2]
 
-@[simp] lemma two_eq_zero : (2 : R) = 0 :=
+lemma two_eq_zero : (2 : R) = 0 :=
 by rw [← nat.cast_two, char_p.cast_eq_zero]
 
 @[simp] lemma add_self_eq_zero (x : R) : x + x = 0 :=

--- a/src/algebra/char_p/two.lean
+++ b/src/algebra/char_p/two.lean
@@ -21,33 +21,30 @@ namespace char_two
 section semiring
 variables [semiring R] [char_p R 2]
 
-lemma two_eq_zero : (2 : R) = 0 :=
+@[simp] lemma two_eq_zero : (2 : R) = 0 :=
 by rw [← nat.cast_two, char_p.cast_eq_zero]
 
-lemma add_self_eq_zero (x : R) : x + x = 0 :=
+@[simp] lemma add_self_eq_zero (x : R) : x + x = 0 :=
 by rw [←two_smul R x, two_eq_zero, zero_smul]
 
-lemma bit0_eq_zero (x : R) : (bit0 x : R) = 0 :=
+@[simp] lemma bit0_eq_zero (x : R) : (bit0 x : R) = 0 :=
 add_self_eq_zero x
 
-lemma bit1_eq_one (x : R) : (bit1 x : R) = 1 :=
+@[simp] lemma bit1_eq_one (x : R) : (bit1 x : R) = 1 :=
 by rw [bit1, bit0_eq_zero, zero_add]
-
-lemma two_mul_eq_zero (x : R) : 2 * x = 0 :=
-(two_mul _).trans (char_two.add_self_eq_zero _)
 
 end semiring
 
 section ring
 variables [ring R] [char_p R 2]
 
-lemma neg_eq (x : R) : -x = x :=
+@[simp] lemma neg_eq (x : R) : -x = x :=
 by rw [neg_eq_iff_add_eq_zero, ←two_smul R x, two_eq_zero, zero_smul]
 
 lemma neg_eq' : has_neg.neg = (id : R → R) :=
 funext neg_eq
 
-lemma sub_eq_add (x y : R) : x - y = x + y :=
+@[simp] lemma sub_eq_add (x y : R) : x - y = x + y :=
 by rw [sub_eq_add_neg, neg_eq]
 
 lemma sub_eq_add' : has_sub.sub = ((+) : R → R → R) :=

--- a/src/algebra/char_p/two.lean
+++ b/src/algebra/char_p/two.lean
@@ -30,13 +30,13 @@ by rw [←two_smul R x, two_eq_zero, zero_smul]
 @[simp] lemma bit0_eq_zero : (bit0 : R → R) = 0 :=
 by { funext, exact add_self_eq_zero _ }
 
-lemma bit0_eq_zero_apply (x : R) : (bit0 x : R) = 0 :=
+lemma bit0_apply_eq_zero (x : R) : (bit0 x : R) = 0 :=
 by simp
 
 @[simp] lemma bit1_eq_one : (bit1 : R → R) = 1 :=
 by { funext, simp [bit1] }
 
-lemma bit1_eq_one_apply (x : R) : (bit1 x : R) = 1 :=
+lemma bit1_apply_eq_one (x : R) : (bit1 x : R) = 1 :=
 by simp
 
 end semiring

--- a/src/algebra/char_p/two.lean
+++ b/src/algebra/char_p/two.lean
@@ -33,7 +33,7 @@ add_self_eq_zero x
 lemma bit1_eq_one (x : R) : (bit1 x : R) = 1 :=
 by rw [bit1, bit0_eq_zero, zero_add]
 
-lemma two_mul_eq_zero (x : R) : (2 : R) * x = 0 :=
+lemma two_mul_eq_zero (x : R) : 2 * x = 0 :=
 (two_mul _).trans (char_two.add_self_eq_zero _)
 
 end semiring

--- a/src/data/zmod/basic.lean
+++ b/src/data/zmod/basic.lean
@@ -715,9 +715,6 @@ begin
   { simp only [neg_eq_self_mod_two, nat.cast_succ, int.nat_abs, int.cast_neg_succ_of_nat] }
 end
 
-@[simp]
-lemma add_self_mod_two : ∀ (m : zmod 2), m + m = 0 := dec_trivial
-
 @[simp] lemma val_eq_zero : ∀ {n : ℕ} (a : zmod n), a.val = 0 ↔ a = 0
 | 0     a := int.nat_abs_eq_zero
 | (n+1) a := by { rw fin.ext_iff, exact iff.rfl }

--- a/src/data/zmod/basic.lean
+++ b/src/data/zmod/basic.lean
@@ -715,6 +715,9 @@ begin
   { simp only [neg_eq_self_mod_two, nat.cast_succ, int.nat_abs, int.cast_neg_succ_of_nat] }
 end
 
+@[simp]
+lemma add_self_mod_two : ∀ (m : zmod 2), m + m = 0 := dec_trivial
+
 @[simp] lemma val_eq_zero : ∀ {n : ℕ} (a : zmod n), a.val = 0 ↔ a = 0
 | 0     a := int.nat_abs_eq_zero
 | (n+1) a := by { rw fin.ext_iff, exact iff.rfl }


### PR DESCRIPTION
I hope that these `simp` attributes will make working with `char_p R 2` smooth!

I felt clumsy with this section, so hopefully this is an improvement.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.
I added this lemma, since I needed it and could not find it.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
