### PR TITLE
[Merged by Bors] - chore(model_theory/definability): Change variable order in definability

### DIFF
--- a/docs/overview.yaml
+++ b/docs/overview.yaml
@@ -420,5 +420,5 @@ Logic and computation:
     first-order formula: 'first_order.language.formula'
     satisfiability: 'first_order.language.Theory.is_satisfiable'
     substructure: 'first_order.language.substructure'
-    definable set: 'set.definable_set'
+    definable set: 'set.definable'
     elementary embedding: 'first_order.language.elementary_embedding'

--- a/docs/overview.yaml
+++ b/docs/overview.yaml
@@ -244,7 +244,7 @@ Analysis:
     local convexity: 'locally_convex_space'
     Bornology: 'bornology'
     weak-* topology for dualities: 'weak_bilin.topological_space'
-    
+
   Normed vector spaces/Banach spaces:
     normed vector space over a normed field: 'normed_space'
     topology on a normed vector space: 'normed_space.has_bounded_smul'
@@ -420,5 +420,5 @@ Logic and computation:
     first-order formula: 'first_order.language.formula'
     satisfiability: 'first_order.language.Theory.is_satisfiable'
     substructure: 'first_order.language.substructure'
-    definable set: 'first_order.language.definable_set'
+    definable set: 'set.definable_set'
     elementary embedding: 'first_order.language.elementary_embedding'

--- a/src/model_theory/definability.lean
+++ b/src/model_theory/definability.lean
@@ -12,74 +12,71 @@ import model_theory.terms_and_formulas
 This file defines what it means for a set over a first-order structure to be definable.
 
 ## Main Definitions
-* `first_order.language.definable` is defined so that `L.definable A s` indicates that the
+* `set.definable` is defined so that `A.definable L s` indicates that the
 set `s` of a finite cartesian power of `M` is definable with parameters in `A`.
-* `first_order.language.definable₁` is defined so that `L.definable₁ A s` indicates that
+* `set.definable₁` is defined so that `A.definable₁ L s` indicates that
 `(s : set M)` is definable with parameters in `A`.
-* `first_order.language.definable₂` is defined so that `L.definable₂ A s` indicates that
+* `set.definable₂` is defined so that `A.definable₂ L s` indicates that
 `(s : set (M × M))` is definable with parameters in `A`.
-* A `first_order.language.definable_set` is defined so that `L.definable_set α A` is the boolean
+* A `set.definable_set` is defined so that `A.definable_set L α` is the boolean
   algebra of subsets of `α → M` defined by formulas with parameters in `A`.
 
 ## Main Results
-* `L.definable_set M α` forms a `boolean_algebra`.
-* `definable.image_comp_sum` shows that definability is closed under projections.
+* `A.definable_set L α` forms a `boolean_algebra`.
 
 -/
 
 universes u v w
 
-namespace first_order
-namespace language
+namespace set
 
-variables (L : language.{u v}) {M : Type w} [L.Structure M] (A : set M)
+variables {M : Type w} (A : set M) (L : first_order.language.{u v}) [L.Structure M]
 open_locale first_order
-open Structure set
+open first_order.language first_order.language.Structure
 
-variables {α : Type} [fintype α] {β : Type} [fintype β]
+variables {α : Type} {β : Type}
 
 /-- A subset of a finite Cartesian product of a structure is definable over a set `A` when
   membership in the set is given by a first-order formula with parameters from `A`. -/
-structure definable (s : set (α → M)) : Prop :=
-(exists_formula : ∃ (φ : L[[A]].formula α), s = set_of φ.realize)
+def definable (s : set (α → M)) : Prop :=
+∃ (φ : L[[A]].formula α), s = set_of φ.realize
 
 variables {L} {A} {B : set M} {s : set (α → M)}
 
+@[simp]
+lemma definable_empty : A.definable L (∅ : set (α → M)) :=
+⟨⊥, by {ext, simp} ⟩
 
 @[simp]
-lemma definable_empty : L.definable A (∅ : set (α → M)) :=
-⟨⟨⊥, by {ext, simp} ⟩⟩
+lemma definable_univ : A.definable L (univ : set (α → M)) :=
+⟨⊤, by {ext, simp} ⟩
 
 @[simp]
-lemma definable_univ : L.definable A (univ : set (α → M)) :=
-⟨⟨⊤, by {ext, simp} ⟩⟩
-
-@[simp]
-lemma definable.inter {f g : set (α → M)} (hf : L.definable A f) (hg : L.definable A g) :
-  L.definable A (f ∩ g) :=
-⟨begin
-  rcases hf.exists_formula with ⟨φ, rfl⟩,
-  rcases hg.exists_formula with ⟨θ, rfl⟩,
+lemma definable.inter {f g : set (α → M)} (hf : A.definable L f) (hg : A.definable L g) :
+  A.definable L (f ∩ g) :=
+begin
+  rcases hf with ⟨φ, rfl⟩,
+  rcases hg with ⟨θ, rfl⟩,
   refine ⟨φ ⊓ θ, _⟩,
   ext,
   simp,
-end⟩
+end
 
 @[simp]
-lemma definable.union {f g : set (α → M)} (hf : L.definable A f) (hg : L.definable A g) :
-  L.definable A (f ∪ g) :=
-⟨begin
-  rcases hf.exists_formula with ⟨φ, hφ⟩,
-  rcases hg.exists_formula with ⟨θ, hθ⟩,
+lemma definable.union {f g : set (α → M)} (hf : A.definable L f) (hg : A.definable L g) :
+  A.definable L (f ∪ g) :=
+begin
+  rcases hf with ⟨φ, hφ⟩,
+  rcases hg with ⟨θ, hθ⟩,
   refine ⟨φ ⊔ θ, _⟩,
   ext,
   rw [hφ, hθ, mem_set_of_eq, formula.realize_sup, mem_union_eq, mem_set_of_eq,
     mem_set_of_eq],
-end⟩
+end
 
 lemma definable_finset_inf {ι : Type*} {f : Π (i : ι), set (α → M)}
-  (hf : ∀ i, L.definable A (f i)) (s : finset ι) :
-  L.definable A (s.inf f) :=
+  (hf : ∀ i, A.definable L (f i)) (s : finset ι) :
+  A.definable L (s.inf f) :=
 begin
   classical,
   refine finset.induction definable_univ (λ i s is h, _) s,
@@ -88,8 +85,8 @@ begin
 end
 
 lemma definable_finset_sup {ι : Type*} {f : Π (i : ι), set (α → M)}
-  (hf : ∀ i, L.definable A (f i)) (s : finset ι) :
-  L.definable A (s.sup f) :=
+  (hf : ∀ i, A.definable L (f i)) (s : finset ι) :
+  A.definable L (s.sup f) :=
 begin
   classical,
   refine finset.induction definable_empty (λ i s is h, _) s,
@@ -98,50 +95,50 @@ begin
 end
 
 lemma definable_finset_bInter {ι : Type*} {f : Π (i : ι), set (α → M)}
-  (hf : ∀ i, L.definable A (f i)) (s : finset ι) :
-  L.definable A (⋂ i ∈ s, f i) :=
+  (hf : ∀ i, A.definable L (f i)) (s : finset ι) :
+  A.definable L (⋂ i ∈ s, f i) :=
 begin
   rw ← finset.inf_set_eq_bInter,
   exact definable_finset_inf hf s,
 end
 
 lemma definable_finset_bUnion {ι : Type*} {f : Π (i : ι), set (α → M)}
-  (hf : ∀ i, L.definable A (f i)) (s : finset ι) :
-  L.definable A (⋃ i ∈ s, f i) :=
+  (hf : ∀ i, A.definable L (f i)) (s : finset ι) :
+  A.definable L (⋃ i ∈ s, f i) :=
 begin
   rw ← finset.sup_set_eq_bUnion,
   exact definable_finset_sup hf s,
 end
 
 @[simp]
-lemma definable.compl {s : set (α → M)} (hf : L.definable A s) :
-  L.definable A sᶜ :=
-⟨begin
-  rcases hf.exists_formula with ⟨φ, hφ⟩,
+lemma definable.compl {s : set (α → M)} (hf : A.definable L s) :
+  A.definable L sᶜ :=
+begin
+  rcases hf with ⟨φ, hφ⟩,
   refine ⟨φ.not, _⟩,
   rw hφ,
   refl,
-end⟩
+end
 
 @[simp]
-lemma definable.sdiff {s t : set (α → M)} (hs : L.definable A s)
-  (ht : L.definable A t) :
-  L.definable A (s \ t) :=
+lemma definable.sdiff {s t : set (α → M)} (hs : A.definable L s)
+  (ht : A.definable L t) :
+  A.definable L (s \ t) :=
 hs.inter ht.compl
 
 lemma definable.preimage_comp (f : α → β) {s : set (α → M)}
-  (h : L.definable A s) :
-  L.definable A ((λ g : β → M, g ∘ f) ⁻¹' s) :=
+  (h : A.definable L s) :
+  A.definable L ((λ g : β → M, g ∘ f) ⁻¹' s) :=
 begin
-  obtain ⟨φ, rfl⟩ := h.exists_formula,
-  refine ⟨⟨(φ.relabel f), _⟩⟩,
+  obtain ⟨φ, rfl⟩ := h,
+  refine ⟨(φ.relabel f), _⟩,
   ext,
   simp only [set.preimage_set_of_eq, mem_set_of_eq, formula.realize_relabel],
 end
 
 lemma definable.image_comp_equiv {s : set (β → M)}
-  (h : L.definable A s) (f : α ≃ β) :
-  L.definable A ((λ g : β → M, g ∘ f) '' s) :=
+  (h : A.definable L s) (f : α ≃ β) :
+  A.definable L ((λ g : β → M, g ∘ f) '' s) :=
 begin
   refine (congr rfl _).mp (h.preimage_comp f.symm),
   rw image_eq_preimage_of_inverse,
@@ -156,95 +153,95 @@ end
 variables (L) {M} (A)
 
 /-- A 1-dimensional version of `definable`, for `set M`. -/
-def definable₁ (s : set M) : Prop := L.definable A { x : fin 1 → M | x 0 ∈ s }
+def definable₁ (s : set M) : Prop := A.definable L { x : fin 1 → M | x 0 ∈ s }
 
 /-- A 2-dimensional version of `definable`, for `set (M × M)`. -/
-def definable₂ (s : set (M × M)) : Prop := L.definable A { x : fin 2 → M | (x 0, x 1) ∈ s }
+def definable₂ (s : set (M × M)) : Prop := A.definable L { x : fin 2 → M | (x 0, x 1) ∈ s }
 
-variables (α)
+variable (α)
 
 /-- Definable sets are subsets of finite Cartesian products of a structure such that membership is
   given by a first-order formula. -/
-def definable_set := subtype (λ s : set (α → M), L.definable A s)
+def definable_set := subtype (λ s : set (α → M), A.definable L s)
 
 namespace definable_set
-variables {A} {α}
+variables {L} {A} {α}
 
-instance : has_top (L.definable_set A α) := ⟨⟨⊤, definable_univ⟩⟩
+instance : has_top (A.definable_set L α) := ⟨⟨⊤, definable_univ⟩⟩
 
-instance : has_bot (L.definable_set A α) := ⟨⟨⊥, definable_empty⟩⟩
+instance : has_bot (A.definable_set L α) := ⟨⟨⊥, definable_empty⟩⟩
 
-instance : inhabited (L.definable_set A α) := ⟨⊥⟩
+instance : inhabited (A.definable_set L α) := ⟨⊥⟩
 
-instance : set_like (L.definable_set A α) (α → M) :=
+instance : set_like (A.definable_set L α) (α → M) :=
 { coe := subtype.val,
   coe_injective' := subtype.val_injective }
 
 @[simp]
-lemma mem_top {x : α → M} : x ∈ (⊤ : L.definable_set A α) := mem_univ x
+lemma mem_top {x : α → M} : x ∈ (⊤ : A.definable_set L α) := mem_univ x
 
 @[simp]
-lemma coe_top : ((⊤ : L.definable_set A α) : set (α → M)) = ⊤ := rfl
+lemma coe_top : ((⊤ : A.definable_set L α) : set (α → M)) = ⊤ := rfl
 
 @[simp]
-lemma not_mem_bot {x : α → M} : ¬ x ∈ (⊥ : L.definable_set A α) := not_mem_empty x
+lemma not_mem_bot {x : α → M} : ¬ x ∈ (⊥ : A.definable_set L α) := not_mem_empty x
 
 @[simp]
-lemma coe_bot : ((⊥ : L.definable_set A α) : set (α → M)) = ⊥ := rfl
+lemma coe_bot : ((⊥ : A.definable_set L α) : set (α → M)) = ⊥ := rfl
 
-instance : lattice (L.definable_set A α) :=
+instance : lattice (A.definable_set L α) :=
 subtype.lattice (λ _ _, definable.union) (λ _ _, definable.inter)
 
-lemma le_iff {s t : L.definable_set A α} : s ≤ t ↔ (s : set (α → M)) ≤ (t : set (α → M)) := iff.rfl
+lemma le_iff {s t : A.definable_set L α} : s ≤ t ↔ (s : set (α → M)) ≤ (t : set (α → M)) := iff.rfl
 
 @[simp]
-lemma coe_sup {s t : L.definable_set A α} : ((s ⊔ t : L.definable_set A α) : set (α → M)) = s ∪ t :=
+lemma coe_sup {s t : A.definable_set L α} : ((s ⊔ t : A.definable_set L α) : set (α → M)) = s ∪ t :=
 rfl
 
 @[simp]
-lemma mem_sup {s t : L.definable_set A α} {x : α → M} : x ∈ s ⊔ t ↔ x ∈ s ∨ x ∈ t := iff.rfl
+lemma mem_sup {s t : A.definable_set L α} {x : α → M} : x ∈ s ⊔ t ↔ x ∈ s ∨ x ∈ t := iff.rfl
 
 @[simp]
-lemma coe_inf {s t : L.definable_set A α} : ((s ⊓ t : L.definable_set A α) : set (α → M)) = s ∩ t :=
+lemma coe_inf {s t : A.definable_set L α} : ((s ⊓ t : A.definable_set L α) : set (α → M)) = s ∩ t :=
 rfl
 
 @[simp]
-lemma mem_inf {s t : L.definable_set A α} {x : α → M} : x ∈ s ⊓ t ↔ x ∈ s ∧ x ∈ t := iff.rfl
+lemma mem_inf {s t : A.definable_set L α} {x : α → M} : x ∈ s ⊓ t ↔ x ∈ s ∧ x ∈ t := iff.rfl
 
-instance : bounded_order (L.definable_set A α) :=
+instance : bounded_order (A.definable_set L α) :=
 { bot_le := λ s x hx, false.elim hx,
   le_top := λ s x hx, mem_univ x,
-  .. definable_set.has_top L,
-  .. definable_set.has_bot L }
+  .. definable_set.has_top,
+  .. definable_set.has_bot }
 
-instance : distrib_lattice (L.definable_set A α) :=
+instance : distrib_lattice (A.definable_set L α) :=
 { le_sup_inf := begin
     intros s t u x,
     simp only [and_imp, mem_inter_eq, set_like.mem_coe, coe_sup, coe_inf, mem_union_eq,
       subtype.val_eq_coe],
     tauto,
   end,
-  .. definable_set.lattice L }
+  .. definable_set.lattice }
 
 /-- The complement of a definable set is also definable. -/
-@[reducible] instance : has_compl (L.definable_set A α) :=
+@[reducible] instance : has_compl (A.definable_set L α) :=
 ⟨λ ⟨s, hs⟩, ⟨sᶜ, hs.compl⟩⟩
 
 @[simp]
-lemma mem_compl {s : L.definable_set A α} {x : α → M} : x ∈ sᶜ ↔ ¬ x ∈ s :=
+lemma mem_compl {s : A.definable_set L α} {x : α → M} : x ∈ sᶜ ↔ ¬ x ∈ s :=
 begin
   cases s with s hs,
   refl,
 end
 
 @[simp]
-lemma coe_compl {s : L.definable_set A α} : ((sᶜ : L.definable_set A α) : set (α → M)) = sᶜ :=
+lemma coe_compl {s : A.definable_set L α} : ((sᶜ : A.definable_set L α) : set (α → M)) = sᶜ :=
 begin
   ext,
   simp,
 end
 
-instance : boolean_algebra (L.definable_set A α) :=
+instance : boolean_algebra (A.definable_set L α) :=
 { sdiff := λ s t, s ⊓ tᶜ,
   sdiff_eq := λ s t, rfl,
   sup_inf_sdiff := λ ⟨s, hs⟩ ⟨t, ht⟩,
@@ -262,11 +259,10 @@ instance : boolean_algebra (L.definable_set A α) :=
   end,
   inf_compl_le_bot := λ ⟨s, hs⟩, by simp [le_iff],
   top_le_sup_compl := λ ⟨s, hs⟩, by simp [le_iff],
-  .. definable_set.has_compl L,
-  .. definable_set.bounded_order L,
-  .. definable_set.distrib_lattice L }
+  .. definable_set.has_compl,
+  .. definable_set.bounded_order,
+  .. definable_set.distrib_lattice }
 
 end definable_set
 
-end language
-end first_order
+end set

--- a/src/model_theory/definability.lean
+++ b/src/model_theory/definability.lean
@@ -18,11 +18,11 @@ set `s` of a finite cartesian power of `M` is definable with parameters in `A`.
 `(s : set M)` is definable with parameters in `A`.
 * `set.definable₂` is defined so that `A.definable₂ L s` indicates that
 `(s : set (M × M))` is definable with parameters in `A`.
-* A `set.definable_set` is defined so that `A.definable_set L α` is the boolean
+* A `first_order.language.definable_set` is defined so that `L.definable_set A α` is the boolean
   algebra of subsets of `α → M` defined by formulas with parameters in `A`.
 
 ## Main Results
-* `A.definable_set L α` forms a `boolean_algebra`.
+* `L.definable_set A α` forms a `boolean_algebra`.
 
 -/
 
@@ -34,7 +34,7 @@ variables {M : Type w} (A : set M) (L : first_order.language.{u v}) [L.Structure
 open_locale first_order
 open first_order.language first_order.language.Structure
 
-variables {α : Type} {β : Type}
+variables {α : Type*} {β : Type*}
 
 /-- A subset of a finite Cartesian product of a structure is definable over a set `A` when
   membership in the set is given by a first-order formula with parameters from `A`. -/
@@ -158,63 +158,69 @@ def definable₁ (s : set M) : Prop := A.definable L { x : fin 1 → M | x 0 ∈
 /-- A 2-dimensional version of `definable`, for `set (M × M)`. -/
 def definable₂ (s : set (M × M)) : Prop := A.definable L { x : fin 2 → M | (x 0, x 1) ∈ s }
 
-variable (α)
+end set
+
+namespace first_order
+namespace language
+open set
+
+variables (L : first_order.language.{u v}) {M : Type w} [L.Structure M] (A : set M) (α : Type*)
 
 /-- Definable sets are subsets of finite Cartesian products of a structure such that membership is
   given by a first-order formula. -/
-def definable_set := subtype (λ s : set (α → M), A.definable L s)
+def definable_set := { s : set (α → M) // A.definable L s}
 
 namespace definable_set
 variables {L} {A} {α}
 
-instance : has_top (A.definable_set L α) := ⟨⟨⊤, definable_univ⟩⟩
+instance : has_top (L.definable_set A α) := ⟨⟨⊤, definable_univ⟩⟩
 
-instance : has_bot (A.definable_set L α) := ⟨⟨⊥, definable_empty⟩⟩
+instance : has_bot (L.definable_set A α) := ⟨⟨⊥, definable_empty⟩⟩
 
-instance : inhabited (A.definable_set L α) := ⟨⊥⟩
+instance : inhabited (L.definable_set A α) := ⟨⊥⟩
 
-instance : set_like (A.definable_set L α) (α → M) :=
+instance : set_like (L.definable_set A α) (α → M) :=
 { coe := subtype.val,
   coe_injective' := subtype.val_injective }
 
 @[simp]
-lemma mem_top {x : α → M} : x ∈ (⊤ : A.definable_set L α) := mem_univ x
+lemma mem_top {x : α → M} : x ∈ (⊤ : L.definable_set A α) := mem_univ x
 
 @[simp]
-lemma coe_top : ((⊤ : A.definable_set L α) : set (α → M)) = ⊤ := rfl
+lemma coe_top : ((⊤ : L.definable_set A α) : set (α → M)) = ⊤ := rfl
 
 @[simp]
-lemma not_mem_bot {x : α → M} : ¬ x ∈ (⊥ : A.definable_set L α) := not_mem_empty x
+lemma not_mem_bot {x : α → M} : ¬ x ∈ (⊥ : L.definable_set A α) := not_mem_empty x
 
 @[simp]
-lemma coe_bot : ((⊥ : A.definable_set L α) : set (α → M)) = ⊥ := rfl
+lemma coe_bot : ((⊥ : L.definable_set A α) : set (α → M)) = ⊥ := rfl
 
-instance : lattice (A.definable_set L α) :=
+instance : lattice (L.definable_set A α) :=
 subtype.lattice (λ _ _, definable.union) (λ _ _, definable.inter)
 
-lemma le_iff {s t : A.definable_set L α} : s ≤ t ↔ (s : set (α → M)) ≤ (t : set (α → M)) := iff.rfl
+lemma le_iff {s t : L.definable_set A α} : s ≤ t ↔ (s : set (α → M)) ≤ (t : set (α → M)) := iff.rfl
 
 @[simp]
-lemma coe_sup {s t : A.definable_set L α} : ((s ⊔ t : A.definable_set L α) : set (α → M)) = s ∪ t :=
+lemma coe_sup {s t : L.definable_set A α} : ((s ⊔ t : L.definable_set A α) : set (α → M)) = s ∪ t :=
 rfl
 
 @[simp]
-lemma mem_sup {s t : A.definable_set L α} {x : α → M} : x ∈ s ⊔ t ↔ x ∈ s ∨ x ∈ t := iff.rfl
+lemma mem_sup {s t : L.definable_set A α} {x : α → M} : x ∈ s ⊔ t ↔ x ∈ s ∨ x ∈ t := iff.rfl
 
 @[simp]
-lemma coe_inf {s t : A.definable_set L α} : ((s ⊓ t : A.definable_set L α) : set (α → M)) = s ∩ t :=
+lemma coe_inf {s t : L.definable_set A α} : ((s ⊓ t : L.definable_set A α) : set (α → M)) = s ∩ t :=
 rfl
 
 @[simp]
-lemma mem_inf {s t : A.definable_set L α} {x : α → M} : x ∈ s ⊓ t ↔ x ∈ s ∧ x ∈ t := iff.rfl
+lemma mem_inf {s t : L.definable_set A α} {x : α → M} : x ∈ s ⊓ t ↔ x ∈ s ∧ x ∈ t := iff.rfl
 
-instance : bounded_order (A.definable_set L α) :=
+instance : bounded_order (L.definable_set A α) :=
 { bot_le := λ s x hx, false.elim hx,
   le_top := λ s x hx, mem_univ x,
   .. definable_set.has_top,
   .. definable_set.has_bot }
 
-instance : distrib_lattice (A.definable_set L α) :=
+instance : distrib_lattice (L.definable_set A α) :=
 { le_sup_inf := begin
     intros s t u x,
     simp only [and_imp, mem_inter_eq, set_like.mem_coe, coe_sup, coe_inf, mem_union_eq,
@@ -224,24 +230,24 @@ instance : distrib_lattice (A.definable_set L α) :=
   .. definable_set.lattice }
 
 /-- The complement of a definable set is also definable. -/
-@[reducible] instance : has_compl (A.definable_set L α) :=
+@[reducible] instance : has_compl (L.definable_set A α) :=
 ⟨λ ⟨s, hs⟩, ⟨sᶜ, hs.compl⟩⟩
 
 @[simp]
-lemma mem_compl {s : A.definable_set L α} {x : α → M} : x ∈ sᶜ ↔ ¬ x ∈ s :=
+lemma mem_compl {s : L.definable_set A α} {x : α → M} : x ∈ sᶜ ↔ ¬ x ∈ s :=
 begin
   cases s with s hs,
   refl,
 end
 
 @[simp]
-lemma coe_compl {s : A.definable_set L α} : ((sᶜ : A.definable_set L α) : set (α → M)) = sᶜ :=
+lemma coe_compl {s : L.definable_set A α} : ((sᶜ : L.definable_set A α) : set (α → M)) = sᶜ :=
 begin
   ext,
   simp,
 end
 
-instance : boolean_algebra (A.definable_set L α) :=
+instance : boolean_algebra (L.definable_set A α) :=
 { sdiff := λ s t, s ⊓ tᶜ,
   sdiff_eq := λ s t, rfl,
   sup_inf_sdiff := λ ⟨s, hs⟩ ⟨t, ht⟩,
@@ -264,5 +270,5 @@ instance : boolean_algebra (A.definable_set L α) :=
   .. definable_set.distrib_lattice }
 
 end definable_set
-
-end set
+end language
+end first_order


### PR DESCRIPTION
Changes `first_order.language.definable` and `first_order.language.definable_set` to `set.definable` and `set.definable_set`.
Makes `set.definable` a `def` rather than a `structure`.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
