### PR TITLE
[Merged by Bors] - doc(archive/100-theorems-list/9_area_of_a_circle): fix `×`

### DIFF
--- a/archive/100-theorems-list/9_area_of_a_circle.lean
+++ b/archive/100-theorems-list/9_area_of_a_circle.lean
@@ -30,7 +30,7 @@ to the derivative of `λ x, r ^ 2 * arcsin (x / r) + x * sqrt (r ^ 2 - x ^ 2)` e
 `Ioo (-r) r` and that those two functions are continuous, then apply the second fundamental theorem
 of calculus with those facts. Some simple algebra then completes the proof.
 
-Note that we choose to define `disc` as a set of points in `ℝ ⨯ ℝ`. This is admittedly not ideal; it
+Note that we choose to define `disc` as a set of points in `ℝ × ℝ`. This is admittedly not ideal; it
 would be more natural to define `disc` as a `metric.ball` in `euclidean_space ℝ (fin 2)` (as well as
 to provide a more general proof in higher dimensions). However, our proof indirectly relies on a
 number of theorems (particularly `measure_theory.measure.prod_apply`) which do not yet exist for


### PR DESCRIPTION
this file used to have the category theory `\cross` as opposed to `\x`

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
