### PR TITLE
[Merged by Bors] - feat(linear_algebra/determinant): no need for `is_domain`

### DIFF
--- a/src/linear_algebra/determinant.lean
+++ b/src/linear_algebra/determinant.lean
@@ -61,7 +61,7 @@ variables {A : Type*} [comm_ring A]
 variables {m n : Type*} [fintype m] [fintype n]
 
 /-- If `R^m` and `R^n` are linearly equivalent, then `m` and `n` are also equivalent. -/
-def equiv_of_pi_lequiv_pi {R : Type*} [comm_ring R] [is_domain R]
+def equiv_of_pi_lequiv_pi {R : Type*} [comm_ring R] [nontrivial R]
   (e : (m → R) ≃ₗ[R] (n → R)) : m ≃ n :=
 basis.index_equiv (basis.of_equiv_fun e.symm) (pi.basis_fun _ _)
 
@@ -69,7 +69,7 @@ namespace matrix
 
 /-- If `M` and `M'` are each other's inverse matrices, they are square matrices up to
 equivalence of types. -/
-def index_equiv_of_inv [is_domain A] [decidable_eq m] [decidable_eq n]
+def index_equiv_of_inv [nontrivial A] [decidable_eq m] [decidable_eq n]
   {M : matrix m n A} {M' : matrix n m A}
   (hMM' : M ⬝ M' = 1) (hM'M : M' ⬝ M = 1) :
   m ≃ n :=
@@ -80,18 +80,21 @@ by rw [det_mul, det_mul, mul_comm]
 
 /-- If there exists a two-sided inverse `M'` for `M` (indexed differently),
 then `det (N ⬝ M) = det (M ⬝ N)`. -/
-lemma det_comm' [is_domain A] [decidable_eq m] [decidable_eq n]
+lemma det_comm' [decidable_eq m] [decidable_eq n]
   {M : matrix n m A} {N : matrix m n A} {M' : matrix m n A}
   (hMM' : M ⬝ M' = 1) (hM'M : M' ⬝ M = 1) :
   det (M ⬝ N) = det (N ⬝ M) :=
--- Although `m` and `n` are different a priori, we will show they have the same cardinality.
--- This turns the problem into one for square matrices, which is easy.
-let e := index_equiv_of_inv hMM' hM'M in
-by rw [← det_minor_equiv_self e, ← minor_mul_equiv _ _ _ (equiv.refl n) _, det_comm,
-  minor_mul_equiv, equiv.coe_refl, minor_id_id]
+begin
+  nontriviality A,
+  -- Although `m` and `n` are different a priori, we will show they have the same cardinality.
+  -- This turns the problem into one for square matrices, which is easy.
+  let e := index_equiv_of_inv hMM' hM'M,
+  rw [← det_minor_equiv_self e, ← minor_mul_equiv _ _ _ (equiv.refl n) _, det_comm,
+    minor_mul_equiv, equiv.coe_refl, minor_id_id]
+end
 
 /-- If `M'` is a two-sided inverse for `M` (indexed differently), `det (M ⬝ N ⬝ M') = det N`. -/
-lemma det_conj [is_domain A] [decidable_eq m] [decidable_eq n]
+lemma det_conj [decidable_eq m] [decidable_eq n]
   {M : matrix m n A} {M' : matrix n m A} {N : matrix n n A}
   (hMM' : M ⬝ M' = 1) (hM'M : M' ⬝ M = 1) :
   det (M ⬝ N ⬝ M') = det N :=
@@ -105,7 +108,7 @@ namespace linear_map
 
 /-! ### Determinant of a linear map -/
 
-variables {A : Type*} [comm_ring A] [is_domain A] [module A M]
+variables {A : Type*} [comm_ring A] [module A M]
 variables {κ : Type*} [fintype κ]
 
 /-- The determinant of `linear_map.to_matrix` does not depend on the choice of basis. -/
@@ -272,7 +275,7 @@ begin
 end
 
 /-- If a linear map is invertible, so is its determinant. -/
-lemma is_unit_det {A : Type*} [comm_ring A] [is_domain A] [module A M]
+lemma is_unit_det {A : Type*} [comm_ring A] [module A M]
   (f : M →ₗ[A] M) (hf : is_unit f) : is_unit f.det :=
 begin
   obtain ⟨g, hg⟩ : ∃ g, f.comp g = 1 := hf.exists_right_inv,
@@ -316,8 +319,6 @@ end linear_map
 
 namespace linear_equiv
 
-variables [is_domain R]
-
 /-- On a `linear_equiv`, the domain of `linear_map.det` can be promoted to `Rˣ`. -/
 protected def det : (M ≃ₗ[R] M) →* Rˣ :=
 (units.map (linear_map.det : (M →ₗ[R] M) →* R)).comp
@@ -340,12 +341,12 @@ by rw [←units.eq_iff, coe_det, coe_det, ←comp_coe, ←comp_coe, linear_map.d
 end linear_equiv
 
 /-- The determinants of a `linear_equiv` and its inverse multiply to 1. -/
-@[simp] lemma linear_equiv.det_mul_det_symm {A : Type*} [comm_ring A] [is_domain A] [module A M]
+@[simp] lemma linear_equiv.det_mul_det_symm {A : Type*} [comm_ring A] [module A M]
   (f : M ≃ₗ[A] M) : (f : M →ₗ[A] M).det * (f.symm : M →ₗ[A] M).det = 1 :=
 by simp [←linear_map.det_comp]
 
 /-- The determinants of a `linear_equiv` and its inverse multiply to 1. -/
-@[simp] lemma linear_equiv.det_symm_mul_det {A : Type*} [comm_ring A] [is_domain A] [module A M]
+@[simp] lemma linear_equiv.det_symm_mul_det {A : Type*} [comm_ring A] [module A M]
   (f : M ≃ₗ[A] M) : (f.symm : M →ₗ[A] M).det * (f : M →ₗ[A] M).det = 1 :=
 by simp [←linear_map.det_comp]
 
@@ -358,7 +359,7 @@ begin
 end
 
 /-- Specialization of `linear_equiv.is_unit_det` -/
-lemma linear_equiv.is_unit_det' {A : Type*} [comm_ring A] [is_domain A] [module A M]
+lemma linear_equiv.is_unit_det' {A : Type*} [comm_ring A] [module A M]
   (f : M ≃ₗ[A] M) : is_unit (linear_map.det (f : M →ₗ[A] M)) :=
 is_unit_of_mul_eq_one _ _ f.det_mul_det_symm
 
@@ -473,7 +474,7 @@ lemma alternating_map.map_basis_ne_zero_iff (f : alternating_map R M R ι) :
   f e ≠ 0 ↔ f ≠ 0 :=
 not_congr $ f.map_basis_eq_zero_iff e
 
-variables {A : Type*} [comm_ring A] [is_domain A] [module A M]
+variables {A : Type*} [comm_ring A] [module A M]
 
 @[simp] lemma basis.det_comp (e : basis ι A M) (f : M →ₗ[A] M) (v : ι → M) :
   e.det (f ∘ v) = f.det * e.det v :=

--- a/src/linear_algebra/matrix/to_linear_equiv.lean
+++ b/src/linear_algebra/matrix/to_linear_equiv.lean
@@ -126,7 +126,7 @@ begin
 end
 
 lemma exists_mul_vec_eq_zero_iff' {A : Type*} (K : Type*) [decidable_eq n]
-  [comm_ring A] [is_domain A]
+  [comm_ring A] [nontrivial A]
   [field K] [algebra A K] [is_fraction_ring A K]
   {M : matrix n n A} :
   (∃ (v ≠ 0), M.mul_vec v = 0) ↔ M.det = 0 :=
@@ -149,7 +149,7 @@ begin
     { have := congr_arg (algebra_map A K) (congr_fun h i),
       rw [hf, subtype.coe_mk, pi.zero_apply, ring_hom.map_zero, algebra.smul_def,
           mul_eq_zero, is_fraction_ring.to_map_eq_zero_iff] at this,
-      exact this.resolve_left (mem_non_zero_divisors_iff_ne_zero.mp hb), },
+      exact this.resolve_left (non_zero_divisors.ne_zero hb), },
     { ext i,
       refine is_fraction_ring.injective A K _,
       calc algebra_map A K (M.mul_vec (λ (i : n), f (v i) _) i)

--- a/src/linear_algebra/orientation.lean
+++ b/src/linear_algebra/orientation.lean
@@ -89,7 +89,7 @@ by simp_rw [basis.orientation, orientation.map_apply, basis.det_map']
 
 /-- The value of `orientation.map` when the index type has the cardinality of a basis, in terms
 of `f.det`. -/
-lemma map_orientation_eq_det_inv_smul [is_domain R] (e : basis ι R M)
+lemma map_orientation_eq_det_inv_smul (e : basis ι R M)
   (x : orientation R M ι) (f : M ≃ₗ[R] M) : orientation.map ι f x = (f.det)⁻¹ • x :=
 begin
   induction x using module.ray.ind with g hg,

--- a/src/ring_theory/norm.lean
+++ b/src/ring_theory/norm.lean
@@ -39,7 +39,7 @@ See also `algebra.trace`, which is defined similarly as the trace of
 
 universes u v w
 
-variables {R S T : Type*} [comm_ring R] [is_domain R] [comm_ring S]
+variables {R S T : Type*} [comm_ring R] [comm_ring S]
 variables [algebra R S]
 variables {K L F : Type*} [field K] [field L] [field F]
 variables [algebra K L] [algebra K F]
@@ -127,7 +127,7 @@ end eq_prod_roots
 
 section eq_zero_iff
 
-lemma norm_eq_zero_iff_of_basis [is_domain S] (b : basis ι R S) {x : S} :
+lemma norm_eq_zero_iff_of_basis [is_domain R] [is_domain S] (b : basis ι R S) {x : S} :
   algebra.norm R x = 0 ↔ x = 0 :=
 begin
   have hι : nonempty ι := b.index_nonempty,
@@ -147,7 +147,7 @@ begin
     rw [alg_hom.map_zero, matrix.det_zero hι] },
 end
 
-lemma norm_ne_zero_iff_of_basis [is_domain S] (b : basis ι R S) {x : S} :
+lemma norm_ne_zero_iff_of_basis [is_domain R] [is_domain S] (b : basis ι R S) {x : S} :
   algebra.norm R x ≠ 0 ↔ x ≠ 0 :=
 not_iff_not.mpr (algebra.norm_eq_zero_iff_of_basis b)
 

--- a/src/topology/algebra/module/basic.lean
+++ b/src/topology/algebra/module/basic.lean
@@ -1146,7 +1146,7 @@ section comm_ring
 
 /-- The determinant of a continuous linear map, mainly as a convenience device to be able to
 write `A.det` instead of `(A : M →ₗ[R] M).det`. -/
-@[reducible] noncomputable def det {R : Type*} [comm_ring R] [is_domain R]
+@[reducible] noncomputable def det {R : Type*} [comm_ring R]
   {M : Type*} [topological_space M] [add_comm_group M] [module R M] (A : M →L[R] M) : R :=
 linear_map.det (A : M →ₗ[R] M)
 


### PR DESCRIPTION
Nontriviality is all that was actually used, and in some cases the statement is already vacuous in the trivial case.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
