### PR TITLE
[Merged by Bors] - feat(group_theory/group_action/basic): Right action of normalizer on left cosets

### DIFF
--- a/src/group_theory/group_action/basic.lean
+++ b/src/group_theory/group_action/basic.lean
@@ -294,20 +294,11 @@ variables [group α] [mul_action α β]
 
 open quotient_group
 
-/-- Action on left cosets. -/
-@[to_additive "Action on left cosets."]
-def mul_left_cosets (H : subgroup α)
-  (x : α) (y : α ⧸ H) : α ⧸ H :=
-quotient.lift_on' y (λ y, quotient_group.mk ((x : α) * y))
-  (λ a b (hab : _ ∈ H), quotient_group.eq.2
-    (by rwa [mul_inv_rev, ← mul_assoc, mul_assoc (a⁻¹), inv_mul_self, mul_one]))
-
 @[to_additive] instance quotient (H : subgroup α) : mul_action α (α ⧸ H) :=
-{ smul := mul_left_cosets H,
-  one_smul := λ a, quotient.induction_on' a (λ a, quotient_group.eq.2
-    (by simp [subgroup.one_mem])),
-  mul_smul := λ x y a, quotient.induction_on' a (λ a, quotient_group.eq.2
-    (by simp [mul_inv_rev, subgroup.one_mem, mul_assoc])) }
+{ smul := λ g, quotient.map' (λ h, g * h)
+    (λ a b, (congr_arg (∈ H) (by rw [mul_inv_rev, mul_assoc, inv_mul_cancel_left])).mpr),
+  one_smul := λ a, quotient.induction_on' a (λ a, congr_arg quotient.mk' (one_mul a)),
+  mul_smul := λ x y a, quotient.induction_on' a (λ a, congr_arg quotient.mk' (mul_assoc x y a)) }
 
 @[simp, to_additive] lemma quotient.smul_mk (H : subgroup α) (a x : α) :
   (a • quotient_group.mk x : α ⧸ H) = quotient_group.mk (a * x) := rfl
@@ -318,6 +309,21 @@ quotient.lift_on' y (λ y, quotient_group.mk ((x : α) * y))
 @[to_additive] instance mul_left_cosets_comp_subtype_val (H I : subgroup α) :
   mul_action I (α ⧸ H) :=
 mul_action.comp_hom (α ⧸ H) (subgroup.subtype I)
+
+@[to_additive] instance quotient' (H : subgroup α) : mul_action H.normalizerᵐᵒᵖ (α ⧸ H) :=
+{ smul := λ g, quotient.map' (* g.unop) (λ a b h, by
+  { have := (g.unop⁻¹.2 (a⁻¹ * b)).mp h,
+    rwa [subtype.val_eq_coe, ←mul_assoc, subgroup.coe_inv, ←mul_inv_rev, mul_assoc,
+      inv_inv] at this }),
+  one_smul := λ a, quotient.induction_on' a (λ a, congr_arg quotient.mk' (mul_one a)),
+  mul_smul := λ x y a, quotient.induction_on' a
+    (λ a, congr_arg quotient.mk' (mul_assoc a y.unop x.unop).symm) }
+
+@[simp, to_additive] lemma quotient'.smul_mk (H : subgroup α) (a : H.normalizerᵐᵒᵖ) (x : α) :
+  (a • quotient_group.mk x : α ⧸ H) = quotient_group.mk (x * a.unop) := rfl
+
+@[simp, to_additive] lemma quotient'.smul_coe (H : subgroup α) (a : H.normalizerᵐᵒᵖ) (x : α) :
+  (a • x : α ⧸ H) = ↑(x * a.unop) := rfl
 
 variables (α) {β} (x : β)
 

--- a/src/group_theory/group_action/basic.lean
+++ b/src/group_theory/group_action/basic.lean
@@ -296,7 +296,7 @@ open quotient_group
 
 @[to_additive] instance quotient (H : subgroup α) : mul_action α (α ⧸ H) :=
 { smul := λ g, quotient.map' (λ h, g * h)
-    (λ a b, (congr_arg (∈ H) (by rw [mul_inv_rev, mul_assoc, inv_mul_cancel_left])).mpr),
+    (λ a b, (congr_arg (∈ H) (by rw [mul_inv_rev, mul_assoc, inv_mul_cancel_left])).mp),
   one_smul := λ a, quotient.induction_on' a (λ a, congr_arg quotient.mk' (one_mul a)),
   mul_smul := λ x y a, quotient.induction_on' a (λ a, congr_arg quotient.mk' (mul_assoc x y a)) }
 
@@ -311,10 +311,8 @@ open quotient_group
 mul_action.comp_hom (α ⧸ H) (subgroup.subtype I)
 
 @[to_additive] instance quotient' (H : subgroup α) : mul_action H.normalizerᵐᵒᵖ (α ⧸ H) :=
-{ smul := λ g, quotient.map' (* g.unop) (λ a b h, by
-  { have := (g.unop⁻¹.2 (a⁻¹ * b)).mp h,
-    rwa [subtype.val_eq_coe, ←mul_assoc, subgroup.coe_inv, ←mul_inv_rev, mul_assoc,
-      inv_inv] at this }),
+{ smul := λ g, quotient.map' (* g.unop) (λ a b, (congr_arg (∈ H) (by rw [subtype.val_eq_coe,
+    subgroup.coe_inv, inv_inv, ←mul_assoc, ←mul_inv_rev, mul_assoc])).mp ∘ (g.unop⁻¹.2 _).mp),
   one_smul := λ a, quotient.induction_on' a (λ a, congr_arg quotient.mk' (mul_one a)),
   mul_smul := λ x y a, quotient.induction_on' a
     (λ a, congr_arg quotient.mk' (mul_assoc a y.unop x.unop).symm) }

--- a/src/group_theory/group_action/basic.lean
+++ b/src/group_theory/group_action/basic.lean
@@ -294,11 +294,20 @@ variables [group α] [mul_action α β]
 
 open quotient_group
 
+/-- Action on left cosets. -/
+@[to_additive "Action on left cosets."]
+def mul_left_cosets (H : subgroup α)
+  (x : α) (y : α ⧸ H) : α ⧸ H :=
+quotient.lift_on' y (λ y, quotient_group.mk ((x : α) * y))
+  (λ a b (hab : _ ∈ H), quotient_group.eq.2
+    (by rwa [mul_inv_rev, ← mul_assoc, mul_assoc (a⁻¹), inv_mul_self, mul_one]))
+
 @[to_additive] instance quotient (H : subgroup α) : mul_action α (α ⧸ H) :=
-{ smul := λ g, quotient.map' (λ h, g * h)
-    (λ a b, (congr_arg (∈ H) (by rw [mul_inv_rev, mul_assoc, inv_mul_cancel_left])).mp),
-  one_smul := λ a, quotient.induction_on' a (λ a, congr_arg quotient.mk' (one_mul a)),
-  mul_smul := λ x y a, quotient.induction_on' a (λ a, congr_arg quotient.mk' (mul_assoc x y a)) }
+{ smul := mul_left_cosets H,
+  one_smul := λ a, quotient.induction_on' a (λ a, quotient_group.eq.2
+    (by simp [subgroup.one_mem])),
+  mul_smul := λ x y a, quotient.induction_on' a (λ a, quotient_group.eq.2
+    (by simp [mul_inv_rev, subgroup.one_mem, mul_assoc])) }
 
 @[simp, to_additive] lemma quotient.smul_mk (H : subgroup α) (a x : α) :
   (a • quotient_group.mk x : α ⧸ H) = quotient_group.mk (a * x) := rfl


### PR DESCRIPTION
This PR adds the right action of the normalizer on left cosets.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
