### PR TITLE
feat(algebra/order/floor): Generalize floor lemmas to ordered_semirings

### DIFF
--- a/src/algebra/continued_fractions/computation/approximation_corollaries.lean
+++ b/src/algebra/continued_fractions/computation/approximation_corollaries.lean
@@ -5,7 +5,6 @@ Authors: Kevin Kappelmann
 -/
 import algebra.continued_fractions.computation.approximations
 import algebra.continued_fractions.convergents_equiv
-import algebra.order.archimedean
 import topology.algebra.order.basic
 
 /-!
@@ -73,7 +72,7 @@ section convergence
 We next show that `(generalized_continued_fraction.of v).convergents v` converges to `v`.
 -/
 
-variable [archimedean K]
+variable [floor_semiring K]
 open nat
 
 theorem of_convergence_epsilon :

--- a/src/number_theory/padics/padic_numbers.lean
+++ b/src/number_theory/padics/padic_numbers.lean
@@ -667,7 +667,7 @@ def lim_seq : ℕ → ℚ := λ n, classical.some (rat_dense' (f n) (div_nat_pos
 lemma exi_rat_seq_conv {ε : ℚ} (hε : 0 < ε) :
   ∃ N, ∀ i ≥ N, padic_norm_e (f i - ((lim_seq f) i : ℚ_[p])) < ε :=
 begin
-  refine (exists_nat_gt (1/ε)).imp (λ N hN i hi, _),
+  refine (nat.exists_nat_gt (1/ε)).imp (λ N hN i hi, _),
   have h := classical.some_spec (rat_dense' (f i) (div_nat_pos i)),
   refine lt_of_lt_of_le h ((div_le_iff' $ by exact_mod_cast succ_pos _).mpr _),
   rw right_distrib,


### PR DESCRIPTION
Many of the lemmas about floor semiring do not require a linear ordering. These have been generalized.

Notably, there _may_ be some nicer ways of writing these lemmas down, in particular, suggestions for specifying the `nonpos_or_nonneg` assumptions would be most welcome.

Requested by @eric-wieser in #12795


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
