### PR TITLE
feat(group_theory/group_action/basic): Add typeclass for actions that descend to the quotient

### DIFF
--- a/src/group_theory/group_action/basic.lean
+++ b/src/group_theory/group_action/basic.lean
@@ -290,8 +290,6 @@ end add_action
 
 namespace mul_action
 
-section quotient_action
-
 open subgroup
 
 variables (α) [monoid α] [mul_action α β] [group β] (H : subgroup β)
@@ -327,7 +325,9 @@ variables {α}
 @[simp, to_additive] lemma quotient.smul_coe [quotient_action α H] (a : α) (b : β) :
   (a • b : β ⧸ H) = ↑(a • b) := rfl
 
-end quotient_action
+end mul_action
+
+namespace mul_action
 
 variables (α) {β} [group α] [mul_action α β] (x : β)
 

--- a/src/group_theory/group_action/basic.lean
+++ b/src/group_theory/group_action/basic.lean
@@ -290,6 +290,8 @@ end add_action
 
 namespace mul_action
 
+section quotient_action
+
 open subgroup
 
 variables (α) [monoid α] [mul_action α β] [group β] (H : subgroup β)
@@ -330,9 +332,7 @@ variables {α}
 @[simp, to_additive] lemma quotient.smul_coe [quotient_action α H] (a : α) (b : β) :
   (a • b : β ⧸ H) = ↑(a • b) := rfl
 
-end mul_action
-
-namespace mul_action
+end quotient_action
 
 variables (α) {β} [group α] [mul_action α β] (x : β)
 

--- a/src/group_theory/group_action/basic.lean
+++ b/src/group_theory/group_action/basic.lean
@@ -288,44 +288,42 @@ have this : stabilizer α x = (stabilizer α y).map (add_aut.conj g).to_add_mono
 
 end add_action
 
-namespace mul_action
+namespace subgroup
 
-open subgroup
+variables (β) [monoid β] [mul_action β α] [group α] (H : subgroup α)
 
-variables (α) [monoid α] [mul_action α β] [group β] (H : subgroup β)
-
-/-- A typeclass for when a `mul_action α β` descends to the quotient `β ⧸ H`. -/
+/-- A typeclass for when a `mul_action β α` descends to the quotient `α ⧸ H`. -/
 class quotient_action : Prop :=
-(inv_mul_mem : ∀ (a : α) {b c : β}, b⁻¹ * c ∈ H → (a • b)⁻¹ * (a • c) ∈ H)
+(inv_mul_mem : ∀ (b : β) {a a' : α}, a⁻¹ * a' ∈ H → (b • a)⁻¹ * (b • a') ∈ H)
 
-/-- A typeclass for when an `add_action α β` descends to the quotient `β ⧸ H`. -/
-class _root_.add_action.quotient_action (α : Type*) {β : Type*} [add_monoid α] [add_action α β]
-  [add_group β] (H : add_subgroup β) : Prop :=
-(inv_mul_mem : ∀ (a : α) {b c : β}, -b + c ∈ H → -(a +ᵥ b) + (a +ᵥ c) ∈ H)
+/-- A typeclass for when an `add_action β α` descends to the quotient `α ⧸ H`. -/
+class _root_.add_subgroup.quotient_action {α : Type*} (β : Type*) [add_monoid β] [add_action β α]
+  [add_group α] (H : add_subgroup α) : Prop :=
+(inv_mul_mem : ∀ (b : β) {a a' : α}, -a + a' ∈ H → -(b +ᵥ a) + (b +ᵥ a') ∈ H)
 
-attribute [to_additive add_action.quotient_action] mul_action.quotient_action
+attribute [to_additive add_subgroup.quotient_action] subgroup.quotient_action
 
-@[to_additive] instance left_quotient_action : quotient_action β H :=
+@[to_additive] instance left_quotient_action : H.quotient_action α :=
 ⟨λ _ _ _ _, by rwa [smul_eq_mul, smul_eq_mul, mul_inv_rev, mul_assoc, inv_mul_cancel_left]⟩
 
-@[to_additive] instance right_quotient_action : quotient_action H.normalizer.opposite H :=
+@[to_additive] instance right_quotient_action : H.quotient_action H.normalizer.opposite :=
 ⟨λ b c _ _, by rwa [smul_def, smul_def, smul_eq_mul_unop, smul_eq_mul_unop, mul_inv_rev,
   ←mul_assoc, ←subtype.val_eq_coe, mem_normalizer_iff'.mp b.2, mul_assoc, mul_inv_cancel_left]⟩
 
-@[to_additive] instance quotient [quotient_action α H] : mul_action α (β ⧸ H) :=
-{ smul := λ a, quotient.map' ((•) a) (λ b c h, quotient_action.inv_mul_mem a h),
-  one_smul := λ q, quotient.induction_on' q (λ b, congr_arg quotient.mk' (one_smul α b)),
-  mul_smul := λ a a' q, quotient.induction_on' q (λ b, congr_arg quotient.mk' (mul_smul a a' b)) }
+@[to_additive] instance quotient [H.quotient_action β] : mul_action β (α ⧸ H) :=
+{ smul := λ b, quotient.map' ((•) b) (λ a a' h, quotient_action.inv_mul_mem b h),
+  one_smul := λ q, quotient.induction_on' q (λ a, congr_arg quotient.mk' (one_smul β a)),
+  mul_smul := λ b b' q, quotient.induction_on' q (λ a, congr_arg quotient.mk' (mul_smul b b' a)) }
 
-variables {α}
+variables {β}
 
-@[simp, to_additive] lemma quotient.smul_mk [quotient_action α H] (a : α) (b : β) :
-  (a • quotient_group.mk b : β ⧸ H) = quotient_group.mk (a • b) := rfl
+@[simp, to_additive] lemma quotient.smul_mk [H.quotient_action β] (a : β) (x : α) :
+  (a • quotient_group.mk x : α ⧸ H) = quotient_group.mk (a • x) := rfl
 
-@[simp, to_additive] lemma quotient.smul_coe [quotient_action α H] (a : α) (b : β) :
-  (a • b : β ⧸ H) = ↑(a • b) := rfl
+@[simp, to_additive] lemma quotient.smul_mk [H.quotient_action β] (a : β) (x : α) :
+  (a • x : α ⧸ H) = ↑(a • x) := rfl
 
-end mul_action
+end subgroup
 
 namespace mul_action
 

--- a/src/group_theory/group_action/basic.lean
+++ b/src/group_theory/group_action/basic.lean
@@ -310,16 +310,9 @@ attribute [to_additive add_action.quotient_action] mul_action.quotient_action
 @[to_additive] instance left_quotient_action : quotient_action β H :=
 ⟨λ _ _ _ _, by rwa [smul_eq_mul, smul_eq_mul, mul_inv_rev, mul_assoc, inv_mul_cancel_left]⟩
 
-@[to_additive] instance right_action : mul_action Hᵐᵒᵖ β :=
-{ smul := λ h, (* h.unop),
-  one_smul := mul_one,
-  mul_smul := λ h₁ h₂ g, (mul_assoc g h₂.unop h₁.unop).symm }
-
-@[to_additive] lemma smul_eq_mul_unop (h : Hᵐᵒᵖ) (b : β) : h • b = b * h.unop := rfl
-
-@[to_additive] instance right_quotient_action : quotient_action H.normalizerᵐᵒᵖ H :=
-⟨λ b c _ _, by rwa [smul_eq_mul_unop, smul_eq_mul_unop, mul_inv_rev, ←mul_assoc, mul_assoc _ c⁻¹,
-  mem_normalizer_iff'.mp (show ↑b.unop ∈ H.normalizer, from b.unop.2), mul_inv_cancel_left]⟩
+@[to_additive] instance right_quotient_action : quotient_action H.normalizer.opposite H :=
+⟨λ b c _ _, by rwa [smul_def, smul_def, smul_eq_mul_unop, smul_eq_mul_unop, mul_inv_rev,
+  ←mul_assoc, ←subtype.val_eq_coe, mem_normalizer_iff'.mp b.2, mul_assoc, mul_inv_cancel_left]⟩
 
 @[to_additive] instance quotient [quotient_action α H] : mul_action α (β ⧸ H) :=
 { smul := λ a, quotient.map' ((•) a) (λ b c h, quotient_action.inv_mul_mem a h),

--- a/src/group_theory/group_action/basic.lean
+++ b/src/group_theory/group_action/basic.lean
@@ -288,46 +288,50 @@ have this : stabilizer α x = (stabilizer α y).map (add_aut.conj g).to_add_mono
 
 end add_action
 
-namespace subgroup
+namespace mul_action
 
-variables (β) [monoid β] [mul_action β α] [group α] (H : subgroup α)
+open subgroup
+
+variable [group α]
+
+section quotient_group
+
+variables (β) [monoid β] [mul_action β α] (H : subgroup α)
 
 /-- A typeclass for when a `mul_action β α` descends to the quotient `α ⧸ H`. -/
 class quotient_action : Prop :=
 (inv_mul_mem : ∀ (b : β) {a a' : α}, a⁻¹ * a' ∈ H → (b • a)⁻¹ * (b • a') ∈ H)
 
 /-- A typeclass for when an `add_action β α` descends to the quotient `α ⧸ H`. -/
-class _root_.add_subgroup.quotient_action {α : Type*} (β : Type*) [add_monoid β] [add_action β α]
-  [add_group α] (H : add_subgroup α) : Prop :=
+class _root_.add_action.quotient_action {α : Type*} (β : Type*) [add_group α] [add_monoid β]
+  [add_action β α] (H : add_subgroup α) : Prop :=
 (inv_mul_mem : ∀ (b : β) {a a' : α}, -a + a' ∈ H → -(b +ᵥ a) + (b +ᵥ a') ∈ H)
 
-attribute [to_additive add_subgroup.quotient_action] subgroup.quotient_action
+attribute [to_additive add_action.quotient_action] mul_action.quotient_action
 
-@[to_additive] instance left_quotient_action : H.quotient_action α :=
+@[to_additive] instance left_quotient_action : quotient_action α H :=
 ⟨λ _ _ _ _, by rwa [smul_eq_mul, smul_eq_mul, mul_inv_rev, mul_assoc, inv_mul_cancel_left]⟩
 
-@[to_additive] instance right_quotient_action : H.quotient_action H.normalizer.opposite :=
+@[to_additive] instance right_quotient_action : quotient_action H.normalizer.opposite H :=
 ⟨λ b c _ _, by rwa [smul_def, smul_def, smul_eq_mul_unop, smul_eq_mul_unop, mul_inv_rev,
   ←mul_assoc, ←subtype.val_eq_coe, mem_normalizer_iff'.mp b.2, mul_assoc, mul_inv_cancel_left]⟩
 
-@[to_additive] instance quotient [H.quotient_action β] : mul_action β (α ⧸ H) :=
+@[to_additive] instance quotient [quotient_action β H] : mul_action β (α ⧸ H) :=
 { smul := λ b, quotient.map' ((•) b) (λ a a' h, quotient_action.inv_mul_mem b h),
   one_smul := λ q, quotient.induction_on' q (λ a, congr_arg quotient.mk' (one_smul β a)),
   mul_smul := λ b b' q, quotient.induction_on' q (λ a, congr_arg quotient.mk' (mul_smul b b' a)) }
 
 variables {β}
 
-@[simp, to_additive] lemma quotient.smul_mk [H.quotient_action β] (a : β) (x : α) :
+@[simp, to_additive] lemma quotient.smul_mk [quotient_action β H] (a : β) (x : α) :
   (a • quotient_group.mk x : α ⧸ H) = quotient_group.mk (a • x) := rfl
 
-@[simp, to_additive] lemma quotient.smul_mk [H.quotient_action β] (a : β) (x : α) :
+@[simp, to_additive] lemma quotient.smul_coe [quotient_action β H] (a : β) (x : α) :
   (a • x : α ⧸ H) = ↑(a • x) := rfl
 
-end subgroup
+end quotient_group
 
-namespace mul_action
-
-variables (α) {β} [group α] [mul_action α β] (x : β)
+variables (α) {β} [mul_action α β] (x : β)
 
 /-- The canonical map from the quotient of the stabilizer to the set. -/
 @[to_additive "The canonical map from the quotient of the stabilizer to the set. "]

--- a/src/group_theory/group_action/basic.lean
+++ b/src/group_theory/group_action/basic.lean
@@ -296,9 +296,11 @@ open subgroup
 
 variables (α) [monoid α] [mul_action α β] [group β] (H : subgroup β)
 
+/-- A typeclass for when a `mul_action α β` descends to the quotient `β ⧸ H`. -/
 class quotient_action : Prop :=
 (inv_mul_mem : ∀ (a : α) {b c : β}, b⁻¹ * c ∈ H → (a • b)⁻¹ * (a • c) ∈ H)
 
+/-- A typeclass for when an `add_action α β` descends to the quotient `β ⧸ H`. -/
 class _root_.add_action.quotient_action (α : Type*) {β : Type*} [add_monoid α] [add_action α β]
   [add_group β] (H : add_subgroup β) : Prop :=
 (inv_mul_mem : ∀ (a : α) {b c : β}, -b + c ∈ H → -(a +ᵥ b) + (a +ᵥ c) ∈ H)

--- a/src/group_theory/group_action/opposite.lean
+++ b/src/group_theory/group_action/opposite.lean
@@ -81,6 +81,9 @@ See also `monoid.to_opposite_mul_action` and `monoid_with_zero.to_opposite_mul_a
 
 @[simp, to_additive] lemma op_smul_eq_mul [has_mul α] {a a' : α} : op a • a' = a' * a := rfl
 
+@[simp, to_additive] lemma smul_eq_mul_unop [has_mul α] {a : αᵐᵒᵖ} {a' : α} :
+  a • a' = a' * a.unop := rfl
+
 /-- The right regular action of a group on itself is transitive. -/
 @[to_additive] instance mul_action.opposite_regular.is_pretransitive {G : Type*} [group G] :
   mul_action.is_pretransitive Gᵐᵒᵖ G :=

--- a/src/linear_algebra/alternating.lean
+++ b/src/linear_algebra/alternating.lean
@@ -644,7 +644,7 @@ begin
   apply σ.induction_on' (λ σ, _),
   dsimp only [quotient.lift_on'_mk', quotient.map'_mk', mul_action.quotient.smul_mk,
     dom_coprod.summand],
-  rw [perm.sign_mul, perm.sign_swap hij],
+  rw [smul_eq_mul, perm.sign_mul, perm.sign_swap hij],
   simp only [one_mul, neg_mul, function.comp_app, units.neg_smul, perm.coe_mul,
     units.coe_neg, multilinear_map.smul_apply, multilinear_map.neg_apply,
     multilinear_map.dom_dom_congr_apply, multilinear_map.dom_coprod_apply],
@@ -675,7 +675,7 @@ begin
     work_on_goal 1 { replace hσ := equiv.congr_fun hσ (sum.inl i'), },
     work_on_goal 2 { replace hσ := equiv.congr_fun hσ (sum.inr i'), },
     all_goals
-    { rw [←equiv.mul_swap_eq_swap_mul, mul_inv_rev, equiv.swap_inv, inv_mul_cancel_right] at hσ,
+    { rw [smul_eq_mul, ←mul_swap_eq_swap_mul, mul_inv_rev, swap_inv, inv_mul_cancel_right] at hσ,
       simpa using hσ, }, },
   case [sum.inr sum.inr : i' j', sum.inl sum.inl : i' j']
   { -- the term does not pair but is zero


### PR DESCRIPTION
This PR adds a typeclass `quotient_action` for the axiom `∀ (a : α) {b c : β}, b⁻¹ * c ∈ H → (a • b)⁻¹ * (a • c) ∈ H`.
If an action satisfies this axiom, then it will descend to an action on the quotient `β ⧸ H`.

My motivation for doing this is twofold:
- First, this provides a unified construction of the left and right actions on the quotient.
- Second, this same axiom will give a unified construction of the left and right actions on left transversals. I will need the left action for the transfer homomorphism, and the right action for the proof of Schur-Zassenhaus.
(The proof of Schur-Zassenhaus currently uses the left action on left transversals, but the current notion of "difference of two left transversals" assumes normality. I plan to refactor the proof to instead use the right action on left transversals, and a modified notion of "difference of two left transversals" that does not assume normality and is compatible with the construction of the transfer homomorphism).

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

- [x] depends on: #12995
- [x] depends on: #12999

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
