### PR TITLE
[Merged by Bors] - feat(data/polynomial/eval + data/polynomial/ring_division): move a lemma and remove assumptions

### DIFF
--- a/src/data/polynomial/eval.lean
+++ b/src/data/polynomial/eval.lean
@@ -463,6 +463,44 @@ begin
   { intros, simp only [add_comp, mul_comp, C_comp, X_comp, pow_succ', ← mul_assoc, *] at * }
 end
 
+lemma coeff_comp_degree_mul_degree {p q : R[X]} (hqd0 : nat_degree q ≠ 0) :
+  coeff (p.comp q) (nat_degree p * nat_degree q) =
+  leading_coeff p * leading_coeff q ^ nat_degree p :=
+begin
+  classical,
+  by_cases hp0 : p = 0, { simp [hp0] },
+  calc coeff (p.comp q) (nat_degree p * nat_degree q)
+      = p.sum (λ n a, coeff (C a * q ^ n) (nat_degree p * nat_degree q)) :
+        by rw [comp, eval₂, coeff_sum]
+  ... = coeff (C (leading_coeff p) * q ^ nat_degree p) (nat_degree p * nat_degree q) :
+        finset.sum_eq_single _
+          begin
+            assume b hbs hbp,
+            have hq0 : q ≠ 0 := λ hq0, hqd0 (by rw [hq0, nat_degree_zero]),
+            have : coeff p b ≠ 0, rwa mem_support_iff at hbs,
+            refine coeff_eq_zero_of_degree_lt ((degree_mul_le _ _).trans_lt _),
+            rw [degree_C this, zero_add],
+            refine (degree_pow_le _ _).trans_lt _,
+            rw [degree_eq_nat_degree hq0, ← with_bot.coe_nsmul, nsmul_eq_mul, with_bot.coe_lt_coe,
+              nat.cast_id, mul_lt_mul_right (pos_iff_ne_zero.mpr hqd0)],
+            exact lt_of_le_of_ne (le_nat_degree_of_ne_zero this) hbp,
+          end
+          begin
+            intro h, contrapose! hp0,
+            rw mem_support_iff at h, push_neg at h,
+            rwa ← leading_coeff_eq_zero,
+          end
+  ... = _ : begin
+    rw [coeff_C_mul],
+    by_cases q0 : q.leading_coeff ^ p.nat_degree = 0,
+    { simp [q0] },
+    have : (q ^ p.nat_degree).nat_degree = p.nat_degree * q.nat_degree,
+    { refine le_antisymm ((nat_degree_pow_le).trans rfl.le) (le_nat_degree_of_ne_zero _),
+      rwa coeff_pow_mul_nat_degree },
+    exact congr_arg _ (coeff_pow_mul_nat_degree _ _),
+  end
+end
+
 end comp
 
 section map

--- a/src/data/polynomial/eval.lean
+++ b/src/data/polynomial/eval.lean
@@ -466,40 +466,24 @@ end
 lemma coeff_comp_degree_mul_degree (hqd0 : nat_degree q ≠ 0) :
   coeff (p.comp q) (nat_degree p * nat_degree q) =
   leading_coeff p * leading_coeff q ^ nat_degree p :=
-begin
-  classical,
-  by_cases hp0 : p = 0, { simp [hp0] },
-  calc coeff (p.comp q) (nat_degree p * nat_degree q)
-      = p.sum (λ n a, coeff (C a * q ^ n) (nat_degree p * nat_degree q)) :
-        by rw [comp, eval₂, coeff_sum]
-  ... = coeff (C (leading_coeff p) * q ^ nat_degree p) (nat_degree p * nat_degree q) :
-        finset.sum_eq_single _
-          begin
-            assume b hbs hbp,
-            have hq0 : q ≠ 0 := λ hq0, hqd0 (by rw [hq0, nat_degree_zero]),
-            have : coeff p b ≠ 0, rwa mem_support_iff at hbs,
-            refine coeff_eq_zero_of_degree_lt ((degree_mul_le _ _).trans_lt _),
-            rw [degree_C this, zero_add],
-            refine (degree_pow_le _ _).trans_lt _,
-            rw [degree_eq_nat_degree hq0, ← with_bot.coe_nsmul, nsmul_eq_mul, with_bot.coe_lt_coe,
-              nat.cast_id, mul_lt_mul_right (pos_iff_ne_zero.mpr hqd0)],
-            exact lt_of_le_of_ne (le_nat_degree_of_ne_zero this) hbp,
-          end
-          begin
-            intro h, contrapose! hp0,
-            rw mem_support_iff at h, push_neg at h,
-            rwa ← leading_coeff_eq_zero,
-          end
-  ... = _ : begin
-    rw [coeff_C_mul],
-    by_cases q0 : q.leading_coeff ^ p.nat_degree = 0,
-    { simp [q0] },
-    have : (q ^ p.nat_degree).nat_degree = p.nat_degree * q.nat_degree,
-    { refine le_antisymm ((nat_degree_pow_le).trans rfl.le) (le_nat_degree_of_ne_zero _),
-      rwa coeff_pow_mul_nat_degree },
-    exact congr_arg _ (coeff_pow_mul_nat_degree _ _),
-  end
-end
+calc coeff (p.comp q) (nat_degree p * nat_degree q)
+    = p.sum (λ n a, coeff (C a * q ^ n) (nat_degree p * nat_degree q)) :
+      by rw [comp, eval₂, coeff_sum]
+... = coeff (C (leading_coeff p) * q ^ nat_degree p) (nat_degree p * nat_degree q) :
+      finset.sum_eq_single _
+        begin
+          assume b hbs hbp,
+          refine coeff_eq_zero_of_nat_degree_lt ((nat_degree_mul_le).trans_lt _),
+          rw [nat_degree_C, zero_add],
+          refine (nat_degree_pow_le).trans_lt ((mul_lt_mul_right (pos_iff_ne_zero.mpr hqd0)).mpr _),
+          exact lt_of_le_of_ne (le_nat_degree_of_mem_supp _ hbs) hbp,
+        end
+        begin
+          intro h,
+          rw [mem_support_iff, not_not, coeff_nat_degree, leading_coeff_eq_zero] at h,
+          simp [h],
+        end
+... = _ : (coeff_C_mul _).trans $ congr_arg _ $ coeff_pow_mul_nat_degree _ _
 
 end comp
 

--- a/src/data/polynomial/eval.lean
+++ b/src/data/polynomial/eval.lean
@@ -463,7 +463,7 @@ begin
   { intros, simp only [add_comp, mul_comp, C_comp, X_comp, pow_succ', ← mul_assoc, *] at * }
 end
 
-lemma coeff_comp_degree_mul_degree {p q : R[X]} (hqd0 : nat_degree q ≠ 0) :
+lemma coeff_comp_degree_mul_degree (hqd0 : nat_degree q ≠ 0) :
   coeff (p.comp q) (nat_degree p * nat_degree q) =
   leading_coeff p * leading_coeff q ^ nat_degree p :=
 begin

--- a/src/data/polynomial/eval.lean
+++ b/src/data/polynomial/eval.lean
@@ -466,20 +466,17 @@ end
 lemma coeff_comp_degree_mul_degree (hqd0 : nat_degree q ≠ 0) :
   coeff (p.comp q) (nat_degree p * nat_degree q) =
   leading_coeff p * leading_coeff q ^ nat_degree p :=
-calc coeff (p.comp q) (nat_degree p * nat_degree q)
-    = p.sum (λ n a, coeff (C a * q ^ n) (nat_degree p * nat_degree q)) :
-      by rw [comp, eval₂, coeff_sum]
-... = coeff (C (leading_coeff p) * q ^ nat_degree p) (nat_degree p * nat_degree q) :
-      finset.sum_eq_single _
-        begin
-          assume b hbs hbp,
-          refine coeff_eq_zero_of_nat_degree_lt ((nat_degree_mul_le).trans_lt _),
-          rw [nat_degree_C, zero_add],
-          refine (nat_degree_pow_le).trans_lt ((mul_lt_mul_right (pos_iff_ne_zero.mpr hqd0)).mpr _),
-          exact lt_of_le_of_ne (le_nat_degree_of_mem_supp _ hbs) hbp,
-        end
-        (λ h, by simp [leading_coeff_eq_zero.mp (not_mem_support_iff.mp h)])
-... = _ : (coeff_C_mul _).trans $ congr_arg _ $ coeff_pow_mul_nat_degree _ _
+begin
+  rw [comp, eval₂, coeff_sum],
+  convert finset.sum_eq_single p.nat_degree _ _,
+  { simp only [coeff_nat_degree, coeff_C_mul, coeff_pow_mul_nat_degree] },
+  { assume b hbs hbp,
+    refine coeff_eq_zero_of_nat_degree_lt ((nat_degree_mul_le).trans_lt _),
+    rw [nat_degree_C, zero_add],
+    refine (nat_degree_pow_le).trans_lt ((mul_lt_mul_right (pos_iff_ne_zero.mpr hqd0)).mpr _),
+    exact lt_of_le_of_ne (le_nat_degree_of_mem_supp _ hbs) hbp },
+  { simp {contextual := tt} }
+end
 
 end comp
 

--- a/src/data/polynomial/eval.lean
+++ b/src/data/polynomial/eval.lean
@@ -478,11 +478,7 @@ calc coeff (p.comp q) (nat_degree p * nat_degree q)
           refine (nat_degree_pow_le).trans_lt ((mul_lt_mul_right (pos_iff_ne_zero.mpr hqd0)).mpr _),
           exact lt_of_le_of_ne (le_nat_degree_of_mem_supp _ hbs) hbp,
         end
-        begin
-          intro h,
-          rw [mem_support_iff, not_not, coeff_nat_degree, leading_coeff_eq_zero] at h,
-          simp [h],
-        end
+        (λ h, by simp [leading_coeff_eq_zero.mp (not_mem_support_iff.mp h)])
 ... = _ : (coeff_C_mul _).trans $ congr_arg _ $ coeff_pow_mul_nat_degree _ _
 
 end comp

--- a/src/data/polynomial/ring_division.lean
+++ b/src/data/polynomial/ring_division.lean
@@ -534,35 +534,6 @@ by rw [nth_roots_finset, mem_to_finset, mem_nth_roots h]
 
 end nth_roots
 
-lemma coeff_comp_degree_mul_degree (hqd0 : nat_degree q ≠ 0) :
-  coeff (p.comp q) (nat_degree p * nat_degree q) =
-  leading_coeff p * leading_coeff q ^ nat_degree p :=
-if hp0 : p = 0 then by simp [hp0] else
-calc coeff (p.comp q) (nat_degree p * nat_degree q)
-  = p.sum (λ n a, coeff (C a * q ^ n) (nat_degree p * nat_degree q)) :
-    by rw [comp, eval₂, coeff_sum]
-... = coeff (C (leading_coeff p) * q ^ nat_degree p) (nat_degree p * nat_degree q) :
-  finset.sum_eq_single _
-  begin
-    assume b hbs hbp,
-    have hq0 : q ≠ 0, from λ hq0, hqd0 (by rw [hq0, nat_degree_zero]),
-    have : coeff p b ≠ 0, by rwa mem_support_iff at hbs,
-    refine coeff_eq_zero_of_degree_lt _,
-    erw [degree_mul, degree_C this, degree_pow, zero_add, degree_eq_nat_degree hq0,
-      ← with_bot.coe_nsmul, nsmul_eq_mul, with_bot.coe_lt_coe, nat.cast_id,
-      mul_lt_mul_right (pos_iff_ne_zero.mpr hqd0)],
-    exact lt_of_le_of_ne (le_nat_degree_of_ne_zero this) hbp,
-  end
-  begin
-    intro h, contrapose! hp0,
-    rw mem_support_iff at h, push_neg at h,
-    rwa ← leading_coeff_eq_zero,
-  end
-... = _ :
-  have coeff (q ^ nat_degree p) (nat_degree p * nat_degree q) = leading_coeff (q ^ nat_degree p),
-    by rw [leading_coeff, nat_degree_pow],
-  by rw [coeff_C_mul, this, leading_coeff_pow]
-
 lemma nat_degree_comp : nat_degree (p.comp q) = nat_degree p * nat_degree q :=
 le_antisymm nat_degree_comp_le
   (if hp0 : p = 0 then by rw [hp0, zero_comp, nat_degree_zero, zero_mul]


### PR DESCRIPTION
A lemma about composition of polynomials assumed `comm_ring` and `is_domain`.  The new version assumes `semiring`.

I golfed slightly the original proof: it may very well be that a shorter proof is available!

I also moved the lemma, since it seems better for this lemma to appear in the file where the definition of `comp` appears.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
