### PR TITLE
[Merged by Bors] - refactor(order/hom/complete_lattice): Fix the definition of `frame_hom`

### DIFF
--- a/src/order/hom/complete_lattice.lean
+++ b/src/order/hom/complete_lattice.lean
@@ -360,6 +360,9 @@ instance : frame_hom_class (frame_hom α β) α β :=
 directly. -/
 instance : has_coe_to_fun (frame_hom α β) (λ _, α → β) := fun_like.has_coe_to_fun
 
+/-- Reinterpret a `frame_hom` as a `lattice_hom`. -/
+def to_lattice_hom (f : frame_hom α β) : lattice_hom α β := f
+
 @[simp] lemma to_fun_eq_coe {f : frame_hom α β} : f.to_fun = (f : α → β) := rfl
 
 @[ext] lemma ext {f g : frame_hom α β} (h : ∀ a, f a = g a) : f = g := fun_like.ext f g h

--- a/src/order/hom/complete_lattice.lean
+++ b/src/order/hom/complete_lattice.lean
@@ -18,7 +18,7 @@ be satisfied by itself and all stricter types.
 
 * `Sup_hom`: Maps which preserve `⨆`.
 * `Inf_hom`: Maps which preserve `⨅`.
-* `frame_hom`: Frame homomorphisms. Maps which preserve `⨆` and `⊓`.
+* `frame_hom`: Frame homomorphisms. Maps which preserve `⨆`, `⊓` and `⊤`.
 * `complete_lattice_hom`: Complete lattice homomorphisms. Maps which preserve `⨆` and `⨅`.
 
 ## Typeclasses
@@ -43,7 +43,8 @@ structure Inf_hom (α β : Type*) [has_Inf α] [has_Inf β] :=
 (to_fun   : α → β)
 (map_Inf' (s : set α) : to_fun (Inf s) = Inf (to_fun '' s))
 
-/-- The type of frame homomorphisms from `α` to `β`. They preserve `⊓` and `⨆`. -/
+/-- The type of frame homomorphisms from `α` to `β`. They preserve finite meets and arbitrary joins.
+-/
 structure frame_hom (α β : Type*) [complete_lattice α] [complete_lattice β]
   extends inf_top_hom α β :=
 (map_Sup' (s : set α) : to_fun (Sup s) = Sup (to_fun '' s))

--- a/src/order/hom/complete_lattice.lean
+++ b/src/order/hom/complete_lattice.lean
@@ -44,18 +44,19 @@ structure Inf_hom (α β : Type*) [has_Inf α] [has_Inf β] :=
 (map_Inf' (s : set α) : to_fun (Inf s) = Inf (to_fun '' s))
 
 /-- The type of frame homomorphisms from `α` to `β`. They preserve `⊓` and `⨆`. -/
-structure frame_hom (α β : Type*) [complete_lattice α] [complete_lattice β] extends Sup_hom α β :=
-(map_inf' (a b : α) : to_fun (a ⊓ b) = to_fun a ⊓ to_fun b)
+structure frame_hom (α β : Type*) [complete_lattice α] [complete_lattice β]
+  extends inf_top_hom α β :=
+(map_Sup' (s : set α) : to_fun (Sup s) = Sup (to_fun '' s))
 
 /-- The type of complete lattice homomorphisms from `α` to `β`. -/
 structure complete_lattice_hom (α β : Type*) [complete_lattice α] [complete_lattice β]
-  extends Sup_hom α β :=
-(map_Inf' (s : set α) : to_fun (Inf s) = Inf (to_fun '' s))
+  extends Inf_hom α β :=
+(map_Sup' (s : set α) : to_fun (Sup s) = Sup (to_fun '' s))
 
 /-- `Sup_hom_class F α β` states that `F` is a type of `⨆`-preserving morphisms.
 
 You should extend this class when you extend `Sup_hom`. -/
-class Sup_hom_class (F : Type*) (α β : out_param $ Type*) [has_Sup α] [has_Sup β]
+@[ext] class Sup_hom_class (F : Type*) (α β : out_param $ Type*) [has_Sup α] [has_Sup β]
   extends fun_like F α (λ _, β) :=
 (map_Sup (f : F) (s : set α) : f (Sup s) = Sup (f '' s))
 
@@ -70,15 +71,15 @@ class Inf_hom_class (F : Type*) (α β : out_param $ Type*) [has_Inf α] [has_In
 
 You should extend this class when you extend `frame_hom`. -/
 class frame_hom_class (F : Type*) (α β : out_param $ Type*) [complete_lattice α]
-  [complete_lattice β] extends Sup_hom_class F α β :=
-(map_inf (f : F) (a b : α) : f (a ⊓ b) = f a ⊓ f b)
+  [complete_lattice β] extends inf_top_hom_class F α β :=
+(map_Sup (f : F) (s : set α) : f (Sup s) = Sup (f '' s))
 
 /-- `complete_lattice_hom_class F α β` states that `F` is a type of complete lattice morphisms.
 
 You should extend this class when you extend `complete_lattice_hom`. -/
 class complete_lattice_hom_class (F : Type*) (α β : out_param $ Type*) [complete_lattice α]
-  [complete_lattice β] extends Sup_hom_class F α β :=
-(map_Inf (f : F) (s : set α) : f (Inf s) = Inf (f '' s))
+  [complete_lattice β] extends Inf_hom_class F α β :=
+(map_Sup (f : F) (s : set α) : f (Sup s) = Sup (f '' s))
 
 export Sup_hom_class (map_Sup)
 export Inf_hom_class (map_Inf)
@@ -102,52 +103,42 @@ lemma map_infi₂ [has_Inf α] [has_Inf β] [Inf_hom_class F α β] (f : F) (g :
 by simp_rw map_infi
 
 @[priority 100] -- See note [lower instance priority]
-instance Sup_hom_class.to_sup_hom_class [complete_lattice α] [complete_lattice β]
+instance Sup_hom_class.to_sup_bot_hom_class [complete_lattice α] [complete_lattice β]
   [Sup_hom_class F α β] :
-  sup_hom_class F α β :=
-⟨λ f a b, by rw [←Sup_pair, map_Sup, set.image_pair, Sup_pair]⟩
+  sup_bot_hom_class F α β :=
+{ map_sup := λ f a b, by rw [←Sup_pair, map_Sup, set.image_pair, Sup_pair],
+  map_bot := λ f, by rw [←Sup_empty, map_Sup, set.image_empty, Sup_empty] }
 
 @[priority 100] -- See note [lower instance priority]
-instance Sup_hom_class.to_bot_hom_class [complete_lattice α] [complete_lattice β]
-  [Sup_hom_class F α β] :
-  bot_hom_class F α β :=
-⟨λ f, by rw [←Sup_empty, map_Sup, set.image_empty, Sup_empty]⟩
-
-@[priority 100] -- See note [lower instance priority]
-instance Inf_hom_class.to_inf_hom_class [complete_lattice α] [complete_lattice β]
+instance Inf_hom_class.to_inf_top_hom_class [complete_lattice α] [complete_lattice β]
   [Inf_hom_class F α β] :
-  inf_hom_class F α β :=
-⟨λ f a b, by rw [←Inf_pair, map_Inf, set.image_pair, Inf_pair]⟩
+  inf_top_hom_class F α β :=
+{ map_inf := λ f a b, by rw [←Inf_pair, map_Inf, set.image_pair, Inf_pair],
+  map_top := λ f, by rw [←Inf_empty, map_Inf, set.image_empty, Inf_empty] }
 
 @[priority 100] -- See note [lower instance priority]
-instance Inf_hom_class.to_top_hom_class [complete_lattice α] [complete_lattice β]
-  [Inf_hom_class F α β] :
-  top_hom_class F α β :=
-⟨λ f, by rw [←Inf_empty, map_Inf, set.image_empty, Inf_empty]⟩
-
-@[priority 100] -- See note [lower instance priority]
-instance frame_hom_class.to_lattice_hom_class [complete_lattice α] [complete_lattice β]
+instance frame_hom_class.to_Sup_hom_class [complete_lattice α] [complete_lattice β]
   [frame_hom_class F α β] :
-  lattice_hom_class F α β :=
+  Sup_hom_class F α β :=
 { .. ‹frame_hom_class F α β› }
 
 @[priority 100] -- See note [lower instance priority]
-instance complete_lattice_hom_class.to_Inf_hom_class [complete_lattice α] [complete_lattice β]
-  [complete_lattice_hom_class F α β] :
-  Inf_hom_class F α β :=
-{ .. ‹complete_lattice_hom_class F α β› }
+instance frame_hom_class.to_bounded_lattice_hom_class [complete_lattice α] [complete_lattice β]
+  [frame_hom_class F α β] :
+  bounded_lattice_hom_class F α β :=
+{ .. ‹frame_hom_class F α β›, ..Sup_hom_class.to_sup_bot_hom_class }
 
 @[priority 100] -- See note [lower instance priority]
 instance complete_lattice_hom_class.to_frame_hom_class [complete_lattice α] [complete_lattice β]
   [complete_lattice_hom_class F α β] :
   frame_hom_class F α β :=
-{ .. ‹complete_lattice_hom_class F α β›, ..Inf_hom_class.to_inf_hom_class }
+{ .. ‹complete_lattice_hom_class F α β›, ..Inf_hom_class.to_inf_top_hom_class }
 
 @[priority 100] -- See note [lower instance priority]
 instance complete_lattice_hom_class.to_bounded_lattice_hom_class [complete_lattice α]
   [complete_lattice β] [complete_lattice_hom_class F α β] :
   bounded_lattice_hom_class F α β :=
-{ ..Sup_hom_class.to_bot_hom_class, ..Inf_hom_class.to_top_hom_class }
+{ ..Sup_hom_class.to_sup_bot_hom_class, ..Inf_hom_class.to_inf_top_hom_class }
 
 @[priority 100] -- See note [lower instance priority]
 instance order_iso.complete_lattice_hom_class [complete_lattice α] [complete_lattice β] :
@@ -164,11 +155,11 @@ instance [has_Inf α] [has_Inf β] [Inf_hom_class F α β] : has_coe_t F (Inf_ho
 
 instance [complete_lattice α] [complete_lattice β] [frame_hom_class F α β] :
   has_coe_t F (frame_hom α β) :=
-⟨λ f, { to_fun := f, map_Sup' := map_Sup f, map_inf' := map_inf f }⟩
+⟨λ f, ⟨f, map_Sup f⟩⟩
 
 instance [complete_lattice α] [complete_lattice β] [complete_lattice_hom_class F α β] :
   has_coe_t F (complete_lattice_hom α β) :=
-⟨λ f, { to_fun := f, map_Sup' := map_Sup f, map_Inf' := map_Inf f }⟩
+⟨λ f, ⟨f, map_Sup f⟩⟩
 
 /-! ### Supremum homomorphisms -/
 
@@ -185,7 +176,7 @@ instance : Sup_hom_class (Sup_hom α β) α β :=
 
 /-- Helper instance for when there's too many metavariables to apply `fun_like.has_coe_to_fun`
 directly. -/
-instance : has_coe_to_fun (Sup_hom α β) (λ _, α → β) := ⟨λ f, f.to_fun⟩
+instance : has_coe_to_fun (Sup_hom α β) (λ _, α → β) := fun_like.has_coe_to_fun
 
 @[simp] lemma to_fun_eq_coe {f : Sup_hom α β} : f.to_fun = (f : α → β) := rfl
 
@@ -266,7 +257,7 @@ instance : Inf_hom_class (Inf_hom α β) α β :=
 
 /-- Helper instance for when there's too many metavariables to apply `fun_like.has_coe_to_fun`
 directly. -/
-instance : has_coe_to_fun (Inf_hom α β) (λ _, α → β) := ⟨λ f, f.to_fun⟩
+instance : has_coe_to_fun (Inf_hom α β) (λ _, α → β) := fun_like.has_coe_to_fun
 
 @[simp] lemma to_fun_eq_coe {f : Inf_hom α β} : f.to_fun = (f : α → β) := rfl
 
@@ -359,18 +350,15 @@ variables [complete_lattice α] [complete_lattice β] [complete_lattice γ] [com
 
 instance : frame_hom_class (frame_hom α β) α β :=
 { coe := λ f, f.to_fun,
-  coe_injective' := λ f g h, by obtain ⟨⟨_, _⟩, _⟩ := f; obtain ⟨⟨_, _⟩, _⟩ := g; congr',
+  coe_injective' := λ f g h,
+    by { obtain ⟨⟨⟨_, _⟩, _⟩, _⟩ := f, obtain ⟨⟨⟨_, _⟩, _⟩, _⟩ := g, congr' },
   map_Sup := λ f, f.map_Sup',
-  map_inf := λ f, f.map_inf' }
+  map_inf := λ f, f.map_inf',
+  map_top := λ f, f.map_top' }
 
 /-- Helper instance for when there's too many metavariables to apply `fun_like.has_coe_to_fun`
 directly. -/
-instance : has_coe_to_fun (frame_hom α β) (λ _, α → β) := ⟨λ f, f.to_fun⟩
-
-/-- Reinterpret a `frame_hom` as a `lattice_hom`. -/
-def to_lattice_hom (f : frame_hom α β) : lattice_hom α β :=
-{ to_fun := f,
-  map_sup' := λ a b, by rw [←Sup_pair, map_Sup, set.image_pair, Sup_pair], ..f }
+instance : has_coe_to_fun (frame_hom α β) (λ _, α → β) := fun_like.has_coe_to_fun
 
 @[simp] lemma to_fun_eq_coe {f : frame_hom α β} : f.to_fun = (f : α → β) := rfl
 
@@ -379,12 +367,12 @@ def to_lattice_hom (f : frame_hom α β) : lattice_hom α β :=
 /-- Copy of a `frame_hom` with a new `to_fun` equal to the old one. Useful to fix definitional
 equalities. -/
 protected def copy (f : frame_hom α β) (f' : α → β) (h : f' = f) : frame_hom α β :=
-{ .. f.to_Sup_hom.copy f' h, .. f.to_lattice_hom.copy f' h }
+{ to_inf_top_hom := f.to_inf_top_hom.copy f' h, ..(f : Sup_hom α β).copy f' h }
 
 variables (α)
 
 /-- `id` as a `frame_hom`. -/
-protected def id : frame_hom α α := { ..Sup_hom.id α, ..inf_hom.id α }
+protected def id : frame_hom α α := { to_inf_top_hom := inf_top_hom.id α, ..Sup_hom.id α }
 
 instance : inhabited (frame_hom α α) := ⟨frame_hom.id α⟩
 
@@ -396,7 +384,8 @@ variables {α}
 
 /-- Composition of `frame_hom`s as a `frame_hom`. -/
 def comp (f : frame_hom β γ) (g : frame_hom α β) : frame_hom α γ :=
-{ ..f.to_Sup_hom.comp g.to_Sup_hom, ..f.to_lattice_hom.comp g.to_lattice_hom }
+{ to_inf_top_hom := f.to_inf_top_hom.comp g.to_inf_top_hom,
+  ..(f : Sup_hom β γ).comp (g : Sup_hom α β) }
 
 @[simp] lemma coe_comp (f : frame_hom β γ) (g : frame_hom α β) : ⇑(f.comp g) = f ∘ g := rfl
 @[simp] lemma comp_apply (f : frame_hom β γ) (g : frame_hom α β) (a : α) : (f.comp g) a = f (g a) :=
@@ -416,14 +405,6 @@ lemma cancel_left {g : frame_hom β γ} {f₁ f₂ : frame_hom α β} (hg : inje
 
 instance : partial_order (frame_hom α β) := partial_order.lift _ fun_like.coe_injective
 
-instance : has_bot (frame_hom α β) :=
-⟨{ .. (inf_hom.const _ _), .. (⊥ : Sup_hom α β) }⟩
-
-instance : order_bot (frame_hom α β) := ⟨⊥, λ f a, bot_le⟩
-
-@[simp] lemma coe_bot : ⇑(⊥ : frame_hom α β) = ⊥ := rfl
-@[simp] lemma bot_apply (a : α) : (⊥ : frame_hom α β) a = ⊥ := rfl
-
 end frame_hom
 
 /-! ### Complete lattice homomorphisms -/
@@ -431,21 +412,18 @@ end frame_hom
 namespace complete_lattice_hom
 variables [complete_lattice α] [complete_lattice β] [complete_lattice γ] [complete_lattice δ]
 
-/-- Reinterpret a `complete_lattice_hom` as an `Inf_hom`. -/
-def to_Inf_hom (f : complete_lattice_hom α β) : Inf_hom α β := { ..f }
-
 instance : complete_lattice_hom_class (complete_lattice_hom α β) α β :=
 { coe := λ f, f.to_fun,
   coe_injective' := λ f g h, by obtain ⟨⟨_, _⟩, _⟩ := f; obtain ⟨⟨_, _⟩, _⟩ := g; congr',
   map_Sup := λ f, f.map_Sup',
   map_Inf := λ f, f.map_Inf' }
 
-/-- Reinterpret a `complete_lattice_hom` as a `bounded_lattice_hom`. -/
-def to_bounded_lattice_hom (f : complete_lattice_hom α β) : bounded_lattice_hom α β := f
+/-- Reinterpret a `complete_lattice_hom` as a `Sup_hom`. -/
+def to_Sup_hom (f : complete_lattice_hom α β) : Sup_hom α β := f
 
 /-- Helper instance for when there's too many metavariables to apply `fun_like.has_coe_to_fun`
 directly. -/
-instance : has_coe_to_fun (complete_lattice_hom α β) (λ _, α → β) := ⟨λ f, f.to_fun⟩
+instance : has_coe_to_fun (complete_lattice_hom α β) (λ _, α → β) := fun_like.has_coe_to_fun
 
 @[simp] lemma to_fun_eq_coe {f : complete_lattice_hom α β} : f.to_fun = (f : α → β) := rfl
 
@@ -455,7 +433,7 @@ instance : has_coe_to_fun (complete_lattice_hom α β) (λ _, α → β) := ⟨�
 definitional equalities. -/
 protected def copy (f : complete_lattice_hom α β) (f' : α → β) (h : f' = f) :
   complete_lattice_hom α β :=
-{ .. f.to_Sup_hom.copy f' h, .. f.to_Inf_hom.copy f' h }
+{ to_Inf_hom := f.to_Inf_hom.copy f' h, .. f.to_Sup_hom.copy f' h }
 
 variables (α)
 
@@ -472,7 +450,7 @@ variables {α}
 
 /-- Composition of `complete_lattice_hom`s as a `complete_lattice_hom`. -/
 def comp (f : complete_lattice_hom β γ) (g : complete_lattice_hom α β) : complete_lattice_hom α γ :=
-{ ..f.to_Sup_hom.comp g.to_Sup_hom, ..f.to_Inf_hom.comp g.to_Inf_hom }
+{ to_Inf_hom := f.to_Inf_hom.comp g.to_Inf_hom, ..f.to_Sup_hom.comp g.to_Sup_hom }
 
 @[simp] lemma coe_comp (f : complete_lattice_hom β γ) (g : complete_lattice_hom α β) :
   ⇑(f.comp g) = f ∘ g := rfl
@@ -496,13 +474,14 @@ lemma cancel_left {g : complete_lattice_hom β γ} {f₁ f₂ : complete_lattice
   g.comp f₁ = g.comp f₂ ↔ f₁ = f₂ :=
 ⟨λ h, ext $ λ a, hg $ by rw [←comp_apply, h, comp_apply], congr_arg _⟩
 
-/-- Reinterpret a lattice homomorphism as a lattice homomorphism between the dual lattices. -/
+/-- Reinterpret a complete lattice homomorphism as a complete lattice homomorphism between the dual
+lattices. -/
 @[simps] protected def dual :
    complete_lattice_hom α β ≃ complete_lattice_hom (order_dual α) (order_dual β) :=
-{ to_fun := λ f, { to_Sup_hom := f.to_Inf_hom.dual,
-                   map_Inf' := λ _, congr_arg to_dual (map_Sup f _) },
-  inv_fun := λ f, { to_Sup_hom := f.to_Inf_hom.dual,
-                    map_Inf' := λ _, congr_arg of_dual (map_Sup f _) },
+{ to_fun := λ f, { to_Inf_hom := f.to_Sup_hom.dual,
+                   map_Sup' := λ _, congr_arg to_dual (map_Inf f _) },
+  inv_fun := λ f, { to_Inf_hom := f.to_Sup_hom.dual,
+                    map_Sup' := λ _, congr_arg of_dual (map_Inf f _) },
   left_inv := λ f, ext $ λ a, rfl,
   right_inv := λ f, ext $ λ a, rfl }
 

--- a/src/order/hom/complete_lattice.lean
+++ b/src/order/hom/complete_lattice.lean
@@ -56,7 +56,7 @@ structure complete_lattice_hom (α β : Type*) [complete_lattice α] [complete_l
 /-- `Sup_hom_class F α β` states that `F` is a type of `⨆`-preserving morphisms.
 
 You should extend this class when you extend `Sup_hom`. -/
-@[ext] class Sup_hom_class (F : Type*) (α β : out_param $ Type*) [has_Sup α] [has_Sup β]
+class Sup_hom_class (F : Type*) (α β : out_param $ Type*) [has_Sup α] [has_Sup β]
   extends fun_like F α (λ _, β) :=
 (map_Sup (f : F) (s : set α) : f (Sup s) = Sup (f '' s))
 
@@ -420,6 +420,9 @@ instance : complete_lattice_hom_class (complete_lattice_hom α β) α β :=
 
 /-- Reinterpret a `complete_lattice_hom` as a `Sup_hom`. -/
 def to_Sup_hom (f : complete_lattice_hom α β) : Sup_hom α β := f
+
+/-- Reinterpret a `complete_lattice_hom` as a `bounded_lattice_hom`. -/
+def to_bounded_lattice_hom (f : complete_lattice_hom α β) : bounded_lattice_hom α β := f
 
 /-- Helper instance for when there's too many metavariables to apply `fun_like.has_coe_to_fun`
 directly. -/

--- a/src/topology/sets/opens.lean
+++ b/src/topology/sets/opens.lean
@@ -179,7 +179,8 @@ def comap (f : C(α, β)) : frame_hom (opens β) (opens α) :=
 { to_fun := λ s, ⟨f ⁻¹' s, s.2.preimage f.continuous⟩,
   map_Sup' := λ s, ext $ by simp only [coe_Sup, preimage_Union, coe_mk, mem_image, Union_exists,
     bUnion_and', Union_Union_eq_right],
-  map_inf' := λ a b, rfl }
+  map_inf' := λ a b, rfl,
+  map_top' := rfl }
 
 @[simp] lemma comap_id : comap (continuous_map.id α) = frame_hom.id _ :=
 frame_hom.ext $ λ a, ext rfl


### PR DESCRIPTION
I misread "preserves finite meet" as "preserves binary meet", meaning that currently a `frame_hom` does not have to preserve `⊤` (subtly, preserving arbitrary join does not imply that either). This fixes my mistake.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

I had to change the extension path for `complete_lattice_hom` because two instances were not defeq (but they were defeq after `ext`). See [Zulip](https://leanprover.zulipchat.com/#narrow/stream/144837-PR-reviews/topic/.2312855.20Fix.20definition.20of.20.60frame_hom.60)

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)