### PR TITLE
[Merged by Bors] - fix(ring_theory/algebraic): Make `is_transcendental_of_subsingleton` fully general

### DIFF
--- a/src/ring_theory/algebraic.lean
+++ b/src/ring_theory/algebraic.lean
@@ -32,7 +32,7 @@ def is_algebraic (x : A) : Prop :=
 /-- An element of an R-algebra is transcendental over R if it is not algebraic over R. -/
 def transcendental (x : A) : Prop := ¬ is_algebraic R x
 
-lemma is_transcendental_of_subsingleton [subsingleton R] (x : R) : transcendental R x :=
+lemma is_transcendental_of_subsingleton [subsingleton R] (x : A) : transcendental R x :=
 λ ⟨p, h, _⟩, h $ subsingleton.elim p 0
 
 variables {R}


### PR DESCRIPTION
I mistyped a single letter.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
