### PR TITLE
[Merged by Bors] - feat(tactic/ext): support rintro patterns in `ext`

### DIFF
--- a/src/tactic/congr.lean
+++ b/src/tactic/congr.lean
@@ -89,10 +89,10 @@ the depth of recursive applications.
   `x : α ⊢ f x = g x`.
 -/
 meta def congr' (n : parse (with_desc "n" small_nat)?) :
-  parse (tk "with" *> prod.mk <$> rcases_patt_parse_hi* <*> (tk ":" *> small_nat)?)? →
+  parse (tk "with" *> prod.mk <$> rintro_patt_parse_hi* <*> (tk ":" *> small_nat)?)? →
   tactic unit
 | none         := tactic.congr' n
-| (some ⟨p, m⟩) := focus1 (tactic.congr' n >> all_goals' (tactic.ext p m $> ()))
+| (some ⟨p, m⟩) := focus1 (tactic.congr' n >> all_goals' (tactic.ext p.join m $> ()))
 
 /--
 Repeatedly and apply `congr'` and `ext`, using the given patterns as arguments for `ext`.
@@ -121,13 +121,13 @@ and `congr' with x` (or `congr', ext x`) would produce
 x : α ⊢ f x + 3 = g x + 3
 ```
 -/
-meta def rcongr : parse rcases_patt_parse_hi* → tactic unit
+meta def rcongr : parse (list.join <$> rintro_patt_parse_hi*) → tactic unit
 | ps := do
   t ← target,
   qs ← try_core (tactic.ext ps none),
   some () ← try_core (tactic.congr' none >>
     (done <|> do s ← target, guard $ ¬ s =ₐ t)) | skip,
-  done <|> rcongr (qs.lhoare ps)
+  done <|> rcongr (qs.get_or_else ps)
 
 add_tactic_doc
 { name       := "congr'",

--- a/src/tactic/ext.lean
+++ b/src/tactic/ext.lean
@@ -442,7 +442,7 @@ do ⟨_, σ⟩ ← state_t.run (ext1_core cfg) {patts := xs},
 /-- Apply multiple extensionality lemmas, destructing the arguments using the given patterns.
   `ext ps (some n)` applies at most `n` extensionality lemmas. Returns the unused patterns. -/
 meta def ext (xs : list rcases_patt) (fuel : option ℕ) (cfg : apply_cfg := {})
-  (trace : bool := ff): tactic (list rcases_patt) :=
+  (trace : bool := ff) : tactic (list rcases_patt) :=
 do ⟨_, σ⟩ ← state_t.run (ext_core cfg) {patts := xs, fuel := fuel},
    when trace $ tactic.trace $ "Try this: " ++  ", ".intercalate σ.trace_msg,
    pure σ.patts
@@ -523,10 +523,10 @@ Try this: apply funext, rintro ⟨a, b⟩
 A maximum depth can be provided with `ext x y z : 3`.
 -/
 meta def interactive.ext :
-  (parse $ (tk "?")?) → parse rcases_patt_parse_hi* → parse (tk ":" *> small_nat)? → tactic unit
+  (parse $ (tk "?")?) → parse rintro_patt_parse_hi* → parse (tk ":" *> small_nat)? → tactic unit
  | trace [] (some n)  := iterate_range 1 n (ext1 [] {} trace.is_some $> ())
  | trace [] none      := repeat1 (ext1 [] {} trace.is_some $> ())
- | trace xs n         := ext xs n {} trace.is_some $> ()
+ | trace xs n         := ext xs.join n {} trace.is_some $> ()
 
 /--
 * `ext1 id` selects and apply one extensionality lemma (with

--- a/test/ext.lean
+++ b/test/ext.lean
@@ -83,7 +83,7 @@ by { ext1, guard_target s₀.nth n = s₁.nth n, simp * }
 example (s₀ s₁ : ℤ → set (ℕ × ℕ))
         (h : ∀ i a b, (a,b) ∈ s₀ i ↔ (a,b) ∈ s₁ i) : s₀ = s₁ :=
 begin
-  ext i ⟨a,b⟩,
+  ext ((i) ⟨a,b⟩),
   apply h
 end
 


### PR DESCRIPTION
The change is actually quite simple, since `rintro_pat*` has approximately the same type as `rcases_pat*`.