### PR TITLE
[Merged by Bors] - docs(data/set/pairwise): Explain preference for `s.pairwise_disjoint id`

### DIFF
--- a/src/data/set/pairwise.lean
+++ b/src/data/set/pairwise.lean
@@ -21,7 +21,7 @@ This file defines pairwise relations and pairwise disjoint indexed sets.
 ## Notes
 
 The spelling `s.pairwise_disjoint id` is preferred over `s.pairwise disjoint` to permit dot notation
-on `set.pairwise_disjoint` even though the latter unfolds to something nicer.
+on `set.pairwise_disjoint`, even though the latter unfolds to something nicer.
 -/
 
 open set function
@@ -223,7 +223,7 @@ variables [semilattice_inf α] [order_bot α] {s t : set ι} {f g : ι → α}
 are disjoint.
 
 `s.pairwise disjoint` is (definitionally) the same as `s.pairwise_disjoint id`. We prefer the latter
-in order to allow dot notation on `set.pairwise_disjoint` even though the former unfolds more
+in order to allow dot notation on `set.pairwise_disjoint`, even though the former unfolds more
 nicely. -/
 def pairwise_disjoint (s : set ι) (f : ι → α) : Prop := s.pairwise (disjoint on f)
 

--- a/src/data/set/pairwise.lean
+++ b/src/data/set/pairwise.lean
@@ -17,6 +17,11 @@ This file defines pairwise relations and pairwise disjoint indexed sets.
 * `set.pairwise`: `s.pairwise r` states that `r i j` for all `i ≠ j` with `i, j ∈ s`.
 * `set.pairwise_disjoint`: `s.pairwise_disjoint f` states that images under `f` of distinct elements
   of `s` are either equal or `disjoint`.
+
+## Notes
+
+The spelling `s.pairwise_disjoint id` is preferred over `s.pairwise disjoint` to permit dot notation
+on `set.pairwise_disjoint` even though the latter unfolds to something nicer.
 -/
 
 open set function
@@ -215,7 +220,11 @@ section semilattice_inf_bot
 variables [semilattice_inf α] [order_bot α] {s t : set ι} {f g : ι → α}
 
 /-- A set is `pairwise_disjoint` under `f`, if the images of any distinct two elements under `f`
-are disjoint. -/
+are disjoint.
+
+`s.pairwise disjoint` is (definitionally) the same as `s.pairwise_disjoint id`. We prefer the latter
+in order to allow dot notation on `set.pairwise_disjoint` even though the former unfolds more
+nicely. -/
 def pairwise_disjoint (s : set ι) (f : ι → α) : Prop := s.pairwise (disjoint on f)
 
 lemma pairwise_disjoint.subset (ht : t.pairwise_disjoint f) (h : s ⊆ t) : s.pairwise_disjoint f :=


### PR DESCRIPTION
... over `s.pairwise disjoint`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
