### PR TITLE
[Merged by Bors] - refactor(algebra/group/to_additive + files containing even/odd): move many lemmas involving even/odd to the same file

### DIFF
--- a/src/algebra/field_power.lean
+++ b/src/algebra/field_power.lean
@@ -28,13 +28,6 @@ f.to_ring_hom.map_zpow
   (-x) ^ (bit0 n) = x ^ bit0 n :=
 by rw [zpow_bit0', zpow_bit0', neg_mul_neg]
 
-lemma even.zpow_neg {K : Type*} [division_ring K] {n : ℤ} (h : even n) (a : K) :
-  (-a) ^ n = a ^ n :=
-begin
-  obtain ⟨k, rfl⟩ := h,
-  rw [←bit0_eq_two_mul, zpow_bit0_neg],
-end
-
 @[simp] lemma zpow_bit1_neg {K : Type*} [division_ring K] (x : K) (n : ℤ) :
   (-x) ^ (bit1 n) = - x ^ bit1 n :=
 by rw [zpow_bit1', zpow_bit1', neg_mul_neg, neg_mul_eq_mul_neg]
@@ -134,48 +127,6 @@ end
 
 @[simp] theorem zpow_bit1_pos_iff : 0 < a ^ bit1 n ↔ 0 < a :=
 lt_iff_lt_of_le_iff_le zpow_bit1_nonpos_iff
-
-lemma even.zpow_nonneg {n : ℤ} (hn : even n) (a : K) :
-  0 ≤ a ^ n :=
-begin
-  cases le_or_lt 0 a with h h,
-  { exact zpow_nonneg h _ },
-  { exact (hn.zpow_neg a).subst (zpow_nonneg (neg_nonneg_of_nonpos h.le) _) }
-end
-
-theorem even.zpow_pos (hn : even n) (ha : a ≠ 0) : 0 < a ^ n :=
-by cases hn with k hk; simpa only [hk, two_mul] using zpow_bit0_pos ha k
-
-theorem odd.zpow_nonneg (hn : odd n) (ha : 0 ≤ a) : 0 ≤ a ^ n :=
-by cases hn with k hk; simpa only [hk, two_mul] using zpow_bit1_nonneg_iff.mpr ha
-
-theorem odd.zpow_pos (hn : odd n) (ha : 0 < a) : 0 < a ^ n :=
-by cases hn with k hk; simpa only [hk, two_mul] using zpow_bit1_pos_iff.mpr ha
-
-theorem odd.zpow_nonpos (hn : odd n) (ha : a ≤ 0) : a ^ n ≤ 0:=
-by cases hn with k hk; simpa only [hk, two_mul] using zpow_bit1_nonpos_iff.mpr ha
-
-theorem odd.zpow_neg (hn : odd n) (ha : a < 0) : a ^ n < 0:=
-by cases hn with k hk; simpa only [hk, two_mul] using zpow_bit1_neg_iff.mpr ha
-
-lemma even.zpow_abs {p : ℤ} (hp : even p) (a : K) : |a| ^ p = a ^ p :=
-begin
-  cases abs_choice a with h h;
-  simp only [h, hp.zpow_neg _],
-end
-
-@[simp] lemma zpow_bit0_abs (a : K) (p : ℤ) : |a| ^ bit0 p = a ^ bit0 p :=
-(even_bit0 _).zpow_abs _
-
-lemma even.abs_zpow {p : ℤ} (hp : even p) (a : K) : |a ^ p| = a ^ p :=
-begin
-  rw [abs_eq_self],
-  exact hp.zpow_nonneg _
-end
-
-@[simp] lemma abs_zpow_bit0 (a : K) (p : ℤ) :
-  |a ^ bit0 p| = a ^ bit0 p :=
-(even_bit0 _).abs_zpow _
 
 end ordered_field_power
 

--- a/src/algebra/group/to_additive.lean
+++ b/src/algebra/group/to_additive.lean
@@ -217,6 +217,7 @@ meta def tr : bool → list string → list string
 | is_comm ("pow" :: s)                := add_comm_prefix is_comm "nsmul"     :: tr ff s
 | is_comm ("npow" :: s)               := add_comm_prefix is_comm "nsmul"     :: tr ff s
 | is_comm ("zpow" :: s)               := add_comm_prefix is_comm "zsmul"     :: tr ff s
+| is_comm ("square" :: s)             := add_comm_prefix is_comm "even"      :: tr ff s
 | is_comm ("monoid" :: s)      := ("add_" ++ add_comm_prefix is_comm "monoid")    :: tr ff s
 | is_comm ("submonoid" :: s)   := ("add_" ++ add_comm_prefix is_comm "submonoid") :: tr ff s
 | is_comm ("group" :: s)       := ("add_" ++ add_comm_prefix is_comm "group")     :: tr ff s

--- a/src/algebra/group/to_additive.lean
+++ b/src/algebra/group/to_additive.lean
@@ -217,7 +217,7 @@ meta def tr : bool → list string → list string
 | is_comm ("pow" :: s)                := add_comm_prefix is_comm "nsmul"     :: tr ff s
 | is_comm ("npow" :: s)               := add_comm_prefix is_comm "nsmul"     :: tr ff s
 | is_comm ("zpow" :: s)               := add_comm_prefix is_comm "zsmul"     :: tr ff s
-| is_comm ("square" :: s)             := add_comm_prefix is_comm "even"      :: tr ff s
+| is_comm ("is" :: "square" :: s)             := add_comm_prefix is_comm "even"      :: tr ff s
 | is_comm ("monoid" :: s)      := ("add_" ++ add_comm_prefix is_comm "monoid")    :: tr ff s
 | is_comm ("submonoid" :: s)   := ("add_" ++ add_comm_prefix is_comm "submonoid") :: tr ff s
 | is_comm ("group" :: s)       := ("add_" ++ add_comm_prefix is_comm "group")     :: tr ff s

--- a/src/algebra/group_power/lemmas.lean
+++ b/src/algebra/group_power/lemmas.lean
@@ -477,41 +477,6 @@ by simp only [le_iff_lt_or_eq, pow_bit1_neg_iff, pow_eq_zero_iff (bit1_pos (zero
 @[simp] theorem pow_bit1_pos_iff : 0 < a ^ bit1 n ↔ 0 < a :=
 lt_iff_lt_of_le_iff_le pow_bit1_nonpos_iff
 
-lemma even.pow_nonneg (hn : even n) (a : R) : 0 ≤ a ^ n :=
-by cases hn with k hk; simpa only [hk, two_mul] using pow_bit0_nonneg a k
-
-lemma even.pow_pos (hn : even n) (ha : a ≠ 0) : 0 < a ^ n :=
-by cases hn with k hk; simpa only [hk, two_mul] using pow_bit0_pos ha k
-
-lemma odd.pow_nonpos (hn : odd n) (ha : a ≤ 0) : a ^ n ≤ 0:=
-by cases hn with k hk; simpa only [hk, two_mul] using pow_bit1_nonpos_iff.mpr ha
-
-lemma odd.pow_neg (hn : odd n) (ha : a < 0) : a ^ n < 0:=
-by cases hn with k hk; simpa only [hk, two_mul] using pow_bit1_neg_iff.mpr ha
-
-lemma odd.pow_nonneg_iff (hn : odd n) : 0 ≤ a ^ n ↔ 0 ≤ a :=
-⟨λ h, le_of_not_lt (λ ha, h.not_lt $ hn.pow_neg ha), λ ha, pow_nonneg ha n⟩
-
-lemma odd.pow_nonpos_iff (hn : odd n) : a ^ n ≤ 0 ↔ a ≤ 0 :=
-⟨λ h, le_of_not_lt (λ ha, h.not_lt $ pow_pos ha _), hn.pow_nonpos⟩
-
-lemma odd.pow_pos_iff (hn : odd n) : 0 < a ^ n ↔ 0 < a :=
-⟨λ h, lt_of_not_ge' (λ ha, h.not_le $ hn.pow_nonpos ha), λ ha, pow_pos ha n⟩
-
-lemma odd.pow_neg_iff (hn : odd n) : a ^ n < 0 ↔ a < 0 :=
-⟨λ h, lt_of_not_ge' (λ ha, h.not_le $ pow_nonneg ha _), hn.pow_neg⟩
-
-lemma even.pow_pos_iff (hn : even n) (h₀ : 0 < n) : 0 < a ^ n ↔ a ≠ 0 :=
-⟨λ h ha, by { rw [ha, zero_pow h₀] at h, exact lt_irrefl 0 h }, hn.pow_pos⟩
-
-lemma even.pow_abs {p : ℕ} (hp : even p) (a : R) : |a| ^ p = a ^ p :=
-begin
-  rw [←abs_pow, abs_eq_self],
-  exact hp.pow_nonneg _
-end
-
-@[simp] lemma pow_bit0_abs (a : R) (p : ℕ) : |a| ^ bit0 p = a ^ bit0 p := (even_bit0 _).pow_abs _
-
 lemma strict_mono_pow_bit1 (n : ℕ) : strict_mono (λ a : R, a ^ bit1 n) :=
 begin
   intros a b hab,
@@ -522,9 +487,6 @@ begin
     { exact (pow_bit1_nonpos_iff.2 ha).trans_lt (pow_bit1_pos_iff.2 hb) } },
   { exact pow_lt_pow_of_lt_left hab ha (bit1_pos (zero_le n)) }
 end
-
-lemma odd.strict_mono_pow (hn : odd n) : strict_mono (λ a : R, a ^ n) :=
-by cases hn with k hk; simpa only [hk, two_mul] using strict_mono_pow_bit1 _
 
 /-- Bernoulli's inequality for `n : ℕ`, `-2 ≤ a`. -/
 theorem one_add_mul_le_pow (H : -2 ≤ a) (n : ℕ) : 1 + (n : R) * a ≤ (1 + a) ^ n :=

--- a/src/algebra/order/ring.lean
+++ b/src/algebra/order/ring.lean
@@ -1317,12 +1317,6 @@ lemma self_dvd_abs (a : α) : a ∣ |a| :=
 lemma abs_dvd_abs (a b : α) : |a| ∣ |b| ↔ a ∣ b :=
 (abs_dvd _ _).trans (dvd_abs _ _)
 
-lemma even_abs {a : α} : even (|a|) ↔ even a :=
-dvd_abs _ _
-
-lemma odd_abs {a : α} : odd (abs a) ↔ odd a :=
-by { cases abs_choice a with h h; simp only [h, odd_neg] }
-
 end
 
 section linear_ordered_comm_ring

--- a/src/algebra/parity.lean
+++ b/src/algebra/parity.lean
@@ -15,6 +15,28 @@ variables {α β : Type*}
 section semiring
 variables [semiring α] [semiring β] {m n : α}
 
+/-- An element `a` of a semiring is even if there exists `k` such `a = 2*k`. -/
+def even (a : α) : Prop := ∃ k, a = 2*k
+
+lemma even_iff_two_dvd {a : α} : even a ↔ 2 ∣ a := iff.rfl
+
+@[simp] lemma range_two_mul (α : Type*) [semiring α] :
+  set.range (λ x : α, 2 * x) = {a | even a} :=
+by { ext x, simp [even, eq_comm] }
+
+@[simp] lemma even_bit0 (a : α) : even (bit0 a) :=
+⟨a, by rw [bit0, two_mul]⟩
+
+/-- An element `a` of a semiring is odd if there exists `k` such `a = 2*k + 1`. -/
+def odd (a : α) : Prop := ∃ k, a = 2*k + 1
+
+@[simp] lemma odd_bit1 (a : α) : odd (bit1 a) :=
+⟨a, by rw [bit1, bit0, two_mul]⟩
+
+@[simp] lemma range_two_mul_add_one (α : Type*) [semiring α] :
+  set.range (λ x : α, 2 * x + 1) = {a | odd a} :=
+by { ext x, simp [odd, eq_comm] }
+
 lemma even.add_even (hm : even m) (hn : even n) : even (m + n) :=
 begin
   rcases hm with ⟨m, rfl⟩,
@@ -91,6 +113,20 @@ end semiring
 
 section ring
 variables [ring α] {m n : α}
+
+@[simp] theorem even_neg (a : α) : even (-a) ↔ even a :=
+dvd_neg _ _
+
+lemma odd.neg {a : α} (hp : odd a) : odd (-a) :=
+begin
+  obtain ⟨k, hk⟩ := hp,
+  use -(k + 1),
+  rw [mul_neg, mul_add, neg_add, add_assoc, two_mul (1 : α), neg_add,
+    neg_add_cancel_right, ←neg_add, hk],
+end
+
+@[simp] lemma odd_neg (a : α) : odd (-a) ↔ odd a :=
+⟨λ h, neg_neg a ▸ h.neg, odd.neg⟩
 
 @[simp] lemma odd_neg_one : odd (- 1 : α) := by simp
 

--- a/src/algebra/parity.lean
+++ b/src/algebra/parity.lean
@@ -19,6 +19,16 @@ variables [semiring α] [semiring β] {m n : α}
 /-- An element `a` of a semiring is even if there exists `k` such `a = 2*k`. -/
 def even (a : α) : Prop := ∃ k, a = 2*k
 
+@[simp] lemma even_zero : even (0 : α) := ⟨0, (mul_zero _).symm⟩
+
+lemma even_two_mul (m : α) : even (2 * m) := ⟨m, rfl⟩
+
+lemma add_monoid_hom.even (f : α →+ β) (hm : even m) : even (f m) :=
+begin
+  rcases hm with ⟨m, rfl⟩,
+  exact ⟨f m, by simp [two_mul]⟩
+end
+
 lemma even_iff_two_dvd {a : α} : even a ↔ 2 ∣ a := iff.rfl
 
 @[simp] lemma range_two_mul (α : Type*) [semiring α] :
@@ -35,17 +45,7 @@ begin
   exact ⟨m + n, (mul_add _ _ _).symm⟩
 end
 
-@[simp] lemma even_zero : even (0 : α) := ⟨0, (mul_zero _).symm⟩
-
 @[simp] lemma even_two : even (2 : α) := ⟨1, (mul_one _).symm⟩
-
-lemma even_two_mul (m : α) : even (2 * m) := ⟨m, rfl⟩
-
-lemma add_monoid_hom.even (f : α →+ β) (hm : even m) : even (f m) :=
-begin
-  rcases hm with ⟨m, rfl⟩,
-  exact ⟨f m, by simp [two_mul]⟩
-end
 
 @[simp] lemma even.mul_right (hm : even m) (n) : even (m * n) :=
 (add_monoid_hom.mul_right n).even hm

--- a/src/algebra/parity.lean
+++ b/src/algebra/parity.lean
@@ -28,6 +28,37 @@ by { ext x, simp [even, eq_comm] }
 @[simp] lemma even_bit0 (a : α) : even (bit0 a) :=
 ⟨a, by rw [bit0, two_mul]⟩
 
+lemma even.add_even (hm : even m) (hn : even n) : even (m + n) :=
+begin
+  rcases hm with ⟨m, rfl⟩,
+  rcases hn with ⟨n, rfl⟩,
+  exact ⟨m + n, (mul_add _ _ _).symm⟩
+end
+
+@[simp] lemma even_zero : even (0 : α) := ⟨0, (mul_zero _).symm⟩
+
+@[simp] lemma even_two : even (2 : α) := ⟨1, (mul_one _).symm⟩
+
+lemma even_two_mul (m : α) : even (2 * m) := ⟨m, rfl⟩
+
+lemma add_monoid_hom.even (f : α →+ β) (hm : even m) : even (f m) :=
+begin
+  rcases hm with ⟨m, rfl⟩,
+  exact ⟨f m, by simp [two_mul]⟩
+end
+
+@[simp] lemma even.mul_right (hm : even m) (n) : even (m * n) :=
+(add_monoid_hom.mul_right n).even hm
+
+@[simp] lemma even.mul_left (hm : even m) (n) : even (n * m) :=
+(add_monoid_hom.mul_left n).even hm
+
+lemma even.pow_of_ne_zero (hm : even m) : ∀ {a : ℕ}, a ≠ 0 → even (m ^ a)
+| 0       a0 := (a0 rfl).elim
+| (a + 1) _  := by { rw pow_succ, exact hm.mul_right _ }
+
+section with_odd
+
 /-- An element `a` of a semiring is odd if there exists `k` such `a = 2*k + 1`. -/
 def odd (a : α) : Prop := ∃ k, a = 2*k + 1
 
@@ -37,13 +68,6 @@ def odd (a : α) : Prop := ∃ k, a = 2*k + 1
 @[simp] lemma range_two_mul_add_one (α : Type*) [semiring α] :
   set.range (λ x : α, 2 * x + 1) = {a | odd a} :=
 by { ext x, simp [odd, eq_comm] }
-
-lemma even.add_even (hm : even m) (hn : even n) : even (m + n) :=
-begin
-  rcases hm with ⟨m, rfl⟩,
-  rcases hn with ⟨n, rfl⟩,
-  exact ⟨m + n, (mul_add _ _ _).symm⟩
-end
 
 lemma even.add_odd (hm : even m) (hn : odd n) : odd (m + n) :=
 begin
@@ -64,34 +88,16 @@ begin
   refl
 end
 
-@[simp] lemma even_zero : even (0 : α) := ⟨0, (mul_zero _).symm⟩
-
 @[simp] lemma odd_one : odd (1 : α) :=
 ⟨0, (zero_add _).symm.trans (congr_arg (+ (1 : α)) (mul_zero _).symm)⟩
 
-@[simp] lemma even_two : even (2 : α) := ⟨1, (mul_one _).symm⟩
-
-lemma even_two_mul (m : α) : even (2 * m) := ⟨m, rfl⟩
-
 @[simp] lemma odd_two_mul_add_one (m : α) : odd (2 * m + 1) := ⟨m, rfl⟩
-
-lemma add_monoid_hom.even (f : α →+ β) (hm : even m) : even (f m) :=
-begin
-  rcases hm with ⟨m, rfl⟩,
-  exact ⟨f m, by simp [two_mul]⟩
-end
 
 lemma ring_hom.odd (f : α →+* β) (hm : odd m) : odd (f m) :=
 begin
   rcases hm with ⟨m, rfl⟩,
   exact ⟨f m, by simp [two_mul]⟩
 end
-
-@[simp] lemma even.mul_right (hm : even m) (n) : even (m * n) :=
-(add_monoid_hom.mul_right n).even hm
-
-@[simp] lemma even.mul_left (hm : even m) (n) : even (n * m) :=
-(add_monoid_hom.mul_left n).even hm
 
 @[simp] lemma odd.mul_odd (hm : odd m) (hn : odd n) : odd (m * n) :=
 begin
@@ -102,13 +108,11 @@ begin
     ← nat.cast_two, ← nat.cast_comm],
 end
 
-lemma even.pow_of_ne_zero (hm : even m) : ∀ {a : ℕ}, a ≠ 0 → even (m ^ a)
-| 0       a0 := (a0 rfl).elim
-| (a + 1) _  := by { rw pow_succ, exact hm.mul_right _ }
-
 lemma odd.pow (hm : odd m) : ∀ {a : ℕ}, odd (m ^ a)
 | 0       := by { rw pow_zero, exact odd_one }
 | (a + 1) := by { rw pow_succ, exact hm.mul_odd odd.pow }
+
+end with_odd
 
 end semiring
 
@@ -117,6 +121,16 @@ variables [ring α] {m n : α}
 
 @[simp] theorem even_neg (a : α) : even (-a) ↔ even a :=
 dvd_neg _ _
+
+@[simp] lemma even_neg_two : even (- 2 : α) := by simp
+
+lemma even.sub_even (hm : even m) (hn : even n) : even (m - n) :=
+by { rw sub_eq_add_neg, exact hm.add_even ((even_neg n).mpr hn) }
+
+-- from src/algebra/order/ring.lean
+variables [linear_order α]
+lemma even_abs {a : α} : even (|a|) ↔ even a :=
+dvd_abs _ _
 
 lemma odd.neg {a : α} (hp : odd a) : odd (-a) :=
 begin
@@ -131,11 +145,6 @@ end
 
 @[simp] lemma odd_neg_one : odd (- 1 : α) := by simp
 
-@[simp] lemma even_neg_two : even (- 2 : α) := by simp
-
-lemma even.sub_even (hm : even m) (hn : even n) : even (m - n) :=
-by { rw sub_eq_add_neg, exact hm.add_even ((even_neg n).mpr hn) }
-
 theorem odd.sub_even (hm : odd m) (hn : even n) : odd (m - n) :=
 by { rw sub_eq_add_neg, exact hm.add_even ((even_neg n).mpr hn) }
 
@@ -146,11 +155,6 @@ lemma odd.sub_odd (hm : odd m) (hn : odd n) : even (m - n) :=
 by { rw sub_eq_add_neg, exact hm.add_odd ((odd_neg n).mpr hn) }
 
 -- from src/algebra/order/ring.lean
-variables [linear_order α]
-lemma even_abs {a : α} : even (|a|) ↔ even a :=
-dvd_abs _ _
-
--- from src/algebra/order/ring.lean
 lemma odd_abs {a : α} : odd (abs a) ↔ odd a :=
 by { cases abs_choice a with h h; simp only [h, odd_neg] }
 
@@ -159,9 +163,7 @@ end ring
 
 -- from src/algebra/group_power/lemmas.lean
 section powers
---open nat int
-variables --{M : Type u} {N : Type v} {G : Type w} {H : Type x} {A : Type y} {B : Type z}
- {R : Type*} --{S : Type u₂}
+variables {R : Type*}
   {a : R} {n : ℕ} [linear_ordered_ring R]
 
 lemma even.pow_nonneg (hn : even n) (a : R) : 0 ≤ a ^ n :=
@@ -212,15 +214,16 @@ lemma fintype.card_fin_even {k : ℕ} : fact (even (fintype.card (fin (bit0 k)))
 
 -- from src/algebra/field_power.lean
 section field_power
+variable {K : Type*}
 
-lemma even.zpow_neg {K : Type*} [division_ring K] {n : ℤ} (h : even n) (a : K) :
+lemma even.zpow_neg [division_ring K] {n : ℤ} (h : even n) (a : K) :
   (-a) ^ n = a ^ n :=
 begin
   obtain ⟨k, rfl⟩ := h,
   rw [←bit0_eq_two_mul, zpow_bit0_neg],
 end
 
-variables {K : Type*} [linear_ordered_field K] {n : ℤ} {a : K}
+variables [linear_ordered_field K] {n : ℤ} {a : K}
 
 lemma even.zpow_nonneg (hn : even n) (a : K) :
   0 ≤ a ^ n :=

--- a/src/algebra/parity.lean
+++ b/src/algebra/parity.lean
@@ -127,11 +127,6 @@ dvd_neg _ _
 lemma even.sub_even (hm : even m) (hn : even n) : even (m - n) :=
 by { rw sub_eq_add_neg, exact hm.add_even ((even_neg n).mpr hn) }
 
--- from src/algebra/order/ring.lean
-variables [linear_order α]
-lemma even_abs {a : α} : even (|a|) ↔ even a :=
-dvd_abs _ _
-
 lemma odd.neg {a : α} (hp : odd a) : odd (-a) :=
 begin
   obtain ⟨k, hk⟩ := hp,
@@ -153,6 +148,11 @@ by { rw sub_eq_add_neg, exact hm.add_odd ((odd_neg n).mpr hn) }
 
 lemma odd.sub_odd (hm : odd m) (hn : odd n) : even (m - n) :=
 by { rw sub_eq_add_neg, exact hm.add_odd ((odd_neg n).mpr hn) }
+
+-- from src/algebra/order/ring.lean
+variables [linear_order α]
+lemma even_abs {a : α} : even (|a|) ↔ even a :=
+dvd_abs _ _
 
 -- from src/algebra/order/ring.lean
 lemma odd_abs {a : α} : odd (abs a) ↔ odd a :=

--- a/src/algebra/ring/basic.lean
+++ b/src/algebra/ring/basic.lean
@@ -269,28 +269,6 @@ lemma ite_mul_zero_right {α : Type*} [mul_zero_class α] (P : Prop) [decidable 
   ite P (a * b) 0 = a * ite P b 0 :=
 by { by_cases h : P; simp [h], }
 
-/-- An element `a` of a semiring is even if there exists `k` such `a = 2*k`. -/
-def even (a : α) : Prop := ∃ k, a = 2*k
-
-lemma even_iff_two_dvd {a : α} : even a ↔ 2 ∣ a := iff.rfl
-
-@[simp] lemma range_two_mul (α : Type*) [semiring α] :
-  set.range (λ x : α, 2 * x) = {a | even a} :=
-by { ext x, simp [even, eq_comm] }
-
-@[simp] lemma even_bit0 (a : α) : even (bit0 a) :=
-⟨a, by rw [bit0, two_mul]⟩
-
-/-- An element `a` of a semiring is odd if there exists `k` such `a = 2*k + 1`. -/
-def odd (a : α) : Prop := ∃ k, a = 2*k + 1
-
-@[simp] lemma odd_bit1 (a : α) : odd (bit1 a) :=
-⟨a, by rw [bit1, bit0, two_mul]⟩
-
-@[simp] lemma range_two_mul_add_one (α : Type*) [semiring α] :
-  set.range (λ x : α, 2 * x + 1) = {a | odd a} :=
-by { ext x, simp [odd, eq_comm] }
-
 theorem dvd_add {a b c : α} (h₁ : a ∣ b) (h₂ : a ∣ c) : a ∣ b + c :=
 dvd.elim h₁ (λ d hd, dvd.elim h₂ (λ e he, dvd.intro (d + e) (by simp [left_distrib, hd, he])))
 
@@ -1059,20 +1037,6 @@ begin
     convert dvd_add h h',
     exact eq_add_of_sub_eq rfl }
 end
-
-@[simp] theorem even_neg (a : α) : even (-a) ↔ even a :=
-dvd_neg _ _
-
-lemma odd.neg {a : α} (hp : odd a) : odd (-a) :=
-begin
-  obtain ⟨k, hk⟩ := hp,
-  use -(k + 1),
-  rw [mul_neg, mul_add, neg_add, add_assoc, two_mul (1 : α), neg_add,
-    neg_add_cancel_right, ←neg_add, hk],
-end
-
-@[simp] lemma odd_neg (a : α) : odd (-a) ↔ odd a :=
-⟨λ h, neg_neg a ▸ h.neg, odd.neg⟩
 
 end ring
 

--- a/src/data/fintype/basic.lean
+++ b/src/data/fintype/basic.lean
@@ -727,11 +727,6 @@ theorem fin.cast_eq_cast' {n m : ℕ} (h : fin n = fin m) :
   cast h = ⇑(fin.cast $ fin_injective h) :=
 (fin.cast_eq_cast _).symm
 
-/-- The cardinality of `fin (bit0 k)` is even, `fact` version.
-This `fact` is needed as an instance by `matrix.special_linear_group.has_neg`. -/
-lemma fintype.card_fin_even {k : ℕ} : fact (even (fintype.card (fin (bit0 k)))) :=
-⟨by { rw [fintype.card_fin], exact even_bit0 k }⟩
-
 lemma card_finset_fin_le {n : ℕ} (s : finset (fin n)) : s.card ≤ n :=
 by simpa only [fintype.card_fin] using s.card_le_univ
 

--- a/src/data/nat/prime.lean
+++ b/src/data/nat/prime.lean
@@ -9,6 +9,7 @@ import data.nat.gcd
 import data.nat.sqrt_norm_num
 import data.set.finite
 import tactic.wlog
+import algebra.parity
 
 /-!
 # Prime numbers

--- a/test/ring.lean
+++ b/test/ring.lean
@@ -1,5 +1,6 @@
 import tactic.ring
 import data.real.basic
+import algebra.parity
 
 example (x y : ℕ) : x + y = y + x := by ring
 example (x y : ℕ) : x + y + y = 2 * y + x := by ring


### PR DESCRIPTION
This is the first step in refactoring the definition of `even` to be the `to_additive` of `square`.

This PR simply gathers together many (though not all) lemmas that involve `even` or `odd` in their assumptions.  The choice of which lemmas to migrate to the file `algebra.parity` was dictated mostly by whether importing `algebra.parity` in the current home would create a cyclic import.

The only change that is not a simple shift from a file to another one is the addition in `to_additive` for support to change `square` in a multiplicative name to `even` in an additive name.

The change to the test file `test.ring` is due to the fact that the definition of `odd` was no longer imported by the file.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
