### PR TITLE
[Merged by Bors] - feat(order/category/FinBoolAlg): The category of finite Boolean algebras

### DIFF
--- a/src/data/set/lattice.lean
+++ b/src/data/set/lattice.lean
@@ -1223,7 +1223,7 @@ by simp_rw preimage_Union
 
 @[simp] theorem preimage_sUnion {f : α → β} {s : set (set β)} :
   f ⁻¹' (⋃₀ s) = (⋃ t ∈ s, f ⁻¹' t) :=
-set.ext $ by simp [preimage]
+by rw [sUnion_eq_bUnion, preimage_Union₂]
 
 lemma preimage_Inter {f : α → β} {s : ι → set β} : f ⁻¹' (⋂ i, s i) = (⋂ i, f ⁻¹' s i) :=
 by ext; simp
@@ -1231,6 +1231,9 @@ by ext; simp
 lemma preimage_Inter₂ {f : α → β} {s : Π i, κ i → set β} :
   f ⁻¹' (⋂ i j, s i j) = ⋂ i j, f ⁻¹' s i j :=
 by simp_rw preimage_Inter
+
+@[simp] lemma preimage_sInter {f : α → β} {s : set (set β)} : f ⁻¹' (⋂₀ s) = ⋂ t ∈ s, f ⁻¹' t :=
+by rw [sInter_eq_bInter, preimage_Inter₂]
 
 @[simp] lemma bUnion_preimage_singleton (f : α → β) (s : set β) : (⋃ y ∈ s, f ⁻¹' {y}) = f ⁻¹' s :=
 by rw [← preimage_Union₂, bUnion_of_singleton]

--- a/src/order/category/BoolAlg.lean
+++ b/src/order/category/BoolAlg.lean
@@ -35,6 +35,8 @@ instance : inhabited BoolAlg := ⟨of punit⟩
 /-- Turn a `BoolAlg` into a `BoundedDistribLattice` by forgetting its complement operation. -/
 def to_BoundedDistribLattice (X : BoolAlg) : BoundedDistribLattice := BoundedDistribLattice.of X
 
+@[simp] lemma coe_to_BoundedDistribLattice (X : BoolAlg) : ↥X.to_BoundedDistribLattice = ↥X := rfl
+
 instance : large_category.{u} BoolAlg := induced_category.category to_BoundedDistribLattice
 instance : concrete_category BoolAlg := induced_category.concrete_category to_BoundedDistribLattice
 

--- a/src/order/category/FinBoolAlg.lean
+++ b/src/order/category/FinBoolAlg.lean
@@ -14,7 +14,7 @@ This file defines `FinBoolAlg`, the category of finite boolean algebras.
 
 ## TODO
 
-Finite Birkhoff's representation.
+Birkhoff's representation for finite Boolean algebras.
 
 `Fintype_to_FinBoolAlg_op.left_op ⋙ FinBoolAlg.dual ≅ Fintype_to_FinBoolAlg_op.left_op`
 -/

--- a/src/order/category/FinBoolAlg.lean
+++ b/src/order/category/FinBoolAlg.lean
@@ -1,0 +1,88 @@
+/-
+Copyright (c) 2022 Yaël Dillies. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Yaël Dillies
+-/
+import order.category.BoolAlg
+import order.category.FinPartialOrder
+import order.hom.complete_lattice
+
+/-!
+# The category of finite boolean algebras
+
+This file defines `FinBoolAlg`, the category of finite boolean algebras.
+
+## TODO
+
+Finite Birkhoff's representation.
+
+`Fintype_to_FinBoolAlg_op.left_op ⋙ FinBoolAlg.dual ≅ Fintype_to_FinBoolAlg_op.left_op`
+-/
+
+universes u
+
+open category_theory order_dual opposite
+
+/-- The category of finite boolean algebras with bounded lattice morphisms. -/
+structure FinBoolAlg :=
+(to_BoolAlg : BoolAlg)
+[is_fintype : fintype to_BoolAlg]
+
+namespace FinBoolAlg
+
+instance : has_coe_to_sort FinBoolAlg Type* := ⟨λ X, X.to_BoolAlg⟩
+instance (X : FinBoolAlg) : boolean_algebra X := X.to_BoolAlg.str
+
+attribute [instance]  FinBoolAlg.is_fintype
+
+@[simp] lemma coe_to_BoolAlg (X : FinBoolAlg) : ↥X.to_BoolAlg = ↥X := rfl
+
+/-- Construct a bundled `FinBoolAlg` from `boolean_algebra` + `fintype`. -/
+def of (α : Type*) [boolean_algebra α] [fintype α] : FinBoolAlg := ⟨⟨α⟩⟩
+
+@[simp] lemma coe_of (α : Type*) [boolean_algebra α] [fintype α] : ↥(of α) = α := rfl
+
+instance : inhabited FinBoolAlg := ⟨of bool⟩
+
+instance large_category : large_category FinBoolAlg :=
+induced_category.category FinBoolAlg.to_BoolAlg
+
+instance concrete_category : concrete_category FinBoolAlg :=
+induced_category.concrete_category FinBoolAlg.to_BoolAlg
+
+instance has_forget_to_BoolAlg : has_forget₂ FinBoolAlg BoolAlg :=
+induced_category.has_forget₂ FinBoolAlg.to_BoolAlg
+
+instance has_forget_to_FinPartialOrder : has_forget₂ FinBoolAlg FinPartialOrder :=
+{ forget₂ := { obj := λ X, FinPartialOrder.of X, map := λ X Y f, begin
+    change bounded_lattice_hom _ _ at f,
+    change order_hom _ _,
+    dsimp at *,
+    exact f,
+  end } }
+
+/-- Constructs an equivalence between finite Boolean algebras from an order isomorphism between
+them. -/
+@[simps] def iso.mk {α β : FinBoolAlg.{u}} (e : α ≃o β) : α ≅ β :=
+{ hom := (e : bounded_lattice_hom α β),
+  inv := (e.symm : bounded_lattice_hom β α),
+  hom_inv_id' := by { ext, exact e.symm_apply_apply _ },
+  inv_hom_id' := by { ext, exact e.apply_symm_apply _ } }
+
+/-- `order_dual` as a functor. -/
+@[simps] def dual : FinBoolAlg ⥤ FinBoolAlg :=
+{ obj := λ X, of (order_dual X), map := λ X Y, bounded_lattice_hom.dual }
+
+/-- The equivalence between `FinBoolAlg` and itself induced by `order_dual` both ways. -/
+@[simps functor inverse] def dual_equiv : FinBoolAlg ≌ FinBoolAlg :=
+equivalence.mk dual dual
+  (nat_iso.of_components (λ X, iso.mk $ order_iso.dual_dual X) $ λ X Y f, rfl)
+  (nat_iso.of_components (λ X, iso.mk $ order_iso.dual_dual X) $ λ X Y f, rfl)
+
+end FinBoolAlg
+
+/-- The powerset functor. `set` as a functor. -/
+def Fintype_to_FinBoolAlg_op : Fintype ⥤ FinBoolAlgᵒᵖ :=
+{ obj := λ X, op $ FinBoolAlg.of (set X),
+  map := λ X Y f, quiver.hom.op $
+    (complete_lattice_hom.set_preimage f : bounded_lattice_hom (set Y) (set X)) }

--- a/src/order/category/FinBoolAlg.lean
+++ b/src/order/category/FinBoolAlg.lean
@@ -17,6 +17,8 @@ This file defines `FinBoolAlg`, the category of finite boolean algebras.
 Birkhoff's representation for finite Boolean algebras.
 
 `Fintype_to_FinBoolAlg_op.left_op ⋙ FinBoolAlg.dual ≅ Fintype_to_FinBoolAlg_op.left_op`
+
+`FinBoolAlg` is essentially small.
 -/
 
 universes u
@@ -42,7 +44,7 @@ def of (α : Type*) [boolean_algebra α] [fintype α] : FinBoolAlg := ⟨⟨α�
 
 @[simp] lemma coe_of (α : Type*) [boolean_algebra α] [fintype α] : ↥(of α) = α := rfl
 
-instance : inhabited FinBoolAlg := ⟨of bool⟩
+instance : inhabited FinBoolAlg := ⟨of punit⟩
 
 instance large_category : large_category FinBoolAlg :=
 induced_category.category FinBoolAlg.to_BoolAlg
@@ -53,9 +55,16 @@ induced_category.concrete_category FinBoolAlg.to_BoolAlg
 instance has_forget_to_BoolAlg : has_forget₂ FinBoolAlg BoolAlg :=
 induced_category.has_forget₂ FinBoolAlg.to_BoolAlg
 
-instance has_forget_to_FinPartialOrder : has_forget₂ FinBoolAlg FinPartialOrder :=
+instance forget_to_BoolAlg_full : full (forget₂ FinBoolAlg BoolAlg) := induced_category.full _
+instance forget_to_BoolAlg_faithful : faithful (forget₂ FinBoolAlg BoolAlg) :=
+induced_category.faithful _
+
+@[simps] instance has_forget_to_FinPartialOrder : has_forget₂ FinBoolAlg FinPartialOrder :=
 { forget₂ := { obj := λ X, FinPartialOrder.of X, map := λ X Y f,
     show order_hom X Y, from ↑(show bounded_lattice_hom X Y, from f) } }
+
+instance forget_to_FinPartialOrder_faithful : faithful (forget₂ FinBoolAlg FinPartialOrder) :=
+⟨λ X Y f g h, by { have := congr_arg (coe_fn : _ → X → Y) h, exact fun_like.coe_injective this }⟩
 
 /-- Constructs an equivalence between finite Boolean algebras from an order isomorphism between
 them. -/

--- a/src/order/category/FinBoolAlg.lean
+++ b/src/order/category/FinBoolAlg.lean
@@ -54,12 +54,8 @@ instance has_forget_to_BoolAlg : has_forget₂ FinBoolAlg BoolAlg :=
 induced_category.has_forget₂ FinBoolAlg.to_BoolAlg
 
 instance has_forget_to_FinPartialOrder : has_forget₂ FinBoolAlg FinPartialOrder :=
-{ forget₂ := { obj := λ X, FinPartialOrder.of X, map := λ X Y f, begin
-    change bounded_lattice_hom _ _ at f,
-    change order_hom _ _,
-    dsimp at *,
-    exact f,
-  end } }
+{ forget₂ := { obj := λ X, FinPartialOrder.of X, map := λ X Y f,
+    show order_hom X Y, from ↑(show bounded_lattice_hom X Y, from f) } }
 
 /-- Constructs an equivalence between finite Boolean algebras from an order isomorphism between
 them. -/
@@ -82,7 +78,7 @@ equivalence.mk dual dual
 end FinBoolAlg
 
 /-- The powerset functor. `set` as a functor. -/
-def Fintype_to_FinBoolAlg_op : Fintype ⥤ FinBoolAlgᵒᵖ :=
+@[simps] def Fintype_to_FinBoolAlg_op : Fintype ⥤ FinBoolAlgᵒᵖ :=
 { obj := λ X, op $ FinBoolAlg.of (set X),
   map := λ X Y f, quiver.hom.op $
     (complete_lattice_hom.set_preimage f : bounded_lattice_hom (set Y) (set X)) }

--- a/src/order/category/FinPartialOrder.lean
+++ b/src/order/category/FinPartialOrder.lean
@@ -29,11 +29,12 @@ structure FinPartialOrder :=
 [is_fintype : fintype to_PartialOrder]
 
 namespace FinPartialOrder
+
 instance : has_coe_to_sort FinPartialOrder Type* := ⟨λ X, X.to_PartialOrder⟩
-
 instance (X : FinPartialOrder) : partial_order X := X.to_PartialOrder.str
-
 attribute [instance]  FinPartialOrder.is_fintype
+
+@[simp] lemma coe_to_PartialOrder (X : FinPartialOrder) : ↥X.to_PartialOrder = ↥X := rfl
 
 /-- Construct a bundled `FinPartialOrder` from `fintype` + `partial_order`. -/
 def of (α : Type*) [partial_order α] [fintype α] : FinPartialOrder := ⟨⟨α⟩⟩

--- a/src/order/hom/complete_lattice.lean
+++ b/src/order/hom/complete_lattice.lean
@@ -511,7 +511,7 @@ def set_preimage (f : α → β) : complete_lattice_hom (set β) (set α) :=
 @[simp] lemma coe_set_preimage (f : α → β) : ⇑(set_preimage f) = preimage f := rfl
 @[simp] lemma set_preimage_apply (f : α → β) (s : set β) : set_preimage f s = s.preimage f := rfl
 @[simp] lemma set_preimage_id : set_preimage (id : α → α) = complete_lattice_hom.id _ := rfl
--- This lemma can't be `simp` because `g ∘ f` matches wildly
+-- This lemma can't be `simp` because `g ∘ f` matches anything (`id ∘ f = f` synctatically)
 lemma set_preimage_comp (g : β → γ) (f : α → β) :
   set_preimage (g ∘ f) = (set_preimage f).comp (set_preimage g) := rfl
 

--- a/src/order/hom/complete_lattice.lean
+++ b/src/order/hom/complete_lattice.lean
@@ -27,9 +27,13 @@ be satisfied by itself and all stricter types.
 * `Inf_hom_class`
 * `frame_hom_class`
 * `complete_lattice_hom_class`
+
+## Concrete homs
+
+* `complete_lattice.set_preimage`: `set.preimage` as a complete lattice homomorphism.
 -/
 
-open function order_dual
+open function order_dual set
 
 variables {F α β γ δ : Type*} {ι : Sort*} {κ : ι → Sort*}
 
@@ -491,5 +495,28 @@ lattices. -/
                     map_Sup' := λ _, congr_arg of_dual (map_Inf f _) },
   left_inv := λ f, ext $ λ a, rfl,
   right_inv := λ f, ext $ λ a, rfl }
+
+end complete_lattice_hom
+
+/-! ### Concrete homs -/
+
+@[simp] lemma preimage_sInter {α β : Type*} {f : α → β} {s : set (set β)} :
+  f ⁻¹' (⋂₀ s) = ⋂ t ∈ s, f ⁻¹' t :=
+set.ext $ by simp only [set.preimage, set.mem_sInter, set.mem_set_of_eq, set.mem_Inter, iff_self,
+  implies_true_iff]
+
+namespace complete_lattice_hom
+
+/-- `set.preimage` as a complete lattice homomorphism. -/
+def set_preimage (f : α → β) : complete_lattice_hom (set β) (set α) :=
+{ to_fun := preimage f,
+  map_Sup' := λ s, preimage_sUnion.trans $ by simp only [set.Sup_eq_sUnion, set.sUnion_image],
+  map_Inf' := λ s, preimage_sInter.trans $ by simp only [set.Inf_eq_sInter, set.sInter_image] }
+
+@[simp] lemma coe_set_preimage (f : α → β) : ⇑(set_preimage f) = preimage f := rfl
+@[simp] lemma set_preimage_apply (f : α → β) (s : set β) : set_preimage f s = s.preimage f := rfl
+@[simp] lemma set_preimage_id : set_preimage (id : α → α) = complete_lattice_hom.id _ := rfl
+@[simp] lemma set_preimage_comp (g : β → γ) (f : α → β) :
+  set_preimage (g ∘ f) = (set_preimage f).comp (set_preimage g) := rfl
 
 end complete_lattice_hom

--- a/src/order/hom/complete_lattice.lean
+++ b/src/order/hom/complete_lattice.lean
@@ -500,11 +500,6 @@ end complete_lattice_hom
 
 /-! ### Concrete homs -/
 
-@[simp] lemma preimage_sInter {α β : Type*} {f : α → β} {s : set (set β)} :
-  f ⁻¹' (⋂₀ s) = ⋂ t ∈ s, f ⁻¹' t :=
-set.ext $ by simp only [set.preimage, set.mem_sInter, set.mem_set_of_eq, set.mem_Inter, iff_self,
-  implies_true_iff]
-
 namespace complete_lattice_hom
 
 /-- `set.preimage` as a complete lattice homomorphism. -/

--- a/src/order/hom/complete_lattice.lean
+++ b/src/order/hom/complete_lattice.lean
@@ -511,7 +511,8 @@ def set_preimage (f : α → β) : complete_lattice_hom (set β) (set α) :=
 @[simp] lemma coe_set_preimage (f : α → β) : ⇑(set_preimage f) = preimage f := rfl
 @[simp] lemma set_preimage_apply (f : α → β) (s : set β) : set_preimage f s = s.preimage f := rfl
 @[simp] lemma set_preimage_id : set_preimage (id : α → α) = complete_lattice_hom.id _ := rfl
-@[simp] lemma set_preimage_comp (g : β → γ) (f : α → β) :
+-- This lemma can't be `simp` because `g ∘ f` matches wildly
+lemma set_preimage_comp (g : β → γ) (f : α → β) :
   set_preimage (g ∘ f) = (set_preimage f).comp (set_preimage g) := rfl
 
 end complete_lattice_hom


### PR DESCRIPTION
Define `FinBoolAlg`, the category of finite Boolean algebras.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
The goal is to construct Birkhoff's finite representation: `Fintype ≌ FinBoolAlgᵒᵖ`. This PR adds the easy half.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
