### PR TITLE
[Merged by Bors] - feat(data/polynomial/erase_lead): add two erase_lead lemmas

### DIFF
--- a/src/data/polynomial/erase_lead.lean
+++ b/src/data/polynomial/erase_lead.lean
@@ -125,6 +125,30 @@ by rw [X_pow_eq_monomial, erase_lead_monomial]
 @[simp] lemma erase_lead_C_mul_X_pow (r : R) (n : ℕ) : erase_lead (C r * X ^ n) = 0 :=
 by rw [C_mul_X_pow_eq_monomial, erase_lead_monomial]
 
+lemma erase_lead_add_of_nat_degree_lt_left {p q : R[X]} (pq : q.nat_degree < p.nat_degree) :
+  (p + q).erase_lead = p.erase_lead + q :=
+begin
+  ext,
+  by_cases nd : n = p.nat_degree,
+  { rw [nd, erase_lead_coeff, if_pos (nat_degree_add_eq_left_of_nat_degree_lt pq).symm],
+    simpa using (coeff_eq_zero_of_nat_degree_lt pq).symm },
+  { rw [erase_lead_coeff, coeff_add, coeff_add, erase_lead_coeff, if_neg, if_neg nd],
+    rintro rfl,
+    exact nd (nat_degree_add_eq_left_of_nat_degree_lt pq) }
+end
+
+lemma erase_lead_add_of_nat_degree_lt_right {p q : R[X]} (pq : p.nat_degree < q.nat_degree) :
+  (p + q).erase_lead = p + q.erase_lead :=
+begin
+  ext,
+  by_cases nd : n = q.nat_degree,
+  { rw [nd, erase_lead_coeff, if_pos (nat_degree_add_eq_right_of_nat_degree_lt pq).symm],
+    simpa using (coeff_eq_zero_of_nat_degree_lt pq).symm },
+  { rw [erase_lead_coeff, coeff_add, coeff_add, erase_lead_coeff, if_neg, if_neg nd],
+    rintro rfl,
+    exact nd (nat_degree_add_eq_right_of_nat_degree_lt pq) }
+end
+
 lemma erase_lead_degree_le : (erase_lead f).degree ≤ f.degree :=
 begin
   rw degree_le_iff_coeff_zero,

--- a/src/data/polynomial/erase_lead.lean
+++ b/src/data/polynomial/erase_lead.lean
@@ -128,7 +128,7 @@ by rw [C_mul_X_pow_eq_monomial, erase_lead_monomial]
 lemma erase_lead_add_of_nat_degree_lt_left {p q : R[X]} (pq : q.nat_degree < p.nat_degree) :
   (p + q).erase_lead = p.erase_lead + q :=
 begin
-  ext,
+  ext n,
   by_cases nd : n = p.nat_degree,
   { rw [nd, erase_lead_coeff, if_pos (nat_degree_add_eq_left_of_nat_degree_lt pq).symm],
     simpa using (coeff_eq_zero_of_nat_degree_lt pq).symm },
@@ -140,7 +140,7 @@ end
 lemma erase_lead_add_of_nat_degree_lt_right {p q : R[X]} (pq : p.nat_degree < q.nat_degree) :
   (p + q).erase_lead = p + q.erase_lead :=
 begin
-  ext,
+  ext n,
   by_cases nd : n = q.nat_degree,
   { rw [nd, erase_lead_coeff, if_pos (nat_degree_add_eq_right_of_nat_degree_lt pq).symm],
     simpa using (coeff_eq_zero_of_nat_degree_lt pq).symm },


### PR DESCRIPTION
The two lemmas show that removing the leading term from the sum of two polynomials of unequal `nat_degree` is the same as removing the leading term of the one of larger `nat_degree` and adding.

The second lemma could be proved with `by rw [add_comm, erase_lead_add_of_nat_degree_lt_left pq, add_comm]`, but I preferred copying the same strategy as the previous one, to avoid interdependencies.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
