### PR TITLE
[Merged by Bors] - feat(ring_theory/coprime/lemmas): alternative characterisations of pairwise coprimeness

### DIFF
--- a/src/data/finset/basic.lean
+++ b/src/data/finset/basic.lean
@@ -2522,6 +2522,36 @@ lemma choose_mem (hp : ∃! a, a ∈ l ∧ p a) : choose p l hp ∈ l := (choose
 lemma choose_property (hp : ∃! a, a ∈ l ∧ p a) : p (choose p l hp) := (choose_spec _ _ _).2
 
 end choose
+
+section pairwise
+variables {s : finset α}
+
+lemma pairwise_subtype_iff_pairwise_finset' (r : β → β → Prop) (f : α → β) :
+  pairwise (r on λ x : s, f x) ↔ (s : set α).pairwise (r on f) :=
+begin
+  refine ⟨λ h x hx y hy hxy, h ⟨x, hx⟩ ⟨y, hy⟩ (by simpa only [subtype.mk_eq_mk, ne.def]), _⟩,
+  rintros h ⟨x, hx⟩ ⟨y, hy⟩ hxy,
+  exact h hx hy (subtype.mk_eq_mk.not.mp hxy)
+end
+
+lemma pairwise_subtype_iff_pairwise_finset (r : α → α → Prop) :
+  pairwise (r on λ x : s, x) ↔ (s : set α).pairwise r :=
+pairwise_subtype_iff_pairwise_finset' r id
+
+lemma pairwise_cons' {a : α} (ha : a ∉ s) (r : β → β → Prop) (f : α → β) :
+  pairwise (r on λ a : s.cons a ha, f a) ↔
+  pairwise (r on λ a : s, f a) ∧ ∀ b ∈ s, r (f a) (f b) ∧ r (f b) (f a) :=
+begin
+  simp only [pairwise_subtype_iff_pairwise_finset', finset.coe_cons, set.pairwise_insert,
+             finset.mem_coe, and.congr_right_iff],
+  exact λ hsr, ⟨λ h b hb, h b hb $ by { rintro rfl, contradiction }, λ h b hb _, h b hb⟩,
+end
+
+lemma pairwise_cons {a : α} (ha : a ∉ s) (r : α → α → Prop) :
+  pairwise (r on λ a : s.cons a ha, a) ↔ pairwise (r on λ a : s, a) ∧ ∀ b ∈ s, r a b ∧ r b a :=
+pairwise_cons' ha r id
+
+end pairwise
 end finset
 
 namespace equiv

--- a/src/data/set/finite.lean
+++ b/src/data/set/finite.lean
@@ -912,26 +912,3 @@ begin
   { dsimp only [x, y] at this, exact key₁ (f.injective $ subtype.coe_injective this) },
   { dsimp only [y, z] at this, exact key₂ (f.injective $ subtype.coe_injective this) }
 end
-
-namespace finset
-variables {s : finset α}
-
-lemma pairwise_cons {a : α} (ha : a ∉ s) (r : α → α → Prop) :
-  pairwise (r on λ a : s.cons a ha, a) ↔ pairwise (r on λ a : s, a) ∧ ∀ b ∈ s, r a b ∧ r b a :=
-begin
-  have : ∀ {s : finset α} {b c : α} {hb : b ∈ s} {hc : c ∈ s}, (⟨b, hb⟩ : s) = ⟨c, hc⟩ → b = c :=
-    λ s b c hb hc eq, congr_arg coe eq,
-  refine ⟨λ h, ⟨λ ⟨b, hb⟩ ⟨c, hc⟩ ne, h ⟨b, subset_cons ha hb⟩ ⟨c, subset_cons ha hc⟩
-    (λ eq, ne $ subtype.ext $ this eq),
-  λ b hb, ⟨h ⟨a, mem_cons_self _ _⟩ ⟨b, subset_cons ha hb⟩ (λ eq, ha $ (this eq).symm.cases_on hb),
-    h ⟨b, subset_cons ha hb⟩ ⟨a, mem_cons_self _ _⟩ (λ eq, ha $ (this eq).cases_on hb)⟩⟩,
-  λ h b c ne, _⟩,
-  obtain ⟨b, hb⟩ := b, obtain ⟨c, hc⟩ := c, change r b c, rw mem_cons at hb hc,
-  cases hb with hb hb; cases hc with hc hc,
-  { exfalso, apply ne, ext, change b = c, rw [hb, hc] },
-  { rw hb, exact (h.right c hc).left },
-  { rw hc, exact (h.right b hb).right },
-  { exact h.left ⟨b, hb⟩ ⟨c, hc⟩ (λ eq, ne $ subtype.ext $ this eq) }
-end
-
-end finset

--- a/src/data/set/finite.lean
+++ b/src/data/set/finite.lean
@@ -912,3 +912,26 @@ begin
   { dsimp only [x, y] at this, exact key₁ (f.injective $ subtype.coe_injective this) },
   { dsimp only [y, z] at this, exact key₂ (f.injective $ subtype.coe_injective this) }
 end
+
+namespace finset
+variables {s : finset α}
+
+lemma pairwise_cons {a : α} (ha : a ∉ s) (r : α → α → Prop) :
+  pairwise (r on λ a : s.cons a ha, a) ↔ pairwise (r on λ a : s, a) ∧ ∀ b ∈ s, r a b ∧ r b a :=
+begin
+  have : ∀ {s : finset α} {b c : α} {hb : b ∈ s} {hc : c ∈ s}, (⟨b, hb⟩ : s) = ⟨c, hc⟩ → b = c :=
+    λ s b c hb hc eq, congr_arg coe eq,
+  refine ⟨λ h, ⟨λ ⟨b, hb⟩ ⟨c, hc⟩ ne, h ⟨b, subset_cons ha hb⟩ ⟨c, subset_cons ha hc⟩
+    (λ eq, ne $ subtype.ext $ this eq),
+    λ b hb, ⟨h ⟨a, mem_cons_self _ _⟩ ⟨b, subset_cons ha hb⟩ (λ eq, ha $ (this eq).symm.cases_on hb),
+      h ⟨b, subset_cons ha hb⟩ ⟨a, mem_cons_self _ _⟩ (λ eq, ha $ (this eq).cases_on hb)⟩⟩,
+  λ h b c ne, _⟩,
+  obtain ⟨b, hb⟩ := b, obtain ⟨c, hc⟩ := c, change r b c, rw mem_cons at hb hc,
+  cases hb with hb hb; cases hc with hc hc,
+  { exfalso, apply ne, ext, change b = c, rw [hb, hc] },
+  { rw hb, exact (h.right c hc).left },
+  { rw hc, exact (h.right b hb).right },
+  { exact h.left ⟨b, hb⟩ ⟨c, hc⟩ (λ eq, ne $ subtype.ext $ this eq) }
+end
+
+end finset

--- a/src/data/set/finite.lean
+++ b/src/data/set/finite.lean
@@ -923,8 +923,8 @@ begin
     λ s b c hb hc eq, congr_arg coe eq,
   refine ⟨λ h, ⟨λ ⟨b, hb⟩ ⟨c, hc⟩ ne, h ⟨b, subset_cons ha hb⟩ ⟨c, subset_cons ha hc⟩
     (λ eq, ne $ subtype.ext $ this eq),
-    λ b hb, ⟨h ⟨a, mem_cons_self _ _⟩ ⟨b, subset_cons ha hb⟩ (λ eq, ha $ (this eq).symm.cases_on hb),
-      h ⟨b, subset_cons ha hb⟩ ⟨a, mem_cons_self _ _⟩ (λ eq, ha $ (this eq).cases_on hb)⟩⟩,
+  λ b hb, ⟨h ⟨a, mem_cons_self _ _⟩ ⟨b, subset_cons ha hb⟩ (λ eq, ha $ (this eq).symm.cases_on hb),
+    h ⟨b, subset_cons ha hb⟩ ⟨a, mem_cons_self _ _⟩ (λ eq, ha $ (this eq).cases_on hb)⟩⟩,
   λ h b c ne, _⟩,
   obtain ⟨b, hb⟩ := b, obtain ⟨c, hc⟩ := c, change r b c, rw mem_cons at hb hc,
   cases hb with hb hb; cases hc with hc hc,

--- a/src/ring_theory/coprime/lemmas.lean
+++ b/src/ring_theory/coprime/lemmas.lean
@@ -18,31 +18,6 @@ lemmas about `has_pow` since these are easiest to prove via `finset.prod`.
 
 -/
 
-namespace finset
-variables {α β : Type*} {s : finset α}
-
-lemma pairwise_subtype_iff_pairwise_finset' (r : β → β → Prop) (f : α → β) :
-  pairwise (r on λ x : s, f x) ↔ (s : set α).pairwise (r on f) :=
-begin
-  refine ⟨λ h x hx y hy hxy, h ⟨x, hx⟩ ⟨y, hy⟩ (by simpa only [subtype.mk_eq_mk, ne.def]), _⟩,
-  rintros h ⟨x, hx⟩ ⟨y, hy⟩ hxy,
-  exact h hx hy (subtype.mk_eq_mk.not.mp hxy)
-end
-
-lemma pairwise_subtype_iff_pairwise_finset (r : α → α → Prop) :
-  pairwise (r on λ x : s, x) ↔ (s : set α).pairwise r :=
-pairwise_subtype_iff_pairwise_finset' r id
-
-lemma pairwise_cons' {a : α} (ha : a ∉ s) (r : β → β → Prop) (f : α → β) :
-  pairwise (r on λ a : s.cons a ha, f a) ↔
-  pairwise (r on λ a : s, f a) ∧ ∀ b ∈ s, r (f a) (f b) ∧ r (f b) (f a) :=
-begin
-  simp only [pairwise_subtype_iff_pairwise_finset', finset.coe_cons, set.pairwise_insert,
-             finset.mem_coe, and.congr_right_iff],
-  exact λ hsr, ⟨λ h b hb, h b hb $ by { rintro rfl, contradiction }, λ h b hb _, h b hb⟩,
-end
-end finset
-
 universes u v
 
 variables {R : Type u} {I : Type v} [comm_semiring R] {x y z : R} {s : I → R} {t : finset I}

--- a/src/ring_theory/coprime/lemmas.lean
+++ b/src/ring_theory/coprime/lemmas.lean
@@ -3,7 +3,7 @@ Copyright (c) 2020 Kenny Lau. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Kenny Lau, Ken Lee, Chris Hughes
 -/
-import algebra.big_operators.basic
+import algebra.big_operators.ring
 import data.fintype.basic
 import data.int.gcd
 import ring_theory.coprime.basic
@@ -70,6 +70,76 @@ end
 theorem fintype.prod_dvd_of_coprime [fintype I] (Hs : pairwise (is_coprime on s))
   (Hs1 : ∀ i, s i ∣ z) : ∏ x, s x ∣ z :=
 finset.prod_dvd_of_coprime (Hs.set_pairwise _) (λ i _, Hs1 i)
+
+open finset
+
+lemma exists_sum_eq_one_iff_pairwise_coprime (h : t.nonempty) :
+  (∃ μ : I → R, ∑ i in t, μ i * ∏ j in t \ {i}, s j = 1) ↔ pairwise (is_coprime on λ i : t, s i) :=
+begin
+  refine h.cons_induction _ _; clear' t h,
+  { simp only [pairwise, sum_singleton, finset.sdiff_self, prod_empty, mul_one,
+      exists_apply_eq_apply, ne.def, true_iff],
+    rintro a ⟨i, hi⟩ ⟨j, hj⟩ h,
+    rw finset.mem_singleton at hi hj,
+    simpa [hi, hj] using h },
+  intros a t hat h ih,
+  have : ∀ t : finset I,
+        (is_coprime on λ i : t, s i) = ((λ x y, is_coprime (s x) (s y)) on λ i : t, i),
+  { simp [function.on_fun] },
+  rw [this, pairwise_cons, ←this],
+  have mem : ∀ x ∈ t, a ∈ insert a t \ {x} := λ x hx, by
+    { rw [mem_sdiff, mem_singleton], exact ⟨mem_insert_self _ _, λ ha, hat (ha.symm.cases_on hx)⟩ },
+  split,
+  { rintro ⟨μ, hμ⟩,
+    rw [sum_cons, cons_eq_insert, sdiff_singleton_eq_erase, erase_insert hat] at hμ,
+    refine ⟨ih.mp ⟨pi.single h.some (μ a * s h.some) + μ * λ _, s a, _⟩, λ b hb, _⟩,
+    { rw [prod_eq_mul_prod_diff_singleton h.some_spec, ← mul_assoc,
+        ← @if_pos _ _ h.some_spec R (_ * _) 0, ← sum_pi_single', ← sum_add_distrib] at hμ,
+      rw [← hμ, sum_congr rfl], intros x hx, convert add_mul _ _ _ using 2,
+      { by_cases hx : x = h.some,
+        { rw [hx, pi.single_eq_same, pi.single_eq_same] },
+        { rw [pi.single_eq_of_ne hx, pi.single_eq_of_ne hx, zero_mul] } },
+      { convert (mul_assoc _ _ _).symm,
+        convert prod_eq_mul_prod_diff_singleton (mem x hx) _ using 3,
+        convert sdiff_sdiff_comm, rw [sdiff_singleton_eq_erase, erase_insert hat] } },
+    { have : is_coprime (s b) (s a) :=
+        ⟨μ a * ∏ i in t \ {b}, s i, ∑ i in t, μ i * ∏ j in t \ {i}, s j, _⟩,
+      { exact ⟨this.symm, this⟩ },
+      rw [mul_assoc, ← prod_eq_prod_diff_singleton_mul hb, sum_mul, ← hμ, sum_congr rfl],
+      intros x hx, convert mul_assoc _ _ _,
+      convert prod_eq_prod_diff_singleton_mul (mem x hx) _ using 3,
+      convert sdiff_sdiff_comm, rw [sdiff_singleton_eq_erase, erase_insert hat] } },
+  { rintro ⟨hs, Hb⟩, obtain ⟨μ, hμ⟩ := ih.mpr hs,
+    obtain ⟨u, v, huv⟩ := is_coprime.prod_left (λ b hb, (Hb b hb).right),
+    use λ i, if i = a then u else v * μ i,
+    have hμ' : ∑ i in t, v * ((μ i * ∏ j in t \ {i}, s j) * s a) = v * s a := by
+      rw [← mul_sum, ← sum_mul, hμ, one_mul],
+    rw [sum_cons, cons_eq_insert, sdiff_singleton_eq_erase, erase_insert hat, if_pos rfl,
+      ← huv, ← hμ', sum_congr rfl], intros x hx,
+    rw [mul_assoc, if_neg (λ ha : x = a, hat (ha.cases_on hx))],
+    convert mul_assoc _ _ _, convert (prod_eq_prod_diff_singleton_mul (mem x hx) _).symm using 3,
+    convert sdiff_sdiff_comm, rw [sdiff_singleton_eq_erase, erase_insert hat] }
+end
+
+lemma exists_sum_eq_one_iff_pairwise_coprime' [fintype I] [nonempty I] :
+  (∃ μ : I → R, ∑ (i : I), μ i * ∏ j in {i}ᶜ, s j = 1) ↔ pairwise (is_coprime on s) := begin
+convert exists_sum_eq_one_iff_pairwise_coprime finset.univ_nonempty using 1, ext, split,
+{ rintro hp ⟨i, _⟩ ⟨j, _⟩ h, apply hp, intro h', apply h, ext, exact h' },
+{ intros hp i j h, apply hp ⟨i, finset.mem_univ i⟩ ⟨j, finset.mem_univ j⟩,
+  rintro ⟨h'⟩, exact h rfl },
+by apply_instance end
+
+lemma pairwise_coprime_iff_coprime_prod :
+  pairwise (is_coprime on λ i : t, s i) ↔ ∀ i ∈ t, is_coprime (s i) (∏ j in t \ {i}, (s j)) :=
+begin
+  split; intro hp,
+  { intros i hi, rw is_coprime.prod_right_iff, intros j hj,
+    rw [finset.mem_sdiff, finset.mem_singleton] at hj, obtain ⟨hj, ji⟩ := hj,
+    apply hp ⟨i, hi⟩ ⟨j, hj⟩, rintro ⟨f⟩, exact ji rfl },
+  { rintro ⟨i, hi⟩ ⟨j, hj⟩ h, specialize hp i hi, rw is_coprime.prod_right_iff at hp, apply hp,
+    rw [finset.mem_sdiff, finset.mem_singleton],
+    refine ⟨hj, λ f, h _⟩, ext, symmetry, exact f }
+end
 
 variables {m n : ℕ}
 


### PR DESCRIPTION
This provides two condtions equivalent to pairwise coprimeness : 

* each term is coprime to the product of all others
* 1 can be obtained as a linear combination of all products with one term missing.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
