### PR TITLE
[Merged by Bors] - feat(logic/nontrivial): `exists_pair_lt`

### DIFF
--- a/src/logic/nontrivial.lean
+++ b/src/logic/nontrivial.lean
@@ -43,16 +43,6 @@ begin
   { exact ⟨y, ne.symm hx⟩ }
 end
 
-lemma exists_pair_lt (α : Type*) [nontrivial α] [linear_order α] : ∃ (x y : α), x < y :=
-begin
-  rcases exists_pair_ne α with ⟨x, y, hxy⟩,
-  cases lt_or_gt_of_ne hxy;
-  exact ⟨_, _, h⟩
-end
-
-lemma nontrivial_iff_lt [linear_order α] : nontrivial α ↔ ∃ (x y : α), x < y :=
-⟨λ h, @exists_pair_lt α h _, λ ⟨x, y, h⟩, ⟨⟨x, y, ne_of_lt h⟩⟩⟩
-
 lemma exists_ne [nontrivial α] (x : α) : ∃ y, y ≠ x :=
 by classical; exact decidable.exists_ne x
 
@@ -63,6 +53,16 @@ lemma nontrivial_of_ne (x y : α) (h : x ≠ y) : nontrivial α :=
 -- `x` and `y` are explicit here, as they are often needed to guide typechecking of `h`.
 lemma nontrivial_of_lt [preorder α] (x y : α) (h : x < y) : nontrivial α :=
 ⟨⟨x, y, ne_of_lt h⟩⟩
+
+lemma exists_pair_lt (α : Type*) [nontrivial α] [linear_order α] : ∃ (x y : α), x < y :=
+begin
+  rcases exists_pair_ne α with ⟨x, y, hxy⟩,
+  cases lt_or_gt_of_ne hxy;
+  exact ⟨_, _, h⟩
+end
+
+lemma nontrivial_iff_lt [linear_order α] : nontrivial α ↔ ∃ (x y : α), x < y :=
+⟨λ h, @exists_pair_lt α h _, λ ⟨x, y, h⟩, nontrivial_of_lt x y h⟩
 
 lemma nontrivial_iff_exists_ne (x : α) : nontrivial α ↔ ∃ y, y ≠ x :=
 ⟨λ h, @exists_ne α h x, λ ⟨y, hy⟩, nontrivial_of_ne _ _ hy⟩

--- a/src/logic/nontrivial.lean
+++ b/src/logic/nontrivial.lean
@@ -43,6 +43,16 @@ begin
   { exact ⟨y, ne.symm hx⟩ }
 end
 
+lemma exists_pair_lt (α : Type*) [nontrivial α] [linear_order α] : ∃ (x y : α), x < y :=
+begin
+  rcases exists_pair_ne α with ⟨x, y, hxy⟩,
+  cases lt_or_gt_of_ne hxy;
+  exact ⟨_, _, h⟩
+end
+
+lemma nontrivial_iff_lt [linear_order α] : nontrivial α ↔ ∃ (x y : α), x < y :=
+⟨λ h, @exists_pair_lt α h _, λ ⟨x, y, h⟩, ⟨⟨x, y, ne_of_lt h⟩⟩⟩
+
 lemma exists_ne [nontrivial α] (x : α) : ∃ y, y ≠ x :=
 by classical; exact decidable.exists_ne x
 


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

There's a slight chance I missed this theorem within the library, if so lmk and I'll close this PR.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
