### PR TITLE
[Merged by Bors] - feat(number_theory/padics/padic_numbers): add padic.add_valuation

### DIFF
--- a/src/algebra/field_power.lean
+++ b/src/algebra/field_power.lean
@@ -161,14 +161,8 @@ lemma min_le_of_zpow_le_max {x : K} (hx : 1 < x) {a b c : ℤ}
   (h_max : x ^ (-c) ≤ max (x ^ (-a)) (x ^ (-b)) ) : min a b ≤ c :=
 begin
   rw min_le_iff,
-<<<<<<< HEAD
   refine or.imp (λ h, _) (λ h, _) (le_max_iff.mp h_max);
   rwa [zpow_le_iff_le hx, neg_le_neg_iff] at h
-=======
-  cases le_max_iff.mp h_max with h; [left, right];
-  rw [zpow_le_iff_le hx, neg_le_neg_iff] at h;
-  exact h
->>>>>>> feat(algebra/field_power): resolve merge conflict
 end
 
 @[simp] lemma pos_div_pow_pos {a b : K} (ha : 0 < a) (hb : 0 < b) (k : ℕ) : 0 < a/b^k :=

--- a/src/algebra/field_power.lean
+++ b/src/algebra/field_power.lean
@@ -161,8 +161,14 @@ lemma min_le_of_zpow_le_max {x : K} (hx : 1 < x) {a b c : ℤ}
   (h_max : x ^ (-c) ≤ max (x ^ (-a)) (x ^ (-b)) ) : min a b ≤ c :=
 begin
   rw min_le_iff,
+<<<<<<< HEAD
   refine or.imp (λ h, _) (λ h, _) (le_max_iff.mp h_max);
   rwa [zpow_le_iff_le hx, neg_le_neg_iff] at h
+=======
+  cases le_max_iff.mp h_max with h; [left, right];
+  rw [zpow_le_iff_le hx, neg_le_neg_iff] at h;
+  exact h
+>>>>>>> feat(algebra/field_power): resolve merge conflict
 end
 
 @[simp] lemma pos_div_pow_pos {a b : K} (ha : 0 < a) (hb : 0 < b) (k : ℕ) : 0 < a/b^k :=

--- a/src/number_theory/padics/padic_numbers.lean
+++ b/src/number_theory/padics/padic_numbers.lean
@@ -18,7 +18,7 @@ and that `ℚ_p` is Cauchy complete.
 
 * `padic` : the type of p-adic numbers
 * `padic_norm_e` : the rational valued p-adic norm on `ℚ_p`
-* `padic.add_valuation` : the additive p-adic valuation on `ℚ_p`, with values in `with_top ℤ`.
+* `padic.add_valuation` : the additive `p`-adic valuation on `ℚ_p`, with values in `with_top ℤ`.
 
 ## Notation
 
@@ -1108,7 +1108,7 @@ begin
         exact valuation_map_add hxy }}}
 end
 
-/-- The additive p-adic valuation on `ℚ_p`, as an `add_valuation`. -/
+/-- The additive `p`-adic valuation on `ℚ_p`, as an `add_valuation`. -/
 def add_valuation : add_valuation ℚ_[p] (with_top ℤ) :=
 add_valuation.of add_valuation_def add_valuation.map_zero add_valuation.map_one
   add_valuation.map_add add_valuation.map_mul


### PR DESCRIPTION
We define the p-adic additive valuation on `Q_[p]`, as an `add_valuation` with values in `with_top Z`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
- [x] depends on: #12915


[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
