### PR TITLE
chore(dynamics/periodic_pts): Change > to <

### DIFF
--- a/src/dynamics/periodic_pts.lean
+++ b/src/dynamics/periodic_pts.lean
@@ -182,13 +182,13 @@ lemma directed_pts_of_period_pnat (f : α → α) : directed (⊆) (λ n : ℕ+,
 λ m n, ⟨m * n, λ x hx, hx.mul_const n, λ x hx, hx.const_mul m⟩
 
 /-- The set of periodic points of a map `f : α → α`. -/
-def periodic_pts (f : α → α) : set α := {x : α | ∃ n > 0, is_periodic_pt f n x}
+def periodic_pts (f : α → α) : set α := {x : α | ∃ n, 0 < n ∧ is_periodic_pt f n x}
 
 lemma mk_mem_periodic_pts (hn : 0 < n) (hx : is_periodic_pt f n x) :
   x ∈ periodic_pts f :=
 ⟨n, hn, hx⟩
 
-lemma mem_periodic_pts : x ∈ periodic_pts f ↔ ∃ n > 0, is_periodic_pt f n x := iff.rfl
+lemma mem_periodic_pts : x ∈ periodic_pts f ↔ ∃ n, 0 < n ∧ is_periodic_pt f n x := iff.rfl
 
 variable (f)
 
@@ -222,7 +222,7 @@ lemma is_periodic_pt_minimal_period (f : α → α) (x : α) :
 begin
   delta minimal_period,
   split_ifs with hx,
-  { exact (nat.find_spec hx).snd },
+  { exact (nat.find_spec hx).2 },
   { exact is_periodic_pt_zero f x }
 end
 
@@ -231,7 +231,7 @@ lemma iterate_eq_mod_minimal_period : f^[n] x = (f^[n % minimal_period f x] x) :
 
 lemma minimal_period_pos_of_mem_periodic_pts (hx : x ∈ periodic_pts f) :
   0 < minimal_period f x :=
-by simp only [minimal_period, dif_pos hx, (nat.find_spec hx).fst.lt]
+by simp only [minimal_period, dif_pos hx, (nat.find_spec hx).1]
 
 lemma is_periodic_pt.minimal_period_pos (hn : 0 < n) (hx : is_periodic_pt f n x) :
   0 < minimal_period f x :=


### PR DESCRIPTION
As per the mathlib style guide, `>` should only be used in exceptional circumstances, and I don't believe this is one of them.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
