### PR TITLE
[Merged by Bors] - fix(data/set/prod): fix the way `×ˢ` associates

### DIFF
--- a/src/data/set/prod.lean
+++ b/src/data/set/prod.lean
@@ -25,7 +25,7 @@ open function
 class has_set_prod (α β : Type*) (γ : out_param Type*) :=
 (prod : α → β → γ)
 
-infix ` ×ˢ `:72 := has_set_prod.prod
+infixr ` ×ˢ `:72 := has_set_prod.prod
 
 namespace set
 


### PR DESCRIPTION
Previously `s ×ˢ t ×ˢ u` was an element of `set ((α × β) × γ)` instead of `set (α × β × γ) = set (α × (β × γ))`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
