### PR TITLE
[Merged by Bors] - feat(data/zmod/basic): add `int_coe_eq_int_coe_iff_dvd_sub`

### DIFF
--- a/src/data/zmod/basic.lean
+++ b/src/data/zmod/basic.lean
@@ -426,7 +426,7 @@ end
 
 lemma int_coe_eq_int_coe_iff_dvd_sub (a b : ℤ) (c : ℕ) : (a : zmod c) = ↑b ↔ ↑c ∣ b-a :=
 begin
-  rw [int_coe_eq_int_coe_iff, int.modeq_iff_dvd],
+  rw [zmod.int_coe_eq_int_coe_iff, int.modeq_iff_dvd],
 end
 
 lemma nat_coe_zmod_eq_zero_iff_dvd (a b : ℕ) : (a : zmod b) = 0 ↔ b ∣ a :=

--- a/src/data/zmod/basic.lean
+++ b/src/data/zmod/basic.lean
@@ -418,13 +418,20 @@ lemma nat_coe_eq_nat_coe_iff' (a b c : ℕ) :
   (a : zmod c) = (b : zmod c) ↔ a % c = b % c :=
 zmod.nat_coe_eq_nat_coe_iff a b c
 
-lemma int_coe_zmod_eq_zero_iff_dvd (a : ℤ) (b : ℕ) : (a : zmod b) = 0 ↔ (b : ℤ) ∣ a :=
+lemma int_coe_eq_zero_iff_dvd (a : ℤ) (b : ℕ) : (a : zmod b) = 0 ↔ (b : ℤ) ∣ a :=
 begin
   change (a : zmod b) = ((0 : ℤ) : zmod b) ↔ (b : ℤ) ∣ a,
   rw [zmod.int_coe_eq_int_coe_iff, int.modeq_zero_iff_dvd],
 end
 
-lemma nat_coe_zmod_eq_zero_iff_dvd (a b : ℕ) : (a : zmod b) = 0 ↔ b ∣ a :=
+lemma int_coe_eq_int_coe_iff_dvd_sub (a b : ℤ) (c : ℕ) : (a : zmod c) = ↑b ↔ ↑c ∣ a-b :=
+begin
+  rw ← sub_eq_zero,
+  norm_cast,
+  exact int_coe_eq_zero_iff_dvd (a-b) c,
+end
+
+lemma nat_coe_eq_zero_iff_dvd (a b : ℕ) : (a : zmod b) = 0 ↔ b ∣ a :=
 begin
   change (a : zmod b) = ((0 : ℕ) : zmod b) ↔ b ∣ a,
   rw [zmod.nat_coe_eq_nat_coe_iff, nat.modeq_zero_iff_dvd],

--- a/src/data/zmod/basic.lean
+++ b/src/data/zmod/basic.lean
@@ -424,11 +424,9 @@ begin
   rw [zmod.int_coe_eq_int_coe_iff, int.modeq_zero_iff_dvd],
 end
 
-lemma int_coe_eq_int_coe_iff_dvd_sub (a b : ℤ) (c : ℕ) : (a : zmod c) = ↑b ↔ ↑c ∣ a-b :=
+lemma int_coe_eq_int_coe_iff_dvd_sub (a b : ℤ) (c : ℕ) : (a : zmod c) = ↑b ↔ ↑c ∣ b-a :=
 begin
-  rw ← sub_eq_zero,
-  norm_cast,
-  exact int_coe_zmod_eq_zero_iff_dvd (a-b) c,
+  rw [int_coe_eq_int_coe_iff, int.modeq_iff_dvd],
 end
 
 lemma nat_coe_zmod_eq_zero_iff_dvd (a b : ℕ) : (a : zmod b) = 0 ↔ b ∣ a :=

--- a/src/data/zmod/basic.lean
+++ b/src/data/zmod/basic.lean
@@ -418,7 +418,7 @@ lemma nat_coe_eq_nat_coe_iff' (a b c : ℕ) :
   (a : zmod c) = (b : zmod c) ↔ a % c = b % c :=
 zmod.nat_coe_eq_nat_coe_iff a b c
 
-lemma int_coe_eq_zero_iff_dvd (a : ℤ) (b : ℕ) : (a : zmod b) = 0 ↔ (b : ℤ) ∣ a :=
+lemma int_coe_zmod_eq_zero_iff_dvd (a : ℤ) (b : ℕ) : (a : zmod b) = 0 ↔ (b : ℤ) ∣ a :=
 begin
   change (a : zmod b) = ((0 : ℤ) : zmod b) ↔ (b : ℤ) ∣ a,
   rw [zmod.int_coe_eq_int_coe_iff, int.modeq_zero_iff_dvd],
@@ -428,10 +428,10 @@ lemma int_coe_eq_int_coe_iff_dvd_sub (a b : ℤ) (c : ℕ) : (a : zmod c) = ↑b
 begin
   rw ← sub_eq_zero,
   norm_cast,
-  exact int_coe_eq_zero_iff_dvd (a-b) c,
+  exact int_coe_zmod_eq_zero_iff_dvd (a-b) c,
 end
 
-lemma nat_coe_eq_zero_iff_dvd (a b : ℕ) : (a : zmod b) = 0 ↔ b ∣ a :=
+lemma nat_coe_zmod_eq_zero_iff_dvd (a b : ℕ) : (a : zmod b) = 0 ↔ b ∣ a :=
 begin
   change (a : zmod b) = ((0 : ℕ) : zmod b) ↔ b ∣ a,
   rw [zmod.nat_coe_eq_nat_coe_iff, nat.modeq_zero_iff_dvd],


### PR DESCRIPTION
This adds the following API lemma.
```
lemma int_coe_eq_int_coe_iff_dvd_sub (a b : ℤ) (c : ℕ) : (a : zmod c) = ↑b ↔ ↑c ∣ b-a
```
extending the already present version with b = 0. [(Zulip discussion)](https://leanprover.zulipchat.com/#narrow/stream/113489-new-members/topic/Missing.20zmod.20lemma.3F)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
