### PR TITLE
[Merged by Bors] - feat(group_theory/free_product): add (m)range_eq_supr

### DIFF
--- a/src/group_theory/free_group.lean
+++ b/src/group_theory/free_group.lean
@@ -456,31 +456,22 @@ lift.symm.injective $ funext h
 theorem lift.of_eq (x : free_group α) : lift of x = x :=
 monoid_hom.congr_fun (lift.apply_symm_apply (monoid_hom.id _)) x
 
-theorem lift.range_subset {s : subgroup β} (H : set.range f ⊆ s) :
-  set.range (lift f) ⊆ s :=
+theorem lift.range_le {s : subgroup β} (H : set.range f ⊆ s) :
+  (lift f).range ≤ s :=
 by rintros _ ⟨⟨L⟩, rfl⟩; exact list.rec_on L s.one_mem
 (λ ⟨x, b⟩ tl ih, bool.rec_on b
     (by simp at ih ⊢; from s.mul_mem
       (s.inv_mem $ H ⟨x, rfl⟩) ih)
     (by simp at ih ⊢; from s.mul_mem (H ⟨x, rfl⟩) ih))
 
-theorem closure_subset {G : Type*} [group G] {s : set G} {t : subgroup G}
-  (h : s ⊆ t) : subgroup.closure s ≤ t :=
-begin
-  simp only [h, subgroup.closure_le],
-end
-
 theorem lift.range_eq_closure :
-  set.range (lift f) = subgroup.closure (set.range f) :=
-set.subset.antisymm
-  (lift.range_subset subgroup.subset_closure)
-  begin
-    suffices : (subgroup.closure (set.range f)) ≤ monoid_hom.range (lift f),
-      simpa,
-    rw subgroup.closure_le,
-    rintros y ⟨x, hx⟩,
-    exact ⟨of x, by simpa⟩
-  end
+  (lift f).range = subgroup.closure (set.range f) :=
+begin
+  apply le_antisymm (lift.range_le subgroup.subset_closure),
+  rw subgroup.closure_le,
+  rintros _ ⟨a, rfl⟩,
+  exact ⟨of a, by simp only [lift.of]⟩,
+end
 
 end lift
 

--- a/src/group_theory/free_product.lean
+++ b/src/group_theory/free_product.lean
@@ -151,8 +151,8 @@ lemma of_left_inverse [decidable_eq ι] (i : ι) :
 lemma of_injective (i : ι) : function.injective ⇑(of : M i →* _) :=
 by { classical, exact (of_left_inverse i).injective }
 
-lemma lift_range_subset_submonoid {N} [monoid N] (f : Π i, M i →* N) {s : submonoid N}
-  (h : ∀ i, set.range (f i) ⊆ s) : set.range (lift f) ⊆ s :=
+lemma lift_mrange_le {N} [monoid N] (f : Π i, M i →* N) {s : submonoid N}
+  (h : ∀ i, (f i).mrange ≤ s) : (lift f).mrange ≤ s :=
 begin
   rintros _ ⟨x, rfl⟩,
   induction x using free_product.induction_on with i x x y hx hy,
@@ -161,24 +161,13 @@ begin
   { simp only [map_mul, set_like.mem_coe], exact s.mul_mem hx hy, },
 end
 
-lemma range_eq_submonoid_closure {N} [monoid N] (f : Π i, M i →* N) :
-  set.range (lift f) = submonoid.closure (⋃ i, set.range (f i)) :=
-begin
-  apply set.subset.antisymm,
-  { exact lift_range_subset_submonoid f
-      (λ i, @set.subset.trans _ _ (⋃ i, set.range (f i)) _
-        (set.subset_Union _ i) submonoid.subset_closure), },
-  { suffices : (submonoid.closure (⋃ i, set.range (f i))) ≤ monoid_hom.mrange (lift f), by simpa,
-    rw submonoid.closure_le,
-    rintros y ⟨_, ⟨⟨i, rfl⟩, ⟨x, rfl⟩⟩⟩,
-    exact ⟨of x, by simp⟩ }
-end
-
 lemma mrange_eq_supr {N} [monoid N] (f : Π i, M i →* N) :
   (lift f).mrange = ⨆ i, (f i).mrange :=
 begin
-  apply set_like.ext',
-  simp only [monoid_hom.coe_mrange, range_eq_submonoid_closure, submonoid.supr_eq_closure],
+  apply le_antisymm (lift_mrange_le f (λ i, le_supr _ i)),
+  apply supr_le _,
+  rintros i _ ⟨x, rfl⟩,
+  exact ⟨of x, by simp only [lift_of]⟩
 end
 
 section group
@@ -206,28 +195,23 @@ instance : group (free_product G) :=
   ..free_product.has_inv G,
   ..free_product.monoid G }
 
-lemma lift_range_subset {N} [group N] (f : Π i, G i →* N) {s : subgroup N} :
-   (∀ i, set.range (f i) ⊆ s) → set.range (lift f) ⊆ s :=
-by { rw ← s.coe_to_submonoid, exact lift_range_subset_submonoid f, }
-
-lemma range_eq_subgroup_closure {N} [group N] (f : Π i, G i →* N) :
-  set.range (lift f) = subgroup.closure (⋃ i, set.range (f i)) :=
+lemma lift_range_le {N} [group N] (f : Π i, G i →* N) {s : subgroup N}
+  (h : ∀ i, (f i).range ≤ s) : (lift f).range ≤ s :=
 begin
-  apply set.subset.antisymm,
-  { exact lift_range_subset _ f
-      (λ i, @set.subset.trans _ _ (⋃ i, set.range (f i)) _
-        (set.subset_Union _ i) subgroup.subset_closure), },
-  { suffices : (subgroup.closure (⋃ i, set.range (f i))) ≤ monoid_hom.range (lift f), by simpa,
-    rw subgroup.closure_le,
-    rintros y ⟨_, ⟨⟨i, rfl⟩, ⟨x, rfl⟩⟩⟩,
-    exact ⟨of x, by simp⟩ }
+  rintros _ ⟨x, rfl⟩,
+  induction x using free_product.induction_on with i x x y hx hy,
+  { exact s.one_mem, },
+  { simp only [lift_of, set_like.mem_coe], exact h i (set.mem_range_self x), },
+  { simp only [map_mul, set_like.mem_coe], exact s.mul_mem hx hy, },
 end
 
 lemma range_eq_supr {N} [group N] (f : Π i, G i →* N) :
   (lift f).range = ⨆ i, (f i).range :=
 begin
-  apply set_like.ext',
-  simp only [monoid_hom.coe_range, range_eq_subgroup_closure, subgroup.supr_eq_closure],
+  apply le_antisymm (lift_range_le _ f (λ i, le_supr _ i)),
+  apply supr_le _,
+  rintros i _ ⟨x, rfl⟩,
+  exact ⟨of x, by simp only [lift_of]⟩
 end
 
 end group

--- a/src/group_theory/free_product.lean
+++ b/src/group_theory/free_product.lean
@@ -206,15 +206,9 @@ instance : group (free_product G) :=
   ..free_product.has_inv G,
   ..free_product.monoid G }
 
-lemma lift_range_subset {N} [group N] (f : Π i, G i →* N) {s : subgroup N}
-  (h : ∀ i, set.range (f i) ⊆ s) : set.range (lift f) ⊆ s :=
-begin
-  rintros _ ⟨x, rfl⟩,
-  induction x using free_product.induction_on with i x x y hx hy,
-  { exact s.one_mem, },
-  { simp only [lift_of, set_like.mem_coe], exact h i (set.mem_range_self x), },
-  { simp only [map_mul, set_like.mem_coe], exact s.mul_mem hx hy, },
-end
+lemma lift_range_subset {N} [group N] (f : Π i, G i →* N) {s : subgroup N} :
+   (∀ i, set.range (f i) ⊆ s) → set.range (lift f) ⊆ s :=
+by { rw ← s.coe_to_submonoid, exact lift_range_subset_submonoid f, }
 
 lemma range_eq_subgroup_closure {N} [group N] (f : Π i, G i →* N) :
   set.range (lift f) = subgroup.closure (⋃ i, set.range (f i)) :=


### PR DESCRIPTION
and lemmas leading to it as inspired by the corresponding lemmas from
`free_groups.lean`.

As suggested by @ocfnash, polish the free group lemmas a bit as well.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
