### PR TITLE
[Merged by Bors] - feat(algebra/order/monoid_lemmas_zero_lt): port some lemmas from `algebra.order.monoid_lemmas`

### DIFF
--- a/src/algebra/order/monoid_lemmas_zero_lt.lean
+++ b/src/algebra/order/monoid_lemmas_zero_lt.lean
@@ -121,85 +121,94 @@ contravariant_class {x : X // 0 < x} X (λ x y, y * x) (≤)
 
 end abbreviations_mono
 
-section has_mul_zero_lt
-variables [has_mul α] [has_zero α] [has_lt α]
+variables {a b c d : α}
 
-lemma mul_lt_mul_left' [pos_mul_strict_mono α] {a b c : α} (bc : b < c) (a0 : 0 < a) :
+section has_mul_zero
+variables [has_mul α] [has_zero α]
+
+section has_lt
+variables [has_lt α]
+
+lemma mul_lt_mul_left' [pos_mul_strict_mono α]
+  (bc : b < c) (a0 : 0 < a) :
   a * b < a * c :=
 @covariant_class.elim α>0 α (λ x y, x * y) (<) _ ⟨a, a0⟩ _ _ bc
 
 lemma mul_lt_mul_right' [mul_pos_strict_mono α]
-  {a b c : α} (bc : b < c) (a0 : 0 < a) :
+  (bc : b < c) (a0 : 0 < a) :
   b * a < c * a :=
 @covariant_class.elim α>0 α (λ x y, y * x) (<) _ ⟨a, a0⟩ _ _ bc
 
 -- proven with `a0 : 0 ≤ a` as `lt_of_mul_lt_mul_left''`
 lemma lt_of_mul_lt_mul_left' [pos_mul_reflect_lt α]
-  {a b c : α} (bc : a * b < a * c) (a0 : 0 < a) :
+  (bc : a * b < a * c) (a0 : 0 < a) :
   b < c :=
 @contravariant_class.elim α>0 α (λ x y, x * y) (<) _ ⟨a, a0⟩ _ _ bc
 
 -- proven with `a0 : 0 ≤ a` as `lt_of_mul_lt_mul_right''`
 lemma lt_of_mul_lt_mul_right' [mul_pos_reflect_lt α]
-  {a b c : α} (bc : b * a < c * a) (a0 : 0 < a) :
+  (bc : b * a < c * a) (a0 : 0 < a) :
   b < c :=
 @contravariant_class.elim α>0 α (λ x y, y * x) (<) _ ⟨a, a0⟩ _ _ bc
 
 @[simp]
 lemma mul_lt_mul_iff_left [pos_mul_strict_mono α] [pos_mul_reflect_lt α]
-  {a b c : α} (a0 : 0 < a) :
+  (a0 : 0 < a) :
   a * b < a * c ↔ b < c :=
 @rel_iff_cov α>0 α (λ x y, x * y) (<) _ _ ⟨a, a0⟩ _ _
 
 @[simp]
 lemma mul_lt_mul_iff_right [mul_pos_strict_mono α] [mul_pos_reflect_lt α]
-  {a b c : α} (a0 : 0 < a) :
+  (a0 : 0 < a) :
   b * a < c * a ↔ b < c :=
 @rel_iff_cov α>0 α (λ x y, y * x) (<) _ _ ⟨a, a0⟩ _ _
 
-end has_mul_zero_lt
+end has_lt
 
-section has_mul_zero_le
-variables [has_mul α] [has_zero α] [preorder α]
+section preorder
+variables [preorder α]
 
-lemma mul_le_mul_left' [pos_mul_mono α] {a b c : α} (bc : b ≤ c) (a0 : 0 < a) :
+lemma mul_le_mul_left' [pos_mul_mono α]
+  (bc : b ≤ c) (a0 : 0 < a) :
   a * b ≤ a * c :=
 @covariant_class.elim α>0 α (λ x y, x * y) (≤) _ ⟨a, a0⟩ _ _ bc
 
 lemma mul_le_mul_right' [mul_pos_mono α]
-  {a b c : α} (bc : b ≤ c) (a0 : 0 < a) :
+  (bc : b ≤ c) (a0 : 0 < a) :
   b * a ≤ c * a :=
 @covariant_class.elim α>0 α (λ x y, y * x) (≤) _ ⟨a, a0⟩ _ _ bc
 
 lemma le_of_mul_le_mul_left' [pos_mul_mono_rev α]
-  {a b c : α} (bc : a * b ≤ a * c) (a0 : 0 < a) :
+  (bc : a * b ≤ a * c) (a0 : 0 < a) :
   b ≤ c :=
 @contravariant_class.elim α>0 α (λ x y, x * y) (≤) _ ⟨a, a0⟩ _ _ bc
 
 lemma le_of_mul_le_mul_right' [mul_pos_mono_rev α]
-  {a b c : α} (bc : b * a ≤ c * a) (a0 : 0 < a) :
+  (bc : b * a ≤ c * a) (a0 : 0 < a) :
   b ≤ c :=
 @contravariant_class.elim α>0 α (λ x y, y * x) (≤) _ ⟨a, a0⟩ _ _ bc
 
 @[simp]
 lemma mul_le_mul_iff_left [pos_mul_mono α] [pos_mul_mono_rev α]
-  {a b c : α} (a0 : 0 < a) :
+  (a0 : 0 < a) :
   a * b ≤ a * c ↔ b ≤ c :=
 @rel_iff_cov α>0 α (λ x y, x * y) (≤) _ _ ⟨a, a0⟩ _ _
 
 @[simp]
 lemma mul_le_mul_iff_right [mul_pos_mono α] [mul_pos_mono_rev α]
-  {a b c : α} (a0 : 0 < a) :
+  (a0 : 0 < a) :
   b * a ≤ c * a ↔ b ≤ c :=
 @rel_iff_cov α>0 α (λ x y, y * x) (≤) _ _ ⟨a, a0⟩ _ _
 
-end has_mul_zero_le
+end preorder
+
+end has_mul_zero
 
 section mul_zero_class_partial_order
 variables [mul_zero_class α] [partial_order α]
 
 lemma lt_of_mul_lt_mul_left'' [pos_mul_reflect_lt α]
-  {a b c : α} (bc : a * b < a * c) (a0 : 0 ≤ a) :
+  (bc : a * b < a * c) (a0 : 0 ≤ a) :
   b < c :=
 begin
   by_cases a₀ : a = 0,
@@ -208,7 +217,7 @@ begin
 end
 
 lemma lt_of_mul_lt_mul_right'' [mul_pos_reflect_lt α]
-  {a b c : α} (bc : b * a < c * a) (a0 : 0 ≤ a) :
+  (bc : b * a < c * a) (a0 : 0 ≤ a) :
   b < c :=
 begin
   by_cases a₀ : a = 0,
@@ -230,28 +239,28 @@ variables [preorder α]
 @[simp]
 lemma le_mul_iff_one_le_right
   [pos_mul_mono α] [pos_mul_mono_rev α]
-  {a b : α} (a0 : 0 < a) :
+  (a0 : 0 < a) :
   a ≤ a * b ↔ 1 ≤ b :=
 iff.trans (by rw [mul_one]) (mul_le_mul_iff_left a0)
 
 @[simp]
 lemma lt_mul_iff_one_lt_right
   [pos_mul_strict_mono α] [pos_mul_reflect_lt α]
-  {a b : α} (a0 : 0 < a) :
+  (a0 : 0 < a) :
   a < a * b ↔ 1 < b :=
 iff.trans (by rw [mul_one]) (mul_lt_mul_iff_left a0)
 
 @[simp]
 lemma mul_le_iff_le_one_right
   [pos_mul_mono α] [pos_mul_mono_rev α]
-  {a b : α} (a0 : 0 < a) :
+  (a0 : 0 < a) :
   a * b ≤ a ↔ b ≤ 1 :=
 iff.trans (by rw [mul_one]) (mul_le_mul_iff_left a0)
 
 @[simp]
 lemma mul_lt_iff_lt_one_left
   [pos_mul_strict_mono α] [pos_mul_reflect_lt α]
-  {a b : α} (a0 : 0 < a) :
+  (a0 : 0 < a) :
   a * b < a ↔ b < 1 :=
 iff.trans (by rw [mul_one]) (mul_lt_mul_iff_left a0)
 
@@ -261,28 +270,28 @@ iff.trans (by rw [mul_one]) (mul_lt_mul_iff_left a0)
 @[simp]
 lemma le_mul_iff_one_le_left
   [mul_pos_mono α] [mul_pos_mono_rev α]
-  {a b : α} (a0 : 0 < a) :
+  (a0 : 0 < a) :
   a ≤ b * a ↔ 1 ≤ b :=
 iff.trans (by rw [one_mul]) (mul_le_mul_iff_right a0)
 
 @[simp]
 lemma lt_mul_iff_one_lt_left
   [mul_pos_strict_mono α] [mul_pos_reflect_lt α]
-  {a b : α} (a0 : 0 < a) :
+  (a0 : 0 < a) :
   a < b * a ↔ 1 < b :=
 iff.trans (by rw [one_mul]) (mul_lt_mul_iff_right a0)
 
 @[simp]
 lemma mul_le_iff_le_one_left
   [mul_pos_mono α] [mul_pos_mono_rev α]
-  {a b : α} (b0 : 0 < b) :
+  (b0 : 0 < b) :
   a * b ≤ b ↔ a ≤ 1 :=
 iff.trans (by rw [one_mul]) (mul_le_mul_iff_right b0)
 
 @[simp]
 lemma mul_lt_iff_lt_one_right
   [mul_pos_strict_mono α] [mul_pos_reflect_lt α]
-  {a b : α} (b0 : 0 < b) :
+  (b0 : 0 < b) :
   a * b < b ↔ a < 1 :=
 iff.trans (by rw [one_mul]) (mul_lt_mul_iff_right b0)
 
@@ -291,47 +300,47 @@ iff.trans (by rw [one_mul]) (mul_lt_mul_iff_right b0)
 
 -- proven with `b0 : 0 ≤ b` as `mul_le_of_le_of_le_one'`
 lemma mul_le_of_le_of_le_one [pos_mul_mono α]
-  {a b c : α} (bc : b ≤ c) (ha : a ≤ 1) (b0 : 0 < b) : b * a ≤ c :=
+  (bc : b ≤ c) (ha : a ≤ 1) (b0 : 0 < b) : b * a ≤ c :=
 calc  b * a ≤ b * 1 : mul_le_mul_left' ha b0
         ... = b     : mul_one b
         ... ≤ c     : bc
 
 lemma mul_lt_of_le_of_lt_one [pos_mul_strict_mono α]
-  {a b c : α} (bc : b ≤ c) (ha : a < 1) (b0 : 0 < b) : b * a < c :=
+  (bc : b ≤ c) (ha : a < 1) (b0 : 0 < b) : b * a < c :=
 calc  b * a < b * 1 : mul_lt_mul_left' ha b0
         ... = b     : mul_one b
         ... ≤ c     : bc
 
 lemma mul_lt_of_lt_of_le_one [pos_mul_mono α]
-  {a b c : α} (bc : b < c) (ha : a ≤ 1) (b0 : 0 < b) : b * a < c :=
+  (bc : b < c) (ha : a ≤ 1) (b0 : 0 < b) : b * a < c :=
 calc  b * a ≤ b * 1 : mul_le_mul_left' ha b0
         ... = b     : mul_one b
         ... < c     : bc
 
 lemma mul_lt_of_lt_of_lt_one [pos_mul_strict_mono α]
-  {a b c : α} (bc : b < c) (ha : a < 1) (b0 : 0 < b) : b * a < c :=
+  (bc : b < c) (ha : a < 1) (b0 : 0 < b) : b * a < c :=
 calc  b * a < b * 1 : mul_lt_mul_left' ha b0
         ... = b     : mul_one b
         ... < c     : bc
 
 /-- Assumes left covariance. -/
 lemma left.mul_le_one_of_le_of_le [pos_mul_mono α]
-  {a b : α} (ha : a ≤ 1) (hb : b ≤ 1) (a0 : 0 < a) : a * b ≤ 1 :=
+  (ha : a ≤ 1) (hb : b ≤ 1) (a0 : 0 < a) : a * b ≤ 1 :=
 mul_le_of_le_of_le_one ha hb a0
 
 /-- Assumes left covariance. -/
 lemma left.mul_lt_one_of_le_of_lt [pos_mul_strict_mono α]
-  {a b : α} (ha : a ≤ 1) (hb : b < 1) (a0 : 0 < a) : a * b < 1 :=
+  (ha : a ≤ 1) (hb : b < 1) (a0 : 0 < a) : a * b < 1 :=
 mul_lt_of_le_of_lt_one ha hb a0
 
 /-- Assumes left covariance. -/
 lemma left.mul_lt_one_of_lt_of_le [pos_mul_mono α]
-  {a b : α} (ha : a < 1) (hb : b ≤ 1) (a0 : 0 < a) : a * b < 1 :=
+  (ha : a < 1) (hb : b ≤ 1) (a0 : 0 < a) : a * b < 1 :=
 mul_lt_of_lt_of_le_one ha hb a0
 
 /-- Assumes left covariance. -/
 lemma left.mul_lt_one_of_lt_of_lt [pos_mul_strict_mono α]
-  {a b : α} (ha : a < 1) (hb : b < 1) (a0 : 0 < a) : a * b < 1 :=
+  (ha : a < 1) (hb : b < 1) (a0 : 0 < a) : a * b < 1 :=
 mul_lt_of_lt_of_lt_one ha hb a0
 
 -- Lemmas in the form of `b ≤ c → 1 ≤ a → 0 < c → b ≤ c * a`,
@@ -339,47 +348,47 @@ mul_lt_of_lt_of_lt_one ha hb a0
 
 -- proven with `c0 : 0 ≤ c` as `le_mul_of_le_of_one_le'`
 lemma le_mul_of_le_of_one_le [pos_mul_mono α]
-  {a b c : α} (bc : b ≤ c) (ha : 1 ≤ a) (c0 : 0 < c) : b ≤ c * a :=
+  (bc : b ≤ c) (ha : 1 ≤ a) (c0 : 0 < c) : b ≤ c * a :=
 calc  b ≤ c     : bc
     ... = c * 1 : (mul_one c).symm
     ... ≤ c * a : mul_le_mul_left' ha c0
 
 lemma lt_mul_of_le_of_one_lt [pos_mul_strict_mono α]
-  {a b c : α} (bc : b ≤ c) (ha : 1 < a) (c0 : 0 < c) : b < c * a :=
+  (bc : b ≤ c) (ha : 1 < a) (c0 : 0 < c) : b < c * a :=
 calc  b ≤ c     : bc
     ... = c * 1 : (mul_one c).symm
     ... < c * a : mul_lt_mul_left' ha c0
 
 lemma lt_mul_of_lt_of_one_le [pos_mul_mono α]
-  {a b c : α} (bc : b < c) (ha : 1 ≤ a) (c0 : 0 < c) : b < c * a :=
+  (bc : b < c) (ha : 1 ≤ a) (c0 : 0 < c) : b < c * a :=
 calc  b < c     : bc
     ... = c * 1 : (mul_one c).symm
     ... ≤ c * a : mul_le_mul_left' ha c0
 
 lemma lt_mul_of_lt_of_one_lt [pos_mul_strict_mono α]
-  {a b c : α} (bc : b < c) (ha : 1 < a) (c0 : 0 < c) : b < c * a :=
+  (bc : b < c) (ha : 1 < a) (c0 : 0 < c) : b < c * a :=
 calc  b < c     : bc
     ... = c * 1 : (mul_one _).symm
     ... < c * a : mul_lt_mul_left' ha c0
 
 /-- Assumes left covariance. -/
 lemma left.one_le_mul_of_le_of_le [pos_mul_mono α]
-  {a b : α} (ha : 1 ≤ a) (hb : 1 ≤ b) (a0 : 0 < a) : 1 ≤ a * b :=
+  (ha : 1 ≤ a) (hb : 1 ≤ b) (a0 : 0 < a) : 1 ≤ a * b :=
 le_mul_of_le_of_one_le ha hb a0
 
 /-- Assumes left covariance. -/
 lemma left.one_lt_mul_of_le_of_lt [pos_mul_strict_mono α]
-  {a b : α} (ha : 1 ≤ a) (hb : 1 < b) (a0 : 0 < a) : 1 < a * b :=
+  (ha : 1 ≤ a) (hb : 1 < b) (a0 : 0 < a) : 1 < a * b :=
 lt_mul_of_le_of_one_lt ha hb a0
 
 /-- Assumes left covariance. -/
 lemma left.one_lt_mul_of_lt_of_le [pos_mul_mono α]
-  {a b : α} (ha : 1 < a) (hb : 1 ≤ b) (a0 : 0 < a) : 1 < a * b :=
+  (ha : 1 < a) (hb : 1 ≤ b) (a0 : 0 < a) : 1 < a * b :=
 lt_mul_of_lt_of_one_le ha hb a0
 
 /-- Assumes left covariance. -/
 lemma left.one_lt_mul_of_lt_of_lt [pos_mul_strict_mono α]
-  {a b : α} (ha : 1 < a) (hb : 1 < b) (a0 : 0 < a) : 1 < a * b :=
+  (ha : 1 < a) (hb : 1 < b) (a0 : 0 < a) : 1 < a * b :=
 lt_mul_of_lt_of_one_lt ha hb a0
 
 -- Lemmas in the form of `a ≤ 1 → b ≤ c → 0 < b → a * b ≤ c`,
@@ -387,47 +396,47 @@ lt_mul_of_lt_of_one_lt ha hb a0
 
 -- proven with `b0 : 0 ≤ b` as `mul_le_of_le_one_of_le'`
 lemma mul_le_of_le_one_of_le [mul_pos_mono α]
-  {a b c : α} (ha : a ≤ 1) (bc : b ≤ c) (b0 : 0 < b) : a * b ≤ c :=
+  (ha : a ≤ 1) (bc : b ≤ c) (b0 : 0 < b) : a * b ≤ c :=
 calc  a * b ≤ 1 * b : mul_le_mul_right' ha b0
         ... = b     : one_mul b
         ... ≤ c     : bc
 
 lemma mul_lt_of_lt_one_of_le [mul_pos_strict_mono α]
-  {a b c : α} (ha : a < 1) (bc : b ≤ c) (b0 : 0 < b) : a * b < c :=
+  (ha : a < 1) (bc : b ≤ c) (b0 : 0 < b) : a * b < c :=
 calc  a * b < 1 * b : mul_lt_mul_right' ha b0
         ... = b     : one_mul b
         ... ≤ c     : bc
 
 lemma mul_lt_of_le_one_of_lt [mul_pos_mono α]
-  {a b c : α} (ha : a ≤ 1) (hb : b < c) (b0 : 0 < b) : a * b < c :=
+  (ha : a ≤ 1) (hb : b < c) (b0 : 0 < b) : a * b < c :=
 calc  a * b ≤ 1 * b : mul_le_mul_right' ha b0
         ... = b     : one_mul b
         ... < c     : hb
 
 lemma mul_lt_of_lt_one_of_lt [mul_pos_strict_mono α]
-  {a b c : α} (ha : a < 1) (bc : b < c) (b0 : 0 < b) : a * b < c :=
+  (ha : a < 1) (bc : b < c) (b0 : 0 < b) : a * b < c :=
 calc  a * b < 1 * b : mul_lt_mul_right' ha b0
         ... = b     : one_mul b
         ... < c     : bc
 
 /-- Assumes right covariance. -/
 lemma right.mul_le_one_of_le_of_le [mul_pos_mono α]
-  {a b : α} (ha : a ≤ 1) (hb : b ≤ 1) (b0 : 0 < b) : a * b ≤ 1 :=
+  (ha : a ≤ 1) (hb : b ≤ 1) (b0 : 0 < b) : a * b ≤ 1 :=
 mul_le_of_le_one_of_le ha hb b0
 
 /-- Assumes right covariance. -/
 lemma right.mul_lt_one_of_lt_of_le [mul_pos_strict_mono α]
-  {a b : α} (ha : a < 1) (hb : b ≤ 1) (b0 : 0 < b) : a * b < 1 :=
+  (ha : a < 1) (hb : b ≤ 1) (b0 : 0 < b) : a * b < 1 :=
 mul_lt_of_lt_one_of_le ha hb b0
 
 /-- Assumes right covariance. -/
 lemma right.mul_lt_one_of_le_of_lt [mul_pos_mono α]
-  {a b : α} (ha : a ≤ 1) (hb : b < 1) (b0 : 0 < b) : a * b < 1 :=
+  (ha : a ≤ 1) (hb : b < 1) (b0 : 0 < b) : a * b < 1 :=
 mul_lt_of_le_one_of_lt ha hb b0
 
 /-- Assumes right covariance. -/
 lemma right.mul_lt_one_of_lt_of_lt [mul_pos_strict_mono α]
-  {a b : α} (ha : a < 1) (hb : b < 1) (b0 : 0 < b) : a * b < 1 :=
+  (ha : a < 1) (hb : b < 1) (b0 : 0 < b) : a * b < 1 :=
 mul_lt_of_lt_one_of_lt ha hb b0
 
 -- Lemmas in the form of `1 ≤ a → b ≤ c → 0 < c → b ≤ a * c`,
@@ -435,66 +444,66 @@ mul_lt_of_lt_one_of_lt ha hb b0
 
 -- proven with `c0 : 0 ≤ c` as `le_mul_of_one_le_of_le'`
 lemma le_mul_of_one_le_of_le [mul_pos_mono α]
-  {a b c : α} (ha : 1 ≤ a) (bc : b ≤ c) (c0 : 0 < c) : b ≤ a * c :=
+  (ha : 1 ≤ a) (bc : b ≤ c) (c0 : 0 < c) : b ≤ a * c :=
 calc  b ≤ c     : bc
     ... = 1 * c : (one_mul c).symm
     ... ≤ a * c : mul_le_mul_right' ha c0
 
 lemma lt_mul_of_one_lt_of_le [mul_pos_strict_mono α]
-  {a b c : α} (ha : 1 < a) (bc : b ≤ c) (c0 : 0 < c) : b < a * c :=
+  (ha : 1 < a) (bc : b ≤ c) (c0 : 0 < c) : b < a * c :=
 calc  b ≤ c     : bc
     ... = 1 * c : (one_mul c).symm
     ... < a * c : mul_lt_mul_right' ha c0
 
 lemma lt_mul_of_one_le_of_lt [mul_pos_mono α]
-  {a b c : α} (ha : 1 ≤ a) (bc : b < c) (c0 : 0 < c) : b < a * c :=
+  (ha : 1 ≤ a) (bc : b < c) (c0 : 0 < c) : b < a * c :=
 calc  b < c     : bc
     ... = 1 * c : (one_mul c).symm
     ... ≤ a * c : mul_le_mul_right' ha c0
 
 lemma lt_mul_of_one_lt_of_lt [mul_pos_strict_mono α]
-  {a b c : α} (ha : 1 < a) (bc : b < c) (c0 : 0 < c) : b < a * c :=
+  (ha : 1 < a) (bc : b < c) (c0 : 0 < c) : b < a * c :=
 calc  b < c     : bc
     ... = 1 * c : (one_mul c).symm
     ... < a * c : mul_lt_mul_right' ha c0
 
 /-- Assumes right covariance. -/
 lemma right.one_le_mul_of_le_of_le [mul_pos_mono α]
-  {a b : α} (ha : 1 ≤ a) (hb : 1 ≤ b) (b0 : 0 < b) : 1 ≤ a * b :=
+  (ha : 1 ≤ a) (hb : 1 ≤ b) (b0 : 0 < b) : 1 ≤ a * b :=
 le_mul_of_one_le_of_le ha hb b0
 
 /-- Assumes right covariance. -/
 lemma right.one_lt_mul_of_lt_of_le [mul_pos_strict_mono α]
-  {a b : α} (ha : 1 < a) (hb : 1 ≤ b) (b0 : 0 < b) : 1 < a * b :=
+  (ha : 1 < a) (hb : 1 ≤ b) (b0 : 0 < b) : 1 < a * b :=
 lt_mul_of_one_lt_of_le ha hb b0
 
 /-- Assumes right covariance. -/
 lemma right.one_lt_mul_of_le_of_lt [mul_pos_mono α]
-  {a b : α} (ha : 1 ≤ a) (hb : 1 < b) (b0 : 0 < b) : 1 < a * b :=
+  (ha : 1 ≤ a) (hb : 1 < b) (b0 : 0 < b) : 1 < a * b :=
 lt_mul_of_one_le_of_lt ha hb b0
 
 /-- Assumes right covariance. -/
 lemma right.one_lt_mul_of_lt_of_lt [mul_pos_strict_mono α]
-  {a b : α} (ha : 1 < a) (hb : 1 < b) (b0 : 0 < b) : 1 < a * b :=
+  (ha : 1 < a) (hb : 1 < b) (b0 : 0 < b) : 1 < a * b :=
 lt_mul_of_one_lt_of_lt ha hb b0
 
 -- proven with `a0 : 0 ≤ a` as `mul_le_of_le_one_right'`
-lemma mul_le_of_le_one_right [pos_mul_mono α] {a b : α} (h : b ≤ 1) (a0 : 0 < a) :
+lemma mul_le_of_le_one_right [pos_mul_mono α] (h : b ≤ 1) (a0 : 0 < a) :
   a * b ≤ a :=
 mul_le_of_le_of_le_one le_rfl h a0
 
 -- proven with `a0 : 0 ≤ a` as `le_mul_of_one_le_right'`
-lemma le_mul_of_one_le_right [pos_mul_mono α] {a b : α} (h : 1 ≤ b) (a0 : 0 < a) :
+lemma le_mul_of_one_le_right [pos_mul_mono α] (h : 1 ≤ b) (a0 : 0 < a) :
   a ≤ a * b :=
 le_mul_of_le_of_one_le le_rfl h a0
 
 -- proven with `b0 : 0 ≤ b` as `mul_le_of_le_one_left'`
-lemma mul_le_of_le_one_left [mul_pos_mono α] {a b : α} (h : a ≤ 1) (b0 : 0 < b) :
+lemma mul_le_of_le_one_left [mul_pos_mono α] (h : a ≤ 1) (b0 : 0 < b) :
   a * b ≤ b :=
 mul_le_of_le_one_of_le h le_rfl b0
 
 -- proven with `b0 : 0 ≤ b` as `le_mul_of_one_le_left'`
-lemma le_mul_of_one_le_left [mul_pos_mono α] {a b : α} (h : 1 ≤ a) (b0 : 0 < b) :
+lemma le_mul_of_one_le_left [mul_pos_mono α] (h : 1 ≤ a) (b0 : 0 < b) :
   b ≤ a * b :=
 le_mul_of_one_le_of_le h le_rfl b0
 
@@ -529,54 +538,54 @@ section partial_order
 variables [partial_order α]
 
 lemma mul_le_of_le_of_le_one' [pos_mul_mono α]
-  {a b c : α} (bc : b ≤ c) (ha : a ≤ 1) (b0 : 0 ≤ b) : b * a ≤ c :=
+  (bc : b ≤ c) (ha : a ≤ 1) (b0 : 0 ≤ b) : b * a ≤ c :=
 b0.lt_or_eq.elim (mul_le_of_le_of_le_one bc ha) (λ h, by rw [← h, zero_mul]; exact b0.trans bc)
 
 /-- Assumes left covariance. -/
 lemma left.mul_le_one_of_le_of_le' [pos_mul_mono α]
-  {a b : α} (ha : a ≤ 1) (hb : b ≤ 1) (a0 : 0 ≤ a) : a * b ≤ 1 :=
+  (ha : a ≤ 1) (hb : b ≤ 1) (a0 : 0 ≤ a) : a * b ≤ 1 :=
 mul_le_of_le_of_le_one' ha hb a0
 
 lemma le_mul_of_le_of_one_le' [pos_mul_mono α]
-  {a b c : α} (bc : b ≤ c) (ha : 1 ≤ a) (c0 : 0 ≤ c) : b ≤ c * a :=
+  (bc : b ≤ c) (ha : 1 ≤ a) (c0 : 0 ≤ c) : b ≤ c * a :=
 c0.lt_or_eq.elim (le_mul_of_le_of_one_le bc ha) (λ h, by rw [← h, zero_mul] at *; exact bc)
 
 /-- Assumes left covariance. -/
 lemma left.one_le_mul_of_le_of_le' [pos_mul_mono α]
-  {a b : α} (ha : 1 ≤ a) (hb : 1 ≤ b) (a0 : 0 ≤ a) : 1 ≤ a * b :=
+  (ha : 1 ≤ a) (hb : 1 ≤ b) (a0 : 0 ≤ a) : 1 ≤ a * b :=
 le_mul_of_le_of_one_le' ha hb a0
 
 lemma mul_le_of_le_one_of_le' [mul_pos_mono α]
-  {a b c : α} (ha : a ≤ 1) (bc : b ≤ c) (b0 : 0 ≤ b) : a * b ≤ c :=
+  (ha : a ≤ 1) (bc : b ≤ c) (b0 : 0 ≤ b) : a * b ≤ c :=
 b0.lt_or_eq.elim (mul_le_of_le_one_of_le ha bc) (λ h, by rw [← h, mul_zero] at *; exact bc)
 
 /-- Assumes right covariance. -/
 lemma right.mul_le_one_of_le_of_le' [mul_pos_mono α]
-  {a b : α} (ha : a ≤ 1) (hb : b ≤ 1) (b0 : 0 < b) : a * b ≤ 1 :=
+  (ha : a ≤ 1) (hb : b ≤ 1) (b0 : 0 < b) : a * b ≤ 1 :=
 mul_le_of_le_one_of_le ha hb b0
 
 lemma le_mul_of_one_le_of_le' [mul_pos_mono α]
-  {a b c : α} (ha : 1 ≤ a) (bc : b ≤ c) (c0 : 0 ≤ c) : b ≤ a * c :=
+  (ha : 1 ≤ a) (bc : b ≤ c) (c0 : 0 ≤ c) : b ≤ a * c :=
 c0.lt_or_eq.elim (le_mul_of_one_le_of_le ha bc) (λ h, by rw [← h, mul_zero] at *; exact bc)
 
 /-- Assumes right covariance. -/
 lemma right.one_le_mul_of_le_of_le' [mul_pos_mono α]
-  {a b : α} (ha : 1 ≤ a) (hb : 1 ≤ b) (b0 : 0 ≤ b) : 1 ≤ a * b :=
+  (ha : 1 ≤ a) (hb : 1 ≤ b) (b0 : 0 ≤ b) : 1 ≤ a * b :=
 le_mul_of_one_le_of_le' ha hb b0
 
-lemma mul_le_of_le_one_right' [pos_mul_mono α] {a b : α} (h : b ≤ 1) (a0 : 0 ≤ a) :
+lemma mul_le_of_le_one_right' [pos_mul_mono α] (h : b ≤ 1) (a0 : 0 ≤ a) :
   a * b ≤ a :=
 mul_le_of_le_of_le_one' le_rfl h a0
 
-lemma le_mul_of_one_le_right' [pos_mul_mono α] {a b : α} (h : 1 ≤ b) (a0 : 0 ≤ a) :
+lemma le_mul_of_one_le_right' [pos_mul_mono α] (h : 1 ≤ b) (a0 : 0 ≤ a) :
   a ≤ a * b :=
 le_mul_of_le_of_one_le' le_rfl h a0
 
-lemma mul_le_of_le_one_left' [mul_pos_mono α] {a b : α} (h : a ≤ 1) (b0 : 0 ≤ b) :
+lemma mul_le_of_le_one_left' [mul_pos_mono α] (h : a ≤ 1) (b0 : 0 ≤ b) :
   a * b ≤ b :=
 mul_le_of_le_one_of_le' h le_rfl b0
 
-lemma le_mul_of_one_le_left' [mul_pos_mono α] {a b : α} (h : 1 ≤ a) (b0 : 0 ≤ b) :
+lemma le_mul_of_one_le_left' [mul_pos_mono α] (h : 1 ≤ a) (b0 : 0 ≤ b) :
   b ≤ a * b :=
 le_mul_of_one_le_of_le' h le_rfl b0
 

--- a/src/algebra/order/monoid_lemmas_zero_lt.lean
+++ b/src/algebra/order/monoid_lemmas_zero_lt.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2022 Damiano Testa. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Damiano Testa
+Authors: Damiano Testa, Yuyang Zhao
 -/
 import algebra.covariant_and_contravariant
 import algebra.group_with_zero.defs
@@ -217,4 +217,369 @@ begin
 end
 
 end mul_zero_class_partial_order
+
+section mul_one_class
+variables [mul_one_class α] [has_zero α]
+
+section preorder
+variables [preorder α]
+
+-- Lemmas in the form of `a ≤ a * b ↔ 1 ≤ b` and `a * b ≤ a ↔ b ≤ 1`,
+-- which assume left covariance.
+
+@[simp]
+lemma le_mul_iff_one_le_right
+  [pos_mul_mono α] [pos_mul_mono_rev α]
+  {a b : α} (a0 : 0 < a) :
+  a ≤ a * b ↔ 1 ≤ b :=
+iff.trans (by rw [mul_one]) (mul_le_mul_iff_left a0)
+
+@[simp]
+lemma lt_mul_iff_one_lt_right
+  [pos_mul_strict_mono α] [pos_mul_reflect_lt α]
+  {a b : α} (a0 : 0 < a) :
+  a < a * b ↔ 1 < b :=
+iff.trans (by rw [mul_one]) (mul_lt_mul_iff_left a0)
+
+@[simp]
+lemma mul_le_iff_le_one_right
+  [pos_mul_mono α] [pos_mul_mono_rev α]
+  {a b : α} (a0 : 0 < a) :
+  a * b ≤ a ↔ b ≤ 1 :=
+iff.trans (by rw [mul_one]) (mul_le_mul_iff_left a0)
+
+@[simp]
+lemma mul_lt_iff_lt_one_left
+  [pos_mul_strict_mono α] [pos_mul_reflect_lt α]
+  {a b : α} (a0 : 0 < a) :
+  a * b < a ↔ b < 1 :=
+iff.trans (by rw [mul_one]) (mul_lt_mul_iff_left a0)
+
+-- Lemmas in the form of `a ≤ b * a ↔ 1 ≤ b` and `a * b ≤ b ↔ a ≤ 1`,
+-- which assume right covariance.
+
+@[simp]
+lemma le_mul_iff_one_le_left
+  [mul_pos_mono α] [mul_pos_mono_rev α]
+  {a b : α} (a0 : 0 < a) :
+  a ≤ b * a ↔ 1 ≤ b :=
+iff.trans (by rw [one_mul]) (mul_le_mul_iff_right a0)
+
+@[simp]
+lemma lt_mul_iff_one_lt_left
+  [mul_pos_strict_mono α] [mul_pos_reflect_lt α]
+  {a b : α} (a0 : 0 < a) :
+  a < b * a ↔ 1 < b :=
+iff.trans (by rw [one_mul]) (mul_lt_mul_iff_right a0)
+
+@[simp]
+lemma mul_le_iff_le_one_left
+  [mul_pos_mono α] [mul_pos_mono_rev α]
+  {a b : α} (b0 : 0 < b) :
+  a * b ≤ b ↔ a ≤ 1 :=
+iff.trans (by rw [one_mul]) (mul_le_mul_iff_right b0)
+
+@[simp]
+lemma mul_lt_iff_lt_one_right
+  [mul_pos_strict_mono α] [mul_pos_reflect_lt α]
+  {a b : α} (b0 : 0 < b) :
+  a * b < b ↔ a < 1 :=
+iff.trans (by rw [one_mul]) (mul_lt_mul_iff_right b0)
+
+-- Lemmas in the form of `b ≤ c → a ≤ 1 → 0 < b → b * a ≤ c`,
+-- which assume left covariance.
+
+-- proven with `b0 : 0 ≤ b` as `mul_le_of_le_of_le_one'`
+lemma mul_le_of_le_of_le_one [pos_mul_mono α]
+  {a b c : α} (bc : b ≤ c) (ha : a ≤ 1) (b0 : 0 < b) : b * a ≤ c :=
+calc  b * a ≤ b * 1 : mul_le_mul_left' ha b0
+        ... = b     : mul_one b
+        ... ≤ c     : bc
+
+lemma mul_lt_of_le_of_lt_one [pos_mul_strict_mono α]
+  {a b c : α} (bc : b ≤ c) (ha : a < 1) (b0 : 0 < b) : b * a < c :=
+calc  b * a < b * 1 : mul_lt_mul_left' ha b0
+        ... = b     : mul_one b
+        ... ≤ c     : bc
+
+lemma mul_lt_of_lt_of_le_one [pos_mul_mono α]
+  {a b c : α} (bc : b < c) (ha : a ≤ 1) (b0 : 0 < b) : b * a < c :=
+calc  b * a ≤ b * 1 : mul_le_mul_left' ha b0
+        ... = b     : mul_one b
+        ... < c     : bc
+
+lemma mul_lt_of_lt_of_lt_one [pos_mul_strict_mono α]
+  {a b c : α} (bc : b < c) (ha : a < 1) (b0 : 0 < b) : b * a < c :=
+calc  b * a < b * 1 : mul_lt_mul_left' ha b0
+        ... = b     : mul_one b
+        ... < c     : bc
+
+/-- Assumes left covariance. -/
+lemma left.mul_le_one_of_le_of_le [pos_mul_mono α]
+  {a b : α} (ha : a ≤ 1) (hb : b ≤ 1) (a0 : 0 < a) : a * b ≤ 1 :=
+mul_le_of_le_of_le_one ha hb a0
+
+/-- Assumes left covariance. -/
+lemma left.mul_lt_one_of_le_of_lt [pos_mul_strict_mono α]
+  {a b : α} (ha : a ≤ 1) (hb : b < 1) (a0 : 0 < a) : a * b < 1 :=
+mul_lt_of_le_of_lt_one ha hb a0
+
+/-- Assumes left covariance. -/
+lemma left.mul_lt_one_of_lt_of_le [pos_mul_mono α]
+  {a b : α} (ha : a < 1) (hb : b ≤ 1) (a0 : 0 < a) : a * b < 1 :=
+mul_lt_of_lt_of_le_one ha hb a0
+
+/-- Assumes left covariance. -/
+lemma left.mul_lt_one_of_lt_of_lt [pos_mul_strict_mono α]
+  {a b : α} (ha : a < 1) (hb : b < 1) (a0 : 0 < a) : a * b < 1 :=
+mul_lt_of_lt_of_lt_one ha hb a0
+
+-- Lemmas in the form of `b ≤ c → 1 ≤ a → 0 < c → b ≤ c * a`,
+-- which assume left covariance.
+
+-- proven with `c0 : 0 ≤ c` as `le_mul_of_le_of_one_le'`
+lemma le_mul_of_le_of_one_le [pos_mul_mono α]
+  {a b c : α} (bc : b ≤ c) (ha : 1 ≤ a) (c0 : 0 < c) : b ≤ c * a :=
+calc  b ≤ c     : bc
+    ... = c * 1 : (mul_one c).symm
+    ... ≤ c * a : mul_le_mul_left' ha c0
+
+lemma lt_mul_of_le_of_one_lt [pos_mul_strict_mono α]
+  {a b c : α} (bc : b ≤ c) (ha : 1 < a) (c0 : 0 < c) : b < c * a :=
+calc  b ≤ c     : bc
+    ... = c * 1 : (mul_one c).symm
+    ... < c * a : mul_lt_mul_left' ha c0
+
+lemma lt_mul_of_lt_of_one_le [pos_mul_mono α]
+  {a b c : α} (bc : b < c) (ha : 1 ≤ a) (c0 : 0 < c) : b < c * a :=
+calc  b < c     : bc
+    ... = c * 1 : (mul_one c).symm
+    ... ≤ c * a : mul_le_mul_left' ha c0
+
+lemma lt_mul_of_lt_of_one_lt [pos_mul_strict_mono α]
+  {a b c : α} (bc : b < c) (ha : 1 < a) (c0 : 0 < c) : b < c * a :=
+calc  b < c     : bc
+    ... = c * 1 : (mul_one _).symm
+    ... < c * a : mul_lt_mul_left' ha c0
+
+/-- Assumes left covariance. -/
+lemma left.one_le_mul_of_le_of_le [pos_mul_mono α]
+  {a b : α} (ha : 1 ≤ a) (hb : 1 ≤ b) (a0 : 0 < a) : 1 ≤ a * b :=
+le_mul_of_le_of_one_le ha hb a0
+
+/-- Assumes left covariance. -/
+lemma left.one_lt_mul_of_le_of_lt [pos_mul_strict_mono α]
+  {a b : α} (ha : 1 ≤ a) (hb : 1 < b) (a0 : 0 < a) : 1 < a * b :=
+lt_mul_of_le_of_one_lt ha hb a0
+
+/-- Assumes left covariance. -/
+lemma left.one_lt_mul_of_lt_of_le [pos_mul_mono α]
+  {a b : α} (ha : 1 < a) (hb : 1 ≤ b) (a0 : 0 < a) : 1 < a * b :=
+lt_mul_of_lt_of_one_le ha hb a0
+
+/-- Assumes left covariance. -/
+lemma left.one_lt_mul_of_lt_of_lt [pos_mul_strict_mono α]
+  {a b : α} (ha : 1 < a) (hb : 1 < b) (a0 : 0 < a) : 1 < a * b :=
+lt_mul_of_lt_of_one_lt ha hb a0
+
+-- Lemmas in the form of `a ≤ 1 → b ≤ c → 0 < b → a * b ≤ c`,
+-- which assume right covariance.
+
+-- proven with `b0 : 0 ≤ b` as `mul_le_of_le_one_of_le'`
+lemma mul_le_of_le_one_of_le [mul_pos_mono α]
+  {a b c : α} (ha : a ≤ 1) (bc : b ≤ c) (b0 : 0 < b) : a * b ≤ c :=
+calc  a * b ≤ 1 * b : mul_le_mul_right' ha b0
+        ... = b     : one_mul b
+        ... ≤ c     : bc
+
+lemma mul_lt_of_lt_one_of_le [mul_pos_strict_mono α]
+  {a b c : α} (ha : a < 1) (bc : b ≤ c) (b0 : 0 < b) : a * b < c :=
+calc  a * b < 1 * b : mul_lt_mul_right' ha b0
+        ... = b     : one_mul b
+        ... ≤ c     : bc
+
+lemma mul_lt_of_le_one_of_lt [mul_pos_mono α]
+  {a b c : α} (ha : a ≤ 1) (hb : b < c) (b0 : 0 < b) : a * b < c :=
+calc  a * b ≤ 1 * b : mul_le_mul_right' ha b0
+        ... = b     : one_mul b
+        ... < c     : hb
+
+lemma mul_lt_of_lt_one_of_lt [mul_pos_strict_mono α]
+  {a b c : α} (ha : a < 1) (bc : b < c) (b0 : 0 < b) : a * b < c :=
+calc  a * b < 1 * b : mul_lt_mul_right' ha b0
+        ... = b     : one_mul b
+        ... < c     : bc
+
+/-- Assumes right covariance. -/
+lemma right.mul_le_one_of_le_of_le [mul_pos_mono α]
+  {a b : α} (ha : a ≤ 1) (hb : b ≤ 1) (b0 : 0 < b) : a * b ≤ 1 :=
+mul_le_of_le_one_of_le ha hb b0
+
+/-- Assumes right covariance. -/
+lemma right.mul_lt_one_of_lt_of_le [mul_pos_strict_mono α]
+  {a b : α} (ha : a < 1) (hb : b ≤ 1) (b0 : 0 < b) : a * b < 1 :=
+mul_lt_of_lt_one_of_le ha hb b0
+
+/-- Assumes right covariance. -/
+lemma right.mul_lt_one_of_le_of_lt [mul_pos_mono α]
+  {a b : α} (ha : a ≤ 1) (hb : b < 1) (b0 : 0 < b) : a * b < 1 :=
+mul_lt_of_le_one_of_lt ha hb b0
+
+/-- Assumes right covariance. -/
+lemma right.mul_lt_one_of_lt_of_lt [mul_pos_strict_mono α]
+  {a b : α} (ha : a < 1) (hb : b < 1) (b0 : 0 < b) : a * b < 1 :=
+mul_lt_of_lt_one_of_lt ha hb b0
+
+-- Lemmas in the form of `1 ≤ a → b ≤ c → 0 < c → b ≤ a * c`,
+-- which assume right covariance.
+
+-- proven with `c0 : 0 ≤ c` as `le_mul_of_one_le_of_le'`
+lemma le_mul_of_one_le_of_le [mul_pos_mono α]
+  {a b c : α} (ha : 1 ≤ a) (bc : b ≤ c) (c0 : 0 < c) : b ≤ a * c :=
+calc  b ≤ c     : bc
+    ... = 1 * c : (one_mul c).symm
+    ... ≤ a * c : mul_le_mul_right' ha c0
+
+lemma lt_mul_of_one_lt_of_le [mul_pos_strict_mono α]
+  {a b c : α} (ha : 1 < a) (bc : b ≤ c) (c0 : 0 < c) : b < a * c :=
+calc  b ≤ c     : bc
+    ... = 1 * c : (one_mul c).symm
+    ... < a * c : mul_lt_mul_right' ha c0
+
+lemma lt_mul_of_one_le_of_lt [mul_pos_mono α]
+  {a b c : α} (ha : 1 ≤ a) (bc : b < c) (c0 : 0 < c) : b < a * c :=
+calc  b < c     : bc
+    ... = 1 * c : (one_mul c).symm
+    ... ≤ a * c : mul_le_mul_right' ha c0
+
+lemma lt_mul_of_one_lt_of_lt [mul_pos_strict_mono α]
+  {a b c : α} (ha : 1 < a) (bc : b < c) (c0 : 0 < c) : b < a * c :=
+calc  b < c     : bc
+    ... = 1 * c : (one_mul c).symm
+    ... < a * c : mul_lt_mul_right' ha c0
+
+/-- Assumes right covariance. -/
+lemma right.one_le_mul_of_le_of_le [mul_pos_mono α]
+  {a b : α} (ha : 1 ≤ a) (hb : 1 ≤ b) (b0 : 0 < b) : 1 ≤ a * b :=
+le_mul_of_one_le_of_le ha hb b0
+
+/-- Assumes right covariance. -/
+lemma right.one_lt_mul_of_lt_of_le [mul_pos_strict_mono α]
+  {a b : α} (ha : 1 < a) (hb : 1 ≤ b) (b0 : 0 < b) : 1 < a * b :=
+lt_mul_of_one_lt_of_le ha hb b0
+
+/-- Assumes right covariance. -/
+lemma right.one_lt_mul_of_le_of_lt [mul_pos_mono α]
+  {a b : α} (ha : 1 ≤ a) (hb : 1 < b) (b0 : 0 < b) : 1 < a * b :=
+lt_mul_of_one_le_of_lt ha hb b0
+
+/-- Assumes right covariance. -/
+lemma right.one_lt_mul_of_lt_of_lt [mul_pos_strict_mono α]
+  {a b : α} (ha : 1 < a) (hb : 1 < b) (b0 : 0 < b) : 1 < a * b :=
+lt_mul_of_one_lt_of_lt ha hb b0
+
+-- proven with `a0 : 0 ≤ a` as `mul_le_of_le_one_right'`
+lemma mul_le_of_le_one_right [pos_mul_mono α] {a b : α} (h : b ≤ 1) (a0 : 0 < a) :
+  a * b ≤ a :=
+mul_le_of_le_of_le_one le_rfl h a0
+
+-- proven with `a0 : 0 ≤ a` as `le_mul_of_one_le_right'`
+lemma le_mul_of_one_le_right [pos_mul_mono α] {a b : α} (h : 1 ≤ b) (a0 : 0 < a) :
+  a ≤ a * b :=
+le_mul_of_le_of_one_le le_rfl h a0
+
+-- proven with `b0 : 0 ≤ b` as `mul_le_of_le_one_left'`
+lemma mul_le_of_le_one_left [mul_pos_mono α] {a b : α} (h : a ≤ 1) (b0 : 0 < b) :
+  a * b ≤ b :=
+mul_le_of_le_one_of_le h le_rfl b0
+
+-- proven with `b0 : 0 ≤ b` as `le_mul_of_one_le_left'`
+lemma le_mul_of_one_le_left [mul_pos_mono α] {a b : α} (h : 1 ≤ a) (b0 : 0 < b) :
+  b ≤ a * b :=
+le_mul_of_one_le_of_le h le_rfl b0
+
+end preorder
+
+section linear_order
+variables [linear_order α]
+
+lemma exists_square_le [pos_mul_strict_mono α]
+  (a : α) (a0 : 0 < a) : ∃ (b : α), b * b ≤ a :=
+begin
+  by_cases h : a < 1,
+  { use a,
+    have : a*a < a*1,
+    exact mul_lt_mul_left' h a0,
+    rw mul_one at this,
+    exact le_of_lt this },
+  { use 1,
+    push_neg at h,
+    rwa mul_one }
+end
+
+end linear_order
+
+end mul_one_class
+
+section mul_zero_one_class
+variables [mul_zero_one_class α]
+
+section partial_order
+variables [partial_order α]
+
+lemma mul_le_of_le_of_le_one' [pos_mul_mono α]
+  {a b c : α} (bc : b ≤ c) (ha : a ≤ 1) (b0 : 0 ≤ b) : b * a ≤ c :=
+b0.lt_or_eq.elim (mul_le_of_le_of_le_one bc ha) (λ h, by rw [← h, zero_mul]; exact b0.trans bc)
+
+/-- Assumes left covariance. -/
+lemma left.mul_le_one_of_le_of_le' [pos_mul_mono α]
+  {a b : α} (ha : a ≤ 1) (hb : b ≤ 1) (a0 : 0 ≤ a) : a * b ≤ 1 :=
+mul_le_of_le_of_le_one' ha hb a0
+
+lemma le_mul_of_le_of_one_le' [pos_mul_mono α]
+  {a b c : α} (bc : b ≤ c) (ha : 1 ≤ a) (c0 : 0 ≤ c) : b ≤ c * a :=
+c0.lt_or_eq.elim (le_mul_of_le_of_one_le bc ha) (λ h, by rw [← h, zero_mul] at *; exact bc)
+
+/-- Assumes left covariance. -/
+lemma left.one_le_mul_of_le_of_le' [pos_mul_mono α]
+  {a b : α} (ha : 1 ≤ a) (hb : 1 ≤ b) (a0 : 0 ≤ a) : 1 ≤ a * b :=
+le_mul_of_le_of_one_le' ha hb a0
+
+lemma mul_le_of_le_one_of_le' [mul_pos_mono α]
+  {a b c : α} (ha : a ≤ 1) (bc : b ≤ c) (b0 : 0 ≤ b) : a * b ≤ c :=
+b0.lt_or_eq.elim (mul_le_of_le_one_of_le ha bc) (λ h, by rw [← h, mul_zero] at *; exact bc)
+
+/-- Assumes right covariance. -/
+lemma right.mul_le_one_of_le_of_le' [mul_pos_mono α]
+  {a b : α} (ha : a ≤ 1) (hb : b ≤ 1) (b0 : 0 < b) : a * b ≤ 1 :=
+mul_le_of_le_one_of_le ha hb b0
+
+lemma le_mul_of_one_le_of_le' [mul_pos_mono α]
+  {a b c : α} (ha : 1 ≤ a) (bc : b ≤ c) (c0 : 0 ≤ c) : b ≤ a * c :=
+c0.lt_or_eq.elim (le_mul_of_one_le_of_le ha bc) (λ h, by rw [← h, mul_zero] at *; exact bc)
+
+/-- Assumes right covariance. -/
+lemma right.one_le_mul_of_le_of_le' [mul_pos_mono α]
+  {a b : α} (ha : 1 ≤ a) (hb : 1 ≤ b) (b0 : 0 ≤ b) : 1 ≤ a * b :=
+le_mul_of_one_le_of_le' ha hb b0
+
+lemma mul_le_of_le_one_right' [pos_mul_mono α] {a b : α} (h : b ≤ 1) (a0 : 0 ≤ a) :
+  a * b ≤ a :=
+mul_le_of_le_of_le_one' le_rfl h a0
+
+lemma le_mul_of_one_le_right' [pos_mul_mono α] {a b : α} (h : 1 ≤ b) (a0 : 0 ≤ a) :
+  a ≤ a * b :=
+le_mul_of_le_of_one_le' le_rfl h a0
+
+lemma mul_le_of_le_one_left' [mul_pos_mono α] {a b : α} (h : a ≤ 1) (b0 : 0 ≤ b) :
+  a * b ≤ b :=
+mul_le_of_le_one_of_le' h le_rfl b0
+
+lemma le_mul_of_one_le_left' [mul_pos_mono α] {a b : α} (h : 1 ≤ a) (b0 : 0 ≤ b) :
+  b ≤ a * b :=
+le_mul_of_one_le_of_le' h le_rfl b0
+
+end partial_order
+
+end mul_zero_one_class
 end zero_lt

--- a/src/algebra/order/monoid_lemmas_zero_lt.lean
+++ b/src/algebra/order/monoid_lemmas_zero_lt.lean
@@ -503,6 +503,7 @@ end preorder
 section linear_order
 variables [linear_order α]
 
+-- proven with `a0 : 0 ≤ a` as `exists_square_le'`
 lemma exists_square_le [pos_mul_strict_mono α]
   (a : α) (a0 : 0 < a) : ∃ (b : α), b * b ≤ a :=
 begin
@@ -580,6 +581,15 @@ lemma le_mul_of_one_le_left' [mul_pos_mono α] {a b : α} (h : 1 ≤ a) (b0 : 0 
 le_mul_of_one_le_of_le' h le_rfl b0
 
 end partial_order
+
+section linear_order
+variables [linear_order α]
+
+lemma exists_square_le' [pos_mul_strict_mono α]
+  (a : α) (a0 : 0 ≤ a) : ∃ (b : α), b * b ≤ a :=
+a0.lt_or_eq.elim (exists_square_le a) (λ h, by rw [← h]; exact ⟨0, by simp⟩)
+
+end linear_order
 
 end mul_zero_one_class
 end zero_lt

--- a/src/algebra/order/monoid_lemmas_zero_lt.lean
+++ b/src/algebra/order/monoid_lemmas_zero_lt.lean
@@ -258,7 +258,7 @@ lemma mul_le_iff_le_one_right
 iff.trans (by rw [mul_one]) (mul_le_mul_iff_left a0)
 
 @[simp]
-lemma mul_lt_iff_lt_one_left
+lemma mul_lt_iff_lt_one_right
   [pos_mul_strict_mono α] [pos_mul_reflect_lt α]
   (a0 : 0 < a) :
   a * b < a ↔ b < 1 :=
@@ -289,7 +289,7 @@ lemma mul_le_iff_le_one_left
 iff.trans (by rw [one_mul]) (mul_le_mul_iff_right b0)
 
 @[simp]
-lemma mul_lt_iff_lt_one_right
+lemma mul_lt_iff_lt_one_left
   [mul_pos_strict_mono α] [mul_pos_reflect_lt α]
   (b0 : 0 < b) :
   a * b < b ↔ a < 1 :=
@@ -514,7 +514,7 @@ variables [linear_order α]
 
 -- proven with `a0 : 0 ≤ a` as `exists_square_le'`
 lemma exists_square_le [pos_mul_strict_mono α]
-  (a : α) (a0 : 0 < a) : ∃ (b : α), b * b ≤ a :=
+  (a0 : 0 < a) : ∃ (b : α), b * b ≤ a :=
 begin
   by_cases h : a < 1,
   { use a,
@@ -595,8 +595,8 @@ section linear_order
 variables [linear_order α]
 
 lemma exists_square_le' [pos_mul_strict_mono α]
-  (a : α) (a0 : 0 ≤ a) : ∃ (b : α), b * b ≤ a :=
-a0.lt_or_eq.elim (exists_square_le a) (λ h, by rw [← h]; exact ⟨0, by simp⟩)
+  (a0 : 0 ≤ a) : ∃ (b : α), b * b ≤ a :=
+a0.lt_or_eq.elim exists_square_le (λ h, by rw [← h]; exact ⟨0, by simp⟩)
 
 end linear_order
 


### PR DESCRIPTION
Although the names of these lemmas are from `algebra.order.monoid_lemmas`, many of the lemmas in `algebra.order.monoid_lemmas` have incorrect names, and some others may not be appropriate. Also, many lemmas are missing in `algebra.order.monoid_lemmas`. It may be necessary to make some renames and additions.



---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
