### PR TITLE
[Merged by Bors] - feat(combinatorics/simple_graph/regularity/bound): Numerical bounds for Szemerédi's regularity lemma

### DIFF
--- a/src/algebra/order/field.lean
+++ b/src/algebra/order/field.lean
@@ -408,6 +408,9 @@ by simpa only [div_one] using div_le_div_of_le_left ha zero_lt_one hb
 lemma div_lt_self (ha : 0 < a) (hb : 1 < b) : a / b < a :=
 by simpa only [div_one] using div_lt_div_of_lt_left ha zero_lt_one hb
 
+lemma le_div_self (ha : 0 ≤ a) (hb₀ : 0 < b) (hb₁ : b ≤ 1) : a ≤ a / b :=
+by simpa only [div_one] using div_le_div_of_le_left ha hb₀ hb₁
+
 lemma one_le_div (hb : 0 < b) : 1 ≤ a / b ↔ b ≤ a :=
 by rw [le_div_iff hb, one_mul]
 

--- a/src/combinatorics/simple_graph/regularity/bound.lean
+++ b/src/combinatorics/simple_graph/regularity/bound.lean
@@ -13,40 +13,40 @@ This file gathers the numerical facts required by the proof of Szemerédi's regu
 
 ## Main declarations
 
-* `szemeredi.exp_bound`: During the inductive step, a partition of size `n` is blown to size at most
-  `exp_bound n`.
-* `szemeredi.initial_bound`: The size of the partition we start the induction with.
-* `szemeredi.bound`: The upper bound on the size of the partition our version of Szemerédi's
-  regularity lemma produces.
+* `szemeredi_regularity.step_bound`: During the inductive step, a partition of size `n` is blown to
+  size at most `step_bound n`.
+* `szemeredi_regularity.initial_bound`: The size of the partition we start the induction with.
+* `szemeredi_regularity.bound`: The upper bound on the size of the partition produced by our version
+  of Szemerédi's regularity lemma.
 -/
 
 open finset fintype function real
 
-namespace szemeredi
+namespace szemeredi_regularity
 
 /-- Auxiliary function for Szemerédi's regularity lemma. Blowing up a partition of size `n` during
-the induction results in a partition of size at most `exp_bound n`. -/
-def exp_bound (n : ℕ) : ℕ := n * 4 ^ n
+the induction results in a partition of size at most `step_bound n`. -/
+def step_bound (n : ℕ) : ℕ := n * 4 ^ n
 
-lemma le_exp_bound : id ≤ exp_bound := λ n, nat.le_mul_of_pos_right $ pow_pos (by norm_num) n
+lemma le_step_bound : id ≤ step_bound := λ n, nat.le_mul_of_pos_right $ pow_pos (by norm_num) n
 
-lemma exp_bound_mono : monotone exp_bound :=
+lemma step_bound_mono : monotone step_bound :=
 λ a b h, nat.mul_le_mul h $ nat.pow_le_pow_of_le_right (by norm_num) h
 
-lemma exp_bound_pos_iff {n : ℕ} : 0 < exp_bound n ↔ 0 < n :=
+lemma step_bound_pos_iff {n : ℕ} : 0 < step_bound n ↔ 0 < n :=
 zero_lt_mul_right $ pow_pos (by norm_num) _
 
-alias exp_bound_pos_iff ↔ _ szemeredi.exp_bound_pos
+alias step_bound_pos_iff ↔ _ szemeredi_regularity.step_bound_pos
 
 variables {α : Type*} [decidable_eq α] [fintype α] {P : finpartition (univ : finset α)}
   {u : finset α} {ε : ℝ}
 
-local notation `m` := (card α/exp_bound P.parts.card : ℕ)
+local notation `m` := (card α/step_bound P.parts.card : ℕ)
 local notation `a` := (card α/P.parts.card - m * 4^P.parts.card : ℕ)
 
 lemma m_pos [nonempty α] (hPα : P.parts.card * 16^P.parts.card ≤ card α) : 0 < m :=
 nat.div_pos ((nat.mul_le_mul_left _ $ nat.pow_le_pow_of_le_left (by norm_num) _).trans hPα) $
-  exp_bound_pos (P.parts_nonempty $ univ_nonempty.ne_empty).card_pos
+  step_bound_pos (P.parts_nonempty $ univ_nonempty.ne_empty).card_pos
 
 lemma m_coe_pos [nonempty α] (hPα : P.parts.card * 16^P.parts.card ≤ card α) : (0 : ℝ) < m :=
 nat.cast_pos.2 $ m_pos hPα
@@ -70,8 +70,8 @@ lemma hundred_div_ε_pow_five_le_m [nonempty α] (hPα : P.parts.card * 16^P.par
 (div_le_of_nonneg_of_le_mul (eps_pow_five_pos hPε).le four_pow_pos.le hPε).trans
 begin
   norm_cast,
-  rwa [nat.le_div_iff_mul_le'(exp_bound_pos (P.parts_nonempty $ univ_nonempty.ne_empty).card_pos),
-    exp_bound, mul_left_comm, ←mul_pow],
+  rwa [nat.le_div_iff_mul_le'(step_bound_pos (P.parts_nonempty $ univ_nonempty.ne_empty).card_pos),
+    step_bound, mul_left_comm, ←mul_pow],
 end
 
 lemma hundred_le_m [nonempty α] (hPα : P.parts.card * 16^P.parts.card ≤ card α)
@@ -83,7 +83,7 @@ by exact_mod_cast
 lemma a_add_one_le_four_pow_parts_card : a + 1 ≤ 4^P.parts.card :=
 begin
   have h : 1 ≤ 4^P.parts.card := one_le_pow_of_one_le (by norm_num) _,
-  rw [exp_bound, ←nat.div_div_eq_div_mul, nat.add_le_to_le_sub _ h, tsub_le_iff_left,
+  rw [step_bound, ←nat.div_div_eq_div_mul, nat.add_le_to_le_sub _ h, tsub_le_iff_left,
     ←nat.add_sub_assoc h],
   exact nat.le_pred_of_lt (nat.lt_div_mul_add h),
 end
@@ -98,7 +98,7 @@ lemma card_aux₂ (hP : P.is_equipartition) (hu : u ∈ P.parts)
   (4^P.parts.card - (a + 1)) * m + (a + 1) * (m + 1) = u.card :=
 begin
   have : m * 4 ^ P.parts.card ≤ card α / P.parts.card,
-  { rw [exp_bound, ←nat.div_div_eq_div_mul],
+  { rw [step_bound, ←nat.div_div_eq_div_mul],
     exact nat.div_mul_le_self _ _ },
   rw nat.add_sub_of_le this at hucard,
   rw [(hP.card_parts_eq_average hu).resolve_left hucard, mul_add, mul_one, ←add_assoc, ←add_mul,
@@ -110,7 +110,7 @@ lemma pow_mul_m_le_card_part (hP : P.is_equipartition) (hu : u ∈ P.parts) :
   (4 : ℝ) ^ P.parts.card * m ≤ u.card :=
 begin
   norm_cast,
-  rw [exp_bound, ←nat.div_div_eq_div_mul],
+  rw [step_bound, ←nat.div_div_eq_div_mul],
   exact (nat.mul_div_le _ _).trans (hP.average_le_card_part hu),
 end
 
@@ -138,12 +138,12 @@ end
 /-- An explicit bound on the size of the equipartition whose existence is given by Szemerédi's
 regularity lemma. -/
 noncomputable def bound : ℕ :=
-(exp_bound^[⌊4 / ε^5⌋₊] $ initial_bound ε l) * 16 ^ (exp_bound^[⌊4 / ε^5⌋₊] $ initial_bound ε l)
+(step_bound^[⌊4 / ε^5⌋₊] $ initial_bound ε l) * 16 ^ (step_bound^[⌊4 / ε^5⌋₊] $ initial_bound ε l)
 
 lemma initial_bound_le_bound : initial_bound ε l ≤ bound ε l :=
-(id_le_iterate_of_id_le le_exp_bound _ _).trans $ nat.le_mul_of_pos_right $ pow_pos (by norm_num) _
+(id_le_iterate_of_id_le le_step_bound _ _).trans $ nat.le_mul_of_pos_right $ pow_pos (by norm_num) _
 
 lemma le_bound : l ≤ bound ε l := (le_initial_bound ε l).trans $ initial_bound_le_bound ε l
 lemma bound_pos : 0 < bound ε l := (initial_bound_pos ε l).trans_le $ initial_bound_le_bound ε l
 
-end szemeredi
+end szemeredi_regularity

--- a/src/combinatorics/simple_graph/szemeredi/bound.lean
+++ b/src/combinatorics/simple_graph/szemeredi/bound.lean
@@ -1,0 +1,147 @@
+/-
+Copyright (c) 2022 Yaël Dillies, Bhavik Mehta. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Yaël Dillies, Bhavik Mehta
+-/
+import analysis.special_functions.pow
+import order.partition.equipartition
+
+/-!
+# Numerical bounds for Szemerédi Regularity Lemma
+
+This file gathers the numerical facts required by the proof of Szemerédi's regularity lemma.
+
+## Main declarations
+
+* `szemeredi.exp_bound`: During the inductive step, a partition of size `n` is blown one of size at
+  most `exp_bound n`.
+* `szemeredi.exp_bound`: During the inductive step, a partition of size `n` is blown one of size at
+  most `exp_bound n`.
+-/
+
+open fintype function real
+
+namespace szemeredi
+
+/-- Auxiliary function to explicit the bound on the size of the equipartition in the proof of
+Szemerédi's regularity lemma -/
+def exp_bound (n : ℕ) : ℕ := n * 4 ^ n
+
+lemma le_exp_bound : id ≤ exp_bound := λ n, nat.le_mul_of_pos_right $ pow_pos (by norm_num) n
+
+lemma exp_bound_mono : monotone exp_bound :=
+λ a b h, nat.mul_le_mul h $ nat.pow_le_pow_of_le_right (by norm_num) h
+
+lemma exp_bound_pos_iff {n : ℕ} : 0 < exp_bound n ↔ 0 < n :=
+zero_lt_mul_right $ pow_pos (by norm_num) _
+
+alias exp_bound_pos_iff ↔ _ szemeredi.exp_bound_pos
+
+variables {α : Type*} [decidable_eq α] [fintype α] {P : finpartition (univ : finset α)}
+  {u : finset α} {ε : ℝ}
+
+local notation `m` := (card α/exp_bound P.parts.card : ℕ)
+local notation `a` := (card α/P.parts.card - m * 4^P.parts.card : ℕ)
+
+lemma m_pos [nonempty α] (hPα : P.parts.card * 16^P.parts.card ≤ card α) : 0 < m :=
+nat.div_pos ((nat.mul_le_mul_left _ $ nat.pow_le_pow_of_le_left (by norm_num) _).trans hPα) $
+  exp_bound_pos (P.parts_nonempty $ univ_nonempty.ne_empty).card_pos
+
+lemma m_coe_pos [nonempty α] (hPα : P.parts.card * 16^P.parts.card ≤ card α) : (0 : ℝ) < m :=
+nat.cast_pos.2 $ m_pos hPα
+
+lemma coe_m_add_one_pos : 0 < (m : ℝ) + 1 := nat.cast_add_one_pos _
+
+lemma one_le_m_coe [nonempty α] (hPα : P.parts.card * 16^P.parts.card ≤ card α) : (1 : ℝ) ≤ m :=
+nat.one_le_cast.2 $ m_pos hPα
+
+lemma eps_pow_five_pos (hPε : 100 ≤ 4^P.parts.card * ε^5) : 0 < ε^5 :=
+pos_of_mul_pos_left ((by norm_num : (0 : ℝ) < 100).trans_le hPε) $ pow_nonneg (by norm_num) _
+
+lemma eps_pos (hPε : 100 ≤ 4^P.parts.card * ε^5) : 0 < ε :=
+pow_bit1_pos_iff.1 $ eps_pow_five_pos hPε
+
+lemma four_pow_pos {n : ℕ} : 0 < (4 : ℝ)^n := pow_pos (by norm_num) n
+
+lemma hundred_div_ε_pow_five_le_m [nonempty α] (hPα : P.parts.card * 16^P.parts.card ≤ card α)
+  (hPε : 100 ≤ 4^P.parts.card * ε^5) :
+  100 / ε^5 ≤ m :=
+(div_le_of_nonneg_of_le_mul (eps_pow_five_pos hPε).le four_pow_pos.le hPε).trans
+begin
+  norm_cast,
+  rwa [nat.le_div_iff_mul_le'(exp_bound_pos (P.parts_nonempty $ univ_nonempty.ne_empty).card_pos),
+    exp_bound, mul_left_comm, ←mul_pow],
+end
+
+lemma hundred_le_m [nonempty α] (hPα : P.parts.card * 16^P.parts.card ≤ card α)
+  (hPε : 100 ≤ 4^P.parts.card * ε^5) (hε : ε ≤ 1) : 100 ≤ m :=
+by exact_mod_cast
+  (le_div_self (by norm_num) (eps_pow_five_pos hPε) $ pow_le_one _ (eps_pos hPε).le hε).trans
+    (hundred_div_ε_pow_five_le_m hPα hPε)
+
+lemma a_add_one_le_four_pow_parts_card : a + 1 ≤ 4^P.parts.card :=
+begin
+  have h : 1 ≤ 4^P.parts.card := one_le_pow_of_one_le (by norm_num) _,
+  rw [exp_bound, ←nat.div_div_eq_div_mul, nat.add_le_to_le_sub _ h, tsub_le_iff_left,
+    ←nat.add_sub_assoc h],
+  exact nat.le_pred_of_lt (nat.lt_div_mul_add h),
+end
+
+lemma card_aux₁ (hucard : u.card = m * 4^P.parts.card + a) :
+  (4^P.parts.card - a) * m + a * (m + 1) = u.card :=
+by rw [hucard, mul_add, mul_one, ←add_assoc, ←add_mul, nat.sub_add_cancel
+  ((nat.le_succ _).trans a_add_one_le_four_pow_parts_card), mul_comm]
+
+lemma card_aux₂ (hP : P.is_equipartition) (hu : u ∈ P.parts)
+  (hucard : ¬u.card = m * 4^P.parts.card + a) :
+  (4^P.parts.card - (a + 1)) * m + (a + 1) * (m + 1) = u.card :=
+begin
+  have : m * 4 ^ P.parts.card ≤ card α / P.parts.card,
+  { rw [exp_bound, ←nat.div_div_eq_div_mul],
+    exact nat.div_mul_le_self _ _ },
+  rw nat.add_sub_of_le this at hucard,
+  rw [(hP.card_parts_eq_average hu).resolve_left hucard, mul_add, mul_one, ←add_assoc, ←add_mul,
+    nat.sub_add_cancel a_add_one_le_four_pow_parts_card, ←add_assoc, mul_comm,
+    nat.add_sub_of_le this, card_univ],
+end
+
+lemma pow_mul_m_le_card_part (hP : P.is_equipartition) (hu : u ∈ P.parts) :
+  (4 : ℝ) ^ P.parts.card * m ≤ u.card :=
+begin
+  norm_cast,
+  rw [exp_bound, ←nat.div_div_eq_div_mul],
+  exact (nat.mul_div_le _ _).trans (hP.average_le_card_part hu),
+end
+
+variables (P ε) (l : ℕ)
+
+/-- The size of the equipartition by which we start blowing in the proof of Szemerédi's . -/
+noncomputable def initial_bound : ℕ := max 7 $ max l $ ⌊log (100 / ε^5) / log 4⌋₊ + 1
+
+lemma le_initial_bound : l ≤ initial_bound ε l := (le_max_left _ _).trans $ le_max_right _ _
+lemma seven_le_initial_bound : 7 ≤ initial_bound ε l := le_max_left _ _
+lemma initial_bound_pos : 0 < initial_bound ε l :=
+nat.succ_pos'.trans_le $ seven_le_initial_bound _ _
+
+lemma hundred_lt_pow_initial_bound_mul {ε : ℝ} (hε : 0 < ε) (l : ℕ) :
+  100 < 4^initial_bound ε l * ε^5 :=
+begin
+  rw [←rpow_nat_cast 4, ←div_lt_iff (pow_pos hε 5), lt_rpow_iff_log_lt _ zero_lt_four,
+    ←div_lt_iff, initial_bound, nat.cast_max, nat.cast_max],
+  { exact lt_max_of_lt_right (lt_max_of_lt_right $ nat.lt_floor_add_one _) },
+  { exact log_pos (by norm_num) },
+  { exact div_pos (by norm_num) (pow_pos hε 5) }
+end
+
+/-- An explicit bound on the size of the equipartition in the proof of Szemerédi's Regularity Lemma.
+-/
+noncomputable def bound : ℕ :=
+(exp_bound^[⌊4 / ε^5⌋₊] $ initial_bound ε l) * 16 ^ (exp_bound^[⌊4 / ε^5⌋₊] $ initial_bound ε l)
+
+lemma initial_bound_le_bound : initial_bound ε l ≤ bound ε l :=
+(id_le_iterate_of_id_le le_exp_bound _ _).trans $ nat.le_mul_of_pos_right $ pow_pos (by norm_num) _
+
+lemma le_bound : l ≤ bound ε l := (le_initial_bound ε l).trans $ initial_bound_le_bound ε l
+lemma bound_pos : 0 < bound ε l := (initial_bound_pos ε l).trans_le $ initial_bound_le_bound ε l
+
+end szemeredi

--- a/src/combinatorics/simple_graph/szemeredi/bound.lean
+++ b/src/combinatorics/simple_graph/szemeredi/bound.lean
@@ -13,18 +13,19 @@ This file gathers the numerical facts required by the proof of Szemerédi's regu
 
 ## Main declarations
 
-* `szemeredi.exp_bound`: During the inductive step, a partition of size `n` is blown one of size at
-  most `exp_bound n`.
-* `szemeredi.exp_bound`: During the inductive step, a partition of size `n` is blown one of size at
-  most `exp_bound n`.
+* `szemeredi.exp_bound`: During the inductive step, a partition of size `n` is blown to size at most
+  `exp_bound n`.
+* `szemeredi.initial_bound`: The size of the partition we start the induction with.
+* `szemeredi.bound`: The upper bound on the size of the partition our version of Szemerédi's
+  regularity lemma produces.
 -/
 
 open fintype function real
 
 namespace szemeredi
 
-/-- Auxiliary function to explicit the bound on the size of the equipartition in the proof of
-Szemerédi's regularity lemma -/
+/-- Auxiliary function for Szemerédi's regularity lemma. Blowing up a partition of size `n` during
+the induction results in a partition of size at most `exp_bound n`. -/
 def exp_bound (n : ℕ) : ℕ := n * 4 ^ n
 
 lemma le_exp_bound : id ≤ exp_bound := λ n, nat.le_mul_of_pos_right $ pow_pos (by norm_num) n
@@ -115,7 +116,8 @@ end
 
 variables (P ε) (l : ℕ)
 
-/-- The size of the equipartition by which we start blowing in the proof of Szemerédi's . -/
+/-- Auxiliary function for Szemerédi's regularity lemma. The size of the partition by which we start
+blowing. -/
 noncomputable def initial_bound : ℕ := max 7 $ max l $ ⌊log (100 / ε^5) / log 4⌋₊ + 1
 
 lemma le_initial_bound : l ≤ initial_bound ε l := (le_max_left _ _).trans $ le_max_right _ _
@@ -133,8 +135,8 @@ begin
   { exact div_pos (by norm_num) (pow_pos hε 5) }
 end
 
-/-- An explicit bound on the size of the equipartition in the proof of Szemerédi's Regularity Lemma.
--/
+/-- An explicit bound on the size of the equipartition whose existence is given by Szemerédi's
+regularity lemma. -/
 noncomputable def bound : ℕ :=
 (exp_bound^[⌊4 / ε^5⌋₊] $ initial_bound ε l) * 16 ^ (exp_bound^[⌊4 / ε^5⌋₊] $ initial_bound ε l)
 

--- a/src/combinatorics/simple_graph/szemeredi/bound.lean
+++ b/src/combinatorics/simple_graph/szemeredi/bound.lean
@@ -20,7 +20,7 @@ This file gathers the numerical facts required by the proof of Szemerédi's regu
   regularity lemma produces.
 -/
 
-open fintype function real
+open finset fintype function real
 
 namespace szemeredi
 

--- a/src/order/partition/equipartition.lean
+++ b/src/order/partition/equipartition.lean
@@ -35,6 +35,10 @@ lemma _root_.set.subsingleton.is_equipartition (h : (P.parts : set (finset α)).
   P.is_equipartition :=
 h.equitable_on _
 
+lemma is_equipartition.card_parts_eq_average (hP : P.is_equipartition) (ht : t ∈ P.parts) :
+  t.card = s.card / P.parts.card ∨ t.card = s.card / P.parts.card + 1 :=
+P.is_equipartition_iff_card_parts_eq_average.1 hP _ ht
+
 lemma is_equipartition.average_le_card_part (hP : P.is_equipartition) (ht : t ∈ P.parts) :
   s.card / P.parts.card ≤ t.card :=
 by { rw ←P.sum_card_parts, exact equitable_on.le hP ht }


### PR DESCRIPTION
Define the constants appearing in Szemerédi's regularity lemma and prove a bunch of numerical facts about them.

Co-authored-by: Bhavik Mehta <bhavik.mehta8@gmail.com>

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

From [SRL](https://github.com/leanprover-community/mathlib/compare/szemeredi)

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
