### PR TITLE
[Merged by Bors] - feat(data/nat/factorization): Generalize natural factorization recursors.

### DIFF
--- a/src/data/nat/factorization.lean
+++ b/src/data/nat/factorization.lean
@@ -418,8 +418,7 @@ begin
   by_cases ha1 : a = 1,
   { rw [ha1, mul_one],
     exact hp p n hp' hn },
-  apply h (p^n) a
-    (lt_of_lt_of_le (hp'.one_lt) (le_self_pow (le_of_lt (prime.one_lt hp')) (succ_le_iff.mpr hn)))
+  refine h (p^n) a ((hp'.one_lt).trans_le (le_self_pow (prime.one_lt hp').le (succ_le_iff.mpr hn)))
     _ _ (hp _ _ hp' hn) hPa,
   { by_contra,
     simp only [not_lt] at h,

--- a/src/data/nat/factorization.lean
+++ b/src/data/nat/factorization.lean
@@ -417,7 +417,7 @@ begin
   intros a p n hp' hpa hn hPa,
   by_cases ha1 : a = 1,
   { rw [ha1, mul_one],
-    apply hp p n hp' hn, },
+    exact hp p n hp' hn },
   apply h (p^n) a
     (lt_of_lt_of_le (hp'.one_lt) (le_self_pow (le_of_lt (prime.one_lt hp')) (succ_le_iff.mpr hn)))
     _ _ (hp _ _ hp' hn) hPa,

--- a/src/data/nat/factorization.lean
+++ b/src/data/nat/factorization.lean
@@ -420,13 +420,10 @@ begin
     exact hp p n hp' hn },
   refine h (p^n) a ((hp'.one_lt).trans_le (le_self_pow (prime.one_lt hp').le (succ_le_iff.mpr hn)))
     _ _ (hp _ _ hp' hn) hPa,
-  { by_contra,
-    simp only [not_lt] at h,
+  { refine lt_of_not_ge (λ (h : a ≤ 1), _),
     interval_cases a,
-    simp only [dvd_zero, not_true] at hpa,
-    assumption,
-    apply ha1,
-    dec_trivial, },
+    { simpa only [dvd_zero, not_true] using hpa },
+    { contradiction } },
   simpa [hn, prime.coprime_iff_not_dvd hp'],
 end
 

--- a/src/data/nat/factorization.lean
+++ b/src/data/nat/factorization.lean
@@ -400,7 +400,7 @@ def rec_on_prime_pow {P : ℕ → Sort*} (h0 : P 0) (h1 : P 1)
     { rw nat.mul_div_cancel' hpt, },
     { rw [nat.dvd_div_iff hpt, ←pow_succ', ht],
       exact pow_succ_factorization_not_dvd (k + 1).succ_ne_zero hp },
-    exact htp,
+    { exact htp },
     { apply hk _ (nat.div_lt_of_lt_mul _),
       simp [lt_mul_iff_one_lt_left nat.succ_pos', one_lt_pow_iff htp.ne, hp.one_lt] },
     end

--- a/src/data/nat/factorization.lean
+++ b/src/data/nat/factorization.lean
@@ -7,6 +7,7 @@ import data.nat.prime
 import data.finsupp.multiset
 import algebra.big_operators.finsupp
 import tactic.linarith
+import tactic.interval_cases
 
 /-!
 # Prime factorizations
@@ -379,7 +380,7 @@ end
 we can define `P` for all natural numbers. -/
 @[elab_as_eliminator]
 def rec_on_prime_pow {P : ℕ → Sort*} (h0 : P 0) (h1 : P 1)
-  (h : ∀ a p n : ℕ, p.prime → ¬ p ∣ a → P a → P (p ^ n * a)) : ∀ (a : ℕ), P a :=
+  (h : ∀ a p n : ℕ, p.prime → ¬ p ∣ a → 0 < n → P a → P (p ^ n * a)) : ∀ (a : ℕ), P a :=
 λ a, nat.strong_rec_on a $ λ n,
   match n with
   | 0     := λ _, h0
@@ -395,10 +396,11 @@ def rec_on_prime_pow {P : ℕ → Sort*} (h0 : P 0) (h1 : P 1)
     have hpt : p ^ t ∣ k + 2 := by { rw ht, exact pow_factorization_dvd _ _ },
     have htp : 0 < t :=
     by { rw ht, exact hp.factorization_pos_of_dvd (nat.succ_ne_zero _) (min_fac_dvd _) },
-    convert h ((k + 2) / p ^ t) p t hp _ _,
-    { rw nat.mul_div_cancel' hpt },
+    convert h ((k + 2) / p ^ t) p t hp _ _ _,
+    { rw nat.mul_div_cancel' hpt, },
     { rw [nat.dvd_div_iff hpt, ←pow_succ', ht],
       exact pow_succ_factorization_not_dvd (k + 1).succ_ne_zero hp },
+      exact htp,
     { apply hk _ (nat.div_lt_of_lt_mul _),
       simp [lt_mul_iff_one_lt_left nat.succ_pos', one_lt_pow_iff htp.ne, hp.one_lt] },
     end
@@ -408,18 +410,37 @@ def rec_on_prime_pow {P : ℕ → Sort*} (h0 : P 0) (h1 : P 1)
 `P b` to `P (a * b)` when `a, b` are positive coprime, we can define `P` for all natural numbers. -/
 @[elab_as_eliminator]
 def rec_on_pos_prime_pos_coprime {P : ℕ → Sort*} (hp : ∀ p n : ℕ, prime p → 0 < n → P (p ^ n))
-  (h0 : P 0) (h1 : P 1) (h : ∀ a b, 0 < a → 0 < b → coprime a b → P a → P b → P (a * b)) :
+  (h0 : P 0) (h1 : P 1) (h : ∀ a b, 1 < a → 1 < b → coprime a b → P a → P b → P (a * b)) :
   ∀ a, P a :=
-rec_on_prime_pow h0 h1 $ λ a p n hp' hpa ha,
-  (h (p ^ n) a (pow_pos hp'.pos _) (nat.pos_of_ne_zero (λ t, by simpa [t] using hpa))
-  (prime.coprime_pow_of_not_dvd hp' hpa).symm
-  (if h : n = 0 then eq.rec h1 h.symm else hp p n hp' $ nat.pos_of_ne_zero h) ha)
+rec_on_prime_pow h0 h1 $
+begin
+  intros a p n hp' hpa ha hPa,
+  by_cases ha1 : a = 1,
+  { rw [ha1, mul_one],
+    apply hp p n hp' ha, },
+  apply h (p^n) a,
+  exact (lt_of_lt_of_le (hp'.one_lt)
+                  (le_self_pow (le_of_lt (prime.one_lt hp')) (succ_le_iff.mpr ha))),
+  { by_contra,
+    simp at h,
+    interval_cases a,
+    simp at hpa,
+    assumption,
+    apply ha1,
+    dec_trivial, },
+  -- simp, -- should simplify here
+  -- library_search, --library_search should get this
+  apply nat.coprime.pow_left,
+  exact (prime.coprime_iff_not_dvd hp').mpr hpa,
+  apply hp _ _ hp' ha,
+  assumption,
+end
 
 /-- Given `P 0`, `P (p ^ n)` for all prime powers, and a way to extend `P a` and `P b` to
 `P (a * b)` when `a, b` are positive coprime, we can define `P` for all natural numbers. -/
 @[elab_as_eliminator]
 def rec_on_prime_coprime {P : ℕ → Sort*} (h0 : P 0) (hp : ∀ p n : ℕ, prime p → P (p ^ n))
-  (h : ∀ a b, 0 < a → 0 < b → coprime a b → P a → P b → P (a * b)) : ∀ a, P a :=
+  (h : ∀ a b, 1 < a → 1 < b → coprime a b → P a → P b → P (a * b)) : ∀ a, P a :=
 rec_on_pos_prime_pos_coprime (λ p n h _, hp p n h) h0 (hp 2 0 prime_two) h
 
 /-- Given `P 0`, `P 1`, `P p` for all primes, and a way to extend `P a` and `P b` to

--- a/src/data/nat/factorization.lean
+++ b/src/data/nat/factorization.lean
@@ -400,7 +400,7 @@ def rec_on_prime_pow {P : ℕ → Sort*} (h0 : P 0) (h1 : P 1)
     { rw nat.mul_div_cancel' hpt, },
     { rw [nat.dvd_div_iff hpt, ←pow_succ', ht],
       exact pow_succ_factorization_not_dvd (k + 1).succ_ne_zero hp },
-      exact htp,
+    exact htp,
     { apply hk _ (nat.div_lt_of_lt_mul _),
       simp [lt_mul_iff_one_lt_left nat.succ_pos', one_lt_pow_iff htp.ne, hp.one_lt] },
     end

--- a/src/data/nat/factorization.lean
+++ b/src/data/nat/factorization.lean
@@ -414,26 +414,21 @@ def rec_on_pos_prime_pos_coprime {P : ℕ → Sort*} (hp : ∀ p n : ℕ, prime 
   ∀ a, P a :=
 rec_on_prime_pow h0 h1 $
 begin
-  intros a p n hp' hpa ha hPa,
+  intros a p n hp' hpa hn hPa,
   by_cases ha1 : a = 1,
   { rw [ha1, mul_one],
-    apply hp p n hp' ha, },
-  apply h (p^n) a,
-  exact (lt_of_lt_of_le (hp'.one_lt)
-                  (le_self_pow (le_of_lt (prime.one_lt hp')) (succ_le_iff.mpr ha))),
+    apply hp p n hp' hn, },
+  apply h (p^n) a
+    (lt_of_lt_of_le (hp'.one_lt) (le_self_pow (le_of_lt (prime.one_lt hp')) (succ_le_iff.mpr hn)))
+    _ _ (hp _ _ hp' hn) hPa,
   { by_contra,
-    simp at h,
+    simp only [not_lt] at h,
     interval_cases a,
-    simp at hpa,
+    simp only [dvd_zero, not_true] at hpa,
     assumption,
     apply ha1,
     dec_trivial, },
-  simp [hn], -- should simplify here, coprime_pow_left_iff should be simp
-  -- library_search, --library_search should get this
-  -- apply nat.coprime.pow_left,
-  exact (prime.coprime_iff_not_dvd hp').mpr hpa,
-  apply hp _ _ hp' ha,
-  assumption,
+  simpa [hn, prime.coprime_iff_not_dvd hp'],
 end
 
 /-- Given `P 0`, `P (p ^ n)` for all prime powers, and a way to extend `P a` and `P b` to

--- a/src/data/nat/factorization.lean
+++ b/src/data/nat/factorization.lean
@@ -428,9 +428,9 @@ begin
     assumption,
     apply ha1,
     dec_trivial, },
-  -- simp, -- should simplify here
+  simp [hn], -- should simplify here, coprime_pow_left_iff should be simp
   -- library_search, --library_search should get this
-  apply nat.coprime.pow_left,
+  -- apply nat.coprime.pow_left,
   exact (prime.coprime_iff_not_dvd hp').mpr hpa,
   apply hp _ _ hp' ha,
   assumption,

--- a/src/data/nat/gcd.lean
+++ b/src/data/nat/gcd.lean
@@ -435,7 +435,7 @@ theorem coprime.pow_right {m k : ℕ} (n : ℕ) (H1 : coprime k m) : coprime k (
 theorem coprime.pow {k l : ℕ} (m n : ℕ) (H1 : coprime k l) : coprime (k ^ m) (l ^ n) :=
 (H1.pow_left _).pow_right _
 
-lemma coprime_pow_left_iff {n : ℕ} (hn : 0 < n) (a b : ℕ)  :
+@[simp] lemma coprime_pow_left_iff {n : ℕ} (hn : 0 < n) (a b : ℕ)  :
   nat.coprime (a ^ n) b ↔ nat.coprime a b :=
 begin
   obtain ⟨n, rfl⟩ := exists_eq_succ_of_ne_zero hn.ne',
@@ -443,7 +443,7 @@ begin
   exact ⟨and.left, λ hab, ⟨hab, hab.pow_left _⟩⟩
 end
 
-lemma coprime_pow_right_iff {n : ℕ} (hn : 0 < n) (a b : ℕ)  :
+@[simp] lemma coprime_pow_right_iff {n : ℕ} (hn : 0 < n) (a b : ℕ)  :
   nat.coprime a (b ^ n) ↔ nat.coprime a b :=
 by rw [nat.coprime_comm, coprime_pow_left_iff hn, nat.coprime_comm]
 

--- a/src/number_theory/von_mangoldt.lean
+++ b/src/number_theory/von_mangoldt.lean
@@ -93,7 +93,7 @@ begin
   simp only [von_mangoldt_apply, ←sum_filter] at ha hb ⊢,
   rw [mul_divisors_filter_prime_pow hab, filter_union,
     sum_union (disjoint_divisors_filter_prime_pow hab), ha, hb, nat.cast_mul,
-    real.log_mul (nat.cast_ne_zero.2  (pos_of_gt ha').ne')
+    real.log_mul (nat.cast_ne_zero.2 (pos_of_gt ha').ne')
       (nat.cast_ne_zero.2 (pos_of_gt hb').ne')],
 end
 

--- a/src/number_theory/von_mangoldt.lean
+++ b/src/number_theory/von_mangoldt.lean
@@ -93,7 +93,8 @@ begin
   simp only [von_mangoldt_apply, ←sum_filter] at ha hb ⊢,
   rw [mul_divisors_filter_prime_pow hab, filter_union,
     sum_union (disjoint_divisors_filter_prime_pow hab), ha, hb, nat.cast_mul,
-    real.log_mul (nat.cast_ne_zero.2 ha'.ne') (nat.cast_ne_zero.2 hb'.ne')],
+    real.log_mul (nat.cast_ne_zero.2  (pos_of_gt ha').ne')
+      (nat.cast_ne_zero.2 (pos_of_gt hb').ne')],
 end
 
 @[simp] lemma von_mangoldt_mul_zeta : Λ * ζ = log :=


### PR DESCRIPTION

Switches `rec_on_prime_pow` precondition to allow use of `0 < n`, and strengthens correspondingly `rec_on_pos_prime_pos_coprime` and `rec_on_prime_coprime`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
