### PR TITLE
[Merged by Bors] - chore(algebra/group_power/lemmas): turn `[zn]smul` lemmas into instances

### DIFF
--- a/src/algebra/group_power/lemmas.lean
+++ b/src/algebra/group_power/lemmas.lean
@@ -342,12 +342,6 @@ by induction n with n ih; [rw [zero_nsmul, nat.cast_zero, mul_zero],
 @[simp] theorem nsmul_eq_mul [semiring R] (n : ℕ) (a : R) : n • a = n * a :=
 by rw [nsmul_eq_mul', (n.cast_commute a).eq]
 
-theorem mul_nsmul_left [semiring R] (a b : R) (n : ℕ) : n • (a * b) = a * (n • b) :=
-by rw [nsmul_eq_mul', nsmul_eq_mul', mul_assoc]
-
-theorem mul_nsmul_assoc [semiring R] (a b : R) (n : ℕ) : n • (a * b) = n • a * b :=
-by rw [nsmul_eq_mul, nsmul_eq_mul, mul_assoc]
-
 @[simp, norm_cast] theorem nat.cast_pow [semiring R] (n m : ℕ) : (↑(n ^ m) : R) = ↑n ^ m :=
 begin
   induction m with m ih,
@@ -382,12 +376,6 @@ by { dsimp [bit1], rw [mul_add, mul_bit0, mul_one], }
 
 theorem zsmul_eq_mul' [ring R] (a : R) (n : ℤ) : n • a = a * n :=
 by rw [zsmul_eq_mul, (n.cast_commute a).eq]
-
-theorem mul_zsmul_left [ring R] (a b : R) (n : ℤ) : n • (a * b) = a * (n • b) :=
-by rw [zsmul_eq_mul', zsmul_eq_mul', mul_assoc]
-
-theorem mul_zsmul_assoc [ring R] (a b : R) (n : ℤ) : n • (a * b) = n • a * b :=
-by rw [zsmul_eq_mul, zsmul_eq_mul, mul_assoc]
 
 lemma zsmul_int_int (a b : ℤ) : a • b = a * b := by simp
 

--- a/src/algebra/group_power/lemmas.lean
+++ b/src/algebra/group_power/lemmas.lean
@@ -342,6 +342,22 @@ by induction n with n ih; [rw [zero_nsmul, nat.cast_zero, mul_zero],
 @[simp] theorem nsmul_eq_mul [semiring R] (n : ℕ) (a : R) : n • a = n * a :=
 by rw [nsmul_eq_mul', (n.cast_commute a).eq]
 
+/-- Note that `add_comm_monoid.nat_smul_comm_class` requires stronger assumptions on `R`. -/
+instance non_unital_non_assoc_semiring.nat_smul_comm_class [non_unital_non_assoc_semiring R] :
+  smul_comm_class ℕ R R :=
+⟨λ n x y, match n with
+  | 0 := by simp_rw [zero_nsmul, smul_eq_mul, mul_zero]
+  | (n + 1) := by simp_rw [succ_nsmul, smul_eq_mul, mul_add, ←smul_eq_mul, _match n]
+  end⟩
+
+/-- Note that `add_comm_monoid.nat_is_scalar_tower` requires stronger assumptions on `R`. -/
+instance non_unital_non_assoc_semiring.nat_is_scalar_tower [non_unital_non_assoc_semiring R] :
+  is_scalar_tower ℕ R R :=
+⟨λ n x y, match n with
+  | 0 := by simp_rw [zero_nsmul, smul_eq_mul, zero_mul]
+  | (n + 1) := by simp_rw [succ_nsmul, ←_match n, smul_eq_mul, add_mul]
+  end⟩
+
 @[simp, norm_cast] theorem nat.cast_pow [semiring R] (n m : ℕ) : (↑(n ^ m) : R) = ↑n ^ m :=
 begin
   induction m with m ih,
@@ -376,6 +392,22 @@ by { dsimp [bit1], rw [mul_add, mul_bit0, mul_one], }
 
 theorem zsmul_eq_mul' [ring R] (a : R) (n : ℤ) : n • a = a * n :=
 by rw [zsmul_eq_mul, (n.cast_commute a).eq]
+
+/-- Note that `add_comm_group.int_smul_comm_class` requires stronger assumptions on `R`. -/
+instance non_unital_non_assoc_ring.int_smul_comm_class [non_unital_non_assoc_ring R] :
+  smul_comm_class ℤ R R :=
+⟨λ n x y, match n with
+  | (n : ℕ) := by simp_rw [coe_nat_zsmul, smul_comm]
+  | -[1+n]  := by simp_rw [zsmul_neg_succ_of_nat, smul_eq_mul, mul_neg, mul_smul_comm]
+  end⟩
+
+/-- Note that `add_comm_group.int_is_scalar_tower` requires stronger assumptions on `R`. -/
+instance non_unital_non_assoc_ring.int_is_scalar_tower [non_unital_non_assoc_ring R] :
+  is_scalar_tower ℤ R R :=
+⟨λ n x y, match n with
+  | (n : ℕ) := by simp_rw [coe_nat_zsmul, smul_assoc]
+  | -[1+n]  := by simp_rw [zsmul_neg_succ_of_nat, smul_eq_mul, neg_mul, smul_mul_assoc]
+  end⟩
 
 lemma zsmul_int_int (a b : ℤ) : a • b = a * b := by simp
 

--- a/src/algebra/module/basic.lean
+++ b/src/algebra/module/basic.lean
@@ -325,7 +325,7 @@ def add_comm_monoid.nat_module.unique : unique (module ℕ M) :=
 { default := by apply_instance,
   uniq := λ P, module.ext' P _ $ λ n, nat_smul_eq_nsmul P n }
 
-instance add_comm_monoid.nat_is_scalar_tower :
+instance add_comm_monoid.nat_is_scalar_tower {R M} [add_comm_monoid R] [add_comm_monoid M] [smul_with_zero R M]:
   is_scalar_tower ℕ R M :=
 { smul_assoc := λ n x y, nat.rec_on n
     (by simp only [zero_smul])

--- a/src/algebra/module/basic.lean
+++ b/src/algebra/module/basic.lean
@@ -325,7 +325,7 @@ def add_comm_monoid.nat_module.unique : unique (module ℕ M) :=
 { default := by apply_instance,
   uniq := λ P, module.ext' P _ $ λ n, nat_smul_eq_nsmul P n }
 
-instance add_comm_monoid.nat_is_scalar_tower {R M} [add_comm_monoid R] [add_comm_monoid M] [smul_with_zero R M]:
+instance add_comm_monoid.nat_is_scalar_tower :
   is_scalar_tower ℕ R M :=
 { smul_assoc := λ n x y, nat.rec_on n
     (by simp only [zero_smul])

--- a/src/tactic/noncomm_ring.lean
+++ b/src/tactic/noncomm_ring.lean
@@ -9,6 +9,9 @@ import algebra.module.basic  -- needed to empower `mul_smul_comm` and `smul_mul_
 namespace tactic
 namespace interactive
 
+example {R} [semiring R] : is_scalar_tower ℕ R R := by refine add_comm_monoid.nat_is_scalar_tower
+example {R} [ring R] : is_scalar_tower ℤ R R := by apply_instance
+
 /-- A tactic for simplifying identities in not-necessarily-commutative rings.
 
 An example:

--- a/src/tactic/noncomm_ring.lean
+++ b/src/tactic/noncomm_ring.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Scott Morrison, Oliver Nash
 -/
 import tactic.abel
+import algebra.module.basic  -- needed to empower `mul_smul_comm` and `smul_mul_assoc`
 
 namespace tactic
 namespace interactive
@@ -26,7 +27,7 @@ meta def noncomm_ring :=
              -- Replace multiplication by numerals with `zsmul`.
              bit0_mul, mul_bit0, bit1_mul, mul_bit1, one_mul, mul_one, zero_mul, mul_zero,
              -- Pull `zsmul n` out the front so `abel` can see them.
-             mul_smul_comm (_ : ℤ), smul_mul_assoc (_ : ℤ),
+             mul_smul_comm, smul_mul_assoc,
              -- Pull out negations.
              neg_mul, mul_neg] {fail_if_unchanged := ff};
   abel]

--- a/src/tactic/noncomm_ring.lean
+++ b/src/tactic/noncomm_ring.lean
@@ -4,13 +4,9 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Scott Morrison, Oliver Nash
 -/
 import tactic.abel
-import algebra.module.basic  -- needed to empower `mul_smul_comm` and `smul_mul_assoc`
 
 namespace tactic
 namespace interactive
-
-example {R} [semiring R] : is_scalar_tower ℕ R R := by refine add_comm_monoid.nat_is_scalar_tower
-example {R} [ring R] : is_scalar_tower ℤ R R := by apply_instance
 
 /-- A tactic for simplifying identities in not-necessarily-commutative rings.
 

--- a/src/tactic/noncomm_ring.lean
+++ b/src/tactic/noncomm_ring.lean
@@ -26,7 +26,7 @@ meta def noncomm_ring :=
              -- Replace multiplication by numerals with `zsmul`.
              bit0_mul, mul_bit0, bit1_mul, mul_bit1, one_mul, mul_one, zero_mul, mul_zero,
              -- Pull `zsmul n` out the front so `abel` can see them.
-             ←mul_zsmul_assoc, ←mul_zsmul_left,
+             mul_smul_comm (_ : ℤ), smul_mul_assoc (_ : ℤ),
              -- Pull out negations.
              neg_mul, mul_neg] {fail_if_unchanged := ff};
   abel]

--- a/test/noncomm_ring.lean
+++ b/test/noncomm_ring.lean
@@ -1,4 +1,5 @@
 import tactic.noncomm_ring
+import algebra.module.basic
 
 local notation `⁅`a`,` b`⁆` := a * b - b * a
 local infix ` ⚬ `:70 := λ a b, a * b + b * a
@@ -22,6 +23,7 @@ example : a ^ 3 = a * a * a := by noncomm_ring
 example : (-a) * b = -(a * b) := by noncomm_ring
 example : a * (-b) = -(a * b) := by noncomm_ring
 example : a * (b + c + b + c - 2*b) = 2*a*c := by noncomm_ring
+example : a * (b + c + b + c - (2 : ℕ) • b) = 2*a*c := by noncomm_ring
 example : (a + b)^2 = a^2 + a*b + b*a + b^2 := by noncomm_ring
 example : (a - b)^2 = a^2 - a*b - b*a + b^2 := by noncomm_ring
 example : (a + b)^3 = a^3 + a^2*b + a*b*a + a*b^2 + b*a^2 + b*a*b + b^2*a + b^3 := by noncomm_ring

--- a/test/noncomm_ring.lean
+++ b/test/noncomm_ring.lean
@@ -1,5 +1,4 @@
 import tactic.noncomm_ring
-import algebra.module.basic
 
 local notation `⁅`a`,` b`⁆` := a * b - b * a
 local infix ` ⚬ `:70 := λ a b, a * b + b * a


### PR DESCRIPTION
This adds new instances such that:

* `mul_[zn]smul_assoc` is `←smul_mul_assoc`
* `mul_[zn]smul_left` is `←mul_smul_comm`

This also makes `noncomm_ring` slightly smarter, and able to handle scalar actions by `nat`.
Thanks to Christopher, this generalizes these instances to non-associative and non-unital rings.

Co-authored-by: Christopher Hoskin <christopher.hoskin@gmail.com>

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:


Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
