### PR TITLE
[Merged by Bors] - feat(algebra/big_operators): `norm_num` plugin for list/multiset/finset prod/sum

### DIFF
--- a/src/algebra/big_operators/norm_num.lean
+++ b/src/algebra/big_operators/norm_num.lean
@@ -325,32 +325,38 @@ by rw [← hs, finset.prod_mk, multiset.coe_map, multiset.coe_prod, hx]
  * `finset.sum`
 -/
 @[norm_num] meta def eval_big_operators : expr → tactic (expr × expr)
-| `(@list.prod %%α %%inst1 %%inst2 %%exs) := tactic.trace_error "" $ do
+| `(@list.prod %%α %%inst1 %%inst2 %%exs) :=
+tactic.trace_error "Internal error in `tactic.norm_num.eval_big_operators`:" $ do
   (xs, list_eq) ← eval_list exs,
   (result, sum_eq) ← list.prove_prod α xs,
   pf ← i_to_expr ``(list.prod_congr %%list_eq %%sum_eq),
   pure (result, pf)
-| `(@list.sum %%α %%inst1 %%inst2 %%exs) := tactic.trace_error "" $ do
+| `(@list.sum %%α %%inst1 %%inst2 %%exs) :=
+tactic.trace_error "Internal error in `tactic.norm_num.eval_big_operators`:" $ do
   (xs, list_eq) ← eval_list exs,
   (result, sum_eq) ← list.prove_sum α xs,
   pf ← i_to_expr ``(list.sum_congr %%list_eq %%sum_eq),
   pure (result, pf)
-| `(@multiset.prod %%α %%inst %%exs) := tactic.trace_error "" $ do
+| `(@multiset.prod %%α %%inst %%exs) :=
+tactic.trace_error "Internal error in `tactic.norm_num.eval_big_operators`:" $ do
   (xs, list_eq) ← eval_multiset exs,
   (result, sum_eq) ← list.prove_prod α xs,
   pf ← i_to_expr ``(multiset.prod_congr %%list_eq %%sum_eq),
   pure (result, pf)
-| `(@multiset.sum %%α %%inst %%exs) := tactic.trace_error "" $ do
+| `(@multiset.sum %%α %%inst %%exs) :=
+tactic.trace_error "Internal error in `tactic.norm_num.eval_big_operators`:" $ do
   (xs, list_eq) ← eval_multiset exs,
   (result, sum_eq) ← list.prove_sum α xs,
   pf ← i_to_expr ``(multiset.sum_congr %%list_eq %%sum_eq),
   pure (result, pf)
-| `(@finset.prod %%β %%α %%inst %%es %%ef) := tactic.trace_error "" $ do
+| `(@finset.prod %%β %%α %%inst %%es %%ef) :=
+tactic.trace_error "Internal error in `tactic.norm_num.eval_big_operators`:" $ do
   (xs, list_eq, nodup) ← eval_finset decide_eq es,
   (result, sum_eq) ← list.prove_prod_map β ef xs,
   pf ← i_to_expr ``(finset.eval_prod_of_list %%es %%ef %%nodup %%list_eq %%sum_eq),
   pure (result, pf)
-| `(@finset.sum %%β %%α %%inst %%es %%ef) := tactic.trace_error "" $ do
+| `(@finset.sum %%β %%α %%inst %%es %%ef) :=
+tactic.trace_error "Internal error in `tactic.norm_num.eval_big_operators`:" $ do
   (xs, list_eq, nodup) ← eval_finset decide_eq es,
   (result, sum_eq) ← list.prove_sum_map β ef xs,
   pf ← i_to_expr ``(finset.eval_sum_of_list %%es %%ef %%nodup %%list_eq %%sum_eq),

--- a/src/algebra/big_operators/norm_num.lean
+++ b/src/algebra/big_operators/norm_num.lean
@@ -5,7 +5,6 @@ Authors: Anne Baanen
 -/
 import algebra.big_operators.basic
 import tactic.norm_num
-import tactic.ring
 
 /-! ### `norm_num` plugin for big operators
 
@@ -33,13 +32,6 @@ Finally, we package up the result using some congruence lemmas.
 -/
 
 open tactic
-
-/-- Convert a list of expressions to an expression denoting the list of those expressions. -/
-meta def expr.of_list (α : expr) : list expr → tactic expr
-| [] := i_to_expr ``(@list.nil %%α)
-| (x :: xs) := do
-  exs ← expr.of_list xs,
-  i_to_expr ``(@list.cons %%α %%x %%exs)
 
 namespace tactic.norm_num
 

--- a/src/algebra/big_operators/norm_num.lean
+++ b/src/algebra/big_operators/norm_num.lean
@@ -1,0 +1,356 @@
+/-
+Copyright (c) 2022 Anne Baanen. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Anne Baanen
+-/
+import algebra.big_operators.basic
+import tactic.norm_num
+import tactic.ring
+
+/-! ### `norm_num` plugin for big operators
+
+This `norm_num` plugin provides support for computing sums and products of
+lists, multisets and finsets.
+
+Example goals this plugin can solve:
+
+ * `∑ i in finset.range 10, (i^2 : ℕ) = 285`
+ * `Π i in {1, 4, 9, 16}, nat.sqrt i = 24`
+ * `([1, 2, 1, 3]).sum = 7`
+
+## Implementation notes
+
+The tactic works by first converting the expression denoting the collection
+(list, multiset, finset) to a list of expressions denoting each element. For
+finsets, this involves erasing duplicate elements (the tactic fails if equality
+or disequality cannot be determined).
+
+After rewriting the big operator to a product/sum of lists, we evaluate this
+using `norm_num` itself to handle multiplication/addition.
+
+Finally, we package up the result using some congruence lemmas.
+
+-/
+
+open tactic
+
+/-- Use `norm_num` to decide equality between two expressions.
+
+If the decision procedure succeeds, the `bool` value indicates whether the expressions are equal,
+and the `expr` is a proof of (dis)equality.
+This procedure is partial: it will fail in cases where `norm_num` can't reduce either side
+to a rational numeral.
+-/
+meta def tactic.norm_num.decide_eq (l r : expr) : tactic (bool × expr) := do
+  (l', l'_pf) ← or_refl_conv norm_num.derive l,
+  (r', r'_pf) ← or_refl_conv norm_num.derive r,
+  n₁ ← l'.to_rat, n₂ ← r'.to_rat,
+  c ← infer_type l' >>= mk_instance_cache,
+  if n₁ = n₂ then do
+    pf ← i_to_expr ``(eq.trans %%l'_pf $ eq.symm %%r'_pf),
+    pure (tt, pf)
+  else do
+    (_, p) ← norm_num.prove_ne c l' r' n₁ n₂,
+    pure (ff, p)
+
+lemma list.not_mem_cons {α : Type*} {x y : α} {ys : list α} (h₁ : x ≠ y) (h₂ : x ∉ ys) :
+  x ∉ y :: ys :=
+λ h, ((list.mem_cons_iff _ _ _).mp h).elim h₁ h₂
+
+/-- Use a decision procedure for the equality of list elements to decide list membership.
+
+If the decision procedure succeeds, the `bool` value indicates whether the expressions are equal,
+and the `expr` is a proof of (dis)equality.
+This procedure is partial iff its parameter `decide_eq` is partial.
+-/
+meta def list.decide_mem (decide_eq : expr → expr → tactic (bool × expr)) :
+  expr → list expr → tactic (bool × expr)
+| x [] := do
+  pf ← i_to_expr ``(list.not_mem_nil %%x),
+  pure (ff, pf)
+| x (y :: ys) := do
+  (is_head, head_pf) ← decide_eq x y,
+  if is_head then do
+    pf ← i_to_expr ``((list.mem_cons_iff %%x %%y _).mpr (or.inl %%head_pf)),
+    pure (tt, pf)
+  else do
+    (mem_tail, tail_pf) ← list.decide_mem x ys,
+    if mem_tail then do
+      pf ← i_to_expr ``((list.mem_cons_iff %%x %%y _).mpr (or.inr %%tail_pf)),
+      pure (tt, pf)
+    else do
+      pf ← i_to_expr ``(list.not_mem_cons %%head_pf %%tail_pf),
+      pure (ff, pf)
+
+lemma finset.insert_eq_coe_list_of_mem {α : Type*} [decidable_eq α] (x : α) (xs : finset α)
+  {xs' : list α} (h : x ∈ xs') (nd_xs : xs'.nodup)
+  (hxs' : xs = finset.mk ↑xs' (multiset.coe_nodup.mpr nd_xs)) :
+  insert x xs = finset.mk ↑xs' (multiset.coe_nodup.mpr nd_xs) :=
+have h : x ∈ xs, by simpa [hxs'] using h,
+by rw [finset.insert_eq_of_mem h, hxs']
+
+lemma finset.insert_eq_coe_list_cons {α : Type*} [decidable_eq α] (x : α) (xs : finset α)
+  {xs' : list α} (h : x ∉ xs') (nd_xs : xs'.nodup) (nd_xxs : (x :: xs').nodup)
+  (hxs' : xs = finset.mk ↑xs' (multiset.coe_nodup.mpr nd_xs)) :
+  insert x xs = finset.mk ↑(x :: xs') (multiset.coe_nodup.mpr nd_xxs) :=
+have h : x ∉ xs, by simpa [hxs'] using h,
+by { rw [← finset.val_inj, finset.insert_val_of_not_mem h, hxs'], simp only [multiset.cons_coe] }
+
+/-- Convert an expression denoting a finset to a list of elements,
+a proof that this list is equal to the original finset,
+and a proof that the list contains no duplicates.
+
+We return a list rather than a finset, so we can more easily iterate over it
+(without having to prove that our tactics are independent of the order of iteration,
+which is in general not true).
+
+`decide_eq` is a (partial) decision procedure for determining whether two
+elements of the finset are equal, for example to parse `{2, 1, 2}` into `[2, 1]`.
+-/
+meta def tactic.norm_num.eval_finset (decide_eq : expr → expr → tactic (bool × expr)) :
+  expr → tactic (list expr × expr × expr)
+| e@`(has_emptyc.emptyc) := do
+  eq ← mk_eq_refl e,
+  nd ← i_to_expr ``(list.nodup_nil),
+  pure ([], eq, nd)
+| e@`(has_singleton.singleton %%x) := do
+  eq ← mk_eq_refl e,
+  nd ← i_to_expr ``(list.nodup_singleton %%x),
+  pure ([x], eq, nd)
+| `(@@has_insert.insert (@@finset.has_insert %%dec) %%x %%xs) := do
+  (exs, xs_eq, xs_nd) ← tactic.norm_num.eval_finset xs,
+  (is_mem, mem_pf) ← list.decide_mem decide_eq x exs,
+  if is_mem then do
+    pf ← i_to_expr ``(finset.insert_eq_coe_list_of_mem %%x %%xs %%mem_pf %%xs_nd %%xs_eq),
+    pure (exs, pf, xs_nd)
+  else do
+    nd ← i_to_expr ``(list.nodup_cons.mpr ⟨%%mem_pf, %%xs_nd⟩),
+    pf ← i_to_expr ``(finset.insert_eq_coe_list_cons %%x %%xs %%mem_pf %%xs_nd %%nd %%xs_eq),
+    pure (x :: exs, pf, nd)
+| `(@@finset.univ %%ft) := do
+  -- Convert the fintype instance expression `ft` to a list of its elements.
+  -- Unfold it to the `fintype.mk` constructor and a list of arguments.
+  `fintype.mk ← get_app_fn_const_whnf ft
+    | fail (to_fmt "Unknown fintype expression" ++ format.line ++ to_fmt ft),
+  [_, args, _] ← get_app_args_whnf ft | fail (to_fmt "Expected 3 arguments to `fintype.mk`"),
+  tactic.norm_num.eval_finset args
+| e@`(finset.range %%en) := do
+  n ← expr.to_nat en,
+  eis ← (list.range n).mmap (λ i, expr.of_nat `(ℕ) i),
+  eq ← mk_eq_refl e,
+  nd ← i_to_expr ``(list.nodup_range %%en),
+  pure (eis, eq, nd)
+| e@`(finset.fin_range %%en) := do
+  n ← expr.to_nat en,
+  eis ← (list.fin_range n).mmap (λ i, expr.of_nat `(fin %%en) i),
+  eq ← mk_eq_refl e,
+  nd ← i_to_expr ``(list.nodup_fin_range %%en),
+  pure (eis, eq, nd)
+| e := fail (to_fmt "Unknown finset expression" ++ format.line ++ to_fmt e)
+
+/-- Convert a list of expressions to an expression denoting the list of those expressions. -/
+meta def expr.of_list (α : expr) : list expr → tactic expr
+| [] := i_to_expr ``(@list.nil %%α)
+| (x :: xs) := do
+  exs ← expr.of_list xs,
+  i_to_expr ``(@list.cons %%α %%x %%exs)
+
+lemma list.map_cons_congr {α β : Type*} (f : α → β) {x : α} {xs : list α} {fx : β} {fxs : list β}
+  (h₁ : f x = fx) (h₂ : xs.map f = fxs) : (x :: xs).map f = fx :: fxs :=
+by rw [list.map_cons, h₁, h₂]
+
+/-- Apply `ef : α → β` to all elements of the list, constructing an equality proof. -/
+meta def tactic.norm_num.eval_list_map (ef : expr) : list expr → tactic (list expr × expr)
+| [] := do
+  eq ← i_to_expr ``(list.map_nil %%ef),
+  pure ([], eq)
+| (x :: xs) := do
+  (fx, fx_eq) ← or_refl_conv norm_num.derive (expr.app ef x),
+  (fxs, fxs_eq) ← tactic.norm_num.eval_list_map xs,
+  eq ← i_to_expr ``(list.map_cons_congr %%ef %%fx_eq %%fxs_eq),
+  pure (fx :: fxs, eq)
+
+lemma multiset.cons_congr {α : Type*} (x : α) {xs : multiset α} {xs' : list α}
+  (xs_eq : (xs' : multiset α) = xs) : (list.cons x xs' : multiset α) = x ::ₘ xs :=
+by rw [← xs_eq]; refl
+
+lemma tactic.norm_num.multiset.map_congr {α β : Type*} (f : α → β) {xs : multiset α}
+  {xs' : list α} {ys : list β} (xs_eq : xs = (xs' : multiset α)) (ys_eq : xs'.map f = ys) :
+  xs.map f = (ys : multiset β) :=
+by rw [← ys_eq, ← multiset.coe_map, xs_eq]
+
+/-- Convert an expression denoting a multiset to a list of elements.
+
+We return a list rather than a finset, so we can more easily iterate over it
+(without having to prove that our tactics are independent of the order of iteration,
+which is in general not true).
+-/
+meta def tactic.norm_num.eval_multiset : expr → tactic (list expr × expr)
+| e@`(@has_zero.zero (multiset _) _) := do
+  eq ← mk_eq_refl e,
+  pure ([], eq)
+| e@`(has_emptyc.emptyc) := do
+  eq ← mk_eq_refl e,
+  pure ([], eq)
+| e@`(has_singleton.singleton %%x) := do
+  eq ← mk_eq_refl e,
+  pure ([x], eq)
+| e@`(multiset.cons %%x %%xs) := do
+  (xs, xs_eq) ← tactic.norm_num.eval_multiset xs,
+  eq ← i_to_expr ``(multiset.cons_congr %%x %%xs_eq),
+  pure (x :: xs, eq)
+| e@`(@@has_insert.insert multiset.has_insert %%x %%xs) := do
+  (xs, xs_eq) ← tactic.norm_num.eval_multiset xs,
+  eq ← i_to_expr ``(multiset.cons_congr %%x %%xs_eq),
+  pure (x :: xs, eq)
+| e@`(multiset.range %%en) := do
+  n ← expr.to_nat en,
+  eis ← (list.range n).mmap (λ i, expr.of_nat `(ℕ) i),
+  eq ← mk_eq_refl e,
+  pure (eis, eq)
+| `(@multiset.map %%α %%β %%ef %%exs) := do
+  (xs, xs_eq) ← tactic.norm_num.eval_multiset exs,
+  (ys, ys_eq) ← tactic.norm_num.eval_list_map ef xs,
+  eq ← i_to_expr ``(tactic.norm_num.multiset.map_congr %%ef %%xs_eq %%ys_eq),
+  pure (ys, eq)
+| e := fail (to_fmt "Unknown multiset expression" ++ format.line ++ to_fmt e)
+
+lemma list.cons_congr {α : Type*} (x : α) {xs : list α} {xs' : list α} (xs_eq : xs' = xs) :
+  x :: xs' = x :: xs :=
+by rw xs_eq
+
+lemma tactic.norm_num.list.map_congr {α β : Type*} (f : α → β) {xs xs' : list α}
+  {ys : list β} (xs_eq : xs = xs') (ys_eq : xs'.map f = ys) :
+  xs.map f = ys :=
+by rw [← ys_eq, xs_eq]
+
+/-- Convert an expression denoting a list to a list of elements. -/
+meta def tactic.norm_num.eval_list : expr → tactic (list expr × expr)
+| e@`(list.nil) := do
+  eq ← mk_eq_refl e,
+  pure ([], eq)
+| e@`(list.cons %%x %%xs) := do
+  (xs, xs_eq) ← tactic.norm_num.eval_list xs,
+  eq ← i_to_expr ``(list.cons_congr %%x %%xs_eq),
+  pure (x :: xs, eq)
+| e@`(list.range %%en) := do
+  n ← expr.to_nat en,
+  eis ← (list.range n).mmap (λ i, expr.of_nat `(ℕ) i),
+  eq ← mk_eq_refl e,
+  pure (eis, eq)
+| `(@list.map %%α %%β %%ef %%exs) := do
+  (xs, xs_eq) ← tactic.norm_num.eval_list exs,
+  (ys, ys_eq) ← tactic.norm_num.eval_list_map ef xs,
+  eq ← i_to_expr ``(tactic.norm_num.list.map_congr %%ef %%xs_eq %%ys_eq),
+  pure (ys, eq)
+| e := fail (to_fmt "Unknown list expression" ++ format.line ++ to_fmt e)
+
+@[to_additive]
+lemma list.prod_cons_congr {α : Type*} [monoid α] (xs : list α) (x y z : α)
+  (his : xs.prod = y) (hi : x * y = z) : (x :: xs).prod = z :=
+by rw [list.prod_cons, his, hi]
+
+/-- Evaluate `list.prod %%xs`,
+producing the evaluated expression and an equality proof. -/
+meta def list.prove_prod (α : expr) : list expr → tactic (expr × expr)
+| [] := do
+  result ← expr.of_nat α 1,
+  proof ← i_to_expr ``(@list.prod_nil %%α _),
+  pure (result, proof)
+| (x :: xs) := do
+  eval_xs ← list.prove_prod xs,
+  xxs ← i_to_expr ``(%%x * %%eval_xs.1),
+  eval_xxs ← or_refl_conv norm_num.derive xxs,
+  exs ← expr.of_list α xs,
+  proof ← i_to_expr
+    ``(list.prod_cons_congr %%exs%%x %%eval_xs.1 %%eval_xxs.1 %%eval_xs.2 %%eval_xxs.2),
+  pure (eval_xxs.1, proof)
+
+/-- Evaluate `list.sum %%xs`,
+sumucing the evaluated expression and an equality proof. -/
+meta def list.prove_sum (α : expr) : list expr → tactic (expr × expr)
+| [] := do
+  result ← expr.of_nat α 0,
+  proof ← i_to_expr ``(@list.sum_nil %%α _),
+  pure (result, proof)
+| (x :: xs) := do
+  eval_xs ← list.prove_sum xs,
+  xxs ← i_to_expr ``(%%x + %%eval_xs.1),
+  eval_xxs ← or_refl_conv norm_num.derive xxs,
+  exs ← expr.of_list α xs,
+  proof ← i_to_expr
+    ``(list.sum_cons_congr %%exs%%x %%eval_xs.1 %%eval_xxs.1 %%eval_xs.2 %%eval_xxs.2),
+  pure (eval_xxs.1, proof)
+
+@[to_additive] lemma list.prod_congr {α : Type*} [monoid α] {xs xs' : list α} {z : α}
+  (h₁ : xs = xs') (h₂ : xs'.prod = z) : xs.prod = z := by cc
+
+@[to_additive] lemma multiset.prod_congr {α : Type*} [comm_monoid α]
+  {xs : multiset α} {xs' : list α} {z : α}
+  (h₁ : xs = (xs' : multiset α)) (h₂ : xs'.prod = z) : xs.prod = z :=
+by rw [← h₂, ← multiset.coe_prod, h₁]
+
+/-- Evaluate `(%%xs.map (%%ef : %%α → %%β)).prod`,
+producing the evaluated expression and an equality proof. -/
+meta def list.prove_prod_map (β ef : expr) (xs : list expr) : tactic (expr × expr) := do
+  (fxs, fxs_eq) ← tactic.norm_num.eval_list_map ef xs,
+  (prod, prod_eq) ← list.prove_prod β fxs,
+  eq ← i_to_expr ``(list.prod_congr %%fxs_eq %%prod_eq),
+  pure (prod, eq)
+
+/-- Evaluate `(%%xs.map (%%ef : %%α → %%β)).sum`,
+producing the evaluated expression and an equality proof. -/
+meta def list.prove_sum_map (β ef : expr) (xs : list expr) : tactic (expr × expr) := do
+  (fxs, fxs_eq) ← tactic.norm_num.eval_list_map ef xs,
+  (sum, sum_eq) ← list.prove_sum β fxs,
+  eq ← i_to_expr ``(list.sum_congr %%fxs_eq %%sum_eq),
+  pure (sum, eq)
+
+@[to_additive]
+lemma finset.eval_prod_of_list {β α : Type*} [comm_monoid β]
+  (s : finset α) (f : α → β) {is : list α} (his : is.nodup)
+  (hs : finset.mk ↑is (multiset.coe_nodup.mpr his) = s)
+  {x : β} (hx : (is.map f).prod = x) :
+  s.prod f = x :=
+by rw [← hs, finset.prod_mk, multiset.coe_map, multiset.coe_prod, hx]
+
+/-- `norm_num` plugin for evaluating big operators:
+ * `list.prod`
+ * `list.sum`
+ * `multiset.prod`
+ * `multiset.sum`
+ * `finset.prod`
+ * `finset.sum`
+-/
+@[norm_num] meta def tactic.norm_num.eval_big_operators : expr → tactic (expr × expr)
+| `(@list.prod %%α %%inst1 %%inst2 %%exs) := tactic.trace_error "" $ do
+  (xs, list_eq) ← tactic.norm_num.eval_list exs,
+  (result, sum_eq) ← list.prove_prod α xs,
+  pf ← i_to_expr ``(list.prod_congr %%list_eq %%sum_eq),
+  pure (result, pf)
+| `(@list.sum %%α %%inst1 %%inst2 %%exs) := tactic.trace_error "" $ do
+  (xs, list_eq) ← tactic.norm_num.eval_list exs,
+  (result, sum_eq) ← list.prove_sum α xs,
+  pf ← i_to_expr ``(list.sum_congr %%list_eq %%sum_eq),
+  pure (result, pf)
+| `(@multiset.prod %%α %%inst %%exs) := tactic.trace_error "" $ do
+  (xs, list_eq) ← tactic.norm_num.eval_multiset exs,
+  (result, sum_eq) ← list.prove_prod α xs,
+  pf ← i_to_expr ``(multiset.prod_congr %%list_eq %%sum_eq),
+  pure (result, pf)
+| `(@multiset.sum %%α %%inst %%exs) := tactic.trace_error "" $ do
+  (xs, list_eq) ← tactic.norm_num.eval_multiset exs,
+  (result, sum_eq) ← list.prove_sum α xs,
+  pf ← i_to_expr ``(multiset.sum_congr %%list_eq %%sum_eq),
+  pure (result, pf)
+| `(@finset.prod %%β %%α %%inst %%es %%ef) := tactic.trace_error "" $ do
+  (xs, list_eq, nodup) ← tactic.norm_num.eval_finset tactic.norm_num.decide_eq es,
+  (result, sum_eq) ← list.prove_prod_map β ef xs,
+  pf ← i_to_expr ``(finset.eval_prod_of_list %%es %%ef %%nodup %%list_eq %%sum_eq),
+  pure (result, pf)
+| `(@finset.sum %%β %%α %%inst %%es %%ef) := tactic.trace_error "" $ do
+  (xs, list_eq, nodup) ← tactic.norm_num.eval_finset tactic.norm_num.decide_eq es,
+  (result, sum_eq) ← list.prove_sum_map β ef xs,
+  pf ← i_to_expr ``(finset.eval_sum_of_list %%es %%ef %%nodup %%list_eq %%sum_eq),
+  pure (result, pf)
+| _ := failed

--- a/src/tactic/core.lean
+++ b/src/tactic/core.lean
@@ -64,6 +64,13 @@ protected meta def of_int (α : expr) : ℤ → tactic expr
   e ← expr.of_nat α (n+1),
   tactic.mk_app ``has_neg.neg [e]
 
+/-- Convert a list of expressions to an expression denoting the list of those expressions. -/
+meta def of_list (α : expr) : list expr → tactic expr
+| [] := tactic.mk_app ``list.nil [α]
+| (x :: xs) := do
+  exs ← of_list xs,
+  tactic.mk_app ``list.cons [α, x, exs]
+
 /-- Generates an expression of the form `∃(args), inner`. `args` is assumed to be a list of local
 constants. When possible, `p ∧ q` is used instead of `∃(_ : p), q`. -/
 meta def mk_exists_lst (args : list expr) (inner : expr) : tactic expr :=

--- a/test/norm_num_ext.lean
+++ b/test/norm_num_ext.lean
@@ -3,11 +3,12 @@ Copyright (c) 2021 Mario Carneiro All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro
 -/
-import data.int.gcd
-import data.nat.sqrt_norm_num
-import data.nat.prime
-import data.nat.fib
+import algebra.big_operators.norm_num
 import algebra.squarefree
+import data.int.gcd
+import data.nat.fib
+import data.nat.prime
+import data.nat.sqrt_norm_num
 
 /-!
 # Tests for `norm_num` extensions
@@ -255,3 +256,39 @@ example : nat.fib 10 = 55 := by norm_num
 example : nat.fib 37 = 24157817 := by norm_num
 example : nat.fib 64 = 10610209857723 := by norm_num
 example : nat.fib 100 + nat.fib 101 = nat.fib 102 := by norm_num
+
+section big_operators
+
+variables {α : Type*} [comm_ring α]
+
+open_locale big_operators
+
+-- Lists:
+example : ([1, 2, 1, 3]).sum = 7 := by norm_num [-list.sum_cons]
+example : (([1, 2, 1, 3] : list ℚ).map (λ i, i^2)).sum = 15 := by norm_num [-list.map]
+example : (list.range 10).sum = 45 := by norm_num [-list.range_succ]
+
+-- Multisets:
+example : (1 ::ₘ 2 ::ₘ 1 ::ₘ 3 ::ₘ {}).sum = 7 := by norm_num [-multiset.sum_cons]
+example : ((1 ::ₘ 2 ::ₘ 1 ::ₘ 3 ::ₘ {}).map (λ i, i^2)).sum = 15 := by norm_num [-multiset.map_cons]
+example : (({1, 2, 1, 3} : multiset ℚ).map (λ i, i^2)).sum = 15 := by norm_num [-multiset.map_cons]
+example : (multiset.range 10).sum = 45 := by norm_num [-multiset.map_cons, -multiset.range_succ]
+
+-- Finsets:
+example (f : fin 0 → α) : ∑ i : fin 0, f i = 0 := by norm_num
+example (f : ℕ → α) : ∑ i in (∅ : finset ℕ), f i = 0 := by norm_num
+example (f : fin 3 → α) : ∑ i : fin 3, f i = f 0 + f 1 + f 2 := by norm_num; ring
+example (f : fin 4 → α) : ∑ i : fin 4, f i = f 0 + f 1 + f 2 + f 3 := by norm_num; ring
+example (f : ℕ → α) : ∑ i in {0, 1, 2}, f i = f 0 + f 1 + f 2 := by norm_num; ring
+example (f : ℕ → α) : ∑ i in {0, 2, 2, 3, 1, 0}, f i = f 0 + f 1 + f 2 + f 3 := by norm_num; ring
+example (f : ℕ → α) : ∑ i in {0, 2, 2 - 3, 3 - 1, 1, 0}, f i = f 0 + f 1 + f 2 := by norm_num; ring
+example : (∑ i in finset.range 10, (i^2 : ℕ)) = 285 := by norm_num
+
+-- Combined with other `norm_num` extensions:
+example : ∏ i in finset.range 9, nat.sqrt (i + 1) = 96 := by norm_num
+example : ∏ i in {1, 4, 9, 16}, nat.sqrt i = 24 := by norm_num
+
+-- Nested operations:
+example : ∑ i : fin 2, ∑ j : fin 2, ![![0, 1], ![2, 3]] i j = 6 := by norm_num
+
+end big_operators


### PR DESCRIPTION
This PR provides a plugin for the `norm_num` tactic that can evaluate finite sums and products, over lists, multisets and finsets.

`simp` could already handle some of these operations, but `norm_num` is overall much more suited to dealing with larger numerical operations such as arising from large sums.

I implemented the tactic as a `norm_num` plugin since it's intended to deal with numbers. I'm happy to make it its own tactic (`norm_bigop`?) if you feel this is outside of the `norm_num` scope. Similarly, I could also make a separate tactic for the parts that rewrite a list/multiset/finset into a sequence of `list.cons`es.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
