### PR TITLE
[Merged by Bors] - chore(analysis/*): move matrix definitions into their own file and generalize

### DIFF
--- a/src/analysis/matrix.lean
+++ b/src/analysis/matrix.lean
@@ -1,0 +1,72 @@
+/-
+Copyright (c) 2021 Heather Macbeth. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Heather Macbeth
+-/
+import analysis.normed_space.basic
+
+/-!
+# Matrices as a normed space
+
+In this file we provide the following non-instances on matrices, using the elementwise norm:
+
+* `matrix.semi_normed_group`
+* `matrix.normed_group`
+* `matrix.normed_space`
+
+These are not declared as instances because there are several natural choices for defining the norm
+of a matrix.
+-/
+
+noncomputable theory
+
+namespace matrix
+
+variables {R n m α : Type*} [fintype n] [fintype m]
+
+section semi_normed_group
+variables [semi_normed_group α]
+
+/-- Seminormed group instance (using sup norm of sup norm) for matrices over a seminormed ring. Not
+declared as an instance because there are several natural choices for defining the norm of a
+matrix. -/
+protected def semi_normed_group : semi_normed_group (matrix n m α) :=
+pi.semi_normed_group
+
+local attribute [instance] matrix.semi_normed_group
+
+lemma norm_le_iff {r : ℝ} (hr : 0 ≤ r) {A : matrix n m α} :
+  ∥A∥ ≤ r ↔ ∀ i j, ∥A i j∥ ≤ r :=
+by simp [pi_norm_le_iff hr]
+
+lemma norm_lt_iff {r : ℝ} (hr : 0 < r) {A : matrix n m α} :
+  ∥A∥ < r ↔ ∀ i j, ∥A i j∥ < r :=
+by simp [pi_norm_lt_iff hr]
+
+lemma norm_entry_le_entrywise_sup_norm (A : matrix n m α) {i : n} {j : m} :
+  ∥A i j∥ ≤ ∥A∥ :=
+(norm_le_pi_norm (A i) j).trans (norm_le_pi_norm A i)
+
+end semi_normed_group
+
+/-- Normed group instance (using sup norm of sup norm) for matrices over a normed ring.  Not
+declared as an instance because there are several natural choices for defining the norm of a
+matrix. -/
+protected def normed_group [normed_group α] : normed_group (matrix n m α) :=
+pi.normed_group
+
+
+section normed_space
+local attribute [instance] matrix.semi_normed_group
+
+variables [normed_field R] [semi_normed_group α] [normed_space R α]
+
+/-- Normed space instance (using sup norm of sup norm) for matrices over a normed field.  Not
+declared as an instance because there are several natural choices for defining the norm of a
+matrix. -/
+protected def normed_space : normed_space R (matrix n m α) :=
+pi.normed_space
+
+end normed_space
+
+end matrix

--- a/src/analysis/normed/normed_field.lean
+++ b/src/analysis/normed/normed_field.lean
@@ -164,25 +164,6 @@ instance prod.non_unital_semi_normed_ring [non_unital_semi_normed_ring β] :
         ... = (∥x∥*∥y∥) : rfl,
   ..prod.semi_normed_group }
 
-/-- Seminormed group instance (using sup norm of sup norm) for matrices over a seminormed ring. Not
-declared as an instance because there are several natural choices for defining the norm of a
-matrix. -/
-def matrix.semi_normed_group {n m : Type*} [fintype n] [fintype m] :
-  semi_normed_group (matrix n m α) :=
-pi.semi_normed_group
-
-local attribute [instance] matrix.semi_normed_group
-
-lemma norm_matrix_le_iff {n m : Type*} [fintype n] [fintype m] {r : ℝ} (hr : 0 ≤ r)
-  {A : matrix n m α} :
-  ∥A∥ ≤ r ↔ ∀ i j, ∥A i j∥ ≤ r :=
-by simp [pi_norm_le_iff hr]
-
-lemma norm_matrix_lt_iff {n m : Type*} [fintype n] [fintype m] {r : ℝ} (hr : 0 < r)
-  {A : matrix n m α} :
-  ∥A∥ < r ↔ ∀ i j, ∥A i j∥ < r :=
-by simp [pi_norm_lt_iff hr]
-
 end non_unital_semi_normed_ring
 
 section semi_normed_ring
@@ -276,11 +257,6 @@ instance prod.non_unital_normed_ring [non_unital_normed_ring β] : non_unital_no
 { norm_mul := norm_mul_le,
   ..prod.semi_normed_group }
 
-/-- Normed group instance (using sup norm of sup norm) for matrices over a normed ring.  Not
-declared as an instance because there are several natural choices for defining the norm of a
-matrix. -/
-def matrix.normed_group {n m : Type*} [fintype n] [fintype m] : normed_group (matrix n m α) :=
-pi.normed_group
 
 end non_unital_normed_ring
 

--- a/src/analysis/normed_space/basic.lean
+++ b/src/analysis/normed_space/basic.lean
@@ -284,23 +284,6 @@ lemma rescale_to_shell {c : α} (hc : 1 < ∥c∥) {ε : ℝ} (εpos : 0 < ε) {
   ∃d:α, d ≠ 0 ∧ ∥d • x∥ < ε ∧ (ε/∥c∥ ≤ ∥d • x∥) ∧ (∥d∥⁻¹ ≤ ε⁻¹ * ∥c∥ * ∥x∥) :=
 rescale_to_shell_semi_normed hc εpos (ne_of_lt (norm_pos_iff.2 hx)).symm
 
-section
-local attribute [instance] matrix.normed_group
-
-/-- Normed space instance (using sup norm of sup norm) for matrices over a normed field.  Not
-declared as an instance because there are several natural choices for defining the norm of a
-matrix. -/
-def matrix.normed_space {α : Type*} [normed_field α] {n m : Type*} [fintype n] [fintype m] :
-  normed_space α (matrix n m α) :=
-pi.normed_space
-
-lemma matrix.norm_entry_le_entrywise_sup_norm {α : Type*} [normed_ring α] {n m : Type*} [fintype n]
-  [fintype m] (M : (matrix n m α)) {i : n} {j : m} :
-  ∥M i j∥ ≤ ∥M∥ :=
-(norm_le_pi_norm (M i) j).trans (norm_le_pi_norm M i)
-
-end
-
 end normed_group
 
 section normed_space_nondiscrete

--- a/src/analysis/normed_space/finite_dimension.lean
+++ b/src/analysis/normed_space/finite_dimension.lean
@@ -7,6 +7,7 @@ import analysis.asymptotics.asymptotic_equivalent
 import analysis.normed_space.affine_isometry
 import analysis.normed_space.operator_norm
 import analysis.normed_space.riesz_lemma
+import analysis.matrix
 import linear_algebra.matrix.to_lin
 import topology.algebra.matrix
 

--- a/src/analysis/normed_space/star/basic.lean
+++ b/src/analysis/normed_space/star/basic.lean
@@ -35,7 +35,7 @@ open_locale topological_space
 local postfix `⋆`:std.prec.max_plus := star
 
 /-- A normed star group is a normed group with a compatible `star` which is isometric. -/
-class normed_star_group (E : Type*) [normed_group E] [star_add_monoid E] : Prop :=
+class normed_star_group (E : Type*) [semi_normed_group E] [star_add_monoid E] : Prop :=
 (norm_star : ∀ {x : E}, ∥x⋆∥ = ∥x∥)
 
 export normed_star_group (norm_star)
@@ -44,7 +44,7 @@ attribute [simp] norm_star
 variables {𝕜 E α : Type*}
 
 section normed_star_group
-variables [normed_group E] [star_add_monoid E] [normed_star_group E]
+variables [semi_normed_group E] [star_add_monoid E] [normed_star_group E]
 
 /-- The `star` map in a normed star group is a normed group homomorphism. -/
 def star_normed_group_hom : normed_group_hom E E :=
@@ -218,25 +218,3 @@ variables {𝕜}
 lemma starₗᵢ_apply {x : E} : starₗᵢ 𝕜 x = star x := rfl
 
 end starₗᵢ
-
-section matrix
-
-local attribute [instance] matrix.normed_group
-
-open_locale matrix
-
-@[simp] lemma matrix.entrywise_sup_norm_star_eq_norm {n : Type*} [normed_ring E] [star_add_monoid E]
-  [normed_star_group E] [fintype n] (M : (matrix n n E)) : ∥star M∥ = ∥M∥ :=
-begin
-  refine le_antisymm (by simp [norm_matrix_le_iff, M.norm_entry_le_entrywise_sup_norm]) _,
-  refine ((norm_matrix_le_iff (norm_nonneg _)).mpr (λ i j, _)).trans
-    (congr_arg _ M.star_eq_conj_transpose).ge,
-  exact (normed_star_group.norm_star).symm.le.trans Mᴴ.norm_entry_le_entrywise_sup_norm
-end
-
-@[priority 100] -- see Note [lower instance priority]
-instance matrix.to_normed_star_group {n : Type*} [normed_ring E] [star_add_monoid E]
-  [normed_star_group E] [fintype n] : normed_star_group (matrix n n E) :=
-⟨matrix.entrywise_sup_norm_star_eq_norm⟩
-
-end matrix

--- a/src/analysis/normed_space/star/matrix.lean
+++ b/src/analysis/normed_space/star/matrix.lean
@@ -3,6 +3,7 @@ Copyright (c) 2022 Hans Parshall. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Hans Parshall
 -/
+import analysis.matrix
 import analysis.normed_space.basic
 import data.complex.is_R_or_C
 import linear_algebra.unitary_group
@@ -15,10 +16,29 @@ This file collects facts about the unitary matrices over `𝕜` (either `ℝ` or
 
 open_locale big_operators matrix
 
-variables {𝕜 n : Type*} [is_R_or_C 𝕜]
-variables [fintype n] [decidable_eq n]
+variables {𝕜 n E : Type*}
+
+namespace matrix
+variables [fintype n] [semi_normed_group E] [star_add_monoid E] [normed_star_group E]
+
+local attribute [instance] matrix.semi_normed_group
+
+@[simp] lemma entrywise_sup_norm_star_eq_norm (M : matrix n n E) : ∥star M∥ = ∥M∥ :=
+begin
+  refine le_antisymm (by simp [matrix.norm_le_iff, M.norm_entry_le_entrywise_sup_norm]) _,
+  refine ((matrix.norm_le_iff (norm_nonneg _)).mpr (λ i j, _)).trans
+    (congr_arg _ M.star_eq_conj_transpose).ge,
+  exact (normed_star_group.norm_star).symm.le.trans Mᴴ.norm_entry_le_entrywise_sup_norm
+end
+
+@[priority 100] -- see Note [lower instance priority]
+instance to_normed_star_group : normed_star_group (matrix n n E) :=
+⟨matrix.entrywise_sup_norm_star_eq_norm⟩
+
+end matrix
 
 section entrywise_sup_norm
+variables [is_R_or_C 𝕜] [fintype n] [decidable_eq n]
 
 lemma entry_norm_bound_of_unitary {U : matrix n n 𝕜} (hU : U ∈ matrix.unitary_group n 𝕜) (i j : n):
   ∥U i j∥ ≤ 1 :=

--- a/src/number_theory/modular.lean
+++ b/src/number_theory/modular.lean
@@ -6,6 +6,7 @@ Authors: Alex Kontorovich, Heather Macbeth, Marc Masdeu
 
 import analysis.complex.upper_half_plane
 import linear_algebra.general_linear_group
+import analysis.matrix
 
 /-!
 # The action of the modular group SL(2, ℤ) on the upper half-plane


### PR DESCRIPTION
This makes it much easier to relax the typeclasses as needed.

`norm_matrix_le_iff` has been renamed to `matrix.norm_le_iff`, the rest of the lemmas have just had their typeclass arguments weakened. No proofs have changed.

The `matrix.normed_space` instance is now of the form `normed_space R (matrix n m α)` instead of `normed_space α (matrix n m α)`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
