### PR TITLE
[Merged by Bors] - feat(group_theory/complement): Existence of transversals

### DIFF
--- a/src/group_theory/complement.lean
+++ b/src/group_theory/complement.lean
@@ -198,7 +198,7 @@ mem_left_transversals_iff_exists_unique_quotient_mk'_eq.trans
 mem_right_transversals_iff_exists_unique_quotient_mk'_eq.trans
   (function.bijective_iff_exists_unique (S.restrict quotient.mk')).symm
 
-lemma exists_left_transversal [decidable_eq (G ⧸ H)] (g : G) :
+@[to_additive] lemma exists_left_transversal [decidable_eq (G ⧸ H)] (g : G) :
   ∃ S ∈ left_transversals (H : set G), g ∈ S :=
 begin
   let f : G ⧸ H → G := function.update quotient.out' g g,
@@ -213,7 +213,8 @@ begin
   exact congr_arg _ (((hf q₁).symm.trans hg).trans (hf q₂)),
 end
 
-lemma exists_right_transversal [decidable_eq (quotient (quotient_group.right_rel H))] (g : G) :
+@[to_additive] lemma exists_right_transversal
+  [decidable_eq (quotient (quotient_group.right_rel H))] (g : G) :
   ∃ S ∈ right_transversals (H : set G), g ∈ S :=
 begin
   let f : _ → G := function.update quotient.out' (quotient.mk' g) g,

--- a/src/group_theory/complement.lean
+++ b/src/group_theory/complement.lean
@@ -198,9 +198,10 @@ mem_left_transversals_iff_exists_unique_quotient_mk'_eq.trans
 mem_right_transversals_iff_exists_unique_quotient_mk'_eq.trans
   (function.bijective_iff_exists_unique (S.restrict quotient.mk')).symm
 
-@[to_additive] lemma exists_left_transversal [decidable_eq (G ⧸ H)] (g : G) :
+@[to_additive] lemma exists_left_transversal (g : G) :
   ∃ S ∈ left_transversals (H : set G), g ∈ S :=
 begin
+  classical,
   let f : G ⧸ H → G := function.update quotient.out' g g,
   have hf : ∀ q, ↑(f q) = q,
   { intro q,
@@ -213,10 +214,10 @@ begin
   exact congr_arg _ (((hf q₁).symm.trans hg).trans (hf q₂)),
 end
 
-@[to_additive] lemma exists_right_transversal
-  [decidable_eq (quotient (quotient_group.right_rel H))] (g : G) :
+@[to_additive] lemma exists_right_transversal (g : G) :
   ∃ S ∈ right_transversals (H : set G), g ∈ S :=
 begin
+  classical,
   let f : _ → G := function.update quotient.out' (quotient.mk' g) g,
   have hf : ∀ q : quotient (quotient_group.right_rel H), quotient.mk' (f q) = q,
   { intro q,

--- a/src/group_theory/complement.lean
+++ b/src/group_theory/complement.lean
@@ -198,6 +198,36 @@ mem_left_transversals_iff_exists_unique_quotient_mk'_eq.trans
 mem_right_transversals_iff_exists_unique_quotient_mk'_eq.trans
   (function.bijective_iff_exists_unique (S.restrict quotient.mk')).symm
 
+lemma exists_left_transversal [decidable_eq (G ⧸ H)] (g : G) :
+  ∃ S ∈ left_transversals (H : set G), g ∈ S :=
+begin
+  let f : G ⧸ H → G := function.update quotient.out' g g,
+  have hf : ∀ q, ↑(f q) = q,
+  { intro q,
+    by_cases hq : q = g,
+    { exact hq.symm ▸ congr_arg _ (function.update_same g g quotient.out') },
+    { exact eq.trans (congr_arg _ (function.update_noteq hq g quotient.out')) q.out_eq' } },
+  refine ⟨set.range f, mem_left_transversals_iff_bijective.mpr ⟨_, λ q, ⟨⟨f q, q, rfl⟩, hf q⟩⟩,
+    ⟨g, function.update_same g g quotient.out'⟩⟩,
+  rintros ⟨-, q₁, rfl⟩ ⟨-, q₂, rfl⟩ hg,
+  exact congr_arg _ (((hf q₁).symm.trans hg).trans (hf q₂)),
+end
+
+lemma exists_right_transversal [decidable_eq (quotient (quotient_group.right_rel H))] (g : G) :
+  ∃ S ∈ right_transversals (H : set G), g ∈ S :=
+begin
+  let f : _ → G := function.update quotient.out' (quotient.mk' g) g,
+  have hf : ∀ q : quotient (quotient_group.right_rel H), quotient.mk' (f q) = q,
+  { intro q,
+    by_cases hq : q = quotient.mk' g,
+    { exact hq.symm ▸ congr_arg _ (function.update_same (quotient.mk' g) g quotient.out') },
+    { exact eq.trans (congr_arg _ (function.update_noteq hq g quotient.out')) q.out_eq' } },
+  refine ⟨set.range f, mem_right_transversals_iff_bijective.mpr ⟨_, λ q, ⟨⟨_, q, rfl⟩, hf q⟩⟩,
+    ⟨quotient.mk' g, function.update_same (quotient.mk' g) g quotient.out'⟩⟩,
+  rintros ⟨-, q₁, rfl⟩ ⟨-, q₂, rfl⟩ hg,
+  exact congr_arg _ (((hf q₁).symm.trans hg).trans (hf q₂)),
+end
+
 namespace mem_left_transversals
 
 /-- A left transversal is in bijection with left cosets. -/


### PR DESCRIPTION
This PR constructs transversals containing a specified element. This will be useful for Schreier's lemma (which requires a transversal containing the identity element).

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
