### PR TITLE
[Merged by Bors] - refactor(group_theory/schur_zassenhaus): Some golfing

### DIFF
--- a/src/group_theory/schur_zassenhaus.lean
+++ b/src/group_theory/schur_zassenhaus.lean
@@ -49,7 +49,7 @@ lemma smul_symm_apply_eq_mul_symm_apply_inv_smul
 begin
   refine (subtype.ext_iff.mp ((to_equiv (g • α).2).apply_eq_iff_eq_symm_apply.mpr _)).trans
     (subtype.coe_mk _ (mem_left_coset g (subtype.mem _))),
-  change q = g • ((to_equiv α.2).symm (to_equiv α.2 (g⁻¹ • q : G ⧸ H))),
+  change q = g • (to_equiv α.2).symm (to_equiv α.2 (g⁻¹ • q)),
   rw [equiv.symm_apply_apply, ←mul_smul, mul_inv_self, one_smul],
 end
 

--- a/src/group_theory/schur_zassenhaus.lean
+++ b/src/group_theory/schur_zassenhaus.lean
@@ -46,12 +46,9 @@ variables {G : Type*} [group G] {H : subgroup G}
 lemma smul_symm_apply_eq_mul_symm_apply_inv_smul
   (g : G) (α : left_transversals (H : set G)) (q : G ⧸ H) :
   ↑(to_equiv (g • α).2 q) = g * (to_equiv α.2 (g⁻¹ • q : G ⧸ H)) :=
-begin
-  refine (subtype.ext_iff.mp ((to_equiv (g • α).2).apply_eq_iff_eq_symm_apply.mpr _)).trans
-    (subtype.coe_mk _ (mem_left_coset g (subtype.mem _))),
-  change q = g • (to_equiv α.2).symm (to_equiv α.2 (g⁻¹ • q)),
-  rw [equiv.symm_apply_apply, smul_inv_smul],
-end
+(subtype.ext_iff.mp (by exact (to_equiv (g • α).2).apply_eq_iff_eq_symm_apply.mpr
+  ((congr_arg _ ((to_equiv α.2).symm_apply_apply _)).trans (smul_inv_smul g q)).symm)).trans
+  (subtype.coe_mk _ (mem_left_coset g (subtype.mem _)))
 
 variables [is_commutative H] [fintype (G ⧸ H)]
 

--- a/src/group_theory/schur_zassenhaus.lean
+++ b/src/group_theory/schur_zassenhaus.lean
@@ -47,8 +47,8 @@ lemma smul_symm_apply_eq_mul_symm_apply_inv_smul
   (g : G) (α : left_transversals (H : set G)) (q : G ⧸ H) :
   ↑(to_equiv (g • α).2 q) = g * (to_equiv α.2 (g⁻¹ • q : G ⧸ H)) :=
 begin
-  change ↑(to_equiv (g • α).2 q) = ↑(⟨_, mem_left_coset g (subtype.mem _)⟩ : (g • α).1),
-  refine subtype.ext_iff.mp ((to_equiv (g • α).2).apply_eq_iff_eq_symm_apply.mpr _),
+  refine eq.trans (subtype.ext_iff.mp ((to_equiv (g • α).2).apply_eq_iff_eq_symm_apply.mpr _))
+    (subtype.coe_mk _ (mem_left_coset g (subtype.mem _))),
   change q = g • ((to_equiv α.2).symm (to_equiv α.2 (g⁻¹ • q : G ⧸ H))),
   rw [equiv.symm_apply_apply, ←mul_smul, mul_inv_self, one_smul],
 end

--- a/src/group_theory/schur_zassenhaus.lean
+++ b/src/group_theory/schur_zassenhaus.lean
@@ -50,7 +50,7 @@ begin
   refine (subtype.ext_iff.mp ((to_equiv (g • α).2).apply_eq_iff_eq_symm_apply.mpr _)).trans
     (subtype.coe_mk _ (mem_left_coset g (subtype.mem _))),
   change q = g • (to_equiv α.2).symm (to_equiv α.2 (g⁻¹ • q)),
-  rw [equiv.symm_apply_apply, ←mul_smul, mul_inv_self, one_smul],
+  rw [equiv.symm_apply_apply, smul_inv_smul],
 end
 
 variables [is_commutative H] [fintype (G ⧸ H)]

--- a/src/group_theory/schur_zassenhaus.lean
+++ b/src/group_theory/schur_zassenhaus.lean
@@ -29,6 +29,8 @@ namespace subgroup
 
 section schur_zassenhaus_abelian
 
+open mem_left_transversals
+
 variables {G : Type*} [group G] {H : subgroup G}
 
 @[to_additive] instance : mul_action G (left_transversals (H : set G)) :=
@@ -43,16 +45,12 @@ variables {G : Type*} [group G] {H : subgroup G}
 
 lemma smul_symm_apply_eq_mul_symm_apply_inv_smul
   (g : G) (α : left_transversals (H : set G)) (q : G ⧸ H) :
-  ↑((equiv.of_bijective _ (mem_left_transversals_iff_bijective.mp (g • α).2)).symm q) =
-    g * ((equiv.of_bijective _ (mem_left_transversals_iff_bijective.mp α.2)).symm
-      (g⁻¹ • q : G ⧸ H)) :=
+  ↑(to_equiv (g • α).2 q) = g * (to_equiv α.2 (g⁻¹ • q : G ⧸ H)) :=
 begin
-  let w := (equiv.of_bijective _ (mem_left_transversals_iff_bijective.mp α.2)),
-  let y := (equiv.of_bijective _ (mem_left_transversals_iff_bijective.mp (g • α).2)),
-  change ↑(y.symm q) = ↑(⟨_, mem_left_coset g (subtype.mem _)⟩ : (g • α).1),
-  refine subtype.ext_iff.mp (y.symm_apply_eq.mpr _),
-  change q = g • (w (w.symm (g⁻¹ • q : G ⧸ H))),
-  rw [equiv.apply_symm_apply, ←mul_smul, mul_inv_self, one_smul],
+  change ↑(to_equiv (g • α).2 q) = ↑(⟨_, mem_left_coset g (subtype.mem _)⟩ : (g • α).1),
+  refine subtype.ext_iff.mp ((to_equiv (g • α).2).apply_eq_iff_eq_symm_apply.mpr _),
+  change q = g • ((to_equiv α.2).symm (to_equiv α.2 (g⁻¹ • q : G ⧸ H))),
+  rw [equiv.symm_apply_apply, ←mul_smul, mul_inv_self, one_smul],
 end
 
 variables [is_commutative H] [fintype (G ⧸ H)]
@@ -62,10 +60,8 @@ variables (α β γ : left_transversals (H : set G))
 /-- The difference of two left transversals -/
 @[to_additive "The difference of two left transversals"]
 noncomputable def diff [hH : normal H] : H :=
-let α' := (equiv.of_bijective _ (mem_left_transversals_iff_bijective.mp α.2)).symm,
-    β' := (equiv.of_bijective _ (mem_left_transversals_iff_bijective.mp β.2)).symm in
-∏ (q : G ⧸ H), ⟨(α' q) * (β' q)⁻¹,
-  hH.mem_comm (quotient.exact' ((β'.symm_apply_apply q).trans (α'.symm_apply_apply q).symm))⟩
+∏ (q : G ⧸ H), ⟨(to_equiv α.2 q) * (to_equiv β.2 q)⁻¹, hH.mem_comm (quotient.exact'
+  (((to_equiv β.2).symm_apply_apply q).trans ((to_equiv α.2).symm_apply_apply q).symm))⟩
 
 @[to_additive] lemma diff_mul_diff [normal H] : diff α β * diff β γ = diff α γ :=
 finset.prod_mul_distrib.symm.trans (finset.prod_congr rfl (λ x hx, subtype.ext

--- a/src/group_theory/schur_zassenhaus.lean
+++ b/src/group_theory/schur_zassenhaus.lean
@@ -47,7 +47,7 @@ lemma smul_symm_apply_eq_mul_symm_apply_inv_smul
   (g : G) (α : left_transversals (H : set G)) (q : G ⧸ H) :
   ↑(to_equiv (g • α).2 q) = g * (to_equiv α.2 (g⁻¹ • q : G ⧸ H)) :=
 begin
-  refine eq.trans (subtype.ext_iff.mp ((to_equiv (g • α).2).apply_eq_iff_eq_symm_apply.mpr _))
+  refine (subtype.ext_iff.mp ((to_equiv (g • α).2).apply_eq_iff_eq_symm_apply.mpr _)).trans
     (subtype.coe_mk _ (mem_left_coset g (subtype.mem _))),
   change q = g • ((to_equiv α.2).symm (to_equiv α.2 (g⁻¹ • q : G ⧸ H))),
   rw [equiv.symm_apply_apply, ←mul_smul, mul_inv_self, one_smul],


### PR DESCRIPTION
This PR uses `mem_left_transversals.to_equiv` to golf the start of `schur_zassenhaus.lean`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
