### PR TITLE
[Merged by Bors] - feat(ring_theory/polynomial/pochhammer): add a binomial like recursion for pochhammer

### DIFF
--- a/src/ring_theory/polynomial/pochhammer.lean
+++ b/src/ring_theory/polynomial/pochhammer.lean
@@ -92,6 +92,26 @@ begin
     refl, },
 end
 
+lemma pochhammer_add_pochhammer_aux {R : Type*} [comm_semiring R] : ∀ (n : ℕ),
+  pochhammer R n + n * (pochhammer R (n - 1)).comp (X + 1) = (pochhammer R n).comp (X + 1)
+| 0       := by simp
+| (n + 1) := begin
+    nth_rewrite 0 pochhammer_succ_left,
+    rw [← nat.pred_eq_sub_one, ← n.succ_eq_add_one, n.pred_succ, ← add_mul,
+      pochhammer_succ_right R n, mul_comp, mul_comm, add_comp, X_comp, nat_cast_comp,
+      n.succ_eq_add_one, n.cast_add, nat.cast_one, add_comm ↑n, ← add_assoc]
+  end
+
+lemma pochhammer_add_pochhammer (n : ℕ) :
+  pochhammer S n + n * (pochhammer S (n - 1)).comp (X + 1) = (pochhammer S n).comp (X + 1) :=
+begin
+  have X1 : map (nat.cast_ring_hom S) (X + 1) = X + 1,
+  { simp only [polynomial.map_add, map_X, polynomial.map_one] },
+  rw [← pochhammer_map (nat.cast_ring_hom S) (n - 1), ← pochhammer_map (nat.cast_ring_hom S) n,
+    ← X1, ← map_comp (nat.cast_ring_hom S) (pochhammer ℕ n) (X + 1)],
+  simp [← pochhammer_add_pochhammer_aux n, map_comp],
+end
+
 lemma polynomial.mul_X_add_nat_cast_comp {p q : S[X]} {n : ℕ} :
   (p * (X + n)).comp q = (p.comp q) * (q + n) :=
 by rw [mul_add, add_comp, mul_X_comp, ←nat.cast_comm, nat_cast_mul_comp, nat.cast_comm, mul_add]

--- a/src/ring_theory/polynomial/pochhammer.lean
+++ b/src/ring_theory/polynomial/pochhammer.lean
@@ -93,14 +93,19 @@ begin
 end
 
 lemma pochhammer_add_pochhammer_aux {R : Type*} [comm_semiring R] : ∀ (n : ℕ),
-  pochhammer R n + n * (pochhammer R (n - 1)).comp (X + 1) = (pochhammer R n).comp (X + 1)
+  pochhammer R (n + 1) + (n + 1) * (pochhammer R n).comp (X + 1) =
+    (pochhammer R (n + 1)).comp (X + 1)
 | 0       := by simp
 | (n + 1) := begin
     nth_rewrite 0 pochhammer_succ_left,
-    rw [← nat.pred_eq_sub_one, ← n.succ_eq_add_one, n.pred_succ, ← add_mul,
-      pochhammer_succ_right R n, mul_comp, mul_comm, add_comp, X_comp, nat_cast_comp,
-      n.succ_eq_add_one, n.cast_add, nat.cast_one, add_comm ↑n, ← add_assoc]
+    rw [← add_mul, pochhammer_succ_right R (n + 1), mul_comp, mul_comm, add_comp, X_comp,
+      nat_cast_comp, add_comm ↑(n + 1), ← add_assoc]
   end
+
+lemma pochhammer_add_pochhammer_aux_pred {R : Type*} [comm_semiring R] : ∀ (n : ℕ),
+  pochhammer R n + n * (pochhammer R (n - 1)).comp (X + 1) = (pochhammer R n).comp (X + 1)
+| 0       := by simp
+| (n + 1) := pochhammer_add_pochhammer_aux n
 
 lemma pochhammer_add_pochhammer (n : ℕ) :
   pochhammer S n + n * (pochhammer S (n - 1)).comp (X + 1) = (pochhammer S n).comp (X + 1) :=
@@ -109,7 +114,7 @@ begin
   { simp only [polynomial.map_add, map_X, polynomial.map_one] },
   rw [← pochhammer_map (nat.cast_ring_hom S) (n - 1), ← pochhammer_map (nat.cast_ring_hom S) n,
     ← X1, ← map_comp (nat.cast_ring_hom S) (pochhammer ℕ n) (X + 1)],
-  simp [← pochhammer_add_pochhammer_aux n, map_comp],
+  simp [← pochhammer_add_pochhammer_aux_pred n, map_comp],
 end
 
 lemma polynomial.mul_X_add_nat_cast_comp {p q : S[X]} {n : ℕ} :

--- a/src/ring_theory/polynomial/pochhammer.lean
+++ b/src/ring_theory/polynomial/pochhammer.lean
@@ -94,7 +94,7 @@ end
 
 lemma pochhammer_succ_comp_X_add_one (n : ℕ) :
   (pochhammer S (n + 1)).comp (X + 1) =
-    pochhammer S (n + 1) + (n + 1) * (pochhammer S n).comp (X + 1) :=
+    pochhammer S (n + 1) + (n + 1) • (pochhammer S n).comp (X + 1) :=
 begin
   suffices : (pochhammer ℕ (n + 1)).comp (X + 1) =
               pochhammer ℕ (n + 1) + (n + 1) * (pochhammer ℕ n).comp (X + 1),
@@ -103,13 +103,8 @@ begin
   { simp },
   { nth_rewrite 1 pochhammer_succ_left,
     rw [← add_mul, pochhammer_succ_right ℕ (n + 1), mul_comp, mul_comm, add_comp, X_comp,
-      nat_cast_comp, add_comm ↑(n + 1), ← add_assoc] },
+      nat_cast_comp, add_comm ↑(n + 1), ← add_assoc] }
 end
-
-lemma pochhammer_add_pochhammer : ∀ (n : ℕ),
-  pochhammer S n + n * (pochhammer S (n - 1)).comp (X + 1) = (pochhammer S n).comp (X + 1)
-| 0       := by simp
-| (n + 1) := (pochhammer_succ_comp_X_add_one _ _).symm
 
 lemma polynomial.mul_X_add_nat_cast_comp {p q : S[X]} {n : ℕ} :
   (p * (X + n)).comp q = (p.comp q) * (q + n) :=

--- a/src/ring_theory/polynomial/pochhammer.lean
+++ b/src/ring_theory/polynomial/pochhammer.lean
@@ -92,30 +92,24 @@ begin
     refl, },
 end
 
-lemma pochhammer_add_pochhammer_aux {R : Type*} [comm_semiring R] : ∀ (n : ℕ),
-  pochhammer R (n + 1) + (n + 1) * (pochhammer R n).comp (X + 1) =
-    (pochhammer R (n + 1)).comp (X + 1)
-| 0       := by simp
-| (n + 1) := begin
-    nth_rewrite 0 pochhammer_succ_left,
-    rw [← add_mul, pochhammer_succ_right R (n + 1), mul_comp, mul_comm, add_comp, X_comp,
-      nat_cast_comp, add_comm ↑(n + 1), ← add_assoc]
-  end
-
-lemma pochhammer_add_pochhammer_aux_pred {R : Type*} [comm_semiring R] : ∀ (n : ℕ),
-  pochhammer R n + n * (pochhammer R (n - 1)).comp (X + 1) = (pochhammer R n).comp (X + 1)
-| 0       := by simp
-| (n + 1) := pochhammer_add_pochhammer_aux n
-
-lemma pochhammer_add_pochhammer (n : ℕ) :
-  pochhammer S n + n * (pochhammer S (n - 1)).comp (X + 1) = (pochhammer S n).comp (X + 1) :=
+lemma pochhammer_succ_comp_X_add_one (n : ℕ) :
+  (pochhammer S (n + 1)).comp (X + 1) =
+    pochhammer S (n + 1) + (n + 1) * (pochhammer S n).comp (X + 1) :=
 begin
-  have X1 : map (nat.cast_ring_hom S) (X + 1) = X + 1,
-  { simp only [polynomial.map_add, map_X, polynomial.map_one] },
-  rw [← pochhammer_map (nat.cast_ring_hom S) (n - 1), ← pochhammer_map (nat.cast_ring_hom S) n,
-    ← X1, ← map_comp (nat.cast_ring_hom S) (pochhammer ℕ n) (X + 1)],
-  simp [← pochhammer_add_pochhammer_aux_pred n, map_comp],
+  suffices : (pochhammer ℕ (n + 1)).comp (X + 1) =
+              pochhammer ℕ (n + 1) + (n + 1) * (pochhammer ℕ n).comp (X + 1),
+  { simpa [map_comp] using congr_arg (polynomial.map (nat.cast_ring_hom S)) this },
+  cases n,
+  { simp },
+  { nth_rewrite 1 pochhammer_succ_left,
+    rw [← add_mul, pochhammer_succ_right ℕ (n + 1), mul_comp, mul_comm, add_comp, X_comp,
+      nat_cast_comp, add_comm ↑(n + 1), ← add_assoc] },
 end
+
+lemma pochhammer_add_pochhammer : ∀ (n : ℕ),
+  pochhammer S n + n * (pochhammer S (n - 1)).comp (X + 1) = (pochhammer S n).comp (X + 1)
+| 0       := by simp
+| (n + 1) := (pochhammer_succ_comp_X_add_one _ _).symm
 
 lemma polynomial.mul_X_add_nat_cast_comp {p q : S[X]} {n : ℕ} :
   (p * (X + n)).comp q = (p.comp q) * (q + n) :=


### PR DESCRIPTION
This PR proves the identity

`pochhammer R n + n * (pochhammer R (n - 1)).comp (X + 1) = (pochhammer R n).comp (X + 1)`

analogous to the additive recursion for binomial coefficients.

For the proof, first we prove the result for a `comm_semiring` as `pochhammer_add_pochhammer_aux`.  Next, we apply this identity in the general case.

If someone has any idea of how to make the maths statement: it suffices to show this identity for pochhammer symbols in the commutative case, I would be *very* happy to know!

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
