### PR TITLE
[Merged by Bors] - chore(data/polynomial/eval): golf two proofs involving evals

### DIFF
--- a/src/data/polynomial/eval.lean
+++ b/src/data/polynomial/eval.lean
@@ -641,18 +641,10 @@ mem_map_srange f
 
 lemma eval₂_map [semiring T] (g : S →+* T) (x : T) :
   (p.map f).eval₂ g x = p.eval₂ (g.comp f) x :=
-begin
-  have A : nat_degree (p.map f) < p.nat_degree.succ :=
-    (nat_degree_map_le _ _).trans_lt (nat.lt_succ_self _),
-  conv_lhs { rw [eval₂_eq_sum], },
-  rw [sum_over_range' _ _ _ A],
-  { simp only [coeff_map, eval₂_eq_sum, sum_over_range, forall_const, zero_mul, ring_hom.map_zero,
-      function.comp_app, ring_hom.coe_comp] },
-  { simp only [forall_const, zero_mul, ring_hom.map_zero] }
-end
+(eval₂_eq_eval_map _).trans $ (congr_arg _ (map_map f g p)).trans (eval₂_eq_eval_map _).symm
 
 lemma eval_map (x : S) : (p.map f).eval x = p.eval₂ f x :=
-eval₂_map f (ring_hom.id _) x
+(eval₂_eq_eval_map f).symm
 
 protected lemma map_sum {ι : Type*} (g : ι → R[X]) (s : finset ι) :
   (∑ i in s, g i).map f = ∑ i in s, (g i).map f :=

--- a/src/data/polynomial/eval.lean
+++ b/src/data/polynomial/eval.lean
@@ -641,7 +641,7 @@ mem_map_srange f
 
 lemma eval₂_map [semiring T] (g : S →+* T) (x : T) :
   (p.map f).eval₂ g x = p.eval₂ (g.comp f) x :=
-(eval₂_eq_eval_map _).trans $ (congr_arg _ (map_map f g p)).trans (eval₂_eq_eval_map _).symm
+by rw [eval₂_eq_eval_map, eval₂_eq_eval_map, map_map]
 
 lemma eval_map (x : S) : (p.map f).eval x = p.eval₂ f x :=
 (eval₂_eq_eval_map f).symm


### PR DESCRIPTION
I shortened two proofs involving `eval/eval₂/comp`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
