### PR TITLE
[Merged by Bors] - feat(algebraic_topology): map_alternating_face_map_complex

### DIFF
--- a/src/algebraic_topology/alternating_face_map_complex.lean
+++ b/src/algebraic_topology/alternating_face_map_complex.lean
@@ -153,7 +153,7 @@ def alternating_face_map_complex : simplicial_object C ⥤ chain_complex C ℕ :
 
 variables {C}
 
-def map_alternating_face_map_complex {D : Type*} [category.{v} D] [preadditive D]
+lemma map_alternating_face_map_complex {D : Type*} [category.{v} D] [preadditive D]
   (F : C ⥤ D) [F.additive] :
   alternating_face_map_complex C ⋙ F.map_homological_complex _ =
   (simplicial_object.whiskering C D).obj F ⋙ alternating_face_map_complex D :=

--- a/src/algebraic_topology/alternating_face_map_complex.lean
+++ b/src/algebraic_topology/alternating_face_map_complex.lean
@@ -4,12 +4,8 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Joël Riou, Adam Topaz, Johan Commelin
 -/
 
-import algebra.homology.homological_complex
-import algebraic_topology.simplicial_object
+import algebra.homology.additive
 import algebraic_topology.Moore_complex
-import category_theory.abelian.basic
-import algebra.big_operators.basic
-import tactic.ring_exp
 import data.fintype.card
 
 /-!
@@ -33,13 +29,15 @@ when `A` is an abelian category.
 -/
 
 open category_theory category_theory.limits category_theory.subobject
-open category_theory.preadditive
+open category_theory.preadditive category_theory.category
 open opposite
 
 open_locale big_operators
 open_locale simplicial
 
 noncomputable theory
+
+universe v
 
 namespace algebraic_topology
 
@@ -145,13 +143,38 @@ chain_complex.of_hom _ _ _ _ _ _
 
 end alternating_face_map_complex
 
-variables (C : Type*) [category C] [preadditive C]
+variables (C : Type*) [category.{v} C] [preadditive C]
 
 /-- The alternating face map complex, as a functor -/
 @[simps]
 def alternating_face_map_complex : simplicial_object C ⥤ chain_complex C ℕ :=
 { obj := alternating_face_map_complex.obj,
   map := λ X Y f, alternating_face_map_complex.map f }
+
+variables {C}
+
+def map_alternating_face_map_complex {D : Type*} [category.{v} D] [preadditive D]
+  (F : C ⥤ D) [F.additive] :
+  alternating_face_map_complex C ⋙ F.map_homological_complex _ =
+  (simplicial_object.whiskering C D).obj F ⋙ alternating_face_map_complex D :=
+begin
+  apply category_theory.functor.ext,
+  { intros X Y f,
+    ext n,
+    simp only [functor.comp_map, alternating_face_map_complex.map,
+      alternating_face_map_complex_map, functor.map_homological_complex_map_f,
+      chain_complex.of_hom_f, simplicial_object.whiskering_obj_map_app,
+      homological_complex.comp_f, homological_complex.eq_to_hom_f,
+      eq_to_hom_refl, comp_id, id_comp], },
+  { intro X,
+    erw chain_complex.map_chain_complex_of,
+    congr,
+    ext n,
+    simp only [alternating_face_map_complex.obj_d, functor.map_sum],
+    congr,
+    ext,
+    apply functor.map_zsmul, },
+end
 
 /-!
 ## Construction of the natural inclusion of the normalized Moore complex


### PR DESCRIPTION
In this PR, we obtain a compatibility `map_alternating_face_map_complex` of the construction of the alternating face map complex functor with respect to additive functors between preadditive categories.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
