### PR TITLE
[Merged by Bors] - feat(category_theory/monoidal): define monoidal structures on cartesian products of monoidal categories, (lax) monoidal functors and monoidal natural transformations

### DIFF
--- a/src/category_theory/monoidal/category.lean
+++ b/src/category_theory/monoidal/category.lean
@@ -615,9 +615,22 @@ instance prod_monoidal : monoidal_category (C₁ × C₂) :=
 { tensor_obj := λ X Y, (X.1 ⊗ Y.1, X.2 ⊗ Y.2),
   tensor_hom := λ _ _ _ _ f g, (f.1 ⊗ g.1, f.2 ⊗ g.2),
   tensor_unit := (𝟙_ C₁, 𝟙_ C₂),
-  associator := λ ⟨X₁, X₂⟩ ⟨Y₁, Y₂⟩ ⟨Z₁, Z₂⟩, (α_ X₁ Y₁ Z₁).prod (α_ X₂ Y₂ Z₂),
-  left_unitor := λ ⟨X₁, X₂⟩, (λ_ X₁).prod (λ_ X₂),
-  right_unitor := λ ⟨X₁, X₂⟩, (ρ_ X₁).prod (ρ_ X₂) }
+  associator := λ X Y Z, (α_ X.1 Y.1 Z.1).prod (α_ X.2 Y.2 Z.2),
+  left_unitor := λ X,
+  begin
+    dsimp,
+    have : X = (X.1, X.2) := prod.ext rfl rfl,
+    rw this,
+    dsimp,
+    exact (λ_ X.1).prod (λ_ X.2),
+  end,
+  right_unitor := λ X,
+  begin
+    dsimp,
+    have : X = (X.1, X.2) := prod.ext rfl rfl,
+    rw this,
+    exact (ρ_ X.1).prod (ρ_ X.2),
+  end }
 
 end
 

--- a/src/category_theory/monoidal/category.lean
+++ b/src/category_theory/monoidal/category.lean
@@ -613,17 +613,11 @@ associator_naturality left_unitor_naturality right_unitor_naturality pentagon
 @[simps]
 instance prod_monoidal : monoidal_category (C₁ × C₂) :=
 { tensor_obj := λ X Y, (X.1 ⊗ Y.1, X.2 ⊗ Y.2),
-  tensor_hom := λ X₁ Y₁ X₂ Y₂ f₁ f₂, (f₁.1 ⊗ f₂.1, f₁.2 ⊗ f₂.2),
+  tensor_hom := λ _ _ _ _ f g, (f.1 ⊗ g.1, f.2 ⊗ g.2),
   tensor_unit := (𝟙_ C₁, 𝟙_ C₂),
-  associator := λ X Y Z,
-    { hom := ((α_ X.1 Y.1 Z.1).hom, (α_ X.2 Y.2 Z.2).hom),
-      inv := ((α_ X.1 Y.1 Z.1).inv, (α_ X.2 Y.2 Z.2).inv) },
-  left_unitor := λ X,
-    { hom := ((λ_ X.1).hom, (λ_ X.2).hom),
-      inv := ((λ_ X.1).inv, (λ_ X.2).inv) },
-  right_unitor := λ X,
-    { hom := ((ρ_ X.1).hom, (ρ_ X.2).hom),
-      inv := ((ρ_ X.1).inv, (ρ_ X.2).inv) } }
+  associator := λ ⟨X₁, X₂⟩ ⟨Y₁, Y₂⟩ ⟨Z₁, Z₂⟩, (α_ X₁ Y₁ Z₁).prod (α_ X₂ Y₂ Z₂),
+  left_unitor := λ ⟨X₁, X₂⟩, (λ_ X₁).prod (λ_ X₂),
+  right_unitor := λ ⟨X₁, X₂⟩, (ρ_ X₁).prod (ρ_ X₂) }
 
 end
 

--- a/src/category_theory/monoidal/category.lean
+++ b/src/category_theory/monoidal/category.lean
@@ -615,7 +615,8 @@ instance prod_monoidal : monoidal_category (C₁ × C₂) :=
     { hom := ((α_ X.1 Y.1 Z.1).hom, (α_ X.2 Y.2 Z.2).hom),
       inv := ((α_ X.1 Y.1 Z.1).inv, (α_ X.2 Y.2 Z.2).inv) },
   associator_naturality' := λ X₁ X₂ X₃ Y₁ Y₂ Y₃ f₁ f₂ f₃,
-    congr_arg2 prod.mk (associator_naturality f₁.1 f₂.1 f₃.1) (associator_naturality f₁.2 f₂.2 f₃.2),
+    congr_arg2 prod.mk
+      (associator_naturality f₁.1 f₂.1 f₃.1) (associator_naturality f₁.2 f₂.2 f₃.2),
   left_unitor := λ X,
     { hom := ((λ_ X.1).hom, (λ_ X.2).hom),
       inv := ((λ_ X.1).inv, (λ_ X.2).inv) },
@@ -626,7 +627,8 @@ instance prod_monoidal : monoidal_category (C₁ × C₂) :=
       inv := ((ρ_ X.1).inv, (ρ_ X.2).inv) },
   right_unitor_naturality' :=
     λ X Y f, congr_arg2 prod.mk (right_unitor_naturality f.1) (right_unitor_naturality f.2),
-  pentagon' := λ W X Y Z, congr_arg2 prod.mk (pentagon W.1 X.1 Y.1 Z.1) (pentagon W.2 X.2 Y.2 Z.2) }
+  pentagon' :=
+    λ W X Y Z, congr_arg2 prod.mk (pentagon W.1 X.1 Y.1 Z.1) (pentagon W.2 X.2 Y.2 Z.2) }
 
 end
 

--- a/src/category_theory/monoidal/category.lean
+++ b/src/category_theory/monoidal/category.lean
@@ -607,6 +607,7 @@ universes v₁ v₂ u₁ u₂
 variables (C₁ : Type u₁) [category.{v₁} C₁] [monoidal_category.{v₁} C₁]
 variables (C₂ : Type u₂) [category.{v₂} C₂] [monoidal_category.{v₂} C₂]
 
+@[simps]
 instance prod_monoidal : monoidal_category (C₁ × C₂) :=
 { tensor_obj := λ X Y, (X.1 ⊗ Y.1, X.2 ⊗ Y.2),
   tensor_hom := λ X₁ Y₁ X₂ Y₂ f₁ f₂, (f₁.1 ⊗ f₂.1, f₁.2 ⊗ f₂.2),

--- a/src/category_theory/monoidal/category.lean
+++ b/src/category_theory/monoidal/category.lean
@@ -610,6 +610,7 @@ variables (C₂ : Type u₂) [category.{v₂} C₂] [monoidal_category.{v₂} C�
 local attribute [simp]
 associator_naturality left_unitor_naturality right_unitor_naturality pentagon
 
+@[simps tensor_obj tensor_hom tensor_unit associator]
 instance prod_monoidal : monoidal_category (C₁ × C₂) :=
 { tensor_obj := λ X Y, (X.1 ⊗ Y.1, X.2 ⊗ Y.2),
   tensor_hom := λ _ _ _ _ f g, (f.1 ⊗ g.1, f.2 ⊗ g.2),
@@ -617,17 +618,6 @@ instance prod_monoidal : monoidal_category (C₁ × C₂) :=
   associator := λ X Y Z, (α_ X.1 Y.1 Z.1).prod (α_ X.2 Y.2 Z.2),
   left_unitor := λ ⟨X₁, X₂⟩, (λ_ X₁).prod (λ_ X₂),
   right_unitor := λ ⟨X₁, X₂⟩, (ρ_ X₁).prod (ρ_ X₂) }
-
-@[simp] lemma prod_monoidal_tensor_obj (X Y : C₁ × C₂) :
-  X ⊗ Y = (X.1 ⊗ Y.1, X.2 ⊗ Y.2) := rfl
-
-@[simp] lemma prod_monoidal_tensor_hom {X Y U V : C₁ × C₂} (f : X ⟶ Y) (g : U ⟶ V) :
-  f ⊗ g = (f.1 ⊗ g.1, f.2 ⊗ g.2) := rfl
-
-@[simp] lemma prod_monoidal_tensor_unit : 𝟙_ (C₁ × C₂) = (𝟙_ C₁, 𝟙_ C₂) := rfl
-
-@[simp] lemma prod_monoidal_associator {X Y Z : C₁ × C₂} :
-  α_ X Y Z = (α_ X.1 Y.1 Z.1).prod (α_ X.2 Y.2 Z.2) := rfl
 
 @[simp] lemma prod_monoidal_left_unitor_hom_fst (X : C₁ × C₂) :
   ((λ_ X).hom : (𝟙_ _) ⊗ X ⟶ X).1 = (λ_ X.1).hom := by { cases X, refl }

--- a/src/category_theory/monoidal/category.lean
+++ b/src/category_theory/monoidal/category.lean
@@ -600,6 +600,91 @@ end
 
 end
 
+section
+
+universes v₁ v₂ u₁ u₂
+
+variables (C₁ : Type u₁) [category.{v₁} C₁] [monoidal_category.{v₁} C₁]
+variables (C₂ : Type u₂) [category.{v₂} C₂] [monoidal_category.{v₂} C₂]
+
+instance prod_monoidal : monoidal_category (C₁ × C₂) :=
+{ tensor_obj := λ X Y, (X.1 ⊗ Y.1, X.2 ⊗ Y.2),
+  tensor_hom := λ X₁ Y₁ X₂ Y₂ f₁ f₂, (f₁.1 ⊗ f₂.1, f₁.2 ⊗ f₂.2),
+  tensor_id' :=
+    λ X₁ X₂,
+      congr_arg2 prod.mk
+        (tensor_id X₁.1 X₂.1)
+        (tensor_id X₁.2 X₂.2),
+  tensor_comp' :=
+    λ X₁ Y₁ Z₁ X₂ Y₂ Z₂ f₁ f₂ g₁ g₂,
+      congr_arg2 prod.mk
+        (tensor_comp f₁.1 f₂.1 g₁.1 g₂.1)
+        (tensor_comp f₁.2 f₂.2 g₁.2 g₂.2),
+  tensor_unit := (tensor_unit C₁, tensor_unit C₂),
+  associator :=
+    λ X Y Z,
+      { hom := ((α_ X.1 Y.1 Z.1).hom, (α_ X.2 Y.2 Z.2).hom),
+        inv := ((α_ X.1 Y.1 Z.1).inv, (α_ X.2 Y.2 Z.2).inv),
+        hom_inv_id' :=
+          congr_arg2 prod.mk
+            (hom_inv_id (α_ X.1 Y.1 Z.1))
+            (hom_inv_id (α_ X.2 Y.2 Z.2)),
+        inv_hom_id' :=
+          congr_arg2 prod.mk
+            (inv_hom_id (α_ X.1 Y.1 Z.1))
+            (inv_hom_id (α_ X.2 Y.2 Z.2)) },
+  associator_naturality' :=
+    λ X₁ X₂ X₃ Y₁ Y₂ Y₃ f₁ f₂ f₃,
+      congr_arg2 prod.mk
+        (associator_naturality f₁.1 f₂.1 f₃.1)
+        (associator_naturality f₁.2 f₂.2 f₃.2),
+  left_unitor :=
+    λ X,
+      { hom := ((λ_ X.1).hom, (λ_ X.2).hom),
+        inv := ((λ_ X.1).inv, (λ_ X.2).inv),
+        hom_inv_id' :=
+          congr_arg2 prod.mk
+            (hom_inv_id (λ_ X.1))
+            (hom_inv_id (λ_ X.2)),
+        inv_hom_id' :=
+          congr_arg2 prod.mk
+            (inv_hom_id (λ_ X.1))
+            (inv_hom_id (λ_ X.2)) },
+  left_unitor_naturality' :=
+    λ X Y f,
+      congr_arg2 prod.mk
+        (left_unitor_naturality f.1)
+        (left_unitor_naturality f.2),
+  right_unitor :=
+    λ X,
+      { hom := ((ρ_ X.1).hom, (ρ_ X.2).hom),
+        inv := ((ρ_ X.1).inv, (ρ_ X.2).inv),
+        hom_inv_id' :=
+          congr_arg2 prod.mk
+            (hom_inv_id (ρ_ X.1))
+            (hom_inv_id (ρ_ X.2)),
+        inv_hom_id' :=
+          congr_arg2 prod.mk
+            (inv_hom_id (ρ_ X.1))
+            (inv_hom_id (ρ_ X.2)) },
+  right_unitor_naturality' :=
+    λ X Y f,
+      congr_arg2 prod.mk
+        (right_unitor_naturality f.1)
+        (right_unitor_naturality f.2),
+  pentagon' :=
+    λ W X Y Z,
+      congr_arg2 prod.mk
+        (pentagon W.1 X.1 Y.1 Z.1)
+        (pentagon W.2 X.2 Y.2 Z.2),
+  triangle' :=
+    λ X Y,
+      congr_arg2 prod.mk
+        (triangle X.1 Y.1)
+        (triangle X.2 Y.2) }
+
+end
+
 end monoidal_category
 
 end category_theory

--- a/src/category_theory/monoidal/category.lean
+++ b/src/category_theory/monoidal/category.lean
@@ -610,27 +610,48 @@ variables (C₂ : Type u₂) [category.{v₂} C₂] [monoidal_category.{v₂} C�
 local attribute [simp]
 associator_naturality left_unitor_naturality right_unitor_naturality pentagon
 
-@[simps]
 instance prod_monoidal : monoidal_category (C₁ × C₂) :=
 { tensor_obj := λ X Y, (X.1 ⊗ Y.1, X.2 ⊗ Y.2),
   tensor_hom := λ _ _ _ _ f g, (f.1 ⊗ g.1, f.2 ⊗ g.2),
   tensor_unit := (𝟙_ C₁, 𝟙_ C₂),
   associator := λ X Y Z, (α_ X.1 Y.1 Z.1).prod (α_ X.2 Y.2 Z.2),
-  left_unitor := λ X,
-  begin
-    dsimp,
-    have : X = (X.1, X.2) := prod.ext rfl rfl,
-    rw this,
-    dsimp,
-    exact (λ_ X.1).prod (λ_ X.2),
-  end,
-  right_unitor := λ X,
-  begin
-    dsimp,
-    have : X = (X.1, X.2) := prod.ext rfl rfl,
-    rw this,
-    exact (ρ_ X.1).prod (ρ_ X.2),
-  end }
+  left_unitor := λ ⟨X₁, X₂⟩, (λ_ X₁).prod (λ_ X₂),
+  right_unitor := λ ⟨X₁, X₂⟩, (ρ_ X₁).prod (ρ_ X₂) }
+
+@[simp] lemma prod_monoidal_tensor_obj (X Y : C₁ × C₂) :
+  X ⊗ Y = (X.1 ⊗ Y.1, X.2 ⊗ Y.2) := rfl
+
+@[simp] lemma prod_monoidal_tensor_hom {X Y U V : C₁ × C₂} (f : X ⟶ Y) (g : U ⟶ V) :
+  f ⊗ g = (f.1 ⊗ g.1, f.2 ⊗ g.2) := rfl
+
+@[simp] lemma prod_monoidal_tensor_unit : 𝟙_ (C₁ × C₂) = (𝟙_ C₁, 𝟙_ C₂) := rfl
+
+@[simp] lemma prod_monoidal_associator {X Y Z : C₁ × C₂} :
+  α_ X Y Z = (α_ X.1 Y.1 Z.1).prod (α_ X.2 Y.2 Z.2) := rfl
+
+@[simp] lemma prod_monoidal_left_unitor_hom_fst (X : C₁ × C₂) :
+  ((λ_ X).hom : (𝟙_ _) ⊗ X ⟶ X).1 = (λ_ X.1).hom := by { cases X, refl }
+
+@[simp] lemma prod_monoidal_left_unitor_hom_snd (X : C₁ × C₂) :
+  ((λ_ X).hom : (𝟙_ _) ⊗ X ⟶ X).2 = (λ_ X.2).hom := by { cases X, refl }
+
+@[simp] lemma prod_monoidal_left_unitor_inv_fst (X : C₁ × C₂) :
+  ((λ_ X).inv : X ⟶ (𝟙_ _) ⊗ X).1 = (λ_ X.1).inv := by { cases X, refl }
+
+@[simp] lemma prod_monoidal_left_unitor_inv_snd (X : C₁ × C₂) :
+  ((λ_ X).inv : X ⟶ (𝟙_ _) ⊗ X).2 = (λ_ X.2).inv := by { cases X, refl }
+
+@[simp] lemma prod_monoidal_right_unitor_hom_fst (X : C₁ × C₂) :
+  ((ρ_ X).hom : X ⊗ (𝟙_ _) ⟶ X).1 = (ρ_ X.1).hom := by { cases X, refl }
+
+@[simp] lemma prod_monoidal_right_unitor_hom_snd (X : C₁ × C₂) :
+  ((ρ_ X).hom : X ⊗ (𝟙_ _) ⟶ X).2 = (ρ_ X.2).hom := by { cases X, refl }
+
+@[simp] lemma prod_monoidal_right_unitor_inv_fst (X : C₁ × C₂) :
+  ((ρ_ X).inv : X ⟶ X ⊗ (𝟙_ _)).1 = (ρ_ X.1).inv := by { cases X, refl }
+
+@[simp] lemma prod_monoidal_right_unitor_inv_snd (X : C₁ × C₂) :
+  ((ρ_ X).inv : X ⟶ X ⊗ (𝟙_ _)).2 = (ρ_ X.2).inv := by { cases X, refl }
 
 end
 

--- a/src/category_theory/monoidal/category.lean
+++ b/src/category_theory/monoidal/category.lean
@@ -610,78 +610,23 @@ variables (C₂ : Type u₂) [category.{v₂} C₂] [monoidal_category.{v₂} C�
 instance prod_monoidal : monoidal_category (C₁ × C₂) :=
 { tensor_obj := λ X Y, (X.1 ⊗ Y.1, X.2 ⊗ Y.2),
   tensor_hom := λ X₁ Y₁ X₂ Y₂ f₁ f₂, (f₁.1 ⊗ f₂.1, f₁.2 ⊗ f₂.2),
-  tensor_id' :=
-    λ X₁ X₂,
-      congr_arg2 prod.mk
-        (tensor_id X₁.1 X₂.1)
-        (tensor_id X₁.2 X₂.2),
-  tensor_comp' :=
-    λ X₁ Y₁ Z₁ X₂ Y₂ Z₂ f₁ f₂ g₁ g₂,
-      congr_arg2 prod.mk
-        (tensor_comp f₁.1 f₂.1 g₁.1 g₂.1)
-        (tensor_comp f₁.2 f₂.2 g₁.2 g₂.2),
   tensor_unit := (tensor_unit C₁, tensor_unit C₂),
-  associator :=
-    λ X Y Z,
-      { hom := ((α_ X.1 Y.1 Z.1).hom, (α_ X.2 Y.2 Z.2).hom),
-        inv := ((α_ X.1 Y.1 Z.1).inv, (α_ X.2 Y.2 Z.2).inv),
-        hom_inv_id' :=
-          congr_arg2 prod.mk
-            (hom_inv_id (α_ X.1 Y.1 Z.1))
-            (hom_inv_id (α_ X.2 Y.2 Z.2)),
-        inv_hom_id' :=
-          congr_arg2 prod.mk
-            (inv_hom_id (α_ X.1 Y.1 Z.1))
-            (inv_hom_id (α_ X.2 Y.2 Z.2)) },
-  associator_naturality' :=
-    λ X₁ X₂ X₃ Y₁ Y₂ Y₃ f₁ f₂ f₃,
-      congr_arg2 prod.mk
-        (associator_naturality f₁.1 f₂.1 f₃.1)
-        (associator_naturality f₁.2 f₂.2 f₃.2),
-  left_unitor :=
-    λ X,
-      { hom := ((λ_ X.1).hom, (λ_ X.2).hom),
-        inv := ((λ_ X.1).inv, (λ_ X.2).inv),
-        hom_inv_id' :=
-          congr_arg2 prod.mk
-            (hom_inv_id (λ_ X.1))
-            (hom_inv_id (λ_ X.2)),
-        inv_hom_id' :=
-          congr_arg2 prod.mk
-            (inv_hom_id (λ_ X.1))
-            (inv_hom_id (λ_ X.2)) },
+  associator := λ X Y Z,
+    { hom := ((α_ X.1 Y.1 Z.1).hom, (α_ X.2 Y.2 Z.2).hom),
+      inv := ((α_ X.1 Y.1 Z.1).inv, (α_ X.2 Y.2 Z.2).inv) },
+  associator_naturality' := λ X₁ X₂ X₃ Y₁ Y₂ Y₃ f₁ f₂ f₃,
+    congr_arg2 prod.mk (associator_naturality f₁.1 f₂.1 f₃.1) (associator_naturality f₁.2 f₂.2 f₃.2),
+  left_unitor := λ X,
+    { hom := ((λ_ X.1).hom, (λ_ X.2).hom),
+      inv := ((λ_ X.1).inv, (λ_ X.2).inv) },
   left_unitor_naturality' :=
-    λ X Y f,
-      congr_arg2 prod.mk
-        (left_unitor_naturality f.1)
-        (left_unitor_naturality f.2),
-  right_unitor :=
-    λ X,
-      { hom := ((ρ_ X.1).hom, (ρ_ X.2).hom),
-        inv := ((ρ_ X.1).inv, (ρ_ X.2).inv),
-        hom_inv_id' :=
-          congr_arg2 prod.mk
-            (hom_inv_id (ρ_ X.1))
-            (hom_inv_id (ρ_ X.2)),
-        inv_hom_id' :=
-          congr_arg2 prod.mk
-            (inv_hom_id (ρ_ X.1))
-            (inv_hom_id (ρ_ X.2)) },
+    λ X Y f, congr_arg2 prod.mk (left_unitor_naturality f.1) (left_unitor_naturality f.2),
+  right_unitor := λ X,
+    { hom := ((ρ_ X.1).hom, (ρ_ X.2).hom),
+      inv := ((ρ_ X.1).inv, (ρ_ X.2).inv) },
   right_unitor_naturality' :=
-    λ X Y f,
-      congr_arg2 prod.mk
-        (right_unitor_naturality f.1)
-        (right_unitor_naturality f.2),
-  pentagon' :=
-    λ W X Y Z,
-      congr_arg2 prod.mk
-        (pentagon W.1 X.1 Y.1 Z.1)
-        (pentagon W.2 X.2 Y.2 Z.2),
-  triangle' :=
-    λ X Y,
-      congr_arg2 prod.mk
-        (triangle X.1 Y.1)
-        (triangle X.2 Y.2) }
+    λ X Y f, congr_arg2 prod.mk (right_unitor_naturality f.1) (right_unitor_naturality f.2),
+  pentagon' := λ W X Y Z, congr_arg2 prod.mk (pentagon W.1 X.1 Y.1 Z.1) (pentagon W.2 X.2 Y.2 Z.2) }
 
 end
 

--- a/src/category_theory/monoidal/category.lean
+++ b/src/category_theory/monoidal/category.lean
@@ -607,29 +607,23 @@ universes v₁ v₂ u₁ u₂
 variables (C₁ : Type u₁) [category.{v₁} C₁] [monoidal_category.{v₁} C₁]
 variables (C₂ : Type u₂) [category.{v₂} C₂] [monoidal_category.{v₂} C₂]
 
+local attribute [simp]
+associator_naturality left_unitor_naturality right_unitor_naturality pentagon
+
 @[simps]
 instance prod_monoidal : monoidal_category (C₁ × C₂) :=
 { tensor_obj := λ X Y, (X.1 ⊗ Y.1, X.2 ⊗ Y.2),
   tensor_hom := λ X₁ Y₁ X₂ Y₂ f₁ f₂, (f₁.1 ⊗ f₂.1, f₁.2 ⊗ f₂.2),
-  tensor_unit := (tensor_unit C₁, tensor_unit C₂),
+  tensor_unit := (𝟙_ C₁, 𝟙_ C₂),
   associator := λ X Y Z,
     { hom := ((α_ X.1 Y.1 Z.1).hom, (α_ X.2 Y.2 Z.2).hom),
       inv := ((α_ X.1 Y.1 Z.1).inv, (α_ X.2 Y.2 Z.2).inv) },
-  associator_naturality' := λ X₁ X₂ X₃ Y₁ Y₂ Y₃ f₁ f₂ f₃,
-    congr_arg2 prod.mk
-      (associator_naturality f₁.1 f₂.1 f₃.1) (associator_naturality f₁.2 f₂.2 f₃.2),
   left_unitor := λ X,
     { hom := ((λ_ X.1).hom, (λ_ X.2).hom),
       inv := ((λ_ X.1).inv, (λ_ X.2).inv) },
-  left_unitor_naturality' :=
-    λ X Y f, congr_arg2 prod.mk (left_unitor_naturality f.1) (left_unitor_naturality f.2),
   right_unitor := λ X,
     { hom := ((ρ_ X.1).hom, (ρ_ X.2).hom),
-      inv := ((ρ_ X.1).inv, (ρ_ X.2).inv) },
-  right_unitor_naturality' :=
-    λ X Y f, congr_arg2 prod.mk (right_unitor_naturality f.1) (right_unitor_naturality f.2),
-  pentagon' :=
-    λ W X Y Z, congr_arg2 prod.mk (pentagon W.1 X.1 Y.1 Z.1) (pentagon W.2 X.2 Y.2 Z.2) }
+      inv := ((ρ_ X.1).inv, (ρ_ X.2).inv) } }
 
 end
 

--- a/src/category_theory/monoidal/functor.lean
+++ b/src/category_theory/monoidal/functor.lean
@@ -292,6 +292,8 @@ end lax_monoidal_functor
 namespace lax_monoidal_functor
 variables (F : lax_monoidal_functor.{v₁ v₂} C D) (G : lax_monoidal_functor.{v₁ v₃} C E)
 
+/-- The cartesian product of two lax monoidal functors starting from the same monoidal category `C`
+    is lax monoidal. -/
 def prod' : lax_monoidal_functor C (D × E) :=
 { ε := (ε F, ε G),
   μ := λ X Y, (μ F X Y, μ G X Y),
@@ -337,6 +339,8 @@ end monoidal_functor
 namespace monoidal_functor
 variables (F : monoidal_functor.{v₁ v₂} C D) (G : monoidal_functor.{v₁ v₃} C E)
 
+/-- The cartesian product of two monoidal functors starting from the same monoidal category `C`
+    is monoidal. -/
 def prod' : monoidal_functor C (D × E) :=
 { ε_is_iso := (is_iso_prod_iff D E).mpr ⟨ε_is_iso F, ε_is_iso G⟩,
   μ_is_iso := λ X Y, (is_iso_prod_iff D E).mpr ⟨μ_is_iso F X Y, μ_is_iso G X Y⟩,

--- a/src/category_theory/monoidal/functor.lean
+++ b/src/category_theory/monoidal/functor.lean
@@ -5,6 +5,7 @@ Authors: Michael Jendrusch, Scott Morrison, Bhavik Mehta
 -/
 import category_theory.monoidal.category
 import category_theory.adjunction.basic
+import category_theory.products.basic
 
 /-!
 # (Lax) monoidal functors
@@ -288,6 +289,36 @@ infixr ` ⊗⋙ `:80 := comp
 
 end lax_monoidal_functor
 
+namespace lax_monoidal_functor
+variables (F : lax_monoidal_functor.{v₁ v₂} C D) (G : lax_monoidal_functor.{v₁ v₃} C E)
+
+def prod' : lax_monoidal_functor C (D × E) :=
+{ ε := (ε F, ε G),
+  μ := λ X Y, (μ F X Y, μ G X Y),
+  μ_natural' :=
+    λ X Y X' Y' f g,
+      congr_arg2 prod.mk
+        (μ_natural F f g)
+        (μ_natural G f g),
+  associativity' :=
+    λ X Y Z,
+      congr_arg2 prod.mk
+        (associativity F X Y Z)
+        (associativity G X Y Z),
+  left_unitality' :=
+    λ X,
+      congr_arg2 prod.mk
+        (left_unitality F X)
+        (left_unitality G X),
+  right_unitality' :=
+    λ X,
+      congr_arg2 prod.mk
+        (right_unitality F X)
+        (right_unitality G X),
+  .. (F.to_functor).prod' (G.to_functor) }
+
+end lax_monoidal_functor
+
 namespace monoidal_functor
 
 variables (F : monoidal_functor.{v₁ v₂} C D) (G : monoidal_functor.{v₂ v₃} D E)
@@ -300,6 +331,16 @@ def comp : monoidal_functor.{v₁ v₃} C E :=
   .. (F.to_lax_monoidal_functor).comp (G.to_lax_monoidal_functor) }.
 
 infixr ` ⊗⋙ `:80 := comp -- We overload notation; potentially dangerous, but it seems to work.
+
+end monoidal_functor
+
+namespace monoidal_functor
+variables (F : monoidal_functor.{v₁ v₂} C D) (G : monoidal_functor.{v₁ v₃} C E)
+
+def prod' : monoidal_functor C (D × E) :=
+{ ε_is_iso := (is_iso_prod_iff D E).mpr ⟨ε_is_iso F, ε_is_iso G⟩,
+  μ_is_iso := λ X Y, (is_iso_prod_iff D E).mpr ⟨μ_is_iso F X Y, μ_is_iso G X Y⟩,
+  .. (F.to_lax_monoidal_functor).prod' (G.to_lax_monoidal_functor) }
 
 end monoidal_functor
 

--- a/src/category_theory/monoidal/functor.lean
+++ b/src/category_theory/monoidal/functor.lean
@@ -291,7 +291,7 @@ end lax_monoidal_functor
 
 namespace lax_monoidal_functor
 universes v₀ u₀
-variables (B : Type u₀) [category.{v₀} B] [monoidal_category.{v₀} B]
+variables {B : Type u₀} [category.{v₀} B] [monoidal_category.{v₀} B]
 variables (F : lax_monoidal_functor.{v₀ v₁} B C) (G : lax_monoidal_functor.{v₂ v₃} D E)
 
 /-- The cartesian product of two lax monoidal functors is lax monoidal. -/
@@ -335,6 +335,19 @@ def comp : monoidal_functor.{v₁ v₃} C E :=
   .. (F.to_lax_monoidal_functor).comp (G.to_lax_monoidal_functor) }.
 
 infixr ` ⊗⋙ `:80 := comp -- We overload notation; potentially dangerous, but it seems to work.
+
+end monoidal_functor
+
+namespace monoidal_functor
+universes v₀ u₀
+variables {B : Type u₀} [category.{v₀} B] [monoidal_category.{v₀} B]
+variables (F : monoidal_functor.{v₀ v₁} B C) (G : monoidal_functor.{v₂ v₃} D E)
+
+/-- The cartesian product of two monoidal functors is monoidal. -/
+def prod : monoidal_functor (B × D) (C × E) :=
+{ ε_is_iso := (is_iso_prod_iff C E).mpr ⟨ε_is_iso F, ε_is_iso G⟩,
+  μ_is_iso := λ X Y, (is_iso_prod_iff C E).mpr ⟨μ_is_iso F X.1 Y.1, μ_is_iso G X.2 Y.2⟩,
+  .. (F.to_lax_monoidal_functor).prod (G.to_lax_monoidal_functor) }
 
 end monoidal_functor
 

--- a/src/category_theory/monoidal/functor.lean
+++ b/src/category_theory/monoidal/functor.lean
@@ -297,26 +297,10 @@ variables (F : lax_monoidal_functor.{v₁ v₂} C D) (G : lax_monoidal_functor.{
 def prod' : lax_monoidal_functor C (D × E) :=
 { ε := (ε F, ε G),
   μ := λ X Y, (μ F X Y, μ G X Y),
-  μ_natural' :=
-    λ X Y X' Y' f g,
-      congr_arg2 prod.mk
-        (μ_natural F f g)
-        (μ_natural G f g),
-  associativity' :=
-    λ X Y Z,
-      congr_arg2 prod.mk
-        (associativity F X Y Z)
-        (associativity G X Y Z),
-  left_unitality' :=
-    λ X,
-      congr_arg2 prod.mk
-        (left_unitality F X)
-        (left_unitality G X),
-  right_unitality' :=
-    λ X,
-      congr_arg2 prod.mk
-        (right_unitality F X)
-        (right_unitality G X),
+  μ_natural' := λ X Y X' Y' f g, congr_arg2 prod.mk (μ_natural F f g) (μ_natural G f g),
+  associativity' := λ X Y Z, congr_arg2 prod.mk (associativity F X Y Z) (associativity G X Y Z),
+  left_unitality' := λ X, congr_arg2 prod.mk (left_unitality F X) (left_unitality G X),
+  right_unitality' := λ X, congr_arg2 prod.mk (right_unitality F X) (right_unitality G X),
   .. (F.to_functor).prod' (G.to_functor) }
 
 end lax_monoidal_functor

--- a/src/category_theory/monoidal/functor.lean
+++ b/src/category_theory/monoidal/functor.lean
@@ -290,6 +290,24 @@ infixr ` ⊗⋙ `:80 := comp
 end lax_monoidal_functor
 
 namespace lax_monoidal_functor
+universes v₀ u₀
+variables (B : Type u₀) [category.{v₀} B] [monoidal_category.{v₀} B]
+variables (F : lax_monoidal_functor.{v₀ v₁} B C) (G : lax_monoidal_functor.{v₂ v₃} D E)
+
+/-- The cartesian product of two lax monoidal functors is lax monoidal. -/
+def prod : lax_monoidal_functor (B × D) (C × E) :=
+{ ε := (ε F, ε G),
+  μ := λ X Y, (μ F X.1 Y.1, μ G X.2 Y.2),
+  μ_natural' := λ X Y X' Y' f g, congr_arg2 prod.mk (μ_natural F f.1 g.1) (μ_natural G f.2 g.2),
+  associativity' :=
+    λ X Y Z, congr_arg2 prod.mk (associativity F X.1 Y.1 Z.1) (associativity G X.2 Y.2 Z.2),
+  left_unitality' := λ X, congr_arg2 prod.mk (left_unitality F X.1) (left_unitality G X.2),
+  right_unitality' := λ X, congr_arg2 prod.mk (right_unitality F X.1) (right_unitality G X.2),
+  .. (F.to_functor).prod (G.to_functor) }
+
+end lax_monoidal_functor
+
+namespace lax_monoidal_functor
 variables (F : lax_monoidal_functor.{v₁ v₂} C D) (G : lax_monoidal_functor.{v₁ v₃} C E)
 
 /-- The cartesian product of two lax monoidal functors starting from the same monoidal category `C`

--- a/src/category_theory/monoidal/functor.lean
+++ b/src/category_theory/monoidal/functor.lean
@@ -308,20 +308,28 @@ def prod : lax_monoidal_functor (B × D) (C × E) :=
 
 end lax_monoidal_functor
 
+namespace monoidal_functor
+variable (C)
+
+/-- The diagonal functor as a monoidal functor. -/
+@[simps]
+def diag : monoidal_functor C (C × C) :=
+{ ε := 𝟙 _,
+  μ := λ X Y, 𝟙 _,
+  .. functor.diag C }
+
+end monoidal_functor
+
 namespace lax_monoidal_functor
 variables (F : lax_monoidal_functor.{v₁ v₂} C D) (G : lax_monoidal_functor.{v₁ v₃} C E)
 
 /-- The cartesian product of two lax monoidal functors starting from the same monoidal category `C`
     is lax monoidal. -/
-@[simps]
 def prod' : lax_monoidal_functor C (D × E) :=
-{ ε := (ε F, ε G),
-  μ := λ X Y, (μ F X Y, μ G X Y),
-  μ_natural' := λ X Y X' Y' f g, congr_arg2 prod.mk (μ_natural F f g) (μ_natural G f g),
-  associativity' := λ X Y Z, congr_arg2 prod.mk (associativity F X Y Z) (associativity G X Y Z),
-  left_unitality' := λ X, congr_arg2 prod.mk (left_unitality F X) (left_unitality G X),
-  right_unitality' := λ X, congr_arg2 prod.mk (right_unitality F X) (right_unitality G X),
-  .. (F.to_functor).prod' (G.to_functor) }
+(monoidal_functor.diag C).to_lax_monoidal_functor ⊗⋙ (F.prod G)
+
+@[simp] lemma prod'_to_functor :
+  (F.prod' G).to_functor = (F.to_functor).prod' (G.to_functor) := rfl
 
 end lax_monoidal_functor
 
@@ -359,11 +367,11 @@ variables (F : monoidal_functor.{v₁ v₂} C D) (G : monoidal_functor.{v₁ v�
 
 /-- The cartesian product of two monoidal functors starting from the same monoidal category `C`
     is monoidal. -/
-@[simps]
-def prod' : monoidal_functor C (D × E) :=
-{ ε_is_iso := (is_iso_prod_iff D E).mpr ⟨ε_is_iso F, ε_is_iso G⟩,
-  μ_is_iso := λ X Y, (is_iso_prod_iff D E).mpr ⟨μ_is_iso F X Y, μ_is_iso G X Y⟩,
-  .. (F.to_lax_monoidal_functor).prod' (G.to_lax_monoidal_functor) }
+def prod' : monoidal_functor C (D × E) := diag C ⊗⋙ (F.prod G)
+
+@[simp] lemma prod'_to_lax_monoidal_functor :
+    (F.prod' G).to_lax_monoidal_functor
+  = (F.to_lax_monoidal_functor).prod' (G.to_lax_monoidal_functor) := rfl
 
 end monoidal_functor
 

--- a/src/category_theory/monoidal/functor.lean
+++ b/src/category_theory/monoidal/functor.lean
@@ -295,6 +295,7 @@ variables {B : Type u₀} [category.{v₀} B] [monoidal_category.{v₀} B]
 variables (F : lax_monoidal_functor.{v₀ v₁} B C) (G : lax_monoidal_functor.{v₂ v₃} D E)
 
 /-- The cartesian product of two lax monoidal functors is lax monoidal. -/
+@[simps]
 def prod : lax_monoidal_functor (B × D) (C × E) :=
 { ε := (ε F, ε G),
   μ := λ X Y, (μ F X.1 Y.1, μ G X.2 Y.2),
@@ -312,6 +313,7 @@ variables (F : lax_monoidal_functor.{v₁ v₂} C D) (G : lax_monoidal_functor.{
 
 /-- The cartesian product of two lax monoidal functors starting from the same monoidal category `C`
     is lax monoidal. -/
+@[simps]
 def prod' : lax_monoidal_functor C (D × E) :=
 { ε := (ε F, ε G),
   μ := λ X Y, (μ F X Y, μ G X Y),
@@ -344,6 +346,7 @@ variables {B : Type u₀} [category.{v₀} B] [monoidal_category.{v₀} B]
 variables (F : monoidal_functor.{v₀ v₁} B C) (G : monoidal_functor.{v₂ v₃} D E)
 
 /-- The cartesian product of two monoidal functors is monoidal. -/
+@[simps]
 def prod : monoidal_functor (B × D) (C × E) :=
 { ε_is_iso := (is_iso_prod_iff C E).mpr ⟨ε_is_iso F, ε_is_iso G⟩,
   μ_is_iso := λ X Y, (is_iso_prod_iff C E).mpr ⟨μ_is_iso F X.1 Y.1, μ_is_iso G X.2 Y.2⟩,
@@ -356,6 +359,7 @@ variables (F : monoidal_functor.{v₁ v₂} C D) (G : monoidal_functor.{v₁ v�
 
 /-- The cartesian product of two monoidal functors starting from the same monoidal category `C`
     is monoidal. -/
+@[simps]
 def prod' : monoidal_functor C (D × E) :=
 { ε_is_iso := (is_iso_prod_iff D E).mpr ⟨ε_is_iso F, ε_is_iso G⟩,
   μ_is_iso := λ X Y, (is_iso_prod_iff D E).mpr ⟨μ_is_iso F X Y, μ_is_iso G X Y⟩,

--- a/src/category_theory/monoidal/functor.lean
+++ b/src/category_theory/monoidal/functor.lean
@@ -294,16 +294,13 @@ universes v₀ u₀
 variables {B : Type u₀} [category.{v₀} B] [monoidal_category.{v₀} B]
 variables (F : lax_monoidal_functor.{v₀ v₁} B C) (G : lax_monoidal_functor.{v₂ v₃} D E)
 
+local attribute [simp] μ_natural associativity left_unitality right_unitality
+
 /-- The cartesian product of two lax monoidal functors is lax monoidal. -/
 @[simps]
 def prod : lax_monoidal_functor (B × D) (C × E) :=
 { ε := (ε F, ε G),
   μ := λ X Y, (μ F X.1 Y.1, μ G X.2 Y.2),
-  μ_natural' := λ X Y X' Y' f g, congr_arg2 prod.mk (μ_natural F f.1 g.1) (μ_natural G f.2 g.2),
-  associativity' :=
-    λ X Y Z, congr_arg2 prod.mk (associativity F X.1 Y.1 Z.1) (associativity G X.2 Y.2 Z.2),
-  left_unitality' := λ X, congr_arg2 prod.mk (left_unitality F X.1) (left_unitality G X.2),
-  right_unitality' := λ X, congr_arg2 prod.mk (right_unitality F X.1) (right_unitality G X.2),
   .. (F.to_functor).prod (G.to_functor) }
 
 end lax_monoidal_functor
@@ -330,6 +327,12 @@ def prod' : lax_monoidal_functor C (D × E) :=
 
 @[simp] lemma prod'_to_functor :
   (F.prod' G).to_functor = (F.to_functor).prod' (G.to_functor) := rfl
+
+@[simp] lemma prod'_ε : (F.prod' G).ε = (F.ε, G.ε) :=
+by { dsimp [prod'], simp }
+
+@[simp] lemma prod'_μ (X Y : C) : (F.prod' G).μ X Y = (F.μ X Y, G.μ X Y) :=
+by { dsimp [prod'], simp }
 
 end lax_monoidal_functor
 

--- a/src/category_theory/monoidal/natural_transformation.lean
+++ b/src/category_theory/monoidal/natural_transformation.lean
@@ -103,6 +103,7 @@ def hcomp {F G : lax_monoidal_functor C D} {H K : lax_monoidal_functor D E}
   end,
   ..(nat_trans.hcomp α.to_nat_trans β.to_nat_trans) }
 
+/-- The cartesian product of two monoidal natural transformations is monoidal. -/
 def prod {F G : lax_monoidal_functor C D} {H K : lax_monoidal_functor C E}
   (α : monoidal_nat_trans F G) (β : monoidal_nat_trans H K) :
   monoidal_nat_trans (F.prod' H) (G.prod' K) :=

--- a/src/category_theory/monoidal/natural_transformation.lean
+++ b/src/category_theory/monoidal/natural_transformation.lean
@@ -104,6 +104,7 @@ def hcomp {F G : lax_monoidal_functor C D} {H K : lax_monoidal_functor D E}
   ..(nat_trans.hcomp α.to_nat_trans β.to_nat_trans) }
 
 /-- The cartesian product of two monoidal natural transformations is monoidal. -/
+@[simps]
 def prod {F G : lax_monoidal_functor C D} {H K : lax_monoidal_functor C E}
   (α : monoidal_nat_trans F G) (β : monoidal_nat_trans H K) :
   monoidal_nat_trans (F.prod' H) (G.prod' K) :=

--- a/src/category_theory/monoidal/natural_transformation.lean
+++ b/src/category_theory/monoidal/natural_transformation.lean
@@ -103,6 +103,14 @@ def hcomp {F G : lax_monoidal_functor C D} {H K : lax_monoidal_functor D E}
   end,
   ..(nat_trans.hcomp α.to_nat_trans β.to_nat_trans) }
 
+def prod {F G : lax_monoidal_functor C D} {H K : lax_monoidal_functor C E}
+  (α : monoidal_nat_trans F G) (β : monoidal_nat_trans H K) :
+  monoidal_nat_trans (F.prod' H) (G.prod' K) :=
+{ app := λ X, (α.app X, β.app X),
+  naturality' := λ X Y f, congr_arg2 prod.mk (α.naturality' f) (β.naturality' f),
+  unit' := congr_arg2 prod.mk α.unit' β.unit',
+  tensor' := λ X Y, congr_arg2 prod.mk (α.tensor' X Y) (β.tensor' X Y) }
+
 end monoidal_nat_trans
 
 namespace monoidal_nat_iso

--- a/src/category_theory/monoidal/natural_transformation.lean
+++ b/src/category_theory/monoidal/natural_transformation.lean
@@ -103,15 +103,18 @@ def hcomp {F G : lax_monoidal_functor C D} {H K : lax_monoidal_functor D E}
   end,
   ..(nat_trans.hcomp α.to_nat_trans β.to_nat_trans) }
 
+section
+
+local attribute [simp] nat_trans.naturality monoidal_nat_trans.unit monoidal_nat_trans.tensor
+
 /-- The cartesian product of two monoidal natural transformations is monoidal. -/
 @[simps]
 def prod {F G : lax_monoidal_functor C D} {H K : lax_monoidal_functor C E}
   (α : monoidal_nat_trans F G) (β : monoidal_nat_trans H K) :
   monoidal_nat_trans (F.prod' H) (G.prod' K) :=
-{ app := λ X, (α.app X, β.app X),
-  naturality' := λ X Y f, congr_arg2 prod.mk (α.naturality' f) (β.naturality' f),
-  unit' := congr_arg2 prod.mk α.unit' β.unit',
-  tensor' := λ X Y, congr_arg2 prod.mk (α.tensor' X Y) (β.tensor' X Y) }
+{ app := λ X, (α.app X, β.app X) }
+
+end
 
 end monoidal_nat_trans
 

--- a/src/category_theory/products/basic.lean
+++ b/src/category_theory/products/basic.lean
@@ -195,6 +195,10 @@ variable (C)
 /-- The diagonal functor. -/
 def diag : C ⥤ C × C := (𝟭 C).prod' (𝟭 C)
 
+@[simp] lemma diag_obj (X : C) : (diag C).obj X = (X, X) := rfl
+
+@[simp] lemma diag_map {X Y : C} (f : X ⟶ Y) : (diag C).map f = (f, f) := rfl
+
 end
 
 end functor

--- a/src/category_theory/products/basic.lean
+++ b/src/category_theory/products/basic.lean
@@ -178,6 +178,14 @@ namespace functor
 { obj := λ a, (F.obj a, G.obj a),
   map := λ x y f, (F.map f, G.map f), }
 
+section
+variable (C)
+
+/-- The diagonal functor. -/
+def diag : C ⥤ C × C := (𝟭 C).prod' (𝟭 C)
+
+end
+
 end functor
 
 namespace nat_trans

--- a/src/category_theory/products/basic.lean
+++ b/src/category_theory/products/basic.lean
@@ -46,6 +46,20 @@ instance prod : category.{max v₁ v₂} (C × D) :=
 @[simp] lemma prod_comp {P Q R : C} {S T U : D} (f : (P, S) ⟶ (Q, T)) (g : (Q, T) ⟶ (R, U)) :
   f ≫ g = (f.1 ≫ g.1, f.2 ≫ g.2) := rfl
 
+lemma is_iso_prod_iff {P Q : C} {S T : D} {f : (P, S) ⟶ (Q, T)} :
+  is_iso f ↔ is_iso f.1 ∧ is_iso f.2 :=
+begin
+  split,
+  { rintros ⟨g, hfg, hgf⟩,
+    simp at hfg hgf,
+    rcases hfg with ⟨hfg₁, hfg₂⟩,
+    rcases hgf with ⟨hgf₁, hgf₂⟩,
+    exact ⟨⟨⟨g.1, hfg₁, hgf₁⟩⟩, ⟨⟨g.2, hfg₂, hgf₂⟩⟩⟩ },
+  { rintros ⟨⟨g₁, hfg₁, hgf₁⟩, ⟨g₂, hfg₂, hgf₂⟩⟩,
+    dsimp at hfg₁ hgf₁ hfg₂ hgf₂,
+    refine ⟨⟨(g₁, g₂), _, _⟩⟩; { simp; split; assumption } }
+end
+
 end
 
 section

--- a/src/category_theory/products/basic.lean
+++ b/src/category_theory/products/basic.lean
@@ -60,6 +60,17 @@ begin
     refine ⟨⟨(g₁, g₂), _, _⟩⟩; { simp; split; assumption } }
 end
 
+section
+variables {C D}
+
+/-- Construct an isomorphism in `C × D` out of two isomorphisms in `C` and `D`. -/
+@[simps]
+def iso.prod {P Q : C} {S T : D} (f : P ≅ Q) (g : S ≅ T) : (P, S) ≅ (Q, T) :=
+{ hom := (f.hom, g.hom),
+  inv := (f.inv, g.inv), }
+
+end
+
 end
 
 section


### PR DESCRIPTION
This PR contains (fairly straightforward) definitions / proofs of the following facts:
- Cartesian product of monoidal categories is a monoidal category.
- Cartesian product of (lax) monoidal functors is a (lax) monoidal functor.
- Cartesian product of monoidal natural transformations is a monoidal natural transformation.

These are prerequisites to defining a monoidal category structure on the category of monoids in a braided monoidal category (with the approach that I've chosen).  In particular, the first bullet point above is a prerequisite to endowing the tensor product functor, viewed as a functor from `C × C` to `C`, where `C` is a braided monoidal category, with a strength that turns it into a monoidal functor (stacked  PR).

This fits as follows into the general strategy for defining a monoidal category structure on the category of monoids in a braided monoidal category `C`, at least conceptually:
first, define a monoidal category structure on the category of lax monoidal functors into `C`, and then transport this structure to the category `Mon_ C` of monoids along the equivalence between `Mon_ C` and the category `lax_monoid_functor (discrete punit) C`.  All, not necessarily lax monoidal functors into `C` form a monoidal category with "pointwise" tensor product.  The tensor product of two lax monoidal functors equals the composition of their cartesian product, which is lax monoidal, with the tensor product on`C`, which is monoidal if `C` is braided.  This gives a way to define a tensor product of two lax monoidal functors.  The details still need to be fleshed out.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
