### PR TITLE
[Merged by Bors] - feat(algebra/big_operators): add `commute.*_sum_{left,right}` lemmas

### DIFF
--- a/src/algebra/big_operators/basic.lean
+++ b/src/algebra/big_operators/basic.lean
@@ -1316,7 +1316,7 @@ end
 lemma _root_.commute.sum_left [non_unital_non_assoc_semiring β] (s : finset α)
   (f : α → β) (b : β) (h : ∀ i ∈ s, commute (f i) b) :
   commute (∑ i in s, f i) b :=
-(commute.sum_right _ _ $ λ i hi, (h _ hi).symm).symm
+(commute.sum_right _ _ _ $ λ i hi, (h _ hi).symm).symm
 
 section opposite
 

--- a/src/algebra/big_operators/basic.lean
+++ b/src/algebra/big_operators/basic.lean
@@ -1305,13 +1305,18 @@ begin
   simp [finset.sum_range_succ', add_comm]
 end
 
-lemma sum_commute [non_unital_non_assoc_semiring β] (s : finset α)
+lemma _root_.commute.sum_right [non_unital_non_assoc_semiring β] (s : finset α)
   (b : β) (f : α → β) (h : ∀ i ∈ s, commute b (f i)) :
   commute b (∑ i in s, f i) :=
-multiset.sum_commute _ _ $ λ b hb, begin
+commute.multiset_sum_right _ _ $ λ b hb, begin
   obtain ⟨i, hi, rfl⟩ := multiset.mem_map.mp hb,
   exact h _ hi
 end
+
+lemma _root_.commute.sum_left [non_unital_non_assoc_semiring β] (s : finset α)
+  (b : β) (f : α → β) (h : ∀ i ∈ s, commute (f i) b) :
+  commute (∑ i in s, f i) b :=
+(commute.sum_right _ _ $ λ i hi, (h _ hi).symm).symm
 
 section opposite
 

--- a/src/algebra/big_operators/basic.lean
+++ b/src/algebra/big_operators/basic.lean
@@ -1305,6 +1305,14 @@ begin
   simp [finset.sum_range_succ', add_comm]
 end
 
+lemma sum_commute [non_unital_non_assoc_semiring β] (s : finset α)
+  (b : β) (f : α → β) (h : ∀ i ∈ s, commute b (f i)) :
+  commute b (∑ i in s, f i) :=
+multiset.sum_commute _ _ $ λ b hb, begin
+  obtain ⟨i, hi, rfl⟩ := multiset.mem_map.mp hb,
+  exact h _ hi
+end
+
 section opposite
 
 open mul_opposite

--- a/src/algebra/big_operators/basic.lean
+++ b/src/algebra/big_operators/basic.lean
@@ -1306,7 +1306,7 @@ begin
 end
 
 lemma _root_.commute.sum_right [non_unital_non_assoc_semiring β] (s : finset α)
-  (b : β) (f : α → β) (h : ∀ i ∈ s, commute b (f i)) :
+  (f : α → β) (b : β) (h : ∀ i ∈ s, commute b (f i)) :
   commute b (∑ i in s, f i) :=
 commute.multiset_sum_right _ _ $ λ b hb, begin
   obtain ⟨i, hi, rfl⟩ := multiset.mem_map.mp hb,
@@ -1314,7 +1314,7 @@ commute.multiset_sum_right _ _ $ λ b hb, begin
 end
 
 lemma _root_.commute.sum_left [non_unital_non_assoc_semiring β] (s : finset α)
-  (b : β) (f : α → β) (h : ∀ i ∈ s, commute (f i) b) :
+  (f : α → β) (b : β) (h : ∀ i ∈ s, commute (f i) b) :
   commute (∑ i in s, f i) b :=
 (commute.sum_right _ _ $ λ i hi, (h _ hi).symm).symm
 

--- a/src/algebra/big_operators/multiset.lean
+++ b/src/algebra/big_operators/multiset.lean
@@ -234,7 +234,15 @@ by { convert (m.map f).prod_hom (zpow_group_hom₀ _ : α →* α), rw map_map, 
 end comm_group_with_zero
 
 section semiring
-variables [semiring α] {a : α} {s : multiset ι} {f : ι → α}
+variables [non_unital_non_assoc_semiring α] {a : α} {s : multiset ι} {f : ι → α}
+
+lemma sum_commute (a : α) (s : multiset α) (h : ∀ b ∈ s, commute a b) :
+  commute a s.sum :=
+begin
+  induction s using quotient.induction_on,
+  rw [quot_mk_to_coe, coe_sum],
+  exact list.sum_commute _ _ h,
+end
 
 lemma sum_map_mul_left : sum (s.map (λ i, a * f i)) = a * sum (s.map f) :=
 multiset.induction_on s (by simp) (λ i s ih, by simp [ih, mul_add])

--- a/src/algebra/big_operators/multiset.lean
+++ b/src/algebra/big_operators/multiset.lean
@@ -236,13 +236,17 @@ end comm_group_with_zero
 section semiring
 variables [non_unital_non_assoc_semiring α] {a : α} {s : multiset ι} {f : ι → α}
 
-lemma sum_commute (a : α) (s : multiset α) (h : ∀ b ∈ s, commute a b) :
+lemma _root_.commute.multiset.sum_right (s : multiset α) (a : α) (h : ∀ b ∈ s, commute a b) :
   commute a s.sum :=
 begin
   induction s using quotient.induction_on,
   rw [quot_mk_to_coe, coe_sum],
-  exact list.sum_commute _ _ h,
+  exact commute.list_sum_right _ _ h,
 end
+
+lemma _root_.commute.multiset.sum_left (s : multiset α) (b : α) (h : ∀ a ∈ s, commute a b) :
+  commute s.sum b :=
+(commute.multiset.sum_right _ _ $ λ a ha, (h _ ha).symm).symm
 
 lemma sum_map_mul_left : sum (s.map (λ i, a * f i)) = a * sum (s.map f) :=
 multiset.induction_on s (by simp) (λ i s ih, by simp [ih, mul_add])

--- a/src/algebra/big_operators/multiset.lean
+++ b/src/algebra/big_operators/multiset.lean
@@ -236,7 +236,7 @@ end comm_group_with_zero
 section semiring
 variables [non_unital_non_assoc_semiring α] {a : α} {s : multiset ι} {f : ι → α}
 
-lemma _root_.commute.multiset.sum_right (s : multiset α) (a : α) (h : ∀ b ∈ s, commute a b) :
+lemma _root_.commute.multiset_sum_right (s : multiset α) (a : α) (h : ∀ b ∈ s, commute a b) :
   commute a s.sum :=
 begin
   induction s using quotient.induction_on,
@@ -244,9 +244,9 @@ begin
   exact commute.list_sum_right _ _ h,
 end
 
-lemma _root_.commute.multiset.sum_left (s : multiset α) (b : α) (h : ∀ a ∈ s, commute a b) :
+lemma _root_.commute.multiset_sum_left (s : multiset α) (b : α) (h : ∀ a ∈ s, commute a b) :
   commute s.sum b :=
-(commute.multiset.sum_right _ _ $ λ a ha, (h _ ha).symm).symm
+(commute.multiset_sum_right _ _ $ λ a ha, (h _ ha).symm).symm
 
 lemma sum_map_mul_left : sum (s.map (λ i, a * f i)) = a * sum (s.map f) :=
 multiset.induction_on s (by simp) (λ i s ih, by simp [ih, mul_add])

--- a/src/data/finset/noncomm_prod.lean
+++ b/src/data/finset/noncomm_prod.lean
@@ -206,7 +206,7 @@ lemma noncomm_prod_commute (s : multiset α)
 begin
   induction s using quotient.induction_on,
   simp only [quot_mk_to_coe, noncomm_prod_coe],
-  exact list.prod_commute _ _ h,
+  exact commute.list_prod_right _ _ h,
 end
 
 end multiset

--- a/src/data/finset/noncomm_prod.lean
+++ b/src/data/finset/noncomm_prod.lean
@@ -199,7 +199,7 @@ begin
   simp
 end
 
-@[to_additive]
+@[to_additive noncomm_sum_add_commute]
 lemma noncomm_prod_commute (s : multiset α)
   (comm : ∀ (x : α), x ∈ s → ∀ (y : α), y ∈ s → commute x y)
   (y : α) (h : ∀ (x : α), x ∈ s → commute y x) : commute y (s.noncomm_prod comm) :=
@@ -282,7 +282,7 @@ begin
   simpa using h,
 end
 
-@[to_additive]
+@[to_additive noncomm_sum_add_commute]
 lemma noncomm_prod_commute (s : finset α) (f : α → β)
   (comm : ∀ (x : α), x ∈ s → ∀ (y : α), y ∈ s → commute (f x) (f y))
   (y : β) (h : ∀ (x : α), x ∈ s → commute y (f x)) : commute y (s.noncomm_prod f comm) :=

--- a/src/data/list/big_operators.lean
+++ b/src/data/list/big_operators.lean
@@ -160,8 +160,9 @@ lemma head_mul_tail_prod_of_ne_nil [inhabited M] (l : list M) (h : l ≠ []) :
   l.head * l.tail.prod = l.prod :=
 by cases l; [contradiction, simp]
 
-@[to_additive sum_add_commute]
-lemma prod_commute (l : list M) (y : M) (h : ∀ (x ∈ l), commute y x) : commute y l.prod :=
+@[to_additive]
+lemma _root_.commute.list_prod_right (l : list M) (y : M) (h : ∀ (x ∈ l), commute y x) :
+  commute y l.prod :=
 begin
   induction l with z l IH,
   { simp },
@@ -170,7 +171,12 @@ begin
     exact commute.mul_right h.1 (IH h.2), }
 end
 
-lemma sum_commute [non_unital_non_assoc_semiring R] (a : R) (l : list R)
+@[to_additive]
+lemma _root_.commute.list_prod_left (l : list M) (y : M) (h : ∀ (x ∈ l), commute x y) :
+  commute l.prod y  :=
+(commute.list_prod_right _ _ $ λ x hx, (h _ hx).symm).symm
+
+lemma _root_.commute.list_sum_right [non_unital_non_assoc_semiring R] (a : R) (l : list R)
   (h : ∀ b ∈ l, commute a b) :
   commute a l.sum :=
 begin
@@ -179,6 +185,11 @@ begin
   { rw sum_cons,
     exact (h _ $ mem_cons_self _ _).add_right (ih $ λ j hj, h _ $ mem_cons_of_mem _ hj) }
 end
+
+lemma _root_.commute.list_sum_left [non_unital_non_assoc_semiring R] (b : R) (l : list R)
+  (h : ∀ a ∈ l, commute a b) :
+  commute l.sum b :=
+(commute.list_sum_right _ _ $ λ x hx, (h _ hx).symm).symm
 
 @[to_additive sum_le_sum] lemma prod_le_prod' [preorder M]
   [covariant_class M M (function.swap (*)) (≤)] [covariant_class M M (*) (≤)]

--- a/src/data/list/big_operators.lean
+++ b/src/data/list/big_operators.lean
@@ -160,7 +160,7 @@ lemma head_mul_tail_prod_of_ne_nil [inhabited M] (l : list M) (h : l ≠ []) :
   l.head * l.tail.prod = l.prod :=
 by cases l; [contradiction, simp]
 
-@[to_additive]
+@[to_additive sum_add_commute]
 lemma prod_commute (l : list M) (y : M) (h : ∀ (x ∈ l), commute y x) : commute y l.prod :=
 begin
   induction l with z l IH,
@@ -168,6 +168,16 @@ begin
   { rw list.ball_cons at h,
     rw list.prod_cons,
     exact commute.mul_right h.1 (IH h.2), }
+end
+
+lemma sum_commute [non_unital_non_assoc_semiring R] (a : R) (l : list R)
+  (h : ∀ b ∈ l, commute a b) :
+  commute a l.sum :=
+begin
+  induction l with x xs ih,
+  { exact commute.zero_right _, },
+  { rw sum_cons,
+    exact (h _ $ mem_cons_self _ _).add_right (ih $ λ j hj, h _ $ mem_cons_of_mem _ hj) }
 end
 
 @[to_additive sum_le_sum] lemma prod_le_prod' [preorder M]


### PR DESCRIPTION
This moves the existing `prod_commute` lemmas into the `commute` namespace for discoverabiliy, and adds the swapped variants.

This also fixes an issue where lemmas about `add_commute` were misnamed using `commute`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
