### PR TITLE
[Merged by Bors] - chore(*): sort out some to_additive and simp orderings

### DIFF
--- a/src/algebra/group/pi.lean
+++ b/src/algebra/group/pi.lean
@@ -195,7 +195,7 @@ def one_hom.single [Π i, has_one $ f i] (i : I) : one_hom (f i) (Π i, f i) :=
 { to_fun := mul_single i,
   map_one' := mul_single_one i }
 
-@[to_additive, simp]
+@[simp, to_additive]
 lemma one_hom.single_apply [Π i, has_one $ f i] (i : I) (x : f i) :
   one_hom.single f i x = mul_single i x := rfl
 
@@ -211,7 +211,7 @@ def monoid_hom.single [Π i, mul_one_class $ f i] (i : I) : f i →* Π i, f i :
 { map_mul' := mul_single_op₂ (λ _, (*)) (λ _, one_mul _) _,
   .. (one_hom.single f i) }
 
-@[to_additive, simp]
+@[simp, to_additive]
 lemma monoid_hom.single_apply [Π i, mul_one_class $ f i] (i : I) (x : f i) :
   monoid_hom.single f i x = mul_single i x := rfl
 

--- a/src/algebra/group/to_additive.lean
+++ b/src/algebra/group/to_additive.lean
@@ -538,7 +538,7 @@ protected meta def attr : user_attribute unit value_type :=
       transform_decl_with_prefix_dict dict val.replace_all val.trace relevant ignore reorder src tgt
         [`reducible, `_refl_lemma, `simp, `norm_cast, `instance, `refl, `symm, `trans,
           `elab_as_eliminator, `no_rsimp, `continuity, `ext, `ematch, `measurability, `alias,
-          `_ext_core, `_ext_lemma_core, `nolint],
+          `_ext_core, `_ext_lemma_core, `nolint, `protected],
       mwhen (has_attribute' `simps src)
         (trace "Apply the simps attribute after the to_additive attribute"),
       mwhen (has_attribute' `mono src)

--- a/src/data/finset/noncomm_prod.lean
+++ b/src/data/finset/noncomm_prod.lean
@@ -163,7 +163,7 @@ begin
         simp [hy] } } }
 end
 
-@[to_additive, protected]
+@[protected, to_additive]
 lemma nocomm_prod_map_aux (s : multiset α)
   (comm : ∀ (x ∈ s) (y ∈ s), commute x y)
   {F : Type*} [monoid_hom_class F α β] (f : F) :

--- a/src/data/part.lean
+++ b/src/data/part.lean
@@ -513,7 +513,7 @@ lemma left_dom_of_mul_dom [has_mul α] {a b : part α} (hab : dom (a * b)) :
 lemma right_dom_of_mul_dom [has_mul α] {a b : part α} (hab : dom (a * b)) :
   b.dom := by tidy
 
-@[to_additive, simp]
+@[simp, to_additive]
 lemma mul_get_eq [has_mul α] (a b : part α) (hab : dom (a * b)) :
   (a * b).get hab = a.get (left_dom_of_mul_dom hab) * b.get (right_dom_of_mul_dom hab) :=
 by tidy
@@ -539,7 +539,7 @@ lemma left_dom_of_div_dom [has_div α] {a b : part α} (hab : dom (a / b)) :
 lemma right_dom_of_div_dom [has_div α] {a b : part α} (hab : dom (a / b)) :
   b.dom := by tidy
 
-@[to_additive, simp]
+@[simp, to_additive]
 lemma div_get_eq [has_div α] (a b : part α) (hab : dom (a / b)) :
   (a / b).get hab = a.get (left_dom_of_div_dom hab) / b.get (right_dom_of_div_dom hab) :=
 by tidy


### PR DESCRIPTION
- To additive should always come after simp, unless the linter complains.
- Also make to_additive transfer the `protected` attribute for consistency.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
