### PR TITLE
[Merged by Bors] - chore(data/set/pointwise): Golf using `set.image2` API

### DIFF
--- a/src/algebra/add_torsor.lean
+++ b/src/algebra/add_torsor.lean
@@ -156,11 +156,6 @@ open_locale pointwise
 @[simp] lemma singleton_vsub_self (p : P) : ({p} : set P) -ᵥ {p} = {(0:G)} :=
 by rw [set.singleton_vsub_singleton, vsub_self]
 
-instance add_action : add_action (set G) (set P) :=
-{ zero_vadd := λ s, by simp [has_vadd.vadd, ←singleton_zero, image2_singleton_left],
-  add_vadd := λ s t p, by { apply image2_assoc, intros, apply add_vadd },
-  ..(show has_vadd (set G) (set P), by apply_instance) }
-
 end set
 
 @[simp] lemma vadd_vsub_vadd_cancel_right (v₁ v₂ : G) (p : P) :

--- a/src/algebra/opposites.lean
+++ b/src/algebra/opposites.lean
@@ -104,11 +104,19 @@ instance [has_sub α] : has_sub αᵐᵒᵖ :=
 instance [has_neg α] : has_neg αᵐᵒᵖ :=
 { neg := λ x, op $ -(unop x) }
 
+instance [has_involutive_neg α] : has_involutive_neg αᵐᵒᵖ :=
+{ neg_neg := λ a, unop_injective $ neg_neg _,
+  ..mul_opposite.has_neg α }
+
 @[to_additive] instance [has_mul α] : has_mul αᵐᵒᵖ :=
 { mul := λ x y, op (unop y * unop x) }
 
 @[to_additive] instance [has_inv α] : has_inv αᵐᵒᵖ :=
 { inv := λ x, op $ (unop x)⁻¹ }
+
+@[to_additive] instance [has_involutive_inv α] : has_involutive_inv αᵐᵒᵖ :=
+{ inv_inv := λ a, unop_injective $ inv_inv _,
+  ..mul_opposite.has_inv α }
 
 @[to_additive] instance (R : Type*) [has_scalar R α] : has_scalar R αᵐᵒᵖ :=
 { smul := λ c x, op (c • unop x) }
@@ -187,6 +195,10 @@ instance [has_mul α] : has_mul αᵃᵒᵖ := { mul := λ a b, op (unop a * uno
 @[simp] lemma unop_mul [has_mul α] (a b : αᵃᵒᵖ) : unop (a * b) = unop a * unop b := rfl
 
 instance [has_inv α] : has_inv αᵃᵒᵖ := { inv := λ a, op (unop a)⁻¹ }
+
+instance [has_involutive_inv α] : has_involutive_inv αᵃᵒᵖ :=
+{ inv_inv := λ a, unop_injective $ inv_inv _,
+  ..add_opposite.has_inv }
 
 @[simp] lemma op_inv [has_inv α] (a : α) : op a⁻¹ = (op a)⁻¹ := rfl
 @[simp] lemma unop_inv [has_inv α] (a : αᵃᵒᵖ) : unop a⁻¹ = (unop a)⁻¹ := rfl

--- a/src/data/set/basic.lean
+++ b/src/data/set/basic.lean
@@ -1350,6 +1350,11 @@ subset.antisymm
 lemma image_image (g : β → γ) (f : α → β) (s : set α) : g '' (f '' s) = (λ x, g (f x)) '' s :=
 (image_comp g f s).symm
 
+lemma image_comm {β'} {f : β → γ} {g : α → β} {f' : α → β'} {g' : β' → γ}
+  (h_comm : ∀ a, f (g a) = g' (f' a)) :
+  (s.image g).image f = (s.image f').image g' :=
+by simp_rw [image_image, h_comm]
+
 /-- Image is monotone with respect to `⊆`. See `set.monotone_image` for the statement in
 terms of `≤`. -/
 theorem image_subset {a b : set α} (f : α → β) (h : a ⊆ b) : f '' a ⊆ f '' b :=
@@ -2273,7 +2278,7 @@ end image_preimage
 
 section n_ary_image
 
-variables {α β γ δ ε : Type*} {f f' : α → β → γ} {g g' : α → β → γ → δ}
+variables {α α' β β' γ γ' δ δ' ε ε' : Type*} {f f' : α → β → γ} {g g' : α → β → γ → δ}
 variables {s s' : set α} {t t' : set β} {u u' : set γ} {a a' : α} {b b' : β} {c c' : γ} {d d' : δ}
 
 
@@ -2431,7 +2436,7 @@ by simp [nonempty_def.mp h, ext_iff]
 @[simp] lemma image2_right (h : s.nonempty) : image2 (λ x y, y) s t = t :=
 by simp [nonempty_def.mp h, ext_iff]
 
-lemma image2_assoc {ε'} {f : δ → γ → ε} {g : α → β → δ} {f' : α → ε' → ε} {g' : β → γ → ε'}
+lemma image2_assoc {f : δ → γ → ε} {g : α → β → δ} {f' : α → ε' → ε} {g' : β → γ → ε'}
   (h_assoc : ∀ a b c, f (g a b) c = f' a (g' b c)) :
   image2 f (image2 g s t) u = image2 f' s (image2 g' t u) :=
 by simp only [image2_image2_left, image2_image2_right, h_assoc]
@@ -2439,30 +2444,73 @@ by simp only [image2_image2_left, image2_image2_right, h_assoc]
 lemma image2_comm {g : β → α → γ} (h_comm : ∀ a b, f a b = g b a) : image2 f s t = image2 g t s :=
 (image2_swap _ _ _).trans $ by simp_rw h_comm
 
-lemma image2_left_comm {δ'} {f : α → δ → ε} {g : β → γ → δ} {f' : α → γ → δ'} {g' : β → δ' → ε}
+lemma image2_left_comm {f : α → δ → ε} {g : β → γ → δ} {f' : α → γ → δ'} {g' : β → δ' → ε}
   (h_left_comm : ∀ a b c, f a (g b c) = g' b (f' a c)) :
   image2 f s (image2 g t u) = image2 g' t (image2 f' s u) :=
 by { rw [image2_swap f', image2_swap f], exact image2_assoc (λ _ _ _, h_left_comm _ _ _) }
 
-lemma image2_right_comm {δ'} {f : δ → γ → ε} {g : α → β → δ} {f' : α → γ → δ'} {g' : δ' → β → ε}
+lemma image2_right_comm {f : δ → γ → ε} {g : α → β → δ} {f' : α → γ → δ'} {g' : δ' → β → ε}
   (h_right_comm : ∀ a b c, f (g a b) c = g' (f' a c) b) :
   image2 f (image2 g s t) u = image2 g' (image2 f' s u) t :=
 by { rw [image2_swap g, image2_swap g'], exact image2_assoc (λ _ _ _, h_right_comm _ _ _) }
 
-lemma image_image2_distrib {α' β'} {g : γ → δ} {f' : α' → β' → δ} {g₁ : α → α'} {g₂ : β → β'}
+lemma image_image2_distrib {g : γ → δ} {f' : α' → β' → δ} {g₁ : α → α'} {g₂ : β → β'}
   (h_distrib : ∀ a b, g (f a b) = f' (g₁ a) (g₂ b)) :
   (image2 f s t).image g = image2 f' (s.image g₁) (t.image g₂) :=
 by simp_rw [image_image2, image2_image_left, image2_image_right, h_distrib]
 
-lemma image_image2_distrib_left {α'} {g : γ → δ} {f' : α' → β → δ} {g' : α → α'}
+/-- Symmetric of `set.image2_image_left_comm`. -/
+lemma image_image2_distrib_left {g : γ → δ} {f' : α' → β → δ} {g' : α → α'}
   (h_distrib : ∀ a b, g (f a b) = f' (g' a) b) :
   (image2 f s t).image g = image2 f' (s.image g') t :=
 (image_image2_distrib h_distrib).trans $ by rw image_id'
 
-lemma image_image2_distrib_right {β'} {g : γ → δ} {f' : α → β' → δ} {g' : β → β'}
+/-- Symmetric of `set.image_image2_right_comm`. -/
+lemma image_image2_distrib_right {g : γ → δ} {f' : α → β' → δ} {g' : β → β'}
   (h_distrib : ∀ a b, g (f a b) = f' a (g' b)) :
   (image2 f s t).image g = image2 f' s (t.image g') :=
 (image_image2_distrib h_distrib).trans $ by rw image_id'
+
+/-- Symmetric of `set.image_image2_distrib_left`. -/
+lemma image2_image_left_comm {f : α' → β → γ} {g : α → α'} {f' : α → β → δ} {g' : δ → γ}
+  (h_left_comm : ∀ a b, f (g a) b = g' (f' a b)) :
+  image2 f (s.image g) t = (image2 f' s t).image g' :=
+(image_image2_distrib_left $ λ a b, (h_left_comm a b).symm).symm
+
+/-- Symmetric of `set.image_image2_distrib_right`. -/
+lemma image_image2_right_comm {f : α → β' → γ} {g : β → β'} {f' : α → β → δ} {g' : δ → γ}
+  (h_right_comm : ∀ a b, f a (g b) = g' (f' a b)) :
+  image2 f s (t.image g) = (image2 f' s t).image g' :=
+(image_image2_distrib_right $ λ a b, (h_right_comm a b).symm).symm
+
+lemma image_image2_antidistrib {g : γ → δ} {f' : β' → α' → δ} {g₁ : β → β'} {g₂ : α → α'}
+  (h_antidistrib : ∀ a b, g (f a b) = f' (g₁ b) (g₂ a)) :
+  (image2 f s t).image g = image2 f' (t.image g₁) (s.image g₂) :=
+by { rw image2_swap f, exact image_image2_distrib (λ _ _, h_antidistrib _ _) }
+
+/-- Symmetric of `set.image2_image_left_anticomm`. -/
+lemma image_image2_antidistrib_left {g : γ → δ} {f' : β' → α → δ} {g' : β → β'}
+  (h_antidistrib : ∀ a b, g (f a b) = f' (g' b) a) :
+  (image2 f s t).image g = image2 f' (t.image g') s :=
+(image_image2_antidistrib h_antidistrib).trans $ by rw image_id'
+
+/-- Symmetric of `set.image_image2_right_anticomm`. -/
+lemma image_image2_antidistrib_right {g : γ → δ} {f' : β → α' → δ} {g' : α → α'}
+  (h_antidistrib : ∀ a b, g (f a b) = f' b (g' a)) :
+  (image2 f s t).image g = image2 f' t (s.image g') :=
+(image_image2_antidistrib h_antidistrib).trans $ by rw image_id'
+
+/-- Symmetric of `set.image_image2_antidistrib_left`. -/
+lemma image2_image_left_anticomm {f : α' → β → γ} {g : α → α'} {f' : β → α → δ} {g' : δ → γ}
+  (h_left_anticomm : ∀ a b, f (g a) b = g' (f' b a)) :
+  image2 f (s.image g) t = (image2 f' t s).image g' :=
+(image_image2_antidistrib_left $ λ a b, (h_left_anticomm b a).symm).symm
+
+/-- Symmetric of `set.image_image2_antidistrib_right`. -/
+lemma image_image2_right_anticomm {f : α → β' → γ} {g : β → β'} {f' : β → α → δ} {g' : δ → γ}
+  (h_right_anticomm : ∀ a b, f a (g b) = g' (f' b a)) :
+  image2 f s (t.image g) = (image2 f' t s).image g' :=
+(image_image2_antidistrib_right $ λ a b, (h_right_anticomm b a).symm).symm
 
 end n_ary_image
 

--- a/src/data/set/pointwise.lean
+++ b/src/data/set/pointwise.lean
@@ -5,8 +5,6 @@ Authors: Johan Commelin, Floris van Doorn
 -/
 import algebra.module.basic
 import data.set.finite
-import algebra.opposites
-import data.set.opposite
 import group_theory.submonoid.basic
 
 /-!
@@ -187,6 +185,9 @@ lemma mul_Inter₂_subset (s : set α) (t : Π i, κ i → set α) :
   s * (⋂ i j, t i j) ⊆ ⋂ i j, s * t i j :=
 image2_Inter₂_subset_right _ _ _
 
+@[to_additive] lemma nonempty.mul : s.nonempty → t.nonempty → (s * t).nonempty := nonempty.image2
+@[to_additive] lemma finite.mul : finite s → finite t → finite (s * t) := finite.image2 _
+
 /-- Under `[has_mul M]`, the `singleton` map from `M` to `set M` as a `mul_hom`, that is, a map
 which preserves multiplication. -/
 @[to_additive "Under `[has_add A]`, the `singleton` map from `A` to `set A` as an `add_hom`,
@@ -194,6 +195,11 @@ that is, a map which preserves addition.", simps]
 def singleton_mul_hom : mul_hom α (set α) :=
 { to_fun := singleton,
   map_mul' := λ a b, singleton_mul_singleton.symm }
+
+open mul_opposite
+
+@[simp, to_additive]
+lemma image_op_mul : op '' (s * t) = op '' t * op '' s := image_image2_antidistrib op_mul
 
 end has_mul
 
@@ -249,7 +255,7 @@ protected def semigroup [semigroup α] : semigroup (set α) :=
 /-- `set α` is a `comm_semigroup` under pointwise operations if `α` is. -/
 @[to_additive "`set α` is an `add_comm_semigroup` under pointwise operations if `α` is."]
 protected def comm_semigroup [comm_semigroup α] : comm_semigroup (set α) :=
-{ mul_comm := λ s t, by simp only [← image2_mul, image2_swap _ s, mul_comm]
+{ mul_comm := λ s t, image2_comm mul_comm
   ..set.semigroup }
 
 /-- `set α` is a `monoid` under pointwise operations if `α` is. -/
@@ -334,13 +340,6 @@ let ⟨a, ha⟩ := ht in eq_univ_of_forall $ λ b, ⟨b * a⁻¹, a, trivial, ha
 def singleton_hom [monoid α] : α →* set α :=
 { to_fun := singleton, map_one' := rfl, map_mul' := λ a b, singleton_mul_singleton.symm }
 
-@[to_additive]
-lemma nonempty.mul [has_mul α] : s.nonempty → t.nonempty → (s * t).nonempty := nonempty.image2
-
-@[to_additive]
-lemma finite.mul [has_mul α] (hs : finite s) (ht : finite t) : finite (s * t) :=
-hs.image2 _ ht
-
 /-- multiplication preserves finiteness -/
 @[to_additive "addition preserves finiteness"]
 def fintype_mul [has_mul α] [decidable_eq α] (s t : set α) [hs : fintype s] [ht : fintype t] :
@@ -355,19 +354,6 @@ begin
   use bA * bB,
   rintro x ⟨xa, xb, hxa, hxb, rfl⟩,
   exact mul_le_mul' (hbA hxa) (hbB hxb),
-end
-
-open mul_opposite
-
-@[to_additive]
-lemma image_op_mul {α : Type*} [has_mul α] {s t : set α} :  op '' (s * t) = (op '' t) * (op '' s) :=
-begin
-  ext x,
-  split,
-  { rintro ⟨-, ⟨x, y, hx, hy, rfl⟩, rfl⟩,
-    apply mul_mem_mul (mem_image_of_mem op hy) (mem_image_of_mem op hx) },
-  { rintro ⟨-, -, ⟨y, hy, rfl⟩, ⟨z, hz, rfl⟩, rfl⟩,
-    refine ⟨z*y, mul_mem_mul hz hy, op_mul z y⟩ }
 end
 
 end mul
@@ -447,7 +433,6 @@ end big_operators
 /-! ### Set negation/inversion -/
 
 section inv
-variables {s t : set α} {a : α}
 
 /-- The set `(s⁻¹ : set α)` is defined as `{x | x⁻¹ ∈ s}` in locale `pointwise`.
 It is equal to `{x⁻¹ | x ∈ s}`, see `set.image_inv`. -/
@@ -459,73 +444,80 @@ protected def has_inv [has_inv α] : has_inv (set α) :=
 
 localized "attribute [instance] set.has_inv set.has_neg" in pointwise
 
-@[simp, to_additive]
-lemma inv_empty [has_inv α] : (∅ : set α)⁻¹ = ∅ := rfl
+section has_inv
+variables [has_inv α] {s t : set α} {a : α}
+
+@[simp, to_additive] lemma inv_empty : (∅ : set α)⁻¹ = ∅ := rfl
+@[simp, to_additive] lemma inv_univ : (univ : set α)⁻¹ = univ := rfl
 
 @[simp, to_additive]
-lemma inv_univ [has_inv α] : (univ : set α)⁻¹ = univ := rfl
+lemma mem_inv : a ∈ s⁻¹ ↔ a⁻¹ ∈ s := iff.rfl
 
 @[simp, to_additive]
-lemma nonempty_inv [has_involutive_inv α] {s : set α} : s⁻¹.nonempty ↔ s.nonempty :=
-inv_involutive.surjective.nonempty_preimage
-
-@[to_additive] lemma nonempty.inv [has_involutive_inv α] {s : set α} (h : s.nonempty) :
-  s⁻¹.nonempty :=
-nonempty_inv.2 h
+lemma inv_preimage : has_inv.inv ⁻¹' s = s⁻¹ := rfl
 
 @[simp, to_additive]
-lemma mem_inv [has_inv α] : a ∈ s⁻¹ ↔ a⁻¹ ∈ s := iff.rfl
-
-@[to_additive]
-lemma inv_mem_inv [has_involutive_inv α] : a⁻¹ ∈ s⁻¹ ↔ a ∈ s :=
-by simp only [mem_inv, inv_inv]
+lemma inter_inv : (s ∩ t)⁻¹ = s⁻¹ ∩ t⁻¹ := preimage_inter
 
 @[simp, to_additive]
-lemma inv_preimage [has_inv α] : has_inv.inv ⁻¹' s = s⁻¹ := rfl
+lemma union_inv : (s ∪ t)⁻¹ = s⁻¹ ∪ t⁻¹ := preimage_union
 
 @[simp, to_additive]
-lemma image_inv [has_involutive_inv α] : has_inv.inv '' s = s⁻¹ :=
-by { simp only [← inv_preimage], rw [image_eq_preimage_of_inverse]; intro; simp only [inv_inv] }
-
-@[simp, to_additive]
-lemma inter_inv [has_inv α] : (s ∩ t)⁻¹ = s⁻¹ ∩ t⁻¹ := preimage_inter
-
-@[simp, to_additive]
-lemma union_inv [has_inv α] : (s ∪ t)⁻¹ = s⁻¹ ∪ t⁻¹ := preimage_union
-
-@[simp, to_additive]
-lemma Inter_inv {ι : Sort*} [has_inv α] (s : ι → set α) : (⋂ i, s i)⁻¹ = ⋂ i, (s i)⁻¹ :=
+lemma Inter_inv {ι : Sort*} (s : ι → set α) : (⋂ i, s i)⁻¹ = ⋂ i, (s i)⁻¹ :=
 preimage_Inter
 
 @[simp, to_additive]
-lemma Union_inv {ι : Sort*} [has_inv α] (s : ι → set α) : (⋃ i, s i)⁻¹ = ⋃ i, (s i)⁻¹ :=
+lemma Union_inv {ι : Sort*} (s : ι → set α) : (⋃ i, s i)⁻¹ = ⋃ i, (s i)⁻¹ :=
 preimage_Union
 
 @[simp, to_additive]
-lemma compl_inv [has_inv α] : (sᶜ)⁻¹ = (s⁻¹)ᶜ := preimage_compl
+lemma compl_inv : (sᶜ)⁻¹ = (s⁻¹)ᶜ := preimage_compl
+
+end has_inv
+
+section has_involutive_inv
+variables [has_involutive_inv α] {s t : set α} {a : α}
+
+@[to_additive] lemma inv_mem_inv : a⁻¹ ∈ s⁻¹ ↔ a ∈ s := by simp only [mem_inv, inv_inv]
+
+@[simp, to_additive] lemma nonempty_inv : s⁻¹.nonempty ↔ s.nonempty :=
+inv_involutive.surjective.nonempty_preimage
+
+@[to_additive] lemma nonempty.inv (h : s.nonempty) : s⁻¹.nonempty := nonempty_inv.2 h
+
+@[to_additive] lemma finite.inv (hs : finite s) : finite s⁻¹ :=
+hs.preimage $ inv_injective.inj_on _
 
 @[simp, to_additive]
-instance [has_involutive_inv α] : has_involutive_inv (set α) :=
+lemma image_inv : has_inv.inv '' s = s⁻¹ :=
+congr_fun (image_eq_preimage_of_inverse inv_involutive.left_inverse inv_involutive.right_inverse) _
+
+@[simp, to_additive]
+instance : has_involutive_inv (set α) :=
 { inv := has_inv.inv,
   inv_inv := λ s, by { simp only [← inv_preimage, preimage_preimage, inv_inv, preimage_id'] } }
 
 @[simp, to_additive]
-lemma inv_subset_inv [has_involutive_inv α] {s t : set α} : s⁻¹ ⊆ t⁻¹ ↔ s ⊆ t :=
+lemma inv_subset_inv : s⁻¹ ⊆ t⁻¹ ↔ s ⊆ t :=
 (equiv.inv α).surjective.preimage_subset_preimage_iff
 
-@[to_additive] lemma inv_subset [has_involutive_inv α] {s t : set α} : s⁻¹ ⊆ t ↔ s ⊆ t⁻¹ :=
-by { rw [← inv_subset_inv, inv_inv] }
+@[to_additive] lemma inv_subset : s⁻¹ ⊆ t ↔ s ⊆ t⁻¹ := by { rw [← inv_subset_inv, inv_inv] }
 
-@[to_additive] lemma finite.inv [has_involutive_inv α] {s : set α} (hs : finite s) : finite s⁻¹ :=
-hs.preimage $ inv_injective.inj_on _
+@[to_additive] lemma inv_singleton (a : α) : ({a} : set α)⁻¹ = {a⁻¹} :=
+by rw [←image_inv, image_singleton]
 
-@[to_additive] lemma inv_singleton {β : Type*} [has_involutive_inv β] (x : β) :
-  ({x} : set β)⁻¹ = {x⁻¹} :=
-by { ext1 y, rw [mem_inv, mem_singleton_iff, mem_singleton_iff, inv_eq_iff_inv_eq, eq_comm], }
+open mul_opposite
+
+@[to_additive]
+lemma image_op_inv : op '' s⁻¹ = (op '' s)⁻¹ := by simp_rw [←image_inv, image_comm op_inv]
+
+end has_involutive_inv
 
 @[to_additive] protected lemma mul_inv_rev [group α] (s t : set α) : (s * t)⁻¹ = t⁻¹ * s⁻¹ :=
-by simp_rw [←image_inv, ←image2_mul, image_image2, image2_image_left, image2_image_right,
-              mul_inv_rev, image2_swap _ s t]
+by { simp_rw ←image_inv, exact image_image2_antidistrib mul_inv_rev }
+
+protected lemma mul_inv_rev₀ [group_with_zero α] (s t : set α) : (s * t)⁻¹ = t⁻¹ * s⁻¹ :=
+by { simp_rw ←image_inv, exact image_image2_antidistrib mul_inv_rev₀ }
 
 end inv
 
@@ -647,24 +639,14 @@ multiplication/division!) of a `set`. -/
 /-- `s / t = s * t⁻¹` for all `s t : set α` if `a / b = a * b⁻¹` for all `a b : α`. -/
 @[to_additive "`s - t = s + -t` for all `s t : set α` if `a - b = a + -b` for all `a b : α`."]
 protected def div_inv_monoid [group α] : div_inv_monoid (set α) :=
-{ div_eq_mul_inv := λ s t, begin
-    rw [←image2_div, ←image2_mul],
-    convert (image2_image_right (*) has_inv.inv).symm,
-    { ext,
-      exact div_eq_mul_inv _ _ },
-    { exact image_inv.symm }
-  end,
+{ div_eq_mul_inv := λ s t,
+    by { rw [←image_id (s / t), ←image_inv], exact image_image2_distrib_right div_eq_mul_inv },
   ..set.monoid, ..set.has_inv, ..set.has_div }
 
 /-- `s / t = s * t⁻¹` for all `s t : set α` if `a / b = a * b⁻¹` for all `a b : α`. -/
 protected def div_inv_monoid' [group_with_zero α] : div_inv_monoid (set α) :=
-{ div_eq_mul_inv := λ s t, begin
-    rw [←image2_div, ←image2_mul],
-    convert (image2_image_right (*) has_inv.inv).symm,
-    { ext,
-      exact div_eq_mul_inv _ _ },
-    { exact image_inv.symm }
-  end,
+{ div_eq_mul_inv := λ s t,
+    by { rw [←image_id (s / t), ←image_inv], exact image_image2_distrib_right div_eq_mul_inv },
   ..set.monoid, ..set.has_inv, ..set.has_div }
 
 localized "attribute [instance] set.has_nsmul set.has_npow set.has_zsmul set.has_zpow
@@ -775,6 +757,9 @@ lemma smul_Inter₂_subset (s : set α) (t : Π i, κ i → set β) :
   s • (⋂ i j, t i j) ⊆ ⋂ i j, s • t i j :=
 image2_Inter₂_subset_right _ _ _
 
+@[to_additive] lemma nonempty.smul : s.nonempty → t.nonempty → (s • t).nonempty := nonempty.image2
+@[to_additive] lemma finite.smul : finite s → finite t → finite (s • t) := finite.image2 _
+
 end has_scalar
 
 section has_scalar_set
@@ -817,7 +802,8 @@ lemma smul_set_Inter₂_subset (a : α) (t : Π i, κ i → set β) :
   a • (⋂ i j, t i j) ⊆ ⋂ i j, a • t i j :=
 image_Inter₂_subset _ _
 
-@[to_additive] lemma finite.smul_set (hs : finite s) : finite (a • s) := hs.image _
+@[to_additive] lemma nonempty.smul_set : s.nonempty → (a • s).nonempty := nonempty.image _
+@[to_additive] lemma finite.smul_set : finite s → finite (a • s) := finite.image _
 
 end has_scalar_set
 
@@ -851,8 +837,7 @@ ext $ λ x, ⟨λ hx, let ⟨p, q, ⟨i, hi⟩, ⟨j, hj⟩, hpq⟩ := set.mem_s
 @[to_additive]
 instance smul_comm_class_set [has_scalar α γ] [has_scalar β γ] [smul_comm_class α β γ] :
   smul_comm_class α (set β) (set γ) :=
-{ smul_comm := λ a T T',
-    by simp only [←image2_smul, ←image_smul, image2_image_right, image_image2, smul_comm] }
+⟨λ _ _ _, image_image2_distrib_right $ smul_comm _⟩
 
 @[to_additive]
 instance smul_comm_class_set' [has_scalar α γ] [has_scalar β γ] [smul_comm_class α β γ] :
@@ -862,10 +847,7 @@ by haveI := smul_comm_class.symm α β γ; exact smul_comm_class.symm _ _ _
 @[to_additive]
 instance smul_comm_class [has_scalar α γ] [has_scalar β γ] [smul_comm_class α β γ] :
   smul_comm_class (set α) (set β) (set γ) :=
-{ smul_comm := λ T T' T'', begin
-    simp only [←image2_smul, image2_swap _ T],
-    exact image2_assoc (λ b c a, smul_comm a b c),
-  end }
+⟨λ _ _ _, image2_left_comm smul_comm⟩
 
 instance is_scalar_tower [has_scalar α β] [has_scalar α γ] [has_scalar β γ]
   [is_scalar_tower α β γ] :
@@ -875,8 +857,7 @@ instance is_scalar_tower [has_scalar α β] [has_scalar α γ] [has_scalar β γ
 instance is_scalar_tower' [has_scalar α β] [has_scalar α γ] [has_scalar β γ]
   [is_scalar_tower α β γ] :
   is_scalar_tower α (set β) (set γ) :=
-{ smul_assoc := λ a T T',
-    by simp only [←image_smul, ←image2_smul, image_image2, image2_image_left, smul_assoc] }
+⟨λ _ _ _, image2_image_left_comm $ smul_assoc _⟩
 
 instance is_scalar_tower'' [has_scalar α β] [has_scalar α γ] [has_scalar β γ]
   [is_scalar_tower α β γ] :
@@ -887,11 +868,44 @@ instance is_central_scalar [has_scalar α β] [has_scalar αᵐᵒᵖ β] [is_ce
   is_central_scalar α (set β) :=
 ⟨λ a S, congr_arg (λ f, f '' S) $ by exact funext (λ _, op_smul_eq_smul _ _)⟩
 
+/-- A multiplicative action of a monoid `α` on a type `β` gives a multiplicative action of `set α`
+on `set β`. -/
+@[to_additive "An additive action of an additive monoid `α` on a type `β` gives an additive action
+of `set α` on `set β`"]
+protected def mul_action [monoid α] [mul_action α β] : mul_action (set α) (set β) :=
+{ mul_smul := λ _ _ _, image2_assoc mul_smul,
+  one_smul := λ s, image2_singleton_left.trans $ by simp_rw [one_smul, image_id'] }
+
+/-- A multiplicative action of a monoid on a type `β` gives a multiplicative action on `set β`. -/
+@[to_additive "An additive action of an additive monoid on a type `β` gives an additive action
+on `set β`."]
+protected def mul_action_set [monoid α] [mul_action α β] : mul_action α (set β) :=
+{ mul_smul := by { intros, simp only [← image_smul, image_image, ← mul_smul] },
+  one_smul := by { intros, simp only [← image_smul, one_smul, image_id'] } }
+
+localized "attribute [instance] set.mul_action_set set.add_action_set
+  set.mul_action set.add_action" in pointwise
+
+/-- A distributive multiplicative action of a monoid on an additive monoid `β` gives a distributive
+multiplicative action on `set β`. -/
+protected def distrib_mul_action_set [monoid α] [add_monoid β] [distrib_mul_action α β] :
+  distrib_mul_action α (set β) :=
+{ smul_add := λ _ _ _, image_image2_distrib $ smul_add _,
+  smul_zero := λ _, image_singleton.trans $ by rw [smul_zero, singleton_zero] }
+
+/-- A multiplicative action of a monoid on a monoid `β` gives a multiplicative action on `set β`. -/
+protected def mul_distrib_mul_action_set [monoid α] [monoid β] [mul_distrib_mul_action α β] :
+  mul_distrib_mul_action α (set β) :=
+{ smul_mul := λ _ _ _, image_image2_distrib $ smul_mul' _,
+  smul_one := λ _, image_singleton.trans $ by rw [smul_one, singleton_one] }
+
+localized "attribute [instance] set.distrib_mul_action_set set.mul_distrib_mul_action_set"
+  in pointwise
+
 end smul
 
 section vsub
-variables {ι : Sort*} {κ : ι → Sort*} [has_vsub α β] {s s₁ s₂ t t₁ t₂ : set β} {a : α}
-  {b c : β}
+variables {ι : Sort*} {κ : ι → Sort*} [has_vsub α β] {s s₁ s₂ t t₁ t₂ : set β} {a : α} {b c : β}
 include α
 
 instance has_vsub : has_vsub (set α) (set β) := ⟨image2 (-ᵥ)⟩
@@ -954,6 +968,7 @@ lemma vsub_Inter₂_subset (s : set β) (t : Π i, κ i → set β) :
   s -ᵥ (⋂ i j, t i j) ⊆ ⋂ i j, s -ᵥ t i j :=
 image2_Inter₂_subset_right _ _ _
 
+lemma nonempty.vsub : s.nonempty → t.nonempty → (s -ᵥ t : set α).nonempty := nonempty.image2
 lemma finite.vsub (hs : finite s) (ht : finite t) : finite (s -ᵥ t) := hs.image2 _ ht
 
 lemma vsub_self_mono (h : s ⊆ t) : s -ᵥ s ⊆ t -ᵥ t := vsub_subset_vsub h h
@@ -1030,24 +1045,12 @@ instance set_semiring.semiring [monoid α] : semiring (set_semiring α) :=
 instance set_semiring.comm_semiring [comm_monoid α] : comm_semiring (set_semiring α) :=
 { ..set.comm_monoid, ..set_semiring.semiring }
 
-/-- A multiplicative action of a monoid on a type β gives also a
- multiplicative action on the subsets of β. -/
-@[to_additive "An additive action of an additive monoid on a type β gives also an additive action
-on the subsets of β."]
-protected def mul_action_set [monoid α] [mul_action α β] : mul_action α (set β) :=
-{ mul_smul := by { intros, simp only [← image_smul, image_image, ← mul_smul] },
-  one_smul := by { intros, simp only [← image_smul, image_eta, one_smul, image_id'] },
-  ..set.has_scalar_set }
-
-localized "attribute [instance] set.mul_action_set set.add_action_set" in pointwise
-
 section mul_hom
 
 variables [has_mul α] [has_mul β] [mul_hom_class F α β] (m : F) {s t : set α}
 
 @[to_additive]
-lemma image_mul : (m : α → β) '' (s * t) = m '' s * m '' t :=
-by simp only [← image2_mul, image_image2, image2_image_left, image2_image_right, map_mul m]
+lemma image_mul : (m : α → β) '' (s * t) = m '' s * m '' t := image_image2_distrib $ map_mul m
 
 @[to_additive]
 lemma preimage_mul_preimage_subset {s t : set β} : (m : α → β) ⁻¹' s * m ⁻¹' t ⊆ m ⁻¹' (s * t) :=


### PR DESCRIPTION
Add some more `set.image2` API and demonstrate use by golfing all relevant `data.set.pointwise` declarations.

Other additions
---
* `has_involutive_inv`/`has_involutive_neg` instances for `mul_opposite`/`add_opposite`
* `set.mul_action`, `set.distrib_mul_action_set`, `set.mul_distrib_mul_action_set`
* `set.mul_inv_rev₀`

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
