### PR TITLE
[Merged by Bors] - refactor(topology/{fiber_bundle, vector_bundle}): make trivializations data rather than an existential

### DIFF
--- a/src/topology/fiber_bundle.lean
+++ b/src/topology/fiber_bundle.lean
@@ -1112,8 +1112,7 @@ begin
   exact le_bsupr e he,
 end
 
-lemma is_open_source_of_mem_pretrivialization_atlas (he : e ∈ a.pretrivialization_atlas) :
-  @is_open _ a.total_space_topology e.source :=
+lemma is_open_source (e : pretrivialization F proj) : @is_open _ a.total_space_topology e.source :=
 begin
   letI := a.total_space_topology,
   refine is_open_supr_iff.mpr (λ e', _),
@@ -1125,13 +1124,13 @@ begin
     pretrivialization.preimage_symm_proj_inter],
 end
 
-lemma is_open_target_of_mem_pretrivialization_atlas_inter {e e' : pretrivialization F proj}
-  (he : e ∈ a.pretrivialization_atlas) (he' : e' ∈ a.pretrivialization_atlas) :
+lemma is_open_target_of_mem_pretrivialization_atlas_inter (e e' : pretrivialization F proj)
+  (he' : e' ∈ a.pretrivialization_atlas) :
   is_open (e'.to_local_equiv.target ∩ e'.to_local_equiv.symm ⁻¹' e.source) :=
 begin
   letI := a.total_space_topology,
   obtain ⟨u, hu1, hu2⟩ := continuous_on_iff'.mp (a.continuous_symm_of_mem_pretrivialization_atlas
-    he') e.source (a.is_open_source_of_mem_pretrivialization_atlas he),
+    he') e.source (a.is_open_source e),
   rw [inter_comm, hu2],
   exact hu1.inter e'.open_target,
 end
@@ -1139,7 +1138,7 @@ end
 /-- Promotion from a `pretrivialization` to a `trivialization`. -/
 def trivialization_of_mem_pretrivialization_atlas (he : e ∈ a.pretrivialization_atlas) :
   @trivialization B F Z _ _ a.total_space_topology proj :=
-{ open_source := a.is_open_source_of_mem_pretrivialization_atlas he,
+{ open_source := a.is_open_source e,
   continuous_to_fun := begin
     letI := a.total_space_topology,
     refine continuous_on_iff'.mpr (λ s hs, ⟨e ⁻¹' s ∩ e.source, (is_open_supr_iff.mpr (λ e', _)),
@@ -1153,7 +1152,7 @@ def trivialization_of_mem_pretrivialization_atlas (he : e ∈ a.pretrivializatio
       (e'.to_local_equiv.symm ⁻¹' e.source), _, by
       { simp only [preimage_inter, inter_univ, subtype.coe_preimage_self, hu3.symm], refl }⟩,
     rw inter_assoc,
-    exact hu1.inter (a.is_open_target_of_mem_pretrivialization_atlas_inter he he'),
+    exact hu1.inter (a.is_open_target_of_mem_pretrivialization_atlas_inter e e' he'),
   end,
   continuous_inv_fun := a.continuous_symm_of_mem_pretrivialization_atlas he,
   .. e }

--- a/src/topology/fiber_bundle.lean
+++ b/src/topology/fiber_bundle.lean
@@ -1087,76 +1087,81 @@ topology in such a way that there is a fiber bundle structure for which the loca
 are also local homeomorphism and hence local trivializations. -/
 @[nolint has_inhabited_instance]
 structure topological_fiber_prebundle (proj : Z → B) :=
+(pretrivialization_atlas : set (pretrivialization F proj))
 (pretrivialization_at : B → pretrivialization F proj)
 (mem_base_pretrivialization_at : ∀ x : B, x ∈ (pretrivialization_at x).base_set)
-(continuous_triv_change : ∀ x y : B, continuous_on ((pretrivialization_at x) ∘
-  (pretrivialization_at y).to_local_equiv.symm) ((pretrivialization_at y).target ∩
-  ((pretrivialization_at y).to_local_equiv.symm ⁻¹' (pretrivialization_at x).source)))
+(pretrivialization_mem_atlas : ∀ x : B, pretrivialization_at x ∈ pretrivialization_atlas)
+(continuous_triv_change : ∀ e e' ∈ pretrivialization_atlas,
+  continuous_on (e ∘ e'.to_local_equiv.symm) (e'.target ∩ (e'.to_local_equiv.symm ⁻¹' e.source)))
 
 namespace topological_fiber_prebundle
 
-variables {F} (a : topological_fiber_prebundle F proj) (x : B)
+variables {F} (a : topological_fiber_prebundle F proj) {e : pretrivialization F proj}
 
 /-- Topology on the total space that will make the prebundle into a bundle. -/
 def total_space_topology (a : topological_fiber_prebundle F proj) : topological_space Z :=
-⨆ x : B, coinduced (a.pretrivialization_at x).set_symm (subtype.topological_space)
+⨆ (e : pretrivialization F proj) (he : e ∈ a.pretrivialization_atlas),
+  coinduced e.set_symm (subtype.topological_space)
 
-lemma continuous_symm_pretrivialization_at : @continuous_on _ _ _ a.total_space_topology
-  (a.pretrivialization_at x).to_local_equiv.symm (a.pretrivialization_at x).target :=
+lemma continuous_symm_of_mem_pretrivialization_atlas (he : e ∈ a.pretrivialization_atlas) :
+  @continuous_on _ _ _ a.total_space_topology
+  e.to_local_equiv.symm e.target :=
 begin
   refine id (λ z H, id (λ U h, preimage_nhds_within_coinduced' H
-    (a.pretrivialization_at x).open_target (le_def.1 (nhds_mono _) U h))),
-  exact le_supr _ x,
+    e.open_target (le_def.1 (nhds_mono _) U h))),
+  exact le_bsupr e he,
 end
 
-lemma is_open_source_pretrivialization_at :
-  @is_open _ a.total_space_topology (a.pretrivialization_at x).source :=
+lemma is_open_source_of_mem_pretrivialization_atlas (he : e ∈ a.pretrivialization_atlas) :
+  @is_open _ a.total_space_topology e.source :=
 begin
   letI := a.total_space_topology,
-  refine is_open_supr_iff.mpr (λ y, is_open_coinduced.mpr (is_open_induced_iff.mpr
-    ⟨(a.pretrivialization_at x).target, (a.pretrivialization_at x).open_target, _⟩)),
-  rw [pretrivialization.set_symm, restrict, (a.pretrivialization_at x).target_eq,
-    (a.pretrivialization_at x).source_eq, preimage_comp, subtype.preimage_coe_eq_preimage_coe_iff,
-    (a.pretrivialization_at y).target_eq, prod_inter_prod, inter_univ,
+  refine is_open_supr_iff.mpr (λ e', _),
+  refine is_open_supr_iff.mpr (λ he', _),
+  refine is_open_coinduced.mpr (is_open_induced_iff.mpr ⟨e.target, e.open_target, _⟩),
+  rw [pretrivialization.set_symm, restrict, e.target_eq,
+    e.source_eq, preimage_comp, subtype.preimage_coe_eq_preimage_coe_iff,
+    e'.target_eq, prod_inter_prod, inter_univ,
     pretrivialization.preimage_symm_proj_inter],
 end
 
-lemma is_open_target_pretrivialization_at_inter (x y : B) :
-  is_open ((a.pretrivialization_at y).to_local_equiv.target ∩
-  (a.pretrivialization_at y).to_local_equiv.symm ⁻¹' (a.pretrivialization_at x).source) :=
+lemma is_open_target_of_mem_pretrivialization_atlas_inter {e e' : pretrivialization F proj}
+  (he : e ∈ a.pretrivialization_atlas) (he' : e' ∈ a.pretrivialization_atlas) :
+  is_open (e'.to_local_equiv.target ∩ e'.to_local_equiv.symm ⁻¹' e.source) :=
 begin
   letI := a.total_space_topology,
-  obtain ⟨u, hu1, hu2⟩ := continuous_on_iff'.mp (a.continuous_symm_pretrivialization_at y)
-    (a.pretrivialization_at x).source (a.is_open_source_pretrivialization_at x),
+  obtain ⟨u, hu1, hu2⟩ := continuous_on_iff'.mp (a.continuous_symm_of_mem_pretrivialization_atlas
+    he') e.source (a.is_open_source_of_mem_pretrivialization_atlas he),
   rw [inter_comm, hu2],
-  exact hu1.inter (a.pretrivialization_at y).open_target,
+  exact hu1.inter e'.open_target,
 end
 
 /-- Promotion from a `pretrivialization` to a `trivialization`. -/
-def trivialization_at (a : topological_fiber_prebundle F proj) (x : B) :
+def trivialization_of_mem_pretrivialization_atlas (he : e ∈ a.pretrivialization_atlas) :
   @trivialization B F Z _ _ a.total_space_topology proj :=
-{ open_source := a.is_open_source_pretrivialization_at x,
+{ open_source := a.is_open_source_of_mem_pretrivialization_atlas he,
   continuous_to_fun := begin
     letI := a.total_space_topology,
-    refine continuous_on_iff'.mpr (λ s hs, ⟨(a.pretrivialization_at x) ⁻¹' s ∩
-      (a.pretrivialization_at x).source, (is_open_supr_iff.mpr (λ y, _)),
+    refine continuous_on_iff'.mpr (λ s hs, ⟨e ⁻¹' s ∩ e.source, (is_open_supr_iff.mpr (λ e', _)),
       by { rw [inter_assoc, inter_self], refl }⟩),
+    refine (is_open_supr_iff.mpr (λ he', _)),
     rw [is_open_coinduced, is_open_induced_iff],
-    obtain ⟨u, hu1, hu2⟩ := continuous_on_iff'.mp (a.continuous_triv_change x y) s hs,
-    have hu3 := congr_arg (λ s, (λ x : (a.pretrivialization_at y).target, (x : B × F)) ⁻¹' s) hu2,
+    obtain ⟨u, hu1, hu2⟩ := continuous_on_iff'.mp (a.continuous_triv_change _ he _ he') s hs,
+    have hu3 := congr_arg (λ s, (λ x : e'.target, (x : B × F)) ⁻¹' s) hu2,
     simp only [subtype.coe_preimage_self, preimage_inter, univ_inter] at hu3,
-    refine ⟨u ∩ (a.pretrivialization_at y).to_local_equiv.target ∩
-      ((a.pretrivialization_at y).to_local_equiv.symm ⁻¹' (a.pretrivialization_at x).source), _, by
+    refine ⟨u ∩ e'.to_local_equiv.target ∩
+      (e'.to_local_equiv.symm ⁻¹' e.source), _, by
       { simp only [preimage_inter, inter_univ, subtype.coe_preimage_self, hu3.symm], refl }⟩,
     rw inter_assoc,
-    exact hu1.inter (a.is_open_target_pretrivialization_at_inter x y),
+    exact hu1.inter (a.is_open_target_of_mem_pretrivialization_atlas_inter he he'),
   end,
-  continuous_inv_fun := a.continuous_symm_pretrivialization_at x,
-  ..(a.pretrivialization_at x) }
+  continuous_inv_fun := a.continuous_symm_of_mem_pretrivialization_atlas he,
+  .. e }
 
 lemma is_topological_fiber_bundle :
   @is_topological_fiber_bundle B F Z _ _ a.total_space_topology proj :=
-λ x, ⟨a.trivialization_at x, a.mem_base_pretrivialization_at x ⟩
+λ x, ⟨a.trivialization_of_mem_pretrivialization_atlas (a.pretrivialization_mem_atlas x),
+  a.mem_base_pretrivialization_at x ⟩
 
 lemma continuous_proj : @continuous _ _ a.total_space_topology _ proj :=
 by { letI := a.total_space_topology, exact a.is_topological_fiber_bundle.continuous_proj, }

--- a/src/topology/vector_bundle.lean
+++ b/src/topology/vector_bundle.lean
@@ -18,8 +18,8 @@ Let `B` be the base space. In our formalism, a topological vector bundle is by d
 `Σ (x : B), E x`, with the interest that one can put another topology than on `Σ (x : B), E x`
 which has the disjoint union topology.
 
-To have a topological vector bundle structure on `bundle.total_space E`, one should addtionally have
-the following data:
+To have a topological vector bundle structure on `bundle.total_space E`, one should
+additionally have the following data:
 
 * `F` should be a topological space and a module over a semiring `R`;
 * There should be a topology on `bundle.total_space E`, for which the projection to `B` is

--- a/src/topology/vector_bundle.lean
+++ b/src/topology/vector_bundle.lean
@@ -585,7 +585,7 @@ begin
   exact (a.continuous_total_space_mk b).cod_restrict (a.mem_trivialization_at_source b),
 end
 
-noncomputable lemma to_topological_vector_bundle :
+lemma to_topological_vector_bundle :
   @topological_vector_bundle R _ F E _ _ _ _ _ _ _ a.total_space_topology _ :=
 { total_space_mk_inducing := λ b, a.inducing_total_space_mk_of_inducing_comp b
     (a.total_space_mk_inducing b),

--- a/src/topology/vector_bundle.lean
+++ b/src/topology/vector_bundle.lean
@@ -18,27 +18,23 @@ Let `B` be the base space. In our formalism, a topological vector bundle is by d
 `Σ (x : B), E x`, with the interest that one can put another topology than on `Σ (x : B), E x`
 which has the disjoint union topology.
 
-To have a topological vector bundle structure on `bundle.total_space E`,
-one should addtionally have the following data:
+To have a topological vector bundle structure on `bundle.total_space E`, one should addtionally have
+the following data:
 
 * `F` should be a topological space and a module over a semiring `R`;
 * There should be a topology on `bundle.total_space E`, for which the projection to `B` is
 a topological fiber bundle with fiber `F` (in particular, each fiber `E x` is homeomorphic to `F`);
 * For each `x`, the fiber `E x` should be a topological vector space over `R`, and the injection
 from `E x` to `bundle.total_space F E` should be an embedding;
-* The most important condition: around each point, there should be a bundle trivialization which
-is a continuous linear equiv in the fibers.
+* There should be a distinguished set of bundle trivializations (which are continuous linear equivs
+in the fibres), the "trivialization atlas"
+* There should be a choice of bundle trivialization at each point, which belongs to this atlas.
 
-If all these conditions are satisfied, we register the typeclass
-`topological_vector_bundle R F E`. We emphasize that the data is provided by other classes, and
-that the `topological_vector_bundle` class is `Prop`-valued.
+If all these conditions are satisfied, we register the typeclass `topological_vector_bundle R F E`.
 
-The point of this formalism is that it is unbundled in the sense that the total space of the bundle
-is a type with a topology, with which one can work or put further structure, and still one can
-perform operations on topological vector bundles.  For instance, assume that `E₁ : B → Type*` and
-`E₂ : B → Type*` define two topological vector bundles over `R` with fiber models `F₁` and `F₂`
-which are normed spaces. Then we construct the vector bundle `E₁ ×ᵇ E₂` of direct sums, with fiber
-`E x := (E₁ x × E₂ x)`. Then one can endow `bundle.total_space (E₁ ×ᵇ E₂)` with a topological vector
+If `E₁ : B → Type*` and `E₂ : B → Type*` define two topological vector bundles over `R` with fiber
+models `F₁` and `F₂`, denote by `E₁ ×ᵇ E₂` the sigma type of direct sums, with fiber
+`E x := (E₁ x × E₂ x)`. We can endow `bundle.total_space (E₁ ×ᵇ E₂)` with a topological vector
 bundle structure, `bundle.prod.topological_vector_bundle`.
 
 A similar construction (which is yet to be formalized) can be done for the vector bundle of
@@ -48,6 +44,16 @@ topology inherited from the norm-topology on `F₁ →L[R] F₂`, without the ne
 topology on continuous linear maps between general topological vector spaces).  Likewise for tensor
 products of topological vector bundles, exterior algebras, and so on, where the topology can be
 defined using a norm on the fiber model if this helps.
+
+## TODO
+
+The definition `topological_vector_bundle` is currently not the standard definition given in the
+literature, but rather a variant definition which agrees *in finite dimension* with the standard
+definition.  The standard definition in the literature requires a further condition on the
+compatibility of transition functions, see
+https://mathoverflow.net/questions/4943/vector-bundle-with-non-smoothly-varying-transition-functions/4997#4997
+https://mathoverflow.net/questions/54550/the-third-axiom-in-the-definition-of-infinite-dimensional-vector-bundles-why/54706#54706
+This will be fixed in a future refactor.
 
 ## Tags
 Vector bundle
@@ -118,10 +124,10 @@ space) has a topological vector space structure with fiber `F` (denoted with
 which is linear in the fibers. -/
 class topological_vector_bundle :=
 (total_space_mk_inducing [] : ∀ (b : B), inducing (total_space_mk E b))
-(trivialization_atlas []            : set (trivialization R F E))
-(trivialization_at []         : B → trivialization R F E)
+(trivialization_atlas [] : set (trivialization R F E))
+(trivialization_at [] : B → trivialization R F E)
 (mem_base_set_trivialization_at [] : ∀ b : B, b ∈ (trivialization_at b).base_set)
-(trivialization_mem_atlas []  : ∀ b : B, trivialization_at b ∈ trivialization_atlas)
+(trivialization_mem_atlas [] : ∀ b : B, trivialization_at b ∈ trivialization_atlas)
 
 export topological_vector_bundle (trivialization_atlas trivialization_at
   mem_base_set_trivialization_at trivialization_mem_atlas)
@@ -585,7 +591,13 @@ begin
   exact (a.continuous_total_space_mk b).cod_restrict (a.mem_trivialization_at_source b),
 end
 
-lemma to_topological_vector_bundle :
+/-- Make a `topological_vector_bundle` from a `topological_vector_prebundle`.  Concretely this means
+that, given a `topological_vector_prebundle` structure for a sigma-type `E` -- which consists of a
+number of "pretrivializations" identifying parts of `E` with product spaces `U × F` -- one
+establishes that for the topology constructed on the sigma-type using
+`topological_vector_prebundle.total_space_topology`, these "pretrivializations" are actually
+"trivializations" (i.e., homeomorphisms with respect to the constructed topology). -/
+def to_topological_vector_bundle :
   @topological_vector_bundle R _ F E _ _ _ _ _ _ _ a.total_space_topology _ :=
 { total_space_mk_inducing := λ b, a.inducing_total_space_mk_of_inducing_comp b
     (a.total_space_mk_inducing b),

--- a/src/topology/vector_bundle.lean
+++ b/src/topology/vector_bundle.lean
@@ -123,7 +123,8 @@ class topological_vector_bundle :=
 (mem_base_set_trivialization_at [] : ∀ b : B, b ∈ (trivialization_at b).base_set)
 (trivialization_mem_atlas []  : ∀ b : B, trivialization_at b ∈ trivialization_atlas)
 
-export topological_vector_bundle (trivialization_at mem_base_set_trivialization_at)
+export topological_vector_bundle (trivialization_atlas trivialization_at
+  mem_base_set_trivialization_at trivialization_mem_atlas)
 
 variable [topological_vector_bundle R F E]
 
@@ -408,7 +409,7 @@ topological_fiber_bundle_core.to_topological_space ι ↑Z
 
 variables {ι} (b : B) (a : F)
 
-@[simp, mfld_simps] lemma coe_cord_change (i j : ι) :
+@[simp, mfld_simps] lemma coe_coord_change (i j : ι) :
   topological_fiber_bundle_core.coord_change ↑Z i j b = Z.coord_change i j b := rfl
 
 /-- Extended version of the local trivialization of a fiber bundle constructed from core,
@@ -470,10 +471,10 @@ instance : topological_vector_bundle R F Z.fiber :=
         exact ha.2.2, },
       { simp only [mem_prod, mem_preimage, mem_inter_eq, local_triv_at_apply],
         exact ⟨Z.mem_base_set_at b, ha⟩, } } end⟩,
-  trivialization_atlas := set.range Z.local_triv_at,
+  trivialization_atlas := set.range Z.local_triv,
   trivialization_at := Z.local_triv_at,
   mem_base_set_trivialization_at := Z.mem_base_set_at,
-  trivialization_mem_atlas := mem_range_self }
+  trivialization_mem_atlas := λ b, ⟨Z.index_at b, rfl⟩ }
 
 /-- The projection on the base of a topological vector bundle created from core is continuous -/
 @[continuity] lemma continuous_proj : continuous Z.proj :=

--- a/src/topology/vector_bundle.lean
+++ b/src/topology/vector_bundle.lean
@@ -116,14 +116,12 @@ variables [∀ x, topological_space (E x)]
 space) has a topological vector space structure with fiber `F` (denoted with
 `topological_vector_bundle R F E`) if around every point there is a fiber bundle trivialization
 which is linear in the fibers. -/
--- /-- `trivialization_at R F E b` is some choice of trivialization of a vector bundle whose base set
--- contains a given point `b`. -/
 class topological_vector_bundle :=
 (total_space_mk_inducing [] : ∀ (b : B), inducing (total_space_mk E b))
-(atlas []            : set (trivialization R F E))
+(trivialization_atlas []            : set (trivialization R F E))
 (trivialization_at []         : B → trivialization R F E)
 (mem_base_set_trivialization_at [] : ∀ b : B, b ∈ (trivialization_at b).base_set)
-(trivialization_mem_atlas []  : ∀ b : B, trivialization_at b ∈ atlas)
+(trivialization_mem_atlas []  : ∀ b : B, trivialization_at b ∈ trivialization_atlas)
 
 export topological_vector_bundle (trivialization_at mem_base_set_trivialization_at)
 
@@ -276,7 +274,7 @@ def trivial_topological_vector_bundle.trivialization : trivialization R F (bundl
 
 instance trivial_bundle.topological_vector_bundle :
   topological_vector_bundle R F (bundle.trivial B F) :=
-{ atlas := {trivial_topological_vector_bundle.trivialization R B F},
+{ trivialization_atlas := {trivial_topological_vector_bundle.trivialization R B F},
   trivialization_at := λ x, trivial_topological_vector_bundle.trivialization R B F,
   mem_base_set_trivialization_at := mem_univ,
   trivialization_mem_atlas := λ x, mem_singleton _,
@@ -472,7 +470,7 @@ instance : topological_vector_bundle R F Z.fiber :=
         exact ha.2.2, },
       { simp only [mem_prod, mem_preimage, mem_inter_eq, local_triv_at_apply],
         exact ⟨Z.mem_base_set_at b, ha⟩, } } end⟩,
-  atlas := set.range Z.local_triv_at,
+  trivialization_atlas := set.range Z.local_triv_at,
   trivialization_at := Z.local_triv_at,
   mem_base_set_trivialization_at := Z.mem_base_set_at,
   trivialization_mem_atlas := mem_range_self }
@@ -578,7 +576,7 @@ lemma to_topological_vector_bundle :
   @topological_vector_bundle R _ F E _ _ _ _ _ _ _ a.total_space_topology _ :=
 { total_space_mk_inducing := λ b, a.inducing_total_space_mk_of_inducing_comp b
     (a.total_space_mk_inducing b),
-  atlas := set.range a.trivialization_at,
+  trivialization_atlas := set.range a.trivialization_at,
   trivialization_at := a.trivialization_at,
   mem_base_set_trivialization_at := a.mem_base_pretrivialization_at,
   trivialization_mem_atlas := mem_range_self }
@@ -785,8 +783,8 @@ instance _root_.bundle.prod.topological_vector_bundle :
     rw (prod.inducing_diag E₁ E₂).inducing_iff,
     exact (total_space_mk_inducing R F₁ E₁ b).prod_mk (total_space_mk_inducing R F₂ E₂ b),
   end,
-  atlas := (λ (p : trivialization R F₁ E₁ × trivialization R F₂ E₂), p.1.prod p.2) ''
-    (atlas R F₁ E₁ ×ˢ atlas R F₂ E₂),
+  trivialization_atlas := (λ (p : trivialization R F₁ E₁ × trivialization R F₂ E₂), p.1.prod p.2) ''
+    (trivialization_atlas R F₁ E₁ ×ˢ trivialization_atlas R F₂ E₂),
   trivialization_at := λ b, (trivialization_at R F₁ E₁ b).prod (trivialization_at R F₂ E₂ b),
   mem_base_set_trivialization_at :=
     λ b, ⟨mem_base_set_trivialization_at R F₁ E₁ b, mem_base_set_trivialization_at R F₂ E₂ b⟩,


### PR DESCRIPTION
Previously, the construction `topological_vector_bundle` was a mixin requiring the _existence_ of a suitable trivialization at each point.

Change this to a class with data: a choice of trivialization at each point.  This has no effect on the mathematics, but it is necessary for the forthcoming refactor in which a further condition is imposed on the mutual compatibility of the trivializations.

Furthermore, attach to `topological_vector_bundle` and to two other constructions `topological_fiber_prebundle`, `topological_vector_prebundle` a further piece of data: an atlas of "good" trivializations.  This is not really mathematically necessary, since you could always take the atlas of "good" trivializations to be simply the set of canonical trivializations at each point in the manifold.  But sometimes one naturally has this larger "good" class and it's convenient to be able to access it.  The `charted_space` definition in the manifolds library does something similar.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
