### PR TITLE
[Merged by Bors] - chore(topology/vector_bundle): use continuous-linear rather than linear in core construction

### DIFF
--- a/src/geometry/manifold/mfderiv.lean
+++ b/src/geometry/manifold/mfderiv.lean
@@ -1253,7 +1253,7 @@ begin
   rotate, { apply_instance },
   simp only [continuous_linear_map.coe_coe, basic_smooth_vector_bundle_core.chart, h,
     tangent_bundle_core, basic_smooth_vector_bundle_core.to_topological_vector_bundle_core,
-    chart_at] with mfld_simps,
+    chart_at, sigma.mk.inj_iff] with mfld_simps,
 end
 
 end charts

--- a/src/geometry/manifold/tangent_bundle.lean
+++ b/src/geometry/manifold/tangent_bundle.lean
@@ -88,7 +88,7 @@ structure basic_smooth_vector_bundle_core {𝕜 : Type*} [nondiscrete_normed_fie
 {H : Type*} [topological_space H] (I : model_with_corners 𝕜 E H)
 (M : Type*) [topological_space M] [charted_space H M] [smooth_manifold_with_corners I M]
 (F : Type*) [normed_group F] [normed_space 𝕜 F] :=
-(coord_change      : atlas H M → atlas H M → H → (F →ₗ[𝕜] F))
+(coord_change      : atlas H M → atlas H M → H → (F →L[𝕜] F))
 (coord_change_self : ∀ i : atlas H M, ∀ x ∈ i.1.target, ∀ v, coord_change i i x v = v)
 (coord_change_comp : ∀ i j k : atlas H M,
   ∀ x ∈ ((i.1.symm.trans j.1).trans (j.1.symm.trans k.1)).source, ∀ v,
@@ -104,7 +104,7 @@ def trivial_basic_smooth_vector_bundle_core {𝕜 : Type*} [nondiscrete_normed_f
 {H : Type*} [topological_space H] (I : model_with_corners 𝕜 E H)
 (M : Type*) [topological_space M] [charted_space H M] [smooth_manifold_with_corners I M]
 (F : Type*) [normed_group F] [normed_space 𝕜 F] : basic_smooth_vector_bundle_core I M F :=
-{ coord_change := λ i j x, linear_map.id,
+{ coord_change := λ i j x, continuous_linear_map.id 𝕜 F,
   coord_change_self := λ i x hx v, rfl,
   coord_change_comp := λ i j k x hx v, rfl,
   coord_change_smooth := λ i j, cont_diff_snd.cont_diff_on }
@@ -449,7 +449,6 @@ def tangent_bundle_core : basic_smooth_vector_bundle_core I M E :=
       simpa only [model_with_corners.left_inv] using hx },
     rw [B, C, D, E] at A,
     simp only [A, continuous_linear_map.coe_comp'] with mfld_simps,
-    simp only [forall_const, eq_self_iff_true, linear_map.coe_comp, continuous_linear_map.coe_comp],
   end }
 
 variable {M}
@@ -552,7 +551,7 @@ begin
   { rintros ⟨x_fst, x_snd⟩,
     simp only [basic_smooth_vector_bundle_core.to_topological_vector_bundle_core,
       tangent_bundle_core, A, continuous_linear_map.coe_id', basic_smooth_vector_bundle_core.chart,
-      chart_at, continuous_linear_map.coe_coe] with mfld_simps, },
+      chart_at, continuous_linear_map.coe_coe, sigma.mk.inj_iff] with mfld_simps, },
   show ((chart_at (model_prod H E) p).to_local_equiv).source = univ,
     by simp only [chart_at] with mfld_simps,
 end

--- a/src/topology/vector_bundle.lean
+++ b/src/topology/vector_bundle.lean
@@ -316,7 +316,7 @@ structure topological_vector_bundle_core (ι : Type*) :=
 (is_open_base_set  : ∀ i, is_open (base_set i))
 (index_at          : B → ι)
 (mem_base_set_at   : ∀ x, x ∈ base_set (index_at x))
-(coord_change      : ι → ι → B → (F →ₗ[R] F))
+(coord_change      : ι → ι → B → (F →L[R] F))
 (coord_change_self : ∀ i, ∀ x ∈ base_set i, ∀ v, coord_change i i x v = v)
 (coord_change_continuous : ∀ i j, continuous_on (λp : B × F, coord_change i j p.1 p.2)
                                                (((base_set i) ∩ (base_set j)) ×ˢ (univ : set F)))
@@ -331,7 +331,7 @@ def trivial_topological_vector_bundle_core (ι : Type*) [inhabited ι] :
   is_open_base_set := λ i, is_open_univ,
   index_at := λ x, default,
   mem_base_set_at := λ x, mem_univ x,
-  coord_change := λ i j x, linear_map.id,
+  coord_change := λ i j x, continuous_linear_map.id R F,
   coord_change_self := λ i x hx v, rfl,
   coord_change_comp := λ i j k x hx v, rfl,
   coord_change_continuous := λ i j, continuous_on_snd, }
@@ -416,8 +416,8 @@ variables {ι} (b : B) (a : F)
 registering additionally in its type that it is a local bundle trivialization. -/
 def local_triv (i : ι) : topological_vector_bundle.trivialization R F Z.fiber :=
 { linear := λ x hx,
-  { map_add := λ v w, by simp only [linear_map.map_add] with mfld_simps,
-    map_smul := λ r v, by simp only [linear_map.map_smul] with mfld_simps},
+  { map_add := λ v w, by simp only [continuous_linear_map.map_add] with mfld_simps,
+    map_smul := λ r v, by simp only [continuous_linear_map.map_smul] with mfld_simps},
   ..topological_fiber_bundle_core.local_triv ↑Z i }
 
 variable (i : ι)


### PR DESCRIPTION
The `vector_bundle_core` construction builds a vector bundle from a cocycle, the data of which are an open cover and a choice of transition function between any two elements of the cover.  Currently, for base `B` and model fibre `F`, the transition function has type `ι → ι → B → (F →ₗ[R] F)`.

This PR changes it to type `ι → ι → B → (F →L[R] F)`.  This is no loss of generality since there already were other conditions which forced the transition function to be continuous-linear on each fibre.  Of course, it is a potential loss of convenience since the proof obligation for continuity now occurs upfront.

The change is needed because in the vector bundle refactor to come, the further condition will be imposed that each transition function `B → (F →L[R] F)` is continuous; stating this requires a topology on `F →L[R] F`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
