### PR TITLE
[Merged by Bors] - feat(order/filter/n_ary): Binary and ternary maps of filters

### DIFF
--- a/src/data/set/basic.lean
+++ b/src/data/set/basic.lean
@@ -1350,11 +1350,6 @@ subset.antisymm
 lemma image_image (g : β → γ) (f : α → β) (s : set α) : g '' (f '' s) = (λ x, g (f x)) '' s :=
 (image_comp g f s).symm
 
-lemma image_comm {β'} {f : β → γ} {g : α → β} {f' : α → β'} {g' : β' → γ}
-  (h_comm : ∀ a, f (g a) = g' (f' a)) :
-  (s.image g).image f = (s.image f').image g' :=
-by simp_rw [image_image, h_comm]
-
 /-- Image is monotone with respect to `⊆`. See `set.monotone_image` for the statement in
 terms of `≤`. -/
 theorem image_subset {a b : set α} (f : α → β) (h : a ⊆ b) : f '' a ⊆ f '' b :=
@@ -2282,7 +2277,7 @@ This section is very similar to `order.filter.n_ary`. Please keep them in sync.
 
 section n_ary_image
 
-variables {α α' β β' γ γ' δ δ' ε ε' : Type*} {f f' : α → β → γ} {g g' : α → β → γ → δ}
+variables {α β γ δ ε : Type*} {f f' : α → β → γ} {g g' : α → β → γ → δ}
 variables {s s' : set α} {t t' : set β} {u u' : set γ} {a a' : α} {b b' : β} {c c' : γ} {d d' : δ}
 
 
@@ -2311,6 +2306,12 @@ lemma image2_subset_left (ht : t ⊆ t') : image2 f s t ⊆ image2 f s t' := ima
 
 lemma image2_subset_right (hs : s ⊆ s') : image2 f s t ⊆ image2 f s' t :=
 image2_subset hs subset.rfl
+
+lemma image_subset_image2_left (hb : b ∈ t) : (λ a, f a b) '' s ⊆ image2 f s t :=
+ball_image_of_ball $ λ a ha, mem_image2_of_mem ha hb
+
+lemma image_subset_image2_right (ha : a ∈ s) : f a '' t ⊆ image2 f s t :=
+ball_image_of_ball $ λ b, mem_image2_of_mem ha
 
 lemma forall_image2_iff {p : γ → Prop} :
   (∀ z ∈ image2 f s t, p z) ↔ ∀ (x ∈ s) (y ∈ t), p (f x y) :=
@@ -2440,7 +2441,7 @@ by simp [nonempty_def.mp h, ext_iff]
 @[simp] lemma image2_right (h : s.nonempty) : image2 (λ x y, y) s t = t :=
 by simp [nonempty_def.mp h, ext_iff]
 
-lemma image2_assoc {f : δ → γ → ε} {g : α → β → δ} {f' : α → ε' → ε} {g' : β → γ → ε'}
+lemma image2_assoc {ε'} {f : δ → γ → ε} {g : α → β → δ} {f' : α → ε' → ε} {g' : β → γ → ε'}
   (h_assoc : ∀ a b c, f (g a b) c = f' a (g' b c)) :
   image2 f (image2 g s t) u = image2 f' s (image2 g' t u) :=
 by simp only [image2_image2_left, image2_image2_right, h_assoc]
@@ -2448,73 +2449,30 @@ by simp only [image2_image2_left, image2_image2_right, h_assoc]
 lemma image2_comm {g : β → α → γ} (h_comm : ∀ a b, f a b = g b a) : image2 f s t = image2 g t s :=
 (image2_swap _ _ _).trans $ by simp_rw h_comm
 
-lemma image2_left_comm {f : α → δ → ε} {g : β → γ → δ} {f' : α → γ → δ'} {g' : β → δ' → ε}
+lemma image2_left_comm {δ'} {f : α → δ → ε} {g : β → γ → δ} {f' : α → γ → δ'} {g' : β → δ' → ε}
   (h_left_comm : ∀ a b c, f a (g b c) = g' b (f' a c)) :
   image2 f s (image2 g t u) = image2 g' t (image2 f' s u) :=
 by { rw [image2_swap f', image2_swap f], exact image2_assoc (λ _ _ _, h_left_comm _ _ _) }
 
-lemma image2_right_comm {f : δ → γ → ε} {g : α → β → δ} {f' : α → γ → δ'} {g' : δ' → β → ε}
+lemma image2_right_comm {δ'} {f : δ → γ → ε} {g : α → β → δ} {f' : α → γ → δ'} {g' : δ' → β → ε}
   (h_right_comm : ∀ a b c, f (g a b) c = g' (f' a c) b) :
   image2 f (image2 g s t) u = image2 g' (image2 f' s u) t :=
 by { rw [image2_swap g, image2_swap g'], exact image2_assoc (λ _ _ _, h_right_comm _ _ _) }
 
-lemma image_image2_distrib {g : γ → δ} {f' : α' → β' → δ} {g₁ : α → α'} {g₂ : β → β'}
+lemma image_image2_distrib {α' β'} {g : γ → δ} {f' : α' → β' → δ} {g₁ : α → α'} {g₂ : β → β'}
   (h_distrib : ∀ a b, g (f a b) = f' (g₁ a) (g₂ b)) :
   (image2 f s t).image g = image2 f' (s.image g₁) (t.image g₂) :=
 by simp_rw [image_image2, image2_image_left, image2_image_right, h_distrib]
 
-/-- Symmetric of `set.image2_image_left_comm`. -/
-lemma image_image2_distrib_left {g : γ → δ} {f' : α' → β → δ} {g' : α → α'}
+lemma image_image2_distrib_left {α'} {g : γ → δ} {f' : α' → β → δ} {g' : α → α'}
   (h_distrib : ∀ a b, g (f a b) = f' (g' a) b) :
   (image2 f s t).image g = image2 f' (s.image g') t :=
 (image_image2_distrib h_distrib).trans $ by rw image_id'
 
-/-- Symmetric of `set.image_image2_right_comm`. -/
-lemma image_image2_distrib_right {g : γ → δ} {f' : α → β' → δ} {g' : β → β'}
+lemma image_image2_distrib_right {β'} {g : γ → δ} {f' : α → β' → δ} {g' : β → β'}
   (h_distrib : ∀ a b, g (f a b) = f' a (g' b)) :
   (image2 f s t).image g = image2 f' s (t.image g') :=
 (image_image2_distrib h_distrib).trans $ by rw image_id'
-
-/-- Symmetric of `set.image_image2_distrib_left`. -/
-lemma image2_image_left_comm {f : α' → β → γ} {g : α → α'} {f' : α → β → δ} {g' : δ → γ}
-  (h_left_comm : ∀ a b, f (g a) b = g' (f' a b)) :
-  image2 f (s.image g) t = (image2 f' s t).image g' :=
-(image_image2_distrib_left $ λ a b, (h_left_comm a b).symm).symm
-
-/-- Symmetric of `set.image_image2_distrib_right`. -/
-lemma image_image2_right_comm {f : α → β' → γ} {g : β → β'} {f' : α → β → δ} {g' : δ → γ}
-  (h_right_comm : ∀ a b, f a (g b) = g' (f' a b)) :
-  image2 f s (t.image g) = (image2 f' s t).image g' :=
-(image_image2_distrib_right $ λ a b, (h_right_comm a b).symm).symm
-
-lemma image_image2_antidistrib {g : γ → δ} {f' : β' → α' → δ} {g₁ : β → β'} {g₂ : α → α'}
-  (h_antidistrib : ∀ a b, g (f a b) = f' (g₁ b) (g₂ a)) :
-  (image2 f s t).image g = image2 f' (t.image g₁) (s.image g₂) :=
-by { rw image2_swap f, exact image_image2_distrib (λ _ _, h_antidistrib _ _) }
-
-/-- Symmetric of `set.image2_image_left_anticomm`. -/
-lemma image_image2_antidistrib_left {g : γ → δ} {f' : β' → α → δ} {g' : β → β'}
-  (h_antidistrib : ∀ a b, g (f a b) = f' (g' b) a) :
-  (image2 f s t).image g = image2 f' (t.image g') s :=
-(image_image2_antidistrib h_antidistrib).trans $ by rw image_id'
-
-/-- Symmetric of `set.image_image2_right_anticomm`. -/
-lemma image_image2_antidistrib_right {g : γ → δ} {f' : β → α' → δ} {g' : α → α'}
-  (h_antidistrib : ∀ a b, g (f a b) = f' b (g' a)) :
-  (image2 f s t).image g = image2 f' t (s.image g') :=
-(image_image2_antidistrib h_antidistrib).trans $ by rw image_id'
-
-/-- Symmetric of `set.image_image2_antidistrib_left`. -/
-lemma image2_image_left_anticomm {f : α' → β → γ} {g : α → α'} {f' : β → α → δ} {g' : δ → γ}
-  (h_left_anticomm : ∀ a b, f (g a) b = g' (f' b a)) :
-  image2 f (s.image g) t = (image2 f' t s).image g' :=
-(image_image2_antidistrib_left $ λ a b, (h_left_anticomm b a).symm).symm
-
-/-- Symmetric of `set.image_image2_antidistrib_right`. -/
-lemma image_image2_right_anticomm {f : α → β' → γ} {g : β → β'} {f' : β → α → δ} {g' : δ → γ}
-  (h_right_anticomm : ∀ a b, f a (g b) = g' (f' b a)) :
-  image2 f s (t.image g) = (image2 f' t s).image g' :=
-(image_image2_antidistrib_right $ λ a b, (h_right_anticomm b a).symm).symm
 
 end n_ary_image
 

--- a/src/data/set/basic.lean
+++ b/src/data/set/basic.lean
@@ -1350,6 +1350,11 @@ subset.antisymm
 lemma image_image (g : β → γ) (f : α → β) (s : set α) : g '' (f '' s) = (λ x, g (f x)) '' s :=
 (image_comp g f s).symm
 
+lemma image_comm {β'} {f : β → γ} {g : α → β} {f' : α → β'} {g' : β' → γ}
+  (h_comm : ∀ a, f (g a) = g' (f' a)) :
+  (s.image g).image f = (s.image f').image g' :=
+by simp_rw [image_image, h_comm]
+
 /-- Image is monotone with respect to `⊆`. See `set.monotone_image` for the statement in
 terms of `≤`. -/
 theorem image_subset {a b : set α} (f : α → β) (h : a ⊆ b) : f '' a ⊆ f '' b :=
@@ -2269,11 +2274,15 @@ by rw [← image_eq_image hf.1, hf.2.image_preimage]
 
 end image_preimage
 
-/-! ### Lemmas about images of binary and ternary functions -/
+/-!
+### Images of binary and ternary functions
+
+This section is very similar to `order.filter.n_ary`. Please keep them in sync.
+-/
 
 section n_ary_image
 
-variables {α β γ δ ε : Type*} {f f' : α → β → γ} {g g' : α → β → γ → δ}
+variables {α α' β β' γ γ' δ δ' ε ε' : Type*} {f f' : α → β → γ} {g g' : α → β → γ → δ}
 variables {s s' : set α} {t t' : set β} {u u' : set γ} {a a' : α} {b b' : β} {c c' : γ} {d d' : δ}
 
 
@@ -2431,7 +2440,7 @@ by simp [nonempty_def.mp h, ext_iff]
 @[simp] lemma image2_right (h : s.nonempty) : image2 (λ x y, y) s t = t :=
 by simp [nonempty_def.mp h, ext_iff]
 
-lemma image2_assoc {ε'} {f : δ → γ → ε} {g : α → β → δ} {f' : α → ε' → ε} {g' : β → γ → ε'}
+lemma image2_assoc {f : δ → γ → ε} {g : α → β → δ} {f' : α → ε' → ε} {g' : β → γ → ε'}
   (h_assoc : ∀ a b c, f (g a b) c = f' a (g' b c)) :
   image2 f (image2 g s t) u = image2 f' s (image2 g' t u) :=
 by simp only [image2_image2_left, image2_image2_right, h_assoc]
@@ -2439,30 +2448,73 @@ by simp only [image2_image2_left, image2_image2_right, h_assoc]
 lemma image2_comm {g : β → α → γ} (h_comm : ∀ a b, f a b = g b a) : image2 f s t = image2 g t s :=
 (image2_swap _ _ _).trans $ by simp_rw h_comm
 
-lemma image2_left_comm {δ'} {f : α → δ → ε} {g : β → γ → δ} {f' : α → γ → δ'} {g' : β → δ' → ε}
+lemma image2_left_comm {f : α → δ → ε} {g : β → γ → δ} {f' : α → γ → δ'} {g' : β → δ' → ε}
   (h_left_comm : ∀ a b c, f a (g b c) = g' b (f' a c)) :
   image2 f s (image2 g t u) = image2 g' t (image2 f' s u) :=
 by { rw [image2_swap f', image2_swap f], exact image2_assoc (λ _ _ _, h_left_comm _ _ _) }
 
-lemma image2_right_comm {δ'} {f : δ → γ → ε} {g : α → β → δ} {f' : α → γ → δ'} {g' : δ' → β → ε}
+lemma image2_right_comm {f : δ → γ → ε} {g : α → β → δ} {f' : α → γ → δ'} {g' : δ' → β → ε}
   (h_right_comm : ∀ a b c, f (g a b) c = g' (f' a c) b) :
   image2 f (image2 g s t) u = image2 g' (image2 f' s u) t :=
 by { rw [image2_swap g, image2_swap g'], exact image2_assoc (λ _ _ _, h_right_comm _ _ _) }
 
-lemma image_image2_distrib {α' β'} {g : γ → δ} {f' : α' → β' → δ} {g₁ : α → α'} {g₂ : β → β'}
+lemma image_image2_distrib {g : γ → δ} {f' : α' → β' → δ} {g₁ : α → α'} {g₂ : β → β'}
   (h_distrib : ∀ a b, g (f a b) = f' (g₁ a) (g₂ b)) :
   (image2 f s t).image g = image2 f' (s.image g₁) (t.image g₂) :=
 by simp_rw [image_image2, image2_image_left, image2_image_right, h_distrib]
 
-lemma image_image2_distrib_left {α'} {g : γ → δ} {f' : α' → β → δ} {g' : α → α'}
+/-- Symmetric of `set.image2_image_left_comm`. -/
+lemma image_image2_distrib_left {g : γ → δ} {f' : α' → β → δ} {g' : α → α'}
   (h_distrib : ∀ a b, g (f a b) = f' (g' a) b) :
   (image2 f s t).image g = image2 f' (s.image g') t :=
 (image_image2_distrib h_distrib).trans $ by rw image_id'
 
-lemma image_image2_distrib_right {β'} {g : γ → δ} {f' : α → β' → δ} {g' : β → β'}
+/-- Symmetric of `set.image_image2_right_comm`. -/
+lemma image_image2_distrib_right {g : γ → δ} {f' : α → β' → δ} {g' : β → β'}
   (h_distrib : ∀ a b, g (f a b) = f' a (g' b)) :
   (image2 f s t).image g = image2 f' s (t.image g') :=
 (image_image2_distrib h_distrib).trans $ by rw image_id'
+
+/-- Symmetric of `set.image_image2_distrib_left`. -/
+lemma image2_image_left_comm {f : α' → β → γ} {g : α → α'} {f' : α → β → δ} {g' : δ → γ}
+  (h_left_comm : ∀ a b, f (g a) b = g' (f' a b)) :
+  image2 f (s.image g) t = (image2 f' s t).image g' :=
+(image_image2_distrib_left $ λ a b, (h_left_comm a b).symm).symm
+
+/-- Symmetric of `set.image_image2_distrib_right`. -/
+lemma image_image2_right_comm {f : α → β' → γ} {g : β → β'} {f' : α → β → δ} {g' : δ → γ}
+  (h_right_comm : ∀ a b, f a (g b) = g' (f' a b)) :
+  image2 f s (t.image g) = (image2 f' s t).image g' :=
+(image_image2_distrib_right $ λ a b, (h_right_comm a b).symm).symm
+
+lemma image_image2_antidistrib {g : γ → δ} {f' : β' → α' → δ} {g₁ : β → β'} {g₂ : α → α'}
+  (h_antidistrib : ∀ a b, g (f a b) = f' (g₁ b) (g₂ a)) :
+  (image2 f s t).image g = image2 f' (t.image g₁) (s.image g₂) :=
+by { rw image2_swap f, exact image_image2_distrib (λ _ _, h_antidistrib _ _) }
+
+/-- Symmetric of `set.image2_image_left_anticomm`. -/
+lemma image_image2_antidistrib_left {g : γ → δ} {f' : β' → α → δ} {g' : β → β'}
+  (h_antidistrib : ∀ a b, g (f a b) = f' (g' b) a) :
+  (image2 f s t).image g = image2 f' (t.image g') s :=
+(image_image2_antidistrib h_antidistrib).trans $ by rw image_id'
+
+/-- Symmetric of `set.image_image2_right_anticomm`. -/
+lemma image_image2_antidistrib_right {g : γ → δ} {f' : β → α' → δ} {g' : α → α'}
+  (h_antidistrib : ∀ a b, g (f a b) = f' b (g' a)) :
+  (image2 f s t).image g = image2 f' t (s.image g') :=
+(image_image2_antidistrib h_antidistrib).trans $ by rw image_id'
+
+/-- Symmetric of `set.image_image2_antidistrib_left`. -/
+lemma image2_image_left_anticomm {f : α' → β → γ} {g : α → α'} {f' : β → α → δ} {g' : δ → γ}
+  (h_left_anticomm : ∀ a b, f (g a) b = g' (f' b a)) :
+  image2 f (s.image g) t = (image2 f' t s).image g' :=
+(image_image2_antidistrib_left $ λ a b, (h_left_anticomm b a).symm).symm
+
+/-- Symmetric of `set.image_image2_antidistrib_right`. -/
+lemma image_image2_right_anticomm {f : α → β' → γ} {g : β → β'} {f' : β → α → δ} {g' : δ → γ}
+  (h_right_anticomm : ∀ a b, f a (g b) = g' (f' b a)) :
+  image2 f s (t.image g) = (image2 f' t s).image g' :=
+(image_image2_antidistrib_right $ λ a b, (h_right_anticomm b a).symm).symm
 
 end n_ary_image
 

--- a/src/order/filter/n_ary.lean
+++ b/src/order/filter/n_ary.lean
@@ -1,0 +1,267 @@
+/-
+Copyright (c) 2022 Yaël Dillies. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Yaël Dillies
+-/
+import order.filter.basic
+
+/-!
+# N-ary maps of filter
+
+This file defines the binary and ternary maps of filters. This is mostly useful to define pointwise
+operations on filters.
+
+## Main declarations
+
+* `filter.map₂`: Binary map of filters.
+* `filter.map₃`: Ternary map of filters.
+-/
+
+open function set
+
+namespace filter
+variables {α α' β β' γ γ' δ δ' ε ε' : Type*} {m : α → β → γ} {f f₁ f₂ : filter α}
+  {g g₁ g₂ : filter β} {h h₁ h₂ : filter γ} {s s₁ s₂ : set α} {t t₁ t₂ : set β} {u : set γ}
+  {v : set δ} {a : α} {b : β} {c : γ}
+
+/-- The image of a binary function `m : α → β → γ` as a function `filter α → filter β → filter γ`.
+Mathematically this should be thought of as the image of the corresponding function `α × β → γ`. -/
+def map₂ (m : α → β → γ) (f : filter α) (g : filter β) : filter γ :=
+{ sets := {s | ∃ u v, u ∈ f ∧ v ∈ g ∧ image2 m u v ⊆ s},
+  univ_sets := ⟨univ, univ, univ_sets _, univ_sets _, subset_univ _⟩,
+  sets_of_superset := λ s t hs hst,
+    Exists₂.imp (λ u v, and.imp_right $ and.imp_right $ λ h, subset.trans h hst) hs,
+  inter_sets := λ s t,
+  begin
+    simp only [exists_prop, mem_set_of_eq, subset_inter_iff],
+    rintro ⟨s₁, s₂, hs₁, hs₂, hs⟩ ⟨t₁, t₂, ht₁, ht₂, ht⟩,
+    exact ⟨s₁ ∩ t₁, s₂ ∩ t₂, inter_sets f hs₁ ht₁, inter_sets g hs₂ ht₂,
+      (image2_subset (inter_subset_left _ _) $ inter_subset_left _ _).trans hs,
+      (image2_subset (inter_subset_right _ _) $ inter_subset_right _ _).trans ht⟩,
+  end }
+
+@[simp] lemma mem_map₂_iff : u ∈ map₂ m f g ↔ ∃ s t, s ∈ f ∧ t ∈ g ∧ image2 m s t ⊆ u := iff.rfl
+
+lemma image2_mem_map₂ (hs : s ∈ f) (ht : t ∈ g) : image2 m s t ∈ map₂ m f g :=
+⟨_, _, hs, ht, subset.rfl⟩
+
+-- lemma image2_mem_map₂_iff (hm : injective2 m) : image2 m s t ∈ map₂ m f g ↔ s ∈ f ∧ t ∈ g :=
+-- ⟨by { rintro ⟨u, v, hu, hv, h⟩, rw image2_subset_image2_iff hm at h,
+--   exact ⟨mem_of_superset hu h.1, mem_of_superset hv h.2⟩ }, λ h, image2_mem_map₂ h.1 h.2⟩
+
+lemma map₂_mono (hf : f₁ ≤ f₂) (hg : g₁ ≤ g₂) : map₂ m f₁ g₁ ≤ map₂ m f₂ g₂ :=
+λ _ ⟨s, t, hs, ht, hst⟩, ⟨s, t, hf hs, hg ht, hst⟩
+
+lemma map₂_mono_left (h : g₁ ≤ g₂) : map₂ m f g₁ ≤ map₂ m f g₂ := map₂_mono subset.rfl h
+lemma map₂_mono_right (h : f₁ ≤ f₂) : map₂ m f₁ g ≤ map₂ m f₂ g := map₂_mono h subset.rfl
+
+@[simp] lemma le_map₂_iff {h : filter γ} :
+  h ≤ map₂ m f g ↔ ∀ ⦃s⦄, s ∈ f → ∀ ⦃t⦄, t ∈ g → image2 m s t ∈ h :=
+⟨λ H s hs t ht, H $ image2_mem_map₂ hs ht, λ H u ⟨s, t, hs, ht, hu⟩, mem_of_superset (H hs ht) hu⟩
+
+@[simp] lemma map₂_bot_left : map₂ m ⊥ g = ⊥ :=
+empty_mem_iff_bot.1 ⟨∅, univ, trivial, univ_mem, (image2_empty_left).subset⟩
+
+@[simp] lemma map₂_bot_right : map₂ m f ⊥ = ⊥ :=
+empty_mem_iff_bot.1 ⟨univ, ∅, univ_mem, trivial, (image2_empty_right).subset⟩
+
+@[simp] lemma map₂_eq_bot_iff : map₂ m f g = ⊥ ↔ f = ⊥ ∨ g = ⊥ :=
+begin
+  simp only [←empty_mem_iff_bot, mem_map₂_iff, subset_empty_iff, image2_eq_empty_iff],
+  split,
+  { rintro ⟨s, t, hs, ht, rfl | rfl⟩,
+    { exact or.inl hs },
+    { exact or.inr ht } },
+  { rintro (h | h),
+    { exact ⟨_, _, h, univ_mem, or.inl rfl⟩ },
+    { exact ⟨_, _, univ_mem, h, or.inr rfl⟩ } }
+end
+
+@[simp] lemma map₂_ne_bot_iff : (map₂ m f g).ne_bot ↔ f.ne_bot ∧ g.ne_bot :=
+by { simp_rw ne_bot_iff, exact map₂_eq_bot_iff.not.trans not_or_distrib }
+
+lemma ne_bot.map₂ (hf : f.ne_bot) (hg : g.ne_bot) : (map₂ m f g).ne_bot :=
+map₂_ne_bot_iff.2 ⟨hf, hg⟩
+
+lemma map₂_sup_left : map₂ m (f₁ ⊔ f₂) g = map₂ m f₁ g ⊔ map₂ m f₂ g :=
+begin
+  ext u,
+  split,
+  { rintro ⟨s, t, ⟨h₁, h₂⟩, ht, hu⟩,
+    exact ⟨mem_of_superset (image2_mem_map₂ h₁ ht) hu,
+      mem_of_superset (image2_mem_map₂ h₂ ht) hu⟩ },
+  { rintro ⟨⟨s₁, t₁, hs₁, ht₁, hu₁⟩, s₂, t₂, hs₂, ht₂, hu₂⟩,
+    refine ⟨s₁ ∪ s₂, t₁ ∩ t₂, union_mem_sup hs₁ hs₂, inter_mem ht₁ ht₂, _⟩,
+    rw image2_union_left,
+    exact union_subset ((image2_subset_left $ inter_subset_left _ _).trans hu₁)
+      ((image2_subset_left $ inter_subset_right _ _).trans hu₂) }
+end
+
+lemma map₂_sup_right : map₂ m f (g₁ ⊔ g₂) = map₂ m f g₁ ⊔ map₂ m f g₂ :=
+begin
+  ext u,
+  split,
+  { rintro ⟨s, t, hs, ⟨h₁, h₂⟩, hu⟩,
+    exact ⟨mem_of_superset (image2_mem_map₂ hs h₁) hu,
+      mem_of_superset (image2_mem_map₂ hs h₂) hu⟩ },
+  { rintro ⟨⟨s₁, t₁, hs₁, ht₁, hu₁⟩, s₂, t₂, hs₂, ht₂, hu₂⟩,
+    refine ⟨s₁ ∩ s₂, t₁ ∪ t₂, inter_mem hs₁ hs₂, union_mem_sup ht₁ ht₂, _⟩,
+    rw image2_union_right,
+    exact union_subset ((image2_subset_right $ inter_subset_left _ _).trans hu₁)
+      ((image2_subset_right $ inter_subset_right _ _).trans hu₂) }
+end
+
+lemma map₂_inf_subset_left : map₂ m (f₁ ⊓ f₂) g ≤ map₂ m f₁ g ⊓ map₂ m f₂ g :=
+le_inf (map₂_mono_right inf_le_left) (map₂_mono_right inf_le_right)
+
+lemma map₂_inf_subset_right : map₂ m f (g₁ ⊓ g₂) ≤ map₂ m f g₁ ⊓ map₂ m f g₂ :=
+le_inf (map₂_mono_left inf_le_left) (map₂_mono_left inf_le_right)
+
+@[simp] lemma map₂_pure_left : map₂ m (pure a) g = g.map (λ b, m a b) :=
+filter.ext $ λ u, ⟨λ ⟨s, t, hs, ht, hu⟩,
+  mem_of_superset (image_mem_map ht) ((image_subset_image2_right $ mem_pure.1 hs).trans hu),
+    λ h, ⟨{a}, _, singleton_mem_pure, h, by rw [image2_singleton_left, image_subset_iff]⟩⟩
+
+@[simp] lemma map₂_pure_right : map₂ m f (pure b) = f.map (λ a, m a b) :=
+filter.ext $ λ u, ⟨λ ⟨s, t, hs, ht, hu⟩,
+  mem_of_superset (image_mem_map hs) ((image_subset_image2_left $ mem_pure.1 ht).trans hu),
+    λ h, ⟨_, {b}, h, singleton_mem_pure, by rw [image2_singleton_right, image_subset_iff]⟩⟩
+
+lemma map₂_pure : map₂ m (pure a) (pure b) = pure (m a b) := by rw [map₂_pure_right, map_pure]
+
+lemma map₂_swap (m : α → β → γ) (f : filter α) (g : filter β) :
+  map₂ m f g = map₂ (λ a b, m b a) g f :=
+by { ext u, split; rintro ⟨s, t, hs, ht, hu⟩; refine ⟨t, s, ht, hs, by rwa image2_swap⟩ }
+
+@[simp] lemma map₂_left (h : g.ne_bot) : map₂ (λ x y, x) f g = f :=
+begin
+  ext u,
+  refine ⟨_, λ hu, ⟨_, _, hu, univ_mem, (image2_left $ h.nonempty_of_mem univ_mem).subset⟩⟩,
+  rintro ⟨s, t, hs, ht, hu⟩,
+  rw image2_left (h.nonempty_of_mem ht) at hu,
+  exact mem_of_superset hs hu,
+end
+
+@[simp] lemma map₂_right (h : f.ne_bot) : map₂ (λ x y, y) f g = g := by rw [map₂_swap, map₂_left h]
+
+/-- The image of a ternary function `m : α → β → γ → δ` as a function
+`filter α → filter β → filter γ → filter δ`. Mathematically this should be thought of as the image
+of the corresponding function `α × β × γ → δ`. -/
+def map₃ (m : α → β → γ → δ) (f : filter α) (g : filter β) (h : filter γ) : filter δ :=
+{ sets := {s | ∃ u v w, u ∈ f ∧ v ∈ g ∧ w ∈ h ∧ image3 m u v w ⊆ s},
+  univ_sets := ⟨univ, univ, univ, univ_sets _, univ_sets _, univ_sets _, subset_univ _⟩,
+  sets_of_superset := λ s t hs hst, Exists₃.imp
+    (λ u v w, and.imp_right $ and.imp_right $ and.imp_right $ λ h, subset.trans h hst) hs,
+  inter_sets := λ s t,
+  begin
+    simp only [exists_prop, mem_set_of_eq, subset_inter_iff],
+    rintro ⟨s₁, s₂, s₃, hs₁, hs₂, hs₃, hs⟩ ⟨t₁, t₂, t₃, ht₁, ht₂, ht₃, ht⟩,
+    exact ⟨s₁ ∩ t₁, s₂ ∩ t₂, s₃ ∩ t₃, inter_mem hs₁ ht₁, inter_mem hs₂ ht₂, inter_mem hs₃ ht₃,
+      (image3_mono (inter_subset_left _ _) (inter_subset_left _ _) $ inter_subset_left _ _).trans
+        hs,
+      (image3_mono (inter_subset_right _ _) (inter_subset_right _ _) $ inter_subset_right _ _).trans
+        ht⟩,
+  end }
+
+-- @[simp] lemma mem_map₃ : d ∈ map₃ g f g h ↔ ∃ a b c, a ∈ f ∧ b ∈ g ∧ c ∈ h ∧ g a b c = d :=
+-- iff.rfl
+
+-- @[congr] lemma map₃_congr (h : ∀ (a ∈ f) (b ∈ g) (c ∈ h), g a b c = g' a b c) :
+--   map₃ g f g h = map₃ g' f g h :=
+-- by { ext x, split;
+--   rintro ⟨a, b, c, ha, hb, hc, rfl⟩; exact ⟨a, b, c, ha, hb, hc, by rw h a ha b hb c hc⟩ }
+
+-- /-- A common special case of `map₃_congr` -/
+-- lemma map₃_congr' (h : ∀ a b c, g a b c = g' a b c) : map₃ g f g h = map₃ g' f g h :=
+-- map₃_congr (λ a _ b _ c _, h a b c)
+
+lemma map₂_map₂_left (m : δ → γ → ε) (n : α → β → δ) :
+  map₂ m (map₂ n f g) h = map₃ (λ a b c, m (n a b) c) f g h :=
+begin
+  ext w,
+  split,
+  { rintro ⟨s, t, ⟨u, v, hu, hv, hs⟩, ht, hw⟩,
+    refine ⟨u, v, t, hu, hv, ht, _⟩,
+    rw ←image2_image2_left,
+    exact (image2_subset_right hs).trans hw },
+  { rintro ⟨s, t, u, hs, ht, hu, hw⟩,
+    exact ⟨_, u, image2_mem_map₂ hs ht, hu, by rwa image2_image2_left⟩ }
+end
+
+lemma map₂_map₂_right (m : α → δ → ε) (n : β → γ → δ) :
+  map₂ m f (map₂ n g h) = map₃ (λ a b c, m a (n b c)) f g h :=
+begin
+  ext w,
+  split,
+  { rintro ⟨s, t, hs, ⟨u, v, hu, hv, ht⟩, hw⟩,
+    refine ⟨s, u, v, hs, hu, hv, _⟩,
+    rw ←image2_image2_right,
+    exact (image2_subset_left ht).trans hw },
+  { rintro ⟨s, t, u, hs, ht, hu, hw⟩,
+    exact ⟨s, _, hs, image2_mem_map₂ ht hu, by rwa image2_image2_right⟩ }
+end
+
+/-!
+### Algebraic replacement rules
+
+A collection of lemmas to transfer associativity, commutativity, distributivity, ... of operations
+to the associativity, commutativity, distributivity, ... of `filter.map₂` of those operations.
+
+The proof pattern is `map₂_lemma operation_lemma`. For example, `map₂_comm mul_comm` proves that
+`map₂ (*) f g = map₂ (*) g f` in a `comm_semigroup`.
+-/
+
+lemma map₂_assoc {m : δ → γ → ε} {n : α → β → δ} {m' : α → ε' → ε} {n' : β → γ → ε'}
+  {h : filter γ} (h_assoc : ∀ a b c, m (n a b) c = m' a (n' b c)) :
+  map₂ m (map₂ n f g) h = map₂ m' f (map₂ n' g h) :=
+by simp only [map₂_map₂_left, map₂_map₂_right, h_assoc]
+
+lemma map₂_comm {n : β → α → γ} (h_comm : ∀ a b, m a b = n b a) : map₂ m f g = map₂ n g f :=
+(map₂_swap _ _ _).trans $ by simp_rw h_comm
+
+lemma map₂_left_comm {m : α → δ → ε} {n : β → γ → δ} {m' : α → γ → δ'} {n' : β → δ' → ε}
+  (h_left_comm : ∀ a b c, m a (n b c) = n' b (m' a c)) :
+  map₂ m f (map₂ n g h) = map₂ n' g (map₂ m' f h) :=
+by { rw [map₂_swap m', map₂_swap m], exact map₂_assoc (λ _ _ _, h_left_comm _ _ _) }
+
+lemma map₂_right_comm {m : δ → γ → ε} {n : α → β → δ} {m' : α → γ → δ'} {n' : δ' → β → ε}
+  (h_right_comm : ∀ a b c, m (n a b) c = n' (m' a c) b) :
+  map₂ m (map₂ n f g) h = map₂ n' (map₂ m' f h) g :=
+by { rw [map₂_swap n, map₂_swap n'], exact map₂_assoc (λ _ _ _, h_right_comm _ _ _) }
+
+lemma map_map₂ (m : α → β → γ) (n : γ → δ) : (map₂ m f g).map n = map₂ (λ a b, n (m a b)) f g :=
+filter.ext $ λ u, exists₂_congr $ λ s t, by rw [←image_subset_iff, image_image2]
+
+lemma map₂_map_left (m : γ → β → δ) (n : α → γ) :
+  map₂ m (f.map n) g = map₂ (λ a b, m (n a) b) f g :=
+begin
+  ext u,
+  split,
+  { rintro ⟨s, t, hs, ht, hu⟩,
+    refine ⟨_, t, hs, ht, _⟩,
+    rw ←image2_image_left,
+    exact (image2_subset_right $ image_preimage_subset _ _).trans hu, },
+  { rintro ⟨s, t, hs, ht, hu⟩,
+    exact ⟨_, t, image_mem_map hs, ht, by rwa image2_image_left⟩ }
+end
+
+lemma map₂_map_right (m : α → γ → δ) (n : β → γ) :
+  map₂ m f (g.map n) = map₂ (λ a b, m a (n b)) f g :=
+by rw [map₂_swap, map₂_map_left, map₂_swap]
+
+lemma map_map₂_distrib {n : γ → δ} {m' : α' → β' → δ} {n₁ : α → α'} {n₂ : β → β'}
+  (h_distrib : ∀ a b, n (m a b) = m' (n₁ a) (n₂ b)) :
+  (map₂ m f g).map n = map₂ m' (f.map n₁) (g.map n₂) :=
+by simp_rw [map_map₂, map₂_map_left, map₂_map_right, h_distrib]
+
+lemma map_map₂_distrib_left {n : γ → δ} {m' : α' → β → δ} {n' : α → α'}
+  (h_distrib : ∀ a b, n (m a b) = m' (n' a) b) :
+  (map₂ m f g).map n = map₂ m' (f.map n') g :=
+map_map₂_distrib h_distrib
+
+lemma map_map₂_distrib_right {n : γ → δ} {m' : α → β' → δ} {n' : β → β'}
+  (h_distrib : ∀ a b, n (m a b) = m' a (n' b)) :
+  (map₂ m f g).map n = map₂ m' f (g.map n') :=
+map_map₂_distrib h_distrib
+
+end filter

--- a/src/order/filter/n_ary.lean
+++ b/src/order/filter/n_ary.lean
@@ -15,6 +15,10 @@ operations on filters.
 
 * `filter.map₂`: Binary map of filters.
 * `filter.map₃`: Ternary map of filters.
+
+## Notes
+
+This file is very similar to the n-ary section of `data.set.basic`. Please keep them in sync.
 -/
 
 open function set
@@ -163,18 +167,6 @@ def map₃ (m : α → β → γ → δ) (f : filter α) (g : filter β) (h : fi
         ht⟩,
   end }
 
--- @[simp] lemma mem_map₃ : d ∈ map₃ g f g h ↔ ∃ a b c, a ∈ f ∧ b ∈ g ∧ c ∈ h ∧ g a b c = d :=
--- iff.rfl
-
--- @[congr] lemma map₃_congr (h : ∀ (a ∈ f) (b ∈ g) (c ∈ h), g a b c = g' a b c) :
---   map₃ g f g h = map₃ g' f g h :=
--- by { ext x, split;
---   rintro ⟨a, b, c, ha, hb, hc, rfl⟩; exact ⟨a, b, c, ha, hb, hc, by rw h a ha b hb c hc⟩ }
-
--- /-- A common special case of `map₃_congr` -/
--- lemma map₃_congr' (h : ∀ a b c, g a b c = g' a b c) : map₃ g f g h = map₃ g' f g h :=
--- map₃_congr (λ a _ b _ c _, h a b c)
-
 lemma map₂_map₂_left (m : δ → γ → ε) (n : α → β → δ) :
   map₂ m (map₂ n f g) h = map₃ (λ a b c, m (n a b) c) f g h :=
 begin
@@ -200,6 +192,26 @@ begin
   { rintro ⟨s, t, u, hs, ht, hu, hw⟩,
     exact ⟨s, _, hs, image2_mem_map₂ ht hu, by rwa image2_image2_right⟩ }
 end
+
+lemma map_map₂ (m : α → β → γ) (n : γ → δ) : (map₂ m f g).map n = map₂ (λ a b, n (m a b)) f g :=
+filter.ext $ λ u, exists₂_congr $ λ s t, by rw [←image_subset_iff, image_image2]
+
+lemma map₂_map_left (m : γ → β → δ) (n : α → γ) :
+  map₂ m (f.map n) g = map₂ (λ a b, m (n a) b) f g :=
+begin
+  ext u,
+  split,
+  { rintro ⟨s, t, hs, ht, hu⟩,
+    refine ⟨_, t, hs, ht, _⟩,
+    rw ←image2_image_left,
+    exact (image2_subset_right $ image_preimage_subset _ _).trans hu },
+  { rintro ⟨s, t, hs, ht, hu⟩,
+    exact ⟨_, t, image_mem_map hs, ht, by rwa image2_image_left⟩ }
+end
+
+lemma map₂_map_right (m : α → γ → δ) (n : β → γ) :
+  map₂ m f (g.map n) = map₂ (λ a b, m a (n b)) f g :=
+by rw [map₂_swap, map₂_map_left, map₂_swap]
 
 /-!
 ### Algebraic replacement rules
@@ -229,39 +241,62 @@ lemma map₂_right_comm {m : δ → γ → ε} {n : α → β → δ} {m' : α �
   map₂ m (map₂ n f g) h = map₂ n' (map₂ m' f h) g :=
 by { rw [map₂_swap n, map₂_swap n'], exact map₂_assoc (λ _ _ _, h_right_comm _ _ _) }
 
-lemma map_map₂ (m : α → β → γ) (n : γ → δ) : (map₂ m f g).map n = map₂ (λ a b, n (m a b)) f g :=
-filter.ext $ λ u, exists₂_congr $ λ s t, by rw [←image_subset_iff, image_image2]
-
-lemma map₂_map_left (m : γ → β → δ) (n : α → γ) :
-  map₂ m (f.map n) g = map₂ (λ a b, m (n a) b) f g :=
-begin
-  ext u,
-  split,
-  { rintro ⟨s, t, hs, ht, hu⟩,
-    refine ⟨_, t, hs, ht, _⟩,
-    rw ←image2_image_left,
-    exact (image2_subset_right $ image_preimage_subset _ _).trans hu, },
-  { rintro ⟨s, t, hs, ht, hu⟩,
-    exact ⟨_, t, image_mem_map hs, ht, by rwa image2_image_left⟩ }
-end
-
-lemma map₂_map_right (m : α → γ → δ) (n : β → γ) :
-  map₂ m f (g.map n) = map₂ (λ a b, m a (n b)) f g :=
-by rw [map₂_swap, map₂_map_left, map₂_swap]
-
 lemma map_map₂_distrib {n : γ → δ} {m' : α' → β' → δ} {n₁ : α → α'} {n₂ : β → β'}
   (h_distrib : ∀ a b, n (m a b) = m' (n₁ a) (n₂ b)) :
   (map₂ m f g).map n = map₂ m' (f.map n₁) (g.map n₂) :=
 by simp_rw [map_map₂, map₂_map_left, map₂_map_right, h_distrib]
 
+/-- Symmetric of `filter.map₂_map_left_comm`. -/
 lemma map_map₂_distrib_left {n : γ → δ} {m' : α' → β → δ} {n' : α → α'}
   (h_distrib : ∀ a b, n (m a b) = m' (n' a) b) :
   (map₂ m f g).map n = map₂ m' (f.map n') g :=
 map_map₂_distrib h_distrib
 
+/-- Symmetric of `filter.map_map₂_right_comm`. -/
 lemma map_map₂_distrib_right {n : γ → δ} {m' : α → β' → δ} {n' : β → β'}
   (h_distrib : ∀ a b, n (m a b) = m' a (n' b)) :
   (map₂ m f g).map n = map₂ m' f (g.map n') :=
 map_map₂_distrib h_distrib
+
+/-- Symmetric of `filter.map_map₂_distrib_left`. -/
+lemma map₂_map_left_comm {m : α' → β → γ} {n : α → α'} {m' : α → β → δ} {n' : δ → γ}
+  (h_left_comm : ∀ a b, m (n a) b = n' (m' a b)) :
+  map₂ m (f.map n) g = (map₂ m' f g).map n' :=
+(map_map₂_distrib_left $ λ a b, (h_left_comm a b).symm).symm
+
+/-- Symmetric of `filter.map_map₂_distrib_right`. -/
+lemma map_map₂_right_comm {m : α → β' → γ} {n : β → β'} {m' : α → β → δ} {n' : δ → γ}
+  (h_right_comm : ∀ a b, m a (n b) = n' (m' a b)) :
+  map₂ m f (g.map n) = (map₂ m' f g).map n' :=
+(map_map₂_distrib_right $ λ a b, (h_right_comm a b).symm).symm
+
+lemma map_map₂_antidistrib {n : γ → δ} {m' : β' → α' → δ} {n₁ : β → β'} {n₂ : α → α'}
+  (h_antidistrib : ∀ a b, n (m a b) = m' (n₁ b) (n₂ a)) :
+  (map₂ m f g).map n = map₂ m' (g.map n₁) (f.map n₂) :=
+by { rw map₂_swap m, exact map_map₂_distrib (λ _ _, h_antidistrib _ _) }
+
+/-- Symmetric of `filter.map₂_map_left_anticomm`. -/
+lemma map_map₂_antidistrib_left {n : γ → δ} {m' : β' → α → δ} {n' : β → β'}
+  (h_antidistrib : ∀ a b, n (m a b) = m' (n' b) a) :
+  (map₂ m f g).map n = map₂ m' (g.map n') f :=
+map_map₂_antidistrib h_antidistrib
+
+/-- Symmetric of `filter.map_map₂_right_anticomm`. -/
+lemma map_map₂_antidistrib_right {n : γ → δ} {m' : β → α' → δ} {n' : α → α'}
+  (h_antidistrib : ∀ a b, n (m a b) = m' b (n' a)) :
+  (map₂ m f g).map n = map₂ m' g (f.map n') :=
+map_map₂_antidistrib h_antidistrib
+
+/-- Symmetric of `filter.map_map₂_antidistrib_left`. -/
+lemma map₂_map_left_anticomm {m : α' → β → γ} {n : α → α'} {m' : β → α → δ} {n' : δ → γ}
+  (h_left_anticomm : ∀ a b, m (n a) b = n' (m' b a)) :
+  map₂ m (f.map n) g = (map₂ m' g f).map n' :=
+(map_map₂_antidistrib_left $ λ a b, (h_left_anticomm b a).symm).symm
+
+/-- Symmetric of `filter.map_map₂_antidistrib_right`. -/
+lemma map_map₂_right_anticomm {m : α → β' → γ} {n : β → β'} {m' : β → α → δ} {n' : δ → γ}
+  (h_right_anticomm : ∀ a b, m a (n b) = n' (m' b a)) :
+  map₂ m f (g.map n) = (map₂ m' g f).map n' :=
+(map_map₂_antidistrib_right $ λ a b, (h_right_anticomm b a).symm).symm
 
 end filter


### PR DESCRIPTION
Define `filter.map₂` and `filter.map₃`, the binary and ternary maps of filters.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

This will make defining pointwise operations on `filter` painless.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
