### PR TITLE
[Merged by Bors] - feat(ring_theory/dedekind_domain): Chinese remainder theorem for Dedekind domains

### DIFF
--- a/src/ring_theory/dedekind_domain/ideal.lean
+++ b/src/ring_theory/dedekind_domain/ideal.lean
@@ -3,10 +3,10 @@ Copyright (c) 2020 Kenji Nakagawa. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Kenji Nakagawa, Anne Baanen, Filippo A. E. Nuccio
 -/
-import algebraic_geometry.prime_spectrum.noetherian
-import ring_theory.fractional_ideal
-import ring_theory.dedekind_domain.basic
 import algebra.algebra.subalgebra.pointwise
+import algebraic_geometry.prime_spectrum.noetherian
+import ring_theory.dedekind_domain.basic
+import ring_theory.fractional_ideal
 
 /-!
 # Dedekind domains and ideals
@@ -857,3 +857,165 @@ end
 end is_dedekind_domain
 
 end height_one_spectrum
+
+section chinese_remainder
+
+open ideal unique_factorization_monoid
+open_locale big_operators
+
+variables {R}
+
+lemma ring.dimension_le_one.prime_le_prime_iff_eq (h : ring.dimension_le_one R)
+  {P Q : ideal R} [hP : P.is_prime] [hQ : Q.is_prime] (hP0 : P ≠ ⊥) :
+  P ≤ Q ↔ P = Q :=
+⟨(h P hP0 hP).eq_of_le hQ.ne_top, eq.le⟩
+
+variables {R} [is_domain R]
+
+lemma ideal.coprime_of_no_prime_ge {R : Type*} [comm_ring R] {I J : ideal R}
+  (h : ∀ P, I ≤ P → J ≤ P → ¬ is_prime P) : I ⊔ J = ⊤ :=
+begin
+  by_contra hIJ,
+  obtain ⟨P, hP, hIJ⟩ := ideal.exists_le_maximal _ hIJ,
+  exact h P (le_trans le_sup_left hIJ) (le_trans le_sup_right hIJ) hP.is_prime
+end
+
+section dedekind_domain
+
+variables [is_dedekind_domain R]
+
+lemma ideal.is_prime.mul_mem_pow (I : ideal R) [hI : I.is_prime] {a b : R} {n : ℕ}
+  (h : a * b ∈ I^n) : a ∈ I ∨ b ∈ I^n :=
+begin
+  cases n, { simp },
+  by_cases hI0 : I = ⊥, { simpa [pow_succ, hI0] using h },
+  simp only [← submodule.span_singleton_le_iff_mem, ideal.submodule_span_eq, ← ideal.dvd_iff_le,
+    ← ideal.span_singleton_mul_span_singleton] at h ⊢,
+  by_cases ha : I ∣ span {a},
+  { exact or.inl ha },
+  rw mul_comm at h,
+  exact or.inr (prime.pow_dvd_of_dvd_mul_right ((ideal.prime_iff_is_prime hI0).mpr hI) _ ha h),
+end
+
+section
+
+open_locale classical
+
+lemma ideal.count_normalized_factors_eq {p x : ideal R} (hp0 : p ≠ ⊥) [hp : p.is_prime] {n : ℕ}
+  (hle : x ≤ p^n) (hlt : ¬ (x ≤ p^(n+1))) :
+  (normalized_factors x).count p = n :=
+count_normalized_factors_eq ((ideal.prime_iff_is_prime hp0).mpr hp).irreducible (normalize_eq _)
+  (ideal.dvd_iff_le.mpr hle) (mt ideal.le_of_dvd hlt)
+
+end
+
+lemma ideal.le_mul_of_no_prime_factors
+  {I J K : ideal R} (coprime : ∀ P, J ≤ P → K ≤ P → ¬ is_prime P) (hJ : I ≤ J) (hK : I ≤ K) :
+  I ≤ J * K :=
+begin
+  simp only [← ideal.dvd_iff_le] at coprime hJ hK ⊢,
+  by_cases hJ0 : J = 0,
+  { simpa only [hJ0, zero_mul] using hJ },
+  obtain ⟨I', rfl⟩ := hK,
+  rw mul_comm,
+  exact mul_dvd_mul_left K
+    (unique_factorization_monoid.dvd_of_dvd_mul_right_of_no_prime_factors hJ0
+      (λ P hPJ hPK, mt ideal.is_prime_of_prime (coprime P hPJ hPK))
+      hJ)
+end
+
+lemma ideal.le_of_pow_le_prime {I P : ideal R} [hP : P.is_prime] {n : ℕ} (h : I^n ≤ P) : I ≤ P :=
+begin
+  by_cases hP0 : P = ⊥,
+  { simp only [hP0, le_bot_iff] at ⊢ h,
+    exact pow_eq_zero h },
+  rw ← ideal.dvd_iff_le at ⊢ h,
+  exact ((ideal.prime_iff_is_prime hP0).mpr hP).dvd_of_dvd_pow h
+end
+
+lemma ideal.pow_le_prime_iff {I P : ideal R} [hP : P.is_prime] {n : ℕ} (hn : n ≠ 0) :
+  I^n ≤ P ↔ I ≤ P :=
+⟨ideal.le_of_pow_le_prime, λ h, trans (ideal.pow_le_self hn) h⟩
+
+lemma ideal.prod_le_prime {ι : Type*} {s : finset ι} {f : ι → ideal R} {P : ideal R}
+  [hP : P.is_prime] :
+  ∏ i in s, f i ≤ P ↔ ∃ i ∈ s, f i ≤ P :=
+begin
+  by_cases hP0 : P = ⊥,
+  { simp only [hP0, le_bot_iff],
+    rw [← ideal.zero_eq_bot, finset.prod_eq_zero_iff] },
+  simp only [← ideal.dvd_iff_le],
+  exact ((ideal.prime_iff_is_prime hP0).mpr hP).dvd_finset_prod_iff _
+end
+
+/-- The intersection of distinct prime powers in a Dedekind domain is the product of these
+prime powers. -/
+lemma is_dedekind_domain.inf_prime_pow_eq_prod {ι : Type*}
+  (s : finset ι) (f : ι → ideal R) (e : ι → ℕ)
+  (prime : ∀ i, prime (f i)) (coprime : ∀ i j, i ≠ j → f i ≠ f j) :
+  s.inf (λ i, f i ^ e i) = ∏ i in s, f i ^ e i :=
+begin
+  letI := classical.dec_eq ι,
+  refine s.induction _ _,
+  { simp },
+  intros a s ha ih,
+  rw [finset.inf_insert, finset.prod_insert ha, ih],
+  refine le_antisymm (ideal.le_mul_of_no_prime_factors _ inf_le_left inf_le_right) ideal.mul_le_inf,
+  intros P hPa hPs hPp,
+  haveI := hPp,
+  obtain ⟨b, hb, hPb⟩ := ideal.prod_le_prime.mp hPs,
+  haveI := ideal.is_prime_of_prime (prime a), haveI := ideal.is_prime_of_prime (prime b),
+  refine coprime a b _
+    (((is_dedekind_domain.dimension_le_one.prime_le_prime_iff_eq _).mp
+        (ideal.le_of_pow_le_prime hPa)).trans
+      ((is_dedekind_domain.dimension_le_one.prime_le_prime_iff_eq _).mp
+        (ideal.le_of_pow_le_prime hPb)).symm),
+  { unfreezingI { rintro rfl }, contradiction },
+  { exact (prime a).ne_zero },
+  { exact (prime b).ne_zero },
+end
+
+/-- **Chinese remainder theorem** for a Dedekind domain: if the ideal `I` factors as
+`∏ i, P i ^ e i`, then `R ⧸ I` factors as `Π i, R ⧸ (P i ^ e i)`. -/
+noncomputable def is_dedekind_domain.quotient_equiv_pi_of_prod_eq {ι : Type*} [fintype ι]
+  (I : ideal R) (P : ι → ideal R) (e : ι → ℕ)
+  (prime : ∀ i, prime (P i)) (coprime : ∀ i j, i ≠ j → P i ≠ P j) (prod_eq : (∏ i, P i ^ e i) = I) :
+  R ⧸ I ≃+* Π i, R ⧸ (P i ^ e i) :=
+(ideal.quot_equiv_of_eq (by { simp only [← prod_eq, finset.inf_eq_infi,
+  ← is_dedekind_domain.inf_prime_pow_eq_prod _ _ _ prime coprime, finset.mem_univ, cinfi_pos] }))
+    .trans $
+ideal.quotient_inf_ring_equiv_pi_quotient _ (λ i j hij, ideal.coprime_of_no_prime_ge (begin
+  intros P hPi hPj hPp,
+  haveI := hPp,
+  haveI := ideal.is_prime_of_prime (prime i), haveI := ideal.is_prime_of_prime (prime j),
+  exact coprime i j hij
+    (((is_dedekind_domain.dimension_le_one.prime_le_prime_iff_eq (prime i).ne_zero).mp
+      (ideal.le_of_pow_le_prime hPi)).trans
+    ((is_dedekind_domain.dimension_le_one.prime_le_prime_iff_eq (prime j).ne_zero).mp
+     (ideal.le_of_pow_le_prime hPj)).symm)
+end))
+
+open_locale classical
+
+/-- **Chinese remainder theorem** for a Dedekind domain: `R ⧸ I` factors as `Π i, R ⧸ (P i ^ e i)`,
+where `P i` ranges over the prime factors of `I` and `e i` over the multiplicities. -/
+noncomputable def is_dedekind_domain.quotient_equiv_pi_factors {I : ideal R} (hI : I ≠ ⊥) :
+  R ⧸ I ≃+* Π (P : (factors I).to_finset), R ⧸ ((P : ideal R) ^ (factors I).count P) :=
+is_dedekind_domain.quotient_equiv_pi_of_prod_eq _ _ _
+  (λ (P : (factors I).to_finset), prime_of_factor _ (multiset.mem_to_finset.mp P.prop))
+  (λ i j hij, subtype.coe_injective.ne hij)
+  (calc ∏ (P : (factors I).to_finset), (P : ideal R) ^ (factors I).count (P : ideal R)
+      = ∏ P in (factors I).to_finset, P ^ (factors I).count P
+    : fintype.prod_coe_sort (factors I).to_finset (λ P, P ^ (factors I).count P)
+  ... = ((factors I).map (λ P, P)).prod : (finset.prod_multiset_map_count (factors I) id).symm
+  ... = (factors I).prod : by rw multiset.map_id'
+  ... = I : (@associated_iff_eq (ideal R) _ ideal.unique_units _ _).mp (factors_prod hI))
+
+@[simp] lemma is_dedekind_domain.quotient_equiv_pi_factors_mk {I : ideal R} (hI : I ≠ ⊥)
+  (x : R) : is_dedekind_domain.quotient_equiv_pi_factors hI (ideal.quotient.mk I x) =
+    λ P, ideal.quotient.mk _ x :=
+rfl
+
+end dedekind_domain
+
+end chinese_remainder

--- a/src/ring_theory/dedekind_domain/ideal.lean
+++ b/src/ring_theory/dedekind_domain/ideal.lean
@@ -870,10 +870,8 @@ lemma ring.dimension_le_one.prime_le_prime_iff_eq (h : ring.dimension_le_one R)
   P ≤ Q ↔ P = Q :=
 ⟨(h P hP0 hP).eq_of_le hQ.ne_top, eq.le⟩
 
-variables {R} [is_domain R]
-
-lemma ideal.coprime_of_no_prime_ge {R : Type*} [comm_ring R] {I J : ideal R}
-  (h : ∀ P, I ≤ P → J ≤ P → ¬ is_prime P) : I ⊔ J = ⊤ :=
+lemma ideal.coprime_of_no_prime_ge {I J : ideal R} (h : ∀ P, I ≤ P → J ≤ P → ¬ is_prime P) :
+  I ⊔ J = ⊤ :=
 begin
   by_contra hIJ,
   obtain ⟨P, hP, hIJ⟩ := ideal.exists_le_maximal _ hIJ,
@@ -882,7 +880,7 @@ end
 
 section dedekind_domain
 
-variables [is_dedekind_domain R]
+variables {R} [is_domain R] [is_dedekind_domain R]
 
 lemma ideal.is_prime.mul_mem_pow (I : ideal R) [hI : I.is_prime] {a b : R} {n : ℕ}
   (h : a * b ∈ I^n) : a ∈ I ∨ b ∈ I^n :=

--- a/src/ring_theory/dedekind_domain/ideal.lean
+++ b/src/ring_theory/dedekind_domain/ideal.lean
@@ -1006,7 +1006,7 @@ is_dedekind_domain.quotient_equiv_pi_of_prod_eq _ _ _
   (λ i j hij, subtype.coe_injective.ne hij)
   (calc ∏ (P : (factors I).to_finset), (P : ideal R) ^ (factors I).count (P : ideal R)
       = ∏ P in (factors I).to_finset, P ^ (factors I).count P
-    : fintype.prod_coe_sort (factors I).to_finset (λ P, P ^ (factors I).count P)
+    : (factors I).to_finset.prod_coe_sort (λ P, P ^ (factors I).count P)
   ... = ((factors I).map (λ P, P)).prod : (finset.prod_multiset_map_count (factors I) id).symm
   ... = (factors I).prod : by rw multiset.map_id'
   ... = I : (@associated_iff_eq (ideal R) _ ideal.unique_units _ _).mp (factors_prod hI))


### PR DESCRIPTION
The general Chinese remainder theorem states `R / I` is isomorphic to a product of `R / (P i ^ e i)`, where `P i` are comaximal, i.e.  `P i + P j = 1` for `i ≠ j`, and the infimum of all `P i` is `I`.

In a Dedekind domain the theorem can be stated in a more friendly way, namely that the `P i` are the factors (in the sense of a unique factorization domain) of `I`. This PR provides two ways of doing so, and includes some more lemmas on the ideals in a Dedekind domain.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

- [x] depends on: #13066
- [x] depends on: #13161 (oops, forgot to cherry-pick this one in the original version of this PR!)

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
