### PR TITLE
[Merged by Bors] - chore(ring_theory/polynomial/pochhammer): make semiring implicit in a lemma that I just moved

### DIFF
--- a/src/ring_theory/polynomial/pochhammer.lean
+++ b/src/ring_theory/polynomial/pochhammer.lean
@@ -92,7 +92,7 @@ begin
     refl, },
 end
 
-lemma pochhammer_succ_eval (n : ℕ) (k : S) :
+lemma pochhammer_succ_eval {S : Type*} [semiring S] (n : ℕ) (k : S) :
   (pochhammer S (n + 1)).eval k = (pochhammer S n).eval k * (k + n) :=
 by rw [pochhammer_succ_right, mul_add, eval_add, eval_mul_X, ← nat.cast_comm, ← C_eq_nat_cast,
     eval_C_mul, nat.cast_comm, ← mul_add]


### PR DESCRIPTION
Moving lemma `pochhammer_succ_eval` to reduce typeclass assumptions (#13024), the `semiring` became accidentally explicit.  Since one of the explicit arguments of the lemma is a term in the semiring, I changed the `semiring` to being implicit.

The neighbouring lemmas do not involve terms in their respective semiring, which is why the semiring is explicit throughout the section.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
