### PR TITLE
[Merged by Bors] - counterexample(counterexamples/char_p_zero_ne_char_zero.lean): `char_p R 0` and `char_zero R` need not coincide

### DIFF
--- a/counterexamples/char_p_zero_ne_char_zero.lean
+++ b/counterexamples/char_p_zero_ne_char_zero.lean
@@ -7,6 +7,12 @@ import algebra.char_p.basic
 
 /-! # `char_p R 0` and `char_zero R` need not coincide for semirings
 
+For rings, the two notions coincide.
+
+In fact, `char_p.of_char_zero` shows that `char_zero R` implies `char_p R 0` for any `char_zero`
+`add_monoid R` with `1`.
+The reverse implication holds for any `add_left_cancel_monoid R` with `1`, by `char_p_to_char_zero`.
+
 This file shows that there are semiring `R` for which `char_p R 0` holds and `char_zero R` does not.
 
 The example is `{0, 1}` with saturating addition.

--- a/counterexamples/char_p_zero_ne_char_zero.lean
+++ b/counterexamples/char_p_zero_ne_char_zero.lean
@@ -1,0 +1,81 @@
+/-
+Copyright (c) 2022 Damiano Testa. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Damiano Testa
+-/
+import algebra.char_p.basic
+
+/-! # `char_p R 0` and `char_zero R` need not coincide for semirings
+
+This file shows that there are semiring `R` for which `char_p R 0` holds and `char_zero R` does not.
+
+The example is `F2 = {0, 1}` with saturating addition.  We actually make `F2` into a semiring,
+but multiplication plays no role.
+--/
+
+/--  `F2` is a `comm_semiring` satisfying `char_p F2 0` and `¬ char_zero F2`. -/
+@[derive [decidable_eq]]
+inductive F2
+| zero
+| one
+
+namespace F2
+
+instance : has_zero F2 := ⟨zero⟩
+instance : has_one F2 := ⟨one⟩
+
+instance inhabited : inhabited F2 := ⟨zero⟩
+
+/-- A tactic to prove facts by cases. -/
+meta def boom : tactic unit :=
+`[repeat {rintro ⟨⟩}; dec_trivial]
+
+/--  The addition on `{0, 1}`: the only sum that is not equal to `1` is `0 + 0`. -/
+def add : F2 → F2 → F2
+| 0 0 := 0
+| _ _ := 1
+
+/--  The multiplication on `{0, 1}`: the only product that is not equal to `0` is `1 * 1`. -/
+def mul : F2 → F2 → F2
+| 1 1 := 1
+| _ _ := 0
+
+instance : comm_semiring F2 :=
+{ add := add,
+  add_assoc := by boom,
+  zero := 0,
+  zero_add := by boom,
+  add_zero := by boom,
+  add_comm := by boom,
+  mul := mul,
+  left_distrib := by boom,
+  right_distrib := by boom,
+  zero_mul := by boom,
+  mul_zero := by boom,
+  mul_assoc := by boom,
+  one := 1,
+  one_mul := by boom,
+  mul_one := by boom,
+  mul_comm := by boom }
+
+@[simp] lemma add_one_eq_one : ∀ (x : F2), x + 1 = 1
+| 0 := rfl
+| 1 := rfl
+
+lemma char_p_F2_zero : char_p F2 0 :=
+begin
+  refine⟨λ x, _⟩,
+  cases x,
+  { simp },
+  { simp only [nat.cast_succ, add_one_eq_one, zero_dvd_iff, nat.succ_ne_zero, iff_false],
+    exact λ h, F2.no_confusion h }
+end
+
+lemma not_char_zero : ¬ char_zero F2 :=
+begin
+  rintro ⟨h⟩,
+  have diff : (coe : ℕ → F2) (1 + 1) ≠ (coe : ℕ → F2) (0 + 1), { exact λ h1, by simpa using h h1 },
+  exact diff (by simp)
+end
+
+end F2

--- a/counterexamples/char_p_zero_ne_char_zero.lean
+++ b/counterexamples/char_p_zero_ne_char_zero.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2022 Damiano Testa. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Damiano Testa
+Authors: Damiano Testa, Eric Wieser
 -/
 import algebra.char_p.basic
 
@@ -9,73 +9,17 @@ import algebra.char_p.basic
 
 This file shows that there are semiring `R` for which `char_p R 0` holds and `char_zero R` does not.
 
-The example is `F2 = {0, 1}` with saturating addition.  We actually make `F2` into a semiring,
-but multiplication plays no role.
+The example is `{0, 1}` with saturating addition.
 --/
 
-/--  `F2` is a `comm_semiring` satisfying `char_p F2 0` and `¬ char_zero F2`. -/
-@[derive [decidable_eq]]
-inductive F2
-| zero
-| one
+local attribute [semireducible] with_zero
 
-namespace F2
-
-instance : has_zero F2 := ⟨zero⟩
-instance : has_one F2 := ⟨one⟩
-
-instance inhabited : inhabited F2 := ⟨zero⟩
-
-/-- A tactic to prove facts by cases. -/
-meta def boom : tactic unit :=
-`[repeat {rintro ⟨⟩}; dec_trivial]
-
-/--  The addition on `{0, 1}`: the only sum that is not equal to `1` is `0 + 0`. -/
-def add : F2 → F2 → F2
-| 0 0 := 0
-| _ _ := 1
-
-/--  The multiplication on `{0, 1}`: the only product that is not equal to `0` is `1 * 1`. -/
-def mul : F2 → F2 → F2
-| 1 1 := 1
-| _ _ := 0
-
-instance : comm_semiring F2 :=
-{ add := add,
-  add_assoc := by boom,
-  zero := 0,
-  zero_add := by boom,
-  add_zero := by boom,
-  add_comm := by boom,
-  mul := mul,
-  left_distrib := by boom,
-  right_distrib := by boom,
-  zero_mul := by boom,
-  mul_zero := by boom,
-  mul_assoc := by boom,
-  one := 1,
-  one_mul := by boom,
-  mul_one := by boom,
-  mul_comm := by boom }
-
-@[simp] lemma add_one_eq_one : ∀ (x : F2), x + 1 = 1
+@[simp] lemma add_one_eq_one : ∀ (x : with_zero unit), x + 1 = 1
 | 0 := rfl
 | 1 := rfl
 
-lemma char_p_F2_zero : char_p F2 0 :=
-begin
-  refine⟨λ x, _⟩,
-  cases x,
-  { simp },
-  { simp only [nat.cast_succ, add_one_eq_one, zero_dvd_iff, nat.succ_ne_zero, iff_false],
-    exact λ h, F2.no_confusion h }
-end
+lemma with_zero_unit_char_p_zero : char_p (with_zero unit) 0 :=
+⟨λ x, by cases x; simp⟩
 
-lemma not_char_zero : ¬ char_zero F2 :=
-begin
-  rintro ⟨h⟩,
-  have diff : (coe : ℕ → F2) (1 + 1) ≠ (coe : ℕ → F2) (0 + 1), { exact λ h1, by simpa using h h1 },
-  exact diff (by simp)
-end
-
-end F2
+lemma with_zero_unit_not_char_zero : ¬ char_zero (with_zero unit) :=
+λ ⟨h⟩, h.ne (by simp : 1 + 1 ≠ 0 + 1) (by simp)

--- a/src/algebra/char_p/basic.lean
+++ b/src/algebra/char_p/basic.lean
@@ -26,6 +26,7 @@ variables (R : Type u)
 
 For instance, endowing `{0, 1}` with addition given by `max` (i.e. `1` is absorbing), shows that
 `char_zero {0, 1}` does not hold and yet `char_p {0, 1} 0` does.
+This example is formalized in `counterexamples/char_p_zero_ne_char_zero`.
  -/
 class char_p [add_monoid R] [has_one R] (p : ℕ) : Prop :=
 (cast_eq_zero_iff [] : ∀ x:ℕ, (x:R) = 0 ↔ p ∣ x)

--- a/src/algebra/char_zero.lean
+++ b/src/algebra/char_zero.lean
@@ -42,6 +42,7 @@ from the natural numbers into it is injective.
 
 For instance, endowing `{0, 1}` with addition given by `max` (i.e. `1` is absorbing), shows that
 `char_zero {0, 1}` does not hold and yet `char_p {0, 1} 0` does.
+This example is formalized in `counterexamples/char_p_zero_ne_char_zero`.
  -/
 class char_zero (R : Type*) [add_monoid R] [has_one R] : Prop :=
 (cast_injective : function.injective (coe : ℕ → R))


### PR DESCRIPTION
Following the [Zulip discussion](https://leanprover.zulipchat.com/#narrow/stream/217875-Is-there-code-for-X.3F), this counterexample formalizes a `semiring R` for which `char_p R 0` holds, but `char_zero R` does not.

See #13075 for the PR that lead to this example.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
