### PR TITLE
[Merged by Bors] - feat(data/option/basic): add `option.coe_get`

### DIFF
--- a/src/data/option/basic.lean
+++ b/src/data/option/basic.lean
@@ -68,6 +68,9 @@ theorem get_of_mem {a : α} : ∀ {o : option α} (h : is_some o), a ∈ o → o
 lemma get_or_else_of_ne_none {x : option α} (hx : x ≠ none) (y : α) : some (x.get_or_else y) = x :=
 by cases x; [contradiction, rw get_or_else_some]
 
+@[simp] lemma coe_get {o : option α} (h : o.is_some) : ((option.get h : α) : option α) = o :=
+option.some_get h
+
 theorem mem_unique {o : option α} {a b : α} (ha : a ∈ o) (hb : b ∈ o) : a = b :=
 option.some.inj $ ha.symm.trans hb
 

--- a/src/data/option/basic.lean
+++ b/src/data/option/basic.lean
@@ -68,7 +68,8 @@ theorem get_of_mem {a : α} : ∀ {o : option α} (h : is_some o), a ∈ o → o
 lemma get_or_else_of_ne_none {x : option α} (hx : x ≠ none) (y : α) : some (x.get_or_else y) = x :=
 by cases x; [contradiction, rw get_or_else_some]
 
-lemma coe_get {o : option α} (h : o.is_some) : ((option.get h : α) : option α) = o := by simp
+@[simp] lemma coe_get {o : option α} (h : o.is_some) : ((option.get h : α) : option α) = o :=
+option.some_get h
 
 theorem mem_unique {o : option α} {a b : α} (ha : a ∈ o) (hb : b ∈ o) : a = b :=
 option.some.inj $ ha.symm.trans hb

--- a/src/data/option/basic.lean
+++ b/src/data/option/basic.lean
@@ -34,7 +34,7 @@ along with a term `a : α` if the value is `true`.
 namespace option
 variables {α : Type*} {β : Type*} {γ : Type*}
 
-lemma coe_def : (coe : α → option α) = some := rfl
+@[simp] lemma coe_def : (coe : α → option α) = some := rfl
 
 lemma some_ne_none (x : α) : some x ≠ none := λ h, option.no_confusion h
 

--- a/src/data/option/basic.lean
+++ b/src/data/option/basic.lean
@@ -68,8 +68,7 @@ theorem get_of_mem {a : α} : ∀ {o : option α} (h : is_some o), a ∈ o → o
 lemma get_or_else_of_ne_none {x : option α} (hx : x ≠ none) (y : α) : some (x.get_or_else y) = x :=
 by cases x; [contradiction, rw get_or_else_some]
 
-@[simp] lemma coe_get {o : option α} (h : o.is_some) : ((option.get h : α) : option α) = o :=
-option.some_get h
+lemma coe_get {o : option α} (h : o.is_some) : ((option.get h : α) : option α) = o := by simp
 
 theorem mem_unique {o : option α} {a b : α} (ha : a ∈ o) (hb : b ∈ o) : a = b :=
 option.some.inj $ ha.symm.trans hb

--- a/src/data/option/basic.lean
+++ b/src/data/option/basic.lean
@@ -34,7 +34,7 @@ along with a term `a : α` if the value is `true`.
 namespace option
 variables {α : Type*} {β : Type*} {γ : Type*}
 
-@[simp] lemma coe_def : (coe : α → option α) = some := rfl
+lemma coe_def : (coe : α → option α) = some := rfl
 
 lemma some_ne_none (x : α) : some x ≠ none := λ h, option.no_confusion h
 


### PR DESCRIPTION
Adds lemma `coe_get {o : option α} (h : o.is_some) : ((option.get h : α) : option α) = o`

Extracted from @huynhtrankhanh's https://github.com/leanprover-community/mathlib/pull/11162, moved here to a separate PR

Co-authored-by: Huỳnh Trần Khanh [qcdz9r6wpcbh59@gmail.com](mailto:qcdz9r6wpcbh59@gmail.com)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
