### PR TITLE
[Merged by Bors] - feat(data/fintype/basic): add `fintype_of_{equiv,option}`

### DIFF
--- a/src/data/fintype/basic.lean
+++ b/src/data/fintype/basic.lean
@@ -841,6 +841,12 @@ lemma univ_option (α : Type*) [fintype α] : (univ : finset (option α)) = inse
   fintype.card (option α) = fintype.card α + 1 :=
 (finset.card_cons _).trans $ congr_arg2 _ (card_map _) rfl
 
+/-- A type is a `fintype` if its successor (using `option`) is a `fintype`. -/
+noncomputable
+def fintype_of_equiv_option [fintype α] (f : option β ≃ α) : fintype β :=
+fintype.of_injective (embedding.coe_option.trans f.to_embedding) $
+injective.comp (equiv.to_embedding f).injective embedding.coe_option.injective
+
 instance {α : Type*} (β : α → Type*)
   [fintype α] [∀ a, fintype (β a)] : fintype (sigma β) :=
 ⟨univ.sigma (λ _, univ), λ ⟨a, b⟩, by simp⟩

--- a/src/data/fintype/basic.lean
+++ b/src/data/fintype/basic.lean
@@ -845,10 +845,8 @@ def fintype_of_option {α : Type*} [fintype (option α)] : fintype α :=
 ⟨finset.erase_none (fintype.elems (option α)), λ x, mem_erase_none.mpr (fintype.complete (some x))⟩
 
 def fintype_of_equiv [fintype α] (f : α ≃ β) : fintype β :=
-begin
-
-  sorry,
-end
+⟨map (equiv.to_embedding f) (fintype.elems α),
+  λ x, finset.mem_map_equiv.mpr (fintype.complete ((equiv.symm f) x))⟩
 
 /-- A type is a `fintype` if its successor (using `option`) is a `fintype`. -/
 def fintype_of_equiv_option [fintype α] (f : option α ≃ β) : fintype β :=

--- a/src/data/fintype/basic.lean
+++ b/src/data/fintype/basic.lean
@@ -850,11 +850,7 @@ def fintype_of_equiv [fintype α] (f : α ≃ β) : fintype β :=
 
 /-- A type is a `fintype` if its successor (using `option`) is a `fintype`. -/
 def fintype_of_equiv_option [fintype α] (f : option α ≃ β) : fintype β :=
-begin
-  haveI := fintype_of_equiv f,
-  exact fintype_of_option,
-end
-#exit
+by { haveI := fintype_of_equiv f, exact fintype_of_option }
 
 instance {α : Type*} (β : α → Type*)
   [fintype α] [∀ a, fintype (β a)] : fintype (sigma β) :=

--- a/src/data/fintype/basic.lean
+++ b/src/data/fintype/basic.lean
@@ -841,9 +841,11 @@ lemma univ_option (α : Type*) [fintype α] : (univ : finset (option α)) = inse
   fintype.card (option α) = fintype.card α + 1 :=
 (finset.card_cons _).trans $ congr_arg2 _ (card_map _) rfl
 
+/-- If `option α` is a `fintype` then so is `α` -/
 def fintype_of_option {α : Type*} [fintype (option α)] : fintype α :=
 ⟨finset.erase_none (fintype.elems (option α)), λ x, mem_erase_none.mpr (fintype.complete (some x))⟩
 
+/-- If `α` is a `fintype` then any type equivalent to `α` is a `fintype` -/
 def fintype_of_equiv [fintype α] (f : α ≃ β) : fintype β :=
 ⟨map (equiv.to_embedding f) (fintype.elems α),
   λ x, finset.mem_map_equiv.mpr (fintype.complete ((equiv.symm f) x))⟩

--- a/src/data/fintype/basic.lean
+++ b/src/data/fintype/basic.lean
@@ -841,11 +841,22 @@ lemma univ_option (α : Type*) [fintype α] : (univ : finset (option α)) = inse
   fintype.card (option α) = fintype.card α + 1 :=
 (finset.card_cons _).trans $ congr_arg2 _ (card_map _) rfl
 
+def fintype_of_option {α : Type*} [fintype (option α)] : fintype α :=
+⟨finset.erase_none (fintype.elems (option α)), λ x, mem_erase_none.mpr (fintype.complete (some x))⟩
+
+def fintype_of_equiv [fintype α] (f : α ≃ β) : fintype β :=
+begin
+
+  sorry,
+end
+
 /-- A type is a `fintype` if its successor (using `option`) is a `fintype`. -/
-noncomputable
-def fintype_of_equiv_option [fintype α] (f : option β ≃ α) : fintype β :=
-fintype.of_injective (embedding.coe_option.trans f.to_embedding) $
-injective.comp (equiv.to_embedding f).injective embedding.coe_option.injective
+def fintype_of_equiv_option [fintype α] (f : option α ≃ β) : fintype β :=
+begin
+  haveI := fintype_of_equiv f,
+  exact fintype_of_option,
+end
+#exit
 
 instance {α : Type*} (β : α → Type*)
   [fintype α] [∀ a, fintype (β a)] : fintype (sigma β) :=

--- a/src/data/fintype/basic.lean
+++ b/src/data/fintype/basic.lean
@@ -849,7 +849,7 @@ def fintype_of_equiv [fintype α] (f : α ≃ β) : fintype β :=
   λ x, finset.mem_map_equiv.mpr (fintype.complete ((equiv.symm f) x))⟩
 
 /-- A type is a `fintype` if its successor (using `option`) is a `fintype`. -/
-def fintype_of_equiv_option [fintype α] (f : option α ≃ β) : fintype β :=
+def fintype_of_option_equiv [fintype α] (f : option α ≃ β) : fintype β :=
 by { haveI := fintype_of_equiv f, exact fintype_of_option }
 
 instance {α : Type*} (β : α → Type*)

--- a/src/data/fintype/basic.lean
+++ b/src/data/fintype/basic.lean
@@ -845,14 +845,9 @@ lemma univ_option (α : Type*) [fintype α] : (univ : finset (option α)) = inse
 def fintype_of_option {α : Type*} [fintype (option α)] : fintype α :=
 ⟨finset.erase_none (fintype.elems (option α)), λ x, mem_erase_none.mpr (fintype.complete (some x))⟩
 
-/-- If `α` is a `fintype` then any type equivalent to `α` is a `fintype` -/
-def fintype_of_equiv [fintype α] (f : α ≃ β) : fintype β :=
-⟨map (equiv.to_embedding f) (fintype.elems α),
-  λ x, finset.mem_map_equiv.mpr (fintype.complete ((equiv.symm f) x))⟩
-
 /-- A type is a `fintype` if its successor (using `option`) is a `fintype`. -/
 def fintype_of_option_equiv [fintype α] (f : option α ≃ β) : fintype β :=
-by { haveI := fintype_of_equiv f, exact fintype_of_option }
+by { haveI := fintype.of_equiv (option α) f, exact fintype_of_option }
 
 instance {α : Type*} (β : α → Type*)
   [fintype α] [∀ a, fintype (β a)] : fintype (sigma β) :=


### PR DESCRIPTION
`fintype_of_option_equiv` was extracted from @huynhtrankhanh's https://github.com/leanprover-community/mathlib/pull/11162, moved here to a separate PR.  The split into `fintype_of_option` and `fintype_of_equiv` is based on a comment on that PR by @jcommelin.

Co-authored-by: Huỳnh Trần Khanh [qcdz9r6wpcbh59@gmail.com](mailto:qcdz9r6wpcbh59@gmail.com)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
