### PR TITLE
refactor(algebra/*): allow linear maps and modules over non-associative rings

### DIFF
--- a/src/algebra/big_operators/multiset.lean
+++ b/src/algebra/big_operators/multiset.lean
@@ -233,8 +233,8 @@ by { convert (m.map f).prod_hom (zpow_group_hom₀ _ : α →* α), rw map_map, 
 
 end comm_group_with_zero
 
-section semiring
-variables [semiring α] {a : α} {s : multiset ι} {f : ι → α}
+section non_unital_non_assoc_semiring
+variables [non_unital_non_assoc_semiring α] {a : α} {s : multiset ι} {f : ι → α}
 
 lemma sum_map_mul_left : sum (s.map (λ i, a * f i)) = a * sum (s.map f) :=
 multiset.induction_on s (by simp) (λ i s ih, by simp [ih, mul_add])
@@ -242,17 +242,17 @@ multiset.induction_on s (by simp) (λ i s ih, by simp [ih, mul_add])
 lemma sum_map_mul_right : sum (s.map (λ i, f i * a)) = sum (s.map f) * a :=
 multiset.induction_on s (by simp) (λ a s ih, by simp [ih, add_mul])
 
-end semiring
+end non_unital_non_assoc_semiring
 
-section comm_semiring
-variables [comm_semiring α]
+section semiring
+variables [semiring α]
 
 lemma dvd_sum {a : α} {s : multiset α} : (∀ x ∈ s, a ∣ x) → a ∣ s.sum :=
 multiset.induction_on s (λ _, dvd_zero _)
   (λ x s ih h, by { rw sum_cons, exact dvd_add
     (h _ (mem_cons_self _ _)) (ih $ λ y hy, h _ $ mem_cons.2 $ or.inr hy) })
 
-end comm_semiring
+end semiring
 
 /-! ### Order -/
 

--- a/src/algebra/big_operators/pi.lean
+++ b/src/algebra/big_operators/pi.lean
@@ -84,10 +84,10 @@ end single
 section ring_hom
 open pi
 variables {I : Type*} [decidable_eq I] {f : I → Type*}
-variables [Π i, semiring (f i)]
+variables [Π i, non_assoc_semiring (f i)]
 
-@[ext] lemma ring_hom.functions_ext [fintype I] (G : Type*) [semiring G] (g h : (Π i, f i) →+* G)
-  (w : ∀ (i : I) (x : f i), g (single i x) = h (single i x)) : g = h :=
+@[ext] lemma ring_hom.functions_ext [fintype I] (G : Type*) [non_assoc_semiring G]
+  (g h : (Π i, f i) →+* G) (w : ∀ (i : I) (x : f i), g (single i x) = h (single i x)) : g = h :=
 ring_hom.coe_add_monoid_hom_injective $
  add_monoid_hom.functions_ext G (g : (Π i, f i) →+ G) h w
 

--- a/src/algebra/big_operators/ring.lean
+++ b/src/algebra/big_operators/ring.lean
@@ -24,6 +24,21 @@ variables {α : Type u} {β : Type v} {γ : Type w}
 namespace finset
 variables {s s₁ s₂ : finset α} {a : α} {b : β}  {f g : α → β}
 
+section comm_monoid
+variables [comm_monoid β]
+
+open_locale classical
+
+lemma prod_pow_eq_pow_sum {x : β} {f : α → ℕ} :
+  ∀ {s : finset α}, (∏ i in s, x ^ (f i)) = x ^ (∑ x in s, f x) :=
+begin
+  apply finset.induction,
+  { simp },
+  { assume a s has H,
+    rw [finset.prod_insert has, finset.sum_insert has, pow_add, H] }
+end
+
+end comm_monoid
 
 section semiring
 variables [non_unital_non_assoc_semiring β]
@@ -178,15 +193,6 @@ begin
   rw [← prod_const, prod_add],
   refine finset.sum_congr rfl (λ t ht, _),
   rw [prod_const, prod_const, ← card_sdiff (mem_powerset.1 ht)]
-end
-
-lemma prod_pow_eq_pow_sum {x : β} {f : α → ℕ} :
-  ∀ {s : finset α}, (∏ i in s, x ^ (f i)) = x ^ (∑ x in s, f x) :=
-begin
-  apply finset.induction,
-  { simp },
-  { assume a s has H,
-    rw [finset.prod_insert has, finset.sum_insert has, pow_add, H] }
 end
 
 theorem dvd_sum {b : β} {s : finset α} {f : α → β}

--- a/src/algebra/char_zero.lean
+++ b/src/algebra/char_zero.lean
@@ -120,7 +120,7 @@ by rwa [nat.cast_two] at this
 end
 
 section
-variables {R : Type*} [semiring R] [no_zero_divisors R] [char_zero R]
+variables {R : Type*} [non_assoc_semiring R] [no_zero_divisors R] [char_zero R]
 
 @[simp]
 lemma add_self_eq_zero {a : R} : a + a = 0 ↔ a = 0 :=
@@ -134,7 +134,7 @@ by { rw [eq_comm], exact bit0_eq_zero }
 end
 
 section
-variables {R : Type*} [ring R] [no_zero_divisors R] [char_zero R]
+variables {R : Type*} [non_assoc_ring R] [no_zero_divisors R] [char_zero R]
 
 lemma neg_eq_self_iff {a : R} : -a = a ↔ a = 0 :=
 neg_eq_iff_add_eq_zero.trans add_self_eq_zero
@@ -207,7 +207,7 @@ end with_top
 
 section ring_hom
 
-variables {R S : Type*} [semiring R] [semiring S]
+variables {R S : Type*} [non_assoc_semiring R] [non_assoc_semiring S]
 
 lemma ring_hom.char_zero (ϕ : R →+* S) [hS : char_zero S] : char_zero R :=
 ⟨λ a b h, char_zero.cast_injective (by rw [←map_nat_cast ϕ, ←map_nat_cast ϕ, h])⟩

--- a/src/algebra/group_power/lemmas.lean
+++ b/src/algebra/group_power/lemmas.lean
@@ -335,11 +335,11 @@ end linear_ordered_add_comm_group
   ((n • a : A) : with_bot A) = n • a :=
 add_monoid_hom.map_nsmul ⟨(coe : A → with_bot A), with_bot.coe_zero, with_bot.coe_add⟩ a n
 
-theorem nsmul_eq_mul' [semiring R] (a : R) (n : ℕ) : n • a = a * n :=
+theorem nsmul_eq_mul' [non_assoc_semiring R] (a : R) (n : ℕ) : n • a = a * n :=
 by induction n with n ih; [rw [zero_nsmul, nat.cast_zero, mul_zero],
   rw [succ_nsmul', ih, nat.cast_succ, mul_add, mul_one]]
 
-@[simp] theorem nsmul_eq_mul [semiring R] (n : ℕ) (a : R) : n • a = n * a :=
+@[simp] theorem nsmul_eq_mul [non_assoc_semiring R] (n : ℕ) (a : R) : n • a = n * a :=
 by rw [nsmul_eq_mul', (n.cast_commute a).eq]
 
 /-- Note that `add_comm_monoid.nat_smul_comm_class` requires stronger assumptions on `R`. -/
@@ -374,19 +374,19 @@ by induction k with k ih; [refl, rw [pow_succ', int.nat_abs_mul, pow_succ', ih]]
 -- The next four lemmas allow us to replace multiplication by a numeral with a `zsmul` expression.
 -- They are used by the `noncomm_ring` tactic, to normalise expressions before passing to `abel`.
 
-lemma bit0_mul [ring R] {n r : R} : bit0 n * r = (2 : ℤ) • (n * r) :=
+lemma bit0_mul [non_unital_non_assoc_ring R] {n r : R} : bit0 n * r = (2 : ℤ) • (n * r) :=
 by { dsimp [bit0], rw [add_mul, add_zsmul, one_zsmul], }
 
-lemma mul_bit0 [ring R] {n r : R} : r * bit0 n = (2 : ℤ) • (r * n) :=
+lemma mul_bit0 [non_unital_non_assoc_ring R] {n r : R} : r * bit0 n = (2 : ℤ) • (r * n) :=
 by { dsimp [bit0], rw [mul_add, add_zsmul, one_zsmul], }
 
-lemma bit1_mul [ring R] {n r : R} : bit1 n * r = (2 : ℤ) • (n * r) + r :=
+lemma bit1_mul [non_assoc_ring R] {n r : R} : bit1 n * r = (2 : ℤ) • (n * r) + r :=
 by { dsimp [bit1], rw [add_mul, bit0_mul, one_mul], }
 
-lemma mul_bit1 [ring R] {n r : R} : r * bit1 n = (2 : ℤ) • (r * n) + r :=
+lemma mul_bit1 [non_assoc_ring R] {n r : R} : r * bit1 n = (2 : ℤ) • (r * n) + r :=
 by { dsimp [bit1], rw [mul_add, mul_bit0, mul_one], }
 
-@[simp] theorem zsmul_eq_mul [ring R] (a : R) : ∀ (n : ℤ), n • a = n * a
+@[simp] theorem zsmul_eq_mul [non_assoc_ring R] (a : R) : ∀ (n : ℤ), n • a = n * a
 | (n : ℕ) := by { rw [coe_nat_zsmul, nsmul_eq_mul], refl }
 | -[1+ n] := by simp [nat.cast_succ, neg_add_rev, int.cast_neg_succ_of_nat, add_mul]
 

--- a/src/algebra/group_ring_action.lean
+++ b/src/algebra/group_ring_action.lean
@@ -33,14 +33,14 @@ open_locale big_operators
 /-- Typeclass for multiplicative actions by monoids on semirings.
 
 This combines `distrib_mul_action` with `mul_distrib_mul_action`. -/
-class mul_semiring_action (M : Type u) (R : Type v) [monoid M] [semiring R]
+class mul_semiring_action (M : Type u) (R : Type v) [mul_one_class M] [non_assoc_semiring R]
   extends distrib_mul_action M R :=
 (smul_one : ∀ (g : M), (g • 1 : R) = 1)
 (smul_mul : ∀ (g : M) (x y : R), g • (x * y) = (g • x) * (g • y))
 
 section semiring
 
-variables (M G : Type u) [monoid M] [group G]
+variables (M G : Type u) [mul_one_class M] [group G]
 variables (A R S F : Type v) [add_monoid A] [semiring R] [comm_semiring S] [division_ring F]
 
 -- note we could not use `extends` since these typeclasses are made with `old_structure_cmd`

--- a/src/algebra/hom/group_action.lean
+++ b/src/algebra/hom/group_action.lean
@@ -30,7 +30,7 @@ variables (M' : Type*)
 variables (X : Type*) [has_scalar M' X]
 variables (Y : Type*) [has_scalar M' Y]
 variables (Z : Type*) [has_scalar M' Z]
-variables (M : Type*) [monoid M]
+variables (M : Type*) [mul_one_class M]
 variables (A : Type*) [add_monoid A] [distrib_mul_action M A]
 variables (A' : Type*) [add_group A'] [distrib_mul_action M A']
 variables (B : Type*) [add_monoid B] [distrib_mul_action M B]
@@ -317,16 +317,18 @@ ext $ λ x, by rw [comp_apply, id_apply]
 end mul_semiring_action_hom
 
 section
-variables (M) {R'} (U : subring R') [is_invariant_subring M U]
+
+variables (M'' : Type*) [monoid M''] {R'} [mul_semiring_action M'' R'] (U : subring R')
+  [is_invariant_subring M'' U]
 
 /-- The canonical inclusion from an invariant subring. -/
-def is_invariant_subring.subtype_hom : U →+*[M] R' :=
+def is_invariant_subring.subtype_hom : U →+*[M''] R' :=
 { map_smul' := λ m s, rfl, ..U.subtype }
 
 @[simp] theorem is_invariant_subring.coe_subtype_hom :
-  (is_invariant_subring.subtype_hom M U : U → R') = coe := rfl
+  (is_invariant_subring.subtype_hom M'' U : U → R') = coe := rfl
 
 @[simp] theorem is_invariant_subring.coe_subtype_hom' :
-  (is_invariant_subring.subtype_hom M U : U →+* R') = U.subtype := rfl
+  (is_invariant_subring.subtype_hom M'' U : U →+* R') = U.subtype := rfl
 
 end

--- a/src/algebra/invertible.lean
+++ b/src/algebra/invertible.lean
@@ -158,7 +158,7 @@ def invertible_one [monoid α] : invertible (1 : α) :=
 inv_of_eq_right_inv (mul_one _)
 
 /-- `-⅟a` is the inverse of `-a` -/
-def invertible_neg [ring α] (a : α) [invertible a] : invertible (-a) :=
+def invertible_neg [non_assoc_ring α] (a : α) [invertible a] : invertible (-a) :=
 ⟨ -⅟a, by simp, by simp ⟩
 
 @[simp] lemma inv_of_neg [ring α] (a : α) [invertible a] [invertible (-a)] : ⅟(-a) = -⅟a :=
@@ -168,7 +168,7 @@ inv_of_eq_right_inv (by simp)
 (is_unit_of_invertible (2:α)).mul_right_inj.1 $
   by rw [mul_sub, mul_inv_of_self, mul_one, bit0, add_sub_cancel]
 
-@[simp] lemma inv_of_two_add_inv_of_two [semiring α] [invertible (2 : α)] :
+@[simp] lemma inv_of_two_add_inv_of_two [non_assoc_semiring α] [invertible (2 : α)] :
   (⅟2 : α) + (⅟2 : α) = 1 :=
 by simp only [←two_mul, mul_inv_of_self]
 

--- a/src/algebra/module/equiv.lean
+++ b/src/algebra/module/equiv.lean
@@ -46,8 +46,8 @@ set_option old_structure_cmd true
 
 /-- A linear equivalence is an invertible linear map. -/
 @[nolint has_inhabited_instance]
-structure linear_equiv {R : Type*} {S : Type*} [semiring R] [semiring S] (σ : R →+* S)
-  {σ' : S →+* R} [ring_hom_inv_pair σ σ'] [ring_hom_inv_pair σ' σ]
+structure linear_equiv {R : Type*} {S : Type*} [non_assoc_semiring R] [non_assoc_semiring S]
+  (σ : R →+* S) {σ' : S →+* R} [ring_hom_inv_pair σ σ'] [ring_hom_inv_pair σ' σ]
   (M : Type*) (M₂ : Type*)
   [add_comm_monoid M] [add_comm_monoid M₂] [module R M] [module S M₂]
   extends linear_map σ M M₂, M ≃+ M₂
@@ -65,7 +65,7 @@ namespace linear_equiv
 section add_comm_monoid
 
 variables {M₄ : Type*}
-variables [semiring R] [semiring S]
+variables [non_assoc_semiring R] [non_assoc_semiring S]
 
 section
 variables [add_comm_monoid M] [add_comm_monoid M₁] [add_comm_monoid M₂]
@@ -114,7 +114,7 @@ fun_like.coe_injective
 end
 
 section
-variables [semiring R₁] [semiring R₂] [semiring R₃]
+variables [non_assoc_semiring R₁] [non_assoc_semiring R₂] [non_assoc_semiring R₃]
 variables [add_comm_monoid M] [add_comm_monoid M₁] [add_comm_monoid M₂]
 variables [add_comm_monoid M₃] [add_comm_monoid M₄]
 variables [add_comm_monoid N₁] [add_comm_monoid N₂]
@@ -167,8 +167,8 @@ def symm (e : M ≃ₛₗ[σ] M₂) : M₂ ≃ₛₗ[σ'] M :=
 omit module_M module_S_M₂ re₁ re₂
 
 /-- See Note [custom simps projection] -/
-def simps.symm_apply {R : Type*} {S : Type*} [semiring R] [semiring S] {σ : R →+* S}
-  {σ' : S →+* R} [ring_hom_inv_pair σ σ'] [ring_hom_inv_pair σ' σ]
+def simps.symm_apply {R : Type*} {S : Type*} [non_assoc_semiring R] [non_assoc_semiring S]
+  {σ : R →+* S} {σ' : S →+* R} [ring_hom_inv_pair σ σ'] [ring_hom_inv_pair σ' σ]
   {M : Type*} {M₂ : Type*} [add_comm_monoid M] [add_comm_monoid M₂] [module R M] [module S M₂]
   (e : M ≃ₛₗ[σ] M₂) : M₂ → M := e.symm
 
@@ -391,7 +391,7 @@ end
 
 /-- Interpret a `ring_equiv` `f` as an `f`-semilinear equiv. -/
 @[simps]
-def _root_.ring_equiv.to_semilinear_equiv (f : R ≃+* S) :
+def _root_.ring_equiv.to_semilinear_equiv {R S : Type*} [semiring R] [semiring S] (f : R ≃+* S) :
   by haveI := ring_hom_inv_pair.of_ring_equiv f;
      haveI := ring_hom_inv_pair.symm (↑f : R →+* S) (f.symm : S →+* R);
      exact (R ≃ₛₗ[(↑f : R →+* S)] S) :=
@@ -400,7 +400,7 @@ by exact
   map_smul' := f.map_mul,
   .. f}
 
-variables [semiring R₁] [semiring R₂] [semiring R₃]
+variables [non_assoc_semiring R₁] [non_assoc_semiring R₂] [non_assoc_semiring R₃]
 variables [add_comm_monoid M] [add_comm_monoid M₁] [add_comm_monoid M₂]
 
 /-- An involutive linear map is a linear equivalence. -/
@@ -508,7 +508,7 @@ end module
 
 namespace distrib_mul_action
 
-variables (R M) [semiring R] [add_comm_monoid M] [module R M]
+variables (R M) [non_assoc_semiring R] [add_comm_monoid M] [module R M]
 variables [group S] [distrib_mul_action S M] [smul_comm_class S R M]
 
 /-- Each element of the group defines a linear equivalence.
@@ -534,7 +534,7 @@ namespace add_equiv
 
 section add_comm_monoid
 
-variables [semiring R] [add_comm_monoid M] [add_comm_monoid M₂] [add_comm_monoid M₃]
+variables [non_assoc_semiring R] [add_comm_monoid M] [add_comm_monoid M₂] [add_comm_monoid M₃]
 variables [module R M] [module R M₂]
 
 variable (e : M ≃+ M₂)

--- a/src/algebra/module/pi.lean
+++ b/src/algebra/module/pi.lean
@@ -53,7 +53,7 @@ instance mul_action_with_zero' {g : I → Type*} [Π i, monoid_with_zero (g i)]
 
 variables (I f)
 
-instance module (α) {r : semiring α} {m : ∀ i, add_comm_monoid $ f i}
+instance module (α) {r : non_assoc_semiring α} {m : ∀ i, add_comm_monoid $ f i}
   [∀ i, module α $ f i] :
   @module α (Π i : I, f i) r (@pi.add_comm_monoid I f m) :=
 { add_smul := λ c f g, funext $ λ i, add_smul _ _ _,

--- a/src/algebra/module/submodule.lean
+++ b/src/algebra/module/submodule.lean
@@ -33,7 +33,7 @@ set_option old_structure_cmd true
 /-- A submodule of a module is one which is closed under vector operations.
   This is a sufficient condition for the subset of vectors in the submodule
   to themselves form a module. -/
-structure submodule (R : Type u) (M : Type v) [semiring R]
+structure submodule (R : Type u) (M : Type v) [non_assoc_semiring R]
   [add_comm_monoid M] [module R M] extends add_submonoid M, sub_mul_action R M : Type v.
 
 /-- Reinterpret a `submodule` as an `add_submonoid`. -/
@@ -44,7 +44,7 @@ add_decl_doc submodule.to_sub_mul_action
 
 namespace submodule
 
-variables [semiring R] [add_comm_monoid M] [module R M]
+variables [non_assoc_semiring R] [add_comm_monoid M] [module R M]
 
 instance : set_like (submodule R M) M :=
 ⟨submodule.carrier, λ p q h, by cases p; cases q; congr'⟩
@@ -123,7 +123,7 @@ namespace submodule
 
 section add_comm_monoid
 
-variables [semiring R] [add_comm_monoid M]
+variables [non_assoc_semiring R] [add_comm_monoid M]
 
 -- We can infer the module structure implicitly from the bundled submodule,
 -- rather than via typeclass resolution.
@@ -189,7 +189,8 @@ variables (p)
 instance : add_comm_monoid p :=
 { add := (+), zero := 0, .. p.to_add_submonoid.to_add_comm_monoid }
 
-instance module' [semiring S] [has_scalar S R] [module S M] [is_scalar_tower S R M] : module S p :=
+instance module' [non_assoc_semiring S] [has_scalar S R] [module S M] [is_scalar_tower S R M] :
+  module S p :=
 by refine {smul := (•), ..p.to_sub_mul_action.mul_action', ..};
    { intros, apply set_coe.ext, simp [smul_add, add_smul, mul_smul] }
 instance : module R p := p.module'
@@ -215,7 +216,7 @@ lemma injective_subtype : injective p.subtype := subtype.coe_injective
 p.subtype.map_sum
 
 section restrict_scalars
-variables (S) [semiring S] [module S M] [module R M] [has_scalar S R] [is_scalar_tower S R M]
+variables (S) [non_assoc_semiring S] [module S M] [module R M] [has_scalar S R] [is_scalar_tower S R M]
 
 /--
 `V.restrict_scalars S` is the `S`-submodule of the `S`-module given by restriction of scalars,
@@ -277,7 +278,7 @@ end add_comm_monoid
 
 section add_comm_group
 
-variables [ring R] [add_comm_group M]
+variables [non_assoc_ring R] [add_comm_group M]
 variables {module_M : module R M}
 variables (p p' : submodule R M)
 variables {r : R} {x y : M}
@@ -354,7 +355,7 @@ end is_domain
 
 section ordered_monoid
 
-variables [semiring R]
+variables [non_assoc_semiring R]
 
 /-- A submodule of an `ordered_add_comm_monoid` is an `ordered_add_comm_monoid`. -/
 instance to_ordered_add_comm_monoid
@@ -385,7 +386,7 @@ end ordered_monoid
 
 section ordered_group
 
-variables [ring R]
+variables [non_assoc_ring R]
 
 /-- A submodule of an `ordered_add_comm_group` is an `ordered_add_comm_group`. -/
 instance to_ordered_add_comm_group

--- a/src/algebra/ring/basic.lean
+++ b/src/algebra/ring/basic.lean
@@ -71,6 +71,9 @@ distrib.right_distrib a b c
 
 alias right_distrib ← add_mul
 
+lemma distrib_three_right [distrib R] (a b c d : R) : (a + b + c) * d = a * d + b * d + c * d :=
+by simp [right_distrib]
+
 /-- Pullback a `distrib` instance along an injective function.
 See note [reducible non-instances]. -/
 @[reducible]
@@ -217,20 +220,30 @@ protected def function.surjective.semiring
 
 end injective_surjective_maps
 
+section non_unital_semiring
+variables [non_unital_semiring α]
+
+theorem dvd_add {a b c : α} (h₁ : a ∣ b) (h₂ : a ∣ c) : a ∣ b + c :=
+dvd.elim h₁ (λ d hd, dvd.elim h₂ (λ e he, dvd.intro (d + e) (by simp [left_distrib, hd, he])))
+
+end non_unital_semiring
+
+section non_assoc_semiring
+variables [non_assoc_semiring α]
+
+theorem two_mul (n : α) : 2 * n = n + n :=
+eq.trans (right_distrib 1 1 n) (by simp)
+
+theorem mul_two (n : α) : n * 2 = n + n :=
+(left_distrib n 1 1).trans (by simp)
+
+end non_assoc_semiring
+
 section semiring
 variables [semiring α]
 
 lemma one_add_one_eq_two : 1 + 1 = (2 : α) :=
 by unfold bit0
-
-theorem two_mul (n : α) : 2 * n = n + n :=
-eq.trans (right_distrib 1 1 n) (by simp)
-
-lemma distrib_three_right (a b c d : α) : (a + b + c) * d = a * d + b * d + c * d :=
-by simp [right_distrib]
-
-theorem mul_two (n : α) : n * 2 = n + n :=
-(left_distrib n 1 1).trans (by simp)
 
 theorem bit0_eq_two_mul (n : α) : bit0 n = 2 * n :=
 (two_mul _).symm
@@ -253,11 +266,11 @@ by split_ifs; refl
 -- `mul_ite` and `ite_mul`.
 attribute [simp] mul_ite ite_mul
 
-@[simp] lemma mul_boole {α} [non_assoc_semiring α] (P : Prop) [decidable P] (a : α) :
+@[simp] lemma mul_boole {α} [mul_zero_one_class α] (P : Prop) [decidable P] (a : α) :
   a * (if P then 1 else 0) = if P then a else 0 :=
 by simp
 
-@[simp] lemma boole_mul {α} [non_assoc_semiring α] (P : Prop) [decidable P] (a : α) :
+@[simp] lemma boole_mul {α} [mul_zero_one_class α] (P : Prop) [decidable P] (a : α) :
   (if P then 1 else 0) * a = if P then a else 0 :=
 by simp
 
@@ -273,9 +286,6 @@ lemma ite_and_mul_zero {α : Type*} [mul_zero_class α]
   (P Q : Prop) [decidable P] [decidable Q] (a b : α) :
   ite (P ∧ Q) (a * b) 0 = ite P a 0 * ite Q b 0 :=
 by simp only [←ite_and, ite_mul, mul_ite, mul_zero, zero_mul, and_comm]
-
-theorem dvd_add {a b c : α} (h₁ : a ∣ b) (h₂ : a ∣ c) : a ∣ b + c :=
-dvd.elim h₁ (λ d hd, dvd.elim h₂ (λ e he, dvd.intro (d + e) (by simp [left_distrib, hd, he])))
 
 end semiring
 
@@ -1117,7 +1127,7 @@ lemma pred_ne_self [ring α] [nontrivial α] (a : α) : a - 1 ≠ a :=
 
 /-- Left `mul` by a `k : α` over `[ring α]` is injective, if `k` is not a zero divisor.
 The typeclass that restricts all terms of `α` to have this property is `no_zero_divisors`. -/
-lemma is_left_regular_of_non_zero_divisor [ring α] (k : α)
+lemma is_left_regular_of_non_zero_divisor [non_unital_non_assoc_ring α] (k : α)
   (h : ∀ (x : α), k * x = 0 → x = 0) : is_left_regular k :=
 begin
   refine λ x y (h' : k * x = k * y), sub_eq_zero.mp (h _ _),
@@ -1126,7 +1136,7 @@ end
 
 /-- Right `mul` by a `k : α` over `[ring α]` is injective, if `k` is not a zero divisor.
 The typeclass that restricts all terms of `α` to have this property is `no_zero_divisors`. -/
-lemma is_right_regular_of_non_zero_divisor [ring α] (k : α)
+lemma is_right_regular_of_non_zero_divisor [non_unital_non_assoc_ring α] (k : α)
   (h : ∀ (x : α), x * k = 0 → x = 0) : is_right_regular k :=
 begin
   refine λ x y (h' : x * k = y * k), sub_eq_zero.mp (h _ _),
@@ -1294,10 +1304,10 @@ h.add_right h
 lemma bit0_left [distrib R] {x y : R} (h : commute x y) : commute (bit0 x) y :=
 h.add_left h
 
-lemma bit1_right [semiring R] {x y : R} (h : commute x y) : commute x (bit1 y) :=
+lemma bit1_right [non_assoc_semiring R] {x y : R} (h : commute x y) : commute x (bit1 y) :=
 h.bit0_right.add_right (commute.one_right x)
 
-lemma bit1_left [semiring R] {x y : R} (h : commute x y) : commute (bit1 x) y :=
+lemma bit1_left [non_assoc_semiring R] {x y : R} (h : commute x y) : commute (bit1 x) y :=
 h.bit0_left.add_left (commute.one_left y)
 
 /-- Representation of a difference of two squares of commuting elements as a product. -/

--- a/src/algebra/ring/comp_typeclasses.lean
+++ b/src/algebra/ring/comp_typeclasses.lean
@@ -41,7 +41,7 @@ Instances of these typeclasses mostly involving `ring_hom.id` are also provided:
 -/
 
 variables {R₁ : Type*} {R₂ : Type*} {R₃ : Type*}
-variables [semiring R₁] [semiring R₂] [semiring R₃]
+variables [non_assoc_semiring R₁] [non_assoc_semiring R₂] [non_assoc_semiring R₃]
 
 /-- Class that expresses the fact that three ring homomorphisms form a composition triple. This is
 used to handle composition of semilinear maps. -/

--- a/src/algebra/ring/equiv.lean
+++ b/src/algebra/ring/equiv.lean
@@ -321,7 +321,7 @@ end semiring
 
 section
 
-variables [ring R] [ring S] (f : R ≃+* S) (x y : R)
+variables [non_assoc_ring R] [non_assoc_ring S] (f : R ≃+* S) (x y : R)
 
 protected lemma map_neg : f (-x) = -f x := map_neg f x
 

--- a/src/data/dfinsupp/basic.lean
+++ b/src/data/dfinsupp/basic.lean
@@ -231,46 +231,46 @@ fun_like.coe_injective.add_comm_group _
 
 /-- Dependent functions with finite support inherit a semiring action from an action on each
 coordinate. -/
-instance [monoid γ] [Π i, add_monoid (β i)] [Π i, distrib_mul_action γ (β i)] :
+instance [mul_one_class γ] [Π i, add_monoid (β i)] [Π i, distrib_mul_action γ (β i)] :
   has_scalar γ (Π₀ i, β i) :=
 ⟨λc v, v.map_range (λ _, (•) c) (λ _, smul_zero _)⟩
 
-lemma smul_apply [monoid γ] [Π i, add_monoid (β i)]
+lemma smul_apply [mul_one_class γ] [Π i, add_monoid (β i)]
   [Π i, distrib_mul_action γ (β i)] (b : γ) (v : Π₀ i, β i) (i : ι) :
   (b • v) i = b • (v i) :=
 map_range_apply _ _ v i
 
-@[simp] lemma coe_smul [monoid γ] [Π i, add_monoid (β i)]
+@[simp] lemma coe_smul [mul_one_class γ] [Π i, add_monoid (β i)]
   [Π i, distrib_mul_action γ (β i)] (b : γ) (v : Π₀ i, β i) :
   ⇑(b • v) = b • v :=
 funext $ smul_apply b v
 
-instance {δ : Type*} [monoid γ] [monoid δ]
+instance {δ : Type*} [mul_one_class γ] [mul_one_class δ]
   [Π i, add_monoid (β i)] [Π i, distrib_mul_action γ (β i)] [Π i, distrib_mul_action δ (β i)]
   [Π i, smul_comm_class γ δ (β i)] :
   smul_comm_class γ δ (Π₀ i, β i) :=
 { smul_comm := λ r s m, ext $ λ i, by simp only [smul_apply, smul_comm r s (m i)] }
 
-instance {δ : Type*} [monoid γ] [monoid δ]
+instance {δ : Type*} [mul_one_class γ] [mul_one_class δ]
   [Π i, add_monoid (β i)] [Π i, distrib_mul_action γ (β i)] [Π i, distrib_mul_action δ (β i)]
   [has_scalar γ δ] [Π i, is_scalar_tower γ δ (β i)] :
   is_scalar_tower γ δ (Π₀ i, β i) :=
 { smul_assoc := λ r s m, ext $ λ i, by simp only [smul_apply, smul_assoc r s (m i)] }
 
-instance [monoid γ] [Π i, add_monoid (β i)] [Π i, distrib_mul_action γ (β i)]
+instance [mul_one_class γ] [Π i, add_monoid (β i)] [Π i, distrib_mul_action γ (β i)]
   [Π i, distrib_mul_action γᵐᵒᵖ (β i)] [∀ i, is_central_scalar γ (β i)] :
   is_central_scalar γ (Π₀ i, β i) :=
 { op_smul_eq_smul := λ r m, ext $ λ i, by simp only [smul_apply, op_smul_eq_smul r (m i)] }
 
 /-- Dependent functions with finite support inherit a `distrib_mul_action` structure from such a
 structure on each coordinate. -/
-instance [monoid γ] [Π i, add_monoid (β i)] [Π i, distrib_mul_action γ (β i)] :
+instance [mul_one_class γ] [Π i, add_monoid (β i)] [Π i, distrib_mul_action γ (β i)] :
   distrib_mul_action γ (Π₀ i, β i) :=
 function.injective.distrib_mul_action coe_fn_add_monoid_hom fun_like.coe_injective coe_smul
 
 /-- Dependent functions with finite support inherit a module structure from such a structure on
 each coordinate. -/
-instance [semiring γ] [Π i, add_comm_monoid (β i)] [Π i, module γ (β i)] :
+instance [non_assoc_semiring γ] [Π i, add_comm_monoid (β i)] [Π i, module γ (β i)] :
   module γ (Π₀ i, β i) :=
 { zero_smul := λ c, ext $ λ i, by simp only [smul_apply, zero_smul, zero_apply],
   add_smul := λ c x y, ext $ λ i, by simp only [add_apply, smul_apply, add_smul],
@@ -315,7 +315,7 @@ by { ext, simp }
   (f + g).filter p = f.filter p + g.filter p :=
 by { ext, simp [ite_add_zero] }
 
-@[simp] lemma filter_smul [monoid γ] [Π i, add_monoid (β i)] [Π i, distrib_mul_action γ (β i)]
+@[simp] lemma filter_smul [mul_one_class γ] [Π i, add_monoid (β i)] [Π i, distrib_mul_action γ (β i)]
   (p : ι → Prop) [decidable_pred p] (r : γ) (f : Π₀ i, β i) :
   (r • f).filter p = r • f.filter p :=
 by { ext, simp [smul_ite] }
@@ -1026,8 +1026,8 @@ support_zip_with
   support (-f) = support f :=
 by ext i; simp
 
-lemma support_smul {γ : Type w} [semiring γ] [Π i, add_comm_monoid (β i)] [Π i, module γ (β i)]
-  [Π ( i : ι) (x : β i), decidable (x ≠ 0)]
+lemma support_smul {γ : Type w} [non_assoc_semiring γ] [Π i, add_comm_monoid (β i)]
+  [Π i, module γ (β i)] [Π (i : ι) (x : β i), decidable (x ≠ 0)]
   (b : γ) (v : Π₀ i, β i) : (b • v).support ⊆ v.support :=
 support_map_range
 

--- a/src/group_theory/group_action/pi.lean
+++ b/src/group_theory/group_action/pi.lean
@@ -94,40 +94,40 @@ instance has_faithful_scalar {α : Type*}
 let ⟨i⟩ := ‹nonempty I› in has_faithful_scalar_at i
 
 @[to_additive]
-instance mul_action (α) {m : monoid α} [Π i, mul_action α $ f i] :
+instance mul_action (α) {m : mul_one_class α} [Π i, mul_action α $ f i] :
   @mul_action α (Π i : I, f i) m :=
 { smul := (•),
   mul_smul := λ r s f, funext $ λ i, mul_smul _ _ _,
   one_smul := λ f, funext $ λ i, one_smul α _ }
 
 @[to_additive]
-instance mul_action' {g : I → Type*} {m : Π i, monoid (f i)} [Π i, mul_action (f i) (g i)] :
-  @mul_action (Π i, f i) (Π i : I, g i) (@pi.monoid I f m) :=
+instance mul_action' {g : I → Type*} {m : Π i, mul_one_class (f i)} [Π i, mul_action (f i) (g i)] :
+  @mul_action (Π i, f i) (Π i : I, g i) (@pi.mul_one_class I f m) :=
 { smul := (•),
   mul_smul := λ r s f, funext $ λ i, mul_smul _ _ _,
   one_smul := λ f, funext $ λ i, one_smul _ _ }
 
-instance distrib_mul_action (α) {m : monoid α} {n : ∀ i, add_monoid $ f i}
+instance distrib_mul_action (α) {m : mul_one_class α} {n : ∀ i, add_monoid $ f i}
   [∀ i, distrib_mul_action α $ f i] :
   @distrib_mul_action α (Π i : I, f i) m (@pi.add_monoid I f n) :=
 { smul_zero := λ c, funext $ λ i, smul_zero _,
   smul_add := λ c f g, funext $ λ i, smul_add _ _ _,
   ..pi.mul_action _ }
 
-instance distrib_mul_action' {g : I → Type*} {m : Π i, monoid (f i)} {n : Π i, add_monoid $ g i}
-  [Π i, distrib_mul_action (f i) (g i)] :
-  @distrib_mul_action (Π i, f i) (Π i : I, g i) (@pi.monoid I f m) (@pi.add_monoid I g n) :=
+instance distrib_mul_action' {g : I → Type*} {m : Π i, mul_one_class (f i)}
+  {n : Π i, add_monoid $ g i} [Π i, distrib_mul_action (f i) (g i)] :
+  @distrib_mul_action (Π i, f i) (Π i : I, g i) (@pi.mul_one_class I f m) (@pi.add_monoid I g n) :=
 { smul_add := by { intros, ext x, apply smul_add },
   smul_zero := by { intros, ext x, apply smul_zero } }
 
-lemma single_smul {α} [monoid α] [Π i, add_monoid $ f i]
+lemma single_smul {α} [mul_one_class α] [Π i, add_monoid $ f i]
   [Π i, distrib_mul_action α $ f i] [decidable_eq I] (i : I) (r : α) (x : f i) :
   single i (r • x) = r • single i x :=
 single_op (λ i : I, ((•) r : f i → f i)) (λ j, smul_zero _) _ _
 
 /-- A version of `pi.single_smul` for non-dependent functions. It is useful in cases Lean fails
 to apply `pi.single_smul`. -/
-lemma single_smul' {α β} [monoid α] [add_monoid β]
+lemma single_smul' {α β} [mul_one_class α] [add_monoid β]
   [distrib_mul_action α β] [decidable_eq I] (i : I) (r : α) (x : β) :
   single i (r • x) = r • single i x :=
 single_smul i r x
@@ -137,16 +137,18 @@ lemma single_smul₀ {g : I → Type*} [Π i, monoid_with_zero (f i)] [Π i, add
   single i (r • x) = single i r • single i x :=
 single_op₂ (λ i : I, ((•) : f i → g i → g i)) (λ j, smul_zero _) _ _ _
 
-instance mul_distrib_mul_action (α) {m : monoid α} {n : Π i, monoid $ f i}
+instance mul_distrib_mul_action (α) {m : mul_one_class α} {n : Π i, mul_one_class $ f i}
   [Π i, mul_distrib_mul_action α $ f i] :
-  @mul_distrib_mul_action α (Π i : I, f i) m (@pi.monoid I f n) :=
+  @mul_distrib_mul_action α (Π i : I, f i) m (@pi.mul_one_class I f n) :=
 { smul_one := λ c, funext $ λ i, smul_one _,
   smul_mul := λ c f g, funext $ λ i, smul_mul' _ _ _,
   ..pi.mul_action _ }
 
-instance mul_distrib_mul_action' {g : I → Type*} {m : Π i, monoid (f i)} {n : Π i, monoid $ g i}
+instance mul_distrib_mul_action' {g : I → Type*}
+  {m : Π i, mul_one_class (f i)} {n : Π i, mul_one_class $ g i}
   [Π i, mul_distrib_mul_action (f i) (g i)] :
-  @mul_distrib_mul_action (Π i, f i) (Π i : I, g i) (@pi.monoid I f m) (@pi.monoid I g n) :=
+  @mul_distrib_mul_action (Π i, f i) (Π i : I, g i)
+    (@pi.mul_one_class I f m) (@pi.mul_one_class I g n) :=
 { smul_mul := by { intros, ext x, apply smul_mul' },
   smul_one := by { intros, ext x, apply smul_one } }
 

--- a/src/group_theory/group_action/sub_mul_action.lean
+++ b/src/group_theory/group_action/sub_mul_action.lean
@@ -102,9 +102,8 @@ end has_scalar
 
 section mul_action_monoid
 
-variables [monoid R] [mul_action R M]
-
 section
+variables [mul_one_class R] [mul_action R M]
 variables [has_scalar S R] [has_scalar S M] [is_scalar_tower S R M]
 variables (p : sub_mul_action R M)
 
@@ -129,6 +128,8 @@ instance [has_scalar Sᵐᵒᵖ R] [has_scalar Sᵐᵒᵖ M] [is_scalar_tower S�
 { op_smul_eq_smul := λ r x, subtype.ext $ op_smul_eq_smul r x }
 
 end
+
+variables [monoid R] [mul_action R M]
 
 section
 

--- a/src/group_theory/group_action/sub_mul_action.lean
+++ b/src/group_theory/group_action/sub_mul_action.lean
@@ -129,11 +129,10 @@ instance [has_scalar Sᵐᵒᵖ R] [has_scalar Sᵐᵒᵖ M] [is_scalar_tower S�
 
 end
 
-variables [monoid R] [mul_action R M]
-
 section
 
-variables [monoid S] [has_scalar S R] [mul_action S M] [is_scalar_tower S R M]
+variables [mul_one_class R] [mul_action R M]
+variables [mul_one_class S] [has_scalar S R] [mul_action S M] [is_scalar_tower S R M]
 variables (p : sub_mul_action R M)
 
 /-- If the scalar product forms a `mul_action`, then the subset inherits this action -/
@@ -146,6 +145,7 @@ instance : mul_action R p := p.mul_action'
 
 end
 
+variables [monoid R] [mul_action R M]
 
 /-- Orbits in a `sub_mul_action` coincide with orbits in the ambient space. -/
 lemma coe_image_orbit {p : sub_mul_action R M} (m : p) :
@@ -184,7 +184,7 @@ end mul_action_group
 
 section module
 
-variables [semiring R] [add_comm_monoid M]
+variables [non_assoc_semiring R] [add_comm_monoid M]
 variables [module R M]
 variables (p : sub_mul_action R M)
 
@@ -200,7 +200,7 @@ end module
 
 section add_comm_group
 
-variables [ring R] [add_comm_group M]
+variables [non_assoc_ring R] [add_comm_group M]
 variables [module R M]
 variables (p p' : sub_mul_action R M)
 variables {r : R} {x y : M}

--- a/src/group_theory/submonoid/operations.lean
+++ b/src/group_theory/submonoid/operations.lean
@@ -965,10 +965,6 @@ instance [has_scalar M' α] [has_faithful_scalar M' α] (S : submonoid M') :
   has_faithful_scalar S α :=
 ⟨λ x y h, subtype.ext $ eq_of_smul_eq_smul h⟩
 
-end mul_one_class
-
-variables [monoid M']
-
 /-- The action by a submonoid is the action by the underlying monoid. -/
 @[to_additive /-"The additive action by an add_submonoid is the action by the underlying
 add_monoid. "-/]
@@ -979,8 +975,13 @@ instance [add_monoid α] [distrib_mul_action M' α] (S : submonoid M') : distrib
 distrib_mul_action.comp_hom _ S.subtype
 
 /-- The action by a submonoid is the action by the underlying monoid. -/
-instance [monoid α] [mul_distrib_mul_action M' α] (S : submonoid M') : mul_distrib_mul_action S α :=
+instance [mul_one_class α] [mul_distrib_mul_action M' α] (S : submonoid M') :
+  mul_distrib_mul_action S α :=
 mul_distrib_mul_action.comp_hom _ S.subtype
+
+end mul_one_class
+
+variables [monoid M']
 
 example {S : submonoid M'} : is_scalar_tower S M' M' := by apply_instance
 

--- a/src/ring_theory/subring/basic.lean
+++ b/src/ring_theory/subring/basic.lean
@@ -813,7 +813,7 @@ end subring
 
 namespace ring_hom
 
-variables [ring T] {s : subring R}
+variables {s : subring R}
 
 open subring
 


### PR DESCRIPTION
I think this is not actually useful...

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
