### PR TITLE
feat(category_theory/adjunction/basic): construct an adjunction from unit and extend

### DIFF
--- a/src/category_theory/adjunction/basic.lean
+++ b/src/category_theory/adjunction/basic.lean
@@ -588,7 +588,6 @@ adjunction.mk_of_hom_equiv
       rw [F.map_comp, category.assoc]
     end,
   hom_equiv_naturality_right' :=
-
     begin
       intros X' X Y f g,
       dsimp [right_adjoint_of_counit_restrict],

--- a/src/category_theory/adjunction/basic.lean
+++ b/src/category_theory/adjunction/basic.lean
@@ -504,4 +504,99 @@ rfl
 
 end functor
 
+section unit_extend
+
+structure unit_extend (F : C ⥤ D) :=
+( obj : D → C )
+( unit : Π (X : D), X ⟶ F.obj (obj X) )
+( extend : Π (X Y), (X ⟶ F.obj Y) → (obj X ⟶ Y))
+( unit_comp_extend : Π (X Y) (f : X ⟶ F.obj Y), unit X ≫ F.map (extend X Y f) = f )
+( extend_unit : Π (X Y) (f : obj X ⟶ Y), extend X Y (unit X ≫ F.map f) = f )
+
+structure counit_restrict (F : C ⥤ D) :=
+( obj : D → C )
+( counit : Π (X : D), F.obj (obj X) ⟶ X )
+( restrict : Π (X Y), (F.obj X ⟶ Y) → (X ⟶ obj Y))
+( restrict_comp_counit : Π (X Y) (f : F.obj X ⟶ Y), F.map (restrict X Y f) ≫ counit Y = f )
+( restrict_counit : Π (X Y) (f : X ⟶ obj Y), restrict X Y (F.map f ≫ counit Y) = f )
+
+variables {F : C ⥤ D} (ue : unit_extend F) (cr : counit_restrict F)
+
+private lemma unit_extend_ext
+  {X : D} {Y : C} {f g : ue.obj X ⟶ Y}
+  (H : ue.unit X ≫ F.map f = ue.unit X ≫ F.map g) : f = g :=
+by rw [← ue.extend_unit _ _ f, H, ue.extend_unit]
+
+private lemma counit_restrict_ext
+  {X : C} {Y : D} {f g : X ⟶ cr.obj Y}
+  (H : F.map f ≫ cr.counit Y = F.map g ≫ cr.counit Y) : f = g :=
+by rw [← cr.restrict_counit _ _ f, H, cr.restrict_counit]
+
+def left_adjoint_of_unit_extend : D ⥤ C :=
+{ obj := ue.obj,
+  map := λ X Y f, ue.extend X (ue.obj Y) (f ≫ ue.unit Y),
+  map_id' := λ X, by rw [category.id_comp, ← category.comp_id (ue.unit X), ← F.map_id,
+      ue.extend_unit],
+  map_comp' := λ X Y Z f g, unit_extend_ext ue $
+    by rw [F.map_comp, ue.unit_comp_extend, ← category.assoc, ue.unit_comp_extend,
+      category.assoc, category.assoc, ue.unit_comp_extend] }
+
+def right_adjoint_of_counit_restrict : D ⥤ C :=
+{ obj := cr.obj,
+  map := λ X Y f, cr.restrict (cr.obj X) Y (cr.counit X ≫ f),
+  map_id' := λ X, by rw [category.comp_id, ← category.id_comp (cr.counit X), ← F.map_id,
+      cr.restrict_counit],
+  map_comp' := λ X Y Z f g, counit_restrict_ext cr $
+    by rw [F.map_comp, cr.restrict_comp_counit, category.assoc, cr.restrict_comp_counit,
+      ← category.assoc, ← category.assoc, cr.restrict_comp_counit] }
+
+def adjunction_of_unit_extend :
+  left_adjoint_of_unit_extend ue ⊣ F :=
+adjunction.mk_of_hom_equiv
+{ hom_equiv := λ X Y,
+  { to_fun := λ f, ue.unit X ≫ F.map f,
+    inv_fun := ue.extend _ _,
+    left_inv := ue.extend_unit _ _,
+    right_inv := ue.unit_comp_extend _ _ },
+  hom_equiv_naturality_left_symm' :=
+    begin
+      intros X' X Y f g,
+      dsimp [left_adjoint_of_unit_extend],
+      apply unit_extend_ext ue,
+      rw [ue.unit_comp_extend, F.map_comp, ← category.assoc,
+        ue.unit_comp_extend, category.assoc, ue.unit_comp_extend],
+    end,
+  hom_equiv_naturality_right' :=
+    begin
+      intros X Y Y' f g,
+      dsimp [left_adjoint_of_unit_extend],
+      rw [F.map_comp, category.assoc]
+    end }
+
+def adjunction_of_counit_restrict :
+  F ⊣ right_adjoint_of_counit_restrict cr :=
+adjunction.mk_of_hom_equiv
+{ hom_equiv := λ X Y,
+  { to_fun := cr.restrict _ _,
+    inv_fun := λ f, F.map f ≫ cr.counit Y,
+    left_inv := cr.restrict_comp_counit _ _,
+    right_inv := cr.restrict_counit _ _ },
+  hom_equiv_naturality_left_symm' :=
+    begin
+      intros X Y Y' f g,
+      dsimp [right_adjoint_of_counit_restrict],
+      rw [F.map_comp, category.assoc]
+    end,
+  hom_equiv_naturality_right' :=
+
+    begin
+      intros X' X Y f g,
+      dsimp [right_adjoint_of_counit_restrict],
+      apply counit_restrict_ext cr,
+      rw [cr.restrict_comp_counit, F.map_comp, category.assoc,
+        cr.restrict_comp_counit, ← category.assoc, cr.restrict_comp_counit],
+    end }
+
+end unit_extend
+
 end category_theory


### PR DESCRIPTION
---
A nice way to construct adjunctions. I think it's nice for two reasons, in practice when you define an adjunction like the free vector space, the first data you define tends to be `obj` `unit` and `extend` or `lift`. The second reason it's nice is because there are only two equalities to prove and both functoriality and adjointness follow from these.

I have not added docstrings yet so it is WIP. It is also my first category theory PR so there may be some style issues.

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
