### PR TITLE
[Merged by Bors] - feat(model_theory/*): Theory of nonempty structures and bundling elementary substructures

### DIFF
--- a/src/model_theory/bundled.lean
+++ b/src/model_theory/bundled.lean
@@ -3,7 +3,7 @@ Copyright (c) 2022 Aaron Anderson. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Aaron Anderson
 -/
-import model_theory.semantics
+import model_theory.elementary_maps
 import category_theory.concrete_category.bundled
 /-!
 # Bundled First-Order Structures
@@ -87,5 +87,10 @@ lemma coe_of {M : Type w} [L.Structure M] [nonempty M] (h : M ⊨ T) :
   (h.bundled : Type w) = M := rfl
 
 end Theory
+
+/-- An elementary substructure of a bundled model as a bundled model. -/
+def elementary_substructure.to_Model {M : T.Model} (S : L.elementary_substructure M) : T.Model :=
+Theory.Model.of T S
+
 end language
 end first_order

--- a/src/model_theory/elementary_maps.lean
+++ b/src/model_theory/elementary_maps.lean
@@ -283,6 +283,25 @@ instance : inhabited (L.elementary_substructure M) := ⟨⊤⟩
 
 @[simp] lemma coe_top : ((⊤ : L.elementary_substructure M) : set M) = set.univ := rfl
 
+@[simp] lemma realize_sentence (S : L.elementary_substructure M) (φ : L.sentence)  :
+  S ⊨ φ ↔ M ⊨ φ :=
+begin
+  have h := S.is_elementary (φ.relabel (empty.elim : empty → fin 0)) default,
+  rw [formula.realize_relabel, formula.realize_relabel] at h,
+  exact (congr (congr rfl (congr rfl (unique.eq_default _))) (congr rfl (unique.eq_default _))).mp
+    h.symm,
+end
+
+@[simp] lemma Theory_model_iff (S : L.elementary_substructure M) (T : L.Theory) :
+  S ⊨ T ↔ M ⊨ T :=
+by simp only [Theory.model_iff, realize_sentence]
+
+instance Theory_model {T : L.Theory} [h : M ⊨ T] {S : L.elementary_substructure M} : S ⊨ T :=
+(Theory_model_iff S T).2 h
+
+instance [h : nonempty M] {S : L.elementary_substructure M} : nonempty S :=
+(Theory.model_nonempty_iff L).1 infer_instance
+
 end elementary_substructure
 
 namespace substructure

--- a/src/model_theory/semantics.lean
+++ b/src/model_theory/semantics.lean
@@ -522,7 +522,7 @@ infix ` ⊨ `:51 := Theory.model -- input using \|= or \vDash, but not using \mo
 
 variables {M} (T : L.Theory)
 
-lemma Theory.model_iff : M ⊨ T ↔ ∀ φ ∈ T, M ⊨ φ := ⟨λ h, h.realize_of_mem, λ h, ⟨h⟩⟩
+@[simp] lemma Theory.model_iff : M ⊨ T ↔ ∀ φ ∈ T, M ⊨ φ := ⟨λ h, h.realize_of_mem, λ h, ⟨h⟩⟩
 
 lemma Theory.realize_sentence_of_mem [M ⊨ T] {φ : L.sentence} (h : φ ∈ T) :
   M ⊨ φ :=

--- a/src/model_theory/semantics.lean
+++ b/src/model_theory/semantics.lean
@@ -522,6 +522,8 @@ infix ` ⊨ `:51 := Theory.model -- input using \|= or \vDash, but not using \mo
 
 variables {M} (T : L.Theory)
 
+lemma Theory.model_iff : M ⊨ T ↔ ∀ φ ∈ T, M ⊨ φ := ⟨λ h, h.realize_of_mem, λ h, ⟨h⟩⟩
+
 lemma Theory.realize_sentence_of_mem [M ⊨ T] {φ : L.sentence} (h : φ ∈ T) :
   M ⊨ φ :=
 Theory.model.realize_of_mem φ h
@@ -545,6 +547,10 @@ instance model_empty : M ⊨ (∅ : L.Theory) := ⟨λ φ hφ, (set.not_mem_empt
 lemma Theory.model.mono {T' : L.Theory} (h : M ⊨ T') (hs : T ⊆ T') :
   M ⊨ T :=
 ⟨λ φ hφ, T'.realize_sentence_of_mem (hs hφ)⟩
+
+lemma Theory.model_singleton_iff {φ : L.sentence} :
+  M ⊨ ({φ} : L.Theory) ↔ M ⊨ φ :=
+by simp [Theory.model_iff]
 
 namespace bounded_formula
 

--- a/src/model_theory/semantics.lean
+++ b/src/model_theory/semantics.lean
@@ -647,5 +647,23 @@ forall_congr (λ _, forall_congr (λ _, realize_sup.trans (or_congr realize_rel�
 
 end relations
 
+section nonempty
+
+variable (L)
+
+@[simp] lemma sentence.realize_nonempty :
+  M ⊨ (sentence.nonempty L) ↔ nonempty M :=
+bounded_formula.realize_ex.trans (trans (exists_congr eq_self_iff_true) exists_true_iff_nonempty)
+
+@[simp] lemma Theory.model_nonempty_iff :
+  M ⊨ (Theory.nonempty L) ↔ nonempty M :=
+Theory.model_singleton_iff.trans (sentence.realize_nonempty L)
+
+instance Theory.model_nonempty [h : nonempty M] :
+  M ⊨ (Theory.nonempty L) :=
+(Theory.model_nonempty_iff L).2 h
+
+end nonempty
+
 end language
 end first_order

--- a/src/model_theory/syntax.lean
+++ b/src/model_theory/syntax.lean
@@ -711,5 +711,17 @@ protected def total : L.sentence :=
 
 end relations
 
+section nonempty
+
+variable (L)
+
+/-- A sentence that indicates a structure is nonempty. -/
+protected def sentence.nonempty : L.sentence := ∃' (&0 =' &0)
+
+/-- A theory that indicates a structure is nonempty. -/
+protected def Theory.nonempty : L.Theory := {sentence.nonempty L}
+
+end nonempty
+
 end language
 end first_order


### PR DESCRIPTION
Defines a sentence and theory to indicate a structure is nonempty
Defines a map to turn elementary substructures of a bundled model into bundled models

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

- [x] depends on: #13117

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
