### PR TITLE
[Merged by Bors] - feat(category_theory/monoidal): coherence tactic

### DIFF
--- a/src/category_theory/monoidal/category.lean
+++ b/src/category_theory/monoidal/category.lean
@@ -600,6 +600,58 @@ end
 
 end
 
+variables {C : Type*} [category C] [monoidal_category C]
+
+class monoidal_coherence (X Y : C) :=
+(iso [] : X ≅ Y)
+
+namespace monoidal_coherence
+
+@[simps]
+instance refl (X : C) : monoidal_coherence X X := ⟨iso.refl _⟩
+instance tensor (X Y Z : C) [monoidal_coherence Y Z] : monoidal_coherence (X ⊗ Y) (X ⊗ Z) :=
+⟨iso.refl X ⊗ monoidal_coherence.iso Y Z⟩
+instance left (X Y : C) [monoidal_coherence X Y] : monoidal_coherence (𝟙_ C ⊗ X) Y :=
+⟨λ_ X ≪≫ monoidal_coherence.iso X Y⟩
+instance left' (X Y : C) [monoidal_coherence X Y] : monoidal_coherence X (𝟙_ C ⊗ Y) :=
+⟨monoidal_coherence.iso X Y ≪≫ (λ_ Y).symm⟩
+instance right (X Y : C) [monoidal_coherence X Y] : monoidal_coherence (X ⊗ 𝟙_ C) Y :=
+⟨ρ_ X ≪≫ monoidal_coherence.iso X Y⟩
+instance right' (X Y : C) [monoidal_coherence X Y] : monoidal_coherence X (Y ⊗ 𝟙_ C) :=
+⟨monoidal_coherence.iso X Y ≪≫ (ρ_ Y).symm⟩
+instance assoc (X Y Z W : C) [monoidal_coherence (X ⊗ (Y ⊗ Z)) W] :
+  monoidal_coherence ((X ⊗ Y) ⊗ Z) W :=
+⟨α_ X Y Z ≪≫
+  monoidal_coherence.iso (X ⊗ (Y ⊗ Z)) W⟩
+instance assoc' (W X Y Z : C) [monoidal_coherence W (X ⊗ (Y ⊗ Z))] :
+  monoidal_coherence W ((X ⊗ Y) ⊗ Z) :=
+⟨monoidal_coherence.iso W (X ⊗ (Y ⊗ Z)) ≪≫
+  (α_ X Y Z).symm⟩
+
+example (X1 X2 X3 X4 X5 X6 X7 X8 X9 : C) : monoidal_coherence
+  (𝟙_ C ⊗ (X1 ⊗ X2 ⊗ ((X3 ⊗ X4) ⊗ X5)) ⊗ X6 ⊗ (X7 ⊗ X8 ⊗ X9))
+  (X1 ⊗ (X2 ⊗ X3) ⊗ X4 ⊗ (X5 ⊗ (𝟙_ C ⊗ X6) ⊗ X7) ⊗ X8 ⊗ X9) :=
+by apply_instance
+
+end monoidal_coherence
+
+def monoidal_comp {W X Y Z : C} [monoidal_coherence X Y] (f : W ⟶ X) (g : Y ⟶ Z) : W ⟶ Z :=
+f ≫ (monoidal_coherence.iso X Y).hom ≫ g
+
+infixr ` ⊗≫ `:80 := monoidal_comp -- type as \gg
+
+-- To automatically insert unitors/associators at the beginning or end,
+-- you can use `f ⊗≫ 𝟙 _`
+example {W X Y Z : C} (f : W ⟶ (X ⊗ Y) ⊗ Z) : W ⟶ X ⊗ (Y ⊗ Z) := f ⊗≫ 𝟙 _
+
+@[simp] lemma monoidal_comp_refl {X Y Z : C} (f : X ⟶ Y) (g : Y ⟶ Z) :
+  f ⊗≫ g = f ≫ g :=
+by { dsimp [monoidal_comp], simp, }
+
+@[simp] lemma monoidal_comp_assoc {U V W X Y Z : C} [monoidal_coherence V (W ⊗ (X ⊗ Y))]
+  (f : U ⟶ V) (g : W ⊗ (X ⊗ Y) ⟶ Z) : f ⊗≫ ((α_ W X Y).hom ≫ g) = f ⊗≫ g :=
+sorry
+
 end monoidal_category
 
 end category_theory

--- a/src/category_theory/monoidal/category.lean
+++ b/src/category_theory/monoidal/category.lean
@@ -600,58 +600,6 @@ end
 
 end
 
-variables {C : Type*} [category C] [monoidal_category C]
-
-class monoidal_coherence (X Y : C) :=
-(iso [] : X ≅ Y)
-
-namespace monoidal_coherence
-
-@[simps]
-instance refl (X : C) : monoidal_coherence X X := ⟨iso.refl _⟩
-instance tensor (X Y Z : C) [monoidal_coherence Y Z] : monoidal_coherence (X ⊗ Y) (X ⊗ Z) :=
-⟨iso.refl X ⊗ monoidal_coherence.iso Y Z⟩
-instance left (X Y : C) [monoidal_coherence X Y] : monoidal_coherence (𝟙_ C ⊗ X) Y :=
-⟨λ_ X ≪≫ monoidal_coherence.iso X Y⟩
-instance left' (X Y : C) [monoidal_coherence X Y] : monoidal_coherence X (𝟙_ C ⊗ Y) :=
-⟨monoidal_coherence.iso X Y ≪≫ (λ_ Y).symm⟩
-instance right (X Y : C) [monoidal_coherence X Y] : monoidal_coherence (X ⊗ 𝟙_ C) Y :=
-⟨ρ_ X ≪≫ monoidal_coherence.iso X Y⟩
-instance right' (X Y : C) [monoidal_coherence X Y] : monoidal_coherence X (Y ⊗ 𝟙_ C) :=
-⟨monoidal_coherence.iso X Y ≪≫ (ρ_ Y).symm⟩
-instance assoc (X Y Z W : C) [monoidal_coherence (X ⊗ (Y ⊗ Z)) W] :
-  monoidal_coherence ((X ⊗ Y) ⊗ Z) W :=
-⟨α_ X Y Z ≪≫
-  monoidal_coherence.iso (X ⊗ (Y ⊗ Z)) W⟩
-instance assoc' (W X Y Z : C) [monoidal_coherence W (X ⊗ (Y ⊗ Z))] :
-  monoidal_coherence W ((X ⊗ Y) ⊗ Z) :=
-⟨monoidal_coherence.iso W (X ⊗ (Y ⊗ Z)) ≪≫
-  (α_ X Y Z).symm⟩
-
-example (X1 X2 X3 X4 X5 X6 X7 X8 X9 : C) : monoidal_coherence
-  (𝟙_ C ⊗ (X1 ⊗ X2 ⊗ ((X3 ⊗ X4) ⊗ X5)) ⊗ X6 ⊗ (X7 ⊗ X8 ⊗ X9))
-  (X1 ⊗ (X2 ⊗ X3) ⊗ X4 ⊗ (X5 ⊗ (𝟙_ C ⊗ X6) ⊗ X7) ⊗ X8 ⊗ X9) :=
-by apply_instance
-
-end monoidal_coherence
-
-def monoidal_comp {W X Y Z : C} [monoidal_coherence X Y] (f : W ⟶ X) (g : Y ⟶ Z) : W ⟶ Z :=
-f ≫ (monoidal_coherence.iso X Y).hom ≫ g
-
-infixr ` ⊗≫ `:80 := monoidal_comp -- type as \gg
-
--- To automatically insert unitors/associators at the beginning or end,
--- you can use `f ⊗≫ 𝟙 _`
-example {W X Y Z : C} (f : W ⟶ (X ⊗ Y) ⊗ Z) : W ⟶ X ⊗ (Y ⊗ Z) := f ⊗≫ 𝟙 _
-
-@[simp] lemma monoidal_comp_refl {X Y Z : C} (f : X ⟶ Y) (g : Y ⟶ Z) :
-  f ⊗≫ g = f ≫ g :=
-by { dsimp [monoidal_comp], simp, }
-
-@[simp] lemma monoidal_comp_assoc {U V W X Y Z : C} [monoidal_coherence V (W ⊗ (X ⊗ Y))]
-  (f : U ⟶ V) (g : W ⊗ (X ⊗ Y) ⟶ Z) : f ⊗≫ ((α_ W X Y).hom ≫ g) = f ⊗≫ g :=
-sorry
-
 end monoidal_category
 
 end category_theory

--- a/src/category_theory/monoidal/center.lean
+++ b/src/category_theory/monoidal/center.lean
@@ -5,6 +5,7 @@ Authors: Scott Morrison
 -/
 import category_theory.monoidal.braided
 import category_theory.functor.reflects_isomorphisms
+import category_theory.monoidal.coherence
 
 /-!
 # Half braidings and the Drinfeld center of a monoidal category
@@ -117,19 +118,21 @@ def tensor_obj (X Y : center C) : center C :=
     begin
       dsimp,
       simp only [comp_tensor_id, id_tensor_comp, category.assoc, half_braiding.monoidal],
-      rw [pentagon_assoc, pentagon_inv_assoc, iso.eq_inv_comp, ←pentagon_assoc,
-        ←id_tensor_comp_assoc, iso.hom_inv_id, tensor_id, category.id_comp,
-        ←associator_naturality_assoc, cancel_epi, cancel_epi,
-        ←associator_inv_naturality_assoc (X.2.β U).hom,
-        associator_inv_naturality_assoc _ _ (Y.2.β U').hom, tensor_id, tensor_id,
-        id_tensor_comp_tensor_id_assoc, associator_naturality_assoc (X.2.β U).hom,
-        ←associator_naturality_assoc _ _ (Y.2.β U').hom, tensor_id, tensor_id,
-        tensor_id_comp_id_tensor_assoc, ←id_tensor_comp_tensor_id, tensor_id, category.comp_id,
-        ←is_iso.inv_comp_eq, inv_tensor, is_iso.inv_id, is_iso.iso.inv_inv, pentagon_assoc,
-        iso.hom_inv_id_assoc, cancel_epi, cancel_epi, ←is_iso.inv_comp_eq, is_iso.iso.inv_hom,
-        ←pentagon_inv_assoc, ←comp_tensor_id_assoc, iso.inv_hom_id, tensor_id, category.id_comp,
-        ←associator_inv_naturality_assoc, cancel_epi, cancel_epi, ←is_iso.inv_comp_eq, inv_tensor,
-        is_iso.iso.inv_hom, is_iso.inv_id, pentagon_inv_assoc, iso.inv_hom_id, category.comp_id],
+      -- On the RHS, we'd like to commute `((X.snd.β U).hom ⊗ 𝟙 Y.fst) ⊗ 𝟙 U'`
+      -- and `𝟙 U ⊗ 𝟙 X.fst ⊗ (Y.snd.β U').hom` past each other,
+      -- but there are some associators we need to get out of the way first.
+      slice_rhs 6 8 { rw pentagon, },
+      slice_rhs 5 6 { rw associator_naturality, },
+      slice_rhs 7 8 { rw ←associator_naturality, },
+      slice_rhs 6 7 { rw [tensor_id, tensor_id, tensor_id_comp_id_tensor, ←id_tensor_comp_tensor_id,
+        ←tensor_id, ←tensor_id], },
+      -- Now insert associators as needed to make the four half-braidings look identical
+      slice_rhs 10 10 { rw ←associator_inv_conjugation, },
+      slice_rhs 7 7 { rw ←associator_inv_conjugation, },
+      slice_rhs 6 6 { rw ←associator_conjugation, },
+      slice_rhs 3 3 { rw ←associator_conjugation, },
+      -- Finish with an application of the coherence theorem.
+      coherence,
     end,
     naturality' := λ U U' f,
     begin

--- a/src/category_theory/monoidal/center.lean
+++ b/src/category_theory/monoidal/center.lean
@@ -175,12 +175,8 @@ def tensor_unit : center C :=
 def associator (X Y Z : center C) : tensor_obj (tensor_obj X Y) Z ≅ tensor_obj X (tensor_obj Y Z) :=
 iso_mk ⟨(α_ X.1 Y.1 Z.1).hom, λ U, begin
   dsimp,
-  simp only [category.assoc, comp_tensor_id, id_tensor_comp],
-  rw [pentagon, pentagon_assoc, ←associator_naturality_assoc (𝟙 X.1) (𝟙 Y.1), tensor_id, cancel_epi,
-    cancel_epi, iso.eq_inv_comp, ←pentagon_assoc, ←id_tensor_comp_assoc, iso.hom_inv_id, tensor_id,
-    category.id_comp, ←associator_naturality_assoc, cancel_epi, cancel_epi, ←is_iso.inv_comp_eq,
-    inv_tensor, is_iso.inv_id, is_iso.iso.inv_inv, pentagon_assoc, iso.hom_inv_id_assoc, ←tensor_id,
-    ←associator_naturality_assoc],
+  simp only [comp_tensor_id, id_tensor_comp, ←tensor_id, ←associator_conjugation],
+  coherence,
 end⟩
 
 /-- Auxiliary definition for the `monoidal_category` instance on `center C`. -/

--- a/src/category_theory/monoidal/coherence.lean
+++ b/src/category_theory/monoidal/coherence.lean
@@ -221,7 +221,7 @@ namespace coherence
 
 /--
 Auxiliary simp lemma for the `coherence` tactic:
-this move brackets to the left in order to expose a maximal prefix
+this moves brackets to the left in order to expose a maximal prefix
 built out of unitors and associators.
 -/
 -- We have unused typeclass arguments here.
@@ -275,7 +275,7 @@ do
   -- To prove an equality `f = g` in a monoidal category,
   -- first try the `pure_coherence` tactic on the entire equation:
   pure_coherence <|> do
-  -- Otherewise, rearrange so we have a maximal prefix of each side
+  -- Otherwise, rearrange so we have a maximal prefix of each side
   -- that is built out of unitors and associators:
   liftable_prefixes <|>
     fail ("Something went wrong in the `coherence` tactic: " ++

--- a/src/category_theory/monoidal/coherence.lean
+++ b/src/category_theory/monoidal/coherence.lean
@@ -171,6 +171,8 @@ f ≫ monoidal_coherence.hom X Y ≫ g
 
 infixr ` ⊗≫ `:80 := monoidal_comp -- type as \ot \gg
 
+example {U V W X Y : C} (f : U ⟶ V ⊗ (W ⊗ X)) (g : (V ⊗ W) ⊗ X ⟶ Y) : U ⟶ Y := f ⊗≫ g
+
 -- To automatically insert unitors/associators at the beginning or end,
 -- you can use `f ⊗≫ 𝟙 _`
 example {W X Y Z : C} (f : W ⟶ (X ⊗ Y) ⊗ Z) : W ⟶ X ⊗ (Y ⊗ Z) := f ⊗≫ 𝟙 _
@@ -181,9 +183,7 @@ by { dsimp [monoidal_comp], simp, }
 
 example {U V W X Y : C} (f : U ⟶ V ⊗ (W ⊗ X)) (g : (V ⊗ W) ⊗ X ⟶ Y) :
   f ⊗≫ g = f ≫ (α_ _ _ _).inv ≫ g :=
-begin
-  simp [monoidal_comp],
-end
+by simp [monoidal_comp]
 
 /-!
 Sadly, we can't prove lemmas such as the following,
@@ -207,7 +207,7 @@ end
 # Proposal for a better `coherence` tactic:
 
 To prove an equality `f = g` in a monoidal category,
-parse each of `f` and `g` as the composition of some lift of morphisms.
+parse each of `f` and `g` as the composition of some list of morphisms.
 Identify the morphisms for which we can not construct a `lift_hom`.
 Make sure the lists of such morphisms in `f` and `g` are identical; fail if not.
 Now split the lists at these points,

--- a/src/category_theory/monoidal/coherence.lean
+++ b/src/category_theory/monoidal/coherence.lean
@@ -282,6 +282,10 @@ different strings with the same source and target.
 That is, `coherence` can handle goals of the form
 `a ≫ f ≫ b ≫ g ≫ c = a' ≫ f ≫ b' ≫ g ≫ c'`
 where `a = a'`, `b = b'`, and `c = c'` can be proved using `pure_coherence`.
+
+(If you have very large equations on which `coherence` is unexpectedly failing,
+you may need to increase the typeclass search depth,
+using e.g. `set_option class.instance_max_depth 100`.)
 -/
 meta def coherence : tactic unit :=
 do

--- a/src/category_theory/monoidal/coherence.lean
+++ b/src/category_theory/monoidal/coherence.lean
@@ -138,6 +138,14 @@ f ≫ monoidal_coherence.hom X Y ≫ g
 
 infixr ` ⊗≫ `:80 := monoidal_comp -- type as \ot \gg
 
+/-- Compose two isomorphisms in a monoidal category,
+inserting unitors and associators between as necessary. -/
+def monoidal_iso_comp {W X Y Z : C} [lift_obj X] [lift_obj Y]
+  [monoidal_coherence X Y] (f : W ≅ X) (g : Y ≅ Z) : W ≅ Z :=
+f ≪≫ as_iso (monoidal_coherence.hom X Y) ≪≫ g
+
+infixr ` ≪⊗≫ `:80 := monoidal_iso_comp -- type as \ot \gg
+
 example {U V W X Y : C} (f : U ⟶ V ⊗ (W ⊗ X)) (g : (V ⊗ W) ⊗ X ⟶ Y) : U ⟶ Y := f ⊗≫ g
 
 -- To automatically insert unitors/associators at the beginning or end,

--- a/src/category_theory/monoidal/coherence.lean
+++ b/src/category_theory/monoidal/coherence.lean
@@ -212,7 +212,7 @@ which are "liftable" (i.e. expressible as compositions of unitors and associator
 meta def liftable_prefixes : tactic unit :=
 try `[simp only [monoidal_comp, category_theory.category.assoc]] >>
   `[apply (cancel_epi (𝟙 _)).1; try { apply_instance }] >>
-  try `[simp only [assoc_lift_hom]]
+  try `[simp only [tactic.coherence.assoc_lift_hom]]
 
 example {W X Y Z : C} (f : Y ⟶ Z) (g) (w : false) : (λ_ _).hom ≫ f = g :=
 begin

--- a/src/category_theory/monoidal/coherence.lean
+++ b/src/category_theory/monoidal/coherence.lean
@@ -266,7 +266,7 @@ do
     tactic.congr_core',
     -- with identical first terms,
     reflexivity <|> fail "`coherence` tactic failed, non-structural morphisms don't match",
-    -- and whose second terms can be identified by recursively called `coherence2`.
+    -- and whose second terms can be identified by recursively called `coherence1`.
     coherence)
 
 run_cmd add_interactive [`coherence1, `coherence]

--- a/src/category_theory/monoidal/coherence.lean
+++ b/src/category_theory/monoidal/coherence.lean
@@ -237,7 +237,7 @@ where `a = a'`, `b = b'`, and `c = c'` can be proved using `coherence1`.
 meta def coherence : tactic unit :=
 do
   -- To prove an equality `f = g` in a monoidal category,
-  -- first try the `coherence` tactic on the entire equation:
+  -- first try the `coherence1` tactic on the entire equation:
   coherence1 <|> do
   -- Otherewise, rearrange so we have a maximal prefix of each side
   -- that is built out of unitors and associators:
@@ -253,7 +253,8 @@ do
   -- Then check that either `g₀` is identically `g₁`,
   reflexivity <|> (do
     -- or that both are compositions,
-    `(_ ≫ _ = _ ≫ _) ← target,
+    `(_ ≫ _ = _ ≫ _) ← target |
+      fail "`coherence` tactic failed, non-structural morphisms don't match",
     tactic.congr_core',
     -- with identical first terms,
     reflexivity <|> fail "`coherence` tactic failed, non-structural morphisms don't match",

--- a/src/category_theory/monoidal/coherence.lean
+++ b/src/category_theory/monoidal/coherence.lean
@@ -188,6 +188,7 @@ setup_tactic_parser
 /-- Coherence tactic for monoidal categories. -/
 meta def monoidal_coherence : tactic unit :=
 do
+  o ← get_options, set_options $ o.set_nat `class.instance_max_depth 128,
   try `[dsimp],
   `(%%lhs = %%rhs) ← target,
   to_expr  ``(project_map id _ _ (lift_hom.lift %%lhs) = project_map id _ _ (lift_hom.lift %%rhs))
@@ -196,7 +197,7 @@ do
 
 /--
 `pure_coherence` uses the coherence theorem for monoidal categories to prove the goal.
-It can prove any equality made up only of associators and unitors.
+It can prove any equality made up only of associators, unitors, and identities.
 ```lean
 example {C : Type} [category C] [monoidal_category C] :
   (λ_ (𝟙_ C)).hom = (ρ_ (𝟙_ C)).hom :=
@@ -257,8 +258,9 @@ open coherence
 
 /--
 Use the coherence theorem for monoidal categories to solve equations in a monoidal equation,
-where the two sides only differ by replacing strings of "structural" morphisms with
-different strings with the same source and target.
+where the two sides only differ by replacing strings of monoidal structural morphisms
+(that is, associators, unitors, and identities)
+with different strings of structural morphisms with the same source and target.
 
 That is, `coherence` can handle goals of the form
 `a ≫ f ≫ b ≫ g ≫ c = a' ≫ f ≫ b' ≫ g ≫ c'`
@@ -266,7 +268,7 @@ where `a = a'`, `b = b'`, and `c = c'` can be proved using `pure_coherence`.
 
 (If you have very large equations on which `coherence` is unexpectedly failing,
 you may need to increase the typeclass search depth,
-using e.g. `set_option class.instance_max_depth 100`.)
+using e.g. `set_option class.instance_max_depth 500`.)
 -/
 meta def coherence : tactic unit :=
 do

--- a/src/category_theory/monoidal/coherence.lean
+++ b/src/category_theory/monoidal/coherence.lean
@@ -188,6 +188,7 @@ setup_tactic_parser
 /-- Coherence tactic for monoidal categories. -/
 meta def monoidal_coherence : tactic unit :=
 do
+  try `[dsimp],
   `(%%lhs = %%rhs) ← target,
   to_expr  ``(project_map id _ _ (lift_hom.lift %%lhs) = project_map id _ _ (lift_hom.lift %%rhs))
     >>= tactic.change,

--- a/src/category_theory/monoidal/coherence.lean
+++ b/src/category_theory/monoidal/coherence.lean
@@ -71,6 +71,10 @@ instance lift_hom_tensor {W X Y Z : C} [lift_obj W] [lift_obj X] [lift_obj Y] [l
   (f : W ⟶ X) (g : Y ⟶ Z) [lift_hom f] [lift_hom g] : lift_hom (f ⊗ g) :=
 { lift := lift_hom.lift f ⊗ lift_hom.lift g }
 
+/--
+A typeclass carrying a choice of monoidal structural isomorphism between two objects.
+Used by the `⊗≫` monoidal composition operator, and the `coherence` tactic.
+-/
 -- We could likely turn this into a `Prop` valued existential if that proves useful.
 class monoidal_coherence (X Y : C) [lift_obj X] [lift_obj Y] :=
 (hom [] : X ⟶ Y)
@@ -205,6 +209,10 @@ Auxiliary simp lemma for the `coherence` tactic:
 this move brackets to the left in order to expose a maximal prefix
 built out of unitors and associators.
 -/
+-- We have unused typeclass arguments here.
+-- They are intentional, to ensure that `simp only [assoc_lift_hom]` only left associates
+-- monoidal structural morphisms.
+@[nolint unused_arguments]
 lemma assoc_lift_hom {W X Y Z : C} [lift_obj W] [lift_obj X] [lift_obj Y]
   (f : W ⟶ X) (g : X ⟶ Y) (h : Y ⟶ Z) [lift_hom f] [lift_hom g] :
   f ≫ (g ≫ h) = (f ≫ g) ≫ h :=

--- a/src/category_theory/monoidal/coherence.lean
+++ b/src/category_theory/monoidal/coherence.lean
@@ -254,26 +254,6 @@ end coherence
 
 open coherence
 
-/-- Implementation of `coherence`. -/
-meta def coherence_loop : tactic unit :=
-  pure_coherence <|> do
-  -- The goal should now look like `f₀ ≫ f₁ = g₀ ≫ g₁`,
-  tactic.congr_core',
-  -- and now we have two goals `f₀ = g₀` and `f₁ = g₁`.
-  -- Discharge the first using `pure_coherence`,
-  focus1 pure_coherence <|>
-    fail "`coherence` tactic failed, subgoal not true in the free bicategory",
-  -- Then check that either `g₀` is identically `g₁`,
-  reflexivity <|> (do
-    -- or that both are compositions,
-    `(_ ≫ _ = _ ≫ _) ← target |
-      fail "`coherence` tactic failed, non-structural morphisms don't match",
-    tactic.congr_core',
-    -- with identical first terms,
-    reflexivity <|> fail "`coherence` tactic failed, non-structural morphisms don't match",
-    -- and whose second terms can be identified by recursively calling `coherence_loop`.
-    coherence_loop)
-
 /--
 Use the coherence theorem for monoidal categories to solve equations in a monoidal equation,
 where the two sides only differ by replacing strings of "structural" morphisms with
@@ -296,8 +276,23 @@ do
   -- that is built out of unitors and associators:
   liftable_prefixes <|>
     fail ("Something went wrong in the `coherence` tactic: " ++
-      "is the target an equation in a bicategory?"),
-  coherence_loop
+      "is the target an equation in a monoidal category?"),
+  -- The goal should now look like `f₀ ≫ f₁ = g₀ ≫ g₁`,
+  tactic.congr_core',
+  -- and now we have two goals `f₀ = g₀` and `f₁ = g₁`.
+  -- Discharge the first using `coherence`,
+  focus1 pure_coherence <|>
+    fail "`coherence` tactic failed, subgoal not true in the free monoidal_category",
+  -- Then check that either `g₀` is identically `g₁`,
+  reflexivity <|> (do
+    -- or that both are compositions,
+    `(_ ≫ _ = _ ≫ _) ← target |
+      fail "`coherence` tactic failed, non-structural morphisms don't match",
+    tactic.congr_core',
+    -- with identical first terms,
+    reflexivity <|> fail "`coherence` tactic failed, non-structural morphisms don't match",
+    -- and whose second terms can be identified by recursively called `coherence`.
+    coherence)
 
 run_cmd add_interactive [`pure_coherence, `coherence]
 

--- a/src/category_theory/monoidal/rigid.lean
+++ b/src/category_theory/monoidal/rigid.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jakob von Raumer
 -/
 
-import category_theory.monoidal.category
+import category_theory.monoidal.coherence
 
 
 /-!
@@ -84,14 +84,8 @@ attribute [reassoc, simp] exact_pairing.evaluation_coevaluation
 instance exact_pairing_unit : exact_pairing (𝟙_ C) (𝟙_ C) :=
 { coevaluation := (ρ_ _).inv,
   evaluation := (ρ_ _).hom,
-  coevaluation_evaluation' := by
-  { rw[monoidal_category.triangle_assoc_comp_right,
-      monoidal_category.unitors_inv_equal,
-      monoidal_category.unitors_equal], simp },
-  evaluation_coevaluation' := by
-  { rw[monoidal_category.triangle_assoc_comp_right_inv_assoc,
-      monoidal_category.unitors_inv_equal,
-      monoidal_category.unitors_equal], simp } }
+  coevaluation_evaluation' := by coherence,
+  evaluation_coevaluation' := by coherence, }
 
 /-- A class of objects which have a right dual. -/
 class has_right_dual (X : C) :=

--- a/test/coherence.lean
+++ b/test/coherence.lean
@@ -52,6 +52,12 @@ by coherence
 example (X Y : C) :
   (𝟙 X ⊗ (λ_ Y).inv) ≫ (α_ X (𝟙_ C) Y).inv = (ρ_ X).inv ⊗ 𝟙 Y :=
 by coherence
+example (X Y : C) (f : 𝟙_ C ⟶ X) (g : X ⟶ Y) (w : false) :
+  (λ_ (𝟙_ C)).hom ≫ f ≫ 𝟙 X ≫ g = (ρ_ (𝟙_ C)).hom ≫ f ≫ g :=
+begin
+  success_if_fail { coherence },
+  cases w
+end
 
 set_option class.instance_max_depth 52
 

--- a/test/coherence.lean
+++ b/test/coherence.lean
@@ -56,8 +56,6 @@ example (X Y : C) (f : 𝟙_ C ⟶ X) (g : X ⟶ Y) (w : false) :
   (λ_ (𝟙_ C)).hom ≫ f ≫ 𝟙 X ≫ g = (ρ_ (𝟙_ C)).hom ≫ f ≫ g :=
 by coherence
 
-set_option class.instance_max_depth 52
-
 example (X₁ Y₁ X₂ Y₂ : C) :
   (α_ (𝟙_ C) (𝟙_ C) (X₁ ⊗ X₂)).hom ≫
     (𝟙 (𝟙_ C) ⊗ (α_ (𝟙_ C) X₁ X₂).inv) ≫

--- a/test/coherence.lean
+++ b/test/coherence.lean
@@ -1,0 +1,75 @@
+import category_theory.monoidal.coherence
+
+open category_theory
+
+universes w v u
+
+-- section bicategory
+-- open_locale bicategory
+-- variables {B : Type u} [bicategory.{w v} B] {a b c d e : B}
+
+-- example : (λ_ (𝟙 a)).hom = (ρ_ (𝟙 a)).hom := by coherence
+-- example : (λ_ (𝟙 a)).inv = (ρ_ (𝟙 a)).inv := by coherence
+-- example (f : a ⟶ b) (g : b ⟶ c) (h : c ⟶ d) :
+--   (α_ f g h).inv ≫ (α_ f g h).hom = 𝟙 (f ≫ g ≫ h) :=
+-- by coherence
+-- example (f : a ⟶ b) (g : b ⟶ c) (h : c ⟶ d) (i : d ⟶ e) :
+--   (f ◁ (α_ g h i).hom) ≫ (α_ f g (h ≫ i)).inv ≫ (α_ (f ≫ g) h i).inv =
+--     (α_ f (g ≫ h) i).inv ≫ ((α_ f g h).inv ▷ i) :=
+-- by coherence
+-- example (f : a ⟶ b) (g : b ⟶ c) :
+--   (f ◁ (λ_ g).inv) ≫ (α_ f (𝟙 b) g).inv = (ρ_ f).inv ▷ g :=
+-- by coherence
+-- example (f₁ : a ⟶ b) (g₁ : b ⟶ a) (f₂ : b ⟶ c) (g₂ : c ⟶ b) :
+--   (α_ (𝟙 a) (𝟙 a) (f₁ ≫ f₂)).hom ≫
+--     (𝟙 a ◁ (α_ (𝟙 a) f₁ f₂).inv) ≫
+--       (𝟙 a ◁ (λ_ f₁).hom ≫ (ρ_ f₁).inv ▷ f₂) ≫
+--         (𝟙 a ◁ (α_ f₁ (𝟙 b) f₂).hom) ≫
+--           (α_ (𝟙 a) f₁ (𝟙 b ≫ f₂)).inv ≫
+--             ((λ_ f₁).hom ≫ (ρ_ f₁).inv ▷ 𝟙 b ≫ f₂) ≫
+--               (α_ f₁ (𝟙 b) (𝟙 b ≫ f₂)).hom ≫
+--                 (f₁ ◁ 𝟙 b ◁ (λ_ f₂).hom ≫ (ρ_ f₂).inv) ≫
+--                   (f₁ ◁ (α_ (𝟙 b) f₂ (𝟙 c)).inv) ≫
+--                     (f₁ ◁ (λ_ f₂).hom ≫ (ρ_ f₂).inv ▷ 𝟙 c) ≫
+--                       (f₁ ◁ (α_ f₂ (𝟙 c) (𝟙 c)).hom) ≫
+--                         (α_ f₁ f₂ (𝟙 c ≫ 𝟙 c)).inv =
+--   (((λ_ (𝟙 a)).hom ▷ f₁ ≫ f₂) ≫ (λ_ (f₁ ≫ f₂)).hom ≫ (ρ_ (f₁ ≫ f₂)).inv) ≫
+--     (f₁ ≫ f₂ ◁ (λ_ (𝟙 c)).inv) :=
+-- by coherence
+
+-- end bicategory
+
+section monoidal
+variables {C : Type u} [category.{v} C] [monoidal_category C]
+
+example : (λ_ (𝟙_ C)).hom = (ρ_ (𝟙_ C)).hom := by coherence
+example : (λ_ (𝟙_ C)).inv = (ρ_ (𝟙_ C)).inv := by coherence
+example (X Y Z : C) : (α_ X Y Z).inv ≫ (α_ X Y Z).hom = 𝟙 (X ⊗ Y ⊗ Z) := by coherence
+example (X Y Z W : C) :
+  (𝟙 X ⊗ (α_ Y Z W).hom) ≫ (α_ X Y (Z ⊗ W)).inv ≫ (α_ (X ⊗ Y) Z W).inv =
+    (α_ X (Y ⊗ Z) W).inv ≫ ((α_ X Y Z).inv ⊗ 𝟙 W) :=
+by coherence
+example (X Y : C) :
+  (𝟙 X ⊗ (λ_ Y).inv) ≫ (α_ X (𝟙_ C) Y).inv = (ρ_ X).inv ⊗ 𝟙 Y :=
+by coherence
+
+set_option class.instance_max_depth 52
+
+example (X₁ Y₁ X₂ Y₂ : C) :
+  (α_ (𝟙_ C) (𝟙_ C) (X₁ ⊗ X₂)).hom ≫
+    (𝟙 (𝟙_ C) ⊗ (α_ (𝟙_ C) X₁ X₂).inv) ≫
+      (𝟙 (𝟙_ C) ⊗ (λ_ _).hom ≫ (ρ_ X₁).inv ⊗ 𝟙 X₂) ≫
+        (𝟙 (𝟙_ C) ⊗ (α_ X₁ (𝟙_ C) X₂).hom) ≫
+          (α_ (𝟙_ C) X₁ (𝟙_ C ⊗ X₂)).inv ≫
+            ((λ_ X₁).hom ≫ (ρ_ X₁).inv ⊗ 𝟙 (𝟙_ C ⊗ X₂)) ≫
+              (α_ X₁ (𝟙_ C) (𝟙_ C ⊗ X₂)).hom ≫
+                (𝟙 X₁ ⊗ 𝟙 (𝟙_ C) ⊗ (λ_ X₂).hom ≫ (ρ_ X₂).inv) ≫
+                  (𝟙 X₁ ⊗ (α_ (𝟙_ C) X₂ (𝟙_ C)).inv) ≫
+                    (𝟙 X₁ ⊗ (λ_ X₂).hom ≫ (ρ_ X₂).inv ⊗ 𝟙 (𝟙_ C)) ≫
+                      (𝟙 X₁ ⊗ (α_ X₂ (𝟙_ C) (𝟙_ C)).hom) ≫
+                        (α_ X₁ X₂ (𝟙_ C ⊗ 𝟙_ C)).inv =
+  (((λ_ (𝟙_ C)).hom ⊗ 𝟙 (X₁ ⊗ X₂)) ≫ (λ_ (X₁ ⊗ X₂)).hom ≫ (ρ_ (X₁ ⊗ X₂)).inv) ≫
+    (𝟙 (X₁ ⊗ X₂) ⊗ (λ_ (𝟙_ C)).inv) :=
+by coherence
+
+end monoidal

--- a/test/coherence.lean
+++ b/test/coherence.lean
@@ -54,10 +54,7 @@ example (X Y : C) :
 by coherence
 example (X Y : C) (f : 𝟙_ C ⟶ X) (g : X ⟶ Y) (w : false) :
   (λ_ (𝟙_ C)).hom ≫ f ≫ 𝟙 X ≫ g = (ρ_ (𝟙_ C)).hom ≫ f ≫ g :=
-begin
-  success_if_fail { coherence },
-  cases w
-end
+by coherence
 
 set_option class.instance_max_depth 52
 


### PR DESCRIPTION
This is an alternative to #12697 (although this one does not handle bicategories!)

From the docstring:
```
Use the coherence theorem for monoidal categories to solve equations in a monoidal equation,
where the two sides only differ by replacing strings of "structural" morphisms with
different strings with the same source and target.

That is, `coherence` can handle goals of the form
`a ≫ f ≫ b ≫ g ≫ c = a' ≫ f ≫ b' ≫ g ≫ c'`
where `a = a'`, `b = b'`, and `c = c'` can be proved using `coherence1`.
```

This PR additionally provides a "composition up to unitors+associators" operation, so you can write
```
example {U V W X Y : C} (f : U ⟶ V ⊗ (W ⊗ X)) (g : (V ⊗ W) ⊗ X ⟶ Y) : U ⟶ Y := f ⊗≫ g
```


---

Co-authored-by: Yuma Mizuno <mizuno.y.aj@gmail.com>
Co-authored-by: Oleksandr Manzyuk <manzyuk@gmail.com>

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
