### PR TITLE
[Merged by Bors] - feat(probability/independence): two lemmas on indep_fun

### DIFF
--- a/src/probability/independence.lean
+++ b/src/probability/independence.lean
@@ -347,7 +347,7 @@ section indep_fun
 variables {α β β' γ γ' : Type*} [measurable_space α] [measurable_space β] [measurable_space β']
 variables [measurable_space γ] [measurable_space γ'] {μ : measure α}
 
-lemma indep_fun_of_indep_fun_of_ae_eq {f g f' g' : α → β} (hfg : indep_fun f g μ)
+lemma indep_fun.ae_eq {f g f' g' : α → β} (hfg : indep_fun f g μ)
   (hf : f =ᵐ[μ] f') (hg : g =ᵐ[μ] g') : indep_fun f' g' μ :=
 begin
   rintro _ _ ⟨A,hA,rfl⟩ ⟨B,hB,rfl⟩,

--- a/src/probability/independence.lean
+++ b/src/probability/independence.lean
@@ -365,7 +365,8 @@ lemma indep_fun.comp {f : α → β} {g : α → β'} (hfg : indep_fun f g μ)
   {φ : β → γ} {ψ : β' → γ'} (hφ : measurable φ) (hψ : measurable ψ) :
   indep_fun (φ ∘ f) (ψ ∘ g) μ :=
 begin
-  rintro _ _ ⟨A,hA,rfl⟩ ⟨B,hB,rfl⟩, apply hfg,
+  rintro _ _ ⟨A, hA, rfl⟩ ⟨B, hB, rfl⟩,
+  apply hfg,
   exact ⟨φ ⁻¹' A, hφ hA, set.preimage_comp.symm⟩,
   exact ⟨ψ ⁻¹' B, hψ hB, set.preimage_comp.symm⟩
 end

--- a/src/probability/independence.lean
+++ b/src/probability/independence.lean
@@ -358,7 +358,7 @@ begin
   have h1 : f ⁻¹' A =ᵐ[μ] f' ⁻¹' A := hf.fun_comp A,
   have h2 : g ⁻¹' B =ᵐ[μ] g' ⁻¹' B := hg.fun_comp B,
   rw [←measure_congr h1, ←measure_congr h2, ←measure_congr (h1.inter h2)],
-  exact hfg _ _ ⟨_,hA,rfl⟩ ⟨_,hB,rfl⟩
+  exact hfg _ _ ⟨_, hA, rfl⟩ ⟨_, hB, rfl⟩
 end
 
 lemma indep_fun.comp {f : α → β} {g : α → β'} (hfg : indep_fun f g μ)

--- a/src/probability/independence.lean
+++ b/src/probability/independence.lean
@@ -344,14 +344,10 @@ end indep_set
 
 section indep_fun
 
-variables {α β β' γ γ' : Type*} {mα : measurable_space α} {mβ : measurable_space β}
-  {mβ' : measurable_space β'} {mγ : measurable_space γ} {mγ' : measurable_space γ'}
-  {μ : measure α}
+variables {α β β' γ γ' : Type*} {mα : measurable_space α} {μ : measure α}
 
-include mα mβ
-
-lemma indep_fun.ae_eq {f g f' g' : α → β} (hfg : indep_fun f g μ)
-  (hf : f =ᵐ[μ] f') (hg : g =ᵐ[μ] g') :
+lemma indep_fun.ae_eq {mβ : measurable_space β} {f g f' g' : α → β}
+  (hfg : indep_fun f g μ) (hf : f =ᵐ[μ] f') (hg : g =ᵐ[μ] g') :
   indep_fun f' g' μ :=
 begin
   rintro _ _ ⟨A, hA, rfl⟩ ⟨B, hB, rfl⟩,
@@ -361,8 +357,10 @@ begin
   exact hfg _ _ ⟨_, hA, rfl⟩ ⟨_, hB, rfl⟩
 end
 
-lemma indep_fun.comp {f : α → β} {g : α → β'} (hfg : indep_fun f g μ)
-  {φ : β → γ} {ψ : β' → γ'} (hφ : measurable φ) (hψ : measurable ψ) :
+lemma indep_fun.comp {mβ : measurable_space β} {mβ' : measurable_space β'}
+  {mγ : measurable_space γ} {mγ' : measurable_space γ'}
+  {f : α → β} {g : α → β'} {φ : β → γ} {ψ : β' → γ'}
+  (hfg : indep_fun f g μ) (hφ : measurable φ) (hψ : measurable ψ) :
   indep_fun (φ ∘ f) (ψ ∘ g) μ :=
 begin
   rintro _ _ ⟨A, hA, rfl⟩ ⟨B, hB, rfl⟩,

--- a/src/probability/independence.lean
+++ b/src/probability/independence.lean
@@ -344,8 +344,11 @@ end indep_set
 
 section indep_fun
 
-variables {α β β' γ γ' : Type*} [measurable_space α] [measurable_space β] [measurable_space β']
-variables [measurable_space γ] [measurable_space γ'] {μ : measure α}
+variables {α β β' γ γ' : Type*} {mα : measurable_space α} {mβ : measurable_space β}
+  {mβ' : measurable_space β'} {mγ : measurable_space γ} {mγ' : measurable_space γ'}
+  {μ : measure α}
+
+include mα mβ
 
 lemma indep_fun.ae_eq {f g f' g' : α → β} (hfg : indep_fun f g μ)
   (hf : f =ᵐ[μ] f') (hg : g =ᵐ[μ] g') :

--- a/src/probability/independence.lean
+++ b/src/probability/independence.lean
@@ -354,7 +354,7 @@ lemma indep_fun.ae_eq {f g f' g' : α → β} (hfg : indep_fun f g μ)
   (hf : f =ᵐ[μ] f') (hg : g =ᵐ[μ] g') :
   indep_fun f' g' μ :=
 begin
-  rintro _ _ ⟨A,hA,rfl⟩ ⟨B,hB,rfl⟩,
+  rintro _ _ ⟨A, hA, rfl⟩ ⟨B, hB, rfl⟩,
   have h1 : f ⁻¹' A =ᵐ[μ] f' ⁻¹' A := hf.fun_comp A,
   have h2 : g ⁻¹' B =ᵐ[μ] g' ⁻¹' B := hg.fun_comp B,
   rw [←measure_congr h1, ←measure_congr h2, ←measure_congr (h1.inter h2)],

--- a/src/probability/independence.lean
+++ b/src/probability/independence.lean
@@ -357,7 +357,7 @@ begin
   exact hfg _ _ ⟨_,hA,rfl⟩ ⟨_,hB,rfl⟩
 end
 
-lemma indep_fun_comp_of_indep_fun {f : α → β} {g : α → β'} (hfg : indep_fun f g μ)
+lemma indep_fun.comp {f : α → β} {g : α → β'} (hfg : indep_fun f g μ)
   {φ : β → γ} {ψ : β' → γ'} (hφ : measurable φ) (hψ : measurable ψ) :
   indep_fun (φ ∘ f) (ψ ∘ g) μ :=
 begin

--- a/src/probability/independence.lean
+++ b/src/probability/independence.lean
@@ -342,4 +342,30 @@ lemma indep_sets.indep_set_of_mem (hs : s ∈ S) (ht : t ∈ T) (hs_meas : measu
 
 end indep_set
 
+section indep_fun
+
+variables {α β β' γ γ' : Type*} [measurable_space α] [measurable_space β] [measurable_space β']
+variables [measurable_space γ] [measurable_space γ'] {μ : measure α}
+
+lemma indep_fun_of_indep_fun_of_ae_eq {f g f' g' : α → β} (hfg : indep_fun f g μ)
+  (hf : f =ᵐ[μ] f') (hg : g =ᵐ[μ] g') : indep_fun f' g' μ :=
+begin
+  rintro _ _ ⟨A,hA,rfl⟩ ⟨B,hB,rfl⟩,
+  have h1 : f ⁻¹' A =ᵐ[μ] f' ⁻¹' A := hf.fun_comp A,
+  have h2 : g ⁻¹' B =ᵐ[μ] g' ⁻¹' B := hg.fun_comp B,
+  rw [←measure_congr h1, ←measure_congr h2, ←measure_congr (h1.inter h2)],
+  exact hfg _ _ ⟨_,hA,rfl⟩ ⟨_,hB,rfl⟩
+end
+
+lemma indep_fun_comp_of_indep_fun {f : α → β} {g : α → β'} (hfg : indep_fun f g μ)
+  {φ : β → γ} {ψ : β' → γ'} (hφ : measurable φ) (hψ : measurable ψ) :
+  indep_fun (φ ∘ f) (ψ ∘ g) μ :=
+begin
+  rintro _ _ ⟨A,hA,rfl⟩ ⟨B,hB,rfl⟩, apply hfg,
+  exact ⟨φ ⁻¹' A, hφ hA, set.preimage_comp.symm⟩,
+  exact ⟨ψ ⁻¹' B, hψ hB, set.preimage_comp.symm⟩
+end
+
+end indep_fun
+
 end probability_theory

--- a/src/probability/independence.lean
+++ b/src/probability/independence.lean
@@ -367,8 +367,8 @@ lemma indep_fun.comp {f : α → β} {g : α → β'} (hfg : indep_fun f g μ)
 begin
   rintro _ _ ⟨A, hA, rfl⟩ ⟨B, hB, rfl⟩,
   apply hfg,
-  exact ⟨φ ⁻¹' A, hφ hA, set.preimage_comp.symm⟩,
-  exact ⟨ψ ⁻¹' B, hψ hB, set.preimage_comp.symm⟩
+  { exact ⟨φ ⁻¹' A, hφ hA, set.preimage_comp.symm⟩ },
+  { exact ⟨ψ ⁻¹' B, hψ hB, set.preimage_comp.symm⟩ }
 end
 
 end indep_fun

--- a/src/probability/independence.lean
+++ b/src/probability/independence.lean
@@ -348,7 +348,8 @@ variables {α β β' γ γ' : Type*} [measurable_space α] [measurable_space β]
 variables [measurable_space γ] [measurable_space γ'] {μ : measure α}
 
 lemma indep_fun.ae_eq {f g f' g' : α → β} (hfg : indep_fun f g μ)
-  (hf : f =ᵐ[μ] f') (hg : g =ᵐ[μ] g') : indep_fun f' g' μ :=
+  (hf : f =ᵐ[μ] f') (hg : g =ᵐ[μ] g') :
+  indep_fun f' g' μ :=
 begin
   rintro _ _ ⟨A,hA,rfl⟩ ⟨B,hB,rfl⟩,
   have h1 : f ⁻¹' A =ᵐ[μ] f' ⁻¹' A := hf.fun_comp A,


### PR DESCRIPTION
These two lemmas show that `indep_fun` is preserved under composition by measurable maps and under a.e. equality.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
