### PR TITLE
[Merged by Bors] - feat(analysis/calculus/fderiv_analytic): an analytic function is smooth

### DIFF
--- a/src/analysis/analytic/composition.lean
+++ b/src/analysis/analytic/composition.lean
@@ -425,9 +425,6 @@ end
 /-! ### Summability properties of the composition of formal power series-/
 section
 
--- this speeds up the proof below a lot, related to leanprover-community/lean#521
-local attribute [-instance] unique.subsingleton
-
 /-- If two formal multilinear series have positive radius of convergence, then the terms appearing
 in the definition of their composition are also summable (when multiplied by a suitable positive
 geometric term). -/
@@ -470,13 +467,13 @@ begin
         ≤ (nnnorm (q c.length) * ∏ i, nnnorm (p (c.blocks_fun i))) * r ^ n :
           mul_le_mul' (q.comp_along_composition_nnnorm p c) le_rfl
     ... = (nnnorm (q c.length) * rq ^ n) * ((∏ i, nnnorm (p (c.blocks_fun i))) * rp ^ n) * r0 ^ n :
-          by { simp only [r, mul_pow], ac_refl }
+          by { simp only [r, mul_pow], ring }
     ... ≤ Cq * Cp ^ n * r0 ^ n : mul_le_mul' (mul_le_mul' A B) le_rfl
     ... = Cq / 4 ^ n :
       begin
         simp only [r0],
         field_simp [mul_pow, (zero_lt_one.trans_le hCp1).ne'],
-        ac_refl
+        ring
       end },
   refine ⟨r, r_pos, nnreal.summable_of_le I _⟩,
   simp_rw div_eq_mul_inv,

--- a/src/analysis/calculus/cont_diff.lean
+++ b/src/analysis/calculus/cont_diff.lean
@@ -80,7 +80,7 @@ can not happen over reals, thanks to partition of unity, but the behavior over a
 not so clear, and we want a definition for general fields). Also, there are locality
 problems for the order parameter: one could image a function which, for each `n`, has a nice
 sequence of derivatives up to order `n`, but they do not coincide for varying `n` and can therefore
-not be  glued to give rise to an infinite sequence of derivatives. This would give a function
+not be glued to give rise to an infinite sequence of derivatives. This would give a function
 which is `C^n` for all `n`, but not `C^∞`. We solve this issue by putting locality conditions
 in space and order in our definition of `cont_diff_within_at` and `cont_diff_on`.
 The resulting definition is slightly more complicated to work with (in fact not so much), but it
@@ -1390,6 +1390,25 @@ begin
   { ext x m,
     rw [iterated_fderiv_succ_apply_left, iterated_fderiv_within_succ_apply_left, IH,
         fderiv_within_univ] }
+end
+
+/-- In an open set, the iterated derivative within this set coincides with the global iterated
+derivative. -/
+lemma iterated_fderiv_within_of_is_open (n : ℕ) (hs : is_open s) :
+  eq_on (iterated_fderiv_within 𝕜 n f s) (iterated_fderiv 𝕜 n f) s :=
+begin
+  induction n with n IH,
+  { assume x hx,
+    ext1 m,
+    simp only [iterated_fderiv_within_zero_apply, iterated_fderiv_zero_apply] },
+  { assume x hx,
+    rw [iterated_fderiv_succ_eq_comp_left, iterated_fderiv_within_succ_eq_comp_left],
+    dsimp,
+    congr' 1,
+    rw fderiv_within_of_open hs hx,
+    apply filter.eventually_eq.fderiv_eq,
+    filter_upwards [hs.mem_nhds hx],
+    exact IH }
 end
 
 lemma ftaylor_series_within_univ :

--- a/src/analysis/calculus/fderiv_analytic.lean
+++ b/src/analysis/calculus/fderiv_analytic.lean
@@ -14,8 +14,6 @@ A function expressible as a power series at a point has a Frechet derivative the
 Also the special case in terms of `deriv` when the domain is 1-dimensional.
 -/
 
-universe u
-
 open filter asymptotics
 open_locale ennreal
 
@@ -165,7 +163,7 @@ lemma analytic_on.deriv [complete_space F] (h : analytic_on 𝕜 f s) :
   analytic_on 𝕜 (deriv f) s :=
 (continuous_linear_map.apply 𝕜 F (1 : 𝕜)).comp_analytic_on h.fderiv
 
-/-- If a function is analytic on a set `s`, so are its successive derivative. -/
+/-- If a function is analytic on a set `s`, so are its successive derivatives. -/
 lemma analytic_on.iterated_deriv [complete_space F] (h : analytic_on 𝕜 f s) (n : ℕ) :
   analytic_on 𝕜 (deriv^[n] f) s :=
 begin

--- a/src/analysis/calculus/fderiv_analytic.lean
+++ b/src/analysis/calculus/fderiv_analytic.lean
@@ -5,6 +5,7 @@ Authors: Yury Kudryashov
 -/
 import analysis.calculus.deriv
 import analysis.analytic.basic
+import analysis.calculus.cont_diff
 
 /-!
 # Frechet derivatives of analytic functions.
@@ -12,6 +13,8 @@ import analysis.analytic.basic
 A function expressible as a power series at a point has a Frechet derivative there.
 Also the special case in terms of `deriv` when the domain is 1-dimensional.
 -/
+
+universe u
 
 open filter asymptotics
 open_locale ennreal
@@ -49,7 +52,7 @@ lemma analytic_at.differentiable_within_at (h : analytic_at 𝕜 f x) :
   differentiable_within_at 𝕜 f s x :=
 h.differentiable_at.differentiable_within_at
 
-lemma has_fpower_series_at.fderiv (h : has_fpower_series_at f p x) :
+lemma has_fpower_series_at.fderiv_eq (h : has_fpower_series_at f p x) :
   fderiv 𝕜 f x = continuous_multilinear_curry_fin1 𝕜 E F (p 1) :=
 h.has_fderiv_at.fderiv
 
@@ -57,6 +60,86 @@ lemma has_fpower_series_on_ball.differentiable_on [complete_space F]
   (h : has_fpower_series_on_ball f p x r) :
   differentiable_on 𝕜 f (emetric.ball x r) :=
 λ y hy, (h.analytic_at_of_mem hy).differentiable_within_at
+
+lemma analytic_on.differentiable_on (h : analytic_on 𝕜 f s) :
+  differentiable_on 𝕜 f s :=
+λ y hy, (h y hy).differentiable_within_at
+
+lemma has_fpower_series_on_ball.has_fderiv_at [complete_space F]
+  (h : has_fpower_series_on_ball f p x r) {y : E} (hy : (∥y∥₊ : ℝ≥0∞) < r) :
+  has_fderiv_at f (continuous_multilinear_curry_fin1 𝕜 E F (p.change_origin y 1)) (x + y) :=
+(h.change_origin hy).has_fpower_series_at.has_fderiv_at
+
+lemma has_fpower_series_on_ball.fderiv_eq [complete_space F]
+  (h : has_fpower_series_on_ball f p x r) {y : E} (hy : (∥y∥₊ : ℝ≥0∞) < r) :
+  fderiv 𝕜 f (x + y) = continuous_multilinear_curry_fin1 𝕜 E F (p.change_origin y 1) :=
+(h.has_fderiv_at hy).fderiv
+
+/-- If a function has a power series on a ball, then so does its derivative. -/
+lemma has_fpower_series_on_ball.fderiv [complete_space F]
+  (h : has_fpower_series_on_ball f p x r) :
+  has_fpower_series_on_ball (fderiv 𝕜 f)
+    ((continuous_multilinear_curry_fin1 𝕜 E F : (E [×1]→L[𝕜] F) →L[𝕜] (E →L[𝕜] F))
+      .comp_formal_multilinear_series (p.change_origin_series 1)) x r :=
+begin
+  suffices A : has_fpower_series_on_ball
+    (λ z, continuous_multilinear_curry_fin1 𝕜 E F (p.change_origin (z - x) 1))
+      ((continuous_multilinear_curry_fin1 𝕜 E F : (E [×1]→L[𝕜] F) →L[𝕜] (E →L[𝕜] F))
+        .comp_formal_multilinear_series (p.change_origin_series 1)) x r,
+  { apply A.congr,
+    assume z hz,
+    dsimp,
+    rw [← h.fderiv_eq, add_sub_cancel'_right],
+    simpa only [edist_eq_coe_nnnorm_sub, emetric.mem_ball] using hz},
+  suffices B : has_fpower_series_on_ball (λ z, p.change_origin (z - x) 1)
+    (p.change_origin_series 1) x r,
+      from (continuous_multilinear_curry_fin1 𝕜 E F).to_continuous_linear_equiv
+        .to_continuous_linear_map.comp_has_fpower_series_on_ball B,
+  simpa using ((p.has_fpower_series_on_ball_change_origin 1 (h.r_pos.trans_le h.r_le)).mono
+    h.r_pos h.r_le).comp_sub x,
+end
+
+/-- If a function is analytic on a set `s`, so is its derivative. -/
+lemma analytic_on.fderiv [complete_space F] (h : analytic_on 𝕜 f s) :
+  analytic_on 𝕜 (fderiv 𝕜 f) s :=
+begin
+  assume y hy,
+  rcases h y hy with ⟨p, r, hp⟩,
+  exact hp.fderiv.analytic_at,
+end
+
+/-- If a function is analytic on a set `s`, so are its successive derivative. -/
+lemma analytic_on.iterated_fderiv [complete_space F] (h : analytic_on 𝕜 f s) (n : ℕ) :
+  analytic_on 𝕜 (iterated_fderiv 𝕜 n f) s :=
+begin
+  induction n with n IH,
+  { rw iterated_fderiv_zero_eq_comp,
+    exact ((continuous_multilinear_curry_fin0 𝕜 E F).symm : F →L[𝕜] (E [×0]→L[𝕜] F))
+      .comp_analytic_on h },
+  { rw iterated_fderiv_succ_eq_comp_left,
+    apply (continuous_multilinear_curry_left_equiv 𝕜 (λ (i : fin (n + 1)), E) F)
+      .to_continuous_linear_equiv.to_continuous_linear_map.comp_analytic_on,
+    exact IH.fderiv }
+end
+
+/-- An analytic function is infinitely differentiable. -/
+lemma analytic_on.cont_diff_on [complete_space F] (h : analytic_on 𝕜 f s) {n : with_top ℕ} :
+  cont_diff_on 𝕜 n f s :=
+begin
+  let t := {x | analytic_at 𝕜 f x},
+  suffices : cont_diff_on 𝕜 n f t, from this.mono h,
+  have H : analytic_on 𝕜 f t := λ x hx, hx,
+  have t_open : is_open t := is_open_analytic_at 𝕜 f,
+  apply cont_diff_on_of_continuous_on_differentiable_on,
+  { assume m hm,
+    apply (H.iterated_fderiv m).continuous_on.congr,
+    assume x hx,
+    exact iterated_fderiv_within_of_is_open _ t_open hx },
+  { assume m hm,
+    apply (H.iterated_fderiv m).differentiable_on.congr,
+    assume x hx,
+    exact iterated_fderiv_within_of_is_open _ t_open hx }
+end
 
 end fderiv
 

--- a/src/analysis/calculus/fderiv_analytic.lean
+++ b/src/analysis/calculus/fderiv_analytic.lean
@@ -99,7 +99,7 @@ begin
     h.r_pos h.r_le).comp_sub x,
 end
 
-/-- If a function is analytic on a set `s`, so is its derivative. -/
+/-- If a function is analytic on a set `s`, so is its Fréchet derivative. -/
 lemma analytic_on.fderiv [complete_space F] (h : analytic_on 𝕜 f s) :
   analytic_on 𝕜 (fderiv 𝕜 f) s :=
 begin
@@ -108,7 +108,7 @@ begin
   exact hp.fderiv.analytic_at,
 end
 
-/-- If a function is analytic on a set `s`, so are its successive derivative. -/
+/-- If a function is analytic on a set `s`, so are its successive Fréchet derivative. -/
 lemma analytic_on.iterated_fderiv [complete_space F] (h : analytic_on 𝕜 f s) (n : ℕ) :
   analytic_on 𝕜 (iterated_fderiv 𝕜 n f) s :=
 begin
@@ -146,7 +146,7 @@ end fderiv
 section deriv
 
 variables {p : formal_multilinear_series 𝕜 𝕜 F} {r : ℝ≥0∞}
-variables {f : 𝕜 → F} {x : 𝕜}
+variables {f : 𝕜 → F} {x : 𝕜} {s : set 𝕜}
 
 protected lemma has_fpower_series_at.has_strict_deriv_at (h : has_fpower_series_at f p x) :
   has_strict_deriv_at f (p 1 (λ _, 1)) x :=
@@ -159,5 +159,19 @@ h.has_strict_deriv_at.has_deriv_at
 protected lemma has_fpower_series_at.deriv (h : has_fpower_series_at f p x) :
   deriv f x = p 1 (λ _, 1) :=
 h.has_deriv_at.deriv
+
+/-- If a function is analytic on a set `s`, so is its derivative. -/
+lemma analytic_on.deriv [complete_space F] (h : analytic_on 𝕜 f s) :
+  analytic_on 𝕜 (deriv f) s :=
+(continuous_linear_map.apply 𝕜 F (1 : 𝕜)).comp_analytic_on h.fderiv
+
+/-- If a function is analytic on a set `s`, so are its successive derivative. -/
+lemma analytic_on.iterated_deriv [complete_space F] (h : analytic_on 𝕜 f s) (n : ℕ) :
+  analytic_on 𝕜 (deriv^[n] f) s :=
+begin
+  induction n with n IH,
+  { exact h },
+  { simpa only [function.iterate_succ', function.comp_app] using IH.deriv }
+end
 
 end deriv

--- a/src/analysis/calculus/formal_multilinear_series.lean
+++ b/src/analysis/calculus/formal_multilinear_series.lean
@@ -115,3 +115,24 @@ normed algebra over `𝕜`. -/
 λ n, (p n).restrict_scalars 𝕜
 
 end formal_multilinear_series
+
+namespace continuous_linear_map
+
+/-- Composing each term `pₙ` in a formal multilinear series with a continuous linear map `f` on the
+left gives a new formal multilinear series `f.comp_formal_multilinear_series p` whose general term
+is `f ∘ pₙ`. -/
+def comp_formal_multilinear_series (f : F →L[𝕜] G) (p : formal_multilinear_series 𝕜 E F) :
+  formal_multilinear_series 𝕜 E G :=
+λ n, f.comp_continuous_multilinear_map (p n)
+
+@[simp] lemma comp_formal_multilinear_series_apply
+  (f : F →L[𝕜] G) (p : formal_multilinear_series 𝕜 E F) (n : ℕ) :
+  (f.comp_formal_multilinear_series p) n = f.comp_continuous_multilinear_map (p n) :=
+rfl
+
+lemma comp_formal_multilinear_series_apply'
+  (f : F →L[𝕜] G) (p : formal_multilinear_series 𝕜 E F) (n : ℕ) (v : fin n → E) :
+  (f.comp_formal_multilinear_series p) n v = f (p n v) :=
+rfl
+
+end continuous_linear_map


### PR DESCRIPTION
This basic fact was missing from the library, but all the nontrivial maths were already there, we are just adding the necessary glue.

Also, replace `ac_refl` by `ring` in several proofs (to go down from 30s to 4s in one proof, for instance). I wonder if we should ban `ac_refl` from mathlib currently.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
