### PR TITLE
[Merged by Bors] - refactor(data/polynomial/basic): overhaul all the misnamed `to_finsupp` lemmas

### DIFF
--- a/src/data/polynomial/algebra_map.lean
+++ b/src/data/polynomial/algebra_map.lean
@@ -49,7 +49,7 @@ rfl
   (algebra_map R (polynomial A) r).to_finsupp = algebra_map R _ r :=
 show to_finsupp (C (algebra_map _ _ r)) = _, by { rw to_finsupp_C, refl }
 
-@[simp] lemma of_finsupp_algebra_map (r : R) :
+lemma of_finsupp_algebra_map (r : R) :
   (⟨algebra_map R _ r⟩ : A[X]) = algebra_map R (polynomial A) r :=
 to_finsupp_injective (to_finsupp_algebra_map _).symm
 

--- a/src/data/polynomial/algebra_map.lean
+++ b/src/data/polynomial/algebra_map.lean
@@ -29,23 +29,29 @@ variables [semiring A] [algebra R A]
 
 /-- Note that this instance also provides `algebra R R[X]`. -/
 instance algebra_of_algebra : algebra R (polynomial A) :=
-{ smul_def' := λ r p, begin
-    rcases p,
-    simp only [C, monomial, monomial_fun, ring_hom.coe_mk, ring_hom.to_fun_eq_coe,
-      function.comp_app, ring_hom.coe_comp, smul_to_finsupp, mul_to_finsupp],
+{ smul_def' := λ r p, to_finsupp_injective $ begin
+    dsimp only [ring_hom.to_fun_eq_coe, ring_hom.comp_apply],
+    rw [to_finsupp_smul, to_finsupp_mul, to_finsupp_C],
     exact algebra.smul_def' _ _,
   end,
-  commutes' := λ r p, begin
-    rcases p,
-    simp only [C, monomial, monomial_fun, ring_hom.coe_mk, ring_hom.to_fun_eq_coe,
-      function.comp_app, ring_hom.coe_comp, mul_to_finsupp],
-    convert algebra.commutes' r p,
+  commutes' := λ r p, to_finsupp_injective $ begin
+    dsimp only [ring_hom.to_fun_eq_coe, ring_hom.comp_apply],
+    simp_rw [to_finsupp_mul, to_finsupp_C],
+    convert algebra.commutes' r p.to_finsupp,
   end,
-  .. C.comp (algebra_map R A) }
+  to_ring_hom := C.comp (algebra_map R A) }
 
 lemma algebra_map_apply (r : R) :
   algebra_map R (polynomial A) r = C (algebra_map R A r) :=
 rfl
+
+@[simp] lemma to_finsupp_algebra_map (r : R) :
+  (algebra_map R (polynomial A) r).to_finsupp = algebra_map R _ r :=
+show to_finsupp (C (algebra_map _ _ r)) = _, by { rw to_finsupp_C, refl }
+
+@[simp] lemma of_finsupp_algebra_map (r : R) :
+  (⟨algebra_map R _ r⟩ : A[X]) = algebra_map R (polynomial A) r :=
+to_finsupp_injective (to_finsupp_algebra_map _).symm
 
 /--
 When we have `[comm_ring R]`, the function `C` is the same as `algebra_map R R[X]`.
@@ -78,8 +84,8 @@ implementation detail, but it can be useful to transfer results from `finsupp` t
 def to_finsupp_iso_alg : R[X] ≃ₐ[R] add_monoid_algebra R ℕ :=
 { commutes' := λ r,
   begin
-    simp only [add_monoid_algebra.coe_algebra_map, algebra.id.map_eq_self, function.comp_app],
-    rw [←C_eq_algebra_map, ←monomial_zero_left, ring_equiv.to_fun_eq_coe, to_finsupp_iso_monomial],
+    dsimp,
+    exact to_finsupp_algebra_map _,
   end,
   ..to_finsupp_iso R }
 

--- a/src/data/polynomial/basic.lean
+++ b/src/data/polynomial/basic.lean
@@ -168,7 +168,8 @@ by rw [←to_finsupp_zero, to_finsupp_inj]
 @[simp] lemma to_finsupp_eq_one {a : R[X]} : a.to_finsupp = 1 ↔ a = 1 :=
 by rw [←to_finsupp_one, to_finsupp_inj]
 
-@[simp] lemma of_finsupp_inj {a b} : (⟨a⟩ : R[X]) = ⟨b⟩ ↔ a = b :=
+/-- A more convenient spelling of `polynomial.of_finsupp.inj_eq` in terms of `iff`. -/
+lemma of_finsupp_inj {a b} : (⟨a⟩ : R[X]) = ⟨b⟩ ↔ a = b :=
 iff_of_eq of_finsupp.inj_eq
 
 @[simp] lemma of_finsupp_eq_zero {a} : (⟨a⟩ : R[X]) = 0 ↔ a = 0 :=
@@ -274,10 +275,6 @@ by simp [monomial, monomial_fun]
 @[simp] lemma of_finsupp_single (n : ℕ) (r : R) :
   (⟨finsupp.single n r⟩ : R[X]) = monomial n r :=
 by simp [monomial, monomial_fun]
-
-@[simp] lemma of_finsupp_of (n : ℕ) :
-  (⟨add_monoid_algebra.of R ℕ (multiplicative.of_add n)⟩ : R[X]) = monomial n 1 :=
-by { rw ←of_finsupp_single, refl }
 
 @[simp]
 lemma monomial_zero_right (n : ℕ) :

--- a/src/data/polynomial/basic.lean
+++ b/src/data/polynomial/basic.lean
@@ -141,7 +141,7 @@ end
 by { cases a, cases b, rw ←of_finsupp_add }
 @[simp] lemma to_finsupp_neg {R : Type u} [ring R] (a : R[X]) : (-a).to_finsupp = -a.to_finsupp :=
 by { cases a, rw ←of_finsupp_neg }
-@[simp] lemma to_finsupp_sub {R : Type u} [ring R] (a b  : R[X]) :
+@[simp] lemma to_finsupp_sub {R : Type u} [ring R] (a b : R[X]) :
   (a - b).to_finsupp = a.to_finsupp - b.to_finsupp :=
 by { rw [sub_eq_add_neg, ←to_finsupp_neg, ←to_finsupp_add], refl }
 @[simp] lemma to_finsupp_mul (a b : R[X]) : (a * b).to_finsupp = a.to_finsupp * b.to_finsupp :=
@@ -767,7 +767,9 @@ lemma C_eq_int_cast (n : ℤ) : C (n : R) = n :=
 end ring
 
 instance [comm_ring R] : comm_ring R[X] :=
-{ .. polynomial.comm_semiring, .. polynomial.ring }
+function.injective.comm_ring to_finsupp to_finsupp_injective
+  to_finsupp_zero to_finsupp_one to_finsupp_add to_finsupp_mul to_finsupp_neg to_finsupp_sub
+  (λ _ _, to_finsupp_smul _ _) (λ _ _, to_finsupp_smul _ _) to_finsupp_pow
 
 section nonzero_semiring
 

--- a/src/data/polynomial/basic.lean
+++ b/src/data/polynomial/basic.lean
@@ -98,7 +98,8 @@ instance {R : Type u} [ring R] : has_sub R[X] := ⟨λ a b, a + -b⟩
 instance : has_mul R[X] := ⟨mul⟩
 instance {S : Type*} [monoid S] [distrib_mul_action S R] : has_scalar S R[X] :=
 ⟨λ r p, ⟨r • p.to_finsupp⟩⟩
-instance : has_pow R[X] ℕ := { pow := λ p n, npow_rec n p }
+@[priority 1]  -- to avoid a bug in the `ring` tactic
+instance has_pow : has_pow R[X] ℕ := { pow := λ p n, npow_rec n p }
 
 @[simp] lemma of_finsupp_zero : (⟨0⟩ : R[X]) = 0 :=
 rfl

--- a/src/data/polynomial/basic.lean
+++ b/src/data/polynomial/basic.lean
@@ -144,6 +144,24 @@ lemma _root_.is_smul_regular.polynomial {S : Type*} [monoid S] [distrib_mul_acti
 lemma to_finsupp_injective : function.injective (to_finsupp : R[X] → add_monoid_algebra _ _) :=
 λ ⟨x⟩ ⟨y⟩, congr_arg _
 
+@[simp] lemma to_finsupp_inj {a b : R[X]} : a.to_finsupp = b.to_finsupp ↔ a = b :=
+to_finsupp_injective.eq_iff
+
+@[simp] lemma to_finsupp_eq_zero {a : R[X]} : a.to_finsupp = 0 ↔ a = 0 :=
+by rw [←to_finsupp_zero, to_finsupp_inj]
+
+@[simp] lemma to_finsupp_eq_one {a : R[X]} : a.to_finsupp = 1 ↔ a = 1 :=
+by rw [←to_finsupp_one, to_finsupp_inj]
+
+@[simp] lemma of_finsupp_inj {a b} : (⟨a⟩ : R[X]) = ⟨b⟩ ↔ a = b :=
+iff_of_eq of_finsupp.inj_eq
+
+@[simp] lemma of_finsupp_eq_zero {a} : (⟨a⟩ : R[X]) = 0 ↔ a = 0 :=
+by rw [←of_finsupp_zero, of_finsupp_inj]
+
+@[simp] lemma of_finsupp_eq_one {a} : (⟨a⟩ : R[X]) = 1 ↔ a = 1 :=
+by rw [←of_finsupp_one, of_finsupp_inj]
+
 instance : inhabited R[X] := ⟨0⟩
 
 instance : semiring R[X] :=
@@ -213,7 +231,7 @@ def support : R[X] → finset ℕ
 rfl
 
 @[simp] lemma support_eq_empty : p.support = ∅ ↔ p = 0 :=
-by { rcases p, simp [support, ← of_finsupp_zero] }
+by { rcases p, simp [support] }
 
 lemma card_support_eq_zero : p.support.card = 0 ↔ p = 0 :=
 by simp
@@ -221,7 +239,7 @@ by simp
 /-- `monomial s a` is the monomial `a * X^s` -/
 def monomial (n : ℕ) : R →ₗ[R] R[X] :=
 { to_fun := monomial_fun n,
-  map_add' := by simp [monomial_fun, ←of_finsupp_add],
+  map_add' := by simp [monomial_fun],
   map_smul' := by simp [monomial_fun, ←of_finsupp_smul] }
 
 @[simp] lemma monomial_to_finsupp (n : ℕ) (r : R) :
@@ -276,14 +294,6 @@ end
 @[simp] lemma monomial_eq_zero_iff (t : R) (n : ℕ) :
   monomial n t = 0 ↔ t = 0 :=
 linear_map.map_eq_zero_iff _ (polynomial.monomial_injective n)
-
-@[simp] lemma op_ring_equiv_monomial (n : ℕ) (r : R) :
-  op_ring_equiv R (mul_opposite.op (monomial n r)) = monomial n (mul_opposite.op r) :=
-begin
-  dsimp [op_ring_equiv],
-end
-
-#exit
 
 lemma support_add : (p + q).support ⊆ p.support ∪ q.support :=
 begin

--- a/src/data/polynomial/coeff.lean
+++ b/src/data/polynomial/coeff.lean
@@ -34,11 +34,11 @@ coeff_monomial
 
 @[simp]
 lemma coeff_add (p q : R[X]) (n : ℕ) : coeff (p + q) n = coeff p n + coeff q n :=
-by { rcases p, rcases q, simp [coeff, add_to_finsupp] }
+by { rcases p, rcases q, simp_rw [←of_finsupp_add, coeff], exact finsupp.add_apply _ _ _ }
 
 @[simp] lemma coeff_smul [monoid S] [distrib_mul_action S R] (r : S) (p : R[X]) (n : ℕ) :
   coeff (r • p) n = r • coeff p n :=
-by { rcases p, simp [coeff, smul_to_finsupp] }
+by { rcases p, simp_rw [←of_finsupp_smul, coeff], exact finsupp.smul_apply _ _ _ }
 
 lemma support_smul [monoid S] [distrib_mul_action S R] (r : S) (p : R[X]) :
   support (r • p) ⊆ support p :=
@@ -87,7 +87,7 @@ lemma coeff_mul (p q : R[X]) (n : ℕ) :
   coeff (p * q) n = ∑ x in nat.antidiagonal n, coeff p x.1 * coeff q x.2 :=
 begin
   rcases p, rcases q,
-  simp only [coeff, mul_to_finsupp],
+  simp_rw [←of_finsupp_mul, coeff],
   exact add_monoid_algebra.mul_apply_antidiagonal p q n _ (λ x, nat.mem_antidiagonal)
 end
 
@@ -108,16 +108,22 @@ lemma coeff_C_mul_X (x : R) (n : ℕ) : coeff (C x * X : R[X]) n = if n = 1 then
 by rw [← pow_one X, coeff_C_mul_X_pow]
 
 @[simp] lemma coeff_C_mul (p : R[X]) : coeff (C a * p) n = a * coeff p n :=
-by { rcases p, simp only [C, monomial, monomial_fun, mul_to_finsupp, ring_hom.coe_mk,
-  coeff, add_monoid_algebra.single_zero_mul_apply p a n] }
+begin
+  rcases p,
+  simp_rw [←monomial_zero_left, ←of_finsupp_single, ←of_finsupp_mul, coeff],
+  exact add_monoid_algebra.single_zero_mul_apply p a n
+end
 
 lemma C_mul' (a : R) (f : R[X]) : C a * f = a • f :=
 by { ext, rw [coeff_C_mul, coeff_smul, smul_eq_mul] }
 
 @[simp] lemma coeff_mul_C (p : R[X]) (n : ℕ) (a : R) :
   coeff (p * C a) n = coeff p n * a :=
-by { rcases p, simp only [C, monomial, monomial_fun, mul_to_finsupp, ring_hom.coe_mk,
-  coeff, add_monoid_algebra.mul_single_zero_apply p a n] }
+begin
+  rcases p,
+  simp_rw [←monomial_zero_left, ←of_finsupp_single, ←of_finsupp_mul, coeff],
+  exact add_monoid_algebra.mul_single_zero_apply p a n
+end
 
 lemma coeff_X_pow (k n : ℕ) :
   coeff (X^k : R[X]) n = if n = k then 1 else 0 :=
@@ -178,7 +184,7 @@ begin
 end
 
 lemma mul_X_injective : function.injective (λ P : R[X], X * P) :=
-by simpa only [pow_one] using mul_X_pow_injective 1
+pow_one (X : R[X]) ▸ mul_X_pow_injective 1
 
 lemma C_mul_X_pow_eq_monomial (c : R) (n : ℕ) : C c * X^n = monomial n c :=
 by { ext1, rw [monomial_eq_smul_X, coeff_smul, coeff_C_mul, smul_eq_mul] }

--- a/src/data/polynomial/eval.lean
+++ b/src/data/polynomial/eval.lean
@@ -125,14 +125,14 @@ end
 
 lemma eval₂_to_finsupp_eq_lift_nc {f : R →+* S} {x : S} {p : add_monoid_algebra R ℕ} :
   eval₂ f x (⟨p⟩ : R[X]) = lift_nc ↑f (powers_hom S x) p :=
-by { simp only [eval₂_eq_sum, sum, sum_to_finsupp, support, coeff], refl }
+by { simp only [eval₂_eq_sum, sum, to_finsupp_sum, support, coeff], refl }
 
 lemma eval₂_mul_noncomm (hf : ∀ k, commute (f $ q.coeff k) x) :
   eval₂ f x (p * q) = eval₂ f x p * eval₂ f x q :=
 begin
   rcases p, rcases q,
   simp only [coeff] at hf,
-  simp only [mul_to_finsupp, eval₂_to_finsupp_eq_lift_nc],
+  simp only [←of_finsupp_mul, eval₂_to_finsupp_eq_lift_nc],
   exact lift_nc_mul _ _ p q (λ k n hn, (hf k).pow_right n)
 end
 

--- a/src/data/polynomial/eval.lean
+++ b/src/data/polynomial/eval.lean
@@ -123,7 +123,7 @@ begin
   rw [sum_insert, eval₂_add, hs, sum_insert]; assumption,
 end
 
-lemma eval₂_to_finsupp_eq_lift_nc {f : R →+* S} {x : S} {p : add_monoid_algebra R ℕ} :
+lemma eval₂_of_finsupp {f : R →+* S} {x : S} {p : add_monoid_algebra R ℕ} :
   eval₂ f x (⟨p⟩ : R[X]) = lift_nc ↑f (powers_hom S x) p :=
 by { simp only [eval₂_eq_sum, sum, to_finsupp_sum, support, coeff], refl }
 
@@ -132,7 +132,7 @@ lemma eval₂_mul_noncomm (hf : ∀ k, commute (f $ q.coeff k) x) :
 begin
   rcases p, rcases q,
   simp only [coeff] at hf,
-  simp only [←of_finsupp_mul, eval₂_to_finsupp_eq_lift_nc],
+  simp only [←of_finsupp_mul, eval₂_of_finsupp],
   exact lift_nc_mul _ _ p q (λ k n hn, (hf k).pow_right n)
 end
 

--- a/src/data/polynomial/monomial.lean
+++ b/src/data/polynomial/monomial.lean
@@ -22,7 +22,10 @@ variables [semiring R] {p q r : R[X]}
 
 lemma monomial_one_eq_iff [nontrivial R] {i j : ℕ} :
   (monomial i 1 : R[X]) = monomial j 1 ↔ i = j :=
-by simp [monomial, monomial_fun, finsupp.single_eq_single_iff]
+begin
+  simp_rw [←of_finsupp_of],
+  exact add_monoid_algebra.of_injective.eq_iff
+end
 
 instance [nontrivial R] : infinite R[X] :=
 infinite.of_injective (λ i, monomial i 1) $

--- a/src/data/polynomial/monomial.lean
+++ b/src/data/polynomial/monomial.lean
@@ -23,7 +23,7 @@ variables [semiring R] {p q r : R[X]}
 lemma monomial_one_eq_iff [nontrivial R] {i j : ℕ} :
   (monomial i 1 : R[X]) = monomial j 1 ↔ i = j :=
 begin
-  simp_rw [←of_finsupp_of],
+  simp_rw [←of_finsupp_single],
   exact add_monoid_algebra.of_injective.eq_iff
 end
 

--- a/src/data/polynomial/reverse.lean
+++ b/src/data/polynomial/reverse.lean
@@ -150,8 +150,9 @@ begin
     -- second induction (right): base case
     { intros N O f g Cf Cg Nf Og,
       rw [← C_mul_X_pow_eq_self Cf, ← C_mul_X_pow_eq_self Cg],
-      simp only [mul_assoc, X_pow_mul, ← pow_add X, reflect_C_mul, reflect_monomial,
-                 add_comm, rev_at_add Nf Og] },
+      simp_rw [mul_assoc, X_pow_mul, mul_assoc, ← pow_add (X : R[X]), reflect_C_mul,
+        reflect_monomial, add_comm, rev_at_add Nf Og, mul_assoc, X_pow_mul, mul_assoc,
+        ← pow_add (X : R[X]), add_comm], },
     -- second induction (right): induction step
     { intros N O f g Cf Cg Nf Og,
       by_cases g0 : g = 0,

--- a/src/data/polynomial/reverse.lean
+++ b/src/data/polynomial/reverse.lean
@@ -109,7 +109,7 @@ end
 
 @[simp] lemma reflect_eq_zero_iff {N : ℕ} {f : R[X]} :
   reflect N (f : R[X]) = 0 ↔ f = 0 :=
-by { rcases f, simp [reflect, ← zero_to_finsupp] }
+by { rcases f, simp [reflect] }
 
 @[simp] lemma reflect_add (f g : R[X]) (N : ℕ) :
   reflect N (f + g) = reflect N f + reflect N g :=

--- a/src/ring_theory/mv_polynomial/basic.lean
+++ b/src/ring_theory/mv_polynomial/basic.lean
@@ -129,6 +129,6 @@ finsupp.basis_single_one.map (to_finsupp_iso_alg R).to_linear_equiv.symm
 
 @[simp] lemma coe_basis_monomials :
   (basis_monomials R : ℕ → R[X]) = λ s, monomial s 1 :=
-_root_.funext $ λ n, to_finsupp_iso_symm_single
+_root_.funext $ λ n, of_finsupp_single _ _
 
 end polynomial

--- a/src/ring_theory/polynomial/basic.lean
+++ b/src/ring_theory/polynomial/basic.lean
@@ -833,7 +833,7 @@ lemma linear_independent_powers_iff_aeval
 begin
   rw linear_independent_iff,
   simp only [finsupp.total_apply, aeval_endomorphism, forall_iff_forall_finsupp, sum, support,
-    coeff, ← zero_to_finsupp],
+    coeff, of_finsupp_eq_zero],
   exact iff.rfl,
 end
 


### PR DESCRIPTION
`zero_to_finsupp` was the statement `of_finsupp 0 = 0`, which doesn't match the name at all.

This change:

* Renames all those lemmas to `of_finsupp_<foo>`
* Changes the direction of `add_to_finsupp` to be `of_finsupp_add`, so the statement is now `of_finsupp (a + b) = _`
* Adds the missing `to_finsupp_<foo>` lemmas
* Uses the new lemmas to golf the semiring and ring instances

The renames include:

* `zero_to_finsupp` → `of_finsupp_zero`
* `one_to_finsupp` → `of_finsupp_one`
* `add_to_finsupp` → `of_finsupp_add` (direction reversed)
* `neg_to_finsupp` → `of_finsupp_neg` (direction reversed)
* `mul_to_finsupp` → `of_finsupp_mul` (direction reversed)
* `smul_to_finsupp` → `of_finsupp_smul` (direction reversed)
* `sum_to_finsupp` → `of_finsupp_sum` (direction reversed)
* `to_finsupp_iso_monomial` → `to_finsupp_monomial`
* `to_finsupp_iso_symm_single` → `of_finsupp_single`
* `eval₂_to_finsupp_eq_lift_nc` → `eval₂_of_finsupp`

The new lemmas include:

* `of_finsupp_sub`
* `of_finsupp_pow`
* `of_finsupp_erase`
* `of_finsupp_algebra_map`
* `of_finsupp_eq_zero`
* `of_finsupp_eq_one`
* `to_finsupp_zero`
* `to_finsupp_one`
* `to_finsupp_add`
* `to_finsupp_neg`
* `to_finsupp_sub`
* `to_finsupp_mul`
* `to_finsupp_pow`
* `to_finsupp_erase`
* `to_finsupp_algebra_map`
* `to_finsupp_eq_zero`
* `to_finsupp_eq_one`
* `to_finsupp_C`

Note that by marking things like `support` and `coeff` as `@[simp]`, they behave as if they were `support_of_finsupp` or `coeff_of_finsupp` lemma. By making `coeff` pattern match fewer arguments, we encourage it to apply more keenly.
Neither lemma will fire unless our expression contains `polynomial.of_finsupp`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)

[This Zulip thread](https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/tactic.23ring.20and.20monoid.2Epow/near/277654945) discusses the CI failure