### PR TITLE
[Merged by Bors] - chore(model_theory/basic): Fix namespace on notation for first-order maps

### DIFF
--- a/src/model_theory/basic.lean
+++ b/src/model_theory/basic.lean
@@ -218,7 +218,7 @@ structure hom :=
 (map_fun' : ∀{n} (f : L.functions n) x, to_fun (fun_map f x) = fun_map f (to_fun ∘ x) . obviously)
 (map_rel' : ∀{n} (r : L.relations n) x, rel_map r x → rel_map r (to_fun ∘ x) . obviously)
 
-localized "notation A ` →[`:25 L `] ` B := L.hom A B" in first_order
+localized "notation A ` →[`:25 L `] ` B := first_order.language.hom L A B" in first_order
 
 /-- An embedding of first-order structures is an embedding that commutes with the
   interpretations of functions and relations. -/
@@ -226,7 +226,7 @@ localized "notation A ` →[`:25 L `] ` B := L.hom A B" in first_order
 (map_fun' : ∀{n} (f : L.functions n) x, to_fun (fun_map f x) = fun_map f (to_fun ∘ x) . obviously)
 (map_rel' : ∀{n} (r : L.relations n) x, rel_map r (to_fun ∘ x) ↔ rel_map r x . obviously)
 
-localized "notation A ` ↪[`:25 L `] ` B := L.embedding A B" in first_order
+localized "notation A ` ↪[`:25 L `] ` B := first_order.language.embedding L A B" in first_order
 
 /-- An equivalence of first-order structures is an equivalence that commutes with the
   interpretations of functions and relations. -/
@@ -234,7 +234,7 @@ structure equiv extends M ≃ N :=
 (map_fun' : ∀{n} (f : L.functions n) x, to_fun (fun_map f x) = fun_map f (to_fun ∘ x) . obviously)
 (map_rel' : ∀{n} (r : L.relations n) x, rel_map r (to_fun ∘ x) ↔ rel_map r x . obviously)
 
-localized "notation A ` ≃[`:25 L `] ` B := L.equiv A B" in first_order
+localized "notation A ` ≃[`:25 L `] ` B := first_order.language.equiv L A B" in first_order
 
 variables {L M N} {P : Type*} [L.Structure P] {Q : Type*} [L.Structure Q]
 

--- a/src/model_theory/elementary_maps.lean
+++ b/src/model_theory/elementary_maps.lean
@@ -37,7 +37,7 @@ structure elementary_embedding :=
 (map_formula' : ∀{n} (φ : L.formula (fin n)) (x : fin n → M),
   φ.realize (to_fun ∘ x) ↔ φ.realize x . obviously)
 
-localized "notation A ` ↪ₑ[`:25 L `] ` B := L.elementary_embedding A B" in first_order
+localized "notation A ` ↪ₑ[`:25 L `] ` B := first_order.language.elementary_embedding L A B" in first_order
 
 variables {L} {M} {N}
 

--- a/src/model_theory/elementary_maps.lean
+++ b/src/model_theory/elementary_maps.lean
@@ -37,7 +37,8 @@ structure elementary_embedding :=
 (map_formula' : ∀{n} (φ : L.formula (fin n)) (x : fin n → M),
   φ.realize (to_fun ∘ x) ↔ φ.realize x . obviously)
 
-localized "notation A ` ↪ₑ[`:25 L `] ` B := first_order.language.elementary_embedding L A B" in first_order
+localized "notation A ` ↪ₑ[`:25 L `] ` B := first_order.language.elementary_embedding L A B"
+  in first_order
 
 variables {L} {M} {N}
 


### PR DESCRIPTION
Removes projection notation from the definition of notation for first-order maps

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
