### PR TITLE
[Merged by Bors] - refactor(analysis/complex): replace `diff_on_int_cont` with `diff_cont_on_cl`

### DIFF
--- a/src/analysis/calculus/diff_on_int_cont.lean
+++ b/src/analysis/calculus/diff_on_int_cont.lean
@@ -20,117 +20,110 @@ variables (𝕜 : Type*) {E F G : Type*} [nondiscrete_normed_field 𝕜] [normed
   [normed_group F] [normed_space 𝕜 E] [normed_space 𝕜 F] [normed_group G] [normed_space 𝕜 G]
   {f g : E → F} {s t : set E} {x : E}
 
-/-- A predicate saying that a function is continuous on a set and is differentiable on its interior.
-This assumption naturally appears in many theorems in complex analysis. -/
-@[protect_proj] structure diff_on_int_cont (f : E → F) (s : set E) : Prop :=
-(differentiable_on : differentiable_on 𝕜 f (interior s))
-(continuous_on : continuous_on f s)
+@[protect_proj] structure diff_cont_on_cl (f : E → F) (s : set E) : Prop :=
+(differentiable_on : differentiable_on 𝕜 f s)
+(continuous_on : continuous_on f (closure s))
 
 variable {𝕜}
 
-lemma differentiable_on.diff_on_int_cont (h : differentiable_on 𝕜 f s) :
-  diff_on_int_cont 𝕜 f s :=
-⟨h.mono interior_subset, h.continuous_on⟩
+lemma differentiable_on.diff_cont_on_cl (h : differentiable_on 𝕜 f (closure s)) :
+  diff_cont_on_cl 𝕜 f s :=
+⟨h.mono subset_closure, h.continuous_on⟩
 
-lemma differentiable.diff_on_int_cont (h : differentiable 𝕜 f) : diff_on_int_cont 𝕜 f s :=
-h.differentiable_on.diff_on_int_cont
+lemma differentiable.diff_cont_on_cl (h : differentiable 𝕜 f) : diff_cont_on_cl 𝕜 f s :=
+⟨h.differentiable_on, h.continuous.continuous_on⟩
 
-lemma diff_on_int_cont_open (hs : is_open s) :
-  diff_on_int_cont 𝕜 f s ↔ differentiable_on 𝕜 f s :=
-⟨λ h, hs.interior_eq ▸ h.differentiable_on, λ h, h.diff_on_int_cont⟩
+lemma is_closed.diff_cont_on_cl_iff (hs : is_closed s) :
+  diff_cont_on_cl 𝕜 f s ↔ differentiable_on 𝕜 f s :=
+⟨λ h, h.differentiable_on, λ h, ⟨h, hs.closure_eq.symm ▸ h.continuous_on⟩⟩
 
-lemma diff_on_int_cont_univ : diff_on_int_cont 𝕜 f univ ↔ differentiable 𝕜 f :=
-(diff_on_int_cont_open is_open_univ).trans differentiable_on_univ
+lemma diff_cont_on_cl_univ : diff_cont_on_cl 𝕜 f univ ↔ differentiable 𝕜 f :=
+is_closed_univ.diff_cont_on_cl_iff.trans differentiable_on_univ
 
-lemma diff_on_int_cont_const {c : F} :
-  diff_on_int_cont 𝕜 (λ x : E, c) s :=
+lemma diff_cont_on_cl_const {c : F} :
+  diff_cont_on_cl 𝕜 (λ x : E, c) s :=
 ⟨differentiable_on_const c, continuous_on_const⟩
 
-lemma differentiable_on.comp_diff_on_int_cont {g : G → E} {t : set G}
-  (hf : differentiable_on 𝕜 f s) (hg : diff_on_int_cont 𝕜 g t) (h : maps_to g t s) :
-  diff_on_int_cont 𝕜 (f ∘ g) t :=
-⟨hf.comp hg.differentiable_on $ h.mono_left interior_subset, hf.continuous_on.comp hg.2 h⟩
+namespace diff_cont_on_cl
 
-lemma differentiable.comp_diff_on_int_cont {g : G → E} {t : set G}
-  (hf : differentiable 𝕜 f) (hg : diff_on_int_cont 𝕜 g t) :
-  diff_on_int_cont 𝕜 (f ∘ g) t :=
-hf.differentiable_on.comp_diff_on_int_cont hg (maps_to_image _ _)
+lemma comp {g : G → E} {t : set G} (hf : diff_cont_on_cl 𝕜 f s) (hg : diff_cont_on_cl 𝕜 g t)
+  (h : maps_to g t s) :
+  diff_cont_on_cl 𝕜 (f ∘ g) t :=
+⟨hf.1.comp hg.1 h, hf.2.comp hg.2 $ h.closure_of_continuous_on hg.2⟩
 
-namespace diff_on_int_cont
-
-lemma comp {g : G → E} {t : set G} (hf : diff_on_int_cont 𝕜 f s) (hg : diff_on_int_cont 𝕜 g t)
-  (h : maps_to g t s) (h' : maps_to g (interior t) (interior s)) :
-  diff_on_int_cont 𝕜 (f ∘ g) t :=
-⟨hf.1.comp hg.1 h', hf.2.comp hg.2 h⟩
-
-lemma differentiable_on_ball {x : E} {r : ℝ} (h : diff_on_int_cont 𝕜 f (closed_ball x r)) :
-  differentiable_on 𝕜 f (ball x r) :=
-h.differentiable_on.mono ball_subset_interior_closed_ball
-
-lemma mk_ball [normed_space ℝ E] {x : E} {r : ℝ} (hd : differentiable_on 𝕜 f (ball x r))
-  (hc : continuous_on f (closed_ball x r)) : diff_on_int_cont 𝕜 f (closed_ball x r) :=
+lemma continuous_on_ball [normed_space ℝ E] {x : E} {r : ℝ} (h : diff_cont_on_cl 𝕜 f (ball x r)) :
+  continuous_on f (closed_ball x r) :=
 begin
-  refine ⟨_, hc⟩,
   rcases eq_or_ne r 0 with rfl|hr,
-  { rw [closed_ball_zero],
-    exact (subsingleton_singleton.mono interior_subset).differentiable_on },
-  { rwa interior_closed_ball x hr }
+  { rw closed_ball_zero,
+    exact continuous_on_singleton f x },
+  { rw ← closure_ball x hr,
+    exact h.continuous_on }
 end
 
-protected lemma differentiable_at (h : diff_on_int_cont 𝕜 f s) (hx : x ∈ interior s) :
+lemma mk_ball [normed_space ℝ E] {x : E} {r : ℝ} (hd : differentiable_on 𝕜 f (ball x r))
+  (hc : continuous_on f (closed_ball x r)) : diff_cont_on_cl 𝕜 f (ball x r) :=
+⟨hd, hc.mono $ closure_ball_subset_closed_ball⟩
+
+protected lemma differentiable_at (h : diff_cont_on_cl 𝕜 f s) (hs : is_open s) (hx : x ∈ s) :
   differentiable_at 𝕜 f x :=
-h.differentiable_on.differentiable_at $ is_open_interior.mem_nhds hx
+h.differentiable_on.differentiable_at $ hs.mem_nhds hx
 
-lemma differentiable_at' (h : diff_on_int_cont 𝕜 f s) (hx : s ∈ 𝓝 x) :
+lemma differentiable_at' (h : diff_cont_on_cl 𝕜 f s) (hx : s ∈ 𝓝 x) :
   differentiable_at 𝕜 f x :=
-h.differentiable_at (mem_interior_iff_mem_nhds.2 hx)
+h.differentiable_on.differentiable_at hx
 
-protected lemma mono (h : diff_on_int_cont 𝕜 f s) (ht : t ⊆ s) : diff_on_int_cont 𝕜 f t :=
-⟨h.differentiable_on.mono (interior_mono ht), h.continuous_on.mono ht⟩
+protected lemma mono (h : diff_cont_on_cl 𝕜 f s) (ht : t ⊆ s) : diff_cont_on_cl 𝕜 f t :=
+⟨h.differentiable_on.mono ht, h.continuous_on.mono (closure_mono ht)⟩
 
-lemma add (hf : diff_on_int_cont 𝕜 f s) (hg : diff_on_int_cont 𝕜 g s) :
-  diff_on_int_cont 𝕜 (f + g) s :=
+lemma add (hf : diff_cont_on_cl 𝕜 f s) (hg : diff_cont_on_cl 𝕜 g s) :
+  diff_cont_on_cl 𝕜 (f + g) s :=
 ⟨hf.1.add hg.1, hf.2.add hg.2⟩
 
-lemma add_const (hf : diff_on_int_cont 𝕜 f s) (c : F) :
-  diff_on_int_cont 𝕜 (λ x, f x + c) s :=
-hf.add diff_on_int_cont_const
+lemma add_const (hf : diff_cont_on_cl 𝕜 f s) (c : F) :
+  diff_cont_on_cl 𝕜 (λ x, f x + c) s :=
+hf.add diff_cont_on_cl_const
 
-lemma const_add (hf : diff_on_int_cont 𝕜 f s) (c : F) :
-  diff_on_int_cont 𝕜 (λ x, c + f x) s :=
-diff_on_int_cont_const.add hf
+lemma const_add (hf : diff_cont_on_cl 𝕜 f s) (c : F) :
+  diff_cont_on_cl 𝕜 (λ x, c + f x) s :=
+diff_cont_on_cl_const.add hf
 
-lemma neg (hf : diff_on_int_cont 𝕜 f s) : diff_on_int_cont 𝕜 (-f) s := ⟨hf.1.neg, hf.2.neg⟩
+lemma neg (hf : diff_cont_on_cl 𝕜 f s) : diff_cont_on_cl 𝕜 (-f) s := ⟨hf.1.neg, hf.2.neg⟩
 
-lemma sub (hf : diff_on_int_cont 𝕜 f s) (hg : diff_on_int_cont 𝕜 g s) :
-  diff_on_int_cont 𝕜 (f - g) s :=
+lemma sub (hf : diff_cont_on_cl 𝕜 f s) (hg : diff_cont_on_cl 𝕜 g s) :
+  diff_cont_on_cl 𝕜 (f - g) s :=
 ⟨hf.1.sub hg.1, hf.2.sub hg.2⟩
 
-lemma sub_const (hf : diff_on_int_cont 𝕜 f s) (c : F) : diff_on_int_cont 𝕜 (λ x, f x - c) s :=
-hf.sub diff_on_int_cont_const
+lemma sub_const (hf : diff_cont_on_cl 𝕜 f s) (c : F) : diff_cont_on_cl 𝕜 (λ x, f x - c) s :=
+hf.sub diff_cont_on_cl_const
 
-lemma const_sub (hf : diff_on_int_cont 𝕜 f s) (c : F) : diff_on_int_cont 𝕜 (λ x, c - f x) s :=
-diff_on_int_cont_const.sub hf
+lemma const_sub (hf : diff_cont_on_cl 𝕜 f s) (c : F) : diff_cont_on_cl 𝕜 (λ x, c - f x) s :=
+diff_cont_on_cl_const.sub hf
 
 lemma const_smul {R : Type*} [semiring R] [module R F] [smul_comm_class 𝕜 R F]
-  [has_continuous_const_smul R F] (hf : diff_on_int_cont 𝕜 f s) (c : R) :
-  diff_on_int_cont 𝕜 (c • f) s :=
+  [has_continuous_const_smul R F] (hf : diff_cont_on_cl 𝕜 f s) (c : R) :
+  diff_cont_on_cl 𝕜 (c • f) s :=
 ⟨hf.1.const_smul c, hf.2.const_smul c⟩
 
 lemma smul {𝕜' : Type*} [nondiscrete_normed_field 𝕜'] [normed_algebra 𝕜 𝕜']
   [normed_space 𝕜' F] [is_scalar_tower 𝕜 𝕜' F] {c : E → 𝕜'} {f : E → F} {s : set E}
-  (hc : diff_on_int_cont 𝕜 c s) (hf : diff_on_int_cont 𝕜 f s) :
-  diff_on_int_cont 𝕜 (λ x, c x • f x) s :=
+  (hc : diff_cont_on_cl 𝕜 c s) (hf : diff_cont_on_cl 𝕜 f s) :
+  diff_cont_on_cl 𝕜 (λ x, c x • f x) s :=
 ⟨hc.1.smul hf.1, hc.2.smul hf.2⟩
 
 lemma smul_const {𝕜' : Type*} [nondiscrete_normed_field 𝕜'] [normed_algebra 𝕜 𝕜']
   [normed_space 𝕜' F] [is_scalar_tower 𝕜 𝕜' F] {c : E → 𝕜'} {s : set E}
-  (hc : diff_on_int_cont 𝕜 c s) (y : F) :
-  diff_on_int_cont 𝕜 (λ x, c x • y) s :=
-hc.smul diff_on_int_cont_const
+  (hc : diff_cont_on_cl 𝕜 c s) (y : F) :
+  diff_cont_on_cl 𝕜 (λ x, c x • y) s :=
+hc.smul diff_cont_on_cl_const
 
-lemma inv {f : E → 𝕜} (hf : diff_on_int_cont 𝕜 f s) (h₀ : ∀ x ∈ s, f x ≠ 0) :
-  diff_on_int_cont 𝕜 f⁻¹ s :=
-⟨differentiable_on_inv.comp hf.1 $ λ x hx, h₀ _ (interior_subset hx), hf.2.inv₀ h₀⟩
+lemma inv {f : E → 𝕜} (hf : diff_cont_on_cl 𝕜 f s) (h₀ : ∀ x ∈ closure s, f x ≠ 0) :
+  diff_cont_on_cl 𝕜 f⁻¹ s :=
+⟨differentiable_on_inv.comp hf.1 $ λ x hx, h₀ _ (subset_closure hx), hf.2.inv₀ h₀⟩
 
-end diff_on_int_cont
+end diff_cont_on_cl
+
+lemma differentiable.comp_diff_cont_on_cl {g : G → E} {t : set G}
+  (hf : differentiable 𝕜 f) (hg : diff_cont_on_cl 𝕜 g t) :
+  diff_cont_on_cl 𝕜 (f ∘ g) t :=
+hf.diff_cont_on_cl.comp hg (maps_to_image _ _)

--- a/src/analysis/calculus/diff_on_int_cont.lean
+++ b/src/analysis/calculus/diff_on_int_cont.lean
@@ -6,10 +6,10 @@ Authors: Yury G. Kudryashov
 import analysis.calculus.deriv
 
 /-!
-# Functions continuous on a domain and differentiable on its interior
+# Functions differentiable on a domain and continuous on its closure
 
-Many theorems in complex analysis assume that a function is continuous on a domain and is complex
-differentiable on its interior. In this file we define a predicate `diff_on_int_cont` that expresses
+Many theorems in complex analysis assume that a function is complex differentiable on a domain and
+is continuous on its closure. In this file we define a predicate `diff_cont_on_cl` that expresses
 this property and prove basic facts about this predicate.
 -/
 
@@ -20,6 +20,8 @@ variables (𝕜 : Type*) {E F G : Type*} [nondiscrete_normed_field 𝕜] [normed
   [normed_group F] [normed_space 𝕜 E] [normed_space 𝕜 F] [normed_group G] [normed_space 𝕜 G]
   {f g : E → F} {s t : set E} {x : E}
 
+/-- A predicate saying that a function is differentiable on a set and is continuous on its
+closure. This is a common assumption in complex analysis. -/
 @[protect_proj] structure diff_cont_on_cl (f : E → F) (s : set E) : Prop :=
 (differentiable_on : differentiable_on 𝕜 f s)
 (continuous_on : continuous_on f (closure s))
@@ -61,7 +63,7 @@ begin
     exact h.continuous_on }
 end
 
-lemma mk_ball [normed_space ℝ E] {x : E} {r : ℝ} (hd : differentiable_on 𝕜 f (ball x r))
+lemma mk_ball {x : E} {r : ℝ} (hd : differentiable_on 𝕜 f (ball x r))
   (hc : continuous_on f (closed_ball x r)) : diff_cont_on_cl 𝕜 f (ball x r) :=
 ⟨hd, hc.mono $ closure_ball_subset_closed_ball⟩
 

--- a/src/analysis/complex/abs_max.lean
+++ b/src/analysis/complex/abs_max.lean
@@ -181,9 +181,9 @@ begin
     (λ x hx y hy, le_trans (hz.2 hy) hx.ge)
 end
 
-/-- **Maximum modulus principle**: if `f : E → F` is complex differentiable on a nonempty compact
-set `K`, then there exists a point `z ∈ frontier K` such that `λ z, ∥f z∥` takes it maximum value on
-`K` at `z`. -/
+/-- **Maximum modulus principle**: if `f : E → F` is complex differentiable on a nonempty bounded
+set `U` and is continuous on its closure, then there exists a point `z ∈ frontier U` such that
+`λ z, ∥f z∥` takes it maximum value on `closure U` at `z`. -/
 lemma exists_mem_frontier_is_max_on_norm [nontrivial E] [finite_dimensional ℂ E]
   {f : E → F} {U : set E} (hb : bounded U) (hne : U.nonempty) (hd : diff_cont_on_cl ℂ f U) :
   ∃ z ∈ frontier U, is_max_on (norm ∘ f) (closure U) z :=
@@ -201,8 +201,8 @@ begin
   exact ball_inf_dist_compl_subset.trans interior_subset
 end
 
-/-- **Maximum modulus principle**: if `f : E → F` is complex differentiable on a compact set `K` and
-`∥f z∥ ≤ C` for any `z ∈ frontier K`, then the same is true for any `z ∈ K`. -/
+/-- **Maximum modulus principle**: if `f : E → F` is complex differentiable on a bounded set `U` and
+`∥f z∥ ≤ C` for any `z ∈ frontier U`, then the same is true for any `z ∈ closure U`. -/
 lemma norm_le_of_forall_mem_frontier_norm_le [nontrivial E] {f : E → F} {U : set E} (hU : bounded U)
   (hd : diff_cont_on_cl ℂ f U) {C : ℝ} (hC : ∀ z ∈ frontier U, ∥f z∥ ≤ C)
   {z : E} (hz : z ∈ closure U) :
@@ -226,9 +226,8 @@ begin
   ... ≤ C : hC _ (hde.continuous.frontier_preimage_subset _ hζU)
 end
 
-
-/-- If two complex differentiable functions `f g : E → F` are equal on the boundary of a compact set
-`K`, then they are equal on `K`. -/
+/-- If two complex differentiable functions `f g : E → F` are equal on the boundary of a bounded set
+`U`, then they are equal on `closure U`. -/
 lemma eq_on_closure_of_eq_on_frontier [nontrivial E] {f g : E → F} {U : set E} (hU : bounded U)
   (hf : diff_cont_on_cl ℂ f U) (hg : diff_cont_on_cl ℂ g U) (hfg : eq_on f g (frontier U)) :
   eq_on f g (closure U) :=
@@ -238,8 +237,8 @@ begin
   simp [hfg hw]
 end
 
-/-- If two complex differentiable functions `f g : E → F` are equal on the boundary of a compact set
-`K`, then they are equal on `K`. -/
+/-- If two complex differentiable functions `f g : E → F` are equal on the boundary of a bounded set
+`U`, then they are equal on `U`. -/
 lemma eq_on_of_eq_on_frontier [nontrivial E] {f g : E → F} {U : set E} (hU : bounded U)
   (hf : diff_cont_on_cl ℂ f U) (hg : diff_cont_on_cl ℂ g U) (hfg : eq_on f g (frontier U)) :
   eq_on f g U :=

--- a/src/analysis/complex/abs_max.lean
+++ b/src/analysis/complex/abs_max.lean
@@ -53,7 +53,7 @@ The only "public API" lemmas in this section are TODO and
 -/
 
 lemma norm_max_aux₁ [complete_space F] {f : ℂ → F} {z w : ℂ}
-  (hd : diff_on_int_cont ℂ f (closed_ball z (dist w z)))
+  (hd : diff_cont_on_cl ℂ f (ball z (dist w z)))
   (hz : is_max_on (norm ∘ f) (closed_ball z (dist w z)) z) :
   ∥f w∥ = ∥f z∥ :=
 begin
@@ -77,7 +77,8 @@ begin
   have hsub : sphere z r ⊆ closed_ball z r, from sphere_subset_closed_ball,
   refine circle_integral.norm_integral_lt_of_norm_le_const_of_lt hr _ _ ⟨w, rfl, _⟩,
   show continuous_on (λ (ζ : ℂ), (ζ - z)⁻¹ • f ζ) (sphere z r),
-  { refine ((continuous_on_id.sub continuous_on_const).inv₀ _).smul (hd.continuous_on.mono hsub),
+  { refine ((continuous_on_id.sub continuous_on_const).inv₀ _).smul
+      (hd.continuous_on_ball.mono hsub),
     exact λ ζ hζ, sub_ne_zero.2 (ne_of_mem_sphere hζ hr.ne') },
   show ∀ ζ ∈ sphere z r, ∥(ζ - z)⁻¹ • f ζ∥ ≤ ∥f z∥ / r,
   { rintros ζ (hζ : abs (ζ - z) = r),
@@ -92,7 +93,7 @@ end
 Now we drop the assumption `complete_space F` by embedding `F` into its completion.
 -/
 
-lemma norm_max_aux₂ {f : ℂ → F} {z w : ℂ} (hd : diff_on_int_cont ℂ f (closed_ball z (dist w z)))
+lemma norm_max_aux₂ {f : ℂ → F} {z w : ℂ} (hd : diff_cont_on_cl ℂ f (ball z (dist w z)))
   (hz : is_max_on (norm ∘ f) (closed_ball z (dist w z)) z) :
   ∥f w∥ = ∥f z∥ :=
 begin
@@ -100,7 +101,7 @@ begin
   have he : ∀ x, ∥e x∥ = ∥x∥, from uniform_space.completion.norm_coe,
   replace hz : is_max_on (norm ∘ (e ∘ f)) (closed_ball z (dist w z)) z,
     by simpa only [is_max_on, (∘), he] using hz,
-  simpa only [he] using norm_max_aux₁ (e.differentiable.comp_diff_on_int_cont hd) hz
+  simpa only [he] using norm_max_aux₁ (e.differentiable.comp_diff_cont_on_cl hd) hz
 end
 
 /-!
@@ -109,14 +110,13 @@ assumption `is_max_on (norm ∘ f) (ball z r) z`.
 -/
 
 lemma norm_max_aux₃ {f : ℂ → F} {z w : ℂ} {r : ℝ} (hr : dist w z = r)
-  (hd : diff_on_int_cont ℂ f (closed_ball z r)) (hz : is_max_on (norm ∘ f) (ball z r) z) :
+  (hd : diff_cont_on_cl ℂ f (ball z r)) (hz : is_max_on (norm ∘ f) (ball z r) z) :
   ∥f w∥ = ∥f z∥ :=
 begin
   subst r,
   rcases eq_or_ne w z with rfl|hne, { refl },
-  have : closure (ball z (dist w z)) = closed_ball z (dist w z),
-    from closure_ball z (dist_ne_zero.2 hne),
-  exact norm_max_aux₂ hd (this ▸ hz.closure (this.symm ▸ hd.continuous_on.norm))
+  rw ← dist_ne_zero at hne,
+  exact norm_max_aux₂ hd (closure_ball z hne ▸ hz.closure hd.continuous_on.norm)
 end
 
 /-!
@@ -127,7 +127,7 @@ Finally, we generalize the theorem from a disk in `ℂ` to a closed ball in any 
 is complex differentiable on the corresponding open ball, and the norm `∥f w∥` takes its maximum
 value on the open ball at its center, then the norm `∥f w∥` is constant on the closed ball.  -/
 lemma norm_eq_on_closed_ball_of_is_max_on {f : E → F} {z : E} {r : ℝ}
-  (hd : diff_on_int_cont ℂ f (closed_ball z r)) (hz : is_max_on (norm ∘ f) (ball z r) z) :
+  (hd : diff_cont_on_cl ℂ f (ball z r)) (hz : is_max_on (norm ∘ f) (ball z r) z) :
   eq_on (norm ∘ f) (const E ∥f z∥) (closed_ball z r) :=
 begin
   intros w hw,
@@ -141,12 +141,8 @@ begin
   { refine ((lipschitz_with_line_map z w).maps_to_ball
       (mt nndist_eq_zero.1 hne) 0 1).mono subset.rfl _,
     simpa only [line_map_apply_zero, mul_one, coe_nndist] using ball_subset_ball hw },
-  refine norm_max_aux₃ hr (diff_on_int_cont.mk_ball
-    (hd.differentiable_on_ball.comp hde.differentiable_on hball)
-    (hd.continuous_on.comp hde.continuous.continuous_on _)) _,
-  { refine ((lipschitz_with_line_map z w).maps_to_closed_ball 0 1).mono_right _,
-    simpa only [line_map_apply_zero, mul_one, coe_nndist] using closed_ball_subset_closed_ball hw },
-  { exact hz.comp_maps_to hball (line_map_apply_zero z w) }
+  exact norm_max_aux₃ hr (hd.comp hde.diff_cont_on_cl hball)
+    (hz.comp_maps_to hball (line_map_apply_zero z w))
 end
 
 /-!
@@ -157,11 +153,9 @@ end
 of `f` takes it maximum on `s` at `z` and `w` is a point such that the closed ball with center `z`
 and radius `dist w z` is included in `s`, then `∥f w∥ = ∥f z∥`. -/
 lemma norm_eq_norm_of_is_max_on_of_closed_ball_subset {f : E → F} {s : set E} {z w : E}
-  (hd : diff_on_int_cont ℂ f s) (hz : is_max_on (norm ∘ f) s z)
-  (hsub : closed_ball z (dist w z) ⊆ s) :
+  (hd : diff_cont_on_cl ℂ f s) (hz : is_max_on (norm ∘ f) s z) (hsub : ball z (dist w z) ⊆ s) :
   ∥f w∥ = ∥f z∥ :=
-norm_eq_on_closed_ball_of_is_max_on (hd.mono hsub)
-  (hz.on_subset $ ball_subset_closed_ball.trans hsub) (mem_closed_ball.2 le_rfl)
+norm_eq_on_closed_ball_of_is_max_on (hd.mono hsub) (hz.on_subset hsub) (mem_closed_ball.2 le_rfl)
 
 /-- **Maximum modulus principle**: if `f : E → F` is complex differentiable in a neighborhood of `c`
 and the norm `∥f z∥` has a local maximum at `c`, then `∥f z∥` is locally constant in a neighborhood
@@ -172,8 +166,9 @@ lemma norm_eventually_eq_of_is_local_max {f : E → F} {c : E}
 begin
   rcases nhds_basis_closed_ball.eventually_iff.1 (hd.and hc) with ⟨r, hr₀, hr⟩,
   exact nhds_basis_closed_ball.eventually_iff.2 ⟨r, hr₀, norm_eq_on_closed_ball_of_is_max_on
-    (differentiable_on.diff_on_int_cont $ λ x hx, (hr hx).1.differentiable_within_at) $
-    λ x hx, (hr $ ball_subset_closed_ball hx).2⟩
+    (differentiable_on.diff_cont_on_cl $
+      λ x hx, (hr $ closure_ball_subset_closed_ball hx).1.differentiable_within_at)
+    (λ x hx, (hr $ ball_subset_closed_ball hx).2)⟩
 end
 
 lemma is_open_set_of_mem_nhds_and_is_max_on_norm {f : E → F} {s : set E}
@@ -189,37 +184,65 @@ end
 /-- **Maximum modulus principle**: if `f : E → F` is complex differentiable on a nonempty compact
 set `K`, then there exists a point `z ∈ frontier K` such that `λ z, ∥f z∥` takes it maximum value on
 `K` at `z`. -/
-lemma exists_mem_frontier_is_max_on_norm [nontrivial E] {f : E → F} {K : set E} (hK : is_compact K)
-  (hne : K.nonempty) (hd : diff_on_int_cont ℂ f K) :
-  ∃ z ∈ frontier K, is_max_on (norm ∘ f) K z :=
+lemma exists_mem_frontier_is_max_on_norm [nontrivial E] [finite_dimensional ℂ E]
+  {f : E → F} {U : set E} (hb : bounded U) (hne : U.nonempty) (hd : diff_cont_on_cl ℂ f U) :
+  ∃ z ∈ frontier U, is_max_on (norm ∘ f) (closure U) z :=
 begin
-  rcases hK.exists_forall_ge hne hd.continuous_on.norm with ⟨w, hwK, hle⟩,
-  rcases hK.exists_mem_frontier_inf_dist_compl_eq_dist hwK with ⟨z, hzK, hzw⟩,
-  refine ⟨z, hzK, λ x hx, (hle x hx).trans_eq _⟩,
-  refine (norm_eq_norm_of_is_max_on_of_closed_ball_subset hd hle _).symm,
-  calc closed_ball w (dist z w) = closed_ball w (inf_dist w Kᶜ) : by rw [hzw, dist_comm]
-  ... ⊆ closure K : closed_ball_inf_dist_compl_subset_closure hwK
-  ... = K : hK.is_closed.closure_eq
+  have hc : is_compact (closure U), from hb.is_compact_closure,
+  obtain ⟨w, hwU, hle⟩ : ∃ w ∈ closure U, is_max_on (norm ∘ f) (closure U) w,
+    from hc.exists_forall_ge hne.closure hd.continuous_on.norm,
+  rw [closure_eq_interior_union_frontier, mem_union_eq] at hwU,
+  cases hwU, rotate, { exact ⟨w, hwU, hle⟩ },
+  have : interior U ≠ univ, from ne_top_of_le_ne_top hc.ne_univ interior_subset_closure,
+  rcases exists_mem_frontier_inf_dist_compl_eq_dist hwU this with ⟨z, hzU, hzw⟩,
+  refine ⟨z, frontier_interior_subset hzU, λ x hx, (mem_set_of_eq.mp $ hle hx).trans_eq _⟩,
+  refine (norm_eq_norm_of_is_max_on_of_closed_ball_subset hd (hle.on_subset subset_closure) _).symm,
+  rw [dist_comm, ← hzw],
+  exact ball_inf_dist_compl_subset.trans interior_subset
 end
 
 /-- **Maximum modulus principle**: if `f : E → F` is complex differentiable on a compact set `K` and
 `∥f z∥ ≤ C` for any `z ∈ frontier K`, then the same is true for any `z ∈ K`. -/
-lemma norm_le_of_forall_mem_frontier_norm_le [nontrivial E] {f : E → F} {K : set E}
-  (hK : is_compact K) (hd : diff_on_int_cont ℂ f K)
-  {C : ℝ} (hC : ∀ z ∈ frontier K, ∥f z∥ ≤ C) {z : E} (hz : z ∈ K) :
+lemma norm_le_of_forall_mem_frontier_norm_le [nontrivial E] {f : E → F} {U : set E} (hU : bounded U)
+  (hd : diff_cont_on_cl ℂ f U) {C : ℝ} (hC : ∀ z ∈ frontier U, ∥f z∥ ≤ C)
+  {z : E} (hz : z ∈ closure U) :
   ∥f z∥ ≤ C :=
-let ⟨w, hwK, hw⟩ := exists_mem_frontier_is_max_on_norm hK ⟨z, hz⟩ hd
-in le_trans (hw hz) (hC w hwK)
+begin
+  rw [closure_eq_self_union_frontier, union_comm, mem_union_eq] at hz,
+  cases hz, { exact hC z hz },
+  /- In case of a finite dimensional domain, one can just apply
+  `complex.exists_mem_frontier_is_max_on_norm`. To make it work in any Banach space, we restrict
+  the function to a line first. -/
+  rcases exists_ne z with ⟨w, hne⟩,
+  set e : ℂ → E := line_map z w,
+  have hde : differentiable ℂ e := (differentiable_id.smul_const (w - z)).add_const z,
+  have hL : antilipschitz_with (nndist z w)⁻¹ e, from antilipschitz_with_line_map hne.symm,
+  replace hd : diff_cont_on_cl ℂ (f ∘ e) (e ⁻¹' U),
+    from hd.comp hde.diff_cont_on_cl (maps_to_preimage _ _),
+  have h₀ : (0 : ℂ) ∈ e ⁻¹' U, by simpa only [e, mem_preimage, line_map_apply_zero],
+  rcases exists_mem_frontier_is_max_on_norm (hL.bounded_preimage hU) ⟨0, h₀⟩ hd with ⟨ζ, hζU, hζ⟩,
+  calc ∥f z∥ = ∥f (e 0)∥ : by simp only [e, line_map_apply_zero]
+  ... ≤ ∥f (e ζ)∥ : hζ (subset_closure h₀)
+  ... ≤ C : hC _ (hde.continuous.frontier_preimage_subset _ hζU)
+end
+
 
 /-- If two complex differentiable functions `f g : E → F` are equal on the boundary of a compact set
 `K`, then they are equal on `K`. -/
-lemma eq_on_of_eq_on_frontier [nontrivial E] {f g : E → F} {K : set E} (hK : is_compact K)
-  (hf : diff_on_int_cont ℂ f K) (hg : diff_on_int_cont ℂ g K) (hfg : eq_on f g (frontier K)) :
-  eq_on f g K :=
+lemma eq_on_closure_of_eq_on_frontier [nontrivial E] {f g : E → F} {U : set E} (hU : bounded U)
+  (hf : diff_cont_on_cl ℂ f U) (hg : diff_cont_on_cl ℂ g U) (hfg : eq_on f g (frontier U)) :
+  eq_on f g (closure U) :=
 begin
-  suffices H : ∀ z ∈ K, ∥f z - g z∥ ≤ 0, by simpa [sub_eq_zero] using H,
-  convert λ z hz, norm_le_of_forall_mem_frontier_norm_le hK (hf.sub hg) _ hz,
-  simpa [sub_eq_zero]
+  suffices H : ∀ z ∈ closure U, ∥(f - g) z∥ ≤ 0, by simpa [sub_eq_zero] using H,
+  refine λ z hz, norm_le_of_forall_mem_frontier_norm_le hU (hf.sub hg) (λ w hw, _) hz,
+  simp [hfg hw]
 end
+
+/-- If two complex differentiable functions `f g : E → F` are equal on the boundary of a compact set
+`K`, then they are equal on `K`. -/
+lemma eq_on_of_eq_on_frontier [nontrivial E] {f g : E → F} {U : set E} (hU : bounded U)
+  (hf : diff_cont_on_cl ℂ f U) (hg : diff_cont_on_cl ℂ g U) (hfg : eq_on f g (frontier U)) :
+  eq_on f g U :=
+(eq_on_closure_of_eq_on_frontier hU hf hg hfg).mono subset_closure
 
 end complex

--- a/src/analysis/complex/cauchy_integral.lean
+++ b/src/analysis/complex/cauchy_integral.lean
@@ -493,22 +493,21 @@ lemma circle_integral_sub_inv_smul_of_differentiable_on_off_countable
 by { rw [← two_pi_I_inv_smul_circle_integral_sub_inv_smul_of_differentiable_on_off_countable
   hs hw hc hd, smul_inv_smul₀], simp [real.pi_ne_zero, I_ne_zero] }
 
-/-- **Cauchy integral formula**: if `f : ℂ → E` is continuous on a closed disc of radius `R` and is
-complex differentiable on its interior, then for any `w` in this interior we have
-$\oint_{|z-c|=R}(z-w)^{-1}f(z)\,dz=2πif(w)$.
--/
-lemma _root_.diff_on_int_cont.circle_integral_sub_inv_smul {R : ℝ} {c w : ℂ} {f : ℂ → E}
-  (h : diff_on_int_cont ℂ f (closed_ball c R)) (hw : w ∈ ball c R) :
+/-- **Cauchy integral formula**: if `f : ℂ → E` is complex differentiable on an open ball and is
+continuous on its closure, then for any `w` in this open ball we have
+$\oint_{|z-c|=R}(z-w)^{-1}f(z)\,dz=2πif(w)$. -/
+lemma _root_.diff_cont_on_cl.circle_integral_sub_inv_smul {R : ℝ} {c w : ℂ} {f : ℂ → E}
+  (h : diff_cont_on_cl ℂ f (ball c R)) (hw : w ∈ ball c R) :
   ∮ z in C(c, R), (z - w)⁻¹ • f z = (2 * π * I : ℂ) • f w :=
 circle_integral_sub_inv_smul_of_differentiable_on_off_countable countable_empty hw
-  h.continuous_on $ λ z hz, h.differentiable_at $ ball_subset_interior_closed_ball hz.1
+  h.continuous_on_ball $ λ x hx, h.differentiable_at is_open_ball hx.1
 
 /-- **Cauchy integral formula**: if `f : ℂ → E` is complex differentiable on a closed disc of radius
 `R`, then for any `w` in its interior we have $\oint_{|z-c|=R}(z-w)^{-1}f(z)\,dz=2πif(w)$. -/
 lemma _root_.differentiable_on.circle_integral_sub_inv_smul {R : ℝ} {c w : ℂ} {f : ℂ → E}
   (hd : differentiable_on ℂ f (closed_ball c R)) (hw : w ∈ ball c R)  :
   ∮ z in C(c, R), (z - w)⁻¹ • f z = (2 * π * I : ℂ) • f w :=
-hd.diff_on_int_cont.circle_integral_sub_inv_smul hw
+(hd.mono closure_ball_subset_closed_ball).diff_cont_on_cl.circle_integral_sub_inv_smul hw
 
 /-- **Cauchy integral formula**: if `f : ℂ → ℂ` is continuous on a closed disc of radius `R` and is
 complex differentiable at all but countably many points of its interior, then for any `w` in this
@@ -544,11 +543,11 @@ lemma has_fpower_series_on_ball_of_differentiable_off_countable {R : ℝ≥0} {c
 /-- If `f : ℂ → E` is continuous on a closed ball of positive radius and is complex differentiable
 on its interior, then it is analytic on the open ball with coefficients of the power series given by
 Cauchy integral formulas. -/
-lemma _root_.diff_on_int_cont.has_fpower_series_on_ball {R : ℝ≥0} {c : ℂ} {f : ℂ → E}
-  (hf : diff_on_int_cont ℂ f (closed_ball c R)) (hR : 0 < R) :
+lemma _root_.diff_cont_on_cl.has_fpower_series_on_ball {R : ℝ≥0} {c : ℂ} {f : ℂ → E}
+  (hf : diff_cont_on_cl ℂ f (ball c R)) (hR : 0 < R) :
   has_fpower_series_on_ball f (cauchy_power_series f c R) c R :=
-has_fpower_series_on_ball_of_differentiable_off_countable countable_empty hf.continuous_on
-  (λ z hz, hf.differentiable_at $ ball_subset_interior_closed_ball hz.1) hR
+has_fpower_series_on_ball_of_differentiable_off_countable countable_empty hf.continuous_on_ball
+  (λ z hz, hf.differentiable_at is_open_ball hz.1) hR
 
 /-- If `f : ℂ → E` is complex differentiable on a closed disc of positive radius, then it is
 analytic on the corresponding open disc, and the coefficients of the power series are given by
@@ -558,7 +557,7 @@ weaker assumptions. -/
 protected lemma _root_.differentiable_on.has_fpower_series_on_ball {R : ℝ≥0} {c : ℂ} {f : ℂ → E}
   (hd : differentiable_on ℂ f (closed_ball c R)) (hR : 0 < R) :
   has_fpower_series_on_ball f (cauchy_power_series f c R) c R :=
-hd.diff_on_int_cont.has_fpower_series_on_ball hR
+(hd.mono closure_ball_subset_closed_ball).diff_cont_on_cl.has_fpower_series_on_ball hR
 
 /-- If `f : ℂ → E` is complex differentiable on some set `s`, then it is analytic at any point `z`
 such that `s ∈ 𝓝 z` (equivalently, `z ∈ interior s`). -/

--- a/src/analysis/complex/cauchy_integral.lean
+++ b/src/analysis/complex/cauchy_integral.lean
@@ -493,7 +493,7 @@ lemma circle_integral_sub_inv_smul_of_differentiable_on_off_countable
 by { rw [← two_pi_I_inv_smul_circle_integral_sub_inv_smul_of_differentiable_on_off_countable
   hs hw hc hd, smul_inv_smul₀], simp [real.pi_ne_zero, I_ne_zero] }
 
-/-- **Cauchy integral formula**: if `f : ℂ → E` is complex differentiable on an open ball and is
+/-- **Cauchy integral formula**: if `f : ℂ → E` is complex differentiable on an open disc and is
 continuous on its closure, then for any `w` in this open ball we have
 $\oint_{|z-c|=R}(z-w)^{-1}f(z)\,dz=2πif(w)$. -/
 lemma _root_.diff_cont_on_cl.circle_integral_sub_inv_smul {R : ℝ} {c w : ℂ} {f : ℂ → E}
@@ -540,8 +540,8 @@ lemma has_fpower_series_on_ball_of_differentiable_off_countable {R : ℝ≥0} {c
         ((hc.mono sphere_subset_closed_ball).circle_integrable R.2) hR).has_sum hw
     end }
 
-/-- If `f : ℂ → E` is continuous on a closed ball of positive radius and is complex differentiable
-on its interior, then it is analytic on the open ball with coefficients of the power series given by
+/-- If `f : ℂ → E` is complex differentiable on an open disc of positive radius and is continuous
+on its closure, then it is analytic on the open disc with coefficients of the power series given by
 Cauchy integral formulas. -/
 lemma _root_.diff_cont_on_cl.has_fpower_series_on_ball {R : ℝ≥0} {c : ℂ} {f : ℂ → E}
   (hf : diff_cont_on_cl ℂ f (ball c R)) (hR : 0 < R) :

--- a/src/analysis/complex/liouville.lean
+++ b/src/analysis/complex/liouville.lean
@@ -31,8 +31,9 @@ local postfix `̂`:100 := uniform_space.completion
 
 namespace complex
 
-/-- If `f` is complex differentiable on a closed disc with center `c` and radius `R > 0`, then
-`f' c` can be represented as an integral over the corresponding circle.
+/-- If `f` is complex differentiable on an open disc with center `c` and radius `R > 0` and is
+continuous on its closure, then `f' c` can be represented as an integral over the corresponding
+circle.
 
 TODO: add a version for `w ∈ metric.ball c R`.
 
@@ -61,9 +62,9 @@ begin
   ... = C / R : by rw [mul_div_comm, div_self_mul_self', div_eq_mul_inv]
 end
 
-/-- If `f` is continuous on a closed disc of radius `R`, is complex differentiable on its interior,
-and its values on the boundary circle of this disc are bounded from above by `C`, then the norm of
-its derivative at the center is at most `C / R`. -/
+/-- If `f` is complex differentiable on an open disc of radius `R > 0`, is continuous on its
+closure, and its values on the boundary circle of this disc are bounded from above by `C`, then the
+norm of its derivative at the center is at most `C / R`. -/
 lemma norm_deriv_le_of_forall_mem_sphere_norm_le {c : ℂ} {R C : ℝ} {f : ℂ → F} (hR : 0 < R)
   (hd : diff_cont_on_cl ℂ f (ball c R)) (hC : ∀ z ∈ sphere c R, ∥f z∥ ≤ C) :
   ∥deriv f c∥ ≤ C / R :=

--- a/src/analysis/complex/liouville.lean
+++ b/src/analysis/complex/liouville.lean
@@ -37,8 +37,8 @@ namespace complex
 TODO: add a version for `w ∈ metric.ball c R`.
 
 TODO: add a version for higher derivatives. -/
-lemma deriv_eq_smul_circle_integral [complete_space F]
-  {R : ℝ} {c : ℂ} {f : ℂ → F} (hR : 0 < R) (hf : diff_on_int_cont ℂ f (closed_ball c R)) :
+lemma deriv_eq_smul_circle_integral [complete_space F] {R : ℝ} {c : ℂ} {f : ℂ → F} (hR : 0 < R)
+  (hf : diff_cont_on_cl ℂ f (ball c R)) :
   deriv f c = (2 * π * I : ℂ)⁻¹ • ∮ z in C(c, R), (z - c) ^ (-2 : ℤ) • f z :=
 begin
   lift R to ℝ≥0 using hR.le,
@@ -48,7 +48,7 @@ begin
 end
 
 lemma norm_deriv_le_aux [complete_space F] {c : ℂ} {R C : ℝ} {f : ℂ → F} (hR : 0 < R)
-  (hf : diff_on_int_cont ℂ f (closed_ball c R)) (hC : ∀ z ∈ sphere c R, ∥f z∥ ≤ C) :
+  (hf : diff_cont_on_cl ℂ f (ball c R)) (hC : ∀ z ∈ sphere c R, ∥f z∥ ≤ C) :
   ∥deriv f c∥ ≤ C / R :=
 begin
   have : ∀ z ∈ sphere c R, ∥(z - c) ^ (-2 : ℤ) • f z∥ ≤ C / (R * R),
@@ -65,17 +65,17 @@ end
 and its values on the boundary circle of this disc are bounded from above by `C`, then the norm of
 its derivative at the center is at most `C / R`. -/
 lemma norm_deriv_le_of_forall_mem_sphere_norm_le {c : ℂ} {R C : ℝ} {f : ℂ → F} (hR : 0 < R)
-  (hd : diff_on_int_cont ℂ f (closed_ball c R)) (hC : ∀ z ∈ sphere c R, ∥f z∥ ≤ C) :
+  (hd : diff_cont_on_cl ℂ f (ball c R)) (hC : ∀ z ∈ sphere c R, ∥f z∥ ≤ C) :
   ∥deriv f c∥ ≤ C / R :=
 begin
   set e : F →L[ℂ] F̂ := uniform_space.completion.to_complL,
   have : has_deriv_at (e ∘ f) (e (deriv f c)) c,
     from e.has_fderiv_at.comp_has_deriv_at c
-      (hd.differentiable_at' $ closed_ball_mem_nhds _ hR).has_deriv_at,
+      (hd.differentiable_at is_open_ball $ mem_ball_self hR).has_deriv_at,
   calc ∥deriv f c∥ = ∥deriv (e ∘ f) c∥ :
     by { rw this.deriv, exact (uniform_space.completion.norm_coe _).symm }
   ... ≤ C / R :
-    norm_deriv_le_aux hR (e.differentiable.comp_diff_on_int_cont hd)
+    norm_deriv_le_aux hR (e.differentiable.comp_diff_cont_on_cl hd)
       (λ z hz, (uniform_space.completion.norm_coe _).trans_le (hC z hz))
 end
 
@@ -91,7 +91,7 @@ begin
       λ z, (hC (f z) (mem_range_self _)).trans (le_max_left _ _)⟩ },
   refine norm_le_zero_iff.1 (le_of_forall_le_of_dense $ λ ε ε₀, _),
   calc ∥deriv f c∥ ≤ C / (C / ε) :
-    norm_deriv_le_of_forall_mem_sphere_norm_le (div_pos C₀ ε₀) hf.diff_on_int_cont (λ z _, hC z)
+    norm_deriv_le_of_forall_mem_sphere_norm_le (div_pos C₀ ε₀) hf.diff_cont_on_cl (λ z _, hC z)
   ... = ε : div_div_cancel' C₀.lt.ne'
 end
 

--- a/src/analysis/complex/schwarz.lean
+++ b/src/analysis/complex/schwarz.lean
@@ -67,16 +67,20 @@ begin
   rw mem_ball at hz,
   filter_upwards [Ioo_mem_nhds_within_Iio ⟨hz, le_rfl⟩] with r hr,
   have hr₀ : 0 < r, from dist_nonneg.trans_lt hr.1,
-  replace hd : differentiable_on ℂ (dslope f c) (closed_ball c r) :=
-    ((differentiable_on_dslope $ ball_mem_nhds _ hR₁).mpr hd).mono (closed_ball_subset_ball hr.2),
-  refine norm_le_of_forall_mem_frontier_norm_le (is_compact_closed_ball c r)
-    hd.diff_on_int_cont _ hr.1.le,
-  rw frontier_closed_ball',
-  intros z hz,
-  have hz' : z ≠ c, by { rintro rfl, simpa [hr₀.ne] using hz },
-  rw [dslope_of_ne _ hz', slope_def_module, norm_smul, norm_inv,
-    (mem_sphere_iff_norm _ _ _).1 hz, ← div_eq_inv_mul, div_le_div_right hr₀, ← dist_eq_norm],
-  exact le_of_lt (h_maps (mem_ball.2 (by { rw mem_sphere.1 hz, exact hr.2 })))
+  replace hd : diff_cont_on_cl ℂ (dslope f c) (ball c r),
+  { refine differentiable_on.diff_cont_on_cl _,
+    rw closure_ball c hr₀.ne',
+    exact ((differentiable_on_dslope $ ball_mem_nhds _ hR₁).mpr hd).mono
+      (closed_ball_subset_ball hr.2) },
+  refine norm_le_of_forall_mem_frontier_norm_le bounded_ball hd _ _,
+  { rw frontier_ball c hr₀.ne',
+    intros z hz,
+    have hz' : z ≠ c, from ne_of_mem_sphere hz hr₀.ne',
+    rw [dslope_of_ne _ hz', slope_def_module, norm_smul, norm_inv,
+      (mem_sphere_iff_norm _ _ _).1 hz, ← div_eq_inv_mul, div_le_div_right hr₀, ← dist_eq_norm],
+    exact le_of_lt (h_maps (mem_ball.2 (by { rw mem_sphere.1 hz, exact hr.2 }))) },
+  { rw [closure_ball c hr₀.ne', mem_closed_ball],
+    exact hr.1.le }
 end
 
 /-- Two cases of the **Schwarz Lemma** (derivative and distance), merged together. -/

--- a/src/analysis/normed_space/add_torsor.lean
+++ b/src/analysis/normed_space/add_torsor.lean
@@ -101,6 +101,14 @@ begin
   exact div_le_div_of_le_of_nonneg (norm_add_le _ _) (norm_nonneg _),
 end
 
+omit V
+include W
+
+lemma antilipschitz_with_line_map [normed_space 𝕜 W] {p₁ p₂ : Q} (h : p₁ ≠ p₂) :
+  antilipschitz_with (nndist p₁ p₂)⁻¹ (line_map p₁ p₂ : 𝕜 → Q) :=
+antilipschitz_with.of_le_mul_dist $ λ c₁ c₂, by rw [dist_line_map_line_map, nnreal.coe_inv,
+  ← dist_nndist, mul_left_comm, inv_mul_cancel (dist_ne_zero.2 h), mul_one]
+
 end normed_space
 
 variables [normed_space ℝ V] [normed_space ℝ W]

--- a/src/analysis/normed_space/add_torsor.lean
+++ b/src/analysis/normed_space/add_torsor.lean
@@ -50,6 +50,15 @@ lemma lipschitz_with_line_map (p₁ p₂ : P) :
 lipschitz_with.of_dist_le_mul $ λ c₁ c₂,
   ((dist_line_map_line_map p₁ p₂ c₁ c₂).trans (mul_comm _ _)).le
 
+omit V
+
+lemma antilipschitz_with_line_map [normed_space 𝕜 W] {p₁ p₂ : Q} (h : p₁ ≠ p₂) :
+  antilipschitz_with (nndist p₁ p₂)⁻¹ (line_map p₁ p₂ : 𝕜 → Q) :=
+antilipschitz_with.of_le_mul_dist $ λ c₁ c₂, by rw [dist_line_map_line_map, nnreal.coe_inv,
+  ← dist_nndist, mul_left_comm, inv_mul_cancel (dist_ne_zero.2 h), mul_one]
+
+include V
+
 @[simp] lemma dist_line_map_left (p₁ p₂ : P) (c : 𝕜) :
   dist (line_map p₁ p₂ c) p₁ = ∥c∥ * dist p₁ p₂ :=
 by simpa only [line_map_apply_zero, dist_zero_right] using dist_line_map_line_map p₁ p₂ c 0
@@ -100,14 +109,6 @@ begin
   rw [midpoint_eq_smul_add, norm_smul, inv_of_eq_inv, norm_inv, ← div_eq_inv_mul],
   exact div_le_div_of_le_of_nonneg (norm_add_le _ _) (norm_nonneg _),
 end
-
-omit V
-include W
-
-lemma antilipschitz_with_line_map [normed_space 𝕜 W] {p₁ p₂ : Q} (h : p₁ ≠ p₂) :
-  antilipschitz_with (nndist p₁ p₂)⁻¹ (line_map p₁ p₂ : 𝕜 → Q) :=
-antilipschitz_with.of_le_mul_dist $ λ c₁ c₂, by rw [dist_line_map_line_map, nnreal.coe_inv,
-  ← dist_nndist, mul_left_comm, inv_mul_cancel (dist_ne_zero.2 h), mul_one]
 
 end normed_space
 

--- a/src/topology/metric_space/hausdorff_distance.lean
+++ b/src/topology/metric_space/hausdorff_distance.lean
@@ -449,6 +449,12 @@ disjoint_left.2 $ λ y hy, not_mem_of_dist_lt_inf_dist $
   calc dist x y = dist y x : dist_comm _ _
   ... < inf_dist x s : hy
 
+lemma ball_inf_dist_subset_compl : ball x (inf_dist x s) ⊆ sᶜ :=
+disjoint_iff_subset_compl_right.1 disjoint_ball_inf_dist
+
+lemma ball_inf_dist_compl_subset : ball x (inf_dist x sᶜ) ⊆ s :=
+ball_inf_dist_subset_compl.trans (compl_compl s).subset
+
 lemma disjoint_closed_ball_of_lt_inf_dist {r : ℝ} (h : r < inf_dist x s) :
   disjoint (closed_ball x r) s :=
 disjoint_ball_inf_dist.mono_left $ closed_ball_subset_ball h


### PR DESCRIPTION
Use "differentiable on a set and continuous on its closure" instead of "continuous on a set and differentiable on its interior".
There are a few reasons to prefer the latter:

* it has better "composition" lemma;
* it allows us to talk about functions that are, e.g., differentiable on `{z : ℂ | abs z < 1 ∧ (re z < 0 ∨ im z ≠ 0)}` and continuous on the closed unit disk.

Also generalize `eq_on_of_eq_on_frontier` from a compact set to a bounded set (so that it works, e.g., for the unit ball in a Banach space).

This PR does not move the file `diff_on_int_cont` to make the diff more readable; the file will be moved in another PR.

---

- [x] fix docstrings: in progress

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
