### PR TITLE
[Merged by Bors] - feat(category_theory/monoidal): upgrades for monoidal equivalences

### DIFF
--- a/src/category_theory/adjunction/basic.lean
+++ b/src/category_theory/adjunction/basic.lean
@@ -474,6 +474,14 @@ mk_of_unit_counit ⟨e.unit, e.counit,
   by { ext, dsimp, simp only [id_comp], exact e.functor_unit_comp _, },
   by { ext, dsimp, simp only [id_comp], exact e.unit_inverse_comp _, }⟩
 
+@[simp] lemma as_equivalence_to_adjunction_unit {e : C ≌ D} :
+  e.functor.as_equivalence.to_adjunction.unit = e.unit :=
+rfl
+
+@[simp] lemma as_equivalence_to_adjunction_counit {e : C ≌ D} :
+  e.functor.as_equivalence.to_adjunction.counit = e.counit :=
+rfl
+
 end equivalence
 
 namespace functor

--- a/src/category_theory/monoidal/functor.lean
+++ b/src/category_theory/monoidal/functor.lean
@@ -430,6 +430,7 @@ def monoidal_adjoint (F : monoidal_functor C D) {G : D ⥤ C} (h : F.to_functor 
   end }.
 
 /-- If a monoidal functor `F` is an equivalence of categories then its inverse is also monoidal. -/
+@[simps]
 noncomputable
 def monoidal_inverse (F : monoidal_functor C D) [is_equivalence F.to_functor] :
   monoidal_functor D C :=

--- a/src/category_theory/monoidal/functor.lean
+++ b/src/category_theory/monoidal/functor.lean
@@ -438,8 +438,4 @@ def monoidal_inverse (F : monoidal_functor C D) [is_equivalence F.to_functor] :
   ε_is_iso := by { dsimp [equivalence.to_adjunction], apply_instance },
   μ_is_iso := λ X Y, by { dsimp [equivalence.to_adjunction], apply_instance } }
 
-@[simp]
-lemma monoidal_inverse_to_functor (F : monoidal_functor C D) [is_equivalence F.to_functor] :
-  (monoidal_inverse F).to_functor = F.to_functor.inv := rfl
-
 end category_theory


### PR DESCRIPTION
(Recall that a "monoidal equivalence" is a functor which is separately monoidal, and an equivalence.
This PR completes the work required to see this is the same as having a monoidal inverse, up to monoidal units and counits.)

* Shows that the unit and counit of a monoidal equivalence have a natural monoidal structure. 
* Previously, when transporting a monoidal structure across a (non-monoidal) equivalence,
we constructed directly the monoidal strength on the inverse functor. In the meantime, @b-mehta has provided a general construction for the monoidal strength on the inverse of any monoidal equivalence, so now we use that.

The proofs of `monoidal_unit` and `monoidal_counit` in `category_theory/monoidal/natural_transformation.lean` are quite ugly. If anyone would like to golf these that would be lovely! :-)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
