### PR TITLE
[Merged by Bors] - feat(ring_theory/polynomial/opposites + data/{polynomial/basic + finsupp/basic}): move `op_ring_equiv` to a new file + lemmas

### DIFF
--- a/src/data/finsupp/basic.lean
+++ b/src/data/finsupp/basic.lean
@@ -523,6 +523,15 @@ support_on_finset_subset
   map_range f hf (single a b) = single a (f b) :=
 ext $ λ a', show f (ite _ _ _) = ite _ _ _, by split_ifs; [refl, exact hf]
 
+lemma support_map_range_of_injective
+  {e : M → N} (he0 : e 0 = 0) (f : ι →₀ M) (he : function.injective e) :
+  (finsupp.map_range e he0 f).support = f.support :=
+begin
+  ext,
+  simp only [finsupp.mem_support_iff, ne.def, finsupp.map_range_apply],
+  exact he.ne_iff' he0,
+end
+
 end map_range
 
 /-! ### Declarations about `emb_domain` -/

--- a/src/data/polynomial/basic.lean
+++ b/src/data/polynomial/basic.lean
@@ -175,12 +175,6 @@ def to_finsupp_iso : R[X] ≃+* add_monoid_algebra R ℕ :=
   map_mul' := by { rintros ⟨⟩ ⟨⟩, simp [mul_to_finsupp] },
   map_add' := by { rintros ⟨⟩ ⟨⟩, simp [add_to_finsupp] } }
 
-/-- Ring isomorphism between `R[X]ᵐᵒᵖ` and `Rᵐᵒᵖ[X]` sending each coefficient of a polynomial
-to the corresponding element of the opposite ring. -/
-@[simps]
-def op_ring_equiv : R[X]ᵐᵒᵖ ≃+* Rᵐᵒᵖ[X] :=
-((to_finsupp_iso R).op.trans add_monoid_algebra.op_ring_equiv).trans (to_finsupp_iso _).symm
-
 variable {R}
 
 lemma sum_to_finsupp {ι : Type*} (s : finset ι) (f : ι → add_monoid_algebra R ℕ) :

--- a/src/ring_theory/polynomial/opposites.lean
+++ b/src/ring_theory/polynomial/opposites.lean
@@ -27,6 +27,7 @@ to the corresponding element of the opposite ring. -/
 def op_ring_equiv (R : Type*) [semiring R] : R[X]ᵐᵒᵖ ≃+* Rᵐᵒᵖ[X] :=
 ((to_finsupp_iso R).op.trans add_monoid_algebra.op_ring_equiv).trans (to_finsupp_iso _).symm
 
+-- for maintenance purposes: `by simp [op_ring_equiv]` proves this lemma
 /-!  Lemmas to get started, using `op_ring_equiv R` on the various expressions of
 `finsupp.single`: `monomial`, `C a`, `X`, `C a * X ^ n`. -/
 @[simp] lemma op_ring_equiv_op_monomial (n : ℕ) (r : R) :

--- a/src/ring_theory/polynomial/opposites.lean
+++ b/src/ring_theory/polynomial/opposites.lean
@@ -34,8 +34,8 @@ def op_ring_equiv (R : Type*) [semiring R] : R[X]ᵐᵒᵖ ≃+* Rᵐᵒᵖ[X] :
 by simp only [op_ring_equiv, ring_equiv.trans_apply, ring_equiv.op_apply_apply,
     ring_equiv.to_add_equiv_eq_coe, add_equiv.mul_op_apply, add_equiv.to_fun_eq_coe,
     add_equiv.coe_trans, op_add_equiv_apply, ring_equiv.coe_to_add_equiv, op_add_equiv_symm_apply,
-    function.comp_app, unop_op, to_finsupp_iso_monomial, add_monoid_algebra.op_ring_equiv_single,
-    to_finsupp_iso_symm_single]
+    function.comp_app, unop_op, to_finsupp_iso_apply, to_finsupp_monomial,
+    add_monoid_algebra.op_ring_equiv_single, to_finsupp_iso_symm_apply, of_finsupp_single]
 
 @[simp] lemma op_ring_equiv_op_C (a : R) :
   op_ring_equiv R (op (C a)) = C (op a) :=
@@ -51,21 +51,21 @@ by simp only [X_pow_mul, op_mul, op_pow, map_mul, map_pow, op_ring_equiv_op_X, o
 
 /-!  Lemmas to get started, using `(op_ring_equiv R).symm` on the various expressions of
 `finsupp.single`: `monomial`, `C a`, `X`, `C a * X ^ n`. -/
-@[simp] lemma op_ring_equiv_symm_op_monomial (n : ℕ) (r : Rᵐᵒᵖ) :
+@[simp] lemma op_ring_equiv_symm_monomial (n : ℕ) (r : Rᵐᵒᵖ) :
   (op_ring_equiv R).symm (monomial n r) = op (monomial n (unop r)) :=
 (op_ring_equiv R).injective (by simp)
 
-@[simp] lemma op_ring_equiv_symm_op_C (a : Rᵐᵒᵖ) :
+@[simp] lemma op_ring_equiv_symm_C (a : Rᵐᵒᵖ) :
   (op_ring_equiv R).symm (C a) = op (C (unop a)) :=
-op_ring_equiv_symm_op_monomial 0 a
+op_ring_equiv_symm_monomial 0 a
 
-@[simp] lemma op_ring_equiv_symm_op_X :
+@[simp] lemma op_ring_equiv_symm_X :
   (op_ring_equiv R).symm (X : Rᵐᵒᵖ[X]) = op X :=
-op_ring_equiv_symm_op_monomial 1 1
+op_ring_equiv_symm_monomial 1 1
 
-lemma op_ring_equiv_symm_op_C_mul_X_pow (r : Rᵐᵒᵖ) (n : ℕ) :
+lemma op_ring_equiv_symm_C_mul_X_pow (r : Rᵐᵒᵖ) (n : ℕ) :
   (op_ring_equiv R).symm (C r * X ^ n : Rᵐᵒᵖ[X]) = op (C (unop r) * X ^ n) :=
-by rw [← monomial_eq_C_mul_X, op_ring_equiv_symm_op_monomial, monomial_eq_C_mul_X]
+by rw [← monomial_eq_C_mul_X, op_ring_equiv_symm_monomial, monomial_eq_C_mul_X]
 
 /-!  Lemmas about more global properties of polynomials and opposites. -/
 @[simp] lemma coeff_op_ring_equiv (p : R[X]ᵐᵒᵖ) (n : ℕ) :

--- a/src/ring_theory/polynomial/opposites.lean
+++ b/src/ring_theory/polynomial/opposites.lean
@@ -24,7 +24,6 @@ namespace polynomial
 
 /-- Ring isomorphism between `R[X]ᵐᵒᵖ` and `Rᵐᵒᵖ[X]` sending each coefficient of a polynomial
 to the corresponding element of the opposite ring. -/
-@[simps]
 def op_ring_equiv (R : Type*) [semiring R] : R[X]ᵐᵒᵖ ≃+* Rᵐᵒᵖ[X] :=
 ((to_finsupp_iso R).op.trans add_monoid_algebra.op_ring_equiv).trans (to_finsupp_iso _).symm
 
@@ -51,17 +50,17 @@ by simp only [X_pow_mul, op_mul, op_pow, map_mul, map_pow, op_ring_equiv_op_X, o
 @[simp] lemma coeff_op_ring_equiv (p : R[X]ᵐᵒᵖ) (n : ℕ) :
   (op_ring_equiv R p).coeff n = op ((unop p).coeff n) :=
 begin
-  nth_rewrite 0 ← op_unop p,
-  generalize' hp' : unop p = p',
-  apply p'.induction_on,
+  induction p using mul_opposite.rec,
+  apply p.induction_on,
   { intros a,
     by_cases n0 : n = 0,
-    { simp only [coeff_C, n0, op_ring_equiv_op_C, eq_self_iff_true, if_true] },
-    { simp only [coeff_C, n0, op_ring_equiv_op_C, if_false, op_zero] } },
+    { simp only [coeff_C, n0, op_ring_equiv_op_C, eq_self_iff_true, if_true, unop_op] },
+    { simp only [coeff_C, n0, op_ring_equiv_op_C, if_false, op_zero, unop_op] } },
   { intros f g hf hg,
-    simp only [hf, hg, op_add, _root_.map_add, coeff_add] },
+    simp only [hf, hg, op_add, _root_.map_add, coeff_add, unop_add] },
   { intros m r hm,
-    rw [op_ring_equiv_op_C_mul_X_pow, coeff_C_mul, coeff_C_mul, op_mul, coeff_X_pow, coeff_X_pow],
+    rw [op_ring_equiv_op_C_mul_X_pow, coeff_C_mul, op_mul, unop_mul, unop_op, coeff_C_mul, op_mul,
+      unop_op, coeff_X_pow, coeff_X_pow],
     split_ifs;
     simp }
 end

--- a/src/ring_theory/polynomial/opposites.lean
+++ b/src/ring_theory/polynomial/opposites.lean
@@ -28,7 +28,7 @@ def op_ring_equiv (R : Type*) [semiring R] : R[X]ᵐᵒᵖ ≃+* Rᵐᵒᵖ[X] :
 ((to_finsupp_iso R).op.trans add_monoid_algebra.op_ring_equiv).trans (to_finsupp_iso _).symm
 
 @[simp] lemma op_ring_equiv_op_monomial (n : ℕ) (r : R) :
-  (op_ring_equiv R) (op (monomial n r : R[X])) = monomial n (op r) :=
+  op_ring_equiv R (op (monomial n r : R[X])) = monomial n (op r) :=
 by simp only [op_ring_equiv, ring_equiv.trans_apply, ring_equiv.op_apply_apply,
     ring_equiv.to_add_equiv_eq_coe, add_equiv.mul_op_apply, add_equiv.to_fun_eq_coe,
     add_equiv.coe_trans, op_add_equiv_apply, ring_equiv.coe_to_add_equiv, op_add_equiv_symm_apply,
@@ -36,15 +36,15 @@ by simp only [op_ring_equiv, ring_equiv.trans_apply, ring_equiv.op_apply_apply,
     to_finsupp_iso_symm_single]
 
 @[simp] lemma op_ring_equiv_op_C (a : R) :
-  (op_ring_equiv R) (op (C a)) = C (op a) :=
+  op_ring_equiv R (op (C a)) = C (op a) :=
 op_ring_equiv_op_monomial 0 a
 
 @[simp] lemma op_ring_equiv_op_X :
-  (op_ring_equiv R) (op (X : R[X])) = X :=
+  op_ring_equiv R (op (X : R[X])) = X :=
 op_ring_equiv_op_monomial 1 1
 
 lemma op_ring_equiv_op_C_mul_X_pow (r : R) (n : ℕ) :
-  (op_ring_equiv R) (op (C r * X ^ n : R[X])) = C (op r) * X ^ n :=
+  op_ring_equiv R (op (C r * X ^ n : R[X])) = C (op r) * X ^ n :=
 by simp only [X_pow_mul, op_mul, op_pow, map_mul, map_pow, op_ring_equiv_op_X, op_ring_equiv_op_C]
 
 @[simp] lemma coeff_op_ring_equiv (p : R[X]ᵐᵒᵖ) (n : ℕ) :

--- a/src/ring_theory/polynomial/opposites.lean
+++ b/src/ring_theory/polynomial/opposites.lean
@@ -51,26 +51,26 @@ by simp only [X_pow_mul, op_mul, op_pow, map_mul, map_pow, op_ring_equiv_op_X, o
   (op_ring_equiv R p).coeff n = op ((unop p).coeff n) :=
 begin
   induction p using mul_opposite.rec,
-  apply p.induction_on,
-  { intros a,
-    by_cases n0 : n = 0,
-    { simp only [coeff_C, n0, op_ring_equiv_op_C, eq_self_iff_true, if_true, unop_op] },
-    { simp only [coeff_C, n0, op_ring_equiv_op_C, if_false, op_zero, unop_op] } },
-  { intros f g hf hg,
-    simp only [hf, hg, op_add, _root_.map_add, coeff_add, unop_add] },
-  { intros m r hm,
-    rw [op_ring_equiv_op_C_mul_X_pow, coeff_C_mul, op_mul, unop_mul, unop_op, coeff_C_mul, op_mul,
-      unop_op, coeff_X_pow, coeff_X_pow],
-    split_ifs;
-    simp }
+  cases p,
+  refl
+end
+
+-- TODO: move to finsupp/basic
+lemma finsupp.support_map_range_of_injective {ι α β} [has_zero α] [has_zero β]
+  {e : α → β} (he0 : e 0 = 0) (f : ι →₀ α) (he : function.injective e) :
+  (finsupp.map_range e he0 f).support = f.support :=
+begin
+  ext,
+  simp only [finsupp.mem_support_iff, ne.def, finsupp.map_range_apply],
+  exact he.ne_iff' he0,
 end
 
 @[simp] lemma support_op_ring_equiv (p : R[X]ᵐᵒᵖ) :
   (op_ring_equiv R p).support = (unop p).support :=
 begin
-  ext,
-  rw [mem_support_iff, mem_support_iff, ne.def, coeff_op_ring_equiv],
-  simp only [op_eq_zero_iff],
+  induction p using mul_opposite.rec,
+  cases p,
+  exact support_map_range_of_injective _ _ op_injective
 end
 
 @[simp] lemma nat_degree_op_ring_equiv (p : R[X]ᵐᵒᵖ) :

--- a/src/ring_theory/polynomial/opposites.lean
+++ b/src/ring_theory/polynomial/opposites.lean
@@ -27,6 +27,8 @@ to the corresponding element of the opposite ring. -/
 def op_ring_equiv (R : Type*) [semiring R] : R[X]ᵐᵒᵖ ≃+* Rᵐᵒᵖ[X] :=
 ((to_finsupp_iso R).op.trans add_monoid_algebra.op_ring_equiv).trans (to_finsupp_iso _).symm
 
+/-!  Lemmas to get started, using `op_ring_equiv R` on the various expressions of
+`finsupp.single`: `monomial`, `C a`, `X`, `C a * X ^ n`. -/
 @[simp] lemma op_ring_equiv_op_monomial (n : ℕ) (r : R) :
   op_ring_equiv R (op (monomial n r : R[X])) = monomial n (op r) :=
 by simp only [op_ring_equiv, ring_equiv.trans_apply, ring_equiv.op_apply_apply,
@@ -47,6 +49,25 @@ lemma op_ring_equiv_op_C_mul_X_pow (r : R) (n : ℕ) :
   op_ring_equiv R (op (C r * X ^ n : R[X])) = C (op r) * X ^ n :=
 by simp only [X_pow_mul, op_mul, op_pow, map_mul, map_pow, op_ring_equiv_op_X, op_ring_equiv_op_C]
 
+/-!  Lemmas to get started, using `(op_ring_equiv R).symm` on the various expressions of
+`finsupp.single`: `monomial`, `C a`, `X`, `C a * X ^ n`. -/
+@[simp] lemma op_ring_equiv_symm_op_monomial (n : ℕ) (r : Rᵐᵒᵖ) :
+  (op_ring_equiv R).symm (monomial n r) = op (monomial n (unop r)) :=
+(op_ring_equiv R).injective (by simp)
+
+@[simp] lemma op_ring_equiv_symm_op_C (a : Rᵐᵒᵖ) :
+  (op_ring_equiv R).symm (C a) = op (C (unop a)) :=
+op_ring_equiv_symm_op_monomial 0 a
+
+@[simp] lemma op_ring_equiv_symm_op_X :
+  (op_ring_equiv R).symm (X : Rᵐᵒᵖ[X]) = op X :=
+op_ring_equiv_symm_op_monomial 1 1
+
+lemma op_ring_equiv_symm_op_C_mul_X_pow (r : Rᵐᵒᵖ) (n : ℕ) :
+  (op_ring_equiv R).symm (C r * X ^ n : Rᵐᵒᵖ[X]) = op (C (unop r) * X ^ n) :=
+by rw [← monomial_eq_C_mul_X, op_ring_equiv_symm_op_monomial, monomial_eq_C_mul_X]
+
+/-!  Lemmas about more global properties of polynomials and opposites. -/
 @[simp] lemma coeff_op_ring_equiv (p : R[X]ᵐᵒᵖ) (n : ℕ) :
   (op_ring_equiv R p).coeff n = op ((unop p).coeff n) :=
 begin

--- a/src/ring_theory/polynomial/opposites.lean
+++ b/src/ring_theory/polynomial/opposites.lean
@@ -60,7 +60,7 @@ end
 begin
   induction p using mul_opposite.rec,
   cases p,
-  exact support_map_range_of_injective _ _ op_injective
+  exact finsupp.support_map_range_of_injective _ _ op_injective
 end
 
 @[simp] lemma nat_degree_op_ring_equiv (p : R[X]ᵐᵒᵖ) :

--- a/src/ring_theory/polynomial/opposites.lean
+++ b/src/ring_theory/polynomial/opposites.lean
@@ -1,0 +1,90 @@
+/-
+Copyright (c) 2022 Damiano Testa. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Damiano Testa
+-/
+
+import data.polynomial.induction
+import data.polynomial.degree.definitions
+
+/-!  #  Interactions between `R[X]` and `Rᵐᵒᵖ[X]`
+
+This file contains the basic API for "pushing through" the isomorphism
+`op_ring_equiv : R[X]ᵐᵒᵖ ≃+* Rᵐᵒᵖ[X]`.  It allows going back and forth between a polynomial ring
+over a semiring and the polynomial ring over the opposite semiring. -/
+
+open_locale polynomial
+open polynomial mul_opposite
+
+variables {R : Type*} [semiring R] {p q : R[X]}
+
+noncomputable theory
+
+namespace polynomial
+
+/-- Ring isomorphism between `R[X]ᵐᵒᵖ` and `Rᵐᵒᵖ[X]` sending each coefficient of a polynomial
+to the corresponding element of the opposite ring. -/
+@[simps]
+def op_ring_equiv (R : Type*) [semiring R] : R[X]ᵐᵒᵖ ≃+* Rᵐᵒᵖ[X] :=
+((to_finsupp_iso R).op.trans add_monoid_algebra.op_ring_equiv).trans (to_finsupp_iso _).symm
+
+@[simp] lemma op_ring_equiv_op_monomial (n : ℕ) (r : R) :
+  (op_ring_equiv R) (op (monomial n r : R[X])) = monomial n (op r) :=
+by simp only [op_ring_equiv, ring_equiv.trans_apply, ring_equiv.op_apply_apply,
+    ring_equiv.to_add_equiv_eq_coe, add_equiv.mul_op_apply, add_equiv.to_fun_eq_coe,
+    add_equiv.coe_trans, op_add_equiv_apply, ring_equiv.coe_to_add_equiv, op_add_equiv_symm_apply,
+    function.comp_app, unop_op, to_finsupp_iso_monomial, add_monoid_algebra.op_ring_equiv_single,
+    to_finsupp_iso_symm_single]
+
+@[simp] lemma op_ring_equiv_op_C (a : R) :
+  (op_ring_equiv R) (op (C a)) = C (op a) :=
+op_ring_equiv_op_monomial 0 a
+
+@[simp] lemma op_ring_equiv_op_X :
+  (op_ring_equiv R) (op (X : R[X])) = X :=
+op_ring_equiv_op_monomial 1 1
+
+lemma op_ring_equiv_op_C_mul_X_pow (r : R) (n : ℕ) :
+  (op_ring_equiv R) (op (C r * X ^ n : R[X])) = C (op r) * X ^ n :=
+by simp only [X_pow_mul, op_mul, op_pow, map_mul, map_pow, op_ring_equiv_op_X, op_ring_equiv_op_C]
+
+@[simp] lemma coeff_op_ring_equiv (p : R[X]ᵐᵒᵖ) (n : ℕ) :
+  (op_ring_equiv R p).coeff n = op ((unop p).coeff n) :=
+begin
+  nth_rewrite 0 ← op_unop p,
+  generalize' hp' : unop p = p',
+  apply p'.induction_on,
+  { intros a,
+    by_cases n0 : n = 0,
+    { simp only [coeff_C, n0, op_ring_equiv_op_C, eq_self_iff_true, if_true] },
+    { simp only [coeff_C, n0, op_ring_equiv_op_C, if_false, op_zero] } },
+  { intros f g hf hg,
+    simp only [hf, hg, op_add, _root_.map_add, coeff_add] },
+  { intros m r hm,
+    rw [op_ring_equiv_op_C_mul_X_pow, coeff_C_mul, coeff_C_mul, op_mul, coeff_X_pow, coeff_X_pow],
+    split_ifs;
+    simp }
+end
+
+@[simp] lemma support_op_ring_equiv (p : R[X]ᵐᵒᵖ) :
+  (op_ring_equiv R p).support = (unop p).support :=
+begin
+  ext,
+  rw [mem_support_iff, mem_support_iff, ne.def, coeff_op_ring_equiv],
+  simp only [op_eq_zero_iff],
+end
+
+@[simp] lemma nat_degree_op_ring_equiv (p : R[X]ᵐᵒᵖ) :
+  (op_ring_equiv R p).nat_degree = (unop p).nat_degree :=
+begin
+  by_cases p0 : p = 0,
+  { simp only [p0, _root_.map_zero, nat_degree_zero, unop_zero] },
+  { simp only [p0, nat_degree_eq_support_max', ne.def, add_equiv_class.map_eq_zero_iff,
+      not_false_iff, support_op_ring_equiv, unop_eq_zero_iff] }
+end
+
+@[simp] lemma leading_coeff_op_ring_equiv (p : R[X]ᵐᵒᵖ) :
+  (op_ring_equiv R p).leading_coeff = op (unop p).leading_coeff :=
+by rw [leading_coeff, coeff_op_ring_equiv, nat_degree_op_ring_equiv, leading_coeff]
+
+end polynomial

--- a/src/ring_theory/polynomial/opposites.lean
+++ b/src/ring_theory/polynomial/opposites.lean
@@ -55,16 +55,6 @@ begin
   refl
 end
 
--- TODO: move to finsupp/basic
-lemma finsupp.support_map_range_of_injective {ι α β} [has_zero α] [has_zero β]
-  {e : α → β} (he0 : e 0 = 0) (f : ι →₀ α) (he : function.injective e) :
-  (finsupp.map_range e he0 f).support = f.support :=
-begin
-  ext,
-  simp only [finsupp.mem_support_iff, ne.def, finsupp.map_range_apply],
-  exact he.ne_iff' he0,
-end
-
 @[simp] lemma support_op_ring_equiv (p : R[X]ᵐᵒᵖ) :
   (op_ring_equiv R p).support = (unop p).support :=
 begin


### PR DESCRIPTION
This PR moves the isomorphism `R[X]ᵐᵒᵖ ≃+* Rᵐᵒᵖ[X]` to a new file `ring_theory.polynomial.opposites`.

I also proved some basic lemmas about the equivalence.

[Zulip discussion](https://leanprover.zulipchat.com/#narrow/stream/113489-new-members)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
