### PR TITLE
[Merged by Bors] - feat(data/polynomial/basic): add simp lemmas X_mul_C and X_pow_mul_C

### DIFF
--- a/src/data/polynomial/basic.lean
+++ b/src/data/polynomial/basic.lean
@@ -352,7 +352,7 @@ by rw [mul_assoc, X_pow_mul, ←mul_assoc]
 /-- Prefer putting constants to the left of `X ^ n`.
 
 This lemma is the loop-avoiding `simp` version of `X_pow_mul_assoc`. -/
-@[simp] lemma X_pow_mul_assoc_C {n : ℕ} (r s : R) : (C r * X^n) * C s = C r * C s * X^n :=
+@[simp] lemma X_pow_mul_assoc_C {n : ℕ} (r : R) : (p * X^n) * C r = p * C r * X^n :=
 X_pow_mul_assoc
 
 lemma commute_X (p : R[X]) : commute X p := X_mul

--- a/src/data/polynomial/basic.lean
+++ b/src/data/polynomial/basic.lean
@@ -334,6 +334,14 @@ begin
     rw [mul_assoc, X_mul, ←mul_assoc, ih, mul_assoc, ←pow_succ'], }
 end
 
+/--  This lemma is the loop-avoiding `simp` version of `X_mul`. -/
+@[simp] lemma X_mul_C {r : R} : X * C r = C r * X :=
+X_mul
+
+/--  This lemma is the loop-avoiding `simp` version of `X_pow_mul`. -/
+@[simp] lemma X_pow_mul_C {r : R} {n : ℕ} : X^n * C r = C r * X^n :=
+X_pow_mul
+
 lemma X_pow_mul_assoc {n : ℕ} : (p * X^n) * q = (p * q) * X^n :=
 by rw [mul_assoc, X_pow_mul, ←mul_assoc]
 

--- a/src/data/polynomial/basic.lean
+++ b/src/data/polynomial/basic.lean
@@ -340,12 +340,20 @@ This lemma is the loop-avoiding `simp` version of `polynomial.X_mul`. -/
 @[simp] lemma X_mul_C (r : R) : X * C r = C r * X :=
 X_mul
 
-/--  This lemma is the loop-avoiding `simp` version of `X_pow_mul`. -/
+/-- Prefer putting constants to the left of `X ^ n`.
+
+This lemma is the loop-avoiding `simp` version of `X_pow_mul`. -/
 @[simp] lemma X_pow_mul_C (r : R) (n : ℕ) : X^n * C r = C r * X^n :=
 X_pow_mul
 
 lemma X_pow_mul_assoc {n : ℕ} : (p * X^n) * q = (p * q) * X^n :=
 by rw [mul_assoc, X_pow_mul, ←mul_assoc]
+
+/-- Prefer putting constants to the left of `X ^ n`.
+
+This lemma is the loop-avoiding `simp` version of `X_pow_mul_assoc`. -/
+@[simp] lemma X_pow_mul_assoc_C {n : ℕ} (r s : R) : (C r * X^n) * C s = C r * C s * X^n :=
+X_pow_mul_assoc
 
 lemma commute_X (p : R[X]) : commute X p := X_mul
 

--- a/src/data/polynomial/basic.lean
+++ b/src/data/polynomial/basic.lean
@@ -334,12 +334,14 @@ begin
     rw [mul_assoc, X_mul, ←mul_assoc, ih, mul_assoc, ←pow_succ'], }
 end
 
-/--  This lemma is the loop-avoiding `simp` version of `X_mul`. -/
-@[simp] lemma X_mul_C {r : R} : X * C r = C r * X :=
+/-- Prefer putting constants to the left of `X`.
+
+This lemma is the loop-avoiding `simp` version of `polynomial.X_mul`. -/
+@[simp] lemma X_mul_C (r : R) : X * C r = C r * X :=
 X_mul
 
 /--  This lemma is the loop-avoiding `simp` version of `X_pow_mul`. -/
-@[simp] lemma X_pow_mul_C {r : R} {n : ℕ} : X^n * C r = C r * X^n :=
+@[simp] lemma X_pow_mul_C (r : R) (n : ℕ) : X^n * C r = C r * X^n :=
 X_pow_mul
 
 lemma X_pow_mul_assoc {n : ℕ} : (p * X^n) * q = (p * q) * X^n :=

--- a/src/linear_algebra/eigenspace.lean
+++ b/src/linear_algebra/eigenspace.lean
@@ -145,7 +145,8 @@ begin
   { intros p q hp hq, simp [hp, hq, add_smul] },
   { intros n a hna,
     rw [mul_comm, pow_succ, mul_assoc, alg_hom.map_mul, linear_map.mul_apply, mul_comm, hna],
-    simp [algebra_map_End_apply, mem_eigenspace_iff.1 h.1, smul_smul, mul_comm] }
+    simp only [mem_eigenspace_iff.1 h.1, smul_smul, aeval_X, eval_mul, eval_C, eval_pow, eval_X,
+      linear_map.map_smulₛₗ, ring_hom.id_apply, mul_comm] }
 end
 
 section minpoly
@@ -248,11 +249,9 @@ begin
       (λ μ, (μ - μ₀) • @linear_map.id K (f.eigenspace μ) _ _ _) l,
     -- The support of `l'` is the support of `l` without `μ₀`.
     have h_l_support' : l'.support = l_support',
-    { have : l_support' = finset.erase l.support μ₀,
-      { rw [h_l_support, finset.erase_insert hμ₀] },
-      rw this,
+    { rw [← finset.erase_insert hμ₀, ← h_l_support],
       ext a,
-      have : ¬(a = μ₀ ∨ l a = 0) ↔ ¬a = μ₀ ∧ ¬l a = 0 := by tauto,
+      have : ¬(a = μ₀ ∨ l a = 0) ↔ ¬a = μ₀ ∧ ¬l a = 0 := not_or_distrib,
       simp only [l', dfinsupp.map_range.linear_map_apply, dfinsupp.map_range_apply,
         dfinsupp.mem_support_iff, finset.mem_erase, id.def, linear_map.id_coe,
         linear_map.smul_apply, ne.def, smul_eq_zero, sub_eq_zero, this] },
@@ -267,7 +266,7 @@ begin
       ... = g (dfinsupp.lsum ℕ (λ μ, (linear_map.id : V →ₗ[K] V)) a) : _
       ... = g (S l) : _
       ... = 0 : by rw [hl, g.map_zero],
-      { rw dfinsupp.sum_map_range_index.linear_map },
+      { exact dfinsupp.sum_map_range_index.linear_map },
       { congr,
         ext μ v,
         simp only [g, eq_self_iff_true, function.comp_app, id.def, linear_map.coe_comp,
@@ -297,24 +296,21 @@ begin
     { rw ←finset.sum_const_zero,
       apply finset.sum_congr rfl,
       intros μ hμ,
-      norm_cast,
-      rw h_lμ_eq_0,
-      intro h,
-      rw h at hμ,
-      contradiction },
+      rw [submodule.coe_eq_zero, h_lμ_eq_0],
+      rintro rfl,
+      exact hμ₀ hμ },
     -- The only potentially nonzero eigenspace-representative in `l` is the one corresponding to
     -- `μ₀`. But since the overall sum is `0` by assumption, this representative must also be `0`.
     have : l μ₀ = 0,
     { simp only [S, dfinsupp.lsum_apply_apply, dfinsupp.sum_add_hom_apply,
         linear_map.to_add_monoid_hom_coe, dfinsupp.sum, h_l_support, submodule.subtype_apply,
         submodule.coe_eq_zero, finset.sum_insert hμ₀, h_sum_l_support'_eq_0, add_zero] at hl,
-      exact_mod_cast hl },
+      exact hl },
     -- Thus, all coefficients in `l` are `0`.
     show l = 0,
     { ext μ,
       by_cases h_cases : μ = μ₀,
-      { rw h_cases,
-        exact_mod_cast this },
+      { rwa [h_cases, set_like.coe_eq_coe, dfinsupp.coe_zero, pi.zero_apply] },
       exact congr_arg (coe : _ → V) (h_lμ_eq_0 μ h_cases) }}
 end
 

--- a/src/linear_algebra/matrix/polynomial.lean
+++ b/src/linear_algebra/matrix/polynomial.lean
@@ -88,8 +88,8 @@ begin
     simp [coeff_C] },
   { intros p hp,
     refine (nat_degree_add_le _ _).trans _,
-    simp,
-    exact (nat_degree_C_mul_le _ _).trans nat_degree_X_le }
+    simpa only [pi.smul_apply, map_apply, algebra.id.smul_eq_mul, X_mul_C, nat_degree_C,
+      max_eq_left, zero_le'] using (nat_degree_C_mul_le _ _).trans nat_degree_X_le }
 end
 
 lemma leading_coeff_det_X_one_add_C (A : matrix n n α) :

--- a/src/linear_algebra/matrix/polynomial.lean
+++ b/src/linear_algebra/matrix/polynomial.lean
@@ -88,7 +88,8 @@ begin
     simp [coeff_C] },
   { intros p hp,
     refine (nat_degree_add_le _ _).trans _,
-    simpa using (nat_degree_mul_C_le _ _).trans nat_degree_X_le }
+    simp,
+    exact (nat_degree_C_mul_le _ _).trans nat_degree_X_le }
 end
 
 lemma leading_coeff_det_X_one_add_C (A : matrix n n α) :


### PR DESCRIPTION
These lemmas are direct applications of `X_mul` and `X_pow_mul`.  However, their more general version cannot be `simp` lemmas since they form loops.  These versions do not, since they involve an explicit `C`.

I golfed slightly a proof in `linear_algebra.eigenspace` since it was timing out.

[Zulip discussion](https://leanprover.zulipchat.com/#narrow/stream/113489-new-members/topic/polynomial.20op_C/near/277703846)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
