### PR TITLE
[Merged by Bors] - chore(number_theory/cyclotomic/discriminant): golf `repr_pow_is_integral` a little

### DIFF
--- a/src/ring_theory/adjoin/power_basis.lean
+++ b/src/ring_theory/adjoin/power_basis.lean
@@ -163,7 +163,7 @@ begin
     { exact is_integral_zero } },
   { intros hx,
     rw [pow_succ],
-    refine repr_mul_is_integral hB hx (λ _, hn _ le_rfl (λ _, hx _) _) hmin }
+    exact repr_mul_is_integral hB hx (λ _, hn _ le_rfl (λ _, hx _) _) hmin }
 end
 
 /-- Let `B B' : power_basis K S` be such that `is_integral R B.gen`, and let `P : R[X]` be such that

--- a/src/ring_theory/adjoin/power_basis.lean
+++ b/src/ring_theory/adjoin/power_basis.lean
@@ -152,22 +152,18 @@ lemma repr_pow_is_integral [is_domain S] {x : A} (hx : ∀ i, is_integral R (B.b
   (hmin : minpoly S B.gen = (minpoly R B.gen).map (algebra_map R S)) (n : ℕ) :
   ∀ i, is_integral R ((B.basis.repr (x ^ n) i)) :=
 begin
-  by_cases htriv : nontrivial A, swap,
-  { intro i,
-    rw [subsingleton_iff.1 (not_nontrivial_iff_subsingleton.1 htriv) (x ^ n) 0],
-    simp [is_integral_zero] },
-  letI := htriv,
+  nontriviality A using [subsingleton.elim (x ^ n) 0, is_integral_zero],
   revert hx,
   refine nat.case_strong_induction_on n _ (λ n hn, _),
   { intros hx i,
     rw [pow_zero, ← pow_zero B.gen, ← fin.coe_mk B.dim_pos, ← B.basis_eq_pow,
       B.basis.repr_self_apply],
-    by_cases hi : (⟨0, B.dim_pos⟩ : fin _) = i,
-    { simp [hi, is_integral_one] },
-    { simp [hi, is_integral_zero] } },
-  { intros hx i,
+    split_ifs,
+    { exact is_integral_one },
+    { exact is_integral_zero } },
+  { intros hx,
     rw [pow_succ],
-    refine repr_mul_is_integral hB hx (λ _, hn _ le_rfl (λ _, hx _) _) hmin _ }
+    refine repr_mul_is_integral hB hx (λ _, hn _ le_rfl (λ _, hx _) _) hmin }
 end
 
 /-- Let `B B' : power_basis K S` be such that `is_integral R B.gen`, and let `P : R[X]` be such that


### PR DESCRIPTION
Using nice mathlib tactics instead of doing boilerplate tasks by hand to reduce the verbosity.


---

This was added in #12710 but I didn't have time to finalize my suggestions before it was merged :)

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
