### PR TITLE
[Merged by Bors] - chore(algebra/monoid_algebra/grading): fix slow elaboration

### DIFF
--- a/src/algebra/monoid_algebra/grading.lean
+++ b/src/algebra/monoid_algebra/grading.lean
@@ -205,7 +205,8 @@ of_grades_by (add_monoid_hom.id ι)
 @[simp]
 lemma of_grades_by_of (i : ι) (x : grade_by R f i) :
   of_grades_by f (direct_sum.of (λ i, grade_by R f i) i x) = x :=
-direct_sum.submodule_coe_alg_hom_of (grade_by R f) i x
+-- Use `simpa only` to help the elaborator decide what to unfold.
+by simpa only [of_grades_by] using direct_sum.submodule_coe_alg_hom_of (grade_by R f) i x
 
 @[simp]
 lemma of_grades_of (i : ι) (x : grade R i) :
@@ -217,7 +218,8 @@ lemma of_grades_by_comp_to_grades_by :
   (of_grades_by f).comp (to_grades_by f) = alg_hom.id R (add_monoid_algebra R M) :=
 begin
   ext : 2,
-  dsimp,
+  dsimp only [monoid_hom.coe_comp, alg_hom.coe_to_monoid_hom, alg_hom.coe_comp, function.comp_app,
+    of_apply, alg_hom.coe_id, function.comp.left_id, id],
   rw [to_grades_by_single, of_grades_by_of, subtype.coe_mk],
 end
 
@@ -240,7 +242,8 @@ lemma to_grades_by_comp_of_grades_by :
   (to_grades_by f).comp (of_grades_by f) = alg_hom.id R (⨁ i : ι, grade_by R f i) :=
 begin
   ext : 2,
-  dsimp [direct_sum.lof_eq_of],
+  dsimp only [direct_sum.lof_eq_of, linear_map.coe_comp, alg_hom.comp_to_linear_map,
+    alg_hom.to_linear_map_apply, function.comp_app, alg_hom.coe_id, id],
   rw [of_grades_by_of, to_grades_by_coe],
 end
 
@@ -276,6 +279,7 @@ lemma grade_by.is_internal : direct_sum.submodule_is_internal (grade_by R f) :=
 
 /-- `add_monoid_algebra.grades` describe an internally graded algebra -/
 lemma grade.is_internal : direct_sum.submodule_is_internal (grade R : ι → submodule R _) :=
-grade_by.is_internal (add_monoid_hom.id ι)
+-- Use `simpa only` to help the elaborator decide what to unfold.
+by simpa only [grade_by_id] using grade_by.is_internal (add_monoid_hom.id ι)
 
 end add_monoid_algebra


### PR DESCRIPTION
There were a couple of lemmas in this file taking multiple seconds to elaborate.  Apart from `squeeze_dsimps`, the main change in this PR is to help the elaborator unfold certain definitions (that it originally did unfold, but only after multiple seconds of trying to unfold other things), by replacing proofs with `by simpa only [some_unfolding_lemma] using the_original_proof`.

The main alternative I discovered for the `simpa` changes was to strategically mark certain definitions irreducible. Those definitions needed to be unfolded in other places in this file, and it's less obviously connected to the source of the slowness: we might keep around the `local attribute [irreducible]` lines even if it's not needed after a refactor.

Zulip thread: https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/Slow.20defeqs.20in.20.60algebra.2Fmonoid_algebra.2Fgrading.2Elean.60



---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
