### PR TITLE
[Merged by Bors] - fix(algebra/module/basic,group_theory/group_action/defs): generalize nat and int smul_comm_class instances

### DIFF
--- a/src/algebra/group_power/basic.lean
+++ b/src/algebra/group_power/basic.lean
@@ -223,7 +223,8 @@ by rw [pow_sub a⁻¹ h, inv_pow, inv_pow, inv_inv]
 
 end nat
 
-@[simp, to_additive zsmul_zero]
+-- the attributes are intentionally out of order. `smul_zero` proves `nsmul_zero`.
+@[to_additive zsmul_zero, simp]
 theorem one_zpow : ∀ (n : ℤ), (1 : G) ^ n = 1
 | (n : ℕ) := by rw [zpow_coe_nat, one_pow]
 | -[1+ n] := by rw [zpow_neg_succ_of_nat, one_pow, one_inv]

--- a/src/algebra/group_power/basic.lean
+++ b/src/algebra/group_power/basic.lean
@@ -223,7 +223,7 @@ by rw [pow_sub a⁻¹ h, inv_pow, inv_pow, inv_inv]
 
 end nat
 
--- the attributes are intentionally out of order. `smul_zero` proves `nsmul_zero`.
+-- the attributes are intentionally out of order. `smul_zero` proves `zsmul_zero`.
 @[to_additive zsmul_zero, simp]
 theorem one_zpow : ∀ (n : ℤ), (1 : G) ^ n = 1
 | (n : ℕ) := by rw [zpow_coe_nat, one_pow]

--- a/src/algebra/module/basic.lean
+++ b/src/algebra/module/basic.lean
@@ -331,15 +331,6 @@ instance add_comm_monoid.nat_is_scalar_tower :
     (by simp only [zero_smul])
     (λ n ih, by simp only [nat.succ_eq_add_one, add_smul, one_smul, ih]) }
 
-instance add_comm_monoid.nat_smul_comm_class : smul_comm_class ℕ R M :=
-{ smul_comm := λ n r m, nat.rec_on n
-    (by simp only [zero_smul, smul_zero])
-    (λ n ih, by simp only [nat.succ_eq_add_one, add_smul, one_smul, ←ih, smul_add]) }
-
--- `smul_comm_class.symm` is not registered as an instance, as it would cause a loop
-instance add_comm_monoid.nat_smul_comm_class' : smul_comm_class R ℕ M :=
-smul_comm_class.symm _ _ _
-
 end add_comm_monoid
 
 section add_comm_group
@@ -454,16 +445,6 @@ lemma rat_cast_smul_eq {E : Type*} (R S : Type*) [add_comm_group E] [division_ri
 instance add_comm_group.int_is_scalar_tower {R : Type u} {M : Type v} [ring R] [add_comm_group M]
   [module R M]: is_scalar_tower ℤ R M :=
 { smul_assoc := λ n x y, ((smul_add_hom R M).flip y).map_int_module_smul n x }
-
-instance add_comm_group.int_smul_comm_class {S : Type u} {M : Type v} [semiring S]
-  [add_comm_group M] [module S M] :
-  smul_comm_class ℤ S M :=
-{ smul_comm := λ n x y, ((smul_add_hom S M x).map_zsmul y n).symm }
-
--- `smul_comm_class.symm` is not registered as an instance, as it would cause a loop
-instance add_comm_group.int_smul_comm_class' {S : Type u} {M : Type v} [semiring S]
-  [add_comm_group M] [module S M] : smul_comm_class S ℤ M :=
-smul_comm_class.symm _ _ _
 
 instance is_scalar_tower.rat {R : Type u} {M : Type v} [ring R] [add_comm_group M]
   [module R M] [module ℚ R] [module ℚ M] : is_scalar_tower ℚ R M :=

--- a/src/algebra/smul_with_zero.lean
+++ b/src/algebra/smul_with_zero.lean
@@ -57,10 +57,6 @@ instance mul_zero_class.to_opposite_smul_with_zero [mul_zero_class R] : smul_wit
   smul_zero := λ r, zero_mul _,
   zero_smul := mul_zero }
 
-instance add_monoid.to_smul_with_zero [add_monoid M] : smul_with_zero ℕ M :=
-{ smul_zero := nsmul_zero,
-  zero_smul := zero_nsmul }
-
 variables (R) {M} [has_zero R] [has_zero M] [smul_with_zero R M]
 
 @[simp] lemma zero_smul (m : M) : (0 : R) • m = 0 := smul_with_zero.zero_smul m
@@ -100,6 +96,14 @@ def smul_with_zero.comp_hom (f : zero_hom R' R) : smul_with_zero R' M :=
   zero_smul := λ m, by simp }
 
 end has_zero
+
+instance add_monoid.nat_smul_with_zero [add_monoid M] : smul_with_zero ℕ M :=
+{ smul_zero := nsmul_zero,
+  zero_smul := zero_nsmul }
+
+instance add_group.int_smul_with_zero [add_group M] : smul_with_zero ℤ M :=
+{ smul_zero := zsmul_zero,
+  zero_smul := zero_zsmul }
 
 section monoid_with_zero
 

--- a/src/group_theory/group_action/defs.lean
+++ b/src/group_theory/group_action/defs.lean
@@ -547,10 +547,24 @@ def distrib_mul_action.to_add_monoid_End : M →* add_monoid.End A :=
   map_one' := add_monoid_hom.ext $ one_smul M,
   map_mul' := λ x y, add_monoid_hom.ext $ mul_smul x y }
 
+instance add_monoid.nat_smul_comm_class : smul_comm_class ℕ M A :=
+{ smul_comm := λ n x y, ((distrib_mul_action.to_add_monoid_hom A x).map_nsmul y n).symm }
+
+-- `smul_comm_class.symm` is not registered as an instance, as it would cause a loop
+instance add_monoid.nat_smul_comm_class' : smul_comm_class M ℕ A :=
+smul_comm_class.symm _ _ _
+
 end
 
 section
 variables [monoid M] [add_group A] [distrib_mul_action M A]
+
+instance add_group.int_smul_comm_class : smul_comm_class ℤ M A :=
+{ smul_comm := λ n x y, ((distrib_mul_action.to_add_monoid_hom A x).map_zsmul y n).symm }
+
+-- `smul_comm_class.symm` is not registered as an instance, as it would cause a loop
+instance add_group.int_smul_comm_class' : smul_comm_class M ℤ A :=
+smul_comm_class.symm _ _ _
 
 @[simp] theorem smul_neg (r : M) (x : A) : r • (-x) = -(r • x) :=
 eq_neg_of_add_eq_zero $ by rw [← smul_add, neg_add_self, smul_zero]

--- a/src/linear_algebra/tensor_product.lean
+++ b/src/linear_algebra/tensor_product.lean
@@ -932,7 +932,7 @@ When `R` is a `ring` we get the required `tensor_product.compatible_smul` instan
 `is_scalar_tower`, but when it is only a `semiring` we need to build it from scratch.
 The instance diamond in `compatible_smul` doesn't matter because it's in `Prop`.
 -/
-instance compatible_smul.int [module ℤ M] [module ℤ N] : compatible_smul R ℤ M N :=
+instance compatible_smul.int : compatible_smul R ℤ M N :=
 ⟨λ r m n, int.induction_on r
   (by simp)
   (λ r ih, by simpa [add_smul, tmul_add, add_tmul] using ih)

--- a/src/tactic/abel.lean
+++ b/src/tactic/abel.lean
@@ -196,7 +196,7 @@ theorem zero_smul {α} [add_comm_monoid α] (c) : smul c (0 : α) = 0 :=
 by simp [smul, nsmul_zero]
 
 theorem zero_smulg {α} [add_comm_group α] (c) : smulg c (0 : α) = 0 :=
-by simp [smulg]
+by simp [smulg, zsmul_zero]
 
 theorem term_smul {α} [add_comm_monoid α] (c n x a n' a')
   (h₁ : c * n = n') (h₂ : smul c a = a') :


### PR DESCRIPTION
The `add_group.int_smul_with_zero` instance appears to be new, everything else is moved and has `[semiring R] [add_comm_monoid M] [module R M]` relaxed to `[monoid R] [add_monoid M] [distrib_mul_action R M]`, with the variables renamed to match the destination file.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
