### PR TITLE
[Merged by Bors] - feat(linear_algebra/bilinear_form): generalize from is_symm to is_refl

### DIFF
--- a/src/linear_algebra/bilinear_form.lean
+++ b/src/linear_algebra/bilinear_form.lean
@@ -976,10 +976,10 @@ end
 lemma nondegenerate.ker_eq_bot {B : bilin_form R₂ M₂} (h : B.nondegenerate) :
   B.to_lin.ker = ⊥ := nondegenerate_iff_ker_eq_bot.mp h
 
-/-- The restriction of a nondegenerate bilinear form `B` onto a submodule `W` is
+/-- The restriction of a nondegenerate reflexive bilinear form `B` onto a submodule `W` is
 nondegenerate if `disjoint W (B.orthogonal W)`. -/
 lemma nondegenerate_restrict_of_disjoint_orthogonal
-  (B : bilin_form R₁ M₁) (b : B.is_symm)
+  (B : bilin_form R₁ M₁) (b : B.is_refl)
   {W : submodule R₁ M₁} (hW : disjoint W (B.orthogonal W)) :
   (B.restrict W).nondegenerate :=
 begin
@@ -987,7 +987,8 @@ begin
   rw [submodule.mk_eq_zero, ← submodule.mem_bot R₁],
   refine hW ⟨hx, λ y hy, _⟩,
   specialize b₁ ⟨y, hy⟩,
-  rwa [restrict_apply, submodule.coe_mk, submodule.coe_mk, b] at b₁
+  rw [restrict_apply, submodule.coe_mk, submodule.coe_mk] at b₁,
+  exact is_ortho_def.mpr (b x y b₁),
 end
 
 /-- An orthogonal basis with respect to a nondegenerate bilinear form has no self-orthogonal
@@ -1032,7 +1033,7 @@ end
 section
 
 lemma to_lin_restrict_ker_eq_inf_orthogonal
-  (B : bilin_form K V) (W : subspace K V) (b : B.is_symm) :
+  (B : bilin_form K V) (W : subspace K V) (b : B.is_refl) :
   (B.to_lin.dom_restrict W).ker.map W.subtype = (W ⊓ B.orthogonal ⊤ : subspace K V) :=
 begin
   ext x, split; intro hx,
@@ -1069,7 +1070,7 @@ variable [finite_dimensional K V]
 open finite_dimensional
 
 lemma finrank_add_finrank_orthogonal
-  {B : bilin_form K V} {W : subspace K V} (b₁ : B.is_symm) :
+  {B : bilin_form K V} {W : subspace K V} (b₁ : B.is_refl) :
   finrank K W + finrank K (B.orthogonal W) =
   finrank K V + finrank K (W ⊓ B.orthogonal ⊤ : subspace K V) :=
 begin
@@ -1083,10 +1084,10 @@ begin
 end
 
 /-- A subspace is complement to its orthogonal complement with respect to some
-bilinear form if that bilinear form restricted on to the subspace is nondegenerate. -/
+reflexive bilinear form if that bilinear form restricted on to the subspace is nondegenerate. -/
 lemma restrict_nondegenerate_of_is_compl_orthogonal
   {B : bilin_form K V} {W : subspace K V}
-  (b₁ : B.is_symm) (b₂ : (B.restrict W).nondegenerate) :
+  (b₁ : B.is_refl) (b₂ : (B.restrict W).nondegenerate) :
   is_compl W (B.orthogonal W) :=
 begin
   have : W ⊓ B.orthogonal W = ⊥,
@@ -1107,10 +1108,10 @@ begin
     exact nat.le.intro rfl }
 end
 
-/-- A subspace is complement to its orthogonal complement with respect to some bilinear form
-if and only if that bilinear form restricted on to the subspace is nondegenerate. -/
+/-- A subspace is complement to its orthogonal complement with respect to some reflexive bilinear
+form if and only if that bilinear form restricted on to the subspace is nondegenerate. -/
 theorem restrict_nondegenerate_iff_is_compl_orthogonal
-  {B : bilin_form K V} {W : subspace K V} (b₁ : B.is_symm) :
+  {B : bilin_form K V} {W : subspace K V} (b₁ : B.is_refl) :
   (B.restrict W).nondegenerate ↔ is_compl W (B.orthogonal W) :=
 ⟨λ b₂, restrict_nondegenerate_of_is_compl_orthogonal b₁ b₂,
  λ h, B.nondegenerate_restrict_of_disjoint_orthogonal b₁ h.1⟩
@@ -1162,10 +1163,10 @@ lemma below since the below lemma does not require `V` to be finite dimensional.
 `bilin_form.restrict_nondegenerate_iff_is_compl_orthogonal` does not require `B` to be nondegenerate
 on the whole space. -/
 
-/-- The restriction of a symmetric, non-degenerate bilinear form on the orthogonal complement of
+/-- The restriction of a reflexive, non-degenerate bilinear form on the orthogonal complement of
 the span of a singleton is also non-degenerate. -/
 lemma restrict_orthogonal_span_singleton_nondegenerate (B : bilin_form K V)
-  (b₁ : B.nondegenerate) (b₂ : B.is_symm) {x : V} (hx : ¬ B.is_ortho x x) :
+  (b₁ : B.nondegenerate) (b₂ : B.is_refl) {x : V} (hx : ¬ B.is_ortho x x) :
   nondegenerate $ B.restrict $ B.orthogonal (K ∙ x) :=
 begin
   refine λ m hm, submodule.coe_eq_zero.1 (b₁ m.1 (λ n, _)),

--- a/src/linear_algebra/bilinear_form.lean
+++ b/src/linear_algebra/bilinear_form.lean
@@ -976,7 +976,7 @@ end
 lemma nondegenerate.ker_eq_bot {B : bilin_form R₂ M₂} (h : B.nondegenerate) :
   B.to_lin.ker = ⊥ := nondegenerate_iff_ker_eq_bot.mp h
 
-/-- The restriction of a nondegenerate reflexive bilinear form `B` onto a submodule `W` is
+/-- The restriction of a reflexive bilinear form `B` onto a submodule `W` is
 nondegenerate if `disjoint W (B.orthogonal W)`. -/
 lemma nondegenerate_restrict_of_disjoint_orthogonal
   (B : bilin_form R₁ M₁) (b : B.is_refl)

--- a/src/linear_algebra/sesquilinear_form.lean
+++ b/src/linear_algebra/sesquilinear_form.lean
@@ -170,20 +170,22 @@ begin
   exact H x y,
 end
 
+@[simp] lemma flip_is_refl_iff : B.flip.is_refl ↔ B.is_refl :=
+⟨λ h x y H, h y x ((B.flip_apply _ _).trans H), λ h x y, h y x⟩
+
+lemma ker_flip_eq_bot (H : B.is_refl) (h : B.ker = ⊥) : B.flip.ker = ⊥ :=
+begin
+  refine ker_eq_bot'.mpr (λ _ hx, ker_eq_bot'.mp h _ _),
+  ext,
+  exact H _ _ (linear_map.congr_fun hx _),
+end
+
 lemma ker_eq_bot_iff_ker_flip_eq_bot (H : B.is_refl) : B.ker = ⊥ ↔ B.flip.ker = ⊥ :=
 begin
-  repeat {rw linear_map.ker_eq_bot'},
-  simp_rw fun_like.ext_iff,
-  simp,
-  split;
-  { intros h m hx,
-    apply h,
-    intro x,
-    specialize hx x,
-    rw eq_zero,
-    exact H,
-    exact hx },
+  refine ⟨ker_flip_eq_bot H, λ h, _⟩,
+  exact (congr_arg _ B.flip_flip.symm).trans (ker_flip_eq_bot (flip_is_refl_iff.mpr H) h),
 end
+
 
 end is_refl
 end reflexive

--- a/src/linear_algebra/sesquilinear_form.lean
+++ b/src/linear_algebra/sesquilinear_form.lean
@@ -206,11 +206,7 @@ lemma is_refl (H : B.is_symm) : B.is_refl := λ x y H1, by { rw ←H.eq, simp [H
 lemma ortho_comm (H : B.is_symm) {x y} : is_ortho B x y ↔ is_ortho B y x := H.is_refl.ortho_comm
 
 lemma dom_restrict_symm (H : B.is_symm) (p : submodule R M) : (B.dom_restrict₁₂ p p).is_symm :=
-begin
-  intros x y,
-  simp_rw dom_restrict₁₂_apply,
-  exact H x y,
-end
+λ _ _, by { simp_rw dom_restrict₁₂_apply, exact H _ _}
 
 end is_symm
 

--- a/src/linear_algebra/sesquilinear_form.lean
+++ b/src/linear_algebra/sesquilinear_form.lean
@@ -164,11 +164,7 @@ lemma eq_zero : ∀ {x y}, B x y = 0 → B y x = 0 := λ x y, H x y
 lemma ortho_comm {x y} : is_ortho B x y ↔ is_ortho B y x := ⟨eq_zero H, eq_zero H⟩
 
 lemma dom_restrict_refl (H : B.is_refl) (p : submodule R₁ M₁) : (B.dom_restrict₁₂ p p).is_refl :=
-begin
-  intros x y,
-  simp_rw dom_restrict₁₂_apply,
-  exact H x y,
-end
+λ _ _, by { simp_rw dom_restrict₁₂_apply, exact H _ _}
 
 @[simp] lemma flip_is_refl_iff : B.flip.is_refl ↔ B.is_refl :=
 ⟨λ h x y H, h y x ((B.flip_apply _ _).trans H), λ h x y, h y x⟩

--- a/src/linear_algebra/sesquilinear_form.lean
+++ b/src/linear_algebra/sesquilinear_form.lean
@@ -163,6 +163,28 @@ lemma eq_zero : ∀ {x y}, B x y = 0 → B y x = 0 := λ x y, H x y
 
 lemma ortho_comm {x y} : is_ortho B x y ↔ is_ortho B y x := ⟨eq_zero H, eq_zero H⟩
 
+lemma dom_restrict_refl (H : B.is_refl) (p : submodule R₁ M₁) : (B.dom_restrict₁₂ p p).is_refl :=
+begin
+  intros x y,
+  simp_rw dom_restrict₁₂_apply,
+  exact H x y,
+end
+
+lemma ker_eq_bot_iff_ker_flip_eq_bot (H : B.is_refl) : B.ker = ⊥ ↔ B.flip.ker = ⊥ :=
+begin
+  repeat {rw linear_map.ker_eq_bot'},
+  simp_rw fun_like.ext_iff,
+  simp,
+  split;
+  { intros h m hx,
+    apply h,
+    intro x,
+    specialize hx x,
+    rw eq_zero,
+    exact H,
+    exact hx },
+end
+
 end is_refl
 end reflexive
 
@@ -428,31 +450,31 @@ section comm_ring
 variables [comm_ring R] [add_comm_group M] [module R M]
   {I I' : R →+* R}
 
-lemma is_symm.nondegenerate_of_separating_left {B : M →ₗ[R] M →ₗ[R] R}
-  (hB : B.is_symm) (hB' : B.separating_left) : B.nondegenerate :=
+lemma is_refl.nondegenerate_of_separating_left {B : M →ₗ[R] M →ₗ[R] R}
+  (hB : B.is_refl) (hB' : B.separating_left) : B.nondegenerate :=
 begin
   refine ⟨hB', _⟩,
-  rw [is_symm_iff_eq_flip.mp hB, flip_separating_right],
-  exact hB',
+  rw [separating_right_iff_flip_ker_eq_bot, hB.ker_eq_bot_iff_ker_flip_eq_bot.mp],
+  rwa ←separating_left_iff_ker_eq_bot,
 end
 
-lemma is_symm.nondegenerate_of_separating_right {B : M →ₗ[R] M →ₗ[R] R}
-  (hB : B.is_symm) (hB' : B.separating_right) : B.nondegenerate :=
+lemma is_refl.nondegenerate_of_separating_right {B : M →ₗ[R] M →ₗ[R] R}
+  (hB : B.is_refl) (hB' : B.separating_right) : B.nondegenerate :=
 begin
   refine ⟨_, hB'⟩,
-  rw [is_symm_iff_eq_flip.mp hB, flip_separating_left],
-  exact hB',
+  rw [separating_left_iff_ker_eq_bot, hB.ker_eq_bot_iff_ker_flip_eq_bot.mpr],
+  rwa ←separating_right_iff_flip_ker_eq_bot,
 end
 
-/-- The restriction of a symmetric bilinear form `B` onto a submodule `W` is
+/-- The restriction of a reflexive bilinear form `B` onto a submodule `W` is
 nondegenerate if `W` has trivial intersection with its orthogonal complement,
 that is `disjoint W (W.orthogonal_bilin B)`. -/
 lemma nondegenerate_restrict_of_disjoint_orthogonal
-  {B : M →ₗ[R] M →ₗ[R] R} (hB : B.is_symm)
+  {B : M →ₗ[R] M →ₗ[R] R} (hB : B.is_refl)
   {W : submodule R M} (hW : disjoint W (W.orthogonal_bilin B)) :
   (B.dom_restrict₁₂ W W).nondegenerate :=
 begin
-  refine (hB.dom_restrict_symm W).nondegenerate_of_separating_left  _,
+  refine (hB.dom_restrict_refl W).nondegenerate_of_separating_left  _,
   rintro ⟨x, hx⟩ b₁,
   rw [submodule.mk_eq_zero, ← submodule.mem_bot R],
   refine hW ⟨hx, λ y hy, _⟩,


### PR DESCRIPTION
Generalize some lemmas that assumed symmetric bilinear forms to reflexive bilinear forms (which is more general) and update docstring (before the condition 'symmetric' was not mentioned)