### PR TITLE
[Merged by Bors] - feat(algebraic_topology/fundamental_groupoid/fundamental_group): add type checker helpers for convertings paths to/from elements of fundamental group

### DIFF
--- a/src/algebraic_topology/fundamental_groupoid/fundamental_group.lean
+++ b/src/algebraic_topology/fundamental_groupoid/fundamental_group.lean
@@ -52,7 +52,6 @@ abbreviation to_arrow {X : Top} {x : X} (p : fundamental_group X x) : x ⟶ x :=
 p.hom
 
 /-- An element of the fundamental group as a quotient of homotopic paths. -/
-@[reducible]
 abbreviation to_path {X : Top} {x : X} (p : fundamental_group X x) :
   path.homotopic.quotient x x := to_arrow p
 

--- a/src/algebraic_topology/fundamental_groupoid/fundamental_group.lean
+++ b/src/algebraic_topology/fundamental_groupoid/fundamental_group.lean
@@ -34,7 +34,7 @@ def fundamental_group (X : Type u) [topological_space X] (x : X) :=
 namespace fundamental_group
 
 local attribute [instance] path.homotopic.setoid
-local attribute [instance] fundamental_groupoid 
+local attribute [reducible] fundamental_groupoid
 
 /-- Get an isomorphism between the fundamental groups at two points given a path -/
 def fundamental_group_mul_equiv_of_path (p : path x₀ x₁) :

--- a/src/algebraic_topology/fundamental_groupoid/fundamental_group.lean
+++ b/src/algebraic_topology/fundamental_groupoid/fundamental_group.lean
@@ -47,28 +47,21 @@ def fundamental_group_mul_equiv_of_path_connected [path_connected_space X] :
   (fundamental_group X x₀) ≃* (fundamental_group X x₁) :=
 fundamental_group_mul_equiv_of_path (path_connected_space.some_path x₀ x₁)
 
-/-- Help the typechecker by converting an element in the fundamental group of
-a topological space back to an arrow in the fundamental groupoid. -/
-@[reducible]
-def to_arrow {X : Top} {x : X} (p : fundamental_group X x) : x ⟶ x :=
+/-- An element of the fundamental group as an arrow in the fundamental groupoid. -/
+abbreviation to_arrow {X : Top} {x : X} (p : fundamental_group X x) : x ⟶ x :=
 p.hom
 
-/-- Help the typechecker by converting an element in the fundamental group of
-a topological space back to a path in that space (i.e. `path.homotopic.quotient`). -/
+/-- An element of the fundamental group as a quotient of homotopic paths. -/
 @[reducible]
-def to_path {X : Top} {x : X} (p : fundamental_group X x) :
+abbreviation to_path {X : Top} {x : X} (p : fundamental_group X x) :
   path.homotopic.quotient x x := to_arrow p
 
-/-- Help the typechecker by convering an arrow loop in the fundamental groupoid to an
-element of the fundamental group. -/
-@[reducible]
-def from_arrow {X : Top} {x : X} (p : x ⟶ x) : fundamental_group X x :=
+/-- An element of the fundamental group, constructed from an arrow in the fundamental groupoid. -/
+abbreviation from_arrow {X : Top} {x : X} (p : x ⟶ x) : fundamental_group X x :=
 ⟨p, category_theory.groupoid.inv p⟩
 
-/-- Help the typechecker by convering a path in a topological space to an element of the
-fundamental group of that space. -/
-@[reducible]
-def from_path {X : Top} {x : X} (p : path.homotopic.quotient x x) :
+/-- An element of the fundamental gorup, constructed from a quotient of homotopic paths. -/
+abbreviation from_path {X : Top} {x : X} (p : path.homotopic.quotient x x) :
   fundamental_group X x := from_arrow p
 
 end fundamental_group

--- a/src/algebraic_topology/fundamental_groupoid/fundamental_group.lean
+++ b/src/algebraic_topology/fundamental_groupoid/fundamental_group.lean
@@ -34,6 +34,7 @@ def fundamental_group (X : Type u) [topological_space X] (x : X) :=
 namespace fundamental_group
 
 local attribute [instance] path.homotopic.setoid
+local attribute [instance] fundamental_groupoid 
 
 /-- Get an isomorphism between the fundamental groups at two points given a path -/
 def fundamental_group_mul_equiv_of_path (p : path x₀ x₁) :
@@ -45,5 +46,29 @@ variables (x₀ x₁)
 def fundamental_group_mul_equiv_of_path_connected [path_connected_space X] :
   (fundamental_group X x₀) ≃* (fundamental_group X x₁) :=
 fundamental_group_mul_equiv_of_path (path_connected_space.some_path x₀ x₁)
+
+/-- Help the typechecker by converting an element in the fundamental group of
+a topological space back to an arrow in the fundamental groupoid. -/
+@[reducible]
+def to_arrow {X : Top} {x : X} (p : fundamental_group X x) : x ⟶ x :=
+p.hom
+
+/-- Help the typechecker by converting an element in the fundamental group of
+a topological space back to a path in that space (i.e. `path.homotopic.quotient`). -/
+@[reducible]
+def to_path {X : Top} {x : X} (p : fundamental_group X x) :
+  path.homotopic.quotient x x := to_arrow p
+
+/-- Help the typechecker by convering an arrow loop in the fundamental groupoid to an
+element of the fundamental group. -/
+@[reducible]
+def from_arrow {X : Top} {x : X} (p : x ⟶ x) : fundamental_group X x :=
+⟨p, category_theory.groupoid.inv p⟩
+
+/-- Help the typechecker by convering a path in a topological space to an element of the
+fundamental group of that space. -/
+@[reducible]
+def from_path {X : Top} {x : X} (p : path.homotopic.quotient x x) :
+  fundamental_group X x := from_arrow p
 
 end fundamental_group


### PR DESCRIPTION
This pr adds the following helper functions for converting paths to and from elements of the fundamental group:
- `to_arrow`: converts element of the fundamental group to an arrow in the fundamental groupoid
- `to_path`: converts element of the fundamental group to a (quotient of homotopic) path in the space
- `from_arrow`: constructs an element of the fundamental group from a self-arrow in the fundamental groupoid
- `from_path`: constructs an element of the fundamental group from a (quotient of homotopic) path in the space

These parallel  the similarly named functions for the fundamental group [here](https://github.com/leanprover-community/mathlib/blob/743ed5d1dd54fffd65e3a7f3522e4a4e85472964/src/algebraic_topology/fundamental_groupoid/basic.lean#L339-L355). They will prove helpful in doing computations with the fundamental group later e.g. for the disk, circle, etc.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
