### PR TITLE
[Merged by Bors] - chore(algebraic_topology/simplex_category): removed ulift

### DIFF
--- a/src/algebraic_topology/alternating_face_map_complex.lean
+++ b/src/algebraic_topology/alternating_face_map_complex.lean
@@ -37,8 +37,6 @@ open_locale simplicial
 
 noncomputable theory
 
-universe v
-
 namespace algebraic_topology
 
 namespace alternating_face_map_complex
@@ -143,7 +141,7 @@ chain_complex.of_hom _ _ _ _ _ _
 
 end alternating_face_map_complex
 
-variables (C : Type*) [category.{v} C] [preadditive C]
+variables (C : Type*) [category C] [preadditive C]
 
 /-- The alternating face map complex, as a functor -/
 @[simps]
@@ -153,7 +151,7 @@ def alternating_face_map_complex : simplicial_object C ⥤ chain_complex C ℕ :
 
 variables {C}
 
-lemma map_alternating_face_map_complex {D : Type*} [category.{v} D] [preadditive D]
+lemma map_alternating_face_map_complex {D : Type*} [category D] [preadditive D]
   (F : C ⥤ D) [F.additive] :
   alternating_face_map_complex C ⋙ F.map_homological_complex _ =
   (simplicial_object.whiskering C D).obj F ⋙ alternating_face_map_complex D :=

--- a/src/algebraic_topology/simplex_category.lean
+++ b/src/algebraic_topology/simplex_category.lean
@@ -31,6 +31,8 @@ We provide the following functions to work with these objects:
 
 -/
 
+universe v
+
 open category_theory
 
 /-- The simplex category:
@@ -308,7 +310,7 @@ section skeleton
 /-- The functor that exhibits `simplex_category` as skeleton
 of `NonemptyFinLinOrd` -/
 @[simps obj map]
-def skeletal_functor : simplex_category ⥤ NonemptyFinLinOrd :=
+def skeletal_functor : simplex_category ⥤ NonemptyFinLinOrd.{v} :=
 { obj := λ a, NonemptyFinLinOrd.of $ ulift (fin (a.len + 1)),
   map := λ a b f,
     ⟨λ i, ulift.up (f.to_order_hom i.down), λ i j h, f.to_order_hom.monotone h⟩,
@@ -327,11 +329,11 @@ end
 
 namespace skeletal_functor
 
-instance : full skeletal_functor :=
+instance : full skeletal_functor.{v} :=
 { preimage := λ a b f, simplex_category.hom.mk ⟨λ i, (f (ulift.up i)).down, λ i j h, f.monotone h⟩,
   witness' := by { intros m n f, dsimp at *, ext1 ⟨i⟩, ext1, ext1, cases x, simp, } }
 
-instance : faithful skeletal_functor :=
+instance : faithful skeletal_functor.{v} :=
 { map_injective' := λ m n f g h,
   begin
     ext1, ext1, ext1 i, apply ulift.up.inj,
@@ -339,7 +341,7 @@ instance : faithful skeletal_functor :=
     rw h,
   end }
 
-instance : ess_surj skeletal_functor :=
+instance : ess_surj skeletal_functor.{v} :=
 { mem_ess_image := λ X, ⟨mk (fintype.card X - 1 : ℕ), ⟨begin
     have aux : fintype.card X = fintype.card X - 1 + 1,
     { exact (nat.succ_pred_eq_of_pos $ fintype.card_pos_iff.mpr ⟨⊥⟩).symm, },
@@ -357,14 +359,14 @@ instance : ess_surj skeletal_functor :=
     { ext1, ext1 i, exact f.apply_symm_apply i },
   end⟩⟩, }
 
-noncomputable instance is_equivalence : is_equivalence skeletal_functor :=
+noncomputable instance is_equivalence : is_equivalence (skeletal_functor.{v}) :=
 equivalence.of_fully_faithfully_ess_surj skeletal_functor
 
 end skeletal_functor
 
 /-- The equivalence that exhibits `simplex_category` as skeleton
 of `NonemptyFinLinOrd` -/
-noncomputable def skeletal_equivalence : simplex_category ≌ NonemptyFinLinOrd :=
+noncomputable def skeletal_equivalence : simplex_category ≌ NonemptyFinLinOrd.{v} :=
 functor.as_equivalence skeletal_functor
 
 end skeleton
@@ -373,7 +375,7 @@ end skeleton
 `simplex_category` is a skeleton of `NonemptyFinLinOrd`.
 -/
 noncomputable
-def is_skeleton_of : is_skeleton_of NonemptyFinLinOrd simplex_category skeletal_functor :=
+def is_skeleton_of : is_skeleton_of NonemptyFinLinOrd simplex_category skeletal_functor.{v} :=
 { skel := skeletal,
   eqv := skeletal_functor.is_equivalence }
 

--- a/src/algebraic_topology/simplex_category.lean
+++ b/src/algebraic_topology/simplex_category.lean
@@ -31,8 +31,6 @@ We provide the following functions to work with these objects:
 
 -/
 
---universes u v
-
 open category_theory
 
 /-- The simplex category:

--- a/src/algebraic_topology/simplex_category.lean
+++ b/src/algebraic_topology/simplex_category.lean
@@ -31,7 +31,7 @@ We provide the following functions to work with these objects:
 
 -/
 
-universes u v
+--universes u v
 
 open category_theory
 
@@ -40,7 +40,7 @@ open category_theory
 * morphisms from `n` to `m` are monotone functions `fin (n+1) → fin (m+1)`
 -/
 @[derive inhabited, irreducible]
-def simplex_category := ulift.{u} ℕ
+def simplex_category := ℕ
 
 namespace simplex_category
 
@@ -49,78 +49,73 @@ local attribute [semireducible] simplex_category
 
 -- TODO: Make `mk` irreducible.
 /-- Interpet a natural number as an object of the simplex category. -/
-def mk (n : ℕ) : simplex_category.{u} := ulift.up n
+def mk (n : ℕ) : simplex_category := n
 
 localized "notation `[`n`]` := simplex_category.mk n" in simplicial
 
 -- TODO: Make `len` irreducible.
 /-- The length of an object of `simplex_category`. -/
-def len (n : simplex_category.{u}) : ℕ := n.down
+def len (n : simplex_category) : ℕ := n
 
-@[ext] lemma ext (a b : simplex_category.{u}) : a.len = b.len → a = b := ulift.ext a b
+@[ext] lemma ext (a b : simplex_category) : a.len = b.len → a = b := id
 @[simp] lemma len_mk (n : ℕ) : [n].len = n := rfl
-@[simp] lemma mk_len (n : simplex_category.{u}) : [n.len] = n := by {cases n, refl}
+@[simp] lemma mk_len (n : simplex_category) : [n.len] = n := rfl
 
 /-- Morphisms in the simplex_category. -/
 @[irreducible, nolint has_inhabited_instance]
-protected def hom (a b : simplex_category.{u}) : Type u :=
-ulift (fin (a.len + 1) →o fin (b.len + 1))
+protected def hom (a b : simplex_category) := fin (a.len + 1) →o fin (b.len + 1)
 
 namespace hom
 
 local attribute [semireducible] simplex_category.hom
 
 /-- Make a moprhism in `simplex_category` from a monotone map of fin's. -/
-def mk {a b : simplex_category.{u}} (f : fin (a.len + 1) →o fin (b.len + 1)) :
-  simplex_category.hom a b :=
-ulift.up f
+def mk {a b : simplex_category} (f : fin (a.len + 1) →o fin (b.len + 1)) :
+  simplex_category.hom a b := f
 
 /-- Recover the monotone map from a morphism in the simplex category. -/
-def to_order_hom {a b : simplex_category.{u}} (f : simplex_category.hom a b) :
-  fin (a.len + 1) →o fin (b.len + 1) :=
-ulift.down f
+def to_order_hom {a b : simplex_category} (f : simplex_category.hom a b) :
+  fin (a.len + 1) →o fin (b.len + 1) := f
 
-@[ext] lemma ext {a b : simplex_category.{u}} (f g : simplex_category.hom a b) :
-  f.to_order_hom = g.to_order_hom → f = g := ulift.ext _ _
+@[ext] lemma ext {a b : simplex_category} (f g : simplex_category.hom a b) :
+  f.to_order_hom = g.to_order_hom → f = g := id
 
-@[simp] lemma mk_to_order_hom {a b : simplex_category.{u}}
-  (f : simplex_category.hom a b) : mk (f.to_order_hom) = f :=
-by {cases f, refl}
+@[simp] lemma mk_to_order_hom {a b : simplex_category}
+  (f : simplex_category.hom a b) : mk (f.to_order_hom) = f := rfl
 
-@[simp] lemma to_order_hom_mk {a b : simplex_category.{u}}
-  (f : fin (a.len + 1) →o fin (b.len + 1)) : (mk f).to_order_hom = f :=
-by simp [to_order_hom, mk]
+@[simp] lemma to_order_hom_mk {a b : simplex_category}
+  (f : fin (a.len + 1) →o fin (b.len + 1)) : (mk f).to_order_hom = f := rfl
 
-lemma mk_to_order_hom_apply {a b : simplex_category.{u}}
+lemma mk_to_order_hom_apply {a b : simplex_category}
   (f : fin (a.len + 1) →o fin (b.len + 1)) (i : fin (a.len + 1)) :
   (mk f).to_order_hom i = f i := rfl
 
 /-- Identity morphisms of `simplex_category`. -/
 @[simp]
-def id (a : simplex_category.{u}) :
+def id (a : simplex_category) :
   simplex_category.hom a a :=
 mk order_hom.id
 
 /-- Composition of morphisms of `simplex_category`. -/
 @[simp]
-def comp {a b c : simplex_category.{u}} (f : simplex_category.hom b c)
+def comp {a b c : simplex_category} (f : simplex_category.hom b c)
   (g : simplex_category.hom a b) : simplex_category.hom a c :=
 mk $ f.to_order_hom.comp g.to_order_hom
 
 end hom
 
 @[simps]
-instance small_category : small_category.{u} simplex_category :=
+instance small_category : small_category.{0} simplex_category :=
 { hom := λ n m, simplex_category.hom n m,
   id := λ m, simplex_category.hom.id _,
   comp := λ _ _ _ f g, simplex_category.hom.comp g f, }
 
 /-- The constant morphism from [0]. -/
-def const (x : simplex_category.{u}) (i : fin (x.len+1)) : [0] ⟶ x :=
+def const (x : simplex_category) (i : fin (x.len+1)) : [0] ⟶ x :=
   hom.mk $ ⟨λ _, i, by tauto⟩
 
 @[simp]
-lemma const_comp (x y : simplex_category.{u}) (i : fin (x.len + 1)) (f : x ⟶ y) :
+lemma const_comp (x y : simplex_category) (i : fin (x.len + 1)) (f : x ⟶ y) :
   const x i ≫ f = const y (f.to_order_hom i) := rfl
 
 /--
@@ -315,14 +310,14 @@ section skeleton
 /-- The functor that exhibits `simplex_category` as skeleton
 of `NonemptyFinLinOrd` -/
 @[simps obj map]
-def skeletal_functor : simplex_category.{u} ⥤ NonemptyFinLinOrd.{v} :=
+def skeletal_functor : simplex_category ⥤ NonemptyFinLinOrd :=
 { obj := λ a, NonemptyFinLinOrd.of $ ulift (fin (a.len + 1)),
   map := λ a b f,
     ⟨λ i, ulift.up (f.to_order_hom i.down), λ i j h, f.to_order_hom.monotone h⟩,
   map_id' := λ a, by { ext, simp, },
   map_comp' := λ a b c f g, by { ext, simp, }, }
 
-lemma skeletal : skeletal simplex_category.{u} :=
+lemma skeletal : skeletal simplex_category :=
 λ X Y ⟨I⟩,
 begin
   suffices : fintype.card (fin (X.len+1)) = fintype.card (fin (Y.len+1)),
@@ -334,11 +329,11 @@ end
 
 namespace skeletal_functor
 
-instance : full skeletal_functor.{u v} :=
+instance : full skeletal_functor :=
 { preimage := λ a b f, simplex_category.hom.mk ⟨λ i, (f (ulift.up i)).down, λ i j h, f.monotone h⟩,
   witness' := by { intros m n f, dsimp at *, ext1 ⟨i⟩, ext1, ext1, cases x, simp, } }
 
-instance : faithful skeletal_functor.{u v} :=
+instance : faithful skeletal_functor :=
 { map_injective' := λ m n f g h,
   begin
     ext1, ext1, ext1 i, apply ulift.up.inj,
@@ -346,7 +341,7 @@ instance : faithful skeletal_functor.{u v} :=
     rw h,
   end }
 
-instance : ess_surj skeletal_functor.{u v} :=
+instance : ess_surj skeletal_functor :=
 { mem_ess_image := λ X, ⟨mk (fintype.card X - 1 : ℕ), ⟨begin
     have aux : fintype.card X = fintype.card X - 1 + 1,
     { exact (nat.succ_pred_eq_of_pos $ fintype.card_pos_iff.mpr ⟨⊥⟩).symm, },
@@ -364,14 +359,14 @@ instance : ess_surj skeletal_functor.{u v} :=
     { ext1, ext1 i, exact f.apply_symm_apply i },
   end⟩⟩, }
 
-noncomputable instance is_equivalence : is_equivalence skeletal_functor.{u v} :=
+noncomputable instance is_equivalence : is_equivalence skeletal_functor :=
 equivalence.of_fully_faithfully_ess_surj skeletal_functor
 
 end skeletal_functor
 
 /-- The equivalence that exhibits `simplex_category` as skeleton
 of `NonemptyFinLinOrd` -/
-noncomputable def skeletal_equivalence : simplex_category.{u} ≌ NonemptyFinLinOrd.{v} :=
+noncomputable def skeletal_equivalence : simplex_category ≌ NonemptyFinLinOrd :=
 functor.as_equivalence skeletal_functor
 
 end skeleton
@@ -380,13 +375,13 @@ end skeleton
 `simplex_category` is a skeleton of `NonemptyFinLinOrd`.
 -/
 noncomputable
-def is_skeleton_of : is_skeleton_of NonemptyFinLinOrd simplex_category skeletal_functor.{u v} :=
+def is_skeleton_of : is_skeleton_of NonemptyFinLinOrd simplex_category skeletal_functor :=
 { skel := skeletal,
   eqv := skeletal_functor.is_equivalence }
 
 /-- The truncated simplex category. -/
 @[derive small_category]
-def truncated (n : ℕ) := {a : simplex_category.{u} // a.len ≤ n}
+def truncated (n : ℕ) := {a : simplex_category // a.len ≤ n}
 
 namespace truncated
 
@@ -397,14 +392,14 @@ The fully faithful inclusion of the truncated simplex category into the usual
 simplex category.
 -/
 @[derive [full, faithful]]
-def inclusion {n : ℕ} : simplex_category.truncated.{u} n ⥤ simplex_category.{u} :=
+def inclusion {n : ℕ} : simplex_category.truncated n ⥤ simplex_category :=
 full_subcategory_inclusion _
 
 end truncated
 
 section concrete
 
-instance : concrete_category.{0} simplex_category.{u} :=
+instance : concrete_category.{0} simplex_category :=
 { forget :=
   { obj := λ i, fin (i.len + 1),
     map := λ i j f, f.to_order_hom },
@@ -416,7 +411,7 @@ section epi_mono
 
 /-- A morphism in `simplex_category` is a monomorphism precisely when it is an injective function
 -/
-theorem mono_iff_injective {n m : simplex_category.{u}} {f : n ⟶ m} :
+theorem mono_iff_injective {n m : simplex_category} {f : n ⟶ m} :
   mono f ↔ function.injective f.to_order_hom :=
 begin
   split,
@@ -431,7 +426,7 @@ end
 
 /-- A morphism in `simplex_category` is an epimorphism if and only if it is a surjective function
 -/
-lemma epi_iff_surjective {n m : simplex_category.{u}} {f: n ⟶ m} :
+lemma epi_iff_surjective {n m : simplex_category} {f: n ⟶ m} :
   epi f ↔ function.surjective f.to_order_hom :=
 begin
   split,
@@ -470,7 +465,7 @@ begin
 end
 
 /-- A monomorphism in `simplex_category` must increase lengths-/
-lemma len_le_of_mono {x y : simplex_category.{u}} {f : x ⟶ y} :
+lemma len_le_of_mono {x y : simplex_category} {f : x ⟶ y} :
   mono f → (x.len ≤ y.len) :=
 begin
   intro hyp_f_mono,
@@ -483,7 +478,7 @@ lemma le_of_mono {n m : ℕ} {f : [n] ⟶ [m]} : (category_theory.mono f) → (n
 len_le_of_mono
 
 /-- An epimorphism in `simplex_category` must decrease lengths-/
-lemma len_le_of_epi {x y : simplex_category.{u}} {f : x ⟶ y} :
+lemma len_le_of_epi {x y : simplex_category} {f : x ⟶ y} :
   epi f → y.len ≤ x.len :=
 begin
   intro hyp_f_epi,
@@ -539,7 +534,7 @@ instance : reflects_isomorphisms (forget simplex_category) :=
     inv_hom_id' := by { ext1, ext1, exact iso.inv_hom_id (as_iso ((forget _).map f)), }, },
 end⟩
 
-lemma is_iso_of_bijective {x y : simplex_category.{u}} {f : x ⟶ y}
+lemma is_iso_of_bijective {x y : simplex_category} {f : x ⟶ y}
   (hf : function.bijective (f.to_order_hom.to_fun)) : is_iso f :=
 begin
   haveI : is_iso ((forget simplex_category).map f) := (is_iso_iff_bijective _).mpr hf,
@@ -548,7 +543,7 @@ end
 
 /-- An isomorphism in `simplex_category` induces an `order_iso`. -/
 @[simp]
-def order_iso_of_iso {x y : simplex_category.{u}} (e : x ≅ y) :
+def order_iso_of_iso {x y : simplex_category} (e : x ≅ y) :
   fin (x.len+1) ≃o fin (y.len+1) :=
 equiv.to_order_iso
   { to_fun    := e.hom.to_order_hom,
@@ -557,7 +552,7 @@ equiv.to_order_iso
     right_inv := λ i, by simpa only using congr_arg (λ φ, (hom.to_order_hom φ) i) e.inv_hom_id', }
   e.hom.to_order_hom.monotone e.inv.to_order_hom.monotone
 
-lemma iso_eq_iso_refl {x : simplex_category.{u}} (e : x ≅ x) :
+lemma iso_eq_iso_refl {x : simplex_category} (e : x ≅ x) :
   e = iso.refl x :=
 begin
   have h : (finset.univ : finset (fin (x.len+1))).card = x.len+1 := finset.card_fin (x.len+1),
@@ -571,7 +566,7 @@ begin
   refl,
 end
 
-lemma eq_id_of_is_iso {x : simplex_category.{u}} {f : x ⟶ x} (hf : is_iso f) : f = 𝟙 _ :=
+lemma eq_id_of_is_iso {x : simplex_category} {f : x ⟶ x} (hf : is_iso f) : f = 𝟙 _ :=
 congr_arg (λ (φ : _ ≅ _), φ.hom) (iso_eq_iso_refl (as_iso f))
 
 lemma eq_σ_comp_of_not_injective' {n : ℕ} {Δ' : simplex_category} (θ : mk (n+1) ⟶ Δ')
@@ -689,7 +684,7 @@ begin
   exact eq_comp_δ_of_not_surjective' θ i (not_exists.mp hi),
 end
 
-lemma eq_id_of_mono {x : simplex_category.{u}} (i : x ⟶ x) [mono i] : i = 𝟙 _ :=
+lemma eq_id_of_mono {x : simplex_category} (i : x ⟶ x) [mono i] : i = 𝟙 _ :=
 begin
   apply eq_id_of_is_iso,
   apply is_iso_of_bijective,
@@ -698,7 +693,7 @@ begin
   apply_instance,
 end
 
-lemma eq_id_of_epi {x : simplex_category.{u}} (i : x ⟶ x) [epi i] : i = 𝟙 _ :=
+lemma eq_id_of_epi {x : simplex_category} (i : x ⟶ x) [epi i] : i = 𝟙 _ :=
 begin
   apply eq_id_of_is_iso,
   apply is_iso_of_bijective,

--- a/src/algebraic_topology/simplicial_object.lean
+++ b/src/algebraic_topology/simplicial_object.lean
@@ -23,7 +23,7 @@ open opposite
 open category_theory
 open category_theory.limits
 
-universes v u
+universes v u v' u'
 
 namespace category_theory
 
@@ -218,7 +218,7 @@ def whiskering_obj (D : Type*) [category D] (F : C ⥤ D) :
 
 /-- Functor composition induces a functor on augmented simplicial objects. -/
 @[simps]
-def whiskering (D : Type*) [category D] :
+def whiskering (D : Type u') [category.{v'} D] :
   (C ⥤ D) ⥤ augmented C ⥤ augmented D :=
 { obj := whiskering_obj _ _,
   map := λ X Y η,
@@ -449,7 +449,7 @@ def whiskering_obj (D : Type*) [category D] (F : C ⥤ D) :
 
 /-- Functor composition induces a functor on augmented cosimplicial objects. -/
 @[simps]
-def whiskering (D : Type*) [category D] :
+def whiskering (D : Type u') [category.{v'} D] :
   (C ⥤ D) ⥤ augmented C ⥤ augmented D :=
 { obj := whiskering_obj _ _,
   map := λ X Y η,

--- a/src/algebraic_topology/simplicial_object.lean
+++ b/src/algebraic_topology/simplicial_object.lean
@@ -32,7 +32,7 @@ variables (C : Type u) [category.{v} C]
 /-- The category of simplicial objects valued in a category `C`.
 This is the category of contravariant functors from `simplex_category` to `C`. -/
 @[derive category, nolint has_inhabited_instance]
-def simplicial_object := simplex_category.{v}ᵒᵖ ⥤ C
+def simplicial_object := simplex_categoryᵒᵖ ⥤ C
 
 namespace simplicial_object
 
@@ -114,13 +114,13 @@ variable (C)
 
 /-- Functor composition induces a functor on simplicial objects. -/
 @[simps]
-def whiskering (D : Type*) [category.{v} D] :
+def whiskering (D : Type*) [category D] :
   (C ⥤ D) ⥤ simplicial_object C ⥤ simplicial_object D :=
 whiskering_right _ _ _
 
 /-- Truncated simplicial objects. -/
 @[derive category, nolint has_inhabited_instance]
-def truncated (n : ℕ) := (simplex_category.truncated.{v} n)ᵒᵖ ⥤ C
+def truncated (n : ℕ) := (simplex_category.truncated n)ᵒᵖ ⥤ C
 
 variable {C}
 
@@ -141,7 +141,7 @@ variable (C)
 
 /-- Functor composition induces a functor on truncated simplicial objects. -/
 @[simps]
-def whiskering {n} (D : Type*) [category.{v} D] :
+def whiskering {n} (D : Type*) [category D] :
   (C ⥤ D) ⥤ truncated C n ⥤ truncated D n :=
 whiskering_right _ _ _
 
@@ -199,7 +199,7 @@ variable (C)
 
 /-- Functor composition induces a functor on augmented simplicial objects. -/
 @[simp]
-def whiskering_obj (D : Type*) [category.{v} D] (F : C ⥤ D) :
+def whiskering_obj (D : Type*) [category D] (F : C ⥤ D) :
   augmented C ⥤ augmented D :=
 { obj := λ X,
   { left := ((whiskering _ _).obj F).obj (drop.obj X),
@@ -218,13 +218,18 @@ def whiskering_obj (D : Type*) [category.{v} D] (F : C ⥤ D) :
 
 /-- Functor composition induces a functor on augmented simplicial objects. -/
 @[simps]
-def whiskering (D : Type*) [category.{v} D] :
+def whiskering (D : Type*) [category D] :
   (C ⥤ D) ⥤ augmented C ⥤ augmented D :=
 { obj := whiskering_obj _ _,
   map := λ X Y η,
   { app := λ A,
     { left := whisker_left _ η,
-      right := η.app _ } } }
+      right := η.app _,
+      w' := begin
+        ext n,
+        dsimp,
+        erw [category.comp_id, category.comp_id, η.naturality],
+      end }, }, }
 
 variable {C}
 
@@ -257,7 +262,7 @@ end simplicial_object
 
 /-- Cosimplicial objects. -/
 @[derive category, nolint has_inhabited_instance]
-def cosimplicial_object := simplex_category.{v} ⥤ C
+def cosimplicial_object := simplex_category ⥤ C
 
 namespace cosimplicial_object
 
@@ -339,13 +344,13 @@ variable (C)
 
 /-- Functor composition induces a functor on cosimplicial objects. -/
 @[simps]
-def whiskering (D : Type*) [category.{v} D] :
+def whiskering (D : Type*) [category D] :
   (C ⥤ D) ⥤ cosimplicial_object C ⥤ cosimplicial_object D :=
 whiskering_right _ _ _
 
 /-- Truncated cosimplicial objects. -/
 @[derive category, nolint has_inhabited_instance]
-def truncated (n : ℕ) := simplex_category.truncated.{v} n ⥤ C
+def truncated (n : ℕ) := simplex_category.truncated n ⥤ C
 
 variable {C}
 
@@ -367,7 +372,7 @@ variable (C)
 
 /-- Functor composition induces a functor on truncated cosimplicial objects. -/
 @[simps]
-def whiskering {n} (D : Type*) [category.{v} D] :
+def whiskering {n} (D : Type*) [category D] :
   (C ⥤ D) ⥤ truncated C n ⥤ truncated D n :=
 whiskering_right _ _ _
 
@@ -425,7 +430,7 @@ variable (C)
 
 /-- Functor composition induces a functor on augmented cosimplicial objects. -/
 @[simp]
-def whiskering_obj (D : Type*) [category.{v} D] (F : C ⥤ D) :
+def whiskering_obj (D : Type*) [category D] (F : C ⥤ D) :
   augmented C ⥤ augmented D :=
 { obj := λ X,
   { left := F.obj (point.obj X),
@@ -444,13 +449,18 @@ def whiskering_obj (D : Type*) [category.{v} D] (F : C ⥤ D) :
 
 /-- Functor composition induces a functor on augmented cosimplicial objects. -/
 @[simps]
-def whiskering (D : Type*) [category.{v} D] :
+def whiskering (D : Type*) [category D] :
   (C ⥤ D) ⥤ augmented C ⥤ augmented D :=
 { obj := whiskering_obj _ _,
   map := λ X Y η,
   { app := λ A,
     { left := η.app _,
-      right := whisker_left _ η } } }
+      right := whisker_left _ η,
+      w' := begin
+        ext n,
+        dsimp,
+        erw [category.id_comp, category.id_comp, η.naturality],
+      end }, }, }
 
 variable {C}
 


### PR DESCRIPTION
---
This PR removes `ulift` in the definition of `simplex_category`, as it was discussed at [https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/is.20ulift.20necessary.20in.20simplex_category.3F](https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/is.20ulift.20necessary.20in.20simplex_category.3F). `simplex_category` becomes synonym of  `ℕ` and morphims synonym of `fin (n+1) →o fin (m+1)`. (However, it might still be advisable to continue using the appropriate constructors.)

This allows to consider `whiskering` functors between (co)simplicial object categories whose underlying categories have different universes for morphisms.

(Doing this change introduced two deterministic timeouts in the definition of whiskering functors for augmented (co)simplicial objects: as a result, two proofs have been added.)

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
