### PR TITLE
[Merged by Bors] - fix(field_theory/galois): update docstring

### DIFF
--- a/src/field_theory/galois.lean
+++ b/src/field_theory/galois.lean
@@ -23,7 +23,7 @@ In this file we define Galois extensions as extensions which are both separable 
 
 ## Main results
 
-- `fixing_subgroup_fixed_field` : If `E/F` is finite dimensional (but not necessarily Galois)
+- `intermediate_field.fixing_subgroup_fixed_field` : If `E/F` is finite dimensional (but not necessarily Galois)
   then `fixing_subgroup (fixed_field H) = H`
 - `fixed_field_fixing_subgroup`: If `E/F` is finite dimensional and Galois
   then `fixed_field (fixing_subgroup K) = K`

--- a/src/field_theory/galois.lean
+++ b/src/field_theory/galois.lean
@@ -23,11 +23,12 @@ In this file we define Galois extensions as extensions which are both separable 
 
 ## Main results
 
-- `intermediate_field.fixing_subgroup_fixed_field` : If `E/F` is finite dimensional (but not necessarily Galois)
-  then `fixing_subgroup (fixed_field H) = H`
+- `intermediate_field.fixing_subgroup_fixed_field` : If `E/F` is finite dimensional (but not
+  necessarily Galois) then `fixing_subgroup (fixed_field H) = H`
 - `intermediate_field.fixed_field_fixing_subgroup`: If `E/F` is finite dimensional and Galois
   then `fixed_field (fixing_subgroup K) = K`
-Together, these two result prove the Galois correspondence
+
+Together, these two result prove the Galois correspondence.
 
 - `is_galois.tfae` : Equivalent characterizations of a Galois extension of finite degree
 -/

--- a/src/field_theory/galois.lean
+++ b/src/field_theory/galois.lean
@@ -23,9 +23,9 @@ In this file we define Galois extensions as extensions which are both separable 
 
 ## Main results
 
-- `fixing_subgroup_of_fixed_field` : If `E/F` is finite dimensional (but not necessarily Galois)
+- `fixing_subgroup_fixed_field` : If `E/F` is finite dimensional (but not necessarily Galois)
   then `fixing_subgroup (fixed_field H) = H`
-- `fixed_field_of_fixing_subgroup`: If `E/F` is finite dimensional and Galois
+- `fixed_field_fixing_subgroup`: If `E/F` is finite dimensional and Galois
   then `fixed_field (fixing_subgroup K) = K`
 Together, these two result prove the Galois correspondence
 

--- a/src/field_theory/galois.lean
+++ b/src/field_theory/galois.lean
@@ -25,7 +25,7 @@ In this file we define Galois extensions as extensions which are both separable 
 
 - `intermediate_field.fixing_subgroup_fixed_field` : If `E/F` is finite dimensional (but not necessarily Galois)
   then `fixing_subgroup (fixed_field H) = H`
-- `fixed_field_fixing_subgroup`: If `E/F` is finite dimensional and Galois
+- `intermediate_field.fixed_field_fixing_subgroup`: If `E/F` is finite dimensional and Galois
   then `fixed_field (fixing_subgroup K) = K`
 Together, these two result prove the Galois correspondence
 

--- a/src/field_theory/galois.lean
+++ b/src/field_theory/galois.lean
@@ -28,7 +28,7 @@ In this file we define Galois extensions as extensions which are both separable 
 - `intermediate_field.fixed_field_fixing_subgroup`: If `E/F` is finite dimensional and Galois
   then `fixed_field (fixing_subgroup K) = K`
 
-Together, these two result prove the Galois correspondence.
+Together, these two results prove the Galois correspondence.
 
 - `is_galois.tfae` : Equivalent characterizations of a Galois extension of finite degree
 -/


### PR DESCRIPTION

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)

Seems it was just plain wrong?
