### PR TITLE
[Merged by Bors] - feat(linear_algebra): add `adjoint_pair` from `bilinear_form`

### DIFF
--- a/src/analysis/inner_product_space/adjoint.lean
+++ b/src/analysis/inner_product_space/adjoint.lean
@@ -179,7 +179,7 @@ variables {E' : Type*} {F' : Type*} [inner_product_space ℝ E'] [inner_product_
 variables [complete_space E'] [complete_space F']
 
 -- Todo: Generalize this to `is_R_or_C`.
-lemma is_adjoint_pair (A : E' →L[ℝ] F') :
+lemma is_adjoint_pair_inner (A : E' →L[ℝ] F') :
   linear_map.is_adjoint_pair (sesq_form_of_inner : E' →ₗ[ℝ] E' →ₗ[ℝ] ℝ)
   (sesq_form_of_inner : F' →ₗ[ℝ] F' →ₗ[ℝ] ℝ) A (A†) :=
 λ x y, by simp only [sesq_form_of_inner_apply_apply, adjoint_inner_left, to_linear_map_eq_coe,
@@ -293,7 +293,7 @@ variables {E' : Type*} {F' : Type*} [inner_product_space ℝ E'] [inner_product_
 variables [finite_dimensional ℝ E'] [finite_dimensional ℝ F']
 
 -- Todo: Generalize this to `is_R_or_C`.
-lemma is_adjoint_pair' (A : E' →ₗ[ℝ] F') :
+lemma is_adjoint_pair_inner (A : E' →ₗ[ℝ] F') :
   is_adjoint_pair (sesq_form_of_inner : E' →ₗ[ℝ] E' →ₗ[ℝ] ℝ)
   (sesq_form_of_inner : F' →ₗ[ℝ] F' →ₗ[ℝ] ℝ) A A.adjoint :=
 λ x y, by simp only [sesq_form_of_inner_apply_apply, adjoint_inner_left]

--- a/src/analysis/inner_product_space/adjoint.lean
+++ b/src/analysis/inner_product_space/adjoint.lean
@@ -178,11 +178,12 @@ section real
 variables {E' : Type*} {F' : Type*} [inner_product_space ℝ E'] [inner_product_space ℝ F']
 variables [complete_space E'] [complete_space F']
 
+-- Todo: Generalize this to `is_R_or_C`.
 lemma is_adjoint_pair (A : E' →L[ℝ] F') :
-  bilin_form.is_adjoint_pair (bilin_form_of_real_inner : bilin_form ℝ E')
-  (bilin_form_of_real_inner : bilin_form ℝ F') A (A†) :=
-λ x y, by simp only [adjoint_inner_right, to_linear_map_eq_coe,
-                     bilin_form_of_real_inner_apply, coe_coe]
+  linear_map.is_adjoint_pair (sesq_form_of_inner : E' →ₗ[ℝ] E' →ₗ[ℝ] ℝ)
+  (sesq_form_of_inner : F' →ₗ[ℝ] F' →ₗ[ℝ] ℝ) A (A†) :=
+λ x y, by simp only [sesq_form_of_inner_apply_apply, adjoint_inner_left, to_linear_map_eq_coe,
+  coe_coe]
 
 end real
 
@@ -291,10 +292,11 @@ section real
 variables {E' : Type*} {F' : Type*} [inner_product_space ℝ E'] [inner_product_space ℝ F']
 variables [finite_dimensional ℝ E'] [finite_dimensional ℝ F']
 
-lemma is_adjoint_pair (A : E' →ₗ[ℝ] F') :
-  bilin_form.is_adjoint_pair (bilin_form_of_real_inner : bilin_form ℝ E')
-  (bilin_form_of_real_inner : bilin_form ℝ F') A A.adjoint :=
-λ x y, by simp only [adjoint_inner_right, bilin_form_of_real_inner_apply]
+-- Todo: Generalize this to `is_R_or_C`.
+lemma is_adjoint_pair' (A : E' →ₗ[ℝ] F') :
+  is_adjoint_pair (sesq_form_of_inner : E' →ₗ[ℝ] E' →ₗ[ℝ] ℝ)
+  (sesq_form_of_inner : F' →ₗ[ℝ] F' →ₗ[ℝ] ℝ) A A.adjoint :=
+λ x y, by simp only [sesq_form_of_inner_apply_apply, adjoint_inner_left]
 
 end real
 

--- a/src/linear_algebra/bilinear_form.lean
+++ b/src/linear_algebra/bilinear_form.lean
@@ -795,7 +795,7 @@ begin
   have he : function.surjective (⇑(↑e : M₃' →ₗ[R₃] M₃) : M₃' → M₃) := e.surjective,
   show bilin_form.is_adjoint_pair _ _ _ _  ↔ bilin_form.is_adjoint_pair _ _ _ _,
   rw [is_adjoint_pair_iff_comp_left_eq_comp_right, is_adjoint_pair_iff_comp_left_eq_comp_right,
-      hᵣ, hₗ, comp_injective _ _ he he],
+      hᵣ, hₗ, comp_inj _ _ he he],
 end
 
 /-- An endomorphism of a module is self-adjoint with respect to a bilinear form if it serves as an

--- a/src/linear_algebra/bilinear_form.lean
+++ b/src/linear_algebra/bilinear_form.lean
@@ -444,7 +444,7 @@ by { ext, refl }
   B.comp linear_map.id linear_map.id = B :=
 by { ext, refl }
 
-lemma comp_injective (B₁ B₂ : bilin_form R M') {l r : M →ₗ[R] M'}
+lemma comp_inj (B₁ B₂ : bilin_form R M') {l r : M →ₗ[R] M'}
   (hₗ : function.surjective l) (hᵣ : function.surjective r) :
   B₁.comp l r = B₂.comp l r ↔ B₁ = B₂ :=
 begin

--- a/src/linear_algebra/bilinear_map.lean
+++ b/src/linear_algebra/bilinear_map.lean
@@ -168,12 +168,13 @@ section comm_semiring
 variables {R : Type*} [comm_semiring R] {R₂ : Type*} [comm_semiring R₂]
 variables {R₃ : Type*} [comm_semiring R₃] {R₄ : Type*} [comm_semiring R₄]
 variables {M : Type*} {N : Type*} {P : Type*} {Q : Type*}
-variables {Nₗ : Type*} {Pₗ : Type*} {Qₗ : Type*}
+variables {Mₗ : Type*} {Nₗ : Type*} {Pₗ : Type*} {Qₗ Qₗ': Type*}
 
 variables [add_comm_monoid M] [add_comm_monoid N] [add_comm_monoid P] [add_comm_monoid Q]
-variables [add_comm_monoid Nₗ] [add_comm_monoid Pₗ] [add_comm_monoid Qₗ]
+variables [add_comm_monoid Mₗ] [add_comm_monoid Nₗ] [add_comm_monoid Pₗ]
+variables [add_comm_monoid Qₗ] [add_comm_monoid Qₗ']
 variables [module R M] [module R₂ N] [module R₃ P] [module R₄ Q]
-variables [module R Nₗ] [module R Pₗ] [module R Qₗ]
+variables [module R Mₗ] [module R Nₗ] [module R Pₗ] [module R Qₗ] [module R Qₗ']
 variables {σ₁₂ : R →+* R₂} {σ₂₃ : R₂ →+* R₃} {σ₁₃ : R →+* R₃}
 variables {σ₄₂ : R₄ →+* R₂} {σ₄₃ : R₄ →+* R₃}
 variables [ring_hom_comp_triple σ₁₂ σ₂₃ σ₁₃] [ring_hom_comp_triple σ₄₂ σ₂₃ σ₄₃]
@@ -248,6 +249,15 @@ include σ₄₃
 @[simp] theorem compl₂_apply (g : Q →ₛₗ[σ₄₂] N) (m : M) (q : Q) :
   f.compl₂ g m q = f m (g q) := rfl
 omit σ₄₃
+
+/-- Composing linear maps `Q → M` and `Q' → N` with a bilinear map `M → N → P` to
+form a bilinear map `Q → Q' → P`. -/
+def compl₁₂ (f : Mₗ →ₗ[R] Nₗ →ₗ[R] Pₗ) (g : Qₗ →ₗ[R] Mₗ) (g' : Qₗ' →ₗ[R] Nₗ) :
+  Qₗ →ₗ[R] Qₗ' →ₗ[R] Pₗ :=
+(f.comp g).compl₂ g'
+
+@[simp] theorem compl₁₂_apply (f : Mₗ →ₗ[R] Nₗ →ₗ[R] Pₗ) (g : Qₗ →ₗ[R] Mₗ) (g' : Qₗ' →ₗ[R] Nₗ)
+  (x : Qₗ) (y : Qₗ') : f.compl₁₂ g g' x y = f (g x) (g' y) := rfl
 
 /-- Composing a linear map `P → Q` and a bilinear map `M → N → P` to
 form a bilinear map `M → N → Q`. -/

--- a/src/linear_algebra/bilinear_map.lean
+++ b/src/linear_algebra/bilinear_map.lean
@@ -259,7 +259,7 @@ def compl₁₂ (f : Mₗ →ₗ[R] Nₗ →ₗ[R] Pₗ) (g : Qₗ →ₗ[R] M�
 @[simp] theorem compl₁₂_apply (f : Mₗ →ₗ[R] Nₗ →ₗ[R] Pₗ) (g : Qₗ →ₗ[R] Mₗ) (g' : Qₗ' →ₗ[R] Nₗ)
   (x : Qₗ) (y : Qₗ') : f.compl₁₂ g g' x y = f (g x) (g' y) := rfl
 
-lemma compl₁₂_injective {f₁ f₂ : Mₗ →ₗ[R] Nₗ →ₗ[R] Pₗ} {g : Qₗ →ₗ[R] Mₗ} {g' : Qₗ' →ₗ[R] Nₗ}
+lemma compl₁₂_inj {f₁ f₂ : Mₗ →ₗ[R] Nₗ →ₗ[R] Pₗ} {g : Qₗ →ₗ[R] Mₗ} {g' : Qₗ' →ₗ[R] Nₗ}
   (hₗ : function.surjective g) (hᵣ : function.surjective g') :
   f₁.compl₁₂ g g' = f₂.compl₁₂ g g' ↔ f₁ = f₂ :=
 begin

--- a/src/linear_algebra/bilinear_map.lean
+++ b/src/linear_algebra/bilinear_map.lean
@@ -259,6 +259,21 @@ def compl₁₂ (f : Mₗ →ₗ[R] Nₗ →ₗ[R] Pₗ) (g : Qₗ →ₗ[R] M�
 @[simp] theorem compl₁₂_apply (f : Mₗ →ₗ[R] Nₗ →ₗ[R] Pₗ) (g : Qₗ →ₗ[R] Mₗ) (g' : Qₗ' →ₗ[R] Nₗ)
   (x : Qₗ) (y : Qₗ') : f.compl₁₂ g g' x y = f (g x) (g' y) := rfl
 
+lemma compl₁₂_injective {f₁ f₂ : Mₗ →ₗ[R] Nₗ →ₗ[R] Pₗ} {g : Qₗ →ₗ[R] Mₗ} {g' : Qₗ' →ₗ[R] Nₗ}
+  (hₗ : function.surjective g) (hᵣ : function.surjective g') :
+  f₁.compl₁₂ g g' = f₂.compl₁₂ g g' ↔ f₁ = f₂ :=
+begin
+  split; intros h,
+  { -- B₁.comp l r = B₂.comp l r → B₁ = B₂
+    ext x y,
+    cases hₗ x with x' hx, subst hx,
+    cases hᵣ y with y' hy, subst hy,
+    convert linear_map.congr_fun₂ h x' y',
+    },
+  { -- B₁ = B₂ → B₁.comp l r = B₂.comp l r
+    subst h, },
+end
+
 /-- Composing a linear map `P → Q` and a bilinear map `M → N → P` to
 form a bilinear map `M → N → Q`. -/
 def compr₂ (f : M →ₗ[R] Nₗ →ₗ[R] Pₗ) (g : Pₗ →ₗ[R] Qₗ) : M →ₗ[R] Nₗ →ₗ[R] Qₗ :=

--- a/src/linear_algebra/bilinear_map.lean
+++ b/src/linear_algebra/bilinear_map.lean
@@ -268,10 +268,9 @@ begin
     ext x y,
     cases hₗ x with x' hx, subst hx,
     cases hᵣ y with y' hy, subst hy,
-    convert linear_map.congr_fun₂ h x' y',
-    },
+    convert linear_map.congr_fun₂ h x' y' },
   { -- B₁ = B₂ → B₁.comp l r = B₂.comp l r
-    subst h, },
+    subst h },
 end
 
 /-- Composing a linear map `P → Q` and a bilinear map `M → N → P` to

--- a/src/linear_algebra/sesquilinear_form.lean
+++ b/src/linear_algebra/sesquilinear_form.lean
@@ -478,8 +478,6 @@ lemma is_pair_self_adjoint_equiv (e : M₁ ≃ₗ[R] M) (f : module.End R M) :
   is_pair_self_adjoint B F f ↔
     is_pair_self_adjoint (B.compl₁₂ ↑e ↑e) (F.compl₁₂ ↑e ↑e) (e.symm.conj f) :=
 begin
-  --dunfold is_pair_self_adjoint,
-  --simp_rw is_adjoint_pair_iff_comp_eq_compl₂,
   have hₗ : (F.compl₁₂ (↑e : M₁ →ₗ[R] M) (↑e : M₁ →ₗ[R] M)).comp (e.symm.conj f) =
     (F.comp f).compl₁₂ (↑e : M₁ →ₗ[R] M) (↑e : M₁ →ₗ[R] M) :=
   by { ext, simp only [linear_equiv.symm_conj_apply, coe_comp, linear_equiv.coe_coe, compl₁₂_apply,
@@ -488,20 +486,9 @@ begin
     (B.compl₂ f).compl₁₂ (↑e : M₁ →ₗ[R] M) (↑e : M₁ →ₗ[R] M) :=
   by { ext, simp only [linear_equiv.symm_conj_apply, compl₂_apply, coe_comp, linear_equiv.coe_coe,
       compl₁₂_apply, linear_equiv.apply_symm_apply] },
+  have he : function.surjective (⇑(↑e : M₁ →ₗ[R] M) : M₁ → M) := e.surjective,
   simp_rw [is_pair_self_adjoint, is_adjoint_pair_iff_comp_eq_compl₂, hₗ, hᵣ,
     compl₁₂_injective he he],
-  --by { ext, squeeze_simp [linear_equiv.conj_apply], },
-  /-
-  have hₗ : (F.compl₁₂ (↑e : M₁ →ₗ[R] M) (↑e : M₁ →ₗ[R] M)).comp (e.symm.conj f) =
-    (F.comp f).compl₁₂ (↑e : M₁ →ₗ[R] M) (↑e : M₁ →ₗ[R] M) :=
-  by { ext, simp only [linear_equiv.symm_conj_apply, coe_comp, linear_equiv.coe_coe, compl₁₂_apply,
-    linear_equiv.apply_symm_apply], },-/
-  --have he : function.surjective (⇑(↑e : M₁ →ₗ[R] M) : M₁ → M) := e.surjective,
-  --rw hₗ,
-  /-show linear_map.is_adjoint_pair _ _ _ _  ↔ linear_map.is_adjoint_pair _ _ _ _,
-  rw [is_adjoint_pair_iff_comp_left_eq_comp_right, is_adjoint_pair_iff_comp_left_eq_comp_right,
-      hᵣ, hₗ, comp_injective _ _ he he],-/
-  sorry,
 end
 
 /-- An endomorphism of a module is skew-adjoint with respect to a bilinear form if its negation
@@ -531,9 +518,6 @@ by { rw is_skew_adjoint_iff_neg_self_adjoint, exact iff.rfl, }
 end add_comm_group
 
 end selfadjoint_pair
-
-#exit
-
 
 /-! ### Nondegenerate bilinear forms -/
 

--- a/src/linear_algebra/sesquilinear_form.lean
+++ b/src/linear_algebra/sesquilinear_form.lean
@@ -485,7 +485,7 @@ variables {B F}
 
 @[simp] lemma mem_is_pair_self_adjoint_submodule (f : module.End R M) :
   f ∈ is_pair_self_adjoint_submodule B F ↔ is_pair_self_adjoint B F f :=
-by refl
+iff.rfl
 
 lemma is_pair_self_adjoint_equiv (e : M₁ ≃ₗ[R] M) (f : module.End R M) :
   is_pair_self_adjoint B F f ↔
@@ -514,7 +514,7 @@ by simp
 
 @[simp] lemma mem_skew_adjoint_submodule (f : module.End R M) :
   f ∈ B.skew_adjoint_submodule ↔ B.is_skew_adjoint f :=
-by { rw is_skew_adjoint_iff_neg_self_adjoint, exact iff.rfl, }
+by { rw is_skew_adjoint_iff_neg_self_adjoint, exact iff.rfl }
 
 end add_comm_group
 

--- a/src/linear_algebra/sesquilinear_form.lean
+++ b/src/linear_algebra/sesquilinear_form.lean
@@ -478,14 +478,30 @@ lemma is_pair_self_adjoint_equiv (e : M₁ ≃ₗ[R] M) (f : module.End R M) :
   is_pair_self_adjoint B F f ↔
     is_pair_self_adjoint (B.compl₁₂ ↑e ↑e) (F.compl₁₂ ↑e ↑e) (e.symm.conj f) :=
 begin
-  have hₗ : (F₃.comp ↑e ↑e).comp_left (e.symm.conj f) = (F₃.comp_left f).comp ↑e ↑e :=
-    by { ext, simp [linear_equiv.symm_conj_apply], },
-  have hᵣ : (B₃.comp ↑e ↑e).comp_right (e.symm.conj f) = (B₃.comp_right f).comp ↑e ↑e :=
-    by { ext, simp [linear_equiv.conj_apply], },
-  have he : function.surjective (⇑(↑e : M₃' →ₗ[R₃] M₃) : M₃' → M₃) := e.surjective,
-  show bilin_form.is_adjoint_pair _ _ _ _  ↔ bilin_form.is_adjoint_pair _ _ _ _,
+  --dunfold is_pair_self_adjoint,
+  --simp_rw is_adjoint_pair_iff_comp_eq_compl₂,
+  have hₗ : (F.compl₁₂ (↑e : M₁ →ₗ[R] M) (↑e : M₁ →ₗ[R] M)).comp (e.symm.conj f) =
+    (F.comp f).compl₁₂ (↑e : M₁ →ₗ[R] M) (↑e : M₁ →ₗ[R] M) :=
+  by { ext, simp only [linear_equiv.symm_conj_apply, coe_comp, linear_equiv.coe_coe, compl₁₂_apply,
+    linear_equiv.apply_symm_apply], },
+  have hᵣ : (B.compl₁₂ (↑e : M₁ →ₗ[R] M) (↑e : M₁ →ₗ[R] M)).compl₂ (e.symm.conj f) =
+    (B.compl₂ f).compl₁₂ (↑e : M₁ →ₗ[R] M) (↑e : M₁ →ₗ[R] M) :=
+  by { ext, simp only [linear_equiv.symm_conj_apply, compl₂_apply, coe_comp, linear_equiv.coe_coe,
+      compl₁₂_apply, linear_equiv.apply_symm_apply] },
+  simp_rw [is_pair_self_adjoint, is_adjoint_pair_iff_comp_eq_compl₂, hₗ, hᵣ,
+    compl₁₂_injective he he],
+  --by { ext, squeeze_simp [linear_equiv.conj_apply], },
+  /-
+  have hₗ : (F.compl₁₂ (↑e : M₁ →ₗ[R] M) (↑e : M₁ →ₗ[R] M)).comp (e.symm.conj f) =
+    (F.comp f).compl₁₂ (↑e : M₁ →ₗ[R] M) (↑e : M₁ →ₗ[R] M) :=
+  by { ext, simp only [linear_equiv.symm_conj_apply, coe_comp, linear_equiv.coe_coe, compl₁₂_apply,
+    linear_equiv.apply_symm_apply], },-/
+  --have he : function.surjective (⇑(↑e : M₁ →ₗ[R] M) : M₁ → M) := e.surjective,
+  --rw hₗ,
+  /-show linear_map.is_adjoint_pair _ _ _ _  ↔ linear_map.is_adjoint_pair _ _ _ _,
   rw [is_adjoint_pair_iff_comp_left_eq_comp_right, is_adjoint_pair_iff_comp_left_eq_comp_right,
-      hᵣ, hₗ, comp_injective _ _ he he],
+      hᵣ, hₗ, comp_injective _ _ he he],-/
+  sorry,
 end
 
 /-- An endomorphism of a module is skew-adjoint with respect to a bilinear form if its negation

--- a/src/linear_algebra/sesquilinear_form.lean
+++ b/src/linear_algebra/sesquilinear_form.lean
@@ -389,8 +389,8 @@ lemma is_adjoint_pair_iff_comp_eq_compl₂ :
   is_adjoint_pair B B' f g ↔ B'.comp f = B.compl₂ g :=
 begin
   split; intros h,
-  { ext x y, rw [comp_apply, compl₂_apply], exact h.eq },
-  { intros x y, rw [←compl₂_apply, ←comp_apply, h] },
+  { ext _ _, rw [comp_apply, compl₂_apply], exact h.eq },
+  { intros _ _, rw [←compl₂_apply, ←comp_apply, h] },
 end
 
 lemma is_adjoint_pair_zero : is_adjoint_pair B B' 0 0 :=
@@ -405,12 +405,12 @@ lemma is_adjoint_pair.add (h : is_adjoint_pair B B' f g) (h' : is_adjoint_pair B
 lemma is_adjoint_pair.comp {f' : M₁ →ₗ[R] M₂} {g' : M₂ →ₗ[R] M₁}
   (h : is_adjoint_pair B B' f g) (h' : is_adjoint_pair B' B'' f' g') :
   is_adjoint_pair B B'' (f'.comp f) (g.comp g') :=
-λ x y, by rw [linear_map.comp_apply, linear_map.comp_apply, h', h]
+λ _ _, by rw [linear_map.comp_apply, linear_map.comp_apply, h', h]
 
 lemma is_adjoint_pair.mul
   {f g f' g' : module.End R M} (h : is_adjoint_pair B B f g) (h' : is_adjoint_pair B B f' g') :
   is_adjoint_pair B B (f * f') (g' * g) :=
-λ x y, by rw [linear_map.mul_apply, linear_map.mul_apply, h, h']
+λ _ _, by rw [linear_map.mul_apply, linear_map.mul_apply, h, h']
 
 end add_comm_monoid
 
@@ -452,7 +452,7 @@ def is_pair_self_adjoint (f : module.End R M) := is_adjoint_pair B F f f
 
 /-- An endomorphism of a module is self-adjoint with respect to a bilinear form if it serves as an
 adjoint for itself. -/
-def is_self_adjoint (f : module.End R M) := is_adjoint_pair B B f f
+protected def is_self_adjoint (f : module.End R M) := is_adjoint_pair B B f f
 
 end add_comm_monoid
 


### PR DESCRIPTION
Copying the definition and theorem about adjoint pairs from `bilinear_form` to `sesquilinear_form`.
Defines the composition of two linear maps with a bilinear map to form a new bilinear map, which was missing from the `bilinear_map` API.

We also use the new definition of adjoint pairs in `analysis/inner_product_space/adjoint`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
