### PR TITLE
[Merged by Bors] - feat(order/monotone): simp lemmas for monotonicity in dual orders

### DIFF
--- a/src/logic/basic.lean
+++ b/src/logic/basic.lean
@@ -963,6 +963,15 @@ theorem exists_swap {p : α → β → Prop} : (∃ x y, p x y) ↔ ∃ y x, p x
 theorem exists_imp_distrib : ((∃ x, p x) → b) ↔ ∀ x, p x → b :=
 forall_exists_index
 
+section dependent
+
+lemma forall₂_swap {ι₁ ι₂ : Sort*} {κ₁ : ι₁ → Sort*} {κ₂ : ι₁ → Sort*}
+  {p : Π i₁, κ₁ i₁ → Π i₂, κ₂ i₂ → Prop} :
+  (∀ i₁ j₁ i₂ j₂, p i₁ j₁ i₂ j₂) ↔ ∀ i₂ j₂ i₁ j₁, p i₁ j₁ i₂ j₂ :=
+⟨λ h i₂ j₂ i₁ j₁, h i₁ j₁ i₂ j₂, λ h i₁ j₁ i₂ j₂, h i₂ j₂ i₁ j₁⟩
+
+end dependent
+
 /--
 Extract an element from a existential statement, using `classical.some`.
 -/

--- a/src/logic/basic.lean
+++ b/src/logic/basic.lean
@@ -209,7 +209,15 @@ library_note "fact non-instances"
 lemma fact.elim {p : Prop} (h : fact p) : p := h.1
 lemma fact_iff {p : Prop} : fact p ↔ p := ⟨λ h, h.1, λ h, ⟨h⟩⟩
 
+/-- Swaps two pairs of arguments to a function. -/
+@[reducible] def function.swap₂ {ι₁ ι₂ : Sort*} {κ₁ : ι₁ → Sort*} {κ₂ : ι₂ → Sort*}
+  {φ : Π i₁, κ₁ i₁ → Π i₂, κ₂ i₂ → Sort*} (f : Π i₁ j₁ i₂ j₂, φ i₁ j₁ i₂ j₂) :
+  Π i₂ j₂ i₁ j₁, φ i₁ j₁ i₂ j₂ :=
+λ i₂ j₂ i₁ j₁, f i₁ j₁ i₂ j₂
+
 end miscellany
+
+open function
 
 /-!
 ### Declarations about propositional connectives
@@ -948,6 +956,11 @@ exists.elim hp (λ a hp', ⟨_, hpq _ hp'⟩)
 theorem forall_swap {p : α → β → Prop} : (∀ x y, p x y) ↔ ∀ y x, p x y :=
 ⟨swap, swap⟩
 
+lemma forall₂_swap {ι₁ ι₂ : Sort*} {κ₁ : ι₁ → Sort*} {κ₂ : ι₂ → Sort*}
+  {p : Π i₁, κ₁ i₁ → Π i₂, κ₂ i₂ → Prop} :
+  (∀ i₁ j₁ i₂ j₂, p i₁ j₁ i₂ j₂) ↔ ∀ i₂ j₂ i₁ j₁, p i₁ j₁ i₂ j₂ :=
+⟨swap₂, swap₂⟩
+
 /-- We intentionally restrict the type of `α` in this lemma so that this is a safer to use in simp
 than `forall_swap`. -/
 lemma imp_forall_iff {α : Type*} {p : Prop} {q : α → Prop} : (p → ∀ x, q x) ↔ (∀ x, p → q x) :=
@@ -962,15 +975,6 @@ theorem exists_swap {p : α → β → Prop} : (∃ x y, p x y) ↔ ∃ y x, p x
 
 theorem exists_imp_distrib : ((∃ x, p x) → b) ↔ ∀ x, p x → b :=
 forall_exists_index
-
-section dependent
-
-lemma forall₂_swap {ι₁ ι₂ : Sort*} {κ₁ : ι₁ → Sort*} {κ₂ : ι₁ → Sort*}
-  {p : Π i₁, κ₁ i₁ → Π i₂, κ₂ i₂ → Prop} :
-  (∀ i₁ j₁ i₂ j₂, p i₁ j₁ i₂ j₂) ↔ ∀ i₂ j₂ i₁ j₁, p i₁ j₁ i₂ j₂ :=
-⟨λ h i₂ j₂ i₁ j₁, h i₁ j₁ i₂ j₂, λ h i₁ j₁ i₂ j₂, h i₂ j₂ i₁ j₁⟩
-
-end dependent
 
 /--
 Extract an element from a existential statement, using `classical.some`.

--- a/src/order/monotone.lean
+++ b/src/order/monotone.lean
@@ -229,19 +229,23 @@ protected lemma strict_anti_on.dual_right (hf : strict_anti_on f s) :
   strict_mono_on (to_dual ∘ f) s :=
 λ a ha b hb, hf ha hb
 
-@[simp] lemma strict_anti_on_to_dual_comp_iff : strict_anti_on (to_dual ∘ f) s ↔ strict_mono_on f s :=
+@[simp] lemma strict_anti_on_to_dual_comp_iff :
+  strict_anti_on (to_dual ∘ f) s ↔ strict_mono_on f s :=
 iff.rfl
 
-@[simp] lemma strict_mono_on_comp_of_dual_iff : strict_mono_on (f ∘ of_dual) s ↔ strict_anti_on f s :=
+@[simp] lemma strict_mono_on_comp_of_dual_iff :
+  strict_mono_on (f ∘ of_dual) s ↔ strict_anti_on f s :=
 -- forall₂_swap
 begin
 split; exact λ hf a ha b hb h, hf hb ha h
 end
 
-@[simp] lemma strict_mono_on_to_dual_comp_iff : strict_mono_on (to_dual ∘ f) s ↔ strict_anti_on f s :=
+@[simp] lemma strict_mono_on_to_dual_comp_iff :
+  strict_mono_on (to_dual ∘ f) s ↔ strict_anti_on f s :=
 iff.rfl
 
-@[simp] lemma strict_anti_on_comp_of_dual_iff : strict_anti_on (f ∘ of_dual) s ↔ strict_mono_on f s :=
+@[simp] lemma strict_anti_on_comp_of_dual_iff :
+  strict_anti_on (f ∘ of_dual) s ↔ strict_mono_on f s :=
 -- forall₂_swap
 begin
 split; exact λ hf a ha b hb h, hf hb ha h

--- a/src/order/monotone.lean
+++ b/src/order/monotone.lean
@@ -100,156 +100,79 @@ end monotone_def
 
 /-! ### Monotonicity on the dual order
 
-Strictly many of the `*_on.dual` lemmas in this section should use `of_dual ⁻¹' s` instead of `s`,
+Strictly, many of the `*_on.dual` lemmas in this section should use `of_dual ⁻¹' s` instead of `s`,
 but right now this is not possible as `set.preimage` is not defined yet, and importing it creates
 an import cycle.
+
+Often, you should not need the rewriting lemmas. Instead, you probably want to add `.dual`,
+`.dual_left` or `.dual_right` to your `monotone`/`antitone` hypothesis.
 -/
 
 section order_dual
 open order_dual
 variables [preorder α] [preorder β] {f : α → β} {s : set α}
 
-protected theorem monotone.dual (hf : monotone f) : monotone (to_dual ∘ f ∘ of_dual) :=
-λ a b h, hf h
-
-protected lemma monotone.dual_left (hf : monotone f) : antitone (f ∘ of_dual) :=
-λ a b h, hf h
-
-protected lemma monotone.dual_right (hf : monotone f) : antitone (to_dual ∘ f) :=
-λ a b h, hf h
-
-protected theorem antitone.dual (hf : antitone f) : antitone (to_dual ∘ f ∘ of_dual) :=
-λ a b h, hf h
-
-protected lemma antitone.dual_left (hf : antitone f) : monotone (f ∘ of_dual) :=
-λ a b h, hf h
-
-protected lemma antitone.dual_right (hf : antitone f) : monotone (to_dual ∘ f) :=
-λ a b h, hf h
-
-@[simp] lemma antitone_to_dual_comp_iff : antitone (to_dual ∘ f) ↔ monotone f :=
-iff.rfl
-
-@[simp] lemma monotone_comp_of_dual_iff : monotone (f ∘ of_dual) ↔ antitone f :=
-forall_swap
-
-@[simp] lemma monotone_to_dual_comp_iff : monotone (to_dual ∘ f) ↔ antitone f :=
-iff.rfl
-
-@[simp] lemma antitone_comp_of_dual_iff : antitone (f ∘ of_dual) ↔ monotone f :=
-forall_swap
-
-protected theorem monotone_on.dual (hf : monotone_on f s) : monotone_on (to_dual ∘ f ∘ of_dual) s :=
-λ a ha b hb, hf hb ha
-
-protected lemma monotone_on.dual_left (hf : monotone_on f s) : antitone_on (f ∘ of_dual) s :=
-λ a ha b hb, hf hb ha
-
-protected lemma monotone_on.dual_right (hf : monotone_on f s) : antitone_on (to_dual ∘ f) s :=
-λ a ha b hb, hf ha hb
-
-protected theorem antitone_on.dual (hf : antitone_on f s) : antitone_on (to_dual ∘ f ∘ of_dual) s :=
-λ a ha b hb, hf hb ha
-
-protected lemma antitone_on.dual_left (hf : antitone_on f s) : monotone_on (f ∘ of_dual) s :=
-λ a ha b hb, hf hb ha
-
-protected lemma antitone_on.dual_right (hf : antitone_on f s) : monotone_on (to_dual ∘ f) s :=
-λ a ha b hb, hf ha hb
-
-@[simp] lemma antitone_on_to_dual_comp_iff : antitone_on (to_dual ∘ f) s ↔ monotone_on f s :=
-iff.rfl
+@[simp] lemma monotone_comp_of_dual_iff : monotone (f ∘ of_dual) ↔ antitone f := forall_swap
+@[simp] lemma antitone_comp_of_dual_iff : antitone (f ∘ of_dual) ↔ monotone f := forall_swap
+@[simp] lemma monotone_to_dual_comp_iff : monotone (to_dual ∘ f) ↔ antitone f := iff.rfl
+@[simp] lemma antitone_to_dual_comp_iff : antitone (to_dual ∘ f) ↔ monotone f := iff.rfl
 
 @[simp] lemma monotone_on_comp_of_dual_iff : monotone_on (f ∘ of_dual) s ↔ antitone_on f s :=
--- forall₂_swap
-begin
-split; exact λ hf a ha b hb h, hf hb ha h
-end
-
+forall₂_swap
+@[simp] lemma antitone_on_comp_of_dual_iff : antitone_on (f ∘ of_dual) s ↔ monotone_on f s :=
+forall₂_swap
 @[simp] lemma monotone_on_to_dual_comp_iff : monotone_on (to_dual ∘ f) s ↔ antitone_on f s :=
 iff.rfl
-
-@[simp] lemma antitone_on_comp_of_dual_iff : antitone_on (f ∘ of_dual) s ↔ monotone_on f s :=
--- forall₂_swap
-begin
-split; exact λ hf a ha b hb h, hf hb ha h
-end
-
-protected theorem strict_mono.dual (hf : strict_mono f) : strict_mono (to_dual ∘ f ∘ of_dual) :=
-λ a b h, hf h
-
-protected lemma strict_mono.dual_left (hf : strict_mono f) : strict_anti (f ∘ of_dual) :=
-λ a b h, hf h
-
-protected lemma strict_mono.dual_right (hf : strict_mono f) : strict_anti (to_dual ∘ f) :=
-λ a b h, hf h
-
-protected theorem strict_anti.dual (hf : strict_anti f) : strict_anti (to_dual ∘ f ∘ of_dual) :=
-λ a b h, hf h
-
-protected lemma strict_anti.dual_left (hf : strict_anti f) : strict_mono (f ∘ of_dual) :=
-λ a b h, hf h
-
-protected lemma strict_anti.dual_right (hf : strict_anti f) : strict_mono (to_dual ∘ f) :=
-λ a b h, hf h
-
-@[simp] lemma strict_anti_to_dual_comp_iff : strict_anti (to_dual ∘ f) ↔ strict_mono f :=
+@[simp] lemma antitone_on_to_dual_comp_iff : antitone_on (to_dual ∘ f) s ↔ monotone_on f s :=
 iff.rfl
 
 @[simp] lemma strict_mono_comp_of_dual_iff : strict_mono (f ∘ of_dual) ↔ strict_anti f :=
 forall_swap
-
-@[simp] lemma strict_mono_to_dual_comp_iff : strict_mono (to_dual ∘ f) ↔ strict_anti f :=
-iff.rfl
-
 @[simp] lemma strict_anti_comp_of_dual_iff : strict_anti (f ∘ of_dual) ↔ strict_mono f :=
 forall_swap
-
-protected theorem strict_mono_on.dual (hf : strict_mono_on f s) :
-  strict_mono_on (to_dual ∘ f ∘ of_dual) s :=
-λ a ha b hb, hf hb ha
-
-protected lemma strict_mono_on.dual_left (hf : strict_mono_on f s) :
-  strict_anti_on (f ∘ of_dual) s :=
-λ a ha b hb, hf hb ha
-
-protected lemma strict_mono_on.dual_right (hf : strict_mono_on f s) :
-  strict_anti_on (to_dual ∘ f) s :=
-λ a ha b hb, hf ha hb
-
-protected theorem strict_anti_on.dual (hf : strict_anti_on f s) :
-  strict_anti_on (to_dual ∘ f ∘ of_dual) s :=
-λ a ha b hb, hf hb ha
-
-protected lemma strict_anti_on.dual_left (hf : strict_anti_on f s) :
-  strict_mono_on (f ∘ of_dual) s :=
-λ a ha b hb, hf hb ha
-
-protected lemma strict_anti_on.dual_right (hf : strict_anti_on f s) :
-  strict_mono_on (to_dual ∘ f) s :=
-λ a ha b hb, hf ha hb
-
-@[simp] lemma strict_anti_on_to_dual_comp_iff :
-  strict_anti_on (to_dual ∘ f) s ↔ strict_mono_on f s :=
-iff.rfl
+@[simp] lemma strict_mono_to_dual_comp_iff : strict_mono (to_dual ∘ f) ↔ strict_anti f := iff.rfl
+@[simp] lemma strict_anti_to_dual_comp_iff : strict_anti (to_dual ∘ f) ↔ strict_mono f := iff.rfl
 
 @[simp] lemma strict_mono_on_comp_of_dual_iff :
-  strict_mono_on (f ∘ of_dual) s ↔ strict_anti_on f s :=
--- forall₂_swap
-begin
-split; exact λ hf a ha b hb h, hf hb ha h
-end
-
-@[simp] lemma strict_mono_on_to_dual_comp_iff :
-  strict_mono_on (to_dual ∘ f) s ↔ strict_anti_on f s :=
-iff.rfl
-
+  strict_mono_on (f ∘ of_dual) s ↔ strict_anti_on f s := forall₂_swap
 @[simp] lemma strict_anti_on_comp_of_dual_iff :
-  strict_anti_on (f ∘ of_dual) s ↔ strict_mono_on f s :=
--- forall₂_swap
-begin
-split; exact λ hf a ha b hb h, hf hb ha h
-end
+  strict_anti_on (f ∘ of_dual) s ↔ strict_mono_on f s := forall₂_swap
+@[simp] lemma strict_mono_on_to_dual_comp_iff :
+  strict_mono_on (to_dual ∘ f) s ↔ strict_anti_on f s := iff.rfl
+@[simp] lemma strict_anti_on_to_dual_comp_iff :
+  strict_anti_on (to_dual ∘ f) s ↔ strict_mono_on f s := iff.rfl
+
+protected lemma monotone.dual (hf : monotone f) : monotone (to_dual ∘ f ∘ of_dual) := swap hf
+protected lemma antitone.dual (hf : antitone f) : antitone (to_dual ∘ f ∘ of_dual) := swap hf
+protected lemma monotone_on.dual (hf : monotone_on f s) : monotone_on (to_dual ∘ f ∘ of_dual) s :=
+swap₂ hf
+protected lemma antitone_on.dual (hf : antitone_on f s) : antitone_on (to_dual ∘ f ∘ of_dual) s :=
+swap₂ hf
+protected lemma strict_mono.dual (hf : strict_mono f) : strict_mono (to_dual ∘ f ∘ of_dual) :=
+swap hf
+protected lemma strict_anti.dual (hf : strict_anti f) : strict_anti (to_dual ∘ f ∘ of_dual) :=
+swap hf
+protected lemma strict_mono_on.dual (hf : strict_mono_on f s) :
+  strict_mono_on (to_dual ∘ f ∘ of_dual) s := swap₂ hf
+protected lemma strict_anti_on.dual (hf : strict_anti_on f s) :
+  strict_anti_on (to_dual ∘ f ∘ of_dual) s := swap₂ hf
+
+alias antitone_comp_of_dual_iff ↔ _ monotone.dual_left
+alias monotone_comp_of_dual_iff ↔ _ antitone.dual_left
+alias antitone_to_dual_comp_iff ↔ _ monotone.dual_right
+alias monotone_to_dual_comp_iff ↔ _ antitone.dual_right
+alias antitone_on_comp_of_dual_iff ↔ _ monotone_on.dual_left
+alias monotone_on_comp_of_dual_iff ↔ _ antitone_on.dual_left
+alias antitone_on_to_dual_comp_iff ↔ _ monotone_on.dual_right
+alias monotone_on_to_dual_comp_iff ↔ _ antitone_on.dual_right
+alias strict_anti_comp_of_dual_iff ↔ _ strict_mono.dual_left
+alias strict_mono_comp_of_dual_iff ↔ _ strict_anti.dual_left
+alias strict_anti_to_dual_comp_iff ↔ _ strict_mono.dual_right
+alias strict_mono_to_dual_comp_iff ↔ _ strict_anti.dual_right
+alias strict_anti_on_comp_of_dual_iff ↔ _ strict_mono_on.dual_left
+alias strict_mono_on_comp_of_dual_iff ↔ _ strict_anti_on.dual_left
+alias strict_anti_on_to_dual_comp_iff ↔ _ strict_mono_on.dual_right
+alias strict_mono_on_to_dual_comp_iff ↔ _ strict_anti_on.dual_right
 
 end order_dual
 

--- a/src/order/monotone.lean
+++ b/src/order/monotone.lean
@@ -127,6 +127,18 @@ protected lemma antitone.dual_left (hf : antitone f) : monotone (f ∘ of_dual) 
 protected lemma antitone.dual_right (hf : antitone f) : monotone (to_dual ∘ f) :=
 λ a b h, hf h
 
+@[simp] lemma antitone_to_dual_comp_iff : antitone (to_dual ∘ f) ↔ monotone f :=
+iff.rfl
+
+@[simp] lemma monotone_comp_of_dual_iff : monotone (f ∘ of_dual) ↔ antitone f :=
+forall_swap
+
+@[simp] lemma monotone_to_dual_comp_iff : monotone (to_dual ∘ f) ↔ antitone f :=
+iff.rfl
+
+@[simp] lemma antitone_comp_of_dual_iff : antitone (f ∘ of_dual) ↔ monotone f :=
+forall_swap
+
 protected theorem monotone_on.dual (hf : monotone_on f s) : monotone_on (to_dual ∘ f ∘ of_dual) s :=
 λ a ha b hb, hf hb ha
 
@@ -145,6 +157,24 @@ protected lemma antitone_on.dual_left (hf : antitone_on f s) : monotone_on (f �
 protected lemma antitone_on.dual_right (hf : antitone_on f s) : monotone_on (to_dual ∘ f) s :=
 λ a ha b hb, hf ha hb
 
+@[simp] lemma antitone_on_to_dual_comp_iff : antitone_on (to_dual ∘ f) s ↔ monotone_on f s :=
+iff.rfl
+
+@[simp] lemma monotone_on_comp_of_dual_iff : monotone_on (f ∘ of_dual) s ↔ antitone_on f s :=
+-- forall₂_swap
+begin
+split; exact λ hf a ha b hb h, hf hb ha h
+end
+
+@[simp] lemma monotone_on_to_dual_comp_iff : monotone_on (to_dual ∘ f) s ↔ antitone_on f s :=
+iff.rfl
+
+@[simp] lemma antitone_on_comp_of_dual_iff : antitone_on (f ∘ of_dual) s ↔ monotone_on f s :=
+-- forall₂_swap
+begin
+split; exact λ hf a ha b hb h, hf hb ha h
+end
+
 protected theorem strict_mono.dual (hf : strict_mono f) : strict_mono (to_dual ∘ f ∘ of_dual) :=
 λ a b h, hf h
 
@@ -162,6 +192,18 @@ protected lemma strict_anti.dual_left (hf : strict_anti f) : strict_mono (f ∘ 
 
 protected lemma strict_anti.dual_right (hf : strict_anti f) : strict_mono (to_dual ∘ f) :=
 λ a b h, hf h
+
+@[simp] lemma strict_anti_to_dual_comp_iff : strict_anti (to_dual ∘ f) ↔ strict_mono f :=
+iff.rfl
+
+@[simp] lemma strict_mono_comp_of_dual_iff : strict_mono (f ∘ of_dual) ↔ strict_anti f :=
+forall_swap
+
+@[simp] lemma strict_mono_to_dual_comp_iff : strict_mono (to_dual ∘ f) ↔ strict_anti f :=
+iff.rfl
+
+@[simp] lemma strict_anti_comp_of_dual_iff : strict_anti (f ∘ of_dual) ↔ strict_mono f :=
+forall_swap
 
 protected theorem strict_mono_on.dual (hf : strict_mono_on f s) :
   strict_mono_on (to_dual ∘ f ∘ of_dual) s :=
@@ -186,6 +228,24 @@ protected lemma strict_anti_on.dual_left (hf : strict_anti_on f s) :
 protected lemma strict_anti_on.dual_right (hf : strict_anti_on f s) :
   strict_mono_on (to_dual ∘ f) s :=
 λ a ha b hb, hf ha hb
+
+@[simp] lemma strict_anti_on_to_dual_comp_iff : strict_anti_on (to_dual ∘ f) s ↔ strict_mono_on f s :=
+iff.rfl
+
+@[simp] lemma strict_mono_on_comp_of_dual_iff : strict_mono_on (f ∘ of_dual) s ↔ strict_anti_on f s :=
+-- forall₂_swap
+begin
+split; exact λ hf a ha b hb h, hf hb ha h
+end
+
+@[simp] lemma strict_mono_on_to_dual_comp_iff : strict_mono_on (to_dual ∘ f) s ↔ strict_anti_on f s :=
+iff.rfl
+
+@[simp] lemma strict_anti_on_comp_of_dual_iff : strict_anti_on (f ∘ of_dual) s ↔ strict_mono_on f s :=
+-- forall₂_swap
+begin
+split; exact λ hf a ha b hb h, hf hb ha h
+end
 
 end order_dual
 


### PR DESCRIPTION
Add 4 lemmas of the kind `antitone_to_dual_comp_iff`
Add their variants for `antitone_on`
Add their strict variants

---

4 proofs (related to `antitone_on` and their strict variants) should work with some `forall2_swap` but do not.

This PR incorporates lemmas that were in #13202 — they have to be deleted there after this one is merged.

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
