### PR TITLE
[Merged by Bors] - chore(algebra/char_p/{basic + algebra}): weaken assumptions for char_p_to_char_zero

### DIFF
--- a/src/algebra/char_p/algebra.lean
+++ b/src/algebra/char_p/algebra.lean
@@ -89,7 +89,7 @@ char_p_of_injective_algebra_map (is_fraction_ring.injective R K) p
 
 /-- If `R` has characteristic `0`, then so does Frac(R). -/
 lemma char_zero_of_is_fraction_ring [char_zero R] : char_zero K :=
-@char_p.char_p_to_char_zero K _ (char_p_of_is_fraction_ring R 0)
+@char_p.char_p_to_char_zero K _ _ (char_p_of_is_fraction_ring R 0)
 
 variables [is_domain R]
 

--- a/src/algebra/char_p/basic.lean
+++ b/src/algebra/char_p/basic.lean
@@ -328,7 +328,7 @@ namespace char_p
 section
 variables [ring R]
 
-lemma char_p_to_char_zero {R : Type*} [add_left_cancel_monoid R] [has_one R] [char_p R 0] :
+lemma char_p_to_char_zero (R : Type*) [add_left_cancel_monoid R] [has_one R] [char_p R 0] :
   char_zero R :=
 char_zero_of_inj_zero $
   λ n h0, eq_zero_of_zero_dvd ((cast_eq_zero_iff R 0 n).mp h0)

--- a/src/algebra/char_p/basic.lean
+++ b/src/algebra/char_p/basic.lean
@@ -328,17 +328,18 @@ namespace char_p
 section
 variables [ring R]
 
-lemma char_p_to_char_zero [char_p R 0] : char_zero R :=
+lemma char_p_to_char_zero {R : Type*} [add_left_cancel_monoid R] [has_one R] [char_p R 0] :
+  char_zero R :=
 char_zero_of_inj_zero $
   λ n h0, eq_zero_of_zero_dvd ((cast_eq_zero_iff R 0 n).mp h0)
 
 lemma cast_eq_mod (p : ℕ) [char_p R p] (k : ℕ) : (k : R) = (k % p : ℕ) :=
 calc (k : R) = ↑(k % p + p * (k / p)) : by rw [nat.mod_add_div]
-         ... = ↑(k % p)               : by simp[cast_eq_zero]
+         ... = ↑(k % p)               : by simp [cast_eq_zero]
 
 theorem char_ne_zero_of_fintype (p : ℕ) [hc : char_p R p] [fintype R] : p ≠ 0 :=
 assume h : p = 0,
-have char_zero R := @char_p_to_char_zero R _ (h ▸ hc),
+have char_zero R := @char_p_to_char_zero R _ _ (h ▸ hc),
 absurd (@nat.cast_injective R _ _ this) (not_injective_infinite_fintype coe)
 
 end


### PR DESCRIPTION
The assumptions for lemma `char_p_to_char_zero` can be weakened, without changing the proof.

Since the weakening breaks up one typeclass assumption into two, when the lemma was applied with `@`, I inserted an extra `_`.  This happens twice: once in the file where the lemma is, and once in a separate file.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
