### PR TITLE
[Merged by Bors] - feat(computability/encoding): Bounds on cardinality from an encoding

### DIFF
--- a/src/computability/encoding.lean
+++ b/src/computability/encoding.lean
@@ -7,6 +7,7 @@ Authors: Pim Spelier, Daan van Gent
 import data.fintype.basic
 import data.num.lemmas
 import tactic.derive_fintype
+import set_theory.cardinal_ordinal
 
 /-!
 # Encodings
@@ -23,18 +24,32 @@ It also contains several examples:
 - `fin_encoding_bool_bool`  : an encoding of bool.
 -/
 
+universes u v
+open_locale cardinal
+
 namespace computability
 
 /-- An encoding of a type in a certain alphabet, together with a decoding. -/
-structure encoding (α : Type) :=
-(Γ : Type)
+structure encoding (α : Type u) :=
+(Γ : Type v)
 (encode : α → list Γ)
 (decode : list Γ → option α)
 (decode_encode : ∀ x, decode (encode x) = some x)
 
+lemma encoding.encode_injective {α : Type u} (e : encoding α) :
+  function.injective e.encode :=
+begin
+  refine λ _ _ h, option.some_injective _ _,
+  rw [← e.decode_encode, ← e.decode_encode, h],
+end
+
 /-- An encoding plus a guarantee of finiteness of the alphabet. -/
-structure fin_encoding (α : Type) extends encoding α :=
+structure fin_encoding (α : Type u) extends encoding α :=
 (Γ_fin : fintype Γ)
+
+instance {α : Type u} (e : fin_encoding α) :
+  fintype e.to_encoding.Γ :=
+e.Γ_fin
 
 /-- A standard Turing machine alphabet, consisting of blank,bit0,bit1,bra,ket,comma. -/
 @[derive [decidable_eq,fintype]]
@@ -174,5 +189,20 @@ def fin_encoding_bool_bool : fin_encoding bool :=
 instance inhabited_fin_encoding : inhabited (fin_encoding bool) := ⟨fin_encoding_bool_bool⟩
 
 instance inhabited_encoding : inhabited (encoding bool) := ⟨fin_encoding_bool_bool.to_encoding⟩
+
+lemma encoding.card_le_card_list {α : Type u} (e : encoding.{u v} α) :
+  cardinal.lift.{v} (# α) ≤ cardinal.lift.{u} (# (list e.Γ)) :=
+(cardinal.lift_mk_le').2 ⟨⟨e.encode, e.encode_injective⟩⟩
+
+lemma fin_encoding.card_le_omega {α : Type u} [nonempty α] (e : fin_encoding.{u v} α) :
+  (# α) ≤ ω :=
+begin
+  refine cardinal.lift_le.1 (e.to_encoding.card_le_card_list.trans _),
+  simp only [cardinal.lift_omega, cardinal.lift_le_omega],
+  haveI : encodable e.Γ := fintype.encodable _,
+  casesI is_empty_or_nonempty e.Γ with h h,
+  { simp only [cardinal.mk_le_omega], },
+  { rw cardinal.mk_list_eq_omega },
+end
 
 end computability

--- a/src/computability/encoding.lean
+++ b/src/computability/encoding.lean
@@ -44,7 +44,7 @@ begin
 end
 
 /-- An encoding plus a guarantee of finiteness of the alphabet. -/
-structure fin_encoding (α : Type u) extends encoding α :=
+structure fin_encoding (α : Type u) extends encoding.{u 0} α :=
 (Γ_fin : fintype Γ)
 
 instance {α : Type u} (e : fin_encoding α) :
@@ -204,7 +204,7 @@ begin
   { rw cardinal.mk_list_eq_omega },
 end
 
-lemma fin_encoding.card_le_omega {α : Type u} (e : fin_encoding.{u v} α) :
+lemma fin_encoding.card_le_omega {α : Type u} (e : fin_encoding α) :
   (# α) ≤ ω :=
 begin
   haveI : encodable e.Γ := fintype.encodable _,

--- a/src/computability/encoding.lean
+++ b/src/computability/encoding.lean
@@ -194,15 +194,21 @@ lemma encoding.card_le_card_list {α : Type u} (e : encoding.{u v} α) :
   cardinal.lift.{v} (# α) ≤ cardinal.lift.{u} (# (list e.Γ)) :=
 (cardinal.lift_mk_le').2 ⟨⟨e.encode, e.encode_injective⟩⟩
 
-lemma fin_encoding.card_le_omega {α : Type u} [nonempty α] (e : fin_encoding.{u v} α) :
+lemma encoding.card_le_omega {α : Type u} (e : encoding.{u v} α) [encodable e.Γ] :
   (# α) ≤ ω :=
 begin
-  refine cardinal.lift_le.1 (e.to_encoding.card_le_card_list.trans _),
+  refine cardinal.lift_le.1 (e.card_le_card_list.trans _),
   simp only [cardinal.lift_omega, cardinal.lift_le_omega],
-  haveI : encodable e.Γ := fintype.encodable _,
   casesI is_empty_or_nonempty e.Γ with h h,
   { simp only [cardinal.mk_le_omega], },
   { rw cardinal.mk_list_eq_omega },
+end
+
+lemma fin_encoding.card_le_omega {α : Type u} (e : fin_encoding.{u v} α) :
+  (# α) ≤ ω :=
+begin
+  haveI : encodable e.Γ := fintype.encodable _,
+  exact e.to_encoding.card_le_omega,
 end
 
 end computability


### PR DESCRIPTION
Generalizes universe variables for `computability.encoding`
Uses a `computability.encoding` to bound the cardinality of a type

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
