### PR TITLE
[Merged by Bors] - fix(tactic/apply_rules): separate single rules and attribute names in syntax

### DIFF
--- a/src/measure_theory/tactic.lean
+++ b/src/measure_theory/tactic.lean
@@ -131,7 +131,7 @@ meta def measurability_tactics (md : transparency := semireducible) : list (tact
                         >> pure "apply_assumption",
   goal_is_not_measurable >> intro1
                         >>= λ ns, pure ("intro " ++ ns.to_string),
-  apply_rules [sum.inl ``measurability] 50 { md := md }
+  apply_rules [] [``measurability] 50 { md := md }
                         >> pure "apply_rules measurability",
   apply_measurable.comp >> pure "refine measurable.comp _ _",
   apply_measurable.comp_ae_measurable

--- a/src/measure_theory/tactic.lean
+++ b/src/measure_theory/tactic.lean
@@ -132,7 +132,7 @@ meta def measurability_tactics (md : transparency := semireducible) : list (tact
   goal_is_not_measurable >> intro1
                         >>= λ ns, pure ("intro " ++ ns.to_string),
   apply_rules [] [``measurability] 50 { md := md }
-                        >> pure "apply_rules measurability",
+                        >> pure "apply_rules with measurability",
   apply_measurable.comp >> pure "refine measurable.comp _ _",
   apply_measurable.comp_ae_measurable
                         >> pure "refine measurable.comp_ae_measurable _ _",

--- a/src/measure_theory/tactic.lean
+++ b/src/measure_theory/tactic.lean
@@ -131,7 +131,7 @@ meta def measurability_tactics (md : transparency := semireducible) : list (tact
                         >> pure "apply_assumption",
   goal_is_not_measurable >> intro1
                         >>= λ ns, pure ("intro " ++ ns.to_string),
-  apply_rules [``(measurability)] 50 { md := md }
+  apply_rules [sum.inl ``measurability] 50 { md := md }
                         >> pure "apply_rules measurability",
   apply_measurable.comp >> pure "refine measurable.comp _ _",
   apply_measurable.comp_ae_measurable

--- a/src/tactic/interactive.lean
+++ b/src/tactic/interactive.lean
@@ -505,14 +505,6 @@ add_tactic_doc
   tags       := ["structures"],
   inherit_description_from := `tactic.interactive.refine_struct }
 
-/-- Given a pexpr parsed by the interactive parser, return a name if it is a single identifier,
-otherwise the original pexpr. -/
-meta def pexpr.to_name_or_pexpr (p : pexpr) : name ⊕ pexpr :=
-match p.local_pp_name with
-| name.anonymous := sum.inr p
-| n := sum.inl n
-end
-
 /--
 `apply_rules hs with attrs n` applies the list of lemmas `hs` and all lemmas tagged with an
 attribute from the list `attrs`, as well as the `assumption` tactic on the

--- a/src/tactic/interactive.lean
+++ b/src/tactic/interactive.lean
@@ -505,6 +505,14 @@ add_tactic_doc
   tags       := ["structures"],
   inherit_description_from := `tactic.interactive.refine_struct }
 
+/-- Parses either an identifier or a pexpr -/
+meta def parser.ident_or_pexpr : lean.parser (name ⊕ pexpr) :=
+sum.inl <$> ident <|> sum.inr <$> parser.pexpr
+
+/-- Parses an identifier, a pexpr, or a list of identifiers or pexprs. -/
+meta def apply_rules_parser : lean.parser (list (name ⊕ pexpr)) :=
+list_of parser.ident_or_pexpr <|> list.ret <$> parser.ident_or_pexpr
+
 /--
 `apply_rules hs n` applies the list of lemmas `hs` and `assumption` on the
 first goal and the resulting subgoals, iteratively, at most `n` times.
@@ -536,7 +544,7 @@ by apply_rules [mono_rules]
 by apply_rules mono_rules
 ```
 -/
-meta def apply_rules (hs : parse pexpr_list_or_texpr) (n : nat := 50) (opt : apply_cfg := {}) :
+meta def apply_rules (hs : parse apply_rules_parser) (n : nat := 50) (opt : apply_cfg := {}) :
   tactic unit :=
 tactic.apply_rules hs n opt
 

--- a/src/tactic/interactive.lean
+++ b/src/tactic/interactive.lean
@@ -514,16 +514,14 @@ match p.local_pp_name with
 end
 
 /--
-`apply_rules hs n` applies the list of lemmas `hs` and `assumption` on the
+`apply_rules hs with attrs n` applies the list of lemmas `hs` and all lemmas tagged with an
+attribute from the list `attrs`, as well as the `assumption` tactic on the
 first goal and the resulting subgoals, iteratively, at most `n` times.
 `n` is optional, equal to 50 by default.
 You can pass an `apply_cfg` option argument as `apply_rules hs n opt`.
 (A typical usage would be with `apply_rules hs n { md := reducible })`,
 which asks `apply_rules` to not unfold `semireducible` definitions (i.e. most)
 when checking if a lemma matches the goal.)
-
-`hs` can contain user attributes: in this case all theorems with this
-attribute are added to the list of rules.
 
 For instance:
 
@@ -540,13 +538,14 @@ a + c * e + a + c + 0 ≤ b + d * e + b + d + e :=
 -- any of the following lines solve the goal:
 add_le_add (add_le_add (add_le_add (add_le_add h1 (mul_le_mul_of_nonneg_right h2 h3)) h1 ) h2) h3
 by apply_rules [add_le_add, mul_le_mul_of_nonneg_right]
-by apply_rules [mono_rules]
-by apply_rules mono_rules
+by apply_rules with mono_rules
+by apply_rules [add_le_add] with mono_rules
 ```
 -/
-meta def apply_rules (hs : parse pexpr_list_or_texpr) (n : nat := 50) (opt : apply_cfg := {}) :
+meta def apply_rules (args : parse opt_pexpr_list) (attrs : parse with_ident_list)
+  (n : nat := 50) (opt : apply_cfg := {}) :
   tactic unit :=
-tactic.apply_rules (hs.map pexpr.to_name_or_pexpr) n opt
+tactic.apply_rules args attrs n opt
 
 add_tactic_doc
 { name       := "apply_rules",

--- a/src/topology/tactic.lean
+++ b/src/topology/tactic.lean
@@ -68,7 +68,7 @@ meta def apply_continuous.comp : tactic unit :=
 meta def continuity_tactics (md : transparency := reducible) : list (tactic string) :=
 [
   intros1               >>= λ ns, pure ("intros " ++ (" ".intercalate (ns.map (λ e, e.to_string)))),
-  apply_rules [sum.inl ``continuity] 50 { md := md }
+  apply_rules [] [``continuity] 50 { md := md }
                         >> pure "apply_rules continuity",
   apply_continuous.comp >> pure "refine continuous.comp _ _"
 ]

--- a/src/topology/tactic.lean
+++ b/src/topology/tactic.lean
@@ -68,7 +68,7 @@ meta def apply_continuous.comp : tactic unit :=
 meta def continuity_tactics (md : transparency := reducible) : list (tactic string) :=
 [
   intros1               >>= λ ns, pure ("intros " ++ (" ".intercalate (ns.map (λ e, e.to_string)))),
-  apply_rules [``(continuity)] 50 { md := md }
+  apply_rules [sum.inl ``continuity] 50 { md := md }
                         >> pure "apply_rules continuity",
   apply_continuous.comp >> pure "refine continuous.comp _ _"
 ]

--- a/src/topology/tactic.lean
+++ b/src/topology/tactic.lean
@@ -69,7 +69,7 @@ meta def continuity_tactics (md : transparency := reducible) : list (tactic stri
 [
   intros1               >>= λ ns, pure ("intros " ++ (" ".intercalate (ns.map (λ e, e.to_string)))),
   apply_rules [] [``continuity] 50 { md := md }
-                        >> pure "apply_rules continuity",
+                        >> pure "apply_rules with continuity",
   apply_continuous.comp >> pure "refine continuous.comp _ _"
 ]
 

--- a/test/apply_rules.lean
+++ b/test/apply_rules.lean
@@ -33,6 +33,7 @@ end
 
 /-
 Test that there are no conflicts between attribute and declaration names.
+After #13227 there is little chance of ambiguity here, but this is still a valid test.
 -/
 
 @[user_attribute]

--- a/test/apply_rules.lean
+++ b/test/apply_rules.lean
@@ -30,3 +30,21 @@ example (P : ℕ → Type) (f : Π {n : ℕ}, P n → P (n + 1)) (g : P 0) : P 2
 begin
   apply_rules [f, g],
 end
+
+/-
+Test that there are no conflicts between attribute and declaration names.
+-/
+
+@[user_attribute]
+meta def p_rules_attr : user_attribute :=
+{ name := `p_rules,
+  descr := "testing" }
+
+constant P : ℕ → Prop
+
+axiom p_rules : P 0
+
+@[p_rules] axiom foo : P 10
+
+example : P 0 := by apply_rules p_rules
+example : P 10 := by apply_rules p_rules

--- a/test/apply_rules.lean
+++ b/test/apply_rules.lean
@@ -19,11 +19,11 @@ attribute [mono_rules] add_le_add mul_le_mul_of_nonneg_right
 
 example {a b c d e : nat} (h1 : a ≤ b) (h2 : c ≤ d) (h3 : 0 ≤ e) :
 a + c * e + a + c + 0 ≤ b + d * e + b + d + e :=
-by apply_rules [mono_rules]
+by apply_rules with mono_rules
 
 example {a b c d e : nat} (h1 : a ≤ b) (h2 : c ≤ d) (h3 : 0 ≤ e) :
 a + c * e + a + c + 0 ≤ b + d * e + b + d + e :=
-by apply_rules mono_rules
+by apply_rules with mono_rules
 
 -- test that metavariables created for implicit arguments don't get stuck
 example (P : ℕ → Type) (f : Π {n : ℕ}, P n → P (n + 1)) (g : P 0) : P 2 :=
@@ -46,5 +46,5 @@ axiom p_rules : P 0
 
 @[p_rules] axiom foo : P 10
 
-example : P 0 := by apply_rules p_rules
-example : P 10 := by apply_rules p_rules
+example : P 0 := by success_if_fail {apply_rules with p_rules}; apply_rules [p_rules]
+example : P 10 := by apply_rules with p_rules 60


### PR DESCRIPTION
@hrmacbeth reported an issue with `apply_rules` [on Zulip](https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/monotonicity.2Eattr.20with.20apply_rules). It boiled down to `apply_rules` not properly distinguishing between attribute names, the names of `user_attribute` declarations, and the names of normal declarations. There's an example of using `apply_rules` with attributes in the docs:
```lean
@[user_attribute]
meta def mono_rules : user_attribute :=
{ name := `mono_rules,
  descr := "lemmas usable to prove monotonicity" }

local attribute [mono_rules] add_le_add

example (a b c d : α) : a + b ≤ c + d :=
begin
  apply_rules mono_rules, -- takes action
end
```
but this only worked by coincidence because the attribute name and the name of the `user_attribute` declaration were the same.

With this change, expressions and names of attributes are now separated: the latter are specified after `with`. The call above becomes `apply_rules with mono_rules`. This mirrors the syntax of `simp`. Note that this feature was only used in meta code in mathlib.

The example from Zulip (modified for proper syntax) still doesn't work with my change:
```lean
import tactic.monotonicity

variables {α : Type*} [linear_ordered_add_comm_group α]

example (a b c d : α) : a + b ≤ c + d :=
begin
  apply_rules with mono,
end
```
but it seems to fail because the `mono` rules cause `apply_rules` to loop -- that is, the rule set is getting applied correctly. 

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
