### PR TITLE
[Merged by Bors] - feat(group_theory/coset): Right cosets are in bijection with left cosets

### DIFF
--- a/src/group_theory/coset.lean
+++ b/src/group_theory/coset.lean
@@ -6,6 +6,7 @@ Authors: Mitchell Rowett, Scott Morrison
 
 import algebra.quotient
 import group_theory.subgroup.basic
+import tactic.group
 
 /-!
 # Cosets
@@ -245,6 +246,18 @@ by { ext, exact (right_coset_eq_iff s).symm }
 @[to_additive]
 instance right_rel_decidable [decidable_pred (∈ s)] :
   decidable_rel (right_rel s).r := λ x y, ‹decidable_pred (∈ s)› _
+
+/-- Right cosets are in bijection with left cosets. -/
+@[to_additive "Right cosets are in bijection with left cosets."]
+def quotient_right_rel_equiv_quotient_left_rel : quotient (quotient_group.right_rel s) ≃ α ⧸ s :=
+{ to_fun := quotient.map' (λ g, g⁻¹) (λ a b h, (congr_arg (∈ s) (by group)).mp (s.inv_mem h)),
+  inv_fun := quotient.map' (λ g, g⁻¹) (λ a b h, (congr_arg (∈ s) (by group)).mp (s.inv_mem h)),
+  left_inv := λ g, quotient.induction_on' g (λ g, quotient.sound' (by
+  { simp only [inv_inv],
+    exact quotient.exact' rfl })),
+  right_inv := λ g, quotient.induction_on' g (λ g, quotient.sound' (by
+  { simp only [inv_inv],
+    exact quotient.exact' rfl })) }
 
 end quotient_group
 


### PR DESCRIPTION
Right cosets are in bijection with left cosets. This came up in some work involving right transversals.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
