### PR TITLE
[Merged by Bors] - refactor(group_theory/commutator): Move `commutator_le_map_commutator`

### DIFF
--- a/src/group_theory/commutator.lean
+++ b/src/group_theory/commutator.lean
@@ -159,6 +159,12 @@ begin
         monoid_hom.fst_comp_inr, monoid_hom.snd_comp_inr ], }, }
 end
 
+variables {H₁ H₂}
+
+lemma commutator_le_map_commutator {f : G →* G'} {K₁ K₂ : subgroup G'}
+  (h₁ : K₁ ≤ H₁.map f) (h₂ : K₂ ≤ H₂.map f) : ⁅K₁, K₂⁆ ≤ ⁅H₁, H₂⁆.map f :=
+(commutator_mono h₁ h₂).trans (ge_of_eq (map_commutator H₁ H₂ f))
+
 /-- The commutator of direct product is contained in the direct product of the commutators.
 
 See `commutator_pi_pi_of_fintype` for equality given `fintype η`.

--- a/src/group_theory/solvable.lean
+++ b/src/group_theory/solvable.lean
@@ -55,10 +55,6 @@ end derived_series
 
 section commutator_map
 
-lemma commutator_le_map_commutator {H₁ H₂ : subgroup G} {K₁ K₂ : subgroup G'} (h₁ : K₁ ≤ H₁.map f)
-  (h₂ : K₂ ≤ H₂.map f) : ⁅K₁, K₂⁆ ≤ ⁅H₁, H₂⁆.map f :=
-by { rw map_commutator, exact commutator_mono h₁ h₂ }
-
 section derived_series_map
 
 variables (f)


### PR DESCRIPTION
`commutator_le_map_commutator` is a general lemma about commutators, so it should be moved from `solvable.lean` to `commutator.lean`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
