### PR TITLE
[Merged by Bors] - feat(group_theory/group_action/basic): Left multiplication satisfies the `quotient_action` axiom

### DIFF
--- a/src/group_theory/group_action/basic.lean
+++ b/src/group_theory/group_action/basic.lean
@@ -309,6 +309,9 @@ class _root_.add_action.quotient_action {α : Type*} (β : Type*) [add_group α]
 
 attribute [to_additive add_action.quotient_action] mul_action.quotient_action
 
+@[to_additive] instance left_quotient_action : quotient_action α H :=
+⟨λ _ _ _ _, by rwa [smul_eq_mul, smul_eq_mul, mul_inv_rev, mul_assoc, inv_mul_cancel_left]⟩
+
 end quotient_action
 
 open quotient_group


### PR DESCRIPTION
This PR adds an instance `quotient_action α H`, meaning that left multiplication satisfies the `quotient_action` axiom.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
