### PR TITLE
feat(group_theory/commutator): Add special case of `commutator_le_map_commutator`

### DIFF
--- a/src/group_theory/commutator.lean
+++ b/src/group_theory/commutator.lean
@@ -165,6 +165,10 @@ lemma commutator_le_map_commutator {f : G →* G'} {K₁ K₂ : subgroup G'}
   (h₁ : K₁ ≤ H₁.map f) (h₂ : K₂ ≤ H₂.map f) : ⁅K₁, K₂⁆ ≤ ⁅H₁, H₂⁆.map f :=
 (commutator_mono h₁ h₂).trans (ge_of_eq (map_commutator H₁ H₂ f))
 
+lemma commutator_le_map_commutator₂ {f : G →* G'} {K₁ : subgroup G'} (h₁ : K₁ ≤ H₁.map f) :
+  ⁅K₁, K₁⁆ ≤ ⁅H₁, H₁⁆.map f :=
+commutator_le_map_commutator h₁ h₁
+
 /-- The commutator of direct product is contained in the direct product of the commutators.
 
 See `commutator_pi_pi_of_fintype` for equality given `fintype η`.

--- a/src/group_theory/solvable.lean
+++ b/src/group_theory/solvable.lean
@@ -75,7 +75,7 @@ begin
   induction n with n ih,
   { rwa [derived_series_zero, derived_series_zero, top_le_iff, ← monoid_hom.range_eq_map,
     ← monoid_hom.range_top_iff_surjective.mpr], },
-  { simp only [*, derived_series_succ, commutator_le_map_commutator], }
+  { exact commutator_le_map_commutator₂ ih }
 end
 
 lemma map_derived_series_eq (hf : function.surjective f) (n : ℕ) :
@@ -170,7 +170,7 @@ begin
     rw [←map_eq_bot_iff, eq_bot_iff, ←hn],
     exact map_derived_series_le_derived_series g n },
   { rw [nat.add_succ, derived_series_succ, derived_series_succ],
-    exact commutator_le_map_commutator hk hk },
+    exact commutator_le_map_commutator₂ hk },
 end
 
 instance solvable_prod {G' : Type*} [group G'] [h : is_solvable G] [h' : is_solvable G'] :


### PR DESCRIPTION
This PR adds a common special case of `commutator_le_map_commutator`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
