### PR TITLE
[Merged by Bors] - feat(category_theory/triangulated): upgrade map_triangle to a functor

### DIFF
--- a/src/category_theory/triangulated/pretriangulated.lean
+++ b/src/category_theory/triangulated/pretriangulated.lean
@@ -78,7 +78,7 @@ class pretriangulated :=
 namespace pretriangulated
 variables [pretriangulated C]
 
-notation `dist_triang`:20 C := distinguished_triangles C
+notation `dist_triang `:20 C := distinguished_triangles C
 /--
 Given any distinguished triangle `T`, then we know `T.rotate` is also distinguished.
 -/
@@ -162,20 +162,38 @@ is a functor `F : C ⥤ D` together with given functorial isomorphisms `ξ X : F
 structure triangulated_functor_struct extends (C ⥤ D) :=
 (comm_shift : shift_functor C (1 : ℤ) ⋙ to_functor ≅ to_functor ⋙ shift_functor D (1 : ℤ))
 
-instance : inhabited (triangulated_functor_struct C C) :=
-⟨{ obj := λ X, X,
+namespace triangulated_functor_struct
+
+/-- The identity `triangulated_functor_struct`. -/
+def id : triangulated_functor_struct C C :=
+{ obj := λ X, X,
   map := λ _ _ f, f,
-  comm_shift := by refl }⟩
+  comm_shift := by refl }
+
+instance : inhabited (triangulated_functor_struct C C) := ⟨id C⟩
 
 variables {C D}
 /--
-Given a `triangulated_functor_struct` we can define a function from triangles of `C` to
+Given a `triangulated_functor_struct` we can define a functor from triangles of `C` to
 triangles of `D`.
 -/
-@[simp]
-def triangulated_functor_struct.map_triangle (F : triangulated_functor_struct C D)
-  (T : triangle C) : triangle D :=
-triangle.mk _ (F.map T.mor₁) (F.map T.mor₂) (F.map T.mor₃ ≫ F.comm_shift.hom.app T.obj₁)
+@[simps]
+def map_triangle (F : triangulated_functor_struct C D) : triangle C ⥤ triangle D :=
+{ obj := λ T, triangle.mk _ (F.map T.mor₁) (F.map T.mor₂)
+    (F.map T.mor₃ ≫ F.comm_shift.hom.app T.obj₁),
+  map := λ S T f,
+  { hom₁ := F.map f.hom₁,
+    hom₂ := F.map f.hom₂,
+    hom₃ := F.map f.hom₃,
+    comm₁' := by { dsimp, simp only [←F.to_functor.map_comp, f.comm₁], },
+    comm₂' := by { dsimp, simp only [←F.to_functor.map_comp, f.comm₂], },
+    comm₃' := begin
+      dsimp,
+      erw [category.assoc, ←F.comm_shift.hom.naturality],
+      simp only [functor.comp_map, ←F.to_functor.map_comp_assoc, f.comm₃],
+    end, }, }
+
+end triangulated_functor_struct
 
 variables (C D)
 /--
@@ -187,8 +205,8 @@ See https://stacks.math.columbia.edu/tag/014V
 -/
 structure triangulated_functor [pretriangulated C] [pretriangulated D] extends
   triangulated_functor_struct C D :=
-(map_distinguished' : Π (T: triangle C), (T ∈ dist_triang C) →
-  (to_triangulated_functor_struct.map_triangle T ∈ dist_triang D) )
+(map_distinguished' : Π (T : triangle C), (T ∈ dist_triang C) →
+  (to_triangulated_functor_struct.map_triangle.obj T ∈ dist_triang D) )
 
 instance [pretriangulated C] : inhabited (triangulated_functor C C) :=
 ⟨{obj := λ X, X,
@@ -202,19 +220,19 @@ instance [pretriangulated C] : inhabited (triangulated_functor C C) :=
 
 variables {C D} [pretriangulated C] [pretriangulated D]
 /--
-Given a `triangulated_functor` we can define a function from triangles of `C` to triangles of `D`.
+Given a `triangulated_functor` we can define a functor from triangles of `C` to triangles of `D`.
 -/
-@[simp]
-def triangulated_functor.map_triangle (F : triangulated_functor C D) (T : triangle C) :
-  triangle D :=
-triangle.mk _ (F.map T.mor₁) (F.map T.mor₂) (F.map T.mor₃ ≫ F.comm_shift.hom.app T.obj₁)
+@[simps]
+def triangulated_functor.map_triangle (F : triangulated_functor C D) :
+  triangle C ⥤ triangle D :=
+F.to_triangulated_functor_struct.map_triangle
 
 /--
 Given a `triangulated_functor` and a distinguished triangle `T` of `C`, then the triangle it
 maps onto in `D` is also distinguished.
 -/
 lemma triangulated_functor.map_distinguished (F : triangulated_functor C D) (T : triangle C)
-  (h : T ∈ dist_triang C) : (F.map_triangle T) ∈ dist_triang D := F.map_distinguished' T h
+  (h : T ∈ dist_triang C) : (F.map_triangle.obj T) ∈ dist_triang D := F.map_distinguished' T h
 
 
 end pretriangulated

--- a/src/category_theory/triangulated/rotate.lean
+++ b/src/category_theory/triangulated/rotate.lean
@@ -158,11 +158,13 @@ def inv_rotate (f : triangle_morphism T₁ T₂) :
 
 end triangle_morphism
 
+variables (C)
+
 /--
 Rotating triangles gives an endofunctor on the category of triangles in `C`.
 -/
 @[simps]
-def rotate : (triangle C) ⥤ (triangle C) :=
+def rotate : triangle C ⥤ triangle C :=
 { obj := triangle.rotate,
   map := λ _ _ f, f.rotate }
 
@@ -170,15 +172,17 @@ def rotate : (triangle C) ⥤ (triangle C) :=
 The inverse rotation of triangles gives an endofunctor on the category of triangles in `C`.
 -/
 @[simps]
-def inv_rotate : (triangle C) ⥤ (triangle C) :=
+def inv_rotate : triangle C ⥤ triangle C :=
 { obj := triangle.inv_rotate,
   map := λ _ _ f, f.inv_rotate }
+
+variables {C}
 
 variables [∀ n : ℤ, functor.additive (shift_functor C n)]
 
 /-- There is a natural map from a triangle to the `inv_rotate` of its `rotate`. -/
 @[simps]
-def to_inv_rotate_rotate (T : triangle C) : T ⟶ inv_rotate.obj (rotate.obj T) :=
+def to_inv_rotate_rotate (T : triangle C) : T ⟶ (inv_rotate C).obj ((rotate C).obj T) :=
 { hom₁ := (shift_shift_neg _ _).inv,
     hom₂ := 𝟙 T.obj₂,
     hom₃ := 𝟙 T.obj₃,
@@ -196,7 +200,7 @@ There is a natural transformation between the identity functor on triangles in `
 and the composition of a rotation with an inverse rotation.
 -/
 @[simps]
-def rot_comp_inv_rot_hom : 𝟭 (triangle C) ⟶ rotate ⋙ inv_rotate :=
+def rot_comp_inv_rot_hom : 𝟭 (triangle C) ⟶ rotate C ⋙ inv_rotate C :=
 { app := to_inv_rotate_rotate,
   naturality' := begin
     introv, ext,
@@ -211,7 +215,7 @@ def rot_comp_inv_rot_hom : 𝟭 (triangle C) ⟶ rotate ⋙ inv_rotate :=
 
 /-- There is a natural map from the `inv_rotate` of the `rotate` of a triangle to itself. -/
 @[simps]
-def from_inv_rotate_rotate (T : triangle C) : inv_rotate.obj (rotate.obj T) ⟶ T :=
+def from_inv_rotate_rotate (T : triangle C) : (inv_rotate C).obj ((rotate C).obj T) ⟶ T :=
 { hom₁ := (shift_equiv C 1).unit_inv.app T.obj₁,
     hom₂ := 𝟙 T.obj₂,
     hom₃ := 𝟙 T.obj₃,
@@ -228,7 +232,7 @@ There is a natural transformation between the composition of a rotation with an 
 on triangles in `C`, and the identity functor.
 -/
 @[simps]
-def rot_comp_inv_rot_inv : rotate ⋙ inv_rotate ⟶ 𝟭 (triangle C) :=
+def rot_comp_inv_rot_inv : rotate C ⋙ inv_rotate C ⟶ 𝟭 (triangle C) :=
 { app := from_inv_rotate_rotate }
 
 /--
@@ -237,13 +241,13 @@ of a rotation with an inverse rotation are natural isomorphisms (they are isomor
 category of functors).
 -/
 @[simps]
-def rot_comp_inv_rot : 𝟭 (triangle C) ≅ rotate ⋙ inv_rotate :=
+def rot_comp_inv_rot : 𝟭 (triangle C) ≅ rotate C ⋙ inv_rotate C :=
 { hom := rot_comp_inv_rot_hom,
   inv := rot_comp_inv_rot_inv }
 
 /-- There is a natural map from the `rotate` of the `inv_rotate` of a triangle to itself. -/
 @[simps]
-def from_rotate_inv_rotate (T : triangle C) : rotate.obj (inv_rotate.obj T) ⟶ T :=
+def from_rotate_inv_rotate (T : triangle C) : (rotate C).obj ((inv_rotate C).obj T) ⟶ T :=
 { hom₁ := 𝟙 T.obj₁,
     hom₂ := 𝟙 T.obj₂,
     hom₃ := (shift_equiv C 1).counit.app T.obj₃,
@@ -270,12 +274,12 @@ There is a natural transformation between the composition of an inverse rotation
 on triangles in `C`, and the identity functor.
 -/
 @[simps]
-def inv_rot_comp_rot_hom : inv_rotate ⋙ rotate ⟶ 𝟭 (triangle C) :=
+def inv_rot_comp_rot_hom : inv_rotate C ⋙ rotate C ⟶ 𝟭 (triangle C) :=
 { app := from_rotate_inv_rotate }
 
 /-- There is a natural map from a triangle to the `rotate` of its `inv_rotate`. -/
 @[simps]
-def to_rotate_inv_rotate (T : triangle C) : T ⟶ rotate.obj (inv_rotate.obj T) :=
+def to_rotate_inv_rotate (T : triangle C) : T ⟶ (rotate C).obj ((inv_rotate C).obj T) :=
 { hom₁ := 𝟙 T.obj₁,
     hom₂ := 𝟙 T.obj₂,
     hom₃ := (shift_equiv C 1).counit_inv.app T.obj₃,
@@ -294,7 +298,7 @@ There is a natural transformation between the identity functor on triangles in `
 and the composition of an inverse rotation with a rotation.
 -/
 @[simps]
-def inv_rot_comp_rot_inv : 𝟭 (triangle C) ⟶ inv_rotate ⋙ rotate :=
+def inv_rot_comp_rot_inv : 𝟭 (triangle C) ⟶ inv_rotate C ⋙ rotate C :=
 { app := to_rotate_inv_rotate,
   naturality' := begin
     introv, ext,
@@ -312,17 +316,19 @@ on triangles in `C`, and the identity functor on triangles are natural isomorphi
 (they are isomorphisms in the category of functors).
 -/
 @[simps]
-def inv_rot_comp_rot : inv_rotate ⋙ rotate ≅ 𝟭 (triangle C) :=
+def inv_rot_comp_rot : inv_rotate C ⋙ rotate C ≅ 𝟭 (triangle C) :=
 { hom := inv_rot_comp_rot_hom,
   inv := inv_rot_comp_rot_inv }
+
+variables (C)
 
 /--
 Rotating triangles gives an auto-equivalence on the category of triangles in `C`.
 -/
 @[simps]
 def triangle_rotation : equivalence (triangle C) (triangle C) :=
-{ functor := rotate,
-  inverse := inv_rotate,
+{ functor := rotate C,
+  inverse := inv_rotate C,
   unit_iso := rot_comp_inv_rot,
   counit_iso := inv_rot_comp_rot,
   functor_unit_iso_comp' := begin
@@ -337,5 +343,16 @@ def triangle_rotation : equivalence (triangle C) (triangle C) :=
       erw [μ_inv_hom_app_assoc, μ_inv_hom_app],
       refl }
   end }
+
+variables {C}
+
+instance : faithful (rotate C) :=
+by { change faithful (triangle_rotation C).functor, apply_instance, }
+instance : full (rotate C) :=
+ by { change full (triangle_rotation C).functor, apply_instance, }
+instance : faithful (inv_rotate C) :=
+by { change faithful (triangle_rotation C).inverse, apply_instance, }
+instance : full (inv_rotate C) :=
+by { change full (triangle_rotation C).inverse, apply_instance, }
 
 end category_theory.triangulated

--- a/src/category_theory/triangulated/rotate.lean
+++ b/src/category_theory/triangulated/rotate.lean
@@ -346,13 +346,9 @@ def triangle_rotation : equivalence (triangle C) (triangle C) :=
 
 variables {C}
 
-instance : faithful (rotate C) :=
-by { change faithful (triangle_rotation C).functor, apply_instance, }
-instance : full (rotate C) :=
- by { change full (triangle_rotation C).functor, apply_instance, }
-instance : faithful (inv_rotate C) :=
-by { change faithful (triangle_rotation C).inverse, apply_instance, }
-instance : full (inv_rotate C) :=
-by { change full (triangle_rotation C).inverse, apply_instance, }
+instance : is_equivalence (rotate C) :=
+by { change is_equivalence (triangle_rotation C).functor, apply_instance, }
+instance : is_equivalence (inv_rotate C) :=
+by { change is_equivalence (triangle_rotation C).inverse, apply_instance, }
 
 end category_theory.triangulated


### PR DESCRIPTION
Useful for LTE.

---

Later, there are some changes that should be made in these files:
* I don't like that `triangle` is inconsistently spelled either `triangle` or `triang`
* similarly for `distinguished` and `dist`
* `triangulated_functor_struct` should be renamed something that doesn't refer at all to triangles, only to the shift functor, and moved
* API for accessing some of the fields of `pretriangulated` are still missing.

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
