### PR TITLE
[Merged by Bors] - feat(probability/integration): characterize indep_fun by expected product of comp

### DIFF
--- a/src/algebra/indicator_function.lean
+++ b/src/algebra/indicator_function.lean
@@ -431,6 +431,10 @@ section mul_zero_one_class
 
 variables [mul_zero_one_class M]
 
+lemma inter_indicator_one {s t : set α} :
+  (s ∩ t).indicator (1 : _ → M) = s.indicator 1 * t.indicator 1 :=
+funext (λ _, by simpa only [← inter_indicator_mul, pi.mul_apply, pi.one_apply, one_mul])
+
 lemma indicator_prod_one {s : set α} {t : set β} {x : α} {y : β} :
   (s ×ˢ t : set _).indicator (1 : _ → M) (x, y) = s.indicator 1 x * t.indicator 1 y :=
 by simp [indicator, ← ite_and]

--- a/src/measure_theory/integral/set_integral.lean
+++ b/src/measure_theory/integral/set_integral.lean
@@ -258,6 +258,11 @@ lemma integral_indicator_const (e : E) ⦃s : set α⦄ (s_meas : measurable_set
   ∫ (a : α), s.indicator (λ (x : α), e) a ∂μ = (μ s).to_real • e :=
 by rw [integral_indicator s_meas, ← set_integral_const]
 
+@[simp]
+lemma integral_indicator_one ⦃s : set α⦄ (hs : measurable_set s) :
+  ∫ a, s.indicator 1 a ∂μ = (μ s).to_real :=
+(integral_indicator_const 1 hs).trans ((smul_eq_mul _).trans (mul_one _))
+
 lemma set_integral_indicator_const_Lp {p : ℝ≥0∞} (hs : measurable_set s) (ht : measurable_set t)
   (hμt : μ t ≠ ∞) (x : E) :
   ∫ a in s, indicator_const_Lp p ht hμt x a ∂μ = (μ (t ∩ s)).to_real • x :=

--- a/src/probability/integration.lean
+++ b/src/probability/integration.lean
@@ -246,15 +246,14 @@ theorem indep_fun_iff_integral_comp_mul [is_finite_measure μ]
     measurable φ → measurable ψ → integrable (φ ∘ f) μ → integrable (ψ ∘ g) μ →
     integral μ ((φ ∘ f) * (ψ ∘ g)) = integral μ (φ ∘ f) * integral μ (ψ ∘ g) :=
 begin
-  have I : ∀ {A : set α} (hA : measurable_set A), integral μ (A.indicator 1) = (μ A).to_real,
-    from λ _ hA, (integral_indicator_const (1 : ℝ) hA).trans ((smul_eq_mul _).trans (mul_one _)),
   refine ⟨λ hfg _ _ hφ hψ, indep_fun.integral_mul_of_integrable (hfg.comp hφ hψ), _⟩,
   rintro h _ _ ⟨A, hA, rfl⟩ ⟨B, hB, rfl⟩,
   specialize h (measurable_one.indicator hA) (measurable_one.indicator hB)
     ((integrable_const 1).indicator (hfm.comp measurable_id hA))
     ((integrable_const 1).indicator (hgm.comp measurable_id hB)),
-  rwa [← ennreal.to_real_eq_to_real (measure_ne_top μ _), ← I ((hfm hA).inter (hgm hB)),
-    set.inter_indicator_one, ennreal.to_real_mul, ← I (hfm hA), ← I (hgm hB)],
+  rwa [← ennreal.to_real_eq_to_real (measure_ne_top μ _), ennreal.to_real_mul,
+    ← integral_indicator_one ((hfm hA).inter (hgm hB)), ← integral_indicator_one (hfm hA),
+    ← integral_indicator_one (hgm hB), set.inter_indicator_one],
   exact ennreal.mul_ne_top (measure_ne_top μ _) (measure_ne_top μ _)
 end
 


### PR DESCRIPTION
This is the third PR into probability/integration, to characterize independence by the expected product of compositions. 

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
