### PR TITLE
[Merged by Bors] - feat(group_theory/transversal): A `quotient_action` induces an action on left transversals

### DIFF
--- a/src/group_theory/complement.lean
+++ b/src/group_theory/complement.lean
@@ -287,6 +287,36 @@ quotient.exact' (mk'_to_equiv hS _)
 
 end mem_right_transversals
 
+section action
+
+open_locale pointwise
+
+open mul_action mem_left_transversals
+
+variables {F : Type*} [group F] [mul_action F G] [quotient_action F H]
+
+@[to_additive] instance : mul_action F (left_transversals (H : set G)) :=
+{ smul := λ f T, ⟨f • T, by
+  { refine mem_left_transversals_iff_exists_unique_inv_mul_mem.mpr (λ g, _),
+    obtain ⟨t, ht1, ht2⟩ := mem_left_transversals_iff_exists_unique_inv_mul_mem.mp T.2 (f⁻¹ • g),
+    refine ⟨⟨f • t, set.smul_mem_smul_set t.2⟩, _, _⟩,
+    { exact (congr_arg _ (smul_inv_smul f g)).mp (quotient_action.inv_mul_mem f ht1) },
+    { rintros ⟨-, t', ht', rfl⟩ h,
+      replace h := quotient_action.inv_mul_mem f⁻¹ h,
+      simp only [subtype.ext_iff, subtype.coe_mk, smul_left_cancel_iff, inv_smul_smul] at h ⊢,
+      exact subtype.ext_iff.mp (ht2 ⟨t', ht'⟩ h) } }⟩,
+  one_smul := λ T, subtype.ext (one_smul F T),
+  mul_smul := λ f₁ f₂ T, subtype.ext (mul_smul f₁ f₂ T) }
+
+@[to_additive] lemma smul_to_fun (f : F) (T : left_transversals (H : set G)) (g : G) :
+  (f • to_fun T.2 g : G) = to_fun (f • T).2 (f • g) :=
+subtype.ext_iff.mp $ @unique_of_exists_unique ↥(f • T) (λ s, (↑s)⁻¹ * f • g ∈ H)
+  (mem_left_transversals_iff_exists_unique_inv_mul_mem.mp (f • T).2 (f • g))
+  ⟨f • to_fun T.2 g, set.smul_mem_smul_set (subtype.coe_prop _)⟩ (to_fun (f • T).2 (f • g))
+  (quotient_action.inv_mul_mem f (inv_to_fun_mul_mem T.2 g)) (inv_to_fun_mul_mem (f • T).2 (f • g))
+
+end action
+
 @[to_additive] instance : inhabited (left_transversals (H : set G)) :=
 ⟨⟨set.range quotient.out', mem_left_transversals_iff_bijective.mpr ⟨by
 { rintros ⟨_, q₁, rfl⟩ ⟨_, q₂, rfl⟩ hg,

--- a/src/group_theory/schur_zassenhaus.lean
+++ b/src/group_theory/schur_zassenhaus.lean
@@ -33,16 +33,6 @@ open mem_left_transversals
 
 variables {G : Type*} [group G] {H : subgroup G}
 
-@[to_additive] instance : mul_action G (left_transversals (H : set G)) :=
-{ smul := λ g T, ⟨left_coset g T, mem_left_transversals_iff_exists_unique_inv_mul_mem.mpr (λ g', by
-  { obtain ⟨t, ht1, ht2⟩ := mem_left_transversals_iff_exists_unique_inv_mul_mem.mp T.2 (g⁻¹ * g'),
-    simp_rw [←mul_assoc, ←mul_inv_rev] at ht1 ht2,
-    refine ⟨⟨g * t, mem_left_coset g t.2⟩, ht1, _⟩,
-    rintros ⟨_, t', ht', rfl⟩ h,
-    exact subtype.ext ((mul_right_inj g).mpr (subtype.ext_iff.mp (ht2 ⟨t', ht'⟩ h))) })⟩,
-  one_smul := λ T, subtype.ext (one_left_coset T),
-  mul_smul := λ g g' T, subtype.ext (left_coset_assoc ↑T g g').symm }
-
 lemma smul_symm_apply_eq_mul_symm_apply_inv_smul
   (g : G) (α : left_transversals (H : set G)) (q : G ⧸ H) :
   ↑(to_equiv (g • α).2 q) = g * (to_equiv α.2 (g⁻¹ • q : G ⧸ H)) :=


### PR DESCRIPTION
A `quotient_action` induces an action on left transversals.

Once #13283 is merged, I'll PR some more API generalizing the existing lemma `smul_symm_apply_eq_mul_symm_apply_inv_smul`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
