### PR TITLE
[Merged by Bors] - fix(algebra/indicator_function): fix name of `mul_indicator_eq_one_iff`

### DIFF
--- a/src/algebra/indicator_function.lean
+++ b/src/algebra/indicator_function.lean
@@ -82,7 +82,7 @@ by simp only [funext_iff, mul_indicator_apply_eq_one, set.disjoint_left, mem_mul
   mul_indicator s f = 1 ↔ disjoint (mul_support f) s :=
 mul_indicator_eq_one
 
-@[to_additive] lemma mul_indicator_ne_one_iff (a : α) :
+@[to_additive] lemma mul_indicator_apply_ne_one {a : α} :
   s.mul_indicator f a ≠ 1 ↔ a ∈ s ∩ mul_support f :=
 by simp only [ne.def, mul_indicator_apply_eq_one, not_imp, mem_inter_eq, mem_mul_support]
 

--- a/src/algebra/indicator_function.lean
+++ b/src/algebra/indicator_function.lean
@@ -82,20 +82,9 @@ by simp only [funext_iff, mul_indicator_apply_eq_one, set.disjoint_left, mem_mul
   mul_indicator s f = 1 ↔ disjoint (mul_support f) s :=
 mul_indicator_eq_one
 
-@[to_additive] lemma mul_indicator_eq_one_iff (a : α) :
+@[to_additive] lemma mul_indicator_ne_one_iff (a : α) :
   s.mul_indicator f a ≠ 1 ↔ a ∈ s ∩ mul_support f :=
-begin
-  split; intro h,
-  { by_contra hmem,
-    simp only [set.mem_inter_eq, not_and, not_not, function.mem_mul_support] at hmem,
-    refine h _,
-    by_cases a ∈ s,
-    { simp_rw [set.mul_indicator, if_pos h],
-      exact hmem h },
-    { simp_rw [set.mul_indicator, if_neg h] } },
-  { simp_rw [set.mul_indicator, if_pos h.1],
-    exact h.2 }
-end
+by simp only [ne.def, mul_indicator_apply_eq_one, not_imp, mem_inter_eq, mem_mul_support]
 
 @[simp, to_additive] lemma mul_support_mul_indicator :
   function.mul_support (s.mul_indicator f) = s ∩ function.mul_support f :=

--- a/src/measure_theory/measure/measure_space_def.lean
+++ b/src/measure_theory/measure/measure_space_def.lean
@@ -393,13 +393,7 @@ h.inter h'
 @[to_additive]
 lemma _root_.set.mul_indicator_ae_eq_one {M : Type*} [has_one M] {f : α → M} {s : set α}
   (h : s.mul_indicator f =ᵐ[μ] 1) : μ (s ∩ function.mul_support f) = 0 :=
-begin
-  rw [filter.eventually_eq, ae_iff] at h,
-  convert h,
-  ext a,
-  rw ← set.mul_indicator_ne_one_iff,
-  refl
-end
+by simpa [filter.eventually_eq, ae_iff] using h
 
 /-- If `s ⊆ t` modulo a set of measure `0`, then `μ s ≤ μ t`. -/
 @[mono] lemma measure_mono_ae (H : s ≤ᵐ[μ] t) : μ s ≤ μ t :=

--- a/src/measure_theory/measure/measure_space_def.lean
+++ b/src/measure_theory/measure/measure_space_def.lean
@@ -397,7 +397,7 @@ begin
   rw [filter.eventually_eq, ae_iff] at h,
   convert h,
   ext a,
-  rw ← set.mul_indicator_eq_one_iff,
+  rw ← set.mul_indicator_ne_one_iff,
   refl
 end
 

--- a/src/measure_theory/probability_mass_function/constructions.lean
+++ b/src/measure_theory/probability_mass_function/constructions.lean
@@ -361,7 +361,7 @@ by rw [filter_apply, set.indicator_apply_eq_zero.mpr (λ ha', absurd ha' ha), ze
 @[simp] lemma support_filter : (p.filter s h).support = s ∩ p.support:=
 begin
   refine set.ext (λ a, _),
-  rw [mem_support_iff, filter_apply, mul_ne_zero_iff, set.indicator_eq_zero_iff],
+  rw [mem_support_iff, filter_apply, mul_ne_zero_iff, set.indicator_ne_zero_iff],
   exact ⟨λ ha, ha.1, λ ha, ⟨ha, inv_ne_zero (nnreal.tsum_indicator_ne_zero p.2.summable h)⟩⟩
 end
 

--- a/src/measure_theory/probability_mass_function/constructions.lean
+++ b/src/measure_theory/probability_mass_function/constructions.lean
@@ -358,15 +358,11 @@ by rw [filter, normalize_apply]
 lemma filter_apply_eq_zero_of_not_mem {a : α} (ha : a ∉ s) : (p.filter s h) a = 0 :=
 by rw [filter_apply, set.indicator_apply_eq_zero.mpr (λ ha', absurd ha' ha), zero_mul]
 
-@[simp] lemma support_filter : (p.filter s h).support = s ∩ p.support:=
-begin
-  refine set.ext (λ a, _),
-  rw [mem_support_iff, filter_apply, mul_ne_zero_iff, set.indicator_ne_zero_iff],
-  exact ⟨λ ha, ha.1, λ ha, ⟨ha, inv_ne_zero (nnreal.tsum_indicator_ne_zero p.2.summable h)⟩⟩
-end
+lemma mem_support_filter_iff {a : α} : a ∈ (p.filter s h).support ↔ a ∈ s ∧ a ∈ p.support :=
+(mem_support_normalize_iff _ _).trans set.indicator_apply_ne_zero
 
-lemma mem_support_filter_iff (a : α) : a ∈ (p.filter s h).support ↔ a ∈ s ∧ a ∈ p.support :=
-by simp
+@[simp] lemma support_filter : (p.filter s h).support = s ∩ p.support:=
+set.ext $ λ x, (mem_support_filter_iff _)
 
 lemma filter_apply_eq_zero_iff (a : α) : (p.filter s h) a = 0 ↔ a ∉ s ∨ a ∉ p.support :=
 by erw [apply_eq_zero_iff, support_filter, set.mem_inter_iff, not_and_distrib]


### PR DESCRIPTION
It is about `≠`, so call it `mul_indicator_ne_one_iff`/`indicator_ne_zero_iff`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
