### PR TITLE
[Merged by Bors] - chore(category_theory/*): reduce imports

### DIFF
--- a/src/algebra/category/Semigroup/basic.lean
+++ b/src/algebra/category/Semigroup/basic.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Julian Kuelshammer
 -/
 import algebra.pempty_instances
+import algebra.hom.equiv
 import category_theory.concrete_category.bundled_hom
 import category_theory.functor.reflects_isomorphisms
 

--- a/src/category_theory/essential_image.lean
+++ b/src/category_theory/essential_image.lean
@@ -5,6 +5,7 @@ Authors: Bhavik Mehta
 -/
 import category_theory.natural_isomorphism
 import category_theory.full_subcategory
+import data.set.basic
 
 /-!
 # Essential image of a functor

--- a/src/category_theory/functor/basic.lean
+++ b/src/category_theory/functor/basic.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Tim Baumann, Stephen Morgan, Scott Morrison
 -/
 import tactic.reassoc_axiom
-import tactic.monotonicity
 import category_theory.category.basic
 
 /-!
@@ -13,7 +12,7 @@ import category_theory.category.basic
 Defines a functor between categories, extending a `prefunctor` between quivers.
 
 Introduces notation `C ⥤ D` for the type of all functors from `C` to `D`.
-(Unfortunately the `⇒` arrow (`\functor`) is taken by core, 
+(Unfortunately the `⇒` arrow (`\functor`) is taken by core,
 but in mathlib4 we should switch to this.)
 -/
 


### PR DESCRIPTION
An unnecessary import of `tactic.monotonicity` earlier in the hierarchy was pulling in quite a lot. A few compensatory imports are needed later.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
