### PR TITLE
[Merged by Bors] - feat(number_theory/quadratic_reciprocity): change order of arguments …

### DIFF
--- a/src/number_theory/quadratic_reciprocity.lean
+++ b/src/number_theory/quadratic_reciprocity.lean
@@ -352,13 +352,15 @@ variables (p q : ℕ) [fact p.prime] [fact q.prime]
 
 namespace zmod
 
-/-- The Legendre symbol of `a` and `p` is an integer defined as
+/-- The Legendre symbol of `a` and `p`, `legendre_sym p a`, is an integer defined as
 
 * `0` if `a` is `0` modulo `p`;
 * `1` if `a ^ (p / 2)` is `1` modulo `p`
    (by `euler_criterion` this is equivalent to “`a` is a square modulo `p`”);
 * `-1` otherwise.
 
+Note the order of the arguments! The advantage of the order chosen here is
+that `legendre_sym p` is a multiplicative function `ℤ → ℤ`.
 -/
 def legendre_sym (p : ℕ) (a : ℤ) : ℤ :=
 if      (a : zmod p) = 0           then  0


### PR DESCRIPTION
…in legendre_sym

This is the first step in a major overhaul of the contents of number_theory/quadratic_reciprocity.

As a first step, the order of the arguments `a` and `p` to `legendre_sym` is swapped, based on a [poll](https://leanprover.zulipchat.com/#narrow/stream/116395-maths/topic/Quadratic.20Hilbert.20symbol.20over.20.E2.84.9A) on Zulip.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
