### PR TITLE
[Merged by Bors] - feat(set_theory/ordinal_arithmetic): `is_normal.monotone`

### DIFF
--- a/src/set_theory/fixed_points.lean
+++ b/src/set_theory/fixed_points.lean
@@ -107,7 +107,7 @@ begin
   { unfreezingI { cases hι with i },
     exact ((H i).self_le b).trans (h i) },
   rw ←nfp_family_fp (H i),
-  exact (H i).strict_mono.monotone h
+  exact (H i).monotone h
 end
 
 theorem nfp_family_eq_self {f : ι → ordinal → ordinal} {a} (h : ∀ i, f i a = a) :
@@ -165,11 +165,11 @@ theorem le_iff_deriv_family (H : ∀ i, is_normal (f i)) {a} :
   from this a ((deriv_family_is_normal _).self_le _),
   refine λ o, limit_rec_on o (λ h₁, ⟨0, le_antisymm _ h₁⟩) (λ o IH h₁, _) (λ o l IH h₁, _),
   { rw deriv_family_zero,
-    exact nfp_family_le_fp (λ i, (H i).strict_mono.monotone) (ordinal.zero_le _) ha },
+    exact nfp_family_le_fp (λ i, (H i).monotone) (ordinal.zero_le _) ha },
   { cases le_or_lt a (deriv_family f o), {exact IH h},
     refine ⟨succ o, le_antisymm _ h₁⟩,
     rw deriv_family_succ,
-    exact nfp_family_le_fp (λ i, (H i).strict_mono.monotone) (succ_le.2 h) ha },
+    exact nfp_family_le_fp (λ i, (H i).monotone) (succ_le.2 h) ha },
   { cases eq_or_lt_of_le h₁, {exact ⟨_, h.symm⟩},
     rw [deriv_family_limit _ l, ← not_le, bsup_le_iff, not_ball] at h,
     exact let ⟨o', h, hl⟩ := h in IH o' h (le_of_not_le hl) }
@@ -262,7 +262,7 @@ begin
   { have ho' : 0 < o := ordinal.pos_iff_ne_zero.2 ho,
     exact ((H 0 ho').self_le b).trans (h 0 ho') },
   rw ←nfp_bfamily_fp (H i hi),
-  exact (H i hi).strict_mono.monotone h
+  exact (H i hi).monotone h
 end
 
 theorem nfp_bfamily_eq_self {a} (h : ∀ i hi, f i hi a = a) : nfp_bfamily o f a = a :=

--- a/src/set_theory/ordinal_arithmetic.lean
+++ b/src/set_theory/ordinal_arithmetic.lean
@@ -390,6 +390,9 @@ theorem is_normal.strict_mono {f} (H : is_normal f) : strict_mono f :=
   (λ b l IH h, lt_of_lt_of_le (H.1 a)
     ((H.2 _ l _).1 le_rfl _ (l.2 _ h)))
 
+theorem is_normal.monotone {f} (H : is_normal f) : monotone f :=
+H.strict_mono.monotone
+
 theorem is_normal_iff_strict_mono_limit (f : ordinal → ordinal) :
   is_normal f ↔ (strict_mono f ∧ ∀ o, is_limit o → ∀ a, (∀ b < o, f b ≤ a) → f o ≤ a) :=
 ⟨λ hf, ⟨hf.strict_mono, λ a ha c, (hf.2 a ha c).2⟩, λ ⟨hs, hl⟩, ⟨λ a, hs (ordinal.lt_succ_self a),
@@ -2567,7 +2570,7 @@ theorem nfp_add_eq_mul_omega {a b} (hba : b ≤ a * omega) :
 begin
   apply le_antisymm ((add_is_normal a).nfp_le_fp hba _),
   { rw ←nfp_add_zero,
-    exact monotone.nfp (add_is_normal a).strict_mono.monotone (ordinal.zero_le b) },
+    exact monotone.nfp (add_is_normal a).monotone (ordinal.zero_le b) },
   { rw [←mul_one_add, one_add_omega] }
 end
 
@@ -2577,7 +2580,7 @@ begin
   { rw [←nfp_add_zero a, ←deriv_zero],
     cases (add_is_normal a).apply_eq_self_iff_deriv.1 h with c hc,
     rw ←hc,
-    exact (deriv_is_normal _).strict_mono.monotone (ordinal.zero_le _) },
+    exact (deriv_is_normal _).monotone (ordinal.zero_le _) },
   { have := ordinal.add_sub_cancel_of_le h,
     nth_rewrite 0 ←this,
     rwa [←add_assoc, ←mul_one_add, one_add_omega] }
@@ -2645,7 +2648,7 @@ begin
   { apply (mul_is_normal ha).nfp_le_fp hba,
     rw [←opow_one_add, one_add_omega] },
   rw ←nfp_mul_one ha,
-  exact monotone.nfp (mul_is_normal ha).strict_mono.monotone (one_le_iff_pos.2 hb)
+  exact monotone.nfp (mul_is_normal ha).monotone (one_le_iff_pos.2 hb)
 end
 
 theorem eq_zero_or_opow_omega_le_of_mul_eq_right {a b : ordinal} (hab : a * b = b) :


### PR DESCRIPTION
We introduce a convenient abbreviation for `is_normal.strict_mono.monotone`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
