### PR TITLE
[Merged by Bors] - chore(*): remove numerous edge cases from lemmas

### DIFF
--- a/src/algebra/big_operators/intervals.lean
+++ b/src/algebra/big_operators/intervals.lean
@@ -233,10 +233,17 @@ begin
   abel,
 end
 
+variable (n)
+
 /-- **Summation by parts** for ranges -/
-lemma sum_range_by_parts (hn : 0 < n) :
+lemma sum_range_by_parts :
   ∑ i in range n, (f i • g i) = f (n-1) • G n - ∑ i in range (n-1), (f (i+1) - f i) • G (i+1) :=
-by rw [range_eq_Ico, sum_Ico_by_parts f g hn, sum_range_zero, smul_zero, sub_zero, range_eq_Ico]
+begin
+  by_cases hn : n = 0,
+  { simp [hn], },
+  { rw [range_eq_Ico, sum_Ico_by_parts f g (nat.pos_of_ne_zero hn), sum_range_zero,
+      smul_zero, sub_zero, range_eq_Ico] },
+end
 
 end module
 

--- a/src/algebra/order/ring.lean
+++ b/src/algebra/order/ring.lean
@@ -687,7 +687,6 @@ lemma add_le_mul' (a2 : 2 ≤ a) (b2 : 2 ≤ b) : a + b ≤ b * a :=
 (le_of_eq (add_comm _ _)).trans (add_le_mul b2 a2)
 
 section
-variables [nontrivial α]
 
 @[simp] lemma bit0_le_bit0 : bit0 a ≤ bit0 b ↔ a ≤ b :=
 by rw [bit0, bit0, ← two_mul, ← two_mul, mul_le_mul_left (zero_lt_two : 0 < (2:α))]

--- a/src/algebra/order/with_zero.lean
+++ b/src/algebra/order/with_zero.lean
@@ -216,14 +216,18 @@ by simpa only [mul_inv_cancel_right₀ h] using (mul_le_mul_right' hab c⁻¹)
 lemma le_mul_inv_of_mul_le (h : c ≠ 0) (hab : a * c ≤ b) : a ≤ b * c⁻¹ :=
 le_of_le_mul_right h (by simpa [h] using hab)
 
-lemma mul_inv_le_of_le_mul (h : c ≠ 0) (hab : a ≤ b * c) : a * c⁻¹ ≤ b :=
-le_of_le_mul_right h (by simpa [h] using hab)
+lemma mul_inv_le_of_le_mul (hab : a ≤ b * c) : a * c⁻¹ ≤ b :=
+begin
+  by_cases h : c = 0,
+  { simp [h], },
+  { exact le_of_le_mul_right h (by simpa [h] using hab), },
+end
 
 lemma le_mul_inv_iff₀ (hc : c ≠ 0) : a ≤ b * c⁻¹ ↔ a * c ≤ b :=
-⟨λ h, inv_inv c ▸ mul_inv_le_of_le_mul (inv_ne_zero hc) h, le_mul_inv_of_mul_le hc⟩
+⟨λ h, inv_inv c ▸ mul_inv_le_of_le_mul h, le_mul_inv_of_mul_le hc⟩
 
 lemma mul_inv_le_iff₀ (hc : c ≠ 0) : a * c⁻¹ ≤ b ↔ a ≤ b * c :=
-⟨λ h, inv_inv c ▸ le_mul_inv_of_mul_le (inv_ne_zero hc) h, mul_inv_le_of_le_mul hc⟩
+⟨λ h, inv_inv c ▸ le_mul_inv_of_mul_le (inv_ne_zero hc) h, mul_inv_le_of_le_mul⟩
 
 lemma div_le_div₀ (a b c d : α) (hb : b ≠ 0) (hd : d ≠ 0) :
   a * b⁻¹ ≤ c * d⁻¹ ↔ a * d ≤ c * b :=
@@ -247,8 +251,7 @@ lemma mul_lt_mul₀ (hab : a < b) (hcd : c < d) : a * c < b * d :=
 mul_lt_mul_of_lt_of_le₀ hab.le (ne_zero_of_lt hab) hcd
 
 lemma mul_inv_lt_of_lt_mul₀ (h : x < y * z) : x * z⁻¹ < y :=
-have hz : z ≠ 0 := (mul_ne_zero_iff.1 $ ne_zero_of_lt h).2,
-by { contrapose! h, simpa only [inv_inv] using mul_inv_le_of_le_mul (inv_ne_zero hz) h }
+by { contrapose! h, simpa only [inv_inv] using mul_inv_le_of_le_mul h }
 
 lemma inv_mul_lt_of_lt_mul₀ (h : x < y * z) : y⁻¹ * x < z :=
 by { rw mul_comm at *, exact mul_inv_lt_of_lt_mul₀ h }

--- a/src/algebra/polynomial/big_operators.lean
+++ b/src/algebra/polynomial/big_operators.lean
@@ -254,9 +254,10 @@ lemma prod_X_sub_C_next_coeff {s : finset ι} (f : ι → R) :
   next_coeff ∏ i in s, (X - C (f i)) = -∑ i in s, f i :=
 by simpa using multiset_prod_X_sub_C_next_coeff (s.1.map f)
 
-lemma multiset_prod_X_sub_C_coeff_card_pred [nontrivial R] (t : multiset R) (ht : 0 < t.card) :
+lemma multiset_prod_X_sub_C_coeff_card_pred (t : multiset R) (ht : 0 < t.card) :
   (t.map (λ x, (X - C x))).prod.coeff (t.card - 1) = -t.sum :=
 begin
+  nontriviality R,
   convert multiset_prod_X_sub_C_next_coeff (by assumption),
   rw next_coeff, split_ifs,
   { rw nat_degree_multiset_prod_of_monic at h; simp only [multiset.mem_map] at *,
@@ -268,7 +269,7 @@ begin
   congr, rw nat_degree_multiset_prod_of_monic; { simp [nat_degree_X_sub_C, monic_X_sub_C] },
 end
 
-lemma prod_X_sub_C_coeff_card_pred [nontrivial R] (s : finset ι) (f : ι → R) (hs : 0 < s.card) :
+lemma prod_X_sub_C_coeff_card_pred (s : finset ι) (f : ι → R) (hs : 0 < s.card) :
   (∏ i in s, (X - C (f i))).coeff (s.card - 1) = - ∑ i in s, f i :=
 by simpa using multiset_prod_X_sub_C_coeff_card_pred (s.1.map f) (by simpa using hs)
 

--- a/src/analysis/specific_limits/normed.lean
+++ b/src/analysis/specific_limits/normed.lean
@@ -551,9 +551,9 @@ variables {b : ℝ} {f : ℕ → ℝ} {z : ℕ → E}
 /-- **Dirichlet's Test** for monotone sequences. -/
 theorem monotone.cauchy_seq_series_mul_of_tendsto_zero_of_bounded
   (hfa : monotone f) (hf0 : tendsto f at_top (𝓝 0)) (hgb : ∀ n, ∥∑ i in range n, z i∥ ≤ b) :
-  cauchy_seq (λ n, ∑ i in range (n+1), (f i) • z i) :=
+  cauchy_seq (λ n, ∑ i in range (n + 1), (f i) • z i) :=
 begin
-  simp_rw [finset.sum_range_by_parts _ _ (nat.succ_pos _), sub_eq_add_neg,
+  simp_rw [finset.sum_range_by_parts _ _ (nat.succ _), sub_eq_add_neg,
            nat.succ_sub_succ_eq_sub, tsub_zero],
   apply (normed_field.tendsto_zero_smul_of_tendsto_zero_of_bounded hf0
     ⟨b, eventually_map.mpr $ eventually_of_forall $ λ n, hgb $ n+1⟩).cauchy_seq.add,

--- a/src/data/nat/factorization.lean
+++ b/src/data/nat/factorization.lean
@@ -290,7 +290,7 @@ begin
     lt_self_iff_false] at hp
 end
 
-lemma dvd_iff_prime_pow_dvd_dvd {n d : ℕ} :
+lemma dvd_iff_prime_pow_dvd_dvd (n d : ℕ) :
   d ∣ n ↔ ∀ p k : ℕ, prime p → p ^ k ∣ d → p ^ k ∣ n :=
 begin
   by_cases hn : n = 0,

--- a/src/data/nat/factorization.lean
+++ b/src/data/nat/factorization.lean
@@ -290,9 +290,20 @@ begin
     lt_self_iff_false] at hp
 end
 
-lemma dvd_iff_prime_pow_dvd_dvd {n d : ℕ} (hd : d ≠ 0) (hn : n ≠ 0) :
+lemma dvd_iff_prime_pow_dvd_dvd {n d : ℕ} :
   d ∣ n ↔ ∀ p k : ℕ, prime p → p ^ k ∣ d → p ^ k ∣ n :=
 begin
+  by_cases hn : n = 0,
+  { simp [hn], },
+  by_cases hd : d = 0,
+  { simp only [hd, hn, zero_dvd_iff, dvd_zero, forall_true_left, false_iff,
+      not_forall, exists_prop, exists_and_distrib_left],
+    refine ⟨2, prime_two, n, λ h, _⟩,
+    have := le_of_dvd (nat.pos_of_ne_zero hn) h,
+    revert this,
+    change ¬ _,
+    rw [not_le],
+    exact lt_two_pow n, },
   refine ⟨λ h p k _ hpkd, dvd_trans hpkd h, _⟩,
   rw [←factorization_le_iff_dvd hd hn, finsupp.le_def],
   intros h p,

--- a/src/data/polynomial/degree/definitions.lean
+++ b/src/data/polynomial/degree/definitions.lean
@@ -1076,18 +1076,23 @@ begin
   { exact nat_degree_eq_of_degree_eq_some (degree_X_pow_add_C (pos_iff_ne_zero.mpr hn) r) },
 end
 
+end semiring
+end nonzero_ring
+
+section semiring
+variable [semiring R]
+
 @[simp] lemma leading_coeff_X_pow_add_C {n : ℕ} (hn : 0 < n) {r : R} :
   (X ^ n + C r).leading_coeff = 1 :=
-by rw [leading_coeff, nat_degree_X_pow_add_C, coeff_add, coeff_X_pow_self,
-  coeff_C, if_neg (pos_iff_ne_zero.mp hn), add_zero]
+begin
+  nontriviality R,
+  rw [leading_coeff, nat_degree_X_pow_add_C, coeff_add, coeff_X_pow_self,
+    coeff_C, if_neg (pos_iff_ne_zero.mp hn), add_zero]
+end
 
 @[simp] lemma leading_coeff_X_add_C [semiring S] (r : S) :
   (X + C r).leading_coeff = 1 :=
-begin
-  nontriviality,
-  rw [←pow_one (X : S[X]), leading_coeff_X_pow_add_C zero_lt_one],
-  apply_instance
-end
+by rw [←pow_one (X : S[X]), leading_coeff_X_pow_add_C zero_lt_one]
 
 @[simp] lemma leading_coeff_X_pow_add_one {n : ℕ} (hn : 0 < n) :
   (X ^ n + 1 : R[X]).leading_coeff = 1 :=
@@ -1099,7 +1104,18 @@ by { nontriviality, rw leading_coeff_pow'; simp }
 
 end semiring
 
-variables [ring R]
+section ring
+variable [ring R]
+
+@[simp] lemma leading_coeff_X_pow_sub_C {n : ℕ} (hn : 0 < n) {r : R} :
+  (X ^ n - C r).leading_coeff = 1 :=
+by rw [sub_eq_add_neg, ←map_neg C r, leading_coeff_X_pow_add_C hn]; apply_instance
+
+@[simp] lemma leading_coeff_X_pow_sub_one {n : ℕ} (hn : 0 < n) :
+  (X ^ n - 1 : R[X]).leading_coeff = 1 :=
+leading_coeff_X_pow_sub_C hn
+
+variables [nontrivial R]
 
 @[simp] lemma degree_X_sub_C (a : R) : degree (X - C a) = 1 :=
 by rw [sub_eq_add_neg, ←map_neg C a, degree_X_add_C]
@@ -1130,19 +1146,11 @@ lemma nat_degree_X_pow_sub_C {n : ℕ} {r : R} :
   (X ^ n - C r).nat_degree = n :=
 by rw [sub_eq_add_neg, ←map_neg C r, nat_degree_X_pow_add_C]
 
-@[simp] lemma leading_coeff_X_pow_sub_C {n : ℕ} (hn : 0 < n) {r : R} :
-  (X ^ n - C r).leading_coeff = 1 :=
-by rw [sub_eq_add_neg, ←map_neg C r, leading_coeff_X_pow_add_C hn]; apply_instance
-
 @[simp] lemma leading_coeff_X_sub_C [ring S] (r : S) :
   (X - C r).leading_coeff = 1 :=
 by rw [sub_eq_add_neg, ←map_neg C r, leading_coeff_X_add_C]
 
-@[simp] lemma leading_coeff_X_pow_sub_one {n : ℕ} (hn : 0 < n) :
-  (X ^ n - 1 : R[X]).leading_coeff = 1 :=
-leading_coeff_X_pow_sub_C hn
-
-end nonzero_ring
+end ring
 
 section no_zero_divisors
 variables [semiring R] [no_zero_divisors R] {p q : R[X]}

--- a/src/data/polynomial/mirror.lean
+++ b/src/data/polynomial/mirror.lean
@@ -59,13 +59,10 @@ lemma mirror_nat_degree : p.mirror.nat_degree = p.nat_degree :=
 begin
   by_cases hp : p = 0,
   { rw [hp, mirror_zero] },
-  by_cases hR : nontrivial R,
-  { haveI := hR,
-    rw [mirror, nat_degree_mul', reverse_nat_degree, nat_degree_X_pow,
-        tsub_add_cancel_of_le p.nat_trailing_degree_le_nat_degree],
-    rwa [leading_coeff_X_pow, mul_one, reverse_leading_coeff, ne, trailing_coeff_eq_zero] },
-  { haveI := not_nontrivial_iff_subsingleton.mp hR,
-    exact congr_arg nat_degree (subsingleton.elim p.mirror p) },
+  nontriviality R,
+  rw [mirror, nat_degree_mul', reverse_nat_degree, nat_degree_X_pow,
+      tsub_add_cancel_of_le p.nat_trailing_degree_le_nat_degree],
+  rwa [leading_coeff_X_pow, mul_one, reverse_leading_coeff, ne, trailing_coeff_eq_zero]
 end
 
 lemma mirror_nat_trailing_degree : p.mirror.nat_trailing_degree = p.nat_trailing_degree :=

--- a/src/data/rat/basic.lean
+++ b/src/data/rat/basic.lean
@@ -549,8 +549,10 @@ else
          ... = (q.num /. q.denom) * (r.denom /. r.num) : by rw inv_def
          ... = (q.num * r.denom) /. (q.denom * r.num) : mul_def (by simpa using denom_ne_zero q) hr
 
-lemma num_denom_mk {q : ℚ} {n d : ℤ} (hn : n ≠ 0) (hd : d ≠ 0) (qdf : q = n /. d) :
+lemma num_denom_mk {q : ℚ} {n d : ℤ} (hd : d ≠ 0) (qdf : q = n /. d) :
       ∃ c : ℤ, n = c * q.num ∧ d = c * q.denom :=
+(eq_or_ne n 0).by_cases
+(λ hn, by simp [*] at *) $ λ hn,
 have hq : q ≠ 0, from
   assume : q = 0,
   hn $ (rat.mk_eq_zero hd).1 (by cc),
@@ -659,12 +661,11 @@ end
 theorem num_div_denom (r : ℚ) : (r.num / r.denom : ℚ) = r :=
 by rw [← int.cast_coe_nat, ← mk_eq_div, num_denom]
 
-lemma exists_eq_mul_div_num_and_eq_mul_div_denom {n d : ℤ} (n_ne_zero : n ≠ 0)
-  (d_ne_zero : d ≠ 0) :
+lemma exists_eq_mul_div_num_and_eq_mul_div_denom {n d : ℤ} (d_ne_zero : d ≠ 0) :
   ∃ (c : ℤ), n = c * ((n : ℚ) / d).num ∧ (d : ℤ) = c * ((n : ℚ) / d).denom :=
 begin
   have : ((n : ℚ) / d) = rat.mk n d, by rw [←rat.mk_eq_div],
-  exact rat.num_denom_mk n_ne_zero d_ne_zero this
+  exact rat.num_denom_mk d_ne_zero this
 end
 
 theorem coe_int_eq_of_int (z : ℤ) : ↑z = of_int z :=

--- a/src/data/rat/basic.lean
+++ b/src/data/rat/basic.lean
@@ -661,7 +661,7 @@ end
 theorem num_div_denom (r : ℚ) : (r.num / r.denom : ℚ) = r :=
 by rw [← int.cast_coe_nat, ← mk_eq_div, num_denom]
 
-lemma exists_eq_mul_div_num_and_eq_mul_div_denom {n d : ℤ} (d_ne_zero : d ≠ 0) :
+lemma exists_eq_mul_div_num_and_eq_mul_div_denom (n : ℤ) {d : ℤ} (d_ne_zero : d ≠ 0) :
   ∃ (c : ℤ), n = c * ((n : ℚ) / d).num ∧ (d : ℤ) = c * ((n : ℚ) / d).denom :=
 begin
   have : ((n : ℚ) / d) = rat.mk n d, by rw [←rat.mk_eq_div],

--- a/src/data/rat/floor.lean
+++ b/src/data/rat/floor.lean
@@ -47,21 +47,19 @@ begin
   rw [rat.floor_def],
   cases decidable.em (d = 0) with d_eq_zero d_ne_zero,
   { simp [d_eq_zero] },
-  { cases decidable.em (n = 0) with n_eq_zero n_ne_zero,
-    { simp [n_eq_zero] },
-    { set q := (n : ℚ) / d with q_eq,
-      obtain ⟨c, n_eq_c_mul_num, d_eq_c_mul_denom⟩ : ∃ c, n = c * q.num ∧ (d : ℤ) = c * q.denom, by
-      { rw q_eq,
-        exact_mod_cast (@rat.exists_eq_mul_div_num_and_eq_mul_div_denom n d n_ne_zero
-          (by exact_mod_cast d_ne_zero)) },
-      suffices : q.num / q.denom = c * q.num / (c * q.denom),
-        by rwa [n_eq_c_mul_num, d_eq_c_mul_denom],
-      suffices : c > 0, by solve_by_elim [int.mul_div_mul_of_pos],
-      have q_denom_mul_c_pos : (0 : ℤ) < q.denom * c, by
-      { have : (d : ℤ) > 0, by exact_mod_cast (pos_iff_ne_zero.elim_right d_ne_zero),
-        rwa [d_eq_c_mul_denom, mul_comm] at this },
-      suffices : (0 : ℤ) ≤ q.denom, from pos_of_mul_pos_left q_denom_mul_c_pos this,
-      exact_mod_cast (le_of_lt q.pos) } }
+  { set q := (n : ℚ) / d with q_eq,
+    obtain ⟨c, n_eq_c_mul_num, d_eq_c_mul_denom⟩ : ∃ c, n = c * q.num ∧ (d : ℤ) = c * q.denom, by
+    { rw q_eq,
+      exact_mod_cast (@rat.exists_eq_mul_div_num_and_eq_mul_div_denom n d
+        (by exact_mod_cast d_ne_zero)) },
+    suffices : q.num / q.denom = c * q.num / (c * q.denom),
+      by rwa [n_eq_c_mul_num, d_eq_c_mul_denom],
+    suffices : c > 0, by solve_by_elim [int.mul_div_mul_of_pos],
+    have q_denom_mul_c_pos : (0 : ℤ) < q.denom * c, by
+    { have : (d : ℤ) > 0, by exact_mod_cast (pos_iff_ne_zero.elim_right d_ne_zero),
+      rwa [d_eq_c_mul_denom, mul_comm] at this },
+    suffices : (0 : ℤ) ≤ q.denom, from pos_of_mul_pos_left q_denom_mul_c_pos this,
+    exact_mod_cast (le_of_lt q.pos) }
 end
 
 end rat

--- a/src/data/zmod/basic.lean
+++ b/src/data/zmod/basic.lean
@@ -710,7 +710,7 @@ lemma neg_one_ne_one {n : ℕ} [fact (2 < n)] :
   (-1 : zmod n) ≠ 1 :=
 char_p.neg_one_ne_one (zmod n) n
 
-@[simp] lemma neg_eq_self_mod_two (a : zmod 2) : -a = a :=
+lemma neg_eq_self_mod_two (a : zmod 2) : -a = a :=
 by fin_cases a; ext; simp [fin.coe_neg, int.nat_mod]; norm_num
 
 @[simp] lemma nat_abs_mod_two (a : ℤ) : (a.nat_abs : zmod 2) = a :=

--- a/src/field_theory/minpoly.lean
+++ b/src/field_theory/minpoly.lean
@@ -154,10 +154,11 @@ nat_degree_pos_iff_degree_pos.mp (nat_degree_pos hx)
 
 /-- If `B/A` is an injective ring extension, and `a` is an element of `A`,
 then the minimal polynomial of `algebra_map A B a` is `X - C a`. -/
-lemma eq_X_sub_C_of_algebra_map_inj [nontrivial A]
+lemma eq_X_sub_C_of_algebra_map_inj
   (a : A) (hf : function.injective (algebra_map A B)) :
   minpoly A (algebra_map A B a) = X - C a :=
 begin
+  nontriviality A,
   have hdegle : (minpoly A (algebra_map A B a)).nat_degree ≤ 1,
   { apply with_bot.coe_le_coe.1,
     rw [←degree_eq_nat_degree (ne_zero (@is_integral_algebra_map A B _ _ _ a)),

--- a/src/field_theory/ratfunc.lean
+++ b/src/field_theory/ratfunc.lean
@@ -957,7 +957,7 @@ by { convert num_div (1 : K[X]) 1; simp }
   num (algebra_map _ _ p) = p :=
 by { convert num_div p 1; simp }
 
-@[simp] lemma num_div_dvd (p : K[X]) {q : K[X]} (hq : q ≠ 0) :
+lemma num_div_dvd (p : K[X]) {q : K[X]} (hq : q ≠ 0) :
   num (algebra_map _ _ p / algebra_map _ _ q) ∣ p :=
 begin
   rw [num_div _ q, C_mul_dvd],
@@ -965,6 +965,11 @@ begin
   { simpa only [ne.def, inv_eq_zero, polynomial.leading_coeff_eq_zero]
       using right_div_gcd_ne_zero hq },
 end
+
+/-- A version of `num_div_dvd` with the LHS in simp normal form -/
+@[simp] lemma num_div_dvd' (p : K[X]) {q : K[X]} (hq : q ≠ 0) :
+  C ((q / gcd p q).leading_coeff)⁻¹ * (p / gcd p q) ∣ p :=
+by simpa using num_div_dvd p hq
 
 /-- `ratfunc.denom` is the denominator of a rational function,
 normalized such that it is monic. -/

--- a/src/field_theory/ratfunc.lean
+++ b/src/field_theory/ratfunc.lean
@@ -933,25 +933,34 @@ end
 normalized such that the denominator is monic. -/
 def num (x : ratfunc K) : K[X] := x.num_denom.1
 
-@[simp] lemma num_div (p : K[X]) {q : K[X]} (hq : q ≠ 0) :
+private lemma num_div' (p : K[X]) {q : K[X]} (hq : q ≠ 0) :
   num (algebra_map _ _ p / algebra_map _ _ q) =
     polynomial.C ((q / gcd p q).leading_coeff⁻¹) * (p / gcd p q) :=
 by rw [num, num_denom_div _ hq]
 
 @[simp] lemma num_zero : num (0 : ratfunc K) = 0 :=
-by { convert num_div (0 : K[X]) one_ne_zero; simp }
+by { convert num_div' (0 : K[X]) one_ne_zero; simp }
+
+@[simp] lemma num_div (p q : K[X]) :
+  num (algebra_map _ _ p / algebra_map _ _ q) =
+    polynomial.C ((q / gcd p q).leading_coeff⁻¹) * (p / gcd p q) :=
+begin
+  by_cases hq : q = 0,
+  { simp [hq] },
+  { exact num_div' p hq, },
+end
 
 @[simp] lemma num_one : num (1 : ratfunc K) = 1 :=
-by { convert num_div (1 : K[X]) one_ne_zero; simp }
+by { convert num_div (1 : K[X]) 1; simp }
 
 @[simp] lemma num_algebra_map (p : K[X]) :
   num (algebra_map _ _ p) = p :=
-by { convert num_div p one_ne_zero; simp }
+by { convert num_div p 1; simp }
 
 @[simp] lemma num_div_dvd (p : K[X]) {q : K[X]} (hq : q ≠ 0) :
   num (algebra_map _ _ p / algebra_map _ _ q) ∣ p :=
 begin
-  rw [num_div _ hq, C_mul_dvd],
+  rw [num_div _ q, C_mul_dvd],
   { exact euclidean_domain.div_dvd_of_dvd (gcd_dvd_left p q) },
   { simpa only [ne.def, inv_eq_zero, polynomial.leading_coeff_eq_zero]
       using right_div_gcd_ne_zero hq },
@@ -1000,7 +1009,7 @@ end
   algebra_map _ _ (num x) / algebra_map _ _ (denom x) = x :=
 x.induction_on (λ p q hq, begin
   have q_div_ne_zero := right_div_gcd_ne_zero hq,
-  rw [num_div p hq, denom_div p hq, ring_hom.map_mul, ring_hom.map_mul,
+  rw [num_div p q, denom_div p hq, ring_hom.map_mul, ring_hom.map_mul,
     mul_div_mul_left, div_eq_div_iff, ← ring_hom.map_mul, ← ring_hom.map_mul, mul_comm _ q,
     ← euclidean_domain.mul_div_assoc, ← euclidean_domain.mul_div_assoc, mul_comm],
   { apply gcd_dvd_right },
@@ -1333,9 +1342,11 @@ begin
   rw mul_assoc
 end
 
-lemma int_degree_add_le {x y : ratfunc K} (hx : x ≠ 0) (hy : y ≠ 0) (hxy : x + y ≠ 0) :
+lemma int_degree_add_le {x y : ratfunc K} (hy : y ≠ 0) (hxy : x + y ≠ 0) :
   int_degree (x + y) ≤ max (int_degree x) (int_degree y) :=
 begin
+  by_cases hx : x = 0,
+  { simp [hx] at *, },
   rw [int_degree_add hxy,
     ← nat_degree_num_mul_right_sub_nat_degree_denom_mul_left_eq_int_degree hx y.denom_ne_zero,
     mul_comm y.denom,

--- a/src/linear_algebra/matrix/charpoly/coeff.lean
+++ b/src/linear_algebra/matrix/charpoly/coeff.lean
@@ -120,7 +120,6 @@ end
 theorem trace_eq_neg_charpoly_coeff [nonempty n] (M : matrix n n R) :
   (trace n R R) M = -M.charpoly.coeff (fintype.card n - 1) :=
 begin
-  nontriviality,
   rw charpoly_coeff_eq_prod_coeff_of_le, swap, refl,
   rw [fintype.card, prod_X_sub_C_coeff_card_pred univ (λ i : n, M i i)], simp,
   rw [← fintype.card, fintype.card_pos_iff], apply_instance,
@@ -209,12 +208,16 @@ end
   (M ^ p).charpoly = M.charpoly :=
 by { have h := finite_field.matrix.charpoly_pow_card M, rwa zmod.card at h, }
 
-lemma finite_field.trace_pow_card {K : Type*} [field K] [fintype K] [nonempty n]
+lemma finite_field.trace_pow_card {K : Type*} [field K] [fintype K]
   (M : matrix n n K) : trace n K K (M ^ (fintype.card K)) = (trace n K K M) ^ (fintype.card K) :=
-by rw [matrix.trace_eq_neg_charpoly_coeff, matrix.trace_eq_neg_charpoly_coeff,
+begin
+  casesI is_empty_or_nonempty n,
+  { simp [zero_pow fintype.card_pos], },
+  rw [matrix.trace_eq_neg_charpoly_coeff, matrix.trace_eq_neg_charpoly_coeff,
        finite_field.matrix.charpoly_pow_card, finite_field.pow_card]
+end
 
-lemma zmod.trace_pow_card {p:ℕ} [fact p.prime] [nonempty n] (M : matrix n n (zmod p)) :
+lemma zmod.trace_pow_card {p:ℕ} [fact p.prime] (M : matrix n n (zmod p)) :
   trace n (zmod p) (zmod p) (M ^ p) = (trace n (zmod p) (zmod p) M)^p :=
 by { have h := finite_field.trace_pow_card M, rwa zmod.card at h, }
 

--- a/src/measure_theory/constructions/pi.lean
+++ b/src/measure_theory/constructions/pi.lean
@@ -147,9 +147,11 @@ lemma pi_premeasure_pi {s : Π i, set (α i)} (hs : (pi univ s).nonempty) :
   pi_premeasure m (pi univ s) = ∏ i, m i (s i) :=
 by simp [hs]
 
-lemma pi_premeasure_pi' [nonempty ι] {s : Π i, set (α i)} :
+lemma pi_premeasure_pi' {s : Π i, set (α i)} :
   pi_premeasure m (pi univ s) = ∏ i, m i (s i) :=
 begin
+  casesI is_empty_or_nonempty ι,
+  { simp, },
   cases (pi univ s).eq_empty_or_nonempty with h h,
   { rcases univ_pi_eq_empty_iff.mp h with ⟨i, hi⟩,
     have : ∃ i, m i (s i) = 0 := ⟨i, by simp [hi]⟩,
@@ -162,7 +164,7 @@ lemma pi_premeasure_pi_mono {s t : set (Π i, α i)} (h : s ⊆ t) :
   pi_premeasure m s ≤ pi_premeasure m t :=
 finset.prod_le_prod' (λ i _, (m i).mono' (image_subset _ h))
 
-lemma pi_premeasure_pi_eval [nonempty ι] {s : set (Π i, α i)} :
+lemma pi_premeasure_pi_eval {s : set (Π i, α i)} :
   pi_premeasure m (pi univ (λ i, eval i '' s)) = pi_premeasure m s :=
 by simp [pi_premeasure_pi']
 

--- a/src/measure_theory/function/uniform_integrable.lean
+++ b/src/measure_theory/function/uniform_integrable.lean
@@ -462,10 +462,12 @@ end
 end
 
 lemma snorm_sub_le_of_dist_bdd
-  {p : ℝ≥0∞} (hp : p ≠ 0) (hp' : p ≠ ∞) {s : set α} (hs : measurable_set[m] s)
+  {p : ℝ≥0∞} (hp' : p ≠ ∞) {s : set α} (hs : measurable_set[m] s)
   {f g : α → β} {c : ℝ} (hc : 0 ≤ c) (hf : ∀ x ∈ s, dist (f x) (g x) ≤ c) :
   snorm (s.indicator (f - g)) p μ ≤ ennreal.of_real c * μ s ^ (1 / p.to_real) :=
 begin
+  by_cases hp : p = 0,
+  { simp [hp], },
   have : ∀ x, ∥s.indicator (f - g) x∥ ≤ ∥s.indicator (λ x, c) x∥,
   { intro x,
     by_cases hx : x ∈ s,
@@ -527,7 +529,7 @@ begin
     exact min_le_right _ _ },
   have hlt : snorm (tᶜ.indicator (f n - g)) p μ ≤ ennreal.of_real (ε.to_real / 3),
   { specialize hN n hn,
-    have := snorm_sub_le_of_dist_bdd μ ((lt_of_lt_of_le ennreal.zero_lt_one hp).ne.symm)
+    have := snorm_sub_le_of_dist_bdd μ
       hp' htm.compl _ (λ x hx, (dist_comm (g x) (f n x) ▸ (hN x hx).le :
       dist (f n x) (g x) ≤ ε.to_real / (3 * measure_univ_nnreal μ ^ (1 / p.to_real)))),
     refine le_trans this _,

--- a/src/measure_theory/integral/circle_integral.lean
+++ b/src/measure_theory/integral/circle_integral.lean
@@ -207,9 +207,11 @@ end circle_integrable
 by simp [circle_integrable]
 
 lemma circle_integrable_iff [normed_space ℂ E]
-  {f : ℂ → E} {c : ℂ} {R : ℝ} (h₀ : R ≠ 0) : circle_integrable f c R ↔
+  {f : ℂ → E} {c : ℂ} (R : ℝ) : circle_integrable f c R ↔
   interval_integrable (λ θ : ℝ, deriv (circle_map c R) θ • f (circle_map c R θ)) volume 0 (2 * π) :=
 begin
+  by_cases h₀ : R = 0,
+  { simp [h₀], },
   refine ⟨λ h, h.out, λ h, _⟩,
   simp only [circle_integrable, interval_integrable_iff, deriv_circle_map] at h ⊢,
   refine (h.norm.const_mul (|R|⁻¹)).mono' _ _,
@@ -238,7 +240,7 @@ radius `|R|` if and only if `R = 0` or `0 ≤ n`, or `w` does not belong to this
 begin
   split,
   { intro h, contrapose! h, rcases h with ⟨hR, hn, hw⟩,
-    simp only [circle_integrable_iff hR, deriv_circle_map],
+    simp only [circle_integrable_iff R, deriv_circle_map],
     rw ← image_circle_map_Ioc at hw, rcases hw with ⟨θ, hθ, rfl⟩,
     replace hθ : θ ∈ [0, 2 * π], from Icc_subset_interval (Ioc_subset_Icc_self hθ),
     refine not_interval_integrable_of_sub_inv_is_O_punctured _ real.two_pi_pos.ne hθ,
@@ -297,10 +299,7 @@ end
 
 lemma integral_undef {f : ℂ → E} {c : ℂ} {R : ℝ} (hf : ¬circle_integrable f c R) :
   ∮ z in C(c, R), f z = 0 :=
-begin
-  rcases eq_or_ne R 0 with rfl|h0, { simp },
-  exact interval_integral.integral_undef (mt (circle_integrable_iff h0).mpr hf)
-end
+interval_integral.integral_undef (mt (circle_integrable_iff R).mpr hf)
 
 lemma integral_sub {f g : ℂ → E} {c : ℂ} {R : ℝ} (hf : circle_integrable f c R)
   (hg : circle_integrable g c R) :

--- a/src/number_theory/cyclotomic/basic.lean
+++ b/src/number_theory/cyclotomic/basic.lean
@@ -351,7 +351,7 @@ lemma splitting_field_X_pow_sub_one : is_splitting_field K L (X ^ (n : ℕ) - 1)
     refine set.ext (λ x, _),
     simp only [polynomial.map_pow, mem_singleton_iff, multiset.mem_to_finset, exists_eq_left,
       mem_set_of_eq, polynomial.map_X, polynomial.map_one, finset.mem_coe, polynomial.map_sub],
-    rwa [← ring_hom.map_one C, mem_roots (@X_pow_sub_C_ne_zero _ (field.to_nontrivial L) _ _
+    rwa [← ring_hom.map_one C, mem_roots (@X_pow_sub_C_ne_zero _ _ (field.to_nontrivial L) _
       n.pos _), is_root.def, eval_sub, eval_pow, eval_C, eval_X, sub_eq_zero]
   end }
 

--- a/src/number_theory/function_field.lean
+++ b/src/number_theory/function_field.lean
@@ -189,7 +189,7 @@ begin
         rw [le_max_iff,
         with_zero.coe_le_coe, multiplicative.of_add_le, with_zero.coe_le_coe,
         multiplicative.of_add_le, ← le_max_iff],
-        exact ratfunc.int_degree_add_le hx hy hxy }}}
+        exact ratfunc.int_degree_add_le hy hxy }}}
 end
 
 @[simp] lemma infty_valuation_of_nonzero {x : ratfunc Fq} (hx : x ≠ 0) :

--- a/src/number_theory/padics/padic_norm.lean
+++ b/src/number_theory/padics/padic_norm.lean
@@ -212,9 +212,8 @@ protected lemma defn {q : ℚ} {n d : ℤ} (hqz : q ≠ 0) (qdf : q = n /. d) :
     ⟨ne.symm $ ne_of_lt p_prime.1.one_lt, λ hn, by simp * at *⟩) -
   (multiplicity (p : ℤ) d).get (finite_int_iff.2 ⟨ne.symm $ ne_of_lt p_prime.1.one_lt,
     λ hd, by simp * at *⟩) :=
-have hn : n ≠ 0, from rat.mk_num_ne_zero_of_ne_zero hqz qdf,
 have hd : d ≠ 0, from rat.mk_denom_ne_zero_of_ne_zero hqz qdf,
-let ⟨c, hc1, hc2⟩ := rat.num_denom_mk hn hd qdf in
+let ⟨c, hc1, hc2⟩ := rat.num_denom_mk hd qdf in
 by rw [padic_val_rat, dif_pos];
   simp [hc1, hc2, multiplicity.mul' (nat.prime_iff_prime_int.1 p_prime.1),
     (ne.symm (ne_of_lt p_prime.1.one_lt)), hqz]
@@ -246,10 +245,14 @@ by induction k; simp [*, padic_val_rat.mul _ hq (pow_ne_zero _ hq),
 /--
 A rewrite lemma for `padic_val_rat p (q⁻¹)` with condition `q ≠ 0`.
 -/
-protected lemma inv {q : ℚ} (hq : q ≠ 0) :
+protected lemma inv (q : ℚ) :
   padic_val_rat p (q⁻¹) = -padic_val_rat p q :=
-by rw [eq_neg_iff_add_eq_zero, ← padic_val_rat.mul p (inv_ne_zero hq) hq,
-    inv_mul_cancel hq, padic_val_rat.one]
+begin
+  by_cases hq : q = 0,
+  { simp [hq], },
+  { rw [eq_neg_iff_add_eq_zero, ← padic_val_rat.mul p (inv_ne_zero hq) hq,
+      inv_mul_cancel hq, padic_val_rat.one] },
+end
 
 /--
 A rewrite lemma for `padic_val_rat p (q / r)` with conditions `q ≠ 0`, `r ≠ 0`.
@@ -257,7 +260,7 @@ A rewrite lemma for `padic_val_rat p (q / r)` with conditions `q ≠ 0`, `r ≠ 
 protected lemma div {q r : ℚ} (hq : q ≠ 0) (hr : r ≠ 0) :
   padic_val_rat p (q / r) = padic_val_rat p q - padic_val_rat p r :=
 by rw [div_eq_mul_inv, padic_val_rat.mul p hq (inv_ne_zero hr),
-    padic_val_rat.inv p hr, sub_eq_add_neg]
+    padic_val_rat.inv p r, sub_eq_add_neg]
 
 /--
 A condition for `padic_val_rat p (n₁ / d₁) ≤ padic_val_rat p (n₂ / d₂),

--- a/src/ring_theory/chain_of_divisors.lean
+++ b/src/ring_theory/chain_of_divisors.lean
@@ -202,9 +202,11 @@ open divisor_chain
 
 lemma pow_image_of_prime_by_factor_order_iso_dvd {m p : associates M} {n : associates N}
   (hn : n ≠ 0) (hp : p ∈ normalized_factors m)
-  (d : {l : associates M // l ≤ m} ≃o {l : associates N // l ≤ n}) {s : ℕ} (hs : s ≠ 0)
+  (d : {l : associates M // l ≤ m} ≃o {l : associates N // l ≤ n}) {s : ℕ}
   (hs' : p^s ≤ m) : (d ⟨p, dvd_of_mem_normalized_factors hp⟩ : associates N)^s ≤ n :=
 begin
+  by_cases hs : s = 0,
+  { simp [hs], },
   suffices : (d ⟨p, dvd_of_mem_normalized_factors hp⟩ : associates N)^s = ↑(d ⟨p^s, hs'⟩),
   { rw this,
     apply subtype.prop (d ⟨p^s, hs'⟩) },
@@ -234,14 +236,15 @@ variables [decidable_rel ((∣) : associates M → associates M → Prop)]
  [decidable_rel ((∣) : associates N → associates N → Prop)]
 
 lemma multiplicity_prime_le_multiplicity_image_by_factor_order_iso {m p : associates M}
-  {n : associates N} (hm : m ≠ 0) (hn : n ≠ 0) (hp : p ∈ normalized_factors m)
+  {n : associates N} (hp : p ∈ normalized_factors m)
   (d : {l : associates M // l ≤ m} ≃o {l : associates N // l ≤ n}) :
   multiplicity p m ≤ multiplicity ↑(d ⟨p, dvd_of_mem_normalized_factors hp⟩) n :=
 begin
+  by_cases hn : n = 0,
+  { simp [hn], },
+  by_cases hm : m = 0,
+  { simpa [hm] using hp, },
   rw [←enat.coe_get (finite_iff_dom.1 $ finite_prime_left (prime_of_normalized_factor p hp) hm),
     ←pow_dvd_iff_le_multiplicity],
-  refine pow_image_of_prime_by_factor_order_iso_dvd hn hp d (λ H, _) (pow_multiplicity_dvd _),
-  refine (dvd_of_mem_normalized_factors hp).multiplicity_pos.ne' (part.eq_some_iff.mpr _),
-  rw ←H,
-  exact part.get_mem _,
+  exact pow_image_of_prime_by_factor_order_iso_dvd hn hp d (pow_multiplicity_dvd _),
 end

--- a/src/ring_theory/dedekind_domain/ideal.lean
+++ b/src/ring_theory/dedekind_domain/ideal.lean
@@ -791,12 +791,13 @@ lemma irreducible_pow_sup (hI : I ≠ ⊥) (hJ : irreducible J) (n : ℕ) :
 by rw [sup_eq_prod_inf_factors (pow_ne_zero n hJ.ne_zero) hI, ← inf_eq_inter,
        normalized_factors_of_irreducible_pow hJ, normalize_eq J, repeat_inf, prod_repeat]
 
-lemma irreducible_pow_sup_of_le (hI : I ≠ ⊥) (hJ : irreducible J) (n : ℕ)
+lemma irreducible_pow_sup_of_le (hJ : irreducible J) (n : ℕ)
   (hn : ↑n ≤ multiplicity J I) : J^n ⊔ I = J^n :=
 begin
+  by_cases hI : I = ⊥,
+  { simp [*] at *, },
   rw [irreducible_pow_sup hI hJ, min_eq_right],
-  rwa [multiplicity_eq_count_normalized_factors hJ hI, enat.coe_le_coe, normalize_eq J]
-    at hn
+  rwa [multiplicity_eq_count_normalized_factors hJ hI, enat.coe_le_coe, normalize_eq J] at hn
 end
 
 lemma irreducible_pow_sup_of_ge (hI : I ≠ ⊥) (hJ : irreducible J) (n : ℕ)

--- a/src/ring_theory/unique_factorization_domain.lean
+++ b/src/ring_theory/unique_factorization_domain.lean
@@ -1466,7 +1466,6 @@ lemma associates.quot_out {α : Type*} [comm_monoid α] (a : associates α):
 associates.mk (quot.out (a)) = a :=
 by rw [←quot_mk_eq_mk, quot.out_eq]
 
-set_option pp.all true
 /-- `to_gcd_monoid` constructs a GCD monoid out of a unique factorization domain. -/
 noncomputable def unique_factorization_monoid.to_gcd_monoid
   (α : Type*) [cancel_comm_monoid_with_zero α] [unique_factorization_monoid α]


### PR DESCRIPTION
This PR uses the same methodology as #10774 to use a linter to remove edge case assumptions from lemmas when the result is easy to prove without the assumption.

These are assumptions things like: n \ne 0, 0 < n, p \ne \top, nontrivial R, nonempty R.
Removing these unneeded assumptions makes such lemmas easier to apply, and lets us golf a few other proofs along the way.

The file with the most changes is `src/ring_theory/unique_factorization_domain.lean` where the linter inspired me to allow trivial monoids in many places.

The code I used to find these is in the branch [https://github.com/leanprover-community/mathlib/tree/alexjbest/simple_edge_cases_linter](https://github.com/leanprover-community/mathlib/tree/alexjbest/simple_edge_cases_linter?rgh-link-date=2021-12-13T23%3A53%3A31Z)


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
