### PR TITLE
[Merged by Bors] - feat(category_theory/fully_faithful): nat_trans_of_comp_fully_faithful

### DIFF
--- a/src/category_theory/functor/fully_faithful.lean
+++ b/src/category_theory/functor/fully_faithful.lean
@@ -135,17 +135,16 @@ def nat_trans_of_comp_fully_faithful (α : F ⋙ H ⟶ G ⋙ H) : F ⟶ G :=
 
 /-- We can construct a natural isomorphism between functors by constructing a natural isomorphism
 between those functors composed with a fully faithful functor. -/
+@[simps]
 def nat_iso_of_comp_fully_faithful (i : F ⋙ H ≅ G ⋙ H) : F ≅ G :=
 nat_iso.of_components
   (λ X, (iso_equiv_of_fully_faithful H).symm (i.app X))
   (λ X Y f, by { dsimp, apply H.map_injective, simpa using i.hom.naturality f, })
 
-@[simp]
 lemma nat_iso_of_comp_fully_faithful_hom (i : F ⋙ H ≅ G ⋙ H) :
   (nat_iso_of_comp_fully_faithful H i).hom = nat_trans_of_comp_fully_faithful H i.hom :=
 by { ext, simp [nat_iso_of_comp_fully_faithful], }
 
-@[simp]
 lemma nat_iso_of_comp_fully_faithful_inv (i : F ⋙ H ≅ G ⋙ H) :
   (nat_iso_of_comp_fully_faithful H i).inv = nat_trans_of_comp_fully_faithful H i.inv :=
 by { ext, simp [←preimage_comp], dsimp, simp, }

--- a/src/category_theory/functor/fully_faithful.lean
+++ b/src/category_theory/functor/fully_faithful.lean
@@ -69,6 +69,7 @@ full.preimage.{v₁ v₂} f
 by unfold preimage; obviously
 end functor
 
+section
 variables {F : C ⥤ D} [full F] [faithful F] {X Y Z : C}
 
 @[simp] lemma preimage_id : F.preimage (𝟙 (F.obj X)) = 𝟙 X :=
@@ -120,14 +121,36 @@ def iso_equiv_of_fully_faithful {X Y} : (X ≅ Y) ≃ (F.obj X ≅ F.obj Y) :=
   left_inv := λ f, by simp,
   right_inv := λ f, by { ext, simp, } }
 
+end
+
+section
+variables {E : Type*} [category E] {F G : C ⥤ D} (H : D ⥤ E) [full H] [faithful H]
+
+/-- We can construct a natural transformation between functors by constructing a
+natural transformation between those functors composed with a fully faithful functor. -/
+@[simps]
+def nat_trans_of_comp_fully_faithful (α : F ⋙ H ⟶ G ⋙ H) : F ⟶ G :=
+{ app := λ X, (equiv_of_fully_faithful H).symm (α.app X),
+  naturality' := λ X Y f, by { dsimp, apply H.map_injective, simpa using α.naturality f, } }
+
 /-- We can construct a natural isomorphism between functors by constructing a natural isomorphism
 between those functors composed with a fully faithful functor. -/
-@[simps]
-def nat_iso_of_comp_fully_faithful {E : Type*} [category E]
-  {F G : C ⥤ D} (H : D ⥤ E) [full H] [faithful H] (i : F ⋙ H ≅ G ⋙ H) : F ≅ G :=
+def nat_iso_of_comp_fully_faithful (i : F ⋙ H ≅ G ⋙ H) : F ≅ G :=
 nat_iso.of_components
   (λ X, (iso_equiv_of_fully_faithful H).symm (i.app X))
   (λ X Y f, by { dsimp, apply H.map_injective, simpa using i.hom.naturality f, })
+
+@[simp]
+lemma nat_iso_of_comp_fully_faithful_hom (i : F ⋙ H ≅ G ⋙ H) :
+  (nat_iso_of_comp_fully_faithful H i).hom = nat_trans_of_comp_fully_faithful H i.hom :=
+by { ext, simp [nat_iso_of_comp_fully_faithful], }
+
+@[simp]
+lemma nat_iso_of_comp_fully_faithful_inv (i : F ⋙ H ≅ G ⋙ H) :
+  (nat_iso_of_comp_fully_faithful H i).inv = nat_trans_of_comp_fully_faithful H i.inv :=
+by { ext, simp [←preimage_comp], dsimp, simp, }
+
+end
 
 end category_theory
 


### PR DESCRIPTION
I added `nat_iso_of_comp_fully_faithful` in an earlier PR, but left out the more basic construction.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
