### PR TITLE
[Merged by Bors] - feat(algebra/group/to_additive): let @[to_additive] mimic alias’s docstrings

### DIFF
--- a/src/algebra/group/to_additive.lean
+++ b/src/algebra/group/to_additive.lean
@@ -553,15 +553,9 @@ protected meta def attr : user_attribute unit value_type :=
       match val.doc with
       | some doc := add_doc_string tgt doc
       | none := do
-        alias_opt ← tactic.alias.get_alias_target src,
-        match alias_opt with
-        | some alias_name := match dict.find alias_name with
-          | some add_alias_name :=
-            add_doc_string tgt ("**Alias** of `" ++ to_string add_alias_name ++ "`.")
-          | none := skip
-          end
-        | none := skip
-        end
+        some alias_name ← tactic.alias.get_alias_target src | skip,
+        some add_alias_name ← pure (dict.find alias_name) | skip,
+        add_doc_string tgt ("**Alias** of `" ++ to_string add_alias_name ++ "`.")
       end }
 
 add_tactic_doc

--- a/src/algebra/group/to_additive.lean
+++ b/src/algebra/group/to_additive.lean
@@ -6,6 +6,7 @@ Authors: Mario Carneiro, Yury Kudryashov, Floris van Doorn
 import tactic.transform_decl
 import tactic.algebra
 import tactic.lint.basic
+import tactic.alias
 
 /-!
 # Transport multiplicative to additive
@@ -579,6 +580,9 @@ them has one -/
 @[linter] meta def linter.to_additive_doc : linter :=
 { test := (λ d, do
     let mul_name := d.to_name,
+    /- Disable this linter for aliases -/
+    is_alias ← tactic.alias.get_alias_target mul_name,
+    if is_alias.is_some then return none else do
     dict ← to_additive.aux_attr.get_cache,
     match dict.find mul_name with
     | some add_name := do

--- a/src/data/buffer/parser/basic.lean
+++ b/src/data/buffer/parser/basic.lean
@@ -6,6 +6,7 @@ Authors: Yakov Pechersky
 import data.string.basic
 import data.buffer.basic
 import data.nat.digits
+import data.buffer.parser
 
 /-!
 # Parsers

--- a/src/tactic/alias.lean
+++ b/src/tactic/alias.lean
@@ -42,7 +42,7 @@ The `..` notation attempts to generate the 'of'-names automatically when the
 input theorem has the form `A_iff_B` or `A_iff_B_left` etc.
 -/
 
-open lean.parser tactic interactive --  parser
+open lean.parser tactic interactive
 
 namespace tactic.alias
 

--- a/src/tactic/alias.lean
+++ b/src/tactic/alias.lean
@@ -3,7 +3,6 @@ Copyright (c) 2017 Mario Carneiro. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro
 -/
-import data.buffer.parser
 import tactic.core
 
 /-!
@@ -43,7 +42,7 @@ The `..` notation attempts to generate the 'of'-names automatically when the
 input theorem has the form `A_iff_B` or `A_iff_B_left` etc.
 -/
 
-open lean.parser tactic interactive parser
+open lean.parser tactic interactive --  parser
 
 namespace tactic.alias
 
@@ -81,7 +80,7 @@ meta def alias_iff (d : declaration) (doc : string) (al : name) (iffmp : name) :
 meta def make_left_right : name → tactic (name × name)
 | (name.mk_string s p) := do
   let buf : char_buffer := s.to_char_buffer,
-  sum.inr parts ← pure $ run (sep_by1 (ch '_') (many_char (sat (≠ '_')))) s.to_char_buffer,
+  let parts := s.split_on '_',
   (left, _::right) ← pure $ parts.span (≠ "iff"),
   let pfx (a b : string) := a.to_list.is_prefix_of b.to_list,
   (suffix', right') ← pure $ right.reverse.span (λ s, pfx "left" s ∨ pfx "right" s),

--- a/test/lint_to_additive_doc.lean
+++ b/test/lint_to_additive_doc.lean
@@ -1,4 +1,5 @@
 import algebra.group.to_additive
+import tactic.alias
 
 /-- Docstring -/
 @[to_additive add_foo]
@@ -11,10 +12,16 @@ def bar (α : Type*) [has_one α] : α := 1
 @[to_additive add_baz "docstring"]
 def baz (α : Type*) [has_one α] : α := 1
 
-@[to_additive add_quuz]
+@[to_additive add_quux]
 def quux (α : Type*) [has_one α] : α := 1
 
 def no_to_additive (α : Type*) [has_one α] : α := 1
+
+-- Aliases always have docstrings, so we do not want to complain if their
+-- additive version do not
+alias quux <- quux_alias
+attribute [to_additive add_quux_alias] quux_alias
+
 
 open tactic
 run_cmd do
@@ -43,6 +50,12 @@ run_cmd do
 
 run_cmd do
   decl ← get_decl ``no_to_additive,
+  res ← linter.to_additive_doc.test decl,
+  -- linter is happy
+  guard $ res.is_none
+
+run_cmd do
+  decl ← get_decl ``quux_alias,
   res ← linter.to_additive_doc.test decl,
   -- linter is happy
   guard $ res.is_none


### PR DESCRIPTION
many of our `nolint.txt` entires are due to code of this shape:

    @[to_additive add_foo]
    lemma foo := .. /- no docstring -/
    alias foo <- bar
    attribute [to_additive add_bar] bar

where now `bar` has a docstring (from `alias`), but `bar_add` does not.

This PR makes `to_additive` detect that `bar` is an alias, and unless an 
explicit docstring is passed to `to_additive`, creates an “alias of add_foo”
docstring.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
