### PR TITLE
[Merged by Bors] - feat(data/fin/tuple/nat_antidiagonal): add `list.nat.antidiagonal_tuple_pairwise_pi_lex`

### DIFF
--- a/src/data/fin/tuple/nat_antidiagonal.lean
+++ b/src/data/fin/tuple/nat_antidiagonal.lean
@@ -208,7 +208,6 @@ lemma mem_antidiagonal_tuple {n : ℕ} {k : ℕ} (x : fin k → ℕ) :
   x ∈ antidiagonal_tuple k n ↔ ∑ i, x i = n :=
 list.nat.mem_antidiagonal_tuple _
 
-
 lemma antidiagonal_tuple_zero_right (k : ℕ) : antidiagonal_tuple k 0 = {0} :=
 finset.eq_of_veq (multiset.nat.antidiagonal_tuple_zero_right k)
 

--- a/src/data/fin/tuple/nat_antidiagonal.lean
+++ b/src/data/fin/tuple/nat_antidiagonal.lean
@@ -46,7 +46,8 @@ namespace list.nat
 
 /-- `list.antidiagonal_tuple k n` is a list of all `k`-tuples which sum to `n`.
 
-This list contains no duplicates, and is sorted lexicographically, starting with `![0, ..., n]`
+This list contains no duplicates (`list.nat.nodup_antidiagonal_tuple`), and is sorted
+lexicographically (`list.nat.antidiagonal_tuple_pairwise_pi_lex`), starting with `![0, ..., n]`
 and ending with `![n, ..., 0]`.
 
 ```
@@ -129,6 +130,31 @@ begin
   simp_rw [antidiagonal_tuple_one, list.map_singleton],
   rw [list.map_eq_bind],
   refl,
+end
+
+lemma antidiagonal_tuple_pairwise_pi_lex (k n : ℕ) :
+  (antidiagonal_tuple k n).pairwise (pi.lex (<) (λ _, (<))) :=
+begin
+  induction k with k ih generalizing n,
+  { cases n,
+    { simp only [antidiagonal_tuple_zero_zero, list.pairwise_singleton] },
+    { simp only [antidiagonal_tuple_zero_succ, list.pairwise.nil] }, },
+  simp_rw [antidiagonal_tuple, list.pairwise_bind, list.pairwise_map, list.mem_map,
+    forall_exists_index, and_imp, forall_apply_eq_imp_iff₂],
+  simp only [mem_antidiagonal, prod.forall, and_imp, forall_apply_eq_imp_iff₂],
+  simp only [fin.pi_lex_lt_cons_cons, eq_self_iff_true, true_and, lt_self_iff_false, false_or],
+  refine ⟨λ _ _ _, ih _, _⟩,
+  induction n,
+  { rw [antidiagonal_zero],
+    exact list.pairwise_singleton _ _ },
+  { rw [antidiagonal_succ, list.pairwise_cons, list.pairwise_map],
+    refine ⟨λ p hp x hx y hy, _, _⟩,
+    { rw [list.mem_map, prod.exists] at hp,
+      obtain ⟨a, b, hab, (rfl : (nat.succ a, b) = p)⟩ := hp,
+      exact or.inl (nat.zero_lt_succ _), },
+    dsimp,
+    simp_rw [nat.succ_inj', nat.succ_lt_succ_iff],
+    exact n_ih },
 end
 
 end list.nat

--- a/src/data/fin/tuple/nat_antidiagonal.lean
+++ b/src/data/fin/tuple/nat_antidiagonal.lean
@@ -110,6 +110,14 @@ begin
       exact h (list.mem_map_of_mem _ hx₁) (list.mem_map_of_mem _ hx₂) }, },
 end
 
+lemma antidiagonal_tuple_zero_right : ∀ k, antidiagonal_tuple k 0 = [0]
+| 0 := congr_arg (λ x, [x]) $ subsingleton.elim _ _
+| (k + 1) := begin
+  rw [antidiagonal_tuple, antidiagonal_zero, list.bind_singleton, antidiagonal_tuple_zero_right k,
+    list.map_singleton],
+  exact congr_arg (λ x, [x]) matrix.cons_zero_zero
+end
+
 @[simp] lemma antidiagonal_tuple_one (n : ℕ) : antidiagonal_tuple 1 n = [![n]] :=
 begin
   simp_rw [antidiagonal_tuple, antidiagonal, list.range_succ, list.map_append, list.map_singleton,
@@ -132,18 +140,16 @@ begin
   refl,
 end
 
-lemma antidiagonal_tuple_pairwise_pi_lex (k n : ℕ) :
-  (antidiagonal_tuple k n).pairwise (pi.lex (<) (λ _, (<))) :=
-begin
-  induction k with k ih generalizing n,
-  { cases n,
-    { simp only [antidiagonal_tuple_zero_zero, list.pairwise_singleton] },
-    { simp only [antidiagonal_tuple_zero_succ, list.pairwise.nil] }, },
+lemma antidiagonal_tuple_pairwise_pi_lex : ∀ k n,
+  (antidiagonal_tuple k n).pairwise (pi.lex (<) (λ _, (<)))
+| 0 0 := list.pairwise_singleton _ _
+| 0 (n + 1) := list.pairwise.nil
+| (k + 1) n := begin
   simp_rw [antidiagonal_tuple, list.pairwise_bind, list.pairwise_map, list.mem_map,
     forall_exists_index, and_imp, forall_apply_eq_imp_iff₂],
   simp only [mem_antidiagonal, prod.forall, and_imp, forall_apply_eq_imp_iff₂],
   simp only [fin.pi_lex_lt_cons_cons, eq_self_iff_true, true_and, lt_self_iff_false, false_or],
-  refine ⟨λ _ _ _, ih _, _⟩,
+  refine ⟨λ _ _ _, antidiagonal_tuple_pairwise_pi_lex k _, _⟩,
   induction n,
   { rw [antidiagonal_zero],
     exact list.pairwise_singleton _ _ },
@@ -176,6 +182,9 @@ list.nat.mem_antidiagonal_tuple _
 lemma nodup_antidiagonal_tuple (k n : ℕ) : (antidiagonal_tuple k n).nodup :=
 list.nat.nodup_antidiagonal_tuple _ _
 
+lemma antidiagonal_tuple_zero_right (k : ℕ) : antidiagonal_tuple k 0 = {0} :=
+congr_arg _ (list.nat.antidiagonal_tuple_zero_right k)
+
 @[simp] lemma antidiagonal_tuple_one (n : ℕ) : antidiagonal_tuple 1 n = { ![n]} :=
 congr_arg _ (list.nat.antidiagonal_tuple_one n)
 
@@ -198,6 +207,10 @@ def antidiagonal_tuple (k n : ℕ) : finset (fin k → ℕ) :=
 lemma mem_antidiagonal_tuple {n : ℕ} {k : ℕ} (x : fin k → ℕ) :
   x ∈ antidiagonal_tuple k n ↔ ∑ i, x i = n :=
 list.nat.mem_antidiagonal_tuple _
+
+
+lemma antidiagonal_tuple_zero_right (k : ℕ) : antidiagonal_tuple k 0 = {0} :=
+finset.eq_of_veq (multiset.nat.antidiagonal_tuple_zero_right k)
 
 @[simp] lemma antidiagonal_tuple_one (n : ℕ) : antidiagonal_tuple 1 n = { ![n]} :=
 finset.eq_of_veq (multiset.nat.antidiagonal_tuple_one n)


### PR DESCRIPTION
This proof feels a little clumsy, but maybe that's unavoidable.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
