### PR TITLE
[Merged by Bors] - refactor(group_theory/group_action/big_operators): extract to a new file

### DIFF
--- a/src/algebra/hom/group_action.lean
+++ b/src/algebra/hom/group_action.lean
@@ -3,7 +3,7 @@ Copyright (c) 2020 Kenny Lau. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Kenny Lau
 -/
-import group_theory.group_action.basic
+import group_theory.group_action.defs
 import algebra.group_ring_action
 
 /-!
@@ -105,14 +105,6 @@ variables {A B}
     calc g (m • x) = g (m • (f (g x))) : by rw h₂
                ... = g (f (m • (g x))) : by rw f.map_smul
                ... = m • g x : by rw h₁, }
-
-variables {G} (H)
-
-/-- The canonical map to the left cosets. -/
-def to_quotient : G →[G] G ⧸ H :=
-⟨coe, λ g x, rfl⟩
-
-@[simp] lemma to_quotient_apply (g : G) : to_quotient H g = g := rfl
 
 end mul_action_hom
 

--- a/src/algebra/hom/group_action.lean
+++ b/src/algebra/hom/group_action.lean
@@ -3,8 +3,8 @@ Copyright (c) 2020 Kenny Lau. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Kenny Lau
 -/
-import group_theory.group_action.defs
 import algebra.group_ring_action
+import group_theory.group_action.defs
 
 /-!
 # Equivariant homomorphisms

--- a/src/algebra/module/basic.lean
+++ b/src/algebra/module/basic.lean
@@ -5,6 +5,7 @@ Authors: Nathaniel Thomas, Jeremy Avigad, Johannes Hölzl, Mario Carneiro
 -/
 import algebra.big_operators.basic
 import algebra.smul_with_zero
+import group_theory.group_action.big_operators
 import group_theory.group_action.group
 import tactic.norm_num
 

--- a/src/data/dfinsupp/interval.lean
+++ b/src/data/dfinsupp/interval.lean
@@ -5,6 +5,7 @@ Authors: Yaël Dillies
 -/
 import data.finset.locally_finite
 import data.finset.pointwise
+import data.fintype.card
 import data.dfinsupp.order
 
 /-!

--- a/src/data/finset/finsupp.lean
+++ b/src/data/finset/finsupp.lean
@@ -5,6 +5,7 @@ Authors: Yaël Dillies
 -/
 import data.finset.pointwise
 import data.finsupp.indicator
+import data.fintype.card
 
 /-!
 # Finitely supported product of finsets

--- a/src/group_theory/group_action/basic.lean
+++ b/src/group_theory/group_action/basic.lean
@@ -11,6 +11,18 @@ import data.fintype.card
 
 /-!
 # Basic properties of group actions
+
+This file primarily concerns itselfs with orbits, stabilizers, and other objects defined in terms of
+actions. Despite this file being called `basic`, low-level helper lemmas for algebraic manipulation
+of `•` belong elsewhere.
+
+## Main definitions
+
+* `mul_action.orbit`
+* `mul_action.fixed_points`
+* `mul_action.fixed_by`
+* `mul_action.stabilizer`
+
 -/
 
 universes u v w
@@ -511,60 +523,17 @@ by rw [← fintype.card_prod, ← fintype.card_sigma,
 
 end mul_action
 
-section
-variables [monoid α] [add_monoid β] [distrib_mul_action α β]
-
-lemma list.smul_sum {r : α} {l : list β} :
-  r • l.sum = (l.map ((•) r)).sum :=
-(distrib_mul_action.to_add_monoid_hom β r).map_list_sum l
-
 /-- `smul` by a `k : M` over a ring is injective, if `k` is not a zero divisor.
 The general theory of such `k` is elaborated by `is_smul_regular`.
 The typeclass that restricts all terms of `M` to have this property is `no_zero_smul_divisors`. -/
-lemma smul_cancel_of_non_zero_divisor {M R : Type*} [monoid M] [ring R] [distrib_mul_action M R]
+lemma smul_cancel_of_non_zero_divisor {M R : Type*}
+  [monoid M] [non_unital_non_assoc_ring R] [distrib_mul_action M R]
   (k : M) (h : ∀ (x : R), k • x = 0 → x = 0) {a b : R} (h' : k • a = k • b) :
   a = b :=
 begin
   rw ←sub_eq_zero,
   refine h _ _,
   rw [smul_sub, h', sub_self]
-end
-
-end
-
-section
-variables [monoid α] [monoid β] [mul_distrib_mul_action α β]
-
-lemma list.smul_prod {r : α} {l : list β} :
-  r • l.prod = (l.map ((•) r)).prod :=
-(mul_distrib_mul_action.to_monoid_hom β r).map_list_prod l
-
-end
-
-section
-variables [monoid α] [add_comm_monoid β] [distrib_mul_action α β]
-
-lemma multiset.smul_sum {r : α} {s : multiset β} :
-  r • s.sum = (s.map ((•) r)).sum :=
-(distrib_mul_action.to_add_monoid_hom β r).map_multiset_sum s
-
-lemma finset.smul_sum {r : α} {f : γ → β} {s : finset γ} :
-  r • ∑ x in s, f x = ∑ x in s, r • f x :=
-(distrib_mul_action.to_add_monoid_hom β r).map_sum f s
-
-end
-
-section
-variables [monoid α] [comm_monoid β] [mul_distrib_mul_action α β]
-
-lemma multiset.smul_prod {r : α} {s : multiset β} :
-  r • s.prod = (s.map ((•) r)).prod :=
-(mul_distrib_mul_action.to_monoid_hom β r).map_multiset_prod s
-
-lemma finset.smul_prod {r : α} {f : γ → β} {s : finset γ} :
-  r • ∏ x in s, f x = ∏ x in s, r • f x :=
-(mul_distrib_mul_action.to_monoid_hom β r).map_prod f s
-
 end
 
 namespace subgroup

--- a/src/group_theory/group_action/basic.lean
+++ b/src/group_theory/group_action/basic.lean
@@ -3,6 +3,7 @@ Copyright (c) 2018 Chris Hughes. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Chris Hughes
 -/
+import algebra.hom.group_action
 import group_theory.group_action.defs
 import group_theory.group_action.group
 import group_theory.quotient_group
@@ -12,7 +13,7 @@ import data.fintype.card
 /-!
 # Basic properties of group actions
 
-This file primarily concerns itselfs with orbits, stabilizers, and other objects defined in terms of
+This file primarily concerns itself with orbits, stabilizers, and other objects defined in terms of
 actions. Despite this file being called `basic`, low-level helper lemmas for algebraic manipulation
 of `•` belong elsewhere.
 
@@ -339,6 +340,13 @@ open quotient_group
 
 @[simp, to_additive] lemma quotient.smul_coe (H : subgroup α) (a x : α) :
   (a • x : α ⧸ H) = ↑(a * x) := rfl
+
+/-- The canonical map to the left cosets. -/
+def _root_.mul_action_hom.to_quotient (H : subgroup α) : α →[α] α ⧸ H :=
+⟨coe, quotient.smul_coe H⟩
+
+@[simp] lemma _root_.mul_action_hom.to_quotient_apply (H : subgroup α) (g : α) :
+  mul_action_hom.to_quotient H g = g := rfl
 
 @[to_additive] instance mul_left_cosets_comp_subtype_val (H I : subgroup α) :
   mul_action I (α ⧸ H) :=

--- a/src/group_theory/group_action/big_operators.lean
+++ b/src/group_theory/group_action/big_operators.lean
@@ -1,0 +1,64 @@
+
+/-
+Copyright (c) 2020 Yury Kudryashov. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Yury Kudryashov
+-/
+import group_theory.group_action.defs
+import data.multiset.basic
+import data.finset.basic
+import algebra.big_operators.basic
+
+/-!
+# Lemmas about group actions on big operators
+
+Note that analogous lemmas for `module`s like `finset.sum_smul` appear in other files.
+-/
+
+variables {α β γ : Type*}
+
+open_locale big_operators
+
+section
+variables [monoid α] [add_monoid β] [distrib_mul_action α β]
+
+lemma list.smul_sum {r : α} {l : list β} :
+  r • l.sum = (l.map ((•) r)).sum :=
+(distrib_mul_action.to_add_monoid_hom β r).map_list_sum l
+
+end
+
+section
+variables [monoid α] [monoid β] [mul_distrib_mul_action α β]
+
+lemma list.smul_prod {r : α} {l : list β} :
+  r • l.prod = (l.map ((•) r)).prod :=
+(mul_distrib_mul_action.to_monoid_hom β r).map_list_prod l
+
+end
+
+section
+variables [monoid α] [add_comm_monoid β] [distrib_mul_action α β]
+
+lemma multiset.smul_sum {r : α} {s : multiset β} :
+  r • s.sum = (s.map ((•) r)).sum :=
+(distrib_mul_action.to_add_monoid_hom β r).map_multiset_sum s
+
+lemma finset.smul_sum {r : α} {f : γ → β} {s : finset γ} :
+  r • ∑ x in s, f x = ∑ x in s, r • f x :=
+(distrib_mul_action.to_add_monoid_hom β r).map_sum f s
+
+end
+
+section
+variables [monoid α] [comm_monoid β] [mul_distrib_mul_action α β]
+
+lemma multiset.smul_prod {r : α} {s : multiset β} :
+  r • s.prod = (s.map ((•) r)).prod :=
+(mul_distrib_mul_action.to_monoid_hom β r).map_multiset_prod s
+
+lemma finset.smul_prod {r : α} {f : γ → β} {s : finset γ} :
+  r • ∏ x in s, f x = ∏ x in s, r • f x :=
+(mul_distrib_mul_action.to_monoid_hom β r).map_prod f s
+
+end

--- a/src/group_theory/group_action/big_operators.lean
+++ b/src/group_theory/group_action/big_operators.lean
@@ -3,10 +3,10 @@ Copyright (c) 2020 Yury Kudryashov. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yury Kudryashov
 -/
-import group_theory.group_action.defs
-import data.multiset.basic
-import data.finset.basic
 import algebra.big_operators.basic
+import data.finset.basic
+import data.multiset.basic
+import group_theory.group_action.defs
 
 /-!
 # Lemmas about group actions on big operators

--- a/src/group_theory/group_action/big_operators.lean
+++ b/src/group_theory/group_action/big_operators.lean
@@ -1,4 +1,3 @@
-
 /-
 Copyright (c) 2020 Yury Kudryashov. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.


### PR DESCRIPTION
`basic` is a misleading name, as `group_action.basic` imports a lot of things.
For now I'm not renaming it, but I've adding a skeletal docstring.

Splitting out the big operator lemmas allows access to big operators before modules and quotients.

This also performs a drive-by generalization of the typeclasses on `smul_cancel_of_non_zero_divisor`.

Authorship is from #1910


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
