### PR TITLE
[Merged by Bors] - feat(algebra/order/monoid): Co/contravariant classes for `with_bot`/`with_top`

### DIFF
--- a/src/algebra/order/monoid.lean
+++ b/src/algebra/order/monoid.lean
@@ -8,7 +8,6 @@ import algebra.group.type_tags
 import algebra.group.prod
 import algebra.hom.equiv
 import algebra.order.monoid_lemmas
-import order.bounded_order
 import order.min_max
 import order.hom.basic
 
@@ -304,222 +303,6 @@ end
 
 end with_zero
 
-namespace with_top
-
-section has_one
-
-variables [has_one α]
-
-@[to_additive] instance : has_one (with_top α) := ⟨(1 : α)⟩
-
-@[simp, norm_cast, to_additive] lemma coe_one : ((1 : α) : with_top α) = 1 := rfl
-
-@[simp, norm_cast, to_additive] lemma coe_eq_one {a : α} : (a : with_top α) = 1 ↔ a = 1 :=
-coe_eq_coe
-
-@[simp, to_additive] protected lemma map_one {β} (f : α → β) :
-  (1 : with_top α).map f = (f 1 : with_top β) := rfl
-
-@[simp, norm_cast, to_additive] theorem one_eq_coe {a : α} : 1 = (a : with_top α) ↔ a = 1 :=
-trans eq_comm coe_eq_one
-
-@[simp, to_additive] theorem top_ne_one : ⊤ ≠ (1 : with_top α) .
-@[simp, to_additive] theorem one_ne_top : (1 : with_top α) ≠ ⊤ .
-
-end has_one
-
-instance [has_add α] : has_add (with_top α) :=
-⟨λ o₁ o₂, o₁.bind (λ a, o₂.map (λ b, a + b))⟩
-
-@[norm_cast] lemma coe_add [has_add α] {a b : α} : ((a + b : α) : with_top α) = a + b := rfl
-
-@[norm_cast] lemma coe_bit0 [has_add α] {a : α} : ((bit0 a : α) : with_top α) = bit0 a := rfl
-
-@[norm_cast]
-lemma coe_bit1 [has_add α] [has_one α] {a : α} : ((bit1 a : α) : with_top α) = bit1 a := rfl
-
-@[simp] lemma add_top [has_add α] : ∀{a : with_top α}, a + ⊤ = ⊤
-| none := rfl
-| (some a) := rfl
-
-@[simp] lemma top_add [has_add α] {a : with_top α} : ⊤ + a = ⊤ := rfl
-
-lemma add_eq_top [has_add α] {a b : with_top α} : a + b = ⊤ ↔ a = ⊤ ∨ b = ⊤ :=
-by cases a; cases b; simp [none_eq_top, some_eq_coe, ←with_top.coe_add, ←with_zero.coe_add]
-
-lemma add_lt_top [has_add α] [partial_order α] {a b : with_top α} : a + b < ⊤ ↔ a < ⊤ ∧ b < ⊤ :=
-by simp [lt_top_iff_ne_top, add_eq_top, not_or_distrib]
-
-lemma add_eq_coe [has_add α] : ∀ {a b : with_top α} {c : α},
-  a + b = c ↔ ∃ (a' b' : α), ↑a' = a ∧ ↑b' = b ∧ a' + b' = c
-| none b c := by simp [none_eq_top]
-| (some a) none c := by simp [none_eq_top]
-| (some a) (some b) c :=
-    by simp only [some_eq_coe, ← coe_add, coe_eq_coe, exists_and_distrib_left, exists_eq_left]
-
-@[simp] lemma add_coe_eq_top_iff [has_add α] {x : with_top α} {y : α} : x + y = ⊤ ↔ x = ⊤ :=
-by { induction x using with_top.rec_top_coe; simp [← coe_add, -with_zero.coe_add] }
-
-@[simp] lemma coe_add_eq_top_iff [has_add α] {x : α} {y : with_top α} : ↑x + y = ⊤ ↔ y = ⊤ :=
-by { induction y using with_top.rec_top_coe; simp [← coe_add, -with_zero.coe_add] }
-
-instance [add_semigroup α] : add_semigroup (with_top α) :=
-{ add_assoc := begin
-    repeat { refine with_top.rec_top_coe _ _; try { intro }};
-    simp [←with_top.coe_add, add_assoc]
-  end,
-  ..with_top.has_add }
-
-instance [add_comm_semigroup α] : add_comm_semigroup (with_top α) :=
-{ add_comm :=
-  begin
-    repeat { refine with_top.rec_top_coe _ _; try { intro }};
-    simp [←with_top.coe_add, add_comm]
-  end,
-  ..with_top.add_semigroup }
-
-instance [add_zero_class α] : add_zero_class (with_top α) :=
-{ zero_add :=
-  begin
-    refine with_top.rec_top_coe _ _,
-    { simp },
-    { intro,
-      rw [←with_top.coe_zero, ←with_top.coe_add, zero_add] }
-  end,
-  add_zero :=
-  begin
-    refine with_top.rec_top_coe _ _,
-    { simp },
-    { intro,
-      rw [←with_top.coe_zero, ←with_top.coe_add, add_zero] }
-  end,
-  ..with_top.has_zero,
-  ..with_top.has_add }
-
-instance [add_monoid α] : add_monoid (with_top α) :=
-{ ..with_top.add_zero_class,
-  ..with_top.has_zero,
-  ..with_top.add_semigroup }
-
-instance [add_comm_monoid α] : add_comm_monoid (with_top α) :=
-{ ..with_top.add_monoid, ..with_top.add_comm_semigroup }
-
-instance [ordered_add_comm_monoid α] : ordered_add_comm_monoid (with_top α) :=
-{ add_le_add_left :=
-    begin
-      rintros a b h (_|c), { simp [none_eq_top] },
-      rcases b with (_|b), { simp [none_eq_top] },
-      rcases le_coe_iff.1 h with ⟨a, rfl, h⟩,
-      simp only [some_eq_coe, ← coe_add, coe_le_coe] at h ⊢,
-      exact add_le_add_left h c
-    end,
-  ..with_top.partial_order, ..with_top.add_comm_monoid }
-
-instance [linear_ordered_add_comm_monoid α] :
-  linear_ordered_add_comm_monoid_with_top (with_top α) :=
-{ top_add' := λ x, with_top.top_add,
-  ..with_top.order_top,
-  ..with_top.linear_order,
-  ..with_top.ordered_add_comm_monoid,
-  ..option.nontrivial }
-
-/-- Coercion from `α` to `with_top α` as an `add_monoid_hom`. -/
-def coe_add_hom [add_monoid α] : α →+ with_top α :=
-⟨coe, rfl, λ _ _, rfl⟩
-
-@[simp] lemma coe_coe_add_hom [add_monoid α] : ⇑(coe_add_hom : α →+ with_top α) = coe := rfl
-
-@[simp] lemma zero_lt_top [ordered_add_comm_monoid α] : (0 : with_top α) < ⊤ :=
-coe_lt_top 0
-
-@[simp, norm_cast] lemma zero_lt_coe [ordered_add_comm_monoid α] (a : α) :
-  (0 : with_top α) < a ↔ 0 < a :=
-coe_lt_coe
-
-end with_top
-
-namespace with_bot
-
-@[to_additive] instance [has_one α] : has_one (with_bot α) := with_top.has_one
-instance [has_add α] : has_add (with_bot α) := with_top.has_add
-instance [add_semigroup α] : add_semigroup (with_bot α) := with_top.add_semigroup
-instance [add_comm_semigroup α] : add_comm_semigroup (with_bot α) := with_top.add_comm_semigroup
-instance [add_zero_class α] : add_zero_class (with_bot α) := with_top.add_zero_class
-instance [add_monoid α] : add_monoid (with_bot α) := with_top.add_monoid
-instance [add_comm_monoid α] : add_comm_monoid (with_bot α) :=  with_top.add_comm_monoid
-
-instance [ordered_add_comm_monoid α] : ordered_add_comm_monoid (with_bot α) :=
-begin
-  suffices, refine
-  { add_le_add_left := this,
-    ..with_bot.partial_order,
-    ..with_bot.add_comm_monoid, ..},
-  { intros a b h c ca h₂,
-    cases c with c, {cases h₂},
-    cases a with a; cases h₂,
-    cases b with b, {cases le_antisymm h bot_le},
-    simp at h,
-    exact ⟨_, rfl, add_le_add_left h _⟩, }
-end
-
-instance [linear_ordered_add_comm_monoid α] : linear_ordered_add_comm_monoid (with_bot α) :=
-{ ..with_bot.linear_order,
-  ..with_bot.ordered_add_comm_monoid }
-
--- `by norm_cast` proves this lemma, so I did not tag it with `norm_cast`
-@[to_additive]
-lemma coe_one [has_one α] : ((1 : α) : with_bot α) = 1 := rfl
-
--- `by norm_cast` proves this lemma, so I did not tag it with `norm_cast`
-@[to_additive]
-lemma coe_eq_one [has_one α] {a : α} : (a : with_bot α) = 1 ↔ a = 1 :=
-with_top.coe_eq_one
-
-@[to_additive] protected lemma map_one {β} [has_one α] (f : α → β) :
-  (1 : with_bot α).map f = (f 1 : with_bot β) := rfl
-
--- `by norm_cast` proves this lemma, so I did not tag it with `norm_cast`
-lemma coe_add [has_add α] (a b : α) : ((a + b : α) : with_bot α) = a + b := by norm_cast
-
--- `by norm_cast` proves this lemma, so I did not tag it with `norm_cast`
-lemma coe_bit0 [has_add α] {a : α} : ((bit0 a : α) : with_bot α) = bit0 a :=
-by norm_cast
-
--- `by norm_cast` proves this lemma, so I did not tag it with `norm_cast`
-lemma coe_bit1 [has_add α] [has_one α] {a : α} : ((bit1 a : α) : with_bot α) = bit1 a :=
-by norm_cast
-
-@[simp] lemma bot_add [has_add α] (a : with_bot α) : ⊥ + a = ⊥ := rfl
-
-@[simp] lemma add_bot [has_add α] (a : with_bot α) : a + ⊥ = ⊥ := by cases a; refl
-
-@[simp] lemma add_eq_bot [has_add α] {m n : with_bot α} :
-  m + n = ⊥ ↔ m = ⊥ ∨ n = ⊥ :=
-with_top.add_eq_top
-
-end with_bot
-
-namespace with_zero
-
-local attribute [semireducible] with_zero
-variables [has_add α]
-
-/-- Making an additive monoid multiplicative then adding a zero is the same as adding a bottom
-element then making it multiplicative. -/
-def to_mul_bot : with_zero (multiplicative α) ≃* multiplicative (with_bot α) :=
-by exact mul_equiv.refl _
-
-@[simp] lemma to_mul_bot_zero :
-  to_mul_bot (0 : with_zero (multiplicative α)) = multiplicative.of_add ⊥ := rfl
-@[simp] lemma to_mul_bot_coe (x : multiplicative α) :
-  to_mul_bot ↑x = multiplicative.of_add (x.to_add : with_bot α) := rfl
-@[simp] lemma to_mul_bot_symm_bot :
-  to_mul_bot.symm (multiplicative.of_add (⊥ : with_bot α)) = 0 := rfl
-@[simp] lemma to_mul_bot_coe_of_add (x : α) :
-  to_mul_bot.symm (multiplicative.of_add (x : with_bot α)) = multiplicative.of_add x := rfl
-
-end with_zero
-
 /-- A canonically ordered additive monoid is an ordered commutative additive monoid
   in which the ordering coincides with the subtractibility relation,
   which is to say, `a ≤ b` iff there exists `c` with `b = a + c`.
@@ -648,25 +431,6 @@ instance with_zero.canonically_ordered_add_monoid {α : Type u} [canonically_ord
   .. with_zero.order_bot,
   .. with_zero.ordered_add_comm_monoid zero_le }
 
-instance with_top.canonically_ordered_add_monoid {α : Type u} [canonically_ordered_add_monoid α] :
-  canonically_ordered_add_monoid (with_top α) :=
-{ le_iff_exists_add := assume a b,
-  match a, b with
-  | ⊤, ⊤ := by simp
-  | (a : α), ⊤ := by { simp only [true_iff, le_top], refine ⟨⊤, _⟩, refl }
-  | (a : α), (b : α) := begin
-      rw [with_top.coe_le_coe, le_iff_exists_add],
-      split,
-      { rintro ⟨c, rfl⟩,
-        refine ⟨c, _⟩, norm_cast },
-      { intro h,
-        exact match b, h with _, ⟨some c, rfl⟩ := ⟨_, rfl⟩ end }
-    end
-  | ⊤, (b : α) := by simp
-  end,
-  .. with_top.order_bot,
-  .. with_top.ordered_add_comm_monoid }
-
 @[priority 100, to_additive]
 instance canonically_ordered_monoid.has_exists_mul_of_le (α : Type u)
   [canonically_ordered_monoid α] : has_exists_mul_of_le α :=
@@ -701,12 +465,6 @@ instance with_zero.canonically_linear_ordered_add_monoid
     canonically_linear_ordered_add_monoid (with_zero α) :=
 { .. with_zero.canonically_ordered_add_monoid,
   .. with_zero.linear_order }
-
-instance with_top.canonically_linear_ordered_add_monoid
-  (α : Type*) [canonically_linear_ordered_add_monoid α] :
-    canonically_linear_ordered_add_monoid (with_top α) :=
-{ .. (infer_instance : canonically_ordered_add_monoid (with_top α)),
-  .. (infer_instance : linear_order (with_top α)) }
 
 @[to_additive]
 lemma min_mul_distrib (a b c : α) : min a (b * c) = min a (min a b * min a c) :=
@@ -911,6 +669,8 @@ def function.injective.linear_ordered_cancel_comm_monoid {β : Type*}
 
 end linear_ordered_cancel_comm_monoid
 
+/-! ### Order dual -/
+
 namespace order_dual
 
 @[to_additive] instance [h : has_mul α] : has_mul (order_dual α) := h
@@ -1002,55 +762,6 @@ instance [linear_ordered_comm_monoid α] :
 
 end order_dual
 
-section linear_ordered_cancel_add_comm_monoid
-variables [linear_ordered_cancel_add_comm_monoid α]
-
-end linear_ordered_cancel_add_comm_monoid
-
-section ordered_cancel_add_comm_monoid
-
-variable [ordered_cancel_add_comm_monoid α]
-
-namespace with_top
-
-lemma add_lt_add_iff_left {a b c : with_top α} (ha : a ≠ ⊤) : a + b < a + c ↔ b < c :=
-begin
-  lift a to α using ha,
-  cases b; cases c,
-  { simp [none_eq_top] },
-  { simp [some_eq_coe, none_eq_top, coe_lt_top] },
-  { simp [some_eq_coe, none_eq_top, ← coe_add, coe_lt_top] },
-  { simp [some_eq_coe, ← coe_add, coe_lt_coe] }
-end
-
-lemma add_lt_add_iff_right {a b c : with_top α} (ha : a ≠ ⊤) : (c + a < b + a ↔ c < b) :=
-by simp only [← add_comm a, add_lt_add_iff_left ha]
-
-instance contravariant_class_add_lt : contravariant_class (with_top α) (with_top α) (+) (<) :=
-begin
-  refine ⟨λ a b c h, _⟩,
-  cases a,
-  { rw [none_eq_top, top_add, top_add] at h, exact (lt_irrefl ⊤ h).elim },
-  { exact (add_lt_add_iff_left coe_ne_top).1 h }
-end
-
-end with_top
-
-namespace with_bot
-
-lemma add_lt_add_iff_left {a b c : with_bot α} (ha : a ≠ ⊥) : a + b < a + c ↔ b < c :=
-@with_top.add_lt_add_iff_left (order_dual α) _ a c b ha
-
-lemma add_lt_add_iff_right {a b c : with_bot α} (ha : a ≠ ⊥) : b + a < c + a ↔ b < c :=
-@with_top.add_lt_add_iff_right (order_dual α) _ _ _ _ ha
-
-instance contravariant_class_add_lt : contravariant_class (with_bot α) (with_bot α) (+) (<) :=
-@order_dual.contravariant_class_add_lt (with_top $ order_dual α) _ _ _
-
-end with_bot
-
-end ordered_cancel_add_comm_monoid
-
 namespace prod
 
 variables {M N : Type*}
@@ -1063,6 +774,408 @@ instance [ordered_cancel_comm_monoid M] [ordered_cancel_comm_monoid N] :
  .. prod.cancel_comm_monoid, .. prod.partial_order M N }
 
 end prod
+
+/-! ### `with_bot`/`with_top`-/
+
+namespace with_top
+
+section has_one
+
+variables [has_one α]
+
+@[to_additive] instance : has_one (with_top α) := ⟨(1 : α)⟩
+
+@[simp, norm_cast, to_additive] lemma coe_one : ((1 : α) : with_top α) = 1 := rfl
+
+@[simp, norm_cast, to_additive] lemma coe_eq_one {a : α} : (a : with_top α) = 1 ↔ a = 1 :=
+coe_eq_coe
+
+@[simp, to_additive] protected lemma map_one {β} (f : α → β) :
+  (1 : with_top α).map f = (f 1 : with_top β) := rfl
+
+@[simp, norm_cast, to_additive] theorem one_eq_coe {a : α} : 1 = (a : with_top α) ↔ a = 1 :=
+trans eq_comm coe_eq_one
+
+@[simp, to_additive] theorem top_ne_one : ⊤ ≠ (1 : with_top α) .
+@[simp, to_additive] theorem one_ne_top : (1 : with_top α) ≠ ⊤ .
+
+end has_one
+
+section has_add
+variables [has_add α] {a b c d : with_top α} {x y : α}
+
+instance : has_add (with_top α) := ⟨λ o₁ o₂, o₁.bind $ λ a, o₂.map $ (+) a⟩
+
+@[norm_cast] lemma coe_add : ((x + y : α) : with_top α) = x + y := rfl
+@[norm_cast] lemma coe_bit0 : ((bit0 x : α) : with_top α) = bit0 x := rfl
+@[norm_cast] lemma coe_bit1 [has_one α] {a : α} : ((bit1 a : α) : with_top α) = bit1 a := rfl
+
+@[simp] lemma top_add (a : with_top α) : ⊤ + a = ⊤ := rfl
+@[simp] lemma add_top (a : with_top α) : a + ⊤ = ⊤ := by cases a; refl
+
+@[simp] lemma add_eq_top : a + b = ⊤ ↔ a = ⊤ ∨ b = ⊤ :=
+by cases a; cases b; simp [none_eq_top, some_eq_coe, ←with_top.coe_add, ←with_zero.coe_add]
+
+lemma add_ne_top : a + b ≠ ⊤ ↔ a ≠ ⊤ ∧ b ≠ ⊤ := add_eq_top.not.trans not_or_distrib
+
+lemma add_lt_top [partial_order α] {a b : with_top α} : a + b < ⊤ ↔ a < ⊤ ∧ b < ⊤ :=
+by simp_rw [lt_top_iff_ne_top, add_ne_top]
+
+lemma add_eq_coe : ∀ {a b : with_top α} {c : α},
+  a + b = c ↔ ∃ (a' b' : α), ↑a' = a ∧ ↑b' = b ∧ a' + b' = c
+| none b c := by simp [none_eq_top]
+| (some a) none c := by simp [none_eq_top]
+| (some a) (some b) c :=
+    by simp only [some_eq_coe, ← coe_add, coe_eq_coe, exists_and_distrib_left, exists_eq_left]
+
+@[simp] lemma add_coe_eq_top_iff {x : with_top α} {y : α} : x + y = ⊤ ↔ x = ⊤ :=
+by { induction x using with_top.rec_top_coe; simp [← coe_add, -with_zero.coe_add] }
+
+@[simp] lemma coe_add_eq_top_iff {y : with_top α} : ↑x + y = ⊤ ↔ y = ⊤ :=
+by { induction y using with_top.rec_top_coe; simp [← coe_add, -with_zero.coe_add] }
+
+variables [preorder α]
+
+instance covariant_class_add_le [covariant_class α α (+) (≤)] :
+  covariant_class (with_top α) (with_top α) (+) (≤) :=
+⟨λ a b c h, begin
+  cases a; cases c; try { exact le_top },
+  cases b,
+  { exact (not_top_le_coe _ h).elim },
+  { exact some_le_some.2 (add_le_add_left (some_le_some.1 h) _) }
+end⟩
+
+instance covariant_class_swap_add_le [covariant_class α α (swap (+)) (≤)] :
+  covariant_class (with_top α) (with_top α) (swap (+)) (≤) :=
+⟨λ a b c h, begin
+  cases a; cases c; try { exact le_top },
+  cases b,
+  { exact (not_top_le_coe _ h).elim },
+  { exact some_le_some.2 (add_le_add_right (some_le_some.1 h) _) }
+end⟩
+
+instance contravariant_class_add_lt [contravariant_class α α (+) (<)] :
+  contravariant_class (with_top α) (with_top α) (+) (<) :=
+⟨λ a b c h, begin
+  cases a; cases b; try { exact (not_top_lt h).elim },
+  cases c,
+  { exact coe_lt_top _ },
+  { exact some_lt_some.2 (lt_of_add_lt_add_left $ some_lt_some.1 h) }
+end⟩
+
+instance contravariant_class_swap_add_lt [contravariant_class α α (swap (+)) (<)] :
+  contravariant_class (with_top α) (with_top α) (swap (+)) (<) :=
+⟨λ a b c h, begin
+  cases a; cases b; try { exact (not_top_lt h).elim },
+  cases c,
+  { exact coe_lt_top _ },
+  { exact some_lt_some.2 (lt_of_add_lt_add_right $ some_lt_some.1 h) }
+end⟩
+
+protected lemma add_lt_add_left [covariant_class α α (+) (<)] (ha : a ≠ ⊤) (h : b < c) :
+  a + b < a + c :=
+begin
+  lift a to α using ha,
+  cases b, exact (not_none_lt _ h).elim,
+  cases c, exact coe_lt_top _,
+  rw some_lt_some at h, simp only [h, some_eq_coe, ← coe_add, coe_lt_coe],
+  exact add_lt_add_left h _
+end
+
+protected lemma add_lt_add_right [covariant_class α α (swap (+)) (<)] (ha : a ≠ ⊤) (h : b < c) :
+  b + a < c + a :=
+begin
+  lift a to α using ha,
+  cases b, exact (not_none_lt _ h).elim,
+  cases c, exact coe_lt_top _,
+  rw some_lt_some at h, simp only [h, some_eq_coe, ← coe_add, coe_lt_coe],
+  exact add_lt_add_right h _
+end
+
+protected lemma le_of_add_le_add_left [contravariant_class α α (+) (≤)] (ha : a ≠ ⊤)
+  (h : a + b ≤ a + c) : b ≤ c :=
+begin
+  lift a to α using ha,
+  cases c; try {exact le_top},
+  cases b, exact (not_top_le_coe _ h).elim,
+  simp only [some_eq_coe, ← coe_add, coe_le_coe] at h, rw some_le_some,
+  exact le_of_add_le_add_left h
+end
+
+protected lemma le_of_add_le_add_right [contravariant_class α α (swap (+)) (≤)] (ha : a ≠ ⊤)
+  (h : b + a ≤ c + a) : b ≤ c :=
+begin
+  lift a to α using ha,
+  cases c,
+  { exact le_top },
+  cases b,
+  { exact (not_top_le_coe _ h).elim },
+  { exact some_le_some.2 (le_of_add_le_add_right $ some_le_some.1 h) }
+end
+
+protected lemma add_lt_add_iff_left [covariant_class α α (+) (<)] [contravariant_class α α (+) (<)]
+  (ha : a ≠ ⊤) : a + b < a + c ↔ b < c :=
+⟨lt_of_add_lt_add_left, with_top.add_lt_add_left ha⟩
+
+protected lemma add_lt_add_iff_right [covariant_class α α (swap (+)) (<)]
+  [contravariant_class α α (swap (+)) (<)] (ha : a ≠ ⊤) : b + a < c + a ↔ b < c :=
+⟨lt_of_add_lt_add_right, with_top.add_lt_add_right ha⟩
+
+protected lemma add_le_add_iff_left [covariant_class α α (+) (≤)] [contravariant_class α α (+) (≤)]
+  (ha : a ≠ ⊤) : a + b ≤ a + c ↔ b ≤ c :=
+⟨with_top.le_of_add_le_add_left ha, λ h, add_le_add_left h a⟩
+
+protected lemma add_le_add_iff_right [covariant_class α α (swap (+)) (≤)]
+  [contravariant_class α α (swap (+)) (≤)] (ha : a ≠ ⊤) : b + a ≤ c + a ↔ b ≤ c :=
+⟨with_top.le_of_add_le_add_right ha, λ h, add_le_add_right h a⟩
+
+protected lemma add_lt_add_of_le_of_lt [covariant_class α α (+) (<)]
+  [covariant_class α α (swap (+)) (≤)] (ha : a ≠ ⊤) (hab : a ≤ b) (hcd : c < d) : a + c < b + d :=
+(with_top.add_lt_add_left ha hcd).trans_le $ add_le_add_right hab _
+
+protected lemma add_lt_add_of_lt_of_le [covariant_class α α (+) (≤)]
+  [covariant_class α α (swap (+)) (<)] (hc : c ≠ ⊤) (hab : a < b) (hcd : c ≤ d) : a + c < b + d :=
+(with_top.add_lt_add_right hc hab).trans_le $ add_le_add_left hcd _
+
+end has_add
+
+instance [add_semigroup α] : add_semigroup (with_top α) :=
+{ add_assoc := begin
+    repeat { refine with_top.rec_top_coe _ _; try { intro }};
+    simp [←with_top.coe_add, add_assoc]
+  end,
+  ..with_top.has_add }
+
+instance [add_comm_semigroup α] : add_comm_semigroup (with_top α) :=
+{ add_comm :=
+  begin
+    repeat { refine with_top.rec_top_coe _ _; try { intro }};
+    simp [←with_top.coe_add, add_comm]
+  end,
+  ..with_top.add_semigroup }
+
+instance [add_zero_class α] : add_zero_class (with_top α) :=
+{ zero_add :=
+  begin
+    refine with_top.rec_top_coe _ _,
+    { simp },
+    { intro,
+      rw [←with_top.coe_zero, ←with_top.coe_add, zero_add] }
+  end,
+  add_zero :=
+  begin
+    refine with_top.rec_top_coe _ _,
+    { simp },
+    { intro,
+      rw [←with_top.coe_zero, ←with_top.coe_add, add_zero] }
+  end,
+  ..with_top.has_zero,
+  ..with_top.has_add }
+
+instance [add_monoid α] : add_monoid (with_top α) :=
+{ ..with_top.add_zero_class,
+  ..with_top.has_zero,
+  ..with_top.add_semigroup }
+
+instance [add_comm_monoid α] : add_comm_monoid (with_top α) :=
+{ ..with_top.add_monoid, ..with_top.add_comm_semigroup }
+
+instance [ordered_add_comm_monoid α] : ordered_add_comm_monoid (with_top α) :=
+{ add_le_add_left :=
+    begin
+      rintros a b h (_|c), { simp [none_eq_top] },
+      rcases b with (_|b), { simp [none_eq_top] },
+      rcases le_coe_iff.1 h with ⟨a, rfl, h⟩,
+      simp only [some_eq_coe, ← coe_add, coe_le_coe] at h ⊢,
+      exact add_le_add_left h c
+    end,
+  ..with_top.partial_order, ..with_top.add_comm_monoid }
+
+instance [linear_ordered_add_comm_monoid α] :
+  linear_ordered_add_comm_monoid_with_top (with_top α) :=
+{ top_add' := with_top.top_add,
+  ..with_top.order_top,
+  ..with_top.linear_order,
+  ..with_top.ordered_add_comm_monoid,
+  ..option.nontrivial }
+
+instance canonically_ordered_add_monoid {α : Type u} [canonically_ordered_add_monoid α] :
+  canonically_ordered_add_monoid (with_top α) :=
+{ le_iff_exists_add := assume a b,
+  match a, b with
+  | ⊤, ⊤ := by simp
+  | (a : α), ⊤ := by { simp only [true_iff, le_top], refine ⟨⊤, _⟩, refl }
+  | (a : α), (b : α) := begin
+      rw [with_top.coe_le_coe, le_iff_exists_add],
+      split,
+      { rintro ⟨c, rfl⟩,
+        refine ⟨c, _⟩, norm_cast },
+      { intro h,
+        exact match b, h with _, ⟨some c, rfl⟩ := ⟨_, rfl⟩ end }
+    end
+  | ⊤, (b : α) := by simp
+  end,
+  .. with_top.order_bot,
+  .. with_top.ordered_add_comm_monoid }
+
+/-- Coercion from `α` to `with_top α` as an `add_monoid_hom`. -/
+def coe_add_hom [add_monoid α] : α →+ with_top α :=
+⟨coe, rfl, λ _ _, rfl⟩
+
+@[simp] lemma coe_coe_add_hom [add_monoid α] : ⇑(coe_add_hom : α →+ with_top α) = coe := rfl
+
+@[simp] lemma zero_lt_top [ordered_add_comm_monoid α] : (0 : with_top α) < ⊤ :=
+coe_lt_top 0
+
+@[simp, norm_cast] lemma zero_lt_coe [ordered_add_comm_monoid α] (a : α) :
+  (0 : with_top α) < a ↔ 0 < a :=
+coe_lt_coe
+
+end with_top
+
+namespace with_bot
+
+@[to_additive] instance [has_one α] : has_one (with_bot α) := with_top.has_one
+instance [has_add α] : has_add (with_bot α) := with_top.has_add
+instance [add_semigroup α] : add_semigroup (with_bot α) := with_top.add_semigroup
+instance [add_comm_semigroup α] : add_comm_semigroup (with_bot α) := with_top.add_comm_semigroup
+instance [add_zero_class α] : add_zero_class (with_bot α) := with_top.add_zero_class
+instance [add_monoid α] : add_monoid (with_bot α) := with_top.add_monoid
+instance [add_comm_monoid α] : add_comm_monoid (with_bot α) :=  with_top.add_comm_monoid
+
+instance [ordered_add_comm_monoid α] : ordered_add_comm_monoid (with_bot α) :=
+begin
+  suffices, refine
+  { add_le_add_left := this,
+    ..with_bot.partial_order,
+    ..with_bot.add_comm_monoid, ..},
+  { intros a b h c ca h₂,
+    cases c with c, {cases h₂},
+    cases a with a; cases h₂,
+    cases b with b, {cases le_antisymm h bot_le},
+    simp at h,
+    exact ⟨_, rfl, add_le_add_left h _⟩, }
+end
+
+instance [linear_ordered_add_comm_monoid α] : linear_ordered_add_comm_monoid (with_bot α) :=
+{ ..with_bot.linear_order, ..with_bot.ordered_add_comm_monoid }
+
+-- `by norm_cast` proves this lemma, so I did not tag it with `norm_cast`
+@[to_additive]
+lemma coe_one [has_one α] : ((1 : α) : with_bot α) = 1 := rfl
+
+-- `by norm_cast` proves this lemma, so I did not tag it with `norm_cast`
+@[to_additive]
+lemma coe_eq_one [has_one α] {a : α} : (a : with_bot α) = 1 ↔ a = 1 :=
+with_top.coe_eq_one
+
+@[to_additive] protected lemma map_one {β} [has_one α] (f : α → β) :
+  (1 : with_bot α).map f = (f 1 : with_bot β) := rfl
+
+section has_add
+variables [has_add α] {a b c d : with_bot α} {x y : α}
+
+-- `norm_cast` proves those lemmas, because `with_top`/`with_bot` are reducible
+lemma coe_add (a b : α) : ((a + b : α) : with_bot α) = a + b := rfl
+lemma coe_bit0 : ((bit0 x : α) : with_bot α) = bit0 x := rfl
+lemma coe_bit1 [has_one α] {a : α} : ((bit1 a : α) : with_bot α) = bit1 a := rfl
+
+@[simp] lemma bot_add (a : with_bot α) : ⊥ + a = ⊥ := rfl
+@[simp] lemma add_bot (a : with_bot α) : a + ⊥ = ⊥ := by cases a; refl
+
+@[simp] lemma add_eq_bot : a + b = ⊥ ↔ a = ⊥ ∨ b = ⊥ := with_top.add_eq_top
+lemma add_ne_bot : a + b ≠ ⊥ ↔ a ≠ ⊥ ∧ b ≠ ⊥ := with_top.add_ne_top
+
+lemma bot_lt_add [partial_order α] {a b : with_bot α} : ⊥ < a + b ↔ ⊥ < a ∧ ⊥ < b :=
+@with_top.add_lt_top (order_dual α) _ _ _ _
+
+lemma add_eq_coe : a + b = x ↔ ∃ (a' b' : α), ↑a' = a ∧ ↑b' = b ∧ a' + b' = x := with_top.add_eq_coe
+
+@[simp] lemma add_coe_eq_bot_iff : a + y = ⊥ ↔ a = ⊥ := with_top.add_coe_eq_top_iff
+@[simp] lemma coe_add_eq_bot_iff : ↑x + b = ⊥ ↔ b = ⊥ := with_top.coe_add_eq_top_iff
+
+variables [preorder α]
+
+instance covariant_class_add_le [covariant_class α α (+) (≤)] :
+  covariant_class (with_bot α) (with_bot α) (+) (≤) :=
+⟨λ a b c h, begin
+  cases a; cases b; try { exact bot_le },
+  cases c,
+  { exact (not_coe_le_bot _ h).elim },
+  { exact some_le_some.2 (add_le_add_left (some_le_some.1 h) _) }
+end⟩
+
+instance covariant_class_swap_add_le [covariant_class α α (swap (+)) (≤)] :
+  covariant_class (with_bot α) (with_bot α) (swap (+)) (≤) :=
+⟨λ a b c h, begin
+  cases a; cases b; try { exact bot_le },
+  cases c,
+  { exact (not_coe_le_bot _ h).elim },
+  { exact some_le_some.2 (add_le_add_right (some_le_some.1 h) _) }
+end⟩
+
+instance contravariant_class_add_lt [contravariant_class α α (+) (<)] :
+  contravariant_class (with_bot α) (with_bot α) (+) (<) :=
+⟨λ a b c h, begin
+  cases a; cases c; try { exact (not_lt_bot h).elim },
+  cases b,
+  { exact bot_lt_coe _ },
+  { exact some_lt_some.2 (lt_of_add_lt_add_left $ some_lt_some.1 h) }
+end⟩
+
+instance contravariant_class_swap_add_lt [contravariant_class α α (swap (+)) (<)] :
+  contravariant_class (with_bot α) (with_bot α) (swap (+)) (<) :=
+⟨λ a b c h, begin
+  cases a; cases c; try { exact (not_lt_bot h).elim },
+  cases b,
+  { exact bot_lt_coe _ },
+  { exact some_lt_some.2 (lt_of_add_lt_add_right $ some_lt_some.1 h) }
+end⟩
+
+protected lemma add_lt_add_left [covariant_class α α (+) (<)] (ha : a ≠ ⊥) (h : b < c) :
+  a + b < a + c :=
+@with_top.add_lt_add_left (order_dual α) _ _ _ _ _ _ ha h
+
+protected lemma add_lt_add_right [covariant_class α α (swap (+)) (<)] (ha : a ≠ ⊥) (h : b < c) :
+  b + a < c + a :=
+@with_top.add_lt_add_right (order_dual α) _ _ _ _ _ _ ha h
+
+protected lemma le_of_add_le_add_left [contravariant_class α α (+) (≤)] (ha : a ≠ ⊥)
+  (h : a + b ≤ a + c) : b ≤ c :=
+@with_top.le_of_add_le_add_left (order_dual α) _ _ _ _ _ _ ha h
+
+protected lemma le_of_add_le_add_right [contravariant_class α α (swap (+)) (≤)] (ha : a ≠ ⊥)
+  (h : b + a ≤ c + a) : b ≤ c :=
+@with_top.le_of_add_le_add_right (order_dual α) _ _ _ _ _ _ ha h
+
+protected lemma add_lt_add_iff_left [covariant_class α α (+) (<)] [contravariant_class α α (+) (<)]
+  (ha : a ≠ ⊥) : a + b < a + c ↔ b < c :=
+⟨lt_of_add_lt_add_left, with_bot.add_lt_add_left ha⟩
+
+protected lemma add_lt_add_iff_right [covariant_class α α (swap (+)) (<)]
+  [contravariant_class α α (swap (+)) (<)] (ha : a ≠ ⊥) : b + a < c + a ↔ b < c :=
+⟨lt_of_add_lt_add_right, with_bot.add_lt_add_right ha⟩
+
+protected lemma add_le_add_iff_left [covariant_class α α (+) (≤)] [contravariant_class α α (+) (≤)]
+  (ha : a ≠ ⊥) : a + b ≤ a + c ↔ b ≤ c :=
+⟨with_bot.le_of_add_le_add_left ha, λ h, add_le_add_left h a⟩
+
+protected lemma add_le_add_iff_right [covariant_class α α (swap (+)) (≤)]
+  [contravariant_class α α (swap (+)) (≤)] (ha : a ≠ ⊥) : b + a ≤ c + a ↔ b ≤ c :=
+⟨with_bot.le_of_add_le_add_right ha, λ h, add_le_add_right h a⟩
+
+protected lemma add_lt_add_of_le_of_lt [covariant_class α α (+) (<)]
+  [covariant_class α α (swap (+)) (≤)] (hb : b ≠ ⊥) (hab : a ≤ b) (hcd : c < d) : a + c < b + d :=
+@with_top.add_lt_add_of_le_of_lt (order_dual α) _ _ _ _ _ _ _ _ hb hab hcd
+
+protected lemma add_lt_add_of_lt_of_le [covariant_class α α (+) (≤)]
+  [covariant_class α α (swap (+)) (<)] (hd : d ≠ ⊥) (hab : a < b) (hcd : c ≤ d) : a + c < b + d :=
+@with_top.add_lt_add_of_lt_of_le (order_dual α) _ _ _ _ _ _ _ _ hd hab hcd
+
+end has_add
+end with_bot
+
+/-! ### `additive`/`multiplicative` -/
 
 section type_tags
 
@@ -1101,18 +1214,6 @@ instance [linear_ordered_comm_monoid α] : linear_ordered_add_comm_monoid (addit
 { ..additive.linear_order,
   ..additive.ordered_add_comm_monoid }
 
-lemma with_zero.to_mul_bot_strict_mono [has_add α] [preorder α] :
-  strict_mono (@with_zero.to_mul_bot α _) :=
-λ x y, id
-
-@[simp] lemma with_zero.to_mul_bot_le [has_add α] [preorder α]
-  (a b : with_zero (multiplicative α)) :
-  with_zero.to_mul_bot a ≤ with_zero.to_mul_bot b ↔ a ≤ b := iff.rfl
-
-@[simp] lemma with_zero.to_mul_bot_lt [has_add α] [preorder α]
-  (a b : with_zero (multiplicative α)) :
-  with_zero.to_mul_bot a < with_zero.to_mul_bot b ↔ a < b := iff.rfl
-
 namespace additive
 
 variables [preorder α]
@@ -1142,6 +1243,33 @@ variables [preorder α]
 end multiplicative
 
 end type_tags
+
+namespace with_zero
+
+local attribute [semireducible] with_zero
+variables [has_add α]
+
+/-- Making an additive monoid multiplicative then adding a zero is the same as adding a bottom
+element then making it multiplicative. -/
+def to_mul_bot : with_zero (multiplicative α) ≃* multiplicative (with_bot α) :=
+by exact mul_equiv.refl _
+
+@[simp] lemma to_mul_bot_zero :
+  to_mul_bot (0 : with_zero (multiplicative α)) = multiplicative.of_add ⊥ := rfl
+@[simp] lemma to_mul_bot_coe (x : multiplicative α) :
+  to_mul_bot ↑x = multiplicative.of_add (x.to_add : with_bot α) := rfl
+@[simp] lemma to_mul_bot_symm_bot :
+  to_mul_bot.symm (multiplicative.of_add (⊥ : with_bot α)) = 0 := rfl
+@[simp] lemma to_mul_bot_coe_of_add (x : α) :
+  to_mul_bot.symm (multiplicative.of_add (x : with_bot α)) = multiplicative.of_add x := rfl
+
+variables [preorder α] (a b : with_zero (multiplicative α))
+
+lemma to_mul_bot_strict_mono : strict_mono (@to_mul_bot α _) := λ x y, id
+@[simp] lemma to_mul_bot_le : to_mul_bot a ≤ to_mul_bot b ↔ a ≤ b := iff.rfl
+@[simp] lemma to_mul_bot_lt : to_mul_bot a < to_mul_bot b ↔ a < b := iff.rfl
+
+end with_zero
 
 /-- The order embedding sending `b` to `a * b`, for some fixed `a`.
 See also `order_iso.mul_left` when working in an ordered group. -/

--- a/src/algebra/order/monoid.lean
+++ b/src/algebra/order/monoid.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jeremy Avigad, Leonardo de Moura, Mario Carneiro, Johannes Hölzl
 -/
 import algebra.group.with_one
-import algebra.group.type_tags
 import algebra.group.prod
 import algebra.hom.equiv
 import algebra.order.monoid_lemmas

--- a/src/algebra/order/monoid.lean
+++ b/src/algebra/order/monoid.lean
@@ -871,26 +871,6 @@ instance contravariant_class_swap_add_lt [contravariant_class α α (swap (+)) (
   { exact some_lt_some.2 (lt_of_add_lt_add_right $ some_lt_some.1 h) }
 end⟩
 
-protected lemma add_lt_add_left [covariant_class α α (+) (<)] (ha : a ≠ ⊤) (h : b < c) :
-  a + b < a + c :=
-begin
-  lift a to α using ha,
-  cases b, exact (not_none_lt _ h).elim,
-  cases c, exact coe_lt_top _,
-  rw some_lt_some at h, simp only [h, some_eq_coe, ← coe_add, coe_lt_coe],
-  exact add_lt_add_left h _
-end
-
-protected lemma add_lt_add_right [covariant_class α α (swap (+)) (<)] (ha : a ≠ ⊤) (h : b < c) :
-  b + a < c + a :=
-begin
-  lift a to α using ha,
-  cases b, exact (not_none_lt _ h).elim,
-  cases c, exact coe_lt_top _,
-  rw some_lt_some at h, simp only [h, some_eq_coe, ← coe_add, coe_lt_coe],
-  exact add_lt_add_right h _
-end
-
 protected lemma le_of_add_le_add_left [contravariant_class α α (+) (≤)] (ha : a ≠ ⊤)
   (h : a + b ≤ a + c) : b ≤ c :=
 begin
@@ -912,13 +892,25 @@ begin
   { exact some_le_some.2 (le_of_add_le_add_right $ some_le_some.1 h) }
 end
 
-protected lemma add_lt_add_iff_left [covariant_class α α (+) (<)] [contravariant_class α α (+) (<)]
-  (ha : a ≠ ⊤) : a + b < a + c ↔ b < c :=
-⟨lt_of_add_lt_add_left, with_top.add_lt_add_left ha⟩
+protected lemma add_lt_add_left [covariant_class α α (+) (<)] (ha : a ≠ ⊤) (h : b < c) :
+  a + b < a + c :=
+begin
+  lift a to α using ha,
+  lift b to α using (h.trans_le le_top).ne,
+  cases c,
+  { exact coe_lt_top _ },
+  { exact some_lt_some.2 (add_lt_add_left $ some_lt_some.1 h) }
+end
 
-protected lemma add_lt_add_iff_right [covariant_class α α (swap (+)) (<)]
-  [contravariant_class α α (swap (+)) (<)] (ha : a ≠ ⊤) : b + a < c + a ↔ b < c :=
-⟨lt_of_add_lt_add_right, with_top.add_lt_add_right ha⟩
+protected lemma add_lt_add_right [covariant_class α α (swap (+)) (<)] (ha : a ≠ ⊤) (h : b < c) :
+  b + a < c + a :=
+begin
+  lift a to α using ha,
+  lift b to α using (h.trans_le le_top).ne,
+  cases c,
+  { exact coe_lt_top _ },
+  { exact some_lt_some.2 (add_lt_add_right $ some_lt_some.1 h) }
+end
 
 protected lemma add_le_add_iff_left [covariant_class α α (+) (≤)] [contravariant_class α α (+) (≤)]
   (ha : a ≠ ⊤) : a + b ≤ a + c ↔ b ≤ c :=
@@ -927,6 +919,14 @@ protected lemma add_le_add_iff_left [covariant_class α α (+) (≤)] [contravar
 protected lemma add_le_add_iff_right [covariant_class α α (swap (+)) (≤)]
   [contravariant_class α α (swap (+)) (≤)] (ha : a ≠ ⊤) : b + a ≤ c + a ↔ b ≤ c :=
 ⟨with_top.le_of_add_le_add_right ha, λ h, add_le_add_right h a⟩
+
+protected lemma add_lt_add_iff_left [covariant_class α α (+) (<)] [contravariant_class α α (+) (<)]
+  (ha : a ≠ ⊤) : a + b < a + c ↔ b < c :=
+⟨lt_of_add_lt_add_left, with_top.add_lt_add_left ha⟩
+
+protected lemma add_lt_add_iff_right [covariant_class α α (swap (+)) (<)]
+  [contravariant_class α α (swap (+)) (<)] (ha : a ≠ ⊤) : b + a < c + a ↔ b < c :=
+⟨lt_of_add_lt_add_right, with_top.add_lt_add_right ha⟩
 
 protected lemma add_lt_add_of_le_of_lt [covariant_class α α (+) (<)]
   [covariant_class α α (swap (+)) (≤)] (ha : a ≠ ⊤) (hab : a ≤ b) (hcd : c < d) : a + c < b + d :=
@@ -1097,47 +1097,19 @@ variables [preorder α]
 
 instance covariant_class_add_le [covariant_class α α (+) (≤)] :
   covariant_class (with_bot α) (with_bot α) (+) (≤) :=
-⟨λ a b c h, begin
-  cases a; cases b; try { exact bot_le },
-  cases c,
-  { exact (not_coe_le_bot _ h).elim },
-  { exact some_le_some.2 (add_le_add_left (some_le_some.1 h) _) }
-end⟩
+@order_dual.covariant_class_add_le (with_top $ order_dual α) _ _ _
 
 instance covariant_class_swap_add_le [covariant_class α α (swap (+)) (≤)] :
   covariant_class (with_bot α) (with_bot α) (swap (+)) (≤) :=
-⟨λ a b c h, begin
-  cases a; cases b; try { exact bot_le },
-  cases c,
-  { exact (not_coe_le_bot _ h).elim },
-  { exact some_le_some.2 (add_le_add_right (some_le_some.1 h) _) }
-end⟩
+@order_dual.covariant_class_swap_add_le (with_top $ order_dual α) _ _ _
 
 instance contravariant_class_add_lt [contravariant_class α α (+) (<)] :
   contravariant_class (with_bot α) (with_bot α) (+) (<) :=
-⟨λ a b c h, begin
-  cases a; cases c; try { exact (not_lt_bot h).elim },
-  cases b,
-  { exact bot_lt_coe _ },
-  { exact some_lt_some.2 (lt_of_add_lt_add_left $ some_lt_some.1 h) }
-end⟩
+@order_dual.contravariant_class_add_lt (with_top $ order_dual α) _ _ _
 
 instance contravariant_class_swap_add_lt [contravariant_class α α (swap (+)) (<)] :
   contravariant_class (with_bot α) (with_bot α) (swap (+)) (<) :=
-⟨λ a b c h, begin
-  cases a; cases c; try { exact (not_lt_bot h).elim },
-  cases b,
-  { exact bot_lt_coe _ },
-  { exact some_lt_some.2 (lt_of_add_lt_add_right $ some_lt_some.1 h) }
-end⟩
-
-protected lemma add_lt_add_left [covariant_class α α (+) (<)] (ha : a ≠ ⊥) (h : b < c) :
-  a + b < a + c :=
-@with_top.add_lt_add_left (order_dual α) _ _ _ _ _ _ ha h
-
-protected lemma add_lt_add_right [covariant_class α α (swap (+)) (<)] (ha : a ≠ ⊥) (h : b < c) :
-  b + a < c + a :=
-@with_top.add_lt_add_right (order_dual α) _ _ _ _ _ _ ha h
+@order_dual.contravariant_class_swap_add_lt (with_top $ order_dual α) _ _ _
 
 protected lemma le_of_add_le_add_left [contravariant_class α α (+) (≤)] (ha : a ≠ ⊥)
   (h : a + b ≤ a + c) : b ≤ c :=
@@ -1147,13 +1119,13 @@ protected lemma le_of_add_le_add_right [contravariant_class α α (swap (+)) (�
   (h : b + a ≤ c + a) : b ≤ c :=
 @with_top.le_of_add_le_add_right (order_dual α) _ _ _ _ _ _ ha h
 
-protected lemma add_lt_add_iff_left [covariant_class α α (+) (<)] [contravariant_class α α (+) (<)]
-  (ha : a ≠ ⊥) : a + b < a + c ↔ b < c :=
-⟨lt_of_add_lt_add_left, with_bot.add_lt_add_left ha⟩
+protected lemma add_lt_add_left [covariant_class α α (+) (<)] (ha : a ≠ ⊥) (h : b < c) :
+  a + b < a + c :=
+@with_top.add_lt_add_left (order_dual α) _ _ _ _ _ _ ha h
 
-protected lemma add_lt_add_iff_right [covariant_class α α (swap (+)) (<)]
-  [contravariant_class α α (swap (+)) (<)] (ha : a ≠ ⊥) : b + a < c + a ↔ b < c :=
-⟨lt_of_add_lt_add_right, with_bot.add_lt_add_right ha⟩
+protected lemma add_lt_add_right [covariant_class α α (swap (+)) (<)] (ha : a ≠ ⊥) (h : b < c) :
+  b + a < c + a :=
+@with_top.add_lt_add_right (order_dual α) _ _ _ _ _ _ ha h
 
 protected lemma add_le_add_iff_left [covariant_class α α (+) (≤)] [contravariant_class α α (+) (≤)]
   (ha : a ≠ ⊥) : a + b ≤ a + c ↔ b ≤ c :=
@@ -1162,6 +1134,14 @@ protected lemma add_le_add_iff_left [covariant_class α α (+) (≤)] [contravar
 protected lemma add_le_add_iff_right [covariant_class α α (swap (+)) (≤)]
   [contravariant_class α α (swap (+)) (≤)] (ha : a ≠ ⊥) : b + a ≤ c + a ↔ b ≤ c :=
 ⟨with_bot.le_of_add_le_add_right ha, λ h, add_le_add_right h a⟩
+
+protected lemma add_lt_add_iff_left [covariant_class α α (+) (<)] [contravariant_class α α (+) (<)]
+  (ha : a ≠ ⊥) : a + b < a + c ↔ b < c :=
+⟨lt_of_add_lt_add_left, with_bot.add_lt_add_left ha⟩
+
+protected lemma add_lt_add_iff_right [covariant_class α α (swap (+)) (<)]
+  [contravariant_class α α (swap (+)) (<)] (ha : a ≠ ⊥) : b + a < c + a ↔ b < c :=
+⟨lt_of_add_lt_add_right, with_bot.add_lt_add_right ha⟩
 
 protected lemma add_lt_add_of_le_of_lt [covariant_class α α (+) (<)]
   [covariant_class α α (swap (+)) (≤)] (hb : b ≠ ⊥) (hab : a ≤ b) (hcd : c < d) : a + c < b + d :=

--- a/src/algebra/order/monoid.lean
+++ b/src/algebra/order/monoid.lean
@@ -998,8 +998,7 @@ instance [linear_ordered_add_comm_monoid α] :
   ..with_top.ordered_add_comm_monoid,
   ..option.nontrivial }
 
-instance canonically_ordered_add_monoid {α : Type u} [canonically_ordered_add_monoid α] :
-  canonically_ordered_add_monoid (with_top α) :=
+instance [canonically_ordered_add_monoid α] : canonically_ordered_add_monoid (with_top α) :=
 { le_iff_exists_add := assume a b,
   match a, b with
   | ⊤, ⊤ := by simp
@@ -1016,6 +1015,10 @@ instance canonically_ordered_add_monoid {α : Type u} [canonically_ordered_add_m
   end,
   .. with_top.order_bot,
   .. with_top.ordered_add_comm_monoid }
+
+instance [canonically_linear_ordered_add_monoid α] :
+  canonically_linear_ordered_add_monoid (with_top α) :=
+{ ..with_top.canonically_ordered_add_monoid, ..with_top.linear_order }
 
 /-- Coercion from `α` to `with_top α` as an `add_monoid_hom`. -/
 def coe_add_hom [add_monoid α] : α →+ with_top α :=

--- a/src/algebra/order/monoid.lean
+++ b/src/algebra/order/monoid.lean
@@ -899,7 +899,7 @@ begin
   lift b to α using (h.trans_le le_top).ne,
   cases c,
   { exact coe_lt_top _ },
-  { exact some_lt_some.2 (add_lt_add_left $ some_lt_some.1 h) }
+  { exact some_lt_some.2 (add_lt_add_left (some_lt_some.1 h) _) }
 end
 
 protected lemma add_lt_add_right [covariant_class α α (swap (+)) (<)] (ha : a ≠ ⊤) (h : b < c) :
@@ -909,7 +909,7 @@ begin
   lift b to α using (h.trans_le le_top).ne,
   cases c,
   { exact coe_lt_top _ },
-  { exact some_lt_some.2 (add_lt_add_right $ some_lt_some.1 h) }
+  { exact some_lt_some.2 (add_lt_add_right (some_lt_some.1 h) _) }
 end
 
 protected lemma add_le_add_iff_left [covariant_class α α (+) (≤)] [contravariant_class α α (+) (≤)]

--- a/src/order/bounded_order.lean
+++ b/src/order/bounded_order.lean
@@ -596,8 +596,7 @@ theorem coe_le [has_le α] {a b : α} :
 
 @[norm_cast]
 lemma coe_lt_coe [has_lt α] {a b : α} : (a : with_bot α) < b ↔ a < b := some_lt_some
-lemma not_coe_le_bot [has_le α] (a : α) : ¬ (a : with_bot α) ≤ ⊥ :=
-λ h, let ⟨b, hb, _⟩ := h _ rfl in option.not_mem_none _ hb
+lemma not_coe_le_bot [preorder α] (a : α) : ¬ (a : with_bot α) ≤ ⊥ := (bot_lt_coe a).not_le
 
 lemma le_coe_get_or_else [preorder α] : ∀ (a : with_bot α) (b : α), a ≤ a.get_or_else b
 | (some a) b := le_refl a
@@ -625,7 +624,7 @@ instance decidable_lt [has_lt α] [@decidable_rel α (<)] : @decidable_rel (with
   else is_false $ by simp *
 | x none := is_false $ by rintro ⟨a,⟨⟨⟩⟩⟩
 
-instance [has_le α] [is_total α (≤)] : is_total (with_bot α) (≤) :=
+instance [partial_order α] [is_total α (≤)] : is_total (with_bot α) (≤) :=
 { total := λ a b, match a, b with
   | none  , _      := or.inl bot_le
   | _     , none   := or.inr bot_le
@@ -861,27 +860,28 @@ theorem le_coe [has_le α] {a b : α} :
   (@has_le.le (with_top α) _ o b ↔ a ≤ b)
 | _ rfl := coe_le_coe
 
-@[norm_cast] lemma coe_lt_coe [has_lt α] {a b : α} : (a : with_top α) < b ↔ a < b := some_lt_some
-lemma coe_lt_top [has_lt α] (a : α) : (a : with_top α) < ⊤ := some_lt_none a
-
-lemma not_top_le_coe [has_le α] (a : α) : ¬ (⊤ : with_top α) ≤ ↑a :=
-λ h, let ⟨b, hb, _⟩ := h _ rfl in option.not_mem_none _ hb
-
-lemma le_coe_iff [has_le α] {b : α} : ∀ {x : with_top α}, x ≤ b ↔ ∃ a : α, x = a ∧ a ≤ b
+theorem le_coe_iff [partial_order α] {b : α} : ∀{x : with_top α}, x ≤ b ↔ (∃a:α, x = a ∧ a ≤ b)
 | (some a) := by simp [some_eq_coe, coe_eq_coe]
-| none     := iff_of_false (not_top_le_coe _) $ by simp [none_eq_top]
+| none     := by simp [none_eq_top]
 
-lemma coe_le_iff [has_le α] {a : α} : ∀ {x : with_top α}, ↑a ≤ x ↔ ∀ b, x = ↑b → a ≤ b
+theorem coe_le_iff [preorder α] {a : α} : ∀{x : with_top α}, ↑a ≤ x ↔ (∀b:α, x = ↑b → a ≤ b)
 | (some b) := by simp [some_eq_coe, coe_eq_coe]
 | none     := by simp [none_eq_top]
 
-lemma coe_lt_iff [has_lt α] {a : α} : ∀ {x : with_top α}, ↑a < x ↔ ∀ b, x = ↑b → a < b
+theorem lt_iff_exists_coe [preorder α] : ∀{a b : with_top α}, a < b ↔ (∃p:α, a = p ∧ ↑p < b)
+| (some a) b := by simp [some_eq_coe, coe_eq_coe]
+| none     b := by simp [none_eq_top]
+
+@[norm_cast]
+lemma coe_lt_coe [has_lt α] {a b : α} : (a : with_top α) < b ↔ a < b := some_lt_some
+
+lemma coe_lt_top [has_lt α] (a : α) : (a : with_top α) < ⊤ := some_lt_none a
+
+theorem coe_lt_iff [preorder α] {a : α} : ∀{x : with_top α}, ↑a < x ↔ (∀b:α, x = ↑b → a < b)
 | (some b) := by simp [some_eq_coe, coe_eq_coe, coe_lt_coe]
 | none     := by simp [none_eq_top, coe_lt_top]
 
-lemma lt_iff_exists_coe [has_lt α] : ∀ {a b : with_top α}, a < b ↔  ∃ p : α, a = p ∧ ↑p < b
-| (some a) b := by simp [some_eq_coe, coe_eq_coe]
-| none     b := iff_of_false (not_none_lt _) $ by simp [none_eq_top]
+lemma not_top_le_coe [preorder α] (a : α) : ¬ (⊤ : with_top α) ≤ ↑a := (coe_lt_top a).not_le
 
 instance decidable_le [has_le α] [@decidable_rel α (≤)] : @decidable_rel (with_top α) (≤) :=
 λ x y, @with_bot.decidable_le (order_dual α) _ _ y x
@@ -889,7 +889,7 @@ instance decidable_le [has_le α] [@decidable_rel α (≤)] : @decidable_rel (wi
 instance decidable_lt [has_lt α] [@decidable_rel α (<)] : @decidable_rel (with_top α) (<) :=
 λ x y, @with_bot.decidable_lt (order_dual α) _ _ y x
 
-instance [has_le α] [is_total α (≤)] : is_total (with_top α) (≤) :=
+instance [partial_order α] [is_total α (≤)] : is_total (with_top α) (≤) :=
 { total := λ a b, match a, b with
   | none  , _      := or.inr le_top
   | _     , none   := or.inl le_top

--- a/src/order/bounded_order.lean
+++ b/src/order/bounded_order.lean
@@ -596,7 +596,8 @@ theorem coe_le [has_le α] {a b : α} :
 
 @[norm_cast]
 lemma coe_lt_coe [has_lt α] {a b : α} : (a : with_bot α) < b ↔ a < b := some_lt_some
-lemma not_coe_le_bot [preorder α] (a : α) : ¬ (a : with_bot α) ≤ ⊥ := (bot_lt_coe a).not_le
+lemma not_coe_le_bot [has_le α] (a : α) : ¬ (a : with_bot α) ≤ ⊥ :=
+λ h, let ⟨b, hb, _⟩ := h _ rfl in option.not_mem_none _ hb
 
 lemma le_coe_get_or_else [preorder α] : ∀ (a : with_bot α) (b : α), a ≤ a.get_or_else b
 | (some a) b := le_refl a
@@ -624,7 +625,7 @@ instance decidable_lt [has_lt α] [@decidable_rel α (<)] : @decidable_rel (with
   else is_false $ by simp *
 | x none := is_false $ by rintro ⟨a,⟨⟨⟩⟩⟩
 
-instance [partial_order α] [is_total α (≤)] : is_total (with_bot α) (≤) :=
+instance [has_le α] [is_total α (≤)] : is_total (with_bot α) (≤) :=
 { total := λ a b, match a, b with
   | none  , _      := or.inl bot_le
   | _     , none   := or.inr bot_le
@@ -860,28 +861,27 @@ theorem le_coe [has_le α] {a b : α} :
   (@has_le.le (with_top α) _ o b ↔ a ≤ b)
 | _ rfl := coe_le_coe
 
-theorem le_coe_iff [partial_order α] {b : α} : ∀{x : with_top α}, x ≤ b ↔ (∃a:α, x = a ∧ a ≤ b)
-| (some a) := by simp [some_eq_coe, coe_eq_coe]
-| none     := by simp [none_eq_top]
+@[norm_cast] lemma coe_lt_coe [has_lt α] {a b : α} : (a : with_top α) < b ↔ a < b := some_lt_some
+lemma coe_lt_top [has_lt α] (a : α) : (a : with_top α) < ⊤ := some_lt_none a
 
-theorem coe_le_iff [preorder α] {a : α} : ∀{x : with_top α}, ↑a ≤ x ↔ (∀b:α, x = ↑b → a ≤ b)
+lemma not_top_le_coe [has_le α] (a : α) : ¬ (⊤ : with_top α) ≤ ↑a :=
+λ h, let ⟨b, hb, _⟩ := h _ rfl in option.not_mem_none _ hb
+
+lemma le_coe_iff [has_le α] {b : α} : ∀ {x : with_top α}, x ≤ b ↔ ∃ a : α, x = a ∧ a ≤ b
+| (some a) := by simp [some_eq_coe, coe_eq_coe]
+| none     := iff_of_false (not_top_le_coe _) $ by simp [none_eq_top]
+
+lemma coe_le_iff [has_le α] {a : α} : ∀ {x : with_top α}, ↑a ≤ x ↔ ∀ b, x = ↑b → a ≤ b
 | (some b) := by simp [some_eq_coe, coe_eq_coe]
 | none     := by simp [none_eq_top]
 
-theorem lt_iff_exists_coe [preorder α] : ∀{a b : with_top α}, a < b ↔ (∃p:α, a = p ∧ ↑p < b)
-| (some a) b := by simp [some_eq_coe, coe_eq_coe]
-| none     b := by simp [none_eq_top]
-
-@[norm_cast]
-lemma coe_lt_coe [has_lt α] {a b : α} : (a : with_top α) < b ↔ a < b := some_lt_some
-
-lemma coe_lt_top [has_lt α] (a : α) : (a : with_top α) < ⊤ := some_lt_none a
-
-theorem coe_lt_iff [preorder α] {a : α} : ∀{x : with_top α}, ↑a < x ↔ (∀b:α, x = ↑b → a < b)
+lemma coe_lt_iff [has_lt α] {a : α} : ∀ {x : with_top α}, ↑a < x ↔ ∀ b, x = ↑b → a < b
 | (some b) := by simp [some_eq_coe, coe_eq_coe, coe_lt_coe]
 | none     := by simp [none_eq_top, coe_lt_top]
 
-lemma not_top_le_coe [preorder α] (a : α) : ¬ (⊤ : with_top α) ≤ ↑a := (coe_lt_top a).not_le
+lemma lt_iff_exists_coe [has_lt α] : ∀ {a b : with_top α}, a < b ↔  ∃ p : α, a = p ∧ ↑p < b
+| (some a) b := by simp [some_eq_coe, coe_eq_coe]
+| none     b := iff_of_false (not_none_lt _) $ by simp [none_eq_top]
 
 instance decidable_le [has_le α] [@decidable_rel α (≤)] : @decidable_rel (with_top α) (≤) :=
 λ x y, @with_bot.decidable_le (order_dual α) _ _ y x
@@ -889,7 +889,7 @@ instance decidable_le [has_le α] [@decidable_rel α (≤)] : @decidable_rel (wi
 instance decidable_lt [has_lt α] [@decidable_rel α (<)] : @decidable_rel (with_top α) (<) :=
 λ x y, @with_bot.decidable_lt (order_dual α) _ _ y x
 
-instance [partial_order α] [is_total α (≤)] : is_total (with_top α) (≤) :=
+instance [has_le α] [is_total α (≤)] : is_total (with_top α) (≤) :=
 { total := λ a b, match a, b with
   | none  , _      := or.inr le_top
   | _     , none   := or.inl le_top

--- a/src/topology/instances/ereal.lean
+++ b/src/topology/instances/ereal.lean
@@ -297,10 +297,8 @@ begin
   refine ⟨λ z, z < ((r - (a + 1): ℝ) : ereal), Iio_mem_nhds (bot_lt_coe _),
           λ z, z < ((a + 1 : ℝ) : ereal), Iio_mem_nhds (by simp [-coe_add, zero_lt_one]),
           λ x hx y hy, _⟩,
-  dsimp,
   convert add_lt_add hx hy,
-  dsimp,
-  ring,
+  rw sub_add_cancel,
 end
 
 lemma continuous_at_add_coe_bot (a : ℝ) :


### PR DESCRIPTION
Add the `covariant_class (with_bot α) (with_bot α) (+) (≤)` and `contravariant_class (with_bot α) (with_bot α) (+) (<)` instances, as well as the lemmas that `covariant_class (with_bot α) (with_bot α) (+) (<)` and `contravariant_class (with_bot α) (with_bot α) (+) (≤)` almost hold.

On the way, match the APIs for `with_bot`/`with_top` by adding missing lemmas.

Co-authored-by: Wrenna Robson <wren.robson@gmail.com>

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
Sorry, the diff is a bit mangled because I had to move `with_top`/`with_bot` down the file to use `order_dual`. Note that I am not adding `with_top.add_lt_add` on purpose. We are currently unsure what the correct typeclass assumptions and whether we are not requiring a new one.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
