### PR TITLE
[Merged by Bors] - fix(category_theory/elements): speed up `groupoid_of_elements`

### DIFF
--- a/src/category_theory/elements.lean
+++ b/src/category_theory/elements.lean
@@ -68,9 +68,11 @@ noncomputable
 instance groupoid_of_elements {G : Type u} [groupoid.{v} G] (F : G ⥤ Type w) :
   groupoid F.elements :=
 { inv := λ p q f, ⟨inv f.val,
-      calc F.map (inv f.val) q.2 = F.map (inv f.val) (F.map f.val p.2) : by rw f.2
-                             ... = (F.map f.val ≫ F.map (inv f.val)) p.2 : by simp
-                             ... = p.2 : by {rw ←functor.map_comp, simp}⟩, }
+    calc F.map (inv f.val) q.2 = F.map (inv f.val) (F.map f.val p.2) : by rw f.2
+                           ... = (F.map f.val ≫ F.map (inv f.val)) p.2 : rfl
+                           ... = p.2 : by {rw ← F.map_comp, simp} ⟩,
+  inv_comp' := λ _ _ _, by { ext, simp },
+  comp_inv' := λ _ _ _, by { ext, simp } }
 
 namespace category_of_elements
 variable (F : C ⥤ Type w)


### PR DESCRIPTION
from 14.5s to 6s

It's [reported](https://leanprover.zulipchat.com/#narrow/stream/116395-maths/topic/Quadratic.20Hilbert.20symbol.20over.20.E2.84.9A/near/278592167) that this is causing timeouts in recent bors batches.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
