### PR TITLE
[Merged by Bors] - chore(category_theory/preadditive/biproducts): Speed up `biprod.column_nonzero_of_iso`

### DIFF
--- a/src/category_theory/preadditive/biproducts.lean
+++ b/src/category_theory/preadditive/biproducts.lean
@@ -248,8 +248,7 @@ lemma biprod.column_nonzero_of_iso {W X Y Z : C}
   (f : W ⊞ X ⟶ Y ⊞ Z) [is_iso f] :
   𝟙 W = 0 ∨ biprod.inl ≫ f ≫ biprod.fst ≠ 0 ∨ biprod.inl ≫ f ≫ biprod.snd ≠ 0 :=
 begin
-  by_contradiction,
-  rw [not_or_distrib, not_or_distrib, not_not, not_not] at h,
+  by_contra' h,
   rcases h with ⟨nz, a₁, a₂⟩,
   set x := biprod.inl ≫ f ≫ inv f ≫ biprod.fst,
   have h₁ : x = 𝟙 W, by simp [x],
@@ -265,7 +264,6 @@ begin
     simp only [zero_comp], },
   exact nz (h₁.symm.trans h₀),
 end
-
 
 end
 


### PR DESCRIPTION
From 76s down to 2s. The decidability synthesis in `by_contradiction` is stupidly expensive.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
