### PR TITLE
[Merged by Bors] - chore(algebra/monoid_algebra/basic): use the homomorphism typeclasses

### DIFF
--- a/src/algebra/monoid_algebra/basic.lean
+++ b/src/algebra/monoid_algebra/basic.lean
@@ -1106,16 +1106,14 @@ by rw [pow_succ, pow_succ, single_pow n, single_mul_single, add_comm, add_nsmul,
 
 /-- Like `finsupp.map_domain_zero`, but for the `1` we define in this file -/
 @[simp] lemma map_domain_one {α : Type*} {β : Type*} {α₂ : Type*}
-  [semiring β] [has_zero α] [has_zero α₂]
-  {F} [zero_hom_class F α α₂] (f : F) (x y : add_monoid_algebra β α):
+  [semiring β] [has_zero α] [has_zero α₂] {F : Type*} [zero_hom_class F α α₂] (f : F) :
   (map_domain f (1 : add_monoid_algebra β α) : add_monoid_algebra β α₂) =
     (1 : add_monoid_algebra β α₂) :=
 by simp_rw [one_def, map_domain_single, map_zero]
 
 /-- Like `finsupp.map_domain_add`, but for the convolutive multiplication we define in this file -/
-lemma map_domain_mul {α : Type*} {β : Type*} {α₂ : Type*}
-  [semiring β] [has_add α] [has_add α₂]
-  {F} [add_hom_class F α α₂] (f : F) (x y : add_monoid_algebra β α):
+lemma map_domain_mul {α : Type*} {β : Type*} {α₂ : Type*} [semiring β] [has_add α] [has_add α₂]
+  {F : Type*} [add_hom_class F α α₂] (f : F) (x y : add_monoid_algebra β α) :
   (map_domain f (x * y : add_monoid_algebra β α) : add_monoid_algebra β α₂) =
     (map_domain f x * map_domain f y : add_monoid_algebra β α₂) :=
 begin

--- a/src/algebra/monoid_algebra/basic.lean
+++ b/src/algebra/monoid_algebra/basic.lean
@@ -336,13 +336,19 @@ subset.trans support_sum $ bUnion_mono $ assume a₁ _,
 
 section
 
+/-- Like `finsupp.map_domain_zero`, but for the `1` we define in this file -/
+@[simp] lemma map_domain_one {α : Type*} {β : Type*} {α₂ : Type*} [semiring β] [has_one α] [has_one α₂]
+  {F : Type*} [one_hom_class F α α₂] (f : F) :
+  (map_domain f (1 : monoid_algebra β α) : monoid_algebra β α₂) = (1 : monoid_algebra β α₂) :=
+by simp_rw [one_def, map_domain_single, map_one]
+
 /-- Like `finsupp.map_domain_add`, but for the convolutive multiplication we define in this file -/
 lemma map_domain_mul {α : Type*} {β : Type*} {α₂ : Type*} [semiring β] [has_mul α] [has_mul α₂]
-  {x y : monoid_algebra β α} (f : mul_hom α α₂) :
+  {F : Type*} [mul_hom_class F α α₂] (f : F) (x y : monoid_algebra β α) :
   (map_domain f (x * y : monoid_algebra β α) : monoid_algebra β α₂) =
     (map_domain f x * map_domain f y : monoid_algebra β α₂) :=
 begin
-  simp_rw [mul_def, map_domain_sum, map_domain_single, f.map_mul],
+  simp_rw [mul_def, map_domain_sum, map_domain_single, map_mul],
   rw finsupp.sum_map_domain_index,
   { congr,
     ext a b,
@@ -1098,14 +1104,22 @@ lemma single_pow [add_monoid G] {a : G} {b : k} :
 | (n+1) :=
 by rw [pow_succ, pow_succ, single_pow n, single_mul_single, add_comm, add_nsmul, one_nsmul]
 
+/-- Like `finsupp.map_domain_zero`, but for the `1` we define in this file -/
+@[simp] lemma map_domain_one {α : Type*} {β : Type*} {α₂ : Type*}
+  [semiring β] [has_zero α] [has_zero α₂]
+  {F} [zero_hom_class F α α₂] (f : F) (x y : add_monoid_algebra β α):
+  (map_domain f (1 : add_monoid_algebra β α) : add_monoid_algebra β α₂) =
+    (1 : add_monoid_algebra β α₂) :=
+by simp_rw [one_def, map_domain_single, map_zero]
+
 /-- Like `finsupp.map_domain_add`, but for the convolutive multiplication we define in this file -/
 lemma map_domain_mul {α : Type*} {β : Type*} {α₂ : Type*}
   [semiring β] [has_add α] [has_add α₂]
-  {x y : add_monoid_algebra β α} (f : add_hom α α₂) :
+  {F} [add_hom_class F α α₂] (f : F) (x y : add_monoid_algebra β α):
   (map_domain f (x * y : add_monoid_algebra β α) : add_monoid_algebra β α₂) =
     (map_domain f x * map_domain f y : add_monoid_algebra β α₂) :=
 begin
-  simp_rw [mul_def, map_domain_sum, map_domain_single, f.map_add],
+  simp_rw [mul_def, map_domain_sum, map_domain_single, map_add],
   rw finsupp.sum_map_domain_index,
   { congr,
     ext a b,
@@ -1250,7 +1264,7 @@ protected def add_monoid_algebra.to_multiplicative [semiring k] [has_add G] :
   map_mul' := λ x y, begin
     repeat {rw equiv_map_domain_eq_map_domain},
     dsimp [multiplicative.of_add],
-    convert monoid_algebra.map_domain_mul (mul_hom.id (multiplicative G)),
+    convert monoid_algebra.map_domain_mul (mul_hom.id (multiplicative G)) _ _,
   end,
   ..finsupp.dom_congr multiplicative.of_add }
 
@@ -1261,7 +1275,7 @@ protected def monoid_algebra.to_additive [semiring k] [has_mul G] :
   map_mul' := λ x y, begin
     repeat {rw equiv_map_domain_eq_map_domain},
     dsimp [additive.of_mul],
-    convert monoid_algebra.map_domain_mul (mul_hom.id G),
+    convert monoid_algebra.map_domain_mul (mul_hom.id G) _ _,
   end,
   ..finsupp.dom_congr additive.of_mul }
 

--- a/src/algebra/monoid_algebra/basic.lean
+++ b/src/algebra/monoid_algebra/basic.lean
@@ -337,8 +337,8 @@ subset.trans support_sum $ bUnion_mono $ assume a₁ _,
 section
 
 /-- Like `finsupp.map_domain_zero`, but for the `1` we define in this file -/
-@[simp] lemma map_domain_one {α : Type*} {β : Type*} {α₂ : Type*} [semiring β] [has_one α] [has_one α₂]
-  {F : Type*} [one_hom_class F α α₂] (f : F) :
+@[simp] lemma map_domain_one {α : Type*} {β : Type*} {α₂ : Type*}
+  [semiring β] [has_one α] [has_one α₂] {F : Type*} [one_hom_class F α α₂] (f : F) :
   (map_domain f (1 : monoid_algebra β α) : monoid_algebra β α₂) = (1 : monoid_algebra β α₂) :=
 by simp_rw [one_def, map_domain_single, map_one]
 


### PR DESCRIPTION
This replaces `mul_hom` with `mul_hom_class` and `add_hom` with `add_hom_class`.

Also adds two trivial lemmas, `monoid_algebra.map_domain_one` and `add_monoid_algebra.map_domain_one`.



---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
