### PR TITLE
[Merged by Bors] - feat(group_theory/subgroup/basic): One more `mem_normalizer_iff` lemma

### DIFF
--- a/src/group_theory/subgroup/basic.lean
+++ b/src/group_theory/subgroup/basic.lean
@@ -1675,16 +1675,16 @@ let ⟨y, hy⟩ := this in conj_injective hy.2 ▸ hy.1⟩
 
 variable {H}
 @[to_additive] lemma mem_normalizer_iff {g : G} :
-  g ∈ normalizer H ↔ ∀ n, n ∈ H ↔ g * n * g⁻¹ ∈ H := iff.rfl
-
-@[to_additive] lemma mem_normalizer_iff' {g : G} : g ∈ normalizer H ↔ ∀ n, n * g ∈ H ↔ g * n ∈ H :=
-⟨λ h n, by rw [h, mul_assoc, mul_inv_cancel_right],
-  λ h n, by rw [mul_assoc, ←h, inv_mul_cancel_right]⟩
+  g ∈ H.normalizer ↔ ∀ h, h ∈ H ↔ g * h * g⁻¹ ∈ H :=
+iff.rfl
 
 @[to_additive] lemma mem_normalizer_iff'' {g : G} :
   g ∈ H.normalizer ↔ ∀ h : G, h ∈ H ↔ g⁻¹ * h * g ∈ H :=
-⟨λ h n, by rw [h (g⁻¹ * n * g), mul_assoc, mul_inv_cancel_right, mul_inv_cancel_left],
-  λ h n, by rw [h (g * n * g⁻¹), mul_assoc, inv_mul_cancel_right, inv_mul_cancel_left]⟩
+by rw [←inv_mem_iff, mem_normalizer_iff, inv_inv]
+
+@[to_additive] lemma mem_normalizer_iff' {g : G} : g ∈ H.normalizer ↔ ∀ n, n * g ∈ H ↔ g * n ∈ H :=
+⟨λ h n, by rw [h, mul_assoc, mul_inv_cancel_right],
+  λ h n, by rw [mul_assoc, ←h, inv_mul_cancel_right]⟩
 
 @[to_additive] lemma le_normalizer : H ≤ normalizer H :=
 λ x xH n, by rw [H.mul_mem_cancel_right (H.inv_mem xH), H.mul_mem_cancel_left xH]

--- a/src/group_theory/subgroup/basic.lean
+++ b/src/group_theory/subgroup/basic.lean
@@ -1689,11 +1689,11 @@ end
 @[to_additive] lemma mem_normalizer_iff'' {g : G} :
   g ∈ H.normalizer ↔ ∀ h : G, h ∈ H ↔ g⁻¹ * h * g ∈ H :=
 begin
-  refine mem_normalizer_iff'.trans ⟨λ h n, _, λ h n, _⟩,
-  { specialize h (g⁻¹ * n),
-    rwa [mul_inv_cancel_left, iff.comm] at h },
-  { specialize h (g * n),
-    rwa [inv_mul_cancel_left, iff.comm] at h },
+  refine ⟨λ h n, _, λ h n, _⟩,
+  { specialize h (g⁻¹ * n * g),
+    rwa [←mul_assoc, mul_inv_cancel_left, mul_inv_cancel_right, iff.comm] at h },
+  { specialize h (g * n * g⁻¹),
+    rwa [←mul_assoc, inv_mul_cancel_left, inv_mul_cancel_right, iff.comm] at h },
 end
 
 @[to_additive] lemma le_normalizer : H ≤ normalizer H :=

--- a/src/group_theory/subgroup/basic.lean
+++ b/src/group_theory/subgroup/basic.lean
@@ -1678,19 +1678,13 @@ variable {H}
   g ∈ normalizer H ↔ ∀ n, n ∈ H ↔ g * n * g⁻¹ ∈ H := iff.rfl
 
 @[to_additive] lemma mem_normalizer_iff' {g : G} : g ∈ normalizer H ↔ ∀ n, n * g ∈ H ↔ g * n ∈ H :=
-begin
-  refine ⟨λ h n, _, λ h n, _⟩,
-  { rw [h, mul_assoc, mul_inv_cancel_right] },
-  { rw [mul_assoc, ←h, inv_mul_cancel_right] },
-end
+⟨λ h n, by rw [h, mul_assoc, mul_inv_cancel_right],
+  λ h n, by rw [mul_assoc, ←h, inv_mul_cancel_right]⟩
 
 @[to_additive] lemma mem_normalizer_iff'' {g : G} :
   g ∈ H.normalizer ↔ ∀ h : G, h ∈ H ↔ g⁻¹ * h * g ∈ H :=
-begin
-  refine ⟨λ h n, _, λ h n, _⟩,
-  { rw [h (g⁻¹ * n * g), mul_assoc, mul_inv_cancel_right, mul_inv_cancel_left] },
-  { rw [h (g * n * g⁻¹), mul_assoc, inv_mul_cancel_right, inv_mul_cancel_left] },
-end
+⟨λ h n, by rw [h (g⁻¹ * n * g), mul_assoc, mul_inv_cancel_right, mul_inv_cancel_left],
+  λ h n, by rw [h (g * n * g⁻¹), mul_assoc, inv_mul_cancel_right, inv_mul_cancel_left]⟩
 
 @[to_additive] lemma le_normalizer : H ≤ normalizer H :=
 λ x xH n, by rw [H.mul_mem_cancel_right (H.inv_mem xH), H.mul_mem_cancel_left xH]

--- a/src/group_theory/subgroup/basic.lean
+++ b/src/group_theory/subgroup/basic.lean
@@ -1680,20 +1680,16 @@ variable {H}
 @[to_additive] lemma mem_normalizer_iff' {g : G} : g ∈ normalizer H ↔ ∀ n, n * g ∈ H ↔ g * n ∈ H :=
 begin
   refine ⟨λ h n, _, λ h n, _⟩,
-  { specialize h (n * g),
-    rwa [mul_assoc, mul_inv_cancel_right] at h },
-  { specialize h (n * g⁻¹),
-    rwa [inv_mul_cancel_right, ←mul_assoc] at h },
+  { rw [h, mul_assoc, mul_inv_cancel_right] },
+  { rw [mul_assoc, ←h, inv_mul_cancel_right] },
 end
 
 @[to_additive] lemma mem_normalizer_iff'' {g : G} :
   g ∈ H.normalizer ↔ ∀ h : G, h ∈ H ↔ g⁻¹ * h * g ∈ H :=
 begin
   refine ⟨λ h n, _, λ h n, _⟩,
-  { specialize h (g⁻¹ * n * g),
-    rwa [←mul_assoc, mul_inv_cancel_left, mul_inv_cancel_right, iff.comm] at h },
-  { specialize h (g * n * g⁻¹),
-    rwa [←mul_assoc, inv_mul_cancel_left, inv_mul_cancel_right, iff.comm] at h },
+  { rw [h (g⁻¹ * n * g), mul_assoc, mul_inv_cancel_right, mul_inv_cancel_left] },
+  { rw [h (g * n * g⁻¹), mul_assoc, inv_mul_cancel_right, inv_mul_cancel_left] },
 end
 
 @[to_additive] lemma le_normalizer : H ≤ normalizer H :=

--- a/src/group_theory/subgroup/basic.lean
+++ b/src/group_theory/subgroup/basic.lean
@@ -1686,6 +1686,16 @@ begin
     rwa [inv_mul_cancel_right, ←mul_assoc] at h },
 end
 
+@[to_additive] lemma mem_normalizer_iff'' {g : G} :
+  g ∈ H.normalizer ↔ ∀ h : G, h ∈ H ↔ g⁻¹ * h * g ∈ H :=
+begin
+  refine mem_normalizer_iff'.trans ⟨λ h n, _, λ h n, _⟩,
+  { specialize h (g⁻¹ * n),
+    rwa [mul_inv_cancel_left, iff.comm] at h },
+  { specialize h (g * n),
+    rwa [inv_mul_cancel_left, iff.comm] at h },
+end
+
 @[to_additive] lemma le_normalizer : H ≤ normalizer H :=
 λ x xH n, by rw [H.mul_mem_cancel_right (H.inv_mem xH), H.mul_mem_cancel_left xH]
 


### PR DESCRIPTION
This PR golfs `mem_normalizer_iff'` and adds `mem_normalizer_iff''`. There are not so easy to deduce from each other, so it's nice to have these variations available.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
