### PR TITLE
[Merged by Bors] - feat(measure_theory/constructions/pi): more `measure_preserving` lemmas

### DIFF
--- a/src/logic/equiv/fin.lean
+++ b/src/logic/equiv/fin.lean
@@ -209,6 +209,23 @@ fin_succ_equiv'_symm_some_below i.2
   fin_succ_equiv_last.symm none = fin.last n :=
 fin_succ_equiv'_symm_none _
 
+/-- Equivalence between `Π j : fin (n + 1), α j` and `α i × Π j : fin n, α (fin.succ_above i j)`. -/
+@[simps { fully_applied := ff}]
+def equiv.pi_fin_succ_above_equiv {n : ℕ} (α : fin (n + 1) → Type u) (i : fin (n + 1)) :
+  (Π j, α j) ≃ α i × (Π j, α (i.succ_above j)) :=
+{ to_fun := λ f, (f i, λ j, f (i.succ_above j)),
+  inv_fun := λ f, i.insert_nth f.1 f.2,
+  left_inv := λ f, by simp [fin.insert_nth_eq_iff],
+  right_inv := λ f, by simp }
+
+/-- Order isomorphism between `Π j : fin (n + 1), α j` and
+`α i × Π j : fin n, α (fin.succ_above i j)`. -/
+def order_iso.pi_fin_succ_above_iso {n : ℕ} (α : fin (n + 1) → Type u) [Π i, has_le (α i)]
+  (i : fin (n + 1)) :
+  (Π j, α j) ≃o α i × (Π j, α (i.succ_above j)) :=
+{ to_equiv := equiv.pi_fin_succ_above_equiv α i,
+  map_rel_iff' := λ f g, i.forall_iff_succ_above.symm }
+
 /-- Equivalence between `fin m ⊕ fin n` and `fin (m + n)` -/
 def fin_sum_fin_equiv : fin m ⊕ fin n ≃ fin (m + n) :=
 { to_fun := sum.elim (fin.cast_add n) (fin.nat_add m),

--- a/src/logic/equiv/set.lean
+++ b/src/logic/equiv/set.lean
@@ -500,6 +500,19 @@ protected lemma preimage_sUnion {α β} (f : α ≃ β) {s : set (set β)} :
   f ⁻¹' (⋃₀ s) = ⋃₀ (_root_.set.image f ⁻¹' s) :=
 by { ext x, simp [(equiv.set.congr f).symm.exists_congr_left] }
 
+lemma preimage_pi_equiv_pi_subtype_prod_symm_pi {α : Type*} {β : α → Type*}
+  (p : α → Prop) [decidable_pred p] (s : Π i, set (β i)) :
+  (pi_equiv_pi_subtype_prod p β).symm ⁻¹' set.pi univ s =
+    (set.pi univ (λ i : {i // p i}, s i)) ×ˢ (set.pi univ (λ i : {i // ¬p i}, s i)) :=
+begin
+  ext ⟨f, g⟩,
+  simp only [mem_preimage, mem_univ_pi, prod_mk_mem_set_prod_eq, subtype.forall,
+    ← forall_and_distrib],
+  refine forall_congr (λ i, _),
+  dsimp only [subtype.coe_mk],
+  by_cases hi : p i; simp [hi]
+end
+
 end equiv
 
 /-- If a function is a bijection between two sets `s` and `t`, then it induces an

--- a/src/measure_theory/constructions/pi.lean
+++ b/src/measure_theory/constructions/pi.lean
@@ -18,11 +18,11 @@ In this file we define and prove properties about finite products of measures
   Given `μ : Π i : ι, measure (α i)` for `[fintype ι]` it has type `measure (Π i : ι, α i)`.
 
 To apply Fubini along some subset of the variables, use
-`measure_theory.measure.map_pi_equiv_pi_subtype_prod` to reduce to the situation of a product
-of two measures: this lemma states that the bijection `equiv.pi_equiv_pi_subtype_prod p α`
-between `(Π i : ι, α i)` and `(Π i : {i // p i}, α i) × (Π i : {i // ¬ p i}, α i)` maps a product
-measure to a direct product of product measures, to which one can apply the usual Fubini for
-direct product of measures.
+`measure_theory.measure_preserving_pi_equiv_pi_subtype_prod` to reduce to the situation of a product
+of two measures: this lemma states that the bijection
+`measurable_equiv.pi_equiv_pi_subtype_prod α p` between `(Π i : ι, α i)` and
+`(Π i : {i // p i}, α i) × (Π i : {i // ¬ p i}, α i)` maps a product measure to a direct product of
+product measures, to which one can apply the usual Fubini for direct product of measures.
 
 ## Implementation Notes
 
@@ -505,40 +505,6 @@ end
 
 variable (μ)
 
-/-- Separating the indices into those that satisfy a predicate `p` and those that don't maps
-a product measure to a product of product measures. This is useful to apply Fubini to some subset
-of the variables. The converse is `measure_theory.measure.map_pi_equiv_pi_subtype_prod`. -/
-lemma map_pi_equiv_pi_subtype_prod_symm (p : ι → Prop) [decidable_pred p] :
-  map (equiv.pi_equiv_pi_subtype_prod p α).symm
-    (measure.prod (measure.pi (λ i, μ i)) (measure.pi (λ i, μ i))) = measure.pi μ :=
-begin
-  refine (measure.pi_eq (λ s hs, _)).symm,
-  have A : (equiv.pi_equiv_pi_subtype_prod p α).symm ⁻¹' (set.pi set.univ (λ (i : ι), s i)) =
-    (set.pi set.univ (λ i : {i // p i}, s i)) ×ˢ (set.pi set.univ (λ i : {i // ¬p i}, s i)),
-  { ext x,
-    simp only [equiv.pi_equiv_pi_subtype_prod_symm_apply, mem_prod, mem_univ_pi, mem_preimage,
-      subtype.forall],
-    split,
-    { exact λ h, ⟨λ i hi, by simpa [dif_pos hi] using h i,
-                  λ i hi, by simpa [dif_neg hi] using h i⟩ },
-    { assume h i,
-      by_cases hi : p i,
-      { simpa only [dif_pos hi] using h.1 i hi },
-      {simpa only [dif_neg hi] using h.2 i hi } } },
-  rw [measure.map_apply (measurable_pi_equiv_pi_subtype_prod_symm _ p)
-        (measurable_set.univ_pi_fintype hs), A,
-      measure.prod_prod, pi_pi, pi_pi, ← fintype.prod_subtype_mul_prod_subtype p (λ i, μ i (s i))],
-end
-
-lemma map_pi_equiv_pi_subtype_prod (p : ι → Prop) [decidable_pred p] :
-  map (equiv.pi_equiv_pi_subtype_prod p α) (measure.pi μ) =
-    measure.prod (measure.pi (λ i, μ i)) (measure.pi (λ i, μ i)) :=
-begin
-  rw [← map_pi_equiv_pi_subtype_prod_symm μ p, measure.map_map
-      (measurable_pi_equiv_pi_subtype_prod _ p) (measurable_pi_equiv_pi_subtype_prod_symm _ p)],
-  simp only [equiv.self_comp_symm, map_id]
-end
-
 @[to_additive] instance pi.is_mul_left_invariant [∀ i, group (α i)] [∀ i, has_measurable_mul (α i)]
   [∀ i, is_mul_left_invariant (μ i)] : is_mul_left_invariant (measure.pi μ) :=
 begin
@@ -611,6 +577,47 @@ measures of corresponding sets (images or preimages) have equal measures and fun
 -/
 
 section measure_preserving
+
+lemma measure_preserving_pi_equiv_pi_subtype_prod {ι : Type u} {α : ι → Type v} [fintype ι]
+  {m : Π i, measurable_space (α i)} (μ : Π i, measure (α i)) [∀ i, sigma_finite (μ i)]
+  (p : ι → Prop) [decidable_pred p] :
+  measure_preserving (measurable_equiv.pi_equiv_pi_subtype_prod α p) (measure.pi μ)
+    ((measure.pi $ λ i : subtype p, μ i).prod (measure.pi $ λ i, μ i)) :=
+begin
+  set e := (measurable_equiv.pi_equiv_pi_subtype_prod α p).symm,
+  suffices : measure_preserving e _ _, from this.symm,
+  refine ⟨e.measurable, (pi_eq $ λ s hs, _).symm⟩,
+  have : e ⁻¹' (pi univ s) =
+    (pi univ (λ i : {i // p i}, s i)) ×ˢ (pi univ (λ i : {i // ¬p i}, s i)),
+    from equiv.preimage_pi_equiv_pi_subtype_prod_symm_pi p s,
+  rw [e.map_apply, this, prod_prod, pi_pi, pi_pi],
+  exact fintype.prod_subtype_mul_prod_subtype p (λ i, μ i (s i))
+end
+
+lemma volume_preserving_pi_equiv_pi_subtype_prod {ι : Type*} (α : ι → Type*) [fintype ι]
+  [Π i, measure_space (α i)] [∀ i, sigma_finite (volume : measure (α i))]
+  (p : ι → Prop) [decidable_pred p] :
+  measure_preserving (measurable_equiv.pi_equiv_pi_subtype_prod α p) :=
+measure_preserving_pi_equiv_pi_subtype_prod (λ i, volume) p
+
+lemma measure_preserving_pi_fin_succ_above_equiv {n : ℕ} {α : fin (n + 1) → Type u}
+  {m : Π i, measurable_space (α i)} (μ : Π i, measure (α i)) [∀ i, sigma_finite (μ i)]
+  (i : fin (n + 1)) :
+  measure_preserving (measurable_equiv.pi_fin_succ_above_equiv α i) (measure.pi μ)
+    ((μ i).prod $ measure.pi $ λ j, μ (i.succ_above j)) :=
+begin
+  set e := (measurable_equiv.pi_fin_succ_above_equiv α i).symm,
+  suffices : measure_preserving e _ _, from this.symm,
+  refine ⟨e.measurable, (pi_eq $ λ s hs, _).symm⟩,
+  rw [e.map_apply, i.prod_univ_succ_above _, ← pi_pi, ← prod_prod],
+  congr' 1 with ⟨x, f⟩,
+  simp [i.forall_iff_succ_above]
+end
+
+lemma volume_preserving_pi_fin_succ_above_equiv {n : ℕ} (α : fin (n + 1) → Type u)
+  [Π i, measure_space (α i)] [∀ i, sigma_finite (volume : measure (α i))] (i : fin (n + 1)) :
+  measure_preserving (measurable_equiv.pi_fin_succ_above_equiv α i) :=
+measure_preserving_pi_fin_succ_above_equiv (λ _, volume) i
 
 lemma measure_preserving_fun_unique {β : Type u} {m : measurable_space β} (μ : measure β)
   (α : Type v) [unique α] :

--- a/src/measure_theory/measurable_space.lean
+++ b/src/measure_theory/measurable_space.lean
@@ -1251,6 +1251,29 @@ def pi_measurable_equiv_tprod [decidable_eq δ']
 /-- The space `fin 2 → α` is measurably equivalent to `α × α`. -/
 @[simps {fully_applied := ff}] def fin_two_arrow : (fin 2 → α) ≃ᵐ α × α := pi_fin_two (λ _, α)
 
+/-- Measurable equivalence between `Π j : fin (n + 1), α j` and
+`α i × Π j : fin n, α (fin.succ_above i j)`. -/
+@[simps {fully_applied := ff}]
+def pi_fin_succ_above_equiv {n : ℕ} (α : fin (n + 1) → Type*) [Π i, measurable_space (α i)]
+  (i : fin (n + 1)) :
+  (Π j, α j) ≃ᵐ α i × (Π j, α (i.succ_above j)) :=
+{ to_equiv := pi_fin_succ_above_equiv α i,
+  measurable_to_fun := (measurable_pi_apply i).prod_mk $ measurable_pi_iff.2 $
+    λ j, measurable_pi_apply _,
+  measurable_inv_fun := by simp [measurable_pi_iff, i.forall_iff_succ_above, measurable_fst,
+    (measurable_pi_apply _).comp measurable_snd]  }
+
+variable (π)
+
+/-- Measurable equivalence between (dependent) functions on a type and pairs of functions on
+`{i // p i}` and `{i // ¬p i}`. See also `equiv.pi_equiv_pi_subtype_prod`. -/
+@[simps {fully_applied := ff}]
+def pi_equiv_pi_subtype_prod (p : δ' → Prop) [decidable_pred p] :
+  (Π i, π i) ≃ᵐ ((Π i : subtype p, π i) × (Π i : {i // ¬p i}, π i)) :=
+{ to_equiv := pi_equiv_pi_subtype_prod p π,
+  measurable_to_fun := measurable_pi_equiv_pi_subtype_prod π p,
+  measurable_inv_fun := measurable_pi_equiv_pi_subtype_prod_symm π p }
+
 end measurable_equiv
 
 namespace measurable_embedding

--- a/src/measure_theory/measure/lebesgue.lean
+++ b/src/measure_theory/measure/lebesgue.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2017 Johannes Hölzl. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Johannes Hölzl, Yury Kudryashov
+Authors: Johannes Hölzl, Sébastien Gouëzel, Yury Kudryashov
 -/
 import dynamics.ergodic.measure_preserving
 import linear_algebra.determinant
@@ -296,28 +296,27 @@ begin
 end
 
 /-- A transvection preserves Lebesgue measure. -/
-lemma map_transvection_volume_pi [decidable_eq ι] (t : transvection_struct ι ℝ) :
-  measure.map (t.to_matrix.to_lin') volume = volume :=
+lemma volume_preserving_transvection_struct [decidable_eq ι] (t : transvection_struct ι ℝ) :
+  measure_preserving (t.to_matrix.to_lin') :=
 begin
   /- We separate the coordinate along which there is a shearing from the other ones, and apply
   Fubini. Along this coordinate (and when all the other coordinates are fixed), it acts like a
   translation, and therefore preserves Lebesgue. -/
-  suffices H : measure_preserving t.to_matrix.to_lin' volume volume, by exact H.2,
   let p : ι → Prop := λ i, i ≠ t.i,
   let α : Type* := {x // p x},
   let β : Type* := {x // ¬ (p x)},
   let g : (α → ℝ) → (β → ℝ) → (β → ℝ) := λ a b, (λ x, t.c * a ⟨t.j, t.hij.symm⟩) + b,
   let F : (α → ℝ) × (β → ℝ) → (α → ℝ) × (β → ℝ) :=
     λ p, (id p.1, g p.1 p.2),
-  let e := equiv.pi_equiv_pi_subtype_prod p (λ (i : ι), ℝ),
+  let e : (ι → ℝ) ≃ᵐ (α → ℝ) × (β → ℝ) := measurable_equiv.pi_equiv_pi_subtype_prod (λ i : ι, ℝ) p,
   have : (t.to_matrix.to_lin' : (ι → ℝ) → (ι → ℝ)) = e.symm ∘ F ∘ e,
   { cases t,
     ext f k,
     simp only [linear_equiv.map_smul, dite_eq_ite, linear_map.id_coe, p, ite_not,
       algebra.id.smul_eq_mul, one_mul, dot_product, std_basis_matrix,
-      equiv.pi_equiv_pi_subtype_prod_symm_apply, id.def, transvection,
+      measurable_equiv.pi_equiv_pi_subtype_prod_symm_apply, id.def, transvection,
       pi.add_apply, zero_mul, linear_map.smul_apply, function.comp_app,
-      equiv.pi_equiv_pi_subtype_prod_apply, matrix.transvection_struct.to_matrix_mk,
+      measurable_equiv.pi_equiv_pi_subtype_prod_apply, matrix.transvection_struct.to_matrix_mk,
       matrix.mul_vec, linear_equiv.map_add, ite_mul, e, matrix.to_lin'_apply,
       pi.smul_apply, subtype.coe_mk, g, linear_map.add_apply, finset.sum_congr, matrix.to_lin'_one],
     by_cases h : t_i = k,
@@ -325,27 +324,23 @@ begin
         one_apply, boole_mul, add_comm], },
     { simp only [h, ne.symm h, add_zero, if_false, finset.sum_const_zero, false_and, mul_zero] } },
   rw this,
-  have A : measure_preserving e volume volume :=
-  ⟨ measurable_pi_equiv_pi_subtype_prod (λ i, ℝ) _,
-    (measure.map_pi_equiv_pi_subtype_prod (λ i, (volume : measure ℝ)) p : _) ⟩,
-  have B : measure_preserving F volume volume,
+  have A : measure_preserving e,
+  { convert volume_preserving_pi_equiv_pi_subtype_prod (λ i : ι, ℝ) p },
+  have B : measure_preserving F,
   { have g_meas : measurable (function.uncurry g),
     { have : measurable (λ (c : (α → ℝ)), c ⟨t.j, t.hij.symm⟩) :=
         measurable_pi_apply ⟨t.j, t.hij.symm⟩,
-      refine measurable.add (measurable_pi_lambda _ (λ i, measurable.const_mul _ _)) measurable_snd,
+      refine (measurable_pi_lambda _ (λ i, measurable.const_mul _ _)).add measurable_snd,
       exact this.comp measurable_fst },
-    exact measure_preserving.skew_product (measure_preserving.id _) g_meas
+    exact (measure_preserving.id _).skew_product g_meas
       (eventually_of_forall (λ a, map_add_left_eq_self _ _)) },
-  have C : measure_preserving e.symm volume volume :=
-  ⟨ (measurable_pi_equiv_pi_subtype_prod_symm (λ (i : ι), ℝ) p : _),
-    (measure.map_pi_equiv_pi_subtype_prod_symm (λ (i : ι), volume) p : _) ⟩,
-  exact (C.comp B).comp A,
+  exact (A.symm.comp B).comp A,
 end
 
 /-- Any invertible matrix rescales Lebesgue measure through the absolute value of its
 determinant. -/
 lemma map_matrix_volume_pi_eq_smul_volume_pi [decidable_eq ι] {M : matrix ι ι ℝ} (hM : det M ≠ 0) :
-  measure.map (M.to_lin') volume = ennreal.of_real (abs (det M)⁻¹) • volume :=
+  measure.map M.to_lin' volume = ennreal.of_real (abs (det M)⁻¹) • volume :=
 begin
   -- This follows from the cases we have already proved, of diagonal matrices and transvections,
   -- as these matrices generate all invertible matrices.
@@ -354,8 +349,8 @@ begin
   { conv_rhs { rw [← smul_map_diagonal_volume_pi hD] },
     rw [smul_smul, ← ennreal.of_real_mul (abs_nonneg _), ← abs_mul, inv_mul_cancel hD, abs_one,
       ennreal.of_real_one, one_smul] },
-  { simp only [matrix.transvection_struct.det, ennreal.of_real_one, map_transvection_volume_pi,
-      one_smul, _root_.inv_one, abs_one] },
+  { simp only [matrix.transvection_struct.det, ennreal.of_real_one,
+      (volume_preserving_transvection_struct _).map_eq, one_smul, _root_.inv_one, abs_one] },
   { rw [to_lin'_mul, det_mul, linear_map.coe_comp, ← measure.map_map, IHB, measure.map_smul,
       IHA, smul_smul, ← ennreal.of_real_mul (abs_nonneg _), ← abs_mul, mul_comm, mul_inv₀],
     { apply continuous.measurable,


### PR DESCRIPTION
* Reformulate `map_pi_equiv_pi_subtype_prod` in terms of
  `measure_preserving`.

* Add more equivalences (bare equivalences, order isomorphisms, and
  measurable equivalences) on pi types.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
