### PR TITLE
feat(topology/algebra/affine): define topological add torsors

### DIFF
--- a/src/analysis/convex/extrema.lean
+++ b/src/analysis/convex/extrema.lean
@@ -20,40 +20,30 @@ variables {E β : Type*} [add_comm_group E] [topological_space E]
   [linear_ordered_add_comm_group β] [module ℝ β] [ordered_smul ℝ β]
   {s : set E}
 
-open set filter
-open_locale classical
+open set filter function
+open_locale classical topological_space
 
 /--
 Helper lemma for the more general case: `is_min_on.of_is_local_min_on_of_convex_on`.
 -/
 lemma is_min_on.of_is_local_min_on_of_convex_on_Icc {f : ℝ → β} {a b : ℝ} (a_lt_b : a < b)
   (h_local_min : is_local_min_on f (Icc a b) a) (h_conv : convex_on ℝ (Icc a b) f) :
-  ∀ x ∈ Icc a b, f a ≤ f x :=
+  is_min_on f (Icc a b) a :=
 begin
-  by_contra' H_cont,
-  rcases H_cont with ⟨x, ⟨h_ax, h_xb⟩, fx_lt_fa⟩,
-  obtain ⟨z, hz, ge_on_nhd⟩ : ∃ z > a, ∀ y ∈ (Icc a z), f y ≥ f a,
-  { rcases eventually_iff_exists_mem.mp h_local_min with ⟨U, U_in_nhds_within, fy_ge_fa⟩,
-    rw [nhds_within_Icc_eq_nhds_within_Ici a_lt_b, mem_nhds_within_Ici_iff_exists_Icc_subset]
-        at U_in_nhds_within,
-    rcases U_in_nhds_within with ⟨ε, ε_in_Ioi, Ioc_in_U⟩,
-    exact ⟨ε, mem_Ioi.mp ε_in_Ioi, λ y y_in_Ioc, fy_ge_fa y $ Ioc_in_U y_in_Ioc⟩ },
-  have a_lt_x : a < x := lt_of_le_of_ne h_ax (λ H, by subst H; exact lt_irrefl (f a) fx_lt_fa),
-  have lt_on_nhd : ∀ y ∈ Ioc a x, f y < f a,
-  { intros y y_in_Ioc,
-    rcases (convex.mem_Ioc a_lt_x).mp y_in_Ioc with ⟨ya, yx, ya_pos, yx_pos, yax, y_combo⟩,
-    calc
-      f y = f (ya * a + yx * x)       : by rw [y_combo]
-      ... ≤ ya • f a + yx • f x
-                : h_conv.2 (left_mem_Icc.mpr (le_of_lt a_lt_b)) ⟨h_ax, h_xb⟩ (ya_pos)
-                    (le_of_lt yx_pos) yax
-      ... < ya • f a + yx • f a       : add_lt_add_left (smul_lt_smul_of_pos fx_lt_fa yx_pos) _
-      ... = f a                       : by rw [←add_smul, yax, one_smul] },
-  by_cases h_xz : x ≤ z,
-  { exact not_lt_of_ge (ge_on_nhd x (show x ∈ Icc a z, by exact ⟨h_ax, h_xz⟩)) fx_lt_fa, },
-  { have h₁ : z ∈ Ioc a x := ⟨hz, le_of_not_ge h_xz⟩,
-    have h₂ : z ∈ Icc a z := ⟨le_of_lt hz, le_refl z⟩,
-    exact not_lt_of_ge (ge_on_nhd z h₂) (lt_on_nhd z h₁) }
+  rintro c hc, dsimp only [mem_set_of_eq],
+  rw [is_local_min_on, nhds_within_Icc_eq_nhds_within_Ici a_lt_b] at h_local_min,
+  rcases hc.1.eq_or_lt with rfl|a_lt_c, { exact le_rfl },
+  have H₁ : ∀ᶠ y in 𝓝[>] a, f a ≤ f y,
+    from h_local_min.filter_mono (nhds_within_mono _ Ioi_subset_Ici_self),
+  have H₂ : ∀ᶠ y in 𝓝[>] a, y ∈ Ioc a c,
+    from Ioc_mem_nhds_within_Ioi (left_mem_Ico.2 a_lt_c),
+  rcases (H₁.and H₂).exists with ⟨y, hfy, hy_ac⟩,
+  rcases (convex.mem_Ioc a_lt_c).mp hy_ac with ⟨ya, yc, ya₀, yc₀, yac, rfl⟩,
+  refine not_lt.1 (λ fc_lt_fa, lt_irrefl (f a) _),
+  calc f a ≤ f (ya * a + yc * c) : hfy
+  ... ≤ ya • f a + yc • f c      : h_conv.2 (left_mem_Icc.2 a_lt_b.le) hc ya₀ yc₀.le yac
+  ... < ya • f a + yc • f a      : add_lt_add_left (smul_lt_smul_of_pos fc_lt_fa yc₀) _
+  ... = f a                      : by rw [← add_smul, yac, one_smul]
 end
 
 /--
@@ -61,37 +51,29 @@ A local minimum of a convex function is a global minimum, restricted to a set `s
 -/
 lemma is_min_on.of_is_local_min_on_of_convex_on {f : E → β} {a : E}
   (a_in_s : a ∈ s) (h_localmin : is_local_min_on f s a) (h_conv : convex_on ℝ s f) :
-  ∀ x ∈ s, f a ≤ f x :=
+  is_min_on f s a :=
 begin
-  by_contra' H_cont,
-  rcases H_cont with ⟨x, ⟨x_in_s, fx_lt_fa⟩⟩,
+  intros x x_in_s,
   let g : ℝ →ᵃ[ℝ] E := affine_map.line_map a x,
   have hg0 : g 0 = a := affine_map.line_map_apply_zero a x,
   have hg1 : g 1 = x := affine_map.line_map_apply_one a x,
-  have fg_local_min_on : is_local_min_on (f ∘ g) (g ⁻¹' s) 0,
-  { rw ←hg0 at h_localmin,
-    refine is_local_min_on.comp_continuous_on h_localmin subset.rfl
-      (continuous.continuous_on (affine_map.line_map_continuous)) _,
-    simp [mem_preimage, hg0, a_in_s] },
-  have fg_min_on : ∀ x ∈ (Icc 0 1 : set ℝ), (f ∘ g) 0 ≤ (f ∘ g) x,
-  { have Icc_in_s' : Icc 0 1 ⊆ (g ⁻¹' s),
-    { have h0 : (0 : ℝ) ∈ (g ⁻¹' s) := by simp [mem_preimage, a_in_s],
-      have h1 : (1 : ℝ) ∈ (g ⁻¹' s) := by simp [mem_preimage, hg1, x_in_s],
-      rw ←segment_eq_Icc (show (0 : ℝ) ≤ 1, by linarith),
-      exact (convex.affine_preimage g h_conv.1).segment_subset
-        (by simp [mem_preimage, hg0, a_in_s]) (by simp [mem_preimage, hg1, x_in_s]) },
-    have fg_local_min_on' : is_local_min_on (f ∘ g) (Icc 0 1) 0 :=
-      is_local_min_on.on_subset fg_local_min_on Icc_in_s',
-    refine is_min_on.of_is_local_min_on_of_convex_on_Icc (by linarith) fg_local_min_on' _,
-    exact (convex_on.comp_affine_map g h_conv).subset Icc_in_s' (convex_Icc 0 1) },
-  have gx_lt_ga : (f ∘ g) 1 < (f ∘ g) 0 := by simp [hg1, fx_lt_fa, hg0],
-  exact not_lt_of_ge (fg_min_on 1 (mem_Icc.mpr ⟨zero_le_one, le_refl 1⟩)) gx_lt_ga,
+  have hgc : continuous g, from continuous_line_map a x,
+  have h_maps : maps_to g (Icc 0 1) s,
+  { simpa only [maps_to', ← segment_eq_image_line_map]
+      using h_conv.1.segment_subset a_in_s x_in_s },
+  have fg_local_min_on : is_local_min_on (f ∘ g) (Icc 0 1) 0,
+  { rw ← hg0 at h_localmin,
+    exact h_localmin.comp_continuous_on h_maps hgc.continuous_on (left_mem_Icc.2 zero_le_one) },
+  have fg_min_on : is_min_on (f ∘ g) (Icc 0 1 : set ℝ) 0,
+  { refine is_min_on.of_is_local_min_on_of_convex_on_Icc one_pos fg_local_min_on _,
+    exact (convex_on.comp_affine_map g h_conv).subset h_maps (convex_Icc 0 1) },
+  simpa only [hg0, hg1, comp_app, mem_set_of_eq] using fg_min_on (right_mem_Icc.2 zero_le_one)
 end
 
 /-- A local maximum of a concave function is a global maximum, restricted to a set `s`. -/
 lemma is_max_on.of_is_local_max_on_of_concave_on {f : E → β} {a : E}
   (a_in_s : a ∈ s) (h_localmax: is_local_max_on f s a) (h_conc : concave_on ℝ s f) :
-  ∀ x ∈ s, f x ≤ f a :=
+  is_max_on f s a :=
 @is_min_on.of_is_local_min_on_of_convex_on
   _ (order_dual β) _ _ _ _ _ _ _ _ s f a a_in_s h_localmax h_conc
 
@@ -99,7 +81,7 @@ lemma is_max_on.of_is_local_max_on_of_concave_on {f : E → β} {a : E}
 lemma is_min_on.of_is_local_min_of_convex_univ {f : E → β} {a : E}
   (h_local_min : is_local_min f a) (h_conv : convex_on ℝ univ f) : ∀ x, f a ≤ f x :=
 λ x, (is_min_on.of_is_local_min_on_of_convex_on (mem_univ a)
-        (is_local_min.on h_local_min univ) h_conv) x (mem_univ x)
+        (h_local_min.on univ) h_conv) (mem_univ x)
 
 /-- A local maximum of a concave function is a global maximum. -/
 lemma is_max_on.of_is_local_max_of_convex_univ {f : E → β} {a : E}

--- a/src/analysis/convex/topology.lean
+++ b/src/analysis/convex/topology.lean
@@ -234,27 +234,15 @@ lemma convex.closure_subset_interior_image_homothety_of_one_lt {s : set E} (hs :
   closure s ⊆ interior (homothety x t '' s) :=
 begin
   intros y hy,
-  let I := { z | ∃ (u : ℝ), u ∈ Ioc (0 : ℝ) 1 ∧ z = y + u • (x - y) },
-  have hI : I ⊆ interior s,
-  { rintros z ⟨u, hu, rfl⟩, exact hs.add_smul_sub_mem_interior' hy hx hu, },
-  let z := homothety x t⁻¹ y,
-  have hz₁ : z ∈ interior s,
-  { suffices : z ∈ I, { exact hI this, },
-    use 1 - t⁻¹,
-    split,
-    { simp only [mem_Ioc, sub_le_self_iff, inv_nonneg, sub_pos, inv_lt_one ht, true_and],
-      linarith, },
-    { simp only [z, homothety_apply, sub_smul, smul_sub, vsub_eq_sub, vadd_eq_add, one_smul],
-      abel, }, },
-  have ht' : t ≠ 0, { linarith, },
-  have hz₂ : y = homothety x t z, { simp [z, ht', homothety_apply, smul_smul], },
-  rw hz₂,
-  rw mem_interior at hz₁ ⊢,
-  obtain ⟨U, hU₁, hU₂, hU₃⟩ := hz₁,
-  exact ⟨homothety x t '' U,
-         image_subset ⇑(homothety x t) hU₁,
-         homothety_is_open_map x t ht' U hU₂,
-         mem_image_of_mem ⇑(homothety x t) hU₃⟩,
+  have ht' : 0 < t, from one_pos.trans ht,
+  obtain ⟨z, rfl⟩ : ∃ z, homothety x t z = y,
+    from (homeomorph.homothety x (units.mk0 t ht'.ne')).surjective y,
+  suffices : z ∈ interior s,
+  { convert (is_open_map_homothety x t ht'.ne').image_interior_subset _ (mem_image_of_mem _ this) },
+  refine hs.open_segment_interior_closure_subset_interior hx hy _,
+  rw [open_segment_eq_image_line_map],
+  use t⁻¹,
+  simp [← homothety_eq_line_map, ← homothety_mul_apply, ht', ht'.ne', inv_lt_one ht]
 end
 
 /-- If we dilate a convex set about a point in its interior by a scale `t > 1`, the interior of
@@ -273,8 +261,8 @@ begin
   intros x x_in y y_in,
   have H := hconv.segment_subset x_in y_in,
   rw segment_eq_image_line_map at H,
-  exact joined_in.of_line affine_map.line_map_continuous.continuous_on (line_map_apply_zero _ _)
-    (line_map_apply_one _ _) H
+  refine joined_in.of_line _ (line_map_apply_zero x y) (line_map_apply_one _ _) H,
+  convert (continuous_line_map x y).continuous_on, apply_instance
 end
 
 /--

--- a/src/analysis/normed/group/add_torsor.lean
+++ b/src/analysis/normed/group/add_torsor.lean
@@ -5,6 +5,7 @@ Authors: Joseph Myers, Yury Kudryashov
 -/
 import analysis.normed.group.basic
 import linear_algebra.affine_space.midpoint
+import topology.algebra.affine
 
 /-!
 # Torsors of additive normed group actions.
@@ -199,48 +200,7 @@ lemma uniform_continuous_vadd : uniform_continuous (λ x : V × P, x.1 +ᵥ x.2)
 lemma uniform_continuous_vsub : uniform_continuous (λ x : P × P, x.1 -ᵥ x.2) :=
 (lipschitz_with.prod_fst.vsub lipschitz_with.prod_snd).uniform_continuous
 
-@[priority 100] instance normed_add_torsor.to_has_continuous_vadd : has_continuous_vadd V P :=
-{ continuous_vadd := uniform_continuous_vadd.continuous }
-
-lemma continuous_vsub : continuous (λ x : P × P, x.1 -ᵥ x.2) :=
-uniform_continuous_vsub.continuous
-
-lemma filter.tendsto.vsub {l : filter α} {f g : α → P} {x y : P}
-  (hf : tendsto f l (𝓝 x)) (hg : tendsto g l (𝓝 y)) :
-  tendsto (f -ᵥ g) l (𝓝 (x -ᵥ y)) :=
-(continuous_vsub.tendsto (x, y)).comp (hf.prod_mk_nhds hg)
-
-section
-
-variables [topological_space α]
-
-lemma continuous.vsub {f g : α → P} (hf : continuous f) (hg : continuous g) :
-  continuous (f -ᵥ g) :=
-continuous_vsub.comp (hf.prod_mk hg : _)
-
-lemma continuous_at.vsub {f g : α → P}  {x : α} (hf : continuous_at f x) (hg : continuous_at g x) :
-  continuous_at (f -ᵥ g) x :=
-hf.vsub hg
-
-lemma continuous_within_at.vsub {f g : α → P} {x : α} {s : set α}
-  (hf : continuous_within_at f s x) (hg : continuous_within_at g s x) :
-  continuous_within_at (f -ᵥ g) s x :=
-hf.vsub hg
-
-end
-
-section
-
-variables {R : Type*} [ring R] [topological_space R] [module R V] [has_continuous_smul R V]
-
-lemma filter.tendsto.line_map {l : filter α} {f₁ f₂ : α → P} {g : α → R} {p₁ p₂ : P} {c : R}
-  (h₁ : tendsto f₁ l (𝓝 p₁)) (h₂ : tendsto f₂ l (𝓝 p₂)) (hg : tendsto g l (𝓝 c)) :
-  tendsto (λ x, affine_map.line_map (f₁ x) (f₂ x) (g x)) l (𝓝 $ affine_map.line_map p₁ p₂ c) :=
-(hg.smul (h₂.vsub h₁)).vadd h₁
-
-lemma filter.tendsto.midpoint [invertible (2:R)] {l : filter α} {f₁ f₂ : α → P} {p₁ p₂ : P}
-  (h₁ : tendsto f₁ l (𝓝 p₁)) (h₂ : tendsto f₂ l (𝓝 p₂)) :
-  tendsto (λ x, midpoint R (f₁ x) (f₂ x)) l (𝓝 $ midpoint R p₁ p₂) :=
-h₁.line_map h₂ tendsto_const_nhds
-
-end
+@[priority 100] instance normed_add_torsor.to_topological_add_torsor :
+  topological_add_torsor V P :=
+{ continuous_vadd := uniform_continuous_vadd.continuous,
+  continuous_vsub := uniform_continuous_vsub.continuous }

--- a/src/analysis/normed_space/affine_isometry.lean
+++ b/src/analysis/normed_space/affine_isometry.lean
@@ -536,31 +536,3 @@ affine_equiv.point_reflection_midpoint_right x y
 end constructions
 
 end affine_isometry_equiv
-
-include V V₂
-
-/-- If `f` is an affine map, then its linear part is continuous iff `f` is continuous. -/
-lemma affine_map.continuous_linear_iff {f : P →ᵃ[𝕜] P₂} :
-  continuous f.linear ↔ continuous f :=
-begin
-  inhabit P,
-  have : (f.linear : V → V₂) =
-    (affine_isometry_equiv.vadd_const 𝕜 $ f default).to_homeomorph.symm ∘ f ∘
-      (affine_isometry_equiv.vadd_const 𝕜 default).to_homeomorph,
-  { ext v, simp },
-  rw this,
-  simp only [homeomorph.comp_continuous_iff, homeomorph.comp_continuous_iff'],
-end
-
-/-- If `f` is an affine map, then its linear part is an open map iff `f` is an open map. -/
-lemma affine_map.is_open_map_linear_iff {f : P →ᵃ[𝕜] P₂} :
-  is_open_map f.linear ↔ is_open_map f :=
-begin
-  inhabit P,
-  have : (f.linear : V → V₂) =
-    (affine_isometry_equiv.vadd_const 𝕜 $ f default).to_homeomorph.symm ∘ f ∘
-      (affine_isometry_equiv.vadd_const 𝕜 default).to_homeomorph,
-  { ext v, simp },
-  rw this,
-  simp only [homeomorph.comp_is_open_map_iff, homeomorph.comp_is_open_map_iff'],
-end

--- a/src/analysis/normed_space/finite_dimension.lean
+++ b/src/analysis/normed_space/finite_dimension.lean
@@ -241,13 +241,12 @@ end
 theorem affine_map.continuous_of_finite_dimensional {PE PF : Type*}
   [metric_space PE] [normed_add_torsor E PE] [metric_space PF] [normed_add_torsor F PF]
   [finite_dimensional 𝕜 E] (f : PE →ᵃ[𝕜] PF) : continuous f :=
-affine_map.continuous_linear_iff.1 f.linear.continuous_of_finite_dimensional
+(affine_map.continuous_linear_iff _).1 f.linear.continuous_of_finite_dimensional
 
 lemma continuous_linear_map.continuous_det :
   continuous (λ (f : E →L[𝕜] E), f.det) :=
 begin
   change continuous (λ (f : E →L[𝕜] E), (f : E →ₗ[𝕜] E).det),
-  classical,
   by_cases h : ∃ (s : finset E), nonempty (basis ↥s 𝕜 E),
   { rcases h with ⟨s, ⟨b⟩⟩,
     haveI : finite_dimensional 𝕜 E := finite_dimensional.of_finset_basis b,
@@ -258,9 +257,7 @@ begin
     { change continuous ((linear_map.to_matrix b b).to_linear_map.comp
         (continuous_linear_map.coe_lm 𝕜)),
       exact linear_map.continuous_of_finite_dimensional _ },
-    convert A.matrix_det,
-    ext f,
-    congr },
+    exact A.matrix_det },
   { unfold linear_map.det,
     simpa only [h, monoid_hom.one_apply, dif_neg, not_false_iff] using continuous_const }
 end

--- a/src/analysis/normed_space/finite_dimension.lean
+++ b/src/analysis/normed_space/finite_dimension.lean
@@ -241,7 +241,7 @@ end
 theorem affine_map.continuous_of_finite_dimensional {PE PF : Type*}
   [metric_space PE] [normed_add_torsor E PE] [metric_space PF] [normed_add_torsor F PF]
   [finite_dimensional 𝕜 E] (f : PE →ᵃ[𝕜] PF) : continuous f :=
-(affine_map.continuous_linear_iff _).1 f.linear.continuous_of_finite_dimensional
+affine_map.continuous_linear_iff.1 f.linear.continuous_of_finite_dimensional
 
 lemma continuous_linear_map.continuous_det :
   continuous (λ (f : E →L[𝕜] E), f.det) :=

--- a/src/linear_algebra/affine_space/affine_map.lean
+++ b/src/linear_algebra/affine_space/affine_map.lean
@@ -594,9 +594,13 @@ by { ext p, simp [homothety_apply] }
 
 @[simp] lemma homothety_apply_same (c : P1) (r : k) : homothety c r c = c := line_map_same_apply c r
 
+lemma homothety_mul_apply (c : P1) (r₁ r₂ : k) (p : P1) :
+  homothety c (r₁ * r₂) p = homothety c r₁ (homothety c r₂ p) :=
+by simp [homothety_apply, mul_smul]
+
 lemma homothety_mul (c : P1) (r₁ r₂ : k) :
   homothety c (r₁ * r₂) = (homothety c r₁).comp (homothety c r₂) :=
-by { ext p, simp [homothety_apply, mul_smul] }
+ext $ homothety_mul_apply c r₁ r₂
 
 @[simp] lemma homothety_zero (c : P1) : homothety c (0:k) = const k P1 c :=
 by { ext p, simp [homothety_apply] }

--- a/src/linear_algebra/affine_space/affine_map.lean
+++ b/src/linear_algebra/affine_space/affine_map.lean
@@ -112,17 +112,22 @@ points. -/
   f.linear (p1 -ᵥ p2) = f p1 -ᵥ f p2 :=
 by conv_rhs { rw [←vsub_vadd p1 p2, map_vadd, vadd_vsub] }
 
+lemma coe_linear (f : P1 →ᵃ[k] P2) (p : P1) :
+  ⇑f.linear = λ v, f (v +ᵥ p) -ᵥ f p :=
+funext $ λ v, by rw [f.map_vadd, vadd_vsub]
+
+lemma coe_of_linear (f : P1 →ᵃ[k] P2) (p : P1) :
+  (f : P1 → P2) = λ p', f.linear (p' -ᵥ p) +ᵥ f p :=
+funext $ λ p', by rw [linear_map_vsub, vsub_vadd]
+
 /-- Two affine maps are equal if they coerce to the same function. -/
 @[ext] lemma ext {f g : P1 →ᵃ[k] P2} (h : ∀ p, f p = g p) : f = g :=
 begin
-  rcases f with ⟨f, f_linear, f_add⟩,
-  rcases g with ⟨g, g_linear, g_add⟩,
-  have : f = g := funext h,
-  subst g,
-  congr' with v,
-  cases (add_torsor.nonempty : nonempty P1) with p,
-  apply vadd_right_cancel (f p),
-  erw [← f_add, ← g_add]
+  inhabit P1,
+  replace h : (f : P1 → P2) = g, from funext h,
+  have H : f.linear = g.linear,
+    by simp only [fun_like.ext'_iff, coe_linear _ default, h],
+  cases f, cases g, congr'
 end
 
 lemma ext_iff {f g : P1 →ᵃ[k] P2} : f = g ↔ ∀ p, f p = g p := ⟨λ h p, h ▸ rfl, ext⟩

--- a/src/topology/algebra/affine.lean
+++ b/src/topology/algebra/affine.lean
@@ -127,7 +127,7 @@ variables [ring R] [module R E] [module R F]
 include E F
 
 /-- The linear part of an affine map is continuous iff the affine map is continuous. -/
-lemma affine_map.continuous_linear_iff (f : PE →ᵃ[R] PF) : continuous f.linear ↔ continuous f :=
+lemma affine_map.continuous_linear_iff {f : PE →ᵃ[R] PF} : continuous f.linear ↔ continuous f :=
 begin
   inhabit PE,
   have : ⇑f.linear = (homeomorph.vadd_const (f default)).symm ∘ f ∘ (homeomorph.vadd_const default),
@@ -136,7 +136,7 @@ begin
 end
 
 /-- The linear part of an affine map is an open map iff the affine map is open. -/
-lemma affine_map.is_open_map_linear_iff (f : PE →ᵃ[R] PF) : is_open_map f.linear ↔ is_open_map f :=
+lemma affine_map.is_open_map_linear_iff {f : PE →ᵃ[R] PF} : is_open_map f.linear ↔ is_open_map f :=
 begin
   inhabit PE,
   have : ⇑f.linear = (homeomorph.vadd_const (f default)).symm ∘ f ∘ (homeomorph.vadd_const default),

--- a/src/topology/algebra/affine.lean
+++ b/src/topology/algebra/affine.lean
@@ -3,7 +3,8 @@ Copyright (c) 2020 Frédéric Dupuis. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Frédéric Dupuis
 -/
-import linear_algebra.affine_space.affine_map
+import linear_algebra.affine_space.affine_equiv
+import linear_algebra.affine_space.midpoint
 import topology.algebra.group
 import topology.algebra.mul_action
 
@@ -18,66 +19,274 @@ we do have some results in this direction under the assumption that the topologi
 (semi)norms.
 -/
 
-namespace affine_map
+open filter affine_map
+open_locale topological_space
 
-variables {R E F : Type*}
-variables [add_comm_group E] [topological_space E]
-variables [add_comm_group F] [topological_space F] [topological_add_group F]
+variables {α X : Type*} [topological_space X]
+
+class topological_add_torsor (E : out_param Type*) [out_param (topological_space E)]
+  [out_param (add_group E)] (P : Type*) [topological_space P]
+  extends add_torsor E P,  has_continuous_vadd E P :=
+(continuous_vsub : continuous (λ p : P × P, p.1 -ᵥ p.2))
+
+@[priority 200]
+instance topological_add_group.to_topological_add_torsor {G : Type*} [add_group G]
+  [topological_space G] [topological_add_group G] : topological_add_torsor G G :=
+⟨continuous_sub⟩
+
+section add_torsor
+
+variables {E P : Type*} [topological_space E] [add_group E] [topological_space P]
+  [topological_add_torsor E P]
+
+include E
+
+lemma filter.tendsto.vsub {f g : α → P} {l : filter α} {x y : P} (hf : tendsto f l (𝓝 x))
+  (hg : tendsto g l (𝓝 y)) : tendsto (λ x, f x -ᵥ g x) l (𝓝 (x -ᵥ y)) :=
+(topological_add_torsor.continuous_vsub.tendsto (x, y)).comp (hf.prod_mk_nhds hg)
+
+variables {f g : X → P} {s : set X} {a : X}
+
+lemma continuous_at.vsub (hf : continuous_at f a) (hg : continuous_at g a) :
+  continuous_at (λ x, f x -ᵥ g x) a :=
+hf.vsub hg
+
+lemma continuous_within_at.vsub (hf : continuous_within_at f s a)
+  (hg : continuous_within_at g s a) : continuous_within_at (λ x, f x -ᵥ g x) s a :=
+hf.vsub hg
+
+lemma continuous_on.vsub (hf : continuous_on f s) (hg : continuous_on g s) :
+  continuous_on (λ x, f x -ᵥ g x) s :=
+λ a ha, (hf a ha).vsub (hg a ha)
+
+@[continuity] lemma continuous.vsub (hf : continuous f) (hg : continuous g) :
+  continuous (λ x, f x -ᵥ g x) :=
+continuous.comp ‹topological_add_torsor E P›.continuous_vsub (hf.prod_mk hg)
+
+section
+
+variables (E P)
+include P
+
+lemma topological_add_torsor.to_topological_add_group : topological_add_group E :=
+begin
+  inhabit P,
+  refine topological_add_group_iff_has_continuous_sub.2 ⟨_⟩,
+  simpa only [← vadd_vsub_vadd_cancel_right _ _ (default : P)]
+    using (continuous_fst.vadd continuous_const).vsub (continuous_snd.vadd continuous_const)
+end
+
+end
+
+namespace homeomorph
+
+/-- `equiv.vadd_const` as a homeomorphism. -/
+@[simps {fully_applied := ff}] def vadd_const (p : P) : E ≃ₜ P :=
+{ to_equiv := equiv.vadd_const p,
+  continuous_to_fun := continuous_id.vadd continuous_const,
+  continuous_inv_fun := continuous_id.vsub continuous_const }
+
+/-- `equiv.const_vsub` as a homeomorphism. -/
+@[simps {fully_applied := ff}] def const_vsub (p : P) : P ≃ₜ E :=
+{ to_equiv := equiv.const_vsub p,
+  continuous_to_fun := continuous_const.vsub continuous_id,
+  continuous_inv_fun :=
+    begin
+      haveI := topological_add_torsor.to_topological_add_group E P,
+      exact continuous_neg.vadd continuous_const
+    end }
+
+/-- `equiv.point_reflection` as a homeomorphism. -/
+@[simps apply {fully_applied := ff}] def point_reflection (x : P) : P ≃ₜ P :=
+(const_vsub x).trans (vadd_const x)
+
+@[simp] lemma point_reflection_symm (x : P) : (point_reflection x).symm = point_reflection x :=
+by { ext y, simp [point_reflection] }
+
+variable (P)
+
+/-- `equiv.const_vadd` as a homeomorphism. -/
+@[simps {fully_applied := ff}] def const_vadd (v : E) : P ≃ₜ P :=
+{ to_equiv := equiv.const_vadd P v,
+  continuous_to_fun := continuous_const.vadd continuous_id,
+  continuous_inv_fun := continuous_const.vadd continuous_id }
+
+end homeomorph
+
+end add_torsor
+
+variables {R E PE F PF : Type*}
+variables [add_comm_group E] [topological_space E] [topological_space PE]
+  [topological_add_torsor E PE]
+variables [add_comm_group F] [topological_space F] [topological_space PF]
+  [topological_add_torsor F PF]
 
 section ring
 
 variables [ring R] [module R E] [module R F]
+include E F
 
-/-- An affine map is continuous iff its underlying linear map is continuous. See also
-`affine_map.continuous_linear_iff`. -/
-lemma continuous_iff {f : E →ᵃ[R] F} :
-  continuous f ↔ continuous f.linear :=
+/-- The linear part of an affine map is continuous iff the affine map is continuous. -/
+lemma affine_map.continuous_linear_iff (f : PE →ᵃ[R] PF) : continuous f.linear ↔ continuous f :=
 begin
-  split,
-  { intro hc,
-    rw decomp' f,
-    have := hc.sub continuous_const,
-    exact this, },
-  { intro hc,
-    rw decomp f,
-    have := hc.add continuous_const,
-    exact this }
+  inhabit PE,
+  have : ⇑f.linear = (homeomorph.vadd_const (f default)).symm ∘ f ∘ (homeomorph.vadd_const default),
+    from f.coe_linear default,
+  rw [this, homeomorph.comp_continuous_iff, homeomorph.comp_continuous_iff']
 end
 
-/-- The line map is continuous. -/
-@[continuity]
-lemma line_map_continuous [topological_space R] [has_continuous_smul R F] {p v : F} :
-  continuous ⇑(line_map p v : R →ᵃ[R] F) :=
-continuous_iff.mpr $ (continuous_id.smul continuous_const).add $
-  @continuous_const _ _ _ _ (0 : F)
+variables [topological_space R] [has_continuous_smul R E]
+omit F
+
+lemma filter.tendsto.line_map {f₁ f₂ : α → PE} {g : α → R} {p₁ p₂ : PE} {c : R} {l : filter α}
+  (h₁ : tendsto f₁ l (𝓝 p₁)) (h₂ : tendsto f₂ l (𝓝 p₂)) (hg : tendsto g l (𝓝 c)) :
+  tendsto (λ x, line_map (f₁ x) (f₂ x) (g x)) l (𝓝 $ line_map p₁ p₂ c) :=
+(hg.smul (h₂.vsub h₁)).vadd h₁
+
+lemma continuous_at.line_map {f₁ f₂ : X → PE} {g : X → R} {a : X}
+  (h₁ : continuous_at f₁ a) (h₂ : continuous_at f₂ a) (hg : continuous_at g a) :
+  continuous_at (λ x, line_map (f₁ x) (f₂ x) (g x)) a :=
+h₁.line_map h₂ hg
+
+lemma continuous_within_at.line_map {f₁ f₂ : X → PE} {g : X → R} {s : set X} {a : X}
+  (h₁ : continuous_within_at f₁ s a) (h₂ : continuous_within_at f₂ s a)
+  (hg : continuous_within_at g s a) :
+  continuous_within_at (λ x, line_map (f₁ x) (f₂ x) (g x)) s a :=
+h₁.line_map h₂ hg
+
+lemma continuous_on.line_map {f₁ f₂ : X → PE} {g : X → R} {s : set X}
+  (h₁ : continuous_on f₁ s) (h₂ : continuous_on f₂ s) (hg : continuous_on g s) :
+  continuous_on (λ x, line_map (f₁ x) (f₂ x) (g x)) s :=
+λ a ha, (h₁ a ha).line_map (h₂ a ha) (hg a ha)
+
+@[continuity] lemma continuous.line_map {f₁ f₂ : X → PE} {g : X → R} (h₁ : continuous f₁)
+  (h₂ : continuous f₂) (hg : continuous g) :
+  continuous (λ x, line_map (f₁ x) (f₂ x) (g x)) :=
+(hg.smul (h₂.vsub h₁)).vadd h₁
 
 end ring
 
-section comm_ring
+section midpoint
 
-variables [comm_ring R] [module R F] [has_continuous_const_smul R F]
+variables [ring R] [invertible (2 : R)] [module R E] [has_continuous_const_smul R E]
+include E
 
-@[continuity]
-lemma homothety_continuous (x : F) (t : R) : continuous $ homothety x t :=
-begin
-  suffices : ⇑(homothety x t) = λ y, t • (y - x) + x, { rw this, continuity, },
-  ext y,
-  simp [homothety_apply],
-end
+lemma filter.tendsto.midpoint {f g : α → PE} {l : filter α} {a b : PE} (hf : tendsto f l (𝓝 a))
+  (hg : tendsto g l (𝓝 b)) :
+  tendsto (λ x, midpoint R (f x) (g x)) l (𝓝 (midpoint R a b)) :=
+((hg.vsub hf).const_smul _).vadd hf
 
-end comm_ring
+variables {f g : X → PE} {s : set X} {a : X}
 
-section field
+lemma continuous_at.midpoint (hf : continuous_at f a) (hg : continuous_at g a) :
+  continuous_at (λ x, midpoint R (f x) (g x)) a :=
+hf.midpoint hg
 
-variables [field R] [module R F] [has_continuous_const_smul R F]
+lemma continuous_within_at.midpoint (hf : continuous_within_at f s a)
+  (hg : continuous_within_at g s a) :
+  continuous_within_at (λ x, midpoint R (f x) (g x)) s a :=
+hf.midpoint hg
 
-lemma homothety_is_open_map (x : F) (t : R) (ht : t ≠ 0) : is_open_map $ homothety x t :=
-begin
-  apply is_open_map.of_inverse (homothety_continuous x t⁻¹);
-  intros e;
-  simp [← affine_map.comp_apply, ← homothety_mul, ht],
-end
+lemma continuous_on.midpoint (hf : continuous_on f s) (hg : continuous_on g s) :
+  continuous_on (λ x, midpoint R (f x) (g x)) s :=
+λ a ha, (hf a ha).midpoint (hg a ha)
 
-end field
+lemma continuous.midpoint (hf : continuous f) (hg : continuous g) :
+  continuous (λ x, midpoint R (f x) (g x)) :=
+continuous_iff_continuous_at.2 $ λ x, hf.continuous_at.midpoint hg.continuous_at
 
-end affine_map
+end midpoint
+
+section midpoint
+
+variables [ring R] [invertible (2 : R)] [module R E] [has_continuous_const_smul R E]
+  [has_continuous_add E]
+include E
+
+lemma filter.tendsto.midpoint' {f g : α → E} {l : filter α} {a b : E} (hf : tendsto f l (𝓝 a))
+  (hg : tendsto g l (𝓝 b)) :
+  tendsto (λ x, midpoint R (f x) (g x)) l (𝓝 (midpoint R a b)) :=
+by simpa only [midpoint_eq_smul_add] using (hf.add hg).const_smul _
+
+variables {f g : X → E} {s : set X} {a : X}
+
+lemma continuous_at.midpoint' (hf : continuous_at f a) (hg : continuous_at g a) :
+  continuous_at (λ x, midpoint R (f x) (g x)) a :=
+hf.midpoint' hg
+
+lemma continuous_within_at.midpoint' (hf : continuous_within_at f s a)
+  (hg : continuous_within_at g s a) :
+  continuous_within_at (λ x, midpoint R (f x) (g x)) s a :=
+hf.midpoint' hg
+
+lemma continuous_on.midpoint' (hf : continuous_on f s) (hg : continuous_on g s) :
+  continuous_on (λ x, midpoint R (f x) (g x)) s :=
+λ a ha, (hf a ha).midpoint' (hg a ha)
+
+lemma continuous.midpoint' (hf : continuous f) (hg : continuous g) :
+  continuous (λ x, midpoint R (f x) (g x)) :=
+continuous_iff_continuous_at.2 $ λ x, hf.continuous_at.midpoint' hg.continuous_at
+
+end midpoint
+
+section homothety
+
+variables [topological_space R] [comm_ring R] [module R E] [has_continuous_smul R E]
+include E
+
+lemma filter.tendsto.homothety {f₁ f₂ : α → PE} {g : α → R} {p₁ p₂ : PE} {c : R} {l : filter α}
+  (h₁ : tendsto f₁ l (𝓝 p₁)) (hg : tendsto g l (𝓝 c)) (h₂ : tendsto f₂ l (𝓝 p₂)) :
+  tendsto (λ x, homothety (f₁ x) (g x) (f₂ x)) l (𝓝 $ homothety p₁ c p₂) :=
+h₁.line_map h₂ hg
+
+lemma continuous_at.homothety {f₁ f₂ : X → PE} {g : X → R} {a : X}
+  (h₁ : continuous_at f₁ a) (hg : continuous_at g a) (h₂ : continuous_at f₂ a) :
+  continuous_at (λ x, homothety (f₁ x) (g x) (f₂ x)) a :=
+h₁.homothety hg h₂
+
+lemma continuous_within_at.homothety {f₁ f₂ : X → PE} {g : X → R} {s : set X} {a : X}
+  (h₁ : continuous_within_at f₁ s a) (hg : continuous_within_at g s a)
+  (h₂ : continuous_within_at f₂ s a) :
+  continuous_within_at (λ x, homothety (f₁ x) (g x) (f₂ x)) s a :=
+h₁.homothety hg h₂
+
+lemma continuous_on.homothety {f₁ f₂ : X → PE} {g : X → R} {s : set X}
+  (h₁ : continuous_on f₁ s) (hg : continuous_on g s) (h₂ : continuous_on f₂ s) :
+  continuous_on (λ x, homothety (f₁ x) (g x) (f₂ x)) s :=
+h₁.line_map h₂ hg
+
+@[continuity] lemma continuous.homothety {f₁ f₂ : X → PE} {g : X → R} (h₁ : continuous f₁)
+  (hg : continuous g) (h₂ : continuous f₂) :
+  continuous (λ x, homothety (f₁ x) (g x) (f₂ x)) :=
+h₁.line_map h₂ hg
+
+end homothety
+
+section const_smul
+
+variables [comm_ring R] [module R E] [has_continuous_const_smul R E]
+include E
+
+@[continuity] lemma continuous_homothety {c : PE} {t : R} : continuous (homothety c t) :=
+show continuous (λ x, t • (x -ᵥ c) +ᵥ c),
+from ((continuous_id.vsub continuous_const).const_smul _).vadd continuous_const
+
+/-- Homothety about `c` with scale factor `t : Rˣ` as a homeomorphism. -/
+@[simps apply {fully_applied := ff}] def homeomorph.homothety (c : PE) (t : Rˣ) : PE ≃ₜ PE :=
+{ to_equiv := affine_equiv.homothety_units_mul_hom c t,
+  continuous_to_fun := continuous_homothety,
+  continuous_inv_fun := continuous_homothety }
+
+@[simp] lemma homeomorph.homothety_symm (c : PE) (t : Rˣ) :
+  (homeomorph.homothety c t).symm = homeomorph.homothety c t⁻¹ :=
+rfl
+
+lemma is_unit.is_open_map_homothety {t : R} (ht : is_unit t) (c : PE) :
+  is_open_map (homothety c t) :=
+(homeomorph.homothety c ht.unit).is_open_map
+
+lemma is_open_map_homothety {k : Type*} [field k] [module k E] [has_continuous_const_smul k E]
+  (c : PE) (t : k) (ht : t ≠ 0) : is_open_map (homothety c t) :=
+(is_unit.mk0 t ht).is_open_map_homothety c
+
+end const_smul

--- a/src/topology/algebra/affine.lean
+++ b/src/topology/algebra/affine.lean
@@ -164,6 +164,9 @@ lemma continuous_on.line_map {f₁ f₂ : X → PE} {g : X → R} {s : set X}
   continuous (λ x, line_map (f₁ x) (f₂ x) (g x)) :=
 (hg.smul (h₂.vsub h₁)).vadd h₁
 
+lemma continuous_line_map (p₁ p₂ : PE) : continuous ⇑(line_map p₁ p₂ : R →ᵃ[R] PE) :=
+continuous_const.line_map continuous_const continuous_id
+
 end ring
 
 section midpoint

--- a/src/topology/algebra/affine.lean
+++ b/src/topology/algebra/affine.lean
@@ -26,7 +26,7 @@ variables {α X : Type*} [topological_space X]
 
 class topological_add_torsor (E : out_param Type*) [out_param (topological_space E)]
   [out_param (add_group E)] (P : Type*) [topological_space P]
-  extends add_torsor E P,  has_continuous_vadd E P :=
+  extends add_torsor E P, has_continuous_vadd E P :=
 (continuous_vsub : continuous (λ p : P × P, p.1 -ᵥ p.2))
 
 @[priority 200]

--- a/src/topology/algebra/affine.lean
+++ b/src/topology/algebra/affine.lean
@@ -135,6 +135,15 @@ begin
   rw [this, homeomorph.comp_continuous_iff, homeomorph.comp_continuous_iff']
 end
 
+/-- The linear part of an affine map is an open map iff the affine map is open. -/
+lemma affine_map.is_open_map_linear_iff (f : PE →ᵃ[R] PF) : is_open_map f.linear ↔ is_open_map f :=
+begin
+  inhabit PE,
+  have : ⇑f.linear = (homeomorph.vadd_const (f default)).symm ∘ f ∘ (homeomorph.vadd_const default),
+    from f.coe_linear default,
+  rw [this, homeomorph.comp_is_open_map_iff, homeomorph.comp_is_open_map_iff']
+end
+
 variables [topological_space R] [has_continuous_smul R E]
 omit F
 

--- a/src/topology/algebra/group.lean
+++ b/src/topology/algebra/group.lean
@@ -321,7 +321,8 @@ section topological_group
 
 A topological group is a group in which the multiplication and inversion operations are
 continuous. Topological additive groups are defined in the same way. Equivalently, we can require
-that the division operation `λ x y, x * y⁻¹` (resp., subtraction) is continuous.
+that the division operation `λ x y, x * y⁻¹` (resp., subtraction) is continuous,
+see `topological_group_iff_has_continuous_div`.
 -/
 
 /-- A topological (additive) group is a group in which the addition and negation operations are
@@ -861,6 +862,20 @@ lemma continuous_on.div' (hf : continuous_on f s) (hg : continuous_on g s) :
 λ x hx, (hf x hx).div' (hg x hx)
 
 end has_continuous_div
+
+@[to_additive]
+lemma topological_group_iff_has_continuous_div {G : Type*} [topological_space G] [group G] :
+  topological_group G ↔ has_continuous_div G :=
+begin
+  refine ⟨@topological_group.to_has_continuous_div _ _ _, _⟩,
+  introI,
+  haveI : has_continuous_inv G,
+  { constructor, simpa only [← one_div] using continuous_const.div' continuous_id },
+  haveI : has_continuous_mul G,
+  { constructor, simpa only [← div_inv_eq_mul] using continuous_fst.div' continuous_snd.inv },
+  constructor
+end
+
 
 section div_in_topological_group
 variables [group G] [topological_space G] [topological_group G]

--- a/src/topology/homeomorph.lean
+++ b/src/topology/homeomorph.lean
@@ -87,6 +87,9 @@ protected def trans (h₁ : α ≃ₜ β) (h₂ : β ≃ₜ γ) : α ≃ₜ γ :
 
 @[simp] lemma trans_apply (h₁ : α ≃ₜ β) (h₂ : β ≃ₜ γ) (a : α) : h₁.trans h₂ a = h₂ (h₁ a) := rfl
 
+@[simp] lemma symm_trans (h₁ : α ≃ₜ β) (h₂ : β ≃ₜ γ) :
+  (h₁.trans h₂).symm = h₂.symm.trans h₁.symm := rfl
+
 @[simp] lemma homeomorph_mk_coe_symm (a : equiv α β) (b c) :
   ((homeomorph.mk a b c).symm : β → α) = a.symm :=
 rfl

--- a/src/topology/urysohns_lemma.lean
+++ b/src/topology/urysohns_lemma.lean
@@ -220,7 +220,7 @@ lemma lim_eq_midpoint (c : CU X) (x : X) :
 begin
   refine tendsto_nhds_unique (c.tendsto_approx_at_top x) ((tendsto_add_at_top_iff_nat 1).1 _),
   simp only [approx],
-  exact (c.left.tendsto_approx_at_top x).midpoint (c.right.tendsto_approx_at_top x)
+  exact (c.left.tendsto_approx_at_top x).midpoint' (c.right.tendsto_approx_at_top x)
 end
 
 lemma approx_le_lim (c : CU X) (x : X) (n : ℕ) : c.approx n x ≤ c.lim x :=


### PR DESCRIPTION
Define `topological_add_torsor`. The main reason is to prove lemmas like `affine_map.continuous_linear_iff` and `continuous_line_map` under assumptions that are automatically satisfied both by a TVS and a normed add torsor.

---

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
