### PR TITLE
[Merged by Bors] - fix(category_theory/monoidal): increase class search depth in coherence tactic

### DIFF
--- a/src/category_theory/monoidal/braided.lean
+++ b/src/category_theory/monoidal/braided.lean
@@ -412,8 +412,6 @@ begin
                       tensor_comp, tensor_comp] },
 end
 
-set_option class.instance_max_depth 64
-
 lemma tensor_associativity (X₁ X₂ Y₁ Y₂ Z₁ Z₂ : C) :
     (tensor_μ C (X₁, X₂) (Y₁, Y₂) ⊗ 𝟙 (Z₁ ⊗ Z₂)) ≫
     tensor_μ C (X₁ ⊗ Y₁, X₂ ⊗ Y₂) (Z₁, Z₂) ≫

--- a/src/category_theory/monoidal/coherence.lean
+++ b/src/category_theory/monoidal/coherence.lean
@@ -241,9 +241,11 @@ where `f₀` and `g₀` are maximal prefixes of `f` and `g` (possibly after reas
 which are "liftable" (i.e. expressible as compositions of unitors and associators).
 -/
 meta def liftable_prefixes : tactic unit :=
-try `[simp only [monoidal_comp, category_theory.category.assoc]] >>
-  `[apply (cancel_epi (𝟙 _)).1; try { apply_instance }] >>
-  try `[simp only [tactic.coherence.assoc_lift_hom]]
+do
+  o ← get_options, set_options $ o.set_nat `class.instance_max_depth 128,
+  try `[simp only [monoidal_comp, category_theory.category.assoc]] >>
+    `[apply (cancel_epi (𝟙 _)).1; try { apply_instance }] >>
+    try `[simp only [tactic.coherence.assoc_lift_hom]]
 
 example {W X Y Z : C} (f : Y ⟶ Z) (g) (w : false) : (λ_ _).hom ≫ f = g :=
 begin


### PR DESCRIPTION
There were two places, not just one, where the class search depth needs to be increased.



---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
