### PR TITLE
[Merged by Bors] - chore(order/bounded_order): Match the `with_bot` and `with_top` API

### DIFF
--- a/src/algebra/cubic_discriminant.lean
+++ b/src/algebra/cubic_discriminant.lean
@@ -220,7 +220,7 @@ begin
   apply (to_finset_card_le P.to_poly.roots).trans,
   by_cases hP : P.to_poly = 0,
   { exact (card_roots' P.to_poly).trans (by { rw [hP, nat_degree_zero], exact zero_le 3 }) },
-  { simpa only [← @with_bot.coe_le_coe _ _ _ 3] using (card_roots hP).trans degree_cubic_le }
+  { exact with_bot.coe_le_coe.1 ((card_roots hP).trans degree_cubic_le) }
 end
 
 end extension

--- a/src/analysis/box_integral/partition/basic.lean
+++ b/src/analysis/box_integral/partition/basic.lean
@@ -344,7 +344,7 @@ lemma of_with_bot_le {boxes : finset (with_bot (box ι))}
   (H : ∀ J ∈ boxes, J ≠ ⊥ → ∃ J' ∈ π, J ≤ ↑J') :
   of_with_bot boxes le_of_mem pairwise_disjoint ≤ π :=
 have ∀ (J : box ι), ↑J ∈ boxes → ∃ J' ∈ π, J ≤ J',
-  from λ J hJ, by simpa only [with_bot.coe_le_coe] using H J hJ (with_bot.coe_ne_bot J),
+  from λ J hJ, by simpa only [with_bot.coe_le_coe] using H J hJ with_bot.coe_ne_bot,
 by simpa [of_with_bot, le_def]
 
 lemma le_of_with_bot {boxes : finset (with_bot (box ι))}
@@ -355,7 +355,7 @@ lemma le_of_with_bot {boxes : finset (with_bot (box ι))}
 begin
   intros J hJ,
   rcases H J hJ with ⟨J', J'mem, hle⟩,
-  lift J' to box ι using ne_bot_of_le_ne_bot (with_bot.coe_ne_bot _) hle,
+  lift J' to box ι using ne_bot_of_le_ne_bot with_bot.coe_ne_bot hle,
   exact ⟨J', mem_of_with_bot.2 J'mem, with_bot.coe_le_coe.1 hle⟩
 end
 
@@ -368,7 +368,7 @@ lemma of_with_bot_mono {boxes₁ : finset (with_bot (box ι))}
   (H : ∀ J ∈ boxes₁, J ≠ ⊥ → ∃ J' ∈ boxes₂, J ≤ J') :
   of_with_bot boxes₁ le_of_mem₁ pairwise_disjoint₁ ≤
     of_with_bot boxes₂ le_of_mem₂ pairwise_disjoint₂ :=
-le_of_with_bot _ $ λ J hJ, H J (mem_of_with_bot.1 hJ) (with_bot.coe_ne_bot _)
+le_of_with_bot _ $ λ J hJ, H J (mem_of_with_bot.1 hJ) with_bot.coe_ne_bot
 
 lemma sum_of_with_bot {M : Type*} [add_comm_monoid M]
   (boxes : finset (with_bot (box ι)))

--- a/src/analysis/box_integral/partition/split.lean
+++ b/src/analysis/box_integral/partition/split.lean
@@ -126,7 +126,7 @@ lemma split_lower_ne_split_upper (I : box ι) (i : ι) (x : ℝ) :
   I.split_lower i x ≠ I.split_upper i x :=
 begin
   cases le_or_lt x (I.lower i),
-  { rw [split_upper_eq_self.2 h, split_lower_eq_bot.2 h], exact with_bot.bot_ne_coe _ },
+  { rw [split_upper_eq_self.2 h, split_lower_eq_bot.2 h], exact with_bot.bot_ne_coe },
   { refine (disjoint_split_lower_split_upper I i x).ne _,
     rwa [ne.def, split_lower_eq_bot, not_le] }
 end

--- a/src/linear_algebra/lagrange.lean
+++ b/src/linear_algebra/lagrange.lean
@@ -201,11 +201,11 @@ begin
   { rw [degree_mul, degree_C (inv_ne_zero (sub_ne_zero.2 hxy.symm)), zero_add],
     refine lt_of_le_of_lt (degree_add_le _ _) (max_lt _ _),
     { rw [degree_mul, degree_X_sub_C],
-      convert (with_bot.add_lt_add_iff_left (with_bot.coe_ne_bot _)).2
+      convert (with_bot.add_lt_add_iff_left with_bot.coe_ne_bot).2
         (degree_interpolate_erase s f hx),
       simp [nat.one_add, nat.sub_one, nat.succ_pred_eq_of_pos (finset.card_pos.2 ⟨x, hx⟩)] },
     { rw [degree_mul, ←neg_sub, degree_neg, degree_X_sub_C],
-      convert (with_bot.add_lt_add_iff_left (with_bot.coe_ne_bot _)).2
+      convert (with_bot.add_lt_add_iff_left with_bot.coe_ne_bot).2
         (degree_interpolate_erase s f hy),
       simp [nat.one_add, nat.sub_one, nat.succ_pred_eq_of_pos (finset.card_pos.2 ⟨y, hy⟩)] } },
   { by_cases hzx : z = x,

--- a/src/order/bounded_order.lean
+++ b/src/order/bounded_order.lean
@@ -477,27 +477,28 @@ end lift
 def with_bot (α : Type*) := option α
 
 namespace with_bot
+variables {a b : α}
 
-meta instance {α} [has_to_format α] : has_to_format (with_bot α) :=
+meta instance [has_to_format α] : has_to_format (with_bot α) :=
 { to_format := λ x,
   match x with
   | none := "⊥"
   | (some x) := to_fmt x
   end }
 
-instance {α : Type u} [has_repr α] : has_repr (with_bot α) :=
+instance [has_repr α] : has_repr (with_bot α) :=
 ⟨λ o, match o with | none := "⊥" | (some a) := "↑" ++ repr a end⟩
 
 instance : has_coe_t α (with_bot α) := ⟨some⟩
-instance has_bot : has_bot (with_bot α) := ⟨none⟩
+instance : has_bot (with_bot α) := ⟨none⟩
 
 instance : inhabited (with_bot α) := ⟨⊥⟩
 
 lemma none_eq_bot : (none : with_bot α) = (⊥ : with_bot α) := rfl
 lemma some_eq_coe (a : α) : (some a : with_bot α) = (↑a : with_bot α) := rfl
 
-@[simp] theorem bot_ne_coe (a : α) : ⊥ ≠ (a : with_bot α) .
-@[simp] theorem coe_ne_bot (a : α) : (a : with_bot α) ≠ ⊥ .
+@[simp] lemma bot_ne_coe : ⊥ ≠ (a : with_bot α) .
+@[simp] lemma coe_ne_bot : (a : with_bot α) ≠ ⊥ .
 
 /-- Recursor for `with_bot` using the preferred forms `⊥` and `↑a`. -/
 @[elab_as_eliminator]
@@ -505,9 +506,7 @@ def rec_bot_coe {C : with_bot α → Sort*} (h₁ : C ⊥) (h₂ : Π (a : α), 
   Π (n : with_bot α), C n :=
 option.rec h₁ h₂
 
-@[norm_cast]
-theorem coe_eq_coe {a b : α} : (a : with_bot α) = b ↔ a = b :=
-by rw [← option.some.inj_eq a b]; refl
+@[norm_cast] lemma coe_eq_coe : (a : with_bot α) = b ↔ a = b := option.some_inj
 
 -- the `by exact` here forces the type of the equality to be `@eq (with_bot α)`
 @[simp] lemma map_bot (f : α → β) :
@@ -515,59 +514,100 @@ by rw [← option.some.inj_eq a b]; refl
 lemma map_coe (f : α → β) (a : α) :
   (by exact option.map f (a : with_bot α)) = (f a : with_bot β) := rfl
 
-lemma ne_bot_iff_exists {x : with_bot α} : x ≠ ⊥ ↔ ∃ (a : α), ↑a = x :=
-option.ne_none_iff_exists
+lemma ne_bot_iff_exists {x : with_bot α} : x ≠ ⊥ ↔ ∃ (a : α), ↑a = x := option.ne_none_iff_exists
 
 /-- Deconstruct a `x : with_bot α` to the underlying value in `α`, given a proof that `x ≠ ⊥`. -/
 def unbot : Π (x : with_bot α), x ≠ ⊥ → α
 | ⊥        h := absurd rfl h
 | (some x) h := x
 
-@[simp] lemma coe_unbot {α : Type*} (x : with_bot α) (h : x ≠ ⊥) :
-  (x.unbot h : with_bot α) = x :=
+@[simp] lemma coe_unbot (x : with_bot α) (h : x ≠ ⊥) : (x.unbot h : with_bot α) = x :=
 by { cases x, simpa using h, refl, }
 
-@[simp] lemma unbot_coe (x : α) (h : (x : with_bot α) ≠ ⊥ := coe_ne_bot _) :
+@[simp] lemma unbot_coe (x : α) (h : (x : with_bot α) ≠ ⊥ := coe_ne_bot) :
   (x : with_bot α).unbot h = x := rfl
-
-@[priority 10]
-instance has_le [has_le α] : has_le (with_bot α) :=
-{ le          := λ o₁ o₂ : option α, ∀ a ∈ o₁, ∃ b ∈ o₂, a ≤ b }
-
-@[priority 10]
-instance has_lt [has_lt α] : has_lt (with_bot α) :=
-{ lt := λ o₁ o₂ : option α, ∃ b ∈ o₂, ∀ a ∈ o₁, a < b }
-
-@[simp] theorem some_lt_some [has_lt α] {a b : α} :
-  @has_lt.lt (with_bot α) _ (some a) (some b) ↔ a < b :=
-by simp [(<)]
-
-lemma none_lt_some [has_lt α] (a : α) :
-  @has_lt.lt (with_bot α) _ none (some a) :=
-⟨a, rfl, λ b hb, (option.not_mem_none _ hb).elim⟩
-
-lemma not_lt_none [has_lt α] (a : option α) : ¬ @has_lt.lt (with_bot α) _ a none :=
-λ ⟨_, h, _⟩, option.not_mem_none _ h
-
-lemma bot_lt_coe [has_lt α] (a : α) : (⊥ : with_bot α) < a := none_lt_some a
 
 instance : can_lift (with_bot α) α :=
 { coe := coe,
   cond := λ r, r ≠ ⊥,
-  prf := λ x hx, ⟨option.get $ option.ne_none_iff_is_some.1 hx, option.some_get _⟩ }
+  prf := λ x h, ⟨x.unbot h, coe_unbot _ _⟩ }
+
+section has_le
+variables [has_le α]
+
+@[priority 10]
+instance : has_le (with_bot α) := ⟨λ o₁ o₂ : option α, ∀ a ∈ o₁, ∃ b ∈ o₂, a ≤ b⟩
+
+@[simp] lemma some_le_some : @has_le.le (with_bot α) _ (some a) (some b) ↔ a ≤ b := by simp [(≤)]
+@[simp, norm_cast] lemma coe_le_coe : (a : with_bot α) ≤ b ↔ a ≤ b := some_le_some
+
+@[simp] lemma none_le {a : with_bot α} : @has_le.le (with_bot α) _ none a :=
+λ b h, option.no_confusion h
+
+instance : order_bot (with_bot α) := { bot_le := λ a, none_le, ..with_bot.has_bot }
+
+instance [order_top α] : order_top (with_bot α) :=
+{ top := some ⊤,
+  le_top := λ o a ha, by cases ha; exact ⟨_, rfl, le_top⟩ }
+
+instance [order_top α] : bounded_order (with_bot α) :=
+{ ..with_bot.order_top, ..with_bot.order_bot }
+
+lemma not_coe_le_bot (a : α) : ¬ (a : with_bot α) ≤ ⊥ :=
+λ h, let ⟨b, hb, _⟩ := h _ rfl in option.not_mem_none _ hb
+
+lemma coe_le : ∀ {o : option α}, b ∈ o → ((a : with_bot α) ≤ o ↔ a ≤ b) | _ rfl := coe_le_coe
+
+lemma coe_le_iff : ∀ {x : with_bot α}, ↑a ≤ x ↔ ∃ b : α, x = b ∧ a ≤ b
+| (some a) := by simp [some_eq_coe, coe_eq_coe]
+| none     := iff_of_false (not_coe_le_bot _) $ by simp [none_eq_bot]
+
+lemma le_coe_iff : ∀ {x : with_bot α}, x ≤ b ↔ ∀ a, x = ↑a → a ≤ b
+| (some b) := by simp [some_eq_coe, coe_eq_coe]
+| none     := by simp [none_eq_bot]
+
+protected lemma _root_.is_max.with_bot (h : is_max a) : is_max (a : with_bot α)
+| none _ := bot_le
+| (some b) hb := some_le_some.2 $ h $ some_le_some.1 hb
+
+end has_le
+
+section has_lt
+variables [has_lt α]
+
+@[priority 10]
+instance : has_lt (with_bot α) := ⟨λ o₁ o₂ : option α, ∃ b ∈ o₂, ∀ a ∈ o₁, a < b⟩
+
+@[simp] lemma some_lt_some : @has_lt.lt (with_bot α) _ (some a) (some b) ↔ a < b := by simp [(<)]
+@[simp, norm_cast] lemma coe_lt_coe : (a : with_bot α) < b ↔ a < b := some_lt_some
+
+@[simp] lemma none_lt_some (a : α) : @has_lt.lt (with_bot α) _ none (some a) :=
+⟨a, rfl, λ b hb, (option.not_mem_none _ hb).elim⟩
+lemma bot_lt_coe (a : α) : (⊥ : with_bot α) < a := none_lt_some a
+
+@[simp] lemma not_lt_none (a : with_bot α) : ¬ @has_lt.lt (with_bot α) _ a none :=
+λ ⟨_, h, _⟩, option.not_mem_none _ h
+
+lemma lt_iff_exists_coe : ∀ {a b : with_bot α}, a < b ↔ ∃ p : α, b = p ∧ a < p
+| a (some b) := by simp [some_eq_coe, coe_eq_coe]
+| a none     := iff_of_false (not_lt_none _) $ by simp [none_eq_bot]
+
+lemma lt_coe_iff : ∀ {x : with_bot α}, x < b ↔ ∀ a, x = ↑a → a < b
+| (some b) := by simp [some_eq_coe, coe_eq_coe, coe_lt_coe]
+| none     := by simp [none_eq_bot, bot_lt_coe]
+
+end has_lt
 
 instance [preorder α] : preorder (with_bot α) :=
 { le          := (≤),
   lt          := (<),
-  lt_iff_le_not_le := by intros; cases a; cases b;
-                         simp [lt_iff_le_not_le]; simp [(≤), (<)];
-                         split; refl,
+  lt_iff_le_not_le := by { intros, cases a; cases b; simp [lt_iff_le_not_le]; simp [(<), (≤)] },
   le_refl     := λ o a ha, ⟨a, ha, le_rfl⟩,
   le_trans    := λ o₁ o₂ o₃ h₁ h₂ a ha,
     let ⟨b, hb, ab⟩ := h₁ a ha, ⟨c, hc, bc⟩ := h₂ b hb in
     ⟨c, hc, le_trans ab bc⟩ }
 
-instance partial_order [partial_order α] : partial_order (with_bot α) :=
+instance [partial_order α] : partial_order (with_bot α) :=
 { le_antisymm := λ o₁ o₂ h₁ h₂, begin
     cases o₁ with a,
     { cases o₂ with b, {refl},
@@ -577,26 +617,6 @@ instance partial_order [partial_order α] : partial_order (with_bot α) :=
       rw le_antisymm h₁' h₂' }
   end,
   .. with_bot.preorder }
-
-instance order_bot [has_le α] : order_bot (with_bot α) :=
-{ bot_le := λ a a' h, option.no_confusion h,
-  ..with_bot.has_bot }
-
-@[simp, norm_cast] theorem coe_le_coe [has_le α] {a b : α} :
-  (a : with_bot α) ≤ b ↔ a ≤ b :=
-⟨λ h, by rcases h a rfl with ⟨_, ⟨⟩, h⟩; exact h,
- λ h a' e, option.some_inj.1 e ▸ ⟨b, rfl, h⟩⟩
-
-@[simp] theorem some_le_some [has_le α] {a b : α} :
-  @has_le.le (with_bot α) _ (some a) (some b) ↔ a ≤ b := coe_le_coe
-
-theorem coe_le [has_le α] {a b : α} :
-  ∀ {o : option α}, b ∈ o → ((a : with_bot α) ≤ o ↔ a ≤ b)
-| _ rfl := coe_le_coe
-
-@[norm_cast]
-lemma coe_lt_coe [has_lt α] {a b : α} : (a : with_bot α) < b ↔ a < b := some_lt_some
-lemma not_coe_le_bot [preorder α] (a : α) : ¬ (a : with_bot α) ≤ ⊥ := (bot_lt_coe a).not_le
 
 lemma le_coe_get_or_else [preorder α] : ∀ (a : with_bot α) (b : α), a ≤ a.get_or_else b
 | (some a) b := le_refl a
@@ -608,30 +628,7 @@ lemma get_or_else_bot_le_iff [has_le α] [order_bot α] {a : with_bot α} {b : �
   a.get_or_else ⊥ ≤ b ↔ a ≤ b :=
 by cases a; simp [none_eq_bot, some_eq_coe]
 
-instance decidable_le [has_le α] [@decidable_rel α (≤)] : @decidable_rel (with_bot α) (≤)
-| none x := is_true $ λ a h, option.no_confusion h
-| (some x) (some y) :=
-  if h : x ≤ y
-  then is_true (some_le_some.2 h)
-  else is_false $ by simp *
-| (some x) none := is_false $ λ h, by rcases h x rfl with ⟨y, ⟨_⟩, _⟩
-
-instance decidable_lt [has_lt α] [@decidable_rel α (<)] : @decidable_rel (with_bot α) (<)
-| none (some x) := is_true $ by existsi [x,rfl]; rintros _ ⟨⟩
-| (some x) (some y) :=
-  if h : x < y
-  then is_true $ by simp *
-  else is_false $ by simp *
-| x none := is_false $ by rintro ⟨a,⟨⟨⟩⟩⟩
-
-instance [partial_order α] [is_total α (≤)] : is_total (with_bot α) (≤) :=
-{ total := λ a b, match a, b with
-  | none  , _      := or.inl bot_le
-  | _     , none   := or.inr bot_le
-  | some x, some y := by simp only [some_le_some, total_of]
-  end }
-
-instance semilattice_sup [semilattice_sup α] : semilattice_sup (with_bot α) :=
+instance [semilattice_sup α] : semilattice_sup (with_bot α) :=
 { sup          := option.lift_or_get (⊔),
   le_sup_left  := λ o₁ o₂ a ha,
     by cases ha; cases o₂; simp [option.lift_or_get],
@@ -650,7 +647,7 @@ instance semilattice_sup [semilattice_sup α] : semilattice_sup (with_bot α) :=
 
 lemma coe_sup [semilattice_sup α] (a b : α) : ((a ⊔ b : α) : with_bot α) = a ⊔ b := rfl
 
-instance semilattice_inf [semilattice_inf α] : semilattice_inf (with_bot α) :=
+instance [semilattice_inf α] : semilattice_inf (with_bot α) :=
 { inf          := λ o₁ o₂, o₁.bind (λ a, o₂.map (λ b, a ⊓ b)),
   inf_le_left  := λ o₁ o₂ a ha, begin
     simp at ha, rcases ha with ⟨b, rfl, c, rfl, rfl⟩,
@@ -671,19 +668,33 @@ instance semilattice_inf [semilattice_inf α] : semilattice_inf (with_bot α) :=
 
 lemma coe_inf [semilattice_inf α] (a b : α) : ((a ⊓ b : α) : with_bot α) = a ⊓ b := rfl
 
-instance lattice [lattice α] : lattice (with_bot α) :=
+instance [lattice α] : lattice (with_bot α) :=
 { ..with_bot.semilattice_sup, ..with_bot.semilattice_inf }
 
-instance le_is_total [preorder α] [is_total α (≤)] : is_total (with_bot α) (≤) :=
-⟨λ o₁ o₂,
-begin
-  cases o₁ with a, {exact or.inl bot_le},
-  cases o₂ with b, {exact or.inr bot_le},
-  exact (total_of (≤) a b).imp some_le_some.mpr some_le_some.mpr,
-end⟩
+instance decidable_le [has_le α] [@decidable_rel α (≤)] : @decidable_rel (with_bot α) (≤)
+| none x := is_true $ λ a h, option.no_confusion h
+| (some x) (some y) :=
+  if h : x ≤ y
+  then is_true (some_le_some.2 h)
+  else is_false $ by simp *
+| (some x) none := is_false $ λ h, by rcases h x rfl with ⟨y, ⟨_⟩, _⟩
 
-instance linear_order [linear_order α] : linear_order (with_bot α) :=
-lattice.to_linear_order _
+instance decidable_lt [has_lt α] [@decidable_rel α (<)] : @decidable_rel (with_bot α) (<)
+| none (some x) := is_true $ by existsi [x,rfl]; rintros _ ⟨⟩
+| (some x) (some y) :=
+  if h : x < y
+  then is_true $ by simp *
+  else is_false $ by simp *
+| x none := is_false $ by rintro ⟨a,⟨⟨⟩⟩⟩
+
+instance is_total_le [has_le α] [is_total α (≤)] : is_total (with_bot α) (≤) :=
+⟨λ a b, match a, b with
+  | none  , _      := or.inl bot_le
+  | _     , none   := or.inr bot_le
+  | some x, some y := (total_of (≤) x y).imp some_le_some.2 some_le_some.2
+  end⟩
+
+instance [linear_order α] : linear_order (with_bot α) := lattice.to_linear_order _
 
 @[norm_cast] -- this is not marked simp because the corresponding with_top lemmas are used
 lemma coe_min [linear_order α] (x y : α) : ((min x y : α) : with_bot α) = min x y := rfl
@@ -691,15 +702,7 @@ lemma coe_min [linear_order α] (x y : α) : ((min x y : α) : with_bot α) = mi
 @[norm_cast] -- this is not marked simp because the corresponding with_top lemmas are used
 lemma coe_max [linear_order α] (x y : α) : ((max x y : α) : with_bot α) = max x y := rfl
 
-instance order_top [has_le α] [order_top α] : order_top (with_bot α) :=
-{ top := some ⊤,
-  le_top := λ o a ha, by cases ha; exact ⟨_, rfl, le_top⟩ }
-
-instance bounded_order [has_le α] [order_top α] : bounded_order (with_bot α) :=
-{ ..with_bot.order_top, ..with_bot.order_bot }
-
-lemma well_founded_lt [preorder α] (h : well_founded ((<) : α → α → Prop)) :
-  well_founded ((<) : with_bot α → with_bot α → Prop) :=
+lemma well_founded_lt [preorder α] (h : @well_founded α (<)) : @well_founded (with_bot α) (<) :=
 have acc_bot : acc ((<) : with_bot α → with_bot α → Prop) ⊥ :=
   acc.intro _ (λ a ha, (not_le_of_gt ha bot_le).elim),
 ⟨λ a, option.rec_on a acc_bot (λ a, acc.intro _ (λ b, option.rec_on b (λ _, acc_bot)
@@ -710,8 +713,7 @@ have acc_bot : acc ((<) : with_bot α → with_bot α → Prop) ⊥ :=
   from λ b ih hba, acc.intro _ (λ c, option.rec_on c (λ _, acc_bot)
     (λ c hc, ih _ (some_lt_some.1 hc) (lt_trans hc hba)))))))⟩
 
-instance densely_ordered [has_lt α] [densely_ordered α] [no_min_order α] :
-  densely_ordered (with_bot α) :=
+instance [has_lt α] [densely_ordered α] [no_min_order α] : densely_ordered (with_bot α) :=
 ⟨ λ a b,
   match a, b with
   | a,      none   := λ h : a < ⊥, (not_lt_none _ h).elim
@@ -719,6 +721,20 @@ instance densely_ordered [has_lt α] [densely_ordered α] [no_min_order α] :
   | some a, some b := λ h, let ⟨a, ha₁, ha₂⟩ := exists_between (coe_lt_coe.1 h) in
     ⟨a, coe_lt_coe.2 ha₁, coe_lt_coe.2 ha₂⟩
   end⟩
+
+lemma lt_iff_exists_coe_btwn [preorder α] [densely_ordered α] [no_min_order α] {a b : with_bot α} :
+  a < b ↔ ∃ x : α, a < ↑x ∧ ↑x < b :=
+⟨λ h, let ⟨y, hy⟩ := exists_between h, ⟨x, hx⟩ := lt_iff_exists_coe.1 hy.1 in ⟨x, hx.1 ▸ hy⟩,
+ λ ⟨x, hx⟩, lt_trans hx.1 hx.2⟩
+
+instance [has_le α] [no_top_order α] [nonempty α] : no_top_order (with_bot α) :=
+⟨begin
+  apply rec_bot_coe,
+  { exact ‹nonempty α›.elim (λ a, ⟨a, not_coe_le_bot a⟩) },
+  { intro a,
+    obtain ⟨b, h⟩ := exists_not_le a,
+    exact ⟨b, by rwa coe_le_coe⟩ }
+end⟩
 
 instance [has_lt α] [no_max_order α] [nonempty α] : no_max_order (with_bot α) :=
 ⟨begin
@@ -730,10 +746,6 @@ instance [has_lt α] [no_max_order α] [nonempty α] : no_max_order (with_bot α
     exact ⟨b, with_bot.coe_lt_coe.mpr ha⟩, }
 end⟩
 
-protected lemma _root_.is_max.with_bot [has_le α] {a : α} (h : is_max a) : is_max (a : with_bot α)
-| none _ := bot_le
-| (some b) hb := some_le_some.2 $ h $ some_le_some.1 hb
-
 end with_bot
 
 --TODO(Mario): Construct using order dual on with_bot
@@ -741,8 +753,9 @@ end with_bot
 def with_top (α : Type*) := option α
 
 namespace with_top
+variables {a b : α}
 
-meta instance {α} [has_to_format α] : has_to_format (with_top α) :=
+meta instance [has_to_format α] : has_to_format (with_top α) :=
 { to_format := λ x,
   match x with
   | none := "⊤"
@@ -753,12 +766,15 @@ instance [has_repr α] : has_repr (with_top α) :=
 ⟨λ o, match o with | none := "⊤" | (some a) := "↑" ++ repr a end⟩
 
 instance : has_coe_t α (with_top α) := ⟨some⟩
-instance has_top : has_top (with_top α) := ⟨none⟩
+instance : has_top (with_top α) := ⟨none⟩
 
 instance : inhabited (with_top α) := ⟨⊤⟩
 
 lemma none_eq_top : (none : with_top α) = (⊤ : with_top α) := rfl
 lemma some_eq_coe (a : α) : (some a : with_top α) = (↑a : with_top α) := rfl
+
+@[simp] lemma top_ne_coe : ⊤ ≠ (a : with_top α) .
+@[simp] lemma coe_ne_top : (a : with_top α) ≠ ⊤ .
 
 /-- Recursor for `with_top` using the preferred forms `⊤` and `↑a`. -/
 @[elab_as_eliminator]
@@ -766,9 +782,7 @@ def rec_top_coe {C : with_top α → Sort*} (h₁ : C ⊤) (h₂ : Π (a : α), 
   Π (n : with_top α), C n :=
 option.rec h₁ h₂
 
-@[norm_cast]
-theorem coe_eq_coe {a b : α} : (a : with_top α) = b ↔ a = b :=
-by rw [← option.some.inj_eq a b]; refl
+@[norm_cast] lemma coe_eq_coe : (a : with_top α) = b ↔ a = b := option.some_inj
 
 -- the `by exact` here forces the type of the equality to be `@eq (with_top α)`
 @[simp] lemma map_top (f : α → β) :
@@ -776,66 +790,100 @@ by rw [← option.some.inj_eq a b]; refl
 lemma map_coe (f : α → β) (a : α) :
   (by exact option.map f (a : with_top α)) = (f a : with_top β) := rfl
 
-@[simp] theorem top_ne_coe {a : α} : ⊤ ≠ (a : with_top α) .
-@[simp] theorem coe_ne_top {a : α} : (a : with_top α) ≠ ⊤ .
-
-lemma ne_top_iff_exists {x : with_top α} : x ≠ ⊤ ↔ ∃ (a : α), ↑a = x :=
-option.ne_none_iff_exists
+lemma ne_top_iff_exists {x : with_top α} : x ≠ ⊤ ↔ ∃ (a : α), ↑a = x := option.ne_none_iff_exists
 
 /-- Deconstruct a `x : with_top α` to the underlying value in `α`, given a proof that `x ≠ ⊤`. -/
 def untop : Π (x : with_top α), x ≠ ⊤ → α :=
 with_bot.unbot
 
-@[simp] lemma coe_untop {α : Type*} (x : with_top α) (h : x ≠ ⊤) :
-  (x.untop h : with_top α) = x :=
+@[simp] lemma coe_untop (x : with_top α) (h : x ≠ ⊤) : (x.untop h : with_top α) = x :=
 by { cases x, simpa using h, refl, }
 
 @[simp] lemma untop_coe (x : α) (h : (x : with_top α) ≠ ⊤ := coe_ne_top) :
   (x : with_top α).untop h = x := rfl
 
-@[priority 10]
-instance has_lt [has_lt α] : has_lt (with_top α) :=
-{ lt := λ o₁ o₂ : option α, ∃ b ∈ o₁, ∀ a ∈ o₂, b < a }
-
-@[priority 10]
-instance has_le [has_le α] : has_le (with_top α) :=
-{ le          := λ o₁ o₂ : option α, ∀ a ∈ o₂, ∃ b ∈ o₁, b ≤ a }
-
-@[simp] theorem some_lt_some [has_lt α] {a b : α} :
-  @has_lt.lt (with_top α) _ (some a) (some b) ↔ a < b :=
-by simp [(<)]
-
-@[simp] theorem some_le_some [has_le α] {a b : α} :
-  @has_le.le (with_top α) _ (some a) (some b) ↔ a ≤ b :=
-by simp [(≤)]
-
-@[simp] theorem le_none [has_le α] {a : with_top α} :
-  @has_le.le (with_top α) _ a none :=
-by simp [(≤)]
-
-@[simp] theorem some_lt_none [has_lt α] (a : α) :
-  @has_lt.lt (with_top α) _ (some a) none :=
-by simp [(<)]; existsi a; refl
-
-@[simp] theorem not_none_lt [has_lt α] (a : option α) : ¬ @has_lt.lt (with_top α) _ none a :=
-λ ⟨_, h, _⟩, option.not_mem_none _ h
-
 instance : can_lift (with_top α) α :=
 { coe := coe,
   cond := λ r, r ≠ ⊤,
-  prf := λ x hx, ⟨option.get $ option.ne_none_iff_is_some.1 hx, option.some_get _⟩ }
+  prf := λ x h, ⟨x.untop h, coe_untop _ _⟩ }
+
+section has_le
+variables [has_le α]
+
+@[priority 10]
+instance : has_le (with_top α) := ⟨λ o₁ o₂ : option α, ∀ a ∈ o₂, ∃ b ∈ o₁, b ≤ a⟩
+
+@[simp] lemma some_le_some : @has_le.le (with_top α) _ (some a) (some b) ↔ a ≤ b := by simp [(≤)]
+@[simp, norm_cast] lemma coe_le_coe : (a : with_top α) ≤ b ↔ a ≤ b := some_le_some
+
+@[simp] lemma le_none {a : with_top α} : @has_le.le (with_top α) _ a none :=
+λ b h, option.no_confusion h
+
+instance : order_top (with_top α) := { le_top := λ a, le_none, .. with_top.has_top }
+
+instance [order_bot α] : order_bot (with_top α) :=
+{ bot := some ⊥,
+  bot_le := λ o a ha, by cases ha; exact ⟨_, rfl, bot_le⟩ }
+
+instance [order_bot α] : bounded_order (with_top α) :=
+{ ..with_top.order_top, ..with_top.order_bot }
+
+lemma not_top_le_coe (a : α) : ¬ (⊤ : with_top α) ≤ ↑a :=
+λ h, let ⟨b, hb, _⟩ := h _ rfl in option.not_mem_none _ hb
+
+lemma le_coe : ∀ {o : option α}, a ∈ o → (@has_le.le (with_top α) _ o b ↔ a ≤ b) | _ rfl :=
+coe_le_coe
+
+lemma le_coe_iff : ∀ {x : with_top α}, x ≤ b ↔ ∃ a : α, x = a ∧ a ≤ b
+| (some a) := by simp [some_eq_coe, coe_eq_coe]
+| none     := iff_of_false (not_top_le_coe _) $ by simp [none_eq_top]
+
+lemma coe_le_iff : ∀ {x : with_top α}, ↑a ≤ x ↔ ∀ b, x = ↑b → a ≤ b
+| (some b) := by simp [some_eq_coe, coe_eq_coe]
+| none     := by simp [none_eq_top]
+
+protected lemma _root_.is_min.with_top (h : is_min a) : is_min (a : with_top α)
+| none _ := le_top
+| (some b) hb := some_le_some.2 $ h $ some_le_some.1 hb
+
+end has_le
+
+section has_lt
+variables [has_lt α]
+
+@[priority 10]
+instance : has_lt (with_top α) := ⟨λ o₁ o₂ : option α, ∃ b ∈ o₁, ∀ a ∈ o₂, b < a⟩
+
+@[simp] lemma some_lt_some : @has_lt.lt (with_top α) _ (some a) (some b) ↔ a < b := by simp [(<)]
+@[simp, norm_cast] lemma coe_lt_coe : (a : with_top α) < b ↔ a < b := some_lt_some
+
+@[simp] lemma some_lt_none (a : α) : @has_lt.lt (with_top α) _ (some a) none :=
+⟨a, rfl, λ b hb, (option.not_mem_none _ hb).elim⟩
+lemma coe_lt_top (a : α) : (a : with_top α) < ⊤ := some_lt_none a
+
+@[simp] lemma not_none_lt (a : with_top α) : ¬ @has_lt.lt (with_top α) _ none a :=
+λ ⟨_, h, _⟩, option.not_mem_none _ h
+
+lemma lt_iff_exists_coe : ∀ {a b : with_top α}, a < b ↔ ∃ p : α, a = p ∧ ↑p < b
+| (some a) b := by simp [some_eq_coe, coe_eq_coe]
+| none     b := iff_of_false (not_none_lt _) $ by simp [none_eq_top]
+
+lemma coe_lt_iff : ∀ {x : with_top α}, ↑a < x ↔ ∀ b, x = ↑b → a < b
+| (some b) := by simp [some_eq_coe, coe_eq_coe, coe_lt_coe]
+| none     := by simp [none_eq_top, coe_lt_top]
+
+end has_lt
 
 instance [preorder α] : preorder (with_top α) :=
-{ le          := λ o₁ o₂ : option α, ∀ a ∈ o₂, ∃ b ∈ o₁, b ≤ a,
+{ le          := (≤),
   lt          := (<),
-  lt_iff_le_not_le := by { intros; cases a; cases b;
-                           simp [lt_iff_le_not_le]; simp [(<),(≤)] },
+  lt_iff_le_not_le := by { intros, cases a; cases b; simp [lt_iff_le_not_le]; simp [(<), (≤)] },
   le_refl     := λ o a ha, ⟨a, ha, le_rfl⟩,
   le_trans    := λ o₁ o₂ o₃ h₁ h₂ c hc,
     let ⟨b, hb, bc⟩ := h₂ c hc, ⟨a, ha, ab⟩ := h₁ b hb in
-    ⟨a, ha, le_trans ab bc⟩, }
+    ⟨a, ha, le_trans ab bc⟩ }
 
-instance partial_order [partial_order α] : partial_order (with_top α) :=
+instance [partial_order α] : partial_order (with_top α) :=
 { le_antisymm := λ o₁ o₂ h₁ h₂, begin
     cases o₂ with b,
     { cases o₁ with a, {refl},
@@ -846,57 +894,7 @@ instance partial_order [partial_order α] : partial_order (with_top α) :=
   end,
   .. with_top.preorder }
 
-instance order_top [has_le α] : order_top (with_top α) :=
-{ le_top := λ a a' h, option.no_confusion h,
-  .. with_top.has_top }
-
-@[simp, norm_cast] theorem coe_le_coe [has_le α] {a b : α} :
-  (a : with_top α) ≤ b ↔ a ≤ b :=
-⟨λ h, by rcases h b rfl with ⟨_, ⟨⟩, h⟩; exact h,
- λ h a' e, option.some_inj.1 e ▸ ⟨a, rfl, h⟩⟩
-
-theorem le_coe [has_le α] {a b : α} :
-  ∀ {o : option α}, a ∈ o →
-  (@has_le.le (with_top α) _ o b ↔ a ≤ b)
-| _ rfl := coe_le_coe
-
-theorem le_coe_iff [partial_order α] {b : α} : ∀{x : with_top α}, x ≤ b ↔ (∃a:α, x = a ∧ a ≤ b)
-| (some a) := by simp [some_eq_coe, coe_eq_coe]
-| none     := by simp [none_eq_top]
-
-theorem coe_le_iff [preorder α] {a : α} : ∀{x : with_top α}, ↑a ≤ x ↔ (∀b:α, x = ↑b → a ≤ b)
-| (some b) := by simp [some_eq_coe, coe_eq_coe]
-| none     := by simp [none_eq_top]
-
-theorem lt_iff_exists_coe [preorder α] : ∀{a b : with_top α}, a < b ↔ (∃p:α, a = p ∧ ↑p < b)
-| (some a) b := by simp [some_eq_coe, coe_eq_coe]
-| none     b := by simp [none_eq_top]
-
-@[norm_cast]
-lemma coe_lt_coe [has_lt α] {a b : α} : (a : with_top α) < b ↔ a < b := some_lt_some
-
-lemma coe_lt_top [has_lt α] (a : α) : (a : with_top α) < ⊤ := some_lt_none a
-
-theorem coe_lt_iff [preorder α] {a : α} : ∀{x : with_top α}, ↑a < x ↔ (∀b:α, x = ↑b → a < b)
-| (some b) := by simp [some_eq_coe, coe_eq_coe, coe_lt_coe]
-| none     := by simp [none_eq_top, coe_lt_top]
-
-lemma not_top_le_coe [preorder α] (a : α) : ¬ (⊤ : with_top α) ≤ ↑a := (coe_lt_top a).not_le
-
-instance decidable_le [has_le α] [@decidable_rel α (≤)] : @decidable_rel (with_top α) (≤) :=
-λ x y, @with_bot.decidable_le (order_dual α) _ _ y x
-
-instance decidable_lt [has_lt α] [@decidable_rel α (<)] : @decidable_rel (with_top α) (<) :=
-λ x y, @with_bot.decidable_lt (order_dual α) _ _ y x
-
-instance [partial_order α] [is_total α (≤)] : is_total (with_top α) (≤) :=
-{ total := λ a b, match a, b with
-  | none  , _      := or.inr le_top
-  | _     , none   := or.inl le_top
-  | some x, some y := by simp only [some_le_some, total_of]
-  end }
-
-instance semilattice_inf [semilattice_inf α] : semilattice_inf (with_top α) :=
+instance [semilattice_inf α] : semilattice_inf (with_top α) :=
 { inf          := option.lift_or_get (⊓),
   inf_le_left  := λ o₁ o₂ a ha,
     by cases ha; cases o₂; simp [option.lift_or_get],
@@ -914,7 +912,7 @@ instance semilattice_inf [semilattice_inf α] : semilattice_inf (with_top α) :=
 
 lemma coe_inf [semilattice_inf α] (a b : α) : ((a ⊓ b : α) : with_top α) = a ⊓ b := rfl
 
-instance semilattice_sup [semilattice_sup α] : semilattice_sup (with_top α) :=
+instance [semilattice_sup α] : semilattice_sup (with_top α) :=
 { sup          := λ o₁ o₂, o₁.bind (λ a, o₂.map (λ b, a ⊔ b)),
   le_sup_left  := λ o₁ o₂ a ha, begin
     simp at ha, rcases ha with ⟨b, rfl, c, rfl, rfl⟩,
@@ -934,35 +932,31 @@ instance semilattice_sup [semilattice_sup α] : semilattice_sup (with_top α) :=
 
 lemma coe_sup [semilattice_sup α] (a b : α) : ((a ⊔ b : α) : with_top α) = a ⊔ b := rfl
 
-instance lattice [lattice α] : lattice (with_top α) :=
+instance [lattice α] : lattice (with_top α) :=
 { ..with_top.semilattice_sup, ..with_top.semilattice_inf }
 
-instance le_is_total [preorder α] [is_total α (≤)] : is_total (with_top α) (≤) :=
-⟨λ o₁ o₂,
-begin
-  cases o₁ with a, {exact or.inr le_top},
-  cases o₂ with b, {exact or.inl le_top},
-  exact (total_of (≤) a b).imp some_le_some.mpr some_le_some.mpr,
-end⟩
+instance decidable_le [has_le α] [@decidable_rel α (≤)] : @decidable_rel (with_top α) (≤) :=
+λ x y, @with_bot.decidable_le (order_dual α) _ _ y x
 
-instance linear_order [linear_order α] : linear_order (with_top α) :=
-lattice.to_linear_order _
+instance decidable_lt [has_lt α] [@decidable_rel α (<)] : @decidable_rel (with_top α) (<) :=
+λ x y, @with_bot.decidable_lt (order_dual α) _ _ y x
+
+instance is_total_le [has_le α] [is_total α (≤)] : is_total (with_top α) (≤) :=
+⟨λ a b, match a, b with
+  | _     , none   := or.inl le_top
+  | none  , _      := or.inr le_top
+  | some x, some y := (total_of (≤) x y).imp some_le_some.2 some_le_some.2
+  end⟩
+
+instance [linear_order α] : linear_order (with_top α) := lattice.to_linear_order _
 
 @[simp, norm_cast]
-lemma coe_min [linear_order α] (x y : α) : ((min x y : α) : with_top α) = min x y := rfl
+lemma coe_min [linear_order α] (x y : α) : (↑(min x y) : with_top α) = min x y := rfl
 
 @[simp, norm_cast]
-lemma coe_max [linear_order α] (x y : α) : ((max x y : α) : with_top α) = max x y := rfl
+lemma coe_max [linear_order α] (x y : α) : (↑(max x y) : with_top α) = max x y := rfl
 
-instance order_bot [has_le α] [order_bot α] : order_bot (with_top α) :=
-{ bot := some ⊥,
-  bot_le := λ o a ha, by cases ha; exact ⟨_, rfl, bot_le⟩ }
-
-instance bounded_order [has_le α] [order_bot α] : bounded_order (with_top α) :=
-{ ..with_top.order_top, ..with_top.order_bot }
-
-lemma well_founded_lt {α : Type*} [preorder α] (h : well_founded ((<) : α → α → Prop)) :
-  well_founded ((<) : with_top α → with_top α → Prop) :=
+lemma well_founded_lt [preorder α] (h : @well_founded α (<)) : @well_founded (with_top α) (<) :=
 have acc_some : ∀ a : α, acc ((<) : with_top α → with_top α → Prop) (some a) :=
 λ a, acc.intro _ (well_founded.induction h a
   (show ∀ b, (∀ c, c < b → ∀ d : with_top α, d < some c → acc (<) d) →
@@ -972,8 +966,14 @@ have acc_some : ∀ a : α, acc ((<) : with_top α → with_top α → Prop) (so
 ⟨λ a, option.rec_on a (acc.intro _ (λ y, option.rec_on y (λ h, (lt_irrefl _ h).elim)
   (λ _ _, acc_some _))) acc_some⟩
 
-instance densely_ordered [has_lt α] [densely_ordered α] [no_max_order α] :
-  densely_ordered (with_top α) :=
+lemma well_founded_gt [preorder α] (h : @well_founded α (>)) : @well_founded (with_top α) (>) :=
+@with_bot.well_founded_lt (order_dual α) _ h
+
+lemma _root_.with_bot.well_founded_gt [preorder α] (h : @well_founded α (>)) :
+  @well_founded (with_bot α) (>) :=
+@with_top.well_founded_lt (order_dual α) _ h
+
+instance [has_lt α] [densely_ordered α] [no_max_order α] : densely_ordered (with_top α) :=
 ⟨ λ a b,
   match a, b with
   | none,   a   := λ h : ⊤ < a, (not_none_lt _ h).elim
@@ -982,25 +982,28 @@ instance densely_ordered [has_lt α] [densely_ordered α] [no_max_order α] :
     ⟨a, coe_lt_coe.2 ha₁, coe_lt_coe.2 ha₂⟩
   end⟩
 
-lemma lt_iff_exists_coe_btwn [partial_order α] [densely_ordered α] [no_max_order α]
-  {a b : with_top α} :
-  (a < b) ↔ (∃ x : α, a < ↑x ∧ ↑x < b) :=
+lemma lt_iff_exists_coe_btwn [preorder α] [densely_ordered α] [no_max_order α] {a b : with_top α} :
+  a < b ↔ ∃ x : α, a < ↑x ∧ ↑x < b :=
 ⟨λ h, let ⟨y, hy⟩ := exists_between h, ⟨x, hx⟩ := lt_iff_exists_coe.1 hy.2 in ⟨x, hx.1 ▸ hy⟩,
  λ ⟨x, hx⟩, lt_trans hx.1 hx.2⟩
 
-instance [has_lt α] [no_min_order α] [nonempty α] : no_min_order (with_top α) :=
+instance [has_le α] [no_bot_order α] [nonempty α] : no_bot_order (with_top α) :=
 ⟨begin
   apply with_top.rec_top_coe,
-  { apply ‹nonempty α›.elim,
-    exact λ a, ⟨a, with_top.coe_lt_top a⟩, },
+  { exact ‹nonempty α›.elim (λ a, ⟨a, not_top_le_coe a⟩) },
   { intro a,
-    obtain ⟨b, ha⟩ := exists_lt a,
-    exact ⟨b, with_top.coe_lt_coe.mpr ha⟩, }
+    obtain ⟨b, h⟩ := exists_not_ge a,
+    exact ⟨b, by rwa coe_le_coe⟩ }
 end⟩
 
-protected lemma _root_.is_min.with_top [has_le α] {a : α} (h : is_min a) : is_min (a : with_top α)
-| none _ := le_top
-| (some b) hb := some_le_some.2 $ h $ some_le_some.1 hb
+instance [has_lt α] [no_min_order α] [nonempty α] : no_min_order (with_top α) :=
+⟨begin
+  apply rec_top_coe,
+  { exact ‹nonempty α›.elim (λ a, ⟨a, with_top.coe_lt_top a⟩) },
+  { intro a,
+    obtain ⟨b, ha⟩ := exists_lt a,
+    exact ⟨b, coe_lt_coe.mpr ha⟩ }
+end⟩
 
 end with_top
 


### PR DESCRIPTION
The API for `with_top` and the API for `with_bot` somehow evolved independently from each other, which created frustating disparity in lemmas and argument implicitness. This synchronizes everything (including the layout), generalize a few lemmas from `preorder`/`partial_order` to `has_le`/`has_lt`, and removes the duplicated `is_total (with_bot α) (≤)`/`is_total (with_top α) (≤)` instances.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
