### PR TITLE
[Merged by Bors] - feat(topology/algebra/module/multilinear): relax requirements for `continuous_multilinear_map.mk_pi_algebra`

### DIFF
--- a/src/analysis/normed_space/multilinear.lean
+++ b/src/analysis/normed_space/multilinear.lean
@@ -285,6 +285,11 @@ open real
 def op_norm := Inf {c | 0 ≤ (c : ℝ) ∧ ∀ m, ∥f m∥ ≤ c * ∏ i, ∥m i∥}
 instance has_op_norm : has_norm (continuous_multilinear_map 𝕜 E G) := ⟨op_norm⟩
 
+/-- An alias of `continuous_multilinear_map.has_op_norm` with non-dependent types to help typeclass
+search. -/
+instance has_op_norm' : has_norm (continuous_multilinear_map 𝕜 (λ (i : ι), G) G') :=
+continuous_multilinear_map.has_op_norm
+
 lemma norm_def : ∥f∥ = Inf {c | 0 ≤ (c : ℝ) ∧ ∀ m, ∥f m∥ ≤ c * ∏ i, ∥m i∥} := rfl
 
 -- So that invocations of `le_cInf` make sense: we show that the set of
@@ -669,23 +674,13 @@ end
 
 section
 
-variables (𝕜 ι) (A : Type*) [normed_comm_ring A] [normed_algebra 𝕜 A]
-
-variables {A 𝕜 ι}
-
--- set_option pp.implicit true
-
--- local attribute [instance, priority 1001]
---   comm_semiring.to_semiring
--- #check continuous_multilinear_map.mk_pi_algebra 𝕜 ι A
--- #check (sorry : continuous_multilinear_map 𝕜 (λ (i : ι), A) A)
+variables {𝕜 ι} {A : Type*} [normed_comm_ring A] [normed_algebra 𝕜 A]
 
 @[simp]
 lemma norm_mk_pi_algebra_le [nonempty ι] :
-  @norm (continuous_multilinear_map 𝕜 (λ (i : ι), A) A) _
-    (continuous_multilinear_map.mk_pi_algebra 𝕜 ι A) ≤ 1 :=
+  ∥continuous_multilinear_map.mk_pi_algebra 𝕜 ι A∥ ≤ 1 :=
 begin
-  have := λ f h', @op_norm_le_bound 𝕜 ι (λ i, A) A _ _ _ _ _ _ _ f _ zero_le_one h',
+  have := λ f, @op_norm_le_bound 𝕜 ι (λ i, A) A _ _ _ _ _ _ _ f _ zero_le_one,
   refine this _ _,
   intros m,
   simp only [continuous_multilinear_map.mk_pi_algebra_apply, one_mul],
@@ -693,11 +688,10 @@ begin
 end
 
 lemma norm_mk_pi_algebra_of_empty [is_empty ι] :
-  @norm (continuous_multilinear_map 𝕜 (λ (i : ι), A) A) _
-    (continuous_multilinear_map.mk_pi_algebra 𝕜 ι A) = ∥(1 : A)∥ :=
+  ∥continuous_multilinear_map.mk_pi_algebra 𝕜 ι A∥ = ∥(1 : A)∥ :=
 begin
   apply le_antisymm,
-  { have := λ f h', @op_norm_le_bound 𝕜 ι (λ i, A) A _ _ _ _ _ _ _ f (∥(1 : A)∥) (norm_nonneg _) h',
+  { have := λ f, @op_norm_le_bound 𝕜 ι (λ i, A) A _ _ _ _ _ _ _ f _ (norm_nonneg (1 : A)),
     refine this _ _,
     simp, },
   { convert ratio_le_op_norm _ (λ _, (1 : A)),
@@ -705,8 +699,7 @@ begin
 end
 
 @[simp] lemma norm_mk_pi_algebra [norm_one_class A] :
-  @norm (continuous_multilinear_map 𝕜 (λ (i : ι), A) A) _
-    (continuous_multilinear_map.mk_pi_algebra 𝕜 ι A) = 1 :=
+  ∥continuous_multilinear_map.mk_pi_algebra 𝕜 ι A∥ = 1 :=
 begin
   casesI is_empty_or_nonempty ι,
   { simp [norm_mk_pi_algebra_of_empty] },
@@ -719,40 +712,42 @@ end
 
 section
 
-variables (𝕜 n) (A : Type*) [normed_ring A] [normed_algebra 𝕜 A]
-
-variables {A 𝕜 n}
+variables {𝕜 n} {A : Type*} [normed_ring A] [normed_algebra 𝕜 A]
 
 lemma norm_mk_pi_algebra_fin_succ_le :
-  @norm (continuous_multilinear_map 𝕜 (λ (i : _), A) A) _
-    (continuous_multilinear_map.mk_pi_algebra_fin 𝕜 n.succ A) ≤ 1 :=
+  ∥continuous_multilinear_map.mk_pi_algebra_fin 𝕜 n.succ A∥ ≤ 1 :=
 begin
-  have := λ f h', @op_norm_le_bound 𝕜 (fin n.succ) (λ i, A) A _ _ _ _ _ _ _ f _ zero_le_one h',
+  have := λ f, @op_norm_le_bound 𝕜 (fin n.succ) (λ i, A) A _ _ _ _ _ _ _ f _ zero_le_one,
   refine this _ _,
   intros m,
-  simp only [continuous_multilinear_map.mk_pi_algebra_fin_apply, one_mul, list.of_fn_eq_map],
+  simp only [continuous_multilinear_map.mk_pi_algebra_fin_apply, one_mul, list.of_fn_eq_map,
+    fin.univ_def, finset.fin_range, finset.prod, multiset.coe_map, multiset.coe_prod],
   refine (list.norm_prod_le' _).trans_eq _,
-  simp,
-  sorry
+  { rw [ne.def, list.map_eq_nil, list.fin_range_eq_nil],
+    exact nat.succ_ne_zero _, },
+  rw list.map_map,
 end
 
 lemma norm_mk_pi_algebra_fin_le_of_pos (hn : 0 < n) :
-  @norm (continuous_multilinear_map 𝕜 (λ (i : _), A) A) _
-    (continuous_multilinear_map.mk_pi_algebra_fin 𝕜 n A) ≤ 1 :=
-by cases n; [exact hn.false.elim, exact norm_mk_pi_algebra_fin_succ_le]
+  ∥continuous_multilinear_map.mk_pi_algebra_fin 𝕜 n A∥ ≤ 1 :=
+begin
+  obtain ⟨n, rfl⟩ := nat.exists_eq_succ_of_ne_zero hn.ne',
+  exact norm_mk_pi_algebra_fin_succ_le
+end
 
 lemma norm_mk_pi_algebra_fin_zero :
-  @norm (continuous_multilinear_map 𝕜 (λ (i : _), A) A) _
-    (continuous_multilinear_map.mk_pi_algebra_fin 𝕜 0 A) = ∥(1 : A)∥ :=
+  ∥continuous_multilinear_map.mk_pi_algebra_fin 𝕜 0 A∥ = ∥(1 : A)∥ :=
 begin
   refine le_antisymm _ _,
-  sorry,
-  convert ratio_le_op_norm _ (λ _, 1); [simp, apply_instance]
+  { have := λ f, @op_norm_le_bound 𝕜 (fin 0) (λ i, A) A _ _ _ _ _ _ _ f _ (norm_nonneg (1 : A)),
+    refine this _ _,
+    simp, },
+  { convert ratio_le_op_norm _ (λ _, (1 : A)),
+    simp }
 end
 
 @[simp] lemma norm_mk_pi_algebra_fin [norm_one_class A] :
-  @norm (continuous_multilinear_map 𝕜 (λ (i : _), A) A) _
-    (continuous_multilinear_map.mk_pi_algebra_fin 𝕜 n A) = 1 :=
+  ∥continuous_multilinear_map.mk_pi_algebra_fin 𝕜 n A∥ = 1 :=
 begin
   cases n,
   { simp [norm_mk_pi_algebra_fin_zero] },

--- a/src/analysis/normed_space/multilinear.lean
+++ b/src/analysis/normed_space/multilinear.lean
@@ -671,26 +671,9 @@ section
 
 variables (𝕜 ι) (A : Type*) [normed_comm_ring A] [normed_algebra 𝕜 A]
 
-/-- The continuous multilinear map on `A^ι`, where `A` is a normed commutative algebra
-over `𝕜`, associating to `m` the product of all the `m i`.
-
-See also `continuous_multilinear_map.mk_pi_algebra_fin`. -/
-protected def mk_pi_algebra : continuous_multilinear_map 𝕜 (λ i : ι, A) A :=
-multilinear_map.mk_continuous
-  (multilinear_map.mk_pi_algebra 𝕜 ι A) (if nonempty ι then 1 else ∥(1 : A)∥) $
-  begin
-    intro m,
-    casesI is_empty_or_nonempty ι with hι hι,
-    { simp [eq_empty_of_is_empty univ, not_nonempty_iff.2 hι] },
-    { simp [norm_prod_le' univ univ_nonempty, hι] }
-  end
-
 variables {A 𝕜 ι}
 
-@[simp] lemma mk_pi_algebra_apply (m : ι → A) :
-  continuous_multilinear_map.mk_pi_algebra 𝕜 ι A m = ∏ i, m i :=
-rfl
-
+@[simp]
 lemma norm_mk_pi_algebra_le [nonempty ι] :
   ∥continuous_multilinear_map.mk_pi_algebra 𝕜 ι A∥ ≤ 1 :=
 calc ∥continuous_multilinear_map.mk_pi_algebra 𝕜 ι A∥ ≤ if nonempty ι then 1 else ∥(1 : A)∥ :
@@ -724,26 +707,7 @@ section
 
 variables (𝕜 n) (A : Type*) [normed_ring A] [normed_algebra 𝕜 A]
 
-/-- The continuous multilinear map on `A^n`, where `A` is a normed algebra over `𝕜`, associating to
-`m` the product of all the `m i`.
-
-See also: `multilinear_map.mk_pi_algebra`. -/
-protected def mk_pi_algebra_fin : continuous_multilinear_map 𝕜 (λ i : fin n, A) A :=
-multilinear_map.mk_continuous
-  (multilinear_map.mk_pi_algebra_fin 𝕜 n A) (nat.cases_on n ∥(1 : A)∥ (λ _, 1)) $
-  begin
-    intro m,
-    cases n,
-    { simp },
-    { have : @list.of_fn A n.succ m ≠ [] := by simp,
-      simpa [← fin.prod_of_fn] using list.norm_prod_le' this }
-  end
-
 variables {A 𝕜 n}
-
-@[simp] lemma mk_pi_algebra_fin_apply (m : fin n → A) :
-  continuous_multilinear_map.mk_pi_algebra_fin 𝕜 n A m = (list.of_fn m).prod :=
-rfl
 
 lemma norm_mk_pi_algebra_fin_succ_le :
   ∥continuous_multilinear_map.mk_pi_algebra_fin 𝕜 n.succ A∥ ≤ 1 :=

--- a/src/analysis/normed_space/multilinear.lean
+++ b/src/analysis/normed_space/multilinear.lean
@@ -673,15 +673,17 @@ variables (𝕜 ι) (A : Type*) [normed_comm_ring A] [normed_algebra 𝕜 A]
 
 variables {A 𝕜 ι}
 
-#check @continuous_multilinear_map.has_op_norm
+-- set_option pp.implicit true
+
+-- local attribute [instance, priority 1001]
+--   comm_semiring.to_semiring
+-- #check continuous_multilinear_map.mk_pi_algebra 𝕜 ι A
+-- #check (sorry : continuous_multilinear_map 𝕜 (λ (i : ι), A) A)
 
 @[simp]
 lemma norm_mk_pi_algebra_le [nonempty ι] :
   @norm (continuous_multilinear_map 𝕜 (λ (i : ι), A) A) _
     (continuous_multilinear_map.mk_pi_algebra 𝕜 ι A) ≤ 1 :=
--- calc ∥continuous_multilinear_map.mk_pi_algebra 𝕜 ι A∥ ≤ if nonempty ι then 1 else ∥(1 : A)∥ :
---   multilinear_map.mk_continuous_norm_le _ (by split_ifs; simp [zero_le_one]) _
--- ... = _ : if_pos ‹_›
 begin
   have := λ f h', @op_norm_le_bound 𝕜 ι (λ i, A) A _ _ _ _ _ _ _ f _ zero_le_one h',
   refine this _ _,
@@ -694,18 +696,17 @@ lemma norm_mk_pi_algebra_of_empty [is_empty ι] :
   @norm (continuous_multilinear_map 𝕜 (λ (i : ι), A) A) _
     (continuous_multilinear_map.mk_pi_algebra 𝕜 ι A) = ∥(1 : A)∥ :=
 begin
-  refine (@norm_def 𝕜 ι (λ i, A) A _ _ _ _ _ _ _ _).trans _,
-  simp,
   apply le_antisymm,
-  calc ∥continuous_multilinear_map.mk_pi_algebra 𝕜 ι A∥ ≤ if nonempty ι then 1 else ∥(1 : A)∥ :
-    multilinear_map.mk_continuous_norm_le _ (by split_ifs; simp [zero_le_one]) _
-  ... = ∥(1 : A)∥ : if_neg (not_nonempty_iff.mpr ‹_›),
-  convert ratio_le_op_norm _ (λ _, (1 : A)),
-  simp [eq_empty_of_is_empty (univ : finset ι)],
+  { have := λ f h', @op_norm_le_bound 𝕜 ι (λ i, A) A _ _ _ _ _ _ _ f (∥(1 : A)∥) (norm_nonneg _) h',
+    refine this _ _,
+    simp, },
+  { convert ratio_le_op_norm _ (λ _, (1 : A)),
+    simp [eq_empty_of_is_empty (univ : finset ι)], },
 end
 
 @[simp] lemma norm_mk_pi_algebra [norm_one_class A] :
-  ∥continuous_multilinear_map.mk_pi_algebra 𝕜 ι A∥ = 1 :=
+  @norm (continuous_multilinear_map 𝕜 (λ (i : ι), A) A) _
+    (continuous_multilinear_map.mk_pi_algebra 𝕜 ι A) = 1 :=
 begin
   casesI is_empty_or_nonempty ι,
   { simp [norm_mk_pi_algebra_of_empty] },
@@ -723,22 +724,35 @@ variables (𝕜 n) (A : Type*) [normed_ring A] [normed_algebra 𝕜 A]
 variables {A 𝕜 n}
 
 lemma norm_mk_pi_algebra_fin_succ_le :
-  ∥continuous_multilinear_map.mk_pi_algebra_fin 𝕜 n.succ A∥ ≤ 1 :=
-multilinear_map.mk_continuous_norm_le _ zero_le_one _
+  @norm (continuous_multilinear_map 𝕜 (λ (i : _), A) A) _
+    (continuous_multilinear_map.mk_pi_algebra_fin 𝕜 n.succ A) ≤ 1 :=
+begin
+  have := λ f h', @op_norm_le_bound 𝕜 (fin n.succ) (λ i, A) A _ _ _ _ _ _ _ f _ zero_le_one h',
+  refine this _ _,
+  intros m,
+  simp only [continuous_multilinear_map.mk_pi_algebra_fin_apply, one_mul, list.of_fn_eq_map],
+  refine (list.norm_prod_le' _).trans_eq _,
+  simp,
+  sorry
+end
 
 lemma norm_mk_pi_algebra_fin_le_of_pos (hn : 0 < n) :
-  ∥continuous_multilinear_map.mk_pi_algebra_fin 𝕜 n A∥ ≤ 1 :=
+  @norm (continuous_multilinear_map 𝕜 (λ (i : _), A) A) _
+    (continuous_multilinear_map.mk_pi_algebra_fin 𝕜 n A) ≤ 1 :=
 by cases n; [exact hn.false.elim, exact norm_mk_pi_algebra_fin_succ_le]
 
 lemma norm_mk_pi_algebra_fin_zero :
-  ∥continuous_multilinear_map.mk_pi_algebra_fin 𝕜 0 A∥ = ∥(1 : A)∥ :=
+  @norm (continuous_multilinear_map 𝕜 (λ (i : _), A) A) _
+    (continuous_multilinear_map.mk_pi_algebra_fin 𝕜 0 A) = ∥(1 : A)∥ :=
 begin
-  refine le_antisymm (multilinear_map.mk_continuous_norm_le _ (norm_nonneg _) _) _,
+  refine le_antisymm _ _,
+  sorry,
   convert ratio_le_op_norm _ (λ _, 1); [simp, apply_instance]
 end
 
 @[simp] lemma norm_mk_pi_algebra_fin [norm_one_class A] :
-  ∥continuous_multilinear_map.mk_pi_algebra_fin 𝕜 n A∥ = 1 :=
+  @norm (continuous_multilinear_map 𝕜 (λ (i : _), A) A) _
+    (continuous_multilinear_map.mk_pi_algebra_fin 𝕜 n A) = 1 :=
 begin
   cases n,
   { simp [norm_mk_pi_algebra_fin_zero] },

--- a/src/analysis/normed_space/multilinear.lean
+++ b/src/analysis/normed_space/multilinear.lean
@@ -673,16 +673,29 @@ variables (𝕜 ι) (A : Type*) [normed_comm_ring A] [normed_algebra 𝕜 A]
 
 variables {A 𝕜 ι}
 
+#check @continuous_multilinear_map.has_op_norm
+
 @[simp]
 lemma norm_mk_pi_algebra_le [nonempty ι] :
-  ∥continuous_multilinear_map.mk_pi_algebra 𝕜 ι A∥ ≤ 1 :=
-calc ∥continuous_multilinear_map.mk_pi_algebra 𝕜 ι A∥ ≤ if nonempty ι then 1 else ∥(1 : A)∥ :
-  multilinear_map.mk_continuous_norm_le _ (by split_ifs; simp [zero_le_one]) _
-... = _ : if_pos ‹_›
+  @norm (continuous_multilinear_map 𝕜 (λ (i : ι), A) A) _
+    (continuous_multilinear_map.mk_pi_algebra 𝕜 ι A) ≤ 1 :=
+-- calc ∥continuous_multilinear_map.mk_pi_algebra 𝕜 ι A∥ ≤ if nonempty ι then 1 else ∥(1 : A)∥ :
+--   multilinear_map.mk_continuous_norm_le _ (by split_ifs; simp [zero_le_one]) _
+-- ... = _ : if_pos ‹_›
+begin
+  have := λ f h', @op_norm_le_bound 𝕜 ι (λ i, A) A _ _ _ _ _ _ _ f _ zero_le_one h',
+  refine this _ _,
+  intros m,
+  simp only [continuous_multilinear_map.mk_pi_algebra_apply, one_mul],
+  exact norm_prod_le' _ univ_nonempty _,
+end
 
 lemma norm_mk_pi_algebra_of_empty [is_empty ι] :
-  ∥continuous_multilinear_map.mk_pi_algebra 𝕜 ι A∥ = ∥(1 : A)∥ :=
+  @norm (continuous_multilinear_map 𝕜 (λ (i : ι), A) A) _
+    (continuous_multilinear_map.mk_pi_algebra 𝕜 ι A) = ∥(1 : A)∥ :=
 begin
+  refine (@norm_def 𝕜 ι (λ i, A) A _ _ _ _ _ _ _ _).trans _,
+  simp,
   apply le_antisymm,
   calc ∥continuous_multilinear_map.mk_pi_algebra 𝕜 ι A∥ ≤ if nonempty ι then 1 else ∥(1 : A)∥ :
     multilinear_map.mk_continuous_norm_le _ (by split_ifs; simp [zero_le_one]) _

--- a/src/topology/algebra/module/multilinear.lean
+++ b/src/topology/algebra/module/multilinear.lean
@@ -409,4 +409,48 @@ def pi_linear_equiv {ι' : Type*} {M' : ι' → Type*}
 
 end module
 
+section comm_algebra
+
+variables (R ι) (A : Type*) [fintype ι] [comm_semiring R] [comm_semiring A] [algebra R A]
+  [topological_space A] [has_continuous_mul A]
+
+/-- The continuous multilinear map on `A^ι`, where `A` is a normed commutative algebra
+over `𝕜`, associating to `m` the product of all the `m i`.
+
+See also `continuous_multilinear_map.mk_pi_algebra_fin`. -/
+protected def mk_pi_algebra : continuous_multilinear_map R (λ i : ι, A) A :=
+{ cont := continuous_finset_prod _ $ λ i hi, continuous_apply _,
+  to_multilinear_map := multilinear_map.mk_pi_algebra R ι A}
+
+@[simp] lemma mk_pi_algebra_apply (m : ι → A) :
+  continuous_multilinear_map.mk_pi_algebra R ι A m = ∏ i, m i :=
+rfl
+
+end comm_algebra
+
+section algebra
+
+variables (R n) (A : Type*) [comm_semiring R] [semiring A] [algebra R A]
+  [topological_space A] [has_continuous_mul A]
+
+/-- The continuous multilinear map on `A^n`, where `A` is a normed algebra over `𝕜`, associating to
+`m` the product of all the `m i`.
+
+See also: `continuous_multilinear_map.mk_pi_algebra`. -/
+protected def mk_pi_algebra_fin : continuous_multilinear_map R (λ i : fin n, A) A :=
+{ cont := begin
+    change continuous (λ m, (list.of_fn m).prod),
+    simp_rw list.of_fn_eq_map,
+    exact continuous_list_prod _ (λ i hi, continuous_apply _),
+  end,
+  to_multilinear_map := multilinear_map.mk_pi_algebra_fin R n A}
+
+variables {R n A}
+
+@[simp] lemma mk_pi_algebra_fin_apply (m : fin n → A) :
+  continuous_multilinear_map.mk_pi_algebra_fin R n A m = (list.of_fn m).prod :=
+rfl
+
+end algebra
+
 end continuous_multilinear_map

--- a/src/topology/algebra/module/multilinear.lean
+++ b/src/topology/algebra/module/multilinear.lean
@@ -437,7 +437,7 @@ variables (R n) (A : Type*) [comm_semiring R] [semiring A] [algebra R A]
 `m` the product of all the `m i`.
 
 See also: `continuous_multilinear_map.mk_pi_algebra`. -/
-protected def mk_pi_algebra_fin : continuous_multilinear_map R (λ i : fin n, A) A :=
+protected def mk_pi_algebra_fin : A [×n]→L[R] A :=
 { cont := begin
     change continuous (λ m, (list.of_fn m).prod),
     simp_rw list.of_fn_eq_map,


### PR DESCRIPTION
`continuous_multilinear_map.mk_pi_algebra` and `continuous_multilinear_map.mk_pi_algebra_fin` do not need a norm on either the algebra or base ring; all they need is a topology on the algebra compatible with multiplication.

The much weaker typeclasses cause some elaboration issues in a few places, as the normed space can no longer be found by unification. Adding a non-dependent version of `continuous_multilinear_map.has_op_norm` largely resolves this, although a few  API proofs about `mk_pi_algebra` and `mk_pi_algebra_fin` end up quite underscore heavy.

This is the first step in being able to define `exp` without first choosing a `norm`.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
