### PR TITLE
[Merged by Bors] - feat(group_theory/group_action/conj_act): conjugation by the units of a monoid

### DIFF
--- a/src/group_theory/group_action/conj_act.lean
+++ b/src/group_theory/group_action/conj_act.lean
@@ -5,6 +5,7 @@ Authors: Chris Hughes
 -/
 import group_theory.group_action.basic
 import group_theory.subgroup.basic
+import algebra.group_ring_action
 /-!
 # Conjugation action of a group on itself
 
@@ -16,6 +17,10 @@ the definition of conjugation as a homomorphism into the automorphism group.
 A type alias `conj_act G` is introduced for a group `G`. The group `conj_act G` acts on `G`
 by conjugation. The group `conj_act G` also acts on any normal subgroup of `G` by conjugation.
 
+As a generalization, this also allows:
+* `conj_act Mˣ` to act on `M`, when `M` is a `monoid`
+* `conj_act G₀` to act on `G₀`, when `G₀` is a `group_with_zero`
+
 ## Implementation Notes
 
 The scalar action in defined in this file can also be written using `mul_aut.conj g • h`. This
@@ -25,7 +30,7 @@ is that some theorems about the group actions will not apply when since this
 
 -/
 
-variables (G : Type*)
+variables (M G G₀ R K : Type*)
 
 /-- A type alias for a group `G`. `conj_act G` acts on `G` by conjugation -/
 def conj_act : Type* := G
@@ -33,7 +38,7 @@ def conj_act : Type* := G
 namespace conj_act
 open mul_action subgroup
 
-variable {G}
+variables {M G G₀ R K}
 
 instance : Π [group G], group (conj_act G) := id
 instance : Π [div_inv_monoid G], div_inv_monoid (conj_act G) := id
@@ -80,19 +85,62 @@ lemma smul_def (g : conj_act G) (h : G) : g • h = of_conj_act g * h * (of_conj
 
 end div_inv_monoid
 
+section units
+
+section monoid
+variables [monoid M]
+
+instance has_units_scalar : has_scalar (conj_act Mˣ) M :=
+{ smul := λ g h, of_conj_act g * h * ↑(of_conj_act g)⁻¹ }
+
+lemma units_smul_def (g : conj_act Mˣ) (h : M) : g • h = of_conj_act g * h * ↑(of_conj_act g)⁻¹ :=
+rfl
+
+instance units_mul_distrib_mul_action : mul_distrib_mul_action (conj_act Mˣ) M :=
+{ smul := (•),
+  one_smul := by simp [units_smul_def],
+  mul_smul := by simp [units_smul_def, mul_assoc, mul_inv_rev₀],
+  smul_mul := by simp [units_smul_def, mul_assoc],
+  smul_one := by simp [units_smul_def], }
+
+end monoid
+
+section semiring
+variables [semiring R]
+
+instance units_mul_semiring_action : mul_semiring_action (conj_act Rˣ) R :=
+{ smul := (•),
+  smul_zero := by simp [units_smul_def],
+  smul_add := by simp [units_smul_def, mul_add, add_mul],
+  ..conj_act.units_mul_distrib_mul_action}
+
+end semiring
+
+end units
+
 section group_with_zero
+variable [group_with_zero G₀]
 
-variable [group_with_zero G]
+@[simp] lemma of_conj_act_zero : of_conj_act (0 : conj_act G₀) = 0 := rfl
+@[simp] lemma to_conj_act_zero : to_conj_act (0 : G₀) = 0 := rfl
 
-@[simp] lemma of_conj_act_zero : of_conj_act (0 : conj_act G) = 0 := rfl
-@[simp] lemma to_conj_act_zero : to_conj_act (0 : G) = 0 := rfl
-
-instance : mul_action (conj_act G) G :=
+instance mul_action₀ : mul_action (conj_act G₀) G₀ :=
 { smul := (•),
   one_smul := by simp [smul_def],
   mul_smul := by simp [smul_def, mul_assoc, mul_inv_rev₀] }
 
 end group_with_zero
+
+section division_ring
+variables [division_ring K]
+
+instance distrib_mul_action₀ : distrib_mul_action (conj_act K) K :=
+{ smul := (•),
+  smul_zero := by simp [smul_def],
+  smul_add := by simp [smul_def, mul_add, add_mul],
+  ..conj_act.mul_action₀ }
+
+end division_ring
 
 variables [group G]
 


### PR DESCRIPTION
I suspect we can make this even more general in future by introducing a compatibility typeclass, but this is good enough for me for now.

This also adds a stronger typeclass for the existing action of `conj_act K` where `K` is a `division_ring`.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
