### PR TITLE
[Merged by Bors] - feat(topology/instances/ennreal): Add lemmas about continuity of ennreal subtraction.

### DIFF
--- a/src/topology/instances/ennreal.lean
+++ b/src/topology/instances/ennreal.lean
@@ -387,6 +387,60 @@ begin
   { simp only [H, true_or, ne.def, not_false_iff] }
 end
 
+lemma ennreal.continuous_on_sub :
+  continuous_on (λ p : ℝ≥0∞ × ℝ≥0∞, p.fst - p.snd) { p : ℝ≥0∞ × ℝ≥0∞ | p ≠ ⟨∞, ∞⟩ } :=
+begin
+  rw continuous_on,
+  rintros ⟨x, y⟩ hp,
+  simp only [ne.def, set.mem_set_of_eq, prod.mk.inj_iff] at hp,
+  refine tendsto_nhds_within_of_tendsto_nhds (ennreal.tendsto_sub (not_and_distrib.mp hp)),
+end
+
+lemma ennreal.continuous_sub_left {a : ℝ≥0∞} (a_ne_top : a ≠ ⊤) :
+  continuous (λ x, a - x) :=
+begin
+  rw (show (λ x, a - x) = (λ p : ℝ≥0∞ × ℝ≥0∞, p.fst - p.snd) ∘ (λ x, ⟨a, x⟩), by refl),
+  apply continuous_on.comp_continuous ennreal.continuous_on_sub (continuous.prod.mk a),
+  intro x,
+  simp only [a_ne_top, ne.def, mem_set_of_eq, prod.mk.inj_iff, false_and, not_false_iff],
+end
+
+lemma ennreal.continuous_nnreal_sub {a : ℝ≥0} :
+  continuous (λ (x : ℝ≥0∞), (a : ℝ≥0∞) - x) :=
+ennreal.continuous_sub_left ennreal.coe_ne_top
+
+lemma ennreal.continuous_on_sub_left (a : ℝ≥0∞) :
+  continuous_on (λ x, a - x) {x : ℝ≥0∞ | x ≠ ∞} :=
+begin
+  rw (show (λ x, a - x) = (λ p : ℝ≥0∞ × ℝ≥0∞, p.fst - p.snd) ∘ (λ x, ⟨a, x⟩), by refl),
+  apply continuous_on.comp ennreal.continuous_on_sub (continuous.continuous_on (continuous.prod.mk a)),
+  rintros _ h (_|_),
+  exact h ennreal.none_eq_top,
+end
+
+lemma ennreal.continuous_sub_right (a : ℝ≥0∞) :
+  continuous (λ x : ℝ≥0∞, x - a) :=
+begin
+  by_cases a_infty : a = ∞,
+  { simp [a_infty, continuous_const], },
+  { rw (show (λ x, x - a) = (λ p : ℝ≥0∞ × ℝ≥0∞, p.fst - p.snd) ∘ (λ x, ⟨x, a⟩), by refl),
+    apply continuous_on.comp_continuous
+      ennreal.continuous_on_sub (continuous_id'.prod_mk continuous_const),
+    intro x,
+    simp only [a_infty, ne.def, mem_set_of_eq, prod.mk.inj_iff, and_false, not_false_iff], },
+end
+
+lemma ennreal.continuous_sub_nnreal {a : ℝ≥0} :
+  continuous (λ (x : ℝ≥0∞), x - a) :=
+begin
+  let f := λ (x : ℝ≥0∞), (⟨x, a⟩ : ℝ≥0∞ × ℝ≥0∞),
+  rw (show (λ (x : ℝ≥0∞), x - a) = (λ p : ℝ≥0∞ × ℝ≥0∞, p.fst - p.snd) ∘ f, by refl),
+  apply continuous_on.comp_continuous ennreal.continuous_on_sub
+    (continuous_id'.prod_mk continuous_const),
+  intros x con,
+  simpa using (show (f x).2 = ∞, from (congr_arg prod.snd con).trans rfl),
+end
+
 protected lemma tendsto.pow {f : filter α} {m : α → ℝ≥0∞} {a : ℝ≥0∞} {n : ℕ}
   (hm : tendsto m f (𝓝 a)) :
   tendsto (λ x, (m x) ^ n) f (𝓝 (a ^ n)) :=

--- a/src/topology/instances/ennreal.lean
+++ b/src/topology/instances/ennreal.lean
@@ -387,58 +387,47 @@ begin
   { simp only [H, true_or, ne.def, not_false_iff] }
 end
 
-lemma ennreal.continuous_on_sub :
+lemma continuous_on_sub :
   continuous_on (λ p : ℝ≥0∞ × ℝ≥0∞, p.fst - p.snd) { p : ℝ≥0∞ × ℝ≥0∞ | p ≠ ⟨∞, ∞⟩ } :=
 begin
   rw continuous_on,
   rintros ⟨x, y⟩ hp,
   simp only [ne.def, set.mem_set_of_eq, prod.mk.inj_iff] at hp,
-  refine tendsto_nhds_within_of_tendsto_nhds (ennreal.tendsto_sub (not_and_distrib.mp hp)),
+  refine tendsto_nhds_within_of_tendsto_nhds (tendsto_sub (not_and_distrib.mp hp)),
 end
 
-lemma ennreal.continuous_sub_left {a : ℝ≥0∞} (a_ne_top : a ≠ ⊤) :
+lemma continuous_sub_left {a : ℝ≥0∞} (a_ne_top : a ≠ ⊤) :
   continuous (λ x, a - x) :=
 begin
   rw (show (λ x, a - x) = (λ p : ℝ≥0∞ × ℝ≥0∞, p.fst - p.snd) ∘ (λ x, ⟨a, x⟩), by refl),
-  apply continuous_on.comp_continuous ennreal.continuous_on_sub (continuous.prod.mk a),
+  apply continuous_on.comp_continuous continuous_on_sub (continuous.prod.mk a),
   intro x,
   simp only [a_ne_top, ne.def, mem_set_of_eq, prod.mk.inj_iff, false_and, not_false_iff],
 end
 
-lemma ennreal.continuous_nnreal_sub {a : ℝ≥0} :
+lemma continuous_nnreal_sub {a : ℝ≥0} :
   continuous (λ (x : ℝ≥0∞), (a : ℝ≥0∞) - x) :=
-ennreal.continuous_sub_left ennreal.coe_ne_top
+continuous_sub_left coe_ne_top
 
-lemma ennreal.continuous_on_sub_left (a : ℝ≥0∞) :
+lemma continuous_on_sub_left (a : ℝ≥0∞) :
   continuous_on (λ x, a - x) {x : ℝ≥0∞ | x ≠ ∞} :=
 begin
   rw (show (λ x, a - x) = (λ p : ℝ≥0∞ × ℝ≥0∞, p.fst - p.snd) ∘ (λ x, ⟨a, x⟩), by refl),
-  apply continuous_on.comp ennreal.continuous_on_sub (continuous.continuous_on (continuous.prod.mk a)),
+  apply continuous_on.comp continuous_on_sub (continuous.continuous_on (continuous.prod.mk a)),
   rintros _ h (_|_),
-  exact h ennreal.none_eq_top,
+  exact h none_eq_top,
 end
 
-lemma ennreal.continuous_sub_right (a : ℝ≥0∞) :
+lemma continuous_sub_right (a : ℝ≥0∞) :
   continuous (λ x : ℝ≥0∞, x - a) :=
 begin
   by_cases a_infty : a = ∞,
   { simp [a_infty, continuous_const], },
   { rw (show (λ x, x - a) = (λ p : ℝ≥0∞ × ℝ≥0∞, p.fst - p.snd) ∘ (λ x, ⟨x, a⟩), by refl),
     apply continuous_on.comp_continuous
-      ennreal.continuous_on_sub (continuous_id'.prod_mk continuous_const),
+      continuous_on_sub (continuous_id'.prod_mk continuous_const),
     intro x,
     simp only [a_infty, ne.def, mem_set_of_eq, prod.mk.inj_iff, and_false, not_false_iff], },
-end
-
-lemma ennreal.continuous_sub_nnreal {a : ℝ≥0} :
-  continuous (λ (x : ℝ≥0∞), x - a) :=
-begin
-  let f := λ (x : ℝ≥0∞), (⟨x, a⟩ : ℝ≥0∞ × ℝ≥0∞),
-  rw (show (λ (x : ℝ≥0∞), x - a) = (λ p : ℝ≥0∞ × ℝ≥0∞, p.fst - p.snd) ∘ f, by refl),
-  apply continuous_on.comp_continuous ennreal.continuous_on_sub
-    (continuous_id'.prod_mk continuous_const),
-  intros x con,
-  simpa using (show (f x).2 = ∞, from (congr_arg prod.snd con).trans rfl),
 end
 
 protected lemma tendsto.pow {f : filter α} {m : α → ℝ≥0∞} {a : ℝ≥0∞} {n : ℕ}


### PR DESCRIPTION
`ennreal` does not have continuous `sub`. This PR adds `ennreal.continuous_on_sub` and related lemmas, which give the continuity of the subtraction in more restricted/specialized setups.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
