### PR TITLE
[Merged by Bors] - feat(ring_theory/dedekind_domain/adic_valuation): extend valuation

### DIFF
--- a/src/ring_theory/dedekind_domain/adic_valuation.lean
+++ b/src/ring_theory/dedekind_domain/adic_valuation.lean
@@ -376,57 +376,57 @@ ring of integers, denoted `v.adic_completion_integers`. -/
 variable {K}
 
 /-- `K` as a valued field with the `v`-adic valuation. -/
-def v_valued_K : valued K (with_zero (multiplicative ℤ)) := ⟨v.valuation⟩
+def adic_valued : valued K (with_zero (multiplicative ℤ)) := ⟨v.valuation⟩
 
-lemma v_valued_K_def {x : K} : @valued.v K _ _ _ (v_valued_K v) (x) = v.valuation_def x := rfl
+lemma adic_valued_def {x : K} : @valued.v K _ _ _ v.adic_valued (x) = v.valuation_def x := rfl
 
 /-- The topological space structure on `K` corresponding to the `v`-adic valuation.
   This cannot be made an instance since it depends on the choice of `v`. -/
-def v_valued_K_topological_space : topological_space K :=
-@valued.topological_space K _ _ _ v.v_valued_K
+def adic_valued_topological_space : topological_space K :=
+@valued.topological_space K _ _ _ v.adic_valued
 
-lemma v_valued_K_topological_division_ring :
-  @topological_division_ring K _ v.v_valued_K_topological_space :=
-@valued.topological_division_ring K _ _ _ v.v_valued_K
+lemma adic_valued_topological_division_ring :
+  @topological_division_ring K _ v.adic_valued_topological_space :=
+@valued.topological_division_ring K _ _ _ v.adic_valued
 
-lemma v_valued_K_topological_ring : @topological_ring K  v.v_valued_K_topological_space _ :=
+lemma adic_valued_topological_ring : @topological_ring K  v.adic_valued_topological_space _ :=
 infer_instance
 
-lemma v_valued_K_topological_add_group :
-  @topological_add_group K v.v_valued_K_topological_space _ := infer_instance
+lemma adic_valued_topological_add_group :
+  @topological_add_group K v.adic_valued_topological_space _ := infer_instance
 
 /-- The uniform space structure on `K` corresponding to the `v`-adic valuation. -/
-def v_valued_K_uniform_space : uniform_space K :=
-@topological_add_group.to_uniform_space K _ v.v_valued_K_topological_space
-  v.v_valued_K_topological_add_group
+def adic_valued_uniform_space : uniform_space K :=
+@topological_add_group.to_uniform_space K _ v.adic_valued_topological_space
+  v.adic_valued_topological_add_group
 
-lemma v_valued_K_uniform_add_group : @uniform_add_group K v.v_valued_K_uniform_space _ :=
-@topological_add_group_is_uniform K _ v.v_valued_K_topological_space
-  v.v_valued_K_topological_add_group
+lemma adic_valued_uniform_add_group : @uniform_add_group K v.adic_valued_uniform_space _ :=
+@topological_add_group_is_uniform K _ v.adic_valued_topological_space
+  v.adic_valued_topological_add_group
 
-lemma v_valued_K_completable_top_field : @completable_top_field K _ v.v_valued_K_uniform_space :=
-@valued.completable K _ _ _ (v_valued_K v)
+lemma adic_valued_completable_top_field : @completable_top_field K _ v.adic_valued_uniform_space :=
+@valued.completable K _ _ _ (adic_valued v)
 
-lemma v_valued_K_separated_space : @separated_space K v.v_valued_K_uniform_space :=
-@valued_ring.separated K _ _ _ (v_valued_K v)
+lemma adic_valued_separated_space : @separated_space K v.adic_valued_uniform_space :=
+@valued_ring.separated K _ _ _ (adic_valued v)
 
 variables (K)
 
 /-- The completion of `K` with respect to its `v`-adic valuation. -/
-def adic_completion := @uniform_space.completion K v.v_valued_K_uniform_space
+def adic_completion := @uniform_space.completion K v.adic_valued_uniform_space
 
 instance : field (v.adic_completion K) :=
-@field_completion K _ v.v_valued_K_uniform_space v.v_valued_K_topological_division_ring _
-  v.v_valued_K_uniform_add_group
+@field_completion K _ v.adic_valued_uniform_space v.adic_valued_topological_division_ring _
+  v.adic_valued_uniform_add_group
 
 instance : inhabited (v.adic_completion K) := ⟨0⟩
 
 variables {K}
 instance valued_adic_completion : valued (v.adic_completion K) (with_zero (multiplicative ℤ)) :=
-⟨@valued.extension_valuation K _ _ _ (v_valued_K v)⟩
+⟨@valued.extension_valuation K _ _ _ v.adic_valued⟩
 
 lemma valued_adic_completion_def {x : v.adic_completion K} :
-  valued.v (x) = @valued.extension K _ _ _ (v_valued_K v)  x := rfl
+  valued.v (x) = @valued.extension K _ _ _ (adic_valued v)  x := rfl
 
 instance adic_completion_topological_space : topological_space (v.adic_completion K) :=
 @valued.topological_space (v.adic_completion K) _ _ _ v.valued_adic_completion
@@ -435,27 +435,18 @@ instance adic_completion_topological_division_ring :
   @topological_division_ring (v.adic_completion K) _ v.adic_completion_topological_space :=
 @valued.topological_division_ring (v.adic_completion K) _ _ _ v.valued_adic_completion
 
-instance adic_completion_topological_ring :
-  @topological_ring (v.adic_completion K) v.adic_completion_topological_space _ :=
-v.adic_completion_topological_division_ring.to_topological_ring
-
-instance adic_completion_topological_add_group :
-  @topological_add_group (v.adic_completion K) v.adic_completion_topological_space _ :=
-@topological_ring.to_topological_add_group (v.adic_completion K) _
-  v.adic_completion_topological_space v.adic_completion_topological_ring
-
 instance adic_completion_uniform_space : uniform_space (v.adic_completion K) :=
-@uniform_space.completion.uniform_space K v.v_valued_K_uniform_space
+@uniform_space.completion.uniform_space K v.adic_valued_uniform_space
 
 instance adic_completion_uniform_add_group :
   @uniform_add_group (v.adic_completion K) v.adic_completion_uniform_space _ :=
-@uniform_space.completion.uniform_add_group K v.v_valued_K_uniform_space _
-  v.v_valued_K_uniform_add_group
+@uniform_space.completion.uniform_add_group K v.adic_valued_uniform_space _
+  v.adic_valued_uniform_add_group
 
 instance adic_completion_complete_space : complete_space (v.adic_completion K) :=
-@uniform_space.completion.complete_space K v.v_valued_K_uniform_space
+@uniform_space.completion.complete_space K v.adic_valued_uniform_space
 
-instance : has_lift_t K (@uniform_space.completion K v.v_valued_K_uniform_space) := infer_instance
+instance : has_lift_t K (@uniform_space.completion K v.adic_valued_uniform_space) := infer_instance
 
 instance adic_completion.has_lift_t : has_lift_t K (v.adic_completion K) :=
 uniform_space.completion.has_lift_t v

--- a/src/ring_theory/dedekind_domain/adic_valuation.lean
+++ b/src/ring_theory/dedekind_domain/adic_valuation.lean
@@ -378,7 +378,7 @@ variable {K}
 /-- `K` as a valued field with the `v`-adic valuation. -/
 def adic_valued : valued K (with_zero (multiplicative ℤ)) := ⟨v.valuation⟩
 
-lemma adic_valued_def {x : K} : @valued.v K _ _ _ v.adic_valued (x) = v.valuation_def x := rfl
+lemma adic_valued_def {x : K} : (v.adic_valued.v : _) x = v.valuation_def x := rfl
 
 /-- The topological space structure on `K` corresponding to the `v`-adic valuation.
   This cannot be made an instance since it depends on the choice of `v`. -/
@@ -387,7 +387,7 @@ def adic_valued_topological_space : topological_space K :=
 
 lemma adic_valued_topological_division_ring :
   @topological_division_ring K _ v.adic_valued_topological_space :=
-@valued.topological_division_ring K _ _ _ v.adic_valued
+infer_instance
 
 lemma adic_valued_topological_ring : @topological_ring K  v.adic_valued_topological_space _ :=
 infer_instance
@@ -428,12 +428,12 @@ instance valued_adic_completion : valued (v.adic_completion K) (with_zero (multi
 lemma valued_adic_completion_def {x : v.adic_completion K} :
   valued.v (x) = @valued.extension K _ _ _ (adic_valued v)  x := rfl
 
-instance adic_completion_topological_space : topological_space (v.adic_completion K) :=
-@valued.topological_space (v.adic_completion K) _ _ _ v.valued_adic_completion
-
 instance adic_completion_topological_division_ring :
-  @topological_division_ring (v.adic_completion K) _ v.adic_completion_topological_space :=
+  topological_division_ring (v.adic_completion K) :=
 @valued.topological_division_ring (v.adic_completion K) _ _ _ v.valued_adic_completion
+
+instance adic_completion_topological_space : topological_space (v.adic_completion K) :=
+infer_instance
 
 instance adic_completion_uniform_space : uniform_space (v.adic_completion K) :=
 @uniform_space.completion.uniform_space K v.adic_valued_uniform_space

--- a/src/ring_theory/dedekind_domain/adic_valuation.lean
+++ b/src/ring_theory/dedekind_domain/adic_valuation.lean
@@ -249,7 +249,7 @@ let s := classical.some (classical.some_spec (is_localization.mk'_surjective
 
 variable (K)
 /-- The valuation of `k ∈ K` is independent on how we express `k` as a fraction. -/
-lemma int_valuation_div_eq_div {r r' : R} {s s' : non_zero_divisors R}
+lemma int_valuation_div_eq {r r' : R} {s s' : non_zero_divisors R}
   (h_mk : is_localization.mk' K r s = is_localization.mk' K r' s') :
   (v.int_valuation_def r)/(v.int_valuation_def s) =
   (v.int_valuation_def r')/(v.int_valuation_def s') :=
@@ -264,14 +264,14 @@ lemma valuation_of_mk' {r : R} {s : non_zero_divisors R} :
   v.valuation_def (is_localization.mk' K r s) = (v.int_valuation_def r)/(v.int_valuation_def s) :=
 begin
   rw valuation_def,
-  exact int_valuation_div_eq_div K v
+  exact int_valuation_div_eq K v
     (classical.some_spec (classical.some_spec (is_localization.mk'_surjective (non_zero_divisors R)
     (is_localization.mk' K r s)))),
 end
 
 variable {K}
 /-- The `v`-adic valuation on `K` extends the `v`-adic valuation on `R`. -/
-lemma valuation_of_algebra_map {r : R} :
+lemma valuation_of_algebra_map (r : R) :
   v.valuation_def (algebra_map R K r) = v.int_valuation_def r :=
 by rw [← is_localization.mk'_one K r, valuation_of_mk', submonoid.coe_one,
     int_valuation.map_one', div_one _]
@@ -285,14 +285,14 @@ lemma valuation_lt_one_iff_dvd (r : R) :
   v.valuation_def (algebra_map R K r) < 1 ↔ v.as_ideal ∣ ideal.span {r} :=
 by { rw valuation_of_algebra_map, exact v.int_valuation_lt_one_iff_dvd r }
 
-/-- The `v`-adic valuation of `0 : R` equals 0. -/
+/-- The `v`-adic valuation of `0 : K` equals 0. -/
 lemma valuation.map_zero' : v.valuation_def (0 : K) = 0 :=
 begin
   rw [← (algebra_map R K).map_zero, valuation_of_algebra_map v],
   exact v.int_valuation.map_zero',
 end
 
-/-- The `v`-adic valuation of `1 : R` equals 1. -/
+/-- The `v`-adic valuation of `1 : K` equals 1. -/
 lemma valuation.map_one' : v.valuation_def (1 : K) = 1 :=
 begin
   rw [← (algebra_map R K).map_one, valuation_of_algebra_map v],
@@ -305,7 +305,7 @@ lemma valuation.map_mul' (x y : K) :
 begin
   rw [valuation_def, valuation_def, valuation_def, div_mul_div_comm₀, ← int_valuation.map_mul',
     ← int_valuation.map_mul', ← submonoid.coe_mul],
-  apply int_valuation_div_eq_div K v,
+  apply int_valuation_div_eq K v,
   rw [(classical.some_spec (valuation_def._proof_2 (x * y))), is_fraction_ring.mk'_eq_div,
     (algebra_map R K).map_mul, submonoid.coe_mul, (algebra_map R K).map_mul, ← div_mul_div_comm₀,
     ← is_fraction_ring.mk'_eq_div, ← is_fraction_ring.mk'_eq_div,
@@ -333,8 +333,8 @@ begin
     { exact with_zero.zero_lt_coe _ },
     { exact non_zero_divisors.ne_zero
         (submonoid.mul_mem (non_zero_divisors R) sx.property sy.property), }},
-  rw [int_valuation_div_eq_div K v h_frac_x, int_valuation_div_eq_div K v h_frac_y,
-    int_valuation_div_eq_div K v h_frac_xy, le_max_iff, div_le_div_right₀ (ne_of_gt h_denom),
+  rw [int_valuation_div_eq K v h_frac_x, int_valuation_div_eq K v h_frac_y,
+    int_valuation_div_eq K v h_frac_xy, le_max_iff, div_le_div_right₀ (ne_of_gt h_denom),
     div_le_div_right₀ (ne_of_gt h_denom), ← le_max_iff],
   exact v.int_valuation.map_add_le_max' _ _,
 end
@@ -380,13 +380,14 @@ def v_valued_K : valued K (with_zero (multiplicative ℤ)) := ⟨v.valuation⟩
 
 lemma v_valued_K_def {x : K} : @valued.v K _ _ _ (v_valued_K v) (x) = v.valuation_def x := rfl
 
-/-- The topological space structure on `K` corresponding to the `v`-adic valuation. -/
+/-- The topological space structure on `K` corresponding to the `v`-adic valuation.
+  This cannot be made an instance since it depends on the choice of `v`. -/
 def v_valued_K_topological_space : topological_space K :=
-@valued.topological_space K _ _ _ (v_valued_K v)
+@valued.topological_space K _ _ _ v.v_valued_K
 
-lemma v_valued_K_topological_division_ring :
+def v_valued_K_topological_division_ring :
   @topological_division_ring K _ v.v_valued_K_topological_space :=
-@valued.topological_division_ring K _ _ _ (v_valued_K v)
+@valued.topological_division_ring K _ _ _ v.v_valued_K
 
 lemma v_valued_K_topological_ring : @topological_ring K  v.v_valued_K_topological_space _ :=
 infer_instance
@@ -410,6 +411,7 @@ lemma v_valued_K_separated_space : @separated_space K v.v_valued_K_uniform_space
 @valued_ring.separated K _ _ _ (v_valued_K v)
 
 variables (K)
+
 /-- The completion of `K` with respect to its `v`-adic valuation. -/
 def adic_completion := @uniform_space.completion K v.v_valued_K_uniform_space
 
@@ -452,6 +454,7 @@ instance adic_completion_uniform_add_group :
   v.adic_completion_topological_add_group
 
 instance : has_lift_t K (@uniform_space.completion K v.v_valued_K_uniform_space) := infer_instance
+
 instance adic_completion.has_lift_t : has_lift_t K (v.adic_completion K) :=
 uniform_space.completion.has_lift_t v
 

--- a/src/ring_theory/dedekind_domain/adic_valuation.lean
+++ b/src/ring_theory/dedekind_domain/adic_valuation.lean
@@ -445,13 +445,15 @@ instance adic_completion_topological_add_group :
   v.adic_completion_topological_space v.adic_completion_topological_ring
 
 instance adic_completion_uniform_space : uniform_space (v.adic_completion K) :=
-@topological_add_group.to_uniform_space (v.adic_completion K) _
-  v.adic_completion_topological_space v.adic_completion_topological_add_group
+@uniform_space.completion.uniform_space K v.v_valued_K_uniform_space
 
 instance adic_completion_uniform_add_group :
   @uniform_add_group (v.adic_completion K) v.adic_completion_uniform_space _ :=
-@topological_add_group_is_uniform (v.adic_completion K) _ v.adic_completion_topological_space
-  v.adic_completion_topological_add_group
+@uniform_space.completion.uniform_add_group K v.v_valued_K_uniform_space _
+  v.v_valued_K_uniform_add_group
+
+instance adic_completion_complete_space : complete_space (v.adic_completion K) :=
+@uniform_space.completion.complete_space K v.v_valued_K_uniform_space
 
 instance : has_lift_t K (@uniform_space.completion K v.v_valued_K_uniform_space) := infer_instance
 

--- a/src/ring_theory/dedekind_domain/adic_valuation.lean
+++ b/src/ring_theory/dedekind_domain/adic_valuation.lean
@@ -385,7 +385,7 @@ lemma v_valued_K_def {x : K} : @valued.v K _ _ _ (v_valued_K v) (x) = v.valuatio
 def v_valued_K_topological_space : topological_space K :=
 @valued.topological_space K _ _ _ v.v_valued_K
 
-def v_valued_K_topological_division_ring :
+lemma v_valued_K_topological_division_ring :
   @topological_division_ring K _ v.v_valued_K_topological_space :=
 @valued.topological_division_ring K _ _ _ v.v_valued_K
 

--- a/src/ring_theory/dedekind_domain/adic_valuation.lean
+++ b/src/ring_theory/dedekind_domain/adic_valuation.lean
@@ -340,8 +340,8 @@ begin
 end
 
 /-- The `v`-adic valuation on `K`. -/
-def valuation  : valuation K (with_zero (multiplicative ℤ)) := {
-  to_fun    := v.valuation_def,
+def valuation  : valuation K (with_zero (multiplicative ℤ)) :=
+{ to_fun    := v.valuation_def,
   map_zero' := valuation.map_zero' v,
   map_one'  := valuation.map_one' v,
   map_mul'  := valuation.map_mul' v,

--- a/src/ring_theory/dedekind_domain/adic_valuation.lean
+++ b/src/ring_theory/dedekind_domain/adic_valuation.lean
@@ -376,33 +376,22 @@ ring of integers, denoted `v.adic_completion_integers`. -/
 variable {K}
 
 /-- `K` as a valued field with the `v`-adic valuation. -/
-def adic_valued : valued K (with_zero (multiplicative ℤ)) := ⟨v.valuation⟩
+def adic_valued : valued K (with_zero (multiplicative ℤ)) := valued.mk' v.valuation
 
 lemma adic_valued_def {x : K} : (v.adic_valued.v : _) x = v.valuation_def x := rfl
+
+
+/-- The uniform space structure on `K` corresponding to the `v`-adic valuation.
+This cannot be made an instance since it depends on the choice of `v`. -/
+def adic_valued_uniform_space : uniform_space K := v.adic_valued.to_uniform_space
+
+lemma adic_valued_uniform_add_group : @uniform_add_group K v.adic_valued_uniform_space _ :=
+v.adic_valued.to_uniform_add_group
 
 /-- The topological space structure on `K` corresponding to the `v`-adic valuation.
   This cannot be made an instance since it depends on the choice of `v`. -/
 def adic_valued_topological_space : topological_space K :=
-@valued.topological_space K _ _ _ v.adic_valued
-
-lemma adic_valued_topological_division_ring :
-  @topological_division_ring K _ v.adic_valued_topological_space :=
-infer_instance
-
-lemma adic_valued_topological_ring : @topological_ring K  v.adic_valued_topological_space _ :=
-infer_instance
-
-lemma adic_valued_topological_add_group :
-  @topological_add_group K v.adic_valued_topological_space _ := infer_instance
-
-/-- The uniform space structure on `K` corresponding to the `v`-adic valuation. -/
-def adic_valued_uniform_space : uniform_space K :=
-@topological_add_group.to_uniform_space K _ v.adic_valued_topological_space
-  v.adic_valued_topological_add_group
-
-lemma adic_valued_uniform_add_group : @uniform_add_group K v.adic_valued_uniform_space _ :=
-@topological_add_group_is_uniform K _ v.adic_valued_topological_space
-  v.adic_valued_topological_add_group
+v.adic_valued_uniform_space.to_topological_space
 
 lemma adic_valued_completable_top_field : @completable_top_field K _ v.adic_valued_uniform_space :=
 @valued.completable K _ _ _ (adic_valued v)
@@ -416,33 +405,18 @@ variables (K)
 def adic_completion := @uniform_space.completion K v.adic_valued_uniform_space
 
 instance : field (v.adic_completion K) :=
-@field_completion K _ v.adic_valued_uniform_space v.adic_valued_topological_division_ring _
-  v.adic_valued_uniform_add_group
+@field_completion K _ v.adic_valued_uniform_space _ _ v.adic_valued_uniform_add_group
 
 instance : inhabited (v.adic_completion K) := ⟨0⟩
 
 variables {K}
 instance valued_adic_completion : valued (v.adic_completion K) (with_zero (multiplicative ℤ)) :=
-⟨@valued.extension_valuation K _ _ _ v.adic_valued⟩
+valued.mk' (@valued.extension_valuation K _ _ _ v.adic_valued)
 
 lemma valued_adic_completion_def {x : v.adic_completion K} :
-  valued.v (x) = @valued.extension K _ _ _ (adic_valued v)  x := rfl
+  valued.v x = @valued.extension K _ _ _ (adic_valued v)  x := rfl
 
-instance adic_completion_topological_division_ring :
-  topological_division_ring (v.adic_completion K) :=
-@valued.topological_division_ring (v.adic_completion K) _ _ _ v.valued_adic_completion
-
-instance adic_completion_topological_space : topological_space (v.adic_completion K) :=
-infer_instance
-
-instance adic_completion_uniform_space : uniform_space (v.adic_completion K) :=
-@uniform_space.completion.uniform_space K v.adic_valued_uniform_space
-
-instance adic_completion_uniform_add_group :
-  @uniform_add_group (v.adic_completion K) v.adic_completion_uniform_space _ :=
-@uniform_space.completion.uniform_add_group K v.adic_valued_uniform_space _
-  v.adic_valued_uniform_add_group
-
+--Fails
 instance adic_completion_complete_space : complete_space (v.adic_completion K) :=
 @uniform_space.completion.complete_space K v.adic_valued_uniform_space
 

--- a/src/ring_theory/dedekind_domain/adic_valuation.lean
+++ b/src/ring_theory/dedekind_domain/adic_valuation.lean
@@ -337,12 +337,11 @@ instance : inhabited (v.adic_completion K) := ⟨0⟩
 
 variables {K}
 instance valued_adic_completion : valued (v.adic_completion K) (with_zero (multiplicative ℤ)) :=
-valued.mk' (@valued.extension_valuation K _ _ _ v.adic_valued)
+@valued.valued_completion _ _ _ _ v.adic_valued
 
 lemma valued_adic_completion_def {x : v.adic_completion K} :
   valued.v x = @valued.extension K _ _ _ (adic_valued v)  x := rfl
 
---Fails
 instance adic_completion_complete_space : complete_space (v.adic_completion K) :=
 @uniform_space.completion.complete_space K v.adic_valued_uniform_space
 

--- a/src/ring_theory/dedekind_domain/adic_valuation.lean
+++ b/src/ring_theory/dedekind_domain/adic_valuation.lean
@@ -4,8 +4,8 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: María Inés de Frutos-Fernández
 -/
 import ring_theory.dedekind_domain.ideal
-import ring_theory.valuation.integers
 import ring_theory.valuation.extend_to_localization
+import ring_theory.valuation.valuation_subring
 import topology.algebra.valued_field
 
 /-!
@@ -244,16 +244,16 @@ end
 /-- The `v`-adic valuation of `x ∈ K` is the valuation of `r` divided by the valuation of `s`,
 where `r` and `s` are chosen so that `x = r/s`. -/
 def valuation  (v : height_one_spectrum R) : valuation K (with_zero (multiplicative ℤ)) :=
-valuation.extend_to_localization v.int_valuation
+v.int_valuation.extend_to_localization
   (λ r hr, set.mem_compl (v.int_valuation_ne_zero' ⟨r, hr⟩)) K
 
 lemma valuation_def (x : K) : v.valuation x = valuation.extend_to_localization v.int_valuation
-  (λ r hr, set.mem_compl (v.int_valuation_ne_zero' ⟨r, hr⟩)) K  x :=
+  (λ r hr, set.mem_compl (v.int_valuation_ne_zero' ⟨r, hr⟩)) K x :=
 rfl
 
 /-- The `v`-adic valuation of `r/s ∈ K` is the valuation of `r` divided by the valuation of `s`. -/
 lemma valuation_of_mk' {r : R} {s : non_zero_divisors R} :
-  v.valuation (is_localization.mk' K r s) = (v.int_valuation_def r)/(v.int_valuation_def s) :=
+  v.valuation (is_localization.mk' K r s) = (v.int_valuation r)/(v.int_valuation s) :=
 begin
   erw [valuation_def, (is_localization.to_localization_map (non_zero_divisors R) K).lift_mk',
     div_eq_mul_inv, mul_eq_mul_left_iff],
@@ -264,8 +264,8 @@ end
 
 /-- The `v`-adic valuation on `K` extends the `v`-adic valuation on `R`. -/
 lemma valuation_of_algebra_map (r : R) :
-  v.valuation (algebra_map R K r) = v.int_valuation_def r :=
-by { rw [valuation_def, valuation.extend_to_localization_apply_map_apply], refl }
+  v.valuation (algebra_map R K r) = v.int_valuation r :=
+by rw [valuation_def, valuation.extend_to_localization_apply_map_apply]
 
 /-- The `v`-adic valuation on `R` is bounded above by 1. -/
 lemma valuation_le_one (r : R) : v.valuation (algebra_map R K r) ≤ 1 :=
@@ -305,33 +305,15 @@ variable {K}
 /-- `K` as a valued field with the `v`-adic valuation. -/
 def adic_valued : valued K (with_zero (multiplicative ℤ)) := valued.mk' v.valuation
 
-lemma adic_valued_def {x : K} : (v.adic_valued.v : _) x = v.valuation x := rfl
-
-/-- The uniform space structure on `K` corresponding to the `v`-adic valuation.
-This cannot be made an instance since it depends on the choice of `v`. -/
-def adic_valued_uniform_space : uniform_space K := v.adic_valued.to_uniform_space
-
-lemma adic_valued_uniform_add_group : @uniform_add_group K v.adic_valued_uniform_space _ :=
-v.adic_valued.to_uniform_add_group
-
-/-- The topological space structure on `K` corresponding to the `v`-adic valuation.
-  This cannot be made an instance since it depends on the choice of `v`. -/
-def adic_valued_topological_space : topological_space K :=
-v.adic_valued_uniform_space.to_topological_space
-
-lemma adic_valued_completable_top_field : @completable_top_field K _ v.adic_valued_uniform_space :=
-@valued.completable K _ _ _ (adic_valued v)
-
-lemma adic_valued_separated_space : @separated_space K v.adic_valued_uniform_space :=
-@valued_ring.separated K _ _ _ (adic_valued v)
+lemma adic_valued_apply {x : K} : (v.adic_valued.v : _) x = v.valuation x := rfl
 
 variables (K)
 
 /-- The completion of `K` with respect to its `v`-adic valuation. -/
-def adic_completion := @uniform_space.completion K v.adic_valued_uniform_space
+def adic_completion := @uniform_space.completion K v.adic_valued.to_uniform_space
 
 instance : field (v.adic_completion K) :=
-@field_completion K _ v.adic_valued_uniform_space _ _ v.adic_valued_uniform_add_group
+@field_completion K _ v.adic_valued.to_uniform_space _ _ v.adic_valued.to_uniform_add_group
 
 instance : inhabited (v.adic_completion K) := ⟨0⟩
 
@@ -343,15 +325,14 @@ lemma valued_adic_completion_def {x : v.adic_completion K} :
   valued.v x = @valued.extension K _ _ _ (adic_valued v)  x := rfl
 
 instance adic_completion_complete_space : complete_space (v.adic_completion K) :=
-@uniform_space.completion.complete_space K v.adic_valued_uniform_space
+@uniform_space.completion.complete_space K v.adic_valued.to_uniform_space
 
 instance adic_completion.has_lift_t : has_lift_t K (v.adic_completion K) :=
-(infer_instance : has_lift_t K (@uniform_space.completion K v.adic_valued_uniform_space))
+(infer_instance : has_lift_t K (@uniform_space.completion K v.adic_valued.to_uniform_space))
 
 variables (K)
 /-- The ring of integers of `adic_completion`. -/
-def adic_completion_integers : subring (v.adic_completion K) :=
-@valuation.integer (v.adic_completion K) (with_zero (multiplicative ℤ)) _ _
-  v.valued_adic_completion.v
+def adic_completion_integers : valuation_subring (v.adic_completion K) :=
+valuation.valuation_subring v.valued_adic_completion.v
 
 end is_dedekind_domain.height_one_spectrum

--- a/src/ring_theory/dedekind_domain/adic_valuation.lean
+++ b/src/ring_theory/dedekind_domain/adic_valuation.lean
@@ -420,10 +420,8 @@ lemma valued_adic_completion_def {x : v.adic_completion K} :
 instance adic_completion_complete_space : complete_space (v.adic_completion K) :=
 @uniform_space.completion.complete_space K v.adic_valued_uniform_space
 
-instance : has_lift_t K (@uniform_space.completion K v.adic_valued_uniform_space) := infer_instance
-
 instance adic_completion.has_lift_t : has_lift_t K (v.adic_completion K) :=
-uniform_space.completion.has_lift_t v
+(infer_instance : has_lift_t K (@uniform_space.completion K v.adic_valued_uniform_space))
 
 variables (K)
 /-- The ring of integers of `adic_completion`. -/

--- a/src/ring_theory/dedekind_domain/adic_valuation.lean
+++ b/src/ring_theory/dedekind_domain/adic_valuation.lean
@@ -234,26 +234,25 @@ begin
   apply congr_arg,
   rw [neg_inj, ← int.coe_nat_one, int.coe_nat_inj'],
   rw [← ideal.dvd_span_singleton, ← associates.mk_le_mk_iff_dvd_iff] at mem nmem,
-  rw [← pow_one ( associates.mk v.as_ideal),
-    associates.prime_pow_dvd_iff_le hπ hv]  at mem,
+  rw [← pow_one (associates.mk v.as_ideal), associates.prime_pow_dvd_iff_le hπ hv] at mem,
   rw [associates.mk_pow, associates.prime_pow_dvd_iff_le hπ hv, not_le] at nmem,
   exact nat.eq_of_le_of_lt_succ mem nmem,
 end
 
 /-! ### Adic valuations on the field of fractions `K` -/
+
 /-- The `v`-adic valuation of `x ∈ K` is the valuation of `r` divided by the valuation of `s`,
 where `r` and `s` are chosen so that `x = r/s`. -/
-def valuation  (v : height_one_spectrum R) : valuation K (with_zero (multiplicative ℤ)) :=
-v.int_valuation.extend_to_localization
-  (λ r hr, set.mem_compl (v.int_valuation_ne_zero' ⟨r, hr⟩)) K
+def valuation (v : height_one_spectrum R) : valuation K (with_zero (multiplicative ℤ)) :=
+v.int_valuation.extend_to_localization (λ r hr, set.mem_compl $ v.int_valuation_ne_zero' ⟨r, hr⟩) K
 
-lemma valuation_def (x : K) : v.valuation x = valuation.extend_to_localization v.int_valuation
+lemma valuation_def (x : K) : v.valuation x = v.int_valuation.extend_to_localization
   (λ r hr, set.mem_compl (v.int_valuation_ne_zero' ⟨r, hr⟩)) K x :=
 rfl
 
 /-- The `v`-adic valuation of `r/s ∈ K` is the valuation of `r` divided by the valuation of `s`. -/
 lemma valuation_of_mk' {r : R} {s : non_zero_divisors R} :
-  v.valuation (is_localization.mk' K r s) = (v.int_valuation r)/(v.int_valuation s) :=
+  v.valuation (is_localization.mk' K r s) = v.int_valuation r / v.int_valuation s :=
 begin
   erw [valuation_def, (is_localization.to_localization_map (non_zero_divisors R) K).lift_mk',
     div_eq_mul_inv, mul_eq_mul_left_iff],
@@ -291,11 +290,12 @@ end
 lemma valuation_uniformizer_ne_zero :
   (classical.some (v.valuation_exists_uniformizer K)) ≠ 0 :=
 begin
-  have hu := (classical.some_spec (v.valuation_exists_uniformizer K)),
+  have hu := classical.some_spec (v.valuation_exists_uniformizer K),
   exact (valuation.ne_zero_iff _).mp (ne_of_eq_of_ne hu with_zero.coe_ne_zero),
 end
 
 /-! ### Completions with respect to adic valuations
+
 Given a Dedekind domain `R` with field of fractions `K` and a maximal ideal `v` of `R`, we define
 the completion of `K` with respect to its `v`-adic valuation, denoted `v.adic_completion`, and its
 ring of integers, denoted `v.adic_completion_integers`. -/
@@ -317,12 +317,11 @@ instance : field (v.adic_completion K) :=
 
 instance : inhabited (v.adic_completion K) := ⟨0⟩
 
-variables {K}
 instance valued_adic_completion : valued (v.adic_completion K) (with_zero (multiplicative ℤ)) :=
 @valued.valued_completion _ _ _ _ v.adic_valued
 
 lemma valued_adic_completion_def {x : v.adic_completion K} :
-  valued.v x = @valued.extension K _ _ _ (adic_valued v)  x := rfl
+  valued.v x = @valued.extension K _ _ _ (adic_valued v) x := rfl
 
 instance adic_completion_complete_space : complete_space (v.adic_completion K) :=
 @uniform_space.completion.complete_space K v.adic_valued.to_uniform_space
@@ -330,9 +329,7 @@ instance adic_completion_complete_space : complete_space (v.adic_completion K) :
 instance adic_completion.has_lift_t : has_lift_t K (v.adic_completion K) :=
 (infer_instance : has_lift_t K (@uniform_space.completion K v.adic_valued.to_uniform_space))
 
-variables (K)
 /-- The ring of integers of `adic_completion`. -/
-def adic_completion_integers : valuation_subring (v.adic_completion K) :=
-valuation.valuation_subring v.valued_adic_completion.v
+def adic_completion_integers : valuation_subring (v.adic_completion K) := valued.v.valuation_subring
 
 end is_dedekind_domain.height_one_spectrum

--- a/src/ring_theory/dedekind_domain/adic_valuation.lean
+++ b/src/ring_theory/dedekind_domain/adic_valuation.lean
@@ -5,6 +5,7 @@ Authors: María Inés de Frutos-Fernández
 -/
 import ring_theory.dedekind_domain.ideal
 import ring_theory.valuation.integers
+import ring_theory.valuation.extend_to_localization
 import topology.algebra.valued_field
 
 /-!
@@ -242,119 +243,47 @@ end
 /-! ### Adic valuations on the field of fractions `K` -/
 /-- The `v`-adic valuation of `x ∈ K` is the valuation of `r` divided by the valuation of `s`,
 where `r` and `s` are chosen so that `x = r/s`. -/
-def valuation_def (x : K) : (with_zero (multiplicative ℤ)) :=
-let s := classical.some (classical.some_spec (is_localization.mk'_surjective
-  (non_zero_divisors R) x)) in (v.int_valuation_def (classical.some
-    (is_localization.mk'_surjective (non_zero_divisors R) x)))/(v.int_valuation_def s)
+def valuation  (v : height_one_spectrum R) : valuation K (with_zero (multiplicative ℤ)) :=
+valuation.extend_to_localization v.int_valuation
+  (λ r hr, set.mem_compl (v.int_valuation_ne_zero' ⟨r, hr⟩)) K
 
-variable (K)
-/-- The valuation of `k ∈ K` is independent on how we express `k` as a fraction. -/
-lemma int_valuation_div_eq {r r' : R} {s s' : non_zero_divisors R}
-  (h_mk : is_localization.mk' K r s = is_localization.mk' K r' s') :
-  (v.int_valuation_def r)/(v.int_valuation_def s) =
-  (v.int_valuation_def r')/(v.int_valuation_def s') :=
-begin
-  rw [div_eq_div_iff (int_valuation_ne_zero' v s) (int_valuation_ne_zero' v s'),
-    ← int_valuation.map_mul', ← int_valuation.map_mul',
-    is_fraction_ring.injective R K (is_localization.mk'_eq_iff_eq.mp h_mk)],
-end
+lemma valuation_def (x : K) : v.valuation x = valuation.extend_to_localization v.int_valuation
+  (λ r hr, set.mem_compl (v.int_valuation_ne_zero' ⟨r, hr⟩)) K  x :=
+rfl
 
 /-- The `v`-adic valuation of `r/s ∈ K` is the valuation of `r` divided by the valuation of `s`. -/
 lemma valuation_of_mk' {r : R} {s : non_zero_divisors R} :
-  v.valuation_def (is_localization.mk' K r s) = (v.int_valuation_def r)/(v.int_valuation_def s) :=
+  v.valuation (is_localization.mk' K r s) = (v.int_valuation_def r)/(v.int_valuation_def s) :=
 begin
-  rw valuation_def,
-  exact int_valuation_div_eq K v
-    (classical.some_spec (classical.some_spec (is_localization.mk'_surjective (non_zero_divisors R)
-    (is_localization.mk' K r s)))),
+  erw [valuation_def, (is_localization.to_localization_map (non_zero_divisors R) K).lift_mk',
+    div_eq_mul_inv, mul_eq_mul_left_iff],
+  left,
+  rw [units.coe_inv', inv_inj],
+  refl,
 end
 
-variable {K}
 /-- The `v`-adic valuation on `K` extends the `v`-adic valuation on `R`. -/
 lemma valuation_of_algebra_map (r : R) :
-  v.valuation_def (algebra_map R K r) = v.int_valuation_def r :=
-by rw [← is_localization.mk'_one K r, valuation_of_mk', submonoid.coe_one,
-    int_valuation.map_one', div_one _]
+  v.valuation (algebra_map R K r) = v.int_valuation_def r :=
+by { rw [valuation_def, valuation.extend_to_localization_apply_map_apply], refl }
 
 /-- The `v`-adic valuation on `R` is bounded above by 1. -/
-lemma valuation_le_one (r : R) : v.valuation_def (algebra_map R K r) ≤ 1 :=
+lemma valuation_le_one (r : R) : v.valuation (algebra_map R K r) ≤ 1 :=
 by { rw valuation_of_algebra_map, exact v.int_valuation_le_one r }
 
 /-- The `v`-adic valuation of `r ∈ R` is less than 1 if and only if `v` divides the ideal `(r)`. -/
 lemma valuation_lt_one_iff_dvd (r : R) :
-  v.valuation_def (algebra_map R K r) < 1 ↔ v.as_ideal ∣ ideal.span {r} :=
+  v.valuation (algebra_map R K r) < 1 ↔ v.as_ideal ∣ ideal.span {r} :=
 by { rw valuation_of_algebra_map, exact v.int_valuation_lt_one_iff_dvd r }
-
-/-- The `v`-adic valuation of `0 : K` equals 0. -/
-lemma valuation.map_zero' : v.valuation_def (0 : K) = 0 :=
-begin
-  rw [← (algebra_map R K).map_zero, valuation_of_algebra_map v],
-  exact v.int_valuation.map_zero',
-end
-
-/-- The `v`-adic valuation of `1 : K` equals 1. -/
-lemma valuation.map_one' : v.valuation_def (1 : K) = 1 :=
-begin
-  rw [← (algebra_map R K).map_one, valuation_of_algebra_map v],
-  exact v.int_valuation.map_one',
-end
-
-/-- The `v`-adic valuation of a product is the product of the valuations. -/
-lemma valuation.map_mul' (x y : K) :
-  v.valuation_def (x * y) = v.valuation_def x * v.valuation_def y :=
-begin
-  rw [valuation_def, valuation_def, valuation_def, div_mul_div_comm₀, ← int_valuation.map_mul',
-    ← int_valuation.map_mul', ← submonoid.coe_mul],
-  apply int_valuation_div_eq K v,
-  rw [(classical.some_spec (valuation_def._proof_2 (x * y))), is_fraction_ring.mk'_eq_div,
-    (algebra_map R K).map_mul, submonoid.coe_mul, (algebra_map R K).map_mul, ← div_mul_div_comm₀,
-    ← is_fraction_ring.mk'_eq_div, ← is_fraction_ring.mk'_eq_div,
-    (classical.some_spec (valuation_def._proof_2 x)),
-    (classical.some_spec (valuation_def._proof_2 y))],
-end
-
-/-- The `v`-adic valuation of a sum is bounded above by the maximum of the valuations. -/
-lemma valuation.map_add_le_max' (x y : K) :
-  v.valuation_def (x + y) ≤ max (v.valuation_def x) (v.valuation_def y) :=
-begin
-  obtain ⟨rx, sx, hx⟩ := is_localization.mk'_surjective (non_zero_divisors R) x,
-  obtain ⟨rxy, sxy, hxy⟩ := is_localization.mk'_surjective (non_zero_divisors R) (x + y),
-  obtain ⟨ry, sy, hy⟩ := is_localization.mk'_surjective (non_zero_divisors R) y,
-  rw [← hxy, ← hx, ← hy, valuation_of_mk', valuation_of_mk', valuation_of_mk'],
-  have h_frac_xy : is_localization.mk' K rxy sxy =
-    is_localization.mk' K (rx*(sy : R) + ry*(sx : R)) (sx*sy),
-  { rw [is_localization.mk'_add, hx, hy, hxy], },
-  have h_frac_x : is_localization.mk' K rx sx = is_localization.mk' K (rx*(sy : R)) (sx*sy),
-  { rw [is_localization.mk'_eq_iff_eq, submonoid.coe_mul, mul_assoc, mul_comm (sy : R) _], },
-  have h_frac_y : is_localization.mk' K ry sy = is_localization.mk' K (ry*(sx : R)) (sx*sy),
-  { rw [is_localization.mk'_eq_iff_eq, submonoid.coe_mul, mul_assoc], },
-  have h_denom : 0 < v.int_valuation_def ↑(sx * sy),
-  { rw [int_valuation_def, if_neg _],
-    { exact with_zero.zero_lt_coe _ },
-    { exact non_zero_divisors.ne_zero
-        (submonoid.mul_mem (non_zero_divisors R) sx.property sy.property), }},
-  rw [int_valuation_div_eq K v h_frac_x, int_valuation_div_eq K v h_frac_y,
-    int_valuation_div_eq K v h_frac_xy, le_max_iff, div_le_div_right₀ (ne_of_gt h_denom),
-    div_le_div_right₀ (ne_of_gt h_denom), ← le_max_iff],
-  exact v.int_valuation.map_add_le_max' _ _,
-end
-
-/-- The `v`-adic valuation on `K`. -/
-def valuation  : valuation K (with_zero (multiplicative ℤ)) :=
-{ to_fun    := v.valuation_def,
-  map_zero' := valuation.map_zero' v,
-  map_one'  := valuation.map_one' v,
-  map_mul'  := valuation.map_mul' v,
-  map_add_le_max'  := valuation.map_add_le_max' v }
 
 variable (K)
 /-- There exists `π ∈ K` with `v`-adic valuation `multiplicative.of_add (-1)`. -/
 lemma valuation_exists_uniformizer :
-  ∃ (π : K), v.valuation_def π = multiplicative.of_add (-1 : ℤ) :=
+  ∃ (π : K), v.valuation π = multiplicative.of_add (-1 : ℤ) :=
 begin
   obtain ⟨r, hr⟩ := v.int_valuation_exists_uniformizer,
   use algebra_map R K r,
-  rw valuation_of_algebra_map v,
+  rw [valuation_def, valuation.extend_to_localization_apply_map_apply],
   exact hr,
 end
 
@@ -363,8 +292,6 @@ lemma valuation_uniformizer_ne_zero :
   (classical.some (v.valuation_exists_uniformizer K)) ≠ 0 :=
 begin
   have hu := (classical.some_spec (v.valuation_exists_uniformizer K)),
-  have h : v.valuation_def (classical.some _) = valuation v (classical.some _) := rfl,
-  rw h at hu,
   exact (valuation.ne_zero_iff _).mp (ne_of_eq_of_ne hu with_zero.coe_ne_zero),
 end
 
@@ -378,8 +305,7 @@ variable {K}
 /-- `K` as a valued field with the `v`-adic valuation. -/
 def adic_valued : valued K (with_zero (multiplicative ℤ)) := valued.mk' v.valuation
 
-lemma adic_valued_def {x : K} : (v.adic_valued.v : _) x = v.valuation_def x := rfl
-
+lemma adic_valued_def {x : K} : (v.adic_valued.v : _) x = v.valuation x := rfl
 
 /-- The uniform space structure on `K` corresponding to the `v`-adic valuation.
 This cannot be made an instance since it depends on the choice of `v`. -/


### PR DESCRIPTION
We extend the `v`-adic valuation on a Dedekind domain `R` to its field of fractions `K` and prove some basic properties. We define the completion of `K` with respect to this valuation, as well as its ring of integers, and provide some topological instances.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
