### PR TITLE
[Merged by Bors] - feat(analysis/calculus/specific_functions): define normed bump functions

### DIFF
--- a/src/analysis/calculus/specific_functions.lean
+++ b/src/analysis/calculus/specific_functions.lean
@@ -31,6 +31,9 @@ function cannot have:
   function: real numbers `r`, `R`, and proofs of `0 < r < R`. The function itself is available
   through `coe_fn`.
 
+* If `f : cont_diff_bump_of_inner c` and `μ` is a measure on the domain of `f`, then `f.normed μ`
+  is a smooth bump function with integral `1` w.r.t. `μ`.
+
 * `f : cont_diff_bump c`, where `c` is a point in a finite dimensional real vector space, is a
   bundled smooth function such that
 

--- a/src/analysis/calculus/specific_functions.lean
+++ b/src/analysis/calculus/specific_functions.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2020 Sébastien Gouëzel. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Sébastien Gouëzel
+Authors: Sébastien Gouëzel, Floris van Doorn
 -/
 import analysis.calculus.iterated_deriv
 import analysis.inner_product_space.euclidean_dist

--- a/src/analysis/calculus/specific_functions.lean
+++ b/src/analysis/calculus/specific_functions.lean
@@ -348,28 +348,6 @@ lemma eventually_eq_one_of_mem_ball (h : x ∈ ball c f.r) :
 lemma eventually_eq_one : f =ᶠ[𝓝 c] 1 :=
 f.eventually_eq_one_of_mem_ball (mem_ball_self f.r_pos)
 
-protected lemma cont_diff_at {n} :
-  cont_diff_at ℝ n f x :=
-begin
-  rcases em (x = c) with rfl|hx,
-  { refine cont_diff_at.congr_of_eventually_eq _ f.eventually_eq_one,
-    rw pi.one_def,
-    exact cont_diff_at_const },
-  { exact real.smooth_transition.cont_diff_at.comp x
-      (cont_diff_at.div_const $ cont_diff_at_const.sub $
-        cont_diff_at_id.dist cont_diff_at_const hx) }
-end
-
-protected lemma cont_diff : cont_diff ℝ n f :=
-cont_diff_iff_cont_diff_at.2 $ λ y, f.cont_diff_at
-
-protected lemma cont_diff_within_at {s} :
-  cont_diff_within_at ℝ n f s x :=
-f.cont_diff_at.cont_diff_within_at
-
-protected lemma continuous : continuous f :=
-cont_diff_zero.mp f.cont_diff
-
 /-- `cont_diff_bump` is `𝒞ⁿ` in all its arguments. -/
 protected lemma _root_.cont_diff_at.cont_diff_bump {c g : X → E}
   {f : ∀ x, cont_diff_bump_of_inner (c x)} {x : X}
@@ -394,6 +372,17 @@ lemma _root_.cont_diff.cont_diff_bump {c g : X → E} {f : ∀ x, cont_diff_bump
   (hg : cont_diff ℝ n g) : cont_diff ℝ n (λ x, f x (g x)) :=
 by { rw [cont_diff_iff_cont_diff_at] at *, exact λ x, (hc x).cont_diff_bump (hr x) (hR x) (hg x) }
 
+protected lemma cont_diff : cont_diff ℝ n f :=
+cont_diff_const.cont_diff_bump cont_diff_const cont_diff_const cont_diff_id
+
+protected lemma cont_diff_at : cont_diff_at ℝ n f x :=
+f.cont_diff.cont_diff_at
+
+protected lemma cont_diff_within_at {s : set E} : cont_diff_within_at ℝ n f s x :=
+f.cont_diff_at.cont_diff_within_at
+
+protected lemma continuous : continuous f :=
+cont_diff_zero.mp f.cont_diff
 
 open measure_theory
 variables [measurable_space E] {μ : measure E}

--- a/src/analysis/normed/group/basic.lean
+++ b/src/analysis/normed/group/basic.lean
@@ -158,6 +158,12 @@ by rw [← dist_zero_left, ← dist_add_left g 0 h, add_zero]
 @[simp] theorem dist_self_add_left (g h : E) : dist (g + h) g = ∥h∥ :=
 by rw [dist_comm, dist_self_add_right]
 
+@[simp] theorem dist_self_sub_right (g h : E) : dist g (g - h) = ∥h∥ :=
+by rw [sub_eq_add_neg, dist_self_add_right, norm_neg]
+
+@[simp] theorem dist_self_sub_left (g h : E) : dist (g - h) g = ∥h∥ :=
+by rw [dist_comm, dist_self_sub_right]
+
 /-- **Triangle inequality** for the norm. -/
 lemma norm_add_le (g h : E) : ∥g + h∥ ≤ ∥g∥ + ∥h∥ :=
 by simpa [dist_eq_norm] using dist_triangle g 0 (-h)

--- a/src/measure_theory/function/l1_space.lean
+++ b/src/measure_theory/function/l1_space.lean
@@ -833,6 +833,10 @@ lemma integrable.mul_const {f : α → ℝ} (h : integrable f μ) (c : ℝ) :
   integrable (λ x, f x * c) μ :=
 by simp_rw [mul_comm, h.const_mul _]
 
+lemma integrable.div_const {f : α → ℝ} (h : integrable f μ) (c : ℝ) :
+  integrable (λ x, f x / c) μ :=
+by simp_rw [div_eq_mul_inv, h.mul_const]
+
 end normed_space
 
 section normed_space_over_complete_field

--- a/src/order/cover.lean
+++ b/src/order/cover.lean
@@ -113,3 +113,15 @@ lemma covby.Icc_eq (h : a ⋖ b) : Icc a b = {a, b} :=
 by { rw [←set.Ico_union_right h.le, h.Ico_eq], refl }
 
 end partial_order
+
+section linear_order
+
+variables [linear_order α] {a b : α}
+
+lemma covby.Ioi_eq (h : a ⋖ b) : Ioi a = Ici b :=
+by rw [← Ioo_union_Ici_eq_Ioi h.lt, h.Ioo_eq, empty_union]
+
+lemma covby.Iio_eq (h : a ⋖ b) : Iio b = Iic a :=
+by rw [← Iic_union_Ioo_eq_Iio h.lt, h.Ioo_eq, union_empty]
+
+end linear_order

--- a/src/topology/algebra/order/basic.lean
+++ b/src/topology/algebra/order/basic.lean
@@ -559,6 +559,20 @@ lemma continuous.if_le [topological_space γ] [Π x, decidable (f x ≤ g x)] {f
   continuous (λ x, if f x ≤ g x then f' x else g' x) :=
 continuous_if_le hf hg hf'.continuous_on hg'.continuous_on hfg
 
+lemma continuous_at.eventually_lt {x₀ : β} (hf : continuous_at f x₀)
+  (hg : continuous_at g x₀) (hfg : f x₀ < g x₀) : ∀ᶠ x in 𝓝 x₀, f x < g x :=
+begin
+  by_cases h : f x₀ ⋖ g x₀,
+  { filter_upwards [hf.preimage_mem_nhds (Iio_mem_nhds hfg),
+      hg.preimage_mem_nhds (Ioi_mem_nhds hfg)],
+    rw [h.Iio_eq],
+    exact λ x hfx hgx, lt_of_le_of_lt hfx hgx },
+  { obtain ⟨z, hfz, hzg⟩ := (not_covby_iff hfg).mp h,
+    filter_upwards [hf.preimage_mem_nhds (Iio_mem_nhds hfz),
+      hg.preimage_mem_nhds (Ioi_mem_nhds hzg)],
+    exact λ x, lt_trans },
+end
+
 @[continuity] lemma continuous.min (hf : continuous f) (hg : continuous g) :
   continuous (λb, min (f b) (g b)) :=
 by { simp only [min_def], exact hf.if_le hg hf hg (λ x, id) }

--- a/src/topology/algebra/order/basic.lean
+++ b/src/topology/algebra/order/basic.lean
@@ -559,19 +559,21 @@ lemma continuous.if_le [topological_space γ] [Π x, decidable (f x ≤ g x)] {f
   continuous (λ x, if f x ≤ g x then f' x else g' x) :=
 continuous_if_le hf hg hf'.continuous_on hg'.continuous_on hfg
 
-lemma continuous_at.eventually_lt {x₀ : β} (hf : continuous_at f x₀)
-  (hg : continuous_at g x₀) (hfg : f x₀ < g x₀) : ∀ᶠ x in 𝓝 x₀, f x < g x :=
+lemma tendsto.eventually_lt {l : filter γ} {f g : γ → α} {y z : α}
+  (hf : tendsto f l (𝓝 y)) (hg : tendsto g l (𝓝 z)) (hyz : y < z) : ∀ᶠ x in l, f x < g x :=
 begin
-  by_cases h : f x₀ ⋖ g x₀,
-  { filter_upwards [hf.preimage_mem_nhds (Iio_mem_nhds hfg),
-      hg.preimage_mem_nhds (Ioi_mem_nhds hfg)],
+  by_cases h : y ⋖ z,
+  { filter_upwards [hf (Iio_mem_nhds hyz), hg (Ioi_mem_nhds hyz)],
     rw [h.Iio_eq],
     exact λ x hfx hgx, lt_of_le_of_lt hfx hgx },
-  { obtain ⟨z, hfz, hzg⟩ := (not_covby_iff hfg).mp h,
-    filter_upwards [hf.preimage_mem_nhds (Iio_mem_nhds hfz),
-      hg.preimage_mem_nhds (Ioi_mem_nhds hzg)],
+  { obtain ⟨w, hyw, hwz⟩ := (not_covby_iff hyz).mp h,
+    filter_upwards [hf (Iio_mem_nhds hyw), hg (Ioi_mem_nhds hwz)],
     exact λ x, lt_trans },
 end
+
+lemma continuous_at.eventually_lt {x₀ : β} (hf : continuous_at f x₀)
+  (hg : continuous_at g x₀) (hfg : f x₀ < g x₀) : ∀ᶠ x in 𝓝 x₀, f x < g x :=
+tendsto.eventually_lt hf hg hfg
 
 @[continuity] lemma continuous.min (hf : continuous f) (hg : continuous g) :
   continuous (λb, min (f b) (g b)) :=


### PR DESCRIPTION
* Normed bump functions have integral 1 w.r.t. the specified measure.
* Also add a few more properties of bump functions, including its smoothness in all arguments (including midpoint and the two radii).
* From the sphere eversion project
* Required for convolutions

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
