### PR TITLE
[Merged by Bors] - feat(src/number_theory/cyclotomic/discriminant): add discr_prime_pow_ne_two

### DIFF
--- a/src/number_theory/cyclotomic/discriminant.lean
+++ b/src/number_theory/cyclotomic/discriminant.lean
@@ -53,41 +53,102 @@ end is_primitive_root
 
 namespace is_cyclotomic_extension
 
-variables {p : ℕ+} (k : ℕ) {K : Type u} {L : Type v} {ζ : L} [field K] [field L]
-variables [algebra K L] [ne_zero ((p : ℕ) : K)]
+variables {p : ℕ+} {k : ℕ} {K : Type u} {L : Type v} {ζ : L} [field K] [field L]
+variables [algebra K L]
 
-/-- If `p` is an odd prime and `is_cyclotomic_extension {p} K L`, then
-`discr K (hζ.power_basis K).basis = (-1) ^ ((p - 1) / 2) * p ^ (p - 2)`. -/
-lemma discr_odd_prime [is_cyclotomic_extension {p} K L] [hp : fact (p : ℕ).prime]
-  (hζ : is_primitive_root ζ p) (hirr : irreducible (cyclotomic p K)) (hodd : p ≠ 2) :
+/-- If `p` is a prime and `is_cyclotomic_extension {p ^ (k + 1)} K L`, then the discriminant of
+`hζ.power_basis K` is `(-1) ^ ((p ^ (k + 1).totient) / 2) * p ^ (p ^ k * ((p - 1) * (k + 1) - 1))`
+if `irreducible (cyclotomic (p ^ (k + 1)) K))`, `irreducible (cyclotomic p K)` and
+`p ^ (k + 1) ≠ 2`. -/
+lemma discr_prime_pow_ne_two [is_cyclotomic_extension {p ^ (k + 1)} K L] [hp : fact (p : ℕ).prime]
+  [ne_zero ((p : ℕ) : K)] (hζ : is_primitive_root ζ ↑(p ^ (k + 1)))
+  (hirr : irreducible (cyclotomic (↑(p ^ (k + 1)) : ℕ) K))
+  (hirr₁ : irreducible (cyclotomic (p : ℕ) K)) (hk : p ^ (k + 1) ≠ 2) :
   discr K (hζ.power_basis K).basis =
-  (-1) ^ (((p : ℕ) - 1) / 2) * p ^ ((p : ℕ) - 2) :=
+  (-1) ^ (((p ^ (k + 1) : ℕ).totient) / 2) * p ^ ((p : ℕ) ^ k * ((p - 1) * (k + 1) - 1)) :=
 begin
-  have hodd' : (p : ℕ) ≠ 2 := λ hn, by exact hodd.symm (pnat.coe_inj.1 hn.symm),
-  have hpos := pos_iff_ne_zero.2 (λ h, (tsub_pos_of_lt (prime.one_lt hp.out)).ne.symm h),
+  haveI : ne_zero ((↑(p ^ (k + 1)) : ℕ) : K),
+  { refine ⟨λ hzero, _⟩,
+    rw [pnat.pow_coe] at hzero,
+    simpa [ne_zero.ne ((p : ℕ) : K)] using hzero },
+  have hp2 : p = 2 → 1 ≤ k,
+  { intro hp,
+    refine one_le_iff_ne_zero.2 (λ h, _),
+    rw [h, hp, zero_add, pow_one] at hk,
+    exact hk rfl },
 
   rw [discr_power_basis_eq_norm, finrank _ hirr, hζ.power_basis_gen _,
-    ← hζ.minpoly_eq_cyclotomic_of_irreducible hirr, totient_prime hp.out],
+    ← hζ.minpoly_eq_cyclotomic_of_irreducible hirr, pnat.pow_coe, totient_prime_pow hp.out
+    (succ_pos k)],
   congr' 1,
-  { have h := even_sub_one_of_prime_ne_two hp.out hodd',
-    rw [← mul_one 2, ← nat.div_mul_div_comm (even_iff_two_dvd.1 h) (one_dvd _), nat.div_one,
-      mul_one, mul_comm, pow_mul],
-    congr' 1,
-    exact (nat.even.sub_odd (one_le_iff_ne_zero.2 hpos.ne') h $ odd_iff.2 rfl).neg_one_pow },
-  { have H := congr_arg derivative (cyclotomic_prime_mul_X_sub_one K p),
-    rw [derivative_mul, derivative_sub, derivative_one, derivative_X, sub_zero, mul_one,
-      derivative_sub, derivative_one, sub_zero, derivative_X_pow] at H,
+  { by_cases hptwo : p = 2,
+    { obtain ⟨k₁, hk₁⟩ := nat.exists_eq_succ_of_ne_zero (one_le_iff_ne_zero.1 (hp2 hptwo)),
+      rw [hk₁, succ_sub_one, hptwo, pnat.coe_bit0, pnat.one_coe, succ_sub_succ_eq_sub, tsub_zero,
+        mul_one, pow_succ, mul_assoc, nat.mul_div_cancel_left _ zero_lt_two,
+        nat.mul_div_cancel_left _ zero_lt_two],
+      by_cases hk₁zero : k₁ = 0,
+      { simp [hk₁zero] },
+      obtain ⟨k₂, rfl⟩ := nat.exists_eq_succ_of_ne_zero hk₁zero,
+      rw [pow_succ, mul_assoc, pow_mul (-1 : K), pow_mul (-1 : K), neg_one_sq, one_pow, one_pow] },
+    { simp only [succ_sub_succ_eq_sub, tsub_zero],
+      replace hptwo : ↑p ≠ 2,
+      { intro h,
+        rw [← pnat.one_coe, ← pnat.coe_bit0, pnat.coe_inj] at h,
+        exact hptwo h },
+      obtain ⟨a, ha⟩ := even_sub_one_of_prime_ne_two hp.out hptwo,
+      rw [mul_comm ((p : ℕ) ^ k), mul_assoc, ha],
+      nth_rewrite 0 [← mul_one a],
+      nth_rewrite 4 [← mul_one a],
+      rw [← nat.mul_succ, mul_comm a, mul_assoc, mul_assoc 2, nat.mul_div_cancel_left _
+        zero_lt_two, nat.mul_div_cancel_left _ zero_lt_two, ← mul_assoc, mul_comm
+        (a * (p : ℕ) ^ k), pow_mul, ← ha],
+      congr' 1,
+      refine odd.neg_one_pow (nat.even.sub_odd (nat.succ_le_iff.2 (mul_pos (tsub_pos_iff_lt.2
+        hp.out.one_lt) (pow_pos hp.out.pos _))) (even.mul_right (nat.even_sub_one_of_prime_ne_two
+        hp.out hptwo) _) odd_one) } },
+  { have H := congr_arg derivative (cyclotomic_prime_pow_mul_X_pow_sub_one K p k),
+    rw [derivative_mul, derivative_sub, derivative_one, sub_zero, derivative_pow,
+      derivative_X, mul_one, derivative_sub, derivative_one, sub_zero, derivative_pow,
+      derivative_X, mul_one, ← pnat.pow_coe, hζ.minpoly_eq_cyclotomic_of_irreducible hirr] at H,
     replace H := congr_arg (λ P, aeval ζ P) H,
-    simp only [hζ.minpoly_eq_cyclotomic_of_irreducible hirr, aeval_add, _root_.map_mul, aeval_one,
-      _root_.map_sub, aeval_X, minpoly.aeval, add_zero, aeval_nat_cast, aeval_X_pow] at H,
+    simp only [aeval_add, aeval_mul, minpoly.aeval, zero_mul, add_zero, aeval_nat_cast,
+      _root_.map_sub, aeval_one, aeval_X_pow] at H,
     replace H := congr_arg (algebra.norm K) H,
-    rw [monoid_hom.map_mul, hζ.sub_one_norm_prime hirr hodd, monoid_hom.map_mul, monoid_hom.map_pow,
-      hζ.norm_eq_one hodd hirr, one_pow, mul_one, ← map_nat_cast (algebra_map K L),
-      norm_algebra_map, finrank _ hirr, totient_prime hp.out, ← succ_pred_eq_of_pos hpos, pow_succ,
-      mul_comm _ (p : K), coe_coe, ← hζ.minpoly_eq_cyclotomic_of_irreducible hirr] at H,
-    simpa [(mul_right_inj' $ ne_zero.ne ↑↑p).1 H],
+    have hnorm : (norm K) (ζ ^ (p : ℕ) ^ k - 1) = p ^ ((p : ℕ) ^ k),
+    { by_cases hp : p = 2,
+      { exact hζ.pow_sub_one_norm_prime_pow_of_one_le hirr (by simpa using hirr₁) rfl.le (hp2 hp) },
+      { exact hζ.pow_sub_one_norm_prime_ne_two hirr (by simpa using hirr₁) rfl.le hp } },
+    rw [monoid_hom.map_mul, hnorm, monoid_hom.map_mul, ← map_nat_cast (algebra_map K L),
+      norm_algebra_map, finrank _ hirr, pnat.pow_coe, totient_prime_pow hp.out (succ_pos k),
+      nat.sub_one, nat.pred_succ, ← hζ.minpoly_eq_cyclotomic_of_irreducible hirr, map_pow,
+      hζ.norm_eq_one hk hirr, one_pow, mul_one, cast_pow, ← coe_coe, ← pow_mul, ← mul_assoc,
+      mul_comm (k + 1), mul_assoc] at H,
+    { have := mul_pos (succ_pos k) (tsub_pos_iff_lt.2 hp.out.one_lt),
+      rw [← succ_pred_eq_of_pos this, mul_succ, pow_add _ _ ((p : ℕ) ^ k)] at H,
+      replace H := (mul_left_inj' (λ h, _)).1 H,
+      { simpa only [← pnat.pow_coe, H, mul_comm _ (k + 1)] },
+      { replace h := pow_eq_zero h,
+        rw [coe_coe] at h,
+        exact ne_zero.ne _ h } },
+    { apply_instance } },
+  { apply_instance }
+end
+
+/-- If `p` is an odd prime and `is_cyclotomic_extension {p} K L`, then
+`discr K (hζ.power_basis K).basis = (-1) ^ ((p - 1) / 2) * p ^ (p - 2)` if
+`irreducible (cyclotomic p K)`. -/
+lemma discr_odd_prime [is_cyclotomic_extension {p} K L] [hp : fact (p : ℕ).prime]
+  [ne_zero ((p : ℕ) : K)] (hζ : is_primitive_root ζ p) (hirr : irreducible (cyclotomic p K))
+  (hodd : p ≠ 2) :
+  discr K (hζ.power_basis K).basis = (-1) ^ (((p : ℕ) - 1) / 2) * p ^ ((p : ℕ) - 2) :=
+begin
+  haveI : is_cyclotomic_extension {p ^ (0 + 1)} K L,
+  { rw [zero_add, pow_one],
     apply_instance },
-  { apply_instance },
+  have hζ' : is_primitive_root ζ ↑(p ^ (0 + 1)) := by simpa using hζ,
+  convert discr_prime_pow_ne_two hζ' (by simpa [hirr]) (by simp [hirr]) (by simp [hodd]),
+  { rw [zero_add, pow_one, totient_prime hp.out] },
+  { rw [pow_zero, one_mul, zero_add, mul_one, nat.sub_sub] }
 end
 
 end is_cyclotomic_extension

--- a/src/number_theory/cyclotomic/primitive_roots.lean
+++ b/src/number_theory/cyclotomic/primitive_roots.lean
@@ -439,6 +439,42 @@ begin
   simpa [hk₁] using sub_one_norm_eq_eval_cyclotomic hζ this hirr,
 end
 
+/-- If `irreducible (cyclotomic (p ^ (k + 1)) K)` and
+`irreducible (cyclotomic (p ^ (k - s + 1)) K))` (in particular for `K = ℚ`) and `p` is a prime,
+then the norm of `ζ ^ (p ^ s) - 1` is `p ^ (p ^ s)` if `1 ≤ k`. -/
+lemma pow_sub_one_norm_prime_pow_of_one_le [hne : ne_zero ((p : ℕ) : K)] {k s : ℕ}
+  (hζ : is_primitive_root ζ ↑(p ^ (k + 1))) [hpri : fact (p : ℕ).prime]
+  [hcycl : is_cyclotomic_extension {p ^ (k + 1)} K L]
+  (hirr : irreducible (cyclotomic (↑(p ^ (k + 1)) : ℕ) K))
+  (hirr₁ : irreducible (cyclotomic (↑(p ^ (k - s + 1)) : ℕ) K)) (hs : s ≤ k)
+  (hk : 1 ≤ k) : norm K (ζ ^ ((p : ℕ) ^ s) - 1) = p ^ ((p : ℕ) ^ s) :=
+begin
+  by_cases htwo : p ^ (k - s + 1) = 2,
+  { have hp : p = 2,
+    { rw [← pnat.coe_inj, pnat.coe_bit0, pnat.one_coe, pnat.pow_coe, ← pow_one 2] at htwo,
+      replace htwo := eq_of_prime_pow_eq (prime_iff.1 hpri.out) (prime_iff.1 nat.prime_two)
+        (succ_pos _) htwo,
+      rwa [show 2 = ((2 : ℕ+) : ℕ), by simp, pnat.coe_inj] at htwo },
+    replace hs : s = k,
+    { rw [hp, ← pnat.coe_inj, pnat.pow_coe, pnat.coe_bit0, pnat.one_coe] at htwo,
+      nth_rewrite 1 [← pow_one 2] at htwo,
+      replace htwo := nat.pow_right_injective rfl.le htwo,
+      rw [add_left_eq_self, nat.sub_eq_zero_iff_le] at htwo,
+      refine le_antisymm hs htwo },
+    haveI : ne_zero (2 : K),
+    { refine ⟨λ h, _⟩,
+      rw [hp, pnat.coe_bit0, one_coe, cast_bit0, cast_one, h] at hne,
+      simpa using hne.out },
+    simp only [hs, hp, pnat.coe_bit0, one_coe, coe_coe, cast_bit0, cast_one,
+      pow_coe] at ⊢ hζ hirr hcycl,
+    haveI := hcycl,
+    obtain ⟨k₁, hk₁⟩ := nat.exists_eq_succ_of_ne_zero (one_le_iff_ne_zero.1 hk),
+    rw [hζ.pow_sub_one_norm_two hirr],
+    rw [hk₁, pow_succ, pow_mul, neg_eq_neg_one_mul, mul_pow, neg_one_sq, one_mul, ← pow_mul,
+      ← pow_succ] },
+  { exact hζ.pow_sub_one_norm_prime_pow_ne_two hirr hirr₁ hs htwo }
+end
+
 end is_primitive_root
 
 namespace is_cyclotomic_extension


### PR DESCRIPTION
We add `discr_prime_pow_ne_two`, the discriminant of the `p^n`-th cyclotomic field.

From flt-regular

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
