### PR TITLE
[Merged by Bors] - fix(data/fintype/basic): fix `fintype_of_option_equiv`

### DIFF
--- a/src/data/fintype/basic.lean
+++ b/src/data/fintype/basic.lean
@@ -845,9 +845,13 @@ lemma univ_option (α : Type*) [fintype α] : (univ : finset (option α)) = inse
 def fintype_of_option {α : Type*} [fintype (option α)] : fintype α :=
 ⟨finset.erase_none (fintype.elems (option α)), λ x, mem_erase_none.mpr (fintype.complete (some x))⟩
 
+/-- A type is a `fintype` if it's the successor (using `option`) of a `fintype`. -/
+def fintype_of_equiv_option [fintype α] (f : option α ≃ β) : fintype β :=
+fintype.of_equiv _ f
+
 /-- A type is a `fintype` if its successor (using `option`) is a `fintype`. -/
-def fintype_of_option_equiv [fintype α] (f : option α ≃ β) : fintype β :=
-by { haveI := fintype.of_equiv (option α) f, exact fintype_of_option }
+def fintype_of_option_equiv [fintype α] (f : α ≃ option β) : fintype β :=
+by { haveI := fintype.of_equiv _ f, exact fintype_of_option }
 
 instance {α : Type*} (β : α → Type*)
   [fintype α] [∀ a, fintype (β a)] : fintype (sigma β) :=

--- a/src/data/fintype/basic.lean
+++ b/src/data/fintype/basic.lean
@@ -845,10 +845,6 @@ lemma univ_option (α : Type*) [fintype α] : (univ : finset (option α)) = inse
 def fintype_of_option {α : Type*} [fintype (option α)] : fintype α :=
 ⟨finset.erase_none (fintype.elems (option α)), λ x, mem_erase_none.mpr (fintype.complete (some x))⟩
 
-/-- A type is a `fintype` if it's the successor (using `option`) of a `fintype`. -/
-def fintype_of_equiv_option [fintype α] (f : option α ≃ β) : fintype β :=
-fintype.of_equiv _ f
-
 /-- A type is a `fintype` if its successor (using `option`) is a `fintype`. -/
 def fintype_of_option_equiv [fintype α] (f : α ≃ option β) : fintype β :=
 by { haveI := fintype.of_equiv _ f, exact fintype_of_option }


### PR DESCRIPTION
A type is a `fintype` if its successor (using `option`) is a `fintype`

This fixes an error introduced in #13086.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
