### PR TITLE
[Merged by Bors] - refactor(analysis/calculus/cont_diff): reorder the file

### DIFF
--- a/src/analysis/calculus/cont_diff.lean
+++ b/src/analysis/calculus/cont_diff.lean
@@ -174,7 +174,7 @@ variables {𝕜 : Type*} [nondiscrete_normed_field 𝕜]
 {F : Type*} [normed_group F] [normed_space 𝕜 F]
 {G : Type*} [normed_group G] [normed_space 𝕜 G]
 {s s₁ t u : set E} {f f₁ : E → F} {g : F → G} {x : E} {c : F}
-{b : E × F → G} {n : with_top ℕ}
+{b : E × F → G} {m n : with_top ℕ}
 
 /-! ### Functions with a Taylor series on a domain -/
 
@@ -213,7 +213,7 @@ lemma has_ftaylor_series_up_to_on.mono
 λ m hm x hx, (h.fderiv_within m hm x (hst hx)).mono hst,
 λ m hm, (h.cont m hm).mono hst⟩
 
-lemma has_ftaylor_series_up_to_on.of_le {m n : with_top ℕ}
+lemma has_ftaylor_series_up_to_on.of_le
   (h : has_ftaylor_series_up_to_on n f p s) (hmn : m ≤ n) :
   has_ftaylor_series_up_to_on m f p s :=
 ⟨h.zero_eq,
@@ -422,7 +422,7 @@ lemma cont_diff_within_at_nat {n : ℕ} :
   has_ftaylor_series_up_to_on n f p u :=
 ⟨λ H, H n le_rfl, λ ⟨u, hu, p, hp⟩ m hm, ⟨u, hu, p, hp.of_le hm⟩⟩
 
-lemma cont_diff_within_at.of_le {m n : with_top ℕ}
+lemma cont_diff_within_at.of_le
   (h : cont_diff_within_at 𝕜 n f s x) (hmn : m ≤ n) :
   cont_diff_within_at 𝕜 m f s x :=
 λ k hk, h k (le_trans hk hmn)
@@ -582,8 +582,7 @@ definition cont_diff_on (n : with_top ℕ) (f : E → F) (s : set E) :=
 
 variable {𝕜}
 
-lemma cont_diff_on.cont_diff_within_at
-  (h : cont_diff_on 𝕜 n f s) (hx : x ∈ s) :
+lemma cont_diff_on.cont_diff_within_at (h : cont_diff_on 𝕜 n f s) (hx : x ∈ s) :
   cont_diff_within_at 𝕜 n f s x :=
 h x hx
 
@@ -611,8 +610,7 @@ begin
   exact nhds_within_mono y (subset_insert _ _) hy.1
 end
 
-lemma cont_diff_on.of_le {m n : with_top ℕ}
-  (h : cont_diff_on 𝕜 n f s) (hmn : m ≤ n) :
+lemma cont_diff_on.of_le (h : cont_diff_on 𝕜 n f s) (hmn : m ≤ n) :
   cont_diff_on 𝕜 m f s :=
 λ x hx, (h x hx).of_le hmn
 
@@ -1062,7 +1060,7 @@ begin
   exact fderiv_within_of_open hs hx
 end
 
-lemma cont_diff_on.fderiv_within {m n : with_top ℕ}
+lemma cont_diff_on.fderiv_within
   (hf : cont_diff_on 𝕜 n f s) (hs : unique_diff_on 𝕜 s) (hmn : m + 1 ≤ n) :
   cont_diff_on 𝕜 m (λ y, fderiv_within 𝕜 f s y) s :=
 begin
@@ -1075,7 +1073,7 @@ begin
     exact ((cont_diff_on_succ_iff_fderiv_within hs).1 (hf.of_le hmn)).2 }
 end
 
-lemma cont_diff_on.fderiv_of_open {m n : with_top ℕ}
+lemma cont_diff_on.fderiv_of_open
   (hf : cont_diff_on 𝕜 n f s) (hs : is_open s) (hmn : m + 1 ≤ n) :
   cont_diff_on 𝕜 m (λ y, fderiv 𝕜 f y) s :=
 (hf.fderiv_within hs.unique_diff_on hmn).congr (λ x hx, (fderiv_within_of_open hs hx).symm)
@@ -1150,7 +1148,7 @@ lemma has_ftaylor_series_up_to.has_ftaylor_series_up_to_on
   has_ftaylor_series_up_to_on n f p s :=
 (has_ftaylor_series_up_to_on_univ_iff.2 h).mono (subset_univ _)
 
-lemma has_ftaylor_series_up_to.of_le {m n : with_top ℕ}
+lemma has_ftaylor_series_up_to.of_le
   (h : has_ftaylor_series_up_to n f p) (hmn : m ≤ n) :
   has_ftaylor_series_up_to m f p :=
 by { rw ← has_ftaylor_series_up_to_on_univ_iff at h ⊢, exact h.of_le hmn }
@@ -1227,7 +1225,7 @@ lemma cont_diff_at.congr_of_eventually_eq
   cont_diff_at 𝕜 n f₁ x :=
 h.congr_of_eventually_eq' (by rwa nhds_within_univ) (mem_univ x)
 
-lemma cont_diff_at.of_le {m n : with_top ℕ}
+lemma cont_diff_at.of_le
   (h : cont_diff_at 𝕜 n f x) (hmn : m ≤ n) :
   cont_diff_at 𝕜 m f x :=
 h.of_le hmn
@@ -1333,7 +1331,7 @@ by simp_rw [show (1 : with_top ℕ) = (0 + 1 : ℕ), from (zero_add 1).symm,
   cont_diff_at_succ_iff_has_fderiv_at, show ((0 : ℕ) : with_top ℕ) = 0, from rfl,
   cont_diff_at_zero, exists_mem_and_iff antitone_bforall antitone_continuous_on, and_comm]
 
-lemma cont_diff.of_le {m n : with_top ℕ}
+lemma cont_diff.of_le
   (h : cont_diff 𝕜 n f) (hmn : m ≤ n) :
   cont_diff 𝕜 m f :=
 cont_diff_on_univ.1 $ (cont_diff_on_univ.2 h).of_le hmn
@@ -1570,7 +1568,7 @@ by { rw [subsingleton.elim f (λ _, 0)], exact cont_diff_within_at_const }
   cont_diff_on 𝕜 n f s :=
 by { rw [subsingleton.elim f (λ _, 0)], exact cont_diff_on_const }
 
-/-! ### Linear functions -/
+/-! ### Smoothness of linear functions -/
 
 /--
 Unbundled bounded linear functions are `C^∞`.
@@ -1585,93 +1583,17 @@ begin
   exact cont_diff_const
 end
 
-lemma continuous_linear_map.cont_diff (f : E →L[𝕜] F) :
-  cont_diff 𝕜 n f :=
+lemma continuous_linear_map.cont_diff (f : E →L[𝕜] F) : cont_diff 𝕜 n f :=
 f.is_bounded_linear_map.cont_diff
 
-lemma continuous_linear_equiv.cont_diff (f : E ≃L[𝕜] F) :
-  cont_diff 𝕜 n f :=
+lemma continuous_linear_equiv.cont_diff (f : E ≃L[𝕜] F) : cont_diff 𝕜 n f :=
 (f : E →L[𝕜] F).cont_diff
 
-lemma linear_isometry.cont_diff (f : E →ₗᵢ[𝕜] F) :
-  cont_diff 𝕜 n f :=
+lemma linear_isometry.cont_diff (f : E →ₗᵢ[𝕜] F) : cont_diff 𝕜 n f :=
 f.to_continuous_linear_map.cont_diff
 
-lemma linear_isometry_equiv.cont_diff (f : E ≃ₗᵢ[𝕜] F) :
-  cont_diff 𝕜 n f :=
+lemma linear_isometry_equiv.cont_diff (f : E ≃ₗᵢ[𝕜] F) : cont_diff 𝕜 n f :=
 (f : E →L[𝕜] F).cont_diff
-
-/--
-The first projection in a product is `C^∞`.
--/
-lemma cont_diff_fst : cont_diff 𝕜 n (prod.fst : E × F → E) :=
-is_bounded_linear_map.cont_diff is_bounded_linear_map.fst
-
-/--
-The first projection on a domain in a product is `C^∞`.
--/
-lemma cont_diff_on_fst {s : set (E×F)} :
-  cont_diff_on 𝕜 n (prod.fst : E × F → E) s :=
-cont_diff.cont_diff_on cont_diff_fst
-
-/--
-The first projection at a point in a product is `C^∞`.
--/
-lemma cont_diff_at_fst {p : E × F} :
-  cont_diff_at 𝕜 n (prod.fst : E × F → E) p :=
-cont_diff_fst.cont_diff_at
-
-/--
-The first projection within a domain at a point in a product is `C^∞`.
--/
-lemma cont_diff_within_at_fst {s : set (E × F)} {p : E × F} :
-  cont_diff_within_at 𝕜 n (prod.fst : E × F → E) s p :=
-cont_diff_fst.cont_diff_within_at
-
-/--
-The second projection in a product is `C^∞`.
--/
-lemma cont_diff_snd : cont_diff 𝕜 n (prod.snd : E × F → F) :=
-is_bounded_linear_map.cont_diff is_bounded_linear_map.snd
-
-/--
-The second projection on a domain in a product is `C^∞`.
--/
-lemma cont_diff_on_snd {s : set (E×F)} :
-  cont_diff_on 𝕜 n (prod.snd : E × F → F) s :=
-cont_diff.cont_diff_on cont_diff_snd
-
-/--
-The second projection at a point in a product is `C^∞`.
--/
-lemma cont_diff_at_snd {p : E × F} :
-  cont_diff_at 𝕜 n (prod.snd : E × F → F) p :=
-cont_diff_snd.cont_diff_at
-
-/--
-The second projection within a domain at a point in a product is `C^∞`.
--/
-lemma cont_diff_within_at_snd {s : set (E × F)} {p : E × F} :
-  cont_diff_within_at 𝕜 n (prod.snd : E × F → F) s p :=
-cont_diff_snd.cont_diff_within_at
-
-/--
-The natural equivalence `(E × F) × G ≃ E × (F × G)` is smooth.
-
-Warning: if you think you need this lemma, it is likely that you can simplify your proof by
-reformulating the lemma that you're applying next using the tips in
-Note [continuity lemma statement]
--/
-lemma cont_diff_prod_assoc : cont_diff 𝕜 ⊤ $ equiv.prod_assoc E F G :=
-(linear_isometry_equiv.prod_assoc 𝕜 E F G).cont_diff
-
-/--
-The natural equivalence `E × (F × G) ≃ (E × F) × G` is smooth.
-
-Warning: see remarks attached to `cont_diff_prod_assoc`
--/
-lemma cont_diff_prod_assoc_symm : cont_diff 𝕜 ⊤ $ (equiv.prod_assoc E F G).symm :=
-(linear_isometry_equiv.prod_assoc 𝕜 E F G).symm.cont_diff
 
 /--
 The identity is `C^∞`.
@@ -1679,16 +1601,13 @@ The identity is `C^∞`.
 lemma cont_diff_id : cont_diff 𝕜 n (id : E → E) :=
 is_bounded_linear_map.id.cont_diff
 
-lemma cont_diff_within_at_id {s x} :
-  cont_diff_within_at 𝕜 n (id : E → E) s x :=
+lemma cont_diff_within_at_id {s x} : cont_diff_within_at 𝕜 n (id : E → E) s x :=
 cont_diff_id.cont_diff_within_at
 
-lemma cont_diff_at_id {x} :
-  cont_diff_at 𝕜 n (id : E → E) x :=
+lemma cont_diff_at_id {x} : cont_diff_at 𝕜 n (id : E → E) x :=
 cont_diff_id.cont_diff_at
 
-lemma cont_diff_on_id {s} :
-  cont_diff_on 𝕜 n (id : E → E) s :=
+lemma cont_diff_on_id {s} : cont_diff_on 𝕜 n (id : E → E) s :=
 cont_diff_id.cont_diff_on
 
 /--
@@ -1881,92 +1800,22 @@ end
 /-- The cartesian product of `C^n` functions on domains is `C^n`. -/
 lemma cont_diff_on.prod {s : set E} {f : E → F} {g : E → G}
   (hf : cont_diff_on 𝕜 n f s) (hg : cont_diff_on 𝕜 n g s) :
-  cont_diff_on 𝕜 n (λx:E, (f x, g x)) s :=
+  cont_diff_on 𝕜 n (λ x : E, (f x, g x)) s :=
 λ x hx, (hf x hx).prod (hg x hx)
 
 /-- The cartesian product of `C^n` functions at a point is `C^n`. -/
 lemma cont_diff_at.prod {f : E → F} {g : E → G}
   (hf : cont_diff_at 𝕜 n f x) (hg : cont_diff_at 𝕜 n g x) :
-  cont_diff_at 𝕜 n (λx:E, (f x, g x)) x :=
+  cont_diff_at 𝕜 n (λ x : E, (f x, g x)) x :=
 cont_diff_within_at_univ.1 $ cont_diff_within_at.prod
   (cont_diff_within_at_univ.2 hf)
   (cont_diff_within_at_univ.2 hg)
 
-/--
-The cartesian product of `C^n` functions is `C^n`.
--/
-lemma cont_diff.prod {f : E → F} {g : E → G}
-  (hf : cont_diff 𝕜 n f) (hg : cont_diff 𝕜 n g) :
-  cont_diff 𝕜 n (λx:E, (f x, g x)) :=
+/-- The cartesian product of `C^n` functions is `C^n`.-/
+lemma cont_diff.prod {f : E → F} {g : E → G} (hf : cont_diff 𝕜 n f) (hg : cont_diff 𝕜 n g) :
+  cont_diff 𝕜 n (λ x : E, (f x, g x)) :=
 cont_diff_on_univ.1 $ cont_diff_on.prod (cont_diff_on_univ.2 hf)
   (cont_diff_on_univ.2 hg)
-
-/-!
-### Smoothness of functions `f : E → Π i, F' i`
--/
-
-section pi
-
-variables {ι : Type*} [fintype ι] {F' : ι → Type*} [Π i, normed_group (F' i)]
-  [Π i, normed_space 𝕜 (F' i)] {φ : Π i, E → F' i}
-  {p' : Π i, E → formal_multilinear_series 𝕜 E (F' i)}
-  {Φ : E → Π i, F' i} {P' : E → formal_multilinear_series 𝕜 E (Π i, F' i)}
-
-
-lemma has_ftaylor_series_up_to_on_pi :
-  has_ftaylor_series_up_to_on n (λ x i, φ i x)
-    (λ x m, continuous_multilinear_map.pi (λ i, p' i x m)) s ↔
-    ∀ i, has_ftaylor_series_up_to_on n (φ i) (p' i) s :=
-begin
-  set pr := @continuous_linear_map.proj 𝕜 _ ι F' _ _ _,
-  letI : Π (m : ℕ) (i : ι), normed_space 𝕜 (E [×m]→L[𝕜] (F' i)) := λ m i, infer_instance,
-  set L : Π m : ℕ, (Π i, E [×m]→L[𝕜] (F' i)) ≃ₗᵢ[𝕜] (E [×m]→L[𝕜] (Π i, F' i)) :=
-    λ m, continuous_multilinear_map.piₗᵢ _ _,
-  refine ⟨λ h i, _, λ h, ⟨λ x hx, _, _, _⟩⟩,
-  { convert h.continuous_linear_map_comp (pr i),
-    ext, refl },
-  { ext1 i,
-    exact (h i).zero_eq x hx },
-  { intros m hm x hx,
-    have := has_fderiv_within_at_pi.2 (λ i, (h i).fderiv_within m hm x hx),
-    convert (L m).has_fderiv_at.comp_has_fderiv_within_at x this },
-  { intros m hm,
-    have := continuous_on_pi.2 (λ i, (h i).cont m hm),
-    convert (L m).continuous.comp_continuous_on this }
-end
-
-@[simp] lemma has_ftaylor_series_up_to_on_pi' :
-  has_ftaylor_series_up_to_on n Φ P' s ↔
-    ∀ i, has_ftaylor_series_up_to_on n (λ x, Φ x i)
-      (λ x m, (@continuous_linear_map.proj 𝕜 _ ι F' _ _ _ i).comp_continuous_multilinear_map
-        (P' x m)) s :=
-by { convert has_ftaylor_series_up_to_on_pi, ext, refl }
-
-lemma cont_diff_within_at_pi :
-  cont_diff_within_at 𝕜 n Φ s x ↔
-    ∀ i, cont_diff_within_at 𝕜 n (λ x, Φ x i) s x :=
-begin
-  set pr := @continuous_linear_map.proj 𝕜 _ ι F' _ _ _,
-  refine ⟨λ h i, h.continuous_linear_map_comp (pr i), λ h m hm, _⟩,
-  choose u hux p hp using λ i, h i m hm,
-  exact ⟨⋂ i, u i, filter.Inter_mem.2 hux, _,
-    has_ftaylor_series_up_to_on_pi.2 (λ i, (hp i).mono $ Inter_subset _ _)⟩,
-end
-
-lemma cont_diff_on_pi :
-  cont_diff_on 𝕜 n Φ s ↔ ∀ i, cont_diff_on 𝕜 n (λ x, Φ x i) s :=
-⟨λ h i x hx, cont_diff_within_at_pi.1 (h x hx) _,
-  λ h x hx, cont_diff_within_at_pi.2 (λ i, h i x hx)⟩
-
-lemma cont_diff_at_pi :
-  cont_diff_at 𝕜 n Φ x ↔ ∀ i, cont_diff_at 𝕜 n (λ x, Φ x i) x :=
-cont_diff_within_at_pi
-
-lemma cont_diff_pi :
-  cont_diff 𝕜 n Φ ↔ ∀ i, cont_diff 𝕜 n (λ x, Φ x i) :=
-by simp only [← cont_diff_on_univ, cont_diff_on_pi]
-
-end pi
 
 /-!
 ### Composition of `C^n` functions
@@ -2178,6 +2027,62 @@ lemma cont_diff.comp_cont_diff_at
   cont_diff_at 𝕜 n (g ∘ f) x :=
 hg.comp_cont_diff_within_at hf
 
+/-- The first projection in a product is `C^∞`. -/
+lemma cont_diff_fst : cont_diff 𝕜 n (prod.fst : E × F → E) :=
+is_bounded_linear_map.cont_diff is_bounded_linear_map.fst
+
+/-- The first projection on a domain in a product is `C^∞`. -/
+lemma cont_diff_on_fst {s : set (E×F)} :
+  cont_diff_on 𝕜 n (prod.fst : E × F → E) s :=
+cont_diff.cont_diff_on cont_diff_fst
+
+/-- The first projection at a point in a product is `C^∞`. -/
+lemma cont_diff_at_fst {p : E × F} :
+  cont_diff_at 𝕜 n (prod.fst : E × F → E) p :=
+cont_diff_fst.cont_diff_at
+
+/-- The first projection within a domain at a point in a product is `C^∞`. -/
+lemma cont_diff_within_at_fst {s : set (E × F)} {p : E × F} :
+  cont_diff_within_at 𝕜 n (prod.fst : E × F → E) s p :=
+cont_diff_fst.cont_diff_within_at
+
+/-- The second projection in a product is `C^∞`. -/
+lemma cont_diff_snd : cont_diff 𝕜 n (prod.snd : E × F → F) :=
+is_bounded_linear_map.cont_diff is_bounded_linear_map.snd
+
+/-- The second projection on a domain in a product is `C^∞`. -/
+lemma cont_diff_on_snd {s : set (E×F)} :
+  cont_diff_on 𝕜 n (prod.snd : E × F → F) s :=
+cont_diff.cont_diff_on cont_diff_snd
+
+/-- The second projection at a point in a product is `C^∞`. -/
+lemma cont_diff_at_snd {p : E × F} :
+  cont_diff_at 𝕜 n (prod.snd : E × F → F) p :=
+cont_diff_snd.cont_diff_at
+
+/-- The second projection within a domain at a point in a product is `C^∞`. -/
+lemma cont_diff_within_at_snd {s : set (E × F)} {p : E × F} :
+  cont_diff_within_at 𝕜 n (prod.snd : E × F → F) s p :=
+cont_diff_snd.cont_diff_within_at
+
+/--
+The natural equivalence `(E × F) × G ≃ E × (F × G)` is smooth.
+
+Warning: if you think you need this lemma, it is likely that you can simplify your proof by
+reformulating the lemma that you're applying next using the tips in
+Note [continuity lemma statement]
+-/
+lemma cont_diff_prod_assoc : cont_diff 𝕜 ⊤ $ equiv.prod_assoc E F G :=
+(linear_isometry_equiv.prod_assoc 𝕜 E F G).cont_diff
+
+/--
+The natural equivalence `E × (F × G) ≃ (E × F) × G` is smooth.
+
+Warning: see remarks attached to `cont_diff_prod_assoc`
+-/
+lemma cont_diff_prod_assoc_symm : cont_diff 𝕜 ⊤ $ (equiv.prod_assoc E F G).symm :=
+(linear_isometry_equiv.prod_assoc 𝕜 E F G).symm.cont_diff
+
 /-- The bundled derivative of a `C^{n+1}` function is `C^n`. -/
 lemma cont_diff_on_fderiv_within_apply {m n : with_top  ℕ} {s : set E}
   {f : E → F} (hf : cont_diff_on 𝕜 n f s) (hs : unique_diff_on 𝕜 s) (hmn : m + 1 ≤ n) :
@@ -2201,7 +2106,7 @@ begin
 end
 
 /-- The bundled derivative of a `C^{n+1}` function is `C^n`. -/
-lemma cont_diff.cont_diff_fderiv_apply {n m : with_top ℕ} {f : E → F}
+lemma cont_diff.cont_diff_fderiv_apply {f : E → F}
   (hf : cont_diff 𝕜 n f) (hmn : m + 1 ≤ n) :
   cont_diff 𝕜 m (λp : E × E, (fderiv 𝕜 f p.1 : E →L[𝕜] F) p.2) :=
 begin
@@ -2210,11 +2115,76 @@ begin
   exact cont_diff_on_fderiv_within_apply hf unique_diff_on_univ hmn
 end
 
+/-!
+### Smoothness of functions `f : E → Π i, F' i`
+-/
+
+section pi
+
+variables {ι : Type*} [fintype ι] {F' : ι → Type*} [Π i, normed_group (F' i)]
+  [Π i, normed_space 𝕜 (F' i)] {φ : Π i, E → F' i}
+  {p' : Π i, E → formal_multilinear_series 𝕜 E (F' i)}
+  {Φ : E → Π i, F' i} {P' : E → formal_multilinear_series 𝕜 E (Π i, F' i)}
+
+lemma has_ftaylor_series_up_to_on_pi :
+  has_ftaylor_series_up_to_on n (λ x i, φ i x)
+    (λ x m, continuous_multilinear_map.pi (λ i, p' i x m)) s ↔
+    ∀ i, has_ftaylor_series_up_to_on n (φ i) (p' i) s :=
+begin
+  set pr := @continuous_linear_map.proj 𝕜 _ ι F' _ _ _,
+  letI : Π (m : ℕ) (i : ι), normed_space 𝕜 (E [×m]→L[𝕜] (F' i)) := λ m i, infer_instance,
+  set L : Π m : ℕ, (Π i, E [×m]→L[𝕜] (F' i)) ≃ₗᵢ[𝕜] (E [×m]→L[𝕜] (Π i, F' i)) :=
+    λ m, continuous_multilinear_map.piₗᵢ _ _,
+  refine ⟨λ h i, _, λ h, ⟨λ x hx, _, _, _⟩⟩,
+  { convert h.continuous_linear_map_comp (pr i),
+    ext, refl },
+  { ext1 i,
+    exact (h i).zero_eq x hx },
+  { intros m hm x hx,
+    have := has_fderiv_within_at_pi.2 (λ i, (h i).fderiv_within m hm x hx),
+    convert (L m).has_fderiv_at.comp_has_fderiv_within_at x this },
+  { intros m hm,
+    have := continuous_on_pi.2 (λ i, (h i).cont m hm),
+    convert (L m).continuous.comp_continuous_on this }
+end
+
+@[simp] lemma has_ftaylor_series_up_to_on_pi' :
+  has_ftaylor_series_up_to_on n Φ P' s ↔
+    ∀ i, has_ftaylor_series_up_to_on n (λ x, Φ x i)
+      (λ x m, (@continuous_linear_map.proj 𝕜 _ ι F' _ _ _ i).comp_continuous_multilinear_map
+        (P' x m)) s :=
+by { convert has_ftaylor_series_up_to_on_pi, ext, refl }
+
+lemma cont_diff_within_at_pi :
+  cont_diff_within_at 𝕜 n Φ s x ↔
+    ∀ i, cont_diff_within_at 𝕜 n (λ x, Φ x i) s x :=
+begin
+  set pr := @continuous_linear_map.proj 𝕜 _ ι F' _ _ _,
+  refine ⟨λ h i, h.continuous_linear_map_comp (pr i), λ h m hm, _⟩,
+  choose u hux p hp using λ i, h i m hm,
+  exact ⟨⋂ i, u i, filter.Inter_mem.2 hux, _,
+    has_ftaylor_series_up_to_on_pi.2 (λ i, (hp i).mono $ Inter_subset _ _)⟩,
+end
+
+lemma cont_diff_on_pi :
+  cont_diff_on 𝕜 n Φ s ↔ ∀ i, cont_diff_on 𝕜 n (λ x, Φ x i) s :=
+⟨λ h i x hx, cont_diff_within_at_pi.1 (h x hx) _,
+  λ h x hx, cont_diff_within_at_pi.2 (λ i, h i x hx)⟩
+
+lemma cont_diff_at_pi :
+  cont_diff_at 𝕜 n Φ x ↔ ∀ i, cont_diff_at 𝕜 n (λ x, Φ x i) x :=
+cont_diff_within_at_pi
+
+lemma cont_diff_pi :
+  cont_diff 𝕜 n Φ ↔ ∀ i, cont_diff 𝕜 n (λ x, Φ x i) :=
+by simp only [← cont_diff_on_univ, cont_diff_on_pi]
+
+end pi
+
 /-! ### Sum of two functions -/
 
 /- The sum is smooth. -/
-lemma cont_diff_add :
-  cont_diff 𝕜 n (λp : F × F, p.1 + p.2) :=
+lemma cont_diff_add : cont_diff 𝕜 n (λp : F × F, p.1 + p.2) :=
 (is_bounded_linear_map.fst.add is_bounded_linear_map.snd).cont_diff
 
 /-- The sum of two `C^n` functions within a set at a point is `C^n` within this set
@@ -2225,14 +2195,12 @@ lemma cont_diff_within_at.add {s : set E} {f g : E → F}
 cont_diff_add.cont_diff_within_at.comp x (hf.prod hg) subset_preimage_univ
 
 /-- The sum of two `C^n` functions at a point is `C^n` at this point. -/
-lemma cont_diff_at.add {f g : E → F}
-  (hf : cont_diff_at 𝕜 n f x) (hg : cont_diff_at 𝕜 n g x) :
+lemma cont_diff_at.add {f g : E → F} (hf : cont_diff_at 𝕜 n f x) (hg : cont_diff_at 𝕜 n g x) :
   cont_diff_at 𝕜 n (λx, f x + g x) x :=
 by rw [← cont_diff_within_at_univ] at *; exact hf.add hg
 
 /-- The sum of two `C^n`functions is `C^n`. -/
-lemma cont_diff.add {f g : E → F}
-  (hf : cont_diff 𝕜 n f) (hg : cont_diff 𝕜 n g) :
+lemma cont_diff.add {f g : E → F} (hf : cont_diff 𝕜 n f) (hg : cont_diff 𝕜 n g) :
   cont_diff 𝕜 n (λx, f x + g x) :=
 cont_diff_add.comp (hf.prod hg)
 
@@ -2245,8 +2213,7 @@ lemma cont_diff_on.add {s : set E} {f g : E → F}
 /-! ### Negative -/
 
 /- The negative is smooth. -/
-lemma cont_diff_neg :
-  cont_diff 𝕜 n (λp : F, -p) :=
+lemma cont_diff_neg : cont_diff 𝕜 n (λp : F, -p) :=
 is_bounded_linear_map.id.neg.cont_diff
 
 /-- The negative of a `C^n` function within a domain at a point is `C^n` within this domain at
@@ -2261,8 +2228,7 @@ lemma cont_diff_at.neg {f : E → F}
 by rw ← cont_diff_within_at_univ at *; exact hf.neg
 
 /-- The negative of a `C^n`function is `C^n`. -/
-lemma cont_diff.neg {f : E → F} (hf : cont_diff 𝕜 n f) :
-  cont_diff 𝕜 n (λx, -f x) :=
+lemma cont_diff.neg {f : E → F} (hf : cont_diff 𝕜 n f) : cont_diff 𝕜 n (λx, -f x) :=
 cont_diff_neg.comp hf
 
 /-- The negative of a `C^n` function on a domain is `C^n`. -/
@@ -2331,8 +2297,7 @@ by simp [← cont_diff_on_univ] at *; exact cont_diff_on.sum h
 /-! ### Product of two functions -/
 
 /- The product is smooth. -/
-lemma cont_diff_mul :
-  cont_diff 𝕜 n (λ p : 𝕜 × 𝕜, p.1 * p.2) :=
+lemma cont_diff_mul : cont_diff 𝕜 n (λ p : 𝕜 × 𝕜, p.1 * p.2) :=
 is_bounded_bilinear_map_mul.cont_diff
 
 /-- The product of two `C^n` functions within a set at a point is `C^n` within this set
@@ -2355,8 +2320,7 @@ lemma cont_diff_on.mul {s : set E} {f g : E → 𝕜}
 λ x hx, (hf x hx).mul (hg x hx)
 
 /-- The product of two `C^n`functions is `C^n`. -/
-lemma cont_diff.mul {f g : E → 𝕜}
-  (hf : cont_diff 𝕜 n f) (hg : cont_diff 𝕜 n g) :
+lemma cont_diff.mul {f g : E → 𝕜} (hf : cont_diff 𝕜 n f) (hg : cont_diff 𝕜 n g) :
   cont_diff 𝕜 n (λ x, f x * g x) :=
 cont_diff_mul.comp (hf.prod hg)
 
@@ -2400,8 +2364,7 @@ lemma cont_diff_on.pow {f : E → 𝕜}
 /-! ### Scalar multiplication -/
 
 /- The scalar multiplication is smooth. -/
-lemma cont_diff_smul :
-  cont_diff 𝕜 n (λ p : 𝕜 × F, p.1 • p.2) :=
+lemma cont_diff_smul : cont_diff 𝕜 n (λ p : 𝕜 × F, p.1 • p.2) :=
 is_bounded_bilinear_map_smul.cont_diff
 
 /-- The scalar multiplication of two `C^n` functions within a set at a point is `C^n` within this
@@ -2418,8 +2381,7 @@ lemma cont_diff_at.smul {f : E → 𝕜} {g : E → F}
 by rw [← cont_diff_within_at_univ] at *; exact hf.smul hg
 
 /-- The scalar multiplication of two `C^n` functions is `C^n`. -/
-lemma cont_diff.smul {f : E → 𝕜} {g : E → F}
-  (hf : cont_diff 𝕜 n f) (hg : cont_diff 𝕜 n g) :
+lemma cont_diff.smul {f : E → 𝕜} {g : E → F} (hf : cont_diff 𝕜 n f) (hg : cont_diff 𝕜 n g) :
   cont_diff 𝕜 n (λ x, f x • g x) :=
 cont_diff_smul.comp (hf.prod hg)
 
@@ -2433,7 +2395,7 @@ lemma cont_diff_on.smul {s : set E} {f : E → 𝕜} {g : E → F}
 
 section prod_map
 variables {E' : Type*} [normed_group E'] [normed_space 𝕜 E']
-{F' : Type*} [normed_group F'] [normed_space 𝕜 F']
+variables {F' : Type*} [normed_group F'] [normed_space 𝕜 F']
 
 
 /-- The product map of two `C^n` functions within a set at a point is `C^n`
@@ -2482,8 +2444,7 @@ begin
 end
 
 /-- The product map of two `C^n` functions is `C^n`. -/
-lemma cont_diff.prod_map
-  {f : E → F} {g : E' → F'}
+lemma cont_diff.prod_map {f : E → F} {g : E' → F'}
   (hf : cont_diff 𝕜 n f) (hg : cont_diff 𝕜 n g) :
   cont_diff 𝕜 n (prod.map f g) :=
 begin
@@ -2907,7 +2868,7 @@ begin
   exact deriv_within_of_open hs hx
 end
 
-lemma cont_diff_on.deriv_within {m n : with_top ℕ}
+lemma cont_diff_on.deriv_within
   (hf : cont_diff_on 𝕜 n f₂ s₂) (hs : unique_diff_on 𝕜 s₂) (hmn : m + 1 ≤ n) :
   cont_diff_on 𝕜 m (deriv_within f₂ s₂) s₂ :=
 begin
@@ -2920,7 +2881,7 @@ begin
     exact ((cont_diff_on_succ_iff_deriv_within hs).1 (hf.of_le hmn)).2 }
 end
 
-lemma cont_diff_on.deriv_of_open {m n : with_top ℕ}
+lemma cont_diff_on.deriv_of_open
   (hf : cont_diff_on 𝕜 n f₂ s₂) (hs : is_open s₂) (hmn : m + 1 ≤ n) :
   cont_diff_on 𝕜 m (deriv f₂) s₂ :=
 (hf.deriv_within hs.unique_diff_on hmn).congr (λ x hx, (deriv_within_of_open hs hx).symm)

--- a/src/analysis/calculus/cont_diff.lean
+++ b/src/analysis/calculus/cont_diff.lean
@@ -174,7 +174,7 @@ variables {𝕜 : Type*} [nondiscrete_normed_field 𝕜]
 {F : Type*} [normed_group F] [normed_space 𝕜 F]
 {G : Type*} [normed_group G] [normed_space 𝕜 G]
 {s s₁ t u : set E} {f f₁ : E → F} {g : F → G} {x : E} {c : F}
-{b : E × F → G}
+{b : E × F → G} {n : with_top ℕ}
 
 /-! ### Functions with a Taylor series on a domain -/
 
@@ -190,14 +190,14 @@ structure has_ftaylor_series_up_to_on (n : with_top ℕ)
    has_fderiv_within_at (λ y, p y m) (p x m.succ).curry_left s x)
 (cont          : ∀ (m : ℕ) (hm : (m : with_top ℕ) ≤ n), continuous_on (λ x, p x m) s)
 
-lemma has_ftaylor_series_up_to_on.zero_eq' {n : with_top ℕ}
+lemma has_ftaylor_series_up_to_on.zero_eq'
   (h : has_ftaylor_series_up_to_on n f p s) {x : E} (hx : x ∈ s) :
   p x 0 = (continuous_multilinear_curry_fin0 𝕜 E F).symm (f x) :=
 by { rw ← h.zero_eq x hx, symmetry, exact continuous_multilinear_map.uncurry0_curry0 _ }
 
 /-- If two functions coincide on a set `s`, then a Taylor series for the first one is as well a
 Taylor series for the second one. -/
-lemma has_ftaylor_series_up_to_on.congr {n : with_top ℕ}
+lemma has_ftaylor_series_up_to_on.congr
   (h : has_ftaylor_series_up_to_on n f p s) (h₁ : ∀ x ∈ s, f₁ x = f x) :
   has_ftaylor_series_up_to_on n f₁ p s :=
 begin
@@ -206,7 +206,7 @@ begin
   exact h.zero_eq x hx
 end
 
-lemma has_ftaylor_series_up_to_on.mono {n : with_top ℕ}
+lemma has_ftaylor_series_up_to_on.mono
   (h : has_ftaylor_series_up_to_on n f p s) {t : set E} (hst : t ⊆ s) :
   has_ftaylor_series_up_to_on n f p t :=
 ⟨λ x hx, h.zero_eq x (hst hx),
@@ -220,7 +220,7 @@ lemma has_ftaylor_series_up_to_on.of_le {m n : with_top ℕ}
 λ k hk x hx, h.fderiv_within k (lt_of_lt_of_le hk hmn) x hx,
 λ k hk, h.cont k (le_trans hk hmn)⟩
 
-lemma has_ftaylor_series_up_to_on.continuous_on {n : with_top ℕ}
+lemma has_ftaylor_series_up_to_on.continuous_on
   (h : has_ftaylor_series_up_to_on n f p s) : continuous_on f s :=
 begin
   have := (h.cont 0 bot_le).congr (λ x hx, (h.zero_eq' hx).symm),
@@ -256,7 +256,7 @@ end
 
 /-- If a function has a Taylor series at order at least `1`, then the term of order `1` of this
 series is a derivative of `f`. -/
-lemma has_ftaylor_series_up_to_on.has_fderiv_within_at {n : with_top ℕ}
+lemma has_ftaylor_series_up_to_on.has_fderiv_within_at
   (h : has_ftaylor_series_up_to_on n f p s) (hn : 1 ≤ n) (hx : x ∈ s) :
   has_fderiv_within_at f (continuous_multilinear_curry_fin1 𝕜 E F (p x 1)) s x :=
 begin
@@ -278,27 +278,27 @@ begin
   refl
 end
 
-lemma has_ftaylor_series_up_to_on.differentiable_on {n : with_top ℕ}
+lemma has_ftaylor_series_up_to_on.differentiable_on
   (h : has_ftaylor_series_up_to_on n f p s) (hn : 1 ≤ n) : differentiable_on 𝕜 f s :=
 λ x hx, (h.has_fderiv_within_at hn hx).differentiable_within_at
 
 /-- If a function has a Taylor series at order at least `1` on a neighborhood of `x`, then the term
 of order `1` of this series is a derivative of `f` at `x`. -/
-lemma has_ftaylor_series_up_to_on.has_fderiv_at {n : with_top ℕ}
+lemma has_ftaylor_series_up_to_on.has_fderiv_at
   (h : has_ftaylor_series_up_to_on n f p s) (hn : 1 ≤ n) (hx : s ∈ 𝓝 x) :
   has_fderiv_at f (continuous_multilinear_curry_fin1 𝕜 E F (p x 1)) x :=
 (h.has_fderiv_within_at hn (mem_of_mem_nhds hx)).has_fderiv_at hx
 
 /-- If a function has a Taylor series at order at least `1` on a neighborhood of `x`, then
 in a neighborhood of `x`, the term of order `1` of this series is a derivative of `f`. -/
-lemma has_ftaylor_series_up_to_on.eventually_has_fderiv_at {n : with_top ℕ}
+lemma has_ftaylor_series_up_to_on.eventually_has_fderiv_at
   (h : has_ftaylor_series_up_to_on n f p s) (hn : 1 ≤ n) (hx : s ∈ 𝓝 x) :
   ∀ᶠ y in 𝓝 x, has_fderiv_at f (continuous_multilinear_curry_fin1 𝕜 E F (p y 1)) y :=
 (eventually_eventually_nhds.2 hx).mono $ λ y hy, h.has_fderiv_at hn hy
 
 /-- If a function has a Taylor series at order at least `1` on a neighborhood of `x`, then
 it is differentiable at `x`. -/
-lemma has_ftaylor_series_up_to_on.differentiable_at {n : with_top ℕ}
+lemma has_ftaylor_series_up_to_on.differentiable_at
   (h : has_ftaylor_series_up_to_on n f p s) (hn : 1 ≤ n) (hx : s ∈ 𝓝 x) :
   differentiable_at 𝕜 f x :=
 (h.has_fderiv_at hn hx).differentiable_at
@@ -427,7 +427,7 @@ lemma cont_diff_within_at.of_le {m n : with_top ℕ}
   cont_diff_within_at 𝕜 m f s x :=
 λ k hk, h k (le_trans hk hmn)
 
-lemma cont_diff_within_at_iff_forall_nat_le {n : with_top ℕ} :
+lemma cont_diff_within_at_iff_forall_nat_le :
   cont_diff_within_at 𝕜 n f s x ↔ ∀ m : ℕ, ↑m ≤ n → cont_diff_within_at 𝕜 m f s x :=
 ⟨λ H m hm, H.of_le hm, λ H m hm, H m hm _ le_rfl⟩
 
@@ -435,7 +435,7 @@ lemma cont_diff_within_at_top :
   cont_diff_within_at 𝕜 ∞ f s x ↔ ∀ (n : ℕ), cont_diff_within_at 𝕜 n f s x :=
 cont_diff_within_at_iff_forall_nat_le.trans $ by simp only [forall_prop_of_true, le_top]
 
-lemma cont_diff_within_at.continuous_within_at {n : with_top ℕ}
+lemma cont_diff_within_at.continuous_within_at
   (h : cont_diff_within_at 𝕜 n f s x) : continuous_within_at f s x :=
 begin
   rcases h 0 bot_le with ⟨u, hu, p, H⟩,
@@ -443,35 +443,35 @@ begin
   exact (H.continuous_on.continuous_within_at hu.1).mono_of_mem hu.2
 end
 
-lemma cont_diff_within_at.congr_of_eventually_eq {n : with_top ℕ}
+lemma cont_diff_within_at.congr_of_eventually_eq
   (h : cont_diff_within_at 𝕜 n f s x) (h₁ : f₁ =ᶠ[𝓝[s] x] f) (hx : f₁ x = f x) :
   cont_diff_within_at 𝕜 n f₁ s x :=
 λ m hm, let ⟨u, hu, p, H⟩ := h m hm in
 ⟨{x ∈ u | f₁ x = f x}, filter.inter_mem hu (mem_nhds_within_insert.2 ⟨hx, h₁⟩), p,
   (H.mono (sep_subset _ _)).congr (λ _, and.right)⟩
 
-lemma cont_diff_within_at.congr_of_eventually_eq' {n : with_top ℕ}
+lemma cont_diff_within_at.congr_of_eventually_eq'
   (h : cont_diff_within_at 𝕜 n f s x) (h₁ : f₁ =ᶠ[𝓝[s] x] f) (hx : x ∈ s) :
   cont_diff_within_at 𝕜 n f₁ s x :=
 h.congr_of_eventually_eq h₁ $ h₁.self_of_nhds_within hx
 
-lemma filter.eventually_eq.cont_diff_within_at_iff {n : with_top ℕ}
+lemma filter.eventually_eq.cont_diff_within_at_iff
   (h₁ : f₁ =ᶠ[𝓝[s] x] f) (hx : f₁ x = f x) :
   cont_diff_within_at 𝕜 n f₁ s x ↔ cont_diff_within_at 𝕜 n f s x :=
 ⟨λ H, cont_diff_within_at.congr_of_eventually_eq H h₁.symm hx.symm,
 λ H, H.congr_of_eventually_eq h₁ hx⟩
 
-lemma cont_diff_within_at.congr {n : with_top ℕ}
+lemma cont_diff_within_at.congr
   (h : cont_diff_within_at 𝕜 n f s x) (h₁ : ∀ y ∈ s, f₁ y = f y) (hx : f₁ x = f x) :
   cont_diff_within_at 𝕜 n f₁ s x :=
 h.congr_of_eventually_eq (filter.eventually_eq_of_mem self_mem_nhds_within h₁) hx
 
-lemma cont_diff_within_at.congr' {n : with_top ℕ}
+lemma cont_diff_within_at.congr'
   (h : cont_diff_within_at 𝕜 n f s x) (h₁ : ∀ y ∈ s, f₁ y = f y) (hx : x ∈ s) :
   cont_diff_within_at 𝕜 n f₁ s x :=
 h.congr h₁ (h₁ _ hx)
 
-lemma cont_diff_within_at.mono_of_mem {n : with_top ℕ}
+lemma cont_diff_within_at.mono_of_mem
   (h : cont_diff_within_at 𝕜 n f s x) {t : set E} (hst : s ∈ 𝓝[t] x) :
   cont_diff_within_at 𝕜 n f t x :=
 begin
@@ -480,31 +480,31 @@ begin
   exact ⟨u, nhds_within_le_of_mem (insert_mem_nhds_within_insert hst) hu, p, H⟩
 end
 
-lemma cont_diff_within_at.mono {n : with_top ℕ}
+lemma cont_diff_within_at.mono
   (h : cont_diff_within_at 𝕜 n f s x) {t : set E} (hst : t ⊆ s) :
   cont_diff_within_at 𝕜 n f t x :=
 h.mono_of_mem $ filter.mem_of_superset self_mem_nhds_within hst
 
-lemma cont_diff_within_at.congr_nhds {n : with_top ℕ}
+lemma cont_diff_within_at.congr_nhds
   (h : cont_diff_within_at 𝕜 n f s x) {t : set E} (hst : 𝓝[s] x = 𝓝[t] x) :
   cont_diff_within_at 𝕜 n f t x :=
 h.mono_of_mem $ hst ▸ self_mem_nhds_within
 
-lemma cont_diff_within_at_congr_nhds {n : with_top ℕ} {t : set E} (hst : 𝓝[s] x = 𝓝[t] x) :
+lemma cont_diff_within_at_congr_nhds {t : set E} (hst : 𝓝[s] x = 𝓝[t] x) :
   cont_diff_within_at 𝕜 n f s x ↔ cont_diff_within_at 𝕜 n f t x :=
 ⟨λ h, h.congr_nhds hst, λ h, h.congr_nhds hst.symm⟩
 
-lemma cont_diff_within_at_inter' {n : with_top ℕ} (h : t ∈ 𝓝[s] x) :
+lemma cont_diff_within_at_inter' (h : t ∈ 𝓝[s] x) :
   cont_diff_within_at 𝕜 n f (s ∩ t) x ↔ cont_diff_within_at 𝕜 n f s x :=
 cont_diff_within_at_congr_nhds $ eq.symm $ nhds_within_restrict'' _ h
 
-lemma cont_diff_within_at_inter {n : with_top ℕ} (h : t ∈ 𝓝 x) :
+lemma cont_diff_within_at_inter (h : t ∈ 𝓝 x) :
   cont_diff_within_at 𝕜 n f (s ∩ t) x ↔ cont_diff_within_at 𝕜 n f s x :=
 cont_diff_within_at_inter' (mem_nhds_within_of_mem_nhds h)
 
 /-- If a function is `C^n` within a set at a point, with `n ≥ 1`, then it is differentiable
 within this set at this point. -/
-lemma cont_diff_within_at.differentiable_within_at' {n : with_top ℕ}
+lemma cont_diff_within_at.differentiable_within_at'
   (h : cont_diff_within_at 𝕜 n f s x) (hn : 1 ≤ n) :
   differentiable_within_at 𝕜 f (insert x s) x :=
 begin
@@ -515,7 +515,7 @@ begin
   exact (differentiable_within_at_inter (is_open.mem_nhds t_open xt)).1 this,
 end
 
-lemma cont_diff_within_at.differentiable_within_at {n : with_top ℕ}
+lemma cont_diff_within_at.differentiable_within_at
   (h : cont_diff_within_at 𝕜 n f s x) (hn : 1 ≤ n) :
   differentiable_within_at 𝕜 f s x :=
 (h.differentiable_within_at' hn).mono  (subset_insert x s)
@@ -582,12 +582,12 @@ definition cont_diff_on (n : with_top ℕ) (f : E → F) (s : set E) :=
 
 variable {𝕜}
 
-lemma cont_diff_on.cont_diff_within_at {n : with_top ℕ}
+lemma cont_diff_on.cont_diff_within_at
   (h : cont_diff_on 𝕜 n f s) (hx : x ∈ s) :
   cont_diff_within_at 𝕜 n f s x :=
 h x hx
 
-lemma cont_diff_within_at.cont_diff_on {n : with_top ℕ} {m : ℕ}
+lemma cont_diff_within_at.cont_diff_on {m : ℕ}
   (hm : (m : with_top ℕ) ≤ n) (h : cont_diff_within_at 𝕜 n f s x) :
   ∃ u ∈ 𝓝[insert x s] x, u ⊆ insert x s ∧ cont_diff_on 𝕜 m f u :=
 begin
@@ -616,7 +616,7 @@ lemma cont_diff_on.of_le {m n : with_top ℕ}
   cont_diff_on 𝕜 m f s :=
 λ x hx, (h x hx).of_le hmn
 
-lemma cont_diff_on_iff_forall_nat_le {n : with_top ℕ} :
+lemma cont_diff_on_iff_forall_nat_le :
   cont_diff_on 𝕜 n f s ↔ ∀ m : ℕ, ↑m ≤ n → cont_diff_on 𝕜 m f s :=
 ⟨λ H m hm, H.of_le hm, λ H x hx m hm, H m hm x hx m le_rfl⟩
 
@@ -632,36 +632,36 @@ begin
   exacts [cont_diff_on_top.2 H, H n]
 end
 
-lemma cont_diff_on.continuous_on {n : with_top ℕ}
+lemma cont_diff_on.continuous_on
   (h : cont_diff_on 𝕜 n f s) : continuous_on f s :=
 λ x hx, (h x hx).continuous_within_at
 
-lemma cont_diff_on.congr {n : with_top ℕ}
+lemma cont_diff_on.congr
   (h : cont_diff_on 𝕜 n f s) (h₁ : ∀ x ∈ s, f₁ x = f x) :
   cont_diff_on 𝕜 n f₁ s :=
 λ x hx, (h x hx).congr h₁ (h₁ x hx)
 
-lemma cont_diff_on_congr {n : with_top ℕ} (h₁ : ∀ x ∈ s, f₁ x = f x) :
+lemma cont_diff_on_congr (h₁ : ∀ x ∈ s, f₁ x = f x) :
   cont_diff_on 𝕜 n f₁ s ↔ cont_diff_on 𝕜 n f s :=
 ⟨λ H, H.congr (λ x hx, (h₁ x hx).symm), λ H, H.congr h₁⟩
 
-lemma cont_diff_on.mono {n : with_top ℕ}
+lemma cont_diff_on.mono
   (h : cont_diff_on 𝕜 n f s) {t : set E} (hst : t ⊆ s) :
   cont_diff_on 𝕜 n f t :=
 λ x hx, (h x (hst hx)).mono hst
 
-lemma cont_diff_on.congr_mono {n : with_top ℕ}
+lemma cont_diff_on.congr_mono
   (hf : cont_diff_on 𝕜 n f s) (h₁ : ∀ x ∈ s₁, f₁ x = f x) (hs : s₁ ⊆ s) :
   cont_diff_on 𝕜 n f₁ s₁ :=
 (hf.mono hs).congr h₁
 
 /-- If a function is `C^n` on a set with `n ≥ 1`, then it is differentiable there. -/
-lemma cont_diff_on.differentiable_on {n : with_top ℕ}
+lemma cont_diff_on.differentiable_on
   (h : cont_diff_on 𝕜 n f s) (hn : 1 ≤ n) : differentiable_on 𝕜 f s :=
 λ x hx, (h x hx).differentiable_within_at hn
 
 /-- If a function is `C^n` around each point in a set, then it is `C^n` on the set. -/
-lemma cont_diff_on_of_locally_cont_diff_on {n : with_top ℕ}
+lemma cont_diff_on_of_locally_cont_diff_on
   (h : ∀ x ∈ s, ∃u, is_open u ∧ x ∈ u ∧ cont_diff_on 𝕜 n f (s ∩ u)) :
   cont_diff_on 𝕜 n f s :=
 begin
@@ -869,7 +869,7 @@ end
 
 /-- On a set with unique differentiability, any choice of iterated differential has to coincide
 with the one we have chosen in `iterated_fderiv_within 𝕜 m f s`. -/
-theorem has_ftaylor_series_up_to_on.eq_ftaylor_series_of_unique_diff_on {n : with_top ℕ}
+theorem has_ftaylor_series_up_to_on.eq_ftaylor_series_of_unique_diff_on
   (h : has_ftaylor_series_up_to_on n f p s)
   {m : ℕ} (hmn : (m : with_top ℕ) ≤ n) (hs : unique_diff_on 𝕜 s) (hx : x ∈ s) :
   p x m = iterated_fderiv_within 𝕜 m f s x :=
@@ -887,7 +887,7 @@ end
 
 /-- When a function is `C^n` in a set `s` of unique differentiability, it admits
 `ftaylor_series_within 𝕜 f s` as a Taylor series up to order `n` in `s`. -/
-theorem cont_diff_on.ftaylor_series_within {n : with_top ℕ}
+theorem cont_diff_on.ftaylor_series_within
   (h : cont_diff_on 𝕜 n f s) (hs : unique_diff_on 𝕜 s) :
   has_ftaylor_series_up_to_on n f (ftaylor_series_within 𝕜 f s) s :=
 begin
@@ -931,7 +931,7 @@ begin
     exact ((Hp.mono ho).cont m le_rfl).congr (λ y hy, (A y hy).symm) }
 end
 
-lemma cont_diff_on_of_continuous_on_differentiable_on {n : with_top ℕ}
+lemma cont_diff_on_of_continuous_on_differentiable_on
   (Hcont : ∀ (m : ℕ), (m : with_top ℕ) ≤ n →
     continuous_on (λ x, iterated_fderiv_within 𝕜 m f s x) s)
   (Hdiff : ∀ (m : ℕ), (m : with_top ℕ) < n →
@@ -954,23 +954,23 @@ begin
     exact Hcont k (le_trans hk hm) }
 end
 
-lemma cont_diff_on_of_differentiable_on {n : with_top ℕ}
+lemma cont_diff_on_of_differentiable_on
   (h : ∀(m : ℕ), (m : with_top ℕ) ≤ n → differentiable_on 𝕜 (iterated_fderiv_within 𝕜 m f s) s) :
   cont_diff_on 𝕜 n f s :=
 cont_diff_on_of_continuous_on_differentiable_on
   (λ m hm, (h m hm).continuous_on) (λ m hm, (h m (le_of_lt hm)))
 
-lemma cont_diff_on.continuous_on_iterated_fderiv_within {n : with_top ℕ} {m : ℕ}
+lemma cont_diff_on.continuous_on_iterated_fderiv_within {m : ℕ}
   (h : cont_diff_on 𝕜 n f s) (hmn : (m : with_top ℕ) ≤ n) (hs : unique_diff_on 𝕜 s) :
   continuous_on (iterated_fderiv_within 𝕜 m f s) s :=
 (h.ftaylor_series_within hs).cont m hmn
 
-lemma cont_diff_on.differentiable_on_iterated_fderiv_within {n : with_top ℕ} {m : ℕ}
+lemma cont_diff_on.differentiable_on_iterated_fderiv_within {m : ℕ}
   (h : cont_diff_on 𝕜 n f s) (hmn : (m : with_top ℕ) < n) (hs : unique_diff_on 𝕜 s) :
   differentiable_on 𝕜 (iterated_fderiv_within 𝕜 m f s) s :=
 λ x hx, ((h.ftaylor_series_within hs).fderiv_within m hmn x hx).differentiable_within_at
 
-lemma cont_diff_on_iff_continuous_on_differentiable_on {n : with_top ℕ}
+lemma cont_diff_on_iff_continuous_on_differentiable_on
   (hs : unique_diff_on 𝕜 s) :
   cont_diff_on 𝕜 n f s ↔
   (∀ (m : ℕ), (m : with_top ℕ) ≤ n →
@@ -1080,12 +1080,12 @@ lemma cont_diff_on.fderiv_of_open {m n : with_top ℕ}
   cont_diff_on 𝕜 m (λ y, fderiv 𝕜 f y) s :=
 (hf.fderiv_within hs.unique_diff_on hmn).congr (λ x hx, (fderiv_within_of_open hs hx).symm)
 
-lemma cont_diff_on.continuous_on_fderiv_within {n : with_top ℕ}
+lemma cont_diff_on.continuous_on_fderiv_within
   (h : cont_diff_on 𝕜 n f s) (hs : unique_diff_on 𝕜 s) (hn : 1 ≤ n) :
   continuous_on (λ x, fderiv_within 𝕜 f s x) s :=
 ((cont_diff_on_succ_iff_fderiv_within hs).1 (h.of_le hn)).2.continuous_on
 
-lemma cont_diff_on.continuous_on_fderiv_of_open {n : with_top ℕ}
+lemma cont_diff_on.continuous_on_fderiv_of_open
   (h : cont_diff_on 𝕜 n f s) (hs : is_open s) (hn : 1 ≤ n) :
   continuous_on (λ x, fderiv 𝕜 f x) s :=
 ((cont_diff_on_succ_iff_fderiv_of_open hs).1 (h.of_le hn)).2.continuous_on
@@ -1093,7 +1093,7 @@ lemma cont_diff_on.continuous_on_fderiv_of_open {n : with_top ℕ}
 /-- If a function is at least `C^1`, its bundled derivative (mapping `(x, v)` to `Df(x) v`) is
 continuous. -/
 lemma cont_diff_on.continuous_on_fderiv_within_apply
-  {n : with_top ℕ} (h : cont_diff_on 𝕜 n f s) (hs : unique_diff_on 𝕜 s) (hn : 1 ≤ n) :
+  (h : cont_diff_on 𝕜 n f s) (hs : unique_diff_on 𝕜 s) (hn : 1 ≤ n) :
   continuous_on (λp : E × E, (fderiv_within 𝕜 f s p.1 : E → F) p.2) (s ×ˢ (univ : set E)) :=
 begin
   have A : continuous (λq : (E →L[𝕜] F) × E, q.1 q.2) := is_bounded_bilinear_map_apply.continuous,
@@ -1116,12 +1116,12 @@ structure has_ftaylor_series_up_to (n : with_top ℕ)
     has_fderiv_at (λ y, p y m) (p x m.succ).curry_left x)
 (cont    : ∀ (m : ℕ) (hm : (m : with_top ℕ) ≤ n), continuous (λ x, p x m))
 
-lemma has_ftaylor_series_up_to.zero_eq' {n : with_top ℕ}
+lemma has_ftaylor_series_up_to.zero_eq'
   (h : has_ftaylor_series_up_to n f p) (x : E) :
   p x 0 = (continuous_multilinear_curry_fin0 𝕜 E F).symm (f x) :=
 by { rw ← h.zero_eq x, symmetry, exact continuous_multilinear_map.uncurry0_curry0 _ }
 
-lemma has_ftaylor_series_up_to_on_univ_iff {n : with_top ℕ} :
+lemma has_ftaylor_series_up_to_on_univ_iff :
   has_ftaylor_series_up_to_on n f p univ ↔ has_ftaylor_series_up_to n f p :=
 begin
   split,
@@ -1145,7 +1145,7 @@ begin
       exact H.cont m hm } }
 end
 
-lemma has_ftaylor_series_up_to.has_ftaylor_series_up_to_on {n : with_top ℕ}
+lemma has_ftaylor_series_up_to.has_ftaylor_series_up_to_on
   (h : has_ftaylor_series_up_to n f p) (s : set E) :
   has_ftaylor_series_up_to_on n f p s :=
 (has_ftaylor_series_up_to_on_univ_iff.2 h).mono (subset_univ _)
@@ -1155,7 +1155,7 @@ lemma has_ftaylor_series_up_to.of_le {m n : with_top ℕ}
   has_ftaylor_series_up_to m f p :=
 by { rw ← has_ftaylor_series_up_to_on_univ_iff at h ⊢, exact h.of_le hmn }
 
-lemma has_ftaylor_series_up_to.continuous {n : with_top ℕ}
+lemma has_ftaylor_series_up_to.continuous
   (h : has_ftaylor_series_up_to n f p) : continuous f :=
 begin
   rw ← has_ftaylor_series_up_to_on_univ_iff at h,
@@ -1170,7 +1170,7 @@ by simp [has_ftaylor_series_up_to_on_univ_iff.symm, continuous_iff_continuous_on
 
 /-- If a function has a Taylor series at order at least `1`, then the term of order `1` of this
 series is a derivative of `f`. -/
-lemma has_ftaylor_series_up_to.has_fderiv_at {n : with_top ℕ}
+lemma has_ftaylor_series_up_to.has_fderiv_at
   (h : has_ftaylor_series_up_to n f p) (hn : 1 ≤ n) (x : E) :
   has_fderiv_at f (continuous_multilinear_curry_fin1 𝕜 E F (p x 1)) x :=
 begin
@@ -1178,7 +1178,7 @@ begin
   exact (has_ftaylor_series_up_to_on_univ_iff.2 h).has_fderiv_within_at hn (mem_univ _)
 end
 
-lemma has_ftaylor_series_up_to.differentiable {n : with_top ℕ}
+lemma has_ftaylor_series_up_to.differentiable
   (h : has_ftaylor_series_up_to n f p) (hn : 1 ≤ n) : differentiable 𝕜 f :=
 λ x, (h.has_fderiv_at hn x).differentiable_at
 
@@ -1205,7 +1205,7 @@ cont_diff_within_at 𝕜 n f univ x
 
 variable {𝕜}
 
-theorem cont_diff_within_at_univ {n : with_top ℕ} :
+theorem cont_diff_within_at_univ :
   cont_diff_within_at 𝕜 n f univ x ↔ cont_diff_at 𝕜 n f x :=
 iff.rfl
 
@@ -1213,16 +1213,16 @@ lemma cont_diff_at_top :
   cont_diff_at 𝕜 ∞ f x ↔ ∀ (n : ℕ), cont_diff_at 𝕜 n f x :=
 by simp [← cont_diff_within_at_univ, cont_diff_within_at_top]
 
-lemma cont_diff_at.cont_diff_within_at {n : with_top ℕ}
+lemma cont_diff_at.cont_diff_within_at
   (h : cont_diff_at 𝕜 n f x) : cont_diff_within_at 𝕜 n f s x :=
 h.mono (subset_univ _)
 
-lemma cont_diff_within_at.cont_diff_at {n : with_top ℕ}
+lemma cont_diff_within_at.cont_diff_at
   (h : cont_diff_within_at 𝕜 n f s x) (hx : s ∈ 𝓝 x) :
   cont_diff_at 𝕜 n f x :=
 by rwa [cont_diff_at, ← cont_diff_within_at_inter hx, univ_inter]
 
-lemma cont_diff_at.congr_of_eventually_eq {n : with_top ℕ}
+lemma cont_diff_at.congr_of_eventually_eq
   (h : cont_diff_at 𝕜 n f x) (hg : f₁ =ᶠ[𝓝 x] f) :
   cont_diff_at 𝕜 n f₁ x :=
 h.congr_of_eventually_eq' (by rwa nhds_within_univ) (mem_univ x)
@@ -1232,12 +1232,12 @@ lemma cont_diff_at.of_le {m n : with_top ℕ}
   cont_diff_at 𝕜 m f x :=
 h.of_le hmn
 
-lemma cont_diff_at.continuous_at {n : with_top ℕ}
+lemma cont_diff_at.continuous_at
   (h : cont_diff_at 𝕜 n f x) : continuous_at f x :=
 by simpa [continuous_within_at_univ] using h.continuous_within_at
 
 /-- If a function is `C^n` with `n ≥ 1` at a point, then it is differentiable there. -/
-lemma cont_diff_at.differentiable_at {n : with_top ℕ}
+lemma cont_diff_at.differentiable_at
   (h : cont_diff_at 𝕜 n f x) (hn : 1 ≤ n) : differentiable_at 𝕜 f x :=
 by simpa [hn, differentiable_within_at_univ] using h.differentiable_within_at
 
@@ -1280,7 +1280,7 @@ definition cont_diff (n : with_top ℕ) (f : E → F)  :=
 
 variable {𝕜}
 
-theorem cont_diff_on_univ {n : with_top ℕ} :
+theorem cont_diff_on_univ :
   cont_diff_on 𝕜 n f univ ↔ cont_diff 𝕜 n f :=
 begin
   split,
@@ -1292,15 +1292,15 @@ begin
     exact ⟨univ, filter.univ_sets _, p, (hp.has_ftaylor_series_up_to_on univ).of_le hm⟩ }
 end
 
-lemma cont_diff_iff_cont_diff_at {n : with_top ℕ} :
+lemma cont_diff_iff_cont_diff_at :
   cont_diff 𝕜 n f ↔ ∀ x, cont_diff_at 𝕜 n f x :=
 by simp [← cont_diff_on_univ, cont_diff_on, cont_diff_at]
 
-lemma cont_diff.cont_diff_at {n : with_top ℕ} (h : cont_diff 𝕜 n f) :
+lemma cont_diff.cont_diff_at (h : cont_diff 𝕜 n f) :
   cont_diff_at 𝕜 n f x :=
 cont_diff_iff_cont_diff_at.1 h x
 
-lemma cont_diff.cont_diff_within_at {n : with_top ℕ} (h : cont_diff 𝕜 n f) :
+lemma cont_diff.cont_diff_within_at (h : cont_diff 𝕜 n f) :
   cont_diff_within_at 𝕜 n f s x :=
 h.cont_diff_at.cont_diff_within_at
 
@@ -1312,7 +1312,7 @@ lemma cont_diff_all_iff_nat :
   (∀ n, cont_diff 𝕜 n f) ↔ (∀ n : ℕ, cont_diff 𝕜 n f) :=
 by simp only [← cont_diff_on_univ, cont_diff_on_all_iff_nat]
 
-lemma cont_diff.cont_diff_on {n : with_top ℕ}
+lemma cont_diff.cont_diff_on
   (h : cont_diff 𝕜 n f) : cont_diff_on 𝕜 n f s :=
 (cont_diff_on_univ.2 h).mono (subset_univ _)
 
@@ -1338,12 +1338,12 @@ lemma cont_diff.of_le {m n : with_top ℕ}
   cont_diff 𝕜 m f :=
 cont_diff_on_univ.1 $ (cont_diff_on_univ.2 h).of_le hmn
 
-lemma cont_diff.continuous {n : with_top ℕ}
+lemma cont_diff.continuous
   (h : cont_diff 𝕜 n f) : continuous f :=
 cont_diff_zero.1 (h.of_le bot_le)
 
 /-- If a function is `C^n` with `n ≥ 1`, then it is differentiable. -/
-lemma cont_diff.differentiable {n : with_top ℕ}
+lemma cont_diff.differentiable
   (h : cont_diff 𝕜 n f) (hn : 1 ≤ n) : differentiable 𝕜 f :=
 differentiable_on_univ.1 $ (cont_diff_on_univ.2 h).differentiable_on hn
 
@@ -1442,7 +1442,7 @@ by { rw [iterated_fderiv_succ_apply_right, iterated_fderiv_zero_apply], refl }
 
 /-- When a function is `C^n` in a set `s` of unique differentiability, it admits
 `ftaylor_series_within 𝕜 f s` as a Taylor series up to order `n` in `s`. -/
-theorem cont_diff_on_iff_ftaylor_series {n : with_top ℕ} :
+theorem cont_diff_on_iff_ftaylor_series :
   cont_diff 𝕜 n f ↔ has_ftaylor_series_up_to n f (ftaylor_series 𝕜 f) :=
 begin
   split,
@@ -1452,7 +1452,7 @@ begin
   { assume h, exact ⟨ftaylor_series 𝕜 f, h⟩ }
 end
 
-lemma cont_diff_iff_continuous_differentiable {n : with_top ℕ} :
+lemma cont_diff_iff_continuous_differentiable :
   cont_diff 𝕜 n f ↔
   (∀ (m : ℕ), (m : with_top ℕ) ≤ n → continuous (λ x, iterated_fderiv 𝕜 m f x))
   ∧ (∀ (m : ℕ), (m : with_top ℕ) < n → differentiable 𝕜 (λ x, iterated_fderiv 𝕜 m f x)) :=
@@ -1460,7 +1460,7 @@ by simp [cont_diff_on_univ.symm, continuous_iff_continuous_on_univ,
     differentiable_on_univ.symm, iterated_fderiv_within_univ,
     cont_diff_on_iff_continuous_on_differentiable_on unique_diff_on_univ]
 
-lemma cont_diff_of_differentiable_iterated_fderiv {n : with_top ℕ}
+lemma cont_diff_of_differentiable_iterated_fderiv
   (h : ∀(m : ℕ), (m : with_top ℕ) ≤ n → differentiable 𝕜 (iterated_fderiv 𝕜 m f)) :
   cont_diff 𝕜 n f :=
 cont_diff_iff_continuous_differentiable.2
@@ -1490,14 +1490,14 @@ begin
   rw cont_diff_on_top_iff_fderiv_within unique_diff_on_univ,
 end
 
-lemma cont_diff.continuous_fderiv {n : with_top ℕ}
+lemma cont_diff.continuous_fderiv
   (h : cont_diff 𝕜 n f) (hn : 1 ≤ n) :
   continuous (λ x, fderiv 𝕜 f x) :=
 ((cont_diff_succ_iff_fderiv).1 (h.of_le hn)).2.continuous
 
 /-- If a function is at least `C^1`, its bundled derivative (mapping `(x, v)` to `Df(x) v`) is
 continuous. -/
-lemma cont_diff.continuous_fderiv_apply {n : with_top ℕ}
+lemma cont_diff.continuous_fderiv_apply
   (h : cont_diff 𝕜 n f) (hn : 1 ≤ n) :
   continuous (λp : E × E, (fderiv 𝕜 f p.1 : E → F) p.2) :=
 begin
@@ -1522,7 +1522,7 @@ begin
     refl }
 end
 
-lemma cont_diff_zero_fun {n : with_top ℕ} :
+lemma cont_diff_zero_fun :
   cont_diff 𝕜 n (λ x : E, (0 : F)) :=
 begin
   apply cont_diff_of_differentiable_iterated_fderiv (λm hm, _),
@@ -1533,7 +1533,7 @@ end
 /--
 Constants are `C^∞`.
 -/
-lemma cont_diff_const {n : with_top ℕ} {c : F} : cont_diff 𝕜 n (λx : E, c) :=
+lemma cont_diff_const {c : F} : cont_diff 𝕜 n (λx : E, c) :=
 begin
   suffices h : cont_diff 𝕜 ∞ (λx : E, c), by exact h.of_le le_top,
   rw cont_diff_top_iff_fderiv,
@@ -1542,31 +1542,31 @@ begin
   exact cont_diff_zero_fun
 end
 
-lemma cont_diff_on_const {n : with_top ℕ} {c : F} {s : set E} :
+lemma cont_diff_on_const {c : F} {s : set E} :
   cont_diff_on 𝕜 n (λx : E, c) s :=
 cont_diff_const.cont_diff_on
 
-lemma cont_diff_at_const {n : with_top ℕ} {c : F} :
+lemma cont_diff_at_const {c : F} :
   cont_diff_at 𝕜 n (λx : E, c) x :=
 cont_diff_const.cont_diff_at
 
-lemma cont_diff_within_at_const {n : with_top ℕ} {c : F} :
+lemma cont_diff_within_at_const {c : F} :
   cont_diff_within_at 𝕜 n (λx : E, c) s x :=
 cont_diff_at_const.cont_diff_within_at
 
-@[nontriviality] lemma cont_diff_of_subsingleton [subsingleton F] {n : with_top ℕ} :
+@[nontriviality] lemma cont_diff_of_subsingleton [subsingleton F] :
   cont_diff 𝕜 n f :=
 by { rw [subsingleton.elim f (λ _, 0)], exact cont_diff_const }
 
-@[nontriviality] lemma cont_diff_at_of_subsingleton [subsingleton F] {n : with_top ℕ} :
+@[nontriviality] lemma cont_diff_at_of_subsingleton [subsingleton F] :
   cont_diff_at 𝕜 n f x :=
 by { rw [subsingleton.elim f (λ _, 0)], exact cont_diff_at_const }
 
-@[nontriviality] lemma cont_diff_within_at_of_subsingleton [subsingleton F] {n : with_top ℕ} :
+@[nontriviality] lemma cont_diff_within_at_of_subsingleton [subsingleton F] :
   cont_diff_within_at 𝕜 n f s x :=
 by { rw [subsingleton.elim f (λ _, 0)], exact cont_diff_within_at_const }
 
-@[nontriviality] lemma cont_diff_on_of_subsingleton [subsingleton F] {n : with_top ℕ} :
+@[nontriviality] lemma cont_diff_on_of_subsingleton [subsingleton F] :
   cont_diff_on 𝕜 n f s :=
 by { rw [subsingleton.elim f (λ _, 0)], exact cont_diff_on_const }
 
@@ -1575,7 +1575,7 @@ by { rw [subsingleton.elim f (λ _, 0)], exact cont_diff_on_const }
 /--
 Unbundled bounded linear functions are `C^∞`.
 -/
-lemma is_bounded_linear_map.cont_diff {n : with_top ℕ} (hf : is_bounded_linear_map 𝕜 f) :
+lemma is_bounded_linear_map.cont_diff (hf : is_bounded_linear_map 𝕜 f) :
   cont_diff 𝕜 n f :=
 begin
   suffices h : cont_diff 𝕜 ∞ f, by exact h.of_le le_top,
@@ -1585,73 +1585,73 @@ begin
   exact cont_diff_const
 end
 
-lemma continuous_linear_map.cont_diff {n : with_top ℕ} (f : E →L[𝕜] F) :
+lemma continuous_linear_map.cont_diff (f : E →L[𝕜] F) :
   cont_diff 𝕜 n f :=
 f.is_bounded_linear_map.cont_diff
 
-lemma continuous_linear_equiv.cont_diff {n : with_top ℕ} (f : E ≃L[𝕜] F) :
+lemma continuous_linear_equiv.cont_diff (f : E ≃L[𝕜] F) :
   cont_diff 𝕜 n f :=
 (f : E →L[𝕜] F).cont_diff
 
-lemma linear_isometry.cont_diff {n : with_top ℕ} (f : E →ₗᵢ[𝕜] F) :
+lemma linear_isometry.cont_diff (f : E →ₗᵢ[𝕜] F) :
   cont_diff 𝕜 n f :=
 f.to_continuous_linear_map.cont_diff
 
-lemma linear_isometry_equiv.cont_diff {n : with_top ℕ} (f : E ≃ₗᵢ[𝕜] F) :
+lemma linear_isometry_equiv.cont_diff (f : E ≃ₗᵢ[𝕜] F) :
   cont_diff 𝕜 n f :=
 (f : E →L[𝕜] F).cont_diff
 
 /--
 The first projection in a product is `C^∞`.
 -/
-lemma cont_diff_fst {n : with_top ℕ} : cont_diff 𝕜 n (prod.fst : E × F → E) :=
+lemma cont_diff_fst : cont_diff 𝕜 n (prod.fst : E × F → E) :=
 is_bounded_linear_map.cont_diff is_bounded_linear_map.fst
 
 /--
 The first projection on a domain in a product is `C^∞`.
 -/
-lemma cont_diff_on_fst {s : set (E×F)} {n : with_top ℕ} :
+lemma cont_diff_on_fst {s : set (E×F)} :
   cont_diff_on 𝕜 n (prod.fst : E × F → E) s :=
 cont_diff.cont_diff_on cont_diff_fst
 
 /--
 The first projection at a point in a product is `C^∞`.
 -/
-lemma cont_diff_at_fst {p : E × F} {n : with_top ℕ} :
+lemma cont_diff_at_fst {p : E × F} :
   cont_diff_at 𝕜 n (prod.fst : E × F → E) p :=
 cont_diff_fst.cont_diff_at
 
 /--
 The first projection within a domain at a point in a product is `C^∞`.
 -/
-lemma cont_diff_within_at_fst {s : set (E × F)} {p : E × F} {n : with_top ℕ} :
+lemma cont_diff_within_at_fst {s : set (E × F)} {p : E × F} :
   cont_diff_within_at 𝕜 n (prod.fst : E × F → E) s p :=
 cont_diff_fst.cont_diff_within_at
 
 /--
 The second projection in a product is `C^∞`.
 -/
-lemma cont_diff_snd {n : with_top ℕ} : cont_diff 𝕜 n (prod.snd : E × F → F) :=
+lemma cont_diff_snd : cont_diff 𝕜 n (prod.snd : E × F → F) :=
 is_bounded_linear_map.cont_diff is_bounded_linear_map.snd
 
 /--
 The second projection on a domain in a product is `C^∞`.
 -/
-lemma cont_diff_on_snd {s : set (E×F)} {n : with_top ℕ} :
+lemma cont_diff_on_snd {s : set (E×F)} :
   cont_diff_on 𝕜 n (prod.snd : E × F → F) s :=
 cont_diff.cont_diff_on cont_diff_snd
 
 /--
 The second projection at a point in a product is `C^∞`.
 -/
-lemma cont_diff_at_snd {p : E × F} {n : with_top ℕ} :
+lemma cont_diff_at_snd {p : E × F} :
   cont_diff_at 𝕜 n (prod.snd : E × F → F) p :=
 cont_diff_snd.cont_diff_at
 
 /--
 The second projection within a domain at a point in a product is `C^∞`.
 -/
-lemma cont_diff_within_at_snd {s : set (E × F)} {p : E × F} {n : with_top ℕ} :
+lemma cont_diff_within_at_snd {s : set (E × F)} {p : E × F} :
   cont_diff_within_at 𝕜 n (prod.snd : E × F → F) s p :=
 cont_diff_snd.cont_diff_within_at
 
@@ -1676,25 +1676,25 @@ lemma cont_diff_prod_assoc_symm : cont_diff 𝕜 ⊤ $ (equiv.prod_assoc E F G).
 /--
 The identity is `C^∞`.
 -/
-lemma cont_diff_id {n : with_top ℕ} : cont_diff 𝕜 n (id : E → E) :=
+lemma cont_diff_id : cont_diff 𝕜 n (id : E → E) :=
 is_bounded_linear_map.id.cont_diff
 
-lemma cont_diff_within_at_id {n : with_top ℕ} {s x} :
+lemma cont_diff_within_at_id {s x} :
   cont_diff_within_at 𝕜 n (id : E → E) s x :=
 cont_diff_id.cont_diff_within_at
 
-lemma cont_diff_at_id {n : with_top ℕ} {x} :
+lemma cont_diff_at_id {x} :
   cont_diff_at 𝕜 n (id : E → E) x :=
 cont_diff_id.cont_diff_at
 
-lemma cont_diff_on_id {n : with_top ℕ} {s} :
+lemma cont_diff_on_id {s} :
   cont_diff_on 𝕜 n (id : E → E) s :=
 cont_diff_id.cont_diff_on
 
 /--
 Bilinear functions are `C^∞`.
 -/
-lemma is_bounded_bilinear_map.cont_diff {n : with_top ℕ} (hb : is_bounded_bilinear_map 𝕜 b) :
+lemma is_bounded_bilinear_map.cont_diff (hb : is_bounded_bilinear_map 𝕜 b) :
   cont_diff 𝕜 n b :=
 begin
   suffices h : cont_diff 𝕜 ∞ b, by exact h.of_le le_top,
@@ -1706,7 +1706,7 @@ end
 
 /-- If `f` admits a Taylor series `p` in a set `s`, and `g` is linear, then `g ∘ f` admits a Taylor
 series whose `k`-th term is given by `g ∘ (p k)`. -/
-lemma has_ftaylor_series_up_to_on.continuous_linear_map_comp {n : with_top ℕ} (g : F →L[𝕜] G)
+lemma has_ftaylor_series_up_to_on.continuous_linear_map_comp (g : F →L[𝕜] G)
   (hf : has_ftaylor_series_up_to_on n f p s) :
   has_ftaylor_series_up_to_on n (g ∘ f) (λ x k, g.comp_continuous_multilinear_map (p x k)) s :=
 begin
@@ -1722,7 +1722,7 @@ end
 
 /-- Composition by continuous linear maps on the left preserves `C^n` functions in a domain
 at a point. -/
-lemma cont_diff_within_at.continuous_linear_map_comp {n : with_top ℕ} (g : F →L[𝕜] G)
+lemma cont_diff_within_at.continuous_linear_map_comp (g : F →L[𝕜] G)
   (hf : cont_diff_within_at 𝕜 n f s x) :
   cont_diff_within_at 𝕜 n (g ∘ f) s x :=
 begin
@@ -1733,19 +1733,19 @@ end
 
 /-- Composition by continuous linear maps on the left preserves `C^n` functions in a domain
 at a point. -/
-lemma cont_diff_at.continuous_linear_map_comp {n : with_top ℕ} (g : F →L[𝕜] G)
+lemma cont_diff_at.continuous_linear_map_comp (g : F →L[𝕜] G)
   (hf : cont_diff_at 𝕜 n f x) :
   cont_diff_at 𝕜 n (g ∘ f) x :=
 cont_diff_within_at.continuous_linear_map_comp g hf
 
 /-- Composition by continuous linear maps on the left preserves `C^n` functions on domains. -/
-lemma cont_diff_on.continuous_linear_map_comp {n : with_top ℕ} (g : F →L[𝕜] G)
+lemma cont_diff_on.continuous_linear_map_comp (g : F →L[𝕜] G)
   (hf : cont_diff_on 𝕜 n f s) :
   cont_diff_on 𝕜 n (g ∘ f) s :=
 λ x hx, (hf x hx).continuous_linear_map_comp g
 
 /-- Composition by continuous linear maps on the left preserves `C^n` functions. -/
-lemma cont_diff.continuous_linear_map_comp {n : with_top ℕ} {f : E → F} (g : F →L[𝕜] G)
+lemma cont_diff.continuous_linear_map_comp {f : E → F} (g : F →L[𝕜] G)
   (hf : cont_diff 𝕜 n f) : cont_diff 𝕜 n (λx, g (f x)) :=
 cont_diff_on_univ.1 $ cont_diff_on.continuous_linear_map_comp
   _ (cont_diff_on_univ.2 hf)
@@ -1753,7 +1753,7 @@ cont_diff_on_univ.1 $ cont_diff_on.continuous_linear_map_comp
 /-- Composition by continuous linear equivs on the left respects higher differentiability on
 domains. -/
 lemma continuous_linear_equiv.comp_cont_diff_within_at_iff
-  {n : with_top ℕ} (e : F ≃L[𝕜] G) :
+  (e : F ≃L[𝕜] G) :
   cont_diff_within_at 𝕜 n (e ∘ f) s x ↔ cont_diff_within_at 𝕜 n f s x :=
 ⟨λ H, by simpa only [(∘), e.symm.coe_coe, e.symm_apply_apply]
   using H.continuous_linear_map_comp (e.symm : G →L[𝕜] F),
@@ -1762,13 +1762,13 @@ lemma continuous_linear_equiv.comp_cont_diff_within_at_iff
 /-- Composition by continuous linear equivs on the left respects higher differentiability on
 domains. -/
 lemma continuous_linear_equiv.comp_cont_diff_on_iff
-  {n : with_top ℕ} (e : F ≃L[𝕜] G) :
+  (e : F ≃L[𝕜] G) :
   cont_diff_on 𝕜 n (e ∘ f) s ↔ cont_diff_on 𝕜 n f s :=
 by simp [cont_diff_on, e.comp_cont_diff_within_at_iff]
 
 /-- If `f` admits a Taylor series `p` in a set `s`, and `g` is linear, then `f ∘ g` admits a Taylor
 series in `g ⁻¹' s`, whose `k`-th term is given by `p k (g v₁, ..., g vₖ)` . -/
-lemma has_ftaylor_series_up_to_on.comp_continuous_linear_map {n : with_top ℕ}
+lemma has_ftaylor_series_up_to_on.comp_continuous_linear_map
   (hf : has_ftaylor_series_up_to_on n f p s) (g : G →L[𝕜] E) :
   has_ftaylor_series_up_to_on n (f ∘ g)
     (λ x k, (p (g x) k).comp_continuous_linear_map (λ _, g)) (g ⁻¹' s) :=
@@ -1796,7 +1796,7 @@ end
 
 /-- Composition by continuous linear maps on the right preserves `C^n` functions at a point on
 a domain. -/
-lemma cont_diff_within_at.comp_continuous_linear_map {n : with_top ℕ} {x : G}
+lemma cont_diff_within_at.comp_continuous_linear_map {x : G}
   (g : G →L[𝕜] E) (hf : cont_diff_within_at 𝕜 n f s (g x)) :
   cont_diff_within_at 𝕜 n (f ∘ g) (g ⁻¹' s) x :=
 begin
@@ -1811,20 +1811,20 @@ begin
 end
 
 /-- Composition by continuous linear maps on the right preserves `C^n` functions on domains. -/
-lemma cont_diff_on.comp_continuous_linear_map {n : with_top ℕ}
+lemma cont_diff_on.comp_continuous_linear_map
   (hf : cont_diff_on 𝕜 n f s) (g : G →L[𝕜] E) :
   cont_diff_on 𝕜 n (f ∘ g) (g ⁻¹' s) :=
 λ x hx, (hf (g x) hx).comp_continuous_linear_map g
 
 /-- Composition by continuous linear maps on the right preserves `C^n` functions. -/
-lemma cont_diff.comp_continuous_linear_map {n : with_top ℕ} {f : E → F} {g : G →L[𝕜] E}
+lemma cont_diff.comp_continuous_linear_map {f : E → F} {g : G →L[𝕜] E}
   (hf : cont_diff 𝕜 n f) : cont_diff 𝕜 n (f ∘ g) :=
 cont_diff_on_univ.1 $
 cont_diff_on.comp_continuous_linear_map (cont_diff_on_univ.2 hf) _
 
 /-- Composition by continuous linear equivs on the right respects higher differentiability at a
 point in a domain. -/
-lemma continuous_linear_equiv.cont_diff_within_at_comp_iff {n : with_top ℕ} (e : G ≃L[𝕜] E) :
+lemma continuous_linear_equiv.cont_diff_within_at_comp_iff (e : G ≃L[𝕜] E) :
   cont_diff_within_at 𝕜 n (f ∘ e) (e ⁻¹' s) (e.symm x) ↔
   cont_diff_within_at 𝕜 n f s x :=
 begin
@@ -1838,7 +1838,7 @@ end
 
 /-- Composition by continuous linear equivs on the right respects higher differentiability on
 domains. -/
-lemma continuous_linear_equiv.cont_diff_on_comp_iff {n : with_top ℕ} (e : G ≃L[𝕜] E) :
+lemma continuous_linear_equiv.cont_diff_on_comp_iff (e : G ≃L[𝕜] E) :
   cont_diff_on 𝕜 n (f ∘ e) (e ⁻¹' s) ↔ cont_diff_on 𝕜 n f s :=
 begin
   refine ⟨λ H, _, λ H, H.comp_continuous_linear_map (e : G →L[𝕜] E)⟩,
@@ -1852,7 +1852,7 @@ end
 
 /-- If two functions `f` and `g` admit Taylor series `p` and `q` in a set `s`, then the cartesian
 product of `f` and `g` admits the cartesian product of `p` and `q` as a Taylor series. -/
-lemma has_ftaylor_series_up_to_on.prod {n : with_top ℕ} (hf : has_ftaylor_series_up_to_on n f p s)
+lemma has_ftaylor_series_up_to_on.prod (hf : has_ftaylor_series_up_to_on n f p s)
   {g : E → G} {q : E → formal_multilinear_series 𝕜 E G} (hg : has_ftaylor_series_up_to_on n g q s) :
   has_ftaylor_series_up_to_on n (λ y, (f y, g y)) (λ y k, (p y k).prod (q y k)) s :=
 begin
@@ -1867,7 +1867,7 @@ begin
 end
 
 /-- The cartesian product of `C^n` functions at a point in a domain is `C^n`. -/
-lemma cont_diff_within_at.prod {n : with_top ℕ} {s : set E} {f : E → F} {g : E → G}
+lemma cont_diff_within_at.prod {s : set E} {f : E → F} {g : E → G}
   (hf : cont_diff_within_at 𝕜 n f s x) (hg : cont_diff_within_at 𝕜 n g s x) :
   cont_diff_within_at 𝕜 n (λx:E, (f x, g x)) s x :=
 begin
@@ -1879,13 +1879,13 @@ begin
 end
 
 /-- The cartesian product of `C^n` functions on domains is `C^n`. -/
-lemma cont_diff_on.prod {n : with_top ℕ} {s : set E} {f : E → F} {g : E → G}
+lemma cont_diff_on.prod {s : set E} {f : E → F} {g : E → G}
   (hf : cont_diff_on 𝕜 n f s) (hg : cont_diff_on 𝕜 n g s) :
   cont_diff_on 𝕜 n (λx:E, (f x, g x)) s :=
 λ x hx, (hf x hx).prod (hg x hx)
 
 /-- The cartesian product of `C^n` functions at a point is `C^n`. -/
-lemma cont_diff_at.prod {n : with_top ℕ} {f : E → F} {g : E → G}
+lemma cont_diff_at.prod {f : E → F} {g : E → G}
   (hf : cont_diff_at 𝕜 n f x) (hg : cont_diff_at 𝕜 n g x) :
   cont_diff_at 𝕜 n (λx:E, (f x, g x)) x :=
 cont_diff_within_at_univ.1 $ cont_diff_within_at.prod
@@ -1895,7 +1895,7 @@ cont_diff_within_at_univ.1 $ cont_diff_within_at.prod
 /--
 The cartesian product of `C^n` functions is `C^n`.
 -/
-lemma cont_diff.prod {n : with_top ℕ} {f : E → F} {g : E → G}
+lemma cont_diff.prod {f : E → F} {g : E → G}
   (hf : cont_diff 𝕜 n f) (hg : cont_diff 𝕜 n g) :
   cont_diff 𝕜 n (λx:E, (f x, g x)) :=
 cont_diff_on_univ.1 $ cont_diff_on.prod (cont_diff_on_univ.2 hf)
@@ -1911,7 +1911,7 @@ variables {ι : Type*} [fintype ι] {F' : ι → Type*} [Π i, normed_group (F' 
   [Π i, normed_space 𝕜 (F' i)] {φ : Π i, E → F' i}
   {p' : Π i, E → formal_multilinear_series 𝕜 E (F' i)}
   {Φ : E → Π i, F' i} {P' : E → formal_multilinear_series 𝕜 E (Π i, F' i)}
-  {n : with_top ℕ}
+
 
 lemma has_ftaylor_series_up_to_on_pi :
   has_ftaylor_series_up_to_on n (λ x i, φ i x)
@@ -2003,7 +2003,7 @@ private lemma cont_diff_on.comp_same_univ
   {Eu : Type u} [normed_group Eu] [normed_space 𝕜 Eu]
   {Fu : Type u} [normed_group Fu] [normed_space 𝕜 Fu]
   {Gu : Type u} [normed_group Gu] [normed_space 𝕜 Gu]
-  {n : with_top ℕ} {s : set Eu} {t : set Fu} {g : Fu → Gu} {f : Eu → Fu}
+  {s : set Eu} {t : set Fu} {g : Fu → Gu} {f : Eu → Fu}
   (hg : cont_diff_on 𝕜 n g t) (hf : cont_diff_on 𝕜 n f s) (st : s ⊆ f ⁻¹' t) :
   cont_diff_on 𝕜 n (g ∘ f) s :=
 begin
@@ -2051,7 +2051,7 @@ end
 
 /-- The composition of `C^n` functions on domains is `C^n`. -/
 lemma cont_diff_on.comp
-  {n : with_top ℕ} {s : set E} {t : set F} {g : F → G} {f : E → F}
+  {s : set E} {t : set F} {g : F → G} {f : E → F}
   (hg : cont_diff_on 𝕜 n g t) (hf : cont_diff_on 𝕜 n f s) (st : s ⊆ f ⁻¹' t) :
   cont_diff_on 𝕜 n (g ∘ f) s :=
 begin
@@ -2094,19 +2094,19 @@ end
 
 /-- The composition of `C^n` functions on domains is `C^n`. -/
 lemma cont_diff_on.comp'
-  {n : with_top ℕ} {s : set E} {t : set F} {g : F → G} {f : E → F}
+  {s : set E} {t : set F} {g : F → G} {f : E → F}
   (hg : cont_diff_on 𝕜 n g t) (hf : cont_diff_on 𝕜 n f s) :
   cont_diff_on 𝕜 n (g ∘ f) (s ∩ f⁻¹' t) :=
 hg.comp (hf.mono (inter_subset_left _ _)) (inter_subset_right _ _)
 
 /-- The composition of a `C^n` function on a domain with a `C^n` function is `C^n`. -/
-lemma cont_diff.comp_cont_diff_on {n : with_top ℕ} {s : set E} {g : F → G} {f : E → F}
+lemma cont_diff.comp_cont_diff_on {s : set E} {g : F → G} {f : E → F}
   (hg : cont_diff 𝕜 n g) (hf : cont_diff_on 𝕜 n f s) :
   cont_diff_on 𝕜 n (g ∘ f) s :=
 (cont_diff_on_univ.2 hg).comp hf subset_preimage_univ
 
 /-- The composition of `C^n` functions is `C^n`. -/
-lemma cont_diff.comp {n : with_top ℕ} {g : F → G} {f : E → F}
+lemma cont_diff.comp {g : F → G} {f : E → F}
   (hg : cont_diff 𝕜 n g) (hf : cont_diff 𝕜 n f) :
   cont_diff 𝕜 n (g ∘ f) :=
 cont_diff_on_univ.1 $ cont_diff_on.comp (cont_diff_on_univ.2 hg)
@@ -2114,7 +2114,7 @@ cont_diff_on_univ.1 $ cont_diff_on.comp (cont_diff_on_univ.2 hg)
 
 /-- The composition of `C^n` functions at points in domains is `C^n`. -/
 lemma cont_diff_within_at.comp
-  {n : with_top ℕ} {s : set E} {t : set F} {g : F → G} {f : E → F} (x : E)
+  {s : set E} {t : set F} {g : F → G} {f : E → F} (x : E)
   (hg : cont_diff_within_at 𝕜 n g t (f x))
   (hf : cont_diff_within_at 𝕜 n f s x) (st : s ⊆ f ⁻¹' t) :
   cont_diff_within_at 𝕜 n (g ∘ f) s x :=
@@ -2143,7 +2143,7 @@ begin
 end
 
 /-- The composition of `C^n` functions at points in domains is `C^n`. -/
-lemma cont_diff_within_at.comp' {n : with_top ℕ} {s : set E} {t : set F} {g : F → G}
+lemma cont_diff_within_at.comp' {s : set E} {t : set F} {g : F → G}
   {f : E → F} (x : E)
   (hg : cont_diff_within_at 𝕜 n g t (f x)) (hf : cont_diff_within_at 𝕜 n f s x) :
   cont_diff_within_at 𝕜 n (g ∘ f) (s ∩ f⁻¹' t) x :=
@@ -2155,14 +2155,14 @@ lemma cont_diff_at.comp_cont_diff_within_at {n} (x : E)
 hg.comp x hf (maps_to_univ _ _)
 
 /-- The composition of `C^n` functions at points is `C^n`. -/
-lemma cont_diff_at.comp {n : with_top ℕ} (x : E)
+lemma cont_diff_at.comp (x : E)
   (hg : cont_diff_at 𝕜 n g (f x))
   (hf : cont_diff_at 𝕜 n f x) :
   cont_diff_at 𝕜 n (g ∘ f) x :=
 hg.comp x hf subset_preimage_univ
 
 lemma cont_diff.comp_cont_diff_within_at
-  {n : with_top ℕ} {g : F → G} {f : E → F} (h : cont_diff 𝕜 n g)
+  {g : F → G} {f : E → F} (h : cont_diff 𝕜 n g)
   (hf : cont_diff_within_at 𝕜 n f t x) :
   cont_diff_within_at 𝕜 n (g ∘ f) t x :=
 begin
@@ -2172,7 +2172,7 @@ begin
 end
 
 lemma cont_diff.comp_cont_diff_at
-  {n : with_top ℕ} {g : F → G} {f : E → F} (x : E)
+  {g : F → G} {f : E → F} (x : E)
   (hg : cont_diff 𝕜 n g)
   (hf : cont_diff_at 𝕜 n f x) :
   cont_diff_at 𝕜 n (g ∘ f) x :=
@@ -2213,31 +2213,31 @@ end
 /-! ### Sum of two functions -/
 
 /- The sum is smooth. -/
-lemma cont_diff_add {n : with_top ℕ} :
+lemma cont_diff_add :
   cont_diff 𝕜 n (λp : F × F, p.1 + p.2) :=
 (is_bounded_linear_map.fst.add is_bounded_linear_map.snd).cont_diff
 
 /-- The sum of two `C^n` functions within a set at a point is `C^n` within this set
 at this point. -/
-lemma cont_diff_within_at.add {n : with_top ℕ} {s : set E} {f g : E → F}
+lemma cont_diff_within_at.add {s : set E} {f g : E → F}
   (hf : cont_diff_within_at 𝕜 n f s x) (hg : cont_diff_within_at 𝕜 n g s x) :
   cont_diff_within_at 𝕜 n (λx, f x + g x) s x :=
 cont_diff_add.cont_diff_within_at.comp x (hf.prod hg) subset_preimage_univ
 
 /-- The sum of two `C^n` functions at a point is `C^n` at this point. -/
-lemma cont_diff_at.add {n : with_top ℕ} {f g : E → F}
+lemma cont_diff_at.add {f g : E → F}
   (hf : cont_diff_at 𝕜 n f x) (hg : cont_diff_at 𝕜 n g x) :
   cont_diff_at 𝕜 n (λx, f x + g x) x :=
 by rw [← cont_diff_within_at_univ] at *; exact hf.add hg
 
 /-- The sum of two `C^n`functions is `C^n`. -/
-lemma cont_diff.add {n : with_top ℕ} {f g : E → F}
+lemma cont_diff.add {f g : E → F}
   (hf : cont_diff 𝕜 n f) (hg : cont_diff 𝕜 n g) :
   cont_diff 𝕜 n (λx, f x + g x) :=
 cont_diff_add.comp (hf.prod hg)
 
 /-- The sum of two `C^n` functions on a domain is `C^n`. -/
-lemma cont_diff_on.add {n : with_top ℕ} {s : set E} {f g : E → F}
+lemma cont_diff_on.add {s : set E} {f g : E → F}
   (hf : cont_diff_on 𝕜 n f s) (hg : cont_diff_on 𝕜 n g s) :
   cont_diff_on 𝕜 n (λx, f x + g x) s :=
 λ x hx, (hf x hx).add (hg x hx)
@@ -2245,28 +2245,28 @@ lemma cont_diff_on.add {n : with_top ℕ} {s : set E} {f g : E → F}
 /-! ### Negative -/
 
 /- The negative is smooth. -/
-lemma cont_diff_neg {n : with_top ℕ} :
+lemma cont_diff_neg :
   cont_diff 𝕜 n (λp : F, -p) :=
 is_bounded_linear_map.id.neg.cont_diff
 
 /-- The negative of a `C^n` function within a domain at a point is `C^n` within this domain at
 this point. -/
-lemma cont_diff_within_at.neg {n : with_top ℕ} {s : set E} {f : E → F}
+lemma cont_diff_within_at.neg {s : set E} {f : E → F}
   (hf : cont_diff_within_at 𝕜 n f s x) : cont_diff_within_at 𝕜 n (λx, -f x) s x :=
 cont_diff_neg.cont_diff_within_at.comp x hf subset_preimage_univ
 
 /-- The negative of a `C^n` function at a point is `C^n` at this point. -/
-lemma cont_diff_at.neg {n : with_top ℕ} {f : E → F}
+lemma cont_diff_at.neg {f : E → F}
   (hf : cont_diff_at 𝕜 n f x) : cont_diff_at 𝕜 n (λx, -f x) x :=
 by rw ← cont_diff_within_at_univ at *; exact hf.neg
 
 /-- The negative of a `C^n`function is `C^n`. -/
-lemma cont_diff.neg {n : with_top ℕ} {f : E → F} (hf : cont_diff 𝕜 n f) :
+lemma cont_diff.neg {f : E → F} (hf : cont_diff 𝕜 n f) :
   cont_diff 𝕜 n (λx, -f x) :=
 cont_diff_neg.comp hf
 
 /-- The negative of a `C^n` function on a domain is `C^n`. -/
-lemma cont_diff_on.neg {n : with_top ℕ} {s : set E} {f : E → F}
+lemma cont_diff_on.neg {s : set E} {f : E → F}
   (hf : cont_diff_on 𝕜 n f s) : cont_diff_on 𝕜 n (λx, -f x) s :=
 λ x hx, (hf x hx).neg
 
@@ -2274,32 +2274,32 @@ lemma cont_diff_on.neg {n : with_top ℕ} {s : set E} {f : E → F}
 
 /-- The difference of two `C^n` functions within a set at a point is `C^n` within this set
 at this point. -/
-lemma cont_diff_within_at.sub {n : with_top ℕ} {s : set E} {f g : E → F}
+lemma cont_diff_within_at.sub {s : set E} {f g : E → F}
   (hf : cont_diff_within_at 𝕜 n f s x) (hg : cont_diff_within_at 𝕜 n g s x) :
   cont_diff_within_at 𝕜 n (λx, f x - g x) s x :=
 by simpa only [sub_eq_add_neg] using hf.add hg.neg
 
 /-- The difference of two `C^n` functions at a point is `C^n` at this point. -/
-lemma cont_diff_at.sub {n : with_top ℕ} {f g : E → F}
+lemma cont_diff_at.sub {f g : E → F}
   (hf : cont_diff_at 𝕜 n f x) (hg : cont_diff_at 𝕜 n g x) :
   cont_diff_at 𝕜 n (λx, f x - g x) x :=
 by simpa only [sub_eq_add_neg] using hf.add hg.neg
 
 /-- The difference of two `C^n` functions on a domain is `C^n`. -/
-lemma cont_diff_on.sub {n : with_top ℕ} {s : set E} {f g : E → F}
+lemma cont_diff_on.sub {s : set E} {f g : E → F}
   (hf : cont_diff_on 𝕜 n f s) (hg : cont_diff_on 𝕜 n g s) :
   cont_diff_on 𝕜 n (λx, f x - g x) s :=
 by simpa only [sub_eq_add_neg] using hf.add hg.neg
 
 /-- The difference of two `C^n` functions is `C^n`. -/
-lemma cont_diff.sub {n : with_top ℕ} {f g : E → F}
+lemma cont_diff.sub {f g : E → F}
   (hf : cont_diff 𝕜 n f) (hg : cont_diff 𝕜 n g) : cont_diff 𝕜 n (λx, f x - g x) :=
 by simpa only [sub_eq_add_neg] using hf.add hg.neg
 
 /-! ### Sum of finitely many functions -/
 
 lemma cont_diff_within_at.sum
-  {ι : Type*} {f : ι → E → F} {s : finset ι} {n : with_top ℕ} {t : set E} {x : E}
+  {ι : Type*} {f : ι → E → F} {s : finset ι} {t : set E} {x : E}
   (h : ∀ i ∈ s, cont_diff_within_at 𝕜 n (λ x, f i x) t x) :
   cont_diff_within_at 𝕜 n (λ x, (∑ i in s, f i x)) t x :=
 begin
@@ -2311,19 +2311,19 @@ begin
 end
 
 lemma cont_diff_at.sum
-  {ι : Type*} {f : ι → E → F} {s : finset ι} {n : with_top ℕ} {x : E}
+  {ι : Type*} {f : ι → E → F} {s : finset ι} {x : E}
   (h : ∀ i ∈ s, cont_diff_at 𝕜 n (λ x, f i x) x) :
   cont_diff_at 𝕜 n (λ x, (∑ i in s, f i x)) x :=
 by rw [← cont_diff_within_at_univ] at *; exact cont_diff_within_at.sum h
 
 lemma cont_diff_on.sum
-  {ι : Type*} {f : ι → E → F} {s : finset ι} {n : with_top ℕ} {t : set E}
+  {ι : Type*} {f : ι → E → F} {s : finset ι} {t : set E}
   (h : ∀ i ∈ s, cont_diff_on 𝕜 n (λ x, f i x) t) :
   cont_diff_on 𝕜 n (λ x, (∑ i in s, f i x)) t :=
 λ x hx, cont_diff_within_at.sum (λ i hi, h i hi x hx)
 
 lemma cont_diff.sum
-  {ι : Type*} {f : ι → E → F} {s : finset ι} {n : with_top ℕ}
+  {ι : Type*} {f : ι → E → F} {s : finset ι}
   (h : ∀ i ∈ s, cont_diff 𝕜 n (λ x, f i x)) :
   cont_diff 𝕜 n (λ x, (∑ i in s, f i x)) :=
 by simp [← cont_diff_on_univ] at *; exact cont_diff_on.sum h
@@ -2331,31 +2331,31 @@ by simp [← cont_diff_on_univ] at *; exact cont_diff_on.sum h
 /-! ### Product of two functions -/
 
 /- The product is smooth. -/
-lemma cont_diff_mul {n : with_top ℕ} :
+lemma cont_diff_mul :
   cont_diff 𝕜 n (λ p : 𝕜 × 𝕜, p.1 * p.2) :=
 is_bounded_bilinear_map_mul.cont_diff
 
 /-- The product of two `C^n` functions within a set at a point is `C^n` within this set
 at this point. -/
-lemma cont_diff_within_at.mul {n : with_top ℕ} {s : set E} {f g : E → 𝕜}
+lemma cont_diff_within_at.mul {s : set E} {f g : E → 𝕜}
   (hf : cont_diff_within_at 𝕜 n f s x) (hg : cont_diff_within_at 𝕜 n g s x) :
   cont_diff_within_at 𝕜 n (λ x, f x * g x) s x :=
 cont_diff_mul.cont_diff_within_at.comp x (hf.prod hg) subset_preimage_univ
 
 /-- The product of two `C^n` functions at a point is `C^n` at this point. -/
-lemma cont_diff_at.mul {n : with_top ℕ} {f g : E → 𝕜}
+lemma cont_diff_at.mul {f g : E → 𝕜}
   (hf : cont_diff_at 𝕜 n f x) (hg : cont_diff_at 𝕜 n g x) :
   cont_diff_at 𝕜 n (λ x, f x * g x) x :=
 by rw [← cont_diff_within_at_univ] at *; exact hf.mul hg
 
 /-- The product of two `C^n` functions on a domain is `C^n`. -/
-lemma cont_diff_on.mul {n : with_top ℕ} {s : set E} {f g : E → 𝕜}
+lemma cont_diff_on.mul {s : set E} {f g : E → 𝕜}
   (hf : cont_diff_on 𝕜 n f s) (hg : cont_diff_on 𝕜 n g s) :
   cont_diff_on 𝕜 n (λ x, f x * g x) s :=
 λ x hx, (hf x hx).mul (hg x hx)
 
 /-- The product of two `C^n`functions is `C^n`. -/
-lemma cont_diff.mul {n : with_top ℕ} {f g : E → 𝕜}
+lemma cont_diff.mul {f g : E → 𝕜}
   (hf : cont_diff 𝕜 n f) (hg : cont_diff 𝕜 n g) :
   cont_diff 𝕜 n (λ x, f x * g x) :=
 cont_diff_mul.comp (hf.prod hg)
@@ -2377,22 +2377,22 @@ lemma cont_diff.div_const {f : E → 𝕜} {n} {c : 𝕜} (hf : cont_diff 𝕜 n
   cont_diff 𝕜 n (λ x, f x / c) :=
 by simpa only [div_eq_mul_inv] using hf.mul cont_diff_const
 
-lemma cont_diff.pow {n : with_top ℕ} {f : E → 𝕜}
+lemma cont_diff.pow {f : E → 𝕜}
   (hf : cont_diff 𝕜 n f) :
   ∀ m : ℕ, cont_diff 𝕜 n (λ x, (f x) ^ m)
 | 0       := by simpa using cont_diff_const
 | (m + 1) := by simpa [pow_succ] using hf.mul (cont_diff.pow m)
 
-lemma cont_diff_at.pow {n : with_top ℕ} {f : E → 𝕜} (hf : cont_diff_at 𝕜 n f x)
+lemma cont_diff_at.pow {f : E → 𝕜} (hf : cont_diff_at 𝕜 n f x)
   (m : ℕ) : cont_diff_at 𝕜 n (λ y, f y ^ m) x :=
 (cont_diff_id.pow m).cont_diff_at.comp x hf
 
-lemma cont_diff_within_at.pow {n : with_top ℕ} {f : E → 𝕜}
+lemma cont_diff_within_at.pow {f : E → 𝕜}
   (hf : cont_diff_within_at 𝕜 n f s x) (m : ℕ) :
   cont_diff_within_at 𝕜 n (λ y, f y ^ m) s x :=
 (cont_diff_id.pow m).cont_diff_at.comp_cont_diff_within_at x hf
 
-lemma cont_diff_on.pow {n : with_top ℕ} {f : E → 𝕜}
+lemma cont_diff_on.pow {f : E → 𝕜}
   (hf : cont_diff_on 𝕜 n f s) (m : ℕ) :
   cont_diff_on 𝕜 n (λ y, f y ^ m) s :=
 λ y hy, (hf y hy).pow m
@@ -2400,31 +2400,31 @@ lemma cont_diff_on.pow {n : with_top ℕ} {f : E → 𝕜}
 /-! ### Scalar multiplication -/
 
 /- The scalar multiplication is smooth. -/
-lemma cont_diff_smul {n : with_top ℕ} :
+lemma cont_diff_smul :
   cont_diff 𝕜 n (λ p : 𝕜 × F, p.1 • p.2) :=
 is_bounded_bilinear_map_smul.cont_diff
 
 /-- The scalar multiplication of two `C^n` functions within a set at a point is `C^n` within this
 set at this point. -/
-lemma cont_diff_within_at.smul {n : with_top ℕ} {s : set E} {f : E → 𝕜} {g : E → F}
+lemma cont_diff_within_at.smul {s : set E} {f : E → 𝕜} {g : E → F}
   (hf : cont_diff_within_at 𝕜 n f s x) (hg : cont_diff_within_at 𝕜 n g s x) :
   cont_diff_within_at 𝕜 n (λ x, f x • g x) s x :=
 cont_diff_smul.cont_diff_within_at.comp x (hf.prod hg) subset_preimage_univ
 
 /-- The scalar multiplication of two `C^n` functions at a point is `C^n` at this point. -/
-lemma cont_diff_at.smul {n : with_top ℕ} {f : E → 𝕜} {g : E → F}
+lemma cont_diff_at.smul {f : E → 𝕜} {g : E → F}
   (hf : cont_diff_at 𝕜 n f x) (hg : cont_diff_at 𝕜 n g x) :
   cont_diff_at 𝕜 n (λ x, f x • g x) x :=
 by rw [← cont_diff_within_at_univ] at *; exact hf.smul hg
 
 /-- The scalar multiplication of two `C^n` functions is `C^n`. -/
-lemma cont_diff.smul {n : with_top ℕ} {f : E → 𝕜} {g : E → F}
+lemma cont_diff.smul {f : E → 𝕜} {g : E → F}
   (hf : cont_diff 𝕜 n f) (hg : cont_diff 𝕜 n g) :
   cont_diff 𝕜 n (λ x, f x • g x) :=
 cont_diff_smul.comp (hf.prod hg)
 
 /-- The scalar multiplication of two `C^n` functions on a domain is `C^n`. -/
-lemma cont_diff_on.smul {n : with_top ℕ} {s : set E} {f : E → 𝕜} {g : E → F}
+lemma cont_diff_on.smul {s : set E} {f : E → 𝕜} {g : E → F}
   (hf : cont_diff_on 𝕜 n f s) (hg : cont_diff_on 𝕜 n g s) :
   cont_diff_on 𝕜 n (λ x, f x • g x) s :=
 λ x hx, (hf x hx).smul (hg x hx)
@@ -2434,7 +2434,7 @@ lemma cont_diff_on.smul {n : with_top ℕ} {s : set E} {f : E → 𝕜} {g : E �
 section prod_map
 variables {E' : Type*} [normed_group E'] [normed_space 𝕜 E']
 {F' : Type*} [normed_group F'] [normed_space 𝕜 F']
-{n : with_top ℕ}
+
 
 /-- The product map of two `C^n` functions within a set at a point is `C^n`
 within the product set at the product point. -/
@@ -2454,7 +2454,7 @@ cont_diff_within_at.prod_map' hf hg
 /-- The product map of two `C^n` functions on a set is `C^n` on the product set. -/
 lemma cont_diff_on.prod_map {E' : Type*} [normed_group E'] [normed_space 𝕜 E']
   {F' : Type*} [normed_group F'] [normed_space 𝕜 F']
-  {s : set E} {t : set E'} {n : with_top ℕ} {f : E → F} {g : E' → F'}
+  {s : set E} {t : set E'} {f : E → F} {g : E' → F'}
   (hf : cont_diff_on 𝕜 n f s) (hg : cont_diff_on 𝕜 n g t) :
   cont_diff_on 𝕜 n (prod.map f g) (s ×ˢ t) :=
 (hf.comp cont_diff_on_fst (prod_subset_preimage_fst _ _)).prod
@@ -2502,7 +2502,7 @@ open normed_ring continuous_linear_map ring
 /-- In a complete normed algebra, the operation of inversion is `C^n`, for all `n`, at each
 invertible element.  The proof is by induction, bootstrapping using an identity expressing the
 derivative of inversion as a bilinear map of inversion itself. -/
-lemma cont_diff_at_ring_inverse [complete_space R] {n : with_top ℕ} (x : Rˣ) :
+lemma cont_diff_at_ring_inverse [complete_space R] (x : Rˣ) :
   cont_diff_at 𝕜 n ring.inverse (x : R) :=
 begin
   induction n using with_top.nat_induction with n IH Itop,
@@ -2596,7 +2596,7 @@ open continuous_linear_map
 
 /-- At a continuous linear equivalence `e : E ≃L[𝕜] F` between Banach spaces, the operation of
 inversion is `C^n`, for all `n`. -/
-lemma cont_diff_at_map_inverse [complete_space E] {n : with_top ℕ} (e : E ≃L[𝕜] F) :
+lemma cont_diff_at_map_inverse [complete_space E] (e : E ≃L[𝕜] F) :
   cont_diff_at 𝕜 n inverse (e : E →L[𝕜] F) :=
 begin
   nontriviality E,
@@ -2632,7 +2632,7 @@ then `f.symm` is `n` times continuously differentiable at the point `a`.
 
 This is one of the easy parts of the inverse function theorem: it assumes that we already have
 an inverse function. -/
-theorem local_homeomorph.cont_diff_at_symm [complete_space E] {n : with_top ℕ}
+theorem local_homeomorph.cont_diff_at_symm [complete_space E]
   (f : local_homeomorph E F) {f₀' : E ≃L[𝕜] F} {a : F} (ha : a ∈ f.target)
   (hf₀' : has_fderiv_at f (f₀' : E →L[𝕜] F) (f.symm a)) (hf : cont_diff_at 𝕜 n f (f.symm a)) :
   cont_diff_at 𝕜 n f.symm a :=
@@ -2687,7 +2687,7 @@ target. if `f` is `n` times continuously differentiable at `f.symm a`, and if th
 
 This is one of the easy parts of the inverse function theorem: it assumes that we already have
 an inverse function. -/
-theorem local_homeomorph.cont_diff_at_symm_deriv [complete_space 𝕜] {n : with_top ℕ}
+theorem local_homeomorph.cont_diff_at_symm_deriv [complete_space 𝕜]
   (f : local_homeomorph 𝕜 𝕜) {f₀' a : 𝕜} (h₀ : f₀' ≠ 0) (ha : a ∈ f.target)
   (hf₀' : has_deriv_at f f₀' (f.symm a)) (hf : cont_diff_at 𝕜 n f (f.symm a)) :
   cont_diff_at 𝕜 n f.symm a :=
@@ -2710,7 +2710,7 @@ variables
 /-- If a function has a Taylor series at order at least 1, then at points in the interior of the
     domain of definition, the term of order 1 of this series is a strict derivative of `f`. -/
 lemma has_ftaylor_series_up_to_on.has_strict_fderiv_at
-  {s : set E'} {f : E' → F'} {x : E'} {p : E' → formal_multilinear_series 𝕂 E' F'} {n : with_top ℕ}
+  {s : set E'} {f : E' → F'} {x : E'} {p : E' → formal_multilinear_series 𝕂 E' F'}
   (hf : has_ftaylor_series_up_to_on n f p s) (hn : 1 ≤ n) (hs : s ∈ 𝓝 x) :
   has_strict_fderiv_at f ((continuous_multilinear_curry_fin1 𝕂 E' F') (p x 1)) x :=
 has_strict_fderiv_at_of_has_fderiv_at_of_continuous_at (hf.eventually_has_fderiv_at hn hs) $
@@ -2721,7 +2721,7 @@ has_strict_fderiv_at_of_has_fderiv_at_of_continuous_at (hf.eventually_has_fderiv
 us as `f'`, then `f'` is also a strict derivative. -/
 lemma cont_diff_at.has_strict_fderiv_at'
   {f : E' → F'} {f' : E' →L[𝕂] F'} {x : E'}
-  {n : with_top ℕ} (hf : cont_diff_at 𝕂 n f x) (hf' : has_fderiv_at f f' x) (hn : 1 ≤ n) :
+  (hf : cont_diff_at 𝕂 n f x) (hf' : has_fderiv_at f f' x) (hn : 1 ≤ n) :
   has_strict_fderiv_at f f' x :=
 begin
   rcases hf 1 hn with ⟨u, H, p, hp⟩,
@@ -2733,33 +2733,33 @@ end
 /-- If a function is `C^n` with `1 ≤ n` around a point, and its derivative at that point is given to
 us as `f'`, then `f'` is also a strict derivative. -/
 lemma cont_diff_at.has_strict_deriv_at' {f : 𝕂 → F'} {f' : F'} {x : 𝕂}
-  {n : with_top ℕ} (hf : cont_diff_at 𝕂 n f x) (hf' : has_deriv_at f f' x) (hn : 1 ≤ n) :
+  (hf : cont_diff_at 𝕂 n f x) (hf' : has_deriv_at f f' x) (hn : 1 ≤ n) :
   has_strict_deriv_at f f' x :=
 hf.has_strict_fderiv_at' hf' hn
 
 /-- If a function is `C^n` with `1 ≤ n` around a point, then the derivative of `f` at this point
 is also a strict derivative. -/
-lemma cont_diff_at.has_strict_fderiv_at {f : E' → F'} {x : E'} {n : with_top ℕ}
+lemma cont_diff_at.has_strict_fderiv_at {f : E' → F'} {x : E'}
   (hf : cont_diff_at 𝕂 n f x) (hn : 1 ≤ n) :
   has_strict_fderiv_at f (fderiv 𝕂 f x) x :=
 hf.has_strict_fderiv_at' (hf.differentiable_at hn).has_fderiv_at hn
 
 /-- If a function is `C^n` with `1 ≤ n` around a point, then the derivative of `f` at this point
 is also a strict derivative. -/
-lemma cont_diff_at.has_strict_deriv_at {f : 𝕂 → F'} {x : 𝕂} {n : with_top ℕ}
+lemma cont_diff_at.has_strict_deriv_at {f : 𝕂 → F'} {x : 𝕂}
   (hf : cont_diff_at 𝕂 n f x) (hn : 1 ≤ n) :
   has_strict_deriv_at f (deriv f x) x :=
 (hf.has_strict_fderiv_at hn).has_strict_deriv_at
 
 /-- If a function is `C^n` with `1 ≤ n`, then the derivative of `f` is also a strict derivative. -/
 lemma cont_diff.has_strict_fderiv_at
-  {f : E' → F'} {x : E'} {n : with_top ℕ} (hf : cont_diff 𝕂 n f) (hn : 1 ≤ n) :
+  {f : E' → F'} {x : E'} (hf : cont_diff 𝕂 n f) (hn : 1 ≤ n) :
   has_strict_fderiv_at f (fderiv 𝕂 f x) x :=
 hf.cont_diff_at.has_strict_fderiv_at hn
 
 /-- If a function is `C^n` with `1 ≤ n`, then the derivative of `f` is also a strict derivative. -/
 lemma cont_diff.has_strict_deriv_at
-  {f : 𝕂 → F'} {x : 𝕂} {n : with_top ℕ} (hf : cont_diff 𝕂 n f) (hn : 1 ≤ n) :
+  {f : 𝕂 → F'} {x : 𝕂} (hf : cont_diff 𝕂 n f) (hn : 1 ≤ n) :
   has_strict_deriv_at f (deriv f x) x :=
 hf.cont_diff_at.has_strict_deriv_at hn
 
@@ -2925,12 +2925,12 @@ lemma cont_diff_on.deriv_of_open {m n : with_top ℕ}
   cont_diff_on 𝕜 m (deriv f₂) s₂ :=
 (hf.deriv_within hs.unique_diff_on hmn).congr (λ x hx, (deriv_within_of_open hs hx).symm)
 
-lemma cont_diff_on.continuous_on_deriv_within {n : with_top ℕ}
+lemma cont_diff_on.continuous_on_deriv_within
   (h : cont_diff_on 𝕜 n f₂ s₂) (hs : unique_diff_on 𝕜 s₂) (hn : 1 ≤ n) :
   continuous_on (deriv_within f₂ s₂) s₂ :=
 ((cont_diff_on_succ_iff_deriv_within hs).1 (h.of_le hn)).2.continuous_on
 
-lemma cont_diff_on.continuous_on_deriv_of_open {n : with_top ℕ}
+lemma cont_diff_on.continuous_on_deriv_of_open
   (h : cont_diff_on 𝕜 n f₂ s₂) (hs : is_open s₂) (hn : 1 ≤ n) :
   continuous_on (deriv f₂) s₂ :=
 ((cont_diff_on_succ_iff_deriv_of_open hs).1 (h.of_le hn)).2.continuous_on
@@ -2958,7 +2958,7 @@ begin
   rw cont_diff_on_top_iff_deriv_within unique_diff_on_univ,
 end
 
-lemma cont_diff.continuous_deriv {n : with_top ℕ} (h : cont_diff 𝕜 n f₂) (hn : 1 ≤ n) :
+lemma cont_diff.continuous_deriv (h : cont_diff 𝕜 n f₂) (hn : 1 ≤ n) :
   continuous (deriv f₂) :=
 (cont_diff_succ_iff_deriv.mp (h.of_le hn)).2.continuous
 
@@ -2977,7 +2977,7 @@ over `𝕜`.
 variables (𝕜) {𝕜' : Type*} [nondiscrete_normed_field 𝕜'] [normed_algebra 𝕜 𝕜']
 variables [normed_space 𝕜' E] [is_scalar_tower 𝕜 𝕜' E]
 variables [normed_space 𝕜' F] [is_scalar_tower 𝕜 𝕜' F]
-variables {p' : E → formal_multilinear_series 𝕜' E F} {n : with_top ℕ}
+variables {p' : E → formal_multilinear_series 𝕜' E F}
 
 lemma has_ftaylor_series_up_to_on.restrict_scalars
   (h : has_ftaylor_series_up_to_on n f p' s) :


### PR DESCRIPTION
* There are no functional changes in this PR (except the order of implicit arguments in some lemmas)
* This PR tries to move `cont_diff.comp` above some other lemmas. In a follow-up PR I will use this to add lemmas like `cont_diff.fst` which requires `cont_diff.comp`, but after this PR we can add it near `cont_diff_fst`.
* We also add `{m n : with_top ℕ}` as variables, so that we don't have to repeat this in every lemma

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
