### PR TITLE
[Merged by Bors] - feat(topology/stone_cech): add stone_cech_hom_ext

### DIFF
--- a/src/topology/stone_cech.lean
+++ b/src/topology/stone_cech.lean
@@ -247,6 +247,7 @@ dense_range_pure.quotient
 section extension
 
 variables {γ : Type u} [topological_space γ] [t2_space γ] [compact_space γ]
+variables {γ' : Type u} [topological_space γ'] [t2_space γ']
 variables {f : α → γ} (hf : continuous f)
 
 local attribute [elab_with_expected_type] quotient.lift
@@ -262,7 +263,7 @@ ultrafilter_extend_extends f
 lemma continuous_stone_cech_extend : continuous (stone_cech_extend hf) :=
 continuous_quot_lift _ (continuous_ultrafilter_extend f)
 
-lemma stone_cech_hom_ext {g₁ g₂ : stone_cech α → γ}
+lemma stone_cech_hom_ext {g₁ g₂ : stone_cech α → γ'}
   (h₁ : continuous g₁) (h₂ : continuous g₂)
   (h : g₁ ∘ stone_cech_unit = g₂ ∘ stone_cech_unit) : g₁ = g₂ :=
 begin

--- a/src/topology/stone_cech.lean
+++ b/src/topology/stone_cech.lean
@@ -262,6 +262,21 @@ ultrafilter_extend_extends f
 lemma continuous_stone_cech_extend : continuous (stone_cech_extend hf) :=
 continuous_quot_lift _ (continuous_ultrafilter_extend f)
 
+lemma unique_stone_cech_extend {g: stone_cech α → γ} (hg: continuous g)
+(hfg: g ∘ stone_cech_unit = (stone_cech_extend hf) ∘ stone_cech_unit):
+g = stone_cech_extend hf :=
+begin
+  have h_eq_on: eq_on g (stone_cech_extend hf) (range stone_cech_unit) :=
+  begin
+    rw eq_on,
+    rintros _ ⟨a, ha⟩,
+    rw [← ha, ← function.comp_apply g stone_cech_unit a],
+    rw [← function.comp_apply (stone_cech_extend hf) stone_cech_unit a, hfg],
+  end,
+    exact continuous.ext_on dense_range_stone_cech_unit hg
+    (continuous_stone_cech_extend hf) h_eq_on,
+end
+
 end extension
 
 lemma convergent_eqv_pure {u : ultrafilter α} {x : α} (ux : ↑u ≤ 𝓝 x) : u ≈ pure x :=

--- a/src/topology/stone_cech.lean
+++ b/src/topology/stone_cech.lean
@@ -262,19 +262,13 @@ ultrafilter_extend_extends f
 lemma continuous_stone_cech_extend : continuous (stone_cech_extend hf) :=
 continuous_quot_lift _ (continuous_ultrafilter_extend f)
 
-lemma unique_stone_cech_extend {g: stone_cech α → γ} (hg: continuous g)
-(hfg: g ∘ stone_cech_unit = (stone_cech_extend hf) ∘ stone_cech_unit):
-g = stone_cech_extend hf :=
+lemma stone_cech_hom_ext {g₁ g₂ : stone_cech α → γ}
+  (h₁ : continuous g₁) (h₂ : continuous g₂)
+  (h : g₁ ∘ stone_cech_unit = g₂ ∘ stone_cech_unit) : g₁ = g₂ :=
 begin
-  have h_eq_on: eq_on g (stone_cech_extend hf) (range stone_cech_unit) :=
-  begin
-    rw eq_on,
-    rintros _ ⟨a, ha⟩,
-    rw [← ha, ← function.comp_apply g stone_cech_unit a],
-    rw [← function.comp_apply (stone_cech_extend hf) stone_cech_unit a, hfg],
-  end,
-    exact continuous.ext_on dense_range_stone_cech_unit hg
-    (continuous_stone_cech_extend hf) h_eq_on,
+  apply continuous.ext_on dense_range_stone_cech_unit h₁ h₂,
+  rintros x ⟨x, rfl⟩,
+  apply (congr_fun h x)
 end
 
 end extension


### PR DESCRIPTION
The universal property that characterises the Stone–Čech compactification of a topological space X is that any function from X to a compact Hausdorff space extends uniquely to a continuous function on βX. Existence is already provided by `unique_stone_cech_extend`, but it seems that the uniqueness lemma was intentionally omitted previously. Easy, but probably worth being explicit about.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
