### PR TITLE
[Merged by Bors] - chore(data/nat/factorization): golf `dvd_iff_prime_pow_dvd_dvd`

### DIFF
--- a/src/data/nat/factorization.lean
+++ b/src/data/nat/factorization.lean
@@ -293,17 +293,11 @@ end
 lemma dvd_iff_prime_pow_dvd_dvd (n d : ℕ) :
   d ∣ n ↔ ∀ p k : ℕ, prime p → p ^ k ∣ d → p ^ k ∣ n :=
 begin
-  by_cases hn : n = 0,
-  { simp [hn], },
-  by_cases hd : d = 0,
-  { simp only [hd, hn, zero_dvd_iff, dvd_zero, forall_true_left, false_iff,
-      not_forall, exists_prop, exists_and_distrib_left],
-    refine ⟨2, prime_two, n, λ h, _⟩,
-    have := le_of_dvd (nat.pos_of_ne_zero hn) h,
-    revert this,
-    change ¬ _,
-    rw [not_le],
-    exact lt_two_pow n, },
+  rcases eq_or_ne n 0 with rfl | hn, { simp },
+  rcases eq_or_ne d 0 with rfl | hd,
+  { simp only [zero_dvd_iff, hn, false_iff, not_forall],
+    refine ⟨2, n, prime_two, ⟨dvd_zero _, _⟩⟩,
+    apply mt (le_of_dvd hn.bot_lt) (not_le.mpr (lt_two_pow n)) },
   refine ⟨λ h p k _ hpkd, dvd_trans hpkd h, _⟩,
   rw [←factorization_le_iff_dvd hd hn, finsupp.le_def],
   intros h p,


### PR DESCRIPTION
Golfing the edge-case proof added in https://github.com/leanprover-community/mathlib/pull/13316

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
