### PR TITLE
[Merged by Bors] - feat(analysis/normed_space/exponential): add `pi.exp_apply`

### DIFF
--- a/src/analysis/normed_space/exponential.lean
+++ b/src/analysis/normed_space/exponential.lean
@@ -478,6 +478,32 @@ map_exp _ (ring_hom.fst 𝔸 𝔹) continuous_fst x
 @[simp] lemma prod.snd_exp [complete_space 𝔹] (x : 𝔸 × 𝔹) : (exp 𝕂 (𝔸 × 𝔹) x).snd = exp 𝕂 𝔹 x.snd :=
 map_exp _ (ring_hom.snd 𝔸 𝔹) continuous_snd x
 
+@[simp] lemma pi.exp_apply {ι : Type*} {𝔸 : ι → Type*} [fintype ι]
+  [Π i, normed_ring (𝔸 i)] [Π i, normed_algebra 𝕂 (𝔸 i)] [Π i, complete_space (𝔸 i)]
+  (x : Π i, 𝔸 i) (i : ι) :
+  exp 𝕂 (Π i, 𝔸 i) x i = exp 𝕂 (𝔸 i) (x i) :=
+begin
+  -- Lean struggles to infer this instance due to it wanting `[Π i, semi_normed_ring (𝔸 i)]`
+  letI : normed_algebra 𝕂 (Π i, 𝔸 i) := pi.normed_algebra _,
+  exact map_exp _ (pi.eval_ring_hom 𝔸 i) (continuous_apply _) x
+end
+
+lemma pi.exp_def {ι : Type*} {𝔸 : ι → Type*} [fintype ι]
+  [Π i, normed_ring (𝔸 i)] [Π i, normed_algebra 𝕂 (𝔸 i)] [Π i, complete_space (𝔸 i)]
+  (x : Π i, 𝔸 i) :
+  exp 𝕂 (Π i, 𝔸 i) x = λ i, exp 𝕂 (𝔸 i) (x i) :=
+funext $ pi.exp_apply 𝕂 x
+
+lemma function.update_exp {ι : Type*} {𝔸 : ι → Type*} [fintype ι] [decidable_eq ι]
+  [Π i, normed_ring (𝔸 i)] [Π i, normed_algebra 𝕂 (𝔸 i)] [Π i, complete_space (𝔸 i)]
+  (x : Π i, 𝔸 i) (j : ι) (xj : 𝔸 j) :
+  function.update (exp 𝕂 (Π i, 𝔸 i) x) j (exp 𝕂 (𝔸 j) xj) = exp 𝕂 _ (function.update x j xj) :=
+begin
+  ext i,
+  simp_rw [pi.exp_def],
+  exact (function.apply_update (λ i, exp 𝕂 (𝔸 i)) x j xj i).symm,
+end
+
 end complete_algebra
 
 lemma algebra_map_exp_comm (x : 𝕂) :


### PR DESCRIPTION
The statement is a bit weird, but this structure is useful because it allows us to push `exp` through `matrix.diagonal` and into its elements.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
-->
- [x] depends on: #13402

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)

~~To avoid a typeclass / elaboration issue, this adds `pi.normed_algebra'` to deal with the usual problems with typeclass search on pi types.~~ After the typeclass weakening for `exp`, this was no longer necessary 🎉 !