### PR TITLE
feat(topology/stone_cech): stone_cech_extension_property

### DIFF
--- a/src/topology/stone_cech.lean
+++ b/src/topology/stone_cech.lean
@@ -307,4 +307,19 @@ end
 instance stone_cech.compact_space : compact_space (stone_cech α) :=
 quotient.compact_space
 
+section universal_property
+
+variables {δ : Type u} [topological_space δ]
+
+/-- The universal property that characterizes the Stone-Čech compactification of `α`,
+  when it's a Tychonoff space. Notice that a suitable `ext_f` always exists by
+  `stone_cech_extend_extends`, `continuous_stone_cech_extend` and `stone_cech_hom_ext`,
+  but `stone_cech_unit` is not an embedding for a general topological space. -/
+def stone_cech_extension_property (e : α → δ) :=
+  ∀ {γ : Type u} [topological_space γ], by exactI ∀ [t2_space γ]
+  [compact_space γ] (f : α → γ) (hf: continuous f),
+  ∃! (ext_f : δ → γ), continuous ext_f ∧ f = ext_f ∘ e
+
+end universal_property
+
 end stone_cech


### PR DESCRIPTION
State the universal property that characterises the Stone-Čech compactification of a Tychonoff space (see Kelley, General Topology, Theorem 5.24). In future PRs, the newly created section will be expanded by the following results:

* Up to isomorphism, there is only one space δ that can have this property.
* The Stone-Čech compactification of X has this property iff X is a Tychonoff space.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
