### PR TITLE
chore(model_theory/encoding): Use max omega instead of add omega

### DIFF
--- a/src/model_theory/encoding.lean
+++ b/src/model_theory/encoding.lean
@@ -16,7 +16,7 @@ import computability.encoding
 
 ## Main Results
 * `first_order.language.term.card_le` shows that the number of terms in `L.term α` is at most
-`# (α ⊕ Σ i, L.functions i) + ω`.
+`max (# (α ⊕ Σ i, L.functions i)) ω`.
 
 ## TODO
 * An encoding for formulas

--- a/src/model_theory/encoding.lean
+++ b/src/model_theory/encoding.lean
@@ -104,15 +104,15 @@ begin
     exact term.encoding.encode_injective }
 end
 
-theorem card_le : # (L.term α) ≤ # (α ⊕ Σ i, L.functions i) + ω :=
+theorem card_le : # (L.term α) ≤ max (#(α ⊕ Σ i, L.functions i)) ω :=
 begin
   have h := (mk_le_of_injective list_encode_injective),
   refine h.trans _,
   casesI fintype_or_infinite (α ⊕ Σ i, L.functions i) with ft inf,
   { haveI := fintype.to_encodable (α ⊕ Σ i, L.functions i),
-    exact le_add_left mk_le_omega },
-  { rw mk_list_eq_mk,
-    exact le_self_add }
+    exact le_max_iff.2 (or.intro_right _ mk_le_omega) },
+  { rw [mk_list_eq_mk, le_max_iff],
+    exact or.intro_left _ le_rfl }
 end
 
 instance [encodable α] [encodable ((Σ i, L.functions i))] [inhabited (L.term α)] :
@@ -124,7 +124,7 @@ lemma card_le_omega [h1 : nonempty (encodable α)] [h2 : L.countable_functions] 
   # (L.term α) ≤ ω :=
 begin
   refine (card_le.trans _),
-  rw [add_le_omega, mk_sum, add_le_omega, lift_le_omega, lift_le_omega, ← encodable_iff],
+  rw [max_le_iff, mk_sum, add_le_omega, lift_le_omega, lift_le_omega, ← encodable_iff],
   exact ⟨⟨h1, L.card_functions_le_omega⟩, refl _⟩,
 end
 

--- a/src/model_theory/substructures.lean
+++ b/src/model_theory/substructures.lean
@@ -263,7 +263,7 @@ begin
 end
 
 theorem lift_card_closure_le : cardinal.lift.{(max u w) w} (# (closure L s)) ≤
-  cardinal.lift.{(max u w) w} (#s) + cardinal.lift.{(max u w) u} (#(Σ i, L.functions i)) + ω :=
+  max (cardinal.lift.{(max u w) w} (#s) + cardinal.lift.{(max u w) u} (#(Σ i, L.functions i))) ω :=
 begin
   refine lift_card_closure_le_card_term.trans (term.card_le.trans _),
   rw [mk_sum, lift_umax', lift_umax],


### PR DESCRIPTION
Changes bounds on cardinality in model theory to use `max _ omega` instead of `_ + omega`

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
