### PR TITLE
[Merged by Bors] - chore(algebra/group/defs): Declare `field_simps` attribute earlier

### DIFF
--- a/src/algebra/field/basic.lean
+++ b/src/algebra/field/basic.lean
@@ -64,8 +64,6 @@ instance division_ring.to_group_with_zero :
 { .. ‹division_ring K›,
   .. (infer_instance : semiring K) }
 
-attribute [field_simps] inv_eq_one_div
-
 local attribute [simp]
   division_def mul_comm mul_assoc
   mul_left_comm mul_inv_cancel inv_mul_cancel

--- a/src/algebra/group/basic.lean
+++ b/src/algebra/group/basic.lean
@@ -193,7 +193,7 @@ section div_inv_monoid
 
 variables {G : Type u} [div_inv_monoid G]
 
-@[to_additive]
+@[to_additive, field_simps] -- The attributes are out of order on purpose
 lemma inv_eq_one_div (x : G) :
   x⁻¹ = 1 / x :=
 by rw [div_eq_mul_inv, one_mul]
@@ -207,7 +207,7 @@ by rw [div_eq_mul_inv, one_mul, div_eq_mul_inv]
 lemma mul_div_assoc (a b c : G) : a * b / c = a * (b / c) :=
 by rw [div_eq_mul_inv, div_eq_mul_inv, mul_assoc _ _ _]
 
-@[to_additive]
+@[to_additive, field_simps] -- The attributes are out of order on purpose
 lemma mul_div_assoc' (a b c : G) : a * (b / c) = (a * b) / c :=
 (mul_div_assoc _ _ _).symm
 

--- a/src/algebra/group/defs.lean
+++ b/src/algebra/group/defs.lean
@@ -80,6 +80,10 @@ universe u
    to the additive one.
 -/
 
+mk_simp_attribute field_simps "The simpset `field_simps` is used by the tactic `field_simp` to
+reduce an expression in a field to an expression of the form `n / d` where `n` and `d` are
+division-free."
+
 section has_mul
 
 variables {G : Type u} [has_mul G]

--- a/src/algebra/group_with_zero/basic.lean
+++ b/src/algebra/group_with_zero/basic.lean
@@ -40,12 +40,6 @@ open function
 
 variables {M₀ G₀ M₀' G₀' : Type*}
 
-mk_simp_attribute field_simps "The simpset `field_simps` is used by the tactic `field_simp` to
-reduce an expression in a field to an expression of the form `n / d` where `n` and `d` are
-division-free."
-
-attribute [field_simps] mul_div_assoc'
-
 section
 
 section mul_zero_class


### PR DESCRIPTION
Declaring `field_simps` earlier make the relevant lemmas taggable as they are declared.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
