### PR TITLE
[Merged by Bors] - feat(analysis/convex/strict_convex_space): Verify strict convexity from fixed scalars

### DIFF
--- a/src/analysis/convex/strict_convex_space.lean
+++ b/src/analysis/convex/strict_convex_space.lean
@@ -106,6 +106,54 @@ begin
     smul_right_inj hb.ne'] using (h _ _ H).norm_smul_eq.symm
 end
 
+lemma strict_convex_space.of_norm_add_lt_aux {a b c d : ℝ} (ha : 0 < a) (hab : a + b = 1)
+  (hc : 0 < c) (hd : 0 < d) (hcd : c + d = 1) (hca : c ≤ a) {x y : E} (hy : ∥y∥ ≤ 1)
+  (hxy : ∥a • x + b • y∥ < 1) :
+  ∥c • x + d • y∥ < 1 :=
+begin
+  have hbd : b ≤ d,
+  { refine le_of_add_le_add_left (hab.trans_le _),
+    rw ←hcd,
+    exact add_le_add_right hca _ },
+  have h₁ : 0 < c / a := div_pos hc ha,
+  have h₂ : 0 ≤ d - c / a * b,
+  { rw [sub_nonneg, mul_comm_div', ←le_div_iff' hc],
+    exact div_le_div hd.le hbd hc hca },
+  calc ∥c • x + d • y∥ = ∥(c / a) • (a • x + b • y) + (d - c / a * b) • y∥
+        : by rw [smul_add, ←mul_smul, ←mul_smul, div_mul_cancel _ ha.ne', sub_smul,
+            add_add_sub_cancel]
+    ... ≤ ∥(c / a) • (a • x + b • y)∥ + ∥(d - c / a * b) • y∥ : norm_add_le _ _
+    ... = c / a * ∥a • x + b • y∥ + (d - c / a * b) * ∥y∥
+        : by rw [norm_smul_of_nonneg h₁.le, norm_smul_of_nonneg h₂]
+    ... < c / a * 1 + (d - c / a * b) * 1
+        : add_lt_add_of_lt_of_le (mul_lt_mul_of_pos_left hxy h₁) (mul_le_mul_of_nonneg_left hy h₂)
+    ... = 1 : begin
+      nth_rewrite 0 ←hab,
+      rw [mul_add, div_mul_cancel _ ha.ne', mul_one, add_add_sub_cancel, hcd],
+    end,
+end
+
+/-- Strict convexity is equivalent to `∥a • x + b • y∥ < 1` for all `x` and `y` of norm at most `1`
+and all strictly positive `a` and `b` such that `a + b = 1`. This shows that we only need to check
+it for fixed `a` and `b`. -/
+lemma strict_convex_space.of_norm_add_lt {a b : ℝ} (ha : 0 < a) (hb : 0 < b) (hab : a + b = 1)
+  (h : ∀ x y : E, ∥x∥ ≤ 1 → ∥y∥ ≤ 1 → x ≠ y → ∥a • x + b • y∥ < 1) :
+  strict_convex_space ℝ E :=
+begin
+  refine strict_convex_space.of_strict_convex_closed_unit_ball _ (λ x hx y hy hxy c d hc hd hcd, _),
+  rw [interior_closed_ball (0 : E) one_ne_zero, mem_ball_zero_iff],
+  rw mem_closed_ball_zero_iff at hx hy,
+  obtain hca | hac := le_total c a,
+  { exact strict_convex_space.of_norm_add_lt_aux ha hab hc hd hcd hca hy (h _ _ hx hy hxy) },
+  rw add_comm at ⊢ hab hcd,
+  refine strict_convex_space.of_norm_add_lt_aux hb hab hd hc hcd _ hx _,
+  { refine le_of_add_le_add_right (hcd.trans_le _),
+    rw ←hab,
+    exact add_le_add_left hac _ },
+  { rw add_comm,
+    exact h _ _ hx hy hxy }
+end
+
 variables [strict_convex_space ℝ E] {x y z : E} {a b r : ℝ}
 
 /-- If `x ≠ y` belong to the same closed ball, then a convex combination of `x` and `y` with


### PR DESCRIPTION
Prove that `∀ x y : E, ∥x∥ ≤ 1 → ∥y∥ ≤ 1 → x ≠ y → ∥a • x + b • y∥ < 1` for **fixed** `a` and `b` is enough for `E` to be a strictly convex space.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
