### PR TITLE
[Merged by Bors] - feat(model_theory/semantics, satisfiability): Complete Theories

### DIFF
--- a/src/model_theory/satisfiability.lean
+++ b/src/model_theory/satisfiability.lean
@@ -62,6 +62,14 @@ lemma is_satisfiable.is_finitely_satisfiable (h : T.is_satisfiable) :
   T.is_finitely_satisfiable :=
 λ _, h.mono
 
+variables (L)
+
+lemma complete_theory.is_satisfiable (M : Type w) [nonempty M] [L.Structure M] :
+  (L.complete_theory M).is_satisfiable :=
+model.is_satisfiable M
+
+variables {L}
+
 /-- The Compactness Theorem of first-order logic: A theory is satisfiable if and only if it is
 finitely satisfiable. -/
 theorem is_satisfiable_iff_is_finitely_satisfiable {T : L.Theory} :

--- a/src/model_theory/satisfiability.lean
+++ b/src/model_theory/satisfiability.lean
@@ -62,14 +62,6 @@ lemma is_satisfiable.is_finitely_satisfiable (h : T.is_satisfiable) :
   T.is_finitely_satisfiable :=
 λ _, h.mono
 
-variables (L)
-
-lemma complete_theory.is_satisfiable (M : Type w) [nonempty M] [L.Structure M] :
-  (L.complete_theory M).is_satisfiable :=
-model.is_satisfiable M
-
-variables {L}
-
 /-- The Compactness Theorem of first-order logic: A theory is satisfiable if and only if it is
 finitely satisfiable. -/
 theorem is_satisfiable_iff_is_finitely_satisfiable {T : L.Theory} :
@@ -193,6 +185,16 @@ begin
 end
 
 end Theory
+
+namespace complete_theory
+
+variables (L) (M : Type w) [nonempty M] [L.Structure M]
+
+lemma complete_theory.is_satisfiable :
+  (L.complete_theory M).is_satisfiable :=
+Theory.model.is_satisfiable M
+
+end complete_theory
 
 namespace bounded_formula
 variables (φ ψ : L.bounded_formula α n)

--- a/src/model_theory/satisfiability.lean
+++ b/src/model_theory/satisfiability.lean
@@ -29,8 +29,7 @@ complete.
 
 ## Implementation Details
 * Satisfiability of an `L.Theory` `T` is defined in the minimal universe containing all the symbols
-of `L`. By Löwenheim-Skolem, this is equivalent to satisfiability in any universe, but this is not
-yet proven in mathlib.
+of `L`. By Löwenheim-Skolem, this is equivalent to satisfiability in any universe.
 
 -/
 

--- a/src/model_theory/satisfiability.lean
+++ b/src/model_theory/satisfiability.lean
@@ -16,12 +16,16 @@ This file deals with the satisfiability of first-order theories, as well as equi
 model.
 * `first_order.language.Theory.is_finitely_satisfiable`: `T.is_finitely_satisfiable` indicates that
 every finite subset of `T` is satisfiable.
+* `first_order.language.Theory.is_complete`: `T.is_complete` indicates that `T` is satisfiable and
+models each sentence or its negation.
 * `first_order.language.Theory.semantically_equivalent`: `T.semantically_equivalent φ ψ` indicates
 that `φ` and `ψ` are equivalent formulas or sentences in models of `T`.
 
 ## Main Results
 * The Compactness Theorem, `first_order.language.Theory.is_satisfiable_iff_is_finitely_satisfiable`,
 shows that a theory is satisfiable iff it is finitely satisfiable.
+* `first_order.language.complete_theory.is_complete`: The complete theory of a structure is
+complete.
 
 ## Implementation Details
 * Satisfiability of an `L.Theory` `T` is defined in the minimal universe containing all the symbols

--- a/src/model_theory/satisfiability.lean
+++ b/src/model_theory/satisfiability.lean
@@ -205,15 +205,8 @@ lemma is_satisfiable [nonempty M] : (L.complete_theory M).is_satisfiable :=
 Theory.model.is_satisfiable M
 
 lemma mem_or_not_mem (φ : L.sentence) :
-  φ ∈ (L.complete_theory M) ∨ (formula.not φ) ∈ (L.complete_theory M) :=
-begin
-  by_cases h : M ⊨ φ,
-  { exact or.intro_left _ h },
-  { right,
-    rw [complete_theory, set.mem_set_of_eq, sentence.realize, formula.realize_not,
-      ← sentence.realize],
-    exact h }
-end
+  φ ∈ L.complete_theory M ∨ φ.not ∈ L.complete_theory M :=
+by simp_rw [complete_theory, set.mem_set_of_eq, sentence.realize, formula.realize_not, or_not]
 
 lemma is_complete [nonempty M] : (L.complete_theory M).is_complete :=
 ⟨is_satisfiable L M,

--- a/src/model_theory/satisfiability.lean
+++ b/src/model_theory/satisfiability.lean
@@ -337,4 +337,3 @@ lemma induction_on_exists_not {P : Π {m}, L.bounded_formula α m → Prop} (φ 
 end bounded_formula
 end language
 end first_order
-#lint

--- a/src/model_theory/satisfiability.lean
+++ b/src/model_theory/satisfiability.lean
@@ -190,7 +190,7 @@ namespace complete_theory
 
 variables (L) (M : Type w) [nonempty M] [L.Structure M]
 
-lemma complete_theory.is_satisfiable :
+lemma is_satisfiable :
   (L.complete_theory M).is_satisfiable :=
 Theory.model.is_satisfiable M
 

--- a/src/model_theory/satisfiability.lean
+++ b/src/model_theory/satisfiability.lean
@@ -199,9 +199,9 @@ end Theory
 
 namespace complete_theory
 
-variables (L) (M : Type w) [nonempty M] [L.Structure M]
+variables (L) (M : Type w) [L.Structure M]
 
-lemma is_satisfiable : (L.complete_theory M).is_satisfiable :=
+lemma is_satisfiable [nonempty M] : (L.complete_theory M).is_satisfiable :=
 Theory.model.is_satisfiable M
 
 lemma mem_or_not_mem (φ : L.sentence) :
@@ -215,7 +215,7 @@ begin
     exact h }
 end
 
-lemma is_complete : (L.complete_theory M).is_complete :=
+lemma is_complete [nonempty M] : (L.complete_theory M).is_complete :=
 ⟨is_satisfiable L M,
   λ φ, ((mem_or_not_mem L M φ).imp Theory.models_sentence_of_mem Theory.models_sentence_of_mem)⟩
 
@@ -337,3 +337,4 @@ lemma induction_on_exists_not {P : Π {m}, L.bounded_formula α m → Prop} (φ 
 end bounded_formula
 end language
 end first_order
+#lint

--- a/src/model_theory/semantics.lean
+++ b/src/model_theory/semantics.lean
@@ -516,6 +516,7 @@ infix ` ⊨ `:51 := sentence.realize -- input using \|= or \vDash, but not using
 
 variables (L)
 
+/-- The complete theory of a structure `M` is the set of all sentences `M` satisfies. -/
 def complete_theory : L.Theory := { φ | M ⊨ φ }
 
 variables {L}

--- a/src/model_theory/semantics.lean
+++ b/src/model_theory/semantics.lean
@@ -514,6 +514,12 @@ infix ` ⊨ `:51 := sentence.realize -- input using \|= or \vDash, but not using
   M ⊨ φ.on_sentence ψ ↔ M ⊨ ψ :=
 φ.realize_on_formula ψ
 
+variables (L)
+
+def complete_theory : L.Theory := { φ | M ⊨ φ }
+
+variables {L}
+
 /-- A model of a theory is a structure in which every sentence is realized as true. -/
 class Theory.model (T : L.Theory) : Prop :=
 (realize_of_mem : ∀ φ ∈ T, M ⊨ φ)
@@ -544,6 +550,13 @@ lemma Theory.model.mono {T' : L.Theory} (h : M ⊨ T') (hs : T ⊆ T') :
 lemma Theory.model_singleton_iff {φ : L.sentence} :
   M ⊨ ({φ} : L.Theory) ↔ M ⊨ φ :=
 by simp
+
+theorem Theory.model_iff_subset_complete_theory :
+  M ⊨ T ↔ T ⊆ L.complete_theory M :=
+T.model_iff
+
+instance model_complete_theory : M ⊨ L.complete_theory M :=
+Theory.model_iff_subset_complete_theory.2 (subset_refl _)
 
 namespace bounded_formula
 

--- a/src/model_theory/semantics.lean
+++ b/src/model_theory/semantics.lean
@@ -509,6 +509,10 @@ def sentence.realize (φ : L.sentence) : Prop :=
 
 infix ` ⊨ `:51 := sentence.realize -- input using \|= or \vDash, but not using \models
 
+@[simp] lemma sentence.realize_not {φ : L.sentence} :
+  M ⊨ φ.not ↔ ¬ M ⊨ φ :=
+iff.rfl
+
 @[simp] lemma Lhom.realize_on_sentence [L'.Structure M] (φ : L →ᴸ L') [φ.is_expansion_on M]
   (ψ : L.sentence) :
   M ⊨ φ.on_sentence ψ ↔ M ⊨ ψ :=
@@ -558,6 +562,19 @@ T.model_iff
 
 instance model_complete_theory : M ⊨ L.complete_theory M :=
 Theory.model_iff_subset_complete_theory.2 (subset_refl _)
+
+variables (M N)
+
+theorem realize_iff_of_model_complete_theory [N ⊨ L.complete_theory M] (φ : L.sentence) :
+  N ⊨ φ ↔ M ⊨ φ :=
+begin
+  refine ⟨λ h, _, Theory.realize_sentence_of_mem (L.complete_theory M)⟩,
+  contrapose! h,
+  rw [← sentence.realize_not] at *,
+  exact Theory.realize_sentence_of_mem (L.complete_theory M) h,
+end
+
+variables {M N}
 
 namespace bounded_formula
 


### PR DESCRIPTION
Defines `first_order.language.Theory.is_complete`, indicating that a theory is complete.
Defines `first_order.language.complete_theory`, the complete theory of a structure.
Shows that the complete theory of a structure is complete.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
