### PR TITLE
[Merged by Bors] - feat(representation_theory/basic): representation theory without scalar actions

### DIFF
--- a/src/representation_theory/basic.lean
+++ b/src/representation_theory/basic.lean
@@ -148,7 +148,7 @@ tensor product `V ⊗[k] W`.
 def tprod : representation k G (V ⊗[k] W) :=
 { to_fun := λ g, tensor_product.map (ρV g) (ρW g),
   map_one' := by simp only [map_one, tensor_product.map_one],
-  map_mul' := λ g h, by simp only [map_mul, mul_eq_comp, tensor_product.map_comp] }
+  map_mul' := λ g h, by simp only [map_mul, tensor_product.map_mul] }
 
 notation ρV ` ⊗ ` ρW := tprod ρV ρW
 

--- a/src/representation_theory/basic.lean
+++ b/src/representation_theory/basic.lean
@@ -33,18 +33,21 @@ homomorphisms `G →* (V →ₗ[k] V)`.
 open monoid_algebra (lift) (of)
 open linear_map
 
-namespace representation
-
 section
 variables (k G V : Type*) [comm_semiring k] [monoid G] [add_comm_monoid V] [module k V]
 
 /--
 A representation of `G` on the `k`-module `V` is an homomorphism `G →* (V →ₗ[k] V)`.
 -/
-@[nolint dup_namespace]
 abbreviation representation := G →* (V →ₗ[k] V)
 
-variables {k G}
+end
+
+namespace representation
+
+section trivial
+
+variables {k G V : Type*} [comm_semiring k] [monoid G] [add_comm_monoid V] [module k V]
 
 /--
 The trivial representation of `G` on the one-dimensional module `k`.
@@ -54,7 +57,7 @@ def trivial : representation k G k := 1
 @[simp]
 lemma trivial_def (g : G) (v : k) : trivial g v = v := rfl
 
-end
+end trivial
 
 section monoid_algebra
 

--- a/src/representation_theory/basic.lean
+++ b/src/representation_theory/basic.lean
@@ -7,105 +7,192 @@ import algebra.module.basic
 import algebra.module.linear_map
 import algebra.monoid_algebra.basic
 import linear_algebra.trace
+import linear_algebra.dual
+import linear_algebra.free_module.basic
 
 /-!
 # Monoid representations
 
-This file introduces monoid representations and their characters and proves basic lemmas about them,
-including equivalences between different definitions of representations.
+This file introduces monoid representations and their characters and defines a few ways to construct
+representations.
 
 ## Main definitions
 
-  * `representation.as_module`
-  * `representation.as_group_hom`
-  * `representation.character`
+  * representation.representation
+  * representation.character
+  * representation.tprod
+  * representation.lin_hom
+  * represensation.dual
 
 ## Implementation notes
 
-A representation of a monoid `G` over a commutative semiring `k` is implemented as a `k`-module `V`
-together with a `distrib_mul_action G V` instance and a `smul_comm_class G k V` instance.
-
-Alternatively, one can use a monoid homomorphism `G →* (V →ₗ[k] V)`. The definitions `as_monoid_hom`
-and `rep_space` allow to go back and forth between these two definitions.
+Representations of a monoid `G` on a `k`-module `V` are implemented as
+homomorphisms `G →* (V →ₗ[k] V)`.
 -/
 
-open monoid_algebra
+open monoid_algebra (lift) (of)
+open linear_map
 
 namespace representation
 
 section
-variables (k G V : Type*) [comm_semiring k] [monoid G] [add_comm_monoid V]
-variables [module k V] [distrib_mul_action G V] [smul_comm_class G k V]
+variables (k G V : Type*) [comm_semiring k] [monoid G] [add_comm_monoid V] [module k V]
+
+/--
+A representation of `G` on the `k`-module `V` is an homomorphism `G →* (V →ₗ[k] V)`.
+-/
+@[nolint dup_namespace]
+abbreviation representation := G →* (V →ₗ[k] V)
+
+variables {k G}
+
+/--
+The trivial representation of `G` on the one-dimensional module `k`.
+-/
+def trivial : representation k G k := 1
+
+@[simp]
+lemma trivial_def (g : G) (v : k) : trivial g v = v := rfl
+
+end
+
+section monoid_algebra
+
+variables {k G V : Type*} [comm_semiring k] [monoid G] [add_comm_monoid V] [module k V]
+variables (ρ : representation k G V)
 
 /--
 A `k`-linear representation of `G` on `V` can be thought of as
 an algebra map from `monoid_algebra k G` into the `k`-linear endomorphisms of `V`.
 -/
 noncomputable def as_algebra_hom : monoid_algebra k G →ₐ[k] (module.End k V) :=
-  (lift k G _) (distrib_mul_action.to_module_End k V)
+  (lift k G _) ρ
 
 lemma as_algebra_hom_def :
-  as_algebra_hom k G V = (lift k G _) (distrib_mul_action.to_module_End k V) := rfl
+  as_algebra_hom ρ = (lift k G _) ρ := rfl
 
 @[simp]
 lemma as_algebra_hom_single (g : G):
-  (as_algebra_hom k G V (finsupp.single g 1)) = (distrib_mul_action.to_module_End k V) g :=
-by simp [as_algebra_hom_def]
+  (as_algebra_hom ρ (finsupp.single g 1)) = ρ g :=
+by simp only [as_algebra_hom_def, monoid_algebra.lift_single, one_smul]
+
+lemma as_algebra_hom_of (g : G):
+  (as_algebra_hom ρ (of k G g)) = ρ g :=
+by simp only [monoid_algebra.of_apply, as_algebra_hom_single]
 
 /--
 A `k`-linear representation of `G` on `V` can be thought of as
 a module over `monoid_algebra k G`.
 -/
-noncomputable instance as_module : module (monoid_algebra k G) V :=
-  module.comp_hom V (as_algebra_hom k G V).to_ring_hom
+noncomputable def as_module : module (monoid_algebra k G) V :=
+  module.comp_hom V (as_algebra_hom ρ).to_ring_hom
 
-lemma as_module_apply (a : monoid_algebra k G) (v : V):
-  a • v = (as_algebra_hom k G V a) v := rfl
-
-lemma of_smul (g : G) (v : V) :
-  (of k G g) • v =  g • v := by simp [as_module_apply]
-
-instance as_module_scalar_tower : is_scalar_tower k (monoid_algebra k G) V :=
-{ smul_assoc := λ r a v, by simp [as_module_apply] }
-
-instance as_module_smul_comm : smul_comm_class k (monoid_algebra k G) V :=
-{ smul_comm := λ r a v, by simp [as_module_apply] }
-
-end
+end monoid_algebra
 
 section group
-variables (k G V : Type*) [comm_semiring k] [group G] [add_comm_monoid V]
-variables [module k V] [distrib_mul_action G V] [smul_comm_class G k V]
+
+variables {k G V : Type*} [comm_semiring k] [group G] [add_comm_monoid V] [module k V]
+variables (ρ : representation k G V)
 
 /--
 When `G` is a group, a `k`-linear representation of `G` on `V` can be thought of as
 a group homomorphism from `G` into the invertible `k`-linear endomorphisms of `V`.
 -/
 def as_group_hom : G →* units (V →ₗ[k] V) :=
-  monoid_hom.to_hom_units (distrib_mul_action.to_module_End k V)
+  monoid_hom.to_hom_units ρ
+
+lemma as_group_hom_apply (g : G) : ↑(as_group_hom ρ g) = ρ g :=
+by simp only [as_group_hom, monoid_hom.coe_to_hom_units]
 
 end group
 
 section character
 
-variables (k G V : Type*) [field k] [group G] [add_comm_group V]
-variables [module k V] [distrib_mul_action G V] [smul_comm_class G k V]
+variables {k G V : Type*} [comm_ring k] [group G] [add_comm_group V] [module k V]
+variables (ρ : representation k G V)
 
 /--
 The character associated to a representation of `G`, which as a map `G → k`
 sends each element to the trace of the corresponding linear map.
 -/
 @[simp]
-noncomputable def character (g : G) : k :=
-linear_map.trace k V (as_group_hom k G V g)
+noncomputable def character (g : G) : k := trace k V (ρ g)
 
-/-- The evaluation of the character at the identity is the dimension of the representation. -/
-theorem char_one [finite_dimensional k V] : character k G V 1 = finite_dimensional.finrank k V :=
-by simp
+theorem char_mul_comm (g : G) (h : G) : character ρ (h * g) = character ρ (g * h) :=
+by simp only [trace_mul_comm, character, map_mul]
 
 /-- The character of a representation is constant on conjugacy classes. -/
-theorem char_conj (g : G) (h : G) : (character k G V) (h * g * h⁻¹) = (character k G V) g := by simp
+theorem char_conj (g : G) (h : G) : (character ρ) (h * g * h⁻¹) = (character ρ) g :=
+by simp only [character, ←as_group_hom_apply, map_mul, map_inv, trace_conj]
+
+variables [nontrivial k] [module.free k V] [module.finite k V]
+
+/-- The evaluation of the character at the identity is the dimension of the representation. -/
+theorem char_one : character ρ 1 = finite_dimensional.finrank k V :=
+by simp only [character, map_one, trace_one]
 
 end character
+
+section tensor_product
+
+variables {k G V W : Type*} [comm_semiring k] [monoid G]
+variables [add_comm_monoid V] [module k V] [add_comm_monoid W] [module k W]
+variables (ρV : representation k G V) (ρW : representation k G W)
+
+open_locale tensor_product
+
+/--
+Given representations of `G` on `V` and `W`, there is a natural representation of `G` on their
+tensor product `V ⊗[k] W`.
+-/
+def tprod : representation k G (V ⊗[k] W) :=
+{ to_fun := λ g, tensor_product.map (ρV g) (ρW g),
+  map_one' := by simp only [map_one, tensor_product.map_one],
+  map_mul' := λ g h, by simp only [map_mul, mul_eq_comp, tensor_product.map_comp] }
+
+notation ρV ` ⊗ ` ρW := tprod ρV ρW
+
+@[simp]
+lemma tprod_apply (g : G) : (ρV ⊗ ρW) g = tensor_product.map (ρV g) (ρW g) := rfl
+
+end tensor_product
+
+section linear_hom
+
+variables {k G V W : Type*} [comm_semiring k] [group G]
+variables [add_comm_monoid V] [module k V] [add_comm_monoid W] [module k W]
+variables (ρV : representation k G V) (ρW : representation k G W)
+
+/--
+Given representations of `G` on `V` and `W`, there is a natural representation of `G` on the
+module `V →ₗ[k] W`, where `G` acts by conjugation.
+-/
+def lin_hom : representation k G (V →ₗ[k] W) :=
+{ to_fun := λ g,
+  { to_fun := λ f, (ρW g) ∘ₗ f ∘ₗ (ρV g⁻¹),
+    map_add' := λ f₁ f₂, by simp only [add_comp, comp_add],
+    map_smul' := λ r f, by {ext, simp only [coe_comp, function.comp_app, smul_apply, map_smulₛₗ]} },
+  map_one' := by {ext, simp only [coe_comp, function.comp_app, map_one, one_inv, coe_mk, one_apply]},
+  map_mul' := λ g h, by {ext, simp}}
+
+@[simp]
+lemma lin_hom_apply (g : G) (f : V →ₗ[k] W) : (lin_hom ρV ρW) g f = (ρW g) ∘ₗ f ∘ₗ (ρV g⁻¹) := rfl
+
+/--
+The dual of a representation `ρ` of `G` on a module `V`, given by `(dual ρ) g f = f ∘ₗ (ρ g⁻¹)`,
+where `f : module.dual k V`.
+-/
+def dual : representation k G (module.dual k V) :=
+{ to_fun := λ g,
+  { to_fun := λ f, f ∘ₗ (ρV g⁻¹),
+    map_add' := λ f₁ f₂, by simp only [add_comp],
+    map_smul' := λ r f, by {ext, simp only [coe_comp, function.comp_app, smul_apply, ring_hom.id_apply]} },
+  map_one' := by {ext, simp only [coe_comp, function.comp_app, map_one, one_inv, coe_mk, one_apply]},
+  map_mul' := λ g h, by {ext, simp only [coe_comp, function.comp_app, mul_inv_rev, map_mul, coe_mk, mul_apply]}}
+
+@[simp]
+lemma dual_apply (g : G) (f : module.dual k V) : (dual ρV) g f = f ∘ₗ (ρV g⁻¹) := rfl
+
+end linear_hom
 
 end representation

--- a/src/representation_theory/basic.lean
+++ b/src/representation_theory/basic.lean
@@ -172,7 +172,8 @@ def lin_hom : representation k G (V →ₗ[k] W) :=
   { to_fun := λ f, (ρW g) ∘ₗ f ∘ₗ (ρV g⁻¹),
     map_add' := λ f₁ f₂, by simp only [add_comp, comp_add],
     map_smul' := λ r f, by {ext, simp only [coe_comp, function.comp_app, smul_apply, map_smulₛₗ]} },
-  map_one' := by {ext, simp only [coe_comp, function.comp_app, map_one, one_inv, coe_mk, one_apply]},
+  map_one' :=
+    by {ext, simp only [coe_comp, function.comp_app, map_one, one_inv, coe_mk, one_apply]},
   map_mul' := λ g h, by {ext, simp}}
 
 @[simp]
@@ -186,9 +187,12 @@ def dual : representation k G (module.dual k V) :=
 { to_fun := λ g,
   { to_fun := λ f, f ∘ₗ (ρV g⁻¹),
     map_add' := λ f₁ f₂, by simp only [add_comp],
-    map_smul' := λ r f, by {ext, simp only [coe_comp, function.comp_app, smul_apply, ring_hom.id_apply]} },
-  map_one' := by {ext, simp only [coe_comp, function.comp_app, map_one, one_inv, coe_mk, one_apply]},
-  map_mul' := λ g h, by {ext, simp only [coe_comp, function.comp_app, mul_inv_rev, map_mul, coe_mk, mul_apply]}}
+    map_smul' := λ r f,
+      by {ext, simp only [coe_comp, function.comp_app, smul_apply, ring_hom.id_apply]} },
+  map_one' :=
+    by {ext, simp only [coe_comp, function.comp_app, map_one, one_inv, coe_mk, one_apply]},
+  map_mul' := λ g h,
+    by {ext, simp only [coe_comp, function.comp_app, mul_inv_rev, map_mul, coe_mk, mul_apply]}}
 
 @[simp]
 lemma dual_apply (g : G) (f : module.dual k V) : (dual ρV) g f = f ∘ₗ (ρV g⁻¹) := rfl

--- a/src/representation_theory/invariants.lean
+++ b/src/representation_theory/invariants.lean
@@ -8,21 +8,20 @@ import representation_theory.basic
 /-!
 # Subspace of invariants a group representation
 
-This file introduce the subspace of invariants of a group representation
-and proves basic result about it.
+This file introduces the subspace of invariants of a group representation
+and proves basic results about it.
 The main tool used is the average of all elements of the group, seen as an element of
-`monoid_algebra k G`. Scalar multiplication by this special element gives a projection onto the
+`monoid_algebra k G`. The action of this special element gives a projection onto the
 subspace of invariants.
 In order for the definition of the average element to make sense, we need to assume for most of the
 results that the order of `G` is invertible in `k` (e. g. `k` has characteristic `0`).
 -/
 
 open_locale big_operators
-open monoid_algebra finset finite_dimensional linear_map representation
+open monoid_algebra
+open representation
 
-namespace representation
-
-section average
+namespace group_algebra
 
 variables (k G : Type*) [comm_semiring k] [group G]
 variables [fintype G] [invertible (fintype.card G : k)]
@@ -63,61 +62,52 @@ begin
   rw function.bijective.sum_comp (group.mul_right_bijective g) _,
 end
 
-end average
+end group_algebra
 
-section invariants
+namespace representation
 
-variables (k G V : Type*) [comm_semiring k] [group G] [add_comm_group V]
-variables [module k V] [distrib_mul_action G V] [smul_comm_class G k V]
+open group_algebra
+
+variables {k G V : Type*} [comm_semiring k] [group G] [add_comm_monoid V] [module k V]
+variables (ρ : representation k G V)
 
 /--
 The subspace of invariants, consisting of the vectors fixed by all elements of `G`.
 -/
 def invariants : submodule k V :=
-{ carrier := set_of (λ v, ∀ (g : G), g • v = v),
-  zero_mem' := by simp only [forall_const, set.mem_set_of_eq, smul_zero],
-  add_mem' := λ v w hv hw g, by simp only [smul_add, add_left_inj, eq_self_iff_true, hv g, hw g],
-  smul_mem' := λ r v hv g, by simp only [eq_self_iff_true, smul_comm, hv g]}
+{ carrier := set_of (λ v, ∀ (g : G), ρ g v = v),
+  zero_mem' := λ g, by simp only [map_zero],
+  add_mem' := λ v w hv hw g, by simp only [hv g, hw g, map_add],
+  smul_mem' := λ r v hv g, by simp only [hv g, linear_map.map_smulₛₗ, ring_hom.id_apply]}
 
 @[simp]
-lemma mem_invariants (v : V) : v ∈ (invariants k G V) ↔ ∀ (g: G), g • v = v := by refl
+lemma mem_invariants (v : V) : v ∈ invariants ρ ↔ ∀ (g: G), ρ g v = v := by refl
 
 lemma invariants_eq_inter :
-  (invariants k G V).carrier = ⋂ g : G, function.fixed_points (has_scalar.smul g) :=
-by { ext, simp [function.is_fixed_pt] }
-
-/--
-The subspace of invariants, as a submodule over `monoid_algebra k G`.
--/
-noncomputable def invariants' : submodule (monoid_algebra k G) V :=
-  submodule_of_smul_mem (invariants k G V) (λ g v hv, by {rw [of_smul, hv g], exact hv})
-
-@[simp] lemma invariants'_carrier :
-  (invariants' k G V).carrier = (invariants k G V).carrier := rfl
+  (invariants ρ).carrier = ⋂ g : G, function.fixed_points (ρ g) :=
+by {ext, simp [function.is_fixed_pt]}
 
 variables [fintype G] [invertible (fintype.card G : k)]
 
 /--
-Scalar multiplication by `average k G` sends elements of `V` to the subspace of invariants.
+The action of `average k G` gives a projection map onto the subspace of invariants.
 -/
-theorem smul_average_invariant (v : V) : (average k G) • v ∈ invariants k G V :=
-λ g, by rw [←of_smul k, smul_smul, of_apply, mul_average_left]
+@[simp]
+noncomputable def average_map : V →ₗ[k] V := as_algebra_hom ρ (average k G)
 
 /--
-`average k G` acts as the identity on the subspace of invariants.
+The `average_map` sends elements of `V` to the subspace of invariants.
 -/
-theorem smul_average_id (v : V) (H : v ∈ invariants k G V) : (average k G) • v = v :=
+theorem average_map_invariant (v : V) : average_map ρ v ∈ invariants ρ :=
+λ g, by rw [average_map, ←as_algebra_hom_single, ←linear_map.mul_apply, ←map_mul (as_algebra_hom ρ), mul_average_left]
+
+/--
+The `average_map` acts as the identity on the subspace of invariants.
+-/
+theorem average_map_id (v : V) (hv : v ∈ invariants ρ) : average_map ρ v = v :=
 begin
-  rw [representation.mem_invariants] at H,
-  simp_rw [average_def, smul_assoc, finset.sum_smul, representation.of_smul, H, finset.sum_const,
-    finset.card_univ, nsmul_eq_smul_cast k _ v, smul_smul, inv_of_mul_self, one_smul],
+  rw mem_invariants at hv,
+  simp [average_def, map_sum, hv, finset.card_univ, nsmul_eq_smul_cast k _ v, smul_smul],
 end
-
-/--
-Scalar multiplication by `average k G` gives a projection map onto the subspace of invariants.
--/
-noncomputable def average_map : V →ₗ[k] V := (as_algebra_hom k G V) (average k G)
-
-end invariants
 
 end representation

--- a/src/representation_theory/invariants.lean
+++ b/src/representation_theory/invariants.lean
@@ -99,7 +99,8 @@ noncomputable def average_map : V →ₗ[k] V := as_algebra_hom ρ (average k G)
 The `average_map` sends elements of `V` to the subspace of invariants.
 -/
 theorem average_map_invariant (v : V) : average_map ρ v ∈ invariants ρ :=
-λ g, by rw [average_map, ←as_algebra_hom_single, ←linear_map.mul_apply, ←map_mul (as_algebra_hom ρ), mul_average_left]
+λ g, by rw [average_map, ←as_algebra_hom_single, ←linear_map.mul_apply, ←map_mul (as_algebra_hom ρ),
+            mul_average_left]
 
 /--
 The `average_map` acts as the identity on the subspace of invariants.


### PR DESCRIPTION
This PR rewrites the files `representation_theory/basic` and `representation_theory/invariants` so that they avoid making use of scalar actions. It also includes the new definitions and lemmas of PR #13502 written with this new approach.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
