### PR TITLE
[Merged by Bors] - feat(analysis/complex/roots_of_unity): arg of a primitive root

### DIFF
--- a/src/analysis/complex/roots_of_unity.lean
+++ b/src/analysis/complex/roots_of_unity.lean
@@ -114,3 +114,60 @@ lemma is_primitive_root.arg_eq_pi_iff {n : ℕ} {ζ : ℂ} (hζ : is_primitive_r
   (hn : n ≠ 0) : ζ.arg = real.pi ↔ ζ = -1 :=
 ⟨λ h, hζ.arg_ext (is_primitive_root.neg_one 0 two_ne_zero.symm) hn two_ne_zero
       (h.trans complex.arg_neg_one.symm), λ h, h.symm ▸ complex.arg_neg_one⟩
+
+lemma is_primitive_root.arg {n : ℕ} {ζ : ℂ} (h : is_primitive_root ζ n) (hn : n ≠ 0) :
+  ∃ i : ℤ, ζ.arg = i / n * (2 * real.pi) ∧ is_coprime i n ∧ i.nat_abs < n :=
+begin
+  rw complex.is_primitive_root_iff _ _ hn at h,
+  obtain ⟨i, h, hin, rfl⟩ := h,
+  rw [mul_comm, ←mul_assoc, complex.exp_mul_I],
+  refine ⟨if i * 2 ≤ n then i else i - n, _, _, _⟩,
+  work_on_goal 2
+  { replace hin := nat.is_coprime_iff_coprime.mpr hin,
+    split_ifs with _,
+    { exact hin },
+    { convert hin.add_mul_left_left (-1),
+      rw [mul_neg_one, sub_eq_add_neg] } },
+  work_on_goal 2
+  { split_ifs with h₂,
+    { exact_mod_cast h },
+    suffices : (i - n : ℤ).nat_abs = n - i,
+    { rw this,
+      apply tsub_lt_self hn.bot_lt,
+      contrapose! h₂,
+      rw [nat.eq_zero_of_le_zero h₂, zero_mul],
+      exact zero_le _ },
+    rw [←int.nat_abs_neg, neg_sub, int.nat_abs_eq_iff],
+    exact or.inl (int.coe_nat_sub h.le).symm },
+  split_ifs with h₂,
+  { convert complex.arg_cos_add_sin_mul_I _,
+    { push_cast },
+    { push_cast },
+    field_simp [hn],
+    refine ⟨(neg_lt_neg real.pi_pos).trans_le _, _⟩,
+    { rw neg_zero,
+      exact mul_nonneg (mul_nonneg i.cast_nonneg $ by simp [real.pi_pos.le]) (by simp) },
+    rw [←mul_rotate', mul_div_assoc],
+    rw ←mul_one n at h₂,
+    exact mul_le_of_le_one_right real.pi_pos.le
+      ((div_le_iff' $ by exact_mod_cast (pos_of_gt h)).mpr $ by exact_mod_cast h₂) },
+  rw [←complex.cos_sub_two_pi, ←complex.sin_sub_two_pi],
+  convert complex.arg_cos_add_sin_mul_I _,
+  { push_cast,
+    rw [←sub_one_mul, sub_div, div_self],
+    exact_mod_cast hn },
+  { push_cast,
+    rw [←sub_one_mul, sub_div, div_self],
+    exact_mod_cast hn },
+  field_simp [hn],
+  refine ⟨_, le_trans _ real.pi_pos.le⟩,
+  work_on_goal 2
+  { rw [mul_div_assoc],
+    exact mul_nonpos_of_nonpos_of_nonneg (sub_nonpos.mpr $ by exact_mod_cast h.le)
+      (div_nonneg (by simp [real.pi_pos.le]) $ by simp) },
+  rw [←mul_rotate', mul_div_assoc, neg_lt, ←mul_neg, mul_lt_iff_lt_one_right real.pi_pos,
+      ←neg_div, ←neg_mul, neg_sub, div_lt_iff, one_mul, sub_mul, sub_lt, ←mul_sub_one],
+  norm_num,
+  exact_mod_cast not_le.mp h₂,
+  { exact (nat.cast_pos.mpr hn.bot_lt) }
+end


### PR DESCRIPTION


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)

I'm not super attached to this result, is_primitive_root.arg_ext is sufficient for what I need. It felt very bad to just let this result rot, though.
