### PR TITLE
[Merged by Bors] - refactor(linear_algebra/quotient): Use the same quotient relation as add_subgroup

### DIFF
--- a/src/algebra/char_p/quotient.lean
+++ b/src/algebra/char_p/quotient.lean
@@ -31,7 +31,7 @@ lemma quotient' {R : Type*} [comm_ring R] (p : ℕ) [char_p R p] (I : ideal R)
   char_p (R ⧸ I) p :=
 ⟨λ x, begin
   rw [←cast_eq_zero_iff R p x, ←map_nat_cast (ideal.quotient.mk I)],
-  refine quotient.eq'.trans (_ : ↑x - 0 ∈ I ↔ _),
+  refine ideal.quotient.eq.trans (_ : ↑x - 0 ∈ I ↔ _),
   rw sub_zero,
   exact ⟨h x, λ h', h'.symm ▸ I.zero_mem⟩,
 end⟩

--- a/src/algebra/lie/quotient.lean
+++ b/src/algebra/lie/quotient.lean
@@ -102,6 +102,7 @@ instance lie_quotient_has_bracket : has_bracket (L ⧸ I) (L ⧸ I) :=
   apply quotient.lift_on₂' x y (λ x' y', mk ⁅x', y'⁆),
   intros x₁ x₂ y₁ y₂ h₁ h₂,
   apply (submodule.quotient.eq I.to_submodule).2,
+  rw submodule.quotient_rel_r_def at h₁ h₂,
   have h : ⁅x₁, x₂⁆ - ⁅y₁, y₂⁆ = ⁅x₁, x₂ - y₂⁆ + ⁅x₁ - y₁, y₂⁆,
     by simp [-lie_skew, sub_eq_add_neg, add_assoc],
   rw h,

--- a/src/algebra/module/torsion.lean
+++ b/src/algebra/module/torsion.lean
@@ -124,7 +124,8 @@ section quotient
 variables [comm_ring R] [add_comm_group M] [module R M] (a : R)
 
 instance : has_scalar (R ⧸ R ∙ a) (torsion_by R M a) :=
-{ smul := λ b x, quotient.lift_on' b (• x) $ λ b₁ b₂ (h : b₁ - b₂ ∈ _), begin
+{ smul := λ b x, quotient.lift_on' b (• x) $ λ b₁ b₂ h, begin
+    rw submodule.quotient_rel_r_def at h,
     show b₁ • x = b₂ • x,
     obtain ⟨c, h⟩ := ideal.mem_span_singleton'.mp h,
     rw [← sub_eq_zero, ← sub_smul, ← h, mul_smul, smul_torsion_by, smul_zero],

--- a/src/algebra/ring_quot.lean
+++ b/src/algebra/ring_quot.lean
@@ -232,7 +232,7 @@ def ring_quot_to_ideal_quotient (r : B → B → Prop) :
   ring_quot r →+* B ⧸ ideal.of_rel r :=
 lift
   ⟨ideal.quotient.mk (ideal.of_rel r),
-   λ x y h, quot.sound (submodule.mem_Inf.mpr (λ p w, w ⟨x, y, h, sub_add_cancel x y⟩))⟩
+    λ x y h, ideal.quotient.eq.2 $ submodule.mem_Inf.mpr (λ p w, w ⟨x, y, h, sub_add_cancel x y⟩)⟩
 
 @[simp] lemma ring_quot_to_ideal_quotient_apply (r : B → B → Prop) (x : B) :
   ring_quot_to_ideal_quotient r (mk_ring_hom r x) = ideal.quotient.mk _ x := rfl

--- a/src/linear_algebra/invariant_basis_number.lean
+++ b/src/linear_algebra/invariant_basis_number.lean
@@ -240,6 +240,7 @@ private def induced_map (I : ideal R) (e : (ι → R) →ₗ[R] (ι' → R)) :
 λ x, quotient.lift_on' x (λ y, ideal.quotient.mk _ (e y))
 begin
   refine λ a b hab, ideal.quotient.eq.2 (λ h, _),
+  rw submodule.quotient_rel_r_def at hab,
   rw ←linear_map.map_sub,
   exact ideal.map_pi _ _ hab e h,
 end

--- a/src/linear_algebra/quotient.lean
+++ b/src/linear_algebra/quotient.lean
@@ -23,12 +23,15 @@ variables (p p' : submodule R M)
 
 open linear_map
 
--- TODO(Mario): Factor through add_subgroup
-/-- The equivalence relation associated to a submodule `p`, defined by `x ≈ y` iff `y - x ∈ p`. -/
+/-- The equivalence relation associated to a submodule `p`, defined by `x ≈ y` iff `-x + y ∈ p`.
+
+Note this is equivalent to `y - x ∈ p`, but defined this way to be be defeq to the `add_subgroup`
+version, where commutativity can't be assumed. -/
 def quotient_rel : setoid M :=
-⟨λ x y, x - y ∈ p, λ x, by simp,
- λ x y h, by simpa using neg_mem h,
- λ x y z h₁ h₂, by simpa [sub_eq_add_neg, add_left_comm, add_assoc] using add_mem h₁ h₂⟩
+quotient_add_group.left_rel p.to_add_subgroup
+
+lemma quotient_rel_r_def {x y : M} : @setoid.r _ (p.quotient_rel) x y ↔ x - y ∈ p :=
+iff.trans (by { rw [sub_eq_add_neg, neg_add, neg_neg], refl }) neg_mem_iff
 
 /-- The quotient of a module `M` by a submodule `p ⊆ M`. -/
 instance has_quotient : has_quotient M (submodule R M) := ⟨λ p, quotient (quotient_rel p)⟩
@@ -44,7 +47,10 @@ def mk {p : submodule R M} : M → M ⧸ p := quotient.mk'
 @[simp] theorem mk'_eq_mk {p : submodule R M} (x : M) : (quotient.mk' x : M ⧸ p) = mk x := rfl
 @[simp] theorem quot_mk_eq_mk {p : submodule R M} (x : M) : (quot.mk _ x : M ⧸ p) = mk x := rfl
 
-protected theorem eq {x y : M} : (mk x : M ⧸ p) = mk y ↔ x - y ∈ p := quotient.eq'
+protected theorem eq' {x y : M} : (mk x : M ⧸ p) = mk y ↔ -x + y ∈ p := quotient.eq'
+
+protected theorem eq {x y : M} : (mk x : M ⧸ p) = mk y ↔ x - y ∈ p :=
+(p^.quotient.eq').trans p.quotient_rel_r_def
 
 instance : has_zero (M ⧸ p) := ⟨mk 0⟩
 instance : inhabited (M ⧸ p) := ⟨0⟩
@@ -54,51 +60,14 @@ instance : inhabited (M ⧸ p) := ⟨0⟩
 @[simp] theorem mk_eq_zero : (mk x : M ⧸ p) = 0 ↔ x ∈ p :=
 by simpa using (quotient.eq p : mk x = 0 ↔ _)
 
-instance : has_add (M ⧸ p) :=
-⟨λ a b, quotient.lift_on₂' a b (λ a b, mk (a + b)) $
-  λ a₁ a₂ b₁ b₂ h₁ h₂, (quotient.eq p).2 $
-    by simpa [sub_eq_add_neg, add_left_comm, add_comm] using add_mem h₁ h₂⟩
+instance add_comm_group : add_comm_group (M ⧸ p) :=
+quotient_add_group.add_comm_group p.to_add_subgroup
 
 @[simp] theorem mk_add : (mk (x + y) : M ⧸ p) = mk x + mk y := rfl
 
-instance : has_neg (M ⧸ p) :=
-⟨λ a, quotient.lift_on' a (λ a, mk (-a)) $
- λ a b h, (quotient.eq p).2 $ by simpa using neg_mem h⟩
-
 @[simp] theorem mk_neg : (mk (-x) : M ⧸ p) = -mk x := rfl
 
-instance : has_sub (M ⧸ p) :=
-⟨λ a b, quotient.lift_on₂' a b (λ a b, mk (a - b)) $
-  λ a₁ a₂ b₁ b₂ h₁ h₂, (quotient.eq p).2 $
-  by simpa [sub_eq_add_neg, add_left_comm, add_comm] using add_mem h₁ (neg_mem h₂)⟩
-
 @[simp] theorem mk_sub : (mk (x - y) : M ⧸ p) = mk x - mk y := rfl
-
-instance add_comm_group : add_comm_group (M ⧸ p) :=
-{ zero := (0 : M ⧸ p),
-  add := (+),
-  neg := has_neg.neg,
-  sub := has_sub.sub,
-  add_assoc := by { rintros ⟨x⟩ ⟨y⟩ ⟨z⟩, simp only [←mk_add p, quot_mk_eq_mk, add_assoc] },
-  zero_add := by { rintro ⟨x⟩, simp only [←mk_zero p, ←mk_add p, quot_mk_eq_mk, zero_add] },
-  add_zero := by { rintro ⟨x⟩, simp only [←mk_zero p, ←mk_add p, add_zero, quot_mk_eq_mk] },
-  add_comm := by { rintros ⟨x⟩ ⟨y⟩, simp only [←mk_add p, quot_mk_eq_mk, add_comm] },
-  add_left_neg := by { rintro ⟨x⟩,
-    simp only [←mk_zero p, ←mk_add p, ←mk_neg p, quot_mk_eq_mk, add_left_neg] },
-  sub_eq_add_neg := by { rintros ⟨x⟩ ⟨y⟩,
-    simp only [←mk_add p, ←mk_neg p, ←mk_sub p, sub_eq_add_neg, quot_mk_eq_mk] },
-  nsmul := λ n x, quotient.lift_on' x (λ x, mk (n • x)) $
-     λ x y h, (quotient.eq p).2 $ by simpa [smul_sub] using smul_of_tower_mem p n h,
-  nsmul_zero' := by { rintros ⟨⟩, simp only [mk_zero, quot_mk_eq_mk, zero_smul], refl },
-  nsmul_succ' := by { rintros n ⟨⟩,
-    simp only [nat.succ_eq_one_add, add_nsmul, mk_add, quot_mk_eq_mk, one_nsmul], refl },
-  zsmul := λ n x, quotient.lift_on' x (λ x, mk (n • x)) $
-     λ x y h, (quotient.eq p).2 $ by simpa [smul_sub] using smul_of_tower_mem p n h,
-  zsmul_zero' := by { rintros ⟨⟩, simp only [mk_zero, quot_mk_eq_mk, zero_smul], refl },
-  zsmul_succ' := by { rintros n ⟨⟩,
-    simp [nat.succ_eq_add_one, add_nsmul, mk_add, quot_mk_eq_mk, one_nsmul, add_smul, add_comm],
-    refl },
-  zsmul_neg' := by { rintros n ⟨x⟩, simp_rw [zsmul_neg_succ_of_nat, coe_nat_zsmul], refl }, }
 
 section has_scalar
 
@@ -221,10 +190,8 @@ linear_map.ext $ λ x, quotient.induction_on' x $ (linear_map.congr_fun h : _)
 /-- The map from the quotient of `M` by a submodule `p` to `M₂` induced by a linear map `f : M → M₂`
 vanishing on `p`, as a linear map. -/
 def liftq (f : M →ₛₗ[τ₁₂] M₂) (h : p ≤ f.ker) : M ⧸ p →ₛₗ[τ₁₂] M₂ :=
-{ to_fun := λ x, _root_.quotient.lift_on' x f $
-    λ a b (ab : a - b ∈ p), eq_of_sub_eq_zero $ by simpa using h ab,
-  map_add' := by rintro ⟨x⟩ ⟨y⟩; exact f.map_add x y,
-  map_smul' := by rintro a ⟨x⟩; exact f.map_smulₛₗ a x }
+{ map_smul' := by rintro a ⟨x⟩; exact f.map_smulₛₗ a x,
+  ..quotient_add_group.lift p.to_add_subgroup f.to_add_monoid_hom h }
 
 @[simp] theorem liftq_apply (f : M →ₛₗ[τ₁₂] M₂) {h} (x : M) :
   p.liftq f h (quotient.mk x) = f x := rfl

--- a/src/ring_theory/ideal/operations.lean
+++ b/src/ring_theory/ideal/operations.lean
@@ -1391,7 +1391,7 @@ ideal.quotient.lift_mk _ _ _
 /-- The induced map from the quotient by the kernel is injective. -/
 lemma ker_lift_injective (f : R →+* S) : function.injective (ker_lift f) :=
 assume a b, quotient.induction_on₂' a b $
-  assume a b (h : f a = f b), quotient.sound' $
+  assume a b (h : f a = f b), ideal.quotient.eq.2 $
 show a - b ∈ ker f, by rw [mem_ker, map_sub, h, sub_self]
 
 variable {f}

--- a/src/ring_theory/valuation/basic.lean
+++ b/src/ring_theory/valuation/basic.lean
@@ -391,8 +391,8 @@ Note: it's just the function; the valuation is `on_quot hJ`. -/
 def on_quot_val {J : ideal R} (hJ : J ≤ supp v) :
   R ⧸ J → Γ₀ :=
 λ q, quotient.lift_on' q v $ λ a b h,
-calc v a = v (b + (a - b)) : by simp
-     ... = v b             : v.map_add_supp b (hJ h)
+calc v a = v (b + -(-a + b)) : by simp
+     ... = v b             : v.map_add_supp b ((ideal.neg_mem_iff _).2 $ hJ h)
 
 /-- The extension of valuation v on R to valuation on R/J if J ⊆ supp v -/
 def on_quot {J : ideal R} (hJ : J ≤ supp v) :
@@ -405,12 +405,7 @@ def on_quot {J : ideal R} (hJ : J ≤ supp v) :
 
 @[simp] lemma on_quot_comap_eq {J : ideal R} (hJ : J ≤ supp v) :
   (v.on_quot hJ).comap (ideal.quotient.mk J) = v :=
-ext $ λ r,
-begin
-  refine @quotient.lift_on_mk _ _ (J.quotient_rel) v (λ a b h, _) _,
-  calc v a = v (b + (a - b)) : by simp
-       ... = v b             : v.map_add_supp b (hJ h)
-end
+ext $ λ r, rfl
 
 lemma comap_supp {S : Type*} [comm_ring S] (f : S →+* R) :
   supp (v.comap f) = ideal.comap f v.supp :=

--- a/src/topology/algebra/uniform_ring.lean
+++ b/src/topology/algebra/uniform_ring.lean
@@ -157,7 +157,8 @@ namespace uniform_space
 variables {α : Type*}
 lemma ring_sep_rel (α) [comm_ring α] [uniform_space α] [uniform_add_group α] [topological_ring α] :
   separation_setoid α = submodule.quotient_rel (ideal.closure ⊥) :=
-setoid.ext $ assume x y, add_group_separation_rel x y
+setoid.ext $ λ x y, (add_group_separation_rel x y).trans $
+  iff.trans (by refl) (submodule.quotient_rel_r_def _).symm
 
 lemma ring_sep_quot
   (α : Type u) [r : comm_ring α] [uniform_space α] [uniform_add_group α] [topological_ring α] :
@@ -170,7 +171,8 @@ corresponding to the closure of zero. -/
 def sep_quot_equiv_ring_quot (α)
   [r : comm_ring α] [uniform_space α] [uniform_add_group α] [topological_ring α] :
   quotient (separation_setoid α) ≃ (α ⧸ (⊥ : ideal α).closure) :=
-quotient.congr_right $ assume x y, add_group_separation_rel x y
+quotient.congr_right $ λ x y, (add_group_separation_rel x y).trans $
+  iff.trans (by refl) (submodule.quotient_rel_r_def _).symm
 
 /- TODO: use a form of transport a.k.a. lift definition a.k.a. transfer -/
 instance comm_ring [comm_ring α] [uniform_space α] [uniform_add_group α] [topological_ring α] :


### PR DESCRIPTION
This means that the quotient by `p` and `p.to_add_subgroup` are defeq as types, and the instances defined on them are defeq too.

This removes a TODO comment by Mario; I can only assume it resolves it in the right direction


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
