### PR TITLE
[Merged by Bors] - chore(analysis/convex): move `convex_on_norm`, change API

### DIFF
--- a/src/analysis/convex/specific_functions.lean
+++ b/src/analysis/convex/specific_functions.lean
@@ -32,14 +32,6 @@ For `p : ℝ`, prove that `λ x, x ^ p` is concave when `0 ≤ p ≤ 1` and stri
 open real set
 open_locale big_operators
 
-/-- The norm of a real normed space is convex. Also see `seminorm.convex_on`. -/
-lemma convex_on_norm {E : Type*} [normed_group E] [normed_space ℝ E] :
-  convex_on ℝ univ (norm : E → ℝ) :=
-⟨convex_univ, λ x y hx hy a b ha hb hab,
-  calc ∥a • x + b • y∥ ≤ ∥a • x∥ + ∥b • y∥ : norm_add_le _ _
-    ... = a * ∥x∥ + b * ∥y∥
-        : by rw [norm_smul, norm_smul, real.norm_of_nonneg ha, real.norm_of_nonneg hb]⟩
-
 /-- `exp` is strictly convex on the whole real line. -/
 lemma strict_convex_on_exp : strict_convex_on ℝ univ exp :=
 strict_convex_on_univ_of_deriv2_pos differentiable_exp (λ x, (iter_deriv_exp 2).symm ▸ exp_pos x)

--- a/src/analysis/convex/topology.lean
+++ b/src/analysis/convex/topology.lean
@@ -314,7 +314,7 @@ by simpa only [metric.closed_ball, sep_univ] using (convex_on_univ_dist a).conve
 of `s` at distance at least `dist x y` from `y`. -/
 lemma convex_hull_exists_dist_ge {s : set E} {x : E} (hx : x ∈ convex_hull ℝ s) (y : E) :
   ∃ x' ∈ s, dist x y ≤ dist x' y :=
-(convex_on_dist y _ (convex_convex_hull ℝ _)).exists_ge_of_mem_convex_hull hx
+(convex_on_dist y (convex_convex_hull ℝ _)).exists_ge_of_mem_convex_hull hx
 
 /-- Given a point `x` in the convex hull of `s` and a point `y` in the convex hull of `t`,
 there exist points `x' ∈ s` and `y' ∈ t` at distance at least `dist x y`. -/

--- a/src/analysis/convex/topology.lean
+++ b/src/analysis/convex/topology.lean
@@ -296,13 +296,13 @@ lemma convex_on_norm {s : set E} (hs : convex ℝ s) : convex_on ℝ s norm :=
 and `convex_on_norm`. -/
 lemma convex_on_univ_norm : convex_on ℝ univ (norm : E → ℝ) := convex_on_norm convex_univ
 
-lemma convex_on_dist (z : E) (s : set E) (hs : convex ℝ s) : convex_on ℝ s (λz', dist z' z) :=
+lemma convex_on_dist (z : E) {s : set E} (hs : convex ℝ s) : convex_on ℝ s (λz', dist z' z) :=
 by simpa [dist_eq_norm, preimage_preimage]
   using (convex_on_norm (hs.translate (-z))).comp_affine_map
     (affine_map.id ℝ E - affine_map.const ℝ E z)
 
 lemma convex_on_univ_dist (z : E) : convex_on ℝ univ (λz', dist z' z) :=
-convex_on_dist z univ convex_univ
+convex_on_dist z convex_univ
 
 lemma convex_ball (a : E) (r : ℝ) : convex ℝ (metric.ball a r) :=
 by simpa only [metric.ball, sep_univ] using (convex_on_univ_dist a).convex_lt r

--- a/src/analysis/convex/topology.lean
+++ b/src/analysis/convex/topology.lean
@@ -18,9 +18,9 @@ We prove the following facts:
 * `convex.closure` : closure of a convex set is convex;
 * `set.finite.compact_convex_hull` : convex hull of a finite set is compact;
 * `set.finite.is_closed_convex_hull` : convex hull of a finite set is closed;
-* `covnex_on_norm`, `convex_on_dist` : norm and distance to a fixed point is convex on any convex
+* `convex_on_norm`, `convex_on_dist` : norm and distance to a fixed point is convex on any convex
   set;
-* `covnex_on_univ_norm`, `convex_on_univ_dist` : norm and distance to a fixed point is convex on
+* `convex_on_univ_norm`, `convex_on_univ_dist` : norm and distance to a fixed point is convex on
   the whole space;
 * `convex_hull_ediam`, `convex_hull_diam` : convex hull of a set has the same (e)metric diameter
   as the original set;
@@ -284,7 +284,7 @@ end has_continuous_smul
 section normed_space
 variables [semi_normed_group E] [normed_space ℝ E]
 
-/-- The norm on a real normed space is convex on any convex set.. See also `seminorm.convex_on`
+/-- The norm on a real normed space is convex on any convex set. See also `seminorm.convex_on`
 and `convex_on_univ_norm`. -/
 lemma convex_on_norm {s : set E} (hs : convex ℝ s) : convex_on ℝ s norm :=
 ⟨hs, λ x y hx hy a b ha hb hab,

--- a/src/analysis/convex/topology.lean
+++ b/src/analysis/convex/topology.lean
@@ -18,7 +18,10 @@ We prove the following facts:
 * `convex.closure` : closure of a convex set is convex;
 * `set.finite.compact_convex_hull` : convex hull of a finite set is compact;
 * `set.finite.is_closed_convex_hull` : convex hull of a finite set is closed;
-* `convex_on_dist` : distance to a fixed point is convex on any convex set;
+* `covnex_on_norm`, `convex_on_dist` : norm and distance to a fixed point is convex on any convex
+  set;
+* `covnex_on_univ_norm`, `convex_on_univ_dist` : norm and distance to a fixed point is convex on
+  the whole space;
 * `convex_hull_ediam`, `convex_hull_diam` : convex hull of a set has the same (e)metric diameter
   as the original set;
 * `bounded_convex_hull` : convex hull of a set is bounded if and only if the original set
@@ -279,28 +282,33 @@ end has_continuous_smul
 /-! ### Normed vector space -/
 
 section normed_space
-variables [normed_group E] [normed_space ℝ E]
+variables [semi_normed_group E] [normed_space ℝ E]
 
-lemma convex_on_dist (z : E) (s : set E) (hs : convex ℝ s) :
-  convex_on ℝ s (λz', dist z' z) :=
-and.intro hs $
-assume x y hx hy a b ha hb hab,
-calc
-  dist (a • x + b • y) z = ∥ (a • x + b • y) - (a + b) • z ∥ :
-    by rw [hab, one_smul, normed_group.dist_eq]
-  ... = ∥a • (x - z) + b • (y - z)∥ :
-    by rw [add_smul, smul_sub, smul_sub, sub_eq_add_neg, sub_eq_add_neg, sub_eq_add_neg, neg_add,
-           ←add_assoc, add_assoc (a • x), add_comm (b • y)]; simp only [add_assoc]
-  ... ≤ ∥a • (x - z)∥ + ∥b • (y - z)∥ :
-    norm_add_le (a • (x - z)) (b • (y - z))
-  ... = a * dist x z + b * dist y z :
-    by simp [norm_smul, normed_group.dist_eq, real.norm_eq_abs, abs_of_nonneg ha, abs_of_nonneg hb]
+/-- The norm on a real normed space is convex on any convex set.. See also `seminorm.convex_on`
+and `convex_on_univ_norm`. -/
+lemma convex_on_norm {s : set E} (hs : convex ℝ s) : convex_on ℝ s norm :=
+⟨hs, λ x y hx hy a b ha hb hab,
+  calc ∥a • x + b • y∥ ≤ ∥a • x∥ + ∥b • y∥ : norm_add_le _ _
+    ... = a * ∥x∥ + b * ∥y∥
+        : by rw [norm_smul, norm_smul, real.norm_of_nonneg ha, real.norm_of_nonneg hb]⟩
+
+/-- The norm on a real normed space is convex on the whole space. See also `seminorm.convex_on`
+and `convex_on_norm`. -/
+lemma convex_on_univ_norm : convex_on ℝ univ (norm : E → ℝ) := convex_on_norm convex_univ
+
+lemma convex_on_dist (z : E) (s : set E) (hs : convex ℝ s) : convex_on ℝ s (λz', dist z' z) :=
+by simpa [dist_eq_norm, preimage_preimage]
+  using (convex_on_norm (hs.translate (-z))).comp_affine_map
+    (affine_map.id ℝ E - affine_map.const ℝ E z)
+
+lemma convex_on_univ_dist (z : E) : convex_on ℝ univ (λz', dist z' z) :=
+convex_on_dist z univ convex_univ
 
 lemma convex_ball (a : E) (r : ℝ) : convex ℝ (metric.ball a r) :=
-by simpa only [metric.ball, sep_univ] using (convex_on_dist a _ convex_univ).convex_lt r
+by simpa only [metric.ball, sep_univ] using (convex_on_univ_dist a).convex_lt r
 
 lemma convex_closed_ball (a : E) (r : ℝ) : convex ℝ (metric.closed_ball a r) :=
-by simpa only [metric.closed_ball, sep_univ] using (convex_on_dist a _ convex_univ).convex_le r
+by simpa only [metric.closed_ball, sep_univ] using (convex_on_univ_dist a).convex_le r
 
 /-- Given a point `x` in the convex hull of `s` and a point `y`, there exists a point
 of `s` at distance at least `dist x y` from `y`. -/


### PR DESCRIPTION
* Move `convex_on_norm` from `specific_functions` to `topology`, use it to golf the proof of `convex_on_dist`.
* The old `convex_on_norm` is now called `convex_on_univ_norm`. The new `convex_on_norm` is about convexity on any convex set.
* Add `convex_on_univ_dist` and make `s : set E` an implicit argument in `convex_on_dist`.

This way APIs about convexity of norm and distance agree.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
