### PR TITLE
Complete the computable version of `real.sqrt`

### DIFF
--- a/src/data/real/sqrt.lean
+++ b/src/data/real/sqrt.lean
@@ -471,7 +471,7 @@ begin
   have t : 0 < 2 * δ := by linarith,
 
   by_cases δ < 3 * ε,
-  { exact or.inr h, },
+  { right, exact h, },
   left, simp at h,
 
   calc (δ + ε) ^ 2 / (4 * sqrt_aux f k ^ 2)
@@ -538,9 +538,9 @@ end
 | (j + 1) pr :=
 begin
   by_cases j + 1 = k,
-  { rw h,
+  { left,
+    rw h,
     have answer := converges_eventually_or_near_step f N f_ge_0 ε ε_pos f_near k k_large,
-    left,
     simp, },
   { have pr : j + 1 > k := (ne.symm h).le_iff_lt.mp pr,
     specialize converges_eventually_or_near_step' j (nat.lt_succ_iff.mp pr),
@@ -737,8 +737,7 @@ begin
   { left, exact h, },
   { right,
     have h := stays_near_if_near'' f N f_ge_0 ε ε_pos f_near k k_large is_near (by linarith),
-    intros m, exact h m m rfl.ge,
-  }
+    intros m, exact h m m rfl.ge, },
 end
 
 theorem shrink_is_one (c : ℚ) (small : ∀ m, c ≤ shrink m) : c ≤ 1 :=
@@ -757,17 +756,31 @@ begin
     sorry, },
 end
 
-theorem stays_near_if_near (f : cau_seq ℚ abs) (N : ℕ) (f_ge_0 : ∀ i ≥ N, 0 ≤ f i)
+theorem it_is_the_one (f : cau_seq ℚ abs) (N : ℕ) (f_ge_0 : ∀ i ≥ N, 0 ≤ f i)
   (ε : ℚ) (ε_pos : 0 < ε) (f_near : ∀ i ≥ N, ∀ j ≥ N, abs (f i - f j) ≤ ε)
-  (k : ℕ) (k_large : k ≥ N) (is_near : sqrt_aux f k ^ 2 - f k ≤ 3 * ε) :
+  (k : ℕ) (k_large : N ≤ k) (is_near : sqrt_aux f k ^ 2 - f k ≤ 3 * ε):
   sqrt_aux f (k + 1) ^ 2 - f (k + 1) ≤ 3 * ε :=
 begin
-  rcases stays_near_if_near_2 f N f_ge_0 ε ε_pos f_near k k_large is_near with done | small,
-  { exact done, },
-  { have u := converges_eventually_if_near_step f N f_ge_0 ε ε_pos f_near k k_large,
-    clear is_near,
-    sorry,
-  }
+  have u := converges_eventually_if_near_step f N f_ge_0 ε ε_pos f_near k k_large,
+  let m := (4 : ℚ) / 3,
+  by_cases sqrt_aux f k ^ 2 ≥ m * ε,
+  { have l : 4 * sqrt_aux f k ^ 2 ≥ 4 * m * ε := by linarith,
+    calc sqrt_aux f (k + 1) ^ 2 - f (k + 1)
+          ≤ (sqrt_aux f k ^ 2 - f k + ε) ^ 2 / (4 * sqrt_aux f k ^ 2) : u
+      ... ≤ (sqrt_aux f k ^ 2 - f k + ε) ^ 2 / (4 * m * ε) : sorry
+      ... ≤ (3 * ε + ε) ^ 2 / (4 * m * ε) : sorry
+      ... ≤ (4 * ε) ^ 2 / (4 * m * ε) : sorry
+      ... = 16 * ε * ε / (4 * m * ε) : sorry
+      ... = 16 * ε / (4 * m) : sorry
+      ... = 16 / (4 * m) * ε : sorry
+      ... = (4 * 4) / (4 * m) * ε : sorry
+      ... = 4 / m * ε : sorry
+      ... = 3 * ε : sorry
+  },
+  { simp at h,
+    -- Since sk^2 is small, sk^2 >= sk
+    have r : sqrt_aux f k ^ 2 ≥ sqrt_aux f k := by sorry,
+   }
 end
 
 #exit

--- a/src/data/real/sqrt.lean
+++ b/src/data/real/sqrt.lean
@@ -564,20 +564,36 @@ begin
       exact found, }, },
 end
 
+theorem pull_neg {P : ℕ → Prop} {Q : Prop} (k : ℕ) (f : ∀ j ≥ k, P j ∨ Q) : (∀ j ≥ k, P j) ∨ Q :=
+begin
+  by_contradiction,
+  push_neg at h,
+  rcases h with ⟨⟨j, ⟨j_big, p_holds⟩⟩, other⟩,
+  specialize f j j_big,
+  cases f,
+  { exact p_holds f, },
+  { exact other f, },
+end
+
 theorem decreasing_and_nonneg (f : ℕ → ℚ) (N : ℕ)
   (nonneg : ∀ k ≥ N, 0 ≤ f k) (decreasing : ∀ k ≥ N, f (k + 1) ≤ f k / 2) :
   ∀ ε > 0, ∃ n ≥ N, ∀ m ≥ n, f m < ε :=
 begin
-  sorry,
+  library_search
 end
 
 theorem global_decreasing (f : cau_seq ℚ abs) (N : ℕ) (f_ge_0 : ∀ i ≥ N, 0 ≤ f i)
   (ε : ℚ) (ε_pos : 0 < ε) (f_near : ∀ i ≥ N, ∀ j ≥ N, abs (f i - f j) ≤ ε) :
   (∀ (k ≥ N), sqrt_aux f (k + 1) ^ 2 - f (k + 1) ≤ (sqrt_aux f k ^ 2 - f k) / 2) ∨ ∃ k ≥ N, (sqrt_aux f k ^ 2 - f k) < 3 * ε :=
 begin
-  by_contradiction,
-  push_neg at h,
-
+  refine pull_neg N _,
+  intros j j_big,
+  have u := converges_eventually_or_near_step' f N f_ge_0 ε ε_pos f_near j j_big (j + 1) (by norm_num),
+  rcases u with step | ⟨l, l_big, pr⟩,
+  { rw [add_tsub_cancel_left j 1, pow_one] at step,
+    left, exact step, },
+  { right,
+    exact ⟨l, by linarith, pr⟩, },
 end
 
 theorem sqrt_aux_eventually_gets_near (f : cau_seq ℚ abs) (N : ℕ) (f_ge_0 : ∀ i ≥ N, 0 ≤ f i)

--- a/src/data/real/sqrt.lean
+++ b/src/data/real/sqrt.lean
@@ -117,34 +117,13 @@ begin
     ... = (a + b) ^ 2 - 4 * a * b : by ring,
 end
 
-lemma div_mul_eq {a c : ℚ} (c_nonzero : c ≠ 0) : a / c * c = a :=
-calc a / c * c = a * c / c : (mul_div_right_comm a c c).symm
-  ... = a * (c / c) : (mul_div a c c).symm
-  ... = a * 1 : by rw (div_self c_nonzero)
-  ... = a : mul_one a
-
-lemma thing3 {a : ℚ} (a_nonzero : a ≠ 0) : a ^ 2 / a = a :=
-calc a ^ 2 / a = (a * a) / a : by ring
-  ... = a * (a / a) : mul_div_assoc a a a
-  ... = a * 1 : by rw (div_self a_nonzero)
-  ... = a : mul_one a
-
-theorem ttt (a b : ℚ) (h : 0 ≤ a) (j : a + b ≤ 0) : b ≤ 0 :=
-calc b ≤ a + b : le_add_of_nonneg_left h
-  ... ≤ 0 : j
-
-theorem fooooo {a b : ℚ} (h1 : 0 < b) (h2 : a ≤ 0) : a * b ≤ 0 :=
-begin
-  by_cases a = 0,
-  { subst h, simp, },
-  { have a_neg : a < 0 := (ne.le_iff_lt h).mp h2,
-    exact le_of_lt (mul_neg_of_neg_of_pos a_neg h1), },
-end
+lemma sq_div_self {a : ℚ} (a_nonzero : a ≠ 0) : a ^ 2 / a = a :=
+by rw [pow_two, div_eq_iff a_nonzero]
 
 theorem uuu {a b : ℚ} (h : 0 < b) (j : a / b ≤ 0) : a ≤ 0 :=
 begin
-  calc a = a / b * b : (div_mul_eq (ne_of_gt h)).symm
-    ... ≤ 0 : fooooo h j
+  calc a = a / b * b : ((eq_div_iff (ne_of_gt h)).mp rfl).symm
+    ... ≤ 0 : by nlinarith
 end
 
 theorem sqrt_aux_overestimate (f : cau_seq ℚ abs) {i : ℕ} (i_pos : 0 < i) :
@@ -164,26 +143,21 @@ begin
         calc 4 * f (i + 1) * sqrt_aux f i ^ 2
               ≤ (f (i + 1) + sqrt_aux f i ^ 2) ^ 2 : rat.cauchy_schwarz _ _
           ... = (sqrt_aux f i ^ 2 + f (i + 1)) ^ 2 : by ring
-          ... = (sqrt_aux f i ^ 2 / sqrt_aux f i * sqrt_aux f i + f (i + 1)) ^ 2 : by rw div_mul_eq nonzero
-          ... = (sqrt_aux f i ^ 2 / sqrt_aux f i * sqrt_aux f i + f (i + 1) / sqrt_aux f i * sqrt_aux f i) ^ 2 : by rw @div_mul_eq (f (i + 1)) _ nonzero
+          ... = (sqrt_aux f i ^ 2 / sqrt_aux f i * sqrt_aux f i + f (i + 1)) ^ 2 : by rw (eq_div_iff nonzero).mp rfl
+          ... = (sqrt_aux f i ^ 2 / sqrt_aux f i * sqrt_aux f i + f (i + 1) / sqrt_aux f i * sqrt_aux f i) ^ 2 : by rw (@eq_div_iff _ _ (f (i + 1)) _ _ nonzero).mp rfl
           ... = (sqrt_aux f i ^ 2 / sqrt_aux f i + f (i + 1) / sqrt_aux f i) ^ 2 * sqrt_aux f i ^ 2 : by ring
-          ... = (sqrt_aux f i + f (i + 1) / sqrt_aux f i) ^ 2 * sqrt_aux f i ^ 2 : by rw thing3 nonzero, }, },
+          ... = (sqrt_aux f i + f (i + 1) / sqrt_aux f i) ^ 2 * sqrt_aux f i ^ 2 : by rw sq_div_self nonzero, }, },
     { rw max_eq_left s,
       simp only [zero_pow', ne.def, bit0_eq_zero, nat.one_ne_zero, not_false_iff],
       simp only [ge_iff_le] at s,
       cases lt_or_ge 0 (sqrt_aux f i),
       { rw div_le_iff at s,
         { simp at s,
-          have u : f (i + 1) / sqrt_aux f i ≤ 0 := ttt (sqrt_aux f i) (f (i + 1) / sqrt_aux f i) _ s,
+          have u : f (i + 1) / sqrt_aux f i ≤ 0 := le_of_add_le_of_nonneg_right s _,
           { left, exact uuu h u, },
           { exact sqrt_aux_nonneg f i, }, },
         { norm_num, }, },
       { right, exact s, }, }, },
-end
-
-lemma blaaaah {a b c : ℚ} (b_pos : 0 < b) (h : a ≤ b * c) : a / b ≤ c :=
-begin
-  sorry,
 end
 
 /-- The sqrt_aux corresponding to decreasing Cauchy sequences is decreasing. -/
@@ -198,27 +172,11 @@ begin
     { cancel_denoms,
       rw two_mul,
       simp,
-      refine blaaaah (all_pos i) _,
+      refine (div_le_iff' (all_pos i)).mpr _,
       calc f (i + 1) ≤ f i : f_decreasing i
         ... ≤ sqrt_aux f i ^ 2 : h
         ... = sqrt_aux f i * sqrt_aux f i : sq _ }, },
   { specialize all_pos i, linarith, },
-end
-
-theorem nat_gcd_eq_zero_iff (a b : ℕ) : a.gcd b = 0 ↔ a = 0 ∧ b = 0 :=
-begin
-  split,
-  { intros gcd_eq_zero,
-    induction a,
-    { simp at gcd_eq_zero,
-      exact ⟨rfl, gcd_eq_zero⟩, },
-    { exfalso,
-      rw nat.gcd_succ at gcd_eq_zero,
-      simp at gcd_eq_zero,
-      exact gcd_eq_zero, }, },
-  { rintros ⟨a_eq_zero, b_eq_zero⟩,
-    rw [a_eq_zero, b_eq_zero],
-    exact nat.gcd_zero_left _, },
 end
 
 /-- If f is positive, then sqrt_aux f is positive. -/
@@ -244,7 +202,7 @@ begin
       apply nat.div_pos,
       { exact (nat.sqrt denom).gcd_le_left sqrt_num_pos, },
       { rcases @eq_zero_or_pos _ _ ((nat.sqrt num).gcd (nat.sqrt denom)),
-        { rw nat_gcd_eq_zero_iff at h,
+        { rw nat.gcd_eq_zero_iff at h,
           rcases h with ⟨num_zero, denom_zero⟩,
           rw [denom_zero] at sqrt_denom_pos,
           linarith, },

--- a/src/data/real/sqrt.lean
+++ b/src/data/real/sqrt.lean
@@ -579,7 +579,7 @@ theorem decreasing_and_nonneg (f : ℕ → ℚ) (N : ℕ)
   (nonneg : ∀ k ≥ N, 0 ≤ f k) (decreasing : ∀ k ≥ N, f (k + 1) ≤ f k / 2) :
   ∀ ε > 0, ∃ n ≥ N, ∀ m ≥ n, f m < ε :=
 begin
-  library_search
+  sorry
 end
 
 theorem global_decreasing (f : cau_seq ℚ abs) (N : ℕ) (f_ge_0 : ∀ i ≥ N, 0 ≤ f i)
@@ -615,32 +615,30 @@ theorem stays_near_if_near_step (f : cau_seq ℚ abs) (N : ℕ) (f_ge_0 : ∀ i 
   (k : ℕ) (k_large : k ≥ N) (is_near : sqrt_aux f k ^ 2 - f k < 3 * ε)
   : sqrt_aux f (k + 1) ^ 2 - f (k + 1) < 3 * ε :=
 begin
-  by_cases sqrt_aux_big: sqrt_aux f k > 1 / 2,
-  { have r : 1 < 4 * sqrt_aux f k ^ 2,
-    { have r : 1 < 2 * sqrt_aux f k := by linarith [sqrt_aux_big],
-      have s : 2 * sqrt_aux f k > 0 := by linarith,
-      calc (1 : ℚ) = (1 : ℚ) * (1 : ℚ) : by norm_num
-        ... < (2 * sqrt_aux f k) * (2 * sqrt_aux f k) : mul_lt_mul r (le_of_lt r) (by norm_num) (le_of_lt s)
-        ... = 4 * sqrt_aux f k ^ 2 : by ring, },
-    have t : 16 * ε ^ 2 ≤ 3 * ε,
-    calc 16 * ε ^ 2 = 16 * ε * ε : by ring
-      ... ≤ 3 * ε : (mul_le_mul_right ε_pos).mpr ε_smallish,
+  have bound_pos : 0 < 16 / 3 * ε := by linarith,
+  by_cases sqrt_aux_big: sqrt_aux f k ^ 2 > 16 / 3 * ε,
+  { have r : 16 / 3 * ε < 4 * sqrt_aux f k ^ 2 := by linarith,
     have u : 0 ≤ sqrt_aux f k ^ 2 - f k + ε := by linarith [sqrt_aux_overestimate' f k],
-    have r' : 0 < 4 * sqrt_aux f k ^ 2 := by linarith,
+    have r' : 0 < 4 * sqrt_aux f k ^ 2 := mul_pos (by norm_num) (sq_pos_of_pos (sqrt_aux_pos f k)),
     have num_pos : 0 ≤ ((sqrt_aux f k ^ 2 - f k) + ε) ^ 2 := sq_nonneg _,
     have one_pos : (0 : ℚ) < 1 := by norm_num,
+    have four_pos : (0 : ℚ) < 4 := by norm_num,
     calc _ ≤ ((sqrt_aux f k ^ 2 - f k) + ε) ^ 2 / (4 * sqrt_aux f k ^ 2) : converges_eventually_if_near_step f N f_ge_0 ε ε_pos f_near k k_large
-      ... ≤ ((sqrt_aux f k ^ 2 - f k) + ε) ^ 2 / 1 : div_le_div (sq_nonneg _) (le_of_eq rfl) one_pos (le_of_lt r)
-      ... = ((sqrt_aux f k ^ 2 - f k) + ε) ^ 2 : by rw div_one
-      ... < (3 * ε + ε) ^ 2 : begin
+      ... ≤ ((sqrt_aux f k ^ 2 - f k) + ε) ^ 2 / (16 / 3 * ε) : div_le_div (sq_nonneg _) (le_of_eq rfl) bound_pos (le_of_lt r)
+      ... < ((3 * ε + ε) ^ 2) / (16 / 3 * ε) : begin
+        refine (div_lt_div_right bound_pos).2 _,
         apply sq_lt_sq,
         have r : 0 ≤ 3 * ε + ε := by linarith,
         rw abs_eq_self.2 r,
         rw abs_eq_self.2 u,
         linarith,
       end
-      ... = 16 * ε ^ 2 : by ring
-      ... ≤ 3 * ε : t, },
+      ... = (16 * ε ^ 2) / (16 / 3 * ε) : by ring
+      ... = (16 * ε ^ 2) / (16 / 3) / ε : by field_simp
+      ... = (16 * ε ^ 2) * (3 / 16) / ε : by field_simp
+      ... = (3 * ε) * (ε / ε) : by ring
+      ... = (3 * ε) * 1 : by rw div_self (ne_of_gt ε_pos)
+      ... = 3 * ε : by field_simp, },
   { simp at sqrt_aux_big,
     have r : _ := converges_eventually_if_near_step f N f_ge_0 ε ε_pos f_near k k_large,
     sorry,

--- a/src/data/real/sqrt.lean
+++ b/src/data/real/sqrt.lean
@@ -170,7 +170,7 @@ begin
 end
 
 theorem sqrt_aux_zero_iff (f : cau_seq ℚ abs) (i : ℕ) :
-  sqrt_aux f (i + 1) = 0 ↔ sqrt_aux f i = 0 ∨ f (i + 1) ≤ - (sqrt_aux f i) ^ 2 :=
+  sqrt_aux f (i + 1) = 0 ↔ sqrt_aux f i = 0 ∨ f (i + 1) ≤ - ((sqrt_aux f i) ^ 2) :=
 begin
   split,
   { intros sqrt_aux_zero,
@@ -201,8 +201,8 @@ begin
         have thing : sqrt_aux f i * sqrt_aux f i + f (i + 1) ≤ 0 := by linarith,
         calc sqrt_aux f i + f (i + 1) / sqrt_aux f i
           = sqrt_aux f i * sqrt_aux f i / sqrt_aux f i + f (i + 1) / sqrt_aux f i : by simp
-          ... = (sqrt_aux f i * sqrt_aux f i + f (i + 1)) / sqrt_aux f i : div_add_div_same (sqrt_aux f i * sqrt_aux f i) (⇑f (i + 1)) (sqrt_aux f i)
-          ... ≤ 0 : blah _ _, }, }, },
+          ... = (sqrt_aux f i * sqrt_aux f i + f (i + 1)) / sqrt_aux f i : div_add_div_same (sqrt_aux f i * sqrt_aux f i) _ (sqrt_aux f i)
+          ... ≤ 0 : blah thing sqrt_aux_pos, }, }, },
 end
 
 /-- The sqrt_aux corresponding to decreasing Cauchy sequences is decreasing. -/

--- a/src/data/real/sqrt.lean
+++ b/src/data/real/sqrt.lean
@@ -181,6 +181,83 @@ begin
       { right, exact s, }, }, },
 end
 
+lemma blaaaah {a b c : ℚ} (b_pos : 0 < b) (h : a ≤ b * c) : a / b ≤ c :=
+begin
+  sorry,
+end
+
+/-- The sqrt_aux corresponding to decreasing Cauchy sequences is decreasing. -/
+theorem sqrt_aux_decreasing (f : cau_seq ℚ abs) (f_decreasing : ∀ i, f (i + 1) ≤ f i)
+  {i : ℕ} (i_pos : 0 < i) (all_pos : ∀ j, 0 < sqrt_aux f j) : sqrt_aux f (i + 1) ≤ sqrt_aux f i :=
+begin
+  unfold sqrt_aux,
+  simp,
+  cases @sqrt_aux_overestimate f i i_pos,
+  { split,
+    { exact (le_of_lt (all_pos i)), },
+    { cancel_denoms,
+      rw two_mul,
+      simp,
+      refine blaaaah (all_pos i) _,
+      calc f (i + 1) ≤ f i : f_decreasing i
+        ... ≤ sqrt_aux f i ^ 2 : h
+        ... = sqrt_aux f i * sqrt_aux f i : sq _ }, },
+  { specialize all_pos i, linarith, },
+end
+
+theorem nat_gcd_eq_zero_iff (a b : ℕ) : a.gcd b = 0 ↔ a = 0 ∧ b = 0 :=
+begin
+  split,
+  { intros gcd_eq_zero,
+    induction a,
+    { simp at gcd_eq_zero,
+      exact ⟨rfl, gcd_eq_zero⟩, },
+    { exfalso,
+      rw nat.gcd_succ at gcd_eq_zero,
+      simp at gcd_eq_zero,
+      exact gcd_eq_zero, }, },
+  { rintros ⟨a_eq_zero, b_eq_zero⟩,
+    rw [a_eq_zero, b_eq_zero],
+    exact nat.gcd_zero_left _, },
+end
+
+/-- If f is positive, then sqrt_aux f is positive. -/
+theorem sqrt_aux_pos (f : cau_seq ℚ abs) (all_pos : ∀ j, 0 < f j) (i : ℕ) : 0 < sqrt_aux f i :=
+begin
+  induction i with i hyp,
+  { unfold sqrt_aux,
+    specialize all_pos 0,
+    rcases f 0,
+    intros pos2,
+    rw rat.lt_def,
+    simp,
+    rw rat.lt_def at pos2,
+    simp at pos2,
+    have sqrt_denom_pos : 0 < nat.sqrt denom := nat.sqrt_pos.mpr pos,
+    unfold rat.mk_nat, simp [ne_of_gt sqrt_denom_pos],
+    cases num,
+    { simp, simp at pos2,
+      have sqrt_num_pos : 0 < nat.sqrt num := nat.sqrt_pos.mpr pos2,
+      unfold rat.mk_pnat,
+      simp,
+      norm_cast,
+      apply nat.div_pos,
+      { exact (nat.sqrt denom).gcd_le_left sqrt_num_pos, },
+      { rcases @eq_zero_or_pos _ _ ((nat.sqrt num).gcd (nat.sqrt denom)),
+        { rw nat_gcd_eq_zero_iff at h,
+          rcases h with ⟨num_zero, denom_zero⟩,
+          rw [denom_zero] at sqrt_denom_pos,
+          linarith, },
+        { assumption, }, }, },
+    { simp at pos2, exfalso, exact pos2, }, },
+  { unfold sqrt_aux,
+    simp,
+    specialize all_pos (i + 1),
+    cancel_denoms,
+    calc 0 < sqrt_aux f i : hyp
+      ... < _ : lt_add_of_pos_right (sqrt_aux f i) (div_pos all_pos hyp), },
+end
+
 /- TODO(Mario): finish the proof
 theorem sqrt_aux_converges (f : cau_seq ℚ abs) : ∃ h x, 0 ≤ x ∧ x * x = max 0 (mk f) ∧
   mk ⟨sqrt_aux f, h⟩ = x :=

--- a/src/data/real/sqrt.lean
+++ b/src/data/real/sqrt.lean
@@ -611,7 +611,7 @@ begin
 end
 
 theorem stays_near_if_near_step (f : cau_seq ℚ abs) (N : ℕ) (f_ge_0 : ∀ i ≥ N, 0 ≤ f i)
-  (ε : ℚ) (ε_pos : 0 < ε) (ε_smallish : 16 * ε ≤ 3) (f_near : ∀ i ≥ N, ∀ j ≥ N, abs (f i - f j) ≤ ε)
+  (ε : ℚ) (ε_pos : 0 < ε) (f_near : ∀ i ≥ N, ∀ j ≥ N, abs (f i - f j) ≤ ε)
   (k : ℕ) (k_large : k ≥ N) (is_near : sqrt_aux f k ^ 2 - f k < 3 * ε)
   : sqrt_aux f (k + 1) ^ 2 - f (k + 1) < 3 * ε :=
 begin
@@ -634,7 +634,6 @@ begin
         linarith,
       end
       ... = (16 * ε ^ 2) / (16 / 3 * ε) : by ring
-      ... = (16 * ε ^ 2) / (16 / 3) / ε : by field_simp
       ... = (16 * ε ^ 2) * (3 / 16) / ε : by field_simp
       ... = (3 * ε) * (ε / ε) : by ring
       ... = (3 * ε) * 1 : by rw div_self (ne_of_gt ε_pos)

--- a/src/data/real/sqrt.lean
+++ b/src/data/real/sqrt.lean
@@ -160,6 +160,51 @@ begin
       { right, exact s, }, }, },
 end
 
+theorem fooo (a : ℚ) {b : ℚ} (b_nonzero : b ≠ 0) : a / b * b = a :=
+(eq_div_iff b_nonzero).mp rfl
+
+theorem blah {a b : ℚ} (ha : a ≤ 0) (hb : 0 < b) : a / b ≤ 0 :=
+begin
+  rw div_nonpos_iff,
+  right, exact ⟨ha, le_of_lt hb⟩,
+end
+
+theorem sqrt_aux_zero_iff (f : cau_seq ℚ abs) (i : ℕ) :
+  sqrt_aux f (i + 1) = 0 ↔ sqrt_aux f i = 0 ∨ f (i + 1) ≤ - (sqrt_aux f i) ^ 2 :=
+begin
+  split,
+  { intros sqrt_aux_zero,
+    unfold sqrt_aux at sqrt_aux_zero,
+    simp at sqrt_aux_zero,
+    rw div_le_iff at sqrt_aux_zero,
+    { simp at sqrt_aux_zero,
+      by_cases sqrt_aux f i = 0,
+      { left, assumption, },
+      { have sqrt_aux_pos : 0 < sqrt_aux f i := (ne.symm h).le_iff_lt.mp (sqrt_aux_nonneg f i),
+        have rewritten : sqrt_aux f i ^ 2 + f (i + 1) ≤ 0,
+        calc sqrt_aux f i ^ 2 + f (i + 1)
+          = (sqrt_aux f i * sqrt_aux f i + f (i + 1)) : by ring
+          ... = (sqrt_aux f i * sqrt_aux f i + f (i + 1) / sqrt_aux f i * sqrt_aux f i) : by rw fooo (f (i + 1)) h
+          ... = (sqrt_aux f i + f (i + 1) / sqrt_aux f i) * sqrt_aux f i : by ring
+          ... ≤ 0 * sqrt_aux f i : mul_mono_nonneg (sqrt_aux_nonneg f i) sqrt_aux_zero
+          ... = 0 : by ring,
+        right,
+        linarith, }, },
+    { exact two_pos, }, },
+  { rintro foo,
+    cases foo,
+    { unfold sqrt_aux, rw foo, simp, },
+    { unfold sqrt_aux, simp, cancel_denoms,
+      by_cases sqrt_aux f i = 0,
+      { rw h, simp, },
+      { have sqrt_aux_pos : 0 < sqrt_aux f i := (ne.symm h).le_iff_lt.mp (sqrt_aux_nonneg f i),
+        have thing : sqrt_aux f i * sqrt_aux f i + f (i + 1) ≤ 0 := by linarith,
+        calc sqrt_aux f i + f (i + 1) / sqrt_aux f i
+          = sqrt_aux f i * sqrt_aux f i / sqrt_aux f i + f (i + 1) / sqrt_aux f i : by simp
+          ... = (sqrt_aux f i * sqrt_aux f i + f (i + 1)) / sqrt_aux f i : div_add_div_same (sqrt_aux f i * sqrt_aux f i) (⇑f (i + 1)) (sqrt_aux f i)
+          ... ≤ 0 : blah _ _, }, }, },
+end
+
 /-- The sqrt_aux corresponding to decreasing Cauchy sequences is decreasing. -/
 theorem sqrt_aux_decreasing (f : cau_seq ℚ abs) (f_decreasing : ∀ i, f (i + 1) ≤ f i)
   {i : ℕ} (i_pos : 0 < i) (all_pos : ∀ j, 0 < sqrt_aux f j) : sqrt_aux f (i + 1) ≤ sqrt_aux f i :=

--- a/src/data/real/sqrt.lean
+++ b/src/data/real/sqrt.lean
@@ -596,6 +596,8 @@ begin
     exact ⟨l, by linarith, pr⟩, },
 end
 
+/-- `sqrt_aux` does eventually get near where it should be (though we have not yet proved that it
+stays near). -/
 theorem sqrt_aux_eventually_gets_near (f : cau_seq ℚ abs) (N : ℕ) (f_ge_0 : ∀ i ≥ N, 0 ≤ f i)
   (ε : ℚ) (ε_pos : 0 < ε) (f_near : ∀ i ≥ N, ∀ j ≥ N, abs (f i - f j) ≤ ε)
   : ∃ k ≥ N, sqrt_aux f k ^ 2 - f k < 3 * ε :=


### PR DESCRIPTION
This PR is *dramatically* not ready for merge, or even for review. I'm putting it up so that I have something to make the subject of an "anyone interested in this project" thread in Zulip.

It may or may not be useful to follow https://proofwiki.org/wiki/Hero%27s_Method.

I've redefined `sqrt_aux` from what was originally there, because the original had some nasty "coalescing at 0" properties (see https://github.com/leanprover-community/mathlib/pull/13634/commits/430413a343c03fd033e9b98186e7cd66851aeab1).

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
