### PR TITLE
[Merged by Bors] - chore(group_theory/exponent): generalise

### DIFF
--- a/src/group_theory/exponent.lean
+++ b/src/group_theory/exponent.lean
@@ -219,12 +219,6 @@ end
 have _ := exponent_ne_zero_iff_range_order_of_finite h,
 by rwa [ne.def, not_iff_comm, iff.comm] at this
 
-end monoid
-
-section left_cancel_monoid
-
-variable [left_cancel_monoid G]
-
 @[to_additive lcm_add_order_eq_exponent]
 lemma lcm_order_eq_exponent [fintype G] : (finset.univ : finset G).lcm order_of = exponent G :=
 begin
@@ -234,6 +228,12 @@ begin
   rw [hm, pow_mul, pow_order_of_eq_one, one_pow]
 end
 
+end monoid
+
+section left_cancel_monoid
+
+variable [left_cancel_monoid G]
+
 @[to_additive]
 lemma exponent_ne_zero_of_fintype [fintype G] : exponent G ≠ 0 :=
 by simpa [←lcm_order_eq_exponent, finset.lcm_eq_zero_iff] using λ x, (order_of_pos x).ne'
@@ -242,7 +242,7 @@ end left_cancel_monoid
 
 section comm_monoid
 
-variable [cancel_comm_monoid G]
+variable [comm_monoid G]
 
 @[to_additive] lemma exponent_eq_supr_order_of (h : ∀ g : G, 0 < order_of g) :
   exponent G = ⨆ g : G, order_of g :=
@@ -296,6 +296,12 @@ begin
     exact exponent_eq_supr_order_of (λ g, ne.bot_lt $ this g) }
 end
 
+end comm_monoid
+
+section cancel_comm_monoid
+
+variables [cancel_comm_monoid G]
+
 @[to_additive] lemma exponent_eq_max'_order_of [fintype G] :
   exponent G = ((@finset.univ G _).image order_of).max' ⟨1, by simp⟩ :=
 begin
@@ -303,6 +309,6 @@ begin
   exact exponent_eq_supr_order_of order_of_pos
 end
 
-end comm_monoid
+end cancel_comm_monoid
 
 end monoid


### PR DESCRIPTION
Generalises a few lemmas to not require cancellativity.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)

This was found by the generalisation linter, and was a huge surprise to me as I remember these needing the cancellation requirement! (I wrote these proofs)
