### PR TITLE
[Merged by Bors] - refactor(linear_algebra/dimension): further generalisations to division_ring

### DIFF
--- a/src/linear_algebra/affine_space/finite_dimensional.lean
+++ b/src/linear_algebra/affine_space/finite_dimensional.lean
@@ -24,12 +24,15 @@ open_locale big_operators classical affine
 
 section affine_space'
 
-variables (k : Type*) {V : Type*} {P : Type*} [field k] [add_comm_group V] [module k V]
+variables (k : Type*) {V : Type*} {P : Type*} [add_comm_group V]
           [affine_space V P]
 variables {ι : Type*}
 include V
 
 open affine_subspace finite_dimensional module
+
+section
+variables [division_ring k] [module k V]
 
 /-- The `vector_span` of a finite set is finite-dimensional. -/
 lemma finite_dimensional_vector_span_of_finite {s : set P} (h : set.finite s) :
@@ -82,6 +85,11 @@ lemma finite_of_fin_dim_affine_independent [finite_dimensional k V]
   {s : set P} (hi : affine_independent k (coe : s → P)) : s.finite :=
 ⟨fintype_of_fin_dim_affine_independent k hi⟩
 
+end
+
+section
+
+variables [field k] [module k V]
 variables {k}
 
 /-- The `vector_span` of a finite subset of an affinely independent
@@ -262,6 +270,11 @@ lemma finrank_vector_span_le_iff_not_affine_independent [fintype ι] (p : ι →
   finrank k (vector_span k (set.range p)) ≤ n ↔ ¬ affine_independent k p :=
 (not_iff_comm.1 (affine_independent_iff_not_finrank_vector_span_le k p hc).symm).symm
 
+end
+
+section division_ring
+variables [division_ring k] [module k V]
+
 /-- A set of points is collinear if their `vector_span` has dimension
 at most `1`. -/
 def collinear (s : set P) : Prop := module.rank k (vector_span k s) ≤ 1
@@ -364,6 +377,11 @@ begin
     simp [hp] }
 end
 
+end division_ring
+
+section field
+variables [field k] [module k V]
+
 /-- Three points are affinely independent if and only if they are not
 collinear. -/
 lemma affine_independent_iff_not_collinear (p : fin 3 → P) :
@@ -377,5 +395,7 @@ lemma collinear_iff_not_affine_independent (p : fin 3 → P) :
   collinear k (set.range p) ↔ ¬ affine_independent k p :=
 by rw [collinear_iff_finrank_le_one,
        finrank_vector_span_le_iff_not_affine_independent k p (fintype.card_fin 3)]
+
+end field
 
 end affine_space'

--- a/src/linear_algebra/affine_space/finite_dimensional.lean
+++ b/src/linear_algebra/affine_space/finite_dimensional.lean
@@ -24,15 +24,14 @@ open_locale big_operators classical affine
 
 section affine_space'
 
-variables (k : Type*) {V : Type*} {P : Type*} [add_comm_group V]
-          [affine_space V P]
+variables (k : Type*) {V : Type*} {P : Type*}
 variables {ι : Type*}
 include V
 
 open affine_subspace finite_dimensional module
 
 section
-variables [division_ring k] [module k V]
+variables [division_ring k] [add_comm_group V] [module k V] [affine_space V P]
 
 /-- The `vector_span` of a finite set is finite-dimensional. -/
 lemma finite_dimensional_vector_span_of_finite {s : set P} (h : set.finite s) :

--- a/src/linear_algebra/affine_space/finite_dimensional.lean
+++ b/src/linear_algebra/affine_space/finite_dimensional.lean
@@ -88,7 +88,7 @@ end
 
 section
 
-variables [field k] [module k V]
+variables [field k] [add_comm_group V] [module k V] [affine_space V P]
 variables {k}
 
 /-- The `vector_span` of a finite subset of an affinely independent
@@ -272,7 +272,7 @@ lemma finrank_vector_span_le_iff_not_affine_independent [fintype ι] (p : ι →
 end
 
 section division_ring
-variables [division_ring k] [module k V]
+variables [division_ring k] [add_comm_group V] [module k V] [affine_space V P]
 
 /-- A set of points is collinear if their `vector_span` has dimension
 at most `1`. -/
@@ -379,7 +379,7 @@ end
 end division_ring
 
 section field
-variables [field k] [module k V]
+variables [field k] [add_comm_group V] [module k V] [affine_space V P]
 
 /-- Three points are affinely independent if and only if they are not
 collinear. -/

--- a/src/linear_algebra/dimension.lean
+++ b/src/linear_algebra/dimension.lean
@@ -1035,7 +1035,6 @@ end division_ring
 section field
 variables [field K] [add_comm_group V] [module K V] [add_comm_group V₁] [module K V₁]
 variables [add_comm_group V'] [module K V']
-variables {K V}
 
 theorem dim_quotient_add_dim (p : submodule K V) :
   module.rank K (V ⧸ p) + module.rank K p = module.rank K V :=
@@ -1119,35 +1118,22 @@ lemma exists_mem_ne_zero_of_dim_pos {s : submodule K V} (h : 0 < module.rank K s
   ∃ b : V, b ∈ s ∧ b ≠ 0 :=
 exists_mem_ne_zero_of_ne_bot $ assume eq, by rw [eq, dim_bot] at h; exact lt_irrefl _ h
 
+end field
+
 section rank
 
--- TODO This definition, and some of the results about it, could be generalized to arbitrary rings.
+section
+variables [ring K] [add_comm_group V] [module K V] [add_comm_group V₁] [module K V₁]
+variables [add_comm_group V'] [module K V']
+
 /-- `rank f` is the rank of a `linear_map f`, defined as the dimension of `f.range`. -/
 def rank (f : V →ₗ[K] V') : cardinal := module.rank K f.range
-
-lemma rank_le_domain (f : V →ₗ[K] V₁) : rank f ≤ module.rank K V :=
-by { rw [← dim_range_add_dim_ker f], exact self_le_add_right _ _ }
 
 lemma rank_le_range (f : V →ₗ[K] V₁) : rank f ≤ module.rank K V₁ :=
 dim_submodule_le _
 
-lemma rank_add_le (f g : V →ₗ[K] V') : rank (f + g) ≤ rank f + rank g :=
-calc rank (f + g) ≤ module.rank K (f.range ⊔ g.range : submodule K V') :
-  begin
-    refine dim_le_of_submodule _ _ _,
-    exact (linear_map.range_le_iff_comap.2 $ eq_top_iff'.2 $
-      assume x, show f x + g x ∈ (f.range ⊔ g.range : submodule K V'), from
-        mem_sup.2 ⟨_, ⟨x, rfl⟩, _, ⟨x, rfl⟩, rfl⟩)
-  end
-  ... ≤ rank f + rank g : dim_add_le_dim_add_dim _ _
-
-@[simp] lemma rank_zero : rank (0 : V →ₗ[K] V') = 0 :=
+@[simp] lemma rank_zero [nontrivial K] : rank (0 : V →ₗ[K] V') = 0 :=
 by rw [rank, linear_map.range_zero, dim_bot]
-
-lemma rank_finset_sum_le {η} (s : finset η) (f : η → V →ₗ[K] V') :
-  rank (∑ d in s, f d) ≤ ∑ d in s, rank (f d) :=
-@finset.sum_hom_rel _ _ _ _ _ (λa b, rank a ≤ b) f (λ d, rank (f d)) s (le_of_eq rank_zero)
-      (λ i g c h, le_trans (rank_add_le _ _) (add_le_add_left h _))
 
 variables [add_comm_group V''] [module K V'']
 
@@ -1163,10 +1149,36 @@ variables [add_comm_group V'₁] [module K V'₁]
 lemma rank_comp_le2 (g : V →ₗ[K] V') (f : V' →ₗ[K] V'₁) : rank (f.comp g) ≤ rank g :=
 by rw [rank, rank, linear_map.range_comp]; exact dim_map_le _ _
 
+end
+
+section field
+variables [field K] [add_comm_group V] [module K V] [add_comm_group V₁] [module K V₁]
+variables [add_comm_group V'] [module K V']
+
+lemma rank_le_domain (f : V →ₗ[K] V₁) : rank f ≤ module.rank K V :=
+by { rw [← dim_range_add_dim_ker f], exact self_le_add_right _ _ }
+
+lemma rank_add_le (f g : V →ₗ[K] V') : rank (f + g) ≤ rank f + rank g :=
+calc rank (f + g) ≤ module.rank K (f.range ⊔ g.range : submodule K V') :
+  begin
+    refine dim_le_of_submodule _ _ _,
+    exact (linear_map.range_le_iff_comap.2 $ eq_top_iff'.2 $
+      assume x, show f x + g x ∈ (f.range ⊔ g.range : submodule K V'), from
+        mem_sup.2 ⟨_, ⟨x, rfl⟩, _, ⟨x, rfl⟩, rfl⟩)
+  end
+  ... ≤ rank f + rank g : dim_add_le_dim_add_dim _ _
+
+lemma rank_finset_sum_le {η} (s : finset η) (f : η → V →ₗ[K] V') :
+  rank (∑ d in s, f d) ≤ ∑ d in s, rank (f d) :=
+@finset.sum_hom_rel _ _ _ _ _ (λa b, rank a ≤ b) f (λ d, rank (f d)) s (le_of_eq rank_zero)
+      (λ i g c h, le_trans (rank_add_le _ _) (add_le_add_left h _))
+
+end field
+
 end rank
 
--- TODO The remainder of this file could be generalized to arbitrary rings.
-
+section division_ring
+variables [division_ring K] [add_comm_group V] [module K V] [add_comm_group V'] [module K V']
 
 /-- The `ι` indexed basis on `V`, where `ι` is an empty type and `V` is zero-dimensional.
 
@@ -1202,40 +1214,6 @@ lemma le_dim_iff_exists_linear_independent_finset {n : ℕ} :
     ∃ s : finset V, s.card = n ∧ linear_independent K (coe : (s : set V) → V) :=
 begin
   simp only [le_dim_iff_exists_linear_independent, cardinal.mk_eq_nat_iff_finset],
-  split,
-  { rintro ⟨s, ⟨t, rfl, rfl⟩, si⟩,
-    exact ⟨t, rfl, si⟩ },
-  { rintro ⟨s, rfl, si⟩,
-    exact ⟨s, ⟨s, rfl, rfl⟩, si⟩ }
-end
-
-lemma le_rank_iff_exists_linear_independent {c : cardinal} {f : V →ₗ[K] V'} :
-  c ≤ rank f ↔
-  ∃ s : set V, cardinal.lift.{v'} (#s) = cardinal.lift.{v} c ∧
-    linear_independent K (λ x : s, f x) :=
-begin
-  rcases f.range_restrict.exists_right_inverse_of_surjective f.range_range_restrict with ⟨g, hg⟩,
-  have fg : left_inverse f.range_restrict g, from linear_map.congr_fun hg,
-  refine ⟨λ h, _, _⟩,
-  { rcases le_dim_iff_exists_linear_independent.1 h with ⟨s, rfl, si⟩,
-    refine ⟨g '' s, cardinal.mk_image_eq_lift _ _ fg.injective, _⟩,
-    replace fg : ∀ x, f (g x) = x, by { intro x, convert congr_arg subtype.val (fg x) },
-    replace si : linear_independent K (λ x : s, f (g x)),
-      by simpa only [fg] using si.map' _ (ker_subtype _),
-    exact si.image_of_comp s g f },
-  { rintro ⟨s, hsc, si⟩,
-    have : linear_independent K (λ x : s, f.range_restrict x),
-      from linear_independent.of_comp (f.range.subtype) (by convert si),
-    convert cardinal_le_dim_of_linear_independent this.image,
-    rw [← cardinal.lift_inj, ← hsc, cardinal.mk_image_eq_of_inj_on_lift],
-    exact inj_on_iff_injective.2 this.injective }
-end
-
-lemma le_rank_iff_exists_linear_independent_finset {n : ℕ} {f : V →ₗ[K] V'} :
-  ↑n ≤ rank f ↔ ∃ s : finset V, s.card = n ∧ linear_independent K (λ x : (s : set V), f x) :=
-begin
-  simp only [le_rank_iff_exists_linear_independent, cardinal.lift_nat_cast,
-    cardinal.lift_eq_nat_iff, cardinal.mk_eq_nat_iff_finset],
   split,
   { rintro ⟨s, ⟨t, rfl, rfl⟩, si⟩,
     exact ⟨t, rfl, si⟩ },
@@ -1313,6 +1291,45 @@ begin
     { push_neg at hw,
       rw ←submodule.eq_bot_iff at hw,
       simp [hw] } }
+end
+
+end division_ring
+
+section field
+variables [field K] [add_comm_group V] [module K V] [add_comm_group V'] [module K V']
+
+lemma le_rank_iff_exists_linear_independent {c : cardinal} {f : V →ₗ[K] V'} :
+  c ≤ rank f ↔
+  ∃ s : set V, cardinal.lift.{v'} (#s) = cardinal.lift.{v} c ∧
+    linear_independent K (λ x : s, f x) :=
+begin
+  rcases f.range_restrict.exists_right_inverse_of_surjective f.range_range_restrict with ⟨g, hg⟩,
+  have fg : left_inverse f.range_restrict g, from linear_map.congr_fun hg,
+  refine ⟨λ h, _, _⟩,
+  { rcases le_dim_iff_exists_linear_independent.1 h with ⟨s, rfl, si⟩,
+    refine ⟨g '' s, cardinal.mk_image_eq_lift _ _ fg.injective, _⟩,
+    replace fg : ∀ x, f (g x) = x, by { intro x, convert congr_arg subtype.val (fg x) },
+    replace si : linear_independent K (λ x : s, f (g x)),
+      by simpa only [fg] using si.map' _ (ker_subtype _),
+    exact si.image_of_comp s g f },
+  { rintro ⟨s, hsc, si⟩,
+    have : linear_independent K (λ x : s, f.range_restrict x),
+      from linear_independent.of_comp (f.range.subtype) (by convert si),
+    convert cardinal_le_dim_of_linear_independent this.image,
+    rw [← cardinal.lift_inj, ← hsc, cardinal.mk_image_eq_of_inj_on_lift],
+    exact inj_on_iff_injective.2 this.injective }
+end
+
+lemma le_rank_iff_exists_linear_independent_finset {n : ℕ} {f : V →ₗ[K] V'} :
+  ↑n ≤ rank f ↔ ∃ s : finset V, s.card = n ∧ linear_independent K (λ x : (s : set V), f x) :=
+begin
+  simp only [le_rank_iff_exists_linear_independent, cardinal.lift_nat_cast,
+    cardinal.lift_eq_nat_iff, cardinal.mk_eq_nat_iff_finset],
+  split,
+  { rintro ⟨s, ⟨t, rfl, rfl⟩, si⟩,
+    exact ⟨t, rfl, si⟩ },
+  { rintro ⟨s, rfl, si⟩,
+    exact ⟨s, ⟨s, rfl, rfl⟩, si⟩ }
 end
 
 end field


### PR DESCRIPTION

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

Should be no changes to content besides weakening some `field` hypotheses to either `ring` or `division_ring`.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
