### PR TITLE
[Merged by Bors] - feat(ring_theory/witt_vector/frobenius): add `witt_vector.frobenius_equiv`

### DIFF
--- a/src/ring_theory/witt_vector/frobenius.lean
+++ b/src/ring_theory/witt_vector/frobenius.lean
@@ -318,13 +318,18 @@ lemma frobenius_zmodp (x : 𝕎 (zmod p)) :
 by simp only [ext_iff, coeff_frobenius_char_p, zmod.pow_card, eq_self_iff_true, forall_const]
 
 variables (p R)
+/-- `witt_vector.frobenius` as an equiv. -/
+@[simps {fully_applied := ff}]
+def frobenius_equiv [perfect_ring R p] : witt_vector p R ≃+* witt_vector p R :=
+{ to_fun := witt_vector.frobenius,
+  inv_fun := map (pth_root R p),
+  left_inv := λ f, ext $ λ n, by { rw frobenius_eq_map_frobenius, exact pth_root_frobenius _ },
+  right_inv := λ f, ext $ λ n, by { rw frobenius_eq_map_frobenius, exact frobenius_pth_root _ },
+   ..(witt_vector.frobenius : witt_vector p R →+* witt_vector p R) }
+
 lemma frobenius_bijective [perfect_ring R p] :
   function.bijective (@witt_vector.frobenius p R _ _) :=
-begin
-  rw witt_vector.frobenius_eq_map_frobenius,
-  exact ⟨witt_vector.map_injective _ (frobenius_equiv R p).injective,
-    witt_vector.map_surjective _ (frobenius_equiv R p).surjective⟩,
-end
+(frobenius_equiv p R).bijective
 
 end char_p
 

--- a/src/ring_theory/witt_vector/frobenius_fraction_field.lean
+++ b/src/ring_theory/witt_vector/frobenius_fraction_field.lean
@@ -219,8 +219,7 @@ begin
     refl }
 end
 
-local notation `φ` := is_fraction_ring.field_equiv_of_ring_equiv
-  (ring_equiv.of_bijective _ (frobenius_bijective p k))
+local notation `φ` := is_fraction_ring.field_equiv_of_ring_equiv (frobenius_equiv p k)
 
 lemma exists_frobenius_solution_fraction_ring {a : fraction_ring (𝕎 k)} (ha : a ≠ 0) :
   ∃ (b : fraction_ring (𝕎 k)) (hb : b ≠ 0) (m : ℤ), φ b * a = p ^ m * b :=
@@ -250,7 +249,7 @@ begin
   simp only [is_fraction_ring.field_equiv_of_ring_equiv,
     is_localization.ring_equiv_of_ring_equiv_eq, ring_equiv.coe_of_bijective],
   convert congr_arg (λ x, algebra_map (𝕎 k) (fraction_ring (𝕎 k)) x) key using 1,
-  { simp only [ring_hom.map_mul, ring_hom.map_pow, map_nat_cast],
+  { simp only [ring_hom.map_mul, ring_hom.map_pow, map_nat_cast, frobenius_equiv_apply],
     ring },
   { simp only [ring_hom.map_mul, ring_hom.map_pow, map_nat_cast] }
 end

--- a/src/ring_theory/witt_vector/isocrystal.lean
+++ b/src/ring_theory/witt_vector/isocrystal.lean
@@ -66,8 +66,8 @@ variables [is_domain k] [char_p k p] [perfect_ring k p]
 /-! ### Frobenius-linear maps -/
 
 /-- The Frobenius automorphism of `k` induces an automorphism of `K`. -/
-def fraction_ring.frobenius : K(p, k) ≃+* K(p, k) := is_fraction_ring.field_equiv_of_ring_equiv
-  (ring_equiv.of_bijective _ (witt_vector.frobenius_bijective p k))
+def fraction_ring.frobenius : K(p, k) ≃+* K(p, k) :=
+is_fraction_ring.field_equiv_of_ring_equiv (frobenius_equiv p k)
 
 /-- The Frobenius automorphism of `k` induces an endomorphism of `K`. For notation purposes. -/
 def fraction_ring.frobenius_ring_hom : K(p, k) →+* K(p, k) := fraction_ring.frobenius p k


### PR DESCRIPTION
This promotes the bijection to an equivalence with an explicit inverse



---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
