### PR TITLE
refactor(set_theory/game/pgame): tweak `subsequent`

### DIFF
--- a/src/set_theory/game/pgame.lean
+++ b/src/set_theory/game/pgame.lean
@@ -151,9 +151,9 @@ def move_right : Π (g : pgame), right_moves g → pgame
 /-- `subsequent p q` says that `p` can be obtained by playing
   some nonempty sequence of moves from `q`. -/
 inductive subsequent : pgame → pgame → Prop
-| left : Π (x : pgame) (i : x.left_moves), subsequent (x.move_left i) x
-| right : Π (x : pgame) (j : x.right_moves), subsequent (x.move_right j) x
-| trans : Π (x y z : pgame), subsequent x y → subsequent y z → subsequent x z
+| move_left  : Π {x : pgame} (i : x.left_moves), subsequent (x.move_left i) x
+| move_right : Π {x : pgame} (j : x.right_moves), subsequent (x.move_right j) x
+| trans      : Π {x y z : pgame}, subsequent x y → subsequent y z → subsequent x z
 
 theorem wf_subsequent : well_founded subsequent :=
 ⟨λ x, begin
@@ -171,20 +171,21 @@ instance : has_well_founded pgame :=
   wf := wf_subsequent }
 
 /-- A move by Left produces a subsequent game. (For use in pgame_wf_tac.) -/
-lemma subsequent.left_move {xl xr} {xL : xl → pgame} {xR : xr → pgame} {i : xl} :
+lemma subsequent.mk_left {xl xr} {xL : xl → pgame} {xR : xr → pgame} {i : xl} :
   subsequent (xL i) (mk xl xr xL xR) :=
-subsequent.left (mk xl xr xL xR) i
+@subsequent.move_left (mk xl xr xL xR) i
+
 /-- A move by Right produces a subsequent game. (For use in pgame_wf_tac.) -/
-lemma subsequent.right_move {xl xr} {xL : xl → pgame} {xR : xr → pgame} {j : xr} :
+lemma subsequent.mk_right {xl xr} {xL : xl → pgame} {xR : xr → pgame} {j : xr} :
   subsequent (xR j) (mk xl xr xL xR) :=
-subsequent.right (mk xl xr xL xR) j
+@subsequent.move_right (mk xl xr xL xR) j
 
 /-- A local tactic for proving well-foundedness of recursive definitions involving pregames. -/
 meta def pgame_wf_tac :=
 `[solve_by_elim
   [psigma.lex.left, psigma.lex.right,
-   subsequent.left_move, subsequent.right_move,
-   subsequent.left, subsequent.right, subsequent.trans]
+   subsequent.move_left, subsequent.move_right,
+   subsequent.mk_left, subsequent.mk_right, subsequent.trans]
   { max_depth := 6 }]
 
 /-- The pre-game `zero` is defined by `0 = { | }`. -/


### PR DESCRIPTION
We rename `subsequent.{left/right}` to `subsequent.move_{left/right}` to better correspond with other lemmas, and infer arguments.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
