### PR TITLE
[Merged by Bors] - feat(ring_theory): factorize a non-unit into irreducible factors without multiplying a unit

### DIFF
--- a/src/algebra/big_operators/multiset.lean
+++ b/src/algebra/big_operators/multiset.lean
@@ -33,7 +33,7 @@ variables [comm_monoid α] {s t : multiset α} {a : α} {m : multiset ι} {f g :
 def prod : multiset α → α := foldr (*) (λ x y z, by simp [mul_left_comm]) 1
 
 @[to_additive]
-lemma prod_eq_foldr (s : multiset α) :  prod s = foldr (*) (λ x y z, by simp [mul_left_comm]) 1 s :=
+lemma prod_eq_foldr (s : multiset α) : prod s = foldr (*) (λ x y z, by simp [mul_left_comm]) 1 s :=
 rfl
 
 @[to_additive]
@@ -53,6 +53,10 @@ end
 
 @[simp, to_additive]
 lemma prod_cons (a : α) (s) : prod (a ::ₘ s) = a * prod s := foldr_cons _ _ _ _ _
+
+lemma prod_erase [decidable_eq α] (h : a ∈ s) : a * (s.erase a).prod = s.prod :=
+by rw [← s.prod_to_list, ← list.prod_erase ((s.mem_to_list a).2 h), ← multiset.coe_prod,
+    ← multiset.coe_erase, s.coe_to_list]
 
 @[simp, to_additive]
 lemma prod_singleton (a : α) : prod {a} = a :=

--- a/src/algebra/big_operators/multiset.lean
+++ b/src/algebra/big_operators/multiset.lean
@@ -56,8 +56,7 @@ lemma prod_cons (a : α) (s) : prod (a ::ₘ s) = a * prod s := foldr_cons _ _ _
 
 @[simp, to_additive]
 lemma prod_erase [decidable_eq α] (h : a ∈ s) : a * (s.erase a).prod = s.prod :=
-by rw [← s.prod_to_list, ← list.prod_erase ((s.mem_to_list a).2 h), ← multiset.coe_prod,
-    ← multiset.coe_erase, s.coe_to_list]
+by rw [← s.coe_to_list, coe_erase, coe_prod, coe_prod, list.prod_erase ((s.mem_to_list a).2 h)]
 
 @[simp, to_additive]
 lemma prod_singleton (a : α) : prod {a} = a :=

--- a/src/algebra/big_operators/multiset.lean
+++ b/src/algebra/big_operators/multiset.lean
@@ -54,6 +54,7 @@ end
 @[simp, to_additive]
 lemma prod_cons (a : α) (s) : prod (a ::ₘ s) = a * prod s := foldr_cons _ _ _ _ _
 
+@[simp, to_additive]
 lemma prod_erase [decidable_eq α] (h : a ∈ s) : a * (s.erase a).prod = s.prod :=
 by rw [← s.prod_to_list, ← list.prod_erase ((s.mem_to_list a).2 h), ← multiset.coe_prod,
     ← multiset.coe_erase, s.coe_to_list]

--- a/src/ring_theory/unique_factorization_domain.lean
+++ b/src/ring_theory/unique_factorization_domain.lean
@@ -107,16 +107,18 @@ induction_on_irreducible a
       by { rw multiset.prod_cons,
            exact hs.2.mul_left _ }⟩⟩)
 
-lemma exists_factors_eq (a : α) (hn0 : a ≠ 0) (hnu : ¬ is_unit a) :
-  ∃ (f : multiset α), (∀ (b : α), b ∈ f → irreducible b) ∧ f.prod = a :=
-begin
-  obtain ⟨P, hi, u, rfl⟩ := exists_factors a hn0,
-  obtain ⟨p, h⟩ := multiset.exists_mem_of_ne_zero (λ h : P = 0, hnu $ by simp [h]),
-  classical, use (P.erase p).cons (p * u), split,
-  { intros a ha, rcases multiset.mem_cons.1 ha with (rfl|ha),
-    exacts [associated.irreducible ⟨u,rfl⟩ (hi p h), hi a (multiset.mem_of_mem_erase ha)] },
-  { rw [multiset.prod_cons, mul_comm p, mul_assoc, multiset.prod_erase h, mul_comm] },
-end
+lemma not_unit_iff_exists_factors_eq (a : α) (hn0 : a ≠ 0) :
+  ¬ is_unit a ↔ ∃ f : multiset α, (∀ b ∈ f, irreducible b) ∧ f.prod = a ∧ f ≠ ∅ :=
+⟨λ hnu, begin
+  obtain ⟨f, hi, u, rfl⟩ := exists_factors a hn0,
+  obtain ⟨b, h⟩ := multiset.exists_mem_of_ne_zero (λ h : f = 0, hnu $ by simp [h]),
+  classical, refine ⟨(f.erase b).cons (b * u), λ a ha, _, _, multiset.cons_ne_zero⟩,
+  { obtain (rfl|ha) := multiset.mem_cons.1 ha,
+    exacts [associated.irreducible ⟨u,rfl⟩ (hi b h), hi a (multiset.mem_of_mem_erase ha)] },
+  { rw [multiset.prod_cons, mul_comm b, mul_assoc, multiset.prod_erase h, mul_comm] },
+end,
+λ ⟨f,hi,he,hne⟩, let ⟨b, h⟩ := multiset.exists_mem_of_ne_zero hne in
+  not_is_unit_of_not_is_unit_dvd (hi b h).not_unit (he.subst $ multiset.dvd_prod h)⟩
 
 end wf_dvd_monoid
 

--- a/src/ring_theory/unique_factorization_domain.lean
+++ b/src/ring_theory/unique_factorization_domain.lean
@@ -52,7 +52,7 @@ open associates nat
 theorem of_wf_dvd_monoid_associates (h : wf_dvd_monoid (associates α)): wf_dvd_monoid α :=
 ⟨begin
   haveI := h,
-  refine (surjective.well_founded_iff mk_surjective _).2 wf_dvd_monoid.well_founded_dvd_not_unit,
+  refine (surjective.well_founded_iff mk_surjective _).2 well_founded_dvd_not_unit,
   intros, rw mk_dvd_not_unit_mk_iff
 end⟩
 
@@ -60,12 +60,12 @@ variables [wf_dvd_monoid α]
 
 instance wf_dvd_monoid_associates : wf_dvd_monoid (associates α) :=
 ⟨begin
-  refine (surjective.well_founded_iff mk_surjective _).1 wf_dvd_monoid.well_founded_dvd_not_unit,
+  refine (surjective.well_founded_iff mk_surjective _).1 well_founded_dvd_not_unit,
   intros, rw mk_dvd_not_unit_mk_iff
 end⟩
 
 theorem well_founded_associates : well_founded ((<) : associates α → associates α → Prop) :=
-subrelation.wf (λ x y, dvd_not_unit_of_lt) wf_dvd_monoid.well_founded_dvd_not_unit
+subrelation.wf (λ x y, dvd_not_unit_of_lt) well_founded_dvd_not_unit
 
 local attribute [elab_as_eliminator] well_founded.fix
 
@@ -73,7 +73,7 @@ lemma exists_irreducible_factor {a : α} (ha : ¬ is_unit a) (ha0 : a ≠ 0) :
   ∃ i, irreducible i ∧ i ∣ a :=
 (irreducible_or_factor a ha).elim (λ hai, ⟨a, hai, dvd_rfl⟩)
   (well_founded.fix
-    wf_dvd_monoid.well_founded_dvd_not_unit
+    well_founded_dvd_not_unit
     (λ a ih ha ha0 ⟨x, y, hx, hy, hxy⟩,
       have hx0 : x ≠ 0, from λ hx0, ha0 (by rw [← hxy, hx0, zero_mul]),
       (irreducible_or_factor x hx).elim
@@ -86,7 +86,7 @@ lemma exists_irreducible_factor {a : α} (ha : ¬ is_unit a) (ha0 : a ≠ 0) :
   (hi : ∀ a i : α, a ≠ 0 → irreducible i → P a → P (i * a)) :
   P a :=
 by haveI := classical.dec; exact
-well_founded.fix wf_dvd_monoid.well_founded_dvd_not_unit
+well_founded.fix well_founded_dvd_not_unit
   (λ a ih, if ha0 : a = 0 then ha0.symm ▸ h0
     else if hau : is_unit a then hu a hau
     else let ⟨i, hii, ⟨b, hb⟩⟩ := exists_irreducible_factor hau ha0 in
@@ -97,7 +97,7 @@ well_founded.fix wf_dvd_monoid.well_founded_dvd_not_unit
 
 lemma exists_factors (a : α) : a ≠ 0 →
   ∃ f : multiset α, (∀ b ∈ f, irreducible b) ∧ associated f.prod a :=
-wf_dvd_monoid.induction_on_irreducible a
+induction_on_irreducible a
   (λ h, (h rfl).elim)
   (λ u hu _, ⟨0, ⟨by simp [hu], associated.symm (by simp [hu, associated_one_iff_is_unit])⟩⟩)
   (λ a i ha0 hii ih hia0,
@@ -110,8 +110,8 @@ wf_dvd_monoid.induction_on_irreducible a
 lemma exists_factors_eq (a : α) (hn0 : a ≠ 0) (hnu : ¬ is_unit a) :
   ∃ (f : multiset α), (∀ (b : α), b ∈ f → irreducible b) ∧ f.prod = a :=
 begin
-  obtain ⟨P,hi,u,rfl⟩ := wf_dvd_monoid.exists_factors a hn0,
-  obtain ⟨p,h⟩ := multiset.exists_mem_of_ne_zero (λ h : P = 0, hnu $ by simp [h]),
+  obtain ⟨P, hi, u, rfl⟩ := exists_factors a hn0,
+  obtain ⟨p, h⟩ := multiset.exists_mem_of_ne_zero (λ h : P = 0, hnu $ by simp [h]),
   classical, use (P.erase p).cons (p * u), split,
   { intros a ha, rcases multiset.mem_cons.1 ha with (rfl|ha),
     exacts [associated.irreducible ⟨u,rfl⟩ (hi p h), hi a (multiset.mem_of_mem_erase ha)] },

--- a/src/ring_theory/unique_factorization_domain.lean
+++ b/src/ring_theory/unique_factorization_domain.lean
@@ -96,7 +96,7 @@ well_founded.fix wf_dvd_monoid.well_founded_dvd_not_unit
   a
 
 lemma exists_factors (a : α) : a ≠ 0 →
-  ∃f : multiset α, (∀b ∈ f, irreducible b) ∧ associated f.prod a :=
+  ∃ f : multiset α, (∀ b ∈ f, irreducible b) ∧ associated f.prod a :=
 wf_dvd_monoid.induction_on_irreducible a
   (λ h, (h rfl).elim)
   (λ u hu _, ⟨0, ⟨by simp [hu], associated.symm (by simp [hu, associated_one_iff_is_unit])⟩⟩)
@@ -106,6 +106,17 @@ wf_dvd_monoid.induction_on_irreducible a
     { intros b H, cases (multiset.mem_cons.mp H), { convert hii }, { exact hs.1 b h } },
       by { rw multiset.prod_cons,
            exact hs.2.mul_left _ }⟩⟩)
+
+lemma exists_factors_eq (a : α) (hn0 : a ≠ 0) (hnu : ¬ is_unit a) :
+  ∃ (f : multiset α), (∀ (b : α), b ∈ f → irreducible b) ∧ f.prod = a :=
+begin
+  obtain ⟨P,hi,u,rfl⟩ := wf_dvd_monoid.exists_factors a hn0,
+  obtain ⟨p,h⟩ := multiset.exists_mem_of_ne_zero (λ h : P = 0, hnu $ by simp [h]),
+  classical, use (P.erase p).cons (p * u), split,
+  { intros a ha, rcases multiset.mem_cons.1 ha with (rfl|ha),
+    exacts [associated.irreducible ⟨u,rfl⟩ (hi p h), hi a (multiset.mem_of_mem_erase ha)] },
+  { rw [multiset.prod_cons, mul_comm p, mul_assoc, multiset.prod_erase h, mul_comm] },
+end
 
 end wf_dvd_monoid
 
@@ -227,7 +238,7 @@ by haveI := classical.dec_eq α; exact
 /-- If an irreducible has a prime factorization,
   then it is an associate of one of its prime factors. -/
 lemma prime_factors_irreducible [cancel_comm_monoid_with_zero α] {a : α} {f : multiset α}
-  (ha : irreducible a) (pfa : (∀b ∈ f, prime b) ∧ f.prod ~ᵤ a) :
+  (ha : irreducible a) (pfa : (∀ b ∈ f, prime b) ∧ f.prod ~ᵤ a) :
   ∃ p, a ~ᵤ p ∧ f = {p} :=
 begin
   haveI := classical.dec_eq α,


### PR DESCRIPTION
Used in https://proofassistants.stackexchange.com/a/1312/93. Also adds simp lemma `multiset.prod_erase` used in the main proof and the auto-generated additive version, which is immediately analogous to [list.prod_erase](https://leanprover-community.github.io/mathlib_docs/data/list/big_operators.html#list.prod_erase). Also removes some extraneous namespace prefix.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
