### PR TITLE
[Merged by Bors] - chore(topology/algebra/valuation): use forgetful inheritance pattern for valued fields

### DIFF
--- a/src/number_theory/function_field.lean
+++ b/src/number_theory/function_field.lean
@@ -229,70 +229,28 @@ end
 
 /-- The valued field `Fq(t)` with the valuation at infinity. -/
 def infty_valued_Fqt : valued (ratfunc Fq) (with_zero (multiplicative ℤ)) :=
-⟨infty_valuation Fq⟩
+valued.mk' (infty_valuation Fq)
 
 lemma infty_valued_Fqt.def {x : ratfunc Fq} :
-  @valued.v (ratfunc Fq) _ _ _ (infty_valued_Fqt Fq) (x) = infty_valuation_def Fq x := rfl
-
-namespace infty_valued_Fqt
-
-/-- The topology structure on `Fq(t)` induced by the valuation at infinity. -/
-def topological_space : topological_space (ratfunc Fq) :=
-@valued.topological_space (ratfunc Fq) _ _ _ (infty_valued_Fqt Fq)
-
-lemma topological_division_ring :
-  @topological_division_ring (ratfunc Fq) _ (topological_space Fq) :=
-@valued.topological_division_ring (ratfunc Fq) _ _ _ (infty_valued_Fqt Fq)
-
-/-- The uniform structure on `k(t)` induced by the valuation at infinity. -/
-def uniform_space : uniform_space (ratfunc Fq) :=
-@topological_add_group.to_uniform_space (ratfunc Fq) _ (topological_space Fq) _
-
-lemma uniform_add_group : @uniform_add_group (ratfunc Fq) (uniform_space Fq) _ :=
-@topological_add_group_is_uniform (ratfunc Fq) _ (topological_space Fq) _
-
-lemma completable_top_field : @completable_top_field (ratfunc Fq) _ (uniform_space Fq) :=
-@valued.completable (ratfunc Fq) _ _ _ (infty_valued_Fqt Fq)
-
-lemma separated_space : @separated_space (ratfunc Fq) (uniform_space Fq) :=
-@valued_ring.separated (ratfunc Fq) _ _ _ (infty_valued_Fqt Fq)
-
-end infty_valued_Fqt
-
-open infty_valued_Fqt
+  @valued.v (ratfunc Fq) _ _ _ (infty_valued_Fqt Fq) x = infty_valuation_def Fq x := rfl
 
 /-- The completion `Fq((t⁻¹))`  of `Fq(t)` with respect to the valuation at infinity. -/
-def Fqt_infty := @uniform_space.completion (ratfunc Fq) (uniform_space Fq)
+def Fqt_infty := @uniform_space.completion (ratfunc Fq) $ (infty_valued_Fqt Fq).to_uniform_space
 
 instance : field (Fqt_infty Fq) :=
-@field_completion (ratfunc Fq) _ (uniform_space Fq) (topological_division_ring Fq) _
-  (uniform_add_group Fq)
+begin
+  letI := infty_valued_Fqt Fq,
+  exact field_completion,
+end
 
 instance : inhabited (Fqt_infty Fq) := ⟨(0 : Fqt_infty Fq)⟩
 
 /-- The valuation at infinity on `k(t)` extends to a valuation on `Fqt_infty`. -/
 instance valued_Fqt_infty : valued (Fqt_infty Fq) (with_zero (multiplicative ℤ)) :=
-⟨@valued.extension_valuation (ratfunc Fq) _ _ _ (infty_valued_Fqt Fq)⟩
+@valued.valued_completion _ _ _ _ (infty_valued_Fqt Fq)
 
 lemma valued_Fqt_infty.def {x : Fqt_infty Fq} :
-  valued.v (x) = @valued.extension (ratfunc Fq) _ _ _ (infty_valued_Fqt Fq) x := rfl
-
-instance Fqt_infty.topological_space : topological_space (Fqt_infty Fq) :=
-valued.topological_space (with_zero (multiplicative ℤ))
-
-instance Fqt_infty.topological_division_ring : topological_division_ring (Fqt_infty Fq) :=
-valued.topological_division_ring
-
-instance : topological_ring (Fqt_infty Fq) :=
-(Fqt_infty.topological_division_ring Fq).to_topological_ring
-
-instance : topological_add_group (Fqt_infty Fq) := topological_ring.to_topological_add_group
-
-instance Fqt_infty.uniform_space : uniform_space (Fqt_infty Fq) :=
-topological_add_group.to_uniform_space (Fqt_infty Fq)
-
-instance Fqt_infty.uniform_add_group : uniform_add_group (Fqt_infty Fq) :=
-topological_add_group_is_uniform
+  valued.v x = @valued.extension (ratfunc Fq) _ _ _ (infty_valued_Fqt Fq) x := rfl
 
 end infty_valuation
 

--- a/src/number_theory/function_field.lean
+++ b/src/number_theory/function_field.lean
@@ -229,7 +229,7 @@ end
 
 /-- The valued field `Fq(t)` with the valuation at infinity. -/
 def infty_valued_Fqt : valued (ratfunc Fq) (with_zero (multiplicative ℤ)) :=
-valued.mk' (infty_valuation Fq)
+valued.mk' $ infty_valuation Fq
 
 lemma infty_valued_Fqt.def {x : ratfunc Fq} :
   @valued.v (ratfunc Fq) _ _ _ (infty_valued_Fqt Fq) x = infty_valuation_def Fq x := rfl

--- a/src/topology/algebra/group_completion.lean
+++ b/src/topology/algebra/group_completion.lean
@@ -32,8 +32,6 @@ noncomputable theory
 
 universes u v
 
-open_locale topological_space
-
 section group
 open uniform_space Cauchy filter set
 variables {α : Type u} [uniform_space α]
@@ -118,32 +116,6 @@ instance {α : Type u} [uniform_space α] [add_comm_group α] [uniform_add_group
       (continuous_map₂ continuous_snd continuous_fst))
     (assume x y, by { change ↑x + ↑y = ↑y + ↑x, rw [← coe_add, ← coe_add, add_comm]}),
   .. completion.add_group }
-
--- Bourbaki GT III §3 no.4 Proposition 7
-lemma _root_.filter.has_basis.completion_has_basis_closure_nhds_zero
-  {ι : Type*} {s : ι → set α} {p : ι → Prop} (h : (𝓝 (0 : α)).has_basis p s) :
-  (𝓝 (0 : completion α)).has_basis p $ λ i, closure $ coe '' (s i) :=
-begin
-  rw filter.has_basis_iff at h ⊢,
-  intro T,
-  refine ⟨λ hT, _, λ hT, _⟩,
-  { obtain ⟨V, hV_unif, hV_ball⟩ := uniform_space.mem_nhds_iff.mp hT,
-    obtain ⟨Z, hZ_unif, hZ_closed, hZV⟩ := mem_uniformity_is_closed hV_unif,
-    have h_coe : coe ⁻¹' (ball 0 Z) ∈ 𝓝 (0 : α),
-    { rw uniform_space.mem_nhds_iff,
-      refine ⟨(λ (p : α × α), (↑(p.fst), ↑(p.snd))) ⁻¹' Z, _, rfl.subset⟩,
-      { rw ← uniform_space.completion.comap_coe_eq_uniformity,
-        use [Z, hZ_unif], }},
-    obtain ⟨i, hi, hsi⟩ := (h (coe ⁻¹' (ball 0 Z))).mp h_coe,
-    have hZ_ball_closed : is_closed (ball 0 Z),
-    { exact is_closed.preimage (continuous.prod.mk 0) hZ_closed, },
-    exact ⟨i, hi, subset_trans ((is_closed.closure_subset_iff (hZ_ball_closed)).mpr
-      (set.image_subset_iff.mpr hsi)) (subset_trans (ball_mono hZV 0) hV_ball)⟩, },
-  { obtain ⟨i, hi, hi'⟩ := hT,
-    suffices : closure (coe '' s i) ∈ 𝓝 (0 : completion α), { filter_upwards [this] using hi', },
-    replace h := (h (s i)).mpr ⟨i, hi, set.subset.rfl⟩,
-    exact completion.dense_inducing_coe.closure_image_mem_nhds h, },
-end
 
 end uniform_add_group
 

--- a/src/topology/algebra/group_completion.lean
+++ b/src/topology/algebra/group_completion.lean
@@ -32,6 +32,8 @@ noncomputable theory
 
 universes u v
 
+open_locale topological_space
+
 section group
 open uniform_space Cauchy filter set
 variables {α : Type u} [uniform_space α]
@@ -116,6 +118,32 @@ instance {α : Type u} [uniform_space α] [add_comm_group α] [uniform_add_group
       (continuous_map₂ continuous_snd continuous_fst))
     (assume x y, by { change ↑x + ↑y = ↑y + ↑x, rw [← coe_add, ← coe_add, add_comm]}),
   .. completion.add_group }
+
+-- Bourbaki GT III §3 no.4 Proposition 7
+lemma _root_.filter.has_basis.completion_has_basis_closure_nhds_zero
+  {ι : Type*} {s : ι → set α} {p : ι → Prop} (h : (𝓝 (0 : α)).has_basis p s) :
+  (𝓝 (0 : completion α)).has_basis p $ λ i, closure $ coe '' (s i) :=
+begin
+  rw filter.has_basis_iff at h ⊢,
+  intro T,
+  refine ⟨λ hT, _, λ hT, _⟩,
+  { obtain ⟨V, hV_unif, hV_ball⟩ := uniform_space.mem_nhds_iff.mp hT,
+    obtain ⟨Z, hZ_unif, hZ_closed, hZV⟩ := mem_uniformity_is_closed hV_unif,
+    have h_coe : coe ⁻¹' (ball 0 Z) ∈ 𝓝 (0 : α),
+    { rw uniform_space.mem_nhds_iff,
+      refine ⟨(λ (p : α × α), (↑(p.fst), ↑(p.snd))) ⁻¹' Z, _, rfl.subset⟩,
+      { rw ← uniform_space.completion.comap_coe_eq_uniformity,
+        use [Z, hZ_unif], }},
+    obtain ⟨i, hi, hsi⟩ := (h (coe ⁻¹' (ball 0 Z))).mp h_coe,
+    have hZ_ball_closed : is_closed (ball 0 Z),
+    { exact is_closed.preimage (continuous.prod.mk 0) hZ_closed, },
+    exact ⟨i, hi, subset_trans ((is_closed.closure_subset_iff (hZ_ball_closed)).mpr
+      (set.image_subset_iff.mpr hsi)) (subset_trans (ball_mono hZV 0) hV_ball)⟩, },
+  { obtain ⟨i, hi, hi'⟩ := hT,
+    suffices : closure (coe '' s i) ∈ 𝓝 (0 : completion α), { filter_upwards [this] using hi', },
+    replace h := (h (s i)).mpr ⟨i, hi, set.subset.rfl⟩,
+    exact completion.dense_inducing_coe.closure_image_mem_nhds h, },
+end
 
 end uniform_add_group
 

--- a/src/topology/algebra/uniform_group.lean
+++ b/src/topology/algebra/uniform_group.lean
@@ -372,14 +372,13 @@ begin
   simpa [(∘), div_eq_mul_inv, mul_comm, mul_left_comm] using this
 end
 
-local attribute [instance] topological_group_is_uniform
-
 open set
 
-@[to_additive] lemma topological_group.separated_iff_one_closed :
-  separated_space G ↔ is_closed ({1} : set G) :=
+@[to_additive] lemma topological_group.t2_space_iff_one_closed :
+  t2_space G ↔ is_closed ({1} : set G) :=
 begin
-  rw [separated_space_iff, ← closure_eq_iff_is_closed],
+  haveI : uniform_group G := topological_group_is_uniform,
+  rw [← separated_iff_t2, separated_space_iff, ← closure_eq_iff_is_closed],
   split; intro h,
   { apply subset.antisymm,
     { intros x x_in,
@@ -395,10 +394,10 @@ begin
     refl }
 end
 
-@[to_additive] lemma topological_group.separated_of_one_sep
-  (H : ∀ x : G, x ≠ 1 → ∃ U ∈ nhds (1 : G), x ∉ U) : separated_space G:=
+@[to_additive] lemma topological_group.t2_space_of_one_sep
+  (H : ∀ x : G, x ≠ 1 → ∃ U ∈ nhds (1 : G), x ∉ U) : t2_space G :=
 begin
-  rw [topological_group.separated_iff_one_closed, ← is_open_compl_iff, is_open_iff_mem_nhds],
+  rw [topological_group.t2_space_iff_one_closed, ← is_open_compl_iff, is_open_iff_mem_nhds],
   intros x x_not,
   have : x ≠ 1, from mem_compl_singleton_iff.mp x_not,
   rcases H x this with ⟨U, U_in, xU⟩,

--- a/src/topology/algebra/valuation.lean
+++ b/src/topology/algebra/valuation.lean
@@ -134,12 +134,12 @@ variables {R Γ₀}
 
 lemma mem_nhds {s : set R} {x : R} :
   (s ∈ 𝓝 x) ↔ ∃ (γ : Γ₀ˣ), {y | (v (y - x) : Γ₀) < γ } ⊆ s :=
-by simp [← nhds_translation_add_neg x, ← sub_eq_add_neg,
+by simp only [← nhds_translation_add_neg x, ← sub_eq_add_neg, preimage_set_of_eq, exists_true_left,
   ((has_basis_nhds_zero R Γ₀).comap (λ y, y - x)).mem_iff]
 
 lemma mem_nhds_zero {s : set R} :
   (s ∈ 𝓝 (0 : R)) ↔ ∃ γ : Γ₀ˣ, {x | v x < (γ : Γ₀) } ⊆ s :=
-by simp [mem_nhds, sub_zero]
+by simp only [mem_nhds, sub_zero]
 
 lemma loc_const {x : R} (h : (v x : Γ₀) ≠ 0) : {y : R | v y = v x} ∈ 𝓝 x :=
 begin

--- a/src/topology/algebra/valuation.lean
+++ b/src/topology/algebra/valuation.lean
@@ -16,31 +16,21 @@ The main definition is a `valued` type class which equips a ring with a valuatio
 values in a group with zero. Other instances are then deduced from this.
 -/
 
-open_locale classical topological_space
+open_locale classical topological_space uniformity
 open set valuation
 noncomputable theory
 
 universes v u
 
-/-- A valued ring is a ring that comes equipped with a distinguished valuation. The class `valued`
-is designed for the situation that there is a canonical valuation on the ring. It allows such a
-valuation to be registered as a typeclass; this is used for instance by `valued.topological_space`.
+variables {R : Type u} [ring R] {Γ₀ : Type v} [linear_ordered_comm_group_with_zero Γ₀]
 
-TODO: show that there always exists an equivalent valuation taking values in a type belonging to
-the same universe as the ring. -/
-class valued (R : Type u) [ring R] (Γ₀ : out_param (Type v))
-  [linear_ordered_comm_group_with_zero Γ₀] :=
-(v : valuation R Γ₀)
+namespace valuation
 
-namespace valued
-variables {R : Type u} [ring R] (Γ₀ : Type v) [linear_ordered_comm_group_with_zero Γ₀]
-  [hv : valued R Γ₀]
+variables (v : valuation R Γ₀)
 
-include hv
-
-/-- The basis of open subgroups for the topology on a valued ring.-/
+/-- The basis of open subgroups for the topology on a ring determined by a valuation. -/
 lemma subgroups_basis :
-  ring_subgroups_basis (λ γ : Γ₀ˣ, (valued.v.lt_add_subgroup γ : add_subgroup R)) :=
+  ring_subgroups_basis (λ γ : Γ₀ˣ, (v.lt_add_subgroup γ : add_subgroup R)) :=
 { inter := begin
     rintros γ₀ γ₁,
     use min γ₀ γ₁,
@@ -87,26 +77,86 @@ lemma subgroups_basis :
       simpa using mul_inv_lt_of_lt_mul₀ vy_lt }
   end }
 
-/-- The topological space structure on a valued ring.
+end valuation
 
-NOTE: The `dangerous_instance` linter does not check whether the metavariables only occur in
-arguments marked with `out_param`, so in this instance it gives a false positive. -/
-@[nolint dangerous_instance, priority 100]
-instance : topological_space R := (subgroups_basis Γ₀).topology
+/-- A valued ring is a ring that comes equipped with a distinguished valuation. The class `valued`
+is designed for the situation that there is a canonical valuation on the ring.
 
-variable {Γ₀}
+TODO: show that there always exists an equivalent valuation taking values in a type belonging to
+the same universe as the ring.
+
+See Note [forgetful inheritance] for why we extend `uniform_space`. -/
+class valued (R : Type u) [ring R] (Γ₀ : out_param (Type v))
+  [linear_ordered_comm_group_with_zero Γ₀] extends uniform_space R :=
+(v : valuation R Γ₀)
+(is_uniform_valuation : ∀ s, s ∈ 𝓤 R ↔ ∃ (γ : Γ₀ˣ), { p : R × R | v (p.2 - p.1) < γ } ⊆ s)
+
+/-- The `dangerous_instance` linter does not check whether the metavariables only occur in
+arguments marked with `out_param`, so in this instance it gives a false positive.-/
+attribute [nolint dangerous_instance] valued.to_uniform_space
+
+namespace valued
+
+/-- Alternative `valued` constructor for use when there is no preferred `uniform_space`
+structure. -/
+def mk' (v : valuation R Γ₀) : valued R Γ₀ :=
+{ v := v,
+  to_uniform_space := @topological_add_group.to_uniform_space R _ v.subgroups_basis.topology _,
+  is_uniform_valuation :=
+  begin
+    letI := @topological_add_group.to_uniform_space R _ v.subgroups_basis.topology _,
+    intros s,
+    suffices : (𝓤 R).has_basis (λ _, true) (λ (γ : Γ₀ˣ), { p : R × R | v (p.2 - p.1) < (γ : Γ₀) }),
+    { rw this.mem_iff,
+      exact exists_congr (λ γ, by simp), },
+    exact v.subgroups_basis.has_basis_nhds_zero.comap _,
+  end }
+
+variables (R Γ₀) [_i : valued R Γ₀]
+include _i
+
+lemma has_basis_uniformity :
+  (𝓤 R).has_basis (λ _, true) (λ (γ : Γ₀ˣ), { p : R × R | v (p.2 - p.1) < (γ : Γ₀) }) :=
+by simp [filter.has_basis_iff, is_uniform_valuation]
+
+lemma uniformity_eq :
+  𝓤 R = (@topological_add_group.to_uniform_space R _ v.subgroups_basis.topology _).uniformity :=
+(has_basis_uniformity R Γ₀).eq_of_same_basis $ v.subgroups_basis.has_basis_nhds_zero.comap _
+
+lemma to_uniform_space_eq :
+  to_uniform_space = @topological_add_group.to_uniform_space R _ v.subgroups_basis.topology _ :=
+uniform_space_eq (uniformity_eq R Γ₀)
+
+lemma to_topological_space_eq :
+  (by apply_instance : topological_space R) = v.subgroups_basis.topology :=
+begin
+  rw to_uniform_space_eq,
+  congr,
+end
+
+lemma has_basis_nhds_zero :
+  (𝓝 (0 : R)).has_basis (λ _, true) (λ (γ : Γ₀ˣ), { x | v x < (γ : Γ₀) }) :=
+begin
+  rw to_topological_space_eq,
+  exact v.subgroups_basis.has_basis_nhds_zero,
+end
+
+variables {R Γ₀}
 
 lemma mem_nhds {s : set R} {x : R} :
   (s ∈ 𝓝 x) ↔ ∃ (γ : Γ₀ˣ), {y | (v (y - x) : Γ₀) < γ } ⊆ s :=
-by simpa [((subgroups_basis Γ₀).has_basis_nhds x).mem_iff]
+begin
+  rw to_topological_space_eq,
+  simpa [(v.subgroups_basis.has_basis_nhds x).mem_iff],
+end
 
 lemma mem_nhds_zero {s : set R} :
   (s ∈ 𝓝 (0 : R)) ↔ ∃ γ : Γ₀ˣ, {x | v x < (γ : Γ₀) } ⊆ s :=
-by simp [valued.mem_nhds, sub_zero]
+by simp [mem_nhds, sub_zero]
 
 lemma loc_const {x : R} (h : (v x : Γ₀) ≠ 0) : {y : R | v y = v x} ∈ 𝓝 x :=
 begin
-  rw valued.mem_nhds,
+  rw mem_nhds,
   rcases units.exists_iff_ne_zero.mpr h with ⟨γ, hx⟩,
   use γ,
   rw hx,
@@ -114,27 +164,34 @@ begin
   exact valuation.map_eq_of_sub_lt _ y_in
 end
 
-/-- The uniform structure on a valued ring.
-
-NOTE: The `dangerous_instance` linter does not check whether the metavariables only occur in
-arguments marked with `out_param`, so in this instance it gives a false positive.-/
-@[nolint dangerous_instance, priority 100]
-instance uniform_space : uniform_space R := topological_add_group.to_uniform_space R
-
-/-- A valued ring is a uniform additive group.-/
 @[priority 100]
-instance uniform_add_group : uniform_add_group R := topological_add_group_is_uniform
+instance to_uniform_add_group : uniform_add_group R :=
+(to_uniform_space_eq R Γ₀).symm ▸ @topological_add_group_is_uniform _ _ v.subgroups_basis.topology _
+
+@[priority 100]
+instance : topological_ring R :=
+(to_uniform_space_eq R Γ₀).symm ▸ v.subgroups_basis.to_ring_filter_basis.is_topological_ring
 
 lemma cauchy_iff {F : filter R} :
   cauchy F ↔ F.ne_bot ∧ ∀ γ : Γ₀ˣ, ∃ M ∈ F, ∀ x y ∈ M, (v (y - x) : Γ₀) < γ :=
 begin
-  rw add_group_filter_basis.cauchy_iff,
+  rw [to_uniform_space_eq, add_group_filter_basis.cauchy_iff],
   apply and_congr iff.rfl,
-  simp_rw (subgroups_basis Γ₀).mem_add_group_filter_basis_iff,
+  simp_rw valued.v.subgroups_basis.mem_add_group_filter_basis_iff,
   split,
   { intros h γ,
-    exact h _ ((subgroups_basis Γ₀).mem_add_group_filter_basis _) },
+    exact h _ (valued.v.subgroups_basis.mem_add_group_filter_basis _) },
   { rintros h - ⟨γ, rfl⟩,
     exact h γ }
 end
+
+lemma separated_of_zero_sep
+  (H : ∀ x : R, x ≠ 0 → ∃ U ∈ 𝓝 (0 : R), x ∉ U) : separated_space R :=
+begin
+  -- TODO Tidy up this proof: looks like missing fact about uniform add group structure
+  rw to_uniform_space_eq,
+  convert topological_add_group.separated_of_zero_sep H,
+  rw to_topological_space_eq,
+end
+
 end valued

--- a/src/topology/algebra/valuation.lean
+++ b/src/topology/algebra/valuation.lean
@@ -89,6 +89,8 @@ See Note [forgetful inheritance] for why we extend `uniform_space`. -/
 class valued (R : Type u) [ring R] (Γ₀ : out_param (Type v))
   [linear_ordered_comm_group_with_zero Γ₀] extends uniform_space R :=
 (v : valuation R Γ₀)
+-- On second thought perhaps `is_uniform_valuation` would be better replaced with a topological
+-- condition characterising the neighbourhoods of (0 : R).
 (is_uniform_valuation : ∀ s, s ∈ 𝓤 R ↔ ∃ (γ : Γ₀ˣ), { p : R × R | v (p.2 - p.1) < γ } ⊆ s)
 
 /-- The `dangerous_instance` linter does not check whether the metavariables only occur in

--- a/src/topology/algebra/valuation.lean
+++ b/src/topology/algebra/valuation.lean
@@ -125,20 +125,10 @@ begin
   exact (has_basis_nhds_zero R Γ₀).comap _,
 end
 
-lemma uniformity_eq :
-  𝓤 R = (@topological_add_group.to_uniform_space R _ v.subgroups_basis.topology _).uniformity :=
-(has_basis_uniformity R Γ₀).eq_of_same_basis $ v.subgroups_basis.has_basis_nhds_zero.comap _
-
 lemma to_uniform_space_eq :
   to_uniform_space = @topological_add_group.to_uniform_space R _ v.subgroups_basis.topology _ :=
-uniform_space_eq (uniformity_eq R Γ₀)
-
-lemma to_topological_space_eq :
-  (by apply_instance : topological_space R) = v.subgroups_basis.topology :=
-begin
-  rw to_uniform_space_eq,
-  congr,
-end
+uniform_space_eq
+  ((has_basis_uniformity R Γ₀).eq_of_same_basis $ v.subgroups_basis.has_basis_nhds_zero.comap _)
 
 variables {R Γ₀}
 
@@ -176,19 +166,6 @@ begin
     exact h _ (valued.v.subgroups_basis.mem_add_group_filter_basis _) },
   { rintros h - ⟨γ, rfl⟩,
     exact h γ }
-end
-
-lemma separated_of_zero_sep
-  (H : ∀ x : R, x ≠ 0 → ∃ U ∈ 𝓝 (0 : R), x ∉ U) : separated_space R :=
-begin
-  -- The nasty typeclass rewrites here ultimately stem from the fact that
-  -- `topological_add_group.separated_of_zero_sep` redundantly demands a `uniform_space`
-  -- structure (which is definitionally `topological_group.to_uniform_space`).
-  -- TODO Change the conclusion to be `t2_space`, both here and in
-  -- `topological_add_group.separated_of_zero_sep`.
-  rw to_uniform_space_eq,
-  convert topological_add_group.separated_of_zero_sep H,
-  rw to_topological_space_eq,
 end
 
 end valued

--- a/src/topology/algebra/valued_field.lean
+++ b/src/topology/algebra/valued_field.lean
@@ -33,7 +33,7 @@ section move_to_correct_file
 open uniform_space
 open_locale topological_space
 
--- Bourbaki GT III §3 no.4 Proposition 7 [I hope]
+-- Bourbaki GT III §3 no.4 Proposition 7
 lemma filter.has_basis.completion_nhds_zero {G ι : Type*}
   [add_group G] [uniform_space G] [uniform_add_group G] {s : ι → set G} {p : ι → Prop}
   (h : (𝓝 (0 : G)).has_basis p s) :
@@ -54,7 +54,10 @@ begin
     { exact is_closed.preimage (continuous.prod.mk 0) hZ_closed, },
     exact ⟨i, hi, subset_trans ((is_closed.closure_subset_iff (hZ_ball_closed)).mpr
       (set.image_subset_iff.mpr hsi)) (subset_trans (ball_mono hZV 0) hV_ball)⟩, },
-  { sorry }
+  { obtain ⟨i, hi, hi'⟩ := hT,
+    suffices : closure (coe '' s i) ∈ 𝓝 (0 : completion G), { filter_upwards [this] using hi', },
+    replace h := (h (s i)).mpr ⟨i, hi, set.subset.rfl⟩,
+    exact completion.dense_inducing_coe.closure_image_mem_nhds h, },
 end
 
 end move_to_correct_file

--- a/src/topology/algebra/valued_field.lean
+++ b/src/topology/algebra/valued_field.lean
@@ -386,8 +386,7 @@ noncomputable instance valued_completion : valued (hat K) Γ₀ :=
 { v := extension_valuation,
   is_topological_valuation := λ s,
   begin
-    suffices : has_basis (𝓝 (0 : hat K)) (λ _, true) (λ (γ : Γ₀ˣ),
-      { x | extension_valuation x < (γ : Γ₀) }),
+    suffices : has_basis (𝓝 (0 : hat K)) (λ _, true) (λ γ : Γ₀ˣ, { x | extension_valuation x < γ }),
     { rw this.mem_iff,
       exact exists_congr (λ γ, by simp), },
     simp_rw ← closure_coe_completion_v_lt,

--- a/src/topology/algebra/valued_field.lean
+++ b/src/topology/algebra/valued_field.lean
@@ -338,7 +338,28 @@ noncomputable def extension_valuation :
 -- Bourbaki CA VI §5 no.3 Proposition 5 (d) [I hope]
 lemma closure_v_lt {γ : Γ₀ˣ} :
   closure (coe '' { x : K | v x < (γ : Γ₀) }) = { x : hat K | extension_valuation x < (γ : Γ₀) } :=
-sorry
+begin
+  refine le_antisymm (λ x hx, _) (λ x hx, _),
+  { -- TODO Golf this ridiculous proof!
+    let γ₀ := extension_valuation x,
+    change γ₀ < (γ : Γ₀),
+    cases eq_or_ne γ₀ 0,
+    { simp [h], },
+    { have hγ₀ : is_open ({ γ₀ } : set Γ₀),
+      { simp only [is_open_iff_mem_nhds, mem_singleton_iff, forall_eq],
+        apply (linear_ordered_comm_group_with_zero.has_basis_nhds_of_ne_zero h).mem_of_mem
+          true.intro,
+        exact unit.star, },
+      let u := (extension_valuation : hat K → Γ₀)⁻¹' { γ₀ },
+      have hu : x ∈ u, { simp, },
+      obtain ⟨-, hy₁, y, hy₂, rfl⟩ :=
+        mem_closure_iff.mp hx u (continuous_extension.is_open_preimage _ hγ₀) hu,
+      replace hy₁ : v y = γ₀, { rw ← extension_extends y, simp at hy₁, exact hy₁, },
+      rw ← hy₁,
+      exact hy₂, }, },
+  { -- Oh, it's basically the same argument. OK tidy up later.
+    sorry, },
+end
 
 noncomputable instance valued_completion : valued (hat K) Γ₀ :=
 { v := valued.extension_valuation,

--- a/src/topology/algebra/valued_field.lean
+++ b/src/topology/algebra/valued_field.lean
@@ -28,6 +28,19 @@ separated, so the map from `K` to `hat K` is injective.
 Then we extend the valuation given on `K` to a valuation on `hat K`.
 -/
 
+section move_to_correct_file
+
+open uniform_space
+open_locale topological_space
+
+-- Bourbaki GT III §3 no.4 Proposition 7 [I hope]
+lemma filter.has_basis.completion_nhds_zero {G ι : Type*}
+  [add_group G] [uniform_space G] [uniform_add_group G] {s : ι → set G} {p : ι → Prop}
+  (h : (𝓝 (0 : G)).has_basis p s) :
+  (𝓝 (0 : completion G)).has_basis p $ λ i, closure $ coe '' (s i) :=
+sorry
+
+end move_to_correct_file
 
 open filter set
 open_locale topological_space
@@ -104,7 +117,7 @@ instance valued.topological_division_ring [valued K Γ₀] : topological_divisio
 @[priority 100]
 instance valued_ring.separated [valued K Γ₀] : separated_space K :=
 begin
-  apply topological_add_group.separated_of_zero_sep,
+  apply valued.separated_of_zero_sep,
   intros x x_ne,
   refine ⟨{k | v k < v x}, _, λ h, lt_irrefl _ h⟩,
   rw valued.mem_nhds,
@@ -142,7 +155,7 @@ end valuation_topological_division_ring
 
 end division_ring
 
-section valuation_on_valued_field_completion
+namespace valued
 open uniform_space
 
 variables {K : Type*} [field K] {Γ₀ : Type*} [linear_ordered_comm_group_with_zero Γ₀]
@@ -150,13 +163,11 @@ variables {K : Type*} [field K] {Γ₀ : Type*} [linear_ordered_comm_group_with_
 
 include hv
 
-open valued uniform_space
-
 local notation `hat ` := completion
 
 /-- A valued field is completable. -/
 @[priority 100]
-instance valued.completable : completable_top_field K :=
+instance completable : completable_top_field K :=
 { nice := begin
     rintros F hF h0,
     have : ∃ (γ₀ : Γ₀ˣ) (M ∈ F), ∀ x ∈ M, (γ₀ : Γ₀) ≤ v x,
@@ -203,10 +214,10 @@ instance valued.completable : completable_top_field K :=
 local attribute [instance] linear_ordered_comm_group_with_zero.topological_space
 
 /-- The extension of the valuation of a valued field to the completion of the field. -/
-noncomputable def valued.extension : hat K → Γ₀ :=
+noncomputable def extension : hat K → Γ₀ :=
 completion.dense_inducing_coe.extend (v : K → Γ₀)
 
-lemma valued.continuous_extension : continuous (valued.extension : hat K → Γ₀) :=
+lemma continuous_extension : continuous (valued.extension : hat K → Γ₀) :=
  begin
   refine completion.dense_inducing_coe.continuous_extend _,
   intro x₀,
@@ -282,8 +293,8 @@ lemma valued.continuous_extension : continuous (valued.extension : hat K → Γ�
          ... = v z₀ : by rw [this, one_mul]  },
 end
 
-@[norm_cast]
-lemma valued.extension_extends (x : K) : (valued.extension (x : hat K) : Γ₀) = v x :=
+@[simp, norm_cast]
+lemma extension_extends (x : K) : extension (x : hat K) = v x :=
 begin
   haveI : t2_space Γ₀ := regular_space.t2_space _,
   refine completion.dense_inducing_coe.extend_eq_of_tendsto _,
@@ -292,7 +303,7 @@ begin
 end
 
 /-- the extension of a valuation on a division ring to its completion. -/
-noncomputable def valued.extension_valuation :
+noncomputable def extension_valuation :
   valuation (hat K) Γ₀ :=
 { to_fun := valued.extension,
   map_zero' := by { rw [← v.map_zero, ← valued.extension_extends (0 : K)], refl, },
@@ -324,4 +335,27 @@ noncomputable def valued.extension_valuation :
       exact v.map_add x y, },
   end }
 
-end valuation_on_valued_field_completion
+-- Bourbaki CA VI §5 no.3 Proposition 5 (d) [I hope]
+lemma closure_v_lt {γ : Γ₀ˣ} :
+  closure (coe '' { x : K | v x < (γ : Γ₀) }) = { x : hat K | extension_valuation x < (γ : Γ₀) } :=
+sorry
+
+noncomputable instance valued_completion : valued (hat K) Γ₀ :=
+{ v := valued.extension_valuation,
+  is_uniform_valuation := λ s,
+  begin
+    suffices : has_basis (𝓝 (0 : hat K)) (λ _, true) (λ (γ : Γ₀ˣ),
+      { x | valued.extension_valuation x < (γ : Γ₀) }),
+    { simp only [uniformity_eq_comap_nhds_zero, mem_comap],
+      split,
+      { rintros ⟨n, hn, hns⟩,
+        obtain ⟨γ, -, hγ⟩ := this.mem_iff.mp hn,
+        exact ⟨γ, subset.trans (preimage_mono hγ) hns⟩, },
+      { rintros ⟨γ, hγ⟩,
+        exact ⟨{ x | valued.extension_valuation x < (γ : Γ₀) },
+          this.mem_iff.mpr ⟨γ, trivial, subset.rfl⟩, subset.trans subset.rfl hγ⟩, }, },
+    simp_rw ← valued.closure_v_lt,
+    exact (valued.has_basis_nhds_zero K Γ₀).completion_nhds_zero,
+  end }
+
+end valued

--- a/src/topology/algebra/valued_field.lean
+++ b/src/topology/algebra/valued_field.lean
@@ -103,7 +103,8 @@ instance valued.topological_division_ring [valued K Γ₀] : topological_divisio
 @[priority 100]
 instance valued_ring.separated [valued K Γ₀] : separated_space K :=
 begin
-  apply valued.separated_of_zero_sep,
+  rw separated_iff_t2,
+  apply topological_add_group.t2_space_of_zero_sep,
   intros x x_ne,
   refine ⟨{k | v k < v x}, _, λ h, lt_irrefl _ h⟩,
   rw valued.mem_nhds,

--- a/src/topology/algebra/valued_field.lean
+++ b/src/topology/algebra/valued_field.lean
@@ -336,27 +336,21 @@ noncomputable def extension_valuation :
   end }
 
 -- Bourbaki CA VI §5 no.3 Proposition 5 (d)
-lemma closure_v_lt {γ : Γ₀ˣ} :
+lemma closure_coe_completion_v_lt {γ : Γ₀ˣ} :
   closure (coe '' { x : K | v x < (γ : Γ₀) }) = { x : hat K | extension_valuation x < (γ : Γ₀) } :=
 begin
   ext x,
   let γ₀ := extension_valuation x,
   suffices : γ₀ ≠ 0 → (x ∈ closure (coe '' { x : K | v x < (γ : Γ₀) }) ↔ γ₀ < (γ : Γ₀)),
   { cases eq_or_ne γ₀ 0,
-    { rw valuation.zero_iff at h,
-      simp only [h, mem_set_of_eq, valuation.map_zero, units.zero_lt, iff_true],
+    { simp only [h, (valuation.zero_iff _).mp h, mem_set_of_eq, valuation.map_zero, units.zero_lt,
+        iff_true],
       apply subset_closure,
-      use 0,
-      simpa only [mem_set_of_eq, valuation.map_zero, units.zero_lt, true_and], },
+      exact ⟨0, by simpa only [mem_set_of_eq, valuation.map_zero, units.zero_lt, true_and]⟩, },
     { exact this h, }, },
   intros h,
-  have hγ₀ : { γ₀ } ∈ 𝓝 γ₀,
-  { apply (linear_ordered_comm_group_with_zero.has_basis_nhds_of_ne_zero h).mem_of_mem
-      true.intro,
-    exact unit.star, },
-  replace hγ₀ := continuous_extension.continuous_at.preimage_mem_nhds hγ₀,
-  let u := (extension_valuation : hat K → Γ₀)⁻¹' { γ₀ },
-  have hu : x ∈ u, { simp, },
+  have hγ₀ : extension ⁻¹' {γ₀} ∈ 𝓝 x := continuous_extension.continuous_at.preimage_mem_nhds
+    (linear_ordered_comm_group_with_zero.singleton_mem_nhds_of_ne_zero h),
   rw mem_closure_iff_nhds',
   refine ⟨λ hx, _, λ hx s hs, _⟩,
   { obtain ⟨⟨-, y, hy₁ : v y < (γ : Γ₀), rfl⟩, hy₂⟩ := hx _ hγ₀,
@@ -369,21 +363,21 @@ begin
 end
 
 noncomputable instance valued_completion : valued (hat K) Γ₀ :=
-{ v := valued.extension_valuation,
+{ v := extension_valuation,
   is_uniform_valuation := λ s,
   begin
     suffices : has_basis (𝓝 (0 : hat K)) (λ _, true) (λ (γ : Γ₀ˣ),
-      { x | valued.extension_valuation x < (γ : Γ₀) }),
+      { x | extension_valuation x < (γ : Γ₀) }),
     { simp only [uniformity_eq_comap_nhds_zero, mem_comap],
       split,
       { rintros ⟨n, hn, hns⟩,
         obtain ⟨γ, -, hγ⟩ := this.mem_iff.mp hn,
         exact ⟨γ, subset.trans (preimage_mono hγ) hns⟩, },
       { rintros ⟨γ, hγ⟩,
-        exact ⟨{ x | valued.extension_valuation x < (γ : Γ₀) },
+        exact ⟨{ x | extension_valuation x < (γ : Γ₀) },
           this.mem_iff.mpr ⟨γ, trivial, subset.rfl⟩, subset.trans subset.rfl hγ⟩, }, },
-    simp_rw ← valued.closure_v_lt,
-    exact (valued.has_basis_nhds_zero K Γ₀).completion_nhds_zero,
+    simp_rw ← closure_coe_completion_v_lt,
+    exact (has_basis_nhds_zero K Γ₀).completion_nhds_zero,
   end }
 
 end valued

--- a/src/topology/algebra/valued_field.lean
+++ b/src/topology/algebra/valued_field.lean
@@ -28,40 +28,6 @@ separated, so the map from `K` to `hat K` is injective.
 Then we extend the valuation given on `K` to a valuation on `hat K`.
 -/
 
-section move_to_correct_file
-
-open uniform_space
-open_locale topological_space
-
--- Bourbaki GT III §3 no.4 Proposition 7
-lemma filter.has_basis.completion_nhds_zero {G ι : Type*}
-  [add_group G] [uniform_space G] [uniform_add_group G] {s : ι → set G} {p : ι → Prop}
-  (h : (𝓝 (0 : G)).has_basis p s) :
-  (𝓝 (0 : completion G)).has_basis p $ λ i, closure $ coe '' (s i) :=
-begin
-  rw filter.has_basis_iff at h ⊢,
-  intro T,
-  refine ⟨λ hT, _, λ hT, _⟩,
-  { obtain ⟨V, hV_unif, hV_ball⟩ := uniform_space.mem_nhds_iff.mp hT,
-    obtain ⟨Z, hZ_unif, hZ_closed, hZV⟩ := mem_uniformity_is_closed hV_unif,
-    have h_coe : coe ⁻¹' (ball 0 Z) ∈ 𝓝 (0 : G),
-    { rw uniform_space.mem_nhds_iff,
-      refine ⟨(λ (p : G × G), (↑(p.fst), ↑(p.snd))) ⁻¹' Z, _, rfl.subset⟩,
-      { rw ← uniform_space.completion.comap_coe_eq_uniformity,
-        use [Z, hZ_unif], }},
-    obtain ⟨i, hi, hsi⟩ := (h (coe ⁻¹' (ball 0 Z))).mp h_coe,
-    have hZ_ball_closed : is_closed (ball 0 Z),
-    { exact is_closed.preimage (continuous.prod.mk 0) hZ_closed, },
-    exact ⟨i, hi, subset_trans ((is_closed.closure_subset_iff (hZ_ball_closed)).mpr
-      (set.image_subset_iff.mpr hsi)) (subset_trans (ball_mono hZV 0) hV_ball)⟩, },
-  { obtain ⟨i, hi, hi'⟩ := hT,
-    suffices : closure (coe '' s i) ∈ 𝓝 (0 : completion G), { filter_upwards [this] using hi', },
-    replace h := (h (s i)).mpr ⟨i, hi, set.subset.rfl⟩,
-    exact completion.dense_inducing_coe.closure_image_mem_nhds h, },
-end
-
-end move_to_correct_file
-
 open filter set
 open_locale topological_space
 
@@ -390,7 +356,7 @@ noncomputable instance valued_completion : valued (hat K) Γ₀ :=
     { rw this.mem_iff,
       exact exists_congr (λ γ, by simp), },
     simp_rw ← closure_coe_completion_v_lt,
-    exact (has_basis_nhds_zero K Γ₀).completion_nhds_zero,
+    exact (has_basis_nhds_zero K Γ₀).completion_has_basis_closure_nhds_zero,
   end }
 
 end valued

--- a/src/topology/algebra/valued_field.lean
+++ b/src/topology/algebra/valued_field.lean
@@ -356,7 +356,7 @@ noncomputable instance valued_completion : valued (hat K) Γ₀ :=
     { rw this.mem_iff,
       exact exists_congr (λ γ, by simp), },
     simp_rw ← closure_coe_completion_v_lt,
-    exact (has_basis_nhds_zero K Γ₀).completion_has_basis_closure_nhds_zero,
+    exact (has_basis_nhds_zero K Γ₀).has_basis_of_dense_inducing completion.dense_inducing_coe,
   end }
 
 end valued

--- a/src/topology/algebra/valued_field.lean
+++ b/src/topology/algebra/valued_field.lean
@@ -38,7 +38,24 @@ lemma filter.has_basis.completion_nhds_zero {G ι : Type*}
   [add_group G] [uniform_space G] [uniform_add_group G] {s : ι → set G} {p : ι → Prop}
   (h : (𝓝 (0 : G)).has_basis p s) :
   (𝓝 (0 : completion G)).has_basis p $ λ i, closure $ coe '' (s i) :=
-sorry
+begin
+  rw filter.has_basis_iff at h ⊢,
+  intro T,
+  refine ⟨λ hT, _, λ hT, _⟩,
+  { obtain ⟨V, hV_unif, hV_ball⟩ := uniform_space.mem_nhds_iff.mp hT,
+    obtain ⟨Z, hZ_unif, hZ_closed, hZV⟩ := mem_uniformity_is_closed hV_unif,
+    have h_coe : coe ⁻¹' (ball 0 Z) ∈ 𝓝 (0 : G),
+    { rw uniform_space.mem_nhds_iff,
+      refine ⟨(λ (p : G × G), (↑(p.fst), ↑(p.snd))) ⁻¹' Z, _, rfl.subset⟩,
+      { rw ← uniform_space.completion.comap_coe_eq_uniformity,
+        use [Z, hZ_unif], }},
+    obtain ⟨i, hi, hsi⟩ := (h (coe ⁻¹' (ball 0 Z))).mp h_coe,
+    have hZ_ball_closed : is_closed (ball 0 Z),
+    { exact is_closed.preimage (continuous.prod.mk 0) hZ_closed, },
+    exact ⟨i, hi, subset_trans ((is_closed.closure_subset_iff (hZ_ball_closed)).mpr
+      (set.image_subset_iff.mpr hsi)) (subset_trans (ball_mono hZV 0) hV_ball)⟩, },
+  { sorry }
+end
 
 end move_to_correct_file
 

--- a/src/topology/algebra/valued_field.lean
+++ b/src/topology/algebra/valued_field.lean
@@ -335,30 +335,37 @@ noncomputable def extension_valuation :
       exact v.map_add x y, },
   end }
 
--- Bourbaki CA VI §5 no.3 Proposition 5 (d) [I hope]
+-- Bourbaki CA VI §5 no.3 Proposition 5 (d)
 lemma closure_v_lt {γ : Γ₀ˣ} :
   closure (coe '' { x : K | v x < (γ : Γ₀) }) = { x : hat K | extension_valuation x < (γ : Γ₀) } :=
 begin
-  refine le_antisymm (λ x hx, _) (λ x hx, _),
-  { -- TODO Golf this ridiculous proof!
-    let γ₀ := extension_valuation x,
-    change γ₀ < (γ : Γ₀),
-    cases eq_or_ne γ₀ 0,
-    { simp [h], },
-    { have hγ₀ : is_open ({ γ₀ } : set Γ₀),
-      { simp only [is_open_iff_mem_nhds, mem_singleton_iff, forall_eq],
-        apply (linear_ordered_comm_group_with_zero.has_basis_nhds_of_ne_zero h).mem_of_mem
-          true.intro,
-        exact unit.star, },
-      let u := (extension_valuation : hat K → Γ₀)⁻¹' { γ₀ },
-      have hu : x ∈ u, { simp, },
-      obtain ⟨-, hy₁, y, hy₂, rfl⟩ :=
-        mem_closure_iff.mp hx u (continuous_extension.is_open_preimage _ hγ₀) hu,
-      replace hy₁ : v y = γ₀, { rw ← extension_extends y, simp at hy₁, exact hy₁, },
-      rw ← hy₁,
-      exact hy₂, }, },
-  { -- Oh, it's basically the same argument. OK tidy up later.
-    sorry, },
+  ext x,
+  let γ₀ := extension_valuation x,
+  suffices : γ₀ ≠ 0 → (x ∈ closure (coe '' { x : K | v x < (γ : Γ₀) }) ↔ γ₀ < (γ : Γ₀)),
+  { cases eq_or_ne γ₀ 0,
+    { rw valuation.zero_iff at h,
+      simp only [h, mem_set_of_eq, valuation.map_zero, units.zero_lt, iff_true],
+      apply subset_closure,
+      use 0,
+      simpa only [mem_set_of_eq, valuation.map_zero, units.zero_lt, true_and], },
+    { exact this h, }, },
+  intros h,
+  have hγ₀ : { γ₀ } ∈ 𝓝 γ₀,
+  { apply (linear_ordered_comm_group_with_zero.has_basis_nhds_of_ne_zero h).mem_of_mem
+      true.intro,
+    exact unit.star, },
+  replace hγ₀ := continuous_extension.continuous_at.preimage_mem_nhds hγ₀,
+  let u := (extension_valuation : hat K → Γ₀)⁻¹' { γ₀ },
+  have hu : x ∈ u, { simp, },
+  rw mem_closure_iff_nhds',
+  refine ⟨λ hx, _, λ hx s hs, _⟩,
+  { obtain ⟨⟨-, y, hy₁ : v y < (γ : Γ₀), rfl⟩, hy₂⟩ := hx _ hγ₀,
+    replace hy₂ : v y = γ₀, { simpa using hy₂, },
+    rwa ← hy₂, },
+  { obtain ⟨y, hy₁, hy₂ : ↑y ∈ s⟩ := completion.dense_range_coe.mem_nhds (inter_mem hγ₀ hs),
+    replace hy₁ : v y = γ₀, { simpa using hy₁, },
+    rw ← hy₁ at hx,
+    exact ⟨⟨y, ⟨y, hx, rfl⟩⟩, hy₂⟩, },
 end
 
 noncomputable instance valued_completion : valued (hat K) Γ₀ :=

--- a/src/topology/algebra/valued_field.lean
+++ b/src/topology/algebra/valued_field.lean
@@ -364,18 +364,12 @@ end
 
 noncomputable instance valued_completion : valued (hat K) Γ₀ :=
 { v := extension_valuation,
-  is_uniform_valuation := λ s,
+  is_topological_valuation := λ s,
   begin
     suffices : has_basis (𝓝 (0 : hat K)) (λ _, true) (λ (γ : Γ₀ˣ),
       { x | extension_valuation x < (γ : Γ₀) }),
-    { simp only [uniformity_eq_comap_nhds_zero, mem_comap],
-      split,
-      { rintros ⟨n, hn, hns⟩,
-        obtain ⟨γ, -, hγ⟩ := this.mem_iff.mp hn,
-        exact ⟨γ, subset.trans (preimage_mono hγ) hns⟩, },
-      { rintros ⟨γ, hγ⟩,
-        exact ⟨{ x | extension_valuation x < (γ : Γ₀) },
-          this.mem_iff.mpr ⟨γ, trivial, subset.rfl⟩, subset.trans subset.rfl hγ⟩, }, },
+    { rw this.mem_iff,
+      exact exists_congr (λ γ, by simp), },
     simp_rw ← closure_coe_completion_v_lt,
     exact (has_basis_nhds_zero K Γ₀).completion_nhds_zero,
   end }

--- a/src/topology/algebra/with_zero_topology.lean
+++ b/src/topology/algebra/with_zero_topology.lean
@@ -160,6 +160,12 @@ lemma has_basis_nhds_of_ne_zero {x : Γ₀} (h : x ≠ 0) :
   has_basis (𝓝 x) (λ i : unit, true) (λ i, {x}) :=
 has_basis_nhds_units (units.mk0 x h)
 
+lemma singleton_mem_nhds_of_ne_zero {x : Γ₀} (h : x ≠ 0) : {x} ∈ 𝓝 x :=
+begin
+  apply (has_basis_nhds_of_ne_zero h).mem_of_mem true.intro,
+  exact unit.star,
+end
+
 lemma tendsto_units {α : Type*} {F : filter α} {f : α → Γ₀} {γ₀ : Γ₀ˣ} :
   tendsto f F (𝓝 (γ₀ : Γ₀)) ↔ { x : α | f x = γ₀ } ∈ F :=
 begin

--- a/src/topology/dense_embedding.lean
+++ b/src/topology/dense_embedding.lean
@@ -337,3 +337,26 @@ lemma dense_range.equalizer (hfd : dense_range f)
   g = h :=
 funext $ λ y, hfd.induction_on y (is_closed_eq hg hh) $ congr_fun H
 end
+
+-- Bourbaki GT III §3 no.4 Proposition 7 (generalised to any dense-inducing map to a regular space)
+lemma filter.has_basis.has_basis_of_dense_inducing
+  [topological_space α] [topological_space β] [regular_space β]
+  {ι : Type*} {s : ι → set α} {p : ι → Prop} {x : α} (h : (𝓝 x).has_basis p s)
+  {f : α → β} (hf : dense_inducing f) :
+  (𝓝 (f x)).has_basis p $ λ i, closure $ f '' (s i) :=
+begin
+  rw filter.has_basis_iff at h ⊢,
+  intros T,
+  refine ⟨λ hT, _, λ hT, _⟩,
+  { obtain ⟨T', hT₁, hT₂, hT₃⟩ := nhds_is_closed hT,
+    have hT₄ : f⁻¹' T' ∈ 𝓝 x,
+    { rw hf.to_inducing.nhds_eq_comap x,
+      exact ⟨T', hT₁, subset.rfl⟩, },
+    obtain ⟨i, hi, hi'⟩ := (h _).mp hT₄,
+    exact ⟨i, hi, (closure_mono (image_subset f hi')).trans (subset.trans (closure_minimal
+      (image_subset_iff.mpr subset.rfl) hT₃) hT₂)⟩, },
+  { obtain ⟨i, hi, hi'⟩ := hT,
+    suffices : closure (f '' s i) ∈ 𝓝 (f x), { filter_upwards [this] using hi', },
+    replace h := (h (s i)).mpr ⟨i, hi, subset.rfl⟩,
+    exact hf.closure_image_mem_nhds h, },
+end


### PR DESCRIPTION
This allows us to solve a `uniform_space` diamond problem that arises when extending valuations to the completion of a valued field.

More precisely, the main goal of this PR is to make the following work:
```lean
import topology.algebra.valued_field

example  {K Γ₀ : Type*} [field K] [linear_ordered_comm_group_with_zero Γ₀] [valued K Γ₀] :
  uniform_space.completion.uniform_space K = valued.to_uniform_space :=
rfl
```

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
