### PR TITLE
feat(linear_algebra/tensor_product): tensor product of finite modules is finite

### DIFF
--- a/src/linear_algebra/tensor_product.lean
+++ b/src/linear_algebra/tensor_product.lean
@@ -366,6 +366,30 @@ begin
   { intros t₁ t₂ ht₁ ht₂, exact submodule.add_mem _ ht₁ ht₂, },
 end
 
+variables {R M N}
+
+theorem span_tmul_set_eq_top {sM : set M} {sN : set N} (hM : submodule.span R sM = ⊤)
+  (hN : submodule.span R sN = ⊤) :
+  submodule.span R { t : M ⊗[R] N | ∃ (m ∈ sM) (n ∈ sN), m ⊗ₜ n = t } = ⊤ :=
+begin
+  ext t, simp only [submodule.mem_top, iff_true],
+  apply t.induction_on,
+  { exact submodule.zero_mem _, },
+  { intros m' n',
+    have hm' : m' ∈ submodule.span R sM := by {rw hM, exact submodule.mem_top},
+    have hn' : n' ∈ submodule.span R sN := by {rw hN, exact submodule.mem_top},
+    refine submodule.span_induction hm' _ _ _ _,
+    { intros m hm, refine submodule.span_induction hn' _ _ _ _,
+      { intros n hn, apply submodule.subset_span, use [m, hm, n, hn], },
+      { rw tmul_zero, exact submodule.zero_mem _, },
+      { intros n₁ n₂ hn₁ hn₂, rw tmul_add, exact submodule.add_mem _ hn₁ hn₂, },
+      { intros r n hn, rw tmul_smul, exact submodule.smul_mem _ r hn, }, },
+    { rw zero_tmul, exact submodule.zero_mem _, },
+    { intros m₁ m₂ hm₁ hm₂, rw add_tmul, exact submodule.add_mem _ hm₁ hm₂, },
+    { intros r m hm, rw ←smul_tmul', exact submodule.smul_mem _ r hm, }, },
+  { intros t₁ t₂ ht₁ ht₂, exact submodule.add_mem _ ht₁ ht₂, },
+end
+
 end module
 
 section UMP

--- a/src/linear_algebra/tensor_product.lean
+++ b/src/linear_algebra/tensor_product.lean
@@ -372,22 +372,17 @@ theorem span_tmul_set_eq_top {sM : set M} {sN : set N} (hM : submodule.span R sM
   (hN : submodule.span R sN = ⊤) :
   submodule.span R { t : M ⊗[R] N | ∃ (m ∈ sM) (n ∈ sN), m ⊗ₜ n = t } = ⊤ :=
 begin
-  ext t, simp only [submodule.mem_top, iff_true],
-  apply t.induction_on,
-  { exact submodule.zero_mem _, },
-  { intros m' n',
-    have hm' : m' ∈ submodule.span R sM := by {rw hM, exact submodule.mem_top},
-    have hn' : n' ∈ submodule.span R sN := by {rw hN, exact submodule.mem_top},
-    refine submodule.span_induction hm' _ _ _ _,
-    { intros m hm, refine submodule.span_induction hn' _ _ _ _,
-      { intros n hn, apply submodule.subset_span, use [m, hm, n, hn], },
-      { rw tmul_zero, exact submodule.zero_mem _, },
-      { intros n₁ n₂ hn₁ hn₂, rw tmul_add, exact submodule.add_mem _ hn₁ hn₂, },
-      { intros r n hn, rw tmul_smul, exact submodule.smul_mem _ r hn, }, },
-    { rw zero_tmul, exact submodule.zero_mem _, },
-    { intros m₁ m₂ hm₁ hm₂, rw add_tmul, exact submodule.add_mem _ hm₁ hm₂, },
-    { intros r m hm, rw ←smul_tmul', exact submodule.smul_mem _ r hm, }, },
-  { intros t₁ t₂ ht₁ ht₂, exact submodule.add_mem _ ht₁ ht₂, },
+  apply le_antisymm, { intros _ _, triv },
+  rw [← span_tmul_eq_top, submodule.span_le], rintro t ⟨m, n, rfl⟩, rw set_like.mem_coe,
+  apply submodule.span_induction (hM.substr (by triv : m ∈ ⊤)),
+  { intros m hm, apply submodule.span_induction (hN.substr (by triv : n ∈ ⊤)),
+    { exact λ n hn, submodule.subset_span ⟨m, hm, n, hn, rfl⟩, },
+    { rw tmul_zero, exact submodule.zero_mem _, },
+    { intros n₁ n₂ hn₁ hn₂, rw tmul_add, exact submodule.add_mem _ hn₁ hn₂, },
+    { intros r n hn, rw tmul_smul, exact submodule.smul_mem _ r hn, }, },
+  { rw zero_tmul, exact submodule.zero_mem _, },
+  { intros m₁ m₂ hm₁ hm₂, rw add_tmul, exact submodule.add_mem _ hm₁ hm₂, },
+  { intros r m hm, rw ←smul_tmul', exact submodule.smul_mem _ r hm, },
 end
 
 end module

--- a/src/linear_algebra/tensor_product_basis.lean
+++ b/src/linear_algebra/tensor_product_basis.lean
@@ -16,6 +16,8 @@ These can not go into `linear_algebra.tensor_product` since they depend on
 noncomputable theory
 open set linear_map submodule
 
+open_locale tensor_product
+
 section comm_ring
 variables {R : Type*} {M : Type*} {N : Type*} {ι : Type*} {κ : Type*}
 variables [comm_ring R] [add_comm_group M] [module R M] [add_comm_group N] [module R N]
@@ -50,3 +52,27 @@ finite_dimensional.of_fintype_basis
   (basis.tensor_product (basis.of_vector_space K V) (basis.of_vector_space K W))
 
 end field
+
+section finiteness
+
+variables {R : Type*} {M : Type*} {N : Type*}
+variables [comm_semiring R] [add_comm_monoid M] [module R M] [add_comm_monoid N] [module R N]
+variables [module.finite R M] [module.finite R N]
+
+instance tensor_product.finite : module.finite R (M ⊗[R] N) :=
+{ out := begin
+  rcases _inst_6.out with ⟨sM, hM⟩,
+  rcases _inst_7.out with ⟨sN, hN⟩,
+  let s := { t : M ⊗[R] N | ∃ (m ∈ sM) (n ∈ sN), m ⊗ₜ n = t },
+  have h : s = (λ p : M × N, p.1 ⊗ₜ p.2) '' (finset.product sM sN) :=
+  by { ext, split,
+       { intro hx, rcases hx with ⟨m, hm, n, hn, hx'⟩,
+       use ⟨(m, n), finset.mk_mem_product hm hn, by rw [←hx']⟩, },
+       { intro hx, rcases hx with ⟨p, hp, hx'⟩,
+       use ⟨p.1, (finset.mem_product.1 hp).1, p.2, (finset.mem_product.1 hp).2, by rw [←hx']⟩, }, },
+  rw submodule.fg_def,
+  use ⟨s, by {rw h, exact finite.image _ (finset.finite_to_set _)},
+    tensor_product.span_tmul_set_eq_top hM hN⟩,
+end }
+
+end finiteness


### PR DESCRIPTION
I'm not sure where to put `tensor_product.finite`. It can't go in `linear_algebra/tensor_product` because I cannot import `ring_theory/finiteness` from there. I've put it in `tensor_product_basis` for now, let me know if you have a better idea of where it should go.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
