### PR TITLE
feat(measure_theory/measure/measure_space): relax a hypothesis for map_map

### DIFF
--- a/src/dynamics/ergodic/measure_preserving.lean
+++ b/src/dynamics/ergodic/measure_preserving.lean
@@ -59,7 +59,8 @@ hf.1.ae_measurable
 lemma symm {e : α ≃ᵐ β} {μa : measure α} {μb : measure β} (h : measure_preserving e μa μb) :
   measure_preserving e.symm μb μa :=
 ⟨e.symm.measurable,
-  by rw [← h.map_eq, map_map e.symm.measurable e.measurable, e.symm_comp_self, map_id]⟩
+  by rw [← h.map_eq, map_map e.symm.measurable e.measurable.ae_measurable, e.symm_comp_self,
+    map_id]⟩
 
 lemma restrict_preimage {f : α → β} (hf : measure_preserving f μa μb) {s : set β}
   (hs : measurable_set s) : measure_preserving f (μa.restrict (f ⁻¹' s)) (μb.restrict s) :=
@@ -86,7 +87,7 @@ protected lemma quasi_measure_preserving {f : α → β} (hf : measure_preservin
 lemma comp {g : β → γ} {f : α → β} (hg : measure_preserving g μb μc)
   (hf : measure_preserving f μa μb) :
   measure_preserving (g ∘ f) μa μc :=
-⟨hg.1.comp hf.1, by rw [← map_map hg.1 hf.1, hf.2, hg.2]⟩
+⟨hg.1.comp hf.1, by rw [← map_map hg.1 hf.1.ae_measurable, hf.2, hg.2]⟩
 
 protected lemma sigma_finite {f : α → β} (hf : measure_preserving f μa μb) [sigma_finite μb] :
   sigma_finite μa :=

--- a/src/measure_theory/category/Meas.lean
+++ b/src/measure_theory/category/Meas.lean
@@ -65,7 +65,8 @@ def Measure : Meas ⥤ Meas :=
   map      := λX Y f, ⟨measure.map (f : X → Y), measure.measurable_map f f.2⟩,
   map_id'  := assume ⟨α, I⟩, subtype.eq $ funext $ assume μ, @measure.map_id α I μ,
   map_comp':=
-    assume X Y Z ⟨f, hf⟩ ⟨g, hg⟩, subtype.eq $ funext $ assume μ, (measure.map_map hg hf).symm }
+    assume X Y Z ⟨f, hf⟩ ⟨g, hg⟩, subtype.eq $ funext $ assume μ,
+      (measure.map_map hg hf.ae_measurable).symm }
 
 /-- The Giry monad, i.e. the monadic structure associated with `Measure`. -/
 def Giry : category_theory.monad Meas :=

--- a/src/measure_theory/function/jacobian.lean
+++ b/src/measure_theory/function/jacobian.lean
@@ -1178,8 +1178,8 @@ begin
   set F : s → E := u ∘ coe with hF,
   have A : measure.map F
     (comap coe (μ.with_density (λ x, ennreal.of_real (|(f' x).det|)))) = μ.restrict (u '' s),
-  { rw [hF, ← measure.map_map u_meas measurable_subtype_coe, map_comap_subtype_coe hs,
-        restrict_with_density hs],
+  { rw [hF, ← measure.map_map u_meas measurable_subtype_coe.ae_measurable,
+        map_comap_subtype_coe hs, restrict_with_density hs],
     exact map_with_density_abs_det_fderiv_eq_add_haar μ hs u' (hf.congr uf.symm) u_meas },
   rw uf.image_eq at A,
   have : F = s.restrict f,

--- a/src/measure_theory/group/integration.lean
+++ b/src/measure_theory/group/integration.lean
@@ -133,7 +133,7 @@ begin
   rw [← map_mul_right_inv_eq_self μ g⁻¹, integrable_map_measure, function.comp],
   { simp_rw [div_inv_eq_mul, mul_inv_cancel_left], exact hf },
   { refine ae_strongly_measurable.comp_measurable _ (measurable_id.const_div g),
-    simp_rw [map_map (measurable_id'.const_div g) (measurable_id'.const_mul g⁻¹).inv,
+    simp_rw [map_map (measurable_id'.const_div g) (ae_measurable_id'.const_mul g⁻¹).inv,
       function.comp, div_inv_eq_mul, mul_inv_cancel_left, map_id'],
     exact hf.ae_strongly_measurable },
   { exact (measurable_id'.const_mul g⁻¹).inv.ae_measurable }

--- a/src/measure_theory/group/measure.lean
+++ b/src/measure_theory/group/measure.lean
@@ -200,8 +200,9 @@ begin
   constructor,
   intro g,
   conv_rhs { rw [← map_mul_left_eq_self μ g⁻¹] },
-  simp_rw [measure.inv, map_map (measurable_mul_const g) measurable_inv,
-    map_map measurable_inv (measurable_const_mul g⁻¹), function.comp, mul_inv_rev, inv_inv]
+  simp_rw [measure.inv, map_map (measurable_mul_const g) measurable_inv.ae_measurable,
+    map_map measurable_inv (measurable_const_mul g⁻¹).ae_measurable, function.comp,
+    mul_inv_rev, inv_inv]
 end
 
 @[to_additive]
@@ -210,8 +211,9 @@ begin
   constructor,
   intro g,
   conv_rhs { rw [← map_mul_right_eq_self μ g⁻¹] },
-  simp_rw [measure.inv, map_map (measurable_const_mul g) measurable_inv,
-    map_map measurable_inv (measurable_mul_const g⁻¹), function.comp, mul_inv_rev, inv_inv]
+  simp_rw [measure.inv, map_map (measurable_const_mul g) measurable_inv.ae_measurable,
+    map_map measurable_inv (measurable_mul_const g⁻¹).ae_measurable, function.comp,
+    mul_inv_rev, inv_inv]
 end
 
 @[to_additive]
@@ -220,7 +222,7 @@ lemma map_div_left_eq_self (μ : measure G) [is_inv_invariant μ] [is_mul_left_i
 begin
   simp_rw [div_eq_mul_inv],
   conv_rhs { rw [← map_mul_left_eq_self μ g, ← map_inv_eq_self μ] },
-  exact (map_map (measurable_const_mul g) measurable_inv).symm
+  exact (map_map (measurable_const_mul g) measurable_inv.ae_measurable).symm
 end
 
 @[to_additive]
@@ -228,7 +230,7 @@ lemma map_mul_right_inv_eq_self (μ : measure G) [is_inv_invariant μ] [is_mul_l
   (g : G) : map (λ t, (g * t)⁻¹) μ = μ :=
 begin
   conv_rhs { rw [← map_inv_eq_self μ, ← map_mul_left_eq_self μ g] },
-  exact (map_map measurable_inv (measurable_const_mul g)).symm
+  exact (map_map measurable_inv (measurable_const_mul g).ae_measurable).symm
 end
 
 end mul_inv
@@ -423,9 +425,9 @@ lemma is_haar_measure_map [borel_space G] [topological_group G] {H : Type*} [gro
 { to_is_mul_left_invariant := begin
     constructor,
     assume h,
-    rw map_map (continuous_mul_left h).measurable hf.measurable,
+    rw map_map (continuous_mul_left h).measurable hf.ae_measurable,
     conv_rhs { rw ← map_mul_left_eq_self μ (f.symm h) },
-    rw map_map hf.measurable (continuous_mul_left _).measurable,
+    rw map_map hf.measurable (continuous_mul_left _).ae_measurable,
     congr' 2,
     ext y,
     simp only [mul_equiv.apply_symm_apply, comp_app, mul_equiv.map_mul],

--- a/src/measure_theory/group/prod.lean
+++ b/src/measure_theory/group/prod.lean
@@ -75,7 +75,8 @@ lemma map_prod_mul_eq_swap [is_mul_left_invariant μ] :
   map (λ z : G × G, (z.2, z.2 * z.1)) (μ.prod ν) = ν.prod μ :=
 begin
   rw [← prod_swap],
-  simp_rw [map_map (measurable_snd.prod_mk (measurable_snd.mul measurable_fst)) measurable_swap],
+  simp_rw [map_map (measurable_snd.prod_mk (measurable_snd.mul measurable_fst))
+    measurable_swap.ae_measurable],
   exact map_prod_mul_eq ν μ
 end
 
@@ -106,8 +107,8 @@ lemma map_prod_inv_mul_eq_swap [is_mul_left_invariant μ] :
   map (λ z : G × G, (z.2, z.2⁻¹ * z.1)) (μ.prod ν) = ν.prod μ :=
 begin
   rw [← prod_swap],
-  simp_rw
-    [map_map (measurable_snd.prod_mk $ measurable_snd.inv.mul measurable_fst) measurable_swap],
+  simp_rw [map_map (measurable_snd.prod_mk $ measurable_snd.inv.mul measurable_fst)
+    measurable_swap.ae_measurable],
   exact map_prod_inv_mul_eq ν μ
 end
 
@@ -121,8 +122,8 @@ begin
     μ.prod ν,
   { convert this, ext1 ⟨x, y⟩, simp },
   simp_rw [← map_map (measurable_snd.prod_mk (measurable_snd.inv.mul measurable_fst))
-    (measurable_snd.prod_mk (measurable_snd.mul measurable_fst)), map_prod_mul_eq_swap μ ν,
-    map_prod_inv_mul_eq_swap ν μ]
+    (measurable_snd.prod_mk (measurable_snd.mul measurable_fst)).ae_measurable,
+    map_prod_mul_eq_swap μ ν, map_prod_inv_mul_eq_swap ν μ]
 end
 
 @[to_additive] lemma quasi_measure_preserving_inv [is_mul_left_invariant μ] :

--- a/src/measure_theory/measure/haar.lean
+++ b/src/measure_theory/measure/haar.lean
@@ -710,7 +710,7 @@ begin
   have : map has_inv.inv (map has_inv.inv μ) = c^2 • μ,
     by simp only [hc, smul_smul, pow_two, map_smul],
   have μeq : μ = c^2 • μ,
-  { rw [map_map continuous_inv.measurable continuous_inv.measurable] at this,
+  { rw [map_map continuous_inv.measurable continuous_inv.ae_measurable] at this,
     { simpa only [inv_involutive, involutive.comp_self, map_id] },
     all_goals { apply_instance } },
   have K : positive_compacts G := classical.arbitrary _,

--- a/src/measure_theory/measure/haar_lebesgue.lean
+++ b/src/measure_theory/measure/haar_lebesgue.lean
@@ -224,12 +224,13 @@ begin
   have Ce : continuous e := (e : E →ₗ[ℝ] (ι → ℝ)).continuous_of_finite_dimensional,
   have Cg : continuous g := linear_map.continuous_of_finite_dimensional g,
   have Cesymm : continuous e.symm := (e.symm : (ι → ℝ) →ₗ[ℝ] E).continuous_of_finite_dimensional,
-  rw [← map_map Cesymm.measurable (Cg.comp Ce).measurable, ← map_map Cg.measurable Ce.measurable],
+  rw [← map_map Cesymm.measurable (Cg.comp Ce).ae_measurable,
+    ← map_map Cg.measurable Ce.ae_measurable],
   haveI : is_add_haar_measure (map e μ) := is_add_haar_measure_map μ e.to_add_equiv Ce Cesymm,
   have ecomp : (e.symm) ∘ e = id,
     by { ext x, simp only [id.def, function.comp_app, linear_equiv.symm_apply_apply] },
   rw [map_linear_map_add_haar_pi_eq_smul_add_haar hf (map e μ), map_smul,
-    map_map Cesymm.measurable Ce.measurable, ecomp, measure.map_id]
+    map_map Cesymm.measurable Ce.ae_measurable, ecomp, measure.map_id]
 end
 
 /-- The preimage of a set `s` under a linear map `f` with nonzero determinant has measure

--- a/src/measure_theory/measure/lebesgue.lean
+++ b/src/measure_theory/measure/lebesgue.lean
@@ -355,7 +355,7 @@ begin
       IHA, smul_smul, ← ennreal.of_real_mul (abs_nonneg _), ← abs_mul, mul_comm, mul_inv₀],
     { apply continuous.measurable,
       apply linear_map.continuous_on_pi },
-    { apply continuous.measurable,
+    { apply continuous.ae_measurable,
       apply linear_map.continuous_on_pi } }
 end
 

--- a/src/measure_theory/measure/measure_space.lean
+++ b/src/measure_theory/measure/measure_space.lean
@@ -978,9 +978,9 @@ ext $ λ s, map_apply measurable_id
 
 @[simp] lemma map_id' : map (λ x, x) μ = μ := map_id
 
-lemma map_map {g : β → γ} {f : α → β} (hg : measurable g) (hf : measurable f) :
+lemma map_map {g : β → γ} {f : α → β} (hg : measurable g) (hf : ae_measurable f μ) :
   (μ.map f).map g = μ.map (g ∘ f) :=
-ext $ λ s hs, by simp [hf, hg, hs, hg hs, hg.comp hf, ← preimage_comp]
+ext $ λ s hs, by simp [hf, hg, hs, hg hs, hg.comp_ae_measurable hf, ← preimage_comp]
 
 @[mono] lemma map_mono {f : α → β} (h : μ ≤ ν) (hf : measurable f) : μ.map f ≤ ν.map f :=
 λ s hs, by simp [hf.ae_measurable, hs, h _ (hf hs)]
@@ -1775,7 +1775,8 @@ lemma mono_right (h : quasi_measure_preserving f μa μb)
 protected lemma comp {g : β → γ} {f : α → β} (hg : quasi_measure_preserving g μb μc)
   (hf : quasi_measure_preserving f μa μb) :
   quasi_measure_preserving (g ∘ f) μa μc :=
-⟨hg.measurable.comp hf.measurable, by { rw ← map_map hg.1 hf.1, exact (hf.2.map hg.1).trans hg.2 }⟩
+⟨hg.measurable.comp hf.measurable,
+  by { rw ← map_map hg.1 hf.1.ae_measurable, exact (hf.2.map hg.1).trans hg.2 }⟩
 
 protected lemma iterate {f : α → α} (hf : quasi_measure_preserving f μa μa) :
   ∀ n, quasi_measure_preserving (f^[n]) μa μa
@@ -2662,7 +2663,8 @@ lemma sigma_finite.of_map (μ : measure α) {f : α → β} (hf : ae_measurable 
 lemma _root_.measurable_equiv.sigma_finite_map {μ : measure α} (f : α ≃ᵐ β) (h : sigma_finite μ) :
   sigma_finite (μ.map f) :=
 by { refine sigma_finite.of_map _ f.symm.measurable.ae_measurable _,
-     rwa [map_map f.symm.measurable f.measurable, f.symm_comp_self, measure.map_id] }
+     rwa [map_map f.symm.measurable f.measurable.ae_measurable, f.symm_comp_self,
+      measure.map_id] }
 
 /-- Similar to `ae_of_forall_measure_lt_top_ae_restrict`, but where you additionally get the
   hypothesis that another σ-finite measure has finite values on `s`. -/
@@ -3034,10 +3036,10 @@ protected theorem map_apply (f : α ≃ᵐ β) (s : set β) : μ.map f s = μ (f
 f.measurable_embedding.map_apply _ _
 
 @[simp] lemma map_symm_map (e : α ≃ᵐ β) : (μ.map e).map e.symm  = μ :=
-by simp [map_map e.symm.measurable e.measurable]
+by simp [map_map e.symm.measurable e.measurable.ae_measurable]
 
 @[simp] lemma map_map_symm (e : α ≃ᵐ β) : (ν.map e.symm).map e  = ν :=
-by simp [map_map e.measurable e.symm.measurable]
+by simp [map_map e.measurable e.symm.measurable.ae_measurable]
 
 lemma map_measurable_equiv_injective (e : α ≃ᵐ β) : injective (map e) :=
 by { intros μ₁ μ₂ hμ, apply_fun map e.symm at hμ, simpa [map_symm_map e] using hμ }

--- a/src/probability/density.lean
+++ b/src/probability/density.lean
@@ -250,7 +250,7 @@ lemma quasi_measure_preserving_has_pdf {X : α → E} [has_pdf X ℙ μ]
   (hmap : (map g (map X ℙ)).have_lebesgue_decomposition ν) :
   has_pdf (g ∘ X) ℙ ν :=
 begin
-  rw [has_pdf_iff, ← map_map hg.measurable (has_pdf.measurable X ℙ μ)],
+  rw [has_pdf_iff, ← map_map hg.measurable (has_pdf.measurable X ℙ μ).ae_measurable],
   refine ⟨hg.measurable.comp (has_pdf.measurable X ℙ μ), hmap, _⟩,
   rw [map_eq_with_density_pdf X ℙ μ],
   refine absolutely_continuous.mk (λ s hsm hs, _),


### PR DESCRIPTION
Not sure if this is useful or misguided (and better done by adding a variant with ae_measurable assumptions), but in the statement of `measure_theory.measure.map_map` it is enough that the inner function `f` be ae_measurable wrt ambient measure, and the outer one `g` be ae_measurable wrt the image measure under f. 

This PR only relaxes the assumption on `f` because that seems to be the more useful case (the motivation is to be able to say things like if `X` is a sequence of iid integrable variables, then so is the sequence of their positive parts, so `f` would be a random variable and `g` would be an explicit and measurable function).



---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
