### PR TITLE
[Merged by Bors] - fix(src/tactic/alias): Teach `get_alias_target` about `alias f ↔ a b`

### DIFF
--- a/src/algebra/parity.lean
+++ b/src/algebra/parity.lean
@@ -53,13 +53,11 @@ by simp [is_square, pow_two]
 
 alias is_square_iff_exists_sq ↔ is_square.exists_sq is_square_of_exists_sq
 
-attribute [to_additive even.exists_two_nsmul] is_square.exists_sq
-/-- Alias of the forwards direction of `even_iff_exists_two_nsmul`. -/
-add_decl_doc even.exists_two_nsmul
+attribute [to_additive even.exists_two_nsmul "Alias of the forwards direction of
+`even_iff_exists_two_nsmul`."] is_square.exists_sq
 
-attribute [to_additive even_of_exists_two_nsmul] is_square_of_exists_sq
-/-- Alias of the backwards direction of `even_iff_exists_two_nsmul`. -/
-add_decl_doc even_of_exists_two_nsmul
+attribute [to_additive even_of_exists_two_nsmul "Alias of the backwards direction of
+`even_iff_exists_two_nsmul`."] is_square_of_exists_sq
 
 @[simp, to_additive]
 lemma is_square_one [mul_one_class α] : is_square (1 : α) := ⟨1, (mul_one _).symm⟩

--- a/test/lint_to_additive_doc.lean
+++ b/test/lint_to_additive_doc.lean
@@ -70,13 +70,15 @@ run_cmd do
   decl ← get_decl ``a_one_iff_b_one,
   res ← linter.to_additive_doc.test decl,
   -- linter is happy
-  guard $ res.is_none,
+  guard $ res.is_none
 
+run_cmd do
   decl ← get_decl ``b_one_of_a_one,
   res ← linter.to_additive_doc.test decl,
   -- linter is happy
-  guard $ res.is_none,
+  guard $ res.is_none
 
+run_cmd do
   decl ← get_decl ``a_one_of_b_one,
   res ← linter.to_additive_doc.test decl,
   -- linter is happy

--- a/test/lint_to_additive_doc.lean
+++ b/test/lint_to_additive_doc.lean
@@ -17,12 +17,6 @@ def quux (α : Type*) [has_one α] : α := 1
 
 def no_to_additive (α : Type*) [has_one α] : α := 1
 
--- Aliases always have docstrings, so we do not want to complain if their
--- additive version do not
-alias quux <- quux_alias
-attribute [to_additive add_quux_alias] quux_alias
-
-
 open tactic
 run_cmd do
   decl ← get_decl ``foo,
@@ -54,8 +48,36 @@ run_cmd do
   -- linter is happy
   guard $ res.is_none
 
+-- Aliases always have docstrings, so we do not want to complain if their
+-- additive version do not
+alias quux <- quux_alias
+attribute [to_additive add_quux_alias] quux_alias
+
 run_cmd do
   decl ← get_decl ``quux_alias,
+  res ← linter.to_additive_doc.test decl,
+  -- linter is happy
+  guard $ res.is_none
+
+-- Same for iff aliases
+def a_one_iff_b_one (α : Type*) [has_one α] (a b : α) (h : a = b) : (a = 1) ↔ (b = 1) := by {subst h}
+alias a_one_iff_b_one ↔ b_one_of_a_one a_one_of_b_one
+attribute [to_additive] a_one_iff_b_one
+attribute [to_additive] b_one_of_a_one
+attribute [to_additive] a_one_of_b_one
+
+run_cmd do
+  decl ← get_decl ``a_one_iff_b_one,
+  res ← linter.to_additive_doc.test decl,
+  -- linter is happy
+  guard $ res.is_none,
+
+  decl ← get_decl ``b_one_of_a_one,
+  res ← linter.to_additive_doc.test decl,
+  -- linter is happy
+  guard $ res.is_none,
+
+  decl ← get_decl ``a_one_of_b_one,
   res ← linter.to_additive_doc.test decl,
   -- linter is happy
   guard $ res.is_none

--- a/test/lint_to_additive_doc.lean
+++ b/test/lint_to_additive_doc.lean
@@ -1,63 +1,54 @@
 import algebra.group.to_additive
 import tactic.alias
 
+/-- Test assertion helpres -/
+meta def assert_ok (n : name) := do
+  decl ← tactic.get_decl n,
+  some msg ← linter.to_additive_doc.test decl | pure (),
+  fail! "Linting {n} complained unexepctedly:\n{msg}"
+
+meta def assert_complain (n : name) := do
+  decl ← tactic.get_decl n,
+  none ← linter.to_additive_doc.test decl | pure (),
+  fail! "Linting {n} succeeded unexepctedly"
+
 /-- Docstring -/
 @[to_additive add_foo]
 def foo (α : Type*) [has_one α] : α := 1
 
+run_cmd assert_complain ``foo
+run_cmd assert_ok ``add_foo
+
 @[to_additive add_bar "docstring"]
 def bar (α : Type*) [has_one α] : α := 1
+
+run_cmd assert_complain ``bar
+run_cmd assert_ok ``add_bar
 
 /-- Docstring -/
 @[to_additive add_baz "docstring"]
 def baz (α : Type*) [has_one α] : α := 1
 
+run_cmd assert_ok ``baz
+run_cmd assert_ok ``add_baz
+
 @[to_additive add_quux]
 def quux (α : Type*) [has_one α] : α := 1
 
-def no_to_additive (α : Type*) [has_one α] : α := 1
+run_cmd assert_ok ``quux
+run_cmd assert_ok ``add_quux
 
-open tactic
-run_cmd do
-  decl ← get_decl ``foo,
-  res ← linter.to_additive_doc.test decl,
-  -- linter complains
-  guard $ res.is_some
+def without_to_additive (α : Type*) [has_one α] : α := 1
 
-run_cmd do
-  decl ← get_decl ``bar,
-  res ← linter.to_additive_doc.test decl,
-  -- linter complains
-  guard $ res.is_some
-
-run_cmd do
-  decl ← get_decl ``baz,
-  res ← linter.to_additive_doc.test decl,
-  -- linter is happy
-  guard $ res.is_none
-
-run_cmd do
-  decl ← get_decl ``quux,
-  res ← linter.to_additive_doc.test decl,
-  -- linter is happy
-  guard $ res.is_none
-
-run_cmd do
-  decl ← get_decl ``no_to_additive,
-  res ← linter.to_additive_doc.test decl,
-  -- linter is happy
-  guard $ res.is_none
+run_cmd assert_ok ``without_to_additive
 
 -- Aliases always have docstrings, so we do not want to complain if their
 -- additive version do not
 alias quux <- quux_alias
 attribute [to_additive add_quux_alias] quux_alias
 
-run_cmd do
-  decl ← get_decl ``quux_alias,
-  res ← linter.to_additive_doc.test decl,
-  -- linter is happy
-  guard $ res.is_none
+run_cmd assert_ok ``quux_alias
+run_cmd assert_ok ``add_quux_alias
 
 -- Same for iff aliases
 def a_one_iff_b_one (α : Type*) [has_one α] (a b : α) (h : a = b) : (a = 1) ↔ (b = 1) := by {subst h}
@@ -66,20 +57,6 @@ attribute [to_additive] a_one_iff_b_one
 attribute [to_additive] b_one_of_a_one
 attribute [to_additive] a_one_of_b_one
 
-run_cmd do
-  decl ← get_decl ``a_one_iff_b_one,
-  res ← linter.to_additive_doc.test decl,
-  -- linter is happy
-  guard $ res.is_none
-
-run_cmd do
-  decl ← get_decl ``b_one_of_a_one,
-  res ← linter.to_additive_doc.test decl,
-  -- linter is happy
-  guard $ res.is_none
-
-run_cmd do
-  decl ← get_decl ``a_one_of_b_one,
-  res ← linter.to_additive_doc.test decl,
-  -- linter is happy
-  guard $ res.is_none
+run_cmd assert_ok ``a_one_iff_b_one
+run_cmd assert_ok ``a_one_of_b_one
+run_cmd assert_ok ``b_one_of_a_one

--- a/test/lint_to_additive_doc.lean
+++ b/test/lint_to_additive_doc.lean
@@ -1,16 +1,16 @@
 import algebra.group.to_additive
 import tactic.alias
 
-/-- Test assertion helpres -/
+/-- Test assertion helpers -/
 meta def assert_ok (n : name) := do
   decl ← tactic.get_decl n,
   some msg ← linter.to_additive_doc.test decl | pure (),
-  fail! "Linting {n} complained unexepctedly:\n{msg}"
+  fail! "Linting {n} complained unexpectedly:\n{msg}"
 
 meta def assert_complain (n : name) := do
   decl ← tactic.get_decl n,
   none ← linter.to_additive_doc.test decl | pure (),
-  fail! "Linting {n} succeeded unexepctedly"
+  fail! "Linting {n} succeeded unexpectedly"
 
 /-- Docstring -/
 @[to_additive add_foo]


### PR DESCRIPTION
the `get_alias_target` function in `alias.lean` is used by the
`to_additive` command to add the “Alias of …” docstring when creating an
additive version of an existing alias (this was #13330).

But `get_alias_target` did not work for `alias f ↔ a b`. This fixes it
by extending the `alias_attr` map to not just store whether a defintion
is an alias, but also what it is an alias of. Much more principled than
trying to reconstruct the alias target from the RHS of the alias
definition.

Note that `alias` currently says “Alias of `foo_iff`” even though it’s
really an alias of `foo_iff.mp`. This is an existing bug, not fixed in
this PR – the effect is just that this “bug” will uniformly apply to
additive lemmas as well.

Hopefully will get rid of plenty of nolint.txt entries, and create
better docs.

Also improve the test file for the linter significantly.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
