### PR TITLE
[Merged by Bors] - feat(model_theory/language_map, bundled): Reducts of structures

### DIFF
--- a/src/model_theory/bundled.lean
+++ b/src/model_theory/bundled.lean
@@ -91,6 +91,14 @@ noncomputable def shrink (M : Model.{u v w} T) [small.{w'} M] :
 def ulift (M : Model.{u v w} T) : Model.{u v (max w w')} T :=
   equiv_induced (equiv.ulift.symm : M ≃ _)
 
+/-- The reduct of any model of `φ.on_Theory T` is a model of `T`. -/
+@[simps] def reduct {L' : language} {φ : L →ᴸ L'} (M : (φ.on_Theory T).Model) :
+  T.Model :=
+{ carrier := M,
+  struc := φ.reduct M,
+  nonempty' := M.nonempty',
+  is_model := (@Lhom.on_Theory_model L L' M (φ.reduct M) _ φ _ T).1 M.is_model, }
+
 end Model
 
 variables {T}

--- a/src/model_theory/language_map.lean
+++ b/src/model_theory/language_map.lean
@@ -57,6 +57,7 @@ protected def mk₂ {c f₁ f₂ : Type u} {r₁ r₂ : Type v}
 
 variables (ϕ : L →ᴸ L')
 
+/-- Pulls a structure back along a language map. -/
 def reduct (M : Type*) [L'.Structure M] : L.Structure M :=
 { fun_map := λ n f xs, fun_map (ϕ.on_function f) xs,
   rel_map := λ n r xs, rel_map (ϕ.on_relation r) xs }

--- a/src/model_theory/language_map.lean
+++ b/src/model_theory/language_map.lean
@@ -210,7 +210,7 @@ instance sum_inr_is_expansion_on (M : Type*)
   (Lhom.sum_inr : L' →ᴸ L.sum L').is_expansion_on M :=
 ⟨λ _ f _, rfl, λ _ R _, rfl⟩
 
-instance is_expansion_on_reduct (ϕ : L →ᴸ L') (M : Type*) [L'.Structure M] :
+@[priority 100] instance is_expansion_on_reduct (ϕ : L →ᴸ L') (M : Type*) [L'.Structure M] :
   @is_expansion_on L L' ϕ M (ϕ.reduct M) _ :=
 begin
   letI := ϕ.reduct M,

--- a/src/model_theory/language_map.lean
+++ b/src/model_theory/language_map.lean
@@ -57,6 +57,10 @@ protected def mk₂ {c f₁ f₂ : Type u} {r₁ r₂ : Type v}
 
 variables (ϕ : L →ᴸ L')
 
+def reduct (M : Type*) [L'.Structure M] : L.Structure M :=
+{ fun_map := λ n f xs, fun_map (ϕ.on_function f) xs,
+  rel_map := λ n r xs, rel_map (ϕ.on_relation r) xs }
+
 /-- The identity language homomorphism. -/
 @[simps] protected def id (L : language) : L →ᴸ L :=
 ⟨λn, id, λ n, id⟩
@@ -204,6 +208,13 @@ instance sum_inr_is_expansion_on (M : Type*)
   [L.Structure M] [L'.Structure M] :
   (Lhom.sum_inr : L' →ᴸ L.sum L').is_expansion_on M :=
 ⟨λ _ f _, rfl, λ _ R _, rfl⟩
+
+instance is_expansion_on_reduct (ϕ : L →ᴸ L') (M : Type*) [L'.Structure M] :
+  @is_expansion_on L L' ϕ M (ϕ.reduct M) _ :=
+begin
+  letI := ϕ.reduct M,
+  exact ⟨λ _ f _, rfl, λ _ R _, rfl⟩,
+end
 
 end Lhom
 


### PR DESCRIPTION
Defines `first_order.language.Lhom.reduct` which pulls a structure back along a language map.
Defines `first_order.language.Theory.Model.reduct` which sends a model of `(φ.on_Theory T)` to its reduct as a model of `T`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
