### PR TITLE
[Merged by Bors] - feat(ring_theory/submonoid/membership): generalize a few lemmas to `mul_mem_class`

### DIFF
--- a/src/group_theory/submonoid/membership.lean
+++ b/src/group_theory/submonoid/membership.lean
@@ -457,12 +457,13 @@ attribute [to_additive add_submonoid.multiples_subset] submonoid.powers_subset
 
 end add_submonoid
 
-/-! Lemmas about additive closures of `submonoid`. -/
-namespace submonoid
+/-! Lemmas about additive closures of `subsemigroup`. -/
+namespace mul_mem_class
 
-variables {R : Type*} [non_assoc_semiring R] (S : submonoid R) {a b : R}
+variables {R : Type*} [non_unital_non_assoc_semiring R] [set_like M R] [mul_mem_class M R]
+  {S : M} {a b : R}
 
-/-- The product of an element of the additive closure of a multiplicative submonoid `M`
+/-- The product of an element of the additive closure of a multiplicative subsemigroup `M`
 and an element of `M` is contained in the additive closure of `M`. -/
 lemma mul_right_mem_add_closure
   (ha : a ∈ add_submonoid.closure (S : set R)) (hb : b ∈ S) :
@@ -470,7 +471,7 @@ lemma mul_right_mem_add_closure
 begin
   revert b,
   refine add_submonoid.closure_induction ha _ _ _; clear ha a,
-  { exact λ r hr b hb, add_submonoid.mem_closure.mpr (λ y hy, hy (S.mul_mem hr hb)) },
+  { exact λ r hr b hb, add_submonoid.mem_closure.mpr (λ y hy, hy (mul_mem hr hb)) },
   { exact λ b hb, by simp only [zero_mul, (add_submonoid.closure (S : set R)).zero_mem] },
   { simp_rw add_mul,
     exact λ r s hr hs b hb, (add_submonoid.closure (S : set R)).add_mem (hr hb) (hs hb) }
@@ -484,7 +485,7 @@ lemma mul_mem_add_closure
 begin
   revert a,
   refine add_submonoid.closure_induction hb _ _ _; clear hb b,
-  { exact λ r hr b hb, S.mul_right_mem_add_closure hb hr },
+  { exact λ r hr b hb, mul_mem_class.mul_right_mem_add_closure hb hr },
   { exact λ b hb, by simp only [mul_zero, (add_submonoid.closure (S : set R)).zero_mem] },
   { simp_rw mul_add,
     exact λ r s hr hs b hb, (add_submonoid.closure (S : set R)).add_mem (hr hb) (hs hb) }
@@ -494,7 +495,11 @@ end
 submonoid `S` is contained in the additive closure of `S`. -/
 lemma mul_left_mem_add_closure (ha : a ∈ S) (hb : b ∈ add_submonoid.closure (S : set R)) :
   a * b ∈ add_submonoid.closure (S : set R) :=
-S.mul_mem_add_closure (add_submonoid.mem_closure.mpr (λ sT hT, hT ha)) hb
+mul_mem_add_closure (add_submonoid.mem_closure.mpr (λ sT hT, hT ha)) hb
+
+end mul_mem_class
+
+namespace submonoid
 
 /-- An element is in the closure of a two-element set if it is a linear combination of those two
 elements. -/

--- a/src/ring_theory/subsemiring/basic.lean
+++ b/src/ring_theory/subsemiring/basic.lean
@@ -582,7 +582,7 @@ namespace submonoid
 /-- The additive closure of a submonoid is a subsemiring. -/
 def subsemiring_closure (M : submonoid R) : subsemiring R :=
 { one_mem' := add_submonoid.mem_closure.mpr (λ y hy, hy M.one_mem),
-  mul_mem' := λ x y, mul_mem_add_closure,
+  mul_mem' := λ x y, mul_mem_class.mul_mem_add_closure,
   ..add_submonoid.closure (M : set R)}
 
 lemma subsemiring_closure_coe :

--- a/src/ring_theory/subsemiring/basic.lean
+++ b/src/ring_theory/subsemiring/basic.lean
@@ -582,7 +582,7 @@ namespace submonoid
 /-- The additive closure of a submonoid is a subsemiring. -/
 def subsemiring_closure (M : submonoid R) : subsemiring R :=
 { one_mem' := add_submonoid.mem_closure.mpr (λ y hy, hy M.one_mem),
-  mul_mem' := λ x y, M.mul_mem_add_closure,
+  mul_mem' := λ x y, mul_mem_add_closure,
   ..add_submonoid.closure (M : set R)}
 
 lemma subsemiring_closure_coe :


### PR DESCRIPTION
This generalizes lemmas relating to the additive closure of a multiplicative monoid so that they also apply to multiplicative semigroups using `mul_mem_class`

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
