### PR TITLE
[Merged by Bors] - feat(linear_algebra/affine_space/basis): add lemma `affine_basis.linear_combination_coord_eq_self`

### DIFF
--- a/src/linear_algebra/affine_space/basis.lean
+++ b/src/linear_algebra/affine_space/basis.lean
@@ -151,6 +151,15 @@ begin
   exact b.coord_apply_combination_of_mem (finset.mem_univ i) hw,
 end
 
+/-- A variant of `affine_basis.affine_combination_coord_eq_self` for the special case when the
+affine space is a module so we can talk about linear combinations. -/
+@[simp] lemma linear_combination_coord_eq_self [fintype ι] (b : affine_basis ι k V) (v : V) :
+  ∑ i, (b.coord i v) • (b.points i) = v :=
+begin
+  have hb := b.affine_combination_coord_eq_self v,
+  rwa finset.univ.affine_combination_eq_linear_combination _ _ (b.sum_coord_apply_eq_one v) at hb,
+end
+
 lemma ext_elem [fintype ι] {q₁ q₂ : P} (h : ∀ i, b.coord i q₁ = b.coord i q₂) : q₁ = q₂ :=
 begin
   rw [← b.affine_combination_coord_eq_self q₁, ← b.affine_combination_coord_eq_self q₂],


### PR DESCRIPTION

Formalized as part of the Sphere Eversion project.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
