### PR TITLE
refactor(algebra/monoid_algebra): remove simp from of_apply

### DIFF
--- a/src/algebra/monoid_algebra/basic.lean
+++ b/src/algebra/monoid_algebra/basic.lean
@@ -1202,10 +1202,10 @@ def of' : G → add_monoid_algebra k G := λ a, single a 1
 
 end
 
-@[simp] lemma of_apply [add_zero_class G] (a : multiplicative G) : of k G a = single a.to_add 1 :=
+lemma of_apply [add_zero_class G] (a : multiplicative G) : of k G a = single a.to_add 1 :=
 rfl
 
-@[simp] lemma of'_apply (a : G) : of' k G a = single a 1 := rfl
+lemma of'_apply (a : G) : of' k G a = single a 1 := rfl
 
 lemma of'_eq_of [add_zero_class G] (a : G) : of' k G a = of k G a := rfl
 
@@ -1542,11 +1542,11 @@ lemma lift_unique' (F : add_monoid_algebra k G →ₐ[k] A) :
 /-- Decomposition of a `k`-algebra homomorphism from `monoid_algebra k G` by
 its values on `F (single a 1)`. -/
 lemma lift_unique (F : add_monoid_algebra k G →ₐ[k] A) (f : monoid_algebra k G) :
-  F f = f.sum (λ a b, b • F (single a 1)) :=
-by conv_lhs { rw lift_unique' F, simp [lift_apply] }
+  F f = f.sum (λ a b, b • F (of k G a)) :=
+by { conv_lhs { rw lift_unique' F, simp [lift_apply], }, refl, }
 
 lemma alg_hom_ext_iff {φ₁ φ₂ : add_monoid_algebra k G →ₐ[k] A} :
-  (∀ x, φ₁ (finsupp.single x 1) = φ₂ (finsupp.single x 1)) ↔ φ₁ = φ₂ :=
+  (∀ x, φ₁ (of k G x) = φ₂ (of k G x)) ↔ φ₁ = φ₂ :=
 ⟨λ h, alg_hom_ext h, by rintro rfl _; refl⟩
 
 end lift

--- a/src/algebra/monoid_algebra/grading.lean
+++ b/src/algebra/monoid_algebra/grading.lean
@@ -177,7 +177,7 @@ graded_algebra.of_alg_hom _
   (decompose_aux f)
   (begin
     ext : 2,
-    dsimp,
+    dsimp [add_monoid_algebra.of_apply],
     rw [decompose_aux_single, direct_sum.submodule_coe_alg_hom_of, subtype.coe_mk],
   end)
   (λ i x, by convert (decompose_aux_coe f x : _))

--- a/src/data/polynomial/monomial.lean
+++ b/src/data/polynomial/monomial.lean
@@ -60,7 +60,7 @@ begin
   have A : f' = g',
   { ext,
     { simp [h₁, ring_equiv.to_ring_hom_eq_coe] },
-    { simpa [ring_equiv.to_ring_hom_eq_coe] using h₂, } },
+    { simpa [ring_equiv.to_ring_hom_eq_coe, add_monoid_algebra.of_apply] using h₂, } },
   have B : f = f'.comp (to_finsupp_iso R),
     by { rw [hf', ring_hom.comp_assoc], ext x, simp only [ring_equiv.to_ring_hom_eq_coe,
       ring_equiv.symm_apply_apply, function.comp_app, ring_hom.coe_comp,


### PR DESCRIPTION
I felt that this was unhelpfully "breaking the API" by dropping us down to stuff about `finsupp`. On the other hand, the line between monoid_algebra and finsupp remains very murky, so it's not clear this is really an improvement.

I'm proposing just this change for now as it would have been helpful for me in other recent work.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
