### PR TITLE
[Merged by Bors] - feat(analysis/calculus/cont_diff): cont_diff_succ_iff_fderiv_apply

### DIFF
--- a/src/algebra/module/equiv.lean
+++ b/src/algebra/module/equiv.lean
@@ -227,7 +227,10 @@ include σ'
 omit σ'
 
 include σ₃₁ σ₂₁ σ₃₂
-@[simp] lemma symm_trans_apply
+@[simp] lemma trans_symm : (e₁₂.trans e₂₃ : M₁ ≃ₛₗ[σ₁₃] M₃).symm = e₂₃.symm.trans e₁₂.symm :=
+rfl
+
+lemma symm_trans_apply
   (c : M₃) : (e₁₂.trans e₂₃ : M₁ ≃ₛₗ[σ₁₃] M₃).symm c = e₁₂.symm (e₂₃.symm c) := rfl
 omit σ₃₁ σ₂₁ σ₃₂
 

--- a/src/analysis/calculus/cont_diff.lean
+++ b/src/analysis/calculus/cont_diff.lean
@@ -2755,7 +2755,7 @@ begin
   let d := finrank 𝕜 F,
   have hd : d = finrank 𝕜 (fin d → 𝕜) := (finrank_fin_fun 𝕜).symm,
   let e₁ := continuous_linear_equiv.of_finrank_eq hd,
-  let e₂ := (e₁.arrow_congr_equivL (1 : G ≃L[𝕜] G)).trans (continuous_linear_equiv.pi_ring (fin d)),
+  let e₂ := (e₁.arrow_congr (1 : G ≃L[𝕜] G)).trans (continuous_linear_equiv.pi_ring (fin d)),
   rw [← comp.left_id f, ← e₂.symm_comp_self],
   exact e₂.symm.cont_diff.comp_cont_diff_on (cont_diff_on_pi.mpr (λ i, h _))
 end

--- a/src/analysis/calculus/cont_diff.lean
+++ b/src/analysis/calculus/cont_diff.lean
@@ -985,33 +985,38 @@ begin
     exact cont_diff_on_of_continuous_on_differentiable_on h.1 h.2 }
 end
 
+lemma cont_diff_on_succ_of_fderiv_within {n : ℕ} (hf : differentiable_on 𝕜 f s)
+  (h : cont_diff_on 𝕜 n (λ y, fderiv_within 𝕜 f s y) s) :
+  cont_diff_on 𝕜 ((n + 1) : ℕ) f s :=
+begin
+  intros x hx,
+  rw [cont_diff_within_at_succ_iff_has_fderiv_within_at, insert_eq_of_mem hx],
+  exact ⟨s, self_mem_nhds_within, fderiv_within 𝕜 f s,
+    λ y hy, (hf y hy).has_fderiv_within_at, h x hx⟩
+end
+
 /-- A function is `C^(n + 1)` on a domain with unique derivatives if and only if it is
 differentiable there, and its derivative (expressed with `fderiv_within`) is `C^n`. -/
 theorem cont_diff_on_succ_iff_fderiv_within {n : ℕ} (hs : unique_diff_on 𝕜 s) :
   cont_diff_on 𝕜 ((n + 1) : ℕ) f s ↔
   differentiable_on 𝕜 f s ∧ cont_diff_on 𝕜 n (λ y, fderiv_within 𝕜 f s y) s :=
 begin
-  split,
-  { assume H,
-    refine ⟨H.differentiable_on (with_top.coe_le_coe.2 (nat.le_add_left 1 n)), λ x hx, _⟩,
-    rcases cont_diff_within_at_succ_iff_has_fderiv_within_at.1 (H x hx)
-      with ⟨u, hu, f', hff', hf'⟩,
-    rcases mem_nhds_within.1 hu with ⟨o, o_open, xo, ho⟩,
-    rw [inter_comm, insert_eq_of_mem hx] at ho,
-    have := hf'.mono ho,
-    rw cont_diff_within_at_inter' (mem_nhds_within_of_mem_nhds (is_open.mem_nhds o_open xo))
-      at this,
-    apply this.congr_of_eventually_eq' _ hx,
-    have : o ∩ s ∈ 𝓝[s] x := mem_nhds_within.2 ⟨o, o_open, xo, subset.refl _⟩,
-    rw inter_comm at this,
-    apply filter.eventually_eq_of_mem this (λ y hy, _),
-    have A : fderiv_within 𝕜 f (s ∩ o) y = f' y :=
-      ((hff' y (ho hy)).mono ho).fderiv_within (hs.inter o_open y hy),
-    rwa fderiv_within_inter (is_open.mem_nhds o_open hy.2) (hs y hy.1) at A, },
-  { rintros ⟨hdiff, h⟩ x hx,
-    rw [cont_diff_within_at_succ_iff_has_fderiv_within_at, insert_eq_of_mem hx],
-    exact ⟨s, self_mem_nhds_within, fderiv_within 𝕜 f s,
-      λ y hy, (hdiff y hy).has_fderiv_within_at, h x hx⟩ }
+  refine ⟨λ H, _, λ h, cont_diff_on_succ_of_fderiv_within h.1 h.2⟩,
+  refine ⟨H.differentiable_on (with_top.coe_le_coe.2 (nat.le_add_left 1 n)), λ x hx, _⟩,
+  rcases cont_diff_within_at_succ_iff_has_fderiv_within_at.1 (H x hx)
+    with ⟨u, hu, f', hff', hf'⟩,
+  rcases mem_nhds_within.1 hu with ⟨o, o_open, xo, ho⟩,
+  rw [inter_comm, insert_eq_of_mem hx] at ho,
+  have := hf'.mono ho,
+  rw cont_diff_within_at_inter' (mem_nhds_within_of_mem_nhds (is_open.mem_nhds o_open xo))
+    at this,
+  apply this.congr_of_eventually_eq' _ hx,
+  have : o ∩ s ∈ 𝓝[s] x := mem_nhds_within.2 ⟨o, o_open, xo, subset.refl _⟩,
+  rw inter_comm at this,
+  apply filter.eventually_eq_of_mem this (λ y hy, _),
+  have A : fderiv_within 𝕜 f (s ∩ o) y = f' y :=
+    ((hff' y (ho hy)).mono ho).fderiv_within (hs.inter o_open y hy),
+  rwa fderiv_within_inter (is_open.mem_nhds o_open hy.2) (hs y hy.1) at A
 end
 
 /-- A function is `C^(n + 1)` on an open domain if and only if it is
@@ -2738,7 +2743,8 @@ end function_inverse
 /-! ### Finite dimensional results -/
 section finite_dimensional
 
--- [complete_space 𝕜]
+open function finite_dimensional
+variables [complete_space 𝕜]
 
 /-- A family of continuous linear maps is `C^n` on `s` if all its applications are. -/
 lemma cont_diff_on_clm_apply {n : with_top ℕ} {f : E → F →L[𝕜] G}
@@ -2758,13 +2764,26 @@ lemma cont_diff_clm_apply {n : with_top ℕ} {f : E → F →L[𝕜] G} [finite_
   cont_diff 𝕜 n f ↔ ∀ y, cont_diff 𝕜 n (λ x, f x y) :=
 by simp_rw [← cont_diff_on_univ, cont_diff_on_clm_apply]
 
+/-- This is a useful lemma to prove that a certain operation preserves functions being `C^n`.
+When you do induction on `n`, this gives a useful characterization of a function being `C^(n+1)`,
+assuming you have already computed the derivative. The advantage of this version over
+`cont_diff_succ_iff_fderiv` is that both occurences of `cont_diff` are for functions with the same
+domain and codomain (`E` and `F`). This is not the case for `cont_diff_succ_iff_fderiv`, which
+often requires an inconvenient need to generalize `F`, which results in universe issues
+(see the discussion in the section of `cont_diff.comp`).
+
+This lemma avoids these universe issues, but only applies for finite dimensional `E`. -/
 lemma cont_diff_succ_iff_fderiv_apply [finite_dimensional 𝕜 E] {n : ℕ} {f : E → F} :
   cont_diff 𝕜 ((n + 1) : ℕ) f ↔
   differentiable 𝕜 f ∧ ∀ y, cont_diff 𝕜 n (λ x, fderiv 𝕜 f x y) :=
 by rw [cont_diff_succ_iff_fderiv, cont_diff_clm_apply]
 
--- `unique_diff_on` should not be necessary from the right-to-left implication, which is the one
--- we really care about.
+lemma cont_diff_on_succ_of_fderiv_apply [finite_dimensional 𝕜 E] {n : ℕ} {f : E → F}
+  {s : set E} (hf : differentiable_on 𝕜 f s)
+  (h : ∀ y, cont_diff_on 𝕜 n (λ x, fderiv_within 𝕜 f s x y) s) :
+  cont_diff_on 𝕜 ((n + 1) : ℕ) f s :=
+cont_diff_on_succ_of_fderiv_within hf $ cont_diff_on_clm_apply.mpr h
+
 lemma cont_diff_on_succ_iff_fderiv_apply [finite_dimensional 𝕜 E] {n : ℕ} {f : E → F}
   {s : set E} (hs : unique_diff_on 𝕜 s) : cont_diff_on 𝕜 ((n + 1) : ℕ) f s ↔
   differentiable_on 𝕜 f s ∧ ∀ y, cont_diff_on 𝕜 n (λ x, fderiv_within 𝕜 f s x y) s :=

--- a/src/analysis/calculus/cont_diff.lean
+++ b/src/analysis/calculus/cont_diff.lean
@@ -2734,6 +2734,45 @@ f.cont_diff_at_symm ha (hf₀'.has_fderiv_at_equiv h₀) hf
 
 end function_inverse
 
+
+/-! ### Finite dimensional results -/
+section finite_dimensional
+
+-- [complete_space 𝕜]
+
+/-- A family of continuous linear maps is `C^n` on `s` if all its applications are. -/
+lemma cont_diff_on_clm_apply {n : with_top ℕ} {f : E → F →L[𝕜] G}
+  {s : set E} [finite_dimensional 𝕜 F] :
+  cont_diff_on 𝕜 n f s ↔ ∀ y, cont_diff_on 𝕜 n (λ x, f x y) s :=
+begin
+  refine ⟨λ h y, (continuous_linear_map.apply 𝕜 G y).cont_diff.comp_cont_diff_on h, λ h, _⟩,
+  let d := finrank 𝕜 F,
+  have hd : d = finrank 𝕜 (fin d → 𝕜) := (finrank_fin_fun 𝕜).symm,
+  let e₁ := continuous_linear_equiv.of_finrank_eq hd,
+  let e₂ := (e₁.arrow_congr_equivL (1 : G ≃L[𝕜] G)).trans (continuous_linear_equiv.pi_ring (fin d)),
+  rw [← comp.left_id f, ← e₂.symm_comp_self],
+  exact e₂.symm.cont_diff.comp_cont_diff_on (cont_diff_on_pi.mpr (λ i, h _))
+end
+
+lemma cont_diff_clm_apply {n : with_top ℕ} {f : E → F →L[𝕜] G} [finite_dimensional 𝕜 F] :
+  cont_diff 𝕜 n f ↔ ∀ y, cont_diff 𝕜 n (λ x, f x y) :=
+by simp_rw [← cont_diff_on_univ, cont_diff_on_clm_apply]
+
+lemma cont_diff_succ_iff_fderiv_apply [finite_dimensional 𝕜 E] {n : ℕ} {f : E → F} :
+  cont_diff 𝕜 ((n + 1) : ℕ) f ↔
+  differentiable 𝕜 f ∧ ∀ y, cont_diff 𝕜 n (λ x, fderiv 𝕜 f x y) :=
+by rw [cont_diff_succ_iff_fderiv, cont_diff_clm_apply]
+
+-- `unique_diff_on` should not be necessary from the right-to-left implication, which is the one
+-- we really care about.
+lemma cont_diff_on_succ_iff_fderiv_apply [finite_dimensional 𝕜 E] {n : ℕ} {f : E → F}
+  {s : set E} (hs : unique_diff_on 𝕜 s) : cont_diff_on 𝕜 ((n + 1) : ℕ) f s ↔
+  differentiable_on 𝕜 f s ∧ ∀ y, cont_diff_on 𝕜 n (λ x, fderiv_within 𝕜 f s x y) s :=
+by rw [cont_diff_on_succ_iff_fderiv_within hs, cont_diff_on_clm_apply]
+
+end finite_dimensional
+
+
 section real
 /-!
 ### Results over `ℝ` or `ℂ`

--- a/src/analysis/normed_space/finite_dimension.lean
+++ b/src/analysis/normed_space/finite_dimension.lean
@@ -744,7 +744,7 @@ open continuous_linear_map
 /-- Continuous linear equivalence between continuous linear functions `𝕜ⁿ → E` and `Eⁿ`.
 The spaces `𝕜ⁿ` and `Eⁿ` are represented as `ι → 𝕜` and `ι → E`, respectively,
 where `ι` is a finite type. -/
-def continuous_linear_equiv.pi_ring (ι : Type*) [fintype ι] [decidable_eq ι] [complete_space 𝕜] :
+def continuous_linear_equiv.pi_ring (ι : Type*) [fintype ι] [decidable_eq ι] :
   ((ι → 𝕜) →L[𝕜] E) ≃L[𝕜] (ι → E) :=
 { continuous_to_fun :=
   begin
@@ -768,7 +768,7 @@ def continuous_linear_equiv.pi_ring (ι : Type*) [fintype ι] [decidable_eq ι] 
   .. linear_map.to_continuous_linear_map.symm.trans (linear_equiv.pi_ring 𝕜 E ι 𝕜) }
 
 /-- A family of continuous linear maps is continuous on `s` if all its applications are. -/
-lemma continuous_on_clm_apply {X : Type*} [topological_space X] [complete_space 𝕜]
+lemma continuous_on_clm_apply {X : Type*} [topological_space X]
   [finite_dimensional 𝕜 E] {f : X → E →L[𝕜] F} {s : set X} :
   continuous_on f s ↔ ∀ y, continuous_on (λ x, f x y) s :=
 begin

--- a/src/analysis/normed_space/finite_dimension.lean
+++ b/src/analysis/normed_space/finite_dimension.lean
@@ -739,22 +739,51 @@ begin
   { simp_rw [hc, smul_zero], exact is_closed_map_const },
   { exact (closed_embedding_smul_left hc).is_closed_map }
 end
-#check@ continuous_linear_equiv.arrow_congr_equivL
+
+open continuous_linear_map
+/-- Continuous linear equivalence between continuous linear functions `𝕜ⁿ → E` and `Eⁿ`.
+The spaces `𝕜ⁿ` and `Eⁿ` are represented as `ι → 𝕜` and `ι → E`, respectively,
+where `ι` is a finite type. -/
+def continuous_linear_equiv.pi_ring (ι : Type*) [fintype ι] [decidable_eq ι] [complete_space 𝕜] :
+  ((ι → 𝕜) →L[𝕜] E) ≃L[𝕜] (ι → E) :=
+{ continuous_to_fun :=
+  begin
+    refine continuous_pi (λ i, _),
+    exact (continuous_linear_map.apply 𝕜 E (pi.single i 1)).continuous,
+  end,
+  continuous_inv_fun :=
+  begin
+    simp_rw [linear_equiv.inv_fun_eq_symm, linear_equiv.trans_symm, linear_equiv.symm_symm],
+    apply linear_map.continuous_of_bound _ (fintype.card ι : ℝ) (λ g, _),
+    rw ← nsmul_eq_mul,
+    apply op_norm_le_bound _ (nsmul_nonneg (norm_nonneg g) (fintype.card ι)) (λ t, _),
+    simp_rw [linear_map.coe_comp, linear_equiv.coe_to_linear_map, function.comp_app,
+      linear_map.coe_to_continuous_linear_map', linear_equiv.pi_ring_symm_apply],
+    apply le_trans (norm_sum_le _ _),
+    rw smul_mul_assoc,
+    refine finset.sum_le_card_nsmul _ _ _ (λ i hi, _),
+    rw [norm_smul, mul_comm],
+    exact mul_le_mul (norm_le_pi_norm g i) (norm_le_pi_norm t i) (norm_nonneg _) (norm_nonneg g),
+  end,
+  .. linear_map.to_continuous_linear_map.symm.trans (linear_equiv.pi_ring 𝕜 E ι 𝕜) }
+
 /-- A family of continuous linear maps is continuous on `s` if all its applications are. -/
-lemma continuous_on_clm_apply {X : Type*} [topological_space X]
+lemma continuous_on_clm_apply {X : Type*} [topological_space X] [complete_space 𝕜]
   [finite_dimensional 𝕜 E] {f : X → E →L[𝕜] F} {s : set X} :
   continuous_on f s ↔ ∀ y, continuous_on (λ x, f x y) s :=
 begin
   refine ⟨λ h y, (continuous_linear_map.apply 𝕜 F y).continuous.comp_continuous_on h, λ h, _⟩,
   let d := finrank 𝕜 E,
   have hd : d = finrank 𝕜 (fin d → 𝕜) := (finrank_fin_fun 𝕜).symm,
-  let e₁ := continuous_linear_equiv.of_finrank_eq hd,
-  let e₂ := (e₁.arrow_congr_equivL (1 : F ≃L[𝕜] F)).trans (continuous_linear_equiv.pi_ring (fin d)),
-  rw [← comp.left_id f, ← e₂.symm_comp_self],
+  let e₁ : E ≃L[𝕜] fin d → 𝕜 := continuous_linear_equiv.of_finrank_eq hd,
+  let e₂ : (E →L[𝕜] F) ≃L[𝕜] fin d → F :=
+    (e₁.arrow_congr_equivL (1 : F ≃L[𝕜] F)).trans (continuous_linear_equiv.pi_ring (fin d)),
+  rw [← function.comp.left_id f, ← e₂.symm_comp_self],
   exact e₂.symm.continuous.comp_continuous_on (continuous_on_pi.mpr (λ i, h _))
 end
 
-lemma continuous_clm_apply {X : Type*} [topological_space X] {f : X → E →L[𝕜] F} :
+lemma continuous_clm_apply {X : Type*} [topological_space X] [finite_dimensional 𝕜 E]
+  {f : X → E →L[𝕜] F} :
   continuous f ↔ ∀ y, continuous (λ x, f x y) :=
 by simp_rw [continuous_iff_continuous_on_univ, continuous_on_clm_apply]
 

--- a/src/analysis/normed_space/finite_dimension.lean
+++ b/src/analysis/normed_space/finite_dimension.lean
@@ -497,7 +497,6 @@ def basis.equiv_funL (v : basis ι 𝕜 E) : E ≃L[𝕜] (ι → 𝕜) :=
   end,
   ..v.equiv_fun }
 
-
 @[simp] lemma basis.constrL_apply (v : basis ι 𝕜 E) (f : ι → F) (e : E) :
   (v.constrL f) e = ∑ i, (v.equiv_fun e i) • f i :=
 v.constr_apply_fintype 𝕜 _ _
@@ -740,6 +739,24 @@ begin
   { simp_rw [hc, smul_zero], exact is_closed_map_const },
   { exact (closed_embedding_smul_left hc).is_closed_map }
 end
+#check@ continuous_linear_equiv.arrow_congr_equivL
+/-- A family of continuous linear maps is continuous on `s` if all its applications are. -/
+lemma continuous_on_clm_apply {X : Type*} [topological_space X]
+  [finite_dimensional 𝕜 E] {f : X → E →L[𝕜] F} {s : set X} :
+  continuous_on f s ↔ ∀ y, continuous_on (λ x, f x y) s :=
+begin
+  refine ⟨λ h y, (continuous_linear_map.apply 𝕜 F y).continuous.comp_continuous_on h, λ h, _⟩,
+  let d := finrank 𝕜 E,
+  have hd : d = finrank 𝕜 (fin d → 𝕜) := (finrank_fin_fun 𝕜).symm,
+  let e₁ := continuous_linear_equiv.of_finrank_eq hd,
+  let e₂ := (e₁.arrow_congr_equivL (1 : F ≃L[𝕜] F)).trans (continuous_linear_equiv.pi_ring (fin d)),
+  rw [← comp.left_id f, ← e₂.symm_comp_self],
+  exact e₂.symm.continuous.comp_continuous_on (continuous_on_pi.mpr (λ i, h _))
+end
+
+lemma continuous_clm_apply {X : Type*} [topological_space X] {f : X → E →L[𝕜] F} :
+  continuous f ↔ ∀ y, continuous (λ x, f x y) :=
+by simp_rw [continuous_iff_continuous_on_univ, continuous_on_clm_apply]
 
 end complete_field
 

--- a/src/analysis/normed_space/finite_dimension.lean
+++ b/src/analysis/normed_space/finite_dimension.lean
@@ -777,7 +777,7 @@ begin
   have hd : d = finrank 𝕜 (fin d → 𝕜) := (finrank_fin_fun 𝕜).symm,
   let e₁ : E ≃L[𝕜] fin d → 𝕜 := continuous_linear_equiv.of_finrank_eq hd,
   let e₂ : (E →L[𝕜] F) ≃L[𝕜] fin d → F :=
-    (e₁.arrow_congr_equivL (1 : F ≃L[𝕜] F)).trans (continuous_linear_equiv.pi_ring (fin d)),
+    (e₁.arrow_congr (1 : F ≃L[𝕜] F)).trans (continuous_linear_equiv.pi_ring (fin d)),
   rw [← function.comp.left_id f, ← e₂.symm_comp_self],
   exact e₂.symm.continuous.comp_continuous_on (continuous_on_pi.mpr (λ i, h _))
 end

--- a/src/analysis/normed_space/operator_norm.lean
+++ b/src/analysis/normed_space/operator_norm.lean
@@ -1747,7 +1747,7 @@ omit σ₂₁ σ₃₄ σ₁₃ σ₂₄
 
 /-- A pair of continuous linear equivalences generates an continuous linear equivalence between
 the spaces of continuous linear maps. -/
-def arrow_congr_equivL {F H : Type*} [normed_group F] [normed_group H]
+def arrow_congr {F H : Type*} [normed_group F] [normed_group H]
   [normed_space 𝕜 F] [normed_space 𝕜 G] [normed_space 𝕜 H]
   (e₁ : E ≃L[𝕜] F) (e₂ : H ≃L[𝕜] G) :
   (E →L[𝕜] H) ≃L[𝕜] (F →L[𝕜] G) :=

--- a/src/analysis/normed_space/operator_norm.lean
+++ b/src/analysis/normed_space/operator_norm.lean
@@ -1753,32 +1753,6 @@ def arrow_congr_equivL {F H : Type*} [normed_group F] [normed_group H]
   (E →L[𝕜] H) ≃L[𝕜] (F →L[𝕜] G) :=
 arrow_congr_equivSL e₁ e₂
 
-/-- Continuous linear equivalence between continuous linear functions `𝕜ⁿ → E` and `Eⁿ`.
-The spaces `𝕜ⁿ` and `Eⁿ` are represented as `ι → 𝕜` and `ι → E`, respectively,
-where `ι` is a finite type. -/
-@[simps] def pi_ring (ι : Type*) [fintype ι] [decidable_eq ι] [complete_space 𝕜] :
-  ((ι → 𝕜) →L[𝕜] G) ≃L[𝕜] (ι → G) :=
-{ continuous_to_fun :=
-  begin
-    refine continuous_pi (λ i, _),
-    exact (continuous_linear_map.apply 𝕜 G (pi.single i 1)).continuous,
-  end,
-  continuous_inv_fun :=
-  begin
-    simp_rw [linear_equiv.inv_fun_eq_symm, linear_equiv.trans_symm_apply, linear_equiv.symm_symm],
-    apply linear_map.continuous_of_bound _ (fintype.card ι : ℝ) (λ g, _),
-    rw ← nsmul_eq_mul,
-    apply op_norm_le_bound _ (nsmul_nonneg (norm_nonneg g) (fintype.card ι)) (λ t, _),
-    simp_rw [linear_map.coe_comp, linear_equiv.coe_to_linear_map, comp_app,
-      linear_map.coe_to_continuous_linear_map', linear_equiv.pi_ring_symm_apply],
-    apply le_trans (norm_sum_le _ _),
-    rw smul_mul_assoc,
-    refine finset.sum_le_card_nsmul _ _ _ (λ i hi, _),
-    rw [norm_smul, mul_comm],
-    exact mul_le_mul (norm_le_pi_norm g i) (norm_le_pi_norm t i) (norm_nonneg _) (norm_nonneg g),
-  end,
-  .. linear_map.to_continuous_linear_map.symm.trans (linear_equiv.pi_ring 𝕜 G ι 𝕜) }
-
 end
 
 end continuous_linear_equiv

--- a/src/analysis/normed_space/operator_norm.lean
+++ b/src/analysis/normed_space/operator_norm.lean
@@ -1731,7 +1731,7 @@ variables [ring_hom_isometric σ₃₄]
 include σ₂₁ σ₃₄ σ₁₃ σ₂₄
 /-- A pair of continuous (semi)linear equivalences generates an continuous (semi)linear equivalence
 between the spaces of continuous (semi)linear maps. -/
-def arrow_congr_equivSL (e₁₂ : E ≃SL[σ₁₂] F) (e₄₃ : H ≃SL[σ₄₃] G) :
+def arrow_congrSL (e₁₂ : E ≃SL[σ₁₂] F) (e₄₃ : H ≃SL[σ₄₃] G) :
   (E →SL[σ₁₄] H) ≃SL[σ₄₃] (F →SL[σ₂₃] G) :=
 { map_add' := λ f g, by simp only [equiv.to_fun_as_coe, add_comp, comp_add,
     continuous_linear_equiv.arrow_congr_equiv_apply],
@@ -1751,7 +1751,7 @@ def arrow_congr {F H : Type*} [normed_group F] [normed_group H]
   [normed_space 𝕜 F] [normed_space 𝕜 G] [normed_space 𝕜 H]
   (e₁ : E ≃L[𝕜] F) (e₂ : H ≃L[𝕜] G) :
   (E →L[𝕜] H) ≃L[𝕜] (F →L[𝕜] G) :=
-arrow_congr_equivSL e₁ e₂
+arrow_congrSL e₁ e₂
 
 end
 

--- a/src/analysis/normed_space/operator_norm.lean
+++ b/src/analysis/normed_space/operator_norm.lean
@@ -1715,6 +1715,67 @@ end
   (coord 𝕜 x h) (⟨x, submodule.mem_span_singleton_self x⟩ : 𝕜 ∙ x) = 1 :=
 linear_equiv.coord_self 𝕜 E x h
 
+variables {𝕜} {𝕜₄ : Type*} [nondiscrete_normed_field 𝕜₄]
+variables {H : Type*} [normed_group H] [normed_space 𝕜₄ H] [normed_space 𝕜₃ G]
+variables {σ₂₃ : 𝕜₂ →+* 𝕜₃} {σ₁₃ : 𝕜 →+* 𝕜₃} [ring_hom_comp_triple σ₁₂ σ₂₃ σ₁₃]
+variables {σ₃₄ : 𝕜₃ →+* 𝕜₄} {σ₄₃ : 𝕜₄ →+* 𝕜₃} [ring_hom_inv_pair σ₃₄ σ₄₃] [ring_hom_inv_pair σ₄₃ σ₃₄]
+variables {σ₂₄ : 𝕜₂ →+* 𝕜₄} {σ₁₄ : 𝕜 →+* 𝕜₄}
+variables [ring_hom_comp_triple σ₂₁ σ₁₄ σ₂₄] [ring_hom_comp_triple σ₂₄ σ₄₃ σ₂₃]
+variables [ring_hom_comp_triple σ₁₂ σ₂₃ σ₁₃] [ring_hom_comp_triple σ₁₃ σ₃₄ σ₁₄]
+variables [ring_hom_isometric σ₁₄] [ring_hom_isometric σ₂₃]
+variables [ring_hom_isometric σ₄₃] [ring_hom_isometric σ₂₄]
+
+include σ₂₁ σ₃₄ σ₁₃ σ₂₄
+#check@ continuous_linear_equiv.arrow_congr_equiv
+#check@ continuous_linear_equiv.arrow_congr_equiv_apply
+@[simps] def arrow_congr_equivL (e₁₂ : E ≃SL[σ₁₂] F) (e₄₃ : H ≃SL[σ₄₃] G) :
+  (E →SL[σ₁₄] H) ≃SL[σ₄₃] (F →SL[σ₂₃] G) :=
+{ map_add' := λ f g, by simp only [equiv.to_fun_as_coe, add_comp, comp_add,
+    continuous_linear_equiv.arrow_congr_equiv_apply],
+  map_smul' := λ t f, by simp only [equiv.to_fun_as_coe, smul_comp, comp_smulₛₗ,
+    continuous_linear_equiv.arrow_congr_equiv_apply],
+  continuous_to_fun := (compSL F H G σ₂₄ σ₄₃ e₄₃).continuous.comp
+    ((compSL F E _ σ₂₁ _).flip e₁₂.symm).continuous,
+  continuous_inv_fun := (compSL E G H σ₁₃ σ₃₄ e₄₃.symm).continuous.comp
+    ((compSL E F _ σ₁₂ _).flip e₁₂).continuous,
+  .. e₁₂.arrow_congr_equiv e₄₃, }
+
+omit σ₂₁ σ₃₄
+
+/-- A pair of continuous linear equivalences generates an continuous linear equivalence between
+  the spaces of continuous linear maps. -/
+@[simps] def arrow_congr_equivL'
+  {H : Type*} [normed_group H] [normed_space 𝕜 H] (e₁ : E ≃L[𝕜] G) (e₂ : F ≃L[𝕜] H)
+   :
+  (E →L[𝕜] F) ≃L[𝕜] (G →L[𝕜] H) :=
+arrow_congr_equivL
+
+/-- Continuous linear equivalence between continuous linear functions `𝕜ⁿ → E` and `Eⁿ`.
+The spaces `𝕜ⁿ` and `Eⁿ` are represented as `ι → 𝕜` and `ι → E`, respectively,
+where `ι` is a finite type. -/
+@[simps] def pi_ring (ι : Type*) [fintype ι] [decidable_eq ι] [complete_space 𝕜] :
+  ((ι → 𝕜) →L[𝕜] G) ≃L[𝕜] (ι → G) :=
+{ continuous_to_fun :=
+  begin
+    refine continuous_pi (λ i, _),
+    exact (continuous_linear_map.apply 𝕜 G (pi.single i 1)).continuous,
+  end,
+  continuous_inv_fun :=
+  begin
+    simp_rw [linear_equiv.inv_fun_eq_symm, linear_equiv.trans_symm_apply, linear_equiv.symm_symm],
+    apply linear_map.continuous_of_bound _ (fintype.card ι : ℝ) (λ g, _),
+    rw ← nsmul_eq_mul,
+    apply op_norm_le_bound _ (nsmul_nonneg (norm_nonneg g) (fintype.card ι)) (λ t, _),
+    simp_rw [linear_map.coe_comp, linear_equiv.coe_to_linear_map, comp_app,
+      linear_map.coe_to_continuous_linear_map', linear_equiv.pi_ring_symm_apply],
+    apply le_trans (norm_sum_le _ _),
+    rw smul_mul_assoc,
+    refine finset.sum_le_card_nsmul _ _ _ (λ i hi, _),
+    rw [norm_smul, mul_comm],
+    exact mul_le_mul (norm_le_pi_norm g i) (norm_le_pi_norm t i) (norm_nonneg _) (norm_nonneg g),
+  end,
+  .. linear_map.to_continuous_linear_map.symm.trans (linear_equiv.pi_ring 𝕜 G ι 𝕜) }
+
 end
 
 end continuous_linear_equiv

--- a/src/analysis/normed_space/operator_norm.lean
+++ b/src/analysis/normed_space/operator_norm.lean
@@ -1717,38 +1717,41 @@ linear_equiv.coord_self 𝕜 E x h
 
 variables {𝕜} {𝕜₄ : Type*} [nondiscrete_normed_field 𝕜₄]
 variables {H : Type*} [normed_group H] [normed_space 𝕜₄ H] [normed_space 𝕜₃ G]
-variables {σ₂₃ : 𝕜₂ →+* 𝕜₃} {σ₁₃ : 𝕜 →+* 𝕜₃} [ring_hom_comp_triple σ₁₂ σ₂₃ σ₁₃]
-variables {σ₃₄ : 𝕜₃ →+* 𝕜₄} {σ₄₃ : 𝕜₄ →+* 𝕜₃} [ring_hom_inv_pair σ₃₄ σ₄₃] [ring_hom_inv_pair σ₄₃ σ₃₄]
+variables {σ₂₃ : 𝕜₂ →+* 𝕜₃} {σ₁₃ : 𝕜 →+* 𝕜₃}
+variables {σ₃₄ : 𝕜₃ →+* 𝕜₄} {σ₄₃ : 𝕜₄ →+* 𝕜₃}
 variables {σ₂₄ : 𝕜₂ →+* 𝕜₄} {σ₁₄ : 𝕜 →+* 𝕜₄}
+variables [ring_hom_inv_pair σ₃₄ σ₄₃] [ring_hom_inv_pair σ₄₃ σ₃₄]
 variables [ring_hom_comp_triple σ₂₁ σ₁₄ σ₂₄] [ring_hom_comp_triple σ₂₄ σ₄₃ σ₂₃]
 variables [ring_hom_comp_triple σ₁₂ σ₂₃ σ₁₃] [ring_hom_comp_triple σ₁₃ σ₃₄ σ₁₄]
 variables [ring_hom_isometric σ₁₄] [ring_hom_isometric σ₂₃]
 variables [ring_hom_isometric σ₄₃] [ring_hom_isometric σ₂₄]
+variables [ring_hom_isometric σ₁₃] [ring_hom_isometric σ₁₂]
+variables [ring_hom_isometric σ₃₄]
 
 include σ₂₁ σ₃₄ σ₁₃ σ₂₄
-#check@ continuous_linear_equiv.arrow_congr_equiv
-#check@ continuous_linear_equiv.arrow_congr_equiv_apply
-@[simps] def arrow_congr_equivL (e₁₂ : E ≃SL[σ₁₂] F) (e₄₃ : H ≃SL[σ₄₃] G) :
+/-- A pair of continuous (semi)linear equivalences generates an continuous (semi)linear equivalence
+between the spaces of continuous (semi)linear maps. -/
+def arrow_congr_equivSL (e₁₂ : E ≃SL[σ₁₂] F) (e₄₃ : H ≃SL[σ₄₃] G) :
   (E →SL[σ₁₄] H) ≃SL[σ₄₃] (F →SL[σ₂₃] G) :=
 { map_add' := λ f g, by simp only [equiv.to_fun_as_coe, add_comp, comp_add,
     continuous_linear_equiv.arrow_congr_equiv_apply],
   map_smul' := λ t f, by simp only [equiv.to_fun_as_coe, smul_comp, comp_smulₛₗ,
     continuous_linear_equiv.arrow_congr_equiv_apply],
   continuous_to_fun := (compSL F H G σ₂₄ σ₄₃ e₄₃).continuous.comp
-    ((compSL F E _ σ₂₁ _).flip e₁₂.symm).continuous,
+    (continuous_linear_map.flip (compSL F E H σ₂₁ σ₁₄) e₁₂.symm).continuous,
   continuous_inv_fun := (compSL E G H σ₁₃ σ₃₄ e₄₃.symm).continuous.comp
-    ((compSL E F _ σ₁₂ _).flip e₁₂).continuous,
+    (continuous_linear_map.flip (compSL E F G σ₁₂ σ₂₃) e₁₂).continuous,
   .. e₁₂.arrow_congr_equiv e₄₃, }
 
-omit σ₂₁ σ₃₄
+omit σ₂₁ σ₃₄ σ₁₃ σ₂₄
 
 /-- A pair of continuous linear equivalences generates an continuous linear equivalence between
-  the spaces of continuous linear maps. -/
-@[simps] def arrow_congr_equivL'
-  {H : Type*} [normed_group H] [normed_space 𝕜 H] (e₁ : E ≃L[𝕜] G) (e₂ : F ≃L[𝕜] H)
-   :
-  (E →L[𝕜] F) ≃L[𝕜] (G →L[𝕜] H) :=
-arrow_congr_equivL
+the spaces of continuous linear maps. -/
+def arrow_congr_equivL {F H : Type*} [normed_group F] [normed_group H]
+  [normed_space 𝕜 F] [normed_space 𝕜 G] [normed_space 𝕜 H]
+  (e₁ : E ≃L[𝕜] F) (e₂ : H ≃L[𝕜] G) :
+  (E →L[𝕜] H) ≃L[𝕜] (F →L[𝕜] G) :=
+arrow_congr_equivSL e₁ e₂
 
 /-- Continuous linear equivalence between continuous linear functions `𝕜ⁿ → E` and `Eⁿ`.
 The spaces `𝕜ⁿ` and `Eⁿ` are represented as `ι → 𝕜` and `ι → E`, respectively,

--- a/src/topology/algebra/module/basic.lean
+++ b/src/topology/algebra/module/basic.lean
@@ -1591,7 +1591,7 @@ variables {M₁} {R₄ : Type*} [semiring R₄] [module R₄ M₄]
 include σ₂₁ σ₃₄ σ₂₃ σ₂₄ σ₁₃
 
 /-- A pair of continuous (semi)linear equivalences generates an equivalence between the spaces of
-continuous linear maps. -/
+continuous linear maps. See also `continuous_linear_equiv.arrow_congr_equivL`. -/
 @[simps] def arrow_congr_equiv (e₁₂ : M₁ ≃SL[σ₁₂] M₂) (e₄₃ : M₄ ≃SL[σ₄₃] M₃) :
   (M₁ →SL[σ₁₄] M₄) ≃ (M₂ →SL[σ₂₃] M₃) :=
 { to_fun := λ f, (e₄₃ : M₄ →SL[σ₄₃] M₃).comp (f.comp (e₁₂.symm : M₂ →SL[σ₂₁] M₁)),

--- a/src/topology/algebra/module/basic.lean
+++ b/src/topology/algebra/module/basic.lean
@@ -1591,7 +1591,7 @@ variables {M₁} {R₄ : Type*} [semiring R₄] [module R₄ M₄]
 include σ₂₁ σ₃₄ σ₂₃ σ₂₄ σ₁₃
 
 /-- A pair of continuous (semi)linear equivalences generates an equivalence between the spaces of
-continuous linear maps. See also `continuous_linear_equiv.arrow_congr_equivL`. -/
+continuous linear maps. See also `continuous_linear_equiv.arrow_congr`. -/
 @[simps] def arrow_congr_equiv (e₁₂ : M₁ ≃SL[σ₁₂] M₂) (e₄₃ : M₄ ≃SL[σ₄₃] M₃) :
   (M₁ →SL[σ₁₄] M₄) ≃ (M₂ →SL[σ₂₃] M₃) :=
 { to_fun := λ f, (e₄₃ : M₄ →SL[σ₄₃] M₃).comp (f.comp (e₁₂.symm : M₂ →SL[σ₂₁] M₁)),


### PR DESCRIPTION
* Prove that a map is `C^(n+1)` iff it is differentiable and all its directional derivatives in all points are `C^n`. 
* Also some supporting lemmas about `continuous_linear_equiv`.
* We only manage to prove this when the domain is finite dimensional.
* Prove one direction of `cont_diff_on_succ_iff_fderiv_within` with fewer assumptions
* From the sphere eversion project

Co-authored by: Patrick Massot [patrick.massot@u-psud.fr](mailto:patrick.massot@u-psud.fr)
Co-authored by: Oliver Nash [github@olivernash.org](mailto:github@olivernash.org)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[Zulip post](https://leanprover.zulipchat.com/#narrow/stream/116395-maths/topic/family.20of.20linear.20maps.20is.20C.5En.20if.20its.20applications.20are.20C.5En)

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
