### PR TITLE
[Merged by Bors] - chore(data/polynomial): use dot notation for sub lemmas

### DIFF
--- a/src/data/polynomial/monic.lean
+++ b/src/data/polynomial/monic.lean
@@ -376,11 +376,11 @@ begin
       nat_degree_one]
 end
 
-lemma monic_sub_of_left {p q : R[X]} (hp : monic p) (hpq : degree q < degree p) :
+lemma monic.sub_of_left {p q : R[X]} (hp : monic p) (hpq : degree q < degree p) :
   monic (p - q) :=
 by { rw sub_eq_add_neg, apply hp.add_of_left, rwa degree_neg }
 
-lemma monic_sub_of_right {p q : R[X]}
+lemma monic.sub_of_right {p q : R[X]}
   (hq : q.leading_coeff = -1) (hpq : degree p < degree q) : monic (p - q) :=
 have (-q).coeff (-q).nat_degree = 1 :=
 by rw [nat_degree_neg, coeff_neg, show q.coeff q.nat_degree = -1, from hq, neg_neg],

--- a/src/ring_theory/power_basis.lean
+++ b/src/ring_theory/power_basis.lean
@@ -209,7 +209,7 @@ nat_degree_eq_of_degree_eq_some pb.degree_minpoly_gen
 
 lemma minpoly_gen_monic (pb : power_basis A S) : monic (minpoly_gen pb) :=
 begin
-  apply monic_sub_of_left (monic_X_pow _) _,
+  apply (monic_X_pow _).sub_of_left _,
   rw degree_X_pow,
   exact degree_sum_fin_lt _
 end


### PR DESCRIPTION
To match the additive versions

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
