### PR TITLE
[Merged by Bors] - feat(algebra/big_operators/finprod): add lemma `finprod_eq_prod_of_mul_support_to_finset_subset'`

### DIFF
--- a/src/algebra/big_operators/finprod.lean
+++ b/src/algebra/big_operators/finprod.lean
@@ -285,6 +285,15 @@ end
   ∏ᶠ i, f i = ∏ i in s, f i :=
 finprod_eq_prod_of_mul_support_subset _ $ λ x hx, h $ hf.mem_to_finset.2 hx
 
+@[to_additive] lemma finprod_eq_prod_of_mul_support_to_finset_subset'
+  (f : α → M) {s : finset α} (h : mul_support f ⊆ (s : set α)) :
+  ∏ᶠ i, f i = ∏ i in s, f i :=
+begin
+  have h' : (s.finite_to_set.subset h).to_finset ⊆ s,
+  { simpa [← finset.coe_subset, set.coe_to_finset], },
+  exact finprod_eq_prod_of_mul_support_to_finset_subset _ _ h',
+end
+
 @[to_additive] lemma finprod_def (f : α → M) [decidable (mul_support f).finite] :
   ∏ᶠ i : α, f i = if h : (mul_support f).finite then ∏ i in h.to_finset, f i else 1 :=
 begin

--- a/src/algebra/big_operators/finprod.lean
+++ b/src/algebra/big_operators/finprod.lean
@@ -285,7 +285,7 @@ end
   ∏ᶠ i, f i = ∏ i in s, f i :=
 finprod_eq_prod_of_mul_support_subset _ $ λ x hx, h $ hf.mem_to_finset.2 hx
 
-@[to_additive] lemma finprod_eq_prod_of_mul_support_to_finset_subset'
+@[to_additive] lemma finprod_eq_finset_prod_of_mul_support_subset
   (f : α → M) {s : finset α} (h : mul_support f ⊆ (s : set α)) :
   ∏ᶠ i, f i = ∏ i in s, f i :=
 begin


### PR DESCRIPTION
Formalized as part of the Sphere Eversion project.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
