### PR TITLE
[Merged by Bors] - feat(algebra/squarefree): relate squarefree on naturals to factorization

### DIFF
--- a/src/algebra/squarefree.lean
+++ b/src/algebra/squarefree.lean
@@ -227,13 +227,12 @@ end
 theorem squarefree_iff_prime_squarefree {n : ℕ} : squarefree n ↔ ∀ x, prime x → ¬ x * x ∣ n :=
 squarefree_iff_irreducible_sq_not_dvd_of_exists_irreducible ⟨_, prime_two⟩
 
-lemma squarefree.factorization_le_one {n : ℕ} (hn : squarefree n) :
-  ∀ p, n.factorization p ≤ 1 :=
+lemma squarefree.factorization_le_one {n : ℕ} (p : ℕ) (hn : squarefree n) :
+  n.factorization p ≤ 1 :=
 begin
   rcases eq_or_ne n 0 with rfl | hn',
   { simp },
   rw [multiplicity.squarefree_iff_multiplicity_le_one] at hn,
-  intros p,
   by_cases hp : p.prime,
   { have := hn p,
     simp only [multiplicity_eq_factorization hp hn', nat.is_unit_iff, hp.ne_one, or_false] at this,
@@ -253,22 +252,18 @@ end
 
 lemma squarefree_iff_factorization_le_one {n : ℕ} (hn : n ≠ 0) :
   squarefree n ↔ ∀ p, n.factorization p ≤ 1 :=
-⟨squarefree.factorization_le_one, squarefree_of_factorization_le_one hn⟩
+⟨λ p hn, squarefree.factorization_le_one hn p, squarefree_of_factorization_le_one hn⟩
 
 lemma squarefree.ext_iff {n m : ℕ} (hn : squarefree n) (hm : squarefree m) :
   n = m ↔ ∀ p, prime p → (p ∣ n ↔ p ∣ m) :=
 begin
-  split,
-  { rintro rfl, simp },
-  intro h,
-  apply eq_of_factorization_eq hn.ne_zero hm.ne_zero,
-  intro p,
+  refine ⟨by { rintro rfl, simp }, λ h, eq_of_factorization_eq hn.ne_zero hm.ne_zero (λ p, _)⟩,
   by_cases hp : p.prime,
   { have h₁ := h _ hp,
     rw [←not_iff_not, hp.dvd_iff_one_le_factorization hn.ne_zero, not_le, lt_one_iff,
       hp.dvd_iff_one_le_factorization hm.ne_zero, not_le, lt_one_iff] at h₁,
-    have h₂ := squarefree.factorization_le_one hn p,
-    have h₃ := squarefree.factorization_le_one hm p,
+    have h₂ := squarefree.factorization_le_one p hn,
+    have h₃ := squarefree.factorization_le_one p hm,
     rw [nat.le_add_one_iff, le_zero_iff] at h₂ h₃,
     cases h₂,
     { rwa [h₂, eq_comm, ←h₁] },
@@ -281,20 +276,11 @@ end
 lemma squarefree_pow_iff {n k : ℕ} (hn : n ≠ 1) (hk : k ≠ 0) :
   squarefree (n ^ k) ↔ squarefree n ∧ k = 1 :=
 begin
-  symmetry,
-  split,
-  { rintro ⟨hn, rfl⟩,
-    simpa },
-  intro h,
+  refine ⟨λ h, _, by { rintro ⟨hn, rfl⟩, simpa }⟩,
   rcases eq_or_ne n 0 with rfl | hn₀,
-  { rw zero_pow hk.bot_lt at h,
-    simpa using h },
-  split,
-  { exact squarefree_of_dvd_of_squarefree (dvd_pow_self _ hk) h },
-  by_contra h₁,
-  have : 2 ≤ k,
-  { rw [nat.two_le_iff],
-    exact ⟨hk, h₁⟩ },
+  { simpa [zero_pow hk.bot_lt] using h },
+  refine ⟨squarefree_of_dvd_of_squarefree (dvd_pow_self _ hk) h, by_contradiction $ λ h₁, _⟩,
+  have : 2 ≤ k := k.two_le_iff.mpr ⟨hk, h₁⟩,
   apply hn (nat.is_unit_iff.1 (h _ _)),
   rw ←sq,
   exact pow_dvd_pow _ this

--- a/src/data/nat/basic.lean
+++ b/src/data/nat/basic.lean
@@ -315,6 +315,11 @@ succ_ne_succ.mpr n.succ_ne_zero
 @[simp] lemma one_lt_succ_succ (n : ℕ) : 1 < n.succ.succ :=
 succ_lt_succ $ succ_pos n
 
+lemma two_le_iff : ∀ n, 2 ≤ n ↔ n ≠ 0 ∧ n ≠ 1
+| 0 := by simp
+| 1 := by simp
+| (n+2) := by simp
+
 theorem succ_le_succ_iff {m n : ℕ} : succ m ≤ succ n ↔ m ≤ n :=
 ⟨le_of_succ_le_succ, succ_le_succ⟩
 

--- a/src/data/nat/factorization.lean
+++ b/src/data/nat/factorization.lean
@@ -255,6 +255,10 @@ lemma prime.pow_dvd_iff_dvd_pow_factorization {p k n : ℕ} (pp : prime p) (hn :
   p ^ k ∣ n ↔ p ^ k ∣ p ^ n.factorization p :=
 by rw [pow_dvd_pow_iff_le_right pp.one_lt, pp.pow_dvd_iff_le_factorization hn]
 
+lemma prime.dvd_iff_one_le_factorization {p n : ℕ} (pp : prime p) (hn : n ≠ 0) :
+  p ∣ n ↔ 1 ≤ n.factorization p :=
+iff.trans (by simp) (pp.pow_dvd_iff_le_factorization hn)
+
 lemma exists_factorization_lt_of_lt {a b : ℕ} (ha : a ≠ 0) (hab : a < b) :
   ∃ p : ℕ, a.factorization p < b.factorization p :=
 begin

--- a/src/data/nat/factorization.lean
+++ b/src/data/nat/factorization.lean
@@ -93,6 +93,9 @@ le_of_mem_factors (factor_iff_mem_factorization.mp h)
 lemma factorization_eq_zero_of_non_prime (n : ℕ) {p : ℕ} (hp : ¬p.prime) : n.factorization p = 0 :=
 not_mem_support_iff.1 (mt prime_of_mem_factorization hp)
 
+lemma dvd_of_factorization_pos {n p : ℕ} (hn : n.factorization p ≠ 0) : p ∣ n :=
+dvd_of_mem_factors (factor_iff_mem_factorization.1 (mem_support_iff.2 hn))
+
 lemma prime.factorization_pos_of_dvd {n p : ℕ} (hp : p.prime) (hn : n ≠ 0) (h : p ∣ n) :
   0 < n.factorization p :=
 by rwa [←factors_count_eq, count_pos, mem_factors_iff_dvd hn hp]

--- a/src/data/nat/prime.lean
+++ b/src/data/nat/prime.lean
@@ -64,12 +64,6 @@ instance prime.one_lt' (p : ℕ) [hp : _root_.fact p.prime] : _root_.fact (1 < p
 lemma prime.ne_one {p : ℕ} (hp : p.prime) : p ≠ 1 :=
 hp.one_lt.ne'
 
-lemma two_le_iff (n : ℕ) : 2 ≤ n ↔ n ≠ 0 ∧ ¬is_unit n :=
-begin
-  rw nat.is_unit_iff,
-  rcases n with _|_|m; norm_num [one_lt_succ_succ, succ_le_iff]
-end
-
 lemma prime.eq_one_or_self_of_dvd {p : ℕ} (pp : p.prime) (m : ℕ) (hm : m ∣ p) : m = 1 ∨ m = p :=
 begin
   obtain ⟨n, hn⟩ := hm,


### PR DESCRIPTION
Also moves `nat.two_le_iff` higher up the hierarchy since it's an elementary lemma and give it a more appropriate type.

The lemma `squarefree_iff_prime_sq_not_dvd` has been deleted because it's a duplicate of a lemma which is already earlier in the same file.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
