### PR TITLE
[Merged by Bors] - chore(order/*): Replace total partial orders by linear orders

### DIFF
--- a/src/analysis/locally_convex/weak_dual.lean
+++ b/src/analysis/locally_convex/weak_dual.lean
@@ -101,11 +101,8 @@ begin
     let U' := hU₁.to_finset,
     by_cases hU₃ : U.fst.nonempty,
     { have hU₃' : U'.nonempty := (set.finite.to_finset.nonempty hU₁).mpr hU₃,
-      let r := U'.inf' hU₃' U.snd,
-      have hr : 0 < r :=
-      (finset.lt_inf'_iff hU₃').mpr (λ y hy, hU₂ y ((set.finite.mem_to_finset hU₁).mp hy)),
-      use [seminorm.ball (U'.sup p) (0 : E) r],
-      refine ⟨p.basis_sets_mem _ hr, λ x hx y hy, _⟩,
+      refine ⟨(U'.sup p).ball 0 $ U'.inf' hU₃' U.snd, p.basis_sets_mem _ $
+        (finset.lt_inf'_iff _).2 $ λ y hy, hU₂ y $ (hU₁.mem_to_finset).mp hy, λ x hx y hy, _⟩,
       simp only [set.mem_preimage, set.mem_pi, mem_ball_zero_iff],
       rw seminorm.mem_ball_zero at hx,
       rw ←linear_map.to_seminorm_family_apply,

--- a/src/analysis/locally_convex/weak_dual.lean
+++ b/src/analysis/locally_convex/weak_dual.lean
@@ -103,7 +103,7 @@ begin
     { have hU₃' : U'.nonempty := (set.finite.to_finset.nonempty hU₁).mpr hU₃,
       let r := U'.inf' hU₃' U.snd,
       have hr : 0 < r :=
-      (finset.lt_inf'_iff hU₃' _).mpr (λ y hy, hU₂ y ((set.finite.mem_to_finset hU₁).mp hy)),
+      (finset.lt_inf'_iff hU₃').mpr (λ y hy, hU₂ y ((set.finite.mem_to_finset hU₁).mp hy)),
       use [seminorm.ball (U'.sup p) (0 : E) r],
       refine ⟨p.basis_sets_mem _ hr, λ x hx y hy, _⟩,
       simp only [set.mem_preimage, set.mem_pi, mem_ball_zero_iff],

--- a/src/data/finset/lattice.lean
+++ b/src/data/finset/lattice.lean
@@ -103,22 +103,6 @@ sup_le (λ b hb, le_trans (h b hb) (le_sup hb))
 lemma sup_mono (h : s₁ ⊆ s₂) : s₁.sup f ≤ s₂.sup f :=
 sup_le $ assume b hb, le_sup (h hb)
 
-@[simp] lemma sup_lt_iff [is_total α (≤)] {a : α} (ha : ⊥ < a) : s.sup f < a ↔ (∀ b ∈ s, f b < a) :=
-⟨(λ hs b hb, lt_of_le_of_lt (le_sup hb) hs), finset.cons_induction_on s (λ _, ha)
-  (λ c t hc, by simpa only [sup_cons, sup_lt_iff, mem_cons, forall_eq_or_imp] using and.imp_right)⟩
-
-@[simp] lemma le_sup_iff [is_total α (≤)] {a : α} (ha : ⊥ < a) : a ≤ s.sup f ↔ ∃ b ∈ s, a ≤ f b :=
-⟨finset.cons_induction_on s (λ h, absurd h (not_le_of_lt ha))
-  (λ c t hc ih, by simpa using @or.rec _ _ (∃ b, (b = c ∨ b ∈ t) ∧ a ≤ f b)
-    (λ h, ⟨c, or.inl rfl, h⟩) (λ h, let ⟨b, hb, hle⟩ := ih h in ⟨b, or.inr hb, hle⟩)),
-(λ ⟨b, hb, hle⟩, trans hle (le_sup hb))⟩
-
-@[simp] lemma lt_sup_iff [is_total α (≤)] {a : α} : a < s.sup f ↔ ∃ b ∈ s, a < f b :=
-⟨finset.cons_induction_on s (λ h, absurd h not_lt_bot)
-  (λ c t hc ih, by simpa using @or.rec _ _ (∃ b, (b = c ∨ b ∈ t) ∧ a < f b)
-    (λ h, ⟨c, or.inl rfl, h⟩) (λ h, let ⟨b, hb, hlt⟩ := ih h in ⟨b, or.inr hb, hlt⟩)),
-(λ ⟨b, hb, hlt⟩, lt_of_lt_of_le hlt (le_sup hb))⟩
-
 lemma sup_comm (s : finset β) (t : finset γ) (f : β → γ → α) :
   s.sup (λ b, t.sup (f b)) = t.sup (λ c, s.sup (λ b, f b c)) :=
 begin
@@ -167,10 +151,6 @@ lemma comp_sup_eq_sup_comp [semilattice_sup γ] [order_bot γ] {s : finset β}
   {f : β → α} (g : α → γ) (g_sup : ∀ x y, g (x ⊔ y) = g x ⊔ g y) (bot : g ⊥ = ⊥) :
   g (s.sup f) = s.sup (g ∘ f) :=
 finset.cons_induction_on s bot (λ c t hc ih, by rw [sup_cons, sup_cons, g_sup, ih])
-
-lemma comp_sup_eq_sup_comp_of_is_total [is_total α (≤)] {γ : Type} [semilattice_sup γ] [order_bot γ]
-  (g : α → γ) (mono_g : monotone g) (bot : g ⊥ = ⊥) : g (s.sup f) = s.sup (g ∘ f) :=
-comp_sup_eq_sup_comp g mono_g.map_sup bot
 
 /-- Computing `sup` in a subtype (closed under `sup`) is the same as computing it in `α`. -/
 lemma sup_coe {P : α → Prop}
@@ -326,15 +306,6 @@ le_inf (λ b hb, le_trans (inf_le hb) (h b hb))
 lemma inf_mono (h : s₁ ⊆ s₂) : s₂.inf f ≤ s₁.inf f :=
 le_inf $ assume b hb, inf_le (h hb)
 
-@[simp] lemma lt_inf_iff [is_total α (≤)] {a : α} (ha : a < ⊤) : a < s.inf f ↔ (∀ b ∈ s, a < f b) :=
-@sup_lt_iff (order_dual α) _ _ _ _ _ _ _ ha
-
-@[simp] lemma inf_le_iff [is_total α (≤)] {a : α} (ha : a < ⊤) : s.inf f ≤ a ↔ (∃ b ∈ s, f b ≤ a) :=
-@le_sup_iff (order_dual α) _ _ _ _ _ _ _ ha
-
-@[simp] lemma inf_lt_iff [is_total α (≤)] {a : α} : s.inf f < a ↔ (∃ b ∈ s, f b < a) :=
-@lt_sup_iff (order_dual α) _ _ _ _ _ _ _
-
 lemma inf_attach (s : finset β) (f : β → α) : s.attach.inf (λ x, f x) = s.inf f :=
 @sup_attach (order_dual α) _ _ _ _ _
 
@@ -383,10 +354,6 @@ lemma comp_inf_eq_inf_comp [semilattice_inf γ] [order_top γ] {s : finset β}
   {f : β → α} (g : α → γ) (g_inf : ∀ x y, g (x ⊓ y) = g x ⊓ g y) (top : g ⊤ = ⊤) :
   g (s.inf f) = s.inf (g ∘ f) :=
 @comp_sup_eq_sup_comp (order_dual α) _ (order_dual γ) _ _ _ _ _ _ _ g_inf top
-
-lemma comp_inf_eq_inf_comp_of_is_total [h : is_total α (≤)] {γ : Type} [semilattice_inf γ]
-  [order_top γ] (g : α → γ) (mono_g : monotone g) (top : g ⊤ = ⊤) : g (s.inf f) = s.inf (g ∘ f) :=
-comp_inf_eq_inf_comp g mono_g.map_inf top
 
 /-- Computing `inf` in a subtype (closed under `inf`) is the same as computing it in `α`. -/
 lemma inf_coe {P : α → Prop}
@@ -452,6 +419,53 @@ lemma inf_sup_distrib_right (s : finset ι) (f : ι → α) (a : α) :
 end order_top
 end distrib_lattice
 
+section linear_order
+variables [linear_order α]
+
+lemma comp_sup_eq_sup_comp_of_is_total [semilattice_sup β] [order_bot β] (g : α → γ)
+  (mono_g : monotone g) (bot : g ⊥ = ⊥) : g (s.sup f) = s.sup (g ∘ f) :=
+comp_sup_eq_sup_comp g mono_g.map_sup bot
+
+lemma comp_inf_eq_inf_comp_of_is_total [semilattice_inf β] [order_top β] (g : α → γ)
+  (mono_g : monotone g) (top : g ⊤ = ⊤) : g (s.inf f) = s.inf (g ∘ f) :=
+comp_inf_eq_inf_comp g mono_g.map_inf top
+
+section order_bot
+variables [order_bot α] {s : finset ι} {f : ι → α} {a : α}
+
+@[simp] lemma le_sup_iff (ha : ⊥ < a) : a ≤ s.sup f ↔ ∃ b ∈ s, a ≤ f b :=
+⟨finset.cons_induction_on s (λ h, absurd h (not_le_of_lt ha))
+  (λ c t hc ih, by simpa using @or.rec _ _ (∃ b, (b = c ∨ b ∈ t) ∧ a ≤ f b)
+    (λ h, ⟨c, or.inl rfl, h⟩) (λ h, let ⟨b, hb, hle⟩ := ih h in ⟨b, or.inr hb, hle⟩)),
+(λ ⟨b, hb, hle⟩, trans hle (le_sup hb))⟩
+
+@[simp] lemma lt_sup_iff : a < s.sup f ↔ ∃ b ∈ s, a < f b :=
+⟨finset.cons_induction_on s (λ h, absurd h not_lt_bot)
+  (λ c t hc ih, by simpa using @or.rec _ _ (∃ b, (b = c ∨ b ∈ t) ∧ a < f b)
+    (λ h, ⟨c, or.inl rfl, h⟩) (λ h, let ⟨b, hb, hlt⟩ := ih h in ⟨b, or.inr hb, hlt⟩)),
+(λ ⟨b, hb, hlt⟩, lt_of_lt_of_le hlt (le_sup hb))⟩
+
+@[simp] lemma sup_lt_iff (ha : ⊥ < a) : s.sup f < a ↔ ∀ b ∈ s, f b < a :=
+⟨(λ hs b hb, lt_of_le_of_lt (le_sup hb) hs), finset.cons_induction_on s (λ _, ha)
+  (λ c t hc, by simpa only [sup_cons, sup_lt_iff, mem_cons, forall_eq_or_imp] using and.imp_right)⟩
+
+end order_bot
+
+section order_top
+variables [order_top α] {s : finset ι} {f : ι → α} {a : α}
+
+@[simp] lemma inf_le_iff (ha : a < ⊤) : s.inf f ≤ a ↔ ∃ b ∈ s, f b ≤ a :=
+@le_sup_iff (order_dual α) _ _ _ _ _ _ ha
+
+@[simp] lemma inf_lt_iff : s.inf f < a ↔ (∃ b ∈ s, f b < a) :=
+@lt_sup_iff (order_dual α) _ _ _ _ _ _
+
+@[simp] lemma lt_inf_iff (ha : a < ⊤) : a < s.inf f ↔ ∀ b ∈ s, a < f b :=
+@sup_lt_iff (order_dual α) _ _ _ _ _ _ ha
+
+end order_top
+end linear_order
+
 lemma inf_eq_infi [complete_lattice β] (s : finset α) (f : α → β) : s.inf f = (⨅a∈s, f a) :=
 @sup_eq_supr _ (order_dual β) _ _ _
 
@@ -512,24 +526,6 @@ end
 @[simp] lemma sup'_le_iff {a : α} : s.sup' H f ≤ a ↔ ∀ b ∈ s, f b ≤ a :=
 iff.intro (λ h b hb, trans (le_sup' f hb) h) (sup'_le H f)
 
-@[simp] lemma sup'_lt_iff [is_total α (≤)] {a : α} : s.sup' H f < a ↔ (∀ b ∈ s, f b < a) :=
-begin
-  rw [←with_bot.coe_lt_coe, coe_sup', sup_lt_iff (with_bot.bot_lt_coe a)],
-  exact ball_congr (λ b hb, with_bot.coe_lt_coe),
-end
-
-@[simp] lemma le_sup'_iff [is_total α (≤)] {a : α} : a ≤ s.sup' H f ↔ (∃ b ∈ s, a ≤ f b) :=
-begin
-  rw [←with_bot.coe_le_coe, coe_sup', le_sup_iff (with_bot.bot_lt_coe a)],
-  exact bex_congr (λ b hb, with_bot.coe_le_coe),
-end
-
-@[simp] lemma lt_sup'_iff [is_total α (≤)] {a : α} : a < s.sup' H f ↔ (∃ b ∈ s, a < f b) :=
-begin
-  rw [←with_bot.coe_lt_coe, coe_sup', lt_sup_iff],
-  exact bex_congr (λ b hb, with_bot.coe_lt_coe),
-end
-
 lemma sup'_bUnion [decidable_eq β] {s : finset γ} (Hs : s.nonempty) {t : γ → finset β}
   (Ht : ∀ b, (t b).nonempty) :
   (s.bUnion t).sup' (Hs.bUnion (λ b _, Ht b)) f = s.sup' Hs (λ b, (t b).sup' (Ht b) f) :=
@@ -561,17 +557,6 @@ begin
   { rw [with_bot.none_eq_bot, bot_sup_eq], exact h₂ },
   cases a₂,
   exacts [h₁, hp a₁ h₁ a₂ h₂]
-end
-
-lemma exists_mem_eq_sup' [is_total α (≤)] : ∃ b, b ∈ s ∧ s.sup' H f = f b :=
-begin
-  refine H.cons_induction (λ c, _) (λ c s hc hs ih, _),
-  { exact ⟨c, mem_singleton_self c, rfl⟩, },
-  { rcases ih with ⟨b, hb, h'⟩,
-    rw [sup'_cons hs, h'],
-    cases total_of (≤) (f b) (f c) with h h,
-    { exact ⟨c, mem_cons.2 (or.inl rfl), sup_eq_left.2 h⟩, },
-    { exact ⟨b, mem_cons.2 (or.inr hb), sup_eq_right.2 h⟩, }, },
 end
 
 lemma sup'_mem
@@ -627,18 +612,6 @@ lemma inf'_le {b : β} (h : b ∈ s) : s.inf' ⟨b, h⟩ f ≤ f b :=
 @[simp] lemma inf'_const (a : α) : s.inf' H (λ b, a) = a :=
 @sup'_const (order_dual α) _ _ _ _ _
 
-@[simp] lemma le_inf'_iff {a : α} : a ≤ s.inf' H f ↔ ∀ b ∈ s, a ≤ f b :=
-@sup'_le_iff (order_dual α) _ _ _ H f _
-
-@[simp] lemma lt_inf'_iff [is_total α (≤)] {a : α} : a < s.inf' H f ↔ (∀ b ∈ s, a < f b) :=
-@sup'_lt_iff (order_dual α) _ _ _ H f _ _
-
-@[simp] lemma inf'_le_iff [is_total α (≤)] {a : α} : s.inf' H f ≤ a ↔ (∃ b ∈ s, f b ≤ a) :=
-@le_sup'_iff (order_dual α) _ _ _ H f _ _
-
-@[simp] lemma inf'_lt_iff [is_total α (≤)] {a : α} : s.inf' H f < a ↔ (∃ b ∈ s, f b < a) :=
-@lt_sup'_iff (order_dual α) _ _ _ H f _ _
-
 lemma inf'_bUnion [decidable_eq β] {s : finset γ} (Hs : s.nonempty) {t : γ → finset β}
   (Ht : ∀ b, (t b).nonempty) :
   (s.bUnion t).inf' (Hs.bUnion (λ b _, Ht b)) f = s.inf' Hs (λ b, (t b).inf' (Ht b) f) :=
@@ -652,9 +625,6 @@ lemma comp_inf'_eq_inf'_comp [semilattice_inf γ] {s : finset β} (H : s.nonempt
 lemma inf'_induction {p : α → Prop} (hp : ∀ a₁, p a₁ → ∀ a₂, p a₂ → p (a₁ ⊓ a₂))
   (hs : ∀ b ∈ s, p (f b)) : p (s.inf' H f) :=
 @sup'_induction (order_dual α) _ _ _ H f _ hp hs
-
-lemma exists_mem_eq_inf' [is_total α (≤)] : ∃ b, b ∈ s ∧ s.inf' H f = f b :=
-@exists_mem_eq_sup' (order_dual α) _ _ _ H f _
 
 lemma inf'_mem (s : set α) (w : ∀ x y ∈ s, x ⊓ y ∈ s)
   {ι : Type*} (t : finset ι) (H : t.nonempty) (p : ι → α) (h : ∀ i ∈ t, p i ∈ s) :
@@ -676,10 +646,6 @@ lemma sup_closed_of_sup_closed {s : set α} (t : finset α) (htne : t.nonempty) 
   (h : ∀ a b ∈ s, a ⊔ b ∈ s) : t.sup id ∈ s :=
 sup'_eq_sup htne id ▸ sup'_induction _ _ h h_subset
 
-lemma exists_mem_eq_sup [is_total α (≤)] (s : finset β) (h : s.nonempty) (f : β → α) :
-  ∃ b, b ∈ s ∧ s.sup f = f b :=
-sup'_eq_sup h f ▸ exists_mem_eq_sup' h f
-
 lemma coe_sup_of_nonempty {s : finset β} (h : s.nonempty) (f : β → α) :
   (↑(s.sup f) : with_bot α) = s.sup (coe ∘ f) :=
 by simp only [←sup'_eq_sup h, coe_sup' h]
@@ -695,10 +661,6 @@ lemma inf'_eq_inf {s : finset β} (H : s.nonempty) (f : β → α) : s.inf' H f 
 lemma inf_closed_of_inf_closed {s : set α} (t : finset α) (htne : t.nonempty) (h_subset : ↑t ⊆ s)
   (h : ∀ a b ∈ s, a ⊓ b ∈ s) : t.inf id ∈ s :=
 @sup_closed_of_sup_closed (order_dual α) _ _ _ t htne h_subset h
-
-lemma exists_mem_eq_inf [is_total α (≤)] (s : finset β) (h : s.nonempty) (f : β → α) :
-  ∃ a, a ∈ s ∧ s.inf f = f a :=
-@exists_mem_eq_sup (order_dual α) _ _ _ _ _ h f
 
 lemma coe_inf_of_nonempty {s : finset β} (h : s.nonempty) (f : β → α):
   (↑(s.inf f) : with_top α) = s.inf (λ i, f i) :=
@@ -745,6 +707,60 @@ protected lemma inf'_apply {s : finset α} (H : s.nonempty) (f : α → Π (b : 
 @finset.sup'_apply _ _ (λ b, order_dual (C b)) _ _ H f b
 
 end inf'
+
+section linear_order
+variables [linear_order α] {s : finset ι} (H : s.nonempty) {f : ι → α} {a : α}
+
+@[simp] lemma le_sup'_iff : a ≤ s.sup' H f ↔ ∃ b ∈ s, a ≤ f b :=
+begin
+  rw [←with_bot.coe_le_coe, coe_sup', le_sup_iff (with_bot.bot_lt_coe a)],
+  exact bex_congr (λ b hb, with_bot.coe_le_coe),
+end
+
+@[simp] lemma lt_sup'_iff : a < s.sup' H f ↔ ∃ b ∈ s, a < f b :=
+begin
+  rw [←with_bot.coe_lt_coe, coe_sup', lt_sup_iff],
+  exact bex_congr (λ b hb, with_bot.coe_lt_coe),
+end
+
+@[simp] lemma sup'_lt_iff : s.sup' H f < a ↔ ∀ i ∈ s, f i < a :=
+begin
+  rw [←with_bot.coe_lt_coe, coe_sup', sup_lt_iff (with_bot.bot_lt_coe a)],
+  exact ball_congr (λ b hb, with_bot.coe_lt_coe),
+end
+
+@[simp] lemma inf'_le_iff : s.inf' H f ≤ a ↔ ∃ i ∈ s, f i ≤ a :=
+@le_sup'_iff (order_dual α) _ _ _ H f _
+
+@[simp] lemma inf'_lt_iff : s.inf' H f < a ↔ ∃ i ∈ s, f i < a :=
+@lt_sup'_iff (order_dual α) _ _ _ H f _
+
+@[simp] lemma lt_inf'_iff : a < s.inf' H f ↔ ∀ i ∈ s, a < f i :=
+@sup'_lt_iff (order_dual α) _ _ _ H f _
+
+lemma exists_mem_eq_sup' : ∃ i, i ∈ s ∧ s.sup' H f = f i :=
+begin
+  refine H.cons_induction (λ c, _) (λ c s hc hs ih, _),
+  { exact ⟨c, mem_singleton_self c, rfl⟩, },
+  { rcases ih with ⟨b, hb, h'⟩,
+    rw [sup'_cons hs, h'],
+    cases total_of (≤) (f b) (f c) with h h,
+    { exact ⟨c, mem_cons.2 (or.inl rfl), sup_eq_left.2 h⟩, },
+    { exact ⟨b, mem_cons.2 (or.inr hb), sup_eq_right.2 h⟩, }, },
+end
+
+lemma exists_mem_eq_inf' : ∃ i, i ∈ s ∧ s.inf' H f = f i :=
+@exists_mem_eq_sup' (order_dual α) _ _ _ H f _
+
+lemma exists_mem_eq_sup [order_bot α] (s : finset ι) (h : s.nonempty) (f : ι → α) :
+  ∃ i, i ∈ s ∧ s.sup f = f i :=
+sup'_eq_sup h f ▸ exists_mem_eq_sup' h f
+
+lemma exists_mem_eq_inf [order_top α] (s : finset ι) (h : s.nonempty) (f : ι → α) :
+  ∃ i, i ∈ s ∧ s.inf f = f i :=
+@exists_mem_eq_sup (order_dual α) _ _ _ _ _ h f
+
+end linear_order
 
 /-! ### max and min of finite sets -/
 section max_min

--- a/src/data/finset/lattice.lean
+++ b/src/data/finset/lattice.lean
@@ -422,30 +422,26 @@ end distrib_lattice
 section linear_order
 variables [linear_order α]
 
-lemma comp_sup_eq_sup_comp_of_is_total [semilattice_sup β] [order_bot β] (g : α → γ)
-  (mono_g : monotone g) (bot : g ⊥ = ⊥) : g (s.sup f) = s.sup (g ∘ f) :=
-comp_sup_eq_sup_comp g mono_g.map_sup bot
-
-lemma comp_inf_eq_inf_comp_of_is_total [semilattice_inf β] [order_top β] (g : α → γ)
-  (mono_g : monotone g) (top : g ⊤ = ⊤) : g (s.inf f) = s.inf (g ∘ f) :=
-comp_inf_eq_inf_comp g mono_g.map_inf top
-
 section order_bot
 variables [order_bot α] {s : finset ι} {f : ι → α} {a : α}
 
-@[simp] lemma le_sup_iff (ha : ⊥ < a) : a ≤ s.sup f ↔ ∃ b ∈ s, a ≤ f b :=
+lemma comp_sup_eq_sup_comp_of_is_total [semilattice_sup β] [order_bot β] (g : α → β)
+  (mono_g : monotone g) (bot : g ⊥ = ⊥) : g (s.sup f) = s.sup (g ∘ f) :=
+comp_sup_eq_sup_comp g mono_g.map_sup bot
+
+@[simp] protected lemma le_sup_iff (ha : ⊥ < a) : a ≤ s.sup f ↔ ∃ b ∈ s, a ≤ f b :=
 ⟨finset.cons_induction_on s (λ h, absurd h (not_le_of_lt ha))
   (λ c t hc ih, by simpa using @or.rec _ _ (∃ b, (b = c ∨ b ∈ t) ∧ a ≤ f b)
     (λ h, ⟨c, or.inl rfl, h⟩) (λ h, let ⟨b, hb, hle⟩ := ih h in ⟨b, or.inr hb, hle⟩)),
 (λ ⟨b, hb, hle⟩, trans hle (le_sup hb))⟩
 
-@[simp] lemma lt_sup_iff : a < s.sup f ↔ ∃ b ∈ s, a < f b :=
+@[simp] protected lemma lt_sup_iff : a < s.sup f ↔ ∃ b ∈ s, a < f b :=
 ⟨finset.cons_induction_on s (λ h, absurd h not_lt_bot)
   (λ c t hc ih, by simpa using @or.rec _ _ (∃ b, (b = c ∨ b ∈ t) ∧ a < f b)
     (λ h, ⟨c, or.inl rfl, h⟩) (λ h, let ⟨b, hb, hlt⟩ := ih h in ⟨b, or.inr hb, hlt⟩)),
 (λ ⟨b, hb, hlt⟩, lt_of_lt_of_le hlt (le_sup hb))⟩
 
-@[simp] lemma sup_lt_iff (ha : ⊥ < a) : s.sup f < a ↔ ∀ b ∈ s, f b < a :=
+@[simp] protected lemma sup_lt_iff (ha : ⊥ < a) : s.sup f < a ↔ ∀ b ∈ s, f b < a :=
 ⟨(λ hs b hb, lt_of_le_of_lt (le_sup hb) hs), finset.cons_induction_on s (λ _, ha)
   (λ c t hc, by simpa only [sup_cons, sup_lt_iff, mem_cons, forall_eq_or_imp] using and.imp_right)⟩
 
@@ -454,14 +450,18 @@ end order_bot
 section order_top
 variables [order_top α] {s : finset ι} {f : ι → α} {a : α}
 
-@[simp] lemma inf_le_iff (ha : a < ⊤) : s.inf f ≤ a ↔ ∃ b ∈ s, f b ≤ a :=
-@le_sup_iff (order_dual α) _ _ _ _ _ _ ha
+lemma comp_inf_eq_inf_comp_of_is_total [semilattice_inf β] [order_top β] (g : α → β)
+  (mono_g : monotone g) (top : g ⊤ = ⊤) : g (s.inf f) = s.inf (g ∘ f) :=
+comp_inf_eq_inf_comp g mono_g.map_inf top
 
-@[simp] lemma inf_lt_iff : s.inf f < a ↔ (∃ b ∈ s, f b < a) :=
-@lt_sup_iff (order_dual α) _ _ _ _ _ _
+@[simp] protected lemma inf_le_iff (ha : a < ⊤) : s.inf f ≤ a ↔ ∃ b ∈ s, f b ≤ a :=
+@finset.le_sup_iff (order_dual α) _ _ _ _ _ _ ha
 
-@[simp] lemma lt_inf_iff (ha : a < ⊤) : a < s.inf f ↔ ∀ b ∈ s, a < f b :=
-@sup_lt_iff (order_dual α) _ _ _ _ _ _ ha
+@[simp] protected lemma inf_lt_iff : s.inf f < a ↔ (∃ b ∈ s, f b < a) :=
+@finset.lt_sup_iff (order_dual α) _ _ _ _ _ _
+
+@[simp] protected lemma lt_inf_iff (ha : a < ⊤) : a < s.inf f ↔ ∀ b ∈ s, a < f b :=
+@finset.sup_lt_iff (order_dual α) _ _ _ _ _ _ ha
 
 end order_top
 end linear_order
@@ -713,19 +713,19 @@ variables [linear_order α] {s : finset ι} (H : s.nonempty) {f : ι → α} {a 
 
 @[simp] lemma le_sup'_iff : a ≤ s.sup' H f ↔ ∃ b ∈ s, a ≤ f b :=
 begin
-  rw [←with_bot.coe_le_coe, coe_sup', le_sup_iff (with_bot.bot_lt_coe a)],
+  rw [←with_bot.coe_le_coe, coe_sup', finset.le_sup_iff (with_bot.bot_lt_coe a)],
   exact bex_congr (λ b hb, with_bot.coe_le_coe),
 end
 
 @[simp] lemma lt_sup'_iff : a < s.sup' H f ↔ ∃ b ∈ s, a < f b :=
 begin
-  rw [←with_bot.coe_lt_coe, coe_sup', lt_sup_iff],
+  rw [←with_bot.coe_lt_coe, coe_sup', finset.lt_sup_iff],
   exact bex_congr (λ b hb, with_bot.coe_lt_coe),
 end
 
 @[simp] lemma sup'_lt_iff : s.sup' H f < a ↔ ∀ i ∈ s, f i < a :=
 begin
-  rw [←with_bot.coe_lt_coe, coe_sup', sup_lt_iff (with_bot.bot_lt_coe a)],
+  rw [←with_bot.coe_lt_coe, coe_sup', finset.sup_lt_iff (with_bot.bot_lt_coe a)],
   exact ball_congr (λ b hb, with_bot.coe_lt_coe),
 end
 
@@ -738,7 +738,7 @@ end
 @[simp] lemma lt_inf'_iff : a < s.inf' H f ↔ ∀ i ∈ s, a < f i :=
 @sup'_lt_iff (order_dual α) _ _ _ H f _
 
-lemma exists_mem_eq_sup' : ∃ i, i ∈ s ∧ s.sup' H f = f i :=
+lemma exists_mem_eq_sup' (f : ι → α) : ∃ i, i ∈ s ∧ s.sup' H f = f i :=
 begin
   refine H.cons_induction (λ c, _) (λ c s hc hs ih, _),
   { exact ⟨c, mem_singleton_self c, rfl⟩, },
@@ -749,8 +749,8 @@ begin
     { exact ⟨b, mem_cons.2 (or.inr hb), sup_eq_right.2 h⟩, }, },
 end
 
-lemma exists_mem_eq_inf' : ∃ i, i ∈ s ∧ s.inf' H f = f i :=
-@exists_mem_eq_sup' (order_dual α) _ _ _ H f _
+lemma exists_mem_eq_inf' (f : ι → α) : ∃ i, i ∈ s ∧ s.inf' H f = f i :=
+@exists_mem_eq_sup' (order_dual α) _ _ _ H f
 
 lemma exists_mem_eq_sup [order_bot α] (s : finset ι) (h : s.nonempty) (f : ι → α) :
   ∃ i, i ∈ s ∧ s.sup f = f i :=
@@ -758,7 +758,7 @@ sup'_eq_sup h f ▸ exists_mem_eq_sup' h f
 
 lemma exists_mem_eq_inf [order_top α] (s : finset ι) (h : s.nonempty) (f : ι → α) :
   ∃ i, i ∈ s ∧ s.inf f = f i :=
-@exists_mem_eq_sup (order_dual α) _ _ _ _ _ h f
+@exists_mem_eq_sup (order_dual α) _ _ _ _ h f
 
 end linear_order
 

--- a/src/data/real/nnreal.lean
+++ b/src/data/real/nnreal.lean
@@ -408,7 +408,7 @@ by simp [nnreal.coe_le_coe.symm, real.to_nnreal, hp]
 
 @[simp] lemma to_nnreal_lt_to_nnreal_iff' {r p : ℝ} :
   real.to_nnreal r < real.to_nnreal p ↔ r < p ∧ 0 < p :=
-by simp [nnreal.coe_lt_coe.symm, real.to_nnreal, lt_irrefl]
+nnreal.coe_lt_coe.symm.trans max_lt_max_left_iff
 
 lemma to_nnreal_lt_to_nnreal_iff {r p : ℝ} (h : 0 < p) :
   real.to_nnreal r < real.to_nnreal p ↔ r < p :=

--- a/src/data/set/intervals/basic.lean
+++ b/src/data/set/intervals/basic.lean
@@ -25,8 +25,7 @@ for some statements it should be `linear_order` or `densely_ordered`).
 TODO: This is just the beginning; a lot of rules are missing
 -/
 
-universe u
-variables {α : Type u}
+variables {α β : Type*}
 
 namespace set
 
@@ -1130,7 +1129,7 @@ end
 
 end linear_order
 
-section
+section lattice
 
 section inf
 
@@ -1241,7 +1240,7 @@ end linear_order
 
 section prod
 
-variables {α β : Type*} [preorder α] [preorder β]
+variables [preorder α] [preorder β]
 
 @[simp] lemma Iic_prod_Iic (a : α) (b : β) : Iic a ×ˢ Iic b = Iic (a, b) := rfl
 
@@ -1265,7 +1264,7 @@ end prod
 
 section ordered_comm_group
 
-variables {α : Type*} [ordered_comm_group α] {a b c d : α}
+variables [ordered_comm_group α] {a b c d : α}
 
 /-! `inv_mem_Ixx_iff`, `sub_mem_Ixx_iff` -/
 @[to_additive] lemma inv_mem_Icc_iff : a⁻¹ ∈ set.Icc c d ↔ a ∈ set.Icc (d⁻¹) (c⁻¹) :=
@@ -1281,7 +1280,7 @@ end ordered_comm_group
 
 section ordered_add_comm_group
 
-variables {α : Type*} [ordered_add_comm_group α] {a b c d : α}
+variables [ordered_add_comm_group α] {a b c d : α}
 
 /-! `add_mem_Ixx_iff_left` -/
 lemma add_mem_Icc_iff_left : a + b ∈ set.Icc c d ↔ a ∈ set.Icc (c - b) (d - b) :=
@@ -1351,7 +1350,6 @@ end set
 open set
 
 namespace order_iso
-variables {α β : Type*}
 
 section preorder
 variables [preorder α] [preorder β]
@@ -1422,7 +1420,7 @@ end order_iso
 
 section dense
 
-variables (α : Type*) [preorder α] [densely_ordered α] {x y : α}
+variables (α) [preorder α] [densely_ordered α] {x y : α}
 
 instance : no_min_order (set.Ioo x y) :=
 ⟨λ ⟨a, ha₁, ha₂⟩, begin

--- a/src/data/set/intervals/basic.lean
+++ b/src/data/set/intervals/basic.lean
@@ -26,6 +26,7 @@ TODO: This is just the beginning; a lot of rules are missing
 -/
 
 universe u
+variables {α : Type u}
 
 namespace set
 
@@ -33,7 +34,7 @@ open set
 open order_dual (to_dual of_dual)
 
 section preorder
-variables {α : Type u} [preorder α] {a a₁ a₂ b b₁ b₂ c x : α}
+variables [preorder α] {a a₁ a₂ b b₁ b₂ c x : α}
 
 /-- Left-open right-open interval -/
 def Ioo (a b : α) := {x | a < x ∧ x < b}
@@ -385,7 +386,7 @@ ext $ λ x, ⟨λ H, ⟨H.2.1, H.1⟩, λ H, ⟨H.2, H.1, H.2.trans h⟩⟩
 end preorder
 
 section partial_order
-variables {α : Type u} [partial_order α] {a b c : α}
+variables [partial_order α] {a b c : α}
 
 @[simp] lemma Icc_self (a : α) : Icc a a = {a} :=
 set.ext $ by simp [Icc, le_antisymm_iff, and_comm]
@@ -529,10 +530,9 @@ end partial_order
 
 section order_top
 
-@[simp] lemma Ici_top {α : Type u} [partial_order α] [order_top α] : Ici (⊤ : α) = {⊤} :=
-is_max_top.Ici_eq
+@[simp] lemma Ici_top [partial_order α] [order_top α] : Ici (⊤ : α) = {⊤} := is_max_top.Ici_eq
 
-variables {α : Type u} [preorder α] [order_top α] {a : α}
+variables [preorder α] [order_top α] {a : α}
 
 @[simp] lemma Ioi_top : Ioi (⊤ : α) = ∅ := is_max_top.Ioi_eq
 @[simp] lemma Iic_top : Iic (⊤ : α) = univ := is_top_top.Iic_eq
@@ -543,10 +543,10 @@ end order_top
 
 section order_bot
 
-@[simp] lemma Iic_bot {α : Type u} [partial_order α] [order_bot α] : Iic (⊥ : α) = {⊥} :=
+@[simp] lemma Iic_bot [partial_order α] [order_bot α] : Iic (⊥ : α) = {⊥} :=
 is_min_bot.Iic_eq
 
-variables {α : Type u} [preorder α] [order_bot α] {a : α}
+variables [preorder α] [order_bot α] {a : α}
 
 @[simp] lemma Iio_bot : Iio (⊥ : α) = ∅ := is_min_bot.Iio_eq
 @[simp] lemma Ici_bot : Ici (⊥ : α) = univ := is_bot_bot.Ici_eq
@@ -555,8 +555,10 @@ variables {α : Type u} [preorder α] [order_bot α] {a : α}
 
 end order_bot
 
+lemma Icc_bot_top [partial_order α] [bounded_order α] : Icc (⊥ : α) ⊤ = univ := by simp
+
 section linear_order
-variables {α : Type u} [linear_order α] {a a₁ a₂ b b₁ b₂ c d : α}
+variables [linear_order α] {a a₁ a₂ b b₁ b₂ c d : α}
 
 lemma not_mem_Ici : c ∉ Ici a ↔ c < a := not_le
 
@@ -1132,13 +1134,10 @@ section lattice
 
 section inf
 
-variables {α : Type u} [semilattice_inf α]
+variables [semilattice_inf α]
 
 @[simp] lemma Iic_inter_Iic {a b : α} : Iic a ∩ Iic b = Iic (a ⊓ b) :=
 by { ext x, simp [Iic] }
-
-@[simp] lemma Iio_inter_Iio [is_total α (≤)] {a b : α} : Iio a ∩ Iio b = Iio (a ⊓ b) :=
-by { ext x, simp [Iio] }
 
 @[simp] lemma Ioc_inter_Iic (a b c : α) : Ioc a b ∩ Iic c = Ioc a (b ⊓ c) :=
 by rw [← Ioi_inter_Iic, ← Ioi_inter_Iic, inter_assoc, Iic_inter_Iic]
@@ -1147,7 +1146,7 @@ end inf
 
 section sup
 
-variables {α : Type u} [semilattice_sup α]
+variables [semilattice_sup α]
 
 @[simp] lemma Ici_inter_Ici {a b : α} : Ici a ∩ Ici b = Ici (a ⊔ b) :=
 by { ext x, simp [Ici] }
@@ -1155,18 +1154,11 @@ by { ext x, simp [Ici] }
 @[simp] lemma Ico_inter_Ici (a b c : α) : Ico a b ∩ Ici c = Ico (a ⊔ c) b :=
 by rw [← Ici_inter_Iio, ← Ici_inter_Iio, ← Ici_inter_Ici, inter_right_comm]
 
-@[simp] lemma Ioi_inter_Ioi [is_total α (≤)] {a b : α} : Ioi a ∩ Ioi b = Ioi (a ⊔ b) :=
-by { ext x, simp [Ioi] }
-
-@[simp] lemma Ioc_inter_Ioi [is_total α (≤)] {a b c : α} : Ioc a b ∩ Ioi c = Ioc (a ⊔ c) b :=
-by rw [← Ioi_inter_Iic, inter_assoc, inter_comm, inter_assoc, Ioi_inter_Ioi, inter_comm,
-  Ioi_inter_Iic, sup_comm]
-
 end sup
 
 section both
 
-variables {α : Type u} [lattice α] [ht : is_total α (≤)] {a b c a₁ a₂ b₁ b₂ : α}
+variables [lattice α] {a b c a₁ a₂ b₁ b₂ : α}
 
 lemma Icc_inter_Icc : Icc a₁ b₁ ∩ Icc a₂ b₂ = Icc (a₁ ⊔ a₂) (b₁ ⊓ b₂) :=
 by simp only [Ici_inter_Iic.symm, Ici_inter_Ici.symm, Iic_inter_Iic.symm]; ac_refl
@@ -1175,7 +1167,14 @@ by simp only [Ici_inter_Iic.symm, Ici_inter_Ici.symm, Iic_inter_Iic.symm]; ac_re
   Icc a b ∩ Icc b c = {b} :=
 by rw [Icc_inter_Icc, sup_of_le_right hab, inf_of_le_left hbc, Icc_self]
 
-include ht
+end both
+end lattice
+
+section linear_order
+variables [linear_order α] {a a₁ a₂ b b₁ b₂ c d : α}
+
+@[simp] lemma Ioi_inter_Ioi : Ioi a ∩ Ioi b = Ioi (a ⊔ b) := ext $ λ _, sup_lt_iff.symm
+@[simp] lemma Iio_inter_Iio : Iio a ∩ Iio b = Iio (a ⊓ b) := ext $ λ _, lt_inf_iff.symm
 
 lemma Ico_inter_Ico : Ico a₁ b₁ ∩ Ico a₂ b₂ = Ico (a₁ ⊔ a₂) (b₁ ⊓ b₂) :=
 by simp only [Ici_inter_Iio.symm, Ici_inter_Ici.symm, Iio_inter_Iio.symm]; ac_refl
@@ -1187,13 +1186,10 @@ lemma Ioo_inter_Ioo : Ioo a₁ b₁ ∩ Ioo a₂ b₂ = Ioo (a₁ ⊔ a₂) (b�
 by simp only [Ioi_inter_Iio.symm, Ioi_inter_Ioi.symm, Iio_inter_Iio.symm]; ac_refl
 
 end both
-
-lemma Icc_bot_top {α} [partial_order α] [bounded_order α] : Icc (⊥ : α) ⊤ = univ := by simp
-
 end lattice
 
 section linear_order
-variables {α : Type u} [linear_order α] {a a₁ a₂ b b₁ b₂ c d : α}
+variables [linear_order α] {a a₁ a₂ b b₁ b₂ c d : α}
 
 lemma Ioc_inter_Ioo_of_left_lt (h : b₁ < b₂) : Ioc a₁ b₁ ∩ Ioo a₂ b₂ = Ioc (max a₁ a₂) b₁ :=
 ext $ λ x, by simp [and_assoc, @and.left_comm (x ≤ _),
@@ -1214,6 +1210,10 @@ by rw [diff_eq, compl_Iio, Ico_inter_Ici, sup_eq_max]
 
 @[simp] lemma Ioc_diff_Ioi : Ioc a b \ Ioi c = Ioc a (min b c) :=
 ext $ by simp [iff_def] {contextual:=tt}
+
+@[simp] lemma Ioc_inter_Ioi : Ioc a b ∩ Ioi c = Ioc (a ⊔ c) b :=
+by rw [← Ioi_inter_Iic, inter_assoc, inter_comm, inter_assoc, Ioi_inter_Ioi, inter_comm,
+  Ioi_inter_Iic, sup_comm]
 
 @[simp] lemma Ico_inter_Iio : Ico a b ∩ Iio c = Ico a (min b c) :=
 ext $ by simp [iff_def] {contextual:=tt}
@@ -1339,7 +1339,7 @@ end ordered_add_comm_group
 
 section linear_ordered_add_comm_group
 
-variables {α : Type u} [linear_ordered_add_comm_group α]
+variables [linear_ordered_add_comm_group α]
 
 /-- If we remove a smaller interval from a larger, the result is nonempty -/
 lemma nonempty_Ico_sdiff {x dx y dy : α} (h : dy < dx) (hx : 0 < dx) :

--- a/src/data/set/intervals/basic.lean
+++ b/src/data/set/intervals/basic.lean
@@ -1130,7 +1130,7 @@ end
 
 end linear_order
 
-section lattice
+section
 
 section inf
 
@@ -1184,12 +1184,6 @@ by simp only [Ioi_inter_Iic.symm, Ioi_inter_Ioi.symm, Iic_inter_Iic.symm]; ac_re
 
 lemma Ioo_inter_Ioo : Ioo a₁ b₁ ∩ Ioo a₂ b₂ = Ioo (a₁ ⊔ a₂) (b₁ ⊓ b₂) :=
 by simp only [Ioi_inter_Iio.symm, Ioi_inter_Ioi.symm, Iio_inter_Iio.symm]; ac_refl
-
-end both
-end lattice
-
-section linear_order
-variables [linear_order α] {a a₁ a₂ b b₁ b₂ c d : α}
 
 lemma Ioc_inter_Ioo_of_left_lt (h : b₁ < b₂) : Ioc a₁ b₁ ∩ Ioo a₂ b₂ = Ioc (max a₁ a₂) b₁ :=
 ext $ λ x, by simp [and_assoc, @and.left_comm (x ≤ _),

--- a/src/order/complete_lattice.lean
+++ b/src/order/complete_lattice.lean
@@ -1177,6 +1177,9 @@ instance Prop.complete_lattice : complete_lattice Prop :=
   .. Prop.bounded_order,
   .. Prop.distrib_lattice }
 
+noncomputable instance Prop.complete_linear_order : complete_linear_order Prop :=
+{ ..Prop.complete_lattice, ..Prop.linear_order }
+
 @[simp] lemma Sup_Prop_eq {s : set Prop} : Sup s = ∃ p ∈ s, p := rfl
 @[simp] lemma Inf_Prop_eq {s : set Prop} : Inf s = ∀ p ∈ s, p := rfl
 

--- a/src/order/lattice.lean
+++ b/src/order/lattice.lean
@@ -791,14 +791,6 @@ lemma map_sup [semilattice_sup β] {f : α → β} (hf : monotone f) (x y : α) 
 lemma map_inf [semilattice_inf β] {f : α → β} (hf : monotone f) (x y : α) : f (x ⊓ y) = f x ⊓ f y :=
 hf.dual.map_sup _ _
 
-variables [linear_order β] {f : α → β}
-
-lemma map_max (hf : monotone f) (x y : α) : f (max x y) = max (f x) (f y) :=
-by simp_rw [←sup_eq_max, hf.map_sup]
-
-lemma map_min (hf : monotone f) (x y : α) : f (min x y) = min (f x) (f y) :=
-by simp_rw [←inf_eq_min, hf.map_inf]
-
 end monotone
 
 namespace antitone
@@ -840,14 +832,6 @@ hf.dual_right.map_sup x y
 
 lemma map_inf [semilattice_sup β] {f : α → β} (hf : antitone f) (x y : α) : f (x ⊓ y) = f x ⊔ f y :=
 hf.dual_right.map_inf x y
-
-variables [linear_order β] {f : α → β}
-
-lemma map_max (hf : antitone f) (x y : α) : f (max x y) = min (f x) (f y) :=
-hf.dual_right.map_max  _ _
-
-lemma map_min (hf : antitone f) (x y : α) : f (min x y) = max (f x) (f y) :=
-hf.dual_right.map_min _ _
 
 end antitone
 

--- a/src/order/lattice.lean
+++ b/src/order/lattice.lean
@@ -186,24 +186,6 @@ sup_le_sup h₁ le_rfl
 theorem le_of_sup_eq (h : a ⊔ b = b) : a ≤ b :=
 by { rw ← h, simp }
 
-lemma sup_ind [is_total α (≤)] (a b : α) {p : α → Prop} (ha : p a) (hb : p b) : p (a ⊔ b) :=
-(is_total.total a b).elim (λ h : a ≤ b, by rwa sup_eq_right.2 h) (λ h, by rwa sup_eq_left.2 h)
-
-@[simp] lemma sup_lt_iff [is_total α (≤)] {a b c : α} : b ⊔ c < a ↔ b < a ∧ c < a :=
-⟨λ h, ⟨le_sup_left.trans_lt h, le_sup_right.trans_lt h⟩, λ h, sup_ind b c h.1 h.2⟩
-
-@[simp] lemma le_sup_iff [is_total α (≤)] {a b c : α} : a ≤ b ⊔ c ↔ a ≤ b ∨ a ≤ c :=
-⟨λ h, (total_of (≤) c b).imp
-  (λ bc, by rwa sup_eq_left.2 bc at h)
-  (λ bc, by rwa sup_eq_right.2 bc at h),
- λ h, h.elim le_sup_of_le_left le_sup_of_le_right⟩
-
-@[simp] lemma lt_sup_iff [is_total α (≤)] {a b c : α} : a < b ⊔ c ↔ a < b ∨ a < c :=
-⟨λ h, (total_of (≤) c b).imp
-  (λ bc, by rwa sup_eq_left.2 bc at h)
-  (λ bc, by rwa sup_eq_right.2 bc at h),
- λ h, h.elim lt_sup_of_lt_left lt_sup_of_lt_right⟩
-
 @[simp] theorem sup_idem : a ⊔ a = a :=
 by apply le_antisymm; simp
 
@@ -380,15 +362,6 @@ inf_le_inf le_rfl h
 
 theorem le_of_inf_eq (h : a ⊓ b = a) : a ≤ b :=
 by { rw ← h, simp }
-
-lemma inf_ind [is_total α (≤)] (a b : α) {p : α → Prop} (ha : p a) (hb : p b) : p (a ⊓ b) :=
-@sup_ind (order_dual α) _ _ _ _ _ ha hb
-
-@[simp] lemma lt_inf_iff [is_total α (≤)] {a b c : α} : a < b ⊓ c ↔ a < b ∧ a < c :=
-@sup_lt_iff (order_dual α) _ _ _ _ _
-
-@[simp] lemma inf_le_iff [is_total α (≤)] {a b c : α} : b ⊓ c ≤ a ↔ b ≤ a ∨ c ≤ a :=
-@le_sup_iff (order_dual α) _ _ _ _ _
 
 @[simp] theorem inf_idem : a ⊓ a = a :=
 @sup_idem (order_dual α) _ _
@@ -666,8 +639,38 @@ instance linear_order.to_lattice {α : Type u} [o : linear_order α] :
   le_inf       := assume a b c, le_min,
   ..o }
 
-theorem sup_eq_max [linear_order α] {x y : α} : x ⊔ y = max x y := rfl
-theorem inf_eq_min [linear_order α] {x y : α} : x ⊓ y = min x y := rfl
+section linear_order
+variables [linear_order α] {a b c : α}
+
+lemma sup_eq_max : a ⊔ b = max a b := rfl
+lemma inf_eq_min : a ⊓ b = min a b := rfl
+
+lemma sup_ind (a b : α) {p : α → Prop} (ha : p a) (hb : p b) : p (a ⊔ b) :=
+(is_total.total a b).elim (λ h : a ≤ b, by rwa sup_eq_right.2 h) (λ h, by rwa sup_eq_left.2 h)
+
+@[simp] lemma le_sup_iff : a ≤ b ⊔ c ↔ a ≤ b ∨ a ≤ c :=
+⟨λ h, (total_of (≤) c b).imp
+  (λ bc, by rwa sup_eq_left.2 bc at h)
+  (λ bc, by rwa sup_eq_right.2 bc at h),
+ λ h, h.elim le_sup_of_le_left le_sup_of_le_right⟩
+
+@[simp] lemma lt_sup_iff : a < b ⊔ c ↔ a < b ∨ a < c :=
+⟨λ h, (total_of (≤) c b).imp
+  (λ bc, by rwa sup_eq_left.2 bc at h)
+  (λ bc, by rwa sup_eq_right.2 bc at h),
+ λ h, h.elim lt_sup_of_lt_left lt_sup_of_lt_right⟩
+
+@[simp] lemma sup_lt_iff : b ⊔ c < a ↔ b < a ∧ c < a :=
+⟨λ h, ⟨le_sup_left.trans_lt h, le_sup_right.trans_lt h⟩, λ h, sup_ind b c h.1 h.2⟩
+
+lemma inf_ind (a b : α) {p : α → Prop} (ha : p a) (hb : p b) : p (a ⊓ b) :=
+@sup_ind (order_dual α) _ _ _ _ ha hb
+
+@[simp] lemma inf_le_iff : b ⊓ c ≤ a ↔ b ≤ a ∨ c ≤ a := @le_sup_iff (order_dual α) _ _ _ _
+@[simp] lemma inf_lt_iff : b ⊓ c < a ↔ b < a ∨ c < a := @lt_sup_iff (order_dual α) _ _ _ _
+@[simp] lemma lt_inf_iff : a < b ⊓ c ↔ a < b ∧ a < c := @sup_lt_iff (order_dual α) _ _ _ _
+
+end linear_order
 
 lemma sup_eq_max_default [semilattice_sup α] [decidable_rel ((≤) : α → α → Prop)]
   [is_total α (≤)] : (⊔) = (max_default : α → α → α) :=
@@ -773,22 +776,28 @@ lemma le_map_sup [semilattice_sup α] [semilattice_sup β]
   f x ⊔ f y ≤ f (x ⊔ y) :=
 sup_le (h le_sup_left) (h le_sup_right)
 
-lemma map_sup [semilattice_sup α] [is_total α (≤)] [semilattice_sup β] {f : α → β}
-  (hf : monotone f) (x y : α) :
-  f (x ⊔ y) = f x ⊔ f y :=
-(is_total.total x y).elim
-  (λ h : x ≤ y, by simp only [h, hf h, sup_of_le_right])
-  (λ h, by simp only [h, hf h, sup_of_le_left])
-
 lemma map_inf_le [semilattice_inf α] [semilattice_inf β]
   {f : α → β} (h : monotone f) (x y : α) :
   f (x ⊓ y) ≤ f x ⊓ f y :=
 le_inf (h inf_le_left) (h inf_le_right)
 
-lemma map_inf [semilattice_inf α] [is_total α (≤)] [semilattice_inf β] {f : α → β}
-  (hf : monotone f) (x y : α) :
-  f (x ⊓ y) = f x ⊓ f y :=
-@monotone.map_sup (order_dual α) _ _ _ _ _ hf.dual x y
+variables [linear_order α]
+
+lemma map_sup [semilattice_sup β] {f : α → β} (hf : monotone f) (x y : α) : f (x ⊔ y) = f x ⊔ f y :=
+(is_total.total x y).elim
+  (λ h : x ≤ y, by simp only [h, hf h, sup_of_le_right])
+  (λ h, by simp only [h, hf h, sup_of_le_left])
+
+lemma map_inf [semilattice_inf β] {f : α → β} (hf : monotone f) (x y : α) : f (x ⊓ y) = f x ⊓ f y :=
+hf.dual.map_sup _ _
+
+variables [linear_order β] {f : α → β}
+
+lemma map_max (hf : monotone f) (x y : α) : f (max x y) = max (f x) (f y) :=
+by simp_rw [←sup_eq_max, hf.map_sup]
+
+lemma map_min (hf : monotone f) (x y : α) : f (min x y) = min (f x) (f y) :=
+by simp_rw [←inf_eq_min, hf.map_inf]
 
 end monotone
 
@@ -819,20 +828,26 @@ lemma map_sup_le [semilattice_sup α] [semilattice_inf β]
   f (x ⊔ y) ≤ f x ⊓ f y :=
 h.dual_right.le_map_sup x y
 
-lemma map_sup [semilattice_sup α] [is_total α (≤)] [semilattice_inf β] {f : α → β}
-  (hf : antitone f) (x y : α) :
-  f (x ⊔ y) = f x ⊓ f y :=
-hf.dual_right.map_sup x y
-
 lemma le_map_inf [semilattice_inf α] [semilattice_sup β]
   {f : α → β} (h : antitone f) (x y : α) :
   f x ⊔ f y ≤ f (x ⊓ y) :=
 h.dual_right.map_inf_le x y
 
-lemma map_inf [semilattice_inf α] [is_total α (≤)] [semilattice_sup β] {f : α → β}
-  (hf : antitone f) (x y : α) :
-  f (x ⊓ y) = f x ⊔ f y :=
+variables [linear_order α]
+
+lemma map_sup [semilattice_inf β] {f : α → β} (hf : antitone f) (x y : α) : f (x ⊔ y) = f x ⊓ f y :=
+hf.dual_right.map_sup x y
+
+lemma map_inf [semilattice_sup β] {f : α → β} (hf : antitone f) (x y : α) : f (x ⊓ y) = f x ⊔ f y :=
 hf.dual_right.map_inf x y
+
+variables [linear_order β] {f : α → β}
+
+lemma map_max (hf : antitone f) (x y : α) : f (max x y) = min (f x) (f y) :=
+hf.dual_right.map_max  _ _
+
+lemma map_min (hf : antitone f) (x y : α) : f (min x y) = max (f x) (f y) :=
+hf.dual_right.map_min _ _
 
 end antitone
 

--- a/src/order/min_max.lean
+++ b/src/order/min_max.lean
@@ -25,7 +25,13 @@ variables [linear_order α] [linear_order β] {f : α → β} {s : set α} {a b 
 
 -- translate from lattices to linear orders (sup → max, inf → min)
 @[simp] lemma le_min_iff : c ≤ min a b ↔ c ≤ a ∧ c ≤ b := le_inf_iff
+@[simp] lemma le_max_iff : a ≤ max b c ↔ a ≤ b ∨ a ≤ c := le_sup_iff
+@[simp] lemma min_le_iff : min a b ≤ c ↔ a ≤ c ∨ b ≤ c := inf_le_iff
 @[simp] lemma max_le_iff : max a b ≤ c ↔ a ≤ c ∧ b ≤ c := sup_le_iff
+@[simp] lemma lt_min_iff : a < min b c ↔ a < b ∧ a < c := lt_inf_iff
+@[simp] lemma lt_max_iff : a < max b c ↔ a < b ∨ a < c := lt_sup_iff
+@[simp] lemma min_lt_iff : min a b < c ↔ a < c ∨ b < c := inf_lt_iff
+@[simp] lemma max_lt_iff : max a b < c ↔ a < c ∧ b < c := sup_lt_iff
 lemma max_le_max : a ≤ c → b ≤ d → max a b ≤ max c d := sup_le_sup
 lemma min_le_min : a ≤ c → b ≤ d → min a b ≤ min c d := inf_le_inf
 lemma le_max_of_le_left : a ≤ b → a ≤ max b c := le_sup_of_le_left
@@ -78,29 +84,23 @@ end
 lemma max_eq_iff : max a b = c ↔ a = c ∧ b ≤ a ∨ b = c ∧ a ≤ b :=
 @min_eq_iff (order_dual α) _ a b c
 
+lemma min_lt_min_left_iff : min a c < min b c ↔ a < b ∧ a < c :=
+by { simp_rw [lt_min_iff, min_lt_iff, or_iff_left (lt_irrefl _)],
+  exact and_congr_left (λ h, or_iff_left_of_imp h.trans) }
+
+lemma min_lt_min_right_iff : min a b < min a c ↔ b < c ∧ b < a :=
+by simp_rw [min_comm a, min_lt_min_left_iff]
+
+lemma max_lt_max_left_iff : max a c < max b c ↔ a < b ∧ c < b :=
+@min_lt_min_left_iff (order_dual α) _ _ _ _
+lemma max_lt_max_right_iff : max a b < max a c ↔ b < c ∧ a < c :=
+@min_lt_min_right_iff (order_dual α) _ _ _ _
+
 /-- An instance asserting that `max a a = a` -/
 instance max_idem : is_idempotent α max := by apply_instance -- short-circuit type class inference
 
 /-- An instance asserting that `min a a = a` -/
 instance min_idem : is_idempotent α min := by apply_instance -- short-circuit type class inference
-
-@[simp] lemma max_lt_iff : max a b < c ↔ (a < c ∧ b < c) :=
-sup_lt_iff
-
-@[simp] lemma lt_min_iff : a < min b c ↔ (a < b ∧ a < c) :=
-lt_inf_iff
-
-@[simp] lemma lt_max_iff : a < max b c ↔ a < b ∨ a < c :=
-lt_sup_iff
-
-@[simp] lemma min_lt_iff : min a b < c ↔ a < c ∨ b < c :=
-@lt_max_iff (order_dual α) _ _ _ _
-
-@[simp] lemma min_le_iff : min a b ≤ c ↔ a ≤ c ∨ b ≤ c :=
-inf_le_iff
-
-@[simp] lemma le_max_iff : a ≤ max b c ↔ a ≤ b ∨ a ≤ c :=
-@min_le_iff (order_dual α) _ _ _ _
 
 lemma min_lt_max : min a b < max a b ↔ a ≠ b := inf_lt_sup
 

--- a/src/order/omega_complete_partial_order.lean
+++ b/src/order/omega_complete_partial_order.lean
@@ -388,6 +388,8 @@ instance : omega_complete_partial_order (α × β) :=
 
 end prod
 
+open omega_complete_partial_order
+
 namespace complete_lattice
 variables (α : Type u)
 
@@ -402,26 +404,6 @@ instance [complete_lattice α] : omega_complete_partial_order α :=
   le_ωSup := assume ⟨c, _⟩ i, by simp only [order_hom.coe_fun_mk]; apply le_supr_of_le i; refl }
 
 variables {α} {β : Type v} [omega_complete_partial_order α] [complete_lattice β]
-open omega_complete_partial_order
-
-lemma inf_continuous [is_total β (≤)] (f g : α →o β) (hf : continuous f) (hg : continuous g) :
-  continuous (f ⊓ g) :=
-begin
-  intro c,
-  apply eq_of_forall_ge_iff, intro z,
-  simp only [inf_le_iff, hf c, hg c, ωSup_le_iff, ←forall_or_distrib_left, ←forall_or_distrib_right,
-             function.comp_app, chain.map_coe, order_hom.has_inf_inf_coe],
-  split,
-  { introv h, apply h },
-  { intros h i j,
-    apply or.imp _ _ (h (max i j)); apply le_trans; mono*; try { exact le_rfl },
-    { apply le_max_left },
-    { apply le_max_right }, },
-end
-
-lemma inf_continuous' [is_total β (≤)] {f g : α → β} (hf : continuous' f) (hg : continuous' g) :
-  continuous' (f ⊓ g) :=
-⟨_, inf_continuous _ _ hf.snd hg.snd⟩
 
 lemma Sup_continuous (s : set $ α →o β) (hs : ∀ f ∈ s, continuous f) :
   continuous (Sup s) :=
@@ -467,6 +449,24 @@ begin
   rw ← Sup_empty,
   exact Sup_continuous _ (λ f hf, hf.elim),
 end
+
+end complete_lattice
+
+namespace complete_lattice
+variables {α β : Type*} [omega_complete_partial_order α] [complete_linear_order β]
+
+lemma inf_continuous (f g : α →o β) (hf : continuous f) (hg : continuous g) : continuous (f ⊓ g) :=
+begin
+  refine λ c, eq_of_forall_ge_iff (λ z, _),
+  simp only [inf_le_iff, hf c, hg c, ωSup_le_iff, ←forall_or_distrib_left, ←forall_or_distrib_right,
+             function.comp_app, chain.map_coe, order_hom.has_inf_inf_coe],
+  exact ⟨λ h _, h _ _, λ h i j, (h (max i j)).imp (le_trans $ f.mono $ c.mono $ le_max_left _ _)
+    (le_trans $ g.mono $ c.mono $ le_max_right _ _)⟩,
+end
+
+lemma inf_continuous' {f g : α → β} (hf : continuous' f) (hg : continuous' g) :
+  continuous' (f ⊓ g) :=
+⟨_, inf_continuous _ _ hf.snd hg.snd⟩
 
 end complete_lattice
 

--- a/src/topology/algebra/order/basic.lean
+++ b/src/topology/algebra/order/basic.lean
@@ -902,7 +902,7 @@ lemma nhds_top_basis [topological_space α] [linear_order α] [order_top α] [or
 lemma nhds_bot_basis [topological_space α] [linear_order α] [order_bot α] [order_topology α]
   [nontrivial α] :
   (𝓝 ⊥).has_basis (λ a : α, ⊥ < a) (λ a : α, Iio a) :=
-@nhds_top_basis (order_dual α) _ _ _ _ _ _
+@nhds_top_basis (order_dual α) _ _ _ _ _
 
 lemma nhds_top_basis_Ici [topological_space α] [linear_order α] [order_top α] [order_topology α]
   [nontrivial α] [densely_ordered α] :
@@ -914,7 +914,7 @@ nhds_top_basis.to_has_basis
 lemma nhds_bot_basis_Iic [topological_space α] [linear_order α] [order_bot α] [order_topology α]
   [nontrivial α] [densely_ordered α] :
   (𝓝 ⊥).has_basis (λ a : α, ⊥ < a) Iic :=
-@nhds_top_basis_Ici (order_dual α) _ _ _ _ _ _ _
+@nhds_top_basis_Ici (order_dual α) _ _ _ _ _ _
 
 lemma tendsto_nhds_top_mono [topological_space β] [partial_order β] [order_top β] [order_topology β]
   {l : filter α} {f g : α → β} (hf : tendsto f l (𝓝 ⊤)) (hg : f ≤ᶠ[l] g) :

--- a/src/topology/algebra/order/basic.lean
+++ b/src/topology/algebra/order/basic.lean
@@ -885,8 +885,8 @@ lemma nhds_bot_order [topological_space α] [partial_order α] [order_bot α] [o
   𝓝 (⊥:α) = (⨅l (h₂ : ⊥ < l), 𝓟 (Iio l)) :=
 by simp [nhds_eq_order (⊥:α)]
 
-lemma nhds_top_basis [topological_space α] [semilattice_sup α] [order_top α] [is_total α has_le.le]
-  [order_topology α] [nontrivial α] :
+lemma nhds_top_basis [topological_space α] [linear_order α] [order_top α] [order_topology α]
+  [nontrivial α] :
   (𝓝 ⊤).has_basis (λ a : α, a < ⊤) (λ a : α, Ioi a) :=
 ⟨ begin
     simp only [nhds_top_order],
@@ -899,20 +899,20 @@ lemma nhds_top_basis [topological_space α] [semilattice_sup α] [order_top α] 
       exact ⟨a, lt_top_iff_ne_top.mpr ha⟩ }
   end ⟩
 
-lemma nhds_bot_basis [topological_space α] [semilattice_inf α] [order_bot α] [is_total α has_le.le]
-  [order_topology α] [nontrivial α] :
+lemma nhds_bot_basis [topological_space α] [linear_order α] [order_bot α] [order_topology α]
+  [nontrivial α] :
   (𝓝 ⊥).has_basis (λ a : α, ⊥ < a) (λ a : α, Iio a) :=
 @nhds_top_basis (order_dual α) _ _ _ _ _ _
 
-lemma nhds_top_basis_Ici [topological_space α] [semilattice_sup α] [order_top α]
-  [is_total α has_le.le] [order_topology α] [nontrivial α] [densely_ordered α] :
+lemma nhds_top_basis_Ici [topological_space α] [linear_order α] [order_top α] [order_topology α]
+  [nontrivial α] [densely_ordered α] :
   (𝓝 ⊤).has_basis (λ a : α, a < ⊤) Ici :=
 nhds_top_basis.to_has_basis
   (λ a ha, let ⟨b, hab, hb⟩ := exists_between ha in ⟨b, hb, Ici_subset_Ioi.mpr hab⟩)
   (λ a ha, ⟨a, ha, Ioi_subset_Ici_self⟩)
 
-lemma nhds_bot_basis_Iic [topological_space α] [semilattice_inf α] [order_bot α]
-  [is_total α has_le.le] [order_topology α] [nontrivial α] [densely_ordered α] :
+lemma nhds_bot_basis_Iic [topological_space α] [linear_order α] [order_bot α] [order_topology α]
+  [nontrivial α] [densely_ordered α] :
   (𝓝 ⊥).has_basis (λ a : α, ⊥ < a) Iic :=
 @nhds_top_basis_Ici (order_dual α) _ _ _ _ _ _ _
 


### PR DESCRIPTION
`partial_order α` + `is_total α (≤)` has no more theorems than `linear_order α`  but is nonetheless used in some places. This replaces those uses by `linear_order α` or `complete_linear_order α`. Also make implicit one argument of `finset.lt_inf'_iff` and friends.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
