### PR TITLE
[Merged by Bors] - docs(*): Wrap some links in < … >

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -126,5 +126,5 @@ enforcement ladder](https://github.com/mozilla/diversity).
 [homepage]: https://www.contributor-covenant.org
 
 For answers to common questions about this code of conduct, see the FAQ at
-https://www.contributor-covenant.org/faq. Translations are available at
-https://www.contributor-covenant.org/translations.
+<https://www.contributor-covenant.org/faq>. Translations are available at
+<https://www.contributor-covenant.org/translations>.

--- a/src/algebraic_geometry/ringed_space.lean
+++ b/src/algebraic_geometry/ringed_space.lean
@@ -15,7 +15,7 @@ import algebra.category.CommRing.limits
 We introduce the category of ringed spaces, as an alias for `SheafedSpace CommRing`.
 
 The facts collected in this file are typically stated for locally ringed spaces, but never actually
-make use of the locality of stalks. See for instance https://stacks.math.columbia.edu/tag/01HZ.
+make use of the locality of stalks. See for instance <https://stacks.math.columbia.edu/tag/01HZ>.
 
 -/
 

--- a/src/category_theory/abelian/basic.lean
+++ b/src/category_theory/abelian/basic.lean
@@ -244,7 +244,7 @@ in which the coimage-image comparison morphism is always an isomorphism,
 is an abelian category.
 
 The Stacks project uses this characterisation at the definition of an abelian category.
-See https://stacks.math.columbia.edu/tag/0109.
+See <https://stacks.math.columbia.edu/tag/0109>.
 -/
 def of_coimage_image_comparison_is_iso : abelian C := {}
 

--- a/src/category_theory/abelian/images.lean
+++ b/src/category_theory/abelian/images.lean
@@ -85,7 +85,7 @@ In any abelian category this is an isomorphism.
 Conversely, any additive category with kernels and cokernels and
 in which this is always an isomorphism, is abelian.
 
-See https://stacks.math.columbia.edu/tag/0107
+See <https://stacks.math.columbia.edu/tag/0107>
 -/
 def coimage_image_comparison : abelian.coimage f ⟶ abelian.image f :=
 cokernel.desc (kernel.ι f) (kernel.lift (cokernel.π f) f (by simp)) $ (by { ext, simp, })

--- a/src/category_theory/abelian/transfer.lean
+++ b/src/category_theory/abelian/transfer.lean
@@ -17,7 +17,7 @@ we have `F : C ⥤ D` `G : D ⥤ C` (both preserving zero morphisms),
 and further we have `adj : G ⊣ F` and `i : F ⋙ G ≅ 𝟭 C`,
 then `C` is also abelian.
 
-See https://stacks.math.columbia.edu/tag/03A3
+See <https://stacks.math.columbia.edu/tag/03A3>
 
 ## Notes
 The hypotheses, following the statement from the Stacks project,
@@ -153,7 +153,7 @@ we have `F : C ⥤ D` `G : D ⥤ C` (both preserving zero morphisms),
 and further we have `adj : G ⊣ F` and `i : F ⋙ G ≅ 𝟭 C`,
 then `C` is also abelian.
 
-See https://stacks.math.columbia.edu/tag/03A3
+See <https://stacks.math.columbia.edu/tag/03A3>
 -/
 def abelian_of_adjunction
   {C : Type u₁} [category.{v} C] [preadditive C] [has_finite_products C]

--- a/src/category_theory/additive/basic.lean
+++ b/src/category_theory/additive/basic.lean
@@ -30,7 +30,7 @@ variables (C : Type u) [category C]
 
 /--
 A preadditive category `C` is called additive if it has all finite biproducts.
-See https://stacks.math.columbia.edu/tag/0104.
+See <https://stacks.math.columbia.edu/tag/0104>.
 -/
 class additive_category extends preadditive C, has_finite_biproducts C
 

--- a/src/category_theory/adjunction/basic.lean
+++ b/src/category_theory/adjunction/basic.lean
@@ -52,7 +52,7 @@ well as their duals) which can be simpler in practice.
 
 Uniqueness of adjoints is shown in `category_theory.adjunction.opposites`.
 
-See https://stacks.math.columbia.edu/tag/0037.
+See <https://stacks.math.columbia.edu/tag/0037>.
 -/
 structure adjunction (F : C ⥤ D) (G : D ⥤ C) :=
 (hom_equiv : Π (X Y), (F.obj X ⟶ Y) ≃ (X ⟶ G.obj Y))
@@ -331,7 +331,7 @@ variables {E : Type u₃} [ℰ : category.{v₃} E] (H : D ⥤ E) (I : E ⥤ D)
 /--
 Composition of adjunctions.
 
-See https://stacks.math.columbia.edu/tag/0DV0.
+See <https://stacks.math.columbia.edu/tag/0DV0>.
 -/
 def comp (adj₁ : F ⊣ G) (adj₂ : H ⊣ I) : F ⋙ H ⊣ I ⋙ G :=
 { hom_equiv := λ X Z, equiv.trans (adj₂.hom_equiv _ _) (adj₁.hom_equiv _ _),

--- a/src/category_theory/adjunction/fully_faithful.lean
+++ b/src/category_theory/adjunction/fully_faithful.lean
@@ -59,7 +59,7 @@ instance unit_is_iso_of_L_fully_faithful [full L] [faithful L] : is_iso (adjunct
 /--
 If the right adjoint is fully faithful, then the counit is an isomorphism.
 
-See https://stacks.math.columbia.edu/tag/07RB (we only prove the forward direction!)
+See <https://stacks.math.columbia.edu/tag/07RB> (we only prove the forward direction!)
 -/
 instance counit_is_iso_of_R_fully_faithful [full R] [faithful R] : is_iso (adjunction.counit h) :=
 @nat_iso.is_iso_of_is_iso_app _ _ _ _ _ _ (adjunction.counit h) $ λ X,

--- a/src/category_theory/adjunction/limits.lean
+++ b/src/category_theory/adjunction/limits.lean
@@ -84,7 +84,7 @@ def functoriality_is_left_adjoint :
 /--
 A left adjoint preserves colimits.
 
-See https://stacks.math.columbia.edu/tag/0038.
+See <https://stacks.math.columbia.edu/tag/0038>.
 -/
 def left_adjoint_preserves_colimits : preserves_colimits_of_size.{v u} F :=
 { preserves_colimits_of_shape := λ J 𝒥,
@@ -194,7 +194,7 @@ def functoriality_is_right_adjoint :
 /--
 A right adjoint preserves limits.
 
-See https://stacks.math.columbia.edu/tag/0038.
+See <https://stacks.math.columbia.edu/tag/0038>.
 -/
 def right_adjoint_preserves_limits : preserves_limits_of_size.{v u} G :=
 { preserves_limits_of_shape := λ J 𝒥,

--- a/src/category_theory/category/basic.lean
+++ b/src/category_theory/category/basic.lean
@@ -87,7 +87,7 @@ The typeclass `category C` describes morphisms associated to objects of type `C`
 The universe levels of the objects and morphisms are unconstrained, and will often need to be
 specified explicitly, as `category.{v} C`. (See also `large_category` and `small_category`.)
 
-See https://stacks.math.columbia.edu/tag/0014.
+See <https://stacks.math.columbia.edu/tag/0014>.
 -/
 class category (obj : Type u)
 extends category_struct.{v} obj : Type (max u (v+1)) :=
@@ -163,7 +163,7 @@ by { split_ifs; refl }
 A morphism `f` is an epimorphism if it can be "cancelled" when precomposed:
 `f ≫ g = f ≫ h` implies `g = h`.
 
-See https://stacks.math.columbia.edu/tag/003B.
+See <https://stacks.math.columbia.edu/tag/003B>.
 -/
 class epi (f : X ⟶ Y) : Prop :=
 (left_cancellation : Π {Z : C} (g h : Y ⟶ Z) (w : f ≫ g = f ≫ h), g = h)
@@ -172,7 +172,7 @@ class epi (f : X ⟶ Y) : Prop :=
 A morphism `f` is a monomorphism if it can be "cancelled" when postcomposed:
 `g ≫ f = h ≫ f` implies `g = h`.
 
-See https://stacks.math.columbia.edu/tag/003B.
+See <https://stacks.math.columbia.edu/tag/003B>.
 -/
 class mono (f : X ⟶ Y) : Prop :=
 (right_cancellation : Π {Z : C} (g h : Z ⟶ X) (w : g ≫ f = h ≫ f), g = h)

--- a/src/category_theory/category/preorder.lean
+++ b/src/category_theory/category/preorder.lean
@@ -39,7 +39,7 @@ Because we don't allow morphisms to live in `Prop`,
 we have to define `X ⟶ Y` as `ulift (plift (X ≤ Y))`.
 See `category_theory.hom_of_le` and `category_theory.le_of_hom`.
 
-See https://stacks.math.columbia.edu/tag/00D3.
+See <https://stacks.math.columbia.edu/tag/00D3>.
 -/
 @[priority 100] -- see Note [lower instance priority]
 instance small_category (α : Type u) [preorder α] : small_category α :=

--- a/src/category_theory/discrete_category.lean
+++ b/src/category_theory/discrete_category.lean
@@ -47,7 +47,7 @@ The "discrete" category on a type, whose morphisms are equalities.
 Because we do not allow morphisms in `Prop` (only in `Type`),
 somewhat annoyingly we have to define `X ⟶ Y` as `ulift (plift (X = Y))`.
 
-See https://stacks.math.columbia.edu/tag/001A
+See <https://stacks.math.columbia.edu/tag/001A>
 -/
 instance discrete_category (α : Type u₁) : small_category (discrete α) :=
 { hom  := λ X Y, ulift (plift (X = Y)),

--- a/src/category_theory/equivalence.lean
+++ b/src/category_theory/equivalence.lean
@@ -71,7 +71,7 @@ universes v₁ v₂ v₃ u₁ u₂ u₃
   complicated if we write it as an equality of natural transformations, because then we would have
   to insert natural transformations like `F ⟶ F1`.
 
-See https://stacks.math.columbia.edu/tag/001J
+See <https://stacks.math.columbia.edu/tag/001J>
 -/
 structure equivalence (C : Type u₁) [category.{v₁} C] (D : Type u₂) [category.{v₂} D] :=
 mk' ::
@@ -557,7 +557,7 @@ namespace equivalence
 /--
 An equivalence is essentially surjective.
 
-See https://stacks.math.columbia.edu/tag/02C3.
+See <https://stacks.math.columbia.edu/tag/02C3>.
 -/
 lemma ess_surj_of_equivalence (F : C ⥤ D) [is_equivalence F] : ess_surj F :=
 ⟨λ Y, ⟨F.inv.obj Y, ⟨F.as_equivalence.counit_iso.app Y⟩⟩⟩
@@ -565,7 +565,7 @@ lemma ess_surj_of_equivalence (F : C ⥤ D) [is_equivalence F] : ess_surj F :=
 /--
 An equivalence is faithful.
 
-See https://stacks.math.columbia.edu/tag/02C3.
+See <https://stacks.math.columbia.edu/tag/02C3>.
 -/
 @[priority 100] -- see Note [lower instance priority]
 instance faithful_of_equivalence (F : C ⥤ D) [is_equivalence F] : faithful F :=
@@ -578,7 +578,7 @@ instance faithful_of_equivalence (F : C ⥤ D) [is_equivalence F] : faithful F :
 /--
 An equivalence is full.
 
-See https://stacks.math.columbia.edu/tag/02C3.
+See <https://stacks.math.columbia.edu/tag/02C3>.
 -/
 @[priority 100] -- see Note [lower instance priority]
 instance full_of_equivalence (F : C ⥤ D) [is_equivalence F] : full F :=
@@ -597,7 +597,7 @@ instance full_of_equivalence (F : C ⥤ D) [is_equivalence F] : full F :=
 /--
 A functor which is full, faithful, and essentially surjective is an equivalence.
 
-See https://stacks.math.columbia.edu/tag/02C3.
+See <https://stacks.math.columbia.edu/tag/02C3>.
 -/
 noncomputable def of_fully_faithfully_ess_surj
   (F : C ⥤ D) [full F] [faithful F] [ess_surj F] : is_equivalence F :=

--- a/src/category_theory/essential_image.lean
+++ b/src/category_theory/essential_image.lean
@@ -97,7 +97,7 @@ end functor
 A functor `F : C ⥤ D` is essentially surjective if every object of `D` is in the essential image
 of `F`. In other words, for every `Y : D`, there is some `X : C` with `F.obj X ≅ Y`.
 
-See https://stacks.math.columbia.edu/tag/001C.
+See <https://stacks.math.columbia.edu/tag/001C>.
 -/
 class ess_surj (F : C ⥤ D) : Prop :=
 (mem_ess_image [] (Y : D) : Y ∈ F.ess_image)

--- a/src/category_theory/filtered.lean
+++ b/src/category_theory/filtered.lean
@@ -74,7 +74,7 @@ A category `is_filtered` if
    are equal, and
 3. there exists some object.
 
-See https://stacks.math.columbia.edu/tag/002V. (They also define a diagram being filtered.)
+See <https://stacks.math.columbia.edu/tag/002V>. (They also define a diagram being filtered.)
 -/
 class is_filtered extends is_filtered_or_empty C : Prop :=
 [nonempty : nonempty C]
@@ -464,7 +464,7 @@ A category `is_cofiltered` if
    are equal, and
 3. there exists some object.
 
-See https://stacks.math.columbia.edu/tag/04AZ.
+See <https://stacks.math.columbia.edu/tag/04AZ>.
 -/
 class is_cofiltered extends is_cofiltered_or_empty C : Prop :=
 [nonempty : nonempty C]

--- a/src/category_theory/full_subcategory.lean
+++ b/src/category_theory/full_subcategory.lean
@@ -83,7 +83,7 @@ variables (Z : C → Prop)
 /--
 The category structure on a subtype; morphisms just ignore the property.
 
-See https://stacks.math.columbia.edu/tag/001D. We do not define 'strictly full' subcategories.
+See <https://stacks.math.columbia.edu/tag/001D>. We do not define 'strictly full' subcategories.
 -/
 instance full_subcategory : category.{v} {X : C // Z X} :=
 induced_category.category subtype.val

--- a/src/category_theory/functor/basic.lean
+++ b/src/category_theory/functor/basic.lean
@@ -33,7 +33,7 @@ To apply a functor `F` to an object use `F.obj X`, and to a morphism use `F.map 
 The axiom `map_id` expresses preservation of identities, and
 `map_comp` expresses functoriality.
 
-See https://stacks.math.columbia.edu/tag/001B.
+See <https://stacks.math.columbia.edu/tag/001B>.
 -/
 structure functor (C : Type u₁) [category.{v₁} C] (D : Type u₂) [category.{v₂} D]
   extends prefunctor C D : Type (max v₁ v₂ u₁ u₂) :=

--- a/src/category_theory/functor/fully_faithful.lean
+++ b/src/category_theory/functor/fully_faithful.lean
@@ -33,7 +33,7 @@ A functor `F : C ⥤ D` is full if for each `X Y : C`, `F.map` is surjective.
 In fact, we use a constructive definition, so the `full F` typeclass contains data,
 specifying a particular preimage of each `f : F.obj X ⟶ F.obj Y`.
 
-See https://stacks.math.columbia.edu/tag/001C.
+See <https://stacks.math.columbia.edu/tag/001C>.
 -/
 class full (F : C ⥤ D) :=
 (preimage : ∀ {X Y : C} (f : (F.obj X) ⟶ (F.obj Y)), X ⟶ Y)
@@ -45,7 +45,7 @@ attribute [simp] full.witness
 /--
 A functor `F : C ⥤ D` is faithful if for each `X Y : C`, `F.map` is injective.
 
-See https://stacks.math.columbia.edu/tag/001C.
+See <https://stacks.math.columbia.edu/tag/001C>.
 -/
 class faithful (F : C ⥤ D) : Prop :=
 (map_injective' [] : ∀ {X Y : C}, function.injective (@functor.map _ _ _ _ F X Y) . obviously)

--- a/src/category_theory/is_connected.lean
+++ b/src/category_theory/is_connected.lean
@@ -66,7 +66,7 @@ component'.
 
 This allows us to show that the functor X ⨯ - preserves connected limits.
 
-See https://stacks.math.columbia.edu/tag/002S
+See <https://stacks.math.columbia.edu/tag/002S>
 -/
 class is_connected (J : Type u₁) [category.{v₁} J] extends is_preconnected J : Prop :=
 [is_nonempty : nonempty J]

--- a/src/category_theory/isomorphism.lean
+++ b/src/category_theory/isomorphism.lean
@@ -43,7 +43,7 @@ The inverse morphism is bundled.
 See also `category_theory.core` for the category with the same objects and isomorphisms playing
 the role of morphisms.
 
-See https://stacks.math.columbia.edu/tag/0017.
+See <https://stacks.math.columbia.edu/tag/0017>.
 -/
 structure iso {C : Type u} [category.{v} C] (X Y : C) :=
 (hom : X ⟶ Y)

--- a/src/category_theory/limits/constructions/limits_of_products_and_equalizers.lean
+++ b/src/category_theory/limits/constructions/limits_of_products_and_equalizers.lean
@@ -105,7 +105,7 @@ has_limit.mk
 /--
 Any category with products and equalizers has all limits.
 
-See https://stacks.math.columbia.edu/tag/002N.
+See <https://stacks.math.columbia.edu/tag/002N>.
 -/
 lemma limits_from_equalizers_and_products
   [has_products C] [has_equalizers C] : has_limits C :=
@@ -115,7 +115,7 @@ lemma limits_from_equalizers_and_products
 /--
 Any category with finite products and equalizers has all finite limits.
 
-See https://stacks.math.columbia.edu/tag/002O.
+See <https://stacks.math.columbia.edu/tag/002O>.
 -/
 lemma finite_limits_from_equalizers_and_finite_products
   [has_finite_products C] [has_equalizers C] : has_finite_limits C :=
@@ -266,7 +266,7 @@ has_colimit.mk
 /--
 Any category with coproducts and coequalizers has all colimits.
 
-See https://stacks.math.columbia.edu/tag/002P.
+See <https://stacks.math.columbia.edu/tag/002P>.
 -/
 lemma colimits_from_coequalizers_and_coproducts
   [has_coproducts C] [has_coequalizers C] : has_colimits C :=
@@ -276,7 +276,7 @@ lemma colimits_from_coequalizers_and_coproducts
 /--
 Any category with finite coproducts and coequalizers has all finite colimits.
 
-See https://stacks.math.columbia.edu/tag/002Q.
+See <https://stacks.math.columbia.edu/tag/002Q>.
 -/
 lemma finite_colimits_from_coequalizers_and_finite_coproducts
   [has_finite_coproducts C] [has_coequalizers C] : has_finite_colimits C :=

--- a/src/category_theory/limits/final.lean
+++ b/src/category_theory/limits/final.lean
@@ -73,7 +73,7 @@ variables {D : Type v} [small_category D]
 A functor `F : C ⥤ D` is final if for every `d : D`, the comma category of morphisms `d ⟶ F.obj c`
 is connected.
 
-See https://stacks.math.columbia.edu/tag/04E6
+See <https://stacks.math.columbia.edu/tag/04E6>
 -/
 class final (F : C ⥤ D) : Prop :=
 (out (d : D) : is_connected (structured_arrow d F))

--- a/src/category_theory/limits/is_limit.lean
+++ b/src/category_theory/limits/is_limit.lean
@@ -48,7 +48,7 @@ variables {F : J ⥤ C}
 A cone `t` on `F` is a limit cone if each cone on `F` admits a unique
 cone morphism to `t`.
 
-See https://stacks.math.columbia.edu/tag/002E.
+See <https://stacks.math.columbia.edu/tag/002E>.
   -/
 @[nolint has_inhabited_instance]
 structure is_limit (t : cone F) :=
@@ -502,7 +502,7 @@ end is_limit
 A cocone `t` on `F` is a colimit cocone if each cocone on `F` admits a unique
 cocone morphism from `t`.
 
-See https://stacks.math.columbia.edu/tag/002F.
+See <https://stacks.math.columbia.edu/tag/002F>.
 -/
 @[nolint has_inhabited_instance]
 structure is_colimit (t : cocone F) :=

--- a/src/category_theory/limits/presheaf.lean
+++ b/src/category_theory/limits/presheaf.lean
@@ -186,7 +186,7 @@ def is_initial (A : C) : is_initial (elements.initial A) :=
 property (up to isomorphism).
 
 The first part of [MM92], Chapter I, Section 5, Corollary 4.
-See Property 1 of https://ncatlab.org/nlab/show/Yoneda+extension#properties.
+See Property 1 of <https://ncatlab.org/nlab/show/Yoneda+extension#properties>.
 -/
 def is_extension_along_yoneda : (yoneda : C ⥤ Cᵒᵖ ⥤ Type u₁) ⋙ extend_along_yoneda A ≅ A :=
 nat_iso.of_components

--- a/src/category_theory/limits/shapes/binary_products.lean
+++ b/src/category_theory/limits/shapes/binary_products.lean
@@ -552,14 +552,14 @@ variables (C)
 /--
 `has_binary_products` represents a choice of product for every pair of objects.
 
-See https://stacks.math.columbia.edu/tag/001T.
+See <https://stacks.math.columbia.edu/tag/001T>.
 -/
 abbreviation has_binary_products := has_limits_of_shape (discrete walking_pair.{v}) C
 
 /--
 `has_binary_coproducts` represents a choice of coproduct for every pair of objects.
 
-See https://stacks.math.columbia.edu/tag/04AP.
+See <https://stacks.math.columbia.edu/tag/04AP>.
 -/
 abbreviation has_binary_coproducts := has_colimits_of_shape (discrete walking_pair.{v}) C
 

--- a/src/category_theory/limits/shapes/pullbacks.lean
+++ b/src/category_theory/limits/shapes/pullbacks.lean
@@ -2138,7 +2138,7 @@ variables (C)
 /--
 `has_pullbacks` represents a choice of pullback for every pair of morphisms
 
-See https://stacks.math.columbia.edu/tag/001W
+See <https://stacks.math.columbia.edu/tag/001W>
 -/
 abbreviation has_pullbacks := has_limits_of_shape walking_cospan.{v} C
 

--- a/src/category_theory/limits/types.lean
+++ b/src/category_theory/limits/types.lean
@@ -33,7 +33,7 @@ def limit_cone_is_limit (F : J ⥤ Type u) : is_limit (limit_cone F) :=
 /--
 The category of types has all limits.
 
-See https://stacks.math.columbia.edu/tag/002U.
+See <https://stacks.math.columbia.edu/tag/002U>.
 -/
 instance : has_limits (Type u) :=
 { has_limits_of_shape := λ J 𝒥, by exactI
@@ -166,7 +166,7 @@ def colimit_cocone_is_colimit (F : J ⥤ Type u) : is_colimit (colimit_cocone F)
 /--
 The category of types has all colimits.
 
-See https://stacks.math.columbia.edu/tag/002U.
+See <https://stacks.math.columbia.edu/tag/002U>.
 -/
 instance : has_colimits (Type u) :=
 { has_colimits_of_shape := λ J 𝒥, by exactI

--- a/src/category_theory/monoidal/braided.lean
+++ b/src/category_theory/monoidal/braided.lean
@@ -211,7 +211,7 @@ end
 /--
 A symmetric monoidal category is a braided monoidal category for which the braiding is symmetric.
 
-See https://stacks.math.columbia.edu/tag/0FFW.
+See <https://stacks.math.columbia.edu/tag/0FFW>.
 -/
 class symmetric_category (C : Type u) [category.{v} C] [monoidal_category.{v} C]
    extends braided_category.{v} C :=

--- a/src/category_theory/monoidal/category.lean
+++ b/src/category_theory/monoidal/category.lean
@@ -42,7 +42,7 @@ This is far from completely effective, but seems to prove a useful principle.
 ## References
 * Tensor categories, Etingof, Gelaki, Nikshych, Ostrik,
   http://www-math.mit.edu/~etingof/egnobookfinal.pdf
-* https://stacks.math.columbia.edu/tag/0FFK.
+* <https://stacks.math.columbia.edu/tag/0FFK>.
 -/
 
 open category_theory
@@ -62,7 +62,7 @@ specified associator, `α_ X Y Z : (X ⊗ Y) ⊗ Z ≅ X ⊗ (Y ⊗ Z)`. There i
 with specified left and right unitor isomorphisms `λ_ X : 𝟙_ C ⊗ X ≅ X` and `ρ_ X : X ⊗ 𝟙_ C ≅ X`.
 These associators and unitors satisfy the pentagon and triangle equations.
 
-See https://stacks.math.columbia.edu/tag/0FFK.
+See <https://stacks.math.columbia.edu/tag/0FFK>.
 -/
 class monoidal_category (C : Type u) [𝒞 : category.{v} C] :=
 -- curried tensor product of objects:

--- a/src/category_theory/monoidal/functor.lean
+++ b/src/category_theory/monoidal/functor.lean
@@ -34,7 +34,7 @@ to monoid objects.
 
 ## References
 
-See https://stacks.math.columbia.edu/tag/0FFL.
+See <https://stacks.math.columbia.edu/tag/0FFL>.
 -/
 
 open category_theory
@@ -130,7 +130,7 @@ end
 /--
 A monoidal functor is a lax monoidal functor for which the tensorator and unitor as isomorphisms.
 
-See https://stacks.math.columbia.edu/tag/0FFL.
+See <https://stacks.math.columbia.edu/tag/0FFL>.
 -/
 structure monoidal_functor
 extends lax_monoidal_functor.{v₁ v₂} C D :=

--- a/src/category_theory/opposites.lean
+++ b/src/category_theory/opposites.lean
@@ -51,7 +51,7 @@ variables [category.{v₁} C]
 /--
 The opposite category.
 
-See https://stacks.math.columbia.edu/tag/001M.
+See <https://stacks.math.columbia.edu/tag/001M>.
 -/
 instance category.opposite : category.{v₁} Cᵒᵖ :=
 { comp := λ _ _ _ f g, (g.unop ≫ f.unop).op,

--- a/src/category_theory/over.lean
+++ b/src/category_theory/over.lean
@@ -31,7 +31,7 @@ variables {T : Type u₁} [category.{v₁} T]
 The over category has as objects arrows in `T` with codomain `X` and as morphisms commutative
 triangles.
 
-See https://stacks.math.columbia.edu/tag/001G.
+See <https://stacks.math.columbia.edu/tag/001G>.
 -/
 @[derive category]
 def over (X : T) := costructured_arrow (𝟭 T) X
@@ -96,7 +96,7 @@ variable (X)
 /--
 The forgetful functor mapping an arrow to its domain.
 
-See https://stacks.math.columbia.edu/tag/001G.
+See <https://stacks.math.columbia.edu/tag/001G>.
 -/
 def forget : over X ⥤ T := comma.fst _ _
 
@@ -112,7 +112,7 @@ end
 /--
 A morphism `f : X ⟶ Y` induces a functor `over X ⥤ over Y` in the obvious way.
 
-See https://stacks.math.columbia.edu/tag/001G.
+See <https://stacks.math.columbia.edu/tag/001G>.
 -/
 def map {Y : T} (f : X ⟶ Y) : over X ⥤ over Y := comma.map_right _ $ discrete.nat_trans (λ _, f)
 

--- a/src/category_theory/products/basic.lean
+++ b/src/category_theory/products/basic.lean
@@ -33,7 +33,7 @@ variables (C : Type u₁) [category.{v₁} C] (D : Type u₂) [category.{v₂} D
 /--
 `prod C D` gives the cartesian product of two categories.
 
-See https://stacks.math.columbia.edu/tag/001K.
+See <https://stacks.math.columbia.edu/tag/001K>.
 -/
 @[simps {not_recursive := []}] -- the generates simp lemmas like `id_fst` and `comp_snd`
 instance prod : category.{max v₁ v₂} (C × D) :=

--- a/src/category_theory/single_obj.lean
+++ b/src/category_theory/single_obj.lean
@@ -65,7 +65,7 @@ lemma comp_as_mul [monoid α] {x y z : single_obj α} (f : x ⟶ y) (g : y ⟶ z
 /--
 Groupoid structure on `single_obj α`.
 
-See https://stacks.math.columbia.edu/tag/0019.
+See <https://stacks.math.columbia.edu/tag/0019>.
 -/
 instance groupoid [group α] : groupoid (single_obj α) :=
 { inv := λ _ _ x, x⁻¹,
@@ -90,7 +90,7 @@ lemma to_End_def [monoid α] (x : α) : to_End α x = x := rfl
     corresponding single-object categories. It means that `single_obj` is a fully faithful
     functor.
 
-See https://stacks.math.columbia.edu/tag/001F --
+See <https://stacks.math.columbia.edu/tag/001F> --
 although we do not characterize when the functor is full or faithful.
 -/
 def map_hom (α : Type u) (β : Type v) [monoid α] [monoid β] :

--- a/src/category_theory/sites/canonical.lean
+++ b/src/category_theory/sites/canonical.lean
@@ -180,7 +180,7 @@ def finest_topology_single (P : Cᵒᵖ ⥤ Type v) : grothendieck_topology C :=
 /--
 Construct the finest (largest) Grothendieck topology for which all the given presheaves are sheaves.
 
-This is equal to the construction of https://stacks.math.columbia.edu/tag/00Z9.
+This is equal to the construction of <https://stacks.math.columbia.edu/tag/00Z9>.
 -/
 def finest_topology (Ps : set (Cᵒᵖ ⥤ Type v)) : grothendieck_topology C :=
 Inf (finest_topology_single '' Ps)
@@ -205,7 +205,7 @@ end
 The `canonical_topology` on a category is the finest (largest) topology for which every
 representable presheaf is a sheaf.
 
-See https://stacks.math.columbia.edu/tag/00ZA
+See <https://stacks.math.columbia.edu/tag/00ZA>
 -/
 def canonical_topology (C : Type u) [category.{v} C] : grothendieck_topology C :=
 finest_topology (set.range yoneda.obj)

--- a/src/category_theory/sites/cover_lifting.lean
+++ b/src/category_theory/sites/cover_lifting.lean
@@ -78,7 +78,7 @@ end cover_lifting
 
 /-!
 We will now prove that `Ran G.op` (`ₚu`) maps sheaves to sheaves if `G` is cover-lifting. This can
-be found in https://stacks.math.columbia.edu/tag/00XK. However, the proof given here uses the
+be found in <https://stacks.math.columbia.edu/tag/00XK>. However, the proof given here uses the
 amalgamation definition of sheaves, and thus does not require that `C` or `D` has categorical
 pullbacks.
 

--- a/src/category_theory/sites/cover_preserving.lean
+++ b/src/category_theory/sites/cover_preserving.lean
@@ -166,7 +166,7 @@ end
 If `G` is cover-preserving and compatible-preserving,
 then `G.op ⋙ _` pulls sheaves back to sheaves.
 
-This result is basically https://stacks.math.columbia.edu/tag/00WW.
+This result is basically <https://stacks.math.columbia.edu/tag/00WW>.
 -/
 theorem pullback_is_sheaf_of_cover_preserving {G : C ⥤ D} (hG₁ : compatible_preserving.{v₃} K G)
   (hG₂ : cover_preserving J K G) (ℱ : Sheaf K A) :

--- a/src/category_theory/sites/grothendieck.lean
+++ b/src/category_theory/sites/grothendieck.lean
@@ -65,7 +65,7 @@ three axioms:
 
 A sieve `S` on `X` is referred to as `J`-covering, (or just covering), if `S ∈ J X`.
 
-See https://stacks.math.columbia.edu/tag/00Z4, or [nlab], or [MM92][] Chapter III, Section 2,
+See <https://stacks.math.columbia.edu/tag/00Z4>, or [nlab], or [MM92][] Chapter III, Section 2,
 Definition 1.
 -/
 structure grothendieck_topology :=
@@ -108,7 +108,7 @@ lemma covering_of_eq_top : S = ⊤ → S ∈ J X := λ h, h.symm ▸ J.top_mem X
 /--
 If `S` is a subset of `R`, and `S` is covering, then `R` is covering as well.
 
-See https://stacks.math.columbia.edu/tag/00Z5 (2), or discussion after [MM92] Chapter III,
+See <https://stacks.math.columbia.edu/tag/00Z5> (2), or discussion after [MM92] Chapter III,
 Section 2, Definition 1.
 -/
 lemma superset_covering (Hss : S ≤ R) (sjx : S ∈ J X) : R ∈ J X :=
@@ -122,7 +122,7 @@ end
 /--
 The intersection of two covering sieves is covering.
 
-See https://stacks.math.columbia.edu/tag/00Z5 (1), or [MM92] Chapter III,
+See <https://stacks.math.columbia.edu/tag/00Z5> (1), or [MM92] Chapter III,
 Section 2, Definition 1 (iv).
 -/
 lemma intersection_covering (rj : R ∈ J X) (sj : S ∈ J X) : R ⊓ S ∈ J X :=
@@ -223,21 +223,21 @@ variable {C}
 
 lemma trivial_covering : S ∈ trivial C X ↔ S = ⊤ := set.mem_singleton_iff
 
-/-- See https://stacks.math.columbia.edu/tag/00Z6 -/
+/-- See <https://stacks.math.columbia.edu/tag/00Z6> -/
 instance : has_le (grothendieck_topology C) :=
 { le := λ J₁ J₂, (J₁ : Π (X : C), set (sieve X)) ≤ (J₂ : Π (X : C), set (sieve X)) }
 
 lemma le_def {J₁ J₂ : grothendieck_topology C} :
   J₁ ≤ J₂ ↔ (J₁ : Π (X : C), set (sieve X)) ≤ J₂ := iff.rfl
 
-/-- See https://stacks.math.columbia.edu/tag/00Z6 -/
+/-- See <https://stacks.math.columbia.edu/tag/00Z6> -/
 instance : partial_order (grothendieck_topology C) :=
 { le_refl := λ J₁, le_def.mpr le_rfl,
   le_trans := λ J₁ J₂ J₃ h₁₂ h₂₃, le_def.mpr (le_trans h₁₂ h₂₃),
   le_antisymm := λ J₁ J₂ h₁₂ h₂₁, grothendieck_topology.ext (le_antisymm h₁₂ h₂₁),
   ..grothendieck_topology.has_le }
 
-/-- See https://stacks.math.columbia.edu/tag/00Z7 -/
+/-- See <https://stacks.math.columbia.edu/tag/00Z7> -/
 instance : has_Inf (grothendieck_topology C) :=
 { Inf := λ T,
   { sieves := Inf (sieves '' T),
@@ -257,7 +257,7 @@ instance : has_Inf (grothendieck_topology C) :=
       apply J.transitive (hS _ ⟨⟨_, _, hJ, rfl⟩, rfl⟩) _ (λ Y f hf, h hf _ ⟨⟨_, _, hJ, rfl⟩, rfl⟩),
     end } }
 
-/-- See https://stacks.math.columbia.edu/tag/00Z7 -/
+/-- See <https://stacks.math.columbia.edu/tag/00Z7> -/
 lemma is_glb_Inf (s : set (grothendieck_topology C)) : is_glb s (Inf s) :=
 begin
   refine @is_glb.of_image _ _ _ _ sieves _ _ _ _,

--- a/src/category_theory/sites/plus.lean
+++ b/src/category_theory/sites/plus.lean
@@ -12,7 +12,7 @@ import category_theory.sites.sheaf
 This file contains the construction of `P⁺`, for a presheaf `P : Cᵒᵖ ⥤ D`
 where `C` is endowed with a grothendieck topology `J`.
 
-See https://stacks.math.columbia.edu/tag/00W1 for details.
+See <https://stacks.math.columbia.edu/tag/00W1> for details.
 
 -/
 

--- a/src/category_theory/sites/pretopology.lean
+++ b/src/category_theory/sites/pretopology.lean
@@ -99,7 +99,7 @@ instance : inhabited (pretopology C) := ⟨⊤⟩
 A pretopology `K` can be completed to a Grothendieck topology `J` by declaring a sieve to be
 `J`-covering if it contains a family in `K`.
 
-See https://stacks.math.columbia.edu/tag/00ZC, or [MM92] Chapter III, Section 2, Equation (2).
+See <https://stacks.math.columbia.edu/tag/00ZC>, or [MM92] Chapter III, Section 2, Equation (2).
 -/
 def to_grothendieck (K : pretopology C) : grothendieck_topology C :=
 { sieves := λ X S, ∃ R ∈ K X, R ≤ (S : presieve _),
@@ -170,7 +170,7 @@ def gi : galois_insertion (to_grothendieck C) (of_grothendieck C) :=
 The trivial pretopology, in which the coverings are exactly singleton isomorphisms. This topology is
 also known as the indiscrete, coarse, or chaotic topology.
 
-See https://stacks.math.columbia.edu/tag/07GE
+See <https://stacks.math.columbia.edu/tag/07GE>
 -/
 def trivial : pretopology C :=
 { coverings := λ X S, ∃ Y (f : Y ⟶ X) (h : is_iso f), S = presieve.singleton f,

--- a/src/category_theory/sites/sheaf.lean
+++ b/src/category_theory/sites/sheaf.lean
@@ -15,7 +15,7 @@ import category_theory.sites.sheaf_of_types
 If C is a category with a Grothendieck topology, we define the notion of a sheaf taking values in
 an arbitrary category `A`. We follow the definition in https://stacks.math.columbia.edu/tag/00VR,
 noting that the presheaf of sets "defined above" can be seen in the comments between tags 00VQ and
-00VR on the page https://stacks.math.columbia.edu/tag/00VL. The advantage of this definition is
+00VR on the page <https://stacks.math.columbia.edu/tag/00VL>. The advantage of this definition is
 that we need no assumptions whatsoever on `A` other than the assumption that the morphisms in `C`
 and `A` live in the same universe.
 
@@ -400,14 +400,14 @@ variables [has_products A]
 
 /--
 The middle object of the fork diagram given in Equation (3) of [MM92], as well as the fork diagram
-of https://stacks.math.columbia.edu/tag/00VM.
+of <https://stacks.math.columbia.edu/tag/00VM>.
 -/
 def first_obj : A :=
 ∏ (λ (f : Σ V, {f : V ⟶ U // R f}), P.obj (op f.1))
 
 /--
 The left morphism of the fork diagram given in Equation (3) of [MM92], as well as the fork diagram
-of https://stacks.math.columbia.edu/tag/00VM.
+of <https://stacks.math.columbia.edu/tag/00VM>.
 -/
 def fork_map : P.obj (op U) ⟶ first_obj R P :=
 pi.lift (λ f, P.map f.2.1.op)
@@ -422,11 +422,11 @@ def second_obj : A :=
 ∏ (λ (fg : (Σ V, {f : V ⟶ U // R f}) × (Σ W, {g : W ⟶ U // R g})),
   P.obj (op (pullback fg.1.2.1 fg.2.2.1)))
 
-/-- The map `pr₀*` of https://stacks.math.columbia.edu/tag/00VM. -/
+/-- The map `pr₀*` of <https://stacks.math.columbia.edu/tag/00VM>. -/
 def first_map : first_obj R P ⟶ second_obj R P :=
 pi.lift (λ fg, pi.π _ _ ≫ P.map pullback.fst.op)
 
-/-- The map `pr₁*` of https://stacks.math.columbia.edu/tag/00VM. -/
+/-- The map `pr₁*` of <https://stacks.math.columbia.edu/tag/00VM>. -/
 def second_map : first_obj R P ⟶ second_obj R P :=
 pi.lift (λ fg, pi.π _ _ ≫ P.map pullback.snd.op)
 

--- a/src/category_theory/sites/sheaf_of_types.lean
+++ b/src/category_theory/sites/sheaf_of_types.lean
@@ -444,7 +444,7 @@ This version is also useful to establish that being a sheaf is preserved under i
 presheaves.
 
 See the discussion before Equation (3) of [MM92], Chapter III, Section 4. See also C2.1.4 of
-[Elephant]. This is also a direct reformulation of https://stacks.math.columbia.edu/tag/00Z8.
+[Elephant]. This is also a direct reformulation of <https://stacks.math.columbia.edu/tag/00Z8>.
 -/
 def yoneda_sheaf_condition (P : Cᵒᵖ ⥤ Type v₁) (S : sieve X) : Prop :=
 ∀ (f : S.functor ⟶ P), ∃! g, S.functor_inclusion ≫ g = f
@@ -456,7 +456,7 @@ def yoneda_sheaf_condition (P : Cᵒᵖ ⥤ Type v₁) (S : sieve X) : Prop :=
 (Implementation). This is a (primarily internal) equivalence between natural transformations
 and compatible families.
 
-Cf the discussion after Lemma 7.47.10 in https://stacks.math.columbia.edu/tag/00YW. See also
+Cf the discussion after Lemma 7.47.10 in <https://stacks.math.columbia.edu/tag/00YW>. See also
 the proof of C2.1.4 of [Elephant], and the discussion in [MM92], Chapter III, Section 4.
 -/
 def nat_trans_equiv_compatible_family {P : Cᵒᵖ ⥤ Type v₁} :
@@ -799,7 +799,7 @@ noncomputable theory
 
 /--
 The middle object of the fork diagram given in Equation (3) of [MM92], as well as the fork diagram
-of https://stacks.math.columbia.edu/tag/00VM.
+of <https://stacks.math.columbia.edu/tag/00VM>.
 -/
 def first_obj : Type (max v₁ u₁) :=
 ∏ (λ (f : Σ Y, {f : Y ⟶ X // R f}), P.obj (op f.1))
@@ -825,7 +825,7 @@ instance : inhabited (first_obj P (⊥ : presieve X)) :=
 
 /--
 The left morphism of the fork diagram given in Equation (3) of [MM92], as well as the fork diagram
-of https://stacks.math.columbia.edu/tag/00VM.
+of <https://stacks.math.columbia.edu/tag/00VM>.
 -/
 def fork_map : P.obj (op X) ⟶ first_obj P R :=
 pi.lift (λ f, P.map f.2.1.op)
@@ -918,13 +918,13 @@ def second_obj : Type (max v₁ u₁) :=
 ∏ (λ (fg : (Σ Y, {f : Y ⟶ X // R f}) × (Σ Z, {g : Z ⟶ X // R g})),
   P.obj (op (pullback fg.1.2.1 fg.2.2.1)))
 
-/-- The map `pr₀*` of https://stacks.math.columbia.edu/tag/00VL. -/
+/-- The map `pr₀*` of <https://stacks.math.columbia.edu/tag/00VL>. -/
 def first_map : first_obj P R ⟶ second_obj P R :=
 pi.lift (λ fg, pi.π _ _ ≫ P.map pullback.fst.op)
 
 instance : inhabited (second_obj P (⊥ : presieve X)) := ⟨first_map _ _ default⟩
 
-/-- The map `pr₁*` of https://stacks.math.columbia.edu/tag/00VL. -/
+/-- The map `pr₁*` of <https://stacks.math.columbia.edu/tag/00VL>. -/
 def second_map : first_obj P R ⟶ second_obj P R :=
 pi.lift (λ fg, pi.π _ _ ≫ P.map pullback.snd.op)
 
@@ -958,7 +958,7 @@ end
 
 /--
 `P` is a sheaf for `R`, iff the fork given by `w` is an equalizer.
-See https://stacks.math.columbia.edu/tag/00VM.
+See <https://stacks.math.columbia.edu/tag/00VM>.
 -/
 lemma sheaf_condition :
   R.is_sheaf_for P ↔ nonempty (is_limit (fork.of_ι _ (w P R))) :=

--- a/src/category_theory/triangulated/basic.lean
+++ b/src/category_theory/triangulated/basic.lean
@@ -33,7 +33,7 @@ variables (C : Type u) [category.{v} C] [has_shift C ℤ]
 /--
 A triangle in `C` is a sextuple `(X,Y,Z,f,g,h)` where `X,Y,Z` are objects of `C`,
 and `f : X ⟶ Y`, `g : Y ⟶ Z`, `h : Z ⟶ X⟦1⟧` are morphisms in `C`.
-See https://stacks.math.columbia.edu/tag/0144.
+See <https://stacks.math.columbia.edu/tag/0144>.
 -/
 structure triangle := mk' ::
 (obj₁ : C)
@@ -87,7 +87,7 @@ In other words, we have a commutative diagram:
   X' ───> Y' ───> Z' ───> X'⟦1⟧
      f'     g'     h'
 ```
-See https://stacks.math.columbia.edu/tag/0144.
+See <https://stacks.math.columbia.edu/tag/0144>.
 -/
 @[ext]
 structure triangle_morphism (T₁ : triangle C) (T₂ : triangle C) :=

--- a/src/category_theory/triangulated/pretriangulated.lean
+++ b/src/category_theory/triangulated/pretriangulated.lean
@@ -58,7 +58,7 @@ relative to that shift is called pretriangulated if the following hold:
   where the left square commutes, and whose rows are distinguished triangles,
   there exists a morphism `c : Z ⟶ Z'` such that `(a,b,c)` is a triangle morphism.
 
-See https://stacks.math.columbia.edu/tag/0145
+See <https://stacks.math.columbia.edu/tag/0145>
 -/
 class pretriangulated :=
 (distinguished_triangles [] : set (triangle C))
@@ -99,7 +99,7 @@ Given any distinguished triangle
   X  ───> Y  ───> Z  ───> X⟦1⟧
 ```
 the composition `f ≫ g = 0`.
-See https://stacks.math.columbia.edu/tag/0146
+See <https://stacks.math.columbia.edu/tag/0146>
 -/
 lemma comp_dist_triangle_mor_zero₁₂ (T ∈ dist_triang C) : T.mor₁ ≫ T.mor₂ = 0 :=
 begin
@@ -121,7 +121,7 @@ Given any distinguished triangle
   X  ───> Y  ───> Z  ───> X⟦1⟧
 ```
 the composition `g ≫ h = 0`.
-See https://stacks.math.columbia.edu/tag/0146
+See <https://stacks.math.columbia.edu/tag/0146>
 -/
 lemma comp_dist_triangle_mor_zero₂₃  (T ∈ dist_triang C) : T.mor₂ ≫ T.mor₃ = 0 :=
 comp_dist_triangle_mor_zero₁₂ C T.rotate (rot_of_dist_triangle C T H)
@@ -133,7 +133,7 @@ Given any distinguished triangle
   X  ───> Y  ───> Z  ───> X⟦1⟧
 ```
 the composition `h ≫ f⟦1⟧ = 0`.
-See https://stacks.math.columbia.edu/tag/0146
+See <https://stacks.math.columbia.edu/tag/0146>
 -/
 lemma comp_dist_triangle_mor_zero₃₁ (T ∈ dist_triang C) :
   T.mor₃ ≫ ((shift_equiv C 1).functor.map T.mor₁) = 0 :=
@@ -201,7 +201,7 @@ A triangulated functor between pretriangulated categories `C` and `D` is a funct
 together with given functorial isomorphisms `ξ X : F(X⟦1⟧) ⟶ F(X)⟦1⟧` such that for every
 distinguished triangle `(X,Y,Z,f,g,h)` of `C`, the triangle
 `(F(X), F(Y), F(Z), F(f), F(g), F(h) ≫ (ξ X))` is a distinguished triangle of `D`.
-See https://stacks.math.columbia.edu/tag/014V
+See <https://stacks.math.columbia.edu/tag/014V>
 -/
 structure triangulated_functor [pretriangulated C] [pretriangulated D] extends
   triangulated_functor_struct C D :=

--- a/src/category_theory/types.lean
+++ b/src/category_theory/types.lean
@@ -163,7 +163,7 @@ lemma hom_of_element_eq_iff {X : Type u} (x y : X) :
 /--
 A morphism in `Type` is a monomorphism if and only if it is injective.
 
-See https://stacks.math.columbia.edu/tag/003C.
+See <https://stacks.math.columbia.edu/tag/003C>.
 -/
 lemma mono_iff_injective {X Y : Type u} (f : X ⟶ Y) : mono f ↔ function.injective f :=
 begin
@@ -181,7 +181,7 @@ lemma injective_of_mono {X Y : Type u} (f : X ⟶ Y) [hf : mono f] : function.in
 /--
 A morphism in `Type` is an epimorphism if and only if it is surjective.
 
-See https://stacks.math.columbia.edu/tag/003C.
+See <https://stacks.math.columbia.edu/tag/003C>.
 -/
 lemma epi_iff_surjective {X Y : Type u} (f : X ⟶ Y) : epi f ↔ function.surjective f :=
 begin

--- a/src/category_theory/yoneda.lean
+++ b/src/category_theory/yoneda.lean
@@ -29,7 +29,7 @@ variables {C : Type u₁} [category.{v₁} C]
 /--
 The Yoneda embedding, as a functor from `C` into presheaves on `C`.
 
-See https://stacks.math.columbia.edu/tag/001O.
+See <https://stacks.math.columbia.edu/tag/001O>.
 -/
 @[simps]
 def yoneda : C ⥤ (Cᵒᵖ ⥤ Type v₁) :=
@@ -62,7 +62,7 @@ by { dsimp, simp }
 /--
 The Yoneda embedding is full.
 
-See https://stacks.math.columbia.edu/tag/001P.
+See <https://stacks.math.columbia.edu/tag/001P>.
 -/
 instance yoneda_full : full (yoneda : C ⥤ Cᵒᵖ ⥤ Type v₁) :=
 { preimage := λ X Y f, f.app (op X) (𝟙 X) }
@@ -70,7 +70,7 @@ instance yoneda_full : full (yoneda : C ⥤ Cᵒᵖ ⥤ Type v₁) :=
 /--
 The Yoneda embedding is faithful.
 
-See https://stacks.math.columbia.edu/tag/001P.
+See <https://stacks.math.columbia.edu/tag/001P>.
 -/
 instance yoneda_faithful : faithful (yoneda : C ⥤ Cᵒᵖ ⥤ Type v₁) :=
 { map_injective' := λ X Y f g p, by convert (congr_fun (congr_app p (op X)) (𝟙 X)); dsimp; simp }
@@ -133,7 +133,7 @@ namespace functor
 /--
 A functor `F : Cᵒᵖ ⥤ Type v₁` is representable if there is object `X` so `F ≅ yoneda.obj X`.
 
-See https://stacks.math.columbia.edu/tag/001Q.
+See <https://stacks.math.columbia.edu/tag/001Q>.
 -/
 class representable (F : Cᵒᵖ ⥤ Type v₁) : Prop :=
 (has_representation : ∃ X (f : yoneda.obj X ⟶ F), is_iso f)
@@ -144,7 +144,7 @@ instance {X : C} : representable (yoneda.obj X) :=
 /--
 A functor `F : C ⥤ Type v₁` is corepresentable if there is object `X` so `F ≅ coyoneda.obj X`.
 
-See https://stacks.math.columbia.edu/tag/001Q.
+See <https://stacks.math.columbia.edu/tag/001Q>.
 -/
 class corepresentable (F : C ⥤ Type v₁) : Prop :=
 (has_corepresentation : ∃ X (f : coyoneda.obj X ⟶ F), is_iso f)
@@ -289,7 +289,7 @@ The Yoneda lemma asserts that that the Yoneda pairing
 `(X : Cᵒᵖ, F : Cᵒᵖ ⥤ Type) ↦ (yoneda.obj (unop X) ⟶ F)`
 is naturally isomorphic to the evaluation `(X, F) ↦ F.obj X`.
 
-See https://stacks.math.columbia.edu/tag/001P.
+See <https://stacks.math.columbia.edu/tag/001P>.
 -/
 def yoneda_lemma : yoneda_pairing C ≅ yoneda_evaluation C :=
 { hom :=

--- a/src/topology/category/Top/limits.lean
+++ b/src/topology/category/Top/limits.lean
@@ -823,7 +823,7 @@ The theorem is specialized to nonempty finite types (which are compact Hausdorff
 discrete topology) in `nonempty_sections_of_fintype_cofiltered_system` and
 `nonempty_sections_of_fintype_inverse_system`.
 
-(See https://stacks.math.columbia.edu/tag/086J for the Set version.)
+(See <https://stacks.math.columbia.edu/tag/086J> for the Set version.)
 -/
 
 variables {J : Type u} [small_category J]

--- a/src/topology/sheaves/forget.lean
+++ b/src/topology/sheaves/forget.lean
@@ -123,7 +123,7 @@ Then to check the sheaf condition it suffices to check it on the underlying shea
 
 Another useful example is the forgetful functor `TopCommRing ⥤ Top`.
 
-See https://stacks.math.columbia.edu/tag/0073.
+See <https://stacks.math.columbia.edu/tag/0073>.
 In fact we prove a stronger version with arbitrary complete target category.
 -/
 lemma is_sheaf_iff_is_sheaf_comp :

--- a/src/topology/sheaves/sheafify.lean
+++ b/src/topology/sheaves/sheafify.lean
@@ -24,7 +24,7 @@ Show that the map induced on stalks by `to_sheafify` is the inverse of `stalk_to
 
 Show sheafification is a functor from presheaves to sheaves,
 and that it is the left adjoint of the forgetful functor,
-following https://stacks.math.columbia.edu/tag/007X.
+following <https://stacks.math.columbia.edu/tag/007X>.
 -/
 
 universes v

--- a/src/topology/tietze_extension.lean
+++ b/src/topology/tietze_extension.lean
@@ -17,7 +17,7 @@ function belong to some (finite or infinite, open or closed) interval, then the 
 chosen so that it takes values in the same interval. In particular, if the original function is a
 bounded function, then there exists a bounded extension of the same norm.
 
-The proof mostly follows https://ncatlab.org/nlab/show/Tietze+extension+theorem. We patch a small
+The proof mostly follows <https://ncatlab.org/nlab/show/Tietze+extension+theorem>. We patch a small
 gap in the proof for unbounded functions, see
 `exists_extension_forall_exists_le_ge_of_closed_embedding`.
 


### PR DESCRIPTION
I noticed that many docs say

    See https://stacks.math.columbia.edu/tag/001T.

and the our documentation will include the final `.` in the URL, causing
the URL to not work.

This tries to fix some of these instances. I intentionally applied this
to some URLs ending with a space, because it does not hurt to be
explicit, and the next contributor cargo-culting the URL is more likely
to get this right.

Obligatory xkcd reference: https://xkcd.com/208/



---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
