### PR TITLE
[Merged by Bors] - chore(algebraic_geometry/AffineScheme): Speed up `Spec`

### DIFF
--- a/src/algebraic_geometry/AffineScheme.lean
+++ b/src/algebraic_geometry/AffineScheme.lean
@@ -69,7 +69,7 @@ by { rw [← mem_AffineScheme] at h ⊢, exact functor.ess_image.of_iso (as_iso 
 namespace AffineScheme
 
 /-- The `Spec` functor into the category of affine schemes. -/
-@[derive [full, faithful, ess_surj], simps]
+@[derive [full, faithful, ess_surj]]
 def Spec : CommRingᵒᵖ ⥤ AffineScheme := Scheme.Spec.to_ess_image
 
 /-- The forgetful functor `AffineScheme ⥤ Scheme`. -/


### PR DESCRIPTION
`simps` take 38s in local and does not seem to generate any useful lemma.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

Here's the trace of `simps?`:
```
[simps] > The given definition is not a constructor application:
        >   Scheme.Spec.to_ess_image
        > Retrying with the options { rhs_md := semireducible, simp_rhs := tt}.
[simps] > adding projection algebraic_geometry.AffineScheme.Spec_obj_coe_to_LocallyRingedSpace_to_SheafedSpace:
        > ∀ (X : CommRingᵒᵖ),
  ↑(Spec.obj X).to_LocallyRingedSpace.to_SheafedSpace = Spec.SheafedSpace_obj (unop X)
[simps] > generating projection information for structure submodule.
[simps] > generated projections for submodule:
        > Projection carrier: λ (R : Type u) (M : Type v) [_inst_1 : semiring R] [_inst_2 : add_comm_monoid M]
[_inst_3 : module R M] (x : submodule R M), x.carrier
        > No lemmas are generated for the projections: add_mem', zero_mem', smul_mem'.
[simps] > adding projection algebraic_geometry.AffineScheme.Spec_map_coe_base_to_fun_coe_carrier:
        > ∀ (X Y : CommRingᵒᵖ) (f : X ⟶ Y) (y : prime_spectrum ↥(unop X)),
  ↑(⇑(↑(Spec.map f).base) y).carrier = ⇑(f.unop) ⁻¹' ↑(y.as_ideal)
[simps] > adding projection algebraic_geometry.AffineScheme.Spec_map_coe_c_app_apply_coe:
        > ∀ (X Y : CommRingᵒᵖ) (f : X ⟶ Y)
(U : (opens ↥((Spec.SheafedSpace_obj (unop Y)).to_PresheafedSpace.carrier))ᵒᵖ)
(s : ↥((structure_sheaf ↥(unop Y)).val.obj (op (unop U))))
(y : ↥((opens.map (Spec.Top_map f.unop)).obj (unop U))),
  ↑(⇑(↑(Spec.map f).c.app U) s) y =
    structure_sheaf.comap_fun f.unop (unop U) ((opens.map (Spec.Top_map f.unop)).obj (unop U)) _ ↑s y
```

None of them seems useful because of the very particular shape of the LHS. Further, it spells some of them as `whatever.carrier` instead of `↑whatever` (anything we can do about that, @Vierkantor?). Is something wrong with `simps` or is such mad recursion expected for complicated types?

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
