### PR TITLE
[Merged by Bors] - refactor(set_theory/game/pgame): Simpler definition for `star`

### DIFF
--- a/src/set_theory/game/pgame.lean
+++ b/src/set_theory/game/pgame.lean
@@ -1126,20 +1126,16 @@ theorem lt_iff_sub_pos {x y : pgame} : x < y ↔ 0 < y - x :=
      ... ≤ y : (add_zero_relabelling y).le⟩
 
 /-- The pre-game `star`, which is fuzzy/confused with zero. -/
-def star : pgame.{u} := of_lists [0] [0]
+def star : pgame.{u} := ⟨punit, punit, λ _, 0, λ _, 0⟩
 
-@[simp] theorem star_left_moves : star.left_moves = ulift (fin 1) := rfl
-@[simp] theorem star_right_moves : star.right_moves = ulift (fin 1) := rfl
+@[simp] theorem star_left_moves : star.left_moves = punit := rfl
+@[simp] theorem star_right_moves : star.right_moves = punit := rfl
 
-@[simp] theorem star_move_left (x) : star.move_left x = 0 :=
-show (of_lists _ _).move_left x = 0, by simp
-@[simp] theorem star_move_right (x) : star.move_right x = 0 :=
-show (of_lists _ _).move_right x = 0, by simp
+@[simp] theorem star_move_left (x) : star.move_left x = 0 := rfl
+@[simp] theorem star_move_right (x) : star.move_right x = 0 := rfl
 
-instance unique_star_left_moves : unique star.left_moves :=
-@equiv.unique _ (fin 1) _ equiv.ulift
-instance unique_star_right_moves : unique star.right_moves :=
-@equiv.unique _ (fin 1) _ equiv.ulift
+instance unique_star_left_moves : unique star.left_moves := punit.unique
+instance unique_star_right_moves : unique star.right_moves := punit.unique
 
 theorem star_lt_zero : star < 0 :=
 by { rw lt_zero, use default, rintros ⟨⟩ }
@@ -1147,7 +1143,7 @@ theorem zero_lt_star : 0 < star :=
 by { rw zero_lt, use default, rintros ⟨⟩ }
 
 @[simp] theorem neg_star : -star = star :=
-by { rw [star, of_lists], simp }
+by simp [star]
 
 /-- The pre-game `ω`. (In fact all ordinals have game and surreal representatives.) -/
 def omega : pgame := ⟨ulift ℕ, pempty, λ n, ↑n.1, pempty.elim⟩


### PR DESCRIPTION
This new definition gives marginally easier proofs for the basic lemmas, and avoids use of the quite incomplete `of_lists` API.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
