### PR TITLE
[Merged by Bors] - feat(analysis/normed_space/exponential): `Aeᴮ = eᴮA` if `AB = BA`

### DIFF
--- a/src/analysis/normed_space/exponential.lean
+++ b/src/analysis/normed_space/exponential.lean
@@ -134,6 +134,9 @@ end
 lemma commute.exp_left [t2_space 𝔸] {x y : 𝔸} (h : commute x y) : commute (exp 𝕂 𝔸 x) y :=
 (h.symm.exp_right 𝕂).symm
 
+lemma commute.exp [t2_space 𝔸] {x y : 𝔸} (h : commute x y) : commute (exp 𝕂 𝔸 x) (exp 𝕂 𝔸 y) :=
+(h.exp_left _).exp_right _
+
 end topological_algebra
 
 section normed
@@ -431,9 +434,6 @@ begin
   letI := invertible_exp 𝕂 x,
   exact ring.inverse_invertible _,
 end
-
-lemma commute.exp {x y : 𝔸} (h : commute x y) : commute (exp 𝕂 𝔸 x) (exp 𝕂 𝔸 y) :=
-(h.exp_left _).exp_right _
 
 end
 

--- a/src/analysis/normed_space/exponential.lean
+++ b/src/analysis/normed_space/exponential.lean
@@ -123,6 +123,17 @@ begin
   simp [h]
 end
 
+variables (𝕂)
+
+lemma commute.exp_right [t2_space 𝔸] {x y : 𝔸} (h : commute x y) : commute x (exp 𝕂 𝔸 y) :=
+begin
+  rw exp_eq_tsum,
+  exact commute.tsum_right x (λ n, (h.pow_right n).smul_right _),
+end
+
+lemma commute.exp_left [t2_space 𝔸] {x y : 𝔸} (h : commute x y) : commute (exp 𝕂 𝔸 x) y :=
+(h.symm.exp_right 𝕂).symm
+
 end topological_algebra
 
 section normed
@@ -421,10 +432,6 @@ begin
   exact ring.inverse_invertible _,
 end
 
-lemma commute.exp {x y : 𝔸} (h : commute x y) :
-  commute (exp 𝕂 𝔸 x) (exp 𝕂 𝔸 y) :=
-(exp_add_of_commute h).symm.trans $ (congr_arg _ $ add_comm _ _).trans (exp_add_of_commute h.symm)
-
 end
 
 /-- In a Banach-algebra `𝔸` over `𝕂 = ℝ` or `𝕂 = ℂ`, if a family of elements `f i` mutually
@@ -432,7 +439,7 @@ commute then `exp 𝕂 𝔸 (∑ i, f i) = ∏ i, exp 𝕂 𝔸 (f i)`. -/
 lemma exp_sum_of_commute {ι} (s : finset ι) (f : ι → 𝔸)
   (h : ∀ (i ∈ s) (j ∈ s), commute (f i) (f j)) :
   exp 𝕂 𝔸 (∑ i in s, f i) = s.noncomm_prod (λ i, exp 𝕂 𝔸 (f i))
-    (λ i hi j hj, (h i hi j hj).exp 𝕂) :=
+    (λ i hi j hj, ((h i hi j hj).exp_left _).exp_right _) :=
 begin
   classical,
   induction s using finset.induction_on with a s ha ih,

--- a/src/analysis/normed_space/exponential.lean
+++ b/src/analysis/normed_space/exponential.lean
@@ -432,6 +432,9 @@ begin
   exact ring.inverse_invertible _,
 end
 
+lemma commute.exp {x y : 𝔸} (h : commute x y) : commute (exp 𝕂 𝔸 x) (exp 𝕂 𝔸 y) :=
+(h.exp_left _).exp_right _
+
 end
 
 /-- In a Banach-algebra `𝔸` over `𝕂 = ℝ` or `𝕂 = ℂ`, if a family of elements `f i` mutually
@@ -439,7 +442,7 @@ commute then `exp 𝕂 𝔸 (∑ i, f i) = ∏ i, exp 𝕂 𝔸 (f i)`. -/
 lemma exp_sum_of_commute {ι} (s : finset ι) (f : ι → 𝔸)
   (h : ∀ (i ∈ s) (j ∈ s), commute (f i) (f j)) :
   exp 𝕂 𝔸 (∑ i in s, f i) = s.noncomm_prod (λ i, exp 𝕂 𝔸 (f i))
-    (λ i hi j hj, ((h i hi j hj).exp_left _).exp_right _) :=
+    (λ i hi j hj, (h i hi j hj).exp 𝕂) :=
 begin
   classical,
   induction s using finset.induction_on with a s ha ih,

--- a/src/topology/algebra/infinite_sum.lean
+++ b/src/topology/algebra/infinite_sum.lean
@@ -777,6 +777,15 @@ lemma summable.tsum_mul_left (a) (hf : summable f) : ∑'b, a * f b = a * ∑'b,
 lemma summable.tsum_mul_right (a) (hf : summable f) : (∑'b, f b * a) = (∑'b, f b) * a :=
 (hf.has_sum.mul_right _).tsum_eq
 
+lemma commute.tsum_right (a) (h : ∀ b, commute a (f b)) : commute a (∑' b, f b) :=
+if hf : summable f then
+  (hf.tsum_mul_left a).symm.trans ((congr_arg _ $ funext h).trans (hf.tsum_mul_right a))
+else
+  (tsum_eq_zero_of_not_summable hf).symm ▸ commute.zero_right _
+
+lemma commute.tsum_left (a) (h : ∀ b, commute (f b) a) : commute (∑' b, f b) a :=
+(commute.tsum_right _ $ λ b, (h b).symm).symm
+
 end tsum
 
 end topological_semiring


### PR DESCRIPTION
This commit shows that the exponenential commutes if the exponent does.
This generalizes a previous weaker result.



---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
