### PR TITLE
[Merged by Bors] - feat(data/zmod/basic): Generalize `zmod.card`

### DIFF
--- a/src/data/zmod/basic.lean
+++ b/src/data/zmod/basic.lean
@@ -87,7 +87,7 @@ int.infinite
 @[simp] lemma card (n : ℕ) [fintype (zmod n)] : fintype.card (zmod n) = n :=
 begin
   casesI n,
-  { exact (not_fintype (zmod 0)).elim },
+  { exfalso, exact not_fintype (zmod 0) },
   { convert fintype.card_fin (n+1) }
 end
 

--- a/src/data/zmod/basic.lean
+++ b/src/data/zmod/basic.lean
@@ -84,11 +84,11 @@ instance fintype : Π (n : ℕ) [fact (0 < n)], fintype (zmod n)
 instance infinite : infinite (zmod 0) :=
 int.infinite
 
-@[simp] lemma card {n : ℕ} [fintype (zmod n)] : fintype.card (zmod n) = n :=
+@[simp] lemma card (n : ℕ) [fintype (zmod n)] : fintype.card (zmod n) = n :=
 begin
   casesI n,
   { exact (not_fintype (zmod 0)).elim },
-  { convert fintype.card_fin n.succ },
+  { convert fintype.card_fin (n+1) },
 end
 
 instance decidable_eq : Π (n : ℕ), decidable_eq (zmod n)

--- a/src/data/zmod/basic.lean
+++ b/src/data/zmod/basic.lean
@@ -84,11 +84,11 @@ instance fintype : Π (n : ℕ) [fact (0 < n)], fintype (zmod n)
 instance infinite : infinite (zmod 0) :=
 int.infinite
 
-@[simp] lemma card (n : ℕ) [fact (0 < n)] : fintype.card (zmod n) = n :=
+@[simp] lemma card {n : ℕ} [fintype (zmod n)] : fintype.card (zmod n) = n :=
 begin
   casesI n,
-  { exfalso, exact nat.not_lt_zero 0 (fact.out _) },
-  { exact fintype.card_fin (n+1) }
+  { exact (not_fintype (zmod 0)).elim },
+  { convert fintype.card_fin n.succ },
 end
 
 instance decidable_eq : Π (n : ℕ), decidable_eq (zmod n)

--- a/src/data/zmod/basic.lean
+++ b/src/data/zmod/basic.lean
@@ -88,7 +88,7 @@ int.infinite
 begin
   casesI n,
   { exact (not_fintype (zmod 0)).elim },
-  { convert fintype.card_fin (n+1) },
+  { convert fintype.card_fin (n+1) }
 end
 
 instance decidable_eq : Π (n : ℕ), decidable_eq (zmod n)


### PR DESCRIPTION
This PR generalizes `zmod.card` from assuming `[fact (0 < n)]` to assuming `[fintype (zmod n)]`.
Note that the latter was already part of the statement, but was previously deduced from the instance `instance fintype : Π (n : ℕ) [fact (0 < n)], fintype (zmod n)` on line 80.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
