### PR TITLE
[Merged by Bors] - feat(data/zmod/basic): Add `zmod.cast_sub_one`

### DIFF
--- a/src/data/zmod/basic.lean
+++ b/src/data/zmod/basic.lean
@@ -473,6 +473,20 @@ begin
   { rw [←nat_cast_val, val_neg_one, nat.cast_succ, add_sub_cancel] },
 end
 
+lemma zmod.cast_sub_one {R : Type*} [ring R] {n : ℕ} (k : zmod n) :
+  ((k - 1 : zmod n) : R) = (if k = 0 then n else k) - 1 :=
+begin
+  by_cases hk : k = 0,
+  { rw [if_pos hk, hk, zero_sub, zmod.cast_neg_one] },
+  { rw [if_neg hk],
+    cases n,
+    { rw [int.cast_sub, int.cast_one] },
+    { rw [←zmod.nat_cast_val, zmod.val, fin.coe_sub_one, if_neg],
+      { rw [nat.cast_sub, nat.cast_one, coe_coe],
+        rwa [fin.ext_iff, fin.coe_zero, ←ne, ←nat.one_le_iff_ne_zero] at hk },
+      { exact hk } } },
+end
+
 lemma nat_coe_zmod_eq_iff (p : ℕ) (n : ℕ) (z : zmod p) [fact (0 < p)] :
   ↑n = z ↔ ∃ k, n = z.val + p * k :=
 begin

--- a/src/data/zmod/basic.lean
+++ b/src/data/zmod/basic.lean
@@ -473,7 +473,7 @@ begin
   { rw [←nat_cast_val, val_neg_one, nat.cast_succ, add_sub_cancel] },
 end
 
-lemma zmod.cast_sub_one {R : Type*} [ring R] {n : ℕ} (k : zmod n) :
+lemma cast_sub_one {R : Type*} [ring R] {n : ℕ} (k : zmod n) :
   ((k - 1 : zmod n) : R) = (if k = 0 then n else k) - 1 :=
 begin
   by_cases hk : k = 0,

--- a/src/data/zmod/basic.lean
+++ b/src/data/zmod/basic.lean
@@ -476,10 +476,9 @@ end
 lemma cast_sub_one {R : Type*} [ring R] {n : ℕ} (k : zmod n) :
   ((k - 1 : zmod n) : R) = (if k = 0 then n else k) - 1 :=
 begin
-  by_cases hk : k = 0,
-  { rw [if_pos hk, hk, zero_sub, zmod.cast_neg_one] },
-  { rw [if_neg hk],
-    cases n,
+  split_ifs with hk,
+  { rw [hk, zero_sub, zmod.cast_neg_one] },
+  { cases n,
     { rw [int.cast_sub, int.cast_one] },
     { rw [←zmod.nat_cast_val, zmod.val, fin.coe_sub_one, if_neg],
       { rw [nat.cast_sub, nat.cast_one, coe_coe],


### PR DESCRIPTION
This PR adds `zmod.cast_sub_one`, an analog of `fin.coe_sub_one`. Unfortunately, the proof is a bit long. But maybe it can be golfed?

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
