### PR TITLE
[Merged by Bors] - feat(linear_algebra/span): add `finite_span_is_compact_element`

### DIFF
--- a/src/linear_algebra/span.lean
+++ b/src/linear_algebra/span.lean
@@ -558,9 +558,8 @@ begin
 end
 
 /-- The span of a finite set is compact in the lattice of submodules. -/
-lemma finite_span_is_compact_element (S : finset M)  :
-  complete_lattice.is_compact_element
-  (span R S : submodule R M) :=
+lemma finite_span_is_compact_element (S : finset M) :
+  complete_lattice.is_compact_element (span R S : submodule R M) :=
 begin
   rw span_eq_supr_of_singleton_spans,
   simp only [finset.mem_coe],

--- a/src/linear_algebra/span.lean
+++ b/src/linear_algebra/span.lean
@@ -557,7 +557,7 @@ begin
   exact ⟨y, ⟨hyd, by simpa only [span_le, singleton_subset_iff]⟩⟩,
 end
 
-/-- The span of a finite set is compact in the lattice of submodules. -/
+/-- The span of a finite subset is compact in the lattice of submodules. -/
 lemma finite_span_is_compact_element (S : finset M) :
   complete_lattice.is_compact_element (span R S : submodule R M) :=
 begin
@@ -567,6 +567,11 @@ begin
   exact complete_lattice.finset_sup_compact_of_compact S
     (λ x _, singleton_span_is_compact_element x),
 end
+
+/-- The span of a finite subset is compact in the lattice of submodules. -/
+lemma finite_span_is_compact_element' (S : set M) (h : S.finite) :
+  complete_lattice.is_compact_element (span R S : submodule R M) :=
+finite.coe_to_finset h ▸ (finite_span_is_compact_element h.to_finset)
 
 instance : is_compactly_generated (submodule R M) :=
 ⟨λ s, ⟨(λ x, span R {x}) '' s, ⟨λ t ht, begin

--- a/src/linear_algebra/span.lean
+++ b/src/linear_algebra/span.lean
@@ -557,6 +557,18 @@ begin
   exact ⟨y, ⟨hyd, by simpa only [span_le, singleton_subset_iff]⟩⟩,
 end
 
+/-- The span of a finite set is compact in the lattice of submodules. -/
+lemma finite_span_is_compact_element (S : finset M)  :
+  complete_lattice.is_compact_element
+  (span R S : submodule R M) :=
+begin
+  rw span_eq_supr_of_singleton_spans,
+  simp only [finset.mem_coe],
+  rw ←finset.sup_eq_supr,
+  exact complete_lattice.finset_sup_compact_of_compact S
+    (λ x _, singleton_span_is_compact_element x),
+end
+
 instance : is_compactly_generated (submodule R M) :=
 ⟨λ s, ⟨(λ x, span R {x}) '' s, ⟨λ t ht, begin
   rcases (set.mem_image _ _ _).1 ht with ⟨x, hx, rfl⟩,

--- a/src/linear_algebra/span.lean
+++ b/src/linear_algebra/span.lean
@@ -558,7 +558,7 @@ begin
 end
 
 /-- The span of a finite subset is compact in the lattice of submodules. -/
-lemma finite_span_is_compact_element (S : finset M) :
+lemma finset_span_is_compact_element (S : finset M) :
   complete_lattice.is_compact_element (span R S : submodule R M) :=
 begin
   rw span_eq_supr_of_singleton_spans,
@@ -569,9 +569,9 @@ begin
 end
 
 /-- The span of a finite subset is compact in the lattice of submodules. -/
-lemma finite_span_is_compact_element' (S : set M) (h : S.finite) :
+lemma finite_span_is_compact_element (S : set M) (h : S.finite) :
   complete_lattice.is_compact_element (span R S : submodule R M) :=
-finite.coe_to_finset h ▸ (finite_span_is_compact_element h.to_finset)
+finite.coe_to_finset h ▸ (finset_span_is_compact_element h.to_finset)
 
 instance : is_compactly_generated (submodule R M) :=
 ⟨λ s, ⟨(λ x, span R {x}) '' s, ⟨λ t ht, begin


### PR DESCRIPTION
This PR adds `finite_span_is_compact_element`, which extends `singleton_span_is_compact_element` to the spans of finite subsets.
This will be useful e.g. when proving the existence of a maximal submodule of a finitely generated module.



---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
