### PR TITLE
[Merged by Bors] - chore(topology/continuous_function/bounded): generalize from `normed_*` to `semi_normed_*`

### DIFF
--- a/src/topology/continuous_function/bounded.lean
+++ b/src/topology/continuous_function/bounded.lean
@@ -33,7 +33,7 @@ you should parametrize over `(F : Type*) [bounded_continuous_map_class F α β] 
 
 When you extend this structure, make sure to extend `bounded_continuous_map_class`. -/
 structure bounded_continuous_function
-  (α : Type u) (β : Type v) [topological_space α] [metric_space β] extends continuous_map α β :
+  (α : Type u) (β : Type v) [topological_space α] [pseudo_metric_space β] extends continuous_map α β :
   Type (max u v) :=
 (map_bounded' : ∃ C, ∀ x y, dist (to_fun x) (to_fun y) ≤ C)
 
@@ -42,7 +42,7 @@ localized "infixr ` →ᵇ `:25 := bounded_continuous_function" in bounded_conti
 /-- `bounded_continuous_map_class F α β` states that `F` is a type of bounded continuous maps.
 
 You should also extend this typeclass when you extend `bounded_continuous_function`. -/
-class bounded_continuous_map_class (F α β : Type*) [topological_space α] [metric_space β]
+class bounded_continuous_map_class (F α β : Type*) [topological_space α] [pseudo_metric_space β]
   extends continuous_map_class F α β :=
 (map_bounded (f : F) : ∃ C, ∀ x y, dist (f x) (f y) ≤ C)
 
@@ -50,7 +50,7 @@ export bounded_continuous_map_class (map_bounded)
 
 namespace bounded_continuous_function
 section basics
-variables [topological_space α] [metric_space β] [metric_space γ]
+variables [topological_space α] [pseudo_metric_space β] [pseudo_metric_space γ]
 variables {f g : α →ᵇ β} {x : α} {C : ℝ}
 
 instance : bounded_continuous_map_class (α →ᵇ β) α β :=
@@ -170,15 +170,18 @@ lemma dist_lt_iff_of_nonempty_compact [nonempty α] [compact_space α] :
   dist f g < C ↔ ∀x:α, dist (f x) (g x) < C :=
 ⟨λ w x, lt_of_le_of_lt (dist_coe_le_dist x) w, dist_lt_of_nonempty_compact⟩
 
-/-- The type of bounded continuous functions, with the uniform distance, is a metric space. -/
-instance : metric_space (α →ᵇ β) :=
+/-- The type of bounded continuous functions, with the uniform distance, is a pseudometric space. -/
+instance : pseudo_metric_space (α →ᵇ β) :=
 { dist_self := λ f, le_antisymm ((dist_le le_rfl).2 $ λ x, by simp) dist_nonneg',
-  eq_of_dist_eq_zero := λ f g hfg, by ext x; exact
-    eq_of_dist_eq_zero (le_antisymm (hfg ▸ dist_coe_le_dist _) dist_nonneg),
   dist_comm := λ f g, by simp [dist_eq, dist_comm],
   dist_triangle := λ f g h,
     (dist_le (add_nonneg dist_nonneg' dist_nonneg')).2 $ λ x,
       le_trans (dist_triangle _ _ _) (add_le_add (dist_coe_le_dist _) (dist_coe_le_dist _)) }
+
+/-- The type of bounded continuous functions, with the uniform distance, is a metric space. -/
+instance {α β} [topological_space α] [metric_space β] : metric_space (α →ᵇ β) :=
+{ eq_of_dist_eq_zero := λ f g hfg, by ext x; exact
+    eq_of_dist_eq_zero (le_antisymm (hfg ▸ dist_coe_le_dist _) dist_nonneg) }
 
 lemma nndist_eq : nndist f g = Inf {C | ∀ x : α, nndist (f x) (g x) ≤ C} :=
 subtype.ext $ dist_eq.trans $ begin
@@ -194,7 +197,7 @@ dist_coe_le_dist x
 
 /-- On an empty space, bounded continuous functions are at distance 0 -/
 lemma dist_zero_of_empty [is_empty α] : dist f g = 0 :=
-dist_eq_zero.2 (eq_of_empty f g)
+by rw [(ext is_empty_elim : f = g), dist_self]
 
 lemma dist_eq_supr : dist f g = ⨆ x : α, dist (f x) (g x) :=
 begin
@@ -396,7 +399,7 @@ end extend
 end basics
 
 section arzela_ascoli
-variables [topological_space α] [compact_space α] [metric_space β]
+variables [topological_space α] [compact_space α] [pseudo_metric_space β]
 variables {f g : α →ᵇ β} {x : α} {C : ℝ}
 
 /- Arzela-Ascoli theorem asserts that, on a compact space, a set of functions sharing
@@ -494,7 +497,7 @@ end
 
 /-- Third (main) version, with pointwise equicontinuity and range in a compact subset, but
 without closedness. The closure is then compact -/
-theorem arzela_ascoli
+theorem arzela_ascoli [t2_space β]
   (s : set β) (hs : is_compact s)
   (A : set (α →ᵇ β))
   (in_s : ∀(f : α →ᵇ β) (x : α), f ∈ A → f x ∈ s)
@@ -524,7 +527,7 @@ arzela_ascoli₂ s hs (closure A) is_closed_closure
 instance is when the source space is a metric space, and there is a fixed modulus of continuity
 for all the functions in the set A -/
 
-lemma equicontinuous_of_continuity_modulus {α : Type u} [metric_space α]
+lemma equicontinuous_of_continuity_modulus {α : Type u} [pseudo_metric_space α]
   (b : ℝ → ℝ) (b_lim : tendsto b (𝓝 0) (𝓝 0))
   (A : set (α →ᵇ β))
   (H : ∀(x y:α) (f : α →ᵇ β), f ∈ A → dist (f x) (f y) ≤ b (dist x y))
@@ -548,7 +551,7 @@ end arzela_ascoli
 
 section has_one
 
-variables [topological_space α] [metric_space β] [has_one β]
+variables [topological_space α] [pseudo_metric_space β] [has_one β]
 
 @[to_additive] instance : has_one (α →ᵇ β) := ⟨const α 1⟩
 
@@ -577,7 +580,7 @@ names (for example, `coe_mul`) to conflict with later lemma names for normed rin
 trivial inconvenience, but in any case there are no obvious applications of the multiplicative
 version. -/
 
-variables [topological_space α] [metric_space β] [add_monoid β]
+variables [topological_space α] [pseudo_metric_space β] [add_monoid β]
 variables [has_lipschitz_add β]
 variables (f g : α →ᵇ β) {x : α} {C : ℝ}
 
@@ -649,7 +652,7 @@ end has_lipschitz_add
 
 section comm_has_lipschitz_add
 
-variables [topological_space α] [metric_space β] [add_comm_monoid β] [has_lipschitz_add β]
+variables [topological_space α] [pseudo_metric_space β] [add_comm_monoid β] [has_lipschitz_add β]
 
 @[to_additive] instance : add_comm_monoid (α →ᵇ β) :=
 { add_comm      := assume f g, by ext; simp [add_comm],
@@ -672,7 +675,7 @@ section normed_group
 continuous functions from α to β inherits a normed group structure, by using
 pointwise operations and checking that they are compatible with the uniform distance. -/
 
-variables [topological_space α] [normed_group β]
+variables [topological_space α] [semi_normed_group β]
 variables (f g : α →ᵇ β) {x : α} {C : ℝ}
 
 instance : has_norm (α →ᵇ β) := ⟨λu, dist u 0⟩
@@ -753,12 +756,12 @@ le_antisymm (norm_const_le b) $ h.elim $ λ x, (const α b).norm_coe_le_norm x
 
 /-- Constructing a bounded continuous function from a uniformly bounded continuous
 function taking values in a normed group. -/
-def of_normed_group {α : Type u} {β : Type v} [topological_space α] [normed_group β]
+def of_normed_group {α : Type u} {β : Type v} [topological_space α] [semi_normed_group β]
   (f : α → β) (Hf : continuous f) (C : ℝ) (H : ∀x, ∥f x∥ ≤ C) : α →ᵇ β :=
 ⟨⟨λn, f n, Hf⟩, ⟨_, dist_le_two_norm' H⟩⟩
 
 @[simp] lemma coe_of_normed_group
-  {α : Type u} {β : Type v} [topological_space α] [normed_group β]
+  {α : Type u} {β : Type v} [topological_space α] [semi_normed_group β]
   (f : α → β) (Hf : continuous f) (C : ℝ) (H : ∀x, ∥f x∥ ≤ C) :
   (of_normed_group f Hf C H : α → β) = f := rfl
 
@@ -769,16 +772,16 @@ lemma norm_of_normed_group_le {f : α → β} (hfc : continuous f) {C : ℝ} (hC
 /-- Constructing a bounded continuous function from a uniformly bounded
 function on a discrete space, taking values in a normed group -/
 def of_normed_group_discrete {α : Type u} {β : Type v}
-  [topological_space α] [discrete_topology α] [normed_group β]
+  [topological_space α] [discrete_topology α] [semi_normed_group β]
   (f : α  → β) (C : ℝ) (H : ∀x, norm (f x) ≤ C) : α →ᵇ β :=
 of_normed_group f continuous_of_discrete_topology C H
 
 @[simp] lemma coe_of_normed_group_discrete
-  {α : Type u} {β : Type v} [topological_space α] [discrete_topology α] [normed_group β]
+  {α : Type u} {β : Type v} [topological_space α] [discrete_topology α] [semi_normed_group β]
   (f : α → β) (C : ℝ) (H : ∀x, ∥f x∥ ≤ C) :
   (of_normed_group_discrete f C H : α → β) = f := rfl
 
-/-- Taking the pointwise norm of a bounded continuous function with values in a `normed_group`,
+/-- Taking the pointwise norm of a bounded continuous function with values in a `semi_normed_group`,
 yields a bounded continuous function with values in ℝ. -/
 def norm_comp : α →ᵇ ℝ :=
 f.comp norm lipschitz_with_one_norm
@@ -834,8 +837,11 @@ instance : add_comm_group (α →ᵇ β) :=
 fun_like.coe_injective.add_comm_group _ coe_zero coe_add coe_neg coe_sub (λ _ _, coe_nsmul _ _)
   (λ _ _, coe_zsmul _ _)
 
-instance : normed_group (α →ᵇ β) :=
+instance : semi_normed_group (α →ᵇ β) :=
 { dist_eq := λ f g, by simp only [norm_eq, dist_eq, dist_eq_norm, sub_apply] }
+
+instance {α β} [topological_space α] [normed_group β] : normed_group (α →ᵇ β) :=
+{ ..bounded_continuous_function.semi_normed_group }
 
 lemma nnnorm_def : ∥f∥₊ = nndist f 0 := rfl
 
@@ -879,7 +885,7 @@ functions from `α` to `β` inherits a so-called `has_bounded_smul` structure (i
 `has_continuous_mul` structure, which is the mathlib formulation of being a topological module), by
 using pointwise operations and checking that they are compatible with the uniform distance. -/
 
-variables {𝕜 : Type*} [pseudo_metric_space 𝕜] [topological_space α] [metric_space β]
+variables {𝕜 : Type*} [pseudo_metric_space 𝕜] [topological_space α] [pseudo_metric_space β]
 
 section has_scalar
 variables [has_zero 𝕜] [has_zero β] [has_scalar 𝕜 β] [has_bounded_smul 𝕜 β]
@@ -973,7 +979,7 @@ continuous functions from `α` to `β` inherits a normed space structure, by usi
 pointwise operations and checking that they are compatible with the uniform distance. -/
 
 variables {𝕜 : Type*}
-variables [topological_space α] [normed_group β]
+variables [topological_space α] [semi_normed_group β]
 variables {f g : α →ᵇ β} {x : α} {C : ℝ}
 
 instance [normed_field 𝕜] [normed_space 𝕜 β] : normed_space 𝕜 (α →ᵇ β) := ⟨λ c f, begin
@@ -982,7 +988,7 @@ instance [normed_field 𝕜] [normed_space 𝕜 β] : normed_space 𝕜 (α →�
     (mul_le_mul_of_nonneg_left (f.norm_coe_le_norm _) (norm_nonneg _))) end⟩
 
 variables [nondiscrete_normed_field 𝕜] [normed_space 𝕜 β]
-variables [normed_group γ] [normed_space 𝕜 γ]
+variables [semi_normed_group γ] [normed_space 𝕜 γ]
 
 variables (α)
 -- TODO does this work in the `has_bounded_smul` setting, too?
@@ -1023,11 +1029,12 @@ variables [topological_space α] {R : Type*}
 
 section non_unital
 
-variables [non_unital_normed_ring R]
+section semi_normed
+variables [non_unital_semi_normed_ring R]
 
 instance : has_mul (α →ᵇ R) :=
 { mul := λ f g, of_normed_group (f * g) (f.continuous.mul g.continuous) (∥f∥ * ∥g∥) $ λ x,
-    le_trans (non_unital_normed_ring.norm_mul (f x) (g x)) $
+    le_trans (norm_mul_le (f x) (g x)) $
       mul_le_mul (f.norm_coe_le_norm x) (g.norm_coe_le_norm x) (norm_nonneg _) (norm_nonneg _) }
 
 @[simp] lemma coe_mul (f g : α →ᵇ R) : ⇑(f * g) = f * g := rfl
@@ -1037,13 +1044,21 @@ instance : non_unital_ring (α →ᵇ R) :=
 fun_like.coe_injective.non_unital_ring _ coe_zero coe_add coe_mul coe_neg coe_sub
   (λ _ _, coe_nsmul _ _) (λ _ _, coe_zsmul _ _)
 
-instance : non_unital_normed_ring (α →ᵇ R) :=
+instance : non_unital_semi_normed_ring (α →ᵇ R) :=
 { norm_mul := λ f g, norm_of_normed_group_le _ (mul_nonneg (norm_nonneg _) (norm_nonneg _)) _,
+  .. bounded_continuous_function.semi_normed_group }
+
+end semi_normed
+
+instance [non_unital_normed_ring R] : non_unital_normed_ring (α →ᵇ R) :=
+{ .. bounded_continuous_function.non_unital_semi_normed_ring,
   .. bounded_continuous_function.normed_group }
 
 end non_unital
 
-variables [normed_ring R]
+section semi_normed
+
+variables [semi_normed_ring R]
 
 @[simp] lemma coe_npow_rec (f : α →ᵇ R) : ∀ n, ⇑(npow_rec n f) = f ^ n
 | 0 := by rw [npow_rec, pow_zero, coe_one]
@@ -1063,7 +1078,12 @@ fun_like.coe_injective.ring _ coe_zero coe_one coe_add coe_mul coe_neg coe_sub
   (λ _ _, coe_zsmul _ _)
   (λ _ _, coe_pow _ _)
 
-instance : normed_ring (α →ᵇ R) :=
+instance : semi_normed_ring (α →ᵇ R) :=
+{ ..bounded_continuous_function.non_unital_semi_normed_ring }
+
+end semi_normed
+
+instance [normed_ring R] : normed_ring (α →ᵇ R) :=
 { ..bounded_continuous_function.non_unital_normed_ring }
 
 end normed_ring
@@ -1076,13 +1096,16 @@ In this section, if `R` is a normed commutative ring, then we show that the spac
 continuous functions from `α` to `R` inherits a normed commutative ring structure, by using
 pointwise operations and checking that they are compatible with the uniform distance. -/
 
-variables [topological_space α] {R : Type*} [normed_comm_ring R]
+variables [topological_space α] {R : Type*}
 
-instance : comm_ring (α →ᵇ R) :=
+instance [semi_normed_comm_ring R] : comm_ring (α →ᵇ R) :=
 { mul_comm := λ f₁ f₂, ext $ λ x, mul_comm _ _,
   .. bounded_continuous_function.ring }
 
-instance : normed_comm_ring (α →ᵇ R) :=
+instance [semi_normed_comm_ring R] : semi_normed_comm_ring (α →ᵇ R) :=
+{ .. bounded_continuous_function.comm_ring, .. bounded_continuous_function.semi_normed_group }
+
+instance [normed_comm_ring R] : normed_comm_ring (α →ᵇ R) :=
 { .. bounded_continuous_function.comm_ring, .. bounded_continuous_function.normed_group }
 
 end normed_comm_ring
@@ -1096,7 +1119,7 @@ continuous functions from `α` to `γ` inherits a normed algebra structure, by u
 pointwise operations and checking that they are compatible with the uniform distance. -/
 
 variables {𝕜 : Type*} [normed_field 𝕜]
-variables [topological_space α] [normed_group β] [normed_space 𝕜 β]
+variables [topological_space α] [semi_normed_group β] [normed_space 𝕜 β]
 variables [normed_ring γ] [normed_algebra 𝕜 γ]
 variables {f g : α →ᵇ γ} {x : α} {c : 𝕜}
 
@@ -1182,7 +1205,7 @@ completeness is guaranteed when `β` is complete (see
 section normed_group
 
 variables {𝕜 : Type*} [normed_field 𝕜] [star_ring 𝕜]
-variables [topological_space α] [normed_group β] [star_add_monoid β] [normed_star_group β]
+variables [topological_space α] [semi_normed_group β] [star_add_monoid β] [normed_star_group β]
 variables [normed_space 𝕜 β] [star_module 𝕜 β]
 
 instance : star_add_monoid (α →ᵇ β) :=

--- a/src/topology/continuous_function/bounded.lean
+++ b/src/topology/continuous_function/bounded.lean
@@ -32,8 +32,8 @@ When possible, instead of parametrizing results over `(f : α →ᵇ β)`,
 you should parametrize over `(F : Type*) [bounded_continuous_map_class F α β] (f : F)`.
 
 When you extend this structure, make sure to extend `bounded_continuous_map_class`. -/
-structure bounded_continuous_function
-  (α : Type u) (β : Type v) [topological_space α] [pseudo_metric_space β] extends continuous_map α β :
+structure bounded_continuous_function (α : Type u) (β : Type v)
+  [topological_space α] [pseudo_metric_space β] extends continuous_map α β :
   Type (max u v) :=
 (map_bounded' : ∃ C, ∀ x y, dist (to_fun x) (to_fun y) ≤ C)
 


### PR DESCRIPTION
Every single lemma in this file generalized, apart from the ones that transferred a `normed_*` instance which obviously need the stronger assumption.

`dist_zero_of_empty` was the only lemma that actually needed reproving from scratch, all the other affected proofs are just split between two instances.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
