### PR TITLE
[Merged by Bors] - doc(order/countable_dense_linear_order): Fix minor mistake

### DIFF
--- a/src/order/countable_dense_linear_order.lean
+++ b/src/order/countable_dense_linear_order.lean
@@ -10,9 +10,9 @@ import order.ideal
 
 ## Results
 
-Suppose `α β` are orders, with `α` countable and `β` dense, nontrivial. Then there is an order
-embedding `α ↪ β`. If in addition `α` is dense, nonempty, without endpoints and `β` is countable,
-without endpoints, then we can upgrade this to an order isomorphism `α ≃ β`.
+Suppose `α β` are linear orders, with `α` countable and `β` dense, nontrivial. Then there is an
+order embedding `α ↪ β`. If in addition `α` is dense, nonempty, without endpoints and `β` is
+countable, without endpoints, then we can upgrade this to an order isomorphism `α ≃ β`.
 
 The idea for both results is to consider "partial isomorphisms", which identify a finite subset of
 `α` with a finite subset of `β`, and prove that for any such partial isomorphism `f` and `a : α`, we
@@ -174,7 +174,7 @@ open partial_iso
 
 variables (α β)
 
-/-- Any countable order embeds in any nontrivial dense linear order. -/
+/-- Any countable linear order embeds in any nontrivial dense linear order. -/
 theorem embedding_from_countable_to_dense [encodable α] [densely_ordered β] [nontrivial β] :
   nonempty (α ↪o β) :=
 begin


### PR DESCRIPTION
I wrongfully removed some instances of the word "linear" in #12928. This is in fact used as a hypothesis.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
