### PR TITLE
[Merged by Bors] - feat(algebra/module/linear_map): `Rᵐᵒᵖ` is isomorphic to `module.End R R`

### DIFF
--- a/src/algebra/module/linear_map.lean
+++ b/src/algebra/module/linear_map.lean
@@ -843,4 +843,18 @@ def to_module_End : S →+* module.End R M :=
   map_add' := λ f g, linear_map.ext $ add_smul _ _,
   ..distrib_mul_action.to_module_End R M }
 
+/-- The canonical (semi)ring isomorphism between between `Rᵐᵒᵖ` and
+`module.End R R` induced by the right multiplication.
+-/
+def module_End_self : Rᵐᵒᵖ ≃+* module.End R R :=
+{ to_fun := λ a, ⟨λ x, x * mul_opposite.unop a, λ _ _, add_mul _ _ _, by simp only [mul_assoc,
+    smul_eq_mul, ring_hom.id_apply, eq_self_iff_true, forall_const] ⟩,
+  inv_fun := λ f, mul_opposite.op (f 1),
+  left_inv := λ _, by simp only [linear_map.coe_mk, one_mul, mul_opposite.op_unop],
+  right_inv := λ _, by { ext1, simp only [mul_opposite.unop_op, linear_map.coe_mk, one_mul] },
+  map_mul' := λ _ _, by { ext1, simp only [mul_opposite.unop_mul,
+    linear_map.coe_mk, one_mul, linear_map.mul_apply] },
+  map_add' := λ _ _, by { ext1, simp only [mul_opposite.unop_add,
+    linear_map.coe_mk, one_mul, linear_map.add_apply] } }
+
 end module

--- a/src/algebra/module/linear_map.lean
+++ b/src/algebra/module/linear_map.lean
@@ -843,18 +843,14 @@ def to_module_End : S →+* module.End R M :=
   map_add' := λ f g, linear_map.ext $ add_smul _ _,
   ..distrib_mul_action.to_module_End R M }
 
-/-- The canonical (semi)ring isomorphism from `Rᵐᵒᵖ`
-to `module.End R R` induced by the right multiplication.
--/
+/-- The canonical (semi)ring isomorphism from `Rᵐᵒᵖ` to `module.End R R` induced by the right
+multiplication. -/
+@[simps]
 def module_End_self : Rᵐᵒᵖ ≃+* module.End R R :=
-{ to_fun := λ a, ⟨λ x, x * mul_opposite.unop a, λ _ _, add_mul _ _ _, by simp only [mul_assoc,
-    smul_eq_mul, ring_hom.id_apply, eq_self_iff_true, forall_const] ⟩,
+{ to_fun := distrib_mul_action.to_linear_map R R,
   inv_fun := λ f, mul_opposite.op (f 1),
-  left_inv := λ _, by simp only [linear_map.coe_mk, one_mul, mul_opposite.op_unop],
-  right_inv := λ _, by { ext1, simp only [mul_opposite.unop_op, linear_map.coe_mk, one_mul] },
-  map_mul' := λ _ _, by { ext1, simp only [mul_opposite.unop_mul,
-    linear_map.coe_mk, one_mul, linear_map.mul_apply] },
-  map_add' := λ _ _, by { ext1, simp only [mul_opposite.unop_add,
-    linear_map.coe_mk, one_mul, linear_map.add_apply] } }
+  left_inv := mul_one,
+  right_inv := λ f, linear_map.ext_ring $ one_mul _,
+  ..module.to_module_End R R }
 
 end module

--- a/src/algebra/module/linear_map.lean
+++ b/src/algebra/module/linear_map.lean
@@ -314,6 +314,9 @@ ext $ λ x, by rw [← mul_one x, ← smul_eq_mul, f.map_smulₛₗ, g.map_smul�
 theorem ext_ring_iff {σ : R →+* R} {f g : R →ₛₗ[σ] M} : f = g ↔ f 1 = g 1 :=
 ⟨λ h, h ▸ rfl, ext_ring⟩
 
+@[ext] theorem ext_ring_op {σ : Rᵐᵒᵖ →+* S} {f g : R →ₛₗ[σ] M₃} (h : f 1 = g 1) : f = g :=
+ext $ λ x, by rw [← one_mul x, ← op_smul_eq_mul, f.map_smulₛₗ, g.map_smulₛₗ, h]
+
 end
 
 /-- Interpret a `ring_hom` `f` as an `f`-semilinear map. -/
@@ -852,5 +855,15 @@ def module_End_self : Rᵐᵒᵖ ≃+* module.End R R :=
   left_inv := mul_one,
   right_inv := λ f, linear_map.ext_ring $ one_mul _,
   ..module.to_module_End R R }
+
+/-- The canonical (semi)ring isomorphism from `R` to `module.End Rᵐᵒᵖ R` induced by the left
+multiplication. -/
+@[simps]
+def module_End_self_op : R ≃+* module.End Rᵐᵒᵖ R :=
+{ to_fun := distrib_mul_action.to_linear_map _ _,
+  inv_fun := λ f, f 1,
+  left_inv := mul_one,
+  right_inv := λ f, linear_map.ext_ring_op $ mul_one _,
+  ..module.to_module_End _ _ }
 
 end module

--- a/src/algebra/module/linear_map.lean
+++ b/src/algebra/module/linear_map.lean
@@ -843,8 +843,8 @@ def to_module_End : S →+* module.End R M :=
   map_add' := λ f g, linear_map.ext $ add_smul _ _,
   ..distrib_mul_action.to_module_End R M }
 
-/-- The canonical (semi)ring isomorphism between between `Rᵐᵒᵖ` and
-`module.End R R` induced by the right multiplication.
+/-- The canonical (semi)ring isomorphism from `Rᵐᵒᵖ`
+to `module.End R R` induced by the right multiplication.
 -/
 def module_End_self : Rᵐᵒᵖ ≃+* module.End R R :=
 { to_fun := λ a, ⟨λ x, x * mul_opposite.unop a, λ _ _, add_mul _ _ _, by simp only [mul_assoc,


### PR DESCRIPTION
This PR adds the canonical (semi)ring isomorphism from `Rᵐᵒᵖ` to
`module.End R R` for a (semi)ring `R`, given by the right multiplication.



---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
