### PR TITLE
WIP(analysis/convolution): Define convolution of a multiplicative group

### DIFF
--- a/src/algebra/group/to_additive.lean
+++ b/src/algebra/group/to_additive.lean
@@ -219,11 +219,12 @@ meta def tr : bool → list string → list string
 | is_comm ("npow" :: s)               := add_comm_prefix is_comm "nsmul"     :: tr ff s
 | is_comm ("zpow" :: s)               := add_comm_prefix is_comm "zsmul"     :: tr ff s
 | is_comm ("is" :: "square" :: s)     := add_comm_prefix is_comm "even"      :: tr ff s
-| is_comm ("is" :: "regular" :: s)    := add_comm_prefix is_comm "is_add_regular"   :: tr ff s
+| is_comm ("is" :: "regular" :: s)    := add_comm_prefix is_comm "is_add_regular" :: tr ff s
 | is_comm ("is" :: "left" :: "regular" :: s)  :=
   add_comm_prefix is_comm "is_add_left_regular"  :: tr ff s
 | is_comm ("is" :: "right" :: "regular" :: s) :=
   add_comm_prefix is_comm "is_add_right_regular" :: tr ff s
+| is_comm ("mconvolution" :: s) := (add_comm_prefix is_comm "convolution")        :: tr ff s
 | is_comm ("monoid" :: s)      := ("add_" ++ add_comm_prefix is_comm "monoid")    :: tr ff s
 | is_comm ("submonoid" :: s)   := ("add_" ++ add_comm_prefix is_comm "submonoid") :: tr ff s
 | is_comm ("group" :: s)       := ("add_" ++ add_comm_prefix is_comm "group")     :: tr ff s

--- a/src/analysis/convolution.lean
+++ b/src/analysis/convolution.lean
@@ -12,7 +12,7 @@ import analysis.calculus.parametric_integral
 /-!
 # Convolution of functions
 
-This file defines the convolution on two functions, i.e. `x ↦ ∫ f(t)g(x - t) ∂t`.
+This file defines the convolution on two functions, i.e. `x ↦ ∫ f(t)g(x / t) ∂t`.
 In the general case, these functions can be vector-valued, and have an arbitrary (additive)
 group as domain. We use a continuous bilinear operation `L` on these function values as
 "multiplication". The domain must be equipped with a Haar measure `μ`
@@ -46,7 +46,7 @@ This generality has several advantages
   `smul` to multiply the functions, that would be an asymmetric definition.
 
 # Main Definitions
-* `convolution f g L μ x = (f ⋆[L, μ] g) x = ∫ t, L (f t) (g (x - t)) ∂μ` is the convolution of
+* `convolution f g L μ x = (f ⋆[L, μ] g) x = ∫ t, L (f t) (g (x / t)) ∂μ` is the convolution of
   `f` and `g` w.r.t. the continuous bilinear map `L` and measure `μ`.
 * `convolution_exists_at f g x L μ` states that the convolution `(f ⋆[L, μ] g) x` is well-defined
   (i.e. the integral exists).
@@ -92,11 +92,13 @@ variables (L : E →L[𝕜] E' →L[𝕜] F)
 
 section no_measurability
 
-variables [add_group G] [topological_space G]
+variables [group G] [topological_space G]
 
-lemma has_compact_support.convolution_integrand_bound_right (hcg : has_compact_support g)
+lemma has_compact_support.convolution_integrand_bound_right {G} [add_group G] [topological_space G]
+  {f : G → E} {g : G → E'}
+  (hcg : has_compact_support g)
   (hg : continuous g) {x t : G} {s : set G} (hx : x ∈ s) :
-  ∥L (f t) (g (x - t))∥ ≤ (- tsupport g + s).indicator (λ t, ∥L∥ * ∥f t∥ * (⨆ i, ∥g i∥)) t :=
+  ∥L (f t) (g (x - t))∥ ≤ (-tsupport g + s).indicator (λ t, ∥L∥ * ∥f t∥ * (⨆ i, ∥g i∥)) t :=
 begin
   refine le_indicator (λ t ht, _) (λ t ht, _) t,
   { refine (L.le_op_norm₂ _ _).trans _,
@@ -109,14 +111,23 @@ begin
     rw [nmem_support.mp this, (L _).map_zero, norm_zero] }
 end
 
-lemma continuous.convolution_integrand_fst [has_continuous_sub G] (hg : continuous g) (t : G) :
-  continuous (λ x, L (f t) (g (x - t))) :=
-L.continuous₂.comp₂ continuous_const $ hg.comp $ continuous_id.sub continuous_const
+@[to_additive]
+lemma has_compact_support.mconvolution_integrand_bound_right (hcg : has_compact_support g)
+  (hg : continuous g) {x t : G} {s : set G} (hx : x ∈ s) :
+  ∥L (f t) (g (x / t))∥ ≤ ((tsupport g)⁻¹ * s).indicator (λ t, ∥L∥ * ∥f t∥ * (⨆ i, ∥g i∥)) t :=
+@has_compact_support.convolution_integrand_bound_right _ _ _ _ _ _ _ _ _ _ _ L
+  (additive G) _ _inst_11 _ _ hcg hg x t s hx
 
-lemma has_compact_support.convolution_integrand_bound_left (hcf : has_compact_support f)
+@[to_additive]
+lemma continuous.mconvolution_integrand_fst [has_continuous_div G] (hg : continuous g) (t : G) :
+  continuous (λ x, L (f t) (g (x / t))) :=
+L.continuous₂.comp₂ continuous_const $ hg.comp $ continuous_id.div' continuous_const
+
+@[to_additive]
+lemma has_compact_support.mconvolution_integrand_bound_left (hcf : has_compact_support f)
   (hf : continuous f) {x t : G} {s : set G} (hx : x ∈ s) :
-  ∥L (f (x - t)) (g t)∥ ≤ (- tsupport f + s).indicator (λ t, ∥L∥ * (⨆ i, ∥f i∥) * ∥g t∥) t :=
-by { convert hcf.convolution_integrand_bound_right L.flip hf hx,
+  ∥L (f (x / t)) (g t)∥ ≤ ((tsupport f)⁻¹ * s).indicator (λ t, ∥L∥ * (⨆ i, ∥f i∥) * ∥g t∥) t :=
+by { convert hcf.mconvolution_integrand_bound_right L.flip hf hx,
   simp_rw [L.op_norm_flip, mul_right_comm] }
 
 end no_measurability
@@ -125,47 +136,53 @@ section measurability
 
 variables [measurable_space G] {μ : measure G}
 
-/-- The convolution of `f` and `g` exists at `x` when the function `t ↦ L (f t) (g (x - t))` is
+/-- The convolution of `f` and `g` exists at `x` when the function `t ↦ L (f t) (g (x / t))` is
 integrable. There are various conditions on `f` and `g` to prove this. -/
-def convolution_exists_at [has_sub G] (f : G → E) (g : G → E') (x : G) (L : E →L[𝕜] E' →L[𝕜] F)
+@[to_additive convolution_exists_at]
+def mconvolution_exists_at [has_div G] (f : G → E) (g : G → E') (x : G) (L : E →L[𝕜] E' →L[𝕜] F)
   (μ : measure G . volume_tac) : Prop :=
-integrable (λ t, L (f t) (g (x - t))) μ
+integrable (λ t, L (f t) (g (x / t))) μ
 
-/-- The convolution of `f` and `g` exists when the function `t ↦ L (f t) (g (x - t))` is integrable
+/-- The convolution of `f` and `g` exists when the function `t ↦ L (f t) (g (x / t))` is integrable
 for all `x : G`. There are various conditions on `f` and `g` to prove this. -/
-def convolution_exists [has_sub G] (f : G → E) (g : G → E') (L : E →L[𝕜] E' →L[𝕜] F)
+@[to_additive convolution_exists]
+def mconvolution_exists [has_div G] (f : G → E) (g : G → E') (L : E →L[𝕜] E' →L[𝕜] F)
   (μ : measure G . volume_tac) : Prop :=
-∀ x : G, convolution_exists_at f g x L μ
+∀ x : G, mconvolution_exists_at f g x L μ
 
-section convolution_exists
+section mconvolution_exists
 
 variables {L}
-lemma convolution_exists_at.integrable [has_sub G] {x : G} (h : convolution_exists_at f g x L μ) :
-  integrable (λ t, L (f t) (g (x - t))) μ :=
+@[to_additive]
+lemma mconvolution_exists_at.integrable [has_div G] {x : G} (h : mconvolution_exists_at f g x L μ) :
+  integrable (λ t, L (f t) (g (x / t))) μ :=
 h
 
 variables (L)
 
 section group
 
-variables [add_group G]
-variables [has_measurable_add₂ G] [has_measurable_neg G]
+variables [group G]
+variables [has_measurable_mul₂ G] [has_measurable_inv G]
 
-lemma measure_theory.ae_strongly_measurable.convolution_integrand' [sigma_finite μ]
+@[to_additive]
+lemma measure_theory.ae_strongly_measurable.mconvolution_integrand' [sigma_finite μ]
   (hf : ae_strongly_measurable f μ)
-  (hg : ae_strongly_measurable g $ map (λ (p : G × G), p.1 - p.2) (μ.prod μ)) :
-  ae_strongly_measurable (λ p : G × G, L (f p.2) (g (p.1 - p.2))) (μ.prod μ) :=
-L.ae_strongly_measurable_comp₂ hf.snd $ hg.comp_measurable $ measurable_fst.sub measurable_snd
+  (hg : ae_strongly_measurable g $ map (λ (p : G × G), p.1 / p.2) (μ.prod μ)) :
+  ae_strongly_measurable (λ p : G × G, L (f p.2) (g (p.1 / p.2))) (μ.prod μ) :=
+L.ae_strongly_measurable_comp₂ hf.snd $ hg.comp_measurable $ measurable_fst.div measurable_snd
 
-lemma measure_theory.ae_strongly_measurable.convolution_integrand_snd'
+@[to_additive]
+lemma measure_theory.ae_strongly_measurable.mconvolution_integrand_snd'
   (hf : ae_strongly_measurable f μ) {x : G}
-  (hg : ae_strongly_measurable g $ map (λ t, x - t) μ) :
-  ae_strongly_measurable (λ t, L (f t) (g (x - t))) μ :=
+  (hg : ae_strongly_measurable g $ map (λ t, x / t) μ) :
+  ae_strongly_measurable (λ t, L (f t) (g (x / t))) μ :=
 L.ae_strongly_measurable_comp₂ hf $ hg.comp_measurable $ measurable_id.const_sub x
 
-lemma measure_theory.ae_strongly_measurable.convolution_integrand_swap_snd'
-  {x : G} (hf : ae_strongly_measurable f $ map (λ t, x - t) μ)
-  (hg : ae_strongly_measurable g μ) : ae_strongly_measurable (λ t, L (f (x - t)) (g t)) μ :=
+@[to_additive]
+lemma measure_theory.ae_strongly_measurable.mconvolution_integrand_swap_snd'
+  {x : G} (hf : ae_strongly_measurable f $ map (λ t, x / t) μ)
+  (hg : ae_strongly_measurable g μ) : ae_strongly_measurable (λ t, L (f (x / t)) (g t)) μ :=
 L.ae_strongly_measurable_comp₂ (hf.comp_measurable $ measurable_id.const_sub x) hg
 
 /-- A sufficient condition to prove that `f ⋆[L, μ] g` exists.
@@ -175,108 +192,114 @@ integrable on the support of the integrand, and that both functions are strongly
 
 Note: we could weaken the measurability condition to hold only for `μ.restrict s`. -/
 lemma bdd_above.convolution_exists_at' {x₀ : G}
-  {s : set G} (hbg : bdd_above ((λ i, ∥g i∥) '' ((λ t, - t + x₀) ⁻¹' s)))
-  (hs : measurable_set s) (h2s : support (λ t, L (f t) (g (x₀ - t))) ⊆ s)
+  {s : set G} (hbg : bdd_above ((λ i, ∥g i∥) '' ((λ t, t⁻¹ * x₀) ⁻¹' s)))
+  (hs : measurable_set s) (h2s : support (λ t, L (f t) (g (x₀ / t))) ⊆ s)
   (hf : integrable_on f s μ)
   (hmf : ae_strongly_measurable f μ)
-  (hmg : ae_strongly_measurable g $ map (λ t, x₀ - t) μ) :
-    convolution_exists_at f g x₀ L μ :=
+  (hmg : ae_strongly_measurable g $ map (λ t, x₀ / t) μ) :
+    mconvolution_exists_at f g x₀ L μ :=
 begin
-  set s' := (λ t, - t + x₀) ⁻¹' s,
+  set s' := (λ t, t⁻¹ * x₀) ⁻¹' s,
   have : ∀ᵐ (t : G) ∂μ,
-    ∥L (f t) (g (x₀ - t))∥ ≤ s.indicator (λ t, ∥L∥ * ∥f t∥ * ⨆ i : s', ∥g i∥) t,
+    ∥L (f t) (g (x₀ / t))∥ ≤ s.indicator (λ t, ∥L∥ * ∥f t∥ * ⨆ i : s', ∥g i∥) t,
   { refine eventually_of_forall _,
     refine le_indicator (λ t ht, _) (λ t ht, _),
     { refine (L.le_op_norm₂ _ _).trans _,
       refine mul_le_mul_of_nonneg_left
         (le_csupr_set hbg $ mem_preimage.mpr _)
         (mul_nonneg (norm_nonneg _) (norm_nonneg _)),
-      rwa [neg_sub, sub_add_cancel] },
-    { have : t ∉ support (λ t, L (f t) (g (x₀ - t))) := mt (λ h, h2s h) ht,
+      rwa [inv_div', div_mul_cancel'] },
+    { have : t ∉ support (λ t, L (f t) (g (x₀ / t))) := mt (λ h, h2s h) ht,
       rw [nmem_support.mp this, norm_zero] } },
   refine integrable.mono' _ _ this,
   { rw [integrable_indicator_iff hs], exact (hf.norm.const_mul _).mul_const _ },
-  { exact hmf.convolution_integrand_snd' L hmg }
+  { exact hmf.mconvolution_integrand_snd' L hmg }
 end
 
 section left
-variables [sigma_finite μ] [is_add_left_invariant μ]
+variables [sigma_finite μ] [is_mul_left_invariant μ]
 
-lemma measure_theory.ae_strongly_measurable.convolution_integrand_snd
+@[to_additive]
+lemma measure_theory.ae_strongly_measurable.mconvolution_integrand_snd
   (hf : ae_strongly_measurable f μ) (hg : ae_strongly_measurable g μ)
-  (x : G) : ae_strongly_measurable (λ t, L (f t) (g (x - t))) μ :=
-hf.convolution_integrand_snd' L $ hg.mono' $ map_sub_left_absolutely_continuous μ x
+  (x : G) : ae_strongly_measurable (λ t, L (f t) (g (x / t))) μ :=
+hf.mconvolution_integrand_snd' L $ hg.mono' $ map_div_left_absolutely_continuous μ x
 
-lemma measure_theory.ae_strongly_measurable.convolution_integrand_swap_snd
+@[to_additive]
+lemma measure_theory.ae_strongly_measurable.mconvolution_integrand_swap_snd
   (hf : ae_strongly_measurable f μ) (hg : ae_strongly_measurable g μ)
-  (x : G) : ae_strongly_measurable (λ t, L (f (x - t)) (g t)) μ :=
-(hf.mono' (map_sub_left_absolutely_continuous μ x)).convolution_integrand_swap_snd' L hg
+  (x : G) : ae_strongly_measurable (λ t, L (f (x / t)) (g t)) μ :=
+(hf.mono' (map_div_left_absolutely_continuous μ x)).mconvolution_integrand_swap_snd' L hg
 
 end left
 
 section right
 
-variables [sigma_finite μ] [is_add_right_invariant μ]
+variables [sigma_finite μ] [is_mul_right_invariant μ]
 
-lemma measure_theory.ae_strongly_measurable.convolution_integrand
+@[to_additive]
+lemma measure_theory.ae_strongly_measurable.mconvolution_integrand
   (hf : ae_strongly_measurable f μ) (hg : ae_strongly_measurable g μ) :
-  ae_strongly_measurable (λ p : G × G, L (f p.2) (g (p.1 - p.2))) (μ.prod μ) :=
-hf.convolution_integrand' L $ hg.mono' (quasi_measure_preserving_sub μ).absolutely_continuous
+  ae_strongly_measurable (λ p : G × G, L (f p.2) (g (p.1 / p.2))) (μ.prod μ) :=
+hf.mconvolution_integrand' L $ hg.mono' (quasi_measure_preserving_div μ).absolutely_continuous
 
-lemma measure_theory.integrable.convolution_integrand (hf : integrable f μ) (hg : integrable g μ) :
-  integrable (λ p : G × G, L (f p.2) (g (p.1 - p.2))) (μ.prod μ) :=
+@[to_additive]
+lemma measure_theory.integrable.mconvolution_integrand (hf : integrable f μ) (hg : integrable g μ) :
+  integrable (λ p : G × G, L (f p.2) (g (p.1 / p.2))) (μ.prod μ) :=
 begin
-  have h_meas : ae_strongly_measurable (λ (p : G × G), L (f p.2) (g (p.1 - p.2))) (μ.prod μ) :=
+  have h_meas : ae_strongly_measurable (λ (p : G × G), L (f p.2) (g (p.1 / p.2))) (μ.prod μ) :=
     hf.ae_strongly_measurable.convolution_integrand L hg.ae_strongly_measurable,
-  have h2_meas : ae_strongly_measurable (λ (y : G), ∫ (x : G), ∥L (f y) (g (x - y))∥ ∂μ) μ :=
+  have h2_meas : ae_strongly_measurable (λ (y : G), ∫ (x : G), ∥L (f y) (g (x / y))∥ ∂μ) μ :=
     h_meas.prod_swap.norm.integral_prod_right',
   simp_rw [integrable_prod_iff' h_meas],
-  refine ⟨eventually_of_forall (λ t, (L (f t)).integrable_comp (hg.comp_sub_right t)), _⟩,
+  refine ⟨eventually_of_forall (λ t, (L (f t)).integrable_comp (hg.comp_div_right t)), _⟩,
   refine integrable.mono' _ h2_meas (eventually_of_forall $
-    λ t, (_ : _ ≤ ∥L∥ * ∥f t∥ * ∫ x, ∥g (x - t)∥ ∂μ)),
-  { simp_rw [integral_sub_right_eq_self (λ t, ∥ g t ∥)],
+    λ t, (_ : _ ≤ ∥L∥ * ∥f t∥ * ∫ x, ∥g (x / t)∥ ∂μ)),
+  { simp_rw [integral_div_right_eq_self (λ t, ∥ g t ∥)],
     exact (hf.norm.const_mul _).mul_const _ },
   { simp_rw [← integral_mul_left],
     rw [real.norm_of_nonneg],
     { exact integral_mono_of_nonneg (eventually_of_forall $ λ t, norm_nonneg _)
-        ((hg.comp_sub_right t).norm.const_mul _) (eventually_of_forall $ λ t, L.le_op_norm₂ _ _) },
+        ((hg.comp_div_right t).norm.const_mul _) (eventually_of_forall $ λ t, L.le_op_norm₂ _ _) },
     exact integral_nonneg (λ x, norm_nonneg _) }
 end
 
 lemma measure_theory.integrable.ae_convolution_exists (hf : integrable f μ) (hg : integrable g μ) :
-  ∀ᵐ x ∂μ, convolution_exists_at f g x L μ :=
+  ∀ᵐ x ∂μ, mconvolution_exists_at f g x L μ :=
 ((integrable_prod_iff $ hf.ae_strongly_measurable.convolution_integrand L
   hg.ae_strongly_measurable).mp $ hf.convolution_integrand L hg).1
 
 end right
 
-variables [topological_space G] [topological_add_group G] [borel_space G]
+variables [topological_space G] [topological_group G] [borel_space G]
   [second_countable_topology G] [sigma_compact_space G]
 
-lemma has_compact_support.convolution_exists_at {x₀ : G}
-  (h : has_compact_support (λ t, L (f t) (g (x₀ - t)))) (hf : locally_integrable f μ)
-  (hg : continuous g) : convolution_exists_at f g x₀ L μ :=
-((((homeomorph.neg G).trans $ homeomorph.add_right x₀).compact_preimage.mpr h).bdd_above_image
-  hg.norm.continuous_on).convolution_exists_at' L is_closed_closure.measurable_set subset_closure
+@[to_additive]
+lemma has_compact_support.mconvolution_exists_at {x₀ : G}
+  (h : has_compact_support (λ t, L (f t) (g (x₀ / t)))) (hf : locally_integrable f μ)
+  (hg : continuous g) : mconvolution_exists_at f g x₀ L μ :=
+((((homeomorph.inv G).trans $ homeomorph.mul_right x₀).compact_preimage.mpr h).bdd_above_image
+  hg.norm.continuous_on).mconvolution_exists_at' L is_closed_closure.measurable_set subset_closure
   (hf h) hf.ae_strongly_measurable hg.ae_strongly_measurable
 
 lemma has_compact_support.convolution_exists_right
   (hcg : has_compact_support g) (hf : locally_integrable f μ) (hg : continuous g) :
-  convolution_exists f g L μ :=
+  mconvolution_exists f g L μ :=
 begin
   intro x₀,
-  refine has_compact_support.convolution_exists_at L _ hf hg,
-  refine (hcg.comp_homeomorph (homeomorph.sub_left x₀)).mono _,
-  refine λ t, mt (λ ht : g (x₀ - t) = 0, _),
+  refine has_compact_support.mconvolution_exists_at L _ hf hg,
+  refine (hcg.comp_homeomorph (homeomorph.div_left x₀)).mono _,
+  refine λ t, mt (λ ht : g (x₀ / t) = 0, _),
   simp_rw [ht, (L _).map_zero]
 end
 
-lemma has_compact_support.convolution_exists_left_of_continuous_right
+@[to_additive]
+lemma has_compact_support.mconvolution_exists_left_of_continuous_right
   (hcf : has_compact_support f) (hf : locally_integrable f μ) (hg : continuous g) :
-  convolution_exists f g L μ :=
+  mconvolution_exists f g L μ :=
 begin
   intro x₀,
-  refine has_compact_support.convolution_exists_at L _ hf hg,
+  refine has_compact_support.mconvolution_exists_at L _ hf hg,
   refine hcf.mono _,
   refine λ t, mt (λ ht : f t = 0, _),
   simp_rw [ht, L.map_zero₂]
@@ -286,11 +309,11 @@ end group
 
 section comm_group
 
-variables [add_comm_group G]
+variables [comm_group G]
 
 section measurable_group
 
-variables [has_measurable_add₂ G] [has_measurable_neg G] [is_add_left_invariant μ]
+variables [has_measurable_mul₂ G] [has_measurable_inv G] [is_mul_left_invariant μ]
 
 /-- A sufficient condition to prove that `f ⋆[L, μ] g` exists.
 We assume that the integrand has compact support and `g` is bounded on this support (note that
@@ -300,149 +323,167 @@ integrable on the support of the integrand, and that both functions are strongly
 This is a variant of `bdd_above.convolution_exists_at'` in an abelian group with a left-invariant
 measure. This allows us to state the boundedness and measurability of `g` in a more natural way. -/
 lemma bdd_above.convolution_exists_at [sigma_finite μ] {x₀ : G}
-  {s : set G} (hbg : bdd_above ((λ i, ∥g i∥) '' ((λ t, x₀ - t) ⁻¹' s)))
-  (hs : measurable_set s) (h2s : support (λ t, L (f t) (g (x₀ - t))) ⊆ s)
+  {s : set G} (hbg : bdd_above ((λ i, ∥g i∥) '' ((λ t, x₀ / t) ⁻¹' s)))
+  (hs : measurable_set s) (h2s : support (λ t, L (f t) (g (x₀ / t))) ⊆ s)
   (hf : integrable_on f s μ)
   (hmf : ae_strongly_measurable f μ)
   (hmg : ae_strongly_measurable g μ) :
-    convolution_exists_at f g x₀ L μ :=
+    mconvolution_exists_at f g x₀ L μ :=
 begin
   refine bdd_above.convolution_exists_at' L _ hs h2s hf hmf _,
   { simp_rw [← sub_eq_neg_add, hbg] },
   { exact hmg.mono' (map_sub_left_absolutely_continuous μ x₀) }
 end
 
-variables {L} [is_neg_invariant μ]
+variables {L} [is_inv_invariant μ]
 
-lemma convolution_exists_at_flip :
-  convolution_exists_at g f x L.flip μ ↔ convolution_exists_at f g x L μ :=
-by simp_rw [convolution_exists_at, ← integrable_comp_sub_left (λ t, L (f t) (g (x - t))) x,
-  sub_sub_cancel, flip_apply]
+@[to_additive]
+lemma mconvolution_exists_at_flip :
+  mconvolution_exists_at g f x L.flip μ ↔ mconvolution_exists_at f g x L μ :=
+by simp_rw [mconvolution_exists_at, ← integrable_comp_div_left (λ t, L (f t) (g (x / t))) x,
+  div_div_cancel, flip_apply]
 
-lemma convolution_exists_at.integrable_swap (h : convolution_exists_at f g x L μ) :
-  integrable (λ t, L (f (x - t)) (g t)) μ :=
-by { convert h.comp_sub_left x, simp_rw [sub_sub_self] }
+@[to_additive]
+lemma mconvolution_exists_at.integrable_swap (h : mconvolution_exists_at f g x L μ) :
+  integrable (λ t, L (f (x / t)) (g t)) μ :=
+by { convert h.comp_div_left x, simp_rw [div_div_self'] }
 
-lemma convolution_exists_at_iff_integrable_swap :
-  convolution_exists_at f g x L μ ↔ integrable (λ t, L (f (x - t)) (g t)) μ :=
-convolution_exists_at_flip.symm
+@[to_additive]
+lemma mconvolution_exists_at_iff_integrable_swap :
+  mconvolution_exists_at f g x L μ ↔ integrable (λ t, L (f (x / t)) (g t)) μ :=
+mconvolution_exists_at_flip.symm
 
 end measurable_group
 
-variables [topological_space G] [topological_add_group G] [borel_space G]
-  [second_countable_topology G] [is_add_left_invariant μ] [is_neg_invariant μ]
+variables [topological_space G] [topological_group G] [borel_space G]
+  [second_countable_topology G] [is_mul_left_invariant μ] [is_inv_invariant μ]
   [sigma_compact_space G]
 
-lemma has_compact_support.convolution_exists_left
+@[to_additive]
+lemma has_compact_support.mconvolution_exists_left
   (hcf : has_compact_support f) (hf : continuous f) (hg : locally_integrable g μ) :
-  convolution_exists f g L μ :=
-λ x₀, convolution_exists_at_flip.mp $ hcf.convolution_exists_right L.flip hg hf x₀
+  mconvolution_exists f g L μ :=
+λ x₀, mconvolution_exists_at_flip.mp $ hcf.mconvolution_exists_right L.flip hg hf x₀
 
-lemma has_compact_support.convolution_exists_right_of_continuous_left
+@[to_additive]
+lemma has_compact_support.mconvolution_exists_right_of_continuous_left
   (hcg : has_compact_support g) (hf : continuous f) (hg : locally_integrable g μ) :
-  convolution_exists f g L μ :=
-λ x₀, convolution_exists_at_flip.mp $
-  hcg.convolution_exists_left_of_continuous_right L.flip hg hf x₀
+  mconvolution_exists f g L μ :=
+λ x₀, mconvolution_exists_at_flip.mp $
+  hcg.mconvolution_exists_left_of_continuous_right L.flip hg hf x₀
 
 end comm_group
 
-end convolution_exists
+end mconvolution_exists
 
 variables [normed_space ℝ F] [complete_space F]
 
 /-- The convolution of two functions `f` and `g` with respect to a continuous bilinear map `L` and
-measure `μ`. It is defined to be `(f ⋆[L, μ] g) x = ∫ t, L (f t) (g (x - t)) ∂μ`. -/
+measure `μ`. It is defined to be `(f ⋆[L, μ] g) x = ∫ t, L (f t) (g (x / t)) ∂μ`. -/
 noncomputable def convolution [has_sub G] (f : G → E) (g : G → E') (L : E →L[𝕜] E' →L[𝕜] F)
   (μ : measure G . volume_tac) : G → F :=
-λ x, ∫ t, L (f t) (g (x - t)) ∂μ
+λ x, ∫ t, L (f t) (g (x / t)) ∂μ
 
-localized "notation f ` ⋆[`:67 L:67 `, ` μ:67 `] `:0 g:66 := convolution f g L μ" in convolution
-localized "notation f ` ⋆[`:67 L:67 `]`:0 g:66 := convolution f g L
+localized "notation f ` ⋆[`:67 L:67 `, ` μ:67 `] `:0 g:66 := mconvolution f g L μ" in convolution
+localized "notation f ` ⋆[`:67 L:67 `]`:0 g:66 := mconvolution f g L
   measure_theory.measure_space.volume" in convolution
-localized "notation f ` ⋆ `:67 g:66 := convolution f g (continuous_linear_map.lsmul ℝ ℝ)
+localized "notation f ` ⋆ `:67 g:66 := mconvolution f g (continuous_linear_map.lsmul ℝ ℝ)
   measure_theory.measure_space.volume" in convolution
 
-lemma convolution_def [has_sub G] : (f ⋆[L, μ] g) x = ∫ t, L (f t) (g (x - t)) ∂μ := rfl
+@[to_additive]
+lemma mconvolution_def [has_div G] : (f ⋆[L, μ] g) x = ∫ t, L (f t) (g (x / t)) ∂μ := rfl
 
 /-- The definition of convolution where the bilinear operator is scalar multiplication.
 Note: it often helps the elaborator to give the type of the convolution explicitly. -/
 lemma convolution_lsmul [has_sub G] {f : G → 𝕜} {g : G → F} :
-  (f ⋆[lsmul 𝕜 𝕜, μ] g : G → F) x = ∫ t, f t • g (x - t) ∂μ := rfl
+  (f ⋆[lsmul 𝕜 𝕜, μ] g : G → F) x = ∫ t, f t • g (x / t) ∂μ := rfl
 
 /-- The definition of convolution where the bilinear operator is multiplication. -/
-lemma convolution_lmul [has_sub G] [normed_space ℝ 𝕜] [complete_space 𝕜] {f : G → 𝕜} {g : G → 𝕜} :
-  (f ⋆[lmul 𝕜 𝕜, μ] g) x = ∫ t, f t * g (x - t) ∂μ := rfl
+@[to_additive /-" The definition of convolution where the bilinear operator is multiplication. "-/]
+lemma mconvolution_lmul [has_div G] [normed_space ℝ 𝕜] [complete_space 𝕜] {f : G → 𝕜} {g : G → 𝕜} :
+  (f ⋆[lmul 𝕜 𝕜, μ] g) x = ∫ t, f t * g (x / t) ∂μ := rfl
 
 section group
 
-variables {L} [add_group G]
+variables {L} [group G]
 
-lemma smul_convolution [smul_comm_class ℝ 𝕜 F]
+@[to_additive]
+lemma smul_mconvolution [smul_comm_class ℝ 𝕜 F]
   {y : 𝕜} : (y • f) ⋆[L, μ] g = y • (f ⋆[L, μ] g) :=
-by { ext, simp only [pi.smul_apply, convolution_def, ← integral_smul, L.map_smul₂] }
+by { ext, simp only [pi.smul_apply, mconvolution_def, ← integral_smul, L.map_smul₂] }
 
-lemma convolution_smul [smul_comm_class ℝ 𝕜 F]
+@[to_additive]
+lemma mconvolution_smul [smul_comm_class ℝ 𝕜 F]
   {y : 𝕜} : f ⋆[L, μ] (y • g) = y • (f ⋆[L, μ] g) :=
-by { ext, simp only [pi.smul_apply, convolution_def, ← integral_smul, (L _).map_smul] }
+by { ext, simp only [pi.smul_apply, mconvolution_def, ← integral_smul, (L _).map_smul] }
 
-lemma zero_convolution : 0 ⋆[L, μ] g = 0 :=
-by { ext, simp_rw [convolution_def, pi.zero_apply, L.map_zero₂, integral_zero] }
+@[to_additive]
+lemma zero_mconvolution : 0 ⋆[L, μ] g = 0 :=
+by { ext, simp_rw [mconvolution_def, pi.zero_apply, L.map_zero₂, integral_zero] }
 
-lemma convolution_zero : f ⋆[L, μ] 0 = 0 :=
-by { ext, simp_rw [convolution_def, pi.zero_apply, (L _).map_zero, integral_zero] }
+@[to_additive]
+lemma mconvolution_zero : f ⋆[L, μ] 0 = 0 :=
+by { ext, simp_rw [mconvolution_def, pi.zero_apply, (L _).map_zero, integral_zero] }
 
-lemma convolution_exists_at.distrib_add {x : G} (hfg : convolution_exists_at f g x L μ)
-  (hfg' : convolution_exists_at f g' x L μ) :
+@[to_additive]
+lemma mconvolution_exists_at.distrib_add {x : G} (hfg : mconvolution_exists_at f g x L μ)
+  (hfg' : mconvolution_exists_at f g' x L μ) :
   (f ⋆[L, μ] (g + g')) x = (f ⋆[L, μ] g) x + (f ⋆[L, μ] g') x :=
-by simp only [convolution_def, (L _).map_add, pi.add_apply, integral_add hfg hfg']
+by simp only [mconvolution_def, (L _).map_add, pi.add_apply, integral_add hfg hfg']
 
-lemma convolution_exists.distrib_add (hfg : convolution_exists f g L μ)
-  (hfg' : convolution_exists f g' L μ) : f ⋆[L, μ] (g + g') = f ⋆[L, μ] g + f ⋆[L, μ] g' :=
+@[to_additive]
+lemma mconvolution_exists.distrib_add (hfg : mconvolution_exists f g L μ)
+  (hfg' : mconvolution_exists f g' L μ) : f ⋆[L, μ] (g + g') = f ⋆[L, μ] g + f ⋆[L, μ] g' :=
 by { ext, exact (hfg x).distrib_add (hfg' x) }
 
-lemma convolution_exists_at.add_distrib {x : G} (hfg : convolution_exists_at f g x L μ)
-  (hfg' : convolution_exists_at f' g x L μ) :
+@[to_additive]
+lemma mconvolution_exists_at.add_distrib {x : G} (hfg : mconvolution_exists_at f g x L μ)
+  (hfg' : mconvolution_exists_at f' g x L μ) :
   ((f + f') ⋆[L, μ] g) x = (f ⋆[L, μ] g) x + (f' ⋆[L, μ] g) x :=
-by simp only [convolution_def, L.map_add₂, pi.add_apply, integral_add hfg hfg']
+by simp only [mconvolution_def, L.map_add₂, pi.add_apply, integral_add hfg hfg']
 
-lemma convolution_exists.add_distrib (hfg : convolution_exists f g L μ)
-  (hfg' : convolution_exists f' g L μ) : (f + f') ⋆[L, μ] g = f ⋆[L, μ] g + f' ⋆[L, μ] g :=
+@[to_additive]
+lemma mconvolution_exists.add_distrib (hfg : mconvolution_exists f g L μ)
+  (hfg' : mconvolution_exists f' g L μ) : (f + f') ⋆[L, μ] g = f ⋆[L, μ] g + f' ⋆[L, μ] g :=
 by { ext, exact (hfg x).add_distrib (hfg' x) }
 
 variables (L)
 
-lemma convolution_congr [has_measurable_add G] [has_measurable_neg G] [is_add_left_invariant μ]
-  [is_neg_invariant μ] (h1 : f =ᵐ[μ] f') (h2 : g =ᵐ[μ] g') :
+@[to_additive]
+lemma mconvolution_congr [has_measurable_mul G] [has_measurable_inv G] [is_mul_left_invariant μ]
+  [is_inv_invariant μ] (h1 : f =ᵐ[μ] f') (h2 : g =ᵐ[μ] g') :
   f ⋆[L, μ] g = f' ⋆[L, μ] g' :=
 begin
   ext x,
   apply integral_congr_ae,
-  exact (h1.prod_mk $ h2.comp_tendsto (map_sub_left_ae μ x).le).fun_comp ↿(λ x y, L x y)
+  exact (h1.prod_mk $ h2.comp_tendsto (map_div_left_ae μ x).le).fun_comp ↿(λ x y, L x y)
 end
 
-lemma support_convolution_subset_swap : support (f ⋆[L, μ] g) ⊆ support g + support f :=
+@[to_additive]
+lemma support_mconvolution_subset_swap : support (f ⋆[L, μ] g) ⊆ support g * support f :=
 begin
   intros x h2x,
   by_contra hx,
   apply h2x,
-  simp_rw [set.mem_add, not_exists, not_and_distrib, nmem_support] at hx,
-  rw [convolution_def],
+  simp_rw [set.mem_mul, not_exists, not_and_distrib, nmem_support] at hx,
+  rw [mconvolution_def],
   convert integral_zero G F,
   ext t,
-  rcases hx (x - t) t with h|h|h,
+  rcases hx (x / t) t with h|h|h,
   { rw [h, (L _).map_zero] },
   { rw [h, L.map_zero₂] },
-  { exact (h $ sub_add_cancel x t).elim }
+  { exact (h $ inv_mul_cancel' x t).elim }
 end
 
 variables [topological_space G]
-variables [topological_add_group G]
+variables [topological_group G]
 
-lemma has_compact_support.convolution [t2_space G] (hcf : has_compact_support f)
+@[to_additive]
+lemma has_compact_support.mconvolution [t2_space G] (hcf : has_compact_support f)
   (hcg : has_compact_support g) : has_compact_support (f ⋆[L, μ] g) :=
-compact_of_is_closed_subset (hcg.is_compact.add hcf) is_closed_closure $ closure_minimal
-  ((support_convolution_subset_swap L).trans $ add_subset_add subset_closure subset_closure)
-  (hcg.is_compact.add hcf).is_closed
+compact_of_is_closed_subset (hcg.is_compact.mul hcf) is_closed_closure $ closure_minimal
+  ((support_mconvolution_subset_swap L).trans $ mul_subset_mul subset_closure subset_closure)
+  (hcg.is_compact.mul hcf).is_closed
 
 variables [borel_space G] [second_countable_topology G]
 
@@ -454,19 +495,19 @@ lemma has_compact_support.continuous_convolution_right [locally_compact_space G]
 begin
   refine continuous_iff_continuous_at.mpr (λ x₀, _),
   obtain ⟨K, hK, h2K⟩ := exists_compact_mem_nhds x₀,
-  let K' := - tsupport g + K,
+  let K' := (tsupport g)⁻¹ * K,
   have hK' : is_compact K' := hcg.neg.add hK,
   have : ∀ᶠ x in 𝓝 x₀, ∀ᵐ (t : G) ∂μ,
-    ∥L (f t) (g (x - t))∥ ≤ K'.indicator (λ t, ∥L∥ * ∥f t∥ * (⨆ i, ∥g i∥)) t :=
+    ∥L (f t) (g (x / t))∥ ≤ K'.indicator (λ t, ∥L∥ * ∥f t∥ * (⨆ i, ∥g i∥)) t :=
   eventually_of_mem h2K (λ x hx, eventually_of_forall $
-    λ t, hcg.convolution_integrand_bound_right L hg hx),
+    λ t, hcg.mconvolution_integrand_bound_right L hg hx),
   refine continuous_at_of_dominated _ this _ _,
   { exact eventually_of_forall
-      (λ x, hf.ae_strongly_measurable.convolution_integrand_snd' L hg.ae_strongly_measurable) },
+      (λ x, hf.ae_strongly_measurable.mconvolution_integrand_snd' L hg.ae_strongly_measurable) },
   { rw [integrable_indicator_iff hK'.measurable_set],
     exact ((hf hK').norm.const_mul _).mul_const _ },
   { exact eventually_of_forall (λ t, (L.continuous₂.comp₂ continuous_const $
-      hg.comp $ continuous_id.sub $ by apply continuous_const).continuous_at) }
+      hg.comp $ continuous_id.div $ by apply continuous_const).continuous_at) }
 end
 
 /-- The convolution is continuous if one function is integrable and the other is bounded and
@@ -477,17 +518,17 @@ lemma bdd_above.continuous_convolution_right_of_integrable
 begin
   refine continuous_iff_continuous_at.mpr (λ x₀, _),
   have : ∀ᶠ x in 𝓝 x₀, ∀ᵐ (t : G) ∂μ,
-    ∥L (f t) (g (x - t))∥ ≤ ∥L∥ * ∥f t∥ * (⨆ i, ∥g i∥),
+    ∥L (f t) (g (x / t))∥ ≤ ∥L∥ * ∥f t∥ * (⨆ i, ∥g i∥),
   { refine eventually_of_forall (λ x, eventually_of_forall $ λ t, _),
     refine (L.le_op_norm₂ _ _).trans _,
-    exact mul_le_mul_of_nonneg_left (le_csupr hbg $ x - t)
+    exact mul_le_mul_of_nonneg_left (le_csupr hbg $ x / t)
       (mul_nonneg (norm_nonneg _) (norm_nonneg _)) },
   refine continuous_at_of_dominated _ this _ _,
   { exact eventually_of_forall
-      (λ x, hf.ae_strongly_measurable.convolution_integrand_snd' L hg.ae_strongly_measurable) },
+      (λ x, hf.ae_strongly_measurable.mconvolution_integrand_snd' L hg.ae_strongly_measurable) },
   { exact (hf.norm.const_mul _).mul_const _ },
   { exact eventually_of_forall (λ t, (L.continuous₂.comp₂ continuous_const $
-      hg.comp $ continuous_id.sub $ by apply continuous_const).continuous_at) }
+      hg.comp $ continuous_id.div $ by apply continuous_const).continuous_at) }
 end
 
 /-- A version of `has_compact_support.continuous_convolution_right` that works if `G` is
@@ -508,51 +549,58 @@ end group
 
 section comm_group
 
-variables [add_comm_group G]
+variables [comm_group G]
 
-lemma support_convolution_subset : support (f ⋆[L, μ] g) ⊆ support f + support g :=
-(support_convolution_subset_swap L).trans (add_comm _ _).subset
+@[to_additive]
+lemma support_mconvolution_subset : support (f ⋆[L, μ] g) ⊆ support f * support g :=
+(support_mconvolution_subset_swap L).trans (mul_comm _ _).subset
 
 variables [topological_space G]
-variables [topological_add_group G]
+variables [topological_group G]
 variables [borel_space G]
-variables [is_add_left_invariant μ]  [is_neg_invariant μ]
+variables [is_mul_left_invariant μ]  [is_inv_invariant μ]
 
 variable (L)
 /-- Commutativity of convolution -/
-lemma convolution_flip : g ⋆[L.flip, μ] f = f ⋆[L, μ] g :=
+@[to_additive /-" Commutativity of convolution "-/]
+lemma mconvolution_flip : g ⋆[L.flip, μ] f = f ⋆[L, μ] g :=
 begin
   ext1 x,
-  simp_rw [convolution_def],
+  simp_rw [mconvolution_def],
   rw [← integral_sub_left_eq_self _ μ x],
   simp_rw [sub_sub_self, flip_apply]
 end
 
 /-- The symmetric definition of convolution. -/
-lemma convolution_eq_swap : (f ⋆[L, μ] g) x = ∫ t, L (f (x - t)) (g t) ∂μ :=
-by { rw [← convolution_flip], refl }
+@[to_additive /-" The symmetric definition of convolution. "-/]
+lemma mconvolution_eq_swap : (f ⋆[L, μ] g) x = ∫ t, L (f (x / t)) (g t) ∂μ :=
+by { rw [← mconvolution_flip], refl }
 
 /-- The symmetric definition of convolution where the bilinear operator is scalar multiplication. -/
-lemma convolution_lsmul_swap {f : G → 𝕜} {g : G → F}:
-  (f ⋆[lsmul 𝕜 𝕜, μ] g : G → F) x = ∫ t, f (x - t) • g t ∂μ :=
-convolution_eq_swap _
+@[to_additive /-" The symmetric definition of convolution where the bilinear operator is scalar multiplication. "-/]
+lemma mconvolution_lsmul_swap {f : G → 𝕜} {g : G → F}:
+  (f ⋆[lsmul 𝕜 𝕜, μ] g : G → F) x = ∫ t, f (x / t) • g t ∂μ :=
+mconvolution_eq_swap _
 
 /-- The symmetric definition of convolution where the bilinear operator is multiplication. -/
-lemma convolution_lmul_swap [normed_space ℝ 𝕜] [complete_space 𝕜] {f : G → 𝕜} {g : G → 𝕜} :
-  (f ⋆[lmul 𝕜 𝕜, μ] g) x = ∫ t, f (x - t) * g t ∂μ :=
-convolution_eq_swap _
+@[to_additive /-" The symmetric definition of convolution where the bilinear operator is multiplication. "-/]
+lemma mconvolution_lmul_swap [normed_space ℝ 𝕜] [complete_space 𝕜] {f : G → 𝕜} {g : G → 𝕜} :
+  (f ⋆[lmul 𝕜 𝕜, μ] g) x = ∫ t, f (x / t) * g t ∂μ :=
+mconvolution_eq_swap _
 
 variables [second_countable_topology G]
 
-lemma has_compact_support.continuous_convolution_left [locally_compact_space G] [t2_space G]
+@[to_additive]
+lemma has_compact_support.continuous_mconvolution_left [locally_compact_space G] [t2_space G]
   (hcf : has_compact_support f) (hf : continuous f) (hg : locally_integrable g μ) :
     continuous (f ⋆[L, μ] g) :=
-by { rw [← convolution_flip], exact hcf.continuous_convolution_right L.flip hg hf }
+by { rw [← mconvolution_flip], exact hcf.continuous_mconvolution_right L.flip hg hf }
 
-lemma bdd_above.continuous_convolution_left_of_integrable
+@[to_additive]
+lemma bdd_above.continuous_mconvolution_left_of_integrable
   (hbf : bdd_above (range (λ x, ∥f x∥))) (hf : continuous f) (hg : integrable g μ) :
     continuous (f ⋆[L, μ] g) :=
-by { rw [← convolution_flip], exact hbf.continuous_convolution_right_of_integrable L.flip hg hf }
+by { rw [← mconvolution_flip], exact hbf.continuous_mconvolution_right_of_integrable L.flip hg hf }
 
 /-- A version of `has_compact_support.continuous_convolution_left` that works if `G` is
 not locally compact but requires that `g` is integrable. -/
@@ -576,20 +624,20 @@ lemma convolution_eq_right' {x₀ : G} {R : ℝ}
   (hf : support f ⊆ ball (0 : G) R)
   (hg : ∀ x ∈ ball x₀ R, g x = g x₀) : (f ⋆[L, μ] g) x₀ = ∫ t, L (f t) (g x₀) ∂μ :=
 begin
-  have h2 : ∀ t, L (f t) (g (x₀ - t)) = L (f t) (g x₀),
+  have h2 : ∀ t, L (f t) (g (x₀ / t)) = L (f t) (g x₀),
   { intro t, by_cases ht : t ∈ support f,
     { have h2t := hf ht,
       rw [mem_ball_zero_iff] at h2t,
-      specialize hg (x₀ - t),
+      specialize hg (x₀ / t),
       rw [sub_eq_add_neg, add_mem_ball_iff_norm, norm_neg, ← sub_eq_add_neg] at hg,
       rw [hg h2t] },
     { rw [nmem_support] at ht,
       simp_rw [ht, L.map_zero₂] } },
-  simp_rw [convolution_def, h2],
+  simp_rw [mconvolution_def, h2],
 end
 
 variables [borel_space G] [second_countable_topology G]
-variables [is_add_left_invariant μ] [sigma_finite μ]
+variables [is_mul_left_invariant μ] [sigma_finite μ]
 
 /-- Approximate `(f ⋆ g) x₀` if the support of the `f` is bounded within a ball, and `g` is near
 `g x₀` on a ball with the same radius around `x₀`. See `dist_convolution_le` for a special case.
@@ -604,7 +652,7 @@ lemma dist_convolution_le' {x₀ : G} {R ε : ℝ}
   (hg : ∀ x ∈ ball x₀ R, dist (g x) (g x₀) ≤ ε) :
   dist ((f ⋆[L, μ] g : G → F) x₀) (∫ t, L (f t) (g x₀) ∂μ) ≤ ∥L∥ * ∫ x, ∥f x∥ ∂μ * ε :=
 begin
-  have hfg : convolution_exists_at f g x₀ L μ,
+  have hfg : mconvolution_exists_at f g x₀ L μ,
   { refine bdd_above.convolution_exists_at L _ metric.is_open_ball.measurable_set
     (subset_trans _ hf) hif.integrable_on hif.ae_strongly_measurable hmg,
     swap, { refine λ t, mt (λ ht : f t = 0, _), simp_rw [ht, L.map_zero₂] },
@@ -613,17 +661,17 @@ begin
     rintro _ ⟨x, hx, rfl⟩,
     refine norm_le_norm_add_const_of_dist_le (hg x _),
     rwa [mem_ball_iff_norm, norm_sub_rev, ← mem_ball_zero_iff] },
-  have h2 : ∀ t, dist (L (f t) (g (x₀ - t))) (L (f t) (g x₀)) ≤ ∥L (f t)∥ * ε,
+  have h2 : ∀ t, dist (L (f t) (g (x₀ / t))) (L (f t) (g x₀)) ≤ ∥L (f t)∥ * ε,
   { intro t, by_cases ht : t ∈ support f,
     { have h2t := hf ht,
       rw [mem_ball_zero_iff] at h2t,
-      specialize hg (x₀ - t),
+      specialize hg (x₀ / t),
       rw [sub_eq_add_neg, add_mem_ball_iff_norm, norm_neg, ← sub_eq_add_neg] at hg,
       refine ((L (f t)).dist_le_op_norm _ _).trans _,
       exact mul_le_mul_of_nonneg_left (hg h2t) (norm_nonneg _) },
     { rw [nmem_support] at ht,
       simp_rw [ht, L.map_zero₂, L.map_zero, norm_zero, zero_mul, dist_self] } },
-  simp_rw [convolution_def],
+  simp_rw [mconvolution_def],
   simp_rw [dist_eq_norm] at h2 ⊢,
   rw [← integral_sub hfg.integrable], swap, { exact (L.flip (g x₀)).integrable_comp hif },
   refine (norm_integral_le_of_norm_le ((L.integrable_comp hif).norm.mul_const ε)
@@ -693,7 +741,7 @@ variables {a : G} {φ : cont_diff_bump_of_inner (0 : G)}
 /-- If `φ` is a bump function, compute `(φ ⋆ g) x₀` if `g` is constant on `metric.ball x₀ φ.R`. -/
 lemma convolution_eq_right {x₀ : G}
   (hg : ∀ x ∈ ball x₀ φ.R, g x = g x₀) : (φ ⋆[lsmul ℝ ℝ, μ] g : G → E') x₀ = integral μ φ • g x₀ :=
-by simp_rw [convolution_eq_right' _ φ.support_eq.subset hg, lsmul_apply, integral_smul_const]
+by simp_rw [mconvolution_eq_right' _ φ.support_eq.subset hg, lsmul_apply, integral_smul_const]
 
 variables [borel_space G]
 variables [is_locally_finite_measure μ] [is_open_pos_measure μ]
@@ -702,10 +750,10 @@ variables [finite_dimensional ℝ G]
 /-- If `φ` is a normed bump function, compute `φ ⋆ g` if `g` is constant on `metric.ball x₀ φ.R`. -/
 lemma normed_convolution_eq_right {x₀ : G}
   (hg : ∀ x ∈ ball x₀ φ.R, g x = g x₀) : (φ.normed μ ⋆[lsmul ℝ ℝ, μ] g : G → E') x₀ = g x₀ :=
-by { simp_rw [convolution_eq_right' _ φ.support_normed_eq.subset hg, lsmul_apply],
+by { simp_rw [mconvolution_eq_right' _ φ.support_normed_eq.subset hg, lsmul_apply],
   exact integral_normed_smul φ μ (g x₀) }
 
-variables [is_add_left_invariant μ]
+variables [is_mul_left_invariant μ]
 
 /-- If `φ` is a normed bump function, approximate `(φ ⋆ g) x₀` if `g` is near `g x₀` on a ball with
 radius `φ.R` around `x₀`. -/
@@ -723,7 +771,7 @@ lemma convolution_tendsto_right' {ι} {φ : ι → cont_diff_bump_of_inner (0 : 
   (hmg : ae_strongly_measurable g μ) {x₀ : G} (hcg : continuous_at g x₀) :
   tendsto (λ i, ((λ x, (φ i).normed μ x) ⋆[lsmul ℝ ℝ, μ] g : G → E') x₀) l (𝓝 (g x₀)) :=
 begin
-  refine convolution_tendsto_right (λ i, (φ i).nonneg_normed) (λ i, (φ i).integral_normed)
+  refine mconvolution_tendsto_right (λ i, (φ i).nonneg_normed) (λ i, (φ i).integral_normed)
     _ hmg hcg,
   rw [normed_group.tendsto_nhds_zero] at hφ,
   rw [tendsto_small_sets_iff],
@@ -740,7 +788,7 @@ lemma convolution_tendsto_right {ι} {φ : ι → cont_diff_bump_of_inner (0 : G
   {l : filter ι} (hφ : tendsto (λ i, (φ i).R) l (𝓝 0))
   (hg : continuous g) (x₀ : G) :
   tendsto (λ i, ((λ x, (φ i).normed μ x) ⋆[lsmul ℝ ℝ, μ] g : G → E') x₀) l (𝓝 (g x₀)) :=
-convolution_tendsto_right' hφ hg.ae_strongly_measurable hg.continuous_at
+mconvolution_tendsto_right' hφ hg.ae_strongly_measurable hg.continuous_at
 
 end cont_diff_bump_of_inner
 
@@ -778,14 +826,14 @@ variables {ν : measure G} [sigma_finite ν] [is_add_right_invariant ν]
 To do: prove that `hi` follows from simpler conditions. -/
 lemma convolution_assoc (hL : ∀ (x : E) (y : E') (z : E''), L₂ (L x y) z = L₃ x (L₄ y z))
   {x₀ : G}
-  (h₄ : convolution_exists g k L₄ ν)
-  (h₁ : convolution_exists f g L μ)
-  (hi : integrable (uncurry (λ x y, (L₃ (f y)) ((L₄ (g (x - y))) (k (x₀ - x))))) (ν.prod μ)) :
+  (h₄ : mconvolution_exists g k L₄ ν)
+  (h₁ : mconvolution_exists f g L μ)
+  (hi : integrable (uncurry (λ x y, (L₃ (f y)) ((L₄ (g (x / y))) (k (x₀ / x))))) (ν.prod μ)) :
   ((f ⋆[L, μ] g) ⋆[L₂, ν] k) x₀ = (f ⋆[L₃, μ] (g ⋆[L₄, ν] k)) x₀ :=
 begin
-  have h1 := λ t, (L₂.flip (k (x₀ - t))).integral_comp_comm (h₁ t),
+  have h1 := λ t, (L₂.flip (k (x₀ / t))).integral_comp_comm (h₁ t),
   dsimp only [flip_apply] at h1,
-  simp_rw [convolution_def, ← (L₃ (f _)).integral_comp_comm (h₄ (x₀ - _)), ← h1, hL],
+  simp_rw [convolution_def, ← (L₃ (f _)).integral_comp_comm (h₄ (x₀ / _)), ← h1, hL],
   rw [integral_integral_swap hi],
   congr', ext t,
   rw [eq_comm, ← integral_sub_right_eq_self _ t],
@@ -798,12 +846,13 @@ end assoc
 variables [normed_group G] [borel_space G]
 variables [second_countable_topology G] [sigma_compact_space G]
 
-lemma convolution_precompR_apply {g : G → E'' →L[𝕜] E'}
+@[to_additive]
+lemma mconvolution_precompR_apply {g : G → E'' →L[𝕜] E'}
   (hf : locally_integrable f μ) (hcg : has_compact_support g) (hg : continuous g)
   (x₀ : G) (x : E'') : (f ⋆[L.precompR E'', μ] g) x₀ x = (f ⋆[L, μ] (λ a, g a x)) x₀  :=
 begin
-  have := hcg.convolution_exists_right (L.precompR E'') hf hg x₀,
-  simp_rw [convolution_def, continuous_linear_map.integral_apply this],
+  have := hcg.mconvolution_exists_right (L.precompR E'') hf hg x₀,
+  simp_rw [mconvolution_def, continuous_linear_map.integral_apply this],
   refl,
 end
 
@@ -818,36 +867,37 @@ lemma has_compact_support.has_fderiv_at_convolution_right
   has_fderiv_at (f ⋆[L, μ] g) ((f ⋆[L.precompR G, μ] fderiv 𝕜 g) x₀) x₀ :=
 begin
   set L' := L.precompR G,
-  have h1 : ∀ᶠ x in 𝓝 x₀, ae_strongly_measurable (λ t, L (f t) (g (x - t))) μ :=
+  have h1 : ∀ᶠ x in 𝓝 x₀, ae_strongly_measurable (λ t, L (f t) (g (x / t))) μ :=
   eventually_of_forall
-    (hf.ae_strongly_measurable.convolution_integrand_snd L hg.continuous.ae_strongly_measurable),
-  have h2 : ∀ x, ae_strongly_measurable (λ t, L' (f t) (fderiv 𝕜 g (x - t))) μ,
-  { exact hf.ae_strongly_measurable.convolution_integrand_snd L'
+    (hf.ae_strongly_measurable.mconvolution_integrand_snd L hg.continuous.ae_strongly_measurable),
+  have h2 : ∀ x, ae_strongly_measurable (λ t, L' (f t) (fderiv 𝕜 g (x / t))) μ,
+  { exact hf.ae_strongly_measurable.mconvolution_integrand_snd L'
       (hg.continuous_fderiv le_rfl).ae_strongly_measurable },
-  have h3 : ∀ x t, has_fderiv_at (λ x, g (x - t)) (fderiv 𝕜 g (x - t)) x,
+  have h3 : ∀ x t, has_fderiv_at (λ x, g (x / t)) (fderiv 𝕜 g (x / t)) x,
   { intros x t,
     simpa using (hg.differentiable le_rfl).differentiable_at.has_fderiv_at.comp x
-      ((has_fderiv_at_id x).sub (has_fderiv_at_const t x)) },
-  let K' := - tsupport (fderiv 𝕜 g) + closed_ball x₀ 1,
+      ((has_fderiv_at_id x).div (has_fderiv_at_const t x)) },
+  let K' := (tsupport (fderiv 𝕜 g))⁻¹ * closed_ball x₀ 1,
   have hK' : is_compact K' := (hcg.fderiv 𝕜).neg.add (is_compact_closed_ball x₀ 1),
   refine has_fderiv_at_integral_of_dominated_of_fderiv_le
     zero_lt_one h1 _ (h2 x₀) _ _ _,
   { exact K'.indicator (λ t, ∥L'∥ * ∥f t∥ * (⨆ x, ∥fderiv 𝕜 g x∥)) },
-  { exact hcg.convolution_exists_right L hf hg.continuous x₀ },
+  { exact hcg.mconvolution_exists_right L hf hg.continuous x₀ },
   { refine eventually_of_forall (λ t x hx, _),
-    exact (hcg.fderiv 𝕜).convolution_integrand_bound_right L'
+    exact (hcg.fderiv 𝕜).mconvolution_integrand_bound_right L'
       (hg.continuous_fderiv le_rfl) (ball_subset_closed_ball hx) },
   { rw [integrable_indicator_iff hK'.measurable_set],
     exact ((hf hK').norm.const_mul _).mul_const _ },
   { exact eventually_of_forall (λ t x hx, (L _).has_fderiv_at.comp x (h3 x t)) },
 end
 
-lemma has_compact_support.has_fderiv_at_convolution_left [is_neg_invariant μ]
+@[to_additive]
+lemma has_compact_support.has_fderiv_at_mconvolution_left [is_inv_invariant μ]
   (hcf : has_compact_support f) (hf : cont_diff 𝕜 1 f) (hg : locally_integrable g μ) (x₀ : G) :
   has_fderiv_at (f ⋆[L, μ] g) ((fderiv 𝕜 f ⋆[L.precompL G, μ] g) x₀) x₀ :=
 begin
-  simp only [← convolution_flip] {single_pass := tt},
-  exact hcf.has_fderiv_at_convolution_right L.flip hg hf x₀,
+  simp only [← mconvolution_flip] {single_pass := tt},
+  exact hcf.has_fderiv_at_mconvolution_right L.flip hg hf x₀,
 end
 
 lemma has_compact_support.cont_diff_convolution_right [finite_dimensional 𝕜 G]
@@ -856,13 +906,13 @@ lemma has_compact_support.cont_diff_convolution_right [finite_dimensional 𝕜 G
 begin
   induction n using with_top.nat_induction with n ih ih generalizing g,
   { rw [cont_diff_zero] at hg ⊢,
-    exact hcg.continuous_convolution_right L hf hg },
+    exact hcg.continuous_mconvolution_right L hf hg },
   { have h : ∀ x, has_fderiv_at (f ⋆[L, μ] g) ((f ⋆[L.precompR G, μ] fderiv 𝕜 g) x) x :=
-      hcg.has_fderiv_at_convolution_right L hf hg.one_of_succ,
+      hcg.has_fderiv_at_mconvolution_right L hf hg.one_of_succ,
     rw cont_diff_succ_iff_fderiv_apply,
     split,
     { exact λ x₀, ⟨_, h x₀⟩ },
-    { simp_rw [fderiv_eq h, convolution_precompR_apply L hf (hcg.fderiv 𝕜)
+    { simp_rw [fderiv_eq h, mconvolution_precompR_apply L hf (hcg.fderiv 𝕜)
         (hg.one_of_succ.continuous_fderiv le_rfl)],
       intro x,
       refine ih _ _,
@@ -873,7 +923,8 @@ begin
   { rw [cont_diff_top] at hg ⊢, exact λ n, ih n hcg (hg n) }
 end
 
-lemma has_compact_support.cont_diff_convolution_left [finite_dimensional 𝕜 G] [is_neg_invariant μ]
+@[to_additive]
+lemma has_compact_support.cont_diff_mconvolution_left [finite_dimensional 𝕜 G] [is_inv_invariant μ]
   (hcf : has_compact_support f) (hf : cont_diff 𝕜 n f) (hg : locally_integrable g μ) :
   cont_diff 𝕜 n (f ⋆[L, μ] g) :=
 by { rw [← convolution_flip], exact hcf.cont_diff_convolution_right L.flip hg hf }
@@ -892,25 +943,27 @@ variables {n : with_top ℕ}
 variables (L : E →L[𝕜] E' →L[𝕜] F)
 variables [complete_space F]
 variables {μ : measure 𝕜}
-variables [is_add_left_invariant μ] [sigma_finite μ]
+variables [is_mul_left_invariant μ] [sigma_finite μ]
 
-lemma has_compact_support.has_deriv_at_convolution_right
+@[to_additive]
+lemma has_compact_support.has_deriv_at_mconvolution_right
   (hf : locally_integrable f₀ μ) (hcg : has_compact_support g₀) (hg : cont_diff 𝕜 1 g₀)
   (x₀ : 𝕜) :
   has_deriv_at (f₀ ⋆[L, μ] g₀) ((f₀ ⋆[L, μ] deriv g₀) x₀) x₀ :=
 begin
-  convert (hcg.has_fderiv_at_convolution_right L hf hg x₀).has_deriv_at,
-  rw [convolution_precompR_apply L hf (hcg.fderiv 𝕜) (hg.continuous_fderiv le_rfl)],
+  convert (hcg.has_fderiv_at_mconvolution_right L hf hg x₀).has_deriv_at,
+  rw [mconvolution_precompR_apply L hf (hcg.fderiv 𝕜) (hg.continuous_fderiv le_rfl)],
   refl,
 end
 
-lemma has_compact_support.has_deriv_at_convolution_left [is_neg_invariant μ]
+@[to_additive]
+lemma has_compact_support.has_deriv_at_mconvolution_left [is_inv_invariant μ]
   (hcf : has_compact_support f₀) (hf : cont_diff 𝕜 1 f₀)
   (hg : locally_integrable g₀ μ) (x₀ : 𝕜) :
   has_deriv_at (f₀ ⋆[L, μ] g₀) ((deriv f₀ ⋆[L, μ] g₀) x₀) x₀ :=
 begin
-  simp only [← convolution_flip] {single_pass := tt},
-  exact hcf.has_deriv_at_convolution_right L.flip hg hf x₀,
+  simp only [← mconvolution_flip] {single_pass := tt},
+  exact hcf.has_deriv_at_mconvolution_right L.flip hg hf x₀,
 end
 
 end real


### PR DESCRIPTION
Unfortunately `@[to_additive]` does not seem able to translate convolutions, since it attempts to change the multiplicative structure of the field `𝕜` to an additive version. So this PR will not be ready to merge until we improve `to_additive` (and really, we should only do that after switching to Lean 4).

---

- [x] depends on: #13540

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
