### PR TITLE
[Merged by Bors] - feat(data/zmod/quotient): Multiplicative version of `zmultiples_quotient_stabilizer_equiv`

### DIFF
--- a/src/data/zmod/quotient.lean
+++ b/src/data/zmod/quotient.lean
@@ -91,3 +91,22 @@ lemma zmultiples_quotient_stabilizer_equiv_symm_apply (n : zmod (minimal_period 
 rfl
 
 end add_action
+
+namespace mul_action
+
+open subgroup function
+
+variables {α β : Type*} [group α] (a : α) [mul_action α β] (b : β)
+
+/-- The quotient `(a ^ ℤ) ⧸ (stabilizer b)` is cyclic of order `minimal_period ((•) a) b`. -/
+noncomputable def zpowers_quotient_stabilizer_equiv :
+  zpowers a ⧸ stabilizer (zpowers a) b ≃* multiplicative (zmod (minimal_period ((•) a) b)) :=
+let f := add_action.zmultiples_quotient_stabilizer_equiv (additive.of_mul a) b in
+⟨f.to_fun, f.inv_fun, f.left_inv, f.right_inv, f.map_add'⟩
+
+lemma zpowers_quotient_stabilizer_equiv_symm_apply (n : zmod (minimal_period ((•) a) b)) :
+  (zpowers_quotient_stabilizer_equiv a b).symm n =
+    (⟨a, mem_zpowers a⟩ : zpowers a) ^ (n : ℤ) :=
+rfl
+
+end mul_action


### PR DESCRIPTION
This PR adds a multiplicative version of `zmultiples_quotient_stabilizer_equiv`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
