### PR TITLE
[Merged by Bors] - ci(gitpod): do not rerun get-cache if a workspace is reloaded

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -6,4 +6,5 @@ vscode:
     - jroesch.lean
 
 tasks:
-  - command: . /home/gitpod/.profile && leanproject get-cache --fallback=download-all
+  - init: leanproject get-cache --fallback=download-all
+    command: . /home/gitpod/.profile

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -6,5 +6,5 @@ vscode:
     - jroesch.lean
 
 tasks:
-  - init: leanproject get-cache --fallback=download-all
+  - init: leanpkg config && leanproject get-cache --fallback=download-all
     command: . /home/gitpod/.profile


### PR DESCRIPTION
Instead, only run it at workspace start. This prevents it clobbering local builds created with `lean --make src` or similar.

I have no idea why the `. /home/gitpod/.profile` line is there, so I've left it to run in the same phase as before.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
