### PR TITLE
[Merged by Bors] - feat(combinatorics/simple_graph/hasse): Hasse diagram and path graph

### DIFF
--- a/src/combinatorics/simple_graph/basic.lean
+++ b/src/combinatorics/simple_graph/basic.lean
@@ -76,6 +76,8 @@ finitely many vertices.
 open finset
 universes u v w
 
+variables {α : Type*}
+
 /--
 A simple graph is an irreflexive symmetric relation `adj` on a vertex type `V`.
 The relation describes which pairs of vertices are adjacent.
@@ -88,6 +90,9 @@ structure simple_graph (V : Type u) :=
 (symm : symmetric adj . obviously)
 (loopless : irreflexive adj . obviously)
 
+noncomputable instance {V : Type u} [fintype V] : fintype (simple_graph V) :=
+by { classical, exact fintype.of_injective simple_graph.adj simple_graph.ext }
+
 /--
 Construct the simple graph induced by the given relation. It
 symmetrizes the relation and makes it irreflexive.
@@ -97,12 +102,20 @@ def simple_graph.from_rel {V : Type u} (r : V → V → Prop) : simple_graph V :
   symm := λ a b ⟨hn, hr⟩, ⟨hn.symm, hr.symm⟩,
   loopless := λ a ⟨hn, _⟩, hn rfl }
 
-noncomputable instance {V : Type u} [fintype V] : fintype (simple_graph V) :=
-by { classical, exact fintype.of_injective simple_graph.adj simple_graph.ext }
+/-- Construct the simple graph induced by a given irreflexive relation. It symmetrizes the relation.
+-/
+def simple_graph.from_irrefl_rel (r : α → α → Prop) [is_irrefl α r] : simple_graph α :=
+{ adj := λ a b, r a b ∨ r b a,
+  symm := λ a b, or.symm,
+  loopless := λ a h, h.elim (irrefl _) (irrefl _) }
 
 @[simp]
 lemma simple_graph.from_rel_adj {V : Type u} (r : V → V → Prop) (v w : V) :
   (simple_graph.from_rel r).adj v w ↔ v ≠ w ∧ (r v w ∨ r w v) :=
+iff.rfl
+
+@[simp] lemma simple_graph.from_irrefl_rel_adj {r : α → α → Prop} [is_irrefl α r] {a b : α} :
+  (simple_graph.from_irrefl_rel r).adj a b ↔ r a b ∨ r b a :=
 iff.rfl
 
 /-- The complete graph on a type `V` is the simple graph with all pairs of distinct vertices
@@ -137,7 +150,7 @@ namespace simple_graph
 variables {V : Type u} {W : Type v} {X : Type w} (G : simple_graph V) (G' : simple_graph W)
   {a b c u v w : V} {e : sym2 V}
 
-@[simp] lemma irrefl {v : V} : ¬G.adj v v := G.loopless v
+@[simp] protected lemma irrefl {v : V} : ¬G.adj v v := G.loopless v
 
 lemma adj_comm (u v : V) : G.adj u v ↔ G.adj v u := ⟨λ x, G.symm x, λ x, G.symm x⟩
 

--- a/src/combinatorics/simple_graph/basic.lean
+++ b/src/combinatorics/simple_graph/basic.lean
@@ -76,8 +76,6 @@ finitely many vertices.
 open finset
 universes u v w
 
-variables {α : Type*}
-
 /--
 A simple graph is an irreflexive symmetric relation `adj` on a vertex type `V`.
 The relation describes which pairs of vertices are adjacent.
@@ -102,20 +100,9 @@ def simple_graph.from_rel {V : Type u} (r : V → V → Prop) : simple_graph V :
   symm := λ a b ⟨hn, hr⟩, ⟨hn.symm, hr.symm⟩,
   loopless := λ a ⟨hn, _⟩, hn rfl }
 
-/-- Construct the simple graph induced by a given irreflexive relation. It symmetrizes the relation.
--/
-def simple_graph.from_irrefl_rel (r : α → α → Prop) [is_irrefl α r] : simple_graph α :=
-{ adj := λ a b, r a b ∨ r b a,
-  symm := λ a b, or.symm,
-  loopless := λ a h, h.elim (irrefl _) (irrefl _) }
-
 @[simp]
 lemma simple_graph.from_rel_adj {V : Type u} (r : V → V → Prop) (v w : V) :
   (simple_graph.from_rel r).adj v w ↔ v ≠ w ∧ (r v w ∨ r w v) :=
-iff.rfl
-
-@[simp] lemma simple_graph.from_irrefl_rel_adj {r : α → α → Prop} [is_irrefl α r] {a b : α} :
-  (simple_graph.from_irrefl_rel r).adj a b ↔ r a b ∨ r b a :=
 iff.rfl
 
 /-- The complete graph on a type `V` is the simple graph with all pairs of distinct vertices

--- a/src/combinatorics/simple_graph/connectivity.lean
+++ b/src/combinatorics/simple_graph/connectivity.lean
@@ -942,7 +942,8 @@ begin
   exact h.elim (λ q, hp q.to_path),
 end
 
-@[refl] protected lemma reachable.refl {u : V} : G.reachable u u := by { fsplit, refl }
+@[refl] protected lemma reachable.refl (u : V) : G.reachable u u := by { fsplit, refl }
+protected lemma reachable.rfl {u : V} : G.reachable u u := reachable.refl _
 
 @[symm] protected lemma reachable.symm {u v : V} (huv : G.reachable u v) : G.reachable v u :=
 huv.elim (λ p, ⟨p.reverse⟩)
@@ -986,7 +987,7 @@ of `h.preconnected u v`. -/
 @[protect_proj]
 structure connected : Prop :=
 (preconnected : G.preconnected)
-(nonempty : nonempty V)
+[nonempty : nonempty V]
 
 instance : has_coe_to_fun G.connected (λ _, Π (u v : V), G.reachable u v) :=
 ⟨λ h, h.preconnected⟩

--- a/src/combinatorics/simple_graph/hasse.lean
+++ b/src/combinatorics/simple_graph/hasse.lean
@@ -1,0 +1,72 @@
+/-
+Copyright (c) 2022 Yaël Dillies. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Yaël Dillies
+-/
+import combinatorics.simple_graph.connectivity
+import data.fin.succ_pred
+import order.succ_pred.relation
+
+/-!
+# The Hasse diagram as a graph
+
+This file defines the Hasse diagram of an order (graph of `covby`, the covering relation) and the
+path graph on `n` vertices.
+
+## Main declarations
+
+* `simple_graph.hasse`: Hasse diagram of an order.
+* `simple_graph.path_graph`: Path graph on `n` vertices.
+-/
+
+open order order_dual relation
+
+namespace simple_graph
+variables (α β : Type*)
+
+section preorder
+variables [preorder α] [preorder β]
+
+/-- The Hasse diagram of an order as a simple graph. The graph of the covering relation. -/
+def hasse : simple_graph α := from_irrefl_rel covby
+
+variables {α β} {a b : α}
+
+@[simp] lemma hasse_adj : (hasse α).adj a b ↔ a ⋖ b ∨ b ⋖ a := iff.rfl
+
+/-- `αᵒᵈ` and `α` have the same Hasse diagram. -/
+def hasse_dual_iso : hasse αᵒᵈ ≃g hasse α :=
+{ map_rel_iff' := λ a b, by simp [or_comm],
+  ..of_dual }
+
+@[simp] lemma hasse_dual_iso_apply (a : αᵒᵈ) : hasse_dual_iso a = of_dual a := rfl
+@[simp] lemma hasse_dual_iso_symm_apply (a : α) : hasse_dual_iso.symm a = to_dual a := rfl
+
+end preorder
+
+section linear_order
+variables [linear_order α]
+
+lemma hasse_preconnected_of_succ [succ_order α] [is_succ_archimedean α] : (hasse α).preconnected :=
+λ a b, begin
+  rw reachable_iff_refl_trans_gen,
+  exact refl_trans_gen_of_succ _ (λ c hc, or.inl $ covby_succ_of_not_is_max hc.2.not_is_max)
+    (λ c hc, or.inr $ covby_succ_of_not_is_max hc.2.not_is_max),
+end
+
+lemma hasse_preconnected_of_pred [pred_order α] [is_pred_archimedean α] : (hasse α).preconnected :=
+λ a b, begin
+  rw [reachable_iff_refl_trans_gen, ←refl_trans_gen_swap],
+  exact refl_trans_gen_of_pred _ (λ c hc, or.inl $ pred_covby_of_not_is_min hc.1.not_is_min)
+    (λ c hc, or.inr $ pred_covby_of_not_is_min hc.1.not_is_min),
+end
+
+end linear_order
+
+/-- The path graph on `n` vertices. -/
+def path_graph (n : ℕ) : simple_graph (fin n) := hasse _
+
+lemma path_graph_preconnected (n : ℕ) : (path_graph n).preconnected := hasse_preconnected_of_succ _
+lemma path_graph_connected (n : ℕ) : (path_graph (n + 1)).connected := ⟨path_graph_preconnected _⟩
+
+end simple_graph

--- a/src/combinatorics/simple_graph/hasse.lean
+++ b/src/combinatorics/simple_graph/hasse.lean
@@ -28,7 +28,10 @@ section preorder
 variables [preorder α] [preorder β]
 
 /-- The Hasse diagram of an order as a simple graph. The graph of the covering relation. -/
-def hasse : simple_graph α := from_irrefl_rel covby
+def hasse : simple_graph α :=
+{ adj := λ a b, a ⋖ b ∨ b ⋖ a,
+  symm := λ a b, or.symm,
+  loopless := λ a h, h.elim (irrefl _) (irrefl _) }
 
 variables {α β} {a b : α}
 


### PR DESCRIPTION
Define the Hasse diagram of an order and the path graph on `n` vertices as the Hasse diagram of `fin n`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
Feat a stupidly slick proof that the path graph is connected, thanks to the combined work on `succ_order` of @fpvandoorn's, @ericrbg and myself (and of course @kmill's connectivity API!).

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
