### PR TITLE
[Merged by Bors] - refactor(set_theory/game/pgame): Remove `pgame.omega`

### DIFF
--- a/src/set_theory/game/pgame.lean
+++ b/src/set_theory/game/pgame.lean
@@ -1199,9 +1199,6 @@ by { rw zero_lt, use default, rintros ⟨⟩ }
 @[simp] theorem neg_star : -star = star :=
 by simp [star]
 
-/-- The pre-game `ω`. (In fact all ordinals have game and surreal representatives.) -/
-def omega : pgame := ⟨ulift ℕ, pempty, λ n, ↑n.1, pempty.elim⟩
-
 @[simp] theorem zero_lt_one : (0 : pgame) < 1 :=
 by { rw zero_lt, use default, rintro ⟨⟩ }
 

--- a/src/set_theory/game/winner.lean
+++ b/src/set_theory/game/winner.lean
@@ -34,8 +34,6 @@ theorem one_left_wins : left_wins 1 :=
 ⟨by { rw lt_def_le, tidy }, by rw le_def; tidy⟩
 
 theorem star_first_wins : first_wins star := ⟨zero_lt_star, star_lt_zero⟩
-theorem omega_left_wins : left_wins omega :=
-⟨by { rw lt_def_le, exact or.inl ⟨ulift.up 0, by tidy⟩ }, by rw le_def; tidy⟩
 
 lemma winner_cases (G : pgame) : G.left_wins ∨ G.right_wins ∨ G.first_loses ∨ G.first_wins :=
 begin

--- a/src/set_theory/surreal/basic.lean
+++ b/src/set_theory/surreal/basic.lean
@@ -187,10 +187,6 @@ theorem numeric_nat : Π (n : ℕ), numeric n
 | 0 := numeric_zero
 | (n + 1) := (numeric_nat n).add numeric_one
 
-/-- The pre-game omega is numeric. -/
-theorem numeric_omega : numeric omega :=
-⟨by rintros ⟨⟩ ⟨⟩, λ i, numeric_nat i.down, by rintros ⟨⟩⟩
-
 /-- The pre-game `half` is numeric. -/
 theorem numeric_half : numeric half :=
 begin


### PR DESCRIPTION
This barely had any API to begin with. Thanks to `ordinal.to_pgame`, it is now entirely redundant.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
