### PR TITLE
[Merged by Bors] - refactor(ring_theory/*): Remove unnecessary commutativity assumptions

### DIFF
--- a/src/ring_theory/artinian.lean
+++ b/src/ring_theory/artinian.lean
@@ -373,7 +373,7 @@ theorem is_artinian_span_of_finite (R) {M} [ring R] [add_comm_group M] [module R
   [is_artinian_ring R] {A : set M} (hA : finite A) : is_artinian R (submodule.span R A) :=
 is_artinian_of_fg_of_artinian _ (submodule.fg_def.mpr ⟨A, hA, rfl⟩)
 
-theorem is_artinian_ring_of_surjective (R) [comm_ring R] (S) [comm_ring S]
+theorem is_artinian_ring_of_surjective (R) [ring R] (S) [ring S]
   (f : R →+* S) (hf : function.surjective f)
   [H : is_artinian_ring R] : is_artinian_ring S :=
 begin
@@ -381,12 +381,12 @@ begin
   exact order_embedding.well_founded (ideal.order_embedding_of_surjective f hf) H,
 end
 
-instance is_artinian_ring_range {R} [comm_ring R] {S} [comm_ring S] (f : R →+* S)
+instance is_artinian_ring_range {R} [ring R] {S} [ring S] (f : R →+* S)
   [is_artinian_ring R] : is_artinian_ring f.range :=
 is_artinian_ring_of_surjective R f.range f.range_restrict
   f.range_restrict_surjective
 
-theorem is_artinian_ring_of_ring_equiv (R) [comm_ring R] {S} [comm_ring S]
+theorem is_artinian_ring_of_ring_equiv (R) [ring R] {S} [ring S]
   (f : R ≃+* S) [is_artinian_ring R] : is_artinian_ring S :=
 is_artinian_ring_of_surjective R S f.to_ring_hom f.to_equiv.surjective
 

--- a/src/ring_theory/finiteness.lean
+++ b/src/ring_theory/finiteness.lean
@@ -134,7 +134,7 @@ lemma trans {R : Type*} (A B : Type*) [comm_semiring R] [comm_semiring A] [algeb
       ht, submodule.restrict_scalars_top]⟩⟩
 
 @[priority 100] -- see Note [lower instance priority]
-instance finite_type {R : Type*} (A : Type*) [comm_semiring R] [comm_semiring A]
+instance finite_type {R : Type*} (A : Type*) [comm_semiring R] [semiring A]
   [algebra R A] [hRA : finite R A] : algebra.finite_type R A :=
 ⟨subalgebra.fg_of_submodule_fg hRA.1⟩
 

--- a/src/ring_theory/ideal/basic.lean
+++ b/src/ring_theory/ideal/basic.lean
@@ -16,6 +16,7 @@ import linear_algebra.finsupp
 # Ideals over a ring
 
 This file defines `ideal R`, the type of (left) ideals over a ring `R`.
+Note that over commutative rings, left ideals and two-sided ideals are equivalent.
 
 ## Implementation notes
 

--- a/src/ring_theory/ideal/basic.lean
+++ b/src/ring_theory/ideal/basic.lean
@@ -15,7 +15,7 @@ import linear_algebra.finsupp
 
 # Ideals over a ring
 
-This file defines `ideal R`, the type of ideals over a commutative ring `R`.
+This file defines `ideal R`, the type of (left) ideals over a ring `R`.
 
 ## Implementation notes
 
@@ -23,7 +23,7 @@ This file defines `ideal R`, the type of ideals over a commutative ring `R`.
 
 ## TODO
 
-Support one-sided ideals, and ideals over non-commutative rings.
+Support right ideals, and two-sided ideals over non-commutative rings.
 -/
 
 universes u v w
@@ -232,7 +232,7 @@ end
 
 /-- If P is not properly contained in any maximal ideal then it is not properly contained
   in any proper ideal -/
-lemma maximal_of_no_maximal {R : Type u} [comm_semiring R] {P : ideal R}
+lemma maximal_of_no_maximal {R : Type u} [semiring R] {P : ideal R}
 (hmax : ∀ m : ideal R, P < m → ¬is_maximal m) (J : ideal R) (hPJ : P < J) : J = ⊤ :=
 begin
   by_contradiction hnonmax,

--- a/src/ring_theory/noetherian.lean
+++ b/src/ring_theory/noetherian.lean
@@ -288,7 +288,7 @@ begin
   { rwa [inf_of_le_right (show f.ker ≤ (comap f g.ker), from comap_mono bot_le)] }
 end
 
-lemma fg_restrict_scalars {R S M : Type*} [comm_ring R] [comm_ring S] [algebra R S]
+lemma fg_restrict_scalars {R S M : Type*} [comm_semiring R] [semiring S] [algebra R S]
   [add_comm_group M] [module S M] [module R M] [is_scalar_tower R S M] (N : submodule S M)
   (hfin : N.fg) (h : function.surjective (algebra_map R S)) : (submodule.restrict_scalars R N).fg :=
 begin
@@ -668,8 +668,8 @@ class is_noetherian_ring (R) [semiring R] extends is_noetherian R R : Prop
 theorem is_noetherian_ring_iff {R} [semiring R] : is_noetherian_ring R ↔ is_noetherian R R :=
 ⟨λ h, h.1, @is_noetherian_ring.mk _ _⟩
 
-/-- A commutative ring is Noetherian if and only if all its ideals are finitely-generated. -/
-lemma is_noetherian_ring_iff_ideal_fg (R : Type*) [comm_semiring R] :
+/-- A ring is Noetherian if and only if all its ideals are finitely-generated. -/
+lemma is_noetherian_ring_iff_ideal_fg (R : Type*) [semiring R] :
   is_noetherian_ring R ↔ ∀ I : ideal R, I.fg :=
 is_noetherian_ring_iff.trans is_noetherian_def
 
@@ -756,7 +756,7 @@ theorem is_noetherian_span_of_finite (R) {M} [ring R] [add_comm_group M] [module
   [is_noetherian_ring R] {A : set M} (hA : finite A) : is_noetherian R (submodule.span R A) :=
 is_noetherian_of_fg_of_noetherian _ (submodule.fg_def.mpr ⟨A, hA, rfl⟩)
 
-theorem is_noetherian_ring_of_surjective (R) [comm_ring R] (S) [comm_ring S]
+theorem is_noetherian_ring_of_surjective (R) [ring R] (S) [ring S]
   (f : R →+* S) (hf : function.surjective f)
   [H : is_noetherian_ring R] : is_noetherian_ring S :=
 begin
@@ -764,12 +764,12 @@ begin
   exact order_embedding.well_founded (ideal.order_embedding_of_surjective f hf).dual H,
 end
 
-instance is_noetherian_ring_range {R} [comm_ring R] {S} [comm_ring S] (f : R →+* S)
+instance is_noetherian_ring_range {R} [ring R] {S} [ring S] (f : R →+* S)
   [is_noetherian_ring R] : is_noetherian_ring f.range :=
 is_noetherian_ring_of_surjective R f.range f.range_restrict
   f.range_restrict_surjective
 
-theorem is_noetherian_ring_of_ring_equiv (R) [comm_ring R] {S} [comm_ring S]
+theorem is_noetherian_ring_of_ring_equiv (R) [ring R] {S} [ring S]
   (f : R ≃+* S) [is_noetherian_ring R] : is_noetherian_ring S :=
 is_noetherian_ring_of_surjective R S f.to_ring_hom f.to_equiv.surjective
 


### PR DESCRIPTION
This replaces `[comm_ring R]` or `[comm_semiring R]` with `[ring R]` or `[semiring R]`, without changing any proofs.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
