### PR TITLE
[Merged by Bors] - fix(tactics/alias): Make docstring calculation available to to_additive

### DIFF
--- a/src/algebra/group/to_additive.lean
+++ b/src/algebra/group/to_additive.lean
@@ -553,9 +553,10 @@ protected meta def attr : user_attribute unit value_type :=
       match val.doc with
       | some doc := add_doc_string tgt doc
       | none := do
-        some alias_name ← tactic.alias.get_alias_target src | skip,
+        some alias_target ← tactic.alias.get_alias_target src | skip,
+        let alias_name := alias_target.to_name,
         some add_alias_name ← pure (dict.find alias_name) | skip,
-        add_doc_string tgt ("**Alias** of `" ++ to_string add_alias_name ++ "`.")
+        add_doc_string tgt alias_target.to_string
       end }
 
 add_tactic_doc

--- a/src/tactic/alias.lean
+++ b/src/tactic/alias.lean
@@ -55,17 +55,15 @@ meta inductive target
 
 /-- The name underlying an alias target -/
 meta def target.to_name : target → name
-| target.plain n := n
-| target.forward n := n
-| target.backwards n := n
-end
+| (target.plain n) := n
+| (target.forward n) := n
+| (target.backwards n) := n
 
 /-- The docstring for an alias. Used by `alias` _and_ by `to_additive` -/
 meta def target.to_string : target → string
-| target.plain n := sformat!"**Alias** of {n}`."
-| target.forward n := sformat!"**Alias** of the forward direction of {n}`."
-| target.backwards n := sformat!"**Alias** of the reverse direction of {n}`."
-end
+| (target.plain n) := sformat!"**Alias** of {n}`."
+| (target.forward n) := sformat!"**Alias** of the forward direction of {n}`."
+| (target.backwards n) := sformat!"**Alias** of the reverse direction of {n}`."
 
 @[user_attribute] meta def alias_attr : user_attribute unit target :=
 { name := `alias, descr := "This definition is an alias of another.", parser := failed }

--- a/src/tactic/alias.lean
+++ b/src/tactic/alias.lean
@@ -54,14 +54,14 @@ meta inductive target
 | backwards : name -> target
 
 /-- The name underlying an alias target -/
-meta def target.to_name (t : target) : name := match t with
+meta def target.to_name : target → name
 | target.plain n := n
 | target.forward n := n
 | target.backwards n := n
 end
 
 /-- The docstring for an alias. Used by `alias` _and_ by `to_additive` -/
-meta def target.to_string (t : target) : string := match t with
+meta def target.to_string : target → string
 | target.plain n := sformat!"**Alias** of {n}`."
 | target.forward n := sformat!"**Alias** of the forward direction of {n}`."
 | target.backwards n := sformat!"**Alias** of the reverse direction of {n}`."

--- a/src/tactic/alias.lean
+++ b/src/tactic/alias.lean
@@ -46,10 +46,28 @@ open lean.parser tactic interactive
 
 namespace tactic.alias
 
-@[user_attribute] meta def alias_attr : user_attribute unit name :=
+@[derive has_reflect]
+meta inductive target
+| plain : name -> target
+| forward : name -> target
+| backwards : name -> target
+
+meta def target.to_name (t : target) : name := match t with
+| target.plain n := n
+| target.forward n := n
+| target.backwards n := n
+end
+
+meta def target.to_string (t : target) : string := match t with
+| target.plain n := sformat!"**Alias** of {n}`."
+| target.forward n := sformat!"**Alias** of the forward direction of {n}`."
+| target.backwards n := sformat!"**Alias** of the reverse direction of {n}`."
+end
+
+@[user_attribute] meta def alias_attr : user_attribute unit target :=
 { name := `alias, descr := "This definition is an alias of another.", parser := failed }
 
-meta def alias_direct (d : declaration) (doc : string) (al : name) : tactic unit :=
+meta def alias_direct (d : declaration) (al : name) : tactic unit :=
 do updateex_env $ λ env,
   env.add (match d.to_definition with
   | declaration.defn n ls t _ _ _ :=
@@ -59,23 +77,26 @@ do updateex_env $ λ env,
     declaration.thm al ls t $ task.pure $ expr.const n (level.param <$> ls)
   | _ := undefined
   end),
-  alias_attr.set al d.to_name tt,
-  add_doc_string al doc
+  let target := target.plain d.to_name,
+  alias_attr.set al target tt,
+  add_doc_string al target.to_string
 
 meta def mk_iff_mp_app (iffmp : name) : expr → (ℕ → expr) → tactic expr
 | (expr.pi n bi e t) f := expr.lam n bi e <$> mk_iff_mp_app t (λ n, f (n+1) (expr.var n))
 | `(%%a ↔ %%b) f := pure $ @expr.const tt iffmp [] a b (f 0)
 | _ f := fail "Target theorem must have the form `Π x y z, a ↔ b`"
 
-meta def alias_iff (d : declaration) (doc : string) (al : name) (iffmp : name) : tactic unit :=
+meta def alias_iff (d : declaration) (al : name) (is_forward : bool) : tactic unit :=
 (if al = `_ then skip else get_decl al >> skip) <|> do
   let ls := d.univ_params,
   let t := d.type,
+  let target := if is_forward then target.forward d.to_name else target.backwards d.to_name,
+  let iffmp := if is_forward then `iff.mp else `iff.mpr,
   v ← mk_iff_mp_app iffmp t (λ_, expr.const d.to_name (level.param <$> ls)),
   t' ← infer_type v,
   updateex_env $ λ env, env.add (declaration.thm al ls t' $ task.pure v),
-  alias_attr.set al d.to_name tt,
-  add_doc_string al doc
+  alias_attr.set al target tt,
+  add_doc_string al target.to_string
 
 meta def make_left_right : name → tactic (name × name)
 | (name.mk_string s p) := do
@@ -134,15 +155,15 @@ do old ← ident,
   do
   { tk "←" <|> tk "<-",
     aliases ← many ident,
-    ↑(aliases.mmap' $ λ al, alias_direct d (doc al "") al) } <|>
+    ↑(aliases.mmap' $ λ al, alias_direct d al) } <|>
   do
   { tk "↔" <|> tk "<->",
     (left, right) ←
       mcond ((tk ".." >> pure tt) <|> pure ff)
         (make_left_right old <|> fail "invalid name for automatic name generation")
         (prod.mk <$> types.ident_ <*> types.ident_),
-    alias_iff d (doc left "the forward direction of ") left `iff.mp,
-    alias_iff d (doc right "the reverse direction of ") right `iff.mpr }
+    alias_iff d left tt,
+    alias_iff d right ff }
 
 add_tactic_doc
 { name                     := "alias",
@@ -154,7 +175,7 @@ meta def get_lambda_body : expr → expr
 | (expr.lam _ _ _ b) := get_lambda_body b
 | a                  := a
 
-meta def get_alias_target (n : name) : tactic (option name) :=
+meta def get_alias_target (n : name) : tactic (option target) :=
 do tt ← has_attribute' `alias n | pure none,
    v ← alias_attr.get_param n,
    pure $ some v

--- a/src/tactic/alias.lean
+++ b/src/tactic/alias.lean
@@ -46,18 +46,21 @@ open lean.parser tactic interactive
 
 namespace tactic.alias
 
+/-- An alias can be in one of three forms -/
 @[derive has_reflect]
 meta inductive target
 | plain : name -> target
 | forward : name -> target
 | backwards : name -> target
 
+/-- The name underlying an alias target -/
 meta def target.to_name (t : target) : name := match t with
 | target.plain n := n
 | target.forward n := n
 | target.backwards n := n
 end
 
+/-- The docstring for an alias. Used by `alias` _and_ by `to_additive` -/
 meta def target.to_string (t : target) : string := match t with
 | target.plain n := sformat!"**Alias** of {n}`."
 | target.forward n := sformat!"**Alias** of the forward direction of {n}`."


### PR DESCRIPTION
PR #13944 fixed the docstrings for iff-style aliases, but because of
code duplication I added in #13330 this did not apply to aliases
introduced by `to_additive`. This fixes that.



---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
