### PR TITLE
[Merged by Bors] - feat(number_theory/legendre_symbol/*): add results on value at -1

### DIFF
--- a/archive/imo/imo2008_q3.lean
+++ b/archive/imo/imo2008_q3.lean
@@ -43,7 +43,7 @@ begin
     simp only [int.nat_abs_sq, int.coe_nat_pow, int.coe_nat_succ, int.coe_nat_dvd.mp],
     refine (zmod.int_coe_zmod_eq_zero_iff_dvd (m ^ 2 + 1) p).mp _,
     simp only [int.cast_pow, int.cast_add, int.cast_one, zmod.coe_val_min_abs],
-    rw hy, exact add_left_neg 1 },
+    rw [pow_two, ← hy], exact add_left_neg 1 },
 
   have hnat₂ : n ≤ p / 2 := zmod.nat_abs_val_min_abs_le y,
   have hnat₃ : p ≥ 2 * n, { linarith [nat.div_mul_le_self p 2] },

--- a/src/number_theory/legendre_symbol/quadratic_reciprocity.lean
+++ b/src/number_theory/legendre_symbol/quadratic_reciprocity.lean
@@ -21,8 +21,8 @@ interpretations in terms of existence of square roots depending on the congruenc
 `exists_sq_eq_prime_iff_of_mod_four_eq_three`.
 
 Also proven are conditions for `-1` and `2` to be a square modulo a prime,
-`exists_sq_eq_neg_one_iff` and
-`exists_sq_eq_two_iff`
+`legende_sym_neg_one` and `exists_sq_eq_neg_one_iff` for `-1`, and
+`exists_sq_eq_two_iff` for `2`
 
 ## Implementation notes
 
@@ -52,11 +52,11 @@ end
 
 /-- Euler's Criterion: a nonzero `a : zmod p` is a square if and only if `x ^ (p / 2) = 1`. -/
 lemma euler_criterion {a : zmod p} (ha : a ≠ 0) :
-  (∃ y : zmod p, y ^ 2 = a) ↔ a ^ (p / 2) = 1 :=
+  is_square (a : zmod p) ↔ a ^ (p / 2) = 1 :=
 begin
   apply (iff_congr _ (by simp [units.ext_iff])).mp (euler_criterion_units p (units.mk0 a ha)),
   simp only [units.ext_iff, sq, units.coe_mk0, units.coe_mul],
-  split, { rintro ⟨y, hy⟩, exact ⟨y, hy⟩ },
+  split, { rintro ⟨y, hy⟩, exact ⟨y, hy.symm⟩ },
   { rintro ⟨y, rfl⟩,
     have hy : y ≠ 0, { rintro rfl, simpa [zero_pow] using ha, },
     refine ⟨units.mk0 y hy, _⟩, simp, }
@@ -64,29 +64,18 @@ end
 
 -- The following is used by number_theory/zsqrtd/gaussian_int.lean and archive/imo/imo2008_q3.lean
 lemma exists_sq_eq_neg_one_iff :
-  (∃ y : zmod p, y ^ 2 = -1) ↔ p % 4 ≠ 3 :=
+  is_square (-1 : zmod p) ↔ p % 4 ≠ 3 :=
 begin
-  cases nat.prime.eq_two_or_odd (fact.out p.prime) with hp2 hp_odd,
-  { substI p, exact dec_trivial },
-  haveI := fact.mk hp_odd,
-  have neg_one_ne_zero : (-1 : zmod p) ≠ 0, from mt neg_eq_zero.1 one_ne_zero,
-  rw [euler_criterion p neg_one_ne_zero, neg_one_pow_eq_pow_mod_two],
-  cases mod_two_eq_zero_or_one (p / 2) with p_half_even p_half_odd,
-  { rw [p_half_even, pow_zero, eq_self_iff_true, true_iff],
-    contrapose! p_half_even with hp,
-    rw [← nat.mod_mul_right_div_self, show 2 * 2 = 4, from rfl, hp],
-    exact dec_trivial },
-  { rw [p_half_odd, pow_one,
-        iff_false_intro (ne_neg_self p one_ne_zero).symm, false_iff, not_not],
-    rw [← nat.mod_mul_right_div_self, show 2 * 2 = 4, from rfl] at p_half_odd,
-    rw [← nat.mod_mul_left_mod _ 2, show 2 * 2 = 4, from rfl] at hp_odd,
-    have hp : p % 4 < 4, from nat.mod_lt _ dec_trivial,
-    revert hp hp_odd p_half_odd,
-    generalize : p % 4 = k, dec_trivial! }
+  have h := @is_square_neg_one_iff (zmod p) _ _,
+  rw card p at h,
+  exact h,
 end
 
 lemma mod_four_ne_three_of_sq_eq_neg_one {y : zmod p} (hy : y ^ 2 = -1) : p % 4 ≠ 3 :=
-(exists_sq_eq_neg_one_iff p).1 ⟨y, hy⟩
+begin
+  rw pow_two at hy,
+  exact (exists_sq_eq_neg_one_iff p).1 ⟨y, hy.symm⟩
+end
 
 lemma mod_four_ne_three_of_sq_eq_neg_sq' {x y : zmod p} (hy : y ≠ 0) (hxy : x ^ 2 = - y ^ 2) :
   p % 4 ≠ 3 :=
@@ -238,6 +227,15 @@ lemma legendre_sym_card_sqrts (hp : p ≠ 2) (a : ℤ) :
 begin
   have h : ring_char (zmod p) ≠ 2 := by { rw ring_char_zmod_n, exact hp, },
   exact quadratic_char_card_sqrts h a,
+end
+
+/-- `legendre_sym p (-1)` is given by `χ₄ p`. -/
+lemma legendre_sym_neg_one (hp : p ≠ 2) : legendre_sym p (-1) = χ₄ p :=
+begin
+  have h : ring_char (zmod p) ≠ 2 := by { rw ring_char_zmod_n, exact hp, },
+  have h₁ := quadratic_char_neg_one h,
+  rw card p at h₁,
+  exact_mod_cast h₁,
 end
 
 open_locale big_operators

--- a/src/number_theory/legendre_symbol/quadratic_reciprocity.lean
+++ b/src/number_theory/legendre_symbol/quadratic_reciprocity.lean
@@ -62,7 +62,6 @@ begin
     refine ⟨units.mk0 y hy, _⟩, simp, }
 end
 
--- The following is used by number_theory/zsqrtd/gaussian_int.lean and archive/imo/imo2008_q3.lean
 lemma exists_sq_eq_neg_one_iff : is_square (-1 : zmod p) ↔ p % 4 ≠ 3 :=
 begin
   have h := @is_square_neg_one_iff (zmod p) _ _,

--- a/src/number_theory/legendre_symbol/quadratic_reciprocity.lean
+++ b/src/number_theory/legendre_symbol/quadratic_reciprocity.lean
@@ -63,8 +63,7 @@ begin
 end
 
 -- The following is used by number_theory/zsqrtd/gaussian_int.lean and archive/imo/imo2008_q3.lean
-lemma exists_sq_eq_neg_one_iff :
-  is_square (-1 : zmod p) ↔ p % 4 ≠ 3 :=
+lemma exists_sq_eq_neg_one_iff : is_square (-1 : zmod p) ↔ p % 4 ≠ 3 :=
 begin
   have h := @is_square_neg_one_iff (zmod p) _ _,
   rw card p at h,

--- a/src/number_theory/zsqrtd/gaussian_int.lean
+++ b/src/number_theory/zsqrtd/gaussian_int.lean
@@ -211,7 +211,8 @@ hp.1.eq_two_or_odd.elim
       obtain ⟨k, k_lt_p, rfl⟩ : ∃ (k' : ℕ) (h : k' < p), (k' : zmod p) = k,
       { refine ⟨k.val, k.val_lt, zmod.nat_cast_zmod_val k⟩ },
       have hpk : p ∣ k ^ 2 + 1,
-        by rw [← char_p.cast_eq_zero_iff (zmod p) p]; simp *,
+        by { rw [pow_two, ← char_p.cast_eq_zero_iff (zmod p) p, nat.cast_add, nat.cast_mul,
+                 nat.cast_one, ← hk, add_left_neg], },
       have hkmul : (k ^ 2 + 1 : ℤ[i]) = ⟨k, 1⟩ * ⟨k, -1⟩ :=
         by simp [sq, zsqrtd.ext],
       have hpne1 : p ≠ 1 := ne_of_gt hp.1.one_lt,


### PR DESCRIPTION
This PR adds code expressing the value of the quadratic character at -1 of a finite field of odd characteristic as χ₄ applied to the cardinality of the field. This is then also done for the Legendre symbol.

Additional changes:
* two helper lemmas `odd_mod_four` and `finite_field.even_card_of_char_two` that are needed
* some API lemmas for χ₄
* write `euler_criterion` and `exists_sq_eq_neg_one_iff` in terms of `is_square`; simplify the proof of the latter using the general result for quadratic characters

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
