### PR TITLE
[Merged by Bors] - feat(model_theory/*): Any theory with infinite models has arbitrarily large models

### DIFF
--- a/src/model_theory/bundled.lean
+++ b/src/model_theory/bundled.lean
@@ -54,6 +54,8 @@ namespace Model
 
 instance : has_coe_to_sort T.Model (Type w) := ⟨Model.carrier⟩
 
+@[simp] lemma carrier_eq_coe (M : T.Model) : M.carrier = M := rfl
+
 /-- The object in the category of R-algebras associated to a type equipped with the appropriate
 typeclasses. -/
 def of (M : Type w) [L.Structure M] [M ⊨ T] [nonempty M] :
@@ -92,7 +94,7 @@ def ulift (M : Model.{u v w} T) : Model.{u v (max w w')} T :=
   equiv_induced (equiv.ulift.symm : M ≃ _)
 
 /-- The reduct of any model of `φ.on_Theory T` is a model of `T`. -/
-@[simps] def reduct {L' : language} {φ : L →ᴸ L'} (M : (φ.on_Theory T).Model) :
+@[simps] def reduct {L' : language} (φ : L →ᴸ L') (M : (φ.on_Theory T).Model) :
   T.Model :=
 { carrier := M,
   struc := φ.reduct M,

--- a/src/model_theory/language_map.lean
+++ b/src/model_theory/language_map.lean
@@ -362,12 +362,12 @@ language.sum_Structure _ _ M
 instance with_constants_self_expansion : (Lhom_with_constants L M).is_expansion_on M :=
 ⟨λ _ _ _, rfl, λ _ _ _, rfl⟩
 
-variables (A : set M)
+variables (α : Type*) [(constants_on α).Structure M]
 
-instance with_constants_Structure : L[[A]].Structure M :=
+instance with_constants_Structure : L[[α]].Structure M :=
 language.sum_Structure _ _ _
 
-instance with_constants_expansion : (L.Lhom_with_constants A).is_expansion_on M :=
+instance with_constants_expansion : (L.Lhom_with_constants α).is_expansion_on M :=
 ⟨λ _ _ _, rfl, λ _ _ _, rfl⟩
 
 instance add_empty_constants_is_expansion_on' :
@@ -380,8 +380,10 @@ Lhom.sum_elim_is_expansion_on _ _ _
 
 instance add_constants_expansion {L' : language} [L'.Structure M] (φ : L →ᴸ L')
   [φ.is_expansion_on M] :
-  (φ.add_constants A).is_expansion_on M :=
+  (φ.add_constants α).is_expansion_on M :=
 Lhom.sum_map_is_expansion_on _ _ M
+
+variables {α} (A : set M)
 
 @[simp] lemma coe_con {a : A} : ((L.con a) : M) = a := rfl
 

--- a/src/model_theory/satisfiability.lean
+++ b/src/model_theory/satisfiability.lean
@@ -26,6 +26,8 @@ that `φ` and `ψ` are equivalent formulas or sentences in models of `T`.
 shows that a theory is satisfiable iff it is finitely satisfiable.
 * `first_order.language.complete_theory.is_complete`: The complete theory of a structure is
 complete.
+* `first_order.language.Theory.exists_large_model_of_infinite_model` shows that any theory with an
+infinite model has arbitrarily large models.
 
 ## Implementation Details
 * Satisfiability of an `L.Theory` `T` is defined in the minimal universe containing all the symbols

--- a/src/model_theory/satisfiability.lean
+++ b/src/model_theory/satisfiability.lean
@@ -33,12 +33,15 @@ of `L`. By Löwenheim-Skolem, this is equivalent to satisfiability in any univer
 
 -/
 
-universes u v w
+universes u v w w'
+
+open cardinal
+open_locale cardinal first_order
 
 namespace first_order
 namespace language
 
-variables {L : language.{u v}} {T : L.Theory} {α : Type*} {n : ℕ}
+variables {L : language.{u v}} {T : L.Theory} {α : Type w} {n : ℕ}
 
 namespace Theory
 
@@ -96,6 +99,55 @@ begin
   intros T0 hT0,
   obtain ⟨i, hi⟩ := h.exists_mem_subset_of_finset_subset_bUnion hT0,
   exact (h' i).mono hi,
+end
+
+theorem is_satisfiable_union_distinct_constants_theory_of_card_le (T : L.Theory) (s : set α)
+  (M : Type w') [nonempty M] [L.Structure M] [M ⊨ T]
+  (h : cardinal.lift.{w'} (# s) ≤ cardinal.lift.{w} (# M)) :
+  ((L.Lhom_with_constants α).on_Theory T ∪ L.distinct_constants_theory s).is_satisfiable :=
+begin
+  haveI : inhabited M := classical.inhabited_of_nonempty infer_instance,
+  rw [cardinal.lift_mk_le'] at h,
+  letI : (constants_on α).Structure M :=
+    constants_on.Structure (function.extend coe h.some default),
+  haveI : M ⊨ (L.Lhom_with_constants α).on_Theory T ∪ L.distinct_constants_theory s,
+  { refine ((Lhom.on_Theory_model _ _).2 infer_instance).union _,
+    rw [model_distinct_constants_theory],
+    refine λ a as b bs ab, _,
+    rw [← subtype.coe_mk a as, ← subtype.coe_mk b bs, ← subtype.ext_iff],
+    exact h.some.injective
+      ((function.extend_apply subtype.coe_injective h.some default ⟨a, as⟩).symm.trans
+      (ab.trans (function.extend_apply subtype.coe_injective h.some default ⟨b, bs⟩))), },
+  exact model.is_satisfiable M,
+end
+
+theorem is_satisfiable_union_distinct_constants_theory_of_infinite (T : L.Theory) (s : set α)
+  (M : Type w') [L.Structure M] [M ⊨ T] [infinite M] :
+  ((L.Lhom_with_constants α).on_Theory T ∪ L.distinct_constants_theory s).is_satisfiable :=
+begin
+  classical,
+  rw [distinct_constants_theory_eq_Union, set.union_Union, is_satisfiable_directed_union_iff],
+  { exact λ t, is_satisfiable_union_distinct_constants_theory_of_card_le T _ M ((lift_le_omega.2
+      (le_of_lt (finset_card_lt_omega _))).trans (omega_le_lift.2 (omega_le_mk M))), },
+  { refine (monotone_const.union (monotone_distinct_constants_theory.comp _)).directed_le,
+    simp only [finset.coe_map, function.embedding.coe_subtype],
+    exact set.monotone_image.comp (λ _ _, finset.coe_subset.2) }
+end
+
+/-- Any theory with an infinite model has arbitrarily large models. -/
+lemma exists_large_model_of_infinite_model (T : L.Theory) (κ : cardinal.{w})
+  (M : Type w') [L.Structure M] [M ⊨ T] [infinite M] :
+  ∃ (N : Model.{_ _ (max u v w)} T), cardinal.lift.{max u v w} κ ≤ # N :=
+begin
+  obtain ⟨N⟩ :=
+    is_satisfiable_union_distinct_constants_theory_of_infinite T (set.univ : set κ.out) M,
+  refine ⟨(N.is_model.mono (set.subset_union_left _ _)).bundled.reduct _, _⟩,
+  haveI : N ⊨ distinct_constants_theory _ _ := N.is_model.mono (set.subset_union_right _ _),
+  simp only [Model.reduct_carrier, coe_of, Model.carrier_eq_coe],
+  refine trans (lift_le.2 (le_of_eq (cardinal.mk_out κ).symm)) _,
+  rw [← mk_univ],
+  refine (card_le_of_model_distinct_constants_theory L set.univ N).trans (lift_le.1 _),
+  rw lift_lift,
 end
 
 variable (T)


### PR DESCRIPTION
Defines the theory `distinct_constants_theory`, indicating that a set of constants are distinct.
Uses that theory to show that any theory with an infinite model has models of arbitrarily large cardinality.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
