### PR TITLE
[Merged by Bors] - chore(analysis/normed_space/exponential): Make the `𝔸` argument implicit

### DIFF
--- a/src/analysis/normed_space/exponential.lean
+++ b/src/analysis/normed_space/exponential.lean
@@ -12,8 +12,8 @@ import data.finset.noncomm_prod
 /-!
 # Exponential in a Banach algebra
 
-In this file, we define `exp 𝕂 𝔸`, the exponential map in a topological algebra `𝔸` over a field
-`𝕂`.
+In this file, we define `exp 𝕂 : 𝔸 → 𝔸`, the exponential map in a topological algebra `𝔸` over a
+field `𝕂`.
 
 While for most interesting results we need `𝔸` to be normed algebra, we do not require this in the
 definition in order to make `exp` independent of a particular choice of norm. The definition also
@@ -31,22 +31,22 @@ We prove most result for an arbitrary field `𝕂`, and then specialize to `𝕂
 
 - `exp_add_of_commute_of_mem_ball` : if `𝕂` has characteristic zero, then given two commuting
   elements `x` and `y` in the disk of convergence, we have
-  `exp 𝕂 𝔸 (x+y) = (exp 𝕂 𝔸 x) * (exp 𝕂 𝔸 y)`
+  `exp 𝕂 (x+y) = (exp 𝕂 x) * (exp 𝕂 y)`
 - `exp_add_of_mem_ball` : if `𝕂` has characteristic zero and `𝔸` is commutative, then given two
   elements `x` and `y` in the disk of convergence, we have
-  `exp 𝕂 𝔸 (x+y) = (exp 𝕂 𝔸 x) * (exp 𝕂 𝔸 y)`
+  `exp 𝕂 (x+y) = (exp 𝕂 x) * (exp 𝕂 y)`
 - `exp_neg_of_mem_ball` : if `𝕂` has characteristic zero and `𝔸` is a division ring, then given an
-  element `x` in the disk of convergence, we have `exp 𝕂 𝔸 (-x) = (exp 𝕂 𝔸 x)⁻¹`.
+  element `x` in the disk of convergence, we have `exp 𝕂 (-x) = (exp 𝕂 x)⁻¹`.
 
 ### `𝕂 = ℝ` or `𝕂 = ℂ`
 
-- `exp_series_radius_eq_top` : the `formal_multilinear_series` defining `exp 𝕂 𝔸` has infinite
+- `exp_series_radius_eq_top` : the `formal_multilinear_series` defining `exp 𝕂` has infinite
   radius of convergence
 - `exp_add_of_commute` : given two commuting elements `x` and `y`, we have
-  `exp 𝕂 𝔸 (x+y) = (exp 𝕂 𝔸 x) * (exp 𝕂 𝔸 y)`
-- `exp_add` : if `𝔸` is commutative, then we have `exp 𝕂 𝔸 (x+y) = (exp 𝕂 𝔸 x) * (exp 𝕂 𝔸 y)`
+  `exp 𝕂 (x+y) = (exp 𝕂 x) * (exp 𝕂 y)`
+- `exp_add` : if `𝔸` is commutative, then we have `exp 𝕂 (x+y) = (exp 𝕂 x) * (exp 𝕂 y)`
   for any `x` and `y`
-- `exp_neg` : if `𝔸` is a division ring, then we have `exp 𝕂 𝔸 (-x) = (exp 𝕂 𝔸 x)⁻¹`.
+- `exp_neg` : if `𝔸` is a division ring, then we have `exp 𝕂 (-x) = (exp 𝕂 x)⁻¹`.
 - `exp_sum_of_commute` : the analogous result to `exp_add_of_commute` for `finset.sum`.
 - `exp_sum` : the analogous result to `exp_add` for `finset.sum`.
 - `exp_nsmul` : repeated addition in the domain corresponds to repeated multiplication in the
@@ -56,7 +56,7 @@ We prove most result for an arbitrary field `𝕂`, and then specialize to `𝕂
 
 ### Other useful compatibility results
 
-- `exp_eq_exp` : if `𝔸` is a normed algebra over two fields `𝕂` and `𝕂'`, then `exp 𝕂 𝔸 = exp 𝕂' 𝔸`
+- `exp_eq_exp` : if `𝔸` is a normed algebra over two fields `𝕂` and `𝕂'`, then `exp 𝕂 = exp 𝕂' 𝔸`
 
 -/
 
@@ -69,11 +69,13 @@ variables (𝕂 𝔸 : Type*) [field 𝕂] [ring 𝔸] [algebra 𝕂 𝔸] [topo
   [topological_ring 𝔸] [has_continuous_const_smul 𝕂 𝔸]
 
 /-- `exp_series 𝕂 𝔸` is the `formal_multilinear_series` whose `n`-th term is the map
-`(xᵢ) : 𝔸ⁿ ↦ (1/n! : 𝕂) • ∏ xᵢ`. Its sum is the exponential map `exp 𝕂 𝔸 : 𝔸 → 𝔸`. -/
+`(xᵢ) : 𝔸ⁿ ↦ (1/n! : 𝕂) • ∏ xᵢ`. Its sum is the exponential map `exp 𝕂 : 𝔸 → 𝔸`. -/
 def exp_series : formal_multilinear_series 𝕂 𝔸 𝔸 :=
 λ n, (n!⁻¹ : 𝕂) • continuous_multilinear_map.mk_pi_algebra_fin 𝕂 n 𝔸
 
-/-- `exp 𝕂 𝔸 : 𝔸 → 𝔸` is the exponential map determined by the action of `𝕂` on `𝔸`.
+variables {𝔸}
+
+/-- `exp 𝕂 : 𝔸 → 𝔸` is the exponential map determined by the action of `𝕂` on `𝔸`.
 It is defined as the sum of the `formal_multilinear_series` `exp_series 𝕂 𝔸`. -/
 noncomputable def exp (x : 𝔸) : 𝔸 := (exp_series 𝕂 𝔸).sum x
 
@@ -104,14 +106,14 @@ lemma exp_series_sum_eq_field [topological_space 𝕂] [topological_ring 𝕂] (
   (exp_series 𝕂 𝕂).sum x = ∑' (n : ℕ), x^n / n! :=
 tsum_congr (λ n, exp_series_apply_eq_field x n)
 
-lemma exp_eq_tsum : exp 𝕂 𝔸 = (λ x : 𝔸, ∑' (n : ℕ), (n!⁻¹ : 𝕂) • x^n) :=
+lemma exp_eq_tsum : exp 𝕂 = (λ x : 𝔸, ∑' (n : ℕ), (n!⁻¹ : 𝕂) • x^n) :=
 funext exp_series_sum_eq
 
 lemma exp_eq_tsum_field [topological_space 𝕂] [topological_ring 𝕂] :
-  exp 𝕂 𝕂 = (λ x : 𝕂, ∑' (n : ℕ), x^n / n!) :=
+  exp 𝕂 = (λ x : 𝕂, ∑' (n : ℕ), x^n / n!) :=
 funext exp_series_sum_eq_field
 
-@[simp] lemma exp_zero [t2_space 𝔸] : exp 𝕂 𝔸 0 = 1 :=
+@[simp] lemma exp_zero [t2_space 𝔸] : exp 𝕂 (0 : 𝔸) = 1 :=
 begin
   suffices : (λ x : 𝔸, ∑' (n : ℕ), (n!⁻¹ : 𝕂) • x^n) 0 = ∑' (n : ℕ), if n = 0 then 1 else 0,
   { have key : ∀ n ∉ ({0} : finset ℕ), (if n = 0 then (1 : 𝔸) else 0) = 0,
@@ -125,16 +127,16 @@ end
 
 variables (𝕂)
 
-lemma commute.exp_right [t2_space 𝔸] {x y : 𝔸} (h : commute x y) : commute x (exp 𝕂 𝔸 y) :=
+lemma commute.exp_right [t2_space 𝔸] {x y : 𝔸} (h : commute x y) : commute x (exp 𝕂 y) :=
 begin
   rw exp_eq_tsum,
   exact commute.tsum_right x (λ n, (h.pow_right n).smul_right _),
 end
 
-lemma commute.exp_left [t2_space 𝔸] {x y : 𝔸} (h : commute x y) : commute (exp 𝕂 𝔸 x) y :=
+lemma commute.exp_left [t2_space 𝔸] {x y : 𝔸} (h : commute x y) : commute (exp 𝕂 x) y :=
 (h.symm.exp_right 𝕂).symm
 
-lemma commute.exp [t2_space 𝔸] {x y : 𝔸} (h : commute x y) : commute (exp 𝕂 𝔸 x) (exp 𝕂 𝔸 y) :=
+lemma commute.exp [t2_space 𝔸] {x y : 𝔸} (h : commute x y) : commute (exp 𝕂 x) (exp 𝕂 y) :=
 (h.exp_left _).exp_right _
 
 end topological_algebra
@@ -189,38 +191,38 @@ summable_of_summable_norm (norm_exp_series_field_summable_of_mem_ball x hx)
 
 lemma exp_series_has_sum_exp_of_mem_ball (x : 𝔸)
   (hx : x ∈ emetric.ball (0 : 𝔸) (exp_series 𝕂 𝔸).radius) :
-  has_sum (λ n, exp_series 𝕂 𝔸 n (λ _, x)) (exp 𝕂 𝔸 x) :=
+  has_sum (λ n, exp_series 𝕂 𝔸 n (λ _, x)) (exp 𝕂 x) :=
 formal_multilinear_series.has_sum (exp_series 𝕂 𝔸) hx
 
 lemma exp_series_has_sum_exp_of_mem_ball' (x : 𝔸)
   (hx : x ∈ emetric.ball (0 : 𝔸) (exp_series 𝕂 𝔸).radius) :
-  has_sum (λ n, (n!⁻¹ : 𝕂) • x^n) (exp 𝕂 𝔸 x):=
+  has_sum (λ n, (n!⁻¹ : 𝕂) • x^n) (exp 𝕂 x):=
 begin
   rw ← exp_series_apply_eq',
   exact exp_series_has_sum_exp_of_mem_ball x hx
 end
 
 lemma exp_series_field_has_sum_exp_of_mem_ball [complete_space 𝕂] (x : 𝕂)
-  (hx : x ∈ emetric.ball (0 : 𝕂) (exp_series 𝕂 𝕂).radius) : has_sum (λ n, x^n / n!) (exp 𝕂 𝕂 x) :=
+  (hx : x ∈ emetric.ball (0 : 𝕂) (exp_series 𝕂 𝕂).radius) : has_sum (λ n, x^n / n!) (exp 𝕂 x) :=
 begin
   rw ← exp_series_apply_eq_field',
   exact exp_series_has_sum_exp_of_mem_ball x hx
 end
 
 lemma has_fpower_series_on_ball_exp_of_radius_pos (h : 0 < (exp_series 𝕂 𝔸).radius) :
-  has_fpower_series_on_ball (exp 𝕂 𝔸) (exp_series 𝕂 𝔸) 0 (exp_series 𝕂 𝔸).radius :=
+  has_fpower_series_on_ball (exp 𝕂) (exp_series 𝕂 𝔸) 0 (exp_series 𝕂 𝔸).radius :=
 (exp_series 𝕂 𝔸).has_fpower_series_on_ball h
 
 lemma has_fpower_series_at_exp_zero_of_radius_pos (h : 0 < (exp_series 𝕂 𝔸).radius) :
-  has_fpower_series_at (exp 𝕂 𝔸) (exp_series 𝕂 𝔸) 0 :=
+  has_fpower_series_at (exp 𝕂) (exp_series 𝕂 𝔸) 0 :=
 (has_fpower_series_on_ball_exp_of_radius_pos h).has_fpower_series_at
 
 lemma continuous_on_exp :
-  continuous_on (exp 𝕂 𝔸) (emetric.ball 0 (exp_series 𝕂 𝔸).radius) :=
+  continuous_on (exp 𝕂 : 𝔸 → 𝔸) (emetric.ball 0 (exp_series 𝕂 𝔸).radius) :=
 formal_multilinear_series.continuous_on
 
 lemma analytic_at_exp_of_mem_ball (x : 𝔸) (hx : x ∈ emetric.ball (0 : 𝔸) (exp_series 𝕂 𝔸).radius) :
-  analytic_at 𝕂 (exp 𝕂 𝔸) x:=
+  analytic_at 𝕂 (exp 𝕂) x:=
 begin
   by_cases h : (exp_series 𝕂 𝔸).radius = 0,
   { rw h at hx, exact (ennreal.not_lt_zero hx).elim },
@@ -229,11 +231,11 @@ begin
 end
 
 /-- In a Banach-algebra `𝔸` over a normed field `𝕂` of characteristic zero, if `x` and `y` are
-in the disk of convergence and commute, then `exp 𝕂 𝔸 (x + y) = (exp 𝕂 𝔸 x) * (exp 𝕂 𝔸 y)`. -/
+in the disk of convergence and commute, then `exp 𝕂 (x + y) = (exp 𝕂 x) * (exp 𝕂 y)`. -/
 lemma exp_add_of_commute_of_mem_ball [char_zero 𝕂]
   {x y : 𝔸} (hxy : commute x y) (hx : x ∈ emetric.ball (0 : 𝔸) (exp_series 𝕂 𝔸).radius)
   (hy : y ∈ emetric.ball (0 : 𝔸) (exp_series 𝕂 𝔸).radius) :
-  exp 𝕂 𝔸 (x + y) = (exp 𝕂 𝔸 x) * (exp 𝕂 𝔸 y) :=
+  exp 𝕂 (x + y) = (exp 𝕂 x) * (exp 𝕂 y) :=
 begin
   rw [exp_eq_tsum, tsum_mul_tsum_eq_tsum_sum_antidiagonal_of_summable_norm
         (norm_exp_series_summable_of_mem_ball' x hx) (norm_exp_series_summable_of_mem_ball' y hy)],
@@ -247,10 +249,10 @@ begin
   field_simp [this]
 end
 
-/-- `exp 𝕂 𝔸 x` has explicit two-sided inverse `exp 𝕂 𝔸 (-x)`. -/
+/-- `exp 𝕂 x` has explicit two-sided inverse `exp 𝕂 (-x)`. -/
 noncomputable def invertible_exp_of_mem_ball [char_zero 𝕂] {x : 𝔸}
-  (hx : x ∈ emetric.ball (0 : 𝔸) (exp_series 𝕂 𝔸).radius) : invertible (exp 𝕂 𝔸 x) :=
-{ inv_of := exp 𝕂 𝔸 (-x),
+  (hx : x ∈ emetric.ball (0 : 𝔸) (exp_series 𝕂 𝔸).radius) : invertible (exp 𝕂 x) :=
+{ inv_of := exp 𝕂 (-x),
   inv_of_mul_self := begin
     have hnx : -x ∈ emetric.ball (0 : 𝔸) (exp_series 𝕂 𝔸).radius,
     { rw [emetric.mem_ball, ←neg_zero, edist_neg_neg],
@@ -267,18 +269,18 @@ noncomputable def invertible_exp_of_mem_ball [char_zero 𝕂] {x : 𝔸}
   end }
 
 lemma is_unit_exp_of_mem_ball [char_zero 𝕂] {x : 𝔸}
-  (hx : x ∈ emetric.ball (0 : 𝔸) (exp_series 𝕂 𝔸).radius) : is_unit (exp 𝕂 𝔸 x) :=
+  (hx : x ∈ emetric.ball (0 : 𝔸) (exp_series 𝕂 𝔸).radius) : is_unit (exp 𝕂 x) :=
 @is_unit_of_invertible _ _ _ (invertible_exp_of_mem_ball hx)
 
 lemma inv_of_exp_of_mem_ball [char_zero 𝕂] {x : 𝔸}
-  (hx : x ∈ emetric.ball (0 : 𝔸) (exp_series 𝕂 𝔸).radius) [invertible (exp 𝕂 𝔸 x)] :
-  ⅟(exp 𝕂 𝔸 x) = exp 𝕂 𝔸 (-x) :=
-by { letI := invertible_exp_of_mem_ball hx, convert (rfl : ⅟(exp 𝕂 𝔸 x) = _) }
+  (hx : x ∈ emetric.ball (0 : 𝔸) (exp_series 𝕂 𝔸).radius) [invertible (exp 𝕂 x)] :
+  ⅟(exp 𝕂 x) = exp 𝕂 (-x) :=
+by { letI := invertible_exp_of_mem_ball hx, convert (rfl : ⅟(exp 𝕂 x) = _) }
 
 /-- Any continuous ring homomorphism commutes with `exp`. -/
 lemma map_exp_of_mem_ball {F} [ring_hom_class F 𝔸 𝔹] (f : F) (hf : continuous f) (x : 𝔸)
   (hx : x ∈ emetric.ball (0 : 𝔸) (exp_series 𝕂 𝔸).radius) :
-  f (exp 𝕂 𝔸 x) = exp 𝕂 𝔹 (f x) :=
+  f (exp 𝕂 x) = exp 𝕂 (f x) :=
 begin
   rw [exp_eq_tsum, exp_eq_tsum],
   refine ((exp_series_summable_of_mem_ball' _ hx).has_sum.map f hf).tsum_eq.symm.trans _,
@@ -290,7 +292,7 @@ end complete_algebra
 
 lemma algebra_map_exp_comm_of_mem_ball [complete_space 𝕂] (x : 𝕂)
   (hx : x ∈ emetric.ball (0 : 𝕂) (exp_series 𝕂 𝕂).radius) :
-  algebra_map 𝕂 𝔸 (exp 𝕂 𝕂 x) = exp 𝕂 𝔸 (algebra_map 𝕂 𝔸 x) :=
+  algebra_map 𝕂 𝔸 (exp 𝕂 x) = exp 𝕂 (algebra_map 𝕂 𝔸 x) :=
 map_exp_of_mem_ball _ (algebra_map_clm _ _).continuous _ hx
 
 end any_field_any_algebra
@@ -301,10 +303,10 @@ variables {𝕂 𝔸 : Type*} [nondiscrete_normed_field 𝕂] [normed_division_r
 
 lemma exp_neg_of_mem_ball [char_zero 𝕂] [complete_space 𝔸] {x : 𝔸}
   (hx : x ∈ emetric.ball (0 : 𝔸) (exp_series 𝕂 𝔸).radius) :
-  exp 𝕂 𝔸 (-x) = (exp 𝕂 𝔸 x)⁻¹ :=
+  exp 𝕂 (-x) = (exp 𝕂 x)⁻¹ :=
 begin
   letI := invertible_exp_of_mem_ball hx,
-  exact inv_of_eq_inv (exp 𝕂 𝔸 x),
+  exact inv_of_eq_inv (exp 𝕂 x),
 end
 
 end any_field_division_algebra
@@ -316,11 +318,11 @@ variables {𝕂 𝔸 : Type*} [nondiscrete_normed_field 𝕂] [normed_comm_ring 
   [complete_space 𝔸]
 
 /-- In a commutative Banach-algebra `𝔸` over a normed field `𝕂` of characteristic zero,
-`exp 𝕂 𝔸 (x+y) = (exp 𝕂 𝔸 x) * (exp 𝕂 𝔸 y)` for all `x`, `y` in the disk of convergence. -/
+`exp 𝕂 (x+y) = (exp 𝕂 x) * (exp 𝕂 y)` for all `x`, `y` in the disk of convergence. -/
 lemma exp_add_of_mem_ball [char_zero 𝕂] {x y : 𝔸}
   (hx : x ∈ emetric.ball (0 : 𝔸) (exp_series 𝕂 𝔸).radius)
   (hy : y ∈ emetric.ball (0 : 𝔸) (exp_series 𝕂 𝔸).radius) :
-  exp 𝕂 𝔸 (x + y) = (exp 𝕂 𝔸 x) * (exp 𝕂 𝔸 y) :=
+  exp 𝕂 (x + y) = (exp 𝕂 x) * (exp 𝕂 y) :=
 exp_add_of_commute_of_mem_ball (commute.all x y) hx hy
 
 end any_field_comm_algebra
@@ -377,26 +379,26 @@ summable_of_summable_norm (norm_exp_series_summable' x)
 lemma exp_series_field_summable (x : 𝕂) : summable (λ n, x^n / n!) :=
 summable_of_summable_norm (norm_exp_series_field_summable x)
 
-lemma exp_series_has_sum_exp (x : 𝔸) : has_sum (λ n, exp_series 𝕂 𝔸 n (λ _, x)) (exp 𝕂 𝔸 x) :=
+lemma exp_series_has_sum_exp (x : 𝔸) : has_sum (λ n, exp_series 𝕂 𝔸 n (λ _, x)) (exp 𝕂 x) :=
 exp_series_has_sum_exp_of_mem_ball x ((exp_series_radius_eq_top 𝕂 𝔸).symm ▸ edist_lt_top _ _)
 
-lemma exp_series_has_sum_exp' (x : 𝔸) : has_sum (λ n, (n!⁻¹ : 𝕂) • x^n) (exp 𝕂 𝔸 x):=
+lemma exp_series_has_sum_exp' (x : 𝔸) : has_sum (λ n, (n!⁻¹ : 𝕂) • x^n) (exp 𝕂 x):=
 exp_series_has_sum_exp_of_mem_ball' x ((exp_series_radius_eq_top 𝕂 𝔸).symm ▸ edist_lt_top _ _)
 
-lemma exp_series_field_has_sum_exp (x : 𝕂) : has_sum (λ n, x^n / n!) (exp 𝕂 𝕂 x):=
+lemma exp_series_field_has_sum_exp (x : 𝕂) : has_sum (λ n, x^n / n!) (exp 𝕂 x):=
 exp_series_field_has_sum_exp_of_mem_ball x ((exp_series_radius_eq_top 𝕂 𝕂).symm ▸ edist_lt_top _ _)
 
 lemma exp_has_fpower_series_on_ball :
-  has_fpower_series_on_ball (exp 𝕂 𝔸) (exp_series 𝕂 𝔸) 0 ∞ :=
+  has_fpower_series_on_ball (exp 𝕂) (exp_series 𝕂 𝔸) 0 ∞ :=
 exp_series_radius_eq_top 𝕂 𝔸 ▸
   has_fpower_series_on_ball_exp_of_radius_pos (exp_series_radius_pos _ _)
 
 lemma exp_has_fpower_series_at_zero :
-  has_fpower_series_at (exp 𝕂 𝔸) (exp_series 𝕂 𝔸) 0 :=
+  has_fpower_series_at (exp 𝕂) (exp_series 𝕂 𝔸) 0 :=
 exp_has_fpower_series_on_ball.has_fpower_series_at
 
 lemma exp_continuous :
-  continuous (exp 𝕂 𝔸) :=
+  continuous (exp 𝕂 : 𝔸 → 𝔸) :=
 begin
   rw [continuous_iff_continuous_on_univ, ← metric.eball_top_eq_univ (0 : 𝔸),
       ← exp_series_radius_eq_top 𝕂 𝔸],
@@ -404,32 +406,32 @@ begin
 end
 
 lemma exp_analytic (x : 𝔸) :
-  analytic_at 𝕂 (exp 𝕂 𝔸) x :=
+  analytic_at 𝕂 (exp 𝕂) x :=
 analytic_at_exp_of_mem_ball x ((exp_series_radius_eq_top 𝕂 𝔸).symm ▸ edist_lt_top _ _)
 
 /-- In a Banach-algebra `𝔸` over `𝕂 = ℝ` or `𝕂 = ℂ`, if `x` and `y` commute, then
-`exp 𝕂 𝔸 (x+y) = (exp 𝕂 𝔸 x) * (exp 𝕂 𝔸 y)`. -/
+`exp 𝕂 (x+y) = (exp 𝕂 x) * (exp 𝕂 y)`. -/
 lemma exp_add_of_commute
   {x y : 𝔸} (hxy : commute x y) :
-  exp 𝕂 𝔸 (x + y) = (exp 𝕂 𝔸 x) * (exp 𝕂 𝔸 y) :=
+  exp 𝕂 (x + y) = (exp 𝕂 x) * (exp 𝕂 y) :=
 exp_add_of_commute_of_mem_ball hxy ((exp_series_radius_eq_top 𝕂 𝔸).symm ▸ edist_lt_top _ _)
   ((exp_series_radius_eq_top 𝕂 𝔸).symm ▸ edist_lt_top _ _)
 
 section
 variables (𝕂)
 
-/-- `exp 𝕂 𝔸 x` has explicit two-sided inverse `exp 𝕂 𝔸 (-x)`. -/
-noncomputable def invertible_exp (x : 𝔸) : invertible (exp 𝕂 𝔸 x) :=
+/-- `exp 𝕂 x` has explicit two-sided inverse `exp 𝕂 (-x)`. -/
+noncomputable def invertible_exp (x : 𝔸) : invertible (exp 𝕂 x) :=
 invertible_exp_of_mem_ball $ (exp_series_radius_eq_top 𝕂 𝔸).symm ▸ edist_lt_top _ _
 
-lemma is_unit_exp (x : 𝔸) : is_unit (exp 𝕂 𝔸 x) :=
+lemma is_unit_exp (x : 𝔸) : is_unit (exp 𝕂 x) :=
 is_unit_exp_of_mem_ball $ (exp_series_radius_eq_top 𝕂 𝔸).symm ▸ edist_lt_top _ _
 
-lemma inv_of_exp (x : 𝔸) [invertible (exp 𝕂 𝔸 x)] :
-  ⅟(exp 𝕂 𝔸 x) = exp 𝕂 𝔸 (-x) :=
+lemma inv_of_exp (x : 𝔸) [invertible (exp 𝕂 x)] :
+  ⅟(exp 𝕂 x) = exp 𝕂 (-x) :=
 inv_of_exp_of_mem_ball $ (exp_series_radius_eq_top 𝕂 𝔸).symm ▸ edist_lt_top _ _
 
-lemma ring.inverse_exp (x : 𝔸) : ring.inverse (exp 𝕂 𝔸 x) = exp 𝕂 𝔸 (-x) :=
+lemma ring.inverse_exp (x : 𝔸) : ring.inverse (exp 𝕂 x) = exp 𝕂 (-x) :=
 begin
   letI := invertible_exp 𝕂 x,
   exact ring.inverse_invertible _,
@@ -438,10 +440,10 @@ end
 end
 
 /-- In a Banach-algebra `𝔸` over `𝕂 = ℝ` or `𝕂 = ℂ`, if a family of elements `f i` mutually
-commute then `exp 𝕂 𝔸 (∑ i, f i) = ∏ i, exp 𝕂 𝔸 (f i)`. -/
+commute then `exp 𝕂 (∑ i, f i) = ∏ i, exp 𝕂 (f i)`. -/
 lemma exp_sum_of_commute {ι} (s : finset ι) (f : ι → 𝔸)
   (h : ∀ (i ∈ s) (j ∈ s), commute (f i) (f j)) :
-  exp 𝕂 𝔸 (∑ i in s, f i) = s.noncomm_prod (λ i, exp 𝕂 𝔸 (f i))
+  exp 𝕂 (∑ i in s, f i) = s.noncomm_prod (λ i, exp 𝕂 (f i))
     (λ i hi j hj, (h i hi j hj).exp 𝕂) :=
 begin
   classical,
@@ -455,7 +457,7 @@ begin
 end
 
 lemma exp_nsmul (n : ℕ) (x : 𝔸) :
-  exp 𝕂 𝔸 (n • x) = exp 𝕂 𝔸 x ^ n :=
+  exp 𝕂 (n • x) = exp 𝕂 x ^ n :=
 begin
   induction n with n ih,
   { rw [zero_smul, pow_zero, exp_zero], },
@@ -465,33 +467,33 @@ end
 variables (𝕂)
 
 /-- Any continuous ring homomorphism commutes with `exp`. -/
-lemma map_exp {F} [ring_hom_class F 𝔸 𝔹] (f : F) (hf : continuous f) (x : 𝔸)  :
-  f (exp 𝕂 𝔸 x) = exp 𝕂 𝔹 (f x) :=
+lemma map_exp {F} [ring_hom_class F 𝔸 𝔹] (f : F) (hf : continuous f) (x : 𝔸) :
+  f (exp 𝕂 x) = exp 𝕂 (f x) :=
 map_exp_of_mem_ball f hf x $ (exp_series_radius_eq_top 𝕂 𝔸).symm ▸ edist_lt_top _ _
 
 lemma exp_smul {G} [monoid G] [mul_semiring_action G 𝔸] [has_continuous_const_smul G 𝔸]
   (g : G) (x : 𝔸) :
-  exp 𝕂 𝔸 (g • x) = g • exp 𝕂 𝔸 x :=
+  exp 𝕂 (g • x) = g • exp 𝕂 x :=
 (map_exp 𝕂 (mul_semiring_action.to_ring_hom G 𝔸 g) (continuous_const_smul _) x).symm
 
 lemma exp_units_conj (y : 𝔸ˣ) (x : 𝔸)  :
-  exp 𝕂 𝔸 (y * x * ↑(y⁻¹)) = y * exp 𝕂 𝔸 x * ↑(y⁻¹) :=
+  exp 𝕂 (y * x * ↑(y⁻¹) : 𝔸) = y * exp 𝕂 x * ↑(y⁻¹) :=
 exp_smul _ (conj_act.to_conj_act y) x
 
 lemma exp_units_conj' (y : 𝔸ˣ) (x : 𝔸)  :
-  exp 𝕂 𝔸 (↑(y⁻¹) * x * y) = ↑(y⁻¹) * exp 𝕂 𝔸 x * y :=
+  exp 𝕂 (↑(y⁻¹) * x * y) = ↑(y⁻¹) * exp 𝕂 x * y :=
 exp_units_conj _ _ _
 
-@[simp] lemma prod.fst_exp [complete_space 𝔹] (x : 𝔸 × 𝔹) : (exp 𝕂 (𝔸 × 𝔹) x).fst = exp 𝕂 𝔸 x.fst :=
+@[simp] lemma prod.fst_exp [complete_space 𝔹] (x : 𝔸 × 𝔹) : (exp 𝕂 x).fst = exp 𝕂 x.fst :=
 map_exp _ (ring_hom.fst 𝔸 𝔹) continuous_fst x
 
-@[simp] lemma prod.snd_exp [complete_space 𝔹] (x : 𝔸 × 𝔹) : (exp 𝕂 (𝔸 × 𝔹) x).snd = exp 𝕂 𝔹 x.snd :=
+@[simp] lemma prod.snd_exp [complete_space 𝔹] (x : 𝔸 × 𝔹) : (exp 𝕂 x).snd = exp 𝕂 x.snd :=
 map_exp _ (ring_hom.snd 𝔸 𝔹) continuous_snd x
 
 @[simp] lemma pi.exp_apply {ι : Type*} {𝔸 : ι → Type*} [fintype ι]
   [Π i, normed_ring (𝔸 i)] [Π i, normed_algebra 𝕂 (𝔸 i)] [Π i, complete_space (𝔸 i)]
   (x : Π i, 𝔸 i) (i : ι) :
-  exp 𝕂 (Π i, 𝔸 i) x i = exp 𝕂 (𝔸 i) (x i) :=
+  exp 𝕂 x i = exp 𝕂 (x i) :=
 begin
   -- Lean struggles to infer this instance due to it wanting `[Π i, semi_normed_ring (𝔸 i)]`
   letI : normed_algebra 𝕂 (Π i, 𝔸 i) := pi.normed_algebra _,
@@ -501,23 +503,23 @@ end
 lemma pi.exp_def {ι : Type*} {𝔸 : ι → Type*} [fintype ι]
   [Π i, normed_ring (𝔸 i)] [Π i, normed_algebra 𝕂 (𝔸 i)] [Π i, complete_space (𝔸 i)]
   (x : Π i, 𝔸 i) :
-  exp 𝕂 (Π i, 𝔸 i) x = λ i, exp 𝕂 (𝔸 i) (x i) :=
+  exp 𝕂 x = λ i, exp 𝕂 (x i) :=
 funext $ pi.exp_apply 𝕂 x
 
 lemma function.update_exp {ι : Type*} {𝔸 : ι → Type*} [fintype ι] [decidable_eq ι]
   [Π i, normed_ring (𝔸 i)] [Π i, normed_algebra 𝕂 (𝔸 i)] [Π i, complete_space (𝔸 i)]
   (x : Π i, 𝔸 i) (j : ι) (xj : 𝔸 j) :
-  function.update (exp 𝕂 (Π i, 𝔸 i) x) j (exp 𝕂 (𝔸 j) xj) = exp 𝕂 _ (function.update x j xj) :=
+  function.update (exp 𝕂 x) j (exp 𝕂 xj) = exp 𝕂 (function.update x j xj) :=
 begin
   ext i,
   simp_rw [pi.exp_def],
-  exact (function.apply_update (λ i, exp 𝕂 (𝔸 i)) x j xj i).symm,
+  exact (function.apply_update (λ i, exp 𝕂) x j xj i).symm,
 end
 
 end complete_algebra
 
 lemma algebra_map_exp_comm (x : 𝕂) :
-  algebra_map 𝕂 𝔸 (exp 𝕂 𝕂 x) = exp 𝕂 𝔸 (algebra_map 𝕂 𝔸 x) :=
+  algebra_map 𝕂 𝔸 (exp 𝕂 x) = exp 𝕂 (algebra_map 𝕂 𝔸 x) :=
 algebra_map_exp_comm_of_mem_ball x $
   (exp_series_radius_eq_top 𝕂 𝕂).symm ▸ edist_lt_top _ _
 
@@ -528,10 +530,10 @@ section division_algebra
 variables {𝕂 𝔸 : Type*} [is_R_or_C 𝕂] [normed_division_ring 𝔸] [normed_algebra 𝕂 𝔸]
 variables [complete_space 𝔸]
 
-lemma exp_neg (x : 𝔸) : exp 𝕂 𝔸 (-x) = (exp 𝕂 𝔸 x)⁻¹ :=
+lemma exp_neg (x : 𝔸) : exp 𝕂 (-x) = (exp 𝕂 x)⁻¹ :=
 exp_neg_of_mem_ball $ (exp_series_radius_eq_top 𝕂 𝔸).symm ▸ edist_lt_top _ _
 
-lemma exp_zsmul (z : ℤ) (x : 𝔸) : exp 𝕂 𝔸 (z • x) = (exp 𝕂 𝔸 x) ^ z :=
+lemma exp_zsmul (z : ℤ) (x : 𝔸) : exp 𝕂 (z • x) = (exp 𝕂 x) ^ z :=
 begin
   obtain ⟨n, rfl | rfl⟩ := z.eq_coe_or_neg,
   { rw [zpow_coe_nat, coe_nat_zsmul, exp_nsmul] },
@@ -539,11 +541,11 @@ begin
 end
 
 lemma exp_conj (y : 𝔸) (x : 𝔸) (hy : y ≠ 0) :
-  exp 𝕂 𝔸 (y * x * y⁻¹) = y * exp 𝕂 𝔸 x * y⁻¹ :=
+  exp 𝕂 (y * x * y⁻¹) = y * exp 𝕂 x * y⁻¹ :=
 exp_units_conj _ (units.mk0 y hy) x
 
 lemma exp_conj' (y : 𝔸) (x : 𝔸)  (hy : y ≠ 0) :
-  exp 𝕂 𝔸 (y⁻¹ * x * y) = y⁻¹ * exp 𝕂 𝔸 x * y :=
+  exp 𝕂 (y⁻¹ * x * y) = y⁻¹ * exp 𝕂 x * y :=
 exp_units_conj' _ (units.mk0 y hy) x
 
 end division_algebra
@@ -553,14 +555,14 @@ section comm_algebra
 variables {𝕂 𝔸 : Type*} [is_R_or_C 𝕂] [normed_comm_ring 𝔸] [normed_algebra 𝕂 𝔸] [complete_space 𝔸]
 
 /-- In a commutative Banach-algebra `𝔸` over `𝕂 = ℝ` or `𝕂 = ℂ`,
-`exp 𝕂 𝔸 (x+y) = (exp 𝕂 𝔸 x) * (exp 𝕂 𝔸 y)`. -/
-lemma exp_add {x y : 𝔸} : exp 𝕂 𝔸 (x + y) = (exp 𝕂 𝔸 x) * (exp 𝕂 𝔸 y) :=
+`exp 𝕂 (x+y) = (exp 𝕂 x) * (exp 𝕂 y)`. -/
+lemma exp_add {x y : 𝔸} : exp 𝕂 (x + y) = (exp 𝕂 x) * (exp 𝕂 y) :=
 exp_add_of_mem_ball ((exp_series_radius_eq_top 𝕂 𝔸).symm ▸ edist_lt_top _ _)
   ((exp_series_radius_eq_top 𝕂 𝔸).symm ▸ edist_lt_top _ _)
 
 /-- A version of `exp_sum_of_commute` for a commutative Banach-algebra. -/
 lemma exp_sum {ι} (s : finset ι) (f : ι → 𝔸) :
-  exp 𝕂 𝔸 (∑ i in s, f i) = ∏ i in s, exp 𝕂 𝔸 (f i) :=
+  exp 𝕂 (∑ i in s, f i) = ∏ i in s, exp 𝕂 (f i) :=
 begin
   rw [exp_sum_of_commute, finset.noncomm_prod_eq_prod],
   exact λ i hi j hj, commute.all _ _,
@@ -586,7 +588,7 @@ by rw [exp_series_apply_eq, exp_series_apply_eq, inv_nat_cast_smul_eq 𝕂 𝕂'
 
 /-- If a normed ring `𝔸` is a normed algebra over two fields, then they define the same
 exponential function on `𝔸`. -/
-lemma exp_eq_exp : exp 𝕂 𝔸 = exp 𝕂' 𝔸 :=
+lemma exp_eq_exp : (exp 𝕂 : 𝔸 → 𝔸) = exp 𝕂' :=
 begin
   ext,
   rw [exp, exp],
@@ -594,14 +596,14 @@ begin
   rw exp_series_eq_exp_series 𝕂 𝕂' 𝔸 n x
 end
 
-lemma exp_ℝ_ℂ_eq_exp_ℂ_ℂ : exp ℝ ℂ = exp ℂ ℂ :=
+lemma exp_ℝ_ℂ_eq_exp_ℂ_ℂ : (exp ℝ : ℂ → ℂ) = exp ℂ :=
 exp_eq_exp ℝ ℂ ℂ
 
 end scalar_tower
 
 lemma star_exp {𝕜 A : Type*} [is_R_or_C 𝕜] [normed_ring A] [normed_algebra 𝕜 A]
   [star_ring A] [normed_star_group A] [complete_space A]
-  [star_module 𝕜 A] (a : A) : star (exp 𝕜 A a) = exp 𝕜 A (star a) :=
+  [star_module 𝕜 A] (a : A) : star (exp 𝕜 a) = exp 𝕜 (star a) :=
 begin
   rw exp_eq_tsum,
   have := continuous_linear_map.map_tsum

--- a/src/analysis/normed_space/spectrum.lean
+++ b/src/analysis/normed_space/spectrum.lean
@@ -373,9 +373,9 @@ local notation `↑ₐ` := algebra_map 𝕜 A
 
 /-- For `𝕜 = ℝ` or `𝕜 = ℂ`, `exp 𝕜 𝕜` maps the spectrum of `a` into the spectrum of `exp 𝕜 A a`. -/
 theorem exp_mem_exp [is_R_or_C 𝕜] [normed_ring A] [normed_algebra 𝕜 A] [complete_space A]
-  (a : A) {z : 𝕜} (hz : z ∈ spectrum 𝕜 a) : exp 𝕜 𝕜 z ∈ spectrum 𝕜 (exp 𝕜 A a) :=
+  (a : A) {z : 𝕜} (hz : z ∈ spectrum 𝕜 a) : exp 𝕜 z ∈ spectrum 𝕜 (exp 𝕜 a) :=
 begin
-  have hexpmul : exp 𝕜 A a = exp 𝕜 A (a - ↑ₐ z) * ↑ₐ (exp 𝕜 𝕜 z),
+  have hexpmul : exp 𝕜 a = exp 𝕜 (a - ↑ₐ z) * ↑ₐ (exp 𝕜 z),
   { rw [algebra_map_exp_comm z, ←exp_add_of_commute (algebra.commutes z (a - ↑ₐz)).symm,
       sub_add_cancel] },
   let b := ∑' n : ℕ, ((n + 1).factorial⁻¹ : 𝕜) • (a - ↑ₐz) ^ n,
@@ -391,13 +391,13 @@ begin
     { simpa only [mul_smul_comm, pow_succ] using hb.tsum_mul_left (a - ↑ₐz) },
   have h₁ : ∑' n : ℕ, ((n + 1).factorial⁻¹ : 𝕜) • (a - ↑ₐz) ^ (n + 1) = b * (a - ↑ₐz),
     { simpa only [pow_succ', algebra.smul_mul_assoc] using hb.tsum_mul_right (a - ↑ₐz) },
-  have h₃ : exp 𝕜 A (a - ↑ₐz) = 1 + (a - ↑ₐz) * b,
+  have h₃ : exp 𝕜 (a - ↑ₐz) = 1 + (a - ↑ₐz) * b,
   { rw exp_eq_tsum,
     convert tsum_eq_zero_add (exp_series_summable' (a - ↑ₐz)),
     simp only [nat.factorial_zero, nat.cast_one, inv_one, pow_zero, one_smul],
     exact h₀.symm },
-  rw [spectrum.mem_iff, is_unit.sub_iff, ←one_mul (↑ₐ(exp 𝕜 𝕜 z)), hexpmul, ←_root_.sub_mul,
-    commute.is_unit_mul_iff (algebra.commutes (exp 𝕜 𝕜 z) (exp 𝕜 A (a - ↑ₐz) - 1)).symm,
+  rw [spectrum.mem_iff, is_unit.sub_iff, ←one_mul (↑ₐ(exp 𝕜 z)), hexpmul, ←_root_.sub_mul,
+    commute.is_unit_mul_iff (algebra.commutes (exp 𝕜 z) (exp 𝕜 (a - ↑ₐz) - 1)).symm,
     sub_eq_iff_eq_add'.mpr h₃, commute.is_unit_mul_iff (h₀ ▸ h₁ : (a - ↑ₐz) * b = b * (a - ↑ₐz))],
   exact not_and_of_not_left _ (not_and_of_not_left _ ((not_iff_not.mpr is_unit.sub_iff).mp hz)),
 end

--- a/src/analysis/normed_space/spectrum.lean
+++ b/src/analysis/normed_space/spectrum.lean
@@ -371,7 +371,7 @@ section exp_mapping
 
 local notation `↑ₐ` := algebra_map 𝕜 A
 
-/-- For `𝕜 = ℝ` or `𝕜 = ℂ`, `exp 𝕜 𝕜` maps the spectrum of `a` into the spectrum of `exp 𝕜 A a`. -/
+/-- For `𝕜 = ℝ` or `𝕜 = ℂ`, `exp 𝕜` maps the spectrum of `a` into the spectrum of `exp 𝕜 a`. -/
 theorem exp_mem_exp [is_R_or_C 𝕜] [normed_ring A] [normed_algebra 𝕜 A] [complete_space A]
   (a : A) {z : 𝕜} (hz : z ∈ spectrum 𝕜 a) : exp 𝕜 z ∈ spectrum 𝕜 (exp 𝕜 a) :=
 begin

--- a/src/analysis/normed_space/star/exponential.lean
+++ b/src/analysis/normed_space/star/exponential.lean
@@ -29,20 +29,20 @@ variables {A : Type*}
 open complex
 
 lemma self_adjoint.exp_i_smul_unitary {a : A} (ha : a ∈ self_adjoint A) :
-  exp ℂ A (I • a) ∈ unitary A :=
+  exp ℂ (I • a) ∈ unitary A :=
 begin
   rw [unitary.mem_iff, star_exp],
   simp only [star_smul, is_R_or_C.star_def, self_adjoint.mem_iff.mp ha, conj_I, neg_smul],
   rw ←@exp_add_of_commute ℂ A _ _ _ _ _ _ ((commute.refl (I • a)).neg_left),
   rw ←@exp_add_of_commute ℂ A _ _ _ _ _ _ ((commute.refl (I • a)).neg_right),
-  simpa only [add_right_neg, add_left_neg, and_self] using (exp_zero : exp ℂ A 0 = 1),
+  simpa only [add_right_neg, add_left_neg, and_self] using (exp_zero : exp ℂ (0 : A) = 1),
 end
 
 /-- The map from the selfadjoint real subspace to the unitary group. This map only makes sense
 over ℂ. -/
 @[simps]
 noncomputable def self_adjoint.exp_unitary (a : self_adjoint A) : unitary A :=
-⟨exp ℂ A (I • a), self_adjoint.exp_i_smul_unitary (a.property)⟩
+⟨exp ℂ (I • a), self_adjoint.exp_i_smul_unitary (a.property)⟩
 
 open self_adjoint
 

--- a/src/analysis/normed_space/star/spectrum.lean
+++ b/src/analysis/normed_space/star/spectrum.lean
@@ -88,11 +88,11 @@ theorem self_adjoint.mem_spectrum_eq_re [star_module ℂ A] [nontrivial A] {a : 
   (ha : a ∈ self_adjoint A) {z : ℂ} (hz : z ∈ spectrum ℂ a) : z = z.re :=
 begin
   let Iu := units.mk0 I I_ne_zero,
-  have : exp ℂ ℂ (I • z) ∈ spectrum ℂ (exp ℂ A (I • a)),
+  have : exp ℂ (I • z) ∈ spectrum ℂ (exp ℂ (I • a)),
     by simpa only [units.smul_def, units.coe_mk0]
       using spectrum.exp_mem_exp (Iu • a) (smul_mem_smul_iff.mpr hz),
   exact complex.ext (of_real_re _)
-    (by simpa only [←complex.exp_eq_exp_ℂ_ℂ, mem_sphere_zero_iff_norm, norm_eq_abs, abs_exp,
+    (by simpa only [←complex.exp_eq_exp_ℂ, mem_sphere_zero_iff_norm, norm_eq_abs, abs_exp,
       real.exp_eq_one_iff, smul_eq_mul, I_mul, neg_eq_zero]
       using spectrum.subset_circle_of_unitary (self_adjoint.exp_i_smul_unitary ha) this),
 end

--- a/src/analysis/special_functions/exponential.lean
+++ b/src/analysis/special_functions/exponential.lean
@@ -11,7 +11,7 @@ import topology.metric_space.cau_seq_filter
 /-!
 # Calculus results on exponential in a Banach algebra
 
-In this file, we prove basic properties about the derivative of the exponential map `exp 𝕂 𝔸`
+In this file, we prove basic properties about the derivative of the exponential map `exp 𝕂`
 in a Banach algebra `𝔸` over a field `𝕂`. We keep them separate from the main file
 `analysis/normed_space/exponential` in order to minimize dependencies.
 
@@ -21,26 +21,26 @@ We prove most result for an arbitrary field `𝕂`, and then specialize to `𝕂
 
 ### General case
 
-- `has_strict_fderiv_at_exp_zero_of_radius_pos` : `exp 𝕂 𝔸` has strict Fréchet-derivative
+- `has_strict_fderiv_at_exp_zero_of_radius_pos` : `exp 𝕂` has strict Fréchet-derivative
   `1 : 𝔸 →L[𝕂] 𝔸` at zero, as long as it converges on a neighborhood of zero
   (see also `has_strict_deriv_at_exp_zero_of_radius_pos` for the case `𝔸 = 𝕂`)
 - `has_strict_fderiv_at_exp_of_lt_radius` : if `𝕂` has characteristic zero and `𝔸` is commutative,
-  then given a point `x` in the disk of convergence, `exp 𝕂 𝔸` as strict Fréchet-derivative
-  `exp 𝕂 𝔸 x • 1 : 𝔸 →L[𝕂] 𝔸` at x (see also `has_strict_deriv_at_exp_of_lt_radius` for the case
+  then given a point `x` in the disk of convergence, `exp 𝕂` as strict Fréchet-derivative
+  `exp 𝕂 x • 1 : 𝔸 →L[𝕂] 𝔸` at x (see also `has_strict_deriv_at_exp_of_lt_radius` for the case
   `𝔸 = 𝕂`)
 
 ### `𝕂 = ℝ` or `𝕂 = ℂ`
 
-- `has_strict_fderiv_at_exp_zero` : `exp 𝕂 𝔸` has strict Fréchet-derivative `1 : 𝔸 →L[𝕂] 𝔸` at zero
+- `has_strict_fderiv_at_exp_zero` : `exp 𝕂` has strict Fréchet-derivative `1 : 𝔸 →L[𝕂] 𝔸` at zero
   (see also `has_strict_deriv_at_exp_zero` for the case `𝔸 = 𝕂`)
-- `has_strict_fderiv_at_exp` : if `𝔸` is commutative, then given any point `x`, `exp 𝕂 𝔸` as strict
-  Fréchet-derivative `exp 𝕂 𝔸 x • 1 : 𝔸 →L[𝕂] 𝔸` at x (see also `has_strict_deriv_at_exp` for the
+- `has_strict_fderiv_at_exp` : if `𝔸` is commutative, then given any point `x`, `exp 𝕂` as strict
+  Fréchet-derivative `exp 𝕂 x • 1 : 𝔸 →L[𝕂] 𝔸` at x (see also `has_strict_deriv_at_exp` for the
   case `𝔸 = 𝕂`)
 
 ### Compatibilty with `real.exp` and `complex.exp`
 
-- `complex.exp_eq_exp_ℂ_ℂ` : `complex.exp = exp ℂ ℂ`
-- `real.exp_eq_exp_ℝ_ℝ` : `real.exp = exp ℝ ℝ`
+- `complex.exp_eq_exp_ℂ` : `complex.exp = exp ℂ ℂ`
+- `real.exp_eq_exp_ℝ` : `real.exp = exp ℝ ℝ`
 
 -/
 
@@ -55,7 +55,7 @@ variables {𝕂 𝔸 : Type*} [nondiscrete_normed_field 𝕂] [normed_ring 𝔸]
 /-- The exponential in a Banach-algebra `𝔸` over a normed field `𝕂` has strict Fréchet-derivative
 `1 : 𝔸 →L[𝕂] 𝔸` at zero, as long as it converges on a neighborhood of zero. -/
 lemma has_strict_fderiv_at_exp_zero_of_radius_pos (h : 0 < (exp_series 𝕂 𝔸).radius) :
-  has_strict_fderiv_at (exp 𝕂 𝔸) (1 : 𝔸 →L[𝕂] 𝔸) 0 :=
+  has_strict_fderiv_at (exp 𝕂) (1 : 𝔸 →L[𝕂] 𝔸) 0 :=
 begin
   convert (has_fpower_series_at_exp_zero_of_radius_pos h).has_strict_fderiv_at,
   ext x,
@@ -66,7 +66,7 @@ end
 /-- The exponential in a Banach-algebra `𝔸` over a normed field `𝕂` has Fréchet-derivative
 `1 : 𝔸 →L[𝕂] 𝔸` at zero, as long as it converges on a neighborhood of zero. -/
 lemma has_fderiv_at_exp_zero_of_radius_pos (h : 0 < (exp_series 𝕂 𝔸).radius) :
-  has_fderiv_at (exp 𝕂 𝔸) (1 : 𝔸 →L[𝕂] 𝔸) 0 :=
+  has_fderiv_at (exp 𝕂) (1 : 𝔸 →L[𝕂] 𝔸) 0 :=
 (has_strict_fderiv_at_exp_zero_of_radius_pos h).has_fderiv_at
 
 end any_field_any_algebra
@@ -77,16 +77,16 @@ variables {𝕂 𝔸 : Type*} [nondiscrete_normed_field 𝕂] [normed_comm_ring 
   [complete_space 𝔸]
 
 /-- The exponential map in a commutative Banach-algebra `𝔸` over a normed field `𝕂` of
-characteristic zero has Fréchet-derivative `exp 𝕂 𝔸 x • 1 : 𝔸 →L[𝕂] 𝔸` at any point `x` in the
+characteristic zero has Fréchet-derivative `exp 𝕂 x • 1 : 𝔸 →L[𝕂] 𝔸` at any point `x` in the
 disk of convergence. -/
 lemma has_fderiv_at_exp_of_mem_ball [char_zero 𝕂] {x : 𝔸}
   (hx : x ∈ emetric.ball (0 : 𝔸) (exp_series 𝕂 𝔸).radius) :
-  has_fderiv_at (exp 𝕂 𝔸) (exp 𝕂 𝔸 x • 1 : 𝔸 →L[𝕂] 𝔸) x :=
+  has_fderiv_at (exp 𝕂) (exp 𝕂 x • 1 : 𝔸 →L[𝕂] 𝔸) x :=
 begin
   have hpos : 0 < (exp_series 𝕂 𝔸).radius := (zero_le _).trans_lt hx,
   rw has_fderiv_at_iff_is_o_nhds_zero,
-  suffices : (λ h, exp 𝕂 𝔸 x * (exp 𝕂 𝔸 (0 + h) - exp 𝕂 𝔸 0 - continuous_linear_map.id 𝕂 𝔸 h))
-    =ᶠ[𝓝 0] (λ h, exp 𝕂 𝔸 (x + h) - exp 𝕂 𝔸 x - exp 𝕂 𝔸 x • continuous_linear_map.id 𝕂 𝔸 h),
+  suffices : (λ h, exp 𝕂 x * (exp 𝕂 (0 + h) - exp 𝕂 0 - continuous_linear_map.id 𝕂 𝔸 h))
+    =ᶠ[𝓝 0] (λ h, exp 𝕂 (x + h) - exp 𝕂 x - exp 𝕂 x • continuous_linear_map.id 𝕂 𝔸 h),
   { refine (is_o.const_mul_left _ _).congr' this (eventually_eq.refl _ _),
     rw ← has_fderiv_at_iff_is_o_nhds_zero,
     exact has_fderiv_at_exp_zero_of_radius_pos hpos },
@@ -98,11 +98,11 @@ begin
 end
 
 /-- The exponential map in a commutative Banach-algebra `𝔸` over a normed field `𝕂` of
-characteristic zero has strict Fréchet-derivative `exp 𝕂 𝔸 x • 1 : 𝔸 →L[𝕂] 𝔸` at any point `x` in
+characteristic zero has strict Fréchet-derivative `exp 𝕂 x • 1 : 𝔸 →L[𝕂] 𝔸` at any point `x` in
 the disk of convergence. -/
 lemma has_strict_fderiv_at_exp_of_mem_ball [char_zero 𝕂] {x : 𝔸}
   (hx : x ∈ emetric.ball (0 : 𝔸) (exp_series 𝕂 𝔸).radius) :
-  has_strict_fderiv_at (exp 𝕂 𝔸) (exp 𝕂 𝔸 x • 1 : 𝔸 →L[𝕂] 𝔸) x :=
+  has_strict_fderiv_at (exp 𝕂) (exp 𝕂 x • 1 : 𝔸 →L[𝕂] 𝔸) x :=
 let ⟨p, hp⟩ := analytic_at_exp_of_mem_ball x hx in
 hp.has_fderiv_at.unique (has_fderiv_at_exp_of_mem_ball hx) ▸ hp.has_strict_fderiv_at
 
@@ -113,29 +113,29 @@ section deriv
 variables {𝕂 : Type*} [nondiscrete_normed_field 𝕂] [complete_space 𝕂]
 
 /-- The exponential map in a complete normed field `𝕂` of characteristic zero has strict derivative
-`exp 𝕂 𝕂 x` at any point `x` in the disk of convergence. -/
+`exp 𝕂 x` at any point `x` in the disk of convergence. -/
 lemma has_strict_deriv_at_exp_of_mem_ball [char_zero 𝕂] {x : 𝕂}
   (hx : x ∈ emetric.ball (0 : 𝕂) (exp_series 𝕂 𝕂).radius) :
-  has_strict_deriv_at (exp 𝕂 𝕂) (exp 𝕂 𝕂 x) x :=
+  has_strict_deriv_at (exp 𝕂) (exp 𝕂 x) x :=
 by simpa using (has_strict_fderiv_at_exp_of_mem_ball hx).has_strict_deriv_at
 
 /-- The exponential map in a complete normed field `𝕂` of characteristic zero has derivative
-`exp 𝕂 𝕂 x` at any point `x` in the disk of convergence. -/
+`exp 𝕂 x` at any point `x` in the disk of convergence. -/
 lemma has_deriv_at_exp_of_mem_ball [char_zero 𝕂] {x : 𝕂}
   (hx : x ∈ emetric.ball (0 : 𝕂) (exp_series 𝕂 𝕂).radius) :
-  has_deriv_at (exp 𝕂 𝕂) (exp 𝕂 𝕂 x) x :=
+  has_deriv_at (exp 𝕂) (exp 𝕂 x) x :=
 (has_strict_deriv_at_exp_of_mem_ball hx).has_deriv_at
 
 /-- The exponential map in a complete normed field `𝕂` of characteristic zero has strict derivative
 `1` at zero, as long as it converges on a neighborhood of zero. -/
 lemma has_strict_deriv_at_exp_zero_of_radius_pos (h : 0 < (exp_series 𝕂 𝕂).radius) :
-  has_strict_deriv_at (exp 𝕂 𝕂) 1 0 :=
+  has_strict_deriv_at (exp 𝕂) (1 : 𝕂) 0 :=
 (has_strict_fderiv_at_exp_zero_of_radius_pos h).has_strict_deriv_at
 
 /-- The exponential map in a complete normed field `𝕂` of characteristic zero has derivative
 `1` at zero, as long as it converges on a neighborhood of zero. -/
 lemma has_deriv_at_exp_zero_of_radius_pos (h : 0 < (exp_series 𝕂 𝕂).radius) :
-  has_deriv_at (exp 𝕂 𝕂) 1 0 :=
+  has_deriv_at (exp 𝕂) (1 : 𝕂) 0 :=
 (has_strict_deriv_at_exp_zero_of_radius_pos h).has_deriv_at
 
 end deriv
@@ -148,13 +148,13 @@ variables {𝕂 𝔸 : Type*} [is_R_or_C 𝕂] [normed_ring 𝔸] [normed_algebr
 /-- The exponential in a Banach-algebra `𝔸` over `𝕂 = ℝ` or `𝕂 = ℂ` has strict Fréchet-derivative
 `1 : 𝔸 →L[𝕂] 𝔸` at zero. -/
 lemma has_strict_fderiv_at_exp_zero :
-  has_strict_fderiv_at (exp 𝕂 𝔸) (1 : 𝔸 →L[𝕂] 𝔸) 0 :=
+  has_strict_fderiv_at (exp 𝕂) (1 : 𝔸 →L[𝕂] 𝔸) 0 :=
 has_strict_fderiv_at_exp_zero_of_radius_pos (exp_series_radius_pos 𝕂 𝔸)
 
 /-- The exponential in a Banach-algebra `𝔸` over `𝕂 = ℝ` or `𝕂 = ℂ` has Fréchet-derivative
 `1 : 𝔸 →L[𝕂] 𝔸` at zero. -/
 lemma has_fderiv_at_exp_zero :
-  has_fderiv_at (exp 𝕂 𝔸) (1 : 𝔸 →L[𝕂] 𝔸) 0 :=
+  has_fderiv_at (exp 𝕂) (1 : 𝔸 →L[𝕂] 𝔸) 0 :=
 has_strict_fderiv_at_exp_zero.has_fderiv_at
 
 end is_R_or_C_any_algebra
@@ -165,15 +165,15 @@ variables {𝕂 𝔸 : Type*} [is_R_or_C 𝕂] [normed_comm_ring 𝔸] [normed_a
   [complete_space 𝔸]
 
 /-- The exponential map in a commutative Banach-algebra `𝔸` over `𝕂 = ℝ` or `𝕂 = ℂ` has strict
-Fréchet-derivative `exp 𝕂 𝔸 x • 1 : 𝔸 →L[𝕂] 𝔸` at any point `x`. -/
+Fréchet-derivative `exp 𝕂 x • 1 : 𝔸 →L[𝕂] 𝔸` at any point `x`. -/
 lemma has_strict_fderiv_at_exp {x : 𝔸} :
-  has_strict_fderiv_at (exp 𝕂 𝔸) (exp 𝕂 𝔸 x • 1 : 𝔸 →L[𝕂] 𝔸) x :=
+  has_strict_fderiv_at (exp 𝕂) (exp 𝕂 x • 1 : 𝔸 →L[𝕂] 𝔸) x :=
 has_strict_fderiv_at_exp_of_mem_ball ((exp_series_radius_eq_top 𝕂 𝔸).symm ▸ edist_lt_top _ _)
 
 /-- The exponential map in a commutative Banach-algebra `𝔸` over `𝕂 = ℝ` or `𝕂 = ℂ` has
-Fréchet-derivative `exp 𝕂 𝔸 x • 1 : 𝔸 →L[𝕂] 𝔸` at any point `x`. -/
+Fréchet-derivative `exp 𝕂 x • 1 : 𝔸 →L[𝕂] 𝔸` at any point `x`. -/
 lemma has_fderiv_at_exp {x : 𝔸} :
-  has_fderiv_at (exp 𝕂 𝔸) (exp 𝕂 𝔸 x • 1 : 𝔸 →L[𝕂] 𝔸) x :=
+  has_fderiv_at (exp 𝕂) (exp 𝕂 x • 1 : 𝔸 →L[𝕂] 𝔸) x :=
 has_strict_fderiv_at_exp.has_fderiv_at
 
 end is_R_or_C_comm_algebra
@@ -182,29 +182,29 @@ section deriv_R_or_C
 
 variables {𝕂 : Type*} [is_R_or_C 𝕂]
 
-/-- The exponential map in `𝕂 = ℝ` or `𝕂 = ℂ` has strict derivative `exp 𝕂 𝕂 x` at any point
+/-- The exponential map in `𝕂 = ℝ` or `𝕂 = ℂ` has strict derivative `exp 𝕂 x` at any point
 `x`. -/
-lemma has_strict_deriv_at_exp {x : 𝕂} : has_strict_deriv_at (exp 𝕂 𝕂) (exp 𝕂 𝕂 x) x :=
+lemma has_strict_deriv_at_exp {x : 𝕂} : has_strict_deriv_at (exp 𝕂) (exp 𝕂 x) x :=
 has_strict_deriv_at_exp_of_mem_ball ((exp_series_radius_eq_top 𝕂 𝕂).symm ▸ edist_lt_top _ _)
 
-/-- The exponential map in `𝕂 = ℝ` or `𝕂 = ℂ` has derivative `exp 𝕂 𝕂 x` at any point `x`. -/
-lemma has_deriv_at_exp {x : 𝕂} : has_deriv_at (exp 𝕂 𝕂) (exp 𝕂 𝕂 x) x :=
+/-- The exponential map in `𝕂 = ℝ` or `𝕂 = ℂ` has derivative `exp 𝕂 x` at any point `x`. -/
+lemma has_deriv_at_exp {x : 𝕂} : has_deriv_at (exp 𝕂) (exp 𝕂 x) x :=
 has_strict_deriv_at_exp.has_deriv_at
 
 /-- The exponential map in `𝕂 = ℝ` or `𝕂 = ℂ` has strict derivative `1` at zero. -/
-lemma has_strict_deriv_at_exp_zero : has_strict_deriv_at (exp 𝕂 𝕂) 1 0 :=
+lemma has_strict_deriv_at_exp_zero : has_strict_deriv_at (exp 𝕂) (1 : 𝕂) 0 :=
 has_strict_deriv_at_exp_zero_of_radius_pos (exp_series_radius_pos 𝕂 𝕂)
 
 /-- The exponential map in `𝕂 = ℝ` or `𝕂 = ℂ` has derivative `1` at zero. -/
 lemma has_deriv_at_exp_zero :
-  has_deriv_at (exp 𝕂 𝕂) 1 0 :=
+  has_deriv_at (exp 𝕂) (1 : 𝕂) 0 :=
 has_strict_deriv_at_exp_zero.has_deriv_at
 
 end deriv_R_or_C
 
 section complex
 
-lemma complex.exp_eq_exp_ℂ_ℂ : complex.exp = exp ℂ ℂ :=
+lemma complex.exp_eq_exp_ℂ : complex.exp = exp ℂ :=
 begin
   refine funext (λ x, _),
   rw [complex.exp, exp_eq_tsum_field],
@@ -216,10 +216,10 @@ end complex
 
 section real
 
-lemma real.exp_eq_exp_ℝ_ℝ : real.exp = exp ℝ ℝ :=
+lemma real.exp_eq_exp_ℝ : real.exp = exp ℝ :=
 begin
   refine funext (λ x, _),
-  rw [real.exp, complex.exp_eq_exp_ℂ_ℂ, ← exp_ℝ_ℂ_eq_exp_ℂ_ℂ, exp_eq_tsum, exp_eq_tsum_field,
+  rw [real.exp, complex.exp_eq_exp_ℂ, ← exp_ℝ_ℂ_eq_exp_ℂ_ℂ, exp_eq_tsum, exp_eq_tsum_field,
       ← re_to_complex, ← re_clm_apply, re_clm.map_tsum (exp_series_summable' (x : ℂ))],
   refine tsum_congr (λ n, _),
   rw [re_clm.map_smul, ← complex.of_real_pow, re_clm_apply, re_to_complex, complex.of_real_re,

--- a/src/combinatorics/derangements/exponential.lean
+++ b/src/combinatorics/derangements/exponential.lean
@@ -34,7 +34,7 @@ begin
     apply has_sum.tendsto_sum_nat,
     -- there's no specific lemma for ℝ that ∑ x^k/k! sums to exp(x), but it's
     -- true in more general fields, so use that lemma
-    rw real.exp_eq_exp_ℝ_ℝ,
+    rw real.exp_eq_exp_ℝ,
     exact exp_series_field_has_sum_exp (-1 : ℝ) },
   intro n,
   rw [← int.cast_coe_nat, num_derangements_sum],


### PR DESCRIPTION
`exp 𝕂 𝔸` is now just `exp 𝕂`.

This also renames two lemmas that refer to this argument in their name to no longer do so.

In a few places we have to add type annotations where they weren't needed before, but nowhere do we need to resort to `@`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
