### PR TITLE
[Merged by Bors] - feat(topology/algebra/monoid): add missing `has_continuous_const_smul` instances

### DIFF
--- a/src/analysis/normed_space/exponential.lean
+++ b/src/analysis/normed_space/exponential.lean
@@ -66,7 +66,7 @@ open_locale nat topological_space big_operators ennreal
 section topological_algebra
 
 variables (𝕂 𝔸 : Type*) [field 𝕂] [ring 𝔸] [algebra 𝕂 𝔸] [topological_space 𝔸]
-  [topological_ring 𝔸] [has_continuous_const_smul 𝕂 𝔸]
+  [topological_ring 𝔸]
 
 /-- `exp_series 𝕂 𝔸` is the `formal_multilinear_series` whose `n`-th term is the map
 `(xᵢ) : 𝔸ⁿ ↦ (1/n! : 𝕂) • ∏ xᵢ`. Its sum is the exponential map `exp 𝕂 𝔸 : 𝔸 → 𝔸`. -/
@@ -576,7 +576,6 @@ section scalar_tower
 
 variables (𝕂 𝕂' 𝔸 : Type*) [field 𝕂] [field 𝕂'] [ring 𝔸] [algebra 𝕂 𝔸] [algebra 𝕂' 𝔸]
   [topological_space 𝔸] [topological_ring 𝔸]
-  [has_continuous_const_smul 𝕂 𝔸] [has_continuous_const_smul 𝕂' 𝔸]
 
 /-- If a normed ring `𝔸` is a normed algebra over two fields, then they define the same
 `exp_series` on `𝔸`. -/

--- a/src/topology/algebra/monoid.lean
+++ b/src/topology/algebra/monoid.lean
@@ -424,6 +424,32 @@ lemma continuous_on.pow {f : X → M} {s : set X} (hf : continuous_on f s) (n : 
   continuous_on (λ x, f x ^ n) s :=
 λ x hx, (hf x hx).pow n
 
+/-- If `R` acts on `A` via `A`, then continuous multiplication implies continuous scalar
+multiplication by constants.
+
+Notably, this instances applies when `R = A`, or when `[algebra R A]` is available. -/
+@[priority 100]
+instance is_scalar_tower.has_continuous_const_smul {R A : Type*} [monoid A] [has_scalar R A]
+  [is_scalar_tower R A A] [topological_space A] [has_continuous_mul A] :
+  has_continuous_const_smul R A :=
+{ continuous_const_smul := λ q, begin
+    simp only [←smul_one_mul q (_ : A)] { single_pass := tt },
+    exact continuous_const.mul continuous_id,
+  end }
+
+/-- If the action of `R` on `A` commutes with left-multiplication, then continuous multiplication
+implies continuous scalar multiplication by constants.
+
+Notably, this instances applies when `R = Aᵐᵒᵖ` -/
+@[priority 100]
+instance smul_comm_class.has_continuous_const_smul {R A : Type*} [monoid A] [has_scalar R A]
+  [smul_comm_class R A A] [topological_space A] [has_continuous_mul A] :
+  has_continuous_const_smul R A :=
+{ continuous_const_smul := λ q, begin
+    simp only [←mul_smul_one q (_ : A)] { single_pass := tt },
+    exact continuous_id.mul continuous_const,
+  end }
+
 end has_continuous_mul
 
 namespace mul_opposite

--- a/src/topology/continuous_function/locally_constant.lean
+++ b/src/topology/continuous_function/locally_constant.lean
@@ -36,7 +36,7 @@ def to_continuous_map_monoid_hom [monoid Y] [has_continuous_mul Y] :
 
 /-- The inclusion of locally-constant functions into continuous functions as an algebra map. -/
 @[simps] def to_continuous_map_alg_hom (R : Type*) [comm_semiring R]
-  [semiring Y] [algebra R Y] [topological_semiring Y] [has_continuous_const_smul R Y] :
+  [semiring Y] [algebra R Y] [topological_semiring Y] :
   locally_constant X Y →ₐ[R] C(X, Y) :=
 { to_fun    := coe,
   map_one'  := by { ext, simp, },


### PR DESCRIPTION
This makes an argument to `exp` redundant.



---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
