### PR TITLE
[Merged by Bors] - docs(data/polynomial/algebra_map): fix a typo in a doc-string

### DIFF
--- a/src/data/polynomial/algebra_map.lean
+++ b/src/data/polynomial/algebra_map.lean
@@ -54,7 +54,7 @@ lemma of_finsupp_algebra_map (r : R) :
 to_finsupp_injective (to_finsupp_algebra_map _).symm
 
 /--
-When we have `[comm_ring R]`, the function `C` is the same as `algebra_map R R[X]`.
+When we have `[comm_semiring R]`, the function `C` is the same as `algebra_map R R[X]`.
 
 (But note that `C` is defined when `R` is not necessarily commutative, in which case
 `algebra_map` is not available.)


### PR DESCRIPTION
The doc-string talks about `comm_ring`, while the lemma uses `comm_semiring`.  I aligned the two to the weaker one!

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
