### PR TITLE
[Merged by Bors] - chore(analysis/normed_space/basic): reorder the `restrict_scalars` definitions

### DIFF
--- a/src/analysis/normed_space/basic.lean
+++ b/src/analysis/normed_space/basic.lean
@@ -453,29 +453,18 @@ section restrict_scalars
 variables (𝕜 : Type*) (𝕜' : Type*) [normed_field 𝕜] [normed_field 𝕜'] [normed_algebra 𝕜 𝕜']
 (E : Type*) [semi_normed_group E] [normed_space 𝕜' E]
 
-/-- Warning: This declaration should be used judiciously.
-Please consider using `is_scalar_tower` instead.
-
-`𝕜`-normed space structure induced by a `𝕜'`-normed space structure when `𝕜'` is a
-normed algebra over `𝕜`. Not registered as an instance as `𝕜'` can not be inferred.
-
-The type synonym `restrict_scalars 𝕜 𝕜' E` will be endowed with this instance by default.
--/
-def normed_space.restrict_scalars : normed_space 𝕜 E :=
-{ norm_smul_le := λc x, le_of_eq $ begin
-    change ∥(algebra_map 𝕜 𝕜' c) • x∥ = ∥c∥ * ∥x∥,
-    simp [norm_smul]
-  end,
-  ..restrict_scalars.module 𝕜 𝕜' E }
-
 instance {𝕜 : Type*} {𝕜' : Type*} {E : Type*} [I : semi_normed_group E] :
   semi_normed_group (restrict_scalars 𝕜 𝕜' E) := I
 
 instance {𝕜 : Type*} {𝕜' : Type*} {E : Type*} [I : normed_group E] :
   normed_group (restrict_scalars 𝕜 𝕜' E) := I
 
+/-- If `E` is a normed space over `𝕜'` and `𝕜` is a normed algebra over `𝕜'`, then
+`restrict_scalars.module` is additionally a normed-/
 instance : normed_space 𝕜 (restrict_scalars 𝕜 𝕜' E) :=
-(normed_space.restrict_scalars 𝕜 𝕜' E : normed_space 𝕜 E)
+{ norm_smul_le := λ c x, (normed_space.norm_smul_le (algebra_map 𝕜 𝕜' c) (_ : E)).trans_eq $
+    by rw norm_algebra_map',
+  ..restrict_scalars.module 𝕜 𝕜' E }
 
 /--
 The action of the original normed_field on `restrict_scalars 𝕜 𝕜' E`.
@@ -486,5 +475,15 @@ This is not an instance as it would be contrary to the purpose of `restrict_scal
 def module.restrict_scalars.normed_space_orig {𝕜 : Type*} {𝕜' : Type*} {E : Type*}
   [normed_field 𝕜'] [semi_normed_group E] [I : normed_space 𝕜' E] :
   normed_space 𝕜' (restrict_scalars 𝕜 𝕜' E) := I
+
+/-- Warning: This declaration should be used judiciously.
+Please consider using `is_scalar_tower` and/or `restrict_scalars 𝕜 𝕜' E` instead.
+
+This definition allows the `restrict_scalars.normed_space` instance to be put directly on `E`
+rather on `restrict_scalars 𝕜 𝕜' E`. This would be a very bad instance; both because `𝕜'` cannot be
+inferred, and because it is likely to create instance diamonds.
+-/
+def normed_space.restrict_scalars : normed_space 𝕜 E :=
+restrict_scalars.normed_space _ 𝕜' _
 
 end restrict_scalars

--- a/src/analysis/normed_space/basic.lean
+++ b/src/analysis/normed_space/basic.lean
@@ -460,7 +460,7 @@ instance {𝕜 : Type*} {𝕜' : Type*} {E : Type*} [I : normed_group E] :
   normed_group (restrict_scalars 𝕜 𝕜' E) := I
 
 /-- If `E` is a normed space over `𝕜'` and `𝕜` is a normed algebra over `𝕜'`, then
-`restrict_scalars.module` is additionally a normed-/
+`restrict_scalars.module` is additionally a `normed_space`. -/
 instance : normed_space 𝕜 (restrict_scalars 𝕜 𝕜' E) :=
 { norm_smul_le := λ c x, (normed_space.norm_smul_le (algebra_map 𝕜 𝕜' c) (_ : E)).trans_eq $
     by rw norm_algebra_map',


### PR DESCRIPTION
This also update the docstrings to make `normed_space.restrict_scalars` even scarier.

The instances here themselves haven't actually changed.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
