### PR TITLE
[Merged by Bors] - refactor(algebra/{group,group_with_zero/basic): Generalize lemmas to division monoids

### DIFF
--- a/src/algebra/continued_fractions/computation/terminates_iff_rat.lean
+++ b/src/algebra/continued_fractions/computation/terminates_iff_rat.lean
@@ -188,8 +188,7 @@ begin
         have : (fr : K)⁻¹ = ((fr⁻¹ : ℚ) : K), by norm_cast,
         have coe_of_fr := (coe_of_rat_eq this),
         simp [int_fract_pair.stream, IH.symm, v_eq_q, stream_q_nth_eq, fr_ne_zero],
-        unfold_coes,
-        simpa [coe_of_fr] } } }
+        exact congr_arg some coe_of_fr } } }
 end
 
 lemma coe_stream_rat_eq :

--- a/src/algebra/group/basic.lean
+++ b/src/algebra/group/basic.lean
@@ -249,48 +249,38 @@ by rw [eq_inv_of_mul_eq_one_left h,  one_div]
 @[to_additive] lemma eq_one_div_of_mul_eq_one_right (h : a * b = 1) : b = 1 / a :=
 by rw [eq_inv_of_mul_eq_one_right h, one_div]
 
+@[to_additive] lemma eq_of_div_eq_one (h : a / b = 1) : a = b :=
+inv_injective $ inv_eq_of_mul_eq_one_right $ by rwa ←div_eq_mul_inv
+
+@[to_additive] lemma div_ne_one_of_ne : a ≠ b → a / b ≠ 1 := mt eq_of_div_eq_one
+
 variables (a b c)
 
 @[to_additive] lemma one_div_mul_one_div_rev : (1 / a) * (1 / b) =  1 / (b * a) := by simp
-
 @[to_additive] lemma inv_div_left : a⁻¹ / b = (b * a)⁻¹ := by simp
-
 @[simp, to_additive] lemma inv_div : (a / b)⁻¹ = b / a := by simp
-
-@[simp, to_additive]
-lemma inv_one : (1 : α)⁻¹ = 1 := by simpa only [one_div, inv_inv] using (inv_div (1 : α) 1).symm
+@[simp, to_additive] lemma one_div_div : 1 / (a / b) = b / a := by simp
+@[simp, to_additive] lemma inv_one : (1 : α)⁻¹ = 1 :=
+by simpa only [one_div, inv_inv] using (inv_div (1 : α) 1).symm
+@[simp, to_additive] lemma div_one : a / 1 = a := by simp
+@[to_additive] lemma one_div_one : (1 : α) / 1 = 1 := div_one _
+@[to_additive] lemma one_div_one_div : 1 / (1 / a) = a := by simp
 
 variables {a b c}
 
 @[simp, to_additive] lemma inv_eq_one : a⁻¹ = 1 ↔ a = 1 := inv_injective.eq_iff' inv_one
 @[simp, to_additive] lemma one_eq_inv : 1 = a⁻¹ ↔ a = 1 := eq_comm.trans inv_eq_one
-
 @[to_additive] lemma inv_ne_one : a⁻¹ ≠ 1 ↔ a ≠ 1 := inv_eq_one.not
-
-@[simp, to_additive] lemma div_one (a : α) : a / 1 = a := by rw [div_eq_mul_inv, inv_one, mul_one]
-
-@[to_additive] lemma one_div_one : (1 : α) / 1 = 1 := div_one _
-
-@[simp, to_additive] lemma one_div_div (a b : α) : 1 / (a / b) = b / a := by rw [one_div, inv_div]
-
-@[to_additive] lemma one_div_one_div (a : α) : 1 / (1 / a) = a := by rw [one_div_div, div_one]
 
 @[to_additive] lemma eq_of_one_div_eq_one_div (h : 1 / a = 1 / b) : a = b :=
 by rw [←one_div_one_div a, h, one_div_one_div]
 
-@[to_additive, field_simps] -- The attributes are out of order on purpose
-lemma div_div_eq_mul_div (a b c : α) : a / (b / c) = (a * c) / b :=
-by rw [div_eq_mul_one_div, one_div_div, ←mul_div_assoc]
+variables (a b c)
 
-@[to_additive] lemma eq_of_div_eq_one (h : a / b = 1) : a = b :=
-by rw [eq_inv_of_mul_eq_one_left (by rwa ←div_eq_mul_inv), inv_inv]
-
-@[to_additive] lemma div_ne_one_of_ne (h : a ≠ b) : a / b ≠ 1 := mt eq_of_div_eq_one h
-
-@[simp, to_additive]
-lemma div_inv_eq_mul (a b : α) : a / b⁻¹ = a * b := by rw [div_eq_mul_inv, inv_inv]
-
-@[to_additive] lemma div_mul_eq_div_div_swap (a b c : α) : a / (b * c) = a / c / b :=
+ -- The attributes are out of order on purpose
+@[to_additive, field_simps] lemma div_div_eq_mul_div : a / (b / c) = a * c / b := by simp
+@[simp, to_additive] lemma div_inv_eq_mul : a / b⁻¹ = a * b := by simp
+@[to_additive] lemma div_mul_eq_div_div_swap : a / (b * c) = a / c / b :=
 by simp only [mul_assoc, mul_inv_rev, div_eq_mul_inv]
 
 end division_monoid
@@ -317,7 +307,6 @@ local attribute [simp] mul_assoc mul_comm mul_left_comm div_eq_mul_inv
 @[to_additive, field_simps] lemma div_mul_eq_mul_div : a / b * c = a * c / b := by simp
 @[to_additive] lemma mul_comm_div : a / b * c = a * (c / b) := by simp
 @[to_additive] lemma div_mul_comm : a / b * c = c / b * a := by simp
-@[to_additive] lemma div_mul_eq_mul_div' : a / c * b = a * (b / c) := by simp
 @[to_additive] lemma div_mul_eq_div_mul_one_div : a / (b * c) = (a / b) * (1 / c) := by simp
 
 @[to_additive] lemma div_div_div_eq : a / b / (c / d) = a * d / (b * c) := by simp
@@ -330,18 +319,11 @@ end division_comm_monoid
 section group
 variables [group G] {a b c d : G}
 
-@[simp, to_additive neg_zero]
-lemma one_inv : 1⁻¹ = (1 : G) :=
-inv_eq_of_mul_eq_one (one_mul 1)
+@[to_additive neg_zero] lemma one_inv : 1⁻¹ = (1 : G) := division_monoid.inv_one
 
-@[simp, to_additive]
-theorem inv_eq_one : a⁻¹ = 1 ↔ a = 1 := division_monoid.inv_eq_one
-
-@[simp, to_additive]
-theorem one_eq_inv : 1 = a⁻¹ ↔ a = 1 := division_monoid.one_eq_inv
-
-@[to_additive]
-theorem inv_ne_one : a⁻¹ ≠ 1 ↔ a ≠ 1 := division_monoid.inv_ne_one
+@[to_additive] theorem inv_eq_one : a⁻¹ = 1 ↔ a = 1 := division_monoid.inv_eq_one
+@[to_additive] theorem one_eq_inv : 1 = a⁻¹ ↔ a = 1 := division_monoid.one_eq_inv
+@[to_additive] theorem inv_ne_one : a⁻¹ ≠ 1 ↔ a ≠ 1 := division_monoid.inv_ne_one
 
 @[simp, to_additive] theorem div_eq_inv_self : a / b = b⁻¹ ↔ a = 1 :=
 by rw [div_eq_mul_inv, mul_left_eq_self]
@@ -437,7 +419,7 @@ by simpa only [div_eq_mul_inv] using λ a a' h, mul_left_injective (b⁻¹) h
 lemma div_right_injective : function.injective (λ a, b / a) :=
 by simpa only [div_eq_mul_inv] using λ a a' h, inv_injective (mul_right_injective b h)
 
-@[simp, to_additive neg_sub]
+@[to_additive neg_sub]
 lemma inv_div' (a b : G) : (a / b)⁻¹ = b / a := division_monoid.inv_div _ _
 
 @[simp, to_additive sub_add_cancel]
@@ -457,7 +439,7 @@ lemma eq_of_div_eq_one' : a / b = 1 → a = b := division_monoid.eq_of_div_eq_on
 
 @[to_additive] lemma div_ne_one_of_ne : a ≠ b → a / b ≠ 1 := division_monoid.div_ne_one_of_ne
 
-@[simp, to_additive]
+@[to_additive]
 lemma div_inv_eq_mul (a b : G) : a / (b⁻¹) = a * b := division_monoid.div_inv_eq_mul _ _
 
 @[to_additive]
@@ -520,8 +502,7 @@ by rw [div_eq_mul_inv, mul_right_eq_self, inv_eq_one]
 
 -- The unprimed version is used by `group_with_zero`.  This is the preferred choice.
 -- See https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/.60div_one'.60
-@[simp, to_additive sub_zero]
-lemma div_one' (a : G) : a / 1 = a := division_monoid.div_one _
+@[to_additive sub_zero] lemma div_one' (a : G) : a / 1 = a := division_monoid.div_one _
 
 @[to_additive eq_sub_iff_add_eq]
 theorem eq_div_iff_mul_eq' : a = b / c ↔ a * c = b :=

--- a/src/algebra/group/basic.lean
+++ b/src/algebra/group/basic.lean
@@ -16,10 +16,13 @@ one-liners from the corresponding axioms. For the definitions of semigroups, mon
 `algebra/group/defs.lean`.
 -/
 
+open function
+
 universe u
+variables {α G : Type*}
 
 section associative
-variables {α : Type u} (f : α → α → α) [is_associative α f] (x y : α)
+variables (f : α → α → α) [is_associative α f] (x y : α)
 
 /--
 Composing two associative operations of `f : α → α → α` on the left
@@ -38,7 +41,6 @@ by { ext z, rw [function.comp_apply, @is_associative.assoc _ f] }
 end associative
 
 section semigroup
-variables {α : Type*}
 
 /--
 Composing two multiplications on the left by `y` then `x`
@@ -90,7 +92,7 @@ lemma mul_one_eq_id : (* (1 : M)) = id := funext mul_one
 end mul_one_class
 
 section comm_semigroup
-variables {G : Type u} [comm_semigroup G]
+variables [comm_semigroup G]
 
 @[no_rsimp, to_additive]
 lemma mul_left_comm : ∀ a b c : G, a * (b * c) = b * (a * c) :=
@@ -160,7 +162,7 @@ eq_comm.trans mul_left_eq_self
 end right_cancel_monoid
 
 section has_involutive_inv
-variables {G : Type u} [has_involutive_inv G] {a b : G}
+variables [has_involutive_inv G] {a b : G}
 
 @[simp, to_additive]
 lemma inv_involutive : function.involutive (has_inv.inv : G → G) := inv_inv
@@ -187,11 +189,15 @@ theorem eq_inv_iff_eq_inv : a = b⁻¹ ↔ b = a⁻¹ :=
 theorem inv_eq_iff_inv_eq  : a⁻¹ = b ↔ b⁻¹ = a :=
 eq_comm.trans $ eq_inv_iff_eq_inv.trans eq_comm
 
+variables (G)
+
+@[to_additive] lemma left_inverse_inv : left_inverse (λ a : G, a⁻¹) (λ a, a⁻¹) := inv_inv
+@[to_additive] lemma right_inverse_inv : left_inverse (λ a : G, a⁻¹) (λ a, a⁻¹) := inv_inv
+
 end has_involutive_inv
 
 section div_inv_monoid
-
-variables {G : Type u} [div_inv_monoid G]
+variables [div_inv_monoid G] {a b c : G}
 
 @[to_additive, field_simps] -- The attributes are out of order on purpose
 lemma inv_eq_one_div (x : G) :
@@ -218,28 +224,124 @@ lemma mul_div_assoc' (a b c : G) : a * (b / c) = (a * b) / c :=
 lemma mul_div (a b c : G) : a * (b / c) = a * b / c :=
 by simp only [mul_assoc, div_eq_mul_inv]
 
+@[to_additive] lemma div_eq_mul_one_div (a b : G) : a / b = a * (1 / b) :=
+by rw [div_eq_mul_inv, one_div]
+
 end div_inv_monoid
 
+namespace division_monoid
+variables [division_monoid α] {a b c : α}
+
+local attribute [simp] mul_assoc div_eq_mul_inv
+
+@[to_additive] lemma inv_eq_of_mul_eq_one_left (h : a * b = 1) : b⁻¹ = a :=
+by rw [←inv_eq_of_mul_eq_one_right h, inv_inv]
+
+@[to_additive] lemma eq_inv_of_mul_eq_one_left (h : a * b = 1) : a = b⁻¹ :=
+(inv_eq_of_mul_eq_one_left h).symm
+
+@[to_additive] lemma eq_inv_of_mul_eq_one_right (h : a * b = 1) : b = a⁻¹ :=
+(inv_eq_of_mul_eq_one_right h).symm
+
+@[to_additive] lemma eq_one_div_of_mul_eq_one_left (h : b * a = 1) : b = 1 / a :=
+by rw [eq_inv_of_mul_eq_one_left h,  one_div]
+
+@[to_additive] lemma eq_one_div_of_mul_eq_one_right (h : a * b = 1) : b = 1 / a :=
+by rw [eq_inv_of_mul_eq_one_right h, one_div]
+
+variables (a b c)
+
+@[to_additive] lemma one_div_mul_one_div_rev : (1 / a) * (1 / b) =  1 / (b * a) := by simp
+
+@[to_additive] lemma inv_div_left : a⁻¹ / b = (b * a)⁻¹ := by simp
+
+@[simp, to_additive] lemma inv_div : (a / b)⁻¹ = b / a := by simp
+
+@[simp, to_additive]
+lemma inv_one : (1 : α)⁻¹ = 1 := by simpa only [one_div, inv_inv] using (inv_div (1 : α) 1).symm
+
+variables {a b c}
+
+@[simp, to_additive] lemma inv_eq_one : a⁻¹ = 1 ↔ a = 1 := inv_injective.eq_iff' inv_one
+@[simp, to_additive] lemma one_eq_inv : 1 = a⁻¹ ↔ a = 1 := eq_comm.trans inv_eq_one
+
+@[to_additive] lemma inv_ne_one : a⁻¹ ≠ 1 ↔ a ≠ 1 := inv_eq_one.not
+
+@[simp, to_additive] lemma div_one (a : α) : a / 1 = a := by rw [div_eq_mul_inv, inv_one, mul_one]
+
+@[to_additive] lemma one_div_one : (1 : α) / 1 = 1 := div_one _
+
+@[simp, to_additive] lemma one_div_div (a b : α) : 1 / (a / b) = b / a := by rw [one_div, inv_div]
+
+@[to_additive] lemma one_div_one_div (a : α) : 1 / (1 / a) = a := by rw [one_div_div, div_one]
+
+@[to_additive] lemma eq_of_one_div_eq_one_div (h : 1 / a = 1 / b) : a = b :=
+by rw [←one_div_one_div a, h, one_div_one_div]
+
+@[to_additive, field_simps] -- The attributes are out of order on purpose
+lemma div_div_eq_mul_div (a b c : α) : a / (b / c) = (a * c) / b :=
+by rw [div_eq_mul_one_div, one_div_div, ←mul_div_assoc]
+
+@[to_additive] lemma eq_of_div_eq_one (h : a / b = 1) : a = b :=
+by rw [eq_inv_of_mul_eq_one_left (by rwa ←div_eq_mul_inv), inv_inv]
+
+@[to_additive] lemma div_ne_one_of_ne (h : a ≠ b) : a / b ≠ 1 := mt eq_of_div_eq_one h
+
+@[simp, to_additive]
+lemma div_inv_eq_mul (a b : α) : a / b⁻¹ = a * b := by rw [div_eq_mul_inv, inv_inv]
+
+@[to_additive] lemma div_mul_eq_div_div_swap (a b c : α) : a / (b * c) = a / c / b :=
+by simp only [mul_assoc, mul_inv_rev, div_eq_mul_inv]
+
+end division_monoid
+
+namespace division_comm_monoid
+variables [division_comm_monoid α] (a b c d : α)
+
+local attribute [simp] mul_assoc mul_comm mul_left_comm div_eq_mul_inv
+
+@[to_additive neg_add] lemma mul_inv : (a * b)⁻¹ = a⁻¹ * b⁻¹ := by simp
+@[to_additive] lemma div_eq_inv_mul : a / b = b⁻¹ * a := by simp
+@[to_additive] lemma inv_mul_eq_div : a⁻¹ * b = b / a := by simp
+@[to_additive] lemma inv_mul' : (a * b)⁻¹ = a⁻¹ / b := by simp
+@[to_additive] lemma inv_div_inv : (a⁻¹ / b⁻¹) = b / a := by simp
+@[to_additive] lemma inv_inv_div_inv : (a⁻¹ / b⁻¹)⁻¹ = a / b := by simp
+@[to_additive] lemma one_div_mul_one_div : (1 / a) * (1 / b) =  1 / (a * b) := by simp
+
+@[to_additive] lemma div_right_comm : a / b / c = a / c / b := by simp
+@[to_additive] lemma div_div : a / b / c = a / (b * c) := by simp
+@[to_additive] lemma div_mul : a / b * c = a / (b / c) := by simp
+@[to_additive] lemma mul_div_left_comm : a * (b / c) = b * (a / c) := by simp
+@[to_additive] lemma mul_div_right_comm : a * b / c = a / c * b := by simp
+@[to_additive] lemma div_mul_eq_div_div : a / (b * c) = a / b / c := by simp
+@[to_additive, field_simps] lemma div_mul_eq_mul_div : a / b * c = a * c / b := by simp
+@[to_additive] lemma mul_comm_div : a / b * c = a * (c / b) := by simp
+@[to_additive] lemma div_mul_comm : a / b * c = c / b * a := by simp
+@[to_additive] lemma div_mul_eq_mul_div' : a / c * b = a * (b / c) := by simp
+@[to_additive] lemma div_mul_eq_div_mul_one_div : a / (b * c) = (a / b) * (1 / c) := by simp
+
+@[to_additive] lemma div_div_div_eq : a / b / (c / d) = a * d / (b * c) := by simp
+@[to_additive] lemma div_div_div_comm : a / b / (c / d) = a / c / (b / d) := by simp
+@[to_additive] lemma div_mul_div_comm : a / b * (c / d) = a * c / (b * d) := by simp
+@[to_additive] lemma mul_div_mul_comm : a * b / (c * d) = a / c * (b / d) := by simp
+
+end division_comm_monoid
+
 section group
-variables {G : Type u} [group G] {a b c d : G}
+variables [group G] {a b c d : G}
 
 @[simp, to_additive neg_zero]
 lemma one_inv : 1⁻¹ = (1 : G) :=
 inv_eq_of_mul_eq_one (one_mul 1)
 
-@[to_additive]
-theorem left_inverse_inv (G) [has_involutive_inv G] :
-  function.left_inverse (λ a : G, a⁻¹) (λ a, a⁻¹) :=
-inv_inv
+@[simp, to_additive]
+theorem inv_eq_one : a⁻¹ = 1 ↔ a = 1 := division_monoid.inv_eq_one
 
 @[simp, to_additive]
-theorem inv_eq_one : a⁻¹ = 1 ↔ a = 1 := inv_injective.eq_iff' one_inv
-
-@[simp, to_additive]
-theorem one_eq_inv : 1 = a⁻¹ ↔ a = 1 := eq_comm.trans inv_eq_one
+theorem one_eq_inv : 1 = a⁻¹ ↔ a = 1 := division_monoid.one_eq_inv
 
 @[to_additive]
-theorem inv_ne_one : a⁻¹ ≠ 1 ↔ a ≠ 1 := not_congr inv_eq_one
+theorem inv_ne_one : a⁻¹ ≠ 1 ↔ a ≠ 1 := division_monoid.inv_ne_one
 
 @[simp, to_additive] theorem div_eq_inv_self : a / b = b⁻¹ ↔ a = 1 :=
 by rw [div_eq_mul_inv, mul_left_eq_self]
@@ -253,9 +355,7 @@ theorem mul_right_surjective (a : G) : function.surjective (λ x, x * a) :=
 λ x, ⟨x * a⁻¹, inv_mul_cancel_right x a⟩
 
 @[to_additive]
-lemma eq_inv_of_mul_eq_one (h : a * b = 1) : a = b⁻¹ :=
-have a⁻¹ = b, from inv_eq_of_mul_eq_one h,
-by simp [this.symm]
+lemma eq_inv_of_mul_eq_one : a * b = 1 → a = b⁻¹ := division_monoid.eq_inv_of_mul_eq_one_left
 
 @[to_additive]
 lemma eq_mul_inv_of_mul_eq (h : a * c = b) : a = b * c⁻¹ :=
@@ -338,8 +438,7 @@ lemma div_right_injective : function.injective (λ a, b / a) :=
 by simpa only [div_eq_mul_inv] using λ a a' h, inv_injective (mul_right_injective b h)
 
 @[simp, to_additive neg_sub]
-lemma inv_div' (a b : G) : (a / b)⁻¹ = b / a :=
-by rw [div_eq_mul_inv, div_eq_mul_inv, mul_inv_rev, inv_inv]
+lemma inv_div' (a b : G) : (a / b)⁻¹ = b / a := division_monoid.inv_div _ _
 
 @[simp, to_additive sub_add_cancel]
 lemma div_mul_cancel' (a b : G) : a / b * b = a :=
@@ -354,21 +453,16 @@ lemma mul_div_cancel'' (a b : G) : a * b / b = a :=
 by rw [div_eq_mul_inv, mul_inv_cancel_right a b]
 
 @[to_additive eq_of_sub_eq_zero]
-lemma eq_of_div_eq_one' (h : a / b = 1) : a = b :=
-calc a = a / b * b : (div_mul_cancel' a b).symm
-   ... = b         : by rw [h, one_mul]
+lemma eq_of_div_eq_one' : a / b = 1 → a = b := division_monoid.eq_of_div_eq_one
 
-@[to_additive]
-lemma div_ne_one_of_ne (h : a ≠ b) : a / b ≠ 1 :=
-mt eq_of_div_eq_one' h
+@[to_additive] lemma div_ne_one_of_ne : a ≠ b → a / b ≠ 1 := division_monoid.div_ne_one_of_ne
 
 @[simp, to_additive]
-lemma div_inv_eq_mul (a b : G) : a / (b⁻¹) = a * b :=
-by rw [div_eq_mul_inv, inv_inv]
+lemma div_inv_eq_mul (a b : G) : a / (b⁻¹) = a * b := division_monoid.div_inv_eq_mul _ _
 
 @[to_additive]
 lemma div_mul_eq_div_div_swap (a b c : G) : a / (b * c) = a / c / b :=
-by simp only [mul_assoc, mul_inv_rev , div_eq_mul_inv]
+division_monoid.div_mul_eq_div_div_swap _ _ _
 
 @[simp, to_additive]
 lemma mul_div_mul_right_eq_div (a b c : G) : (a * c) / (b * c) = a / b :=
@@ -407,8 +501,7 @@ lemma div_div_div_cancel_right' (a b c : G) : (a / c) / (b / c) = a / b :=
 by rw [← inv_div' c b, div_inv_eq_mul, div_mul_div_cancel']
 
 @[to_additive]
-theorem div_div_assoc_swap : a / (b / c) = a * c / b :=
-by simp only [mul_assoc, mul_inv_rev, inv_inv, div_eq_mul_inv]
+theorem div_div_assoc_swap : a / (b / c) = a * c / b := division_monoid.div_div_eq_mul_div _ _ _
 
 @[to_additive]
 theorem div_eq_one : a / b = 1 ↔ a = b :=
@@ -428,8 +521,7 @@ by rw [div_eq_mul_inv, mul_right_eq_self, inv_eq_one]
 -- The unprimed version is used by `group_with_zero`.  This is the preferred choice.
 -- See https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/.60div_one'.60
 @[simp, to_additive sub_zero]
-lemma div_one' (a : G) : a / 1 = a :=
-div_eq_self.2 rfl
+lemma div_one' (a : G) : a / 1 = a := division_monoid.div_one _
 
 @[to_additive eq_sub_iff_add_eq]
 theorem eq_div_iff_mul_eq' : a = b / c ↔ a * c = b :=
@@ -475,13 +567,12 @@ end
 end group
 
 section comm_group
-variables {G : Type u} [comm_group G] {a b c d : G}
+variables [comm_group G] {a b c d : G}
 
 local attribute [simp] mul_assoc mul_comm mul_left_comm div_eq_mul_inv
 
 @[to_additive neg_add]
-lemma mul_inv (a b : G) : (a * b)⁻¹ = a⁻¹ * b⁻¹ :=
-by rw [mul_inv_rev, mul_comm]
+lemma mul_inv (a b : G) : (a * b)⁻¹ = a⁻¹ * b⁻¹ := division_comm_monoid.mul_inv _ _
 
 @[to_additive]
 lemma div_eq_of_eq_mul' {a b c : G} (h : a = b * c) : a / b = c :=
@@ -489,34 +580,32 @@ by rw [h, div_eq_mul_inv, mul_comm, inv_mul_cancel_left]
 
 @[to_additive]
 lemma mul_div_left_comm {x y z : G} : x * (y / z) = y * (x / z) :=
-by simp_rw [div_eq_mul_inv, mul_left_comm]
+division_comm_monoid.mul_div_left_comm _ _ _
 
 @[to_additive]
 lemma div_mul_div_comm (a b c d : G) : a / b * (c / d) = a * c / (b * d) :=
-by simp
+division_comm_monoid.div_mul_div_comm _ _ _ _
 
 @[to_additive]
-lemma div_div_div_comm (a b c d : G) : (a / b) / (c / d) = (a / c) / (b / d) := by simp
+lemma div_div_div_comm (a b c d : G) : (a / b) / (c / d) = (a / c) / (b / d) :=
+division_comm_monoid.div_div_div_comm _ _ _ _
 
 @[to_additive]
 lemma div_mul_eq_div_div (a b c : G) : a / (b * c) = a / b / c :=
-by simp
+division_comm_monoid.div_mul_eq_div_div _ _ _
 
 @[to_additive]
-lemma inv_mul_eq_div (a b : G) : a⁻¹ * b = b / a :=
-by simp
+lemma inv_mul_eq_div (a b : G) : a⁻¹ * b = b / a := division_comm_monoid.inv_mul_eq_div _ _
 
 @[to_additive sub_add_eq_add_sub]
 lemma div_mul_eq_mul_div' (a b c : G) : a / b * c = a * c / b :=
-by simp
+division_comm_monoid.div_mul_eq_mul_div _ _ _
 
 @[to_additive]
-lemma div_div (a b c : G) : a / b / c = a / (b * c) :=
-by simp
+lemma div_div (a b c : G) : a / b / c = a / (b * c) := division_comm_monoid.div_div _ _ _
 
 @[to_additive]
-lemma div_mul (a b c : G) : a / b * c = a / (b / c) :=
-by simp
+lemma div_mul (a b c : G) : a / b * c = a / (b / c) := division_comm_monoid.div_mul _ _ _
 
 @[simp, to_additive]
 lemma mul_div_mul_left_eq_div (a b c : G) : (c * a) / (c * b) = a / b :=
@@ -540,33 +629,28 @@ by simpa using mul_inv_cancel_left a b
 
 @[to_additive add_sub_comm]
 lemma mul_div_comm' (a b c d : G) : a * b / (c * d) = (a / c) * (b / d) :=
-by simp
+division_comm_monoid.mul_div_mul_comm _ _ _ _
 
 @[to_additive]
-lemma div_eq_div_mul_div (a b c : G) : a / b = c / b * (a / c) :=
-begin simp, rw [mul_left_comm c], simp end
+lemma div_eq_div_mul_div (a b c : G) : a / b = c / b * (a / c) := by simp [mul_left_comm c]
 
 @[to_additive]
-lemma inv_inv_div_inv (a b : G) : (a⁻¹ / b⁻¹)⁻¹ = a / b :=
-by simp
+lemma inv_inv_div_inv (a b : G) : (a⁻¹ / b⁻¹)⁻¹ = a / b := division_comm_monoid.inv_inv_div_inv _ _
 
 @[simp, to_additive]
 lemma div_div_cancel (a b : G) : a / (a / b) = b := div_div_self' a b
 
 @[to_additive sub_eq_neg_add]
-lemma div_eq_inv_mul' (a b : G) : a / b = b⁻¹ * a :=
-by rw [div_eq_mul_inv, mul_comm _ _]
+lemma div_eq_inv_mul' (a b : G) : a / b = b⁻¹ * a := division_comm_monoid.div_eq_inv_mul _ _
 
 @[simp, to_additive]
 lemma div_div_cancel_left (a b : G) : a / b / a = b⁻¹ := by simp
 
 @[to_additive]
-theorem inv_mul' (a b : G) : (a * b)⁻¹ = a⁻¹ / b :=
-by rw [div_eq_mul_inv, mul_inv a b]
+theorem inv_mul' (a b : G) : (a * b)⁻¹ = a⁻¹ / b := division_comm_monoid.inv_mul' _ _
 
 @[simp, to_additive]
-lemma inv_div_inv (a b : G) : a⁻¹ / b⁻¹ = b / a :=
-by simp [div_eq_inv_mul', mul_comm]
+lemma inv_div_inv (a b : G) : a⁻¹ / b⁻¹ = b / a := division_comm_monoid.inv_div_inv _ _
 
 @[to_additive eq_sub_iff_add_eq']
 lemma eq_div_iff_mul_eq'' : a = b / c ↔ c * a = b :=
@@ -597,7 +681,7 @@ by rw [← div_eq_mul_inv, mul_div_cancel'_right a b]
 
 @[to_additive sub_right_comm]
 lemma div_right_comm' (a b c : G) : a / b / c = a / c / b :=
-by { repeat { rw div_eq_mul_inv }, exact mul_right_comm _ _ _ }
+division_comm_monoid.div_right_comm _ _ _
 
 @[simp, to_additive]
 lemma mul_mul_div_cancel (a b c : G) : (a * c) * (b / c) = a * b :=

--- a/src/algebra/group/defs.lean
+++ b/src/algebra/group/defs.lean
@@ -685,6 +685,9 @@ variables [division_monoid G] {a b : G}
 @[simp, to_additive neg_add_rev] lemma mul_inv_rev (a b : G) : (a * b)⁻¹ = b⁻¹ * a⁻¹ :=
 division_monoid.mul_inv_rev _ _
 
+@[to_additive]
+lemma inv_eq_of_mul_eq_one_right : a * b = 1 → a⁻¹ = b := division_monoid.inv_eq_of_mul _ _
+
 @[simp, to_additive]
 lemma inv_eq_of_mul_eq_one : a * b = 1 → a⁻¹ = b := division_monoid.inv_eq_of_mul _ _
 

--- a/src/algebra/group_with_zero/basic.lean
+++ b/src/algebra/group_with_zero/basic.lean
@@ -570,10 +570,6 @@ calc (a * b⁻¹) * b = a * (b⁻¹ * b) : mul_assoc _ _ _
 calc a⁻¹ * (a * b) = (a⁻¹ * a) * b : (mul_assoc _ _ _).symm
                ... = b             : by simp [h]
 
-@[simp] lemma inv_one : 1⁻¹ = (1:G₀) :=
-calc 1⁻¹ = 1 * 1⁻¹ : by rw [one_mul]
-     ... = (1:G₀)  : by simp
-
 private lemma inv_eq_of_mul (h : a * b = 1) : a⁻¹ = b :=
 by rw [← inv_mul_cancel_left₀ (left_ne_zero_of_mul_eq_one h) b, h, mul_one]
 
@@ -593,6 +589,8 @@ instance group_with_zero.to_division_monoid : division_monoid G₀ :=
   end,
   inv_eq_of_mul := λ a b, inv_eq_of_mul,
   ..‹group_with_zero G₀› }
+
+@[simp] lemma inv_one : 1⁻¹ = (1:G₀) := division_monoid.inv_one
 
 /-- Multiplying `a` by itself and then by its inverse results in `a`
 (whether or not `a` is zero). -/
@@ -631,16 +629,10 @@ by rw [div_eq_mul_inv, mul_self_mul_inv a]
 @[simp] lemma div_self_mul_self (a : G₀) : a / a * a = a :=
 by rw [div_eq_mul_inv, mul_inv_mul_self a]
 
-lemma eq_inv_of_mul_right_eq_one (h : a * b = 1) :
-  b = a⁻¹ :=
-by rw [← inv_mul_cancel_left₀ (left_ne_zero_of_mul_eq_one h) b, h, mul_one]
+lemma eq_inv_of_mul_right_eq_one : a * b = 1 → b = a⁻¹ := division_monoid.eq_inv_of_mul_eq_one_right
+lemma eq_inv_of_mul_left_eq_one : a * b = 1 → a = b⁻¹ := division_monoid.eq_inv_of_mul_eq_one_left
 
-lemma eq_inv_of_mul_left_eq_one (h : a * b = 1) :
-  a = b⁻¹ :=
-by rw [← mul_inv_cancel_right₀ (right_ne_zero_of_mul_eq_one h) a, h, one_mul]
-
-@[simp] lemma inv_eq_one₀ : g⁻¹ = 1 ↔ g = 1 :=
-by rw [inv_eq_iff_inv_eq, inv_one, eq_comm]
+@[simp] lemma inv_eq_one₀ : g⁻¹ = 1 ↔ g = 1 := division_monoid.inv_eq_one
 
 lemma eq_mul_inv_iff_mul_eq₀ (hc : c ≠ 0) : a = b * c⁻¹ ↔ a * c = b :=
 by split; rintro rfl; [rw inv_mul_cancel_right₀ hc, rw mul_inv_cancel_right₀ hc]
@@ -756,20 +748,12 @@ instance group_with_zero.cancel_monoid_with_zero : cancel_monoid_with_zero G₀ 
     units.mk0 x (mul_ne_zero_iff.mp hxy).1 * units.mk0 y (mul_ne_zero_iff.mp hxy).2 :=
 by { ext, refl }
 
-lemma mul_inv_rev₀ (x y : G₀) : (x * y)⁻¹ = y⁻¹ * x⁻¹ :=
-begin
-  by_cases hx : x = 0, { simp [hx] },
-  by_cases hy : y = 0, { simp [hy] },
-  symmetry,
-  apply eq_inv_of_mul_left_eq_one,
-  simp [mul_assoc, hx, hy]
-end
+lemma mul_inv_rev₀ (x y : G₀) : (x * y)⁻¹ = y⁻¹ * x⁻¹ := mul_inv_rev _ _
 
 @[simp] lemma div_self {a : G₀} (h : a ≠ 0) : a / a = 1 :=
 by rw [div_eq_mul_inv, mul_inv_cancel h]
 
-@[simp] lemma div_one (a : G₀) : a / 1 = a :=
-by simp [div_eq_mul_inv a 1]
+@[simp] lemma div_one (a : G₀) : a / 1 = a := division_monoid.div_one _
 
 @[simp] lemma zero_div (a : G₀) : 0 / a = 0 :=
 by rw [div_eq_mul_inv, zero_mul]
@@ -792,11 +776,8 @@ classical.by_cases (λ hb : b = 0, by simp [*]) (mul_div_cancel a)
 local attribute [simp] div_eq_mul_inv mul_comm mul_assoc mul_left_comm
 
 @[simp] lemma div_self_mul_self' (a : G₀) : a / (a * a) = a⁻¹ :=
-calc a / (a * a) = a⁻¹⁻¹ * a⁻¹ * a⁻¹ : by simp [mul_inv_rev₀]
+calc a / (a * a) = a⁻¹⁻¹ * a⁻¹ * a⁻¹ : by simp [mul_inv_rev]
 ... = a⁻¹ : inv_mul_mul_self _
-
-lemma div_eq_mul_one_div (a b : G₀) : a / b = a * (1 / b) :=
-by simp
 
 lemma mul_one_div_cancel {a : G₀} (h : a ≠ 0) : a * (1 / a) = 1 :=
 by simp [h]
@@ -804,26 +785,23 @@ by simp [h]
 lemma one_div_mul_cancel {a : G₀} (h : a ≠ 0) : (1 / a) * a = 1 :=
 by simp [h]
 
-lemma one_div_one : 1 / 1 = (1:G₀) :=
-div_self (ne.symm zero_ne_one)
+lemma one_div_one : 1 / 1 = (1:G₀) := division_monoid.one_div_one
 
 lemma one_div_ne_zero {a : G₀} (h : a ≠ 0) : 1 / a ≠ 0 :=
 by simpa only [one_div] using inv_ne_zero h
 
-lemma eq_one_div_of_mul_eq_one {a b : G₀} (h : a * b = 1) : b = 1 / a :=
-by simpa only [one_div] using eq_inv_of_mul_right_eq_one h
+lemma eq_one_div_of_mul_eq_one {a b : G₀} : a * b = 1 → b = 1 / a :=
+division_monoid.eq_one_div_of_mul_eq_one_right
 
-lemma eq_one_div_of_mul_eq_one_left {a b : G₀} (h : b * a = 1) : b = 1 / a :=
-by simpa only [one_div] using eq_inv_of_mul_left_eq_one h
+lemma eq_one_div_of_mul_eq_one_left {a b : G₀} : b * a = 1 → b = 1 / a :=
+division_monoid.eq_one_div_of_mul_eq_one_left
 
-@[simp] lemma one_div_div (a b : G₀) : 1 / (a / b) = b / a :=
-by rw [one_div, div_eq_mul_inv, mul_inv_rev₀, inv_inv, div_eq_mul_inv]
+@[simp] lemma one_div_div (a b : G₀) : 1 / (a / b) = b / a := division_monoid.one_div_div _ _
 
-lemma one_div_one_div (a : G₀) : 1 / (1 / a) = a :=
-by simp
+lemma one_div_one_div (a : G₀) : 1 / (1 / a) = a := division_monoid.one_div_one_div _
 
-lemma eq_of_one_div_eq_one_div {a b : G₀} (h : 1 / a = 1 / b) : a = b :=
-by rw [← one_div_one_div a, h, one_div_one_div]
+lemma eq_of_one_div_eq_one_div {a b : G₀} : 1 / a = 1 / b → a = b :=
+division_monoid.eq_of_one_div_eq_one_div
 
 variables {a b c : G₀}
 
@@ -834,7 +812,7 @@ by rw [inv_eq_iff_inv_eq, inv_zero, eq_comm]
 eq_comm.trans $ inv_eq_zero.trans eq_comm
 
 lemma one_div_mul_one_div_rev (a b : G₀) : (1 / a) * (1 / b) =  1 / (b * a) :=
-by simp only [div_eq_mul_inv, one_mul, mul_inv_rev₀]
+division_monoid.one_div_mul_one_div_rev _ _
 
 theorem divp_eq_div (a : G₀) (u : G₀ˣ) : a /ₚ u = a / u :=
 by simpa only [div_eq_mul_inv] using congr_arg ((*) a) u.coe_inv'
@@ -843,11 +821,9 @@ by simpa only [div_eq_mul_inv] using congr_arg ((*) a) u.coe_inv'
   a /ₚ units.mk0 b hb = a / b :=
 divp_eq_div _ _
 
-lemma inv_div : (a / b)⁻¹ = b / a :=
-by rw [div_eq_mul_inv, mul_inv_rev₀, div_eq_mul_inv, inv_inv]
+lemma inv_div : (a / b)⁻¹ = b / a := division_monoid.inv_div _ _
 
-lemma inv_div_left : a⁻¹ / b = (b * a)⁻¹ :=
-by rw [mul_inv_rev₀, div_eq_mul_inv]
+lemma inv_div_left : a⁻¹ / b = (b * a)⁻¹ := division_monoid.inv_div_left _ _
 
 lemma div_ne_zero (ha : a ≠ 0) (hb : b ≠ 0) : a / b ≠ 0 :=
 by { rw div_eq_mul_inv, exact mul_ne_zero ha (inv_ne_zero hb) }
@@ -874,13 +850,7 @@ lemma div_eq_of_eq_mul {x : G₀} (hx : x ≠ 0) {y z : G₀} (h : y = z * x) : 
 lemma eq_div_of_mul_eq {x : G₀} (hx : x ≠ 0) {y z : G₀} (h : z * x = y) : z = y / x :=
 eq.symm $ div_eq_of_eq_mul hx h.symm
 
-lemma eq_of_div_eq_one (h : a / b = 1) : a = b :=
-begin
-  by_cases hb : b = 0,
-  { rw [hb, div_zero] at h,
-    exact eq_of_zero_eq_one h a b },
-  { rwa [div_eq_iff_mul_eq hb, one_mul, eq_comm] at h }
-end
+lemma eq_of_div_eq_one : a / b = 1 → a = b := division_monoid.eq_of_div_eq_one
 
 lemma div_eq_one_iff_eq (hb : b ≠ 0) : a / b = 1 ↔ a = b :=
 ⟨eq_of_div_eq_one, λ h, h.symm ▸ div_self hb⟩
@@ -907,7 +877,7 @@ funext ring.inverse_eq_inv
 
 @[field_simps] lemma div_div_eq_mul_div (a b c : G₀) :
   a / (b / c) = (a * c) / b :=
-by rw [div_eq_mul_one_div, one_div_div, ← mul_div_assoc]
+division_monoid.div_div_eq_mul_div _ _ _
 
 /-- Dividing `a` by the result of dividing `a` by itself results in
 `a` (whether or not `a` is zero). -/
@@ -972,11 +942,10 @@ protected def function.surjective.comm_group_with_zero [has_zero G₀'] [has_mul
   comm_group_with_zero G₀' :=
 { .. hf.group_with_zero h01 f zero one mul inv div npow zpow, .. hf.comm_semigroup f mul }
 
-lemma mul_inv₀ : (a * b)⁻¹ = a⁻¹ * b⁻¹ :=
-by rw [mul_inv_rev₀, mul_comm]
+lemma mul_inv₀ : (a * b)⁻¹ = a⁻¹ * b⁻¹ := division_comm_monoid.mul_inv _ _
 
 lemma one_div_mul_one_div (a b : G₀) : (1 / a) * (1 / b) = 1 / (a * b) :=
-by rw [one_div_mul_one_div_rev, mul_comm b]
+division_comm_monoid.one_div_mul_one_div _ _
 
 lemma div_mul_right {a : G₀} (b : G₀) (ha : a ≠ 0) : a / (a * b) = 1 / b :=
 by rw [mul_comm, div_mul_left ha]
@@ -997,21 +966,21 @@ local attribute [simp] mul_assoc mul_comm mul_left_comm
 
 lemma div_mul_div_comm₀ (a b c d : G₀) :
       (a / b) * (c / d) = (a * c) / (b * d) :=
-by simp [div_eq_mul_inv, mul_inv₀]
+division_comm_monoid.div_mul_div_comm _ _ _ _
 
 lemma div_div_div_comm₀ (a b c d : G₀) : (a / b) / (c / d) = (a / c) / (b / d) :=
-by simp_rw [div_eq_mul_inv, mul_inv₀, inv_inv, mul_mul_mul_comm]
+division_comm_monoid.div_div_div_comm _ _ _ _
 
 lemma mul_div_mul_left (a b : G₀) {c : G₀} (hc : c ≠ 0) :
       (c * a) / (c * b) = a / b :=
 by rw [mul_comm c, mul_comm c, mul_div_mul_right _ _ hc]
 
 @[field_simps] lemma div_mul_eq_mul_div (a b c : G₀) : (b / c) * a = (b * a) / c :=
-by simp [div_eq_mul_inv]
+division_comm_monoid.div_mul_eq_mul_div _ _ _
 
 lemma div_mul_eq_mul_div_comm (a b c : G₀) :
       (b / c) * a = b * (a / c) :=
-by rw [div_mul_eq_mul_div, ← one_mul c, ← div_mul_div_comm₀, div_one, one_mul]
+division_comm_monoid.mul_comm_div _ _ _
 
 lemma mul_eq_mul_of_div_eq_div (a : G₀) {b : G₀} (c : G₀) {d : G₀} (hb : b ≠ 0)
       (hd : d ≠ 0) (h : a / b = c / d) : a * d = c * b :=
@@ -1020,15 +989,15 @@ by rw [← mul_one (a*d), mul_assoc, mul_comm d, ← mul_assoc, ← div_self hb,
 
 @[field_simps] lemma div_div_eq_div_mul (a b c : G₀) :
       (a / b) / c = a / (b * c) :=
-by rw [div_eq_mul_one_div, div_mul_div_comm₀, mul_one]
+division_comm_monoid.div_div _ _ _
 
 lemma div_div_div_div_eq (a : G₀) {b c d : G₀} :
       (a / b) / (c / d) = (a * d) / (b * c) :=
-by rw [div_div_eq_mul_div, div_mul_eq_mul_div, div_div_eq_div_mul]
+division_comm_monoid.div_div_div_eq _ _ _  _
 
 lemma div_mul_eq_div_mul_one_div (a b c : G₀) :
       a / (b * c) = (a / b) * (1 / c) :=
-by rw [← div_div_eq_div_mul, ← div_eq_mul_one_div]
+division_comm_monoid.div_mul_eq_div_mul_one_div _ _ _
 
 lemma div_helper {a : G₀} (b : G₀) (h : a ≠ 0) : (1 / (a * b)) * a = 1 / b :=
 by rw [div_mul_eq_mul_div, one_mul, div_mul_right _ h]
@@ -1038,23 +1007,22 @@ end comm_group_with_zero
 section comm_group_with_zero
 variables [comm_group_with_zero G₀] {a b c d : G₀}
 
-lemma div_eq_inv_mul : a / b = b⁻¹ * a :=
-by rw [div_eq_mul_inv, mul_comm]
+lemma div_eq_inv_mul : a / b = b⁻¹ * a := division_comm_monoid.div_eq_inv_mul _ _
 
 lemma mul_div_right_comm (a b c : G₀) : (a * b) / c = (a / c) * b :=
-by rw [div_eq_mul_inv, mul_assoc, mul_comm b, ← mul_assoc, div_eq_mul_inv]
+division_comm_monoid.mul_div_right_comm _ _ _
 
-lemma mul_comm_div' (a b c : G₀) : (a / b) * c = a * (c / b) :=
-by rw [← mul_div_assoc, mul_div_right_comm]
+lemma mul_comm_div' (a b c : G₀) : a / b * c = a * (c / b) :=
+division_comm_monoid.mul_comm_div _ _ _
 
 lemma div_mul_comm' (a b c : G₀) : (a / b) * c = (c / b) * a :=
-by rw [div_mul_eq_mul_div, mul_comm, mul_div_right_comm]
+division_comm_monoid.div_mul_comm _ _ _
 
 lemma mul_div_comm (a b c : G₀) : a * (b / c) = b * (a / c) :=
-by rw [← mul_div_assoc, mul_comm, mul_div_assoc]
+division_comm_monoid.mul_div_left_comm _ _ _
 
 lemma div_right_comm (a : G₀) : (a / b) / c = (a / c) / b :=
-by rw [div_div_eq_div_mul, div_div_eq_div_mul, mul_comm]
+division_comm_monoid.div_right_comm _ _ _
 
 @[field_simps] lemma div_eq_div_iff (hb : b ≠ 0) (hd : d ≠ 0) : a / b = c / d ↔ a * d = c * b :=
 calc a / b = c / d ↔ a / b * (b * d) = c / d * (b * d) :

--- a/src/algebra/group_with_zero/basic.lean
+++ b/src/algebra/group_with_zero/basic.lean
@@ -632,7 +632,7 @@ by rw [div_eq_mul_inv, mul_inv_mul_self a]
 lemma eq_inv_of_mul_right_eq_one : a * b = 1 → b = a⁻¹ := division_monoid.eq_inv_of_mul_eq_one_right
 lemma eq_inv_of_mul_left_eq_one : a * b = 1 → a = b⁻¹ := division_monoid.eq_inv_of_mul_eq_one_left
 
-@[simp] lemma inv_eq_one₀ : g⁻¹ = 1 ↔ g = 1 := division_monoid.inv_eq_one
+lemma inv_eq_one₀ : g⁻¹ = 1 ↔ g = 1 := division_monoid.inv_eq_one
 
 lemma eq_mul_inv_iff_mul_eq₀ (hc : c ≠ 0) : a = b * c⁻¹ ↔ a * c = b :=
 by split; rintro rfl; [rw inv_mul_cancel_right₀ hc, rw mul_inv_cancel_right₀ hc]
@@ -753,7 +753,7 @@ lemma mul_inv_rev₀ (x y : G₀) : (x * y)⁻¹ = y⁻¹ * x⁻¹ := mul_inv_re
 @[simp] lemma div_self {a : G₀} (h : a ≠ 0) : a / a = 1 :=
 by rw [div_eq_mul_inv, mul_inv_cancel h]
 
-@[simp] lemma div_one (a : G₀) : a / 1 = a := division_monoid.div_one _
+lemma div_one (a : G₀) : a / 1 = a := division_monoid.div_one _
 
 @[simp] lemma zero_div (a : G₀) : 0 / a = 0 :=
 by rw [div_eq_mul_inv, zero_mul]
@@ -776,7 +776,7 @@ classical.by_cases (λ hb : b = 0, by simp [*]) (mul_div_cancel a)
 local attribute [simp] div_eq_mul_inv mul_comm mul_assoc mul_left_comm
 
 @[simp] lemma div_self_mul_self' (a : G₀) : a / (a * a) = a⁻¹ :=
-calc a / (a * a) = a⁻¹⁻¹ * a⁻¹ * a⁻¹ : by simp [mul_inv_rev]
+calc a / (a * a) = a⁻¹⁻¹ * a⁻¹ * a⁻¹ : by simp [mul_inv_rev₀]
 ... = a⁻¹ : inv_mul_mul_self _
 
 lemma mul_one_div_cancel {a : G₀} (h : a ≠ 0) : a * (1 / a) = 1 :=
@@ -796,7 +796,7 @@ division_monoid.eq_one_div_of_mul_eq_one_right
 lemma eq_one_div_of_mul_eq_one_left {a b : G₀} : b * a = 1 → b = 1 / a :=
 division_monoid.eq_one_div_of_mul_eq_one_left
 
-@[simp] lemma one_div_div (a b : G₀) : 1 / (a / b) = b / a := division_monoid.one_div_div _ _
+lemma one_div_div (a b : G₀) : 1 / (a / b) = b / a := division_monoid.one_div_div _ _
 
 lemma one_div_one_div (a : G₀) : 1 / (1 / a) = a := division_monoid.one_div_one_div _
 

--- a/src/analysis/special_functions/trigonometric/complex.lean
+++ b/src/analysis/special_functions/trigonometric/complex.lean
@@ -217,7 +217,7 @@ by simpa [mul_comm x] using strict_concave_on_sin_Icc.concave_on.2 ⟨le_rfl, pi
 lemma mul_lt_sin {x : ℝ} (hx : 0 < x) (hx' : x < π / 2) : (2 / π) * x < sin x :=
 begin
   rw [←inv_div],
-  simpa [pi_div_two_pos.ne', mul_nonneg, inv_nonneg] using @lt_sin_mul ((π / 2)⁻¹ * x) _ _,
+  simpa [-division_monoid.inv_div, pi_div_two_pos.ne'] using @lt_sin_mul ((π / 2)⁻¹ * x) _ _,
   { exact mul_pos (inv_pos.2 pi_div_two_pos) hx },
   { rwa [←div_eq_inv_mul, div_lt_one pi_div_two_pos] },
 end
@@ -227,7 +227,7 @@ of Jordan's inequality, the other half is `real.sin_lt` -/
 lemma mul_le_sin {x : ℝ} (hx : 0 ≤ x) (hx' : x ≤ π / 2) : (2 / π) * x ≤ sin x :=
 begin
   rw [←inv_div],
-  simpa [pi_div_two_pos.ne', mul_nonneg, inv_nonneg] using @le_sin_mul ((π / 2)⁻¹ * x) _ _,
+  simpa [-division_monoid.inv_div, pi_div_two_pos.ne'] using @le_sin_mul ((π / 2)⁻¹ * x) _ _,
   { exact mul_nonneg (inv_nonneg.2 pi_div_two_pos.le) hx },
   { rwa [←div_eq_inv_mul, div_le_one pi_div_two_pos] },
 end


### PR DESCRIPTION
Generalize `group` and `group_with_zero` lemmas to `division_monoid`. We do not actually delete the original lemmas but make them one-liners from the new ones. The next PR will then delete the old lemmas and perform the renames in all files.

Lemmas are renamed because
* one of the `group` or `group_with_zero` name has to go
* the new API should have a consistent naming convention

Pre-emptive lemma renames
---
`group` lemma, `group_with_zero` lemma → new `division_monoid`/`division_comm_monoid` lemma
* `inv_eq_of_mul_eq_one`, `inv_eq_of_mul_left_eq_one` → `inv_eq_of_mul_eq_one_left`
* -, `inv_eq_of_mul_right_eq_one` → `inv_eq_of_mul_eq_one_right`
* `eq_inv_of_mul_eq_one`, `eq_inv_of_mul_left_eq_one` → `eq_inv_of_mul_eq_one_left`
* -, `eq_inv_of_mul_right_eq_one` → `eq_inv_of_mul_eq_one_right`
* -, `eq_one_div_of_mul_eq_one` → `eq_one_div_of_mul_eq_one_right`
* `inv_div'`, `inv_div` → `inv_div`
* `div_one'`, `div_one` → `div_one`
* `eq_of_div_eq_one'`, `eq_of_div_eq_one` → `eq_of_div_eq_one`
* `div_eq_inv_mul'`, `div_eq_inv_mul` → `div_eq_inv_mul`
* `div_right_comm'`, `div_right_comm` → `div_right_comm`
* `div_mul_eq_mul_div'`, `div_mul_eq_mul_div` → `div_mul_eq_mul_div`
* `mul_comm_div'`, `div_mul_eq_mul_div_comm` → `mul_comm_div`
* `mul_inv`, `mul_inv₀` → `mul_inv`
* `inv_eq_one`, `inv_eq_one₀` → `inv_eq_one`
* `one_eq_inv`, `one_eq_inv₀` → `one_eq_inv`
* `div_div_div_comm`, `div_div_div_comm₀` → `div_div_div_comm`
* `div_mul_div_comm`, `div_mul_div_comm₀` → `div_mul_div_comm`
* `mul_div_comm'`, - → `mul_div_mul_comm`
* `one_inv`, `inv_one` → `inv_one`
* `div_div`, `div_div_eq_div_mul` → `div_div`
* `mul_div_left_comm`, `mul_div_comm` → `mul_div_left_comm`
* `div_div_assoc_swap`, `div_div_eq_mul_div` → `div_div_eq_mul_div`

Other changes
---
* Generalize `left_inverse_inv` and `right_inverse_inv` to `has_involutive_inv`, and `div_eq_mul_one_div` to `div_inv_monoid`.
* Arguments order
* Arguments implicitness

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

I found that splitting the refactor in this unusual way allowed me to have a cleaner diff and be systematically sure that I wasn't missing lemmas. The only problem is that I have to unsimp the old lemmas.

Here's what to look out for if you want to check for yourself:
* All lemma renames are either because of the `group`/`group_with_zero` disparity or naming consistency within the new API.
* `simp` and `field_simp` are copied correctly.
* Every eligible `group`/`group_with_zero` lemma in the two files has been one-lined (some in other files haven't, but I will take care of them in another PR.
* Every new `division_monoid` lemma is used to one-line an old lemma.
* Arguments are explicit for unconditional equalities and implicit for implications and iffs.
* Everything is additivized.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
