### PR TITLE
[Merged by Bors] - chore(measure_theory/function/conditional_expectation): change the definition of condexp and its notation

### DIFF
--- a/src/measure_theory/function/conditional_expectation.lean
+++ b/src/measure_theory/function/conditional_expectation.lean
@@ -33,12 +33,12 @@ The construction is done in four steps:
 
 The conditional expectation and its properties
 
-* `condexp (hm : m ≤ m0) (μ : measure α) (f : α → E)`: conditional expectation of `f` with respect
-  to `m`.
+* `condexp (m : measurable_space α) (μ : measure α) (f : α → E)`: conditional expectation of `f`
+  with respect to `m`.
 * `integrable_condexp` : `condexp` is integrable.
-* `measurable_condexp` : `condexp` is `m`-measurable.
+* `strongly_measurable_condexp` : `condexp` is `m`-strongly-measurable.
 * `set_integral_condexp (hf : integrable f μ) (hs : measurable_set[m] s)` : the conditional
-  expectation verifies `∫ x in s, condexp hm μ f x ∂μ = ∫ x in s, f x ∂μ` for any `m`-measurable
+  expectation verifies `∫ x in s, condexp m μ f x ∂μ = ∫ x in s, f x ∂μ` for any `m`-measurable
   set `s`.
 
 While `condexp` is function-valued, we also define `condexp_L1` with value in `L1` and a continuous
@@ -57,8 +57,8 @@ Uniqueness of the conditional expectation
 ## Notations
 
 For a measure `μ` defined on a measurable space structure `m0`, another measurable space structure
-`m` with `hm : m ≤ m0` (a sub-sigma-algebra) and a function `f`, we define the notation
-* `μ[f|hm] = condexp hm μ f`.
+`m` with `hm : m ≤ m0` (a sub-σ-algebra) and a function `f`, we define the notation
+* `μ[f|m] = condexp m μ f`.
 
 ## Implementation notes
 
@@ -1814,37 +1814,52 @@ section condexp
 
 open_locale classical
 
-variables {𝕜} {m m0 : measurable_space α} {μ : measure α}
-  {hm : m ≤ m0} [sigma_finite (μ.trim hm)] {f g : α → F'} {s : set α}
+variables {𝕜} {m m0 : measurable_space α} {μ : measure α} {f g : α → F'} {s : set α}
 
 variables (m)
-/-- Conditional expectation of a function. Its value is 0 if the function is not integrable. -/
-@[irreducible] def condexp (hm : m ≤ m0) (μ : measure α) [sigma_finite (μ.trim hm)] (f : α → F') :
+/-- Conditional expectation of a function. Its value is 0 if the function is not integrable, if
+the σ-algebra is not a sub-σ-algebra or if the measure is not σ-finite on that σ-algebra. -/
+@[irreducible] def condexp (μ : measure α) (f : α → F') :
   α → F' :=
-if (strongly_measurable[m] f ∧ integrable f μ) then f
-else ae_strongly_measurable'_condexp_L1.mk (condexp_L1 hm μ f)
+if hm : m ≤ m0
+  then if hμ : sigma_finite (μ.trim hm)
+    then if (strongly_measurable[m] f ∧ integrable f μ)
+      then f
+      else (@ae_strongly_measurable'_condexp_L1 _ _ _ _ _ m m0 μ hm hμ _).mk
+        (@condexp_L1 _ _ _ _ _ _ _ hm μ hμ f)
+    else 0
+  else 0
 
 variables {m}
 
--- We define notations `μ[f|hm]` and `μ[f|m,hm]` for the conditional expectation of `f` with
--- respect to `m`. Both can be used in code but only the second one will be used by the goal view.
--- The first notation avoids the repetition of `m`, which is already present in `hm`. The second
--- one ensures that `m` stays visible in the goal view: when `hm` is complicated, it gets rendered
--- as `_` and the measurable space would not be visible in `μ[f|_]`, but is clear in `μ[f|m,_]`.
-localized "notation  μ `[` f `|` hm `]` := measure_theory.condexp _ hm μ f" in measure_theory
-localized "notation  μ `[` f `|` m `,` hm `]` := measure_theory.condexp m hm μ f" in measure_theory
+-- We define notation `μ[f|m]` for the conditional expectation of `f` with respect to `m`.
+localized "notation  μ `[` f `|` m `]` := measure_theory.condexp m μ f" in measure_theory
 
-lemma condexp_of_strongly_measurable
+lemma condexp_of_not_le (hm_not : ¬ m ≤ m0) : μ[f|m] = 0 := by rw [condexp, dif_neg hm_not]
+
+lemma condexp_of_not_sigma_finite (hm : m ≤ m0) (hμm_not : ¬ sigma_finite (μ.trim hm)) :
+  μ[f|m] = 0 :=
+by rw [condexp, dif_pos hm, dif_neg hμm_not]
+
+lemma condexp_of_sigma_finite (hm : m ≤ m0) (hμm : sigma_finite (μ.trim hm)) :
+  μ[f|m] =
+  if (strongly_measurable[m] f ∧ integrable f μ)
+    then f else ae_strongly_measurable'_condexp_L1.mk (condexp_L1 hm μ f) :=
+by rw [condexp, dif_pos hm, dif_pos hμm]
+
+lemma condexp_of_strongly_measurable (hm : m ≤ m0) [hμm : sigma_finite (μ.trim hm)]
   {f : α → F'} (hf : strongly_measurable[m] f) (hfi : integrable f μ) :
-  μ[f|m,hm] = f :=
-by rw [condexp, if_pos (⟨hf, hfi⟩ : strongly_measurable[m] f ∧ integrable f μ)]
+  μ[f|m] = f :=
+by rw [condexp_of_sigma_finite hm hμm,
+  if_pos (⟨hf, hfi⟩ : strongly_measurable[m] f ∧ integrable f μ)]
 
-lemma condexp_const (c : F') [is_finite_measure μ] : μ[(λ x : α, c)|m,hm] = λ _, c :=
-condexp_of_strongly_measurable (@strongly_measurable_const _ _ m _ _) (integrable_const c)
+lemma condexp_const (hm : m ≤ m0) (c : F') [is_finite_measure μ] : μ[(λ x : α, c)|m] = λ _, c :=
+condexp_of_strongly_measurable hm (@strongly_measurable_const _ _ m _ _) (integrable_const c)
 
-lemma condexp_ae_eq_condexp_L1 (f : α → F') : μ[f|m,hm] =ᵐ[μ] condexp_L1 hm μ f :=
+lemma condexp_ae_eq_condexp_L1 (hm : m ≤ m0) [hμm : sigma_finite (μ.trim hm)]
+  (f : α → F') : μ[f|m] =ᵐ[μ] condexp_L1 hm μ f :=
 begin
-  unfold condexp,
+  rw condexp_of_sigma_finite hm hμm,
   by_cases hfm : strongly_measurable[m] f,
   { by_cases hfi : integrable f μ,
     { rw if_pos (⟨hfm, hfi⟩ : strongly_measurable[m] f ∧ integrable f μ),
@@ -1856,25 +1871,43 @@ begin
   exact (ae_strongly_measurable'.ae_eq_mk ae_strongly_measurable'_condexp_L1).symm,
 end
 
-lemma condexp_ae_eq_condexp_L1_clm (hf : integrable f μ) :
-  μ[f|m,hm] =ᵐ[μ] condexp_L1_clm hm μ (hf.to_L1 f) :=
+lemma condexp_ae_eq_condexp_L1_clm (hm : m ≤ m0) [sigma_finite (μ.trim hm)] (hf : integrable f μ) :
+  μ[f|m] =ᵐ[μ] condexp_L1_clm hm μ (hf.to_L1 f) :=
 begin
-  refine (condexp_ae_eq_condexp_L1 f).trans (eventually_of_forall (λ x, _)),
+  refine (condexp_ae_eq_condexp_L1 hm f).trans (eventually_of_forall (λ x, _)),
   rw condexp_L1_eq hf,
 end
 
-lemma condexp_undef (hf : ¬ integrable f μ) : μ[f|m,hm] =ᵐ[μ] 0 :=
+lemma condexp_undef (hf : ¬ integrable f μ) : μ[f|m] =ᵐ[μ] 0 :=
 begin
-  refine (condexp_ae_eq_condexp_L1 f).trans (eventually_eq.trans _ (coe_fn_zero _ 1 _)),
+  by_cases hm : m ≤ m0,
+  swap, { rw condexp_of_not_le hm, },
+  by_cases hμm : sigma_finite (μ.trim hm),
+  swap, { rw condexp_of_not_sigma_finite hm hμm, },
+  haveI : sigma_finite (μ.trim hm) := hμm,
+  refine (condexp_ae_eq_condexp_L1 hm f).trans (eventually_eq.trans _ (coe_fn_zero _ 1 _)),
   rw condexp_L1_undef hf,
 end
 
-@[simp] lemma condexp_zero : μ[(0 : α → F')|m,hm] = 0 :=
-condexp_of_strongly_measurable (@strongly_measurable_zero _ _ m _ _) (integrable_zero _ _ _)
-
-lemma strongly_measurable_condexp : strongly_measurable[m] (μ[f|m,hm]) :=
+@[simp] lemma condexp_zero : μ[(0 : α → F')|m] = 0 :=
 begin
-  unfold condexp,
+  by_cases hm : m ≤ m0,
+  swap, { rw condexp_of_not_le hm, },
+  by_cases hμm : sigma_finite (μ.trim hm),
+  swap, { rw condexp_of_not_sigma_finite hm hμm, },
+  haveI : sigma_finite (μ.trim hm) := hμm,
+  exact condexp_of_strongly_measurable hm (@strongly_measurable_zero _ _ m _ _)
+    (integrable_zero _ _ _),
+end
+
+lemma strongly_measurable_condexp : strongly_measurable[m] (μ[f|m]) :=
+begin
+  by_cases hm : m ≤ m0,
+  swap, { rw condexp_of_not_le hm, exact strongly_measurable_zero, },
+  by_cases hμm : sigma_finite (μ.trim hm),
+  swap, { rw condexp_of_not_sigma_finite hm hμm, exact strongly_measurable_zero, },
+  haveI : sigma_finite (μ.trim hm) := hμm,
+  rw condexp_of_sigma_finite hm hμm,
   by_cases hfm : strongly_measurable[m] f,
   { by_cases hfi : integrable f μ,
     { rwa if_pos (⟨hfm, hfi⟩ : strongly_measurable[m] f ∧ integrable f μ), },
@@ -1884,25 +1917,30 @@ begin
   exact ae_strongly_measurable'.strongly_measurable_mk _,
 end
 
-lemma integrable_condexp : integrable (μ[f|m,hm]) μ :=
-(integrable_condexp_L1 f).congr (condexp_ae_eq_condexp_L1 f).symm
-
-variable (hm)
+lemma integrable_condexp : integrable (μ[f|m]) μ :=
+begin
+  by_cases hm : m ≤ m0,
+  swap, { rw condexp_of_not_le hm, exact integrable_zero _ _ _, },
+  by_cases hμm : sigma_finite (μ.trim hm),
+  swap, { rw condexp_of_not_sigma_finite hm hμm, exact integrable_zero _ _ _, },
+  haveI : sigma_finite (μ.trim hm) := hμm,
+  exact (integrable_condexp_L1 f).congr (condexp_ae_eq_condexp_L1 hm f).symm,
+end
 
 /-- The integral of the conditional expectation `μ[f|hm]` over an `m`-measurable set is equal to
 the integral of `f` on that set. -/
-lemma set_integral_condexp (hf : integrable f μ) (hs : measurable_set[m] s) :
-  ∫ x in s, μ[f|m,hm] x ∂μ = ∫ x in s, f x ∂μ :=
+lemma set_integral_condexp (hm : m ≤ m0) [sigma_finite (μ.trim hm)]
+  (hf : integrable f μ) (hs : measurable_set[m] s) :
+  ∫ x in s, μ[f|m] x ∂μ = ∫ x in s, f x ∂μ :=
 begin
-  rw set_integral_congr_ae (hm s hs) ((condexp_ae_eq_condexp_L1 f).mono (λ x hx _, hx)),
+  rw set_integral_congr_ae (hm s hs) ((condexp_ae_eq_condexp_L1 hm f).mono (λ x hx _, hx)),
   exact set_integral_condexp_L1 hf hs,
 end
 
-variable {hm}
-
-lemma integral_condexp (hf : integrable f μ) : ∫ x, μ[f|m,hm] x ∂μ = ∫ x, f x ∂μ :=
+lemma integral_condexp {hm : m ≤ m0} [hμm : sigma_finite (μ.trim hm)]
+  (hf : integrable f μ) : ∫ x, μ[f|m] x ∂μ = ∫ x, f x ∂μ :=
 begin
-  suffices : ∫ x in set.univ, μ[f|m,hm] x ∂μ = ∫ x in set.univ, f x ∂μ,
+  suffices : ∫ x in set.univ, μ[f|m] x ∂μ = ∫ x in set.univ, f x ∂μ,
     by { simp_rw integral_univ at this, exact this, },
   exact set_integral_condexp hm hf (@measurable_set.univ _ m),
 end
@@ -1915,7 +1953,7 @@ lemma ae_eq_condexp_of_forall_set_integral_eq (hm : m ≤ m0) [sigma_finite (μ.
   (hg_int_finite : ∀ s, measurable_set[m] s → μ s < ∞ → integrable_on g s μ)
   (hg_eq : ∀ s : set α, measurable_set[m] s → μ s < ∞ → ∫ x in s, g x ∂μ = ∫ x in s, f x ∂μ)
   (hgm : ae_strongly_measurable' m g μ) :
-  g =ᵐ[μ] μ[f|m,hm] :=
+  g =ᵐ[μ] μ[f|m] :=
 begin
   refine ae_eq_of_forall_set_integral_eq_of_sigma_finite' hm hg_int_finite
     (λ s hs hμs, integrable_condexp.integrable_on) (λ s hs hμs, _) hgm
@@ -1924,56 +1962,70 @@ begin
 end
 
 lemma condexp_add (hf : integrable f μ) (hg : integrable g μ) :
-  μ[f + g | m,hm] =ᵐ[μ] μ[f|m,hm] + μ[g|m,hm] :=
+  μ[f + g | m] =ᵐ[μ] μ[f|m] + μ[g|m] :=
 begin
-  refine (condexp_ae_eq_condexp_L1 _).trans _,
+  by_cases hm : m ≤ m0,
+  swap, { simp_rw condexp_of_not_le hm, simp, },
+  by_cases hμm : sigma_finite (μ.trim hm),
+  swap, { simp_rw condexp_of_not_sigma_finite hm hμm, simp, },
+  haveI : sigma_finite (μ.trim hm) := hμm,
+  refine (condexp_ae_eq_condexp_L1 hm _).trans _,
   rw condexp_L1_add hf hg,
   exact (coe_fn_add _ _).trans
-    ((condexp_ae_eq_condexp_L1 _).symm.add (condexp_ae_eq_condexp_L1 _).symm),
+    ((condexp_ae_eq_condexp_L1 hm _).symm.add (condexp_ae_eq_condexp_L1 hm _).symm),
 end
 
-lemma condexp_smul (c : 𝕜) (f : α → F') : μ[c • f | m,hm] =ᵐ[μ] c • μ[f|m,hm] :=
+lemma condexp_smul (c : 𝕜) (f : α → F') : μ[c • f | m] =ᵐ[μ] c • μ[f|m] :=
 begin
-  refine (condexp_ae_eq_condexp_L1 _).trans _,
+  by_cases hm : m ≤ m0,
+  swap, { simp_rw condexp_of_not_le hm, simp, },
+  by_cases hμm : sigma_finite (μ.trim hm),
+  swap, { simp_rw condexp_of_not_sigma_finite hm hμm, simp, },
+  haveI : sigma_finite (μ.trim hm) := hμm,
+  refine (condexp_ae_eq_condexp_L1 hm _).trans _,
   rw condexp_L1_smul c f,
   refine (@condexp_ae_eq_condexp_L1 _ _ _ _ _ m _ _ hm _ f).mp _,
   refine (coe_fn_smul c (condexp_L1 hm μ f)).mono (λ x hx1 hx2, _),
   rw [hx1, pi.smul_apply, pi.smul_apply, hx2],
 end
 
-lemma condexp_neg (f : α → F') : μ[-f|m,hm] =ᵐ[μ] - μ[f|m,hm] :=
+lemma condexp_neg (f : α → F') : μ[-f|m] =ᵐ[μ] - μ[f|m] :=
 by letI : module ℝ (α → F') := @pi.module α (λ _, F') ℝ _ _ (λ _, infer_instance);
-calc μ[-f|m,hm] = μ[(-1 : ℝ) • f|m,hm] : by rw neg_one_smul ℝ f
-... =ᵐ[μ] (-1 : ℝ) • μ[f|m,hm] : condexp_smul (-1) f
-... = -μ[f|m,hm] : neg_one_smul ℝ (μ[f|m,hm])
+calc μ[-f|m] = μ[(-1 : ℝ) • f|m] : by rw neg_one_smul ℝ f
+... =ᵐ[μ] (-1 : ℝ) • μ[f|m] : condexp_smul (-1) f
+... = -μ[f|m] : neg_one_smul ℝ (μ[f|m])
 
 lemma condexp_sub (hf : integrable f μ) (hg : integrable g μ) :
-  μ[f - g | m,hm] =ᵐ[μ] μ[f|m,hm] - μ[g|m,hm] :=
+  μ[f - g | m] =ᵐ[μ] μ[f|m] - μ[g|m] :=
 begin
   simp_rw sub_eq_add_neg,
   exact (condexp_add hf hg.neg).trans (eventually_eq.rfl.add (condexp_neg g)),
 end
 
-lemma condexp_condexp_of_le {m₁ m₂ m0 : measurable_space α} {μ : measure α}
-  (hm₁₂ : m₁ ≤ m₂) (hm₂ : m₂ ≤ m0) [sigma_finite (μ.trim (hm₁₂.trans hm₂))]
-  [sigma_finite (μ.trim hm₂)] :
-  μ[ μ[f|m₂, hm₂] | m₁, hm₁₂.trans hm₂] =ᵐ[μ] μ[f | m₁, hm₁₂.trans hm₂] :=
+lemma condexp_condexp_of_le {m₁ m₂ m0 : measurable_space α} {μ : measure α} (hm₁₂ : m₁ ≤ m₂)
+  (hm₂ : m₂ ≤ m0) [sigma_finite (μ.trim hm₂)] :
+  μ[ μ[f|m₂] | m₁] =ᵐ[μ] μ[f | m₁] :=
 begin
+  by_cases hμm₁ : sigma_finite (μ.trim (hm₁₂.trans hm₂)),
+  swap, { simp_rw condexp_of_not_sigma_finite (hm₁₂.trans hm₂) hμm₁, },
+  haveI : sigma_finite (μ.trim (hm₁₂.trans hm₂)) := hμm₁,
   refine ae_eq_of_forall_set_integral_eq_of_sigma_finite' (hm₁₂.trans hm₂)
     (λ s hs hμs, integrable_condexp.integrable_on) (λ s hs hμs, integrable_condexp.integrable_on)
     _ (strongly_measurable.ae_strongly_measurable' strongly_measurable_condexp)
       (strongly_measurable.ae_strongly_measurable' strongly_measurable_condexp),
   intros s hs hμs,
-  rw set_integral_condexp _ integrable_condexp hs,
+  rw set_integral_condexp (hm₁₂.trans hm₂) integrable_condexp hs,
+  swap, apply_instance,
   by_cases hf : integrable f μ,
-  { rw [set_integral_condexp _ hf hs, set_integral_condexp _ hf (hm₁₂ s hs)], },
+  { rw [set_integral_condexp (hm₁₂.trans hm₂) hf hs, set_integral_condexp hm₂ hf (hm₁₂ s hs)], },
   { simp_rw integral_congr_ae (ae_restrict_of_ae (condexp_undef hf)), },
 end
 
 section real
 
-lemma rn_deriv_ae_eq_condexp {f : α → ℝ} (hf : integrable f μ) :
-  signed_measure.rn_deriv ((μ.with_densityᵥ f).trim hm) (μ.trim hm) =ᵐ[μ] μ[f | m,hm] :=
+lemma rn_deriv_ae_eq_condexp {hm : m ≤ m0} [hμm : sigma_finite (μ.trim hm)] {f : α → ℝ}
+  (hf : integrable f μ) :
+  signed_measure.rn_deriv ((μ.with_densityᵥ f).trim hm) (μ.trim hm) =ᵐ[μ] μ[f | m] :=
 begin
   refine ae_eq_condexp_of_forall_set_integral_eq hm hf _ _ _,
   { exact λ _ _ _, (integrable_of_integrable_trim hm (signed_measure.integrable_rn_deriv

--- a/src/probability/martingale.lean
+++ b/src/probability/martingale.lean
@@ -43,30 +43,27 @@ namespace measure_theory
 variables {α E ι : Type*} [preorder ι]
   {m0 : measurable_space α} {μ : measure α}
   [normed_group E] [normed_space ℝ E] [complete_space E]
-  {f g : ι → α → E} {ℱ : filtration ι m0} [sigma_finite_filtration μ ℱ]
+  {f g : ι → α → E} {ℱ : filtration ι m0}
 
 /-- A family of functions `f : ι → α → E` is a martingale with respect to a filtration `ℱ` if `f`
 is adapted with respect to `ℱ` and for all `i ≤ j`, `μ[f j | ℱ i] =ᵐ[μ] f i`. -/
-def martingale (f : ι → α → E) (ℱ : filtration ι m0) (μ : measure α)
-  [sigma_finite_filtration μ ℱ] : Prop :=
+def martingale (f : ι → α → E) (ℱ : filtration ι m0) (μ : measure α) : Prop :=
 adapted ℱ f ∧ ∀ i j, i ≤ j → μ[f j | ℱ i] =ᵐ[μ] f i
 
 /-- A family of integrable functions `f : ι → α → E` is a supermartingale with respect to a
 filtration `ℱ` if `f` is adapted with respect to `ℱ` and for all `i ≤ j`,
 `μ[f j | ℱ.le i] ≤ᵐ[μ] f i`. -/
-def supermartingale [has_le E] (f : ι → α → E) (ℱ : filtration ι m0) (μ : measure α)
-  [sigma_finite_filtration μ ℱ] : Prop :=
+def supermartingale [has_le E] (f : ι → α → E) (ℱ : filtration ι m0) (μ : measure α) : Prop :=
 adapted ℱ f ∧ (∀ i j, i ≤ j → μ[f j | ℱ i] ≤ᵐ[μ] f i) ∧ ∀ i, integrable (f i) μ
 
 /-- A family of integrable functions `f : ι → α → E` is a submartingale with respect to a
 filtration `ℱ` if `f` is adapted with respect to `ℱ` and for all `i ≤ j`,
 `f i ≤ᵐ[μ] μ[f j | ℱ.le i]`. -/
-def submartingale [has_le E] (f : ι → α → E) (ℱ : filtration ι m0) (μ : measure α)
-  [sigma_finite_filtration μ ℱ] : Prop :=
+def submartingale [has_le E] (f : ι → α → E) (ℱ : filtration ι m0) (μ : measure α) : Prop :=
 adapted ℱ f ∧ (∀ i j, i ≤ j → f i ≤ᵐ[μ] μ[f j | ℱ i]) ∧ ∀ i, integrable (f i) μ
 
 variables (E)
-lemma martingale_zero (ℱ : filtration ι m0) (μ : measure α) [sigma_finite_filtration μ ℱ] :
+lemma martingale_zero (ℱ : filtration ι m0) (μ : measure α) :
   martingale (0 : ι → α → E) ℱ μ :=
 ⟨adapted_zero E ℱ, λ i j hij, by { rw [pi.zero_apply, condexp_zero], simp, }⟩
 variables {E}
@@ -88,8 +85,8 @@ hf.2 i j hij
 lemma integrable (hf : martingale f ℱ μ) (i : ι) : integrable (f i) μ :=
 integrable_condexp.congr (hf.condexp_ae_eq (le_refl i))
 
-lemma set_integral_eq (hf : martingale f ℱ μ) {i j : ι} (hij : i ≤ j) {s : set α}
-  (hs : measurable_set[ℱ i] s) :
+lemma set_integral_eq [sigma_finite_filtration μ ℱ] (hf : martingale f ℱ μ) {i j : ι} (hij : i ≤ j)
+  {s : set α} (hs : measurable_set[ℱ i] s) :
   ∫ x in s, f i x ∂μ = ∫ x in s, f j x ∂μ :=
 begin
   rw ← @set_integral_condexp _ _ _ _ _ (ℱ i) m0 _ _ _ (ℱ.le i) _ (hf.integrable j) hs,
@@ -152,7 +149,7 @@ lemma condexp_ae_le [has_le E] (hf : supermartingale f ℱ μ) {i j : ι} (hij :
   μ[f j | ℱ i] ≤ᵐ[μ] f i :=
 hf.2.1 i j hij
 
-lemma set_integral_le {f : ι → α → ℝ} (hf : supermartingale f ℱ μ)
+lemma set_integral_le [sigma_finite_filtration μ ℱ] {f : ι → α → ℝ} (hf : supermartingale f ℱ μ)
   {i j : ι} (hij : i ≤ j) {s : set α} (hs : measurable_set[ℱ i] s) :
   ∫ x in s, f j x ∂μ ≤ ∫ x in s, f i x ∂μ :=
 begin
@@ -226,7 +223,7 @@ begin
 end
 
 /-- The converse of this lemma is `measure_theory.submartingale_of_set_integral_le`. -/
-lemma set_integral_le {f : ι → α → ℝ} (hf : submartingale f ℱ μ)
+lemma set_integral_le [sigma_finite_filtration μ ℱ] {f : ι → α → ℝ} (hf : submartingale f ℱ μ)
   {i j : ι} (hij : i ≤ j) {s : set α} (hs : measurable_set[ℱ i] s) :
   ∫ x in s, f i x ∂μ ≤ ∫ x in s, f j x ∂μ :=
 begin

--- a/src/probability/martingale.lean
+++ b/src/probability/martingale.lean
@@ -11,11 +11,11 @@ import probability.stopping
 
 A family of functions `f : ι → α → E` is a martingale with respect to a filtration `ℱ` if every
 `f i` is integrable, `f` is adapted with respect to `ℱ` and for all `i ≤ j`,
-`μ[f j | ℱ.le i] =ᵐ[μ] f i`. On the other hand, `f : ι → α → E` is said to be a supermartingale
+`μ[f j | ℱ i] =ᵐ[μ] f i`. On the other hand, `f : ι → α → E` is said to be a supermartingale
 with respect to the filtration `ℱ` if `f i` is integrable, `f` is adapted with resepct to `ℱ`
-and for all `i ≤ j`, `μ[f j | ℱ.le i] ≤ᵐ[μ] f i`. Finally, `f : ι → α → E` is said to be a
+and for all `i ≤ j`, `μ[f j | ℱ i] ≤ᵐ[μ] f i`. Finally, `f : ι → α → E` is said to be a
 submartingale with respect to the filtration `ℱ` if `f i` is integrable, `f` is adapted with
-resepct to `ℱ` and for all `i ≤ j`, `f i ≤ᵐ[μ] μ[f j | ℱ.le i]`.
+resepct to `ℱ` and for all `i ≤ j`, `f i ≤ᵐ[μ] μ[f j | ℱ i]`.
 
 The definitions of filtration and adapted can be found in `probability.stopping`.
 
@@ -46,24 +46,24 @@ variables {α E ι : Type*} [preorder ι]
   {f g : ι → α → E} {ℱ : filtration ι m0} [sigma_finite_filtration μ ℱ]
 
 /-- A family of functions `f : ι → α → E` is a martingale with respect to a filtration `ℱ` if `f`
-is adapted with respect to `ℱ` and for all `i ≤ j`, `μ[f j | ℱ.le i] =ᵐ[μ] f i`. -/
+is adapted with respect to `ℱ` and for all `i ≤ j`, `μ[f j | ℱ i] =ᵐ[μ] f i`. -/
 def martingale (f : ι → α → E) (ℱ : filtration ι m0) (μ : measure α)
   [sigma_finite_filtration μ ℱ] : Prop :=
-adapted ℱ f ∧ ∀ i j, i ≤ j → μ[f j | ℱ i, ℱ.le i] =ᵐ[μ] f i
+adapted ℱ f ∧ ∀ i j, i ≤ j → μ[f j | ℱ i] =ᵐ[μ] f i
 
 /-- A family of integrable functions `f : ι → α → E` is a supermartingale with respect to a
 filtration `ℱ` if `f` is adapted with respect to `ℱ` and for all `i ≤ j`,
 `μ[f j | ℱ.le i] ≤ᵐ[μ] f i`. -/
 def supermartingale [has_le E] (f : ι → α → E) (ℱ : filtration ι m0) (μ : measure α)
   [sigma_finite_filtration μ ℱ] : Prop :=
-adapted ℱ f ∧ (∀ i j, i ≤ j → μ[f j | ℱ i, ℱ.le i] ≤ᵐ[μ] f i) ∧ ∀ i, integrable (f i) μ
+adapted ℱ f ∧ (∀ i j, i ≤ j → μ[f j | ℱ i] ≤ᵐ[μ] f i) ∧ ∀ i, integrable (f i) μ
 
 /-- A family of integrable functions `f : ι → α → E` is a submartingale with respect to a
 filtration `ℱ` if `f` is adapted with respect to `ℱ` and for all `i ≤ j`,
 `f i ≤ᵐ[μ] μ[f j | ℱ.le i]`. -/
 def submartingale [has_le E] (f : ι → α → E) (ℱ : filtration ι m0) (μ : measure α)
   [sigma_finite_filtration μ ℱ] : Prop :=
-adapted ℱ f ∧ (∀ i j, i ≤ j → f i ≤ᵐ[μ] μ[f j | ℱ i, ℱ.le i]) ∧ ∀ i, integrable (f i) μ
+adapted ℱ f ∧ (∀ i j, i ≤ j → f i ≤ᵐ[μ] μ[f j | ℱ i]) ∧ ∀ i, integrable (f i) μ
 
 variables (E)
 lemma martingale_zero (ℱ : filtration ι m0) (μ : measure α) [sigma_finite_filtration μ ℱ] :
@@ -81,7 +81,7 @@ lemma strongly_measurable (hf : martingale f ℱ μ) (i : ι) : strongly_measura
 hf.adapted i
 
 lemma condexp_ae_eq (hf : martingale f ℱ μ) {i j : ι} (hij : i ≤ j) :
-  μ[f j | ℱ i, ℱ.le i] =ᵐ[μ] f i :=
+  μ[f j | ℱ i] =ᵐ[μ] f i :=
 hf.2 i j hij
 
 @[protected]
@@ -92,7 +92,7 @@ lemma set_integral_eq (hf : martingale f ℱ μ) {i j : ι} (hij : i ≤ j) {s :
   (hs : measurable_set[ℱ i] s) :
   ∫ x in s, f i x ∂μ = ∫ x in s, f j x ∂μ :=
 begin
-  rw ← @set_integral_condexp _ _ _ _ _ (ℱ i) m0 _ (ℱ.le i) _ _ _ (hf.integrable j) hs,
+  rw ← @set_integral_condexp _ _ _ _ _ (ℱ i) m0 _ _ _ (ℱ.le i) _ (hf.integrable j) hs,
   refine set_integral_congr_ae (ℱ.le i s hs) _,
   filter_upwards [hf.2 i j hij] with _ heq _ using heq.symm,
 end
@@ -132,8 +132,8 @@ lemma martingale_iff [partial_order E] : martingale f ℱ μ ↔
 
 lemma martingale_condexp (f : α → E) (ℱ : filtration ι m0) (μ : measure α)
   [sigma_finite_filtration μ ℱ] :
-  martingale (λ i, μ[f | ℱ i, ℱ.le i]) ℱ μ :=
-⟨λ i, strongly_measurable_condexp, λ i j hij, condexp_condexp_of_le (ℱ.mono hij) _⟩
+  martingale (λ i, μ[f | ℱ i]) ℱ μ :=
+⟨λ i, strongly_measurable_condexp, λ i j hij, condexp_condexp_of_le (ℱ.mono hij) (ℱ.le j)⟩
 
 namespace supermartingale
 
@@ -149,7 +149,7 @@ hf.adapted i
 lemma integrable [has_le E] (hf : supermartingale f ℱ μ) (i : ι) : integrable (f i) μ := hf.2.2 i
 
 lemma condexp_ae_le [has_le E] (hf : supermartingale f ℱ μ) {i j : ι} (hij : i ≤ j) :
-  μ[f j | ℱ i, ℱ.le i] ≤ᵐ[μ] f i :=
+  μ[f j | ℱ i] ≤ᵐ[μ] f i :=
 hf.2.1 i j hij
 
 lemma set_integral_le {f : ι → α → ℝ} (hf : supermartingale f ℱ μ)
@@ -200,7 +200,7 @@ hf.adapted i
 lemma integrable [has_le E] (hf : submartingale f ℱ μ) (i : ι) : integrable (f i) μ := hf.2.2 i
 
 lemma ae_le_condexp [has_le E] (hf : submartingale f ℱ μ) {i j : ι} (hij : i ≤ j) :
-  f i ≤ᵐ[μ] μ[f j | ℱ i, ℱ.le i] :=
+  f i ≤ᵐ[μ] μ[f j | ℱ i] :=
 hf.2.1 i j hij
 
 lemma add [preorder E] [covariant_class E E (+) (≤)]
@@ -253,9 +253,9 @@ lemma submartingale_of_set_integral_le [is_finite_measure μ]
   submartingale f ℱ μ :=
 begin
   refine ⟨hadp, λ i j hij, _, hint⟩,
-  suffices : f i ≤ᵐ[μ.trim (ℱ.le i)] μ[f j| ℱ.le i],
+  suffices : f i ≤ᵐ[μ.trim (ℱ.le i)] μ[f j| ℱ i],
   { exact ae_le_of_ae_le_trim this },
-  suffices : 0 ≤ᵐ[μ.trim (ℱ.le i)] μ[f j| ℱ.le i] - f i,
+  suffices : 0 ≤ᵐ[μ.trim (ℱ.le i)] μ[f j| ℱ i] - f i,
   { filter_upwards [this] with x hx,
     rwa ← sub_nonneg },
   refine ae_nonneg_of_forall_set_integral_nonneg_of_finite_measure
@@ -264,7 +264,7 @@ begin
   specialize hf i j hij s hs,
   rwa [← set_integral_trim _ (strongly_measurable_condexp.sub $ hadp i) hs,
     integral_sub' integrable_condexp.integrable_on (hint i).integrable_on, sub_nonneg,
-    set_integral_condexp _ (hint j) hs],
+    set_integral_condexp (ℱ.le i) (hint j) hs],
 end
 
 end

--- a/src/probability/martingale.lean
+++ b/src/probability/martingale.lean
@@ -333,7 +333,7 @@ end submartingale
 
 section nat
 
-variables {𝒢 : filtration ℕ m0} [sigma_finite_filtration μ 𝒢]
+variables {𝒢 : filtration ℕ m0}
 
 namespace submartingale
 
@@ -348,7 +348,8 @@ integrable_stopped_value hτ hf.integrable hbdd
 /-- Given a submartingale `f` and bounded stopping times `τ` and `π` such that `τ ≤ π`, the
 expectation of `stopped_value f τ` is less than or equal to the expectation of `stopped_value f π`.
 This is the forward direction of the optional stopping theorem. -/
-lemma expected_stopped_value_mono {f : ℕ → α → ℝ} (hf : submartingale f 𝒢 μ) {τ π : α → ℕ}
+lemma expected_stopped_value_mono [sigma_finite_filtration μ 𝒢]
+  {f : ℕ → α → ℝ} (hf : submartingale f 𝒢 μ) {τ π : α → ℕ}
   (hτ : is_stopping_time 𝒢 τ) (hπ : is_stopping_time 𝒢 π) (hle : τ ≤ π)
   {N : ℕ} (hbdd : ∀ x, π x ≤ N) :
   μ[stopped_value f τ] ≤ μ[stopped_value f π] :=

--- a/src/probability/notation.lean
+++ b/src/probability/notation.lean
@@ -11,8 +11,8 @@ This file defines the following notations, for functions `X,Y`, measures `P, Q` 
 measurable space `m0`, and another measurable space structure `m` with `hm : m ≤ m0`,
 - `P[X] = ∫ a, X a ∂P`
 - `𝔼[X] = ∫ a, X a`
-- `𝔼[X|m,hm]`: conditional expectation of `X` with respect to the measure `volume` and the
-  measurable space `m`. The similar `P[X|m,hm]` for a measure `P` is defined in
+- `𝔼[X|m]`: conditional expectation of `X` with respect to the measure `volume` and the
+  measurable space `m`. The similar `P[X|m]` for a measure `P` is defined in
   measure_theory.function.conditional_expectation.
 - `X =ₐₛ Y`: `X =ᵐ[volume] Y`
 - `X ≤ₐₛ Y`: `X ≤ᵐ[volume] Y`
@@ -26,15 +26,9 @@ We note that the notation `∂P/∂Q` applies to three different cases, namely,
 
 open measure_theory
 
--- We define notations `𝔼[f|hm]` and `𝔼[f|m,hm]` for the conditional expectation of `f` with
--- respect to `m`. Both can be used in code but only the second one will be used by the goal view.
--- The first notation avoids the repetition of `m`, which is already present in `hm`. The second
--- one ensures that `m` stays visible in the goal view: when `hm` is complicated, it gets rendered
--- as `_` and the measurable space would not be visible in `𝔼[f|_]`, but is clear in `𝔼[f|m,_]`.
-localized "notation `𝔼[` X `|` hm `]` :=
-  measure_theory.condexp _ hm measure_theory.measure_space.volume X" in probability_theory
-localized "notation `𝔼[` X `|` m `,` hm `]` :=
-  measure_theory.condexp m hm measure_theory.measure_space.volume X" in probability_theory
+-- We define notations `𝔼[f|m]` for the conditional expectation of `f` with respect to `m`.
+localized "notation `𝔼[` X `|` m `]` :=
+  measure_theory.condexp m measure_theory.measure_space.volume X" in probability_theory
 
 localized "notation P `[` X `]` := ∫ x, X x ∂P" in probability_theory
 

--- a/src/probability/stopping.lean
+++ b/src/probability/stopping.lean
@@ -214,6 +214,10 @@ instance sigma_finite_of_sigma_finite_filtration [preorder ι] (μ : measure α)
   sigma_finite (μ.trim (f.le i)) :=
 by apply hf.sigma_finite -- can't exact here
 
+instance is_finite_measure.sigma_finite_filtration [preorder ι] (μ : measure α) (f : filtration ι m)
+  [is_finite_measure μ] :
+  sigma_finite_filtration μ f :=
+⟨λ n, by apply_instance⟩
 
 section adapted_process
 

--- a/src/probability/stopping.lean
+++ b/src/probability/stopping.lean
@@ -214,6 +214,7 @@ instance sigma_finite_of_sigma_finite_filtration [preorder ι] (μ : measure α)
   sigma_finite (μ.trim (f.le i)) :=
 by apply hf.sigma_finite -- can't exact here
 
+@[priority 100]
 instance is_finite_measure.sigma_finite_filtration [preorder ι] (μ : measure α) (f : filtration ι m)
   [is_finite_measure μ] :
   sigma_finite_filtration μ f :=


### PR DESCRIPTION
Before this PR, the conditional expectation `condexp` was defined using an argument `(hm : m ≤ m0)`.
This changes the definition to take only `m`, and assigns the default value 0 if we don't have `m ≤ m0`.

The notation for `condexp m μ f` is simplified to `μ[f|m]`.

The change makes the proofs of the condexp API longer, but no change is needed to lemmas outside of that file. See the file `martingale.lean`: the notation is now simpler, but otherwise little else changes besides removing the now unused argument `[sigma_finite_filtration μ ℱ]` from many lemmas.

Also add an instance `is_finite_measure.sigma_finite_filtration`: we had a lemma with both `is_finite_measure` and `sigma_finite_filtration` arguments, but the first one implies the other.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
