### PR TITLE
[Merged by Bors] - feat(number_theory/divisors): add `filter_dvd_eq_proper_divisors`

### DIFF
--- a/src/number_theory/divisors.lean
+++ b/src/number_theory/divisors.lean
@@ -416,7 +416,7 @@ end
 
 @[simp]
 lemma filter_dvd_eq_divisors (h : n ≠ 0) :
-  finset.filter (λ (x : ℕ), x ∣ n) (finset.range (n : ℕ).succ) = (n : ℕ).divisors :=
+  (finset.range n.succ).filter (∣ n) = n.divisors :=
 begin
   ext,
   simp only [divisors, mem_filter, mem_range, mem_Ico, and.congr_left_iff, iff_and_self],
@@ -425,7 +425,7 @@ end
 
 @[simp]
 lemma filter_dvd_eq_proper_divisors (h : n ≠ 0) :
-  finset.filter (λ (x : ℕ), x ∣ n) (finset.range (n : ℕ)) = (n : ℕ).proper_divisors :=
+  (finset.range n).filter (∣ n) = n.proper_divisors :=
 begin
   ext,
   simp only [proper_divisors, mem_filter, mem_range, mem_Ico, and.congr_left_iff, iff_and_self],

--- a/src/number_theory/divisors.lean
+++ b/src/number_theory/divisors.lean
@@ -49,6 +49,22 @@ def divisors_antidiagonal : finset (ℕ × ℕ) :=
 
 variable {n}
 
+@[simp] lemma filter_dvd_eq_divisors (h : n ≠ 0) :
+  (finset.range n.succ).filter (∣ n) = n.divisors :=
+begin
+  ext,
+  simp only [divisors, mem_filter, mem_range, mem_Ico, and.congr_left_iff, iff_and_self],
+  exact λ ha _, succ_le_iff.mpr (pos_of_dvd_of_pos ha h.bot_lt),
+end
+
+@[simp] lemma filter_dvd_eq_proper_divisors (h : n ≠ 0) :
+  (finset.range n).filter (∣ n) = n.proper_divisors :=
+begin
+  ext,
+  simp only [proper_divisors, mem_filter, mem_range, mem_Ico, and.congr_left_iff, iff_and_self],
+  exact λ ha _, succ_le_iff.mpr (pos_of_dvd_of_pos ha h.bot_lt),
+end
+
 lemma proper_divisors.not_self_mem : ¬ n ∈ proper_divisors n :=
 begin
   rw proper_divisors,
@@ -412,24 +428,6 @@ lemma prod_divisors_antidiagonal' {M : Type*} [comm_monoid M] (f : ℕ → ℕ �
 begin
   rw [←map_swap_divisors_antidiagonal, finset.prod_map],
   exact prod_divisors_antidiagonal (λ i j, f j i),
-end
-
-@[simp]
-lemma filter_dvd_eq_divisors (h : n ≠ 0) :
-  (finset.range n.succ).filter (∣ n) = n.divisors :=
-begin
-  ext,
-  simp only [divisors, mem_filter, mem_range, mem_Ico, and.congr_left_iff, iff_and_self],
-  exact λ ha _, succ_le_iff.mpr (pos_of_dvd_of_pos ha h.bot_lt),
-end
-
-@[simp]
-lemma filter_dvd_eq_proper_divisors (h : n ≠ 0) :
-  (finset.range n).filter (∣ n) = n.proper_divisors :=
-begin
-  ext,
-  simp only [proper_divisors, mem_filter, mem_range, mem_Ico, and.congr_left_iff, iff_and_self],
-  exact λ ha _, succ_le_iff.mpr (pos_of_dvd_of_pos ha h.bot_lt),
 end
 
 /-- The factors of `n` are the prime divisors -/

--- a/src/number_theory/divisors.lean
+++ b/src/number_theory/divisors.lean
@@ -49,7 +49,8 @@ def divisors_antidiagonal : finset (ℕ × ℕ) :=
 
 variable {n}
 
-@[simp] lemma filter_dvd_eq_divisors (h : n ≠ 0) :
+@[simp]
+lemma filter_dvd_eq_divisors (h : n ≠ 0) :
   (finset.range n.succ).filter (∣ n) = n.divisors :=
 begin
   ext,
@@ -57,7 +58,8 @@ begin
   exact λ ha _, succ_le_iff.mpr (pos_of_dvd_of_pos ha h.bot_lt),
 end
 
-@[simp] lemma filter_dvd_eq_proper_divisors (h : n ≠ 0) :
+@[simp]
+lemma filter_dvd_eq_proper_divisors (h : n ≠ 0) :
   (finset.range n).filter (∣ n) = n.proper_divisors :=
 begin
   ext,

--- a/src/number_theory/divisors.lean
+++ b/src/number_theory/divisors.lean
@@ -415,7 +415,7 @@ begin
 end
 
 @[simp]
-lemma filter_dvd_eq_divisors {n : ℕ} (h : n ≠ 0) :
+lemma filter_dvd_eq_divisors (h : n ≠ 0) :
   finset.filter (λ (x : ℕ), x ∣ n) (finset.range (n : ℕ).succ) = (n : ℕ).divisors :=
 begin
   ext,
@@ -424,7 +424,7 @@ begin
 end
 
 @[simp]
-lemma filter_dvd_eq_proper_divisors {n : ℕ} (h : n ≠ 0) :
+lemma filter_dvd_eq_proper_divisors (h : n ≠ 0) :
   finset.filter (λ (x : ℕ), x ∣ n) (finset.range (n : ℕ)) = (n : ℕ).proper_divisors :=
 begin
   ext,

--- a/src/number_theory/divisors.lean
+++ b/src/number_theory/divisors.lean
@@ -171,10 +171,7 @@ end
 lemma pos_of_mem_divisors {m : ℕ} (h : m ∈ n.divisors) : 0 < m :=
 begin
   cases m,
-  { rw [mem_divisors, zero_dvd_iff] at h,
-    rcases h with ⟨rfl, h⟩,
-    exfalso,
-    apply h rfl },
+  { rw [mem_divisors, zero_dvd_iff] at h, cases h.2 h.1 },
   apply nat.succ_pos,
 end
 

--- a/src/number_theory/divisors.lean
+++ b/src/number_theory/divisors.lean
@@ -84,21 +84,12 @@ by rw [divisors, proper_divisors, Ico_succ_right_eq_insert_Ico h, finset.filter_
   if_pos (dvd_refl n)]
 
 @[simp]
-lemma mem_divisors {m : ℕ} :
-  n ∈ divisors m ↔ (n ∣ m ∧ m ≠ 0) :=
+lemma mem_divisors {m : ℕ} : n ∈ divisors m ↔ (n ∣ m ∧ m ≠ 0) :=
 begin
-  cases m,
-  { simp [divisors] },
-  simp only [divisors, finset.mem_Ico, ne.def, finset.mem_filter, succ_ne_zero, and_true,
-             and_iff_right_iff_imp, not_false_iff],
-  intro hdvd,
-  split,
-  { apply nat.pos_of_ne_zero,
-    rintro rfl,
-    apply nat.succ_ne_zero,
-    rwa zero_dvd_iff at hdvd },
-  { rw nat.lt_succ_iff,
-    apply nat.le_of_dvd (nat.succ_pos m) hdvd }
+  rcases eq_or_ne m 0 with rfl | hm, { simp [divisors] },
+  simp only [hm, ne.def, not_false_iff, and_true, ←filter_dvd_eq_divisors hm, mem_filter,
+    mem_range, and_iff_right_iff_imp, lt_succ_iff],
+  exact le_of_dvd hm.bot_lt,
 end
 
 lemma mem_divisors_self (n : ℕ) (h : n ≠ 0) : n ∈ n.divisors := mem_divisors.2 ⟨dvd_rfl, h⟩

--- a/src/number_theory/divisors.lean
+++ b/src/number_theory/divisors.lean
@@ -66,10 +66,7 @@ begin
 end
 
 lemma proper_divisors.not_self_mem : ¬ n ∈ proper_divisors n :=
-begin
-  rw proper_divisors,
-  simp,
-end
+by simp [proper_divisors]
 
 @[simp]
 lemma mem_proper_divisors {m : ℕ} : n ∈ proper_divisors m ↔ n ∣ m ∧ n < m :=

--- a/src/number_theory/divisors.lean
+++ b/src/number_theory/divisors.lean
@@ -418,11 +418,18 @@ end
 lemma filter_dvd_eq_divisors {n : ℕ} (h : n ≠ 0) :
   finset.filter (λ (x : ℕ), x ∣ n) (finset.range (n : ℕ).succ) = (n : ℕ).divisors :=
 begin
-  apply finset.ext,
-  simp only [h, mem_filter, and_true, and_iff_right_iff_imp, cast_id, mem_range, ne.def,
-  not_false_iff, mem_divisors],
-  intros a ha,
-  exact nat.lt_succ_of_le (nat.divisor_le (nat.mem_divisors.2 ⟨ha, h⟩))
+  ext,
+  simp only [divisors, mem_filter, mem_range, mem_Ico, and.congr_left_iff, iff_and_self],
+  exact λ ha _, succ_le_iff.mpr (pos_of_dvd_of_pos ha h.bot_lt),
+end
+
+@[simp]
+lemma filter_dvd_eq_proper_divisors {n : ℕ} (h : n ≠ 0) :
+  finset.filter (λ (x : ℕ), x ∣ n) (finset.range (n : ℕ)) = (n : ℕ).proper_divisors :=
+begin
+  ext,
+  simp only [proper_divisors, mem_filter, mem_range, mem_Ico, and.congr_left_iff, iff_and_self],
+  exact λ ha _, succ_le_iff.mpr (pos_of_dvd_of_pos ha h.bot_lt),
 end
 
 /-- The factors of `n` are the prime divisors -/

--- a/src/number_theory/divisors.lean
+++ b/src/number_theory/divisors.lean
@@ -74,14 +74,8 @@ end
 @[simp]
 lemma mem_proper_divisors {m : ℕ} : n ∈ proper_divisors m ↔ n ∣ m ∧ n < m :=
 begin
-  rw [proper_divisors, finset.mem_filter, finset.mem_Ico, and_comm],
-  apply and_congr_right,
-  rw and_iff_right_iff_imp,
-  intros hdvd hlt,
-  apply nat.pos_of_ne_zero _,
-  rintro rfl,
-  rw zero_dvd_iff.1 hdvd at hlt,
-  apply lt_irrefl 0 hlt,
+  rcases eq_or_ne m 0 with rfl | hm, { simp [proper_divisors] },
+  simp only [and_comm, ←filter_dvd_eq_proper_divisors hm, mem_filter, mem_range],
 end
 
 lemma divisors_eq_proper_divisors_insert_self_of_pos (h : 0 < n):


### PR DESCRIPTION
Adds `filter_dvd_eq_proper_divisors` and golfs `filter_dvd_eq_divisors` and a few other lemmas

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
