### PR TITLE
feat(linear_algebra/basis): strictly triangular basis

### DIFF
--- a/src/linear_algebra/basis.lean
+++ b/src/linear_algebra/basis.lean
@@ -1191,6 +1191,94 @@ end
 
 end exists_basis
 
+namespace strictly_triangular_basis
+
+lemma subset_next_ker_of_span_eq_ker {i : ℕ} {f : V →ₗ[K] V} {s : set V}
+  (hker : span K s = (f ^ i).ker) : s ⊆ (f ^ (i + 1)).ker :=
+begin
+  have h_ker_le_ker : (f ^ i).ker ≤ (f ^ (i + 1)).ker := linear_map.ker_le_ker_comp _ _,
+  show s ⊆ (f ^ (i + 1)).ker,
+  { refine subset_trans (subset_span : s ⊆ span K s) _,
+    rw [hker],
+    exact set_like.coe_subset_coe.2 h_ker_le_ker },
+end
+
+def basis_step {i : ℕ} {f : V →ₗ[K] V} {s : set V}
+  (hs : linear_independent K (coe : s → V))
+  (hker : span K s = (f ^ i).ker) : set V :=
+hs.extend (subset_next_ker_of_span_eq_ker hker)
+
+lemma linear_independent_basis_step {i : ℕ} {f : V →ₗ[K] V} {s : set V}
+  (hs : linear_independent K (coe : s → V))
+  (hker : span K s = (f ^ i).ker) :
+  linear_independent K (coe : basis_step hs hker → V) :=
+hs.linear_independent_extend (subset_next_ker_of_span_eq_ker hker)
+
+lemma span_basis_step {i : ℕ} {f : V →ₗ[K] V} {s : set V}
+  (hs : linear_independent K (coe : s → V))
+  (hker : span K s = (f ^ i).ker) :
+  span K (basis_step hs hker) = (f ^ (i + 1)).ker :=
+hs.span_extend_eq (subset_next_ker_of_span_eq_ker hker)
+
+lemma subset_basis_step {i : ℕ} {f : V →ₗ[K] V} {s : set V}
+  (hs : linear_independent K (coe : s → V))
+  (hker : span K s = (f ^ i).ker) :
+  s ⊆ basis_step hs hker :=
+hs.subset_extend (subset_next_ker_of_span_eq_ker hker)
+
+def basis_aux (f : V →ₗ[K] V) : Π (i : ℕ),
+  { s : set V // linear_independent K (coe : s → V) ∧ span K s = (f ^ i).ker}
+| 0 := ⟨∅, begin
+    refine ⟨linear_independent_empty _ _, _⟩,
+    simpa using linear_map.ker_id.symm
+  end⟩
+| (i + 1) := ⟨basis_step (basis_aux i).property.1 (basis_aux i).property.2,
+  begin
+    split,
+    { apply linear_independent_basis_step },
+    { apply span_basis_step }
+  end⟩
+
+lemma basis_aux_subset_add (f : V →ₗ[K] V) {i j : ℕ} :
+  (basis_aux f i).val ⊆ (basis_aux f (i + j)).val :=
+begin
+  induction j with j hj,
+  { exact subset_refl _ },
+  { refine (subset_trans hj) _,
+    rw [nat.add_succ],
+    exact subset_basis_step
+      (basis_aux f (i + j)).property.1
+      (basis_aux f (i + j)).property.2 }
+end
+
+def strictly_triangular_basis_set (f : V →ₗ[K] V) (n : ℕ) : set V :=
+  (basis_aux f n).val
+
+def strictly_triangular_basis {f : V →ₗ[K] V} {n : ℕ} (hf : f ^ n = 0) :
+  basis (strictly_triangular_basis_set f n) K V :=
+begin
+  refine basis.mk (basis_aux f n).property.1 _,
+  rw [subtype.range_coe, (basis_aux f n).property.2,
+    hf, linear_map.ker_zero]
+end
+
+lemma strictly_triangular_basis_set_subset_ker {f : V →ₗ[K] V} {n : ℕ} :
+  strictly_triangular_basis_set f n ⊆ (f ^ n).ker :=
+begin
+  rw [← (basis_aux f n).property.2],
+  apply subset_span
+end
+
+def smallest_ker
+#check Nat.find
+
+def strictly_triangular_order {f : V →ₗ[K] V} {n : ℕ}
+  (x y : strictly_triangular_basis_set f n) : Prop :=
+
+def
+
+end strictly_triangular_basis
+
 end basis
 
 open fintype

--- a/src/linear_algebra/basis.lean
+++ b/src/linear_algebra/basis.lean
@@ -1200,6 +1200,7 @@ end
 end exists_basis
 
 namespace strictly_triangular_basis
+/- In this section we construct a basis that triangulates a nilpotent linear map. -/
 
 lemma subset_next_ker_of_span_eq_ker {i : ℕ} {f : V →ₗ[K] V} {s : set V}
   (hker : span K s = (f ^ i).ker) : s ⊆ (f ^ (i + 1)).ker :=
@@ -1211,6 +1212,8 @@ begin
     exact set_like.coe_subset_coe.2 h_ker_le_ker },
 end
 
+/-- A single step of the triangulation construction: We extend a given basis of `(f ^ i).ker` to a
+basis of `(f ^ (i + 1)).ker`-/
 def basis_step {i : ℕ} {f : V →ₗ[K] V} {s : set V}
   (hs : linear_independent K (coe : s → V))
   (hker : span K s = (f ^ i).ker) : set V :=
@@ -1234,6 +1237,7 @@ lemma subset_basis_step {i : ℕ} {f : V →ₗ[K] V} {s : set V}
   s ⊆ basis_step hs hker :=
 hs.subset_extend (subset_next_ker_of_span_eq_ker hker)
 
+/-- This definition recursively constructs a basis of `(f ^ i).ker` triangulating `f`. -/
 def basis_aux (f : V →ₗ[K] V) : Π (i : ℕ),
   { s : set V // linear_independent K (coe : s → V) ∧ span K s = (f ^ i).ker}
 | 0 := ⟨∅, begin
@@ -1247,6 +1251,7 @@ def basis_aux (f : V →ₗ[K] V) : Π (i : ℕ),
     { apply span_basis_step }
   end⟩
 
+/-- A basis of `(f ^ i).ker` triangulating `f` as a `set` -/
 def basis_set (f : V →ₗ[K] V) (n : ℕ) : set V :=
   (basis_aux f n).val
 
@@ -1270,6 +1275,8 @@ begin
       (basis_aux f (i + j)).property.2 }
 end
 
+/-- A basis of `V` triangulating a nilpotent linear map `f`. Due to the nilpotency the main diagonal
+of the matrix representation of `f` under this basis is zero, making it *strictly* triangular. -/
 def strictly_triangular_basis {f : V →ₗ[K] V} {n : ℕ} (hf : f ^ n = 0) :
   basis (basis_set f n) K V :=
 begin
@@ -1285,6 +1292,8 @@ begin
   apply subset_span
 end
 
+/-- The smallest exponent `i` of `f` such that `x` is contained in `(f ^ i).ker`. This gives us the
+iteration of the construction in which the vector `x` was added to the basis. -/
 def smallest_ker {f : V →ₗ[K] V} {n : ℕ} {x : V} (hx : x ∈ basis_set f n) : ℕ :=
 nat.find (exists.intro n (basis_set_subset_ker f n hx))
 
@@ -1333,7 +1342,9 @@ begin
   apply basis.mk_apply,
 end
 
-lemma repr_strictly_triangular_basis {f : V →ₗ[K] V} {n : ℕ} (hf : f ^ n = 0)
+/-- If we order the `strictly_triangular_basis` elements by `smallest_ker`, we obtain a strictly
+triangular matrix (i.e., it is triangular and the diagonal is also zero). -/
+theorem repr_strictly_triangular_basis {f : V →ₗ[K] V} {n : ℕ} (hf : f ^ n = 0)
   {x y : V} (hx : x ∈ basis_set f n) (hy : y ∈ basis_set f n)
   (h : smallest_ker hx ≤ smallest_ker hy) :
     (strictly_triangular_basis hf).repr (f x) ⟨y, hy⟩ = 0 :=

--- a/src/linear_algebra/linear_independent.lean
+++ b/src/linear_algebra/linear_independent.lean
@@ -1215,6 +1215,16 @@ lemma linear_independent.subset_span_extend (hs : linear_independent K (λ x, x 
   (hst : s ⊆ t) : t ⊆ span K (hs.extend hst) :=
 let ⟨hbt, hsb, htb, hli⟩ := classical.some_spec (exists_linear_independent_extension hs hst) in htb
 
+lemma linear_independent.span_extend_eq {t : submodule K V}
+  (hs : linear_independent K (λ x, x : s → V)) (hst : s ⊆ t) :
+  span K (hs.extend hst) = t :=
+begin
+  apply submodule.span_eq_of_le,
+  { apply linear_independent.extend_subset },
+  { rw [← set_like.coe_subset_coe],
+    refine linear_independent.subset_span_extend _ _ },
+end
+
 lemma linear_independent.linear_independent_extend (hs : linear_independent K (λ x, x : s → V))
   (hst : s ⊆ t) : linear_independent K (coe : hs.extend hst → V) :=
 let ⟨hbt, hsb, htb, hli⟩ := classical.some_spec (exists_linear_independent_extension hs hst) in hli


### PR DESCRIPTION
Construction of a basis that triangulates a nilpotent linear map.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)

I plan to use this result to triangularize more general matrices.