### PR TITLE
[Merged by Bors] - perf(field_theory/primitive_element): declare auxiliary function `noncomputable!`

### DIFF
--- a/src/field_theory/primitive_element.lean
+++ b/src/field_theory/primitive_element.lean
@@ -211,7 +211,9 @@ variables (K : Type*) [field K] [algebra F K]
 variables (E F)
 
 /-- Function from Hom_K(E,L) to pi type Π (x : basis), roots of min poly of x -/
-def roots_of_min_poly_pi_type (φ : E →ₐ[F] K)
+-- Marked as `noncomputable!` since this definition takes multiple seconds to compile,
+-- and isn't very computable in practice (since neither `finrank` nor `fin_basis` are).
+noncomputable! def roots_of_min_poly_pi_type (φ : E →ₐ[F] K)
   (x : set.range (finite_dimensional.fin_basis F E : _ → E)) :
   {l : K // l ∈ (((minpoly F x.1).map (algebra_map F K)).roots : multiset K)} :=
 ⟨φ x, begin


### PR DESCRIPTION
The declaration `roots_of_min_poly_pi_type` is computable and gets compiled by Lean. Unfortunately, compilation takes about 2-3s on my machine and times out under #11759 (with timeouts disabled, it takes about 11s on that branch). Since the parameters are all elements of noncomputable types and its only use is a noncomputable `fintype` instance, nobody will care if we explicitly make it computable, and it saves a lot of compilation time.

See also this Zulip thread on `noncomputable!` fixing mysterious timeouts: https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/Timeout/near/278494746

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
