### PR TITLE
[Merged by Bors] - feat(algebra/*): Division monoid instances for `with_zero` and `mul_opposite`

### DIFF
--- a/src/algebra/group/basic.lean
+++ b/src/algebra/group/basic.lean
@@ -191,6 +191,9 @@ eq_comm.trans $ eq_inv_iff_eq_inv.trans eq_comm
 
 variables (G)
 
+@[simp, to_additive] lemma inv_comp_inv : has_inv.inv ∘ has_inv.inv = @id G :=
+inv_involutive.comp_self
+
 @[to_additive] lemma left_inverse_inv : left_inverse (λ a : G, a⁻¹) (λ a, a⁻¹) := inv_inv
 @[to_additive] lemma right_inverse_inv : left_inverse (λ a : G, a⁻¹) (λ a, a⁻¹) := inv_inv
 

--- a/src/algebra/group/opposite.lean
+++ b/src/algebra/group/opposite.lean
@@ -98,13 +98,23 @@ We also generate additive structures on `αᵃᵒᵖ` using `to_additive`
 @[to_additive] instance [cancel_comm_monoid α] : cancel_comm_monoid αᵐᵒᵖ :=
 { .. mul_opposite.cancel_monoid α, .. mul_opposite.comm_monoid α }
 
-@[to_additive] instance [div_inv_monoid α] : div_inv_monoid αᵐᵒᵖ :=
+@[to_additive add_opposite.sub_neg_monoid] instance [div_inv_monoid α] : div_inv_monoid αᵐᵒᵖ :=
 { zpow := λ n x, op $ x.unop ^ n,
   zpow_zero' := λ x, unop_injective $ div_inv_monoid.zpow_zero' x.unop,
   zpow_succ' := λ n x, unop_injective $
     by rw [unop_op, zpow_of_nat, zpow_of_nat, pow_succ', unop_mul, unop_op],
   zpow_neg' := λ z x, unop_injective $ div_inv_monoid.zpow_neg' z x.unop,
   .. mul_opposite.monoid α, .. mul_opposite.has_inv α }
+
+@[to_additive add_opposite.subtraction_monoid] instance [division_monoid α] :
+  division_monoid αᵐᵒᵖ :=
+{ mul_inv_rev := λ a b, unop_injective $ mul_inv_rev _ _,
+  inv_eq_of_mul := λ a b h, unop_injective $ inv_eq_of_mul_eq_one_left $ congr_arg unop h,
+  .. mul_opposite.div_inv_monoid α, .. mul_opposite.has_involutive_inv α }
+
+@[to_additive add_opposite.subtraction_comm_monoid] instance [division_comm_monoid α] :
+  division_comm_monoid αᵐᵒᵖ :=
+{ ..mul_opposite.division_monoid α, ..mul_opposite.comm_semigroup α }
 
 @[to_additive] instance [group α] : group αᵐᵒᵖ :=
 { mul_left_inv := λ x, unop_injective $ mul_inv_self $ unop x,
@@ -224,7 +234,7 @@ open mul_opposite
 `mul_equiv.inv`. -/
 @[to_additive "Negation on an additive group is an `add_equiv` to the opposite group. When `G`
 is commutative, there is `add_equiv.inv`.", simps { fully_applied := ff, simp_rhs := tt }]
-def mul_equiv.inv' (G : Type*) [group G] : G ≃* Gᵐᵒᵖ :=
+def mul_equiv.inv' (G : Type*) [division_monoid G] : G ≃* Gᵐᵒᵖ :=
 { map_mul' := λ x y, unop_injective $ mul_inv_rev x y,
   .. (equiv.inv G).trans op_equiv }
 

--- a/src/algebra/group/opposite.lean
+++ b/src/algebra/group/opposite.lean
@@ -234,7 +234,7 @@ open mul_opposite
 `mul_equiv.inv`. -/
 @[to_additive "Negation on an additive group is an `add_equiv` to the opposite group. When `G`
 is commutative, there is `add_equiv.inv`.", simps { fully_applied := ff, simp_rhs := tt }]
-def mul_equiv.inv' (G : Type*) [division_monoid G] : G ≃* Gᵐᵒᵖ :=
+def mul_equiv.inv' (G : Type*) [group G] : G ≃* Gᵐᵒᵖ :=
 { map_mul' := λ x y, unop_injective $ mul_inv_rev x y,
   .. (equiv.inv G).trans op_equiv }
 

--- a/src/algebra/group/with_one.lean
+++ b/src/algebra/group/with_one.lean
@@ -45,7 +45,9 @@ instance : has_one (with_one α) := ⟨none⟩
 @[to_additive]
 instance [has_mul α] : has_mul (with_one α) := ⟨option.lift_or_get (*)⟩
 
-@[to_additive]
+/-- When `α` has multiplicative inverses, `with_one α` also has multiplicative inverses, by defining
+`1⁻¹ = 1`. -/
+@[to_additive "When `α` has a negation, `with_one α` also has a negation, by defining `-0 = 0`."]
 instance [has_inv α] : has_inv (with_one α) := ⟨λ a, option.map has_inv.inv a⟩
 
 @[to_additive]
@@ -292,8 +294,8 @@ instance [monoid α] : monoid_with_zero (with_zero α) :=
 instance [comm_monoid α] : comm_monoid_with_zero (with_zero α) :=
 { ..with_zero.monoid_with_zero, ..with_zero.comm_semigroup }
 
-/-- Given an inverse operation on `α` there is an inverse operation
-  on `with_zero α` sending `0` to `0`-/
+/-- When `α` has multiplicative inverses, `with_zero α` also has multiplicative inverses, by
+defining `0⁻¹ = 0`. -/
 @[to_additive] instance [has_inv α] : has_inv (with_zero α) := ⟨λ a, option.map has_inv.inv a⟩
 
 @[simp, norm_cast, to_additive] lemma coe_inv [has_inv α] (a : α) :

--- a/src/algebra/group/with_one.lean
+++ b/src/algebra/group/with_one.lean
@@ -359,6 +359,9 @@ instance [division_monoid α] : division_monoid (with_zero α) :=
     end,
   .. with_zero.div_inv_monoid, .. with_zero.has_involutive_inv }
 
+instance [division_comm_monoid α] : division_comm_monoid (with_zero α) :=
+{ .. with_zero.division_monoid, .. with_zero.comm_semigroup }
+
 section group
 variables [group α]
 

--- a/src/algebra/group/with_one.lean
+++ b/src/algebra/group/with_one.lean
@@ -301,10 +301,6 @@ instance [comm_monoid α] : comm_monoid_with_zero (with_zero α) :=
 
 @[simp, to_additive] lemma inv_zero [has_inv α] : (0 : with_zero α)⁻¹ = 0 := rfl
 
-@[simp, to_additive] lemma inv_comp_inv [has_involutive_inv α] :
-  has_inv.inv ∘ has_inv.inv = @id α :=
-inv_involutive.comp_self
-
 @[to_additive] instance [has_involutive_inv α] : has_involutive_inv (with_zero α) :=
 { inv_inv := λ a, (option.map_map _ _ _).trans $ by simp_rw [inv_comp_inv, option.map_id, id],
   ..with_zero.has_inv }

--- a/src/algebra/group/with_one.lean
+++ b/src/algebra/group/with_one.lean
@@ -295,8 +295,8 @@ instance [monoid α] : monoid_with_zero (with_zero α) :=
 instance [comm_monoid α] : comm_monoid_with_zero (with_zero α) :=
 { ..with_zero.monoid_with_zero, ..with_zero.comm_semigroup }
 
-/-- When `α` has multiplicative inverses, `with_zero α` also has multiplicative inverses, by
-defining `0⁻¹ = 0`. -/
+/-- Given an inverse operation on `α` there is an inverse operation
+  on `with_zero α` sending `0` to `0`-/
 instance [has_inv α] : has_inv (with_zero α) := ⟨λ a, option.map has_inv.inv a⟩
 
 @[simp, norm_cast] lemma coe_inv [has_inv α] (a : α) : ((a⁻¹ : α) : with_zero α) = a⁻¹ := rfl

--- a/src/algebra/group/with_one.lean
+++ b/src/algebra/group/with_one.lean
@@ -45,10 +45,11 @@ instance : has_one (with_one α) := ⟨none⟩
 @[to_additive]
 instance [has_mul α] : has_mul (with_one α) := ⟨option.lift_or_get (*)⟩
 
-/-- When `α` has multiplicative inverses, `with_one α` also has multiplicative inverses, by defining
-`1⁻¹ = 1`. -/
-@[to_additive "When `α` has a negation, `with_one α` also has a negation, by defining `-0 = 0`."]
-instance [has_inv α] : has_inv (with_one α) := ⟨λ a, option.map has_inv.inv a⟩
+@[to_additive] instance [has_inv α] : has_inv (with_one α) := ⟨λ a, option.map has_inv.inv a⟩
+
+@[to_additive] instance [has_involutive_inv α] : has_involutive_inv (with_one α) :=
+{ inv_inv := λ a, (option.map_map _ _ _).trans $ by simp_rw [inv_comp_inv, option.map_id, id],
+  ..with_one.has_inv }
 
 @[to_additive]
 instance : inhabited (with_one α) := ⟨1⟩
@@ -296,14 +297,13 @@ instance [comm_monoid α] : comm_monoid_with_zero (with_zero α) :=
 
 /-- When `α` has multiplicative inverses, `with_zero α` also has multiplicative inverses, by
 defining `0⁻¹ = 0`. -/
-@[to_additive] instance [has_inv α] : has_inv (with_zero α) := ⟨λ a, option.map has_inv.inv a⟩
+instance [has_inv α] : has_inv (with_zero α) := ⟨λ a, option.map has_inv.inv a⟩
 
-@[simp, norm_cast, to_additive] lemma coe_inv [has_inv α] (a : α) :
-  ((a⁻¹ : α) : with_zero α) = a⁻¹ := rfl
+@[simp, norm_cast] lemma coe_inv [has_inv α] (a : α) : ((a⁻¹ : α) : with_zero α) = a⁻¹ := rfl
 
-@[simp, to_additive] lemma inv_zero [has_inv α] : (0 : with_zero α)⁻¹ = 0 := rfl
+@[simp] lemma inv_zero [has_inv α] : (0 : with_zero α)⁻¹ = 0 := rfl
 
-@[to_additive] instance [has_involutive_inv α] : has_involutive_inv (with_zero α) :=
+instance [has_involutive_inv α] : has_involutive_inv (with_zero α) :=
 { inv_inv := λ a, (option.map_map _ _ _).trans $ by simp_rw [inv_comp_inv, option.map_id, id],
   ..with_zero.has_inv }
 


### PR DESCRIPTION
A few missing instances of `division_monoid` and friends.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
