### PR TITLE
[Merged by Bors] - feat(analysis/asymptotics): use weaker TC assumptions

### DIFF
--- a/src/analysis/asymptotics/asymptotics.lean
+++ b/src/analysis/asymptotics/asymptotics.lean
@@ -346,11 +346,8 @@ end
 theorem is_O.trans_is_o (hfg : is_O f g' l) (hgk : is_o g' k l) : is_o f k l :=
 let ⟨c, cpos, hc⟩ := hfg.exists_pos in hc.trans_is_o hgk cpos
 
-theorem is_o.trans (hfg : is_o f g l) (hgk : is_o g k' l) : is_o f k' l :=
-hfg.trans_is_O hgk.is_O
-
-theorem is_o.trans' (hfg : is_o f g' l) (hgk : is_o g' k l) : is_o f k l :=
-hfg.is_O.trans_is_o hgk
+theorem is_o.trans (hfg : is_o f g l) (hgk : is_o g k l) : is_o f k l :=
+hfg.trans_is_O_with hgk.is_O_with one_pos
 
 section
 


### PR DESCRIPTION
Merge `is_o.trans` with `is_o.trans'`: both lemmas previously took one `semi_normed_group` argument on the primed type (corresponding to the primed function), but now only assume `has_norm` on all three types.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
