### PR TITLE
[Merged by Bors] - feat(*): Pointwise monoids have distributive negations

### DIFF
--- a/src/algebra/ring/basic.lean
+++ b/src/algebra/ring/basic.lean
@@ -927,6 +927,37 @@ lemma neg_mul_eq_mul_neg (a b : α) : -(a * b) = a * -b :=
 lemma neg_mul_comm (a b : α) : -a * b = a * -b :=
 by simp
 
+/-- A type endowed with `-` and `*` has distributive negation, if it admits an injective map that
+preserves `-` and `*` to a type which has distributive negation. -/
+protected def function.injective.has_distrib_neg [has_neg β] [has_mul β] (f : β → α)
+  (hf : injective f) (neg :  ∀ a, f (-a) = -f a) (mul : ∀ a b, f (a * b) = f a * f b) :
+  has_distrib_neg β :=
+{ neg_mul := λ x y, hf $ by erw [neg, mul, neg, neg_mul, mul],
+  mul_neg := λ x y, hf $ by erw [neg, mul, neg, mul_neg, mul],
+  ..hf.has_involutive_neg _ neg, ..‹has_mul β› }
+
+/-- A type endowed with `-` and `*` has distributive negation, if it admits a surjective map that
+preserves `-` and `*` from a type which has distributive negation. -/
+protected def function.surjective.has_distrib_neg [has_neg β] [has_mul β] (f : α → β)
+  (hf : surjective f) (neg :  ∀ a, f (-a) = -f a) (mul : ∀ a b, f (a * b) = f a * f b) :
+  has_distrib_neg β :=
+{ neg_mul := hf.forall₂.2 $ λ x y, by { erw [←neg, ← mul, neg_mul, neg, mul], refl },
+  mul_neg := hf.forall₂.2 $ λ x y, by { erw [←neg, ← mul, mul_neg, neg, mul], refl },
+  ..hf.has_involutive_neg _ neg, ..‹has_mul β› }
+
+namespace add_opposite
+
+instance : has_distrib_neg αᵃᵒᵖ := unop_injective.has_distrib_neg _ unop_neg unop_mul
+
+end add_opposite
+
+open mul_opposite
+
+instance : has_distrib_neg αᵐᵒᵖ :=
+{ neg_mul := λ _ _, unop_injective $ mul_neg _ _,
+  mul_neg := λ _ _, unop_injective $ neg_mul _ _,
+  ..mul_opposite.has_involutive_neg _ }
+
 end has_mul
 
 section mul_one_class
@@ -948,7 +979,7 @@ end mul_one_class
 section mul_zero_class
 variables [mul_zero_class α] [has_distrib_neg α]
 
-/-- Prefer `neg_zero` if `add_comm_group` is available. -/
+/-- Prefer `neg_zero` if `subtraction_monoid` is available. -/
 @[simp] lemma neg_zero' : (-0 : α) = 0 :=
 by rw [←zero_mul (0 : α), ←neg_mul, mul_zero, mul_zero]
 
@@ -1234,11 +1265,7 @@ instance : has_neg αˣ := ⟨λu, ⟨-↑u, -↑u⁻¹, by simp, by simp⟩ ⟩
 
 @[simp, norm_cast] protected theorem coe_neg_one : ((-1 : αˣ) : α) = -1 := rfl
 
-instance : has_distrib_neg αˣ :=
-{ neg := has_neg.neg,
-  neg_neg := λ u, units.ext $ neg_neg _,
-  neg_mul := λ u₁ u₂, units.ext $ neg_mul _ _,
-  mul_neg := λ u₁ u₂, units.ext $ mul_neg _ _, }
+instance : has_distrib_neg αˣ := units.ext.has_distrib_neg _ units.coe_neg units.coe_mul
 
 end units
 

--- a/src/algebra/ring/basic.lean
+++ b/src/algebra/ring/basic.lean
@@ -929,6 +929,7 @@ by simp
 
 /-- A type endowed with `-` and `*` has distributive negation, if it admits an injective map that
 preserves `-` and `*` to a type which has distributive negation. -/
+@[reducible] -- See note [reducible non-instances]
 protected def function.injective.has_distrib_neg [has_neg β] [has_mul β] (f : β → α)
   (hf : injective f) (neg :  ∀ a, f (-a) = -f a) (mul : ∀ a b, f (a * b) = f a * f b) :
   has_distrib_neg β :=
@@ -938,6 +939,7 @@ protected def function.injective.has_distrib_neg [has_neg β] [has_mul β] (f : 
 
 /-- A type endowed with `-` and `*` has distributive negation, if it admits a surjective map that
 preserves `-` and `*` from a type which has distributive negation. -/
+@[reducible] -- See note [reducible non-instances]
 protected def function.surjective.has_distrib_neg [has_neg β] [has_mul β] (f : α → β)
   (hf : surjective f) (neg :  ∀ a, f (-a) = -f a) (mul : ∀ a b, f (a * b) = f a * f b) :
   has_distrib_neg β :=

--- a/src/algebra/ring/basic.lean
+++ b/src/algebra/ring/basic.lean
@@ -931,7 +931,7 @@ by simp
 preserves `-` and `*` to a type which has distributive negation. -/
 @[reducible] -- See note [reducible non-instances]
 protected def function.injective.has_distrib_neg [has_neg β] [has_mul β] (f : β → α)
-  (hf : injective f) (neg :  ∀ a, f (-a) = -f a) (mul : ∀ a b, f (a * b) = f a * f b) :
+  (hf : injective f) (neg : ∀ a, f (-a) = -f a) (mul : ∀ a b, f (a * b) = f a * f b) :
   has_distrib_neg β :=
 { neg_mul := λ x y, hf $ by erw [neg, mul, neg, neg_mul, mul],
   mul_neg := λ x y, hf $ by erw [neg, mul, neg, mul_neg, mul],
@@ -941,7 +941,7 @@ protected def function.injective.has_distrib_neg [has_neg β] [has_mul β] (f : 
 preserves `-` and `*` from a type which has distributive negation. -/
 @[reducible] -- See note [reducible non-instances]
 protected def function.surjective.has_distrib_neg [has_neg β] [has_mul β] (f : α → β)
-  (hf : surjective f) (neg :  ∀ a, f (-a) = -f a) (mul : ∀ a b, f (a * b) = f a * f b) :
+  (hf : surjective f) (neg : ∀ a, f (-a) = -f a) (mul : ∀ a b, f (a * b) = f a * f b) :
   has_distrib_neg β :=
 { neg_mul := hf.forall₂.2 $ λ x y, by { erw [←neg, ← mul, neg_mul, neg, mul], refl },
   mul_neg := hf.forall₂.2 $ λ x y, by { erw [←neg, ← mul, mul_neg, neg, mul], refl },

--- a/src/algebra/star/unitary.lean
+++ b/src/algebra/star/unitary.lean
@@ -136,10 +136,7 @@ instance : has_neg (unitary R) :=
 @[norm_cast] lemma coe_neg (U : unitary R) : ↑(-U) = (-U : R) := rfl
 
 instance : has_distrib_neg (unitary R) :=
-{ neg := has_neg.neg,
-  neg_neg := λ U, subtype.ext $ neg_neg _,
-  neg_mul := λ U₁ U₂, subtype.ext $ neg_mul _ _,
-  mul_neg := λ U₁ U₂, subtype.ext $ mul_neg _ _ }
+subtype.coe_injective.has_distrib_neg coe_neg (unitary R).coe_mul
 
 end ring
 

--- a/src/algebra/star/unitary.lean
+++ b/src/algebra/star/unitary.lean
@@ -136,7 +136,7 @@ instance : has_neg (unitary R) :=
 @[norm_cast] lemma coe_neg (U : unitary R) : ↑(-U) = (-U : R) := rfl
 
 instance : has_distrib_neg (unitary R) :=
-subtype.coe_injective.has_distrib_neg coe_neg (unitary R).coe_mul
+subtype.coe_injective.has_distrib_neg _ coe_neg (unitary R).coe_mul
 
 end ring
 

--- a/src/data/finset/n_ary.lean
+++ b/src/data/finset/n_ary.lean
@@ -214,13 +214,13 @@ lemma image_image₂_right_comm {f : α → β' → γ} {g : β → β'} {f' : �
 (image_image₂_distrib_right $ λ a b, (h_right_comm a b).symm).symm
 
 /-- The other direction does not hold because of the `s`-`s` cross terms on the RHS. -/
-lemma image₂_distrib_subset_left {f : α → δ → ε} {g : β → γ → δ} {f₁ : α → β → β'} {f₂ : α → γ → γ'}
-  {g' : β' → γ' → ε} (h_distrib : ∀ a b c, f a (g b c) = g' (f₁ a b) (f₂ a c)) :
+lemma image₂_distrib_subset_left {γ : Type*} {f : α → δ → ε} {g : β → γ → δ} {f₁ : α → β → β'}
+  {f₂ : α → γ → γ'} {g' : β' → γ' → ε} (h_distrib : ∀ a b c, f a (g b c) = g' (f₁ a b) (f₂ a c)) :
   image₂ f s (image₂ g t u) ⊆ image₂ g' (image₂ f₁ s t) (image₂ f₂ s u) :=
 coe_subset.1 $ by { push_cast, exact set.image2_distrib_subset_left h_distrib }
 
 /-- The other direction does not hold because of the `u`-`u` cross terms on the RHS. -/
-lemma image₂_distrib_subset_right {f : δ → γ → ε} {g : α → β → δ} {f₁ : α → γ → α'}
+lemma image₂_distrib_subset_right {γ : Type*} {f : δ → γ → ε} {g : α → β → δ} {f₁ : α → γ → α'}
   {f₂ : β → γ → β'} {g' : α' → β' → ε} (h_distrib : ∀ a b c, f (g a b) c = g' (f₁ a c) (f₂ b c)) :
   image₂ f (image₂ g s t) u ⊆ image₂ g' (image₂ f₁ s u) (image₂ f₂ t u) :=
 coe_subset.1 $ by { push_cast, exact set.image2_distrib_subset_right h_distrib }

--- a/src/data/finset/n_ary.lean
+++ b/src/data/finset/n_ary.lean
@@ -25,8 +25,8 @@ open function set
 namespace finset
 
 variables {α α' β β' γ γ' δ δ' ε ε' : Type*}
-  [decidable_eq α'] [decidable_eq β'] [decidable_eq γ] [decidable_eq δ] [decidable_eq δ']
-  [decidable_eq ε] [decidable_eq ε']
+  [decidable_eq α'] [decidable_eq β'] [decidable_eq γ] [decidable_eq γ'] [decidable_eq δ]
+  [decidable_eq δ'] [decidable_eq ε] [decidable_eq ε']
   {f f' : α → β → γ} {g g' : α → β → γ → δ} {s s' : finset α} {t t' : finset β} {u u' : finset γ}
   {a a' : α} {b b' : β} {c : γ}
 
@@ -212,6 +212,18 @@ lemma image_image₂_right_comm {f : α → β' → γ} {g : β → β'} {f' : �
   (h_right_comm : ∀ a b, f a (g b) = g' (f' a b)) :
   image₂ f s (t.image g) = (image₂ f' s t).image g' :=
 (image_image₂_distrib_right $ λ a b, (h_right_comm a b).symm).symm
+
+/-- The other direction does not hold because of the `s`-`s` cross terms on the RHS. -/
+lemma image₂_distrib_subset_left {f : α → δ → ε} {g : β → γ → δ} {f₁ : α → β → β'} {f₂ : α → γ → γ'}
+  {g' : β' → γ' → ε} (h_distrib : ∀ a b c, f a (g b c) = g' (f₁ a b) (f₂ a c)) :
+  image₂ f s (image₂ g t u) ⊆ image₂ g' (image₂ f₁ s t) (image₂ f₂ s u) :=
+coe_subset.1 $ by { push_cast, exact set.image2_distrib_subset_left h_distrib }
+
+/-- The other direction does not hold because of the `u`-`u` cross terms on the RHS. -/
+lemma image₂_distrib_subset_right {f : δ → γ → ε} {g : α → β → δ} {f₁ : α → γ → α'}
+  {f₂ : β → γ → β'} {g' : α' → β' → ε} (h_distrib : ∀ a b c, f (g a b) c = g' (f₁ a c) (f₂ b c)) :
+  image₂ f (image₂ g s t) u ⊆ image₂ g' (image₂ f₁ s u) (image₂ f₂ t u) :=
+coe_subset.1 $ by { push_cast, exact set.image2_distrib_subset_right h_distrib }
 
 lemma image_image₂_antidistrib {g : γ → δ} {f' : β' → α' → δ} {g₁ : β → β'} {g₂ : α → α'}
   (h_antidistrib : ∀ a b, g (f a b) = f' (g₁ b) (g₂ a)) :

--- a/src/data/finset/n_ary.lean
+++ b/src/data/finset/n_ary.lean
@@ -214,14 +214,16 @@ lemma image_image₂_right_comm {f : α → β' → γ} {g : β → β'} {f' : �
 (image_image₂_distrib_right $ λ a b, (h_right_comm a b).symm).symm
 
 /-- The other direction does not hold because of the `s`-`s` cross terms on the RHS. -/
-lemma image₂_distrib_subset_left {γ : Type*} {f : α → δ → ε} {g : β → γ → δ} {f₁ : α → β → β'}
-  {f₂ : α → γ → γ'} {g' : β' → γ' → ε} (h_distrib : ∀ a b c, f a (g b c) = g' (f₁ a b) (f₂ a c)) :
+lemma image₂_distrib_subset_left {γ : Type*} {u : finset γ} {f : α → δ → ε} {g : β → γ → δ}
+  {f₁ : α → β → β'} {f₂ : α → γ → γ'} {g' : β' → γ' → ε}
+  (h_distrib : ∀ a b c, f a (g b c) = g' (f₁ a b) (f₂ a c)) :
   image₂ f s (image₂ g t u) ⊆ image₂ g' (image₂ f₁ s t) (image₂ f₂ s u) :=
 coe_subset.1 $ by { push_cast, exact set.image2_distrib_subset_left h_distrib }
 
 /-- The other direction does not hold because of the `u`-`u` cross terms on the RHS. -/
-lemma image₂_distrib_subset_right {γ : Type*} {f : δ → γ → ε} {g : α → β → δ} {f₁ : α → γ → α'}
-  {f₂ : β → γ → β'} {g' : α' → β' → ε} (h_distrib : ∀ a b c, f (g a b) c = g' (f₁ a c) (f₂ b c)) :
+lemma image₂_distrib_subset_right {γ : Type*} {u : finset γ} {f : δ → γ → ε} {g : α → β → δ}
+  {f₁ : α → γ → α'} {f₂ : β → γ → β'} {g' : α' → β' → ε}
+  (h_distrib : ∀ a b c, f (g a b) c = g' (f₁ a c) (f₂ b c)) :
   image₂ f (image₂ g s t) u ⊆ image₂ g' (image₂ f₁ s u) (image₂ f₂ t u) :=
 coe_subset.1 $ by { push_cast, exact set.image2_distrib_subset_right h_distrib }
 

--- a/src/data/finset/pointwise.lean
+++ b/src/data/finset/pointwise.lean
@@ -417,11 +417,13 @@ variables [distrib α] (s t u : finset α)
 Note that `finset α` is not a `distrib` because `s * t + s * u` has cross terms that `s * (t + u)`
 lacks.
 
--- `{10, 16, 18, 20, 8, 9}`
+```lean
+-- {10, 16, 18, 20, 8, 9}
 #eval {1, 2} * ({3, 4} + {5, 6} : finset ℕ)
 
--- `{10, 11, 12, 13, 14, 15, 16, 18, 20, 8, 9}`
+-- {10, 11, 12, 13, 14, 15, 16, 18, 20, 8, 9}
 #eval ({1, 2} : finset ℕ) * {3, 4} + {1, 2} * {5, 6}
+```
 -/
 
 lemma mul_add_subset : s * (t + u) ⊆ s * t + s * u := image₂_distrib_subset_left mul_add

--- a/src/data/finset/pointwise.lean
+++ b/src/data/finset/pointwise.lean
@@ -402,8 +402,32 @@ pointwise operations if `α` is."]
 protected def division_comm_monoid [division_comm_monoid α] : division_comm_monoid (finset α) :=
 coe_injective.division_comm_monoid _ coe_one coe_mul coe_inv coe_div coe_pow coe_zpow
 
+/-- `finset α` has distributive negation if `α` has. -/
+protected def has_distrib_neg [has_mul α] [has_distrib_neg α] : has_distrib_neg (finset α) :=
+coe_injective.has_distrib_neg _ coe_neg coe_mul
+
 localized "attribute [instance] finset.comm_monoid finset.add_comm_monoid finset.division_monoid
-  finset.subtraction_monoid finset.division_comm_monoid finset.subtraction_comm_monoid" in pointwise
+  finset.subtraction_monoid finset.division_comm_monoid finset.subtraction_comm_monoid
+  finset.has_distrib_neg" in pointwise
+
+section distrib
+variables [distrib α] (s t u : finset α)
+
+/-!
+Note that `finset α` is not a `distrib` because `s * t + s * u` has cross terms that `s * (t + u)`
+lacks.
+
+-- `{10, 16, 18, 20, 8, 9}`
+#eval {1, 2} * ({3, 4} + {5, 6} : finset ℕ)
+
+-- `{10, 11, 12, 13, 14, 15, 16, 18, 20, 8, 9}`
+#eval ({1, 2} : finset ℕ) * {3, 4} + {1, 2} * {5, 6}
+-/
+
+lemma mul_add_subset : s * (t + u) ⊆ s * t + s * u := image₂_distrib_subset_left mul_add
+lemma add_mul_subset : (s + t) * u ⊆ s * u + t * u := image₂_distrib_subset_right add_mul
+
+end distrib
 
 section group
 variables [group α] {s t : finset α}

--- a/src/data/set/basic.lean
+++ b/src/data/set/basic.lean
@@ -2538,6 +2538,26 @@ lemma image_image2_right_comm {f : α → β' → γ} {g : β → β'} {f' : α 
   image2 f s (t.image g) = (image2 f' s t).image g' :=
 (image_image2_distrib_right $ λ a b, (h_right_comm a b).symm).symm
 
+/-- The other direction does not hold because of the `s`-`s` cross terms on the RHS. -/
+lemma image2_distrib_subset_left {f : α → δ → ε} {g : β → γ → δ} {f₁ : α → β → β'} {f₂ : α → γ → γ'}
+  {g' : β' → γ' → ε} (h_distrib : ∀ a b c, f a (g b c) = g' (f₁ a b) (f₂ a c)) :
+  image2 f s (image2 g t u) ⊆ image2 g' (image2 f₁ s t) (image2 f₂ s u) :=
+begin
+  rintro _ ⟨a, _, ha, ⟨b, c, hb, hc, rfl⟩, rfl⟩,
+  rw h_distrib,
+  exact mem_image2_of_mem (mem_image2_of_mem ha hb) (mem_image2_of_mem ha hc),
+end
+
+/-- The other direction does not hold because of the `u`-`u` cross terms on the RHS. -/
+lemma image2_distrib_subset_right {f : δ → γ → ε} {g : α → β → δ} {f₁ : α → γ → α'}
+  {f₂ : β → γ → β'} {g' : α' → β' → ε} (h_distrib : ∀ a b c, f (g a b) c = g' (f₁ a c) (f₂ b c)) :
+  image2 f (image2 g s t) u ⊆ image2 g' (image2 f₁ s u) (image2 f₂ t u) :=
+begin
+  rintro _ ⟨_, c, ⟨a, b, ha, hb, rfl⟩, hc, rfl⟩,
+  rw h_distrib,
+  exact mem_image2_of_mem (mem_image2_of_mem ha hc) (mem_image2_of_mem hb hc),
+end
+
 lemma image_image2_antidistrib {g : γ → δ} {f' : β' → α' → δ} {g₁ : β → β'} {g₂ : α → α'}
   (h_antidistrib : ∀ a b, g (f a b) = f' (g₁ b) (g₂ a)) :
   (image2 f s t).image g = image2 f' (t.image g₁) (s.image g₂) :=

--- a/src/data/set/pointwise.lean
+++ b/src/data/set/pointwise.lean
@@ -518,8 +518,27 @@ operations if `α` is."]
 protected def division_comm_monoid [division_comm_monoid α] : division_comm_monoid (set α) :=
 { ..set.division_monoid, ..set.comm_semigroup }
 
+/-- `set α` has distributive negation if `α` has. -/
+protected def has_distrib_neg [has_mul α] [has_distrib_neg α] : has_distrib_neg (set α) :=
+{ neg_mul := λ _ _, by { simp_rw ←image_neg, exact image2_image_left_comm neg_mul },
+  mul_neg := λ _ _, by { simp_rw ←image_neg, exact image_image2_right_comm mul_neg },
+  ..set.has_involutive_neg }
+
 localized "attribute [instance] set.division_monoid set.subtraction_monoid set.division_comm_monoid
-  set.subtraction_comm_monoid" in pointwise
+  set.subtraction_comm_monoid set.has_distrib_neg" in pointwise
+
+section distrib
+variables [distrib α] (s t u : set α)
+
+/-!
+Note that `set α` is not a `distrib` because `s * t + s * u` has cross terms that `s * (t + u)`
+lacks.
+-/
+
+lemma mul_add_subset : s * (t + u) ⊆ s * t + s * u := image2_distrib_subset_left mul_add
+lemma add_mul_subset : (s + t) * u ⊆ s * u + t * u := image2_distrib_subset_right add_mul
+
+end distrib
 
 section group
 variables [group α] {s t : set α} {a b : α}
@@ -968,10 +987,10 @@ by simp_rw [←image_smul, ←image_neg, image_image, neg_smul]
 by simp_rw [←image_smul, ←image_neg, image_image, smul_neg]
 
 @[simp] protected lemma neg_smul : -s • t = -(s • t) :=
-by simp_rw [←image2_smul, ←image_neg, image2_image_left, image_image2, neg_smul]
+by { simp_rw ←image_neg, exact image2_image_left_comm neg_smul }
 
 @[simp] protected lemma smul_neg : s • -t = -(s • t) :=
-by simp_rw [←image2_smul, ←image_neg, image2_image_right, image_image2, smul_neg]
+by { simp_rw ←image_neg, exact image_image2_right_comm smul_neg }
 
 end ring
 

--- a/src/linear_algebra/general_linear_group.lean
+++ b/src/linear_algebra/general_linear_group.lean
@@ -155,15 +155,15 @@ instance : has_neg (GL_pos n R) :=
     exact g.prop,
   end⟩⟩
 
-@[simp] lemma GL_pos.coe_neg (g : GL_pos n R) : ↑(- g) = - (↑g : matrix n n R) :=
-rfl
+@[simp] lemma GL_pos.coe_neg_GL (g : GL_pos n R) : ↑(-g) = -(g : GL n R) := rfl
+@[simp] lemma GL_pos.coe_neg (g : GL_pos n R) : ↑(-g) = -(g : matrix n n R) := rfl
 
 @[simp] lemma GL_pos.coe_neg_apply (g : GL_pos n R) (i j : n) :
   (↑(-g) : matrix n n R) i j = -((↑g : matrix n n R) i j) :=
 rfl
 
 instance : has_distrib_neg (GL_pos n R) :=
-subtype.coe_injective.has_distrib_neg _ GL_pos.coe_neg (GL_pos n R).coe_mul
+subtype.coe_injective.has_distrib_neg _ GL_pos.coe_neg_GL (GL_pos n R).coe_mul
 
 end has_neg
 

--- a/src/linear_algebra/general_linear_group.lean
+++ b/src/linear_algebra/general_linear_group.lean
@@ -155,18 +155,15 @@ instance : has_neg (GL_pos n R) :=
     exact g.prop,
   end⟩⟩
 
-instance : has_distrib_neg (GL_pos n R) :=
-{ neg := has_neg.neg,
-  neg_neg := λ x, subtype.ext $ neg_neg _,
-  neg_mul := λ x y, subtype.ext $ neg_mul _ _,
-  mul_neg := λ x y, subtype.ext $ mul_neg _ _ }
-
 @[simp] lemma GL_pos.coe_neg (g : GL_pos n R) : ↑(- g) = - (↑g : matrix n n R) :=
 rfl
 
 @[simp] lemma GL_pos.coe_neg_apply (g : GL_pos n R) (i j : n) :
   (↑(-g) : matrix n n R) i j = -((↑g : matrix n n R) i j) :=
 rfl
+
+instance : has_distrib_neg (GL_pos n R) :=
+subtype.coe_injective.has_distrib_neg GL_pos.coe_neg (GL_pos n R).coe_mul
 
 end has_neg
 

--- a/src/linear_algebra/general_linear_group.lean
+++ b/src/linear_algebra/general_linear_group.lean
@@ -163,7 +163,7 @@ rfl
 rfl
 
 instance : has_distrib_neg (GL_pos n R) :=
-subtype.coe_injective.has_distrib_neg GL_pos.coe_neg (GL_pos n R).coe_mul
+subtype.coe_injective.has_distrib_neg _ GL_pos.coe_neg (GL_pos n R).coe_mul
 
 end has_neg
 

--- a/src/linear_algebra/special_linear_group.lean
+++ b/src/linear_algebra/special_linear_group.lean
@@ -198,14 +198,12 @@ instance : has_neg (special_linear_group n R) :=
   ⟨- g, by simpa [(fact.out $ even $ fintype.card n).neg_one_pow, g.det_coe] using
   det_smul ↑ₘg (-1)⟩⟩
 
-@[simp] lemma coe_neg (g : special_linear_group n R) :
-  ↑(- g) = - (↑g : matrix n n R) :=
-rfl
+@[simp] lemma coe_neg (g : special_linear_group n R) : ↑(- g) = - (g : matrix n n R) := rfl
 
 instance : has_distrib_neg (special_linear_group n R) :=
-subtype.coe_injective.has_distrib_neg _ coe_neg coe_mul
+function.injective.has_distrib_neg _ subtype.coe_injective coe_neg coe_mul
 
-@[simp] lemma coe_int_neg (g : (special_linear_group n ℤ)) :
+@[simp] lemma coe_int_neg (g : special_linear_group n ℤ) :
   ↑(-g) = (-↑g : special_linear_group n R) :=
 subtype.ext $ (@ring_hom.map_matrix n _ _ _ _ _ _ (int.cast_ring_hom R)).map_neg ↑g
 

--- a/src/linear_algebra/special_linear_group.lean
+++ b/src/linear_algebra/special_linear_group.lean
@@ -203,10 +203,7 @@ instance : has_neg (special_linear_group n R) :=
 rfl
 
 instance : has_distrib_neg (special_linear_group n R) :=
-{ neg := has_neg.neg,
-  neg_neg := λ x, subtype.ext $ neg_neg _,
-  neg_mul := λ x y, subtype.ext $ neg_mul _ _,
-  mul_neg := λ x y, subtype.ext $ mul_neg _ _ }
+subtype.coe_injective.has_distrib_neg coe_neg coe_mul
 
 @[simp] lemma coe_int_neg (g : (special_linear_group n ℤ)) :
   ↑(-g) = (-↑g : special_linear_group n R) :=

--- a/src/linear_algebra/special_linear_group.lean
+++ b/src/linear_algebra/special_linear_group.lean
@@ -203,7 +203,7 @@ instance : has_neg (special_linear_group n R) :=
 rfl
 
 instance : has_distrib_neg (special_linear_group n R) :=
-subtype.coe_injective.has_distrib_neg coe_neg coe_mul
+subtype.coe_injective.has_distrib_neg _ coe_neg coe_mul
 
 @[simp] lemma coe_int_neg (g : (special_linear_group n ℤ)) :
   ↑(-g) = (-↑g : special_linear_group n R) :=

--- a/src/order/filter/n_ary.lean
+++ b/src/order/filter/n_ary.lean
@@ -300,6 +300,30 @@ lemma map_map₂_right_comm {m : α → β' → γ} {n : β → β'} {m' : α �
   map₂ m f (g.map n) = (map₂ m' f g).map n' :=
 (map_map₂_distrib_right $ λ a b, (h_right_comm a b).symm).symm
 
+/-- The other direction does not hold because of the `f`-`f` cross terms on the RHS. -/
+lemma map₂_distrib_le_left {m : α → δ → ε} {n : β → γ → δ} {m₁ : α → β → β'} {m₂ : α → γ → γ'}
+  {n' : β' → γ' → ε} (h_distrib : ∀ a b c, m a (n b c) = n' (m₁ a b) (m₂ a c)) :
+  map₂ m f (map₂ n g h) ≤ map₂ n' (map₂ m₁ f g) (map₂ m₂ f h) :=
+begin
+  rintro s ⟨t₁, t₂, ⟨u₁, v, hu₁, hv, ht₁⟩, ⟨u₂, w, hu₂, hw, ht₂⟩, hs⟩,
+  refine ⟨u₁ ∩ u₂, _, inter_mem hu₁ hu₂, image2_mem_map₂ hv hw, _⟩,
+  refine (image2_distrib_subset_left h_distrib).trans ((image2_subset _ _).trans hs),
+  { exact (image2_subset_right $ inter_subset_left _ _).trans ht₁ },
+  { exact (image2_subset_right $ inter_subset_right _ _).trans ht₂ }
+end
+
+/-- The other direction does not hold because of the `h`-`h` cross terms on the RHS. -/
+lemma map₂_distrib_le_right {m : δ → γ → ε} {n : α → β → δ} {m₁ : α → γ → α'}
+  {m₂ : β → γ → β'} {n' : α' → β' → ε} (h_distrib : ∀ a b c, m (n a b) c = n' (m₁ a c) (m₂ b c)) :
+  map₂ m (map₂ n f g) h ≤ map₂ n' (map₂ m₁ f h) (map₂ m₂ g h) :=
+begin
+  rintro s ⟨t₁, t₂, ⟨u, w₁, hu, hw₁, ht₁⟩, ⟨v, w₂, hv, hw₂, ht₂⟩, hs⟩,
+  refine ⟨_, w₁ ∩ w₂, image2_mem_map₂ hu hv, inter_mem hw₁ hw₂, _⟩,
+  refine (image2_distrib_subset_right h_distrib).trans ((image2_subset _ _).trans hs),
+  { exact (image2_subset_left $ inter_subset_left _ _).trans ht₁ },
+  { exact (image2_subset_left $ inter_subset_right _ _).trans ht₂ }
+end
+
 lemma map_map₂_antidistrib {n : γ → δ} {m' : β' → α' → δ} {n₁ : β → β'} {n₂ : α → α'}
   (h_antidistrib : ∀ a b, n (m a b) = m' (n₁ b) (n₂ a)) :
   (map₂ m f g).map n = map₂ m' (g.map n₁) (f.map n₂) :=

--- a/src/order/filter/pointwise.lean
+++ b/src/order/filter/pointwise.lean
@@ -352,8 +352,28 @@ pointwise operations if `α` is."]
 protected def division_comm_monoid [division_comm_monoid α] : division_comm_monoid (filter α) :=
 { ..filter.division_monoid, ..filter.comm_semigroup }
 
+/-- `filter α` has distributive negation if `α` has. -/
+protected def has_distrib_neg [has_mul α] [has_distrib_neg α] : has_distrib_neg (filter α) :=
+{ neg_mul := λ _ _, map₂_map_left_comm neg_mul,
+  mul_neg := λ _ _, map_map₂_right_comm mul_neg,
+  ..filter.has_involutive_neg }
+
 localized "attribute [instance] filter.comm_monoid filter.add_comm_monoid filter.division_monoid
-  filter.subtraction_monoid filter.division_comm_monoid filter.subtraction_comm_monoid" in pointwise
+  filter.subtraction_monoid filter.division_comm_monoid filter.subtraction_comm_monoid
+  filter.has_distrib_neg" in pointwise
+
+section distrib
+variables [distrib α] {f g h : filter α}
+
+/-!
+Note that `filter α` is not a `distrib` because `f * g + f * h` has cross terms that `f * (g + h)`
+lacks.
+-/
+
+lemma mul_add_subset : f * (g + h) ≤ f * g + f * h := map₂_distrib_le_left mul_add
+lemma add_mul_subset : (f + g) * h ≤ f * h + g * h := map₂_distrib_le_right add_mul
+
+end distrib
 
 section group
 variables [group α] [group β] [monoid_hom_class F α β] (m : F) {f g f₁ g₁ : filter α}


### PR DESCRIPTION
More instances of `has_distrib_neg`:
* `function.injective.has_distrib_neg`, `function.surjective.has_distrib_neg`
* `add_opposite`, `mul_opposite`
* `set`, `finset`, `filter`

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
