### PR TITLE
[Merged by Bors] - test({data/{finset,set},order/filter}/pointwise): Ensure priority of the `ℕ` and `ℤ` actions

### DIFF
--- a/src/data/finset/pointwise.lean
+++ b/src/data/finset/pointwise.lean
@@ -281,21 +281,21 @@ section instances
 variables [decidable_eq α]
 
 /-- Repeated pointwise addition (not the same as pointwise repeated addition!) of a `finset`. See
-Note [pointwise nat action]. -/
+note [pointwise nat action]. -/
 protected def has_nsmul [has_zero α] [has_add α] : has_scalar ℕ (finset α) := ⟨nsmul_rec⟩
 
 /-- Repeated pointwise multiplication (not the same as pointwise repeated multiplication!) of a
-`finset`. See Note [pointwise nat action]. -/
+`finset`. See note [pointwise nat action]. -/
 @[to_additive]
 protected def has_npow [has_one α] [has_mul α] : has_pow (finset α) ℕ := ⟨λ s n, npow_rec n s⟩
 
 /-- Repeated pointwise addition/subtraction (not the same as pointwise repeated
-addition/subtraction!) of a `finset`. See Note [pointwise nat action]. -/
+addition/subtraction!) of a `finset`. See note [pointwise nat action]. -/
 protected def has_zsmul [has_zero α] [has_add α] [has_neg α] : has_scalar ℤ (finset α) :=
 ⟨zsmul_rec⟩
 
 /-- Repeated pointwise multiplication/division (not the same as pointwise repeated
-multiplication/division!) of a `finset`. See Note [pointwise nat action]. -/
+multiplication/division!) of a `finset`. See note [pointwise nat action]. -/
 @[to_additive] protected def has_zpow [has_one α] [has_mul α] [has_inv α] : has_pow (finset α) ℤ :=
 ⟨λ s n, zpow_rec n s⟩
 

--- a/src/data/finset/pointwise.lean
+++ b/src/data/finset/pointwise.lean
@@ -280,21 +280,22 @@ open_locale pointwise
 section instances
 variables [decidable_eq α]
 
-/-- Repeated pointwise addition (not the same as pointwise repeated addition!) of a `finset`. -/
+/-- Repeated pointwise addition (not the same as pointwise repeated addition!) of a `finset`. See
+Note [pointwise nat action]. -/
 protected def has_nsmul [has_zero α] [has_add α] : has_scalar ℕ (finset α) := ⟨nsmul_rec⟩
 
 /-- Repeated pointwise multiplication (not the same as pointwise repeated multiplication!) of a
-`finset`. -/
+`finset`. See Note [pointwise nat action]. -/
 @[to_additive]
 protected def has_npow [has_one α] [has_mul α] : has_pow (finset α) ℕ := ⟨λ s n, npow_rec n s⟩
 
 /-- Repeated pointwise addition/subtraction (not the same as pointwise repeated
-addition/subtraction!) of a `finset`. -/
+addition/subtraction!) of a `finset`. See Note [pointwise nat action]. -/
 protected def has_zsmul [has_zero α] [has_add α] [has_neg α] : has_scalar ℤ (finset α) :=
 ⟨zsmul_rec⟩
 
 /-- Repeated pointwise multiplication/division (not the same as pointwise repeated
-multiplication/division!) of a `finset`. -/
+multiplication/division!) of a `finset`. See Note [pointwise nat action]. -/
 @[to_additive] protected def has_zpow [has_one α] [has_mul α] [has_inv α] : has_pow (finset α) ℤ :=
 ⟨λ s n, zpow_rec n s⟩
 

--- a/src/data/set/pointwise.lean
+++ b/src/data/set/pointwise.lean
@@ -54,6 +54,16 @@ set multiplication, set addition, pointwise addition, pointwise multiplication,
 pointwise subtraction
 -/
 
+/--
+Pointwise monoids (`set`, `finset`, `filter`) have derived pointwise actions of the form
+`has_scalar α β → has_scalar α (set β)`. When `α` is `ℕ` or `ℤ`, this action conflicts with the
+nat or int action coming from `set β` being a `monoid` or `div_inv_monoid`.
+
+Because the pointwise can easily be spelled out in such cases, we give higher priority to the nat
+and int actions.
+-/
+library_note "pointwise nat action"
+
 open function
 
 variables {F α β γ : Type*}
@@ -450,22 +460,25 @@ localized "attribute [instance] set.comm_monoid set.add_comm_monoid" in pointwis
 
 open_locale pointwise
 
-/-- Repeated pointwise addition (not the same as pointwise repeated addition!) of a `finset`. -/
+/-- Repeated pointwise addition (not the same as pointwise repeated addition!) of a `finset`. See
+Note [pointwise nat action].-/
 protected def has_nsmul [has_zero α] [has_add α] : has_scalar ℕ (set α) := ⟨nsmul_rec⟩
 
 /-- Repeated pointwise multiplication (not the same as pointwise repeated multiplication!) of a
-`set`. -/
+`set`. See Note [pointwise nat action]. -/
 @[to_additive]
 protected def has_npow [has_one α] [has_mul α] : has_pow (set α) ℕ := ⟨λ s n, npow_rec n s⟩
 
 /-- Repeated pointwise addition/subtraction (not the same as pointwise repeated
-addition/subtraction!) of a `set`. -/
+addition/subtraction!) of a `set`. See Note [pointwise nat action]. -/
 protected def has_zsmul [has_zero α] [has_add α] [has_neg α] : has_scalar ℤ (set α) := ⟨zsmul_rec⟩
 
 /-- Repeated pointwise multiplication/division (not the same as pointwise repeated
-multiplication/division!) of a `set`. -/
+multiplication/division!) of a `set`. See Note [pointwise nat action]. -/
 @[to_additive] protected def has_zpow [has_one α] [has_mul α] [has_inv α] : has_pow (set α) ℤ :=
 ⟨λ s n, zpow_rec n s⟩
+
+localized "attribute [instance] set.has_nsmul set.has_npow set.has_zsmul set.has_zpow" in pointwise
 
 section division_monoid
 variables [division_monoid α] {s t : set α}

--- a/src/data/set/pointwise.lean
+++ b/src/data/set/pointwise.lean
@@ -58,10 +58,12 @@ pointwise subtraction
 Pointwise monoids (`set`, `finset`, `filter`) have derived pointwise actions of the form
 `has_scalar α β → has_scalar α (set β)`. When `α` is `ℕ` or `ℤ`, this action conflicts with the
 nat or int action coming from `set β` being a `monoid` or `div_inv_monoid`. For example,
-`2 • {a, b}` can both be `{2 • a, 2 • b}` and `{a + a, a + b, b + a, b + b}`.
+`2 • {a, b}` can both be `{2 • a, 2 • b}` (pointwise action, pointwise repeated addition,
+`set.has_scalar_set`) and `{a + a, a + b, b + a, b + b}` (nat or int action, repeated pointwise
+addition, `set.has_nsmul`).
 
-Because the pointwise can easily be spelled out in such cases, we give higher priority to the nat
-and int actions.
+Because the pointwise action can easily be spelled out in such cases, we give higher priority to the
+nat and int actions.
 -/
 library_note "pointwise nat action"
 
@@ -368,20 +370,20 @@ end has_div
 open_locale pointwise
 
 /-- Repeated pointwise addition (not the same as pointwise repeated addition!) of a `finset`. See
-Note [pointwise nat action].-/
+note [pointwise nat action].-/
 protected def has_nsmul [has_zero α] [has_add α] : has_scalar ℕ (set α) := ⟨nsmul_rec⟩
 
 /-- Repeated pointwise multiplication (not the same as pointwise repeated multiplication!) of a
-`set`. See Note [pointwise nat action]. -/
+`set`. See note [pointwise nat action]. -/
 @[to_additive]
 protected def has_npow [has_one α] [has_mul α] : has_pow (set α) ℕ := ⟨λ s n, npow_rec n s⟩
 
 /-- Repeated pointwise addition/subtraction (not the same as pointwise repeated
-addition/subtraction!) of a `set`. See Note [pointwise nat action]. -/
+addition/subtraction!) of a `set`. See note [pointwise nat action]. -/
 protected def has_zsmul [has_zero α] [has_add α] [has_neg α] : has_scalar ℤ (set α) := ⟨zsmul_rec⟩
 
 /-- Repeated pointwise multiplication/division (not the same as pointwise repeated
-multiplication/division!) of a `set`. See Note [pointwise nat action]. -/
+multiplication/division!) of a `set`. See note [pointwise nat action]. -/
 @[to_additive] protected def has_zpow [has_one α] [has_mul α] [has_inv α] : has_pow (set α) ℤ :=
 ⟨λ s n, zpow_rec n s⟩
 

--- a/src/data/set/pointwise.lean
+++ b/src/data/set/pointwise.lean
@@ -57,7 +57,8 @@ pointwise subtraction
 /--
 Pointwise monoids (`set`, `finset`, `filter`) have derived pointwise actions of the form
 `has_scalar α β → has_scalar α (set β)`. When `α` is `ℕ` or `ℤ`, this action conflicts with the
-nat or int action coming from `set β` being a `monoid` or `div_inv_monoid`.
+nat or int action coming from `set β` being a `monoid` or `div_inv_monoid`. For example,
+`2 • {a, b}` can both be `{2 • a, 2 • b}` and `{a + a, a + b, b + a, b + b}`.
 
 Because the pointwise can easily be spelled out in such cases, we give higher priority to the nat
 and int actions.
@@ -364,6 +365,28 @@ image2_Inter₂_subset_right _ _ _
 
 end has_div
 
+open_locale pointwise
+
+/-- Repeated pointwise addition (not the same as pointwise repeated addition!) of a `finset`. See
+Note [pointwise nat action].-/
+protected def has_nsmul [has_zero α] [has_add α] : has_scalar ℕ (set α) := ⟨nsmul_rec⟩
+
+/-- Repeated pointwise multiplication (not the same as pointwise repeated multiplication!) of a
+`set`. See Note [pointwise nat action]. -/
+@[to_additive]
+protected def has_npow [has_one α] [has_mul α] : has_pow (set α) ℕ := ⟨λ s n, npow_rec n s⟩
+
+/-- Repeated pointwise addition/subtraction (not the same as pointwise repeated
+addition/subtraction!) of a `set`. See Note [pointwise nat action]. -/
+protected def has_zsmul [has_zero α] [has_add α] [has_neg α] : has_scalar ℤ (set α) := ⟨zsmul_rec⟩
+
+/-- Repeated pointwise multiplication/division (not the same as pointwise repeated
+multiplication/division!) of a `set`. See Note [pointwise nat action]. -/
+@[to_additive] protected def has_zpow [has_one α] [has_mul α] [has_inv α] : has_pow (set α) ℤ :=
+⟨λ s n, zpow_rec n s⟩
+
+localized "attribute [instance] set.has_nsmul set.has_npow set.has_zsmul set.has_zpow" in pointwise
+
 /-- `set α` is a `semigroup` under pointwise operations if `α` is. -/
 @[to_additive "`set α` is an `add_semigroup` under pointwise operations if `α` is."]
 protected def semigroup [semigroup α] : semigroup (set α) :=
@@ -410,7 +433,7 @@ variables [monoid α] {s t : set α} {a : α}
 
 /-- `set α` is a `monoid` under pointwise operations if `α` is. -/
 @[to_additive "`set α` is an `add_monoid` under pointwise operations if `α` is."]
-protected def monoid : monoid (set α) := { ..set.semigroup, ..set.mul_one_class }
+protected def monoid : monoid (set α) := { ..set.semigroup, ..set.mul_one_class, ..set.has_npow }
 
 localized "attribute [instance] set.monoid set.add_monoid" in pointwise
 
@@ -460,26 +483,6 @@ localized "attribute [instance] set.comm_monoid set.add_comm_monoid" in pointwis
 
 open_locale pointwise
 
-/-- Repeated pointwise addition (not the same as pointwise repeated addition!) of a `finset`. See
-Note [pointwise nat action].-/
-protected def has_nsmul [has_zero α] [has_add α] : has_scalar ℕ (set α) := ⟨nsmul_rec⟩
-
-/-- Repeated pointwise multiplication (not the same as pointwise repeated multiplication!) of a
-`set`. See Note [pointwise nat action]. -/
-@[to_additive]
-protected def has_npow [has_one α] [has_mul α] : has_pow (set α) ℕ := ⟨λ s n, npow_rec n s⟩
-
-/-- Repeated pointwise addition/subtraction (not the same as pointwise repeated
-addition/subtraction!) of a `set`. See Note [pointwise nat action]. -/
-protected def has_zsmul [has_zero α] [has_add α] [has_neg α] : has_scalar ℤ (set α) := ⟨zsmul_rec⟩
-
-/-- Repeated pointwise multiplication/division (not the same as pointwise repeated
-multiplication/division!) of a `set`. See Note [pointwise nat action]. -/
-@[to_additive] protected def has_zpow [has_one α] [has_mul α] [has_inv α] : has_pow (set α) ℤ :=
-⟨λ s n, zpow_rec n s⟩
-
-localized "attribute [instance] set.has_nsmul set.has_npow set.has_zsmul set.has_zpow" in pointwise
-
 section division_monoid
 variables [division_monoid α] {s t : set α}
 
@@ -509,7 +512,7 @@ protected def division_monoid : division_monoid (set α) :=
   end,
   div_eq_mul_inv := λ s t,
     by { rw [←image_id (s / t), ←image_inv], exact image_image2_distrib_right div_eq_mul_inv },
-  ..set.monoid, ..set.has_involutive_inv, ..set.has_div }
+  ..set.monoid, ..set.has_involutive_inv, ..set.has_div, ..set.has_zpow }
 
 @[simp, to_additive] lemma is_unit_iff : is_unit s ↔ ∃ a, s = {a} ∧ is_unit a :=
 begin

--- a/src/order/filter/pointwise.lean
+++ b/src/order/filter/pointwise.lean
@@ -302,6 +302,28 @@ protected def comm_monoid [comm_monoid α] : comm_monoid (filter α) :=
 
 open_locale pointwise
 
+/-- Repeated pointwise addition (not the same as pointwise repeated addition!) of a `filter`. See
+Note [pointwise nat action].-/
+protected def has_nsmul [has_zero α] [has_add α] : has_scalar ℕ (filter α) := ⟨nsmul_rec⟩
+
+/-- Repeated pointwise multiplication (not the same as pointwise repeated multiplication!) of a
+`filter`. See Note [pointwise nat action]. -/
+@[to_additive]
+protected def has_npow [has_one α] [has_mul α] : has_pow (filter α) ℕ := ⟨λ s n, npow_rec n s⟩
+
+/-- Repeated pointwise addition/subtraction (not the same as pointwise repeated
+addition/subtraction!) of a `filter`. See Note [pointwise nat action]. -/
+protected def has_zsmul [has_zero α] [has_add α] [has_neg α] : has_scalar ℤ (filter α) :=
+⟨zsmul_rec⟩
+
+/-- Repeated pointwise multiplication/division (not the same as pointwise repeated
+multiplication/division!) of a `filter`. See Note [pointwise nat action]. -/
+@[to_additive] protected def has_zpow [has_one α] [has_mul α] [has_inv α] : has_pow (filter α) ℤ :=
+⟨λ s n, zpow_rec n s⟩
+
+localized "attribute [instance] filter.has_nsmul filter.has_npow filter.has_zsmul filter.has_zpow"
+  in pointwise
+
 section division_monoid
 variables [division_monoid α] {f g : filter α}
 

--- a/src/order/filter/pointwise.lean
+++ b/src/order/filter/pointwise.lean
@@ -219,6 +219,28 @@ end div
 
 open_locale pointwise
 
+/-- Repeated pointwise addition (not the same as pointwise repeated addition!) of a `filter`. See
+Note [pointwise nat action].-/
+protected def has_nsmul [has_zero α] [has_add α] : has_scalar ℕ (filter α) := ⟨nsmul_rec⟩
+
+/-- Repeated pointwise multiplication (not the same as pointwise repeated multiplication!) of a
+`filter`. See Note [pointwise nat action]. -/
+@[to_additive]
+protected def has_npow [has_one α] [has_mul α] : has_pow (filter α) ℕ := ⟨λ s n, npow_rec n s⟩
+
+/-- Repeated pointwise addition/subtraction (not the same as pointwise repeated
+addition/subtraction!) of a `filter`. See Note [pointwise nat action]. -/
+protected def has_zsmul [has_zero α] [has_add α] [has_neg α] : has_scalar ℤ (filter α) :=
+⟨zsmul_rec⟩
+
+/-- Repeated pointwise multiplication/division (not the same as pointwise repeated
+multiplication/division!) of a `filter`. See Note [pointwise nat action]. -/
+@[to_additive] protected def has_zpow [has_one α] [has_mul α] [has_inv α] : has_pow (filter α) ℤ :=
+⟨λ s n, zpow_rec n s⟩
+
+localized "attribute [instance] filter.has_nsmul filter.has_npow filter.has_zsmul filter.has_zpow"
+  in pointwise
+
 /-- `filter α` is a `semigroup` under pointwise operations if `α` is.-/
 @[to_additive "`filter α` is an `add_semigroup` under pointwise operations if `α` is."]
 protected def semigroup [semigroup α] : semigroup (filter α) :=
@@ -282,7 +304,7 @@ variables [monoid α] {f g : filter α} {s : set α} {a : α}
 /-- `filter α` is a `monoid` under pointwise operations if `α` is. -/
 @[to_additive "`filter α` is an `add_monoid` under pointwise operations if `α` is."]
 protected def monoid : monoid (filter α) :=
-{ ..filter.mul_one_class, ..filter.semigroup }
+{ ..filter.mul_one_class, ..filter.semigroup, ..filter.has_npow }
 
 localized "attribute [instance] filter.monoid filter.add_monoid" in pointwise
 
@@ -301,28 +323,6 @@ protected def comm_monoid [comm_monoid α] : comm_monoid (filter α) :=
 { ..filter.mul_one_class, ..filter.comm_semigroup }
 
 open_locale pointwise
-
-/-- Repeated pointwise addition (not the same as pointwise repeated addition!) of a `filter`. See
-Note [pointwise nat action].-/
-protected def has_nsmul [has_zero α] [has_add α] : has_scalar ℕ (filter α) := ⟨nsmul_rec⟩
-
-/-- Repeated pointwise multiplication (not the same as pointwise repeated multiplication!) of a
-`filter`. See Note [pointwise nat action]. -/
-@[to_additive]
-protected def has_npow [has_one α] [has_mul α] : has_pow (filter α) ℕ := ⟨λ s n, npow_rec n s⟩
-
-/-- Repeated pointwise addition/subtraction (not the same as pointwise repeated
-addition/subtraction!) of a `filter`. See Note [pointwise nat action]. -/
-protected def has_zsmul [has_zero α] [has_add α] [has_neg α] : has_scalar ℤ (filter α) :=
-⟨zsmul_rec⟩
-
-/-- Repeated pointwise multiplication/division (not the same as pointwise repeated
-multiplication/division!) of a `filter`. See Note [pointwise nat action]. -/
-@[to_additive] protected def has_zpow [has_one α] [has_mul α] [has_inv α] : has_pow (filter α) ℤ :=
-⟨λ s n, zpow_rec n s⟩
-
-localized "attribute [instance] filter.has_nsmul filter.has_npow filter.has_zsmul filter.has_zpow"
-  in pointwise
 
 section division_monoid
 variables [division_monoid α] {f g : filter α}
@@ -352,7 +352,7 @@ protected def division_monoid : division_monoid (filter α) :=
     rw [inv_pure, inv_eq_of_mul_eq_one_right hab],
   end,
   div_eq_mul_inv := λ f g, map_map₂_distrib_right div_eq_mul_inv,
-  ..filter.monoid, ..filter.has_involutive_inv, ..filter.has_div }
+  ..filter.monoid, ..filter.has_involutive_inv, ..filter.has_div, ..filter.has_zpow }
 
 @[to_additive] lemma is_unit_iff : is_unit f ↔ ∃ a, f = pure a ∧ is_unit a :=
 begin

--- a/test/pointwise_nsmul.lean
+++ b/test/pointwise_nsmul.lean
@@ -1,0 +1,33 @@
+/-
+Copyright (c) 2022 Yaël Dillies. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Yaël Dillies
+-/
+import data.finset.pointwise
+import order.filter.pointwise
+
+/-!
+# Ensuring priority of the `ℕ` and `ℤ` actions over pointwise ones
+
+See Note [pointwise nat action].
+-/
+
+open_locale pointwise
+
+variables {α β : Type*} [add_group α] [decidable_eq α] [group β] [decidable_eq β]
+
+example (s : set α) (n : ℕ) : n • s = nsmul_rec n s := rfl
+example (s : set α) (n : ℤ) : n • s = zsmul_rec n s := rfl
+example (s : set β) (n : ℕ) : s ^ n = npow_rec n s := rfl
+example (s : set β) (n : ℤ) : s ^ n = zpow_rec n s := rfl
+example (s : finset α) (n : ℕ) : n • s = nsmul_rec n s := rfl
+example (s : finset α) (n : ℤ) : n • s = zsmul_rec n s := rfl
+example (s : finset β) (n : ℕ) : s ^ n = npow_rec n s := rfl
+example (s : finset β) (n : ℤ) : s ^ n = zpow_rec n s := rfl
+example (s : filter α) (n : ℕ) : n • s = nsmul_rec n s := rfl
+example (s : filter α) (n : ℤ) : n • s = zsmul_rec n s := rfl
+example (s : filter β) (n : ℕ) : s ^ n = npow_rec n s := rfl
+example (s : filter β) (n : ℤ) : s ^ n = zpow_rec n s := rfl
+
+example : 2 • ({2, 3} : finset ℕ) = {4, 5, 6} := rfl
+example : ({2, 3}^2 : finset ℕ) = {4, 6, 9} := rfl

--- a/test/pointwise_nsmul.lean
+++ b/test/pointwise_nsmul.lean
@@ -16,6 +16,7 @@ open_locale pointwise
 
 variables {α β : Type*} [add_group α] [decidable_eq α] [group β] [decidable_eq β]
 
+-- It is ok for the proofs to stop being `rfl`, but these statements should remain true
 example (s : set α) (n : ℕ) : n • s = nsmul_rec n s := rfl
 example (s : set α) (n : ℤ) : n • s = zsmul_rec n s := rfl
 example (s : set β) (n : ℕ) : s ^ n = npow_rec n s := rfl


### PR DESCRIPTION
Each of `set`, `finset`, `filter` creates (non propeq) diamonds with the fundamental `ℕ` and `ℤ` actions because of instances of the form `has_scalar α β → has_scalar α (set β)`. For example, `{2, 3}^2` could well be `{4, 9}` or `{4, 6, 9}`.

The instances involved are all too important to be discarded, so we decide to live with the diamonds but give priority to the `ℕ` and `ℤ` actions. The reasoning for the priority is that those can't easily be spelled out, while the derived actions can. For example, `s.image ((•) 2)` easily replaces `2 • s`. Incidentally, additive combinatorics uses extensively the `ℕ` action.

This PR adds both a library note and tests to ensure this stays the case. It also fixes the additive `set` and `filter` versions, which were not conforming to the test.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
