### PR TITLE
[Merged by Bors] - feat(data/zmod/quotient): More API for `orbit_zpowers_equiv`

### DIFF
--- a/src/data/zmod/quotient.lean
+++ b/src/data/zmod/quotient.lean
@@ -130,10 +130,9 @@ rfl
 lemma orbit_zpowers_equiv_symm_apply' (k : ℤ) : (orbit_zpowers_equiv a b).symm k =
   (⟨a, mem_zpowers a⟩ : zpowers a) ^ k • ⟨b, mem_orbit_self b⟩ :=
 begin
-  conv_rhs { rw ← int.mod_add_div k (minimal_period ((•) a) b) },
-  rw [zpow_add, mul_smul, orbit_zpowers_equiv_symm_apply, zmod.coe_int_cast, smul_left_cancel_iff,
-      subtype.ext_iff, orbit.coe_smul, eq_comm, zpow_smul_eq_iff_minimal_period_dvd],
-  apply dvd_mul_right,
+  ext,
+  rw [orbit_zpowers_equiv_symm_apply, zmod.coe_int_cast],
+  exact zpow_smul_mod_minimal_period _ _ _
 end
 
 lemma _root_.add_action.orbit_zmultiples_equiv_symm_apply'

--- a/src/data/zmod/quotient.lean
+++ b/src/data/zmod/quotient.lean
@@ -127,8 +127,9 @@ lemma orbit_zpowers_equiv_symm_apply (k : zmod (minimal_period ((•) a) b)) :
     (⟨a, mem_zpowers a⟩ : zpowers a) ^ (k : ℤ) • ⟨b, mem_orbit_self b⟩ :=
 rfl
 
-lemma orbit_zpowers_equiv_symm_apply' (k : ℤ) : (orbit_zpowers_equiv a b).symm k =
-  (⟨a, mem_zpowers a⟩ : zpowers a) ^ k • ⟨b, mem_orbit_self b⟩ :=
+lemma orbit_zpowers_equiv_symm_apply' (k : ℤ) :
+  (orbit_zpowers_equiv a b).symm k =
+    (⟨a, mem_zpowers a⟩ : zpowers a) ^ k • ⟨b, mem_orbit_self b⟩ :=
 begin
   rw [orbit_zpowers_equiv_symm_apply, zmod.coe_int_cast],
   exact subtype.ext (zpow_smul_mod_minimal_period _ _ k),

--- a/src/data/zmod/quotient.lean
+++ b/src/data/zmod/quotient.lean
@@ -130,9 +130,8 @@ rfl
 lemma orbit_zpowers_equiv_symm_apply' (k : ℤ) : (orbit_zpowers_equiv a b).symm k =
   (⟨a, mem_zpowers a⟩ : zpowers a) ^ k • ⟨b, mem_orbit_self b⟩ :=
 begin
-  ext,
   rw [orbit_zpowers_equiv_symm_apply, zmod.coe_int_cast],
-  exact zpow_smul_mod_minimal_period _ _ _
+  exact subtype.ext (zpow_smul_mod_minimal_period k _ _),
 end
 
 lemma _root_.add_action.orbit_zmultiples_equiv_symm_apply'

--- a/src/data/zmod/quotient.lean
+++ b/src/data/zmod/quotient.lean
@@ -131,7 +131,7 @@ lemma orbit_zpowers_equiv_symm_apply' (k : ℤ) : (orbit_zpowers_equiv a b).symm
   (⟨a, mem_zpowers a⟩ : zpowers a) ^ k • ⟨b, mem_orbit_self b⟩ :=
 begin
   rw [orbit_zpowers_equiv_symm_apply, zmod.coe_int_cast],
-  exact subtype.ext (zpow_smul_mod_minimal_period k _ _),
+  exact subtype.ext (zpow_smul_mod_minimal_period _ _ k),
 end
 
 lemma _root_.add_action.orbit_zmultiples_equiv_symm_apply'
@@ -139,10 +139,8 @@ lemma _root_.add_action.orbit_zmultiples_equiv_symm_apply'
   (add_action.orbit_zmultiples_equiv a b).symm k =
     (k • (⟨a, mem_zmultiples a⟩ : zmultiples a)) +ᵥ ⟨b, add_action.mem_orbit_self b⟩ :=
 begin
-  conv_rhs { rw ← int.mod_add_div k (minimal_period ((+ᵥ) a) b) },
-  rw [add_zsmul, add_vadd, add_action.orbit_zmultiples_equiv_symm_apply, zmod.coe_int_cast,
-      vadd_left_cancel_iff, eq_comm],
-  exact subtype.ext (zsmul_vadd_eq_iff_minimal_period_dvd.mpr (dvd_mul_right _ _)),
+  rw [add_action.orbit_zmultiples_equiv_symm_apply, zmod.coe_int_cast],
+  exact subtype.ext (zsmul_vadd_mod_minimal_period _ _ k),
 end
 
 attribute [to_additive orbit_zmultiples_equiv_symm_apply'] orbit_zpowers_equiv_symm_apply'

--- a/src/data/zmod/quotient.lean
+++ b/src/data/zmod/quotient.lean
@@ -105,8 +105,7 @@ let f := zmultiples_quotient_stabilizer_equiv (additive.of_mul a) b in
 ⟨f.to_fun, f.inv_fun, f.left_inv, f.right_inv, f.map_add'⟩
 
 lemma zpowers_quotient_stabilizer_equiv_symm_apply (n : zmod (minimal_period ((•) a) b)) :
-  (zpowers_quotient_stabilizer_equiv a b).symm n =
-    (⟨a, mem_zpowers a⟩ : zpowers a) ^ (n : ℤ) :=
+  (zpowers_quotient_stabilizer_equiv a b).symm n = (⟨a, mem_zpowers a⟩ : zpowers a) ^ (n : ℤ) :=
 rfl
 
 /-- The orbit `(a ^ ℤ) • b` is a cycle of order `minimal_period ((•) a) b`. -/
@@ -131,7 +130,7 @@ rfl
 lemma orbit_zpowers_equiv_symm_apply' (k : ℤ) : (orbit_zpowers_equiv a b).symm k =
   (⟨a, mem_zpowers a⟩ : zpowers a) ^ k • ⟨b, mem_orbit_self b⟩ :=
 begin
-  conv_rhs { rw ← int.mod_add_div k (function.minimal_period ((•) a) b) },
+  conv_rhs { rw ← int.mod_add_div k (minimal_period ((•) a) b) },
   rw [zpow_add, mul_smul, orbit_zpowers_equiv_symm_apply, zmod.coe_int_cast, smul_left_cancel_iff,
       subtype.ext_iff, orbit.coe_smul, eq_comm, zpow_smul_eq_iff_minimal_period_dvd],
   apply dvd_mul_right,
@@ -142,11 +141,10 @@ lemma _root_.add_action.orbit_zmultiples_equiv_symm_apply'
   (add_action.orbit_zmultiples_equiv a b).symm k =
     (k • (⟨a, mem_zmultiples a⟩ : zmultiples a)) +ᵥ ⟨b, add_action.mem_orbit_self b⟩ :=
 begin
-  conv_rhs { rw ← int.mod_add_div k (function.minimal_period ((+ᵥ) a) b) },
+  conv_rhs { rw ← int.mod_add_div k (minimal_period ((+ᵥ) a) b) },
   rw [add_zsmul, add_vadd, add_action.orbit_zmultiples_equiv_symm_apply, zmod.coe_int_cast,
-      vadd_left_cancel_iff, subtype.ext_iff, orbit.coe_vadd, eq_comm,
-      zsmul_vadd_eq_iff_minimal_period_dvd],
-  apply dvd_mul_right,
+      vadd_left_cancel_iff, eq_comm],
+  exact subtype.ext (zsmul_vadd_eq_iff_minimal_period_dvd.mpr (dvd_mul_right _ _)),
 end
 
 attribute [to_additive orbit_zmultiples_equiv_symm_apply'] orbit_zpowers_equiv_symm_apply'

--- a/src/data/zmod/quotient.lean
+++ b/src/data/zmod/quotient.lean
@@ -94,14 +94,14 @@ end add_action
 
 namespace mul_action
 
-open subgroup function
+open add_action subgroup add_subgroup function
 
 variables {α β : Type*} [group α] (a : α) [mul_action α β] (b : β)
 
 /-- The quotient `(a ^ ℤ) ⧸ (stabilizer b)` is cyclic of order `minimal_period ((•) a) b`. -/
 noncomputable def zpowers_quotient_stabilizer_equiv :
   zpowers a ⧸ stabilizer (zpowers a) b ≃* multiplicative (zmod (minimal_period ((•) a) b)) :=
-let f := add_action.zmultiples_quotient_stabilizer_equiv (additive.of_mul a) b in
+let f := zmultiples_quotient_stabilizer_equiv (additive.of_mul a) b in
 ⟨f.to_fun, f.inv_fun, f.left_inv, f.right_inv, f.map_add'⟩
 
 lemma zpowers_quotient_stabilizer_equiv_symm_apply (n : zmod (minimal_period ((•) a) b)) :
@@ -116,16 +116,39 @@ noncomputable def orbit_zpowers_equiv : orbit (zpowers a) b ≃ zmod (minimal_pe
 /-- The orbit `(ℤ • a) +ᵥ b` is a cycle of order `minimal_period ((+ᵥ) a) b`. -/
 noncomputable def _root_.add_action.orbit_zmultiples_equiv
   {α β : Type*} [add_group α] (a : α) [add_action α β] (b : β) :
-  add_action.orbit (add_subgroup.zmultiples a) b ≃ zmod (minimal_period ((+ᵥ) a) b) :=
-(add_action.orbit_equiv_quotient_stabilizer (add_subgroup.zmultiples a) b).trans
-  (add_action.zmultiples_quotient_stabilizer_equiv a b).to_equiv
+  add_action.orbit (zmultiples a) b ≃ zmod (minimal_period ((+ᵥ) a) b) :=
+(add_action.orbit_equiv_quotient_stabilizer (zmultiples a) b).trans
+  (zmultiples_quotient_stabilizer_equiv a b).to_equiv
 
 attribute [to_additive orbit_zmultiples_equiv] orbit_zpowers_equiv
 
 @[to_additive orbit_zmultiples_equiv_symm_apply]
-lemma orbit_zpowers_equiv_symm_apply {α β : Type*} [group α] (a : α) [mul_action α β] (b : β)
-  (k : zmod (minimal_period ((•) a) b)) : (orbit_zpowers_equiv a b).symm k =
-  (⟨a, mem_zpowers a⟩ : zpowers a) ^ (k : ℤ) • ⟨b, mem_orbit_self b⟩ :=
+lemma orbit_zpowers_equiv_symm_apply (k : zmod (minimal_period ((•) a) b)) :
+  (orbit_zpowers_equiv a b).symm k =
+    (⟨a, mem_zpowers a⟩ : zpowers a) ^ (k : ℤ) • ⟨b, mem_orbit_self b⟩ :=
 rfl
+
+lemma orbit_zpowers_equiv_symm_apply' (k : ℤ) : (orbit_zpowers_equiv a b).symm k =
+  (⟨a, mem_zpowers a⟩ : zpowers a) ^ k • ⟨b, mem_orbit_self b⟩ :=
+begin
+  conv_rhs { rw ← int.mod_add_div k (function.minimal_period ((•) a) b) },
+  rw [zpow_add, mul_smul, orbit_zpowers_equiv_symm_apply, zmod.coe_int_cast, smul_left_cancel_iff,
+      subtype.ext_iff, orbit.coe_smul, eq_comm, zpow_smul_eq_iff_minimal_period_dvd],
+  apply dvd_mul_right,
+end
+
+lemma _root_.add_action.orbit_zmultiples_equiv_symm_apply'
+  {α β : Type*} [add_group α] (a : α) [add_action α β] (b : β) (k : ℤ) :
+  (add_action.orbit_zmultiples_equiv a b).symm k =
+    (k • (⟨a, mem_zmultiples a⟩ : zmultiples a)) +ᵥ ⟨b, add_action.mem_orbit_self b⟩ :=
+begin
+  conv_rhs { rw ← int.mod_add_div k (function.minimal_period ((+ᵥ) a) b) },
+  rw [add_zsmul, add_vadd, add_action.orbit_zmultiples_equiv_symm_apply, zmod.coe_int_cast,
+      vadd_left_cancel_iff, subtype.ext_iff, orbit.coe_vadd, eq_comm,
+      zsmul_vadd_eq_iff_minimal_period_dvd],
+  apply dvd_mul_right,
+end
+
+attribute [to_additive orbit_zmultiples_equiv_symm_apply'] orbit_zpowers_equiv_symm_apply'
 
 end mul_action

--- a/src/dynamics/periodic_pts.lean
+++ b/src/dynamics/periodic_pts.lean
@@ -403,4 +403,14 @@ begin
         dvd_neg, int.coe_nat_dvd, pow_smul_eq_iff_minimal_period_dvd] },
 end
 
+@[to_additive] lemma pow_smul_mod_minimal_period (n : ℕ) :
+  a ^ (n % function.minimal_period ((•) a) b) • b = a ^ n • b :=
+by conv_rhs { rw [← nat.mod_add_div n (minimal_period ((•) a) b), pow_add, mul_smul,
+    pow_smul_eq_iff_minimal_period_dvd.mpr (dvd_mul_right _ _)] }
+
+@[to_additive] lemma zpow_smul_mod_minimal_period (n : ℤ) :
+  a ^ (n % (function.minimal_period ((•) a) b : ℤ)) • b = a ^ n • b :=
+by conv_rhs { rw [← int.mod_add_div n (minimal_period ((•) a) b), zpow_add, mul_smul,
+    zpow_smul_eq_iff_minimal_period_dvd.mpr (dvd_mul_right _ _)] }
+
 end mul_action

--- a/src/dynamics/periodic_pts.lean
+++ b/src/dynamics/periodic_pts.lean
@@ -405,7 +405,7 @@ end
 
 variables (a b)
 
-@[to_additive] lemma pow_smul_mod_minimal_period (n : ℕ) :
+@[simp, to_additive] lemma pow_smul_mod_minimal_period (n : ℕ) :
   a ^ (n % function.minimal_period ((•) a) b) • b = a ^ n • b :=
 by conv_rhs { rw [← nat.mod_add_div n (minimal_period ((•) a) b), pow_add, mul_smul,
     pow_smul_eq_iff_minimal_period_dvd.mpr (dvd_mul_right _ _)] }

--- a/src/dynamics/periodic_pts.lean
+++ b/src/dynamics/periodic_pts.lean
@@ -410,7 +410,7 @@ variables (a b)
 by conv_rhs { rw [← nat.mod_add_div n (minimal_period ((•) a) b), pow_add, mul_smul,
     pow_smul_eq_iff_minimal_period_dvd.mpr (dvd_mul_right _ _)] }
 
-@[to_additive] lemma zpow_smul_mod_minimal_period (n : ℤ) :
+@[simp, to_additive] lemma zpow_smul_mod_minimal_period (n : ℤ) :
   a ^ (n % (function.minimal_period ((•) a) b : ℤ)) • b = a ^ n • b :=
 by conv_rhs { rw [← int.mod_add_div n (minimal_period ((•) a) b), zpow_add, mul_smul,
     zpow_smul_eq_iff_minimal_period_dvd.mpr (dvd_mul_right _ _)] }

--- a/src/dynamics/periodic_pts.lean
+++ b/src/dynamics/periodic_pts.lean
@@ -403,6 +403,8 @@ begin
         dvd_neg, int.coe_nat_dvd, pow_smul_eq_iff_minimal_period_dvd] },
 end
 
+variables (a b)
+
 @[to_additive] lemma pow_smul_mod_minimal_period (n : ℕ) :
   a ^ (n % function.minimal_period ((•) a) b) • b = a ^ n • b :=
 by conv_rhs { rw [← nat.mod_add_div n (minimal_period ((•) a) b), pow_add, mul_smul,


### PR DESCRIPTION
This PR adds another `symm_apply` API lemma for `orbit_zpowers_equiv`, taking `(k : ℤ)` rather than `(k : zmod (minimal_period ((•) a) b))`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
