### PR TITLE
[Merged by Bors] - feat(data/zmod/quotient): The minimal period equals the cardinality of the orbit

### DIFF
--- a/src/data/zmod/quotient.lean
+++ b/src/data/zmod/quotient.lean
@@ -132,8 +132,4 @@ rfl
   function.minimal_period ((•) a) b = fintype.card (mul_action.orbit (zpowers a) b) :=
 by rw [←fintype.of_equiv_card (mul_action.orbit_zpowers_equiv a b), zmod.card]
 
-@[to_additive] instance [fintype (mul_action.orbit (zpowers a) b)] :
-  fact (0 < function.minimal_period ((•) a) b) :=
-⟨by rw [minimal_period_eq_card, fintype.card_pos_iff]; exact (orbit_nonempty b).to_subtype⟩
-
 end mul_action

--- a/src/data/zmod/quotient.lean
+++ b/src/data/zmod/quotient.lean
@@ -123,9 +123,17 @@ noncomputable def _root_.add_action.orbit_zmultiples_equiv
 attribute [to_additive orbit_zmultiples_equiv] orbit_zpowers_equiv
 
 @[to_additive orbit_zmultiples_equiv_symm_apply]
-lemma orbit_zpowers_equiv_symm_apply {α β : Type*} [group α] (a : α) [mul_action α β] (b : β)
+lemma orbit_zpowers_equiv_symm_apply
   (k : zmod (minimal_period ((•) a) b)) : (orbit_zpowers_equiv a b).symm k =
   (⟨a, mem_zpowers a⟩ : zpowers a) ^ (k : ℤ) • ⟨b, mem_orbit_self b⟩ :=
 rfl
+
+@[to_additive] lemma minimal_period_eq_card [fintype (mul_action.orbit (zpowers a) b)] :
+  function.minimal_period ((•) a) b = fintype.card (mul_action.orbit (zpowers a) b) :=
+by rw [←fintype.of_equiv_card (mul_action.orbit_zpowers_equiv a b), zmod.card]
+
+@[to_additive] instance [fintype (mul_action.orbit (zpowers a) b)] :
+  fact (0 < function.minimal_period ((•) a) b) :=
+⟨by rw [minimal_period_eq_card, fintype.card_pos_iff]; exact (orbit_nonempty b).to_subtype⟩
 
 end mul_action

--- a/src/data/zmod/quotient.lean
+++ b/src/data/zmod/quotient.lean
@@ -128,8 +128,8 @@ lemma orbit_zpowers_equiv_symm_apply
   (⟨a, mem_zpowers a⟩ : zpowers a) ^ (k : ℤ) • ⟨b, mem_orbit_self b⟩ :=
 rfl
 
-@[to_additive] lemma minimal_period_eq_card [fintype (mul_action.orbit (zpowers a) b)] :
-  function.minimal_period ((•) a) b = fintype.card (mul_action.orbit (zpowers a) b) :=
-by rw [←fintype.of_equiv_card (mul_action.orbit_zpowers_equiv a b), zmod.card]
+@[to_additive] lemma minimal_period_eq_card [fintype (orbit (zpowers a) b)] :
+  minimal_period ((•) a) b = fintype.card (orbit (zpowers a) b) :=
+by rw [←fintype.of_equiv_card (orbit_zpowers_equiv a b), zmod.card]
 
 end mul_action


### PR DESCRIPTION
This PR adds a lemma stating that `minimal_period ((•) a) b = card (orbit (zpowers a) b)`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
