### PR TITLE
[Merged by Bors] - feat(category_theory/limits): monos have images

### DIFF
--- a/src/category_theory/limits/shapes/images.lean
+++ b/src/category_theory/limits/shapes/images.lean
@@ -247,6 +247,7 @@ lemma has_image.of_arrow_iso {f g : arrow C} [h : has_image f.hom] (sq : f ⟶ g
   has_image g.hom :=
 ⟨⟨h.exists_image.some.of_arrow_iso sq⟩⟩
 
+@[priority 100]
 instance mono_has_image (f : X ⟶ Y) [mono f] : has_image f :=
 has_image.mk ⟨_, is_image.self f⟩
 

--- a/src/category_theory/limits/shapes/images.lean
+++ b/src/category_theory/limits/shapes/images.lean
@@ -247,6 +247,9 @@ lemma has_image.of_arrow_iso {f g : arrow C} [h : has_image f.hom] (sq : f ⟶ g
   has_image g.hom :=
 ⟨⟨h.exists_image.some.of_arrow_iso sq⟩⟩
 
+instance mono_has_image (f : X ⟶ Y) [mono f] : has_image f :=
+has_image.mk ⟨_, is_image.self f⟩
+
 section
 variable [has_image f]
 
@@ -327,7 +330,7 @@ attribute [instance, priority 100] has_images.has_image
 end
 
 section
-variables (f) [has_image f]
+variables (f)
 /-- The image of a monomorphism is isomorphic to the source. -/
 def image_mono_iso_source [mono f] : image f ≅ X :=
 is_image.iso_ext (image.is_image f) (is_image.self f)
@@ -346,7 +349,7 @@ end
 -- from https://en.wikipedia.org/wiki/Image_%28category_theory%29, which is in turn taken from:
 -- Mitchell, Barry (1965), Theory of categories, MR 0202787, p.12, Proposition 10.1
 @[ext]
-lemma image.ext {W : C} {g h : image f ⟶ W} [has_limit (parallel_pair g h)]
+lemma image.ext [has_image f] {W : C} {g h : image f ⟶ W} [has_limit (parallel_pair g h)]
   (w : factor_thru_image f ≫ g = factor_thru_image f ≫ h) :
   g = h :=
 begin
@@ -371,7 +374,7 @@ begin
      ... = h                : by rw [category.id_comp]
 end
 
-instance [Π {Z : C} (g h : image f ⟶ Z), has_limit (parallel_pair g h)] :
+instance [has_image f] [Π {Z : C} (g h : image f ⟶ Z), has_limit (parallel_pair g h)] :
   epi (factor_thru_image f) :=
 ⟨λ Z g h w, image.ext f w⟩
 

--- a/src/category_theory/subobject/limits.lean
+++ b/src/category_theory/subobject/limits.lean
@@ -328,6 +328,9 @@ by simp [image_subobject_comp_iso]
 
 end
 
+lemma image_subobject_mono (f : X ⟶ Y) [mono f] : image_subobject f = mk f :=
+eq_of_comm (image_subobject_iso f ≪≫ image_mono_iso_source f ≪≫ (underlying_iso f).symm) (by simp)
+
 /-- Precomposing by an isomorphism does not change the image subobject. -/
 lemma image_subobject_iso_comp [has_equalizers C]
   {X' : C} (h : X' ⟶ X) [is_iso h] (f : X ⟶ Y) [has_image f] :


### PR DESCRIPTION
Turning on an instance for `has_image` for any monomorphism.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
