### PR TITLE
[Merged by Bors] - refactor(algebra/parity): Generalize to division monoids

### DIFF
--- a/src/algebra/group/opposite.lean
+++ b/src/algebra/group/opposite.lean
@@ -234,7 +234,7 @@ open mul_opposite
 `mul_equiv.inv`. -/
 @[to_additive "Negation on an additive group is an `add_equiv` to the opposite group. When `G`
 is commutative, there is `add_equiv.inv`.", simps { fully_applied := ff, simp_rhs := tt }]
-def mul_equiv.inv' (G : Type*) [group G] : G ≃* Gᵐᵒᵖ :=
+def mul_equiv.inv' (G : Type*) [division_monoid G] : G ≃* Gᵐᵒᵖ :=
 { map_mul' := λ x y, unop_injective $ mul_inv_rev x y,
   .. (equiv.inv G).trans op_equiv }
 

--- a/src/algebra/parity.lean
+++ b/src/algebra/parity.lean
@@ -37,27 +37,26 @@ Odd elements are not unified with a multiplicative notion.
 open mul_opposite
 variables {F α β R : Type*}
 
+section has_mul
+variables [has_mul α]
+
 /--  An element `a` of a type `α` with multiplication satisfies `square a` if `a = r * r`,
 for some `r : α`. -/
 @[to_additive
 "An element `a` of a type `α` with addition satisfies `even a` if `a = r + r`,
 for some `r : α`."]
-def is_square [has_mul α] (a : α) : Prop := ∃ r, a = r * r
+def is_square (a : α) : Prop := ∃ r, a = r * r
 
-@[simp, to_additive]
-lemma is_square_mul_self [has_mul α] (m : α) : is_square (m * m) := ⟨m, rfl⟩
+@[simp, to_additive] lemma is_square_mul_self (m : α) : is_square (m * m) := ⟨m, rfl⟩
 
-@[to_additive even_iff_exists_two_nsmul]
-lemma is_square_iff_exists_sq [monoid α] (m : α) : is_square m ↔ ∃ c, m = c ^ 2 :=
-by simp [is_square, pow_two]
+@[to_additive] lemma is_square_op_iff (a : α) : is_square (op a) ↔ is_square a :=
+⟨λ ⟨c, hc⟩, ⟨unop c, by rw [← unop_mul, ← hc, unop_op]⟩, λ ⟨c, hc⟩, by simp [hc]⟩
 
-alias is_square_iff_exists_sq ↔ is_square.exists_sq is_square_of_exists_sq
+/-- Create a decidability instance for `is_square` on `fintype`s. -/
+instance is_square_decidable [fintype α] [decidable_eq α] : decidable_pred (is_square : α → Prop) :=
+λ a, fintype.decidable_exists_fintype
 
-attribute [to_additive even.exists_two_nsmul "Alias of the forwards direction of
-`even_iff_exists_two_nsmul`."] is_square.exists_sq
-
-attribute [to_additive even_of_exists_two_nsmul "Alias of the backwards direction of
-`even_iff_exists_two_nsmul`."] is_square_of_exists_sq
+end has_mul
 
 @[simp, to_additive]
 lemma is_square_one [mul_one_class α] : is_square (1 : α) := ⟨1, (mul_one _).symm⟩
@@ -67,13 +66,20 @@ lemma is_square.map [mul_one_class α] [mul_one_class β] [monoid_hom_class F α
   is_square m → is_square (f m) :=
 by { rintro ⟨m, rfl⟩, exact ⟨f m, by simp⟩ }
 
-/-- Create a decidability instance for `is_square` on `fintype`s. -/
-instance is_square_decidable [fintype α] [has_mul α] [decidable_eq α] :
-  decidable_pred (is_square : α → Prop) :=
-λ a, fintype.decidable_exists_fintype
-
 section monoid
 variables [monoid α]
+
+@[to_additive even_iff_exists_two_nsmul]
+lemma is_square_iff_exists_sq (m : α) : is_square m ↔ ∃ c, m = c ^ 2 :=
+by simp [is_square, pow_two]
+
+alias is_square_iff_exists_sq ↔ is_square.exists_sq is_square_of_exists_sq
+
+attribute [to_additive even.exists_two_nsmul "Alias of the forwards direction of
+`even_iff_exists_two_nsmul`."] is_square.exists_sq
+
+attribute [to_additive even_of_exists_two_nsmul "Alias of the backwards direction of
+`even_iff_exists_two_nsmul`."] is_square_of_exists_sq
 
 @[simp, to_additive even_two_nsmul]
 lemma is_square_sq (a : α) : is_square (a ^ 2) := ⟨a, pow_two _⟩
@@ -85,29 +91,20 @@ by { rintro ⟨c, rfl⟩ a, simp_rw [←two_mul, pow_mul, neg_sq] }
 
 lemma even.neg_one_pow (h : even n) : (-1 : α) ^ n = 1 := by rw [h.neg_pow, one_pow]
 
+end monoid
+
 /-- `0` is always a square (in a monoid with zero). -/
 lemma is_square_zero (M : Type*) [monoid_with_zero M] : is_square (0 : M) :=
 by { use 0, simp only [mul_zero] }
 
-end monoid
+@[to_additive] lemma is_square.mul [comm_semigroup α] {a b : α} :
+  is_square a → is_square b → is_square (a * b) :=
+by { rintro ⟨a, rfl⟩ ⟨b, rfl⟩, exact ⟨a * b, mul_mul_mul_comm _ _ _ _⟩ }
 
-@[to_additive]
-lemma is_square.mul_is_square [comm_monoid α] {m n : α} (hm : is_square m) (hn : is_square n) :
-  is_square (m * n) :=
-begin
-  rcases hm with ⟨m, rfl⟩,
-  rcases hn with ⟨n, rfl⟩,
-  refine ⟨m * n, mul_mul_mul_comm m m n n⟩,
-end
+section division_monoid
+variables [division_monoid α] {a : α}
 
-section group
-variable [group α]
-
-@[to_additive]
-lemma is_square_op_iff (a : α) : is_square (op a) ↔ is_square a :=
-⟨λ ⟨c, hc⟩, ⟨unop c, by rw [← unop_mul, ← hc, unop_op]⟩, λ ⟨c, hc⟩, by simp [hc]⟩
-
-@[simp, to_additive] lemma is_square_inv (a : α) : is_square a⁻¹ ↔ is_square a :=
+@[simp, to_additive] lemma is_square_inv : is_square a⁻¹ ↔ is_square a :=
 begin
   refine ⟨λ h, _, λ h, _⟩,
   { rw [← is_square_op_iff, ← inv_inv a],
@@ -115,19 +112,29 @@ begin
   { exact ((is_square_op_iff a).mpr h).map (mul_equiv.inv' α).symm }
 end
 
-end group
+alias is_square_inv ↔ _ is_square.inv
 
-section comm_group
-variable [comm_group α]
+attribute [to_additive] is_square.inv
+
+variables [has_distrib_neg α] {n : ℤ}
+
+lemma even.neg_zpow : even n → ∀ a : α, (-a) ^ n = a ^ n :=
+by { rintro ⟨c, rfl⟩ a, exact zpow_bit0_neg _ _ }
+
+lemma even.neg_one_zpow (h : even n) : (-1 : α) ^ n = 1 := by rw [h.neg_zpow, one_zpow]
+
+end division_monoid
+
+lemma even_abs [subtraction_monoid α] [linear_order α] {a : α} : even (|a|) ↔ even a :=
+by cases abs_choice a; simp only [h, even_neg]
 
 @[to_additive]
-lemma is_square.div_is_square {m n : α} (hm : is_square m) (hn : is_square n) : is_square (m / n) :=
-by { rw div_eq_mul_inv,  exact hm.mul_is_square ((is_square_inv n).mpr hn) }
+lemma is_square.div [division_comm_monoid α] {a b : α} (ha : is_square a) (hb : is_square b) :
+  is_square (a / b) :=
+by { rw div_eq_mul_inv, exact ha.mul hb.inv }
 
-end comm_group
-
--- `odd.tsub_odd` requires `canonically_linear_ordered_semiring`, which we don't have
-lemma  even.tsub_even [canonically_linear_ordered_add_monoid α] [has_sub α] [has_ordered_sub α]
+-- `odd.tsub` requires `canonically_linear_ordered_semiring`, which we don't have
+lemma even.tsub [canonically_linear_ordered_add_monoid α] [has_sub α] [has_ordered_sub α]
   [contravariant_class α α (+) (≤)] {m n : α} (hm : even m) (hn : even n) : even (m - n) :=
 begin
   obtain ⟨a, rfl⟩ := hm,
@@ -187,20 +194,15 @@ alias odd_iff_exists_bit1 ↔ odd.exists_bit1 _
   set.range (λ x : α, 2 * x + 1) = {a | odd a} :=
 by { ext x, simp [odd, eq_comm] }
 
-lemma even.add_odd (hm : even m) (hn : odd n) : odd (m + n) :=
-begin
-  rcases hm with ⟨m, rfl⟩,
-  rcases hn with ⟨n, rfl⟩,
-  exact ⟨m + n, by rw [mul_add, ← two_mul, add_assoc]⟩
-end
+lemma even.add_odd : even m → odd n → odd (m + n) :=
+by { rintro ⟨m, rfl⟩ ⟨n, rfl⟩, exact ⟨m + n, by rw [mul_add, ← two_mul, add_assoc]⟩ }
 
 lemma odd.add_even (hm : odd m) (hn : even n) : odd (m + n) :=
 by { rw add_comm, exact hn.add_odd hm }
 
-lemma odd.add_odd (hm : odd m) (hn : odd n) : even (m + n) :=
+lemma odd.add_odd : odd m → odd n → even (m + n) :=
 begin
-  rcases hm with ⟨m, rfl⟩,
-  rcases hn with ⟨n, rfl⟩,
+  rintro ⟨m, rfl⟩ ⟨n, rfl⟩,
   refine ⟨n + m + 1, _⟩,
   rw [← two_mul, ←add_assoc, add_comm _ (2 * n), ←add_assoc, ←mul_add, add_assoc, mul_add _ (n + m),
     mul_one],
@@ -212,16 +214,12 @@ end
 
 @[simp] lemma odd_two_mul_add_one (m : α) : odd (2 * m + 1) := ⟨m, rfl⟩
 
-lemma ring_hom.odd (f : α →+* β) (hm : odd m) : odd (f m) :=
-begin
-  rcases hm with ⟨m, rfl⟩,
-  exact ⟨f m, by simp [two_mul]⟩
-end
+lemma odd.map [ring_hom_class F α β] (f : F) : odd m → odd (f m) :=
+by { rintro ⟨m, rfl⟩, exact ⟨f m, by simp [two_mul]⟩ }
 
-@[simp] lemma odd.mul_odd (hm : odd m) (hn : odd n) : odd (m * n) :=
+@[simp] lemma odd.mul : odd m → odd n → odd (m * n) :=
 begin
-  rcases hm with ⟨m, rfl⟩,
-  rcases hn with ⟨n, rfl⟩,
+  rintro ⟨m, rfl⟩ ⟨n, rfl⟩,
   refine ⟨2 * m * n + n + m, _⟩,
   rw [mul_add, add_mul, mul_one, ← add_assoc, one_mul, mul_assoc, ← mul_add, ← mul_add, ← mul_assoc,
     ← nat.cast_two, ← nat.cast_comm],
@@ -229,7 +227,7 @@ end
 
 lemma odd.pow (hm : odd m) : ∀ {a : ℕ}, odd (m ^ a)
 | 0       := by { rw pow_zero, exact odd_one }
-| (a + 1) := by { rw pow_succ, exact hm.mul_odd odd.pow }
+| (a + 1) := by { rw pow_succ, exact hm.mul odd.pow }
 
 end with_odd
 end semiring
@@ -248,12 +246,6 @@ variables [ring α] {a b : α} {n : ℕ}
 
 @[simp] lemma even_neg_two : even (- 2 : α) := by simp only [even_neg, even_two]
 
-lemma even_abs [linear_order α] {a : α} : even (|a|) ↔ even a :=
-begin
-  rcases abs_choice a with h | h; rw h,
-  exact even_neg a,
-end
-
 lemma odd.neg (hp : odd a) : odd (-a) :=
 begin
   obtain ⟨k, hk⟩ := hp,
@@ -262,22 +254,21 @@ begin
     neg_add_cancel_right, ←neg_add, hk],
 end
 
-@[simp] lemma odd_neg (a : α) : odd (-a) ↔ odd a :=
-⟨λ h, neg_neg a ▸ h.neg, odd.neg⟩
+@[simp] lemma odd_neg : odd (-a) ↔ odd a := ⟨λ h, neg_neg a ▸ h.neg, odd.neg⟩
 
 @[simp] lemma odd_neg_one : odd (- 1 : α) := by simp
 
 lemma odd.sub_even (ha : odd a) (hb : even b) : odd (a - b) :=
-by { rw sub_eq_add_neg, exact ha.add_even ((even_neg _).mpr hb) }
+by { rw sub_eq_add_neg, exact ha.add_even hb.neg }
 
 lemma even.sub_odd (ha : even a) (hb : odd b) : odd (a - b) :=
-by { rw sub_eq_add_neg, exact ha.add_odd ((odd_neg _).mpr hb) }
+by { rw sub_eq_add_neg, exact ha.add_odd hb.neg }
 
 lemma odd.sub_odd (ha : odd a) (hb : odd b) : even (a - b) :=
-by { rw sub_eq_add_neg, exact ha.add_odd ((odd_neg _).mpr hb) }
+by { rw sub_eq_add_neg, exact ha.add_odd hb.neg }
 
-lemma odd_abs [linear_order α] {a : α} : odd (abs a) ↔ odd a :=
-by { cases abs_choice a with h h; simp only [h, odd_neg] }
+lemma odd_abs [linear_order α] : odd (abs a) ↔ odd a :=
+by cases abs_choice a with h h; simp only [h, odd_neg]
 
 end ring
 
@@ -335,13 +326,9 @@ variable {K : Type*}
 section division_ring
 variables [division_ring K] {n : ℤ}
 
-lemma even.neg_zpow (h : even n) (a : K) : (-a) ^ n = a ^ n :=
-by { obtain ⟨k, rfl⟩ := h, exact zpow_bit0_neg _ _ }
-
 lemma odd.neg_zpow (h : odd n) (a : K) : (-a) ^ n = - a ^ n :=
 by { obtain ⟨k, rfl⟩ := h.exists_bit1, exact zpow_bit1_neg _ _ }
 
-lemma even.neg_one_zpow (h : even n) : (-1 : K) ^ n = 1 := by rw [h.neg_zpow, one_zpow]
 lemma odd.neg_one_zpow (h : odd n) : (-1 : K) ^ n = -1 := by rw [h.neg_zpow, one_zpow]
 
 end division_ring

--- a/src/analysis/convex/specific_functions.lean
+++ b/src/analysis/convex/specific_functions.lean
@@ -45,7 +45,7 @@ begin
   apply convex_on_univ_of_deriv2_nonneg differentiable_pow,
   { simp only [deriv_pow', differentiable.mul, differentiable_const, differentiable_pow] },
   { intro x,
-    obtain ⟨k, hk⟩ := (hn.tsub_even $ even_bit0 _).exists_two_nsmul _,
+    obtain ⟨k, hk⟩ := (hn.tsub $ even_bit0 _).exists_two_nsmul _,
     rw [iter_deriv_pow, finset.prod_range_cast_nat_sub, hk, nsmul_eq_mul, pow_mul'],
     exact mul_nonneg (nat.cast_nonneg _) (pow_two_nonneg _) }
 end


### PR DESCRIPTION
Generalize lemmas about `is_square`, `even` and `odd`. Improve dot notation.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
