### PR TITLE
[Merged by Bors] - refactor(algebra/big_operators/*): Generalize to division monoids

### DIFF
--- a/src/algebra/big_operators/basic.lean
+++ b/src/algebra/big_operators/basic.lean
@@ -1416,11 +1416,6 @@ multiset.prod_map_inv
 lemma prod_div_distrib : (∏ x in s, f x / g x) = (∏ x in s, f x) / ∏ x in s, g x :=
 multiset.prod_map_div
 
-@[simp, to_additive]
-lemma prod_sdiff_eq_div [decidable_eq α] (h : s₁ ⊆ s₂) :
-  (∏ x in (s₂ \ s₁), f x) = (∏ x in s₂, f x) / (∏ x in s₁, f x) :=
-by rw [eq_div_iff_mul_eq', prod_sdiff h]
-
 @[to_additive]
 lemma prod_zpow (f : α → β) (s : finset α) (n : ℤ) : ∏ a in s, (f a) ^ n = (∏ a in s, f a) ^ n :=
 multiset.prod_map_zpow
@@ -1429,6 +1424,10 @@ end division_comm_monoid
 
 section comm_group
 variables [comm_group β] [decidable_eq α]
+
+@[simp, to_additive] lemma prod_sdiff_eq_div (h : s₁ ⊆ s₂) :
+ (∏ x in (s₂ \ s₁), f x) = (∏ x in s₂, f x) / (∏ x in s₁, f x) :=
+by rw [eq_div_iff_mul_eq', prod_sdiff h]
 
 @[to_additive] lemma prod_sdiff_div_prod_sdiff :
   (∏ x in s₂ \ s₁, f x) / (∏ x in s₁ \ s₂, f x) = (∏ x in s₂, f x) / (∏ x in s₁, f x) :=

--- a/src/algebra/big_operators/basic.lean
+++ b/src/algebra/big_operators/basic.lean
@@ -1083,7 +1083,8 @@ A telescoping sum along `{0, ..., n-1}` of an `ℕ`-valued function
 reduces to the difference of the last and first terms
 when the function we are summing is monotone.
 -/
-lemma sum_range_sub_of_monotone {f : ℕ → ℕ} (h : monotone f) (n : ℕ) :
+lemma sum_range_sub_of_monotone [canonically_ordered_add_monoid α] [has_sub α] [has_ordered_sub α]
+  [contravariant_class α α (+) (≤)] {f : ℕ → α} (h : monotone f) (n : ℕ) :
   ∑ i in range n, (f (i+1) - f i) = f n - f 0 :=
 begin
   refine sum_range_induction _ _ (tsub_self _) (λ n, _) _,
@@ -1405,16 +1406,15 @@ open mul_opposite
 
 end opposite
 
-section comm_group
-variables [comm_group β]
+section division_comm_monoid
+variables [division_comm_monoid β]
+
+@[simp, to_additive] lemma prod_inv_distrib : (∏ x in s, (f x)⁻¹) = (∏ x in s, f x)⁻¹ :=
+multiset.prod_map_inv
 
 @[simp, to_additive]
-lemma prod_inv_distrib : (∏ x in s, (f x)⁻¹) = (∏ x in s, f x)⁻¹ := multiset.prod_map_inv'
-
-@[to_additive zsmul_sum]
-lemma prod_zpow (f : α → β) (s : finset α) (n : ℤ) :
-  (∏ a in s, f a) ^ n = ∏ a in s, (f a) ^ n :=
-multiset.prod_map_zpow.symm
+lemma prod_div_distrib : (∏ x in s, f x / g x) = (∏ x in s, f x) / ∏ x in s, g x :=
+multiset.prod_map_div
 
 @[simp, to_additive]
 lemma prod_sdiff_eq_div [decidable_eq α] (h : s₁ ⊆ s₂) :
@@ -1422,15 +1422,21 @@ lemma prod_sdiff_eq_div [decidable_eq α] (h : s₁ ⊆ s₂) :
 by rw [eq_div_iff_mul_eq', prod_sdiff h]
 
 @[to_additive]
-lemma prod_sdiff_div_prod_sdiff [decidable_eq α] :
-  (∏ x in s₂ \ s₁, f x) / (∏ x in s₁ \ s₂, f x)
-  = (∏ x in s₂, f x) / (∏ x in s₁, f x) :=
+lemma prod_zpow (f : α → β) (s : finset α) (n : ℤ) : ∏ a in s, (f a) ^ n = (∏ a in s, f a) ^ n :=
+multiset.prod_map_zpow
+
+end division_comm_monoid
+
+section comm_group
+variables [comm_group β] [decidable_eq α]
+
+@[to_additive] lemma prod_sdiff_div_prod_sdiff :
+  (∏ x in s₂ \ s₁, f x) / (∏ x in s₁ \ s₂, f x) = (∏ x in s₂, f x) / (∏ x in s₁, f x) :=
 by simp [← finset.prod_sdiff (@inf_le_left _ _ s₁ s₂),
   ← finset.prod_sdiff (@inf_le_right _ _ s₁ s₂)]
 
 @[simp, to_additive]
-lemma prod_erase_eq_div [decidable_eq α] {a : α} (h : a ∈ s) :
-  (∏ x in s.erase a, f x) = (∏ x in s, f x) / f a :=
+lemma prod_erase_eq_div {a : α} (h : a ∈ s) : (∏ x in s.erase a, f x) = (∏ x in s, f x) / f a :=
 by rw [eq_div_iff_mul_eq', prod_erase_mul _ _ h]
 
 end comm_group
@@ -1464,10 +1470,6 @@ by simp only [card_eq_sum_ones, sum_fiberwise_of_maps_to H]
 theorem card_eq_sum_card_image [decidable_eq β] (f : α → β) (s : finset α) :
   s.card = ∑ a in s.image f, (s.filter (λ x, f x = a)).card :=
 card_eq_sum_card_fiberwise (λ _, mem_image_of_mem _)
-
-@[simp] lemma sum_sub_distrib [add_comm_group β] :
-  ∑ x in s, (f x - g x) = (∑ x in s, f x) - (∑ x in s, g x) :=
-by simpa only [sub_eq_add_neg] using sum_add_distrib.trans (congr_arg _ sum_neg_distrib)
 
 lemma mem_sum {f : α → multiset β} (s : finset α) (b : β) :
   b ∈ ∑ x in s, f x ↔ ∃ a ∈ s, b ∈ f a :=
@@ -1512,24 +1514,6 @@ theorem prod_ne_zero_iff : (∏ x in s, f x) ≠ 0 ↔ (∀ a ∈ s, f a ≠ 0) 
 by { rw [ne, prod_eq_zero_iff], push_neg }
 
 end prod_eq_zero
-
-section comm_group_with_zero
-variables [comm_group_with_zero β]
-
-@[simp]
-lemma prod_inv_distrib' : (∏ x in s, (f x)⁻¹) = (∏ x in s, f x)⁻¹ :=
-begin
-  classical,
-  by_cases h : ∃ x ∈ s, f x = 0,
-  { simpa [prod_eq_zero_iff.mpr h, prod_eq_zero_iff] using h },
-  { push_neg at h,
-    have h' := prod_ne_zero_iff.mpr h,
-    have hf : ∀ x ∈ s, (f x)⁻¹ * f x = 1 := λ x hx, inv_mul_cancel (h x hx),
-    apply mul_right_cancel₀ h',
-    simp [h, h', ← finset.prod_mul_distrib, prod_congr rfl hf] }
-end
-
-end comm_group_with_zero
 
 @[to_additive]
 lemma prod_unique_nonempty {α β : Type*} [comm_monoid β] [unique α]

--- a/src/algebra/big_operators/finprod.lean
+++ b/src/algebra/big_operators/finprod.lean
@@ -74,7 +74,7 @@ open function set
 -/
 
 section sort
-variables {M N : Type*} {α β ι : Sort*} [comm_monoid M] [comm_monoid N]
+variables {G M N : Type*} {α β ι : Sort*} [comm_monoid M] [comm_monoid N]
 
 open_locale big_operators
 
@@ -238,19 +238,15 @@ begin
   exact (smul_add_hom R M c).map_finsum_of_injective (smul_right_injective M hc) _
 end
 
-@[to_additive] lemma finprod_inv_distrib {G : Type*} [comm_group G] (f : α → G) :
+@[to_additive] lemma finprod_inv_distrib [division_comm_monoid G] (f : α → G) :
   ∏ᶠ x, (f x)⁻¹ = (∏ᶠ x, f x)⁻¹ :=
 ((mul_equiv.inv G).map_finprod f).symm
-
-lemma finprod_inv_distrib₀ {G : Type*} [comm_group_with_zero G] (f : α → G) :
-  ∏ᶠ x, (f x)⁻¹ = (∏ᶠ x, f x)⁻¹ :=
-((mul_equiv.inv₀ G).map_finprod f).symm
 
 end sort
 
 section type
 
-variables {α β ι M N : Type*} [comm_monoid M] [comm_monoid N]
+variables {α β ι G M N : Type*} [comm_monoid M] [comm_monoid N]
 
 open_locale big_operators
 
@@ -442,17 +438,11 @@ end
 equals the product of `f i` divided by the product of `g i`. -/
 @[to_additive "If the additive supports of `f` and `g` are finite, then the sum of `f i - g i`
 equals the sum of `f i` minus the sum of `g i`."]
-lemma finprod_div_distrib {G : Type*} [comm_group G] {f g : α → G} (hf : (mul_support f).finite)
+lemma finprod_div_distrib [division_comm_monoid G] {f g : α → G} (hf : (mul_support f).finite)
   (hg : (mul_support g).finite) :
   ∏ᶠ i, f i / g i = (∏ᶠ i, f i) / ∏ᶠ i, g i :=
 by simp only [div_eq_mul_inv, finprod_mul_distrib hf ((mul_support_inv g).symm.rec hg),
               finprod_inv_distrib]
-
-lemma finprod_div_distrib₀ {G : Type*} [comm_group_with_zero G] {f g : α → G}
-  (hf : (mul_support f).finite) (hg : (mul_support g).finite) :
-  ∏ᶠ i, f i / g i = (∏ᶠ i, f i) / ∏ᶠ i, g i :=
-by simp only [div_eq_mul_inv, finprod_mul_distrib hf ((mul_support_inv₀ g).symm.rec hg),
-              finprod_inv_distrib₀]
 
 /-- A more general version of `finprod_mem_mul_distrib` that only requires `s ∩ mul_support f` and
 `s ∩ mul_support g` rather than `s` to be finite. -/
@@ -525,25 +515,17 @@ g.map_finprod_mem' (hs.inter_of_left _)
   (hs : s.finite) : g (∏ᶠ i ∈ s, f i) = ∏ᶠ i ∈ s, g (f i) :=
 g.to_monoid_hom.map_finprod_mem f hs
 
-@[to_additive] lemma finprod_mem_inv_distrib {G : Type*} [comm_group G] (f : α → G)
-  (hs : s.finite) : ∏ᶠ x ∈ s, (f x)⁻¹ = (∏ᶠ x ∈ s, f x)⁻¹ :=
+@[to_additive] lemma finprod_mem_inv_distrib [division_comm_monoid G] (f : α → G) (hs : s.finite) :
+  ∏ᶠ x ∈ s, (f x)⁻¹ = (∏ᶠ x ∈ s, f x)⁻¹ :=
 ((mul_equiv.inv G).map_finprod_mem f hs).symm
-
-lemma finprod_mem_inv_distrib₀ {G : Type*} [comm_group_with_zero G] (f : α → G)
-  (hs : s.finite) : ∏ᶠ x ∈ s, (f x)⁻¹ = (∏ᶠ x ∈ s, f x)⁻¹ :=
-((mul_equiv.inv₀ G).map_finprod_mem f hs).symm
 
 /-- Given a finite set `s`, the product of `f i / g i` over `i ∈ s` equals the product of `f i`
 over `i ∈ s` divided by the product of `g i` over `i ∈ s`. -/
 @[to_additive "Given a finite set `s`, the sum of `f i / g i` over `i ∈ s` equals the sum of `f i`
 over `i ∈ s` minus the sum of `g i` over `i ∈ s`."]
-lemma finprod_mem_div_distrib {G : Type*} [comm_group G] (f g : α → G) (hs : s.finite) :
+lemma finprod_mem_div_distrib [division_comm_monoid G] (f g : α → G) (hs : s.finite) :
   ∏ᶠ i ∈ s, f i / g i = (∏ᶠ i ∈ s, f i) / ∏ᶠ i ∈ s, g i :=
 by simp only [div_eq_mul_inv, finprod_mem_mul_distrib hs, finprod_mem_inv_distrib g hs]
-
-lemma finprod_mem_div_distrib₀ {G : Type*} [comm_group_with_zero G] (f g : α → G)
-  (hs : s.finite) : ∏ᶠ i ∈ s, f i / g i = (∏ᶠ i ∈ s, f i) / ∏ᶠ i ∈ s, g i :=
-by simp only [div_eq_mul_inv, finprod_mem_mul_distrib hs, finprod_mem_inv_distrib₀ g hs]
 
 /-!
 ### `∏ᶠ x ∈ s, f x` and set operations

--- a/src/algebra/big_operators/multiset.lean
+++ b/src/algebra/big_operators/multiset.lean
@@ -202,12 +202,14 @@ lemma prod_ne_zero (h : (0 : α) ∉ s) : s.prod ≠ 0 := mt prod_eq_zero_iff.1 
 
 end comm_monoid_with_zero
 
-section comm_group
-variables [comm_group α] {m : multiset ι} {f g : ι → α}
+section division_comm_monoid
+variables [division_comm_monoid α] {m : multiset ι} {f g : ι → α}
 
-@[simp, to_additive]
-lemma prod_map_inv' : (m.map $ λ i, (f i)⁻¹).prod = (m.map f).prod ⁻¹ :=
-by { convert (m.map f).prod_hom (comm_group.inv_monoid_hom : α →* α), rw map_map, refl }
+@[to_additive] lemma prod_map_inv' (m : multiset α) : (m.map has_inv.inv).prod = m.prod⁻¹ :=
+m.prod_hom (inv_monoid_hom : α →* α)
+
+@[simp, to_additive] lemma prod_map_inv : (m.map $ λ i, (f i)⁻¹).prod = (m.map f).prod ⁻¹ :=
+by { convert (m.map f).prod_map_inv', rw map_map }
 
 @[simp, to_additive]
 lemma prod_map_div : (m.map $ λ i, f i / g i).prod = (m.map f).prod / (m.map g).prod :=
@@ -217,29 +219,7 @@ m.prod_hom₂ (/) mul_div_mul_comm (div_one _) _ _
 lemma prod_map_zpow {n : ℤ} : (m.map $ λ i, f i ^ n).prod = (m.map f).prod ^ n :=
 by { convert (m.map f).prod_hom (zpow_group_hom _ : α →* α), rw map_map, refl }
 
-@[simp] lemma coe_inv_monoid_hom : (comm_group.inv_monoid_hom : α → α) = has_inv.inv := rfl
-
-@[simp, to_additive]
-lemma prod_map_inv (m : multiset α) : (m.map has_inv.inv).prod = m.prod⁻¹ :=
-m.prod_hom (comm_group.inv_monoid_hom : α →* α)
-
-end comm_group
-
-section comm_group_with_zero
-variables [comm_group_with_zero α] {m : multiset ι} {f g : ι → α}
-
-@[simp]
-lemma prod_map_inv₀ : (m.map $ λ i, (f i)⁻¹).prod = (m.map f).prod ⁻¹ :=
-by { convert (m.map f).prod_hom (inv_monoid_with_zero_hom : α →*₀ α), rw map_map, refl }
-
-@[simp]
-lemma prod_map_div₀ : (m.map $ λ i, f i / g i).prod = (m.map f).prod / (m.map g).prod :=
-m.prod_hom₂ (/) (λ _ _ _ _, (div_mul_div_comm _ _ _ _).symm) (div_one _) _ _
-
-lemma prod_map_zpow₀ {n : ℤ} : prod (m.map $ λ i, f i ^ n) = (m.map f).prod ^ n :=
-by { convert (m.map f).prod_hom (zpow_group_hom _ : α →* α), rw map_map, refl }
-
-end comm_group_with_zero
+end division_comm_monoid
 
 section non_unital_non_assoc_semiring
 variables [non_unital_non_assoc_semiring α] {a : α} {s : multiset ι} {f : ι → α}

--- a/src/algebra/hom/equiv.lean
+++ b/src/algebra/hom/equiv.lean
@@ -664,24 +664,17 @@ end group_with_zero
 
 end equiv
 
-/-- When the group is commutative, `equiv.inv` is a `mul_equiv`. There is a variant of this
+/-- In a `division_comm_monoid`, `equiv.inv` is a `mul_equiv`. There is a variant of this
 `mul_equiv.inv' G : G ≃* Gᵐᵒᵖ` for the non-commutative case. -/
-@[to_additive "When the `add_group` is commutative, `equiv.neg` is an `add_equiv`."]
-def mul_equiv.inv (G : Type*) [comm_group G] : G ≃* G :=
+@[to_additive "When the `add_group` is commutative, `equiv.neg` is an `add_equiv`.", simps apply]
+def mul_equiv.inv (G : Type*) [division_comm_monoid G] : G ≃* G :=
 { to_fun   := has_inv.inv,
   inv_fun  := has_inv.inv,
   map_mul' := mul_inv,
   ..equiv.inv G }
 
-/-- When the group with zero is commutative, `equiv.inv₀` is a `mul_equiv`. -/
-@[simps apply] def mul_equiv.inv₀ (G : Type*) [comm_group_with_zero G] : G ≃* G :=
-{ to_fun   := has_inv.inv,
-  inv_fun  := has_inv.inv,
-  map_mul' := mul_inv,
-  ..equiv.inv G }
-
-@[simp] lemma mul_equiv.inv₀_symm (G : Type*) [comm_group_with_zero G] :
-  (mul_equiv.inv₀ G).symm = mul_equiv.inv₀ G := rfl
+@[simp] lemma mul_equiv.inv_symm (G : Type*) [division_comm_monoid G] :
+  (mul_equiv.inv G).symm = mul_equiv.inv G := rfl
 
 section type_tags
 

--- a/src/algebra/hom/freiman.lean
+++ b/src/algebra/hom/freiman.lean
@@ -232,7 +232,7 @@ Freiman homomorphism sending `x` to `-f x`."]
 instance : has_inv (A →*[n] G) :=
 ⟨λ f, { to_fun := λ x, (f x)⁻¹,
   map_prod_eq_map_prod' := λ s t hsA htA hs ht h,
-    by rw [prod_map_inv', prod_map_inv', map_prod_eq_map_prod f hsA htA hs ht h] }⟩
+    by rw [prod_map_inv, prod_map_inv, map_prod_eq_map_prod f hsA htA hs ht h] }⟩
 
 @[simp, to_additive] lemma inv_apply (f : A →*[n] G) (x : α) : f⁻¹ x = (f x)⁻¹ := rfl
 

--- a/src/algebra/hom/group.lean
+++ b/src/algebra/hom/group.lean
@@ -672,8 +672,7 @@ protected lemma monoid_with_zero_hom.map_mul [mul_zero_one_class M] [mul_zero_on
 add_decl_doc add_monoid_hom.map_add
 
 namespace monoid_hom
-variables {mM : mul_one_class M} {mN : mul_one_class N} {mP : mul_one_class P}
-variables [group G] [comm_group H] [monoid_hom_class F M N]
+variables {mM : mul_one_class M} {mN : mul_one_class N} [monoid_hom_class F M N]
 
 include mM mN
 
@@ -696,13 +695,21 @@ let ⟨y, hy⟩ := hx in ⟨f y, map_mul_eq_one f hy⟩
 
 end monoid_hom
 
+section division_comm_monoid
+variables [division_comm_monoid α]
+
 /-- Inversion on a commutative group, considered as a monoid homomorphism. -/
-@[to_additive "Inversion on a commutative additive group, considered as an additive
-monoid homomorphism."]
-def comm_group.inv_monoid_hom {G : Type*} [comm_group G] : G →* G :=
+@[to_additive "Negation on a commutative additive group, considered as an additive monoid
+homomorphism."]
+def inv_monoid_hom : α →* α :=
 { to_fun := has_inv.inv,
   map_one' := inv_one,
   map_mul' := mul_inv }
+
+@[simp] lemma coe_inv_monoid_hom : (inv_monoid_hom : α → α) = has_inv.inv := rfl
+@[simp] lemma inv_monoid_hom_apply (a : α) : inv_monoid_hom a = a⁻¹ := rfl
+
+end division_comm_monoid
 
 /-- The identity map from a type with 1 to itself. -/
 @[to_additive, simps]

--- a/src/algebra/support.lean
+++ b/src/algebra/support.lean
@@ -180,29 +180,23 @@ begin
       using subset_trans (mul_support_mul f _) (union_subset (subset.refl _) hfn) }
 end
 
-@[simp, to_additive] lemma mul_support_inv [group G] (f : α → G) :
-  mul_support (λ x, (f x)⁻¹) = mul_support f :=
-set.ext $ λ x, not_congr inv_eq_one
+section division_monoid
+variables [division_monoid G] (f g : α → G)
 
-@[simp, to_additive] lemma mul_support_inv' [group G] (f : α → G) :
-  mul_support (f⁻¹) = mul_support f :=
-mul_support_inv f
+@[simp, to_additive]
+lemma mul_support_inv : mul_support (λ x, (f x)⁻¹) = mul_support f := ext $ λ _, inv_ne_one
 
-@[simp] lemma mul_support_inv₀ [group_with_zero G₀] (f : α → G₀) :
-  mul_support (λ x, (f x)⁻¹) = mul_support f :=
-set.ext $ λ x, inv_ne_one
+@[simp, to_additive] lemma mul_support_inv' : mul_support f⁻¹ = mul_support f := mul_support_inv f
 
-@[to_additive] lemma mul_support_mul_inv [group G] (f g : α → G) :
+@[to_additive] lemma mul_support_mul_inv :
   mul_support (λ x, f x * (g x)⁻¹) ⊆ mul_support f ∪ mul_support g :=
 mul_support_binop_subset (λ a b, a * b⁻¹) (by simp) f g
 
-@[to_additive support_sub] lemma mul_support_group_div [group G] (f g : α → G) :
+@[to_additive] lemma mul_support_div :
   mul_support (λ x, f x / g x) ⊆ mul_support f ∪ mul_support g :=
-mul_support_binop_subset (/) (by simp only [one_div, inv_one]) f g
+mul_support_binop_subset (/) one_div_one f g
 
-lemma mul_support_div [group_with_zero G₀] (f g : α → G₀) :
-  mul_support (λ x, f x / g x) ⊆ mul_support f ∪ mul_support g :=
-mul_support_binop_subset (/) (by simp only [div_one]) f g
+end division_monoid
 
 @[simp] lemma support_mul [mul_zero_class R] [no_zero_divisors R] (f g : α → R) :
   support (λ x, f x * g x) = support f ∩ support g :=

--- a/src/analysis/specific_limits/basic.lean
+++ b/src/analysis/specific_limits/basic.lean
@@ -499,7 +499,7 @@ tendsto_of_tendsto_of_tendsto_of_le_of_le'
     refine (eventually_gt_at_top 0).mono (λ n hn, _),
     rcases nat.exists_eq_succ_of_ne_zero hn.ne.symm with ⟨k, rfl⟩,
     rw [← prod_range_add_one_eq_factorial, pow_eq_prod_const, div_eq_mul_inv, ← inv_eq_one_div,
-      prod_nat_cast, nat.cast_succ, ← prod_inv_distrib', ← prod_mul_distrib,
+      prod_nat_cast, nat.cast_succ, ← prod_inv_distrib, ← prod_mul_distrib,
       finset.prod_range_succ'],
     simp only [prod_range_succ', one_mul, nat.cast_add, zero_add, nat.cast_one],
     refine mul_le_of_le_one_left (inv_nonneg.mpr $ by exact_mod_cast hn.le) (prod_le_one _ _);

--- a/src/data/dfinsupp/basic.lean
+++ b/src/data/dfinsupp/basic.lean
@@ -1367,7 +1367,7 @@ finset.prod_mul_distrib
 @[simp, to_additive] lemma prod_inv [Π i, add_comm_monoid (β i)] [Π i (x : β i), decidable (x ≠ 0)]
   [comm_group γ] {f : Π₀ i, β i} {h : Π i, β i → γ} :
   f.prod (λi b, (h i b)⁻¹) = (f.prod h)⁻¹ :=
-((comm_group.inv_monoid_hom : γ →* γ).map_prod _ f.support).symm
+((inv_monoid_hom : γ →* γ).map_prod _ f.support).symm
 
 @[to_additive] lemma prod_eq_one [Π i, has_zero (β i)] [Π i (x : β i), decidable (x ≠ 0)]
   [comm_monoid γ] {f : Π₀ i, β i} {h : Π i, β i → γ} (hyp : ∀ i, h i (f i) = 1) :

--- a/src/data/real/pi/wallis.lean
+++ b/src/data/real/pi/wallis.lean
@@ -59,26 +59,16 @@ theorem tendsto_prod_pi_div_two :
   tendsto (λ k, ∏ i in range k,
     (((2:ℝ) * i + 2) / (2 * i + 1)) * ((2 * i + 2) / (2 * i + 3))) at_top (𝓝 (π/2)) :=
 begin
-  suffices h : tendsto (λ k, 2 / π  * ∏ i in range k,
-    (((2:ℝ) * i + 2) / (2 * i + 1)) * ((2 * i + 2) / (2 * i + 3))) at_top (𝓝 1),
-  { have := tendsto.const_mul (π / 2) h,
-    have h : π / 2 ≠ 0, norm_num [pi_ne_zero],
-    simp only [← mul_assoc, ←inv_div π 2, mul_inv_cancel h, one_mul, mul_one] at this,
-    exact this },
-  have h : (λ (k : ℕ), (2:ℝ) / π * ∏ (i : ℕ) in range k,
-    ((2 * i + 2) / (2 * i + 1)) * ((2 * i + 2) / (2 * i + 3))) =
-  λ k, (2 * ∏ i in range k,
-    (2 * i + 2) / (2 * i + 3)) / (π * ∏ (i : ℕ) in range k, (2 * i + 1) / (2 * i + 2)),
-  { funext,
-    have h : ∏ (i : ℕ) in range k, ((2:ℝ) * ↑i + 2) / (2 * ↑i + 1) =
-      1 / (∏ (i : ℕ) in range k, (2 * ↑i + 1) / (2 * ↑i + 2)),
-    { rw [one_div, ← finset.prod_inv_distrib'],
-      refine prod_congr rfl (λ x hx, _),
-      field_simp },
-    rw [prod_mul_distrib, h],
-    field_simp },
-  simp only [h, ← integral_sin_pow_even, ← integral_sin_pow_odd],
-  exact integral_sin_pow_div_tendsto_one,
+  suffices h : tendsto (λ k, (π / 2)⁻¹ * ∏ i in range k,
+    (2 * i + 2) / (2 * i + 1) * ((2 * i + 2) / (2 * i + 3))) at_top (𝓝 1),
+  { convert h.const_mul (π / 2),
+    { simp_rw mul_inv_cancel_left₀ (show π / 2 ≠ 0, by norm_num [pi_ne_zero]) },
+    { rw mul_one } },
+  convert integral_sin_pow_div_tendsto_one,
+  funext,
+  rw [integral_sin_pow_even, integral_sin_pow_odd, mul_div_mul_comm, ←prod_div_distrib, inv_div],
+  congr' with i,
+  rw [div_div_div_comm, div_div_eq_mul_div, mul_div_assoc],
 end
 
 end real

--- a/src/field_theory/splitting_field.lean
+++ b/src/field_theory/splitting_field.lean
@@ -523,7 +523,7 @@ lemma sum_roots_eq_next_coeff_of_monic_of_split {P : K[X]} (hmo : P.monic)
 begin
   nth_rewrite 0 [eq_prod_roots_of_monic_of_splits_id hmo hP],
   rw [monic.next_coeff_multiset_prod _ _ (λ a ha, _)],
-  { simp_rw [next_coeff_X_sub_C, multiset.sum_map_neg] },
+  { simp_rw [next_coeff_X_sub_C, multiset.sum_map_neg'] },
   { exact monic_X_sub_C a }
 end
 

--- a/src/topology/algebra/continuous_monoid_hom.lean
+++ b/src/topology/algebra/continuous_monoid_hom.lean
@@ -170,7 +170,7 @@ mk' mul_monoid_hom continuous_mul
 /-- The continuous homomorphism given by inversion. -/
 @[to_additive "The continuous homomorphism given by negation.", simps]
 def inv : continuous_monoid_hom E E :=
-mk' comm_group.inv_monoid_hom continuous_inv
+mk' inv_monoid_hom continuous_inv
 
 variables {A B C D E}
 


### PR DESCRIPTION
Generalize big operators lemmas to `division_comm_monoid`. Rename `comm_group.inv_monoid_hom` to `inv_monoid_hom` because it is not about`comm_group` anymore and we do not use classes as namespaces.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
