### PR TITLE
[Merged by Bors] - feat(logic/hydra): termination of a hydra game

### DIFF
--- a/src/data/multiset/basic.lean
+++ b/src/data/multiset/basic.lean
@@ -683,6 +683,14 @@ theorem le_cons_erase (s : multiset α) (a : α) : s ≤ a ::ₘ s.erase a :=
 if h : a ∈ s then le_of_eq (cons_erase h).symm
 else by rw erase_of_not_mem h; apply le_cons_self
 
+lemma add_singleton_eq_iff {s t : multiset α} {a : α} :
+  s + {a} = t ↔ a ∈ t ∧ s = t.erase a :=
+begin
+  rw [add_comm, singleton_add], split,
+  { rintro rfl, exact ⟨s.mem_cons_self a, (s.erase_cons_head a).symm⟩ },
+  { rintro ⟨h, rfl⟩, exact cons_erase h },
+end
+
 theorem erase_add_left_pos {a : α} {s : multiset α} (t) : a ∈ s → (s + t).erase a = s.erase a + t :=
 quotient.induction_on₂ s t $ λ l₁ l₂ h, congr_arg coe $ erase_append_left l₂ h
 

--- a/src/logic/hydra.lean
+++ b/src/logic/hydra.lean
@@ -24,9 +24,9 @@ valid "moves" of the game are modelled by the relation `cut_expand r` on `multis
 adding back an arbitrary multiset `t` of heads such that all `a' ∈ t` satisfy `r a' a`.
 
 To prove this theorem, we follow the proof by Peter LeFanu Lumsdaine at
-https://mathoverflow.net/a/229084/3332, and introduce the notion of `fibration` of relations, and
-a special addition of relations `game_add` that is used to define addition of games in
-combinatorial game theory.
+https://mathoverflow.net/a/229084/3332, and along the way we introduce the notion of `fibration`
+of relations, and a new operation `game_add` that combines to relations to form a relation on the
+product type, which is used to define addition of games in combinatorial game theory.
 
 TODO: formalize the relations corresponding to more powerful (e.g. Kirby–Paris and Buchholz)
 hydras, and prove their well-foundedness.

--- a/src/logic/hydra.lean
+++ b/src/logic/hydra.lean
@@ -1,0 +1,174 @@
+/-
+Copyright (c) 2022 Junyan Xu. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Junyan Xu
+-/
+import data.multiset.basic
+import order.well_founded
+
+/-!
+# Termination of a hydra game
+
+This file deals with the following version of the hydra game: each head of the hydra is
+labelled by an element in a type `α`, and when you cut off one head with label `a`, it
+grows back an arbitrary but finite number of heads, all labelled by elements smaller than
+`a` with respect to a well-founded relation `r` on `α`. We show that no matter how (in\
+what order) you cut off the heads, the game always terminates, i.e. all heads will
+eventually be cut off (but of course it can last arbitrarily long, i.e. takes an
+arbitrary finite number of steps).
+
+This result is stated as the well-foundedness of the `cut_expand` relation defined in
+this file: we model the heads of the hydra as a multiset of elements of `α`, and the
+valid "moves" of the game are modelled by the relation `cut_expand r` on `multiset α`:
+`cut_expand r s' s` is true iff `s'` is obtained by removing one head `a ∈ s` and
+adding back an arbitrary multiset `t` of heads such that all `a' ∈ t` satisfy `r a' a`.
+
+To prove this theorem, we follow the proof by Peter LeFanu Lumsdaine at
+https://mathoverflow.net/a/229084/3332, and introduce the notion of `fibration` of relations, and
+a special addition of relations `game_add` that is used to define addition of games in
+combinatorial game theory.
+
+TODO: formalize the relations corresponding to more powerful (e.g. Kirby–Paris and Buchholz)
+hydras, and prove their well-foundedness.
+-/
+
+namespace relation
+
+variables {α β : Type*}
+
+section two_rels
+variables (rα : α → α → Prop) (rβ : β → β → Prop) (f : α → β)
+
+/-- A function `f : α → β` is a fibration between the relation `rα` and `rβ` if for all
+  `a : α` and `b : β`, whenever `b : β` and `f a` are related by `rβ`, `b` is the image
+  of some `a' : α` under `f`, and `a'` and `a` are related by `rα`. -/
+def fibration := ∀ ⦃a b⦄, rβ b (f a) → ∃ a', rα a' a ∧ f a' = b
+
+variables {rα rβ}
+/-- If `f : α → β` is a fibration between relations `rα` and `rβ`, and `a : α` is
+  accessible under `rα`, then `f a` is accessible under `rβ`. -/
+lemma _root_.acc.of_fibration (fib : fibration rα rβ f) {a} (ha : acc rα a) : acc rβ (f a) :=
+begin
+  induction ha with a ha ih,
+  refine acc.intro (f a) (λ b hr, _),
+  obtain ⟨a', hr', rfl⟩ := fib hr,
+  exact ih a' hr',
+end
+
+lemma _root_.acc.of_downward_closed (dc : ∀ {a b}, rβ b (f a) → b ∈ set.range f)
+  (a : α) (ha : acc (inv_image rβ f) a) : acc rβ (f a) :=
+ha.of_fibration f (λ a b h, let ⟨a', he⟩ := dc h in ⟨a', he.substr h, he⟩)
+
+variables (rα rβ)
+/-- The "addition of games" relation in combinatorial game theory, on the product type: if
+  `rα a' a` means that `a ⟶ a'` is a valid move in game `α`, and `rβ b' b` means that `b ⟶ b'`
+  is a valid move in game `β`, then `game_add rα rβ` specifies the valid moves in the juxtaposition
+  of `α` and `β`: the player is free to choose one of the games and make a move in it,
+  while leaving the other game unchanged.
+
+  This relation is a `subrelation` of `prod.lex`, but neither contains nor is contained in
+  `prod.rprod`. -/
+inductive game_add : α × β → α × β → Prop
+| fst {a' a b} : rα a' a → game_add (a',b) (a,b)
+| snd {a b' b} : rβ b' b → game_add (a,b') (a,b)
+
+variables {rα rβ}
+/-- If `a` is accessible under `rα` and `b` is accessible under `rβ`, then `(a, b)` is
+  accessible under `(a, b)`. Notice that `prod.lex_accessible` requires the stronger
+  condition `∀ b, acc rb b`. -/
+lemma _root_.acc.game_add {a b} (ha : acc rα a) (hb : acc rβ b) : acc (game_add rα rβ) (a, b) :=
+begin
+  induction ha with a ha iha generalizing b,
+  induction hb with b hb ihb,
+  refine acc.intro _ (λ h, _),
+  rintro (⟨_,_,_,ra⟩|⟨_,_,_,rb⟩),
+  exacts [iha _ ra (acc.intro b hb), ihb _ rb],
+end
+
+/-- The addition of two well-founded games is well-founded. -/
+lemma _root_.well_founded.game_add (hα : well_founded rα) (hβ : well_founded rβ) :
+  well_founded (game_add rα rβ) := ⟨λ ⟨a,b⟩, (hα.apply a).game_add (hβ.apply b)⟩
+
+end two_rels
+
+section hydra
+open game_add multiset
+
+variable (r : α → α → Prop)
+
+/-- The relation that specifies valid moves in our hydra game. `cut_expand r s' s`
+  means that `s'` is obtained by removing one head `a ∈ s` and adding back an arbitrary
+  multiset `t` of heads such that all `a' ∈ t` satisfy `r a' a`. This could be written
+  as `s' = s.erase a + t` but that requires `decidable_eq α`, so we opt for the current
+  definition, which is also easier to do computation with. We also don't include the
+  condition `a ∈ s` because `s' + {a} = s + t` already guarantees `a ∈ s + t`, and if
+  `r` is irreflexive then `a ∉ t`, which is the case when `r` is well-founded, the case
+  we are primarily interested in. -/
+def cut_expand (s' s : multiset α) : Prop :=
+∃ (t : multiset α) (a : α), (∀ a' ∈ t, r a' a) ∧ s' + {a} = s + t
+
+lemma cut_expand_iff [decidable_eq α] (hr : irreflexive r) (s' s : multiset α) :
+  cut_expand r s' s ↔ ∃ (t : multiset α) a, (∀ a' ∈ t, r a' a) ∧ a ∈ s ∧ s' = s.erase a + t :=
+begin
+  simp_rw [cut_expand, add_singleton_eq_iff],
+  refine exists₂_congr (λ t a, _), split,
+  { rintro ⟨ht, ha, rfl⟩,
+    obtain (h|h) := mem_add.1 ha,
+    exacts [⟨ht, h, t.erase_add_left_pos h⟩, (hr a $ ht a h).elim] },
+  { rintro ⟨ht, h, rfl⟩,
+    exact ⟨ht, mem_add.2 (or.inl h), (t.erase_add_left_pos h).symm⟩ },
+end
+
+/-- For any relation `r` on `α`, multiset addition `multiset α × multiset α → multiset α` is a
+  fibration between the game sum of `cut_expand r` with itself and `cut_expand r` itself. -/
+lemma cut_expand_fibration :
+  fibration (game_add (cut_expand r) (cut_expand r)) (cut_expand r) (λ s, s.1 + s.2) :=
+begin
+  rintro ⟨s₁, s₂⟩ s ⟨t, a, hr, he⟩, dsimp at he ⊢,
+  classical, obtain ⟨ha, rfl⟩ := add_singleton_eq_iff.1 he,
+  rw [add_assoc, mem_add] at ha, obtain (h|h) := ha,
+  { refine ⟨(s₁.erase a + t, s₂), fst ⟨t, a, hr, _⟩, _⟩,
+    { rw [add_comm, ← add_assoc, singleton_add, cons_erase h] },
+    { rw [add_assoc s₁, erase_add_left_pos _ h, add_right_comm, add_assoc] } },
+  { refine ⟨(s₁, (s₂ + t).erase a), snd ⟨t, a, hr, _⟩, _⟩,
+    { rw [add_comm, singleton_add, cons_erase h] },
+    { rw add_assoc, exact (erase_add_right_pos _ h).symm } },
+end
+
+/-- A multiset is accessible under `cut_expand` if all its singleton subsets are,
+  assuming `r` is irreflexive. -/
+lemma acc_of_singleton (h : irreflexive r) (s : multiset α) :
+  (∀ a ∈ s, acc (cut_expand r) {a}) → acc (cut_expand r) s :=
+begin
+  refine multiset.induction _ _ s,
+  { refine λ _, acc.intro 0 (λ s, _),
+    rintro ⟨t, a, hr, he⟩, rw zero_add at he,
+    classical, exact (h _ $ hr _ (add_singleton_eq_iff.1 he).1).elim },
+  { intros a s ih hacc, rw ← s.singleton_add a,
+    apply acc.of_fibration _ (cut_expand_fibration r)
+      ((hacc a $ s.mem_cons_self a).game_add $ ih $ λ a ha, hacc a $ mem_cons_of_mem ha) },
+end
+
+/-- A singleton `{a}` is accessible under `cut_expand r` if `a` is accessible under `r`,
+  assuming `r` is irreflexive. -/
+lemma _root_.acc.cut_expand (hi : irreflexive r)
+  (a : α) (hacc : acc r a) : acc (cut_expand r) {a} :=
+begin
+  induction hacc with a h ih,
+  refine acc.intro _ (λ s, _),
+  classical, rw cut_expand_iff r hi,
+  rintro ⟨t, a, hr, ha, rfl⟩,
+  cases mem_singleton.1 ha,
+  refine acc_of_singleton r hi _ (λ a', _),
+  rw [erase_singleton, zero_add],
+  exact ih a' ∘ hr a',
+end
+
+/-- `cut_expand r` is well-founded when `r` is. -/
+theorem _root_.well_founded.cut_expand (hr : well_founded r) : well_founded (cut_expand r) :=
+⟨λ s, acc_of_singleton r hr.is_irrefl.irrefl s $
+ λ a _, (hr.apply a).cut_expand r hr.is_irrefl.irrefl a⟩
+
+end hydra
+
+end relation

--- a/src/logic/hydra.lean
+++ b/src/logic/hydra.lean
@@ -174,8 +174,7 @@ end
 
 /-- `cut_expand r` is well-founded when `r` is. -/
 theorem _root_.well_founded.cut_expand (hr : well_founded r) : well_founded (cut_expand r) :=
-⟨λ s, acc_of_singleton r hr.is_irrefl.irrefl s $
- λ a _, (hr.apply a).cut_expand r hr.is_irrefl.irrefl a⟩
+⟨λ s, acc_of_singleton r hr.is_irrefl.1 s $ λ a _, (hr.apply a).cut_expand r hr.is_irrefl.1 a⟩
 
 end hydra
 

--- a/src/logic/hydra.lean
+++ b/src/logic/hydra.lean
@@ -12,8 +12,8 @@ import order.well_founded
 This file deals with the following version of the hydra game: each head of the hydra is
 labelled by an element in a type `α`, and when you cut off one head with label `a`, it
 grows back an arbitrary but finite number of heads, all labelled by elements smaller than
-`a` with respect to a well-founded relation `r` on `α`. We show that no matter how (in\
-what order) you cut off the heads, the game always terminates, i.e. all heads will
+`a` with respect to a well-founded relation `r` on `α`. We show that no matter how (in
+what order) you choose cut off the heads, the game always terminates, i.e. all heads will
 eventually be cut off (but of course it can last arbitrarily long, i.e. takes an
 arbitrary finite number of steps).
 
@@ -132,7 +132,7 @@ begin
     { rw [add_assoc s₁, erase_add_left_pos _ h, add_right_comm, add_assoc] } },
   { refine ⟨(s₁, (s₂ + t).erase a), snd ⟨t, a, hr, _⟩, _⟩,
     { rw [add_comm, singleton_add, cons_erase h] },
-    { rw add_assoc, exact (erase_add_right_pos _ h).symm } },
+    { rw [add_assoc, erase_add_right_pos _ h] } },
 end
 
 /-- A multiset is accessible under `cut_expand` if all its singleton subsets are,
@@ -145,8 +145,8 @@ begin
     rintro ⟨t, a, hr, he⟩, rw zero_add at he,
     classical, exact (h _ $ hr _ (add_singleton_eq_iff.1 he).1).elim },
   { intros a s ih hacc, rw ← s.singleton_add a,
-    apply acc.of_fibration _ (cut_expand_fibration r)
-      ((hacc a $ s.mem_cons_self a).game_add $ ih $ λ a ha, hacc a $ mem_cons_of_mem ha) },
+    exact ((hacc a $ s.mem_cons_self a).game_add $ ih $ λ a ha,
+      hacc a $ mem_cons_of_mem ha).of_fibration _ (cut_expand_fibration r) },
 end
 
 /-- A singleton `{a}` is accessible under `cut_expand r` if `a` is accessible under `r`,

--- a/src/logic/hydra.lean
+++ b/src/logic/hydra.lean
@@ -109,12 +109,15 @@ variable (r : α → α → Prop)
 
 /-- The relation that specifies valid moves in our hydra game. `cut_expand r s' s`
   means that `s'` is obtained by removing one head `a ∈ s` and adding back an arbitrary
-  multiset `t` of heads such that all `a' ∈ t` satisfy `r a' a`. This could be written
-  as `s' = s.erase a + t` but that requires `decidable_eq α`, so we opt for the current
-  definition, which is also easier to do computation with. We also don't include the
-  condition `a ∈ s` because `s' + {a} = s + t` already guarantees `a ∈ s + t`, and if
-  `r` is irreflexive then `a ∉ t`, which is the case when `r` is well-founded, the case
-  we are primarily interested in. -/
+  multiset `t` of heads such that all `a' ∈ t` satisfy `r a' a`.
+
+  This could alternatively be written as `s' = s.erase a + t` but that requires
+  `decidable_eq α`, so we opt for the current definition, which is also easier to do
+  computation with.
+
+  We also don't include the condition `a ∈ s` because `s' + {a} = s + t` already
+  guarantees `a ∈ s + t`, and if `r` is irreflexive then `a ∉ t`, which is the
+  case when `r` is well-founded, the case we are primarily interested in. -/
 def cut_expand (s' s : multiset α) : Prop :=
 ∃ (t : multiset α) (a : α), (∀ a' ∈ t, r a' a) ∧ s' + {a} = s + t
 
@@ -122,7 +125,7 @@ lemma cut_expand_iff [decidable_eq α] {r} (hr : irreflexive r) {s' s : multiset
   cut_expand r s' s ↔ ∃ (t : multiset α) a, (∀ a' ∈ t, r a' a) ∧ a ∈ s ∧ s' = s.erase a + t :=
 begin
   simp_rw [cut_expand, add_singleton_eq_iff],
-  refine exists₂_congr (λ t a, _), split,
+  refine exists₂_congr (λ t a, ⟨_, _⟩),
   { rintro ⟨ht, ha, rfl⟩,
     obtain (h|h) := mem_add.1 ha,
     exacts [⟨ht, h, t.erase_add_left_pos h⟩, (hr a $ ht a h).elim] },

--- a/src/logic/hydra.lean
+++ b/src/logic/hydra.lean
@@ -75,7 +75,7 @@ lemma game_add_le_lex : game_add rα rβ ≤ prod.lex rα rβ :=
 
 /-- `prod.rprod` is a subrelation of the transitive closure of `game_add`. -/
 lemma rprod_le_trans_gen_game_add : prod.rprod rα rβ ≤ trans_gen (game_add rα rβ) :=
-λ _ _ h, h.rec $ begin
+λ _ _ h, h.rec begin
   intros _ _ _ _ hα hβ,
   exact trans_gen.tail (trans_gen.single $ game_add.fst hα) (game_add.snd hβ),
 end

--- a/src/logic/hydra.lean
+++ b/src/logic/hydra.lean
@@ -111,13 +111,16 @@ variable (r : α → α → Prop)
   means that `s'` is obtained by removing one head `a ∈ s` and adding back an arbitrary
   multiset `t` of heads such that all `a' ∈ t` satisfy `r a' a`.
 
-  This could alternatively be written as `s' = s.erase a + t` but that requires
-  `decidable_eq α`, so we opt for the current definition, which is also easier to do
-  computation with.
+  This is most directly translated into `s' = s.erase a + t`, but `multiset.erase` requires
+  `decidable_eq α`, so we use the equivalent condition `s' + {a} = s + t` instead, which
+  is also easier to verify for explicit multisets `s'`, `s` and `t`.
 
   We also don't include the condition `a ∈ s` because `s' + {a} = s + t` already
   guarantees `a ∈ s + t`, and if `r` is irreflexive then `a ∉ t`, which is the
-  case when `r` is well-founded, the case we are primarily interested in. -/
+  case when `r` is well-founded, the case we are primarily interested in.
+
+  The lemma `relation.cut_expand_iff` below converts between this convenient definition
+  and the direct translation when `r` is irreflexive. -/
 def cut_expand (s' s : multiset α) : Prop :=
 ∃ (t : multiset α) (a : α), (∀ a' ∈ t, r a' a) ∧ s' + {a} = s + t
 

--- a/src/logic/hydra.lean
+++ b/src/logic/hydra.lean
@@ -64,13 +64,21 @@ variables (rα rβ)
   `rα a' a` means that `a ⟶ a'` is a valid move in game `α`, and `rβ b' b` means that `b ⟶ b'`
   is a valid move in game `β`, then `game_add rα rβ` specifies the valid moves in the juxtaposition
   of `α` and `β`: the player is free to choose one of the games and make a move in it,
-  while leaving the other game unchanged.
-
-  This relation is a `subrelation` of `prod.lex`, but neither contains nor is contained in
-  `prod.rprod`. -/
+  while leaving the other game unchanged. -/
 inductive game_add : α × β → α × β → Prop
 | fst {a' a b} : rα a' a → game_add (a',b) (a,b)
 | snd {a b' b} : rβ b' b → game_add (a,b') (a,b)
+
+/-- `game_add` is a `subrelation` of `prod.lex`. -/
+lemma game_add_le_lex : game_add rα rβ ≤ prod.lex rα rβ :=
+λ _ _ h, h.rec (λ _ _ b, prod.lex.left b b) (λ a _ _, prod.lex.right a)
+
+/-- `prod.rprod` is a subrelation of the transitive closure of `game_add`. -/
+lemma rprod_le_trans_gen_game_add : prod.rprod rα rβ ≤ trans_gen (game_add rα rβ) :=
+λ _ _ h, h.rec $ begin
+  intros _ _ _ _ hα hβ,
+  exact trans_gen.tail (trans_gen.single $ game_add.fst hα) (game_add.snd hβ),
+end
 
 variables {rα rβ}
 /-- If `a` is accessible under `rα` and `b` is accessible under `rβ`, then `(a, b)` is

--- a/src/logic/relation.lean
+++ b/src/logic/relation.lean
@@ -375,7 +375,7 @@ end trans_gen
 
 lemma _root_.acc.trans_gen {α} {r : α → α → Prop} {a : α} (h : acc r a) : acc (trans_gen r) a :=
 begin
-  refine h.rec_on (λ x _ H, _),
+  induction h with x _ H,
   refine acc.intro x (λ y hy, _),
   cases hy with _ hyx z _ hyz hzx,
   exacts [H y hyx, (H z hzx).inv hyz],

--- a/src/logic/relation.lean
+++ b/src/logic/relation.lean
@@ -373,13 +373,16 @@ end
 
 end trans_gen
 
-lemma _root_.well_founded.trans_gen {α} {r : α → α → Prop} (h : well_founded r) :
-  well_founded (trans_gen r) :=
-⟨λ a, h.induction a (λ x H, acc.intro x (λ y hy, begin
+lemma _root_.acc.trans_gen {α} {r : α → α → Prop} {a : α} (h : acc r a) : acc (trans_gen r) a :=
+begin
+  refine h.rec_on (λ x _ H, _),
+  refine acc.intro x (λ y hy, _),
   cases hy with _ hyx z _ hyz hzx,
-  { exact H y hyx },
-  { exact acc.inv (H z hzx) hyz }
-end))⟩
+  exacts [H y hyx, (H z hzx).inv hyz],
+end
+
+lemma _root_.well_founded.trans_gen {α} {r : α → α → Prop} (h : well_founded r) :
+  well_founded (trans_gen r) := ⟨λ a, (h.apply a).trans_gen⟩
 
 section trans_gen
 


### PR DESCRIPTION
+ The added file logic/hydra.lean deals with the following version of the hydra game: each head of the hydra is labelled by an element in a type `α`, and when you cut off one head with label `a`, it grows back an arbitrary but finite number of heads, all labelled by elements smaller than `a` with respect to a well-founded relation `r` on `α`. We show that no matter how (in what order) you choose cut off the heads, the game always terminates, i.e. all heads will eventually be cut off. The proof follows https://mathoverflow.net/a/229084/3332, and the notion of `fibration` and the `game_add` relation on the product of two types arise in the proof.

+ The results is used to show the well-foundedness of the intricate induction used to show that multiplication of games is well-defined on surreals, see [Zulip discussion](https://leanprover.zulipchat.com/#narrow/stream/116395-maths/topic/Well-founded.20recursion.20for.20pgames/near/282379832).

+ One lemma `add_singleton_eq_iff` is added to data/multiset/basic.

+ `acc.trans_gen` is added, closing [a comment](https://github.com/leanprover-community/lean/pull/713/files#r867394835) at lean#713.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
