### PR TITLE
[Merged by Bors] - chore(linear_algebra/multilinear/basic): move finite-dimensionality to a new file

### DIFF
--- a/src/linear_algebra/matrix/charpoly/minpoly.lean
+++ b/src/linear_algebra/matrix/charpoly/minpoly.lean
@@ -5,6 +5,7 @@ Authors: Aaron Anderson, Jalex Stark
 -/
 
 import linear_algebra.matrix.charpoly.coeff
+import linear_algebra.matrix.to_lin
 import ring_theory.power_basis
 
 /-!

--- a/src/linear_algebra/multilinear/basic.lean
+++ b/src/linear_algebra/multilinear/basic.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Sébastien Gouëzel
 -/
 import linear_algebra.basic
-import linear_algebra.matrix.to_lin
 import algebra.algebra.basic
 import algebra.big_operators.order
 import algebra.big_operators.ring
@@ -1286,29 +1285,5 @@ def range [nonempty ι] (f : multilinear_map R M₁ M₂) : sub_mul_action R M�
 f.map (λ i, ⊤)
 
 end submodule
-
-section finite_dimensional
-
-variables [fintype ι] [field R] [add_comm_group M₂] [module R M₂] [finite_dimensional R M₂]
-variables [∀ i, add_comm_group (M₁ i)] [∀ i, module R (M₁ i)] [∀ i, finite_dimensional R (M₁ i)]
-
-instance : finite_dimensional R (multilinear_map R M₁ M₂) :=
-begin
-  suffices : ∀ n (N : fin n → Type*) [∀ i, add_comm_group (N i)],
-    by exactI ∀ [∀ i, module R (N i)], by exactI ∀ [∀ i, finite_dimensional R (N i)],
-    finite_dimensional R (multilinear_map R N M₂),
-  { haveI := this _ (M₁ ∘ (fintype.equiv_fin ι).symm),
-    have e := dom_dom_congr_linear_equiv' R M₁ M₂ (fintype.equiv_fin ι),
-    exact e.symm.finite_dimensional, },
-  intros,
-  induction n with n ih,
-  { exactI (const_linear_equiv_of_is_empty R N M₂ : _).finite_dimensional, },
-  { resetI,
-    suffices : finite_dimensional R (N 0 →ₗ[R] multilinear_map R (λ (i : fin n), N i.succ) M₂),
-    { exact (multilinear_curry_left_equiv R N M₂).finite_dimensional, },
-    apply linear_map.finite_dimensional, },
-end
-
-end finite_dimensional
 
 end multilinear_map

--- a/src/linear_algebra/multilinear/finite_dimensional.lean
+++ b/src/linear_algebra/multilinear/finite_dimensional.lean
@@ -1,0 +1,41 @@
+/-
+Copyright (c) 2022 Oliver Nash. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Oliver Nash
+-/
+import linear_algebra.multilinear.basic
+import linear_algebra.matrix.to_lin
+
+/-! # Multilinear maps over finite dimensional spaces
+
+The main result of this file is `multilinear_map.finite_dimensional`.
+
+We do not put this in `linear_algebra/multilinear_map/basic`, as `matrix.to_lin` pulls in a lot of
+imports, which can cause timeouts downstream.
+-/
+
+namespace multilinear_map
+
+variables {ι R M₂ : Type*} {M₁ : ι → Type*}
+variables [decidable_eq ι]
+variables [fintype ι] [field R] [add_comm_group M₂] [module R M₂] [finite_dimensional R M₂]
+variables [∀ i, add_comm_group (M₁ i)] [∀ i, module R (M₁ i)] [∀ i, finite_dimensional R (M₁ i)]
+
+instance : finite_dimensional R (multilinear_map R M₁ M₂) :=
+begin
+  suffices : ∀ n (N : fin n → Type*) [∀ i, add_comm_group (N i)],
+    by exactI ∀ [∀ i, module R (N i)], by exactI ∀ [∀ i, finite_dimensional R (N i)],
+    finite_dimensional R (multilinear_map R N M₂),
+  { haveI := this _ (M₁ ∘ (fintype.equiv_fin ι).symm),
+    have e := dom_dom_congr_linear_equiv' R M₁ M₂ (fintype.equiv_fin ι),
+    exact e.symm.finite_dimensional, },
+  intros,
+  induction n with n ih,
+  { exactI (const_linear_equiv_of_is_empty R N M₂ : _).finite_dimensional, },
+  { resetI,
+    suffices : finite_dimensional R (N 0 →ₗ[R] multilinear_map R (λ (i : fin n), N i.succ) M₂),
+    { exact (multilinear_curry_left_equiv R N M₂).finite_dimensional, },
+    apply linear_map.finite_dimensional, },
+end
+
+end multilinear_map


### PR DESCRIPTION
`linear_algebra.matrix.to_lin` pulls in a lot of imports that appear to slow things down considerably in downstream files.

The proof is moved without modification.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
