### PR TITLE
[Merged by Bors] - doc(src/deprecated/*): add module docstrings

### DIFF
--- a/src/deprecated/group.lean
+++ b/src/deprecated/group.lean
@@ -11,10 +11,12 @@ import algebra.hom.units
 /-!
 # Unbundled monoid and group homomorphisms
 
-This file defines predicates for unbundled monoid and group homomorphisms. Though
-bundled morphisms are preferred in mathlib, these unbundled predicates are still occasionally used
-in mathlib, and probably will not go away before Lean 4
-because Lean 3 often fails to coerce a bundled homomorphism to a function.
+This file is deprecated, and is no longer imported by anything in mathlib other than other
+deprecated files, and test files. You should not need to import it.
+
+This file defines predicates for unbundled monoid and group homomorphisms. Instead of using
+this file, please use `monoid_hom`, defined in `algebra.hom.group`, with notation `→*`, for
+morphisms between monoids or groups. For example use `φ : G →* H` to represent a group homomorphism.
 
 ## Main Definitions
 

--- a/src/deprecated/group.lean
+++ b/src/deprecated/group.lean
@@ -16,7 +16,9 @@ deprecated files, and test files. You should not need to import it.
 
 This file defines predicates for unbundled monoid and group homomorphisms. Instead of using
 this file, please use `monoid_hom`, defined in `algebra.hom.group`, with notation `→*`, for
-morphisms between monoids or groups. For example use `φ : G →* H` to represent a group homomorphism.
+morphisms between monoids or groups. For example use `φ : G →* H` to represent a group
+homomorphism between multiplicative groups, and `ψ : A →+ B` to represent a group homomorphism
+between additive groups.
 
 ## Main Definitions
 

--- a/src/deprecated/ring.lean
+++ b/src/deprecated/ring.lean
@@ -8,10 +8,13 @@ import deprecated.group
 /-!
 # Unbundled semiring and ring homomorphisms (deprecated)
 
-This file defines structures for unbundled semiring and ring homomorphisms. Though bundled
-morphisms are now preferred, the unbundled structures are still occasionally used in mathlib,
-and probably will not go away before Lean 4 because Lean 3 often fails to coerce a bundled
-homomorphism to a function.
+This file is deprecated, and is no longer imported by anything in mathlib other than other
+deprecated files, and test files. You should not need to import it.
+
+This file defines predicates for unbundled semiring and ring homomorphisms. Instead of using
+this file, please use `ring_hom`, defined in `algebra.hom.ring`, with notation `→+*`, for
+morphisms between semirings or rings. For example use `φ : A →+* B` to represent a
+ring homomorphism.
 
 ## Main Definitions
 

--- a/src/deprecated/subfield.lean
+++ b/src/deprecated/subfield.lean
@@ -5,18 +5,21 @@ Authors: Andreas Swerdlow
 -/
 import deprecated.subring
 import algebra.group_with_zero.power
+
 /-
 
-# Unbundled subfields
+# Unbundled subfields (deprecated)
 
-This file introduces the predicate `is_subfield` on `S : set F` where `F` is a field.
-This is *not* the preferred way to do subfields in Lean 3: in general `S : subfield F`
-works more smoothly.
+This file is deprecated, and is no longer imported by anything in mathlib other than other
+deprecated files, and test files. You should not need to import it.
+
+This file defines predicates for unbundled subfields. Instead of using this file, please use
+`subfield`, defined in `field_theory.subfield`, for subfields of fields.
 
 ## Main definitions
 
-`is_subfield (S : set F)` : the predicate that `S` is the underlying set of a subfield
-of the field `F`. Note that the bundled variant `subfield F` is preferred to this approach.
+`is_subfield (S : set F) : Prop` : the predicate that `S` is the underlying set of a subfield
+of the field `F`. The bundled variant `subfield F` should be used in preference to this.
 
 ## Tags
 

--- a/src/deprecated/subgroup.lean
+++ b/src/deprecated/subgroup.lean
@@ -6,18 +6,20 @@ Authors: Johannes Hölzl, Mitchell Rowett, Scott Morrison, Johan Commelin, Mario
 -/
 import group_theory.subgroup.basic
 import deprecated.submonoid
-/-!
-# Unbundled subgroups
 
-This file defines unbundled multiplicative and additive subgroups `is_subgroup` and
-`is_add_subgroup`. These are not the preferred way to talk about subgroups and should
-not be used for any new projects. The preferred way in mathlib are the bundled
-versions `subgroup G` and `add_subgroup G`.
+/-!
+# Unbundled subgroups (deprecated)
+
+This file is deprecated, and is no longer imported by anything in mathlib other than other
+deprecated files, and test files. You should not need to import it.
+
+This file defines unbundled multiplicative and additive subgroups. Instead of using this file,
+please use `subgroup G` and `add_subgroup A`, defined in `group_theory.subgroup.basic`.
 
 ## Main definitions
 
-`is_add_subgroup (S : set G)` : the predicate that `S` is the underlying subset of an additive
-subgroup of `G`. The bundled variant `add_subgroup G` should be used in preference to this.
+`is_add_subgroup (S : set A)` : the predicate that `S` is the underlying subset of an additive
+subgroup of `A`. The bundled variant `add_subgroup A` should be used in preference to this.
 
 `is_subgroup (S : set G)` : the predicate that `S` is the underlying subset of a subgroup
 of `G`. The bundled variant `subgroup G` should be used in preference to this.

--- a/src/deprecated/submonoid.lean
+++ b/src/deprecated/submonoid.lean
@@ -8,24 +8,21 @@ import algebra.big_operators.basic
 import deprecated.group
 
 /-!
-# Unbundled submonoids
+# Unbundled submonoids (deprecated)
 
-This file defines unbundled multiplicative and additive submonoids `is_submonoid` and
-`is_add_submonoid`. These are not the preferred way to talk about submonoids and should
-not be used for any new projects. The preferred way in mathlib are the bundled
-versions `submonoid G` and `add_submonoid G`.
+This file is deprecated, and is no longer imported by anything in mathlib other than other
+deprecated files, and test files. You should not need to import it.
+
+This file defines unbundled multiplicative and additive submonoids. Instead of using this file,
+please use `submonoid G` and `add_submonoid A`, defined in `group_theory.submonoid.basic`.
 
 ## Main definitions
 
-`is_add_submonoid (S : set G)` : the predicate that `S` is the underlying subset of an additive
-submonoid of `G`. The bundled variant `add_subgroup G` should be used in preference to this.
+`is_add_submonoid (S : set M)` : the predicate that `S` is the underlying subset of an additive
+submonoid of `M`. The bundled variant `add_submonoid M` should be used in preference to this.
 
-`is_submonoid (S : set G)` : the predicate that `S` is the underlying subset of a submonoid
-of `G`. The bundled variant `submonoid G` should be used in preference to this.
-
-## Tags
-
-subgroup, subgroups, is_subgroup
+`is_submonoid (S : set M)` : the predicate that `S` is the underlying subset of a submonoid
+of `M`. The bundled variant `submonoid M` should be used in preference to this.
 
 ## Tags
 submonoid, submonoids, is_submonoid

--- a/src/deprecated/subring.lean
+++ b/src/deprecated/subring.lean
@@ -7,6 +7,25 @@ import deprecated.subgroup
 import deprecated.group
 import ring_theory.subring.basic
 
+/-
+
+# Unbundled subrings (deprecated)
+
+This file is deprecated, and is no longer imported by anything in mathlib other than other
+deprecated files, and test files. You should not need to import it.
+
+This file defines predicates for unbundled subrings. Instead of using this file, please use
+`subring`, defined in `ring_theory.subring.basic`, for subrings of rings.
+
+## Main definitions
+
+`is_subring (S : set R) : Prop` : the predicate that `S` is the underlying set of a subring
+of the ring `R`. The bundled variant `subring R` should be used in preference to this.
+
+## Tags
+
+is_subring
+-/
 universes u v
 
 open group


### PR DESCRIPTION
Although we don't ever import them now, I add module docstrings for a couple of deprecated files to make the linter happier. I also attempt to unify the style in the docstrings of all the deprecated files.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
