### PR TITLE
refactor(linear_algebra/clifford_algebra): generalize to non-quadratic forms

### DIFF
--- a/src/linear_algebra/clifford_algebra/basic.lean
+++ b/src/linear_algebra/clifford_algebra/basic.lean
@@ -6,7 +6,6 @@ Authors: Eric Wieser, Utensil Song
 
 import algebra.ring_quot
 import linear_algebra.tensor_algebra.basic
-import linear_algebra.exterior_algebra.basic
 import linear_algebra.quadratic_form.basic
 
 /-!
@@ -33,7 +32,6 @@ of the Clifford algebra.
 1. `ι_comp_lift` is the fact that the composition of `ι Q` with `lift Q f cond` agrees with `f`.
 2. `lift_unique` ensures the uniqueness of `lift Q f cond` with respect to 1.
 
-Additionally, when `Q = 0` an `alg_equiv` to the `exterior_algebra` is provided as `as_exterior`.
 
 ## Implementation details
 
@@ -45,8 +43,6 @@ The Clifford algebra of `M` is constructed as a quotient of the tensor algebra, 
 Note that while conventionally the clifford algebra is defined over `Q` a quadratic form, for parts
 of this file we permit `Q` to be any function, as that allows us to use the same definition for
 the exterior algebra over a semiring.
-
-This file is almost identical to `linear_algebra/exterior_algebra.lean`.
 -/
 
 variables {R M M₁ M₂ M₃ A : Type*}
@@ -204,25 +200,6 @@ begin
   convert subtype.prop (lift Q of a),
   exact alg_hom.congr_fun of_id a,
 end
-
-/-- A Clifford algebra with a zero quadratic form is isomorphic to an `exterior_algebra` -/
-def as_exterior : clifford_algebra 0 ≃ₐ[R] exterior_algebra R M :=
-alg_equiv.of_alg_hom
-  (clifford_algebra.lift 0 ⟨(exterior_algebra.ι R),
-    by simp only [forall_const, ring_hom.map_zero,
-                  exterior_algebra.ι_sq_zero, pi.zero_apply]⟩)
-  (exterior_algebra.lift R ⟨(ι 0),
-    by simp only [forall_const, ring_hom.map_zero, pi.zero_apply, ι_sq_scalar]⟩)
-  (exterior_algebra.hom_ext $ linear_map.ext $
-    by simp only [alg_hom.comp_to_linear_map, linear_map.coe_comp,
-                  function.comp_app, alg_hom.to_linear_map_apply,
-                  exterior_algebra.lift_ι_apply, clifford_algebra.lift_ι_apply,
-                  alg_hom.to_linear_map_id, linear_map.id_comp, eq_self_iff_true, forall_const])
-  (clifford_algebra.hom_ext $ linear_map.ext $
-    by simp only [alg_hom.comp_to_linear_map, linear_map.coe_comp,
-                  function.comp_app, alg_hom.to_linear_map_apply,
-                  clifford_algebra.lift_ι_apply, exterior_algebra.lift_ι_apply,
-                  alg_hom.to_linear_map_id, linear_map.id_comp, eq_self_iff_true, forall_const])
 
 @[simp]
 lemma ι_range_map_lift (f : M →ₗ[R] A) (cond : ∀ m, f m * f m = algebra_map _ _ (Q m)) :

--- a/src/linear_algebra/clifford_algebra/basic.lean
+++ b/src/linear_algebra/clifford_algebra/basic.lean
@@ -74,16 +74,6 @@ ring_quot (clifford_algebra.rel Q)
 instance [comm_ring R] [add_comm_group M] [module R M] (Q : M → R) : ring (clifford_algebra Q) :=
 { zero := 0, add := (+), one := 1, mul := (*), ..ring_quot.ring _}
 
-section
-local attribute [-instance] clifford_algebra.semiring
-
-/-- A copy of `clifford_algebra.algebra` that refers to `clifford_algebra.ring`. -/
-instance algebra' [comm_ring R] [add_comm_group M] [module R M] (Q : M → R) :
-  algebra R (clifford_algebra Q) :=
-clifford_algebra.algebra Q
-
-end
-
 namespace clifford_algebra
 
 section semiring
@@ -96,7 +86,8 @@ variables (Q : M → R)
 The canonical linear map `M →ₗ[R] clifford_algebra Q`.
 -/
 def ι : M →ₗ[R] clifford_algebra Q :=
-(ring_quot.mk_alg_hom R _).to_linear_map.comp (tensor_algebra.ι R)
+by exact (ring_quot.mk_alg_hom R _).to_linear_map.comp (tensor_algebra.ι R)
+-- note the implicit arguments in the type are much worse without the `by exact`
 
 /-- As well as being linear, `ι Q` squares to the quadratic form -/
 @[simp]

--- a/src/linear_algebra/clifford_algebra/conjugation.lean
+++ b/src/linear_algebra/clifford_algebra/conjugation.lean
@@ -30,32 +30,35 @@ https://en.wikipedia.org/wiki/Clifford_algebra#Antiautomorphisms
 
 -/
 
-variables {R : Type*} [comm_ring R]
-variables {M : Type*} [add_comm_group M] [module R M]
-variables {Q : quadratic_form R M}
+variables {R R' M M' : Type*}
+variables [comm_semiring R] [add_comm_monoid M] [module R M]
+variables [comm_ring R'] [add_comm_group M'] [module R' M']
+variables {Q : M → R} {Q' : M' → R'}
 
 namespace clifford_algebra
 
 section involute
 
 /-- Grade involution, inverting the sign of each basis vector. -/
-def involute : clifford_algebra Q →ₐ[R] clifford_algebra Q :=
-clifford_algebra.lift Q ⟨-(ι Q), λ m, by simp⟩
+def involute : clifford_algebra Q' →ₐ[R'] clifford_algebra Q' :=
+clifford_algebra.lift Q' ⟨-(ι Q'), λ m, by
+  simp only [linear_map.neg_apply, neg_mul_neg, ι_sq_scalar Q']⟩
 
-@[simp] lemma involute_ι (m : M) : involute (ι Q m) = -ι Q m :=
+@[simp] lemma involute_ι (m : M') : involute (ι Q' m) = -ι Q' m :=
 lift_ι_apply _ _ m
 
-@[simp] lemma involute_comp_involute : involute.comp involute = alg_hom.id R (clifford_algebra Q) :=
+@[simp] lemma involute_comp_involute :
+  involute.comp involute = alg_hom.id R' (clifford_algebra Q') :=
 by { ext, simp }
 
-lemma involute_involutive : function.involutive (involute : _ → clifford_algebra Q) :=
+lemma involute_involutive : function.involutive (involute : _ → clifford_algebra Q') :=
 alg_hom.congr_fun involute_comp_involute
 
-@[simp] lemma involute_involute : ∀ a : clifford_algebra Q, involute (involute a) = a :=
+@[simp] lemma involute_involute : ∀ a : clifford_algebra Q', involute (involute a) = a :=
 involute_involutive
 
 /-- `clifford_algebra.involute` as an `alg_equiv`. -/
-@[simps] def involute_equiv : clifford_algebra Q ≃ₐ[R] clifford_algebra Q :=
+@[simps] def involute_equiv : clifford_algebra Q' ≃ₐ[R'] clifford_algebra Q' :=
 alg_equiv.of_alg_hom involute involute
   (alg_hom.ext $ involute_involute) (alg_hom.ext $ involute_involute)
 
@@ -110,7 +113,7 @@ linear_equiv.of_involutive reverse reverse_involutive
 
 lemma reverse_comp_involute :
   reverse.comp involute.to_linear_map =
-    (involute.to_linear_map.comp reverse : _ →ₗ[R] clifford_algebra Q) :=
+    (involute.to_linear_map.comp reverse : _ →ₗ[R'] clifford_algebra Q') :=
 begin
   ext,
   simp only [linear_map.comp_apply, alg_hom.to_linear_map_apply],
@@ -123,10 +126,10 @@ end
 
 /-- `clifford_algebra.reverse` and `clifford_algebra.inverse` commute. Note that the composition
 is sometimes referred to as the "clifford conjugate". -/
-lemma reverse_involute_commute : function.commute (reverse : _ → clifford_algebra Q) involute :=
+lemma reverse_involute_commute : function.commute (reverse : _ → clifford_algebra Q') involute :=
 linear_map.congr_fun reverse_comp_involute
 
-lemma reverse_involute : ∀ a : clifford_algebra Q, reverse (involute a) = involute (reverse a) :=
+lemma reverse_involute : ∀ a : clifford_algebra Q', reverse (involute a) = involute (reverse a) :=
 reverse_involute_commute
 
 end reverse
@@ -145,8 +148,8 @@ lemma reverse_prod_map_ι : ∀ (l : list M), reverse (l.map $ ι Q).prod = (l.m
 
 /-- Taking the involute of the product a list of $n$ vectors lifted via `ι` is equivalent to
 premultiplying by ${-1}^n$. -/
-lemma involute_prod_map_ι : ∀ l : list M,
-  involute (l.map $ ι Q).prod = ((-1 : R)^l.length) • (l.map $ ι Q).prod
+lemma involute_prod_map_ι : ∀ l : list M',
+  involute (l.map $ ι Q').prod = ((-1 : R')^l.length) • (l.map $ ι Q').prod
 | [] := by simp
 | (x :: xs) := by simp [pow_add, involute_prod_map_ι xs]
 
@@ -158,27 +161,27 @@ end list
 
 section submodule
 
-variables (Q)
+variables (Q Q')
 
 section involute
 
-lemma submodule_map_involute_eq_comap (p : submodule R (clifford_algebra Q)) :
+lemma submodule_map_involute_eq_comap (p : submodule R' (clifford_algebra Q')) :
   p.map involute.to_linear_map = p.comap involute.to_linear_map :=
-(submodule.map_equiv_eq_comap_symm involute_equiv.to_linear_equiv _)
+(submodule.map_equiv_eq_comap_symm involute_equiv.to_linear_equiv p)
 
-@[simp] lemma ι_range_map_involute : (ι Q).range.map involute.to_linear_map = (ι Q).range :=
+@[simp] lemma ι_range_map_involute : (ι Q').range.map involute.to_linear_map = (ι Q').range :=
 (ι_range_map_lift _ _).trans (linear_map.range_neg _)
 
-@[simp] lemma ι_range_comap_involute : (ι Q).range.comap involute.to_linear_map = (ι Q).range :=
-by rw [←submodule_map_involute_eq_comap, ι_range_map_involute]
+@[simp] lemma ι_range_comap_involute : (ι Q').range.comap involute.to_linear_map = (ι Q').range :=
+by rw [←submodule_map_involute_eq_comap Q', ι_range_map_involute Q']
 
 @[simp] lemma even_odd_map_involute (n : zmod 2) :
-  (even_odd Q n).map involute.to_linear_map = (even_odd Q n) :=
+  (even_odd Q' n).map involute.to_linear_map = (even_odd Q' n) :=
 by simp_rw [even_odd, submodule.map_supr, submodule.map_pow, ι_range_map_involute]
 
 @[simp] lemma even_odd_comap_involute (n : zmod 2) :
-  (even_odd Q n).comap involute.to_linear_map = even_odd Q n :=
-by rw [←submodule_map_involute_eq_comap, even_odd_map_involute]
+  (even_odd Q' n).comap involute.to_linear_map = even_odd Q' n :=
+by rw [←submodule_map_involute_eq_comap Q', even_odd_map_involute Q']
 
 end involute
 
@@ -225,9 +228,9 @@ by rw [←submodule_map_reverse_eq_comap, even_odd_map_reverse]
 
 end reverse
 
-@[simp] lemma involute_mem_even_odd_iff {x : clifford_algebra Q} {n : zmod 2} :
-  involute x ∈ even_odd Q n ↔ x ∈ even_odd Q n :=
-set_like.ext_iff.mp (even_odd_comap_involute Q n) x
+@[simp] lemma involute_mem_even_odd_iff {x : clifford_algebra Q'} {n : zmod 2} :
+  involute x ∈ even_odd Q' n ↔ x ∈ even_odd Q' n :=
+set_like.ext_iff.mp (even_odd_comap_involute Q' n) x
 
 @[simp] lemma reverse_mem_even_odd_iff {x : clifford_algebra Q} {n : zmod 2} :
   reverse x ∈ even_odd Q n ↔ x ∈ even_odd Q n :=
@@ -241,20 +244,20 @@ end submodule
 TODO: show that these are `iff`s when `invertible (2 : R)`.
 -/
 
-lemma involute_eq_of_mem_even {x : clifford_algebra Q} (h : x ∈ even_odd Q 0) :
+lemma involute_eq_of_mem_even {x : clifford_algebra Q'} (h : x ∈ even_odd Q' 0) :
   involute x = x :=
 begin
-  refine even_induction Q (alg_hom.commutes _) _ _ x h,
+  refine even_induction Q' (alg_hom.commutes _) _ _ x h,
   { rintros x y hx hy ihx ihy,
     rw [map_add, ihx, ihy]},
   { intros m₁ m₂ x hx ihx,
     rw [map_mul, map_mul, involute_ι, involute_ι, ihx, neg_mul_neg], },
 end
 
-lemma involute_eq_of_mem_odd {x : clifford_algebra Q} (h : x ∈ even_odd Q 1) :
+lemma involute_eq_of_mem_odd {x : clifford_algebra Q'} (h : x ∈ even_odd Q' 1) :
   involute x = -x :=
 begin
-  refine odd_induction Q involute_ι _ _ x h,
+  refine odd_induction Q' involute_ι _ _ x h,
   { rintros x y hx hy ihx ihy,
     rw [map_add, ihx, ihy, neg_add] },
   { intros m₁ m₂ x hx ihx,

--- a/src/linear_algebra/clifford_algebra/grading.lean
+++ b/src/linear_algebra/clifford_algebra/grading.lean
@@ -15,8 +15,8 @@ The main result is `clifford_algebra.graded_algebra`, which says that the cliffo
 -/
 
 namespace clifford_algebra
-variables {R M : Type*} [comm_ring R] [add_comm_group M] [module R M]
-variables {Q : quadratic_form R M}
+variables {R M : Type*} [comm_semiring R] [add_comm_monoid M] [module R M]
+variables {Q : M → R}
 
 open_locale direct_sum
 

--- a/src/linear_algebra/exterior_algebra/basic.lean
+++ b/src/linear_algebra/exterior_algebra/basic.lean
@@ -5,7 +5,7 @@ Authors: Zhangir Azerbayev, Adam Topaz, Eric Wieser
 -/
 
 import algebra.ring_quot
-import linear_algebra.tensor_algebra.basic
+import linear_algebra.clifford_algebra.basic
 import linear_algebra.alternating
 import group_theory.perm.sign
 
@@ -38,11 +38,7 @@ of the exterior algebra.
 
 ## Implementation details
 
-The exterior algebra of `M` is constructed as a quotient of the tensor algebra, as follows.
-1. We define a relation `exterior_algebra.rel R M` on `tensor_algebra R M`.
-   This is the smallest relation which identifies squares of elements of `M` with `0`.
-2. The exterior algebra is the quotient of the tensor algebra by this relation.
-
+The exterior algebra of `M` is constructed as simply `clifford_algebra (0 : M → R)`.
 -/
 
 universes u1 u2 u3
@@ -50,46 +46,27 @@ universes u1 u2 u3
 variables (R : Type u1) [comm_semiring R]
 variables (M : Type u2) [add_comm_monoid M] [module R M]
 
-namespace exterior_algebra
-open tensor_algebra
-
-/-- `rel` relates each `ι m * ι m`, for `m : M`, with `0`.
-
-The exterior algebra of `M` is defined as the quotient modulo this relation.
--/
-inductive rel : tensor_algebra R M → tensor_algebra R M → Prop
-| of (m : M) : rel ((ι R m) * (ι R m)) 0
-
-end exterior_algebra
-
 /--
 The exterior algebra of an `R`-module `M`.
 -/
-@[derive [inhabited, semiring, algebra R]]
-def exterior_algebra := ring_quot (exterior_algebra.rel R M)
+@[reducible]
+def exterior_algebra := clifford_algebra (0 : M → R)
 
 namespace exterior_algebra
 
 variables {M}
 
-instance {S : Type u3} [comm_ring S] [module S M] : ring (exterior_algebra S M) :=
-ring_quot.ring (exterior_algebra.rel S M)
-
 /--
 The canonical linear map `M →ₗ[R] exterior_algebra R M`.
 -/
-def ι : M →ₗ[R] exterior_algebra R M :=
-(ring_quot.mk_alg_hom R _).to_linear_map.comp (tensor_algebra.ι R)
-
+def ι : M →ₗ[R] exterior_algebra R M := by exact clifford_algebra.ι _
 
 variables {R}
 
 /-- As well as being linear, `ι m` squares to zero -/
 @[simp]
 theorem ι_sq_zero (m : M) : (ι R m) * (ι R m) = 0 :=
-begin
-  erw [←alg_hom.map_mul, ring_quot.mk_alg_hom_rel R (rel.of m), alg_hom.map_zero _],
-end
+(clifford_algebra.ι_sq_scalar (0 : M → R) m).trans $ map_zero _
 
 variables {A : Type*} [semiring A] [algebra R A]
 
@@ -107,65 +84,39 @@ from `exterior_algebra R M` to `A`.
 -/
 @[simps symm_apply]
 def lift : {f : M →ₗ[R] A // ∀ m, f m * f m = 0} ≃ (exterior_algebra R M →ₐ[R] A) :=
-{ to_fun := λ f,
-  ring_quot.lift_alg_hom R ⟨tensor_algebra.lift R (f : M →ₗ[R] A),
-    λ x y (h : rel R M x y), by
-    { induction h,
-      rw [alg_hom.map_zero, alg_hom.map_mul, tensor_algebra.lift_ι_apply, f.prop] }⟩,
-  inv_fun := λ F, ⟨F.to_linear_map.comp (ι R), λ m, by rw [
-    linear_map.comp_apply, alg_hom.to_linear_map_apply, comp_ι_sq_zero]⟩,
-  left_inv := λ f, by { ext, simp [ι] },
-  right_inv := λ F, by { ext, simp [ι] } }
+equiv.trans (equiv.subtype_equiv (equiv.refl _) $ by simp) $ clifford_algebra.lift (0 : M → R)
 
 @[simp]
 theorem ι_comp_lift (f : M →ₗ[R] A) (cond : ∀ m, f m * f m = 0) :
   (lift R ⟨f, cond⟩).to_linear_map.comp (ι R) = f :=
-(subtype.mk_eq_mk.mp $ (lift R).symm_apply_apply ⟨f, cond⟩)
+clifford_algebra.ι_comp_lift f _
 
 @[simp]
 theorem lift_ι_apply (f : M →ₗ[R] A) (cond : ∀ m, f m * f m = 0) (x) :
   lift R ⟨f, cond⟩ (ι R x) = f x :=
-(linear_map.ext_iff.mp $ ι_comp_lift R f cond) x
+clifford_algebra.lift_ι_apply f _ x
 
 @[simp]
 theorem lift_unique (f : M →ₗ[R] A) (cond : ∀ m, f m * f m = 0)
   (g : exterior_algebra R M →ₐ[R] A) : g.to_linear_map.comp (ι R) = f ↔ g = lift R ⟨f, cond⟩ :=
-begin
-  convert (lift R).symm_apply_eq,
-  rw lift_symm_apply,
-  simp only,
-end
-
-attribute [irreducible] ι lift
--- Marking `exterior_algebra` irreducible makes our `ring` instances inaccessible.
--- https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/algebra.2Esemiring_to_ring.20breaks.20semimodule.20typeclass.20lookup/near/212580241
--- For now, we avoid this by not marking it irreducible.
+clifford_algebra.lift_unique f _ _
 
 variables {R M}
 
 @[simp]
 theorem lift_comp_ι (g : exterior_algebra R M →ₐ[R] A) :
   lift R ⟨g.to_linear_map.comp (ι R), comp_ι_sq_zero _⟩ = g :=
-begin
-  convert (lift R).apply_symm_apply g,
-  rw lift_symm_apply,
-  refl,
-end
+clifford_algebra.lift_comp_ι g
 
 /-- See note [partially-applied ext lemmas]. -/
 @[ext]
 theorem hom_ext {f g : exterior_algebra R M →ₐ[R] A}
   (h : f.to_linear_map.comp (ι R) = g.to_linear_map.comp (ι R)) : f = g :=
-begin
-  apply (lift R).symm.injective,
-  rw [lift_symm_apply, lift_symm_apply],
-  simp only [h],
-end
+clifford_algebra.hom_ext h
 
 /-- If `C` holds for the `algebra_map` of `r : R` into `exterior_algebra R M`, the `ι` of `x : M`,
 and is preserved under addition and muliplication, then it holds for all of `exterior_algebra R M`.
 -/
--- This proof closely follows `tensor_algebra.induction`
 @[elab_as_eliminator]
 lemma induction {C : exterior_algebra R M → Prop}
   (h_grade0 : ∀ r, C (algebra_map R (exterior_algebra R M) r))
@@ -174,24 +125,7 @@ lemma induction {C : exterior_algebra R M → Prop}
   (h_add : ∀ a b, C a → C b → C (a + b))
   (a : exterior_algebra R M) :
   C a :=
-begin
-  -- the arguments are enough to construct a subalgebra, and a mapping into it from M
-  let s : subalgebra R (exterior_algebra R M) :=
-  { carrier := C,
-    mul_mem' := h_mul,
-    add_mem' := h_add,
-    algebra_map_mem' := h_grade0, },
-  let of : { f : M →ₗ[R] s // ∀ m, f m * f m = 0 } :=
-  ⟨(ι R).cod_restrict s.to_submodule h_grade1,
-    λ m, subtype.eq $ ι_sq_zero m ⟩,
-  -- the mapping through the subalgebra is the identity
-  have of_id : alg_hom.id R (exterior_algebra R M) = s.val.comp (lift R of),
-  { ext,
-    simp [of], },
-  -- finding a proof is finding an element of the subalgebra
-  convert subtype.prop (lift R of a),
-  exact alg_hom.congr_fun of_id a,
-end
+clifford_algebra.induction h_grade0 h_grade1 h_mul h_add a
 
 /-- The left-inverse of `algebra_map`. -/
 def algebra_map_inv : exterior_algebra R M →ₐ[R] R :=


### PR DESCRIPTION
This changes `Q : quadratic_form R M` to `Q : M → R`, such that we can use the same definition for the exterior algebra.
With this done, we can make `exterior_algebra R M = clifford_algebra (0 : M → R)`.

This creates weird elaboration pain in places. 

[Zulip thread](https://leanprover.zulipchat.com/#narrow/stream/116395-maths/topic/Exterior.20algebras.20over.20semiring/near/282806575)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
