### PR TITLE
[Merged by Bors] - doc(deprecated/*): all deprecated files now lint

### DIFF
--- a/src/deprecated/group.lean
+++ b/src/deprecated/group.lean
@@ -56,7 +56,8 @@ lemma comp {f : α → β} {g : β → γ} (hf : is_mul_hom f) (hg : is_mul_hom 
 
 /-- A product of maps which preserve multiplication,
 preserves multiplication when the target is commutative. -/
-@[to_additive]
+@[to_additive "A sum of maps which preserves addition, preserves addition when the target
+is commutative."]
 lemma mul {α β} [semigroup α] [comm_semigroup β]
   {f g : α → β} (hf : is_mul_hom f) (hg : is_mul_hom g) :
   is_mul_hom (λ a, f a * g a) :=
@@ -64,7 +65,8 @@ lemma mul {α β} [semigroup α] [comm_semigroup β]
 
 /-- The inverse of a map which preserves multiplication,
 preserves multiplication when the target is commutative. -/
-@[to_additive]
+@[to_additive "The negation of a map which preserves addition, preserves addition when
+the target is commutative."]
 lemma inv {α β} [has_mul α] [comm_group β] {f : α → β} (hf : is_mul_hom f) :
   is_mul_hom (λ a, (f a)⁻¹) :=
 { map_mul := λ a b, (hf.map_mul a b).symm ▸ mul_inv _ _ }
@@ -111,12 +113,13 @@ namespace mul_equiv
 variables {M : Type*} {N : Type*} [mul_one_class M] [mul_one_class N]
 
 /-- A multiplicative isomorphism preserves multiplication (deprecated). -/
-@[to_additive]
+@[to_additive "An additive isomorphism preserves addition (deprecated)."]
 theorem is_mul_hom (h : M ≃* N) : is_mul_hom h := ⟨h.map_mul⟩
 
 /-- A multiplicative bijection between two monoids is a monoid hom
   (deprecated -- use `mul_equiv.to_monoid_hom`). -/
-@[to_additive]
+@[to_additive "An additive bijection between two additive monoids is an additive
+monoid hom (deprecated). "]
 lemma is_monoid_hom (h : M ≃* N) : is_monoid_hom h :=
 { map_mul := h.map_mul,
   map_one := h.map_one }
@@ -127,13 +130,14 @@ namespace is_monoid_hom
 variables [mul_one_class α] [mul_one_class β] {f : α → β} (hf : is_monoid_hom f)
 
 /-- A monoid homomorphism preserves multiplication. -/
-@[to_additive]
+@[to_additive "An additive monoid homomorphism preserves addition."]
 lemma map_mul (x y) : f (x * y) = f x * f y :=
 hf.map_mul x y
 
 /-- The inverse of a map which preserves multiplication,
 preserves multiplication when the target is commutative. -/
-@[to_additive]
+@[to_additive "The negation of a map which preserves addition, preserves addition
+when the target is commutative."]
 lemma inv {α β} [mul_one_class α] [comm_group β] {f : α → β} (hf : is_monoid_hom f) :
   is_monoid_hom (λ a, (f a)⁻¹) :=
 { map_one := hf.map_one.symm ▸ inv_one,
@@ -142,7 +146,8 @@ lemma inv {α β} [mul_one_class α] [comm_group β] {f : α → β} (hf : is_mo
 end is_monoid_hom
 
 /-- A map to a group preserving multiplication is a monoid homomorphism. -/
-@[to_additive]
+@[to_additive "A map to an additive group preserving addition is an additive monoid
+homomorphism."]
 theorem is_mul_hom.to_is_monoid_hom [mul_one_class α] [group β] {f : α → β} (hf : is_mul_hom f) :
   is_monoid_hom f :=
 { map_one := mul_right_eq_self.1 $ by rw [← hf.map_mul, one_mul],
@@ -152,11 +157,12 @@ namespace is_monoid_hom
 variables [mul_one_class α] [mul_one_class β] {f : α → β}
 
 /-- The identity map is a monoid homomorphism. -/
-@[to_additive]
+@[to_additive "The identity map is an additive monoid homomorphism."]
 lemma id : is_monoid_hom (@id α) := { map_one := rfl, map_mul := λ _ _, rfl }
 
 /-- The composite of two monoid homomorphisms is a monoid homomorphism. -/
-@[to_additive]
+@[to_additive "The composite of two additive monoid homomorphisms is an additive monoid
+homomorphism."]
 lemma comp (hf : is_monoid_hom f) {γ} [mul_one_class γ] {g : β → γ} (hg : is_monoid_hom g) :
   is_monoid_hom (g ∘ f) :=
 { map_one := show g _ = 1, by rw [hf.map_one, hg.map_one],
@@ -195,7 +201,7 @@ lemma mul_equiv.is_group_hom {G H : Type*} {_ : group G} {_ : group H} (h : G �
   is_group_hom h := { map_mul := h.map_mul }
 
 /-- Construct `is_group_hom` from its only hypothesis. -/
-@[to_additive]
+@[to_additive "Construct `is_add_group_hom` from its only hypothesis."]
 lemma is_group_hom.mk' [group α] [group β] {f : α → β} (hf : ∀ x y, f (x * y) = f x * f y) :
   is_group_hom f :=
 { map_mul := hf }
@@ -207,16 +213,16 @@ open is_mul_hom (map_mul)
 lemma map_mul : ∀ (x y), f (x * y) = f x * f y := hf.to_is_mul_hom.map_mul
 
 /-- A group homomorphism is a monoid homomorphism. -/
-@[to_additive]
+@[to_additive "An additive group homomorphism is an additive monoid homomorphism."]
 lemma to_is_monoid_hom : is_monoid_hom f :=
 hf.to_is_mul_hom.to_is_monoid_hom
 
 /-- A group homomorphism sends 1 to 1. -/
-@[to_additive]
+@[to_additive "An additive group homomorphism sends 0 to 0."]
 lemma map_one : f 1 = 1 := hf.to_is_monoid_hom.map_one
 
 /-- A group homomorphism sends inverses to inverses. -/
-@[to_additive]
+@[to_additive "An additive group homomorphism sends negations to negations."]
 theorem map_inv (hf : is_group_hom f) (a : α) : f a⁻¹ = (f a)⁻¹ :=
 eq_inv_of_mul_eq_one_left $ by rw [← hf.map_mul, inv_mul_self, hf.map_one]
 
@@ -224,31 +230,34 @@ eq_inv_of_mul_eq_one_left $ by rw [← hf.map_mul, inv_mul_self, hf.map_one]
 by simp_rw [div_eq_mul_inv, hf.map_mul, hf.map_inv]
 
 /-- The identity is a group homomorphism. -/
-@[to_additive]
+@[to_additive "The identity is an additive group homomorphism."]
 lemma id : is_group_hom (@id α) := { map_mul := λ _ _, rfl}
 
 /-- The composition of two group homomorphisms is a group homomorphism. -/
-@[to_additive]
+@[to_additive "The composition of two additive group homomorphisms is an additive
+group homomorphism."]
 lemma comp (hf : is_group_hom f) {γ} [group γ] {g : β → γ} (hg : is_group_hom g) :
   is_group_hom (g ∘ f) :=
 { ..is_mul_hom.comp hf.to_is_mul_hom hg.to_is_mul_hom }
 
 /-- A group homomorphism is injective iff its kernel is trivial. -/
-@[to_additive]
+@[to_additive "An additive group homomorphism is injective if its kernel is trivial."]
 lemma injective_iff {f : α → β} (hf : is_group_hom f) :
   function.injective f ↔ (∀ a, f a = 1 → a = 1) :=
 ⟨λ h _, by rw ← hf.map_one; exact @h _ _,
   λ h x y hxy, eq_of_div_eq_one $ h _ $ by rwa [hf.map_div, div_eq_one]⟩
 
 /-- The product of group homomorphisms is a group homomorphism if the target is commutative. -/
-@[to_additive]
+@[to_additive "The sum of two additive group homomorphisms is an additive group homomorphism
+if the target is commutative."]
 lemma mul {α β} [group α] [comm_group β]
   {f g : α → β} (hf : is_group_hom f) (hg : is_group_hom g) :
   is_group_hom (λa, f a * g a) :=
 { map_mul := (hf.to_is_mul_hom.mul hg.to_is_mul_hom).map_mul }
 
 /-- The inverse of a group homomorphism is a group homomorphism if the target is commutative. -/
-@[to_additive]
+@[to_additive "The negation of an additive group homomorphism is an additive group homomorphism
+if the target is commutative."]
 lemma inv {α β} [group α] [comm_group β] {f : α → β} (hf : is_group_hom f) :
   is_group_hom (λa, (f a)⁻¹) :=
 { map_mul := hf.to_is_mul_hom.inv.map_mul }

--- a/src/deprecated/subfield.lean
+++ b/src/deprecated/subfield.lean
@@ -26,6 +26,9 @@ is_subfield
 -/
 variables {F : Type*} [field F] (S : set F)
 
+/-- `is_subfield (S : set F)` is the predicate saying that a given subset of a field is
+the set underlying a subfield. This structure is deprecated; use the bundled variant
+`subfield F` to model subfields of a field. -/
 structure is_subfield extends is_subring S : Prop :=
 (inv_mem : ∀ {x : F}, x ∈ S → x⁻¹ ∈ S)
 

--- a/src/deprecated/subfield.lean
+++ b/src/deprecated/subfield.lean
@@ -6,8 +6,7 @@ Authors: Andreas Swerdlow
 import deprecated.subring
 import algebra.group_with_zero.power
 
-/-
-
+/-!
 # Unbundled subfields (deprecated)
 
 This file is deprecated, and is no longer imported by anything in mathlib other than other

--- a/src/deprecated/subring.lean
+++ b/src/deprecated/subring.lean
@@ -7,8 +7,7 @@ import deprecated.subgroup
 import deprecated.group
 import ring_theory.subring.basic
 
-/-
-
+/-!
 # Unbundled subrings (deprecated)
 
 This file is deprecated, and is no longer imported by anything in mathlib other than other

--- a/src/deprecated/subring.lean
+++ b/src/deprecated/subring.lean
@@ -85,6 +85,8 @@ lemma is_subring_Union_of_directed {ι : Type*} [hι : nonempty ι]
 
 namespace ring
 
+/-- The smallest subring containing a given subset of a ring, considered as a set. This function
+is deprecated; use `subring.closure`. -/
 def closure (s : set R) := add_group.closure (monoid.closure s)
 
 variable {s : set R}


### PR DESCRIPTION
I am happy to remove some nolints for you.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)

In what is surely my most futile PR ever, I ensure that a bunch of files which are never imported now pass the linter. Still, every little counts, eh?