### PR TITLE
[Merged by Bors] - feat(data/polynomial/mirror): `mirror_eq_iff`

### DIFF
--- a/src/data/polynomial/mirror.lean
+++ b/src/data/polynomial/mirror.lean
@@ -30,7 +30,7 @@ open_locale polynomial
 
 section semiring
 
-variables {R : Type*} [semiring R] (p : R[X])
+variables {R : Type*} [semiring R] (p q : R[X])
 
 /-- mirror of a polynomial: reverses the coefficients while preserving `polynomial.nat_degree` -/
 noncomputable def mirror := p.reverse * X ^ p.nat_trailing_degree
@@ -118,8 +118,15 @@ lemma mirror_mirror : p.mirror.mirror = p :=
 polynomial.ext (λ n, by rw [coeff_mirror, coeff_mirror,
   mirror_nat_degree, mirror_nat_trailing_degree, rev_at_invol])
 
+variables {p q}
+
+lemma mirror_eq_iff : p.mirror = q ↔ p = q.mirror :=
+⟨λ h, h ▸ p.mirror_mirror.symm, λ h, h.symm ▸ q.mirror_mirror⟩
+
 lemma mirror_eq_zero : p.mirror = 0 ↔ p = 0 :=
 ⟨λ h, by rw [←p.mirror_mirror, h, mirror_zero], λ h, by rw [h, mirror_zero]⟩
+
+variables (p q)
 
 lemma mirror_trailing_coeff : p.mirror.trailing_coeff = p.leading_coeff :=
 by rw [leading_coeff, trailing_coeff, mirror_nat_trailing_degree, coeff_mirror,

--- a/src/data/polynomial/mirror.lean
+++ b/src/data/polynomial/mirror.lean
@@ -120,19 +120,22 @@ polynomial.ext (λ n, by rw [coeff_mirror, coeff_mirror,
 
 variables {p q}
 
-lemma mirror_eq_iff : p.mirror = q ↔ p = q.mirror :=
-⟨λ h, h ▸ p.mirror_mirror.symm, λ h, h.symm ▸ q.mirror_mirror⟩
+lemma mirror_involutive : function.involutive (mirror : R[X] → R[X]) :=
+mirror_mirror
 
-lemma mirror_eq_zero : p.mirror = 0 ↔ p = 0 :=
+lemma mirror_eq_iff : p.mirror = q ↔ p = q.mirror :=
+mirror_involutive.eq_iff
+
+@[simp] lemma mirror_eq_zero : p.mirror = 0 ↔ p = 0 :=
 ⟨λ h, by rw [←p.mirror_mirror, h, mirror_zero], λ h, by rw [h, mirror_zero]⟩
 
 variables (p q)
 
-lemma mirror_trailing_coeff : p.mirror.trailing_coeff = p.leading_coeff :=
+@[simp] lemma mirror_trailing_coeff : p.mirror.trailing_coeff = p.leading_coeff :=
 by rw [leading_coeff, trailing_coeff, mirror_nat_trailing_degree, coeff_mirror,
   rev_at_le (nat.le_add_left _ _), add_tsub_cancel_right]
 
-lemma mirror_leading_coeff : p.mirror.leading_coeff = p.trailing_coeff :=
+@[simp] lemma mirror_leading_coeff : p.mirror.leading_coeff = p.trailing_coeff :=
 by rw [←p.mirror_mirror, mirror_trailing_coeff, p.mirror_mirror]
 
 lemma coeff_mul_mirror :


### PR DESCRIPTION
This PR adds a lemma stating that `p.mirror = q ↔ p = q.mirror`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
