### PR TITLE
[Merged by Bors] - refactor(category_theory): remove some simp lemmas about eq_to_hom

### DIFF
--- a/src/algebra/homology/additive.lean
+++ b/src/algebra/homology/additive.lean
@@ -163,6 +163,8 @@ variables [has_zero_object V] {W : Type*} [category W] [preadditive W] [has_zero
 
 namespace homological_complex
 
+local attribute [simp] eq_to_hom_map
+
 /--
 Turning an object into a complex supported at `j` then applying a functor is
 the same as applying the functor then forming the complex.

--- a/src/algebraic_geometry/AffineScheme.lean
+++ b/src/algebraic_geometry/AffineScheme.lean
@@ -202,7 +202,7 @@ begin
   cases h,
   refine (Scheme.congr_app this _).trans _,
   erw category.id_comp,
-  simpa
+  simpa [eq_to_hom_map],
 end
 
 lemma is_affine_open.Spec_Γ_identity_hom_app_from_Spec {X : Scheme} {U : opens X.carrier}

--- a/src/algebraic_geometry/Spec.lean
+++ b/src/algebraic_geometry/Spec.lean
@@ -95,7 +95,7 @@ begin
   dsimp,
   erw [PresheafedSpace.id_c_app, comap_id], swap,
   { rw [Spec.Top_map_id, topological_space.opens.map_id_obj_unop] },
-  simpa,
+  simpa [eq_to_hom_map],
 end
 
 lemma Spec.SheafedSpace_map_comp {R S T : CommRing} (f : R ⟶ S) (g : S ⟶ T) :

--- a/src/algebraic_geometry/open_immersion.lean
+++ b/src/algebraic_geometry/open_immersion.lean
@@ -388,7 +388,7 @@ begin
     rw ← is_iso.comp_inv_eq at this,
     reassoc! this,
     erw [← this, hf.inv_app_app_assoc, s.fst.c.naturality_assoc],
-    simpa },
+    simpa [eq_to_hom_map], },
   { change pullback.lift _ _ _ ≫ pullback.fst = _,
     simp }
 end
@@ -1515,7 +1515,7 @@ lemma lift_uniq (H' : set.range g.1.base ⊆ set.range f.1.base) (l : Y ⟶ X)
   (hl : l ≫ f = g) : l = lift f g H' :=
 LocallyRingedSpace.is_open_immersion.lift_uniq f g H' l hl
 
-/-- Two open immersions with equal range is isomorphic. -/
+/-- Two open immersions with equal range are isomorphic. -/
 @[simps] def iso_of_range_eq [is_open_immersion g] (e : set.range f.1.base = set.range g.1.base) :
   X ≅ Y :=
 { hom := lift g f (le_of_eq e),

--- a/src/algebraic_geometry/open_immersion.lean
+++ b/src/algebraic_geometry/open_immersion.lean
@@ -109,12 +109,6 @@ variables {X Y : PresheafedSpace C} {f : X ⟶ Y} (H : is_open_immersion f)
 /-- The functor `opens X ⥤ opens Y` associated with an open immersion `f : X ⟶ Y`. -/
 abbreviation open_functor := H.base_open.is_open_map.functor
 
-/-
-We want to keep `eq_to_hom`s in the form of `F.map (eq_to_hom _)` so that the lemmas about
-naturality can be applied.
--/
-local attribute [-simp] eq_to_hom_map eq_to_iso_map
-
 /-- An open immersion `f : X ⟶ Y` induces an isomorphism `X ≅ Y|_{f(X)}`. -/
 @[simps] noncomputable
 def iso_restrict : X ≅ Y.restrict H.base_open :=

--- a/src/algebraic_geometry/presheafed_space.lean
+++ b/src/algebraic_geometry/presheafed_space.lean
@@ -143,6 +143,7 @@ instance category_of_PresheafedSpaces : category (PresheafedSpace C) :=
 end
 
 variables {C}
+local attribute [simp] eq_to_hom_map
 
 @[simp] lemma id_base (X : PresheafedSpace C) :
   ((𝟙 X) : X ⟶ X).base = 𝟙 (X : Top.{v}) := rfl

--- a/src/algebraic_geometry/presheafed_space/gluing.lean
+++ b/src/algebraic_geometry/presheafed_space/gluing.lean
@@ -195,7 +195,7 @@ begin
   have e := (D.snd_inv_app_t_app' i j k U).some_spec,
   reassoc! e,
   rw ← e,
-  simp,
+  simp [eq_to_hom_map],
 end
 
 variable [has_limits C]

--- a/src/algebraic_geometry/presheafed_space/has_colimits.lean
+++ b/src/algebraic_geometry/presheafed_space/has_colimits.lean
@@ -52,6 +52,8 @@ namespace algebraic_geometry
 
 namespace PresheafedSpace
 
+local attribute [simp] eq_to_hom_map
+
 @[simp]
 lemma map_id_c_app (F : J ⥤ PresheafedSpace C) (j) (U) :
   (F.map (𝟙 j)).c.app (op U) =

--- a/src/category_theory/category/Cat.lean
+++ b/src/category_theory/category/Cat.lean
@@ -54,16 +54,11 @@ instance bicategory : bicategory.{(max v u) (max v u)} Cat.{v u} :=
   pentagon' := λ A B C D E, functor.pentagon,
   triangle' := λ A B C, functor.triangle }
 
-section
-local attribute [simp] eq_to_hom_app
-
 /-- `Cat` is a strict bicategory. -/
 instance bicategory.strict : bicategory.strict Cat.{v u} :=
 { id_comp' := λ C D F, by cases F; refl,
   comp_id' := λ C D F, by cases F; refl,
   assoc' := by intros; refl }
-
-end
 
 /-- Category structure on `Cat` -/
 instance category : large_category.{max v u} Cat.{v u} := strict_bicategory.category Cat.{v u}
@@ -89,7 +84,7 @@ def objects : Cat.{v u} ⥤ Type u :=
   map := λ C D F, F.obj }
 
 section
-local attribute [simp] eq_to_hom_map eq_to_hom_app
+local attribute [simp] eq_to_hom_map
 
 /-- Any isomorphism in `Cat` induces an equivalence of the underlying categories. -/
 def equiv_of_iso {C D : Cat} (γ : C ≅ D) : C ≌ D :=

--- a/src/category_theory/category/Cat.lean
+++ b/src/category_theory/category/Cat.lean
@@ -54,11 +54,16 @@ instance bicategory : bicategory.{(max v u) (max v u)} Cat.{v u} :=
   pentagon' := λ A B C D E, functor.pentagon,
   triangle' := λ A B C, functor.triangle }
 
+section
+local attribute [simp] eq_to_hom_app
+
 /-- `Cat` is a strict bicategory. -/
 instance bicategory.strict : bicategory.strict Cat.{v u} :=
 { id_comp' := λ C D F, by cases F; refl,
   comp_id' := λ C D F, by cases F; refl,
   assoc' := by intros; refl }
+
+end
 
 /-- Category structure on `Cat` -/
 instance category : large_category.{max v u} Cat.{v u} := strict_bicategory.category Cat.{v u}
@@ -83,12 +88,17 @@ def objects : Cat.{v u} ⥤ Type u :=
 { obj := λ C, C,
   map := λ C D F, F.obj }
 
+section
+local attribute [simp] eq_to_hom_map eq_to_hom_app
+
 /-- Any isomorphism in `Cat` induces an equivalence of the underlying categories. -/
 def equiv_of_iso {C D : Cat} (γ : C ≅ D) : C ≌ D :=
 { functor := γ.hom,
   inverse := γ.inv,
   unit_iso := eq_to_iso $ eq.symm γ.hom_inv_id,
   counit_iso := eq_to_iso γ.inv_hom_id }
+
+end
 
 end Cat
 

--- a/src/category_theory/category/Cat/limit.lean
+++ b/src/category_theory/category/Cat/limit.lean
@@ -54,7 +54,7 @@ def hom_diagram {F : J ⥤ Cat.{v v}} (X Y : limit (F ⋙ Cat.objects.{v v})) : 
   end,
   map_comp' := λ X Y Z f g, begin
     ext h, dsimp,
-    simp [functor.congr_hom (F.map_comp f g) h],
+    simp [functor.congr_hom (F.map_comp f g) h, eq_to_hom_map],
     refl,
   end, }
 

--- a/src/category_theory/differential_object.lean
+++ b/src/category_theory/differential_object.lean
@@ -225,6 +225,7 @@ def shift_functor (n : ℤ) : differential_object C ⥤ differential_object C :=
   map_id' := by { intros X, ext1, dsimp, rw functor.map_id },
   map_comp' := by { intros X Y Z f g, ext1, dsimp, rw functor.map_comp } }
 
+local attribute [simp] eq_to_hom_map eq_to_hom_app
 local attribute [reducible] discrete.add_monoidal shift_comm
 
 /-- The shift functor on `differential_object C` is additive. -/

--- a/src/category_theory/differential_object.lean
+++ b/src/category_theory/differential_object.lean
@@ -225,7 +225,7 @@ def shift_functor (n : ℤ) : differential_object C ⥤ differential_object C :=
   map_id' := by { intros X, ext1, dsimp, rw functor.map_id },
   map_comp' := by { intros X Y Z f g, ext1, dsimp, rw functor.map_comp } }
 
-local attribute [simp] eq_to_hom_map eq_to_hom_app
+local attribute [simp] eq_to_hom_map
 local attribute [reducible] discrete.add_monoidal shift_comm
 
 /-- The shift functor on `differential_object C` is additive. -/

--- a/src/category_theory/eq_to_hom.lean
+++ b/src/category_theory/eq_to_hom.lean
@@ -175,15 +175,25 @@ end heq
 
 end functor
 
+/--
+This is not always a good idea as a `@[simp]` lemma,
+as we lose the ability to use results that interact with `F`,
+e.g. the naturality of a natural transformation.
+
+In some files it may be appropriate to use `local attribute [simp] eq_to_hom_map`, however.
+-/
 lemma eq_to_hom_map (F : C ⥤ D) {X Y : C} (p : X = Y) :
   F.map (eq_to_hom p) = eq_to_hom (congr_arg F.obj p) :=
 by cases p; simp
 
+/--
+See the note on `eq_to_hom_map` regarding using this as a `simp` lemma.
+-/
 lemma eq_to_iso_map (F : C ⥤ D) {X Y : C} (p : X = Y) :
   F.map_iso (eq_to_iso p) = eq_to_iso (congr_arg F.obj p) :=
 by ext; cases p; simp
 
-lemma eq_to_hom_app {F G : C ⥤ D} (h : F = G) (X : C) :
+@[simp] lemma eq_to_hom_app {F G : C ⥤ D} (h : F = G) (X : C) :
   (eq_to_hom h : F ⟶ G).app X = eq_to_hom (functor.congr_obj h X) :=
 by subst h; refl
 

--- a/src/category_theory/eq_to_hom.lean
+++ b/src/category_theory/eq_to_hom.lean
@@ -175,21 +175,21 @@ end heq
 
 end functor
 
-@[simp] lemma eq_to_hom_map (F : C ⥤ D) {X Y : C} (p : X = Y) :
+lemma eq_to_hom_map (F : C ⥤ D) {X Y : C} (p : X = Y) :
   F.map (eq_to_hom p) = eq_to_hom (congr_arg F.obj p) :=
 by cases p; simp
 
-@[simp] lemma eq_to_iso_map (F : C ⥤ D) {X Y : C} (p : X = Y) :
+lemma eq_to_iso_map (F : C ⥤ D) {X Y : C} (p : X = Y) :
   F.map_iso (eq_to_iso p) = eq_to_iso (congr_arg F.obj p) :=
 by ext; cases p; simp
 
-@[simp] lemma eq_to_hom_app {F G : C ⥤ D} (h : F = G) (X : C) :
+lemma eq_to_hom_app {F G : C ⥤ D} (h : F = G) (X : C) :
   (eq_to_hom h : F ⟶ G).app X = eq_to_hom (functor.congr_obj h X) :=
 by subst h; refl
 
 lemma nat_trans.congr {F G : C ⥤ D} (α : F ⟶ G) {X Y : C} (h : X = Y) :
   α.app X = F.map (eq_to_hom h) ≫ α.app Y ≫ G.map (eq_to_hom h.symm) :=
-by { rw [α.naturality_assoc], simp }
+by { rw [α.naturality_assoc], simp [eq_to_hom_map], }
 
 lemma eq_conj_eq_to_hom {X Y : C} (f : X ⟶ Y) :
   f = eq_to_hom rfl ≫ f ≫ eq_to_hom rfl :=

--- a/src/category_theory/functor/flat.lean
+++ b/src/category_theory/functor/flat.lean
@@ -203,6 +203,8 @@ s'.X.hom ≫ (F.map $ hc.lift $
 lemma fac (x : J) : lift F hc s ≫ (F.map_cone c).π.app x = s.π.app x :=
 by simpa [lift, ←functor.map_comp]
 
+local attribute [simp] eq_to_hom_map
+
 lemma uniq {K : J ⥤ C} {c : cone K} (hc : is_limit c)
   (s : cone (K ⋙ F)) (f₁ f₂ : s.X ⟶ F.obj c.X)
   (h₁ : ∀ (j : J), f₁ ≫ (F.map_cone c).π.app j = s.π.app j)

--- a/src/category_theory/grothendieck.lean
+++ b/src/category_theory/grothendieck.lean
@@ -98,6 +98,8 @@ def comp {X Y Z : grothendieck F} (f : hom X Y) (g : hom Y Z) : hom X Z :=
   eq_to_hom (by erw [functor.map_comp, functor.comp_obj]) ≫
     (F.map g.base).map f.fiber ≫ g.fiber, }
 
+local attribute [simp] eq_to_hom_map eq_to_hom_app
+
 instance : category (grothendieck F) :=
 { hom := λ X Y, grothendieck.hom X Y,
   id := λ X, grothendieck.id X,

--- a/src/category_theory/grothendieck.lean
+++ b/src/category_theory/grothendieck.lean
@@ -98,7 +98,7 @@ def comp {X Y Z : grothendieck F} (f : hom X Y) (g : hom Y Z) : hom X Z :=
   eq_to_hom (by erw [functor.map_comp, functor.comp_obj]) ≫
     (F.map g.base).map f.fiber ≫ g.fiber, }
 
-local attribute [simp] eq_to_hom_map eq_to_hom_app
+local attribute [simp] eq_to_hom_map
 
 instance : category (grothendieck F) :=
 { hom := λ X Y, grothendieck.hom X Y,

--- a/src/category_theory/limits/shapes/products.lean
+++ b/src/category_theory/limits/shapes/products.lean
@@ -237,7 +237,7 @@ def limit_cone_of_unique : limit_cone (discrete.functor f) :=
     fac' := λ s j, begin
       have w := (s.π.naturality (eq_to_hom (unique.default_eq _))).symm,
       dsimp at w,
-      simpa using w,
+      simpa [eq_to_hom_map] using w,
     end,
     uniq' := λ s m w, begin
       specialize w default,
@@ -264,7 +264,7 @@ def colimit_cocone_of_unique : colimit_cocone (discrete.functor f) :=
     fac' := λ s j, begin
       have w := (s.ι.naturality (eq_to_hom (unique.eq_default _))),
       dsimp at w,
-      simpa using w,
+      simpa [eq_to_hom_map] using w,
     end,
     uniq' := λ s m w, begin
       specialize w default,
@@ -301,7 +301,8 @@ begin
     equivalence.equivalence_mk'_counit, discrete.equivalence_counit_iso, discrete.nat_iso_hom_app,
     eq_to_iso.hom, eq_to_hom_map],
   dsimp,
-  simpa using limit.w (discrete.functor (f ∘ ε)) (discrete.eq_to_hom' (ε.symm_apply_apply b)),
+  simpa [eq_to_hom_map] using
+    limit.w (discrete.functor (f ∘ ε)) (discrete.eq_to_hom' (ε.symm_apply_apply b)),
 end
 
 @[simp, reassoc]
@@ -325,7 +326,8 @@ begin
     discrete.equivalence_unit_iso, discrete.nat_iso_hom_app, eq_to_iso.hom, eq_to_hom_map,
     discrete.nat_iso_inv_app],
   dsimp,
-  simp [←colimit.w (discrete.functor f) (discrete.eq_to_hom' (ε.apply_symm_apply (ε b)))],
+  simp [eq_to_hom_map,
+    ←colimit.w (discrete.functor f) (discrete.eq_to_hom' (ε.apply_symm_apply (ε b)))],
 end
 
 @[simp, reassoc]

--- a/src/category_theory/monoidal/CommMon_.lean
+++ b/src/category_theory/monoidal/CommMon_.lean
@@ -134,6 +134,7 @@ def CommMon_to_lax_braided : CommMon_ C ⥤ lax_braided_functor (discrete punit.
     tensor' := λ _ _, f.mul_hom, }, }
 
 local attribute [tidy] tactic.discrete_cases
+local attribute [simp] eq_to_iso_map
 
 /-- Implementation of `CommMon_.equiv_lax_braided_functor_punit`. -/
 @[simps]

--- a/src/category_theory/monoidal/CommMon_.lean
+++ b/src/category_theory/monoidal/CommMon_.lean
@@ -156,6 +156,7 @@ nat_iso.of_components (λ F, { hom := { hom := 𝟙 _, }, inv := { hom := 𝟙 _
 end equiv_lax_braided_functor_punit
 
 open equiv_lax_braided_functor_punit
+local attribute [simp] eq_to_iso_map
 
 /--
 Commutative monoid objects in `C` are "just" braided lax monoidal functors from the trivial

--- a/src/category_theory/monoidal/Mon_.lean
+++ b/src/category_theory/monoidal/Mon_.lean
@@ -290,6 +290,8 @@ end equiv_lax_monoidal_functor_punit
 
 open equiv_lax_monoidal_functor_punit
 
+local attribute [simp] eq_to_iso_map
+
 /--
 Monoid objects in `C` are "just" lax monoidal functors from the trivial monoidal category to `C`.
 -/

--- a/src/category_theory/monoidal/Mon_.lean
+++ b/src/category_theory/monoidal/Mon_.lean
@@ -267,6 +267,7 @@ def Mon_to_lax_monoidal : Mon_ C ⥤ lax_monoidal_functor (discrete punit.{u+1})
     tensor' := λ _ _, f.mul_hom, }, }
 
 local attribute [tidy] tactic.discrete_cases
+local attribute [simp] eq_to_hom_map
 
 /-- Implementation of `Mon_.equiv_lax_monoidal_functor_punit`. -/
 @[simps]

--- a/src/category_theory/monoidal/Mon_.lean
+++ b/src/category_theory/monoidal/Mon_.lean
@@ -267,7 +267,7 @@ def Mon_to_lax_monoidal : Mon_ C ⥤ lax_monoidal_functor (discrete punit.{u+1})
     tensor' := λ _ _, f.mul_hom, }, }
 
 local attribute [tidy] tactic.discrete_cases
-local attribute [simp] eq_to_hom_map
+local attribute [simp] eq_to_iso_map
 
 /-- Implementation of `Mon_.equiv_lax_monoidal_functor_punit`. -/
 @[simps]

--- a/src/category_theory/preadditive/Mat.lean
+++ b/src/category_theory/preadditive/Mat.lean
@@ -210,7 +210,7 @@ end Mat_
 namespace functor
 variables {C} {D : Type*} [category.{v₁} D] [preadditive D]
 
-local attribute [simp] Mat_.id_apply
+local attribute [simp] Mat_.id_apply eq_to_hom_map
 
 /--
 A functor induces a functor of matrix categories.

--- a/src/category_theory/shift.lean
+++ b/src/category_theory/shift.lean
@@ -94,6 +94,7 @@ structure shift_mk_core :=
     eq_to_hom (by { dsimp, rw add_zero }) . obviously)
 
 section
+local attribute [simp] eq_to_hom_map eq_to_hom_app
 local attribute [reducible] endofunctor_monoidal_category discrete.add_monoidal
 
 /-- Constructs a `has_shift C A` instance from `shift_mk_core`. -/
@@ -208,6 +209,8 @@ lemma opaque_eq_to_iso_symm (h : i = j) :
 lemma opaque_eq_to_iso_inv (h : i = j) :
   (opaque_eq_to_iso h).inv = (opaque_eq_to_iso h.symm).hom := rfl
 
+local attribute [simp] eq_to_hom_map eq_to_hom_app
+
 @[simp, reassoc]
 lemma map_opaque_eq_to_iso_comp_app (F : discrete ι ⥤ C ⥤ C) (h : i = j) (h' : j = k) (X : C) :
   (F.map (opaque_eq_to_iso h).hom).app X ≫ (F.map (opaque_eq_to_iso h').hom).app X =
@@ -284,6 +287,7 @@ lemma shift_equiv_triangle (n : A) (X : C) :
 (add_neg_equiv (shift_monoidal_functor C A) n).functor_unit_iso_comp X
 
 section
+local attribute [simp] eq_to_hom_map eq_to_hom_app
 local attribute [reducible] discrete.add_monoidal
 
 lemma shift_shift_neg_hom_shift (n : A) (X : C) :

--- a/src/category_theory/shift.lean
+++ b/src/category_theory/shift.lean
@@ -94,7 +94,7 @@ structure shift_mk_core :=
     eq_to_hom (by { dsimp, rw add_zero }) . obviously)
 
 section
-local attribute [simp] eq_to_hom_map eq_to_hom_app
+local attribute [simp] eq_to_hom_map
 local attribute [reducible] endofunctor_monoidal_category discrete.add_monoidal
 
 /-- Constructs a `has_shift C A` instance from `shift_mk_core`. -/
@@ -209,7 +209,7 @@ lemma opaque_eq_to_iso_symm (h : i = j) :
 lemma opaque_eq_to_iso_inv (h : i = j) :
   (opaque_eq_to_iso h).inv = (opaque_eq_to_iso h.symm).hom := rfl
 
-local attribute [simp] eq_to_hom_map eq_to_hom_app
+local attribute [simp] eq_to_hom_map
 
 @[simp, reassoc]
 lemma map_opaque_eq_to_iso_comp_app (F : discrete ι ⥤ C ⥤ C) (h : i = j) (h' : j = k) (X : C) :
@@ -287,7 +287,7 @@ lemma shift_equiv_triangle (n : A) (X : C) :
 (add_neg_equiv (shift_monoidal_functor C A) n).functor_unit_iso_comp X
 
 section
-local attribute [simp] eq_to_hom_map eq_to_hom_app
+local attribute [simp] eq_to_hom_map
 local attribute [reducible] discrete.add_monoidal
 
 lemma shift_shift_neg_hom_shift (n : A) (X : C) :

--- a/src/category_theory/structured_arrow.lean
+++ b/src/category_theory/structured_arrow.lean
@@ -81,7 +81,7 @@ and to check that the triangle commutes.
 @[simps]
 def iso_mk {f f' : structured_arrow S T} (g : f.right ≅ f'.right)
   (w : f.hom ≫ T.map g.hom = f'.hom) : f ≅ f' :=
-comma.iso_mk (eq_to_iso (by ext)) g (by simpa using w.symm)
+comma.iso_mk (eq_to_iso (by ext)) g (by simpa [eq_to_hom_map] using w.symm)
 
 /--
 A morphism between source objects `S ⟶ S'`
@@ -180,7 +180,7 @@ def hom_mk {f f' : costructured_arrow S T} (g : f.left ⟶ f'.left) (w : S.map g
   f ⟶ f' :=
 { left := g,
   right := eq_to_hom (by ext),
-  w' := by simpa using w, }
+  w' := by simpa [eq_to_hom_map] using w, }
 
 /--
 To construct an isomorphism of costructured arrows,
@@ -190,7 +190,7 @@ and to check that the triangle commutes.
 @[simps]
 def iso_mk {f f' : costructured_arrow S T} (g : f.left ≅ f'.left)
   (w : S.map g.hom ≫ f'.hom = f.hom) : f ≅ f' :=
-comma.iso_mk g (eq_to_iso (by ext)) (by simpa using w)
+comma.iso_mk g (eq_to_iso (by ext)) (by simpa [eq_to_hom_map] using w)
 
 /--
 A morphism between target objects `T ⟶ T'`

--- a/src/category_theory/triangulated/rotate.lean
+++ b/src/category_theory/triangulated/rotate.lean
@@ -306,7 +306,7 @@ def inv_rot_comp_rot_inv : 𝟭 (triangle C) ⟶ inv_rotate C ⋙ rotate C :=
     { dsimp, rw [comp_id, id_comp] },
     { dsimp, rw [comp_id, id_comp] },
     { dsimp,
-      rw [add_neg_equiv_counit_iso_inv, eq_to_hom_refl, id_comp],
+      rw [add_neg_equiv_counit_iso_inv, eq_to_hom_map, eq_to_hom_refl, id_comp],
       simp only [nat_trans.comp_app, assoc],
       erw [μ_inv_naturality, ε_naturality_assoc] },
   end }

--- a/src/category_theory/yoneda.lean
+++ b/src/category_theory/yoneda.lean
@@ -386,7 +386,8 @@ lemma yoneda_sections_small_inv_app_apply {C : Type u₁} [small_category C] (X 
   ((yoneda_sections_small X F).inv t).app Y f = F.map f.op t :=
 rfl
 
-local attribute[ext] functor.ext
+local attribute [ext] functor.ext
+local attribute [simp] eq_to_hom_app
 
 /-- The curried version of yoneda lemma when `C` is small. -/
 def curried_yoneda_lemma {C : Type u₁} [small_category C] :

--- a/src/category_theory/yoneda.lean
+++ b/src/category_theory/yoneda.lean
@@ -387,7 +387,6 @@ lemma yoneda_sections_small_inv_app_apply {C : Type u₁} [small_category C] (X 
 rfl
 
 local attribute [ext] functor.ext
-local attribute [simp] eq_to_hom_app
 
 /-- The curried version of yoneda lemma when `C` is small. -/
 def curried_yoneda_lemma {C : Type u₁} [small_category C] :

--- a/src/topology/sheaves/presheaf.lean
+++ b/src/topology/sheaves/presheaf.lean
@@ -79,7 +79,7 @@ by simp [pushforward_eq]
 lemma pushforward_eq'_hom_app
   {X Y : Top.{v}} {f g : X ⟶ Y} (h : f = g) (ℱ : X.presheaf C) (U) :
   nat_trans.app (eq_to_hom (pushforward_eq' h ℱ)) U = ℱ.map (eq_to_hom (by rw h)) :=
-by simpa
+by simpa [eq_to_hom_map]
 
 @[simp]
 lemma pushforward_eq_rfl {X Y : Top.{v}} (f : X ⟶ Y) (ℱ : X.presheaf C) (U) :
@@ -197,7 +197,7 @@ nat_iso.of_components
     ℱ.map_iso (eq_to_iso (by simp)))
   (λ U V i,
   begin
-      ext, simp [-eq_to_hom_map,-eq_to_iso_map],
+      ext, simp,
       erw colimit.pre_desc_assoc,
       erw colimit.ι_desc_assoc,
       erw colimit.ι_desc_assoc,
@@ -208,7 +208,7 @@ lemma id_inv_app (U : opens Y) :
   (id ℱ).inv.app (op U) = colimit.ι (Lan.diagram (opens.map (𝟙 Y)).op ℱ (op U))
     (@costructured_arrow.mk _ _ _ _ _ (op U) _ (eq_to_hom (by simp))) :=
 begin
-  dsimp[id], simp[-eq_to_hom_map,-eq_to_iso_map],dsimp[colimit_of_diagram_terminal],
+  dsimp[id], simp, dsimp[colimit_of_diagram_terminal],
   delta Lan.diagram,
   refine eq.trans _ (category.id_comp _),
   rw ← ℱ.map_id,
@@ -236,7 +236,10 @@ lemma pushforward_map_app' {X Y : Top.{v}} (f : X ⟶ Y)
 lemma id_pushforward {X : Top.{v}} : pushforward C (𝟙 X) = 𝟭 (X.presheaf C) :=
 begin
   apply category_theory.functor.ext,
-  { intros, ext U, have h := f.congr, erw h (opens.op_map_id_obj U), simpa },
+  { intros,
+    ext U,
+    have h := f.congr, erw h (opens.op_map_id_obj U),
+    simpa [eq_to_hom_map], },
   { intros, apply pushforward.id_eq },
 end
 
@@ -266,10 +269,10 @@ lemma to_pushforward_of_iso_app {X Y : Top} (H₁ : X ≅ Y) {ℱ : X.presheaf C
 begin
   delta to_pushforward_of_iso,
   simp only [equiv.to_fun_as_coe, nat_trans.comp_app, equivalence.equivalence_mk'_unit,
-    eq_to_hom_map, presheaf_equiv_of_iso_unit_iso_hom_app_app, equivalence.to_adjunction,
-    equivalence.equivalence_mk'_counit, presheaf_equiv_of_iso_inverse_map_app,
-    adjunction.mk_of_unit_counit_hom_equiv_apply],
-  congr
+    eq_to_hom_map, eq_to_hom_op, eq_to_hom_trans, presheaf_equiv_of_iso_unit_iso_hom_app_app,
+    equivalence.to_adjunction, equivalence.equivalence_mk'_counit,
+    presheaf_equiv_of_iso_inverse_map_app, adjunction.mk_of_unit_counit_hom_equiv_apply],
+  congr,
 end
 
 /--

--- a/src/topology/sheaves/sheaf_condition/opens_le_cover.lean
+++ b/src/topology/sheaves/sheaf_condition/opens_le_cover.lean
@@ -271,8 +271,8 @@ variables {Y : opens X} (hY : Y = supr U)
   inv :=
   { hom := F.map (eq_to_hom (congr_arg op hY)),
     w' := λ j, by { erw ← F.map_comp, congr } },
-  hom_inv_id' := by { ext, simp },
-  inv_hom_id' := by { ext, simp } }
+  hom_inv_id' := by { ext, simp [eq_to_hom_map], },
+  inv_hom_id' := by { ext, simp [eq_to_hom_map], } }
 
 /-- Given a presheaf `F` on the topological space `X` and a family of opens `U` of `X`,
     the natural cone associated to `F` and `U` used in the definition of

--- a/src/topology/sheaves/sheaf_condition/sites.lean
+++ b/src/topology/sheaves/sheaf_condition/sites.lean
@@ -213,7 +213,10 @@ fork.mk_hom (F.map (eq_to_hom (supr_eq_of_mem_grothendieck U R hR)).op)
 instance is_iso_postcompose_diagram_fork_hom_hom
   (hR : sieve.generate R ∈ opens.grothendieck_topology X U) :
   is_iso (postcompose_diagram_fork_hom F U R hR).hom :=
-begin rw postcompose_diagram_fork_hom_hom, apply eq_to_hom.is_iso, end
+begin
+  rw [postcompose_diagram_fork_hom_hom, eq_to_hom_map],
+  apply eq_to_hom.is_iso,
+end
 
 instance is_iso_postcompose_diagram_fork_hom
   (hR : sieve.generate R ∈ opens.grothendieck_topology X U) :


### PR DESCRIPTION
The simp lemma `eq_to_hom_map : F.map (eq_to_hom p) = eq_to_hom (congr_arg F.obj p)` is rather dangerous, but after it has fired it's much harder to see the functor `F` (e.g. to use naturality of a natural transformation).

This PR removes `@[simp]` from that lemma, at the expense of having a few `local attribute [simp]`s, and adding it explicitly to simp sets.

On the upside, we also get to *remove* some `simp [-eq_to_hom_map]`s. I'm hoping also to soon be able to remove `opaque_eq_to_hom`, as it was introduced to avoid the problem this simp lemma was causing.

The PR is part of an effort to solve some problems identified on [zulip](https://leanprover.zulipchat.com/#narrow/stream/116395-maths/topic/trouble.20in.20.60shift_functor.60.20land).

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
