### PR TITLE
[Merged by Bors] - chore(linear_algebra): generalize conversion between matrices and bilinear forms to semirings

### DIFF
--- a/src/linear_algebra/basic.lean
+++ b/src/linear_algebra/basic.lean
@@ -418,12 +418,6 @@ def dom_restrict'
 @[simp] lemma dom_restrict'_apply (f : M →ₗ[R] M₂) (p : submodule R M) (x : p) :
   dom_restrict' p f x = f x := rfl
 
-end comm_semiring
-
-section comm_ring
-variables [comm_ring R] [add_comm_group M] [add_comm_group M₂] [add_comm_group M₃]
-variables [module R M] [module R M₂] [module R M₃]
-
 /--
 The family of linear maps `M₂ → M` parameterised by `f ∈ M₂ → R`, `x ∈ M`, is linear in `f`, `x`.
 -/
@@ -438,7 +432,7 @@ def smul_rightₗ : (M₂ →ₗ[R] R) →ₗ[R] M →ₗ[R] M₂ →ₗ[R] M :=
 @[simp] lemma smul_rightₗ_apply (f : M₂ →ₗ[R] R) (x : M) (c : M₂) :
   (smul_rightₗ : (M₂ →ₗ[R] R) →ₗ[R] M →ₗ[R] M₂ →ₗ[R] M) f x c = (f c) • x := rfl
 
-end comm_ring
+end comm_semiring
 
 end linear_map
 

--- a/src/linear_algebra/basis.lean
+++ b/src/linear_algebra/basis.lean
@@ -851,7 +851,7 @@ section module
 open linear_map
 
 variables {v : ι → M}
-variables [semiring R] [add_comm_group M] [add_comm_group M'] [add_comm_group M'']
+variables [ring R] [add_comm_group M] [add_comm_group M'] [add_comm_group M'']
 variables [module R M] [module R M'] [module R M'']
 variables {c d : R} {x y : M}
 variables (b : basis ι R M)

--- a/src/linear_algebra/basis.lean
+++ b/src/linear_algebra/basis.lean
@@ -851,7 +851,7 @@ section module
 open linear_map
 
 variables {v : ι → M}
-variables [ring R] [add_comm_group M] [add_comm_group M'] [add_comm_group M'']
+variables [semiring R] [add_comm_group M] [add_comm_group M'] [add_comm_group M'']
 variables [module R M] [module R M'] [module R M'']
 variables {c d : R} {x y : M}
 variables (b : basis ι R M)

--- a/src/linear_algebra/bilinear_form.lean
+++ b/src/linear_algebra/bilinear_form.lean
@@ -616,20 +616,20 @@ end
 
 section basis
 
-variables {B₃ F₃ : bilin_form R₃ M₃}
-variables {ι : Type*} (b : basis ι R₃ M₃)
+variables {F₂ : bilin_form R₂ M₂}
+variables {ι : Type*} (b : basis ι R₂ M₂)
 
 /-- Two bilinear forms are equal when they are equal on all basis vectors. -/
-lemma ext_basis (h : ∀ i j, B₃ (b i) (b j) = F₃ (b i) (b j)) : B₃ = F₃ :=
+lemma ext_basis (h : ∀ i j, B₂ (b i) (b j) = F₂ (b i) (b j)) : B₂ = F₂ :=
 to_lin.injective $ b.ext $ λ i, b.ext $ λ j, h i j
 
 /-- Write out `B x y` as a sum over `B (b i) (b j)` if `b` is a basis. -/
-lemma sum_repr_mul_repr_mul (x y : M₃) :
-  (b.repr x).sum (λ i xi, (b.repr y).sum (λ j yj, xi • yj • B₃ (b i) (b j))) = B₃ x y :=
+lemma sum_repr_mul_repr_mul (x y : M₂) :
+  (b.repr x).sum (λ i xi, (b.repr y).sum (λ j yj, xi • yj • B₂ (b i) (b j))) = B₂ x y :=
 begin
   conv_rhs { rw [← b.total_repr x, ← b.total_repr y] },
   simp_rw [finsupp.total_apply, finsupp.sum, sum_left, sum_right,
-    smul_left, smul_right, smul_eq_mul]
+    smul_left, smul_right, smul_eq_mul],
 end
 
 end basis
@@ -781,18 +781,17 @@ def is_pair_self_adjoint_submodule : submodule R₂ (module.End R₂ M₂) :=
   f ∈ is_pair_self_adjoint_submodule B₂ F₂ ↔ is_pair_self_adjoint B₂ F₂ f :=
 by refl
 
-variables {M₃' : Type*} [add_comm_group M₃'] [module R₃ M₃']
-variables (B₃ F₃ : bilin_form R₃ M₃)
+-- variables [add_comm_group M₂'] [module R₂ M₂']
 
-lemma is_pair_self_adjoint_equiv (e : M₃' ≃ₗ[R₃] M₃) (f : module.End R₃ M₃) :
-  is_pair_self_adjoint B₃ F₃ f ↔
-    is_pair_self_adjoint (B₃.comp ↑e ↑e) (F₃.comp ↑e ↑e) (e.symm.conj f) :=
+lemma is_pair_self_adjoint_equiv (e : M₂' ≃ₗ[R₂] M₂) (f : module.End R₂ M₂) :
+  is_pair_self_adjoint B₂ F₂ f ↔
+    is_pair_self_adjoint (B₂.comp ↑e ↑e) (F₂.comp ↑e ↑e) (e.symm.conj f) :=
 begin
-  have hₗ : (F₃.comp ↑e ↑e).comp_left (e.symm.conj f) = (F₃.comp_left f).comp ↑e ↑e :=
+  have hₗ : (F₂.comp ↑e ↑e).comp_left (e.symm.conj f) = (F₂.comp_left f).comp ↑e ↑e :=
     by { ext, simp [linear_equiv.symm_conj_apply], },
-  have hᵣ : (B₃.comp ↑e ↑e).comp_right (e.symm.conj f) = (B₃.comp_right f).comp ↑e ↑e :=
+  have hᵣ : (B₂.comp ↑e ↑e).comp_right (e.symm.conj f) = (B₂.comp_right f).comp ↑e ↑e :=
     by { ext, simp [linear_equiv.conj_apply], },
-  have he : function.surjective (⇑(↑e : M₃' →ₗ[R₃] M₃) : M₃' → M₃) := e.surjective,
+  have he : function.surjective (⇑(↑e : M₂' →ₗ[R₂] M₂) : M₂' → M₂) := e.surjective,
   show bilin_form.is_adjoint_pair _ _ _ _  ↔ bilin_form.is_adjoint_pair _ _ _ _,
   rw [is_adjoint_pair_iff_comp_left_eq_comp_right, is_adjoint_pair_iff_comp_left_eq_comp_right,
       hᵣ, hₗ, comp_inj _ _ he he],
@@ -817,6 +816,8 @@ def self_adjoint_submodule := is_pair_self_adjoint_submodule B₂ B₂
 
 @[simp] lemma mem_self_adjoint_submodule (f : module.End R₂ M₂) :
   f ∈ B₂.self_adjoint_submodule ↔ B₂.is_self_adjoint f := iff.rfl
+
+variables (B₃ : bilin_form R₃ M₃)
 
 /-- The set of skew-adjoint endomorphisms of a module with bilinear form is a submodule. (In fact
 it is a Lie subalgebra.) -/

--- a/src/linear_algebra/bilinear_form.lean
+++ b/src/linear_algebra/bilinear_form.lean
@@ -781,8 +781,6 @@ def is_pair_self_adjoint_submodule : submodule R₂ (module.End R₂ M₂) :=
   f ∈ is_pair_self_adjoint_submodule B₂ F₂ ↔ is_pair_self_adjoint B₂ F₂ f :=
 by refl
 
--- variables [add_comm_group M₂'] [module R₂ M₂']
-
 lemma is_pair_self_adjoint_equiv (e : M₂' ≃ₗ[R₂] M₂) (f : module.End R₂ M₂) :
   is_pair_self_adjoint B₂ F₂ f ↔
     is_pair_self_adjoint (B₂.comp ↑e ↑e) (F₂.comp ↑e ↑e) (e.symm.conj f) :=

--- a/src/linear_algebra/contraction.lean
+++ b/src/linear_algebra/contraction.lean
@@ -20,8 +20,7 @@ some basic properties of these maps.
 contraction, dual module, tensor product
 -/
 
-variables (R M N P Q : Type*) [add_comm_monoid M]
-variables [add_comm_monoid N] [add_comm_monoid P] [add_comm_monoid Q]
+variables {ι : Type*} (R M N P Q : Type*)
 
 local attribute [ext] tensor_product.ext
 
@@ -31,9 +30,10 @@ open tensor_product linear_map matrix
 open_locale tensor_product big_operators
 
 section comm_semiring
-
-variables [comm_semiring R] [module R M] [module R N] [module R P] [module R Q]
-variables {ι : Type*} [decidable_eq ι] [fintype ι] (b : basis ι R M)
+variables [comm_semiring R]
+variables [add_comm_monoid M] [add_comm_monoid N] [add_comm_monoid P] [add_comm_monoid Q]
+variables [module R M] [module R N] [module R P] [module R Q]
+variables [decidable_eq ι] [fintype ι] (b : basis ι R M)
 
 /-- The natural left-handed pairing between a module and its dual. -/
 def contract_left : (module.dual R M) ⊗ M →ₗ[R] R := (uncurry _ _ _ _).to_fun linear_map.id
@@ -100,6 +100,16 @@ begin
   rw [and_iff_not_or_not, not_not] at hij, cases hij; simp [hij],
 end
 
+end comm_semiring
+
+section comm_ring
+variables [comm_ring R]
+variables [add_comm_group M] [add_comm_group N] [add_comm_group P] [add_comm_group Q]
+variables [module R M] [module R N] [module R P] [module R Q]
+variables [decidable_eq ι] [fintype ι] (b : basis ι R M)
+
+variables {R M N P Q}
+
 /-- If `M` is free, the natural linear map $M^* ⊗ N → Hom(M, N)$ is an equivalence. This function
 provides this equivalence in return for a basis of `M`. -/
 @[simps apply]
@@ -145,7 +155,7 @@ equivalence. -/
 @[simp] noncomputable def dual_tensor_hom_equiv : (module.dual R M) ⊗[R] N ≃ₗ[R] M →ₗ[R] N :=
 dual_tensor_hom_equiv_of_basis (module.free.choose_basis R M)
 
-end comm_semiring
+end comm_ring
 
 end contraction
 
@@ -157,7 +167,9 @@ open module tensor_product linear_map
 
 section comm_ring
 
-variables [comm_ring R] [module R M] [module R N] [module R P] [module R Q]
+variables [comm_ring R]
+variables [add_comm_group M] [add_comm_group N] [add_comm_group P] [add_comm_group Q]
+variables [module R M] [module R N] [module R P] [module R Q]
 variables [free R M] [finite R M] [free R N] [finite R N] [nontrivial R]
 
 /-- When `M` is a finite free module, the map `ltensor_hom_to_hom_ltensor` is an equivalence. Note

--- a/src/linear_algebra/contraction.lean
+++ b/src/linear_algebra/contraction.lean
@@ -20,8 +20,8 @@ some basic properties of these maps.
 contraction, dual module, tensor product
 -/
 
-variables (R M N P Q : Type*) [add_comm_group M]
-variables [add_comm_group N] [add_comm_group P] [add_comm_group Q]
+variables (R M N P Q : Type*) [add_comm_monoid M]
+variables [add_comm_monoid N] [add_comm_monoid P] [add_comm_monoid Q]
 
 local attribute [ext] tensor_product.ext
 
@@ -30,9 +30,9 @@ section contraction
 open tensor_product linear_map matrix
 open_locale tensor_product big_operators
 
-section comm_ring
+section comm_semiring
 
-variables [comm_ring R] [module R M] [module R N] [module R P] [module R Q]
+variables [comm_semiring R] [module R M] [module R N] [module R P] [module R Q]
 variables {ι : Type*} [decidable_eq ι] [fintype ι] (b : basis ι R M)
 
 /-- The natural left-handed pairing between a module and its dual. -/
@@ -70,7 +70,7 @@ fst_apply, prod.smul_mk, zero_apply, smul_zero]}
   dual_tensor_hom R (M × N) (P × Q) ((g ∘ₗ snd R M N) ⊗ₜ inr R P Q q) :=
 by {ext; simp only [coe_comp, coe_inr, function.comp_app, prod_map_apply, dual_tensor_hom_apply,
   snd_apply, prod.smul_mk, zero_apply, smul_zero]}
-  
+
 lemma map_dual_tensor_hom (f : module.dual R M) (p : P) (g : module.dual R N) (q : Q) :
   tensor_product.map (dual_tensor_hom R M P (f ⊗ₜ[R] p)) (dual_tensor_hom R N Q (g ⊗ₜ[R] q)) =
   dual_tensor_hom R (M ⊗[R] N) (P ⊗[R] Q) (dual_distrib R M N (f ⊗ₜ g) ⊗ₜ[R] (p ⊗ₜ[R] q)) :=
@@ -145,7 +145,7 @@ equivalence. -/
 @[simp] noncomputable def dual_tensor_hom_equiv : (module.dual R M) ⊗[R] N ≃ₗ[R] M →ₗ[R] N :=
 dual_tensor_hom_equiv_of_basis (module.free.choose_basis R M)
 
-end comm_ring
+end comm_semiring
 
 end contraction
 

--- a/src/linear_algebra/dual.lean
+++ b/src/linear_algebra/dual.lean
@@ -351,7 +351,7 @@ section dual_pair
 open module
 
 variables {R M ι : Type*}
-variables [comm_ring R] [add_comm_group M] [module R M] [decidable_eq ι]
+variables [comm_semiring R] [add_comm_monoid M] [module R M] [decidable_eq ι]
 
 /-- `e` and `ε` have characteristic properties of a basis and its dual -/
 @[nolint has_inhabited_instance]
@@ -448,7 +448,7 @@ namespace submodule
 
 universes u v w
 
-variables {R : Type u} {M : Type v} [comm_ring R] [add_comm_group M] [module R M]
+variables {R : Type u} {M : Type v} [comm_semiring R] [add_comm_monoid M] [module R M]
 variable {W : submodule R M}
 
 /-- The `dual_restrict` of a submodule `W` of `M` is the linear map from the
@@ -464,7 +464,7 @@ linear_map.dom_restrict' W
 
 /-- The `dual_annihilator` of a submodule `W` is the set of linear maps `φ` such
   that `φ w = 0` for all `w ∈ W`. -/
-def dual_annihilator {R : Type u} {M : Type v} [comm_ring R] [add_comm_group M]
+def dual_annihilator {R : Type u} {M : Type v} [comm_semiring R] [add_comm_monoid M]
   [module R M] (W : submodule R M) : submodule R $ module.dual R M :=
 W.dual_restrict.ker
 
@@ -624,10 +624,11 @@ end
 
 end subspace
 
-variables {R : Type*} [comm_ring R] {M₁ : Type*} {M₂ : Type*}
-variables [add_comm_group M₁] [module R M₁] [add_comm_group M₂] [module R M₂]
-
 open module
+
+section dual_map
+variables {R : Type*} [comm_semiring R] {M₁ : Type*} {M₂ : Type*}
+variables [add_comm_monoid M₁] [module R M₁] [add_comm_monoid M₂] [module R M₂]
 
 /-- Given a linear map `f : M₁ →ₗ[R] M₂`, `f.dual_map` is the linear map between the dual of
 `M₂` and `M₁` such that it maps the functional `φ` to `φ ∘ f`. -/
@@ -680,7 +681,11 @@ lemma linear_equiv.dual_map_trans {M₃ : Type*} [add_comm_group M₃] [module R
   g.dual_map.trans f.dual_map = (f.trans g).dual_map :=
 rfl
 
+end dual_map
+
 namespace linear_map
+variables {R : Type*} [comm_semiring R] {M₁ : Type*} {M₂ : Type*}
+variables [add_comm_monoid M₁] [module R M₁] [add_comm_monoid M₂] [module R M₂]
 
 variable (f : M₁ →ₗ[R] M₂)
 
@@ -765,11 +770,11 @@ end field
 
 end linear_map
 
+#where
+
 namespace tensor_product
 
-variables (R) (M : Type*) (N : Type*)
-variables [add_comm_group M] [add_comm_group N]
-variables [module R M] [module R N]
+variables (R : Type*) (M : Type*) (N : Type*)
 
 variables {ι κ : Type*}
 variables [decidable_eq ι] [decidable_eq κ]
@@ -782,7 +787,10 @@ local attribute [ext] tensor_product.ext
 
 open tensor_product
 open linear_map
-open module (dual)
+
+section
+variables [comm_semiring R] [add_comm_monoid M] [add_comm_monoid N]
+variables [module R M] [module R N]
 
 /--
 The canonical linear map from `dual M ⊗ dual N` to `dual (M ⊗ N)`,
@@ -794,6 +802,18 @@ def dual_distrib : (dual R M) ⊗[R] (dual R N) →ₗ[R] dual R (M ⊗[R] N) :=
 
 variables {R M N}
 
+@[simp]
+lemma dual_distrib_apply (f : dual R M) (g : dual R N) (m : M) (n : N) :
+  dual_distrib R M N (f ⊗ₜ g) (m ⊗ₜ n) = f m * g n :=
+by simp only [dual_distrib, coe_comp, function.comp_app, hom_tensor_hom_map_apply,
+  comp_right_apply, linear_equiv.coe_coe, map_tmul, lid_tmul, algebra.id.smul_eq_mul]
+
+end
+
+variables {R M N}
+variables [comm_ring R] [add_comm_group M] [add_comm_group N]
+variables [module R M] [module R N]
+
 /--
 An inverse to `dual_tensor_dual_map` given bases.
 -/
@@ -802,12 +822,6 @@ def dual_distrib_inv_of_basis (b : basis ι R M) (c : basis κ R N) :
   dual R (M ⊗[R] N) →ₗ[R] (dual R M) ⊗[R] (dual R N) :=
 ∑ i j, (ring_lmap_equiv_self R ℕ _).symm (b.dual_basis i ⊗ₜ c.dual_basis j)
     ∘ₗ applyₗ (c j) ∘ₗ applyₗ (b i) ∘ₗ (lcurry R M N R)
-
-@[simp]
-lemma dual_distrib_apply (f : dual R M) (g : dual R N) (m : M) (n : N) :
-  dual_distrib R M N (f ⊗ₜ g) (m ⊗ₜ n) = f m * g n :=
-by simp only [dual_distrib, coe_comp, function.comp_app, hom_tensor_hom_map_apply,
-  comp_right_apply, linear_equiv.coe_coe, map_tmul, lid_tmul, algebra.id.smul_eq_mul]
 
 @[simp]
 lemma dual_distrib_inv_of_basis_apply (b : basis ι R M) (c : basis κ R N)

--- a/src/linear_algebra/dual.lean
+++ b/src/linear_algebra/dual.lean
@@ -770,8 +770,6 @@ end field
 
 end linear_map
 
-#where
-
 namespace tensor_product
 
 variables (R : Type*) (M : Type*) (N : Type*)

--- a/src/linear_algebra/matrix/basis.lean
+++ b/src/linear_algebra/matrix/basis.lean
@@ -39,6 +39,7 @@ section basis_to_matrix
 
 variables {ι ι' κ κ' : Type*}
 variables {R M : Type*} [comm_semiring R] [add_comm_monoid M] [module R M]
+variables {R₂ M₂ : Type*} [comm_ring R₂] [add_comm_group M₂] [module R₂ M₂]
 
 open function matrix
 
@@ -84,7 +85,7 @@ begin
 end
 
 /-- The basis constructed by `units_smul` has vectors given by a diagonal matrix. -/
-@[simp] lemma to_matrix_units_smul [decidable_eq ι] (w : ι → Rˣ) :
+@[simp] lemma to_matrix_units_smul [decidable_eq ι] (e : basis ι R₂ M₂) (w : ι → R₂ˣ) :
   e.to_matrix (e.units_smul w) = diagonal (coe ∘ w) :=
 begin
   ext i j,
@@ -94,7 +95,8 @@ begin
 end
 
 /-- The basis constructed by `is_unit_smul` has vectors given by a diagonal matrix. -/
-@[simp] lemma to_matrix_is_unit_smul [decidable_eq ι] {w : ι → R} (hw : ∀ i, is_unit (w i)) :
+@[simp] lemma to_matrix_is_unit_smul [decidable_eq ι] (e : basis ι R₂ M₂) {w : ι → R₂}
+  (hw : ∀ i, is_unit (w i)) :
   e.to_matrix (e.is_unit_smul hw) = diagonal w :=
 e.to_matrix_units_smul _
 
@@ -147,7 +149,7 @@ end basis
 
 section mul_linear_map_to_matrix
 
-variables {N : Type*} [add_comm_group N] [module R N]
+variables {N : Type*} [add_comm_monoid N] [module R N]
 variables (b : basis ι R M) (b' : basis ι' R M) (c : basis κ R N) (c' : basis κ' R N)
 variables (f : M →ₗ[R] N)
 

--- a/src/linear_algebra/matrix/basis.lean
+++ b/src/linear_algebra/matrix/basis.lean
@@ -38,7 +38,7 @@ open_locale matrix
 section basis_to_matrix
 
 variables {ι ι' κ κ' : Type*}
-variables {R M : Type*} [comm_ring R] [add_comm_group M] [module R M]
+variables {R M : Type*} [comm_semiring R] [add_comm_monoid M] [module R M]
 
 open function matrix
 

--- a/src/linear_algebra/matrix/bilinear_form.lean
+++ b/src/linear_algebra/matrix/bilinear_form.lean
@@ -296,7 +296,7 @@ by { ext B, rw [bilin_form.to_matrix_apply, bilin_form.to_matrix'_apply,
   bilin_form.to_matrix b (matrix.to_bilin b M) = M :=
 (bilin_form.to_matrix b).apply_symm_apply M
 
-variables {M₂' : Type*} [add_comm_group M₂'] [module R₂ M₂']
+variables {M₂' : Type*} [add_comm_monoid M₂'] [module R₂ M₂']
 variables (c : basis o R₂ M₂')
 variables [decidable_eq o]
 
@@ -338,23 +338,23 @@ lemma bilin_form.to_matrix_mul_basis_to_matrix (c : basis o R₂ M₂) (B : bili
 by rw [← linear_map.to_matrix_id_eq_basis_to_matrix, ← bilin_form.to_matrix_comp,
        bilin_form.comp_id_id]
 
-lemma bilin_form.mul_to_matrix_mul (B : bilin_form R₃ M₃)
-  (M : matrix o n R₃) (N : matrix n o R₃) :
+lemma bilin_form.mul_to_matrix_mul (B : bilin_form R₂ M₂)
+  (M : matrix o n R₂) (N : matrix n o R₂) :
   M ⬝ bilin_form.to_matrix b B ⬝ N =
     bilin_form.to_matrix c (B.comp (to_lin c b Mᵀ) (to_lin c b N)) :=
 by simp only [B.to_matrix_comp b c, to_matrix_to_lin, transpose_transpose]
 
-lemma bilin_form.mul_to_matrix (B : bilin_form R₃ M₃) (M : matrix n n R₃) :
+lemma bilin_form.mul_to_matrix (B : bilin_form R₂ M₂) (M : matrix n n R₂) :
   M ⬝ bilin_form.to_matrix b B =
     bilin_form.to_matrix b (B.comp_left (to_lin b b Mᵀ)) :=
 by rw [B.to_matrix_comp_left b, to_matrix_to_lin, transpose_transpose]
 
-lemma bilin_form.to_matrix_mul (B : bilin_form R₃ M₃) (M : matrix n n R₃) :
+lemma bilin_form.to_matrix_mul (B : bilin_form R₂ M₂) (M : matrix n n R₂) :
   bilin_form.to_matrix b B ⬝ M =
     bilin_form.to_matrix b (B.comp_right (to_lin b b M)) :=
 by rw [B.to_matrix_comp_right b, to_matrix_to_lin]
 
-lemma matrix.to_bilin_comp (M : matrix n n R₃) (P Q : matrix n o R₃) :
+lemma matrix.to_bilin_comp (M : matrix n n R₂) (P Q : matrix n o R₂) :
   (matrix.to_bilin b M).comp (to_lin c b P) (to_lin c b Q) = matrix.to_bilin c (Pᵀ ⬝ M ⬝ Q) :=
 (bilin_form.to_matrix c).injective
   (by simp only [bilin_form.to_matrix_comp b c, bilin_form.to_matrix_to_bilin, to_matrix_to_lin])
@@ -492,8 +492,8 @@ open matrix
 variables {A : Type*} [comm_ring A] [is_domain A] [module A M₃] (B₃ : bilin_form A M₃)
 variables {ι : Type*} [decidable_eq ι] [fintype ι]
 
-lemma _root_.matrix.nondegenerate_to_bilin'_iff_nondegenerate_to_bilin {M : matrix ι ι R₃}
-  (b : basis ι R₃ M₃) : M.to_bilin'.nondegenerate ↔ (matrix.to_bilin b M).nondegenerate :=
+lemma _root_.matrix.nondegenerate_to_bilin'_iff_nondegenerate_to_bilin {M : matrix ι ι R₂}
+  (b : basis ι R₂ M₂) : M.to_bilin'.nondegenerate ↔ (matrix.to_bilin b M).nondegenerate :=
 (nondegenerate_congr_iff b.equiv_fun.symm).symm
 
 -- Lemmas transferring nondegeneracy between a matrix and its associated bilinear form

--- a/src/linear_algebra/matrix/bilinear_form.lean
+++ b/src/linear_algebra/matrix/bilinear_form.lean
@@ -93,10 +93,10 @@ def bilin_form.to_matrix_aux (b : n → M₂) : bilin_form R₂ M₂ →ₗ[R₂
 
 variables [fintype n] [fintype o]
 
-lemma to_bilin'_aux_to_matrix_aux [decidable_eq n] (B₃ : bilin_form R₃ (n → R₃)) :
-  matrix.to_bilin'_aux (bilin_form.to_matrix_aux (λ j, std_basis R₃ (λ _, R₃) j 1) B₃) = B₃ :=
+lemma to_bilin'_aux_to_matrix_aux [decidable_eq n] (B₂ : bilin_form R₂ (n → R₂)) :
+  matrix.to_bilin'_aux (bilin_form.to_matrix_aux (λ j, std_basis R₂ (λ _, R₂) j 1) B₂) = B₂ :=
 begin
-  refine ext_basis (pi.basis_fun R₃ n) (λ i j, _),
+  refine ext_basis (pi.basis_fun R₂ n) (λ i j, _),
   rw [bilin_form.to_matrix_aux, linear_map.coe_mk, pi.basis_fun_apply, pi.basis_fun_apply,
       matrix.to_bilin'_aux_std_basis]
 end
@@ -105,36 +105,36 @@ section to_matrix'
 
 /-! ### `to_matrix'` section
 
-This section deals with the conversion between matrices and bilinear forms on `n → R₃`.
+This section deals with the conversion between matrices and bilinear forms on `n → R₂`.
 -/
 
 variables [decidable_eq n] [decidable_eq o]
 
 /-- The linear equivalence between bilinear forms on `n → R` and `n × n` matrices -/
-def bilin_form.to_matrix' : bilin_form R₃ (n → R₃) ≃ₗ[R₃] matrix n n R₃ :=
+def bilin_form.to_matrix' : bilin_form R₂ (n → R₂) ≃ₗ[R₂] matrix n n R₂ :=
 { inv_fun := matrix.to_bilin'_aux,
   left_inv := by convert to_bilin'_aux_to_matrix_aux,
   right_inv := λ M,
     by { ext i j, simp only [bilin_form.to_matrix_aux, matrix.to_bilin'_aux_std_basis] },
-  ..bilin_form.to_matrix_aux (λ j, std_basis R₃ (λ _, R₃) j 1) }
+  ..bilin_form.to_matrix_aux (λ j, std_basis R₂ (λ _, R₂) j 1) }
 
-@[simp] lemma bilin_form.to_matrix_aux_std_basis (B : bilin_form R₃ (n → R₃)) :
-  bilin_form.to_matrix_aux (λ j, std_basis R₃ (λ _, R₃) j 1) B =
+@[simp] lemma bilin_form.to_matrix_aux_std_basis (B : bilin_form R₂ (n → R₂)) :
+  bilin_form.to_matrix_aux (λ j, std_basis R₂ (λ _, R₂) j 1) B =
     bilin_form.to_matrix' B :=
 rfl
 
 /-- The linear equivalence between `n × n` matrices and bilinear forms on `n → R` -/
-def matrix.to_bilin' : matrix n n R₃ ≃ₗ[R₃] bilin_form R₃ (n → R₃) :=
+def matrix.to_bilin' : matrix n n R₂ ≃ₗ[R₂] bilin_form R₂ (n → R₂) :=
 bilin_form.to_matrix'.symm
 
-@[simp] lemma matrix.to_bilin'_aux_eq (M : matrix n n R₃) :
+@[simp] lemma matrix.to_bilin'_aux_eq (M : matrix n n R₂) :
   matrix.to_bilin'_aux M = matrix.to_bilin' M :=
 rfl
 
-lemma matrix.to_bilin'_apply (M : matrix n n R₃) (x y : n → R₃) :
+lemma matrix.to_bilin'_apply (M : matrix n n R₂) (x y : n → R₂) :
   matrix.to_bilin' M x y = ∑ i j, x i * M i j * y j := rfl
 
-lemma matrix.to_bilin'_apply' (M : matrix n n R₃) (v w : n → R₃) :
+lemma matrix.to_bilin'_apply' (M : matrix n n R₂) (v w : n → R₂) :
   matrix.to_bilin' M v w = matrix.dot_product v (M.mul_vec w) :=
 begin
   simp_rw [matrix.to_bilin'_apply, matrix.dot_product,
@@ -145,41 +145,41 @@ begin
   rw ← mul_assoc,
 end
 
-@[simp] lemma matrix.to_bilin'_std_basis (M : matrix n n R₃) (i j : n) :
-  matrix.to_bilin' M (std_basis R₃ (λ _, R₃) i 1) (std_basis R₃ (λ _, R₃) j 1) =
+@[simp] lemma matrix.to_bilin'_std_basis (M : matrix n n R₂) (i j : n) :
+  matrix.to_bilin' M (std_basis R₂ (λ _, R₂) i 1) (std_basis R₂ (λ _, R₂) j 1) =
     M i j :=
 matrix.to_bilin'_aux_std_basis M i j
 
 @[simp] lemma bilin_form.to_matrix'_symm :
-  (bilin_form.to_matrix'.symm : matrix n n R₃ ≃ₗ[R₃] _) = matrix.to_bilin' :=
+  (bilin_form.to_matrix'.symm : matrix n n R₂ ≃ₗ[R₂] _) = matrix.to_bilin' :=
 rfl
 
 @[simp] lemma matrix.to_bilin'_symm :
-  (matrix.to_bilin'.symm : _ ≃ₗ[R₃] matrix n n R₃) = bilin_form.to_matrix' :=
+  (matrix.to_bilin'.symm : _ ≃ₗ[R₂] matrix n n R₂) = bilin_form.to_matrix' :=
 bilin_form.to_matrix'.symm_symm
 
-@[simp] lemma matrix.to_bilin'_to_matrix' (B : bilin_form R₃ (n → R₃)) :
+@[simp] lemma matrix.to_bilin'_to_matrix' (B : bilin_form R₂ (n → R₂)) :
   matrix.to_bilin' (bilin_form.to_matrix' B) = B :=
 matrix.to_bilin'.apply_symm_apply B
 
-@[simp] lemma bilin_form.to_matrix'_to_bilin' (M : matrix n n R₃) :
+@[simp] lemma bilin_form.to_matrix'_to_bilin' (M : matrix n n R₂) :
   bilin_form.to_matrix' (matrix.to_bilin' M) = M :=
 bilin_form.to_matrix'.apply_symm_apply M
 
-@[simp] lemma bilin_form.to_matrix'_apply (B : bilin_form R₃ (n → R₃)) (i j : n) :
+@[simp] lemma bilin_form.to_matrix'_apply (B : bilin_form R₂ (n → R₂)) (i j : n) :
   bilin_form.to_matrix' B i j =
-    B (std_basis R₃ (λ _, R₃) i 1) (std_basis R₃ (λ _, R₃) j 1) :=
+    B (std_basis R₂ (λ _, R₂) i 1) (std_basis R₂ (λ _, R₂) j 1) :=
 rfl
 
-@[simp] lemma bilin_form.to_matrix'_comp (B : bilin_form R₃ (n → R₃))
-  (l r : (o → R₃) →ₗ[R₃] (n → R₃)) :
+@[simp] lemma bilin_form.to_matrix'_comp (B : bilin_form R₂ (n → R₂))
+  (l r : (o → R₂) →ₗ[R₂] (n → R₂)) :
   (B.comp l r).to_matrix' = l.to_matrix'ᵀ ⬝ B.to_matrix' ⬝ r.to_matrix' :=
 begin
   ext i j,
   simp only [bilin_form.to_matrix'_apply, bilin_form.comp_apply, transpose_apply, matrix.mul_apply,
     linear_map.to_matrix', linear_equiv.coe_mk, sum_mul],
   rw sum_comm,
-  conv_lhs { rw ← bilin_form.sum_repr_mul_repr_mul (pi.basis_fun R₃ n) (l _) (r _) },
+  conv_lhs { rw ← bilin_form.sum_repr_mul_repr_mul (pi.basis_fun R₂ n) (l _) (r _) },
   rw finsupp.sum_fintype,
   { apply sum_congr rfl,
     rintros i' -,
@@ -192,29 +192,29 @@ begin
   { intros, simp only [zero_smul, finsupp.sum_zero] }
 end
 
-lemma bilin_form.to_matrix'_comp_left (B : bilin_form R₃ (n → R₃))
-  (f : (n → R₃) →ₗ[R₃] (n → R₃)) : (B.comp_left f).to_matrix' = f.to_matrix'ᵀ ⬝ B.to_matrix' :=
+lemma bilin_form.to_matrix'_comp_left (B : bilin_form R₂ (n → R₂))
+  (f : (n → R₂) →ₗ[R₂] (n → R₂)) : (B.comp_left f).to_matrix' = f.to_matrix'ᵀ ⬝ B.to_matrix' :=
 by simp only [bilin_form.comp_left, bilin_form.to_matrix'_comp, to_matrix'_id, matrix.mul_one]
 
-lemma bilin_form.to_matrix'_comp_right (B : bilin_form R₃ (n → R₃))
-  (f : (n → R₃) →ₗ[R₃] (n → R₃)) : (B.comp_right f).to_matrix' = B.to_matrix' ⬝ f.to_matrix' :=
+lemma bilin_form.to_matrix'_comp_right (B : bilin_form R₂ (n → R₂))
+  (f : (n → R₂) →ₗ[R₂] (n → R₂)) : (B.comp_right f).to_matrix' = B.to_matrix' ⬝ f.to_matrix' :=
 by simp only [bilin_form.comp_right, bilin_form.to_matrix'_comp, to_matrix'_id,
               transpose_one, matrix.one_mul]
 
-lemma bilin_form.mul_to_matrix'_mul (B : bilin_form R₃ (n → R₃))
-  (M : matrix o n R₃) (N : matrix n o R₃) :
+lemma bilin_form.mul_to_matrix'_mul (B : bilin_form R₂ (n → R₂))
+  (M : matrix o n R₂) (N : matrix n o R₂) :
   M ⬝ B.to_matrix' ⬝ N = (B.comp Mᵀ.to_lin' N.to_lin').to_matrix' :=
 by simp only [B.to_matrix'_comp, transpose_transpose, to_matrix'_to_lin']
 
-lemma bilin_form.mul_to_matrix' (B : bilin_form R₃ (n → R₃)) (M : matrix n n R₃) :
+lemma bilin_form.mul_to_matrix' (B : bilin_form R₂ (n → R₂)) (M : matrix n n R₂) :
   M ⬝ B.to_matrix' = (B.comp_left Mᵀ.to_lin').to_matrix' :=
 by simp only [B.to_matrix'_comp_left, transpose_transpose, to_matrix'_to_lin']
 
-lemma bilin_form.to_matrix'_mul (B : bilin_form R₃ (n → R₃)) (M : matrix n n R₃) :
+lemma bilin_form.to_matrix'_mul (B : bilin_form R₂ (n → R₂)) (M : matrix n n R₂) :
   B.to_matrix' ⬝ M = (B.comp_right M.to_lin').to_matrix' :=
 by simp only [B.to_matrix'_comp_right, to_matrix'_to_lin']
 
-lemma matrix.to_bilin'_comp (M : matrix n n R₃) (P Q : matrix n o R₃) :
+lemma matrix.to_bilin'_comp (M : matrix n n R₂) (P Q : matrix n o R₂) :
   M.to_bilin'.comp P.to_lin' Q.to_lin' = (Pᵀ ⬝ M ⬝ Q).to_bilin' :=
 bilin_form.to_matrix'.injective
   (by simp only [bilin_form.to_matrix'_comp, bilin_form.to_matrix'_to_bilin', to_matrix'_to_lin'])
@@ -229,20 +229,20 @@ This section deals with the conversion between matrices and bilinear forms on
 a module with a fixed basis.
 -/
 
-variables [decidable_eq n] (b : basis n R₃ M₃)
+variables [decidable_eq n] (b : basis n R₂ M₂)
 
 /-- `bilin_form.to_matrix b` is the equivalence between `R`-bilinear forms on `M` and
 `n`-by-`n` matrices with entries in `R`, if `b` is an `R`-basis for `M`. -/
-noncomputable def bilin_form.to_matrix : bilin_form R₃ M₃ ≃ₗ[R₃] matrix n n R₃ :=
+noncomputable def bilin_form.to_matrix : bilin_form R₂ M₂ ≃ₗ[R₂] matrix n n R₂ :=
 (bilin_form.congr b.equiv_fun).trans bilin_form.to_matrix'
 
 /-- `bilin_form.to_matrix b` is the equivalence between `R`-bilinear forms on `M` and
 `n`-by-`n` matrices with entries in `R`, if `b` is an `R`-basis for `M`. -/
-noncomputable def matrix.to_bilin : matrix n n R₃ ≃ₗ[R₃] bilin_form R₃ M₃ :=
+noncomputable def matrix.to_bilin : matrix n n R₂ ≃ₗ[R₂] bilin_form R₂ M₂ :=
 (bilin_form.to_matrix b).symm
 
 @[simp] lemma basis.equiv_fun_symm_std_basis (i : n) :
-  b.equiv_fun.symm (std_basis R₃ (λ _, R₃) i 1) = b i :=
+  b.equiv_fun.symm (std_basis R₂ (λ _, R₂) i 1) = b i :=
 begin
   rw [b.equiv_fun_symm_apply, finset.sum_eq_single i],
   { rw [std_basis_same, one_smul] },
@@ -253,12 +253,12 @@ begin
     contradiction }
 end
 
-@[simp] lemma bilin_form.to_matrix_apply (B : bilin_form R₃ M₃) (i j : n) :
+@[simp] lemma bilin_form.to_matrix_apply (B : bilin_form R₂ M₂) (i j : n) :
   bilin_form.to_matrix b B i j = B (b i) (b j) :=
 by rw [bilin_form.to_matrix, linear_equiv.trans_apply, bilin_form.to_matrix'_apply, congr_apply,
        b.equiv_fun_symm_std_basis, b.equiv_fun_symm_std_basis]
 
-@[simp] lemma matrix.to_bilin_apply (M : matrix n n R₃) (x y : M₃) :
+@[simp] lemma matrix.to_bilin_apply (M : matrix n n R₂) (x y : M₂) :
   matrix.to_bilin b M x y = ∑ i j, b.repr x i * M i j * b.repr y j :=
 begin
   rw [matrix.to_bilin, bilin_form.to_matrix, linear_equiv.symm_trans_apply, ← matrix.to_bilin'],
@@ -267,7 +267,7 @@ begin
 end
 
 -- Not a `simp` lemma since `bilin_form.to_matrix` needs an extra argument
-lemma bilinear_form.to_matrix_aux_eq (B : bilin_form R₃ M₃) :
+lemma bilinear_form.to_matrix_aux_eq (B : bilin_form R₂ M₂) :
   bilin_form.to_matrix_aux b B = bilin_form.to_matrix b B :=
 ext (λ i j, by rw [bilin_form.to_matrix_apply, bilin_form.to_matrix_aux, linear_map.coe_mk])
 
@@ -280,29 +280,29 @@ rfl
 (bilin_form.to_matrix b).symm_symm
 
 lemma matrix.to_bilin_basis_fun :
-  matrix.to_bilin (pi.basis_fun R₃ n) = matrix.to_bilin' :=
+  matrix.to_bilin (pi.basis_fun R₂ n) = matrix.to_bilin' :=
 by { ext M, simp only [matrix.to_bilin_apply, matrix.to_bilin'_apply, pi.basis_fun_repr] }
 
 lemma bilin_form.to_matrix_basis_fun :
-  bilin_form.to_matrix (pi.basis_fun R₃ n) = bilin_form.to_matrix' :=
+  bilin_form.to_matrix (pi.basis_fun R₂ n) = bilin_form.to_matrix' :=
 by { ext B, rw [bilin_form.to_matrix_apply, bilin_form.to_matrix'_apply,
                 pi.basis_fun_apply, pi.basis_fun_apply] }
 
-@[simp] lemma matrix.to_bilin_to_matrix (B : bilin_form R₃ M₃) :
+@[simp] lemma matrix.to_bilin_to_matrix (B : bilin_form R₂ M₂) :
   matrix.to_bilin b (bilin_form.to_matrix b B) = B :=
 (matrix.to_bilin b).apply_symm_apply B
 
-@[simp] lemma bilin_form.to_matrix_to_bilin (M : matrix n n R₃) :
+@[simp] lemma bilin_form.to_matrix_to_bilin (M : matrix n n R₂) :
   bilin_form.to_matrix b (matrix.to_bilin b M) = M :=
 (bilin_form.to_matrix b).apply_symm_apply M
 
-variables {M₃' : Type*} [add_comm_group M₃'] [module R₃ M₃']
-variables (c : basis o R₃ M₃')
+variables {M₂' : Type*} [add_comm_group M₂'] [module R₂ M₂']
+variables (c : basis o R₂ M₂')
 variables [decidable_eq o]
 
 -- Cannot be a `simp` lemma because `b` must be inferred.
 lemma bilin_form.to_matrix_comp
-  (B : bilin_form R₃ M₃) (l r : M₃' →ₗ[R₃] M₃) :
+  (B : bilin_form R₂ M₂) (l r : M₂' →ₗ[R₂] M₂) :
   bilin_form.to_matrix c (B.comp l r) =
     (to_matrix c b l)ᵀ ⬝ bilin_form.to_matrix b B ⬝ to_matrix c b r :=
 begin
@@ -323,17 +323,17 @@ begin
   { intros, simp only [zero_smul, finsupp.sum_zero] }
 end
 
-lemma bilin_form.to_matrix_comp_left (B : bilin_form R₃ M₃) (f : M₃ →ₗ[R₃] M₃) :
+lemma bilin_form.to_matrix_comp_left (B : bilin_form R₂ M₂) (f : M₂ →ₗ[R₂] M₂) :
   bilin_form.to_matrix b (B.comp_left f) = (to_matrix b b f)ᵀ ⬝ bilin_form.to_matrix b B :=
 by simp only [comp_left, bilin_form.to_matrix_comp b b, to_matrix_id, matrix.mul_one]
 
-lemma bilin_form.to_matrix_comp_right (B : bilin_form R₃ M₃) (f : M₃ →ₗ[R₃] M₃) :
+lemma bilin_form.to_matrix_comp_right (B : bilin_form R₂ M₂) (f : M₂ →ₗ[R₂] M₂) :
   bilin_form.to_matrix b (B.comp_right f) = bilin_form.to_matrix b B ⬝ (to_matrix b b f) :=
 by simp only [bilin_form.comp_right, bilin_form.to_matrix_comp b b, to_matrix_id,
               transpose_one, matrix.one_mul]
 
 @[simp]
-lemma bilin_form.to_matrix_mul_basis_to_matrix (c : basis o R₃ M₃) (B : bilin_form R₃ M₃) :
+lemma bilin_form.to_matrix_mul_basis_to_matrix (c : basis o R₂ M₂) (B : bilin_form R₂ M₂) :
   (b.to_matrix c)ᵀ ⬝ bilin_form.to_matrix b B ⬝ b.to_matrix c = bilin_form.to_matrix c B :=
 by rw [← linear_map.to_matrix_id_eq_basis_to_matrix, ← bilin_form.to_matrix_comp,
        bilin_form.comp_id_id]

--- a/src/linear_algebra/matrix/to_lin.lean
+++ b/src/linear_algebra/matrix/to_lin.lean
@@ -354,9 +354,9 @@ end to_matrix'
 
 section to_matrix
 
-variables {R : Type*} [comm_ring R]
+variables {R : Type*} [comm_semiring R]
 variables {l m n : Type*} [fintype n] [fintype m] [decidable_eq n]
-variables {M₁ M₂ : Type*} [add_comm_group M₁] [add_comm_group M₂] [module R M₁] [module R M₂]
+variables {M₁ M₂ : Type*} [add_comm_monoid M₁] [add_comm_monoid M₂] [module R M₁] [module R M₂]
 variables (v₁ : basis n R M₁) (v₂ : basis m R M₂)
 
 /-- Given bases of two modules `M₁` and `M₂` over a commutative ring `R`, we get a linear
@@ -460,7 +460,7 @@ theorem linear_map.to_matrix_reindex_range [decidable_eq M₁] [decidable_eq M�
     linear_map.to_matrix v₁ v₂ f k i :=
 by simp_rw [linear_map.to_matrix_apply, basis.reindex_range_self, basis.reindex_range_repr]
 
-variables {M₃ : Type*} [add_comm_group M₃] [module R M₃] (v₃ : basis l R M₃)
+variables {M₃ : Type*} [add_comm_monoid M₃] [module R M₃] (v₃ : basis l R M₃)
 
 lemma linear_map.to_matrix_comp [fintype l] [decidable_eq m] (f : M₂ →ₗ[R] M₃) (g : M₁ →ₗ[R] M₂) :
   linear_map.to_matrix v₁ v₃ (f.comp g) =

--- a/src/linear_algebra/trace.lean
+++ b/src/linear_algebra/trace.lean
@@ -35,7 +35,7 @@ open finite_dimensional
 open_locale tensor_product
 
 section
-variables (R : Type u) [comm_ring R] {M : Type v} [add_comm_group M] [module R M]
+variables (R : Type u) [comm_semiring R] {M : Type v} [add_comm_monoid M] [module R M]
 variables {ι : Type w} [decidable_eq ι] [fintype ι]
 variables {κ : Type*} [decidable_eq κ] [fintype κ]
 variables (b : basis ι R M) (c : basis κ R M)

--- a/src/topology/algebra/module/basic.lean
+++ b/src/topology/algebra/module/basic.lean
@@ -1201,10 +1201,10 @@ end smul
 
 section smul_rightₗ
 
-variables {R S T M M₂ : Type*} [ring R] [ring S] [ring T] [module R S]
-  [add_comm_group M₂] [module R M₂] [module S M₂] [is_scalar_tower R S M₂]
+variables {R S T M M₂ : Type*} [semiring R] [semiring S] [semiring T] [module R S]
+  [add_comm_monoid M₂] [module R M₂] [module S M₂] [is_scalar_tower R S M₂]
   [topological_space S] [topological_space M₂] [has_continuous_smul S M₂]
-  [topological_space M] [add_comm_group M] [module R M] [topological_add_group M₂]
+  [topological_space M] [add_comm_monoid M] [module R M] [has_continuous_add M₂]
   [module T M₂] [has_continuous_const_smul T M₂]
   [smul_comm_class R T M₂] [smul_comm_class S T M₂]
 


### PR DESCRIPTION
Only one lemma was moved (`dual_distrib_apply`), none were renamed, and no proofs were meaningfully changed.

Section markers were shuffled around, and some variables exchanged for variables with weaker typeclass assumptions.

A few other things have been generalized to semiring at the same time; `linear_map.trace` and `linear_map.smul_rightₗ`

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
