### PR TITLE
[Merged by Bors] - chore(data/list/forall2): fix incorrect docstring

### DIFF
--- a/src/data/list/forall2.lean
+++ b/src/data/list/forall2.lean
@@ -9,7 +9,8 @@ import data.list.infix
 # Double universal quantification on a list
 
 This file provides an API for `list.forall₂` (definition in `data.list.defs`).
-`forall₂ r l₁ l₂` means that `∀ a ∈ l₁, ∀ b ∈ l₂, r a b`, where `l₁`, `l₂` are lists.
+`forall₂ R l₁ l₂` means that `l₁` and `l₂` have the same length, and whenever `a` is the nth element
+of `l₁`, and `b` is the nth element of `l₂`, then `R a b` is satisfied.
 -/
 
 open nat function


### PR DESCRIPTION
The previous docstring was false, this corrects the definition. 

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
