### PR TITLE
[Merged by Bors] - chore(data/set/pointwise): Move into the `set` namespace

### DIFF
--- a/src/algebra/algebra/spectrum.lean
+++ b/src/algebra/algebra/spectrum.lean
@@ -37,6 +37,8 @@ This theory will serve as the foundation for spectral theory in Banach algebras.
 * `σ a` : `spectrum R a` of `a : A`
 -/
 
+open set
+
 universes u v
 
 section defs

--- a/src/data/set/pointwise.lean
+++ b/src/data/set/pointwise.lean
@@ -1022,13 +1022,6 @@ by { rintro _ ⟨_, _, _, _, rfl⟩, exact ⟨_, _, ‹_›, ‹_›, (map_mul m
 
 end mul_hom
 
-end set
-
-open set
-open_locale pointwise
-
-section
-
 section smul_with_zero
 variables [has_zero α] [has_zero β] [smul_with_zero α β]
 
@@ -1153,7 +1146,12 @@ eq_univ_of_forall $ λ b, ⟨a⁻¹ • b, trivial, smul_inv_smul₀ ha _⟩
 
 end group_with_zero
 
-end
+end set
+
+/-! ### Miscellaneous -/
+
+open set
+open_locale pointwise
 
 /-! Some lemmas about pointwise multiplication and submonoids. Ideally we put these in
   `group_theory.submonoid.basic`, but currently we cannot because that file is imported by this. -/

--- a/src/group_theory/free_product.lean
+++ b/src/group_theory/free_product.lean
@@ -63,6 +63,8 @@ another answer, which is constructively more satisfying, could be obtained by sh
 
 -/
 
+open set
+
 variables {ι : Type*} (M : Π i : ι, Type*) [Π i, monoid (M i)]
 
 /-- A relation on the free monoid on alphabet `Σ i, M i`, relating `⟨i, 1⟩` with `1` and

--- a/src/group_theory/subgroup/pointwise.lean
+++ b/src/group_theory/subgroup/pointwise.lean
@@ -23,6 +23,8 @@ This file is almost identical to `group_theory/submonoid/pointwise.lean`. Where 
 keep them in sync.
 -/
 
+open set
+
 variables {α : Type*} {G : Type*} {A : Type*} [group G] [add_group A]
 
 namespace subgroup

--- a/src/group_theory/submonoid/pointwise.lean
+++ b/src/group_theory/submonoid/pointwise.lean
@@ -34,6 +34,8 @@ on `set`s.
 
 -/
 
+open set
+
 variables {α : Type*} {G : Type*} {M : Type*} {R : Type*} {A : Type*}
 variables [monoid M] [add_monoid A]
 

--- a/src/ring_theory/subring/pointwise.lean
+++ b/src/ring_theory/subring/pointwise.lean
@@ -21,6 +21,8 @@ keep them in sync.
 
 -/
 
+open set
+
 variables {M R : Type*}
 
 namespace subring

--- a/src/ring_theory/subsemiring/pointwise.lean
+++ b/src/ring_theory/subsemiring/pointwise.lean
@@ -19,6 +19,8 @@ This file is almost identical to `group_theory/submonoid/pointwise.lean`. Where 
 keep them in sync.
 -/
 
+open set
+
 variables {M R : Type*}
 
 namespace subsemiring


### PR DESCRIPTION
A bunch of lemmas about scalar multiplications of sets were dumped in root namespace for some reason.

The lemmas moved to `set.*` are:
* `zero_smul_set`
* `zero_smul_subset`
* `subsingleton_zero_smul_set`
* `zero_mem_smul_set`
* `zero_mem_smul_iff`
* `zero_mem_smul_set_iff`
* `smul_add_set`
* `smul_mem_smul_set_iff`
* `mem_smul_set_iff_inv_smul_mem`
* `mem_inv_smul_set_iff`
* `preimage_smul`
* `preimage_smul_inv`
* `set_smul_subset_set_smul_iff`
* `set_smul_subset_iff`
* `subset_set_smul_iff`
* `smul_mem_smul_set_iff₀`
* `mem_smul_set_iff_inv_smul_mem₀`
* `mem_inv_smul_set_iff₀`
* `preimage_smul₀`
* `preimage_smul_inv₀`
* `set_smul_subset_set_smul_iff₀`
* `set_smul_subset_iff₀`
* `subset_set_smul_iff₀`
* `smul_univ₀`
* `smul_set_univ₀`

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
