### PR TITLE
[Merged by Bors] - feat(category_theory/monoidal/subcategory): full monoidal subcategories

### DIFF
--- a/src/algebra/category/FinVect.lean
+++ b/src/algebra/category/FinVect.lean
@@ -26,7 +26,7 @@ universes u
 
 variables (K : Type u) [field K]
 
-instance monoidal_proedicate_finite_dimensional :
+instance monoidal_predicate_finite_dimensional :
   monoidal_category.monoidal_predicate (λ V : Module.{u} K, finite_dimensional K V) :=
 { prop_id' := finite_dimensional.finite_dimensional_self K,
   prop_tensor' := λ X Y hX hY, by exactI module.finite.tensor_product K X Y }

--- a/src/algebra/category/FinVect.lean
+++ b/src/algebra/category/FinVect.lean
@@ -13,29 +13,28 @@ import algebra.category.Module.monoidal
 # The category of finite dimensional vector spaces
 
 This introduces `FinVect K`, the category of finite dimensional vector spaces over a field `K`.
-It is implemented as a full monoidal subcategory on a subtype of `Module K`.
-We create the instance as a symmetric monoidal category, and then provide a right rigid monoidal
-category instance.
+It is implemented as a full subcategory on a subtype of `Module K`, which inherits monoidal and
+symmetric structure as `finite_dimensional K` is a monoidal predicate.
+We also provide a right rigid monoidal category instance.
 -/
 noncomputable theory
 
-open category_theory Module.monoidal_category category_theory.monoidal_category
+open category_theory Module.monoidal_category
 open_locale classical big_operators
 
 universes u
 
 variables (K : Type u) [field K]
 
-def FinVect_monoidal_predicate : monoidal_predicate (Module.{u} K) :=
-{ P := λ V, finite_dimensional K V,
-  h_id := finite_dimensional.finite_dimensional_self K,
-  h_tensor := λ X Y hX hY, by exactI module.finite.tensor_product K X Y }
+instance monoidal_proedicate_finite_dimensional :
+  monoidal_category.monoidal_predicate (λ V : Module.{u} K, finite_dimensional K V) :=
+{ prop_id' := finite_dimensional.finite_dimensional_self K,
+  prop_tensor' := λ X Y hX hY, by exactI module.finite.tensor_product K X Y }
 
 /-- Define `FinVect` as the subtype of `Module.{u} K` of finite dimensional vector spaces. -/
-@[derive [large_category, concrete_category, monoidal_category, symmetric_category]]
-def FinVect := full_monoidal_subcategory (FinVect_monoidal_predicate K)
-
-instance : has_coe_to_sort (FinVect K) (Sort*) := ⟨λ V, V.1⟩
+@[derive [large_category, λ α, has_coe_to_sort α (Sort*), concrete_category, monoidal_category,
+symmetric_category]]
+def FinVect := { V : Module.{u} K // finite_dimensional K V }
 
 namespace FinVect
 

--- a/src/algebra/category/FinVect.lean
+++ b/src/algebra/category/FinVect.lean
@@ -33,7 +33,7 @@ instance monoidal_predicate_finite_dimensional :
 
 /-- Define `FinVect` as the subtype of `Module.{u} K` of finite dimensional vector spaces. -/
 @[derive [large_category, λ α, has_coe_to_sort α (Sort*), concrete_category, monoidal_category,
-symmetric_category]]
+  symmetric_category]]
 def FinVect := { V : Module.{u} K // finite_dimensional K V }
 
 namespace FinVect

--- a/src/algebra/category/FinVect.lean
+++ b/src/algebra/category/FinVect.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jakob von Raumer
 -/
 import category_theory.monoidal.rigid.basic
+import category_theory.monoidal.subcategory
 import linear_algebra.tensor_product_basis
 import linear_algebra.coevaluation
 import algebra.category.Module.monoidal
@@ -12,27 +13,29 @@ import algebra.category.Module.monoidal
 # The category of finite dimensional vector spaces
 
 This introduces `FinVect K`, the category of finite dimensional vector spaces over a field `K`.
-It is implemented as a full subcategory on a subtype of `Module K`.
-We first create the instance as a category, then as a monoidal category and then as a rigid monoidal
-category.
-
-## Future work
-
-* Show that `FinVect K` is a symmetric monoidal category.
-
+It is implemented as a full monoidal subcategory on a subtype of `Module K`.
+We create the instance as a symmetric monoidal category, and then provide a right rigid monoidal
+category instance.
 -/
 noncomputable theory
 
-open category_theory Module.monoidal_category
+open category_theory Module.monoidal_category category_theory.monoidal_category
 open_locale classical big_operators
 
 universes u
 
 variables (K : Type u) [field K]
 
+def FinVect_monoidal_predicate : monoidal_predicate (Module.{u} K) :=
+{ P := λ V, finite_dimensional K V,
+  h_id := finite_dimensional.finite_dimensional_self K,
+  h_tensor := λ X Y hX hY, by exactI module.finite.tensor_product K X Y }
+
 /-- Define `FinVect` as the subtype of `Module.{u} K` of finite dimensional vector spaces. -/
-@[derive [large_category, λ α, has_coe_to_sort α (Sort*), concrete_category]]
-def FinVect := { V : Module.{u} K // finite_dimensional K V }
+@[derive [large_category, concrete_category, monoidal_category, symmetric_category]]
+def FinVect := full_monoidal_subcategory (FinVect_monoidal_predicate K)
+
+instance : has_coe_to_sort (FinVect K) (Sort*) := ⟨λ V, V.1⟩
 
 namespace FinVect
 
@@ -54,12 +57,6 @@ by { dsimp [FinVect], apply_instance, }
 
 instance : full (forget₂ (FinVect K) (Module.{u} K)) :=
 { preimage := λ X Y f, f, }
-
-instance monoidal_category : monoidal_category (FinVect K) :=
-monoidal_category.full_monoidal_subcategory
-  (λ V, finite_dimensional K V)
-  (finite_dimensional.finite_dimensional_self K)
-  (λ X Y hX hY, by exactI module.finite.tensor_product K X Y)
 
 variables (V : FinVect K)
 

--- a/src/algebra/category/FinVect/limits.lean
+++ b/src/algebra/category/FinVect/limits.lean
@@ -44,7 +44,7 @@ end
 
 /-- Finite limits of finite finite dimensional vectors spaces are finite dimensional,
 because we can realise them as subobjects of a finite product. -/
-instance finite_dimensional_limit (F : J ⥤ FinVect k) :
+instance (F : J ⥤ FinVect k) :
   finite_dimensional k (limit (F ⋙ forget₂ (FinVect k) (Module.{v} k)) : Module.{v} k) :=
 begin
   haveI : ∀ j, finite_dimensional k ((F ⋙ forget₂ (FinVect k) (Module.{v} k)).obj j),
@@ -58,8 +58,7 @@ end
 def forget₂_creates_limit (F : J ⥤ FinVect k) :
   creates_limit F (forget₂ (FinVect k) (Module.{v} k)) :=
 creates_limit_of_fully_faithful_of_iso
-  ⟨(limit (F ⋙ forget₂ (FinVect k) (Module.{v} k)) : Module.{v} k),
-    FinVect.finite_dimensional_limit F⟩
+  ⟨(limit (F ⋙ forget₂ (FinVect k) (Module.{v} k)) : Module.{v} k), by apply_instance⟩
   (iso.refl _)
 
 instance : creates_limits_of_shape J (forget₂ (FinVect k) (Module.{v} k)) :=

--- a/src/algebra/category/FinVect/limits.lean
+++ b/src/algebra/category/FinVect/limits.lean
@@ -44,7 +44,7 @@ end
 
 /-- Finite limits of finite finite dimensional vectors spaces are finite dimensional,
 because we can realise them as subobjects of a finite product. -/
-instance (F : J ⥤ FinVect k) :
+instance finite_dimensional_limit (F : J ⥤ FinVect k) :
   finite_dimensional k (limit (F ⋙ forget₂ (FinVect k) (Module.{v} k)) : Module.{v} k) :=
 begin
   haveI : ∀ j, finite_dimensional k ((F ⋙ forget₂ (FinVect k) (Module.{v} k)).obj j),
@@ -58,7 +58,8 @@ end
 def forget₂_creates_limit (F : J ⥤ FinVect k) :
   creates_limit F (forget₂ (FinVect k) (Module.{v} k)) :=
 creates_limit_of_fully_faithful_of_iso
-  ⟨(limit (F ⋙ forget₂ (FinVect k) (Module.{v} k)) : Module.{v} k), by apply_instance⟩
+  ⟨(limit (F ⋙ forget₂ (FinVect k) (Module.{v} k)) : Module.{v} k),
+    FinVect.finite_dimensional_limit F⟩
   (iso.refl _)
 
 instance : creates_limits_of_shape J (forget₂ (FinVect k) (Module.{v} k)) :=

--- a/src/category_theory/monoidal/category.lean
+++ b/src/category_theory/monoidal/category.lean
@@ -477,31 +477,6 @@ rfl
   (tensor_right_tensor X Y).inv.app Z = (associator Z X Y).hom :=
 by simp [tensor_right_tensor]
 
-variables {C}
-
-/--
-Any property closed under `𝟙_` and `⊗` induces a full monoidal subcategory of `C`, where
-the category on the subtype is given by `full_subcategory`.
--/
-def full_monoidal_subcategory (P : C → Prop) (h_id : P (𝟙_ C))
- (h_tensor : ∀ {X Y}, P X → P Y → P (X ⊗ Y)) : monoidal_category {X : C // P X} :=
-{ tensor_obj := λ X Y, ⟨X ⊗ Y, h_tensor X.2 Y.2⟩,
-  tensor_hom := λ X₁ Y₁ X₂ Y₂ f g, by { change X₁.1 ⊗ X₂.1 ⟶ Y₁.1 ⊗ Y₂.1,
-    change X₁.1 ⟶ Y₁.1 at f, change X₂.1 ⟶ Y₂.1 at g, exact f ⊗ g },
-  tensor_unit := ⟨𝟙_ C, h_id⟩,
-  associator := λ X Y Z,
-    ⟨(α_ X.1 Y.1 Z.1).hom, (α_ X.1 Y.1 Z.1).inv,
-     hom_inv_id (α_ X.1 Y.1 Z.1), inv_hom_id (α_ X.1 Y.1 Z.1)⟩,
-  left_unitor := λ X, ⟨(λ_ X.1).hom, (λ_ X.1).inv, hom_inv_id (λ_ X.1), inv_hom_id (λ_ X.1)⟩,
-  right_unitor := λ X, ⟨(ρ_ X.1).hom, (ρ_ X.1).inv, hom_inv_id (ρ_ X.1), inv_hom_id (ρ_ X.1)⟩,
-  tensor_id' := λ X Y, tensor_id X.1 Y.1,
-  tensor_comp' := λ X₁ Y₁ Z₁ X₂ Y₂ Z₂ f₁ f₂ g₁ g₂, tensor_comp f₁ f₂ g₁ g₂,
-  associator_naturality' := λ X₁ X₂ X₃ Y₁ Y₂ Y₃ f₁ f₂ f₃, associator_naturality f₁ f₂ f₃,
-  left_unitor_naturality' := λ X Y f, left_unitor_naturality f,
-  right_unitor_naturality' := λ X Y f, right_unitor_naturality f,
-  pentagon' := λ W X Y Z, pentagon W.1 X.1 Y.1 Z.1,
-  triangle' := λ X Y, triangle X.1 Y.1 }
-
 end
 
 end

--- a/src/category_theory/monoidal/subcategory.lean
+++ b/src/category_theory/monoidal/subcategory.lean
@@ -29,6 +29,7 @@ variables (C : Type u) [category.{v} C] [monoidal_category C]
 /--
 A property of objects of a monoidal category `C` which is closed under `𝟙_` and `⊗`.
 -/
+@[nolint has_inhabited_instance]
 structure monoidal_predicate :=
   (P : C → Prop)
   (h_id : P (𝟙_ C))
@@ -40,7 +41,7 @@ variables {C} (p : monoidal_predicate C)
 `full_monoidal_subcategory p`, where `p : monoidal_predicate C`, is a typeclass synonym for the full
 subcategory `{X : C // p.P X}`, which provides a monoidal structure induced by that of `C`.
 -/
-@[derive category]
+@[nolint has_inhabited_instance, derive category]
 def full_monoidal_subcategory := {X : C // p.P X}
 
 /--

--- a/src/category_theory/monoidal/subcategory.lean
+++ b/src/category_theory/monoidal/subcategory.lean
@@ -31,8 +31,8 @@ variables {C : Type u} [category.{v} C] [monoidal_category C] (P : C → Prop)
 A property `C → Prop` is a monoidal predicate if it is closed under `𝟙_` and `⊗`.
 -/
 class monoidal_predicate :=
-  (prop_id' : P (𝟙_ C))
-  (prop_tensor' : ∀ {X Y}, P X → P Y → P (X ⊗ Y))
+(prop_id' : P (𝟙_ C))
+(prop_tensor' : ∀ {X Y}, P X → P Y → P (X ⊗ Y))
 
 lemma prop_id [hP : monoidal_predicate P] : P (𝟙_ C) := hP.prop_id'
 

--- a/src/category_theory/monoidal/subcategory.lean
+++ b/src/category_theory/monoidal/subcategory.lean
@@ -36,9 +36,8 @@ class monoidal_predicate :=
 
 lemma prop_id [hP : monoidal_predicate P] : P (𝟙_ C) := hP.prop_id'
 
--- For some reason which I don't understand `hP.prop_tensor' hX hY` doesn't work here.
 lemma prop_tensor [hP : monoidal_predicate P] {X Y : C} (hX : P X) (hY : P Y) : P (X ⊗ Y) :=
-by { apply hP.prop_tensor', exact hX, exact hY }
+monoidal_predicate.prop_tensor' hX hY
 
 variables [monoidal_predicate P]
 
@@ -81,7 +80,7 @@ instance full_monoidal_subcategory.faithful :
 
 variables {P} {P' : C → Prop} [monoidal_predicate P']
 
-/-- An implication of predicates `p.P → p'.P` induces a monoidal functor between full monoidal
+/-- An implication of predicates `P → P'` induces a monoidal functor between full monoidal
 subcategories. -/
 @[simps]
 def full_monoidal_subcategory.map (h : ∀ ⦃X⦄, P X → P' X) :
@@ -100,7 +99,7 @@ section braided
 variables (P) [braided_category C]
 
 /--
-The monoidal structure on `full_monoidal_subcategory p` inherited by the braided structure on `C`.
+The braided structure on `{X : C // P X}` inherited by the braided structure on `C`.
 -/
 instance full_braided_subcategory : braided_category {X : C // P X} :=
 braided_category_of_faithful (full_monoidal_subcategory_inclusion P)
@@ -123,7 +122,7 @@ instance full_braided_subcategory.faithful :
 
 variables {P}
 
-/-- An implication of predicates `p.P → p'.P` induces a braided functor between full braided
+/-- An implication of predicates `P → P'` induces a braided functor between full braided
 subcategories. -/
 @[simps]
 def full_braided_subcategory.map (h : ∀ ⦃X⦄, P X → P' X) :

--- a/src/category_theory/monoidal/subcategory.lean
+++ b/src/category_theory/monoidal/subcategory.lean
@@ -15,6 +15,9 @@ structure is defined in `category_theory.full_subcategory`).
 
 When `C` is also braided/symmetric, the full monoidal subcategory also inherits the
 braided/symmetric structure.
+
+## TODO
+* Add monoidal/braided versions of `category_theory.full_subcategory.lift`
 -/
 
 universes u v

--- a/src/category_theory/monoidal/subcategory.lean
+++ b/src/category_theory/monoidal/subcategory.lean
@@ -1,0 +1,152 @@
+/-
+Copyright (c) 2022 Antoine Labelle. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Antoine Labelle
+-/
+import category_theory.monoidal.braided
+
+/-!
+# Full monoidal subcategories
+
+Given a monidal category `C` and a monoidal predicate on `C`, that is a function `P : C → Prop`
+closed under `𝟙_` and `⊗`, we can put a monoidal structure on `{X : C // P X}` (the category
+structure is defined in `category_theory.full_subcategory`).
+
+When `C` is also braided/symmetric, the full monoidal subcategory also inherits the
+braided/symmetric structure.
+-/
+
+universes u v
+
+namespace category_theory
+
+namespace monoidal_category
+
+open iso
+
+variables (C : Type u) [category.{v} C] [monoidal_category C]
+
+/--
+A property of objects of a monoidal category `C` which is closed under `𝟙_` and `⊗`.
+-/
+structure monoidal_predicate :=
+  (P : C → Prop)
+  (h_id : P (𝟙_ C))
+  (h_tensor : ∀ {X Y}, P X → P Y → P (X ⊗ Y))
+
+variables {C} (p : monoidal_predicate C)
+
+/--
+`full_monoidal_subcategory p`, where `p : monoidal_predicate C`, is a typeclass synonym for the full
+subcategory `{X : C // p.P X}`, which provides a monoidal structure induced by that of `C`.
+-/
+@[derive category]
+def full_monoidal_subcategory := {X : C // p.P X}
+
+/--
+The monoidal structure on `full_monoidal_subcategory p`
+-/
+instance full_monoidal_subcategory.monoidal : monoidal_category (full_monoidal_subcategory p) :=
+{ tensor_obj := λ X Y, ⟨X.1 ⊗ Y.1, p.h_tensor X.2 Y.2⟩,
+  tensor_hom := λ X₁ Y₁ X₂ Y₂ f g, by { change X₁.1 ⊗ X₂.1 ⟶ Y₁.1 ⊗ Y₂.1,
+    change X₁.1 ⟶ Y₁.1 at f, change X₂.1 ⟶ Y₂.1 at g, exact f ⊗ g },
+  tensor_unit := ⟨𝟙_ C, p.h_id⟩,
+  associator := λ X Y Z,
+    ⟨(α_ X.1 Y.1 Z.1).hom, (α_ X.1 Y.1 Z.1).inv,
+     hom_inv_id (α_ X.1 Y.1 Z.1), inv_hom_id (α_ X.1 Y.1 Z.1)⟩,
+  left_unitor := λ X, ⟨(λ_ X.1).hom, (λ_ X.1).inv, hom_inv_id (λ_ X.1), inv_hom_id (λ_ X.1)⟩,
+  right_unitor := λ X, ⟨(ρ_ X.1).hom, (ρ_ X.1).inv, hom_inv_id (ρ_ X.1), inv_hom_id (ρ_ X.1)⟩,
+  tensor_id' := λ X Y, tensor_id X.1 Y.1,
+  tensor_comp' := λ X₁ Y₁ Z₁ X₂ Y₂ Z₂ f₁ f₂ g₁ g₂, tensor_comp f₁ f₂ g₁ g₂,
+  associator_naturality' := λ X₁ X₂ X₃ Y₁ Y₂ Y₃ f₁ f₂ f₃, associator_naturality f₁ f₂ f₃,
+  left_unitor_naturality' := λ X Y f, left_unitor_naturality f,
+  right_unitor_naturality' := λ X Y f, right_unitor_naturality f,
+  pentagon' := λ W X Y Z, pentagon W.1 X.1 Y.1 Z.1,
+  triangle' := λ X Y, triangle X.1 Y.1 }
+
+/--
+The forgetful monoidal functor from a full monoidal subcategory into the original category
+("forgetting" the condition).
+-/
+@[simps]
+def full_monoidal_subcategory_inclusion : monoidal_functor (full_monoidal_subcategory p) C :=
+{ to_functor := full_subcategory_inclusion p.P,
+  ε := 𝟙 _,
+  μ := λ X Y, 𝟙 _ }
+
+instance full_monoidal_subcategory.full :
+  full (full_monoidal_subcategory_inclusion p).to_functor := full_subcategory.full p.P
+instance full_monoidal_subcategory.faithful :
+  faithful (full_monoidal_subcategory_inclusion p).to_functor := full_subcategory.faithful p.P
+
+variables {p} {p' : monoidal_predicate C}
+
+/-- An implication of predicates `p.P → p'.P` induces a monoidal functor between full monoidal
+subcategories. -/
+@[simps]
+def full_monoidal_subcategory.map (h : ∀ ⦃X⦄, p.P X → p'.P X) :
+  monoidal_functor (full_monoidal_subcategory p) (full_monoidal_subcategory p')  :=
+{ to_functor := full_subcategory.map h,
+  ε := 𝟙 _,
+  μ := λ X Y, 𝟙 _ }
+
+instance full_monoidal_subcategory.map_full (h : ∀ ⦃X⦄, p.P X → p'.P X) :
+  full (full_monoidal_subcategory.map h).to_functor := { preimage := λ X Y f, f }
+instance full_monoidal_subcategory.map_faithful (h : ∀ ⦃X⦄, p.P X → p'.P X) :
+  faithful (full_monoidal_subcategory.map h).to_functor := {}
+
+section braided
+
+variables (p) [braided_category C]
+
+/--
+The monoidal structure on `full_monoidal_subcategory p` inherited by the braided structure on `C`.
+-/
+instance full_braided_subcategory : braided_category (full_monoidal_subcategory p) :=
+braided_category_of_faithful (full_monoidal_subcategory_inclusion p)
+  (λ X Y, ⟨(β_ X.1 Y.1).hom, (β_ X.1 Y.1).inv, (β_ X.1 Y.1).hom_inv_id, (β_ X.1 Y.1).inv_hom_id⟩)
+  (λ X Y, by tidy)
+
+/--
+The forgetful braided functor from a full braided subcategory into the original category
+("forgetting" the condition).
+-/
+@[simps]
+def full_braided_subcategory_inclusion : braided_functor (full_monoidal_subcategory p) C :=
+{ to_monoidal_functor := full_monoidal_subcategory_inclusion p,
+  braided' := λ X Y, by { rw [is_iso.eq_inv_comp], tidy }  }
+
+instance full_braided_subcategory.full :
+  full (full_braided_subcategory_inclusion p).to_functor := full_monoidal_subcategory.full p
+instance full_braided_subcategory.faithful :
+  faithful (full_braided_subcategory_inclusion p).to_functor := full_monoidal_subcategory.faithful p
+
+variables {p}
+
+/-- An implication of predicates `p.P → p'.P` induces a braided functor between full braided
+subcategories. -/
+@[simps]
+def full_braided_subcategory.map (h : ∀ ⦃X⦄, p.P X → p'.P X) :
+  braided_functor (full_monoidal_subcategory p) (full_monoidal_subcategory p')  :=
+{ to_monoidal_functor := full_monoidal_subcategory.map h,
+  braided' := λ X Y, by { rw [is_iso.eq_inv_comp], tidy }  }
+
+instance full_braided_subcategory.map_full (h : ∀ ⦃X⦄, p.P X → p'.P X) :
+  full (full_braided_subcategory.map h).to_functor := full_monoidal_subcategory.map_full h
+instance full_braided_subcategory.map_faithful (h : ∀ ⦃X⦄, p.P X → p'.P X) :
+  faithful (full_braided_subcategory.map h).to_functor := full_monoidal_subcategory.map_faithful h
+
+end braided
+
+section symmetric
+
+variables (p) [symmetric_category C]
+
+instance full_symmetric_subcategory : symmetric_category (full_monoidal_subcategory p) :=
+symmetric_category_of_faithful (full_braided_subcategory_inclusion p)
+
+end symmetric
+
+end monoidal_category
+
+end category_theory

--- a/src/category_theory/monoidal/subcategory.lean
+++ b/src/category_theory/monoidal/subcategory.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Antoine Labelle
 -/
 import category_theory.monoidal.braided
+import category_theory.concrete_category.basic
 
 /-!
 # Full monoidal subcategories
@@ -43,6 +44,11 @@ subcategory `{X : C // p.P X}`, which provides a monoidal structure induced by t
 -/
 @[nolint has_inhabited_instance, derive category]
 def full_monoidal_subcategory := {X : C // p.P X}
+
+instance full_monoidal_subcategory.concrete_category [concrete_category C] :
+  concrete_category (full_monoidal_subcategory p) := full_subcategory.concrete_category p.P
+instance full_subcategory.has_forget₂ [concrete_category C] :
+  has_forget₂ (full_monoidal_subcategory p) C := full_subcategory.has_forget₂ p.P
 
 /--
 The monoidal structure on `full_monoidal_subcategory p`

--- a/src/category_theory/monoidal/subcategory.lean
+++ b/src/category_theory/monoidal/subcategory.lean
@@ -31,13 +31,13 @@ variables {C : Type u} [category.{v} C] [monoidal_category C] (P : C → Prop)
 A property `C → Prop` is a monoidal predicate if it is closed under `𝟙_` and `⊗`.
 -/
 class monoidal_predicate :=
-(prop_id' : P (𝟙_ C))
-(prop_tensor' : ∀ {X Y}, P X → P Y → P (X ⊗ Y))
+(prop_id' : P (𝟙_ C) . obviously)
+(prop_tensor' : ∀ {X Y}, P X → P Y → P (X ⊗ Y) . obviously)
 
-lemma prop_id [hP : monoidal_predicate P] : P (𝟙_ C) := hP.prop_id'
+restate_axiom monoidal_predicate.prop_id'
+restate_axiom monoidal_predicate.prop_tensor'
 
-lemma prop_tensor [hP : monoidal_predicate P] {X Y : C} (hX : P X) (hY : P Y) : P (X ⊗ Y) :=
-monoidal_predicate.prop_tensor' hX hY
+open monoidal_predicate
 
 variables [monoidal_predicate P]
 
@@ -46,10 +46,10 @@ When `P` is a monoidal predicate, the full subcategory `{X : C // P X}` inherits
 structure of `C`
 -/
 instance full_monoidal_subcategory : monoidal_category {X : C // P X} :=
-{ tensor_obj := λ X Y, ⟨X ⊗ Y, prop_tensor P X.2 Y.2⟩,
+{ tensor_obj := λ X Y, ⟨X ⊗ Y, prop_tensor X.2 Y.2⟩,
   tensor_hom := λ X₁ Y₁ X₂ Y₂ f g, by { change X₁.1 ⊗ X₂.1 ⟶ Y₁.1 ⊗ Y₂.1,
     change X₁.1 ⟶ Y₁.1 at f, change X₂.1 ⟶ Y₂.1 at g, exact f ⊗ g },
-  tensor_unit := ⟨𝟙_ C, prop_id P⟩,
+  tensor_unit := ⟨𝟙_ C, prop_id⟩,
   associator := λ X Y Z,
     ⟨(α_ X.1 Y.1 Z.1).hom, (α_ X.1 Y.1 Z.1).inv,
      hom_inv_id (α_ X.1 Y.1 Z.1), inv_hom_id (α_ X.1 Y.1 Z.1)⟩,


### PR DESCRIPTION
We use a type synonym for `{X : C // P X}` when `C` is a monoidal category and the property `P` is closed under the monoidal unit and tensor product so that `full_monoidal_subcategory` can be made an instance.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
