### PR TITLE
[Merged by Bors] - feat(linear_algebra/affine_space/affine_equiv): extra lemmas and docstrings

### DIFF
--- a/src/linear_algebra/affine_space/affine_equiv.lean
+++ b/src/linear_algebra/affine_space/affine_equiv.lean
@@ -325,6 +325,12 @@ def const_vadd_hom : multiplicative V₁ →* P₁ ≃ᵃ[k] P₁ :=
   map_one' := const_vadd_zero _ _,
   map_mul' := const_vadd_add _ _ }
 
+lemma const_vadd_nsmul (n : ℕ) (v : V₁) : const_vadd k P₁ (n • v) = (const_vadd k P₁ v)^n :=
+(const_vadd_hom k P₁).map_pow _ _
+
+lemma const_vadd_zsmul (z : ℤ) (v : V₁) : const_vadd k P₁ (z • v) = (const_vadd k P₁ v)^z :=
+(const_vadd_hom k P₁).map_zpow _ _
+
 section homothety
 
 omit V₁

--- a/src/linear_algebra/affine_space/affine_equiv.lean
+++ b/src/linear_algebra/affine_space/affine_equiv.lean
@@ -300,12 +300,30 @@ def const_vsub (p : P₁) : P₁ ≃ᵃ[k] V₁ :=
 
 variable (P₁)
 
-/-- The map `p ↦ v +ᵥ p` as an affine automorphism of an affine space. -/
-@[simps]
+/-- The map `p ↦ v +ᵥ p` as an affine automorphism of an affine space.
+
+Note that there is no need for an `affine_map.const_vadd` as it is always an equivalence.
+This is roughly to `distrib_mul_action.to_linear_equiv` as `+ᵥ` is to `•`. -/
+@[simps apply linear]
 def const_vadd (v : V₁) : P₁ ≃ᵃ[k] P₁ :=
 { to_equiv := equiv.const_vadd P₁ v,
   linear := linear_equiv.refl _ _,
   map_vadd' := λ p w, vadd_comm _ _ _ }
+
+@[simp] lemma const_vadd_zero : const_vadd k P₁ 0 = affine_equiv.refl _ _ := ext $ zero_vadd _
+
+@[simp] lemma const_vadd_add (v w : V₁) :
+  const_vadd k P₁ (v + w) = (const_vadd k P₁ w).trans (const_vadd k P₁ v) := ext $ add_vadd _ _
+
+@[simp] lemma const_vadd_symm (v : V₁) : (const_vadd k P₁ v).symm = const_vadd k P₁ (-v) :=
+ext $ λ _, rfl
+
+/-- A more bundled version of `affine_equiv.const_vadd`. -/
+@[simps]
+def const_vadd_hom : multiplicative V₁ →* P₁ ≃ᵃ[k] P₁ :=
+{ to_fun := λ v, const_vadd k P₁ v.to_add,
+  map_one' := const_vadd_zero _ _,
+  map_mul' := const_vadd_add _ _ }
 
 section homothety
 

--- a/src/linear_algebra/affine_space/affine_map.lean
+++ b/src/linear_algebra/affine_space/affine_map.lean
@@ -363,6 +363,25 @@ end
 
 omit V2
 
+section
+variables (k)
+
+/-- `x ↦ v +ᵥ x` as an `affine_map`. The name is chosen to match `module.to_linear_map`. -/
+@[simps]
+def _root_.affine_space.to_affine_map (v : V1) : P1 →ᵃ[k] P1 :=
+{ to_fun := (+ᵥ) v,
+  linear := linear_map.id,
+  map_vadd' := λ p v, vadd_comm _ _ _ }
+
+/-- A more bundled version of `affine_space.to_affine_map`. -/
+@[simps]
+def _root_.affine_space.to_affine_map_hom : multiplicative V1 →* P1 →ᵃ[k] P1 :=
+{ to_fun := λ v, affine_space.to_affine_map k v.to_add,
+  map_one' := affine_map.ext $ zero_vadd _,
+  map_mul' := λ x y, affine_map.ext $ add_vadd _ _ }
+
+end
+
 /-! ### Definition of `affine_map.line_map` and lemmas about it -/
 
 /-- The affine map from `k` to `P1` sending `0` to `p₀` and `1` to `p₁`. -/

--- a/src/linear_algebra/affine_space/affine_map.lean
+++ b/src/linear_algebra/affine_space/affine_map.lean
@@ -363,25 +363,6 @@ end
 
 omit V2
 
-section
-variables (k)
-
-/-- `x ↦ v +ᵥ x` as an `affine_map`. The name is chosen to match `module.to_linear_map`. -/
-@[simps]
-def _root_.affine_space.to_affine_map (v : V1) : P1 →ᵃ[k] P1 :=
-{ to_fun := (+ᵥ) v,
-  linear := linear_map.id,
-  map_vadd' := λ p v, vadd_comm _ _ _ }
-
-/-- A more bundled version of `affine_space.to_affine_map`. -/
-@[simps]
-def _root_.affine_space.to_affine_map_hom : multiplicative V1 →* P1 →ᵃ[k] P1 :=
-{ to_fun := λ v, affine_space.to_affine_map k v.to_add,
-  map_one' := affine_map.ext $ zero_vadd _,
-  map_mul' := λ x y, affine_map.ext $ add_vadd _ _ }
-
-end
-
 /-! ### Definition of `affine_map.line_map` and lemmas about it -/
 
 /-- The affine map from `k` to `P1` sending `0` to `p₀` and `1` to `p₁`. -/


### PR DESCRIPTION
I was struggling to find this definition, so added some more lemmas and a docstring.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

~~There didn't seem to be anywhere immediately obvious to put this, but it seemed more primitive than `line_map` so I put it there.~~

~~It's possible we already have this, but I couldn't find it.~~

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
