### PR TITLE
chore(topology/metric_space): make `(anti)lipschitz_with` take `has_edist`

### DIFF
--- a/src/topology/metric_space/algebra.lean
+++ b/src/topology/metric_space/algebra.lean
@@ -64,7 +64,7 @@ end
 
 @[to_additive, priority 100] -- see Note [lower instance priority]
 instance has_lipschitz_mul.has_continuous_mul : has_continuous_mul β :=
-⟨ lipschitz_with_lipschitz_const_mul_edist.continuous ⟩
+⟨(@lipschitz_with_lipschitz_const_mul_edist β _ _ _).continuous⟩
 
 @[to_additive] instance submonoid.has_lipschitz_mul (s : submonoid β) : has_lipschitz_mul s :=
 { lipschitz_mul := ⟨has_lipschitz_mul.C β, begin

--- a/src/topology/metric_space/antilipschitz.lean
+++ b/src/topology/metric_space/antilipschitz.lean
@@ -23,18 +23,18 @@ we do not have a `posreal` type.
 variables {α : Type*} {β : Type*} {γ : Type*}
 
 open_locale nnreal ennreal uniformity
-open set
+open set filter bornology
 
 /-- We say that `f : α → β` is `antilipschitz_with K` if for any two points `x`, `y` we have
 `K * edist x y ≤ edist (f x) (f y)`. -/
-def antilipschitz_with [pseudo_emetric_space α] [pseudo_emetric_space β] (K : ℝ≥0) (f : α → β) :=
+def antilipschitz_with [has_edist α] [has_edist β] (K : ℝ≥0) (f : α → β) :=
 ∀ x y, edist x y ≤ K * edist (f x) (f y)
 
-lemma antilipschitz_with.edist_lt_top [pseudo_emetric_space α] [pseudo_metric_space β] {K : ℝ≥0}
+lemma antilipschitz_with.edist_lt_top [has_edist α] [pseudo_metric_space β] {K : ℝ≥0}
   {f : α → β} (h : antilipschitz_with K f) (x y : α) : edist x y < ⊤ :=
 (h x y).trans_lt $ ennreal.mul_lt_top ennreal.coe_ne_top (edist_ne_top _ _)
 
-lemma antilipschitz_with.edist_ne_top [pseudo_emetric_space α] [pseudo_metric_space β] {K : ℝ≥0}
+lemma antilipschitz_with.edist_ne_top [has_edist α] [pseudo_metric_space β] {K : ℝ≥0}
   {f : α → β} (h : antilipschitz_with K f) (x y : α) : edist x y ≠ ⊤ :=
 (h.edist_lt_top x y).ne
 

--- a/src/topology/metric_space/lipschitz.lean
+++ b/src/topology/metric_space/lipschitz.lean
@@ -46,7 +46,7 @@ variables {α : Type u} {β : Type v} {γ : Type w} {ι : Type x}
 
 /-- A function `f` is Lipschitz continuous with constant `K ≥ 0` if for all `x, y`
 we have `dist (f x) (f y) ≤ K * dist x y` -/
-def lipschitz_with [pseudo_emetric_space α] [pseudo_emetric_space β] (K : ℝ≥0) (f : α → β) :=
+def lipschitz_with [has_edist α] [has_edist β] (K : ℝ≥0) (f : α → β) :=
 ∀x y, edist (f x) (f y) ≤ K * edist x y
 
 lemma lipschitz_with_iff_dist_le_mul [pseudo_metric_space α] [pseudo_metric_space β] {K : ℝ≥0}
@@ -57,15 +57,15 @@ alias lipschitz_with_iff_dist_le_mul ↔ lipschitz_with.dist_le_mul lipschitz_wi
 
 /-- A function `f` is Lipschitz continuous with constant `K ≥ 0` on `s` if for all `x, y` in `s`
 we have `dist (f x) (f y) ≤ K * dist x y` -/
-def lipschitz_on_with [pseudo_emetric_space α] [pseudo_emetric_space β] (K : ℝ≥0) (f : α → β)
+def lipschitz_on_with [has_edist α] [has_edist β] (K : ℝ≥0) (f : α → β)
   (s : set α) :=
 ∀ ⦃x⦄ (hx : x ∈ s) ⦃y⦄ (hy : y ∈ s), edist (f x) (f y) ≤ K * edist x y
 
-@[simp] lemma lipschitz_on_with_empty [pseudo_emetric_space α] [pseudo_emetric_space β] (K : ℝ≥0)
+@[simp] lemma lipschitz_on_with_empty [has_edist α] [has_edist β] (K : ℝ≥0)
   (f : α → β) : lipschitz_on_with K f ∅ :=
 λ x x_in y y_in, false.elim x_in
 
-lemma lipschitz_on_with.mono [pseudo_emetric_space α] [pseudo_emetric_space β] {K : ℝ≥0}
+lemma lipschitz_on_with.mono [has_edist α] [has_edist β] {K : ℝ≥0}
   {s t : set α} {f : α → β} (hf : lipschitz_on_with K f t) (h : s ⊆ t) : lipschitz_on_with K f s :=
 λ x x_in y y_in, hf (h x_in) (h y_in)
 
@@ -77,7 +77,7 @@ by { simp only [lipschitz_on_with, edist_nndist, dist_nndist], norm_cast }
 alias lipschitz_on_with_iff_dist_le_mul ↔
   lipschitz_on_with.dist_le_mul lipschitz_on_with.of_dist_le_mul
 
-@[simp] lemma lipschitz_on_univ [pseudo_emetric_space α] [pseudo_emetric_space β] {K : ℝ≥0}
+@[simp] lemma lipschitz_on_univ [has_edist α] [has_edist β] {K : ℝ≥0}
   {f : α → β} : lipschitz_on_with K f univ ↔ lipschitz_with K f :=
 by simp [lipschitz_on_with, lipschitz_with]
 


### PR DESCRIPTION
Sometimes we have an auxiliary `emetric_space` definition that is later used in the actual instance. With this definition we can prove `(anti)lipshictz_with` lemmas for these auxiliary instances, then use them with the actual instances.

UPD: probably, it creates more issues than it solves.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
