### PR TITLE
[Merged by Bors] - refactor(algebra/direct_sum/basic): use the new polymorphic subobject API  

### DIFF
--- a/counterexamples/direct_sum_is_internal.lean
+++ b/counterexamples/direct_sum_is_internal.lean
@@ -14,7 +14,7 @@ This shows that while `ℤ≤0` and `ℤ≥0` are complementary `ℕ`-submodules
 implies as a collection they are `complete_lattice.independent` and that they span all of `ℤ`, they
 do not form a decomposition into a direct sum.
 
-This file demonstrates why `direct_sum.submodule_is_internal_of_independent_of_supr_eq_top` must
+This file demonstrates why `direct_sum.is_internal_submodule_of_independent_of_supr_eq_top` must
 take `ring R` and not `semiring R`.
 -/
 

--- a/counterexamples/direct_sum_is_internal.lean
+++ b/counterexamples/direct_sum_is_internal.lean
@@ -89,5 +89,5 @@ begin
 end
 
 /-- And so they do not represent an internal direct sum. -/
-lemma with_sign.not_internal : ¬direct_sum.submodule_is_internal with_sign :=
+lemma with_sign.not_internal : ¬direct_sum.is_internal with_sign :=
 with_sign.not_injective ∘ and.elim_left

--- a/counterexamples/homogeneous_prime_not_prime.lean
+++ b/counterexamples/homogeneous_prime_not_prime.lean
@@ -91,7 +91,7 @@ def grading.decompose : (R × R) →+ direct_sum two (λ i, grading R i) :=
   end }
 
 lemma grading.left_inv :
-  function.left_inverse grading.decompose (submodule_coe (grading R)) := λ zz,
+  function.left_inverse grading.decompose (coe_linear_map (grading R)) := λ zz,
 begin
   induction zz using direct_sum.induction_on with i zz d1 d2 ih1 ih2,
   { simp only [map_zero],},
@@ -101,11 +101,11 @@ begin
 end
 
 lemma grading.right_inv :
-  function.right_inverse grading.decompose (submodule_coe (grading R)) := λ zz,
+  function.right_inverse grading.decompose (coe_linear_map (grading R)) := λ zz,
 begin
   cases zz with a b,
   unfold grading.decompose,
-  simp only [add_monoid_hom.coe_mk, map_add, submodule_coe_of, subtype.coe_mk, prod.mk_add_mk,
+  simp only [add_monoid_hom.coe_mk, map_add, coe_linear_map_of, subtype.coe_mk, prod.mk_add_mk,
     add_zero, add_sub_cancel'_right],
 end
 

--- a/docs/undergrad.yaml
+++ b/docs/undergrad.yaml
@@ -9,7 +9,7 @@ Linear algebra:
     vector subspace: 'subspace'
     quotient space: 'submodule.has_quotient'
     sum of subspaces: 'submodule.complete_lattice'
-    direct sum: 'direct_sum.submodule_is_internal'
+    direct sum: 'direct_sum.is_internal'
     complementary subspaces: 'submodule.exists_is_compl'
     linear independence: 'linear_independent'
     generating sets: 'submodule.span'

--- a/src/algebra/direct_sum/basic.lean
+++ b/src/algebra/direct_sum/basic.lean
@@ -271,7 +271,7 @@ end
 
 For the alternate statement in terms of independence and spanning, see
 `direct_sum.subgroup_is_internal_iff_independent_and_supr_eq_top` and
-`direct_sum.submodule_is_internal_iff_independent_and_supr_eq_top`. -/
+`direct_sum.is_internal_submodule_iff_independent_and_supr_eq_top`. -/
 def is_internal {M S : Type*} [decidable_eq ι] [add_comm_monoid M]
   [set_like S M] [add_submonoid_class S M] (A : ι → S) : Prop :=
 function.bijective (direct_sum.coe_add_monoid_hom A)

--- a/src/algebra/direct_sum/basic.lean
+++ b/src/algebra/direct_sum/basic.lean
@@ -245,73 +245,43 @@ noncomputable def sigma_curry_equiv : (⨁ (i : Σ i, _), δ i.1 i.2) ≃+ ⨁ i
 end sigma
 
 /-- The canonical embedding from `⨁ i, A i` to `M` where `A` is a collection of `add_submonoid M`
-indexed by `ι`-/
-def add_submonoid_coe {M : Type*} [decidable_eq ι] [add_comm_monoid M]
-  (A : ι → add_submonoid M) : (⨁ i, A i) →+ M :=
-to_add_monoid (λ i, (A i).subtype)
+indexed by `ι`.
 
-@[simp] lemma add_submonoid_coe_of {M : Type*} [decidable_eq ι] [add_comm_monoid M]
-  (A : ι → add_submonoid M) (i : ι) (x : A i) :
-  add_submonoid_coe A (of (λ i, A i) i x) = x :=
+When `S = submodule _ M`, this is available as a `linear_map`, `direct_sum.coe_linear_map`. -/
+protected def coe_add_monoid_hom {M S : Type*} [decidable_eq ι] [add_comm_monoid M]
+  [set_like S M] [add_submonoid_class S M] (A : ι → S) : (⨁ i, A i) →+ M :=
+to_add_monoid (λ i, add_submonoid_class.subtype (A i))
+
+@[simp] lemma coe_add_monoid_hom_of {M S : Type*} [decidable_eq ι] [add_comm_monoid M]
+  [set_like S M] [add_submonoid_class S M] (A : ι → S) (i : ι) (x : A i) :
+  direct_sum.coe_add_monoid_hom A (of (λ i, A i) i x) = x :=
 to_add_monoid_of _ _ _
 
-lemma coe_of_add_submonoid_apply {M : Type*} [decidable_eq ι] [add_comm_monoid M]
-  {A : ι → add_submonoid M} (i j : ι) (x : A i) :
+lemma coe_of_apply {M S : Type*} [decidable_eq ι] [add_comm_monoid M]
+  [set_like S M] [add_submonoid_class S M] {A : ι → S} (i j : ι) (x : A i) :
   (of _ i x j : M) = if i = j then x else 0 :=
 begin
   obtain rfl | h := decidable.eq_or_ne i j,
   { rw [direct_sum.of_eq_same, if_pos rfl], },
-  { rw [direct_sum.of_eq_of_ne _ _ _ _ h, if_neg h, add_submonoid.coe_zero], },
+  { rw [direct_sum.of_eq_of_ne _ _ _ _ h, if_neg h, add_submonoid_class.coe_zero], },
 end
 
-/-- The `direct_sum` formed by a collection of `add_submonoid`s of `M` is said to be internal if the
-canonical map `(⨁ i, A i) →+ M` is bijective.
+/-- The `direct_sum` formed by a collection of additive submonoids (or subgroups, or submodules) of
+`M` is said to be internal if the canonical map `(⨁ i, A i) →+ M` is bijective.
 
-See `direct_sum.add_subgroup_is_internal` for the same statement about `add_subgroup`s. -/
-def add_submonoid_is_internal {M : Type*} [decidable_eq ι] [add_comm_monoid M]
-  (A : ι → add_submonoid M) : Prop :=
-function.bijective (add_submonoid_coe A)
+For the alternate statement in terms of independence and spanning, see
+`direct_sum.subgroup_is_internal_iff_independent_and_supr_eq_top` and
+`direct_sum.submodule_is_internal_iff_independent_and_supr_eq_top`. -/
+def is_internal {M S : Type*} [decidable_eq ι] [add_comm_monoid M]
+  [set_like S M] [add_submonoid_class S M] (A : ι → S) : Prop :=
+function.bijective (direct_sum.coe_add_monoid_hom A)
 
-lemma add_submonoid_is_internal.supr_eq_top {M : Type*} [decidable_eq ι] [add_comm_monoid M]
+lemma is_internal.add_submonoid_supr_eq_top {M : Type*} [decidable_eq ι] [add_comm_monoid M]
   (A : ι → add_submonoid M)
-  (h : add_submonoid_is_internal A) : supr A = ⊤ :=
+  (h : is_internal A) : supr A = ⊤ :=
 begin
   rw [add_submonoid.supr_eq_mrange_dfinsupp_sum_add_hom, add_monoid_hom.mrange_top_iff_surjective],
   exact function.bijective.surjective h,
 end
-
-/-- The canonical embedding from `⨁ i, A i` to `M`  where `A` is a collection of `add_subgroup M`
-indexed by `ι`-/
-def add_subgroup_coe {M : Type*} [decidable_eq ι] [add_comm_group M]
-  (A : ι → add_subgroup M) : (⨁ i, A i) →+ M :=
-to_add_monoid (λ i, (A i).subtype)
-
-@[simp] lemma add_subgroup_coe_of {M : Type*} [decidable_eq ι] [add_comm_group M]
-  (A : ι → add_subgroup M) (i : ι) (x : A i) :
-  add_subgroup_coe A (of (λ i, A i) i x) = x :=
-to_add_monoid_of _ _ _
-
-lemma coe_of_add_subgroup_apply {M : Type*} [decidable_eq ι] [add_comm_group M]
-  {A : ι → add_subgroup M} (i j : ι) (x : A i) :
-  (of _ i x j : M) = if i = j then x else 0 :=
-begin
-  obtain rfl | h := decidable.eq_or_ne i j,
-  { rw [direct_sum.of_eq_same, if_pos rfl], },
-  { rw [direct_sum.of_eq_of_ne _ _ _ _ h, if_neg h, add_subgroup.coe_zero], },
-end
-
-/-- The `direct_sum` formed by a collection of `add_subgroup`s of `M` is said to be internal if the
-canonical map `(⨁ i, A i) →+ M` is bijective.
-
-See `direct_sum.submodule_is_internal` for the same statement about `submodules`s. -/
-def add_subgroup_is_internal {M : Type*} [decidable_eq ι] [add_comm_group M]
-  (A : ι → add_subgroup M) : Prop :=
-function.bijective (add_subgroup_coe A)
-
-lemma add_subgroup_is_internal.to_add_submonoid
-  {M : Type*} [decidable_eq ι] [add_comm_group M] (A : ι → add_subgroup M) :
-  add_subgroup_is_internal A ↔
-    add_submonoid_is_internal (λ i, (A i).to_add_submonoid) :=
-iff.rfl
 
 end direct_sum

--- a/src/algebra/direct_sum/internal.lean
+++ b/src/algebra/direct_sum/internal.lean
@@ -14,8 +14,9 @@ import algebra.direct_sum.algebra
 This module provides `gsemiring` and `gcomm_semiring` instances for a collection of subobjects `A`
 when a `set_like.graded_monoid` instance is available:
 
+* `set_like.gnon_unital_non_assoc_semiring`
 * `set_like.gsemiring`
-* `set_like.gcomm_semiring`.
+* `set_like.gcomm_semiring`
 
 With these instances in place, it provides the bundled canonical maps out of a direct sum of
 subobjects into their carrier type:
@@ -56,6 +57,17 @@ variables [decidable_eq ι]
 /-! #### From `add_submonoid`s and `add_subgroup`s -/
 
 namespace set_like
+
+/-- Build a `gnon_unital_non_assoc_semiring` instance for a collection of additive submonoids. -/
+instance gnon_unital_non_assoc_semiring [has_add ι] [non_unital_non_assoc_semiring R]
+  [set_like σ R] [add_submonoid_class σ R]
+  (A : ι → σ) [set_like.has_graded_mul A] :
+  direct_sum.gnon_unital_non_assoc_semiring (λ i, A i) :=
+{ mul_zero := λ i j _, subtype.ext (mul_zero _),
+  zero_mul := λ i j _, subtype.ext (zero_mul _),
+  mul_add := λ i j _ _ _, subtype.ext (mul_add _ _ _),
+  add_mul := λ i j _ _ _, subtype.ext (add_mul _ _ _),
+  ..set_like.ghas_mul A }
 
 /-- Build a `gsemiring` instance for a collection of additive submonoids. -/
 instance gsemiring [add_monoid ι] [semiring R] [set_like σ R] [add_submonoid_class σ R]
@@ -99,7 +111,7 @@ begin
   simp_rw [direct_sum.coe_of_apply, ←finset.sum_filter, set_like.coe_ghas_mul],
 end
 
-/-! #### From `submodules`s -/
+/-! #### From `submodule`s -/
 
 namespace submodule
 

--- a/src/algebra/direct_sum/internal.lean
+++ b/src/algebra/direct_sum/internal.lean
@@ -26,10 +26,10 @@ subobjects into their carrier type:
 Strictly the definitions in this file are not sufficient to fully define an "internal" direct sum;
 to represent this case, `(h : direct_sum.is_internal A) [set_like.graded_monoid A]` is
 needed. In the future there will likely be a data-carrying, constructive, typeclass version of
-`direct_sum.submodule_is_internal` for providing an explicit decomposition function.
+`direct_sum.is_internal` for providing an explicit decomposition function.
 
 When `complete_lattice.independent (set.range A)` (a weaker condition than
-`direct_sum.submodule_is_internal A`), these provide a grading of `⨆ i, A i`, and the
+`direct_sum.is_internal A`), these provide a grading of `⨆ i, A i`, and the
 mapping `⨁ i, A i →+ ⨆ i, A i` can be obtained as
 `direct_sum.to_monoid (λ i, add_submonoid.inclusion $ le_supr A i)`.
 

--- a/src/algebra/direct_sum/internal.lean
+++ b/src/algebra/direct_sum/internal.lean
@@ -14,19 +14,17 @@ import algebra.direct_sum.algebra
 This module provides `gsemiring` and `gcomm_semiring` instances for a collection of subobjects `A`
 when a `set_like.graded_monoid` instance is available:
 
-* on `add_submonoid R`s: `add_submonoid.gsemiring`, `add_submonoid.gcomm_semiring`.
-* on `add_subgroup R`s: `add_subgroup.gsemiring`, `add_subgroup.gcomm_semiring`.
-* on `submodule S R`s: `submodule.gsemiring`, `submodule.gcomm_semiring`.
+* `set_like.gsemiring`
+* `set_like.gcomm_semiring`.
 
 With these instances in place, it provides the bundled canonical maps out of a direct sum of
 subobjects into their carrier type:
 
-* `direct_sum.add_submonoid_coe_ring_hom` (a `ring_hom` version of `direct_sum.add_submonoid_coe`)
-* `direct_sum.add_subgroup_coe_ring_hom` (a `ring_hom` version of `direct_sum.add_subgroup_coe`)
-* `direct_sum.submodule_coe_alg_hom` (an `alg_hom` version of `direct_sum.submodule_coe`)
+* `direct_sum.coe_ring_hom` (a `ring_hom` version of `direct_sum.coe_add_monoid_hom`)
+* `direct_sum.coe_alg_hom` (an `alg_hom` version of `direct_sum.submodule_coe`)
 
 Strictly the definitions in this file are not sufficient to fully define an "internal" direct sum;
-to represent this case, `(h : direct_sum.submodule_is_internal A) [set_like.graded_monoid A]` is
+to represent this case, `(h : direct_sum.is_internal A) [set_like.graded_monoid A]` is
 needed. In the future there will likely be a data-carrying, constructive, typeclass version of
 `direct_sum.submodule_is_internal` for providing an explicit decomposition function.
 
@@ -42,7 +40,7 @@ internally graded ring
 
 open_locale direct_sum big_operators
 
-variables {ι : Type*} {S R : Type*}
+variables {ι : Type*} {σ S R : Type*}
 
 lemma set_like.has_graded_one.algebra_map_mem [has_zero ι]
   [comm_semiring S] [semiring R] [algebra S R]
@@ -55,13 +53,13 @@ end
 section direct_sum
 variables [decidable_eq ι]
 
-/-! #### From `add_submonoid`s -/
+/-! #### From `add_submonoid`s and `add_subgroup`s -/
 
-namespace add_submonoid
+namespace set_like
 
-/-- Build a `gsemiring` instance for a collection of `add_submonoid`s. -/
-instance gsemiring [add_monoid ι] [semiring R]
-  (A : ι → add_submonoid R) [set_like.graded_monoid A] :
+/-- Build a `gsemiring` instance for a collection of additive submonoids. -/
+instance gsemiring [add_monoid ι] [semiring R] [set_like σ R] [add_submonoid_class σ R]
+  (A : ι → σ) [set_like.graded_monoid A] :
   direct_sum.gsemiring (λ i, A i) :=
 { mul_zero := λ i j _, subtype.ext (mul_zero _),
   zero_mul := λ i j _, subtype.ext (zero_mul _),
@@ -69,28 +67,28 @@ instance gsemiring [add_monoid ι] [semiring R]
   add_mul := λ i j _ _ _, subtype.ext (add_mul _ _ _),
   ..set_like.gmonoid A }
 
-/-- Build a `gcomm_semiring` instance for a collection of `add_submonoid`s. -/
-instance gcomm_semiring [add_comm_monoid ι] [comm_semiring R]
-  (A : ι → add_submonoid R) [set_like.graded_monoid A] :
+/-- Build a `gcomm_semiring` instance for a collection of additive submonoids. -/
+instance gcomm_semiring [add_comm_monoid ι] [comm_semiring R] [set_like σ R]
+  [add_submonoid_class σ R] (A : ι → σ) [set_like.graded_monoid A] :
   direct_sum.gcomm_semiring (λ i, A i) :=
 { ..set_like.gcomm_monoid A,
-  ..add_submonoid.gsemiring A, }
+  ..set_like.gsemiring A, }
 
-end add_submonoid
-
-/-- The canonical ring isomorphism between `⨁ i, A i` and `R`-/
-def direct_sum.submonoid_coe_ring_hom [add_monoid ι] [semiring R]
-  (A : ι → add_submonoid R) [h : set_like.graded_monoid A] : (⨁ i, A i) →+* R :=
-direct_sum.to_semiring (λ i, (A i).subtype) rfl (λ _ _ _ _, rfl)
+end set_like
 
 /-- The canonical ring isomorphism between `⨁ i, A i` and `R`-/
-@[simp] lemma direct_sum.submonoid_coe_ring_hom_of [add_monoid ι] [semiring R]
-  (A : ι → add_submonoid R) [h : set_like.graded_monoid A] (i : ι) (x : A i) :
-  direct_sum.submonoid_coe_ring_hom A (direct_sum.of (λ i, A i) i x) = x :=
+def direct_sum.coe_ring_hom [add_monoid ι] [semiring R] [set_like σ R]
+  [add_submonoid_class σ R] (A : ι → σ) [set_like.graded_monoid A] : (⨁ i, A i) →+* R :=
+direct_sum.to_semiring (λ i, add_submonoid_class.subtype (A i)) rfl (λ _ _ _ _, rfl)
+
+/-- The canonical ring isomorphism between `⨁ i, A i` and `R`-/
+@[simp] lemma direct_sum.coe_ring_hom_of [add_monoid ι] [semiring R]
+  (A : ι → add_submonoid R) [set_like.graded_monoid A] (i : ι) (x : A i) :
+  direct_sum.coe_ring_hom A (direct_sum.of (λ i, A i) i x) = x :=
 direct_sum.to_semiring_of _ _ _ _ _
 
-lemma direct_sum.coe_mul_apply_add_submonoid [add_monoid ι] [semiring R]
-  (A : ι → add_submonoid R) [set_like.graded_monoid A]
+lemma direct_sum.coe_mul_apply [add_monoid ι] [semiring R] [set_like σ R]
+  [add_submonoid_class σ R] (A : ι → σ) [set_like.graded_monoid A]
   [Π (i : ι) (x : A i), decidable (x ≠ 0)] (r r' : ⨁ i, A i) (i : ι) :
   ((r * r') i : R) =
     ∑ ij in finset.filter (λ ij : ι × ι, ij.1 + ij.2 = i) (r.support.product r'.support),
@@ -98,75 +96,17 @@ lemma direct_sum.coe_mul_apply_add_submonoid [add_monoid ι] [semiring R]
 begin
   rw [direct_sum.mul_eq_sum_support_ghas_mul, dfinsupp.finset_sum_apply,
     add_submonoid_class.coe_finset_sum],
-  simp_rw [direct_sum.coe_of_add_submonoid_apply, ←finset.sum_filter, set_like.coe_ghas_mul],
-end
-
-/-! #### From `add_subgroup`s -/
-
-namespace add_subgroup
-
-/-- Build a `gsemiring` instance for a collection of `add_subgroup`s. -/
-instance gsemiring [add_monoid ι] [ring R]
-  (A : ι → add_subgroup R) [h : set_like.graded_monoid A] :
-  direct_sum.gsemiring (λ i, A i) :=
-have i' : set_like.graded_monoid (λ i, (A i).to_add_submonoid) := {..h},
-by exactI add_submonoid.gsemiring (λ i, (A i).to_add_submonoid)
-
-/-- Build a `gcomm_semiring` instance for a collection of `add_subgroup`s. -/
-instance gcomm_semiring [add_comm_group ι] [comm_ring R]
-  (A : ι → add_subgroup R) [h : set_like.graded_monoid A] :
-  direct_sum.gsemiring (λ i, A i) :=
-have i' : set_like.graded_monoid (λ i, (A i).to_add_submonoid) := {..h},
-by exactI add_submonoid.gsemiring (λ i, (A i).to_add_submonoid)
-
-end add_subgroup
-
-/-- The canonical ring isomorphism between `⨁ i, A i` and `R`. -/
-def direct_sum.subgroup_coe_ring_hom [add_monoid ι] [ring R]
-  (A : ι → add_subgroup R) [set_like.graded_monoid A] : (⨁ i, A i) →+* R :=
-direct_sum.to_semiring (λ i, (A i).subtype) rfl (λ _ _ _ _, rfl)
-
-@[simp] lemma direct_sum.subgroup_coe_ring_hom_of [add_monoid ι] [ring R]
-  (A : ι → add_subgroup R) [set_like.graded_monoid A] (i : ι) (x : A i) :
-  direct_sum.subgroup_coe_ring_hom A (direct_sum.of (λ i, A i) i x) = x :=
-direct_sum.to_semiring_of _ _ _ _ _
-
-lemma direct_sum.coe_mul_apply_add_subgroup [add_monoid ι] [ring R]
-  (A : ι → add_subgroup R) [set_like.graded_monoid A] [Π (i : ι) (x : A i), decidable (x ≠ 0)]
-  (r r' : ⨁ i, A i) (i : ι) :
-  ((r * r') i : R) =
-    ∑ ij in finset.filter (λ ij : ι × ι, ij.1 + ij.2 = i) (r.support.product r'.support),
-      r ij.1 * r' ij.2 :=
-begin
-  rw [direct_sum.mul_eq_sum_support_ghas_mul, dfinsupp.finset_sum_apply,
-    add_submonoid_class.coe_finset_sum],
-  simp_rw [direct_sum.coe_of_add_subgroup_apply, ←finset.sum_filter, set_like.coe_ghas_mul],
+  simp_rw [direct_sum.coe_of_apply, ←finset.sum_filter, set_like.coe_ghas_mul],
 end
 
 /-! #### From `submodules`s -/
 
 namespace submodule
 
-/-- Build a `gsemiring` instance for a collection of `submodule`s. -/
-instance gsemiring [add_monoid ι]
-  [comm_semiring S] [semiring R] [algebra S R]
-  (A : ι → submodule S R) [h : set_like.graded_monoid A] :
-  direct_sum.gsemiring (λ i, A i) :=
-have i' : set_like.graded_monoid (λ i, (A i).to_add_submonoid) := {..h},
-by exactI add_submonoid.gsemiring (λ i, (A i).to_add_submonoid)
-
-/-- Build a `gsemiring` instance for a collection of `submodule`s. -/
-instance gcomm_semiring [add_comm_monoid ι]
-  [comm_semiring S] [comm_semiring R] [algebra S R]
-  (A : ι → submodule S R) [h : set_like.graded_monoid A] :
-  direct_sum.gcomm_semiring (λ i, A i) :=
-have i' : set_like.graded_monoid (λ i, (A i).to_add_submonoid) := {..h},
-by exactI add_submonoid.gcomm_semiring (λ i, (A i).to_add_submonoid)
-
 /-- Build a `galgebra` instance for a collection of `submodule`s. -/
 instance galgebra [add_monoid ι]
   [comm_semiring S] [semiring R] [algebra S R]
-  (A : ι → submodule S R) [h : set_like.graded_monoid A] :
+  (A : ι → submodule S R) [set_like.graded_monoid A] :
   direct_sum.galgebra S (λ i, A i) :=
 { to_fun := ((algebra.linear_map S R).cod_restrict (A 0) $
     set_like.has_graded_one.algebra_map_mem A).to_add_monoid_hom,
@@ -178,7 +118,7 @@ instance galgebra [add_monoid ι]
 
 @[simp] lemma set_like.coe_galgebra_to_fun [add_monoid ι]
   [comm_semiring S] [semiring R] [algebra S R]
-  (A : ι → submodule S R) [h : set_like.graded_monoid A] (s : S) :
+  (A : ι → submodule S R) [set_like.graded_monoid A] (s : S) :
     ↑(@direct_sum.galgebra.to_fun _ S (λ i, A i) _ _ _ _ _ _ _ s) = (algebra_map S R s : R) := rfl
 
 /-- A direct sum of powers of a submodule of an algebra has a multiplicative structure. -/
@@ -191,35 +131,23 @@ instance nat_power_graded_monoid
 end submodule
 
 /-- The canonical algebra isomorphism between `⨁ i, A i` and `R`. -/
-def direct_sum.submodule_coe_alg_hom [add_monoid ι]
+def direct_sum.coe_alg_hom [add_monoid ι]
   [comm_semiring S] [semiring R] [algebra S R]
-  (A : ι → submodule S R) [h : set_like.graded_monoid A] : (⨁ i, A i) →ₐ[S] R :=
+  (A : ι → submodule S R) [set_like.graded_monoid A] : (⨁ i, A i) →ₐ[S] R :=
 direct_sum.to_algebra S _ (λ i, (A i).subtype) rfl (λ _ _ _ _, rfl) (λ _, rfl)
 
 /-- The supremum of submodules that form a graded monoid is a subalgebra, and equal to the range of
-`direct_sum.submodule_coe_alg_hom`. -/
+`direct_sum.coe_alg_hom`. -/
 lemma submodule.supr_eq_to_submodule_range [add_monoid ι]
   [comm_semiring S] [semiring R] [algebra S R] (A : ι → submodule S R) [set_like.graded_monoid A] :
-  (⨆ i, A i) = (direct_sum.submodule_coe_alg_hom A).range.to_submodule :=
+  (⨆ i, A i) = (direct_sum.coe_alg_hom A).range.to_submodule :=
 (submodule.supr_eq_range_dfinsupp_lsum A).trans $ set_like.coe_injective rfl
 
-@[simp] lemma direct_sum.submodule_coe_alg_hom_of [add_monoid ι]
+@[simp] lemma direct_sum.coe_alg_hom_of [add_monoid ι]
   [comm_semiring S] [semiring R] [algebra S R]
-  (A : ι → submodule S R) [h : set_like.graded_monoid A] (i : ι) (x : A i) :
-  direct_sum.submodule_coe_alg_hom A (direct_sum.of (λ i, A i) i x) = x :=
+  (A : ι → submodule S R) [set_like.graded_monoid A] (i : ι) (x : A i) :
+  direct_sum.coe_alg_hom A (direct_sum.of (λ i, A i) i x) = x :=
 direct_sum.to_semiring_of _ rfl (λ _ _ _ _, rfl) _ _
-
-lemma direct_sum.coe_mul_apply_submodule [add_monoid ι]
-  [comm_semiring S] [semiring R] [algebra S R]
-  (A : ι → submodule S R) [Π (i : ι) (x : A i), decidable (x ≠ 0)]
-  [set_like.graded_monoid A] (r r' : ⨁ i, A i) (i : ι) :
-  ((r * r') i : R) =
-    ∑ ij in finset.filter (λ ij : ι × ι, ij.1 + ij.2 = i) (r.support.product r'.support),
-      r ij.1 * r' ij.2 :=
-begin
-  rw [direct_sum.mul_eq_sum_support_ghas_mul, dfinsupp.finset_sum_apply, submodule.coe_sum],
-  simp_rw [direct_sum.coe_of_submodule_apply, ←finset.sum_filter, set_like.coe_ghas_mul],
-end
 
 end direct_sum
 

--- a/src/algebra/direct_sum/module.lean
+++ b/src/algebra/direct_sum/module.lean
@@ -14,10 +14,11 @@ construction of the direct sum using the universal property and proves its uniqu
 (`direct_sum.to_module.unique`).
 
 The second part of the file covers the special case of direct sums of submodules of a fixed module
-`M`.  There is a canonical linear map from this direct sum to `M`, and the construction is
-of particular importance when this linear map is an equivalence; that is, when the submodules
-provide an internal decomposition of `M`.  The property is defined as
-`direct_sum.submodule_is_internal`, and its basic consequences are established.
+`M`.  There is a canonical linear map from this direct sum to `M` (`direct_sum.coe_linear_map`), and the
+construction is of particular importance when this linear map is an equivalence; that is, when the
+submodules provide an internal decomposition of `M`.  The property is defined more generally
+elsewhere as `direct_sum.is_internal`, but its basic consequences on `submodule`s are established
+in this file.
 
 -/
 
@@ -258,60 +259,41 @@ variables {M : Type*} [add_comm_monoid M] [module R M]
 variables (A : ι → submodule R M)
 
 /-- The canonical embedding from `⨁ i, A i` to `M`  where `A` is a collection of `submodule R M`
-indexed by `ι`-/
-def submodule_coe : (⨁ i, A i) →ₗ[R] M := to_module R ι M (λ i, (A i).subtype)
+indexed by `ι`. This is `direct_sum.coe_add_monoid_hom` as a `linear_map`. -/
+def coe_linear_map : (⨁ i, A i) →ₗ[R] M := to_module R ι M (λ i, (A i).subtype)
 
-@[simp] lemma submodule_coe_of (i : ι) (x : A i) : submodule_coe A (of (λ i, A i) i x) = x :=
+@[simp] lemma coe_linear_map_of (i : ι) (x : A i) : direct_sum.coe_linear_map A (of (λ i, A i) i x) = x :=
 to_add_monoid_of _ _ _
-
-lemma coe_of_submodule_apply (i j : ι) (x : A i) :
-  (direct_sum.of _ i x j : M) = if i = j then x else 0 :=
-begin
-  obtain rfl | h := decidable.eq_or_ne i j,
-  { rw [direct_sum.of_eq_same, if_pos rfl], },
-  { rw [direct_sum.of_eq_of_ne _ _ _ _ h, if_neg h, submodule.coe_zero], },
-end
-
-/-- The `direct_sum` formed by a collection of `submodule`s of `M` is said to be internal if the
-canonical map `(⨁ i, A i) →ₗ[R] M` is bijective.
-
-For the alternate statement in terms of independence and spanning, see
-`direct_sum.submodule_is_internal_iff_independent_and_supr_eq_top`. -/
-def submodule_is_internal : Prop := function.bijective (submodule_coe A)
-
-lemma submodule_is_internal.to_add_submonoid :
-  submodule_is_internal A ↔ add_submonoid_is_internal (λ i, (A i).to_add_submonoid) :=
-iff.rfl
 
 variables {A}
 
 /-- If a direct sum of submodules is internal then the submodules span the module. -/
-lemma submodule_is_internal.supr_eq_top (h : submodule_is_internal A) : supr A = ⊤ :=
+lemma is_internal.submodule_supr_eq_top (h : is_internal A) : supr A = ⊤ :=
 begin
   rw [submodule.supr_eq_range_dfinsupp_lsum, linear_map.range_eq_top],
   exact function.bijective.surjective h,
 end
 
 /-- If a direct sum of submodules is internal then the submodules are independent. -/
-lemma submodule_is_internal.independent (h : submodule_is_internal A) :
+lemma is_internal.submodule_independent (h : is_internal A) :
   complete_lattice.independent A :=
 complete_lattice.independent_of_dfinsupp_lsum_injective _ h.injective
 
 /-- Given an internal direct sum decomposition of a module `M`, and a basis for each of the
 components of the direct sum, the disjoint union of these bases is a basis for `M`. -/
-noncomputable def submodule_is_internal.collected_basis
-  (h : submodule_is_internal A) {α : ι → Type*} (v : Π i, basis (α i) R (A i)) :
+noncomputable def is_internal.collected_basis
+  (h : is_internal A) {α : ι → Type*} (v : Π i, basis (α i) R (A i)) :
   basis (Σ i, α i) R M :=
-{ repr := (linear_equiv.of_bijective _ h.injective h.surjective).symm ≪≫ₗ
+{ repr := (linear_equiv.of_bijective (direct_sum.coe_linear_map A) h.injective h.surjective).symm ≪≫ₗ
       (dfinsupp.map_range.linear_equiv (λ i, (v i).repr)) ≪≫ₗ
       (sigma_finsupp_lequiv_dfinsupp R).symm }
 
-@[simp] lemma submodule_is_internal.collected_basis_coe
-  (h : submodule_is_internal A) {α : ι → Type*} (v : Π i, basis (α i) R (A i)) :
+@[simp] lemma is_internal.collected_basis_coe
+  (h : is_internal A) {α : ι → Type*} (v : Π i, basis (α i) R (A i)) :
   ⇑(h.collected_basis v) = λ a : Σ i, (α i), ↑(v a.1 a.2) :=
 begin
   funext a,
-  simp only [submodule_is_internal.collected_basis, to_module, submodule_coe,
+  simp only [is_internal.collected_basis, to_module, coe_linear_map,
     add_equiv.to_fun_eq_coe, basis.coe_of_repr, basis.repr_symm_apply, dfinsupp.lsum_apply_apply,
     dfinsupp.map_range.linear_equiv_apply, dfinsupp.map_range.linear_equiv_symm,
     dfinsupp.map_range_single, finsupp.total_single, linear_equiv.of_bijective_apply,
@@ -321,17 +303,17 @@ begin
   convert dfinsupp.sum_add_hom_single (λ i, (A i).subtype.to_add_monoid_hom) a.1 (v a.1 a.2),
 end
 
-lemma submodule_is_internal.collected_basis_mem
-  (h : submodule_is_internal A) {α : ι → Type*} (v : Π i, basis (α i) R (A i)) (a : Σ i, α i) :
+lemma is_internal.collected_basis_mem
+  (h : is_internal A) {α : ι → Type*} (v : Π i, basis (α i) R (A i)) (a : Σ i, α i) :
   h.collected_basis v a ∈ A a.1 :=
 by simp
 
-/-- When indexed by only two distinct elements, `direct_sum.submodule_is_internal` implies
+/-- When indexed by only two distinct elements, `direct_sum.is_internal` implies
 the two submodules are complementary. Over a `ring R`, this is true as an iff, as
-`direct_sum.submodule_is_internal_iff_is_compl`. --/
-lemma submodule_is_internal.is_compl {A : ι → submodule R M} {i j : ι} (hij : i ≠ j)
-  (h : (set.univ : set ι) = {i, j}) (hi : submodule_is_internal A) : is_compl (A i) (A j) :=
-⟨hi.independent.pairwise_disjoint _ _ hij, eq.le $ hi.supr_eq_top.symm.trans $
+`direct_sum.is_internal_iff_is_compl`. --/
+lemma is_internal.is_compl {A : ι → submodule R M} {i j : ι} (hij : i ≠ j)
+  (h : (set.univ : set ι) = {i, j}) (hi : is_internal A) : is_compl (A i) (A j) :=
+⟨hi.submodule_independent.pairwise_disjoint _ _ hij, eq.le $ hi.submodule_supr_eq_top.symm.trans $
   by rw [←Sup_pair, supr, ←set.image_univ, h, set.image_insert_eq, set.image_singleton]⟩
 
 end semiring
@@ -342,33 +324,29 @@ variables {ι : Type v} [dec_ι : decidable_eq ι]
 include dec_ι
 variables {M : Type*} [add_comm_group M] [module R M]
 
-lemma submodule_is_internal.to_add_subgroup (A : ι → submodule R M) :
-  submodule_is_internal A ↔ add_subgroup_is_internal (λ i, (A i).to_add_subgroup) :=
-iff.rfl
-
 /-- Note that this is not generally true for `[semiring R]`; see
 `complete_lattice.independent.dfinsupp_lsum_injective` for details. -/
-lemma submodule_is_internal_of_independent_of_supr_eq_top {A : ι → submodule R M}
-  (hi : complete_lattice.independent A) (hs : supr A = ⊤) : submodule_is_internal A :=
+lemma is_internal_submodule_of_independent_of_supr_eq_top {A : ι → submodule R M}
+  (hi : complete_lattice.independent A) (hs : supr A = ⊤) : is_internal A :=
 ⟨hi.dfinsupp_lsum_injective, linear_map.range_eq_top.1 $
   (submodule.supr_eq_range_dfinsupp_lsum _).symm.trans hs⟩
 
-/-- `iff` version of `direct_sum.submodule_is_internal_of_independent_of_supr_eq_top`,
-`direct_sum.submodule_is_internal.independent`, and `direct_sum.submodule_is_internal.supr_eq_top`.
+/-- `iff` version of `direct_sum.is_internal_submodule_of_independent_of_supr_eq_top`,
+`direct_sum.is_internal.independent`, and `direct_sum.is_internal.supr_eq_top`.
 -/
-lemma submodule_is_internal_iff_independent_and_supr_eq_top (A : ι → submodule R M) :
-    submodule_is_internal A ↔ complete_lattice.independent A ∧ supr A = ⊤ :=
-⟨λ i, ⟨i.independent, i.supr_eq_top⟩,
- and.rec submodule_is_internal_of_independent_of_supr_eq_top⟩
+lemma is_internal_submodule_iff_independent_and_supr_eq_top (A : ι → submodule R M) :
+    is_internal A ↔ complete_lattice.independent A ∧ supr A = ⊤ :=
+⟨λ i, ⟨i.submodule_independent, i.submodule_supr_eq_top⟩,
+ and.rec is_internal_submodule_of_independent_of_supr_eq_top⟩
 
 /-- If a collection of submodules has just two indices, `i` and `j`, then
-`direct_sum.submodule_is_internal` is equivalent to `is_compl`. -/
-lemma submodule_is_internal_iff_is_compl (A : ι → submodule R M) {i j : ι} (hij : i ≠ j)
+`direct_sum.is_internal` is equivalent to `is_compl`. -/
+lemma is_internal_submodule_iff_is_compl (A : ι → submodule R M) {i j : ι} (hij : i ≠ j)
   (h : (set.univ : set ι) = {i, j}) :
-  submodule_is_internal A ↔ is_compl (A i) (A j) :=
+  is_internal A ↔ is_compl (A i) (A j) :=
 begin
   have : ∀ k, k = i ∨ k = j := λ k, by simpa using set.ext_iff.mp h k,
-  rw [submodule_is_internal_iff_independent_and_supr_eq_top,
+  rw [is_internal_submodule_iff_independent_and_supr_eq_top,
     supr, ←set.image_univ, h, set.image_insert_eq, set.image_singleton, Sup_pair,
     complete_lattice.independent_pair hij this],
   exact ⟨λ ⟨hd, ht⟩, ⟨hd, ht.ge⟩, λ ⟨hd, ht⟩, ⟨hd, eq_top_iff.mpr ht⟩⟩,
@@ -376,13 +354,13 @@ end
 
 /-! Now copy the lemmas for subgroup and submonoids. -/
 
-lemma add_submonoid_is_internal.independent {M : Type*} [add_comm_monoid M]
-  {A : ι → add_submonoid M} (h : add_submonoid_is_internal A) :
+lemma is_internal.add_submonoid_independent {M : Type*} [add_comm_monoid M]
+  {A : ι → add_submonoid M} (h : is_internal A) :
   complete_lattice.independent A :=
 complete_lattice.independent_of_dfinsupp_sum_add_hom_injective _ h.injective
 
-lemma add_subgroup_is_internal.independent {M : Type*} [add_comm_group M]
-  {A : ι → add_subgroup M} (h : add_subgroup_is_internal A) :
+lemma is_internal.add_subgroup_independent {M : Type*} [add_comm_group M]
+  {A : ι → add_subgroup M} (h : is_internal A) :
   complete_lattice.independent A :=
 complete_lattice.independent_of_dfinsupp_sum_add_hom_injective' _ h.injective
 

--- a/src/algebra/direct_sum/module.lean
+++ b/src/algebra/direct_sum/module.lean
@@ -262,7 +262,8 @@ variables (A : ι → submodule R M)
 indexed by `ι`. This is `direct_sum.coe_add_monoid_hom` as a `linear_map`. -/
 def coe_linear_map : (⨁ i, A i) →ₗ[R] M := to_module R ι M (λ i, (A i).subtype)
 
-@[simp] lemma coe_linear_map_of (i : ι) (x : A i) : direct_sum.coe_linear_map A (of (λ i, A i) i x) = x :=
+@[simp] lemma coe_linear_map_of (i : ι) (x : A i) :
+  direct_sum.coe_linear_map A (of (λ i, A i) i x) = x :=
 to_add_monoid_of _ _ _
 
 variables {A}
@@ -284,7 +285,8 @@ components of the direct sum, the disjoint union of these bases is a basis for `
 noncomputable def is_internal.collected_basis
   (h : is_internal A) {α : ι → Type*} (v : Π i, basis (α i) R (A i)) :
   basis (Σ i, α i) R M :=
-{ repr := (linear_equiv.of_bijective (direct_sum.coe_linear_map A) h.injective h.surjective).symm ≪≫ₗ
+{ repr :=
+    (linear_equiv.of_bijective (direct_sum.coe_linear_map A) h.injective h.surjective).symm ≪≫ₗ
       (dfinsupp.map_range.linear_equiv (λ i, (v i).repr)) ≪≫ₗ
       (sigma_finsupp_lequiv_dfinsupp R).symm }
 

--- a/src/algebra/direct_sum/module.lean
+++ b/src/algebra/direct_sum/module.lean
@@ -14,9 +14,9 @@ construction of the direct sum using the universal property and proves its uniqu
 (`direct_sum.to_module.unique`).
 
 The second part of the file covers the special case of direct sums of submodules of a fixed module
-`M`.  There is a canonical linear map from this direct sum to `M` (`direct_sum.coe_linear_map`), and the
-construction is of particular importance when this linear map is an equivalence; that is, when the
-submodules provide an internal decomposition of `M`.  The property is defined more generally
+`M`.  There is a canonical linear map from this direct sum to `M` (`direct_sum.coe_linear_map`), and
+the construction is of particular importance when this linear map is an equivalence; that is, when
+the submodules provide an internal decomposition of `M`.  The property is defined more generally
 elsewhere as `direct_sum.is_internal`, but its basic consequences on `submodule`s are established
 in this file.
 

--- a/src/algebra/graded_monoid.lean
+++ b/src/algebra/graded_monoid.lean
@@ -69,7 +69,7 @@ provides the `Prop` typeclasses:
 Strictly this last class is unecessary as it has no fields not present in its parents, but it is
 included for convenience. Note that there is no need for `graded_ring` or similar, as all the
 information it would contain is already supplied by `graded_monoid` when `A` is a collection
-of additively-closed set_like objects such as `submodules`. These constructions are explored in
+of additively-closed set_like objects such as `submodule`s. These constructions are explored in
 `algebra.direct_sum.internal`.
 
 This file also contains the definition of `set_like.homogeneous_submonoid A`, which is, as the name

--- a/src/algebra/module/torsion.lean
+++ b/src/algebra/module/torsion.lean
@@ -291,8 +291,8 @@ include hp
 /--If the `p i` are pairwise coprime, a `∏ i, p i`-torsion module is the internal direct sum of
 its `p i`-torsion submodules.-/
 lemma torsion_is_internal [decidable_eq ι] (hM : torsion_by R M (∏ i in S, p i) = ⊤) :
-  direct_sum.submodule_is_internal (λ i : S, torsion_by R M (p i)) :=
-direct_sum.submodule_is_internal_of_independent_of_supr_eq_top
+  direct_sum.is_internal (λ i : S, torsion_by R M (p i)) :=
+direct_sum.is_internal_submodule_of_independent_of_supr_eq_top
   (torsion_by_independent hp) (by { rw ← hM, exact supr_torsion_by_eq_torsion_by_prod hp})
 
 end submodule

--- a/src/algebra/monoid_algebra/grading.lean
+++ b/src/algebra/monoid_algebra/grading.lean
@@ -202,11 +202,11 @@ lemma grade.decompose_single (i : ι) (r : R) :
 decompose_aux_single _ _ _
 
 /-- `add_monoid_algebra.gradesby` describe an internally graded algebra -/
-lemma grade_by.is_internal : direct_sum.submodule_is_internal (grade_by R f) :=
+lemma grade_by.is_internal : direct_sum.is_internal (grade_by R f) :=
 graded_algebra.is_internal _
 
 /-- `add_monoid_algebra.grades` describe an internally graded algebra -/
-lemma grade.is_internal : direct_sum.submodule_is_internal (grade R : ι → submodule R _) :=
+lemma grade.is_internal : direct_sum.is_internal (grade R : ι → submodule R _) :=
 graded_algebra.is_internal _
 
 end add_monoid_algebra

--- a/src/algebra/monoid_algebra/grading.lean
+++ b/src/algebra/monoid_algebra/grading.lean
@@ -178,7 +178,7 @@ graded_algebra.of_alg_hom _
   (begin
     ext : 2,
     dsimp,
-    rw [decompose_aux_single, direct_sum.submodule_coe_alg_hom_of, subtype.coe_mk],
+    rw [decompose_aux_single, direct_sum.coe_alg_hom_of, subtype.coe_mk],
   end)
   (λ i x, by convert (decompose_aux_coe f x : _))
 

--- a/src/analysis/inner_product_space/basic.lean
+++ b/src/analysis/inner_product_space/basic.lean
@@ -1989,9 +1989,9 @@ begin
 end
 
 include dec_ι
-lemma direct_sum.submodule_is_internal.collected_basis_orthonormal {V : ι → submodule 𝕜 E}
+lemma direct_sum.is_internal.collected_basis_orthonormal {V : ι → submodule 𝕜 E}
   (hV : @orthogonal_family 𝕜 _ _ _ _ (λ i, V i) _ (λ i, (V i).subtypeₗᵢ))
-  (hV_sum : direct_sum.submodule_is_internal (λ i, V i))
+  (hV_sum : direct_sum.is_internal (λ i, V i))
   {α : ι → Type*}
   {v_family : Π i, basis (α i) 𝕜 (V i)} (hv_family : ∀ i, orthonormal 𝕜 (v_family i)) :
   orthonormal 𝕜 (hV_sum.collected_basis v_family) :=

--- a/src/analysis/inner_product_space/pi_L2.lean
+++ b/src/analysis/inner_product_space/pi_L2.lean
@@ -120,7 +120,7 @@ def direct_sum.is_internal.isometry_L2_of_orthogonal_family
   E ≃ₗᵢ[𝕜] pi_Lp 2 (λ i, V i) :=
 begin
   let e₁ := direct_sum.linear_equiv_fun_on_fintype 𝕜 ι (λ i, V i),
-  let e₂ := linear_equiv.of_bijective _ hV.injective hV.surjective,
+  let e₂ := linear_equiv.of_bijective (direct_sum.coe_linear_map V) hV.injective hV.surjective,
   refine (e₂.symm.trans e₁).isometry_of_inner _,
   suffices : ∀ v w, ⟪v, w⟫ = ⟪e₂ (e₁.symm v), e₂ (e₁.symm w)⟫,
   { intros v₀ w₀,
@@ -140,11 +140,11 @@ end
 begin
   classical,
   let e₁ := direct_sum.linear_equiv_fun_on_fintype 𝕜 ι (λ i, V i),
-  let e₂ := linear_equiv.of_bijective _ hV.injective hV.surjective,
+  let e₂ := linear_equiv.of_bijective (direct_sum.coe_linear_map V) hV.injective hV.surjective,
   suffices : ∀ v : ⨁ i, V i, e₂ v = ∑ i, e₁ v i,
   { exact this (e₁.symm w) },
   intros v,
-  simp [e₂, direct_sum.submodule_coe, direct_sum.to_module, dfinsupp.sum_add_hom_apply]
+  simp [e₂, direct_sum.coe_linear_map, direct_sum.to_module, dfinsupp.sum_add_hom_apply]
 end
 
 end

--- a/src/analysis/inner_product_space/pi_L2.lean
+++ b/src/analysis/inner_product_space/pi_L2.lean
@@ -114,8 +114,8 @@ lemma finrank_euclidean_space_fin {n : ℕ} :
 
 /-- A finite, mutually orthogonal family of subspaces of `E`, which span `E`, induce an isometry
 from `E` to `pi_Lp 2` of the subspaces equipped with the `L2` inner product. -/
-def direct_sum.submodule_is_internal.isometry_L2_of_orthogonal_family
-  [decidable_eq ι] {V : ι → submodule 𝕜 E} (hV : direct_sum.submodule_is_internal V)
+def direct_sum.is_internal.isometry_L2_of_orthogonal_family
+  [decidable_eq ι] {V : ι → submodule 𝕜 E} (hV : direct_sum.is_internal V)
   (hV' : @orthogonal_family 𝕜 _ _ _ _ (λ i, V i) _ (λ i, (V i).subtypeₗᵢ)) :
   E ≃ₗᵢ[𝕜] pi_Lp 2 (λ i, V i) :=
 begin
@@ -132,8 +132,8 @@ begin
   { congr; simp }
 end
 
-@[simp] lemma direct_sum.submodule_is_internal.isometry_L2_of_orthogonal_family_symm_apply
-  [decidable_eq ι] {V : ι → submodule 𝕜 E} (hV : direct_sum.submodule_is_internal V)
+@[simp] lemma direct_sum.is_internal.isometry_L2_of_orthogonal_family_symm_apply
+  [decidable_eq ι] {V : ι → submodule 𝕜 E} (hV : direct_sum.is_internal V)
   (hV' : @orthogonal_family 𝕜 _ _ _ _ (λ i, V i) _ (λ i, (V i).subtypeₗᵢ))
   (w : pi_Lp 2 (λ i, V i)) :
   (hV.isometry_L2_of_orthogonal_family hV').symm w = ∑ i, (w i : E) :=

--- a/src/analysis/inner_product_space/projection.lean
+++ b/src/analysis/inner_product_space/projection.lean
@@ -1021,28 +1021,28 @@ end orthogonal
 section orthogonal_family
 variables {ι : Type*}
 
-/-- An orthogonal family of subspaces of `E` satisfies `direct_sum.submodule_is_internal` (that is,
+/-- An orthogonal family of subspaces of `E` satisfies `direct_sum.is_internal` (that is,
 they provide an internal direct sum decomposition of `E`) if and only if their span has trivial
 orthogonal complement. -/
-lemma orthogonal_family.submodule_is_internal_iff_of_is_complete [decidable_eq ι]
+lemma orthogonal_family.is_internal_submodule_iff_of_is_complete [decidable_eq ι]
   {V : ι → submodule 𝕜 E} (hV : @orthogonal_family 𝕜 _ _ _ _ (λ i, V i) _ (λ i, (V i).subtypeₗᵢ))
   (hc : is_complete (↑(supr V) : set E)) :
-  direct_sum.submodule_is_internal V ↔ (supr V)ᗮ = ⊥ :=
+  direct_sum.is_internal V ↔ (supr V)ᗮ = ⊥ :=
 begin
   haveI : complete_space ↥(supr V) := hc.complete_space_coe,
-  simp only [direct_sum.submodule_is_internal_iff_independent_and_supr_eq_top, hV.independent,
+  simp only [direct_sum.is_internal_submodule_iff_independent_and_supr_eq_top, hV.independent,
     true_and, submodule.orthogonal_eq_bot_iff]
 end
 
-/-- An orthogonal family of subspaces of `E` satisfies `direct_sum.submodule_is_internal` (that is,
+/-- An orthogonal family of subspaces of `E` satisfies `direct_sum.is_internal` (that is,
 they provide an internal direct sum decomposition of `E`) if and only if their span has trivial
 orthogonal complement. -/
-lemma orthogonal_family.submodule_is_internal_iff [decidable_eq ι] [finite_dimensional 𝕜 E]
+lemma orthogonal_family.is_internal_iff [decidable_eq ι] [finite_dimensional 𝕜 E]
   {V : ι → submodule 𝕜 E} (hV : @orthogonal_family 𝕜 _ _ _ _ (λ i, V i) _ (λ i, (V i).subtypeₗᵢ)) :
-  direct_sum.submodule_is_internal V ↔ (supr V)ᗮ = ⊥ :=
+  direct_sum.is_internal V ↔ (supr V)ᗮ = ⊥ :=
 begin
   haveI h := finite_dimensional.proper_is_R_or_C 𝕜 ↥(supr V),
-  exact hV.submodule_is_internal_iff_of_is_complete
+  exact hV.is_internal_submodule_iff_of_is_complete
     (complete_space_coe_iff_is_complete.mp infer_instance)
 end
 
@@ -1196,18 +1196,18 @@ by { simp only [fin_std_orthonormal_basis, basis.coe_reindex], assumption }, -- 
 section subordinate_orthonormal_basis
 open direct_sum
 variables {n : ℕ} (hn : finrank 𝕜 E = n) {ι : Type*} [fintype ι] [decidable_eq ι]
-  {V : ι → submodule 𝕜 E} (hV : submodule_is_internal V)
+  {V : ι → submodule 𝕜 E} (hV : is_internal V)
 
 /-- Exhibit a bijection between `fin n` and the index set of a certain basis of an `n`-dimensional
 inner product space `E`.  This should not be accessed directly, but only via the subsequent API. -/
-@[irreducible] def direct_sum.submodule_is_internal.sigma_orthonormal_basis_index_equiv :
+@[irreducible] def direct_sum.is_internal.sigma_orthonormal_basis_index_equiv :
   (Σ i, orthonormal_basis_index 𝕜 (V i)) ≃ fin n :=
 let b := hV.collected_basis (λ i, std_orthonormal_basis 𝕜 (V i)) in
 fintype.equiv_fin_of_card_eq $ (finite_dimensional.finrank_eq_card_basis b).symm.trans hn
 
 /-- An `n`-dimensional `inner_product_space` equipped with a decomposition as an internal direct
 sum has an orthonormal basis indexed by `fin n` and subordinate to that direct sum. -/
-@[irreducible] def direct_sum.submodule_is_internal.subordinate_orthonormal_basis :
+@[irreducible] def direct_sum.is_internal.subordinate_orthonormal_basis :
   basis (fin n) 𝕜 E :=
 (hV.collected_basis (λ i, std_orthonormal_basis 𝕜 (V i))).reindex
   (hV.sigma_orthonormal_basis_index_equiv hn)
@@ -1215,15 +1215,15 @@ sum has an orthonormal basis indexed by `fin n` and subordinate to that direct s
 /-- An `n`-dimensional `inner_product_space` equipped with a decomposition as an internal direct
 sum has an orthonormal basis indexed by `fin n` and subordinate to that direct sum. This function
 provides the mapping by which it is subordinate. -/
-def direct_sum.submodule_is_internal.subordinate_orthonormal_basis_index (a : fin n) : ι :=
+def direct_sum.is_internal.subordinate_orthonormal_basis_index (a : fin n) : ι :=
 ((hV.sigma_orthonormal_basis_index_equiv hn).symm a).1
 
 /-- The basis constructed in `orthogonal_family.subordinate_orthonormal_basis` is orthonormal. -/
-lemma direct_sum.submodule_is_internal.subordinate_orthonormal_basis_orthonormal
+lemma direct_sum.is_internal.subordinate_orthonormal_basis_orthonormal
   (hV' : @orthogonal_family 𝕜 _ _ _ _ (λ i, V i) _ (λ i, (V i).subtypeₗᵢ)) :
   orthonormal 𝕜 (hV.subordinate_orthonormal_basis hn) :=
 begin
-  simp only [direct_sum.submodule_is_internal.subordinate_orthonormal_basis, basis.coe_reindex],
+  simp only [direct_sum.is_internal.subordinate_orthonormal_basis, basis.coe_reindex],
   have : orthonormal 𝕜 (hV.collected_basis (λ i, std_orthonormal_basis 𝕜 (V i))) :=
     hV.collected_basis_orthonormal hV' (λ i, std_orthonormal_basis_orthonormal 𝕜 (V i)),
   exact this.comp _ (equiv.injective _),
@@ -1231,13 +1231,13 @@ end
 
 /-- The basis constructed in `orthogonal_family.subordinate_orthonormal_basis` is subordinate to
 the `orthogonal_family` in question. -/
-lemma direct_sum.submodule_is_internal.subordinate_orthonormal_basis_subordinate (a : fin n) :
+lemma direct_sum.is_internal.subordinate_orthonormal_basis_subordinate (a : fin n) :
   hV.subordinate_orthonormal_basis hn a ∈ V (hV.subordinate_orthonormal_basis_index hn a) :=
-by simpa only [direct_sum.submodule_is_internal.subordinate_orthonormal_basis, basis.coe_reindex]
+by simpa only [direct_sum.is_internal.subordinate_orthonormal_basis, basis.coe_reindex]
   using hV.collected_basis_mem (λ i, std_orthonormal_basis 𝕜 (V i))
     ((hV.sigma_orthonormal_basis_index_equiv hn).symm a)
 
-attribute [irreducible] direct_sum.submodule_is_internal.subordinate_orthonormal_basis_index
+attribute [irreducible] direct_sum.is_internal.subordinate_orthonormal_basis_index
 
 end subordinate_orthonormal_basis
 

--- a/src/analysis/inner_product_space/projection.lean
+++ b/src/analysis/inner_product_space/projection.lean
@@ -1024,7 +1024,7 @@ variables {ι : Type*}
 /-- An orthogonal family of subspaces of `E` satisfies `direct_sum.is_internal` (that is,
 they provide an internal direct sum decomposition of `E`) if and only if their span has trivial
 orthogonal complement. -/
-lemma orthogonal_family.is_internal_submodule_iff_of_is_complete [decidable_eq ι]
+lemma orthogonal_family.is_internal_iff_of_is_complete [decidable_eq ι]
   {V : ι → submodule 𝕜 E} (hV : @orthogonal_family 𝕜 _ _ _ _ (λ i, V i) _ (λ i, (V i).subtypeₗᵢ))
   (hc : is_complete (↑(supr V) : set E)) :
   direct_sum.is_internal V ↔ (supr V)ᗮ = ⊥ :=
@@ -1042,7 +1042,7 @@ lemma orthogonal_family.is_internal_iff [decidable_eq ι] [finite_dimensional �
   direct_sum.is_internal V ↔ (supr V)ᗮ = ⊥ :=
 begin
   haveI h := finite_dimensional.proper_is_R_or_C 𝕜 ↥(supr V),
-  exact hV.is_internal_submodule_iff_of_is_complete
+  exact hV.is_internal_iff_of_is_complete
     (complete_space_coe_iff_is_complete.mp infer_instance)
 end
 

--- a/src/analysis/inner_product_space/spectrum.lean
+++ b/src/analysis/inner_product_space/spectrum.lean
@@ -134,9 +134,9 @@ include dec_𝕜
 
 /-- The eigenspaces of a self-adjoint operator on a finite-dimensional inner product space `E` give
 an internal direct sum decomposition of `E`. -/
-lemma direct_sum_submodule_is_internal :
-  direct_sum.submodule_is_internal (λ μ : eigenvalues T, eigenspace T μ) :=
-hT.orthogonal_family_eigenspaces'.submodule_is_internal_iff.mpr
+lemma direct_sum_is_internal :
+  direct_sum.is_internal (λ μ : eigenvalues T, eigenspace T μ) :=
+hT.orthogonal_family_eigenspaces'.is_internal_iff.mpr
   hT.orthogonal_supr_eigenspaces_eq_bot'
 
 section version1
@@ -144,12 +144,12 @@ section version1
 /-- Isometry from an inner product space `E` to the direct sum of the eigenspaces of some
 self-adjoint operator `T` on `E`. -/
 noncomputable def diagonalization : E ≃ₗᵢ[𝕜] pi_Lp 2 (λ μ : eigenvalues T, eigenspace T μ) :=
-hT.direct_sum_submodule_is_internal.isometry_L2_of_orthogonal_family
+hT.direct_sum_is_internal.isometry_L2_of_orthogonal_family
   hT.orthogonal_family_eigenspaces'
 
 @[simp] lemma diagonalization_symm_apply (w : pi_Lp 2 (λ μ : eigenvalues T, eigenspace T μ)) :
   hT.diagonalization.symm w = ∑ μ, w μ :=
-hT.direct_sum_submodule_is_internal.isometry_L2_of_orthogonal_family_symm_apply
+hT.direct_sum_is_internal.isometry_L2_of_orthogonal_family_symm_apply
   hT.orthogonal_family_eigenspaces' w
 
 /-- *Diagonalization theorem*, *spectral theorem*; version 1: A self-adjoint operator `T` on a
@@ -180,10 +180,10 @@ finite-dimensional inner product space `E`.
 TODO Postcompose with a permutation so that these eigenvectors are listed in increasing order of
 eigenvalue. -/
 noncomputable def eigenvector_basis : basis (fin n) 𝕜 E :=
-hT.direct_sum_submodule_is_internal.subordinate_orthonormal_basis hn
+hT.direct_sum_is_internal.subordinate_orthonormal_basis hn
 
 lemma eigenvector_basis_orthonormal : orthonormal 𝕜 (hT.eigenvector_basis hn) :=
-hT.direct_sum_submodule_is_internal.subordinate_orthonormal_basis_orthonormal hn
+hT.direct_sum_is_internal.subordinate_orthonormal_basis_orthonormal hn
   hT.orthogonal_family_eigenspaces'
 
 /-- The sequence of real eigenvalues associated to the standard orthonormal basis of eigenvectors
@@ -191,17 +191,17 @@ for a self-adjoint operator `T` on `E`.
 
 TODO Postcompose with a permutation so that these eigenvalues are listed in increasing order. -/
 noncomputable def eigenvalues (i : fin n) : ℝ :=
-@is_R_or_C.re 𝕜 _ $ hT.direct_sum_submodule_is_internal.subordinate_orthonormal_basis_index hn i
+@is_R_or_C.re 𝕜 _ $ hT.direct_sum_is_internal.subordinate_orthonormal_basis_index hn i
 
 lemma has_eigenvector_eigenvector_basis (i : fin n) :
   has_eigenvector T (hT.eigenvalues hn i) (hT.eigenvector_basis hn i) :=
 begin
   let v : E := hT.eigenvector_basis hn i,
-  let μ : 𝕜 := hT.direct_sum_submodule_is_internal.subordinate_orthonormal_basis_index hn i,
+  let μ : 𝕜 := hT.direct_sum_is_internal.subordinate_orthonormal_basis_index hn i,
   change has_eigenvector T (is_R_or_C.re μ) v,
   have key : has_eigenvector T μ v,
   { have H₁ : v ∈ eigenspace T μ,
-    { exact hT.direct_sum_submodule_is_internal.subordinate_orthonormal_basis_subordinate hn i },
+    { exact hT.direct_sum_is_internal.subordinate_orthonormal_basis_subordinate hn i },
     have H₂ : v ≠ 0 := (hT.eigenvector_basis_orthonormal hn).ne_zero i,
     exact ⟨H₁, H₂⟩ },
   have re_μ : ↑(is_R_or_C.re μ) = μ,

--- a/src/linear_algebra/clifford_algebra/grading.lean
+++ b/src/linear_algebra/clifford_algebra/grading.lean
@@ -84,7 +84,7 @@ end
 
 /-- The clifford algebra is graded by the even and odd parts. -/
 instance graded_algebra : graded_algebra (even_odd Q) :=
-graded_algebra.of_alg_hom _
+graded_algebra.of_alg_hom (even_odd Q)
   (lift _ $ ⟨graded_algebra.ι Q, graded_algebra.ι_sq_scalar Q⟩)
   -- the proof from here onward is mostly similar to the `tensor_algebra` case, with some extra
   -- handling for the `supr` in `even_odd`.
@@ -106,9 +106,9 @@ graded_algebra.of_alg_hom _
       { rw [alg_hom.map_add, ihx, ihy, ←map_add], refl },
       { obtain ⟨_, rfl⟩ := hm,
         rw [alg_hom.map_mul, ih, lift_ι_apply, graded_algebra.ι_apply, direct_sum.of_mul_of],
-        refine direct_sum.of_eq_of_graded_monoid_eq (sigma.subtype_ext _ _),
+        refine direct_sum.of_eq_of_graded_monoid_eq (sigma.subtype_ext _ _);
           dsimp only [graded_monoid.mk, subtype.coe_mk],
-        { rw [nat.succ_eq_add_one, add_comm], refl },
+        { rw [nat.succ_eq_add_one, add_comm, nat.cast_add, nat.cast_one] },
         refl } },
     { rw alg_hom.map_zero,
       apply eq.symm,
@@ -118,7 +118,7 @@ graded_algebra.of_alg_hom _
 
 lemma supr_ι_range_eq_top : (⨆ i : ℕ, (ι Q).range ^ i) = ⊤ :=
 begin
-  rw [← (graded_algebra.is_internal $ λ i, even_odd Q i).supr_eq_top, eq_comm],
+  rw [← (graded_algebra.is_internal $ λ i, even_odd Q i).submodule_supr_eq_top, eq_comm],
   dunfold even_odd,
   calc    (⨆ (i : zmod 2) (j : {n // ↑n = i}), (ι Q).range ^ ↑j)
         = (⨆ (i : Σ i : zmod 2, {n : ℕ // ↑n = i}), (ι Q).range ^ (i.2 : ℕ)) : by rw supr_sigma

--- a/src/linear_algebra/clifford_algebra/grading.lean
+++ b/src/linear_algebra/clifford_algebra/grading.lean
@@ -92,7 +92,7 @@ graded_algebra.of_alg_hom _
     ext m,
     dsimp only [linear_map.comp_apply, alg_hom.to_linear_map_apply, alg_hom.comp_apply,
       alg_hom.id_apply],
-    rw [lift_ι_apply, graded_algebra.ι_apply, direct_sum.submodule_coe_alg_hom_of, subtype.coe_mk],
+    rw [lift_ι_apply, graded_algebra.ι_apply, direct_sum.coe_alg_hom_of, subtype.coe_mk],
   end)
   (λ i' x', begin
     cases x' with x' hx',

--- a/src/linear_algebra/exterior_algebra/grading.lean
+++ b/src/linear_algebra/exterior_algebra/grading.lean
@@ -51,7 +51,7 @@ graded_algebra.of_alg_hom _
     ext m,
     dsimp only [linear_map.comp_apply, alg_hom.to_linear_map_apply, alg_hom.comp_apply,
       alg_hom.id_apply],
-    rw [lift_ι_apply, graded_algebra.ι_apply, direct_sum.submodule_coe_alg_hom_of, subtype.coe_mk],
+    rw [lift_ι_apply, graded_algebra.ι_apply, direct_sum.coe_alg_hom_of, subtype.coe_mk],
   end)
   (λ i x, begin
     cases x with x hx,

--- a/src/linear_algebra/tensor_algebra/grading.lean
+++ b/src/linear_algebra/tensor_algebra/grading.lean
@@ -42,7 +42,7 @@ graded_algebra.of_alg_hom _
     ext m,
     dsimp only [linear_map.comp_apply, alg_hom.to_linear_map_apply, alg_hom.comp_apply,
       alg_hom.id_apply],
-    rw [lift_ι_apply, graded_algebra.ι_apply, direct_sum.submodule_coe_alg_hom_of, subtype.coe_mk],
+    rw [lift_ι_apply, graded_algebra.ι_apply, direct_sum.coe_alg_hom_of, subtype.coe_mk],
   end)
   (λ i x, begin
     cases x with x hx,

--- a/src/ring_theory/graded_algebra/basic.lean
+++ b/src/ring_theory/graded_algebra/basic.lean
@@ -18,7 +18,7 @@ See the docstring of that typeclass for more information.
 ## Main definitions
 
 * `graded_algebra 𝒜`: the typeclass, which is a combination of `set_like.graded_monoid`, and
-  a constructive version of `direct_sum.submodule_is_internal 𝒜`.
+  a constructive version of `direct_sum.is_internal 𝒜`.
 * `graded_algebra.decompose : A ≃ₐ[R] ⨁ i, 𝒜 i`, which breaks apart an element of the algebra into
   its constituent pieces.
 * `graded_algebra.proj 𝒜 i` is the linear map from `A` to its degree `i : ι` component, such that
@@ -57,11 +57,10 @@ algebra structure `direct_sum.galgebra R (λ i, ↥(𝒜 i))`, which in turn mak
 
 class graded_algebra extends set_like.graded_monoid 𝒜 :=
 (decompose' : A → ⨁ i, 𝒜 i)
-(left_inv : function.left_inverse decompose' (direct_sum.submodule_coe 𝒜))
-(right_inv : function.right_inverse decompose' (direct_sum.submodule_coe 𝒜))
+(left_inv : function.left_inverse decompose' (direct_sum.coe_add_monoid_hom 𝒜))
+(right_inv : function.right_inverse decompose' (direct_sum.coe_add_monoid_hom 𝒜))
 
-lemma graded_algebra.is_internal [graded_algebra 𝒜] :
-  direct_sum.submodule_is_internal 𝒜 :=
+protected lemma graded_algebra.is_internal [graded_algebra 𝒜] : direct_sum.is_internal 𝒜 :=
 ⟨graded_algebra.left_inv.injective, graded_algebra.right_inv.surjective⟩
 
 /-- A helper to construct a `graded_algebra` when the `set_like.graded_monoid` structure is already
@@ -71,16 +70,16 @@ condition in a way that allows custom `@[ext]` lemmas to apply.
 See note [reducible non-instances]. -/
 @[reducible]
 def graded_algebra.of_alg_hom [set_like.graded_monoid 𝒜] (decompose : A →ₐ[R] ⨁ i, 𝒜 i)
-  (right_inv : (direct_sum.submodule_coe_alg_hom 𝒜).comp decompose = alg_hom.id R A)
+  (right_inv : (direct_sum.coe_alg_hom 𝒜).comp decompose = alg_hom.id R A)
   (left_inv : ∀ i (x : 𝒜 i), decompose (x : A) = direct_sum.of (λ i, ↥(𝒜 i)) i x) :
   graded_algebra 𝒜 :=
 { decompose' := decompose,
   right_inv := alg_hom.congr_fun right_inv,
   left_inv := begin
-    suffices : decompose.comp (direct_sum.submodule_coe_alg_hom 𝒜) = alg_hom.id _ _,
+    suffices : decompose.comp (direct_sum.coe_alg_hom 𝒜) = alg_hom.id _ _,
     from alg_hom.congr_fun this,
     ext i x : 2,
-    exact (decompose.congr_arg $ direct_sum.submodule_coe_alg_hom_of _ _ _).trans (left_inv i x),
+    exact (decompose.congr_arg $ direct_sum.coe_alg_hom_of _ _ _).trans (left_inv i x),
   end}
 
 variable [graded_algebra 𝒜]
@@ -88,7 +87,7 @@ variable [graded_algebra 𝒜]
 /-- If `A` is graded by `ι` with degree `i` component `𝒜 i`, then it is isomorphic as
 an algebra to a direct sum of components. -/
 def graded_algebra.decompose : A ≃ₐ[R] ⨁ i, 𝒜 i := alg_equiv.symm
-{ to_fun := direct_sum.submodule_coe_alg_hom 𝒜,
+{ to_fun := direct_sum.coe_alg_hom 𝒜,
   inv_fun := graded_algebra.decompose',
   left_inv := graded_algebra.left_inv,
   right_inv := graded_algebra.right_inv,
@@ -101,7 +100,7 @@ def graded_algebra.decompose : A ≃ₐ[R] ⨁ i, 𝒜 i := alg_equiv.symm
 
 @[simp] lemma graded_algebra.decompose_symm_of {i : ι} (x : 𝒜 i) :
   (graded_algebra.decompose 𝒜).symm (direct_sum.of _ i x) = x :=
-direct_sum.submodule_coe_alg_hom_of 𝒜 _ _
+direct_sum.coe_alg_hom_of 𝒜 _ _
 
 /-- The projection maps of graded algebra-/
 def graded_algebra.proj (𝒜 : ι → submodule R A) [graded_algebra 𝒜] (i : ι) : A →ₗ[R] A :=
@@ -179,7 +178,8 @@ def graded_algebra.proj_zero_ring_hom : A →+* A :=
   map_zero' := by simp only [subtype.ext_iff_val, map_zero, zero_apply, submodule.coe_zero],
   map_add' := λ _ _, by simp [subtype.ext_iff_val, map_add, add_apply, submodule.coe_add],
   map_mul' := λ x y,
-    have m : ∀ x, x ∈ supr 𝒜, from λ x, (is_internal 𝒜).supr_eq_top.symm ▸ submodule.mem_top,
+    have m : ∀ x, x ∈ supr 𝒜,
+    from λ x, (graded_algebra.is_internal 𝒜).submodule_supr_eq_top.symm ▸ submodule.mem_top,
     begin
     refine submodule.supr_induction 𝒜 (m x) (λ i c hc, _) _ _,
     { refine submodule.supr_induction 𝒜 (m y) (λ j c' hc', _) _ _,

--- a/src/ring_theory/graded_algebra/homogeneous_ideal.lean
+++ b/src/ring_theory/graded_algebra/homogeneous_ideal.lean
@@ -128,7 +128,7 @@ begin
   have mem₁ : (graded_algebra.decompose 𝒜 r k : A) * x ∈ 𝒜 (k + i) := graded_monoid.mul_mem
     (submodule.coe_mem _) hi,
   erw [graded_algebra.proj_apply, graded_algebra.decompose_of_mem 𝒜 mem₁,
-    coe_of_submodule_apply 𝒜, submodule.coe_mk],
+    coe_of_apply, submodule.coe_mk],
   split_ifs,
   { exact I.mul_mem_left _ hx₂ },
   { exact I.zero_mem },

--- a/src/ring_theory/graded_algebra/radical.lean
+++ b/src/ring_theory/graded_algebra/radical.lean
@@ -65,9 +65,9 @@ lemma ideal.is_homogeneous.is_prime_of_homogeneous_mem_or_mem
   This is a contradiction, because both `proj (max₁ + max₂) (x * y) ∈ I` and the sum on the
   right hand side is in `I` however `proj max₁ x * proj max₂ y` is not in `I`.
   -/
+  classical,
   letI : Π (x : A),
     decidable_pred (λ (i : ι), proj 𝒜 i x ∉ I) := λ x, classical.dec_pred _,
-  letI : Π i (x : 𝒜 i), decidable (x ≠ 0) := λ i x, classical.dec _,
   set set₁ := (support 𝒜 x).filter (λ i, proj 𝒜 i x ∉ I) with set₁_eq,
   set set₂ := (support 𝒜 y).filter (λ i, proj 𝒜 i y ∉ I) with set₂_eq,
   have nonempty : ∀ (x : A), (x ∉ I) → ((support 𝒜 x).filter (λ i, proj 𝒜 i x ∉ I)).nonempty,
@@ -91,7 +91,7 @@ lemma ideal.is_homogeneous.is_prime_of_homogeneous_mem_or_mem
     have eq_add_sum :=
       calc  proj 𝒜 (max₁ + max₂) (x * y)
           = ∑ ij in antidiag, proj 𝒜 ij.1 x * proj 𝒜 ij.2 y
-          : by simp_rw [ha, proj_apply, map_mul, support, direct_sum.coe_mul_apply_submodule]
+          : by simp_rw [ha, proj_apply, map_mul, support, direct_sum.coe_mul_apply 𝒜]
       ... = proj 𝒜 max₁ x * proj 𝒜 max₂ y + ∑ ij in antidiag.erase (max₁, max₂),
                                               proj 𝒜 ij.1 x * proj 𝒜 ij.2 y
           : (add_sum_erase _ _ mem_antidiag).symm,


### PR DESCRIPTION
This doesn't let us deduplicate the lattice lemmas, but does eliminate the duplicate instances and definitions!

This merges:

* `direct_sum.add_submonoid_is_internal`, `direct_sum.add_subgroup_is_internal`, `direct_sum.submodule_is_internal` into `direct_sum.is_internal`
* `direct_sum.add_submonoid_coe`, `direct_sum.add_subgroup_coe` into `direct_sum.coe_add_monoid_hom`
* `direct_sum.add_submonoid_coe_ring_hom`, `direct_sum.add_subgroup_coe_ring_hom` into `direct_sum.coe_ring_hom`
* `add_submonoid.gsemiring`, `add_subgroup.gsemiring`, `submodule.gsemiring` into `set_like.gsemiring`
* `add_submonoid.gcomm_semiring`, `add_subgroup.gcomm_semiring`, `submodule.gcomm_semiring` into `set_like.gcomm_semiring`

Renames

* `direct_sum.submodule_coe` into `direct_sum.coe_linear_map`
* `direct_sum.submodule_coe_alg_hom` into `direct_sum.coe_alg_hom

And adds:

* `set_like.gnon_unital_non_assoc_semiring`, now that it doesn't need to be repeated three times!

A large number of related lemmas are also renamed to match the new definition names.

This was what originally motivated the `set_like` typeclass; thanks to @Vierkantor for doing the subobject follow up I never got around to!

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->


[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
