### PR TITLE
[Merged by Bors] - fix(topology/vector_bundle): squeeze simp, remove non-terminal simp

### DIFF
--- a/src/topology/vector_bundle.lean
+++ b/src/topology/vector_bundle.lean
@@ -743,8 +743,7 @@ instance : topological_vector_bundle R F Z.fiber :=
       { simp only [base_set_at, local_triv_at_def, mem_inter_eq, mem_local_triv_at_base_set] at *,
         tauto },
       simp only [dif_pos, hb, Z.coord_change_comp _ _ _ _ this,
-        continuous_linear_equiv.equiv_of_inverse_apply, trivialization.coe_coe] with mfld_simps
-       }
+        continuous_linear_equiv.equiv_of_inverse_apply, trivialization.coe_coe] with mfld_simps }
   end }
 
 /-- The projection on the base of a topological vector bundle created from core is continuous -/

--- a/src/topology/vector_bundle.lean
+++ b/src/topology/vector_bundle.lean
@@ -726,23 +726,25 @@ instance : topological_vector_bundle R F Z.fiber :=
         (Z.coord_change i i' b) (Z.coord_change i' i b) _ _ else continuous_linear_equiv.refl R F,
       _, _⟩,
     { ext ⟨b, f⟩,
-      simp },
+      simp only with mfld_simps },
     { ext ⟨b, f⟩,
-      simp [and_comm] },
+      simp only [and_comm] with mfld_simps },
     { intro f,
       rw [Z.coord_change_comp _ _ _ _ ⟨h, h.1⟩, Z.coord_change_self _ _ h.1] },
     { intro f,
       rw [Z.coord_change_comp _ _ _ _ ⟨⟨h.2, h.1⟩, h.2⟩, Z.coord_change_self _ _ h.2] },
     { apply continuous_on.congr (Z.coord_change_continuous i i'),
       intros b hb,
-      simp [hb],
       ext v,
-      refl },
+      simp only [hb, dif_pos, continuous_linear_equiv.coe_coe,
+        continuous_linear_equiv.equiv_of_inverse_apply] with mfld_simps },
     { intros b hb v,
       have : b ∈ Z.base_set i ∩ Z.base_set (Z.index_at b) ∩ Z.base_set i',
       { simp only [base_set_at, local_triv_at_def, mem_inter_eq, mem_local_triv_at_base_set] at *,
         tauto },
-      simp [hb, Z.coord_change_comp _ _ _ _ this] }
+      simp only [dif_pos, hb, Z.coord_change_comp _ _ _ _ this,
+        continuous_linear_equiv.equiv_of_inverse_apply, trivialization.coe_coe] with mfld_simps
+       }
   end }
 
 /-- The projection on the base of a topological vector bundle created from core is continuous -/


### PR DESCRIPTION
For some reason I had to mention `trivialization.coe_coe` explicitly, even though it is in `mfld_simps` (maybe because another simp lemma would otherwise apply first?)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
