### PR TITLE
[Merged by Bors] - feat(data/list/of_fn): Add `list.of_fn_add` and `list.of_fn_mul`

### DIFF
--- a/src/data/list/join.lean
+++ b/src/data/list/join.lean
@@ -27,6 +27,9 @@ attribute [simp] join
 @[simp] lemma join_append (L₁ L₂ : list (list α)) : join (L₁ ++ L₂) = join L₁ ++ join L₂ :=
 by induction L₁; [refl, simp only [*, join, cons_append, append_assoc]]
 
+lemma join_concat (L : list (list α)) (l : list α) : join (L.concat l) = join L ++ l :=
+by simp
+
 @[simp] lemma join_filter_empty_eq_ff [decidable_pred (λ l : list α, l.empty = ff)] :
   ∀ {L : list (list α)}, join (L.filter (λ l, l.empty = ff)) = L.join
 | []              := rfl

--- a/src/data/list/of_fn.lean
+++ b/src/data/list/of_fn.lean
@@ -13,7 +13,7 @@ import data.list.join
 Theorems and lemmas for dealing with `list.of_fn`, which converts a function on `fin n` to a list
 of length `n`.
 
-## Main Statementss
+## Main Statements
 
 The main statements pertain to lists generated using `of_fn`
 

--- a/src/data/list/of_fn.lean
+++ b/src/data/list/of_fn.lean
@@ -88,6 +88,24 @@ begin
   rw [of_fn_aux, IH], refl
 end
 
+@[simp] lemma of_fn_add {m n} (f : fin (m + n) → α) :
+  list.of_fn f = list.of_fn (λ i, f (fin.cast_add n i)) ++ list.of_fn (λ j, f (fin.nat_add m j)) :=
+begin
+  -- There's probably a clever trick to prove this like `of_fn_succ`, but this required less insight
+  apply list.ext_le,
+  { rw [list.length_of_fn, list.length_append, list.length_of_fn, list.length_of_fn] },
+  intros n ha hb,
+  simp_rw list.nth_le_of_fn',
+  cases lt_or_le n m,
+  { rw [list.nth_le_append, list.nth_le_of_fn', fin.cast_add_mk],
+    rw list.length_of_fn, exact h },
+  { obtain ⟨n', rfl⟩ := nat.exists_eq_add_of_le h,
+    rw [list.nth_le_append_right, list.nth_le_of_fn'],
+    simp_rw [list.length_of_fn, add_tsub_cancel_left, fin.nat_add_mk],
+    rw list.length_of_fn,
+    exact h },
+end
+
 theorem of_fn_nth_le : ∀ l : list α, of_fn (λ i, nth_le l i i.2) = l
 | [] := rfl
 | (a::l) := by { rw of_fn_succ, congr, simp only [fin.coe_succ], exact of_fn_nth_le l }

--- a/src/data/list/of_fn.lean
+++ b/src/data/list/of_fn.lean
@@ -82,8 +82,7 @@ theorem of_fn_congr {m n : ℕ} (h : m = n) (f : fin m → α) :
   of_fn f = of_fn (λ i : fin n, f (fin.cast h.symm i)) :=
 begin
   subst h,
-  simp_rw fin.cast_refl,
-  refl,
+  simp_rw [fin.cast_refl, order_iso.refl_apply],
 end
 
 /-- `of_fn` on an empty domain is the empty list. -/

--- a/src/data/list/of_fn.lean
+++ b/src/data/list/of_fn.lean
@@ -13,9 +13,9 @@ import data.list.join
 Theorems and lemmas for dealing with `list.of_fn`, which converts a function on `fin n` to a list
 of length `n`.
 
-## Main Definitions
+## Main Statementss
 
-The main definitions pertain to lists generated using `of_fn`
+The main statements pertain to lists generated using `of_fn`
 
 - `list.length_of_fn`, which tells us the length of such a list
 - `list.nth_of_fn`, which tells us the nth element of such a list

--- a/src/data/list/of_fn.lean
+++ b/src/data/list/of_fn.lean
@@ -88,22 +88,23 @@ begin
   rw [of_fn_aux, IH], refl
 end
 
-@[simp] lemma of_fn_add {m n} (f : fin (m + n) → α) :
+theorem of_fn_succ' {n} (f : fin (succ n) → α) :
+  of_fn f = (of_fn (λ i, f i.cast_succ)).concat (f (fin.last _)) :=
+begin
+  induction n with n IH,
+  { rw [of_fn_zero, concat_nil, of_fn_succ, of_fn_zero], refl },
+  { rw [of_fn_succ, IH, of_fn_succ, concat_cons, fin.cast_succ_zero],
+    congr' 3,
+    simp_rw [fin.cast_succ_fin_succ], }
+end
+
+/-- Note this matches the convention of `list.of_fn_succ'`, putting the `fin m` elements first. -/
+theorem of_fn_add {m n} (f : fin (m + n) → α) :
   list.of_fn f = list.of_fn (λ i, f (fin.cast_add n i)) ++ list.of_fn (λ j, f (fin.nat_add m j)) :=
 begin
-  -- There's probably a clever trick to prove this like `of_fn_succ`, but this required less insight
-  apply list.ext_le,
-  { rw [list.length_of_fn, list.length_append, list.length_of_fn, list.length_of_fn] },
-  intros n ha hb,
-  simp_rw list.nth_le_of_fn',
-  cases lt_or_le n m,
-  { rw [list.nth_le_append, list.nth_le_of_fn', fin.cast_add_mk],
-    rw list.length_of_fn, exact h },
-  { obtain ⟨n', rfl⟩ := nat.exists_eq_add_of_le h,
-    rw [list.nth_le_append_right, list.nth_le_of_fn'],
-    simp_rw [list.length_of_fn, add_tsub_cancel_left, fin.nat_add_mk],
-    rw list.length_of_fn,
-    exact h },
+  induction n with n IH,
+  { rw [of_fn_zero, append_nil, fin.cast_add_zero, fin.cast_refl], refl },
+  { rw [of_fn_succ', of_fn_succ', IH, append_concat], refl, },
 end
 
 theorem of_fn_nth_le : ∀ l : list α, of_fn (λ i, nth_le l i i.2) = l


### PR DESCRIPTION
This adds some lemmas to split up lists generated over `fin (n + m)` and `fin (n * m)` into their constituent parts.

It also adds a congr lemma to allow `list.of_fn (λ i : fin n, _)` to be rewritten into `list.of_fn (λ i : fin m, _)` by `simp` when `h : n = m` is available.

I'll need these eventually to prove some things about products of tensor powers.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
