### PR TITLE
feat(number_theory/cyclotomic/basic): remove unnecessary assumptions

### DIFF
--- a/src/algebra/char_p/basic.lean
+++ b/src/algebra/char_p/basic.lean
@@ -324,6 +324,19 @@ theorem frobenius_inj [comm_ring R] [is_reduced R]
   function.injective (frobenius R p) :=
 λ x h H, by { rw ← sub_eq_zero at H ⊢, rw ← frobenius_sub at H, exact is_reduced.eq_zero _ ⟨_,H⟩ }
 
+@[simp]
+lemma pow_prime_pow_mul_eq_one_iff [comm_ring R] [is_reduced R] (p k m : ℕ) [fact p.prime]
+  [char_p R p] (x : R) :
+  x ^ (p ^ k * m) = 1 ↔ x ^ m = 1 :=
+begin
+  induction k with k hk,
+  { rw [pow_zero, one_mul] },
+  { refine ⟨λ h, _, λ h, _⟩,
+    { rw [pow_succ, mul_assoc, pow_mul', ← frobenius_def, ← frobenius_one p] at h,
+      exact hk.1 (frobenius_inj R p h) },
+    { rw [pow_mul', h, one_pow] } }
+end
+
 namespace char_p
 
 section

--- a/src/number_theory/cyclotomic/basic.lean
+++ b/src/number_theory/cyclotomic/basic.lean
@@ -420,7 +420,7 @@ lemma splitting_field_X_pow_sub_one_char_p {p k m : ℕ} {n : ℕ+} [fact (p.pri
     rw [mem_roots, is_root.def, eval_sub, eval_pow, eval_X, eval_one, hn,
       pow_prime_pow_mul_eq_one_iff, sub_eq_zero],
     rw [← ring_hom.map_one C],
-    refine X_pow_sub_C_ne_zero (ne_zero.pos_of_ne_zero_coe K) _
+    exact X_pow_sub_C_ne_zero (ne_zero.pos_of_ne_zero_coe K) _
     end }
 
 lemma is_galois : is_galois K L :=

--- a/src/number_theory/cyclotomic/basic.lean
+++ b/src/number_theory/cyclotomic/basic.lean
@@ -429,7 +429,7 @@ begin
   have hfin := (multiplicity.finite_nat_iff.2 ⟨char_p.char_ne_one K p, n.pos⟩),
   obtain ⟨m, hm⟩ := multiplicity.exists_eq_pow_mul_and_not_dvd hfin,
   by_cases hp : p ∣ n,
-  { haveI : fact (p.prime),
+  { haveI : fact p.prime,
     { refine ⟨(or_iff_left (λ h, _)).1 (char_p.char_is_prime_or_zero K p)⟩,
       have := hm.1,
       conv at this { congr, skip, congr, congr, rw [h] },

--- a/src/number_theory/cyclotomic/basic.lean
+++ b/src/number_theory/cyclotomic/basic.lean
@@ -518,24 +518,27 @@ no_zero_smul_divisors.of_algebra_map_injective (adjoin_algebra_injective n A K)
 instance : is_scalar_tower A (cyclotomic_ring n A K) (cyclotomic_field n K) :=
 is_scalar_tower.subalgebra' _ _ _ _
 
-instance is_cyclotomic_extension [ne_zero ((n : ℕ) : A)] :
+instance is_cyclotomic_extension :
   is_cyclotomic_extension {n} A (cyclotomic_ring n A K) :=
 { exists_root := λ a han,
   begin
     rw mem_singleton_iff at han,
     subst a,
-    haveI := ne_zero.of_no_zero_smul_divisors A K n,
-    haveI := ne_zero.of_no_zero_smul_divisors A (cyclotomic_ring n A K) n,
-    haveI := ne_zero.of_no_zero_smul_divisors A (cyclotomic_field n K) n,
     obtain ⟨μ, hμ⟩ := let h := (cyclotomic_field.is_cyclotomic_extension n K).exists_root
                       in h $ mem_singleton n,
-    refine ⟨⟨μ, subset_adjoin _⟩, _⟩,
-    { apply (is_root_of_unity_iff n.pos (cyclotomic_field n K)).mpr,
+    have hμmem : μ ∈ (adjoin A {b : cyclotomic_field n K | b ^ (n : ℕ) = 1}),
+    { refine subset_adjoin _,
+      apply (is_root_of_unity_iff n.pos (cyclotomic_field n K)).mpr,
       refine ⟨n, nat.mem_divisors_self _ n.ne_zero, _⟩,
       rwa [aeval_def, eval₂_eq_eval_map, map_cyclotomic] at hμ },
-    simp_rw [aeval_def, eval₂_eq_eval_map,
-      map_cyclotomic, ←is_root.def, is_root_cyclotomic_iff] at hμ ⊢,
-    rwa ←is_primitive_root.map_iff_of_injective (adjoin_algebra_injective n A K)
+    refine ⟨⟨μ, hμmem⟩, _⟩,
+    have := adjoin_algebra_injective n A K,
+    rw [ring_hom.injective_iff_ker_eq_bot, ring_hom.ker_eq_bot_iff_eq_zero] at this,
+    simp_rw [aeval_def, eval₂_eq_eval_map, map_cyclotomic],
+    refine this _ _,
+    have h : (algebra_map (cyclotomic_ring n A K) (cyclotomic_field n K)) ⟨μ, hμmem⟩ = μ := rfl,
+    rw [← aeval_algebra_map_apply, h, aeval_def, eval₂_eq_eval_map, map_cyclotomic],
+    rwa [aeval_def, eval₂_eq_eval_map, map_cyclotomic] at hμ,
   end,
   adjoin_roots := λ x,
   begin

--- a/src/number_theory/cyclotomic/basic.lean
+++ b/src/number_theory/cyclotomic/basic.lean
@@ -491,7 +491,7 @@ instance is_cyclotomic_extension :
         conv at this { congr, skip, congr, congr, rw [h] },
         rw [zero_pow, zero_mul] at this,
         { exact pnat.ne_zero n this },
-        { refine multiplicity.pos_of_dvd hfin hp } },
+        { exact multiplicity.pos_of_dvd hfin hp } },
       letI hmz : ne_zero (m : L) := ne_zero.of_not_dvd L hm.2,
       rw [is_root_cyclotomic_prime_pow_mul_iff_of_char_p] at hζ,
       have H₁ : ({b : cyclotomic_field n K | ∃ (a : ℕ+), a ∈ ({n} : set ℕ+) ∧ b ^ (a : ℕ) = 1}) =

--- a/src/number_theory/cyclotomic/basic.lean
+++ b/src/number_theory/cyclotomic/basic.lean
@@ -385,7 +385,7 @@ localized "attribute [instance] is_cyclotomic_extension.splitting_field_cyclotom
 
 omit hne
 
-lemma splits_X_pow_sub_one_char_p {p k m : ℕ} {n : ℕ+} [fact (p.prime)] (hn : ↑n = (p ^ k) * m)
+lemma splits_X_pow_sub_one_char_p {p k m : ℕ} {n : ℕ+} [fact p.prime] (hn : ↑n = p ^ k * m)
   (K : Type*) (L : Type*) [field K] [field L] [algebra K L] [char_p K p] [ne_zero (m : K)]
   [is_cyclotomic_extension {n} K L] :
   splits (algebra_map K L) (X ^ m - 1) :=

--- a/src/number_theory/cyclotomic/basic.lean
+++ b/src/number_theory/cyclotomic/basic.lean
@@ -60,7 +60,7 @@ included in the `cyclotomic` locale.
 
 -/
 
-open polynomial algebra finite_dimensional module set
+open polynomial algebra finite_dimensional module set char_p
 
 open_locale big_operators
 
@@ -426,15 +426,10 @@ lemma splitting_field_X_pow_sub_one_char_p {p k m : ℕ} {n : ℕ+} [fact p.prim
 lemma is_galois : is_galois K L :=
 begin
   let p := ring_char K,
-  have hfin := (multiplicity.finite_nat_iff.2 ⟨char_p.char_ne_one K p, n.pos⟩),
+  have hfin := (multiplicity.finite_nat_iff.2 ⟨char_ne_one K p, n.pos⟩),
   obtain ⟨m, hm⟩ := multiplicity.exists_eq_pow_mul_and_not_dvd hfin,
   by_cases hp : p ∣ n,
-  { haveI : fact p.prime,
-    { refine ⟨(or_iff_left (λ h, _)).1 (char_p.char_is_prime_or_zero K p)⟩,
-      have := hm.1,
-      conv at this { congr, skip, congr, congr, rw [h] },
-      rw [zero_pow (multiplicity.pos_of_dvd hfin hp), zero_mul] at this,
-      exact pnat.ne_zero n this },
+  { haveI : fact p.prime := @char_is_prime_of_pos K _ _ _ p ⟨nat.pos_of_dvd_of_pos hp n.pos⟩ _,
     letI : ne_zero (m : K) := ne_zero.of_not_dvd K hm.2,
     letI := splitting_field_X_pow_sub_one_char_p hm.1 K L,
     exact is_galois.of_separable_splitting_field
@@ -481,15 +476,10 @@ instance is_cyclotomic_extension :
     let L := (cyclotomic ↑n K).splitting_field,
     let p := ring_char L,
     by_cases hp : p ∣ n,
-    { have hfin := (multiplicity.finite_nat_iff.2 ⟨char_p.char_ne_one L p, n.pos⟩),
+    { have hfin := (multiplicity.finite_nat_iff.2 ⟨char_ne_one L p, n.pos⟩),
       obtain ⟨m, hm⟩ := multiplicity.exists_eq_pow_mul_and_not_dvd hfin,
       conv at hζ { congr, congr, rw [hm.1] },
-      haveI : fact (p.prime),
-      { refine ⟨(or_iff_left (λ h, _)).1 (char_p.char_is_prime_or_zero L p)⟩,
-        have := hm.1,
-        conv at this { congr, skip, congr, congr, rw [h] },
-        rw [zero_pow (multiplicity.pos_of_dvd hfin hp), zero_mul] at this,
-        exact pnat.ne_zero n this },
+      haveI : fact p.prime := @char_is_prime_of_pos L _ _ _ p ⟨nat.pos_of_dvd_of_pos hp n.pos⟩ _,
       letI hmz : ne_zero (m : L) := ne_zero.of_not_dvd L hm.2,
       rw [is_root_cyclotomic_prime_pow_mul_iff_of_char_p] at hζ,
       have H₁ : ({b : cyclotomic_field n K | ∃ (a : ℕ+), a ∈ ({n} : set ℕ+) ∧ b ^ (a : ℕ) = 1}) =

--- a/src/number_theory/cyclotomic/basic.lean
+++ b/src/number_theory/cyclotomic/basic.lean
@@ -403,7 +403,7 @@ begin
 end
 
 lemma splitting_field_X_pow_sub_one_char_p {p k m : ℕ} {n : ℕ+} [fact (p.prime)]
-  (hn : ↑n = (p ^ k) * m) (K : Type*) (L : Type*) [field K] [field L] [algebra K L] [char_p K p]
+  (hn : ↑n = p ^ k * m) (K : Type*) (L : Type*) [field K] [field L] [algebra K L] [char_p K p]
   [ne_zero (m : K)] [is_cyclotomic_extension {n} K L] :
   is_splitting_field K L (X ^ m - 1) :=
 { splits := splits_X_pow_sub_one_char_p hn K L,

--- a/src/number_theory/cyclotomic/basic.lean
+++ b/src/number_theory/cyclotomic/basic.lean
@@ -551,8 +551,7 @@ instance is_cyclotomic_extension :
     { exact subalgebra.mul_mem _ hy hz },
   end }
 
-instance [ne_zero ((n : ℕ) : A)] :
-  is_fraction_ring (cyclotomic_ring n A K) (cyclotomic_field n K) :=
+instance : is_fraction_ring (cyclotomic_ring n A K) (cyclotomic_field n K) :=
 { map_units := λ ⟨x, hx⟩, begin
     rw is_unit_iff_ne_zero,
     apply map_ne_zero_of_mem_non_zero_divisors,
@@ -561,7 +560,6 @@ instance [ne_zero ((n : ℕ) : A)] :
   end,
   surj := λ x,
   begin
-    letI : ne_zero ((n : ℕ) : K) := ne_zero.nat_of_injective (is_fraction_ring.injective A K),
     refine algebra.adjoin_induction (((is_cyclotomic_extension.iff_singleton n K _).1
       (cyclotomic_field.is_cyclotomic_extension n K)).2 x) (λ y hy, _) (λ k, _) _ _,
     { exact ⟨⟨⟨y, subset_adjoin hy⟩, 1⟩, by simpa⟩ },

--- a/src/number_theory/cyclotomic/basic.lean
+++ b/src/number_theory/cyclotomic/basic.lean
@@ -402,7 +402,7 @@ begin
   refine X_pow_sub_one_splits hz,
 end
 
-lemma splitting_field_X_pow_sub_one_char_p {p k m : ℕ} {n : ℕ+} [fact (p.prime)]
+lemma splitting_field_X_pow_sub_one_char_p {p k m : ℕ} {n : ℕ+} [fact p.prime]
   (hn : ↑n = p ^ k * m) (K : Type*) (L : Type*) [field K] [field L] [algebra K L] [char_p K p]
   [ne_zero (m : K)] [is_cyclotomic_extension {n} K L] :
   is_splitting_field K L (X ^ m - 1) :=

--- a/src/number_theory/cyclotomic/basic.lean
+++ b/src/number_theory/cyclotomic/basic.lean
@@ -421,7 +421,7 @@ lemma splitting_field_X_pow_sub_one_char_p {p k m : ℕ} {n : ℕ+} [fact p.prim
       pow_prime_pow_mul_eq_one_iff, sub_eq_zero],
     rw [← ring_hom.map_one C],
     exact X_pow_sub_C_ne_zero (ne_zero.pos_of_ne_zero_coe K) _
-    end }
+  end }
 
 lemma is_galois : is_galois K L :=
 begin

--- a/src/number_theory/cyclotomic/basic.lean
+++ b/src/number_theory/cyclotomic/basic.lean
@@ -584,7 +584,7 @@ instance is_cyclotomic_extension :
     subst a,
     obtain ⟨μ, hμ⟩ := let h := (cyclotomic_field.is_cyclotomic_extension n K).exists_root
                       in h $ mem_singleton n,
-    have hμmem : μ ∈ (adjoin A {b : cyclotomic_field n K | b ^ (n : ℕ) = 1}),
+    have hμmem : μ ∈ adjoin A {b : cyclotomic_field n K | b ^ (n : ℕ) = 1},
     { refine subset_adjoin _,
       apply (is_root_of_unity_iff n.pos (cyclotomic_field n K)).mpr,
       refine ⟨n, nat.mem_divisors_self _ n.ne_zero, _⟩,

--- a/src/number_theory/cyclotomic/basic.lean
+++ b/src/number_theory/cyclotomic/basic.lean
@@ -576,8 +576,7 @@ no_zero_smul_divisors.of_algebra_map_injective (adjoin_algebra_injective n A K)
 instance : is_scalar_tower A (cyclotomic_ring n A K) (cyclotomic_field n K) :=
 is_scalar_tower.subalgebra' _ _ _ _
 
-instance is_cyclotomic_extension :
-  is_cyclotomic_extension {n} A (cyclotomic_ring n A K) :=
+instance is_cyclotomic_extension : is_cyclotomic_extension {n} A (cyclotomic_ring n A K) :=
 { exists_root := λ a han,
   begin
     rw mem_singleton_iff at han,

--- a/src/number_theory/cyclotomic/basic.lean
+++ b/src/number_theory/cyclotomic/basic.lean
@@ -433,9 +433,8 @@ begin
     { refine ⟨(or_iff_left (λ h, _)).1 (char_p.char_is_prime_or_zero K p)⟩,
       have := hm.1,
       conv at this { congr, skip, congr, congr, rw [h] },
-      rw [zero_pow, zero_mul] at this,
-      { exact pnat.ne_zero n this },
-      { refine multiplicity.pos_of_dvd hfin hp } },
+      rw [zero_pow (multiplicity.pos_of_dvd hfin hp), zero_mul] at this,
+      exact pnat.ne_zero n this },
     letI : ne_zero (m : K) := ne_zero.of_not_dvd K hm.2,
     letI := splitting_field_X_pow_sub_one_char_p hm.1 K L,
     exact is_galois.of_separable_splitting_field
@@ -489,9 +488,8 @@ instance is_cyclotomic_extension :
       { refine ⟨(or_iff_left (λ h, _)).1 (char_p.char_is_prime_or_zero L p)⟩,
         have := hm.1,
         conv at this { congr, skip, congr, congr, rw [h] },
-        rw [zero_pow, zero_mul] at this,
-        { exact pnat.ne_zero n this },
-        { exact multiplicity.pos_of_dvd hfin hp } },
+        rw [zero_pow (multiplicity.pos_of_dvd hfin hp), zero_mul] at this,
+        exact pnat.ne_zero n this },
       letI hmz : ne_zero (m : L) := ne_zero.of_not_dvd L hm.2,
       rw [is_root_cyclotomic_prime_pow_mul_iff_of_char_p] at hζ,
       have H₁ : ({b : cyclotomic_field n K | ∃ (a : ℕ+), a ∈ ({n} : set ℕ+) ∧ b ^ (a : ℕ) = 1}) =

--- a/src/number_theory/cyclotomic/basic.lean
+++ b/src/number_theory/cyclotomic/basic.lean
@@ -399,7 +399,7 @@ begin
   haveI := ne_zero.of_no_zero_smul_divisors K L m,
   rw [aeval_def, eval₂_eq_eval_map, map_cyclotomic, hn, ← is_root.def,
     is_root_cyclotomic_prime_pow_mul_iff_of_char_p] at hz,
-  refine X_pow_sub_one_splits hz,
+  exact X_pow_sub_one_splits hz
 end
 
 lemma splitting_field_X_pow_sub_one_char_p {p k m : ℕ} {n : ℕ+} [fact p.prime]

--- a/src/number_theory/cyclotomic/basic.lean
+++ b/src/number_theory/cyclotomic/basic.lean
@@ -386,7 +386,7 @@ localized "attribute [instance] is_cyclotomic_extension.splitting_field_cyclotom
 omit hne
 
 lemma splits_X_pow_sub_one_char_p {p k m : ℕ} {n : ℕ+} [fact p.prime] (hn : ↑n = p ^ k * m)
-  (K : Type*) (L : Type*) [field K] [field L] [algebra K L] [char_p K p] [ne_zero (m : K)]
+  (K L : Type*) [field K] [field L] [algebra K L] [char_p K p] [ne_zero (m : K)]
   [is_cyclotomic_extension {n} K L] :
   splits (algebra_map K L) (X ^ m - 1) :=
 begin
@@ -403,7 +403,7 @@ begin
 end
 
 lemma splitting_field_X_pow_sub_one_char_p {p k m : ℕ} {n : ℕ+} [fact p.prime]
-  (hn : ↑n = p ^ k * m) (K : Type*) (L : Type*) [field K] [field L] [algebra K L] [char_p K p]
+  (hn : ↑n = p ^ k * m) (K L : Type*) [field K] [field L] [algebra K L] [char_p K p]
   [ne_zero (m : K)] [is_cyclotomic_extension {n} K L] :
   is_splitting_field K L (X ^ m - 1) :=
 { splits := splits_X_pow_sub_one_char_p hn K L,

--- a/src/number_theory/cyclotomic/rat.lean
+++ b/src/number_theory/cyclotomic/rat.lean
@@ -137,8 +137,7 @@ lemma cyclotomic_ring_is_integral_closure_of_prime_pow :
 begin
   haveI : is_cyclotomic_extension {p ^ k} ℚ (cyclotomic_field (p ^ k) ℚ),
   { convert cyclotomic_field.is_cyclotomic_extension (p ^ k) _,
-    { exact subsingleton.elim _ _ },
-    { exact ne_zero.char_zero } },
+    { exact subsingleton.elim _ _ } },
   have hζ := zeta_primitive_root (p ^ k) ℚ (cyclotomic_field (p ^ k) ℚ),
   refine ⟨is_fraction_ring.injective _ _, λ x, ⟨λ h, ⟨⟨x, _⟩, rfl⟩, _⟩⟩,
   { have := (is_integral_closure_adjoing_singleton_of_prime_pow hζ).is_integral_iff,
@@ -150,8 +149,7 @@ begin
       exact hζ.pow_eq_one } },
   { haveI : is_cyclotomic_extension {p ^ k} ℤ (cyclotomic_ring (p ^ k) ℤ ℚ),
     { convert cyclotomic_ring.is_cyclotomic_extension _ ℤ ℚ,
-      { exact subsingleton.elim _ _ },
-      { exact ne_zero.char_zero } },
+      { exact subsingleton.elim _ _ } },
     rintro ⟨y, rfl⟩,
     exact is_integral.algebra_map ((is_cyclotomic_extension.integral {p ^ k} ℤ _) _) }
 end

--- a/src/ring_theory/roots_of_unity.lean
+++ b/src/ring_theory/roots_of_unity.lean
@@ -84,6 +84,10 @@ def roots_of_unity (k : ℕ+) (M : Type*) [comm_monoid M] : subgroup Mˣ :=
 @[simp] lemma mem_roots_of_unity (k : ℕ+) (ζ : Mˣ) :
   ζ ∈ roots_of_unity k M ↔ ζ ^ (k : ℕ) = 1 := iff.rfl
 
+lemma mem_roots_of_unity' (k : ℕ+) (ζ : Mˣ) :
+  ζ ∈ roots_of_unity k M ↔ (ζ : M) ^ (k : ℕ) = 1 :=
+by { rw [mem_roots_of_unity], norm_cast }
+
 lemma roots_of_unity.coe_injective {n : ℕ+} : function.injective (coe : (roots_of_unity n M) → M) :=
 units.ext.comp (λ x y, subtype.ext)
 
@@ -231,6 +235,17 @@ begin
 end
 
 end is_domain
+
+section reduced
+
+variables (R) [comm_ring R] [is_reduced R]
+
+@[simp] lemma mem_roots_of_unity_prime_pow_mul_iff (p k : ℕ) (m : ℕ+) [hp : fact p.prime]
+  [char_p R p] {ζ : Rˣ} :
+  ζ ∈ roots_of_unity (⟨p, hp.1.pos⟩ ^ k * m) R ↔ ζ ∈ roots_of_unity m R :=
+by simp [mem_roots_of_unity']
+
+end reduced
 
 end roots_of_unity
 


### PR DESCRIPTION
We remove the useless `ne_zero` assumption from `is_cyclotomic_extension.is_galois`, `cyclotomic_field.is_cyclotomic_extension` and `cyclotomic_ring.is_cyclotomic_extension`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
