### PR TITLE
[Merged by Bors] - feat(tactic/ring): recursive ring_nf

### DIFF
--- a/src/algebra/continued_fractions/computation/approximations.lean
+++ b/src/algebra/continued_fractions/computation/approximations.lean
@@ -515,8 +515,7 @@ begin
       simp only [stream_nth_fr_ne_zero, conts_eq.symm, pred_conts_eq.symm] at tmp,
       rw tmp,
       simp only [denom'],
-      ring_nf,
-      ac_refl },
+      ring_nf },
     rwa this },
   -- derive some tedious inequalities that we need to rewrite our goal
   have nextConts_b_ineq : (fib (n + 2) : K) ≤ (pred_conts.b + gp.b * conts.b), by

--- a/src/ring_theory/trace.lean
+++ b/src/ring_theory/trace.lean
@@ -396,7 +396,7 @@ begin
     trace_form_apply, algebra.smul_mul_assoc],
   rw [mul_comm (b x), ← smul_def],
   ring_nf,
-  simp,
+  simp [mul_comm],
 end
 
 lemma trace_matrix_of_matrix_mul_vec [fintype κ] (b : κ → B) (P : matrix κ κ A) :

--- a/src/tactic/ring.lean
+++ b/src/tactic/ring.lean
@@ -623,6 +623,10 @@ meta def normalize (red : transparency) (mode := normalize_mode.horner)
   (recursive := tt) (e : expr) : tactic (expr × expr) :=
 using_new_ref mk_buffer $ λ atoms, normalize' atoms red mode recursive e
 
+/-- Configuration for `ring_nf`.
+
+  * `recursive`: if true, atoms inside ring expressions will be reduced recursively
+-/
 @[derive inhabited] structure ring_nf_cfg := (recursive := tt)
 
 end ring

--- a/src/tactic/ring.lean
+++ b/src/tactic/ring.lean
@@ -619,8 +619,8 @@ meta def normalize' (atoms : ref (buffer expr))
     This results in terms like `(3 * x ^ 2 * y + 1) * x + y`.
   * `SOP` means sum of products form, expanding everything to monomials.
     This results in terms like `3 * x ^ 3 * y + x + y`. -/
-meta def normalize (red : transparency) (mode := normalize_mode.horner) (recursive := tt) (e : expr) :
-  tactic (expr × expr) :=
+meta def normalize (red : transparency) (mode := normalize_mode.horner)
+  (recursive := tt) (e : expr) : tactic (expr × expr) :=
 using_new_ref mk_buffer $ λ atoms, normalize' atoms red mode recursive e
 
 structure ring_nf_cfg := (recursive := tt)

--- a/src/tactic/ring.lean
+++ b/src/tactic/ring.lean
@@ -623,7 +623,7 @@ meta def normalize (red : transparency) (mode := normalize_mode.horner)
   (recursive := tt) (e : expr) : tactic (expr × expr) :=
 using_new_ref mk_buffer $ λ atoms, normalize' atoms red mode recursive e
 
-structure ring_nf_cfg := (recursive := tt)
+@[derive inhabited] structure ring_nf_cfg := (recursive := tt)
 
 end ring
 

--- a/src/tactic/ring.lean
+++ b/src/tactic/ring.lean
@@ -553,7 +553,8 @@ instance : inhabited normalize_mode := ⟨normalize_mode.horner⟩
 /-- A `ring`-based normalization simplifier that rewrites ring expressions into the specified mode.
   See `normalize`. This version takes a list of atoms to persist across multiple calls. -/
 meta def normalize' (atoms : ref (buffer expr))
-  (red : transparency) (mode := normalize_mode.horner) : expr → opt_param _ ff → tactic (expr × expr)
+  (red : transparency) (mode := normalize_mode.horner) :
+  expr → opt_param _ ff → tactic (expr × expr)
 | e inner := do
   pow_lemma ← simp_lemmas.mk.add_simp ``pow_one,
   let lemmas := match mode with

--- a/test/ring.lean
+++ b/test/ring.lean
@@ -89,3 +89,9 @@ by transitivity; [exact h, ring]
 
 -- `ring_nf` should descend into the subexpressions `x * -a` and `-a * x`:
 example {a x : ℚ} : x * -a = - a * x := by ring_nf
+
+example (f : ℤ → ℤ) (a b : ℤ) : f (2 * a + b) + b = b + f (b + a + a) :=
+begin
+  success_if_fail {{ ring_nf {recursive := ff} }},
+  ring_nf
+end

--- a/test/ring.lean
+++ b/test/ring.lean
@@ -36,6 +36,19 @@ begin
   ring
 end
 
+example {A : ℤ} (f : ℤ → ℤ) : f 0 = f (A - A) := by ring_nf
+example {A : ℤ} (f : ℤ → ℤ) : f 0 = f (A + -A) := by ring_nf
+
+example {a b c : ℝ} (h : 0 < a ^ 4 + b ^ 4 + c ^ 4) :
+  a ^ 4 / (a ^ 4 + b ^ 4 + c ^ 4) +
+  b ^ 4 / (b ^ 4 + c ^ 4 + a ^ 4) +
+  c ^ 4 / (c ^ 4 + a ^ 4 + b ^ 4)
+  = 1 :=
+begin
+  ring_nf at ⊢ h,
+  field_simp [h.ne'],
+end
+
 example (a b c d x y : ℚ) (hx : x ≠ 0) (hy : y ≠ 0) :
   a + b / x - c / x^2 + d / x^3 = a + x⁻¹ * (y * b / y + (d / x - c) / x) :=
 begin


### PR DESCRIPTION
As [reported on Zulip](https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/.60ring_nf.60.20not.20consistently.20normalizing.3F). This allows `ring_nf` to rewrite inside the atoms of a ring expression, meaning that things like `f (a + b) + c` can simplify in both `+` expressions.