### PR TITLE
[Merged by Bors] - feat(topology/continuous_function/compact): `cstar_ring` instance on `C(α, β)` when `α` is compact

### DIFF
--- a/src/topology/algebra/star.lean
+++ b/src/topology/algebra/star.lean
@@ -64,6 +64,9 @@ lemma continuous_within_at.star (hf : continuous_within_at f s x) :
   continuous_within_at (λ x, star (f x)) s x :=
 hf.star
 
+/-- The star operation bundled as a continuous map. -/
+@[simps] def star_continuous_map : C(R, R) := ⟨star, continuous_star⟩
+
 end continuity
 
 section instances

--- a/src/topology/continuous_function/algebra.lean
+++ b/src/topology/continuous_function/algebra.lean
@@ -762,6 +762,12 @@ end lattice
 
 If `β` has a continuous star operation, we put a star structure on `C(α, β)` by using the
 star operation pointwise.
+
+If `β` is a ⋆-ring, then `C(α, β)` inherits a ⋆-ring structure.
+
+If `β` is a ⋆-ring and a ⋆-module over `R`, then the space of continuous functions from `α` to `β`
+is a ⋆-module over `R`.
+
 -/
 
 section star_structure

--- a/src/topology/continuous_function/algebra.lean
+++ b/src/topology/continuous_function/algebra.lean
@@ -7,6 +7,7 @@ import topology.algebra.module.basic
 import topology.continuous_function.ordered
 import topology.algebra.uniform_group
 import topology.uniform_space.compact_convergence
+import topology.algebra.star
 import algebra.algebra.subalgebra.basic
 import tactic.field_simp
 
@@ -755,5 +756,29 @@ lemma sup_eq (f g : C(α, β)) : f ⊔ g = (2⁻¹ : β) • (f + g + |f - g|) :
 ext (λ x, by simpa [mul_add] using @max_eq_half_add_add_abs_sub _ _ (f x) (g x))
 
 end lattice
+
+/-!
+### Star structure
+
+If `β` has a continuous star operation, we put a star structure on `C(α, β)` by using the
+star operation pointwise.
+-/
+
+section star_structure
+
+variables {α : Type*} {β : Type*}
+variables [topological_space α] [topological_space β] [add_monoid β] [has_continuous_add β]
+  [star_add_monoid β] [has_continuous_star β]
+
+instance : star_add_monoid C(α, β) :=
+{ star            := λ f, star_continuous_map.comp f,
+  star_involutive := λ f, by { ext, exact star_star _ },
+  star_add        := λ f g, by { ext, exact star_add _ _ } }
+
+@[simp] lemma coe_star (f : C(α, β)) : ⇑(star f) = star f := rfl
+
+@[simp] lemma star_apply (f : C(α, β)) (x : α) : star f x = star (f x) := rfl
+
+end star_structure
 
 end continuous_map

--- a/src/topology/continuous_function/algebra.lean
+++ b/src/topology/continuous_function/algebra.lean
@@ -765,19 +765,40 @@ star operation pointwise.
 -/
 
 section star_structure
+variables {R α β : Type*}
+variables [topological_space α] [topological_space β]
 
-variables {α : Type*} {β : Type*}
-variables [topological_space α] [topological_space β] [add_monoid β] [has_continuous_add β]
-  [star_add_monoid β] [has_continuous_star β]
+section has_star
+variables [has_star β] [has_continuous_star β]
 
-instance : star_add_monoid C(α, β) :=
-{ star            := λ f, star_continuous_map.comp f,
-  star_involutive := λ f, by { ext, exact star_star _ },
-  star_add        := λ f g, by { ext, exact star_add _ _ } }
+instance : has_star C(α, β) :=
+{ star := λ f, star_continuous_map.comp f }
 
 @[simp] lemma coe_star (f : C(α, β)) : ⇑(star f) = star f := rfl
 
 @[simp] lemma star_apply (f : C(α, β)) (x : α) : star f x = star (f x) := rfl
+
+end has_star
+
+instance [has_involutive_star β] [has_continuous_star β] : has_involutive_star C(α, β) :=
+{ star_involutive := λ f, ext $ λ x, star_star _ }
+
+instance [add_monoid β] [has_continuous_add β] [star_add_monoid β] [has_continuous_star β] :
+  star_add_monoid C(α, β) :=
+{ star_add := λ f g, ext $ λ x, star_add _ _ }
+
+instance [semigroup β] [has_continuous_mul β] [star_semigroup β] [has_continuous_star β] :
+  star_semigroup C(α, β) :=
+{ star_mul := λ f g, ext $ λ x, star_mul _ _ }
+
+instance [non_unital_semiring β] [topological_semiring β] [star_ring β] [has_continuous_star β] :
+  star_ring C(α, β) :=
+{ ..continuous_map.star_add_monoid }
+
+instance [has_star R] [has_star β] [has_scalar R β] [star_module R β]
+  [has_continuous_star β] [has_continuous_const_smul R β] :
+  star_module R C(α, β) :=
+{ star_smul := λ k f, ext $ λ x, star_smul _ _ }
 
 end star_structure
 

--- a/src/topology/continuous_function/compact.lean
+++ b/src/topology/continuous_function/compact.lean
@@ -434,13 +434,6 @@ end weierstrass
 In this section, if `β` is a normed ⋆-group, then so is the space of
 continuous functions from `α` to `β`, by using the star operation pointwise.
 
-If `𝕜` is normed field and a ⋆-ring over which `β` is a normed algebra and a
-star module, then the space of continuous functions from `α` to `β`
-is a star module.
-
-If `β` is a ⋆-ring in addition to being a normed ⋆-group, then `C(α, β)`
-inherits a ⋆-ring structure.
-
 Furthermore, if `α` is compact and `β` is a C⋆-ring, then `C(α, β)` is a C⋆-ring.  -/
 
 section normed_space

--- a/src/topology/continuous_function/compact.lean
+++ b/src/topology/continuous_function/compact.lean
@@ -445,10 +445,8 @@ Furthermore, if `α` is compact and `β` is a C⋆-ring, then `C(α, β)` is a C
 
 section normed_space
 
-variables {α : Type*} {β : Type*} {𝕜 : Type*}
-variables [normed_field 𝕜] [star_ring 𝕜]
-variables [topological_space α] [normed_group β] [star_add_monoid β]
-  [normed_star_group β] [normed_space 𝕜 β] [star_module 𝕜 β]
+variables {α : Type*} {β : Type*}
+variables [topological_space α] [normed_group β] [star_add_monoid β] [normed_star_group β]
 
 lemma _root_.bounded_continuous_function.mk_of_compact_star [compact_space α] (f : C(α, β)) :
   mk_of_compact (star f) = star (mk_of_compact f) := rfl
@@ -462,8 +460,7 @@ end normed_space
 
 section cstar_ring
 
-variables {α : Type*} {β : Type*} {𝕜 : Type*}
-variables [normed_field 𝕜] [star_ring 𝕜]
+variables {α : Type*} {β : Type*}
 variables [topological_space α] [normed_ring β] [star_ring β]
 
 instance [compact_space α] [cstar_ring β] : cstar_ring C(α, β) :=

--- a/src/topology/continuous_function/compact.lean
+++ b/src/topology/continuous_function/compact.lean
@@ -458,9 +458,6 @@ instance [compact_space α] : normed_star_group C(α, β) :=
                           bounded_continuous_function.mk_of_compact_star, norm_star,
                           bounded_continuous_function.norm_mk_of_compact] }
 
-instance : star_module 𝕜 C(α, β) :=
-{ star_smul := λ k f, by { ext, exact star_smul _ _ } }
-
 end normed_space
 
 section cstar_ring
@@ -468,10 +465,6 @@ section cstar_ring
 variables {α : Type*} {β : Type*} {𝕜 : Type*}
 variables [normed_field 𝕜] [star_ring 𝕜]
 variables [topological_space α] [normed_ring β] [star_ring β]
-
-instance [has_continuous_star β] : star_ring C(α, β) :=
-{ star_mul := λ f g, by { ext, exact star_mul _ _ },
-  ..continuous_map.star_add_monoid }
 
 instance [compact_space α] [cstar_ring β] : cstar_ring C(α, β) :=
 { norm_star_mul_self :=

--- a/src/topology/continuous_function/compact.lean
+++ b/src/topology/continuous_function/compact.lean
@@ -428,3 +428,86 @@ end
 end weierstrass
 
 end continuous_map
+
+/-!
+### Star structures
+
+In this section, if `β` is a normed ⋆-group, then so is the space of
+continuous functions from `α` to `β`, by using the star operation pointwise.
+
+If `𝕜` is normed field and a ⋆-ring over which `β` is a normed algebra and a
+star module, then the space of continuous functions from `α` to `β`
+is a star module.
+
+If `β` is a ⋆-ring in addition to being a normed ⋆-group, then `C(α, β)`
+inherits a ⋆-ring structure.
+
+Furthermore, if `α` is compact and `β` is a C⋆-ring, then `C(α, β)` is a C⋆-ring.  -/
+
+section continuous_star
+
+variables {α : Type*} {β : Type*}
+variables [topological_space α] [topological_space β] [add_monoid β] [has_continuous_add β]
+  [star_add_monoid β] [has_continuous_star β]
+
+instance : star_add_monoid C(α, β) :=
+{ star            := λ f, star_continuous_map.comp f,
+  star_involutive := λ f, by { ext, exact star_star _ },
+  star_add        := λ f g, by { ext, exact star_add _ _ } }
+
+@[simp] lemma coe_star (f : C(α, β)) : ⇑(star f) = star f := rfl
+
+@[simp] lemma star_apply (f : C(α, β)) (x : α) : star f x = star (f x) := rfl
+
+end continuous_star
+
+section normed_space
+
+variables {α : Type*} {β : Type*} {𝕜 : Type*}
+variables [normed_field 𝕜] [star_ring 𝕜]
+variables [topological_space α] [compact_space α] [normed_group β] [star_add_monoid β]
+  [normed_star_group β] [normed_space 𝕜 β] [star_module 𝕜 β]
+
+lemma _root_.bounded_continuous_function.mk_of_compact_star (f : C(α, β)) :
+  mk_of_compact (star f) = star (mk_of_compact f) := rfl
+
+instance : normed_star_group C(α, β) :=
+{ norm_star := λ f, by rw [←bounded_continuous_function.norm_mk_of_compact,
+                          bounded_continuous_function.mk_of_compact_star, norm_star,
+                          bounded_continuous_function.norm_mk_of_compact] }
+
+instance : star_module 𝕜 C(α, β) :=
+{ star_smul := λ k f, by { ext, exact star_smul _ _ } }
+
+end normed_space
+
+section cstar_ring
+
+variables {α : Type*} {β : Type*} {𝕜 : Type*}
+variables [normed_field 𝕜] [star_ring 𝕜]
+variables [topological_space α] [compact_space α] [normed_ring β] [star_ring β]
+
+instance [has_continuous_star β] : star_ring C(α, β) :=
+{ star_mul := λ f g, by { ext, exact star_mul _ _ },
+  ..continuous_map.star_add_monoid }
+
+instance [cstar_ring β] : cstar_ring C(α, β) :=
+{ norm_star_mul_self :=
+  begin
+    intros f,
+    refine le_antisymm _ _,
+    { rw [←sq, continuous_map.norm_le _ (sq_nonneg _)],
+      intro x,
+      simp only [continuous_map.coe_mul, _root_.coe_star, pi.mul_apply, pi.star_apply,
+                 cstar_ring.norm_star_mul_self, ←sq],
+      refine sq_le_sq' _ _,
+      { linarith [norm_nonneg (f x), norm_nonneg f] },
+      { exact continuous_map.norm_coe_le_norm f x }, },
+    { rw [←sq, ←real.le_sqrt (norm_nonneg _) (norm_nonneg _),
+          continuous_map.norm_le _ (real.sqrt_nonneg _)],
+      intro x,
+      rw [real.le_sqrt (norm_nonneg _) (norm_nonneg _), sq, ←cstar_ring.norm_star_mul_self],
+      exact continuous_map.norm_coe_le_norm (star f * f) x },
+  end }
+
+end cstar_ring

--- a/src/topology/continuous_function/compact.lean
+++ b/src/topology/continuous_function/compact.lean
@@ -427,7 +427,6 @@ end
 
 end weierstrass
 
-end continuous_map
 
 /-!
 ### Star structures
@@ -444,34 +443,17 @@ inherits a ⋆-ring structure.
 
 Furthermore, if `α` is compact and `β` is a C⋆-ring, then `C(α, β)` is a C⋆-ring.  -/
 
-section continuous_star
-
-variables {α : Type*} {β : Type*}
-variables [topological_space α] [topological_space β] [add_monoid β] [has_continuous_add β]
-  [star_add_monoid β] [has_continuous_star β]
-
-instance : star_add_monoid C(α, β) :=
-{ star            := λ f, star_continuous_map.comp f,
-  star_involutive := λ f, by { ext, exact star_star _ },
-  star_add        := λ f g, by { ext, exact star_add _ _ } }
-
-@[simp] lemma coe_star (f : C(α, β)) : ⇑(star f) = star f := rfl
-
-@[simp] lemma star_apply (f : C(α, β)) (x : α) : star f x = star (f x) := rfl
-
-end continuous_star
-
 section normed_space
 
 variables {α : Type*} {β : Type*} {𝕜 : Type*}
 variables [normed_field 𝕜] [star_ring 𝕜]
-variables [topological_space α] [compact_space α] [normed_group β] [star_add_monoid β]
+variables [topological_space α] [normed_group β] [star_add_monoid β]
   [normed_star_group β] [normed_space 𝕜 β] [star_module 𝕜 β]
 
-lemma _root_.bounded_continuous_function.mk_of_compact_star (f : C(α, β)) :
+lemma _root_.bounded_continuous_function.mk_of_compact_star [compact_space α] (f : C(α, β)) :
   mk_of_compact (star f) = star (mk_of_compact f) := rfl
 
-instance : normed_star_group C(α, β) :=
+instance [compact_space α] : normed_star_group C(α, β) :=
 { norm_star := λ f, by rw [←bounded_continuous_function.norm_mk_of_compact,
                           bounded_continuous_function.mk_of_compact_star, norm_star,
                           bounded_continuous_function.norm_mk_of_compact] }
@@ -485,20 +467,20 @@ section cstar_ring
 
 variables {α : Type*} {β : Type*} {𝕜 : Type*}
 variables [normed_field 𝕜] [star_ring 𝕜]
-variables [topological_space α] [compact_space α] [normed_ring β] [star_ring β]
+variables [topological_space α] [normed_ring β] [star_ring β]
 
 instance [has_continuous_star β] : star_ring C(α, β) :=
 { star_mul := λ f g, by { ext, exact star_mul _ _ },
   ..continuous_map.star_add_monoid }
 
-instance [cstar_ring β] : cstar_ring C(α, β) :=
+instance [compact_space α] [cstar_ring β] : cstar_ring C(α, β) :=
 { norm_star_mul_self :=
   begin
     intros f,
     refine le_antisymm _ _,
     { rw [←sq, continuous_map.norm_le _ (sq_nonneg _)],
       intro x,
-      simp only [continuous_map.coe_mul, _root_.coe_star, pi.mul_apply, pi.star_apply,
+      simp only [continuous_map.coe_mul, coe_star, pi.mul_apply, pi.star_apply,
                  cstar_ring.norm_star_mul_self, ←sq],
       refine sq_le_sq' _ _,
       { linarith [norm_nonneg (f x), norm_nonneg f] },
@@ -511,3 +493,5 @@ instance [cstar_ring β] : cstar_ring C(α, β) :=
   end }
 
 end cstar_ring
+
+end continuous_map


### PR DESCRIPTION
We define the star operation on `C(α, β)` by applying `β`'s star operation pointwise. In the case when `α` is compact, then `C(α, β)` has a norm, and we show that it is a `cstar_ring`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

~~Note: I put everything in `topology/continuous_function/compact` because it seems like the only existing file with the right imports, even though the star structure doesn't require compactness. I could move this part to a new file if this is deemed useful.~~


[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
