### PR TITLE
[Merged by Bors] - feat(ci): Add support for "notice"-level messages

### DIFF
--- a/scripts/detect_errors.py
+++ b/scripts/detect_errors.py
@@ -11,10 +11,9 @@ def encode_msg_text_for_github(msg):
 def format_msg(msg):
     # Formatted for https://github.com/actions/toolkit/blob/master/docs/commands.md#log-level
     
-    # mapping between lean severity levels and github levels.
-    # github does not support info levels, which are emitted by `#check` etc:
+    # See also
     # https://docs.github.com/en/actions/reference/workflow-commands-for-github-actions#setting-a-debug-message
-    severity_map = {'information': 'warning'}
+    severity_map = {'information': 'notice'}
     severity = msg.get('severity')
     severity = severity_map.get(severity, severity)
     

--- a/test/abel.lean
+++ b/test/abel.lean
@@ -18,4 +18,3 @@ begin
   success_if_fail { abel; done },
   abel!
 end
-#check 1

--- a/test/abel.lean
+++ b/test/abel.lean
@@ -18,3 +18,4 @@ begin
   success_if_fail { abel; done },
   abel!
 end
+#check 1


### PR DESCRIPTION
It looks like support for this was added recently, it's now documented at the same link already in our source code.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)

![image](https://user-images.githubusercontent.com/425260/170844026-3339b72d-fffc-484a-81b2-41f31bc1631c.png)
