### PR TITLE
chore(*): `↥{x | p x}` to `{x // p x}`

### DIFF
--- a/src/logic/equiv/set.lean
+++ b/src/logic/equiv/set.lean
@@ -130,7 +130,7 @@ by simpa only [equiv.image_eq_preimage] using prod_assoc_preimage
 
 /-- A set `s` in `α × β` is equivalent to the sigma-type `Σ x, {y | (x, y) ∈ s}`. -/
 def set_prod_equiv_sigma {α β : Type*} (s : set (α × β)) :
-  s ≃ Σ x : α, {y | (x, y) ∈ s} :=
+  s ≃ Σ x : α, {y // (x, y) ∈ s} :=
 { to_fun := λ x, ⟨x.1.1, x.1.2, by simp⟩,
   inv_fun := λ x, ⟨(x.1, x.2.1), x.2.2⟩,
   left_inv := λ ⟨⟨x, y⟩, h⟩, rfl,

--- a/src/logic/equiv/set.lean
+++ b/src/logic/equiv/set.lean
@@ -399,7 +399,7 @@ protected def congr {α β : Type*} (e : α ≃ β) : set α ≃ set β :=
 
 /-- The set `{x ∈ s | t x}` is equivalent to the set of `x : s` such that `t x`. -/
 protected def sep {α : Type u} (s : set α) (t : α → Prop) :
-  ({ x ∈ s | t x } : set α) ≃ { x : s | t x } :=
+  ({x ∈ s | t x} : set α) ≃ {x : s // t x} :=
 (equiv.subtype_subtype_equiv_subtype_inter s t).symm
 
 /-- The set `𝒫 S := {x | x ⊆ S}` is equivalent to the type `set S`. -/

--- a/src/set_theory/cardinal/basic.lean
+++ b/src/set_theory/cardinal/basic.lean
@@ -1422,12 +1422,12 @@ by { convert mk_preimage_of_injective_of_subset_range_lift.{u u} f s h h2 using 
 
 lemma mk_subset_ge_of_subset_image_lift {α : Type u} {β : Type v} (f : α → β) {s : set α}
   {t : set β} (h : t ⊆ f '' s) :
-    lift.{u} (#t) ≤ lift.{v} (#({ x ∈ s | f x ∈ t } : set α)) :=
+    lift.{u} (#t) ≤ lift.{v} (#({x ∈ s | f x ∈ t} : set α)) :=
 by { rw [image_eq_range] at h, convert mk_preimage_of_subset_range_lift _ _ h using 1,
      rw [mk_sep], refl }
 
 lemma mk_subset_ge_of_subset_image (f : α → β) {s : set α} {t : set β} (h : t ⊆ f '' s) :
-  #t ≤ #({ x ∈ s | f x ∈ t } : set α) :=
+  #t ≤ #({x ∈ s | f x ∈ t} : set α) :=
 by { rw [image_eq_range] at h, convert mk_preimage_of_subset_range _ _ h using 1,
      rw [mk_sep], refl }
 

--- a/src/set_theory/cardinal/basic.lean
+++ b/src/set_theory/cardinal/basic.lean
@@ -1382,7 +1382,7 @@ lemma mk_subtype_of_equiv {α β : Type u} (p : β → Prop) (e : α ≃ β) :
   #{a : α // p (e a)} = #{b : β // p b} :=
 mk_congr (equiv.subtype_equiv_of_subtype e)
 
-lemma mk_sep (s : set α) (t : α → Prop) : #({ x ∈ s | t x } : set α) = #{ x : s | t x.1 } :=
+lemma mk_sep (s : set α) (t : α → Prop) : #({x ∈ s | t x} : set α) = #{x : s // t x.1} :=
 mk_congr (equiv.set.sep s t)
 
 lemma mk_preimage_of_injective_lift {α : Type u} {β : Type v} (f : α → β) (s : set β)


### PR DESCRIPTION
Tweaked a few theorem statements in accordance to #14441.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

There's probably many others, but I don't know how to find them.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
