### PR TITLE
[Merged by Bors] - feat(analysis/normed_space/hahn-banach/separation): Eidelheit's theorem

### DIFF
--- a/src/analysis/normed_space/hahn_banach/separation.lean
+++ b/src/analysis/normed_space/hahn_banach/separation.lean
@@ -187,7 +187,7 @@ begin
   exact ⟨f, by linarith [hs x rfl, ht y rfl]⟩,
 end
 
-/-- **Eidelheit's Theorem** -/
+/-- A closed convex set is the intersection of the halfspaces containing it. -/
 lemma Inter_halfspaces_eq (hs₁ : convex ℝ s) (hs₂ : is_closed s) :
   (⋂ (l : E →L[ℝ] ℝ), {x | ∃ y ∈ s, l x ≤ l y}) = s :=
 begin

--- a/src/analysis/normed_space/hahn_banach/separation.lean
+++ b/src/analysis/normed_space/hahn_banach/separation.lean
@@ -186,3 +186,16 @@ begin
       (convex_singleton y) is_closed_singleton (disjoint_singleton.2 hxy),
   exact ⟨f, by linarith [hs x rfl, ht y rfl]⟩,
 end
+
+/-- **Eidelheit's Theorem** -/
+lemma Inter_halfspaces_eq (hs₁ : convex ℝ s) (hs₂ : is_closed s) :
+  (⋂ (l : E →L[ℝ] ℝ), {x | ∃ y ∈ s, l x ≤ l y}) = s :=
+begin
+  ext,
+  simp only [mem_Inter],
+  refine ⟨λ hx, _, λ hx l, ⟨x, hx, le_rfl⟩⟩,
+  by_contra,
+  obtain ⟨l, s, hlA, hl⟩ := geometric_hahn_banach_closed_point hs₁ hs₂ h,
+  obtain ⟨y, hy, hxy⟩ := hx l,
+  linarith [hlA y hy],
+end

--- a/src/analysis/normed_space/hahn_banach/separation.lean
+++ b/src/analysis/normed_space/hahn_banach/separation.lean
@@ -191,11 +191,10 @@ end
 lemma Inter_halfspaces_eq (hs₁ : convex ℝ s) (hs₂ : is_closed s) :
   (⋂ (l : E →L[ℝ] ℝ), {x | ∃ y ∈ s, l x ≤ l y}) = s :=
 begin
-  ext,
-  simp only [mem_Inter],
-  refine ⟨λ hx, _, λ hx l, ⟨x, hx, le_rfl⟩⟩,
+  rw set.Inter_set_of,
+  refine set.subset.antisymm (λ x hx, _) (λ x hx l, ⟨x, hx, le_rfl⟩),
   by_contra,
   obtain ⟨l, s, hlA, hl⟩ := geometric_hahn_banach_closed_point hs₁ hs₂ h,
   obtain ⟨y, hy, hxy⟩ := hx l,
-  linarith [hlA y hy],
+  exact ((hxy.trans_lt (hlA y hy)).trans hl).not_le le_rfl,
 end


### PR DESCRIPTION
Prove Eidelheit's theorem as a corollary to the geometric Hahn-Banach.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
