### PR TITLE
[Merged by Bors] - feat(algebra/order/monoid): Missing `has_exists_mul_of_le` instances

### DIFF
--- a/src/algebra/order/monoid.lean
+++ b/src/algebra/order/monoid.lean
@@ -1207,6 +1207,12 @@ instance : Π [partial_order α], partial_order (multiplicative α) := id
 instance : Π [partial_order α], partial_order (additive α) := id
 instance : Π [linear_order α], linear_order (multiplicative α) := id
 instance : Π [linear_order α], linear_order (additive α) := id
+instance [has_le α] : Π [order_bot α], order_bot (multiplicative α) := id
+instance [has_le α] : Π [order_bot α], order_bot (additive α) := id
+instance [has_le α] : Π [order_top α], order_top (multiplicative α) := id
+instance [has_le α] : Π [order_top α], order_top (additive α) := id
+instance [has_le α] : Π [bounded_order α], bounded_order (multiplicative α) := id
+instance [has_le α] : Π [bounded_order α], bounded_order (additive α) := id
 
 instance [ordered_add_comm_monoid α] : ordered_comm_monoid (multiplicative α) :=
 { mul_le_mul_left := @ordered_add_comm_monoid.add_le_add_left α _,
@@ -1242,6 +1248,22 @@ instance [has_add α] [has_le α]  [has_exists_add_of_le α] :
 
 instance [has_mul α] [has_le α]  [has_exists_mul_of_le α] : has_exists_add_of_le (additive α) :=
 ⟨@exists_mul_of_le α _ _ _⟩
+
+instance [canonically_ordered_add_monoid α] : canonically_ordered_monoid (multiplicative α) :=
+{ le_iff_exists_mul := @le_iff_exists_add α _,
+  ..multiplicative.ordered_comm_monoid, ..multiplicative.order_bot }
+
+instance [canonically_ordered_monoid α] : canonically_ordered_add_monoid (additive α) :=
+{ le_iff_exists_add := @le_iff_exists_mul α _,
+  ..additive.ordered_add_comm_monoid, ..additive.order_bot }
+
+instance [canonically_linear_ordered_add_monoid α] :
+  canonically_linear_ordered_monoid (multiplicative α) :=
+{ ..multiplicative.canonically_ordered_monoid, ..multiplicative.linear_order }
+
+instance [canonically_linear_ordered_monoid α] :
+  canonically_linear_ordered_add_monoid (additive α) :=
+{ ..additive.canonically_ordered_add_monoid, ..additive.linear_order }
 
 namespace additive
 

--- a/src/algebra/order/monoid.lean
+++ b/src/algebra/order/monoid.lean
@@ -26,7 +26,7 @@ set_option old_structure_cmd true
 open function
 
 universe u
-variable {α : Type u}
+variables {α : Type u} {β : Type*}
 
 /-- An ordered commutative monoid is a commutative monoid
 with a partial order such that `a ≤ b → c * a ≤ c * b` (multiplication is monotone)
@@ -85,13 +85,13 @@ end ordered_instances
 /-- An `ordered_comm_monoid` with one-sided 'division' in the sense that
 if `a ≤ b`, there is some `c` for which `a * c = b`. This is a weaker version
 of the condition on canonical orderings defined by `canonically_ordered_monoid`. -/
-class has_exists_mul_of_le (α : Type u) [ordered_comm_monoid α] : Prop :=
+class has_exists_mul_of_le (α : Type u) [has_mul α] [has_le α] : Prop :=
 (exists_mul_of_le : ∀ {a b : α}, a ≤ b → ∃ (c : α), b = a * c)
 
 /-- An `ordered_add_comm_monoid` with one-sided 'subtraction' in the sense that
 if `a ≤ b`, then there is some `c` for which `a + c = b`. This is a weaker version
 of the condition on canonical orderings defined by `canonically_ordered_add_monoid`. -/
-class has_exists_add_of_le (α : Type u) [ordered_add_comm_monoid α] : Prop :=
+class has_exists_add_of_le (α : Type u) [has_add α] [has_le α] : Prop :=
 (exists_add_of_le : ∀ {a b : α}, a ≤ b → ∃ (c : α), b = a + c)
 
 attribute [to_additive] has_exists_mul_of_le
@@ -770,11 +770,26 @@ namespace prod
 variables {M N : Type*}
 
 @[to_additive]
+instance [ordered_comm_monoid α] [ordered_comm_monoid β] : ordered_comm_monoid (α × β) :=
+{ mul_le_mul_left := λ a b h c, ⟨mul_le_mul_left' h.1 _, mul_le_mul_left' h.2 _⟩,
+  .. prod.comm_monoid, .. prod.partial_order _ _ }
+
+@[to_additive]
 instance [ordered_cancel_comm_monoid M] [ordered_cancel_comm_monoid N] :
   ordered_cancel_comm_monoid (M × N) :=
-{ mul_le_mul_left := λ a b h c, ⟨mul_le_mul_left' h.1 _, mul_le_mul_left' h.2 _⟩,
-  le_of_mul_le_mul_left := λ a b c h, ⟨le_of_mul_le_mul_left' h.1, le_of_mul_le_mul_left' h.2⟩,
- .. prod.cancel_comm_monoid, .. prod.partial_order M N }
+{ le_of_mul_le_mul_left := λ a b c h, ⟨le_of_mul_le_mul_left' h.1, le_of_mul_le_mul_left' h.2⟩,
+  .. prod.cancel_comm_monoid, .. prod.ordered_comm_monoid }
+
+@[to_additive] instance [has_le α] [has_le β] [has_mul α] [has_mul β] [has_exists_mul_of_le α]
+  [has_exists_mul_of_le β] : has_exists_mul_of_le (α × β) :=
+⟨λ a b h, let ⟨c, hc⟩ := exists_mul_of_le h.1, ⟨d, hd⟩ := exists_mul_of_le h.2 in
+  ⟨(c, d), ext hc hd⟩⟩
+
+@[to_additive] instance [canonically_ordered_monoid α] [canonically_ordered_monoid β] :
+  canonically_ordered_monoid (α × β) :=
+{ le_iff_exists_mul := λ a b,
+    ⟨exists_mul_of_le, by { rintro ⟨c, rfl⟩, exact ⟨le_self_mul, le_self_mul⟩ }⟩,
+  .. prod.ordered_comm_monoid, .. prod.order_bot _ _ }
 
 end prod
 
@@ -1182,6 +1197,10 @@ end with_bot
 
 section type_tags
 
+instance : Π [has_le α], has_le (multiplicative α) := id
+instance : Π [has_le α], has_le (additive α) := id
+instance : Π [has_lt α], has_lt (multiplicative α) := id
+instance : Π [has_lt α], has_lt (additive α) := id
 instance : Π [preorder α], preorder (multiplicative α) := id
 instance : Π [preorder α], preorder (additive α) := id
 instance : Π [partial_order α], partial_order (multiplicative α) := id
@@ -1216,6 +1235,13 @@ instance [linear_ordered_add_comm_monoid α] : linear_ordered_comm_monoid (multi
 instance [linear_ordered_comm_monoid α] : linear_ordered_add_comm_monoid (additive α) :=
 { ..additive.linear_order,
   ..additive.ordered_add_comm_monoid }
+
+instance [has_add α] [has_le α]  [has_exists_add_of_le α] :
+  has_exists_mul_of_le (multiplicative α) :=
+⟨@exists_add_of_le α _ _ _⟩
+
+instance [has_mul α] [has_le α]  [has_exists_mul_of_le α] : has_exists_add_of_le (additive α) :=
+⟨@exists_mul_of_le α _ _ _⟩
 
 namespace additive
 

--- a/src/algebra/order/monoid.lean
+++ b/src/algebra/order/monoid.lean
@@ -1242,11 +1242,11 @@ instance [linear_ordered_comm_monoid α] : linear_ordered_add_comm_monoid (addit
 { ..additive.linear_order,
   ..additive.ordered_add_comm_monoid }
 
-instance [has_add α] [has_le α]  [has_exists_add_of_le α] :
+instance [has_add α] [has_le α] [has_exists_add_of_le α] :
   has_exists_mul_of_le (multiplicative α) :=
 ⟨@exists_add_of_le α _ _ _⟩
 
-instance [has_mul α] [has_le α]  [has_exists_mul_of_le α] : has_exists_add_of_le (additive α) :=
+instance [has_mul α] [has_le α] [has_exists_mul_of_le α] : has_exists_add_of_le (additive α) :=
 ⟨@exists_mul_of_le α _ _ _⟩
 
 instance [canonically_ordered_add_monoid α] : canonically_ordered_monoid (multiplicative α) :=

--- a/src/algebra/order/pi.lean
+++ b/src/algebra/order/pi.lean
@@ -28,23 +28,18 @@ instance ordered_comm_monoid {ι : Type*} {Z : ι → Type*} [∀ i, ordered_com
   ..pi.partial_order,
   ..pi.comm_monoid, }
 
+@[to_additive] instance {ι : Type*} {α : ι → Type*} [Π i, has_le (α i)] [Π i, has_mul (α i)]
+  [Π i, has_exists_mul_of_le (α i)] :
+  has_exists_mul_of_le (Π i, α i) :=
+⟨λ a b h, ⟨λ i, (exists_mul_of_le $ h i).some, funext $ λ i, (exists_mul_of_le $ h i).some_spec⟩⟩
+
 /-- The product of a family of canonically ordered monoids is a canonically ordered monoid. -/
 @[to_additive "The product of a family of canonically ordered additive monoids is
   a canonically ordered additive monoid."]
 instance {ι : Type*} {Z : ι → Type*} [∀ i, canonically_ordered_monoid (Z i)] :
   canonically_ordered_monoid (Π i, Z i) :=
-{ le_iff_exists_mul := λ f g, begin
-    fsplit,
-    { intro w,
-      fsplit,
-      { exact λ i, (le_iff_exists_mul.mp (w i)).some, },
-      { ext i,
-        exact (le_iff_exists_mul.mp (w i)).some_spec, }, },
-    { rintro ⟨h, rfl⟩,
-      exact λ i, le_mul_right le_rfl, },
-  end,
-  ..pi.order_bot,
-  ..pi.ordered_comm_monoid, }
+{ le_iff_exists_mul := λ f g, ⟨exists_mul_of_le, by { rintro ⟨h, rfl⟩, exact λ i, le_self_mul }⟩,
+  ..pi.order_bot, ..pi.ordered_comm_monoid }
 
 @[to_additive]
 instance ordered_cancel_comm_monoid [∀ i, ordered_cancel_comm_monoid $ f i] :


### PR DESCRIPTION
Add a few `has_exists_mul_of_le` instances, generalize `has_exists_mul_of_le` to `has_le` + `has_mul`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
