### PR TITLE
[Merged by Bors] - feat(topology/vector_bundle): define some useful linear maps globally

### DIFF
--- a/src/topology/continuous_on.lean
+++ b/src/topology/continuous_on.lean
@@ -1026,10 +1026,15 @@ lemma continuous.if {p : α → Prop} {f g : α → β} [∀ a, decidable (p a)]
   continuous (λ a, if p a then f a else g a) :=
 continuous_if hp hf.continuous_on hg.continuous_on
 
+lemma continuous_if_const (p : Prop) {f g : α → β} [decidable p]
+  (hf : p → continuous f) (hg : ¬ p → continuous g) :
+  continuous (λ a, if p then f a else g a) :=
+by { split_ifs, exact hf h, exact hg h }
+
 lemma continuous.if_const (p : Prop) {f g : α → β} [decidable p]
   (hf : continuous f) (hg : continuous g) :
   continuous (λ a, if p then f a else g a) :=
-continuous_if (if h : p then by simp [h] else by simp [h]) hf.continuous_on hg.continuous_on
+continuous_if_const p (λ _, hf) (λ _, hg)
 
 lemma continuous_piecewise {s : set α} {f g : α → β} [∀ a, decidable (a ∈ s)]
   (hs : ∀ a ∈ frontier s, f a = g a) (hf : continuous_on f (closure s))

--- a/src/topology/vector_bundle.lean
+++ b/src/topology/vector_bundle.lean
@@ -378,7 +378,7 @@ e.to_pretrivialization.linear_equiv_at b hb
 
 @[simp]
 lemma linear_equiv_at_apply (e : trivialization R F E) (b : B) (hb : b ∈ e.base_set) (v : E b) :
-  e.linear_equiv_at b hb v = (e (total_space_mk E b v)).2 := rfl
+  e.linear_equiv_at b hb v = (e (total_space_mk b v)).2 := rfl
 
 @[simp]
 lemma linear_equiv_at_symm_apply (e : trivialization R F E) (b : B) (hb : b ∈ e.base_set) (v : F) :
@@ -396,15 +396,15 @@ protected def linear_map_at (e : trivialization R F E) (b : B) : E b →ₗ[R] F
 e.to_pretrivialization.linear_map_at b
 
 lemma coe_linear_map_at (e : trivialization R F E) (b : B) :
-  ⇑(e.linear_map_at b) = λ y, if b ∈ e.base_set then (e (total_space_mk E b y)).2 else 0 :=
+  ⇑(e.linear_map_at b) = λ y, if b ∈ e.base_set then (e (total_space_mk b y)).2 else 0 :=
 e.to_pretrivialization.coe_linear_map_at b
 
 lemma coe_linear_map_at_of_mem (e : trivialization R F E) {b : B} (hb : b ∈ e.base_set) :
-  ⇑(e.linear_map_at b) = λ y, (e (total_space_mk E b y)).2 :=
+  ⇑(e.linear_map_at b) = λ y, (e (total_space_mk b y)).2 :=
 by simp_rw [coe_linear_map_at, if_pos hb]
 
 lemma linear_map_at_apply (e : trivialization R F E) {b : B} (y : E b) :
-  e.linear_map_at b y = if b ∈ e.base_set then (e (total_space_mk E b y)).2 else 0 :=
+  e.linear_map_at b y = if b ∈ e.base_set then (e (total_space_mk b y)).2 else 0 :=
 by rw [coe_linear_map_at]
 
 lemma linear_map_at_def_of_mem (e : trivialization R F E) {b : B} (hb : b ∈ e.base_set) :

--- a/src/topology/vector_bundle.lean
+++ b/src/topology/vector_bundle.lean
@@ -376,6 +376,53 @@ def linear_equiv_at (e : trivialization R F E) (b : B) (hb : b ∈ e.base_set) :
   E b ≃ₗ[R] F :=
 e.to_pretrivialization.linear_equiv_at b hb
 
+@[simp]
+lemma linear_equiv_at_apply (e : trivialization R F E) (b : B) (hb : b ∈ e.base_set) (v : E b) :
+  e.linear_equiv_at b hb v = (e (total_space_mk E b v)).2 := rfl
+
+@[simp]
+lemma linear_equiv_at_symm_apply (e : trivialization R F E) (b : B) (hb : b ∈ e.base_set) (v : F) :
+  (e.linear_equiv_at b hb).symm v = e.symm b v := rfl
+
+/-- A fiberwise linear inverse to `e`. -/
+protected def symmₗ (e : trivialization R F E) (b : B) : F →ₗ[R] E b :=
+e.to_pretrivialization.symmₗ b
+
+lemma coe_symmₗ (e : trivialization R F E) (b : B) : ⇑(e.symmₗ b) = e.symm b :=
+rfl
+
+/-- A fiberwise linear map equal to `e` on `e.base_set`. -/
+protected def linear_map_at (e : trivialization R F E) (b : B) : E b →ₗ[R] F :=
+e.to_pretrivialization.linear_map_at b
+
+lemma coe_linear_map_at (e : trivialization R F E) (b : B) :
+  ⇑(e.linear_map_at b) = λ y, if b ∈ e.base_set then (e (total_space_mk E b y)).2 else 0 :=
+e.to_pretrivialization.coe_linear_map_at b
+
+lemma coe_linear_map_at_of_mem (e : trivialization R F E) {b : B} (hb : b ∈ e.base_set) :
+  ⇑(e.linear_map_at b) = λ y, (e (total_space_mk E b y)).2 :=
+by simp_rw [coe_linear_map_at, if_pos hb]
+
+lemma linear_map_at_apply (e : trivialization R F E) {b : B} (y : E b) :
+  e.linear_map_at b y = if b ∈ e.base_set then (e (total_space_mk E b y)).2 else 0 :=
+by rw [coe_linear_map_at]
+
+lemma linear_map_at_def_of_mem (e : trivialization R F E) {b : B} (hb : b ∈ e.base_set) :
+  e.linear_map_at b = e.linear_equiv_at b hb :=
+dif_pos hb
+
+lemma linear_map_at_def_of_not_mem (e : trivialization R F E) {b : B} (hb : b ∉ e.base_set) :
+  e.linear_map_at b = 0 :=
+dif_neg hb
+
+lemma symmₗ_linear_map_at (e : trivialization R F E) {b : B} (hb : b ∈ e.base_set) (y : E b) :
+  e.symmₗ b (e.linear_map_at b y) = y :=
+e.to_pretrivialization.symmₗ_linear_map_at hb y
+
+lemma linear_map_at_symmₗ (e : trivialization R F E) {b : B} (hb : b ∈ e.base_set) (y : F) :
+  e.linear_map_at b (e.symmₗ b y) = y :=
+e.to_pretrivialization.linear_map_at_symmₗ hb y
+
 /-- A coordinate change function between two trivializations, as a continuous linear equivalence.
   Defined to be the identity when `b` does not lie in the base set of both trivializations. -/
 def coord_change (e e' : trivialization R F E) (b : B) : F ≃L[R] F :=

--- a/src/topology/vector_bundle.lean
+++ b/src/topology/vector_bundle.lean
@@ -531,10 +531,13 @@ namespace trivialization
 @[simps apply {fully_applied := ff}]
 def continuous_linear_map_at (e : trivialization R F E) (b : B) :
   E b →L[R] F :=
-{ cont := by { dsimp, rw [e.coe_linear_map_at b],
-  refine continuous_if_const _ (λ hb, _) (λ _, continuous_zero),
-  refine continuous_snd.comp (e.to_local_homeomorph.continuous_on.comp_continuous
-    (total_space_mk_inducing R F E b).continuous (λ x, e.mem_source.mpr hb)) },
+{ cont := begin
+    dsimp,
+    rw [e.coe_linear_map_at b],
+    refine continuous_if_const _ (λ hb, _) (λ _, continuous_zero),
+    exact continuous_snd.comp (e.to_local_homeomorph.continuous_on.comp_continuous
+      (total_space_mk_inducing R F E b).continuous (λ x, e.mem_source.mpr hb))
+  end,
   .. e.linear_map_at b }
 
 /-- Backwards map of `continuous_linear_equiv_at`, defined everywhere. -/

--- a/src/topology/vector_bundle.lean
+++ b/src/topology/vector_bundle.lean
@@ -526,20 +526,13 @@ namespace topological_vector_bundle
 
 namespace trivialization
 
-lemma _root_.continuous.if_const' {α β : Type*} [topological_space α] [topological_space β] (p : Prop)
-  {f g : α → β} [decidable p]
-  (hf : p → continuous f) (hg : ¬ p → continuous g) :
-  continuous (λ a, if p then f a else g a) :=
-by { split_ifs, exact hf h, exact hg h }
-
-
 /-- Forward map of `continuous_linear_equiv_at` (only propositionally equal),
   defined everywhere (`0` outside domain). -/
 @[simps apply {fully_applied := ff}]
 def continuous_linear_map_at (e : trivialization R F E) (b : B) :
   E b →L[R] F :=
 { cont := by { dsimp, rw [e.coe_linear_map_at b],
-  refine continuous.if_const' _ (λ hb, _) (λ _, continuous_zero),
+  refine continuous_if_const _ (λ hb, _) (λ _, continuous_zero),
   refine continuous_snd.comp (e.to_local_homeomorph.continuous_on.comp_continuous
     (total_space_mk_inducing R F E b).continuous (λ x, e.mem_source.mpr hb)) },
   .. e.linear_map_at b }

--- a/src/topology/vector_bundle.lean
+++ b/src/topology/vector_bundle.lean
@@ -480,53 +480,6 @@ lemma coord_change_symm_apply (e e' : trivialization R F E) {b : B}
   ⇑(coord_change e e' b).symm = (e'.linear_equiv_at b hb.2).symm.trans (e.linear_equiv_at b hb.1) :=
 congr_arg linear_equiv.inv_fun (dif_pos hb)
 
-@[simp]
-lemma linear_equiv_at_apply (e : trivialization R F E) (b : B) (hb : b ∈ e.base_set) (v : E b) :
-  e.linear_equiv_at b hb v = (e (total_space_mk b v)).2 := rfl
-
-@[simp]
-lemma linear_equiv_at_symm_apply (e : trivialization R F E) (b : B) (hb : b ∈ e.base_set) (v : F) :
-  (e.linear_equiv_at b hb).symm v = e.symm b v := rfl
-
-/-- A fiberwise linear inverse to `e`. -/
-protected def symmₗ (e : trivialization R F E) (b : B) : F →ₗ[R] E b :=
-e.to_pretrivialization.symmₗ b
-
-lemma coe_symmₗ (e : trivialization R F E) (b : B) : ⇑(e.symmₗ b) = e.symm b :=
-rfl
-
-/-- A fiberwise linear map equal to `e` on `e.base_set`. -/
-protected def linear_map_at (e : trivialization R F E) (b : B) : E b →ₗ[R] F :=
-e.to_pretrivialization.linear_map_at b
-
-lemma coe_linear_map_at (e : trivialization R F E) (b : B) :
-  ⇑(e.linear_map_at b) = λ y, if b ∈ e.base_set then (e (total_space_mk b y)).2 else 0 :=
-e.to_pretrivialization.coe_linear_map_at b
-
-lemma coe_linear_map_at_of_mem (e : trivialization R F E) {b : B} (hb : b ∈ e.base_set) :
-  ⇑(e.linear_map_at b) = λ y, (e (total_space_mk b y)).2 :=
-by simp_rw [coe_linear_map_at, if_pos hb]
-
-lemma linear_map_at_apply (e : trivialization R F E) {b : B} (y : E b) :
-  e.linear_map_at b y = if b ∈ e.base_set then (e (total_space_mk b y)).2 else 0 :=
-by rw [coe_linear_map_at]
-
-lemma linear_map_at_def_of_mem (e : trivialization R F E) {b : B} (hb : b ∈ e.base_set) :
-  e.linear_map_at b = e.linear_equiv_at b hb :=
-dif_pos hb
-
-lemma linear_map_at_def_of_not_mem (e : trivialization R F E) {b : B} (hb : b ∉ e.base_set) :
-  e.linear_map_at b = 0 :=
-dif_neg hb
-
-lemma symmₗ_linear_map_at (e : trivialization R F E) {b : B} (hb : b ∈ e.base_set) (y : E b) :
-  e.symmₗ b (e.linear_map_at b y) = y :=
-e.to_pretrivialization.symmₗ_linear_map_at hb y
-
-lemma linear_map_at_symmₗ (e : trivialization R F E) {b : B} (hb : b ∈ e.base_set) (y : F) :
-  e.linear_map_at b (e.symmₗ b y) = y :=
-e.to_pretrivialization.linear_map_at_symmₗ hb y
-
 end topological_vector_bundle.trivialization
 
 end topological_vector_space


### PR DESCRIPTION
* Define `pretrivialization.symmₗ`, `pretrivialization.linear_map_at`, `trivialization.symmL`, `trivialization.continuous_linear_map_at`
* These are globally-defined (continuous) linear maps. They are linear equivalences on `e.base_set`, but it is useful to define these globally. They are defined as `0` outside `e.base_set`
* These are convenient to define the vector bundle of continuous linear maps.

---

- [x] depends on: #14359 

This (slightly) conflicts with #14462. ~Please merge that PR first, unless this reviews much more easily (branch `vb-hom-floris` has the merge conflict resolved)~

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
