### PR TITLE
[Merged by Bors] - feat(analysis/asymptotics/asymptotics): generalize `is_O.smul` etc

### DIFF
--- a/src/analysis/asymptotics/asymptotics.lean
+++ b/src/analysis/asymptotics/asymptotics.lean
@@ -1115,29 +1115,29 @@ end smul_const
 
 section smul
 
-variables [normed_space 𝕜 E'] [normed_space 𝕜 F']
+variables [normed_space 𝕜 E'] [normed_space 𝕜' F'] {k₁ : α → 𝕜} {k₂ : α → 𝕜'}
 
-theorem is_O_with.smul {k₁ k₂ : α → 𝕜} (h₁ : is_O_with c l k₁ k₂) (h₂ : is_O_with c' l f' g') :
+theorem is_O_with.smul (h₁ : is_O_with c l k₁ k₂) (h₂ : is_O_with c' l f' g') :
   is_O_with (c * c') l (λ x, k₁ x • f' x) (λ x, k₂ x • g' x) :=
 by refine ((h₁.norm_norm.mul h₂.norm_norm).congr rfl _ _).of_norm_norm;
   by intros; simp only [norm_smul]
 
-theorem is_O.smul {k₁ k₂ : α → 𝕜} (h₁ : k₁ =O[l] k₂) (h₂ : f' =O[l] g') :
+theorem is_O.smul (h₁ : k₁ =O[l] k₂) (h₂ : f' =O[l] g') :
   (λ x, k₁ x • f' x) =O[l] (λ x, k₂ x • g' x) :=
 by refine ((h₁.norm_norm.mul h₂.norm_norm).congr _ _).of_norm_norm;
   by intros; simp only [norm_smul]
 
-theorem is_O.smul_is_o {k₁ k₂ : α → 𝕜} (h₁ : k₁ =O[l] k₂) (h₂ : f' =o[l] g') :
+theorem is_O.smul_is_o (h₁ : k₁ =O[l] k₂) (h₂ : f' =o[l] g') :
   (λ x, k₁ x • f' x) =o[l] (λ x, k₂ x • g' x) :=
 by refine ((h₁.norm_norm.mul_is_o h₂.norm_norm).congr _ _).of_norm_norm;
   by intros; simp only [norm_smul]
 
-theorem is_o.smul_is_O {k₁ k₂ : α → 𝕜} (h₁ : k₁ =o[l] k₂) (h₂ : f' =O[l] g') :
+theorem is_o.smul_is_O (h₁ : k₁ =o[l] k₂) (h₂ : f' =O[l] g') :
   (λ x, k₁ x • f' x) =o[l] (λ x, k₂ x • g' x) :=
 by refine ((h₁.norm_norm.mul_is_O h₂.norm_norm).congr _ _).of_norm_norm;
   by intros; simp only [norm_smul]
 
-theorem is_o.smul {k₁ k₂ : α → 𝕜} (h₁ : k₁ =o[l] k₂) (h₂ : f' =o[l] g') :
+theorem is_o.smul (h₁ : k₁ =o[l] k₂) (h₂ : f' =o[l] g') :
   (λ x, k₁ x • f' x) =o[l] (λ x, k₂ x • g' x) :=
 by refine ((h₁.norm_norm.mul h₂.norm_norm).congr _ _).of_norm_norm;
   by intros; simp only [norm_smul]


### PR DESCRIPTION
Allow `(k₁ : α → 𝕜) (k₂ : α → 𝕜')` instead of `(k₁ k₂ : α → 𝕜)`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
