### PR TITLE
[Merged by Bors] - feat(tactic/set): fix a bug

### DIFF
--- a/src/algebra/order/lattice_group.lean
+++ b/src/algebra/order/lattice_group.lean
@@ -29,7 +29,7 @@ number of equations and inequalities.
 
 - `a⁺ = a ⊔ 0`: The *positive component* of an element `a` of a lattice ordered commutative group
 - `a⁻ = (-a) ⊔ 0`: The *negative component* of an element `a` of a lattice ordered commutative group
-* `|a| = a⊔(-a)`: The *absolute value* of an element `a` of a lattice ordered commutative group
+- `|a| = a⊔(-a)`: The *absolute value* of an element `a` of a lattice ordered commutative group
 
 ## Implementation notes
 

--- a/src/data/nat/prime.lean
+++ b/src/data/nat/prime.lean
@@ -25,8 +25,8 @@ This file deals with prime numbers: natural numbers `p ≥ 2` whose only divisor
   This also appears as `nat.not_bdd_above_set_of_prime` and `nat.infinite_set_of_prime`.
 - `nat.factors n`: the prime factorization of `n`
 - `nat.factors_unique`: uniqueness of the prime factorisation
-* `nat.prime_iff`: `nat.prime` coincides with the general definition of `prime`
-* `nat.irreducible_iff_prime`: a non-unit natural number is only divisible by `1` iff it is prime
+- `nat.prime_iff`: `nat.prime` coincides with the general definition of `prime`
+- `nat.irreducible_iff_prime`: a non-unit natural number is only divisible by `1` iff it is prime
 
 -/
 

--- a/src/tactic/interactive.lean
+++ b/src/tactic/interactive.lean
@@ -828,7 +828,7 @@ end
 meta def set (h_simp : parse (tk "!")?) (a : parse ident) (tp : parse ((tk ":") *> texpr)?)
   (_ : parse (tk ":=")) (pv : parse texpr)
   (rev_name : parse opt_dir_with) :=
-do tp ← i_to_expr $ tp.get_or_else pexpr.mk_placeholder,
+do tp ← i_to_expr $ let t := tp.get_or_else pexpr.mk_placeholder in ``(%%t : Sort*),
    pv ← to_expr ``(%%pv : %%tp),
    tp ← instantiate_mvars tp,
    definev a tp pv,

--- a/test/set.lean
+++ b/test/set.lean
@@ -36,3 +36,18 @@ begin
   set b : T := u, -- the type `T` can't be fully elaborated without the body but this is fine
   trivial
 end
+
+section fivefivefive
+
+inductive foo | bar
+
+instance : has_coe_to_sort foo _ :=
+⟨λ _, unit⟩
+
+example : true :=
+begin
+  set x : foo.bar := (),
+  trivial,
+end
+
+end fivefivefive

--- a/test/set.lean
+++ b/test/set.lean
@@ -37,7 +37,7 @@ begin
   trivial
 end
 
-section fivefivefive
+section lean_555 -- https://github.com/leanprover-community/mathlib/pull/14488
 
 inductive foo | bar
 
@@ -50,4 +50,4 @@ begin
   trivial,
 end
 
-end fivefivefive
+end lean_555


### PR DESCRIPTION
We make the behaviour of `tactic.interactive.set` closer to that of `tactic.interactive.let`, this should fix the following issue reported in https://leanprover.zulipchat.com/#narrow/stream/113489-new-members/topic/set.20bug.3F/near/284471523:
```lean
import ring_theory.adjoin.basic

example {R S : Type*} [comm_ring R] [comm_ring S] [algebra R S] (x : S): false :=
begin
  let y : algebra.adjoin R ({x} : set S) := ⟨x, algebra.self_mem_adjoin_singleton R x⟩, -- works
  set y : algebra.adjoin R ({x} : set S) := ⟨x, algebra.self_mem_adjoin_singleton R x⟩, -- error
  sorry
end
```
This is related to [lean#555
](https://github.com/leanprover-community/lean/pull/555)

I also fix two completely unrelated docstrings (where the list syntax created two lists instead of one) as I wouldn't want to separately add them to CI...

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
