### PR TITLE
[Merged by Bors] - feat(data/int/basic): Lemmas for when a square equals 1

### DIFF
--- a/src/data/int/basic.lean
+++ b/src/data/int/basic.lean
@@ -1604,7 +1604,7 @@ begin
   exact lt_of_lt_of_le h2 (le_abs_self m),
 end
 
-lemma sq_eq_one_of_sq_lt {x : ℤ} (h1 : x ^ 2 < 4) (h2 : x ≠ 0) : x ^ 2 = 1 :=
+lemma sq_eq_one_of_sq_lt_four {x : ℤ} (h1 : x ^ 2 < 4) (h2 : x ≠ 0) : x ^ 2 = 1 :=
 sq_eq_one_iff.mpr ((abs_eq (@zero_le_one ℤ _)).mp (le_antisymm (lt_add_one_iff.mp
   (abs_lt_of_sq_lt_sq h1 zero_le_two)) (sub_one_lt_iff.mp (abs_pos.mpr h2))))
 

--- a/src/data/int/basic.lean
+++ b/src/data/int/basic.lean
@@ -1609,7 +1609,7 @@ sq_eq_one_iff.mpr ((abs_eq (@zero_le_one ℤ _)).mp (le_antisymm (lt_add_one_iff
   (abs_lt_of_sq_lt_sq h1 zero_le_two)) (sub_one_lt_iff.mp (abs_pos.mpr h2))))
 
 lemma sq_eq_one_of_sq_le_three {x : ℤ} (h1 : x ^ 2 ≤ 3) (h2 : x ≠ 0) : x ^ 2 = 1 :=
-sq_eq_one_of_sq_lt (lt_of_le_of_lt h1 (lt_add_one 3)) h2
+sq_eq_one_of_sq_lt_four (lt_of_le_of_lt h1 (lt_add_one 3)) h2
 
 end int
 

--- a/src/data/int/basic.lean
+++ b/src/data/int/basic.lean
@@ -1608,7 +1608,7 @@ lemma sq_eq_one_of_sq_lt_four {x : ℤ} (h1 : x ^ 2 < 4) (h2 : x ≠ 0) : x ^ 2 
 sq_eq_one_iff.mpr ((abs_eq (@zero_le_one ℤ _)).mp (le_antisymm (lt_add_one_iff.mp
   (abs_lt_of_sq_lt_sq h1 zero_le_two)) (sub_one_lt_iff.mp (abs_pos.mpr h2))))
 
-lemma sq_eq_one_of_sq_le {x : ℤ} (h1 : x ^ 2 ≤ 3) (h2 : x ≠ 0) : x ^ 2 = 1 :=
+lemma sq_eq_one_of_sq_le_three {x : ℤ} (h1 : x ^ 2 ≤ 3) (h2 : x ≠ 0) : x ^ 2 = 1 :=
 sq_eq_one_of_sq_lt (lt_of_le_of_lt h1 (lt_add_one 3)) h2
 
 end int

--- a/src/data/int/basic.lean
+++ b/src/data/int/basic.lean
@@ -1604,6 +1604,13 @@ begin
   exact lt_of_lt_of_le h2 (le_abs_self m),
 end
 
+lemma sq_eq_one_of_sq_lt {x : ℤ} (h1 : x ^ 2 < 4) (h2 : x ≠ 0) : x ^ 2 = 1 :=
+sq_eq_one_iff.mpr ((abs_eq (@zero_le_one ℤ _)).mp (le_antisymm (lt_add_one_iff.mp
+  (abs_lt_of_sq_lt_sq h1 zero_le_two)) (sub_one_lt_iff.mp (abs_pos.mpr h2))))
+
+lemma sq_eq_one_of_sq_le {x : ℤ} (h1 : x ^ 2 ≤ 3) (h2 : x ≠ 0) : x ^ 2 = 1 :=
+sq_eq_one_of_sq_lt (lt_of_le_of_lt h1 (lt_add_one 3)) h2
+
 end int
 
 attribute [irreducible] int.nonneg


### PR DESCRIPTION
This PR adds two lemmas for when a square equals one. The `lt` lemma will be useful for irreducibility of x^n-x-1.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
