### PR TITLE
[Merged by Bors] - feat(linear_algebra/basis): repr_support_of_mem_span

### DIFF
--- a/src/linear_algebra/basis.lean
+++ b/src/linear_algebra/basis.lean
@@ -147,7 +147,7 @@ lemma mem_span_repr_support {ι : Type*} (b : basis ι R M) (m : M) :
 (finsupp.mem_span_image_iff_total _).2 ⟨b.repr m, (by simp [finsupp.mem_supported_support])⟩
 
 lemma repr_support_of_mem_span {ι : Type*}
-  (b : basis ι R M) (s : set ι) (m : M) (hm : m ∈ span R (b '' s)) : ↑(b.repr m).support ⊆ s :=
+  (b : basis ι R M) (s : set ι) {m : M} (hm : m ∈ span R (b '' s)) : ↑(b.repr m).support ⊆ s :=
 begin
   rcases (finsupp.mem_span_image_iff_total _).1 hm with ⟨l, hl, hlm⟩,
   rwa [←hlm, repr_total, ←finsupp.mem_supported R l]

--- a/src/linear_algebra/basis.lean
+++ b/src/linear_algebra/basis.lean
@@ -146,7 +146,7 @@ lemma mem_span_repr_support {ι : Type*} (b : basis ι R M) (m : M) :
   m ∈ span R (b '' (b.repr m).support) :=
 (finsupp.mem_span_image_iff_total _).2 ⟨b.repr m, (by simp [finsupp.mem_supported_support])⟩
 
-lemma repr_support_of_mem_span {ι : Type*}
+lemma repr_support_subset_of_mem_span {ι : Type*}
   (b : basis ι R M) (s : set ι) {m : M} (hm : m ∈ span R (b '' s)) : ↑(b.repr m).support ⊆ s :=
 begin
   rcases (finsupp.mem_span_image_iff_total _).1 hm with ⟨l, hl, hlm⟩,

--- a/src/linear_algebra/basis.lean
+++ b/src/linear_algebra/basis.lean
@@ -146,6 +146,13 @@ lemma mem_span_repr_support {ι : Type*} (b : basis ι R M) (m : M) :
   m ∈ span R (b '' (b.repr m).support) :=
 (finsupp.mem_span_image_iff_total _).2 ⟨b.repr m, (by simp [finsupp.mem_supported_support])⟩
 
+lemma repr_support_of_mem_span {ι : Type*}
+  (b : basis ι R M) (s : set ι) (m : M) (hm : m ∈ span R (b '' s)) : ↑(b.repr m).support ⊆ s :=
+begin
+  rcases (finsupp.mem_span_image_iff_total _).1 hm with ⟨l, hl, hlm⟩,
+  rwa [←hlm, repr_total, ←finsupp.mem_supported R l],
+end
+
 end repr
 
 section coord

--- a/src/linear_algebra/basis.lean
+++ b/src/linear_algebra/basis.lean
@@ -150,7 +150,7 @@ lemma repr_support_of_mem_span {ι : Type*}
   (b : basis ι R M) (s : set ι) (m : M) (hm : m ∈ span R (b '' s)) : ↑(b.repr m).support ⊆ s :=
 begin
   rcases (finsupp.mem_span_image_iff_total _).1 hm with ⟨l, hl, hlm⟩,
-  rwa [←hlm, repr_total, ←finsupp.mem_supported R l],
+  rwa [←hlm, repr_total, ←finsupp.mem_supported R l]
 end
 
 end repr


### PR DESCRIPTION
This lemma states that if a vector is in the span of a subset of the basis vectors, only this subset of basis vectors will be used in its `repr` representation.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
