### PR TITLE
feat(category_theory/sites/cover_lifting): Compatibility between pullback and sheafificatiion

### DIFF
--- a/src/category_theory/sites/cover_lifting.lean
+++ b/src/category_theory/sites/cover_lifting.lean
@@ -97,7 +97,7 @@ In `glued_limit_cone`, we verify these obtained sections are indeed compatible, 
 A `X ⟶ 𝒢(U)`. The remaining work is to verify that this is indeed the amalgamation and is unique.
 -/
 variables {C D : Type u} [category.{v} C] [category.{v} D]
-variables {A : Type w} [category.{max u v} A] [has_limits A]
+variables {A : Type w} [category.{max v u} A] [has_limits A]
 variables {J : grothendieck_topology C} {K : grothendieck_topology D}
 
 namespace Ran_is_sheaf_of_cover_lifting
@@ -282,5 +282,39 @@ def sites.pullback_copullback_adjunction {G : C ⥤ D} (Hp : cover_preserving J 
     naturality' := λ _ _ f, Sheaf.hom.ext _ _ $ (Ran.adjunction A G.op).counit.naturality f.val },
   hom_equiv_unit' := λ X Y f, by { ext1, apply (Ran.adjunction A G.op).hom_equiv_unit },
   hom_equiv_counit' := λ X Y f, by { ext1, apply (Ran.adjunction A G.op).hom_equiv_counit } }
+
+namespace sites
+
+variables
+  [concrete_category.{max v u} A]
+  [preserves_limits (forget A)]
+  [reflects_isomorphisms (forget A)]
+  [Π (X : C), preserves_colimits_of_shape (J.cover X)ᵒᵖ (forget A)]
+  [∀ (X : C), has_colimits_of_shape (J.cover X)ᵒᵖ A]
+  [Π (X : D), preserves_colimits_of_shape (K.cover X)ᵒᵖ (forget A)]
+  [∀ (X : D), has_colimits_of_shape (K.cover X)ᵒᵖ A]
+
+/-- The isomorphism exhibiting compatibility between pullback and sheafification. -/
+def whiskering_left_comp_presheaf_to_Sheaf_iso_presheaf_to_Sheaf_comp_pullback
+  {G : C ⥤ D} (Hp : cover_preserving J K G)
+  (Hl : cover_lifting J K G) (Hc : compatible_preserving K G) :
+  (whiskering_left _ _ A).obj G.op ⋙ presheaf_to_Sheaf J A ≅
+  presheaf_to_Sheaf K A ⋙ sites.pullback A Hc Hp :=
+let A1 : (whiskering_left _ _ A).obj G.op ⊣ _ := Ran.adjunction _ _,
+    A2 : presheaf_to_Sheaf J A ⊣ _ := sheafification_adjunction _ _,
+    B1 : presheaf_to_Sheaf K A ⊣ _ := sheafification_adjunction _ _,
+    B2 : sites.pullback A Hc Hp ⊣ _ := sites.pullback_copullback_adjunction _ _ Hl _,
+    A := A1.comp _ _ A2,
+    B := B1.comp _ _ B2 in
+A.left_adjoint_uniq B
+
+lemma whiskering_left_comp_presheaf_to_Sheaf_iso_presheaf_to_Sheaf_comp_pullback_hom_apply_val
+  {G : C ⥤ D} (Hp : cover_preserving J K G)
+  (Hl : cover_lifting J K G) (Hc : compatible_preserving K G) (F) :
+((sites.whiskering_left_comp_presheaf_to_Sheaf_iso_presheaf_to_Sheaf_comp_pullback.{w v u}
+  A Hp Hl Hc).hom.app F).val = J.sheafify_lift
+  (whisker_left _ (K.to_sheafify _)) (Sheaf.cond _) := sorry
+
+end sites
 
 end category_theory

--- a/src/category_theory/sites/cover_lifting.lean
+++ b/src/category_theory/sites/cover_lifting.lean
@@ -295,7 +295,7 @@ variables
   [∀ (X : D), has_colimits_of_shape (K.cover X)ᵒᵖ A]
 
 /-- The isomorphism exhibiting compatibility between pullback and sheafification. -/
-def whiskering_left_comp_presheaf_to_Sheaf_iso_presheaf_to_Sheaf_comp_pullback
+def pullback_sheafification_compatibility
   {G : C ⥤ D} (Hp : cover_preserving J K G)
   (Hl : cover_lifting J K G) (Hc : compatible_preserving K G) :
   (whiskering_left _ _ A).obj G.op ⋙ presheaf_to_Sheaf J A ≅
@@ -304,16 +304,49 @@ let A1 : (whiskering_left _ _ A).obj G.op ⊣ _ := Ran.adjunction _ _,
     A2 : presheaf_to_Sheaf J A ⊣ _ := sheafification_adjunction _ _,
     B1 : presheaf_to_Sheaf K A ⊣ _ := sheafification_adjunction _ _,
     B2 : sites.pullback A Hc Hp ⊣ _ := sites.pullback_copullback_adjunction _ _ Hl _,
-    A := A1.comp _ _ A2,
-    B := B1.comp _ _ B2 in
-A.left_adjoint_uniq B
+    A12 := A1.comp _ _ A2,
+    B12 := B1.comp _ _ B2 in
+A12.left_adjoint_uniq B12
 
-lemma whiskering_left_comp_presheaf_to_Sheaf_iso_presheaf_to_Sheaf_comp_pullback_hom_apply_val
+lemma to_sheafify_pullback_sheafification_compatibility
   {G : C ⥤ D} (Hp : cover_preserving J K G)
   (Hl : cover_lifting J K G) (Hc : compatible_preserving K G) (F) :
-((sites.whiskering_left_comp_presheaf_to_Sheaf_iso_presheaf_to_Sheaf_comp_pullback.{w v u}
-  A Hp Hl Hc).hom.app F).val = J.sheafify_lift
-  (whisker_left _ (K.to_sheafify _)) (Sheaf.cond _) := sorry
+  J.to_sheafify (G.op ⋙ F) ≫
+  ((pullback_sheafification_compatibility.{w v u} A Hp Hl Hc).hom.app F).val =
+  whisker_left _ (K.to_sheafify _) :=
+begin
+  dsimp [pullback_sheafification_compatibility, adjunction.left_adjoint_uniq],
+  apply quiver.hom.op_inj,
+  apply coyoneda.map_injective, swap, apply_instance,
+  ext E f : 2,
+  dsimp [functor.preimage, full.preimage, coyoneda, adjunction.left_adjoints_coyoneda_equiv],
+  simp only [adjunction.hom_equiv_unit, functor.comp_map, Sheaf_to_presheaf_map,
+    adjunction.hom_equiv_naturality_left_symm, whiskering_left_obj_map,
+    adjunction.hom_equiv_counit, Sheaf.category_theory.category_comp_val,
+    presheaf_to_Sheaf_map_val],
+  dsimp [adjunction.comp],
+  simp only [sheafification_adjunction_unit_app, category.comp_id, functor.map_id,
+    whisker_left_id', category.assoc, grothendieck_topology.sheafify_map_sheafify_lift,
+    category.id_comp, grothendieck_topology.to_sheafify_sheafify_lift],
+  ext t,
+  dsimp, simp only [category.assoc], congr' 1, simp only [← category.assoc],
+  convert category.id_comp _,
+  dsimp [pullback_sheaf],
+  have := (Ran.adjunction A G.op).left_triangle,
+  apply_fun (λ e, (e.app (K.sheafify F)).app x) at this,
+  exact this,
+end
+
+@[simp]
+lemma pullback_sheafification_compatibility_hom_apply_val
+  {G : C ⥤ D} (Hp : cover_preserving J K G)
+  (Hl : cover_lifting J K G) (Hc : compatible_preserving K G) (F) :
+((pullback_sheafification_compatibility.{w v u} A Hp Hl Hc).hom.app F).val =
+  J.sheafify_lift (whisker_left _ $ K.to_sheafify _) (Sheaf.cond _) :=
+begin
+  apply J.sheafify_lift_unique,
+  apply to_sheafify_pullback_sheafification_compatibility,
+end
 
 end sites
 

--- a/src/category_theory/sites/dense_subsite.lean
+++ b/src/category_theory/sites/dense_subsite.lean
@@ -494,6 +494,8 @@ variables
   [Π (X : D), limits.preserves_colimits_of_shape (K.cover X)ᵒᵖ (forget A)]
   [∀ (X : D), limits.has_colimits_of_shape (K.cover X)ᵒᵖ A]
 
+/-- The isomorphism exhibiting the compatibiility of
+`Sheaf_equiv_of_cover_preserving_cover_lifting` with sheafification. -/
 noncomputable
 abbreviation Sheaf_equiv_of_cover_preserving_cover_lifting_sheafification_compatibility :
   (whiskering_left _ _ A).obj G.op ⋙ presheaf_to_Sheaf _ _ ≅

--- a/src/category_theory/sites/dense_subsite.lean
+++ b/src/category_theory/sites/dense_subsite.lean
@@ -485,4 +485,19 @@ begin
     functor_unit_iso_comp' := λ ℱ, by convert α.left_triangle_components }
 end
 
+variables
+  [concrete_category.{max v u} A]
+  [limits.preserves_limits (forget A)]
+  [reflects_isomorphisms (forget A)]
+  [Π (X : C), limits.preserves_colimits_of_shape (J.cover X)ᵒᵖ (forget A)]
+  [∀ (X : C), limits.has_colimits_of_shape (J.cover X)ᵒᵖ A]
+  [Π (X : D), limits.preserves_colimits_of_shape (K.cover X)ᵒᵖ (forget A)]
+  [∀ (X : D), limits.has_colimits_of_shape (K.cover X)ᵒᵖ A]
+
+noncomputable
+abbreviation Sheaf_equiv_of_cover_preserving_cover_lifting_sheafification_compatibility :
+  (whiskering_left _ _ A).obj G.op ⋙ presheaf_to_Sheaf _ _ ≅
+  presheaf_to_Sheaf _ _ ⋙ (Sheaf_equiv_of_cover_preserving_cover_lifting Hd Hp Hl).inverse :=
+sites.pullback_sheafification_compatibility _ _ Hl _
+
 end category_theory.cover_dense

--- a/src/category_theory/sites/dense_subsite.lean
+++ b/src/category_theory/sites/dense_subsite.lean
@@ -458,7 +458,7 @@ open category_theory
 variables {C D : Type u} [category.{v} C] [category.{v} D]
 variables {G : C ⥤ D} [full G] [faithful G]
 variables {J : grothendieck_topology C} {K : grothendieck_topology D}
-variables {A : Type w} [category.{max u v} A] [limits.has_limits A]
+variables {A : Type w} [category.{max v u} A] [limits.has_limits A]
 variables (Hd : cover_dense K G) (Hp : cover_preserving J K G) (Hl : cover_lifting J K G)
 
 include Hd Hp Hl


### PR DESCRIPTION
This was needed in LTE, and the proof is quick, so I figured I should add it to mathlib now.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
