### PR TITLE
[Merged by Bors] - refactor(group_theory/group_action/defs): rename has_faithful_scalar

### DIFF
--- a/scripts/nolints.txt
+++ b/scripts/nolints.txt
@@ -413,7 +413,7 @@ apply_nolint monoid.to_opposite_mul_action to_additive_doc
 -- group_theory/group_action/pi.lean
 apply_nolint function.has_scalar to_additive_doc
 apply_nolint function.smul_comm_class to_additive_doc
-apply_nolint pi.has_faithful_scalar_at to_additive_doc
+apply_nolint pi.has_faithful_smul_at to_additive_doc
 
 -- group_theory/group_action/sub_mul_action.lean
 apply_nolint sub_mul_action.has_zero fails_quickly

--- a/src/algebra/algebra/basic.lean
+++ b/src/algebra/algebra/basic.lean
@@ -1157,7 +1157,7 @@ instance apply_mul_semiring_action : mul_semiring_action (A₁ ≃ₐ[R] A₁) A
 
 @[simp] protected lemma smul_def (f : A₁ ≃ₐ[R] A₁) (a : A₁) : f • a = f a := rfl
 
-instance apply_has_faithful_scalar : has_faithful_scalar (A₁ ≃ₐ[R] A₁) A₁ :=
+instance apply_has_faithful_smul : has_faithful_smul (A₁ ≃ₐ[R] A₁) A₁ :=
 ⟨λ _ _, alg_equiv.ext⟩
 
 instance apply_smul_comm_class : smul_comm_class R (A₁ ≃ₐ[R] A₁) A₁ :=
@@ -1228,7 +1228,7 @@ This is a stronger version of `mul_semiring_action.to_ring_hom` and
 def to_alg_hom (m : M) : A →ₐ[R] A :=
 alg_hom.mk' (mul_semiring_action.to_ring_hom _ _ m) (smul_comm _)
 
-theorem to_alg_hom_injective [has_faithful_scalar M A] :
+theorem to_alg_hom_injective [has_faithful_smul M A] :
   function.injective (mul_semiring_action.to_alg_hom R A : M → A →ₐ[R] A) :=
 λ m₁ m₂ h, eq_of_smul_eq_smul $ λ r, alg_hom.ext_iff.1 h r
 
@@ -1246,7 +1246,7 @@ def to_alg_equiv (g : G) : A ≃ₐ[R] A :=
 { .. mul_semiring_action.to_ring_equiv _ _ g,
   .. mul_semiring_action.to_alg_hom R A g }
 
-theorem to_alg_equiv_injective [has_faithful_scalar G A] :
+theorem to_alg_equiv_injective [has_faithful_smul G A] :
   function.injective (mul_semiring_action.to_alg_equiv R A : G → A ≃ₐ[R] A) :=
 λ m₁ m₂ h, eq_of_smul_eq_smul $ λ r, alg_equiv.ext_iff.1 h r
 

--- a/src/algebra/algebra/subalgebra/basic.lean
+++ b/src/algebra/algebra/subalgebra/basic.lean
@@ -934,9 +934,9 @@ instance is_scalar_tower_left
   is_scalar_tower S α β :=
 S.to_subsemiring.is_scalar_tower
 
-instance [has_scalar A α] [has_faithful_scalar A α] (S : subalgebra R A) :
-  has_faithful_scalar S α :=
-S.to_subsemiring.has_faithful_scalar
+instance [has_scalar A α] [has_faithful_smul A α] (S : subalgebra R A) :
+  has_faithful_smul S α :=
+S.to_subsemiring.has_faithful_smul
 
 /-- The action by a subalgebra is the action by the underlying algebra. -/
 instance [mul_action A α] (S : subalgebra R A) : mul_action S α :=

--- a/src/algebra/group_ring_action.lean
+++ b/src/algebra/group_ring_action.lean
@@ -55,7 +55,7 @@ def mul_semiring_action.to_ring_hom [mul_semiring_action M R] (x : M) : R →+* 
 { .. mul_distrib_mul_action.to_monoid_hom R x,
   .. distrib_mul_action.to_add_monoid_hom R x }
 
-theorem to_ring_hom_injective [mul_semiring_action M R] [has_faithful_scalar M R] :
+theorem to_ring_hom_injective [mul_semiring_action M R] [has_faithful_smul M R] :
   function.injective (mul_semiring_action.to_ring_hom M R) :=
 λ m₁ m₂ h, eq_of_smul_eq_smul $ λ r, ring_hom.ext_iff.1 h r
 

--- a/src/algebra/hom/aut.lean
+++ b/src/algebra/hom/aut.lean
@@ -83,7 +83,7 @@ instance apply_mul_distrib_mul_action {M} [monoid M] : mul_distrib_mul_action (m
 @[simp] protected lemma smul_def {M} [monoid M] (f : mul_aut M) (a : M) : f • a = f a := rfl
 
 /-- `mul_aut.apply_mul_action` is faithful. -/
-instance apply_has_faithful_scalar {M} [monoid M] : has_faithful_scalar (mul_aut M) M :=
+instance apply_has_faithful_smul {M} [monoid M] : has_faithful_smul (mul_aut M) M :=
 ⟨λ _ _, mul_equiv.ext⟩
 
 /-- Group conjugation, `mul_aut.conj g h = g * h * g⁻¹`, as a monoid homomorphism
@@ -159,7 +159,7 @@ instance apply_distrib_mul_action {A} [add_monoid A] : distrib_mul_action (add_a
 @[simp] protected lemma smul_def {A} [add_monoid A] (f : add_aut A) (a : A) : f • a = f a := rfl
 
 /-- `add_aut.apply_distrib_mul_action` is faithful. -/
-instance apply_has_faithful_scalar {A} [add_monoid A] : has_faithful_scalar (add_aut A) A :=
+instance apply_has_faithful_smul {A} [add_monoid A] : has_faithful_smul (add_aut A) A :=
 ⟨λ _ _, add_equiv.ext⟩
 
 /-- Additive group conjugation, `add_aut.conj g h = g + h - g`, as an additive monoid

--- a/src/algebra/module/basic.lean
+++ b/src/algebra/module/basic.lean
@@ -297,7 +297,7 @@ instance ring_hom.apply_distrib_mul_action [semiring R] : distrib_mul_action (R 
   f • a = f a := rfl
 
 /-- `ring_hom.apply_distrib_mul_action` is faithful. -/
-instance ring_hom.apply_has_faithful_scalar [semiring R] : has_faithful_scalar (R →+* R) R :=
+instance ring_hom.apply_has_faithful_smul [semiring R] : has_faithful_smul (R →+* R) R :=
 ⟨ring_hom.ext⟩
 
 section add_comm_monoid

--- a/src/algebra/module/equiv.lean
+++ b/src/algebra/module/equiv.lean
@@ -481,7 +481,7 @@ instance apply_distrib_mul_action : distrib_mul_action (M ≃ₗ[R] M) M :=
   f • a = f a := rfl
 
 /-- `linear_equiv.apply_distrib_mul_action` is faithful. -/
-instance apply_has_faithful_scalar : has_faithful_scalar (M ≃ₗ[R] M) M :=
+instance apply_has_faithful_smul : has_faithful_smul (M ≃ₗ[R] M) M :=
 ⟨λ _ _, linear_equiv.ext⟩
 
 instance apply_smul_comm_class : smul_comm_class R (M ≃ₗ[R] M) M :=

--- a/src/algebra/module/linear_map.lean
+++ b/src/algebra/module/linear_map.lean
@@ -847,7 +847,7 @@ instance apply_module : module (module.End R M) M :=
 @[simp] protected lemma smul_def (f : module.End R M) (a : M) : f • a = f a := rfl
 
 /-- `linear_map.apply_module` is faithful. -/
-instance apply_has_faithful_scalar : has_faithful_scalar (module.End R M) M :=
+instance apply_has_faithful_smul : has_faithful_smul (module.End R M) M :=
 ⟨λ _ _, linear_map.ext⟩
 
 instance apply_smul_comm_class : smul_comm_class R (module.End R M) M :=

--- a/src/algebra/monoid_algebra/basic.lean
+++ b/src/algebra/monoid_algebra/basic.lean
@@ -270,9 +270,9 @@ instance [semiring R] [semiring k] [module R k] :
   module R (monoid_algebra k G) :=
 finsupp.module G k
 
-instance [monoid R] [semiring k] [distrib_mul_action R k] [has_faithful_scalar R k] [nonempty G] :
-  has_faithful_scalar R (monoid_algebra k G) :=
-finsupp.has_faithful_scalar
+instance [monoid R] [semiring k] [distrib_mul_action R k] [has_faithful_smul R k] [nonempty G] :
+  has_faithful_smul R (monoid_algebra k G) :=
+finsupp.has_faithful_smul
 
 instance [monoid R] [monoid S] [semiring k] [distrib_mul_action R k] [distrib_mul_action S k]
   [has_scalar R S] [is_scalar_tower R S k] :
@@ -1106,9 +1106,9 @@ instance [monoid R] [semiring k] [distrib_mul_action R k] :
   distrib_mul_action R (add_monoid_algebra k G) :=
 finsupp.distrib_mul_action G k
 
-instance [monoid R] [semiring k] [distrib_mul_action R k] [has_faithful_scalar R k] [nonempty G] :
-  has_faithful_scalar R (add_monoid_algebra k G) :=
-finsupp.has_faithful_scalar
+instance [monoid R] [semiring k] [distrib_mul_action R k] [has_faithful_smul R k] [nonempty G] :
+  has_faithful_smul R (add_monoid_algebra k G) :=
+finsupp.has_faithful_smul
 
 instance [semiring R] [semiring k] [module R k] : module R (add_monoid_algebra k G) :=
 finsupp.module G k

--- a/src/analysis/normed_space/M_structure.lean
+++ b/src/analysis/normed_space/M_structure.lean
@@ -90,7 +90,7 @@ lemma Lcomplement {P : M} (h: is_Lprojection X P) : is_Lprojection X (1 - P) :=
 lemma Lcomplement_iff (P : M) : is_Lprojection X P ↔ is_Lprojection X (1 - P) :=
 ⟨Lcomplement, λ h, sub_sub_cancel 1 P ▸ h.Lcomplement⟩
 
-lemma commute [has_faithful_scalar M X] {P Q : M} (h₁ : is_Lprojection X P)
+lemma commute [has_faithful_smul M X] {P Q : M} (h₁ : is_Lprojection X P)
   (h₂ : is_Lprojection X Q) : commute P Q :=
 begin
   have PR_eq_RPR : ∀ R : M, is_Lprojection X R → P * R = R * P * R := λ R h₃,
@@ -130,7 +130,7 @@ begin
   show P * Q = Q * P, by rw [QP_eq_QPQ, PR_eq_RPR Q h₂]
 end
 
-lemma mul [has_faithful_scalar M X] {P Q : M} (h₁ : is_Lprojection X P) (h₂ : is_Lprojection X Q) :
+lemma mul [has_faithful_smul M X] {P Q : M} (h₁ : is_Lprojection X P) (h₂ : is_Lprojection X Q) :
   is_Lprojection X (P * Q) :=
 begin
   refine ⟨is_idempotent_elem.mul_of_commute (h₁.commute h₂) h₁.proj h₂.proj, _⟩,
@@ -151,7 +151,7 @@ begin
       mul_smul] }
 end
 
-lemma join [has_faithful_scalar M X] {P Q : M} (h₁ : is_Lprojection X P) (h₂ : is_Lprojection X Q) :
+lemma join [has_faithful_smul M X] {P Q : M} (h₁ : is_Lprojection X P) (h₂ : is_Lprojection X Q) :
   is_Lprojection X (P + Q - P * Q) :=
 begin
   convert (Lcomplement_iff _).mp (h₁.Lcomplement.mul h₂.Lcomplement) using 1,
@@ -164,31 +164,31 @@ instance : has_compl { f : M // is_Lprojection X f } :=
 @[simp] lemma coe_compl (P : {P : M // is_Lprojection X P}) :
   ↑(Pᶜ) = (1 : M) - ↑P := rfl
 
-instance [has_faithful_scalar M X] : has_inf {P : M // is_Lprojection X P} :=
+instance [has_faithful_smul M X] : has_inf {P : M // is_Lprojection X P} :=
 ⟨λ P Q, ⟨P * Q, P.prop.mul Q.prop⟩ ⟩
 
-@[simp] lemma coe_inf [has_faithful_scalar M X] (P Q : {P : M // is_Lprojection X P}) :
+@[simp] lemma coe_inf [has_faithful_smul M X] (P Q : {P : M // is_Lprojection X P}) :
   ↑(P ⊓ Q) = ((↑P : (M)) * ↑Q) := rfl
 
-instance [has_faithful_scalar M X] : has_sup {P : M // is_Lprojection X P} :=
+instance [has_faithful_smul M X] : has_sup {P : M // is_Lprojection X P} :=
 ⟨λ P Q, ⟨P + Q - P * Q, P.prop.join Q.prop⟩ ⟩
 
-@[simp] lemma coe_sup [has_faithful_scalar M X] (P Q : {P : M // is_Lprojection X P}) :
+@[simp] lemma coe_sup [has_faithful_smul M X] (P Q : {P : M // is_Lprojection X P}) :
   ↑(P ⊔ Q) = ((↑P : M) + ↑Q - ↑P * ↑Q) := rfl
 
-instance [has_faithful_scalar M X] : has_sdiff {P : M // is_Lprojection X P} :=
+instance [has_faithful_smul M X] : has_sdiff {P : M // is_Lprojection X P} :=
 ⟨λ P Q, ⟨P * (1 - Q), by exact P.prop.mul Q.prop.Lcomplement ⟩⟩
 
-@[simp] lemma coe_sdiff [has_faithful_scalar M X] (P Q : {P : M // is_Lprojection X P}) :
+@[simp] lemma coe_sdiff [has_faithful_smul M X] (P Q : {P : M // is_Lprojection X P}) :
   ↑(P \ Q) = (↑P : M) * (1 - ↑Q) := rfl
 
-instance [has_faithful_scalar M X] : partial_order {P : M // is_Lprojection X P} :=
+instance [has_faithful_smul M X] : partial_order {P : M // is_Lprojection X P} :=
 { le := λ P Q, (↑P : M) = ↑(P ⊓ Q),
   le_refl := λ P, by simpa only [coe_inf, ←sq] using (P.prop.proj.eq).symm,
   le_trans := λ P Q R h₁ h₂, by { simp only [coe_inf] at ⊢ h₁ h₂, rw [h₁, mul_assoc, ←h₂] },
   le_antisymm := λ P Q h₁ h₂, subtype.eq (by convert (P.prop.commute Q.prop).eq) }
 
-lemma le_def [has_faithful_scalar M X] (P Q : {P : M // is_Lprojection X P}) :
+lemma le_def [has_faithful_smul M X] (P Q : {P : M // is_Lprojection X P}) :
   P ≤ Q ↔ (P : M) = ↑(P ⊓ Q) :=
 iff.rfl
 
@@ -206,16 +206,16 @@ instance : has_one {P : M // is_Lprojection X P} :=
 @[simp] lemma coe_one : ↑(1 : {P : M // is_Lprojection X P}) = (1 : M) :=
 rfl
 
-instance [has_faithful_scalar M X] : bounded_order {P : M // is_Lprojection X P} :=
+instance [has_faithful_smul M X] : bounded_order {P : M // is_Lprojection X P} :=
 { top := 1,
   le_top := λ P, (mul_one (P : M)).symm,
   bot := 0,
   bot_le := λ P, (zero_mul (P : M)).symm, }
 
-@[simp] lemma coe_bot [has_faithful_scalar M X] :
+@[simp] lemma coe_bot [has_faithful_smul M X] :
   ↑(bounded_order.bot : {P : M // is_Lprojection X P}) = (0 : M) := rfl
 
-@[simp] lemma coe_top [has_faithful_scalar M X] :
+@[simp] lemma coe_top [has_faithful_smul M X] :
   ↑(bounded_order.top : {P : M // is_Lprojection X P}) = (1 : M) := rfl
 
 lemma compl_mul {P : {P : M // is_Lprojection X P}} {Q : M} :
@@ -225,7 +225,7 @@ lemma mul_compl_self {P : {P : M // is_Lprojection X P}} :
   (↑P : M) * (↑Pᶜ) = 0 :=
 by rw [coe_compl, mul_sub, mul_one, P.prop.proj.eq, sub_self]
 
-lemma distrib_lattice_lemma [has_faithful_scalar M X] {P Q R : {P : M // is_Lprojection X P}} :
+lemma distrib_lattice_lemma [has_faithful_smul M X] {P Q R : {P : M // is_Lprojection X P}} :
   ((↑P : M) + ↑Pᶜ * R) * (↑P + ↑Q * ↑R * ↑Pᶜ) = (↑P + ↑Q * ↑R * ↑Pᶜ) :=
 by rw [add_mul, mul_add, mul_add, mul_assoc ↑Pᶜ ↑R (↑Q * ↑R * ↑Pᶜ), ← mul_assoc ↑R (↑Q * ↑R) ↑Pᶜ,
     ← coe_inf Q, (Pᶜ.prop.commute R.prop).eq, ((Q ⊓ R).prop.commute Pᶜ.prop).eq,
@@ -235,7 +235,7 @@ by rw [add_mul, mul_add, mul_add, mul_assoc ↑Pᶜ ↑R (↑Q * ↑R * ↑Pᶜ)
     P.prop.proj.eq, R.prop.proj.eq, ← coe_inf Q, mul_assoc, ((Q ⊓ R).prop.commute Pᶜ.prop).eq,
     ← mul_assoc, Pᶜ.prop.proj.eq]
 
-instance [has_faithful_scalar M X] : distrib_lattice {P : M // is_Lprojection X P} :=
+instance [has_faithful_smul M X] : distrib_lattice {P : M // is_Lprojection X P} :=
 { le_sup_left := λ P Q, by rw [le_def, coe_inf, coe_sup, ← add_sub, mul_add, mul_sub, ← mul_assoc,
     P.prop.proj.eq, sub_self, add_zero],
   le_sup_right := λ P Q,
@@ -277,7 +277,7 @@ instance [has_faithful_scalar M X] : distrib_lattice {P : M // is_Lprojection X 
   .. is_Lprojection.subtype.has_sup,
   .. is_Lprojection.subtype.partial_order }
 
-instance [has_faithful_scalar M X] : boolean_algebra {P : M // is_Lprojection X P} :=
+instance [has_faithful_smul M X] : boolean_algebra {P : M // is_Lprojection X P} :=
 { sup_inf_sdiff := λ P Q, subtype.ext $
     by rw [coe_sup, coe_inf, coe_sdiff, mul_assoc, ← mul_assoc ↑Q,
     (Q.prop.commute P.prop).eq, mul_assoc ↑P ↑Q, ← coe_compl, mul_compl_self, mul_zero, mul_zero,

--- a/src/data/finsupp/basic.lean
+++ b/src/data/finsupp/basic.lean
@@ -2471,8 +2471,8 @@ lemma _root_.is_smul_regular.finsupp {_ : monoid R} [add_monoid M] [distrib_mul_
   (hk : is_smul_regular M k) : is_smul_regular (α →₀ M) k :=
 λ _ _ h, ext $ λ i, hk (congr_fun h i)
 
-instance [monoid R] [nonempty α] [add_monoid M] [distrib_mul_action R M] [has_faithful_scalar R M] :
-  has_faithful_scalar R (α →₀ M) :=
+instance [monoid R] [nonempty α] [add_monoid M] [distrib_mul_action R M] [has_faithful_smul R M] :
+  has_faithful_smul R (α →₀ M) :=
 { eq_of_smul_eq_smul := λ r₁ r₂ h, let ⟨a⟩ := ‹nonempty α› in eq_of_smul_eq_smul $ λ m : M,
     by simpa using congr_fun (h (single a m)) a }
 

--- a/src/data/mv_polynomial/basic.lean
+++ b/src/data/mv_polynomial/basic.lean
@@ -106,9 +106,9 @@ instance [comm_semiring R] : inhabited (mv_polynomial σ R) := ⟨0⟩
 instance [monoid R] [comm_semiring S₁] [distrib_mul_action R S₁] :
   distrib_mul_action R (mv_polynomial σ S₁) :=
 add_monoid_algebra.distrib_mul_action
-instance [monoid R] [comm_semiring S₁] [distrib_mul_action R S₁] [has_faithful_scalar R S₁] :
-  has_faithful_scalar R (mv_polynomial σ S₁) :=
-add_monoid_algebra.has_faithful_scalar
+instance [monoid R] [comm_semiring S₁] [distrib_mul_action R S₁] [has_faithful_smul R S₁] :
+  has_faithful_smul R (mv_polynomial σ S₁) :=
+add_monoid_algebra.has_faithful_smul
 instance [semiring R] [comm_semiring S₁] [module R S₁] : module R (mv_polynomial σ S₁) :=
 add_monoid_algebra.module
 instance [monoid R] [monoid S₁] [comm_semiring S₂]

--- a/src/data/polynomial/basic.lean
+++ b/src/data/polynomial/basic.lean
@@ -191,8 +191,8 @@ instance {S} [monoid S] [distrib_mul_action S R] : distrib_mul_action S R[X] :=
 function.injective.distrib_mul_action
   ⟨to_finsupp, to_finsupp_zero, to_finsupp_add⟩ to_finsupp_injective to_finsupp_smul
 
-instance {S} [monoid S] [distrib_mul_action S R] [has_faithful_scalar S R] :
-  has_faithful_scalar S R[X] :=
+instance {S} [monoid S] [distrib_mul_action S R] [has_faithful_smul S R] :
+  has_faithful_smul S R[X] :=
 { eq_of_smul_eq_smul := λ s₁ s₂ h, eq_of_smul_eq_smul $ λ a : ℕ →₀ R, congr_arg to_finsupp (h ⟨a⟩) }
 
 instance {S} [semiring S] [module S R] : module S R[X] :=

--- a/src/field_theory/fixed.lean
+++ b/src/field_theory/fixed.lean
@@ -296,7 +296,7 @@ fintype_card_le_finrank_of_linear_independent $ linear_independent_to_linear_map
 namespace fixed_points
 
 theorem finrank_eq_card (G : Type u) (F : Type v) [group G] [field F]
-  [fintype G] [mul_semiring_action G F] [has_faithful_scalar G F] :
+  [fintype G] [mul_semiring_action G F] [has_faithful_smul G F] :
   finrank (fixed_points.subfield G F) F = fintype.card G :=
 le_antisymm (fixed_points.finrank_le_card G F) $
 calc  fintype.card G
@@ -307,7 +307,7 @@ calc  fintype.card G
 
 /-- `mul_semiring_action.to_alg_hom` is bijective. -/
 theorem to_alg_hom_bijective (G : Type u) (F : Type v) [group G] [field F]
-  [fintype G] [mul_semiring_action G F] [has_faithful_scalar G F] :
+  [fintype G] [mul_semiring_action G F] [has_faithful_smul G F] :
   function.bijective (mul_semiring_action.to_alg_hom _ _ : G → F →ₐ[subfield G F] F) :=
 begin
   rw fintype.bijective_iff_injective_and_card,
@@ -321,7 +321,7 @@ end
 
 /-- Bijection between G and algebra homomorphisms that fix the fixed points -/
 def to_alg_hom_equiv (G : Type u) (F : Type v) [group G] [field F]
-  [fintype G] [mul_semiring_action G F] [has_faithful_scalar G F] :
+  [fintype G] [mul_semiring_action G F] [has_faithful_smul G F] :
     G ≃ (F →ₐ[fixed_points.subfield G F] F) :=
 equiv.of_bijective _ (to_alg_hom_bijective G F)
 

--- a/src/group_theory/group_action/defs.lean
+++ b/src/group_theory/group_action/defs.lean
@@ -58,15 +58,15 @@ class has_faithful_vadd (G : Type*) (P : Type*) [has_vadd G P] : Prop :=
 
 /-- Typeclass for faithful actions. -/
 @[to_additive has_faithful_vadd]
-class has_faithful_scalar (M : Type*) (α : Type*) [has_scalar M α] : Prop :=
+class has_faithful_smul (M : Type*) (α : Type*) [has_scalar M α] : Prop :=
 (eq_of_smul_eq_smul : ∀ {m₁ m₂ : M}, (∀ a : α, m₁ • a = m₂ • a) → m₁ = m₂)
 
-export has_faithful_scalar (eq_of_smul_eq_smul) has_faithful_vadd (eq_of_vadd_eq_vadd)
+export has_faithful_smul (eq_of_smul_eq_smul) has_faithful_vadd (eq_of_vadd_eq_vadd)
 
 @[to_additive]
-lemma smul_left_injective' [has_scalar M α] [has_faithful_scalar M α] :
+lemma smul_left_injective' [has_scalar M α] [has_faithful_smul M α] :
   function.injective ((•) : M → α → α) :=
-λ m₁ m₂ h, has_faithful_scalar.eq_of_smul_eq_smul (congr_fun h)
+λ m₁ m₂ h, has_faithful_smul.eq_of_smul_eq_smul (congr_fun h)
 
 /-- See also `monoid.to_mul_action` and `mul_zero_class.to_smul_with_zero`. -/
 @[priority 910, to_additive] -- see Note [lower instance priority]
@@ -721,7 +721,7 @@ instance function.End.apply_mul_action : mul_action (function.End α) α :=
 @[simp] lemma function.End.smul_def (f : function.End α) (a : α) : f • a = f a := rfl
 
 /-- `function.End.apply_mul_action` is faithful. -/
-instance function.End.apply_has_faithful_scalar : has_faithful_scalar (function.End α) α :=
+instance function.End.apply_has_faithful_smul : has_faithful_smul (function.End α) α :=
 ⟨λ x y, funext⟩
 
 /-- The tautological action by `add_monoid.End α` on `α`.
@@ -739,8 +739,8 @@ instance add_monoid.End.apply_distrib_mul_action [add_monoid α] :
   f • a = f a := rfl
 
 /-- `add_monoid.End.apply_distrib_mul_action` is faithful. -/
-instance add_monoid.End.apply_has_faithful_scalar [add_monoid α] :
-  has_faithful_scalar (add_monoid.End α) α :=
+instance add_monoid.End.apply_has_faithful_smul [add_monoid α] :
+  has_faithful_smul (add_monoid.End α) α :=
 ⟨add_monoid_hom.ext⟩
 
 /-- The monoid hom representing a monoid action.

--- a/src/group_theory/group_action/defs.lean
+++ b/src/group_theory/group_action/defs.lean
@@ -57,7 +57,7 @@ class has_faithful_vadd (G : Type*) (P : Type*) [has_vadd G P] : Prop :=
 (eq_of_vadd_eq_vadd : ∀ {g₁ g₂ : G}, (∀ p : P, g₁ +ᵥ p = g₂ +ᵥ p) → g₁ = g₂)
 
 /-- Typeclass for faithful actions. -/
-@[to_additive has_faithful_vadd]
+@[to_additive]
 class has_faithful_smul (M : Type*) (α : Type*) [has_scalar M α] : Prop :=
 (eq_of_smul_eq_smul : ∀ {m₁ m₂ : M}, (∀ a : α, m₁ • a = m₂ • a) → m₁ = m₂)
 

--- a/src/group_theory/group_action/group.lean
+++ b/src/group_theory/group_action/group.lean
@@ -19,8 +19,8 @@ section mul_action
 
 /-- `monoid.to_mul_action` is faithful on cancellative monoids. -/
 @[to_additive /-" `add_monoid.to_add_action` is faithful on additive cancellative monoids. "-/]
-instance right_cancel_monoid.to_has_faithful_scalar [right_cancel_monoid α] :
-  has_faithful_scalar α α :=
+instance right_cancel_monoid.to_has_faithful_smul [right_cancel_monoid α] :
+  has_faithful_smul α α :=
 ⟨λ x y h, mul_right_cancel (h 1)⟩
 
 section group
@@ -40,7 +40,7 @@ by rw [smul_smul, mul_right_inv, one_smul]
 add_decl_doc add_action.to_perm
 
 /-- `mul_action.to_perm` is injective on faithful actions. -/
-@[to_additive] lemma mul_action.to_perm_injective [has_faithful_scalar α β] :
+@[to_additive] lemma mul_action.to_perm_injective [has_faithful_smul α β] :
   function.injective (mul_action.to_perm : α → equiv.perm β) :=
 (show function.injective (equiv.to_fun ∘ mul_action.to_perm), from smul_left_injective').of_comp
 
@@ -74,7 +74,7 @@ instance equiv.perm.apply_mul_action (α : Type*) : mul_action (equiv.perm α) �
 rfl
 
 /-- `equiv.perm.apply_mul_action` is faithful. -/
-instance equiv.perm.apply_has_faithful_scalar (α : Type*) : has_faithful_scalar (equiv.perm α) α :=
+instance equiv.perm.apply_has_faithful_smul (α : Type*) : has_faithful_smul (equiv.perm α) α :=
 ⟨λ x y, equiv.ext⟩
 
 variables {α} {β}
@@ -123,8 +123,8 @@ mul_action.injective g h
 end group
 
 /-- `monoid.to_mul_action` is faithful on nontrivial cancellative monoids with zero. -/
-instance cancel_monoid_with_zero.to_has_faithful_scalar [cancel_monoid_with_zero α] [nontrivial α] :
-  has_faithful_scalar α α :=
+instance cancel_monoid_with_zero.to_has_faithful_smul [cancel_monoid_with_zero α] [nontrivial α] :
+  has_faithful_smul α α :=
 ⟨λ x y h, mul_left_injective₀ one_ne_zero (h 1)⟩
 
 section gwz

--- a/src/group_theory/group_action/opposite.lean
+++ b/src/group_theory/group_action/opposite.lean
@@ -123,10 +123,10 @@ example [monoid α] : monoid.to_mul_action αᵐᵒᵖ = mul_opposite.mul_action
 
 /-- `monoid.to_opposite_mul_action` is faithful on cancellative monoids. -/
 @[to_additive] instance left_cancel_monoid.to_has_faithful_opposite_scalar [left_cancel_monoid α] :
-  has_faithful_scalar αᵐᵒᵖ α :=
+  has_faithful_smul αᵐᵒᵖ α :=
 ⟨λ x y h, unop_injective $ mul_left_cancel (h 1)⟩
 
 /-- `monoid.to_opposite_mul_action` is faithful on nontrivial cancellative monoids with zero. -/
 instance cancel_monoid_with_zero.to_has_faithful_opposite_scalar
-  [cancel_monoid_with_zero α] [nontrivial α] : has_faithful_scalar αᵐᵒᵖ α :=
+  [cancel_monoid_with_zero α] [nontrivial α] : has_faithful_smul αᵐᵒᵖ α :=
 ⟨λ x y h, unop_injective $ mul_left_cancel₀ one_ne_zero (h 1)⟩

--- a/src/group_theory/group_action/pi.lean
+++ b/src/group_theory/group_action/pi.lean
@@ -78,9 +78,9 @@ instance {α : Type*} [Π i, has_scalar α $ f i] [Π i, has_scalar αᵐᵒᵖ 
 /-- If `f i` has a faithful scalar action for a given `i`, then so does `Π i, f i`. This is
 not an instance as `i` cannot be inferred. -/
 @[to_additive pi.has_faithful_vadd_at]
-lemma has_faithful_scalar_at {α : Type*}
-  [Π i, has_scalar α $ f i] [Π i, nonempty (f i)] (i : I) [has_faithful_scalar α (f i)] :
-  has_faithful_scalar α (Π i, f i) :=
+lemma has_faithful_smul_at {α : Type*}
+  [Π i, has_scalar α $ f i] [Π i, nonempty (f i)] (i : I) [has_faithful_smul α (f i)] :
+  has_faithful_smul α (Π i, f i) :=
 ⟨λ x y h, eq_of_smul_eq_smul $ λ a : f i, begin
   classical,
   have := congr_fun (h $ function.update (λ j, classical.choice (‹Π i, nonempty (f i)› j)) i a) i,
@@ -88,10 +88,10 @@ lemma has_faithful_scalar_at {α : Type*}
 end⟩
 
 @[to_additive pi.has_faithful_vadd]
-instance has_faithful_scalar {α : Type*}
-  [nonempty I] [Π i, has_scalar α $ f i] [Π i, nonempty (f i)] [Π i, has_faithful_scalar α (f i)] :
-  has_faithful_scalar α (Π i, f i) :=
-let ⟨i⟩ := ‹nonempty I› in has_faithful_scalar_at i
+instance has_faithful_smul {α : Type*}
+  [nonempty I] [Π i, has_scalar α $ f i] [Π i, nonempty (f i)] [Π i, has_faithful_smul α (f i)] :
+  has_faithful_smul α (Π i, f i) :=
+let ⟨i⟩ := ‹nonempty I› in has_faithful_smul_at i
 
 @[to_additive]
 instance mul_action (α) {m : monoid α} [Π i, mul_action α $ f i] :

--- a/src/group_theory/group_action/prod.lean
+++ b/src/group_theory/group_action/prod.lean
@@ -46,12 +46,12 @@ instance [has_scalar Mᵐᵒᵖ α] [has_scalar Mᵐᵒᵖ β] [is_central_scala
   is_central_scalar M (α × β) :=
 ⟨λ r m, prod.ext (op_smul_eq_smul _ _) (op_smul_eq_smul _ _)⟩
 
-@[to_additive has_faithful_vadd_left]
+@[to_additive]
 instance has_faithful_smul_left [has_faithful_smul M α] [nonempty β] :
   has_faithful_smul M (α × β) :=
 ⟨λ x y h, let ⟨b⟩ := ‹nonempty β› in eq_of_smul_eq_smul $ λ a : α, by injection h (a, b)⟩
 
-@[to_additive has_faithful_vadd_right]
+@[to_additive]
 instance has_faithful_smul_right [nonempty α] [has_faithful_smul M β] :
   has_faithful_smul M (α × β) :=
 ⟨λ x y h, let ⟨a⟩ := ‹nonempty α› in eq_of_smul_eq_smul $ λ b : β, by injection h (a, b)⟩

--- a/src/group_theory/group_action/prod.lean
+++ b/src/group_theory/group_action/prod.lean
@@ -47,13 +47,13 @@ instance [has_scalar Mᵐᵒᵖ α] [has_scalar Mᵐᵒᵖ β] [is_central_scala
 ⟨λ r m, prod.ext (op_smul_eq_smul _ _) (op_smul_eq_smul _ _)⟩
 
 @[to_additive has_faithful_vadd_left]
-instance has_faithful_scalar_left [has_faithful_scalar M α] [nonempty β] :
-  has_faithful_scalar M (α × β) :=
+instance has_faithful_smul_left [has_faithful_smul M α] [nonempty β] :
+  has_faithful_smul M (α × β) :=
 ⟨λ x y h, let ⟨b⟩ := ‹nonempty β› in eq_of_smul_eq_smul $ λ a : α, by injection h (a, b)⟩
 
 @[to_additive has_faithful_vadd_right]
-instance has_faithful_scalar_right [nonempty α] [has_faithful_scalar M β] :
-  has_faithful_scalar M (α × β) :=
+instance has_faithful_smul_right [nonempty α] [has_faithful_smul M β] :
+  has_faithful_smul M (α × β) :=
 ⟨λ x y h, let ⟨a⟩ := ‹nonempty α› in eq_of_smul_eq_smul $ λ b : β, by injection h (a, b)⟩
 
 end

--- a/src/group_theory/group_action/units.lean
+++ b/src/group_theory/group_action/units.lean
@@ -41,7 +41,7 @@ lemma _root_.is_unit.inv_smul [monoid α] {a : α} (h : is_unit a) :
 h.coe_inv_mul
 
 @[to_additive]
-instance [monoid M] [has_scalar M α] [has_faithful_scalar M α] : has_faithful_scalar Mˣ α :=
+instance [monoid M] [has_scalar M α] [has_faithful_smul M α] : has_faithful_smul Mˣ α :=
 { eq_of_smul_eq_smul := λ u₁ u₂ h, units.ext $ eq_of_smul_eq_smul h, }
 
 @[to_additive]

--- a/src/group_theory/perm/subgroup.lean
+++ b/src/group_theory/perm/subgroup.lean
@@ -59,9 +59,9 @@ fintype.card_eq.mpr ⟨(of_injective (subtype_congr_hom p) (subtype_congr_hom_in
 
 /-- **Cayley's theorem**: Every group G is isomorphic to a subgroup of the symmetric group acting on
 `G`. Note that we generalize this to an arbitrary "faithful" group action by `G`. Setting `H = G`
-recovers the usual statement of Cayley's theorem via `right_cancel_monoid.to_has_faithful_scalar` -/
+recovers the usual statement of Cayley's theorem via `right_cancel_monoid.to_has_faithful_smul` -/
 noncomputable def subgroup_of_mul_action (G H : Type*) [group G] [mul_action G H]
-  [has_faithful_scalar G H] : G ≃* (mul_action.to_perm_hom G H).range :=
+  [has_faithful_smul G H] : G ≃* (mul_action.to_perm_hom G H).range :=
 mul_equiv.of_left_inverse' _ (classical.some_spec mul_action.to_perm_injective.has_left_inverse)
 
 end perm

--- a/src/group_theory/subgroup/basic.lean
+++ b/src/group_theory/subgroup/basic.lean
@@ -3125,9 +3125,9 @@ instance
   is_scalar_tower S α β :=
 S.to_submonoid.is_scalar_tower
 
-instance [mul_action G α] [has_faithful_scalar G α] (S : subgroup G) :
-  has_faithful_scalar S α :=
-S.to_submonoid.has_faithful_scalar
+instance [mul_action G α] [has_faithful_smul G α] (S : subgroup G) :
+  has_faithful_smul S α :=
+S.to_submonoid.has_faithful_smul
 
 /-- The action by a subgroup is the action by the underlying group. -/
 instance [add_monoid α] [distrib_mul_action G α] (S : subgroup G) : distrib_mul_action S α :=

--- a/src/group_theory/submonoid/operations.lean
+++ b/src/group_theory/submonoid/operations.lean
@@ -1066,8 +1066,8 @@ instance
 @[to_additive]
 lemma smul_def [has_scalar M' α] {S : submonoid M'} (g : S) (m : α) : g • m = (g : M') • m := rfl
 
-instance [has_scalar M' α] [has_faithful_scalar M' α] (S : submonoid M') :
-  has_faithful_scalar S α :=
+instance [has_scalar M' α] [has_faithful_smul M' α] (S : submonoid M') :
+  has_faithful_smul S α :=
 ⟨λ x y h, subtype.ext $ eq_of_smul_eq_smul h⟩
 
 end mul_one_class

--- a/src/ring_theory/subring/basic.lean
+++ b/src/ring_theory/subring/basic.lean
@@ -1118,9 +1118,9 @@ instance
   is_scalar_tower S α β :=
 S.to_subsemiring.is_scalar_tower
 
-instance [has_scalar R α] [has_faithful_scalar R α] (S : subring R) :
-  has_faithful_scalar S α :=
-S.to_subsemiring.has_faithful_scalar
+instance [has_scalar R α] [has_faithful_smul R α] (S : subring R) :
+  has_faithful_smul S α :=
+S.to_subsemiring.has_faithful_smul
 
 /-- The action by a subring is the action by the underlying ring. -/
 instance [mul_action R α] (S : subring R) : mul_action S α :=

--- a/src/ring_theory/subsemiring/basic.lean
+++ b/src/ring_theory/subsemiring/basic.lean
@@ -973,9 +973,9 @@ instance [has_scalar α β] [has_scalar R' α] [has_scalar R' β] [is_scalar_tow
   is_scalar_tower S α β :=
 S.to_submonoid.is_scalar_tower
 
-instance [has_scalar R' α] [has_faithful_scalar R' α] (S : subsemiring R') :
-  has_faithful_scalar S α :=
-S.to_submonoid.has_faithful_scalar
+instance [has_scalar R' α] [has_faithful_smul R' α] (S : subsemiring R') :
+  has_faithful_smul S α :=
+S.to_submonoid.has_faithful_smul
 
 /-- The action by a subsemiring is the action by the underlying semiring. -/
 instance [has_zero α] [smul_with_zero R' α] (S : subsemiring R') : smul_with_zero S α :=

--- a/src/topology/algebra/module/basic.lean
+++ b/src/topology/algebra/module/basic.lean
@@ -659,7 +659,7 @@ module.comp_hom _ to_linear_map_ring_hom
 @[simp] protected lemma smul_def (f : M₁ →L[R₁] M₁) (a : M₁) : f • a = f a := rfl
 
 /-- `continuous_linear_map.apply_module` is faithful. -/
-instance apply_has_faithful_scalar : has_faithful_scalar (M₁ →L[R₁] M₁) M₁ :=
+instance apply_has_faithful_smul : has_faithful_smul (M₁ →L[R₁] M₁) M₁ :=
 ⟨λ _ _, continuous_linear_map.ext⟩
 
 instance apply_smul_comm_class : smul_comm_class R₁ (M₁ →L[R₁] M₁) M₁ :=


### PR DESCRIPTION
This is the first scalar -> smul renaming transition.

Discussion: https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/scalar.20smul.20naming.20discrepancy