### PR TITLE
[Merged by Bors] - perf(measure_theory/probability_mass_function/monad): speed up proof

### DIFF
--- a/src/measure_theory/probability_mass_function/monad.lean
+++ b/src/measure_theory/probability_mass_function/monad.lean
@@ -307,9 +307,10 @@ calc (p.bind_on_support f).to_outer_measure s
   ... = ∑' (a : α), ↑(p a) * if h : p a = 0 then 0 else (f a h).to_outer_measure s :
     tsum_congr (λ a, congr_arg (has_mul.mul ↑(p a)) begin
       split_ifs with h h,
-      { exact ennreal.tsum_eq_zero.mpr (λ x,
-          (by simp [g, h] : (0 : ℝ≥0∞) = ↑(g a x)) ▸ (if_t_t (x ∈ s) 0)) },
-      { simp [to_outer_measure_apply, g, h, set.indicator_apply] }
+      { refine ennreal.tsum_eq_zero.mpr (λ x, _),
+        simp only [g, h, dif_pos, ennreal.coe_zero],
+        exact if_t_t (x ∈ s) 0 },
+      { simp only [to_outer_measure_apply, g, h, set.indicator_apply, not_false_iff, dif_neg] }
     end)
 
 /-- The measure of a set under `p.bind_on_support f` is the sum over `a : α`

--- a/src/measure_theory/probability_mass_function/monad.lean
+++ b/src/measure_theory/probability_mass_function/monad.lean
@@ -308,8 +308,8 @@ calc (p.bind_on_support f).to_outer_measure s
     tsum_congr (λ a, congr_arg (has_mul.mul ↑(p a)) begin
       split_ifs with h h,
       { refine ennreal.tsum_eq_zero.mpr (λ x, _),
-        simp only [g, h, dif_pos, ennreal.coe_zero],
-        exact if_t_t (x ∈ s) 0 },
+        simp only [g, h, dif_pos],
+        apply if_t_t },
       { simp only [to_outer_measure_apply, g, h, set.indicator_apply, not_false_iff, dif_neg] }
     end)
 


### PR DESCRIPTION
This causes a deterministic timeout in another PR.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
