### PR TITLE
[Merged by Bors] - refactor(topology): move code around

### DIFF
--- a/src/topology/continuous_function/basic.lean
+++ b/src/topology/continuous_function/basic.lean
@@ -105,7 +105,7 @@ lemma coe_injective : @function.injective (C(α, β)) (α → β) coe_fn :=
 @[simp] lemma coe_mk (f : α → β) (h : continuous f) :
   ⇑(⟨f, h⟩ : C(α, β)) = f := rfl
 
-lemma continuous_map.map_specialization {x y : α} (h : x ⤳ y) (f : C(α, β)) : f x ⤳ f y :=
+lemma map_specialization {x y : α} (h : x ⤳ y) (f : C(α, β)) : f x ⤳ f y :=
 h.map f.2
 
 section

--- a/src/topology/continuous_function/basic.lean
+++ b/src/topology/continuous_function/basic.lean
@@ -105,6 +105,9 @@ lemma coe_injective : @function.injective (C(α, β)) (α → β) coe_fn :=
 @[simp] lemma coe_mk (f : α → β) (h : continuous f) :
   ⇑(⟨f, h⟩ : C(α, β)) = f := rfl
 
+lemma continuous_map.map_specialization {x y : α} (h : x ⤳ y) (f : C(α, β)) : f x ⤳ f y :=
+h.map f.2
+
 section
 variables (α β)
 

--- a/src/topology/inseparable.lean
+++ b/src/topology/inseparable.lean
@@ -1,0 +1,123 @@
+/-
+Copyright (c) 2021 Andrew Yang. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Andrew Yang, Yury G. Kudryashov
+-/
+import topology.constructions
+
+/-!
+# Inseparable points
+
+In this file we require two relations on a topological space: `specializes` (notation : `x ⤳ y`) and
+`inseparable`, then prove some basic lemmas about these relations.
+
+## Main definitions
+
+* `specializes` : `specializes x y` (`x ⤳ y`) means that `x` specializes to `y`, i.e.
+  `y` is in the closure of `x`.
+
+* `specialization_preorder` : specialization gives a preorder on a topological space. In case of a
+  T₀ space, this preorder is a partial order, see `specialization_order`.
+
+* `inseparable x y` means that two points can't be separated by an open set.
+-/
+
+open_locale topological_space
+open set
+
+variables {X Y : Type*} [topological_space X] [topological_space Y] {x y z : X}
+
+/-- `x` specializes to `y` if `y` is in the closure of `x`. The notation used is `x ⤳ y`. -/
+def specializes (x y : X) : Prop := y ∈ closure ({x} : set X)
+
+infix ` ⤳ `:300 := specializes
+
+lemma specializes_def (x y : X) : x ⤳ y ↔ y ∈ closure ({x} : set X) := iff.rfl
+
+lemma specializes_iff_closure_subset : x ⤳ y ↔ closure ({y} : set X) ⊆ closure ({x} : set X) :=
+is_closed_closure.mem_iff_closure_subset
+
+lemma specializes_rfl : x ⤳ x := subset_closure (mem_singleton x)
+
+lemma specializes_refl (x : X) : x ⤳ x := specializes_rfl
+
+lemma specializes.trans : x ⤳ y → y ⤳ z → x ⤳ z :=
+by { simp_rw specializes_iff_closure_subset, exact λ a b, b.trans a }
+
+lemma specializes_iff_forall_closed :
+  x ⤳ y ↔ ∀ (Z : set X) (h : is_closed Z), x ∈ Z → y ∈ Z :=
+begin
+  split,
+  { intros h Z hZ,
+    rw [hZ.mem_iff_closure_subset, hZ.mem_iff_closure_subset],
+    exact (specializes_iff_closure_subset.mp h).trans },
+  { intro h, exact h _ is_closed_closure (subset_closure $ set.mem_singleton x) }
+end
+
+lemma specializes_iff_forall_open :
+  x ⤳ y ↔ ∀ (U : set X) (h : is_open U), y ∈ U → x ∈ U :=
+begin
+  rw specializes_iff_forall_closed,
+  exact ⟨λ h U hU, not_imp_not.mp (h _ (is_closed_compl_iff.mpr hU)),
+    λ h U hU, not_imp_not.mp (h _ (is_open_compl_iff.mpr hU))⟩,
+end
+
+lemma specializes.map (h : x ⤳ y) {f : X → Y} (hf : continuous f) : f x ⤳ f y :=
+begin
+  rw [specializes_def, ← set.image_singleton],
+  exact image_closure_subset_closure_image hf ⟨_, h, rfl⟩,
+end
+
+section specialize_order
+
+variable (X)
+
+/-- Specialization forms a preorder on the topological space. -/
+def specialization_preorder : preorder X :=
+{ le := λ x y, y ⤳ x,
+  le_refl := λ x, specializes_refl x,
+  le_trans := λ _ _ _ h₁ h₂, specializes.trans h₂ h₁ }
+
+local attribute [instance] specialization_preorder
+
+variable {X}
+
+lemma specialization_order.monotone_of_continuous (f : X → Y) (hf : continuous f) : monotone f :=
+λ x y h, specializes.map h hf
+
+end specialize_order
+
+/-- Two points are topologically inseparable if no open set separates them. -/
+def inseparable (x y : X) : Prop := ∀ (U : set X) (hU : is_open U), x ∈ U ↔ y ∈ U
+
+lemma inseparable_iff_nhds_eq : inseparable x y ↔ 𝓝 x = 𝓝 y :=
+⟨λ h, by simp only [nhds_def', h _] { contextual := tt },
+  λ h U hU, by simp only [← hU.mem_nhds_iff, h]⟩
+
+alias inseparable_iff_nhds_eq ↔ inseparable.nhds_eq _
+
+lemma inseparable.map {f : X → Y} (h : inseparable x y) (hf : continuous f) :
+  inseparable (f x) (f y) :=
+λ U hU, h (f ⁻¹' U) (hU.preimage hf)
+
+lemma inseparable_iff_closed :
+  inseparable x y ↔ ∀ (U : set X) (hU : is_closed U), x ∈ U ↔ y ∈ U :=
+⟨λ h U hU, not_iff_not.mp (h _ hU.1), λ h U hU, not_iff_not.mp (h _ (is_closed_compl_iff.mpr hU))⟩
+
+lemma inseparable_iff_closure (x y : X) :
+  inseparable x y ↔ x ∈ closure ({y} : set X) ∧ y ∈ closure ({x} : set X) :=
+begin
+  rw inseparable_iff_closed,
+  exact ⟨λ h, ⟨(h _ is_closed_closure).mpr (subset_closure $ set.mem_singleton y),
+      (h _ is_closed_closure).mp (subset_closure $ set.mem_singleton x)⟩,
+    λ h U hU, ⟨λ hx, (is_closed.closure_subset_iff hU).mpr (set.singleton_subset_iff.mpr hx) h.2,
+      λ hy, (is_closed.closure_subset_iff hU).mpr (set.singleton_subset_iff.mpr hy) h.1⟩⟩
+end
+
+lemma inseparable_iff_specializes_and (x y : X) :
+  inseparable x y ↔ x ⤳ y ∧ y ⤳ x :=
+(inseparable_iff_closure x y).trans (and_comm _ _)
+
+lemma subtype_inseparable_iff {U : set X} (x y : U) :
+  inseparable x y ↔ inseparable (x : X) y :=
+by { simp_rw [inseparable_iff_closure, closure_subtype, image_singleton] }

--- a/src/topology/separation.lean
+++ b/src/topology/separation.lean
@@ -6,6 +6,7 @@ Authors: Johannes Hölzl, Mario Carneiro
 import topology.subset_properties
 import topology.connected
 import topology.nhds_set
+import topology.inseparable
 
 /-!
 # Separation properties of topological spaces.
@@ -166,21 +167,6 @@ lemma t0_space_def (α : Type u) [topological_space α] :
   t0_space α ↔ ∀ x y, x ≠ y → ∃ U:set α, is_open U ∧ (xor (x ∈ U) (y ∈ U)) :=
 by { split, apply @t0_space.t0, apply t0_space.mk }
 
-/-- Two points are topologically inseparable if no open set separates them. -/
-def inseparable {α : Type u} [topological_space α] (x y : α) : Prop :=
-∀ (U : set α) (hU : is_open U), x ∈ U ↔ y ∈ U
-
-lemma inseparable_iff_nhds_eq {x y : α} : inseparable x y ↔ 𝓝 x = 𝓝 y :=
-⟨λ h, by simp only [nhds_def', h _] { contextual := tt },
-  λ h U hU, by simp only [← hU.mem_nhds_iff, h]⟩
-
-alias inseparable_iff_nhds_eq ↔ inseparable.nhds_eq _
-
-lemma inseparable.map [topological_space β] {x y : α} {f : α → β}
-  (h : inseparable x y) (hf : continuous f) :
-  inseparable (f x) (f y) :=
-λ U hU, h (f ⁻¹' U) (hU.preimage hf)
-
 lemma t0_space_iff_not_inseparable (α : Type u) [topological_space α] :
   t0_space α ↔ ∀ (x y : α), x ≠ y → ¬inseparable x y :=
 by simp only [t0_space_def, xor_iff_not_iff, not_forall, exists_prop, inseparable]
@@ -192,6 +178,14 @@ by simp only [t0_space_iff_not_inseparable, ne.def, not_imp_not]
 lemma inseparable.eq [t0_space α] {x y : α} (h : inseparable x y) : x = y :=
 (t0_space_iff_inseparable α).1 ‹_› x y h
 
+lemma specializes_antisymm [t0_space α] (x y : α) : x ⤳ y → y ⤳ x → x = y :=
+λ h₁ h₂, ((inseparable_iff_specializes_and _ _).mpr ⟨h₁, h₂⟩).eq
+
+/-- Specialization forms a partial order on a t0 topological space. -/
+def specialization_order (α : Type*) [topological_space α] [t0_space α] : partial_order α :=
+{ le_antisymm := λ _ _ h₁ h₂, specializes_antisymm _ _ h₂ h₁,
+  .. specialization_preorder α }
+
 lemma t0_space_iff_nhds_injective (α : Type u) [topological_space α] :
   t0_space α ↔ injective (𝓝 : α → filter α) :=
 by simp only [t0_space_iff_inseparable, injective, inseparable_iff_nhds_eq]
@@ -201,24 +195,6 @@ lemma nhds_injective [t0_space α] : injective (𝓝 : α → filter α) :=
 
 @[simp] lemma nhds_eq_nhds_iff [t0_space α] {a b : α} : 𝓝 a = 𝓝 b ↔ a = b :=
 nhds_injective.eq_iff
-
-lemma inseparable_iff_closed {x y : α} :
-  inseparable x y ↔ ∀ (U : set α) (hU : is_closed U), x ∈ U ↔ y ∈ U :=
-⟨λ h U hU, not_iff_not.mp (h _ hU.1), λ h U hU, not_iff_not.mp (h _ (is_closed_compl_iff.mpr hU))⟩
-
-lemma inseparable_iff_closure (x y : α) :
-  inseparable x y ↔ x ∈ closure ({y} : set α) ∧ y ∈ closure ({x} : set α) :=
-begin
-  rw inseparable_iff_closed,
-  exact ⟨λ h, ⟨(h _ is_closed_closure).mpr (subset_closure $ set.mem_singleton y),
-      (h _ is_closed_closure).mp (subset_closure $ set.mem_singleton x)⟩,
-    λ h U hU, ⟨λ hx, (is_closed.closure_subset_iff hU).mpr (set.singleton_subset_iff.mpr hx) h.2,
-      λ hy, (is_closed.closure_subset_iff hU).mpr (set.singleton_subset_iff.mpr hy) h.1⟩⟩
-end
-
-lemma subtype_inseparable_iff {α : Type u} [topological_space α] {U : set α} (x y : U) :
-  inseparable x y ↔ inseparable (x : α) y :=
-by { simp_rw [inseparable_iff_closure, closure_subtype, image_singleton] }
 
 theorem minimal_nonempty_closed_subsingleton [t0_space α] {s : set α} (hs : is_closed s)
   (hmin : ∀ t ⊆ s, t.nonempty → is_closed t → t = s) :
@@ -512,6 +488,12 @@ hs.induction_on (by simp) $ λ x, by simp
 @[simp] lemma subsingleton_closure [t1_space α] {s : set α} :
   (closure s).subsingleton ↔ s.subsingleton :=
 ⟨λ h, h.mono subset_closure, λ h, h.closure⟩
+
+lemma specializes.eq [t1_space α] {x y : α} (h : x ⤳ y) : x = y :=
+by simpa only [specializes, closure_singleton, mem_singleton_iff, eq_comm] using h
+
+@[simp] lemma specializes_iff_eq [t1_space α] {x y : α} : x ⤳ y ↔ x = y :=
+⟨specializes.eq, λ h, h ▸ specializes_refl _⟩
 
 lemma is_closed_map_const {α β} [topological_space α] [topological_space β] [t1_space β] {y : β} :
   is_closed_map (function.const α y) :=

--- a/src/topology/sober.lean
+++ b/src/topology/sober.lean
@@ -17,9 +17,6 @@ stated via `[quasi_sober α] [t0_space α]`.
 
 ## Main definition
 
-* `specializes` : `specializes x y` (`x ⤳ y`) means that `x` specializes to `y`, i.e.
-  `y` is in the closure of `x`.
-* `specialization_preorder` : specialization gives a preorder on a topological space.
 * `specialization_order` : specialization gives a partial order on a T0 space.
 * `is_generic_point` : `x` is the generic point of `S` if `S` is the closure of `x`.
 * `quasi_sober` : A space is quasi-sober if every irreducible closed subset has a generic point.
@@ -27,89 +24,6 @@ stated via `[quasi_sober α] [t0_space α]`.
 -/
 
 variables {α β : Type*} [topological_space α] [topological_space β]
-
-section specialize_order
-
-/-- `x` specializes to `y` if `y` is in the closure of `x`. The notation used is `x ⤳ y`. -/
-def specializes (x y : α) : Prop := y ∈ closure ({x} : set α)
-
-infix ` ⤳ `:300 := specializes
-
-lemma specializes_def (x y : α) : x ⤳ y ↔ y ∈ closure ({x} : set α) := iff.rfl
-
-lemma specializes_iff_closure_subset {x y : α} :
-  x ⤳ y ↔ closure ({y} : set α) ⊆ closure ({x} : set α) :=
-is_closed_closure.mem_iff_closure_subset
-
-lemma specializes_rfl {x : α} : x ⤳ x := subset_closure (set.mem_singleton x)
-
-lemma specializes_refl (x : α) : x ⤳ x := specializes_rfl
-
-lemma specializes.trans {x y z : α} : x ⤳ y → y ⤳ z → x ⤳ z :=
-by { simp_rw specializes_iff_closure_subset, exact λ a b, b.trans a }
-
-lemma specializes_iff_forall_closed {x y : α} :
-  x ⤳ y ↔ ∀ (Z : set α) (h : is_closed Z), x ∈ Z → y ∈ Z :=
-begin
-  split,
-  { intros h Z hZ,
-    rw [hZ.mem_iff_closure_subset, hZ.mem_iff_closure_subset],
-    exact (specializes_iff_closure_subset.mp h).trans },
-  { intro h, exact h _ is_closed_closure (subset_closure $ set.mem_singleton x) }
-end
-
-lemma specializes_iff_forall_open {x y : α} :
-  x ⤳ y ↔ ∀ (U : set α) (h : is_open U), y ∈ U → x ∈ U :=
-begin
-  rw specializes_iff_forall_closed,
-  exact ⟨λ h U hU, not_imp_not.mp (h _ (is_closed_compl_iff.mpr hU)),
-    λ h U hU, not_imp_not.mp (h _ (is_open_compl_iff.mpr hU))⟩,
-end
-
-lemma inseparable_iff_specializes_and (x y : α) :
-  inseparable x y ↔ x ⤳ y ∧ y ⤳ x :=
-(inseparable_iff_closure x y).trans (and_comm _ _)
-
-lemma specializes_antisymm [t0_space α] (x y : α) : x ⤳ y → y ⤳ x → x = y :=
-λ h₁ h₂, ((inseparable_iff_specializes_and _ _).mpr ⟨h₁, h₂⟩).eq
-
-lemma specializes.map {x y : α} (h : x ⤳ y) {f : α → β} (hf : continuous f) : f x ⤳ f y :=
-begin
-  rw [specializes_def, ← set.image_singleton],
-  exact image_closure_subset_closure_image hf ⟨_, h, rfl⟩,
-end
-
-lemma continuous_map.map_specialization {x y : α} (h : x ⤳ y) (f : C(α, β)) : f x ⤳ f y :=
-h.map f.2
-
-lemma specializes.eq [t1_space α] {x y : α} (h : x ⤳ y) : x = y :=
-(set.mem_singleton_iff.mp
-  ((specializes_iff_forall_closed.mp h) _ (t1_space.t1 _) (set.mem_singleton _))).symm
-
-@[simp] lemma specializes_iff_eq [t1_space α] {x y : α} : x ⤳ y ↔ x = y :=
-⟨specializes.eq, λ h, h ▸ specializes_refl _⟩
-
-variable (α)
-
-/-- Specialization forms a preorder on the topological space. -/
-def specialization_preorder : preorder α :=
-{ le := λ x y, y ⤳ x,
-  le_refl := λ x, specializes_refl x,
-  le_trans := λ _ _ _ h₁ h₂, specializes.trans h₂ h₁ }
-
-local attribute [instance] specialization_preorder
-
-/-- Specialization forms a partial order on a t0 topological space. -/
-def specialization_order [t0_space α] : partial_order α :=
-{ le_antisymm := λ _ _ h₁ h₂, specializes_antisymm _ _ h₂ h₁,
-  .. specialization_preorder α }
-
-variable {α}
-
-lemma specialization_order.monotone_of_continuous (f : α → β) (hf : continuous f) : monotone f :=
-λ x y h, specializes.map h hf
-
-end specialize_order
 
 section generic_point
 


### PR DESCRIPTION
Create a new file `topology/inseparable` and more the definitions of `specializes` and `inseparable` to this file. This is a preparation to a larger refactor of these definitions.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
