### PR TITLE
[Merged by Bors] - feat(analysis/calculus/fderiv_measurable): the right derivative is measurable

### DIFF
--- a/src/analysis/calculus/deriv.lean
+++ b/src/analysis/calculus/deriv.lean
@@ -445,33 +445,14 @@ by { unfold deriv_within, rw fderiv_within_of_open hs hx, refl }
 
 lemma deriv_mem_iff {f : 𝕜 → F} {s : set F} {x : 𝕜} :
   deriv f x ∈ s ↔ (differentiable_at 𝕜 f x ∧ deriv f x ∈ s) ∨
-    (0 : F) ∈ s ∧ ¬differentiable_at 𝕜 f x :=
-begin
-  split,
-  { intro hfx,
-    by_cases hx : differentiable_at 𝕜 f x,
-    { exact or.inl ⟨hx, hfx⟩ },
-    { rw [deriv_zero_of_not_differentiable_at hx] at hfx,
-      exact or.inr ⟨hfx, hx⟩ } },
-  { rintro (⟨hf, hf'⟩|⟨h₀, hx⟩),
-    { exact hf' },
-    { rwa [deriv_zero_of_not_differentiable_at hx] } }
-end
+    (¬differentiable_at 𝕜 f x ∧ (0 : F) ∈ s) :=
+by by_cases hx : differentiable_at 𝕜 f x; simp [deriv_zero_of_not_differentiable_at, *]
 
 lemma deriv_within_mem_iff {f : 𝕜 → F} {t : set 𝕜} {s : set F} {x : 𝕜} :
   deriv_within f t x ∈ s ↔ (differentiable_within_at 𝕜 f t x ∧ deriv_within f t x ∈ s) ∨
-    (0 : F) ∈ s ∧ ¬differentiable_within_at 𝕜 f t x :=
-begin
-  split,
-  { intro hfx,
-    by_cases hx : differentiable_within_at 𝕜 f t x,
-    { exact or.inl ⟨hx, hfx⟩ },
-    { rw [deriv_within_zero_of_not_differentiable_within_at hx] at hfx,
-      exact or.inr ⟨hfx, hx⟩ } },
-  { rintro (⟨hf, hf'⟩|⟨h₀, hx⟩),
-    { exact hf' },
-    { rwa [deriv_within_zero_of_not_differentiable_within_at hx] } }
-end
+    (¬differentiable_within_at 𝕜 f t x ∧ (0 : F) ∈ s) :=
+by by_cases hx : differentiable_within_at 𝕜 f t x;
+  simp [deriv_within_zero_of_not_differentiable_within_at, *]
 
 lemma differentiable_within_at_Ioi_iff_Ici [partial_order 𝕜] :
   differentiable_within_at 𝕜 f (Ioi x) x ↔ differentiable_within_at 𝕜 f (Ici x) x :=

--- a/src/analysis/calculus/deriv.lean
+++ b/src/analysis/calculus/deriv.lean
@@ -225,14 +225,27 @@ theorem unique_diff_within_at.eq_deriv (s : set 𝕜) (H : unique_diff_within_at
   (h : has_deriv_within_at f f' s x) (h₁ : has_deriv_within_at f f₁' s x) : f' = f₁' :=
 smul_right_one_eq_iff.mp $ unique_diff_within_at.eq H h h₁
 
+theorem has_deriv_at_filter_iff_is_o :
+  has_deriv_at_filter f f' x L ↔ (λ x' : 𝕜, f x' - f x - (x' - x) • f') =o[L] (λ x', x' - x) :=
+iff.rfl
+
 theorem has_deriv_at_filter_iff_tendsto :
   has_deriv_at_filter f f' x L ↔
   tendsto (λ x' : 𝕜, ∥x' - x∥⁻¹ * ∥f x' - f x - (x' - x) • f'∥) L (𝓝 0) :=
 has_fderiv_at_filter_iff_tendsto
 
+theorem has_deriv_within_at_iff_is_o :
+  has_deriv_within_at f f' s x
+    ↔ (λ x' : 𝕜, f x' - f x - (x' - x) • f') =o[𝓝[s] x] (λ x', x' - x) :=
+iff.rfl
+
 theorem has_deriv_within_at_iff_tendsto : has_deriv_within_at f f' s x ↔
   tendsto (λ x', ∥x' - x∥⁻¹ * ∥f x' - f x - (x' - x) • f'∥) (𝓝[s] x) (𝓝 0) :=
 has_fderiv_at_filter_iff_tendsto
+
+theorem has_deriv_at_iff_is_o :
+  has_deriv_at f f' x ↔ (λ x' : 𝕜, f x' - f x - (x' - x) • f') =o[𝓝 x] (λ x', x' - x) :=
+iff.rfl
 
 theorem has_deriv_at_iff_tendsto : has_deriv_at f f' x ↔
   tendsto (λ x', ∥x' - x∥⁻¹ * ∥f x' - f x - (x' - x) • f'∥) (𝓝 x) (𝓝 0) :=
@@ -429,6 +442,53 @@ by { unfold deriv_within, rw fderiv_within_inter ht hs }
 lemma deriv_within_of_open (hs : is_open s) (hx : x ∈ s) :
   deriv_within f s x = deriv f x :=
 by { unfold deriv_within, rw fderiv_within_of_open hs hx, refl }
+
+lemma deriv_mem_iff {f : 𝕜 → F} {s : set F} {x : 𝕜} :
+  deriv f x ∈ s ↔ (differentiable_at 𝕜 f x ∧ deriv f x ∈ s) ∨
+    (0 : F) ∈ s ∧ ¬differentiable_at 𝕜 f x :=
+begin
+  split,
+  { intro hfx,
+    by_cases hx : differentiable_at 𝕜 f x,
+    { exact or.inl ⟨hx, hfx⟩ },
+    { rw [deriv_zero_of_not_differentiable_at hx] at hfx,
+      exact or.inr ⟨hfx, hx⟩ } },
+  { rintro (⟨hf, hf'⟩|⟨h₀, hx⟩),
+    { exact hf' },
+    { rwa [deriv_zero_of_not_differentiable_at hx] } }
+end
+
+lemma deriv_within_mem_iff {f : 𝕜 → F} {t : set 𝕜} {s : set F} {x : 𝕜} :
+  deriv_within f t x ∈ s ↔ (differentiable_within_at 𝕜 f t x ∧ deriv_within f t x ∈ s) ∨
+    (0 : F) ∈ s ∧ ¬differentiable_within_at 𝕜 f t x :=
+begin
+  split,
+  { intro hfx,
+    by_cases hx : differentiable_within_at 𝕜 f t x,
+    { exact or.inl ⟨hx, hfx⟩ },
+    { rw [deriv_within_zero_of_not_differentiable_within_at hx] at hfx,
+      exact or.inr ⟨hfx, hx⟩ } },
+  { rintro (⟨hf, hf'⟩|⟨h₀, hx⟩),
+    { exact hf' },
+    { rwa [deriv_within_zero_of_not_differentiable_within_at hx] } }
+end
+
+lemma differentiable_within_at_Ioi_iff_Ici [partial_order 𝕜] :
+  differentiable_within_at 𝕜 f (Ioi x) x ↔ differentiable_within_at 𝕜 f (Ici x) x :=
+⟨λ h, h.has_deriv_within_at.Ici_of_Ioi.differentiable_within_at,
+λ h, h.has_deriv_within_at.Ioi_of_Ici.differentiable_within_at⟩
+
+lemma deriv_within_Ioi_eq_Ici {E : Type*} [normed_group E] [normed_space ℝ E] (f : ℝ → E) (x : ℝ) :
+  deriv_within f (Ioi x) x = deriv_within f (Ici x) x :=
+begin
+  by_cases H : differentiable_within_at ℝ f (Ioi x) x,
+  { have A := H.has_deriv_within_at.Ici_of_Ioi,
+    have B := (differentiable_within_at_Ioi_iff_Ici.1 H).has_deriv_within_at,
+    simpa using (unique_diff_on_Ici x).eq le_rfl A B },
+  { rw [deriv_within_zero_of_not_differentiable_within_at H,
+      deriv_within_zero_of_not_differentiable_within_at],
+    rwa differentiable_within_at_Ioi_iff_Ici at H }
+end
 
 section congr
 /-! ### Congruence properties of derivatives -/

--- a/src/analysis/calculus/fderiv.lean
+++ b/src/analysis/calculus/fderiv.lean
@@ -624,6 +624,21 @@ begin
     { rwa [fderiv_zero_of_not_differentiable_at hx] } }
 end
 
+lemma fderiv_within_mem_iff {f : E → F} {t : set E} {s : set (E →L[𝕜] F)} {x : E} :
+  fderiv_within 𝕜 f t x ∈ s ↔ (differentiable_within_at 𝕜 f t x ∧ fderiv_within 𝕜 f t x ∈ s) ∨
+    (0 : E →L[𝕜] F) ∈ s ∧ ¬differentiable_within_at 𝕜 f t x :=
+begin
+  split,
+  { intro hfx,
+    by_cases hx : differentiable_within_at 𝕜 f t x,
+    { exact or.inl ⟨hx, hfx⟩ },
+    { rw [fderiv_within_zero_of_not_differentiable_within_at hx] at hfx,
+      exact or.inr ⟨hfx, hx⟩ } },
+  { rintro (⟨hf, hf'⟩|⟨h₀, hx⟩),
+    { exact hf' },
+    { rwa [fderiv_within_zero_of_not_differentiable_within_at hx] } }
+end
+
 end fderiv_properties
 
 section continuous

--- a/src/analysis/calculus/fderiv.lean
+++ b/src/analysis/calculus/fderiv.lean
@@ -611,33 +611,14 @@ end
 
 lemma fderiv_mem_iff {f : E → F} {s : set (E →L[𝕜] F)} {x : E} :
   fderiv 𝕜 f x ∈ s ↔ (differentiable_at 𝕜 f x ∧ fderiv 𝕜 f x ∈ s) ∨
-    (0 : E →L[𝕜] F) ∈ s ∧ ¬differentiable_at 𝕜 f x :=
-begin
-  split,
-  { intro hfx,
-    by_cases hx : differentiable_at 𝕜 f x,
-    { exact or.inl ⟨hx, hfx⟩ },
-    { rw [fderiv_zero_of_not_differentiable_at hx] at hfx,
-      exact or.inr ⟨hfx, hx⟩ } },
-  { rintro (⟨hf, hf'⟩|⟨h₀, hx⟩),
-    { exact hf' },
-    { rwa [fderiv_zero_of_not_differentiable_at hx] } }
-end
+    (¬differentiable_at 𝕜 f x ∧ (0 : E →L[𝕜] F) ∈ s) :=
+by by_cases hx : differentiable_at 𝕜 f x; simp [fderiv_zero_of_not_differentiable_at, *]
 
 lemma fderiv_within_mem_iff {f : E → F} {t : set E} {s : set (E →L[𝕜] F)} {x : E} :
   fderiv_within 𝕜 f t x ∈ s ↔ (differentiable_within_at 𝕜 f t x ∧ fderiv_within 𝕜 f t x ∈ s) ∨
-    (0 : E →L[𝕜] F) ∈ s ∧ ¬differentiable_within_at 𝕜 f t x :=
-begin
-  split,
-  { intro hfx,
-    by_cases hx : differentiable_within_at 𝕜 f t x,
-    { exact or.inl ⟨hx, hfx⟩ },
-    { rw [fderiv_within_zero_of_not_differentiable_within_at hx] at hfx,
-      exact or.inr ⟨hfx, hx⟩ } },
-  { rintro (⟨hf, hf'⟩|⟨h₀, hx⟩),
-    { exact hf' },
-    { rwa [fderiv_within_zero_of_not_differentiable_within_at hx] } }
-end
+    (¬differentiable_within_at 𝕜 f t x ∧ (0 : E →L[𝕜] F) ∈ s) :=
+by by_cases hx : differentiable_within_at 𝕜 f t x;
+  simp [fderiv_within_zero_of_not_differentiable_within_at, *]
 
 end fderiv_properties
 

--- a/src/analysis/calculus/fderiv_measurable.lean
+++ b/src/analysis/calculus/fderiv_measurable.lean
@@ -432,21 +432,20 @@ end fderiv
 
 section right_deriv
 
-
 variables {F : Type*} [normed_group F] [normed_space ℝ F]
 variables {f : ℝ → F} (K : set F)
 
 namespace right_deriv_measurable_aux
 
 /-- The set `A f L r ε` is the set of points `x` around which the function `f` is well approximated
-at scale `r` by the linear map `L`, up to an error `ε`. We tweak the definition to make sure that
-this is an open set.-/
+at scale `r` by the linear map `h ↦ h • L`, up to an error `ε`. We tweak the definition to
+make sure that this is open on the right. -/
 def A (f : ℝ → F) (L : F) (r ε : ℝ) : set ℝ :=
 {x | ∃ r' ∈ Ioc (r/2) r, ∀ y z ∈ Icc x (x + r'), ∥f z - f y - (z-y) • L∥ ≤ ε * r}
 
-/-- The set `B f K r s ε` is the set of points `x` around which there exists a continuous linear map
-`L` belonging to `K` (a given set of continuous linear maps) that approximates well the
-function `f` (up to an error `ε`), simultaneously at scales `r` and `s`. -/
+/-- The set `B f K r s ε` is the set of points `x` around which there exists a vector
+`L` belonging to `K` (a given set of vectors) such that `h • L` approximates well `f (x + h)`
+(up to an error `ε`), simultaneously at scales `r` and `s`. -/
 def B (f : ℝ → F) (K : set F) (r s ε : ℝ) : set ℝ :=
 ⋃ (L ∈ K), (A f L r ε) ∩ (A f L s ε)
 
@@ -658,7 +657,7 @@ begin
     /- to get an approximation with a precision `ε`, we will replace `f` with `L e (n e) m` for
     some large enough `e` (yielding a small error by uniform approximation). As one can vary `m`,
     this makes it possible to cover all scales, and thus to obtain a good linear approximation in
-    the whole ball of radius `(1/2)^(n e)`. -/
+    the whole interval of length `(1/2)^(n e)`. -/
     assume ε εpos,
     obtain ⟨e, he⟩ : ∃ (e : ℕ), (1 / 2) ^ e < ε / 16 :=
       exists_pow_lt_of_lt_one (div_pos εpos (by norm_num)) (by norm_num),
@@ -667,7 +666,7 @@ begin
         zero_lt_one],
     filter_upwards [Icc_mem_nhds_within_Ici xmem] with y hy,
     -- We need to show that `f y - f x - f' (y - x)` is small. For this, we will work at scale
-    -- `k` where `k` is chosen with `∥y∥ ∼ 2 ^ (-k)`.
+    -- `k` where `k` is chosen with `∥y - x∥ ∼ 2 ^ (-k)`.
     rcases eq_or_lt_of_le hy.1 with rfl|xy,
     { simp only [sub_self, zero_smul, norm_zero, mul_zero]},
     have yzero : 0 < y - x := sub_pos.2 xy,
@@ -677,7 +676,7 @@ begin
     obtain ⟨k, hk, h'k⟩ : ∃ (k : ℕ), (1/2) ^ (k + 1) < y - x ∧ y - x ≤ (1/2) ^ k :=
       exists_nat_pow_near_of_lt_one yzero yone (by norm_num : (0 : ℝ) < 1/2)
       (by norm_num : (1 : ℝ)/2 < 1),
-    -- the scale is large enough (as `y` is small enough)
+    -- the scale is large enough (as `y - x` is small enough)
     have k_gt : n e < k,
     { have : ((1:ℝ)/2) ^ (k + 1) < (1/2) ^ (n e + 1) := lt_of_lt_of_le hk y_le,
       rw pow_lt_pow_iff_of_lt_one (by norm_num : (0 : ℝ) < 1/2) (by norm_num) at this,

--- a/src/analysis/calculus/fderiv_measurable.lean
+++ b/src/analysis/calculus/fderiv_measurable.lean
@@ -397,11 +397,11 @@ end
 begin
   refine measurable_of_is_closed (λ s hs, _),
   have : fderiv 𝕜 f ⁻¹' s = {x | differentiable_at 𝕜 f x ∧ fderiv 𝕜 f x ∈ s} ∪
-    {x | (0 : E →L[𝕜] F) ∈ s} ∩ {x | ¬differentiable_at 𝕜 f x} :=
+    ({x | ¬differentiable_at 𝕜 f x} ∩ {x | (0 : E →L[𝕜] F) ∈ s}) :=
     set.ext (λ x, mem_preimage.trans fderiv_mem_iff),
   rw this,
   exact (measurable_set_of_differentiable_at_of_is_complete _ _ hs.is_complete).union
-    ((measurable_set.const _).inter (measurable_set_of_differentiable_at _ _).compl)
+    ((measurable_set_of_differentiable_at _ _).compl.inter (measurable_set.const _))
 end
 
 @[measurability] lemma measurable_fderiv_apply_const [measurable_space F] [borel_space F] (y : E) :
@@ -749,11 +749,11 @@ begin
   refine measurable_of_is_closed (λ s hs, _),
   have : (λ x, deriv_within f (Ici x) x) ⁻¹' s =
     {x | differentiable_within_at ℝ f (Ici x) x ∧ deriv_within f (Ici x) x ∈ s} ∪
-    {x | (0 : F) ∈ s} ∩ {x | ¬differentiable_within_at ℝ f (Ici x) x} :=
+    ({x | ¬differentiable_within_at ℝ f (Ici x) x} ∩ {x | (0 : F) ∈ s}) :=
     set.ext (λ x, mem_preimage.trans deriv_within_mem_iff),
   rw this,
   exact (measurable_set_of_differentiable_within_at_Ici_of_is_complete _ hs.is_complete).union
-    ((measurable_set.const _).inter (measurable_set_of_differentiable_within_at_Ici _).compl)
+    ((measurable_set_of_differentiable_within_at_Ici _).compl.inter (measurable_set.const _))
 end
 
 lemma strongly_measurable_deriv_within_Ici [second_countable_topology F] :

--- a/src/analysis/calculus/fderiv_measurable.lean
+++ b/src/analysis/calculus/fderiv_measurable.lean
@@ -20,6 +20,10 @@ function. Namely, we prove:
   is measurable;
 * `measurable_deriv`: the function `deriv f` is measurable (for `f : 𝕜 → F`).
 
+We also show the same results for the right derivative on the real line
+(see `measurable_deriv_within_Ici` and ``measurable_deriv_within_Ioi`), following the same
+proof strategy.
+
 ## Implementation
 
 We give a proof that avoids second-countability issues, by expressing the differentiability set
@@ -86,6 +90,8 @@ lemma measurable_apply₂ [measurable_space E] [opens_measurable_space E]
 is_bounded_bilinear_map_apply.continuous.measurable
 
 end continuous_linear_map
+
+section fderiv
 
 variables {𝕜 : Type*} [nondiscrete_normed_field 𝕜]
 variables {E : Type*} [normed_group E] [normed_space 𝕜 E]
@@ -421,3 +427,369 @@ lemma ae_strongly_measurable_deriv [measurable_space 𝕜] [opens_measurable_spa
   [second_countable_topology F] (f : 𝕜 → F) (μ : measure 𝕜) :
   ae_strongly_measurable (deriv f) μ :=
 (strongly_measurable_deriv f).ae_strongly_measurable
+
+end fderiv
+
+section right_deriv
+
+
+variables {F : Type*} [normed_group F] [normed_space ℝ F]
+variables {f : ℝ → F} (K : set F)
+
+namespace right_deriv_measurable_aux
+
+/-- The set `A f L r ε` is the set of points `x` around which the function `f` is well approximated
+at scale `r` by the linear map `L`, up to an error `ε`. We tweak the definition to make sure that
+this is an open set.-/
+def A (f : ℝ → F) (L : F) (r ε : ℝ) : set ℝ :=
+{x | ∃ r' ∈ Ioc (r/2) r, ∀ y z ∈ Icc x (x + r'), ∥f z - f y - (z-y) • L∥ ≤ ε * r}
+
+/-- The set `B f K r s ε` is the set of points `x` around which there exists a continuous linear map
+`L` belonging to `K` (a given set of continuous linear maps) that approximates well the
+function `f` (up to an error `ε`), simultaneously at scales `r` and `s`. -/
+def B (f : ℝ → F) (K : set F) (r s ε : ℝ) : set ℝ :=
+⋃ (L ∈ K), (A f L r ε) ∩ (A f L s ε)
+
+/-- The set `D f K` is a complicated set constructed using countable intersections and unions. Its
+main use is that, when `K` is complete, it is exactly the set of points where `f` is differentiable,
+with a derivative in `K`. -/
+def D (f : ℝ → F) (K : set F) : set ℝ :=
+⋂ (e : ℕ), ⋃ (n : ℕ), ⋂ (p ≥ n) (q ≥ n), B f K ((1/2) ^ p) ((1/2) ^ q) ((1/2) ^ e)
+
+lemma A_mem_nhds_within_Ioi {L : F} {r ε x : ℝ} (hx : x ∈ A f L r ε) :
+  A f L r ε ∈ 𝓝[>] x :=
+begin
+  rcases hx with ⟨r', rr', hr'⟩,
+  rw mem_nhds_within_Ioi_iff_exists_Ioo_subset,
+  obtain ⟨s, s_gt, s_lt⟩ : ∃ (s : ℝ), r / 2 < s ∧ s < r' := exists_between rr'.1,
+  have : s ∈ Ioc (r/2) r := ⟨s_gt, le_of_lt (s_lt.trans_le rr'.2)⟩,
+  refine ⟨x + r' - s, by { simp only [mem_Ioi], linarith }, λ x' hx', ⟨s, this, _⟩⟩,
+  have A : Icc x' (x' + s) ⊆ Icc x (x + r'),
+  { apply Icc_subset_Icc hx'.1.le,
+    linarith [hx'.2] },
+  assume y hy z hz,
+  exact hr' y (A hy) z (A hz)
+end
+
+lemma B_mem_nhds_within_Ioi {K : set F} {r s ε x : ℝ} (hx : x ∈ B f K r s ε) :
+  B f K r s ε ∈ 𝓝[>] x :=
+begin
+  obtain ⟨L, LK, hL₁, hL₂⟩ : ∃ (L : F), L ∈ K ∧ x ∈ A f L r ε ∧ x ∈ A f L s ε,
+    by simpa only [B, mem_Union, mem_inter_eq, exists_prop] using hx,
+  filter_upwards [A_mem_nhds_within_Ioi hL₁, A_mem_nhds_within_Ioi hL₂] with y hy₁ hy₂,
+  simp only [B, mem_Union, mem_inter_eq, exists_prop],
+  exact ⟨L, LK, hy₁, hy₂⟩
+end
+
+lemma measurable_set_B {K : set F} {r s ε : ℝ} : measurable_set (B f K r s ε) :=
+measurable_set_of_mem_nhds_within_Ioi (λ x hx, B_mem_nhds_within_Ioi hx)
+
+lemma A_mono (L : F) (r : ℝ) {ε δ : ℝ} (h : ε ≤ δ) :
+  A f L r ε ⊆ A f L r δ :=
+begin
+  rintros x ⟨r', r'r, hr'⟩,
+  refine ⟨r', r'r, λ y hy z hz, (hr' y hy z hz).trans (mul_le_mul_of_nonneg_right h _)⟩,
+  linarith [hy.1, hy.2, r'r.2],
+end
+
+lemma le_of_mem_A {r ε : ℝ} {L : F} {x : ℝ} (hx : x ∈ A f L r ε)
+  {y z : ℝ} (hy : y ∈ Icc x (x + r/2)) (hz : z ∈ Icc x (x + r/2)) :
+  ∥f z - f y - (z-y) • L∥ ≤ ε * r :=
+begin
+  rcases hx with ⟨r', r'mem, hr'⟩,
+  have A : x + r / 2 ≤ x + r', by linarith [r'mem.1],
+  exact hr' _ ((Icc_subset_Icc le_rfl A) hy) _ ((Icc_subset_Icc le_rfl A) hz),
+end
+
+lemma mem_A_of_differentiable {ε : ℝ} (hε : 0 < ε) {x : ℝ}
+  (hx : differentiable_within_at ℝ f (Ici x) x) :
+  ∃ R > 0, ∀ r ∈ Ioo (0 : ℝ) R, x ∈ A f (deriv_within f (Ici x) x) r ε :=
+begin
+  have := hx.has_deriv_within_at,
+  simp_rw [has_deriv_within_at_iff_is_o, is_o_iff] at this,
+  rcases mem_nhds_within_Ici_iff_exists_Ico_subset.1 (this (half_pos hε)) with ⟨m, xm, hm⟩,
+  refine ⟨m - x, by linarith [show x < m, from xm], λ r hr, _⟩,
+  have : r ∈ Ioc (r/2) r := ⟨half_lt_self hr.1, le_rfl⟩,
+  refine ⟨r, this, λ y hy z hz, _⟩,
+  calc  ∥f z - f y - (z - y) • deriv_within f (Ici x) x∥
+      = ∥(f z - f x - (z - x) • deriv_within f (Ici x) x)
+           - (f y - f x - (y - x) • deriv_within f (Ici x) x)∥ :
+    by { congr' 1, simp only [sub_smul], abel }
+  ... ≤ ∥f z - f x - (z - x) • deriv_within f (Ici x) x∥
+         + ∥f y - f x - (y - x) • deriv_within f (Ici x) x∥ :
+    norm_sub_le _ _
+  ... ≤ ε / 2 * ∥z - x∥ + ε / 2 * ∥y - x∥ :
+    add_le_add (hm ⟨hz.1, hz.2.trans_lt (by linarith [hr.2])⟩)
+               (hm ⟨hy.1, hy.2.trans_lt (by linarith [hr.2])⟩)
+  ... ≤ ε / 2 * r + ε / 2 * r :
+  begin
+    apply add_le_add,
+    { apply mul_le_mul_of_nonneg_left _ (le_of_lt (half_pos hε)),
+      rw [real.norm_of_nonneg];
+      linarith [hz.1, hz.2] },
+    { apply mul_le_mul_of_nonneg_left _ (le_of_lt (half_pos hε)),
+      rw [real.norm_of_nonneg];
+      linarith [hy.1, hy.2] },
+   end
+  ... = ε * r : by ring
+end
+
+lemma norm_sub_le_of_mem_A
+  {r x : ℝ} (hr : 0 < r) (ε : ℝ) {L₁ L₂ : F}
+  (h₁ : x ∈ A f L₁ r ε) (h₂ : x ∈ A f L₂ r ε) : ∥L₁ - L₂∥ ≤ 4 * ε :=
+begin
+  suffices H : ∥(r/2) • (L₁ - L₂)∥ ≤ (r / 2) * (4 * ε),
+    by rwa [norm_smul, real.norm_of_nonneg (half_pos hr).le, mul_le_mul_left (half_pos hr)] at H,
+  calc
+  ∥(r/2) • (L₁ - L₂)∥
+      = ∥(f (x + r/2) - f x - (x + r/2 - x) • L₂) - (f (x + r/2) - f x - (x + r/2 - x) • L₁)∥ :
+    by simp [smul_sub]
+  ... ≤ ∥f (x + r/2) - f x - (x + r/2 - x) • L₂∥ + ∥f (x + r/2) - f x - (x + r/2 - x) • L₁∥ :
+    norm_sub_le _ _
+  ... ≤ ε * r + ε * r :
+    begin
+      apply add_le_add,
+      { apply le_of_mem_A h₂;
+        simp [(half_pos hr).le] },
+      { apply le_of_mem_A h₁;
+        simp [(half_pos hr).le] },
+    end
+  ... = (r / 2) * (4 * ε) : by ring
+end
+
+/-- Easy inclusion: a differentiability point with derivative in `K` belongs to `D f K`. -/
+lemma differentiable_set_subset_D :
+  {x | differentiable_within_at ℝ f (Ici x) x ∧ deriv_within f (Ici x) x ∈ K} ⊆ D f K :=
+begin
+  assume x hx,
+  rw [D, mem_Inter],
+  assume e,
+  have : (0 : ℝ) < (1/2) ^ e := pow_pos (by norm_num) _,
+  rcases mem_A_of_differentiable this hx.1 with ⟨R, R_pos, hR⟩,
+  obtain ⟨n, hn⟩ : ∃ (n : ℕ), (1/2) ^ n < R :=
+    exists_pow_lt_of_lt_one R_pos (by norm_num : (1 : ℝ)/2 < 1),
+  simp only [mem_Union, mem_Inter, B, mem_inter_eq],
+  refine ⟨n, λ p hp q hq, ⟨deriv_within f (Ici x) x, hx.2, ⟨_, _⟩⟩⟩;
+  { refine hR _ ⟨pow_pos (by norm_num) _, lt_of_le_of_lt _ hn⟩,
+    exact pow_le_pow_of_le_one (by norm_num) (by norm_num) (by assumption) }
+end
+
+/-- Harder inclusion: at a point in `D f K`, the function `f` has a derivative, in `K`. -/
+lemma D_subset_differentiable_set {K : set F} (hK : is_complete K) :
+  D f K ⊆ {x | differentiable_within_at ℝ f (Ici x) x ∧ deriv_within f (Ici x) x ∈ K} :=
+begin
+  have P : ∀ {n : ℕ}, (0 : ℝ) < (1/2) ^ n := pow_pos (by norm_num),
+  assume x hx,
+  have : ∀ (e : ℕ), ∃ (n : ℕ), ∀ p q, n ≤ p → n ≤ q → ∃ L ∈ K,
+    x ∈ A f L ((1/2) ^ p) ((1/2) ^ e) ∩ A f L ((1/2) ^ q) ((1/2) ^ e),
+  { assume e,
+    have := mem_Inter.1 hx e,
+    rcases mem_Union.1 this with ⟨n, hn⟩,
+    refine ⟨n, λ p q hp hq, _⟩,
+    simp only [mem_Inter, ge_iff_le] at hn,
+    rcases mem_Union.1 (hn p hp q hq) with ⟨L, hL⟩,
+    exact ⟨L, mem_Union.1 hL⟩, },
+  /- Recast the assumptions: for each `e`, there exist `n e` and linear maps `L e p q` in `K`
+  such that, for `p, q ≥ n e`, then `f` is well approximated by `L e p q` at scale `2 ^ (-p)` and
+  `2 ^ (-q)`, with an error `2 ^ (-e)`. -/
+  choose! n L hn using this,
+  /- All the operators `L e p q` that show up are close to each other. To prove this, we argue
+    that `L e p q` is close to `L e p r` (where `r` is large enough), as both approximate `f` at
+    scale `2 ^(- p)`. And `L e p r` is close to `L e' p' r` as both approximate `f` at scale
+    `2 ^ (- r)`. And `L e' p' r` is close to `L e' p' q'` as both approximate `f` at scale
+    `2 ^ (- p')`. -/
+  have M : ∀ e p q e' p' q', n e ≤ p → n e ≤ q → n e' ≤ p' → n e' ≤ q' → e ≤ e' →
+    ∥L e p q - L e' p' q'∥ ≤ 12 * (1/2) ^ e,
+  { assume e p q e' p' q' hp hq hp' hq' he',
+    let r := max (n e) (n e'),
+    have I : ((1:ℝ)/2)^e' ≤ (1/2)^e := pow_le_pow_of_le_one (by norm_num) (by norm_num) he',
+    have J1 : ∥L e p q - L e p r∥ ≤ 4 * (1/2)^e,
+    { have I1 : x ∈ A f (L e p q) ((1 / 2) ^ p) ((1/2)^e) :=
+        (hn e p q hp hq).2.1,
+      have I2 : x ∈ A f (L e p r) ((1 / 2) ^ p) ((1/2)^e) :=
+        (hn e p r hp (le_max_left _ _)).2.1,
+      exact norm_sub_le_of_mem_A P _ I1 I2 },
+    have J2 : ∥L e p r - L e' p' r∥ ≤ 4 * (1/2)^e,
+    { have I1 : x ∈ A f (L e p r) ((1 / 2) ^ r) ((1/2)^e) :=
+        (hn e p r hp (le_max_left _ _)).2.2,
+      have I2 : x ∈ A f (L e' p' r) ((1 / 2) ^ r) ((1/2)^e') :=
+        (hn e' p' r hp' (le_max_right _ _)).2.2,
+      exact norm_sub_le_of_mem_A P _ I1 (A_mono _ _ I I2) },
+    have J3 : ∥L e' p' r - L e' p' q'∥ ≤ 4 * (1/2)^e,
+    { have I1 : x ∈ A f (L e' p' r) ((1 / 2) ^ p') ((1/2)^e') :=
+        (hn e' p' r hp' (le_max_right _ _)).2.1,
+      have I2 : x ∈ A f (L e' p' q') ((1 / 2) ^ p') ((1/2)^e') :=
+        (hn e' p' q' hp' hq').2.1,
+      exact norm_sub_le_of_mem_A P _ (A_mono _ _ I I1) (A_mono _ _ I I2) },
+    calc ∥L e p q - L e' p' q'∥
+          = ∥(L e p q - L e p r) + (L e p r - L e' p' r) + (L e' p' r - L e' p' q')∥ :
+        by { congr' 1, abel }
+      ... ≤ ∥L e p q - L e p r∥ + ∥L e p r - L e' p' r∥ + ∥L e' p' r - L e' p' q'∥ :
+        le_trans (norm_add_le _ _) (add_le_add_right (norm_add_le _ _) _)
+      ... ≤ 4 * (1/2)^e + 4 * (1/2)^e + 4 * (1/2)^e :
+        by apply_rules [add_le_add]
+      ... = 12 * (1/2)^e : by ring },
+  /- For definiteness, use `L0 e = L e (n e) (n e)`, to have a single sequence. We claim that this
+  is a Cauchy sequence. -/
+  let L0 : ℕ → F := λ e, L e (n e) (n e),
+  have : cauchy_seq L0,
+  { rw metric.cauchy_seq_iff',
+    assume ε εpos,
+    obtain ⟨e, he⟩ : ∃ (e : ℕ), (1/2) ^ e < ε / 12 :=
+      exists_pow_lt_of_lt_one (div_pos εpos (by norm_num)) (by norm_num),
+    refine ⟨e, λ e' he', _⟩,
+    rw [dist_comm, dist_eq_norm],
+    calc ∥L0 e - L0 e'∥
+          ≤ 12 * (1/2)^e : M _ _ _ _ _ _ le_rfl le_rfl le_rfl le_rfl he'
+      ... < 12 * (ε / 12) :
+        mul_lt_mul' le_rfl he (le_of_lt P) (by norm_num)
+      ... = ε : by { field_simp [(by norm_num : (12 : ℝ) ≠ 0)], ring } },
+  /- As it is Cauchy, the sequence `L0` converges, to a limit `f'` in `K`.-/
+  obtain ⟨f', f'K, hf'⟩ : ∃ f' ∈ K, tendsto L0 at_top (𝓝 f') :=
+    cauchy_seq_tendsto_of_is_complete hK (λ e, (hn e (n e) (n e) le_rfl le_rfl).1) this,
+  have Lf' : ∀ e p, n e ≤ p → ∥L e (n e) p - f'∥ ≤ 12 * (1/2)^e,
+  { assume e p hp,
+    apply le_of_tendsto (tendsto_const_nhds.sub hf').norm,
+    rw eventually_at_top,
+    exact ⟨e, λ e' he', M _ _ _ _ _ _ le_rfl hp le_rfl le_rfl he'⟩ },
+  /- Let us show that `f` has right derivative `f'` at `x`. -/
+  have : has_deriv_within_at f f' (Ici x) x,
+  { simp only [has_deriv_within_at_iff_is_o, is_o_iff],
+    /- to get an approximation with a precision `ε`, we will replace `f` with `L e (n e) m` for
+    some large enough `e` (yielding a small error by uniform approximation). As one can vary `m`,
+    this makes it possible to cover all scales, and thus to obtain a good linear approximation in
+    the whole ball of radius `(1/2)^(n e)`. -/
+    assume ε εpos,
+    obtain ⟨e, he⟩ : ∃ (e : ℕ), (1 / 2) ^ e < ε / 16 :=
+      exists_pow_lt_of_lt_one (div_pos εpos (by norm_num)) (by norm_num),
+    have xmem : x ∈ Ico x (x + (1/2)^(n e + 1)),
+      by simp only [one_div, left_mem_Ico, lt_add_iff_pos_right, inv_pos, pow_pos, zero_lt_bit0,
+        zero_lt_one],
+    filter_upwards [Icc_mem_nhds_within_Ici xmem] with y hy,
+    -- We need to show that `f y - f x - f' (y - x)` is small. For this, we will work at scale
+    -- `k` where `k` is chosen with `∥y∥ ∼ 2 ^ (-k)`.
+    rcases eq_or_lt_of_le hy.1 with rfl|xy,
+    { simp only [sub_self, zero_smul, norm_zero, mul_zero]},
+    have yzero : 0 < y - x := sub_pos.2 xy,
+    have y_le : y - x ≤ (1/2) ^ (n e + 1), by linarith [hy.2],
+    have yone : y - x ≤ 1 := le_trans y_le (pow_le_one _ (by norm_num) (by norm_num)),
+    -- define the scale `k`.
+    obtain ⟨k, hk, h'k⟩ : ∃ (k : ℕ), (1/2) ^ (k + 1) < y - x ∧ y - x ≤ (1/2) ^ k :=
+      exists_nat_pow_near_of_lt_one yzero yone (by norm_num : (0 : ℝ) < 1/2)
+      (by norm_num : (1 : ℝ)/2 < 1),
+    -- the scale is large enough (as `y` is small enough)
+    have k_gt : n e < k,
+    { have : ((1:ℝ)/2) ^ (k + 1) < (1/2) ^ (n e + 1) := lt_of_lt_of_le hk y_le,
+      rw pow_lt_pow_iff_of_lt_one (by norm_num : (0 : ℝ) < 1/2) (by norm_num) at this,
+      linarith },
+    set m := k - 1 with hl,
+    have m_ge : n e ≤ m := nat.le_pred_of_lt k_gt,
+    have km : k = m + 1 := (nat.succ_pred_eq_of_pos (lt_of_le_of_lt (zero_le _) k_gt)).symm,
+    rw km at hk h'k,
+    -- `f` is well approximated by `L e (n e) k` at the relevant scale
+    -- (in fact, we use `m = k - 1` instead of `k` because of the precise definition of `A`).
+    have J : ∥f y - f x - (y - x) • L e (n e) m∥ ≤ 4 * (1/2) ^ e * ∥y - x∥ := calc
+      ∥f y - f x - (y - x) • L e (n e) m∥ ≤ (1/2) ^ e * (1/2) ^ m :
+        begin
+          apply le_of_mem_A (hn e (n e) m le_rfl m_ge).2.2,
+          { simp only [one_div, inv_pow, left_mem_Icc, le_add_iff_nonneg_right],
+            exact div_nonneg (inv_nonneg.2 (pow_nonneg zero_le_two _)) zero_le_two },
+          { simp only [pow_add, tsub_le_iff_left] at h'k,
+            simpa only [hy.1, mem_Icc, true_and, one_div, pow_one] using h'k }
+        end
+      ... = 4 * (1/2) ^ e * (1/2) ^ (m + 2) : by { field_simp, ring_exp }
+      ... ≤ 4 * (1/2) ^ e * (y - x) :
+        mul_le_mul_of_nonneg_left (le_of_lt hk) (mul_nonneg (by norm_num) (le_of_lt P))
+      ... = 4 * (1/2) ^ e * ∥y - x∥ : by rw [real.norm_of_nonneg yzero.le],
+    calc ∥f y - f x - (y - x) • f'∥
+        = ∥(f y - f x - (y - x) • L e (n e) m) + (y - x) • (L e (n e) m - f')∥ :
+      by simp only [smul_sub, sub_add_sub_cancel]
+    ... ≤ 4 * (1/2) ^ e * ∥y - x∥ + ∥y - x∥ * (12 * (1/2) ^ e) : norm_add_le_of_le J
+      (by { rw [norm_smul], exact mul_le_mul_of_nonneg_left (Lf' _ _ m_ge) (norm_nonneg _) })
+    ... = 16 * ∥y - x∥ * (1/2) ^ e : by ring
+    ... ≤ 16 * ∥y - x∥ * (ε / 16) :
+      mul_le_mul_of_nonneg_left he.le (mul_nonneg (by norm_num) (norm_nonneg _))
+    ... = ε * ∥y - x∥ : by ring },
+  rw ← this.deriv_within (unique_diff_on_Ici x x le_rfl) at f'K,
+  exact ⟨this.differentiable_within_at, f'K⟩,
+end
+
+theorem differentiable_set_eq_D (hK : is_complete K) :
+  {x | differentiable_within_at ℝ f (Ici x) x ∧ deriv_within f (Ici x) x ∈ K} = D f K :=
+subset.antisymm (differentiable_set_subset_D _) (D_subset_differentiable_set hK)
+
+end right_deriv_measurable_aux
+
+open right_deriv_measurable_aux
+
+variables (f)
+
+/-- The set of right differentiability points of a function, with derivative in a given complete
+set, is Borel-measurable. -/
+theorem measurable_set_of_differentiable_within_at_Ici_of_is_complete
+  {K : set F} (hK : is_complete K) :
+  measurable_set {x | differentiable_within_at ℝ f (Ici x) x ∧ deriv_within f (Ici x) x ∈ K} :=
+by simp [differentiable_set_eq_D K hK, D, measurable_set_B, measurable_set.Inter_Prop,
+         measurable_set.Inter, measurable_set.Union]
+
+variable [complete_space F]
+
+/-- The set of right differentiability points of a function taking values in a complete space is
+Borel-measurable. -/
+theorem measurable_set_of_differentiable_within_at_Ici :
+  measurable_set {x | differentiable_within_at ℝ f (Ici x) x} :=
+begin
+  have : is_complete (univ : set F) := complete_univ,
+  convert measurable_set_of_differentiable_within_at_Ici_of_is_complete f this,
+  simp
+end
+
+@[measurability] lemma measurable_deriv_within_Ici [measurable_space F] [borel_space F] :
+  measurable (λ x, deriv_within f (Ici x) x) :=
+begin
+  refine measurable_of_is_closed (λ s hs, _),
+  have : (λ x, deriv_within f (Ici x) x) ⁻¹' s =
+    {x | differentiable_within_at ℝ f (Ici x) x ∧ deriv_within f (Ici x) x ∈ s} ∪
+    {x | (0 : F) ∈ s} ∩ {x | ¬differentiable_within_at ℝ f (Ici x) x} :=
+    set.ext (λ x, mem_preimage.trans deriv_within_mem_iff),
+  rw this,
+  exact (measurable_set_of_differentiable_within_at_Ici_of_is_complete _ hs.is_complete).union
+    ((measurable_set.const _).inter (measurable_set_of_differentiable_within_at_Ici _).compl)
+end
+
+lemma strongly_measurable_deriv_within_Ici [second_countable_topology F] :
+  strongly_measurable (λ x, deriv_within f (Ici x) x) :=
+by { borelize F, exact (measurable_deriv_within_Ici f).strongly_measurable }
+
+lemma ae_measurable_deriv_within_Ici [measurable_space F] [borel_space F]
+  (μ : measure ℝ) : ae_measurable (λ x, deriv_within f (Ici x) x) μ :=
+(measurable_deriv_within_Ici f).ae_measurable
+
+lemma ae_strongly_measurable_deriv_within_Ici [second_countable_topology F] (μ : measure ℝ) :
+  ae_strongly_measurable (λ x, deriv_within f (Ici x) x) μ :=
+(strongly_measurable_deriv_within_Ici f).ae_strongly_measurable
+
+/-- The set of right differentiability points of a function taking values in a complete space is
+Borel-measurable. -/
+theorem measurable_set_of_differentiable_within_at_Ioi :
+  measurable_set {x | differentiable_within_at ℝ f (Ioi x) x} :=
+by simpa [differentiable_within_at_Ioi_iff_Ici]
+  using measurable_set_of_differentiable_within_at_Ici f
+
+@[measurability] lemma measurable_deriv_within_Ioi [measurable_space F] [borel_space F] :
+  measurable (λ x, deriv_within f (Ioi x) x) :=
+by simpa [deriv_within_Ioi_eq_Ici] using measurable_deriv_within_Ici f
+
+lemma strongly_measurable_deriv_within_Ioi [second_countable_topology F] :
+  strongly_measurable (λ x, deriv_within f (Ioi x) x) :=
+by { borelize F, exact (measurable_deriv_within_Ioi f).strongly_measurable }
+
+lemma ae_measurable_deriv_within_Ioi [measurable_space F] [borel_space F]
+  (μ : measure ℝ) : ae_measurable (λ x, deriv_within f (Ioi x) x) μ :=
+(measurable_deriv_within_Ioi f).ae_measurable
+
+lemma ae_strongly_measurable_deriv_within_Ioi [second_countable_topology F] (μ : measure ℝ) :
+  ae_strongly_measurable (λ x, deriv_within f (Ioi x) x) μ :=
+(strongly_measurable_deriv_within_Ioi f).ae_strongly_measurable
+
+end right_deriv

--- a/src/measure_theory/constructions/borel_space.lean
+++ b/src/measure_theory/constructions/borel_space.lean
@@ -1136,6 +1136,55 @@ lemma ae_measurable_restrict_of_antitone_on [linear_order β] [order_closed_topo
   ae_measurable f (μ.restrict s) :=
 @ae_measurable_restrict_of_monotone_on αᵒᵈ β _ _ ‹_› _ _ _ _ _ ‹_› _ _ _ _ hs _ hf
 
+private lemma measurable_set_of_mem_nhds_within_Ioi_aux [densely_ordered α]
+  {s : set α} (h : ∀ x ∈ s, s ∈ 𝓝[>] x) (h' : ∀ x ∈ s, ∃ y, x < y):
+  measurable_set s :=
+begin
+  choose! M hM using h',
+  suffices H : (s \ interior s).countable,
+  { have : s = interior s ∪ (s \ interior s), by rw union_diff_cancel interior_subset,
+    rw this,
+    exact is_open_interior.measurable_set.union H.measurable_set },
+  have A : ∀ x ∈ s, ∃ y ∈ Ioi x, Ioo x y ⊆ s :=
+    λ x hx, (mem_nhds_within_Ioi_iff_exists_Ioo_subset' (hM x hx)).1 (h x hx),
+  choose! y hy h'y using A,
+  have B : set.pairwise_disjoint (s \ interior s) (λ x, Ioo x (y x)),
+  { assume x hx x' hx' hxx',
+    rcases lt_or_gt_of_ne hxx' with h'|h',
+    { apply disjoint_left.2 (λ z hz h'z, _),
+      have : x' ∈ interior s :=
+        mem_interior.2 ⟨Ioo x (y x), h'y _ hx.1, is_open_Ioo, ⟨h', h'z.1.trans hz.2⟩⟩,
+      exact false.elim (hx'.2 this) },
+    { apply disjoint_left.2 (λ z hz h'z, _),
+      have : x ∈ interior s :=
+        mem_interior.2 ⟨Ioo x' (y x'), h'y _ hx'.1, is_open_Ioo, ⟨h', hz.1.trans h'z.2⟩⟩,
+      exact false.elim (hx.2 this) } },
+  apply B.countable_of_is_open (λ x hx, is_open_Ioo) (λ x hx, _),
+  simpa using hy x hx.1
+end
+
+/-- If a set is a right-neighborhood of all of its points, then it is measurable. -/
+lemma measurable_set_of_mem_nhds_within_Ioi [densely_ordered α] {s : set α}
+  (h : ∀ x ∈ s, s ∈ 𝓝[>] x) : measurable_set s :=
+begin
+  by_cases H : ∃ x ∈ s, is_top x,
+  { rcases H with ⟨x₀, x₀s, h₀⟩,
+    have : s = {x₀} ∪ (s \ {x₀}), by rw union_diff_cancel (singleton_subset_iff.2 x₀s),
+    rw this,
+    refine (measurable_set_singleton _).union _,
+    have A : ∀ x ∈ s \ {x₀}, x < x₀ :=
+      λ x hx, lt_of_le_of_ne (h₀ _) (by simpa using hx.2),
+    refine measurable_set_of_mem_nhds_within_Ioi_aux (λ x hx, _) (λ x hx, ⟨x₀, A x hx⟩),
+    obtain ⟨u, hu, us⟩ : ∃ (u : α) (H : u ∈ Ioi x), Ioo x u ⊆ s :=
+      (mem_nhds_within_Ioi_iff_exists_Ioo_subset' (A x hx)).1 (h x hx.1),
+    refine (mem_nhds_within_Ioi_iff_exists_Ioo_subset' (A x hx)).2 ⟨u, hu, λ y hy, ⟨us hy, _⟩⟩,
+    exact ne_of_lt (hy.2.trans_le (h₀ _)) },
+  { apply measurable_set_of_mem_nhds_within_Ioi_aux h,
+    simp only [is_top] at H,
+    push_neg at H,
+    exact H }
+end
+
 end linear_order
 
 @[measurability]

--- a/src/measure_theory/constructions/borel_space.lean
+++ b/src/measure_theory/constructions/borel_space.lean
@@ -1137,7 +1137,7 @@ lemma ae_measurable_restrict_of_antitone_on [linear_order β] [order_closed_topo
 @ae_measurable_restrict_of_monotone_on αᵒᵈ β _ _ ‹_› _ _ _ _ _ ‹_› _ _ _ _ hs _ hf
 
 private lemma measurable_set_of_mem_nhds_within_Ioi_aux [densely_ordered α]
-  {s : set α} (h : ∀ x ∈ s, s ∈ 𝓝[>] x) (h' : ∀ x ∈ s, ∃ y, x < y):
+  {s : set α} (h : ∀ x ∈ s, s ∈ 𝓝[>] x) (h' : ∀ x ∈ s, ∃ y, x < y) :
   measurable_set s :=
 begin
   choose! M hM using h',

--- a/src/measure_theory/constructions/borel_space.lean
+++ b/src/measure_theory/constructions/borel_space.lean
@@ -1136,7 +1136,7 @@ lemma ae_measurable_restrict_of_antitone_on [linear_order β] [order_closed_topo
   ae_measurable f (μ.restrict s) :=
 @ae_measurable_restrict_of_monotone_on αᵒᵈ β _ _ ‹_› _ _ _ _ _ ‹_› _ _ _ _ hs _ hf
 
-private lemma measurable_set_of_mem_nhds_within_Ioi_aux [densely_ordered α]
+lemma measurable_set_of_mem_nhds_within_Ioi_aux [densely_ordered α]
   {s : set α} (h : ∀ x ∈ s, s ∈ 𝓝[>] x) (h' : ∀ x ∈ s, ∃ y, x < y) :
   measurable_set s :=
 begin


### PR DESCRIPTION
We already know that the full Fréchet derivative is measurable. In this PR, we follow the same proof to show that the right derivative of a function defined on the real line is also measurable (the target space may be any complete vector space).

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
