### PR TITLE
[Merged by Bors] - feat(analysis/calculus/tangent_cone): unique differentiability of open interval at endpoint

### DIFF
--- a/src/analysis/calculus/tangent_cone.lean
+++ b/src/analysis/calculus/tangent_cone.lean
@@ -3,7 +3,7 @@ Copyright (c) 2019 Sébastien Gouëzel. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Sébastien Gouëzel
 -/
-import analysis.convex.basic
+import analysis.convex.topology
 import analysis.normed_space.basic
 import analysis.specific_limits.basic
 
@@ -205,25 +205,25 @@ begin
       exact tendsto_pow_at_top_nhds_0_of_lt_1 one_half_pos.le one_half_lt_one } }
 end
 
-/-- If a subset of a real vector space contains a segment, then the direction of this
+/-- If a subset of a real vector space contains an open segment, then the direction of this
 segment belongs to the tangent cone at its endpoints. -/
-lemma mem_tangent_cone_of_segment_subset {s : set G} {x y : G} (h : segment ℝ x y ⊆ s) :
+lemma mem_tangent_cone_of_open_segment_subset {s : set G} {x y : G} (h : open_segment ℝ x y ⊆ s) :
   y - x ∈ tangent_cone_at ℝ s x :=
 begin
-  let c := λn:ℕ, (2:ℝ)^n,
+  let c := λn:ℕ, (2:ℝ)^(n+1),
   let d := λn:ℕ, (c n)⁻¹ • (y-x),
   refine ⟨c, d, filter.univ_mem' (λn, h _), _, _⟩,
-  show x + d n ∈ segment ℝ x y,
-  { rw segment_eq_image,
+  show x + d n ∈ open_segment ℝ x y,
+  { rw open_segment_eq_image,
     refine ⟨(c n)⁻¹, ⟨_, _⟩, _⟩,
-    { rw inv_nonneg, apply pow_nonneg, norm_num },
-    { apply inv_le_one, apply one_le_pow_of_one_le, norm_num },
+    { rw inv_pos, apply pow_pos, norm_num },
+    { apply inv_lt_one, apply one_lt_pow _ (nat.succ_ne_zero _), norm_num },
     { simp only [d, sub_smul, smul_sub, one_smul], abel } },
   show filter.tendsto (λ (n : ℕ), ∥c n∥) filter.at_top filter.at_top,
   { have : (λ (n : ℕ), ∥c n∥) = c,
       by { ext n, exact abs_of_nonneg (pow_nonneg (by norm_num) _) },
     rw this,
-    exact tendsto_pow_at_top_at_top_of_one_lt (by norm_num) },
+    exact (tendsto_pow_at_top_at_top_of_one_lt (by norm_num)).comp (tendsto_add_at_top_nat 1) },
   show filter.tendsto (λ (n : ℕ), c n • d n) filter.at_top (𝓝 (y - x)),
   { have : (λ (n : ℕ), c n • d n) = (λn, y - x),
     { ext n,
@@ -233,6 +233,12 @@ begin
     rw this,
     apply tendsto_const_nhds }
 end
+
+/-- If a subset of a real vector space contains a segment, then the direction of this
+segment belongs to the tangent cone at its endpoints. -/
+lemma mem_tangent_cone_of_segment_subset {s : set G} {x y : G} (h : segment ℝ x y ⊆ s) :
+  y - x ∈ tangent_cone_at ℝ s x :=
+mem_tangent_cone_of_open_segment_subset ((open_segment_subset_segment ℝ x y).trans h)
 
 end tangent_cone
 
@@ -366,21 +372,28 @@ lemma unique_diff_on.univ_pi (ι : Type*) [fintype ι] (E : ι → Type*)
 unique_diff_on.pi _ _ _ _ $ λ i _, h i
 
 /-- In a real vector space, a convex set with nonempty interior is a set of unique
+differentiability at every point of its closure. -/
+theorem unique_diff_within_at_convex {s : set G} (conv : convex ℝ s) (hs : (interior s).nonempty)
+  {x : G} (hx : x ∈ closure s) : unique_diff_within_at ℝ s x :=
+begin
+  rcases hs with ⟨y, hy⟩,
+  suffices : y - x ∈ interior (tangent_cone_at ℝ s x),
+  { refine ⟨dense.of_closure _, hx⟩,
+    simp [(submodule.span ℝ (tangent_cone_at ℝ s x)).eq_top_of_nonempty_interior'
+      ⟨y - x, interior_mono submodule.subset_span this⟩] },
+  rw [mem_interior_iff_mem_nhds],
+  replace hy : interior s ∈ 𝓝 y := is_open.mem_nhds is_open_interior hy,
+  apply mem_of_superset ((is_open_map_sub_right x).image_mem_nhds hy),
+  rintros _ ⟨z, zs, rfl⟩,
+  refine mem_tangent_cone_of_open_segment_subset (subset.trans _ interior_subset),
+  exact conv.open_segment_closure_interior_subset_interior hx zs,
+end
+
+/-- In a real vector space, a convex set with nonempty interior is a set of unique
 differentiability. -/
 theorem unique_diff_on_convex {s : set G} (conv : convex ℝ s) (hs : (interior s).nonempty) :
   unique_diff_on ℝ s :=
-begin
-  assume x xs,
-  rcases hs with ⟨y, hy⟩,
-  suffices : y - x ∈ interior (tangent_cone_at ℝ s x),
-  { refine ⟨dense.of_closure _, subset_closure xs⟩,
-    simp [(submodule.span ℝ (tangent_cone_at ℝ s x)).eq_top_of_nonempty_interior'
-      ⟨y - x, interior_mono submodule.subset_span this⟩] },
-  rw [mem_interior_iff_mem_nhds] at hy ⊢,
-  apply mem_of_superset ((is_open_map_sub_right x).image_mem_nhds hy),
-  rintros _ ⟨z, zs, rfl⟩,
-  exact mem_tangent_cone_of_segment_subset (conv.segment_subset xs zs)
-end
+λ x xs, unique_diff_within_at_convex conv hs (subset_closure xs)
 
 lemma unique_diff_on_Ici (a : ℝ) : unique_diff_on ℝ (Ici a) :=
 unique_diff_on_convex (convex_Ici a) $ by simp only [interior_Ici, nonempty_Ioi]
@@ -413,5 +426,11 @@ is_open_Ioo.unique_diff_on
 /-- The real interval `[0, 1]` is a set of unique differentiability. -/
 lemma unique_diff_on_Icc_zero_one : unique_diff_on ℝ (Icc (0:ℝ) 1) :=
 unique_diff_on_Icc zero_lt_one
+
+lemma unique_diff_within_at_Ioi (a : ℝ) : unique_diff_within_at ℝ (Ioi a) a :=
+unique_diff_within_at_convex (convex_Ioi a) (by simp) (by simp)
+
+lemma unique_diff_within_at_Iio (a : ℝ) : unique_diff_within_at ℝ (Iio a) a :=
+unique_diff_within_at_convex (convex_Iio a) (by simp) (by simp)
 
 end unique_diff


### PR DESCRIPTION
We show that, if a point belongs to the closure of a convex set with nonempty interior, then it is a point of unique differentiability. We apply this to the specific situation of `Ioi` and `Iio`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
