### PR TITLE
[Merged by Bors] - feat(ring_theory/valuation/valuation_subring): define unit group of valuation subring and provide basic API

### DIFF
--- a/src/ring_theory/valuation/basic.lean
+++ b/src/ring_theory/valuation/basic.lean
@@ -280,6 +280,19 @@ begin
   simpa using this
 end
 
+lemma map_one_add_of_lt (h : v x < 1) : v (1 + x) = 1 :=
+begin
+  rw ← v.map_one at h,
+  simpa only [v.map_one] using v.map_add_eq_of_lt_left h
+end
+
+lemma map_one_sub_of_lt (h : v x < 1) : v (1 - x) = 1 :=
+begin
+  rw [← v.map_one, ← v.map_neg] at h,
+  rw sub_eq_add_neg 1 x,
+  simpa only [v.map_one, v.map_neg] using v.map_add_eq_of_lt_left h
+end
+
 /-- The subgroup of elements whose valuation is less than a certain unit.-/
 def lt_add_subgroup (v : valuation R Γ₀) (γ : Γ₀ˣ) : add_subgroup R :=
 { carrier   := {x | v x < γ},

--- a/src/ring_theory/valuation/valuation_subring.lean
+++ b/src/ring_theory/valuation/valuation_subring.lean
@@ -369,19 +369,20 @@ def unit_group : subgroup Kˣ :=
 
 lemma mem_unit_group_iff (x : Kˣ) : x ∈ A.unit_group ↔ A.valuation x = 1 := iff.refl _
 
-lemma eq_iff_unit_group (A B : valuation_subring K) :
-  A = B ↔ A.unit_group = B.unit_group :=
-begin
+lemma unit_group_injective : function.injective (unit_group : valuation_subring K → subgroup _) :=
+λ A B, begin
   rw [← A.valuation_subring_valuation, ← B.valuation_subring_valuation,
     ← valuation.is_equiv_iff_valuation_subring,
     A.valuation_subring_valuation, B.valuation_subring_valuation,
     valuation.is_equiv_iff_val_eq_one, set_like.ext_iff],
-  split,
-  { intros h x, apply h },
-  { intros h x,
-    by_cases hx : x = 0, { simp only [hx, valuation.map_zero, zero_ne_one] },
-    exact h (units.mk0 x hx) }
+  intros h x,
+  by_cases hx : x = 0, { simp only [hx, valuation.map_zero, zero_ne_one] },
+  exact h (units.mk0 x hx)
 end
+
+lemma eq_iff_unit_group {A B : valuation_subring K} :
+  A = B ↔ A.unit_group = B.unit_group :=
+unit_group_injective.eq_iff.symm
 
 /-- For a valuation subring `A`, `A.unit_group` agrees with the units of `A`. -/
 def unit_group_mul_equiv : A.unit_group ≃* Aˣ :=

--- a/src/ring_theory/valuation/valuation_subring.lean
+++ b/src/ring_theory/valuation/valuation_subring.lean
@@ -407,7 +407,7 @@ lemma coe_unit_group_mul_equiv_symm_apply (a : Aˣ) :
 /-- The map on valuation subrings to their unit groups is an order embedding. -/
 def unit_group_order_embedding : valuation_subring K ↪o subgroup Kˣ :=
 { to_fun := λ A, A.unit_group,
-  inj' := λ A B h, by rwa eq_iff_unit_group,
+  inj' := unit_group_injective,
   map_rel_iff' := begin
     intros A B,
     split,

--- a/src/ring_theory/valuation/valuation_subring.lean
+++ b/src/ring_theory/valuation/valuation_subring.lean
@@ -404,9 +404,10 @@ lemma coe_unit_group_mul_equiv_symm_apply (a : Aˣ) :
   (A.unit_group_mul_equiv.symm a : K) = a := rfl
 
 lemma unit_group_le_unit_group {A B : valuation_subring K} :
-  A.unit_group ≤ B.unit_group → A ≤ B :=
+  A.unit_group ≤ B.unit_group ↔ A ≤ B :=
 begin
-  rintros h x hx,
+  split,
+  { rintros h x hx,
     rw [← A.valuation_le_one_iff x, le_iff_lt_or_eq] at hx,
     by_cases h_1 : x = 0, { simp only [h_1, zero_mem] },
     by_cases h_2 : 1 + x = 0,
@@ -417,21 +418,17 @@ begin
         (show 1 + x ∈ B, from set_like.coe_mem ((B.unit_group_mul_equiv ⟨_, this⟩) : B))
         (B.neg_mem _ B.one_mem) },
     { have := h (show (units.mk0 x h_1) ∈ A.unit_group, from hx),
-      refine set_like.coe_mem ((B.unit_group_mul_equiv ⟨_, this⟩) : B) }
+      refine set_like.coe_mem ((B.unit_group_mul_equiv ⟨_, this⟩) : B) } },
+  { rintros h x (hx : A.valuation x = 1),
+    apply_fun A.map_of_le B h at hx,
+    simpa using hx }
 end
 
 /-- The map on valuation subrings to their unit groups is an order embedding. -/
 def unit_group_order_embedding : valuation_subring K ↪o subgroup Kˣ :=
 { to_fun := λ A, A.unit_group,
   inj' := unit_group_injective,
-  map_rel_iff' := begin
-    intros A B,
-    split,
-    { exact unit_group_le_unit_group },
-    { rintros h x (hx : A.valuation x = 1),
-      apply_fun A.map_of_le B h at hx,
-      simpa using hx }
-  end }
+  map_rel_iff' := λ A B, unit_group_le_unit_group }
 
 lemma unit_group_strict_mono : strict_mono (unit_group : valuation_subring K → subgroup _) :=
 unit_group_order_embedding.strict_mono

--- a/src/ring_theory/valuation/valuation_subring.lean
+++ b/src/ring_theory/valuation/valuation_subring.lean
@@ -365,19 +365,7 @@ section unit_group
 
 /-- The unit group of a valuation subring, as a subgroup of `Kˣ`. -/
 def unit_group : subgroup Kˣ :=
-{ carrier := { x | A.valuation x = 1 },
-  mul_mem' := begin
-    intros a b ha hb,
-    dsimp at *,
-    rw [A.valuation.map_mul, ha, hb, one_mul],
-  end,
-  one_mem' := A.valuation.map_one,
-  inv_mem' := begin
-    intros a ha,
-    dsimp at *,
-    push_cast,
-    rw [A.valuation.map_inv, ha, inv_one],
-  end }
+(A.valuation.to_monoid_with_zero_hom.to_monoid_hom.comp (units.coe_hom K)).ker
 
 lemma mem_unit_group_iff (x : Kˣ) : x ∈ A.unit_group ↔ A.valuation x = 1 := iff.refl _
 

--- a/src/ring_theory/valuation/valuation_subring.lean
+++ b/src/ring_theory/valuation/valuation_subring.lean
@@ -403,6 +403,23 @@ lemma coe_unit_group_mul_equiv_apply (a : A.unit_group) :
 lemma coe_unit_group_mul_equiv_symm_apply (a : Aˣ) :
   (A.unit_group_mul_equiv.symm a : K) = a := rfl
 
+lemma unit_group_le_unit_group {A B : valuation_subring K} :
+  A.unit_group ≤ B.unit_group → A ≤ B :=
+begin
+  rintros h x hx,
+    rw [← A.valuation_le_one_iff x, le_iff_lt_or_eq] at hx,
+    by_cases h_1 : x = 0, { simp only [h_1, zero_mem] },
+    by_cases h_2 : 1 + x = 0,
+      { simp only [← add_eq_zero_iff_neg_eq.1 h_2, neg_mem _ _ (one_mem _)] },
+    cases hx,
+    { have := h (show (units.mk0 _ h_2) ∈ A.unit_group, from A.valuation.map_one_add_of_lt hx),
+      simpa using B.add_mem _ _
+        (show 1 + x ∈ B, from set_like.coe_mem ((B.unit_group_mul_equiv ⟨_, this⟩) : B))
+        (B.neg_mem _ B.one_mem) },
+    { have := h (show (units.mk0 x h_1) ∈ A.unit_group, from hx),
+      refine set_like.coe_mem ((B.unit_group_mul_equiv ⟨_, this⟩) : B) }
+end
+
 /-- The map on valuation subrings to their unit groups is an order embedding. -/
 def unit_group_order_embedding : valuation_subring K ↪o subgroup Kˣ :=
 { to_fun := λ A, A.unit_group,
@@ -410,18 +427,7 @@ def unit_group_order_embedding : valuation_subring K ↪o subgroup Kˣ :=
   map_rel_iff' := begin
     intros A B,
     split,
-    { rintros h x hx,
-      rw [← A.valuation_le_one_iff x, le_iff_lt_or_eq] at hx,
-      by_cases h_1 : x = 0, { simp only [h_1, zero_mem] },
-      by_cases h_2 : 1 + x = 0,
-        { simp only [← add_eq_zero_iff_neg_eq.1 h_2, neg_mem _ _ (one_mem _)] },
-      cases hx,
-      { have := h (show (units.mk0 _ h_2) ∈ A.unit_group, from A.valuation.map_one_add_of_lt hx),
-        simpa using B.add_mem _ _
-          (show 1 + x ∈ B, from set_like.coe_mem ((B.unit_group_mul_equiv ⟨_, this⟩) : B))
-          (B.neg_mem _ B.one_mem) },
-      { have := h (show (units.mk0 x h_1) ∈ A.unit_group, from hx),
-        refine set_like.coe_mem ((B.unit_group_mul_equiv ⟨_, this⟩) : B) } },
+    { exact unit_group_le_unit_group },
     { rintros h x (hx : A.valuation x = 1),
       apply_fun A.map_of_le B h at hx,
       simpa using hx }

--- a/src/ring_theory/valuation/valuation_subring.lean
+++ b/src/ring_theory/valuation/valuation_subring.lean
@@ -424,6 +424,7 @@ lemma coe_unit_group_mul_equiv_apply (a : A.unit_group) :
 lemma coe_unit_group_mul_equiv_symm_apply (a : Aˣ) :
   (A.unit_group_mul_equiv.symm a : K) = a := rfl
 
+/-- The map on valuation subrings to their unit groups is an order embedding. -/
 def unit_group_order_embedding : valuation_subring K ↪o subgroup Kˣ :=
 { to_fun := λ A, A.unit_group,
   inj' := λ A B h, by rwa eq_iff_unit_group,

--- a/src/ring_theory/valuation/valuation_subring.lean
+++ b/src/ring_theory/valuation/valuation_subring.lean
@@ -370,12 +370,11 @@ def unit_group : subgroup Kˣ :=
 lemma mem_unit_group_iff (x : Kˣ) : x ∈ A.unit_group ↔ A.valuation x = 1 := iff.refl _
 
 lemma unit_group_injective : function.injective (unit_group : valuation_subring K → subgroup _) :=
-λ A B, begin
+λ A B h, begin
   rw [← A.valuation_subring_valuation, ← B.valuation_subring_valuation,
-    ← valuation.is_equiv_iff_valuation_subring,
-    A.valuation_subring_valuation, B.valuation_subring_valuation,
-    valuation.is_equiv_iff_val_eq_one, set_like.ext_iff],
-  intros h x,
+    ← valuation.is_equiv_iff_valuation_subring, valuation.is_equiv_iff_val_eq_one],
+  rw set_like.ext_iff at h,
+  intros x,
   by_cases hx : x = 0, { simp only [hx, valuation.map_zero, zero_ne_one] },
   exact h (units.mk0 x hx)
 end
@@ -427,6 +426,9 @@ def unit_group_order_embedding : valuation_subring K ↪o subgroup Kˣ :=
       apply_fun A.map_of_le B h at hx,
       simpa using hx }
   end }
+
+lemma unit_group_strict_mono : strict_mono (unit_group : valuation_subring K → subgroup _) :=
+unit_group_order_embedding.strict_mono
 
 end unit_group
 

--- a/src/ring_theory/valuation/valuation_subring.lean
+++ b/src/ring_theory/valuation/valuation_subring.lean
@@ -395,7 +395,7 @@ begin
     exact h (units.mk0 x hx) }
 end
 
-/-- `A.unit_group` agrees with the units of `A`. -/
+/-- For a valuation subring `A`, `A.unit_group` agrees with the units of `A`. -/
 def unit_group_mul_equiv : A.unit_group ≃* Aˣ :=
 { to_fun := λ x,
   ⟨⟨x, (A.valuation_le_one_iff _).1 (le_of_eq x.2)⟩,⟨x⁻¹,

--- a/src/ring_theory/valuation/valuation_subring.lean
+++ b/src/ring_theory/valuation/valuation_subring.lean
@@ -387,20 +387,11 @@ unit_group_injective.eq_iff.symm
 /-- For a valuation subring `A`, `A.unit_group` agrees with the units of `A`. -/
 def unit_group_mul_equiv : A.unit_group ≃* Aˣ :=
 { to_fun := λ x,
-  ⟨⟨x, (A.valuation_le_one_iff _).1 (le_of_eq x.2)⟩,⟨x⁻¹,
-  begin
-    rw ← A.valuation_le_one_iff,
-    apply le_of_eq,
-    rw [A.valuation.map_inv, inv_eq_one],
-    exact x.2,
-  end⟩,
-    by { ext, exact mul_inv_cancel x.1.ne_zero },
-    by { ext, exact inv_mul_cancel x.1.ne_zero }⟩,
-  inv_fun := λ x, ⟨⟨x, (x : K)⁻¹,
-    mul_inv_cancel ((units.map A.subtype.to_monoid_hom x).ne_zero),
-    inv_mul_cancel ((units.map A.subtype.to_monoid_hom x).ne_zero)⟩, begin
-      rw mem_unit_group_iff, simpa using A.valuation_unit x,
-    end⟩,
+  { val := ⟨x, mem_of_valuation_le_one A _ x.prop.le⟩,
+    inv := ⟨↑(x⁻¹), mem_of_valuation_le_one _ _ (x⁻¹).prop.le⟩,
+    val_inv := subtype.ext (units.mul_inv x),
+    inv_val := subtype.ext (units.inv_mul x) },
+  inv_fun := λ x, ⟨units.map A.subtype.to_monoid_hom x, A.valuation_unit x⟩,
   left_inv := λ a, by { ext, refl },
   right_inv := λ a, by { ext, refl },
   map_mul' := λ a b, by { ext, refl } }


### PR DESCRIPTION

This PR defines the unit group of a valuation subring as a multiplicative subgroup of the units of the field. We show two valuation subrings are equivalent iff they have the same unit group. We show the map sending a valuation to its unit group is an order embedding.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
