### PR TITLE
feat(algebra/char_p/mixed_char_zero): Add equal/mixed characteristic zero

### DIFF
--- a/src/algebra/char_p/mixed_char_zero.lean
+++ b/src/algebra/char_p/mixed_char_zero.lean
@@ -64,7 +64,8 @@ end⟩
 namespace equal_char_zero
 
 /-- Equal characteristics zero implies `char(R) = 0`. -/
-instance char_zero (R : Type*) [comm_ring R] [nontrivial R] [equal_char_zero R] : char_zero R :=
+@[priority 100] instance char_zero (R : Type*) [comm_ring R] [nontrivial R] [equal_char_zero R] :
+  char_zero R :=
 ⟨begin
   intros x y h,
   apply (equal_char_zero.residue_char_zero (⊥:ideal R) bot_ne_top).cast_injective,

--- a/src/algebra/char_p/mixed_char_zero.lean
+++ b/src/algebra/char_p/mixed_char_zero.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2022 Jon Eugster.
 Released under Apache 2.0 license as described in the file LICENSE.
-Author: Jon Eugster.
+Authors: Jon Eugster
 -/
 import algebra.char_p.basic
 import ring_theory.ideal.quotient

--- a/src/algebra/char_p/mixed_char_zero.lean
+++ b/src/algebra/char_p/mixed_char_zero.lean
@@ -85,5 +85,5 @@ i.e. if there exists an ideal `I` such that `R/I` has positive characteristic.
 -/
 class mixed_char_zero (R : Type*) [comm_ring R] (p : ℕ) : Prop :=
   (char_zero : char_zero R)
-  (hp : p ≠ 0)
+  (p_pos : p ≠ 0)
   (residue_char_p : ∃(I : ideal R), (I ≠ ⊤) ∧ char_p (R⧸I) p)

--- a/src/algebra/char_p/mixed_char_zero.lean
+++ b/src/algebra/char_p/mixed_char_zero.lean
@@ -9,16 +9,16 @@ import ring_theory.ideal.quotient
 /-!
 # Equal and mixed characteristics
 
-A commutative ring of characteristics zero can either be of equal characteristics zero
-or of mixed characteristics. 'Equal characteristics zero' means that all the quotient
-rings `R⧸I` have characteristics zero for all proper ideals `I ⊆ R`.
+A commutative ring of characteristic zero can either be of 'equal characteristic zero'
+or of 'mixed characteristic'. 'Equal characteristic zero' means that the quotient
+ring `R⧸I` has characteristic zero for all proper ideals `I ⊆ R`.
 Equivalently, `R` has equal characteristics zero if there is an injective
 ring homomorphism `ℚ → R`, i.e. `R` contains a copy of `ℚ`.
 
 Mixed characteristics `(0,p)` means `R` has characteristics `0` but there
 exists an ideal such that `R⧸I` has characteristics `p`. Note that a ring
 can be of different mixed characteristics simultaneously, e.g. `ℤ` has mixed
-characteristics `(0,p)` for any prime number `p`.
+characteristics `(0,p)` for any `p ≠ 0`.
 
 In this document we define equal characteristics zero and provide a theorem to split
 into cases by characteristics.
@@ -42,10 +42,10 @@ into cases by characteristics.
 
 /-- A ring has equal characteristic zero if `char(R⧸I) = 0` for all proper ideals `I ⊂ R`. -/
 class equal_char_zero (R : Type*) [comm_ring R] : Prop :=
-  (residue_char_zero: ∀(I: ideal R), I ≠ ⊤ → char_zero (R ⧸ I))
+  (residue_char_zero : ∀(I : ideal R), I ≠ ⊤ → char_zero (R ⧸ I))
 
 /-- This definition is trivial if `R` is a field. -/
-lemma field.equal_char_zero (K : Type*) [field K] [h_char: char_zero K] :
+lemma field.equal_char_zero (K : Type*) [field K] [h_char : char_zero K] :
   equal_char_zero K :=
 ⟨begin
   intros I hI',
@@ -83,7 +83,7 @@ end equal_char_zero
 A ring `R` of `char_zero` is of mixed characteristics if it is not of `equal_char_zero`.
 i.e. if there exists an ideal `I` such that `R/I` has positive characteristic.
 -/
-class mixed_char_zero (R : Type*) [comm_ring R] (p:ℕ) : Prop :=
-  (char_zero: char_zero R)
-  (hp: p ≠ 0)
-  (residue_char_p: ∃(I: ideal R), (I ≠ ⊤) ∧ char_p (R⧸I) p)
+class mixed_char_zero (R : Type*) [comm_ring R] (p : ℕ) : Prop :=
+  (char_zero : char_zero R)
+  (hp : p ≠ 0)
+  (residue_char_p : ∃(I : ideal R), (I ≠ ⊤) ∧ char_p (R⧸I) p)

--- a/src/algebra/char_p/mixed_char_zero.lean
+++ b/src/algebra/char_p/mixed_char_zero.lean
@@ -1,0 +1,89 @@
+/-
+Copyright (c) 2022 Jon Eugster.
+Released under Apache 2.0 license as described in the file LICENSE.
+Author: Jon Eugster.
+-/
+import algebra.char_p.basic
+import ring_theory.ideal.quotient
+
+/-!
+# Equal and mixed characteristics
+
+A commutative ring of characteristics zero can either be of equal characteristics zero
+or of mixed characteristics. 'Equal characteristics zero' means that all the quotient
+rings `R⧸I` have characteristics zero for all proper ideals `I ⊆ R`.
+Equivalently, `R` has equal characteristics zero if there is an injective
+ring homomorphism `ℚ → R`, i.e. `R` contains a copy of `ℚ`.
+
+Mixed characteristics `(0,p)` means `R` has characteristics `0` but there
+exists an ideal such that `R⧸I` has characteristics `p`. Note that a ring
+can be of different mixed characteristics simultaneously, e.g. `ℤ` has mixed
+characteristics `(0,p)` for any prime number `p`.
+
+In this document we define equal characteristics zero and provide a theorem to split
+into cases by characteristics.
+
+## Main definitions
+
+- `equal_char_zero` : class for a ring to be of 'equal characteristic zero'.
+- `mixed_char_zero` : class for a ring to be of 'mixed characteristic zero'.
+
+## Main results
+
+## Implementation notes
+
+## References
+
+-/
+
+/-!
+### Equal characteristics zero
+-/
+
+/-- A ring has equal characteristic zero if `char(R⧸I) = 0` for all proper ideals `I ⊂ R`. -/
+class equal_char_zero (R : Type*) [comm_ring R] : Prop :=
+  (residue_char_zero: ∀(I: ideal R), I ≠ ⊤ → char_zero (R ⧸ I))
+
+/-- This definition is trivial if `R` is a field. -/
+lemma field.equal_char_zero (K : Type*) [field K] [h_char: char_zero K] :
+  equal_char_zero K :=
+⟨begin
+  intros I hI',
+  have hI := or_iff_not_imp_right.1 (ideal.eq_bot_or_top I) hI',
+  exact ⟨begin
+    intros x y h,
+    apply h_char.cast_injective,
+    calc ↑x = I.quot_equiv_of_eq_bot hI (submodule.quotient.mk x) : rfl
+        ... = I.quot_equiv_of_eq_bot hI (submodule.quotient.mk y) : by {simp only [
+                                                                    ideal.quotient.mk_eq_mk,
+                                                                    map_nat_cast], rw h}
+        ... = ↑y                                                  : rfl,
+  end⟩
+end⟩
+
+namespace equal_char_zero
+
+/-- Equal characteristics zero implies `char(R) = 0`. -/
+instance char_zero (R : Type*) [comm_ring R] [nontrivial R] [equal_char_zero R] : char_zero R :=
+⟨begin
+  intros x y h,
+  apply (equal_char_zero.residue_char_zero (⊥:ideal R) bot_ne_top).cast_injective,
+  replace h := congr_arg (ideal.quotient.mk ⊥) h,
+  simp at h,
+  exact h,
+end⟩
+
+end equal_char_zero
+
+/-!
+### Mixed characteristics
+-/
+
+/--
+A ring `R` of `char_zero` is of mixed characteristics if it is not of `equal_char_zero`.
+i.e. if there exists an ideal `I` such that `R/I` has positive characteristic.
+-/
+class mixed_char_zero (R : Type*) [comm_ring R] (p:ℕ) : Prop :=
+  (char_zero: char_zero R)
+  (hp: p ≠ 0)
+  (residue_char_p: ∃(I: ideal R), (I ≠ ⊤) ∧ char_p (R⧸I) p)


### PR DESCRIPTION
Add basic definitions for mixed and equal characteristic zero.

---

The entire API is in PR #14672. Split this out in hope to focus on the definitions first.

Help wanted: Do the definitions look good that way or are there suggestions to modify them?

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
