### PR TITLE
chore(set_theory/cardinal/basic): unmark redundant `simp` lemma

### DIFF
--- a/src/set_theory/cardinal/basic.lean
+++ b/src/set_theory/cardinal/basic.lean
@@ -804,7 +804,7 @@ by rw [←lift_aleph_0, lift_le]
 
 /-! ### Properties about the cast from `ℕ` -/
 
-@[simp] theorem mk_fin (n : ℕ) : #(fin n) = n := by simp
+theorem mk_fin (n : ℕ) : #(fin n) = n := by simp
 
 @[simp] theorem lift_nat_cast (n : ℕ) : lift.{u} (n : cardinal.{v}) = n :=
 by induction n; simp *


### PR DESCRIPTION
The lemma `mk_fin` is unmarked as `simp`, since it's solved by the two `simp` lemmas `mk_fintype` and `fintype.card_fin`. 

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
