### PR TITLE
[Merged by Bors] - feat(measure_theory/measure/finite_measure_weak_convergence): Characterize weak convergence of finite measures in terms of integrals of bounded continuous real-valued functions.

### DIFF
--- a/src/algebra/order/ring.lean
+++ b/src/algebra/order/ring.lean
@@ -1185,13 +1185,9 @@ end
 lemma max_zero_add_max_neg_zero_eq_abs_self (a : α) :
   max a 0 + max (-a) 0 = |a| :=
 begin
-  by_cases sign_a : 0 ≤ a,
-  { simp only [sign_a, max_eq_left, max_eq_right,
-               right.neg_nonpos_iff, add_zero, abs_eq_self.mpr sign_a], },
-  { rw not_le at sign_a,
-    have aux : a ≤ 0, from sign_a.le,
-    simp only [aux, max_eq_right, max_eq_left,
-               right.nonneg_neg_iff, zero_add, abs_eq_neg_self.mpr aux], },
+  symmetry,
+  rcases le_total 0 a with ha|ha;
+  simp [ha],
 end
 
 lemma gt_of_mul_lt_mul_neg_left (h : c * a < c * b) (hc : c ≤ 0) : b < a :=

--- a/src/algebra/order/ring.lean
+++ b/src/algebra/order/ring.lean
@@ -1182,7 +1182,7 @@ begin
     exact ⟨abs_eq_neg_self.mpr (le_of_lt h), h⟩ }
 end
 
-lemma max_zero_add_max_neg_zero_eq_abs_self (a : α) :
+@[simp] lemma max_zero_add_max_neg_zero_eq_abs_self (a : α) :
   max a 0 + max (-a) 0 = |a| :=
 begin
   symmetry,

--- a/src/algebra/order/ring.lean
+++ b/src/algebra/order/ring.lean
@@ -1182,6 +1182,18 @@ begin
     exact ⟨abs_eq_neg_self.mpr (le_of_lt h), h⟩ }
 end
 
+lemma max_zero_add_max_neg_zero_eq_abs_self (a : α) :
+  max a 0 + max (-a) 0 = |a| :=
+begin
+  by_cases sign_a : 0 ≤ a,
+  { simp only [sign_a, max_eq_left, max_eq_right,
+               right.neg_nonpos_iff, add_zero, abs_eq_self.mpr sign_a], },
+  { rw not_le at sign_a,
+    have aux : a ≤ 0, from sign_a.le,
+    simp only [aux, max_eq_right, max_eq_left,
+               right.nonneg_neg_iff, zero_add, abs_eq_neg_self.mpr aux], },
+end
+
 lemma gt_of_mul_lt_mul_neg_left (h : c * a < c * b) (hc : c ≤ 0) : b < a :=
 have nhc : 0 ≤ -c, from neg_nonneg_of_nonpos hc,
 have h2 : -(c * b) < -(c * a), from neg_lt_neg h,

--- a/src/measure_theory/measure/finite_measure_weak_convergence.lean
+++ b/src/measure_theory/measure/finite_measure_weak_convergence.lean
@@ -450,43 +450,7 @@ In this section we characterize the weak convergence of finite measures by the m
 
 namespace finite_measure
 
-variables {α : Type*} [measurable_space α] [topological_space α]
-
-/-- The nonnegative part of a bounded continuous `ℝ`-valued function as a bounded
-continuous `ℝ≥0`-valued function. -/
-def _root_.bounded_continuous_function.nnreal_part (f : α →ᵇ ℝ) : α →ᵇ ℝ≥0 :=
-bounded_continuous_function.comp _
-  (show lipschitz_with 1 real.to_nnreal, from lipschitz_with_pos) f
-
-@[simp] lemma _root_.bounded_continuous_function.nnreal_part_coe_fun_eq (f : α →ᵇ ℝ) :
-  ⇑(f.nnreal_part) = real.to_nnreal ∘ ⇑f := rfl
-
-/-- The absolute value of a bounded continuous `ℝ`-valued function as a bounded
-continuous `ℝ≥0`-valued function. -/
-def _root_.bounded_continuous_function.nnnorm (f : α →ᵇ ℝ) : α →ᵇ ℝ≥0 :=
-bounded_continuous_function.comp _
-  (show lipschitz_with 1 (λ (x : ℝ), ∥x∥₊), from lipschitz_with_one_norm) f
-
-@[simp] lemma _root_.bounded_continuous_function.nnnorm_coe_fun_eq (f : α →ᵇ ℝ) :
-  ⇑(f.nnnorm) = nnnorm ∘ ⇑f := rfl
-
-@[simp] lemma _root_.bounded_continuous_function.nnnorm_apply_coe (f : α →ᵇ ℝ) (a : α) :
-  (f.nnnorm a : ℝ) = |f a| := rfl
-
-open order real nnreal ennreal
-
-/-- Decompose a bounded continuous function to its positive and negative parts. -/
-lemma _root_.bounded_continuous_function.self_eq_nnreal_part_sub_nnreal_part_neg (f : α →ᵇ ℝ) :
-  ⇑f = coe ∘ f.nnreal_part - coe ∘ (-f).nnreal_part :=
-by { funext x, dsimp, simp only [max_zero_sub_max_neg_zero_eq_self], }
-
-/-- Express the absolute value of a bounded continuous function in terms of its
-positive and negative parts. -/
-lemma _root_.bounded_continuous_function.abs_self_eq_nnreal_part_add_nnreal_part_neg (f : α →ᵇ ℝ) :
-  abs ∘ ⇑f = coe ∘ f.nnreal_part + coe ∘ (-f).nnreal_part :=
-by { funext x, dsimp, simp only [max_zero_add_max_neg_zero_eq_abs_self], }
-
-variables [opens_measurable_space α]
+variables {α : Type*} [measurable_space α] [topological_space α] [opens_measurable_space α]
 
 lemma integrable_of_bounded_continuous_to_nnreal (μ : finite_measure α) (f : α →ᵇ ℝ≥0) :
   integrable ((coe : ℝ≥0 → ℝ) ∘ ⇑f) (μ : measure α) :=

--- a/src/measure_theory/measure/finite_measure_weak_convergence.lean
+++ b/src/measure_theory/measure/finite_measure_weak_convergence.lean
@@ -370,7 +370,7 @@ This formulation assumes:
  * integration is `lintegral`, i.e., the functions and their integrals are `ℝ≥0∞`-valued.
 -/
 lemma tendsto_lintegral_nn_filter_of_le_const {ι : Type*} {L : filter ι} [L.is_countably_generated]
-  (μ : finite_measure α) {fs : ι → (α →ᵇ ℝ≥0)} {c : ℝ≥0}
+  (μ : measure α) [is_finite_measure μ] {fs : ι → (α →ᵇ ℝ≥0)} {c : ℝ≥0}
   (fs_le_const : ∀ᶠ i in L, ∀ᵐ (a : α) ∂(μ : measure α), fs i a ≤ c) {f : α → ℝ≥0}
   (fs_lim : ∀ᵐ (a : α) ∂(μ : measure α), tendsto (λ i, fs i a) L (𝓝 (f a))) :
   tendsto (λ i, (∫⁻ a, fs i a ∂(μ : measure α))) L (𝓝 (∫⁻ a, (f a) ∂(μ : measure α))) :=
@@ -694,12 +694,12 @@ This formulation assumes:
 -/
 lemma measure_of_cont_bdd_of_tendsto_filter_indicator {ι : Type*} {L : filter ι}
   [L.is_countably_generated] [topological_space α] [opens_measurable_space α]
-  (μ : finite_measure α) {c : ℝ≥0} {E : set α} (E_mble : measurable_set E)
+  (μ : measure α) [is_finite_measure μ] {c : ℝ≥0} {E : set α} (E_mble : measurable_set E)
   (fs : ι → (α →ᵇ ℝ≥0)) (fs_bdd : ∀ᶠ i in L, ∀ᵐ (a : α) ∂(μ : measure α), fs i a ≤ c)
   (fs_lim : ∀ᵐ (a : α) ∂(μ : measure α),
             tendsto (λ (i : ι), (coe_fn : (α →ᵇ ℝ≥0) → (α → ℝ≥0)) (fs i) a) L
                     (𝓝 (indicator E (λ x, (1 : ℝ≥0)) a))) :
-  tendsto (λ n, lintegral (μ : measure α) (λ a, fs n a)) L (𝓝 ((μ : measure α) E)) :=
+  tendsto (λ n, lintegral μ (λ a, fs n a)) L (𝓝 (μ E)) :=
 begin
   convert finite_measure.tendsto_lintegral_nn_filter_of_le_const μ fs_bdd fs_lim,
   have aux : ∀ a, indicator E (λ x, (1 : ℝ≥0∞)) a = ↑(indicator E (λ x, (1 : ℝ≥0)) a),
@@ -716,11 +716,11 @@ A similar result with more general assumptions is `measure_of_cont_bdd_of_tendst
 -/
 lemma measure_of_cont_bdd_of_tendsto_indicator
   [topological_space α] [opens_measurable_space α]
-  (μ : finite_measure α) {c : ℝ≥0} {E : set α} (E_mble : measurable_set E)
+  (μ : measure α) [is_finite_measure μ] {c : ℝ≥0} {E : set α} (E_mble : measurable_set E)
   (fs : ℕ → (α →ᵇ ℝ≥0)) (fs_bdd : ∀ n a, fs n a ≤ c)
   (fs_lim : tendsto (λ (n : ℕ), (coe_fn : (α →ᵇ ℝ≥0) → (α → ℝ≥0)) (fs n))
             at_top (𝓝 (indicator E (λ x, (1 : ℝ≥0))))) :
-  tendsto (λ n, lintegral (μ : measure α) (λ a, fs n a)) at_top (𝓝 ((μ : measure α) E)) :=
+  tendsto (λ n, lintegral μ (λ a, fs n a)) at_top (𝓝 (μ E)) :=
 begin
   have fs_lim' : ∀ a, tendsto (λ (n : ℕ), (fs n a : ℝ≥0))
                  at_top (𝓝 (indicator E (λ x, (1 : ℝ≥0)) a)),
@@ -734,10 +734,10 @@ measure of the closed set if the thickening radii tend to zero.
 -/
 lemma tendsto_lintegral_thickened_indicator_of_is_closed
   {α : Type*} [measurable_space α] [pseudo_emetric_space α] [opens_measurable_space α]
-  (μ : finite_measure α) {F : set α} (F_closed : is_closed F) {δs : ℕ → ℝ}
+  (μ : measure α) [is_finite_measure μ] {F : set α} (F_closed : is_closed F) {δs : ℕ → ℝ}
   (δs_pos : ∀ n, 0 < δs n) (δs_lim : tendsto δs at_top (𝓝 0)) :
-  tendsto (λ n, lintegral (μ : measure α) (λ a, (thickened_indicator (δs_pos n) F a : ℝ≥0∞)))
-          at_top (𝓝 ((μ : measure α) F)) :=
+  tendsto (λ n, lintegral μ (λ a, (thickened_indicator (δs_pos n) F a : ℝ≥0∞)))
+          at_top (𝓝 (μ F)) :=
 begin
   apply measure_of_cont_bdd_of_tendsto_indicator μ F_closed.measurable_set
           (λ n, thickened_indicator (δs_pos n) F)
@@ -764,7 +764,8 @@ begin
   set δs := λ (n : ℕ), (1 : ℝ) / (n+1) with def_δs,
   have δs_pos : ∀ n, 0 < δs n, from λ n, nat.one_div_pos_of_nat,
   have δs_lim : tendsto δs at_top (𝓝 0), from tendsto_one_div_add_at_top_nhds_0_nat,
-  have key₁ := tendsto_lintegral_thickened_indicator_of_is_closed μ F_closed δs_pos δs_lim,
+  have key₁ := tendsto_lintegral_thickened_indicator_of_is_closed
+                  (μ : measure α) F_closed δs_pos δs_lim,
   have room₁ : (μ : measure α) F < (μ : measure α) F + ε / 2,
   { apply ennreal.lt_add_right (measure_lt_top (μ : measure α) F).ne
           ((ennreal.div_pos_iff.mpr

--- a/src/measure_theory/measure/finite_measure_weak_convergence.lean
+++ b/src/measure_theory/measure/finite_measure_weak_convergence.lean
@@ -200,7 +200,7 @@ measurable_coe_nnreal_ennreal.comp f.continuous.measurable
 
 lemma _root_.measure_theory.lintegral_lt_top_of_bounded_continuous_to_nnreal
   (μ : measure α) [is_finite_measure μ] (f : α →ᵇ ℝ≥0) :
-  ∫⁻ x, f x ∂(μ : measure α) < ∞ :=
+  ∫⁻ x, f x ∂μ < ∞ :=
 begin
   apply is_finite_measure.lintegral_lt_top_of_bounded_to_ennreal,
   use nndist f 0,
@@ -455,7 +455,7 @@ variables {α : Type*} [measurable_space α] [topological_space α] [opens_measu
 
 lemma integrable_of_bounded_continuous_to_nnreal
   (μ : measure α) [is_finite_measure μ] (f : α →ᵇ ℝ≥0) :
-  integrable ((coe : ℝ≥0 → ℝ) ∘ ⇑f) (μ : measure α) :=
+  integrable ((coe : ℝ≥0 → ℝ) ∘ ⇑f) μ :=
 begin
   refine ⟨(nnreal.continuous_coe.comp f.continuous).measurable.ae_strongly_measurable, _⟩,
   simp only [has_finite_integral, nnreal.nnnorm_eq],

--- a/src/measure_theory/measure/finite_measure_weak_convergence.lean
+++ b/src/measure_theory/measure/finite_measure_weak_convergence.lean
@@ -213,11 +213,6 @@ begin
   rwa eq at key,
 end
 
-/- lemma lintegral_lt_top_of_bounded_continuous_to_nnreal (μ : finite_measure α) (f : α →ᵇ ℝ≥0) :
-  ∫⁻ x, f x ∂(μ : measure α) < ∞ :=
-lintegral_lt_top_of_bounded_continuous_to_nnreal _ _
- -/
-
 @[simp] lemma test_against_nn_coe_eq {μ : finite_measure α} {f : α →ᵇ ℝ≥0} :
   (μ.test_against_nn f : ℝ≥0∞) = ∫⁻ x, f x ∂(μ : measure α) :=
 ennreal.coe_to_nnreal (lintegral_lt_top_of_bounded_continuous_to_nnreal _ f).ne
@@ -629,14 +624,7 @@ by { rw [← coe_fn_comp_to_finite_measure_eq_coe_fn,
 @[simp] lemma mass_to_finite_measure (μ : probability_measure α) :
   μ.to_finite_measure.mass = 1 := μ.coe_fn_univ
 
-variables [topological_space α]
-
-/- lemma lintegral_lt_top_of_bounded_continuous_to_nnreal (μ : probability_measure α) (f : α →ᵇ ℝ≥0) :
-  ∫⁻ x, f x ∂(μ : measure α) < ∞ :=
-lintegral_lt_top_of_bounded_continuous_to_nnreal _ f
- -/
-
-variables [opens_measurable_space α]
+variables [topological_space α] [opens_measurable_space α]
 
 lemma test_against_nn_lipschitz (μ : probability_measure α) :
   lipschitz_with 1 (λ (f : α →ᵇ ℝ≥0), μ.to_finite_measure.test_against_nn f) :=

--- a/src/measure_theory/measure/finite_measure_weak_convergence.lean
+++ b/src/measure_theory/measure/finite_measure_weak_convergence.lean
@@ -450,15 +450,28 @@ In this section we characterize the weak convergence of finite measures by the m
 
 namespace finite_measure
 
-variables {α : Type*} [measurable_space α] [topological_space α] [opens_measurable_space α]
+variables {α : Type*} [measurable_space α] [topological_space α]
 
-@[simps] def _root_.bounded_continuous_function.nnreal_part (f : α →ᵇ ℝ) : α →ᵇ ℝ≥0 :=
+/-- The nonnegative part of a bounded continuous `ℝ`-valued function as a bounded
+continuous `ℝ≥0`-valued function. -/
+def _root_.bounded_continuous_function.nnreal_part (f : α →ᵇ ℝ) : α →ᵇ ℝ≥0 :=
 bounded_continuous_function.comp _
   (show lipschitz_with 1 real.to_nnreal, from lipschitz_with_pos) f
 
-@[simps] def _root_.bounded_continuous_function.nnnorm (f : α →ᵇ ℝ) : α →ᵇ ℝ≥0 :=
+@[simp] lemma _root_.bounded_continuous_function.nnreal_part_coe_fun_eq (f : α →ᵇ ℝ) :
+  ⇑(f.nnreal_part) = real.to_nnreal ∘ ⇑f := rfl
+
+/-- The absolute value of a bounded continuous `ℝ`-valued function as a bounded
+continuous `ℝ≥0`-valued function. -/
+def _root_.bounded_continuous_function.nnnorm (f : α →ᵇ ℝ) : α →ᵇ ℝ≥0 :=
 bounded_continuous_function.comp _
   (show lipschitz_with 1 (λ (x : ℝ), ∥x∥₊), from lipschitz_with_one_norm) f
+
+@[simp] lemma _root_.bounded_continuous_function.nnnorm_coe_fun_eq (f : α →ᵇ ℝ) :
+  ⇑(f.nnnorm) = nnnorm ∘ ⇑f := rfl
+
+@[simp] lemma _root_.bounded_continuous_function.nnnorm_apply_coe (f : α →ᵇ ℝ) (a : α) :
+  (f.nnnorm a : ℝ) = |f a| := rfl
 
 open order real nnreal ennreal
 
@@ -473,6 +486,8 @@ lemma _root_.bounded_continuous_function.abs_self_eq_nnreal_part_add_nnreal_part
   abs ∘ ⇑f = coe ∘ f.nnreal_part + coe ∘ (-f).nnreal_part :=
 by { funext x, dsimp, simp only [max_zero_add_max_neg_zero_eq_abs_self], }
 
+variables [opens_measurable_space α]
+
 lemma integrable_of_bounded_continuous_to_nnreal (μ : finite_measure α) (f : α →ᵇ ℝ≥0) :
   integrable ((coe : ℝ≥0 → ℝ) ∘ ⇑f) (μ : measure α) :=
 begin
@@ -486,7 +501,8 @@ lemma integrable_of_bounded_continuous_to_real (μ : finite_measure α) (f : α 
 begin
   refine ⟨f.continuous.measurable.ae_strongly_measurable, _⟩,
   have aux : (coe : ℝ≥0 → ℝ) ∘ ⇑f.nnnorm = (λ x, ∥f x∥),
-  { ext x, simp only [function.comp_app, bounded_continuous_function.nnnorm_apply_coe], },
+  { ext x,
+    simp only [function.comp_app, bounded_continuous_function.nnnorm_coe_fun_eq, coe_nnnorm], },
   apply (has_finite_integral_iff_norm ⇑f).mpr,
   rw ← of_real_integral_eq_lintegral_of_real,
   { exact ennreal.of_real_lt_top, },
@@ -762,7 +778,7 @@ begin
       (eventually_of_forall (λ n, eventually_of_forall (fs_bdd n))) (eventually_of_forall fs_lim'),
 end
 
-/-- The integrals of thickenined indicators of a closed set against a finite measure tend to the
+/-- The integrals of thickened indicators of a closed set against a finite measure tend to the
 measure of the closed set if the thickening radii tend to zero.
 -/
 lemma tendsto_lintegral_thickened_indicator_of_is_closed

--- a/src/measure_theory/measure/finite_measure_weak_convergence.lean
+++ b/src/measure_theory/measure/finite_measure_weak_convergence.lean
@@ -480,7 +480,7 @@ lemma lintegral_lt_top_of_bounded_continuous_to_real
   ∫⁻ x, ennreal.of_real (f x) ∂μ < ∞ :=
 lintegral_lt_top_of_bounded_continuous_to_nnreal _ f.nnreal_part
 
-theorem tendsto_if_forall_integral_tendsto {γ : Type*} {F : filter γ}
+theorem tendsto_of_forall_integral_tendsto {γ : Type*} {F : filter γ}
   {μs : γ → finite_measure α} {μ : finite_measure α} :
   ((∀ (f : α →ᵇ ℝ),
     tendsto (λ i, (∫ x, (f x) ∂(μs(i) : measure α))) F (𝓝 ((∫ x, (f x) ∂(μ : measure α))))))
@@ -509,8 +509,8 @@ begin
 end
 
 lemma bounded_continuous_function.nnreal.to_real_lintegral_eq_integral
-  {μ : measure α} (f : α →ᵇ ℝ≥0) :
-  (∫⁻ x, (f x : ℝ≥0∞) ∂μ).to_real = (∫ x, (f x) ∂μ) :=
+  (f : α →ᵇ ℝ≥0) (μ : measure α) :
+  (∫⁻ x, (f x : ℝ≥0∞) ∂μ).to_real = (∫ x, f x ∂μ) :=
 begin
   rw integral_eq_lintegral_of_nonneg_ae _
      (nnreal.continuous_coe.comp f.continuous).measurable.ae_strongly_measurable,
@@ -525,7 +525,7 @@ theorem tendsto_iff_forall_integral_tendsto {γ : Type*} {F : filter γ}
   {μs : γ → finite_measure α} {μ : finite_measure α} :
   tendsto μs F (𝓝 μ) ↔
   ∀ (f : α →ᵇ ℝ),
-    tendsto (λ i, (∫ x, (f x) ∂(μs(i) : measure α))) F (𝓝 ((∫ x, (f x) ∂(μ : measure α)))) :=
+    tendsto (λ i, (∫ x, (f x) ∂(μs i : measure α))) F (𝓝 ((∫ x, (f x) ∂(μ : measure α)))) :=
 begin
   refine ⟨_, tendsto_if_forall_integral_tendsto⟩,
   rw finite_measure.tendsto_iff_forall_lintegral_tendsto,

--- a/src/measure_theory/measure/finite_measure_weak_convergence.lean
+++ b/src/measure_theory/measure/finite_measure_weak_convergence.lean
@@ -108,6 +108,19 @@ end
 
 namespace measure_theory
 
+section finite_measure
+/-! ### Finite measures
+
+In this section we define the `Type` of `finite_measure α`, when `α` measurable space. Finite
+measures on `α` are a module over `ℝ≥0`.
+
+If `α` is moreover a topological space and the sigma algebra on `α` is finer than the Borel sigma
+algebra (i.e. `[opens_measurable_space α]`), then `finite_measure α` is equipped with the topology
+of weak convergence of measures. This is implemented by defining a pairing of finite measures `μ`
+on `α` with continuous bounded nonnegative functions `f : α →ᵇ ℝ≥0` via integration, and using the
+associated weak topology.
+-/
+
 variables {α : Type*} [measurable_space α]
 
 /-- Finite measures are defined as the subtype of measures that have the property of being finite
@@ -351,6 +364,20 @@ begin
            ennreal.tendsto_coe, ennreal.to_nnreal_coe],
 end
 
+end finite_measure -- namespace
+
+end finite_measure -- section
+
+section finite_measure_bounded_convergence
+/-! ### Bounded convergence results for finite measures
+
+This section is about bounded convergence theorems for finite measures.
+-/
+
+namespace finite_measure
+
+variables {α : Type*} [measurable_space α] [topological_space α] [opens_measurable_space α]
+
 /-- A bounded convergence theorem for a finite measure:
 If bounded continuous non-negative functions are uniformly bounded by a constant and tend to a
 limit, then their integrals against the finite measure tend to the integral of the limit.
@@ -424,6 +451,21 @@ lemma tendsto_test_against_nn_of_le_const {μ : finite_measure α}
   tendsto (λ n, μ.test_against_nn (fs n)) at_top (𝓝 (μ.test_against_nn f)) :=
 tendsto_test_against_nn_filter_of_le_const
   (eventually_of_forall (λ n, eventually_of_forall (fs_le_const n))) (eventually_of_forall fs_lim)
+
+end finite_measure -- namespace
+
+end finite_measure_bounded_convergence -- section
+
+section finite_measure_convergence_by_bounded_continuous_functions
+/-! ### Weak convergence of finite measures with bounded continuous real-valued functions
+
+In this section we characterize the weak convergence of finite measures by the most common
+(defining) condition of convergence of integrals of all bounded continuous real-valued functions.
+-/
+
+namespace finite_measure
+
+variables {α : Type*} [measurable_space α] [topological_space α] [opens_measurable_space α]
 
 @[simps] def _root_.bounded_continuous_function.nnreal_part (f : α →ᵇ ℝ) : α →ᵇ ℝ≥0 :=
 bounded_continuous_function.comp _
@@ -543,7 +585,21 @@ begin
   exact tendsto.sub tends_pos tends_neg,
 end
 
-end finite_measure
+end finite_measure -- namespace
+
+end finite_measure_convergence_by_bounded_continuous_functions -- section
+
+section probability_measure
+/-! ### Probability measures
+
+In this section we define the `Type*` of probability measures on a measurable space `α`, denoted by
+`probability_measure α`. TODO: Probability measures form a convex space.
+
+If `α` is moreover a topological space and the sigma algebra on `α` is finer than the Borel sigma
+algebra (i.e. `[opens_measurable_space α]`), then `probability_measure α` is equipped with the
+topology of weak convergence of measures. Since every probability measure is a finite measure, this
+is implemented as the induced topology from the coercion `probability_measure.to_finite_measure`.
+-/
 
 /-- Probability measures are defined as the subtype of measures that have the property of being
 probability measures (i.e., their total mass is one). -/
@@ -551,6 +607,8 @@ def probability_measure (α : Type*) [measurable_space α] : Type* :=
 {μ : measure α // is_probability_measure μ}
 
 namespace probability_measure
+
+variables {α : Type*} [measurable_space α]
 
 instance [inhabited α] : inhabited (probability_measure α) :=
 ⟨⟨measure.dirac default, measure.dirac.is_probability_measure⟩⟩
@@ -660,9 +718,20 @@ begin
   exact finite_measure.tendsto_iff_forall_lintegral_tendsto,
 end
 
-end probability_measure
+end probability_measure -- namespace
+
+end probability_measure -- section
 
 section convergence_implies_limsup_closed_le
+/-! ### Portmanteau implication: weak convergence implies a limsup condition for closed sets
+
+In this section we prove, under the assumption that the underlying topological space `α` is
+pseudo-emetrizable, that the weak convergence of measures on `finite_measure α` implies that for
+any closed set `F` in `α` the limsup of the measures of `F` is at most the limit measure of `F`.
+This is one implication of the portmanteau theorem characterizing weak convergence of measures.
+-/
+
+variables {α : Type*} [measurable_space α]
 
 /-- If bounded continuous functions tend to the indicator of a measurable set and are
 uniformly bounded, then their integrals against a finite measure tend to the measure of the set.
@@ -768,6 +837,6 @@ begin
   simp only [add_assoc, ennreal.add_halves, le_refl],
 end
 
-end convergence_implies_limsup_closed_le
+end convergence_implies_limsup_closed_le --section
 
-end measure_theory
+end measure_theory --namespace

--- a/src/measure_theory/measure/finite_measure_weak_convergence.lean
+++ b/src/measure_theory/measure/finite_measure_weak_convergence.lean
@@ -198,7 +198,8 @@ lemma _root_.bounded_continuous_function.nnreal.to_ennreal_comp_measurable {α :
   measurable (λ x, (f x : ℝ≥0∞)) :=
 measurable_coe_nnreal_ennreal.comp f.continuous.measurable
 
-lemma lintegral_lt_top_of_bounded_continuous_to_nnreal (μ : finite_measure α) (f : α →ᵇ ℝ≥0) :
+lemma _root_.measure_theory.lintegral_lt_top_of_bounded_continuous_to_nnreal
+  (μ : measure α) [is_finite_measure μ] (f : α →ᵇ ℝ≥0) :
   ∫⁻ x, f x ∂(μ : measure α) < ∞ :=
 begin
   apply is_finite_measure.lintegral_lt_top_of_bounded_to_ennreal,
@@ -212,9 +213,14 @@ begin
   rwa eq at key,
 end
 
+/- lemma lintegral_lt_top_of_bounded_continuous_to_nnreal (μ : finite_measure α) (f : α →ᵇ ℝ≥0) :
+  ∫⁻ x, f x ∂(μ : measure α) < ∞ :=
+lintegral_lt_top_of_bounded_continuous_to_nnreal _ _
+ -/
+
 @[simp] lemma test_against_nn_coe_eq {μ : finite_measure α} {f : α →ᵇ ℝ≥0} :
   (μ.test_against_nn f : ℝ≥0∞) = ∫⁻ x, f x ∂(μ : measure α) :=
-ennreal.coe_to_nnreal (lintegral_lt_top_of_bounded_continuous_to_nnreal μ f).ne
+ennreal.coe_to_nnreal (lintegral_lt_top_of_bounded_continuous_to_nnreal _ f).ne
 
 lemma test_against_nn_const (μ : finite_measure α) (c : ℝ≥0) :
   μ.test_against_nn (bounded_continuous_function.const α c) = c * μ.mass :=
@@ -417,7 +423,7 @@ lemma tendsto_test_against_nn_filter_of_le_const {ι : Type*} {L : filter ι}
   tendsto (λ i, μ.test_against_nn (fs i)) L (𝓝 (μ.test_against_nn f)) :=
 begin
   apply (ennreal.tendsto_to_nnreal
-         (μ.lintegral_lt_top_of_bounded_continuous_to_nnreal f).ne).comp,
+         (lintegral_lt_top_of_bounded_continuous_to_nnreal (μ : measure α) f).ne).comp,
   exact finite_measure.tendsto_lintegral_nn_filter_of_le_const μ fs_le_const fs_lim,
 end
 
@@ -452,12 +458,21 @@ namespace finite_measure
 
 variables {α : Type*} [measurable_space α] [topological_space α] [opens_measurable_space α]
 
-lemma integrable_of_bounded_continuous_to_nnreal (μ : finite_measure α) (f : α →ᵇ ℝ≥0) :
+lemma integrable_of_bounded_continuous_to_nnreal
+  (μ : measure α) [is_finite_measure μ] (f : α →ᵇ ℝ≥0) :
   integrable ((coe : ℝ≥0 → ℝ) ∘ ⇑f) (μ : measure α) :=
 begin
   refine ⟨(nnreal.continuous_coe.comp f.continuous).measurable.ae_strongly_measurable, _⟩,
   simp only [has_finite_integral, nnreal.nnnorm_eq],
-  exact μ.lintegral_lt_top_of_bounded_continuous_to_nnreal f,
+  exact lintegral_lt_top_of_bounded_continuous_to_nnreal _ f,
+end
+
+lemma integrable_of_bounded_continuous_to_nnreal' (μ : finite_measure α) (f : α →ᵇ ℝ≥0) :
+  integrable ((coe : ℝ≥0 → ℝ) ∘ ⇑f) (μ : measure α) :=
+begin
+  refine ⟨(nnreal.continuous_coe.comp f.continuous).measurable.ae_strongly_measurable, _⟩,
+  simp only [has_finite_integral, nnreal.nnnorm_eq],
+  exact lintegral_lt_top_of_bounded_continuous_to_nnreal _ f,
 end
 
 lemma integrable_of_bounded_continuous_to_real (μ : finite_measure α) (f : α →ᵇ ℝ) :
@@ -484,7 +499,7 @@ by simp only [f.self_eq_nnreal_part_sub_nnreal_part_neg,
 
 lemma lintegral_lt_top_of_bounded_continuous_to_real (μ : finite_measure α) (f : α →ᵇ ℝ) :
   ∫⁻ x, ennreal.of_real (f x) ∂(μ : measure α) < ∞ :=
-μ.lintegral_lt_top_of_bounded_continuous_to_nnreal f.nnreal_part
+lintegral_lt_top_of_bounded_continuous_to_nnreal _ f.nnreal_part
 
 theorem tendsto_if_forall_integral_tendsto {γ : Type*} {F : filter γ}
   {μs : γ → finite_measure α} {μ : finite_measure α} :
@@ -496,8 +511,8 @@ begin
   apply (@finite_measure.tendsto_iff_forall_lintegral_tendsto α _ _ _ γ F μs μ).mpr,
   intro f,
   have key := @ennreal.tendsto_to_real_iff _ F
-              _ (λ i, ((μs i).lintegral_lt_top_of_bounded_continuous_to_nnreal f).ne)
-              _ (μ.lintegral_lt_top_of_bounded_continuous_to_nnreal f).ne,
+              _ (λ i, (lintegral_lt_top_of_bounded_continuous_to_nnreal (μs i : measure α) f).ne)
+              _ (lintegral_lt_top_of_bounded_continuous_to_nnreal (μ : measure α) f).ne,
   simp only [ennreal.of_real_coe_nnreal] at key,
   apply key.mp,
   have lip : lipschitz_with 1 (coe : ℝ≥0 → ℝ), from isometry_subtype_coe.lipschitz,
@@ -540,9 +555,9 @@ begin
   set f_pos := f.nnreal_part with def_f_pos,
   set f_neg := (-f).nnreal_part with def_f_neg,
   have tends_pos := (ennreal.tendsto_to_real
-          ((μ.lintegral_lt_top_of_bounded_continuous_to_nnreal f_pos).ne)).comp (h f_pos),
+    ((lintegral_lt_top_of_bounded_continuous_to_nnreal (μ : measure α) f_pos).ne)).comp (h f_pos),
   have tends_neg := (ennreal.tendsto_to_real
-          ((μ.lintegral_lt_top_of_bounded_continuous_to_nnreal f_neg).ne)).comp (h f_neg),
+    ((lintegral_lt_top_of_bounded_continuous_to_nnreal (μ : measure α) f_neg).ne)).comp (h f_neg),
   have aux : ∀ (g : α →ᵇ ℝ≥0), ennreal.to_real ∘ (λ (i : γ), ∫⁻ (x : α), ↑(g x) ∂(μs i : measure α))
          = λ (i : γ), (∫⁻ (x : α), ↑(g x) ∂(μs i : measure α)).to_real, from λ _, rfl,
   simp_rw [aux, bounded_continuous_function.nnreal.to_real_lintegral_eq_integral]
@@ -616,9 +631,10 @@ by { rw [← coe_fn_comp_to_finite_measure_eq_coe_fn,
 
 variables [topological_space α]
 
-lemma lintegral_lt_top_of_bounded_continuous_to_nnreal (μ : probability_measure α) (f : α →ᵇ ℝ≥0) :
+/- lemma lintegral_lt_top_of_bounded_continuous_to_nnreal (μ : probability_measure α) (f : α →ᵇ ℝ≥0) :
   ∫⁻ x, f x ∂(μ : measure α) < ∞ :=
-μ.to_finite_measure.lintegral_lt_top_of_bounded_continuous_to_nnreal f
+lintegral_lt_top_of_bounded_continuous_to_nnreal _ f
+ -/
 
 variables [opens_measurable_space α]
 
@@ -788,7 +804,7 @@ begin
   have room₂ : lintegral (μ : measure α) (λ a, thickened_indicator (δs_pos M) F a)
                 < lintegral (μ : measure α) (λ a, thickened_indicator (δs_pos M) F a) + ε / 2,
   { apply ennreal.lt_add_right
-          (finite_measure.lintegral_lt_top_of_bounded_continuous_to_nnreal μ _).ne
+          (lintegral_lt_top_of_bounded_continuous_to_nnreal (μ : measure α) _).ne
           ((ennreal.div_pos_iff.mpr
               ⟨(ennreal.coe_pos.mpr ε_pos).ne.symm, ennreal.two_ne_top⟩).ne.symm), },
   have ev_near := eventually.mono (eventually_lt_of_tendsto_lt room₂ key₂) (λ n, le_of_lt),

--- a/src/measure_theory/measure/finite_measure_weak_convergence.lean
+++ b/src/measure_theory/measure/finite_measure_weak_convergence.lean
@@ -509,7 +509,7 @@ begin
 end
 
 lemma bounded_continuous_function.nnreal.to_real_lintegral_eq_integral
-  {μ : measure α} [is_finite_measure μ] (f : α →ᵇ ℝ≥0) :
+  {μ : measure α} (f : α →ᵇ ℝ≥0) :
   (∫⁻ x, (f x : ℝ≥0∞) ∂μ).to_real = (∫ x, (f x) ∂μ) :=
 begin
   rw integral_eq_lintegral_of_nonneg_ae _

--- a/src/measure_theory/measure/finite_measure_weak_convergence.lean
+++ b/src/measure_theory/measure/finite_measure_weak_convergence.lean
@@ -334,7 +334,7 @@ inducing.tendsto_nhds_iff ⟨rfl⟩
 theorem tendsto_iff_forall_test_against_nn_tendsto {γ : Type*} {F : filter γ}
   {μs : γ → finite_measure α} {μ : finite_measure α} :
   tendsto μs F (𝓝 μ) ↔
-  ∀ (f : α →ᵇ ℝ≥0), tendsto (λ i, (μs(i)).to_weak_dual_bcnn f) F (𝓝 (μ.to_weak_dual_bcnn f)) :=
+  ∀ (f : α →ᵇ ℝ≥0), tendsto (λ i, (μs i).to_weak_dual_bcnn f) F (𝓝 (μ.to_weak_dual_bcnn f)) :=
 by { rw [tendsto_iff_weak_star_tendsto, tendsto_iff_forall_eval_tendsto_top_dual_pairing], refl, }
 
 /-- A characterization of weak convergence in terms of integrals of bounded continuous
@@ -484,7 +484,7 @@ lintegral_lt_top_of_bounded_continuous_to_nnreal _ f.nnreal_part
 theorem tendsto_of_forall_integral_tendsto
   {γ : Type*} {F : filter γ} {μs : γ → finite_measure α} {μ : finite_measure α}
   (h : (∀ (f : α →ᵇ ℝ),
-       tendsto (λ i, (∫ x, (f x) ∂(μs(i) : measure α))) F (𝓝 ((∫ x, (f x) ∂(μ : measure α)))))) :
+       tendsto (λ i, (∫ x, (f x) ∂(μs i : measure α))) F (𝓝 ((∫ x, (f x) ∂(μ : measure α)))))) :
   tendsto μs F (𝓝 μ) :=
 begin
   apply (@finite_measure.tendsto_iff_forall_lintegral_tendsto α _ _ _ γ F μs μ).mpr,
@@ -499,7 +499,7 @@ begin
   have f₀_eq : ⇑f₀ = (coe : ℝ≥0 → ℝ) ∘ ⇑f, by refl,
   have f₀_nn : 0 ≤ ⇑f₀, from λ _, by simp only [f₀_eq, pi.zero_apply, nnreal.zero_le_coe],
   have f₀_ae_nn : 0 ≤ᵐ[(μ : measure α)] ⇑f₀, from eventually_of_forall f₀_nn,
-  have f₀_ae_nns : ∀ i, 0 ≤ᵐ[(μs(i) : measure α)] ⇑f₀, from λ i, eventually_of_forall f₀_nn,
+  have f₀_ae_nns : ∀ i, 0 ≤ᵐ[(μs i : measure α)] ⇑f₀, from λ i, eventually_of_forall f₀_nn,
   have aux := integral_eq_lintegral_of_nonneg_ae f₀_ae_nn
               f₀.continuous.measurable.ae_strongly_measurable,
   have auxs := λ i, integral_eq_lintegral_of_nonneg_ae (f₀_ae_nns i)

--- a/src/measure_theory/measure/finite_measure_weak_convergence.lean
+++ b/src/measure_theory/measure/finite_measure_weak_convergence.lean
@@ -475,7 +475,8 @@ by simp only [f.self_eq_nnreal_part_sub_nnreal_part_neg,
               pi.sub_apply, integral_sub, integrable_of_bounded_continuous_to_nnreal]
 
 lemma lintegral_lt_top_of_bounded_continuous_to_real
-  {α : Type*} [measurable_space α] [topological_space α] (μ : measure α) [is_finite_measure μ] (f : α →ᵇ ℝ) :
+  {α : Type*} [measurable_space α] [topological_space α] (μ : measure α) [is_finite_measure μ]
+  (f : α →ᵇ ℝ) :
   ∫⁻ x, ennreal.of_real (f x) ∂μ < ∞ :=
 lintegral_lt_top_of_bounded_continuous_to_nnreal _ f.nnreal_part
 

--- a/src/measure_theory/measure/finite_measure_weak_convergence.lean
+++ b/src/measure_theory/measure/finite_measure_weak_convergence.lean
@@ -93,6 +93,8 @@ open_locale topological_space ennreal nnreal bounded_continuous_function
 
 namespace measure_theory
 
+namespace finite_measure
+
 section finite_measure
 /-! ### Finite measures
 
@@ -110,10 +112,8 @@ variables {α : Type*} [measurable_space α]
 
 /-- Finite measures are defined as the subtype of measures that have the property of being finite
 measures (i.e., their total mass is finite). -/
-def finite_measure (α : Type*) [measurable_space α] : Type* :=
+def _root_.measure_theory.finite_measure (α : Type*) [measurable_space α] : Type* :=
 {μ : measure α // is_finite_measure μ}
-
-namespace finite_measure
 
 /-- A finite measure can be interpreted as a measure. -/
 instance : has_coe (finite_measure α) (measure_theory.measure α) := coe_subtype
@@ -350,8 +350,6 @@ begin
            ennreal.tendsto_coe, ennreal.to_nnreal_coe],
 end
 
-end finite_measure -- namespace
-
 end finite_measure -- section
 
 section finite_measure_bounded_convergence
@@ -359,8 +357,6 @@ section finite_measure_bounded_convergence
 
 This section is about bounded convergence theorems for finite measures.
 -/
-
-namespace finite_measure
 
 variables {α : Type*} [measurable_space α] [topological_space α] [opens_measurable_space α]
 
@@ -419,7 +415,7 @@ lemma tendsto_test_against_nn_filter_of_le_const {ι : Type*} {L : filter ι}
 begin
   apply (ennreal.tendsto_to_nnreal
          (lintegral_lt_top_of_bounded_continuous_to_nnreal (μ : measure α) f).ne).comp,
-  exact finite_measure.tendsto_lintegral_nn_filter_of_le_const μ fs_le_const fs_lim,
+  exact tendsto_lintegral_nn_filter_of_le_const μ fs_le_const fs_lim,
 end
 
 /-- A bounded convergence theorem for a finite measure:
@@ -438,8 +434,6 @@ lemma tendsto_test_against_nn_of_le_const {μ : finite_measure α}
 tendsto_test_against_nn_filter_of_le_const
   (eventually_of_forall (λ n, eventually_of_forall (fs_le_const n))) (eventually_of_forall fs_lim)
 
-end finite_measure -- namespace
-
 end finite_measure_bounded_convergence -- section
 
 section finite_measure_convergence_by_bounded_continuous_functions
@@ -448,8 +442,6 @@ section finite_measure_convergence_by_bounded_continuous_functions
 In this section we characterize the weak convergence of finite measures by the most common
 (defining) condition of convergence of integrals of all bounded continuous real-valued functions.
 -/
-
-namespace finite_measure
 
 variables {α : Type*} [measurable_space α] [topological_space α] [opens_measurable_space α]
 
@@ -561,9 +553,9 @@ begin
   exact tendsto.sub tends_pos tends_neg,
 end
 
-end finite_measure -- namespace
-
 end finite_measure_convergence_by_bounded_continuous_functions -- section
+
+end finite_measure -- namespace
 
 section probability_measure
 /-! ### Probability measures

--- a/src/measure_theory/measure/finite_measure_weak_convergence.lean
+++ b/src/measure_theory/measure/finite_measure_weak_convergence.lean
@@ -98,14 +98,14 @@ namespace finite_measure
 section finite_measure
 /-! ### Finite measures
 
-In this section we define the `Type` of `finite_measure α`, when `α` measurable space. Finite
+In this section we define the `Type` of `finite_measure α`, when `α` is a measurable space. Finite
 measures on `α` are a module over `ℝ≥0`.
 
 If `α` is moreover a topological space and the sigma algebra on `α` is finer than the Borel sigma
 algebra (i.e. `[opens_measurable_space α]`), then `finite_measure α` is equipped with the topology
 of weak convergence of measures. This is implemented by defining a pairing of finite measures `μ`
 on `α` with continuous bounded nonnegative functions `f : α →ᵇ ℝ≥0` via integration, and using the
-associated weak topology.
+associated weak topology (essentially the weak-star topology on the dual of `α →ᵇ ℝ≥0`).
 -/
 
 variables {α : Type*} [measurable_space α]
@@ -439,8 +439,8 @@ end finite_measure_bounded_convergence -- section
 section finite_measure_convergence_by_bounded_continuous_functions
 /-! ### Weak convergence of finite measures with bounded continuous real-valued functions
 
-In this section we characterize the weak convergence of finite measures by the most common
-(defining) condition of convergence of integrals of all bounded continuous real-valued functions.
+In this section we characterize the weak convergence of finite measures by the usual (defining)
+condition that the integrals of all bounded continuous real-valued functions converge.
 -/
 
 variables {α : Type*} [measurable_space α] [topological_space α] [opens_measurable_space α]
@@ -454,7 +454,8 @@ begin
   exact lintegral_lt_top_of_bounded_continuous_to_nnreal _ f,
 end
 
-lemma integrable_of_bounded_continuous_to_real (μ : measure α) [is_finite_measure μ] (f : α →ᵇ ℝ) :
+lemma integrable_of_bounded_continuous_to_real
+  (μ : measure α) [is_finite_measure μ] (f : α →ᵇ ℝ) :
   integrable ⇑f μ :=
 begin
   refine ⟨f.continuous.measurable.ae_strongly_measurable, _⟩,
@@ -468,7 +469,7 @@ begin
   { exact eventually_of_forall (λ x, norm_nonneg (f x)), },
 end
 
-lemma bounded_continuous_function.integral_eq_integral_nnreal_part_sub
+lemma _root_.bounded_continuous_function.integral_eq_integral_nnreal_part_sub
   (μ : measure α) [is_finite_measure μ] (f : α →ᵇ ℝ) :
   ∫ x, f x ∂μ = ∫ x, f.nnreal_part x ∂μ - ∫ x, (-f).nnreal_part x ∂μ :=
 by simp only [f.self_eq_nnreal_part_sub_nnreal_part_neg,
@@ -480,10 +481,10 @@ lemma lintegral_lt_top_of_bounded_continuous_to_real
   ∫⁻ x, ennreal.of_real (f x) ∂μ < ∞ :=
 lintegral_lt_top_of_bounded_continuous_to_nnreal _ f.nnreal_part
 
-theorem tendsto_of_forall_integral_tendsto {γ : Type*} {F : filter γ}
-  {μs : γ → finite_measure α} {μ : finite_measure α}
-  (h : (∀ (f : α →ᵇ ℝ), tendsto (λ i, (∫ x, (f x) ∂(μs(i) : measure α)))
-        F (𝓝 ((∫ x, (f x) ∂(μ : measure α)))))) :
+theorem tendsto_of_forall_integral_tendsto
+  {γ : Type*} {F : filter γ} {μs : γ → finite_measure α} {μ : finite_measure α}
+  (h : (∀ (f : α →ᵇ ℝ),
+       tendsto (λ i, (∫ x, (f x) ∂(μs(i) : measure α))) F (𝓝 ((∫ x, (f x) ∂(μ : measure α)))))) :
   tendsto μs F (𝓝 μ) :=
 begin
   apply (@finite_measure.tendsto_iff_forall_lintegral_tendsto α _ _ _ γ F μs μ).mpr,
@@ -520,8 +521,8 @@ end
 
 /-- A characterization of weak convergence in terms of integrals of bounded continuous
 real-valued functions. -/
-theorem tendsto_iff_forall_integral_tendsto {γ : Type*} {F : filter γ}
-  {μs : γ → finite_measure α} {μ : finite_measure α} :
+theorem tendsto_iff_forall_integral_tendsto
+  {γ : Type*} {F : filter γ} {μs : γ → finite_measure α} {μ : finite_measure α} :
   tendsto μs F (𝓝 μ) ↔
   ∀ (f : α →ᵇ ℝ),
     tendsto (λ i, (∫ x, (f x) ∂(μs i : measure α))) F (𝓝 ((∫ x, (f x) ∂(μ : measure α)))) :=
@@ -656,10 +657,9 @@ lemma tendsto_nhds_iff_to_finite_measures_tendsto_nhds {δ : Type*}
   tendsto μs F (𝓝 μ₀) ↔ tendsto (to_finite_measure ∘ μs) F (𝓝 (μ₀.to_finite_measure)) :=
 embedding.tendsto_nhds_iff (probability_measure.to_finite_measure_embedding α)
 
-/-- The usual definition of weak convergence of probability measures is given in terms of sequences
-of probability measures: it is the requirement that the integrals of all continuous bounded
-functions against members of the sequence converge. This version is a characterization using
-nonnegative bounded continuous functions. -/
+/-- A characterization of weak convergence of probability measures by the condition that the
+integrals of every continuous bounded nonnegative function converge to the integral of the function
+against the limit measure. -/
 theorem tendsto_iff_forall_lintegral_tendsto {γ : Type*} {F : filter γ}
   {μs : γ → probability_measure α} {μ : probability_measure α} :
   tendsto μs F (𝓝 μ) ↔
@@ -668,6 +668,20 @@ theorem tendsto_iff_forall_lintegral_tendsto {γ : Type*} {F : filter γ}
 begin
   rw tendsto_nhds_iff_to_finite_measures_tendsto_nhds,
   exact finite_measure.tendsto_iff_forall_lintegral_tendsto,
+end
+
+/-- The characterization of weak convergence of probability measures by the usual (defining)
+condition that the integrals of every continuous bounded function converge to the integral of the
+function against the limit measure. -/
+theorem tendsto_iff_forall_integral_tendsto
+  {γ : Type*} {F : filter γ} {μs : γ → probability_measure α} {μ : probability_measure α} :
+  tendsto μs F (𝓝 μ) ↔
+  ∀ (f : α →ᵇ ℝ),
+    tendsto (λ i, (∫ x, (f x) ∂(μs i : measure α))) F (𝓝 ((∫ x, (f x) ∂(μ : measure α)))) :=
+begin
+  rw tendsto_nhds_iff_to_finite_measures_tendsto_nhds,
+  rw finite_measure.tendsto_iff_forall_integral_tendsto,
+  simp only [coe_comp_to_finite_measure_eq_coe],
 end
 
 end probability_measure -- namespace

--- a/src/measure_theory/measure/finite_measure_weak_convergence.lean
+++ b/src/measure_theory/measure/finite_measure_weak_convergence.lean
@@ -454,16 +454,8 @@ begin
   exact lintegral_lt_top_of_bounded_continuous_to_nnreal _ f,
 end
 
-lemma integrable_of_bounded_continuous_to_nnreal' (μ : finite_measure α) (f : α →ᵇ ℝ≥0) :
-  integrable ((coe : ℝ≥0 → ℝ) ∘ ⇑f) (μ : measure α) :=
-begin
-  refine ⟨(nnreal.continuous_coe.comp f.continuous).measurable.ae_strongly_measurable, _⟩,
-  simp only [has_finite_integral, nnreal.nnnorm_eq],
-  exact lintegral_lt_top_of_bounded_continuous_to_nnreal _ f,
-end
-
-lemma integrable_of_bounded_continuous_to_real (μ : finite_measure α) (f : α →ᵇ ℝ) :
-  integrable ⇑f (μ : measure α) :=
+lemma integrable_of_bounded_continuous_to_real (μ : measure α) [is_finite_measure μ] (f : α →ᵇ ℝ) :
+  integrable ⇑f μ :=
 begin
   refine ⟨f.continuous.measurable.ae_strongly_measurable, _⟩,
   have aux : (coe : ℝ≥0 → ℝ) ∘ ⇑f.nnnorm = (λ x, ∥f x∥),
@@ -477,15 +469,13 @@ begin
 end
 
 lemma bounded_continuous_function.integral_eq_integral_nnreal_part_sub
-  (μ : finite_measure α) (f : α →ᵇ ℝ) :
-  ∫ x, f x ∂(μ : measure α) =
-      ∫ x, f.nnreal_part x ∂(μ : measure α)
-    - ∫ x, (-f).nnreal_part x ∂(μ : measure α) :=
+  (μ : measure α) [is_finite_measure μ] (f : α →ᵇ ℝ) :
+  ∫ x, f x ∂μ = ∫ x, f.nnreal_part x ∂μ - ∫ x, (-f).nnreal_part x ∂μ :=
 by simp only [f.self_eq_nnreal_part_sub_nnreal_part_neg,
               pi.sub_apply, integral_sub, integrable_of_bounded_continuous_to_nnreal]
 
 lemma lintegral_lt_top_of_bounded_continuous_to_real
-  {α : Type*} [measurable_space α] [topological_space α] (μ : finite_measure α) (f : α →ᵇ ℝ) :
+  {α : Type*} [measurable_space α] [topological_space α] (μ : measure α) [is_finite_measure μ] (f : α →ᵇ ℝ) :
   ∫⁻ x, ennreal.of_real (f x) ∂(μ : measure α) < ∞ :=
 lintegral_lt_top_of_bounded_continuous_to_nnreal _ f.nnreal_part
 
@@ -518,8 +508,8 @@ begin
 end
 
 lemma bounded_continuous_function.nnreal.to_real_lintegral_eq_integral
-  {μ : finite_measure α} (f : α →ᵇ ℝ≥0) :
-  (∫⁻ x, (f x : ℝ≥0∞) ∂(μ : measure α)).to_real = (∫ x, (f x) ∂(μ : measure α)) :=
+  {μ : measure α} [is_finite_measure μ] (f : α →ᵇ ℝ≥0) :
+  (∫⁻ x, (f x : ℝ≥0∞) ∂μ).to_real = (∫ x, (f x) ∂μ) :=
 begin
   rw integral_eq_lintegral_of_nonneg_ae _
      (nnreal.continuous_coe.comp f.continuous).measurable.ae_strongly_measurable,

--- a/src/measure_theory/measure/finite_measure_weak_convergence.lean
+++ b/src/measure_theory/measure/finite_measure_weak_convergence.lean
@@ -18,8 +18,6 @@ for every bounded continuous `ℝ≥0`-valued function `f`, the integration of `
 measure is continuous.
 
 TODOs:
-* Prove that an equivalent definition of the topologies is obtained requiring continuity of
-  integration of bounded continuous `ℝ`-valued functions instead.
 * Include the portmanteau theorem on characterizations of weak convergence of (Borel) probability
   measures.
 
@@ -92,19 +90,6 @@ open set
 open filter
 open bounded_continuous_function
 open_locale topological_space ennreal nnreal bounded_continuous_function
-
--- TODO: Move to algebra.order.ring
-lemma max_zero_add_max_neg_zero_eq_abs_self {R : Type*} [linear_ordered_ring R] (x : R) :
-  max x 0 + max (-x) 0 = |x| :=
-begin
-  by_cases sign_x : 0 ≤ x,
-  { simp only [sign_x, max_eq_left, max_eq_right,
-               right.neg_nonpos_iff, add_zero, abs_eq_self.mpr sign_x], },
-  { rw not_le at sign_x,
-    have aux : x ≤ 0, from sign_x.le,
-    simp only [aux, max_eq_right, max_eq_left,
-               right.nonneg_neg_iff, zero_add, abs_eq_neg_self.mpr aux], },
-end
 
 namespace measure_theory
 

--- a/src/measure_theory/measure/finite_measure_weak_convergence.lean
+++ b/src/measure_theory/measure/finite_measure_weak_convergence.lean
@@ -481,12 +481,11 @@ lemma lintegral_lt_top_of_bounded_continuous_to_real
 lintegral_lt_top_of_bounded_continuous_to_nnreal _ f.nnreal_part
 
 theorem tendsto_of_forall_integral_tendsto {γ : Type*} {F : filter γ}
-  {μs : γ → finite_measure α} {μ : finite_measure α} :
-  ((∀ (f : α →ᵇ ℝ),
-    tendsto (λ i, (∫ x, (f x) ∂(μs(i) : measure α))) F (𝓝 ((∫ x, (f x) ∂(μ : measure α))))))
-  → tendsto μs F (𝓝 μ) :=
+  {μs : γ → finite_measure α} {μ : finite_measure α}
+  (h : (∀ (f : α →ᵇ ℝ), tendsto (λ i, (∫ x, (f x) ∂(μs(i) : measure α)))
+        F (𝓝 ((∫ x, (f x) ∂(μ : measure α)))))) :
+  tendsto μs F (𝓝 μ) :=
 begin
-  intro h,
   apply (@finite_measure.tendsto_iff_forall_lintegral_tendsto α _ _ _ γ F μs μ).mpr,
   intro f,
   have key := @ennreal.tendsto_to_real_iff _ F
@@ -527,7 +526,7 @@ theorem tendsto_iff_forall_integral_tendsto {γ : Type*} {F : filter γ}
   ∀ (f : α →ᵇ ℝ),
     tendsto (λ i, (∫ x, (f x) ∂(μs i : measure α))) F (𝓝 ((∫ x, (f x) ∂(μ : measure α)))) :=
 begin
-  refine ⟨_, tendsto_if_forall_integral_tendsto⟩,
+  refine ⟨_, tendsto_of_forall_integral_tendsto⟩,
   rw finite_measure.tendsto_iff_forall_lintegral_tendsto,
   intros h f,
   simp_rw bounded_continuous_function.integral_eq_integral_nnreal_part_sub,

--- a/src/measure_theory/measure/finite_measure_weak_convergence.lean
+++ b/src/measure_theory/measure/finite_measure_weak_convergence.lean
@@ -492,7 +492,8 @@ lemma bounded_continuous_function.integral_eq_integral_nnreal_part_sub
 by simp only [f.self_eq_nnreal_part_sub_nnreal_part_neg,
               pi.sub_apply, integral_sub, integrable_of_bounded_continuous_to_nnreal]
 
-lemma lintegral_lt_top_of_bounded_continuous_to_real (μ : finite_measure α) (f : α →ᵇ ℝ) :
+lemma lintegral_lt_top_of_bounded_continuous_to_real
+  {α : Type*} [measurable_space α] [topological_space α] (μ : finite_measure α) (f : α →ᵇ ℝ) :
   ∫⁻ x, ennreal.of_real (f x) ∂(μ : measure α) < ∞ :=
 lintegral_lt_top_of_bounded_continuous_to_nnreal _ f.nnreal_part
 

--- a/src/measure_theory/measure/finite_measure_weak_convergence.lean
+++ b/src/measure_theory/measure/finite_measure_weak_convergence.lean
@@ -373,7 +373,7 @@ lemma tendsto_lintegral_nn_filter_of_le_const {ι : Type*} {L : filter ι} [L.is
   (μ : measure α) [is_finite_measure μ] {fs : ι → (α →ᵇ ℝ≥0)} {c : ℝ≥0}
   (fs_le_const : ∀ᶠ i in L, ∀ᵐ (a : α) ∂(μ : measure α), fs i a ≤ c) {f : α → ℝ≥0}
   (fs_lim : ∀ᵐ (a : α) ∂(μ : measure α), tendsto (λ i, fs i a) L (𝓝 (f a))) :
-  tendsto (λ i, (∫⁻ a, fs i a ∂(μ : measure α))) L (𝓝 (∫⁻ a, (f a) ∂(μ : measure α))) :=
+  tendsto (λ i, (∫⁻ a, fs i a ∂μ)) L (𝓝 (∫⁻ a, (f a) ∂μ)) :=
 begin
   simpa only using tendsto_lintegral_filter_of_dominated_convergence (λ _, c)
     (eventually_of_forall ((λ i, (ennreal.continuous_coe.comp (fs i).continuous).measurable)))
@@ -476,7 +476,7 @@ by simp only [f.self_eq_nnreal_part_sub_nnreal_part_neg,
 
 lemma lintegral_lt_top_of_bounded_continuous_to_real
   {α : Type*} [measurable_space α] [topological_space α] (μ : measure α) [is_finite_measure μ] (f : α →ᵇ ℝ) :
-  ∫⁻ x, ennreal.of_real (f x) ∂(μ : measure α) < ∞ :=
+  ∫⁻ x, ennreal.of_real (f x) ∂μ < ∞ :=
 lintegral_lt_top_of_bounded_continuous_to_nnreal _ f.nnreal_part
 
 theorem tendsto_if_forall_integral_tendsto {γ : Type*} {F : filter γ}
@@ -695,8 +695,8 @@ This formulation assumes:
 lemma measure_of_cont_bdd_of_tendsto_filter_indicator {ι : Type*} {L : filter ι}
   [L.is_countably_generated] [topological_space α] [opens_measurable_space α]
   (μ : measure α) [is_finite_measure μ] {c : ℝ≥0} {E : set α} (E_mble : measurable_set E)
-  (fs : ι → (α →ᵇ ℝ≥0)) (fs_bdd : ∀ᶠ i in L, ∀ᵐ (a : α) ∂(μ : measure α), fs i a ≤ c)
-  (fs_lim : ∀ᵐ (a : α) ∂(μ : measure α),
+  (fs : ι → (α →ᵇ ℝ≥0)) (fs_bdd : ∀ᶠ i in L, ∀ᵐ (a : α) ∂μ, fs i a ≤ c)
+  (fs_lim : ∀ᵐ (a : α) ∂μ,
             tendsto (λ (i : ι), (coe_fn : (α →ᵇ ℝ≥0) → (α → ℝ≥0)) (fs i) a) L
                     (𝓝 (indicator E (λ x, (1 : ℝ≥0)) a))) :
   tendsto (λ n, lintegral μ (λ a, fs n a)) L (𝓝 (μ E)) :=

--- a/src/measure_theory/measure/finite_measure_weak_convergence.lean
+++ b/src/measure_theory/measure/finite_measure_weak_convergence.lean
@@ -507,7 +507,7 @@ begin
   simpa only [←aux, ←auxs] using h f₀,
 end
 
-lemma bounded_continuous_function.nnreal.to_real_lintegral_eq_integral
+lemma _root_.bounded_continuous_function.nnreal.to_real_lintegral_eq_integral
   (f : α →ᵇ ℝ≥0) (μ : measure α) :
   (∫⁻ x, (f x : ℝ≥0∞) ∂μ).to_real = (∫ x, f x ∂μ) :=
 begin

--- a/src/topology/continuous_function/bounded.lean
+++ b/src/topology/continuous_function/bounded.lean
@@ -1346,8 +1346,6 @@ bounded_continuous_function.comp _
 
 @[simp] lemma nnnorm_coe_fun_eq (f : α →ᵇ ℝ) : ⇑(f.nnnorm) = has_nnnorm.nnnorm ∘ ⇑f := rfl
 
-@[simp] lemma nnnorm_apply_coe (f : α →ᵇ ℝ) (a : α) : (f.nnnorm a : ℝ) = |f a| := rfl
-
 /-- Decompose a bounded continuous function to its positive and negative parts. -/
 lemma self_eq_nnreal_part_sub_nnreal_part_neg (f : α →ᵇ ℝ) :
   ⇑f = coe ∘ f.nnreal_part - coe ∘ (-f).nnreal_part :=

--- a/src/topology/continuous_function/bounded.lean
+++ b/src/topology/continuous_function/bounded.lean
@@ -1326,4 +1326,39 @@ instance : normed_lattice_add_comm_group (α →ᵇ β) :=
 
 end normed_lattice_ordered_group
 
+section nonnegative_part
+
+variables [topological_space α]
+
+/-- The nonnegative part of a bounded continuous `ℝ`-valued function as a bounded
+continuous `ℝ≥0`-valued function. -/
+def nnreal_part (f : α →ᵇ ℝ) : α →ᵇ ℝ≥0 :=
+bounded_continuous_function.comp _
+  (show lipschitz_with 1 real.to_nnreal, from lipschitz_with_pos) f
+
+@[simp] lemma nnreal_part_coe_fun_eq (f : α →ᵇ ℝ) : ⇑(f.nnreal_part) = real.to_nnreal ∘ ⇑f := rfl
+
+/-- The absolute value of a bounded continuous `ℝ`-valued function as a bounded
+continuous `ℝ≥0`-valued function. -/
+def nnnorm (f : α →ᵇ ℝ) : α →ᵇ ℝ≥0 :=
+bounded_continuous_function.comp _
+  (show lipschitz_with 1 (λ (x : ℝ), ∥x∥₊), from lipschitz_with_one_norm) f
+
+@[simp] lemma nnnorm_coe_fun_eq (f : α →ᵇ ℝ) : ⇑(f.nnnorm) = has_nnnorm.nnnorm ∘ ⇑f := rfl
+
+@[simp] lemma nnnorm_apply_coe (f : α →ᵇ ℝ) (a : α) : (f.nnnorm a : ℝ) = |f a| := rfl
+
+/-- Decompose a bounded continuous function to its positive and negative parts. -/
+lemma self_eq_nnreal_part_sub_nnreal_part_neg (f : α →ᵇ ℝ) :
+  ⇑f = coe ∘ f.nnreal_part - coe ∘ (-f).nnreal_part :=
+by { funext x, dsimp, simp only [max_zero_sub_max_neg_zero_eq_self], }
+
+/-- Express the absolute value of a bounded continuous function in terms of its
+positive and negative parts. -/
+lemma abs_self_eq_nnreal_part_add_nnreal_part_neg (f : α →ᵇ ℝ) :
+  abs ∘ ⇑f = coe ∘ f.nnreal_part + coe ∘ (-f).nnreal_part :=
+by { funext x, dsimp, simp only [max_zero_add_max_neg_zero_eq_abs_self], }
+
+end nonnegative_part
+
 end bounded_continuous_function


### PR DESCRIPTION
Weak convergence of measures was defined in terms of integrals of bounded continuous nnreal-valued functions. This PR shows the equivalence to the textbook condition in terms of integrals of bounded continuous real-valued functions.

Also the file `measure_theory/measure/finite_measure_weak_convergence.lean` is divided to sections with dosctrings for clarity.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
