### PR TITLE
[Merged by Bors] - feat(order/topology/**/uniform*): Lemmas about uniform convergence

### DIFF
--- a/src/order/filter/bases.lean
+++ b/src/order/filter/bases.lean
@@ -721,41 +721,6 @@ lemma has_basis.coprod {ι ι' : Type*} {pa : ι → Prop} {sa : ι → set α} 
 
 end two_types
 
-open equiv
-
-lemma prod_assoc (f : filter α) (g : filter β) (h : filter γ) :
-  map (prod_assoc α β γ) ((f ×ᶠ g) ×ᶠ h) = f ×ᶠ (g ×ᶠ h) :=
-begin
-  apply ((((basis_sets f).prod $ basis_sets g).prod $ basis_sets h).map _).eq_of_same_basis,
-  simpa only [prod_assoc_image, function.comp, and_assoc] using
-    ((basis_sets f).prod $ (basis_sets g).prod $ basis_sets h).comp_equiv (prod_assoc _ _ _)
-end
-
-theorem prod_assoc_symm (f : filter α) (g : filter β) (h : filter γ) :
-map (equiv.prod_assoc α β γ).symm (f.prod (g.prod h)) = (f.prod g).prod h :=
-begin
-  apply (((basis_sets f).prod ((basis_sets g).prod $ basis_sets h)).map _).eq_of_same_basis,
-  simpa only [equiv.prod_assoc_symm_image, function.comp, and_assoc] using
-    (((basis_sets f).prod $ basis_sets g).prod $ basis_sets h).comp_equiv
-      (equiv.prod_assoc _ _ _).symm,
-end
-
-lemma tendsto_prod_assoc {f : filter α} {g : filter β} {h : filter γ} :
-  tendsto (equiv.prod_assoc α β γ) (f ×ᶠ g ×ᶠ h) (f ×ᶠ (g ×ᶠ h)) :=
-begin
-  unfold tendsto,
-  rw prod_assoc,
-  exact rfl.le,
-end
-
-lemma tendsto_prod_assoc_symm {f : filter α} {g : filter β} {h : filter γ} :
-  tendsto (equiv.prod_assoc α β γ).symm (f ×ᶠ (g ×ᶠ h)) (f ×ᶠ g ×ᶠ h) :=
-begin
-  unfold tendsto,
-  rw prod_assoc_symm,
-  exact rfl.le,
-end
-
 end filter
 
 end sort

--- a/src/order/filter/bases.lean
+++ b/src/order/filter/bases.lean
@@ -731,6 +731,31 @@ begin
     ((basis_sets f).prod $ (basis_sets g).prod $ basis_sets h).comp_equiv (prod_assoc _ _ _)
 end
 
+theorem prod_assoc_symm (f : filter α) (g : filter β) (h : filter γ) :
+map (equiv.prod_assoc α β γ).symm (f.prod (g.prod h)) = (f.prod g).prod h :=
+begin
+  apply (((basis_sets f).prod ((basis_sets g).prod $ basis_sets h)).map _).eq_of_same_basis,
+  simpa only [equiv.prod_assoc_symm_image, function.comp, and_assoc] using
+    (((basis_sets f).prod $ basis_sets g).prod $ basis_sets h).comp_equiv
+      (equiv.prod_assoc _ _ _).symm,
+end
+
+lemma tendsto_prod_assoc {f : filter α} {g : filter β} {h : filter γ} :
+  tendsto (equiv.prod_assoc α β γ) (f ×ᶠ g ×ᶠ h) (f ×ᶠ (g ×ᶠ h)) :=
+begin
+  unfold tendsto,
+  rw prod_assoc,
+  exact rfl.le,
+end
+
+lemma tendsto_prod_assoc_symm {f : filter α} {g : filter β} {h : filter γ} :
+  tendsto (equiv.prod_assoc α β γ).symm (f ×ᶠ (g ×ᶠ h)) (f ×ᶠ g ×ᶠ h) :=
+begin
+  unfold tendsto,
+  rw prod_assoc_symm,
+  exact rfl.le,
+end
+
 end filter
 
 end sort

--- a/src/order/filter/basic.lean
+++ b/src/order/filter/basic.lean
@@ -2592,25 +2592,11 @@ end
 
 /-- A fact that is eventually true about all pairs `l ×ᶠ l` is eventually true about
 all diagonal pairs `(i, i)` -/
-lemma eventually_diag_of_eventually_prod {f : filter α} {p : α × α → Prop}
+lemma eventually.diag_of_prod {f : filter α} {p : α × α → Prop}
   (h : ∀ᶠ i in (f.prod f), p i) : (∀ᶠ i in f, p (i, i)) :=
 begin
-  rw eventually_iff,
-  rw [eventually_iff, mem_prod_iff] at h,
-  obtain ⟨t, ht, s, hs, hst⟩ := h,
-  have ht_in_f : t ∩ s ∈ f, simp [hs, ht],
-  refine f.sets_of_superset ht_in_f _,
-  rw set.subset_def,
-  intros x hx,
-  have := calc (x, x) ∈ (t ∩ s) ×ˢ (t ∩ s) : by simpa using hx
-    ... ⊆ t ×ˢ s : begin
-      rw set.subset_def,
-      intros y hy,
-      simp at hy,
-      simp [hy],
-    end
-    ... ⊆ {x : α × α | p x} : hst,
-  simpa using this,
+  obtain ⟨t, ht, s, hs, hst⟩ := eventually_prod_iff.1 h,
+  apply (ht.and hs).mono (λ x hx, hst hx.1 hx.2),
 end
 
 lemma prod_infi_left [nonempty ι] {f : ι → filter α} {g : filter β}:

--- a/src/order/filter/basic.lean
+++ b/src/order/filter/basic.lean
@@ -2590,6 +2590,29 @@ begin
   exact ha.mono (λ a ha, hb.mono $ λ b hb, h ha hb)
 end
 
+/-- A fact that is eventually true about all pairs `l ×ᶠ l` is eventually true about
+all diagonal pairs `(i, i)` -/
+lemma eventually_diag_of_eventually_prod {f : filter α} {p : α × α → Prop}
+  (h : ∀ᶠ i in (f.prod f), p i) : (∀ᶠ i in f, p (i, i)) :=
+begin
+  rw eventually_iff,
+  rw [eventually_iff, mem_prod_iff] at h,
+  obtain ⟨t, ht, s, hs, hst⟩ := h,
+  have ht_in_f : t ∩ s ∈ f, simp [hs, ht],
+  refine f.sets_of_superset ht_in_f _,
+  rw set.subset_def,
+  intros x hx,
+  have := calc (x, x) ∈ (t ∩ s) ×ˢ (t ∩ s) : by simpa using hx
+    ... ⊆ t ×ˢ s : begin
+      rw set.subset_def,
+      intros y hy,
+      simp at hy,
+      simp [hy],
+    end
+    ... ⊆ {x : α × α | p x} : hst,
+  simpa using this,
+end
+
 lemma prod_infi_left [nonempty ι] {f : ι → filter α} {g : filter β}:
   (⨅ i, f i) ×ᶠ g = (⨅ i, (f i) ×ᶠ g) :=
 by { rw [filter.prod, comap_infi, infi_inf], simp only [filter.prod, eq_self_iff_true] }

--- a/src/order/filter/basic.lean
+++ b/src/order/filter/basic.lean
@@ -2559,6 +2559,10 @@ lemma tendsto.prod_mk {f : filter α} {g : filter β} {h : filter γ} {m₁ : α
   (h₁ : tendsto m₁ f g) (h₂ : tendsto m₂ f h) : tendsto (λ x, (m₁ x, m₂ x)) f (g ×ᶠ h) :=
 tendsto_inf.2 ⟨tendsto_comap_iff.2 h₁, tendsto_comap_iff.2 h₂⟩
 
+lemma tendsto_prod_swap {α1 α2 : Type*} {a1 : filter α1} {a2 : filter α2} :
+  tendsto (prod.swap : α1 × α2 → α2 × α1) (a1 ×ᶠ a2) (a2 ×ᶠ a1) :=
+tendsto_snd.prod_mk tendsto_fst
+
 lemma eventually.prod_inl {la : filter α} {p : α → Prop} (h : ∀ᶠ x in la, p x) (lb : filter β) :
   ∀ᶠ x in la ×ᶠ lb, p (x : α × β).1 :=
 tendsto_fst.eventually h
@@ -2598,6 +2602,9 @@ begin
   obtain ⟨t, ht, s, hs, hst⟩ := eventually_prod_iff.1 h,
   apply (ht.and hs).mono (λ x hx, hst hx.1 hx.2),
 end
+
+lemma tendsto_diag : tendsto (λ i, (i, i)) f (f ×ᶠ f) :=
+tendsto_iff_eventually.mpr (λ _ hpr, hpr.diag_of_prod)
 
 lemma prod_infi_left [nonempty ι] {f : ι → filter α} {g : filter β}:
   (⨅ i, f i) ×ᶠ g = (⨅ i, (f i) ×ᶠ g) :=

--- a/src/order/filter/basic.lean
+++ b/src/order/filter/basic.lean
@@ -2593,7 +2593,7 @@ end
 /-- A fact that is eventually true about all pairs `l ×ᶠ l` is eventually true about
 all diagonal pairs `(i, i)` -/
 lemma eventually.diag_of_prod {f : filter α} {p : α × α → Prop}
-  (h : ∀ᶠ i in (f.prod f), p i) : (∀ᶠ i in f, p (i, i)) :=
+  (h : ∀ᶠ i in f ×ᶠ f, p i) : (∀ᶠ i in f, p (i, i)) :=
 begin
   obtain ⟨t, ht, s, hs, hst⟩ := eventually_prod_iff.1 h,
   apply (ht.and hs).mono (λ x hx, hst hx.1 hx.2),

--- a/src/order/filter/basic.lean
+++ b/src/order/filter/basic.lean
@@ -233,7 +233,7 @@ add_tactic_doc
 end tactic.interactive
 
 namespace filter
-variables {α : Type u} {β : Type v} {γ : Type w} {ι : Sort x}
+variables {α : Type u} {β : Type v} {γ : Type w} {δ : Type*} {ι : Sort x}
 
 section principal
 
@@ -1647,7 +1647,6 @@ lemma comap_comap {m : γ → β} {n : β → α} : comap m (comap n f) = comap 
 filter.coext $ λ s, by simp only [compl_mem_comap, image_image]
 
 section comm
-variables  {δ : Type*}
 
 /-!
 The variables in the following lemmas are used as in this diagram:
@@ -2000,6 +1999,12 @@ lemma comap_equiv_symm (e : α ≃ β) (f : filter α) :
 
 lemma map_swap_eq_comap_swap {f : filter (α × β)} : prod.swap <$> f = comap prod.swap f :=
 map_eq_comap_of_inverse prod.swap_swap_eq prod.swap_swap_eq
+
+/-- A useful lemma when dealing with uniformities. -/
+lemma map_swap4_eq_comap {f : filter ((α × β) × (γ × δ))} :
+  map (λ p : (α × β) × (γ × δ), ((p.1.1, p.2.1), (p.1.2, p.2.2))) f =
+  comap (λ p : (α × γ) × (β × δ), ((p.1.1, p.2.1), (p.1.2, p.2.2))) f :=
+map_eq_comap_of_inverse (funext $ λ ⟨⟨_, _⟩, ⟨_, _⟩⟩, rfl) (funext $ λ ⟨⟨_, _⟩, ⟨_, _⟩⟩, rfl)
 
 lemma le_map {f : filter α} {m : α → β} {g : filter β} (h : ∀ s ∈ f, m '' s ∈ g) :
   g ≤ f.map m :=
@@ -2629,6 +2634,35 @@ by simp only [filter.prod, comap_comap, (∘), inf_comm, prod.fst_swap,
 
 lemma prod_comm : f ×ᶠ g = map (λ p : β×α, (p.2, p.1)) (g ×ᶠ f) :=
 by { rw [prod_comm', ← map_swap_eq_comap_swap], refl }
+
+lemma prod_assoc (f : filter α) (g : filter β) (h : filter γ) :
+  map (equiv.prod_assoc α β γ) ((f ×ᶠ g) ×ᶠ h) = f ×ᶠ (g ×ᶠ h) :=
+by simp_rw [← comap_equiv_symm, filter.prod, comap_inf, comap_comap, inf_assoc, function.comp,
+  equiv.prod_assoc_symm_apply]
+
+theorem prod_assoc_symm (f : filter α) (g : filter β) (h : filter γ) :
+map (equiv.prod_assoc α β γ).symm (f ×ᶠ (g ×ᶠ h)) = (f ×ᶠ g) ×ᶠ h :=
+by simp_rw [map_equiv_symm, filter.prod, comap_inf, comap_comap, inf_assoc, function.comp,
+  equiv.prod_assoc_apply]
+
+lemma tendsto_prod_assoc {f : filter α} {g : filter β} {h : filter γ} :
+  tendsto (equiv.prod_assoc α β γ) (f ×ᶠ g ×ᶠ h) (f ×ᶠ (g ×ᶠ h)) :=
+(prod_assoc f g h).le
+
+lemma tendsto_prod_assoc_symm {f : filter α} {g : filter β} {h : filter γ} :
+  tendsto (equiv.prod_assoc α β γ).symm (f ×ᶠ (g ×ᶠ h)) (f ×ᶠ g ×ᶠ h) :=
+(prod_assoc_symm f g h).le
+
+/-- A useful lemma when dealing with uniformities. -/
+lemma map_swap4_prod {f : filter α} {g : filter β} {h : filter γ} {k : filter δ} :
+  map (λ p : (α × β) × (γ × δ), ((p.1.1, p.2.1), (p.1.2, p.2.2))) ((f ×ᶠ g) ×ᶠ (h ×ᶠ k)) =
+  (f ×ᶠ h) ×ᶠ (g ×ᶠ k) :=
+by simp_rw [map_swap4_eq_comap, filter.prod, comap_inf, comap_comap, inf_assoc, inf_left_comm]
+
+lemma tendsto_swap4_prod {f : filter α} {g : filter β} {h : filter γ} {k : filter δ} :
+  tendsto (λ p : (α × β) × (γ × δ), ((p.1.1, p.2.1), (p.1.2, p.2.2)))
+    ((f ×ᶠ g) ×ᶠ (h ×ᶠ k)) ((f ×ᶠ h) ×ᶠ (g ×ᶠ k)) :=
+map_swap4_prod.le
 
 lemma prod_map_map_eq {α₁ : Type u} {α₂ : Type v} {β₁ : Type w} {β₂ : Type x}
   {f₁ : filter α₁} {f₂ : filter α₂} {m₁ : α₁ → β₁} {m₂ : α₂ → β₂} :

--- a/src/topology/algebra/uniform_group.lean
+++ b/src/topology/algebra/uniform_group.lean
@@ -266,27 +266,26 @@ uniform_continuous_inv.comp_cauchy_seq h
 (𝓝 (1 : α)).basis_sets.uniformity_of_nhds_one_inv_mul_swapped.totally_bounded_iff.trans $
   by simp [← preimage_smul_inv, preimage]
 
-@[to_additive] lemma tendsto_uniformly_on.mul {ι β : Type*} {l : filter ι} {f f' : ι → β → α}
-  {g g' : β → α} {s : set β} (hf : tendsto_uniformly_on f g l s)
+section uniform_convergence
+variables {ι : Type*} {l : filter ι} {f f' : ι → β → α} {g g' : β → α} {s : set β}
+
+@[to_additive] lemma tendsto_uniformly_on.mul (hf : tendsto_uniformly_on f g l s)
   (hf' : tendsto_uniformly_on f' g' l s) : tendsto_uniformly_on (f * f') (g * g') l s :=
 λ u hu, (((hf.prod hf').comp' uniform_continuous_mul) u hu).diag_of_prod
 
-@[to_additive] lemma tendsto_uniformly_on.div {ι β : Type*} {l : filter ι} {f f' : ι → β → α}
-  {g g' : β → α} {s : set β} (hf : tendsto_uniformly_on f g l s)
+@[to_additive] lemma tendsto_uniformly_on.div (hf : tendsto_uniformly_on f g l s)
   (hf' : tendsto_uniformly_on f' g' l s) : tendsto_uniformly_on (f / f') (g / g') l s :=
 λ u hu, (((hf.prod hf').comp' uniform_continuous_div) u hu).diag_of_prod
 
-@[to_additive] lemma uniform_cauchy_seq_on.mul {ι β : Type*} {l : filter ι} {f f' : ι → β → α}
-  {s : set β} (hf : uniform_cauchy_seq_on f l s)
+@[to_additive] lemma uniform_cauchy_seq_on.mul (hf : uniform_cauchy_seq_on f l s)
   (hf' : uniform_cauchy_seq_on f' l s) : uniform_cauchy_seq_on (f * f') l s :=
 λ u hu, by simpa using (((hf.prod' hf').comp' uniform_continuous_mul) u hu)
 
-@[to_additive] lemma uniform_cauchy_seq_on.div {ι β : Type*} {l : filter ι} {f f' : ι → β → α}
-  {s : set β} (hf : uniform_cauchy_seq_on f l s)
+@[to_additive] lemma uniform_cauchy_seq_on.div (hf : uniform_cauchy_seq_on f l s)
   (hf' : uniform_cauchy_seq_on f' l s) : uniform_cauchy_seq_on (f / f') l s :=
 λ u hu, by simpa using (((hf.prod' hf').comp' uniform_continuous_div) u hu)
 
-
+end uniform_convergence
 end uniform_group
 
 section topological_comm_group

--- a/src/topology/algebra/uniform_group.lean
+++ b/src/topology/algebra/uniform_group.lean
@@ -269,12 +269,12 @@ uniform_continuous_inv.comp_cauchy_seq h
 @[to_additive] lemma tendsto_uniformly_on.mul {ι β : Type*} {l : filter ι} {f f' : ι → β → α}
   {g g' : β → α} {s : set β} (hf : tendsto_uniformly_on f g l s)
   (hf' : tendsto_uniformly_on f' g' l s) : tendsto_uniformly_on (f * f') (g * g') l s :=
-λ u hu, eventually_diag_of_eventually_prod (((hf.prod hf').comp' uniform_continuous_mul) u hu)
+λ u hu, (((hf.prod hf').comp' uniform_continuous_mul) u hu).diag_of_prod
 
 @[to_additive] lemma tendsto_uniformly_on.div {ι β : Type*} {l : filter ι} {f f' : ι → β → α}
   {g g' : β → α} {s : set β} (hf : tendsto_uniformly_on f g l s)
   (hf' : tendsto_uniformly_on f' g' l s) : tendsto_uniformly_on (f / f') (g / g') l s :=
-λ u hu, eventually_diag_of_eventually_prod (((hf.prod hf').comp' uniform_continuous_div) u hu)
+λ u hu, (((hf.prod hf').comp' uniform_continuous_div) u hu).diag_of_prod
 
 @[to_additive] lemma uniform_cauchy_seq_on.mul {ι β : Type*} {l : filter ι} {f f' : ι → β → α}
   {s : set β} (hf : uniform_cauchy_seq_on f l s)

--- a/src/topology/algebra/uniform_group.lean
+++ b/src/topology/algebra/uniform_group.lean
@@ -266,6 +266,27 @@ uniform_continuous_inv.comp_cauchy_seq h
 (𝓝 (1 : α)).basis_sets.uniformity_of_nhds_one_inv_mul_swapped.totally_bounded_iff.trans $
   by simp [← preimage_smul_inv, preimage]
 
+@[to_additive] lemma tendsto_uniformly_on.mul {ι β : Type*} {l : filter ι} {f f' : ι → β → α}
+  {g g' : β → α} {s : set β} (hf : tendsto_uniformly_on f g l s)
+  (hf' : tendsto_uniformly_on f' g' l s) : tendsto_uniformly_on (f * f') (g * g') l s :=
+λ u hu, filter.eventually_diag_of_eventually_prod (((hf.prod hf').comp' uniform_continuous_mul) u hu)
+
+@[to_additive] lemma tendsto_uniformly_on.div {ι β : Type*} {l : filter ι} {f f' : ι → β → α}
+  {g g' : β → α} {s : set β} (hf : tendsto_uniformly_on f g l s)
+  (hf' : tendsto_uniformly_on f' g' l s) : tendsto_uniformly_on (f / f') (g / g') l s :=
+λ u hu, filter.eventually_diag_of_eventually_prod (((hf.prod hf').comp' uniform_continuous_div) u hu)
+
+@[to_additive] lemma uniform_cauchy_seq_on.mul {ι β : Type*} {l : filter ι} {f f' : ι → β → α}
+  {s : set β} (hf : uniform_cauchy_seq_on f l s)
+  (hf' : uniform_cauchy_seq_on f' l s) : uniform_cauchy_seq_on (f * f') l s :=
+λ u hu, by simpa using (((hf.prod' hf').comp' uniform_continuous_mul) u hu)
+
+@[to_additive] lemma uniform_cauchy_seq_on.div {ι β : Type*} {l : filter ι} {f f' : ι → β → α}
+  {s : set β} (hf : uniform_cauchy_seq_on f l s)
+  (hf' : uniform_cauchy_seq_on f' l s) : uniform_cauchy_seq_on (f / f') l s :=
+λ u hu, by simpa using (((hf.prod' hf').comp' uniform_continuous_div) u hu)
+
+
 end uniform_group
 
 section topological_comm_group

--- a/src/topology/algebra/uniform_group.lean
+++ b/src/topology/algebra/uniform_group.lean
@@ -269,12 +269,12 @@ uniform_continuous_inv.comp_cauchy_seq h
 @[to_additive] lemma tendsto_uniformly_on.mul {ι β : Type*} {l : filter ι} {f f' : ι → β → α}
   {g g' : β → α} {s : set β} (hf : tendsto_uniformly_on f g l s)
   (hf' : tendsto_uniformly_on f' g' l s) : tendsto_uniformly_on (f * f') (g * g') l s :=
-λ u hu, filter.eventually_diag_of_eventually_prod (((hf.prod hf').comp' uniform_continuous_mul) u hu)
+λ u hu, eventually_diag_of_eventually_prod (((hf.prod hf').comp' uniform_continuous_mul) u hu)
 
 @[to_additive] lemma tendsto_uniformly_on.div {ι β : Type*} {l : filter ι} {f f' : ι → β → α}
   {g g' : β → α} {s : set β} (hf : tendsto_uniformly_on f g l s)
   (hf' : tendsto_uniformly_on f' g' l s) : tendsto_uniformly_on (f / f') (g / g') l s :=
-λ u hu, filter.eventually_diag_of_eventually_prod (((hf.prod hf').comp' uniform_continuous_div) u hu)
+λ u hu, eventually_diag_of_eventually_prod (((hf.prod hf').comp' uniform_continuous_div) u hu)
 
 @[to_additive] lemma uniform_cauchy_seq_on.mul {ι β : Type*} {l : filter ι} {f f' : ι → β → α}
   {s : set β} (hf : uniform_cauchy_seq_on f l s)

--- a/src/topology/algebra/uniform_group.lean
+++ b/src/topology/algebra/uniform_group.lean
@@ -271,19 +271,19 @@ variables {ι : Type*} {l : filter ι} {f f' : ι → β → α} {g g' : β → 
 
 @[to_additive] lemma tendsto_uniformly_on.mul (hf : tendsto_uniformly_on f g l s)
   (hf' : tendsto_uniformly_on f' g' l s) : tendsto_uniformly_on (f * f') (g * g') l s :=
-λ u hu, (((hf.prod hf').comp' uniform_continuous_mul) u hu).diag_of_prod
+λ u hu, ((uniform_continuous_mul.comp_tendsto_uniformly_on (hf.prod hf')) u hu).diag_of_prod
 
 @[to_additive] lemma tendsto_uniformly_on.div (hf : tendsto_uniformly_on f g l s)
   (hf' : tendsto_uniformly_on f' g' l s) : tendsto_uniformly_on (f / f') (g / g') l s :=
-λ u hu, (((hf.prod hf').comp' uniform_continuous_div) u hu).diag_of_prod
+λ u hu, ((uniform_continuous_div.comp_tendsto_uniformly_on (hf.prod hf')) u hu).diag_of_prod
 
 @[to_additive] lemma uniform_cauchy_seq_on.mul (hf : uniform_cauchy_seq_on f l s)
   (hf' : uniform_cauchy_seq_on f' l s) : uniform_cauchy_seq_on (f * f') l s :=
-λ u hu, by simpa using (((hf.prod' hf').comp' uniform_continuous_mul) u hu)
+λ u hu, by simpa using ((uniform_continuous_mul.comp_uniform_cauchy_seq_on (hf.prod' hf')) u hu)
 
 @[to_additive] lemma uniform_cauchy_seq_on.div (hf : uniform_cauchy_seq_on f l s)
   (hf' : uniform_cauchy_seq_on f' l s) : uniform_cauchy_seq_on (f / f') l s :=
-λ u hu, by simpa using (((hf.prod' hf').comp' uniform_continuous_div) u hu)
+λ u hu, by simpa using ((uniform_continuous_div.comp_uniform_cauchy_seq_on (hf.prod' hf')) u hu)
 
 end uniform_convergence
 end uniform_group

--- a/src/topology/continuous_function/algebra.lean
+++ b/src/topology/continuous_function/algebra.lean
@@ -279,17 +279,17 @@ coe_injective.comm_group _ coe_one coe_mul coe_inv coe_div coe_pow coe_zpow
     rw continuous_iff_continuous_at,
     rintros ⟨f, g⟩,
     rw [continuous_at, tendsto_iff_forall_compact_tendsto_uniformly_on, nhds_prod_eq],
-    exactI λ K hK, ((tendsto_iff_forall_compact_tendsto_uniformly_on.mp filter.tendsto_id K hK).prod
-      (tendsto_iff_forall_compact_tendsto_uniformly_on.mp filter.tendsto_id K hK)).comp'
-      uniform_continuous_mul },
+    exactI λ K hK, uniform_continuous_mul.comp_tendsto_uniformly_on
+      ((tendsto_iff_forall_compact_tendsto_uniformly_on.mp filter.tendsto_id K hK).prod
+      (tendsto_iff_forall_compact_tendsto_uniformly_on.mp filter.tendsto_id K hK)), },
   continuous_inv := by
   { letI : uniform_space β := topological_group.to_uniform_space β,
     have : uniform_group β := topological_group_is_uniform,
     rw continuous_iff_continuous_at,
     intro f,
     rw [continuous_at, tendsto_iff_forall_compact_tendsto_uniformly_on],
-    exactI λ K hK, (tendsto_iff_forall_compact_tendsto_uniformly_on.mp filter.tendsto_id K hK).comp'
-      uniform_continuous_inv } }
+    exactI λ K hK, uniform_continuous_inv.comp_tendsto_uniformly_on
+      (tendsto_iff_forall_compact_tendsto_uniformly_on.mp filter.tendsto_id K hK), } }
 
 end continuous_map
 

--- a/src/topology/uniform_space/basic.lean
+++ b/src/topology/uniform_space/basic.lean
@@ -1290,13 +1290,8 @@ theorem uniformity_prod [uniform_space α] [uniform_space β] : 𝓤 (α × β) 
 inf_uniformity
 
 lemma uniformity_prod_eq_prod [uniform_space α] [uniform_space β] :
-  𝓤 (α×β) =
-    map (λp:(α×α)×(β×β), ((p.1.1, p.2.1), (p.1.2, p.2.2))) (𝓤 α ×ᶠ 𝓤 β) :=
-have map (λp:(α×α)×(β×β), ((p.1.1, p.2.1), (p.1.2, p.2.2))) =
-  comap (λp:(α×β)×(α×β), ((p.1.1, p.2.1), (p.1.2, p.2.2))),
-  from funext $ assume f, map_eq_comap_of_inverse
-    (funext $ assume ⟨⟨_, _⟩, ⟨_, _⟩⟩, rfl) (funext $ assume ⟨⟨_, _⟩, ⟨_, _⟩⟩, rfl),
-by rw [this, uniformity_prod, filter.prod, comap_inf, comap_comap, comap_comap]
+  𝓤 (α × β) = map (λ p : (α × α) × (β × β), ((p.1.1, p.2.1), (p.1.2, p.2.2))) (𝓤 α ×ᶠ 𝓤 β) :=
+by rw [map_swap4_eq_comap, uniformity_prod, filter.prod, comap_inf, comap_comap, comap_comap]
 
 lemma mem_map_iff_exists_image' {α : Type*} {β : Type*} {f : filter α} {m : α → β} {t : set β} :
   t ∈ (map m f).sets ↔ (∃s∈f, m '' s ⊆ t) :=

--- a/src/topology/uniform_space/uniform_convergence.lean
+++ b/src/topology/uniform_space/uniform_convergence.lean
@@ -327,7 +327,7 @@ begin
   intros u hu,
   rw [uniformity_prod_eq_prod, mem_map, mem_prod_iff] at hu,
   obtain ⟨v, hv, w, hw, hvw⟩ := hu,
-  simp,
+  simp only [mem_prod, prod_map, and_imp, prod.forall],
   let pr := (λ (m : (ι × ι') × ι × ι'), ∀ (a : α) (b : α'),
     a ∈ s → b ∈ s' → ((F m.fst.fst a, F' m.fst.snd b), F m.snd.fst a, F' m.snd.snd b) ∈ u),
   have foo : ∀ m : (ι × ι') × ι × ι', (∀ (a : α) (b : α'),

--- a/src/topology/uniform_space/uniform_convergence.lean
+++ b/src/topology/uniform_space/uniform_convergence.lean
@@ -327,13 +327,27 @@ begin
   intros u hu,
   rw [uniformity_prod_eq_prod, mem_map, mem_prod_iff] at hu,
   obtain ⟨v, hv, w, hw, hvw⟩ := hu,
-  rw eventually_iff,
-  rw mem_prod_iff,
-  specialize h v hv,
-  specialize h' w hw,
-  have := (h.prod_mk h'),
-  exact mem_prod_iff.mpr ⟨_, h v hv, _, h' w hw,
-    λ i hi a ha, hvw (show (_, _) ∈ v ×ˢ w, from ⟨hi.1 a.1 ha.1, hi.2 a.2 ha.2⟩)⟩,
+  simp,
+  let pr := (λ (m : (ι × ι') × ι × ι'), ∀ (a : α) (b : α'),
+    a ∈ s → b ∈ s' → ((F m.fst.fst a, F' m.fst.snd b), F m.snd.fst a, F' m.snd.snd b) ∈ u),
+  have foo : ∀ m : (ι × ι') × ι × ι', (∀ (a : α) (b : α'),
+    a ∈ s → b ∈ s' → ((F m.fst.fst a, F' m.fst.snd b), F m.snd.fst a, F' m.snd.snd b) ∈ u) ↔ (pr m),
+  {
+    intros m,
+    simp [pr],
+  },
+  simp_rw foo,
+
+  have : tendsto (λ m : (ι × ι') × ι × ι', ((m.fst.fst, m.snd.fst), m.fst.snd, m.snd.snd)) (p ×ᶠ p' ×ᶠ (p ×ᶠ p')) (p ×ᶠ p ×ᶠ (p' ×ᶠ p')), {
+    sorry,
+  },
+  apply (this.eventually ((h v hv).prod_mk (h' w hw))).mono,
+  intros x hx a b ha hb,
+  rw ←set.image_subset_iff at hvw,
+  refine set.mem_of_mem_of_subset _ hvw,
+  simp only [mem_image, mem_prod, prod.mk.inj_iff, prod.exists],
+  refine ⟨_, _, _, _, ⟨hx.1 a ha, hx.2 b hb⟩, _⟩,
+  simp only [eq_self_iff_true, and_self],
 end
 
 lemma uniform_cauchy_seq_on.prod {ι' β' : Type*} [uniform_space β'] {F' : ι' → α → β'}

--- a/src/topology/uniform_space/uniform_convergence.lean
+++ b/src/topology/uniform_space/uniform_convergence.lean
@@ -177,16 +177,20 @@ lemma tendsto_uniformly.prod {ι' β' : Type*} [uniform_space β'] {F' : ι' →
   tendsto_uniformly (λ (i : ι × ι') a, (F i.1 a, F' i.2 a)) (λ a, (f a, f' a)) (p.prod p') :=
 (h.prod_map h').comp (λ a, (a, a))
 
+/-- Uniform convergence on a set `s` to a constant function is equivalent to convergence in
+`p ×ᶠ 𝓟 s`. -/
+lemma tendsto_prod_principal_iff {c : β} :
+  tendsto ↿F (p ×ᶠ 𝓟 s) (𝓝 c) ↔ tendsto_uniformly_on F (λ _, c) p s :=
+begin
+  unfold tendsto,
+  simp_rw [nhds_eq_comap_uniformity, map_le_iff_le_comap.symm, map_map, le_def, mem_map,
+    mem_prod_principal],
+  simpa,
+end
+
 /-- Uniform convergence to a constant function is equivalent to convergence in `p ×ᶠ ⊤`. -/
 lemma tendsto_prod_top_iff {c : β} : tendsto ↿F (p ×ᶠ ⊤) (𝓝 c) ↔ tendsto_uniformly F (λ _, c) p :=
-let j : β → β × β := prod.mk c in
-calc tendsto ↿F (p ×ᶠ ⊤) (𝓝 c)
-    ↔ map ↿F (p ×ᶠ ⊤) ≤ (𝓝 c) : iff.rfl
-... ↔ map ↿F (p ×ᶠ ⊤) ≤ comap j (𝓤 β) : by rw nhds_eq_comap_uniformity
-... ↔ map j (map ↿F (p ×ᶠ ⊤)) ≤ 𝓤 β : map_le_iff_le_comap.symm
-... ↔ map (j ∘ ↿F) (p ×ᶠ ⊤) ≤ 𝓤 β : by rw map_map
-... ↔ ∀ V ∈ 𝓤 β, {x | (c, ↿F x) ∈ V} ∈ p ×ᶠ (⊤ : filter α) : iff.rfl
-... ↔ ∀ V ∈ 𝓤 β, {i | ∀ a, (c, F i a) ∈ V} ∈ p : by simpa [mem_prod_top]
+by rw [←principal_univ, ←tendsto_uniformly_on_univ, ←tendsto_prod_principal_iff]
 
 /-- Uniform convergence on the empty set is vacuously true -/
 lemma tendsto_uniformly_on_empty :
@@ -199,6 +203,8 @@ lemma tendsto_uniformly_on_singleton_iff_tendsto :
 by simp_rw [uniform.tendsto_nhds_right, tendsto_uniformly_on, mem_singleton_iff, forall_eq,
   tendsto_def, preimage, filter.eventually]
 
+/-- If a sequence `g` converges to some `b`, then the sequence of constant functions
+`λ n, λ a, g n` converges to the constant function `λ a, b` on any set `s` -/
 lemma filter.tendsto.tendsto_uniformly_on_const
   {g : ι → β} {b : β} (hg : tendsto g p (𝓝 b)) (s : set α) :
   tendsto_uniformly_on (λ n : ι, λ a : α, g n) (λ a : α, b) p s :=

--- a/src/topology/uniform_space/uniform_convergence.lean
+++ b/src/topology/uniform_space/uniform_convergence.lean
@@ -318,22 +318,49 @@ lemma uniform_continuous.comp_uniform_cauchy_seq_on [uniform_space γ] {g : β �
   uniform_cauchy_seq_on (λ n, g ∘ (F n)) p s :=
 λ u hu, hf _ (hg hu)
 
+lemma uniform_cauchy_seq_on.prod_map {ι' α' β' : Type*} [uniform_space β']
+  {F' : ι' → α' → β'} {p' : filter ι'} {s' : set α'}
+  (h : uniform_cauchy_seq_on F p s) (h' : uniform_cauchy_seq_on F' p' s') :
+  uniform_cauchy_seq_on (λ (i : ι × ι'), prod.map (F i.1) (F' i.2))
+    (p.prod p') (s ×ˢ s') :=
+begin
+  intros u hu,
+  rw [uniformity_prod_eq_prod, mem_map, mem_prod_iff] at hu,
+  obtain ⟨v, hv, w, hw, hvw⟩ := hu,
+  rw eventually_iff,
+  rw mem_prod_iff,
+  specialize h v hv,
+  specialize h' w hw,
+  have := (h.prod_mk h'),
+  exact mem_prod_iff.mpr ⟨_, h v hv, _, h' w hw,
+    λ i hi a ha, hvw (show (_, _) ∈ v ×ˢ w, from ⟨hi.1 a.1 ha.1, hi.2 a.2 ha.2⟩)⟩,
+end
+
+lemma uniform_cauchy_seq_on.prod {ι' β' : Type*} [uniform_space β'] {F' : ι' → α → β'}
+  {p' : filter ι'}
+  (h : uniform_cauchy_seq_on F p s) (h' : uniform_cauchy_seq_on F' p' s) :
+  uniform_cauchy_seq_on (λ (i : ι × ι') a, (F i.fst a, F' i.snd a)) (p ×ᶠ p') s :=
+(congr_arg _ s.inter_self).mp ((h.prod_map h').comp (λ a, (a, a)))
+
 lemma uniform_cauchy_seq_on.prod' {β' : Type*} [uniform_space β'] {F' : ι → α → β'}
   (h : uniform_cauchy_seq_on F p s) (h' : uniform_cauchy_seq_on F' p s) :
   uniform_cauchy_seq_on (λ (i : ι) a, (F i a, F' i a)) p s :=
 begin
   intros u hu,
-  rw [uniformity_prod_eq_prod, filter.mem_map, mem_prod_iff] at hu,
-  obtain ⟨t, ht, t', ht', htt'⟩ := hu,
-  apply ((h t ht).prod_mk (h' t' ht')).diag_of_prod.mono,
-  intros x hx y hy,
-  cases hx with hxt hxt',
-  specialize hxt y hy,
-  specialize hxt' y hy,
-  simp only at hxt hxt' ⊢,
-  have := calc ((F x.fst y, F x.snd y), (F' x.fst y, F' x.snd y)) ∈ t ×ˢ t' : by simp [hxt, hxt']
-    ... ⊆ (λ (p : (β × β) × β' × β'), ((p.fst.fst, p.snd.fst), p.fst.snd, p.snd.snd)) ⁻¹' u : htt',
-  simpa using this,
+  have hh : tendsto (λ x : ι, (x, x)) p (p ×ᶠ p),
+  { rw tendsto_iff_eventually,
+    intros pr hpr,
+    exact hpr.diag_of_prod, },
+  let pr := (λ (m : (ι × ι) × ι × ι),
+      (∀ (x : α), x ∈ s →
+        ((F m.fst.fst x, F' m.fst.snd x),
+        (F m.snd.fst x, F' m.snd.snd x)) ∈ u)),
+  have foo : ∀ m : ι × ι, ((∀ x : α, x ∈ s → ((F m.fst x, F' m.fst x), F m.snd x, F' m.snd x) ∈ u)
+    ↔ (pr ((m.fst, m.fst), m.snd, m.snd))),
+  { intros m,
+    simp [pr], },
+  simp_rw foo,
+  exact (hh.prod_map hh).eventually ((h.prod h') u hu),
 end
 
 section seq_tendsto

--- a/src/topology/uniform_space/uniform_convergence.lean
+++ b/src/topology/uniform_space/uniform_convergence.lean
@@ -137,13 +137,15 @@ lemma tendsto_uniformly.comp (h : tendsto_uniformly F f p) (g : γ → α) :
 
 /-- Composing on the left by a uniformly continuous function preserves
   uniform convergence on a set -/
-lemma tendsto_uniformly_on.comp' [uniform_space γ] {g : β → γ} (h : tendsto_uniformly_on F f p s)
-  (hg : uniform_continuous g) : tendsto_uniformly_on (λ i, g ∘ (F i)) (g ∘ f) p s :=
+lemma uniform_continuous.comp_tendsto_uniformly_on [uniform_space γ] {g : β → γ}
+  (hg : uniform_continuous g) (h : tendsto_uniformly_on F f p s) :
+  tendsto_uniformly_on (λ i, g ∘ (F i)) (g ∘ f) p s :=
 λ u hu, h _ (hg hu)
 
 /-- Composing on the left by a uniformly continuous function preserves uniform convergence -/
-lemma tendsto_uniformly.comp' [uniform_space γ] {g : β → γ} (h : tendsto_uniformly F f p)
-  (hg : uniform_continuous g) : tendsto_uniformly (λ i, g ∘ (F i)) (g ∘ f) p :=
+lemma uniform_continuous.comp_tendsto_uniformly [uniform_space γ] {g : β → γ}
+  (hg : uniform_continuous g) (h : tendsto_uniformly F f p) :
+  tendsto_uniformly (λ i, g ∘ (F i)) (g ∘ f) p :=
 λ u hu, h _ (hg hu)
 
 lemma tendsto_uniformly_on.prod_map {ι' α' β' : Type*} [uniform_space β']
@@ -311,8 +313,8 @@ lemma uniform_cauchy_seq_on.comp {γ : Type*} (hf : uniform_cauchy_seq_on F p s)
 
 /-- Composing on the left by a uniformly continuous function preserves
 uniform Cauchy sequences -/
-lemma uniform_cauchy_seq_on.comp' [uniform_space γ] {g : β → γ} (hf : uniform_cauchy_seq_on F p s)
-  (hg : uniform_continuous g) :
+lemma uniform_continuous.comp_uniform_cauchy_seq_on [uniform_space γ] {g : β → γ}
+  (hg : uniform_continuous g) (hf : uniform_cauchy_seq_on F p s) :
   uniform_cauchy_seq_on (λ n, g ∘ (F n)) p s :=
 λ u hu, hf _ (hg hu)
 

--- a/src/topology/uniform_space/uniform_convergence.lean
+++ b/src/topology/uniform_space/uniform_convergence.lean
@@ -332,15 +332,34 @@ begin
     a ∈ s → b ∈ s' → ((F m.fst.fst a, F' m.fst.snd b), F m.snd.fst a, F' m.snd.snd b) ∈ u),
   have foo : ∀ m : (ι × ι') × ι × ι', (∀ (a : α) (b : α'),
     a ∈ s → b ∈ s' → ((F m.fst.fst a, F' m.fst.snd b), F m.snd.fst a, F' m.snd.snd b) ∈ u) ↔ (pr m),
-  {
-    intros m,
-    simp [pr],
-  },
+  { intros m,
+    simp only [pr], },
   simp_rw foo,
 
-  have : tendsto (λ m : (ι × ι') × ι × ι', ((m.fst.fst, m.snd.fst), m.fst.snd, m.snd.snd)) (p ×ᶠ p' ×ᶠ (p ×ᶠ p')) (p ×ᶠ p ×ᶠ (p' ×ᶠ p')), {
-    sorry,
-  },
+  have : tendsto (λ m : (ι × ι') × ι × ι', ((m.fst.fst, m.snd.fst), m.fst.snd, m.snd.snd))
+    (p ×ᶠ p' ×ᶠ (p ×ᶠ p')) (p ×ᶠ p ×ᶠ (p' ×ᶠ p')),
+  { unfold tendsto,
+    rw le_def,
+    intros s hs,
+    simp [hs],
+    simp_rw mem_prod_iff,
+    simp_rw mem_prod_iff at hs,
+    rcases hs with ⟨t₁, ⟨t₁', ht₁', t₁'', ht₁'', ht₁⟩, t₂, ⟨t₂', ht₂', t₂'', ht₂'', ht₂⟩, hts⟩,
+    use [t₁' ×ˢ t₂', t₁', ht₁', t₂', ht₂'],
+    refine ⟨t₁'' ×ˢ t₂'', ⟨t₁'', ht₁'', t₂'', ht₂'', rfl.subset⟩, _⟩,
+    rw set.subset_def,
+    intros x hx,
+    simp,
+    calc ((x.fst.fst, x.snd.fst), x.fst.snd, x.snd.snd) ∈ (t₁' ×ˢ t₁'') ×ˢ t₂' ×ˢ t₂'' : begin
+      simp at hx,
+      simp [hx],
+    end
+    ... ⊆ t₁ ×ˢ t₂ : begin
+      rw prod_subset_prod_iff,
+      left,
+      exact ⟨ht₁, ht₂⟩,
+      end
+    ... ⊆ s : hts, },
   apply (this.eventually ((h v hv).prod_mk (h' w hw))).mono,
   intros x hx a b ha hb,
   rw ←set.image_subset_iff at hvw,

--- a/src/topology/uniform_space/uniform_convergence.lean
+++ b/src/topology/uniform_space/uniform_convergence.lean
@@ -112,7 +112,7 @@ lemma tendsto_uniformly_on.mono {s' : set α}
   (h : tendsto_uniformly_on F f p s) (h' : s' ⊆ s) : tendsto_uniformly_on F f p s' :=
 λ u hu, (h u hu).mono (λ n hn x hx, hn x (h' hx))
 
-lemma tendsto_uniformly_on.congr_fun {F' : ι → α → β}
+lemma tendsto_uniformly_on.congr {F' : ι → α → β}
   (hf : tendsto_uniformly_on F f p s) (hff' : ∀ᶠ n in p, set.eq_on (F n) (F' n) s) :
   tendsto_uniformly_on F' f p s :=
 begin
@@ -189,7 +189,7 @@ calc tendsto ↿F (p ×ᶠ ⊤) (𝓝 c)
 ... ↔ ∀ V ∈ 𝓤 β, {i | ∀ a, (c, F i a) ∈ V} ∈ p : by simpa [mem_prod_top]
 
 /-- Uniform convergence on the empty set is vacuously true -/
-lemma tendsto_uniformly_on_of_empty :
+lemma tendsto_uniformly_on_empty :
   tendsto_uniformly_on F f p ∅ :=
 λ u hu, by simp
 
@@ -204,7 +204,7 @@ lemma filter.tendsto.tendsto_uniformly_on_const
   tendsto_uniformly_on (λ n : ι, λ a : α, g n) (λ a : α, b) p s :=
 begin
   by_cases hs : s = ∅,
-  { rw hs, exact tendsto_uniformly_on_of_empty, },
+  { rw hs, exact tendsto_uniformly_on_empty, },
   have hs : s.nonempty,
   { by_contradiction H,
     rw set.not_nonempty_iff_eq_empty at H,
@@ -321,7 +321,7 @@ begin
   intros u hu,
   rw [uniformity_prod_eq_prod, filter.mem_map, mem_prod_iff] at hu,
   obtain ⟨t, ht, t', ht', htt'⟩ := hu,
-  apply (filter.eventually_diag_of_eventually_prod ((h t ht).prod_mk (h' t' ht'))).mono,
+  apply ((h t ht).prod_mk (h' t' ht')).diag_of_prod.mono,
   intros x hx y hy,
   cases hx with hxt hxt',
   specialize hxt y hy,

--- a/src/topology/uniform_space/uniform_convergence.lean
+++ b/src/topology/uniform_space/uniform_convergence.lean
@@ -210,25 +210,8 @@ by simp_rw [uniform.tendsto_nhds_right, tendsto_uniformly_on, mem_singleton_iff,
 lemma filter.tendsto.tendsto_uniformly_on_const
   {g : ι → β} {b : β} (hg : tendsto g p (𝓝 b)) (s : set α) :
   tendsto_uniformly_on (λ n : ι, λ a : α, g n) (λ a : α, b) p s :=
-begin
-  rcases set.eq_empty_or_nonempty s with rfl | hs,
-  { exact tendsto_uniformly_on_empty, },
-
-  intros u hu,
-  rw tendsto_iff_eventually at hg,
-  simp,
-  let p := (λ c, ∀ y : α, y ∈ s → (b, c) ∈ u),
-  have hhp : ∀ c, ( ∀ y : α, y ∈ s → (b, c) ∈ u) = p c,
-  { intros c, simp [p], },
-  have hhp' : ∀ c, ((b, c) ∈ u) = p c,
-  { cases hs with x hx,
-    intros c, simp [p],
-    exact ⟨λ h y hy, h, λ h, h x hx⟩, },
-  conv { congr, funext, rw [hhp (g n), ←hhp' (g n)], },
-  apply @hg (λ c, (b, c) ∈ u),
-  rw eventually_iff,
-  exact mem_nhds_left b hu,
-end
+λ u hu, hg.eventually
+  (eventually_of_mem (mem_nhds_left b hu) (λ x hx y hy, hx) : ∀ᶠ x in 𝓝 b, ∀ y ∈ s, (b, x) ∈ u)
 
 lemma uniform_continuous_on.tendsto_uniformly [uniform_space α] [uniform_space γ]
   {x : α} {U : set α} (hU : U ∈ 𝓝 x)
@@ -327,25 +310,11 @@ begin
   intros u hu,
   rw [uniformity_prod_eq_prod, mem_map, mem_prod_iff] at hu,
   obtain ⟨v, hv, w, hw, hvw⟩ := hu,
-  simp only [mem_prod, prod_map, and_imp, prod.forall],
-
-  -- unfold some abstract nonsense
-  let fff := (equiv.prod_assoc _ _ _)
-    ∘ (prod.map (equiv.prod_assoc _ _ _).symm id)
-    ∘ (prod.map (prod.map id prod.swap ∘ (equiv.prod_assoc _ _ _)) id)
-    ∘ (equiv.prod_assoc (ι × ι') ι ι').symm,
-  have : tendsto fff (p ×ᶠ p' ×ᶠ (p ×ᶠ p')) (p ×ᶠ p ×ᶠ (p' ×ᶠ p')),
-  { apply tendsto_prod_assoc.comp,
-    apply (tendsto_prod_assoc_symm.prod_map tendsto_id).comp,
-    refine (((tendsto_id.prod_map tendsto_prod_swap).comp tendsto_prod_assoc).prod_map
-      tendsto_id).comp tendsto_prod_assoc_symm, },
-  apply (this.eventually ((h v hv).prod_mk (h' w hw))).mono,
+  simp_rw [mem_prod, prod_map, and_imp, prod.forall],
+  rw [← set.image_subset_iff] at hvw,
+  apply (tendsto_swap4_prod.eventually ((h v hv).prod_mk (h' w hw))).mono,
   intros x hx a b ha hb,
-  rw ←set.image_subset_iff at hvw,
-  refine set.mem_of_mem_of_subset _ hvw,
-  simp only [mem_image, mem_prod, prod.mk.inj_iff, prod.exists],
-  refine ⟨_, _, _, _, ⟨hx.1 a ha, hx.2 b hb⟩, _⟩,
-  simp [fff],
+  refine hvw ⟨_, mk_mem_prod (hx.1 a ha) (hx.2 b hb), rfl⟩,
 end
 
 lemma uniform_cauchy_seq_on.prod {ι' β' : Type*} [uniform_space β'] {F' : ι' → α → β'}

--- a/src/topology/uniform_space/uniform_convergence.lean
+++ b/src/topology/uniform_space/uniform_convergence.lean
@@ -196,16 +196,8 @@ lemma tendsto_uniformly_on_of_empty :
 /-- Uniform convergence on a singleton is equivalent to regular convergence -/
 lemma tendsto_uniformly_on_singleton_iff_tendsto :
   tendsto_uniformly_on F f p {x} ↔ tendsto (λ n : ι, F n x) p (𝓝 (f x)) :=
-begin
-  rw uniform.tendsto_nhds_right,
-  unfold tendsto,
-  rw filter.le_def,
-  simp_rw filter.mem_map',
-
-  split,
-  exact (λ h u hu, by simpa using eventually_iff.mp (h u hu)),
-  exact (λ h u hu, by simpa using eventually_iff.mp (h u hu)),
-end
+by simp_rw [uniform.tendsto_nhds_right, tendsto_uniformly_on, mem_singleton_iff, forall_eq,
+  tendsto_def, preimage, filter.eventually]
 
 lemma filter.tendsto.tendsto_uniformly_on_const
   {g : ι → β} {b : β} (hg : tendsto g p (𝓝 b)) (s : set α) :
@@ -310,13 +302,13 @@ lemma uniform_cauchy_seq_on.mono {s' : set α} (hf : uniform_cauchy_seq_on F p s
   uniform_cauchy_seq_on F p s' :=
 λ u hu, (hf u hu).mono (λ x hx y hy, hx y (hss' hy))
 
-/-- Composing on the right by a function preserves uniform convergence -/
+/-- Composing on the right by a function preserves uniform Cauchy sequences -/
 lemma uniform_cauchy_seq_on.comp {γ : Type*} (hf : uniform_cauchy_seq_on F p s) (g : γ → α) :
   uniform_cauchy_seq_on (λ n, F n ∘ g) p (g ⁻¹' s) :=
 λ u hu, (hf u hu).mono (λ x hx y hy, hx (g y) hy)
 
 /-- Composing on the left by a uniformly continuous function preserves
-uniform convergence -/
+uniform Cauchy sequences -/
 lemma uniform_cauchy_seq_on.comp' [uniform_space γ] {g : β → γ} (hf : uniform_cauchy_seq_on F p s)
   (hg : uniform_continuous g) :
   uniform_cauchy_seq_on (λ n, g ∘ (F n)) p s :=

--- a/src/topology/uniform_space/uniform_convergence.lean
+++ b/src/topology/uniform_space/uniform_convergence.lean
@@ -359,10 +359,7 @@ lemma uniform_cauchy_seq_on.prod' {β' : Type*} [uniform_space β'] {F' : ι →
   uniform_cauchy_seq_on (λ (i : ι) a, (F i a, F' i a)) p s :=
 begin
   intros u hu,
-  have hh : tendsto (λ x : ι, (x, x)) p (p ×ᶠ p),
-  { rw tendsto_iff_eventually,
-    intros pr hpr,
-    exact hpr.diag_of_prod, },
+  have hh : tendsto (λ x : ι, (x, x)) p (p ×ᶠ p), { exact tendsto_diag, },
   exact (hh.prod_map hh).eventually ((h.prod h') u hu),
 end
 

--- a/src/topology/uniform_space/uniform_convergence.lean
+++ b/src/topology/uniform_space/uniform_convergence.lean
@@ -209,12 +209,8 @@ lemma filter.tendsto.tendsto_uniformly_on_const
   {g : ι → β} {b : β} (hg : tendsto g p (𝓝 b)) (s : set α) :
   tendsto_uniformly_on (λ n : ι, λ a : α, g n) (λ a : α, b) p s :=
 begin
-  by_cases hs : s = ∅,
-  { rw hs, exact tendsto_uniformly_on_empty, },
-  have hs : s.nonempty,
-  { by_contradiction H,
-    rw set.not_nonempty_iff_eq_empty at H,
-    exact hs H, },
+  rcases set.eq_empty_or_nonempty s with rfl | hs,
+  { exact tendsto_uniformly_on_empty, },
 
   intros u hu,
   rw tendsto_iff_eventually at hg,

--- a/src/topology/uniform_space/uniform_convergence.lean
+++ b/src/topology/uniform_space/uniform_convergence.lean
@@ -328,45 +328,24 @@ begin
   rw [uniformity_prod_eq_prod, mem_map, mem_prod_iff] at hu,
   obtain ⟨v, hv, w, hw, hvw⟩ := hu,
   simp only [mem_prod, prod_map, and_imp, prod.forall],
-  let pr := (λ (m : (ι × ι') × ι × ι'), ∀ (a : α) (b : α'),
-    a ∈ s → b ∈ s' → ((F m.fst.fst a, F' m.fst.snd b), F m.snd.fst a, F' m.snd.snd b) ∈ u),
-  have foo : ∀ m : (ι × ι') × ι × ι', (∀ (a : α) (b : α'),
-    a ∈ s → b ∈ s' → ((F m.fst.fst a, F' m.fst.snd b), F m.snd.fst a, F' m.snd.snd b) ∈ u) ↔ (pr m),
-  { intros m,
-    simp only [pr], },
-  simp_rw foo,
 
-  have : tendsto (λ m : (ι × ι') × ι × ι', ((m.fst.fst, m.snd.fst), m.fst.snd, m.snd.snd))
-    (p ×ᶠ p' ×ᶠ (p ×ᶠ p')) (p ×ᶠ p ×ᶠ (p' ×ᶠ p')),
-  { unfold tendsto,
-    rw le_def,
-    intros s hs,
-    simp [hs],
-    simp_rw mem_prod_iff,
-    simp_rw mem_prod_iff at hs,
-    rcases hs with ⟨t₁, ⟨t₁', ht₁', t₁'', ht₁'', ht₁⟩, t₂, ⟨t₂', ht₂', t₂'', ht₂'', ht₂⟩, hts⟩,
-    use [t₁' ×ˢ t₂', t₁', ht₁', t₂', ht₂'],
-    refine ⟨t₁'' ×ˢ t₂'', ⟨t₁'', ht₁'', t₂'', ht₂'', rfl.subset⟩, _⟩,
-    rw set.subset_def,
-    intros x hx,
-    simp,
-    calc ((x.fst.fst, x.snd.fst), x.fst.snd, x.snd.snd) ∈ (t₁' ×ˢ t₁'') ×ˢ t₂' ×ˢ t₂'' : begin
-      simp at hx,
-      simp [hx],
-    end
-    ... ⊆ t₁ ×ˢ t₂ : begin
-      rw prod_subset_prod_iff,
-      left,
-      exact ⟨ht₁, ht₂⟩,
-      end
-    ... ⊆ s : hts, },
+  -- unfold some abstract nonsense
+  let fff := (equiv.prod_assoc _ _ _)
+    ∘ (prod.map (equiv.prod_assoc _ _ _).symm id)
+    ∘ (prod.map (prod.map id prod.swap ∘ (equiv.prod_assoc _ _ _)) id)
+    ∘ (equiv.prod_assoc (ι × ι') ι ι').symm,
+  have : tendsto fff (p ×ᶠ p' ×ᶠ (p ×ᶠ p')) (p ×ᶠ p ×ᶠ (p' ×ᶠ p')),
+  { apply tendsto_prod_assoc.comp,
+    apply (tendsto_prod_assoc_symm.prod_map tendsto_id).comp,
+    refine (((tendsto_id.prod_map tendsto_prod_swap).comp tendsto_prod_assoc).prod_map
+      tendsto_id).comp tendsto_prod_assoc_symm, },
   apply (this.eventually ((h v hv).prod_mk (h' w hw))).mono,
   intros x hx a b ha hb,
   rw ←set.image_subset_iff at hvw,
   refine set.mem_of_mem_of_subset _ hvw,
   simp only [mem_image, mem_prod, prod.mk.inj_iff, prod.exists],
   refine ⟨_, _, _, _, ⟨hx.1 a ha, hx.2 b hb⟩, _⟩,
-  simp only [eq_self_iff_true, and_self],
+  simp [fff],
 end
 
 lemma uniform_cauchy_seq_on.prod {ι' β' : Type*} [uniform_space β'] {F' : ι' → α → β'}
@@ -384,15 +363,6 @@ begin
   { rw tendsto_iff_eventually,
     intros pr hpr,
     exact hpr.diag_of_prod, },
-  let pr := (λ (m : (ι × ι) × ι × ι),
-      (∀ (x : α), x ∈ s →
-        ((F m.fst.fst x, F' m.fst.snd x),
-        (F m.snd.fst x, F' m.snd.snd x)) ∈ u)),
-  have foo : ∀ m : ι × ι, ((∀ x : α, x ∈ s → ((F m.fst x, F' m.fst x), F m.snd x, F' m.snd x) ∈ u)
-    ↔ (pr ((m.fst, m.fst), m.snd, m.snd))),
-  { intros m,
-    simp [pr], },
-  simp_rw foo,
   exact (hh.prod_map hh).eventually ((h.prod h') u hu),
 end
 


### PR DESCRIPTION
To prove facts about uniform convergence, it is often useful to manipulate the various functions without dealing with the ε's and δ's. To do so, you need auxiliary lemmas about adding/muliplying/etc Cauchy sequences.

This commit adds several such lemmas. It supports #14090, which we're slowly transforming to use these lemmas instead of doing direct ε/δ manipulation.



---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
