### PR TITLE
[Merged by Bors] - feat(algebraic_topology): alternating_coface_map_complex

### DIFF
--- a/src/algebraic_topology/simplicial_object.lean
+++ b/src/algebraic_topology/simplicial_object.lean
@@ -495,6 +495,11 @@ end cosimplicial_object
 def simplicial_cosimplicial_equiv : (simplicial_object C)ᵒᵖ ≌ (cosimplicial_object Cᵒᵖ) :=
 functor.left_op_right_op_equiv _ _
 
+/-- The anti-equivalence between cosimplicial objects and simplicial objects. -/
+@[simps]
+def cosimplicial_simplicial_equiv : (cosimplicial_object C)ᵒᵖ ≌ (simplicial_object Cᵒᵖ) :=
+functor.op_unop_equiv _ _
+
 variable {C}
 
 /-- Construct an augmented cosimplicial object in the opposite

--- a/src/category_theory/preadditive/opposite.lean
+++ b/src/category_theory/preadditive/opposite.lean
@@ -42,6 +42,7 @@ instance module_End_left {X : Cᵒᵖ} {Y : C} : module (End X) (unop X ⟶ Y) :
 
 variable {C}
 
+/-- `unop` induces morphisms of monoids on hom groups of a preadditive category -/
 @[simps] def unop_hom (X Y : Cᵒᵖ) : (X ⟶ Y) →+ (opposite.unop Y ⟶ opposite.unop X) :=
 add_monoid_hom.mk' (λ f, f.unop) $ λ f g, unop_add _ f g
 
@@ -49,8 +50,8 @@ add_monoid_hom.mk' (λ f, f.unop) $ λ f g, unop_add _ f g
   (s.sum f).unop = s.sum (λ i, (f i).unop) :=
 (unop_hom X Y).map_sum _ _
 
-@[simps]
-def op_hom (X Y : C) : (X ⟶ Y) →+ (opposite.op Y ⟶ opposite.op X) :=
+/-- `op` induces morphisms of monoids on hom groups of a preadditive category -/
+@[simps] def op_hom (X Y : C) : (X ⟶ Y) →+ (opposite.op Y ⟶ opposite.op X) :=
 add_monoid_hom.mk' (λ f, f.op) $ λ f g, op_add _ f g
 
 @[simp] lemma op_sum (X Y : C) {ι : Type*} (s : finset ι) (f : ι → (X ⟶ Y)) :

--- a/src/category_theory/preadditive/opposite.lean
+++ b/src/category_theory/preadditive/opposite.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2021 Scott Morrison. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Scott Morrison, Adam Topaz
+Authors: Scott Morrison, Adam Topaz, Johan Commelin, Joël Riou
 -/
 import category_theory.preadditive
 import category_theory.preadditive.additive_functor
@@ -33,10 +33,31 @@ instance module_End_left {X : Cᵒᵖ} {Y : C} : module (End X) (unop X ⟶ Y) :
 
 @[simp] lemma unop_zero (X Y : Cᵒᵖ) : (0 : X ⟶ Y).unop = 0 := rfl
 @[simp] lemma unop_add {X Y : Cᵒᵖ} (f g : X ⟶ Y) : (f + g).unop = f.unop + g.unop := rfl
+@[simp] lemma unop_zsmul {X Y : Cᵒᵖ} (k : ℤ) (f : X ⟶ Y) : (k • f).unop = k • f.unop := rfl
+@[simp] lemma unop_neg {X Y : Cᵒᵖ}(f : X ⟶ Y) : (-f).unop = -(f.unop) := rfl
 @[simp] lemma op_zero (X Y : C) : (0 : X ⟶ Y).op = 0 := rfl
 @[simp] lemma op_add {X Y : C} (f g : X ⟶ Y) : (f + g).op = f.op + g.op := rfl
+@[simp] lemma op_zsmul {X Y : C} (k : ℤ) (f : X ⟶ Y) : (k • f).op = k • f.op := rfl
+@[simp] lemma op_neg {X Y : C}(f : X ⟶ Y) : (-f).op = -(f.op) := rfl
 
-variables {C} {D : Type*} [category D] [preadditive D]
+variable {C}
+
+@[simps] def unop_hom (X Y : Cᵒᵖ) : (X ⟶ Y) →+ (opposite.unop Y ⟶ opposite.unop X) :=
+add_monoid_hom.mk' (λ f, f.unop) $ λ f g, unop_add _ f g
+
+@[simp] lemma unop_sum (X Y : Cᵒᵖ) {ι : Type*} (s : finset ι) (f : ι → (X ⟶ Y)) :
+  (s.sum f).unop = s.sum (λ i, (f i).unop) :=
+(unop_hom X Y).map_sum _ _
+
+@[simps]
+def op_hom (X Y : C) : (X ⟶ Y) →+ (opposite.op Y ⟶ opposite.op X) :=
+add_monoid_hom.mk' (λ f, f.op) $ λ f g, op_add _ f g
+
+@[simp] lemma op_sum (X Y : C) {ι : Type*} (s : finset ι) (f : ι → (X ⟶ Y)) :
+  (s.sum f).op = s.sum (λ i, (f i).op) :=
+(op_hom X Y).map_sum _ _
+
+variables {D : Type*} [category D] [preadditive D]
 
 instance functor.op_additive (F : C ⥤ D) [F.additive] : F.op.additive := {}
 


### PR DESCRIPTION
This PR constructs the alternating coface map complex of a cosimplicial object in an additive category. This construction is dual to the alternating face map complex.

---
Part of the code is imported from the LTE.

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
