### PR TITLE
[Merged by Bors] - chore(ring_theory/dedekind_domain/ideal): speed up a proof

### DIFF
--- a/src/ring_theory/dedekind_domain/ideal.lean
+++ b/src/ring_theory/dedekind_domain/ideal.lean
@@ -902,8 +902,12 @@ open_locale classical
 lemma ideal.count_normalized_factors_eq {p x : ideal R} (hp0 : p ≠ ⊥) [hp : p.is_prime] {n : ℕ}
   (hle : x ≤ p^n) (hlt : ¬ (x ≤ p^(n+1))) :
   (normalized_factors x).count p = n :=
-count_normalized_factors_eq ((ideal.prime_iff_is_prime hp0).mpr hp).irreducible (normalize_eq _)
-  (ideal.dvd_iff_le.mpr hle) (mt ideal.le_of_dvd hlt)
+begin
+  apply count_normalized_factors_eq ((ideal.prime_iff_is_prime hp0).mpr hp).irreducible,
+  { haveI : unique (ideal R)ˣ := ideal.unique_units, apply normalize_eq },
+  convert ideal.dvd_iff_le.mpr hle,
+  convert mt ideal.le_of_dvd hlt,
+end
 
 end
 

--- a/src/ring_theory/dedekind_domain/ideal.lean
+++ b/src/ring_theory/dedekind_domain/ideal.lean
@@ -902,12 +902,9 @@ open_locale classical
 lemma ideal.count_normalized_factors_eq {p x : ideal R} (hp0 : p ≠ ⊥) [hp : p.is_prime] {n : ℕ}
   (hle : x ≤ p^n) (hlt : ¬ (x ≤ p^(n+1))) :
   (normalized_factors x).count p = n :=
-begin
-  apply count_normalized_factors_eq ((ideal.prime_iff_is_prime hp0).mpr hp).irreducible,
-  { haveI : unique (ideal R)ˣ := ideal.unique_units, apply normalize_eq },
-  convert ideal.dvd_iff_le.mpr hle,
-  convert mt ideal.le_of_dvd hlt,
-end
+count_normalized_factors_eq ((ideal.prime_iff_is_prime hp0).mpr hp).irreducible
+  (by { haveI : unique (ideal R)ˣ := ideal.unique_units, apply normalize_eq })
+  (by convert ideal.dvd_iff_le.mpr hle) (by convert mt ideal.le_of_dvd hlt)
 
 end
 

--- a/src/ring_theory/dedekind_domain/ideal.lean
+++ b/src/ring_theory/dedekind_domain/ideal.lean
@@ -906,7 +906,7 @@ count_normalized_factors_eq ((ideal.prime_iff_is_prime hp0).mpr hp).irreducible
   (by { haveI : unique (ideal R)ˣ := ideal.unique_units, apply normalize_eq })
   (by convert ideal.dvd_iff_le.mpr hle) (by convert mt ideal.le_of_dvd hlt)
 /- Warning: even though a pure term-mode proof typechecks (the `by convert` can simply be
-  removed), it's slower and has caused timeout. -/
+  removed), it's slower to the point of a possible timeout. -/
 
 end
 

--- a/src/ring_theory/dedekind_domain/ideal.lean
+++ b/src/ring_theory/dedekind_domain/ideal.lean
@@ -905,6 +905,8 @@ lemma ideal.count_normalized_factors_eq {p x : ideal R} (hp0 : p ≠ ⊥) [hp : 
 count_normalized_factors_eq ((ideal.prime_iff_is_prime hp0).mpr hp).irreducible
   (by { haveI : unique (ideal R)ˣ := ideal.unique_units, apply normalize_eq })
   (by convert ideal.dvd_iff_le.mpr hle) (by convert mt ideal.le_of_dvd hlt)
+/- Warning: even though a pure term-mode proof typechecks (the `by convert` can simply be
+  removed), it's slower and has caused timeout. -/
 
 end
 


### PR DESCRIPTION
... which causes recurring timeout at irrelevant places, see https://github.com/leanprover-community/mathlib/pull/14585#issuecomment-1148222373 and referenced Zulip discussion.

Feel free to push golfs that remains fast (1-2s)!

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
