### PR TITLE
[Merged by Bors] - feat(model_theory/substructures): tweak universes for `lift_card_closure_le`

### DIFF
--- a/src/model_theory/substructures.lean
+++ b/src/model_theory/substructures.lean
@@ -262,11 +262,12 @@ begin
   exact cardinal.mk_range_le_lift,
 end
 
-theorem lift_card_closure_le : cardinal.lift.{(max u w) w} (# (closure L s)) ≤
-  max ℵ₀ (cardinal.lift.{(max u w) w} (#s) + cardinal.lift.{(max u w) u} (#(Σ i, L.functions i))) :=
+theorem lift_card_closure_le : cardinal.lift.{u w} (# (closure L s)) ≤
+  max ℵ₀ (cardinal.lift.{u w} (#s) + cardinal.lift.{w u} (#(Σ i, L.functions i))) :=
 begin
+  rw ←lift_umax,
   refine lift_card_closure_le_card_term.trans (term.card_le.trans _),
-  rw [mk_sum, lift_umax', lift_umax],
+  rw [mk_sum, lift_umax],
 end
 
 variable (L)


### PR DESCRIPTION
Since `cardinal.lift.{(max u v) u} = cardinal.lift.{v u}`, the latter form should be preferred.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
