### PR TITLE
[Merged by Bors] - feat(logic/equiv/basic): two empty types are equivalent; remove various redundant lemmas

### DIFF
--- a/src/logic/equiv/basic.lean
+++ b/src/logic/equiv/basic.lean
@@ -363,7 +363,7 @@ def prop_equiv_punit {p : Prop} (h : p) : p ≃ punit :=
 
 /-- The `Sort` of proofs of a false proposition is equivalent to `pempty`. -/
 def prop_equiv_pempty {p : Prop} (h : ¬p) : p ≃ pempty :=
-⟨λ x, absurd x h, λ x, by cases x, λ x, absurd x h, λ x, by cases x⟩
+@equiv_pempty p $ is_empty.prop_iff.2 h
 
 /-- `true` is equivalent to `punit`. -/
 def true_equiv_punit : true ≃ punit := prop_equiv_punit trivial

--- a/src/logic/equiv/basic.lean
+++ b/src/logic/equiv/basic.lean
@@ -345,29 +345,17 @@ end perm_congr
 def equiv_empty (α : Sort u) [is_empty α] : α ≃ empty :=
 ⟨is_empty_elim, λ e, e.rec _, is_empty_elim, λ e, e.rec _⟩
 
+/-- Two empty types are equivalent. -/
+def empty_equiv_empty (α β : Sort*) [is_empty α] [is_empty β] : α ≃ β :=
+(equiv_empty α).trans (equiv_empty β).symm
+
+/-- If `α` is an empty type, then it is equivalent to the `pempty` type in any universe. -/
+def equiv_pempty (α : Sort v) [is_empty α] : α ≃ pempty.{u} :=
+empty_equiv_empty α _
+
 /-- `α` is equivalent to an empty type iff `α` is empty. -/
 def equiv_empty_equiv (α : Sort u) : (α ≃ empty) ≃ is_empty α :=
 ⟨λ e, function.is_empty e, @equiv_empty α, λ e, ext $ λ x, (e x).elim, λ p, rfl⟩
-
-/-- `false` is equivalent to `empty`. -/
-def false_equiv_empty : false ≃ empty :=
-equiv_empty _
-
-/-- If `α` is an empty type, then it is equivalent to the `pempty` type in any universe. -/
-def {u' v'} equiv_pempty (α : Sort v') [is_empty α] : α ≃ pempty.{u'} :=
-⟨is_empty_elim, λ e, e.rec _, is_empty_elim, λ e, e.rec _⟩
-
-/-- `false` is equivalent to `pempty`. -/
-def false_equiv_pempty : false ≃ pempty :=
-equiv_pempty _
-
-/-- `empty` is equivalent to `pempty`. -/
-def empty_equiv_pempty : empty ≃ pempty :=
-equiv_pempty _
-
-/-- `pempty` types from any two universes are equivalent. -/
-def pempty_equiv_pempty : pempty.{v} ≃ pempty.{w} :=
-equiv_pempty _
 
 /-- The `Sort` of proofs of a true proposition is equivalent to `punit`. -/
 def prop_equiv_punit {p : Prop} (h : p) : p ≃ punit :=

--- a/src/logic/equiv/basic.lean
+++ b/src/logic/equiv/basic.lean
@@ -342,16 +342,16 @@ by { ext, simp }
 end perm_congr
 
 /-- Two empty types are equivalent. -/
-def equiv_of_empty (α β : Sort*) [is_empty α] [is_empty β] : α ≃ β :=
+def equiv_of_is_empty  (α β : Sort*) [is_empty α] [is_empty β] : α ≃ β :=
 ⟨is_empty_elim, is_empty_elim, is_empty_elim, is_empty_elim⟩
 
 /-- If `α` is an empty type, then it is equivalent to the `empty` type. -/
 def equiv_empty (α : Sort u) [is_empty α] : α ≃ empty :=
-equiv_of_empty α _
+equiv_of_is_empty  α _
 
 /-- If `α` is an empty type, then it is equivalent to the `pempty` type in any universe. -/
 def equiv_pempty (α : Sort v) [is_empty α] : α ≃ pempty.{u} :=
-equiv_of_empty α _
+equiv_of_is_empty  α _
 
 /-- `α` is equivalent to an empty type iff `α` is empty. -/
 def equiv_empty_equiv (α : Sort u) : (α ≃ empty) ≃ is_empty α :=

--- a/src/logic/equiv/basic.lean
+++ b/src/logic/equiv/basic.lean
@@ -342,16 +342,16 @@ by { ext, simp }
 end perm_congr
 
 /-- Two empty types are equivalent. -/
-def empty_equiv_empty (α β : Sort*) [is_empty α] [is_empty β] : α ≃ β :=
+def equiv_of_empty (α β : Sort*) [is_empty α] [is_empty β] : α ≃ β :=
 ⟨is_empty_elim, is_empty_elim, is_empty_elim, is_empty_elim⟩
 
 /-- If `α` is an empty type, then it is equivalent to the `empty` type. -/
 def equiv_empty (α : Sort u) [is_empty α] : α ≃ empty :=
-empty_equiv_empty α _
+equiv_of_empty α _
 
 /-- If `α` is an empty type, then it is equivalent to the `pempty` type in any universe. -/
 def equiv_pempty (α : Sort v) [is_empty α] : α ≃ pempty.{u} :=
-empty_equiv_empty α _
+equiv_of_empty α _
 
 /-- `α` is equivalent to an empty type iff `α` is empty. -/
 def equiv_empty_equiv (α : Sort u) : (α ≃ empty) ≃ is_empty α :=

--- a/src/logic/equiv/basic.lean
+++ b/src/logic/equiv/basic.lean
@@ -341,13 +341,13 @@ by { ext, simp }
 
 end perm_congr
 
-/-- If `α` is an empty type, then it is equivalent to the `empty` type. -/
-def equiv_empty (α : Sort u) [is_empty α] : α ≃ empty :=
-⟨is_empty_elim, λ e, e.rec _, is_empty_elim, λ e, e.rec _⟩
-
 /-- Two empty types are equivalent. -/
 def empty_equiv_empty (α β : Sort*) [is_empty α] [is_empty β] : α ≃ β :=
-(equiv_empty α).trans (equiv_empty β).symm
+⟨is_empty_elim, is_empty_elim, is_empty_elim, is_empty_elim⟩
+
+/-- If `α` is an empty type, then it is equivalent to the `empty` type. -/
+def equiv_empty (α : Sort u) [is_empty α] : α ≃ empty :=
+empty_equiv_empty α _
 
 /-- If `α` is an empty type, then it is equivalent to the `pempty` type in any universe. -/
 def equiv_pempty (α : Sort v) [is_empty α] : α ≃ pempty.{u} :=

--- a/src/set_theory/ordinal/basic.lean
+++ b/src/set_theory/ordinal/basic.lean
@@ -748,7 +748,7 @@ instance : has_zero ordinal :=
 instance : inhabited ordinal := ⟨0⟩
 
 theorem zero_eq_type_empty : 0 = @type empty empty_relation _ :=
-quotient.sound ⟨⟨empty_equiv_empty _ _, λ _ _, iff.rfl⟩⟩
+quotient.sound ⟨⟨equiv_of_empty _ _, λ _ _, iff.rfl⟩⟩
 
 @[simp] theorem card_zero : card 0 = 0 := rfl
 
@@ -862,7 +862,7 @@ by simp only [lt_iff_le_not_le, lift_le]
 
 @[simp] theorem lift_zero : lift 0 = 0 :=
 quotient.sound ⟨(rel_iso.preimage equiv.ulift _).trans
- ⟨empty_equiv_empty _ _, λ a b, iff.rfl⟩⟩
+ ⟨equiv_of_empty _ _, λ a b, iff.rfl⟩⟩
 
 theorem zero_eq_lift_type_empty : 0 = lift.{u} (@type empty empty_relation _) :=
 by rw [← zero_eq_type_empty, lift_zero]

--- a/src/set_theory/ordinal/basic.lean
+++ b/src/set_theory/ordinal/basic.lean
@@ -748,7 +748,7 @@ instance : has_zero ordinal :=
 instance : inhabited ordinal := ⟨0⟩
 
 theorem zero_eq_type_empty : 0 = @type empty empty_relation _ :=
-quotient.sound ⟨⟨equiv_of_empty _ _, λ _ _, iff.rfl⟩⟩
+quotient.sound ⟨⟨equiv_of_is_empty  _ _, λ _ _, iff.rfl⟩⟩
 
 @[simp] theorem card_zero : card 0 = 0 := rfl
 
@@ -862,7 +862,7 @@ by simp only [lt_iff_le_not_le, lift_le]
 
 @[simp] theorem lift_zero : lift 0 = 0 :=
 quotient.sound ⟨(rel_iso.preimage equiv.ulift _).trans
- ⟨equiv_of_empty _ _, λ a b, iff.rfl⟩⟩
+ ⟨equiv_of_is_empty  _ _, λ a b, iff.rfl⟩⟩
 
 theorem zero_eq_lift_type_empty : 0 = lift.{u} (@type empty empty_relation _) :=
 by rw [← zero_eq_type_empty, lift_zero]

--- a/src/set_theory/ordinal/basic.lean
+++ b/src/set_theory/ordinal/basic.lean
@@ -748,7 +748,7 @@ instance : has_zero ordinal :=
 instance : inhabited ordinal := ⟨0⟩
 
 theorem zero_eq_type_empty : 0 = @type empty empty_relation _ :=
-quotient.sound ⟨⟨empty_equiv_pempty.symm, λ _ _, iff.rfl⟩⟩
+quotient.sound ⟨⟨empty_equiv_empty _ _, λ _ _, iff.rfl⟩⟩
 
 @[simp] theorem card_zero : card 0 = 0 := rfl
 
@@ -862,7 +862,7 @@ by simp only [lt_iff_le_not_le, lift_le]
 
 @[simp] theorem lift_zero : lift 0 = 0 :=
 quotient.sound ⟨(rel_iso.preimage equiv.ulift _).trans
- ⟨pempty_equiv_pempty, λ a b, iff.rfl⟩⟩
+ ⟨empty_equiv_empty _ _, λ a b, iff.rfl⟩⟩
 
 theorem zero_eq_lift_type_empty : 0 = lift.{u} (@type empty empty_relation _) :=
 by rw [← zero_eq_type_empty, lift_zero]


### PR DESCRIPTION
We prove `equiv_of_is_empty`, which states two empty types are equivalent. This allows us to remove various redundant lemmas.

We keep `empty_equiv_empty` and `empty_equiv_pempty` as these specific instantiations of that lemma are widely used.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
