### PR TITLE
[Merged by Bors] - chore(data/finset): remove duplicated lemma

### DIFF
--- a/src/combinatorics/set_family/lym.lean
+++ b/src/combinatorics/set_family/lym.lean
@@ -141,7 +141,7 @@ begin
   { rintro ⟨⟨t, ht, hst⟩, hs⟩,
     by_cases s ∈ 𝒜,
     { exact or.inl ⟨h, hs⟩ },
-    obtain ⟨a, ha, hst⟩ := ssubset_iff_exists_insert_subset.1
+    obtain ⟨a, ha, hst⟩ := ssubset_iff.1
       (ssubset_of_subset_of_ne hst (ht.ne_of_not_mem h).symm),
     refine or.inr ⟨insert a s, ⟨⟨t, ht, hst⟩, _⟩, a, mem_insert_self _ _, erase_insert ha⟩,
     rw [card_insert_of_not_mem ha, hs] }

--- a/src/data/finset/basic.lean
+++ b/src/data/finset/basic.lean
@@ -627,9 +627,6 @@ by exact_mod_cast @set.ssubset_iff_insert α s t
 
 lemma ssubset_insert (h : a ∉ s) : s ⊂ insert a s := ssubset_iff.mpr ⟨a, h, subset.rfl⟩
 
-lemma ssubset_iff_exists_insert_subset {s t : finset α} : s ⊂ t ↔ ∃ a ∉ s, insert a s ⊆ t :=
-by simp_rw [ssubset_iff_exists_cons_subset, cons_eq_insert]
-
 @[elab_as_eliminator]
 lemma cons_induction {α : Type*} {p : finset α → Prop}
   (h₁ : p ∅) (h₂ : ∀ ⦃a : α⦄ {s : finset α} (h : a ∉ s), p s → p (cons a s h)) : ∀ s, p s


### PR DESCRIPTION
The lemma `ssubset_iff_exists_insert_subset` was added in #11248 but is just a duplicate of the `ssubset_iff` lemma a few lines earlier in the file. It's only used once.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
