### PR TITLE
[Merged by Bors] - feat(logic/basic): add lemma `pi_congr`

### DIFF
--- a/src/logic/basic.lean
+++ b/src/logic/basic.lean
@@ -934,7 +934,7 @@ variables {β : α → Sort*} {γ : Π a, β a → Sort*} {δ : Π a b, γ a b �
   {ε : Π a b c, δ a b c → Sort*}
 
 lemma pi_congr {β' : α → Sort*} (h : ∀ a, β a = β' a) : (Π a, β a) = Π a, β' a :=
-by rw show β = β', from funext h
+(funext h : β = β') ▸ rfl
 
 lemma forall₂_congr {p q : Π a, β a → Prop} (h : ∀ a b, p a b ↔ q a b) :
   (∀ a b, p a b) ↔ ∀ a b, q a b :=

--- a/src/logic/basic.lean
+++ b/src/logic/basic.lean
@@ -933,6 +933,9 @@ section dependent
 variables {β : α → Sort*} {γ : Π a, β a → Sort*} {δ : Π a b, γ a b → Sort*}
   {ε : Π a b c, δ a b c → Sort*}
 
+lemma pi_congr {β' : α → Sort*} (h : ∀ a, β a = β' a) : (Π a, β a) = Π a, β' a :=
+by rw show β = β', from funext h
+
 lemma forall₂_congr {p q : Π a, β a → Prop} (h : ∀ a b, p a b ↔ q a b) :
   (∀ a b, p a b) ↔ ∀ a b, q a b :=
 forall_congr $ λ a, forall_congr $ h a


### PR DESCRIPTION
This lemma is used in #14153, where `congrm` is defined.

A big reason for splitting these 3 lines off the main PR is that they are the only ones that are not in a leaf of the import hierarchy: this hopefully saves lots of CI time, when doing trivial changes to the main PR.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

Co-authored-by: Gabriel Ebner <[gebner@gebner.org](mailto:gebner@gebner.org)>

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
