### PR TITLE
[Merged by Bors] - feat(tactic/core + test/list_summands): a function extracting a list of summands from an expression

### DIFF
--- a/src/meta/expr.lean
+++ b/src/meta/expr.lean
@@ -584,8 +584,14 @@ meta def to_implicit_binder : expr → expr
 `list_binary_operands f x` breaks `x` apart into successions of applications of `f` until this can
 no longer be done and returns a list of the leaves of the process.
 
-E.g. (code not actually working) `list_binary_operands + (3 + (4 * 5 + 6) + 7 / 3)` returns
-`[3, 4 * 5, 6, 7 / 3]`. -/
+For example:
+```lean
+#eval list_binary_operands `(@has_add.add ℕ _) `(3 + (4 * 5 + 6) + 7 / 3) >>= tactic.trace
+-- [3, 4 * 5, 6, 7 / 3]
+#eval list_binary_operands `(@list.append ℕ) `([1, 2] ++ [3, 4] ++ (1 :: [])) >>= tactic.trace
+-- [[1, 2], [3, 4], [1]]
+```
+-/
 meta def list_binary_operands (f : expr) : expr → tactic (list expr)
 | x@(expr.app (expr.app g a) b) := do
   some _ ← try_core (unify f g) | pure [x],

--- a/src/meta/expr.lean
+++ b/src/meta/expr.lean
@@ -580,7 +580,7 @@ meta def to_implicit_binder : expr → expr
 | (pi n _ d b) := pi n binder_info.implicit d b
 | e  := e
 
-/--  Takes two `expr`s `f` and `x`, where `f` represents a bunary operation.  Decomposes the
+/--  Takes two `expr`s `f` and `x`, where `f` represents a binary operation.  Decomposes the
 second expression `x` into repeated applications of `f`, returning a list of the atoms of the
 matching process.
 

--- a/src/meta/expr.lean
+++ b/src/meta/expr.lean
@@ -580,12 +580,18 @@ meta def to_implicit_binder : expr → expr
 | (pi n _ d b) := pi n binder_info.implicit d b
 | e  := e
 
-/--  Takes an `expr` and returns a list of its summands. -/
+/--  Takes an `expr` and returns a list of its summands.
+
+See the related `expr.list_binary_operands` in `tactic.core` for a `tactic` version that takes an
+arbitrary (binary) operation as a parameter. -/
 meta def list_summands : expr → list expr
 | `(has_add.add %%a %%b) := a.list_summands ++ b.list_summands
 | a                      := [a]
 
-/--  Takes an `expr` and returns a list of its factors. -/
+/--  Takes an `expr` and returns a list of its factors.
+
+See the related `expr.list_binary_operands` in `tactic.core` for a `tactic` version that takes an
+arbitrary (binary) operation as a parameter. -/
 meta def list_factors : expr → list expr
 | `(has_mul.mul %%a %%b) := a.list_summands ++ b.list_summands
 | a                      := [a]

--- a/src/meta/expr.lean
+++ b/src/meta/expr.lean
@@ -592,6 +592,7 @@ meta def list_binary_operands (f : expr) : expr → list expr
 | a := [a]
 
 /--  Takes an `expr` and returns a list of its summands.
+For instance, ``list_summands `(a + (b + c))`` will return ``[`(a), `(b), `(c)]``.
 
 See the related `expr.list_binary_operands` in `tactic.core` for a `tactic` version that takes an
 arbitrary (binary) operation as a parameter. -/
@@ -601,6 +602,7 @@ meta def list_summands : expr → list expr
 | a                      := [a]
 
 /--  Takes an `expr` and returns a list of its factors.
+For instance, ``list_factors `(a * (b * c))`` will return ``[`(a), `(b), `(c)]``.
 
 See the related `expr.list_binary_operands` in `tactic.core` for a `tactic` version that takes an
 arbitrary (binary) operation as a parameter. -/

--- a/src/meta/expr.lean
+++ b/src/meta/expr.lean
@@ -580,6 +580,11 @@ meta def to_implicit_binder : expr → expr
 | (pi n _ d b) := pi n binder_info.implicit d b
 | e  := e
 
+/--  Takes an `expr` and returns a list of its summands. -/
+meta def list_summands : expr → list expr
+| `(has_add.add %%a %%b) := a.list_summands ++ b.list_summands
+| a                      := [a]
+
 /-- Returns a list of all local constants in an expression (without duplicates). -/
 meta def list_local_consts (e : expr) : list expr :=
 e.fold [] (λ e' _ es, if e'.is_local_constant then insert e' es else es)

--- a/src/meta/expr.lean
+++ b/src/meta/expr.lean
@@ -593,7 +593,7 @@ meta def list_summands : expr → list expr
 See the related `expr.list_binary_operands` in `tactic.core` for a `tactic` version that takes an
 arbitrary (binary) operation as a parameter. -/
 meta def list_factors : expr → list expr
-| `(has_mul.mul %%a %%b) := a.list_summands ++ b.list_summands
+| `(has_mul.mul %%a %%b) := a.list_factors ++ b.list_factors
 | a                      := [a]
 
 /-- Returns a list of all local constants in an expression (without duplicates). -/

--- a/src/meta/expr.lean
+++ b/src/meta/expr.lean
@@ -580,26 +580,6 @@ meta def to_implicit_binder : expr → expr
 | (pi n _ d b) := pi n binder_info.implicit d b
 | e  := e
 
-/--  Given an expression `f` (likely a binary operation) and a further expression `x`, calling
-`list_binary_operands f x` breaks `x` apart into successions of applications of `f` until this can
-no longer be done and returns a list of the leaves of the process.
-
-For example:
-```lean
-#eval list_binary_operands `(@has_add.add ℕ _) `(3 + (4 * 5 + 6) + 7 / 3) >>= tactic.trace
--- [3, 4 * 5, 6, 7 / 3]
-#eval list_binary_operands `(@list.append ℕ) `([1, 2] ++ [3, 4] ++ (1 :: [])) >>= tactic.trace
--- [[1, 2], [3, 4], [1]]
-```
--/
-meta def list_binary_operands (f : expr) : expr → tactic (list expr)
-| x@(expr.app (expr.app g a) b) := do
-  some _ ← try_core (unify f g) | pure [x],
-  as ← a.list_binary_operands,
-  bs ← b.list_binary_operands,
-  pure (as ++ bs)
-| a                      := pure [a]
-
 /--  Takes an `expr` and returns a list of its summands. -/
 meta def list_summands : expr → list expr
 | `(has_add.add %%a %%b) := a.list_summands ++ b.list_summands

--- a/src/meta/expr.lean
+++ b/src/meta/expr.lean
@@ -580,37 +580,6 @@ meta def to_implicit_binder : expr → expr
 | (pi n _ d b) := pi n binder_info.implicit d b
 | e  := e
 
-/--  Takes two `expr`s `f` and `x`, where `f` represents a binary operation.  Decomposes the
-second expression `x` into repeated applications of `f`, returning a list of the atoms of the
-matching process.
-
-See the related `expr.list_summands` and `expr.list_factors` for versions specialized to
-addition and multiplication. -/
-meta def list_binary_operands (f : expr) : expr → list expr
-| x@(expr.app (expr.app g a) b) :=
-  if f =ₐ g then a.list_binary_operands ++ b.list_binary_operands else [x]
-| a := [a]
-
-/--  Takes an `expr` and returns a list of its summands.
-For instance, ``list_summands `(a + (b + c))`` will return ``[`(a), `(b), `(c)]``.
-
-See the related `expr.list_binary_operands` in `tactic.core` for a `tactic` version that takes an
-arbitrary (binary) operation as a parameter. -/
-meta def list_summands : expr → list expr
-| e@(app (app f a) b) :=
-  if f.is_app_of `has_add.add then list_binary_operands f a ++ list_binary_operands f b else [e]
-| a                      := [a]
-
-/--  Takes an `expr` and returns a list of its factors.
-For instance, ``list_factors `(a * (b * c))`` will return ``[`(a), `(b), `(c)]``.
-
-See the related `expr.list_binary_operands` in `tactic.core` for a `tactic` version that takes an
-arbitrary (binary) operation as a parameter. -/
-meta def list_factors : expr → list expr
-| e@(app (app f a) b) :=
-  if f.is_app_of `has_mul.mul then list_binary_operands f a ++ list_binary_operands f b else [e]
-| a                      := [a]
-
 /-- Returns a list of all local constants in an expression (without duplicates). -/
 meta def list_local_consts (e : expr) : list expr :=
 e.fold [] (λ e' _ es, if e'.is_local_constant then insert e' es else es)

--- a/src/tactic/core.lean
+++ b/src/tactic/core.lean
@@ -364,6 +364,8 @@ meta def lambdas : list expr → expr → tactic expr
 `list_binary_operands f x` breaks `x` apart into successions of applications of `f` until this can
 no longer be done and returns a list of the leaves of the process.
 
+This matches `f` up to semiredicible unification. In particular it will match applications of the same polymorphic function with different type class arguments. E.g., if `i1` and `i2` are both instances of `has_add T` and `e := has_add.add T i1 x (has_add.add T i2 y z)`, then ``list_binary_operands `((+) : T → T → T) e`` will return `[x, y, z]`.
+
 For example:
 ```lean
 #eval list_binary_operands `(@has_add.add ℕ _) `(3 + (4 * 5 + 6) + 7 / 3) >>= tactic.trace

--- a/src/tactic/core.lean
+++ b/src/tactic/core.lean
@@ -364,7 +364,12 @@ meta def lambdas : list expr → expr → tactic expr
 `list_binary_operands f x` breaks `x` apart into successions of applications of `f` until this can
 no longer be done and returns a list of the leaves of the process.
 
-This matches `f` up to semiredicible unification. In particular it will match applications of the same polymorphic function with different type class arguments. E.g., if `i1` and `i2` are both instances of `has_add T` and `e := has_add.add T i1 x (has_add.add T i2 y z)`, then ``list_binary_operands `((+) : T → T → T) e`` will return `[x, y, z]`.
+This matches `f` up to semireducible unification. In particular, it will match applications of the
+same polymorphic function with different type-class arguments.
+
+E.g., if `i1` and `i2` are both instances of `has_add T` and
+`e := has_add.add T i1 x (has_add.add T i2 y z)`, then ``list_binary_operands `((+) : T → T → T) e``
+returns `[x, y, z]`.
 
 For example:
 ```lean

--- a/test/list_summands.lean
+++ b/test/list_summands.lean
@@ -31,6 +31,13 @@ open expr
 --         @has_add.add _ (add_semigroup.to_has_add _) 2 3),
 --   guard $ ops = [`(1), `(2), `(3)]
 
+-- this fails
+-- #eval show tactic unit, from do
+--    let ops := list_factors
+--      `(@has_mul.mul _ (mul_one_class.to_has_mul _) 1 $
+--         @has_mul.mul _ (semigroup.to_has_mul _) 2 3),
+--   guard $ ops = [`(1), `(2), `(3)]
+
 def a : fin 2 → fin 2 → ℕ := λ _ _, 0
 
 #eval show tactic unit, from do

--- a/test/list_summands.lean
+++ b/test/list_summands.lean
@@ -1,0 +1,49 @@
+import tactic.core
+import data.matrix.basic
+
+section tactic
+open tactic
+
+#eval show tactic unit, from do
+  ops ← list_binary_operands `(@has_add.add ℕ _) `(3 + (4 * 5 + 6) + 7 / 3),
+  guard $ ops = [`(3), `(4*5), `(6), `(7/3)]
+
+#eval show tactic unit, from do
+  ops ← list_binary_operands `(@list.append ℕ) `([1, 2] ++ [3, 4] ++ (1 :: [])),
+  guard $ ops = [`([1, 2]), `([3, 4]), `([1])]
+
+-- matches should not care about the paths taken to find a typeclass
+#eval show tactic unit, from do
+  ops ← list_binary_operands `(@has_add.add ℕ _)
+    `(@has_add.add _ (add_zero_class.to_has_add _) 1 $
+        @has_add.add _ (add_semigroup.to_has_add _) 2 3),
+  guard $ ops = [`(1), `(2), `(3)]
+
+end tactic
+
+section expr
+open expr
+
+-- this fails
+-- #eval show tactic unit, from do
+--   let ops := list_summands
+--     `(@has_add.add _ (add_zero_class.to_has_add _) 1 $
+--         @has_add.add _ (add_semigroup.to_has_add _) 2 3),
+--   guard $ ops = [`(1), `(2), `(3)]
+
+def a : fin 2 → fin 2 → ℕ := λ _ _, 0
+
+#eval show tactic unit, from do
+  let ops := list_factors `(a * a),
+  guard $ ops = [`(a), `(a)]
+
+-- if the operation are actually different, always use the outermost one
+#eval show tactic unit, from do
+  let ops := list_factors `(a * (a * a : matrix _ _ ℕ)),
+  guard $ ops = [`(a), `(a * a : matrix _ _ ℕ)]
+
+#eval show tactic unit, from do
+  let ops := list_factors `(a * (a * a : _) : matrix _ _ ℕ),
+  guard $ ops = [`(a), `(a * a)]
+
+end expr

--- a/test/list_summands.lean
+++ b/test/list_summands.lean
@@ -20,37 +20,3 @@ open tactic
   guard $ ops = [`(1), `(2), `(3)]
 
 end tactic
-
-section expr
-open expr
-
--- this fails
--- #eval show tactic unit, from do
---   let ops := list_summands
---     `(@has_add.add _ (add_zero_class.to_has_add _) 1 $
---         @has_add.add _ (add_semigroup.to_has_add _) 2 3),
---   guard $ ops = [`(1), `(2), `(3)]
-
--- this fails
--- #eval show tactic unit, from do
---    let ops := list_factors
---      `(@has_mul.mul _ (mul_one_class.to_has_mul _) 1 $
---         @has_mul.mul _ (semigroup.to_has_mul _) 2 3),
---   guard $ ops = [`(1), `(2), `(3)]
-
-def a : fin 2 → fin 2 → ℕ := λ _ _, 0
-
-#eval show tactic unit, from do
-  let ops := list_factors `(a * a),
-  guard $ ops = [`(a), `(a)]
-
--- if the operation are actually different, always use the outermost one
-#eval show tactic unit, from do
-  let ops := list_factors `(a * (a * a : matrix _ _ ℕ)),
-  guard $ ops = [`(a), `(a * a : matrix _ _ ℕ)]
-
-#eval show tactic unit, from do
-  let ops := list_factors `(a * (a * a : _) : matrix _ _ ℕ),
-  guard $ ops = [`(a), `(a * a)]
-
-end expr


### PR DESCRIPTION
This meta def is used in #13483, where `move_add` is defined.

A big reason for splitting these 5 lines off the main PR is that they are not in a leaf of the import hierarchy: this hopefully saves lots of CI time, when doing trivial changes to the main PR.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

Co-authored-by: Arthur Paulino <[arthurleonardo.ap@gmail.com](mailto:arthurleonardo.ap@gmail.com)>

Co-authored-by: Rob Lewis <[rob.y.lewis](mailto:rob.y.lewis@gmail.com)>

Co-authored-by: Eric Wieser
<[github.com/eric-wieser](https://github.com/eric-wieser)>

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
