### PR TITLE
[Merged by Bors] - feat(special_functions/integrals): exponential of complex multiple of x

### DIFF
--- a/src/analysis/special_functions/integrals.lean
+++ b/src/analysis/special_functions/integrals.lean
@@ -315,8 +315,8 @@ lemma integral_exp_mul_complex {c : ℂ} (hc : c ≠ 0) :
 begin
   have D : ∀ (x : ℝ), has_deriv_at (λ (y : ℝ), complex.exp (c * y) / c) (complex.exp (c * x)) x,
   { intro x,
-    conv begin congr, skip, rw ←mul_div_cancel (complex.exp (c * x)) hc, end,
-    convert (has_deriv_at.comp x (complex.has_deriv_at_exp _) _).div_const c using 1,
+    conv { congr, skip, rw ←mul_div_cancel (complex.exp (c * x)) hc, },
+    convert ((complex.has_deriv_at_exp _).comp x _).div_const c using 1,
     simpa only [complex.of_real_clm_apply, complex.of_real_one, one_mul, mul_one, mul_comm] using
       complex.of_real_clm.has_deriv_at.mul_const c },
   rw integral_deriv_eq_sub' _ (funext (λ x, (D x).deriv)) (λ x hx, (D x).differentiable_at),

--- a/src/analysis/special_functions/integrals.lean
+++ b/src/analysis/special_functions/integrals.lean
@@ -5,7 +5,6 @@ Authors: Benjamin Davidson
 -/
 import measure_theory.integral.interval_integral
 import analysis.special_functions.trigonometric.arctan_deriv
-import measure_theory.integral.integral_eq_improper
 
 /-!
 # Integration of specific interval integrals
@@ -310,6 +309,20 @@ by simp only [one_div, integral_inv_of_neg ha hb]
 @[simp]
 lemma integral_exp : ∫ x in a..b, exp x = exp b - exp a :=
 by rw integral_deriv_eq_sub'; norm_num [continuous_on_exp]
+
+lemma integral_exp_mul_complex {c : ℂ} (hc : c ≠ 0) :
+  ∫ x in a..b, complex.exp (c * x) = (complex.exp (c * b) - complex.exp (c * a)) / c :=
+begin
+  have D : ∀ (x : ℝ), has_deriv_at (λ (y : ℝ), complex.exp (c * y) / c) (complex.exp (c * x)) x,
+  { intro x,
+    conv begin congr, skip, rw ←mul_div_cancel (complex.exp (c * x)) hc, end,
+    convert (has_deriv_at.comp x (complex.has_deriv_at_exp _) _).div_const c using 1,
+    simpa only [complex.of_real_clm_apply, complex.of_real_one, one_mul, mul_one, mul_comm] using
+      complex.of_real_clm.has_deriv_at.mul_const c },
+  rw integral_deriv_eq_sub' _ (funext (λ x, (D x).deriv)) (λ x hx, (D x).differentiable_at),
+  { ring_nf },
+  { apply continuous.continuous_on, continuity,}
+end
 
 @[simp]
 lemma integral_log (h : (0:ℝ) ∉ [a, b]) :


### PR DESCRIPTION
We add an integral for `exp (c * x)` for `c` complex (so this cannot be reduced to integration of `exp x` on the real line). This is useful for Fourier series.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
