### PR TITLE
[Merged by Bors] - feat(group_theory/sylow): Sylow subgroups are Hall subgroups

### DIFF
--- a/src/group_theory/sylow.lean
+++ b/src/group_theory/sylow.lean
@@ -526,6 +526,7 @@ begin
   rwa pow_one at key,
 end
 
+/-- Sylow subgroups are Hall subgroups. -/
 lemma card_coprime_index [fintype G] {p : ℕ} [hp : fact p.prime] (P : sylow p G) :
   (card P).coprime (index (P : subgroup G)) :=
 let ⟨n, hn⟩ := is_p_group.iff_card.mp P.2 in

--- a/src/group_theory/sylow.lean
+++ b/src/group_theory/sylow.lean
@@ -526,6 +526,11 @@ begin
   rwa pow_one at key,
 end
 
+lemma card_coprime_index [fintype G] {p : ℕ} [hp : fact p.prime] (P : sylow p G) :
+  (card P).coprime (index (P : subgroup G)) :=
+let ⟨n, hn⟩ := is_p_group.iff_card.mp P.2 in
+hn.symm ▸ (hp.1.coprime_pow_of_not_dvd (not_dvd_index_sylow P index_ne_zero_of_fintype)).symm
+
 lemma ne_bot_of_dvd_card [fintype G] {p : ℕ} [hp : fact p.prime] (P : sylow p G)
   (hdvd : p ∣ card G) : (P : subgroup G) ≠ ⊥ :=
 begin


### PR DESCRIPTION
This PR adds a lemma stating that Sylow subgroups are Hall subgroups (cardinality is coprime to index).

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
