### PR TITLE
[Merged by Bors] - feat(number_theory/bernoulli_polynomials): Derivative of Bernoulli polynomial

### DIFF
--- a/src/number_theory/bernoulli_polynomials.lean
+++ b/src/number_theory/bernoulli_polynomials.lean
@@ -1,9 +1,10 @@
 /-
 Copyright (c) 2021 Ashvni Narayanan. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Ashvni Narayanan
+Authors: Ashvni Narayanan, David Loeffler
 -/
 import data.polynomial.algebra_map
+import data.polynomial.derivative
 import data.nat.choose.cast
 import number_theory.bernoulli
 
@@ -33,7 +34,7 @@ Bernoulli polynomials are defined using `bernoulli`, the Bernoulli numbers.
 
 ## TODO
 
-- `bernoulli_eval_one_neg` : $$ B_n(1 - x) = (-1)^n*B_n(x) $$
+- `bernoulli_eval_one_neg` : $$ B_n(1 - x) = (-1)^n B_n(x) $$
 
 -/
 
@@ -89,6 +90,25 @@ begin
 end
 
 end examples
+
+lemma deriv_bernoulli (k : ℕ) : (bernoulli k).derivative = k * bernoulli (k - 1) :=
+begin
+  rcases nat.eq_zero_or_pos k with hk|hk,
+  { rw [hk, nat.cast_zero, zero_mul, bernoulli_zero, derivative_one], },
+  simp_rw [bernoulli, derivative_sum, nat.sub_add_cancel hk, derivative_monomial],
+  -- LHS sum has an extra term, but the coefficient is zero:
+  rw [range_add_one, sum_insert not_mem_range_self, tsub_self, cast_zero, mul_zero, map_zero,
+    zero_add, mul_sum],
+  -- the rest of the sum is termwise equal:
+  refine sum_congr (by refl) (λ m hm, _),
+  rw [←C_eq_nat_cast, C_mul_monomial, nat.sub_sub, nat.sub_sub, add_comm],
+  congr' 1,
+  rw ←mul_assoc, conv { to_rhs, congr, rw mul_comm }, rw [mul_assoc, mul_assoc],
+  congr' 1, norm_cast,
+  convert (choose_mul_succ_eq (k - 1) m).symm using 1,
+  { rw nat.sub_add_cancel hk,},
+  { rw [mul_comm, nat.sub_add_cancel hk], },
+end
 
 @[simp] theorem sum_bernoulli (n : ℕ) :
   ∑ k in range (n + 1), ((n + 1).choose k : ℚ) • bernoulli k = monomial n (n + 1 : ℚ) :=

--- a/src/number_theory/bernoulli_polynomials.lean
+++ b/src/number_theory/bernoulli_polynomials.lean
@@ -91,23 +91,26 @@ end
 
 end examples
 
-lemma deriv_bernoulli (k : ℕ) : (bernoulli k).derivative = k * bernoulli (k - 1) :=
+lemma derivative_bernoulli_add_one (k : ℕ) :
+  (bernoulli (k + 1)).derivative = (k + 1) * bernoulli k :=
 begin
-  rcases nat.eq_zero_or_pos k with hk|hk,
-  { rw [hk, nat.cast_zero, zero_mul, bernoulli_zero, derivative_one], },
-  simp_rw [bernoulli, derivative_sum, nat.sub_add_cancel hk, derivative_monomial],
+  simp_rw [bernoulli, derivative_sum, derivative_monomial, nat.sub_sub, nat.add_sub_add_right],
   -- LHS sum has an extra term, but the coefficient is zero:
   rw [range_add_one, sum_insert not_mem_range_self, tsub_self, cast_zero, mul_zero, map_zero,
     zero_add, mul_sum],
   -- the rest of the sum is termwise equal:
   refine sum_congr (by refl) (λ m hm, _),
-  rw [←C_eq_nat_cast, C_mul_monomial, nat.sub_sub, nat.sub_sub, add_comm],
-  congr' 1,
-  rw ←mul_assoc, conv { to_rhs, congr, rw mul_comm }, rw [mul_assoc, mul_assoc],
-  congr' 1, norm_cast,
-  convert (choose_mul_succ_eq (k - 1) m).symm using 1,
-  { rw nat.sub_add_cancel hk,},
-  { rw [mul_comm, nat.sub_add_cancel hk], },
+  conv_rhs { rw [←nat.cast_one, ←nat.cast_add, ←C_eq_nat_cast, C_mul_monomial, mul_comm], },
+  rw [mul_assoc, mul_assoc, ←nat.cast_mul, ←nat.cast_mul],
+  congr' 3,
+  rw [(choose_mul_succ_eq k m).symm, mul_comm],
+end
+
+lemma derivative_bernoulli (k : ℕ) : (bernoulli k).derivative = k * bernoulli (k - 1) :=
+begin
+  cases k,
+  { rw [nat.cast_zero, zero_mul, bernoulli_zero, derivative_one], },
+  { exact derivative_bernoulli_add_one k, }
 end
 
 @[simp] theorem sum_bernoulli (n : ℕ) :


### PR DESCRIPTION
Add the statement that the derivative of `bernoulli k x` is `k * bernoulli (k-1) x`. This will be used in a subsequent PR to evaluate the even positive integer values of the Riemann zeta function.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
