### PR TITLE
feat(set_theory/game/pgame): define `up`, prove basic properties

### DIFF
--- a/src/set_theory/game/pgame.lean
+++ b/src/set_theory/game/pgame.lean
@@ -1452,6 +1452,6 @@ theorem up_pos : 0 < up :=
 lt_of_le_of_lf (zero_le_lf.2 (λ j, star_fuzzy_zero.gf)) (zero_lf_le.2 ⟨default, le_rfl⟩)
 
 theorem up_fuzzy_star : up ∥ star :=
-⟨lf_move_right punit.star, lf_up_iff.2 $ by simpa using or.inr up_pos.le⟩
+⟨lf_move_right punit.star, star_lf_of_zero_le up_pos.le⟩
 
 end pgame

--- a/src/set_theory/game/pgame.lean
+++ b/src/set_theory/game/pgame.lean
@@ -625,6 +625,9 @@ by { simp only [lt_iff_le_and_lf, fuzzy, ←pgame.not_le], tauto! }
 theorem lf_of_fuzzy {x y : pgame} (h : x ∥ y) : x ⧏ y := lf_iff_lt_or_fuzzy.2 (or.inr h)
 alias lf_of_fuzzy ← pgame.fuzzy.lf
 
+theorem gf_of_fuzzy {x y : pgame} (h : x ∥ y) : y ⧏ x := h.swap.lf
+alias gf_of_fuzzy ← pgame.fuzzy.gf
+
 theorem lt_or_fuzzy_of_lf {x y : pgame} : x ⧏ y → x < y ∨ x ∥ y :=
 lf_iff_lt_or_fuzzy.1
 
@@ -1395,5 +1398,21 @@ begin
     { exact ⟨sum.inr punit.star, (add_zero_equiv _).2⟩ },
     { exact ⟨sum.inl punit.star, (zero_add_equiv _).2⟩ } }
 end
+
+/-- The pre-game `up` is defined as `{0 | *}`. It's positive but smaller than all positive numeric
+games. -/
+def up : pgame.{u} := ⟨punit, punit, 0, λ _, star⟩
+
+@[simp] theorem up_left_moves : up.left_moves = punit := rfl
+@[simp] theorem up_right_moves : up.right_moves = punit := rfl
+
+@[simp] theorem up_move_left (x) : up.move_left x = 0 := rfl
+@[simp] theorem up_move_right (x) : up.move_right x = star := rfl
+
+instance unique_up_left_moves : unique up.left_moves := punit.unique
+instance unique_up_right_moves : unique up.right_moves := punit.unique
+
+theorem up_pos : 0 < up :=
+lt_of_le_of_lf (zero_le_lf.2 (λ j, star_fuzzy_zero.gf)) (zero_lf_le.2 ⟨default, le_rfl⟩)
 
 end pgame

--- a/src/set_theory/game/pgame.lean
+++ b/src/set_theory/game/pgame.lean
@@ -1451,7 +1451,16 @@ by { rw lf_iff_forall_le, simp }
 theorem up_pos : 0 < up :=
 lt_of_le_of_lf (zero_le_lf.2 (λ j, star_fuzzy_zero.gf)) (zero_lf_le.2 ⟨default, le_rfl⟩)
 
+theorem up_lf_star : up ⧏ star :=
+lf_move_right punit.star
+
+theorem star_lf_up : star ⧏ up :=
+star_lf_of_zero_le up_pos.le
+
 theorem up_fuzzy_star : up ∥ star :=
-⟨lf_move_right punit.star, star_lf_of_zero_le up_pos.le⟩
+⟨up_lf_star, star_lf_up⟩
+
+theorem up_lf_of_star_le {x} : star ≤ x → up ⧏ x :=
+lf_of_lf_of_le up_lf_star
 
 end pgame

--- a/src/set_theory/game/pgame.lean
+++ b/src/set_theory/game/pgame.lean
@@ -1451,7 +1451,7 @@ by { rw lf_iff_forall_le, simp }
 theorem up_pos : 0 < up :=
 lt_of_le_of_lf (zero_le_lf.2 (λ j, star_fuzzy_zero.gf)) (zero_lf_le.2 ⟨default, le_rfl⟩)
 
-theorem up_lf_star : up ⧏ star :=
-lf_move_right punit.star
+theorem up_fuzzy_star : up ∥ star :=
+⟨lf_move_right punit.star, lf_up_iff.2 $ by simpa using or.inr up_pos.le⟩
 
 end pgame

--- a/src/set_theory/game/pgame.lean
+++ b/src/set_theory/game/pgame.lean
@@ -1349,8 +1349,32 @@ def star : pgame.{u} := ⟨punit, punit, λ _, 0, λ _, 0⟩
 instance unique_star_left_moves : unique star.left_moves := punit.unique
 instance unique_star_right_moves : unique star.right_moves := punit.unique
 
+theorem star_le_iff {x} : star ≤ x ↔ 0 ⧏ x ∧ ∀ j, star ⧏ x.move_right j :=
+by { rw le_iff_forall_lf, simp }
+
+theorem le_star_iff {x} : x ≤ star ↔ (∀ i, x.move_left i ⧏ star) ∧ x ⧏ 0 :=
+by { rw le_iff_forall_lf, simp }
+
+theorem star_lf_iff {x} : star ⧏ x ↔ (∃ i, star ≤ x.move_left i) ∨ 0 ≤ x :=
+by { rw lf_iff_forall_le, simp }
+
+theorem lf_star_iff {x} : x ⧏ star ↔ x ≤ 0 ∨ ∃ j, x.move_right j ≤ star :=
+by { rw lf_iff_forall_le, simp }
+
+theorem star_lf_zero : star ⧏ 0 :=
+star_lf_iff.2 (or.inr le_rfl)
+
+theorem zero_lf_star : 0 ⧏ star :=
+lf_star_iff.2 (or.inl le_rfl)
+
 theorem star_fuzzy_zero : star ∥ 0 :=
-⟨by { rw lf_zero, use default, rintros ⟨⟩ }, by { rw zero_lf, use default, rintros ⟨⟩ }⟩
+⟨star_lf_zero, zero_lf_star⟩
+
+theorem star_lf_of_zero_le {x} : 0 ≤ x → star ⧏ x :=
+lf_of_lf_of_le star_lf_zero
+
+theorem lf_star_of_le_zero {x} : x ≤ 0 → x ⧏ star :=
+λ h, lf_of_le_of_lf h zero_lf_star
 
 @[simp] theorem neg_star : -star = star :=
 by simp [star]
@@ -1412,7 +1436,22 @@ def up : pgame.{u} := ⟨punit, punit, 0, λ _, star⟩
 instance unique_up_left_moves : unique up.left_moves := punit.unique
 instance unique_up_right_moves : unique up.right_moves := punit.unique
 
+theorem up_le_iff {x} : up ≤ x ↔ 0 ⧏ x ∧ ∀ j, up ⧏ x.move_right j :=
+by { rw le_iff_forall_lf, simp }
+
+theorem le_up_iff {x} : x ≤ up ↔ (∀ i, x.move_left i ⧏ up) ∧ x ⧏ star :=
+by { rw le_iff_forall_lf, simp }
+
+theorem up_lf_iff {x} : up ⧏ x ↔ (∃ i, up ≤ x.move_left i) ∨ star ≤ x :=
+by { rw lf_iff_forall_le, simp }
+
+theorem lf_up_iff {x} : x ⧏ up ↔ x ≤ 0 ∨ ∃ j, x.move_right j ≤ up :=
+by { rw lf_iff_forall_le, simp }
+
 theorem up_pos : 0 < up :=
 lt_of_le_of_lf (zero_le_lf.2 (λ j, star_fuzzy_zero.gf)) (zero_lf_le.2 ⟨default, le_rfl⟩)
+
+theorem up_lf_star : up ⧏ star :=
+lf_move_right punit.star
 
 end pgame

--- a/src/set_theory/surreal/basic.lean
+++ b/src/set_theory/surreal/basic.lean
@@ -223,7 +223,7 @@ lt_of_le_of_lf
   (star_lf_of_zero_le hx.le)
 
 /-- The game `up` is smaller than all positive numeric games. -/
-theorem up_lt_numeric_pos {x} : numeric x → 0 < x → up < x :=
+theorem up_lt_of_numeric_of_pos {x} : numeric x → 0 < x → up < x :=
 begin
   apply pgame.move_rec_on x,
   exact λ x _ IH ox h, lt_of_le_of_lf

--- a/src/set_theory/surreal/basic.lean
+++ b/src/set_theory/surreal/basic.lean
@@ -217,6 +217,7 @@ begin
   simpa using λ i, IH _ (ordinal.to_left_moves_to_pgame_symm_lt i)
 end
 
+/-- The game `star` is smaller than all positive numeric games. -/
 theorem star_lt_of_numeric_of_pos {x} (ox : numeric x) (hx : 0 < x) : star < x :=
 lt_of_le_of_lf
   (star_le_iff.2 ⟨hx.lf, λ j, star_lf_zero.trans_lt $ hx.trans $ ox.lt_move_right j⟩)

--- a/src/set_theory/surreal/basic.lean
+++ b/src/set_theory/surreal/basic.lean
@@ -229,7 +229,7 @@ begin
   apply pgame.move_rec_on x,
   exact λ x _ IH ox h, lt_of_le_of_lf
     (up_le_iff.2 ⟨h.lf, λ j, (IH j (ox.move_right j) $ h.trans $ ox.lt_move_right j).lf⟩)
-    (up_lf_iff.2 $ or.inr $ (ox.star_lt_of_pos h).le)
+    (up_lf_of_star_le (ox.star_lt_of_pos h).le)
 end
 
 end pgame

--- a/src/set_theory/surreal/basic.lean
+++ b/src/set_theory/surreal/basic.lean
@@ -218,18 +218,18 @@ begin
 end
 
 /-- The game `star` is smaller than all positive numeric games. -/
-theorem star_lt_of_numeric_of_pos {x} (ox : numeric x) (hx : 0 < x) : star < x :=
+theorem numeric.star_lt_of_pos {x} (ox : numeric x) (hx : 0 < x) : star < x :=
 lt_of_le_of_lf
   (star_le_iff.2 ⟨hx.lf, λ j, star_lf_zero.trans_lt $ hx.trans $ ox.lt_move_right j⟩)
   (star_lf_of_zero_le hx.le)
 
 /-- The game `up` is smaller than all positive numeric games. -/
-theorem up_lt_of_numeric_of_pos {x} : numeric x → 0 < x → up < x :=
+theorem numeric.up_lt_of_pos {x} : numeric x → 0 < x → up < x :=
 begin
   apply pgame.move_rec_on x,
   exact λ x _ IH ox h, lt_of_le_of_lf
     (up_le_iff.2 ⟨h.lf, λ j, (IH j (ox.move_right j) $ h.trans $ ox.lt_move_right j).lf⟩)
-    (up_lf_iff.2 $ or.inr $ (star_lt_of_numeric_of_pos ox h).le)
+    (up_lf_iff.2 $ or.inr $ (ox.star_lt_of_pos h).le)
 end
 
 end pgame

--- a/src/set_theory/surreal/basic.lean
+++ b/src/set_theory/surreal/basic.lean
@@ -217,6 +217,20 @@ begin
   simpa using λ i, IH _ (ordinal.to_left_moves_to_pgame_symm_lt i)
 end
 
+theorem star_lt_of_numeric_of_pos {x} (ox : numeric x) (hx : 0 < x) : star < x :=
+lt_of_le_of_lf
+  (star_le_iff.2 ⟨hx.lf, λ j, star_lf_zero.trans_lt $ hx.trans $ ox.lt_move_right j⟩)
+  (star_lf_of_zero_le hx.le)
+
+/-- The game `up` is smaller than all positive numeric games. -/
+theorem up_lt_numeric_pos {x} : numeric x → 0 < x → up < x :=
+begin
+  apply pgame.move_rec_on x,
+  exact λ x _ IH ox h, lt_of_le_of_lf
+    (up_le_iff.2 ⟨h.lf, λ j, (IH j (ox.move_right j) $ h.trans $ ox.lt_move_right j).lf⟩)
+    (up_lf_iff.2 $ or.inr $ (star_lt_of_numeric_of_pos ox h).le)
+end
+
 end pgame
 
 /-- The equivalence on numeric pre-games. -/


### PR DESCRIPTION
We define `up = {0 | *}`. We prove that it's positive, yet smaller than any positive numeric game. To do this, we also add some extra API on `star`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
