### PR TITLE
[Merged by Bors] - feat(measure_theory/integral/circle_integral): add lemma `circle_map_nmem_ball`

### DIFF
--- a/src/data/set/basic.lean
+++ b/src/data/set/basic.lean
@@ -240,6 +240,12 @@ theorem subset.rfl {s : set α} : s ⊆ s := subset.refl s
 @[trans] theorem mem_of_eq_of_mem {x y : α} {s : set α} (hx : x = y) (h : y ∈ s) : x ∈ s :=
 hx.symm ▸ h
 
+lemma ne_of_mem_nmem {x y : α} (hx : x ∈ s) (hy : y ∉ s) : y ≠ x :=
+begin
+  contrapose! hy,
+  exact mem_of_eq_of_mem hy hx,
+end
+
 theorem subset.antisymm {a b : set α} (h₁ : a ⊆ b) (h₂ : b ⊆ a) : a = b :=
 set.ext $ λ x, ⟨@h₁ _, @h₂ _⟩
 

--- a/src/data/set/basic.lean
+++ b/src/data/set/basic.lean
@@ -240,12 +240,6 @@ theorem subset.rfl {s : set α} : s ⊆ s := subset.refl s
 @[trans] theorem mem_of_eq_of_mem {x y : α} {s : set α} (hx : x = y) (h : y ∈ s) : x ∈ s :=
 hx.symm ▸ h
 
-lemma ne_of_mem_nmem {x y : α} (hx : x ∈ s) (hy : y ∉ s) : y ≠ x :=
-begin
-  contrapose! hy,
-  exact mem_of_eq_of_mem hy hx,
-end
-
 theorem subset.antisymm {a b : set α} (h₁ : a ⊆ b) (h₂ : b ⊆ a) : a = b :=
 set.ext $ λ x, ⟨@h₁ _, @h₂ _⟩
 

--- a/src/measure_theory/integral/circle_integral.lean
+++ b/src/measure_theory/integral/circle_integral.lean
@@ -109,12 +109,12 @@ lemma circle_map_mem_closed_ball (c : ℂ) {R : ℝ} (hR : 0 ≤ R) (θ : ℝ) :
   circle_map c R θ ∈ closed_ball c R :=
 sphere_subset_closed_ball (circle_map_mem_sphere c hR θ)
 
-lemma circle_map_nmem_ball (c : ℂ) (R : ℝ) (θ : ℝ) : circle_map c R θ ∉ ball c R :=
+lemma circle_map_not_mem_ball (c : ℂ) (R : ℝ) (θ : ℝ) : circle_map c R θ ∉ ball c R :=
 by simp [dist_eq, le_abs_self]
 
 lemma circle_map_ne_mem_ball {c : ℂ} {R : ℝ} {w : ℂ} (hw : w ∈ ball c R) (θ : ℝ) :
   circle_map c R θ ≠ w :=
-(ne_of_mem_of_not_mem hw (circle_map_nmem_ball _ _ _)).symm
+(ne_of_mem_of_not_mem hw (circle_map_not_mem_ball _ _ _)).symm
 
 /-- The range of `circle_map c R` is the circle with center `c` and radius `|R|`. -/
 @[simp] lemma range_circle_map (c : ℂ) (R : ℝ) : range (circle_map c R) = sphere c (|R|) :=

--- a/src/measure_theory/integral/circle_integral.lean
+++ b/src/measure_theory/integral/circle_integral.lean
@@ -109,12 +109,12 @@ lemma circle_map_mem_closed_ball (c : ℂ) {R : ℝ} (hR : 0 ≤ R) (θ : ℝ) :
   circle_map c R θ ∈ closed_ball c R :=
 sphere_subset_closed_ball (circle_map_mem_sphere c hR θ)
 
-lemma circle_map_nmem_ball (c : ℂ) {R : ℝ} (hR : 0 ≤ R) (θ : ℝ) : circle_map c R θ ∉ ball c R :=
-begin
-  replace hR := circle_map_mem_sphere c hR θ,
-  simp only [mem_ball, mem_sphere] at hR ⊢,
-  linarith,
-end
+lemma circle_map_nmem_ball (c : ℂ) (R : ℝ) (θ : ℝ) : circle_map c R θ ∉ ball c R :=
+by simp [dist_eq, le_abs_self]
+
+lemma circle_map_ne_mem_ball {c : ℂ} {R : ℝ} {w : ℂ} (hw : w ∈ ball c R) (θ : ℝ) :
+  circle_map c R θ ≠ w :=
+(ne_of_mem_of_not_mem hw (circle_map_nmem_ball _ _ _)).symm
 
 /-- The range of `circle_map c R` is the circle with center `c` and radius `|R|`. -/
 @[simp] lemma range_circle_map (c : ℂ) (R : ℝ) : range (circle_map c R) = sphere c (|R|) :=

--- a/src/measure_theory/integral/circle_integral.lean
+++ b/src/measure_theory/integral/circle_integral.lean
@@ -109,6 +109,13 @@ lemma circle_map_mem_closed_ball (c : ℂ) {R : ℝ} (hR : 0 ≤ R) (θ : ℝ) :
   circle_map c R θ ∈ closed_ball c R :=
 sphere_subset_closed_ball (circle_map_mem_sphere c hR θ)
 
+lemma circle_map_nmem_ball (c : ℂ) {R : ℝ} (hR : 0 ≤ R) (θ : ℝ) : circle_map c R θ ∉ ball c R :=
+begin
+  replace hR := circle_map_mem_sphere c hR θ,
+  simp only [mem_ball, mem_sphere] at hR ⊢,
+  linarith,
+end
+
 /-- The range of `circle_map c R` is the circle with center `c` and radius `|R|`. -/
 @[simp] lemma range_circle_map (c : ℂ) (R : ℝ) : range (circle_map c R) = sphere c (|R|) :=
 calc range (circle_map c R) = c +ᵥ R • range (λ θ : ℝ, exp (θ * I)) :


### PR DESCRIPTION
The lemma `set.ne_of_mem_nmem` is unrelated except that both of these should be helpful for:
https://github.com/leanprover-community/mathlib/pull/13885



---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
