### PR TITLE
[Merged by Bors] - feat(data/fintype/basic): add `card_subtype_mono`

### DIFF
--- a/src/data/fintype/basic.lean
+++ b/src/data/fintype/basic.lean
@@ -1456,6 +1456,11 @@ begin
   intro; simp only [set.mem_to_finset, set.mem_compl_eq]; refl,
 end
 
+theorem card_subtype_le_of_imp (p q : α → Prop) (h : p ≤ q)
+  [fintype {x // p x}] [fintype {x // q x}] :
+  fintype.card {x // p x} ≤ fintype.card {x // q x} :=
+fintype.card_le_of_embedding (subtype.imp_embedding _ _ h)
+
 /-- If two subtypes of a fintype have equal cardinality, so do their complements. -/
 lemma fintype.card_compl_eq_card_compl [fintype α]
   (p q : α → Prop)

--- a/src/data/fintype/basic.lean
+++ b/src/data/fintype/basic.lean
@@ -1456,7 +1456,7 @@ begin
   intro; simp only [set.mem_to_finset, set.mem_compl_eq]; refl,
 end
 
-theorem card_subtype_le_of_imp (p q : α → Prop) (h : p ≤ q)
+theorem card_subtype_mono (p q : α → Prop) (h : p ≤ q)
   [fintype {x // p x}] [fintype {x // q x}] :
   fintype.card {x // p x} ≤ fintype.card {x // q x} :=
 fintype.card_le_of_embedding (subtype.imp_embedding _ _ h)


### PR DESCRIPTION
This lemma naturally forms a counterpart to existing lemmas.

I've also renamed a lemma it uses that didn't seem to fit the existing naming pattern.

---

We were missing this which was a fairly straightforward lemma, so I added it (and edited a lemma name that looked misnamed).
