### PR TITLE
[Merged by Bors] - chore(ring_theory/unique_factorization_domain): drop simp annotation for factors_pow

### DIFF
--- a/src/ring_theory/unique_factorization_domain.lean
+++ b/src/ring_theory/unique_factorization_domain.lean
@@ -461,7 +461,7 @@ begin
   exact (associated.mul_mul (factors_prod hx) (factors_prod hy)).symm,
 end
 
-@[simp] lemma factors_pow {x : α} (n : ℕ) :
+lemma factors_pow {x : α} (n : ℕ) :
   multiset.rel associated (factors (x ^ n)) (n • factors x) :=
 begin
   induction n with n ih,


### PR DESCRIPTION
Followup to https://github.com/leanprover-community/mathlib/pull/14555.



---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
