### PR TITLE
[Merged by Bors] - refactor(data/option/defs): Swap arguments to `option.elim`

### DIFF
--- a/src/algebra/big_operators/option.lean
+++ b/src/algebra/big_operators/option.lean
@@ -26,11 +26,11 @@ variables {α M : Type*} [comm_monoid M]
 by simp [insert_none]
 
 @[to_additive] lemma prod_erase_none (f : α → M) (s : finset (option α)) :
-  ∏ x in s.erase_none, f x = ∏ x in s, option.elim x 1 f :=
+  ∏ x in s.erase_none, f x = ∏ x in s, option.elim 1 f x :=
 by classical;
-calc ∏ x in s.erase_none, f x = ∏ x in s.erase_none.map embedding.some, option.elim x 1 f :
-  (prod_map s.erase_none embedding.some (λ x, option.elim x 1 f)).symm
-... = ∏ x in s.erase none, option.elim x 1 f : by rw map_some_erase_none
-... = ∏ x in s, option.elim x 1 f : prod_erase _ rfl
+calc ∏ x in s.erase_none, f x = ∏ x in s.erase_none.map embedding.some, option.elim 1 f x :
+  (prod_map s.erase_none embedding.some $ option.elim 1 f).symm
+... = ∏ x in s.erase none, option.elim 1 f x : by rw map_some_erase_none
+... = ∏ x in s, option.elim 1 f x : prod_erase _ rfl
 
 end finset

--- a/src/analysis/box_integral/partition/basic.lean
+++ b/src/analysis/box_integral/partition/basic.lean
@@ -376,7 +376,7 @@ lemma sum_of_with_bot {M : Type*} [add_comm_monoid M]
   (pairwise_disjoint : set.pairwise (boxes : set (with_bot (box ι))) disjoint)
   (f : box ι → M) :
   ∑ J in (of_with_bot boxes le_of_mem pairwise_disjoint).boxes, f J =
-    ∑ J in boxes, option.elim J 0 f :=
+    ∑ J in boxes, option.elim 0 f J :=
 finset.sum_erase_none _ _
 
 /-- Restrict a prepartition to a box. -/

--- a/src/analysis/calculus/lagrange_multipliers.lean
+++ b/src/analysis/calculus/lagrange_multipliers.lean
@@ -138,11 +138,11 @@ lemma is_local_extr_on.linear_dependent_of_has_strict_fderiv_at {ι : Type*} [fi
   (hextr : is_local_extr_on φ {x | ∀ i, f i x = f i x₀} x₀)
   (hf' : ∀ i, has_strict_fderiv_at (f i) (f' i) x₀)
   (hφ' : has_strict_fderiv_at φ φ' x₀) :
-  ¬linear_independent ℝ (λ i, option.elim i φ' f' : option ι → E →L[ℝ] ℝ) :=
+  ¬linear_independent ℝ (option.elim φ' f' : option ι → E →L[ℝ] ℝ) :=
 begin
   rw [fintype.linear_independent_iff], push_neg,
   rcases hextr.exists_multipliers_of_has_strict_fderiv_at hf' hφ' with ⟨Λ, Λ₀, hΛ, hΛf⟩,
-  refine ⟨λ i, option.elim i Λ₀ Λ, _, _⟩,
+  refine ⟨option.elim Λ₀ Λ, _, _⟩,
   { simpa [add_comm] using hΛf },
   { simpa [function.funext_iff, not_and_distrib, or_comm, option.exists] using hΛ }
 end

--- a/src/category_theory/category/PartialFun.lean
+++ b/src/category_theory/category/PartialFun.lean
@@ -72,7 +72,7 @@ instance : faithful Type_to_PartialFun := ⟨λ X Y, pfun.coe_injective⟩
 
 /-- The functor which deletes the point of a pointed type. In return, this makes the maps partial.
 This the computable part of the equivalence `PartialFun_equiv_Pointed`. -/
-def Pointed_to_PartialFun : Pointed.{u} ⥤ PartialFun :=
+@[simps map] def Pointed_to_PartialFun : Pointed.{u} ⥤ PartialFun :=
 { obj := λ X, {x : X // x ≠ X.point},
   map := λ X Y f, pfun.to_subtype _ f.to_fun ∘ subtype.val,
   map_id' := λ X, pfun.ext $ λ a b,
@@ -89,10 +89,10 @@ def Pointed_to_PartialFun : Pointed.{u} ⥤ PartialFun :=
 /-- The functor which maps undefined values to a new point. This makes the maps total and creates
 pointed types. This the noncomputable part of the equivalence `PartialFun_equiv_Pointed`. It can't
 be computable because `= option.none` is decidable while the domain of a general `part` isn't. -/
-noncomputable def PartialFun_to_Pointed : PartialFun ⥤ Pointed :=
+@[simps map] noncomputable def PartialFun_to_Pointed : PartialFun ⥤ Pointed :=
 by classical; exact
 { obj := λ X, ⟨option X, none⟩,
-  map := λ X Y f, ⟨λ o, o.elim none (λ a, (f a).to_option), rfl⟩,
+  map := λ X Y f, ⟨option.elim none (λ a, (f a).to_option), rfl⟩,
   map_id' := λ X, Pointed.hom.ext _ _ $ funext $ λ o,
     option.rec_on o rfl $ λ a, part.some_to_option _,
   map_comp' := λ X Y Z f g, Pointed.hom.ext _ _ $ funext $ λ o, option.rec_on o rfl $ λ a,
@@ -121,7 +121,7 @@ equivalence.mk PartialFun_to_Pointed Pointed_to_PartialFun
         exact eq_comm,
       end)
   (nat_iso.of_components (λ X, Pointed.iso.mk
-    { to_fun := λ a, a.elim X.point subtype.val,
+    { to_fun := option.elim X.point subtype.val,
       inv_fun := λ a, if h : a = X.point then none else some ⟨_, h⟩,
       left_inv := λ a, option.rec_on a (dif_pos rfl) $ λ a, (dif_neg a.2).trans $
         by simp only [option.elim, subtype.val_eq_coe, subtype.coe_eta],
@@ -132,8 +132,10 @@ equivalence.mk PartialFun_to_Pointed Pointed_to_PartialFun
         { refl }
       end } rfl) $ λ X Y f, Pointed.hom.ext _ _ $ funext $ λ a, option.rec_on a f.map_point.symm $
     λ a, begin
-      change option.elim _ _ (option.elim _ _ _) = _,
-      rw [option.elim, part.elim_to_option],
+      unfold_projs,
+      dsimp,
+      change option.elim _ _ _ = _,
+      rw part.elim_to_option,
       split_ifs,
       { refl },
       { exact eq.symm (of_not_not h) }

--- a/src/category_theory/category/PartialFun.lean
+++ b/src/category_theory/category/PartialFun.lean
@@ -126,13 +126,13 @@ equivalence.mk PartialFun_to_Pointed Pointed_to_PartialFun
       left_inv := λ a, option.rec_on a (dif_pos rfl) $ λ a, (dif_neg a.2).trans $
         by simp only [option.elim, subtype.val_eq_coe, subtype.coe_eta],
       right_inv := λ a, begin
-        change option.elim (dite _ _ _) _ _ = _,
+        change option.elim _ _ (dite _ _ _) = _,
         split_ifs,
         { rw h, refl },
         { refl }
       end } rfl) $ λ X Y f, Pointed.hom.ext _ _ $ funext $ λ a, option.rec_on a f.map_point.symm $
     λ a, begin
-      change option.elim (option.elim _ _ _) _ _ = _,
+      change option.elim _ _ (option.elim _ _ _) = _,
       rw [option.elim, part.elim_to_option],
       split_ifs,
       { refl },

--- a/src/computability/tm_to_partrec.lean
+++ b/src/computability/tm_to_partrec.lean
@@ -1005,7 +1005,7 @@ def split_at_pred {α} (p : α → bool) : list α → list α × option α × l
 
 theorem split_at_pred_eq {α} (p : α → bool) : ∀ L l₁ o l₂,
   (∀ x ∈ l₁, p x = ff) →
-  option.elim o (L = l₁ ∧ l₂ = []) (λ a, p a = tt ∧ L = l₁ ++ a :: l₂) →
+  option.elim (L = l₁ ∧ l₂ = []) (λ a, p a = tt ∧ L = l₁ ++ a :: l₂) o →
   split_at_pred p L = (l₁, o, l₂)
 | [] _ none _ _ ⟨rfl, rfl⟩ := rfl
 | [] l₁ (some o) l₂ h₁ ⟨h₂, h₃⟩ := by simp at h₃; contradiction

--- a/src/data/finset/basic.lean
+++ b/src/data/finset/basic.lean
@@ -2592,7 +2592,7 @@ def sigma_equiv_option_of_inhabited (α : Type u) [inhabited α] [decidable_eq �
   Σ (β : Type u), α ≃ option β :=
 ⟨{x : α // x ≠ default},
 { to_fun := λ (x : α), if h : x = default then none else some ⟨x, h⟩,
-  inv_fun := λ o, option.elim o default coe,
+  inv_fun := option.elim default coe,
   left_inv := λ x, by { dsimp only, split_ifs; simp [*] },
   right_inv := begin
     rintro (_|⟨x,h⟩),

--- a/src/data/mv_polynomial/variables.lean
+++ b/src/data/mv_polynomial/variables.lean
@@ -770,7 +770,7 @@ lemma exists_rename_eq_of_vars_subset_range
   (p : mv_polynomial σ R) (f : τ → σ)
   (hfi : injective f) (hf : ↑p.vars ⊆ set.range f) :
   ∃ q : mv_polynomial τ R, rename f q = p :=
-⟨bind₁ (λ i : σ, option.elim (partial_inv f i) 0 X) p,
+⟨bind₁ (λ i : σ, option.elim 0 X $ partial_inv f i) p,
   begin
     show (rename f).to_ring_hom.comp _ p = ring_hom.id _ p,
     refine hom_congr_vars _ _ _,

--- a/src/data/option/basic.lean
+++ b/src/data/option/basic.lean
@@ -490,11 +490,7 @@ rfl
 @[simp] lemma to_list_none (α : Type*) : (none : option α).to_list = [] :=
 rfl
 
---TODO: Swap arguments to `option.elim` so that it is exactly `option.cons`
-/-- Functions from `option` can be combined similarly to `vector.cons`. -/
-def cons (a : β) (f : α → β) : option α → β := λ o, o.elim a f
-
-@[simp] lemma cons_none_some (f : option α → β) : cons (f none) (f ∘ some) = f :=
+@[simp] lemma elim_none_some (f : option α → β) : option.elim (f none) (f ∘ some) = f :=
 funext $ λ o, by cases o; refl
 
 end option

--- a/src/data/option/defs.lean
+++ b/src/data/option/defs.lean
@@ -18,10 +18,8 @@ variables {α : Type*} {β : Type*}
 
 attribute [inline] option.is_some option.is_none
 
-/-- An elimination principle for `option`. It is a nondependent version of `option.rec_on`. -/
-@[simp] protected def elim : option α → β → (α → β) → β
-| (some x) y f := f x
-| none     y f := y
+/-- An elimination principle for `option`. It is a nondependent version of `option.rec`. -/
+@[simp] protected def elim : β → (α → β) → option α → β := @option.rec α (λ _, β)
 
 instance has_mem : has_mem α (option α) := ⟨λ a b, b = some a⟩
 
@@ -161,12 +159,12 @@ def {u v w} mmap {m : Type u → Type v} [monad m] {α : Type w} {β : Type u} (
   (o : option α) : m (option β) := (o.map f).maybe
 
 /-- A monadic analogue of `option.elim`. -/
-def melim {α β : Type*} {m : Type* → Type*} [monad m] (x : m (option α)) (y : m β) (z : α → m β) :
+def melim {α β : Type*} {m : Type* → Type*} [monad m] (y : m β) (z : α → m β) (x : m (option α)) :
   m β :=
-x >>= λ o, option.elim o y z
+x >>= option.elim y z
 
 /-- A monadic analogue of `option.get_or_else`. -/
 def mget_or_else {α : Type*} {m : Type* → Type*} [monad m] (x : m (option α)) (y : m α) : m α :=
-melim x y pure
+melim y pure x
 
 end option

--- a/src/data/option/defs.lean
+++ b/src/data/option/defs.lean
@@ -19,7 +19,9 @@ variables {α : Type*} {β : Type*}
 attribute [inline] option.is_some option.is_none
 
 /-- An elimination principle for `option`. It is a nondependent version of `option.rec`. -/
-@[simp] protected def elim : β → (α → β) → option α → β := @option.rec α (λ _, β)
+@[simp] protected def elim (b : β) (f : α → β) : option α → β
+| (some a) := f a
+| none     := b
 
 instance has_mem : has_mem α (option α) := ⟨λ a b, b = some a⟩
 

--- a/src/logic/embedding.lean
+++ b/src/logic/embedding.lean
@@ -173,7 +173,7 @@ def coe_with_top {α} : α ↪ with_top α := { to_fun := coe, ..embedding.some}
 `option α ↪ β`. -/
 @[simps] def option_elim {α β} (f : α ↪ β) (x : β) (h : x ∉ set.range f) :
   option α ↪ β :=
-⟨λ o, o.elim x f, option.injective_iff.2 ⟨f.2, h⟩⟩
+⟨option.elim x f, option.injective_iff.2 ⟨f.2, h⟩⟩
 
 /-- Equivalence between embeddings of `option α` and a sigma type over the embeddings of `α`. -/
 @[simps]

--- a/src/measure_theory/measure/outer_measure.lean
+++ b/src/measure_theory/measure/outer_measure.lean
@@ -1414,7 +1414,7 @@ lemma trim_supr {ι} [encodable ι] (μ : ι → outer_measure α) :
   trim (⨆ i, μ i) = ⨆ i, trim (μ i) :=
 begin
   ext1 s,
-  rcases exists_measurable_superset_forall_eq_trim (λ o, option.elim o (supr μ) μ) s
+  rcases exists_measurable_superset_forall_eq_trim (option.elim (supr μ) μ) s
     with ⟨t, hst, ht, hμt⟩,
   simp only [option.forall, option.elim] at hμt,
   simp only [supr_apply, ← hμt.1, ← hμt.2]

--- a/src/number_theory/dioph.lean
+++ b/src/number_theory/dioph.lean
@@ -51,7 +51,7 @@ Matiyasevic's theorem, Hilbert's tenth problem
 
 open fin2 function nat sum
 
-local infixr ` ::ₒ `:67 := option.cons
+local infixr ` ::ₒ `:67 := option.elim
 local infixr ` ⊗ `:65 := sum.elim
 
 universe u
@@ -349,7 +349,7 @@ ext (dioph_fn_comp1 (reindex_dioph _ (none :: some) d) df) $ λ v,
 theorem vec_ex1_dioph (n) {S : set (vector3 ℕ (succ n))} (d : dioph S) :
   dioph {v : fin2 n → ℕ | ∃ x, x :: v ∈ S} :=
 ext (ex1_dioph $ reindex_dioph _ (none :: some) d) $ λ v, exists_congr $ λ x, by { dsimp,
-  rw [show (option.cons x v) ∘ (cons none some) = x :: v,
+  rw [show option.elim x v ∘ cons none some = x :: v,
   from funext $ λ s, by cases s with a b; refl] }
 
 lemma dioph_fn_vec (f : vector3 ℕ n → ℕ) : dioph_fn f ↔ dioph {v | f (v ∘ fs) = v fz} :=

--- a/src/tactic/linarith/frontend.lean
+++ b/src/tactic/linarith/frontend.lean
@@ -257,7 +257,7 @@ do hyps ← hyps.mmap $ λ e, i_to_expr e >>= note_anon none,
      else fail "linarith failed: target is not a valid comparison",
    let cfg := cfg.update_reducibility reduce_semi,
    let (pref_type, new_var) :=
-     pref_type_and_new_var_from_tgt.elim (none, none) (λ ⟨a, b⟩, (some a, some b)),
+     pref_type_and_new_var_from_tgt.elim (none, none) (prod.map some some),
    -- set up the list of hypotheses, considering the `only_on` and `restrict_type` options
    hyps ← if only_on then return (new_var.elim [] singleton ++ hyps)
           else (++ hyps) <$> local_context,

--- a/src/topology/paracompact.lean
+++ b/src/topology/paracompact.lean
@@ -95,7 +95,7 @@ lemma precise_refinement_set [paracompact_space X] {s : set X} (hs : is_closed s
   (u : ι → set X) (uo : ∀ i, is_open (u i)) (us : s ⊆ ⋃ i, u i) :
   ∃ v : ι → set X, (∀ i, is_open (v i)) ∧ (s ⊆ ⋃ i, v i) ∧ locally_finite v ∧ (∀ i, v i ⊆ u i) :=
 begin
-  rcases precise_refinement (λ i, option.elim i sᶜ u)
+  rcases precise_refinement (option.elim sᶜ u)
     (option.forall.2 ⟨is_open_compl_iff.2 hs, uo⟩) _ with ⟨v, vo, vc, vf, vu⟩,
   refine ⟨v ∘ some, λ i, vo _, _, vf.comp_injective (option.some_injective _), λ i, vu _⟩,
   { simp only [Union_option, ← compl_subset_iff_union] at vc,


### PR DESCRIPTION
Make `option.elim` a non-dependent version of `option.rec` rather than a non-dependent version of `option.rec_on`. Same for `option.melim`.

This replaces `option.cons`, and brings `option.elim` in line with `nat.elim`, `sum.elim`, and `iff.elim`.
It addresses the TODO comment added in 22c4291217925c6957c0f5a44551c9917b56c7cf.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[Zulip](https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/option.2Eelim)

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
