### PR TITLE
[Merged by Bors] - feat(linear_algebra/vandermonde): add lemmas about det equals zero

### DIFF
--- a/src/linear_algebra/vandermonde.lean
+++ b/src/linear_algebra/vandermonde.lean
@@ -122,7 +122,7 @@ begin
       exact nat.lt_succ_iff.mp (finset.mem_range.mp hi') } }
 end
 
-lemma det_vandermonde_eq_zero_iff [is_domain R] {n : ℕ} (v : fin n → R) :
+lemma det_vandermonde_eq_zero_iff [is_domain R] {n : ℕ} {v : fin n → R} :
   det (vandermonde v) = 0 ↔ ∃ (i j : fin n), v i = v j ∧ i ≠ j :=
 begin
   split,

--- a/src/linear_algebra/vandermonde.lean
+++ b/src/linear_algebra/vandermonde.lean
@@ -129,8 +129,8 @@ begin
   { simp only [det_vandermonde v, finset.prod_eq_zero_iff, sub_eq_zero, forall_exists_index],
     exact λ i _ j h₁ h₂, ⟨j, i, h₂, (finset.mem_filter.mp h₁).2.ne'⟩ },
   { simp only [ne.def, forall_exists_index, and_imp],
-    exact λ i j h₁ h₂, matrix.det_zero_of_row_eq h₂
-      (funext (λ k, (by simp only [vandermonde_apply, h₁]))) }
+    refine λ i j h₁ h₂, matrix.det_zero_of_row_eq h₂ (funext $ λ k, _),
+    rw [vandermonde_apply, vandermonde_apply, h₁], }
 end
 
 lemma det_vandermonde_ne_zero_iff [is_domain R] {n : ℕ} (v : fin n → R) :

--- a/src/linear_algebra/vandermonde.lean
+++ b/src/linear_algebra/vandermonde.lean
@@ -122,4 +122,19 @@ begin
       exact nat.lt_succ_iff.mp (finset.mem_range.mp hi') } }
 end
 
+lemma det_vandermonde_eq_zero_iff [is_domain R] {n : ℕ} (v : fin n → R) :
+  det (vandermonde v) = 0 ↔ ∃ (i j : fin n), v i = v j ∧ i ≠ j :=
+begin
+  split,
+  { simp only [det_vandermonde v, finset.prod_eq_zero_iff, sub_eq_zero, forall_exists_index],
+    exact λ i _ j h₁ h₂, ⟨j, i, h₂, (finset.mem_filter.mp h₁).2.ne'⟩ },
+  { simp only [ne.def, forall_exists_index, and_imp],
+    exact λ i j h₁ h₂, matrix.det_zero_of_row_eq h₂
+      (funext (λ k, (by simp only [vandermonde_apply, h₁]))) }
+end
+
+lemma det_vandermonde_ne_zero_iff [is_domain R] {n : ℕ} (v : fin n → R) :
+  det (vandermonde v) ≠ 0 ↔ function.injective v :=
+by simpa only [det_vandermonde_eq_zero_iff, ne.def, not_exists, not_and, not_not]
+
 end matrix

--- a/src/linear_algebra/vandermonde.lean
+++ b/src/linear_algebra/vandermonde.lean
@@ -133,7 +133,7 @@ begin
     rw [vandermonde_apply, vandermonde_apply, h₁], }
 end
 
-lemma det_vandermonde_ne_zero_iff [is_domain R] {n : ℕ} (v : fin n → R) :
+lemma det_vandermonde_ne_zero_iff [is_domain R] {n : ℕ} {v : fin n → R} :
   det (vandermonde v) ≠ 0 ↔ function.injective v :=
 by simpa only [det_vandermonde_eq_zero_iff, ne.def, not_exists, not_and, not_not]
 


### PR DESCRIPTION
Adding two lemmas about when the determinant is zero.
I shortened the first with the help of some code I found in `ring_theory/trace.lean`, lemma `det_trace_matrix_ne_zero'`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
