### PR TITLE
[Merged by Bors] - chore(analysis/convex/extreme): Make arguments semi-implicit

### DIFF
--- a/src/analysis/convex/extreme.lean
+++ b/src/analysis/convex/extreme.lean
@@ -35,6 +35,8 @@ See chapter 8 of [Barry Simon, *Convexity*][simon2011]
 
 ## TODO
 
+Define intrinsic frontier and prove lemmas related to extreme sets and points.
+
 More not-yet-PRed stuff is available on the branch `sperner_again`.
 -/
 

--- a/src/analysis/convex/extreme.lean
+++ b/src/analysis/convex/extreme.lean
@@ -35,8 +35,6 @@ See chapter 8 of [Barry Simon, *Convexity*][simon2011]
 
 ## TODO
 
-Define intrinsic frontier and prove lemmas related to extreme sets and points.
-
 More not-yet-PRed stuff is available on the branch `sperner_again`.
 -/
 
@@ -51,12 +49,12 @@ variables [ordered_semiring 𝕜] [add_comm_monoid E] [has_scalar 𝕜 E]
 /-- A set `B` is an extreme subset of `A` if `B ⊆ A` and all points of `B` only belong to open
 segments whose ends are in `B`. -/
 def is_extreme (A B : set E) : Prop :=
-B ⊆ A ∧ ∀ x₁ x₂ ∈ A, ∀ x ∈ B, x ∈ open_segment 𝕜 x₁ x₂ → x₁ ∈ B ∧ x₂ ∈ B
+B ⊆ A ∧ ∀ ⦃x₁⦄, x₁ ∈ A → ∀ ⦃x₂⦄, x₂ ∈ A → ∀ ⦃x⦄, x ∈ B → x ∈ open_segment 𝕜 x₁ x₂ → x₁ ∈ B ∧ x₂ ∈ B
 
 /-- A point `x` is an extreme point of a set `A` if `x` belongs to no open segment with ends in
 `A`, except for the obvious `open_segment x x`. -/
 def set.extreme_points (A : set E) : set E :=
-{x ∈ A | ∀ (x₁ x₂ ∈ A), x ∈ open_segment 𝕜 x₁ x₂ → x₁ = x ∧ x₂ = x}
+{x ∈ A | ∀ ⦃x₁⦄, x₁ ∈ A → ∀ ⦃x₂⦄, x₂ ∈ A → x ∈ open_segment 𝕜 x₁ x₂ → x₁ = x ∧ x₂ = x}
 
 @[refl] protected lemma is_extreme.refl (A : set E) :
   is_extreme 𝕜 A A :=
@@ -72,8 +70,8 @@ is_extreme.refl 𝕜 A
   is_extreme 𝕜 A C :=
 begin
   refine ⟨subset.trans hBC.1 hAB.1, λ x₁ hx₁A x₂ hx₂A x hxC hx, _⟩,
-  obtain ⟨hx₁B, hx₂B⟩ := hAB.2 x₁ hx₁A x₂ hx₂A x (hBC.1 hxC) hx,
-  exact hBC.2 x₁ hx₁B x₂ hx₂B x hxC hx,
+  obtain ⟨hx₁B, hx₂B⟩ := hAB.2 hx₁A hx₂A (hBC.1 hxC) hx,
+  exact hBC.2 hx₁B hx₂B hxC hx,
 end
 
 protected lemma is_extreme.antisymm :
@@ -89,25 +87,24 @@ lemma is_extreme.inter (hAB : is_extreme 𝕜 A B) (hAC : is_extreme 𝕜 A C) :
   is_extreme 𝕜 A (B ∩ C) :=
 begin
   use subset.trans (inter_subset_left _ _) hAB.1,
-  rintro x₁ x₂ hx₁A hx₂A x ⟨hxB, hxC⟩ hx,
-  obtain ⟨hx₁B, hx₂B⟩ := hAB.2 x₁ x₂ hx₁A hx₂A x hxB hx,
-  obtain ⟨hx₁C, hx₂C⟩ := hAC.2 x₁ x₂ hx₁A hx₂A x hxC hx,
+  rintro x₁ hx₁A x₂ hx₂A x ⟨hxB, hxC⟩ hx,
+  obtain ⟨hx₁B, hx₂B⟩ := hAB.2 hx₁A hx₂A hxB hx,
+  obtain ⟨hx₁C, hx₂C⟩ := hAC.2 hx₁A hx₂A hxC hx,
   exact ⟨⟨hx₁B, hx₁C⟩, hx₂B, hx₂C⟩,
 end
 
 protected lemma is_extreme.mono (hAC : is_extreme 𝕜 A C) (hBA : B ⊆ A) (hCB : C ⊆ B) :
   is_extreme 𝕜 B C :=
-⟨hCB, λ x₁ hx₁B x₂ hx₂B x hxC hx, hAC.2 x₁ (hBA hx₁B) x₂ (hBA hx₂B) x hxC hx⟩
+⟨hCB, λ x₁ hx₁B x₂ hx₂B x hxC hx, hAC.2 (hBA hx₁B) (hBA hx₂B) hxC hx⟩
 
 lemma is_extreme_Inter {ι : Type*} [nonempty ι] {F : ι → set E}
   (hAF : ∀ i : ι, is_extreme 𝕜 A (F i)) :
   is_extreme 𝕜 A (⋂ i : ι, F i) :=
 begin
   obtain i := classical.arbitrary ι,
-  use Inter_subset_of_subset i (hAF i).1,
-  rintro x₁ x₂ hx₁A hx₂A x hxF hx,
+  refine ⟨Inter_subset_of_subset i (hAF i).1, λ x₁ hx₁A x₂ hx₂A x hxF hx, _⟩,
   simp_rw mem_Inter at ⊢ hxF,
-  have h := λ i, (hAF i).2 x₁ x₂ hx₁A hx₂A x (hxF i) hx,
+  have h := λ i, (hAF i).2 hx₁A hx₂A (hxF i) hx,
   exact ⟨λ i, (h i).1, λ i, (h i).2⟩,
 end
 
@@ -116,9 +113,9 @@ lemma is_extreme_bInter {F : set (set E)} (hF : F.nonempty)
   is_extreme 𝕜 A (⋂ B ∈ F, B) :=
 begin
   obtain ⟨B, hB⟩ := hF,
-  refine ⟨(bInter_subset_of_mem hB).trans (hAF B hB).1, λ x₁ x₂ hx₁A hx₂A x hxF hx, _⟩,
+  refine ⟨(bInter_subset_of_mem hB).trans (hAF B hB).1, λ x₁ hx₁A x₂ hx₂A x hxF hx, _⟩,
   simp_rw mem_Inter₂ at ⊢ hxF,
-  have h := λ B hB, (hAF B hB).2 x₁ x₂ hx₁A hx₂A x (hxF B hB) hx,
+  have h := λ B hB, (hAF B hB).2 hx₁A hx₂A (hxF B hB) hx,
   exact ⟨λ B hB, (h B hB).1, λ B hB, (h B hB).2⟩,
 end
 
@@ -127,9 +124,9 @@ lemma is_extreme_sInter {F : set (set E)} (hF : F.nonempty)
   is_extreme 𝕜 A (⋂₀ F) :=
 begin
   obtain ⟨B, hB⟩ := hF,
-  refine ⟨(sInter_subset_of_mem hB).trans (hAF B hB).1, λ x₁ x₂ hx₁A hx₂A x hxF hx, _⟩,
+  refine ⟨(sInter_subset_of_mem hB).trans (hAF B hB).1, λ x₁ hx₁A x₂ hx₂A x hxF hx, _⟩,
   simp_rw mem_sInter at ⊢ hxF,
-  have h := λ B hB, (hAF B hB).2 x₁ x₂ hx₁A hx₂A x (hxF B hB) hx,
+  have h := λ B hB, (hAF B hB).2 hx₁A hx₂A (hxF B hB) hx,
   exact ⟨λ B hB, (h B hB).1, λ B hB, (h B hB).2⟩,
 end
 
@@ -141,11 +138,11 @@ iff.rfl
 lemma mem_extreme_points_iff_extreme_singleton :
   x ∈ A.extreme_points 𝕜 ↔ is_extreme 𝕜 A {x} :=
 begin
-  refine ⟨_, λ hx, ⟨singleton_subset_iff.1 hx.1, λ x₁ x₂ hx₁ hx₂, hx.2 x₁ x₂ hx₁ hx₂ x rfl⟩⟩,
+  refine ⟨_, λ hx, ⟨singleton_subset_iff.1 hx.1, λ x₁ hx₁ x₂ hx₂, hx.2 hx₁ hx₂ rfl⟩⟩,
   rintro ⟨hxA, hAx⟩,
   use singleton_subset_iff.2 hxA,
-  rintro x₁ x₂ hx₁A hx₂A y (rfl : y = x),
-  exact hAx x₁ x₂ hx₁A hx₂A,
+  rintro x₁ hx₁A x₂ hx₂A y (rfl : y = x),
+  exact hAx hx₁A hx₂A,
 end
 
 lemma extreme_points_subset : A.extreme_points 𝕜 ⊆ A := λ x hx, hx.1
@@ -161,7 +158,7 @@ extreme_points_subset.antisymm $ singleton_subset_iff.2
 
 lemma inter_extreme_points_subset_extreme_points_of_subset (hBA : B ⊆ A) :
   B ∩ A.extreme_points 𝕜 ⊆ B.extreme_points 𝕜 :=
-λ x ⟨hxB, hxA⟩, ⟨hxB, λ x₁ hx₁ x₂ hx₂ hx, hxA.2 x₁ (hBA hx₁) x₂ (hBA hx₂) hx⟩
+λ x ⟨hxB, hxA⟩, ⟨hxB, λ x₁ hx₁ x₂ hx₂ hx, hxA.2 (hBA hx₁) (hBA hx₂) hx⟩
 
 lemma is_extreme.extreme_points_subset_extreme_points (hAB : is_extreme 𝕜 A B) :
   B.extreme_points 𝕜 ⊆ A.extreme_points 𝕜 :=
@@ -181,7 +178,7 @@ variables {𝕜} [ordered_semiring 𝕜] [add_comm_group E] [module 𝕜 E] {A B
 lemma is_extreme.convex_diff (hA : convex 𝕜 A) (hAB : is_extreme 𝕜 A B) :
   convex 𝕜 (A \ B) :=
 convex_iff_open_segment_subset.2 (λ x₁ x₂ ⟨hx₁A, hx₁B⟩ ⟨hx₂A, hx₂B⟩ x hx,
-    ⟨hA.open_segment_subset hx₁A hx₂A hx, λ hxB, hx₁B (hAB.2 x₁ hx₁A x₂ hx₂A x hxB hx).1⟩)
+    ⟨hA.open_segment_subset hx₁A hx₂A hx, λ hxB, hx₁B (hAB.2 hx₁A hx₂A hxB hx).1⟩)
 
 end ordered_semiring
 


### PR DESCRIPTION
Change the definition of `is_extreme` from
```
B ⊆ A ∧ ∀ x₁ x₂ ∈ A, ∀ x ∈ B, x ∈ open_segment 𝕜 x₁ x₂ → x₁ ∈ B ∧ x₂ ∈ B
```
to
```
B ⊆ A ∧ ∀ ⦃x₁⦄, x₁ ∈ A → ∀ ⦃x₂⦄, x₂ ∈ A → ∀ ⦃x⦄, x ∈ B → x ∈ open_segment 𝕜 x₁ x₂ → x₁ ∈ B ∧ x₂ ∈ B
```
and similar for `extreme_points`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
