### PR TITLE
refactor(set_theory/ordinal/basic): "strengthen" `well_ordering_rel`

### DIFF
--- a/counterexamples/phillips.lean
+++ b/counterexamples/phillips.lean
@@ -451,25 +451,23 @@ We need the continuum hypothesis to construct it.
 theorem sierpinski_pathological_family (Hcont : #ℝ = aleph 1) :
   ∃ (f : ℝ → set ℝ), (∀ x, countable (univ \ f x)) ∧ (∀ y, countable {x | y ∈ f x}) :=
 begin
-  rcases cardinal.ord_eq ℝ with ⟨r, hr, H⟩,
-  resetI,
-  refine ⟨λ x, {y | r x y}, λ x, _, λ y, _⟩,
-  { have : univ \ {y | r x y} = {y | r y x} ∪ {x},
+  refine ⟨λ x, {y | well_ordering_rel x y}, λ x, _, λ y, _⟩,
+  { have : univ \ {y | well_ordering_rel x y} = {y | well_ordering_rel y x} ∪ {x},
     { ext y,
       simp only [true_and, mem_univ, mem_set_of_eq, mem_insert_iff, union_singleton, mem_diff],
-      rcases trichotomous_of r x y with h|rfl|h,
+      rcases trichotomous_of well_ordering_rel x y with h|rfl|h,
       { simp only [h, not_or_distrib, false_iff, not_true],
         split,
-        { rintros rfl, exact irrefl_of r y h },
+        { rintros rfl, exact irrefl_of well_ordering_rel y h },
         { exact asymm h } },
       { simp only [true_or, eq_self_iff_true, iff_true], exact irrefl x },
       { simp only [h, iff_true, or_true], exact asymm h } },
     rw this,
     apply countable.union _ (countable_singleton _),
     rw [cardinal.countable_iff_lt_aleph_one, ← Hcont],
-    exact cardinal.card_typein_lt r x H },
+    exact cardinal.card_typein_lt r x type_well_ordering_rel.symm },
   { rw [cardinal.countable_iff_lt_aleph_one, ← Hcont],
-    exact cardinal.card_typein_lt r y H }
+    exact cardinal.card_typein_lt r y type_well_ordering_rel.symm }
 end
 
 /-- A family of sets in `ℝ` which only miss countably many points, but such that any point is

--- a/counterexamples/phillips.lean
+++ b/counterexamples/phillips.lean
@@ -465,9 +465,9 @@ begin
     rw this,
     apply countable.union _ (countable_singleton _),
     rw [cardinal.countable_iff_lt_aleph_one, ← Hcont],
-    exact cardinal.card_typein_lt r x type_well_ordering_rel.symm },
+    exact cardinal.card_typein_lt _ x ordinal.type_well_ordering_rel.symm },
   { rw [cardinal.countable_iff_lt_aleph_one, ← Hcont],
-    exact cardinal.card_typein_lt r y type_well_ordering_rel.symm }
+    exact cardinal.card_typein_lt _ y ordinal.type_well_ordering_rel.symm }
 end
 
 /-- A family of sets in `ℝ` which only miss countably many points, but such that any point is

--- a/src/set_theory/cardinal/ordinal.lean
+++ b/src/set_theory/cardinal/ordinal.lean
@@ -307,9 +307,9 @@ begin
   refine acc.rec_on (cardinal.lt_wf.apply c) (λ c _,
     quotient.induction_on c $ λ α IH ol, _) h,
   -- consider the minimal well-order `r` on `α` (a type with cardinality `c`).
-  rcases ord_eq α with ⟨r, wo, e⟩, resetI,
-  letI := linear_order_of_STO' r,
-  haveI : is_well_order α (<) := wo,
+  resetI,
+  letI := linear_order_of_STO' (@well_ordering_rel α),
+  haveI : is_well_order α (<) := well_ordering_rel.is_well_order,
   -- Define an order `s` on `α × α` by writing `(a, b) < (c, d)` if `max a b < max c d`, or
   -- the max are equal and `a < c`, or the max are equal and `a = c` and `b < d`.
   let g : α × α → α := λ p, max p.1 p.2,
@@ -323,10 +323,10 @@ begin
     `β × β` for some `β` of cardinality `< c`. By the inductive assumption, this set has the
     same cardinality as `β` (or it is finite if `β` is finite), so it is `< c`, which is a
     contradiction. -/
-  suffices : type s ≤ type r, {exact card_le_card this},
+  apply @card_le_card (type s) (type (@well_ordering_rel α)),
   refine le_of_forall_lt (λ o h, _),
   rcases typein_surj s h with ⟨p, rfl⟩,
-  rw [← e, lt_ord],
+  rw [type_well_ordering_rel, lt_ord],
   refine lt_of_le_of_lt
     (_ : _ ≤ card (succ (typein (<) (g p))) * card (succ (typein (<) (g p)))) _,
   { have : {q | s q p} ⊆ insert (g p) {x | x < g p} ×ˢ insert (g p) {x | x < g p},
@@ -334,17 +334,18 @@ begin
       simp only [s, embedding.coe_fn_mk, order.preimage, typein_lt_typein, prod.lex_def, typein_inj]
         at h,
       exact max_le_iff.1 (le_iff_lt_or_eq.2 $ h.imp_right and.left) },
-    suffices H : (insert (g p) {x | r x (g p)} : set α) ≃ ({x | r x (g p)} ⊕ punit),
+    suffices H : (insert (g p) {x | well_ordering_rel x (g p)} : set α) ≃
+      ({x | well_ordering_rel x (g p)} ⊕ punit),
     { exact ⟨(set.embedding_of_subset _ _ this).trans
         ((equiv.set.prod _ _).trans (H.prod_congr H)).to_embedding⟩ },
     refine (equiv.set.insert _).trans
       ((equiv.refl _).sum_congr punit_equiv_punit),
-    apply @irrefl _ r },
+    apply @irrefl _ well_ordering_rel },
   cases lt_or_le (card (succ (typein (<) (g p)))) ℵ₀ with qo qo,
   { exact (mul_lt_aleph_0 qo qo).trans_le ol },
   { suffices, {exact (IH _ this qo).trans_lt this},
     rw ← lt_ord, apply (ord_is_limit ol).2,
-    rw [mk_def, e], apply typein_lt_type }
+    rw [mk_def, ←type_well_ordering_rel], apply typein_lt_type }
 end
 
 end using_ordinals

--- a/src/set_theory/ordinal/basic.lean
+++ b/src/set_theory/ordinal/basic.lean
@@ -440,7 +440,7 @@ def embedding_to_cardinal : σ ↪ cardinal.{u} := classical.choice nonempty_emb
 
 /-- We don't make this into a definition, as we define a well ordering `well_ordering_rel` with
 the extra property `type (@well_ordering_rel α) = (#α).ord` later. -/
-instance : nonempty {r // is_well_order σ r} :=
+instance is_well_order.subtype_nonempty : nonempty {r // is_well_order σ r} :=
 ⟨⟨embedding_to_cardinal ⁻¹'o (<), (rel_embedding.preimage _ _).is_well_order⟩⟩
 
 end well_ordering_thm
@@ -1220,7 +1220,7 @@ by { convert (ordinal.card_type (<)).symm, exact (ordinal.type_lt o).symm }
 def ord (c : cardinal) : ordinal :=
 begin
   let ι := λ α, {r // is_well_order α r},
-  let F := λ α, ordinal.min ⟨classical.arbitrary {r // _}⟩ (λ i:ι α, ⟦⟨α, i.1, i.2⟩⟧),
+  let F := λ α, ordinal.min infer_instance (λ i:ι α, ⟦⟨α, i.1, i.2⟩⟧),
   refine quot.lift_on c F _,
   suffices : ∀ {α β}, α ≈ β → F α ≤ F β,
   from λ α β h, le_antisymm (this h) (this (setoid.symm h)),
@@ -1233,11 +1233,11 @@ begin
 end
 
 lemma ord_eq_min (α : Type u) : ord (#α) =
-  @ordinal.min {r // is_well_order α r} (by apply_instance) (λ i, ⟦⟨α, i.1, i.2⟩⟧) := rfl
+  @ordinal.min {r // is_well_order α r} infer_instance (λ i, ⟦⟨α, i.1, i.2⟩⟧) := rfl
 
 private theorem ord_eq (α) : ∃ (r : α → α → Prop) [wo : is_well_order α r],
   ord (#α) = @type α r wo :=
-let ⟨⟨r, wo⟩, h⟩ := @ordinal.min_eq {r // is_well_order α r} (by apply_instance)
+let ⟨⟨r, wo⟩, h⟩ := @ordinal.min_eq {r // is_well_order α r} infer_instance
   (λ i:{r // is_well_order α r}, ⟦⟨α, i.1, i.2⟩⟧) in
 ⟨r, wo, h⟩
 
@@ -1252,7 +1252,7 @@ classical.some $ classical.some_spec $ ord_eq α
 (classical.some_spec $ classical.some_spec $ ord_eq α).symm
 
 theorem ord_le_type (r : α → α → Prop) [is_well_order α r] : ord (#α) ≤ ordinal.type r :=
-@ordinal.min_le {r // is_well_order α r} (by apply_instance)
+@ordinal.min_le {r // is_well_order α r} infer_instance
   (λ i:{r // is_well_order α r}, ⟦⟨α, i.1, i.2⟩⟧) ⟨r, _⟩
 
 theorem ord_le {c o} : ord c ≤ o ↔ c ≤ o.card :=

--- a/src/set_theory/ordinal/basic.lean
+++ b/src/set_theory/ordinal/basic.lean
@@ -1248,7 +1248,7 @@ classical.some $ ord_eq α
 instance _root_.well_ordering_rel.is_well_order : is_well_order α well_ordering_rel :=
 classical.some $ classical.some_spec $ ord_eq α
 
-@[simp] theorem type_well_ordering_rel : type (@well_ordering_rel α) = (#α).ord :=
+@[simp] theorem _root_.ordinal.type_well_ordering_rel : type (@well_ordering_rel α) = (#α).ord :=
 (classical.some_spec $ classical.some_spec $ ord_eq α).symm
 
 theorem ord_le_type (r : α → α → Prop) [is_well_order α r] : ord (#α) ≤ ordinal.type r :=

--- a/src/set_theory/ordinal/basic.lean
+++ b/src/set_theory/ordinal/basic.lean
@@ -439,7 +439,7 @@ theorem nonempty_embedding_to_cardinal : nonempty (σ ↪ cardinal.{u}) :=
 def embedding_to_cardinal : σ ↪ cardinal.{u} := classical.choice nonempty_embedding_to_cardinal
 
 /-- We don't make this into a definition, as we define a well ordering `well_ordering_rel` with
-extra properties later. -/
+the extra property `type (@well_ordering_rel α) = (#α).ord` later. -/
 instance : nonempty {r // is_well_order σ r} :=
 ⟨⟨embedding_to_cardinal ⁻¹'o (<), (rel_embedding.preimage _ _).is_well_order⟩⟩
 
@@ -1242,10 +1242,10 @@ let ⟨⟨r, wo⟩, h⟩ := @ordinal.min_eq {r // is_well_order α r} (by apply_
 ⟨r, wo, h⟩
 
 /-- Any type `α` can be endowed with a well order whose order type equals `(#α).ord`. -/
-def well_ordering_rel : α → α → Prop :=
+def _root_.well_ordering_rel : α → α → Prop :=
 classical.some $ ord_eq α
 
-instance well_ordering_rel.is_well_order : is_well_order α well_ordering_rel :=
+instance _root_.well_ordering_rel.is_well_order : is_well_order α well_ordering_rel :=
 classical.some $ classical.some_spec $ ord_eq α
 
 @[simp] theorem type_well_ordering_rel : type (@well_ordering_rel α) = (#α).ord :=

--- a/src/set_theory/ordinal/basic.lean
+++ b/src/set_theory/ordinal/basic.lean
@@ -1248,7 +1248,9 @@ classical.some $ ord_eq α
 instance _root_.well_ordering_rel.is_well_order : is_well_order α well_ordering_rel :=
 classical.some $ classical.some_spec $ ord_eq α
 
-@[simp] theorem _root_.ordinal.type_well_ordering_rel : type (@well_ordering_rel α) = (#α).ord :=
+/-- This theorem isn't marked as `simp`, as there are circumstances where knowing the exact order
+type of this relation is just noise. -/
+theorem _root_.ordinal.type_well_ordering_rel : type (@well_ordering_rel α) = (#α).ord :=
 (classical.some_spec $ classical.some_spec $ ord_eq α).symm
 
 theorem ord_le_type (r : α → α → Prop) [is_well_order α r] : ord (#α) ≤ ordinal.type r :=

--- a/src/set_theory/ordinal/basic.lean
+++ b/src/set_theory/ordinal/basic.lean
@@ -1248,7 +1248,7 @@ classical.some $ ord_eq α
 instance well_ordering_rel.is_well_order : is_well_order α well_ordering_rel :=
 classical.some $ classical.some_spec $ ord_eq α
 
-@[simp] theorem type_well_ordering_rel' : type (@well_ordering_rel α) = (#α).ord :=
+@[simp] theorem type_well_ordering_rel : type (@well_ordering_rel α) = (#α).ord :=
 (classical.some_spec $ classical.some_spec $ ord_eq α).symm
 
 theorem ord_le_type (r : α → α → Prop) [is_well_order α r] : ord (#α) ≤ ordinal.type r :=
@@ -1259,7 +1259,7 @@ theorem ord_le {c o} : ord c ≤ o ↔ c ≤ o.card :=
 induction_on c $ λ α, ordinal.induction_on o $ λ β s _,
 begin
   resetI, simp only [card_type], split; intro h,
-  { rw ←type_well_ordering_rel' at h,
+  { rw ←type_well_ordering_rel at h,
     exact let ⟨f⟩ := h in ⟨f.to_embedding⟩ },
   { cases h with f,
     have g := rel_embedding.preimage f s,
@@ -1271,8 +1271,7 @@ theorem lt_ord {c o} : o < ord c ↔ o.card < c :=
 by rw [← not_le, ← not_le, ord_le]
 
 @[simp] theorem card_ord (c) : (ord c).card = c :=
-quotient.induction_on c $ λ α,
-let ⟨r, _, e⟩ := ord_eq α in by simp only [mk_def, e, card_type]
+quotient.induction_on c $ λ α, by simp only [mk_def, ←type_well_ordering_rel, card_type]
 
 theorem ord_card_le (o : ordinal) : o.card.ord ≤ o :=
 ord_le.2 le_rfl

--- a/src/set_theory/ordinal/basic.lean
+++ b/src/set_theory/ordinal/basic.lean
@@ -1259,7 +1259,7 @@ theorem ord_le {c o} : ord c ≤ o ↔ c ≤ o.card :=
 induction_on c $ λ α, ordinal.induction_on o $ λ β s _,
 begin
   resetI, simp only [card_type], split; intro h,
-  { rw ←type_well_ordering_rel at h,
+  { rw ←ordinal.type_well_ordering_rel at h,
     exact let ⟨f⟩ := h in ⟨f.to_embedding⟩ },
   { cases h with f,
     have g := rel_embedding.preimage f s,
@@ -1271,7 +1271,7 @@ theorem lt_ord {c o} : o < ord c ↔ o.card < c :=
 by rw [← not_le, ← not_le, ord_le]
 
 @[simp] theorem card_ord (c) : (ord c).card = c :=
-quotient.induction_on c $ λ α, by simp only [mk_def, ←type_well_ordering_rel, card_type]
+quotient.induction_on c $ λ α, by simp only [mk_def, ←ordinal.type_well_ordering_rel, card_type]
 
 theorem ord_card_le (o : ordinal) : o.card.ord ≤ o :=
 ord_le.2 le_rfl


### PR DESCRIPTION
We redefine `well_ordering_rel` so that `type (@well_ordering_rel α) = (#α).ord`. Since the original `well_ordering_rel` was an entirely arbitrary well-ordered relation, this extra property doesn't hurt. Further, doing this means that we don't need to `case` on `ord_eq` whenever we're looking for one such relation.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
