### PR TITLE
[Merged by Bors] - doc(field_theory/finite/trace): fix module docstring

### DIFF
--- a/src/field_theory/finite/trace.lean
+++ b/src/field_theory/finite/trace.lean
@@ -10,9 +10,8 @@ import field_theory.finite.galois_field
 /-!
 # The trace map for finite fields
 
-We define `trace_to_zmod F` for a finite field `F` as the trace map
-from `F` to its prime field `zmod p` (where `p = ring_char F`),
-and we state the fact that this trace map is nondegenerate.
+We state the fact that the trace map from a finite field of
+characteristic `p` to `zmod p` is nondegenerate.
 
 ## Tags
 finite field, trace


### PR DESCRIPTION
This PR just fixes the docstring in `field_theory/finite/trace.lean`. It was still mentioning a definition that was removed.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
