### PR TITLE
[Merged by Bors] - feat(data/zmod/basic): fix a diamond in comm_ring and field

### DIFF
--- a/src/data/zmod/basic.lean
+++ b/src/data/zmod/basic.lean
@@ -103,6 +103,9 @@ instance has_repr : Π (n : ℕ), has_repr (zmod n)
 | 0     := int.has_repr
 | (n+1) := fin.has_repr _
 
+/- We define each field by cases, to ensure that the eta-expanded `zmod.comm_ring` is defeq to the
+original, this helps avoid diamonds with instances coming from classes extending `comm_ring` such as
+field. -/
 instance comm_ring (n : ℕ) : comm_ring (zmod n) :=
 { add := nat.cases_on n ((@has_add.add) int _) (λ n, @has_add.add (fin n.succ) _),
   add_assoc := nat.cases_on n (@add_assoc int _) (λ n, @add_assoc (fin n.succ) _),

--- a/src/data/zmod/basic.lean
+++ b/src/data/zmod/basic.lean
@@ -104,30 +104,25 @@ instance has_repr : Π (n : ℕ), has_repr (zmod n)
 | (n+1) := fin.has_repr _
 
 instance comm_ring (n : ℕ) : comm_ring (zmod n) :=
-{ add := nat.cases_on n
-    (@comm_ring.add _ int.comm_ring) (λ n, @comm_ring.add _ (fin.comm_ring _)),
-  add_assoc := nat.cases_on n comm_ring.add_assoc (λ n, comm_ring.add_assoc),
-  zero := nat.cases_on n
-    (@comm_ring.zero _ int.comm_ring) (λ n, @comm_ring.zero _ (fin.comm_ring _)),
-  zero_add := nat.cases_on n comm_ring.zero_add (λ n, comm_ring.zero_add),
-  add_zero := nat.cases_on n comm_ring.add_zero (λ n, comm_ring.add_zero),
-  neg := nat.cases_on n
-    (@comm_ring.neg _ int.comm_ring) (λ n, @comm_ring.neg _ (fin.comm_ring _)),
-  sub := nat.cases_on n
-    (@comm_ring.sub _ int.comm_ring) (λ n, @comm_ring.sub _ (fin.comm_ring _)),
-  sub_eq_add_neg := begin cases n; exact comm_ring.sub_eq_add_neg, end,
-  add_left_neg := begin cases n; exact comm_ring.add_left_neg, end,
-  add_comm := begin cases n; exact comm_ring.add_comm, end,
-  mul := nat.cases_on n
-    (@comm_ring.mul _ int.comm_ring) (λ n, @comm_ring.mul _ (fin.comm_ring _)),
-  mul_assoc := begin cases n; exact comm_ring.mul_assoc, end,
-  one := nat.cases_on n
-    (@comm_ring.one _ int.comm_ring) (λ n, @comm_ring.one _ (fin.comm_ring _)),
-  one_mul := nat.cases_on n comm_ring.one_mul (λ n, comm_ring.one_mul),
-  mul_one := nat.cases_on n comm_ring.mul_one (λ n, comm_ring.mul_one),
-  left_distrib := begin cases n; exact comm_ring.left_distrib, end,
-  right_distrib := begin cases n; exact comm_ring.right_distrib, end,
-  mul_comm := begin cases n; exact comm_ring.mul_comm, end, }
+{ add := nat.cases_on n ((@has_add.add) int _) (λ n, @has_add.add (fin n.succ) _),
+  add_assoc := nat.cases_on n (@add_assoc int _) (λ n, @add_assoc (fin n.succ) _),
+  zero := nat.cases_on n (0 : int) (λ n, (0 : fin n.succ)),
+  zero_add := nat.cases_on n (@zero_add int _) (λ n, @zero_add (fin n.succ) _),
+  add_zero := nat.cases_on n (@add_zero int _) (λ n, @add_zero (fin n.succ) _),
+  neg := nat.cases_on n ((@has_neg.neg) int _) (λ n, @has_neg.neg (fin n.succ) _),
+  sub := nat.cases_on n ((@has_sub.sub) int _) (λ n, @has_sub.sub (fin n.succ) _),
+  sub_eq_add_neg := nat.cases_on n (@sub_eq_add_neg int _) (λ n, @sub_eq_add_neg (fin n.succ) _),
+  add_left_neg := by { cases n, exacts [@add_left_neg int _, @add_left_neg (fin n.succ) _] },
+  add_comm := nat.cases_on n (@add_comm int _) (λ n, @add_comm (fin n.succ) _),
+  mul := nat.cases_on n ((@has_mul.mul) int _) (λ n, @has_mul.mul (fin n.succ) _),
+  mul_assoc := nat.cases_on n (@mul_assoc int _) (λ n, @mul_assoc (fin n.succ) _),
+  one := nat.cases_on n (1 : int) (λ n, (1 : fin n.succ)),
+  one_mul := nat.cases_on n (@one_mul int _) (λ n, @one_mul (fin n.succ) _),
+  mul_one := nat.cases_on n (@mul_one int _) (λ n, @mul_one (fin n.succ) _),
+  left_distrib := nat.cases_on n (@left_distrib int _ _ _) (λ n, @left_distrib (fin n.succ) _ _ _),
+  right_distrib :=
+    nat.cases_on n (@right_distrib int _ _ _) (λ n, @right_distrib (fin n.succ) _ _ _),
+  mul_comm := nat.cases_on n (@mul_comm int _) (λ n, @mul_comm (fin n.succ) _) }
 
 instance inhabited (n : ℕ) : inhabited (zmod n) := ⟨0⟩
 

--- a/src/data/zmod/basic.lean
+++ b/src/data/zmod/basic.lean
@@ -115,6 +115,18 @@ instance comm_ring (n : ℕ) : comm_ring (zmod n) :=
   neg := nat.cases_on n ((@has_neg.neg) int _) (λ n, @has_neg.neg (fin n.succ) _),
   sub := nat.cases_on n ((@has_sub.sub) int _) (λ n, @has_sub.sub (fin n.succ) _),
   sub_eq_add_neg := nat.cases_on n (@sub_eq_add_neg int _) (λ n, @sub_eq_add_neg (fin n.succ) _),
+  zsmul := nat.cases_on n ((@comm_ring.zsmul) int _) (λ n, @comm_ring.zsmul (fin n.succ) _),
+  zsmul_zero' := nat.cases_on n (@comm_ring.zsmul_zero' int _)
+    (λ n, @comm_ring.zsmul_zero' (fin n.succ) _),
+  zsmul_succ' := nat.cases_on n (@comm_ring.zsmul_succ' int _)
+    (λ n, @comm_ring.zsmul_succ' (fin n.succ) _),
+  zsmul_neg' := nat.cases_on n (@comm_ring.zsmul_neg' int _)
+    (λ n, @comm_ring.zsmul_neg' (fin n.succ) _),
+  nsmul := nat.cases_on n ((@comm_ring.nsmul) int _) (λ n, @comm_ring.nsmul (fin n.succ) _),
+  nsmul_zero' := nat.cases_on n (@comm_ring.nsmul_zero' int _)
+    (λ n, @comm_ring.nsmul_zero' (fin n.succ) _),
+  nsmul_succ' := nat.cases_on n (@comm_ring.nsmul_succ' int _)
+    (λ n, @comm_ring.nsmul_succ' (fin n.succ) _),
   add_left_neg := by { cases n, exacts [@add_left_neg int _, @add_left_neg (fin n.succ) _] },
   add_comm := nat.cases_on n (@add_comm int _) (λ n, @add_comm (fin n.succ) _),
   mul := nat.cases_on n ((@has_mul.mul) int _) (λ n, @has_mul.mul (fin n.succ) _),

--- a/src/data/zmod/basic.lean
+++ b/src/data/zmod/basic.lean
@@ -103,9 +103,31 @@ instance has_repr : Π (n : ℕ), has_repr (zmod n)
 | 0     := int.has_repr
 | (n+1) := fin.has_repr _
 
-instance comm_ring : Π (n : ℕ), comm_ring (zmod n)
-| 0     := int.comm_ring
-| (n+1) := fin.comm_ring n
+instance comm_ring (n : ℕ) : comm_ring (zmod n) :=
+{ add := nat.cases_on n
+    (@comm_ring.add _ int.comm_ring) (λ n, @comm_ring.add _ (fin.comm_ring _)),
+  add_assoc := nat.cases_on n comm_ring.add_assoc (λ n, comm_ring.add_assoc),
+  zero := nat.cases_on n
+    (@comm_ring.zero _ int.comm_ring) (λ n, @comm_ring.zero _ (fin.comm_ring _)),
+  zero_add := nat.cases_on n comm_ring.zero_add (λ n, comm_ring.zero_add),
+  add_zero := nat.cases_on n comm_ring.add_zero (λ n, comm_ring.add_zero),
+  neg := nat.cases_on n
+    (@comm_ring.neg _ int.comm_ring) (λ n, @comm_ring.neg _ (fin.comm_ring _)),
+  sub := nat.cases_on n
+    (@comm_ring.sub _ int.comm_ring) (λ n, @comm_ring.sub _ (fin.comm_ring _)),
+  sub_eq_add_neg := begin cases n; exact comm_ring.sub_eq_add_neg, end,
+  add_left_neg := begin cases n; exact comm_ring.add_left_neg, end,
+  add_comm := begin cases n; exact comm_ring.add_comm, end,
+  mul := nat.cases_on n
+    (@comm_ring.mul _ int.comm_ring) (λ n, @comm_ring.mul _ (fin.comm_ring _)),
+  mul_assoc := begin cases n; exact comm_ring.mul_assoc, end,
+  one := nat.cases_on n
+    (@comm_ring.one _ int.comm_ring) (λ n, @comm_ring.one _ (fin.comm_ring _)),
+  one_mul := nat.cases_on n comm_ring.one_mul (λ n, comm_ring.one_mul),
+  mul_one := nat.cases_on n comm_ring.mul_one (λ n, comm_ring.mul_one),
+  left_distrib := begin cases n; exact comm_ring.left_distrib, end,
+  right_distrib := begin cases n; exact comm_ring.right_distrib, end,
+  mul_comm := begin cases n; exact comm_ring.mul_comm, end, }
 
 instance inhabited (n : ℕ) : inhabited (zmod n) := ⟨0⟩
 

--- a/test/instance_diamonds.lean
+++ b/test/instance_diamonds.lean
@@ -10,6 +10,7 @@ import group_theory.group_action.prod
 import group_theory.group_action.units
 import data.complex.module
 import ring_theory.algebraic
+import data.zmod.basic
 
 /-! # Tests that instances do not form diamonds -/
 
@@ -170,3 +171,13 @@ example [comm_semiring R] [nontrivial R] :
 rfl
 
 end polynomial
+
+/-! ## `zmod` instances -/
+section zmod
+
+variables {p : ℕ} [fact p.prime]
+example : @euclidean_domain.to_comm_ring _ (@field.to_euclidean_domain _ (zmod.field p)) =
+  zmod.comm_ring p :=
+rfl
+
+end zmod

--- a/test/instance_diamonds.lean
+++ b/test/instance_diamonds.lean
@@ -182,5 +182,6 @@ example : @euclidean_domain.to_comm_ring _ (@field.to_euclidean_domain _ (zmod.f
 rfl
 
 example (n : ℕ) : zmod.comm_ring (n + 1) = fin.comm_ring n := rfl
+example : zmod.comm_ring 0 = int.comm_ring := rfl
 
 end zmod

--- a/test/instance_diamonds.lean
+++ b/test/instance_diamonds.lean
@@ -176,8 +176,11 @@ end polynomial
 section zmod
 
 variables {p : ℕ} [fact p.prime]
+
 example : @euclidean_domain.to_comm_ring _ (@field.to_euclidean_domain _ (zmod.field p)) =
   zmod.comm_ring p :=
 rfl
+
+example (n : ℕ) : zmod.comm_ring (n + 1) = fin.comm_ring n := rfl
 
 end zmod


### PR DESCRIPTION
Before this change the following diamond existed:
```lean
import data.zmod.basic

variables {p : ℕ} [fact p.prime]
example :
  @euclidean_domain.to_comm_ring _ (@field.to_euclidean_domain _ (zmod.field p)) = zmod.comm_ring p :=
rfl
```
as the eta-expanded `zmod.comm_ring` was not defeq to itself, as it is defined via cases.
We fix this by instead defining each field by cases, which looks worse but at least seems to resolve the issue.

See https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/zmod.20comm_ring.20field.20diamond/near/285847071 for discussion

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
