### PR TITLE
[Merged by Bors] - feat(number_theory/wilson): add Wilson's Theorem

### DIFF
--- a/src/number_theory/wilson.lean
+++ b/src/number_theory/wilson.lean
@@ -26,10 +26,9 @@ open_locale nat
 namespace nat
 
 /-- For `n > 1`, `(n-1)!` is congruent to `-1` modulo `n` only if n is prime. --/
-private lemma wilsons_theorem_only_if_direction (n : ℕ) (h1 : 1 < n):
-(((n - 1)! : zmod n) = -1) → (prime n) :=
+private lemma wilsons_theorem_only_if_direction (n : ℕ) (h : (((n - 1)! : zmod n) = -1)) (h1 : 1 < n) :
+(prime n) :=
 begin
-  intro h,
   have hp : ((n - 1)! + 1 : zmod n) = 0,
   { rw h, simp, },
   have hn_divides : n ∣(n-1)! + 1,
@@ -58,16 +57,19 @@ begin
     ((nat.dvd_add_right hm_divides_fact).mp (dvd_of_mul_right_dvd hn_divides)),
 
   cases h_1.right,
-  linarith,
+  linarith
 end
 
 /-- **Wilson's Theorem**: For `n > 1`, `(n-1)!` is congruent to `-1` modulo `n` iff n is prime. --/
-theorem wilsons_theorem (n : ℕ) (h1 : 1 < n) :
+theorem wilsons_theorem (n : ℕ) (h : 1 < n) :
   (prime n) ↔ (((n - 1)! : zmod n) = -1) :=
 begin
   split,
-  { intro h2, rw ← zmod.wilsons_lemma _, exact fact_iff.mpr h2 },
-  { apply wilsons_theorem_only_if_direction _, exact h1 }
+  { intro h1, rw ← zmod.wilsons_lemma _, exact fact_iff.mpr h1 },
+  intro h2,
+  apply wilsons_theorem_only_if_direction _ _,
+  { exact h, },
+  exact h2
 end
 
 end nat

--- a/src/number_theory/wilson.lean
+++ b/src/number_theory/wilson.lean
@@ -29,16 +29,12 @@ namespace nat
 lemma wilsons_theorem_only_if_direction
   {n : ℕ} (h : ((n - 1)! : zmod n) = -1) (h1 : 1 < n) : prime n :=
 begin
-  have hn_divides : n ∣ (n-1)! + 1,
-  { rw [←zmod.nat_coe_zmod_eq_zero_iff_dvd, cast_add, cast_one, h, add_left_neg] },
-
   by_contradiction h2,
-  obtain ⟨m, hm1, hm2, hm3⟩ := exists_dvd_of_not_prime2 h1 h2,
+  obtain ⟨m, hm1, hm2 : 1 < m, hm3⟩ := exists_dvd_of_not_prime2 h1 h2,
   rw [lt_iff_add_one_le, nat.add_le_to_le_sub m h1.le] at hm3,
-  have hm_divides_fact : m ∣ (n-1)! := nat.dvd_factorial (pos_of_gt hm2) hm3,
-  have m_is_one : m = 1 :=
-  nat.dvd_one.mp ((nat.dvd_add_right hm_divides_fact).mp (hm1.trans hn_divides)),
-  linarith,
+  replace hm3 := nat.dvd_factorial (pos_of_gt hm2) hm3,
+  refine hm2.ne' (nat.dvd_one.mp ((nat.dvd_add_right hm3).mp (hm1.trans _))),
+  rw [←zmod.nat_coe_zmod_eq_zero_iff_dvd, cast_add, cast_one, h, add_left_neg],
 end
 
 /-- **Wilson's Theorem**: For `n > 1`, `(n-1)!` is congruent to `-1` modulo `n` iff n is prime. --/

--- a/src/number_theory/wilson.lean
+++ b/src/number_theory/wilson.lean
@@ -26,19 +26,19 @@ open_locale nat
 namespace nat
 
 /-- For `n > 1`, `(n-1)!` is congruent to `-1` modulo `n` only if n is prime. --/
-private lemma wilsons_theorem_only_if_direction  (n : ℕ) (h1: 1 < n) :
-(((n - 1)! : zmod n) = -1)  → (prime n):=
+private lemma wilsons_theorem_only_if_direction (n : ℕ) (h1 : 1 < n) :
+(((n - 1)! : zmod n) = -1) → (prime n) :=
 begin
   intro h,
-  have hp: ((n - 1)! + 1 : zmod n) = 0,
+  have hp : ((n - 1)! + 1 : zmod n) = 0,
   rw h,
   simp,
-  have hn_divides: n ∣(n-1)! + 1,
+  have hn_divides : n ∣(n-1)! + 1,
   rw ← zmod.nat_coe_zmod_eq_zero_iff_dvd,
   exact hp,
 
   by_contradiction h2,
-  obtain ⟨m⟩  := exists_dvd_of_not_prime2 h1 h2,
+  obtain ⟨m⟩ := exists_dvd_of_not_prime2 h1 h2,
   have m_leq_n_minus_one : m ≤ (n-1),
   cases h_1.right,
   rw lt_iff_add_one_le at right,
@@ -55,7 +55,7 @@ begin
 
   clear h h1 h2 h_2 hp m_leq_n_minus_one,
 
-  have m_is_one: (m = 1), from
+  have m_is_one : (m = 1), from
     nat.dvd_one.mp
     ((nat.dvd_add_right hm_divides_fact).mp (dvd_of_mul_right_dvd hn_divides)),
 
@@ -64,7 +64,7 @@ begin
 end
 
 /-- **Wilson's Theorem**: For `n > 1`, `(n-1)!` is congruent to `-1` modulo `n` iff n is prime. --/
-theorem wilsons_theorem (n : ℕ) (h1: 1 < n) :
+theorem wilsons_theorem (n : ℕ) (h1 : 1 < n) :
   (prime n) ↔ (((n - 1)! : zmod n) = -1) :=
 begin
   split,

--- a/src/number_theory/wilson.lean
+++ b/src/number_theory/wilson.lean
@@ -57,7 +57,7 @@ begin
     ((nat.dvd_add_right hm_divides_fact).mp (dvd_of_mul_right_dvd hn_divides)),
 
   cases h_1.right,
-  linarith
+  linarith,
 end
 
 /-- **Wilson's Theorem**: For `n > 1`, `(n-1)!` is congruent to `-1` modulo `n` iff n is prime. --/
@@ -69,7 +69,7 @@ begin
   intro h2,
   apply wilsons_theorem_only_if_direction _ _,
   { exact h, },
-  exact h2
+  exact h2,
 end
 
 end nat

--- a/src/number_theory/wilson.lean
+++ b/src/number_theory/wilson.lean
@@ -26,7 +26,7 @@ open_locale nat
 namespace nat
 
 /-- For `n > 1`, `(n-1)!` is congruent to `-1` modulo `n` only if n is prime. --/
-lemma wilsons_theorem_only_if_direction
+lemma prime_of_fac_equiv_neg_one
   {n : ℕ} (h : ((n - 1)! : zmod n) = -1) (h1 : 1 < n) : prime n :=
 begin
   by_contradiction h2,
@@ -41,7 +41,7 @@ end
 theorem wilsons_theorem {n : ℕ} (h : 1 < n) :
   prime n ↔ ((n - 1)! : zmod n) = -1 :=
 begin
-  refine ⟨λ h1, _, λ h2, wilsons_theorem_only_if_direction h2 h⟩,
+  refine ⟨λ h1, _, λ h2, prime_of_fac_equiv_neg_one h2 h⟩,
   haveI := fact.mk h1,
   exact zmod.wilsons_lemma n,
 end

--- a/src/number_theory/wilson.lean
+++ b/src/number_theory/wilson.lean
@@ -26,8 +26,8 @@ open_locale nat
 namespace nat
 
 /-- For `n > 1`, `(n-1)!` is congruent to `-1` modulo `n` only if n is prime. --/
-private lemma wilsons_theorem_only_if_direction (n : ℕ) (h : (((n - 1)! : zmod n) = -1)) (h1 : 1 < n) :
-(prime n) :=
+private lemma wilsons_theorem_only_if_direction
+  (n : ℕ) (h : (((n - 1)! : zmod n) = -1)) (h1 : 1 < n) : (prime n) :=
 begin
   have hp : ((n - 1)! + 1 : zmod n) = 0,
   { rw h, simp, },

--- a/src/number_theory/wilson.lean
+++ b/src/number_theory/wilson.lean
@@ -26,7 +26,7 @@ open_locale nat
 namespace nat
 
 /-- For `n > 1`, `(n-1)!` is congruent to `-1` modulo `n` only if n is prime. --/
-lemma prime_if_fac_equiv_neg_one
+lemma prime_of_fac_equiv_neg_one
   {n : ℕ} (h : ((n - 1)! : zmod n) = -1) (h1 : 1 < n) : prime n :=
 begin
   by_contradiction h2,
@@ -40,7 +40,7 @@ end
 theorem prime_iff_fac_equiv_neg_one {n : ℕ} (h : 1 < n) :
   prime n ↔ ((n - 1)! : zmod n) = -1 :=
 begin
-  refine ⟨λ h1, _, λ h2, prime_if_fac_equiv_neg_one h2 h⟩,
+  refine ⟨λ h1, _, λ h2, prime_of_fac_equiv_neg_one h2 h⟩,
   haveI := fact.mk h1,
   exact zmod.wilsons_lemma n,
 end

--- a/src/number_theory/wilson.lean
+++ b/src/number_theory/wilson.lean
@@ -26,25 +26,25 @@ open_locale nat
 namespace nat
 
 /-- For `n > 1`, `(n-1)!` is congruent to `-1` modulo `n` only if n is prime. --/
-private lemma wilsons_theorem_only_if_direction  (n : ℕ) [hyp: n > 1] :
+private lemma wilsons_theorem_only_if_direction  (n : ℕ) (h1: 1 < n) :
 (((n - 1)! : zmod n) = -1)  → (prime n):=
 begin
   intro h,
-  have hp2: ((n - 1)! + 1 : zmod n) = 0,
+  have hp: ((n - 1)! + 1 : zmod n) = 0,
   rw h,
   simp,
   have hn_divides: n ∣(n-1)! + 1,
   rw ← zmod.nat_coe_zmod_eq_zero_iff_dvd,
-  exact hp2,
+  exact hp,
 
   by_contradiction h2,
-  obtain ⟨m⟩  := exists_dvd_of_not_prime2 hyp h2,
+  obtain ⟨m⟩  := exists_dvd_of_not_prime2 h1 h2,
   have m_leq_n_minus_one : m ≤ (n-1),
   cases h_1.right,
   rw lt_iff_add_one_le at right,
   rw nat.add_le_to_le_sub at right,
   exact right,
-  exact le_of_lt hyp,
+  exact le_of_lt h1,
 
   have hm_divides_fact : (m ∣(n-1)!),
   refine nat.dvd_factorial _ m_leq_n_minus_one,
@@ -53,7 +53,7 @@ begin
   cases h_1.left,
   rw h_2 at hn_divides hm_divides_fact,
 
-  clear h h_2 h2 hp2 hyp m_leq_n_minus_one,
+  clear h h1 h2 h_2 hp m_leq_n_minus_one,
 
   have m_is_one: (m = 1), from
     nat.dvd_one.mp
@@ -64,12 +64,12 @@ begin
 end
 
 /-- **Wilson's Theorem**: For `n > 1`, `(n-1)!` is congruent to `-1` modulo `n` iff n is prime. --/
-theorem wilsons_theorem (n : ℕ) [hyp: n > 1] :
+theorem wilsons_theorem (n : ℕ) (h1: 1 < n) :
   (prime n) ↔ (((n - 1)! : zmod n) = -1) :=
 begin
   split,
-  { intro hp, rw ← zmod.wilsons_lemma _, exact fact_iff.mpr hp },
-  { apply wilsons_theorem_only_if_direction _, exact hyp }
+  { intro h2, rw ← zmod.wilsons_lemma _, exact fact_iff.mpr h2 },
+  { apply wilsons_theorem_only_if_direction _, exact h1 }
 end
 
 end nat

--- a/src/number_theory/wilson.lean
+++ b/src/number_theory/wilson.lean
@@ -1,0 +1,75 @@
+/-
+Copyright (c) 2022 John Nicol. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: John Nicol
+-/
+import number_theory.legendre_symbol.gauss_eisenstein_lemmas
+
+/-!
+# Wilson's theorem.
+
+This file contains a proof of Wilson's theorem.
+
+The heavy lifting is mostly done by the previous `wilsons_lemma`,
+but here we also prove the other logical direction.
+
+This could be generalized to similar results about finite abelian groups.
+
+## References
+
+* [Wilson's Theorem](https://en.wikipedia.org/wiki/Wilson%27s_theorem)
+
+-/
+
+open_locale nat
+
+namespace nat
+
+/-- For `n > 1`, `(n-1)!` is congruent to `-1` modulo `n` only if n is prime. --/
+private lemma wilsons_theorem_only_if_direction  (n : ℕ) [hyp: n > 1] :
+(((n - 1)! : zmod n) = -1)  → (prime n):=
+begin
+  intro h,
+  have hp2: ((n - 1)! + 1 : zmod n) = 0,
+  rw h,
+  simp,
+  have hn_divides: n ∣(n-1)! + 1,
+  rw ← zmod.nat_coe_zmod_eq_zero_iff_dvd,
+  exact hp2,
+
+  by_contradiction h2,
+  obtain ⟨m⟩  := exists_dvd_of_not_prime2 hyp h2,
+  have m_leq_n_minus_one : m ≤ (n-1),
+  cases h_1.right,
+  rw lt_iff_add_one_le at right,
+  rw nat.add_le_to_le_sub at right,
+  exact right,
+  exact le_of_lt hyp,
+
+  have hm_divides_fact : (m ∣(n-1)!),
+  refine nat.dvd_factorial _ m_leq_n_minus_one,
+  cases h_1.right,
+  exact pos_of_gt left,
+  cases h_1.left,
+  rw h_2 at hn_divides hm_divides_fact,
+
+  clear h h_2 h2 hp2 hyp m_leq_n_minus_one,
+
+  have m_is_one: (m = 1), from
+    nat.dvd_one.mp
+    ((nat.dvd_add_right hm_divides_fact).mp (dvd_of_mul_right_dvd hn_divides)),
+
+  cases h_1.right,
+  linarith,
+end
+
+/-- **Wilson's Theorem**: For `n > 1`, `(n-1)!` is congruent to `-1` modulo `n` iff n is prime. --/
+theorem wilsons_theorem (n : ℕ) [hyp: n > 1] :
+  (prime n) ↔ (((n - 1)! : zmod n) = -1) :=
+begin
+  split,
+  { intro hp, rw ← zmod.wilsons_lemma _, exact fact_iff.mpr hp },
+  { apply wilsons_theorem_only_if_direction _, exact hyp }
+end
+
+end nat

--- a/src/number_theory/wilson.lean
+++ b/src/number_theory/wilson.lean
@@ -26,28 +26,26 @@ open_locale nat
 namespace nat
 
 /-- For `n > 1`, `(n-1)!` is congruent to `-1` modulo `n` only if n is prime. --/
-private lemma wilsons_theorem_only_if_direction
-  (n : ℕ) (h : ((n - 1)! : zmod n) = -1) (h1 : 1 < n) : prime n :=
+lemma wilsons_theorem_only_if_direction
+  {n : ℕ} (h : ((n - 1)! : zmod n) = -1) (h1 : 1 < n) : prime n :=
 begin
   have hn_divides : n ∣ (n-1)! + 1,
   { rw [←zmod.nat_coe_zmod_eq_zero_iff_dvd, cast_add, cast_one, h, add_left_neg] },
 
   by_contradiction h2,
   obtain ⟨m, hm1, hm2, hm3⟩ := exists_dvd_of_not_prime2 h1 h2,
-  have m_leq_n_minus_one : m ≤ n-1,
-  { rwa [lt_iff_add_one_le, nat.add_le_to_le_sub m h1.le] at hm3 },
-  have hm_divides_fact : m ∣ (n-1)! :=
-  nat.dvd_factorial (pos_of_gt hm2) m_leq_n_minus_one ,
+  rw [lt_iff_add_one_le, nat.add_le_to_le_sub m h1.le] at hm3,
+  have hm_divides_fact : m ∣ (n-1)! := nat.dvd_factorial (pos_of_gt hm2) hm3,
   have m_is_one : m = 1 :=
   nat.dvd_one.mp ((nat.dvd_add_right hm_divides_fact).mp (hm1.trans hn_divides)),
   linarith,
 end
 
 /-- **Wilson's Theorem**: For `n > 1`, `(n-1)!` is congruent to `-1` modulo `n` iff n is prime. --/
-theorem wilsons_theorem (n : ℕ) (h : 1 < n) :
+theorem wilsons_theorem {n : ℕ} (h : 1 < n) :
   prime n ↔ ((n - 1)! : zmod n) = -1 :=
 begin
-  refine ⟨λ h1, _, λ h2, wilsons_theorem_only_if_direction n h2 h⟩,
+  refine ⟨λ h1, _, λ h2, wilsons_theorem_only_if_direction h2 h⟩,
   haveI := fact.mk h1,
   exact zmod.wilsons_lemma n,
 end

--- a/src/number_theory/wilson.lean
+++ b/src/number_theory/wilson.lean
@@ -29,10 +29,8 @@ namespace nat
 private lemma wilsons_theorem_only_if_direction
   (n : ℕ) (h : ((n - 1)! : zmod n) = -1) (h1 : 1 < n) : prime n :=
 begin
-  have hp : ((n - 1)! + 1 : zmod n) = 0,
-  { rw h, simp, },
   have hn_divides : n ∣ (n-1)! + 1,
-  { rw ← zmod.nat_coe_zmod_eq_zero_iff_dvd, exact hp, },
+  { rw [←zmod.nat_coe_zmod_eq_zero_iff_dvd, cast_add, cast_one, h, add_left_neg] },
 
   by_contradiction h2,
   obtain ⟨m, hm1, hm2, hm3⟩ := exists_dvd_of_not_prime2 h1 h2,
@@ -49,10 +47,9 @@ end
 theorem wilsons_theorem (n : ℕ) (h : 1 < n) :
   prime n ↔ ((n - 1)! : zmod n) = -1 :=
 begin
-  split,
-  { intro h1, rw ← zmod.wilsons_lemma _, exact fact_iff.mpr h1 },
-  intro h2,
-  apply wilsons_theorem_only_if_direction n h2 h,
+  refine ⟨λ h1, _, λ h2, wilsons_theorem_only_if_direction n h2 h⟩,
+  haveI := fact.mk h1,
+  exact zmod.wilsons_lemma n,
 end
 
 end nat

--- a/src/number_theory/wilson.lean
+++ b/src/number_theory/wilson.lean
@@ -35,28 +35,13 @@ begin
   { rw ← zmod.nat_coe_zmod_eq_zero_iff_dvd, exact hp, },
 
   by_contradiction h2,
-  obtain ⟨m, hm⟩ := exists_dvd_of_not_prime2 h1 h2,
+  obtain ⟨m, hm1, hm2, hm3⟩ := exists_dvd_of_not_prime2 h1 h2,
   have m_leq_n_minus_one : m ≤ n-1,
-  { cases hm.right,
-    rw lt_iff_add_one_le at right,
-    rw nat.add_le_to_le_sub at right,
-    exact right,
-    exact le_of_lt h1, },
-
-  have hm_divides_fact : m ∣ (n-1)!,
-  { refine nat.dvd_factorial _ m_leq_n_minus_one,
-    cases hm.right,
-    exact pos_of_gt left, },
-  cases hm.left with _ hm_left,
-  rw hm_left at hn_divides hm_divides_fact,
-
-  clear h h1 h2 hp hm_left m_leq_n_minus_one,
-
-  have m_is_one : m = 1, from
-    nat.dvd_one.mp
-    ((nat.dvd_add_right hm_divides_fact).mp (dvd_of_mul_right_dvd hn_divides)),
-
-  cases hm.right,
+  { rwa [lt_iff_add_one_le, nat.add_le_to_le_sub m h1.le] at hm3 },
+  have hm_divides_fact : m ∣ (n-1)! :=
+  nat.dvd_factorial (pos_of_gt hm2) m_leq_n_minus_one ,
+  have m_is_one : m = 1 :=
+  nat.dvd_one.mp ((nat.dvd_add_right hm_divides_fact).mp (hm1.trans hn_divides)),
   linarith,
 end
 
@@ -67,8 +52,7 @@ begin
   split,
   { intro h1, rw ← zmod.wilsons_lemma _, exact fact_iff.mpr h1 },
   intro h2,
-  apply wilsons_theorem_only_if_direction n h2,
-  exact h,
+  apply wilsons_theorem_only_if_direction n h2 h,
 end
 
 end nat

--- a/src/number_theory/wilson.lean
+++ b/src/number_theory/wilson.lean
@@ -27,49 +27,48 @@ namespace nat
 
 /-- For `n > 1`, `(n-1)!` is congruent to `-1` modulo `n` only if n is prime. --/
 private lemma wilsons_theorem_only_if_direction
-  (n : ℕ) (h : (((n - 1)! : zmod n) = -1)) (h1 : 1 < n) : (prime n) :=
+  (n : ℕ) (h : ((n - 1)! : zmod n) = -1) (h1 : 1 < n) : prime n :=
 begin
   have hp : ((n - 1)! + 1 : zmod n) = 0,
   { rw h, simp, },
-  have hn_divides : n ∣(n-1)! + 1,
+  have hn_divides : n ∣ (n-1)! + 1,
   { rw ← zmod.nat_coe_zmod_eq_zero_iff_dvd, exact hp, },
 
   by_contradiction h2,
-  obtain ⟨m⟩ := exists_dvd_of_not_prime2 h1 h2,
-  have m_leq_n_minus_one : m ≤ (n-1),
-  { cases h_1.right,
+  obtain ⟨m, hm⟩ := exists_dvd_of_not_prime2 h1 h2,
+  have m_leq_n_minus_one : m ≤ n-1,
+  { cases hm.right,
     rw lt_iff_add_one_le at right,
     rw nat.add_le_to_le_sub at right,
     exact right,
     exact le_of_lt h1, },
 
-  have hm_divides_fact : (m ∣(n-1)!),
+  have hm_divides_fact : m ∣ (n-1)!,
   { refine nat.dvd_factorial _ m_leq_n_minus_one,
-    cases h_1.right,
+    cases hm.right,
     exact pos_of_gt left, },
-  cases h_1.left,
-  rw h_2 at hn_divides hm_divides_fact,
+  cases hm.left with _ hm_left,
+  rw hm_left at hn_divides hm_divides_fact,
 
-  clear h h1 h2 h_2 hp m_leq_n_minus_one,
+  clear h h1 h2 hp hm_left m_leq_n_minus_one,
 
-  have m_is_one : (m = 1), from
+  have m_is_one : m = 1, from
     nat.dvd_one.mp
     ((nat.dvd_add_right hm_divides_fact).mp (dvd_of_mul_right_dvd hn_divides)),
 
-  cases h_1.right,
+  cases hm.right,
   linarith,
 end
 
 /-- **Wilson's Theorem**: For `n > 1`, `(n-1)!` is congruent to `-1` modulo `n` iff n is prime. --/
 theorem wilsons_theorem (n : ℕ) (h : 1 < n) :
-  (prime n) ↔ (((n - 1)! : zmod n) = -1) :=
+  prime n ↔ ((n - 1)! : zmod n) = -1 :=
 begin
   split,
   { intro h1, rw ← zmod.wilsons_lemma _, exact fact_iff.mpr h1 },
   intro h2,
-  apply wilsons_theorem_only_if_direction _ _,
-  { exact h, },
-  exact h2,
+  apply wilsons_theorem_only_if_direction n h2,
+  exact h,
 end
 
 end nat

--- a/src/number_theory/wilson.lean
+++ b/src/number_theory/wilson.lean
@@ -26,22 +26,21 @@ open_locale nat
 namespace nat
 
 /-- For `n > 1`, `(n-1)!` is congruent to `-1` modulo `n` only if n is prime. --/
-lemma prime_of_fac_equiv_neg_one
+lemma prime_if_fac_equiv_neg_one
   {n : ℕ} (h : ((n - 1)! : zmod n) = -1) (h1 : 1 < n) : prime n :=
 begin
   by_contradiction h2,
   obtain ⟨m, hm1, hm2 : 1 < m, hm3⟩ := exists_dvd_of_not_prime2 h1 h2,
-  rw [lt_iff_add_one_le, nat.add_le_to_le_sub m h1.le] at hm3,
-  replace hm3 := nat.dvd_factorial (pos_of_gt hm2) hm3,
-  refine hm2.ne' (nat.dvd_one.mp ((nat.dvd_add_right hm3).mp (hm1.trans _))),
+  have hm : m ∣ (n - 1)! := nat.dvd_factorial (pos_of_gt hm2) (le_pred_of_lt hm3),
+  refine hm2.ne' (nat.dvd_one.mp ((nat.dvd_add_right hm).mp (hm1.trans _))),
   rw [←zmod.nat_coe_zmod_eq_zero_iff_dvd, cast_add, cast_one, h, add_left_neg],
 end
 
 /-- **Wilson's Theorem**: For `n > 1`, `(n-1)!` is congruent to `-1` modulo `n` iff n is prime. --/
-theorem wilsons_theorem {n : ℕ} (h : 1 < n) :
+theorem prime_iff_fac_equiv_neg_one {n : ℕ} (h : 1 < n) :
   prime n ↔ ((n - 1)! : zmod n) = -1 :=
 begin
-  refine ⟨λ h1, _, λ h2, prime_of_fac_equiv_neg_one h2 h⟩,
+  refine ⟨λ h1, _, λ h2, prime_if_fac_equiv_neg_one h2 h⟩,
   haveI := fact.mk h1,
   exact zmod.wilsons_lemma n,
 end

--- a/src/number_theory/wilson.lean
+++ b/src/number_theory/wilson.lean
@@ -26,30 +26,28 @@ open_locale nat
 namespace nat
 
 /-- For `n > 1`, `(n-1)!` is congruent to `-1` modulo `n` only if n is prime. --/
-private lemma wilsons_theorem_only_if_direction (n : ℕ) (h1 : 1 < n) :
+private lemma wilsons_theorem_only_if_direction (n : ℕ) (h1 : 1 < n):
 (((n - 1)! : zmod n) = -1) → (prime n) :=
 begin
   intro h,
   have hp : ((n - 1)! + 1 : zmod n) = 0,
-  rw h,
-  simp,
+  { rw h, simp, },
   have hn_divides : n ∣(n-1)! + 1,
-  rw ← zmod.nat_coe_zmod_eq_zero_iff_dvd,
-  exact hp,
+  { rw ← zmod.nat_coe_zmod_eq_zero_iff_dvd, exact hp, },
 
   by_contradiction h2,
   obtain ⟨m⟩ := exists_dvd_of_not_prime2 h1 h2,
   have m_leq_n_minus_one : m ≤ (n-1),
-  cases h_1.right,
-  rw lt_iff_add_one_le at right,
-  rw nat.add_le_to_le_sub at right,
-  exact right,
-  exact le_of_lt h1,
+  { cases h_1.right,
+    rw lt_iff_add_one_le at right,
+    rw nat.add_le_to_le_sub at right,
+    exact right,
+    exact le_of_lt h1, },
 
   have hm_divides_fact : (m ∣(n-1)!),
-  refine nat.dvd_factorial _ m_leq_n_minus_one,
-  cases h_1.right,
-  exact pos_of_gt left,
+  { refine nat.dvd_factorial _ m_leq_n_minus_one,
+    cases h_1.right,
+    exact pos_of_gt left, },
   cases h_1.left,
   rw h_2 at hn_divides hm_divides_fact,
 

--- a/src/number_theory/wilson.lean
+++ b/src/number_theory/wilson.lean
@@ -19,15 +19,19 @@ This could be generalized to similar results about finite abelian groups.
 
 * [Wilson's Theorem](https://en.wikipedia.org/wiki/Wilson%27s_theorem)
 
+## TODO
+
+* Move `wilsons_lemma` into this file, and give it a descriptive name.
 -/
 
 open_locale nat
 
 namespace nat
+variable {n : ℕ}
 
 /-- For `n > 1`, `(n-1)!` is congruent to `-1` modulo `n` only if n is prime. --/
 lemma prime_of_fac_equiv_neg_one
-  {n : ℕ} (h : ((n - 1)! : zmod n) = -1) (h1 : 1 < n) : prime n :=
+  (h : ((n - 1)! : zmod n) = -1) (h1 : 1 < n) : prime n :=
 begin
   by_contradiction h2,
   obtain ⟨m, hm1, hm2 : 1 < m, hm3⟩ := exists_dvd_of_not_prime2 h1 h2,
@@ -37,7 +41,7 @@ begin
 end
 
 /-- **Wilson's Theorem**: For `n > 1`, `(n-1)!` is congruent to `-1` modulo `n` iff n is prime. --/
-theorem prime_iff_fac_equiv_neg_one {n : ℕ} (h : 1 < n) :
+theorem prime_iff_fac_equiv_neg_one (h : 1 < n) :
   prime n ↔ ((n - 1)! : zmod n) = -1 :=
 begin
   refine ⟨λ h1, _, λ h2, prime_of_fac_equiv_neg_one h2 h⟩,


### PR DESCRIPTION
The previous "Wilson's lemma" (zmod.wilsons_lemma) was a single direction of the iff for Wilson's Theorem. This finishes the proof by adding the (admittedly, much simpler) direction where, if the congruence is satisfied for `n`, then `n` is prime.



---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
