### PR TITLE
feat (special_functions/complex) Branch of complex arg function valued in (0, 2π]

### DIFF
--- a/src/analysis/special_functions/complex/arg.lean
+++ b/src/analysis/special_functions/complex/arg.lean
@@ -557,4 +557,44 @@ by simpa only [arg_eq_pi_iff.2 ⟨hre, him⟩]
 
 end continuity
 
+section arg'
+
+/-- Branch of argument function valued in `(0, 2 * π]`. -/
+def arg' (x : ℂ) : ℝ := if (0 < arg x) then arg x else arg x + 2 * π
+
+lemma arg'_mem_Ioc (x : ℂ) : arg' x ∈ Ioc 0 (2 * π) :=
+begin
+  rw arg', split_ifs,
+  { refine ⟨h, _⟩, linarith [arg_le_pi x, real.pi_pos], },
+  { push_neg at h, split, linarith [neg_pi_lt_arg x], linarith, }
+end
+
+lemma arg'_eq_arg (x : ℂ) : (arg' x = arg x) ∨ (arg' x = arg x + 2 * π) :=
+begin
+  rw arg', split_ifs, tauto, tauto,
+end
+
+/-- Alternate definition of arg' for nonzero `x`. Note it is false for `x = 0`! -/
+lemma arg'_eq_arg_neg_add (x : ℂ) (hx : x ≠ 0) : arg' x = arg (-x) + π :=
+begin
+  rw arg', split_ifs,
+  { apply eq_add_of_sub_eq, symmetry,
+    rw arg_neg_eq_arg_sub_pi_iff,
+    rw lt_iff_le_and_ne at h, cases h, rw arg_nonneg_iff at h_left,
+    rw le_iff_lt_or_eq at h_left, cases h_left, tauto, contrapose! hx,
+    cases hx, replace hx_right := hx_right h_left.symm,
+    symmetry' at h_right,
+    rw [ne.def, arg_eq_zero_iff] at h_right,  push_neg at h_right, tauto },
+  { push_neg at h,
+    apply eq_add_of_sub_eq, ring_nf, symmetry,
+    rw arg_neg_eq_arg_add_pi_iff, rcases h.lt_or_eq,
+    { rw arg_neg_iff at h_1, tauto, },
+    { rw arg_eq_zero_iff at h_1, right, split, tauto,
+      rcases h_1.1.lt_or_eq, tauto,
+      exfalso, contrapose! hx, ext1, tauto, tauto, } },
+end
+
+end arg'
+
+
 end complex

--- a/src/analysis/special_functions/complex/circle.lean
+++ b/src/analysis/special_functions/complex/circle.lean
@@ -47,7 +47,7 @@ noncomputable def arg_local_equiv : local_equiv circle ℝ :=
   left_inv' := λ z _, exp_map_circle_arg z,
   right_inv' := λ x hx, arg_exp_map_circle hx.1 hx.2 }
 
-/-- `complex.arg` and `exp_map_circle` define an equivalence between `circle and `(-π, π]`. -/
+/-- `complex.arg` and `exp_map_circle` define an equivalence between `circle` and `(-π, π]`. -/
 @[simps { fully_applied := ff }]
 noncomputable def arg_equiv : circle ≃ Ioc (-π) π :=
 { to_fun := λ z, ⟨arg z, neg_pi_lt_arg _, arg_le_pi _⟩,
@@ -87,6 +87,43 @@ periodic_exp_map_circle.sub_eq x
 lemma exp_map_circle_add_two_pi (x : ℝ) : exp_map_circle (x + 2 * π) = exp_map_circle x :=
 periodic_exp_map_circle x
 
+
+section arg'_equiv
+
+lemma arg'_exp_map_circle {x : ℝ} (h₁ : 0 < x) (h₂ : x ≤ 2 * π) : arg' (exp_map_circle x) = x :=
+begin
+  rw arg'_eq_arg_neg_add _ (ne_zero_of_mem_circle _), apply add_eq_of_eq_sub,
+  have : arg (exp_map_circle (x - π)) = x - π,
+  { apply arg_exp_map_circle, linarith, linarith },
+  rw [←this, exp_map_circle_apply, exp_map_circle_apply, of_real_sub, sub_mul, exp_sub,
+    exp_pi_mul_I, div_neg, div_one],
+end
+
+lemma exp_map_circle_arg' (z : circle) : exp_map_circle (arg' z) = z :=
+begin
+  rcases arg'_eq_arg z,
+  { rw h, apply exp_map_circle_arg, },
+  { rw [h, exp_map_circle_add_two_pi], apply exp_map_circle_arg },
+end
+
+namespace circle
+
+/-- Equivalence between `circle` and `(0, 2 * π]` given by `arg'`. -/
+noncomputable def arg'_equiv : circle ≃ Ioc 0 (2 * π) :=
+{ to_fun := λ z, ⟨arg' z, arg'_mem_Ioc z⟩,
+  inv_fun := exp_map_circle ∘ coe,
+  left_inv := λ z, exp_map_circle_arg' z,
+  right_inv := λ x, subtype.ext (arg'_exp_map_circle x.2.1 x.2.2) }
+
+/-- Equivalence between `(0, 2 * π]` and `circle` given by `exp_map_circle`. -/
+noncomputable def circle_equiv : Ioc 0 (2 * π) ≃ circle := arg'_equiv.symm
+
+end circle
+
+end arg'_equiv
+
+section angle
+
 /-- `exp_map_circle`, applied to a `real.angle`. -/
 noncomputable def real.angle.exp_map_circle (θ : real.angle) : circle :=
 periodic_exp_map_circle.lift θ
@@ -122,3 +159,5 @@ begin
   rw [real.angle.exp_map_circle_coe, exp_map_circle_apply, exp_mul_I, ←of_real_cos,
       ←of_real_sin, ←real.angle.cos_coe, ←real.angle.sin_coe, arg_cos_add_sin_mul_I_coe_angle]
 end
+
+end angle


### PR DESCRIPTION
This PR adds a function `arg'`, which is a branch of the argument function on the complex numbers taking values in `(0, 2 * π]`. This will be used in subsequent PR's to set up Fourier theory for periodic functions on `ℝ` using `(0, 2 * π]` as the fundamental period. 

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
