### PR TITLE
[Merged by Bors] - chore(field_theory/intermediate_field): fix timeout

### DIFF
--- a/src/field_theory/intermediate_field.lean
+++ b/src/field_theory/intermediate_field.lean
@@ -290,8 +290,7 @@ e.subalgebra_map E.to_subalgebra
   (a : E) : ↑(intermediate_field_map e E a) = e a := rfl
 
 @[simp] lemma intermediate_field_map_symm_apply_coe (e : L ≃ₐ[K] L') (E : intermediate_field K L)
-  (a : E.map e.to_alg_hom) :
-  ↑((intermediate_field_map e E).symm a) = e.symm a := rfl
+  (a : E.map e.to_alg_hom) : ↑((intermediate_field_map e E).symm a) = e.symm a := rfl
 
 /-- The embedding from an intermediate field of `L / K` to `L`. -/
 def val : S →ₐ[K] L :=

--- a/src/field_theory/intermediate_field.lean
+++ b/src/field_theory/intermediate_field.lean
@@ -280,9 +280,18 @@ set_like.coe_injective $ set.image_image _ _ _
 /-- Given an equivalence `e : L ≃ₐ[K] L'` of `K`-field extensions and an intermediate
 field `E` of `L/K`, `intermediate_field_equiv_map e E` is the induced equivalence
 between `E` and `E.map e` -/
-@[simps] def intermediate_field_map (e : L ≃ₐ[K] L') (E : intermediate_field K L) :
+def intermediate_field_map (e : L ≃ₐ[K] L') (E : intermediate_field K L) :
   E ≃ₐ[K] (E.map e.to_alg_hom) :=
 e.subalgebra_map E.to_subalgebra
+
+/- We add these two simp lemmas manually because `@[simps]` before `intermediate_field_map`
+  led to a timeout. -/
+@[simp] lemma intermediate_field_map_apply_coe (e : L ≃ₐ[K] L') (E : intermediate_field K L) (a : E) :
+  ↑(intermediate_field_map e E a) = e a := rfl
+
+@[simp] lemma intermediate_field_map_symm_apply_coe (e : L ≃ₐ[K] L') (E : intermediate_field K L)
+  (a : subsemiring.map e.to_ring_equiv.to_ring_hom E.to_subalgebra.to_subsemiring) :
+  ↑((intermediate_field_map e E).symm a) = e.symm a := rfl
 
 /-- The embedding from an intermediate field of `L / K` to `L`. -/
 def val : S →ₐ[K] L :=

--- a/src/field_theory/intermediate_field.lean
+++ b/src/field_theory/intermediate_field.lean
@@ -284,12 +284,12 @@ def intermediate_field_map (e : L ≃ₐ[K] L') (E : intermediate_field K L) :
   E ≃ₐ[K] (E.map e.to_alg_hom) :=
 e.subalgebra_map E.to_subalgebra
 
-/- We add these two simp lemmas manually because `@[simps]` before `intermediate_field_map`
+/- We manually add these two simp lemmas because `@[simps]` before `intermediate_field_map`
   led to a timeout. -/
-lemma intermediate_field_map_apply_coe (e : L ≃ₐ[K] L') (E : intermediate_field K L) (a : E) :
-  ↑(intermediate_field_map e E a) = e a := rfl
+@[simp] lemma intermediate_field_map_apply_coe (e : L ≃ₐ[K] L') (E : intermediate_field K L)
+  (a : E) : ↑(intermediate_field_map e E a) = e a := rfl
 
-lemma intermediate_field_map_symm_apply_coe (e : L ≃ₐ[K] L') (E : intermediate_field K L)
+@[simp] lemma intermediate_field_map_symm_apply_coe (e : L ≃ₐ[K] L') (E : intermediate_field K L)
   (a : subsemiring.map e.to_ring_equiv.to_ring_hom E.to_subalgebra.to_subsemiring) :
   ↑((intermediate_field_map e E).symm a) = e.symm a := rfl
 

--- a/src/field_theory/intermediate_field.lean
+++ b/src/field_theory/intermediate_field.lean
@@ -290,7 +290,7 @@ e.subalgebra_map E.to_subalgebra
   (a : E) : ↑(intermediate_field_map e E a) = e a := rfl
 
 @[simp] lemma intermediate_field_map_symm_apply_coe (e : L ≃ₐ[K] L') (E : intermediate_field K L)
-  (a : subsemiring.map e.to_ring_equiv.to_ring_hom E.to_subalgebra.to_subsemiring) :
+  (a : E.map e.to_alg_hom) :
   ↑((intermediate_field_map e E).symm a) = e.symm a := rfl
 
 /-- The embedding from an intermediate field of `L / K` to `L`. -/

--- a/src/field_theory/intermediate_field.lean
+++ b/src/field_theory/intermediate_field.lean
@@ -286,10 +286,10 @@ e.subalgebra_map E.to_subalgebra
 
 /- We add these two simp lemmas manually because `@[simps]` before `intermediate_field_map`
   led to a timeout. -/
-@[simp] lemma intermediate_field_map_apply_coe (e : L ≃ₐ[K] L') (E : intermediate_field K L) (a : E) :
+lemma intermediate_field_map_apply_coe (e : L ≃ₐ[K] L') (E : intermediate_field K L) (a : E) :
   ↑(intermediate_field_map e E a) = e a := rfl
 
-@[simp] lemma intermediate_field_map_symm_apply_coe (e : L ≃ₐ[K] L') (E : intermediate_field K L)
+lemma intermediate_field_map_symm_apply_coe (e : L ≃ₐ[K] L') (E : intermediate_field K L)
   (a : subsemiring.map e.to_ring_equiv.to_ring_hom E.to_subalgebra.to_subsemiring) :
   ↑((intermediate_field_map e E).symm a) = e.symm a := rfl
 


### PR DESCRIPTION
+ Remove `@[simps]` from `intermediate_field_map` to reduce `decl post-processing of intermediate_field_map` from 18.3s to 46.4ms (on my machine).

+ Manually provide the two `simp` lemmas previously auto-generated by `@[simps]`. Mathlib compiles even without the two simp lemmas (see commit 1f5a7f1), but I am inclined to keep them in case some other branches/projects are using them.

[Zulip reports](https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/deterministic.20timeout/near/285792556) about `intermediate_field_map` causing timeout in two separate branches

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
