### PR TITLE
feat(analysis/fourier) Make Fourier theory more usable

### DIFF
--- a/docs/100.yaml
+++ b/docs/100.yaml
@@ -288,8 +288,8 @@
 76:
   title  : Fourier Series
   decls   :
-    - fourier_series_repr
-    - has_sum_fourier_series
+    - fourier_circle.fourier_series_repr
+    - fourier_circle.has_sum_fourier_series
   author : Heather Macbeth
 77:
   title  : Sum of kth powers

--- a/docs/undergrad.yaml
+++ b/docs/undergrad.yaml
@@ -352,7 +352,7 @@ Single Variable Real Analysis:
     continuity of the limit: 'continuous_of_uniform_approx_of_continuous'
     differentiability of the limit: 'https://en.wikipedia.org/wiki/Uniform_convergence#To_differentiability'
     Weierstrass polynomial approximation theorem: 'polynomial_functions_closure_eq_top'
-    Weierstrass trigonometric approximation theorem: 'span_fourier_closure_eq_top'
+    Weierstrass trigonometric approximation theorem: 'fourier_circle.span_fourier_closure_eq_top'
   Convexity:
     convex functions of a real variable: 'convex_on'
     continuity and differentiability of convex functions: 'https://en.wikipedia.org/wiki/Convex_function#Functions_of_one_variable'
@@ -435,7 +435,7 @@ Topology:
     inner product space $L^2$: 'measure_theory.L2.inner_product_space'
     its completeness: 'measure_theory.Lp.complete_space'
     Hilbert bases: 'hilbert_basis' # the document specifies "in the separable case" but we don't require this
-    example, the Hilbert basis of trigonometric polynomials: 'fourier_series'
+    example, the Hilbert basis of trigonometric polynomials: 'fourier_circle.fourier_series'
     example, classical Hilbert bases of orthogonal polynomials: ''
     Lax-Milgram theorem: 'is_coercive.continuous_linear_equiv_of_bilin'
     $H^1_0([0,1])$ and its application to the one-dimensional Dirichlet problem: ''
@@ -524,7 +524,7 @@ Measures and integral calculus:
     convolution product of periodic functions: ''
     Dirichlet theorem: ''
     Fejer theorem: ''
-    Parseval theorem: 'tsum_sq_fourier_series_repr'
+    Parseval theorem: 'fourier_circle.tsum_sq_fourier_series_repr'
     Fourier transforms on $\mathrm{L}^1(\R^d)$ and $\mathrm{L}^2(\R^d)$: ''
     Plancherel’s theorem: ''
 

--- a/src/analysis/fourier.lean
+++ b/src/analysis/fourier.lean
@@ -107,16 +107,14 @@ end
 def circle_measure : measure circle :=
   (ennreal.of_real (1 / (2 * π)) • volume).map circle_m_equiv
 
-lemma circle_measure_univ : circle_measure univ = 1 :=
-begin
+instance : is_probability_measure circle_measure :=
+⟨begin
   dsimp only [circle_measure],
   rw [circle_m_equiv.map_apply, preimage_univ, measure.smul_apply, id.smul_eq_mul,
     ←volume_image_subtype_coe (@measurable_set_Ioc ℝ _ _ _ _ _ _ _), image_univ,
     subtype.range_coe, real.volume_Ioc, ←ennreal.of_real_mul (one_div_nonneg.mpr two_pi_pos.le)],
   ring_nf, field_simp [real.pi_ne_zero],
-end
-
-instance : is_probability_measure circle_measure := ⟨circle_measure_univ⟩
+end⟩
 
 instance : measure_space circle := { volume := circle_measure,  .. circle.measurable_space }
 

--- a/src/analysis/special_functions/complex/arg.lean
+++ b/src/analysis/special_functions/complex/arg.lean
@@ -557,4 +557,44 @@ by simpa only [arg_eq_pi_iff.2 ⟨hre, him⟩]
 
 end continuity
 
+section arg'
+
+/-- Branch of argument function valued in `(0, 2 * π]`. -/
+def arg' (x : ℂ) : ℝ := if (0 < arg x) then arg x else arg x + 2 * π
+
+lemma arg'_mem_Ioc (x : ℂ) : arg' x ∈ Ioc 0 (2 * π) :=
+begin
+  rw arg', split_ifs,
+  { refine ⟨h, _⟩, linarith [arg_le_pi x, real.pi_pos], },
+  { push_neg at h, split, linarith [neg_pi_lt_arg x], linarith, }
+end
+
+lemma arg'_eq_arg (x : ℂ) : (arg' x = arg x) ∨ (arg' x = arg x + 2 * π) :=
+begin
+  rw arg', split_ifs, tauto, tauto,
+end
+
+/-- Alternate definition of arg' for nonzero `x`. Note it is false for `x = 0`! -/
+lemma arg'_eq_arg_neg_add (x : ℂ) (hx : x ≠ 0) : arg' x = arg (-x) + π :=
+begin
+  rw arg', split_ifs,
+  { apply eq_add_of_sub_eq, symmetry,
+    rw arg_neg_eq_arg_sub_pi_iff,
+    rw lt_iff_le_and_ne at h, cases h, rw arg_nonneg_iff at h_left,
+    rw le_iff_lt_or_eq at h_left, cases h_left, tauto, contrapose! hx,
+    cases hx, replace hx_right := hx_right h_left.symm,
+    symmetry' at h_right,
+    rw [ne.def, arg_eq_zero_iff] at h_right,  push_neg at h_right, tauto },
+  { push_neg at h,
+    apply eq_add_of_sub_eq, ring_nf, symmetry,
+    rw arg_neg_eq_arg_add_pi_iff, rcases h.lt_or_eq,
+    { rw arg_neg_iff at h_1, tauto, },
+    { rw arg_eq_zero_iff at h_1, right, split, tauto,
+      rcases h_1.1.lt_or_eq, tauto,
+      exfalso, contrapose! hx, ext1, tauto, tauto, } },
+end
+
+end arg'
+
+
 end complex

--- a/src/analysis/special_functions/complex/circle.lean
+++ b/src/analysis/special_functions/complex/circle.lean
@@ -47,7 +47,7 @@ noncomputable def arg_local_equiv : local_equiv circle ℝ :=
   left_inv' := λ z _, exp_map_circle_arg z,
   right_inv' := λ x hx, arg_exp_map_circle hx.1 hx.2 }
 
-/-- `complex.arg` and `exp_map_circle` define an equivalence between `circle and `(-π, π]`. -/
+/-- `complex.arg` and `exp_map_circle` define an equivalence between `circle` and `(-π, π]`. -/
 @[simps { fully_applied := ff }]
 noncomputable def arg_equiv : circle ≃ Ioc (-π) π :=
 { to_fun := λ z, ⟨arg z, neg_pi_lt_arg _, arg_le_pi _⟩,
@@ -87,6 +87,43 @@ periodic_exp_map_circle.sub_eq x
 lemma exp_map_circle_add_two_pi (x : ℝ) : exp_map_circle (x + 2 * π) = exp_map_circle x :=
 periodic_exp_map_circle x
 
+
+section arg'_equiv
+
+lemma arg'_exp_map_circle {x : ℝ} (h₁ : 0 < x) (h₂ : x ≤ 2 * π) : arg' (exp_map_circle x) = x :=
+begin
+  rw arg'_eq_arg_neg_add _ (ne_zero_of_mem_circle _), apply add_eq_of_eq_sub,
+  have : arg (exp_map_circle (x - π)) = x - π,
+  { apply arg_exp_map_circle, linarith, linarith },
+  rw [←this, exp_map_circle_apply, exp_map_circle_apply, of_real_sub, sub_mul, exp_sub,
+    exp_pi_mul_I, div_neg, div_one],
+end
+
+lemma exp_map_circle_arg' (z : circle) : exp_map_circle (arg' z) = z :=
+begin
+  rcases arg'_eq_arg z,
+  { rw h, apply exp_map_circle_arg, },
+  { rw [h, exp_map_circle_add_two_pi], apply exp_map_circle_arg },
+end
+
+namespace circle
+
+/-- Equivalence between `circle` and `(0, 2 * π]` given by `arg'`. -/
+noncomputable def arg'_equiv : circle ≃ Ioc 0 (2 * π) :=
+{ to_fun := λ z, ⟨arg' z, arg'_mem_Ioc z⟩,
+  inv_fun := exp_map_circle ∘ coe,
+  left_inv := λ z, exp_map_circle_arg' z,
+  right_inv := λ x, subtype.ext (arg'_exp_map_circle x.2.1 x.2.2) }
+
+/-- Equivalence between `(0, 2 * π]` and `circle` given by `exp_map_circle`. -/
+noncomputable def circle_equiv : Ioc 0 (2 * π) ≃ circle := arg'_equiv.symm
+
+end circle
+
+end arg'_equiv
+
+section angle
+
 /-- `exp_map_circle`, applied to a `real.angle`. -/
 noncomputable def real.angle.exp_map_circle (θ : real.angle) : circle :=
 periodic_exp_map_circle.lift θ
@@ -122,3 +159,5 @@ begin
   rw [real.angle.exp_map_circle_coe, exp_map_circle_apply, exp_mul_I, ←of_real_cos,
       ←of_real_sin, ←real.angle.cos_coe, ←real.angle.sin_coe, arg_cos_add_sin_mul_I_coe_angle]
 end
+
+end angle


### PR DESCRIPTION
The file `analysis/fourier.lean` has some great results, but it is less usable than it might be. One difficulty in using the present formulations is that the results are formulated intrinsically for functions on `circle`, i.e. the unit circle in ℂ, rather than identifying the circle with a quotient of ℝ. The main change in this PR is to change the definition of the measure on `circle` to be the pushforward of the measure from `(0, 2 * π]`, and thus get access to all the library results about integrals over intervals in  ℝ.

(A future PR, building on this one, will give a direct definition of Fourier coefficients for functions on ℝ.)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)

- [x] depends on: #14722