### PR TITLE
[Merged by Bors] - feat(geometry/manifold/diffeomorph): some additions needed for smooth vector bundles

### DIFF
--- a/src/geometry/manifold/cont_mdiff.lean
+++ b/src/geometry/manifold/cont_mdiff.lean
@@ -850,6 +850,16 @@ lemma smooth.comp_smooth_on {f : M → M'} {g : M' → M''} {s : set M}
   smooth_on I I'' (g ∘ f) s :=
 hg.smooth_on.comp hf set.subset_preimage_univ
 
+lemma cont_mdiff_on.comp_cont_mdiff {t : set M'} {g : M' → M''}
+  (hg : cont_mdiff_on I' I'' n g t) (hf : cont_mdiff I I' n f)
+  (ht : ∀ x, f x ∈ t) : cont_mdiff I I'' n (g ∘ f) :=
+cont_mdiff_on_univ.mp $ hg.comp hf.cont_mdiff_on (λ x _, ht x)
+
+lemma smooth_on.comp_smooth {t : set M'} {g : M' → M''}
+  (hg : smooth_on I' I'' g t) (hf : smooth I I' f)
+  (ht : ∀ x, f x ∈ t) : smooth I I'' (g ∘ f) :=
+hg.comp_cont_mdiff hf ht
+
 end composition
 
 /-! ### Atlas members are smooth -/

--- a/src/geometry/manifold/diffeomorph.lean
+++ b/src/geometry/manifold/diffeomorph.lean
@@ -53,12 +53,14 @@ variables {𝕜 : Type*} [nondiscrete_normed_field 𝕜]
 {H : Type*} [topological_space H]
 {H' : Type*} [topological_space H']
 {G : Type*} [topological_space G]
+{G' : Type*} [topological_space G']
 {I : model_with_corners 𝕜 E H} {I' : model_with_corners 𝕜 E' H'}
-{J : model_with_corners 𝕜 F G}
+{J : model_with_corners 𝕜 F G} {J' : model_with_corners 𝕜 F G'}
 
 variables {M : Type*} [topological_space M] [charted_space H M]
 {M' : Type*} [topological_space M'] [charted_space H' M']
 {N : Type*} [topological_space N] [charted_space G N]
+{N' : Type*} [topological_space N'] [charted_space G' N']
 {n : with_top ℕ}
 
 section defs
@@ -256,6 +258,46 @@ forall_congr $ λ x, h.cont_mdiff_within_at_diffeomorph_comp_iff hm
 lemma to_local_homeomorph_mdifferentiable (h : M ≃ₘ^n⟮I, J⟯ N) (hn : 1 ≤ n) :
   h.to_homeomorph.to_local_homeomorph.mdifferentiable I J :=
 ⟨h.mdifferentiable_on _ hn, h.symm.mdifferentiable_on _ hn⟩
+
+section constructions
+
+/-- Product of two diffeomorphisms. -/
+def prod_congr (h₁ : M ≃ₘ^n⟮I, I'⟯ M') (h₂ : N ≃ₘ^n⟮J, J'⟯ N') :
+  M × N ≃ₘ^n⟮I.prod J, I'.prod J'⟯ M' × N' :=
+{ cont_mdiff_to_fun  := (h₁.cont_mdiff.comp cont_mdiff_fst).prod_mk
+    (h₂.cont_mdiff.comp cont_mdiff_snd),
+  cont_mdiff_inv_fun := (h₁.symm.cont_mdiff.comp cont_mdiff_fst).prod_mk
+    (h₂.symm.cont_mdiff.comp cont_mdiff_snd),
+  to_equiv := h₁.to_equiv.prod_congr h₂.to_equiv }
+
+@[simp] lemma prod_congr_symm (h₁ : M ≃ₘ^n⟮I, I'⟯ M') (h₂ : N ≃ₘ^n⟮J, J'⟯ N') :
+  (h₁.prod_congr h₂).symm = h₁.symm.prod_congr h₂.symm := rfl
+
+@[simp] lemma coe_prod_congr (h₁ : M ≃ₘ^n⟮I, I'⟯ M') (h₂ : N ≃ₘ^n⟮J, J'⟯ N') :
+  ⇑(h₁.prod_congr h₂) = prod.map h₁ h₂ := rfl
+
+section
+variables (I J J' M N N' n)
+
+/-- `M × N` is diffeomorphic to `N × M`. -/
+def prod_comm : M × N ≃ₘ^n⟮I.prod J, J.prod I⟯ N × M :=
+{ cont_mdiff_to_fun  := cont_mdiff_snd.prod_mk cont_mdiff_fst,
+  cont_mdiff_inv_fun := cont_mdiff_snd.prod_mk cont_mdiff_fst,
+  to_equiv := equiv.prod_comm M N }
+
+@[simp] lemma prod_comm_symm : (prod_comm I J M N n).symm = prod_comm J I N M n := rfl
+@[simp] lemma coe_prod_comm : ⇑(prod_comm I J M N n) = prod.swap := rfl
+
+/-- `(M × N) × N'` is diffeomorphic to `M × (N × N')`. -/
+def prod_assoc : (M × N) × N' ≃ₘ^n⟮(I.prod J).prod J', I.prod (J.prod J')⟯ M × (N × N') :=
+{ cont_mdiff_to_fun  := (cont_mdiff_fst.comp cont_mdiff_fst).prod_mk
+    ((cont_mdiff_snd.comp cont_mdiff_fst).prod_mk cont_mdiff_snd),
+  cont_mdiff_inv_fun := (cont_mdiff_fst.prod_mk (cont_mdiff_fst.comp cont_mdiff_snd)).prod_mk
+    (cont_mdiff_snd.comp cont_mdiff_snd),
+  to_equiv := equiv.prod_assoc M N N' }
+
+end
+end constructions
 
 variables [smooth_manifold_with_corners I M] [smooth_manifold_with_corners J N]
 

--- a/src/topology/fiber_bundle.lean
+++ b/src/topology/fiber_bundle.lean
@@ -1052,20 +1052,31 @@ end
 @[simp, mfld_simps] lemma local_triv_apply (p : Z.total_space) :
   (Z.local_triv i) p = ⟨p.1, Z.coord_change (Z.index_at p.1) i p.1 p.2⟩ := rfl
 
+@[simp, mfld_simps] lemma local_triv_at_apply (p : Z.total_space) :
+  ((Z.local_triv_at p.1) p) = ⟨p.1, p.2⟩ :=
+by { rw [local_triv_at, local_triv_apply, coord_change_self], exact Z.mem_base_set_at p.1 }
+
+@[simp, mfld_simps] lemma local_triv_at_apply_mk (b : B) (a : F) :
+  ((Z.local_triv_at b) ⟨b, a⟩) = ⟨b, a⟩ :=
+Z.local_triv_at_apply _
+
 @[simp, mfld_simps] lemma mem_local_triv_source (p : Z.total_space) :
   p ∈ (Z.local_triv i).source ↔ p.1 ∈ (Z.local_triv i).base_set := iff.rfl
+
+@[simp, mfld_simps] lemma mem_local_triv_at_source (p : Z.total_space) (b : B) :
+  p ∈ (Z.local_triv_at b).source ↔ p.1 ∈ (Z.local_triv_at b).base_set := iff.rfl
 
 @[simp, mfld_simps] lemma mem_local_triv_target (p : B × F) :
   p ∈ (Z.local_triv i).target ↔ p.1 ∈ (Z.local_triv i).base_set :=
 trivialization.mem_target _
 
-@[simp, mfld_simps] lemma local_triv_symm_fst (p : B × F) :
+@[simp, mfld_simps] lemma mem_local_triv_at_target (p : B × F) (b : B) :
+  p ∈ (Z.local_triv_at b).target ↔ p.1 ∈ (Z.local_triv_at b).base_set :=
+trivialization.mem_target _
+
+@[simp, mfld_simps] lemma local_triv_symm_apply (p : B × F) :
   (Z.local_triv i).to_local_homeomorph.symm p =
     ⟨p.1, Z.coord_change i (Z.index_at p.1) p.1 p.2⟩ := rfl
-
-@[simp, mfld_simps] lemma local_triv_at_apply (b : B) (a : F) :
-  ((Z.local_triv_at b) ⟨b, a⟩) = ⟨b, a⟩ :=
-by { rw [local_triv_at, local_triv_apply, coord_change_self], exact Z.mem_base_set_at b }
 
 @[simp, mfld_simps] lemma mem_local_triv_at_base_set (b : B) :
   b ∈ (Z.local_triv_at b).base_set :=

--- a/src/topology/vector_bundle/basic.lean
+++ b/src/topology/vector_bundle/basic.lean
@@ -742,14 +742,14 @@ namespace topological_vector_bundle_core
 variables {R B F} {ι : Type*} (Z : topological_vector_bundle_core R B F ι)
 
 /-- Natural identification to a `topological_fiber_bundle_core`. -/
-def to_topological_vector_bundle_core : topological_fiber_bundle_core ι B F :=
+def to_topological_fiber_bundle_core : topological_fiber_bundle_core ι B F :=
 { coord_change := λ i j b, Z.coord_change i j b,
   coord_change_continuous := λ i j, is_bounded_bilinear_map_apply.continuous.comp_continuous_on
       ((Z.coord_change_continuous i j).prod_map continuous_on_id),
   ..Z }
 
-instance to_topological_vector_bundle_core_coe : has_coe (topological_vector_bundle_core R B F ι)
-  (topological_fiber_bundle_core ι B F) := ⟨to_topological_vector_bundle_core⟩
+instance to_topological_fiber_bundle_core_coe : has_coe (topological_vector_bundle_core R B F ι)
+  (topological_fiber_bundle_core ι B F) := ⟨to_topological_fiber_bundle_core⟩
 
 include Z
 
@@ -858,8 +858,13 @@ Z.local_triv (Z.index_at b)
 @[simp, mfld_simps] lemma mem_source_at : (⟨b, a⟩ : Z.total_space) ∈ (Z.local_triv_at b).source :=
 by { rw [local_triv_at, mem_local_triv_source], exact Z.mem_base_set_at b }
 
-@[simp, mfld_simps] lemma local_triv_at_apply : ((Z.local_triv_at b) ⟨b, a⟩) = ⟨b, a⟩ :=
-topological_fiber_bundle_core.local_triv_at_apply Z b a
+@[simp, mfld_simps] lemma local_triv_at_apply (p : Z.total_space) :
+  ((Z.local_triv_at p.1) p) = ⟨p.1, p.2⟩ :=
+topological_fiber_bundle_core.local_triv_at_apply Z p
+
+@[simp, mfld_simps] lemma local_triv_at_apply_mk (b : B) (a : F) :
+  ((Z.local_triv_at b) ⟨b, a⟩) = ⟨b, a⟩ :=
+Z.local_triv_at_apply _
 
 @[simp, mfld_simps] lemma mem_local_triv_at_base_set :
   b ∈ (Z.local_triv_at b).base_set :=
@@ -876,9 +881,9 @@ instance : topological_vector_bundle R F Z.fiber :=
       rw [preimage_inter, ←preimage_comp, function.comp],
       simp only [total_space_mk],
       refine ext_iff.mpr (λ a, ⟨λ ha, _, λ ha, ⟨Z.mem_base_set_at b, _⟩⟩),
-      { simp only [mem_prod, mem_preimage, mem_inter_eq, local_triv_at_apply] at ha,
+      { simp only [mem_prod, mem_preimage, mem_inter_eq, local_triv_at_apply_mk] at ha,
         exact ha.2.2, },
-      { simp only [mem_prod, mem_preimage, mem_inter_eq, local_triv_at_apply],
+      { simp only [mem_prod, mem_preimage, mem_inter_eq, local_triv_at_apply_mk],
         exact ⟨Z.mem_base_set_at b, ha⟩, } } end⟩,
   trivialization_atlas := set.range Z.local_triv,
   trivialization_at := Z.local_triv_at,


### PR DESCRIPTION
* Define `diffeomorph.prod_comm`, `diffeomorph.prod_congr`, `diffeomorph.prod_assoc`
* Prove `cont_mdiff_on.comp_cont_mdiff`
* In `fiber_bundle`, define some lemmas for `local_triv_at` that were already there for `local_triv`
* Yes, this PR does a couple different things, but it is still very small
* This is part of #14412

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
