### PR TITLE
[Merged by Bors] - chore(data/nat/factorization/basic): delete two duplicate lemmas

### DIFF
--- a/src/data/nat/factorization/basic.lean
+++ b/src/data/nat/factorization/basic.lean
@@ -385,38 +385,6 @@ begin
     simp [←factorization_le_iff_dvd he_pos hd_pos, h1, hea', heb'] },
 end
 
-lemma div_factorization_pos {q r : ℕ} (hr : nat.prime r) (hq : q ≠ 0) :
-  q / (r ^ (q.factorization r)) ≠ 0 :=
-begin
-  set n := q.factorization r,
-  set a := q / (r ^ n),
-  apply mt (nat.div_eq_zero_iff (pow_pos (nat.prime.pos hr) _)).1,
-  exact not_lt.mpr (nat.le_of_dvd (pos_iff_ne_zero.mpr hq) (nat.pow_factorization_dvd q r)),
-end
-
-lemma ne_dvd_factorization_div {q r : ℕ} (hr : nat.prime r) (hq : q ≠ 0) :
-  ¬(r ∣ (q / (r ^ (q.factorization r)))) :=
-begin
-  set n := q.factorization r,
-  set a := q / (r ^ n),
-  by_contradiction r_dvd_a,
-
-  have a_fact_r_pos : a.factorization r ≠ 0 := ne_of_gt (
-    nat.prime.factorization_pos_of_dvd hr (div_factorization_pos hr hq) r_dvd_a),
-
-  have a_fact_r_zero: a.factorization r = 0 :=
-  calc  a.factorization r
-    = (q.factorization - (r ^ n).factorization) r     : by rw ←nat.factorization_div (
-                                                        nat.pow_factorization_dvd q r)
-    ... = q.factorization r - (r ^ n).factorization r : (nat.factorization q).tsub_apply
-                                                        (r ^ n).factorization r
-    ... = n - (finsupp.single r n) r                  : by rw nat.prime.factorization_pow hr
-    ... = n - n                                       : by rw [finsupp.single_eq_same, tsub_self]
-    ... = 0                                           : tsub_self n,
-
-  exact absurd a_fact_r_zero a_fact_r_pos,
-end
-
 /-! ### Factorization and coprimes -/
 
 /-- For coprime `a` and `b`, the power of `p` in `a * b` is the sum of the powers in `a` and `b` -/


### PR DESCRIPTION
Deleting two lemmas introduced in #14461 that are duplicates of lemmas already present, as follows:

```
lemma div_factorization_pos {q r : ℕ} (hr : nat.prime r) (hq : q ≠ 0) :
  q / (r ^ (q.factorization r)) ≠ 0 := div_pow_factorization_ne_zero r hq
```

```
lemma ne_dvd_factorization_div {q r : ℕ} (hr : nat.prime r) (hq : q ≠ 0) :
  ¬(r ∣ (q / (r ^ (q.factorization r)))) := not_dvd_div_pow_factorization hr hq
```

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
