### PR TITLE
[Merged by Bors] - feat(model_theory/satisfiability): The Łoś–Vaught Test

### DIFF
--- a/docs/overview.yaml
+++ b/docs/overview.yaml
@@ -427,5 +427,4 @@ Logic and computation:
     definable set: 'set.definable'
     elementary embedding: 'first_order.language.elementary_embedding'
     Compactness theorem: 'first_order.language.Theory.is_satisfiable_iff_is_finitely_satisfiable'
-    Downward Löwenheim-Skolem: 'first_order.language.exists_elementary_substructure_card_eq'
-    Upward Löwenheim-Skolem: 'first_order.language.Theory.exists_elementary_embedding_card_eq'
+    Löwenheim-Skolem: 'first_order.language.exists_elementary_embedding_card_eq'

--- a/src/model_theory/bundled.lean
+++ b/src/model_theory/bundled.lean
@@ -27,9 +27,27 @@ variables {L : first_order.language.{u v}}
   L.Structure M :=
 M.str
 
+open_locale first_order cardinal
+
+namespace equiv
+
+variables (L) {M : Type w} [L.Structure M] {N : Type w'} (g : M ≃ N)
+
+/-- A type bundled with the structure induced by an equivalence. -/
+@[simps] def bundled_induced  :
+  category_theory.bundled.{w'} L.Structure :=
+⟨N, g.induced_Structure⟩
+
+/-- An equivalence of types as a first-order equivalence to the bundled structure on the codomain.
+-/
+@[simp] def bundled_induced_equiv :
+  M ≃[L] g.bundled_induced L :=
+g.induced_Structure_equiv
+
+end equiv
+
 namespace first_order
 namespace language
-open_locale first_order
 
 /-- The equivalence relation on bundled `L.Structure`s indicating that they are isomorphic. -/
 instance equiv_setoid : setoid (category_theory.bundled L.Structure) :=
@@ -85,6 +103,9 @@ def equiv_induced {M : Model.{u v w} T} {N : Type w'} (e : M ≃ N) :
   is_model := @equiv.Theory_model L M N _ e.induced_Structure T e.induced_Structure_equiv _,
   nonempty' := e.symm.nonempty }
 
+instance of_small (M : Type w) [nonempty M] [L.Structure M] [M ⊨ T] [h : small.{w'} M] :
+  small.{w'} (Model.of T M) := h
+
 /-- Shrinks a small model to a particular universe. -/
 noncomputable def shrink (M : Model.{u v w} T) [small.{w'} M] :
   Model.{u v w'} T := equiv_induced (equiv_shrink M)
@@ -124,9 +145,17 @@ lemma coe_of {M : Type w} [L.Structure M] [nonempty M] (h : M ⊨ T) :
 
 end Theory
 
+/-- A structure that is elementarily equivalent to a model, bundled as a model. -/
+def elementarily_equivalent.to_Model {M : T.Model} {N : Type*} [LN : L.Structure N] (h : M ≅[L] N) :
+  T.Model :=
+{ carrier := N,
+  struc := LN,
+  nonempty' := h.nonempty,
+  is_model := h.Theory_model }
+
 /-- An elementary substructure of a bundled model as a bundled model. -/
 def elementary_substructure.to_Model {M : T.Model} (S : L.elementary_substructure M) : T.Model :=
-Theory.Model.of T S
+S.elementarily_equivalent.symm.to_Model T
 
 instance {M : T.Model} (S : L.elementary_substructure M) [h : small S] :
   small (S.to_Model T) :=

--- a/src/model_theory/semantics.lean
+++ b/src/model_theory/semantics.lean
@@ -785,6 +785,9 @@ by rw [sentence.realize, sentence.realize, ← g.realize_formula, unique.eq_defa
 lemma Theory_model (g : M ≃[L] N) [M ⊨ T] : N ⊨ T :=
 ⟨λ φ hφ, (g.realize_sentence φ).1 (Theory.realize_sentence_of_mem T hφ)⟩
 
+lemma elementarily_equivalent (g : M ≃[L] N) : M ≅[L] N :=
+elementarily_equivalent_iff.2 g.realize_sentence
+
 end equiv
 
 namespace relations
@@ -887,6 +890,37 @@ lemma card_le_of_model_distinct_constants_theory (s : set α) (M : Type w) [L[[�
 lift_mk_le'.2 ⟨⟨_, set.inj_on_iff_injective.1 ((L.model_distinct_constants_theory s).1 h)⟩⟩
 
 end cardinality
+
+namespace elementarily_equivalent
+
+@[symm] lemma symm (h : M ≅[L] N) : N ≅[L] M := h.symm
+
+@[trans] lemma trans (MN : M ≅[L] N) (NP : N ≅[L] P) : M ≅[L] P := MN.trans NP
+
+lemma complete_theory_eq (h : M ≅[L] N) : L.complete_theory M = L.complete_theory N := h
+
+lemma realize_sentence (h : M ≅[L] N) (φ : L.sentence) : M ⊨ φ ↔ N ⊨ φ :=
+(elementarily_equivalent_iff.1 h) φ
+
+lemma Theory_model_iff (h : M ≅[L] N) : M ⊨ T ↔ N ⊨ T :=
+by rw [Theory.model_iff_subset_complete_theory, Theory.model_iff_subset_complete_theory,
+    h.complete_theory_eq]
+
+lemma Theory_model [MT : M ⊨ T] (h : M ≅[L] N) : N ⊨ T :=
+h.Theory_model_iff.1 MT
+
+lemma nonempty_iff (h : M ≅[L] N) : nonempty M ↔ nonempty N :=
+(model_nonempty_theory_iff L).symm.trans (h.Theory_model_iff.trans (model_nonempty_theory_iff L))
+
+lemma nonempty [Mn : nonempty M] (h : M ≅[L] N) : nonempty N := h.nonempty_iff.1 Mn
+
+lemma infinite_iff (h : M ≅[L] N) : infinite M ↔ infinite N :=
+(model_infinite_theory_iff L).symm.trans (h.Theory_model_iff.trans (model_infinite_theory_iff L))
+
+lemma infinite [Mi : infinite M] (h : M ≅[L] N) : infinite N := h.infinite_iff.1 Mi
+
+end elementarily_equivalent
+
 
 end language
 end first_order

--- a/src/set_theory/cardinal/basic.lean
+++ b/src/set_theory/cardinal/basic.lean
@@ -654,6 +654,18 @@ end
 @[simp] protected theorem supr_of_empty {ι} (f : ι → cardinal) [is_empty ι] : supr f = 0 :=
 csupr_of_empty f
 
+@[simp] lemma lift_mk_shrink (α : Type u) [small.{v} α] :
+  cardinal.lift.{max u w} (# (shrink.{v} α)) = cardinal.lift.{max v w} (# α) :=
+lift_mk_eq.2 ⟨(equiv_shrink α).symm⟩
+
+@[simp] lemma lift_mk_shrink' (α : Type u) [small.{v} α] :
+  cardinal.lift.{u} (# (shrink.{v} α)) = cardinal.lift.{v} (# α) :=
+lift_mk_shrink.{u v 0} α
+
+@[simp] lemma lift_mk_shrink'' (α : Type (max u v)) [small.{v} α] :
+  cardinal.lift.{u} (# (shrink.{v} α)) = # α :=
+by rw [← lift_umax', lift_mk_shrink.{(max u v) v 0} α, ← lift_umax, lift_id]
+
 /-- The indexed product of cardinals is the cardinality of the Pi type
   (dependent product). -/
 def prod {ι : Type u} (f : ι → cardinal) : cardinal := #(Π i, (f i).out)


### PR DESCRIPTION
Provides more API for elementary equivalence
Shows that a `κ`-categorical theory with only infinite models is complete.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
