### PR TITLE
[Merged by Bors] - chore(order/pfilter): more `principal` API

### DIFF
--- a/src/order/pfilter.lean
+++ b/src/order/pfilter.lean
@@ -161,4 +161,3 @@ end complete_semilattice_Inf_stuff
 end pfilter
 
 end order
-#lint

--- a/src/order/pfilter.lean
+++ b/src/order/pfilter.lean
@@ -95,8 +95,9 @@ ideal.mem_of_mem_of_le
 /-- The smallest filter containing a given element. -/
 def principal (p : P) : pfilter P := ⟨ideal.principal p⟩
 
-@[simp] lemma mem_def (x : P) (I : ideal Pᵒᵈ) : x ∈ ({dual := I} : pfilter P) ↔
-  order_dual.to_dual x ∈ I := iff.rfl
+@[simp] lemma mem_def (x : P) (I : ideal Pᵒᵈ) :
+  x ∈ (⟨I⟩ : pfilter P) ↔ order_dual.to_dual x ∈ I :=
+iff.rfl
 
 @[simp] lemma principal_le_iff {F : pfilter P} : principal x ≤ F ↔ x ∈ F :=
 ideal.principal_le_iff

--- a/src/order/pfilter.lean
+++ b/src/order/pfilter.lean
@@ -144,11 +144,13 @@ section complete_semilattice_Inf_stuff
 
 variables [complete_semilattice_Inf P] {F : pfilter P}
 
-lemma Inf_gc : galois_connection (λ x, order_dual.to_dual (principal x)) (λ F, Inf (order_dual.of_dual F : pfilter P)) :=
+lemma Inf_gc : galois_connection (λ x, order_dual.to_dual (principal x))
+  (λ F, Inf (order_dual.of_dual F : pfilter P)) :=
 λ x F, by { simp, refl }
 
 /-- If a poset `P` admits arbitrary `Inf`s, then `principal` and `Inf` form a Galois coinsertion. -/
-def Inf_gi : galois_coinsertion (λ x, order_dual.to_dual (principal x)) (λ F, Inf (order_dual.of_dual F : pfilter P)) :=
+def Inf_gi : galois_coinsertion (λ x, order_dual.to_dual (principal x))
+  (λ F, Inf (order_dual.of_dual F : pfilter P)) :=
 { choice := λ F _, Inf (id F : pfilter P),
   gc := Inf_gc,
   u_l_le := λ s, Inf_le $ mem_principal.2 $ le_refl s,

--- a/src/order/pfilter.lean
+++ b/src/order/pfilter.lean
@@ -141,7 +141,7 @@ ideal.sup_mem_iff
 
 end semilattice_inf
 
-section complete_semilattice_Inf_stuff
+section complete_semilattice_Inf
 
 variables [complete_semilattice_Inf P] {F : pfilter P}
 

--- a/src/order/pfilter.lean
+++ b/src/order/pfilter.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mathieu Guay-Paquet
 -/
 import order.ideal
-
+import data.real.ennreal -- just for examples, can remove later
 /-!
 # Order filters
 
@@ -63,6 +63,8 @@ namespace pfilter
 section preorder
 variables [preorder P] {x y : P} (F s t : pfilter P)
 
+instance [inhabited P] : inhabited (pfilter P) := ⟨⟨default⟩⟩
+
 /-- A filter on `P` is a subset of `P`. -/
 instance : has_coe (pfilter P) (set P) := ⟨λ F, F.dual.carrier⟩
 
@@ -80,11 +82,6 @@ lemma directed : directed_on (≥) (F : set P) := F.dual.directed
 
 lemma mem_of_le {F : pfilter P} : x ≤ y → x ∈ F → y ∈ F := λ h, F.dual.lower h
 
-/-- The smallest filter containing a given element. -/
-def principal (p : P) : pfilter P := ⟨ideal.principal p⟩
-
-instance [inhabited P] : inhabited (pfilter P) := ⟨⟨default⟩⟩
-
 /-- Two filters are equal when their underlying sets are equal. -/
 @[ext] lemma ext (h : (s : set P) = t) : s = t :=
 by { cases s, cases t, exact congr_arg _ (ideal.ext h) }
@@ -95,8 +92,22 @@ instance : partial_order (pfilter P) := partial_order.lift coe ext
 @[trans] lemma mem_of_mem_of_le {F G : pfilter P} : x ∈ F → F ≤ G → x ∈ G :=
 ideal.mem_of_mem_of_le
 
+/-- The smallest filter containing a given element. -/
+def principal (p : P) : pfilter P := ⟨ideal.principal p⟩
+
+@[simp] lemma mem_def (x : P) (I : ideal Pᵒᵈ) : x ∈ ({dual := I} : pfilter P) ↔ x ∈ I :=
+iff.rfl
+
 @[simp] lemma principal_le_iff {F : pfilter P} : principal x ≤ F ↔ x ∈ F :=
 ideal.principal_le_iff
+
+@[simp] lemma mem_principal : x ∈ principal y ↔ y ≤ x :=
+ideal.mem_principal -- defeq abuse
+
+lemma principal_le_congr {p q : P} (h : p ≤ q) : principal q ≤ principal p :=
+by simp [h]
+
+lemma principal_le_principal_iff {p q : P} : principal p ≤ principal q ↔ q ≤ p := by simp
 
 end preorder
 
@@ -128,6 +139,24 @@ lemma inf_mem (hx : x ∈ F) (hy : y ∈ F) : x ⊓ y ∈ F := ideal.sup_mem hx 
 ideal.sup_mem_iff
 
 end semilattice_inf
+
+section complete_semilattice_Inf_stuff
+
+variables [complete_semilattice_Inf P] {F : pfilter P}
+
+-- be careful! Attempting to remove the @ may leave you with false goals because unification
+-- may not pick up the op
+lemma Inf_gc : @galois_connection P (pfilter P)ᵒᵈ _ _ principal (λ F, Inf (id F : pfilter P)) :=
+λ _ _, by simp; refl
+
+/-- If a poset `P` admits arbitrary `Inf`s, then `principal` and `Inf` form a Galois coinsertion. -/
+def Inf_gi : @galois_coinsertion P (pfilter P)ᵒᵈ _ _   principal (λ F, Inf F : pfilter P → P) :=
+{ choice := λ F _, Inf (id F : pfilter P),
+  gc := Inf_gc,
+  u_l_le := λ s, Inf_le $ mem_principal.2 $ le_refl s,
+  choice_eq := λ _ _, rfl }
+
+end complete_semilattice_Inf_stuff
 
 end pfilter
 

--- a/src/order/pfilter.lean
+++ b/src/order/pfilter.lean
@@ -104,10 +104,10 @@ ideal.principal_le_iff
 @[simp] lemma mem_principal : x ∈ principal y ↔ y ≤ x :=
 ideal.mem_principal -- defeq abuse
 
-lemma principal_le_congr {p q : P} (h : p ≤ q) : principal q ≤ principal p :=
-by simp [h]
-
 lemma antitone_principal {p q : P} : antitone (principal : P → pfilter P) := by delta antitone; simp
+
+lemma principal_le_principal_iff {p q : P} : principal q ≤ principal p ↔ p ≤ q :=
+by simp
 
 end preorder
 

--- a/src/order/pfilter.lean
+++ b/src/order/pfilter.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mathieu Guay-Paquet
 -/
 import order.ideal
-import data.real.ennreal -- just for examples, can remove later
+
 /-!
 # Order filters
 

--- a/src/order/pfilter.lean
+++ b/src/order/pfilter.lean
@@ -157,7 +157,7 @@ def Inf_gi : galois_coinsertion (λ x, order_dual.to_dual (principal x))
   u_l_le := λ s, Inf_le $ mem_principal.2 $ le_refl s,
   choice_eq := λ _ _, rfl }
 
-end complete_semilattice_Inf_stuff
+end complete_semilattice_Inf
 
 end pfilter
 

--- a/src/order/pfilter.lean
+++ b/src/order/pfilter.lean
@@ -144,13 +144,11 @@ section complete_semilattice_Inf_stuff
 
 variables [complete_semilattice_Inf P] {F : pfilter P}
 
--- be careful! Attempting to remove the @ may leave you with false goals because unification
--- may not pick up the op
-lemma Inf_gc : @galois_connection P (pfilter P)ᵒᵈ _ _ principal (λ F, Inf (id F : pfilter P)) :=
-λ _ _, by simp; refl
+lemma Inf_gc : galois_connection (λ x, order_dual.to_dual (principal x)) (λ F, Inf (order_dual.of_dual F : pfilter P)) :=
+λ x F, by { simp, refl }
 
 /-- If a poset `P` admits arbitrary `Inf`s, then `principal` and `Inf` form a Galois coinsertion. -/
-def Inf_gi : @galois_coinsertion P (pfilter P)ᵒᵈ _ _   principal (λ F, Inf F : pfilter P → P) :=
+def Inf_gi : galois_coinsertion (λ x, order_dual.to_dual (principal x)) (λ F, Inf (order_dual.of_dual F : pfilter P)) :=
 { choice := λ F _, Inf (id F : pfilter P),
   gc := Inf_gc,
   u_l_le := λ s, Inf_le $ mem_principal.2 $ le_refl s,

--- a/src/order/pfilter.lean
+++ b/src/order/pfilter.lean
@@ -104,7 +104,7 @@ ideal.principal_le_iff
 @[simp] lemma mem_principal : x ∈ principal y ↔ y ≤ x :=
 ideal.mem_principal -- defeq abuse
 
-lemma antitone_principal {p q : P} : antitone (principal : P → pfilter P) := by delta antitone; simp
+lemma antitone_principal : antitone (principal : P → pfilter P) := by delta antitone; simp
 
 lemma principal_le_principal_iff {p q : P} : principal q ≤ principal p ↔ p ≤ q :=
 by simp
@@ -161,3 +161,4 @@ end complete_semilattice_Inf_stuff
 end pfilter
 
 end order
+#lint

--- a/src/order/pfilter.lean
+++ b/src/order/pfilter.lean
@@ -95,8 +95,8 @@ ideal.mem_of_mem_of_le
 /-- The smallest filter containing a given element. -/
 def principal (p : P) : pfilter P := ⟨ideal.principal p⟩
 
-@[simp] lemma mem_def (x : P) (I : ideal Pᵒᵈ) : x ∈ ({dual := I} : pfilter P) ↔ x ∈ I :=
-iff.rfl
+@[simp] lemma mem_def (x : P) (I : ideal Pᵒᵈ) : x ∈ ({dual := I} : pfilter P) ↔
+  order_dual.to_dual x ∈ I := iff.rfl
 
 @[simp] lemma principal_le_iff {F : pfilter P} : principal x ≤ F ↔ x ∈ F :=
 ideal.principal_le_iff
@@ -107,7 +107,7 @@ ideal.mem_principal -- defeq abuse
 lemma principal_le_congr {p q : P} (h : p ≤ q) : principal q ≤ principal p :=
 by simp [h]
 
-lemma principal_le_principal_iff {p q : P} : principal p ≤ principal q ↔ q ≤ p := by simp
+lemma antitone_principal {p q : P} : antitone (principal : P → pfilter P) := by delta antitone; simp
 
 end preorder
 


### PR DESCRIPTION
`principal` and `Inf` form a Galois coinsertion.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

I'm running a project on filters at Imperial and was just doing some Lean experiments to make sure I understood them properly.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
