### PR TITLE
[Merged by Bors] - feat(order/rel_iso): two reflexive/irreflexive relations on a unique type are isomorphic

### DIFF
--- a/src/order/rel_classes.lean
+++ b/src/order/rel_classes.lean
@@ -87,14 +87,8 @@ lemma ne_of_irrefl' {r} [is_irrefl α r] : ∀ {x y : α}, r x y → y ≠ x | _
 lemma not_rel_of_subsingleton (r) [is_irrefl α r] [subsingleton α] (x y) : ¬ r x y :=
 subsingleton.elim x y ▸ irrefl x
 
-lemma not_rel_iff_of_subsingleton (r) [is_irrefl α r] [subsingleton α] (x y) : r x y ↔ false :=
-iff_false_intro $ not_rel_of_subsingleton r x y
-
 lemma rel_of_subsingleton (r) [is_refl α r] [subsingleton α] (x y) : r x y :=
 subsingleton.elim x y ▸ refl x
-
-lemma rel_iff_of_subsingleton (r) [is_refl α r] [subsingleton α] (x y) : r x y ↔ true :=
-iff_true_intro $ rel_of_subsingleton r x y
 
 @[simp] lemma empty_relation_apply (a b : α) : empty_relation a b ↔ false := iff.rfl
 

--- a/src/order/rel_classes.lean
+++ b/src/order/rel_classes.lean
@@ -87,7 +87,8 @@ lemma ne_of_irrefl' {r} [is_irrefl α r] : ∀ {x y : α}, r x y → y ≠ x | _
 lemma not_rel_of_subsingleton (r) [is_irrefl α r] [subsingleton α] (x y) : ¬ r x y :=
 subsingleton.elim x y ▸ irrefl x
 
-@[simp] lemma not_rel_iff_of_subsingleton (r) [is_irrefl α r] [subsingleton α] (x y) : r x y ↔ false :=
+@[simp] lemma not_rel_iff_of_subsingleton (r) [is_irrefl α r] [subsingleton α] (x y) :
+  r x y ↔ false :=
 iff_false_intro $ not_rel_of_subsingleton r x y
 
 lemma rel_of_subsingleton (r) [is_refl α r] [subsingleton α] (x y) : r x y :=

--- a/src/order/rel_classes.lean
+++ b/src/order/rel_classes.lean
@@ -84,13 +84,22 @@ instance is_total.to_is_refl (r) [is_total α r] : is_refl α r :=
 lemma ne_of_irrefl {r} [is_irrefl α r] : ∀ {x y : α}, r x y → x ≠ y | _ _ h rfl := irrefl _ h
 lemma ne_of_irrefl' {r} [is_irrefl α r] : ∀ {x y : α}, r x y → y ≠ x | _ _ h rfl := irrefl _ h
 
-lemma not_rel (r) [is_irrefl α r] [subsingleton α] (x y) : ¬ r x y :=
+lemma not_rel_of_subsingleton (r) [is_irrefl α r] [subsingleton α] (x y) : ¬ r x y :=
 subsingleton.elim x y ▸ irrefl x
+
+@[simp] lemma not_rel_iff_of_subsingleton (r) [is_irrefl α r] [subsingleton α] (x y) : r x y ↔ false :=
+iff_false_intro $ not_rel_of_subsingleton r x y
+
+lemma rel_of_subsingleton (r) [is_refl α r] [subsingleton α] (x y) : r x y :=
+subsingleton.elim x y ▸ refl x
+
+lemma rel_iff_of_subsingleton (r) [is_refl α r] [subsingleton α] (x y) : r x y ↔ true :=
+iff_true_intro $ rel_of_subsingleton r x y
 
 @[simp] lemma empty_relation_apply (a b : α) : empty_relation a b ↔ false := iff.rfl
 
 lemma eq_empty_relation (r) [is_irrefl α r] [subsingleton α] : r = empty_relation :=
-funext₂ $ by simpa using not_rel r
+funext₂ $ by simpa using not_rel_of_subsingleton r
 
 instance : is_irrefl α empty_relation := ⟨λ a, id⟩
 
@@ -246,8 +255,8 @@ def is_well_order.to_has_well_founded [has_lt α] [hwo : is_well_order α (<)] :
 theorem subsingleton.is_well_order [subsingleton α] (r : α → α → Prop) [hr : is_irrefl α r] :
   is_well_order α r :=
 { trichotomous := λ a b, or.inr $ or.inl $ subsingleton.elim a b,
-  trans        := λ a b c h, (not_rel r a b h).elim,
-  wf           := ⟨λ a, ⟨_, λ y h, (not_rel r y a h).elim⟩⟩,
+  trans        := λ a b c h, (not_rel_of_subsingleton r a b h).elim,
+  wf           := ⟨λ a, ⟨_, λ y h, (not_rel_of_subsingleton r y a h).elim⟩⟩,
   ..hr }
 
 instance empty_relation.is_well_order [subsingleton α] : is_well_order α empty_relation :=

--- a/src/order/rel_classes.lean
+++ b/src/order/rel_classes.lean
@@ -87,8 +87,7 @@ lemma ne_of_irrefl' {r} [is_irrefl α r] : ∀ {x y : α}, r x y → y ≠ x | _
 lemma not_rel_of_subsingleton (r) [is_irrefl α r] [subsingleton α] (x y) : ¬ r x y :=
 subsingleton.elim x y ▸ irrefl x
 
-@[simp] lemma not_rel_iff_of_subsingleton (r) [is_irrefl α r] [subsingleton α] (x y) :
-  r x y ↔ false :=
+lemma not_rel_iff_of_subsingleton (r) [is_irrefl α r] [subsingleton α] (x y) : r x y ↔ false :=
 iff_false_intro $ not_rel_of_subsingleton r x y
 
 lemma rel_of_subsingleton (r) [is_refl α r] [subsingleton α] (x y) : r x y :=

--- a/src/order/rel_iso.lean
+++ b/src/order/rel_iso.lean
@@ -496,7 +496,7 @@ def rel_iso_of_unique_of_irrefl (r : α → α → Prop) (s : β → β → Prop
 ⟨equiv.equiv_of_unique α β,
   λ _ _, by rw [not_rel_iff_of_subsingleton r, not_rel_iff_of_subsingleton s]⟩
 
-  /-- Two reflexive relations on a unique type are isomorphic. -/
+/-- Two reflexive relations on a unique type are isomorphic. -/
 def rel_iso_of_unique_of_refl (r : α → α → Prop) (s : β → β → Prop)
   [is_refl α r] [is_refl β s] [unique α] [unique β] : r ≃r s :=
 ⟨equiv.equiv_of_unique α β,

--- a/src/order/rel_iso.lean
+++ b/src/order/rel_iso.lean
@@ -490,6 +490,18 @@ lemma mul_apply (e₁ e₂ : r ≃r r) (x : α) : (e₁ * e₂) x = e₁ (e₂ x
 def rel_iso_of_is_empty (r : α → α → Prop) (s : β → β → Prop) [is_empty α] [is_empty β] : r ≃r s :=
 ⟨equiv.equiv_of_is_empty α β, is_empty_elim⟩
 
+/-- Two irreflexive relations on a unique type are isomorphic. -/
+def rel_iso_of_unique_of_irrefl (r : α → α → Prop) (s : β → β → Prop)
+  [is_irrefl α r] [is_irrefl β s] [unique α] [unique β] : r ≃r s :=
+⟨equiv.equiv_of_unique α β,
+  λ _ _, by rw [not_rel_iff_of_subsingleton r, not_rel_iff_of_subsingleton s]⟩
+
+  /-- Two reflexive relations on a unique type are isomorphic. -/
+def rel_iso_of_unique_of_refl (r : α → α → Prop) (s : β → β → Prop)
+  [is_refl α r] [is_refl β s] [unique α] [unique β] : r ≃r s :=
+⟨equiv.equiv_of_unique α β,
+  λ _ _, by rw [rel_iff_of_subsingleton r, rel_iff_of_subsingleton s]⟩
+
 end rel_iso
 
 /-- `subrel r p` is the inherited relation on a subset. -/

--- a/src/order/rel_iso.lean
+++ b/src/order/rel_iso.lean
@@ -494,13 +494,13 @@ def rel_iso_of_is_empty (r : α → α → Prop) (s : β → β → Prop) [is_em
 def rel_iso_of_unique_of_irrefl (r : α → α → Prop) (s : β → β → Prop)
   [is_irrefl α r] [is_irrefl β s] [unique α] [unique β] : r ≃r s :=
 ⟨equiv.equiv_of_unique α β,
-  λ _ _, by rw [not_rel_iff_of_subsingleton r, not_rel_iff_of_subsingleton s]⟩
+  λ x y, by simp [not_rel_of_subsingleton r, not_rel_of_subsingleton s]⟩
 
 /-- Two reflexive relations on a unique type are isomorphic. -/
 def rel_iso_of_unique_of_refl (r : α → α → Prop) (s : β → β → Prop)
   [is_refl α r] [is_refl β s] [unique α] [unique β] : r ≃r s :=
 ⟨equiv.equiv_of_unique α β,
-  λ _ _, by rw [rel_iff_of_subsingleton r, rel_iff_of_subsingleton s]⟩
+  λ x y, by simp [rel_of_subsingleton r, rel_of_subsingleton s]⟩
 
 end rel_iso
 


### PR DESCRIPTION
We also rename `not_rel` to the more descriptive name `not_rel_of_subsingleton`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
