### PR TITLE
[Merged by Bors] - fix(data/rat/basic): Remove incorrect simp attribute

### DIFF
--- a/src/data/rat/basic.lean
+++ b/src/data/rat/basic.lean
@@ -675,7 +675,7 @@ by rw [div_eq_mul_inv, inv_def, mk_mul_mk_cancel hx]
 lemma mk_div_mk_cancel_right {x : ℤ} (hx : x ≠ 0) (n d : ℤ) : (x /. n) / (x /. d) = d /. n :=
 by rw [div_eq_mul_inv, inv_def, mul_comm, mk_mul_mk_cancel hx]
 
-@[simp] lemma coe_int_div_eq_mk {n d : ℤ} : (n : ℚ) / ↑d = n /. d :=
+lemma coe_int_div_eq_mk {n d : ℤ} : (n : ℚ) / ↑d = n /. d :=
 begin
   repeat {rw coe_int_eq_mk},
   exact mk_div_mk_cancel_left one_ne_zero n d,


### PR DESCRIPTION
Remove simp attribute that breaks `field_simp`.

---

Reverting a mistake from #14456.

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
