### PR TITLE
[Merged by Bors] - feat(meta/univs): Add a reflect_name tactic, make reflected instances universe polymorphic

### DIFF
--- a/src/data/fin/vec_notation.lean
+++ b/src/data/fin/vec_notation.lean
@@ -6,6 +6,7 @@ Authors: Anne Baanen
 import data.fin.tuple
 import data.list.range
 import group_theory.group_action.pi
+import meta.univs
 
 /-!
 # Matrix and vector notation
@@ -146,11 +147,12 @@ by { refine fin.forall_fin_one.2 _ i, refl }
 lemma cons_fin_one (x : α) (u : fin 0 → α) : vec_cons x u = (λ _, x) :=
 funext (cons_val_fin_one x u)
 
-meta instance _root_.pi_fin.reflect {α : Type} [reflected α] [h : has_reflect α] :
+meta instance _root_.pi_fin.reflect [reflected_univ.{u}] {α : Type u} [reflected α] [h : has_reflect α] :
   Π {n}, has_reflect (fin n → α)
-| 0 v := (subsingleton.elim vec_empty v).rec (`(λ a, @vec_empty.{0} a).subst `(α))
+| 0 v := (subsingleton.elim vec_empty v).rec
+    ((by reflect_name : reflected (@vec_empty.{u})).subst `(α))
 | (n + 1) v := (cons_head_tail v).rec $
-  (`(λ x (xs : fin n → α), vec_cons x xs).subst (h _)).subst (_root_.pi_fin.reflect _)
+    (by reflect_name : reflected @vec_cons.{u}).subst₄ `(α) `(n) (h _) (_root_.pi_fin.reflect _)
 
 /-! ### Numeral (`bit0` and `bit1`) indices
 The following definitions and `simp` lemmas are to allow any

--- a/src/data/fin/vec_notation.lean
+++ b/src/data/fin/vec_notation.lean
@@ -147,12 +147,12 @@ by { refine fin.forall_fin_one.2 _ i, refl }
 lemma cons_fin_one (x : α) (u : fin 0 → α) : vec_cons x u = (λ _, x) :=
 funext (cons_val_fin_one x u)
 
-meta instance _root_.pi_fin.reflect [reflected_univ.{u}] {α : Type u} [reflected α] [h : has_reflect α] :
+meta instance _root_.pi_fin.reflect [reflected_univ.{u}] [reflected α] [has_reflect α] :
   Π {n}, has_reflect (fin n → α)
 | 0 v := (subsingleton.elim vec_empty v).rec
     ((by reflect_name : reflected (@vec_empty.{u})).subst `(α))
 | (n + 1) v := (cons_head_tail v).rec $
-    (by reflect_name : reflected @vec_cons.{u}).subst₄ `(α) `(n) (h _) (_root_.pi_fin.reflect _)
+    (by reflect_name : reflected @vec_cons.{u}).subst₄ `(α) `(n) `(_) (_root_.pi_fin.reflect _)
 
 /-! ### Numeral (`bit0` and `bit1`) indices
 The following definitions and `simp` lemmas are to allow any

--- a/src/data/vector/basic.lean
+++ b/src/data/vector/basic.lean
@@ -7,6 +7,7 @@ import data.vector
 import data.list.nodup
 import data.list.of_fn
 import control.applicative
+import meta.univs
 /-!
 # Additional theorems and definitions about the `vector` type
 
@@ -564,9 +565,10 @@ instance : is_lawful_traversable.{u} (flip vector n) :=
   id_map := by intros; cases x; simp! [(<$>)],
   comp_map := by intros; cases x; simp! [(<$>)] }
 
-meta instance reflect {α : Type} [has_reflect α] [reflected α] {n : ℕ} : has_reflect (vector α n) :=
+meta instance reflect [reflected_univ.{u}] {α : Type u} [has_reflect α] [reflected α] {n : ℕ} :
+  has_reflect (vector α n) :=
 λ v, @vector.induction_on n α (λ n, reflected) v
-  (`(λ a, @vector.nil.{0} a).subst `(α))
-  (λ n x xs ih, (`(λ x xs, vector.cons.{0} x xs).subst `(x)).subst ih)
+  ((by reflect_name : reflected @vector.nil.{u}).subst `(α))
+  (λ n x xs ih, (by reflect_name : reflected @vector.cons.{u}).subst₄ `(α) `(n) `(x) ih)
 
 end vector

--- a/src/meta/univs.lean
+++ b/src/meta/univs.lean
@@ -1,0 +1,104 @@
+/-
+Copyright (c) 2022 Gabriel Ebner. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Gabriel Ebner, Eric Wieser
+-/
+
+/-!
+# Reflection of universe variables
+
+The `reflect` and `has_reflect` machinery (sometimes via the `` `(expr) `` syntax) allows
+terms to be converted to the expression that constructs them. However, this construction does not
+support universe variables.
+
+This file provides a typeclass `reflected_univ.{u}` to match a universe variable `u` with a level
+`l`, which allows `reflect` to be used universe-polymorphically.
+
+## Main definitions
+
+* `reflect_univ.{u} : level`: Obtain the level of a universe by typeclass search
+* `tactic.interactive.reflect_name`: solve goals of the form `reflected (foo.{u v})` by searching
+  for `reflected_univ.{u}` instances.
+
+-/
+
+
+/-- A typeclass to translate a universe argument into a `level`. Note that `level.mvar` and
+`level.param` are not supported. -/
+meta class {u} reflected_univ :=
+(lvl : level)
+meta def {u} reflect_univ [reflected_univ.{u}] : level :=
+reflected_univ.lvl
+
+meta instance reflect_univ.zero : reflected_univ.{0} :=
+⟨level.zero⟩
+
+@[instance] meta def {u} reflect_univ.succ [reflected_univ.{u}] : reflected_univ.{u+1} :=
+⟨level.succ reflect_univ.{u}⟩
+
+@[instance] meta def {u v} reflect_univ.max [reflected_univ.{u}] [reflected_univ.{v}] :
+  reflected_univ.{max u v} :=
+⟨level.max reflect_univ.{u} reflect_univ.{v}⟩
+
+@[instance] meta def {u v} reflect_univ.imax [reflected_univ.{u}] [reflected_univ.{v}] :
+  reflected_univ.{imax u v} :=
+⟨level.imax reflect_univ.{u} reflect_univ.{v}⟩
+
+section
+local attribute [semireducible] reflected
+/-- This definition is evil, as it circumvents the protection that `reflected` tried to enforce. -/
+private meta def reflected.of {α : Sort*} {a : α} (e : expr) : reflected a := e
+end
+
+/-- Reflect a universe-polymorphic name, by searching for `reflected_univ` instances. -/
+meta def tactic.interactive.reflect_name : tactic unit :=
+do
+  tgt ← tactic.target,
+  `(reflected %%x) ← pure tgt,
+  expr.const name levels ← pure x,
+  levels ← levels.mmap (λ l, do
+    inst ← tactic.mk_instance (expr.const `reflected_univ [l]),
+    pure $ expr.app (expr.const `reflect_univ [l]) inst),
+  let levels := list.foldr (λ a l, `(@list.cons level %%a %%l)) `(@list.nil level) levels,
+  let e := `(@expr.const tt %%`(name) %%levels),
+  let e2 := ``(reflected.of %%e : %%tgt),
+  e2 ← tactic.to_expr e2,
+  tactic.exact e2
+
+universes u v w x y
+
+set_option pp.universes true
+
+/-- Convenience helper for two consecutive `reflected.subst` applications -/
+meta def reflected.subst₂ {α : Sort u} {β : α → Sort v} {γ : Π a, β a → Sort w}
+  {f : Π a b, γ a b} {a : α} {b : β a} :
+  reflected f → reflected a → reflected b → reflected (f a b) :=
+(∘) reflected.subst ∘ reflected.subst
+
+/-- Convenience helper for three consecutive `reflected.subst` applications -/
+meta def reflected.subst₃ {α : Sort u} {β : α → Sort v} {γ : Π a, β a → Sort w}
+  {δ : Π a b, γ a b → Sort x}
+  {f : Π a b c, δ a b c} {a : α} {b : β a} {c : γ a b}:
+  reflected f → reflected a → reflected b → reflected c → reflected (f a b c) :=
+(∘) reflected.subst₂ ∘ reflected.subst
+
+/-- Convenience helper for four consecutive `reflected.subst` applications -/
+meta def reflected.subst₄ {α : Sort u} {β : α → Sort v} {γ : Π a, β a → Sort w}
+  {δ : Π a b, γ a b → Sort x} {ε : Π a b c, δ a b c → Sort y}
+  {f : Π a b c d, ε a b c d} {a : α} {b : β a} {c : γ a b} {d : δ a b c} :
+  reflected f → reflected a → reflected b → reflected c → reflected d → reflected (f a b c d) :=
+(∘) reflected.subst₃ ∘ reflected.subst
+
+/-- Universe polymorphic version of the builtin `punit.reflect`. -/
+meta instance punit.reflect' [reflected_univ.{u}] : has_reflect punit.{u}
+| punit.star := by reflect_name
+
+/-- Universe polymorphic version of the builtin `list.reflect`. -/
+meta instance list.reflect' [reflected_univ.{u}] {α : Type u} [has_reflect α] [reflected α] :
+  has_reflect (list α)
+| []     := (by reflect_name : reflected @list.nil.{u}).subst `(α)
+| (h::t) := (by reflect_name : reflected @list.cons.{u}).subst₃ `(α) `(h) (list.reflect' t)
+
+meta instance ulift.reflect' [reflected_univ.{u}] [reflected_univ.{v}] {α : Type v}
+  [reflected α] [has_reflect α] : has_reflect (ulift.{u v} α)
+| (ulift.up x) := (by reflect_name : reflected @ulift.up.{u v}).subst₂ `(α) `(x)

--- a/src/meta/univs.lean
+++ b/src/meta/univs.lean
@@ -67,8 +67,6 @@ do
 
 universes u v w x y
 
-set_option pp.universes true
-
 /-- Convenience helper for two consecutive `reflected.subst` applications -/
 meta def reflected.subst₂ {α : Sort u} {β : α → Sort v} {γ : Π a, β a → Sort w}
   {f : Π a b, γ a b} {a : α} {b : β a} :
@@ -88,6 +86,8 @@ meta def reflected.subst₄ {α : Sort u} {β : α → Sort v} {γ : Π a, β a 
   {f : Π a b c d, ε a b c d} {a : α} {b : β a} {c : γ a b} {d : δ a b c} :
   reflected f → reflected a → reflected b → reflected c → reflected d → reflected (f a b c d) :=
 (∘) reflected.subst₃ ∘ reflected.subst
+
+/-! ### Universe-polymorphic `has_reflect` instances -/
 
 /-- Universe polymorphic version of the builtin `punit.reflect`. -/
 meta instance punit.reflect' [reflected_univ.{u}] : has_reflect punit.{u}

--- a/test/vec_notation.lean
+++ b/test/vec_notation.lean
@@ -12,6 +12,10 @@ import data.fin.vec_notation
   tactic.is_def_eq `(x) `(![1, 2, 3])
 
 #eval do
+  let x := ![ulift.up.{3} 1, ulift.up.{3} 2],
+  tactic.is_def_eq (reflect x) `(![ulift.up.{3} 1, ulift.up.{3} 2])
+
+#eval do
   let x := ![![1, 2], ![3, 4]],
   tactic.is_def_eq `(x) `(![![1, 2], ![3, 4]])
 


### PR DESCRIPTION
The existing `list.reflect` instance only works for `Type 0`, this version works for `Type u` providing `u` is known.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
