### PR TITLE
[Merged by Bors] - feat(algebra/algebra/basic) : add ring_hom.equiv_rat_alg_hom

### DIFF
--- a/src/algebra/algebra/basic.lean
+++ b/src/algebra/algebra/basic.lean
@@ -1300,11 +1300,9 @@ def to_rat_alg_hom [ring R] [ring S] [algebra ℚ R] [algebra ℚ S] (f : R →+
 def equiv_rat_alg_hom [ring R] [ring S] [algebra ℚ R] [algebra ℚ S] :
 (R →ₐ[ℚ] S) ≃ (R →+* S) :=
 { to_fun := coe,
-  inv_fun := λ f : R →+* S, alg_hom.mk' f (λ (c : ℚ) x, map_rat_smul f _ _),
-  left_inv  := λ x, alg_hom.ext  $ by simp only [forall_const, alg_hom.coe_to_ring_hom,
-                                                 eq_self_iff_true, alg_hom.coe_mk'],
-  right_inv := λ x, ring_hom.ext $ by simp only [forall_const, alg_hom.coe_to_ring_hom,
-                                                 eq_self_iff_true, alg_hom.coe_mk'] }
+  inv_fun := λ f : R →+* S, f.to_rat_alg_hom,
+  left_inv  := λ x, alg_hom.ext $ by { intro x, refl, },
+  right_inv := λ x, ring_hom.ext $ by { intro x, refl, }, }
 
 end ring_hom
 

--- a/src/algebra/algebra/basic.lean
+++ b/src/algebra/algebra/basic.lean
@@ -1291,10 +1291,20 @@ def to_int_alg_hom [ring R] [ring S] [algebra ℤ R] [algebra ℤ S] (f : R →+
   (f : R →+* S) (r : ℚ) : f (algebra_map ℚ R r) = algebra_map ℚ S r :=
 ring_hom.ext_iff.1 (subsingleton.elim (f.comp (algebra_map ℚ R)) (algebra_map ℚ S)) r
 
-/-- Reinterpret a `ring_hom` as a `ℚ`-algebra homomorphism. -/
+/-- Reinterpret a `ring_hom` as a `ℚ`-algebra homomorphism. This actually yields an equivalence,
+see `ring_hom.equiv_rat_alg_hom`. -/
 def to_rat_alg_hom [ring R] [ring S] [algebra ℚ R] [algebra ℚ S] (f : R →+* S) :
   R →ₐ[ℚ] S :=
 { commutes' := f.map_rat_algebra_map, .. f }
+
+def equiv_rat_alg_hom [ring R] [ring S] [algebra ℚ R] [algebra ℚ S] :
+(R →ₐ[ℚ] S) ≃ (R →+* S) :=
+{ to_fun := coe,
+  inv_fun := λ f : R →+* S, alg_hom.mk' f (λ (c : ℚ) x, map_rat_smul f _ _),
+  left_inv  := λ x, alg_hom.ext  $ by simp only [forall_const, alg_hom.coe_to_ring_hom,
+                                                 eq_self_iff_true, alg_hom.coe_mk'],
+  right_inv := λ x, ring_hom.ext $ by simp only [forall_const, alg_hom.coe_to_ring_hom,
+                                                 eq_self_iff_true, alg_hom.coe_mk'] }
 
 end ring_hom
 

--- a/src/algebra/algebra/basic.lean
+++ b/src/algebra/algebra/basic.lean
@@ -1298,8 +1298,8 @@ def to_rat_alg_hom [ring R] [ring S] [algebra ℚ R] [algebra ℚ S] (f : R →+
 { commutes' := f.map_rat_algebra_map, .. f }
 
 @[simp]
-lemma rat_alg_hom_to_ring_hom_eq_id [ring R] [ring S] [algebra ℚ R] [algebra ℚ S]
-(f : R →+* S) : f.to_rat_alg_hom.to_ring_hom = f :=
+lemma to_rat_alg_hom_to_ring_hom [ring R] [ring S] [algebra ℚ R] [algebra ℚ S]
+  (f : R →+* S) : f.to_rat_alg_hom.to_ring_hom = f :=
 ring_hom.ext (by {intro x, refl, })
 
 end ring_hom
@@ -1309,17 +1309,17 @@ section
 variables {R S : Type*}
 
 @[simp]
-lemma alg_hom.ring_hom_to_rat_alg_hom_eq_id [ring R] [ring S] [algebra ℚ R] [algebra ℚ S]
-(f : R →ₐ[ℚ] S) : f.to_ring_hom.to_rat_alg_hom = f :=
+lemma alg_hom.to_ring_hom_to_rat_alg_hom [ring R] [ring S] [algebra ℚ R] [algebra ℚ S]
+  (f : R →ₐ[ℚ] S) : f.to_ring_hom.to_rat_alg_hom = f :=
 alg_hom.ext (by {intro x, refl, })
 
 @[simps]
 def ring_hom.equiv_rat_alg_hom [ring R] [ring S] [algebra ℚ R] [algebra ℚ S] :
-(R →ₐ[ℚ] S) ≃ (R →+* S) :=
+  (R →ₐ[ℚ] S) ≃ (R →+* S) :=
 { to_fun := coe,
   inv_fun := λ f : R →+* S, f.to_rat_alg_hom,
-  left_inv := λ f, alg_hom.ring_hom_to_rat_alg_hom_eq_id _,
-  right_inv := λ f, ring_hom.rat_alg_hom_to_ring_hom_eq_id _, }
+  left_inv := alg_hom.to_ring_hom_to_rat_alg_hom,
+  right_inv := ring_hom.to_rat_alg_hom_to_ring_hom, }
 
 end
 

--- a/src/algebra/algebra/basic.lean
+++ b/src/algebra/algebra/basic.lean
@@ -1299,7 +1299,7 @@ def to_rat_alg_hom [ring R] [ring S] [algebra ℚ R] [algebra ℚ S] (f : R →+
 
 @[simp]
 lemma to_rat_alg_hom_to_ring_hom [ring R] [ring S] [algebra ℚ R] [algebra ℚ S]
-  (f : R →+* S) : (f : R →+* S).to_rat_alg_hom = f :=
+  (f : R →+* S) : ↑f.to_rat_alg_hom = f :=
 ring_hom.ext $ λ x, rfl
 
 end ring_hom

--- a/src/algebra/algebra/basic.lean
+++ b/src/algebra/algebra/basic.lean
@@ -1299,8 +1299,8 @@ def to_rat_alg_hom [ring R] [ring S] [algebra ℚ R] [algebra ℚ S] (f : R →+
 
 @[simp]
 lemma to_rat_alg_hom_to_ring_hom [ring R] [ring S] [algebra ℚ R] [algebra ℚ S]
-  (f : R →+* S) : ↑f.to_rat_alg_hom = f :=
-ring_hom.ext (by {intro x, refl, })
+  (f : R →+* S) : (f : R →+* S).to_rat_alg_hom = f :=
+ring_hom.ext $ λ x, rfl
 
 end ring_hom
 
@@ -1311,7 +1311,7 @@ variables {R S : Type*}
 @[simp]
 lemma alg_hom.to_ring_hom_to_rat_alg_hom [ring R] [ring S] [algebra ℚ R] [algebra ℚ S]
   (f : R →ₐ[ℚ] S) : (f : R →+* S).to_rat_alg_hom = f :=
-alg_hom.ext (by {intro x, refl, })
+alg_hom.ext $ λ x, rfl
 
 /-- The equivalence between `ring_hom` and `ℚ`-algebra homomorphisms. -/
 @[simps]

--- a/src/algebra/algebra/basic.lean
+++ b/src/algebra/algebra/basic.lean
@@ -1299,7 +1299,7 @@ def to_rat_alg_hom [ring R] [ring S] [algebra ℚ R] [algebra ℚ S] (f : R →+
 
 @[simp]
 lemma to_rat_alg_hom_to_ring_hom [ring R] [ring S] [algebra ℚ R] [algebra ℚ S]
-  (f : R →+* S) : f.to_rat_alg_hom.to_ring_hom = f :=
+  (f : R →+* S) : ↑f.to_rat_alg_hom = f :=
 ring_hom.ext (by {intro x, refl, })
 
 end ring_hom
@@ -1313,13 +1313,14 @@ lemma alg_hom.to_ring_hom_to_rat_alg_hom [ring R] [ring S] [algebra ℚ R] [alge
   (f : R →ₐ[ℚ] S) : f.to_ring_hom.to_rat_alg_hom = f :=
 alg_hom.ext (by {intro x, refl, })
 
+/-- The equivalence between `ring_hom` and `ℚ`-algebra homomorphisms. -/
 @[simps]
 def ring_hom.equiv_rat_alg_hom [ring R] [ring S] [algebra ℚ R] [algebra ℚ S] :
-  (R →ₐ[ℚ] S) ≃ (R →+* S) :=
-{ to_fun := coe,
-  inv_fun := λ f : R →+* S, f.to_rat_alg_hom,
-  left_inv := alg_hom.to_ring_hom_to_rat_alg_hom,
-  right_inv := ring_hom.to_rat_alg_hom_to_ring_hom, }
+  (R →+* S) ≃ (R →ₐ[ℚ] S) :=
+{ to_fun := ring_hom.to_rat_alg_hom,
+  inv_fun := alg_hom.to_ring_hom,
+  left_inv := ring_hom.to_rat_alg_hom_to_ring_hom,
+  right_inv := alg_hom.to_ring_hom_to_rat_alg_hom, }
 
 end
 

--- a/src/algebra/algebra/basic.lean
+++ b/src/algebra/algebra/basic.lean
@@ -1297,15 +1297,31 @@ def to_rat_alg_hom [ring R] [ring S] [algebra ℚ R] [algebra ℚ S] (f : R →+
   R →ₐ[ℚ] S :=
 { commutes' := f.map_rat_algebra_map, .. f }
 
+@[simp]
+lemma rat_alg_hom_to_ring_hom_eq_id [ring R] [ring S] [algebra ℚ R] [algebra ℚ S]
+(f : R →+* S) : f.to_rat_alg_hom.to_ring_hom = f :=
+ring_hom.ext (by {intro x, refl, })
+
+end ring_hom
+
+section
+
+variables {R S : Type*}
+
+@[simp]
+lemma alg_hom.ring_hom_to_rat_alg_hom_eq_id [ring R] [ring S] [algebra ℚ R] [algebra ℚ S]
+(f : R →ₐ[ℚ] S) : f.to_ring_hom.to_rat_alg_hom = f :=
+alg_hom.ext (by {intro x, refl, })
+
 @[simps]
-def equiv_rat_alg_hom [ring R] [ring S] [algebra ℚ R] [algebra ℚ S] :
+def ring_hom.equiv_rat_alg_hom [ring R] [ring S] [algebra ℚ R] [algebra ℚ S] :
 (R →ₐ[ℚ] S) ≃ (R →+* S) :=
 { to_fun := coe,
   inv_fun := λ f : R →+* S, f.to_rat_alg_hom,
-  left_inv  := λ x, alg_hom.ext $ by { intro x, refl, },
-  right_inv := λ x, ring_hom.ext $ by { intro x, refl, }, }
+  left_inv := λ f, alg_hom.ring_hom_to_rat_alg_hom_eq_id _,
+  right_inv := λ f, ring_hom.rat_alg_hom_to_ring_hom_eq_id _, }
 
-end ring_hom
+end
 
 section rat
 

--- a/src/algebra/algebra/basic.lean
+++ b/src/algebra/algebra/basic.lean
@@ -1297,6 +1297,7 @@ def to_rat_alg_hom [ring R] [ring S] [algebra ℚ R] [algebra ℚ S] (f : R →+
   R →ₐ[ℚ] S :=
 { commutes' := f.map_rat_algebra_map, .. f }
 
+@[simps]
 def equiv_rat_alg_hom [ring R] [ring S] [algebra ℚ R] [algebra ℚ S] :
 (R →ₐ[ℚ] S) ≃ (R →+* S) :=
 { to_fun := coe,

--- a/src/algebra/algebra/basic.lean
+++ b/src/algebra/algebra/basic.lean
@@ -1310,7 +1310,7 @@ variables {R S : Type*}
 
 @[simp]
 lemma alg_hom.to_ring_hom_to_rat_alg_hom [ring R] [ring S] [algebra ℚ R] [algebra ℚ S]
-  (f : R →ₐ[ℚ] S) : f.to_ring_hom.to_rat_alg_hom = f :=
+  (f : R →ₐ[ℚ] S) : (f : R →+* S).to_rat_alg_hom = f :=
 alg_hom.ext (by {intro x, refl, })
 
 /-- The equivalence between `ring_hom` and `ℚ`-algebra homomorphisms. -/


### PR DESCRIPTION
Proves the equivalence between `ring_hom` and `rat_alg_hom`.

From flt-regular

Co-authored-by: Alex J. Best <alex.j.best@gmail.com>

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
