### PR TITLE
[Merged by Bors] - feat(set/basic, order/boolean_algebra): generalized `compl_comp_compl`

### DIFF
--- a/src/data/set/basic.lean
+++ b/src/data/set/basic.lean
@@ -909,8 +909,6 @@ ext $ λ x, and_iff_not_or_not
 
 @[simp] theorem compl_union_self (s : set α) : sᶜ ∪ s = univ := by rw [union_comm, union_compl_self]
 
-theorem compl_comp_compl [boolean_algebra α] : compl ∘ compl = @id α := funext compl_compl
-
 theorem compl_subset_comm {s t : set α} : sᶜ ⊆ t ↔ tᶜ ⊆ s := @compl_le_iff_compl_le _ s t _
 
 @[simp] lemma compl_subset_compl {s t : set α} : sᶜ ⊆ tᶜ ↔ t ⊆ s := @compl_le_compl_iff_le _ t s _

--- a/src/data/set/basic.lean
+++ b/src/data/set/basic.lean
@@ -909,7 +909,7 @@ ext $ λ x, and_iff_not_or_not
 
 @[simp] theorem compl_union_self (s : set α) : sᶜ ∪ s = univ := by rw [union_comm, union_compl_self]
 
-theorem compl_comp_compl : compl ∘ compl = @id (set α) := funext compl_compl
+theorem compl_comp_compl [boolean_algebra α] : compl ∘ compl = @id α := funext compl_compl
 
 theorem compl_subset_comm {s t : set α} : sᶜ ⊆ t ↔ tᶜ ⊆ s := @compl_le_iff_compl_le _ s t _
 
@@ -1436,9 +1436,9 @@ by simp [←preimage_compl_eq_image_compl]
 
 theorem image_id (s : set α) : id '' s = s := by simp
 
-theorem compl_compl_image [boolean_algebra α] {S : set α} :
+theorem compl_compl_image [boolean_algebra α] (S : set α) :
   compl '' (compl '' S) = S :=
-by {ext, simp}
+by rw [←image_comp, compl_comp_compl, image_id]
 
 theorem image_insert_eq {f : α → β} {a : α} {s : set α} :
   f '' (insert a s) = insert (f a) (f '' s) :=

--- a/src/order/boolean_algebra.lean
+++ b/src/order/boolean_algebra.lean
@@ -658,6 +658,8 @@ is_compl_bot_top.compl_eq
 @[simp] theorem compl_compl (x : α) : xᶜᶜ = x :=
 is_compl_compl.symm.compl_eq
 
+theorem compl_comp_compl : compl ∘ compl = @id α := funext compl_compl
+
 @[simp] theorem compl_involutive : function.involutive (compl : α → α) := compl_compl
 
 theorem compl_bijective : function.bijective (compl : α → α) :=


### PR DESCRIPTION
This PR generalizes `compl_comp_compl` to apply whenever there is a `boolean_algebra` instance. We also make the set parameter of `compl_compl_image` explicit. 

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
