### PR TITLE
feat(order/upper_lower, order/minimal): Upper/lower closures

### DIFF
--- a/src/data/set/basic.lean
+++ b/src/data/set/basic.lean
@@ -909,7 +909,7 @@ ext $ λ x, and_iff_not_or_not
 
 @[simp] theorem compl_union_self (s : set α) : sᶜ ∪ s = univ := by rw [union_comm, union_compl_self]
 
-theorem compl_comp_compl : compl ∘ compl = @id (set α) := funext compl_compl
+theorem compl_comp_compl [boolean_algebra α]: compl ∘ compl = @id α := funext compl_compl
 
 theorem compl_subset_comm {s t : set α} : sᶜ ⊆ t ↔ tᶜ ⊆ s := @compl_le_iff_compl_le _ s t _
 
@@ -1438,7 +1438,7 @@ theorem image_id (s : set α) : id '' s = s := by simp
 
 theorem compl_compl_image [boolean_algebra α] {S : set α} :
   compl '' (compl '' S) = S :=
-by {ext, simp}
+by rw [←image_comp, compl_comp_compl, image_id]
 
 theorem image_insert_eq {f : α → β} {a : α} {s : set α} :
   f '' (insert a s) = insert (f a) (f '' s) :=

--- a/src/data/set/basic.lean
+++ b/src/data/set/basic.lean
@@ -909,7 +909,7 @@ ext $ λ x, and_iff_not_or_not
 
 @[simp] theorem compl_union_self (s : set α) : sᶜ ∪ s = univ := by rw [union_comm, union_compl_self]
 
-theorem compl_comp_compl [boolean_algebra α]: compl ∘ compl = @id α := funext compl_compl
+theorem compl_comp_compl : compl ∘ compl = @id (set α) := funext compl_compl
 
 theorem compl_subset_comm {s t : set α} : sᶜ ⊆ t ↔ tᶜ ⊆ s := @compl_le_iff_compl_le _ s t _
 
@@ -1438,7 +1438,7 @@ theorem image_id (s : set α) : id '' s = s := by simp
 
 theorem compl_compl_image [boolean_algebra α] {S : set α} :
   compl '' (compl '' S) = S :=
-by rw [←image_comp, compl_comp_compl, image_id]
+by {ext, simp}
 
 theorem image_insert_eq {f : α → β} {a : α} {s : set α} :
   f '' (insert a s) = insert (f a) (f '' s) :=

--- a/src/order/minimal.lean
+++ b/src/order/minimal.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yaël Dillies
 -/
 import order.antichain
+import order.upper_lower
 
 /-!
 # Minimal/maximal elements of a set
@@ -131,16 +132,12 @@ lemma is_greatest.maximals_eq (h : is_greatest s a) : maximals (≤) s = {a} :=
 eq_singleton_iff_unique_mem.2 ⟨h.mem_maximals, λ b hb, hb.2 h.1 $ h.2 hb.1⟩
 
 lemma is_antichain.max_lower_set_of (hs : is_antichain (≤) s) :
-  maximals (≤) {x | ∃ y ∈ s, x ≤ y} = s :=
-begin
-  ext x,
-  simp only [maximals, exists_prop, mem_set_of_eq, forall_exists_index, and_imp, sep_set_of],
-  refine ⟨λ h, exists.elim h.1 (λ y hy, ((h.2 _ hy.1 rfl.le hy.2).symm.subst hy.1)),
-    λ h, ⟨⟨x,h,rfl.le⟩,λ b y hy hby hxy, _⟩⟩,
-  have : x = y := by_contra (λ h_eq, (hs h hy h_eq (hxy.trans hby)).elim),
-  exact hxy.antisymm (this.symm.subst hby),
-end
+  maximals (≤) (set.lower_set_of s) = s :=
+hs.max_maximals (λ x, λ ⟨⟨z,hzs,hxz⟩,hy⟩, by rwa (hy ⟨z,hzs,rfl.le⟩ hxz))
+  (λ a has, ⟨a,⟨⟨a,has,rfl.le⟩, λ y ⟨z,hz,hyz⟩ hay, by_contra
+    (λ haz, hs has hz (λ haz', haz (hay.antisymm (le_of_le_of_eq hyz haz'.symm)))
+      (hay.trans hyz) )⟩,rfl.le⟩)
 
 lemma is_antichain.min_upper_set_of (hs : is_antichain (≤) s) :
-  minimals (≤) {x | ∃ y ∈ s, y ≤ x} = s :=
+  minimals (≤) (set.upper_set_of s) = s :=
 hs.to_dual.max_lower_set_of

--- a/src/order/upper_lower.lean
+++ b/src/order/upper_lower.lean
@@ -25,6 +25,8 @@ This file defines upper and lower sets in an order.
 * `upper_set.Ioi`: Strict principal upper set. `set.Ioi` as an upper set.
 * `lower_set.Iic`: Principal lower set. `set.Iic` as an lower set.
 * `lower_set.Iio`: Strict principal lower set. `set.Iio` as an lower set.
+* `upper_set.upper_set_of` : The minimal upper_set containing a given set, bundled.
+* `lower_set.lower_set_of` : The minimal lower_set containing a given set, bundled.
 
 ## TODO
 


### PR DESCRIPTION
This PR defines unbundled and bundled versions of `lower_set_of s`, which is the smallest
lower set containing `s`, defined as `{x | ∃ a ∈ s, x ≤ a}`, and some auxiliary lemmas.  Same for upper. 

We also update two antichain lemmas in `minimal` to be stated in terms of this definition. 

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
