### PR TITLE
[Merged by Bors] - feat(order/lattice, data/set): some helper lemmas

### DIFF
--- a/src/data/set/basic.lean
+++ b/src/data/set/basic.lean
@@ -603,7 +603,7 @@ lemma inter_eq_inter_of_subset_of_subset {s t a : set α} (h1 : t ∩ a ⊆ s) (
   s ∩ a = t ∩ a :=
 inf_eq_inf_of_le_of_le h1 h2
 
-lemma inter_eq_inter_iff_subset_subset {s t a : set α} : s ∩ a = t ∩ a ↔ t ∩ a ≤ s ∧ s ∩ a ≤ t :=
+lemma inter_eq_inter_iff_subset_subset {s t a : set α} : s ∩ a = t ∩ a ↔ t ∩ a ⊆ s ∧ s ∩ a ⊆ t :=
 inf_eq_inf_iff_le_le
 
 @[simp] theorem inter_univ (a : set α) : a ∩ univ = a := inf_top_eq

--- a/src/data/set/basic.lean
+++ b/src/data/set/basic.lean
@@ -599,11 +599,11 @@ inter_eq_left_iff_subset.mpr
 theorem inter_eq_self_of_subset_right {s t : set α} : t ⊆ s → s ∩ t = t :=
 inter_eq_right_iff_subset.mpr
 
-lemma inter_eq_inter_of_subset_of_subset {s t a : set α} (h1 : s ∩ a ⊆ t) (h2 : t ∩ a ⊆ s) :
+lemma inter_eq_inter_of_subset_of_subset {s t a : set α} (h1 : t ∩ a ⊆ s) (h2 : s ∩ a ⊆ t) :
   s ∩ a = t ∩ a :=
 inf_eq_inf_of_le_of_le h1 h2
 
-lemma inter_eq_inter_iff_subset_subset {s t a : set α} : s ∩ a = t ∩ a ↔ s ∩ a ≤ t ∧ t ∩ a ≤ s :=
+lemma inter_eq_inter_iff_subset_subset {s t a : set α} : s ∩ a = t ∩ a ↔ t ∩ a ≤ s ∧ s ∩ a ≤ t :=
 inf_eq_inf_iff_le_le
 
 @[simp] theorem inter_univ (a : set α) : a ∩ univ = a := inf_top_eq

--- a/src/data/set/basic.lean
+++ b/src/data/set/basic.lean
@@ -534,7 +534,7 @@ lemma union_eq_union_of_subset_of_subset {s t a : set α} (h1 : s ⊆ t ∪ a) (
   s ∪ a = t ∪ a :=
 sup_eq_sup_of_le_of_le h1 h2
 
-lemma union_eq_union_iff_subset_subset {s t a : set α} : s ∪ a = t ∪ a ↔ s ≤ t ∪ a ∧ t ≤ s ∪ a :=
+lemma union_eq_union_iff_subset_subset {s t a : set α} : s ∪ a = t ∪ a ↔ s ⊆ t ∪ a ∧ t ⊆ s ∪ a :=
 sup_eq_sup_iff_le_le
 
 @[simp] theorem union_empty_iff {s t : set α} : s ∪ t = ∅ ↔ s = ∅ ∧ t = ∅ :=
@@ -603,7 +603,7 @@ lemma inter_eq_inter_of_subset_of_subset {s t a : set α} (h1 : s ∩ a ⊆ t) (
   s ∩ a = t ∩ a :=
 inf_eq_inf_of_le_of_le h1 h2
 
-lemma inter_eq_inter_iff_subset_subset {s t a : set α} : s ∩ a = t ∩ a ↔ s ∩ a ≤ t ∧ t ∩ a ≤ s :=
+lemma inter_eq_inter_iff_subset_subset {s t a : set α} : s ∩ a = t ∩ a ↔ s ∩ a ⊆ t ∧ t ∩ a ⊆ s :=
 inf_eq_inf_iff_le_le
 
 @[simp] theorem inter_univ (a : set α) : a ∩ univ = a := inf_top_eq

--- a/src/data/set/basic.lean
+++ b/src/data/set/basic.lean
@@ -530,6 +530,13 @@ subset.trans h (subset_union_left t u)
 lemma subset_union_of_subset_right {s u : set α} (h : s ⊆ u) (t : set α) : s ⊆ t ∪ u :=
 subset.trans h (subset_union_right t u)
 
+lemma union_eq_union_of_subset_of_subset {s t a : set α} (h1 : s ⊆ t ∪ a) (h2 : t ⊆ s ∪ a) :
+  s ∪ a = t ∪ a :=
+sup_eq_sup_of_le_of_le h1 h2
+
+lemma union_eq_union_iff_subset_subset {s t a : set α} : s ∪ a = t ∪ a ↔ s ≤ t ∪ a ∧ t ≤ s ∪ a :=
+sup_eq_sup_iff_le_le
+
 @[simp] theorem union_empty_iff {s t : set α} : s ∪ t = ∅ ↔ s = ∅ ∧ t = ∅ :=
 by simp only [← subset_empty_iff]; exact union_subset_iff
 
@@ -591,6 +598,13 @@ inter_eq_left_iff_subset.mpr
 
 theorem inter_eq_self_of_subset_right {s t : set α} : t ⊆ s → s ∩ t = t :=
 inter_eq_right_iff_subset.mpr
+
+lemma inter_eq_inter_of_subset_of_subset {s t a : set α} (h1 : s ∩ a ⊆ t) (h2 : t ∩ a ⊆ s) :
+  s ∩ a = t ∩ a :=
+inf_eq_inf_of_le_of_le h1 h2
+
+lemma inter_eq_inter_iff_subset_subset {s t a : set α} : s ∩ a = t ∩ a ↔ s ∩ a ≤ t ∧ t ∩ a ≤ s :=
+inf_eq_inf_iff_le_le
 
 @[simp] theorem inter_univ (a : set α) : a ∩ univ = a := inf_top_eq
 

--- a/src/order/lattice.lean
+++ b/src/order/lattice.lean
@@ -242,6 +242,13 @@ by rw [sup_sup_sup_comm, sup_idem]
 lemma sup_sup_distrib_right (a b c : α) : (a ⊔ b) ⊔ c = (a ⊔ c) ⊔ (b ⊔ c) :=
 by rw [sup_sup_sup_comm, sup_idem]
 
+lemma sup_eq_sup_of_le_of_le (h1 : a ≤ b ⊔ c) (h2 : b ≤ a ⊔ c) : a ⊔ c = b ⊔ c :=
+  (sup_le h1 le_sup_right).antisymm (sup_le h2 le_sup_right)
+
+lemma sup_eq_sup_iff_le_le : a ⊔ c = b ⊔ c ↔ a ≤ b ⊔ c ∧ b ≤ a ⊔ c :=
+⟨λ h, ⟨by {rw ←h, exact le_sup_left}, by {rw h, exact le_sup_left}⟩,
+  λ h, sup_eq_sup_of_le_of_le h.1 h.2⟩
+
 /-- If `f` is monotone, `g` is antitone, and `f ≤ g`, then for all `a`, `b` we have `f a ≤ g b`. -/
 theorem monotone.forall_le_of_antitone {β : Type*} [preorder β] {f g : α → β}
   (hf : monotone f) (hg : antitone g) (h : f ≤ g) (m n : α) :
@@ -394,6 +401,13 @@ lemma inf_inf_distrib_left (a b c : α) : a ⊓ (b ⊓ c) = (a ⊓ b) ⊓ (a ⊓
 
 lemma inf_inf_distrib_right (a b c : α) : (a ⊓ b) ⊓ c = (a ⊓ c) ⊓ (b ⊓ c) :=
 @sup_sup_distrib_right αᵒᵈ _ _ _ _
+
+lemma inf_eq_inf_of_le_of_le (h1 : a ⊓ c ≤ b) (h2 : b ⊓ c ≤ a) : a ⊓ c = b ⊓ c :=
+(le_inf h1 inf_le_right).antisymm (le_inf h2 inf_le_right)
+
+lemma inf_eq_inf_iff_le_le : a ⊓ c = b ⊓ c ↔ a ⊓ c ≤ b ∧ b ⊓ c ≤ a :=
+⟨λ h, ⟨by {rw h, exact inf_le_left},by {rw ←h, exact inf_le_left}⟩,
+  λ h, inf_eq_inf_of_le_of_le h.1 h.2⟩
 
 theorem semilattice_inf.ext_inf {α} {A B : semilattice_inf α}
   (H : ∀ x y : α, (by haveI := A; exact x ≤ y) ↔ x ≤ y)

--- a/src/order/lattice.lean
+++ b/src/order/lattice.lean
@@ -243,11 +243,10 @@ lemma sup_sup_distrib_right (a b c : α) : (a ⊔ b) ⊔ c = (a ⊔ c) ⊔ (b �
 by rw [sup_sup_sup_comm, sup_idem]
 
 lemma sup_eq_sup_of_le_of_le (h1 : a ≤ b ⊔ c) (h2 : b ≤ a ⊔ c) : a ⊔ c = b ⊔ c :=
-  (sup_le h1 le_sup_right).antisymm (sup_le h2 le_sup_right)
+(sup_le h1 le_sup_right).antisymm (sup_le h2 le_sup_right)
 
 lemma sup_eq_sup_iff_le_le : a ⊔ c = b ⊔ c ↔ a ≤ b ⊔ c ∧ b ≤ a ⊔ c :=
-⟨λ h, ⟨by {rw ←h, exact le_sup_left}, by {rw h, exact le_sup_left}⟩,
-  λ h, sup_eq_sup_of_le_of_le h.1 h.2⟩
+⟨λ h, ⟨h ▸ le_sup_left, h.symm ▸ le_sup_left⟩, λ h, sup_eq_sup_of_le_of_le h.1 h.2⟩
 
 /-- If `f` is monotone, `g` is antitone, and `f ≤ g`, then for all `a`, `b` we have `f a ≤ g b`. -/
 theorem monotone.forall_le_of_antitone {β : Type*} [preorder β] {f g : α → β}
@@ -402,12 +401,11 @@ lemma inf_inf_distrib_left (a b c : α) : a ⊓ (b ⊓ c) = (a ⊓ b) ⊓ (a ⊓
 lemma inf_inf_distrib_right (a b c : α) : (a ⊓ b) ⊓ c = (a ⊓ c) ⊓ (b ⊓ c) :=
 @sup_sup_distrib_right αᵒᵈ _ _ _ _
 
-lemma inf_eq_inf_of_le_of_le (h1 : a ⊓ c ≤ b) (h2 : b ⊓ c ≤ a) : a ⊓ c = b ⊓ c :=
-(le_inf h1 inf_le_right).antisymm (le_inf h2 inf_le_right)
+lemma inf_eq_inf_of_le_of_le (h1 : b ⊓ c ≤ a) (h2 : a ⊓ c ≤ b) : a ⊓ c = b ⊓ c :=
+@sup_eq_sup_of_le_of_le αᵒᵈ _ _ _ _ h1 h2
 
-lemma inf_eq_inf_iff_le_le : a ⊓ c = b ⊓ c ↔ a ⊓ c ≤ b ∧ b ⊓ c ≤ a :=
-⟨λ h, ⟨by {rw h, exact inf_le_left},by {rw ←h, exact inf_le_left}⟩,
-  λ h, inf_eq_inf_of_le_of_le h.1 h.2⟩
+lemma inf_eq_inf_iff_le_le : a ⊓ c = b ⊓ c ↔ b ⊓ c ≤ a ∧ a ⊓ c ≤ b :=
+@sup_eq_sup_iff_le_le αᵒᵈ _ _ _ _
 
 theorem semilattice_inf.ext_inf {α} {A B : semilattice_inf α}
   (H : ∀ x y : α, (by haveI := A; exact x ≤ y) ↔ x ≤ y)


### PR DESCRIPTION
This PR provides lemmas describing when `s ∪ a = t ∪ a`, in both necessary and iff forms, as well as intersection and lattice versions. 

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
