### PR TITLE
[Merged by Bors] - feat(linear_algebra/matrix): inner prod of matrix

### DIFF
--- a/src/linear_algebra/matrix/pos_def.lean
+++ b/src/linear_algebra/matrix/pos_def.lean
@@ -20,14 +20,16 @@ quadratic forms.
 
 namespace matrix
 
-variables {R : Type*} [ordered_semiring R] [star_ring R] {n : Type*} [fintype n]
+variables {𝕜 : Type*} [is_R_or_C 𝕜] {n : Type*} [fintype n]
 
 open_locale matrix
 
 /-- A matrix `M : matrix n n R` is positive definite if it is hermitian
    and `xᴴMx` is greater than zero for all nonzero `x`. -/
-def pos_def (M : matrix n n R) :=
-M.is_hermitian ∧ ∀ x : n → R, x ≠ 0 → 0 < dot_product (star x) (M.mul_vec x)
+def pos_def (M : matrix n n 𝕜) :=
+M.is_hermitian ∧ ∀ x : n → 𝕜, x ≠ 0 → 0 < is_R_or_C.re (dot_product (star x) (M.mul_vec x))
+
+lemma pos_def.is_hermitian {M : matrix n n 𝕜} (hM : M.pos_def) : M.is_hermitian := hM.1
 
 lemma pos_def_of_to_quadratic_form' [decidable_eq n] {M : matrix n n ℝ}
   (hM : M.is_symm) (hMq : M.to_quadratic_form'.pos_def) :
@@ -71,3 +73,31 @@ begin
 end
 
 end quadratic_form
+
+namespace matrix
+
+variables {𝕜 : Type*} [is_R_or_C 𝕜] {n : Type*} [fintype n]
+
+/-- A positive definite matrix `M` induces an inner product `⟪x, y⟫ = xᴴMy`. -/
+noncomputable def inner_product_space.of_matrix
+  {M : matrix n n 𝕜} (hM : M.pos_def) : inner_product_space 𝕜 (n → 𝕜) :=
+inner_product_space.of_core
+{ inner := λ x y, dot_product (star x) (M.mul_vec y),
+  conj_sym := λ x y, by
+    rw [star_dot_product, star_ring_end_apply, star_star, star_mul_vec,
+      dot_product_mul_vec, hM.is_hermitian.eq],
+  nonneg_re := λ x,
+    begin
+      by_cases h : x = 0,
+      { simp [h] },
+      { exact le_of_lt (hM.2 x h) }
+    end,
+  definite := λ x hx,
+    begin
+      by_contra' h,
+      simpa [hx, lt_self_iff_false] using hM.2 x h,
+    end,
+  add_left := by simp only [star_add, add_dot_product, eq_self_iff_true, forall_const],
+  smul_left := λ x y r, by rw [← smul_eq_mul, ←smul_dot_product, star_ring_end_apply, ← star_smul] }
+
+end matrix


### PR DESCRIPTION
A positive definite matrix `M` induces an inner product `⟪x, y⟫ = xᴴMy`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
