### PR TITLE
[Merged by Bors] - feat(linear_algebra/alternating): add more compositional API

### DIFF
--- a/src/linear_algebra/alternating.lean
+++ b/src/linear_algebra/alternating.lean
@@ -54,7 +54,7 @@ variables {N : Type*} [add_comm_monoid N] [module R N]
 variables {M' : Type*} [add_comm_group M'] [module R M']
 variables {N' : Type*} [add_comm_group N'] [module R N']
 
-variables {ι ι' : Type*} [decidable_eq ι] [decidable_eq ι']
+variables {ι ι' ι'' : Type*} [decidable_eq ι] [decidable_eq ι'] [decidable_eq ι'']
 
 set_option old_structure_cmd true
 
@@ -479,6 +479,9 @@ def dom_dom_congr (σ : ι ≃ ι') (f : alternating_map R M N ι) : alternating
   map_eq_zero_of_eq' := λ v i j hv hij,
     f.map_eq_zero_of_eq (v ∘ σ) (by simpa using hv) (σ.symm.injective.ne hij),
   .. f.to_multilinear_map.dom_dom_congr σ }
+
+lemma dom_dom_congr_trans (σ₁ : ι ≃ ι') (σ₂ : ι' ≃ ι'') (f : alternating_map R M N ι) :
+  f.dom_dom_congr (σ₁.trans σ₂) = (f.dom_dom_congr σ₁).dom_dom_congr σ₂ := rfl
 
 lemma dom_dom_congr_perm [fintype ι] (σ : equiv.perm ι) :
   g.dom_dom_congr σ = σ.sign • g :=

--- a/src/linear_algebra/alternating.lean
+++ b/src/linear_algebra/alternating.lean
@@ -470,6 +470,8 @@ lemma map_congr_perm [fintype ι] (σ : equiv.perm ι) :
   g v = σ.sign • g (v ∘ σ) :=
 by { rw [g.map_perm, smul_smul], simp }
 
+section dom_dom_congr
+
 /-- Transfer the arguments to a map along an equivalence between argument indices.
 
 This is the alternating version of `multilinear_map.dom_dom_congr`. -/
@@ -486,6 +488,35 @@ def dom_dom_congr (σ : ι ≃ ι') (f : alternating_map R M N ι) : alternating
 lemma dom_dom_congr_trans (σ₁ : ι ≃ ι') (σ₂ : ι' ≃ ι'') (f : alternating_map R M N ι) :
   f.dom_dom_congr (σ₁.trans σ₂) = (f.dom_dom_congr σ₁).dom_dom_congr σ₂ := rfl
 
+@[simp] lemma dom_dom_congr_zero (σ : ι ≃ ι') :
+  (0 : alternating_map R M N ι).dom_dom_congr σ = 0 :=
+rfl
+
+@[simp] lemma dom_dom_congr_add (σ : ι ≃ ι') (f g : alternating_map R M N ι) :
+  (f + g).dom_dom_congr σ = f.dom_dom_congr σ + g.dom_dom_congr σ :=
+rfl
+
+/-- `alternating_map.dom_dom_congr` as an equivalence.
+
+This is declared separately because it does not work with dot notation. -/
+@[simps apply symm_apply]
+def dom_dom_congr_equiv (σ : ι ≃ ι') :
+  alternating_map R M N ι ≃+ alternating_map R M N ι' :=
+{ to_fun := dom_dom_congr σ,
+  inv_fun := dom_dom_congr σ.symm,
+  left_inv := λ f, by { ext, simp [function.comp] },
+  right_inv := λ m, by { ext, simp [function.comp] },
+  map_add' := dom_dom_congr_add σ }
+
+/-- The results of applying `dom_dom_congr` to two maps are equal if and only if those maps are. -/
+@[simp] lemma dom_dom_congr_eq_iff (σ : ι ≃ ι') (f g : alternating_map R M N ι) :
+  f.dom_dom_congr σ = g.dom_dom_congr σ ↔ f = g :=
+(dom_dom_congr_equiv σ : _ ≃+ alternating_map R M N ι').apply_eq_iff_eq
+
+@[simp] lemma dom_dom_congr_eq_zero_iff (σ : ι ≃ ι') (f : alternating_map R M N ι) :
+  f.dom_dom_congr σ = 0 ↔ f = 0 :=
+(dom_dom_congr_equiv σ : alternating_map R M N ι ≃+ alternating_map R M N ι').map_eq_zero_iff
+
 lemma dom_dom_congr_perm [fintype ι] (σ : equiv.perm ι) :
   g.dom_dom_congr σ = σ.sign • g :=
 alternating_map.ext $ λ v, g.map_perm v σ
@@ -493,6 +524,8 @@ alternating_map.ext $ λ v, g.map_perm v σ
 @[norm_cast] lemma coe_dom_dom_congr [fintype ι] (σ : ι ≃ ι') :
   ↑(f.dom_dom_congr σ) = (f : multilinear_map R (λ _ : ι, M) N).dom_dom_congr σ :=
 multilinear_map.ext $ λ v, rfl
+
+end dom_dom_congr
 
 /-- If the arguments are linearly dependent then the result is `0`. -/
 lemma map_linear_dependent

--- a/src/linear_algebra/alternating.lean
+++ b/src/linear_algebra/alternating.lean
@@ -911,18 +911,29 @@ a linear map into alternating maps in `n` variables, given by `x ↦ (m ↦ f (m
 
 This is `multilinear_map.curry_left` for `alternating_map`. -/
 @[simps]
-def curry_left {n : ℕ} :
+def curry_left {n : ℕ} (f : alternating_map R' M'' N'' (fin n.succ)) :
+  M'' →ₗ[R'] alternating_map R' M'' N'' (fin n) :=
+{ to_fun := λ m,
+  { to_fun    := λ v, f (matrix.vec_cons m v),
+    map_eq_zero_of_eq' := λ v i j hv hij, f.map_eq_zero_of_eq _
+      (by rwa [matrix.cons_val_succ, matrix.cons_val_succ]) ((fin.succ_injective _).ne hij),
+    .. f.to_multilinear_map.curry_left m },
+  map_add' := λ m₁ m₂, ext $ λ v, f.map_vec_cons_add _ _ _,
+  map_smul' := λ r m, ext $ λ v, f.map_vec_cons_smul _ _ _ }
+
+/-- `alternating_map.curry_left` as a `linear_map`. This is a separate definition as dot notation
+does not work for this version. -/
+@[simps]
+def curry_left_linear_map {n : ℕ} :
   alternating_map R' M'' N'' (fin n.succ) →ₗ[R'] M'' →ₗ[R'] alternating_map R' M'' N'' (fin n) :=
-{ to_fun := λ f,
-  { to_fun := λ m,
-    { to_fun    := λ v, f (matrix.vec_cons m v),
-      map_eq_zero_of_eq' := λ v i j hv hij, f.map_eq_zero_of_eq _
-        (by rwa [matrix.cons_val_succ, matrix.cons_val_succ]) ((fin.succ_injective _).ne hij),
-      .. f.to_multilinear_map.curry_left m },
-    map_add' := λ m₁ m₂, ext $ λ v, f.map_vec_cons_add _ _ _,
-    map_smul' := λ r m, ext $ λ v, f.map_vec_cons_smul _ _ _ },
+{ to_fun := λ f, f.curry_left,
   map_add' := λ f₁ f₂, rfl,
   map_smul' := λ f₁ f₂, rfl }
+
+/-- Currying with the same element twice gives the zero map. -/
+@[simp] lemma curry_left_same {n : ℕ} (f : alternating_map R' M'' N'' (fin n.succ.succ)) (m : M'') :
+  (f.curry_left m).curry_left m = 0 :=
+ext $ λ x, f.map_eq_zero_of_eq _ (by simp) fin.zero_ne_one
 
 /-- The space of constant maps is equivalent to the space of maps that are alternating with respect
 to an empty family. -/

--- a/src/linear_algebra/alternating.lean
+++ b/src/linear_algebra/alternating.lean
@@ -521,7 +521,7 @@ lemma dom_dom_congr_perm [fintype ι] (σ : equiv.perm ι) :
   g.dom_dom_congr σ = σ.sign • g :=
 alternating_map.ext $ λ v, g.map_perm v σ
 
-@[norm_cast] lemma coe_dom_dom_congr [fintype ι] (σ : ι ≃ ι') :
+@[norm_cast] lemma coe_dom_dom_congr (σ : ι ≃ ι') :
   ↑(f.dom_dom_congr σ) = (f : multilinear_map R (λ _ : ι, M) N).dom_dom_congr σ :=
 multilinear_map.ext $ λ v, rfl
 

--- a/src/linear_algebra/alternating.lean
+++ b/src/linear_algebra/alternating.lean
@@ -480,6 +480,9 @@ def dom_dom_congr (σ : ι ≃ ι') (f : alternating_map R M N ι) : alternating
     f.map_eq_zero_of_eq (v ∘ σ) (by simpa using hv) (σ.symm.injective.ne hij),
   .. f.to_multilinear_map.dom_dom_congr σ }
 
+@[simp] lemma dom_dom_congr_refl (f : alternating_map R M N ι) :
+  f.dom_dom_congr (equiv.refl ι) = f := ext $ λ v, rfl
+
 lemma dom_dom_congr_trans (σ₁ : ι ≃ ι') (σ₂ : ι' ≃ ι'') (f : alternating_map R M N ι) :
   f.dom_dom_congr (σ₁.trans σ₂) = (f.dom_dom_congr σ₁).dom_dom_congr σ₂ := rfl
 

--- a/src/linear_algebra/alternating.lean
+++ b/src/linear_algebra/alternating.lean
@@ -924,8 +924,10 @@ namespace alternating_map
 
 /-- Given an alternating map `f` in `n+1` variables, split the first variable to obtain
 a linear map into alternating maps in `n` variables, given by `x ↦ (m ↦ f (matrix.vec_cons x m))`.
+It can be thought of as a map $Hom(\bigwedge^{n+1} M, N) \to Hom(M, Hom(\bigwedge^n M, N))$.
 
-This is `multilinear_map.curry_left` for `alternating_map`. -/
+This is `multilinear_map.curry_left` for `alternating_map`. See also
+`alternating_map.curry_left_linear_map`. -/
 @[simps]
 def curry_left {n : ℕ} (f : alternating_map R' M'' N'' (fin n.succ)) :
   M'' →ₗ[R'] alternating_map R' M'' N'' (fin n) :=


### PR DESCRIPTION
These will be helpful in relating `alternating_map`s to the `exterior_algebra`.
This adds:

* `alternating_map.curry_left`
* `alternating_map.const_linear_equiv_of_is_empty`
* `alternating_map.dom_dom_congr`


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
