### PR TITLE
[Merged by Bors] - feat(probability/independence): equivalent ways to check indep_fun

### DIFF
--- a/src/measure_theory/measurable_space.lean
+++ b/src/measure_theory/measurable_space.lean
@@ -100,7 +100,7 @@ lemma comap_eq_generate_from (m : measurable_space β) (f : α → β) :
 begin
   have : {t | ∃ s, measurable_set s ∧ f ⁻¹' s = t} = (m.comap f).measurable_set' := rfl,
   rw this,
-  exact generate_from_measurable_set.symm,
+  convert generate_from_measurable_set.symm,
 end
 
 @[simp] lemma comap_id : m.comap id = m :=

--- a/src/measure_theory/measurable_space.lean
+++ b/src/measure_theory/measurable_space.lean
@@ -97,11 +97,7 @@ protected def comap (f : α → β) (m : measurable_space β) : measurable_space
 
 lemma comap_eq_generate_from (m : measurable_space β) (f : α → β) :
   m.comap f = generate_from {t | ∃ s, measurable_set s ∧ f ⁻¹' s = t} :=
-begin
-  have : {t | ∃ s, measurable_set s ∧ f ⁻¹' s = t} = (m.comap f).measurable_set' := rfl,
-  rw this,
-  convert generate_from_measurable_set.symm,
-end
+by convert generate_from_measurable_set.symm
 
 @[simp] lemma comap_id : m.comap id = m :=
 measurable_space.ext $ assume s, ⟨assume ⟨s', hs', h⟩, h ▸ hs', assume h, ⟨s, h, rfl⟩⟩

--- a/src/measure_theory/measurable_space.lean
+++ b/src/measure_theory/measurable_space.lean
@@ -97,7 +97,11 @@ protected def comap (f : α → β) (m : measurable_space β) : measurable_space
 
 lemma comap_eq_generate_from (m : measurable_space β) (f : α → β) :
   m.comap f = generate_from {t | ∃ s, measurable_set s ∧ f ⁻¹' s = t} :=
-(generate_from_measurable_set' (m.comap f)).symm
+begin
+  have : {t | ∃ s, measurable_set s ∧ f ⁻¹' s = t} = (m.comap f).measurable_set' := rfl,
+  rw this,
+  exact generate_from_measurable_set.symm,
+end
 
 @[simp] lemma comap_id : m.comap id = m :=
 measurable_space.ext $ assume s, ⟨assume ⟨s', hs', h⟩, h ▸ hs', assume h, ⟨s, h, rfl⟩⟩

--- a/src/measure_theory/measurable_space.lean
+++ b/src/measure_theory/measurable_space.lean
@@ -95,6 +95,10 @@ protected def comap (f : α → β) (m : measurable_space β) : measurable_space
     let ⟨s', hs'⟩ := classical.axiom_of_choice hs in
     ⟨⋃ i, s' i, m.measurable_set_Union _ (λ i, (hs' i).left), by simp [hs'] ⟩ }
 
+lemma comap_eq_generate_from (m : measurable_space β) (f : α → β) :
+  m.comap f = generate_from {t | ∃ s, measurable_set s ∧ f ⁻¹' s = t} :=
+(generate_from_measurable_set' (m.comap f)).symm
+
 @[simp] lemma comap_id : m.comap id = m :=
 measurable_space.ext $ assume s, ⟨assume ⟨s', hs', h⟩, h ▸ hs', assume h, ⟨s, h, rfl⟩⟩
 

--- a/src/measure_theory/measurable_space_def.lean
+++ b/src/measure_theory/measurable_space_def.lean
@@ -323,10 +323,6 @@ iff.intro
   generate_from {s : set α | measurable_set s} = ‹_› :=
 le_antisymm (generate_from_le $ λ _, id) $ λ s, measurable_set_generate_from
 
-lemma generate_from_measurable_set' (m : measurable_space α) :
-  generate_from m.measurable_set' = m :=
-generate_from_measurable_set
-
 /-- If `g` is a collection of subsets of `α` such that the `σ`-algebra generated from `g` contains
 the same sets as `g`, then `g` was already a `σ`-algebra. -/
 protected def mk_of_closure (g : set (set α)) (hg : {t | measurable_set[generate_from g] t} = g) :

--- a/src/measure_theory/measurable_space_def.lean
+++ b/src/measure_theory/measurable_space_def.lean
@@ -313,6 +313,10 @@ assume t (ht : generate_measurable s t), ht.rec_on h
   (assume s _ hs, measurable_set_compl m s hs)
   (assume f _ hf, measurable_set_Union m f hf)
 
+lemma generate_from_measurable_set' (m : measurable_space α) :
+  generate_from m.measurable_set' = m :=
+le_antisymm (generate_from_le (λ t ht, ht)) (λ s hs, measurable_set_generate_from hs)
+
 lemma generate_from_le_iff {s : set (set α)} (m : measurable_space α) :
   generate_from s ≤ m ↔ s ⊆ {t | measurable_set[m] t} :=
 iff.intro

--- a/src/measure_theory/measurable_space_def.lean
+++ b/src/measure_theory/measurable_space_def.lean
@@ -313,10 +313,6 @@ assume t (ht : generate_measurable s t), ht.rec_on h
   (assume s _ hs, measurable_set_compl m s hs)
   (assume f _ hf, measurable_set_Union m f hf)
 
-lemma generate_from_measurable_set' (m : measurable_space α) :
-  generate_from m.measurable_set' = m :=
-le_antisymm (generate_from_le (λ t ht, ht)) (λ s hs, measurable_set_generate_from hs)
-
 lemma generate_from_le_iff {s : set (set α)} (m : measurable_space α) :
   generate_from s ≤ m ↔ s ⊆ {t | measurable_set[m] t} :=
 iff.intro
@@ -326,6 +322,10 @@ iff.intro
 @[simp] lemma generate_from_measurable_set [measurable_space α] :
   generate_from {s : set α | measurable_set s} = ‹_› :=
 le_antisymm (generate_from_le $ λ _, id) $ λ s, measurable_set_generate_from
+
+lemma generate_from_measurable_set' (m : measurable_space α) :
+  generate_from m.measurable_set' = m :=
+generate_from_measurable_set
 
 /-- If `g` is a collection of subsets of `α` such that the `σ`-algebra generated from `g` contains
 the same sets as `g`, then `g` was already a `σ`-algebra. -/

--- a/src/probability/independence.lean
+++ b/src/probability/independence.lean
@@ -372,13 +372,13 @@ begin
   have hSg_pi : is_pi_system Sg,
   { rintros s ⟨s', hs', rfl⟩ t ⟨t', ht', rfl⟩ hst_nonempty,
     exact ⟨s' ∩ t', hs'.inter ht', rfl⟩, },
-  have hSf_gen : generate_from Sf = mβ.comap f := (mβ.comap_eq_generate_from f).symm,
-  have hSg_gen : generate_from Sg = mβ'.comap g := (mβ'.comap_eq_generate_from g).symm,
+  have hSf_gen : mβ.comap f = generate_from Sf := mβ.comap_eq_generate_from f,
+  have hSg_gen : mβ'.comap g = generate_from Sg := mβ'.comap_eq_generate_from g,
   rw indep_fun,
   split; intro h,
-  { rw [← hSf_gen, ← hSg_gen] at h,
+  { rw [hSf_gen, hSg_gen] at h,
     exact indep.indep_sets h, },
-  { exact indep_sets.indep hf.comap_le hg.comap_le hSf_pi hSg_pi hSf_gen.symm hSg_gen.symm h, },
+  { exact indep_sets.indep hf.comap_le hg.comap_le hSf_pi hSg_pi hSf_gen hSg_gen h, },
 end
 
 lemma indep_fun_iff_indep_set_preimage {mβ : measurable_space β} {mβ' : measurable_space β'}


### PR DESCRIPTION
Prove:
- `indep_fun f g μ ↔ ∀ s t, measurable_set s → measurable_set t → μ (f ⁻¹' s ∩ g ⁻¹' t) = μ (f ⁻¹' s) * μ (g ⁻¹' t)`,
- `indep_fun f g μ ↔ ∀ s t, measurable_set s → measurable_set t → indep_set (f ⁻¹' s) (g ⁻¹' t) μ`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
