### PR TITLE
[Merged by Bors] - feat(logic/unique): functions from a `unique` type is `const`

### DIFF
--- a/src/logic/unique.lean
+++ b/src/logic/unique.lean
@@ -137,21 +137,34 @@ lemma unique_iff_subsingleton_and_nonempty (α : Sort u) :
 ⟨λ ⟨u⟩, by split; exactI infer_instance,
  λ ⟨hs, hn⟩, ⟨by { resetI, inhabit α, exact unique.mk' α }⟩⟩
 
-@[simp] lemma pi.default_def {β : Π a : α, Sort v} [Π a, inhabited (β a)] :
+@[simp] lemma pi.default_def {β : α → Sort v} [Π a, inhabited (β a)] :
   @default (Π a, β a) _ = λ a : α, @default (β a) _ := rfl
 
-lemma pi.default_apply {β : Π a : α, Sort v} [Π a, inhabited (β a)] (a : α) :
+lemma pi.default_apply {β : α → Sort v} [Π a, inhabited (β a)] (a : α) :
   @default (Π a, β a) _ a = default := rfl
 
-instance pi.unique {β : Π a : α, Sort v} [Π a, unique (β a)] : unique (Π a, β a) :=
+instance pi.unique {β : α → Sort v} [Π a, unique (β a)] : unique (Π a, β a) :=
 { uniq := λ f, funext $ λ x, unique.eq_default _,
   .. pi.inhabited α }
 
 /-- There is a unique function on an empty domain. -/
-instance pi.unique_of_is_empty [is_empty α] (β : Π a : α, Sort v) :
+instance pi.unique_of_is_empty [is_empty α] (β : α → Sort v) :
   unique (Π a, β a) :=
 { default := is_empty_elim,
   uniq := λ f, funext is_empty_elim }
+
+lemma congr_arg_heq_of_subsingleton [subsingleton α] {β : α → Sort v}
+  (f : Π a, β a) (i j : α) : f i == f j := by rw subsingleton.elim i j
+
+lemma congr_arg_of_subsingleton [subsingleton α]
+  (f : α → β) (i j : α) : f i = f j := by rw subsingleton.elim i j
+
+lemma eq_const_of_unique [unique α] (f : α → β) : f = λ _, f default :=
+by { ext, apply congr_arg_of_subsingleton }
+
+lemma heq_const_of_unique [unique α] {β : α → Sort v}
+  (f : Π a, β a) : f == λ a : α, f default :=
+function.hfunext rfl (λ i _ _, by rw subsingleton.elim i default)
 
 namespace function
 

--- a/src/logic/unique.lean
+++ b/src/logic/unique.lean
@@ -153,18 +153,12 @@ instance pi.unique_of_is_empty [is_empty α] (β : α → Sort v) :
 { default := is_empty_elim,
   uniq := λ f, funext is_empty_elim }
 
-lemma congr_arg_heq_of_subsingleton [subsingleton α] {β : α → Sort v}
-  (f : Π a, β a) (i j : α) : f i == f j := by rw subsingleton.elim i j
-
-lemma congr_arg_of_subsingleton [subsingleton α]
-  (f : α → β) (i j : α) : f i = f j := by rw subsingleton.elim i j
-
-lemma eq_const_of_unique [unique α] (f : α → β) : f = λ _, f default :=
-by { ext, apply congr_arg_of_subsingleton }
+lemma eq_const_of_unique [unique α] (f : α → β) : f = function.const α (f default) :=
+by { ext x, rw subsingleton.elim x default }
 
 lemma heq_const_of_unique [unique α] {β : α → Sort v}
-  (f : Π a, β a) : f == λ a : α, f default :=
-function.hfunext rfl (λ i _ _, by rw subsingleton.elim i default)
+  (f : Π a, β a) : f == function.const α (f default) :=
+function.hfunext rfl $ λ i _ _, by rw subsingleton.elim i default
 
 namespace function
 


### PR DESCRIPTION
+ A function `f` from a `unique` type is equal to the constant function with value `f default`, and the analogous heq version for dependent functions.

+ Also changes `Π a : α, Sort v` in the file to `α → Sort v`.

Inspired by https://github.com/leanprover-community/mathlib/pull/14724#discussion_r900542203

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
