### PR TITLE
[Merged by Bors] - feat(data/nat/totient): more general multiplicativity lemmas for totient

### DIFF
--- a/src/data/nat/totient.lean
+++ b/src/data/nat/totient.lean
@@ -359,9 +359,9 @@ begin
   simp only [totient_eq_div_factors_mul],
   rw [shuffle, shuffle],
   rotate, repeat { apply prod_prime_factors_dvd },
-  simp only [prod_factors_gcd_mul_prod_factors_mul],
-  rw [eq_comm, mul_comm, ←mul_assoc, ←nat.mul_div_assoc],
-  exact mul_dvd_mul (prod_prime_factors_dvd a) (prod_prime_factors_dvd b)
+  { simp only [prod_factors_gcd_mul_prod_factors_mul],
+    rw [eq_comm, mul_comm, ←mul_assoc, ←nat.mul_div_assoc],
+    exact mul_dvd_mul (prod_prime_factors_dvd a) (prod_prime_factors_dvd b) }
 end
 
 lemma totient_super_multiplicative (a b : ℕ) : φ a * φ b ≤ φ (a * b) :=

--- a/src/data/nat/totient.lean
+++ b/src/data/nat/totient.lean
@@ -335,7 +335,7 @@ begin
   rw [sub_mul, one_mul, mul_comm, mul_inv_cancel hp', cast_pred hp],
 end
 
-lemma gcd_prod_double_counting {β : Type*} [comm_monoid β] (m n : ℕ) (f : ℕ → β) :
+lemma prod_factors_gcd_mul_prod_factors_mul {β : Type*} [comm_monoid β] (m n : ℕ) (f : ℕ → β) :
   (m.gcd n).factors.to_finset.prod f * (m * n).factors.to_finset.prod f
     = m.factors.to_finset.prod f * n.factors.to_finset.prod f :=
 begin
@@ -359,7 +359,7 @@ begin
   rw shuffle _ _,
   rw shuffle _ _,
   rotate, repeat { apply prod_prime_factors_dvd },
-  simp only [gcd_prod_double_counting],
+  simp only [prod_factors_gcd_mul_prod_factors_mul],
   rw [eq_comm, mul_comm, ←mul_assoc, ←nat.mul_div_assoc],
   exact mul_dvd_mul (prod_prime_factors_dvd a) (prod_prime_factors_dvd b)
 end

--- a/src/data/nat/totient.lean
+++ b/src/data/nat/totient.lean
@@ -336,7 +336,8 @@ begin
 end
 
 lemma gcd_prod_double_counting {β : Type*} [comm_monoid β] (m n : ℕ) (f : ℕ → β) :
-    (∏ (x : ℕ) in (m.gcd n).factors.to_finset, f x) * ∏ (x : ℕ) in (m * n).factors.to_finset, f x = (∏ (x : ℕ) in m.factors.to_finset, f x) * ∏ (x : ℕ) in n.factors.to_finset, f x :=
+    (∏ (x : ℕ) in (m.gcd n).factors.to_finset, f x) * ∏ (x : ℕ) in (m * n).factors.to_finset, f x
+     = (∏ (x : ℕ) in m.factors.to_finset, f x) * ∏ (x : ℕ) in n.factors.to_finset, f x :=
 begin
   rcases eq_or_ne n 0 with rfl | hm0, { simp },
   rcases eq_or_ne m 0 with rfl | hn0, { simp },
@@ -364,3 +365,4 @@ begin
 end
 
 end nat
+#lint

--- a/src/data/nat/totient.lean
+++ b/src/data/nat/totient.lean
@@ -364,4 +364,13 @@ begin
   exact mul_dvd_mul (prod_prime_factors_dvd a) (prod_prime_factors_dvd b)
 end
 
+lemma totient_super_multiplicative (a b : ℕ) : a.totient * b.totient ≤ (a * b).totient :=
+begin
+  let d := a.gcd b,
+  by_cases ha0 : a = 0, { simp [ha0] },
+  have hd0 : 0 < d, { apply nat.pos_of_ne_zero, contrapose! ha0, exact (gcd_eq_zero_iff.1 ha0).1 },
+  rw [←mul_le_mul_right hd0, ←totient_mul_general a b, mul_comm],
+  apply mul_le_mul_left' (nat.totient_le d),
+end
+
 end nat

--- a/src/data/nat/totient.lean
+++ b/src/data/nat/totient.lean
@@ -335,19 +335,6 @@ begin
   rw [sub_mul, one_mul, mul_comm, mul_inv_cancel hp', cast_pred hp],
 end
 
-@[to_additive sum_factors_gcd_add_sum_factors_mul]
-lemma prod_factors_gcd_mul_prod_factors_mul {β : Type*} [comm_monoid β] (m n : ℕ) (f : ℕ → β) :
-  (m.gcd n).factors.to_finset.prod f * (m * n).factors.to_finset.prod f
-    = m.factors.to_finset.prod f * n.factors.to_finset.prod f :=
-begin
-  rcases eq_or_ne n 0 with rfl | hm0, { simp },
-  rcases eq_or_ne m 0 with rfl | hn0, { simp },
-  rw [←@prod_union_inter _ _ m.factors.to_finset n.factors.to_finset, mul_comm],
-  congr,
-  { apply factors_mul_to_finset; assumption },
-  { simp only [←support_factorization, factorization_gcd hn0 hm0, finsupp.support_inf] },
-end
-
 lemma totient_gcd_mul_totient_mul (a b : ℕ) : φ (a.gcd b) * φ (a * b) = φ a * φ b * (a.gcd b) :=
 begin
   have shuffle : ∀ a1 a2 b1 b2 c1 c2 : ℕ, b1 ∣ a1 → b2 ∣ a2 →

--- a/src/data/nat/totient.lean
+++ b/src/data/nat/totient.lean
@@ -336,8 +336,8 @@ begin
 end
 
 lemma gcd_prod_double_counting {β : Type*} [comm_monoid β] (m n : ℕ) (f : ℕ → β) :
-    (∏ (x : ℕ) in (m.gcd n).factors.to_finset, f x) * ∏ (x : ℕ) in (m * n).factors.to_finset, f x
-     = (∏ (x : ℕ) in m.factors.to_finset, f x) * ∏ (x : ℕ) in n.factors.to_finset, f x :=
+  (m.gcd n).factors.to_finset.prod f * (m * n).factors.to_finset.prod f
+    = m.factors.to_finset.prod f * n.factors.to_finset.prod f :=
 begin
   rcases eq_or_ne n 0 with rfl | hm0, { simp },
   rcases eq_or_ne m 0 with rfl | hn0, { simp },

--- a/src/data/nat/totient.lean
+++ b/src/data/nat/totient.lean
@@ -335,6 +335,7 @@ begin
   rw [sub_mul, one_mul, mul_comm, mul_inv_cancel hp', cast_pred hp],
 end
 
+@[to_additive sum_factors_gcd_add_sum_factors_mul]
 lemma prod_factors_gcd_mul_prod_factors_mul {β : Type*} [comm_monoid β] (m n : ℕ) (f : ℕ → β) :
   (m.gcd n).factors.to_finset.prod f * (m * n).factors.to_finset.prod f
     = m.factors.to_finset.prod f * n.factors.to_finset.prod f :=

--- a/src/data/nat/totient.lean
+++ b/src/data/nat/totient.lean
@@ -357,8 +357,7 @@ begin
       (a1/b1 * c1) * (a2/b2 * c2) = ((a1/b1) * (a2/b2)) * (c1*c2) : by apply mul_mul_mul_comm
       ... = (a1*a2)/(b1*b2) * (c1*c2) : by { congr' 1, exact div_mul_div_comm h1 h2 } },
   simp only [totient_eq_div_factors_mul],
-  rw shuffle _ _,
-  rw shuffle _ _,
+  rw [shuffle, shuffle],
   rotate, repeat { apply prod_prime_factors_dvd },
   simp only [prod_factors_gcd_mul_prod_factors_mul],
   rw [eq_comm, mul_comm, ←mul_assoc, ←nat.mul_div_assoc],

--- a/src/data/nat/totient.lean
+++ b/src/data/nat/totient.lean
@@ -365,4 +365,3 @@ begin
 end
 
 end nat
-#lint

--- a/src/data/nat/totient.lean
+++ b/src/data/nat/totient.lean
@@ -367,8 +367,8 @@ end
 lemma totient_super_multiplicative (a b : ℕ) : φ a * φ b ≤ φ (a * b) :=
 begin
   let d := a.gcd b,
-  by_cases ha0 : a = 0, { simp [ha0] },
-  have hd0 : 0 < d, { apply nat.pos_of_ne_zero, contrapose! ha0, exact (gcd_eq_zero_iff.1 ha0).1 },
+  rcases (zero_le a).eq_or_lt with rfl | ha0, { simp },
+  have hd0 : 0 < d, from nat.gcd_pos_of_pos_left _ ha0,
   rw [←mul_le_mul_right hd0, ←totient_gcd_mul_totient_mul a b, mul_comm],
   apply mul_le_mul_left' (nat.totient_le d),
 end

--- a/src/data/nat/totient.lean
+++ b/src/data/nat/totient.lean
@@ -347,7 +347,7 @@ begin
   { simp only [←support_factorization, factorization_gcd hn0 hm0, finsupp.support_inf] },
 end
 
-lemma totient_mul_general (a b : ℕ) : φ (a.gcd b) * φ (a * b) = φ a * φ b * (a.gcd b) :=
+lemma totient_gcd_mul_totient_mul (a b : ℕ) : φ (a.gcd b) * φ (a * b) = φ a * φ b * (a.gcd b) :=
 begin
   have shuffle : ∀ a1 a2 b1 b2 c1 c2 : ℕ, b1 ∣ a1 → b2 ∣ a2 →
     (a1/b1 * c1) * (a2/b2 * c2) = (a1*a2)/(b1*b2) * (c1*c2),
@@ -364,12 +364,12 @@ begin
   exact mul_dvd_mul (prod_prime_factors_dvd a) (prod_prime_factors_dvd b)
 end
 
-lemma totient_super_multiplicative (a b : ℕ) : a.totient * b.totient ≤ (a * b).totient :=
+lemma totient_super_multiplicative (a b : ℕ) : φ a * φ b ≤ φ (a * b) :=
 begin
   let d := a.gcd b,
   by_cases ha0 : a = 0, { simp [ha0] },
   have hd0 : 0 < d, { apply nat.pos_of_ne_zero, contrapose! ha0, exact (gcd_eq_zero_iff.1 ha0).1 },
-  rw [←mul_le_mul_right hd0, ←totient_mul_general a b, mul_comm],
+  rw [←mul_le_mul_right hd0, ←totient_gcd_mul_totient_mul a b, mul_comm],
   apply mul_le_mul_left' (nat.totient_le d),
 end
 

--- a/src/data/nat/totient.lean
+++ b/src/data/nat/totient.lean
@@ -335,4 +335,32 @@ begin
   rw [sub_mul, one_mul, mul_comm, mul_inv_cancel hp', cast_pred hp],
 end
 
+lemma gcd_prod_double_counting {β : Type*} [comm_monoid β] (m n : ℕ) (f : ℕ → β) :
+    (∏ (x : ℕ) in (m.gcd n).factors.to_finset, f x) * ∏ (x : ℕ) in (m * n).factors.to_finset, f x = (∏ (x : ℕ) in m.factors.to_finset, f x) * ∏ (x : ℕ) in n.factors.to_finset, f x :=
+begin
+  rcases eq_or_ne n 0 with rfl | hm0, { simp },
+  rcases eq_or_ne m 0 with rfl | hn0, { simp },
+  rw [←@prod_union_inter _ _ m.factors.to_finset n.factors.to_finset, mul_comm],
+  congr,
+  { apply factors_mul_to_finset; assumption },
+  { simp only [←support_factorization, factorization_gcd hn0 hm0, finsupp.support_inf] },
+end
+
+lemma totient_mul_general (a b : ℕ) : φ (a.gcd b) * φ (a * b) = φ a * φ b * (a.gcd b) :=
+begin
+  have shuffle : ∀ a1 a2 b1 b2 c1 c2 : ℕ, b1 ∣ a1 → b2 ∣ a2 →
+    (a1/b1 * c1) * (a2/b2 * c2) = (a1*a2)/(b1*b2) * (c1*c2),
+  { intros a1 a2 b1 b2 c1 c2 h1 h2,
+    calc
+      (a1/b1 * c1) * (a2/b2 * c2) = ((a1/b1) * (a2/b2)) * (c1*c2) : by apply mul_mul_mul_comm
+      ... = (a1*a2)/(b1*b2) * (c1*c2) : by { congr' 1, exact div_mul_div_comm h1 h2 } },
+  simp only [totient_eq_div_factors_mul],
+  rw shuffle _ _,
+  rw shuffle _ _,
+  rotate, repeat { apply prod_prime_factors_dvd },
+  simp only [gcd_prod_double_counting],
+  rw [eq_comm, mul_comm, ←mul_assoc, ←nat.mul_div_assoc],
+  exact mul_dvd_mul (prod_prime_factors_dvd a) (prod_prime_factors_dvd b)
+end
+
 end nat

--- a/src/ring_theory/multiplicity.lean
+++ b/src/ring_theory/multiplicity.lean
@@ -499,4 +499,17 @@ lemma multiplicity_eq_factorization {n p : ℕ} (pp : p.prime) (hn : n ≠ 0) :
   multiplicity p n = n.factorization p :=
 multiplicity.eq_coe_iff.mpr ⟨pow_factorization_dvd n p, pow_succ_factorization_not_dvd hn pp⟩
 
+@[to_additive sum_factors_gcd_add_sum_factors_mul]
+lemma prod_factors_gcd_mul_prod_factors_mul {β : Type*} [comm_monoid β] (m n : ℕ) (f : ℕ → β) :
+  (m.gcd n).factors.to_finset.prod f * (m * n).factors.to_finset.prod f
+    = m.factors.to_finset.prod f * n.factors.to_finset.prod f :=
+begin
+  rcases eq_or_ne n 0 with rfl | hm0, { simp },
+  rcases eq_or_ne m 0 with rfl | hn0, { simp },
+  rw [←@finset.prod_union_inter _ _ m.factors.to_finset n.factors.to_finset, mul_comm],
+  congr,
+  { apply factors_mul_to_finset; assumption },
+  { simp only [←support_factorization, factorization_gcd hn0 hm0, finsupp.support_inf] },
+end
+
 end nat


### PR DESCRIPTION
Adds lemmas: 
`totient_gcd_mul_totient_mul : φ (a.gcd b) * φ (a * b) = φ a * φ b * (a.gcd b)`
`totient_super_multiplicative : φ a * φ b ≤ φ (a * b)`

`totient_gcd_mul_totient_mul` is Theorem 2.5(b) in Apostol (1976) Introduction to Analytic Number Theory.

Developed while reviewing @CBirkbeck 's #14828


---

cc @vihdzp who reviewed #14828


<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
