### PR TITLE
[Merged by Bors] - feat(set_theory/cardinal/basic): lemmas about `#(finset α)`

### DIFF
--- a/src/data/fintype/basic.lean
+++ b/src/data/fintype/basic.lean
@@ -1318,6 +1318,14 @@ by rw [←e.equiv_of_fintype_self_embedding_to_embedding, univ_map_equiv_to_embe
 
 namespace fintype
 
+/-- Given `fintype α`, `equiv_set_on_fintype` is the equiv between `finset α` and `set α`. (All
+set on a finite type are finite.) -/
+@[simps] noncomputable def equiv_set_on_fintype [fintype α] : finset α ≃ set α :=
+{ to_fun := coe,
+  inv_fun := by classical; exact λ s, s.to_finset,
+  left_inv := λ A, by { ext, rw [set.mem_to_finset, finset.mem_coe] },
+  right_inv := λ A, by rw [set.coe_to_finset] }
+
 lemma card_lt_of_surjective_not_injective [fintype α] [fintype β] (f : α → β)
   (h : function.surjective f) (h' : ¬function.injective f) : card β < card α :=
 card_lt_of_injective_not_surjective _ (function.injective_surj_inv h) $ λ hg,

--- a/src/data/fintype/basic.lean
+++ b/src/data/fintype/basic.lean
@@ -1323,8 +1323,8 @@ set on a finite type are finite.) -/
 @[simps] noncomputable def equiv_set_on_fintype [fintype α] : finset α ≃ set α :=
 { to_fun := coe,
   inv_fun := by classical; exact λ s, s.to_finset,
-  left_inv := λ A, by { ext, rw [set.mem_to_finset, finset.mem_coe] },
-  right_inv := λ A, by rw [set.coe_to_finset] }
+  left_inv := λ s, by { ext, rw [set.mem_to_finset, finset.mem_coe] },
+  right_inv := λ s, by rw set.coe_to_finset }
 
 lemma card_lt_of_surjective_not_injective [fintype α] [fintype β] (f : α → β)
   (h : function.surjective f) (h' : ¬function.injective f) : card β < card α :=

--- a/src/data/fintype/basic.lean
+++ b/src/data/fintype/basic.lean
@@ -1326,7 +1326,7 @@ namespace fintype
 set on a finite type are finite.) -/
 @[simps] noncomputable def finset_equiv_set [fintype α] : finset α ≃ set α :=
 { to_fun := coe,
-  inv_fun := by classical; exact λ s, s.to_finset,
+  inv_fun := by { classical, exact λ s, s.to_finset },
   left_inv := λ s, by convert finset.to_finset_coe s,
   right_inv := λ s, s.coe_to_finset }
 

--- a/src/data/fintype/basic.lean
+++ b/src/data/fintype/basic.lean
@@ -729,10 +729,6 @@ by { ext, simp only [mem_filter, finset.mem_univ, true_and, mem_to_finset] }
 
 end set
 
-@[simp] lemma finset.to_finset_coe (s : finset α) [fintype ↥(s : set α)] :
-  (s : set α).to_finset = s :=
-ext $ λ _, set.mem_to_finset
-
 lemma finset.card_univ [fintype α] : (finset.univ : finset α).card = fintype.card α :=
 rfl
 
@@ -1321,14 +1317,6 @@ lemma finset.univ_map_embedding {α : Type*} [fintype α] (e : α ↪ α) :
 by rw [←e.equiv_of_fintype_self_embedding_to_embedding, univ_map_equiv_to_embedding]
 
 namespace fintype
-
-/-- Given `fintype α`, `finset_equiv_set` is the equiv between `finset α` and `set α`. (All
-set on a finite type are finite.) -/
-@[simps] noncomputable def finset_equiv_set [fintype α] : finset α ≃ set α :=
-{ to_fun := coe,
-  inv_fun := by { classical, exact λ s, s.to_finset },
-  left_inv := λ s, by convert finset.to_finset_coe s,
-  right_inv := λ s, s.coe_to_finset }
 
 lemma card_lt_of_surjective_not_injective [fintype α] [fintype β] (f : α → β)
   (h : function.surjective f) (h' : ¬function.injective f) : card β < card α :=

--- a/src/data/fintype/basic.lean
+++ b/src/data/fintype/basic.lean
@@ -729,6 +729,10 @@ by { ext, simp only [mem_filter, finset.mem_univ, true_and, mem_to_finset] }
 
 end set
 
+@[simp] lemma finset.to_finset_coe (s : finset α) [fintype ↥(s : set α)] :
+  (s : set α).to_finset = s :=
+ext $ λ _, set.mem_to_finset
+
 lemma finset.card_univ [fintype α] : (finset.univ : finset α).card = fintype.card α :=
 rfl
 
@@ -1318,13 +1322,13 @@ by rw [←e.equiv_of_fintype_self_embedding_to_embedding, univ_map_equiv_to_embe
 
 namespace fintype
 
-/-- Given `fintype α`, `equiv_set_on_fintype` is the equiv between `finset α` and `set α`. (All
+/-- Given `fintype α`, `finset_equiv_set` is the equiv between `finset α` and `set α`. (All
 set on a finite type are finite.) -/
-@[simps] noncomputable def equiv_set_on_fintype [fintype α] : finset α ≃ set α :=
+@[simps] noncomputable def finset_equiv_set [fintype α] : finset α ≃ set α :=
 { to_fun := coe,
   inv_fun := by classical; exact λ s, s.to_finset,
-  left_inv := λ s, by { ext, rw [set.mem_to_finset, finset.mem_coe] },
-  right_inv := λ s, by rw set.coe_to_finset }
+  left_inv := λ s, by convert finset.to_finset_coe s,
+  right_inv := λ s, s.coe_to_finset }
 
 lemma card_lt_of_surjective_not_injective [fintype α] [fintype β] (f : α → β)
   (h : function.surjective f) (h' : ¬function.injective f) : card β < card α :=

--- a/src/field_theory/fixed.lean
+++ b/src/field_theory/fixed.lean
@@ -243,7 +243,7 @@ instance separable : is_separable (fixed_points.subfield G F) F :=
   exact polynomial.separable_prod_X_sub_C_iff.2 (injective_of_quotient_stabilizer G x) }⟩
 
 lemma dim_le_card : module.rank (fixed_points.subfield G F) F ≤ fintype.card G :=
-dim_le $ λ s hs, by simpa only [dim_fun', cardinal.mk_finset, finset.coe_sort_coe,
+dim_le $ λ s hs, by simpa only [dim_fun', cardinal.mk_of_finset, finset.coe_sort_coe,
   cardinal.lift_nat_cast, cardinal.nat_cast_le]
   using cardinal_lift_le_dim_of_linear_independent'
     (linear_independent_smul_of_linear_independent G F hs)

--- a/src/field_theory/fixed.lean
+++ b/src/field_theory/fixed.lean
@@ -243,7 +243,7 @@ instance separable : is_separable (fixed_points.subfield G F) F :=
   exact polynomial.separable_prod_X_sub_C_iff.2 (injective_of_quotient_stabilizer G x) }⟩
 
 lemma dim_le_card : module.rank (fixed_points.subfield G F) F ≤ fintype.card G :=
-dim_le $ λ s hs, by simpa only [dim_fun', cardinal.mk_of_finset, finset.coe_sort_coe,
+dim_le $ λ s hs, by simpa only [dim_fun', cardinal.mk_coe_finset, finset.coe_sort_coe,
   cardinal.lift_nat_cast, cardinal.nat_cast_le]
   using cardinal_lift_le_dim_of_linear_independent'
     (linear_independent_smul_of_linear_independent G F hs)

--- a/src/linear_algebra/dimension.lean
+++ b/src/linear_algebra/dimension.lean
@@ -720,7 +720,7 @@ lemma linear_independent_le_infinite_basis
   #κ ≤ #ι :=
 begin
   by_contradiction,
-  rw [not_le, ← cardinal.mk_finset_eq_mk ι] at h,
+  rw [not_le, ← cardinal.mk_finset_of_infinite ι] at h,
   let Φ := λ k : κ, (b.repr (v k)).support,
   obtain ⟨s, w : infinite ↥(Φ ⁻¹' {s})⟩ := cardinal.exists_infinite_fiber Φ h (by apply_instance),
   let v' := λ k : Φ ⁻¹' {s}, v k,
@@ -982,7 +982,7 @@ end
 lemma dim_span_of_finset (s : finset V) :
   module.rank K (span K (↑s : set V)) < ℵ₀ :=
 calc module.rank K (span K (↑s : set V)) ≤ #(↑s : set V) : dim_span_le ↑s
-                             ... = s.card : by rw [finset.coe_sort_coe, cardinal.mk_finset]
+                             ... = s.card : by rw [finset.coe_sort_coe, cardinal.mk_of_finset]
                              ... < ℵ₀ : cardinal.nat_lt_aleph_0 _
 
 theorem dim_prod : module.rank K (V × V₁) = module.rank K V + module.rank K V₁ :=

--- a/src/linear_algebra/dimension.lean
+++ b/src/linear_algebra/dimension.lean
@@ -982,7 +982,7 @@ end
 lemma dim_span_of_finset (s : finset V) :
   module.rank K (span K (↑s : set V)) < ℵ₀ :=
 calc module.rank K (span K (↑s : set V)) ≤ #(↑s : set V) : dim_span_le ↑s
-                             ... = s.card : by rw [finset.coe_sort_coe, cardinal.mk_of_finset]
+                             ... = s.card : by rw [finset.coe_sort_coe, cardinal.mk_coe_finset]
                              ... < ℵ₀ : cardinal.nat_lt_aleph_0 _
 
 theorem dim_prod : module.rank K (V × V₁) = module.rank K V + module.rank K V₁ :=

--- a/src/set_theory/cardinal/basic.lean
+++ b/src/set_theory/cardinal/basic.lean
@@ -827,10 +827,7 @@ theorem lift_mk_fin (n : ℕ) : lift (#(fin n)) = n := by simp
 lemma mk_of_finset {α : Type u} {s : finset α} : #s = ↑(finset.card s) := by simp
 
 @[simp] lemma mk_finset_of_fintype [fintype α] : #(finset α) = 2 ^ #α :=
-begin
-  rw ←mk_set,
-  apply equiv.cardinal_eq,
-end
+by { rw ←mk_set, exact fintype.equiv_set_on_fintype.cardinal_eq }
 
 theorem card_le_of_finset {α} (s : finset α) : (s.card : cardinal) ≤ #α :=
 begin

--- a/src/set_theory/cardinal/basic.lean
+++ b/src/set_theory/cardinal/basic.lean
@@ -824,7 +824,7 @@ by rw [←lift_nat_cast.{v} n, lift_inj]
 
 theorem lift_mk_fin (n : ℕ) : lift (#(fin n)) = n := by simp
 
-lemma mk_of_finset {α : Type u} {s : finset α} : #s = ↑(finset.card s) := by simp
+lemma mk_coe_finset {α : Type u} {s : finset α} : #s = ↑(finset.card s) := by simp
 
 lemma mk_finset_of_fintype [fintype α] : #(finset α) = 2 ^ℕ fintype.card α := by simp
 
@@ -1309,7 +1309,7 @@ begin
     lift s to finset α using lt_aleph_0_iff_finite.1 (h.symm ▸ nat_lt_aleph_0 n),
     simpa using h },
   { rintro ⟨t, rfl, rfl⟩,
-    exact mk_of_finset }
+    exact mk_coe_finset }
 end
 
 theorem mk_union_add_mk_inter {α : Type u} {S T : set α} :
@@ -1437,7 +1437,7 @@ begin
   contrapose! h,
   calc # α = # (set.univ : set α) : mk_univ.symm
     ... ≤ # l.to_finset           : mk_le_mk_of_subset (λ x _, list.mem_to_finset.mpr (h x))
-    ... = l.to_finset.card        : cardinal.mk_of_finset
+    ... = l.to_finset.card        : cardinal.mk_coe_finset
     ... ≤ l.length                : cardinal.nat_cast_le.mpr (list.to_finset_card_le l),
 end
 

--- a/src/set_theory/cardinal/basic.lean
+++ b/src/set_theory/cardinal/basic.lean
@@ -824,7 +824,13 @@ by rw [←lift_nat_cast.{v} n, lift_inj]
 
 theorem lift_mk_fin (n : ℕ) : lift (#(fin n)) = n := by simp
 
-lemma mk_finset {α : Type u} {s : finset α} : #s = ↑(finset.card s) := by simp
+lemma mk_of_finset {α : Type u} {s : finset α} : #s = ↑(finset.card s) := by simp
+
+@[simp] lemma mk_finset_of_fintype [fintype α] : #(finset α) = 2 ^ #α :=
+begin
+  rw ←mk_set,
+  apply equiv.cardinal_eq,
+end
 
 theorem card_le_of_finset {α} (s : finset α) : (s.card : cardinal) ≤ #α :=
 begin
@@ -1307,7 +1313,7 @@ begin
     lift s to finset α using lt_aleph_0_iff_finite.1 (h.symm ▸ nat_lt_aleph_0 n),
     simpa using h },
   { rintro ⟨t, rfl, rfl⟩,
-    exact mk_finset }
+    exact mk_of_finset }
 end
 
 theorem mk_union_add_mk_inter {α : Type u} {S T : set α} :
@@ -1435,7 +1441,7 @@ begin
   contrapose! h,
   calc # α = # (set.univ : set α) : mk_univ.symm
     ... ≤ # l.to_finset           : mk_le_mk_of_subset (λ x _, list.mem_to_finset.mpr (h x))
-    ... = l.to_finset.card        : cardinal.mk_finset
+    ... = l.to_finset.card        : cardinal.mk_of_finset
     ... ≤ l.length                : cardinal.nat_cast_le.mpr (list.to_finset_card_le l),
 end
 

--- a/src/set_theory/cardinal/basic.lean
+++ b/src/set_theory/cardinal/basic.lean
@@ -826,8 +826,7 @@ theorem lift_mk_fin (n : ℕ) : lift (#(fin n)) = n := by simp
 
 lemma mk_of_finset {α : Type u} {s : finset α} : #s = ↑(finset.card s) := by simp
 
-lemma mk_finset_of_fintype [fintype α] : #(finset α) = 2 ^ℕ fintype.card α :=
-by simp
+lemma mk_finset_of_fintype [fintype α] : #(finset α) = 2 ^ℕ fintype.card α := by simp
 
 theorem card_le_of_finset {α} (s : finset α) : (s.card : cardinal) ≤ #α :=
 begin

--- a/src/set_theory/cardinal/basic.lean
+++ b/src/set_theory/cardinal/basic.lean
@@ -826,8 +826,8 @@ theorem lift_mk_fin (n : ℕ) : lift (#(fin n)) = n := by simp
 
 lemma mk_of_finset {α : Type u} {s : finset α} : #s = ↑(finset.card s) := by simp
 
-@[simp] lemma mk_finset_of_fintype [fintype α] : #(finset α) = ↑(2 ^ (fintype.card α)) :=
-by simpa using fintype.equiv_set_on_fintype.cardinal_eq
+lemma mk_finset_of_fintype [fintype α] : #(finset α) = 2 ^ℕ fintype.card α :=
+by simp
 
 theorem card_le_of_finset {α} (s : finset α) : (s.card : cardinal) ≤ #α :=
 begin

--- a/src/set_theory/cardinal/basic.lean
+++ b/src/set_theory/cardinal/basic.lean
@@ -826,8 +826,8 @@ theorem lift_mk_fin (n : ℕ) : lift (#(fin n)) = n := by simp
 
 lemma mk_of_finset {α : Type u} {s : finset α} : #s = ↑(finset.card s) := by simp
 
-@[simp] lemma mk_finset_of_fintype [fintype α] : #(finset α) = 2 ^ #α :=
-by { rw ←mk_set, exact fintype.equiv_set_on_fintype.cardinal_eq }
+@[simp] lemma mk_finset_of_fintype [fintype α] : #(finset α) = ↑(2 ^ (fintype.card α)) :=
+by simpa using fintype.equiv_set_on_fintype.cardinal_eq
 
 theorem card_le_of_finset {α} (s : finset α) : (s.card : cardinal) ≤ #α :=
 begin

--- a/src/set_theory/cardinal/ordinal.lean
+++ b/src/set_theory/cardinal/ordinal.lean
@@ -685,7 +685,7 @@ begin
     apply le_max_right }
 end
 
-theorem mk_finset_eq_mk (α : Type u) [infinite α] : #(finset α) = #α :=
+@[simp] theorem mk_finset_of_infinite (α : Type u) [infinite α] : #(finset α) = #α :=
 eq.symm $ le_antisymm (mk_le_of_injective (λ x y, finset.singleton_inj.1)) $
 calc #(finset α) ≤ #(list α) : mk_le_of_surjective list.to_finset_surjective
 ... = #α : mk_list_eq_mk α
@@ -757,8 +757,8 @@ begin
   classical,
   lift s to finset α using finite.of_fintype s,
   lift t to finset β using finite.of_fintype t,
-  simp only [finset.coe_sort_coe, mk_finset, lift_nat_cast, nat.cast_inj] at h2,
-  simp only [← finset.coe_compl, finset.coe_sort_coe, mk_finset, finset.card_compl,
+  simp only [finset.coe_sort_coe, mk_of_finset, lift_nat_cast, nat.cast_inj] at h2,
+  simp only [← finset.coe_compl, finset.coe_sort_coe, mk_of_finset, finset.card_compl,
     lift_nat_cast, nat.cast_inj, h1, h2]
 end
 

--- a/src/set_theory/cardinal/ordinal.lean
+++ b/src/set_theory/cardinal/ordinal.lean
@@ -757,8 +757,8 @@ begin
   classical,
   lift s to finset α using finite.of_fintype s,
   lift t to finset β using finite.of_fintype t,
-  simp only [finset.coe_sort_coe, mk_of_finset, lift_nat_cast, nat.cast_inj] at h2,
-  simp only [← finset.coe_compl, finset.coe_sort_coe, mk_of_finset, finset.card_compl,
+  simp only [finset.coe_sort_coe, mk_coe_finset, lift_nat_cast, nat.cast_inj] at h2,
+  simp only [← finset.coe_compl, finset.coe_sort_coe, mk_coe_finset, finset.card_compl,
     lift_nat_cast, nat.cast_inj, h1, h2]
 end
 


### PR DESCRIPTION
This PR does the following:
- prove `mk_finset_of_fintype : #(finset α) = 2 ^ℕ fintype.card α` for `fintype α`
- rename `mk_finset_eq_mk` to `mk_finset_of_infinite` to match the former
- rename `mk_finset` to `mk_coe_finset` to avoid confusion with these two lemmas

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
