### PR TITLE
[Merged by Bors] - refactor(data/set/basic): Adds `inter_nonempty` to match `union_nonempty`.

### DIFF
--- a/src/data/set/basic.lean
+++ b/src/data/set/basic.lean
@@ -338,11 +338,13 @@ lemma nonempty.left (h : (s ∩ t).nonempty) : s.nonempty := h.imp $ λ _, and.l
 
 lemma nonempty.right (h : (s ∩ t).nonempty) : t.nonempty := h.imp $ λ _, and.right
 
-lemma nonempty_inter_iff_exists_right : (s ∩ t).nonempty ↔ ∃ x : t, ↑x ∈ s :=
-⟨λ ⟨x, xs, xt⟩, ⟨⟨x, xt⟩, xs⟩, λ ⟨⟨x, xt⟩, xs⟩, ⟨x, xs, xt⟩⟩
+@[simp] lemma inter_nonempty : (s ∩ t).nonempty ↔ ∃ x, x ∈ s ∧ x ∈ t := iff.rfl
 
-lemma nonempty_inter_iff_exists_left : (s ∩ t).nonempty ↔ ∃ x : s, ↑x ∈ t :=
-⟨λ ⟨x, xs, xt⟩, ⟨⟨x, xs⟩, xt⟩, λ ⟨⟨x, xt⟩, xs⟩, ⟨x, xt, xs⟩⟩
+lemma inter_nonempty_iff_exists_left : (s ∩ t).nonempty ↔ ∃ x ∈ s, x ∈ t :=
+by simp_rw [inter_nonempty, exists_prop]
+
+lemma inter_nonempty_iff_exists_right : (s ∩ t).nonempty ↔ ∃ x ∈ t, x ∈ s :=
+by simp_rw [inter_nonempty, exists_prop, and_comm]
 
 lemma nonempty_iff_univ_nonempty : nonempty α ↔ (univ : set α).nonempty :=
 ⟨λ ⟨x⟩, ⟨x, trivial⟩, λ ⟨x, _⟩, ⟨x⟩⟩

--- a/src/data/set/basic.lean
+++ b/src/data/set/basic.lean
@@ -316,27 +316,26 @@ protected noncomputable def nonempty.some (h : s.nonempty) : α := classical.som
 
 protected lemma nonempty.some_mem (h : s.nonempty) : h.some ∈ s := classical.some_spec h
 
-lemma nonempty.mono (ht : s ⊆ t) (hs : s.nonempty) : t.nonempty := hs.imp ht
+lemma nonempty.mono (ht : s ⊆ t) : s.nonempty → t.nonempty := λ ⟨_, h⟩, ⟨_, ht h⟩
 
 lemma nonempty_of_not_subset (h : ¬s ⊆ t) : (s \ t).nonempty :=
-let ⟨x, xs, xt⟩ := not_subset.1 h in ⟨x, xs, xt⟩
+let ⟨_, xs, xt⟩ := not_subset.1 h in ⟨_, xs, xt⟩
 
-lemma nonempty_of_ssubset (ht : s ⊂ t) : (t \ s).nonempty :=
-nonempty_of_not_subset ht.2
+lemma nonempty_of_ssubset (ht : s ⊂ t) : (t \ s).nonempty := nonempty_of_not_subset ht.2
 
-lemma nonempty.of_diff (h : (s \ t).nonempty) : s.nonempty := h.imp $ λ _, and.left
+lemma nonempty.of_diff : (s \ t).nonempty → s.nonempty := λ ⟨_, h⟩, ⟨_, h.1⟩
 
 lemma nonempty_of_ssubset' (ht : s ⊂ t) : t.nonempty := (nonempty_of_ssubset ht).of_diff
 
-lemma nonempty.inl (hs : s.nonempty) : (s ∪ t).nonempty := hs.imp $ λ _, or.inl
+lemma nonempty.inl : s.nonempty → (s ∪ t).nonempty := λ ⟨_, h⟩, ⟨_, or.inl h⟩
 
-lemma nonempty.inr (ht : t.nonempty) : (s ∪ t).nonempty := ht.imp $ λ _, or.inr
+lemma nonempty.inr : t.nonempty → (s ∪ t).nonempty := λ ⟨_, h⟩, ⟨_, or.inr h⟩
 
 @[simp] lemma union_nonempty : (s ∪ t).nonempty ↔ s.nonempty ∨ t.nonempty := exists_or_distrib
 
-lemma nonempty.left (h : (s ∩ t).nonempty) : s.nonempty := h.imp $ λ _, and.left
+lemma nonempty.left : (s ∩ t).nonempty → s.nonempty := λ ⟨_, h, _⟩, ⟨_, h⟩
 
-lemma nonempty.right (h : (s ∩ t).nonempty) : t.nonempty := h.imp $ λ _, and.right
+lemma nonempty.right : (s ∩ t).nonempty → t.nonempty := λ ⟨_, _, h⟩, ⟨_, h⟩
 
 @[simp] lemma inter_nonempty : (s ∩ t).nonempty ↔ ∃ x, x ∈ s ∧ x ∈ t := iff.rfl
 
@@ -349,18 +348,17 @@ by simp_rw [inter_nonempty, exists_prop, and_comm]
 lemma nonempty_iff_univ_nonempty : nonempty α ↔ (univ : set α).nonempty :=
 ⟨λ ⟨x⟩, ⟨x, trivial⟩, λ ⟨x, _⟩, ⟨x⟩⟩
 
-@[simp] lemma univ_nonempty : ∀ [h : nonempty α], (univ : set α).nonempty
-| ⟨x⟩ := ⟨x, trivial⟩
+lemma nonempty_of_nonempty_subtype [nonempty s] : s.nonempty :=
+nonempty_subtype.mp ‹_›
 
-lemma nonempty.to_subtype (h : s.nonempty) : nonempty s :=
-nonempty_subtype.2 h
+@[simp] lemma univ_nonempty [nonempty α] : (univ : set α).nonempty :=
+nonempty_iff_univ_nonempty.mp (by assumption)
+
+lemma nonempty.to_subtype (h : s.nonempty) : nonempty s := nonempty_subtype.2 h
 
 instance [nonempty α] : nonempty (set.univ : set α) := set.univ_nonempty.to_subtype
 
 @[simp] lemma nonempty_insert (a : α) (s : set α) : (insert a s).nonempty := ⟨a, or.inl rfl⟩
-
-lemma nonempty_of_nonempty_subtype [nonempty s] : s.nonempty :=
-nonempty_subtype.mp ‹_›
 
 /-! ### Lemmas about the empty set -/
 

--- a/src/data/set/basic.lean
+++ b/src/data/set/basic.lean
@@ -316,26 +316,27 @@ protected noncomputable def nonempty.some (h : s.nonempty) : α := classical.som
 
 protected lemma nonempty.some_mem (h : s.nonempty) : h.some ∈ s := classical.some_spec h
 
-lemma nonempty.mono (ht : s ⊆ t) : s.nonempty → t.nonempty := λ ⟨_, h⟩, ⟨_, ht h⟩
+lemma nonempty.mono (ht : s ⊆ t) (hs : s.nonempty) : t.nonempty := hs.imp ht
 
 lemma nonempty_of_not_subset (h : ¬s ⊆ t) : (s \ t).nonempty :=
-let ⟨_, xs, xt⟩ := not_subset.1 h in ⟨_, xs, xt⟩
+let ⟨x, xs, xt⟩ := not_subset.1 h in ⟨x, xs, xt⟩
 
-lemma nonempty_of_ssubset (ht : s ⊂ t) : (t \ s).nonempty := nonempty_of_not_subset ht.2
+lemma nonempty_of_ssubset (ht : s ⊂ t) : (t \ s).nonempty :=
+nonempty_of_not_subset ht.2
 
-lemma nonempty.of_diff : (s \ t).nonempty → s.nonempty := λ ⟨_, h⟩, ⟨_, h.1⟩
+lemma nonempty.of_diff (h : (s \ t).nonempty) : s.nonempty := h.imp $ λ _, and.left
 
 lemma nonempty_of_ssubset' (ht : s ⊂ t) : t.nonempty := (nonempty_of_ssubset ht).of_diff
 
-lemma nonempty.inl : s.nonempty → (s ∪ t).nonempty := λ ⟨_, h⟩, ⟨_, or.inl h⟩
+lemma nonempty.inl (hs : s.nonempty) : (s ∪ t).nonempty := hs.imp $ λ _, or.inl
 
-lemma nonempty.inr : t.nonempty → (s ∪ t).nonempty := λ ⟨_, h⟩, ⟨_, or.inr h⟩
+lemma nonempty.inr (ht : t.nonempty) : (s ∪ t).nonempty := ht.imp $ λ _, or.inr
 
 @[simp] lemma union_nonempty : (s ∪ t).nonempty ↔ s.nonempty ∨ t.nonempty := exists_or_distrib
 
-lemma nonempty.left : (s ∩ t).nonempty → s.nonempty := λ ⟨_, h, _⟩, ⟨_, h⟩
+lemma nonempty.left (h : (s ∩ t).nonempty) : s.nonempty := h.imp $ λ _, and.left
 
-lemma nonempty.right : (s ∩ t).nonempty → t.nonempty := λ ⟨_, _, h⟩, ⟨_, h⟩
+lemma nonempty.right (h : (s ∩ t).nonempty) : t.nonempty := h.imp $ λ _, and.right
 
 @[simp] lemma inter_nonempty : (s ∩ t).nonempty ↔ ∃ x, x ∈ s ∧ x ∈ t := iff.rfl
 
@@ -348,17 +349,18 @@ by simp_rw [inter_nonempty, exists_prop, and_comm]
 lemma nonempty_iff_univ_nonempty : nonempty α ↔ (univ : set α).nonempty :=
 ⟨λ ⟨x⟩, ⟨x, trivial⟩, λ ⟨x, _⟩, ⟨x⟩⟩
 
-lemma nonempty_of_nonempty_subtype [nonempty s] : s.nonempty :=
-nonempty_subtype.mp ‹_›
+@[simp] lemma univ_nonempty : ∀ [h : nonempty α], (univ : set α).nonempty
+| ⟨x⟩ := ⟨x, trivial⟩
 
-@[simp] lemma univ_nonempty [nonempty α] : (univ : set α).nonempty :=
-nonempty_iff_univ_nonempty.mp (by assumption)
-
-lemma nonempty.to_subtype (h : s.nonempty) : nonempty s := nonempty_subtype.2 h
+lemma nonempty.to_subtype (h : s.nonempty) : nonempty s :=
+nonempty_subtype.2 h
 
 instance [nonempty α] : nonempty (set.univ : set α) := set.univ_nonempty.to_subtype
 
 @[simp] lemma nonempty_insert (a : α) (s : set α) : (insert a s).nonempty := ⟨a, or.inl rfl⟩
+
+lemma nonempty_of_nonempty_subtype [nonempty s] : s.nonempty :=
+nonempty_subtype.mp ‹_›
 
 /-! ### Lemmas about the empty set -/
 

--- a/src/data/set/basic.lean
+++ b/src/data/set/basic.lean
@@ -338,7 +338,7 @@ lemma nonempty.left (h : (s ∩ t).nonempty) : s.nonempty := h.imp $ λ _, and.l
 
 lemma nonempty.right (h : (s ∩ t).nonempty) : t.nonempty := h.imp $ λ _, and.right
 
-@[simp] lemma inter_nonempty : (s ∩ t).nonempty ↔ ∃ x, x ∈ s ∧ x ∈ t := iff.rfl
+lemma inter_nonempty : (s ∩ t).nonempty ↔ ∃ x, x ∈ s ∧ x ∈ t := iff.rfl
 
 lemma inter_nonempty_iff_exists_left : (s ∩ t).nonempty ↔ ∃ x ∈ s, x ∈ t :=
 by simp_rw [inter_nonempty, exists_prop]

--- a/src/topology/basic.lean
+++ b/src/topology/basic.lean
@@ -1018,13 +1018,13 @@ mem_closure_iff_cluster_pt.trans cluster_pt_principal_iff
 
 theorem mem_closure_iff_nhds' {s : set α} {a : α} :
   a ∈ closure s ↔ ∀ t ∈ 𝓝 a, ∃ y : s, ↑y ∈ t :=
-by simp only [  mem_closure_iff_nhds, set.inter_nonempty_iff_exists_right,
-                set_coe.exists, subtype.coe_mk]
+by simp only [mem_closure_iff_nhds, set.inter_nonempty_iff_exists_right,
+              set_coe.exists, subtype.coe_mk]
 
 theorem mem_closure_iff_comap_ne_bot {A : set α} {x : α} :
   x ∈ closure A ↔ ne_bot (comap (coe : A → α) (𝓝 x)) :=
-by simp_rw [  mem_closure_iff_nhds, comap_ne_bot_iff, set.inter_nonempty_iff_exists_right,
-              set_coe.exists, subtype.coe_mk]
+by simp_rw [mem_closure_iff_nhds, comap_ne_bot_iff, set.inter_nonempty_iff_exists_right,
+            set_coe.exists, subtype.coe_mk]
 
 theorem mem_closure_iff_nhds_basis' {a : α} {p : ι → Prop} {s : ι → set α} (h : (𝓝 a).has_basis p s)
   {t : set α} :

--- a/src/topology/basic.lean
+++ b/src/topology/basic.lean
@@ -1018,11 +1018,13 @@ mem_closure_iff_cluster_pt.trans cluster_pt_principal_iff
 
 theorem mem_closure_iff_nhds' {s : set α} {a : α} :
   a ∈ closure s ↔ ∀ t ∈ 𝓝 a, ∃ y : s, ↑y ∈ t :=
-by simp only [mem_closure_iff_nhds, set.nonempty_inter_iff_exists_right]
+by simp only [  mem_closure_iff_nhds, set.inter_nonempty_iff_exists_right,
+                set_coe.exists, subtype.coe_mk]
 
 theorem mem_closure_iff_comap_ne_bot {A : set α} {x : α} :
   x ∈ closure A ↔ ne_bot (comap (coe : A → α) (𝓝 x)) :=
-by simp_rw [mem_closure_iff_nhds, comap_ne_bot_iff, set.nonempty_inter_iff_exists_right]
+by simp_rw [  mem_closure_iff_nhds, comap_ne_bot_iff, set.inter_nonempty_iff_exists_right,
+              set_coe.exists, subtype.coe_mk]
 
 theorem mem_closure_iff_nhds_basis' {a : α} {p : ι → Prop} {s : ι → set α} (h : (𝓝 a).has_basis p s)
   {t : set α} :


### PR DESCRIPTION
Also changes existing `inter_nonempty` lemmas to match.

---
