### PR TITLE
[Merged by Bors] - feat(algebra/group/units): add decidability instance for `is_unit`

### DIFF
--- a/src/algebra/group/units.lean
+++ b/src/algebra/group/units.lean
@@ -415,6 +415,10 @@ begin
   simp [h.unit_spec]
 end
 
+/-- `is_unit x` is decidable if we can decide if `x` comes from `Mˣ`. -/
+instance {M : Type*} [monoid M] (x : M) : Π [decidable (∃ u : Mˣ, ↑u = x)], decidable (is_unit x) :=
+id
+
 section monoid
 variables [monoid M] {a b c : M}
 

--- a/src/algebra/group/units.lean
+++ b/src/algebra/group/units.lean
@@ -416,8 +416,7 @@ begin
 end
 
 /-- `is_unit x` is decidable if we can decide if `x` comes from `Mˣ`. -/
-instance [monoid M] (x : M) : Π [decidable (∃ u : Mˣ, ↑u = x)], decidable (is_unit x) :=
-id
+instance [monoid M] (x : M) [h : decidable (∃ u : Mˣ, ↑u = x)] : decidable (is_unit x) := h
 
 section monoid
 variables [monoid M] {a b c : M}

--- a/src/algebra/group/units.lean
+++ b/src/algebra/group/units.lean
@@ -416,7 +416,7 @@ begin
 end
 
 /-- `is_unit x` is decidable if we can decide if `x` comes from `Mˣ`. -/
-instance {M : Type*} [monoid M] (x : M) : Π [decidable (∃ u : Mˣ, ↑u = x)], decidable (is_unit x) :=
+instance [monoid M] (x : M) : Π [decidable (∃ u : Mˣ, ↑u = x)], decidable (is_unit x) :=
 id
 
 section monoid


### PR DESCRIPTION
This adds a decidability instance for the `is_unit` predicate. See [here](https://leanprover.zulipchat.com/#narrow/stream/217875-Is-there-code-for-X.3F/topic/Decidability.20of.20.60is_unit.60.20on.20finite.20rings/near/286543269).

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
