### PR TITLE
[Merged by Bors] - fix(meta/expr): remove `has_reflect.has_to_pexpr`

### DIFF
--- a/src/meta/expr.lean
+++ b/src/meta/expr.lean
@@ -21,9 +21,6 @@ open tactic
 
 attribute [derive has_reflect, derive decidable_eq] binder_info congr_arg_kind
 
-@[priority 100] meta instance has_reflect.has_to_pexpr {α} [has_reflect α] : has_to_pexpr α :=
-⟨λ b, pexpr.of_expr (reflect b)⟩
-
 namespace binder_info
 
 /-! ### Declarations about `binder_info` -/

--- a/src/tactic/core.lean
+++ b/src/tactic/core.lean
@@ -2438,7 +2438,7 @@ then do
   user_attr_nm ← get_user_attribute_name attr_name,
   user_attr_const ← mk_const user_attr_nm,
   tac ← eval_pexpr (tactic unit)
-    ``(user_attribute.set %%user_attr_const %%c_name default %%persistent) <|>
+    ``(user_attribute.set %%user_attr_const %%`(c_name) default %%`(persistent)) <|>
     fail! ("Cannot set attribute @[{attr_name}].\n" ++
       "The corresponding user attribute {user_attr_nm} " ++
       "has a parameter without a default value.\n" ++

--- a/src/tactic/transform_decl.lean
+++ b/src/tactic/transform_decl.lean
@@ -26,8 +26,8 @@ tactic unit := do
       then do
         user_attr_const ← (get_user_attribute_name attr_name >>= mk_const),
         tac ← eval_pexpr (tactic unit)
-        ``(user_attribute.get_param_untyped %%user_attr_const %%src >>=
-          λ x, user_attribute.set_untyped %%user_attr_const %%tgt x %%p %%prio),
+        ``(user_attribute.get_param_untyped %%user_attr_const %%`(src) >>=
+          λ x, user_attribute.set_untyped %%user_attr_const %%`(tgt) x %%`(p) %%`(prio)),
         tac
       else fail msg
 

--- a/test/norm_swap.lean
+++ b/test/norm_swap.lean
@@ -20,12 +20,12 @@ if `norm_swap.eval` is behaving properly.
 example : true := by do
   let l : list ℕ := [0, 1, 2, 3],
   let l' : list ((ℕ × ℕ) × ℕ) := (do a ← l, b ← l, c ← l, pure ((a, b), c)),
-  (lhs : list expr) ← mmap (λ (tup : (ℕ × ℕ) × ℕ),
-    to_expr ``(equiv.swap %%tup.fst.fst %%tup.fst.snd %%tup.snd)) l',
-  (rhs : list expr) ← mmap (λ (tup : (ℕ × ℕ) × ℕ),
-    if tup.snd = tup.fst.fst then to_expr ``(%%tup.fst.snd)
-    else if tup.snd = tup.fst.snd then to_expr ``(%%tup.fst.fst)
-    else to_expr ``(%%tup.snd)) l',
+  let lhs : list expr := l'.map (λ (tup : (ℕ × ℕ) × ℕ),
+    `(equiv.swap tup.fst.fst tup.fst.snd tup.snd).to_expr),
+  let rhs : list expr := l'.map (λ (tup : (ℕ × ℕ) × ℕ),
+    if tup.snd = tup.fst.fst then `(tup.fst.snd)
+    else if tup.snd = tup.fst.snd then `(tup.fst.fst)
+    else `(tup.snd)),
   let eqs : list expr := list.zip_with (λ L R, `(@eq.{1} ℕ %%L %%R)) lhs rhs,
   g ← get_goals,
   gls ← mmap mk_meta_var eqs,


### PR DESCRIPTION
This instance (introduced in #3477) forms a diamond with the builtin `pexpr.has_to_pexpr`:
```lean
import meta.expr

#eval show tactic unit, from do
  let i1 : has_to_pexpr pexpr := pexpr.has_to_pexpr,
  let i2 : has_to_pexpr pexpr := has_reflect.has_to_pexpr,
  let e := ``(1),
  let p1 := @to_pexpr _ i1 e,
  let p2 := @to_pexpr _ i2 e,
  guard (p1 = p2) -- fails
```

The consequence is that in cases where `bar` is not a `pexpr` or `expr` but a value to be reflected, ``` ``(foo %%bar) ``` now has to be written ``` ``(foo %%`(bar)) ```; a spelling already used in various existing files.

[Zulip thread](https://leanprover.zulipchat.com/#narrow/stream/239415-metaprogramming-.2F-tactics/topic/Instance.20diamonds.20in.20has_to_pexpr/near/287083928)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
