### PR TITLE
[Merged by Bors] - feat(data/int/basic): add a better `has_reflect int` instance

### DIFF
--- a/src/data/int/basic.lean
+++ b/src/data/int/basic.lean
@@ -110,9 +110,8 @@ section
 -- the expression we use here is equivalent.
 local attribute [semireducible] reflected
 meta instance reflect : has_reflect ℤ :=
-int.mk_numeral `(by apply_instance : has_zero ℤ)
-  `(by apply_instance : has_one ℤ) `(by apply_instance : has_add ℤ)
-  `(by apply_instance : has_neg ℤ) `(by apply_instance : has_div ℤ)
+int.mk_numeral `(ℤ) `(by apply_instance : has_zero ℤ) `(by apply_instance : has_one ℤ)
+                    `(by apply_instance : has_add ℤ) `(by apply_instance : has_neg ℤ)
 end
 
 attribute [simp] int.coe_nat_add int.coe_nat_mul int.coe_nat_zero int.coe_nat_one int.coe_nat_succ

--- a/src/data/int/basic.lean
+++ b/src/data/int/basic.lean
@@ -103,7 +103,17 @@ by rw [abs_eq_nat_abs, sign_mul_nat_abs]
 @[simp] lemma default_eq_zero : default = (0 : ℤ) := rfl
 
 meta instance : has_to_format ℤ := ⟨λ z, to_string z⟩
-meta instance : has_reflect ℤ := by tactic.mk_has_reflect_instance
+
+section
+-- Note that here we are disabling the "safety" of reflected, to allow us to reuse `int.mk_numeral`.
+-- The usual way to provide the required `reflected` instance would be via rewriting to prove that
+-- the expression we use here is equivalent.
+local attribute [semireducible] reflected
+meta instance reflect : has_reflect ℤ :=
+int.mk_numeral `(by apply_instance : has_zero ℤ)
+  `(by apply_instance : has_one ℤ) `(by apply_instance : has_add ℤ)
+  `(by apply_instance : has_neg ℤ) `(by apply_instance : has_div ℤ)
+end
 
 attribute [simp] int.coe_nat_add int.coe_nat_mul int.coe_nat_zero int.coe_nat_one int.coe_nat_succ
 attribute [simp] int.of_nat_eq_coe int.bodd

--- a/src/data/rat/meta_defs.lean
+++ b/src/data/rat/meta_defs.lean
@@ -42,15 +42,17 @@ meta def rat.mk_numeral (type has_zero has_one has_add has_neg has_div : expr) :
     let dene := denom.mk_numeral type has_zero has_one has_add in
     `(@has_div.div.{0} %%type %%has_div %%nume %%dene)
 
-/-- `rat.reflect q` represents the rational number `q` as a numeral expression of type `ℚ`. -/
-protected meta def rat.reflect : ℚ → expr :=
-rat.mk_numeral `(ℚ) `((by apply_instance : has_zero ℚ))
-         `((by apply_instance : has_one ℚ))`((by apply_instance : has_add ℚ))
-         `((by apply_instance : has_neg ℚ)) `(by apply_instance : has_div ℚ)
 
 section
+-- Note that here we are disabling the "safety" of reflected, to allow us to reuse `rat.mk_numeral`.
+-- The usual way to provide the required `reflected` instance would be via rewriting to prove that
+-- the expression we use here is equivalent.
 local attribute [semireducible] reflected
-meta instance : has_reflect ℚ := rat.reflect
+/-- `rat.reflect q` represents the rational number `q` as a numeral expression of type `ℚ`. -/
+meta instance rat.reflect : has_reflect ℚ :=
+rat.mk_numeral `(ℚ) `(by apply_instance : has_zero ℚ)
+  `(by apply_instance : has_one ℚ) `(by apply_instance : has_add ℚ)
+  `(by apply_instance : has_neg ℚ) `(by apply_instance : has_div ℚ)
 end
 
 /--

--- a/src/number_theory/lucas_lehmer.lean
+++ b/src/number_theory/lucas_lehmer.lean
@@ -445,9 +445,6 @@ example : (mersenne 5).prime := lucas_lehmer_sufficiency 5 (by norm_num) dec_tri
 namespace lucas_lehmer
 open tactic
 
-meta instance nat_pexpr : has_to_pexpr ℕ := ⟨pexpr.of_expr ∘ λ n, reflect n⟩
-meta instance int_pexpr : has_to_pexpr ℤ := ⟨pexpr.of_expr ∘ λ n, reflect n⟩
-
 lemma s_mod_succ {p a i b c}
   (h1 : (2^p - 1 : ℤ) = a)
   (h2 : s_mod p i = b)
@@ -466,16 +463,16 @@ do `(lucas_lehmer_test %%p) ← target,
    p ← eval_expr ℕ p,
    -- Calculate the candidate Mersenne prime
    let M : ℤ := 2^p - 1,
-   t ← to_expr ``(2^%%p - 1 = %%M),
-   v ← to_expr ``(by norm_num : 2^%%p - 1 = %%M),
+   t ← to_expr ``(2^%%`(p) - 1 = %%`(M)),
+   v ← to_expr ``(by norm_num : 2^%%`(p) - 1 = %%`(M)),
    w ← assertv `w t v,
    -- Unfortunately this creates something like `w : 2^5 - 1 = int.of_nat 31`.
    -- We could make a better `has_to_pexpr ℤ` instance, or just:
    `[simp only [int.coe_nat_zero, int.coe_nat_succ,
        int.of_nat_eq_coe, zero_add, int.coe_nat_bit1] at w],
    -- base case
-   t ← to_expr ``(s_mod %%p 0 = 4),
-   v ← to_expr ``(by norm_num [lucas_lehmer.s_mod] : s_mod %%p 0 = 4),
+   t ← to_expr ``(s_mod %%`(p) 0 = 4),
+   v ← to_expr ``(by norm_num [lucas_lehmer.s_mod] : s_mod %%`(p) 0 = 4),
    h ← assertv `h t v,
    -- step case, repeated p-2 times
    iterate_exactly (p-2) `[replace h := lucas_lehmer.s_mod_succ w h (by { norm_num, refl })],

--- a/src/number_theory/lucas_lehmer.lean
+++ b/src/number_theory/lucas_lehmer.lean
@@ -466,8 +466,8 @@ do `(lucas_lehmer_test %%p) ← target,
    t ← to_expr ``(2^%%`(p) - 1 = %%`(M)),
    v ← to_expr ``(by norm_num : 2^%%`(p) - 1 = %%`(M)),
    w ← assertv `w t v,
-   -- Unfortunately this creates something like `w : 2^5 - 1 = int.of_nat 31`.
-   -- We could make a better `has_to_pexpr ℤ` instance, or just:
+   -- This used to creates something like `w : 2^5 - 1 = int.of_nat 31`.
+   -- Do we still need this?
    `[simp only [int.coe_nat_zero, int.coe_nat_succ,
        int.of_nat_eq_coe, zero_add, int.coe_nat_bit1] at w],
    -- base case

--- a/src/number_theory/lucas_lehmer.lean
+++ b/src/number_theory/lucas_lehmer.lean
@@ -466,10 +466,6 @@ do `(lucas_lehmer_test %%p) ← target,
    t ← to_expr ``(2^%%`(p) - 1 = %%`(M)),
    v ← to_expr ``(by norm_num : 2^%%`(p) - 1 = %%`(M)),
    w ← assertv `w t v,
-   -- This used to creates something like `w : 2^5 - 1 = int.of_nat 31`.
-   -- Do we still need this?
-   `[simp only [int.coe_nat_zero, int.coe_nat_succ,
-       int.of_nat_eq_coe, zero_add, int.coe_nat_bit1] at w],
    -- base case
    t ← to_expr ``(s_mod %%`(p) 0 = 4),
    v ← to_expr ``(by norm_num [lucas_lehmer.s_mod] : s_mod %%`(p) 0 = 4),
@@ -496,7 +492,9 @@ is out of reach with the current implementation.
 
 There's still low hanging fruit available to do faster computations
 based on the formula
-  n ≡ (n % 2^p) + (n / 2^p) [MOD 2^p - 1]
+```
+n ≡ (n % 2^p) + (n / 2^p) [MOD 2^p - 1]
+```
 and the fact that `% 2^p` and `/ 2^p` can be very efficient on the binary representation.
 Someone should do this, too!
 -/

--- a/test/rat.lean
+++ b/test/rat.lean
@@ -9,4 +9,4 @@ attribute [instance] h
 
 run_cmd guard $ expr.eval_rat `(1/3 - 100/6 : α) = some (-49/3)
 
-run_cmd guard $ (expr.eval_rat ∘ rat.reflect) (-(5/3) : ℚ) = some (-5/3)
+run_cmd guard $ (expr.eval_rat $ rat.reflect (-(5/3) : ℚ)) = some (-5/3)


### PR DESCRIPTION
This closes a todo comment in `number_theory.lucas_lehmer`.

This also merges `rat.has_reflect` with `rat.reflect` to match `nat.reflect`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
-->
- [x] depends on: #14905

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
