### PR TITLE
[Merged by Bors] - feat(analysis/locally_convex/bounded): continuous linear image of bounded set is bounded

### DIFF
--- a/src/analysis/locally_convex/bounded.lean
+++ b/src/analysis/locally_convex/bounded.lean
@@ -32,6 +32,7 @@ von Neumann-bounded sets.
 
 variables {𝕜 E ι : Type*}
 
+open filter
 open_locale topological_space pointwise
 
 namespace bornology
@@ -92,6 +93,27 @@ lemma is_vonN_bounded.of_topological_space_le {t t' : topological_space E} (h : 
 λ V hV, hs $ (le_iff_nhds t t').mp h 0 hV
 
 end multiple_topologies
+
+section image
+
+variables {F : Type*} [normed_division_ring 𝕜] [add_comm_group E] [module 𝕜 E]
+  [add_comm_group F] [module 𝕜 F] [topological_space E] [topological_space F]
+
+/-- A continuous linear image of a bounded set is bounded. -/
+lemma is_vonN_bounded.image {s : set E} (hs : is_vonN_bounded 𝕜 s) (f : E →L[𝕜] F) :
+  is_vonN_bounded 𝕜 (f '' s) :=
+begin
+  have := f.continuous.tendsto 0,
+  rw map_zero at this,
+  intros V hV,
+  rcases hs (this hV) with ⟨r, hrpos, hr⟩,
+  refine ⟨r, hrpos, λ a ha, _⟩,
+  have : a ≠ 0 := norm_pos_iff.mp (hrpos.trans_le ha),
+  rw [set.image_subset_iff, continuous_linear_map.preimage_smul_set _ this.is_unit],
+  exact hr a ha
+end
+
+end image
 
 section normed_field
 

--- a/src/analysis/locally_convex/bounded.lean
+++ b/src/analysis/locally_convex/bounded.lean
@@ -103,10 +103,10 @@ variables {F : Type*} [normed_division_ring 𝕜] [add_comm_group E] [module �
 lemma is_vonN_bounded.image {s : set E} (hs : is_vonN_bounded 𝕜 s) (f : E →L[𝕜] F) :
   is_vonN_bounded 𝕜 (f '' s) :=
 begin
-  have := f.continuous.tendsto 0,
-  rw map_zero at this,
+  have f_tendsto_zero := f.continuous.tendsto 0,
+  rw map_zero at f_tendsto_zero,
   intros V hV,
-  rcases hs (this hV) with ⟨r, hrpos, hr⟩,
+  rcases hs (f_tendsto_zero hV) with ⟨r, hrpos, hr⟩,
   refine ⟨r, hrpos, λ a ha, _⟩,
   have : a ≠ 0 := norm_pos_iff.mp (hrpos.trans_le ha),
   rw [set.image_subset_iff, continuous_linear_map.preimage_smul_set _ this.is_unit],

--- a/src/analysis/locally_convex/bounded.lean
+++ b/src/analysis/locally_convex/bounded.lean
@@ -96,13 +96,14 @@ end multiple_topologies
 
 section image
 
-variables {F : Type*} [normed_division_ring 𝕜] [add_comm_group E] [module 𝕜 E]
-  [add_comm_group F] [module 𝕜 F] [topological_space E] [topological_space F]
+variables {𝕜₁ 𝕜₂ F : Type*} [normed_division_ring 𝕜₁] [normed_division_ring 𝕜₂]
+  [add_comm_group E] [module 𝕜₁ E] [add_comm_group F] [module 𝕜₂ F]
+  [topological_space E] [topological_space F]
 
 /-- A continuous linear image of a bounded set is bounded. -/
-lemma is_vonN_bounded.image {σ : 𝕜 →+* 𝕜} [ring_hom_surjective σ] [ring_hom_isometric σ]
-  {s : set E} (hs : is_vonN_bounded 𝕜 s) (f : E →SL[σ] F) :
-  is_vonN_bounded 𝕜 (f '' s) :=
+lemma is_vonN_bounded.image {σ : 𝕜₁ →+* 𝕜₂} [ring_hom_surjective σ] [ring_hom_isometric σ]
+  {s : set E} (hs : is_vonN_bounded 𝕜₁ s) (f : E →SL[σ] F) :
+  is_vonN_bounded 𝕜₂ (f '' s) :=
 begin
   let σ' := ring_equiv.of_bijective σ ⟨σ.injective, σ.is_surjective⟩,
   have σ_iso : isometry σ := σ.to_add_monoid_hom.isometry_of_norm (λ x, ring_hom_isometric.is_iso),

--- a/src/analysis/locally_convex/bounded.lean
+++ b/src/analysis/locally_convex/bounded.lean
@@ -100,17 +100,25 @@ variables {F : Type*} [normed_division_ring 𝕜] [add_comm_group E] [module �
   [add_comm_group F] [module 𝕜 F] [topological_space E] [topological_space F]
 
 /-- A continuous linear image of a bounded set is bounded. -/
-lemma is_vonN_bounded.image {s : set E} (hs : is_vonN_bounded 𝕜 s) (f : E →L[𝕜] F) :
+lemma is_vonN_bounded.image {σ : 𝕜 →+* 𝕜} [ring_hom_surjective σ] [ring_hom_isometric σ]
+  {s : set E} (hs : is_vonN_bounded 𝕜 s) (f : E →SL[σ] F) :
   is_vonN_bounded 𝕜 (f '' s) :=
 begin
+  let σ' := ring_equiv.of_bijective σ ⟨σ.injective, σ.is_surjective⟩,
+  have σ_iso : isometry σ := σ.to_add_monoid_hom.isometry_of_norm (λ x, ring_hom_isometric.is_iso),
+  have σ'_symm_iso : isometry σ'.symm := σ_iso.right_inv σ'.right_inv,
   have f_tendsto_zero := f.continuous.tendsto 0,
   rw map_zero at f_tendsto_zero,
   intros V hV,
   rcases hs (f_tendsto_zero hV) with ⟨r, hrpos, hr⟩,
   refine ⟨r, hrpos, λ a ha, _⟩,
-  have : a ≠ 0 := norm_pos_iff.mp (hrpos.trans_le ha),
-  rw [set.image_subset_iff, continuous_linear_map.preimage_smul_set _ this.is_unit],
-  exact hr a ha
+  rw ← σ'.apply_symm_apply a,
+  have hanz : a ≠ 0 := norm_pos_iff.mp (hrpos.trans_le ha),
+  have : σ'.symm a ≠ 0 := (ring_hom.map_ne_zero σ'.symm.to_ring_hom).mpr hanz,
+  change _ ⊆ σ _ • _,
+  rw [set.image_subset_iff, f.preimage_smul_setₛₗ this.is_unit],
+  refine hr (σ'.symm a) _,
+  rwa σ'_symm_iso.norm_map_of_map_zero (map_zero _)
 end
 
 end image


### PR DESCRIPTION
This is needed to prove that the usual strong topology on continuous linear maps satisfies `has_continuous_smul`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
