### PR TITLE
chore(*): replace some `decidable (x ≠ 0)` by `decidable_eq R`

### DIFF
--- a/src/algebra/direct_sum/decomposition.lean
+++ b/src/algebra/direct_sum/decomposition.lean
@@ -119,7 +119,7 @@ map_sum (decompose_add_equiv ℳ) f s
   (decompose ℳ).symm (∑ i in s, f i) = ∑ i in s, (decompose ℳ).symm (f i) :=
 map_sum (decompose_add_equiv ℳ).symm f s
 
-lemma sum_support_decompose [Π i (x : ℳ i), decidable (x ≠ 0)] (r : M) :
+lemma sum_support_decompose [decidable_eq M] (r : M) :
   ∑ i in (decompose ℳ r).support, (decompose ℳ r i : M) = r :=
 begin
   conv_rhs { rw [←(decompose ℳ).symm_apply_apply r,

--- a/src/algebra/direct_sum/internal.lean
+++ b/src/algebra/direct_sum/internal.lean
@@ -101,7 +101,7 @@ direct_sum.to_semiring_of _ _ _ _ _
 
 lemma direct_sum.coe_mul_apply [add_monoid ι] [semiring R] [set_like σ R]
   [add_submonoid_class σ R] (A : ι → σ) [set_like.graded_monoid A]
-  [Π (i : ι) (x : A i), decidable (x ≠ 0)] (r r' : ⨁ i, A i) (i : ι) :
+  [decidable_eq R] (r r' : ⨁ i, A i) (i : ι) :
   ((r * r') i : R) =
     ∑ ij in finset.filter (λ ij : ι × ι, ij.1 + ij.2 = i) (r.support.product r'.support),
       r ij.1 * r' ij.2 :=

--- a/src/ring_theory/graded_algebra/basic.lean
+++ b/src/ring_theory/graded_algebra/basic.lean
@@ -119,11 +119,8 @@ lemma graded_algebra.proj_recompose (a : ⨁ i, 𝒜 i) (i : ι) :
   (decompose 𝒜).symm (of _ i (a i)) :=
 by rw [graded_algebra.proj_apply, decompose_symm_of, equiv.apply_symm_apply]
 
--- Without the `by exact` lean doesn't accept our `decidable` argument as it gets stuck unifying
--- under binders.
-lemma graded_algebra.mem_support_iff
-  [Π i (x : 𝒜 i), decidable (x ≠ 0)] (r : A) (i : ι) :
-  i ∈ (by exact decompose 𝒜 r : ⨁ i, 𝒜 i).support ↔ graded_algebra.proj 𝒜 i r ≠ 0 :=
+lemma graded_algebra.mem_support_iff [decidable_eq A] (r : A) (i : ι) :
+  i ∈ (decompose 𝒜 r).support ↔ graded_algebra.proj 𝒜 i r ≠ 0 :=
 dfinsupp.mem_support_iff.trans submodule.coe_eq_zero.not.symm
 
 end graded_algebra


### PR DESCRIPTION
This is about situations where we consider a family of subobjects `M` of some structure `R` and then write `∀ (i : ι) (x : M i), decidable (x ≠ 0)`, which causes various issues with type class synthesis because of the unnecessary quantifiers.  We can just write `decidable_eq R` instead.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
