### PR TITLE
[Merged by Bors] - chore(data/nat/factorization/basic): golf pow_succ_factorization_not_dvd, remove import

### DIFF
--- a/src/data/nat/factorization/basic.lean
+++ b/src/data/nat/factorization/basic.lean
@@ -6,7 +6,6 @@ Authors: Stuart Presnell
 import data.nat.prime
 import data.finsupp.multiset
 import algebra.big_operators.finsupp
-import tactic.linarith
 import tactic.interval_cases
 
 /-!
@@ -248,15 +247,6 @@ begin
   { simp [nat.factorization_eq_zero_of_non_prime n pp, hn] },
 end
 
-lemma pow_succ_factorization_not_dvd {n p : ℕ} (hn : n ≠ 0) (hp : p.prime) :
-  ¬ p ^ (n.factorization p + 1) ∣ n :=
-begin
-  intro h,
-  have := factors_sublist_of_dvd h hn,
-  rw [hp.factors_pow, ←le_count_iff_repeat_sublist, factors_count_eq] at this,
-  linarith
-end
-
 lemma factorization_le_iff_dvd {d n : ℕ} (hd : d ≠ 0) (hn : n ≠ 0) :
   d.factorization ≤ n.factorization ↔ d ∣ n :=
 begin
@@ -267,6 +257,14 @@ begin
     rw [←factorization_prod_pow_eq_self hn, ←factorization_prod_pow_eq_self hd,
         ←finsupp.prod_add_index' pow_zero pow_add, hK, add_tsub_cancel_of_le hdn] },
   { rintro ⟨c, rfl⟩, rw factorization_mul hd (right_ne_zero_of_mul hn), simp },
+end
+
+lemma pow_succ_factorization_not_dvd {n p : ℕ} (hn : n ≠ 0) (hp : p.prime) :
+  ¬ p ^ (n.factorization p + 1) ∣ n :=
+begin
+  intro h,
+  rw ←factorization_le_iff_dvd (pow_pos hp.pos _).ne' hn at h,
+  simpa [hp.factorization] using h p,
 end
 
 lemma factorization_le_factorization_mul_left {a b : ℕ} (hb : b ≠ 0) :


### PR DESCRIPTION
Move `pow_succ_factorization_not_dvd` below `factorization_le_iff_dvd` and use this to golf it, eliminating the need for `tactic.linarith`


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
