### PR TITLE
feat(set_theory/game/basic): review comparison API

### DIFF
--- a/src/set_theory/game/basic.lean
+++ b/src/set_theory/game/basic.lean
@@ -40,24 +40,24 @@ instance pgame.setoid : setoid pgame :=
   `x ≈ y ↔ x ≤ y ∧ y ≤ x`. -/
 abbreviation game := quotient pgame.setoid
 
-theorem pgame.equiv.quot_eq {x y : pgame} (h : x ≈ y) : ⟦x⟧ = ⟦y⟧ :=
+theorem pgame.equiv.game_eq {x y : pgame} (h : x ≈ y) : ⟦x⟧ = ⟦y⟧ :=
 quot.sound h
 
-theorem pgame.relabelling.quot_eq {x y : pgame} (h : x ≡r y) : ⟦x⟧ = ⟦y⟧ :=
-h.equiv.quot_eq
+theorem pgame.relabelling.game_eq {x y : pgame} (h : x ≡r y) : ⟦x⟧ = ⟦y⟧ :=
+h.equiv.game_eq
 
 namespace game
 
 instance : add_comm_group game :=
 { zero := ⟦0⟧,
-  neg := quot.lift (λ x, ⟦-x⟧) (λ x y h, ((@neg_equiv_neg_iff x y).2 h).quot_eq),
+  neg := quot.lift (λ x, ⟦-x⟧) (λ x y h, ((@neg_equiv_neg_iff x y).2 h).game_eq),
   add := quotient.lift₂ (λ x y : pgame, ⟦x + y⟧)
-    (λ x₁ y₁ x₂ y₂ hx hy, (pgame.add_congr hx hy).quot_eq),
-  add_zero := by { rintro ⟨x⟩, exact (add_zero_relabelling x).quot_eq },
-  zero_add := by { rintro ⟨x⟩, exact (zero_add_relabelling x).quot_eq },
-  add_assoc := by { rintros ⟨x⟩ ⟨y⟩ ⟨z⟩, exact (add_assoc_relabelling x y z).quot_eq },
-  add_left_neg := by { rintro ⟨x⟩, exact (add_left_neg_equiv x).quot_eq },
-  add_comm := by { rintros ⟨x⟩ ⟨y⟩, exact (add_comm_relabelling x y).quot_eq } }
+    (λ x₁ y₁ x₂ y₂ hx hy, (pgame.add_congr hx hy).game_eq),
+  add_zero := by { rintro ⟨x⟩, exact (add_zero_relabelling x).game_eq },
+  zero_add := by { rintro ⟨x⟩, exact (zero_add_relabelling x).game_eq },
+  add_assoc := by { rintros ⟨x⟩ ⟨y⟩ ⟨z⟩, exact (add_assoc_relabelling x y z).game_eq },
+  add_left_neg := by { rintro ⟨x⟩, exact (add_left_neg_equiv x).game_eq },
+  add_comm := by { rintros ⟨x⟩ ⟨y⟩, exact (add_comm_relabelling x y).game_eq } }
 
 instance : has_one game := ⟨⟦1⟧⟩
 instance : inhabited game := ⟨0⟩

--- a/src/set_theory/game/basic.lean
+++ b/src/set_theory/game/basic.lean
@@ -40,18 +40,24 @@ instance pgame.setoid : setoid pgame :=
   `x ≈ y ↔ x ≤ y ∧ y ≤ x`. -/
 abbreviation game := quotient pgame.setoid
 
+theorem pgame.equiv.quot_eq {x y : pgame} (h : x ≈ y) : ⟦x⟧ = ⟦y⟧ :=
+quot.sound h
+
+theorem pgame.relabelling.quot_eq {x y : pgame} (h : x ≡r y) : ⟦x⟧ = ⟦y⟧ :=
+h.equiv.quot_eq
+
 namespace game
 
 instance : add_comm_group game :=
 { zero := ⟦0⟧,
-  neg := quot.lift (λ x, ⟦-x⟧) (λ x y h, quot.sound ((@neg_equiv_neg_iff x y).2 h)),
+  neg := quot.lift (λ x, ⟦-x⟧) (λ x y h, ((@neg_equiv_neg_iff x y).2 h).quot_eq),
   add := quotient.lift₂ (λ x y : pgame, ⟦x + y⟧)
-    (λ x₁ y₁ x₂ y₂ hx hy, quot.sound (pgame.add_congr hx hy)),
-  add_zero := by { rintro ⟨x⟩, exact quot.sound (add_zero_equiv x) },
-  zero_add := by { rintro ⟨x⟩, exact quot.sound (zero_add_equiv x) },
-  add_assoc := by { rintros ⟨x⟩ ⟨y⟩ ⟨z⟩, exact quot.sound add_assoc_equiv },
-  add_left_neg := by { rintro ⟨x⟩, exact quot.sound (add_left_neg_equiv x) },
-  add_comm := by { rintros ⟨x⟩ ⟨y⟩, exact quot.sound add_comm_equiv } }
+    (λ x₁ y₁ x₂ y₂ hx hy, (pgame.add_congr hx hy).quot_eq),
+  add_zero := by { rintro ⟨x⟩, exact (add_zero_relabelling x).quot_eq },
+  zero_add := by { rintro ⟨x⟩, exact (zero_add_relabelling x).quot_eq },
+  add_assoc := by { rintros ⟨x⟩ ⟨y⟩ ⟨z⟩, exact (add_assoc_relabelling x y z).quot_eq },
+  add_left_neg := by { rintro ⟨x⟩, exact (add_left_neg_equiv x).quot_eq },
+  add_comm := by { rintros ⟨x⟩ ⟨y⟩, exact (add_comm_relabelling x y).quot_eq } }
 
 instance : has_one game := ⟨⟦1⟧⟩
 instance : inhabited game := ⟨0⟩
@@ -60,7 +66,7 @@ instance : partial_order game :=
 { le := quotient.lift₂ (λ x y, x ≤ y) (λ x₁ y₁ x₂ y₂ hx hy, propext (le_congr hx hy)),
   le_refl := by { rintro ⟨x⟩, exact le_refl x },
   le_trans := by { rintro ⟨x⟩ ⟨y⟩ ⟨z⟩, exact @le_trans _ _ x y z },
-  le_antisymm := by { rintro ⟨x⟩ ⟨y⟩ h₁ h₂, apply quot.sound, exact ⟨h₁, h₂⟩ } }
+  le_antisymm := by { rintro ⟨x⟩ ⟨y⟩ h₁ h₂, exact quot.sound ⟨h₁, h₂⟩ } }
 
 /-- The less or fuzzy relation on games.
 
@@ -133,16 +139,93 @@ namespace pgame
 
 @[simp] lemma quot_sub (a b : pgame) : ⟦a - b⟧ = ⟦a⟧ - ⟦b⟧ := rfl
 
+/-- The lemma `pgame.equiv_of_mk_equiv` written in terms of quotients. -/
 theorem quot_eq_of_mk_quot_eq {x y : pgame}
   (L : x.left_moves ≃ y.left_moves) (R : x.right_moves ≃ y.right_moves)
-  (hl : ∀ (i : x.left_moves), ⟦x.move_left i⟧ = ⟦y.move_left (L i)⟧)
-  (hr : ∀ (j : y.right_moves), ⟦x.move_right (R.symm j)⟧ = ⟦y.move_right j⟧) :
+  (hl : ∀ i, ⟦x.move_left i⟧ = ⟦y.move_left (L i)⟧)
+  (hr : ∀ j, ⟦x.move_right (R.symm j)⟧ = ⟦y.move_right j⟧) :
   ⟦x⟧ = ⟦y⟧ :=
-begin
-  simp only [quotient.eq] at hl hr,
-  apply quotient.sound,
-  apply equiv_of_mk_equiv L R hl hr,
-end
+by { simp_rw quotient.eq at hl hr ⊢, exact equiv_of_mk_equiv L R hl hr }
+
+/-! We prove various inequalities on pre-games taking advantage of the extra structure on games. -/
+
+theorem neg_le {x y : pgame} : -x ≤ y ↔ -y ≤ x :=
+@neg_le game _ _ _ _ ⟦x⟧ ⟦y⟧
+
+theorem neg_lt {x y : pgame} : -x < y ↔ -y < x :=
+@neg_lt game _ _ _ _ ⟦x⟧ ⟦y⟧
+
+theorem le_neg {x y : pgame} : x ≤ -y ↔ y ≤ -x :=
+@le_neg game _ _ _ _ ⟦x⟧ ⟦y⟧
+
+theorem lt_neg {x y : pgame} : x < -y ↔ y < -x :=
+@lt_neg game _ _ _ _ ⟦x⟧ ⟦y⟧
+
+theorem neg_lf {x y : pgame} : -x ⧏ y ↔ -y ⧏ x :=
+by rw [←pgame.not_le, ←pgame.not_le, not_iff_not, le_neg]
+
+theorem lf_neg {x y : pgame} : x ⧏ -y ↔ y ⧏ -x :=
+by rw [←pgame.not_le, ←pgame.not_le, not_iff_not, neg_le]
+
+theorem equiv_neg_iff_equiv_neg {x y : pgame} : x ≈ -y ↔ y ≈ -x :=
+by simp only [equiv, le_neg, neg_le, and_comm]
+
+theorem neg_equiv_iff_neg_equiv {x y : pgame} : -x ≈ y ↔ -y ≈ x :=
+by simp only [equiv, le_neg, neg_le, and_comm]
+
+theorem fuzzy_neg_iff_fuzzy_neg {x y : pgame} : x ∥ -y ↔ y ∥ -x :=
+by simp only [fuzzy, lf_neg, neg_lf, and_comm]
+
+theorem neg_fuzzy_iff_neg_fuzzy {x y : pgame} : -x ∥ y ↔ -y ∥ x :=
+by simp only [fuzzy, lf_neg, neg_lf, and_comm]
+
+@[simp] theorem neg_le_zero_iff {x : pgame} : -x ≤ 0 ↔ 0 ≤ x :=
+@neg_nonpos game _ _ _ ⟦x⟧
+
+@[simp] theorem zero_le_neg_iff {x : pgame} : 0 ≤ -x ↔ x ≤ 0 :=
+@neg_nonneg game _ _ _ ⟦x⟧
+
+@[simp] theorem neg_lt_zero_iff {x : pgame} : -x < 0 ↔ 0 < x :=
+@neg_lt_zero game _ _ _ ⟦x⟧
+
+@[simp] theorem zero_lt_neg_iff {x : pgame} : 0 < -x ↔ x < 0 :=
+@neg_pos game _ _ _ ⟦x⟧
+
+@[simp] theorem neg_lf_zero_iff {x : pgame} : -x ⧏ 0 ↔ 0 ⧏ x :=
+by rw [neg_lf, pgame.neg_zero]
+
+@[simp] theorem zero_lf_neg_iff {x : pgame} : 0 ⧏ -x ↔ x ⧏ 0 :=
+by rw [lf_neg, pgame.neg_zero]
+
+@[simp] theorem neg_equiv_zero {x : pgame} : -x ≈ 0 ↔ x ≈ 0 :=
+by rw [neg_equiv_iff_neg_equiv, pgame.neg_zero, equiv.comm]
+
+@[simp] theorem neg_fuzzy_zero {x : pgame} : -x ∥ 0 ↔ x ∥ 0 :=
+by rw [neg_fuzzy_iff_neg_fuzzy, pgame.neg_zero, fuzzy.comm]
+
+@[simp] theorem zero_equiv_neg {x : pgame} : 0 ≈ -x ↔ 0 ≈ x :=
+by rw [equiv_neg_iff_equiv_neg, pgame.neg_zero, equiv.comm]
+
+@[simp] theorem zero_fuzzy_neg {x : pgame} : 0 ∥ -x ↔ 0 ∥ x :=
+by rw [fuzzy_neg_iff_fuzzy_neg, pgame.neg_zero, fuzzy.comm]
+
+theorem sub_le_zero_iff {x y : pgame} : x - y ≤ 0 ↔ x ≤ y :=
+@sub_nonpos game _ _ _ ⟦x⟧ ⟦y⟧
+
+theorem zero_le_sub_iff {x y : pgame} : 0 ≤ x - y ↔ y ≤ x :=
+@sub_nonneg game _ _ _ ⟦x⟧ ⟦y⟧
+
+theorem sub_lt_zero_iff {x y : pgame} : x - y < 0 ↔ x < y :=
+@sub_neg game _ _ _ ⟦x⟧ ⟦y⟧
+
+theorem zero_lt_sub_iff {x y : pgame} : 0 < x - y ↔ y < x :=
+@sub_pos game _ _ _ ⟦x⟧ ⟦y⟧
+
+theorem sub_lf_zero_iff {x y : pgame} : x - y ⧏ 0 ↔ x ⧏ y :=
+by rw [←pgame.not_le, ←pgame.not_le, not_iff_not, zero_le_sub_iff]
+
+theorem zero_lf_sub_iff {x y : pgame} : 0 ⧏ x - y ↔ y ⧏ x :=
+by rw [←pgame.not_le, ←pgame.not_le, not_iff_not, sub_le_zero_iff]
 
 /-! Multiplicative operations can be defined at the level of pre-games,
 but to prove their properties we need to use the abelian group structure of games.

--- a/src/set_theory/game/basic.lean
+++ b/src/set_theory/game/basic.lean
@@ -162,10 +162,10 @@ theorem lt_neg {x y : pgame} : x < -y ↔ y < -x :=
 @lt_neg game _ _ _ _ ⟦x⟧ ⟦y⟧
 
 theorem neg_lf {x y : pgame} : -x ⧏ y ↔ -y ⧏ x :=
-by rw [←pgame.not_le, ←pgame.not_le, not_iff_not, le_neg]
+by rw [←le_iff_le_iff_lf_iff_lf, le_neg]
 
 theorem lf_neg {x y : pgame} : x ⧏ -y ↔ y ⧏ -x :=
-by rw [←pgame.not_le, ←pgame.not_le, not_iff_not, neg_le]
+by rw [←le_iff_le_iff_lf_iff_lf, neg_le]
 
 theorem equiv_neg_iff_equiv_neg {x y : pgame} : x ≈ -y ↔ y ≈ -x :=
 by simp only [equiv, le_neg, neg_le, and_comm]
@@ -222,10 +222,10 @@ theorem zero_lt_sub_iff {x y : pgame} : 0 < x - y ↔ y < x :=
 @sub_pos game _ _ _ ⟦x⟧ ⟦y⟧
 
 theorem sub_lf_zero_iff {x y : pgame} : x - y ⧏ 0 ↔ x ⧏ y :=
-by rw [←pgame.not_le, ←pgame.not_le, not_iff_not, zero_le_sub_iff]
+by rw [←le_iff_le_iff_lf_iff_lf, zero_le_sub_iff]
 
 theorem zero_lf_sub_iff {x y : pgame} : 0 ⧏ x - y ↔ y ⧏ x :=
-by rw [←pgame.not_le, ←pgame.not_le, not_iff_not, sub_le_zero_iff]
+by rw [←le_iff_le_iff_lf_iff_lf, sub_le_zero_iff]
 
 /-! Multiplicative operations can be defined at the level of pre-games,
 but to prove their properties we need to use the abelian group structure of games.

--- a/src/set_theory/game/birthday.lean
+++ b/src/set_theory/game/birthday.lean
@@ -132,6 +132,6 @@ le_def.2 ⟨λ i, or.inl ⟨to_left_moves_to_pgame ⟨_, birthday_move_left_lt i
   by simp [le_birthday (xL i)]⟩, is_empty_elim⟩
 
 theorem neg_birthday_le (x : pgame) : -x.birthday.to_pgame ≤ x :=
-let h := le_birthday (-x) in by rwa [neg_birthday, neg_le_iff] at h
+let h := le_birthday (-x) in by rwa [neg_birthday, neg_le] at h
 
 end pgame

--- a/src/set_theory/game/nim.lean
+++ b/src/set_theory/game/nim.lean
@@ -76,8 +76,6 @@ by { rw nim_def, exact ordinal.unique_out_one }
 /-- `nim 0` has exactly the same moves as `0`. -/
 def nim_zero_relabelling : nim 0 ≡r 0 := relabelling.is_empty _
 
-@[simp] theorem nim_zero_equiv : nim 0 ≈ 0 := equiv.is_empty _
-
 /-- `nim 1` has exactly the same moves as `star`. -/
 noncomputable def nim_one_relabelling : nim 1 ≡r star :=
 begin
@@ -86,8 +84,6 @@ begin
   any_goals { dsimp, apply equiv.equiv_of_unique },
   all_goals { simp, exact nim_zero_relabelling }
 end
-
-@[simp] theorem nim_one_equiv : nim 1 ≈ star := nim_one_relabelling.equiv
 
 @[simp] lemma nim_birthday (O : ordinal) : (nim O).birthday = O :=
 begin
@@ -183,7 +179,7 @@ begin
       refine ⟨to_left_moves_add (sum.inr _), _⟩,
       { exact (ordinal.principal_seg_out h).top },
       { simpa using (impartial.add_self (nim O₁)).2 } },
-    { exact (fuzzy_congr_left add_comm_equiv).1 (this (ne.symm h)) } },
+    { exact (fuzzy_congr_left (add_comm_relabelling _ _).equiv).1 (this (ne.symm h)) } },
   { rintro rfl,
     exact impartial.add_self (nim O₁) }
 end
@@ -258,12 +254,12 @@ by simp
   grundy_value G = grundy_value H ↔ G ≈ H :=
 (grundy_value_eq_iff_equiv_nim _ _).trans (equiv_congr_left.1 (equiv_nim_grundy_value H) _).symm
 
-@[simp] lemma grundy_value_zero : grundy_value 0 = 0 := by simp [nim.nim_zero_equiv.symm]
+@[simp] lemma grundy_value_zero : grundy_value 0 = 0 := by simp [nim.nim_zero_relabelling.equiv']
 
 @[simp] lemma grundy_value_iff_equiv_zero (G : pgame) [G.impartial] : grundy_value G = 0 ↔ G ≈ 0 :=
 by rw [←grundy_value_eq_iff_equiv, grundy_value_zero]
 
-lemma grundy_value_star : grundy_value star = 1 := by simp [nim.nim_one_equiv.symm]
+@[simp] lemma grundy_value_star : grundy_value star = 1 := by simp [nim.nim_one_relabelling.equiv']
 
 @[simp] lemma grundy_value_nim_add_nim (n m : ℕ) :
   grundy_value (nim.{u} n + nim.{u} m) = nat.lxor n m :=

--- a/src/set_theory/game/pgame.lean
+++ b/src/set_theory/game/pgame.lean
@@ -108,6 +108,8 @@ inductive pgame : Type (u+1)
 
 namespace pgame
 
+/-! ### Basic API on moves -/
+
 /-- The indexing type for allowable moves by Left. -/
 def left_moves : pgame → Type u
 | (mk l _ _ _) := l
@@ -228,6 +230,8 @@ meta def pgame_wf_tac :=
    subsequent.mk_left, subsequent.mk_right, subsequent.trans]
   { max_depth := 6 }]
 
+/-! ### Basic pre-games -/
+
 /-- The pre-game `zero` is defined by `0 = { | }`. -/
 instance : has_zero pgame := ⟨⟨pempty, pempty, pempty.elim, pempty.elim⟩⟩
 
@@ -248,6 +252,8 @@ instance : has_one pgame := ⟨⟨punit, pempty, λ _, 0, pempty.elim⟩⟩
 
 instance unique_one_left_moves : unique (left_moves 1) := punit.unique
 instance is_empty_one_right_moves : is_empty (right_moves 1) := pempty.is_empty
+
+/-! ### Pre-game comparison -/
 
 /-- Define simultaneously by mutual induction the `≤` relation and its swapped converse `⧏` on
   pre-games.
@@ -518,6 +524,7 @@ theorem equiv.ge {x y : pgame} (h : x ≈ y) : y ≤ x := h.2
 theorem equiv_refl (x) : x ≈ x := refl x
 @[symm] protected theorem equiv.symm {x y} : x ≈ y → y ≈ x := symm
 @[trans] protected theorem equiv.trans {x y z} : x ≈ y → y ≈ z → x ≈ z := trans
+protected theorem equiv.comm {x y} : x ≈ y ↔ y ≈ x := comm
 
 theorem equiv_of_eq {x y} (h : x = y) : x ≈ y := by subst h
 
@@ -585,10 +592,11 @@ theorem equiv_congr_right {x₁ x₂} : x₁ ≈ x₂ ↔ ∀ y₁, x₁ ≈ y�
 ⟨λ h y₁, ⟨λ h', h.symm.trans h', λ h', h.trans h'⟩,
  λ h, (h x₂).2 $ equiv_rfl⟩
 
+/-- Pre-games made out of equivalent left and right moves are equivalent. -/
 theorem equiv_of_mk_equiv {x y : pgame}
   (L : x.left_moves ≃ y.left_moves) (R : x.right_moves ≃ y.right_moves)
-  (hl : ∀ (i : x.left_moves), x.move_left i ≈ y.move_left (L i))
-  (hr : ∀ (j : y.right_moves), x.move_right (R.symm j) ≈ y.move_right j) :
+  (hl : ∀ i, x.move_left i ≈ y.move_left (L i))
+  (hr : ∀ j, x.move_right (R.symm j) ≈ y.move_right j) :
   x ≈ y :=
 begin
   fsplit; rw le_def,
@@ -615,7 +623,7 @@ localized "infix ` ∥ `:50 := pgame.fuzzy" in pgame
 
 @[symm] theorem fuzzy.swap {x y : pgame} : x ∥ y → y ∥ x := and.swap
 instance : is_symm _ (∥) := ⟨λ x y, fuzzy.swap⟩
-theorem fuzzy.swap_iff {x y : pgame} : x ∥ y ↔ y ∥ x := ⟨fuzzy.swap, fuzzy.swap⟩
+theorem fuzzy.comm {x y : pgame} : x ∥ y ↔ y ∥ x := comm
 
 theorem fuzzy_irrefl (x : pgame) : ¬ x ∥ x := λ h, lf_irrefl x h.1
 instance : is_irrefl _ (∥) := ⟨fuzzy_irrefl⟩
@@ -671,9 +679,11 @@ end
 
 theorem lt_or_equiv_or_gf (x y : pgame) : x < y ∨ x ≈ y ∨ y ⧏ x :=
 begin
-  rw [lf_iff_lt_or_fuzzy, fuzzy.swap_iff],
+  rw [lf_iff_lt_or_fuzzy, fuzzy.comm],
   exact lt_or_equiv_or_gt_or_fuzzy x y
 end
+
+/-! ### Relabellings -/
 
 /-- `restricted x y` says that Left always has no more moves in `x` than in `y`,
      and Right always has no more moves in `y` than in `x` -/
@@ -780,6 +790,8 @@ by simp
 def relabel_relabelling {x : pgame} {xl' xr'} (el : x.left_moves ≃ xl') (er : x.right_moves ≃ xr') :
   x ≡r relabel el er :=
 relabelling.mk el er (λ i, by simp) (λ j, by simp)
+
+/-! ### Negation -/
 
 /-- The negation of `{L | R}` is `{-R | -L}`. -/
 def neg : pgame → pgame
@@ -902,59 +914,7 @@ by rw [equiv, equiv, neg_le_neg_iff, neg_le_neg_iff, and.comm]
 @[simp] theorem neg_fuzzy_neg_iff {x y : pgame} : -x ∥ -y ↔ x ∥ y :=
 by rw [fuzzy, fuzzy, neg_lf_neg_iff, neg_lf_neg_iff, and.comm]
 
-theorem neg_le_iff {x y : pgame} : -y ≤ x ↔ -x ≤ y :=
-by rw [←neg_neg x, neg_le_neg_iff, neg_neg]
-
-theorem neg_lf_iff {x y : pgame} : -y ⧏ x ↔ -x ⧏ y :=
-by rw [←neg_neg x, neg_lf_neg_iff, neg_neg]
-
-theorem neg_lt_iff {x y : pgame} : -y < x ↔ -x < y :=
-by rw [←neg_neg x, neg_lt_neg_iff, neg_neg]
-
-theorem neg_equiv_iff {x y : pgame} : -x ≈ y ↔ x ≈ -y :=
-by rw [←neg_neg y, neg_equiv_neg_iff, neg_neg]
-
-theorem neg_fuzzy_iff {x y : pgame} : -x ∥ y ↔ x ∥ -y :=
-by rw [←neg_neg y, neg_fuzzy_neg_iff, neg_neg]
-
-theorem le_neg_iff {x y : pgame} : y ≤ -x ↔ x ≤ -y :=
-by rw [←neg_neg x, neg_le_neg_iff, neg_neg]
-
-theorem lf_neg_iff {x y : pgame} : y ⧏ -x ↔ x ⧏ -y :=
-by rw [←neg_neg x, neg_lf_neg_iff, neg_neg]
-
-theorem lt_neg_iff {x y : pgame} : y < -x ↔ x < -y :=
-by rw [←neg_neg x, neg_lt_neg_iff, neg_neg]
-
-@[simp] theorem neg_le_zero_iff {x : pgame} : -x ≤ 0 ↔ 0 ≤ x :=
-by rw [neg_le_iff, pgame.neg_zero]
-
-@[simp] theorem zero_le_neg_iff {x : pgame} : 0 ≤ -x ↔ x ≤ 0 :=
-by rw [le_neg_iff, pgame.neg_zero]
-
-@[simp] theorem neg_lf_zero_iff {x : pgame} : -x ⧏ 0 ↔ 0 ⧏ x :=
-by rw [neg_lf_iff, pgame.neg_zero]
-
-@[simp] theorem zero_lf_neg_iff {x : pgame} : 0 ⧏ -x ↔ x ⧏ 0 :=
-by rw [lf_neg_iff, pgame.neg_zero]
-
-@[simp] theorem neg_lt_zero_iff {x : pgame} : -x < 0 ↔ 0 < x :=
-by rw [neg_lt_iff, pgame.neg_zero]
-
-@[simp] theorem zero_lt_neg_iff {x : pgame} : 0 < -x ↔ x < 0 :=
-by rw [lt_neg_iff, pgame.neg_zero]
-
-@[simp] theorem neg_equiv_zero_iff {x : pgame} : -x ≈ 0 ↔ x ≈ 0 :=
-by rw [neg_equiv_iff, pgame.neg_zero]
-
-@[simp] theorem neg_fuzzy_zero_iff {x : pgame} : -x ∥ 0 ↔ x ∥ 0 :=
-by rw [neg_fuzzy_iff, pgame.neg_zero]
-
-@[simp] theorem zero_equiv_neg_iff {x : pgame} : 0 ≈ -x ↔ 0 ≈ x :=
-by rw [←neg_equiv_iff, pgame.neg_zero]
-
-@[simp] theorem zero_fuzzy_neg_iff {x : pgame} : 0 ∥ -x ↔ 0 ∥ x :=
-by rw [←neg_fuzzy_iff, pgame.neg_zero]
+/-! ### Addition and subtraction -/
 
 /-- The sum of `x = {xL | xR}` and `y = {yL | yR}` is `{xL + y, x + yL | xR + y, x + yR}`. -/
 instance : has_add pgame.{u} := ⟨λ x y, begin
@@ -997,10 +957,6 @@ begin
     apply add_zero_relabelling, }
 end
 
-/-- `x + 0` is equivalent to `x`. -/
-lemma add_zero_equiv (x : pgame.{u}) : x + 0 ≈ x :=
-(add_zero_relabelling x).equiv
-
 /-- `0 + x` has exactly the same moves as `x`. -/
 def zero_add_relabelling : Π (x : pgame.{u}), 0 + x ≡r x
 | (mk xl xr xL xR) :=
@@ -1011,10 +967,6 @@ begin
   { rintro j,
     apply zero_add_relabelling, }
 end
-
-/-- `0 + x` is equivalent to `x`. -/
-lemma zero_add_equiv (x : pgame.{u}) : 0 + x ≈ x :=
-(zero_add_relabelling x).equiv
 
 theorem left_moves_add : ∀ (x y : pgame.{u}),
   (x + y).left_moves = (x.left_moves ⊕ y.left_moves)
@@ -1139,9 +1091,6 @@ begin
 end
 using_well_founded { dec_tac := pgame_wf_tac }
 
-theorem neg_add_le {x y : pgame} : -(x + y) ≤ -x + -y :=
-(neg_add_relabelling x y).le
-
 /-- `x + y` has exactly the same moves as `y + x`. -/
 def add_comm_relabelling : Π (x y : pgame.{u}), x + y ≡r y + x
 | (mk xl xr xL xR) (mk yl yr yL yR) :=
@@ -1151,12 +1100,6 @@ begin
   { dsimp [left_moves_add, right_moves_add], apply add_comm_relabelling }
 end
 using_well_founded { dec_tac := pgame_wf_tac }
-
-theorem add_comm_le {x y : pgame} : x + y ≤ y + x :=
-(add_comm_relabelling x y).le
-
-theorem add_comm_equiv {x y : pgame} : x + y ≈ y + x :=
-(add_comm_relabelling x y).equiv
 
 /-- `(x + y) + z` has exactly the same moves as `x + (y + z)`. -/
 def add_assoc_relabelling : Π (x y z : pgame.{u}), x + y + z ≡r x + (y + z)
@@ -1170,9 +1113,6 @@ begin
     { apply add_assoc_relabelling ⟨xl, xr, xL, xR⟩ ⟨yl, yr, yL, yR⟩ } }
 end
 using_well_founded { dec_tac := pgame_wf_tac }
-
-theorem add_assoc_equiv {x y z : pgame} : (x + y) + z ≈ x + (y + z) :=
-(add_assoc_relabelling x y z).equiv
 
 theorem add_left_neg_le_zero : ∀ (x : pgame), -x + x ≤ 0
 | ⟨xl, xr, xL, xR⟩ :=
@@ -1192,17 +1132,17 @@ end
 theorem zero_le_add_left_neg (x : pgame) : 0 ≤ -x + x :=
 begin
   rw [←neg_le_neg_iff, pgame.neg_zero],
-  exact neg_add_le.trans (add_left_neg_le_zero _)
+  exact (neg_add_relabelling _ x).le.trans (add_left_neg_le_zero _)
 end
 
 theorem add_left_neg_equiv (x : pgame) : -x + x ≈ 0 :=
 ⟨add_left_neg_le_zero x, zero_le_add_left_neg x⟩
 
 theorem add_right_neg_le_zero (x : pgame) : x + -x ≤ 0 :=
-add_comm_le.trans (add_left_neg_le_zero x)
+(add_comm_relabelling x _).le.trans (add_left_neg_le_zero x)
 
 theorem zero_le_add_right_neg (x : pgame) : 0 ≤ x + -x :=
-(zero_le_add_left_neg x).trans add_comm_le
+(zero_le_add_left_neg x).trans (add_comm_relabelling _ _).le
 
 theorem add_right_neg_equiv (x : pgame) : x + -x ≈ 0 :=
 ⟨add_right_neg_le_zero x, zero_le_add_right_neg x⟩
@@ -1238,20 +1178,24 @@ instance covariant_class_swap_add_le : covariant_class pgame pgame (swap (+)) (�
 ⟨λ x y z, add_le_add_right'⟩
 
 instance covariant_class_add_le : covariant_class pgame pgame (+) (≤) :=
-⟨λ x y z h, (add_comm_le.trans (add_le_add_right h x)).trans add_comm_le⟩
+⟨λ x y z h,
+  ((add_comm_relabelling _ _).le.trans (add_le_add_right h x)).trans (add_comm_relabelling _ _).le⟩
 
 theorem add_lf_add_right {y z : pgame} (h : y ⧏ z) (x) : y + x ⧏ z + x :=
 suffices z + x ≤ y + x → z ≤ y, by { rw ←pgame.not_le at ⊢ h, exact mt this h }, λ w,
-  calc z ≤ z + 0        : (add_zero_relabelling _).symm.le
+  calc z ≤ z + 0        : (add_zero_relabelling _).ge
      ... ≤ z + (x + -x) : add_le_add_left (zero_le_add_right_neg x) _
-     ... ≤ z + x + -x   : (add_assoc_relabelling _ _ _).symm.le
+     ... ≤ z + x + -x   : (add_assoc_relabelling _ _ _).ge
      ... ≤ y + x + -x   : add_le_add_right w _
      ... ≤ y + (x + -x) : (add_assoc_relabelling _ _ _).le
      ... ≤ y + 0        : add_le_add_left (add_right_neg_le_zero x) _
      ... ≤ y            : (add_zero_relabelling _).le
 
 theorem add_lf_add_left {y z : pgame} (h : y ⧏ z) (x) : x + y ⧏ x + z :=
-by { rw lf_congr add_comm_equiv add_comm_equiv, apply add_lf_add_right h }
+begin
+  rw lf_congr (add_comm_relabelling x y).equiv (add_comm_relabelling x z).equiv,
+  apply add_lf_add_right h
+end
 
 instance covariant_class_swap_add_lt : covariant_class pgame pgame (swap (+)) (<) :=
 ⟨λ x y z h, begin
@@ -1290,32 +1234,7 @@ sub_congr h equiv_rfl
 theorem sub_congr_right {x y z : pgame} : y ≈ z → x - y ≈ x - z :=
 sub_congr equiv_rfl
 
-theorem le_iff_sub_nonneg {x y : pgame} : x ≤ y ↔ 0 ≤ y - x :=
-⟨λ h, (zero_le_add_right_neg x).trans (add_le_add_right h _),
- λ h,
-  calc x ≤ 0 + x : (zero_add_relabelling x).symm.le
-     ... ≤ y - x + x : add_le_add_right h _
-     ... ≤ y + (-x + x) : (add_assoc_relabelling _ _ _).le
-     ... ≤ y + 0 : add_le_add_left (add_left_neg_le_zero x) _
-     ... ≤ y : (add_zero_relabelling y).le⟩
-
-theorem lf_iff_sub_zero_lf {x y : pgame} : x ⧏ y ↔ 0 ⧏ y - x :=
-⟨λ h, (zero_le_add_right_neg x).trans_lf (add_lf_add_right h _),
- λ h,
-  calc x ≤ 0 + x : (zero_add_relabelling x).symm.le
-     ... ⧏ y - x + x : add_lf_add_right h _
-     ... ≤ y + (-x + x) : (add_assoc_relabelling _ _ _).le
-     ... ≤ y + 0 : add_le_add_left (add_left_neg_le_zero x) _
-     ... ≤ y : (add_zero_relabelling y).le⟩
-
-theorem lt_iff_sub_pos {x y : pgame} : x < y ↔ 0 < y - x :=
-⟨λ h, lt_of_le_of_lt (zero_le_add_right_neg x) (add_lt_add_right h _),
- λ h,
-  calc x ≤ 0 + x : (zero_add_relabelling x).symm.le
-     ... < y - x + x : add_lt_add_right h _
-     ... ≤ y + (-x + x) : (add_assoc_relabelling _ _ _).le
-     ... ≤ y + 0 : add_le_add_left (add_left_neg_le_zero x) _
-     ... ≤ y : (add_zero_relabelling y).le⟩
+/-! ### Special pre-games -/
 
 /-- The pre-game `star`, which is fuzzy with zero. -/
 def star : pgame.{u} := ⟨punit, punit, λ _, 0, λ _, 0⟩
@@ -1342,5 +1261,7 @@ instance : zero_le_one_class pgame := ⟨zero_lt_one.le⟩
 
 @[simp] theorem zero_lf_one : (0 : pgame) ⧏ 1 :=
 zero_lt_one.lf
+
+-- TODO: add API on `up = {star | 0}`.
 
 end pgame

--- a/src/set_theory/game/pgame.lean
+++ b/src/set_theory/game/pgame.lean
@@ -767,6 +767,11 @@ lf_of_lf_of_equiv h₁ h₂.equiv
 @[trans] theorem lf_of_relabelling_of_lf {x y z} (h₁ : x ≡r y) : y ⧏ z → x ⧏ z :=
 lf_of_equiv_of_lf h₁.equiv
 
+@[trans] theorem lt_of_lt_of_relabelling {x y z} (h₁ : x < y) (h₂ : y ≡r z) : x < z :=
+lt_of_lt_of_equiv h₁ h₂.equiv
+@[trans] theorem lt_of_relabelling_of_lt {x y z} (h₁ : x ≡r y) : y < z → x < z :=
+lt_of_equiv_of_lt h₁.equiv
+
 /-- Any game without left or right moves is a relabelling of 0. -/
 def relabelling.is_empty (x : pgame) [is_empty x.left_moves] [is_empty x.right_moves] : x ≡r 0 :=
 ⟨equiv.equiv_pempty _, equiv.equiv_pempty _, is_empty_elim, is_empty_elim⟩

--- a/src/set_theory/game/pgame.lean
+++ b/src/set_theory/game/pgame.lean
@@ -326,6 +326,9 @@ theorem lf.not_ge {x y : pgame} : x ⧏ y → ¬ y ≤ x := pgame.not_le.2
 theorem le_or_gf (x y : pgame) : x ≤ y ∨ y ⧏ x :=
 by { rw ←pgame.not_le, apply em }
 
+theorem le_iff_le_iff_lf_iff_lf {a b c d : pgame} : a ≤ b ↔ c ≤ d ↔ (b ⧏ a ↔ d ⧏ c) :=
+by rw [←pgame.not_le, ←pgame.not_le, not_iff_not]
+
 theorem move_left_lf_of_le {x y : pgame} (i) (h : x ≤ y) : x.move_left i ⧏ y :=
 (le_iff_forall_lf.1 h).1 i
 

--- a/src/set_theory/game/pgame.lean
+++ b/src/set_theory/game/pgame.lean
@@ -757,6 +757,16 @@ theorem relabelling.equiv' {x y : pgame} (r : x ≡r y) : y ≈ x := ⟨r.ge, r.
 ⟨L₁.trans L₂, R₁.trans R₂,
   λ i, by simpa using (hL₁ i).trans (hL₂ _), λ j, by simpa using (hR₁ _).trans (hR₂ j)⟩
 
+@[trans] theorem le_of_le_of_relabelling {x y z} (h₁ : x ≤ y) (h₂ : y ≡r z) : x ≤ z :=
+le_of_le_of_equiv h₁ h₂.equiv
+@[trans] theorem le_of_relabelling_of_le {x y z} (h₁ : x ≡r y) : y ≤ z → x ≤ z :=
+le_of_equiv_of_le h₁.equiv
+
+@[trans] theorem lf_of_lf_of_relabelling {x y z} (h₁ : x ⧏ y) (h₂ : y ≡r z) : x ⧏ z :=
+lf_of_lf_of_equiv h₁ h₂.equiv
+@[trans] theorem lf_of_relabelling_of_lf {x y z} (h₁ : x ≡r y) : y ⧏ z → x ⧏ z :=
+lf_of_equiv_of_lf h₁.equiv
+
 /-- Any game without left or right moves is a relabelling of 0. -/
 def relabelling.is_empty (x : pgame) [is_empty x.left_moves] [is_empty x.right_moves] : x ≡r 0 :=
 ⟨equiv.equiv_pempty _, equiv.equiv_pempty _, is_empty_elim, is_empty_elim⟩
@@ -1182,13 +1192,13 @@ instance covariant_class_add_le : covariant_class pgame pgame (+) (≤) :=
 
 theorem add_lf_add_right {y z : pgame} (h : y ⧏ z) (x) : y + x ⧏ z + x :=
 suffices z + x ≤ y + x → z ≤ y, by { rw ←pgame.not_le at ⊢ h, exact mt this h }, λ w,
-  calc z ≤ z + 0        : (add_zero_relabelling _).ge
-     ... ≤ z + (x + -x) : add_le_add_left (zero_le_add_right_neg x) _
-     ... ≤ z + x + -x   : (add_assoc_relabelling _ _ _).ge
-     ... ≤ y + x + -x   : add_le_add_right w _
-     ... ≤ y + (x + -x) : (add_assoc_relabelling _ _ _).le
-     ... ≤ y + 0        : add_le_add_left (add_right_neg_le_zero x) _
-     ... ≤ y            : (add_zero_relabelling _).le
+  calc z ≡r z + 0        : (add_zero_relabelling z).symm
+     ... ≤ z + (x + -x)  : add_le_add_left (zero_le_add_right_neg x) z
+     ... ≡r z + x + -x   : (add_assoc_relabelling z x _).symm
+     ... ≤ y + x + -x    : add_le_add_right w _
+     ... ≡r y + (x + -x) : add_assoc_relabelling y x _
+     ... ≤ y + 0         : add_le_add_left (add_right_neg_le_zero x) _
+     ... ≡r y            : add_zero_relabelling y
 
 theorem add_lf_add_left {y z : pgame} (h : y ⧏ z) (x) : x + y ⧏ x + z :=
 begin

--- a/src/set_theory/game/pgame.lean
+++ b/src/set_theory/game/pgame.lean
@@ -749,6 +749,8 @@ theorem relabelling.ge {x y : pgame} (r : x ≡r y) : y ≤ x := r.symm.restrict
 /-- A relabelling lets us prove equivalence of games. -/
 theorem relabelling.equiv {x y : pgame} (r : x ≡r y) : x ≈ y := ⟨r.le, r.ge⟩
 
+theorem relabelling.equiv' {x y : pgame} (r : x ≡r y) : y ≈ x := ⟨r.ge, r.le⟩
+
 /-- Transitivity of relabelling. -/
 @[trans] def relabelling.trans : Π {x y z : pgame}, x ≡r y → y ≡r z → x ≡r z
 | ⟨xl, xr, xL, xR⟩ ⟨yl, yr, yL, yR⟩ ⟨zl, zr, zL, zR⟩ ⟨L₁, R₁, hL₁, hR₁⟩ ⟨L₂, R₂, hL₂, hR₂⟩ :=
@@ -758,9 +760,6 @@ theorem relabelling.equiv {x y : pgame} (r : x ≡r y) : x ≈ y := ⟨r.le, r.g
 /-- Any game without left or right moves is a relabelling of 0. -/
 def relabelling.is_empty (x : pgame) [is_empty x.left_moves] [is_empty x.right_moves] : x ≡r 0 :=
 ⟨equiv.equiv_pempty _, equiv.equiv_pempty _, is_empty_elim, is_empty_elim⟩
-
-theorem equiv.is_empty (x : pgame) [is_empty x.left_moves] [is_empty x.right_moves] : x ≈ 0 :=
-(relabelling.is_empty x).equiv
 
 instance {x y : pgame} : has_coe (x ≡r y) (x ≈ y) := ⟨relabelling.equiv⟩
 

--- a/src/set_theory/surreal/basic.lean
+++ b/src/set_theory/surreal/basic.lean
@@ -274,21 +274,24 @@ instance : has_neg surreal  :=
   (λ _ _ _ _ a, quotient.sound (pgame.neg_equiv_neg_iff.2 a))⟩
 
 instance : ordered_add_comm_group surreal :=
-{ add               := (+),
-  add_assoc         := by { rintros ⟨_⟩ ⟨_⟩ ⟨_⟩, exact quotient.sound add_assoc_equiv },
-  zero              := 0,
-  zero_add          := by { rintros ⟨_⟩, exact quotient.sound (pgame.zero_add_equiv a) },
-  add_zero          := by { rintros ⟨_⟩, exact quotient.sound (pgame.add_zero_equiv a) },
-  neg               := has_neg.neg,
-  add_left_neg      := by { rintros ⟨_⟩, exact quotient.sound (pgame.add_left_neg_equiv a) },
-  add_comm          := by { rintros ⟨_⟩ ⟨_⟩, exact quotient.sound pgame.add_comm_equiv },
-  le                := (≤),
-  lt                := (<),
-  le_refl           := by { rintros ⟨_⟩, apply @le_rfl pgame },
-  le_trans          := by { rintros ⟨_⟩ ⟨_⟩ ⟨_⟩, apply @le_trans pgame },
-  lt_iff_le_not_le  := by { rintros ⟨_, ox⟩ ⟨_, oy⟩, exact lt_iff_le_not_le },
-  le_antisymm       := by { rintros ⟨_⟩ ⟨_⟩ h₁ h₂, exact quotient.sound ⟨h₁, h₂⟩ },
-  add_le_add_left   := by { rintros ⟨_⟩ ⟨_⟩ hx ⟨_⟩, exact @add_le_add_left pgame _ _ _ _ _ hx _ } }
+{ add              := (+),
+  add_assoc        := begin
+                        rintros ⟨_⟩ ⟨_⟩ ⟨_⟩,
+                        exact quot.sound (add_assoc_relabelling _ _ _).equiv
+                      end,
+  zero             := 0,
+  zero_add         := by { rintro ⟨_⟩, exact quot.sound (zero_add_relabelling _).equiv },
+  add_zero         := by { rintro ⟨_⟩, exact quot.sound (add_zero_relabelling _).equiv },
+  neg              := has_neg.neg,
+  add_left_neg     := by { rintros ⟨_⟩, exact quot.sound (add_left_neg_equiv a) },
+  add_comm         := by { rintros ⟨_⟩ ⟨_⟩, exact quot.sound (add_comm_relabelling _ _).equiv },
+  le               := (≤),
+  lt               := (<),
+  le_refl          := by { rintros ⟨_⟩, apply @le_rfl pgame },
+  le_trans         := by { rintros ⟨_⟩ ⟨_⟩ ⟨_⟩, apply @le_trans pgame },
+  lt_iff_le_not_le := by { rintros ⟨_, ox⟩ ⟨_, oy⟩, exact lt_iff_le_not_le },
+  le_antisymm      := by { rintros ⟨_⟩ ⟨_⟩ h₁ h₂, exact quotient.sound ⟨h₁, h₂⟩ },
+  add_le_add_left  := by { rintros ⟨_⟩ ⟨_⟩ hx ⟨_⟩, exact @add_le_add_left pgame _ _ _ _ _ hx _ } }
 
 noncomputable instance : linear_ordered_add_comm_group surreal :=
 { le_total := by rintro ⟨⟨x, ox⟩⟩ ⟨⟨y, oy⟩⟩; classical; exact

--- a/src/set_theory/surreal/dyadic.lean
+++ b/src/set_theory/surreal/dyadic.lean
@@ -96,10 +96,10 @@ begin
   induction n using nat.strong_induction_on with n hn,
   { split; rw le_iff_forall_lf; split,
     { rintro (⟨⟨ ⟩⟩ | ⟨⟨ ⟩⟩); apply lf_of_lt,
-      { calc 0 + pow_half n.succ ≡r pow_half n.succ : (zero_add_relabelling _)
-                             ... < pow_half n      : pow_half_succ_lt_pow_half n },
-      { calc pow_half n.succ + 0 ≈ pow_half n.succ : (add_zero_relabelling _).equiv
-                             ... < pow_half n      : pow_half_succ_lt_pow_half n } },
+      { calc 0 + pow_half n.succ ≡r pow_half n.succ : zero_add_relabelling _
+                             ... < pow_half n       : pow_half_succ_lt_pow_half n },
+      { calc pow_half n.succ + 0 ≡r pow_half n.succ : add_zero_relabelling _
+                             ... < pow_half n       : pow_half_succ_lt_pow_half n } },
     { cases n, { rintro ⟨ ⟩ },
       rintro ⟨ ⟩,
       apply lf_of_move_right_le,
@@ -109,16 +109,14 @@ begin
       ... ≈ pow_half n                        : hn _ (nat.lt_succ_self n) },
     { simp only [pow_half_move_left, forall_const],
       apply lf_of_lt,
-      calc 0 ≈ 0 + 0                            : (add_zero_relabelling 0).equiv'
-        ... ≤ pow_half n.succ + 0               : add_le_add_right (zero_le_pow_half _) _
-        ... < pow_half n.succ + pow_half n.succ : add_lt_add_left (pow_half_pos _) _ },
+      calc 0 ≡r 0 + 0                            : (add_zero_relabelling 0).symm
+         ... ≤ pow_half n.succ + 0               : add_le_add_right (zero_le_pow_half _) _
+         ... < pow_half n.succ + pow_half n.succ : add_lt_add_left (pow_half_pos _) _ },
     { rintro (⟨⟨ ⟩⟩ | ⟨⟨ ⟩⟩); apply lf_of_lt,
-      { calc pow_half n
-            ≈ pow_half n + 0               : (add_zero_relabelling _).equiv'
-        ... < pow_half n + pow_half n.succ : add_lt_add_left (pow_half_pos _) _ },
-      { calc pow_half n
-            ≈ 0 + pow_half n               : (zero_add_relabelling _).equiv'
-        ... < pow_half n.succ + pow_half n : add_lt_add_right (pow_half_pos _) _  } } }
+      { calc pow_half n ≡r pow_half n + 0 : (add_zero_relabelling _).symm
+       ... < pow_half n + pow_half n.succ : add_lt_add_left (pow_half_pos _) _ },
+      { calc pow_half n ≡r 0 + pow_half n : (zero_add_relabelling _).symm
+       ... < pow_half n.succ + pow_half n : add_lt_add_right (pow_half_pos _) _ } } }
 end
 
 theorem half_add_half_equiv_one : pow_half 1 + pow_half 1 ≈ 1 :=

--- a/src/set_theory/surreal/dyadic.lean
+++ b/src/set_theory/surreal/dyadic.lean
@@ -26,7 +26,7 @@ rational numbers to construct an ordered field embedding of ℝ into `surreal`.
 
 universes u
 
-local infix ` ≈ ` := pgame.equiv
+open_locale pgame
 
 namespace pgame
 
@@ -96,9 +96,9 @@ begin
   induction n using nat.strong_induction_on with n hn,
   { split; rw le_iff_forall_lf; split,
     { rintro (⟨⟨ ⟩⟩ | ⟨⟨ ⟩⟩); apply lf_of_lt,
-      { calc 0 + pow_half n.succ ≈ pow_half n.succ : zero_add_equiv _
+      { calc 0 + pow_half n.succ ≡r pow_half n.succ : (zero_add_relabelling _)
                              ... < pow_half n      : pow_half_succ_lt_pow_half n },
-      { calc pow_half n.succ + 0 ≈ pow_half n.succ : add_zero_equiv _
+      { calc pow_half n.succ + 0 ≈ pow_half n.succ : (add_zero_relabelling _).equiv
                              ... < pow_half n      : pow_half_succ_lt_pow_half n } },
     { cases n, { rintro ⟨ ⟩ },
       rintro ⟨ ⟩,
@@ -109,15 +109,15 @@ begin
       ... ≈ pow_half n                        : hn _ (nat.lt_succ_self n) },
     { simp only [pow_half_move_left, forall_const],
       apply lf_of_lt,
-      calc 0 ≈ 0 + 0                            : (add_zero_equiv 0).symm
+      calc 0 ≈ 0 + 0                            : (add_zero_relabelling 0).equiv'
         ... ≤ pow_half n.succ + 0               : add_le_add_right (zero_le_pow_half _) _
         ... < pow_half n.succ + pow_half n.succ : add_lt_add_left (pow_half_pos _) _ },
     { rintro (⟨⟨ ⟩⟩ | ⟨⟨ ⟩⟩); apply lf_of_lt,
       { calc pow_half n
-            ≈ pow_half n + 0               : (add_zero_equiv _).symm
+            ≈ pow_half n + 0               : (add_zero_relabelling _).equiv'
         ... < pow_half n + pow_half n.succ : add_lt_add_left (pow_half_pos _) _ },
       { calc pow_half n
-            ≈ 0 + pow_half n               : (zero_add_equiv _).symm
+            ≈ 0 + pow_half n               : (zero_add_relabelling _).equiv'
         ... < pow_half n.succ + pow_half n : add_lt_add_right (pow_half_pos _) _  } } }
 end
 


### PR DESCRIPTION
This PR does the following:
- Remove various lemmas on equivalences that are inferred from relabellings. The reasoning for this is the same as the one for having `<` lemmas supersede their `≤` counterparts. This will make the API significantly less cluttered with when we add the `identical` relation.
- Add various `trans` lemmas with relabellings.
- Move various theorems from `set_theory/game/pgame.lean` to `set_theory/game/basic.lean`, where they can be much easily proven by using the `add_comm_group` structure on `game` and various def-eqs.
- Rename `fuzzy.swap_iff` to `fuzzy.comm` to match other `comm` lemmas in mathlib.
- Add various doc comments to organize the file.
- General golfing.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
