### PR TITLE
[Merged by Bors] - feat(algebra/homology): homotopy equivalences are quasi-isomorphisms

### DIFF
--- a/src/algebra/homology/quasi_iso.lean
+++ b/src/algebra/homology/quasi_iso.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Scott Morrison
 -/
 import algebra.homology.homology
+import algebra.homology.homotopy
 
 /-!
 # Quasi-isomorphisms
@@ -53,3 +54,15 @@ lemma quasi_iso_of_comp_left (f : C ⟶ D) [quasi_iso f] (g : D ⟶ E) [quasi_is
 lemma quasi_iso_of_comp_right (f : C ⟶ D) (g : D ⟶ E) [quasi_iso g] [quasi_iso (f ≫ g)] :
   quasi_iso f :=
 { is_iso := λ i, is_iso.of_is_iso_fac_right ((homology_functor V c i).map_comp f g).symm }
+
+/-- An homotopy equivalence is a quasi-isomorphism. -/
+lemma quasi_iso.of_homotopy_equiv {W : Type*} [category W] [preadditive W]
+  [has_cokernels W] [has_images W] [has_equalizers W] [has_zero_object W]
+  [has_image_maps W] {C D : homological_complex W c} (e : homotopy_equiv C D) :
+  quasi_iso e.hom :=
+⟨λ i, begin
+  refine ⟨⟨(homology_functor W c i).map e.inv, _⟩⟩,
+  simp only [← functor.map_comp, ← (homology_functor W c i).map_id],
+  split; apply homology_map_eq_of_homotopy,
+  exacts [e.homotopy_hom_inv_id, e.homotopy_inv_hom_id],
+end⟩

--- a/src/algebra/homology/quasi_iso.lean
+++ b/src/algebra/homology/quasi_iso.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2021 Scott Morrison. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Scott Morrison
+Authors: Scott Morrison, Joël Riou
 -/
 import algebra.homology.homology
 import algebra.homology.homotopy

--- a/src/algebra/homology/quasi_iso.lean
+++ b/src/algebra/homology/quasi_iso.lean
@@ -56,7 +56,7 @@ lemma quasi_iso_of_comp_right (f : C ⟶ D) (g : D ⟶ E) [quasi_iso g] [quasi_i
 { is_iso := λ i, is_iso.of_is_iso_fac_right ((homology_functor V c i).map_comp f g).symm }
 
 /-- An homotopy equivalence is a quasi-isomorphism. -/
-lemma quasi_iso.of_homotopy_equiv {W : Type*} [category W] [preadditive W]
+lemma homotopy_equiv.to_quasi_iso {W : Type*} [category W] [preadditive W]
   [has_cokernels W] [has_images W] [has_equalizers W] [has_zero_object W]
   [has_image_maps W] {C D : homological_complex W c} (e : homotopy_equiv C D) :
   quasi_iso e.hom :=


### PR DESCRIPTION
In this PR, it is shown that homotopy equivalences of homological complexes are quasi-isomorphisms.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
