### PR TITLE
feat(field_theory/finite/galois_field): remove algebra instance to remove diamond

### DIFF
--- a/src/data/zmod/algebra.lean
+++ b/src/data/zmod/algebra.lean
@@ -15,6 +15,18 @@ namespace zmod
 
 variables (R : Type*) [ring R]
 
+instance (p : ℕ) : subsingleton (algebra (zmod p) R) :=
+⟨λ x y, begin
+  casesI p,
+  { exact @@subsingleton.elim int_algebra_subsingleton x y },
+  refine x.algebra_ext y (λ r, _),
+  convert_to (@algebra_map _ _ _ _ x) ((coe : zmod p.succ → zmod p.succ) r) =
+             (@algebra_map _ _ _ _ y) ((coe : zmod p.succ → zmod p.succ) r),
+  { rw [cast_id] },
+  { rw [cast_id] },
+  rw [←nat_cast_val r, ←nat.smul_one_eq_coe, map_nsmul, map_nsmul, map_one, map_one]
+end⟩
+
 section
 variables {n : ℕ} (m : ℕ) [char_p R m]
 
@@ -34,9 +46,8 @@ def algebra' (h : m ∣ n) : algebra (zmod n) R :=
 end
 
 section
-variables (n : ℕ) [char_p R n]
 
-instance : algebra (zmod n) R := algebra' R n (dvd_refl n)
+instance (p : ℕ) [char_p R p] : algebra (zmod p) R := algebra' R p dvd_rfl
 
 end
 

--- a/src/field_theory/finite/galois_field.lean
+++ b/src/field_theory/finite/galois_field.lean
@@ -163,7 +163,7 @@ begin
 end
 
 /-- Any finite field is (possibly non canonically) isomorphic to some Galois field. -/
-lemma alg_equiv_galois_field (h : fintype.card K = p ^ n) :
+def alg_equiv_galois_field (h : fintype.card K = p ^ n) :
   K ≃ₐ[zmod p] galois_field p n :=
 by convert @@is_splitting_field.alg_equiv _ _ _ _ _ (is_splitting_field_of_card_eq _ _ h)
 


### PR DESCRIPTION
This removes the `galois_field.algebra` instance, instead using the generic instance for `char_p` rings.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

- [x] depends on: #14946 

Some of these results have now far more awkward proofs, because a lot of results come from `splitting_field` and thus its algebra instance. Is this the best solution or is there another way forward? (note in specific the very slow convert on l91)

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
