### PR TITLE
feat(group_theory/subgroup/basic): add center_of_comm_eq_top

### DIFF
--- a/src/group_theory/subgroup/basic.lean
+++ b/src/group_theory/subgroup/basic.lean
@@ -1649,7 +1649,7 @@ def _root_.group.comm_group_of_center_eq_top (h : center G = ⊤) : comm_group G
   .. (_ : group G) }
 
 /-- The center of an abelian group is ⊤ -/
-lemma _root_.group.center_of_comm_eq_top {H : Type*} [group H] (h : ∀ a b : H, a * b = b * a) :
+lemma _root_.group.center_eq_top_of_comm {H : Type*} [group H] (h : ∀ a b : H, a * b = b * a) :
 subgroup.center H = ⊤ :=
 begin
   rw subgroup.eq_top_iff',

--- a/src/group_theory/subgroup/basic.lean
+++ b/src/group_theory/subgroup/basic.lean
@@ -1648,7 +1648,9 @@ def _root_.group.comm_group_of_center_eq_top (h : center G = ⊤) : comm_group G
 { mul_comm := by { rw eq_top_iff' at h, intros x y, exact h y x },
   .. (_ : group G) }
 
-lemma _root_.group.center_eq_top_of_comm {H : Type*} [group H] (h : ∀ a b : H, a * b = b * a) : subgroup.center H = ⊤ :=
+/-- The center of an abelian group is ⊤ -/
+lemma _root_.group.center_eq_top_of_comm {H : Type*} [group H] (h : ∀ a b : H, a * b = b * a) :
+subgroup.center H = ⊤ :=
 begin
   rw subgroup.eq_top_iff',
   intros x y,

--- a/src/group_theory/subgroup/basic.lean
+++ b/src/group_theory/subgroup/basic.lean
@@ -1648,6 +1648,13 @@ def _root_.group.comm_group_of_center_eq_top (h : center G = ⊤) : comm_group G
 { mul_comm := by { rw eq_top_iff' at h, intros x y, exact h y x },
   .. (_ : group G) }
 
+lemma _root_.group.center_eq_top_of_comm {H : Type*} [group H] (h : ∀ a b : H, a * b = b * a) : subgroup.center H = ⊤ :=
+begin
+  rw subgroup.eq_top_iff',
+  intros x y,
+  exact h y x,
+end
+
 variables {G} (H)
 
 section normalizer

--- a/src/group_theory/subgroup/basic.lean
+++ b/src/group_theory/subgroup/basic.lean
@@ -1649,7 +1649,7 @@ def _root_.group.comm_group_of_center_eq_top (h : center G = ⊤) : comm_group G
   .. (_ : group G) }
 
 /-- The center of an abelian group is ⊤ -/
-lemma _root_.group.center_eq_top_of_comm {H : Type*} [group H] (h : ∀ a b : H, a * b = b * a) :
+lemma _root_.group.center_of_comm_eq_top {H : Type*} [group H] (h : ∀ a b : H, a * b = b * a) :
 subgroup.center H = ⊤ :=
 begin
   rw subgroup.eq_top_iff',


### PR DESCRIPTION

---
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)

Hi, I’ve made this modification because I’m trying to prove in Lean that all groups of order p² (p prime) are abelian, and in the proof, I need to use the result that the center of a group cannot have prime index. In the proof of that result, I need the result that the center of an abelian group is top.