### PR TITLE
[Merged by Bors] - feat(analysis/special_functions/trigonometric/angle): topology

### DIFF
--- a/src/analysis/special_functions/trigonometric/angle.lean
+++ b/src/analysis/special_functions/trigonometric/angle.lean
@@ -27,9 +27,18 @@ namespace angle
 instance angle.add_comm_group : add_comm_group angle :=
 quotient_add_group.add_comm_group _
 
+instance : topological_space angle :=
+quotient_add_group.quotient.topological_space _
+
+instance : topological_add_group angle :=
+topological_add_group_quotient _
+
 instance : inhabited angle := ⟨0⟩
 
 instance : has_coe ℝ angle := ⟨quotient_add_group.mk' _⟩
+
+@[continuity] lemma continuous_coe : continuous (coe : ℝ → angle) :=
+continuous_quotient_mk
 
 /-- Coercion `ℝ → angle` as an additive homomorphism. -/
 def coe_hom : ℝ →+ angle := quotient_add_group.mk' _
@@ -149,11 +158,17 @@ def sin (θ : angle) : ℝ := sin_periodic.lift θ
 @[simp] lemma sin_coe (x : ℝ) : sin (x : angle) = real.sin x :=
 rfl
 
+@[continuity] lemma continuous_sin : continuous sin :=
+continuous_quotient_lift_on' _ real.continuous_sin
+
 /-- The cosine of a `real.angle`. -/
 def cos (θ : angle) : ℝ := cos_periodic.lift θ
 
 @[simp] lemma cos_coe (x : ℝ) : cos (x : angle) = real.cos x :=
 rfl
+
+@[continuity] lemma continuous_cos : continuous cos :=
+continuous_quotient_lift_on' _ real.continuous_cos
 
 end angle
 

--- a/src/analysis/special_functions/trigonometric/angle.lean
+++ b/src/analysis/special_functions/trigonometric/angle.lean
@@ -19,19 +19,11 @@ noncomputable theory
 namespace real
 
 /-- The type of angles -/
+@[derive [add_comm_group, topological_space, topological_add_group]]
 def angle : Type :=
 ℝ ⧸ (add_subgroup.zmultiples (2 * π))
 
 namespace angle
-
-instance angle.add_comm_group : add_comm_group angle :=
-quotient_add_group.add_comm_group _
-
-instance : topological_space angle :=
-quotient_add_group.quotient.topological_space _
-
-instance : topological_add_group angle :=
-topological_add_group_quotient _
 
 instance : inhabited angle := ⟨0⟩
 


### PR DESCRIPTION
Give `real.angle` the structure of a `topological_add_group` (rather
than just an `add_comm_group`), so that it's possible to talk about
continuity for functions involving this type, and add associated
continuity lemmas for `coe : ℝ → angle`, `real.angle.sin` and
`real.angle.cos`.



---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
