### PR TITLE
[Merged by Bors] - fix(linear_algebra/{exterior,clifford}_algebra/basic): add some missing namespaces

### DIFF
--- a/src/linear_algebra/clifford_algebra/grading.lean
+++ b/src/linear_algebra/clifford_algebra/grading.lean
@@ -82,7 +82,7 @@ begin
   refine direct_sum.of_eq_of_graded_monoid_eq (sigma.subtype_ext rfl $ ι_sq_scalar _ _),
 end
 
-lemma lift_ι_eq (i' : zmod 2) (x' : even_odd Q i') :
+lemma graded_algebra.lift_ι_eq (i' : zmod 2) (x' : even_odd Q i') :
   lift Q ⟨graded_algebra.ι Q, graded_algebra.ι_sq_scalar Q⟩ x' =
     direct_sum.of (λ i, even_odd Q i) i' x' :=
 begin
@@ -119,7 +119,7 @@ graded_algebra.of_alg_hom (even_odd Q)
       alg_hom.id_apply],
     rw [lift_ι_apply, graded_algebra.ι_apply, direct_sum.coe_alg_hom_of, subtype.coe_mk],
   end)
-  (by exact lift_ι_eq Q)
+  (by exact graded_algebra.lift_ι_eq Q)
 
 lemma supr_ι_range_eq_top : (⨆ i : ℕ, (ι Q).range ^ i) = ⊤ :=
 begin

--- a/src/linear_algebra/exterior_algebra/grading.lean
+++ b/src/linear_algebra/exterior_algebra/grading.lean
@@ -58,7 +58,8 @@ begin
   { rw [alg_hom.commutes, direct_sum.algebra_map_apply], refl },
   { rw [alg_hom.map_add, ihx, ihy, ←map_add], refl },
   { obtain ⟨_, rfl⟩ := hm,
-    rw [alg_hom.map_mul, ih, lift_ι, lift_ι_apply, graded_algebra.ι_apply, direct_sum.of_mul_of],
+    rw [alg_hom.map_mul, ih, graded_algebra.lift_ι, lift_ι_apply, graded_algebra.ι_apply,
+      direct_sum.of_mul_of],
     exact direct_sum.of_eq_of_graded_monoid_eq (sigma.subtype_ext (add_comm _ _) rfl) }
 end
 
@@ -71,7 +72,7 @@ graded_algebra.of_alg_hom _ (graded_algebra.lift_ι R M)
   (begin
     ext m,
     dsimp only [linear_map.comp_apply, alg_hom.to_linear_map_apply, alg_hom.comp_apply,
-      alg_hom.id_apply, lift_ι],
+      alg_hom.id_apply, graded_algebra.lift_ι],
     rw [lift_ι_apply, graded_algebra.ι_apply, direct_sum.coe_alg_hom_of, subtype.coe_mk],
   end)
   (by exact graded_algebra.lift_ι_eq)

--- a/src/linear_algebra/exterior_algebra/grading.lean
+++ b/src/linear_algebra/exterior_algebra/grading.lean
@@ -38,16 +38,17 @@ begin
   refine dfinsupp.single_eq_zero.mpr (subtype.ext $ ι_sq_zero _),
 end
 
-/-- `graded_algebra.ι` lifted to exterior algebra. This is
+/-- `exterior_algebra.graded_algebra.ι` lifted to exterior algebra. This is
 primarily an auxiliary construction used to provide `exterior_algebra.graded_algebra`. -/
-def lift_ι : exterior_algebra R M →ₐ[R]
+def graded_algebra.lift_ι : exterior_algebra R M →ₐ[R]
   ⨁ (i : ℕ), ↥((ι R).range ^ i : submodule R (exterior_algebra R M)) :=
 lift R ⟨graded_algebra.ι R M, graded_algebra.ι_sq_zero R M⟩
 
 variables {R M}
 
-lemma lift_ι_eq (i : ℕ) (x : ((ι R).range ^ i : submodule R (exterior_algebra R M))) :
-  lift_ι R M x =
+lemma graded_algebra.lift_ι_eq (i : ℕ)
+  (x : ((ι R).range ^ i : submodule R (exterior_algebra R M))) :
+  graded_algebra.lift_ι R M x =
     direct_sum.of (λ i, (((ι R).range ^ i : submodule R (exterior_algebra R M)) : Type*)) i x :=
 begin
   cases x with x hx,
@@ -65,7 +66,7 @@ end
 instance graded_algebra :
   graded_algebra
     ((^) (ι R : M →ₗ[R] exterior_algebra R M).range : ℕ → submodule R (exterior_algebra R M)) :=
-graded_algebra.of_alg_hom _ (lift_ι R M)
+graded_algebra.of_alg_hom _ (graded_algebra.lift_ι R M)
   -- the proof from here onward is identical to the `tensor_algebra` case
   (begin
     ext m,
@@ -73,6 +74,6 @@ graded_algebra.of_alg_hom _ (lift_ι R M)
       alg_hom.id_apply, lift_ι],
     rw [lift_ι_apply, graded_algebra.ι_apply, direct_sum.coe_alg_hom_of, subtype.coe_mk],
   end)
-  (by exact lift_ι_eq)
+  (by exact graded_algebra.lift_ι_eq)
 
 end exterior_algebra


### PR DESCRIPTION
These lemmas are about the auxiliary `{exterior,clifford}_algebra.graded_algebra.ι` not `{exterior,clifford}_algebra.ι`, so should have `graded_algebra` in their names.
This is a follow up to #12182

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
