### PR TITLE
[Merged by Bors] - chore(algebra/direct_sum/ring): add new `int_cast` and `nat_cast` fields to match `ring` and `semiring`

### DIFF
--- a/src/algebra/direct_sum/internal.lean
+++ b/src/algebra/direct_sum/internal.lean
@@ -47,12 +47,38 @@ instance add_comm_monoid.of_submonoid_on_semiring [semiring R] [set_like σ R]
   [add_submonoid_class σ R] (A : ι → σ) : ∀ i, add_comm_monoid (A i) :=
 λ i, by apply_instance
 
+instance add_comm_group.of_subgroup_on_semiring [ring R] [set_like σ R]
+  [add_subgroup_class σ R] (A : ι → σ) : ∀ i, add_comm_group (A i) :=
+λ i, by apply_instance
+
 lemma set_like.has_graded_one.algebra_map_mem [has_zero ι]
   [comm_semiring S] [semiring R] [algebra S R]
   (A : ι → submodule S R) [set_like.has_graded_one A] (s : S) : algebra_map S R s ∈ A 0 :=
 begin
   rw algebra.algebra_map_eq_smul_one,
   exact ((A 0).smul_mem s set_like.has_graded_one.one_mem),
+end
+
+lemma set_like.has_graded_one.nat_cast_mem [has_zero ι] [add_monoid_with_one R]
+  [set_like σ R] [add_submonoid_class σ R] (A : ι → σ) [set_like.has_graded_one A] (n : ℕ) :
+  (n : R) ∈ A 0:=
+begin
+  induction n,
+  { rw nat.cast_zero,
+    exact zero_mem (A 0), },
+  { rw nat.cast_succ,
+    exact add_mem n_ih set_like.has_graded_one.one_mem, },
+end
+
+lemma set_like.has_graded_one.int_cast_mem [has_zero ι] [add_group_with_one R]
+  [set_like σ R] [add_subgroup_class σ R] (A : ι → σ) [set_like.has_graded_one A] (z : ℤ) :
+  (z : R) ∈ A 0:=
+begin
+  induction z,
+  { rw int.cast_of_nat,
+    exact set_like.has_graded_one.nat_cast_mem _ _, },
+  { rw int.cast_neg_succ_of_nat,
+    exact neg_mem (set_like.has_graded_one.nat_cast_mem _ _), },
 end
 
 section direct_sum
@@ -81,6 +107,9 @@ instance gsemiring [add_monoid ι] [semiring R] [set_like σ R] [add_submonoid_c
   zero_mul := λ i j _, subtype.ext (zero_mul _),
   mul_add := λ i j _ _ _, subtype.ext (mul_add _ _ _),
   add_mul := λ i j _ _ _, subtype.ext (add_mul _ _ _),
+  nat_cast := λ n, ⟨n, set_like.has_graded_one.nat_cast_mem _ _⟩,
+  nat_cast_zero := subtype.ext nat.cast_zero,
+  nat_cast_succ := λ n, subtype.ext (nat.cast_succ n),
   ..set_like.gmonoid A }
 
 /-- Build a `gcomm_semiring` instance for a collection of additive submonoids. -/
@@ -89,6 +118,22 @@ instance gcomm_semiring [add_comm_monoid ι] [comm_semiring R] [set_like σ R]
   direct_sum.gcomm_semiring (λ i, A i) :=
 { ..set_like.gcomm_monoid A,
   ..set_like.gsemiring A, }
+
+/-- Build a `gring` instance for a collection of additive subgroups. -/
+instance gring [add_monoid ι] [ring R] [set_like σ R] [add_subgroup_class σ R]
+  (A : ι → σ) [set_like.graded_monoid A] :
+  direct_sum.gring (λ i, A i) :=
+{ int_cast := λ z, ⟨z, set_like.has_graded_one.int_cast_mem _ _⟩,
+  int_cast_of_nat := λ n, subtype.ext $ int.cast_of_nat _,
+  int_cast_neg_succ_of_nat := λ n, subtype.ext $ int.cast_neg_succ_of_nat n,
+  ..set_like.gsemiring A }
+
+/-- Build a `gcomm_semiring` instance for a collection of additive submonoids. -/
+instance gcomm_ring [add_comm_monoid ι] [comm_ring R] [set_like σ R]
+  [add_subgroup_class σ R] (A : ι → σ) [set_like.graded_monoid A] :
+  direct_sum.gcomm_ring (λ i, A i) :=
+{ ..set_like.gcomm_monoid A,
+  ..set_like.gring A, }
 
 end set_like
 

--- a/src/algebra/direct_sum/ring.lean
+++ b/src/algebra/direct_sum/ring.lean
@@ -17,25 +17,33 @@ additively-graded ring. The typeclasses are:
 
 * `direct_sum.gnon_unital_non_assoc_semiring A`
 * `direct_sum.gsemiring A`
+* `direct_sum.gring A`
 * `direct_sum.gcomm_semiring A`
+* `direct_sum.gcomm_ring A`
 
 Respectively, these imbue the external direct sum `⨁ i, A i` with:
 
 * `direct_sum.non_unital_non_assoc_semiring`, `direct_sum.non_unital_non_assoc_ring`
-* `direct_sum.semiring`, `direct_sum.ring`
-* `direct_sum.comm_semiring`, `direct_sum.comm_ring`
+* `direct_sum.semiring`
+* `direct_sum.ring`
+* `direct_sum.comm_semiring`
+* `direct_sum.comm_ring`
 
 the base ring `A 0` with:
 
 * `direct_sum.grade_zero.non_unital_non_assoc_semiring`,
   `direct_sum.grade_zero.non_unital_non_assoc_ring`
-* `direct_sum.grade_zero.semiring`, `direct_sum.grade_zero.ring`
-* `direct_sum.grade_zero.comm_semiring`, `direct_sum.grade_zero.comm_ring`
+* `direct_sum.grade_zero.semiring`
+* `direct_sum.grade_zero.ring`
+* `direct_sum.grade_zero.comm_semiring`
+* `direct_sum.grade_zero.comm_ring`
 
 and the `i`th grade `A i` with `A 0`-actions (`•`) defined as left-multiplication:
 
 * `direct_sum.grade_zero.has_scalar (A 0)`, `direct_sum.grade_zero.smul_with_zero (A 0)`
 * `direct_sum.grade_zero.module (A 0)`
+* (nothing)
+* (nothing)
 * (nothing)
 
 Note that in the presence of these instances, `⨁ i, A i` itself inherits an `A 0`-action.
@@ -95,11 +103,24 @@ variables (A : ι → Type*)
 
 /-- A graded version of `semiring`. -/
 class gsemiring [add_monoid ι] [Π i, add_comm_monoid (A i)] extends
-  gnon_unital_non_assoc_semiring A, graded_monoid.gmonoid A
+  gnon_unital_non_assoc_semiring A, graded_monoid.gmonoid A :=
+(nat_cast : ℕ → A 0)
+(nat_cast_zero : nat_cast 0 = 0)
+(nat_cast_succ : ∀ n : ℕ, nat_cast (n + 1) = nat_cast n + graded_monoid.ghas_one.one)
 
 /-- A graded version of `comm_semiring`. -/
 class gcomm_semiring [add_comm_monoid ι] [Π i, add_comm_monoid (A i)] extends
   gsemiring A, graded_monoid.gcomm_monoid A
+
+/-- A graded version of `ring`. -/
+class gring [add_monoid ι] [Π i, add_comm_group (A i)] extends gsemiring A :=
+(int_cast : ℤ → A 0)
+(int_cast_of_nat : ∀ n : ℕ, int_cast n = nat_cast n)
+(int_cast_neg_succ_of_nat : ∀ n : ℕ, int_cast (-(n+1 : ℕ)) = -nat_cast (n+1 : ℕ))
+
+/-- A graded version of `comm_ring`. -/
+class gcomm_ring [add_comm_monoid ι] [Π i, add_comm_group (A i)] extends
+  gring A, gcomm_semiring A
 
 end defs
 
@@ -214,7 +235,9 @@ instance semiring : semiring (⨁ i, A i) :=
   one_mul := one_mul A,
   mul_one := mul_one A,
   mul_assoc := mul_assoc A,
-  ..add_monoid_with_one.unary,
+  nat_cast := λ n, of _ _ (gsemiring.nat_cast n),
+  nat_cast_zero := by rw [gsemiring.nat_cast_zero, map_zero],
+  nat_cast_succ := λ n, by { rw [gsemiring.nat_cast_succ, map_add], refl },
   ..direct_sum.non_unital_non_assoc_semiring _, }
 
 lemma of_pow {i} (a : A i) (n : ℕ) :
@@ -299,7 +322,7 @@ instance non_assoc_ring : non_unital_non_assoc_ring (⨁ i, A i) :=
 end non_unital_non_assoc_ring
 
 section ring
-variables [Π i, add_comm_group (A i)] [add_monoid ι] [gsemiring A]
+variables [Π i, add_comm_group (A i)] [add_monoid ι] [gring A]
 
 /-- The `ring` derived from `gsemiring A`. -/
 instance ring : ring (⨁ i, A i) :=
@@ -308,14 +331,17 @@ instance ring : ring (⨁ i, A i) :=
   zero := 0,
   add := (+),
   neg := has_neg.neg,
+  int_cast := λ z, of _ _ (gring.int_cast z),
+  int_cast_of_nat := λ z, congr_arg _ $ gring.int_cast_of_nat _,
+  int_cast_neg_succ_of_nat := λ z,
+    (congr_arg _ $ gring.int_cast_neg_succ_of_nat _).trans (map_neg _ _),
   ..(direct_sum.semiring _),
   ..(direct_sum.add_comm_group _), }
-
 
 end ring
 
 section comm_ring
-variables [Π i, add_comm_group (A i)] [add_comm_monoid ι] [gcomm_semiring A]
+variables [Π i, add_comm_group (A i)] [add_comm_monoid ι] [gcomm_ring A]
 
 /-- The `comm_ring` derived from `gcomm_semiring A`. -/
 instance comm_ring : comm_ring (⨁ i, A i) :=
@@ -373,12 +399,10 @@ variables [Π i, add_comm_monoid (A i)] [add_monoid ι] [gsemiring A]
 | 0 := by rw [pow_zero, pow_zero, direct_sum.of_zero_one]
 | (n + 1) := by rw [pow_succ, pow_succ, of_zero_mul, of_zero_pow]
 
-instance : has_nat_cast (A 0) := ⟨nat.unary_cast⟩
+instance : has_nat_cast (A 0) := ⟨gsemiring.nat_cast⟩
 
 @[simp] lemma of_nat_cast (n : ℕ) : of A 0 n = n :=
-by induction n; simp [(of A 0).map_zero, (of A 0).map_add, *,
-  show ((0 : ℕ) : A 0) = 0, from rfl,
-  λ n : ℕ, show (n.succ : A 0) = (n : A 0) + 1, from rfl]
+rfl
 
 /-- The `semiring` structure derived from `gsemiring A`. -/
 instance grade_zero.semiring : semiring (A 0) :=
@@ -433,12 +457,12 @@ function.injective.non_unital_non_assoc_ring (of A 0) dfinsupp.single_injective
 end ring
 
 section ring
-variables [Π i, add_comm_group (A i)] [add_monoid ι] [gsemiring A]
+variables [Π i, add_comm_group (A i)] [add_monoid ι] [gring A]
 
-instance : has_int_cast (A 0) := ⟨int.cast_def⟩
+instance : has_int_cast (A 0) := ⟨gring.int_cast⟩
 
 @[simp] lemma of_int_cast (n : ℤ) : of A 0 n = n :=
-show of A 0 n.cast_def = n, by cases n; simp [int.cast_def]
+rfl
 
 /-- The `ring` derived from `gsemiring A`. -/
 instance grade_zero.ring : ring (A 0) :=
@@ -458,7 +482,7 @@ function.injective.ring (of A 0) dfinsupp.single_injective
 end ring
 
 section comm_ring
-variables [Π i, add_comm_group (A i)] [add_comm_monoid ι] [gcomm_semiring A]
+variables [Π i, add_comm_group (A i)] [add_comm_monoid ι] [gcomm_ring A]
 
 /-- The `comm_ring` derived from `gcomm_semiring A`. -/
 instance grade_zero.comm_ring : comm_ring (A 0) :=
@@ -588,7 +612,11 @@ instance non_unital_non_assoc_semiring.direct_sum_gnon_unital_non_assoc_semiring
 /-- A direct sum of copies of a `semiring` inherits the multiplication structure. -/
 instance semiring.direct_sum_gsemiring {R : Type*} [add_monoid ι] [semiring R] :
   direct_sum.gsemiring (λ i : ι, R) :=
-{ ..non_unital_non_assoc_semiring.direct_sum_gnon_unital_non_assoc_semiring ι, ..monoid.gmonoid ι }
+{ nat_cast := λ n, n,
+  nat_cast_zero := nat.cast_zero,
+  nat_cast_succ := nat.cast_succ,
+  ..non_unital_non_assoc_semiring.direct_sum_gnon_unital_non_assoc_semiring ι,
+  ..monoid.gmonoid ι }
 
 open_locale direct_sum
 


### PR DESCRIPTION
This was deliberately left to a follow up in #12182

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
