### PR TITLE
[Merged by Bors] - feat(field_theory/minpoly): generalize statements about GCD domains

### DIFF
--- a/src/field_theory/minpoly.lean
+++ b/src/field_theory/minpoly.lean
@@ -262,8 +262,9 @@ variables {x : B}
 
 variables (A x)
 
-/-- If an element `x` is a root of a nonzero polynomial `p`,
-then the degree of `p` is at least the degree of the minimal polynomial of `x`. -/
+/-- If an element `x` is a root of a nonzero polynomial `p`, then the degree of `p` is at least the
+degree of the minimal polynomial of `x`. See also `gcd_domain_degree_le_of_ne_zero` which relaxes
+the assumptions on `A` in exchange for stronger assumptions on `B`. -/
 lemma degree_le_of_ne_zero
   {p : A[X]} (pnz : p ≠ 0) (hp : polynomial.aeval x p = 0) :
   degree (minpoly A x) ≤ degree p :=
@@ -275,8 +276,9 @@ lemma ne_zero_of_finite_field_extension (e : B) [finite_dimensional A B] : minpo
 minpoly.ne_zero $ is_integral_of_noetherian (is_noetherian.iff_fg.2 infer_instance) _
 
 /-- The minimal polynomial of an element `x` is uniquely characterized by its defining property:
-if there is another monic polynomial of minimal degree that has `x` as a root,
-then this polynomial is equal to the minimal polynomial of `x`. -/
+if there is another monic polynomial of minimal degree that has `x` as a root, then this polynomial
+is equal to the minimal polynomial of `x`. See also `minpoly.gcd_unique` which relaxes the
+assumptions on `A` in exchange for stronger assumptions on `B`. -/
 lemma unique {p : A[X]}
   (pmonic : p.monic) (hp : polynomial.aeval x p = 0)
   (pmin : ∀ q : A[X], q.monic → polynomial.aeval x q = 0 → degree p ≤ degree q) :
@@ -293,8 +295,9 @@ begin
       (pmin (minpoly A x) (monic hx) (aeval A x)) }
 end
 
-/-- If an element `x` is a root of a polynomial `p`,
-then the minimal polynomial of `x` divides `p`. -/
+/-- If an element `x` is a root of a polynomial `p`, then the minimal polynomial of `x` divides `p`.
+See also `minpoly.gcd_domain_dvd` which relaxes the assumptions on `A` in exchange for stronger
+assumptions on `B`. -/
 lemma dvd {p : A[X]} (hp : polynomial.aeval x p = 0) : minpoly A x ∣ p :=
 begin
   by_cases hp0 : p = 0,
@@ -422,7 +425,8 @@ end
 variable [no_zero_smul_divisors R S]
 
 /-- For GCD domains, the minimal polynomial divides any primitive polynomial that has the integral
-element as root. -/
+element as root. See also `minpoly.dvd` which relaxes the assumptions on `S` in exchange for
+stronger assumptions on `R`. -/
 lemma gcd_domain_dvd {P : R[X]} (hP : P ≠ 0) (hroot : polynomial.aeval s P = 0) : minpoly R s ∣ P :=
 begin
   let K := fraction_ring R,
@@ -440,6 +444,9 @@ begin
     eval_map, ← aeval_def, aeval_prim_part_eq_zero hP hroot, map_zero]
 end
 
+/-- If an element `x` is a root of a nonzero polynomial `p`, then the degree of `p` is at least the
+degree of the minimal polynomial of `x`. See also `minpoly.degree_le_of_ne_zero` which relaxes the
+assumptions on `S` in exchange for stronger assumptions on `R`. -/
 lemma gcd_domain_degree_le_of_ne_zero {p : R[X]} (hp0 : p ≠ 0) (hp : polynomial.aeval s p = 0) :
   degree (minpoly R s) ≤ degree p :=
 begin
@@ -450,8 +457,10 @@ end
 
 omit hs
 
-/-- See also `minpoly.unique` which relaxes the assumptions on `S`
-in exchange for stronger assumptions on `R`. -/
+/-- The minimal polynomial of an element `x` is uniquely characterized by its defining property:
+if there is another monic polynomial of minimal degree that has `x` as a root, then this polynomial
+is equal to the minimal polynomial of `x`. See also `minpoly.unique` which relaxes the
+assumptions on `S` in exchange for stronger assumptions on `R`. -/
 lemma gcd_domain_unique {P : R[X]} (hmo : P.monic) (hP : polynomial.aeval s P = 0)
   (Pmin : ∀ Q : R[X], Q.monic → polynomial.aeval s Q = 0 → degree P ≤ degree Q) :
   P = minpoly R s :=

--- a/src/field_theory/minpoly.lean
+++ b/src/field_theory/minpoly.lean
@@ -398,13 +398,24 @@ over the fraction field. -/
 lemma gcd_domain_eq_field_fractions :
   minpoly K (algebra_map S L s) = (minpoly R s).map (algebra_map R K) :=
 begin
-  symmetry,
-  refine eq_of_irreducible_of_monic _ _ _,
+  refine (eq_of_irreducible_of_monic _ _ _).symm,
   { exact (polynomial.is_primitive.irreducible_iff_irreducible_map_fraction_map
       (polynomial.monic.is_primitive (monic hs))).1 (irreducible hs) },
    { rw [aeval_map, aeval_def, is_scalar_tower.algebra_map_eq R S L, ← eval₂_map, eval₂_at_apply,
       eval_map, ← aeval_def, aeval, map_zero] },
   { exact (monic hs).map _ }
+end
+
+/-- For GCD domains, the minimal polynomial over the ring is the same as the minimal polynomial
+over the fraction field. Compared to `gcd_domain_eq_field_fractions`, this version is useful if
+the element is in a ring that is already a `K`-algebra. -/
+lemma gcd_domain_eq_field_fractions' [algebra K S] [is_scalar_tower R K S] :
+  minpoly K s = (minpoly R s).map (algebra_map R K) :=
+begin
+  let L := fraction_ring S,
+  rw [← gcd_domain_eq_field_fractions K L hs],
+  refine minpoly.eq_of_algebra_map_eq (is_fraction_ring.injective S L)
+    (is_integral_of_is_scalar_tower _ hs) rfl
 end
 
 /-- For GCD domains, the minimal polynomial divides any primitive polynomial that has the integral
@@ -417,7 +428,7 @@ begin
   haveI : no_zero_smul_divisors R L,
   { refine no_zero_smul_divisors.iff_algebra_map_injective.2 _,
     rw [is_scalar_tower.algebra_map_eq R S L],
-    refine (is_fraction_ring.injective S L).comp hinj },
+    exact (is_fraction_ring.injective S L).comp hinj },
   let P₁ := P.prim_part,
   suffices : minpoly R s ∣ P₁,
   { exact dvd_trans this (prim_part_dvd _) },

--- a/src/field_theory/minpoly.lean
+++ b/src/field_theory/minpoly.lean
@@ -458,6 +458,8 @@ begin
   exact nat_degree_le_of_dvd (gcd_domain_dvd hs hinj hp0 hp) hp0
 end
 
+omit hs
+
 lemma gcd_domain_unique (hinj : function.injective (algebra_map R S)) {P : R[X]} (hmo : P.monic)
   (hP : polynomial.aeval s P = 0)
   (Pmin : ∀ Q : R[X], Q.monic → polynomial.aeval s Q = 0 → degree P ≤ degree Q) :

--- a/src/field_theory/minpoly.lean
+++ b/src/field_theory/minpoly.lean
@@ -394,7 +394,8 @@ variables {R S : Type*} (K L : Type*) [comm_ring R] [is_domain R] [normalized_gc
 include hs
 
 /-- For GCD domains, the minimal polynomial over the ring is the same as the minimal polynomial
-over the fraction field. -/
+over the fraction field. See `minpoly.gcd_domain_eq_field_fractions'` if `S` is already a
+`K`-algebra. -/
 lemma gcd_domain_eq_field_fractions :
   minpoly K (algebra_map S L s) = (minpoly R s).map (algebra_map R K) :=
 begin
@@ -407,8 +408,8 @@ begin
 end
 
 /-- For GCD domains, the minimal polynomial over the ring is the same as the minimal polynomial
-over the fraction field. Compared to `gcd_domain_eq_field_fractions`, this version is useful if
-the element is in a ring that is already a `K`-algebra. -/
+over the fraction field. Compared to `minpoly.gcd_domain_eq_field_fractions`, this version is useful
+if the element is in a ring that is already a `K`-algebra. -/
 lemma gcd_domain_eq_field_fractions' [algebra K S] [is_scalar_tower R K S] :
   minpoly K s = (minpoly R s).map (algebra_map R K) :=
 begin

--- a/src/field_theory/minpoly.lean
+++ b/src/field_theory/minpoly.lean
@@ -263,9 +263,8 @@ variables {x : B}
 variables (A x)
 
 /-- If an element `x` is a root of a nonzero polynomial `p`,
-then the degree of `p` is at least the degree of the minimal polynomial of `x`. This version
-works over a field, see `minpoly.degree_le_of_ne_zero` for a more general result. -/
-lemma degree_le_of_ne_zero_aux
+then the degree of `p` is at least the degree of the minimal polynomial of `x`. -/
+lemma degree_le_of_ne_zero
   {p : A[X]} (pnz : p ≠ 0) (hp : polynomial.aeval x p = 0) :
   degree (minpoly A x) ≤ degree p :=
 calc degree (minpoly A x) ≤ degree (p * C (leading_coeff p)⁻¹) :
@@ -277,9 +276,8 @@ minpoly.ne_zero $ is_integral_of_noetherian (is_noetherian.iff_fg.2 infer_instan
 
 /-- The minimal polynomial of an element `x` is uniquely characterized by its defining property:
 if there is another monic polynomial of minimal degree that has `x` as a root,
-then this polynomial is equal to the minimal polynomial of `x`. This version
-works over a field, see `minpoly.unique` for a more general result. -/
-lemma unique_aux {p : A[X]}
+then this polynomial is equal to the minimal polynomial of `x`. -/
+lemma unique {p : A[X]}
   (pmonic : p.monic) (hp : polynomial.aeval x p = 0)
   (pmin : ∀ q : A[X], q.monic → polynomial.aeval x q = 0 → degree p ≤ degree q) :
   p = minpoly A x :=
@@ -287,7 +285,7 @@ begin
   have hx : is_integral A x := ⟨p, pmonic, hp⟩,
   symmetry, apply eq_of_sub_eq_zero,
   by_contra hnz,
-  have := degree_le_of_ne_zero_aux A x hnz (by simp [hp]),
+  have := degree_le_of_ne_zero A x hnz (by simp [hp]),
   contrapose! this,
   apply degree_sub_lt _ (ne_zero hx),
   { rw [(monic hx).leading_coeff, pmonic.leading_coeff] },
@@ -295,9 +293,9 @@ begin
       (pmin (minpoly A x) (monic hx) (aeval A x)) }
 end
 
-/-- If an element `x` is a root of a polynomial `p`,then the minimal polynomial of `x` divides `p`.
-This version works over a field, see `minpoly.dvd` for a more general result. -/
-lemma dvd_aux {p : A[X]} (hp : polynomial.aeval x p = 0) : minpoly A x ∣ p :=
+/-- If an element `x` is a root of a polynomial `p`,
+then the minimal polynomial of `x` divides `p`. -/
+lemma dvd {p : A[X]} (hp : polynomial.aeval x p = 0) : minpoly A x ∣ p :=
 begin
   by_cases hp0 : p = 0,
   { simp only [hp0, dvd_zero] },
@@ -305,7 +303,7 @@ begin
   { rw ← is_algebraic_iff_is_integral, exact ⟨p, hp0, hp⟩ },
   rw ← dvd_iff_mod_by_monic_eq_zero (monic hx),
   by_contra hnz,
-  have := degree_le_of_ne_zero_aux A x hnz _,
+  have := degree_le_of_ne_zero A x hnz _,
   { contrapose! this,
     exact degree_mod_by_monic_lt _ (monic hx) },
   { rw ← mod_by_monic_add_div p (monic hx) at hp,
@@ -315,7 +313,7 @@ end
 lemma dvd_map_of_is_scalar_tower (A K : Type*) {R : Type*} [comm_ring A] [field K] [comm_ring R]
   [algebra A K] [algebra A R] [algebra K R] [is_scalar_tower A K R] (x : R) :
   minpoly K x ∣ (minpoly A x).map (algebra_map A K) :=
-by { refine minpoly.dvd_aux K x _, rw [← is_scalar_tower.aeval_apply, minpoly.aeval] }
+by { refine minpoly.dvd K x _, rw [← is_scalar_tower.aeval_apply, minpoly.aeval] }
 
 /-- If `y` is a conjugate of `x` over a field `K`, then it is a conjugate over a subring `R`. -/
 lemma aeval_of_is_scalar_tower (R : Type*) {K T U : Type*} [comm_ring R] [field K] [comm_ring T]
@@ -332,7 +330,7 @@ variables {A x}
 theorem eq_of_irreducible_of_monic
   [nontrivial B] {p : A[X]} (hp1 : _root_.irreducible p)
   (hp2 : polynomial.aeval x p = 0) (hp3 : p.monic) : p = minpoly A x :=
-let ⟨q, hq⟩ := dvd_aux A x hp2 in
+let ⟨q, hq⟩ := dvd A x hp2 in
 eq_of_monic_of_associated hp3 (monic ⟨p, ⟨hp3, hp2⟩⟩) $
 mul_one (minpoly A x) ▸ hq.symm ▸ associated.mul_left _ $
 associated_one_iff_is_unit.2 $ (hp1.is_unit_or_is_unit hq).resolve_left $ not_is_unit A x
@@ -359,7 +357,7 @@ lemma eq_of_algebra_map_eq {K S T : Type*} [field K] [comm_ring S] [comm_ring T]
   [is_scalar_tower K S T] (hST : function.injective (algebra_map S T))
   {x : S} {y : T} (hx : is_integral K x) (h : y = algebra_map S T x) :
   minpoly K x = minpoly K y :=
-minpoly.unique_aux _ _ (minpoly.monic hx)
+minpoly.unique _ _ (minpoly.monic hx)
   (by rw [h, ← is_scalar_tower.algebra_map_aeval, minpoly.aeval, ring_hom.map_zero])
   (λ q q_monic root_q, minpoly.min _ _ q_monic
     (is_scalar_tower.aeval_eq_zero_of_aeval_algebra_map_eq_zero K S T hST
@@ -369,7 +367,7 @@ lemma add_algebra_map {B : Type*} [comm_ring B] [algebra A B] {x : B}
   (hx : is_integral A x) (a : A) :
   minpoly A (x + (algebra_map A B a)) = (minpoly A x).comp (X - C a) :=
 begin
-  refine (minpoly.unique_aux _ _ ((minpoly.monic hx).comp_X_sub_C _) _ (λ q qmo hq, _)).symm,
+  refine (minpoly.unique _ _ ((minpoly.monic hx).comp_X_sub_C _) _ (λ q qmo hq, _)).symm,
   { simp [aeval_comp] },
   { have : (polynomial.aeval x) (q.comp (X + C a)) = 0 := by simpa [aeval_comp] using hq,
     have H := minpoly.min A x (qmo.comp_X_add_C _) this,
@@ -421,22 +419,24 @@ begin
     (is_integral_of_is_scalar_tower _ hs) rfl
 end
 
-variables [no_zero_smul_divisors R S] (R s)
-
 /-- For GCD domains, the minimal polynomial divides any primitive polynomial that has the integral
 element as root. -/
-lemma dvd {P : R[X]} (hP : P ≠ 0) (hroot : polynomial.aeval s P = 0) :
-  minpoly R s ∣ P :=
+lemma gcd_domain_dvd (hinj : function.injective (algebra_map R S))
+  {P : R[X]} (hP : P ≠ 0) (hroot : polynomial.aeval s P = 0) : minpoly R s ∣ P :=
 begin
   let K := fraction_ring R,
   let L := fraction_ring S,
+  haveI : no_zero_smul_divisors R L,
+  { refine no_zero_smul_divisors.iff_algebra_map_injective.2 _,
+    rw [is_scalar_tower.algebra_map_eq R S L],
+    exact (is_fraction_ring.injective S L).comp hinj },
   let P₁ := P.prim_part,
   suffices : minpoly R s ∣ P₁,
   { exact dvd_trans this (prim_part_dvd _) },
   have hP₁ : polynomial.aeval s P₁ = 0,
   { rw [eq_C_content_mul_prim_part P, map_mul, aeval_C] at hroot,
     have hcont : P.content ≠ 0 := λ h, hP (content_eq_zero_iff.1 h),
-    replace hcont := function.injective.ne (no_zero_smul_divisors.algebra_map_injective R S) hcont,
+    replace hcont := function.injective.ne hinj hcont,
     rw [map_zero] at hcont,
     exact eq_zero_of_ne_zero_of_mul_left_eq_zero hcont hroot },
   apply (is_primitive.dvd_iff_fraction_map_dvd_fraction_map K (monic hs).is_primitive
@@ -444,29 +444,31 @@ begin
   let y := algebra_map S L s,
   have hy : is_integral R y := hs.algebra_map,
   rw [← gcd_domain_eq_field_fractions K L hs],
-  refine dvd_aux _ _ _,
+  refine dvd _ _ _,
   rw [aeval_map, aeval_def, is_scalar_tower.algebra_map_eq R S L, ← eval₂_map, eval₂_at_apply,
     eval_map, ← aeval_def, hP₁, map_zero]
 end
 
-lemma degree_le_of_ne_zero {p : R[X]} (hp0 : p ≠ 0) (hp : polynomial.aeval s p = 0) :
+lemma gcd_domain_degree_le_of_ne_zero (hinj : function.injective (algebra_map R S))
+  {p : R[X]} (hp0 : p ≠ 0) (hp : polynomial.aeval s p = 0) :
   degree (minpoly R s) ≤ degree p :=
 begin
   rw [degree_eq_nat_degree (minpoly.ne_zero hs), degree_eq_nat_degree hp0],
   norm_cast,
-  exact nat_degree_le_of_dvd (dvd R s hs hp0 hp) hp0
+  exact nat_degree_le_of_dvd (gcd_domain_dvd hs hinj hp0 hp) hp0
 end
 
 omit hs
 
-lemma unique {P : R[X]} (hmo : P.monic) (hP : polynomial.aeval s P = 0)
+lemma gcd_domain_unique (hinj : function.injective (algebra_map R S)) {P : R[X]} (hmo : P.monic)
+  (hP : polynomial.aeval s P = 0)
   (Pmin : ∀ Q : R[X], Q.monic → polynomial.aeval s Q = 0 → degree P ≤ degree Q) :
   P = minpoly R s :=
 begin
   have hs : is_integral R s := ⟨P, hmo, hP⟩,
   symmetry, apply eq_of_sub_eq_zero,
   by_contra hnz,
-  have := degree_le_of_ne_zero R s hs hnz (by simp [hP]),
+  have := gcd_domain_degree_le_of_ne_zero hs hinj hnz (by simp [hP]),
   contrapose! this,
   refine degree_sub_lt _ (ne_zero hs) _,
   { exact le_antisymm (min R s hmo hP)
@@ -509,7 +511,7 @@ begin
   rintros p q ⟨d, h⟩,
   have :    polynomial.aeval x (p*q) = 0 := by simp [h, aeval A x],
   replace : polynomial.aeval x p = 0 ∨ polynomial.aeval x q = 0 := by simpa,
-  exact or.imp (dvd_aux A x) (dvd_aux A x) this
+  exact or.imp (dvd A x) (dvd A x) this
 end
 
 /-- If `L/K` is a field extension and an element `y` of `K` is a root of the minimal polynomial

--- a/src/field_theory/minpoly.lean
+++ b/src/field_theory/minpoly.lean
@@ -450,6 +450,8 @@ end
 
 omit hs
 
+/-- See also `minpoly.unique` which relaxes the assumptions on `S`
+in exchange for stronger assumptions on `R`. -/
 lemma gcd_domain_unique {P : R[X]} (hmo : P.monic) (hP : polynomial.aeval s P = 0)
   (Pmin : ∀ Q : R[X], Q.monic → polynomial.aeval s Q = 0 → degree P ≤ degree Q) :
   P = minpoly R s :=

--- a/src/number_theory/cyclotomic/discriminant.lean
+++ b/src/number_theory/cyclotomic/discriminant.lean
@@ -44,9 +44,9 @@ begin
     (λ i j, to_matrix_is_integral H₁ _ _ _ _)
     (λ i j, to_matrix_is_integral H₂ _ _ _ _),
   { exact hζ.is_integral n.pos },
-  { refine minpoly.gcd_domain_eq_field_fractions _ (hζ.is_integral n.pos) },
+  { refine minpoly.gcd_domain_eq_field_fractions' _ (hζ.is_integral n.pos) },
   { exact is_integral_sub (hζ.is_integral n.pos) is_integral_one },
-  { refine minpoly.gcd_domain_eq_field_fractions _ _,
+  { refine minpoly.gcd_domain_eq_field_fractions' _ _,
     exact is_integral_sub (hζ.is_integral n.pos) is_integral_one }
 end
 

--- a/src/number_theory/cyclotomic/rat.lean
+++ b/src/number_theory/cyclotomic/rat.lean
@@ -104,7 +104,7 @@ begin
     rw [← hz, ← is_scalar_tower.algebra_map_apply],
     exact subalgebra.algebra_map_mem  _ _ },
   { have hmin : (minpoly ℤ B.gen).is_eisenstein_at (submodule.span ℤ {((p : ℕ) : ℤ)}),
-    { have h₁ := minpoly.gcd_domain_eq_field_fractions ℚ hint,
+    { have h₁ := minpoly.gcd_domain_eq_field_fractions' ℚ hint,
       have h₂ := hζ.minpoly_sub_one_eq_cyclotomic_comp
         (cyclotomic.irreducible_rat (p ^ _).pos),
       rw [is_primitive_root.sub_one_power_basis_gen] at h₁,

--- a/src/ring_theory/polynomial/content.lean
+++ b/src/ring_theory/polynomial/content.lean
@@ -275,6 +275,28 @@ end
 lemma prim_part_dvd (p : R[X]) : p.prim_part ∣ p :=
 dvd.intro_left (C p.content) p.eq_C_content_mul_prim_part.symm
 
+lemma aeval_prim_part_eq_zero {S : Type*} [ring S] [is_domain S] [algebra R S]
+  [no_zero_smul_divisors R S] {p : R[X]} {s : S} (hpzero : p ≠ 0) (hp : aeval s p = 0) :
+  aeval s p.prim_part = 0 :=
+begin
+  rw [eq_C_content_mul_prim_part p, map_mul, aeval_C] at hp,
+  have hcont : p.content ≠ 0 := λ h, hpzero (content_eq_zero_iff.1 h),
+  replace hcont := function.injective.ne (no_zero_smul_divisors.algebra_map_injective R S) hcont,
+  rw [map_zero] at hcont,
+  exact eq_zero_of_ne_zero_of_mul_left_eq_zero hcont hp
+end
+
+lemma eval₂_prim_part_eq_zero {S : Type*} [comm_ring S] [is_domain S] {f : R →+* S}
+  (hinj : function.injective f) {p : R[X]} {s : S} (hpzero : p ≠ 0)
+  (hp : eval₂ f s p = 0) : eval₂ f s p.prim_part = 0 :=
+begin
+  rw [eq_C_content_mul_prim_part p, eval₂_mul, eval₂_C] at hp,
+  have hcont : p.content ≠ 0 := λ h, hpzero (content_eq_zero_iff.1 h),
+  replace hcont := function.injective.ne hinj hcont,
+  rw [map_zero] at hcont,
+  exact eq_zero_of_ne_zero_of_mul_left_eq_zero hcont hp
+end
+
 end prim_part
 
 lemma gcd_content_eq_of_dvd_sub {a : R} {p q : R[X]} (h : C a ∣ p - q) :

--- a/src/ring_theory/polynomial/cyclotomic/basic.lean
+++ b/src/ring_theory/polynomial/cyclotomic/basic.lean
@@ -858,7 +858,7 @@ lemma cyclotomic_eq_minpoly_rat {n : ℕ} {K : Type*} [field K] {μ : K}
   cyclotomic n ℚ = minpoly ℚ μ :=
 begin
   rw [← map_cyclotomic_int, cyclotomic_eq_minpoly h hpos],
-  simpa using (minpoly.gcd_domain_eq_field_fractions' ℚ (is_integral h hpos)).symm
+  exact (minpoly.gcd_domain_eq_field_fractions' _ (is_integral h hpos)).symm
 end
 
 /-- `cyclotomic n ℤ` is irreducible. -/

--- a/src/ring_theory/polynomial/cyclotomic/basic.lean
+++ b/src/ring_theory/polynomial/cyclotomic/basic.lean
@@ -828,7 +828,8 @@ lemma _root_.is_primitive_root.minpoly_dvd_cyclotomic {n : ℕ} {K : Type*} [fie
   (h : is_primitive_root μ n) (hpos : 0 < n) [char_zero K] :
   minpoly ℤ μ ∣ cyclotomic n ℤ :=
 begin
-  apply minpoly.gcd_domain_dvd ℚ (is_integral h hpos) (cyclotomic.monic n ℤ).is_primitive,
+  apply minpoly.gcd_domain_dvd (is_integral h hpos) (algebra_map ℤ K).injective_int
+    (cyclotomic_ne_zero n ℤ),
   simpa [aeval_def, eval₂_eq_eval_map, is_root.def] using is_root_cyclotomic hpos h
 end
 
@@ -857,7 +858,7 @@ lemma cyclotomic_eq_minpoly_rat {n : ℕ} {K : Type*} [field K] {μ : K}
   cyclotomic n ℚ = minpoly ℚ μ :=
 begin
   rw [← map_cyclotomic_int, cyclotomic_eq_minpoly h hpos],
-  exact (minpoly.gcd_domain_eq_field_fractions _ (is_integral h hpos)).symm
+  simpa using (minpoly.gcd_domain_eq_field_fractions ℚ K (is_integral h hpos)).symm
 end
 
 /-- `cyclotomic n ℤ` is irreducible. -/
@@ -950,9 +951,8 @@ begin
   { have hpos := nat.mul_pos hzero hp.pos,
     have hprim := complex.is_primitive_root_exp _ hpos.ne.symm,
     rw [cyclotomic_eq_minpoly hprim hpos],
-    refine @minpoly.gcd_domain_dvd ℤ ℂ ℚ _ _ _ _ _ _ _ _ complex.algebra (algebra_int ℂ) _ _
-      (is_primitive_root.is_integral hprim hpos) _ ((cyclotomic.monic n ℤ).expand
-      hp.pos).is_primitive _,
+    refine minpoly.gcd_domain_dvd (hprim.is_integral hpos) (algebra_map ℤ ℂ).injective_int
+      ((cyclotomic.monic n ℤ).expand hp.pos).ne_zero _,
     rw [aeval_def, ← eval_map, map_expand, map_cyclotomic, expand_eval,
         ← is_root.def, is_root_cyclotomic_iff],
     { convert is_primitive_root.pow_of_dvd hprim hp.ne_zero (dvd_mul_left p n),

--- a/src/ring_theory/polynomial/cyclotomic/basic.lean
+++ b/src/ring_theory/polynomial/cyclotomic/basic.lean
@@ -858,7 +858,7 @@ lemma cyclotomic_eq_minpoly_rat {n : ℕ} {K : Type*} [field K] {μ : K}
   cyclotomic n ℚ = minpoly ℚ μ :=
 begin
   rw [← map_cyclotomic_int, cyclotomic_eq_minpoly h hpos],
-  simpa using (minpoly.gcd_domain_eq_field_fractions ℚ K (is_integral h hpos)).symm
+  simpa using (minpoly.gcd_domain_eq_field_fractions' ℚ (is_integral h hpos)).symm
 end
 
 /-- `cyclotomic n ℤ` is irreducible. -/

--- a/src/ring_theory/polynomial/cyclotomic/basic.lean
+++ b/src/ring_theory/polynomial/cyclotomic/basic.lean
@@ -828,8 +828,7 @@ lemma _root_.is_primitive_root.minpoly_dvd_cyclotomic {n : ℕ} {K : Type*} [fie
   (h : is_primitive_root μ n) (hpos : 0 < n) [char_zero K] :
   minpoly ℤ μ ∣ cyclotomic n ℤ :=
 begin
-  apply minpoly.gcd_domain_dvd (is_integral h hpos) (algebra_map ℤ K).injective_int
-    (cyclotomic_ne_zero n ℤ),
+  apply minpoly.gcd_domain_dvd (is_integral h hpos) (cyclotomic_ne_zero n ℤ),
   simpa [aeval_def, eval₂_eq_eval_map, is_root.def] using is_root_cyclotomic hpos h
 end
 
@@ -951,7 +950,7 @@ begin
   { have hpos := nat.mul_pos hzero hp.pos,
     have hprim := complex.is_primitive_root_exp _ hpos.ne.symm,
     rw [cyclotomic_eq_minpoly hprim hpos],
-    refine minpoly.gcd_domain_dvd (hprim.is_integral hpos) (algebra_map ℤ ℂ).injective_int
+    refine minpoly.gcd_domain_dvd (hprim.is_integral hpos)
       ((cyclotomic.monic n ℤ).expand hp.pos).ne_zero _,
     rw [aeval_def, ← eval_map, map_expand, map_cyclotomic, expand_eval,
         ← is_root.def, is_root_cyclotomic_iff],

--- a/src/ring_theory/polynomial/eisenstein.lean
+++ b/src/ring_theory/polynomial/eisenstein.lean
@@ -317,7 +317,7 @@ begin
   have finrank_K_L : finite_dimensional.finrank K L = B.dim := B.finrank,
   have deg_K_P : (minpoly K B.gen).nat_degree = B.dim := B.nat_degree_minpoly,
   have deg_R_P : P.nat_degree = B.dim,
-  { rw [← deg_K_P, minpoly.gcd_domain_eq_field_fractions K hBint,
+  { rw [← deg_K_P, minpoly.gcd_domain_eq_field_fractions' K hBint,
         (minpoly.monic hBint).nat_degree_map (algebra_map R K)] },
   choose! f hf using hei.is_weakly_eisenstein_at.exists_mem_adjoin_mul_eq_pow_nat_degree_le
     (minpoly.aeval R B.gen) (minpoly.monic hBint),
@@ -359,7 +359,7 @@ begin
   ... = _ : _,
   { simp only [algebra.smul_def, algebra_map_apply R K L, algebra.norm_algebra_map, _root_.map_mul,
       _root_.map_pow, finrank_K_L, power_basis.norm_gen_eq_coeff_zero_minpoly,
-      minpoly.gcd_domain_eq_field_fractions K hBint, coeff_map, ← hn],
+      minpoly.gcd_domain_eq_field_fractions' K hBint, coeff_map, ← hn],
     ring_exp },
   swap, { simp_rw [← smul_sum, ← smul_sub, algebra.smul_def p, algebra_map_apply R K L,
       _root_.map_mul, algebra.norm_algebra_map, finrank_K_L, hr, ← hn] },
@@ -493,7 +493,7 @@ begin
     rw [nat.succ_eq_add_one, add_assoc, ← nat.add_sub_assoc H, ← add_assoc, add_comm (j + 1),
       nat.add_sub_add_left, ← nat.add_sub_assoc, nat.add_sub_add_left, hP,
       ← (minpoly.monic hBint).nat_degree_map  (algebra_map R K),
-      ← minpoly.gcd_domain_eq_field_fractions K hBint, nat_degree_minpoly, hn, nat.sub_one,
+      ← minpoly.gcd_domain_eq_field_fractions' K hBint, nat_degree_minpoly, hn, nat.sub_one,
       nat.pred_succ],
     linarith },
 
@@ -531,7 +531,7 @@ begin
     rw [algebra.smul_def, mul_assoc, ← mul_sub, _root_.map_mul, algebra_map_apply R K L, map_pow,
       algebra.norm_algebra_map, _root_.map_mul, algebra_map_apply R K L, algebra.norm_algebra_map,
       finrank B, ← hr,
-      power_basis.norm_gen_eq_coeff_zero_minpoly, minpoly.gcd_domain_eq_field_fractions K hBint,
+      power_basis.norm_gen_eq_coeff_zero_minpoly, minpoly.gcd_domain_eq_field_fractions' K hBint,
       coeff_map, show (-1 : K) = algebra_map R K (-1), by simp, ← map_pow, ← map_pow,
       ← _root_.map_mul, ← map_pow, ← _root_.map_mul, ← map_pow, ← _root_.map_mul] at hQ,
 

--- a/src/ring_theory/roots_of_unity.lean
+++ b/src/ring_theory/roots_of_unity.lean
@@ -958,7 +958,6 @@ lemma minpoly_dvd_X_pow_sub_one : minpoly ℤ μ ∣ X ^ n - 1 :=
 begin
   by_cases hpos : n = 0, { simp [hpos], },
   apply minpoly.gcd_domain_dvd (is_integral h (nat.pos_of_ne_zero hpos))
-    (algebra_map ℤ K).injective_int
     (monic_X_pow_sub_C 1 (ne_of_lt (nat.pos_of_ne_zero hpos)).symm).ne_zero,
   simp only [((is_primitive_root.iff_def μ n).mp h).left, aeval_X_pow, ring_hom.eq_int_cast,
   int.cast_one, aeval_one, alg_hom.map_sub, sub_self]
@@ -991,7 +990,7 @@ lemma minpoly_dvd_expand {p : ℕ} (hprime : nat.prime p) (hdiv : ¬ p ∣ n) :
 begin
   by_cases hn : n = 0, { simp * at *, },
   have hpos := nat.pos_of_ne_zero hn,
-  refine minpoly.gcd_domain_dvd (h.is_integral hpos) (algebra_map ℤ K).injective_int _ _,
+  refine minpoly.gcd_domain_dvd (h.is_integral hpos) _ _,
   { apply monic.ne_zero,
     rw [polynomial.monic, leading_coeff, nat_degree_expand, mul_comm, coeff_expand_mul'
         (nat.prime.pos hprime), ← leading_coeff, ← polynomial.monic],

--- a/src/ring_theory/roots_of_unity.lean
+++ b/src/ring_theory/roots_of_unity.lean
@@ -957,8 +957,9 @@ omit hpos
 lemma minpoly_dvd_X_pow_sub_one : minpoly ℤ μ ∣ X ^ n - 1 :=
 begin
   by_cases hpos : n = 0, { simp [hpos], },
-  apply minpoly.gcd_domain_dvd ℚ (is_integral h (nat.pos_of_ne_zero hpos))
-    (polynomial.monic.is_primitive (monic_X_pow_sub_C 1 (ne_of_lt (nat.pos_of_ne_zero hpos)).symm)),
+  apply minpoly.gcd_domain_dvd (is_integral h (nat.pos_of_ne_zero hpos))
+    (algebra_map ℤ K).injective_int
+    (monic_X_pow_sub_C 1 (ne_of_lt (nat.pos_of_ne_zero hpos)).symm).ne_zero,
   simp only [((is_primitive_root.iff_def μ n).mp h).left, aeval_X_pow, ring_hom.eq_int_cast,
   int.cast_one, aeval_one, alg_hom.map_sub, sub_self]
 end
@@ -990,8 +991,8 @@ lemma minpoly_dvd_expand {p : ℕ} (hprime : nat.prime p) (hdiv : ¬ p ∣ n) :
 begin
   by_cases hn : n = 0, { simp * at *, },
   have hpos := nat.pos_of_ne_zero hn,
-  apply minpoly.gcd_domain_dvd ℚ (h.is_integral hpos),
-  { apply monic.is_primitive,
+  refine minpoly.gcd_domain_dvd (h.is_integral hpos) (algebra_map ℤ K).injective_int _ _,
+  { apply monic.ne_zero,
     rw [polynomial.monic, leading_coeff, nat_degree_expand, mul_comm, coeff_expand_mul'
         (nat.prime.pos hprime), ← leading_coeff, ← polynomial.monic],
     exact minpoly.monic (is_integral (pow_of_prime h hprime hdiv) hpos) },


### PR DESCRIPTION
Currently, the statements about the minimal polynomial over a GCD domain `R` require the element to be in a `K`-algebra, where `K` is the fraction field of `R`. We remove this assumption.

From flt-regular.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
