### PR TITLE
[Merged by Bors] - refactor(order/upper_lower): Reverse the order on `upper_set`

### DIFF
--- a/src/order/upper_lower.lean
+++ b/src/order/upper_lower.lean
@@ -332,7 +332,7 @@ protected lemma compl_inf (s t : lower_set α) : (s ⊓ t).compl = s.compl ⊓ t
 upper_set.ext compl_inf
 protected lemma compl_top : (⊤ : lower_set α).compl = ⊤ := upper_set.ext compl_univ
 protected lemma compl_bot : (⊥ : lower_set α).compl = ⊥ := upper_set.ext compl_empty
-protected lemma compl_Sup (S : set (lower_set α)) : (Sup S).compl = ⨆  s ∈ S, lower_set.compl s :=
+protected lemma compl_Sup (S : set (lower_set α)) : (Sup S).compl = ⨆ s ∈ S, lower_set.compl s :=
 upper_set.ext $ by simp only [coe_compl, coe_Sup, compl_Union₂, upper_set.coe_supr₂]
 
 protected lemma compl_Inf (S : set (lower_set α)) : (Inf S).compl = ⨅ s ∈ S, lower_set.compl s :=
@@ -349,7 +349,7 @@ upper_set.ext $ by simp only [coe_compl, coe_infi, compl_Inter, upper_set.coe_in
 by simp_rw lower_set.compl_supr
 
 @[simp] lemma compl_infi₂ (f : Π i, κ i → lower_set α) :
-  (⨅ i j, f i j).compl =  ⨅ i j, (f i j).compl :=
+  (⨅ i j, f i j).compl = ⨅ i j, (f i j).compl :=
 by simp_rw lower_set.compl_infi
 
 end lower_set

--- a/src/order/upper_lower.lean
+++ b/src/order/upper_lower.lean
@@ -24,6 +24,11 @@ This file defines upper and lower sets in an order.
 * `lower_set.Iic`: Principal lower set. `set.Iic` as an lower set.
 * `lower_set.Iio`: Strict principal lower set. `set.Iio` as an lower set.
 
+## Notes
+
+Upper sets are ordered by **reverse** inclusion. This convention is motivated by the fact that this
+makes them order-isomorphic to lower sets and antichains, and matches the convention on `filter`.
+
 ## TODO
 
 Lattice structure on antichains. Order equivalence between upper/lower sets and antichains.
@@ -354,8 +359,8 @@ by simp_rw lower_set.compl_infi
 
 end lower_set
 
-/-- Upper sets are isomorphic to lower sets under complementation. -/
-def upper_set_iso_lower_set : upper_set α ≃o lower_set α :=
+/-- Upper sets are order-isomorphic to lower sets under complementation. -/
+@[simps] def upper_set_iso_lower_set : upper_set α ≃o lower_set α :=
 { to_fun := upper_set.compl,
   inv_fun := lower_set.compl,
   left_inv := upper_set.compl_compl,

--- a/src/order/upper_lower.lean
+++ b/src/order/upper_lower.lean
@@ -179,47 +179,47 @@ end lower_set
 namespace upper_set
 variables {S : set (upper_set α)} {s t : upper_set α} {a : α}
 
-instance : has_sup (upper_set α) := ⟨λ s t, ⟨s ∪ t, s.upper.union t.upper⟩⟩
-instance : has_inf (upper_set α) := ⟨λ s t, ⟨s ∩ t, s.upper.inter t.upper⟩⟩
-instance : has_top (upper_set α) := ⟨⟨univ, is_upper_set_univ⟩⟩
-instance : has_bot (upper_set α) := ⟨⟨∅, is_upper_set_empty⟩⟩
+instance : has_sup (upper_set α) := ⟨λ s t, ⟨s ∩ t, s.upper.inter t.upper⟩⟩
+instance : has_inf (upper_set α) := ⟨λ s t, ⟨s ∪ t, s.upper.union t.upper⟩⟩
+instance : has_top (upper_set α) := ⟨⟨∅, is_upper_set_empty⟩⟩
+instance : has_bot (upper_set α) := ⟨⟨univ, is_upper_set_univ⟩⟩
 instance : has_Sup (upper_set α) :=
-⟨λ S, ⟨⋃ s ∈ S, ↑s, is_upper_set_Union₂ $ λ s _, s.upper⟩⟩
-instance : has_Inf (upper_set α) :=
 ⟨λ S, ⟨⋂ s ∈ S, ↑s, is_upper_set_Inter₂ $ λ s _, s.upper⟩⟩
+instance : has_Inf (upper_set α) :=
+⟨λ S, ⟨⋃ s ∈ S, ↑s, is_upper_set_Union₂ $ λ s _, s.upper⟩⟩
 
 instance : complete_distrib_lattice (upper_set α) :=
-set_like.coe_injective.complete_distrib_lattice _
+(to_dual.injective.comp $ set_like.coe_injective).complete_distrib_lattice _
   (λ _ _, rfl) (λ _ _, rfl) (λ _, rfl) (λ _, rfl) rfl rfl
 
 instance : inhabited (upper_set α) := ⟨⊥⟩
 
-@[simp] lemma coe_top : ((⊤ : upper_set α) : set α) = univ := rfl
-@[simp] lemma coe_bot : ((⊥ : upper_set α) : set α) = ∅ := rfl
-@[simp] lemma coe_sup (s t : upper_set α) : (↑(s ⊔ t) : set α) = s ∪ t := rfl
-@[simp] lemma coe_inf (s t : upper_set α) : (↑(s ⊓ t) : set α) = s ∩ t := rfl
-@[simp] lemma coe_Sup (S : set (upper_set α)) : (↑(Sup S) : set α) = ⋃ s ∈ S, ↑s := rfl
-@[simp] lemma coe_Inf (S : set (upper_set α)) : (↑(Inf S) : set α) = ⋂ s ∈ S, ↑s := rfl
-@[simp] lemma coe_supr (f : ι → upper_set α) : (↑(⨆ i, f i) : set α) = ⋃ i, f i := by simp [supr]
-@[simp] lemma coe_infi (f : ι → upper_set α) : (↑(⨅ i, f i) : set α) = ⋂ i, f i := by simp [infi]
-@[simp] lemma coe_supr₂ (f : Π i, κ i → upper_set α) : (↑(⨆ i j, f i j) : set α) = ⋃ i j, f i j :=
+@[simp] lemma coe_top : ((⊤ : upper_set α) : set α) = ∅ := rfl
+@[simp] lemma coe_bot : ((⊥ : upper_set α) : set α) = univ := rfl
+@[simp] lemma coe_sup (s t : upper_set α) : (↑(s ⊔ t) : set α) = s ∩ t := rfl
+@[simp] lemma coe_inf (s t : upper_set α) : (↑(s ⊓ t) : set α) = s ∪ t := rfl
+@[simp] lemma coe_Sup (S : set (upper_set α)) : (↑(Sup S) : set α) = ⋂ s ∈ S, ↑s := rfl
+@[simp] lemma coe_Inf (S : set (upper_set α)) : (↑(Inf S) : set α) = ⋃ s ∈ S, ↑s := rfl
+@[simp] lemma coe_supr (f : ι → upper_set α) : (↑(⨆ i, f i) : set α) = ⋂ i, f i := by simp [supr]
+@[simp] lemma coe_infi (f : ι → upper_set α) : (↑(⨅ i, f i) : set α) = ⋃ i, f i := by simp [infi]
+@[simp] lemma coe_supr₂ (f : Π i, κ i → upper_set α) : (↑(⨆ i j, f i j) : set α) = ⋂ i j, f i j :=
 by simp_rw coe_supr
-@[simp] lemma coe_infi₂ (f : Π i, κ i → upper_set α) : (↑(⨅ i j, f i j) : set α) = ⋂ i j, f i j :=
+@[simp] lemma coe_infi₂ (f : Π i, κ i → upper_set α) : (↑(⨅ i j, f i j) : set α) = ⋃ i j, f i j :=
 by simp_rw coe_infi
 
-@[simp] lemma mem_top : a ∈ (⊤ : upper_set α) := trivial
-@[simp] lemma not_mem_bot : a ∉ (⊥ : upper_set α) := id
-@[simp] lemma mem_sup_iff : a ∈ s ⊔ t ↔ a ∈ s ∨ a ∈ t := iff.rfl
-@[simp] lemma mem_inf_iff : a ∈ s ⊓ t ↔ a ∈ s ∧ a ∈ t := iff.rfl
-@[simp] lemma mem_Sup_iff : a ∈ Sup S ↔ ∃ s ∈ S, a ∈ s := mem_Union₂
-@[simp] lemma mem_Inf_iff  : a ∈ Inf S ↔ ∀ s ∈ S, a ∈ s := mem_Inter₂
-@[simp] lemma mem_supr_iff {f : ι → upper_set α} : a ∈ (⨆ i, f i) ↔ ∃ i, a ∈ f i :=
-by { rw [←set_like.mem_coe, coe_supr], exact mem_Union }
-@[simp] lemma mem_infi_iff {f : ι → upper_set α} : a ∈ (⨅ i, f i) ↔ ∀ i, a ∈ f i :=
-by { rw [←set_like.mem_coe, coe_infi], exact mem_Inter }
-@[simp] lemma mem_supr₂_iff {f : Π i, κ i → upper_set α} : a ∈ (⨆ i j, f i j) ↔ ∃ i j, a ∈ f i j :=
+@[simp] lemma not_mem_top : a ∉ (⊤ : upper_set α) := id
+@[simp] lemma mem_bot : a ∈ (⊥ : upper_set α) := trivial
+@[simp] lemma mem_sup_iff : a ∈ s ⊔ t ↔ a ∈ s ∧ a ∈ t := iff.rfl
+@[simp] lemma mem_inf_iff : a ∈ s ⊓ t ↔ a ∈ s ∨ a ∈ t := iff.rfl
+@[simp] lemma mem_Sup_iff : a ∈ Sup S ↔ ∀ s ∈ S, a ∈ s := mem_Inter₂
+@[simp] lemma mem_Inf_iff  : a ∈ Inf S ↔ ∃ s ∈ S, a ∈ s := mem_Union₂
+@[simp] lemma mem_supr_iff {f : ι → upper_set α} : a ∈ (⨆ i, f i) ↔ ∀ i, a ∈ f i :=
+by { rw [←set_like.mem_coe, coe_supr], exact mem_Inter }
+@[simp] lemma mem_infi_iff {f : ι → upper_set α} : a ∈ (⨅ i, f i) ↔ ∃ i, a ∈ f i :=
+by { rw [←set_like.mem_coe, coe_infi], exact mem_Union }
+@[simp] lemma mem_supr₂_iff {f : Π i, κ i → upper_set α} : a ∈ (⨆ i j, f i j) ↔ ∀ i j, a ∈ f i j :=
 by simp_rw mem_supr_iff
-@[simp] lemma mem_infi₂_iff {f : Π i, κ i → upper_set α} : a ∈ (⨅ i j, f i j) ↔ ∀ i j, a ∈ f i j :=
+@[simp] lemma mem_infi₂_iff {f : Π i, κ i → upper_set α} : a ∈ (⨅ i j, f i j) ↔ ∃ i j, a ∈ f i j :=
 by simp_rw mem_infi_iff
 
 end upper_set
@@ -281,76 +281,87 @@ def upper_set.compl (s : upper_set α) : lower_set α := ⟨sᶜ, s.upper.compl�
 def lower_set.compl (s : lower_set α) : upper_set α := ⟨sᶜ, s.lower.compl⟩
 
 namespace upper_set
-variables {s : upper_set α} {a : α}
+variables {s t : upper_set α} {a : α}
 
 @[simp] lemma coe_compl (s : upper_set α) : (s.compl : set α) = sᶜ := rfl
 @[simp] lemma mem_compl_iff : a ∈ s.compl ↔ a ∉ s := iff.rfl
 @[simp] lemma compl_compl (s : upper_set α) : s.compl.compl = s := upper_set.ext $ compl_compl _
+@[simp] lemma compl_le_compl : s.compl ≤ t.compl ↔ s ≤ t := compl_subset_compl
 
-@[simp] protected lemma compl_sup (s t : upper_set α) : (s ⊔ t).compl = s.compl ⊓ t.compl :=
-lower_set.ext compl_sup
-@[simp] protected lemma compl_inf (s t : upper_set α) : (s ⊓ t).compl = s.compl ⊔ t.compl :=
+@[simp] protected lemma compl_sup (s t : upper_set α) : (s ⊔ t).compl = s.compl ⊔ t.compl :=
 lower_set.ext compl_inf
-@[simp] protected lemma compl_top : (⊤ : upper_set α).compl = ⊥ := lower_set.ext compl_univ
-@[simp] protected lemma compl_bot : (⊥ : upper_set α).compl = ⊤ := lower_set.ext compl_empty
+@[simp] protected lemma compl_inf (s t : upper_set α) : (s ⊓ t).compl = s.compl ⊓ t.compl :=
+lower_set.ext compl_sup
+@[simp] protected lemma compl_top : (⊤ : upper_set α).compl = ⊤ := lower_set.ext compl_empty
+@[simp] protected lemma compl_bot : (⊥ : upper_set α).compl = ⊥  := lower_set.ext compl_univ
 @[simp] protected lemma compl_Sup (S : set (upper_set α)) :
-  (Sup S).compl = ⨅ s ∈ S, upper_set.compl s :=
-lower_set.ext $ by simp only [coe_compl, coe_Sup, compl_Union₂, lower_set.coe_infi₂]
+  (Sup S).compl = ⨆ s ∈ S, upper_set.compl s :=
+lower_set.ext $ by simp only [coe_compl, coe_Sup, compl_Inter₂, lower_set.coe_supr₂]
 
 @[simp] protected lemma compl_Inf (S : set (upper_set α)) :
-  (Inf S).compl = ⨆ s ∈ S, upper_set.compl s :=
-lower_set.ext $ by simp only [coe_compl, coe_Inf, compl_Inter₂, lower_set.coe_supr₂]
+  (Inf S).compl = ⨅ s ∈ S, upper_set.compl s :=
+lower_set.ext $ by simp only [coe_compl, coe_Inf, compl_Union₂, lower_set.coe_infi₂]
 
-@[simp] protected lemma compl_supr (f : ι → upper_set α) : (⨆ i, f i).compl = ⨅ i, (f i).compl :=
-lower_set.ext $ by simp only [coe_compl, coe_supr, compl_Union, lower_set.coe_infi]
+@[simp] protected lemma compl_supr (f : ι → upper_set α) : (⨆ i, f i).compl = ⨆ i, (f i).compl :=
+lower_set.ext $ by simp only [coe_compl, coe_supr, compl_Inter, lower_set.coe_supr]
 
-@[simp] protected lemma compl_infi (f : ι → upper_set α) : (⨅ i, f i).compl = ⨆ i, (f i).compl :=
-lower_set.ext $ by simp only [coe_compl, coe_infi, compl_Inter, lower_set.coe_supr]
+@[simp] protected lemma compl_infi (f : ι → upper_set α) : (⨅ i, f i).compl = ⨅ i, (f i).compl :=
+lower_set.ext $ by simp only [coe_compl, coe_infi, compl_Union, lower_set.coe_infi]
 
 @[simp] lemma compl_supr₂ (f : Π i, κ i → upper_set α) :
-  (⨆ i j, f i j).compl = ⨅ i j, (f i j).compl :=
+  (⨆ i j, f i j).compl = ⨆ i j, (f i j).compl :=
 by simp_rw upper_set.compl_supr
 
 @[simp] lemma compl_infi₂ (f : Π i, κ i → upper_set α) :
-  (⨅ i j, f i j).compl =  ⨆ i j, (f i j).compl :=
+  (⨅ i j, f i j).compl = ⨅ i j, (f i j).compl :=
 by simp_rw upper_set.compl_infi
 
 end upper_set
 
 namespace lower_set
-variables {s : lower_set α} {a : α}
+variables {s t : lower_set α} {a : α}
 
 @[simp] lemma coe_compl (s : lower_set α) : (s.compl : set α) = sᶜ := rfl
 @[simp] lemma mem_compl_iff : a ∈ s.compl ↔ a ∉ s := iff.rfl
 @[simp] lemma compl_compl (s : lower_set α) : s.compl.compl = s := lower_set.ext $ compl_compl _
+@[simp] lemma compl_le_compl : s.compl ≤ t.compl ↔ s ≤ t := compl_subset_compl
 
-protected lemma compl_sup (s t : lower_set α) : (s ⊔ t).compl = s.compl ⊓ t.compl :=
+protected lemma compl_sup (s t : lower_set α) : (s ⊔ t).compl = s.compl ⊔ t.compl :=
 upper_set.ext compl_sup
-protected lemma compl_inf (s t : lower_set α) : (s ⊓ t).compl = s.compl ⊔ t.compl :=
+protected lemma compl_inf (s t : lower_set α) : (s ⊓ t).compl = s.compl ⊓ t.compl :=
 upper_set.ext compl_inf
-protected lemma compl_top : (⊤ : lower_set α).compl = ⊥ := upper_set.ext compl_univ
-protected lemma compl_bot : (⊥ : lower_set α).compl = ⊤ := upper_set.ext compl_empty
-protected lemma compl_Sup (S : set (lower_set α)) : (Sup S).compl = ⨅ s ∈ S, lower_set.compl s :=
-upper_set.ext $ by simp only [coe_compl, coe_Sup, compl_Union₂, upper_set.coe_infi₂]
+protected lemma compl_top : (⊤ : lower_set α).compl = ⊤ := upper_set.ext compl_univ
+protected lemma compl_bot : (⊥ : lower_set α).compl = ⊥ := upper_set.ext compl_empty
+protected lemma compl_Sup (S : set (lower_set α)) : (Sup S).compl = ⨆  s ∈ S, lower_set.compl s :=
+upper_set.ext $ by simp only [coe_compl, coe_Sup, compl_Union₂, upper_set.coe_supr₂]
 
-protected lemma compl_Inf (S : set (lower_set α)) : (Inf S).compl = ⨆ s ∈ S, lower_set.compl s :=
-upper_set.ext $ by simp only [coe_compl, coe_Inf, compl_Inter₂, upper_set.coe_supr₂]
+protected lemma compl_Inf (S : set (lower_set α)) : (Inf S).compl = ⨅ s ∈ S, lower_set.compl s :=
+upper_set.ext $ by simp only [coe_compl, coe_Inf, compl_Inter₂, upper_set.coe_infi₂]
 
-protected lemma compl_supr (f : ι → lower_set α) : (⨆ i, f i).compl = ⨅ i, (f i).compl :=
-upper_set.ext $ by simp only [coe_compl, coe_supr, compl_Union, upper_set.coe_infi]
+protected lemma compl_supr (f : ι → lower_set α) : (⨆ i, f i).compl = ⨆ i, (f i).compl :=
+upper_set.ext $ by simp only [coe_compl, coe_supr, compl_Union, upper_set.coe_supr]
 
-protected lemma compl_infi (f : ι → lower_set α) : (⨅ i, f i).compl = ⨆ i, (f i).compl :=
-upper_set.ext $ by simp only [coe_compl, coe_infi, compl_Inter, upper_set.coe_supr]
+protected lemma compl_infi (f : ι → lower_set α) : (⨅ i, f i).compl = ⨅ i, (f i).compl :=
+upper_set.ext $ by simp only [coe_compl, coe_infi, compl_Inter, upper_set.coe_infi]
 
 @[simp] lemma compl_supr₂ (f : Π i, κ i → lower_set α) :
-  (⨆ i j, f i j).compl = ⨅ i j, (f i j).compl :=
+  (⨆ i j, f i j).compl = ⨆ i j, (f i j).compl :=
 by simp_rw lower_set.compl_supr
 
 @[simp] lemma compl_infi₂ (f : Π i, κ i → lower_set α) :
-  (⨅ i j, f i j).compl =  ⨆ i j, (f i j).compl :=
+  (⨅ i j, f i j).compl =  ⨅ i j, (f i j).compl :=
 by simp_rw lower_set.compl_infi
 
 end lower_set
+
+/-- Upper sets are isomorphic to lower sets under complementation. -/
+def upper_set_iso_lower_set : upper_set α ≃o lower_set α :=
+{ to_fun := upper_set.compl,
+  inv_fun := lower_set.compl,
+  left_inv := upper_set.compl_compl,
+  right_inv := lower_set.compl_compl,
+  map_rel_iff' := λ _ _, upper_set.compl_le_compl }
+
 end has_le
 
 /-! #### Principal sets -/
@@ -370,40 +381,39 @@ def Ioi (a : α) : upper_set α := ⟨Ioi a, is_upper_set_Ioi a⟩
 @[simp] lemma mem_Ici_iff : b ∈ Ici a ↔ a ≤ b := iff.rfl
 @[simp] lemma mem_Ioi_iff : b ∈ Ioi a ↔ a < b := iff.rfl
 
-lemma Ioi_le_Ici (a : α) : Ioi a ≤ Ici a := Ioi_subset_Ici_self
+lemma Icoi_le_Ioi (a : α) : Ici a ≤ Ioi a := Ioi_subset_Ici_self
 
-@[simp] lemma Ici_top [order_bot α] : Ici (⊥ : α) = ⊤ := set_like.coe_injective Ici_bot
-@[simp] lemma Ioi_bot [order_top α] : Ioi (⊤ : α) = ⊥ := set_like.coe_injective Ioi_top
+@[simp] lemma Ioi_top [order_top α] : Ioi (⊤ : α) = ⊤ := set_like.coe_injective Ioi_top
+@[simp] lemma Ici_bot [order_bot α] : Ici (⊥ : α) = ⊥ := set_like.coe_injective Ici_bot
 
 end preorder
 
 section semilattice_sup
 variables [semilattice_sup α]
 
-@[simp] lemma Ici_sup (a b : α) : Ici (a ⊔ b) = Ici a ⊓ Ici b := ext Ici_inter_Ici.symm
+@[simp] lemma Ici_sup (a b : α) : Ici (a ⊔ b) = Ici a ⊔ Ici b := ext Ici_inter_Ici.symm
 
 /-- `upper_set.Ici` as a `sup_hom`. -/
-def Ici_sup_hom : sup_hom α (upper_set α)ᵒᵈ := ⟨Ici, Ici_sup⟩
+def Ici_sup_hom : sup_hom α (upper_set α) := ⟨Ici, Ici_sup⟩
 
-@[simp] lemma Ici_sup_hom_apply (a : α) : Ici_sup_hom a = to_dual (Ici a) := rfl
+@[simp] lemma Ici_sup_hom_apply (a : α) : Ici_sup_hom a = (Ici a) := rfl
 
 end semilattice_sup
 
 section complete_lattice
 variables [complete_lattice α]
 
-@[simp] lemma Ici_Sup (S : set α) : Ici (Sup S) = ⨅ a ∈ S, Ici a :=
-set_like.ext $ λ c, by simp only [mem_Ici_iff, mem_infi_iff, Sup_le_iff]
+@[simp] lemma Ici_Sup (S : set α) : Ici (Sup S) = ⨆ a ∈ S, Ici a :=
+set_like.ext $ λ c, by simp only [mem_Ici_iff, mem_supr_iff, Sup_le_iff]
 
-@[simp] lemma Ici_supr (f : ι → α) : Ici (⨆ i, f i) = ⨅ i, Ici (f i) :=
-set_like.ext $ λ c, by simp only [mem_Ici_iff, mem_infi_iff, supr_le_iff]
+@[simp] lemma Ici_supr (f : ι → α) : Ici (⨆ i, f i) = ⨆ i, Ici (f i) :=
+set_like.ext $ λ c, by simp only [mem_Ici_iff, mem_supr_iff, supr_le_iff]
 
-@[simp] lemma Ici_supr₂ (f : Π i, κ i → α) : Ici (⨆ i j, f i j) = ⨅ i j, Ici (f i j) :=
+@[simp] lemma Ici_supr₂ (f : Π i, κ i → α) : Ici (⨆ i j, f i j) = ⨆ i j, Ici (f i j) :=
 by simp_rw Ici_supr
 
 /-- `upper_set.Ici` as a `Sup_hom`. -/
-def Ici_Sup_hom : Sup_hom α (upper_set α)ᵒᵈ :=
-⟨Ici, λ s, (Ici_Sup s).trans Inf_image.symm⟩
+def Ici_Sup_hom : Sup_hom α (upper_set α) := ⟨Ici, λ s, (Ici_Sup s).trans Sup_image.symm⟩
 
 @[simp] lemma Ici_Sup_hom_apply (a : α) : Ici_Sup_hom a = to_dual (Ici a) := rfl
 


### PR DESCRIPTION
Having `upper_set` being ordered by reverse inclusion makes it order-isomorphic to `lower_set` (and antichains once we have them as a type) and it matches the order on `filter`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
