### PR TITLE
[Merged by Bors] - chore(data/int/cast): redo #14890, moving field-specific lemmas

### DIFF
--- a/src/data/int/cast.lean
+++ b/src/data/int/cast.lean
@@ -5,7 +5,6 @@ Authors: Mario Carneiro
 -/
 import data.int.basic
 import data.nat.cast
-import algebra.field.basic
 import tactic.pi_instances
 
 /-!
@@ -144,15 +143,6 @@ end linear_ordered_ring
 lemma coe_int_dvd [comm_ring α] (m n : ℤ) (h : m ∣ n) :
   (m : α) ∣ (n : α) :=
 ring_hom.map_dvd (int.cast_ring_hom α) h
-
-/--
-Auxiliary lemma for norm_cast to move the cast `-↑n` upwards to `↑-↑n`.
-
-(The restriction to `field` is necessary, otherwise this would also apply in the case where
-`R = ℤ` and cause nontermination.)
--/
-@[norm_cast]
-lemma cast_neg_nat_cast {R} [field R] (n : ℕ) : ((-n : ℤ) : R) = -n := by simp
 
 end cast
 

--- a/src/data/int/cast_field.lean
+++ b/src/data/int/cast_field.lean
@@ -21,6 +21,15 @@ namespace int
 open nat
 variables {α : Type*}
 
+/--
+Auxiliary lemma for norm_cast to move the cast `-↑n` upwards to `↑-↑n`.
+
+(The restriction to `field` is necessary, otherwise this would also apply in the case where
+`R = ℤ` and cause nontermination.)
+-/
+@[norm_cast]
+lemma cast_neg_nat_cast {R} [field R] (n : ℕ) : ((-n : ℤ) : R) = -n := by simp
+
 @[simp] theorem cast_div [field α] {m n : ℤ} (n_dvd : n ∣ m) (n_nonzero : (n : α) ≠ 0) :
   ((m / n : ℤ) : α) = m / n :=
 begin


### PR DESCRIPTION
In #14894, I want to refer to the rational numbers in the definition of a field, meaning we can't have `algebra.field.basic` in the transitive imports of `data.rat.defs`.

Apparently this dependency was re-added, so I'm going to have to split it again...

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
