### PR TITLE
[Merged by Bors] - feat(analysis/special_functions/pow): Rational powers are dense

### DIFF
--- a/src/analysis/special_functions/pow.lean
+++ b/src/analysis/special_functions/pow.lean
@@ -1312,7 +1312,8 @@ lemma exists_rat_pow_btwn_rat_aux (hn : n ≠ 0) (x y : ℝ) (h : x < y) (hy : 0
   ∃ q : ℚ, 0 < q ∧ x < q^n ∧ ↑q^n < y :=
 begin
   have hn' : 0 < (n : ℝ) := by exact_mod_cast hn.bot_lt,
-  obtain ⟨q, hxq, hqy⟩ := exists_rat_btwn (rpow_lt_rpow (le_max_left 0 x) (max_lt hy h) $ inv_pos.mpr hn'),
+  obtain ⟨q, hxq, hqy⟩ := exists_rat_btwn (rpow_lt_rpow (le_max_left 0 x) (max_lt hy h) $
+    inv_pos.mpr hn'),
   have := rpow_nonneg_of_nonneg (le_max_left 0 x) n⁻¹,
   have hq := this.trans_lt hxq,
   replace hxq := rpow_lt_rpow this hxq hn',

--- a/src/analysis/special_functions/pow.lean
+++ b/src/analysis/special_functions/pow.lean
@@ -1305,6 +1305,42 @@ end
 
 end nnreal
 
+namespace real
+variables {n : ℕ}
+
+lemma exists_rat_pow_btwn_rat_aux (hn : n ≠ 0) (x y : ℝ) (h : x < y) (hy : 0 < y) :
+  ∃ q : ℚ, 0 < q ∧ x < q^n ∧ ↑q^n < y :=
+begin
+  have hn' : 0 < (n : ℝ) := by exact_mod_cast hn.bot_lt,
+  obtain ⟨q, hxq, hqy⟩ := exists_rat_btwn (rpow_lt_rpow (le_max_left 0 x) (max_lt hy h) $ inv_pos.mpr hn'),
+  have := rpow_nonneg_of_nonneg (le_max_left 0 x) n⁻¹,
+  have hq := this.trans_lt hxq,
+  replace hxq := rpow_lt_rpow this hxq hn',
+  replace hqy := rpow_lt_rpow hq.le hqy hn',
+  rw [rpow_nat_cast, rpow_nat_cast, rpow_nat_inv_pow_nat _ hn.bot_lt] at hxq hqy,
+  exact ⟨q, by exact_mod_cast hq, (le_max_right _ _).trans_lt hxq, hqy⟩,
+  { exact le_max_left _ _ },
+  { exact hy.le }
+end
+
+lemma exists_rat_pow_btwn_rat (hn : n ≠ 0) {x y : ℚ} (h : x < y) (hy : 0 < y) :
+  ∃ q : ℚ, 0 < q ∧ x < q^n ∧ q^n < y :=
+by apply_mod_cast exists_rat_pow_btwn_rat_aux hn x y; assumption
+
+/-- There is a rational power between any two positive elements of an archimedean ordered field. -/
+lemma exists_rat_pow_btwn {α : Type*} [linear_ordered_field α] [archimedean α] (hn : n ≠ 0)
+  {x y : α} (h : x < y) (hy : 0 < y) : ∃ q : ℚ, 0 < q ∧ x < q^n ∧ (q^n : α) < y :=
+begin
+  obtain ⟨q₂, hx₂, hy₂⟩ := exists_rat_btwn (max_lt h hy),
+  obtain ⟨q₁, hx₁, hq₁₂⟩ := exists_rat_btwn hx₂,
+  have : (0 : α) < q₂ := (le_max_right _ _).trans_lt hx₂,
+  norm_cast at hq₁₂ this,
+  obtain ⟨q, hq, hq₁, hq₂⟩ := exists_rat_pow_btwn_rat hn hq₁₂ this,
+  refine ⟨q, hq, (le_max_left _ _).trans_lt $ hx₁.trans _, hy₂.trans' _⟩; assumption_mod_cast,
+end
+
+end real
+
 open filter
 
 lemma filter.tendsto.nnrpow {α : Type*} {f : filter α} {u : α → ℝ≥0} {v : α → ℝ} {x : ℝ≥0} {y : ℝ}

--- a/src/data/real/sqrt.lean
+++ b/src/data/real/sqrt.lean
@@ -341,23 +341,23 @@ open real
 variables {α : Type*}
 
 lemma exists_rat_sq_btwn_rat_aux (x y : ℝ) (h : x < y) (hy : 0 < y) :
-  ∃ q : ℚ, 0 ≤ q ∧ x < q^2 ∧ ↑q^2 < y :=
+  ∃ q : ℚ, 0 < q ∧ x < q^2 ∧ ↑q^2 < y :=
 begin
-  rw ←sqrt_lt_sqrt_iff_of_pos hy at h,
-  obtain ⟨q, hxq, hqy⟩ := exists_rat_btwn h,
-  have hq : (0 : ℝ) ≤ q := x.sqrt_nonneg.trans hxq.le,
-  refine ⟨q, _, lt_sq_of_sqrt_lt hxq, _⟩,
+  obtain ⟨q, hxq, hqy⟩ := exists_rat_btwn
+    (max_lt ((sqrt_lt_sqrt_iff_of_pos hy).2 h) $ sqrt_pos.2 hy),
+  have hq : (0 : ℝ) < q := (le_max_right _ _).trans_lt hxq,
+  refine ⟨q, _, lt_sq_of_sqrt_lt $ (le_max_left _ _).trans_lt hxq, _⟩,
   { assumption_mod_cast },
-  { rwa [←real.sqrt_lt_sqrt_iff (pow_nonneg hq 2), real.sqrt_sq hq] }
+  { rwa [←real.sqrt_lt_sqrt_iff (pow_nonneg hq.le 2), real.sqrt_sq hq.le] }
 end
 
 lemma exists_rat_sq_btwn_rat {x y : ℚ} (h : x < y) (hy : 0 < y) :
-  ∃ q : ℚ, 0 ≤ q ∧ x < q^2 ∧ q^2 < y :=
+  ∃ q : ℚ, 0 < q ∧ x < q^2 ∧ q^2 < y :=
 by apply_mod_cast exists_rat_sq_btwn_rat_aux x y; assumption
 
 /-- There is a rational square between any two positive elements of an archimedean ordered field. -/
 lemma exists_rat_sq_btwn [linear_ordered_field α] [archimedean α] {x y : α} (h : x < y)
-  (hy : 0 < y) : ∃ q : ℚ, 0 ≤ q ∧ x < q^2 ∧ (q^2 : α) < y :=
+  (hy : 0 < y) : ∃ q : ℚ, 0 < q ∧ x < q^2 ∧ (q^2 : α) < y :=
 begin
   obtain ⟨q₂, hx₂, hy₂⟩ := exists_rat_btwn (max_lt h hy),
   obtain ⟨q₁, hx₁, hq₁₂⟩ := exists_rat_btwn hx₂,

--- a/src/data/real/sqrt.lean
+++ b/src/data/real/sqrt.lean
@@ -306,6 +306,10 @@ theorem neg_sqrt_lt_of_sq_lt (h : x^2 < y) : -sqrt y < x := (sq_lt.mp h).1
 
 theorem lt_sqrt_of_sq_lt (h : x^2 < y) : x < sqrt y := (sq_lt.mp h).2
 
+lemma lt_sq_of_sqrt_lt {x y : ℝ} (h : sqrt x < y) : x < y ^ 2 :=
+by { have hy := x.sqrt_nonneg.trans_lt h,
+  rwa [←sqrt_lt_sqrt_iff_of_pos (sq_pos_of_pos hy), sqrt_sq hy.le] }
+
 /-- The natural square root is at most the real square root -/
 lemma nat_sqrt_le_real_sqrt {a : ℕ} : ↑(nat.sqrt a) ≤ real.sqrt ↑a :=
 begin
@@ -335,6 +339,33 @@ end real
 open real
 
 variables {α : Type*}
+
+lemma exists_rat_sq_btwn_rat_aux (x y : ℝ) (h : x < y) (hy : 0 < y) :
+  ∃ q : ℚ, 0 ≤ q ∧ x < q^2 ∧ ↑q^2 < y :=
+begin
+  rw ←sqrt_lt_sqrt_iff_of_pos hy at h,
+  obtain ⟨q, hxq, hqy⟩ := exists_rat_btwn h,
+  have hq : (0 : ℝ) ≤ q := x.sqrt_nonneg.trans hxq.le,
+  refine ⟨q, _, lt_sq_of_sqrt_lt hxq, _⟩,
+  { assumption_mod_cast },
+  { rwa [←real.sqrt_lt_sqrt_iff (pow_nonneg hq 2), real.sqrt_sq hq] }
+end
+
+lemma exists_rat_sq_btwn_rat {x y : ℚ} (h : x < y) (hy : 0 < y) :
+  ∃ q : ℚ, 0 ≤ q ∧ x < q^2 ∧ q^2 < y :=
+by apply_mod_cast exists_rat_sq_btwn_rat_aux x y; assumption
+
+/-- There is a rational square between any two positive elements of an archimedean ordered field. -/
+lemma exists_rat_sq_btwn [linear_ordered_field α] [archimedean α] {x y : α} (h : x < y)
+  (hy : 0 < y) : ∃ q : ℚ, 0 ≤ q ∧ x < q^2 ∧ (q^2 : α) < y :=
+begin
+  obtain ⟨q₂, hx₂, hy₂⟩ := exists_rat_btwn (max_lt h hy),
+  obtain ⟨q₁, hx₁, hq₁₂⟩ := exists_rat_btwn hx₂,
+  have : (0 : α) < q₂ := (le_max_right _ _).trans_lt hx₂,
+  norm_cast at hq₁₂ this,
+  obtain ⟨q, hq, hq₁, hq₂⟩ := exists_rat_sq_btwn_rat hq₁₂ this,
+  refine ⟨q, hq, (le_max_left _ _).trans_lt $ hx₁.trans _, hy₂.trans' _⟩; assumption_mod_cast
+end
 
 lemma filter.tendsto.sqrt {f : α → ℝ} {l : filter α} {x : ℝ} (h : tendsto f l (𝓝 x)) :
   tendsto (λ x, sqrt (f x)) l (𝓝 (sqrt x)) :=

--- a/src/data/real/sqrt.lean
+++ b/src/data/real/sqrt.lean
@@ -340,33 +340,6 @@ open real
 
 variables {α : Type*}
 
-lemma exists_rat_sq_btwn_rat_aux (x y : ℝ) (h : x < y) (hy : 0 < y) :
-  ∃ q : ℚ, 0 < q ∧ x < q^2 ∧ ↑q^2 < y :=
-begin
-  obtain ⟨q, hxq, hqy⟩ := exists_rat_btwn
-    (max_lt ((sqrt_lt_sqrt_iff_of_pos hy).2 h) $ sqrt_pos.2 hy),
-  have hq : (0 : ℝ) < q := (le_max_right _ _).trans_lt hxq,
-  refine ⟨q, _, lt_sq_of_sqrt_lt $ (le_max_left _ _).trans_lt hxq, _⟩,
-  { assumption_mod_cast },
-  { rwa [←real.sqrt_lt_sqrt_iff (pow_nonneg hq.le 2), real.sqrt_sq hq.le] }
-end
-
-lemma exists_rat_sq_btwn_rat {x y : ℚ} (h : x < y) (hy : 0 < y) :
-  ∃ q : ℚ, 0 < q ∧ x < q^2 ∧ q^2 < y :=
-by apply_mod_cast exists_rat_sq_btwn_rat_aux x y; assumption
-
-/-- There is a rational square between any two positive elements of an archimedean ordered field. -/
-lemma exists_rat_sq_btwn [linear_ordered_field α] [archimedean α] {x y : α} (h : x < y)
-  (hy : 0 < y) : ∃ q : ℚ, 0 < q ∧ x < q^2 ∧ (q^2 : α) < y :=
-begin
-  obtain ⟨q₂, hx₂, hy₂⟩ := exists_rat_btwn (max_lt h hy),
-  obtain ⟨q₁, hx₁, hq₁₂⟩ := exists_rat_btwn hx₂,
-  have : (0 : α) < q₂ := (le_max_right _ _).trans_lt hx₂,
-  norm_cast at hq₁₂ this,
-  obtain ⟨q, hq, hq₁, hq₂⟩ := exists_rat_sq_btwn_rat hq₁₂ this,
-  refine ⟨q, hq, (le_max_left _ _).trans_lt $ hx₁.trans _, hy₂.trans' _⟩; assumption_mod_cast
-end
-
 lemma filter.tendsto.sqrt {f : α → ℝ} {l : filter α} {x : ℝ} (h : tendsto f l (𝓝 x)) :
   tendsto (λ x, sqrt (f x)) l (𝓝 (sqrt x)) :=
 (continuous_sqrt.tendsto _).comp h


### PR DESCRIPTION
There is a rational power between any two positive elements of an archimedean ordered field.

Co-authored-by: Alex Best <alex.j.best@gmail.com>

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
There is probably a more general statement hiding behind this, but this the last prerequisite to #3292 so I would be happy for it to be merged as is.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
