### PR TITLE
feat(data/zmod/basic): add injectivity result for `zmod.lift`

### DIFF
--- a/src/data/zmod/basic.lean
+++ b/src/data/zmod/basic.lean
@@ -1053,6 +1053,14 @@ funext $ lift_coe _ _
   (zmod.lift n f).comp (int.cast_add_hom (zmod n)) = f :=
 add_monoid_hom.ext $ lift_cast_add_hom _ _
 
+lemma lift_injective_iff :
+  function.injective (zmod.lift n f) ↔ ∀ k : zmod n, f.val k = 0 → k = 0 :=
+begin
+  split; intro h,
+  { intros k hk, apply h, convert hk, apply map_zero },
+  { intros k l he, rw ← sub_eq_zero at he ⊢, rw ← map_sub at he, exact h _ he },
+end
+
 end lift
 
 end zmod


### PR DESCRIPTION
The new lemma proves a necessary and sufficient injectivity condition of a `zmod.lift` homomorphism.

Co-authored-by: Junyan Xu <junyanxu.math@gmail.com>

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)

[Zulip](https://leanprover.zulipchat.com/#narrow/stream/217875-Is-there-code-for-X.3F/topic/Algebraic.20Conjugate.20over.20Finite.20Fields)