### PR TITLE
[Merged by Bors] - refactor(analysis/convex/specific_functions): Remove hypothesis from `deriv_sqrt_mul_log`

### DIFF
--- a/src/analysis/calculus/deriv.lean
+++ b/src/analysis/calculus/deriv.lean
@@ -424,6 +424,11 @@ lemma differentiable_at.deriv_within (h : differentiable_at 𝕜 f x)
   (hxs : unique_diff_within_at 𝕜 s x) : deriv_within f s x = deriv f x :=
 by { unfold deriv_within deriv, rw h.fderiv_within hxs }
 
+theorem has_deriv_within_at.deriv_eq_zero (hd : has_deriv_within_at f 0 s x)
+  (H : unique_diff_within_at 𝕜 s x) : deriv f x = 0 :=
+(em' (differentiable_at 𝕜 f x)).elim deriv_zero_of_not_differentiable_at $
+  λ h, H.eq_deriv _ h.has_deriv_at.has_deriv_within_at hd
+
 lemma deriv_within_subset (st : s ⊆ t) (ht : unique_diff_within_at 𝕜 s x)
   (h : differentiable_within_at 𝕜 f t x) :
   deriv_within f s x = deriv_within f t x :=
@@ -487,6 +492,10 @@ has_fderiv_within_at.congr_mono h ht hx h₁
 lemma has_deriv_within_at.congr (h : has_deriv_within_at f f' s x) (hs : ∀x ∈ s, f₁ x = f x)
   (hx : f₁ x = f x) : has_deriv_within_at f₁ f' s x :=
 h.congr_mono hs hx (subset.refl _)
+
+lemma has_deriv_within_at.congr_of_mem (h : has_deriv_within_at f f' s x) (hs : ∀x ∈ s, f₁ x = f x)
+  (hx : x ∈ s) : has_deriv_within_at f₁ f' s x :=
+h.congr hs (hs _ hx)
 
 lemma has_deriv_within_at.congr_of_eventually_eq (h : has_deriv_within_at f f' s x)
   (h₁ : f₁ =ᶠ[𝓝[s] x] f) (hx : f₁ x = f x) : has_deriv_within_at f₁ f' s x :=

--- a/src/analysis/convex/specific_functions.lean
+++ b/src/analysis/convex/specific_functions.lean
@@ -208,9 +208,16 @@ end
 
 section sqrt_mul_log
 
-lemma deriv_sqrt_mul_log (x : ℝ) (hx : 0 < x) :
-  deriv (λ x, sqrt x * log x) x = (2 + log x) / (2 * sqrt x) :=
+lemma deriv_sqrt_mul_log (x : ℝ) : deriv (λ x, sqrt x * log x) x = (2 + log x) / (2 * sqrt x) :=
 begin
+  cases le_or_lt x 0 with hx hx,
+  { rw [sqrt_eq_zero_of_nonpos hx, mul_zero, div_zero],
+    cases em' (differentiable_at ℝ (λ x, sqrt x * log x) x) with h h,
+    { rw deriv_zero_of_not_differentiable_at h },
+    have h0 : unique_diff_within_at ℝ (Iic 0) x := unique_diff_on_Iic 0 x hx,
+    have h1 : ∀ x ∈ Iic (0 : ℝ), sqrt x * log x = 0 :=
+    λ x hx, by rw [sqrt_eq_zero_of_nonpos hx, zero_mul],
+    rw [←h.deriv_within h0, deriv_within_congr h0 h1 (h1 x hx), deriv_within_const x _ _ h0] },
   simp only [sqrt_eq_rpow],
   refine (deriv_mul (has_deriv_at_rpow_const (or.inl hx.ne')).differentiable_at
     (differentiable_at_log hx.ne')).trans _,
@@ -224,13 +231,9 @@ lemma deriv2_sqrt_mul_log (x : ℝ) (hx : 0 < x) :
   deriv^[2] (λ x, sqrt x * log x) x = -log x / (4 * sqrt x ^ 3) :=
 begin
   let h := (has_deriv_at_rpow_const (or.inl hx.ne')).differentiable_at,
-  rw [function.iterate_succ, function.iterate_one, function.comp_app,
-      ←deriv_within_of_open is_open_Ioi (set.mem_Ioi.mpr hx)],
-  refine (deriv_within_congr (unique_diff_on_Ioi 0 x hx) deriv_sqrt_mul_log
-    (deriv_sqrt_mul_log x hx)).trans _,
-  simp only [sqrt_eq_rpow],
-  rw [deriv_within_of_open is_open_Ioi (set.mem_Ioi.mpr hx),
-      deriv_div ((differentiable_at_log hx.ne').const_add 2) (h.const_mul 2)
+  change deriv (λ x, deriv (λ x, sqrt x * log x) x) x = _,
+  simp_rw [deriv_sqrt_mul_log, sqrt_eq_rpow],
+  rw [deriv_div ((differentiable_at_log hx.ne').const_add 2) (h.const_mul 2)
       (ne_of_gt (mul_pos two_pos (rpow_pos_of_pos hx 0.5))), deriv_const_add, deriv_log,
       deriv_const_mul 2 h, deriv_rpow_const (or.inl hx.ne'), one_div, mul_comm x⁻¹, mul_assoc,
       mul_inv_cancel_left₀ (show (2 : ℝ) ≠ (0 : ℝ), from two_ne_zero), ←div_eq_mul_inv,

--- a/src/analysis/convex/specific_functions.lean
+++ b/src/analysis/convex/specific_functions.lean
@@ -246,7 +246,7 @@ lemma strict_concave_on_sqrt_mul_log_Ioi : strict_concave_on ℝ (set.Ioi 1) (λ
 begin
   refine strict_concave_on_open_of_deriv2_neg (convex_Ioi 1) is_open_Ioi
     (λ x hx, differentiable_within_at_of_deriv_within_ne_zero _) (λ x hx, _),
-  { rw [deriv_within_of_open is_open_Ioi hx, deriv_sqrt_mul_log x (zero_lt_one.trans hx)],
+  { rw [deriv_within_of_open is_open_Ioi hx, deriv_sqrt_mul_log],
     refine div_ne_zero _ (mul_ne_zero two_ne_zero (sqrt_ne_zero'.mpr (zero_lt_one.trans hx))),
     linarith [log_pos hx] },
   { rw deriv2_sqrt_mul_log x (zero_lt_one.trans hx),

--- a/src/analysis/convex/specific_functions.lean
+++ b/src/analysis/convex/specific_functions.lean
@@ -213,22 +213,18 @@ lemma has_deriv_at_sqrt_mul_log {x : ℝ} (hx : x ≠ 0) :
   has_deriv_at (λ x, sqrt x * log x) ((2 + log x) / (2 * sqrt x)) x :=
 begin
   convert (has_deriv_at_sqrt hx).mul (has_deriv_at_log hx),
-  rw [one_div, inv_mul_eq_div, ← div_eq_mul_inv, sqrt_div_self, add_div, add_comm, div_mul_right,
-    one_div],
-  exact two_ne_zero
+  rw [add_div, div_mul_right (sqrt x) two_ne_zero, ←div_eq_mul_inv, sqrt_div_self',
+      add_comm, div_eq_mul_one_div, mul_comm],
 end
 
 lemma deriv_sqrt_mul_log (x : ℝ) : deriv (λ x, sqrt x * log x) x = (2 + log x) / (2 * sqrt x) :=
 begin
-  rcases ne_or_eq x 0 with hx|rfl,
+  rcases ne_or_eq x 0 with hx | rfl,
   { exact (has_deriv_at_sqrt_mul_log hx).deriv },
   rw [sqrt_zero, mul_zero, div_zero],
-  -- The function is not differentiable at zero but we don't prove it. Instead, we show that the
-  -- left side derivative is zero.
-  suffices : has_deriv_within_at (λ x, sqrt x * log x) 0 (Iic 0) 0,
-    from this.deriv_eq_zero (unique_diff_on_Iic 0 _ right_mem_Iic),
-  refine (has_deriv_within_at_const _ _ 0).congr_of_mem (λ x hx, _) right_mem_Iic,
-  rw [sqrt_eq_zero_of_nonpos hx, zero_mul]
+  refine has_deriv_within_at.deriv_eq_zero _ (unique_diff_on_Iic 0 0 right_mem_Iic),
+  refine (has_deriv_within_at_const 0 _ 0).congr_of_mem (λ x hx, _) right_mem_Iic,
+  rw [sqrt_eq_zero_of_nonpos hx, zero_mul],
 end
 
 lemma deriv_sqrt_mul_log' : deriv (λ x, sqrt x * log x) = λ x, (2 + log x) / (2 * sqrt x) :=

--- a/src/analysis/convex/specific_functions.lean
+++ b/src/analysis/convex/specific_functions.lean
@@ -219,12 +219,12 @@ end
 
 lemma deriv_sqrt_mul_log (x : ℝ) : deriv (λ x, sqrt x * log x) x = (2 + log x) / (2 * sqrt x) :=
 begin
-  rcases ne_or_eq x 0 with hx | rfl,
-  { exact (has_deriv_at_sqrt_mul_log hx).deriv },
-  rw [sqrt_zero, mul_zero, div_zero],
-  refine has_deriv_within_at.deriv_eq_zero _ (unique_diff_on_Iic 0 0 right_mem_Iic),
-  refine (has_deriv_within_at_const 0 _ 0).congr_of_mem (λ x hx, _) right_mem_Iic,
-  rw [sqrt_eq_zero_of_nonpos hx, zero_mul],
+  cases lt_or_le 0 x with hx hx,
+  { exact (has_deriv_at_sqrt_mul_log hx.ne').deriv },
+  { rw [sqrt_eq_zero_of_nonpos hx, mul_zero, div_zero],
+    refine has_deriv_within_at.deriv_eq_zero _ (unique_diff_on_Iic 0 x hx),
+    refine (has_deriv_within_at_const x _ 0).congr_of_mem (λ x hx, _) hx,
+    rw [sqrt_eq_zero_of_nonpos hx, zero_mul] },
 end
 
 lemma deriv_sqrt_mul_log' : deriv (λ x, sqrt x * log x) = λ x, (2 + log x) / (2 * sqrt x) :=
@@ -236,8 +236,7 @@ begin
   simp only [nat.iterate, deriv_sqrt_mul_log'],
   cases le_or_lt x 0 with hx hx,
   { rw [sqrt_eq_zero_of_nonpos hx, zero_pow zero_lt_three, mul_zero, div_zero],
-    suffices : has_deriv_within_at (λ x, (2 + log x) / (2 * sqrt x)) 0 (Iic 0) x,
-      from this.deriv_eq_zero (unique_diff_on_Iic _ _ hx),
+    refine has_deriv_within_at.deriv_eq_zero _ (unique_diff_on_Iic 0 x hx),
     refine (has_deriv_within_at_const _ _ 0).congr_of_mem (λ x hx, _) hx,
     rw [sqrt_eq_zero_of_nonpos hx, mul_zero, div_zero] },
   { have h₀ : sqrt x ≠ 0, from sqrt_ne_zero'.2 hx,

--- a/src/analysis/convex/specific_functions.lean
+++ b/src/analysis/convex/specific_functions.lean
@@ -5,6 +5,7 @@ Authors: Yury Kudryashov, Sébastien Gouëzel
 -/
 import analysis.calculus.mean_value
 import analysis.special_functions.pow_deriv
+import analysis.special_functions.sqrt
 
 /-!
 # Collection of convex functions
@@ -208,48 +209,54 @@ end
 
 section sqrt_mul_log
 
-lemma deriv_sqrt_mul_log (x : ℝ) : deriv (λ x, sqrt x * log x) x = (2 + log x) / (2 * sqrt x) :=
+lemma has_deriv_at_sqrt_mul_log {x : ℝ} (hx : x ≠ 0) :
+  has_deriv_at (λ x, sqrt x * log x) ((2 + log x) / (2 * sqrt x)) x :=
 begin
-  cases le_or_lt x 0 with hx hx,
-  { rw [sqrt_eq_zero_of_nonpos hx, mul_zero, div_zero],
-    cases em' (differentiable_at ℝ (λ x, sqrt x * log x) x) with h h,
-    { rw deriv_zero_of_not_differentiable_at h },
-    have h0 : unique_diff_within_at ℝ (Iic 0) x := unique_diff_on_Iic 0 x hx,
-    have h1 : ∀ x ∈ Iic (0 : ℝ), sqrt x * log x = 0 :=
-    λ x hx, by rw [sqrt_eq_zero_of_nonpos hx, zero_mul],
-    rw [←h.deriv_within h0, deriv_within_congr h0 h1 (h1 x hx), deriv_within_const x _ _ h0] },
-  simp only [sqrt_eq_rpow],
-  refine (deriv_mul (has_deriv_at_rpow_const (or.inl hx.ne')).differentiable_at
-    (differentiable_at_log hx.ne')).trans _,
-  rw [deriv_rpow_const (or.inl hx.ne'), deriv_log, add_comm],
-  simp only [div_eq_mul_inv, mul_inv, ←rpow_neg hx.le, ←rpow_neg_one x, ←rpow_add hx],
-  rw [add_mul, mul_comm (log x), ←mul_assoc],
-  norm_num,
+  convert (has_deriv_at_sqrt hx).mul (has_deriv_at_log hx),
+  rw [one_div, inv_mul_eq_div, ← div_eq_mul_inv, sqrt_div_self, add_div, add_comm, div_mul_right,
+    one_div],
+  exact two_ne_zero
 end
 
-lemma deriv2_sqrt_mul_log (x : ℝ) (hx : 0 < x) :
+lemma deriv_sqrt_mul_log (x : ℝ) : deriv (λ x, sqrt x * log x) x = (2 + log x) / (2 * sqrt x) :=
+begin
+  rcases ne_or_eq x 0 with hx|rfl,
+  { exact (has_deriv_at_sqrt_mul_log hx).deriv },
+  rw [sqrt_zero, mul_zero, div_zero],
+  -- The function is not differentiable at zero but we don't prove it. Instead, we show that the
+  -- left side derivative is zero.
+  suffices : has_deriv_within_at (λ x, sqrt x * log x) 0 (Iic 0) 0,
+    from this.deriv_eq_zero (unique_diff_on_Iic 0 _ right_mem_Iic),
+  refine (has_deriv_within_at_const _ _ 0).congr_of_mem (λ x hx, _) right_mem_Iic,
+  rw [sqrt_eq_zero_of_nonpos hx, zero_mul]
+end
+
+lemma deriv_sqrt_mul_log' : deriv (λ x, sqrt x * log x) = λ x, (2 + log x) / (2 * sqrt x) :=
+funext deriv_sqrt_mul_log
+
+lemma deriv2_sqrt_mul_log (x : ℝ) :
   deriv^[2] (λ x, sqrt x * log x) x = -log x / (4 * sqrt x ^ 3) :=
 begin
-  let h := (has_deriv_at_rpow_const (or.inl hx.ne')).differentiable_at,
-  change deriv (λ x, deriv (λ x, sqrt x * log x) x) x = _,
-  simp_rw [deriv_sqrt_mul_log, sqrt_eq_rpow],
-  rw [deriv_div ((differentiable_at_log hx.ne').const_add 2) (h.const_mul 2)
-      (ne_of_gt (mul_pos two_pos (rpow_pos_of_pos hx 0.5))), deriv_const_add, deriv_log,
-      deriv_const_mul 2 h, deriv_rpow_const (or.inl hx.ne'), one_div, mul_comm x⁻¹, mul_assoc,
-      mul_inv_cancel_left₀ (show (2 : ℝ) ≠ (0 : ℝ), from two_ne_zero), ←div_eq_mul_inv,
-      ←rpow_sub_one hx.ne', ←sub_mul, sub_add_cancel', mul_pow, ←div_div_eq_mul_div, ←mul_div],
-    simp only [mul_pow, pow_succ, pow_zero, mul_one, ←rpow_add hx, ←rpow_sub hx],
-    norm_num,
+  simp only [nat.iterate, deriv_sqrt_mul_log'],
+  cases le_or_lt x 0 with hx hx,
+  { rw [sqrt_eq_zero_of_nonpos hx, zero_pow zero_lt_three, mul_zero, div_zero],
+    suffices : has_deriv_within_at (λ x, (2 + log x) / (2 * sqrt x)) 0 (Iic 0) x,
+      from this.deriv_eq_zero (unique_diff_on_Iic _ _ hx),
+    refine (has_deriv_within_at_const _ _ 0).congr_of_mem (λ x hx, _) hx,
+    rw [sqrt_eq_zero_of_nonpos hx, mul_zero, div_zero] },
+  { have h₀ : sqrt x ≠ 0, from sqrt_ne_zero'.2 hx,
+    convert (((has_deriv_at_log hx.ne').const_add 2).div
+      ((has_deriv_at_sqrt hx.ne').const_mul 2) $ mul_ne_zero two_ne_zero h₀).deriv using 1,
+    nth_rewrite 2 [← mul_self_sqrt hx.le],
+    field_simp, ring },
 end
 
 lemma strict_concave_on_sqrt_mul_log_Ioi : strict_concave_on ℝ (set.Ioi 1) (λ x, sqrt x * log x) :=
 begin
-  refine strict_concave_on_open_of_deriv2_neg (convex_Ioi 1) is_open_Ioi
-    (λ x hx, differentiable_within_at_of_deriv_within_ne_zero _) (λ x hx, _),
-  { rw [deriv_within_of_open is_open_Ioi hx, deriv_sqrt_mul_log x (zero_lt_one.trans hx)],
-    refine div_ne_zero _ (mul_ne_zero two_ne_zero (sqrt_ne_zero'.mpr (zero_lt_one.trans hx))),
-    linarith [log_pos hx] },
-  { rw deriv2_sqrt_mul_log x (zero_lt_one.trans hx),
+  refine strict_concave_on_open_of_deriv2_neg (convex_Ioi 1) is_open_Ioi (λ x hx, _) (λ x hx, _),
+  { have h₀ : x ≠ 0, from (one_pos.trans hx.out).ne',
+    exact (has_deriv_at_sqrt_mul_log h₀).differentiable_at.differentiable_within_at },
+  { rw [deriv2_sqrt_mul_log x],
     exact div_neg_of_neg_of_pos (neg_neg_of_pos (log_pos hx))
       (mul_pos four_pos (pow_pos (sqrt_pos.mpr (zero_lt_one.trans hx)) 3)) },
 end

--- a/src/analysis/convex/specific_functions.lean
+++ b/src/analysis/convex/specific_functions.lean
@@ -208,7 +208,9 @@ end
 
 section sqrt_mul_log
 
-lemma deriv_sqrt_mul_log (x : ℝ) : deriv (λ x, sqrt x * log x) x = (2 + log x) / (2 * sqrt x) :=
+variables (x : ℝ)
+
+lemma deriv_sqrt_mul_log : deriv (λ x, sqrt x * log x) x = (2 + log x) / (2 * sqrt x) :=
 begin
   cases le_or_lt x 0 with hx hx,
   { rw [sqrt_eq_zero_of_nonpos hx, mul_zero, div_zero],
@@ -227,19 +229,27 @@ begin
   norm_num,
 end
 
-lemma deriv2_sqrt_mul_log (x : ℝ) (hx : 0 < x) :
-  deriv^[2] (λ x, sqrt x * log x) x = -log x / (4 * sqrt x ^ 3) :=
+lemma deriv2_sqrt_mul_log : deriv^[2] (λ x, sqrt x * log x) x = -log x / (4 * sqrt x ^ 3) :=
 begin
-  let h := (has_deriv_at_rpow_const (or.inl hx.ne')).differentiable_at,
   change deriv (λ x, deriv (λ x, sqrt x * log x) x) x = _,
-  simp_rw [deriv_sqrt_mul_log, sqrt_eq_rpow],
+  simp only [deriv_sqrt_mul_log],
+  cases le_or_lt x 0 with hx hx,
+  { rw [sqrt_eq_zero_of_nonpos hx, zero_pow zero_lt_three, mul_zero, div_zero],
+    cases em' (differentiable_at ℝ (λ x, (2 + log x) / (2 * sqrt x)) x) with h h,
+    { rw deriv_zero_of_not_differentiable_at h },
+    have h0 : unique_diff_within_at ℝ (Iic 0) x := unique_diff_on_Iic 0 x hx,
+    have h1 : ∀ x ∈ Iic (0 : ℝ), (2 + log x) / (2 * sqrt x) = 0 :=
+    λ x hx, by rw [sqrt_eq_zero_of_nonpos hx, mul_zero, div_zero],
+    rw [←h.deriv_within h0, deriv_within_congr h0 h1 (h1 x hx), deriv_within_const x _ _ h0] },
+  let h := (has_deriv_at_rpow_const (or.inl hx.ne')).differentiable_at,
+  simp only [sqrt_eq_rpow],
   rw [deriv_div ((differentiable_at_log hx.ne').const_add 2) (h.const_mul 2)
       (ne_of_gt (mul_pos two_pos (rpow_pos_of_pos hx 0.5))), deriv_const_add, deriv_log,
       deriv_const_mul 2 h, deriv_rpow_const (or.inl hx.ne'), one_div, mul_comm x⁻¹, mul_assoc,
       mul_inv_cancel_left₀ (show (2 : ℝ) ≠ (0 : ℝ), from two_ne_zero), ←div_eq_mul_inv,
       ←rpow_sub_one hx.ne', ←sub_mul, sub_add_cancel', mul_pow, ←div_div_eq_mul_div, ←mul_div],
-    simp only [mul_pow, pow_succ, pow_zero, mul_one, ←rpow_add hx, ←rpow_sub hx],
-    norm_num,
+  simp only [mul_pow, pow_succ, pow_zero, mul_one, ←rpow_add hx, ←rpow_sub hx],
+  norm_num,
 end
 
 lemma strict_concave_on_sqrt_mul_log_Ioi : strict_concave_on ℝ (set.Ioi 1) (λ x, sqrt x * log x) :=
@@ -249,7 +259,7 @@ begin
   { rw [deriv_within_of_open is_open_Ioi hx, deriv_sqrt_mul_log],
     refine div_ne_zero _ (mul_ne_zero two_ne_zero (sqrt_ne_zero'.mpr (zero_lt_one.trans hx))),
     linarith [log_pos hx] },
-  { rw deriv2_sqrt_mul_log x (zero_lt_one.trans hx),
+  { rw deriv2_sqrt_mul_log,
     exact div_neg_of_neg_of_pos (neg_neg_of_pos (log_pos hx))
       (mul_pos four_pos (pow_pos (sqrt_pos.mpr (zero_lt_one.trans hx)) 3)) },
 end

--- a/src/topology/continuous_on.lean
+++ b/src/topology/continuous_on.lean
@@ -117,6 +117,9 @@ mem_inf_of_left h
 theorem self_mem_nhds_within {a : α} {s : set α} : s ∈ 𝓝[s] a :=
 mem_inf_of_right (mem_principal_self s)
 
+theorem eventually_mem_nhds_within {a : α} {s : set α} : ∀ᶠ x in 𝓝[s] a, x ∈ s :=
+self_mem_nhds_within
+
 theorem inter_mem_nhds_within (s : set α) {t : set α} {a : α} (h : t ∈ 𝓝 a) :
   s ∩ t ∈ 𝓝[s] a :=
 inter_mem self_mem_nhds_within (mem_inf_of_left h)


### PR DESCRIPTION
This PR removes the `hx : 0 < x` hypothesis from `deriv_sqrt_mul_log`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
