### PR TITLE
[Merged by Bors] - feat(analysis/inner_product_space): add simple lemmas for the orthogonal complement

### DIFF
--- a/src/analysis/inner_product_space/projection.lean
+++ b/src/analysis/inner_product_space/projection.lean
@@ -772,7 +772,7 @@ lemma orthogonal_projection_mem_subspace_orthogonal_precomplement_eq_zero
 orthogonal_projection_mem_subspace_orthogonal_complement_eq_zero (K.le_orthogonal_orthogonal hv)
 
 /-- The orthogonal complement satisfies `Kᗮᗮᗮ = Kᗮ`. -/
-lemma submodule.orthogonal3_eq_orthogonal [complete_space E] : Kᗮᗮᗮ = Kᗮ :=
+lemma submodule.triorthogonal_eq_orthogonal [complete_space E] : Kᗮᗮᗮ = Kᗮ :=
 begin
   rw Kᗮ.orthogonal_orthogonal_eq_closure,
   exact K.is_closed_orthogonal.topological_closure_eq,
@@ -783,7 +783,7 @@ lemma topological_closure_eq_top_iff [complete_space E] : K.topological_closure 
 begin
   rw ←submodule.orthogonal_orthogonal_eq_closure,
   split; intro h,
-  { rw [←submodule.orthogonal3_eq_orthogonal, h, submodule.top_orthogonal_eq_bot] },
+  { rw [←submodule.triorthogonal_eq_orthogonal, h, submodule.top_orthogonal_eq_bot] },
   { rw [h, submodule.bot_orthogonal_eq_top] }
 end
 

--- a/src/analysis/inner_product_space/projection.lean
+++ b/src/analysis/inner_product_space/projection.lean
@@ -771,6 +771,22 @@ lemma orthogonal_projection_mem_subspace_orthogonal_precomplement_eq_zero
   orthogonal_projection Kᗮ v = 0 :=
 orthogonal_projection_mem_subspace_orthogonal_complement_eq_zero (K.le_orthogonal_orthogonal hv)
 
+/-- The orthogonal complement satisfies `Kᗮᗮᗮ = Kᗮ`. -/
+lemma submodule.orthogonal3_eq_orthogonal [complete_space E] : Kᗮᗮᗮ = Kᗮ :=
+begin
+  rw Kᗮ.orthogonal_orthogonal_eq_closure,
+  exact K.is_closed_orthogonal.topological_closure_eq,
+end
+
+/-- The closure of `K` is the full space iff `Kᗮ` is trivial. -/
+lemma topological_closure_eq_top_iff [complete_space E] : K.topological_closure = ⊤ ↔ Kᗮ = ⊥ :=
+begin
+  rw ←submodule.orthogonal_orthogonal_eq_closure,
+  split; intro h,
+  { rw [←submodule.orthogonal3_eq_orthogonal, h, submodule.top_orthogonal_eq_bot] },
+  { rw [h, submodule.bot_orthogonal_eq_top] }
+end
+
 /-- The reflection in `Kᗮ` of an element of `K` is its negation. -/
 lemma reflection_mem_subspace_orthogonal_precomplement_eq_neg
   [complete_space E] {v : E} (hv : v ∈ K) :

--- a/src/analysis/inner_product_space/projection.lean
+++ b/src/analysis/inner_product_space/projection.lean
@@ -775,7 +775,7 @@ orthogonal_projection_mem_subspace_orthogonal_complement_eq_zero (K.le_orthogona
 lemma submodule.triorthogonal_eq_orthogonal [complete_space E] : Kᗮᗮᗮ = Kᗮ :=
 begin
   rw Kᗮ.orthogonal_orthogonal_eq_closure,
-  exact K.is_closed_orthogonal.topological_closure_eq,
+  exact K.is_closed_orthogonal.submodule_topological_closure_eq,
 end
 
 /-- The closure of `K` is the full space iff `Kᗮ` is trivial. -/

--- a/src/analysis/inner_product_space/projection.lean
+++ b/src/analysis/inner_product_space/projection.lean
@@ -779,7 +779,8 @@ begin
 end
 
 /-- The closure of `K` is the full space iff `Kᗮ` is trivial. -/
-lemma topological_closure_eq_top_iff [complete_space E] : K.topological_closure = ⊤ ↔ Kᗮ = ⊥ :=
+lemma submodule.topological_closure_eq_top_iff [complete_space E] :
+  K.topological_closure = ⊤ ↔ Kᗮ = ⊥ :=
 begin
   rw ←submodule.orthogonal_orthogonal_eq_closure,
   split; intro h,

--- a/src/topology/algebra/module/basic.lean
+++ b/src/topology/algebra/module/basic.lean
@@ -236,6 +236,16 @@ lemma submodule.topological_closure_mono {s : submodule R M} {t : submodule R M}
 s.topological_closure_minimal (h.trans t.submodule_topological_closure)
   t.is_closed_topological_closure
 
+/-- The topological closure of a closed submodule `s` is equal to `s`. -/
+lemma is_closed.topological_closure_eq {s : submodule R M} (hs : is_closed (s : set M)) :
+  s.topological_closure = s :=
+le_antisymm (s.topological_closure_minimal rfl.le hs) s.submodule_topological_closure
+
+/-- A subspace is dense iff its topological closure is the entire space. -/
+lemma dense_topological_closure_eq_top_iff {s : submodule R M} :
+  dense (s : set M) ↔ s.topological_closure = ⊤ :=
+by { rw [←set_like.coe_set_eq, dense_iff_closure_eq], simp }
+
 end closure
 
 /-- Continuous linear maps between modules. We only put the type classes that are necessary for the

--- a/src/topology/algebra/module/basic.lean
+++ b/src/topology/algebra/module/basic.lean
@@ -237,12 +237,12 @@ s.topological_closure_minimal (h.trans t.submodule_topological_closure)
   t.is_closed_topological_closure
 
 /-- The topological closure of a closed submodule `s` is equal to `s`. -/
-lemma is_closed.topological_closure_eq {s : submodule R M} (hs : is_closed (s : set M)) :
+lemma is_closed.submodule_topological_closure_eq {s : submodule R M} (hs : is_closed (s : set M)) :
   s.topological_closure = s :=
 le_antisymm (s.topological_closure_minimal rfl.le hs) s.submodule_topological_closure
 
 /-- A subspace is dense iff its topological closure is the entire space. -/
-lemma dense_topological_closure_eq_top_iff {s : submodule R M} :
+lemma submodule.dense_iff_topological_closure_eq_top {s : submodule R M} :
   dense (s : set M) ↔ s.topological_closure = ⊤ :=
 by { rw [←set_like.coe_set_eq, dense_iff_closure_eq], simp }
 


### PR DESCRIPTION
We show that the orthogonal complement of a dense subspace is trivial.

---

I am surprised that all these lemmas were missing - but I could not find any of them with `library_search`.

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
