### PR TITLE
[Merged by Bors] - feat(algebra/order/field): Linearly ordered semifields

### DIFF
--- a/src/algebra/field_power.lean
+++ b/src/algebra/field_power.lean
@@ -14,55 +14,57 @@ This file collects basic facts about the operation of raising an element of a `d
 integer power. More specialised results are provided in the case of a linearly ordered field.
 -/
 
-universe u
+open function int
 
-@[simp] lemma ring_hom.map_zpow {K L : Type*} [division_ring K] [division_ring L] (f : K →+* L) :
-  ∀ (a : K) (n : ℤ), f (a ^ n) = f a ^ n :=
+variables {α β : Type*}
+
+section division_ring
+variables [division_ring α] [division_ring β]
+
+@[simp] lemma ring_hom.map_zpow (f : α →+* β) : ∀ (a : α) (n : ℤ), f (a ^ n) = f a ^ n :=
 f.to_monoid_with_zero_hom.map_zpow
 
-@[simp] lemma ring_equiv.map_zpow {K L : Type*} [division_ring K] [division_ring L] (f : K ≃+* L) :
-  ∀ (a : K) (n : ℤ), f (a ^ n) = f a ^ n :=
+@[simp] lemma ring_equiv.map_zpow (f : α ≃+* β) : ∀ (a : α) (n : ℤ), f (a ^ n) = f a ^ n :=
 f.to_ring_hom.map_zpow
 
-@[simp] lemma zpow_bit1_neg {K : Type*} [division_ring K] (x : K) (n : ℤ) :
-  (-x) ^ (bit1 n) = - x ^ bit1 n :=
+@[simp] lemma zpow_bit1_neg (x : α) (n : ℤ) : (-x) ^ bit1 n = - x ^ bit1 n :=
 by rw [zpow_bit1', zpow_bit1', neg_mul_neg, neg_mul_eq_mul_neg]
 
-section ordered_field_power
-open int
+@[simp, norm_cast] lemma rat.cast_zpow [char_zero α] (q : ℚ) (n : ℤ) : ((q ^ n : ℚ) : α) = q ^ n :=
+(rat.cast_hom α).map_zpow q n
 
-variables {K : Type u} [linear_ordered_field K] {a : K} {n : ℤ}
+end division_ring
 
-lemma zpow_nonneg {a : K} (ha : 0 ≤ a) : ∀ (z : ℤ), 0 ≤ a ^ z
+section linear_ordered_semifield
+variables [linear_ordered_semifield α] {a b x : α} {m n : ℤ}
+
+lemma zpow_nonneg (ha : 0 ≤ a) : ∀ (z : ℤ), 0 ≤ a ^ z
 | (n : ℕ) := by { rw zpow_coe_nat, exact pow_nonneg ha _ }
 | -[1+n]  := by { rw zpow_neg_succ_of_nat, exact inv_nonneg.2 (pow_nonneg ha _) }
 
-lemma zpow_pos_of_pos {a : K} (ha : 0 < a) : ∀ (z : ℤ), 0 < a ^ z
+lemma zpow_pos_of_pos (ha : 0 < a) : ∀ (z : ℤ), 0 < a ^ z
 | (n : ℕ) := by { rw zpow_coe_nat, exact pow_pos ha _ }
 | -[1+n]  := by { rw zpow_neg_succ_of_nat, exact inv_pos.2 (pow_pos ha _) }
 
-lemma zpow_le_of_le {x : K} (hx : 1 ≤ x) {a b : ℤ} (h : a ≤ b) : x ^ a ≤ x ^ b :=
+lemma zpow_le_of_le (ha : 1 ≤ a) (h : m ≤ n) : a ^ m ≤ a ^ n :=
 begin
-  induction a with a a; induction b with b b,
+  induction m with m m; induction n with n n,
   { simp only [of_nat_eq_coe, zpow_coe_nat],
-    apply pow_le_pow hx,
-    apply le_of_coe_nat_le_coe_nat h },
-  { apply absurd h,
-    apply not_le_of_gt,
-    exact lt_of_lt_of_le (neg_succ_lt_zero _) (of_nat_nonneg _) },
+    exact pow_le_pow ha (le_of_coe_nat_le_coe_nat h) },
+  { cases h.not_lt ((neg_succ_lt_zero _).trans_le $ of_nat_nonneg _) },
   { simp only [zpow_neg_succ_of_nat, one_div, of_nat_eq_coe, zpow_coe_nat],
-    apply le_trans (inv_le_one _); apply one_le_pow_of_one_le hx },
+    apply le_trans (inv_le_one _); apply one_le_pow_of_one_le ha },
   { simp only [zpow_neg_succ_of_nat],
     apply (inv_le_inv _ _).2,
-    { apply pow_le_pow hx,
-      have : -(↑(a+1) : ℤ) ≤ -(↑(b+1) : ℤ), from h,
+    { apply pow_le_pow ha,
+      have : -(↑(m+1) : ℤ) ≤ -(↑(n+1) : ℤ), from h,
       have h' := le_of_neg_le_neg this,
       apply le_of_coe_nat_le_coe_nat h' },
-    repeat { apply pow_pos (lt_of_lt_of_le zero_lt_one hx) } }
+    repeat { apply pow_pos (zero_lt_one.trans_le ha) } }
 end
 
-lemma pow_le_max_of_min_le {x : K} (hx : 1 ≤ x) {a b c : ℤ} (h : min a b ≤ c) :
-      x ^ (-c) ≤ max (x ^ (-a)) (x ^ (-b)) :=
+lemma pow_le_max_of_min_le (hx : 1 ≤ x) {a b c : ℤ} (h : min a b ≤ c) :
+  x ^ (-c) ≤ max (x ^ (-a)) (x ^ (-b)) :=
 begin
   wlog hle : a ≤ b,
   have hnle : -b ≤ -a, from neg_le_neg hle,
@@ -73,25 +75,81 @@ begin
   simpa only [max_eq_left hfle]
 end
 
-lemma zpow_le_one_of_nonpos {p : K} (hp : 1 ≤ p) {z : ℤ} (hz : z ≤ 0) : p ^ z ≤ 1 :=
-calc p ^ z ≤ p ^ 0 : zpow_le_of_le hp hz
-          ... = 1        : by simp
+lemma zpow_le_one_of_nonpos (ha : 1 ≤ a) (hn : n ≤ 0) : a ^ n ≤ 1 :=
+(zpow_le_of_le ha hn).trans_eq $ zpow_zero _
 
-lemma one_le_zpow_of_nonneg {p : K} (hp : 1 ≤ p) {z : ℤ} (hz : 0 ≤ z) : 1 ≤ p ^ z :=
-calc p ^ z ≥ p ^ 0 : zpow_le_of_le hp hz
-          ... = 1        : by simp
+lemma one_le_zpow_of_nonneg (ha : 1 ≤ a) (hn : 0 ≤ n) : 1 ≤ a ^ n :=
+(zpow_zero _).symm.trans_le $ zpow_le_of_le ha hn
 
-theorem zpow_bit0_nonneg (a : K) (n : ℤ) : 0 ≤ a ^ bit0 n :=
-by { rw zpow_bit0, exact mul_self_nonneg _ }
+protected lemma nat.zpow_pos_of_pos {a : ℕ} (h : 0 < a) (n : ℤ) : 0 < (a : α)^n :=
+by { apply zpow_pos_of_pos, exact_mod_cast h }
 
-theorem zpow_two_nonneg (a : K) : 0 ≤ a ^ (2 : ℤ) :=
-zpow_bit0_nonneg a 1
+lemma nat.zpow_ne_zero_of_pos {a : ℕ} (h : 0 < a) (n : ℤ) : (a : α)^n ≠ 0 :=
+(nat.zpow_pos_of_pos h n).ne'
 
-theorem zpow_bit0_pos {a : K} (h : a ≠ 0) (n : ℤ) : 0 < a ^ bit0 n :=
+lemma one_lt_zpow (ha : 1 < a) : ∀ n : ℤ, 0 < n → 1 < a ^ n
+| (n : ℕ) h := (zpow_coe_nat _ _).symm.subst (one_lt_pow ha $ int.coe_nat_ne_zero.mp h.ne')
+| -[1+ n] h := ((int.neg_succ_not_pos _).mp h).elim
+
+lemma zpow_strict_mono (hx : 1 < x) : strict_mono ((^) x : ℤ → α) :=
+strict_mono_int_of_lt_succ $ λ n,
+have xpos : 0 < x, from zero_lt_one.trans hx,
+calc x ^ n < x ^ n * x : lt_mul_of_one_lt_right (zpow_pos_of_pos xpos _) hx
+... = x ^ (n + 1) : (zpow_add_one₀ xpos.ne' _).symm
+
+lemma zpow_strict_anti (h₀ : 0 < x) (h₁ : x < 1) : strict_anti ((^) x : ℤ → α) :=
+strict_anti_int_of_succ_lt $ λ n,
+calc x ^ (n + 1) = x ^ n * x : zpow_add_one₀ h₀.ne' _
+... < x ^ n * 1 : (mul_lt_mul_left $ zpow_pos_of_pos h₀ _).2 h₁
+... = x ^ n : mul_one _
+
+@[simp] lemma zpow_lt_iff_lt (hx : 1 < x) : x ^ m < x ^ n ↔ m < n := (zpow_strict_mono hx).lt_iff_lt
+@[simp] lemma zpow_le_iff_le (hx : 1 < x) : x ^ m ≤ x ^ n ↔ m ≤ n := (zpow_strict_mono hx).le_iff_le
+
+lemma min_le_of_zpow_le_max (hx : 1 < x) {a b c : ℤ}
+  (h_max : x ^ (-c) ≤ max (x ^ (-a)) (x ^ (-b))) : min a b ≤ c :=
+begin
+  rw min_le_iff,
+  refine or.imp (λ h, _) (λ h, _) (le_max_iff.mp h_max);
+  rwa [zpow_le_iff_le hx, neg_le_neg_iff] at h
+end
+
+@[simp] lemma pos_div_pow_pos (ha : 0 < a) (hb : 0 < b) (k : ℕ) : 0 < a/b^k :=
+div_pos ha (pow_pos hb k)
+
+@[simp] lemma div_pow_le (ha : 0 < a) (hb : 1 ≤ b) (k : ℕ) : a/b^k ≤ a :=
+(div_le_iff $ pow_pos (lt_of_lt_of_le zero_lt_one hb) k).mpr
+(calc a = a * 1 : (mul_one a).symm
+   ...  ≤ a*b^k : (mul_le_mul_left ha).mpr $ one_le_pow_of_one_le hb _)
+
+lemma zpow_injective (h₀ : 0 < x) (h₁ : x ≠ 1) : injective ((^) x : ℤ → α) :=
+begin
+  intros m n h,
+  rcases h₁.lt_or_lt with H|H,
+  { apply (zpow_strict_mono (one_lt_inv h₀ H)).injective,
+    show x⁻¹ ^ m = x⁻¹ ^ n,
+    rw [← zpow_neg_one, ← zpow_mul, ← zpow_mul, mul_comm _ m, mul_comm _ n, zpow_mul, zpow_mul,
+      h], },
+  { exact (zpow_strict_mono H).injective h, },
+end
+
+@[simp] lemma zpow_inj (h₀ : 0 < x) (h₁ : x ≠ 1) : x ^ m = x ^ n ↔ m = n :=
+(zpow_injective h₀ h₁).eq_iff
+
+end linear_ordered_semifield
+
+section linear_ordered_field
+variables [linear_ordered_field α] {a x : α} {m n : ℤ}
+
+lemma zpow_bit0_nonneg (a : α) (n : ℤ) : 0 ≤ a ^ bit0 n :=
+(mul_self_nonneg _).trans_eq $ (zpow_bit0 _ _).symm
+
+lemma zpow_two_nonneg (a : α) : 0 ≤ a ^ (2 : ℤ) := zpow_bit0_nonneg _ _
+
+lemma zpow_bit0_pos (h : a ≠ 0) (n : ℤ) : 0 < a ^ bit0 n :=
 (zpow_bit0_nonneg a n).lt_of_ne (zpow_ne_zero _ h).symm
 
-theorem zpow_two_pos_of_ne_zero (a : K) (h : a ≠ 0) : 0 < a ^ (2 : ℤ) :=
-zpow_bit0_pos h 1
+lemma zpow_two_pos_of_ne_zero (h : a ≠ 0) : 0 < a ^ (2 : ℤ) := zpow_bit0_pos h _
 
 @[simp] theorem zpow_bit1_neg_iff : a ^ bit1 n < 0 ↔ a < 0 :=
 ⟨λ h, not_le.1 $ λ h', not_le.2 h $ zpow_nonneg h' _,
@@ -116,82 +174,4 @@ end
 @[simp] theorem zpow_bit1_pos_iff : 0 < a ^ bit1 n ↔ 0 < a :=
 lt_iff_lt_of_le_iff_le zpow_bit1_nonpos_iff
 
-end ordered_field_power
-
-lemma one_lt_zpow {K} [linear_ordered_field K] {p : K} (hp : 1 < p) :
-  ∀ z : ℤ, 0 < z → 1 < p ^ z
-| (n : ℕ) h := (zpow_coe_nat p n).symm.subst (one_lt_pow hp $ int.coe_nat_ne_zero.mp h.ne')
-| -[1+ n] h := ((int.neg_succ_not_pos _).mp h).elim
-
-section ordered
-variables  {K : Type*} [linear_ordered_field K]
-
-lemma nat.zpow_pos_of_pos {p : ℕ} (h : 0 < p) (n:ℤ) : 0 < (p:K)^n :=
-by { apply zpow_pos_of_pos, exact_mod_cast h }
-
-lemma nat.zpow_ne_zero_of_pos {p : ℕ} (h : 0 < p) (n:ℤ) : (p:K)^n ≠ 0 :=
-ne_of_gt (nat.zpow_pos_of_pos h n)
-
-lemma zpow_strict_mono {x : K} (hx : 1 < x) :
-  strict_mono (λ n:ℤ, x ^ n) :=
-strict_mono_int_of_lt_succ $ λ n,
-have xpos : 0 < x, from zero_lt_one.trans hx,
-calc x ^ n < x ^ n * x : lt_mul_of_one_lt_right (zpow_pos_of_pos xpos _) hx
-... = x ^ (n + 1) : (zpow_add_one₀ xpos.ne' _).symm
-
-lemma zpow_strict_anti {x : K} (h₀ : 0 < x) (h₁ : x < 1) : strict_anti (λ n : ℤ, x ^ n) :=
-strict_anti_int_of_succ_lt $ λ n,
-calc x ^ (n + 1) = x ^ n * x : zpow_add_one₀ h₀.ne' _
-... < x ^ n * 1 : (mul_lt_mul_left $ zpow_pos_of_pos h₀ _).2 h₁
-... = x ^ n : mul_one _
-
-@[simp] lemma zpow_lt_iff_lt {x : K} (hx : 1 < x) {m n : ℤ} :
-  x ^ m < x ^ n ↔ m < n :=
-(zpow_strict_mono hx).lt_iff_lt
-
-@[simp] lemma zpow_le_iff_le {x : K} (hx : 1 < x) {m n : ℤ} :
-  x ^ m ≤ x ^ n ↔ m ≤ n :=
-(zpow_strict_mono hx).le_iff_le
-
-lemma min_le_of_zpow_le_max {x : K} (hx : 1 < x) {a b c : ℤ}
-  (h_max : x ^ (-c) ≤ max (x ^ (-a)) (x ^ (-b)) ) : min a b ≤ c :=
-begin
-  rw min_le_iff,
-  refine or.imp (λ h, _) (λ h, _) (le_max_iff.mp h_max);
-  rwa [zpow_le_iff_le hx, neg_le_neg_iff] at h
-end
-
-@[simp] lemma pos_div_pow_pos {a b : K} (ha : 0 < a) (hb : 0 < b) (k : ℕ) : 0 < a/b^k :=
-div_pos ha (pow_pos hb k)
-
-@[simp] lemma div_pow_le {a b : K} (ha : 0 < a) (hb : 1 ≤ b) (k : ℕ) : a/b^k ≤ a :=
-(div_le_iff $ pow_pos (lt_of_lt_of_le zero_lt_one hb) k).mpr
-(calc a = a * 1 : (mul_one a).symm
-   ...  ≤ a*b^k : (mul_le_mul_left ha).mpr $ one_le_pow_of_one_le hb _)
-
-lemma zpow_injective {x : K} (h₀ : 0 < x) (h₁ : x ≠ 1) :
-  function.injective ((^) x : ℤ → K) :=
-begin
-  intros m n h,
-  rcases h₁.lt_or_lt with H|H,
-  { apply (zpow_strict_mono (one_lt_inv h₀ H)).injective,
-    show x⁻¹ ^ m = x⁻¹ ^ n,
-    rw [← zpow_neg_one, ← zpow_mul, ← zpow_mul, mul_comm _ m, mul_comm _ n, zpow_mul, zpow_mul,
-      h], },
-  { exact (zpow_strict_mono H).injective h, },
-end
-
-@[simp] lemma zpow_inj {x : K} (h₀ : 0 < x) (h₁ : x ≠ 1) {m n : ℤ} :
-  x ^ m = x ^ n ↔ m = n :=
-(zpow_injective h₀ h₁).eq_iff
-
-end ordered
-
-section
-variables {K : Type*} [division_ring K]
-
-@[simp, norm_cast] theorem rat.cast_zpow [char_zero K] (q : ℚ) (n : ℤ) :
-  ((q ^ n : ℚ) : K) = q ^ n :=
-(rat.cast_hom K).map_zpow q n
-
-end
+end linear_ordered_field

--- a/src/algebra/order/field.lean
+++ b/src/algebra/order/field.lean
@@ -11,29 +11,71 @@ import order.bounds
 import tactic.monotonicity.basic
 
 /-!
-# Linear ordered fields
+# Linear ordered (semi)fields
 
-A linear ordered field is a field equipped with a linear order such that
+A linear ordered (semi)field is a (semi)field equipped with a linear order such that
 * addition respects the order: `a ≤ b → c + a ≤ c + b`;
 * multiplication of positives is positive: `0 < a → 0 < b → 0 < a * b`;
 * `0 < 1`.
 
 ## Main Definitions
 
-* `linear_ordered_field`: the class of linear ordered fields.
+* `linear_ordered_semifield`: Typeclass for linear order semifields.
+* `linear_ordered_field`: Typeclass for linear ordered fields.
 -/
 
 set_option old_structure_cmd true
 
-variable {α : Type*}
+variables {α β : Type*}
+
+/-- A linear ordered semifield is a field with a linear order respecting the operations. -/
+@[protect_proj] class linear_ordered_semifield (α : Type*)
+  extends linear_ordered_semiring α, semifield α
 
 /-- A linear ordered field is a field with a linear order respecting the operations. -/
 @[protect_proj] class linear_ordered_field (α : Type*) extends linear_ordered_comm_ring α, field α
 
-section linear_ordered_field
-variables [linear_ordered_field α] {a b c d e : α}
+@[priority 100] -- See note [lower instance priority]
+instance linear_ordered_field.to_linear_ordered_semifield [linear_ordered_field α] :
+  linear_ordered_semifield α :=
+{ ..linear_ordered_ring.to_linear_ordered_semiring, ..‹linear_ordered_field α› }
 
-section
+namespace function
+
+/-- Pullback a `linear_ordered_semifield` under an injective map. -/
+@[reducible] -- See note [reducible non-instances]
+def injective.linear_ordered_semifield [linear_ordered_semifield α] [has_zero β] [has_one β]
+  [has_add β] [has_mul β] [has_pow β ℕ] [has_scalar ℕ β] [has_nat_cast β] [has_inv β] [has_div β]
+  [has_pow β ℤ] (f : β → α) (hf : injective f) (zero : f 0 = 0) (one : f 1 = 1)
+  (add : ∀ x y, f (x + y) = f x + f y) (mul : ∀ x y, f (x * y) = f x * f y)
+  (inv : ∀ x, f (x⁻¹) = (f x)⁻¹) (div : ∀ x y, f (x / y) = f x / f y)
+  (nsmul : ∀ x (n : ℕ), f (n • x) = n • f x)
+  (npow : ∀ x (n : ℕ), f (x ^ n) = f x ^ n) (zpow : ∀ x (n : ℤ), f (x ^ n) = f x ^ n)
+  (nat_cast : ∀ n : ℕ, f n = n) :
+  linear_ordered_semifield β :=
+{ ..hf.linear_ordered_semiring f zero one add mul nsmul npow nat_cast,
+  ..hf.semifield f zero one add mul inv div nsmul npow zpow nat_cast }
+
+/-- Pullback a `linear_ordered_field` under an injective map. -/
+@[reducible] -- See note [reducible non-instances]
+def injective.linear_ordered_field [linear_ordered_field α] [has_zero β] [has_one β] [has_add β]
+  [has_mul β] [has_neg β] [has_sub β] [has_pow β ℕ] [has_scalar ℕ β] [has_scalar ℤ β]
+  [has_nat_cast β] [has_int_cast β][has_inv β] [has_div β] [has_pow β ℤ]
+  (f : β → α) (hf : injective f) (zero : f 0 = 0) (one : f 1 = 1)
+  (add : ∀ x y, f (x + y) = f x + f y) (mul : ∀ x y, f (x * y) = f x * f y)
+  (neg : ∀ x, f (-x) = -f x) (sub : ∀ x y, f (x - y) = f x - f y)
+  (inv : ∀ x, f (x⁻¹) = (f x)⁻¹) (div : ∀ x y, f (x / y) = f x / f y)
+  (nsmul : ∀ x (n : ℕ), f (n • x) = n • f x) (zsmul : ∀ x (n : ℤ), f (n • x) = n • f x)
+  (npow : ∀ x (n : ℕ), f (x ^ n) = f x ^ n) (zpow : ∀ x (n : ℤ), f (x ^ n) = f x ^ n)
+  (nat_cast : ∀ n : ℕ, f n = n) (int_cast : ∀ n : ℤ, f n = n) :
+  linear_ordered_field β :=
+{ .. hf.linear_ordered_ring f zero one add mul neg sub nsmul zsmul npow nat_cast int_cast,
+  .. hf.field f zero one add mul neg sub inv div nsmul zsmul npow zpow nat_cast int_cast }
+
+end function
+
+section linear_ordered_semifield
+variables [linear_ordered_semifield α] {a b c d e : α}
 
 /-- `equiv.mul_left₀` as an order_iso. -/
 @[simps {simp_rhs := tt}]
@@ -44,8 +86,6 @@ def order_iso.mul_left₀ (a : α) (ha : 0 < a) : α ≃o α :=
 @[simps {simp_rhs := tt}]
 def order_iso.mul_right₀ (a : α) (ha : 0 < a) : α ≃o α :=
 { map_rel_iff' := λ _ _, mul_le_mul_right ha, ..equiv.mul_right₀ a ha.ne' }
-
-end
 
 /-!
 ### Lemmas about pos, nonneg, nonpos, neg
@@ -77,41 +117,11 @@ inv_eq_one_div a ▸ inv_nonneg
 lemma one_div_nonpos : 1 / a ≤ 0 ↔ a ≤ 0 :=
 inv_eq_one_div a ▸ inv_nonpos
 
-lemma div_pos_iff : 0 < a / b ↔ 0 < a ∧ 0 < b ∨ a < 0 ∧ b < 0 :=
-by simp [division_def, mul_pos_iff]
-
-lemma div_neg_iff : a / b < 0 ↔ 0 < a ∧ b < 0 ∨ a < 0 ∧ 0 < b :=
-by simp [division_def, mul_neg_iff]
-
-lemma div_nonneg_iff : 0 ≤ a / b ↔ 0 ≤ a ∧ 0 ≤ b ∨ a ≤ 0 ∧ b ≤ 0 :=
-by simp [division_def, mul_nonneg_iff]
-
-lemma div_nonpos_iff : a / b ≤ 0 ↔ 0 ≤ a ∧ b ≤ 0 ∨ a ≤ 0 ∧ 0 ≤ b :=
-by simp [division_def, mul_nonpos_iff]
-
 lemma div_pos (ha : 0 < a) (hb : 0 < b) : 0 < a / b :=
-div_pos_iff.2 $ or.inl ⟨ha, hb⟩
-
-lemma div_pos_of_neg_of_neg (ha : a < 0) (hb : b < 0) : 0 < a / b :=
-div_pos_iff.2 $ or.inr ⟨ha, hb⟩
-
-lemma div_neg_of_neg_of_pos (ha : a < 0) (hb : 0 < b) : a / b < 0 :=
-div_neg_iff.2 $ or.inr ⟨ha, hb⟩
-
-lemma div_neg_of_pos_of_neg (ha : 0 < a) (hb : b < 0) : a / b < 0 :=
-div_neg_iff.2 $ or.inl ⟨ha, hb⟩
+by { rw div_eq_mul_inv, exact mul_pos ha (inv_pos.2 hb) }
 
 lemma div_nonneg (ha : 0 ≤ a) (hb : 0 ≤ b) : 0 ≤ a / b :=
-div_nonneg_iff.2 $ or.inl ⟨ha, hb⟩
-
-lemma div_nonneg_of_nonpos (ha : a ≤ 0) (hb : b ≤ 0) : 0 ≤ a / b :=
-div_nonneg_iff.2 $ or.inr ⟨ha, hb⟩
-
-lemma div_nonpos_of_nonpos_of_nonneg (ha : a ≤ 0) (hb : 0 ≤ b) : a / b ≤ 0 :=
-div_nonpos_iff.2 $ or.inr ⟨ha, hb⟩
-
-lemma div_nonpos_of_nonneg_of_nonpos (ha : 0 ≤ a) (hb : b ≤ 0) : a / b ≤ 0 :=
-div_nonpos_iff.2 $ or.inl ⟨ha, hb⟩
+by { rw div_eq_mul_inv, exact mul_nonneg ha (inv_nonneg.2 hb) }
 
 /-!
 ### Relating one division with another term.
@@ -197,35 +207,6 @@ by { rw [inv_eq_one_div], exact div_lt_iff ha }
 lemma inv_pos_lt_iff_one_lt_mul' (ha : 0 < a) : a⁻¹ < b ↔ 1 < a * b :=
 by { rw [inv_eq_one_div], exact div_lt_iff' ha }
 
-lemma div_le_iff_of_neg (hc : c < 0) : b / c ≤ a ↔ a * c ≤ b :=
-⟨λ h, div_mul_cancel b (ne_of_lt hc) ▸ mul_le_mul_of_nonpos_right h hc.le,
-  λ h, calc
-    a = a * c * (1 / c) : mul_mul_div a (ne_of_lt hc)
-  ... ≥ b * (1 / c)     : mul_le_mul_of_nonpos_right h (one_div_neg.2 hc).le
-  ... = b / c           : (div_eq_mul_one_div b c).symm⟩
-
-lemma div_le_iff_of_neg' (hc : c < 0) : b / c ≤ a ↔ c * a ≤ b :=
-by rw [mul_comm, div_le_iff_of_neg hc]
-
-lemma le_div_iff_of_neg (hc : c < 0) : a ≤ b / c ↔ b ≤ a * c :=
-by rw [← neg_neg c, mul_neg, div_neg, le_neg,
-    div_le_iff (neg_pos.2 hc), neg_mul]
-
-lemma le_div_iff_of_neg' (hc : c < 0) : a ≤ b / c ↔ b ≤ c * a :=
-by rw [mul_comm, le_div_iff_of_neg hc]
-
-lemma div_lt_iff_of_neg (hc : c < 0) : b / c < a ↔ a * c < b :=
-lt_iff_lt_of_le_iff_le $ le_div_iff_of_neg hc
-
-lemma div_lt_iff_of_neg' (hc : c < 0) : b / c < a ↔ c * a < b :=
-by rw [mul_comm, div_lt_iff_of_neg hc]
-
-lemma lt_div_iff_of_neg (hc : c < 0) : a < b / c ↔ b < a * c :=
-lt_iff_lt_of_le_iff_le $ div_le_iff_of_neg hc
-
-lemma lt_div_iff_of_neg' (hc : c < 0) : a < b / c ↔ b < c * a :=
-by rw [mul_comm, lt_div_iff_of_neg hc]
-
 /-- One direction of `div_le_iff` where `b` is allowed to be `0` (but `c` must be nonnegative) -/
 lemma div_le_of_nonneg_of_le_mul (hb : 0 ≤ b) (hc : 0 ≤ c) (h : a ≤ c * b) : a / b ≤ c :=
 by { rcases eq_or_lt_of_le hb with rfl|hb', simp [hc], rwa [div_le_iff hb'] }
@@ -272,24 +253,6 @@ lemma inv_lt_of_inv_lt (ha : 0 < a) (h : a⁻¹ < b) : b⁻¹ < a :=
 
 lemma lt_inv (ha : 0 < a) (hb : 0 < b) : a < b⁻¹ ↔ b < a⁻¹ :=
 lt_iff_lt_of_le_iff_le (inv_le hb ha)
-
-lemma inv_le_inv_of_neg (ha : a < 0) (hb : b < 0) : a⁻¹ ≤ b⁻¹ ↔ b ≤ a :=
-by rw [← one_div, div_le_iff_of_neg ha, ← div_eq_inv_mul, div_le_iff_of_neg hb, one_mul]
-
-lemma inv_le_of_neg (ha : a < 0) (hb : b < 0) : a⁻¹ ≤ b ↔ b⁻¹ ≤ a :=
-by rw [← inv_le_inv_of_neg hb (inv_lt_zero.2 ha), inv_inv]
-
-lemma le_inv_of_neg (ha : a < 0) (hb : b < 0) : a ≤ b⁻¹ ↔ b ≤ a⁻¹ :=
-by rw [← inv_le_inv_of_neg (inv_lt_zero.2 hb) ha, inv_inv]
-
-lemma inv_lt_inv_of_neg (ha : a < 0) (hb : b < 0) : a⁻¹ < b⁻¹ ↔ b < a :=
-lt_iff_lt_of_le_iff_le (inv_le_inv_of_neg hb ha)
-
-lemma inv_lt_of_neg (ha : a < 0) (hb : b < 0) : a⁻¹ < b ↔ b⁻¹ < a :=
-lt_iff_lt_of_le_iff_le (le_inv_of_neg hb ha)
-
-lemma lt_inv_of_neg (ha : a < 0) (hb : b < 0) : a < b⁻¹ ↔ b < a⁻¹ :=
-lt_iff_lt_of_le_iff_le (inv_le_of_neg hb ha)
 
 lemma inv_lt_one (ha : 1 < a) : a⁻¹ < 1 :=
 by rwa [inv_lt ((@zero_lt_one α _ _).trans ha) zero_lt_one, inv_one]
@@ -346,35 +309,17 @@ end
 lemma div_le_div_of_le_of_nonneg (hab : a ≤ b) (hc : 0 ≤ c) : a / c ≤ b / c :=
 div_le_div_of_le hc hab
 
-lemma div_le_div_of_nonpos_of_le (hc : c ≤ 0) (h : b ≤ a) : a / c ≤ b / c :=
-begin
-  rw [div_eq_mul_one_div a c, div_eq_mul_one_div b c],
-  exact mul_le_mul_of_nonpos_right h (one_div_nonpos.2 hc)
-end
-
 lemma div_lt_div_of_lt (hc : 0 < c) (h : a < b) : a / c < b / c :=
 begin
   rw [div_eq_mul_one_div a c, div_eq_mul_one_div b c],
   exact mul_lt_mul_of_pos_right h (one_div_pos.2 hc)
 end
 
-lemma div_lt_div_of_neg_of_lt (hc : c < 0) (h : b < a) : a / c < b / c :=
-begin
-  rw [div_eq_mul_one_div a c, div_eq_mul_one_div b c],
-  exact mul_lt_mul_of_neg_right h (one_div_neg.2 hc)
-end
-
 lemma div_le_div_right (hc : 0 < c) : a / c ≤ b / c ↔ a ≤ b :=
 ⟨le_imp_le_of_lt_imp_lt $ div_lt_div_of_lt hc, div_le_div_of_le $ hc.le⟩
 
-lemma div_le_div_right_of_neg (hc : c < 0) : a / c ≤ b / c ↔ b ≤ a :=
-⟨le_imp_le_of_lt_imp_lt $ div_lt_div_of_neg_of_lt hc, div_le_div_of_nonpos_of_le $ hc.le⟩
-
 lemma div_lt_div_right (hc : 0 < c) : a / c < b / c ↔ a < b :=
 lt_iff_lt_of_le_iff_le $ div_le_div_right hc
-
-lemma div_lt_div_right_of_neg (hc : c < 0) : a / c < b / c ↔ b < a :=
-lt_iff_lt_of_le_iff_le $ div_le_div_right_of_neg hc
 
 lemma div_lt_div_left (ha : 0 < a) (hb : 0 < b) (hc : 0 < c) : a / b < a / c ↔ c < b :=
 by simp only [div_eq_mul_inv, mul_lt_mul_left ha, inv_lt_inv hb hc]
@@ -428,18 +373,6 @@ by rw [lt_div_iff hb, one_mul]
 lemma div_lt_one (hb : 0 < b) : a / b < 1 ↔ a < b :=
 by rw [div_lt_iff hb, one_mul]
 
-lemma one_le_div_of_neg (hb : b < 0) : 1 ≤ a / b ↔ a ≤ b :=
-by rw [le_div_iff_of_neg hb, one_mul]
-
-lemma div_le_one_of_neg (hb : b < 0) : a / b ≤ 1 ↔ b ≤ a :=
-by rw [div_le_iff_of_neg hb, one_mul]
-
-lemma one_lt_div_of_neg (hb : b < 0) : 1 < a / b ↔ a < b :=
-by rw [lt_div_iff_of_neg hb, one_mul]
-
-lemma div_lt_one_of_neg (hb : b < 0) : a / b < 1 ↔ b < a :=
-by rw [div_lt_iff_of_neg hb, one_mul]
-
 lemma one_div_le (ha : 0 < a) (hb : 0 < b) : 1 / a ≤ b ↔ 1 / b ≤ a :=
 by simpa using inv_le ha hb
 
@@ -451,6 +384,285 @@ by simpa using le_inv ha hb
 
 lemma lt_one_div (ha : 0 < a) (hb : 0 < b) : a < 1 / b ↔ b < 1 / a :=
 by simpa using lt_inv ha hb
+
+/-!
+### Relating two divisions, involving `1`
+-/
+lemma one_div_le_one_div_of_le (ha : 0 < a) (h : a ≤ b) : 1 / b ≤ 1 / a :=
+by simpa using inv_le_inv_of_le ha h
+
+lemma one_div_lt_one_div_of_lt (ha : 0 < a) (h : a < b) : 1 / b < 1 / a :=
+by rwa [lt_div_iff' ha, ← div_eq_mul_one_div, div_lt_one (ha.trans h)]
+
+lemma le_of_one_div_le_one_div (ha : 0 < a) (h : 1 / a ≤ 1 / b) : b ≤ a :=
+le_imp_le_of_lt_imp_lt (one_div_lt_one_div_of_lt ha) h
+
+lemma lt_of_one_div_lt_one_div (ha : 0 < a) (h : 1 / a < 1 / b) : b < a :=
+lt_imp_lt_of_le_imp_le (one_div_le_one_div_of_le ha) h
+
+/-- For the single implications with fewer assumptions, see `one_div_le_one_div_of_le` and
+  `le_of_one_div_le_one_div` -/
+lemma one_div_le_one_div (ha : 0 < a) (hb : 0 < b) : 1 / a ≤ 1 / b ↔ b ≤ a :=
+div_le_div_left zero_lt_one ha hb
+
+/-- For the single implications with fewer assumptions, see `one_div_lt_one_div_of_lt` and
+  `lt_of_one_div_lt_one_div` -/
+lemma one_div_lt_one_div (ha : 0 < a) (hb : 0 < b) : 1 / a < 1 / b ↔ b < a :=
+div_lt_div_left zero_lt_one ha hb
+
+lemma one_lt_one_div (h1 : 0 < a) (h2 : a < 1) : 1 < 1 / a :=
+by rwa [lt_one_div (@zero_lt_one α _ _) h1, one_div_one]
+
+lemma one_le_one_div (h1 : 0 < a) (h2 : a ≤ 1) : 1 ≤ 1 / a :=
+by rwa [le_one_div (@zero_lt_one α _ _) h1, one_div_one]
+
+/-!
+### Results about halving.
+
+The equalities also hold in semifields of characteristic `0`.
+-/
+
+/- TODO: Unify `add_halves` and `add_halves'` into a single lemma about
+`division_semiring` + `char_zero` -/
+lemma add_halves (a : α) : a / 2 + a / 2 = a :=
+by rw [div_add_div_same, ← two_mul, mul_div_cancel_left a two_ne_zero]
+
+-- TODO: Generalize to `division_semiring`
+lemma add_self_div_two (a : α) : (a + a) / 2 = a :=
+by rw [← mul_two, mul_div_cancel a two_ne_zero]
+
+lemma half_pos (h : 0 < a) : 0 < a / 2 := div_pos h zero_lt_two
+
+lemma one_half_pos : (0:α) < 1 / 2 := half_pos zero_lt_one
+
+lemma div_two_lt_of_pos (h : 0 < a) : a / 2 < a :=
+by { rw [div_lt_iff (@zero_lt_two α _ _)], exact lt_mul_of_one_lt_right h one_lt_two }
+
+lemma half_lt_self : 0 < a → a / 2 < a := div_two_lt_of_pos
+
+lemma half_le_self (ha_nonneg : 0 ≤ a) : a / 2 ≤ a :=
+begin
+  by_cases h0 : a = 0,
+  { simp [h0], },
+  { rw ← ne.def at h0,
+    exact (half_lt_self (lt_of_le_of_ne ha_nonneg h0.symm)).le, },
+end
+
+lemma one_half_lt_one : (1 / 2 : α) < 1 := half_lt_self zero_lt_one
+
+lemma left_lt_add_div_two : a < (a + b) / 2 ↔ a < b := by simp [lt_div_iff, mul_two]
+
+lemma add_div_two_lt_right : (a + b) / 2 < b ↔ a < b := by simp [div_lt_iff, mul_two]
+
+/-!
+### Miscellaneous lemmas
+-/
+
+lemma mul_le_mul_of_mul_div_le (h : a * (b / c) ≤ d) (hc : 0 < c) : b * a ≤ d * c :=
+begin
+  rw [← mul_div_assoc] at h,
+  rwa [mul_comm b, ← div_le_iff hc],
+end
+
+lemma div_mul_le_div_mul_of_div_le_div (h : a / b ≤ c / d) (he : 0 ≤ e) :
+  a / (b * e) ≤ c / (d * e) :=
+begin
+  rw [div_mul_eq_div_mul_one_div, div_mul_eq_div_mul_one_div],
+  exact mul_le_mul_of_nonneg_right h (one_div_nonneg.2 he)
+end
+
+lemma exists_pos_mul_lt {a : α} (h : 0 < a) (b : α) : ∃ c : α, 0 < c ∧ b * c < a :=
+begin
+  have : 0 < a / max (b + 1) 1, from div_pos h (lt_max_iff.2 (or.inr zero_lt_one)),
+  refine ⟨a / max (b + 1) 1, this, _⟩,
+  rw [← lt_div_iff this, div_div_cancel' h.ne'],
+  exact lt_max_iff.2 (or.inl $ lt_add_one _)
+end
+
+lemma monotone.div_const {β : Type*} [preorder β] {f : β → α} (hf : monotone f)
+  {c : α} (hc : 0 ≤ c) : monotone (λ x, (f x) / c) :=
+by simpa only [div_eq_mul_inv] using hf.mul_const (inv_nonneg.2 hc)
+
+lemma strict_mono.div_const {β : Type*} [preorder β] {f : β → α} (hf : strict_mono f)
+  {c : α} (hc : 0 < c) :
+  strict_mono (λ x, (f x) / c) :=
+by simpa only [div_eq_mul_inv] using hf.mul_const (inv_pos.2 hc)
+
+@[priority 100] -- see Note [lower instance priority]
+instance linear_ordered_field.to_densely_ordered : densely_ordered α :=
+{ dense := λ a₁ a₂ h, ⟨(a₁ + a₂) / 2,
+  calc a₁ = (a₁ + a₁) / 2 : (add_self_div_two a₁).symm
+      ... < (a₁ + a₂) / 2 : div_lt_div_of_lt zero_lt_two (add_lt_add_left h _),
+  calc (a₁ + a₂) / 2 < (a₂ + a₂) / 2 : div_lt_div_of_lt zero_lt_two (add_lt_add_right h _)
+                 ... = a₂            : add_self_div_two a₂⟩ }
+
+lemma min_div_div_right {c : α} (hc : 0 ≤ c) (a b : α) : min (a / c) (b / c) = (min a b) / c :=
+eq.symm $ monotone.map_min (λ x y, div_le_div_of_le hc)
+
+lemma max_div_div_right {c : α} (hc : 0 ≤ c) (a b : α) : max (a / c) (b / c) = (max a b) / c :=
+eq.symm $ monotone.map_max (λ x y, div_le_div_of_le hc)
+
+lemma one_div_strict_anti_on : strict_anti_on (λ x : α, 1 / x) (set.Ioi 0) :=
+λ x x1 y y1 xy, (one_div_lt_one_div (set.mem_Ioi.mp y1) (set.mem_Ioi.mp x1)).mpr xy
+
+lemma one_div_pow_le_one_div_pow_of_le (a1 : 1 ≤ a) {m n : ℕ} (mn : m ≤ n) :
+  1 / a ^ n ≤ 1 / a ^ m :=
+by refine (one_div_le_one_div _ _).mpr (pow_le_pow a1 mn);
+  exact pow_pos (zero_lt_one.trans_le a1) _
+
+lemma one_div_pow_lt_one_div_pow_of_lt (a1 : 1 < a) {m n : ℕ} (mn : m < n) :
+  1 / a ^ n < 1 / a ^ m :=
+by refine (one_div_lt_one_div _ _).mpr (pow_lt_pow a1 mn);
+  exact pow_pos (trans zero_lt_one a1) _
+
+lemma one_div_pow_anti (a1 : 1 ≤ a) : antitone (λ n : ℕ, 1 / a ^ n) :=
+λ m n, one_div_pow_le_one_div_pow_of_le a1
+
+lemma one_div_pow_strict_anti (a1 : 1 < a) : strict_anti (λ n : ℕ, 1 / a ^ n) :=
+λ m n, one_div_pow_lt_one_div_pow_of_lt a1
+
+lemma inv_strict_anti_on : strict_anti_on (λ x : α, x⁻¹) (set.Ioi 0) :=
+λ x hx y hy xy, (inv_lt_inv hy hx).2 xy
+
+lemma inv_pow_le_inv_pow_of_le (a1 : 1 ≤ a) {m n : ℕ} (mn : m ≤ n) :
+  (a ^ n)⁻¹ ≤ (a ^ m)⁻¹ :=
+by convert one_div_pow_le_one_div_pow_of_le a1 mn; simp
+
+lemma inv_pow_lt_inv_pow_of_lt (a1 : 1 < a) {m n : ℕ} (mn : m < n) :
+  (a ^ n)⁻¹ < (a ^ m)⁻¹ :=
+by convert one_div_pow_lt_one_div_pow_of_lt a1 mn; simp
+
+lemma inv_pow_anti (a1 : 1 ≤ a) : antitone (λ n : ℕ, (a ^ n)⁻¹) :=
+λ m n, inv_pow_le_inv_pow_of_le a1
+
+lemma inv_pow_strict_anti (a1 : 1 < a) : strict_anti (λ n : ℕ, (a ^ n)⁻¹) :=
+λ m n, inv_pow_lt_inv_pow_of_lt a1
+
+/-! ### Results about `is_lub` and `is_glb` -/
+
+lemma is_glb.mul_left {s : set α} (ha : 0 ≤ a) (hs : is_glb s b) :
+  is_glb ((λ b, a * b) '' s) (a * b) :=
+begin
+  rcases lt_or_eq_of_le ha with ha | rfl,
+  { exact (order_iso.mul_left₀ _ ha).is_glb_image'.2 hs, },
+  { simp_rw zero_mul,
+    rw hs.nonempty.image_const,
+    exact is_glb_singleton },
+end
+
+lemma is_glb.mul_right {s : set α} (ha : 0 ≤ a) (hs : is_glb s b) :
+  is_glb ((λ b, b * a) '' s) (b * a) :=
+by simpa [mul_comm] using hs.mul_left ha
+
+end linear_ordered_semifield
+
+section
+variables [linear_ordered_field α] {a b c d : α}
+
+/-! ### Lemmas about pos, nonneg, nonpos, neg -/
+
+lemma div_pos_iff : 0 < a / b ↔ 0 < a ∧ 0 < b ∨ a < 0 ∧ b < 0 := by simp [division_def, mul_pos_iff]
+lemma div_neg_iff : a / b < 0 ↔ 0 < a ∧ b < 0 ∨ a < 0 ∧ 0 < b := by simp [division_def, mul_neg_iff]
+
+lemma div_nonneg_iff : 0 ≤ a / b ↔ 0 ≤ a ∧ 0 ≤ b ∨ a ≤ 0 ∧ b ≤ 0 :=
+by simp [division_def, mul_nonneg_iff]
+
+lemma div_nonpos_iff : a / b ≤ 0 ↔ 0 ≤ a ∧ b ≤ 0 ∨ a ≤ 0 ∧ 0 ≤ b :=
+by simp [division_def, mul_nonpos_iff]
+
+lemma div_pos_of_neg_of_neg (ha : a < 0) (hb : b < 0) : 0 < a / b :=
+div_pos_iff.2 $ or.inr ⟨ha, hb⟩
+
+lemma div_neg_of_neg_of_pos (ha : a < 0) (hb : 0 < b) : a / b < 0 :=
+div_neg_iff.2 $ or.inr ⟨ha, hb⟩
+
+lemma div_neg_of_pos_of_neg (ha : 0 < a) (hb : b < 0) : a / b < 0 :=
+div_neg_iff.2 $ or.inl ⟨ha, hb⟩
+
+/-! ### Relating one division with another term -/
+
+lemma div_le_iff_of_neg (hc : c < 0) : b / c ≤ a ↔ a * c ≤ b :=
+⟨λ h, div_mul_cancel b (ne_of_lt hc) ▸ mul_le_mul_of_nonpos_right h hc.le,
+  λ h, calc
+    a = a * c * (1 / c) : mul_mul_div a (ne_of_lt hc)
+  ... ≥ b * (1 / c)     : mul_le_mul_of_nonpos_right h (one_div_neg.2 hc).le
+  ... = b / c           : (div_eq_mul_one_div b c).symm⟩
+
+lemma div_le_iff_of_neg' (hc : c < 0) : b / c ≤ a ↔ c * a ≤ b :=
+by rw [mul_comm, div_le_iff_of_neg hc]
+
+lemma le_div_iff_of_neg (hc : c < 0) : a ≤ b / c ↔ b ≤ a * c :=
+by rw [← neg_neg c, mul_neg, div_neg, le_neg,
+    div_le_iff (neg_pos.2 hc), neg_mul]
+
+lemma le_div_iff_of_neg' (hc : c < 0) : a ≤ b / c ↔ b ≤ c * a :=
+by rw [mul_comm, le_div_iff_of_neg hc]
+
+lemma div_lt_iff_of_neg (hc : c < 0) : b / c < a ↔ a * c < b :=
+lt_iff_lt_of_le_iff_le $ le_div_iff_of_neg hc
+
+lemma div_lt_iff_of_neg' (hc : c < 0) : b / c < a ↔ c * a < b :=
+by rw [mul_comm, div_lt_iff_of_neg hc]
+
+lemma lt_div_iff_of_neg (hc : c < 0) : a < b / c ↔ b < a * c :=
+lt_iff_lt_of_le_iff_le $ div_le_iff_of_neg hc
+
+lemma lt_div_iff_of_neg' (hc : c < 0) : a < b / c ↔ b < c * a :=
+by rw [mul_comm, lt_div_iff_of_neg hc]
+
+/-! ### Bi-implications of inequalities using inversions -/
+
+lemma inv_le_inv_of_neg (ha : a < 0) (hb : b < 0) : a⁻¹ ≤ b⁻¹ ↔ b ≤ a :=
+by rw [← one_div, div_le_iff_of_neg ha, ← div_eq_inv_mul, div_le_iff_of_neg hb, one_mul]
+
+lemma inv_le_of_neg (ha : a < 0) (hb : b < 0) : a⁻¹ ≤ b ↔ b⁻¹ ≤ a :=
+by rw [← inv_le_inv_of_neg hb (inv_lt_zero.2 ha), inv_inv]
+
+lemma le_inv_of_neg (ha : a < 0) (hb : b < 0) : a ≤ b⁻¹ ↔ b ≤ a⁻¹ :=
+by rw [← inv_le_inv_of_neg (inv_lt_zero.2 hb) ha, inv_inv]
+
+lemma inv_lt_inv_of_neg (ha : a < 0) (hb : b < 0) : a⁻¹ < b⁻¹ ↔ b < a :=
+lt_iff_lt_of_le_iff_le (inv_le_inv_of_neg hb ha)
+
+lemma inv_lt_of_neg (ha : a < 0) (hb : b < 0) : a⁻¹ < b ↔ b⁻¹ < a :=
+lt_iff_lt_of_le_iff_le (le_inv_of_neg hb ha)
+
+lemma lt_inv_of_neg (ha : a < 0) (hb : b < 0) : a < b⁻¹ ↔ b < a⁻¹ :=
+lt_iff_lt_of_le_iff_le (inv_le_of_neg hb ha)
+
+/-! ### Relating two divisions -/
+
+lemma div_le_div_of_nonpos_of_le (hc : c ≤ 0) (h : b ≤ a) : a / c ≤ b / c :=
+begin
+  rw [div_eq_mul_one_div a c, div_eq_mul_one_div b c],
+  exact mul_le_mul_of_nonpos_right h (one_div_nonpos.2 hc)
+end
+
+lemma div_lt_div_of_neg_of_lt (hc : c < 0) (h : b < a) : a / c < b / c :=
+begin
+  rw [div_eq_mul_one_div a c, div_eq_mul_one_div b c],
+  exact mul_lt_mul_of_neg_right h (one_div_neg.2 hc)
+end
+
+lemma div_le_div_right_of_neg (hc : c < 0) : a / c ≤ b / c ↔ b ≤ a :=
+⟨le_imp_le_of_lt_imp_lt $ div_lt_div_of_neg_of_lt hc, div_le_div_of_nonpos_of_le $ hc.le⟩
+
+lemma div_lt_div_right_of_neg (hc : c < 0) : a / c < b / c ↔ b < a :=
+lt_iff_lt_of_le_iff_le $ div_le_div_right_of_neg hc
+
+/-! ### Relating one division and involving `1` -/
+
+lemma one_le_div_of_neg (hb : b < 0) : 1 ≤ a / b ↔ a ≤ b :=
+by rw [le_div_iff_of_neg hb, one_mul]
+
+lemma div_le_one_of_neg (hb : b < 0) : a / b ≤ 1 ↔ b ≤ a :=
+by rw [div_le_iff_of_neg hb, one_mul]
+
+lemma one_lt_div_of_neg (hb : b < 0) : 1 < a / b ↔ a < b :=
+by rw [lt_div_iff_of_neg hb, one_mul]
+
+lemma div_lt_one_of_neg (hb : b < 0) : a / b < 1 ↔ b < a :=
+by rw [div_lt_iff_of_neg hb, one_mul]
 
 lemma one_div_le_of_neg (ha : a < 0) (hb : b < 0) : 1 / a ≤ b ↔ 1 / b ≤ a :=
 by simpa using inv_le_of_neg ha hb
@@ -496,14 +708,7 @@ begin
   { simp [hb, hb.not_lt, div_le_one, hb.ne.symm] }
 end
 
-/-!
-### Relating two divisions, involving `1`
--/
-lemma one_div_le_one_div_of_le (ha : 0 < a) (h : a ≤ b) : 1 / b ≤ 1 / a :=
-by simpa using inv_le_inv_of_le ha h
-
-lemma one_div_lt_one_div_of_lt (ha : 0 < a) (h : a < b) : 1 / b < 1 / a :=
-by rwa [lt_div_iff' ha, ← div_eq_mul_one_div, div_lt_one (ha.trans h)]
+/-! ### Relating two divisions, involving `1` -/
 
 lemma one_div_le_one_div_of_neg_of_le (hb : b < 0) (h : a ≤ b) : 1 / b ≤ 1 / a :=
 by rwa [div_le_iff_of_neg' hb, ← div_eq_mul_one_div, div_le_one_of_neg (h.trans_lt hb)]
@@ -511,27 +716,11 @@ by rwa [div_le_iff_of_neg' hb, ← div_eq_mul_one_div, div_le_one_of_neg (h.tran
 lemma one_div_lt_one_div_of_neg_of_lt (hb : b < 0) (h : a < b) : 1 / b < 1 / a :=
 by rwa [div_lt_iff_of_neg' hb, ← div_eq_mul_one_div, div_lt_one_of_neg (h.trans hb)]
 
-lemma le_of_one_div_le_one_div (ha : 0 < a) (h : 1 / a ≤ 1 / b) : b ≤ a :=
-le_imp_le_of_lt_imp_lt (one_div_lt_one_div_of_lt ha) h
-
-lemma lt_of_one_div_lt_one_div (ha : 0 < a) (h : 1 / a < 1 / b) : b < a :=
-lt_imp_lt_of_le_imp_le (one_div_le_one_div_of_le ha) h
-
 lemma le_of_neg_of_one_div_le_one_div (hb : b < 0) (h : 1 / a ≤ 1 / b) : b ≤ a :=
 le_imp_le_of_lt_imp_lt (one_div_lt_one_div_of_neg_of_lt hb) h
 
 lemma lt_of_neg_of_one_div_lt_one_div (hb : b < 0) (h : 1 / a < 1 / b) : b < a :=
 lt_imp_lt_of_le_imp_le (one_div_le_one_div_of_neg_of_le hb) h
-
-/-- For the single implications with fewer assumptions, see `one_div_le_one_div_of_le` and
-  `le_of_one_div_le_one_div` -/
-lemma one_div_le_one_div (ha : 0 < a) (hb : 0 < b) : 1 / a ≤ 1 / b ↔ b ≤ a :=
-div_le_div_left zero_lt_one ha hb
-
-/-- For the single implications with fewer assumptions, see `one_div_lt_one_div_of_lt` and
-  `lt_of_one_div_lt_one_div` -/
-lemma one_div_lt_one_div (ha : 0 < a) (hb : 0 < b) : 1 / a < 1 / b ↔ b < a :=
-div_lt_div_left zero_lt_one ha hb
 
 /-- For the single implications with fewer assumptions, see `one_div_lt_one_div_of_neg_of_lt` and
   `lt_of_one_div_lt_one_div` -/
@@ -543,12 +732,6 @@ by simpa [one_div] using inv_le_inv_of_neg ha hb
 lemma one_div_lt_one_div_of_neg (ha : a < 0) (hb : b < 0) : 1 / a < 1 / b ↔ b < a :=
 lt_iff_lt_of_le_iff_le (one_div_le_one_div_of_neg hb ha)
 
-lemma one_lt_one_div (h1 : 0 < a) (h2 : a < 1) : 1 < 1 / a :=
-by rwa [lt_one_div (@zero_lt_one α _ _) h1, one_div_one]
-
-lemma one_le_one_div (h1 : 0 < a) (h2 : a ≤ 1) : 1 ≤ 1 / a :=
-by rwa [le_one_div (@zero_lt_one α _ _) h1, one_div_one]
-
 lemma one_div_lt_neg_one (h1 : a < 0) (h2 : -1 < a) : 1 / a < -1 :=
 suffices 1 / a < 1 / -1, by rwa one_div_neg_one_eq_neg_one at this,
 one_div_lt_one_div_of_neg_of_lt h1 h2
@@ -557,12 +740,7 @@ lemma one_div_le_neg_one (h1 : a < 0) (h2 : -1 ≤ a) : 1 / a ≤ -1 :=
 suffices 1 / a ≤ 1 / -1, by rwa one_div_neg_one_eq_neg_one at this,
 one_div_le_one_div_of_neg_of_le h1 h2
 
-/-!
-### Results about halving.
-
-The equalities also hold in fields of characteristic `0`. -/
-lemma add_halves (a : α) : a / 2 + a / 2 = a :=
-by rw [div_add_div_same, ← two_mul, mul_div_cancel_left a two_ne_zero]
+/-! ### Results about halving -/
 
 lemma sub_self_div_two (a : α) : a - a / 2 = a / 2 :=
 suffices a / 2 + a / 2 - a / 2 = a / 2, by rwa add_halves at this,
@@ -572,198 +750,28 @@ lemma div_two_sub_self (a : α) : a / 2 - a = - (a / 2) :=
 suffices a / 2 - (a / 2 + a / 2) = - (a / 2), by rwa add_halves at this,
 by rw [sub_add_eq_sub_sub, sub_self, zero_sub]
 
-lemma add_self_div_two (a : α) : (a + a) / 2 = a :=
-by rw [← mul_two, mul_div_cancel a two_ne_zero]
-
-lemma half_pos (h : 0 < a) : 0 < a / 2 := div_pos h zero_lt_two
-
-lemma one_half_pos : (0:α) < 1 / 2 := half_pos zero_lt_one
-
-lemma div_two_lt_of_pos (h : 0 < a) : a / 2 < a :=
-by { rw [div_lt_iff (@zero_lt_two α _ _)], exact lt_mul_of_one_lt_right h one_lt_two }
-
-lemma half_lt_self : 0 < a → a / 2 < a := div_two_lt_of_pos
-
-lemma half_le_self (ha_nonneg : 0 ≤ a) : a / 2 ≤ a :=
-begin
-  by_cases h0 : a = 0,
-  { simp [h0], },
-  { rw ← ne.def at h0,
-    exact (half_lt_self (lt_of_le_of_ne ha_nonneg h0.symm)).le, },
-end
-
-lemma one_half_lt_one : (1 / 2 : α) < 1 := half_lt_self zero_lt_one
-
 lemma add_sub_div_two_lt (h : a < b) : a + (b - a) / 2 < b :=
 begin
   rwa [← div_sub_div_same, sub_eq_add_neg, add_comm (b/2), ← add_assoc, ← sub_eq_add_neg,
     ← lt_sub_iff_add_lt, sub_self_div_two, sub_self_div_two, div_lt_div_right (@zero_lt_two α _ _)]
 end
 
-lemma left_lt_add_div_two : a < (a + b) / 2 ↔ a < b := by simp [lt_div_iff, mul_two]
-
-lemma add_div_two_lt_right : (a + b) / 2 < b ↔ a < b := by simp [div_lt_iff, mul_two]
-
 /--  An inequality involving `2`. -/
-lemma sub_one_div_inv_le_two (a2 : 2 ≤ a) :
-  (1 - 1 / a)⁻¹ ≤ 2 :=
+lemma sub_one_div_inv_le_two (a2 : 2 ≤ a) : (1 - 1 / a)⁻¹ ≤ 2 :=
 begin
   -- Take inverses on both sides to obtain `2⁻¹ ≤ 1 - 1 / a`
-  refine trans (inv_le_inv_of_le (inv_pos.mpr zero_lt_two) _) (inv_inv (2 : α)).le,
+  refine (inv_le_inv_of_le (inv_pos.2 zero_lt_two) _).trans_eq (inv_inv (2 : α)),
   -- move `1 / a` to the left and `1 - 1 / 2 = 1 / 2` to the right to obtain `1 / a ≤ ⅟ 2`
-  refine trans ((le_sub_iff_add_le.mpr ((_ : _ + 2⁻¹ = _ ).le))) ((sub_le_sub_iff_left 1).mpr _),
+  refine (le_sub_iff_add_le.2 (_ : _ + 2⁻¹ = _ ).le).trans ((sub_le_sub_iff_left 1).2 _),
   { -- show 2⁻¹ + 2⁻¹ = 1
-    exact trans (two_mul _).symm (mul_inv_cancel two_ne_zero) },
+    exact (two_mul _).symm.trans (mul_inv_cancel two_ne_zero) },
   { -- take inverses on both sides and use the assumption `2 ≤ a`.
     exact (one_div a).le.trans (inv_le_inv_of_le zero_lt_two a2) }
 end
 
-/-!
-### Miscellaneous lemmas
--/
-
-/-- Pullback a `linear_ordered_field` under an injective map.
-See note [reducible non-instances]. -/
-@[reducible]
-def function.injective.linear_ordered_field {β : Type*}
-  [has_zero β] [has_one β] [has_add β] [has_mul β] [has_neg β] [has_sub β]
-  [has_pow β ℕ] [has_scalar ℕ β] [has_scalar ℤ β] [has_nat_cast β] [has_int_cast β]
-  [has_inv β] [has_div β] [has_pow β ℤ]
-  (f : β → α) (hf : function.injective f) (zero : f 0 = 0) (one : f 1 = 1)
-  (add : ∀ x y, f (x + y) = f x + f y) (mul : ∀ x y, f (x * y) = f x * f y)
-  (neg : ∀ x, f (-x) = -f x) (sub : ∀ x y, f (x - y) = f x - f y)
-  (inv : ∀ x, f (x⁻¹) = (f x)⁻¹) (div : ∀ x y, f (x / y) = f x / f y)
-  (nsmul : ∀ x (n : ℕ), f (n • x) = n • f x) (zsmul : ∀ x (n : ℤ), f (n • x) = n • f x)
-  (npow : ∀ x (n : ℕ), f (x ^ n) = f x ^ n) (zpow : ∀ x (n : ℤ), f (x ^ n) = f x ^ n)
-  (nat_cast : ∀ n : ℕ, f n = n) (int_cast : ∀ n : ℤ, f n = n) :
-  linear_ordered_field β :=
-{ .. hf.linear_ordered_ring f zero one add mul neg sub nsmul zsmul npow nat_cast int_cast,
-  .. hf.field f zero one add mul neg sub inv div nsmul zsmul npow zpow nat_cast int_cast }
-
-lemma mul_sub_mul_div_mul_neg_iff (hc : c ≠ 0) (hd : d ≠ 0) :
-  (a * d - b * c) / (c * d) < 0 ↔ a / c < b / d :=
-by rw [mul_comm b c, ← div_sub_div _ _ hc hd, sub_lt_zero]
-
-alias mul_sub_mul_div_mul_neg_iff ↔ div_lt_div_of_mul_sub_mul_div_neg mul_sub_mul_div_mul_neg
-
-lemma mul_sub_mul_div_mul_nonpos_iff (hc : c ≠ 0) (hd : d ≠ 0) :
-      (a * d - b * c) / (c * d) ≤ 0 ↔ a / c ≤ b / d :=
-by rw [mul_comm b c, ← div_sub_div _ _ hc hd, sub_nonpos]
-
-alias mul_sub_mul_div_mul_nonpos_iff ↔
-  div_le_div_of_mul_sub_mul_div_nonpos mul_sub_mul_div_mul_nonpos
-
-lemma mul_le_mul_of_mul_div_le (h : a * (b / c) ≤ d) (hc : 0 < c) : b * a ≤ d * c :=
-begin
-  rw [← mul_div_assoc] at h,
-  rwa [mul_comm b, ← div_le_iff hc],
-end
-
-lemma div_mul_le_div_mul_of_div_le_div (h : a / b ≤ c / d) (he : 0 ≤ e) :
-  a / (b * e) ≤ c / (d * e) :=
-begin
-  rw [div_mul_eq_div_mul_one_div, div_mul_eq_div_mul_one_div],
-  exact mul_le_mul_of_nonneg_right h (one_div_nonneg.2 he)
-end
-
-lemma exists_add_lt_and_pos_of_lt (h : b < a) : ∃ c : α, b + c < a ∧ 0 < c :=
-⟨(a - b) / 2, add_sub_div_two_lt h, div_pos (sub_pos_of_lt h) zero_lt_two⟩
-
-lemma exists_pos_mul_lt {a : α} (h : 0 < a) (b : α) : ∃ c : α, 0 < c ∧ b * c < a :=
-begin
-  have : 0 < a / max (b + 1) 1, from div_pos h (lt_max_iff.2 (or.inr zero_lt_one)),
-  refine ⟨a / max (b + 1) 1, this, _⟩,
-  rw [← lt_div_iff this, div_div_cancel' h.ne'],
-  exact lt_max_iff.2 (or.inl $ lt_add_one _)
-end
-
-lemma le_of_forall_sub_le (h : ∀ ε > 0, b - ε ≤ a) : b ≤ a :=
-begin
-  contrapose! h,
-  simpa only [and_comm ((0 : α) < _), lt_sub_iff_add_lt, gt_iff_lt]
-    using exists_add_lt_and_pos_of_lt h,
-end
-
-lemma monotone.div_const {β : Type*} [preorder β] {f : β → α} (hf : monotone f)
-  {c : α} (hc : 0 ≤ c) : monotone (λ x, (f x) / c) :=
-by simpa only [div_eq_mul_inv] using hf.mul_const (inv_nonneg.2 hc)
-
-lemma strict_mono.div_const {β : Type*} [preorder β] {f : β → α} (hf : strict_mono f)
-  {c : α} (hc : 0 < c) :
-  strict_mono (λ x, (f x) / c) :=
-by simpa only [div_eq_mul_inv] using hf.mul_const (inv_pos.2 hc)
-
-@[priority 100] -- see Note [lower instance priority]
-instance linear_ordered_field.to_densely_ordered : densely_ordered α :=
-{ dense := λ a₁ a₂ h, ⟨(a₁ + a₂) / 2,
-  calc a₁ = (a₁ + a₁) / 2 : (add_self_div_two a₁).symm
-      ... < (a₁ + a₂) / 2 : div_lt_div_of_lt zero_lt_two (add_lt_add_left h _),
-  calc (a₁ + a₂) / 2 < (a₂ + a₂) / 2 : div_lt_div_of_lt zero_lt_two (add_lt_add_right h _)
-                 ... = a₂            : add_self_div_two a₂⟩ }
-
-lemma mul_self_inj_of_nonneg (a0 : 0 ≤ a) (b0 : 0 ≤ b) : a * a = b * b ↔ a = b :=
-mul_self_eq_mul_self_iff.trans $ or_iff_left_of_imp $
-  λ h, by { subst a, have : b = 0 := le_antisymm (neg_nonneg.1 a0) b0, rw [this, neg_zero] }
-
-lemma min_div_div_right {c : α} (hc : 0 ≤ c) (a b : α) : min (a / c) (b / c) = (min a b) / c :=
-eq.symm $ monotone.map_min (λ x y, div_le_div_of_le hc)
-
-lemma max_div_div_right {c : α} (hc : 0 ≤ c) (a b : α) : max (a / c) (b / c) = (max a b) / c :=
-eq.symm $ monotone.map_max (λ x y, div_le_div_of_le hc)
-
-lemma min_div_div_right_of_nonpos {c : α} (hc : c ≤ 0) (a b : α) :
-  min (a / c) (b / c) = (max a b) / c :=
-eq.symm $ antitone.map_max $ λ x y, div_le_div_of_nonpos_of_le hc
-
-lemma max_div_div_right_of_nonpos {c : α} (hc : c ≤ 0) (a b : α) :
-  max (a / c) (b / c) = (min a b) / c :=
-eq.symm $ antitone.map_min $ λ x y, div_le_div_of_nonpos_of_le hc
-
-lemma abs_div (a b : α) : |a / b| = |a| / |b| := (abs_hom : α →*₀ α).map_div a b
-
-lemma abs_one_div (a : α) : |1 / a| = 1 / |a| :=
-by rw [abs_div, abs_one]
-
-lemma abs_inv (a : α) : |a⁻¹| = (|a|)⁻¹ := (abs_hom : α →*₀ α).map_inv a
-
-lemma one_div_strict_anti_on : strict_anti_on (λ x : α, 1 / x) (set.Ioi 0) :=
-λ x x1 y y1 xy, (one_div_lt_one_div (set.mem_Ioi.mp y1) (set.mem_Ioi.mp x1)).mpr xy
-
-lemma one_div_pow_le_one_div_pow_of_le (a1 : 1 ≤ a) {m n : ℕ} (mn : m ≤ n) :
-  1 / a ^ n ≤ 1 / a ^ m :=
-by refine (one_div_le_one_div _ _).mpr (pow_le_pow a1 mn);
-  exact pow_pos (zero_lt_one.trans_le a1) _
-
-lemma one_div_pow_lt_one_div_pow_of_lt (a1 : 1 < a) {m n : ℕ} (mn : m < n) :
-  1 / a ^ n < 1 / a ^ m :=
-by refine (one_div_lt_one_div _ _).mpr (pow_lt_pow a1 mn);
-  exact pow_pos (trans zero_lt_one a1) _
-
-lemma one_div_pow_anti (a1 : 1 ≤ a) : antitone (λ n : ℕ, 1 / a ^ n) :=
-λ m n, one_div_pow_le_one_div_pow_of_le a1
-
-lemma one_div_pow_strict_anti (a1 : 1 < a) : strict_anti (λ n : ℕ, 1 / a ^ n) :=
-λ m n, one_div_pow_lt_one_div_pow_of_lt a1
-
-lemma inv_strict_anti_on : strict_anti_on (λ x : α, x⁻¹) (set.Ioi 0) :=
-λ x hx y hy xy, (inv_lt_inv hy hx).2 xy
-
-lemma inv_pow_le_inv_pow_of_le (a1 : 1 ≤ a) {m n : ℕ} (mn : m ≤ n) :
-  (a ^ n)⁻¹ ≤ (a ^ m)⁻¹ :=
-by convert one_div_pow_le_one_div_pow_of_le a1 mn; simp
-
-lemma inv_pow_lt_inv_pow_of_lt (a1 : 1 < a) {m n : ℕ} (mn : m < n) :
-  (a ^ n)⁻¹ < (a ^ m)⁻¹ :=
-by convert one_div_pow_lt_one_div_pow_of_lt a1 mn; simp
-
-lemma inv_pow_anti (a1 : 1 ≤ a) : antitone (λ n : ℕ, (a ^ n)⁻¹) :=
-λ m n, inv_pow_le_inv_pow_of_le a1
-
-lemma inv_pow_strict_anti (a1 : 1 < a) : strict_anti (λ n : ℕ, (a ^ n)⁻¹) :=
-λ m n, inv_pow_lt_inv_pow_of_lt a1
-
 /-! ### Results about `is_lub` and `is_glb` -/
 
+-- TODO: Generalize to `linear_ordered_semifield`
 lemma is_lub.mul_left {s : set α} (ha : 0 ≤ a) (hs : is_lub s b) :
   is_lub ((λ b, a * b) '' s) (a * b) :=
 begin
@@ -774,28 +782,48 @@ begin
     exact is_lub_singleton },
 end
 
+-- TODO: Generalize to `linear_ordered_semifield`
 lemma is_lub.mul_right {s : set α} (ha : 0 ≤ a) (hs : is_lub s b) :
   is_lub ((λ b, b * a) '' s) (b * a) :=
 by simpa [mul_comm] using hs.mul_left ha
 
-lemma is_glb.mul_left {s : set α} (ha : 0 ≤ a) (hs : is_glb s b) :
-  is_glb ((λ b, a * b) '' s) (a * b) :=
+/-! ### Miscellaneous lemmmas -/
+
+lemma mul_sub_mul_div_mul_neg_iff (hc : c ≠ 0) (hd : d ≠ 0) :
+  (a * d - b * c) / (c * d) < 0 ↔ a / c < b / d :=
+by rw [mul_comm b c, ← div_sub_div _ _ hc hd, sub_lt_zero]
+
+lemma mul_sub_mul_div_mul_nonpos_iff (hc : c ≠ 0) (hd : d ≠ 0) :
+  (a * d - b * c) / (c * d) ≤ 0 ↔ a / c ≤ b / d :=
+by rw [mul_comm b c, ← div_sub_div _ _ hc hd, sub_nonpos]
+
+alias mul_sub_mul_div_mul_neg_iff ↔ div_lt_div_of_mul_sub_mul_div_neg mul_sub_mul_div_mul_neg
+alias mul_sub_mul_div_mul_nonpos_iff ↔
+  div_le_div_of_mul_sub_mul_div_nonpos mul_sub_mul_div_mul_nonpos
+
+lemma exists_add_lt_and_pos_of_lt (h : b < a) : ∃ c, b + c < a ∧ 0 < c :=
+⟨(a - b) / 2, add_sub_div_two_lt h, div_pos (sub_pos_of_lt h) zero_lt_two⟩
+
+lemma le_of_forall_sub_le (h : ∀ ε > 0, b - ε ≤ a) : b ≤ a :=
 begin
-  rcases lt_or_eq_of_le ha with ha | rfl,
-  { exact (order_iso.mul_left₀ _ ha).is_glb_image'.2 hs, },
-  { simp_rw zero_mul,
-    rw hs.nonempty.image_const,
-    exact is_glb_singleton },
+  contrapose! h,
+  simpa only [and_comm ((0 : α) < _), lt_sub_iff_add_lt, gt_iff_lt]
+    using exists_add_lt_and_pos_of_lt h,
 end
 
-lemma is_glb.mul_right {s : set α} (ha : 0 ≤ a) (hs : is_glb s b) :
-  is_glb ((λ b, b * a) '' s) (b * a) :=
-by simpa [mul_comm] using hs.mul_left ha
+lemma mul_self_inj_of_nonneg (a0 : 0 ≤ a) (b0 : 0 ≤ b) : a * a = b * b ↔ a = b :=
+mul_self_eq_mul_self_iff.trans $ or_iff_left_of_imp $
+  λ h, by { subst a, have : b = 0 := le_antisymm (neg_nonneg.1 a0) b0, rw [this, neg_zero] }
 
-end linear_ordered_field
+lemma min_div_div_right_of_nonpos (hc : c ≤ 0) (a b : α) : min (a / c) (b / c) = (max a b) / c :=
+eq.symm $ antitone.map_max $ λ x y, div_le_div_of_nonpos_of_le hc
 
-section
-variables {R : Type*} [linear_ordered_field R] {a : R}
+lemma max_div_div_right_of_nonpos (hc : c ≤ 0) (a b : α) : max (a / c) (b / c) = (min a b) / c :=
+eq.symm $ antitone.map_min $ λ x y, div_le_div_of_nonpos_of_le hc
+
+lemma abs_inv (a : α) : |a⁻¹| = (|a|)⁻¹ := (abs_hom : α →*₀ α).map_inv a
+lemma abs_div (a b : α) : |a / b| = |a| / |b| := (abs_hom : α →*₀ α).map_div a b
+lemma abs_one_div (a : α) : |1 / a| = 1 / |a| := by rw [abs_div, abs_one]
 
 lemma pow_minus_two_nonneg : 0 ≤ a^(-2 : ℤ) :=
 begin
@@ -805,17 +833,14 @@ begin
   apply sq_nonneg,
 end
 
-/-- Bernoulli's inequality reformulated to estimate `(n : K)`. -/
-theorem nat.cast_le_pow_sub_div_sub {K : Type*} [linear_ordered_field K] {a : K} (H : 1 < a)
-  (n : ℕ) :
-  (n : K) ≤ (a ^ n - 1) / (a - 1) :=
+/-- Bernoulli's inequality reformulated to estimate `(n : α)`. -/
+lemma nat.cast_le_pow_sub_div_sub (H : 1 < a)  (n : ℕ) : (n : α) ≤ (a ^ n - 1) / (a - 1) :=
 (le_div_iff (sub_pos.2 H)).2 $ le_sub_left_of_add_le $
   one_add_mul_sub_le_pow ((neg_le_self zero_le_one).trans H.le) _
 
 /-- For any `a > 1` and a natural `n` we have `n ≤ a ^ n / (a - 1)`. See also
 `nat.cast_le_pow_sub_div_sub` for a stronger inequality with `a ^ n - 1` in the numerator. -/
-theorem nat.cast_le_pow_div_sub {K : Type*} [linear_ordered_field K] {a : K} (H : 1 < a) (n : ℕ) :
-  (n : K) ≤ a ^ n / (a - 1) :=
+theorem nat.cast_le_pow_div_sub (H : 1 < a) (n : ℕ) : (n : α) ≤ a ^ n / (a - 1) :=
 (n.cast_le_pow_sub_div_sub H).trans $ div_le_div_of_le (sub_nonneg.2 H.le)
   (sub_le_self _ zero_le_one)
 

--- a/src/algebra/order/field.lean
+++ b/src/algebra/order/field.lean
@@ -123,6 +123,12 @@ by { rw div_eq_mul_inv, exact mul_pos ha (inv_pos.2 hb) }
 lemma div_nonneg (ha : 0 ≤ a) (hb : 0 ≤ b) : 0 ≤ a / b :=
 by { rw div_eq_mul_inv, exact mul_nonneg ha (inv_nonneg.2 hb) }
 
+lemma div_nonpos_of_nonpos_of_nonneg (ha : a ≤ 0) (hb : 0 ≤ b) : a / b ≤ 0 :=
+by { rw div_eq_mul_inv, exact mul_nonpos_of_nonpos_of_nonneg ha (inv_nonneg.2 hb) }
+
+lemma div_nonpos_of_nonneg_of_nonpos (ha : 0 ≤ a) (hb : b ≤ 0) : a / b ≤ 0 :=
+by { rw div_eq_mul_inv, exact mul_nonpos_of_nonneg_of_nonpos ha (inv_nonpos.2 hb) }
+
 /-!
 ### Relating one division with another term.
 -/
@@ -569,6 +575,9 @@ by simp [division_def, mul_nonneg_iff]
 
 lemma div_nonpos_iff : a / b ≤ 0 ↔ 0 ≤ a ∧ b ≤ 0 ∨ a ≤ 0 ∧ 0 ≤ b :=
 by simp [division_def, mul_nonpos_iff]
+
+lemma div_nonneg_of_nonpos (ha : a ≤ 0) (hb : b ≤ 0) : 0 ≤ a / b :=
+div_nonneg_iff.2 $ or.inr ⟨ha, hb⟩
 
 lemma div_pos_of_neg_of_neg (ha : a < 0) (hb : b < 0) : 0 < a / b :=
 div_pos_iff.2 $ or.inr ⟨ha, hb⟩

--- a/src/algebra/order/floor.lean
+++ b/src/algebra/order/floor.lean
@@ -306,8 +306,8 @@ lt_ceil.1 $ (nat.lt_succ_self _).trans_le (ceil_add_one ha).ge
 
 end linear_ordered_ring
 
-section linear_ordered_field
-variables [linear_ordered_field α] [floor_semiring α]
+section linear_ordered_semifield
+variables [linear_ordered_semifield α] [floor_semiring α]
 
 lemma floor_div_nat (a : α) (n : ℕ) : ⌊a / n⌋₊ = ⌊a⌋₊ / n :=
 begin
@@ -330,7 +330,7 @@ end
 lemma floor_div_eq_div (m n : ℕ) : ⌊(m : α) / n⌋₊ = m / n :=
 by { convert floor_div_nat (m : α) n, rw m.floor_coe }
 
-end linear_ordered_field
+end linear_ordered_semifield
 
 end nat
 

--- a/src/data/int/log.lean
+++ b/src/data/int/log.lean
@@ -44,9 +44,9 @@ def digits (b : ℕ) (q : ℚ) (n : ℕ) : ℕ :=
     `(b : R) ^ (clog b r - 1) < r ≤ (b : R) ^ clog b r`.
   * `int.clog_zpow_gi`:  the galois insertion between `int.clog` and `zpow`.
 * `int.neg_log_inv_eq_clog`, `int.neg_clog_inv_eq_log`: the link between the two definitions.
-
 -/
-variables {R : Type*} [linear_ordered_field R] [floor_ring R]
+
+variables {R : Type*} [linear_ordered_semifield R] [floor_semiring R]
 
 namespace int
 
@@ -252,9 +252,9 @@ end
 lemma zpow_pred_clog_lt_self {b : ℕ} {r : R} (hb : 1 < b) (hr : 0 < r) :
   (b : R) ^ (clog b r - 1) < r :=
 begin
-  rw [←neg_log_inv_eq_clog, ←neg_add', zpow_neg, inv_lt (zpow_pos_of_pos _ _) hr],
+  rw [←neg_log_inv_eq_clog, ←neg_add', zpow_neg, inv_lt _ hr],
   { exact lt_zpow_succ_log_self hb _, },
-  { exact nat.cast_pos.mpr (zero_le_one.trans_lt hb), },
+  { exact zpow_pos_of_pos (nat.cast_pos.mpr $ zero_le_one.trans_lt hb) _ }
 end
 
 @[simp] lemma clog_zero_right (b : ℕ) : clog b (0 : R) = 0 :=

--- a/src/data/nat/cast_field.lean
+++ b/src/data/nat/cast_field.lean
@@ -29,9 +29,8 @@ begin
   rw [nat.mul_div_cancel_left _ this.bot_lt, cast_mul, mul_div_cancel_left _ n_nonzero],
 end
 
-
-section linear_ordered_field
-variables [linear_ordered_field α]
+section linear_ordered_semifield
+variables [linear_ordered_semifield α]
 
 /-- Natural division is always less than division in the field. -/
 lemma cast_div_le {m n : ℕ} : ((m / n : ℕ) : α) ≤ m / n :=
@@ -55,6 +54,5 @@ by { refine one_div_le_one_div_of_le _ _, exact nat.cast_add_one_pos _, simpa }
 lemma one_div_lt_one_div {n m : ℕ} (h : n < m) : 1 / ((m : α) + 1) < 1 / ((n : α) + 1) :=
 by { refine one_div_lt_one_div_of_lt _ _, exact nat.cast_add_one_pos _, simpa }
 
-end linear_ordered_field
-
+end linear_ordered_semifield
 end nat

--- a/src/number_theory/padics/padic_numbers.lean
+++ b/src/number_theory/padics/padic_numbers.lean
@@ -1027,12 +1027,9 @@ end
 @[simp] lemma valuation_p : valuation (p : ℚ_[p]) = 1 :=
 begin
   have h : (1 : ℝ) < p := by exact_mod_cast (fact.out p.prime).one_lt,
-  rw ← neg_inj,
-  apply (zpow_strict_mono h).injective,
-  dsimp only,
-  rw ← norm_eq_pow_val,
-  { simp },
-  { exact_mod_cast (fact.out p.prime).ne_zero }
+  refine neg_injective ((zpow_strict_mono h).injective $ (norm_eq_pow_val _).symm.trans _),
+  { exact_mod_cast (fact.out p.prime).ne_zero },
+  { simp }
 end
 
 lemma valuation_map_add {x y : ℚ_[p]} (hxy : x + y ≠ 0) :


### PR DESCRIPTION
Define `linear_ordered_semifield` and generalize lemmas within `algebra.order.field`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
This is not enough for `nnreal` and the future `nnrat`. I will also introduce `canonically_linear_ordered_semifield`.


[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
