### PR TITLE
chore(algebra/hom): add `inline` attributes to preserve computability

### DIFF
--- a/src/algebra/group/pi.lean
+++ b/src/algebra/group/pi.lean
@@ -150,22 +150,22 @@ variables (f) [Π i, has_mul (f i)]
 /-- Evaluation of functions into an indexed collection of semigroups at a point is a semigroup
 homomorphism.
 This is `function.eval i` as a `mul_hom`. -/
-@[to_additive "Evaluation of functions into an indexed collection of additive semigroups at a
-point is an additive semigroup homomorphism.
+@[inline, to_additive "Evaluation of functions into an indexed collection of additive semigroups at
+a point is an additive semigroup homomorphism.
 This is `function.eval i` as an `add_hom`.", simps]
 def pi.eval_mul_hom (i : I) : (Π i, f i) →ₙ* f i :=
 { to_fun := λ g, g i,
   map_mul' := λ x y, pi.mul_apply _ _ i, }
 
 /-- `function.const` as a `mul_hom`. -/
-@[to_additive "`function.const` as an `add_hom`.", simps]
+@[inline, to_additive "`function.const` as an `add_hom`.", simps]
 def pi.const_mul_hom (α β : Type*) [has_mul β] : β →ₙ* (α → β) :=
 { to_fun := function.const α,
   map_mul' := λ _ _, rfl }
 
 /-- Coercion of a `mul_hom` into a function is itself a `mul_hom`.
 See also `mul_hom.eval`. -/
-@[to_additive "Coercion of an `add_hom` into a function is itself a `add_hom`.
+@[inline, to_additive "Coercion of an `add_hom` into a function is itself a `add_hom`.
 See also `add_hom.eval`. ", simps]
 def mul_hom.coe_fn (α β : Type*) [has_mul α] [comm_semigroup β] : (α →ₙ* β) →ₙ* (α → β) :=
 { to_fun := λ g, g,
@@ -173,8 +173,8 @@ def mul_hom.coe_fn (α β : Type*) [has_mul α] [comm_semigroup β] : (α →ₙ
 
 /-- Semigroup homomorphism between the function spaces `I → α` and `I → β`, induced by a semigroup
 homomorphism `f` between `α` and `β`. -/
-@[to_additive "Additive semigroup homomorphism between the function spaces `I → α` and `I → β`,
-induced by an additive semigroup homomorphism `f` between `α` and `β`", simps]
+@[inline, to_additive "Additive semigroup homomorphism between the function spaces `I → α` and
+`I → β`, induced by an additive semigroup homomorphism `f` between `α` and `β`", simps]
 protected def mul_hom.comp_left {α β : Type*} [has_mul α] [has_mul β] (f : α →ₙ* β)
   (I : Type*) :
   (I → α) →ₙ* (I → β) :=
@@ -190,7 +190,7 @@ variables (f) [Π i, mul_one_class (f i)]
 /-- Evaluation of functions into an indexed collection of monoids at a point is a monoid
 homomorphism.
 This is `function.eval i` as a `monoid_hom`. -/
-@[to_additive "Evaluation of functions into an indexed collection of additive monoids at a
+@[inline, to_additive "Evaluation of functions into an indexed collection of additive monoids at a
 point is an additive monoid homomorphism.
 This is `function.eval i` as an `add_monoid_hom`.", simps]
 def pi.eval_monoid_hom (i : I) : (Π i, f i) →* f i :=
@@ -199,7 +199,7 @@ def pi.eval_monoid_hom (i : I) : (Π i, f i) →* f i :=
   map_mul' := λ x y, pi.mul_apply _ _ i, }
 
 /-- `function.const` as a `monoid_hom`. -/
-@[to_additive "`function.const` as an `add_monoid_hom`.", simps]
+@[inline, to_additive "`function.const` as an `add_monoid_hom`.", simps]
 def pi.const_monoid_hom (α β : Type*) [mul_one_class β] : β →* (α → β) :=
 { to_fun := function.const α,
   map_one' := rfl,
@@ -208,7 +208,7 @@ def pi.const_monoid_hom (α β : Type*) [mul_one_class β] : β →* (α → β)
 /-- Coercion of a `monoid_hom` into a function is itself a `monoid_hom`.
 
 See also `monoid_hom.eval`. -/
-@[to_additive "Coercion of an `add_monoid_hom` into a function is itself a `add_monoid_hom`.
+@[inline, to_additive "Coercion of an `add_monoid_hom` into a function is itself a `add_monoid_hom`.
 
 See also `add_monoid_hom.eval`. ", simps]
 def monoid_hom.coe_fn (α β : Type*) [mul_one_class α] [comm_monoid β] : (α →* β) →* (α → β) :=
@@ -218,7 +218,7 @@ def monoid_hom.coe_fn (α β : Type*) [mul_one_class α] [comm_monoid β] : (α 
 
 /-- Monoid homomorphism between the function spaces `I → α` and `I → β`, induced by a monoid
 homomorphism `f` between `α` and `β`. -/
-@[to_additive "Additive monoid homomorphism between the function spaces `I → α` and `I → β`,
+@[inline, to_additive "Additive monoid homomorphism between the function spaces `I → α` and `I → β`,
 induced by an additive monoid homomorphism `f` between `α` and `β`", simps]
 protected def monoid_hom.comp_left {α β : Type*} [mul_one_class α] [mul_one_class β] (f : α →* β)
   (I : Type*) :

--- a/src/algebra/group/prod.lean
+++ b/src/algebra/group/prod.lean
@@ -302,12 +302,12 @@ namespace monoid_hom
 variables (M N) [mul_one_class M] [mul_one_class N]
 
 /-- Given monoids `M`, `N`, the natural projection homomorphism from `M × N` to `M`.-/
-@[to_additive "Given additive monoids `A`, `B`, the natural projection homomorphism
+@[inline, to_additive "Given additive monoids `A`, `B`, the natural projection homomorphism
 from `A × B` to `A`"]
 def fst : M × N →* M := ⟨prod.fst, rfl, λ _ _, rfl⟩
 
 /-- Given monoids `M`, `N`, the natural projection homomorphism from `M × N` to `N`.-/
-@[to_additive "Given additive monoids `A`, `B`, the natural projection homomorphism
+@[inline, to_additive "Given additive monoids `A`, `B`, the natural projection homomorphism
 from `A × B` to `B`"]
 def snd : M × N →* N := ⟨prod.snd, rfl, λ _ _, rfl⟩
 

--- a/src/algebra/group/to_additive.lean
+++ b/src/algebra/group/to_additive.lean
@@ -544,7 +544,7 @@ protected meta def attr : user_attribute unit value_type :=
       transform_decl_with_prefix_dict dict val.replace_all val.trace relevant ignore reorder src tgt
         [`reducible, `_refl_lemma, `simp, `norm_cast, `instance, `refl, `symm, `trans,
           `elab_as_eliminator, `no_rsimp, `continuity, `ext, `ematch, `measurability, `alias,
-          `_ext_core, `_ext_lemma_core, `nolint, `protected],
+          `_ext_core, `_ext_lemma_core, `nolint, `protected, `inline],
       mwhen (has_attribute' `simps src)
         (trace "Apply the simps attribute after the to_additive attribute"),
       mwhen (has_attribute' `mono src)

--- a/src/algebra/group/type_tags.lean
+++ b/src/algebra/group/type_tags.lean
@@ -289,7 +289,7 @@ open multiplicative (of_add)
 open additive (of_mul)
 
 /-- Reinterpret `α →+ β` as `multiplicative α →* multiplicative β`. -/
-@[simps] def add_monoid_hom.to_multiplicative [add_zero_class α] [add_zero_class β] :
+@[inline, simps] def add_monoid_hom.to_multiplicative [add_zero_class α] [add_zero_class β] :
   (α →+ β) ≃ (multiplicative α →* multiplicative β) :=
 { to_fun := λ f, ⟨λ a, of_add (f a.to_add), f.2, f.3⟩,
   inv_fun := λ f, ⟨λ a, (f (of_add a)).to_add, f.2, f.3⟩,
@@ -297,7 +297,7 @@ open additive (of_mul)
   right_inv := λ x, by { ext, refl, } }
 
 /-- Reinterpret `α →* β` as `additive α →+ additive β`. -/
-@[simps] def monoid_hom.to_additive [mul_one_class α] [mul_one_class β] :
+@[inline, simps] def monoid_hom.to_additive [mul_one_class α] [mul_one_class β] :
   (α →* β) ≃ (additive α →+ additive β) :=
 { to_fun := λ f, ⟨λ a, of_mul (f a.to_mul), f.2, f.3⟩,
   inv_fun := λ f, ⟨λ a, (f (of_mul a)).to_mul, f.2, f.3⟩,
@@ -305,7 +305,7 @@ open additive (of_mul)
   right_inv := λ x, by { ext, refl, } }
 
 /-- Reinterpret `additive α →+ β` as `α →* multiplicative β`. -/
-@[simps] def add_monoid_hom.to_multiplicative' [mul_one_class α] [add_zero_class β] :
+@[inline, simps] def add_monoid_hom.to_multiplicative' [mul_one_class α] [add_zero_class β] :
   (additive α →+ β) ≃ (α →* multiplicative β) :=
 { to_fun := λ f, ⟨λ a, of_add (f (of_mul a)), f.2, f.3⟩,
   inv_fun := λ f, ⟨λ a, (f a.to_mul).to_add, f.2, f.3⟩,
@@ -313,12 +313,12 @@ open additive (of_mul)
   right_inv := λ x, by { ext, refl, } }
 
 /-- Reinterpret `α →* multiplicative β` as `additive α →+ β`. -/
-@[simps] def monoid_hom.to_additive' [mul_one_class α] [add_zero_class β] :
+@[inline, simps] def monoid_hom.to_additive' [mul_one_class α] [add_zero_class β] :
   (α →* multiplicative β) ≃ (additive α →+ β) :=
 add_monoid_hom.to_multiplicative'.symm
 
 /-- Reinterpret `α →+ additive β` as `multiplicative α →* β`. -/
-@[simps] def add_monoid_hom.to_multiplicative'' [add_zero_class α] [mul_one_class β] :
+@[inline, simps] def add_monoid_hom.to_multiplicative'' [add_zero_class α] [mul_one_class β] :
   (α →+ additive β) ≃ (multiplicative α →* β) :=
 { to_fun := λ f, ⟨λ a, (f a.to_add).to_mul, f.2, f.3⟩,
   inv_fun := λ f, ⟨λ a, of_mul (f (of_add a)), f.2, f.3⟩,
@@ -326,7 +326,7 @@ add_monoid_hom.to_multiplicative'.symm
   right_inv := λ x, by { ext, refl, } }
 
 /-- Reinterpret `multiplicative α →* β` as `α →+ additive β`. -/
-@[simps] def monoid_hom.to_additive'' [add_zero_class α] [mul_one_class β] :
+@[inline, simps] def monoid_hom.to_additive'' [add_zero_class α] [mul_one_class β] :
   (multiplicative α →* β) ≃ (α →+ additive β) :=
 add_monoid_hom.to_multiplicative''.symm
 

--- a/src/algebra/hom/equiv.lean
+++ b/src/algebra/hom/equiv.lean
@@ -58,6 +58,9 @@ set_option old_structure_cmd true
 @[ancestor equiv add_hom]
 structure add_equiv (A B : Type*) [has_add A] [has_add B] extends A ≃ B, add_hom A B
 
+-- see note [inline attributes for morphisms]
+attribute [inline] add_equiv.to_fun add_equiv.inv_fun add_equiv.to_equiv add_equiv.to_add_hom
+
 /-- `add_equiv_class F A B` states that `F` is a type of addition-preserving morphisms.
 You should extend this class when you extend `add_equiv`. -/
 class add_equiv_class (F A B : Type*) [has_add A] [has_add B]
@@ -72,6 +75,9 @@ add_decl_doc add_equiv.to_add_hom
 /-- `mul_equiv α β` is the type of an equiv `α ≃ β` which preserves multiplication. -/
 @[ancestor equiv mul_hom, to_additive]
 structure mul_equiv (M N : Type*) [has_mul M] [has_mul N] extends M ≃ N, M →ₙ* N
+
+-- see note [inline attributes for morphisms]
+attribute [inline] mul_equiv.to_fun mul_equiv.inv_fun mul_equiv.to_equiv mul_equiv.to_mul_hom
 
 /-- The `equiv` underlying a `mul_equiv`. -/
 add_decl_doc mul_equiv.to_equiv
@@ -138,7 +144,7 @@ end mul_equiv_class
 
 namespace mul_equiv
 
-@[to_additive]
+@[inline, to_additive]
 instance [has_mul M] [has_mul N] : has_coe_to_fun (M ≃* N) (λ _, M → N) := ⟨mul_equiv.to_fun⟩
 
 @[to_additive]
@@ -180,7 +186,7 @@ protected lemma injective (e : M ≃* N) : function.injective e := equiv_like.in
 protected lemma surjective (e : M ≃* N) : function.surjective e := equiv_like.surjective e
 
 /-- The identity map is a multiplicative isomorphism. -/
-@[refl, to_additive "The identity map is an additive isomorphism."]
+@[refl, inline, to_additive "The identity map is an additive isomorphism."]
 def refl (M : Type*) [has_mul M] : M ≃* M :=
 { map_mul' := λ _ _, rfl,
 ..equiv.refl _}
@@ -189,7 +195,7 @@ def refl (M : Type*) [has_mul M] : M ≃* M :=
 instance : inhabited (M ≃* M) := ⟨refl M⟩
 
 /-- The inverse of an isomorphism is an isomorphism. -/
-@[symm, to_additive "The inverse of an isomorphism is an isomorphism."]
+@[symm, inline, to_additive "The inverse of an isomorphism is an isomorphism."]
 def symm (h : M ≃* N) : N ≃* M :=
 { map_mul' := (h.to_mul_hom.inverse h.to_equiv.symm h.left_inv h.right_inv).map_mul,
   .. h.to_equiv.symm}
@@ -233,7 +239,7 @@ theorem symm_mk (f : M → N) (g h₁ h₂ h₃) :
 theorem refl_symm : (refl M).symm = refl M := rfl
 
 /-- Transitivity of multiplication-preserving isomorphisms -/
-@[trans, to_additive "Transitivity of addition-preserving isomorphisms"]
+@[trans, inline, to_additive "Transitivity of addition-preserving isomorphisms"]
 def trans (h1 : M ≃* N) (h2 : N ≃* P) : (M ≃* P) :=
 { map_mul' := λ x y, show h2 (h1 (x * y)) = h2 (h1 x) * h2 (h1 y),
     by rw [h1.map_mul, h2.map_mul],
@@ -319,7 +325,7 @@ fun_like.congr_arg f
 fun_like.congr_fun h x
 
 /-- The `mul_equiv` between two monoids with a unique element. -/
-@[to_additive "The `add_equiv` between two add_monoids with a unique element."]
+@[inline, to_additive "The `add_equiv` between two add_monoids with a unique element."]
 def mul_equiv_of_unique {M N}
   [unique M] [unique N] [has_mul M] [has_mul N] : M ≃* N :=
 { map_mul' := λ _ _, subsingleton.elim _ _,
@@ -364,7 +370,7 @@ noncomputable def of_bijective {M N F} [has_mul M] [has_mul N] [mul_hom_class F 
 Extract the forward direction of a multiplicative equivalence
 as a multiplication-preserving function.
 -/
-@[to_additive "Extract the forward direction of an additive equivalence
+@[inline, to_additive "Extract the forward direction of an additive equivalence
 as an addition-preserving function."]
 def to_monoid_hom {M N} [mul_one_class M] [mul_one_class N] (h : M ≃* N) : (M →* N) :=
 { map_one' := h.map_one, .. h }
@@ -378,12 +384,11 @@ rfl
   function.injective (to_monoid_hom : (M ≃* N) → M →* N) :=
 λ f g h, mul_equiv.ext (monoid_hom.ext_iff.1 h)
 
-
 /--
 A multiplicative analogue of `equiv.arrow_congr`,
 where the equivalence between the targets is multiplicative.
 -/
-@[to_additive "An additive analogue of `equiv.arrow_congr`,
+@[inline, to_additive "An additive analogue of `equiv.arrow_congr`,
 where the equivalence between the targets is additive.", simps apply]
 def arrow_congr {M N P Q : Type*} [has_mul P] [has_mul Q]
   (f : M ≃ N) (g : P ≃* Q) : (M → P) ≃* (N → Q) :=
@@ -397,7 +402,7 @@ def arrow_congr {M N P Q : Type*} [has_mul P] [has_mul Q]
 A multiplicative analogue of `equiv.arrow_congr`,
 for multiplicative maps from a monoid to a commutative monoid.
 -/
-@[to_additive "An additive analogue of `equiv.arrow_congr`,
+@[inline, to_additive "An additive analogue of `equiv.arrow_congr`,
 for additive maps from an additive monoid to a commutative additive monoid.", simps apply]
 def monoid_hom_congr {M N P Q} [mul_one_class M] [mul_one_class N] [comm_monoid P] [comm_monoid Q]
   (f : M ≃* N) (g : P ≃* Q) : (M →* P) ≃* (N →* Q) :=
@@ -415,7 +420,8 @@ multiplicative equivalence between `Π j, Ms j` and `Π j, Ns j`.
 This is the `mul_equiv` version of `equiv.Pi_congr_right`, and the dependent version of
 `mul_equiv.arrow_congr`.
 -/
-@[to_additive add_equiv.Pi_congr_right "A family of additive equivalences `Π j, (Ms j ≃+ Ns j)`
+@[inline, to_additive add_equiv.Pi_congr_right
+"A family of additive equivalences `Π j, (Ms j ≃+ Ns j)`
 generates an additive equivalence between `Π j, Ms j` and `Π j, Ns j`.
 
 This is the `add_equiv` version of `equiv.Pi_congr_right`, and the dependent version of
@@ -446,7 +452,7 @@ lemma Pi_congr_right_trans {η : Type*}
 
 /-- A family indexed by a nonempty subsingleton type is equivalent to the element at the single
 index. -/
-@[to_additive add_equiv.Pi_subsingleton "A family indexed by a nonempty subsingleton type is
+@[inline, to_additive add_equiv.Pi_subsingleton "A family indexed by a nonempty subsingleton type is
 equivalent to the element at the single index.", simps]
 def Pi_subsingleton
   {ι : Type*} (M : ι → Type*) [Π j, has_mul (M j)] [subsingleton ι] (i : ι) :
@@ -473,7 +479,8 @@ end mul_equiv
 /-- Given a pair of monoid homomorphisms `f`, `g` such that `g.comp f = id` and `f.comp g = id`,
 returns an multiplicative equivalence with `to_fun = f` and `inv_fun = g`.  This constructor is
 useful if the underlying type(s) have specialized `ext` lemmas for monoid homomorphisms. -/
-@[to_additive /-"Given a pair of additive monoid homomorphisms `f`, `g` such that `g.comp f = id`
+@[inline,
+  to_additive /-"Given a pair of additive monoid homomorphisms `f`, `g` such that `g.comp f = id`
 and `f.comp g = id`, returns an additive equivalence with `to_fun = f` and `inv_fun = g`.  This
 constructor is useful if the underlying type(s) have specialized `ext` lemmas for additive
 monoid homomorphisms."-/, simps {fully_applied := ff}]
@@ -487,7 +494,7 @@ def monoid_hom.to_mul_equiv [mul_one_class M] [mul_one_class N] (f : M →* N) (
   map_mul' := f.map_mul }
 
 /-- A group is isomorphic to its group of units. -/
-@[to_additive "An additive group is isomorphic to its group of additive units"]
+@[inline, to_additive "An additive group is isomorphic to its group of additive units"]
 def to_units [group G] : G ≃* Gˣ :=
 { to_fun := λ x, ⟨x, x⁻¹, mul_inv_self _, inv_mul_self _⟩,
   inv_fun := coe,
@@ -507,7 +514,7 @@ variables [monoid M] [monoid N] [monoid P]
 
 /-- A multiplicative equivalence of monoids defines a multiplicative equivalence
 of their groups of units. -/
-def map_equiv (h : M ≃* N) : Mˣ ≃* Nˣ :=
+@[inline] def map_equiv (h : M ≃* N) : Mˣ ≃* Nˣ :=
 { inv_fun := map h.symm.to_monoid_hom,
   left_inv := λ u, ext $ h.left_inv u,
   right_inv := λ u, ext $ h.right_inv u,
@@ -679,7 +686,7 @@ def mul_equiv.inv (G : Type*) [division_comm_monoid G] : G ≃* G :=
 section type_tags
 
 /-- Reinterpret `G ≃+ H` as `multiplicative G ≃* multiplicative H`. -/
-def add_equiv.to_multiplicative [add_zero_class G] [add_zero_class H] :
+@[inline] def add_equiv.to_multiplicative [add_zero_class G] [add_zero_class H] :
   (G ≃+ H) ≃ (multiplicative G ≃* multiplicative H) :=
 { to_fun := λ f, ⟨f.to_add_monoid_hom.to_multiplicative,
                   f.symm.to_add_monoid_hom.to_multiplicative, f.3, f.4, f.5⟩,
@@ -688,7 +695,7 @@ def add_equiv.to_multiplicative [add_zero_class G] [add_zero_class H] :
   right_inv := λ x, by { ext, refl, }, }
 
 /-- Reinterpret `G ≃* H` as `additive G ≃+ additive H`. -/
-def mul_equiv.to_additive [mul_one_class G] [mul_one_class H] :
+@[inline] def mul_equiv.to_additive [mul_one_class G] [mul_one_class H] :
   (G ≃* H) ≃ (additive G ≃+ additive H) :=
 { to_fun := λ f, ⟨f.to_monoid_hom.to_additive, f.symm.to_monoid_hom.to_additive, f.3, f.4, f.5⟩,
   inv_fun := λ f, ⟨f.to_add_monoid_hom, f.symm.to_add_monoid_hom, f.3, f.4, f.5⟩,
@@ -696,7 +703,7 @@ def mul_equiv.to_additive [mul_one_class G] [mul_one_class H] :
   right_inv := λ x, by { ext, refl, }, }
 
 /-- Reinterpret `additive G ≃+ H` as `G ≃* multiplicative H`. -/
-def add_equiv.to_multiplicative' [mul_one_class G] [add_zero_class H] :
+@[inline] def add_equiv.to_multiplicative' [mul_one_class G] [add_zero_class H] :
   (additive G ≃+ H) ≃ (G ≃* multiplicative H) :=
 { to_fun := λ f, ⟨f.to_add_monoid_hom.to_multiplicative',
                   f.symm.to_add_monoid_hom.to_multiplicative'', f.3, f.4, f.5⟩,
@@ -705,12 +712,12 @@ def add_equiv.to_multiplicative' [mul_one_class G] [add_zero_class H] :
   right_inv := λ x, by { ext, refl, }, }
 
 /-- Reinterpret `G ≃* multiplicative H` as `additive G ≃+ H` as. -/
-def mul_equiv.to_additive' [mul_one_class G] [add_zero_class H] :
+@[inline] def mul_equiv.to_additive' [mul_one_class G] [add_zero_class H] :
   (G ≃* multiplicative H) ≃ (additive G ≃+ H) :=
 add_equiv.to_multiplicative'.symm
 
 /-- Reinterpret `G ≃+ additive H` as `multiplicative G ≃* H`. -/
-def add_equiv.to_multiplicative'' [add_zero_class G] [mul_one_class H] :
+@[inline] def add_equiv.to_multiplicative'' [add_zero_class G] [mul_one_class H] :
   (G ≃+ additive H) ≃ (multiplicative G ≃* H) :=
 { to_fun := λ f, ⟨f.to_add_monoid_hom.to_multiplicative'',
                   f.symm.to_add_monoid_hom.to_multiplicative', f.3, f.4, f.5⟩,
@@ -719,7 +726,7 @@ def add_equiv.to_multiplicative'' [add_zero_class G] [mul_one_class H] :
   right_inv := λ x, by { ext, refl, }, }
 
 /-- Reinterpret `multiplicative G ≃* H` as `G ≃+ additive H` as. -/
-def mul_equiv.to_additive'' [add_zero_class G] [mul_one_class H] :
+@[inline] def mul_equiv.to_additive'' [add_zero_class G] [mul_one_class H] :
   (multiplicative G ≃* H) ≃ (G ≃+ additive H) :=
 add_equiv.to_multiplicative''.symm
 

--- a/src/algebra/hom/group.lean
+++ b/src/algebra/hom/group.lean
@@ -58,6 +58,14 @@ monoid_hom, add_monoid_hom
 
 -/
 
+/--
+For bundled morphisms involving algebraic structure, we mark any `def` that does not directly
+compute with the algebraic structure as `inline`, including the field and base structure
+projections. This means that expressions like `f.comp g` are computable for `f g : A →+ A`, even if
+the addition on `A` is noncomputable.
+-/
+library_note "inline attributes for morphisms"
+
 variables {α β M N P : Type*} -- monoids
 variables {G : Type*} {H : Type*} -- groups
 variables {F : Type*} -- homs
@@ -77,6 +85,9 @@ When you extend this structure, make sure to also extend `zero_hom_class`.
 structure zero_hom (M : Type*) (N : Type*) [has_zero M] [has_zero N] :=
 (to_fun : M → N)
 (map_zero' : to_fun 0 = 0)
+
+-- see note [inline attributes for morphisms]
+attribute [inline] zero_hom.to_fun
 
 /-- `zero_hom_class F M N` states that `F` is a type of zero-preserving homomorphisms.
 
@@ -104,6 +115,9 @@ structure add_hom (M : Type*) (N : Type*) [has_add M] [has_add N] :=
 (to_fun : M → N)
 (map_add' : ∀ x y, to_fun (x + y) = to_fun x + to_fun y)
 
+-- see note [inline attributes for morphisms]
+attribute [inline] add_hom.to_fun
+
 /-- `add_hom_class F M N` states that `F` is a type of addition-preserving homomorphisms.
 You should declare an instance of this typeclass when you extend `add_hom`.
 -/
@@ -130,6 +144,8 @@ When you extend this structure, make sure to extend `add_monoid_hom_class`.
 structure add_monoid_hom (M : Type*) (N : Type*) [add_zero_class M] [add_zero_class N]
   extends zero_hom M N, add_hom M N
 
+-- see note [inline attributes for morphisms]
+attribute [inline] add_monoid_hom.to_fun add_monoid_hom.to_zero_hom add_monoid_hom.to_add_hom
 attribute [nolint doc_blame] add_monoid_hom.to_add_hom
 attribute [nolint doc_blame] add_monoid_hom.to_zero_hom
 
@@ -164,6 +180,8 @@ When you extend this structure, make sure to also extend `one_hom_class`.
 structure one_hom (M : Type*) (N : Type*) [has_one M] [has_one N] :=
 (to_fun : M → N)
 (map_one' : to_fun 1 = 1)
+
+attribute [inline] one_hom.to_fun
 
 /-- `one_hom_class F M N` states that `F` is a type of one-preserving homomorphisms.
 You should extend this typeclass when you extend `one_hom`.
@@ -221,6 +239,9 @@ structure mul_hom (M : Type*) (N : Type*) [has_mul M] [has_mul N] :=
 (to_fun : M → N)
 (map_mul' : ∀ x y, to_fun (x * y) = to_fun x * to_fun y)
 
+-- see note [inline attributes for morphisms]
+attribute [inline] mul_hom.to_fun
+
 infixr ` →ₙ* `:25 := mul_hom
 
 /-- `mul_hom_class F M N` states that `F` is a type of multiplication-preserving homomorphisms.
@@ -264,6 +285,8 @@ When you extend this structure, make sure to extend `monoid_hom_class`.
 structure monoid_hom (M : Type*) (N : Type*) [mul_one_class M] [mul_one_class N]
   extends one_hom M N, M →ₙ* N
 
+-- see note [inline attributes for morphisms]
+attribute [inline] monoid_hom.to_fun monoid_hom.to_one_hom monoid_hom.to_mul_hom
 attribute [nolint doc_blame] monoid_hom.to_mul_hom
 attribute [nolint doc_blame] monoid_hom.to_one_hom
 
@@ -374,6 +397,9 @@ When you extend this structure, make sure to extend `monoid_with_zero_hom_class`
 structure monoid_with_zero_hom (M : Type*) (N : Type*) [mul_zero_one_class M] [mul_zero_one_class N]
   extends zero_hom M N, monoid_hom M N
 
+-- see note [inline attributes for morphisms]
+attribute [inline] monoid_with_zero_hom.to_fun monoid_with_zero_hom.to_zero_hom
+                   monoid_with_zero_hom.to_monoid_hom
 attribute [nolint doc_blame] monoid_with_zero_hom.to_monoid_hom
 attribute [nolint doc_blame] monoid_with_zero_hom.to_zero_hom
 
@@ -437,15 +463,16 @@ lemma monoid_with_zero_hom.coe_eq_to_zero_hom
   (f : zero_hom M N) = f.to_zero_hom := rfl
 
 -- Fallback `has_coe_to_fun` instances to help the elaborator
-@[to_additive]
+@[inline, to_additive]
 instance {mM : has_one M} {mN : has_one N} : has_coe_to_fun (one_hom M N) (λ _, M → N) :=
 ⟨one_hom.to_fun⟩
-@[to_additive]
+@[inline, to_additive]
 instance {mM : has_mul M} {mN : has_mul N} : has_coe_to_fun (M →ₙ* N) (λ _, M → N) :=
 ⟨mul_hom.to_fun⟩
-@[to_additive]
+@[inline, to_additive]
 instance {mM : mul_one_class M} {mN : mul_one_class N} : has_coe_to_fun (M →* N) (λ _, M → N) :=
 ⟨monoid_hom.to_fun⟩
+@[inline]
 instance {mM : mul_zero_one_class M} {mN : mul_zero_one_class N} :
   has_coe_to_fun (M →*₀ N) (λ _, M → N) :=
 ⟨monoid_with_zero_hom.to_fun⟩
@@ -614,7 +641,7 @@ end coes
 
 /-- Copy of a `one_hom` with a new `to_fun` equal to the old one. Useful to fix definitional
 equalities. -/
-@[to_additive "Copy of a `zero_hom` with a new `to_fun` equal to the old one. Useful to fix
+@[inline, to_additive "Copy of a `zero_hom` with a new `to_fun` equal to the old one. Useful to fix
 definitional equalities."]
 protected def one_hom.copy {hM : has_one M} {hN : has_one N} (f : one_hom M N) (f' : M → N)
   (h : f' = f) : one_hom M N :=
@@ -623,7 +650,7 @@ protected def one_hom.copy {hM : has_one M} {hN : has_one N} (f : one_hom M N) (
 
 /-- Copy of a `mul_hom` with a new `to_fun` equal to the old one. Useful to fix definitional
 equalities. -/
-@[to_additive "Copy of an `add_hom` with a new `to_fun` equal to the old one. Useful to fix
+@[inline, to_additive "Copy of an `add_hom` with a new `to_fun` equal to the old one. Useful to fix
 definitional equalities."]
 protected def mul_hom.copy {hM : has_mul M} {hN : has_mul N} (f : M →ₙ* N) (f' : M → N)
   (h : f' = f) : M →ₙ* N :=
@@ -632,7 +659,8 @@ protected def mul_hom.copy {hM : has_mul M} {hN : has_mul N} (f : M →ₙ* N) (
 
 /-- Copy of a `monoid_hom` with a new `to_fun` equal to the old one. Useful to fix
 definitional equalities. -/
-@[to_additive "Copy of an `add_monoid_hom` with a new `to_fun` equal to the old one. Useful to fix
+@[inline,
+  to_additive "Copy of an `add_monoid_hom` with a new `to_fun` equal to the old one. Useful to fix
 definitional equalities."]
 protected def monoid_hom.copy {hM : mul_one_class M} {hN : mul_one_class N} (f : M →* N)
   (f' : M → N) (h : f' = f) : M →* N :=
@@ -640,6 +668,7 @@ protected def monoid_hom.copy {hM : mul_one_class M} {hN : mul_one_class N} (f :
 
 /-- Copy of a `monoid_hom` with a new `to_fun` equal to the old one. Useful to fix
 definitional equalities. -/
+@[inline]
 protected def monoid_with_zero_hom.copy {hM : mul_zero_one_class M} {hN : mul_zero_one_class N}
   (f : M →*₀ N) (f' : M → N) (h : f' = f) : M →* N :=
 { ..f.to_zero_hom.copy f' h, ..f.to_monoid_hom.copy f' h }
@@ -736,23 +765,24 @@ add_decl_doc add_hom.id
 add_decl_doc add_monoid_hom.id
 
 /-- Composition of `one_hom`s as a `one_hom`. -/
-@[to_additive]
+@[inline, to_additive]
 def one_hom.comp [has_one M] [has_one N] [has_one P]
   (hnp : one_hom N P) (hmn : one_hom M N) : one_hom M P :=
 { to_fun := hnp ∘ hmn, map_one' := by simp, }
 /-- Composition of `mul_hom`s as a `mul_hom`. -/
-@[to_additive]
+@[inline, to_additive]
 def mul_hom.comp [has_mul M] [has_mul N] [has_mul P]
   (hnp : N →ₙ* P) (hmn : M →ₙ* N) : M →ₙ* P :=
 { to_fun := hnp ∘ hmn, map_mul' := by simp, }
 
 /-- Composition of monoid morphisms as a monoid morphism. -/
-@[to_additive]
+@[inline, to_additive]
 def monoid_hom.comp [mul_one_class M] [mul_one_class N] [mul_one_class P]
   (hnp : N →* P) (hmn : M →* N) : M →* P :=
 { to_fun := hnp ∘ hmn, map_one' := by simp, map_mul' := by simp, }
 
 /-- Composition of `monoid_with_zero_hom`s as a `monoid_with_zero_hom`. -/
+@[inline]
 def monoid_with_zero_hom.comp [mul_zero_one_class M] [mul_zero_one_class N] [mul_zero_one_class P]
   (hnp : N →*₀ P) (hmn : M →*₀ N) : M →*₀ P :=
 { to_fun := hnp ∘ hmn, map_zero' := by simp, map_one' := by simp, map_mul' := by simp, }
@@ -1114,7 +1144,8 @@ lemma _root_.injective_iff_map_eq_one' {G H} [group G] [mul_one_class H] [monoid
 
 include mM
 /-- Makes a group homomorphism from a proof that the map preserves multiplication. -/
-@[to_additive "Makes an additive group homomorphism from a proof that the map preserves addition.",
+@[inline,
+  to_additive "Makes an additive group homomorphism from a proof that the map preserves addition.",
   simps {fully_applied := ff}]
 def mk' (f : M → G) (map_mul : ∀ a b : M, f (a * b) = f a * f b) : M →* G :=
 { to_fun := f,
@@ -1126,7 +1157,7 @@ omit mM
 /-- Makes a group homomorphism from a proof that the map preserves right division `λ x y, x * y⁻¹`.
 See also `monoid_hom.of_map_div` for a version using `λ x y, x / y`.
 -/
-@[to_additive "Makes an additive group homomorphism from a proof that the map preserves
+@[inline, to_additive "Makes an additive group homomorphism from a proof that the map preserves
 the operation `λ a b, a + -b`. See also `add_monoid_hom.of_map_sub` for a version using
 `λ a b, a - b`."]
 def of_map_mul_inv {H : Type*} [group H] (f : G → H)
@@ -1142,7 +1173,8 @@ calc f (x * y) = f x * (f $ 1 * 1⁻¹ * y⁻¹)⁻¹ : by simp only [one_mul, i
 rfl
 
 /-- Define a morphism of additive groups given a map which respects ratios. -/
-@[to_additive /-"Define a morphism of additive groups given a map which respects difference."-/]
+@[inline,
+  to_additive /-"Define a morphism of additive groups given a map which respects difference."-/]
 def of_map_div {H : Type*} [group H] (f : G → H) (hf : ∀ x y, f (x / y) = f x / f y) : G →* H :=
 of_map_mul_inv f (by simpa only [div_eq_mul_inv] using hf)
 

--- a/test/noncomputable_hom.lean
+++ b/test/noncomputable_hom.lean
@@ -1,0 +1,29 @@
+-- see note [inline attributes for morphisms]
+-- None of the `example`s in this file should be made noncomputable by `A.add_zero_class`.
+
+import algebra.hom.equiv
+import algebra.group.prod
+import algebra.group.pi
+
+def A : Type* := ℕ
+@[instance]
+noncomputable constant A.add_zero_class : add_zero_class A
+
+def ok : A ≃+ A :=
+{ to_fun := id,
+  inv_fun := id,
+  left_inv := λ _, rfl,
+  right_inv := λ _, rfl,
+  map_add' := λ _ _, rfl }
+
+example : A → A := ok
+example : A ≃ A := ok.to_equiv
+example : A ≃+ A := add_equiv.refl _
+example : A ≃+ A := ok.trans ok
+example : A ≃+ A := ok.symm
+example : A →+ A := ok.to_add_monoid_hom
+example : multiplicative A ≃* multiplicative A := ok.to_multiplicative
+
+example : A × A →+ A := add_monoid_hom.fst _ _
+example : A × A →+ A := add_monoid_hom.snd _ _
+example : (ℕ → A) →+ A := pi.eval_add_monoid_hom _ 0


### PR DESCRIPTION
This only makes the changes to group homomorphisms.

See the test for the effect this has.

[Zulip](https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/continuous.20bilinear.20map.20application.20is.20noncomputable/near/275535002)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
