### PR TITLE
[Merged by Bors] - feat(data/nat/basic): add `mul_div_mul_comm_of_dvd_dvd`

### DIFF
--- a/src/algebra/euclidean_domain.lean
+++ b/src/algebra/euclidean_domain.lean
@@ -434,6 +434,17 @@ begin
          mul_div_cancel_left _ (mul_ne_zero ha hc)]
 end
 
+lemma mul_div_mul_comm_of_dvd_dvd {a b c d : R} (hac : c ∣ a) (hbd : d ∣ b) :
+  (a * b) / (c * d) = (a / c) * (b / d) :=
+begin
+  rcases eq_or_ne c 0 with rfl | hc0, { simp only [zero_mul, div_zero], },
+  rcases eq_or_ne d 0 with rfl | hd0, { simp },
+  rcases hac with ⟨k1, rfl⟩,
+  rcases hbd with ⟨k2, rfl⟩,
+  rw [mul_div_cancel_left _ hc0, mul_div_cancel_left _ hd0, mul_mul_mul_comm,
+    mul_div_cancel_left _ (mul_ne_zero hc0 hd0)],
+end
+
 end div
 
 end euclidean_domain

--- a/src/algebra/euclidean_domain.lean
+++ b/src/algebra/euclidean_domain.lean
@@ -434,17 +434,6 @@ begin
          mul_div_cancel_left _ (mul_ne_zero ha hc)]
 end
 
-lemma mul_div_mul_comm_of_dvd_dvd {a b c d : R} (hac : c ∣ a) (hbd : d ∣ b) :
-  a * b / (c * d) = a / c * (b / d) :=
-begin
-  rcases eq_or_ne c 0 with rfl | hc0, { simp },
-  rcases eq_or_ne d 0 with rfl | hd0, { simp },
-  rcases hac with ⟨k1, rfl⟩,
-  rcases hbd with ⟨k2, rfl⟩,
-  rw [mul_div_cancel_left _ hc0, mul_div_cancel_left _ hd0, mul_mul_mul_comm,
-    mul_div_cancel_left _ (mul_ne_zero hc0 hd0)],
-end
-
 end div
 
 end euclidean_domain

--- a/src/algebra/euclidean_domain.lean
+++ b/src/algebra/euclidean_domain.lean
@@ -435,9 +435,9 @@ begin
 end
 
 lemma mul_div_mul_comm_of_dvd_dvd {a b c d : R} (hac : c ∣ a) (hbd : d ∣ b) :
-  (a * b) / (c * d) = (a / c) * (b / d) :=
+  a * b / (c * d) = a / c * (b / d) :=
 begin
-  rcases eq_or_ne c 0 with rfl | hc0, { simp only [zero_mul, div_zero], },
+  rcases eq_or_ne c 0 with rfl | hc0, { simp },
   rcases eq_or_ne d 0 with rfl | hd0, { simp },
   rcases hac with ⟨k1, rfl⟩,
   rcases hbd with ⟨k2, rfl⟩,

--- a/src/algebra/euclidean_domain.lean
+++ b/src/algebra/euclidean_domain.lean
@@ -439,8 +439,8 @@ lemma mul_div_mul_comm_of_dvd_dvd {a b c d : R} (hac : c ∣ a) (hbd : d ∣ b) 
 begin
   rcases eq_or_ne c 0 with rfl | hc0, { simp },
   rcases eq_or_ne d 0 with rfl | hd0, { simp },
-  rcases hac with ⟨k1, rfl⟩,
-  rcases hbd with ⟨k2, rfl⟩,
+  obtain ⟨k1, rfl⟩ := hac,
+  obtain ⟨k2, rfl⟩ := hbd,
   rw [mul_div_cancel_left _ hc0, mul_div_cancel_left _ hd0, mul_mul_mul_comm,
     mul_div_cancel_left _ (mul_ne_zero hc0 hd0)],
 end

--- a/src/algebra/euclidean_domain.lean
+++ b/src/algebra/euclidean_domain.lean
@@ -434,6 +434,17 @@ begin
          mul_div_cancel_left _ (mul_ne_zero ha hc)]
 end
 
+lemma mul_div_mul_comm_of_dvd_dvd {a b c d : R} (hac : c ∣ a) (hbd : d ∣ b) :
+  a * b / (c * d) = a / c * (b / d) :=
+begin
+  rcases eq_or_ne c 0 with rfl | hc0, { simp },
+  rcases eq_or_ne d 0 with rfl | hd0, { simp },
+  rcases hac with ⟨k1, rfl⟩,
+  rcases hbd with ⟨k2, rfl⟩,
+  rw [mul_div_cancel_left _ hc0, mul_div_cancel_left _ hd0, mul_mul_mul_comm,
+    mul_div_cancel_left _ (mul_ne_zero hc0 hd0)],
+end
+
 end div
 
 end euclidean_domain

--- a/src/data/nat/basic.lean
+++ b/src/data/nat/basic.lean
@@ -943,6 +943,17 @@ begin
   { intros h, rw h },
 end
 
+lemma mul_div_mul_comm_of_dvd_dvd {a b c d : ℕ} (hac : c ∣ a) (hbd : d ∣ b) :
+  a * b / (c * d) = a / c * (b / d) :=
+begin
+  rcases c.eq_zero_or_pos with rfl | hc0, { simp },
+  rcases d.eq_zero_or_pos with rfl | hd0, { simp },
+  obtain ⟨k1, rfl⟩ := hac,
+  obtain ⟨k2, rfl⟩ := hbd,
+  rw [mul_mul_mul_comm, nat.mul_div_cancel_left _ hc0, nat.mul_div_cancel_left _ hd0,
+      nat.mul_div_cancel_left _ (mul_pos hc0 hd0)],
+end
+
 @[simp]
 protected lemma div_left_inj {a b d : ℕ} (hda : d ∣ a) (hdb : d ∣ b) : a / d = b / d ↔ a = b :=
 begin


### PR DESCRIPTION
Add lemma `mul_div_mul_comm_of_dvd_dvd (hac : c ∣ a) (hbd : d ∣ b) : (a * b) / (c * d) = (a / c) * (b / d)`

(Compare with `mul_div_mul_comm`, which holds for a `division_comm_monoid`)

Also adds the same lemma for a `euclidean_domain`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
