### PR TITLE
refactor(set_theory/cardinal/basic): tweak basic API

### DIFF
--- a/archive/100-theorems-list/82_cubing_a_cube.lean
+++ b/archive/100-theorems-list/82_cubing_a_cube.lean
@@ -510,9 +510,9 @@ omit h
 theorem not_correct : ¬correct cs :=
 begin
   intro h, apply (lt_aleph_0_of_fintype ι).not_le,
-  rw [aleph_0, lift_id], fapply mk_le_of_injective, exact λ n, (sequence_of_cubes h n).1,
+  rw [aleph_0, lift_id], apply mk_le_of_injective (λ n, (sequence_of_cubes h n).1),
   intros n m hnm, apply (strict_anti_sequence_of_cubes h).injective,
-  dsimp only [decreasing_sequence], rw hnm
+  apply congr_arg (λ x, (cs x).w) hnm
 end
 
 /-- **Dissection of Cubes**: A cube cannot be cubed. -/

--- a/src/algebra/algebraic_card.lean
+++ b/src/algebra/algebraic_card.lean
@@ -26,8 +26,7 @@ namespace algebraic
 
 theorem aleph_0_le_cardinal_mk_of_char_zero (R A : Type*) [comm_ring R] [is_domain R]
   [ring A] [algebra R A] [char_zero A] : ℵ₀ ≤ #{x : A // is_algebraic R x} :=
-@mk_le_of_injective (ulift ℕ) {x : A | is_algebraic R x} (λ n, ⟨_, is_algebraic_nat n.down⟩)
-  (λ m n hmn, by simpa using hmn)
+mk_le_of_injective (λ n, ⟨_, is_algebraic_nat n.down⟩) (λ m n hmn, by simpa using hmn)
 
 section lift
 

--- a/src/category_theory/limits/small_complete.lean
+++ b/src/category_theory/limits/small_complete.lean
@@ -65,12 +65,10 @@ begin
     { intros f,
       ext ⟨j⟩,
       simp } },
-  { apply cardinal.mk_le_of_injective _,
-    { intro f,
-      exact ⟨_, _, f⟩ },
-    { rintro f g k,
-      cases k,
-      refl } },
+  { apply cardinal.mk_le_of_injective (λ f, (⟨_, _, f⟩ : md)),
+    rintro f g k,
+    cases k,
+    refl } ,
 end⟩
 
 end category_theory

--- a/src/computability/encoding.lean
+++ b/src/computability/encoding.lean
@@ -24,7 +24,7 @@ It also contains several examples:
 - `fin_encoding_bool_bool`  : an encoding of bool.
 -/
 
-universes u v
+universes u v w
 open_locale cardinal
 
 namespace computability
@@ -191,8 +191,8 @@ instance inhabited_fin_encoding : inhabited (fin_encoding bool) := ⟨fin_encodi
 instance inhabited_encoding : inhabited (encoding bool) := ⟨fin_encoding_bool_bool.to_encoding⟩
 
 lemma encoding.card_le_card_list {α : Type u} (e : encoding.{u v} α) :
-  cardinal.lift.{v} (# α) ≤ cardinal.lift.{u} (# (list e.Γ)) :=
-mk_lift_le_of_injective _ e.encode_injective
+  cardinal.lift.{max v w} (# α) ≤ cardinal.lift.{max u w} (# (list e.Γ)) :=
+cardinal.mk_lift_le_of_injective _ e.encode_injective
 
 lemma encoding.card_le_aleph_0 {α : Type u} (e : encoding.{u v} α) [encodable e.Γ] : #α ≤ ℵ₀ :=
 begin

--- a/src/computability/encoding.lean
+++ b/src/computability/encoding.lean
@@ -192,7 +192,7 @@ instance inhabited_encoding : inhabited (encoding bool) := ⟨fin_encoding_bool_
 
 lemma encoding.card_le_card_list {α : Type u} (e : encoding.{u v} α) :
   cardinal.lift.{v} (# α) ≤ cardinal.lift.{u} (# (list e.Γ)) :=
-(cardinal.lift_mk_le').2 ⟨⟨e.encode, e.encode_injective⟩⟩
+mk_lift_le_of_injective _ e.encode_injective
 
 lemma encoding.card_le_aleph_0 {α : Type u} (e : encoding.{u v} α) [encodable e.Γ] : #α ≤ ℵ₀ :=
 begin

--- a/src/data/W/cardinal.lean
+++ b/src/data/W/cardinal.lean
@@ -46,7 +46,7 @@ begin
   induction κ using cardinal.induction_on with γ,
   simp only [cardinal.power_def, ← cardinal.mk_sigma, cardinal.le_def] at hκ,
   cases hκ,
-  exact cardinal.mk_le_of_injective (elim_injective _ hκ.1 hκ.2)
+  exact cardinal.mk_le_of_injective _ (elim_injective _ hκ.1 hκ.2)
 end
 
 /-- If, for any `a : α`, `β a` is finite, then the cardinality of `W_type β`

--- a/src/data/mv_polynomial/cardinal.lean
+++ b/src/data/mv_polynomial/cardinal.lean
@@ -94,7 +94,7 @@ of `#R`, `#σ` and `ℵ₀` -/
 lemma cardinal_mk_le_max {σ R : Type u} [comm_semiring R] :
   #(mv_polynomial σ R) ≤ max (max (#R) (#σ)) ℵ₀ :=
 calc #(mv_polynomial σ R) ≤ #(W_type (arity σ R)) :
-  cardinal.mk_le_of_surjective to_mv_polynomial_surjective
+  cardinal.mk_le_of_surjective _ to_mv_polynomial_surjective
 ... ≤ max (#(mv_polynomial_fun σ R)) ℵ₀ : W_type.cardinal_mk_le_max_aleph_0_of_fintype
 ... ≤ _ : max_le_max cardinal_mv_polynomial_fun_le le_rfl
 ... ≤ _ : by simp only [max_assoc, max_self]

--- a/src/data/real/cardinality.lean
+++ b/src/data/real/cardinality.lean
@@ -154,7 +154,7 @@ begin
   { rw real.equiv_Cauchy.cardinal_eq,
     apply mk_quotient_le.trans, apply (mk_subtype_le _).trans_eq,
     rw [← power_def, mk_nat, mk_rat, aleph_0_power_aleph_0] },
-  { convert mk_le_of_injective (cantor_function_injective _ _),
+  { convert mk_le_of_injective _ (cantor_function_injective _ _),
     rw [←power_def, mk_bool, mk_nat, two_power_aleph_0], exact 1 / 3, norm_num, norm_num }
 end
 

--- a/src/field_theory/is_alg_closed/classification.lean
+++ b/src/field_theory/is_alg_closed/classification.lean
@@ -36,7 +36,7 @@ variables [no_zero_smul_divisors R L] (halg : algebra.is_algebraic R L)
 
 lemma cardinal_mk_le_sigma_polynomial :
   #L ≤ #(Σ p : R[X], { x : L // x ∈ (p.map (algebra_map R L)).roots }) :=
-@mk_le_of_injective L (Σ p : R[X], { x : L | x ∈ (p.map (algebra_map R L)).roots })
+mk_le_of_injective
   (λ x : L, let p := classical.indefinite_description _ (halg x) in
     ⟨p.1, x,
       begin
@@ -47,7 +47,8 @@ lemma cardinal_mk_le_sigma_polynomial :
         exact p.2.1 },
       erw [polynomial.mem_roots h, polynomial.is_root, polynomial.eval_map,
         ← polynomial.aeval_def, p.2.2],
-      end⟩) (λ x y, begin
+      end⟩)
+  (λ x y, begin
     intro h,
     simp only at h,
     refine (subtype.heq_iff_coe_eq _).1 h.2,
@@ -154,7 +155,7 @@ le_antisymm
          { exact le_trans hR this },
          { exact le_max_of_le_right this }
        end)
-  (mk_le_of_injective (show function.injective v, from hv.1.injective))
+  (mk_le_of_injective v hv.1.injective)
 
 end cardinal
 

--- a/src/group_theory/index.lean
+++ b/src/group_theory/index.lean
@@ -220,7 +220,7 @@ nat.le_of_dvd (nat.pos_of_ne_zero hHL) (relindex_dvd_of_le_left L hHK)
 @[to_additive] lemma relindex_le_of_le_right (hKL : K ≤ L) (hHL : H.relindex L ≠ 0) :
   H.relindex K ≤ H.relindex L :=
 cardinal.to_nat_le_of_le_of_lt_aleph_0 (lt_of_not_ge (mt cardinal.to_nat_apply_of_aleph_0_le hHL))
-  (cardinal.mk_le_of_injective (quotient_subgroup_of_embedding_of_le H hKL).2)
+  (quotient_subgroup_of_embedding_of_le H hKL).cardinal_le
 
 @[to_additive] lemma relindex_ne_zero_trans (hHK : H.relindex K ≠ 0) (hKL : K.relindex L ≠ 0) :
   H.relindex L ≠ 0 :=

--- a/src/linear_algebra/dimension.lean
+++ b/src/linear_algebra/dimension.lean
@@ -485,7 +485,7 @@ variables {M : Type v} [add_comm_group M] [module R M]
 /-- The dimension theorem: if `v` and `v'` are two bases, their index types
 have the same cardinalities. -/
 theorem {m} mk_eq_mk_of_basis (v : basis ι R M) (v' : basis ι' R M) :
-  cardinal.lift.{w' m} (#ι) = cardinal.lift.{w m} (#ι') :=
+  cardinal.lift.{max w' m} (#ι) = cardinal.lift.{max w m} (#ι') :=
 begin
   haveI := nontrivial_of_invariant_basis_number R,
   casesI fintype_or_infinite ι,

--- a/src/linear_algebra/dimension.lean
+++ b/src/linear_algebra/dimension.lean
@@ -115,15 +115,15 @@ variables {M : Type v} [add_comm_group M] [module R M]
 variables {M' : Type v'} [add_comm_group M'] [module R M']
 variables {M₁ : Type v} [add_comm_group M₁] [module R M₁]
 
-theorem linear_map.lift_dim_le_of_injective (f : M →ₗ[R] M') (i : injective f) :
-  cardinal.lift.{v'} (module.rank R M) ≤ cardinal.lift.{v} (module.rank R M') :=
+theorem {m} linear_map.lift_dim_le_of_injective (f : M →ₗ[R] M') (i : injective f) :
+  cardinal.lift.{max v' m} (module.rank R M) ≤ cardinal.lift.{max v m} (module.rank R M') :=
 begin
   dsimp [module.rank],
   rw [cardinal.lift_supr (cardinal.bdd_above_range.{v' v'} _),
     cardinal.lift_supr (cardinal.bdd_above_range.{v v} _)],
   apply csupr_mono' (cardinal.bdd_above_range.{v' v} _),
   rintro ⟨s, li⟩,
-  refine ⟨⟨f '' s, _⟩, cardinal.lift_mk_le'.mpr ⟨(equiv.set.image f s i).to_embedding⟩⟩,
+  refine ⟨⟨f '' s, _⟩, cardinal.lift_mk_le.mpr ⟨(equiv.set.image f s i).to_embedding⟩⟩,
   exact (li.map' _ $ linear_map.ker_eq_bot.mpr i).image,
 end
 
@@ -153,7 +153,7 @@ begin
   refine (le_csupr (cardinal.bdd_above_range.{v v} _) ⟨range_splitting f '' s, _⟩),
   { apply linear_independent.of_comp f.range_restrict,
     convert li.comp (equiv.set.range_splitting_image_equiv f s) (equiv.injective _) using 1, },
-  { exact (cardinal.lift_mk_eq'.mpr ⟨equiv.set.range_splitting_image_equiv f s⟩).ge, },
+  { exact (set.range_splitting_image_equiv f s).cardinal_lift_eq.ge, },
 end
 
 lemma dim_range_le (f : M →ₗ[R] M₁) : module.rank R f.range ≤ module.rank R M :=
@@ -395,17 +395,17 @@ Over any ring `R`, if `b` is an infinite basis for a module `M`,
 and `s` is a maximal linearly independent set,
 then the cardinality of `b` is bounded by the cardinality of `s`.
 -/
-lemma infinite_basis_le_maximal_linear_independent'
+lemma {m} infinite_basis_le_maximal_linear_independent'
   {ι : Type w} (b : basis ι R M) [infinite ι]
   {κ : Type w'} (v : κ → M) (i : linear_independent R v) (m : i.maximal) :
-  cardinal.lift.{w'} (#ι) ≤ cardinal.lift.{w} (#κ) :=
+  cardinal.lift.{max w' m} (#ι) ≤ cardinal.lift.{max w m} (#κ) :=
 begin
   let Φ := λ k : κ, (b.repr (v k)).support,
   have w₁ : #ι ≤ #(set.range Φ),
   { apply cardinal.le_range_of_union_finset_eq_top,
     exact union_support_maximal_linear_independent_eq_range_basis b v i m, },
   have w₂ :
-    cardinal.lift.{w'} (#(set.range Φ)) ≤ cardinal.lift.{w} (#κ) :=
+    cardinal.lift.{w' m} (#(set.range Φ)) ≤ cardinal.lift.{w m} (#κ) :=
     cardinal.mk_range_le_lift,
   exact (cardinal.lift_le.mpr w₁).trans w₂,
 end
@@ -423,9 +423,9 @@ lemma infinite_basis_le_maximal_linear_independent
   #ι ≤ #κ :=
 cardinal.lift_le.mp (infinite_basis_le_maximal_linear_independent' b v i m)
 
-lemma complete_lattice.independent.subtype_ne_bot_le_rank [no_zero_smul_divisors R M]
+lemma {m} complete_lattice.independent.subtype_ne_bot_le_rank [no_zero_smul_divisors R M]
   {V : ι → submodule R M} (hV : complete_lattice.independent V) :
-  cardinal.lift.{v} (#{i : ι // V i ≠ ⊥}) ≤ cardinal.lift.{w} (module.rank R M) :=
+  cardinal.lift.{max v m} (#{i : ι // V i ≠ ⊥}) ≤ cardinal.lift.{max w m} (module.rank R M) :=
 begin
   set I := {i : ι // V i ≠ ⊥},
   have hI : ∀ i : I, ∃ v ∈ V i, v ≠ (0:M),
@@ -484,8 +484,8 @@ variables {M : Type v} [add_comm_group M] [module R M]
 
 /-- The dimension theorem: if `v` and `v'` are two bases, their index types
 have the same cardinalities. -/
-theorem mk_eq_mk_of_basis (v : basis ι R M) (v' : basis ι' R M) :
-  cardinal.lift.{w'} (#ι) = cardinal.lift.{w} (#ι') :=
+theorem {m} mk_eq_mk_of_basis (v : basis ι R M) (v' : basis ι' R M) :
+  cardinal.lift.{w' m} (#ι) = cardinal.lift.{w m} (#ι') :=
 begin
   haveI := nontrivial_of_invariant_basis_number R,
   casesI fintype_or_infinite ι,
@@ -505,7 +505,7 @@ begin
     -- we see they have the same cardinality.
     have w₁ :=
       infinite_basis_le_maximal_linear_independent' v _ v'.linear_independent v'.maximal,
-    rcases cardinal.lift_mk_le'.mp w₁ with ⟨f⟩,
+    rcases cardinal.lift_mk_le.mp w₁ with ⟨f⟩,
     haveI : infinite ι' := infinite.of_injective f f.2,
     have w₂ :=
       infinite_basis_le_maximal_linear_independent' v' _ v.linear_independent v.maximal,

--- a/src/model_theory/basic.lean
+++ b/src/model_theory/basic.lean
@@ -695,15 +695,15 @@ section empty
 section
 variables [language.empty.Structure M] [language.empty.Structure N]
 
-@[simp] lemma empty.nonempty_embedding_iff :
-  nonempty (M ↪[language.empty] N) ↔ cardinal.lift.{w'} (# M) ≤ cardinal.lift.{w} (# N) :=
+@[simp] lemma empty.nonempty_embedding_iff : nonempty (M ↪[language.empty] N) ↔
+  cardinal.lift.{max w' u} (# M) ≤ cardinal.lift.{max w u} (# N) :=
 trans ⟨nonempty.map (λ f, f.to_embedding), nonempty.map (λ f, {to_embedding := f})⟩
-  cardinal.lift_mk_le'.symm
+  cardinal.lift_mk_le.symm
 
-@[simp] lemma empty.nonempty_equiv_iff :
-  nonempty (M ≃[language.empty] N) ↔ cardinal.lift.{w'} (# M) = cardinal.lift.{w} (# N) :=
+@[simp] lemma empty.nonempty_equiv_iff : nonempty (M ≃[language.empty] N) ↔
+  cardinal.lift.{max w' u} (# M) = cardinal.lift.{max w u} (# N) :=
 trans ⟨nonempty.map (λ f, f.to_equiv), nonempty.map (λ f, {to_equiv := f})⟩
-  cardinal.lift_mk_eq'.symm
+  cardinal.lift_mk_eq.symm
 
 end
 

--- a/src/model_theory/satisfiability.lean
+++ b/src/model_theory/satisfiability.lean
@@ -107,13 +107,13 @@ begin
   exact (h' i).mono hi,
 end
 
-theorem is_satisfiable_union_distinct_constants_theory_of_card_le (T : L.Theory) (s : set α)
+theorem {x} is_satisfiable_union_distinct_constants_theory_of_card_le (T : L.Theory) (s : set α)
   (M : Type w') [nonempty M] [L.Structure M] [M ⊨ T]
-  (h : cardinal.lift.{w'} (# s) ≤ cardinal.lift.{w} (# M)) :
+  (h : cardinal.lift.{max w' x} (# s) ≤ cardinal.lift.{max w x} (# M)) :
   ((L.Lhom_with_constants α).on_Theory T ∪ L.distinct_constants_theory s).is_satisfiable :=
 begin
   haveI : inhabited M := classical.inhabited_of_nonempty infer_instance,
-  rw [cardinal.lift_mk_le'] at h,
+  rw cardinal.lift_mk_le at h,
   letI : (constants_on α).Structure M :=
     constants_on.Structure (function.extend coe h.some default),
   haveI : M ⊨ (L.Lhom_with_constants α).on_Theory T ∪ L.distinct_constants_theory s,

--- a/src/model_theory/semantics.lean
+++ b/src/model_theory/semantics.lean
@@ -884,7 +884,8 @@ end
 lemma {m} card_le_of_model_distinct_constants_theory (s : set α) (M : Type w) [L[[α]].Structure M]
   [h : M ⊨ L.distinct_constants_theory s] :
   cardinal.lift.{max w m} (# s) ≤ cardinal.lift.{max u' m} (# M) :=
-mk_lift_le_of_injective _ $ set.inj_on_iff_injective.1 ((L.model_distinct_constants_theory s).1 h)
+cardinal.mk_lift_le_of_injective _ $ set.inj_on_iff_injective.1
+  ((L.model_distinct_constants_theory s).1 h)
 
 end cardinality
 

--- a/src/model_theory/semantics.lean
+++ b/src/model_theory/semantics.lean
@@ -881,10 +881,10 @@ begin
     exact λ contra, ab (h as bs contra) }
 end
 
-lemma card_le_of_model_distinct_constants_theory (s : set α) (M : Type w) [L[[α]].Structure M]
+lemma {m} card_le_of_model_distinct_constants_theory (s : set α) (M : Type w) [L[[α]].Structure M]
   [h : M ⊨ L.distinct_constants_theory s] :
-  cardinal.lift.{w} (# s) ≤ cardinal.lift.{u'} (# M) :=
-lift_mk_le'.2 ⟨⟨_, set.inj_on_iff_injective.1 ((L.model_distinct_constants_theory s).1 h)⟩⟩
+  cardinal.lift.{max w m} (# s) ≤ cardinal.lift.{max u' m} (# M) :=
+mk_lift_le_of_injective _ $ set.inj_on_iff_injective.1 ((L.model_distinct_constants_theory s).1 h)
 
 end cardinality
 

--- a/src/ring_theory/localization/cardinality.lean
+++ b/src/ring_theory/localization/cardinality.lean
@@ -66,6 +66,6 @@ variables (L)
 
 /-- If you do not localize at any zero-divisors, localization preserves cardinality. -/
 lemma card (hS : S ≤ R⁰) : #R = #L :=
-(cardinal.mk_le_of_injective (is_localization.injective L hS)).antisymm (card_le S)
+(cardinal.mk_le_of_injective _ (is_localization.injective L hS)).antisymm (card_le S)
 
 end is_localization

--- a/src/ring_theory/localization/cardinality.lean
+++ b/src/ring_theory/localization/cardinality.lean
@@ -52,10 +52,10 @@ lemma card_le : #L ≤ #R :=
 begin
   classical,
   casesI fintype_or_infinite R,
-  { exact cardinal.mk_le_of_surjective (algebra_map_surjective_of_fintype S) },
+  { exact cardinal.mk_le_of_surjective _ (algebra_map_surjective_of_fintype S) },
   erw [←cardinal.mul_eq_self $ cardinal.aleph_0_le_mk R],
   set f : R × R → L := λ aa, is_localization.mk' _ aa.1 (if h : aa.2 ∈ S then ⟨aa.2, h⟩ else 1),
-  refine @cardinal.mk_le_of_surjective _ _ f (λ a, _),
+  refine cardinal.mk_le_of_surjective f (λ a, _),
   obtain ⟨x, y, h⟩ := is_localization.mk'_surjective S a,
   use (x, y),
   dsimp [f],

--- a/src/set_theory/cardinal/basic.lean
+++ b/src/set_theory/cardinal/basic.lean
@@ -114,13 +114,13 @@ protected lemma eq : #α = #β ↔ nonempty (α ≃ β) := quotient.eq
 
 @[simp] theorem mk_def (α : Type u) : @eq cardinal ⟦α⟧ (#α) := rfl
 
-@[simp] theorem mk_out (c : cardinal) : #(c.out) = c := quotient.out_eq _
+@[simp] theorem mk_out (c : cardinal) : #(c.out) = c := quotient.out_eq c
 
 /-- The representative of the cardinal of a type is equivalent ot the original type. -/
 def out_mk_equiv {α : Type v} : (#α).out ≃ α :=
 nonempty.some $ cardinal.eq.mp (by simp)
 
-lemma mk_congr (e : α ≃ β) : # α = # β := quot.sound ⟨e⟩
+lemma mk_congr (e : α ≃ β) : #α = #β := quot.sound ⟨e⟩
 
 alias mk_congr ← equiv.cardinal_eq
 
@@ -180,16 +180,35 @@ instance : partial_order cardinal.{u} :=
   le_trans    := by rintros ⟨α⟩ ⟨β⟩ ⟨γ⟩ ⟨e₁⟩ ⟨e₂⟩; exact ⟨e₁.trans e₂⟩,
   le_antisymm := by { rintros ⟨α⟩ ⟨β⟩ ⟨e₁⟩ ⟨e₂⟩, exact quotient.sound (e₁.antisymm e₂) } }
 
-theorem le_def (α β : Type u) : #α ≤ #β ↔ nonempty (α ↪ β) :=
-iff.rfl
+theorem le_def (α β : Type u) : #α ≤ #β ↔ nonempty (α ↪ β) := iff.rfl
 
-theorem mk_le_of_injective {α β : Type u} {f : α → β} (hf : injective f) : #α ≤ #β :=
-⟨⟨f, hf⟩⟩
+theorem mk_le_of_injective {α β : Type u} (f : α → β) (hf : injective f) : #α ≤ #β := ⟨⟨f, hf⟩⟩
 
 theorem _root_.function.embedding.cardinal_le {α β : Type u} (f : α ↪ β) : #α ≤ #β := ⟨f⟩
 
-theorem mk_le_of_surjective {α β : Type u} {f : α → β} (hf : surjective f) : #β ≤ #α :=
+theorem mk_le_of_surjective {α β : Type u} (f : α → β) (hf : surjective f) : #β ≤ #α :=
 ⟨embedding.of_surjective f hf⟩
+
+theorem lift_mk_le {α : Type u} {β : Type v} :
+  lift.{max v w} (#α) ≤ lift.{max u w} (#β) ↔ nonempty (α ↪ β) :=
+⟨λ ⟨f⟩, ⟨embedding.congr equiv.ulift equiv.ulift f⟩,
+ λ ⟨f⟩, ⟨embedding.congr equiv.ulift.symm equiv.ulift.symm f⟩⟩
+
+theorem _root_.function.embedding.cardinal_lift_le {α : Type u} {β : Type v} (f : α ↪ β) :
+  lift.{max v w} (#α) ≤ lift.{max u w} (#β) :=
+lift_mk_le.2 ⟨f⟩
+
+theorem lift_mk_eq {α : Type u} {β : Type v} :
+  lift.{max v w} (#α) = lift.{max u w} (#β) ↔ nonempty (α ≃ β) :=
+quotient.eq.trans
+⟨λ ⟨f⟩, ⟨equiv.ulift.symm.trans $ f.trans equiv.ulift⟩,
+ λ ⟨f⟩, ⟨equiv.ulift.trans $ f.trans equiv.ulift.symm⟩⟩
+
+theorem congr_lift_mk {α : Type u} {β : Type v} (h : α ≃ β) :
+  lift.{max v w} (#α) = lift.{max u w} (#β) :=
+lift_mk_eq.2 ⟨h⟩
+
+alias congr_lift_mk ← equiv.cardinal_lift_eq
 
 theorem le_mk_iff_exists_set {c : cardinal} {α : Type u} :
   c ≤ #α ↔ ∃ p : set α, #p = c :=
@@ -205,33 +224,6 @@ mk_subtype_le s
 
 theorem out_embedding {c c' : cardinal} : c ≤ c' ↔ nonempty (c.out ↪ c'.out) :=
 by { transitivity _, rw [←quotient.out_eq c, ←quotient.out_eq c'], refl }
-
-theorem lift_mk_le {α : Type u} {β : Type v} :
-  lift.{(max v w)} (#α) ≤ lift.{max u w} (#β) ↔ nonempty (α ↪ β) :=
-⟨λ ⟨f⟩, ⟨embedding.congr equiv.ulift equiv.ulift f⟩,
- λ ⟨f⟩, ⟨embedding.congr equiv.ulift.symm equiv.ulift.symm f⟩⟩
-
-/-- A variant of `cardinal.lift_mk_le` with specialized universes.
-Because Lean often can not realize it should use this specialization itself,
-we provide this statement separately so you don't have to solve the specialization problem either.
--/
-theorem lift_mk_le' {α : Type u} {β : Type v} :
-  lift.{v} (#α) ≤ lift.{u} (#β) ↔ nonempty (α ↪ β) :=
-lift_mk_le.{u v 0}
-
-theorem lift_mk_eq {α : Type u} {β : Type v} :
-  lift.{max v w} (#α) = lift.{max u w} (#β) ↔ nonempty (α ≃ β) :=
-quotient.eq.trans
-⟨λ ⟨f⟩, ⟨equiv.ulift.symm.trans $ f.trans equiv.ulift⟩,
- λ ⟨f⟩, ⟨equiv.ulift.trans $ f.trans equiv.ulift.symm⟩⟩
-
-/-- A variant of `cardinal.lift_mk_eq` with specialized universes.
-Because Lean often can not realize it should use this specialization itself,
-we provide this statement separately so you don't have to solve the specialization problem either.
--/
-theorem lift_mk_eq' {α : Type u} {β : Type v} :
-  lift.{v} (#α) = lift.{u} (#β) ↔ nonempty (α ≃ β) :=
-lift_mk_eq.{u v 0}
 
 @[simp] theorem lift_le {a b : cardinal} : lift a ≤ lift b ↔ a ≤ b :=
 induction_on₂ a b $ λ α β, by { rw ← lift_umax, exact lift_mk_le }
@@ -542,7 +534,7 @@ begin
   refine (le_cInf_iff'' (exists_gt c)).2 (λ b hlt, _),
   rcases ⟨b, c⟩ with ⟨⟨β⟩, ⟨γ⟩⟩,
   cases le_of_lt hlt with f,
-  have : ¬ surjective f := λ hn, (not_le_of_lt hlt) (mk_le_of_surjective hn),
+  have : ¬ surjective f := λ hn, (not_le_of_lt hlt) (mk_le_of_surjective f hn),
   simp only [surjective, not_forall] at this,
   rcases this with ⟨b, hb⟩,
   calc #γ + 1 = #(option γ) : mk_option.symm
@@ -1226,7 +1218,7 @@ calc #(list α) = #(Σ n, vector α n) : mk_congr (equiv.sigma_fiber_equiv list.
 ... = sum (λ n : ℕ, (#α) ^ℕ n) : by simp
 
 theorem mk_quot_le {α : Type u} {r : α → α → Prop} : #(quot r) ≤ #α :=
-mk_le_of_surjective quot.exists_rep
+mk_le_of_surjective _ quot.exists_rep
 
 theorem mk_quotient_le {α : Type u} {s : setoid α} : #(quotient s) ≤ #α :=
 mk_quot_le
@@ -1250,14 +1242,14 @@ end
 mk_congr (equiv.set.univ α)
 
 theorem mk_image_le {α β : Type u} {f : α → β} {s : set α} : #(f '' s) ≤ #s :=
-mk_le_of_surjective surjective_onto_image
+mk_le_of_surjective _ surjective_onto_image
 
 theorem mk_image_le_lift {α : Type u} {β : Type v} {f : α → β} {s : set α} :
   lift.{u} (#(f '' s)) ≤ lift.{v} (#s) :=
 lift_mk_le.{v u 0}.mpr ⟨embedding.of_surjective _ surjective_onto_image⟩
 
 theorem mk_range_le {α β : Type u} {f : α → β} : #(range f) ≤ #α :=
-mk_le_of_surjective surjective_onto_range
+mk_le_of_surjective _ surjective_onto_range
 
 theorem mk_range_le_lift {α : Type u} {β : Type v} {f : α → β} :
   lift.{u} (#(range f)) ≤ lift.{v} (#α) :=
@@ -1267,8 +1259,8 @@ lemma mk_range_eq (f : α → β) (h : injective f) : #(range f) = #α :=
 mk_congr ((equiv.of_injective f h).symm)
 
 lemma mk_range_eq_of_injective {α : Type u} {β : Type v} {f : α → β} (hf : injective f) :
-  lift.{u} (#(range f)) = lift.{v} (#α) :=
-lift_mk_eq'.mpr ⟨(equiv.of_injective f hf).symm⟩
+  lift.{max u w} (#(range f)) = lift.{max v w} (#α) :=
+(equiv.of_injective f hf).symm.cardinal_lift_eq
 
 lemma mk_range_eq_lift {α : Type u} {β : Type v} {f : α → β} (hf : injective f) :
   lift.{max u w} (# (range f)) = lift.{max v w} (# α) :=
@@ -1279,13 +1271,13 @@ theorem mk_image_eq {α β : Type u} {f : α → β} {s : set α} (hf : injectiv
 mk_congr ((equiv.set.image f s hf).symm)
 
 theorem mk_Union_le_sum_mk {α ι : Type u} {f : ι → set α} : #(⋃ i, f i) ≤ sum (λ i, #(f i)) :=
-calc #(⋃ i, f i) ≤ #(Σ i, f i)        : mk_le_of_surjective (set.sigma_to_Union_surjective f)
+calc #(⋃ i, f i) ≤ #(Σ i, f i)        : mk_le_of_surjective _ (set.sigma_to_Union_surjective f)
               ... = sum (λ i, #(f i)) : mk_sigma _
 
-theorem mk_Union_eq_sum_mk {α ι : Type u} {f : ι → set α} (h : ∀i j, i ≠ j → disjoint (f i) (f j)) :
+theorem mk_Union_eq_sum_mk {α ι : Type u} {f : ι → set α} (h : ∀ i j, i ≠ j → disjoint (f i) (f j)) :
   #(⋃ i, f i) = sum (λ i, #(f i)) :=
-calc #(⋃ i, f i) = #(Σ i, f i)       : mk_congr (set.Union_eq_sigma_of_disjoint h)
-              ... = sum (λi, #(f i)) : mk_sigma _
+calc #(⋃ i, f i) = #(Σ i, f i)        : mk_congr (set.Union_eq_sigma_of_disjoint h)
+              ... = sum (λ i, #(f i)) : mk_sigma _
 
 lemma mk_Union_le {α ι : Type u} (f : ι → set α) : #(⋃ i, f i) ≤ #ι * ⨆ i, #(f i) :=
 mk_Union_le_sum_mk.trans (sum_le_supr _)

--- a/src/set_theory/cardinal/cofinality.lean
+++ b/src/set_theory/cardinal/cofinality.lean
@@ -217,7 +217,7 @@ begin
     exact hb'.trans_lt (lt_lsub.{u u} f ⟨b, hb⟩) }
 end
 
-@[simp] theorem lift_cof (o) : (cof o).lift = cof o.lift :=
+@[simp] theorem lift_cof (o : ordinal.{u}) : cardinal.lift.{v} (cof o) = cof o.lift :=
 begin
   refine induction_on o _,
   introsI α r _,
@@ -226,7 +226,7 @@ begin
   { unfreezingI { refine le_cof_type.2 (λ S H, _) },
     have : (#(ulift.up ⁻¹' S)).lift ≤ #S,
     { rw [← cardinal.lift_umax, ← cardinal.lift_id' (#S)],
-      exact mk_preimage_of_injective_lift ulift.up _ ulift.up_injective },
+      exact mk_preimage_of_injective_lift.{u (max u v) 0} ulift.up _ ulift.up_injective },
     refine (cardinal.lift_le.2 $ cof_type_le _).trans this,
     exact λ a, let ⟨⟨b⟩, bs, br⟩ := H ⟨a⟩ in ⟨b, bs, br⟩ },
   { rcases cof_eq r with ⟨S, H, e'⟩,

--- a/src/set_theory/cardinal/cofinality.lean
+++ b/src/set_theory/cardinal/cofinality.lean
@@ -196,7 +196,7 @@ begin
   refine le_antisymm (le_cInf (cof_lsub_def_nonempty o) _) (cInf_le' _),
   { rintros a ⟨ι, f, hf, rfl⟩,
     rw ←type_lt o,
-    refine (cof_type_le (λ a, _)).trans (@mk_le_of_injective _ _
+    refine (cof_type_le (λ a, _)).trans (mk_le_of_injective
       (λ s : (typein ((<) : o.out.α → o.out.α → Prop))⁻¹' (set.range f), classical.some s.prop)
       (λ s t hst, let H := congr_arg f hst in by rwa [classical.some_spec s.prop,
         classical.some_spec t.prop, typein_inj, subtype.coe_inj] at H)),
@@ -778,7 +778,7 @@ begin
     apply (h'.two_power_lt _).le,
     rw [coe_set_of, card_typein, ←lt_ord, hr],
     apply typein_lt_type },
-  { refine @mk_le_of_injective α _ (λ x, subtype.mk {x} _) _,
+  { refine mk_le_of_injective (λ x, subtype.mk {x} _) _,
     { apply bounded_singleton,
       rw ←hr,
       apply ord_is_limit ha },
@@ -800,7 +800,7 @@ begin
     apply mk_le_mk_of_subset (λ s hs, _),
     rw hr at hs,
     exact lt_cof_type hs },
-  { refine @mk_le_of_injective α _ (λ x, subtype.mk {x} _) _,
+  { refine mk_le_of_injective (λ x, subtype.mk {x} _) _,
     { rw mk_singleton,
       exact one_lt_aleph_0.trans_le (aleph_0_le_cof.2 (ord_is_limit h'.is_limit.aleph_0_le)) },
     { intros a b hab,

--- a/src/set_theory/cardinal/ordinal.lean
+++ b/src/set_theory/cardinal/ordinal.lean
@@ -687,7 +687,7 @@ end
 
 @[simp] theorem mk_finset_of_infinite (α : Type u) [infinite α] : #(finset α) = #α :=
 eq.symm $ le_antisymm (mk_le_of_injective _ (λ x y, finset.singleton_inj.1)) $
-calc #(finset α) ≤ #(list α) : mk_le_of_surjective list.to_finset_surjective
+calc #(finset α) ≤ #(list α) : mk_le_of_surjective _ list.to_finset_surjective
 ... = #α : mk_list_eq_mk α
 
 lemma mk_bounded_set_le_of_infinite (α : Type u) [infinite α] (c : cardinal) :
@@ -695,10 +695,8 @@ lemma mk_bounded_set_le_of_infinite (α : Type u) [infinite α] (c : cardinal) :
 begin
   refine le_trans _ (by rw [←add_one_eq (aleph_0_le_mk α)]),
   induction c using cardinal.induction_on with β,
-  fapply mk_le_of_surjective,
-  { intro f, use sum.inl ⁻¹' range f,
-    refine le_trans (mk_preimage_of_injective _ _ (λ x y, sum.inl.inj)) _,
-    apply mk_range_le },
+  refine mk_le_of_surjective (λ f, ⟨sum.inl ⁻¹' range f,
+    le_trans (mk_preimage_of_injective _ _ (λ x y, sum.inl.inj)) mk_range_le⟩) _,
   rintro ⟨s, ⟨g⟩⟩,
   use λ y, if h : ∃(x : s), g x = y then sum.inl (classical.some h).val else sum.inr ⟨⟩,
   apply subtype.eq, ext,
@@ -799,7 +797,7 @@ begin
   casesI fintype_or_infinite α,
   { exact extend_function_finite f h },
   { apply extend_function f, cases id h with g, haveI := infinite.of_injective _ g.injective,
-    rw [← lift_mk_eq'] at h ⊢,
+    rw [← lift_mk_eq] at h ⊢,
     rwa [mk_compl_of_infinite s hs, mk_compl_of_infinite],
     rwa [← lift_lt, mk_range_eq_of_injective f.injective, ← h, lift_lt] },
 end

--- a/src/set_theory/cardinal/ordinal.lean
+++ b/src/set_theory/cardinal/ordinal.lean
@@ -686,7 +686,7 @@ begin
 end
 
 @[simp] theorem mk_finset_of_infinite (α : Type u) [infinite α] : #(finset α) = #α :=
-eq.symm $ le_antisymm (mk_le_of_injective (λ x y, finset.singleton_inj.1)) $
+eq.symm $ le_antisymm (mk_le_of_injective _ (λ x y, finset.singleton_inj.1)) $
 calc #(finset α) ≤ #(list α) : mk_le_of_surjective list.to_finset_surjective
 ... = #α : mk_list_eq_mk α
 

--- a/src/set_theory/ordinal/arithmetic.lean
+++ b/src/set_theory/ordinal/arithmetic.lean
@@ -1580,14 +1580,11 @@ begin
   by_contra' h,
   apply (lt_succ (#ι)).not_le,
   have H := λ a, exists_of_lt_mex ((typein_lt_self a).trans_le h),
-  let g : (succ (#ι)).ord.out.α → ι := λ a, classical.some (H a),
-  have hg : injective g := λ a b h', begin
-    have Hf : ∀ x, f (g x) = typein (<) x := λ a, classical.some_spec (H a),
-    apply_fun f at h',
-    rwa [Hf, Hf, typein_inj] at h'
-  end,
-  convert cardinal.mk_le_of_injective hg,
-  rw cardinal.mk_ord_out
+  rw ←cardinal.mk_ord_out (succ _),
+  apply cardinal.mk_le_of_injective (λ a, classical.some (H a)) (λ a b h', _),
+  have Hf : ∀ x, f _ = typein (<) x := λ a, classical.some_spec (H a),
+  apply_fun f at h',
+  rwa [Hf, Hf, typein_inj] at h'
 end
 
 /-- The minimum excluded ordinal of a family of ordinals indexed by the set of ordinals less than


### PR DESCRIPTION
This PR consists of three changes that affect the same part of the code:
- We make the function arguments to `mk_le_of_injective`, etc. explicit. This is because in practice, this theorem is used with quite elaborate functions, which then are proven injective.
- We add lemmas like `mk_le_of_injective` for lifts, and allow for dot notation.
- We generalize universes in many theorems about lifts. This could potentially make universe elaboration harder, but given that almost all API on `cardinal.lift` needs universe annotations anyways, this doesn't seem like much of an issue.
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
