### PR TITLE
[Merged by Bors] - feat(data/fin/tuple/basic): add lemmas for rewriting exists and forall over `n+1`-tuples

### DIFF
--- a/src/data/fin/tuple/basic.lean
+++ b/src/data/fin/tuple/basic.lean
@@ -132,6 +132,14 @@ begin
   exact tail_cons _ _
 end
 
+@[simp] lemma forall_fin_zero_pi {α : fin 0 → Sort*} {P : (Π i, α i) → Prop} :
+  (∀ x, P x) ↔ P fin_zero_elim :=
+⟨λ h, h _, λ h x, subsingleton.elim fin_zero_elim x ▸ h⟩
+
+@[simp] lemma exists_fin_zero_pi {α : fin 0 → Sort*} {P : (Π i, α i) → Prop} :
+  (∃ x, P x) ↔ P fin_zero_elim :=
+⟨λ ⟨x, h⟩, subsingleton.elim x fin_zero_elim ▸ h, λ h, ⟨_, h⟩⟩
+
 lemma forall_fin_succ_pi {P : (Π i, α i) → Prop} :
   (∀ x, P x) ↔ (∀ a v, P (fin.cons a v)) :=
 ⟨λ h a v, h (fin.cons a v), cons_induction⟩

--- a/src/data/fin/tuple/basic.lean
+++ b/src/data/fin/tuple/basic.lean
@@ -132,6 +132,14 @@ begin
   exact tail_cons _ _
 end
 
+lemma forall_fin_succ_pi {P : (Π i, α i) → Prop} :
+  (∀ x, P x) ↔ (∀ a v, P (fin.cons a v)) :=
+⟨λ h a v, h (fin.cons a v), cons_induction⟩
+
+lemma exists_fin_succ_pi {P : (Π i, α i) → Prop} :
+  (∃ x, P x) ↔ (∃ a v, P (fin.cons a v)) :=
+⟨λ ⟨x, h⟩, ⟨x 0, tail x, (cons_self_tail x).symm ▸ h⟩, λ ⟨a, v, h⟩, ⟨_, h⟩⟩
+
 /-- Updating the first element of a tuple does not change the tail. -/
 @[simp] lemma tail_update_zero : tail (update q 0 z) = tail q :=
 by { ext j, simp [tail, fin.succ_ne_zero] }


### PR DESCRIPTION
The lemma names `fin.forall_fin_succ_pi` and `fin.exists_fin_succ_pi` mirror the existing `fin.forall_fin_succ` and `fin.exists_fin_succ`.



---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
