### PR TITLE
[Merged by Bors] - feat(data/fin/basic): `induction_zero` and `induction_succ` lemmas

### DIFF
--- a/src/data/fin/basic.lean
+++ b/src/data/fin/basic.lean
@@ -1006,18 +1006,13 @@ begin
     exact IH (lt_of_succ_lt hi) }
 end
 
-@[simp] lemma induction_zero {n : ℕ}
-  {C : fin (n + 1) → Sort*}
-  (h0 : C 0)
+@[simp] lemma induction_zero {C : fin (n + 1) → Sort*} (h0 : C 0)
   (hs : ∀ i : fin n, C i.cast_succ → C i.succ) :
-  @fin.induction n C h0 hs 0 = h0 := rfl
+  (induction h0 hs : _) 0 = h0 := rfl
 
-@[simp] lemma induction_succ {n : ℕ}
-  {C : fin (n + 1) → Sort*}
-  (h0 : C 0)
+@[simp] lemma induction_succ {C : fin (n + 1) → Sort*} (h0 : C 0)
   (hs : ∀ i : fin n, C i.cast_succ → C i.succ) (i : fin n) :
-  @fin.induction n C h0 hs i.succ =
-    hs i (@fin.induction n C h0 hs i.cast_succ) := by cases i; refl
+  (induction h0 hs : _) i.succ = hs i (induction h0 hs i.cast_succ) := by cases i; refl
 
 /--
 Define `C i` by induction on `i : fin (n + 1)` via induction on the underlying `nat` value.

--- a/src/data/fin/basic.lean
+++ b/src/data/fin/basic.lean
@@ -1006,6 +1006,19 @@ begin
     exact IH (lt_of_succ_lt hi) }
 end
 
+@[simp] lemma induction_zero {n : ℕ}
+  {C : fin (n + 1) → Sort*}
+  (h0 : C 0)
+  (hs : ∀ i : fin n, C i.cast_succ → C i.succ) :
+  @fin.induction n C h0 hs 0 = h0 := rfl
+
+@[simp] lemma induction_succ {n : ℕ}
+  {C : fin (n + 1) → Sort*}
+  (h0 : C 0)
+  (hs : ∀ i : fin n, C i.cast_succ → C i.succ) (i : fin n) :
+  @fin.induction n C h0 hs i.succ =
+    hs i (@fin.induction n C h0 hs i.cast_succ) := by cases i; refl
+
 /--
 Define `C i` by induction on `i : fin (n + 1)` via induction on the underlying `nat` value.
 This function has two arguments: `h0` handles the base case on `C 0`,


### PR DESCRIPTION
This pull request introduces `fin.induction_zero` and `fin.induction_succ` simp lemmas for `fin.induction`, similar to `fin.cases_zero` and `fin.cases_succ` for `fin.cases`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
