### PR TITLE
[Merged by Bors] - feat(data/nat/basic): add `strong_sub_recursion` and `pincer_recursion`

### DIFF
--- a/src/data/nat/basic.lean
+++ b/src/data/nat/basic.lean
@@ -764,6 +764,24 @@ begin
 end
 using_well_founded { rel_tac := λ _ _, `[exact ⟨_, measure_wf (λ p, p.1 + p.2.1)⟩] }
 
+/-- Given `P : ℕ → ℕ → Sort*`, if for all `a b : ℕ` we can extend `P` from the rectangle
+strictly below `(a,b)` to `P a b`, then we have `P n m` for all `n m : ℕ` -/
+def strong_sub_induction {P : ℕ → ℕ → Sort*}
+  (H : ∀ a b, (∀ x y, x < a → y < b → P x y) → P a b) : Π (n m : ℕ), P n m
+| n m := H n m (λ x y hx hy, strong_sub_induction x y)
+
+/-- Given `P : ℕ → ℕ → Sort*`, if we have `P i 0` and `P 0 i` for all `i : ℕ`,
+and for any `x y : ℕ` we can extend `P` from `(x,y+1)` and `(x+1,y)` to `(x+1,y+1)`,
+then we have `P n m` for all `n m : ℕ` -/
+def pincer_induction {P : ℕ → ℕ → Sort*} (Ha0 : ∀ a : ℕ, P a 0) (H0b : ∀ b : ℕ, P 0 b)
+  (H : ∀ x y : ℕ, P x y.succ → P x.succ y → P x.succ y.succ) : Π (n m : ℕ), P n m :=
+begin
+  intros n m,
+  induction n with n IHn generalizing m, { apply H0b },
+  induction m with m IH generalizing n, { apply Ha0 },
+  exact H _ _ (IHn _) (IH _ IHn),
+end
+
 /-- Recursion starting at a non-zero number: given a map `C k → C (k+1)` for each `k ≥ n`,
 there is a map from `C n` to each `C m`, `n ≤ m`. -/
 @[elab_as_eliminator]

--- a/src/data/nat/basic.lean
+++ b/src/data/nat/basic.lean
@@ -766,6 +766,7 @@ using_well_founded { rel_tac := λ _ _, `[exact ⟨_, measure_wf (λ p, p.1 + p.
 
 /-- Given `P : ℕ → ℕ → Sort*`, if for all `a b : ℕ` we can extend `P` from the rectangle
 strictly below `(a,b)` to `P a b`, then we have `P n m` for all `n m : ℕ` -/
+@[elab_as_eliminator]
 def strong_sub_recursion {P : ℕ → ℕ → Sort*}
   (H : ∀ a b, (∀ x y, x < a → y < b → P x y) → P a b) : Π (n m : ℕ), P n m
 | n m := H n m (λ x y hx hy, strong_sub_induction x y)
@@ -773,6 +774,7 @@ def strong_sub_recursion {P : ℕ → ℕ → Sort*}
 /-- Given `P : ℕ → ℕ → Sort*`, if we have `P i 0` and `P 0 i` for all `i : ℕ`,
 and for any `x y : ℕ` we can extend `P` from `(x,y+1)` and `(x+1,y)` to `(x+1,y+1)`,
 then we have `P n m` for all `n m : ℕ` -/
+@[elab_as_eliminator]
 def pincer_recursion {P : ℕ → ℕ → Sort*} (Ha0 : ∀ a : ℕ, P a 0) (H0b : ∀ b : ℕ, P 0 b)
   (H : ∀ x y : ℕ, P x y.succ → P x.succ y → P x.succ y.succ) : Π (n m : ℕ), P n m :=
 begin

--- a/src/data/nat/basic.lean
+++ b/src/data/nat/basic.lean
@@ -764,22 +764,26 @@ begin
 end
 using_well_founded { rel_tac := λ _ _, `[exact ⟨_, measure_wf (λ p, p.1 + p.2.1)⟩] }
 
-/-- Given a predicate on two naturals `P : ℕ → ℕ → Prop`, if for all `a b : ℕ` we can extend `P`
-from the rectangle strictly below `(a,b)` to `P a b`, then we have `P n m` for all `n m : ℕ` -/
+/-- Given `P : ℕ → ℕ → Sort*`, if for all `a b : ℕ` we can extend `P` from the rectangle
+strictly below `(a,b)` to `P a b`, then we have `P n m` for all `n m : ℕ`.
+Note that for non-`Prop` output it is preferable to use the equation compiler directly if possible,
+since this produces equation lemmas. -/
 @[elab_as_eliminator]
-lemma strong_sub_induction {P : ℕ → ℕ → Prop}
+def strong_sub_recursion {P : ℕ → ℕ → Sort*}
   (H : ∀ a b, (∀ x y, x < a → y < b → P x y) → P a b) : Π (n m : ℕ), P n m
-| n m := H n m (λ x y hx hy, strong_sub_induction x y)
+| n m := H n m (λ x y hx hy, strong_sub_recursion x y)
 
-/-- Given a predicate on two naturals `P : ℕ → ℕ → Prop`, if we have `P i 0` and `P 0 i`
-for all `i : ℕ`, and for any `x y : ℕ` we can extend `P` from `(x,y+1)` and `(x+1,y)` to `(x+1,y+1)`
-then we have `P n m` for all `n m : ℕ` -/
+/-- Given `P : ℕ → ℕ → Sort*`, if we have `P i 0` and `P 0 i` for all `i : ℕ`,
+and for any `x y : ℕ` we can extend `P` from `(x,y+1)` and `(x+1,y)` to `(x+1,y+1)`
+then we have `P n m` for all `n m : ℕ`.
+Note that for non-`Prop` output it is preferable to use the equation compiler directly if possible,
+since this produces equation lemmas. -/
 @[elab_as_eliminator]
-lemma pincer_induction {P : ℕ → ℕ → Prop} (Ha0 : ∀ a : ℕ, P a 0) (H0b : ∀ b : ℕ, P 0 b)
+def pincer_recursion {P : ℕ → ℕ → Sort*} (Ha0 : ∀ a : ℕ, P a 0) (H0b : ∀ b : ℕ, P 0 b)
   (H : ∀ x y : ℕ, P x y.succ → P x.succ y → P x.succ y.succ) : ∀ (n m : ℕ), P n m
 | a 0 := Ha0 a
 | 0 b := H0b b
-| (nat.succ a) (nat.succ b) := H _ _ (pincer_induction _ _) (pincer_induction _ _)
+| (nat.succ a) (nat.succ b) := H _ _ (pincer_recursion _ _) (pincer_recursion _ _)
 
 /-- Recursion starting at a non-zero number: given a map `C k → C (k+1)` for each `k ≥ n`,
 there is a map from `C n` to each `C m`, `n ≤ m`. -/

--- a/src/data/nat/basic.lean
+++ b/src/data/nat/basic.lean
@@ -767,7 +767,7 @@ using_well_founded { rel_tac := λ _ _, `[exact ⟨_, measure_wf (λ p, p.1 + p.
 /-- Given a predicate on two naturals `P : ℕ → ℕ → Prop`, if for all `a b : ℕ` we can extend `P`
 from the rectangle strictly below `(a,b)` to `P a b`, then we have `P n m` for all `n m : ℕ` -/
 @[elab_as_eliminator]
-def strong_sub_induction {P : ℕ → ℕ → Prop}
+lemma strong_sub_induction {P : ℕ → ℕ → Prop}
   (H : ∀ a b, (∀ x y, x < a → y < b → P x y) → P a b) : Π (n m : ℕ), P n m
 | n m := H n m (λ x y hx hy, strong_sub_induction x y)
 
@@ -775,7 +775,7 @@ def strong_sub_induction {P : ℕ → ℕ → Prop}
 for all `i : ℕ`, and for any `x y : ℕ` we can extend `P` from `(x,y+1)` and `(x+1,y)` to `(x+1,y+1)`
 then we have `P n m` for all `n m : ℕ` -/
 @[elab_as_eliminator]
-def pincer_induction {P : ℕ → ℕ → Prop} (Ha0 : ∀ a : ℕ, P a 0) (H0b : ∀ b : ℕ, P 0 b)
+lemma pincer_induction {P : ℕ → ℕ → Prop} (Ha0 : ∀ a : ℕ, P a 0) (H0b : ∀ b : ℕ, P 0 b)
   (H : ∀ x y : ℕ, P x y.succ → P x.succ y → P x.succ y.succ) : ∀ (n m : ℕ), P n m
 | a 0 := Ha0 a
 | 0 b := H0b b

--- a/src/data/nat/basic.lean
+++ b/src/data/nat/basic.lean
@@ -766,14 +766,14 @@ using_well_founded { rel_tac := λ _ _, `[exact ⟨_, measure_wf (λ p, p.1 + p.
 
 /-- Given `P : ℕ → ℕ → Sort*`, if for all `a b : ℕ` we can extend `P` from the rectangle
 strictly below `(a,b)` to `P a b`, then we have `P n m` for all `n m : ℕ` -/
-def strong_sub_induction {P : ℕ → ℕ → Sort*}
+def strong_sub_recursion {P : ℕ → ℕ → Sort*}
   (H : ∀ a b, (∀ x y, x < a → y < b → P x y) → P a b) : Π (n m : ℕ), P n m
 | n m := H n m (λ x y hx hy, strong_sub_induction x y)
 
 /-- Given `P : ℕ → ℕ → Sort*`, if we have `P i 0` and `P 0 i` for all `i : ℕ`,
 and for any `x y : ℕ` we can extend `P` from `(x,y+1)` and `(x+1,y)` to `(x+1,y+1)`,
 then we have `P n m` for all `n m : ℕ` -/
-def pincer_induction {P : ℕ → ℕ → Sort*} (Ha0 : ∀ a : ℕ, P a 0) (H0b : ∀ b : ℕ, P 0 b)
+def pincer_recursion {P : ℕ → ℕ → Sort*} (Ha0 : ∀ a : ℕ, P a 0) (H0b : ∀ b : ℕ, P 0 b)
   (H : ∀ x y : ℕ, P x y.succ → P x.succ y → P x.succ y.succ) : Π (n m : ℕ), P n m :=
 begin
   intros n m,

--- a/src/data/nat/basic.lean
+++ b/src/data/nat/basic.lean
@@ -769,7 +769,7 @@ strictly below `(a,b)` to `P a b`, then we have `P n m` for all `n m : ℕ` -/
 @[elab_as_eliminator]
 def strong_sub_recursion {P : ℕ → ℕ → Sort*}
   (H : ∀ a b, (∀ x y, x < a → y < b → P x y) → P a b) : Π (n m : ℕ), P n m
-| n m := H n m (λ x y hx hy, strong_sub_induction x y)
+| n m := H n m (λ x y hx hy, strong_sub_recursion x y)
 
 /-- Given `P : ℕ → ℕ → Sort*`, if we have `P i 0` and `P 0 i` for all `i : ℕ`,
 and for any `x y : ℕ` we can extend `P` from `(x,y+1)` and `(x+1,y)` to `(x+1,y+1)`,
@@ -778,7 +778,6 @@ then we have `P n m` for all `n m : ℕ` -/
 def pincer_recursion {P : ℕ → ℕ → Sort*} (Ha0 : ∀ a : ℕ, P a 0) (H0b : ∀ b : ℕ, P 0 b)
   (H : ∀ x y : ℕ, P x y.succ → P x.succ y → P x.succ y.succ) (n m : ℕ) : P n m :=
 begin
-  intros n m,
   induction n with n IHn generalizing m, { apply H0b },
   induction m with m IH generalizing n, { apply Ha0 },
   exact H _ _ (IHn _) (IH _ IHn),

--- a/src/data/nat/basic.lean
+++ b/src/data/nat/basic.lean
@@ -776,12 +776,10 @@ and for any `x y : ℕ` we can extend `P` from `(x,y+1)` and `(x+1,y)` to `(x+1,
 then we have `P n m` for all `n m : ℕ` -/
 @[elab_as_eliminator]
 def pincer_recursion {P : ℕ → ℕ → Sort*} (Ha0 : ∀ a : ℕ, P a 0) (H0b : ∀ b : ℕ, P 0 b)
-  (H : ∀ x y : ℕ, P x y.succ → P x.succ y → P x.succ y.succ) (n m : ℕ) : P n m :=
-begin
-  induction n with n IHn generalizing m, { apply H0b },
-  induction m with m IH generalizing n, { apply Ha0 },
-  exact H _ _ (IHn _) (IH _ IHn),
-end
+  (H : ∀ x y : ℕ, P x y.succ → P x.succ y → P x.succ y.succ) : ∀ (n m : ℕ), P n m
+| a 0 := Ha0 a
+| 0 b := H0b b
+| (nat.succ a) (nat.succ b) := H _ _ (pincer_recursion _ _) (pincer_recursion _ _)
 
 /-- Recursion starting at a non-zero number: given a map `C k → C (k+1)` for each `k ≥ n`,
 there is a map from `C n` to each `C m`, `n ≤ m`. -/

--- a/src/data/nat/basic.lean
+++ b/src/data/nat/basic.lean
@@ -764,22 +764,22 @@ begin
 end
 using_well_founded { rel_tac := λ _ _, `[exact ⟨_, measure_wf (λ p, p.1 + p.2.1)⟩] }
 
-/-- Given `P : ℕ → ℕ → Sort*`, if for all `a b : ℕ` we can extend `P` from the rectangle
-strictly below `(a,b)` to `P a b`, then we have `P n m` for all `n m : ℕ` -/
+/-- Given a predicate on two naturals `P : ℕ → ℕ → Prop`, if for all `a b : ℕ` we can extend `P`
+from the rectangle strictly below `(a,b)` to `P a b`, then we have `P n m` for all `n m : ℕ` -/
 @[elab_as_eliminator]
-def strong_sub_recursion {P : ℕ → ℕ → Sort*}
+def strong_sub_induction {P : ℕ → ℕ → Prop}
   (H : ∀ a b, (∀ x y, x < a → y < b → P x y) → P a b) : Π (n m : ℕ), P n m
-| n m := H n m (λ x y hx hy, strong_sub_recursion x y)
+| n m := H n m (λ x y hx hy, strong_sub_induction x y)
 
-/-- Given `P : ℕ → ℕ → Sort*`, if we have `P i 0` and `P 0 i` for all `i : ℕ`,
-and for any `x y : ℕ` we can extend `P` from `(x,y+1)` and `(x+1,y)` to `(x+1,y+1)`,
+/-- Given a predicate on two naturals `P : ℕ → ℕ → Prop`, if we have `P i 0` and `P 0 i`
+for all `i : ℕ`, and for any `x y : ℕ` we can extend `P` from `(x,y+1)` and `(x+1,y)` to `(x+1,y+1)`
 then we have `P n m` for all `n m : ℕ` -/
 @[elab_as_eliminator]
-def pincer_recursion {P : ℕ → ℕ → Sort*} (Ha0 : ∀ a : ℕ, P a 0) (H0b : ∀ b : ℕ, P 0 b)
+def pincer_induction {P : ℕ → ℕ → Prop} (Ha0 : ∀ a : ℕ, P a 0) (H0b : ∀ b : ℕ, P 0 b)
   (H : ∀ x y : ℕ, P x y.succ → P x.succ y → P x.succ y.succ) : ∀ (n m : ℕ), P n m
 | a 0 := Ha0 a
 | 0 b := H0b b
-| (nat.succ a) (nat.succ b) := H _ _ (pincer_recursion _ _) (pincer_recursion _ _)
+| (nat.succ a) (nat.succ b) := H _ _ (pincer_induction _ _) (pincer_induction _ _)
 
 /-- Recursion starting at a non-zero number: given a map `C k → C (k+1)` for each `k ≥ n`,
 there is a map from `C n` to each `C m`, `n ≤ m`. -/

--- a/src/data/nat/basic.lean
+++ b/src/data/nat/basic.lean
@@ -776,7 +776,7 @@ and for any `x y : ℕ` we can extend `P` from `(x,y+1)` and `(x+1,y)` to `(x+1,
 then we have `P n m` for all `n m : ℕ` -/
 @[elab_as_eliminator]
 def pincer_recursion {P : ℕ → ℕ → Sort*} (Ha0 : ∀ a : ℕ, P a 0) (H0b : ∀ b : ℕ, P 0 b)
-  (H : ∀ x y : ℕ, P x y.succ → P x.succ y → P x.succ y.succ) : Π (n m : ℕ), P n m :=
+  (H : ∀ x y : ℕ, P x y.succ → P x.succ y → P x.succ y.succ) (n m : ℕ) : P n m :=
 begin
   intros n m,
   induction n with n IHn generalizing m, { apply H0b },


### PR DESCRIPTION
Adding two recursion principles for `P : ℕ → ℕ → Sort*`

`strong_sub_recursion`: if for all `a b : ℕ` we can extend `P` from the rectangle strictly below `(a,b)` to `P a b`, then we have `P n m` for all `n m : ℕ`.

`pincer_recursion`: if we have `P i 0` and `P 0 i` for all `i : ℕ`, and for any `x y : ℕ` we can extend `P` from `(x,y+1)` and `(x+1,y)` to `(x+1,y+1)` then we have `P n m` for all `n m : ℕ`.


`strong_sub_recursion` is adapted by @vihdzp from @CBirkbeck 's #14828

Co-authored-by: Chris Birkbeck <cd.birkbeck@gmail.com>
Co-authored-by: Violeta Hernández <vi.hdz.p@gmail.com>
Co-authored-by: Eric Wieser <wieser.eric@gmail.com>

---

Very open to suggestions for better names and/or docstrings!

Discussed in [this Zulip thread](https://leanprover.zulipchat.com/#narrow/stream/217875-Is-there-code-for-X.3F/topic/Two.20induction.20principles/near/287911531)

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
