### PR TITLE
[Merged by Bors] - feat(measure_theory/pmf): lawful monad instance for probability mass function monad

### DIFF
--- a/src/measure_theory/probability_mass_function/basic.lean
+++ b/src/measure_theory/probability_mass_function/basic.lean
@@ -26,7 +26,7 @@ so we can further extend this to a `measure` on `α`, see `pmf.to_measure`.
 probability mass function, discrete probability measure
 -/
 noncomputable theory
-variables {α : Type*} {β : Type*} {γ : Type*}
+variables {α β γ : Type*}
 open_locale classical big_operators nnreal ennreal
 
 /-- A probability mass function, or discrete probability measures is a function `α → ℝ≥0` such that

--- a/src/measure_theory/probability_mass_function/basic.lean
+++ b/src/measure_theory/probability_mass_function/basic.lean
@@ -26,7 +26,7 @@ so we can further extend this to a `measure` on `α`, see `pmf.to_measure`.
 probability mass function, discrete probability measure
 -/
 noncomputable theory
-variables {α β γ : Type*}
+variables {α : Type*} {β : Type*} {γ : Type*}
 open_locale classical big_operators nnreal ennreal
 
 /-- A probability mass function, or discrete probability measures is a function `α → ℝ≥0` such that

--- a/src/measure_theory/probability_mass_function/constructions.lean
+++ b/src/measure_theory/probability_mass_function/constructions.lean
@@ -25,77 +25,13 @@ and `filter` uses this to filter the support of a `pmf` and re-normalize the new
 
 -/
 
-namespace pmf
+universes u v
 
 noncomputable theory
-variables {α : Type*} {β : Type*} {γ : Type*}
+variables {α β γ : Type u}
 open_locale classical big_operators nnreal ennreal
 
-section map
-
-/-- The functorial action of a function on a `pmf`. -/
-def map (f : α → β) (p : pmf α) : pmf β := bind p (pure ∘ f)
-
-variables (f : α → β) (p : pmf α) (b : β)
-
-@[simp] lemma map_apply : (map f p) b = ∑' a, if b = f a then p a else 0 := by simp [map]
-
-@[simp] lemma support_map : (map f p).support = f '' p.support :=
-set.ext (λ b, by simp [map, @eq_comm β b])
-
-lemma mem_support_map_iff : b ∈ (map f p).support ↔ ∃ a ∈ p.support, f a = b := by simp
-
-lemma bind_pure_comp : bind p (pure ∘ f) = map f p := rfl
-
-lemma map_id : map id p = p := by simp [map]
-
-lemma map_comp (g : β → γ) : (p.map f).map g = p.map (g ∘ f) :=
-by simp [map]
-
-lemma pure_map (a : α) : (pure a).map f = pure (f a) :=
-by simp [map]
-
-section measure
-
-variable (s : set β)
-
-@[simp] lemma to_outer_measure_map_apply :
-  (p.map f).to_outer_measure s = p.to_outer_measure (f ⁻¹' s) :=
-by simp [map, set.indicator, to_outer_measure_apply p (f ⁻¹' s)]
-
-@[simp] lemma to_measure_map_apply [measurable_space α] [measurable_space β] (hf : measurable f)
-  (hs : measurable_set s) : (p.map f).to_measure s = p.to_measure (f ⁻¹' s) :=
-begin
-  rw [to_measure_apply_eq_to_outer_measure_apply _ s hs,
-    to_measure_apply_eq_to_outer_measure_apply _ (f ⁻¹' s) (measurable_set_preimage hf hs)],
-  exact to_outer_measure_map_apply f p s,
-end
-
-end measure
-
-end map
-
-section seq
-
-/-- The monadic sequencing operation for `pmf`. -/
-def seq (q : pmf (α → β)) (p : pmf α) : pmf β := q.bind (λ m, p.bind $ λ a, pure (m a))
-
-variables (q : pmf (α → β)) (p : pmf α) (b : β)
-
-@[simp] lemma seq_apply : (seq q p) b = ∑' (f : α → β) (a : α), if b = f a then q f * p a else 0 :=
-begin
-  simp only [seq, mul_boole, bind_apply, pure_apply],
-  refine tsum_congr (λ f, (nnreal.tsum_mul_left (q f) _).symm.trans (tsum_congr (λ a, _))),
-  simpa only [mul_zero] using mul_ite (b = f a) (q f) (p a) 0
-end
-
-@[simp] lemma support_seq : (seq q p).support = ⋃ f ∈ q.support, f '' p.support :=
-set.ext (λ b, by simp [-mem_support_iff, seq, @eq_comm β b])
-
-lemma mem_support_seq_iff : b ∈ (seq q p).support ↔ ∃ (f ∈ q.support), b ∈ f '' p.support :=
-by simp
-
-end seq
+namespace pmf
 
 section of_finset
 

--- a/src/measure_theory/probability_mass_function/constructions.lean
+++ b/src/measure_theory/probability_mass_function/constructions.lean
@@ -108,9 +108,9 @@ instance : is_lawful_functor pmf :=
 
 instance : is_lawful_monad pmf :=
 { bind_pure_comp_eq_map := λ α β f x, rfl,
+  bind_map_eq_seq := λ α β f x, rfl,
   pure_bind := λ α β, pure_bind,
-  bind_assoc := λ α β γ, bind_bind,
-  bind_map_eq_seq := λ α β f x, rfl }
+  bind_assoc := λ α β γ, bind_bind }
 
 section of_finset
 

--- a/src/measure_theory/probability_mass_function/constructions.lean
+++ b/src/measure_theory/probability_mass_function/constructions.lean
@@ -25,11 +25,11 @@ and `filter` uses this to filter the support of a `pmf` and re-normalize the new
 
 -/
 
+namespace pmf
+
 noncomputable theory
 variables {α : Type*} {β : Type*} {γ : Type*}
 open_locale classical big_operators nnreal ennreal
-
-namespace pmf
 
 section map
 

--- a/src/measure_theory/probability_mass_function/constructions.lean
+++ b/src/measure_theory/probability_mass_function/constructions.lean
@@ -101,6 +101,17 @@ by simp
 
 end seq
 
+instance : is_lawful_functor pmf :=
+{ map_const_eq := λ α β, rfl,
+  id_map := λ α, bind_pure,
+  comp_map := λ α β γ g h x, (map_comp _ _ _).symm }
+
+instance : is_lawful_monad pmf :=
+{ bind_pure_comp_eq_map := λ α β f x, rfl,
+  bind_map_eq_seq := λ α β f x, rfl,
+  pure_bind := λ α β x f, pure_bind f x,
+  bind_assoc := λ α β γ, bind_bind }
+
 section of_finset
 
 /-- Given a finset `s` and a function `f : α → ℝ≥0` with sum `1` on `s`,

--- a/src/measure_theory/probability_mass_function/constructions.lean
+++ b/src/measure_theory/probability_mass_function/constructions.lean
@@ -25,13 +25,81 @@ and `filter` uses this to filter the support of a `pmf` and re-normalize the new
 
 -/
 
-universes u v
-
 noncomputable theory
-variables {α β γ : Type u}
+variables {α : Type*} {β : Type*} {γ : Type*}
 open_locale classical big_operators nnreal ennreal
 
 namespace pmf
+
+section map
+
+/-- The functorial action of a function on a `pmf`. -/
+def map (f : α → β) (p : pmf α) : pmf β := bind p (pure ∘ f)
+
+variables (f : α → β) (p : pmf α) (b : β)
+
+lemma monad_map_eq_map {α β : Type*} (f : α → β) (p : pmf α) : f <$> p = p.map f := rfl
+
+@[simp] lemma map_apply : (map f p) b = ∑' a, if b = f a then p a else 0 := by simp [map]
+
+@[simp] lemma support_map : (map f p).support = f '' p.support :=
+set.ext (λ b, by simp [map, @eq_comm β b])
+
+lemma mem_support_map_iff : b ∈ (map f p).support ↔ ∃ a ∈ p.support, f a = b := by simp
+
+lemma bind_pure_comp : bind p (pure ∘ f) = map f p := rfl
+
+lemma map_id : map id p = p := by simp [map]
+
+lemma map_comp (g : β → γ) : (p.map f).map g = p.map (g ∘ f) :=
+by simp [map]
+
+lemma pure_map (a : α) : (pure a).map f = pure (f a) :=
+by simp [map]
+
+section measure
+
+variable (s : set β)
+
+@[simp] lemma to_outer_measure_map_apply :
+  (p.map f).to_outer_measure s = p.to_outer_measure (f ⁻¹' s) :=
+by simp [map, set.indicator, to_outer_measure_apply p (f ⁻¹' s)]
+
+@[simp] lemma to_measure_map_apply [measurable_space α] [measurable_space β] (hf : measurable f)
+  (hs : measurable_set s) : (p.map f).to_measure s = p.to_measure (f ⁻¹' s) :=
+begin
+  rw [to_measure_apply_eq_to_outer_measure_apply _ s hs,
+    to_measure_apply_eq_to_outer_measure_apply _ (f ⁻¹' s) (measurable_set_preimage hf hs)],
+  exact to_outer_measure_map_apply f p s,
+end
+
+end measure
+
+end map
+
+section seq
+
+/-- The monadic sequencing operation for `pmf`. -/
+def seq (q : pmf (α → β)) (p : pmf α) : pmf β := q.bind (λ m, p.bind $ λ a, pure (m a))
+
+variables (q : pmf (α → β)) (p : pmf α) (b : β)
+
+lemma monad_seq_eq_seq {α β : Type*} (q : pmf (α → β)) (p : pmf α) : q <*> p = q.seq p := rfl
+
+@[simp] lemma seq_apply : (seq q p) b = ∑' (f : α → β) (a : α), if b = f a then q f * p a else 0 :=
+begin
+  simp only [seq, mul_boole, bind_apply, pure_apply],
+  refine tsum_congr (λ f, (nnreal.tsum_mul_left (q f) _).symm.trans (tsum_congr (λ a, _))),
+  simpa only [mul_zero] using mul_ite (b = f a) (q f) (p a) 0
+end
+
+@[simp] lemma support_seq : (seq q p).support = ⋃ f ∈ q.support, f '' p.support :=
+set.ext (λ b, by simp [-mem_support_iff, seq, @eq_comm β b])
+
+lemma mem_support_seq_iff : b ∈ (seq q p).support ↔ ∃ (f ∈ q.support), b ∈ f '' p.support :=
+by simp
+
+end seq
 
 section of_finset
 

--- a/src/measure_theory/probability_mass_function/constructions.lean
+++ b/src/measure_theory/probability_mass_function/constructions.lean
@@ -108,9 +108,9 @@ instance : is_lawful_functor pmf :=
 
 instance : is_lawful_monad pmf :=
 { bind_pure_comp_eq_map := λ α β f x, rfl,
-  bind_map_eq_seq := λ α β f x, rfl,
   pure_bind := λ α β, pure_bind,
-  bind_assoc := λ α β γ, bind_bind }
+  bind_assoc := λ α β γ, bind_bind,
+  bind_map_eq_seq := λ α β f x, rfl }
 
 section of_finset
 

--- a/src/measure_theory/probability_mass_function/constructions.lean
+++ b/src/measure_theory/probability_mass_function/constructions.lean
@@ -28,7 +28,7 @@ and `filter` uses this to filter the support of a `pmf` and re-normalize the new
 namespace pmf
 
 noncomputable theory
-variables {α : Type*} {β : Type*} {γ : Type*}
+variables {α β γ : Type*}
 open_locale classical big_operators nnreal ennreal
 
 section map

--- a/src/measure_theory/probability_mass_function/monad.lean
+++ b/src/measure_theory/probability_mass_function/monad.lean
@@ -21,7 +21,7 @@ so that the second argument only needs to be defined on the support of the first
 universes u v
 
 noncomputable theory
-variables {α β γ : Type u}
+variables {α : Type*} {β : Type*} {γ : Type*}
 open_locale classical big_operators nnreal ennreal
 
 namespace pmf
@@ -177,56 +177,6 @@ instance : is_lawful_monad pmf :=
   bind_map_eq_seq := λ α β f x, rfl,
   pure_bind := λ α β f x, pmf.pure_bind x f,
   bind_assoc := λ α β γ x f g, pmf.bind_bind x f g }
-
-section map
-
-variables (f : α → β) (p : pmf α) (b : β)
-
-@[simp] lemma map_apply : (f <$> p) b = ∑' a, if b = f a then p a else 0 := by simp [functor.map]
-
-@[simp] lemma support_map : (f <$> p).support = f '' p.support :=
-set.ext (λ b, by simp [functor.map, @eq_comm β b])
-
-lemma mem_support_map_iff : b ∈ (f <$> p).support ↔ ∃ a ∈ p.support, f a = b := by simp
-
-section measure
-
-variable (s : set β)
-
-@[simp] lemma to_outer_measure_map_apply :
-  (f <$> p).to_outer_measure s = p.to_outer_measure (f ⁻¹' s) :=
-by simp [functor.map, set.indicator, to_outer_measure_apply p (f ⁻¹' s)]
-
-@[simp] lemma to_measure_map_apply [measurable_space α] [measurable_space β] (hf : measurable f)
-  (hs : measurable_set s) : (f <$> p).to_measure s = p.to_measure (f ⁻¹' s) :=
-begin
-  rw [to_measure_apply_eq_to_outer_measure_apply _ s hs,
-    to_measure_apply_eq_to_outer_measure_apply _ (f ⁻¹' s) (measurable_set_preimage hf hs)],
-  exact to_outer_measure_map_apply f p s,
-end
-
-end measure
-
-end map
-
-section seq
-
-variables (q : pmf (α → β)) (p : pmf α) (b : β)
-
-@[simp] lemma seq_apply : (q <*> p) b = ∑' (f : α → β) (a : α), if b = f a then q f * p a else 0 :=
-begin
-  simp only [has_seq.seq, mul_boole, bind_apply, pure_apply],
-  refine tsum_congr (λ f, (nnreal.tsum_mul_left (q f) _).symm.trans (tsum_congr (λ a, _))),
-  simpa only [mul_zero] using mul_ite (b = f a) (q f) (p a) 0
-end
-
-@[simp] lemma support_seq : (q <*> p).support = ⋃ f ∈ q.support, f '' p.support :=
-set.ext (λ b, by simp [-mem_support_iff, has_seq.seq, @eq_comm β b])
-
-lemma mem_support_seq_iff : b ∈ (q <*> p).support ↔ ∃ (f ∈ q.support), b ∈ f '' p.support :=
-by simp only [support_seq, set.mem_Union]
-
-end seq
 
 section bind_on_support
 

--- a/src/measure_theory/probability_mass_function/monad.lean
+++ b/src/measure_theory/probability_mass_function/monad.lean
@@ -97,7 +97,7 @@ by simp
 lemma coe_bind_apply (b : β) : (p.bind f b : ℝ≥0∞) = ∑'a, p a * f a b :=
 eq.trans (ennreal.coe_tsum $ bind.summable p f b) $ by simp
 
-@[simp] lemma pure_bind (a : α) : (pure a).bind f = f a :=
+@[simp] lemma pure_bind (a : α) (f : α → pmf β) : (pure a).bind f = f a :=
 have ∀ b a', ite (a' = a) 1 0 * f a' b = ite (a' = a) (f a b) 0, from
   assume b a', by split_ifs; simp; subst h; simp,
 by ext b; simp [this]
@@ -173,8 +173,8 @@ instance : is_lawful_functor pmf :=
 instance : is_lawful_monad pmf :=
 { bind_pure_comp_eq_map := λ α β f x, rfl,
   bind_map_eq_seq := λ α β f x, rfl,
-  pure_bind := λ α β f x, pmf.pure_bind x f,
-  bind_assoc := λ α β γ x f g, pmf.bind_bind x f g }
+  pure_bind := λ α β, pmf.pure_bind,
+  bind_assoc := λ α β γ, pmf.bind_bind }
 
 section bind_on_support
 

--- a/src/measure_theory/probability_mass_function/monad.lean
+++ b/src/measure_theory/probability_mass_function/monad.lean
@@ -18,10 +18,8 @@ so that the second argument only needs to be defined on the support of the first
 
 -/
 
-universes u v
-
 noncomputable theory
-variables {α : Type*} {β : Type*} {γ : Type*}
+variables {α β γ : Type*}
 open_locale classical big_operators nnreal ennreal
 
 namespace pmf

--- a/src/measure_theory/probability_mass_function/monad.lean
+++ b/src/measure_theory/probability_mass_function/monad.lean
@@ -165,16 +165,16 @@ instance : monad pmf :=
 { pure := λ A a, pure a,
   bind := λ A B pa pb, pa.bind pb }
 
-instance : is_lawful_functor pmf :=
-{ map_const_eq := λ α β, rfl,
-  id_map := λ α x, pmf.bind_pure x,
-  comp_map := λ α β γ g h x, by simp only [functor.map, bind_bind, pure_bind] }
+-- instance : is_lawful_functor pmf :=
+-- { map_const_eq := λ α β, rfl,
+--   id_map := λ α x, pmf.bind_pure x,
+--   comp_map := λ α β γ g h x, by simp only [functor.map, bind_bind, pure_bind] }
 
-instance : is_lawful_monad pmf :=
-{ bind_pure_comp_eq_map := λ α β f x, rfl,
-  bind_map_eq_seq := λ α β f x, rfl,
-  pure_bind := λ α β f x, pmf.pure_bind x f,
-  bind_assoc := λ α β γ x f g, pmf.bind_bind x f g }
+-- instance : is_lawful_monad pmf :=
+-- { bind_pure_comp_eq_map := λ α β f x, rfl,
+--   bind_map_eq_seq := λ α β f x, rfl,
+--   pure_bind := λ α β f x, pmf.pure_bind x f,
+--   bind_assoc := λ α β γ x f g, pmf.bind_bind x f g }
 
 section bind_on_support
 


### PR DESCRIPTION
Provide `is_lawful_functor` and `is_lawful_monad` instances for `pmf`. Also switch the `seq` and `map` operations to the ones coming from the `monad` instance.

---
~~This required changing some universe levels to match the way they are in the monad api. I don't think the more general case is generally useful, so I don't think this should be a problem.~~

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
