### PR TITLE
feat(model_theory/algebraic): add algebraic languages of monoids, groups, rings, and theory of comm rings and fields

### DIFF
--- a/src/model_theory/algebraic.lean
+++ b/src/model_theory/algebraic.lean
@@ -76,6 +76,8 @@ instance : has_pow (language.ring.term α) ℕ := ⟨ λ t n, npow_rec n t ⟩
 @[simp] lemma pow_zero (t : language.ring.term α) : t ^ 0 = 1 := rfl
 @[simp] lemma pow_succ {n} (t : language.ring.term α) : t ^ (n + 1) = t * t ^ n := rfl
 
+end language.ring
+
 /-- Any type with instances of `has_one` and `has_mul` is a
   structure in the language of monoids. -/
 def monoid.Structure_of_has_one_has_mul {α : Type*} [has_one α] [has_mul α] :
@@ -142,6 +144,10 @@ protected def field_inv : L.sentence :=
 
 end functions
 
+section ring_theories
+
+open language.ring
+
 /-- The theory of commutative rings. -/
 def Theory.comm_ring : Theory language.ring :=
 { functions.assoc add,
@@ -159,6 +165,7 @@ Theory.comm_ring ∪ {
   functions.field_inv zero one mul,
   sentence.card_ge _ 1 }
 
-end language.ring
+end ring_theories
+
 end language
 end first_order

--- a/src/model_theory/algebraic.lean
+++ b/src/model_theory/algebraic.lean
@@ -1,0 +1,164 @@
+/-
+Copyright (c) 2022 Joseph Hua. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Joseph Hua
+-/
+import model_theory.syntax
+
+/-!
+# The language of rings
+## Main Definitions
+* `first_order.language.monoid` defines the language of monoids,
+  which consists of 1`, `*`.
+* `first_order.language.group` defines the language of groups,
+  which consists of `0`, `-`, `+`.
+* `first_order.language.ring` defines the language of rings,
+  which consists of `0`, `1`, `-`, `+`, `*`,
+  as the sum of the languages of monoids and groups.
+* `first_order.language.Theory.comm_ring` defines the theory of commutative rings.
+* `first_order.language.Theory.field` defines the theory of fields.
+-/
+universes u
+
+namespace first_order
+namespace language
+open_locale first_order
+open Structure
+
+/-- The language of monoids -/
+protected def monoid : language :=
+language.mk₂ unit empty unit empty empty
+
+/-- The language of groups -/
+protected def group : language :=
+language.mk₂ unit unit unit empty empty
+
+/-- The language of rings -/
+protected def ring : language :=
+language.sum language.group language.monoid
+
+variable {α : Type u}
+
+namespace language.ring
+
+/-- The function symbol representing zero. -/
+def zero : language.ring.constants := sum.inl ⟨⟩
+
+/-- The function symbol representing one. -/
+def one : language.ring.constants := sum.inr ⟨⟩
+
+/-- The function symbol representing negation. -/
+def neg : language.ring.functions 1 := sum.inl ⟨⟩
+
+/-- The function symbol representing addition. -/
+def add : language.ring.functions 2 := sum.inl ⟨⟩
+
+/-- The function symbol representing multiplication. -/
+def mul : language.ring.functions 2 := sum.inr ⟨⟩
+
+@[simp] instance : has_zero (language.ring.term α) := ⟨ constants.term (sum.inl ⟨⟩) ⟩
+
+@[simp] instance : has_one (language.ring.term α) := ⟨ constants.term (sum.inr ⟨⟩) ⟩
+
+@[simp] instance : has_neg (language.ring.term α) :=
+  ⟨ λ x, func language.ring.neg ![x] ⟩
+
+@[simp] instance : has_add (language.ring.term α) :=
+⟨ λ x y, func language.ring.add ![x, y] ⟩
+
+@[simp] instance : has_mul (language.ring.term α) :=
+⟨ λ x y, func language.ring.mul ![x, y] ⟩
+
+@[simp] instance : has_sub (language.ring.term α) := ⟨ λ x y, x + - y ⟩
+
+instance : has_pow (language.ring.term α) ℕ := ⟨ λ t n, npow_rec n t ⟩
+
+@[simp] lemma pow_zero (t : language.ring.term α) : t ^ 0 = 1 := rfl
+@[simp] lemma pow_succ {n} (t : language.ring.term α) : t ^ (n + 1) = t * t ^ n := rfl
+
+/-- Any type with instances of `has_one` and `has_mul` is a
+  structure in the language of monoids. -/
+def monoid.Structure_of_has_one_has_mul {α : Type*} [has_one α] [has_mul α] :
+  language.monoid.Structure α :=
+Structure.mk₂ (λ _, 1) empty.elim (λ _, has_mul.mul) empty.elim empty.elim
+
+/-- Any type with instances of `has_one`, `has_inv` and `has_mul` is a
+  structure in the language of groups. -/
+def group_Structure_of_has_zero_has_neg_has_add {α : Type} [has_zero α] [has_neg α] [has_add α] :
+  language.group.Structure α :=
+Structure.mk₂ (λ _, 0) (λ _, has_neg.neg) (λ _, has_add.add) empty.elim empty.elim
+
+/- Any monoid is a structure in the language of monoids. -/
+def _root_.monoid.Structure (M : Type) [monoid M] : language.monoid.Structure M :=
+monoid.Structure_of_has_one_has_mul
+
+/- Any group is a structure in the language of groups. -/
+def _root_.add_comm_group.Structure (G : Type) [add_comm_group G] : language.group.Structure G :=
+group_Structure_of_has_zero_has_neg_has_add
+
+/- Any ring is a structure in the language of ring. -/
+def _root_.ring.Structure (R : Type*) [ring R] : language.ring.Structure R :=
+@language.sum_Structure _ _ _ (add_comm_group.Structure R) (monoid.Structure R)
+
+namespace functions
+
+variables {L : language} (c₀ c₁ : L.constants) (i : L.functions 1) (a : L.functions 2)
+  (m : L.functions 2)
+
+/-- The sentence indicating that a binary function symbol is commutative. -/
+protected def comm : L.sentence := ∀' ∀' (m.apply₂ &0 &1 =' m.apply₂ &1 &0)
+
+/-- The sentence indicating that a binary function symbol is associative. -/
+protected def assoc : L.sentence :=
+∀' ∀' ∀' (m.apply₂ (m.apply₂ &0 &1) &2 =' m.apply₂ &0 (m.apply₂ &1 &2))
+
+/-- The sentence indicating that applying a constant symbol on the right of
+  a binary symbol is the identity. -/
+protected def mul_id : L.sentence :=
+∀' (m.apply₂ &0 c₁.term =' &0)
+
+/-- The sentence indicating that applying a constant symbol on the right of
+  a binary symbol is the identity. -/
+protected def id_mul : L.sentence :=
+∀' (m.apply₂ c₁.term &0 =' &0)
+
+/-- The sentence indicating that left composing a unary symbol with a binary symbol
+  is equal to a constant symbol. -/
+protected def inv_mul : L.sentence :=
+∀' (m.apply₂ (i.apply₁ &0) &0 =' c₁.term)
+
+/-- The sentence indicating that left composing a unary symbol with a binary symbol
+  is equal to a constant symbol. -/
+protected def mul_inv : L.sentence :=
+∀' (m.apply₂ &0 (i.apply₁ &0) =' c₁.term)
+
+/-- The sentence indicating that a binary function symbol distributes over another -/
+protected def add_mul : L.sentence :=
+∀' ∀' ∀' (m.apply₂ (a.apply₂ &0 &1) &2 =' a.apply₂ (m.apply₂ &0 &2) (m.apply₂ &1 &2))
+
+/-- The sentence indicating that multiplication has an inverse away from a constant zero -/
+protected def field_inv : L.sentence :=
+∀' (&0 =' c₀.term ⊔ ∃' (m.apply₂ &1 &0 =' c₁.term))
+
+end functions
+
+/-- The theory of commutative rings. -/
+def Theory.comm_ring : Theory language.ring :=
+{ functions.assoc add,
+  functions.mul_id zero add,
+  functions.comm add,
+  functions.inv_mul zero neg add,
+  functions.assoc mul,
+  functions.mul_id one mul,
+  functions.comm mul,
+  functions.add_mul add mul }
+
+/-- The theory of fields. -/
+def Theory.field : Theory language.ring :=
+Theory.comm_ring ∪ {
+  functions.field_inv zero one mul,
+  sentence.card_ge _ 1 }
+
+end language.ring
+end language
+end first_order

--- a/src/model_theory/algebraic.lean
+++ b/src/model_theory/algebraic.lean
@@ -203,47 +203,47 @@ end term_pow
 
 /-- Any type with instances of `has_one` and `has_mul` is a
   structure in the language of monoids. -/
-def monoid.Structure_of_has_one_has_mul {α : Type*} [has_one α] [has_mul α] :
+def monoid.Structure_of_has_one_has_mul [has_one α] [has_mul α] :
   language.monoid.Structure α :=
 Structure.mk₂ (λ _, 1) empty.elim (λ _, has_mul.mul) empty.elim empty.elim
 
 /-- Any type with instances of `has_zero` and `has_add` is a
   structure in the language of additive monoids. -/
-def add_monoid.Structure_of_has_zero_has_add {α : Type*} [has_zero α] [has_add α] :
+def add_monoid.Structure_of_has_zero_has_add [has_zero α] [has_add α] :
   language.monoid.Structure α :=
 Structure.mk₂ (λ _, 0) empty.elim (λ _, has_add.add) empty.elim empty.elim
 
 /-- Any type with instances of `has_one`, `has_inv` and `has_mul` is a
   structure in the language of groups. -/
-def group.Structure_of_has_one_has_inv_has_mul {α : Type} [has_one α] [has_inv α] [has_mul α] :
+def group.Structure_of_has_one_has_inv_has_mul [has_one α] [has_inv α] [has_mul α] :
   language.group.Structure α :=
 Structure.mk₂ (λ _, 1) (λ _, has_inv.inv) (λ _, has_mul.mul) empty.elim empty.elim
 
 /-- Any type with instances of `has_zero`, `has_neg` and `has_add` is a
   structure in the language of additive groups. -/
-def add_group.Structure_of_has_zero_has_neg_has_add {α : Type} [has_zero α] [has_neg α] [has_add α] :
+def add_group.Structure_of_has_zero_has_neg_has_add [has_zero α] [has_neg α] [has_add α] :
   language.group.Structure α :=
 Structure.mk₂ (λ _, 0) (λ _, has_neg.neg) (λ _, has_add.add) empty.elim empty.elim
 
 /-- Any monoid is a structure in the language of monoids. -/
-def _root_.monoid.Structure (M : Type) [monoid M] : language.monoid.Structure M :=
+def _root_.monoid.Structure [monoid α] : language.monoid.Structure α :=
 monoid.Structure_of_has_one_has_mul
 
 /-- Any additive monoid is a structure in the language of additive monoids. -/
-def _root_.add_monoid.Structure (M : Type) [add_monoid M] : language.monoid.Structure M :=
+def _root_.add_monoid.Structure [add_monoid α] : language.monoid.Structure α :=
 add_monoid.Structure_of_has_zero_has_add
 
 /-- Any group is a structure in the language of groups. -/
-def _root_.group.Structure (G : Type) [group G] : language.group.Structure G :=
+def _root_.group.Structure [group α] : language.group.Structure α :=
 group.Structure_of_has_one_has_inv_has_mul
 
 /-- Any additive group is a structure in the language of additive groups. -/
-def _root_.add_comm_group.Structure (G : Type) [add_comm_group G] : language.group.Structure G :=
+def _root_.add_comm_group.Structure [add_comm_group α] : language.group.Structure α :=
 add_group.Structure_of_has_zero_has_neg_has_add
 
 /-- Any ring is a structure in the language of ring. -/
-def _root_.ring.Structure (R : Type*) [ring R] : language.ring.Structure R :=
-@language.sum_Structure _ _ _ (add_comm_group.Structure R) (monoid.Structure R)
+def _root_.ring.Structure [ring α] : language.ring.Structure α :=
+@language.sum_Structure _ _ _ add_comm_group.Structure monoid.Structure
 
 section sentences
 

--- a/src/model_theory/algebraic.lean
+++ b/src/model_theory/algebraic.lean
@@ -56,7 +56,7 @@ def add : language.ring.functions 2 := sum.inl ⟨⟩
 /-- The function symbol representing multiplication. -/
 def mul : language.ring.functions 2 := sum.inr ⟨⟩
 
-@[simp] instance : has_zero (language.ring.term α) := ⟨ constants.term (sum.inl ⟨⟩) ⟩
+@[simp] instance : has_zero (language.ring.term α) := ⟨ constants.term zero ⟩
 
 @[simp] instance : has_one (language.ring.term α) := ⟨ constants.term (sum.inr ⟨⟩) ⟩
 

--- a/src/model_theory/algebraic.lean
+++ b/src/model_theory/algebraic.lean
@@ -39,7 +39,7 @@ language.sum language.group language.monoid
 
 variable {α : Type u}
 
-namespace language.ring
+namespace ring
 
 /-- The function symbol representing zero. -/
 def zero : language.ring.constants := sum.inl ⟨⟩
@@ -76,7 +76,7 @@ instance : has_pow (language.ring.term α) ℕ := ⟨ λ t n, npow_rec n t ⟩
 @[simp] lemma pow_zero (t : language.ring.term α) : t ^ 0 = 1 := rfl
 @[simp] lemma pow_succ {n} (t : language.ring.term α) : t ^ (n + 1) = t * t ^ n := rfl
 
-end language.ring
+end ring
 
 /-- Any type with instances of `has_one` and `has_mul` is a
   structure in the language of monoids. -/
@@ -90,15 +90,15 @@ def group_Structure_of_has_zero_has_neg_has_add {α : Type} [has_zero α] [has_n
   language.group.Structure α :=
 Structure.mk₂ (λ _, 0) (λ _, has_neg.neg) (λ _, has_add.add) empty.elim empty.elim
 
-/- Any monoid is a structure in the language of monoids. -/
+/-- Any monoid is a structure in the language of monoids. -/
 def _root_.monoid.Structure (M : Type) [monoid M] : language.monoid.Structure M :=
 monoid.Structure_of_has_one_has_mul
 
-/- Any group is a structure in the language of groups. -/
+/-- Any group is a structure in the language of groups. -/
 def _root_.add_comm_group.Structure (G : Type) [add_comm_group G] : language.group.Structure G :=
 group_Structure_of_has_zero_has_neg_has_add
 
-/- Any ring is a structure in the language of ring. -/
+/-- Any ring is a structure in the language of ring. -/
 def _root_.ring.Structure (R : Type*) [ring R] : language.ring.Structure R :=
 @language.sum_Structure _ _ _ (add_comm_group.Structure R) (monoid.Structure R)
 
@@ -169,3 +169,4 @@ end ring_theories
 
 end language
 end first_order
+

--- a/src/model_theory/algebraic.lean
+++ b/src/model_theory/algebraic.lean
@@ -58,7 +58,7 @@ def mul : language.ring.functions 2 := sum.inr ⟨⟩
 
 @[simp] instance : has_zero (language.ring.term α) := ⟨ constants.term zero ⟩
 
-@[simp] instance : has_one (language.ring.term α) := ⟨ constants.term (sum.inr ⟨⟩) ⟩
+@[simp] instance : has_one (language.ring.term α) := ⟨ constants.term one ⟩
 
 @[simp] instance : has_neg (language.ring.term α) :=
   ⟨ λ x, func language.ring.neg ![x] ⟩

--- a/src/model_theory/algebraic.lean
+++ b/src/model_theory/algebraic.lean
@@ -18,65 +18,188 @@ import model_theory.syntax
 * `first_order.language.Theory.comm_ring` defines the theory of commutative rings.
 * `first_order.language.Theory.field` defines the theory of fields.
 -/
-universes u
+universes u v u' v'
 
 namespace first_order
 namespace language
 open_locale first_order
 open Structure
 
+section sentences
+
+variables {L : language.{u v}} (c₀ c₁ : L.constants) (i : L.functions 1) (a m : L.functions 2)
+
+/-- The sentence indicating that a binary functionol is commutative. -/
+protected def comm : L.sentence := ∀' ∀' (m.apply₂ &0 &1 =' m.apply₂ &1 &0)
+
+/-- The sentence indicating that a binary function symbol is associative. -/
+protected def assoc : L.sentence :=
+∀' ∀' ∀' (m.apply₂ (m.apply₂ &0 &1) &2 =' m.apply₂ &0 (m.apply₂ &1 &2))
+
+/-- The sentence indicating that applying a constant symbol on the left of
+  a binary symbol is the identity. -/
+def id_left : L.sentence :=
+∀' (m.apply₂ c₁.term &0 =' &0)
+
+/-- The sentence indicating that applying a constant symbol on the right of
+  a binary symbol is the identity. -/
+def id_right : L.sentence :=
+∀' (m.apply₂ &0 c₁.term =' &0)
+
+/-- The sentence indicating that left composing a unary symbol with a binary symbol
+  is equal to a constant symbol. -/
+def cancel_left : L.sentence :=
+∀' (m.apply₂ (i.apply₁ &0) &0 =' c₁.term)
+
+/-- The sentence indicating that right composing a unary symbol with a binary symbol
+  is equal to a constant symbol. -/
+def cancel_right : L.sentence :=
+∀' (m.apply₂ &0 (i.apply₁ &0) =' c₁.term)
+
+/-- The sentence indicating that a binary function symbol distributes over another -/
+protected def distrib : L.sentence :=
+∀' ∀' ∀' (m.apply₂ (a.apply₂ &0 &1) &2 =' a.apply₂ (m.apply₂ &0 &2) (m.apply₂ &1 &2))
+
+end sentences
+
 /-- The language of monoids -/
 protected def monoid : language :=
+language.mk₂ unit empty unit empty empty
+
+/-- The language of additive monoids -/
+protected def add_monoid : language :=
 language.mk₂ unit empty unit empty empty
 
 /-- The language of groups -/
 protected def group : language :=
 language.mk₂ unit unit unit empty empty
 
+/-- The language of additive groups -/
+protected def add_group : language :=
+language.mk₂ unit unit unit empty empty
+
 /-- The language of rings -/
 protected def ring : language :=
-language.sum language.group language.monoid
+language.add_group.sum language.monoid
 
-variable {α : Type u}
+variables (L : language.{u v}) (L' : language.{u' v'})
 
-namespace ring
+/-- A language having a symbol representing `0`. -/
+class has_zero_symb := (symb : L.constants)
 
-/-- The function symbol representing zero. -/
-def zero : language.ring.constants := sum.inl ⟨⟩
+/-- A language having a symbol representing `1`. -/
+class has_one_symb := (symb : L.constants)
 
-/-- The function symbol representing one. -/
-def one : language.ring.constants := sum.inr ⟨⟩
+/-- A language having a symbol representing `-`. -/
+class has_neg_symb := (symb : L.functions 1)
 
-/-- The function symbol representing negation. -/
-def neg : language.ring.functions 1 := sum.inl ⟨⟩
+/-- A language having a symbol representing `⁻¹`. -/
+class has_inv_symb := (symb : L.functions 1)
 
-/-- The function symbol representing addition. -/
-def add : language.ring.functions 2 := sum.inl ⟨⟩
+/-- A language having a symbol representing `+`. -/
+class has_add_symb := (symb : L.functions 2)
 
-/-- The function symbol representing multiplication. -/
-def mul : language.ring.functions 2 := sum.inr ⟨⟩
+/-- A language having a symbol representing `*`. -/
+class has_mul_symb := (symb : L.functions 2)
 
-@[simp] instance : has_zero (language.ring.term α) := ⟨ constants.term zero ⟩
+namespace sum
 
-@[simp] instance : has_one (language.ring.term α) := ⟨ constants.term one ⟩
+variables {L} {L'}
 
-@[simp] instance : has_neg (language.ring.term α) :=
-  ⟨ λ x, func language.ring.neg ![x] ⟩
+instance has_zero_symb_of_left [L.has_zero_symb] : (L.sum L').has_zero_symb :=
+{ symb := sum.inl has_zero_symb.symb }
 
-@[simp] instance : has_add (language.ring.term α) :=
-⟨ λ x y, func language.ring.add ![x, y] ⟩
+instance has_zero_symb_of_right [L'.has_zero_symb] : (L.sum L').has_zero_symb :=
+{ symb := sum.inr has_zero_symb.symb }
 
-@[simp] instance : has_mul (language.ring.term α) :=
-⟨ λ x y, func language.ring.mul ![x, y] ⟩
+instance has_one_symb_of_left [L.has_one_symb] : (L.sum L').has_one_symb :=
+{ symb := sum.inl has_one_symb.symb }
 
-@[simp] instance : has_sub (language.ring.term α) := ⟨ λ x y, x + - y ⟩
+instance has_one_symb_of_right [L'.has_one_symb] : (L.sum L').has_one_symb :=
+{ symb := sum.inr has_one_symb.symb }
 
-instance : has_pow (language.ring.term α) ℕ := ⟨ λ t n, npow_rec n t ⟩
+instance has_neg_symb_of_left [L.has_neg_symb] : (L.sum L').has_neg_symb :=
+{ symb := sum.inl has_neg_symb.symb }
 
-@[simp] lemma pow_zero (t : language.ring.term α) : t ^ 0 = 1 := rfl
-@[simp] lemma pow_succ {n} (t : language.ring.term α) : t ^ (n + 1) = t * t ^ n := rfl
+instance has_neg_symb_of_right [L'.has_neg_symb] : (L.sum L').has_neg_symb :=
+{ symb := sum.inr has_neg_symb.symb }
 
-end ring
+instance has_add_symb_of_left [L.has_add_symb] : (L.sum L').has_add_symb :=
+{ symb := sum.inl has_add_symb.symb }
+
+instance has_add_symb_of_right [L'.has_add_symb] : (L.sum L').has_add_symb :=
+{ symb := sum.inr has_add_symb.symb }
+
+instance has_mul_symb_of_left [L.has_mul_symb] : (L.sum L').has_mul_symb :=
+{ symb := sum.inl has_mul_symb.symb }
+
+instance has_mul_symb_of_right [L'.has_mul_symb] : (L.sum L').has_mul_symb :=
+{ symb := sum.inr has_mul_symb.symb }
+
+end sum
+
+namespace monoid
+
+instance has_one_symb : language.monoid.has_one_symb := { symb := ⟨⟩ }
+
+instance has_mul_symb : language.monoid.has_mul_symb := { symb := ⟨⟩ }
+
+end monoid
+
+namespace add_monoid
+
+instance has_zero_symb : language.add_monoid.has_zero_symb := { symb := ⟨⟩ }
+
+instance add_monoid.has_add_symb : language.add_monoid.has_add_symb := { symb := ⟨⟩ }
+
+end add_monoid
+
+namespace group
+
+instance group.has_one_symb : language.group.has_one_symb := { symb := ⟨⟩ }
+
+instance group.has_inv_symb : language.group.has_inv_symb := { symb := ⟨⟩ }
+
+instance group.has_mul_symb : language.group.has_mul_symb := { symb := ⟨⟩ }
+
+end group
+
+namespace add_group
+
+instance add_group.has_zero_symb : language.add_group.has_zero_symb := { symb := ⟨⟩ }
+
+instance add_group.has_neg_symb : language.add_group.has_neg_symb := { symb := ⟨⟩ }
+
+instance add_group.has_add_symb : language.add_group.has_add_symb := { symb := ⟨⟩ }
+
+end add_group
+
+-- instance why : language.ring.has_one_symb := by apply_instance
+
+variables {L} {α : Type*}
+
+instance [has_zero_symb L] : has_zero (L.term α) := { zero := has_zero_symb.symb.term }
+
+instance [has_one_symb L] : has_one (L.term α) := { one := has_one_symb.symb.term }
+
+instance [has_neg_symb L] : has_neg (L.term α) := { neg := λ x, func has_neg_symb.symb ![x] }
+
+instance [has_inv_symb L] : has_inv (L.term α) := { inv := λ x, func has_inv_symb.symb ![x] }
+
+instance [has_add_symb L] : has_add (L.term α) := { add := λ x y, func has_add_symb.symb ![x, y] }
+
+instance [has_mul_symb L] : has_mul (L.term α) := { mul := λ x y, func has_mul_symb.symb ![x, y] }
+
+section term_pow
+
+variables [has_one_symb L] [has_mul_symb L]
+
+instance : has_pow (L.term α) ℕ := ⟨ λ t n, npow_rec n t ⟩
+
+@[simp] lemma pow_zero (t : L.term α) : t ^ 0 = 1 := rfl
+@[simp] lemma pow_succ {n} (t : L.term α) : t ^ (n + 1) = t * t ^ n := rfl
+
+end term_pow
 
 /-- Any type with instances of `has_one` and `has_mul` is a
   structure in the language of monoids. -/
@@ -84,9 +207,21 @@ def monoid.Structure_of_has_one_has_mul {α : Type*} [has_one α] [has_mul α] :
   language.monoid.Structure α :=
 Structure.mk₂ (λ _, 1) empty.elim (λ _, has_mul.mul) empty.elim empty.elim
 
+/-- Any type with instances of `has_zero` and `has_add` is a
+  structure in the language of additive monoids. -/
+def add_monoid.Structure_of_has_zero_has_add {α : Type*} [has_zero α] [has_add α] :
+  language.monoid.Structure α :=
+Structure.mk₂ (λ _, 0) empty.elim (λ _, has_add.add) empty.elim empty.elim
+
 /-- Any type with instances of `has_one`, `has_inv` and `has_mul` is a
   structure in the language of groups. -/
-def group_Structure_of_has_zero_has_neg_has_add {α : Type} [has_zero α] [has_neg α] [has_add α] :
+def group.Structure_of_has_one_has_inv_has_mul {α : Type} [has_one α] [has_inv α] [has_mul α] :
+  language.group.Structure α :=
+Structure.mk₂ (λ _, 1) (λ _, has_inv.inv) (λ _, has_mul.mul) empty.elim empty.elim
+
+/-- Any type with instances of `has_zero`, `has_neg` and `has_add` is a
+  structure in the language of additive groups. -/
+def add_group.Structure_of_has_zero_has_neg_has_add {α : Type} [has_zero α] [has_neg α] [has_add α] :
   language.group.Structure α :=
 Structure.mk₂ (λ _, 0) (λ _, has_neg.neg) (λ _, has_add.add) empty.elim empty.elim
 
@@ -94,79 +229,88 @@ Structure.mk₂ (λ _, 0) (λ _, has_neg.neg) (λ _, has_add.add) empty.elim emp
 def _root_.monoid.Structure (M : Type) [monoid M] : language.monoid.Structure M :=
 monoid.Structure_of_has_one_has_mul
 
+/-- Any additive monoid is a structure in the language of additive monoids. -/
+def _root_.add_monoid.Structure (M : Type) [add_monoid M] : language.monoid.Structure M :=
+add_monoid.Structure_of_has_zero_has_add
+
 /-- Any group is a structure in the language of groups. -/
+def _root_.group.Structure (G : Type) [group G] : language.group.Structure G :=
+group.Structure_of_has_one_has_inv_has_mul
+
+/-- Any additive group is a structure in the language of additive groups. -/
 def _root_.add_comm_group.Structure (G : Type) [add_comm_group G] : language.group.Structure G :=
-group_Structure_of_has_zero_has_neg_has_add
+add_group.Structure_of_has_zero_has_neg_has_add
 
 /-- Any ring is a structure in the language of ring. -/
 def _root_.ring.Structure (R : Type*) [ring R] : language.ring.Structure R :=
 @language.sum_Structure _ _ _ (add_comm_group.Structure R) (monoid.Structure R)
 
-namespace functions
+section sentences
 
-variables {L : language} (c₀ c₁ : L.constants) (i : L.functions 1) (a : L.functions 2)
-  (m : L.functions 2)
+/-- The sentence indicating associativity of addition -/
+protected def add_assoc [has_add_symb L] : L.sentence := language.assoc has_add_symb.symb
 
-/-- The sentence indicating that a binary function symbol is commutative. -/
-protected def comm : L.sentence := ∀' ∀' (m.apply₂ &0 &1 =' m.apply₂ &1 &0)
+/-- The sentence indicating commutativity of addition -/
+protected def add_comm [has_add_symb L] : L.sentence := language.comm has_add_symb.symb
 
-/-- The sentence indicating that a binary function symbol is associative. -/
-protected def assoc : L.sentence :=
-∀' ∀' ∀' (m.apply₂ (m.apply₂ &0 &1) &2 =' m.apply₂ &0 (m.apply₂ &1 &2))
+/-- The sentence indicating associativity of multiplication -/
+protected def mul_assoc [has_mul_symb L] : L.sentence := language.assoc has_mul_symb.symb
 
-/-- The sentence indicating that applying a constant symbol on the right of
-  a binary symbol is the identity. -/
-protected def mul_id : L.sentence :=
-∀' (m.apply₂ &0 c₁.term =' &0)
+/-- The sentence indicating commutativity of multiplication -/
+protected def mul_comm [has_mul_symb L] : L.sentence := language.comm has_mul_symb.symb
 
-/-- The sentence indicating that applying a constant symbol on the right of
-  a binary symbol is the identity. -/
-protected def id_mul : L.sentence :=
-∀' (m.apply₂ c₁.term &0 =' &0)
+/-- The sentence indicating that zero is a right identity to addition -/
+protected def add_zero [has_zero_symb L] [has_add_symb L] : L.sentence :=
+id_right has_zero_symb.symb has_add_symb.symb
 
-/-- The sentence indicating that left composing a unary symbol with a binary symbol
-  is equal to a constant symbol. -/
-protected def inv_mul : L.sentence :=
-∀' (m.apply₂ (i.apply₁ &0) &0 =' c₁.term)
+/-- The sentence indicating that zero is a left identity to addition -/
+protected def zero_add [has_zero_symb L] [has_add_symb L] : L.sentence :=
+id_left has_zero_symb.symb has_add_symb.symb
 
-/-- The sentence indicating that left composing a unary symbol with a binary symbol
-  is equal to a constant symbol. -/
-protected def mul_inv : L.sentence :=
-∀' (m.apply₂ &0 (i.apply₁ &0) =' c₁.term)
+/-- The sentence indicating that one is a right identity to addition -/
+protected def mul_one [has_one_symb L] [has_mul_symb L] : L.sentence :=
+id_right has_one_symb.symb has_mul_symb.symb
 
-/-- The sentence indicating that a binary function symbol distributes over another -/
-protected def add_mul : L.sentence :=
-∀' ∀' ∀' (m.apply₂ (a.apply₂ &0 &1) &2 =' a.apply₂ (m.apply₂ &0 &2) (m.apply₂ &1 &2))
+/-- The sentence indicating that one is a left identity to addition -/
+protected def one_mul [has_one_symb L] [has_mul_symb L] : L.sentence :=
+id_left has_one_symb.symb has_mul_symb.symb
 
-/-- The sentence indicating that multiplication has an inverse away from a constant zero -/
-protected def field_inv : L.sentence :=
-∀' (&0 =' c₀.term ⊔ ∃' (m.apply₂ &1 &0 =' c₁.term))
+/-- The sentence indicating that negation is the left inverse to addition -/
+protected def neg_add_self [has_zero_symb L] [has_neg_symb L] [has_add_symb L] : L.sentence :=
+cancel_left has_zero_symb.symb has_neg_symb.symb has_add_symb.symb
 
-end functions
+/-- The sentence indicating that negation is the right inverse to addition -/
+protected def add_neg_self [has_zero_symb L] [has_neg_symb L] [has_add_symb L] : L.sentence :=
+cancel_right has_zero_symb.symb has_neg_symb.symb has_add_symb.symb
 
-section ring_theories
+/-- The sentence indicating that left multiplication distributes over addition -/
+protected def mul_add [has_add_symb L] [has_mul_symb L] : L.sentence :=
+language.distrib has_add_symb.symb has_mul_symb.symb
 
-open language.ring
+end sentences
+
+instance ring.has_zero_symb : language.ring.has_zero_symb := sum.has_zero_symb_of_left
+instance ring.has_one_symb : language.ring.has_one_symb := sum.has_one_symb_of_right
+instance ring.has_neg_symb : language.ring.has_neg_symb := sum.has_neg_symb_of_left
+instance ring.has_add_symb : language.ring.has_add_symb := sum.has_add_symb_of_left
+instance ring.has_mul_symb : language.ring.has_mul_symb := sum.has_mul_symb_of_right
 
 /-- The theory of commutative rings. -/
 def Theory.comm_ring : Theory language.ring :=
-{ functions.assoc add,
-  functions.mul_id zero add,
-  functions.comm add,
-  functions.inv_mul zero neg add,
-  functions.assoc mul,
-  functions.mul_id one mul,
-  functions.comm mul,
-  functions.add_mul add mul }
+{ language.add_assoc,
+  language.add_zero,
+  language.add_comm,
+  language.neg_add_self,
+  language.mul_assoc,
+  language.mul_one,
+  language.mul_comm,
+  language.mul_add }
 
 /-- The theory of fields. -/
 def Theory.field : Theory language.ring :=
 Theory.comm_ring ∪ {
-  functions.field_inv zero one mul,
+  ∀' (&0 =' 0 ⊔ ∃' ((&1 * &0) =' 1)),
   sentence.card_ge _ 1 }
-
-end ring_theories
 
 end language
 end first_order
-

--- a/src/model_theory/basic.lean
+++ b/src/model_theory/basic.lean
@@ -58,7 +58,7 @@ namespace first_order
 structure language :=
 (functions : ℕ → Type u) (relations : ℕ → Type v)
 
-/-- Used to define `first_order.language₂`. -/
+/-- Used to define `first_order.language.mk₂`. -/
 @[simp] def sequence₂ (a₀ a₁ a₂ : Type u) : ℕ → Type u
 | 0 := a₀
 | 1 := a₁
@@ -316,7 +316,7 @@ def rel_map₂ {c f₁ f₂ : Type u} {r₁ r₂ : Type v}
 | 2 r x := r₂' r (x 0) (x 1)
 | (n + 3) r _ := pempty.elim r
 
-/-- A structure constructor to match `first_order.language₂`. -/
+/-- A structure constructor to match `first_order.language.mk₂`. -/
 protected def Structure.mk₂ {c f₁ f₂ : Type u} {r₁ r₂ : Type v}
   (c' : c → M) (f₁' : f₁ → M → M) (f₂' : f₂ → M → M → M)
   (r₁' : r₁ → set M) (r₂' : r₂ → M → M → Prop) :


### PR DESCRIPTION
I used `language.mk₂` to make the languages of monoids and groups, then took the `language.sum` to make the language of rings. Then in the language of rings I define the theory of commutative rings and fields. I imitated the order and graph theory work by making general sentences for commutativity and associativity etc. 

Tangential issues:
- I changed two docstrings in `model_theory/basic` from using `language₂` to `language.mk₂`
- I've noticed an inconsistency in naming theories. Sometimes it is `Theory.preorder` and other times it is `infinite_theory`, 
  these conventions appear respectively in `model_theory/order` and `model_theory/syntax`
  I went with `Theory.comm_ring`.
- I can't decide whether or not it is worth refactoring the theory of rings as the theory of `add_comm_group` and `comm_monoid`. Would this be easy to work with when I try to make the API for `comm_ring` <--> models of `Theory.comm_ring`?

By the way, my original project writeup is [here (for formalizing Ax-Grothendieck)](https://github.com/Jlh18/ModelTheory8Report/blob/main/report/m4r.pdf).

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
