### PR TITLE
[Merged by Bors] - feat(data/nat/choose/basic): Definition of `multichoose` and basic lemmas

### DIFF
--- a/src/data/nat/choose/basic.lean
+++ b/src/data/nat/choose/basic.lean
@@ -287,4 +287,46 @@ lemma choose_le_choose {a b : ℕ} (c : ℕ) (h : a ≤ b) : choose a c ≤ choo
 
 lemma choose_mono (b : ℕ) : monotone (λ a, choose a b) := λ _ _, choose_le_choose b
 
+/-! #### Multichoose -/
+
+def multichoose : ℕ → ℕ → ℕ
+| _             0 := 1
+| 0       (k + 1) := 0
+| (n + 1) (k + 1) := multichoose n (k + 1) + multichoose (n + 1) k
+
+@[simp] lemma multichoose_zero_right (n : ℕ) : multichoose n 0 = 1 :=
+by { cases n; simp [multichoose] }
+
+@[simp] lemma multichoose_zero_succ (k : ℕ) : multichoose 0 (k + 1) = 0 := by simp [multichoose]
+
+lemma multichoose_succ_succ (n k : ℕ) :
+  multichoose (n + 1) (k + 1) = multichoose n (k + 1) + multichoose (n + 1) k :=
+by simp [multichoose]
+
+@[simp] lemma multichoose_one (k : ℕ) : multichoose 1 k = 1 :=
+begin
+  induction k with k IH, { simp },
+  simp [multichoose_succ_succ 0 k, IH],
+end
+
+@[simp] lemma multichoose_two (k : ℕ) : multichoose 2 k = k + 1 :=
+begin
+  induction k with k IH, { simp },
+  simp [multichoose_succ_succ 1 k, IH],
+  rw add_comm,
+end
+
+@[simp] lemma multichoose_one_right (n : ℕ) : multichoose n 1 = n :=
+begin
+  induction n with n IH, { simp },
+  simp [multichoose_succ_succ n 0, IH],
+end
+
+lemma multichoose_eq : ∀ (n k : ℕ), multichoose n k = (n + k - 1).choose k
+| _      0    := by simp
+| 0     (k+1) := by simp
+| (n+1) (k+1) := by
+  { rw [multichoose_succ_succ, add_comm, nat.succ_add_sub_one, ←add_assoc, nat.choose_succ_succ],
+    simp [multichoose_eq] }
+
 end nat

--- a/src/data/nat/choose/basic.lean
+++ b/src/data/nat/choose/basic.lean
@@ -287,8 +287,17 @@ lemma choose_le_choose {a b : ℕ} (c : ℕ) (h : a ≤ b) : choose a c ≤ choo
 
 lemma choose_mono (b : ℕ) : monotone (λ a, choose a b) := λ _ _, choose_le_choose b
 
-/-! #### Multichoose -/
+/-! #### Multichoose
 
+Whereas `choose n k` is the number of subsets of cardinality `k` from a type of cardinality `n`,
+`multichoose n k` is the number of multisets of cardinality `k` from a type of cardinality `n`.
+
+Alternatively, whereas `choose n k` is the number of ways to select `k` items (up to permutation)
+from `n` items without replacement, `multichoose n k` is the number of ways to select `k` items
+(up to permutation) from `n` items with replacement. -/
+
+/--
+`multichoose n k` is the number of multisets of cardinality `k` from a type of cardinality `n`. -/
 def multichoose : ℕ → ℕ → ℕ
 | _             0 := 1
 | 0       (k + 1) := 0

--- a/src/data/nat/choose/basic.lean
+++ b/src/data/nat/choose/basic.lean
@@ -21,7 +21,12 @@ requiring more imports).
 * `nat.desc_factorial_eq_factorial_mul_choose`: Relates binomial coefficients to the descending
   factorial. This is used to prove `nat.choose_le_pow` and variants. We provide similar statements
   for the ascending factorial.
+* `nat.multichoose`: whereas `choose` counts combinations, `multichoose` counts multicombinations.
+* `nat.multichoose_eq` : a proof that `multichoose n k = (n + k - 1).choose k`
 
+## Tags
+
+binomial coefficient, combination, multicombination
 -/
 
 open_locale nat
@@ -292,9 +297,12 @@ lemma choose_mono (b : ℕ) : monotone (λ a, choose a b) := λ _ _, choose_le_c
 Whereas `choose n k` is the number of subsets of cardinality `k` from a type of cardinality `n`,
 `multichoose n k` is the number of multisets of cardinality `k` from a type of cardinality `n`.
 
-Alternatively, whereas `choose n k` is the number of ways to select `k` items (up to permutation)
-from `n` items without replacement, `multichoose n k` is the number of ways to select `k` items
-(up to permutation) from `n` items with replacement. -/
+Alternatively, whereas `choose n k` counts the number of combinations,
+i.e. ways to select `k` items (up to permutation) from `n` items without replacement,
+`multichoose n k` counts the number of multicombinations,
+i.e. ways to select `k` items (up to permutation) from `n` items with replacement.
+
+Note that `multichoose` is *not* the multinomial coefficient. -/
 
 /--
 `multichoose n k` is the number of multisets of cardinality `k` from a type of cardinality `n`. -/

--- a/src/data/nat/choose/basic.lean
+++ b/src/data/nat/choose/basic.lean
@@ -302,7 +302,9 @@ i.e. ways to select `k` items (up to permutation) from `n` items without replace
 `multichoose n k` counts the number of multicombinations,
 i.e. ways to select `k` items (up to permutation) from `n` items with replacement.
 
-Note that `multichoose` is *not* the multinomial coefficient. -/
+Note that `multichoose` is *not* the multinomial coefficient, although it can be computed
+in terms of multinomial coefficients. For details see https://mathworld.wolfram.com/Multichoose.html
+-/
 
 /--
 `multichoose n k` is the number of multisets of cardinality `k` from a type of cardinality `n`. -/

--- a/src/data/nat/choose/basic.lean
+++ b/src/data/nat/choose/basic.lean
@@ -304,6 +304,11 @@ i.e. ways to select `k` items (up to permutation) from `n` items with replacemen
 
 Note that `multichoose` is *not* the multinomial coefficient, although it can be computed
 in terms of multinomial coefficients. For details see https://mathworld.wolfram.com/Multichoose.html
+
+TODO: Prove that `choose (-n) k = (-1)^k * multichoose n k`,
+where `choose` is the generalized binomial coefficient.
+<https://github.com/leanprover-community/mathlib/pull/15072#issuecomment-1171415738>
+
 -/
 
 /--


### PR DESCRIPTION
Defining `multichoose` which (by contrast with `choose`) counts the number of _multisets_ of cardinality `k` from a type of cardinality `n`, or equivalently the number of ways to select `k` items (up to permutation) from `n` items _with_ replacement.

For eventual use in @huynhtrankhanh's #11162  ("stars and bars")

---

cc @YaelDillies @eric-wieser and @kmill, who were involved in reviewing #11162

In #11162 `multichoose n k` is defined as `(n + k - 1).choose k`, and the recursion relation is proved as a lemma.  But I think it's neater to define `multichoose` directly via the recursion relation and then prove `multichoose n k = (n + k - 1).choose k` as a lemma (`multichoose_eq`).

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
