### PR TITLE
feat(tactic/congrm + test/congrm): partially fix a parsing issue

### DIFF
--- a/src/tactic/congrm.lean
+++ b/src/tactic/congrm.lean
@@ -131,7 +131,7 @@ try $ applyc ``_root_.eq.to_iff,
 `(@eq %%ty _ _) ← target | fail "congrm: goal must be an equality or iff",
 match arg with
 | [arg] := to_expr ``((%%arg : %%ty)) tt ff >>= equate_with_pattern
-| _     := fail "`congrm` only accepts one argument"
+| _     := fail "`congrm` accepts exactly one argument"
 end
 
 add_tactic_doc

--- a/src/tactic/congrm.lean
+++ b/src/tactic/congrm.lean
@@ -126,11 +126,13 @@ begin
 end
 ```
 -/
-meta def congrm (arg : parse texpr) : tactic unit := do
+meta def congrm (arg : parse pexpr_list_or_texpr) : tactic unit := do
 try $ applyc ``_root_.eq.to_iff,
 `(@eq %%ty _ _) ← target | fail "congrm: goal must be an equality or iff",
-ta ← to_expr ``((%%arg : %%ty)) tt ff,
-equate_with_pattern ta
+match arg with
+| [arg] := to_expr ``((%%arg : %%ty)) tt ff >>= equate_with_pattern
+| _     := fail "`congrm` only accepts one argument"
+end
 
 add_tactic_doc
 { name := "congrm",

--- a/test/congrm.lean
+++ b/test/congrm.lean
@@ -1,5 +1,9 @@
 import tactic.congrm
 
+example {p q r s : Prop} (pr : p ↔ r) (qs : q ↔ s) :
+  p ∨ q ↔ r ∨ s :=
+by congrm _ ∨ _; assumption
+
 variables {X : Type*} [has_add X] [has_mul X] (a b c d : X) (f : X → X)
 
 example (H : a = b) : f a + f a = f b + f b :=


### PR DESCRIPTION
This PR tries to fix [this issue](https://leanprover.zulipchat.com/#narrow/stream/239415-metaprogramming-.2F-tactics/topic/variant.20syntax.20for.20.60congr'.60/near/287465291) raised by Heather.  However, it only fixes the [further minimized](https://leanprover.zulipchat.com/#narrow/stream/239415-metaprogramming-.2F-tactics/topic/variant.20syntax.20for.20.60congr'.60/near/288030170) issue.

I added the solved issue as a test, but am stumped on solving the full issue.

E.g., can you get both of the following examples to work?
```lean
import tactic.congrm

--  works
example {a : Prop} :
  (∃ k : Prop, a) ↔ ∃ k : Prop, a :=
by congrm (∃ k, _); refl

--  fails
example {a : Prop} :
  (∃ k : Prop, a) ↔ ∃ k : Prop, a :=
by congrm ∃ k, _; refl
```

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
