### PR TITLE
feat(algebra/cubic_discriminant): remove custom `cubic` structure and replace by API about new `to_poly`

### DIFF
--- a/docs/undergrad.yaml
+++ b/docs/undergrad.yaml
@@ -162,7 +162,7 @@ Ring Theory:
     polynomial algebra in one or several indeterminates over a commutative ring: 'mv_polynomial'
     roots of a polynomial: 'polynomial.roots'
     multiplicity: 'polynomial.root_multiplicity'
-    relationship between the coefficients and the roots of a split polynomial: 'https://en.wikipedia.org/wiki/Vieta%27s_formulas'
+    relationship between the coefficients and the roots of a split polynomial: 'polynoial.vieta'
     Newton's identities: 'https://en.wikipedia.org/wiki/Newton%27s_identities'
     polynomial derivative: 'polynomial.derivative'
     decomposition into sums of homogeneous polynomials: 'mv_polynomial.sum_homogeneous_component'

--- a/docs/undergrad.yaml
+++ b/docs/undergrad.yaml
@@ -162,7 +162,7 @@ Ring Theory:
     polynomial algebra in one or several indeterminates over a commutative ring: 'mv_polynomial'
     roots of a polynomial: 'polynomial.roots'
     multiplicity: 'polynomial.root_multiplicity'
-    relationship between the coefficients and the roots of a split polynomial: 'polynoial.vieta'
+    relationship between the coefficients and the roots of a split polynomial: 'polynomial.vieta'
     Newton's identities: 'https://en.wikipedia.org/wiki/Newton%27s_identities'
     polynomial derivative: 'polynomial.derivative'
     decomposition into sums of homogeneous polynomials: 'mv_polynomial.sum_homogeneous_component'

--- a/src/algebra/big_operators/multiset.lean
+++ b/src/algebra/big_operators/multiset.lean
@@ -113,6 +113,17 @@ lemma prod_map_one : prod (m.map (λ i, (1 : α))) = 1 := by rw [map_const, prod
 lemma prod_map_mul : (m.map $ λ i, f i * g i).prod = (m.map f).prod * (m.map g).prod :=
 m.prod_hom₂ (*) mul_mul_mul_comm (mul_one _) _ _
 
+@[simp]
+lemma prod_map_neg [has_distrib_neg α] (s : multiset α) :
+  (s.map has_neg.neg).prod = (-1) ^ s.card * s.prod :=
+begin
+  convert @prod_map_mul α α _ s (λ _, -1) id,
+  { ext, rw neg_one_mul, refl },
+  { convert (prod_repeat _ _).symm, rw eq_repeat,
+    use s.card_map _, intro, rw mem_map, rintro ⟨_, _, rfl⟩, refl },
+  { rw s.map_id },
+end
+
 @[to_additive]
 lemma prod_map_pow {n : ℕ} : (m.map $ λ i, f i ^ n).prod = (m.map f).prod ^ n :=
 m.prod_hom' (pow_monoid_hom n : α →* α) f

--- a/src/algebra/cubic_discriminant.lean
+++ b/src/algebra/cubic_discriminant.lean
@@ -43,17 +43,17 @@ section to_poly
 section basic
 variables [semiring R] {N : ℕ}
 
-/- Convert a vector to a polynomial. This construction allows one to work with the module of
+/-- Convert a vector to a polynomial. This construction allows one to work with the module of
 polynomials of a guaranteed maximal degree, known in mathlib as `degree_lt R`, while retaining easy
 access to the coefficients (which for an element `P : ↥(degree_lt R N)` would be accessed with the
 more cumbersome invocation `(P : R[X]).coeff`). -/
-def to_poly : (fin N → R) →+ R[X] :=
-(add_submonoid_class.subtype (degree_lt R N)).comp (degree_lt_equiv R N).symm
+def to_poly : (fin N → R) →ₗ[R] R[X] :=
+(degree_lt R N).subtype.comp (↑(degree_lt_equiv R N).symm : (fin N → R) →ₗ[R] degree_lt R N)
 
 lemma to_poly_apply (P : fin N → R) : to_poly P =  ∑ i : fin N, monomial i (P i) := rfl
 
 @[simp] lemma polynomial.degree_lt_equiv_symm_apply (P : fin N → R) :
-  ((degree_lt_equiv R N).to_equiv.symm P : R[X]) = to_poly P :=
+  ((degree_lt_equiv R N).symm P : R[X]) = to_poly P :=
 rfl
 
 lemma to_poly_mem_degree_lt (P : fin N → R) : to_poly P ∈ degree_lt R N :=

--- a/src/algebra/cubic_discriminant.lean
+++ b/src/algebra/cubic_discriminant.lean
@@ -38,21 +38,21 @@ open_locale polynomial big_operators
 
 variables {R S F K : Type*}
 
-namespace vec_polynomial
+section to_poly
 
 section basic
 variables [semiring R] {N : ℕ}
 
 /- Convert a vector to a polynomial. This construction allows one to work with the module of
 polynomials of a guaranteed maximal degree, known in mathlib as `degree_lt R`, while retaining easy
-access to the coefficients (which for an element `P : ↥(degree_lt R N)` would be accessed as
-`(P : R[X]).coeff`). -/
+access to the coefficients (which for an element `P : ↥(degree_lt R N)` would be accessed with the
+more cumbersome invocation `(P : R[X]).coeff`). -/
 def to_poly : (fin N → R) →+ R[X] :=
 (add_submonoid_class.subtype (degree_lt R N)).comp (degree_lt_equiv R N).symm
 
 lemma to_poly_apply (P : fin N → R) : to_poly P =  ∑ i : fin N, monomial i (P i) := rfl
 
-@[simp] lemma degree_lt_equiv_symm_apply (P : fin N → R) :
+@[simp] lemma polynomial.degree_lt_equiv_symm_apply (P : fin N → R) :
   ((degree_lt_equiv R N).to_equiv.symm P : R[X]) = to_poly P :=
 rfl
 
@@ -74,15 +74,19 @@ variables {R N}
 @[simp] lemma to_poly_eq_zero_iff (P : fin N → R) : to_poly P = 0 ↔ P = 0 :=
 by rw [← to_poly_zero, to_poly_eq_iff]
 
+lemma map_to_poly [semiring S] {P : fin N → R} {φ : R →+* S} :
+  to_poly (φ ∘ P) = polynomial.map φ (to_poly P) :=
+by simp [to_poly_apply, polynomial.map_sum]
+
 /-! ### Coefficients -/
 
 section coeff
 variables {P : fin N → R}
 
-lemma coeff_ge_four (P : fin N → R) (n : ℕ) (hn : N ≤ n) : (to_poly P).coeff n = 0 :=
+lemma coeff_to_poly_ge_four (P : fin N → R) (n : ℕ) (hn : N ≤ n) : (to_poly P).coeff n = 0 :=
 (submodule.mem_infi _).mp ((submodule.mem_infi _).mp (to_poly_mem_degree_lt P) n : _ ∈ _) hn
 
-@[simp] lemma coeff_le_three (P : fin N → R) (n : fin N) : (to_poly P).coeff n = P n :=
+@[simp] lemma coeff_to_poly_le_three (P : fin N → R) (n : fin N) : (to_poly P).coeff n = P n :=
 by simp [to_poly_apply, coeff_monomial, set_coe.ext_iff, finset.sum_ite_eq']
 
 end coeff
@@ -91,48 +95,38 @@ end coeff
 
 section degree
 
-lemma degree_lt (P : fin N → R) : (to_poly P).degree < N :=
+lemma degree_to_poly_lt (P : fin N → R) : (to_poly P).degree < N :=
 by simpa [mem_degree_lt] using to_poly_mem_degree_lt P
 
 variables (P : fin N.succ → R)
 
-lemma degree_le : (to_poly P).degree ≤ N :=
-(degree_le_iff_coeff_zero _ _).mpr (λ m hm, coeff_ge_four P m (by simpa using hm))
+lemma degree_to_poly_le : (to_poly P).degree ≤ N :=
+(degree_le_iff_coeff_zero _ _).mpr (λ m hm, coeff_to_poly_ge_four P m (by simpa using hm))
 
-lemma nat_degree_le : (to_poly P).nat_degree ≤ N :=
+lemma nat_degree_to_poly_le : (to_poly P).nat_degree ≤ N :=
 begin
   by_cases hP : to_poly P = 0,
   { simp [hP] },
-  simpa [degree_eq_nat_degree hP] using degree_le P,
+  simpa [degree_eq_nat_degree hP] using degree_to_poly_le P,
 end
 
 variables {P}
 
-lemma degree (ha : P N ≠ 0) : (to_poly P).degree = N :=
-le_antisymm (degree_le P) $
+lemma degree_to_poly (ha : P N ≠ 0) : (to_poly P).degree = N :=
+le_antisymm (degree_to_poly_le P) $
 calc (N : with_bot ℕ) = _ : congr_arg some (fin.coe_coe_of_lt (nat.lt.base N)).symm
-... ≤ (to_poly P).degree : le_degree_of_ne_zero (by rwa ← coeff_le_three P at ha)
+... ≤ (to_poly P).degree : le_degree_of_ne_zero (by rwa ← coeff_to_poly_le_three P at ha)
 
-lemma nat_degree (ha : P N ≠ 0) : (to_poly P).nat_degree = N :=
-le_antisymm (nat_degree_le P) $
+lemma nat_degree_to_poly (ha : P N ≠ 0) : (to_poly P).nat_degree = N :=
+le_antisymm (nat_degree_to_poly_le P) $
 calc N = _ : (fin.coe_coe_of_lt (nat.lt.base N)).symm
-... ≤ _ : le_nat_degree_of_ne_zero (by rwa ← coeff_le_three P at ha)
+... ≤ _ : le_nat_degree_of_ne_zero (by rwa ← coeff_to_poly_le_three P at ha)
 
 lemma leading_coeff (ha : P N ≠ 0) : (to_poly P).leading_coeff = P N :=
-by rw [leading_coeff, nat_degree ha, ← coeff_le_three P, fin.coe_coe_of_lt (nat.lt.base N)]
+by rw [leading_coeff, nat_degree_to_poly ha, ← coeff_to_poly_le_three P,
+  fin.coe_coe_of_lt (nat.lt.base N)]
 
 end degree
-
-/-! ### Map across a homomorphism -/
-
-section map
-
-variables [semiring S] {P : fin N → R} {φ : R →+* S}
-
-lemma map_to_poly : to_poly (φ ∘ P) = polynomial.map φ (to_poly P) :=
-by simp [to_poly_apply, polynomial.map_sum]
-
-end map
 
 end basic
 
@@ -145,21 +139,17 @@ open multiset
 section extension
 variables [comm_ring R] [comm_ring S] {N: ℕ} {P : fin N → R} {φ : R →+* S}
 
-theorem mem_roots_iff [is_domain R] (h0 : to_poly P ≠ 0) (x : R) :
+theorem mem_roots_to_poly_iff [is_domain R] (h0 : to_poly P ≠ 0) (x : R) :
   x ∈ (to_poly P).roots ↔ ∑ i, P i * x ^ (i:ℕ) = 0 :=
 begin
   rw [mem_roots h0, is_root, to_poly_apply, eval_finset_sum],
   simp only [eval_monomial],
 end
 
-theorem card_roots_le {P : fin N.succ → R} [is_domain R] [decidable_eq R] :
+theorem card_roots_to_poly_le {P : fin N.succ → R} [is_domain R] [decidable_eq R] :
   (to_poly P).roots.to_finset.card ≤ N :=
-begin
-  apply (to_finset_card_le (to_poly P).roots).trans,
-  by_cases hP : to_poly P = 0,
-  { simp [hP] },
-  { exact with_bot.coe_le_coe.1 ((card_roots hP).trans (degree_le P)) },
-end
+(to_finset_card_le (to_poly P).roots).trans $
+(card_roots' (to_poly P)).trans $ nat_degree_to_poly_le P
 
 end extension
 
@@ -168,56 +158,49 @@ end extension
 section split
 variables [field F] [field K] {N : ℕ} {P : fin N.succ → F} {φ : F →+* K} {x y z : K}
 
-theorem splits_iff_card_roots (ha : P N ≠ 0) :
+theorem to_poly_splits_iff_card_roots (ha : P N ≠ 0) :
   splits φ (to_poly P) ↔ (to_poly (φ ∘ P)).roots.card = N :=
 begin
-  replace ha : (φ ∘ P) N ≠ 0 := (ring_hom.map_ne_zero φ).mpr ha,
-  nth_rewrite_lhs 0 [← ring_hom.id_comp φ],
-  rwa [← splits_map_iff, ← map_to_poly, splits_iff_card_roots, nat_degree],
+  replace ha : (φ ∘ P) N ≠ 0 := φ.map_ne_zero.mpr ha,
+  nth_rewrite_lhs 0 [← φ.id_comp],
+  rwa [← splits_map_iff, ← map_to_poly, splits_iff_card_roots, nat_degree_to_poly],
 end
 
--- in #14908
-theorem vieta {R} [comm_ring R] [is_domain R] (p : R[X])
-  (hroots : p.roots.card = p.nat_degree) (k : ℕ) (h : k ≤ p.nat_degree) :
-  p.coeff k = p.leading_coeff * (-1) ^ (p.nat_degree - k) *
-    ((p.roots.powerset_len (p.nat_degree - k)).map multiset.prod).sum :=
-sorry
-
-lemma to_poly_vieta {P : fin N.succ → F} (ha : P N ≠ 0) (hP : splits φ (to_poly P))
+lemma vieta_to_poly {P : fin N.succ → F} (ha : P N ≠ 0) (hP : splits φ (to_poly P))
   (k : fin N.succ) :
   φ (P k)
   = φ (P N) * (-1) ^ (N - k)
     * (((to_poly (φ ∘ P)).roots.powerset_len (N - k)).map multiset.prod).sum :=
 begin
-  rw [splits_iff_card_roots ha, map_to_poly] at hP,
+  rw [to_poly_splits_iff_card_roots ha, map_to_poly] at hP,
   convert @vieta K _ _ (map φ (to_poly P)) _ k _;
-  simp [leading_coeff ha, nat_degree ha, fin.is_le k, hP, map_to_poly]
+  simp [leading_coeff ha, nat_degree_to_poly ha, fin.is_le k, hP, map_to_poly]
 end
 
 end split
 
 end roots
 
-end vec_polynomial
-
+end to_poly
 
 namespace cubic
 
-open polynomial vec_polynomial multiset
+open polynomial multiset
 
 variables [field F] [field K] {P : fin 4 → F}  {φ : F →+* K} {x y z : K}
 
 section roots
 
-/-! ### Roots of a cubic over a splitting field -/
+/-! ### Roots over a splitting field -/
 
 section split
 
 theorem splits_iff_roots_eq_three (ha : P 3 ≠ 0) :
   splits φ (to_poly P) ↔ ∃ x y z : K, (to_poly (φ ∘ P)).roots = {x, y, z} :=
-by { rw [splits_iff_card_roots ha], norm_num, rw [card_eq_three], refl }
+by { rw [to_poly_splits_iff_card_roots ha], norm_num, rw [card_eq_three], refl }
 
-theorem splits_of_three_roots (ha : P 3 ≠ 0) {x y z : K} (h3 : (to_poly (φ ∘ P)).roots = {x, y, z}) :
+theorem splits_of_three_roots (ha : P 3 ≠ 0) {x y z : K}
+  (h3 : (to_poly (φ ∘ P)).roots = {x, y, z}) :
   splits φ (to_poly P) :=
 (splits_iff_roots_eq_three ha).mpr ⟨x, y, z, h3⟩
 
@@ -232,25 +215,25 @@ end
 
 theorem b_eq_three_roots (ha : P 3 ≠ 0) (h3 : (to_poly (φ ∘ P)).roots = {x, y, z}) :
   φ (P 2) = φ (P 3) * -(x + y + z) :=
-calc φ (P 2)
-    = - φ (P 3) * (z + y + x) : by { rw to_poly_vieta ha (splits_of_three_roots ha h3), norm_num [h3] }
+calc φ (P 2) = - φ (P 3) * (z + y + x) : by
+          { rw vieta_to_poly ha (splits_of_three_roots ha h3), norm_num [h3] }
 ... = _ : by ring
 
 theorem c_eq_three_roots (ha : P 3 ≠ 0) (h3 : (to_poly (φ ∘ P)).roots = {x, y, z}) :
   φ (P 1) = φ (P 3) * (x * y + x * z + y * z) :=
-calc φ (P 1)
-    = φ (P 3) * (y * z + (x * z + x * y)) : by { rw to_poly_vieta ha (splits_of_three_roots ha h3), norm_num [h3] }
+calc φ (P 1) = φ (P 3) * (y * z + (x * z + x * y)) : by
+          { rw vieta_to_poly ha (splits_of_three_roots ha h3), norm_num [h3] }
 ... = _ : by ring
 
 theorem d_eq_three_roots (ha : P 3 ≠ 0) (h3 : (to_poly (φ ∘ P)).roots = {x, y, z}) :
   φ (P 0) = φ (P 3) * -(x * y * z) :=
-calc φ (P 0)
-    = -(φ (P 3) * (x * (y * z))) : by { rw to_poly_vieta ha (splits_of_three_roots ha h3), norm_num [h3] }
+calc φ (P 0) = -(φ (P 3) * (x * (y * z))) : by
+          { rw vieta_to_poly ha (splits_of_three_roots ha h3), norm_num [h3] }
 ... = _ : by ring
 
 end split
 
-/-! ### Discriminant of a cubic over a splitting field -/
+/-! ### Discriminant over a splitting field -/
 
 section discriminant
 
@@ -292,7 +275,7 @@ theorem card_roots_of_disc_ne_zero [decidable_eq K] (ha : P 3 ≠ 0)
   (to_poly (φ ∘ P)).roots.to_finset.card = 3 :=
 begin
   rw [to_finset_card_of_nodup $ (disc_ne_zero_iff_roots_nodup ha h3).mp hd,
-        ← @vec_polynomial.splits_iff_card_roots F K _ _ 3 P φ ha, splits_iff_roots_eq_three ha],
+        ← @to_poly_splits_iff_card_roots F K _ _ 3 P φ ha, splits_iff_roots_eq_three ha],
   exact ⟨x, ⟨y, ⟨z, h3⟩⟩⟩
 end
 

--- a/src/algebra/cubic_discriminant.lean
+++ b/src/algebra/cubic_discriminant.lean
@@ -38,79 +38,88 @@ open_locale polynomial big_operators
 
 variables {R S F K : Type*}
 
-variables {N : ℕ}
-
 namespace vec_polynomial
 
-/- Convert a vector to a polynomial. -/
-def to_poly {R : Type*} [semiring R] {N : ℕ} (P : fin N → R) : R[X] := ∑ i : fin N, monomial i (P i)
+section basic
+variables [semiring R] {N : ℕ}
 
-@[simp] lemma degree_lt_equiv_symm_apply [semiring R] (P : fin N → R) :
+/- Convert a vector to a polynomial. This construction allows one to work with the module of
+polynomials of a guaranteed maximal degree, known in mathlib as `degree_lt R`, while retaining easy
+access to the coefficients (which for an element `P : ↥(degree_lt R N)` would be accessed as
+`(P : R[X]).coeff`). -/
+def to_poly : (fin N → R) →+ R[X] :=
+(add_submonoid_class.subtype (degree_lt R N)).comp (degree_lt_equiv R N).symm
+
+lemma to_poly_apply (P : fin N → R) : to_poly P =  ∑ i : fin N, monomial i (P i) := rfl
+
+@[simp] lemma degree_lt_equiv_symm_apply (P : fin N → R) :
   ((degree_lt_equiv R N).to_equiv.symm P : R[X]) = to_poly P :=
 rfl
 
-lemma to_poly_mem_degree_lt [semiring R] (P : fin N → R) : to_poly P ∈ degree_lt R N :=
+lemma to_poly_mem_degree_lt (P : fin N → R) : to_poly P ∈ degree_lt R N :=
 ((degree_lt_equiv R N).symm P).prop
 
-section basic
-variables [semiring R]
+variables (R N)
+
+@[simp] lemma to_poly_injective : function.injective (to_poly : (fin N → R) → R[X]) :=
+(submodule.injective_subtype (degree_lt R N)).comp (degree_lt_equiv R N).symm.injective
+
+@[simp] lemma to_poly_zero : to_poly (0 : fin N → R) = 0 := (@to_poly R _ _).map_zero
+
+variables {R N}
+
+@[simp] lemma to_poly_eq_iff (P Q : fin N → R) : to_poly P = to_poly Q ↔ P = Q :=
+(to_poly_injective R N).eq_iff
+
+@[simp] lemma to_poly_eq_zero_iff (P : fin N → R) : to_poly P = 0 ↔ P = 0 :=
+by rw [← to_poly_zero, to_poly_eq_iff]
 
 /-! ### Coefficients -/
 
 section coeff
 variables {P : fin N → R}
 
-lemma coeff_gt_three (P : fin N.succ → R) (n : ℕ) (hn : N < n) :
-  (to_poly P).coeff n = 0 :=
+lemma coeff_ge_four (P : fin N → R) (n : ℕ) (hn : N ≤ n) : (to_poly P).coeff n = 0 :=
 (submodule.mem_infi _).mp ((submodule.mem_infi _).mp (to_poly_mem_degree_lt P) n : _ ∈ _) hn
 
-@[simp] lemma coeff_le_three (P : fin N → R) (n : fin N) :
-  (to_poly P).coeff n = P n :=
-begin
-  rw ← degree_lt_equiv_symm_apply,
-end
-
-@[simp] lemma to_poly_injective (P Q : fin N → R) : to_poly P = to_poly Q ↔ P = Q :=
-⟨λ h, by { ext i, rw [← coeff_le_three P, ← coeff_le_three Q, h] }, congr_arg _⟩
-
-@[simp] lemma of_zero (ha : P = 0) : to_poly P = 0 := by simp [ha, ← degree_lt_equiv_symm_apply]
-
-@[simp] lemma zero : to_poly (0 : fin N → R) = 0 := of_zero rfl
-
-@[simp] lemma eq_zero_iff : (to_poly P) = 0 ↔ P = 0 := by rw [← zero, to_poly_injective]
+@[simp] lemma coeff_le_three (P : fin N → R) (n : fin N) : (to_poly P).coeff n = P n :=
+by simp [to_poly_apply, coeff_monomial, set_coe.ext_iff, finset.sum_ite_eq']
 
 end coeff
 
 /-! ### Degrees -/
 
 section degree
+
+lemma degree_lt (P : fin N → R) : (to_poly P).degree < N :=
+by simpa [mem_degree_lt] using to_poly_mem_degree_lt P
+
 variables (P : fin N.succ → R)
 
 lemma degree_le : (to_poly P).degree ≤ N :=
-(degree_le_iff_coeff_zero _ _).mpr (λ m hm, coeff_gt_three P m (by simpa using hm))
+(degree_le_iff_coeff_zero _ _).mpr (λ m hm, coeff_ge_four P m (by simpa using hm))
 
 lemma nat_degree_le : (to_poly P).nat_degree ≤ N :=
 begin
   by_cases hP : to_poly P = 0,
-  { have hP' : P = 0 := by simpa [eq_zero_iff] using hP,
-    simp [hP'] },
+  { simp [hP] },
   simpa [degree_eq_nat_degree hP] using degree_le P,
 end
 
 variables {P}
 
 lemma degree (ha : P N ≠ 0) : (to_poly P).degree = N :=
-begin
-  refine le_antisymm (degree_le P) _,
-  rw ← coeff_le_three P at ha,
-  have := le_degree_of_ne_zero ha,
-  convert this,
-  -- library_search
-end
+le_antisymm (degree_le P) $
+calc (N : with_bot ℕ) = _ : congr_arg some (fin.coe_coe_of_lt (nat.lt.base N)).symm
+... ≤ (to_poly P).degree : le_degree_of_ne_zero (by rwa ← coeff_le_three P at ha)
 
-lemma degree_of_zero (hP : P = 0) : (to_poly P).degree = ⊥ := by rwa [of_zero, degree_zero]
+lemma nat_degree (ha : P N ≠ 0) : (to_poly P).nat_degree = N :=
+le_antisymm (nat_degree_le P) $
+calc N = _ : (fin.coe_coe_of_lt (nat.lt.base N)).symm
+... ≤ _ : le_nat_degree_of_ne_zero (by rwa ← coeff_le_three P at ha)
 
-lemma leading_coeff (ha : P N ≠ 0) : (to_poly P).leading_coeff = P N := sorry --leading_coeff_cubic ha
+lemma leading_coeff (ha : P N ≠ 0) : (to_poly P).leading_coeff = P N :=
+by rw [leading_coeff, nat_degree ha, ← coeff_le_three P, fin.coe_coe_of_lt (nat.lt.base N)]
 
 end degree
 
@@ -118,10 +127,10 @@ end degree
 
 section map
 
-variables {P : fin N → R} [semiring S] {φ : R →+* S}
+variables [semiring S] {P : fin N → R} {φ : R →+* S}
 
 lemma map_to_poly : to_poly (φ ∘ P) = polynomial.map φ (to_poly P) :=
-by simp [to_poly, polynomial.map_sum]
+by simp [to_poly_apply, polynomial.map_sum]
 
 end map
 
@@ -134,13 +143,12 @@ open multiset
 /-! ### Roots over an extension -/
 
 section extension
+variables [comm_ring R] [comm_ring S] {N: ℕ} {P : fin N → R} {φ : R →+* S}
 
-variables {P : fin N → R} [comm_ring R] [comm_ring S] {φ : R →+* S}
-
-theorem mem_roots_iff [is_domain R] (h0 : (to_poly P) ≠ 0) (x : R) :
+theorem mem_roots_iff [is_domain R] (h0 : to_poly P ≠ 0) (x : R) :
   x ∈ (to_poly P).roots ↔ ∑ i, P i * x ^ (i:ℕ) = 0 :=
 begin
-  rw [mem_roots h0, is_root, to_poly, eval_finset_sum],
+  rw [mem_roots h0, is_root, to_poly_apply, eval_finset_sum],
   simp only [eval_monomial],
 end
 
@@ -148,34 +156,43 @@ theorem card_roots_le {P : fin N.succ → R} [is_domain R] [decidable_eq R] :
   (to_poly P).roots.to_finset.card ≤ N :=
 begin
   apply (to_finset_card_le (to_poly P).roots).trans,
-  by_cases hP : (to_poly P) = 0,
-  { exact (card_roots' (to_poly P)).trans (by { rw [hP, nat_degree_zero], exact zero_le N }) },
-  { exact with_bot.coe_le_coe.1 ((card_roots hP).trans degree_le) },
+  by_cases hP : to_poly P = 0,
+  { simp [hP] },
+  { exact with_bot.coe_le_coe.1 ((card_roots hP).trans (degree_le P)) },
 end
 
 end extension
 
-variables {P : fin N.succ → F} [field F] [field K] {φ : F →+* K} {x y z : K}
-
 /-! ### Roots over a splitting field -/
 
 section split
+variables [field F] [field K] {N : ℕ} {P : fin N.succ → F} {φ : F →+* K} {x y z : K}
 
 theorem splits_iff_card_roots (ha : P N ≠ 0) :
   splits φ (to_poly P) ↔ (to_poly (φ ∘ P)).roots.card = N :=
 begin
   replace ha : (φ ∘ P) N ≠ 0 := (ring_hom.map_ne_zero φ).mpr ha,
   nth_rewrite_lhs 0 [← ring_hom.id_comp φ],
-  rw [← splits_map_iff, ← map_to_poly, splits_iff_card_roots,
-      ← ((degree_eq_iff_nat_degree_eq $ ne_zero_of_a_ne_zero ha).mp $ degree ha : _ = 3)]
+  rwa [← splits_map_iff, ← map_to_poly, splits_iff_card_roots, nat_degree],
 end
 
-lemma vieta {P : fin N.succ → F} (hP : splits φ (to_poly P)) (k : fin N.succ) :
-  φ (P k)
-  = (-1) ^ (N - k) * φ (P N) * (((to_poly (φ ∘ P)).roots.powerset_len (N - k)).map multiset.prod).sum :=
+-- in #14908
+theorem vieta {R} [comm_ring R] [is_domain R] (p : R[X])
+  (hroots : p.roots.card = p.nat_degree) (k : ℕ) (h : k ≤ p.nat_degree) :
+  p.coeff k = p.leading_coeff * (-1) ^ (p.nat_degree - k) *
+    ((p.roots.powerset_len (p.nat_degree - k)).map multiset.prod).sum :=
 sorry
-  -- (finset.univ.prod (λ (i : σ), ⇑polynomial.C (r i) + polynomial.X)).coeff k = (finset.powerset_len (fintype.card σ - k) finset.univ).sum (λ (t : finset σ), t.prod (λ (i : σ), r i))
 
+lemma to_poly_vieta {P : fin N.succ → F} (ha : P N ≠ 0) (hP : splits φ (to_poly P))
+  (k : fin N.succ) :
+  φ (P k)
+  = φ (P N) * (-1) ^ (N - k)
+    * (((to_poly (φ ∘ P)).roots.powerset_len (N - k)).map multiset.prod).sum :=
+begin
+  rw [splits_iff_card_roots ha, map_to_poly] at hP,
+  convert @vieta K _ _ (map φ (to_poly P)) _ k _;
+  simp [leading_coeff ha, nat_degree ha, fin.is_le k, hP, map_to_poly]
+end
 
 end split
 
@@ -188,7 +205,7 @@ namespace cubic
 
 open polynomial vec_polynomial multiset
 
-variables {P : fin 4 → F} [field F] [field K] {φ : F →+* K} {x y z : K}
+variables [field F] [field K] {P : fin 4 → F}  {φ : F →+* K} {x y z : K}
 
 section roots
 
@@ -213,22 +230,22 @@ begin
   rw [prod_cons, prod_cons, prod_singleton, mul_assoc, mul_assoc]
 end
 
--- move this
-@[simp] lemma foo {α : Type*} (a : α) : powerset_len 1 ({a} : multiset α) = {{a}} := sorry
-
 theorem b_eq_three_roots (ha : P 3 ≠ 0) (h3 : (to_poly (φ ∘ P)).roots = {x, y, z}) :
   φ (P 2) = φ (P 3) * -(x + y + z) :=
-calc φ (P 2) = - φ (P 3) * (z + y + x) : by { rw vieta (splits_of_three_roots ha h3), simp [h3] }
+calc φ (P 2)
+    = - φ (P 3) * (z + y + x) : by { rw to_poly_vieta ha (splits_of_three_roots ha h3), norm_num [h3] }
 ... = _ : by ring
 
 theorem c_eq_three_roots (ha : P 3 ≠ 0) (h3 : (to_poly (φ ∘ P)).roots = {x, y, z}) :
   φ (P 1) = φ (P 3) * (x * y + x * z + y * z) :=
-calc φ (P 1) = φ (P 3) * (y * z + (x * z + x * y)) : by { rw vieta (splits_of_three_roots ha h3), simp [h3] }
+calc φ (P 1)
+    = φ (P 3) * (y * z + (x * z + x * y)) : by { rw to_poly_vieta ha (splits_of_three_roots ha h3), norm_num [h3] }
 ... = _ : by ring
 
 theorem d_eq_three_roots (ha : P 3 ≠ 0) (h3 : (to_poly (φ ∘ P)).roots = {x, y, z}) :
   φ (P 0) = φ (P 3) * -(x * y * z) :=
-calc φ (P 0) = -(φ (P 3) * (x * (y * z))) : by { rw vieta (splits_of_three_roots ha h3), simp [h3] }
+calc φ (P 0)
+    = -(φ (P 3) * (x * (y * z))) : by { rw to_poly_vieta ha (splits_of_three_roots ha h3), norm_num [h3] }
 ... = _ : by ring
 
 end split
@@ -275,7 +292,7 @@ theorem card_roots_of_disc_ne_zero [decidable_eq K] (ha : P 3 ≠ 0)
   (to_poly (φ ∘ P)).roots.to_finset.card = 3 :=
 begin
   rw [to_finset_card_of_nodup $ (disc_ne_zero_iff_roots_nodup ha h3).mp hd,
-        ← @vec_polynomial.splits_iff_card_roots F K 3 P _ _ φ ha, splits_iff_roots_eq_three ha],
+        ← @vec_polynomial.splits_iff_card_roots F K _ _ 3 P φ ha, splits_iff_roots_eq_three ha],
   exact ⟨x, ⟨y, ⟨z, h3⟩⟩⟩
 end
 

--- a/src/data/fintype/basic.lean
+++ b/src/data/fintype/basic.lean
@@ -786,6 +786,17 @@ instance (n : ℕ) : fintype (fin n) :=
 
 lemma fin.univ_def (n : ℕ) : (univ : finset (fin n)) = finset.fin_range n := rfl
 
+@[simp] theorem multiset.map_of_fin_card (s : multiset α) :
+  (univ : finset (fin s.card)).val.map s.of_fin_card = s :=
+begin
+  conv_rhs { rw ← s.coe_to_list },
+  convert multiset.coe_map _ _,
+  convert ← s.to_list.map_nth_le.symm,
+  { exact s.length_to_list },
+  { rw fin.heq_fun_iff s.length_to_list, intro, refl },
+  { exact s.length_to_list },
+end
+
 @[simp] theorem fintype.card_fin (n : ℕ) : fintype.card (fin n) = n :=
 list.length_fin_range n
 

--- a/src/data/fintype/basic.lean
+++ b/src/data/fintype/basic.lean
@@ -786,16 +786,10 @@ instance (n : ℕ) : fintype (fin n) :=
 
 lemma fin.univ_def (n : ℕ) : (univ : finset (fin n)) = finset.fin_range n := rfl
 
-@[simp] theorem multiset.map_of_fin_card (s : multiset α) :
-  (univ : finset (fin s.card)).val.map s.of_fin_card = s :=
-begin
-  conv_rhs { rw ← s.coe_to_list },
-  convert multiset.coe_map _ _,
-  convert ← s.to_list.map_nth_le.symm,
-  { exact s.length_to_list },
-  { rw fin.heq_fun_iff s.length_to_list, intro, refl },
-  { exact s.length_to_list },
-end
+@[simp] theorem multiset.map_enum_of_fin_card
+  (s : multiset α) {l : list α} (h : (l : multiset α) = s) :
+  (univ : finset (fin s.card)).val.map (s.enum_of_fin_card h) = s :=
+by { subst h, exact congr_arg coe l.map_nth_le }
 
 @[simp] theorem fintype.card_fin (n : ℕ) : fintype.card (fin n) = n :=
 list.length_fin_range n

--- a/src/data/list/range.lean
+++ b/src/data/list/range.lean
@@ -282,6 +282,11 @@ option.some.inj $ by rw [← nth_le_nth _, nth_range (by simpa using H)]
   (fin_range n).nth_le i h = ⟨i, length_fin_range n ▸ h⟩ :=
 by simp only [fin_range, nth_le_range, nth_le_pmap, fin.mk_eq_subtype_mk]
 
+@[simp] lemma map_nth_le (l : list α) :
+  (fin_range l.length).map (λ n, l.nth_le n n.2) = l :=
+ext_le (by rw [length_map, length_fin_range]) $ λ n _ h,
+by { rw ← nth_le_map_rev, congr, { rw nth_le_fin_range, refl }, { rw length_fin_range, exact h } }
+
 theorem of_fn_eq_pmap {α n} {f : fin n → α} :
   of_fn f = pmap (λ i hi, f ⟨i, hi⟩) (range n) (λ _, mem_range.1) :=
 by rw [pmap_eq_map_attach]; from ext_le (by simp)

--- a/src/data/multiset/basic.lean
+++ b/src/data/multiset/basic.lean
@@ -481,6 +481,13 @@ def card : multiset α →+ ℕ :=
 
 @[simp] theorem coe_card (l : list α) : card (l : multiset α) = length l := rfl
 
+@[simp] theorem length_to_list (s : multiset α) : s.to_list.length = s.card :=
+by rw [← coe_card, coe_to_list]
+
+/-- Index the elements of a multiset `s` using a function from the finite type `fin s.card`. -/
+noncomputable def of_fin_card (s : multiset α) (n : fin s.card) : α :=
+s.to_list.nth_le n.1 (by { rw s.length_to_list, exact n.2 })
+
 @[simp] theorem card_zero : @card α 0 = 0 := rfl
 
 theorem card_add (s t : multiset α) : card (s + t) = card s + card t :=

--- a/src/data/multiset/basic.lean
+++ b/src/data/multiset/basic.lean
@@ -484,9 +484,10 @@ def card : multiset α →+ ℕ :=
 @[simp] theorem length_to_list (s : multiset α) : s.to_list.length = s.card :=
 by rw [← coe_card, coe_to_list]
 
-/-- Index the elements of a multiset `s` using a function from the finite type `fin s.card`. -/
-noncomputable def of_fin_card (s : multiset α) (n : fin s.card) : α :=
-s.to_list.nth_le n.1 (by { rw s.length_to_list, exact n.2 })
+/-- Enumerate the elements of a multiset `s` using a function from `fin s.card`,
+  once you choose an ordering `l` on `s`. -/
+def enum_of_fin_card (s : multiset α) {l : list α} (h : (l : multiset α) = s)
+  (n : fin s.card) : α := l.nth_le n.1 (by { subst h, exact n.2 })
 
 @[simp] theorem card_zero : @card α 0 = 0 := rfl
 

--- a/src/data/multiset/powerset.lean
+++ b/src/data/multiset/powerset.lean
@@ -218,6 +218,9 @@ theorem powerset_len_zero_right (n : ℕ) :
   powerset_len (n + 1) s + map (cons a) (powerset_len n s) :=
 quotient.induction_on s $ λ l, by simp [powerset_len_coe']; refl
 
+@[simp] lemma powerset_len_one_singleton (a : α) : powerset_len 1 ({a} : multiset α) = {{a}} :=
+@powerset_len_cons α 0 a 0
+
 @[simp] theorem mem_powerset_len {n : ℕ} {s t : multiset α} :
   s ∈ powerset_len n t ↔ s ≤ t ∧ card s = n :=
 quotient.induction_on t $ λ l, by simp [powerset_len_coe']

--- a/src/ring_theory/polynomial/vieta.lean
+++ b/src/ring_theory/polynomial/vieta.lean
@@ -108,7 +108,7 @@ lemma _root_.multiset.prod_C_add_X_coeff (s : multiset R) (k : ℕ) (h : k ≤ s
   (s.map (λ r, C r + X)).prod.coeff k =
   ((s.powerset_len (s.card - k)).map multiset.prod).sum :=
 begin
-  rw ← s.map_of_fin_card,
+  rw ← s.map_enum_of_fin_card s.coe_to_list,
   rw [multiset.map_map, ← prod_eq_multiset_prod, prod_C_add_X_coeff],
   swap, { exact h.trans (fintype.card_fin _).ge },
   rw [multiset.powerset_len_map, ← map_val_val_powerset_len],

--- a/src/ring_theory/polynomial/vieta.lean
+++ b/src/ring_theory/polynomial/vieta.lean
@@ -76,8 +76,8 @@ by simp only [esymm, eval_sum, eval_prod, eval_X, map_sum, map_prod]
 /-- Vieta's formula for the coefficients of the product of linear terms `X + r i`,
 The `k`th coefficient is `∑ t in powerset_len (card σ - k) (univ : finset σ), ∏ i in t, r i`,
 i.e. the symmetric polynomial `esymm σ R (card σ - k)` of the constant terms `r i`. -/
-lemma prod_X_add_C_coeff (r : σ → R) (k : ℕ) (h : k ≤ card σ):
-  polynomial.coeff (∏ i : σ, (polynomial.C (r i) + polynomial.X)) k =
+lemma prod_X_add_C_coeff (r : σ → R) (k : ℕ) (h : k ≤ card σ) :
+  (∏ i : σ, (polynomial.C (r i) + polynomial.X)).coeff k =
   ∑ t in powerset_len (card σ - k) (univ : finset σ), ∏ i in t, r i :=
 begin
   have hk : filter (λ (x : ℕ), k = card σ - x) (range (card σ + 1)) = {card σ - k} :=

--- a/src/ring_theory/polynomial/vieta.lean
+++ b/src/ring_theory/polynomial/vieta.lean
@@ -131,8 +131,8 @@ end
 /-- Vieta's formula for the coefficients and the roots of a split polynomial.
   When `R` is a field, use `polynomial.splits_iff_card_roots` to derive the
   condition `hroots` from `p.splits (ring_hom.id R)`.  -/
-theorem vieta [comm_ring R] [is_domain R] (p : R[X]) (h0 : p ≠ 0) (k : ℕ)
-  (h : k ≤ p.nat_degree) (hroots : p.roots.card = p.nat_degree) :
+theorem vieta {R} [comm_ring R] [is_domain R] (p : R[X])
+  (hroots : p.roots.card = p.nat_degree) (k : ℕ) (h : k ≤ p.nat_degree) :
   p.coeff k = p.leading_coeff * (-1) ^ (p.nat_degree - k) *
     ((p.roots.powerset_len (p.nat_degree - k)).map multiset.prod).sum :=
 begin

--- a/src/ring_theory/polynomial/vieta.lean
+++ b/src/ring_theory/polynomial/vieta.lean
@@ -9,8 +9,8 @@ import ring_theory.polynomial.symmetric
 /-!
 # Vieta's Formula
 
-The main result is `polynomial.prod_X_add_C_eq_sum_esymm`, which shows that the product of linear terms
-`λ + X i` is equal to a linear combination of the symmetric polynomials `esymm σ R j`.
+The main result is `polynomial.prod_X_add_C_eq_sum_esymm`, which shows that the product of linear
+terms `λ + X i` is equal to a linear combination of the symmetric polynomials `esymm σ R j`.
 
 ## Implementation Notes:
 

--- a/src/ring_theory/polynomial/vieta.lean
+++ b/src/ring_theory/polynomial/vieta.lean
@@ -105,7 +105,7 @@ begin
 end
 
 lemma _root_.multiset.prod_C_add_X_coeff (s : multiset R) (k : ℕ) (h : k ≤ s.card) :
-  (s.map (λ r, polynomial.C r + polynomial.X)).prod.coeff k =
+  (s.map (λ r, C r + X)).prod.coeff k =
   ((s.powerset_len (s.card - k)).map multiset.prod).sum :=
 begin
   rw ← s.map_of_fin_card,
@@ -117,7 +117,7 @@ begin
 end
 
 lemma _root_.multiset.prod_X_sub_C_coeff {R} [comm_ring R] (s : multiset R) (k : ℕ)
-  (h : k ≤ s.card) : (s.map (λ r, polynomial.X - polynomial.C r)).prod.coeff k =
+  (h : k ≤ s.card) : (s.map (λ r, X - C r)).prod.coeff k =
   (-1) ^ (s.card - k) * ((s.powerset_len (s.card - k)).map multiset.prod).sum :=
 begin
   convert (s.map (λ x, -x)).prod_C_add_X_coeff k _ using 2,

--- a/src/ring_theory/polynomial/vieta.lean
+++ b/src/ring_theory/polynomial/vieta.lean
@@ -104,7 +104,7 @@ begin
     mv_polynomial.eval_prod, mv_polynomial.eval_X, add_zero, sum_const_zero],
 end
 
-lemma multiset_prod_C_add_X_coeff (s : multiset R) (k : ℕ) (h : k ≤ s.card) :
+lemma _root_.multiset.prod_C_add_X_coeff (s : multiset R) (k : ℕ) (h : k ≤ s.card) :
   (s.map (λ r, polynomial.C r + polynomial.X)).prod.coeff k =
   ((s.powerset_len (s.card - k)).map multiset.prod).sum :=
 begin
@@ -120,7 +120,7 @@ lemma _root_.multiset.prod_X_sub_C_coeff {R} [comm_ring R] (s : multiset R) (k :
   (h : k ≤ s.card) : (s.map (λ r, polynomial.X - polynomial.C r)).prod.coeff k =
   (-1) ^ (s.card - k) * ((s.powerset_len (s.card - k)).map multiset.prod).sum :=
 begin
-  convert multiset_prod_C_add_X_coeff (s.map (λ x, -x)) k _ using 2,
+  convert (s.map (λ x, -x)).prod_C_add_X_coeff k _ using 2,
   { rw multiset.map_map, congr, ext1, rw [sub_eq_add_neg, ← C_neg, add_comm] },
   all_goals { rw multiset.card_map }, swap, { exact h },
   { rw [← multiset.sum_map_mul_left, multiset.powerset_len_map, multiset.map_map],

--- a/src/ring_theory/polynomial/vieta.lean
+++ b/src/ring_theory/polynomial/vieta.lean
@@ -9,7 +9,7 @@ import ring_theory.polynomial.symmetric
 /-!
 # Vieta's Formula
 
-The main result is `vieta.prod_X_add_C_eq_sum_esymm`, which shows that the product of linear terms
+The main result is `polynomial.prod_X_add_C_eq_sum_esymm`, which shows that the product of linear terms
 `λ + X i` is equal to a linear combination of the symmetric polynomials `esymm σ R j`.
 
 ## Implementation Notes:
@@ -17,31 +17,40 @@ The main result is `vieta.prod_X_add_C_eq_sum_esymm`, which shows that the produ
 We first take the viewpoint where the "roots" `X i` are variables. This means we work over
 `polynomial (mv_polynomial σ R)`, which enables us to talk about linear combinations of
 `esymm σ R j`. We then derive Vieta's formula in `polynomial R` by giving a
-valuation from each `X i` to `r i`.
+valuation from each `X i` to `r i`. Finally, for `R` be an integral domain (so that `p.roots`
+is defined for any `p : R[X]` as a multiset), we derive the relationship between the coefficients
+and the roots of `p` for a polynomial `p` that splits (i.e. having as many roots as its degree).
 
 -/
 
 open_locale big_operators polynomial
 
-open finset polynomial fintype
-
-namespace mv_polynomial
+open finset fintype
 
 variables {R : Type*} [comm_semiring R]
 variables (σ : Type*) [fintype σ]
 
+namespace mv_polynomial
+
+lemma esymm_to_sum (r : σ → R) (j : ℕ) : polynomial.C (eval r (esymm σ R j)) =
+  ∑ t in powerset_len j (univ : finset σ), ∏ i in t, polynomial.C (r i) :=
+by simp only [esymm, eval_sum, eval_prod, eval_X, map_sum, map_prod]
+
+end mv_polynomial
+
+namespace polynomial
+
 /-- A sum version of Vieta's formula. Viewing `X i` as variables,
 the product of linear terms `λ + X i` is equal to a linear combination of
 the symmetric polynomials `esymm σ R j`. -/
-lemma prod_X_add_C_eq_sum_esymm :
-  (∏ i : σ, (polynomial.C (X i) + polynomial.X) : polynomial (mv_polynomial σ R) )=
-  ∑ j in range (card σ + 1),
-    (polynomial.C (esymm σ R j) * polynomial.X ^ (card σ - j)) :=
+lemma prod_C_add_X_eq_sum_esymm :
+  (∏ i : σ, (C (mv_polynomial.X i) + X) : (mv_polynomial σ R)[X]) =
+  ∑ j in range (card σ + 1), C (mv_polynomial.esymm σ R j) * X ^ (card σ - j) :=
 begin
   classical,
   rw [prod_add, sum_powerset],
   refine sum_congr begin congr end (λ j hj, _),
-  rw [esymm, map_sum, sum_mul],
+  rw [mv_polynomial.esymm, map_sum, sum_mul],
   refine sum_congr rfl (λ t ht, _),
   have h : (univ \ t).card = card σ - j :=
   by { rw card_sdiff (mem_powerset_len.mp ht).1, congr, exact (mem_powerset_len.mp ht).2 },
@@ -51,53 +60,85 @@ end
 /-- A fully expanded sum version of Vieta's formula, evaluated at the roots.
 The product of linear terms `X + r i` is equal to `∑ j in range (n + 1), e_j * X ^ (n - j)`,
 where `e_j` is the `j`th symmetric polynomial of the constant terms `r i`. -/
-lemma prod_X_add_C_eval (r : σ → R) : ∏ i : σ, (polynomial.C (r i) + polynomial.X) =
-  ∑ i in range (card σ + 1), (∑ t in powerset_len i (univ : finset σ),
-    ∏ i in t, polynomial.C (r i)) * polynomial.X ^ (card σ - i) :=
+lemma prod_C_add_X_eval (r : σ → R) : ∏ i : σ, (C (r i) + X) =
+  ∑ i in range (card σ + 1), (∑ t in powerset_len i (univ : finset σ), ∏ i in t, C (r i)) *
+  X ^ (card σ - i) :=
 begin
   classical,
-  have h := @prod_X_add_C_eq_sum_esymm _ _ σ _,
-  apply_fun (polynomial.map (eval r)) at h,
+  have h := @prod_C_add_X_eq_sum_esymm _ _ σ _,
+  apply_fun (map (mv_polynomial.eval r)) at h,
   rw [polynomial.map_prod, polynomial.map_sum] at h,
   convert h,
-  simp only [eval_X, polynomial.map_add, polynomial.map_C, polynomial.map_X, eq_self_iff_true],
+  simp only [mv_polynomial.eval_X, polynomial.map_add, map_C, map_X, eq_self_iff_true],
   funext,
-  simp only [function.funext_iff, esymm, polynomial.map_C, polynomial.map_sum, map_sum,
-    polynomial.map_C, polynomial.map_pow, polynomial.map_X, polynomial.map_mul],
+  simp only [function.funext_iff, mv_polynomial.esymm, map_C, polynomial.map_sum, map_sum,
+    map_C, polynomial.map_pow, map_X, polynomial.map_mul],
   congr,
   funext,
-  simp only [eval_prod, eval_X, map_prod],
+  simp only [eval_prod, mv_polynomial.eval_X, map_prod],
 end
-
-lemma esymm_to_sum (r : σ → R) (j : ℕ) : polynomial.C (eval r (esymm σ R j)) =
-  ∑ t in powerset_len j (univ : finset σ), ∏ i in t, polynomial.C (r i) :=
-by simp only [esymm, eval_sum, eval_prod, eval_X, map_sum, map_prod]
 
 /-- Vieta's formula for the coefficients of the product of linear terms `X + r i`,
 The `k`th coefficient is `∑ t in powerset_len (card σ - k) (univ : finset σ), ∏ i in t, r i`,
 i.e. the symmetric polynomial `esymm σ R (card σ - k)` of the constant terms `r i`. -/
-lemma prod_X_add_C_coeff (r : σ → R) (k : ℕ) (h : k ≤ card σ) :
-  (∏ i : σ, (polynomial.C (r i) + polynomial.X)).coeff k =
+lemma prod_C_add_X_coeff (r : σ → R) (k : ℕ) (h : k ≤ card σ) :
+  (∏ i : σ, (C (r i) + X)).coeff k =
   ∑ t in powerset_len (card σ - k) (univ : finset σ), ∏ i in t, r i :=
 begin
-  have hk : filter (λ (x : ℕ), k = card σ - x) (range (card σ + 1)) = {card σ - k} :=
-  begin
-    refine finset.ext (λ a, ⟨λ ha, _, λ ha, _ ⟩),
+  have hk : filter (λ (x : ℕ), k = card σ - x) (range (card σ + 1)) = {card σ - k},
+  { refine finset.ext (λ a, ⟨λ ha, _, λ ha, _ ⟩),
     rw mem_singleton,
     have hσ := (tsub_eq_iff_eq_add_of_le (mem_range_succ_iff.mp
-      (mem_filter.mp ha).1)).mp ((mem_filter.mp ha).2).symm,
+      (mem_filter.mp ha).1)).mp (mem_filter.mp ha).2.symm,
     symmetry,
-    rwa [(tsub_eq_iff_eq_add_of_le h), add_comm],
+    rwa [tsub_eq_iff_eq_add_of_le h, add_comm],
     rw mem_filter,
     have haσ : a ∈ range (card σ + 1) :=
     by { rw mem_singleton.mp ha, exact mem_range_succ_iff.mpr (@tsub_le_self _ _ _ _ _ k) },
     refine ⟨haσ, eq.symm _⟩,
     rw tsub_eq_iff_eq_add_of_le (mem_range_succ_iff.mp haσ),
     have hσ := (tsub_eq_iff_eq_add_of_le h).mp (mem_singleton.mp ha).symm,
-    rwa add_comm,
-  end,
-  simp only [prod_X_add_C_eval, ← esymm_to_sum, finset_sum_coeff, coeff_C_mul_X_pow, sum_ite, hk,
-    sum_singleton, esymm, eval_sum, eval_prod, eval_X, add_zero, sum_const_zero],
+    rwa add_comm },
+  simp only [prod_C_add_X_eval, ← mv_polynomial.esymm_to_sum, finset_sum_coeff, coeff_C_mul_X_pow,
+    sum_ite, hk, sum_singleton, mv_polynomial.esymm, mv_polynomial.eval_sum,
+    mv_polynomial.eval_prod, mv_polynomial.eval_X, add_zero, sum_const_zero],
 end
 
-end mv_polynomial
+lemma multiset_prod_C_add_X_coeff (s : multiset R) (k : ℕ) (h : k ≤ s.card) :
+  (s.map (λ r, polynomial.C r + polynomial.X)).prod.coeff k =
+  ((s.powerset_len (s.card - k)).map multiset.prod).sum :=
+begin
+  rw ← s.map_of_fin_card,
+  rw [multiset.map_map, ← prod_eq_multiset_prod, prod_C_add_X_coeff],
+  swap, { exact h.trans (fintype.card_fin _).ge },
+  rw [multiset.powerset_len_map, ← map_val_val_powerset_len],
+  rw [sum_eq_multiset_sum, multiset.map_map, multiset.map_map, multiset.card_map],
+  refl,
+end
+
+lemma _root_.multiset.prod_X_sub_C_coeff {R} [comm_ring R] (s : multiset R) (k : ℕ)
+  (h : k ≤ s.card) : (s.map (λ r, polynomial.X - polynomial.C r)).prod.coeff k =
+  (-1) ^ (s.card - k) * ((s.powerset_len (s.card - k)).map multiset.prod).sum :=
+begin
+  convert multiset_prod_C_add_X_coeff (s.map (λ x, -x)) k _ using 2,
+  { rw multiset.map_map, congr, ext1, rw [sub_eq_add_neg, ← C_neg, add_comm] },
+  all_goals { rw multiset.card_map }, swap, { exact h },
+  { rw [← multiset.sum_map_mul_left, multiset.powerset_len_map, multiset.map_map],
+    congr' 1, apply multiset.map_congr rfl,
+    intros x hx, convert ← x.prod_map_neg.symm, exact (multiset.mem_powerset_len.1 hx).2 },
+end
+
+/-- Vieta's formula for the coefficients and the roots of a split polynomial.
+  When `R` is a field, use `polynomial.splits_iff_card_roots` to derive the
+  condition `hroots` from `p.splits (ring_hom.id R)`.  -/
+theorem vieta [comm_ring R] [is_domain R] (p : R[X]) (h0 : p ≠ 0) (k : ℕ)
+  (h : k ≤ p.nat_degree) (hroots : p.roots.card = p.nat_degree) :
+  p.coeff k = p.leading_coeff * (-1) ^ (p.nat_degree - k) *
+    ((p.roots.powerset_len (p.nat_degree - k)).map multiset.prod).sum :=
+begin
+  conv_lhs { rw ← C_leading_coeff_mul_prod_multiset_X_sub_C hroots },
+  rw [coeff_C_mul, mul_assoc], congr,
+  convert p.roots.prod_X_sub_C_coeff k _ using 3; rw hroots, exact h,
+end
+
+end polynomial


### PR DESCRIPTION
Currently, the leaf file `algebra/cubic_discriminant` by @Multramate introduces a custom `cubic` structure for polynomials of degree at most 3, which consists of a 4-tuple representing the coefficients plus some API.

As far as I can tell, this structure would be just as useful if it worked for `N`-tuples rather than just 4-tuples.  So in this PR I introduce a constructor (temporarily named `to_poly`, following the existing name for cubics) for a polynomial over `R` given a vector `fin N → R` of the coefficients, and switch the `cubic_discriminant` file over to this, deleting the `cubic` structure.

If the idea is accepted as a good one, I will move the material about `to_poly` out of the `cubic_discriminant` file into `data/polynomial` somewhere.  But for now, I am keeping everything in `algebra/cubic_discriminant` to demonstrate that it at least has the merit of decreasing the length of that file by 40 lines.

[Zulip](https://leanprover.zulipchat.com/#narrow/stream/144837-PR-reviews/topic/.2315088.20rewrite.20cubics)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)

- [x] depends on: #14908
- [x] depends on: #15008

The PR generalizes some of the existing results from cubics to arbitrary-length polynomials, which depends on a variant of Vieta's formulas, coincidentally recently PR'd.  The diff of this PR is therefore large, but all the changes I propose are (temporarily) in the `cubic_discriminant` file.