### PR TITLE
[Merged by Bors] - feat(data/nat/basic): split `exists_lt_and_lt_iff_not_dvd` into `if` and `iff` lemmas

### DIFF
--- a/src/data/nat/basic.lean
+++ b/src/data/nat/basic.lean
@@ -1281,8 +1281,8 @@ lemma not_dvd_iff_between_consec_multiples (n : ℕ) {a : ℕ} (ha : 0 < a) :
   (∃ k : ℕ, a * k < n ∧ n < a * (k + 1)) ↔ ¬ a ∣ n :=
 begin
   refine ⟨λ ⟨k, hk1, hk2⟩, not_dvd_of_between_consec_multiples hk1 hk2,
-          λ han, ⟨n/a, ⟨_, lt_mul_div_succ _ ha⟩⟩⟩,
-  exact lt_of_le_of_ne (mul_div_le n a) (mt (dvd.intro (n/a)) han),
+          λ han, ⟨n/a, ⟨lt_of_le_of_ne (mul_div_le n a) _, lt_mul_div_succ _ ha⟩⟩⟩,
+  exact mt (dvd.intro (n/a)) han,
 end
 
 /-- Two natural numbers are equal if and only if they have the same multiples. -/

--- a/src/data/nat/basic.lean
+++ b/src/data/nat/basic.lean
@@ -1272,11 +1272,10 @@ end
 lemma not_dvd_of_between_consec_multiples {n a k : ℕ} (h1 : a * k < n) (h2 : n < a * (k + 1)) :
   ¬ a ∣ n :=
 begin
-  rcases eq_or_ne n 0 with rfl | hn, { cases h1 },
-  rcases a.eq_zero_or_pos with rfl | ha, { simp [hn] },
-  rintros ⟨j,rfl⟩,
-  rw mul_lt_mul_left ha at h1 h2,
-  exact lt_le_antisymm h2 (succ_le_iff.mpr h1),
+  have H := monotone.ne_of_lt_of_lt_nat (covariant.monotone_of_const a) k h1 h2,
+  contrapose! H,
+  rcases H with ⟨d, rfl⟩,
+  simp,
 end
 
 /-- `n` is not divisible by `a` iff it is between `a * k` and `a * (k + 1)` for some `k`. -/

--- a/src/data/nat/basic.lean
+++ b/src/data/nat/basic.lean
@@ -1272,10 +1272,8 @@ end
 lemma not_dvd_of_between_consec_multiples {n a k : ℕ} (h1 : a * k < n) (h2 : n < a * (k + 1)) :
   ¬ a ∣ n :=
 begin
-  have H := monotone.ne_of_lt_of_lt_nat (covariant.monotone_of_const a) k h1 h2,
-  contrapose! H,
-  rcases H with ⟨d, rfl⟩,
-  simp,
+  rintro ⟨d, rfl⟩,
+  exact monotone.ne_of_lt_of_lt_nat (covariant.monotone_of_const a) k h1 h2 d rfl,
 end
 
 /-- `n` is not divisible by `a` iff it is between `a * k` and `a * (k + 1)` for some `k`. -/

--- a/src/data/nat/basic.lean
+++ b/src/data/nat/basic.lean
@@ -1268,24 +1268,31 @@ begin
   { exact nat.div_eq_zero (m.mod_lt n.succ_pos) }
 end
 
-/-- `m` is not divisible by `n` iff it is between `n * k` and `n * (k + 1)` for some `k`. -/
-lemma exists_lt_and_lt_iff_not_dvd (m : ℕ) {n : ℕ} (hn : 0 < n) :
-  (∃ k, n * k < m ∧ m < n * (k + 1)) ↔ ¬ n ∣ m :=
+/-- `n` is not divisible by `a` if it is between `a * k` and `a * (k + 1)` for some `k`. -/
+lemma not_dvd_of_between_consec_multiples {n a k : ℕ} (h1 : a * k < n) (h2 : n < a * (k + 1)) :
+  ¬ a ∣ n :=
 begin
-  split,
-  { rintro ⟨k, h1k, h2k⟩ ⟨l, rfl⟩, rw [mul_lt_mul_left hn] at h1k h2k,
-    rw [lt_succ_iff, ← not_lt] at h2k, exact h2k h1k },
-  { intro h, rw [dvd_iff_mod_eq_zero, ← ne.def, ← pos_iff_ne_zero] at h,
-    simp only [← mod_add_div m n] {single_pass := tt},
-    refine ⟨m / n, lt_add_of_pos_left _ h, _⟩,
-    rw [add_comm _ 1, left_distrib, mul_one], exact add_lt_add_right (mod_lt _ hn) _ }
+  rcases eq_or_ne n 0 with rfl | hn, { cases h1 },
+  rcases a.eq_zero_or_pos with rfl | ha, { simp [hn] },
+  rintros ⟨j,rfl⟩,
+  rw mul_lt_mul_left ha at h1 h2,
+  exact lt_le_antisymm h2 (succ_le_iff.mpr h1),
 end
 
-/-- Two natural numbers are equal if and only if the have the same multiples. -/
+/-- `n` is not divisible by `a` iff it is between `a * k` and `a * (k + 1)` for some `k`. -/
+lemma not_dvd_iff_between_consec_multiples (n : ℕ) {a : ℕ} (ha : 0 < a) :
+  (∃ k : ℕ, a * k < n ∧ n < a * (k + 1)) ↔ ¬ a ∣ n :=
+begin
+  refine ⟨λ ⟨k, hk1, hk2⟩, not_dvd_of_between_consec_multiples hk1 hk2,
+          λ han, ⟨n/a, ⟨_, lt_mul_div_succ _ ha⟩⟩⟩,
+  exact lt_of_le_of_ne (mul_div_le n a) (mt (dvd.intro (n/a)) han),
+end
+
+/-- Two natural numbers are equal if and only if they have the same multiples. -/
 lemma dvd_right_iff_eq {m n : ℕ} : (∀ a : ℕ, m ∣ a ↔ n ∣ a) ↔ m = n :=
 ⟨λ h, dvd_antisymm ((h _).mpr dvd_rfl) ((h _).mp dvd_rfl), λ h n, by rw h⟩
 
-/-- Two natural numbers are equal if and only if the have the same divisors. -/
+/-- Two natural numbers are equal if and only if they have the same divisors. -/
 lemma dvd_left_iff_eq {m n : ℕ} : (∀ a : ℕ, a ∣ m ↔ a ∣ n) ↔ m = n :=
 ⟨λ h, dvd_antisymm ((h _).mp dvd_rfl) ((h _).mpr dvd_rfl), λ h n, by rw h⟩
 

--- a/src/data/nat/multiplicity.lean
+++ b/src/data/nat/multiplicity.lean
@@ -120,7 +120,8 @@ begin
   revert hm,
   have h4 : ∀ m ∈ Ico (p * n + 1) (p * (n + 1)), multiplicity p m = 0,
   { intros m hm, apply multiplicity_eq_zero_of_not_dvd,
-    rw [← exists_lt_and_lt_iff_not_dvd _ (pos_iff_ne_zero.mpr hp.ne_zero)], rw [mem_Ico] at hm,
+    rw [← not_dvd_iff_between_consec_multiples _ (pos_iff_ne_zero.mpr hp.ne_zero)],
+    rw [mem_Ico] at hm,
     exact ⟨n, lt_of_succ_le hm.1, hm.2⟩ },
   simp_rw [← prod_Ico_id_eq_factorial, multiplicity.finset.prod hp', ← sum_Ico_consecutive _ h1 h3,
     add_assoc], intro h,
@@ -194,7 +195,7 @@ lemma multiplicity_le_multiplicity_choose_add {p : ℕ} (hp : p.prime) : ∀ (n 
   multiplicity p n ≤ multiplicity p (choose n k) + multiplicity p k
 | _     0     := by simp
 | 0     (_+1) := by simp
-| (n+1) (k+1) := 
+| (n+1) (k+1) :=
 begin
   rw ← hp.multiplicity_mul,
   refine multiplicity_le_multiplicity_of_dvd_right _,


### PR DESCRIPTION
Pull out from `exists_lt_and_lt_iff_not_dvd` ("`n` is not divisible by `a` iff it is between `a * k` and `a * (k + 1)` for some `k`") a separate lemma proving the forward direction (which doesn't need the `0 < a` assumption) and use this to golf the `iff` lemma.

Also renames the lemma to the more descriptive `not_dvd_{of,iff}_between_consec_multiples`.

---

Open to suggestions for alternative names for this lemma if this is too verbose or not appropriate. 

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
