### PR TITLE
[Merged by Bors] - feat(data/rat/defs): add denominator as pnat

### DIFF
--- a/src/data/rat/defs.lean
+++ b/src/data/rat/defs.lean
@@ -888,7 +888,7 @@ def pnat_denom (x : ℚ) : ℕ+ := ⟨x.denom, x.pos⟩
 @[simp] lemma mk_pnat_pnat_denom_eq (x : ℚ) : mk_pnat x.num x.pnat_denom = x :=
 by rw [pnat_denom, mk_pnat_eq, num_denom]
 
-lemma pnat_denom_iff_denom {x : ℚ} {n : ℕ+} : x.pnat_denom = n ↔ x.denom = ↑n :=
+lemma pnat_denom_eq_iff_denom_eq {x : ℚ} {n : ℕ+} : x.pnat_denom = n ↔ x.denom = ↑n :=
 subtype.ext_iff
 
 end pnat_denom

--- a/src/data/rat/defs.lean
+++ b/src/data/rat/defs.lean
@@ -883,28 +883,28 @@ section pnat_denom
 /-- Denominator as `ℕ+`. -/
 def pnat_denom (x : ℚ) : ℕ+ := ⟨x.denom, x.pos⟩
 
+/--
+This takes care of most occurances of `rat.pnat_denom` where `rat.denom` could be used instead.
+Sometimes it is necessary to do `apply pnat.eq` first.
+-/
 @[simp] lemma pnat_denom_eq_denom (x : ℚ) : (x.pnat_denom : ℕ) = x.denom :=
 begin
   unfold rat.pnat_denom,
   rw pnat.mk_coe
 end
 
-lemma mk_pnat_pnat_denom_eq (x : ℚ) : mk_pnat x.num x.pnat_denom = x :=
+@[simp] lemma mk_pnat_pnat_denom_eq (x : ℚ) : mk_pnat x.num x.pnat_denom = x :=
 begin
   unfold pnat_denom,
   rw [mk_pnat_eq, num_denom]
 end
 
-@[simp] lemma zero_pnat_denom : (0 : ℚ).pnat_denom = 1 :=
+lemma pnat_denom_iff_denom {x : ℚ} {n : ℕ+} : x.pnat_denom = n ↔ x.denom = ↑n :=
 begin
-  unfold rat.pnat_denom,
-  simp only [rat.denom_zero, pnat.mk_one]
-end
-
-@[simp] lemma one_pnat_denom : (1 : ℚ).pnat_denom = 1 :=
-begin
-  unfold rat.pnat_denom,
-  simp only [rat.denom_one, pnat.mk_one]
+  rw [←pnat_denom_eq_denom],
+  split,
+  { apply congr_arg },
+  { apply pnat.eq }
 end
 
 end pnat_denom

--- a/src/data/rat/defs.lean
+++ b/src/data/rat/defs.lean
@@ -897,7 +897,7 @@ end
 
 lemma pnat_denom_iff_denom {x : ℚ} {n : ℕ+} : x.pnat_denom = n ↔ x.denom = ↑n :=
 begin
-  rw [←pnat_denom_eq_denom],
+  rw [←coe_pnat_denom],
   split,
   { apply congr_arg },
   { apply pnat.eq }

--- a/src/data/rat/defs.lean
+++ b/src/data/rat/defs.lean
@@ -887,11 +887,7 @@ def pnat_denom (x : ℚ) : ℕ+ := ⟨x.denom, x.pos⟩
 This takes care of most occurances of `rat.pnat_denom` where `rat.denom` could be used instead.
 Sometimes it is necessary to do `apply pnat.eq` first.
 -/
-@[simp] lemma pnat_denom_eq_denom (x : ℚ) : (x.pnat_denom : ℕ) = x.denom :=
-begin
-  unfold rat.pnat_denom,
-  rw pnat.mk_coe
-end
+@[simp] lemma coe_pnat_denom (x : ℚ) : (x.pnat_denom : ℕ) = x.denom := rfl
 
 @[simp] lemma mk_pnat_pnat_denom_eq (x : ℚ) : mk_pnat x.num x.pnat_denom = x :=
 begin

--- a/src/data/rat/defs.lean
+++ b/src/data/rat/defs.lean
@@ -875,4 +875,38 @@ protected lemma «forall» {p : ℚ → Prop} : (∀ r, p r) ↔ ∀ a b : ℤ, 
 protected lemma «exists» {p : ℚ → Prop} : (∃ r, p r) ↔ ∃ a b : ℤ, p (a / b) :=
 ⟨λ ⟨r, hr⟩, ⟨r.num, r.denom, by rwa [← mk_eq_div, num_denom]⟩, λ ⟨a, b, h⟩, ⟨_, h⟩⟩
 
+/-!
+### Denominator as `ℕ+`
+-/
+section pnat_denom
+
+/-- Denominator as `ℕ+`. -/
+def pnat_denom (x : ℚ) : ℕ+ := ⟨x.denom, x.pos⟩
+
+@[simp] lemma pnat_denom_eq_denom (x : ℚ) : (x.pnat_denom : ℕ) = x.denom :=
+begin
+  unfold rat.pnat_denom,
+  rw pnat.mk_coe
+end
+
+lemma mk_pnat_pnat_denom_eq (x : ℚ) : mk_pnat x.num x.pnat_denom = x :=
+begin
+  unfold pnat_denom,
+  rw [mk_pnat_eq, num_denom]
+end
+
+@[simp] lemma zero_pnat_denom : (0 : ℚ).pnat_denom = 1 :=
+begin
+  unfold rat.pnat_denom,
+  simp only [rat.denom_zero, pnat.mk_one]
+end
+
+@[simp] lemma one_pnat_denom : (1 : ℚ).pnat_denom = 1 :=
+begin
+  unfold rat.pnat_denom,
+  simp only [rat.denom_one, pnat.mk_one]
+end
+
+end pnat_denom
+
 end rat

--- a/src/data/rat/defs.lean
+++ b/src/data/rat/defs.lean
@@ -883,25 +883,13 @@ section pnat_denom
 /-- Denominator as `ℕ+`. -/
 def pnat_denom (x : ℚ) : ℕ+ := ⟨x.denom, x.pos⟩
 
-/--
-This takes care of most occurances of `rat.pnat_denom` where `rat.denom` could be used instead.
-Sometimes it is necessary to do `apply pnat.eq` first.
--/
 @[simp] lemma coe_pnat_denom (x : ℚ) : (x.pnat_denom : ℕ) = x.denom := rfl
 
 @[simp] lemma mk_pnat_pnat_denom_eq (x : ℚ) : mk_pnat x.num x.pnat_denom = x :=
-begin
-  unfold pnat_denom,
-  rw [mk_pnat_eq, num_denom]
-end
+by rw [pnat_denom, mk_pnat_eq, num_denom]
 
 lemma pnat_denom_iff_denom {x : ℚ} {n : ℕ+} : x.pnat_denom = n ↔ x.denom = ↑n :=
-begin
-  rw [←coe_pnat_denom],
-  split,
-  { apply congr_arg },
-  { apply pnat.eq }
-end
+subtype.ext_iff
 
 end pnat_denom
 


### PR DESCRIPTION
Option to bundle `x.denom` and `x.pos` into a pnat, which can be useful in defining functions using the denominator.

---

Used in #14672 to construct a map `ℚ →+* R` (`R` a comm_ring) by doing the division in `R`. That way this function takes the nice form `λ x, x.num /ₚ ↑(x.pnat_denom)`.

Compatible with all currently existing theorems in this file about `rat.denom`, just sometimes one needs to apply one of `pnat.eq`, or `pnat.dvd_iff.mpr` first before using the original theorem, like this:
```lean
theorem add_pnat_denom_dvd (q₁ q₂ : ℚ) : (q₁ + q₂).pnat_denom ∣ q₁.pnat_denom * q₂.pnat_denom :=
begin
  apply pnat.dvd_iff.mpr,
  simp [add_denom_dvd]
end
```
I believe it unecessary to add all these modified versions, as the proofs are straightforward, or not?

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
