### PR TITLE
[Merged by Bors] - feat(topology): basic simplification lemmas for `continuous_map`s

### DIFF
--- a/src/topology/compact_open.lean
+++ b/src/topology/compact_open.lean
@@ -333,6 +333,10 @@ begin
   apply_instance
 end
 
+@[simp]
+lemma uncurry_apply [locally_compact_space β] (f : C(α, C(β, γ))) (a : α) (b : β) :
+  f.uncurry ⟨a, b⟩ = f a b := rfl
+
 /-- The family of constant maps: `β → C(α, β)` as a continuous map. -/
 def const' : C(β, C(α, β)) := curry ⟨prod.fst, continuous_fst⟩
 

--- a/src/topology/compact_open.lean
+++ b/src/topology/compact_open.lean
@@ -320,7 +320,7 @@ continuous_eval'.comp $ f.continuous.prod_map continuous_id
 /-- The uncurried form of a continuous map `α → C(β, γ)` as a continuous map `α × β → γ` (if `β` is
     locally compact). If `α` is also locally compact, then this is a homeomorphism between the two
     function spaces, see `homeomorph.curry`. -/
-def uncurry [locally_compact_space β] (f : C(α, C(β, γ))) : C(α × β, γ) :=
+@[simps] def uncurry [locally_compact_space β] (f : C(α, C(β, γ))) : C(α × β, γ) :=
 ⟨_, continuous_uncurry_of_continuous f⟩
 
 /-- The uncurrying process is a continuous map between function spaces. -/
@@ -332,10 +332,6 @@ begin
   apply continuous.comp continuous_eval' (continuous.prod_map continuous_eval' continuous_id);
   apply_instance
 end
-
-@[simp]
-lemma uncurry_apply [locally_compact_space β] (f : C(α, C(β, γ))) (p : α × β) :
-  f.uncurry p = f p.fst p.snd := rfl
 
 /-- The family of constant maps: `β → C(α, β)` as a continuous map. -/
 def const' : C(β, C(α, β)) := curry ⟨prod.fst, continuous_fst⟩

--- a/src/topology/compact_open.lean
+++ b/src/topology/compact_open.lean
@@ -334,8 +334,8 @@ begin
 end
 
 @[simp]
-lemma uncurry_apply [locally_compact_space β] (f : C(α, C(β, γ))) (a : α) (b : β) :
-  f.uncurry ⟨a, b⟩ = f a b := rfl
+lemma uncurry_apply [locally_compact_space β] (f : C(α, C(β, γ))) (p : α × β) :
+  f.uncurry p = f p.fst p.snd := rfl
 
 /-- The family of constant maps: `β → C(α, β)` as a continuous map. -/
 def const' : C(β, C(α, β)) := curry ⟨prod.fst, continuous_fst⟩

--- a/src/topology/continuous_function/basic.lean
+++ b/src/topology/continuous_function/basic.lean
@@ -183,6 +183,9 @@ def prod_map (f : C(α₁, α₂)) (g : C(β₁, β₂)) :
 @[simp] lemma prod_eval (f : C(α, β₁)) (g : C(α, β₂)) (a : α) :
   (prod_mk f g) a = (f a, g a) := rfl
 
+@[simp] lemma prod_map_eval (f : C(α₁, α₂)) (g : C(β₁, β₂)) (x : α₁) (y : β₁) :
+  f.prod_map g ⟨x,y⟩ = ⟨f x, g y⟩ := rfl
+
 end prod
 
 section pi

--- a/src/topology/continuous_function/basic.lean
+++ b/src/topology/continuous_function/basic.lean
@@ -175,16 +175,13 @@ def prod_mk (f : C(α, β₁)) (g : C(α, β₂)) :
   continuous_to_fun := continuous.prod_mk f.continuous g.continuous }
 
 /-- Given two continuous maps `f` and `g`, this is the continuous map `(x, y) ↦ (f x, g y)`. -/
-def prod_map (f : C(α₁, α₂)) (g : C(β₁, β₂)) :
+@[simps] def prod_map (f : C(α₁, α₂)) (g : C(β₁, β₂)) :
   C(α₁ × β₁, α₂ × β₂) :=
 { to_fun := prod.map f g,
   continuous_to_fun := continuous.prod_map f.continuous g.continuous }
 
 @[simp] lemma prod_eval (f : C(α, β₁)) (g : C(α, β₂)) (a : α) :
   (prod_mk f g) a = (f a, g a) := rfl
-
-@[simp] lemma prod_map_eval (f : C(α₁, α₂)) (g : C(β₁, β₂)) (x : α₁) (y : β₁) :
-  f.prod_map g ⟨x,y⟩ = ⟨f x, g y⟩ := rfl
 
 end prod
 


### PR DESCRIPTION
This PR adds the `@[simps]` attribute at two definitions

- at [continuous_map.uncurry](https://leanprover-community.github.io/mathlib_docs/topology/compact_open.html#continuous_map.uncurry) and,
- at  [continuous.prod_map](https://leanprover-community.github.io/mathlib_docs/topology/constructions.html#continuous.prod_map)
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
