### PR TITLE
[Merged by Bors] - feat(algebra/module/linear_map): use morphisms class for lemmas about linear [pre]images of `c • S`

### DIFF
--- a/src/algebra/module/equiv.lean
+++ b/src/algebra/module/equiv.lean
@@ -367,30 +367,6 @@ e.to_equiv.image_eq_preimage s
 protected lemma image_symm_eq_preimage (s : set M₂) : e.symm '' s = e ⁻¹' s :=
 e.to_equiv.symm.image_eq_preimage s
 
-section pointwise
-open_locale pointwise
-
-@[simp] lemma image_smul_setₛₗ (c : R) (s : set M) :
-  e '' (c • s) = (σ c) • e '' s :=
-linear_map.image_smul_setₛₗ e.to_linear_map c s
-
-@[simp] lemma preimage_smul_setₛₗ (c : S) (s : set M₂) :
-  e ⁻¹' (c • s) = σ' c • e ⁻¹' s :=
-by rw [← linear_equiv.image_symm_eq_preimage, ← linear_equiv.image_symm_eq_preimage,
-  image_smul_setₛₗ]
-
-include module_M₁ module_N₁
-
-@[simp] lemma image_smul_set (e : M₁ ≃ₗ[R₁] N₁) (c : R₁) (s : set M₁) :
-  e '' (c • s) = c • e '' s :=
-linear_map.image_smul_set e.to_linear_map c s
-
-@[simp] lemma preimage_smul_set (e : M₁ ≃ₗ[R₁] N₁) (c : R₁) (s : set N₁) :
-  e ⁻¹' (c • s) = c • e ⁻¹' s :=
-e.preimage_smul_setₛₗ c s
-
-end pointwise
-
 end
 
 /-- Interpret a `ring_equiv` `f` as an `f`-semilinear equiv. -/

--- a/src/algebra/module/linear_map.lean
+++ b/src/algebra/module/linear_map.lean
@@ -258,36 +258,38 @@ by simp
 section pointwise
 open_locale pointwise
 
-@[simp] lemma image_smul_setₛₗ (c : R) (s : set M) :
-  f '' (c • s) = (σ c) • f '' s :=
+variables {F : Type*} (h : F)
+
+lemma _root_.image_smul_setₛₗ [semilinear_map_class F σ M M₃] (c : R) (s : set M) :
+  h '' (c • s) = (σ c) • h '' s :=
 begin
   apply set.subset.antisymm,
   { rintros x ⟨y, ⟨z, zs, rfl⟩, rfl⟩,
-    exact ⟨f z, set.mem_image_of_mem _ zs, (f.map_smulₛₗ _ _).symm ⟩ },
+    exact ⟨h z, set.mem_image_of_mem _ zs, (map_smulₛₗ _ _ _).symm ⟩ },
   { rintros x ⟨y, ⟨z, hz, rfl⟩, rfl⟩,
-    exact (set.mem_image _ _ _).2 ⟨c • z, set.smul_mem_smul_set hz, f.map_smulₛₗ _ _⟩ }
+    exact (set.mem_image _ _ _).2 ⟨c • z, set.smul_mem_smul_set hz, map_smulₛₗ _ _ _⟩ }
 end
 
-lemma image_smul_set (c : R) (s : set M) :
-  fₗ '' (c • s) = c • fₗ '' s :=
-by simp
+lemma _root_.image_smul_set [linear_map_class F R M M₂] (c : R) (s : set M) :
+  h '' (c • s) = c • h '' s :=
+image_smul_setₛₗ h c s
 
-lemma preimage_smul_setₛₗ {c : R} (hc : is_unit c) (s : set M₃) :
-  f ⁻¹' (σ c • s) = c • f ⁻¹' s :=
+lemma _root_.preimage_smul_setₛₗ [semilinear_map_class F σ M M₃] {c : R} (hc : is_unit c)
+  (s : set M₃) : h ⁻¹' (σ c • s) = c • h ⁻¹' s :=
 begin
   apply set.subset.antisymm,
   { rintros x ⟨y, ys, hy⟩,
     refine ⟨(hc.unit.inv : R) • x, _, _⟩,
-    { simp only [←hy, smul_smul, set.mem_preimage, units.inv_eq_coe_inv, map_smulₛₗ f, ← map_mul,
+    { simp only [←hy, smul_smul, set.mem_preimage, units.inv_eq_coe_inv, map_smulₛₗ h, ← map_mul,
         is_unit.coe_inv_mul, one_smul, map_one, ys] },
     { simp only [smul_smul, is_unit.mul_coe_inv, one_smul, units.inv_eq_coe_inv] } },
   { rintros x ⟨y, hy, rfl⟩,
-    refine ⟨f y, hy, by simp only [ring_hom.id_apply, map_smulₛₗ f]⟩ }
+    refine ⟨h y, hy, by simp only [ring_hom.id_apply, map_smulₛₗ h]⟩ }
 end
 
-lemma preimage_smul_set {c : R} (hc : is_unit c) (s : set M₂) :
-  fₗ ⁻¹' (c • s) = c • fₗ ⁻¹' s :=
-fₗ.preimage_smul_setₛₗ hc s
+lemma _root_.preimage_smul_set [linear_map_class F R M M₂] {c : R} (hc : is_unit c) (s : set M₂) :
+  h ⁻¹' (c • s) = c • h ⁻¹' s :=
+preimage_smul_setₛₗ h hc s
 
 end pointwise
 

--- a/src/algebra/module/linear_map.lean
+++ b/src/algebra/module/linear_map.lean
@@ -258,7 +258,7 @@ by simp
 section pointwise
 open_locale pointwise
 
-variables ⦃M M₃ σ⦄ {F : Type*} (h : F)
+variables (M M₃ σ) {F : Type*} (h : F)
 
 @[simp] lemma _root_.image_smul_setₛₗ [semilinear_map_class F σ M M₃] (c : R) (s : set M) :
   h '' (c • s) = (σ c) • h '' s :=
@@ -283,15 +283,15 @@ begin
     refine ⟨h y, hy, by simp only [ring_hom.id_apply, map_smulₛₗ h]⟩ }
 end
 
-variables ⦃R M₂⦄
+variables (M₂)
 
 lemma _root_.image_smul_set [linear_map_class F R M M₂] (c : R) (s : set M) :
   h '' (c • s) = c • h '' s :=
-image_smul_setₛₗ h c s
+image_smul_setₛₗ _ _ _ h c s
 
 lemma _root_.preimage_smul_set [linear_map_class F R M M₂] {c : R} (hc : is_unit c) (s : set M₂) :
   h ⁻¹' (c • s) = c • h ⁻¹' s :=
-preimage_smul_setₛₗ h hc s
+preimage_smul_setₛₗ _ _ _ h hc s
 
 end pointwise
 

--- a/src/algebra/module/linear_map.lean
+++ b/src/algebra/module/linear_map.lean
@@ -258,7 +258,7 @@ by simp
 section pointwise
 open_locale pointwise
 
-variables ⦃R M M₂⦄ {F : Type*} (h : F)
+variables ⦃M M₂ σ⦄ {F : Type*} (h : F)
 
 lemma _root_.image_smul_setₛₗ [semilinear_map_class F σ M M₃] (c : R) (s : set M) :
   h '' (c • s) = (σ c) • h '' s :=
@@ -269,10 +269,6 @@ begin
   { rintros x ⟨y, ⟨z, hz, rfl⟩, rfl⟩,
     exact (set.mem_image _ _ _).2 ⟨c • z, set.smul_mem_smul_set hz, map_smulₛₗ _ _ _⟩ }
 end
-
-lemma _root_.image_smul_set [linear_map_class F R M M₂] (c : R) (s : set M) :
-  h '' (c • s) = c • h '' s :=
-image_smul_setₛₗ h c s
 
 lemma _root_.preimage_smul_setₛₗ [semilinear_map_class F σ M M₃] {c : R} (hc : is_unit c)
   (s : set M₃) : h ⁻¹' (σ c • s) = c • h ⁻¹' s :=
@@ -286,6 +282,12 @@ begin
   { rintros x ⟨y, hy, rfl⟩,
     refine ⟨h y, hy, by simp only [ring_hom.id_apply, map_smulₛₗ h]⟩ }
 end
+
+variables ⦃R⦄
+
+lemma _root_.image_smul_set [linear_map_class F R M M₂] (c : R) (s : set M) :
+  h '' (c • s) = c • h '' s :=
+image_smul_setₛₗ h c s
 
 lemma _root_.preimage_smul_set [linear_map_class F R M M₂] {c : R} (hc : is_unit c) (s : set M₂) :
   h ⁻¹' (c • s) = c • h ⁻¹' s :=

--- a/src/algebra/module/linear_map.lean
+++ b/src/algebra/module/linear_map.lean
@@ -283,7 +283,7 @@ begin
     refine ⟨h y, hy, by simp only [ring_hom.id_apply, map_smulₛₗ h]⟩ }
 end
 
-variables (M₂)
+variables (R M₂)
 
 lemma _root_.image_smul_set [linear_map_class F R M M₂] (c : R) (s : set M) :
   h '' (c • s) = c • h '' s :=

--- a/src/algebra/module/linear_map.lean
+++ b/src/algebra/module/linear_map.lean
@@ -258,7 +258,7 @@ by simp
 section pointwise
 open_locale pointwise
 
-variables {F : Type*} (h : F)
+variables ⦃R M M₂⦄ {F : Type*} (h : F)
 
 lemma _root_.image_smul_setₛₗ [semilinear_map_class F σ M M₃] (c : R) (s : set M) :
   h '' (c • s) = (σ c) • h '' s :=

--- a/src/algebra/module/linear_map.lean
+++ b/src/algebra/module/linear_map.lean
@@ -283,7 +283,7 @@ begin
     refine ⟨h y, hy, by simp only [ring_hom.id_apply, map_smulₛₗ h]⟩ }
 end
 
-variables ⦃R⦄
+variables ⦃R M₂⦄
 
 lemma _root_.image_smul_set [linear_map_class F R M M₂] (c : R) (s : set M) :
   h '' (c • s) = c • h '' s :=

--- a/src/algebra/module/linear_map.lean
+++ b/src/algebra/module/linear_map.lean
@@ -258,9 +258,9 @@ by simp
 section pointwise
 open_locale pointwise
 
-variables ⦃M M₂ σ⦄ {F : Type*} (h : F)
+variables ⦃M M₃ σ⦄ {F : Type*} (h : F)
 
-lemma _root_.image_smul_setₛₗ [semilinear_map_class F σ M M₃] (c : R) (s : set M) :
+@[simp] lemma _root_.image_smul_setₛₗ [semilinear_map_class F σ M M₃] (c : R) (s : set M) :
   h '' (c • s) = (σ c) • h '' s :=
 begin
   apply set.subset.antisymm,

--- a/src/analysis/locally_convex/bounded.lean
+++ b/src/analysis/locally_convex/bounded.lean
@@ -118,7 +118,7 @@ begin
   have hanz : a ≠ 0 := norm_pos_iff.mp (hrpos.trans_le ha),
   have : σ'.symm a ≠ 0 := (ring_hom.map_ne_zero σ'.symm.to_ring_hom).mpr hanz,
   change _ ⊆ σ _ • _,
-  rw [set.image_subset_iff, preimage_smul_setₛₗ f this.is_unit],
+  rw [set.image_subset_iff, preimage_smul_setₛₗ _ _ _ f this.is_unit],
   refine hr (σ'.symm a) _,
   rwa σ'_symm_iso.norm_map_of_map_zero (map_zero _)
 end

--- a/src/analysis/locally_convex/bounded.lean
+++ b/src/analysis/locally_convex/bounded.lean
@@ -118,7 +118,7 @@ begin
   have hanz : a ≠ 0 := norm_pos_iff.mp (hrpos.trans_le ha),
   have : σ'.symm a ≠ 0 := (ring_hom.map_ne_zero σ'.symm.to_ring_hom).mpr hanz,
   change _ ⊆ σ _ • _,
-  rw [set.image_subset_iff, f.preimage_smul_setₛₗ this.is_unit],
+  rw [set.image_subset_iff, preimage_smul_setₛₗ f this.is_unit],
   refine hr (σ'.symm a) _,
   rwa σ'_symm_iso.norm_map_of_map_zero (map_zero _)
 end

--- a/src/measure_theory/function/jacobian.lean
+++ b/src/measure_theory/function/jacobian.lean
@@ -331,7 +331,7 @@ begin
     have : A '' (closed_ball 0 r) + closed_ball (f x) (ε * r)
       = {f x} + r • (A '' (closed_ball 0 1) + closed_ball 0 ε),
       by rw [smul_add, ← add_assoc, add_comm ({f x}), add_assoc, smul_closed_ball _ _ εpos.le,
-        smul_zero, singleton_add_closed_ball_zero, ← image_smul_set ℝ E E A,
+        smul_zero, singleton_add_closed_ball_zero, ← @image_smul_set _ E E _ _ _ _ _ _ A _ r,
         smul_closed_ball _ _ zero_le_one, smul_zero, real.norm_eq_abs, abs_of_nonneg r0, mul_one,
         mul_comm],
     rw this at K,

--- a/src/measure_theory/function/jacobian.lean
+++ b/src/measure_theory/function/jacobian.lean
@@ -331,7 +331,7 @@ begin
     have : A '' (closed_ball 0 r) + closed_ball (f x) (ε * r)
       = {f x} + r • (A '' (closed_ball 0 1) + closed_ball 0 ε),
       by rw [smul_add, ← add_assoc, add_comm ({f x}), add_assoc, smul_closed_ball _ _ εpos.le,
-        smul_zero, singleton_add_closed_ball_zero, ← image_smul_set ℝ E E A,
+        smul_zero, singleton_add_closed_ball_zero, ← @image_smul_set ℝ E E _ _ _ _ _ _ A _ _,
         smul_closed_ball _ _ zero_le_one, smul_zero, real.norm_eq_abs, abs_of_nonneg r0, mul_one,
         mul_comm],
     rw this at K,

--- a/src/measure_theory/function/jacobian.lean
+++ b/src/measure_theory/function/jacobian.lean
@@ -331,7 +331,7 @@ begin
     have : A '' (closed_ball 0 r) + closed_ball (f x) (ε * r)
       = {f x} + r • (A '' (closed_ball 0 1) + closed_ball 0 ε),
       by rw [smul_add, ← add_assoc, add_comm ({f x}), add_assoc, smul_closed_ball _ _ εpos.le,
-        smul_zero, singleton_add_closed_ball_zero, ← @image_smul_set ℝ E E _ _ _ _ _ _ A _ _,
+        smul_zero, singleton_add_closed_ball_zero, ← image_smul_set ℝ E E A,
         smul_closed_ball _ _ zero_le_one, smul_zero, real.norm_eq_abs, abs_of_nonneg r0, mul_one,
         mul_comm],
     rw this at K,

--- a/src/measure_theory/function/jacobian.lean
+++ b/src/measure_theory/function/jacobian.lean
@@ -331,7 +331,7 @@ begin
     have : A '' (closed_ball 0 r) + closed_ball (f x) (ε * r)
       = {f x} + r • (A '' (closed_ball 0 1) + closed_ball 0 ε),
       by rw [smul_add, ← add_assoc, add_comm ({f x}), add_assoc, smul_closed_ball _ _ εpos.le,
-        smul_zero, singleton_add_closed_ball_zero, ← @image_smul_set _ E E _ _ _ _ _ _ A _ r,
+        smul_zero, singleton_add_closed_ball_zero, ← image_smul_set ℝ E E A,
         smul_closed_ball _ _ zero_le_one, smul_zero, real.norm_eq_abs, abs_of_nonneg r0, mul_one,
         mul_comm],
     rw this at K,

--- a/src/measure_theory/function/jacobian.lean
+++ b/src/measure_theory/function/jacobian.lean
@@ -331,7 +331,7 @@ begin
     have : A '' (closed_ball 0 r) + closed_ball (f x) (ε * r)
       = {f x} + r • (A '' (closed_ball 0 1) + closed_ball 0 ε),
       by rw [smul_add, ← add_assoc, add_comm ({f x}), add_assoc, smul_closed_ball _ _ εpos.le,
-        smul_zero, singleton_add_closed_ball_zero, ← A.image_smul_set,
+        smul_zero, singleton_add_closed_ball_zero, ← image_smul_set A,
         smul_closed_ball _ _ zero_le_one, smul_zero, real.norm_eq_abs, abs_of_nonneg r0, mul_one,
         mul_comm],
     rw this at K,

--- a/src/measure_theory/function/jacobian.lean
+++ b/src/measure_theory/function/jacobian.lean
@@ -331,7 +331,7 @@ begin
     have : A '' (closed_ball 0 r) + closed_ball (f x) (ε * r)
       = {f x} + r • (A '' (closed_ball 0 1) + closed_ball 0 ε),
       by rw [smul_add, ← add_assoc, add_comm ({f x}), add_assoc, smul_closed_ball _ _ εpos.le,
-        smul_zero, singleton_add_closed_ball_zero, ← image_smul_set A,
+        smul_zero, singleton_add_closed_ball_zero, ← image_smul_set ℝ E E A,
         smul_closed_ball _ _ zero_le_one, smul_zero, real.norm_eq_abs, abs_of_nonneg r0, mul_one,
         mul_comm],
     rw this at K,

--- a/src/topology/algebra/module/basic.lean
+++ b/src/topology/algebra/module/basic.lean
@@ -897,27 +897,6 @@ rfl
 
 end
 
-section pointwise
-open_locale pointwise
-
-@[simp] lemma image_smul_setₛₗ (f : M₁ →SL[σ₁₂] M₂) (c : R₁) (s : set M₁) :
-  f '' (c • s) = (σ₁₂ c) • f '' s :=
-f.to_linear_map.image_smul_setₛₗ c s
-
-lemma image_smul_set (fₗ : M₁ →L[R₁] M'₁) (c : R₁) (s : set M₁) :
-  fₗ '' (c • s) = c • fₗ '' s :=
-fₗ.to_linear_map.image_smul_set c s
-
-lemma preimage_smul_setₛₗ (f : M₁ →SL[σ₁₂] M₂) {c : R₁} (hc : is_unit c) (s : set M₂) :
-  f ⁻¹' (σ₁₂ c • s) = c • f ⁻¹' s :=
-f.to_linear_map.preimage_smul_setₛₗ hc s
-
-lemma preimage_smul_set (fₗ : M₁ →L[R₁] M'₁) {c : R₁} (hc : is_unit c) (s : set M'₁) :
-  fₗ ⁻¹' (c • s) = c • fₗ ⁻¹' s :=
-fₗ.to_linear_map.preimage_smul_set hc s
-
-end pointwise
-
 variables [module R₁ M₂] [topological_space R₁] [has_continuous_smul R₁ M₂]
 
 @[simp]
@@ -1642,29 +1621,6 @@ rfl
   (equiv_of_inverse f₁ f₂ h₁ h₂).symm = equiv_of_inverse f₂ f₁ h₂ h₁ :=
 rfl
 omit σ₂₁
-
-section pointwise
-open_locale pointwise
-include σ₂₁
-
-@[simp] lemma image_smul_setₛₗ (e : M₁ ≃SL[σ₁₂] M₂) (c : R₁) (s : set M₁) :
-  e '' (c • s) = (σ₁₂ c) • e '' s :=
-e.to_linear_equiv.image_smul_setₛₗ c s
-
-@[simp] lemma preimage_smul_setₛₗ (e : M₁ ≃SL[σ₁₂] M₂) (c : R₂) (s : set M₂) :
-  e ⁻¹' (c • s) = σ₂₁ c • e ⁻¹' s :=
-e.to_linear_equiv.preimage_smul_setₛₗ c s
-omit σ₂₁
-
-@[simp] lemma image_smul_set (e : M₁ ≃L[R₁] M'₁) (c : R₁) (s : set M₁) :
-  e '' (c • s) = c • e '' s :=
-e.to_linear_equiv.image_smul_set c s
-
-@[simp] lemma preimage_smul_set (e : M₁ ≃L[R₁] M'₁) (c : R₁) (s : set M'₁) :
-  e ⁻¹' (c • s) = c • e ⁻¹' s :=
-e.to_linear_equiv.preimage_smul_set c s
-
-end pointwise
 
 variable (M₁)
 

--- a/src/topology/algebra/module/basic.lean
+++ b/src/topology/algebra/module/basic.lean
@@ -280,13 +280,6 @@ abbreviation continuous_linear_map_class (F : Type*)
   [module R M] [module R M₂] :=
 continuous_semilinear_map_class F (ring_hom.id R) M M₂
 
-instance shortcut_linear (F : Type*) (R : out_param Type*) [semiring R]
-  (M : out_param Type*) [topological_space M] [add_comm_monoid M]
-  (M₂ : out_param Type*) [topological_space M₂] [add_comm_monoid M₂]
-  [module R M] [module R M₂] [continuous_linear_map_class F R M M₂] :
-  linear_map_class F R M M₂ :=
-infer_instance
-
 /-- Continuous linear equivalences between modules. We only put the type classes that are necessary
 for the definition, although in applications `M` and `M₂` will be topological modules over the
 topological semiring `R`. -/

--- a/src/topology/algebra/module/basic.lean
+++ b/src/topology/algebra/module/basic.lean
@@ -280,6 +280,13 @@ abbreviation continuous_linear_map_class (F : Type*)
   [module R M] [module R M₂] :=
 continuous_semilinear_map_class F (ring_hom.id R) M M₂
 
+instance shortcut_linear (F : Type*) (R : out_param Type*) [semiring R]
+  (M : out_param Type*) [topological_space M] [add_comm_monoid M]
+  (M₂ : out_param Type*) [topological_space M₂] [add_comm_monoid M₂]
+  [module R M] [module R M₂] [continuous_linear_map_class F R M M₂] :
+  linear_map_class F R M M₂ :=
+infer_instance
+
 /-- Continuous linear equivalences between modules. We only put the type classes that are necessary
 for the definition, although in applications `M` and `M₂` will be topological modules over the
 topological semiring `R`. -/


### PR DESCRIPTION
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

Unfortunately we need to add more explicit arguments, because the typeclass system can't always guess which `semilinear_map_class` instance to search for.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
