### PR TITLE
[Merged by Bors] - chore(*): add missing `to_fun → apply` configurations for `simps`

### DIFF
--- a/src/analysis/fourier.lean
+++ b/src/analysis/fourier.lean
@@ -200,7 +200,7 @@ begin
   intros i j,
   rw continuous_map.inner_to_Lp haar_circle (fourier i) (fourier j),
   split_ifs,
-  { simp [h, is_probability_measure.measure_univ, ← fourier_neg, ← fourier_add, -fourier_to_fun] },
+  { simp [h, is_probability_measure.measure_univ, ← fourier_neg, ← fourier_add, -fourier_apply] },
   simp only [← fourier_add, ← fourier_neg],
   have hij : -i + j ≠ 0,
   { rw add_comm,

--- a/src/linear_algebra/quadratic_form/basic.lean
+++ b/src/linear_algebra/quadratic_form/basic.lean
@@ -142,6 +142,9 @@ variables (Q)
 /-- The `simp` normal form for a quadratic form is `coe_fn`, not `to_fun`. -/
 @[simp] lemma to_fun_eq_coe : Q.to_fun = ⇑Q := rfl
 
+-- this must come after the coe_to_fun definition
+initialize_simps_projections quadratic_form (to_fun → apply)
+
 variables {Q}
 
 @[ext] lemma ext (H : ∀ (x : M), Q x = Q' x) : Q = Q' := fun_like.ext _ _ H

--- a/src/linear_algebra/quadratic_form/prod.lean
+++ b/src/linear_algebra/quadratic_form/prod.lean
@@ -64,7 +64,7 @@ lemma anisotropic_of_prod {R} [ordered_ring R] [module R M₁] [module R M₂]
   {Q₁ : quadratic_form R M₁} {Q₂ : quadratic_form R M₂} (h : (Q₁.prod Q₂).anisotropic) :
   Q₁.anisotropic ∧ Q₂.anisotropic :=
 begin
-  simp_rw [anisotropic, prod_to_fun, prod.forall, prod.mk_eq_zero] at h,
+  simp_rw [anisotropic, prod_apply, prod.forall, prod.mk_eq_zero] at h,
   split,
   { intros x hx,
     refine (h x 0 _).1,
@@ -78,7 +78,7 @@ lemma nonneg_prod_iff {R} [ordered_ring R] [module R M₁] [module R M₂]
   {Q₁ : quadratic_form R M₁} {Q₂ : quadratic_form R M₂} :
   (∀ x, 0 ≤ (Q₁.prod Q₂) x) ↔ (∀ x, 0 ≤ Q₁ x) ∧ (∀ x, 0 ≤ Q₂ x) :=
 begin
-  simp_rw [prod.forall, prod_to_fun],
+  simp_rw [prod.forall, prod_apply],
   split,
   { intro h,
     split,

--- a/src/order/hom/bounded.lean
+++ b/src/order/hom/bounded.lean
@@ -142,6 +142,9 @@ instance : has_coe_to_fun (top_hom α β) (λ _, α → β) := fun_like.has_coe_
 
 @[simp] lemma to_fun_eq_coe {f : top_hom α β} : f.to_fun = (f : α → β) := rfl
 
+-- this must come after the coe_to_fun definition
+initialize_simps_projections top_hom (to_fun → apply)
+
 @[ext] lemma ext {f g : top_hom α β} (h : ∀ a, f a = g a) : f = g := fun_like.ext f g h
 
 /-- Copy of a `top_hom` with a new `to_fun` equal to the old one. Useful to fix definitional
@@ -255,6 +258,9 @@ directly. -/
 instance : has_coe_to_fun (bot_hom α β) (λ _, α → β) := fun_like.has_coe_to_fun
 
 @[simp] lemma to_fun_eq_coe {f : bot_hom α β} : f.to_fun = (f : α → β) := rfl
+
+-- this must come after the coe_to_fun definition
+initialize_simps_projections bot_hom (to_fun → apply)
 
 @[ext] lemma ext {f g : bot_hom α β} (h : ∀ a, f a = g a) : f = g := fun_like.ext f g h
 

--- a/src/topology/continuous_function/basic.lean
+++ b/src/topology/continuous_function/basic.lean
@@ -73,6 +73,9 @@ instance : has_coe_to_fun (C(α, β)) (λ _, α → β) := fun_like.has_coe_to_f
 
 @[simp] lemma to_fun_eq_coe {f : C(α, β)} : f.to_fun = (f : α → β) := rfl
 
+-- this must come after the coe_to_fun definition
+initialize_simps_projections continuous_map (to_fun → apply)
+
 @[ext] lemma ext {f g : C(α, β)} (h : ∀ a, f a = g a) : f = g := fun_like.ext _ _ h
 
 /-- Copy of a `continuous_map` with a new `to_fun` equal to the old one. Useful to fix definitional

--- a/src/topology/continuous_function/polynomial.lean
+++ b/src/topology/continuous_function/polynomial.lean
@@ -155,7 +155,7 @@ begin
         polynomial.eval_X, polynomial.eval_neg, polynomial.eval_C, polynomial.eval_smul,
         smul_eq_mul, polynomial.eval_mul, polynomial.eval_add, polynomial.coe_aeval_eq_eval,
         polynomial.eval_comp, polynomial.to_continuous_map_on_alg_hom_apply,
-        polynomial.to_continuous_map_on_apply, polynomial.to_continuous_map_to_fun],
+        polynomial.to_continuous_map_on_apply, polynomial.to_continuous_map_apply],
       convert w ⟨_, _⟩; clear w,
       { -- why does `comm_ring.add` appear here!?
         change x = (Icc_homeo_I a b h).symm ⟨_ + _, _⟩,

--- a/src/topology/continuous_function/polynomial.lean
+++ b/src/topology/continuous_function/polynomial.lean
@@ -155,7 +155,7 @@ begin
         polynomial.eval_X, polynomial.eval_neg, polynomial.eval_C, polynomial.eval_smul,
         smul_eq_mul, polynomial.eval_mul, polynomial.eval_add, polynomial.coe_aeval_eq_eval,
         polynomial.eval_comp, polynomial.to_continuous_map_on_alg_hom_apply,
-        polynomial.to_continuous_map_on_to_fun, polynomial.to_continuous_map_to_fun],
+        polynomial.to_continuous_map_on_apply, polynomial.to_continuous_map_to_fun],
       convert w ⟨_, _⟩; clear w,
       { -- why does `comm_ring.add` appear here!?
         change x = (Icc_homeo_I a b h).symm ⟨_ + _, _⟩,

--- a/src/topology/continuous_function/stone_weierstrass.lean
+++ b/src/topology/continuous_function/stone_weierstrass.lean
@@ -65,7 +65,7 @@ begin
     polynomial.to_continuous_map_on_to_fun,
     polynomial.aeval_subalgebra_coe,
     polynomial.aeval_continuous_map_apply,
-    polynomial.to_continuous_map_to_fun],
+    polynomial.to_continuous_map_apply],
 end
 
 /--

--- a/src/topology/continuous_function/stone_weierstrass.lean
+++ b/src/topology/continuous_function/stone_weierstrass.lean
@@ -62,7 +62,7 @@ begin
   ext,
   simp only [continuous_map.coe_comp, function.comp_app,
     continuous_map.attach_bound_apply_coe,
-    polynomial.to_continuous_map_on_to_fun,
+    polynomial.to_continuous_map_on_apply,
     polynomial.aeval_subalgebra_coe,
     polynomial.aeval_continuous_map_apply,
     polynomial.to_continuous_map_apply],

--- a/src/topology/gluing.lean
+++ b/src/topology/gluing.lean
@@ -184,7 +184,7 @@ begin
     generalize : (sigma_iso_sigma.{u} D.V).hom x = x',
     obtain ⟨⟨i,j⟩,y⟩ := x',
     unfold inv_image multispan_index.fst_sigma_map multispan_index.snd_sigma_map,
-    simp only [opens.inclusion_to_fun, Top.comp_app, sigma_iso_sigma_inv_apply,
+    simp only [opens.inclusion_apply, Top.comp_app, sigma_iso_sigma_inv_apply,
       category_theory.limits.colimit.ι_desc_apply, cofan.mk_ι_app,
       sigma_iso_sigma_hom_ι_apply, continuous_map.to_fun_eq_coe],
     erw [sigma_iso_sigma_hom_ι_apply, sigma_iso_sigma_hom_ι_apply],


### PR DESCRIPTION
This improves the names of some generated lemmas for `continuous_map` and `quadratic_form`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
