### PR TITLE
[Merged by Bors] - doc(tactic/wlog): use markdown lists rather than indentation

### DIFF
--- a/src/tactic/wlog.lean
+++ b/src/tactic/wlog.lean
@@ -101,43 +101,43 @@ private meta def parse_permutations : option (list (list name)) → tactic (list
 Given a goal of the form `g xs`, a predicate `p` over a set of variables, as well as variable
 permutations `xs_i`. Then `wlog` produces goals of the form
 
-The case goal, i.e. the permutation `xs_i` covers all possible cases:
+* The case goal, i.e. the permutation `xs_i` covers all possible cases:
   `⊢ p xs_0 ∨ ⋯ ∨ p xs_n`
-The main goal, i.e. the goal reduced to `xs_0`:
+* The main goal, i.e. the goal reduced to `xs_0`:
   `(h : p xs_0) ⊢ g xs_0`
-The invariant goals, i.e. `g` is invariant under `xs_i`:
+* The invariant goals, i.e. `g` is invariant under `xs_i`:
   `(h : p xs_i) (this : g xs_0) ⊢ gs xs_i`
 
 Either the permutation is provided, or a proof of the disjunction is provided to compute the
 permutation. The disjunction need to be in assoc normal form, e.g. `p₀ ∨ (p₁ ∨ p₂)`. In many cases
 the invariant goals can be solved by AC rewriting using `cc` etc.
 
-Example:
-  On a state `(n m : ℕ) ⊢ p n m` the tactic `wlog h : n ≤ m using [n m, m n]` produces the following
-  states:
-    `(n m : ℕ) ⊢ n ≤ m ∨ m ≤ n`
-    `(n m : ℕ) (h : n ≤ m) ⊢ p n m`
-    `(n m : ℕ) (h : m ≤ n) (this : p n m) ⊢ p m n`
+For example, on a state `(n m : ℕ) ⊢ p n m` the tactic `wlog h : n ≤ m using [n m, m n]` produces
+the following states:
+* `(n m : ℕ) ⊢ n ≤ m ∨ m ≤ n`
+* `(n m : ℕ) (h : n ≤ m) ⊢ p n m`
+* `(n m : ℕ) (h : m ≤ n) (this : p n m) ⊢ p m n`
 
 `wlog` supports different calling conventions. The name `h` is used to give a name to the introduced
 case hypothesis. If the name is avoided, the default will be `case`.
 
-(1) `wlog : p xs0 using [xs0, …, xsn]`
-  Results in the case goal `p xs0 ∨ ⋯ ∨ ps xsn`, the main goal `(case : p xs0) ⊢ g xs0` and the
-  invariance goals `(case : p xsi) (this : g xs0) ⊢ g xsi`.
+1. `wlog : p xs0 using [xs0, …, xsn]`
+   Results in the case goal `p xs0 ∨ ⋯ ∨ ps xsn`, the main goal `(case : p xs0) ⊢ g xs0` and the
+   invariance goals `(case : p xsi) (this : g xs0) ⊢ g xsi`.
 
-(2) `wlog : p xs0 := r using xs0`
-  The expression `r` is a proof of the shape `p xs0 ∨ ⋯ ∨ p xsi`, it is also used to compute the
-  variable permutations.
+2. `wlog : p xs0 := r using xs0`  
+   The expression `r` is a proof of the shape `p xs0 ∨ ⋯ ∨ p xsi`, it is also used to compute the
+   variable permutations.
 
-(3) `wlog := r using xs0`
-  The expression `r` is a proof of the shape `p xs0 ∨ ⋯ ∨ p xsi`, it is also used to compute the
-  variable permutations. This is not as stable as (2), for example `p` cannot be a disjunction.
+3. `wlog := r using xs0`
+   The expression `r` is a proof of the shape `p xs0 ∨ ⋯ ∨ p xsi`, it is also used to compute the
+   variable permutations. This is not as stable as (2), for example `p` cannot be a disjunction.
 
-(4) `wlog : R x y using x y` and `wlog : R x y`
-  Produces the case `R x y ∨ R y x`. If `R` is ≤, then the disjunction discharged using linearity.
-  If `using x y` is avoided then `x` and `y` are the last two variables appearing in the
-  expression `R x y`. -/
+4. `wlog : R x y using x y` and `wlog : R x y`
+   Produces the case `R x y ∨ R y x`. If `R` is ≤, then the disjunction discharged using linearity.
+   If `using x y` is avoided then `x` and `y` are the last two variables appearing in the
+   expression `R x y`.
+-/
 meta def wlog
   (h : parse ident?)
   (pat : parse (tk ":" *> texpr)?)

--- a/src/tactic/wlog.lean
+++ b/src/tactic/wlog.lean
@@ -121,7 +121,7 @@ the following states:
 `wlog` supports different calling conventions. The name `h` is used to give a name to the introduced
 case hypothesis. If the name is avoided, the default will be `case`.
 
-1. `wlog : p xs0 using [xs0, …, xsn]`
+1. `wlog : p xs0 using [xs0, …, xsn]`  
    Results in the case goal `p xs0 ∨ ⋯ ∨ ps xsn`, the main goal `(case : p xs0) ⊢ g xs0` and the
    invariance goals `(case : p xsi) (this : g xs0) ⊢ g xsi`.
 
@@ -129,11 +129,11 @@ case hypothesis. If the name is avoided, the default will be `case`.
    The expression `r` is a proof of the shape `p xs0 ∨ ⋯ ∨ p xsi`, it is also used to compute the
    variable permutations.
 
-3. `wlog := r using xs0`
+3. `wlog := r using xs0`  
    The expression `r` is a proof of the shape `p xs0 ∨ ⋯ ∨ p xsi`, it is also used to compute the
    variable permutations. This is not as stable as (2), for example `p` cannot be a disjunction.
 
-4. `wlog : R x y using x y` and `wlog : R x y`
+4. `wlog : R x y using x y` and `wlog : R x y`  
    Produces the case `R x y ∨ R y x`. If `R` is ≤, then the disjunction discharged using linearity.
    If `using x y` is avoided then `x` and `y` are the last two variables appearing in the
    expression `R x y`.


### PR DESCRIPTION
The indentation used in this docstring was lost in the web docs.



---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)

Preview: https://observablehq.com/@bryangingechen/github-lean-doc-preview?url=%2215113%22#docs