### PR TITLE
[Merged by Bors] - feat(geometry/manifold/local_invariant_properties): simplify definitions and proofs

### DIFF
--- a/src/geometry/manifold/charted_space.lean
+++ b/src/geometry/manifold/charted_space.lean
@@ -497,6 +497,9 @@ variables (H) [topological_space H] [topological_space M] [charted_space H M]
 lemma mem_chart_target (x : M) : chart_at H x x ∈ (chart_at H x).target :=
 (chart_at H x).map_source (mem_chart_source _ _)
 
+lemma chart_source_mem_nhds (x : M) : (chart_at H x).source ∈ 𝓝 x :=
+(chart_at H x).open_source.mem_nhds $ mem_chart_source H x
+
 open topological_space
 
 lemma charted_space.second_countable_of_countable_cover [second_countable_topology H]

--- a/src/geometry/manifold/charted_space.lean
+++ b/src/geometry/manifold/charted_space.lean
@@ -500,6 +500,9 @@ lemma mem_chart_target (x : M) : chart_at H x x ∈ (chart_at H x).target :=
 lemma chart_source_mem_nhds (x : M) : (chart_at H x).source ∈ 𝓝 x :=
 (chart_at H x).open_source.mem_nhds $ mem_chart_source H x
 
+lemma chart_target_mem_nhds (x : M) : (chart_at H x).target ∈ 𝓝 (chart_at H x x) :=
+(chart_at H x).open_target.mem_nhds $ mem_chart_target H x
+
 open topological_space
 
 lemma charted_space.second_countable_of_countable_cover [second_countable_topology H]
@@ -519,8 +522,7 @@ lemma charted_space.second_countable_of_sigma_compact [second_countable_topology
   second_countable_topology M :=
 begin
   obtain ⟨s, hsc, hsU⟩ : ∃ s, set.countable s ∧ (⋃ x (hx : x ∈ s), (chart_at H x).source) = univ :=
-    countable_cover_nhds_of_sigma_compact
-      (λ x : M, is_open.mem_nhds (chart_at H x).open_source (mem_chart_source H x)),
+    countable_cover_nhds_of_sigma_compact (λ x : M, chart_source_mem_nhds H x),
   exact charted_space.second_countable_of_countable_cover H hsU hsc
 end
 
@@ -536,7 +538,7 @@ begin
   { intro x,
     rw [← (chart_at H x).symm_map_nhds_eq (mem_chart_source H x)],
     exact ((compact_basis_nhds (chart_at H x x)).has_basis_self_subset
-      (is_open.mem_nhds (chart_at H x).open_target (mem_chart_target H x))).map _ },
+      (chart_target_mem_nhds H x)).map _ },
   refine locally_compact_space_of_has_basis this _,
   rintro x s ⟨h₁, h₂, h₃⟩,
   exact h₂.image_of_continuous_on ((chart_at H x).continuous_on_symm.mono h₃)

--- a/src/geometry/manifold/cont_mdiff.lean
+++ b/src/geometry/manifold/cont_mdiff.lean
@@ -254,7 +254,7 @@ iff.rfl
 
 /-- One can reformulate smoothness within a set at a point as continuity within this set at this
 point, and smoothness in the corresponding extended chart. This form states smoothness of `f`
-written om sicj a way that the set is restrited to lie within the domain/codomain of the
+written in such a way that the set is restricted to lie within the domain/codomain of the
 corresponding charts.
 Even though this expression is more complicated than the one in `cont_mdiff_within_at_iff`, it is
 a smaller set, but their germs at `ext_chart_at I x x` are equal. It is sometimes useful to rewrite
@@ -270,7 +270,6 @@ begin
   rw [cont_mdiff_within_at_iff, and.congr_right_iff],
   set e := ext_chart_at I x, set e' := ext_chart_at I' (f x),
   refine λ hc, cont_diff_within_at_congr_nhds _,
-  -- [⇑(e.symm) ⁻¹' s ∩ range ⇑I] ⇑e x' = 𝓝[e.target ∩ ⇑(e.symm) ⁻¹' (s ∩ f ⁻¹' (ext_chart_at I' y).source)] ⇑e x'
   rw [← e.image_source_inter_eq', ← ext_chart_at_map_nhds_within_eq_image,
       ← ext_chart_at_map_nhds_within, inter_comm, nhds_within_inter_of_mem],
   exact hc (ext_chart_at_source_mem_nhds _ _)
@@ -340,7 +339,7 @@ begin
   exact hc ((ext_chart_at_open_source _ _).mem_nhds hy)
 end
 
-lemma cont_mdiff_at_iff' {x' : M} {y : M'} (hx : x' ∈ (chart_at H x).source)
+lemma cont_mdiff_at_iff_of_mem_source {x' : M} {y : M'} (hx : x' ∈ (chart_at H x).source)
   (hy : f x' ∈ (chart_at H' y).source) :
   cont_mdiff_at I I' n f x' ↔ continuous_at f x' ∧
     cont_diff_within_at 𝕜 n (ext_chart_at I' y ∘ f ∘ (ext_chart_at I x).symm)
@@ -354,7 +353,7 @@ omit I's
 lemma cont_mdiff_at_ext_chart_at' {x' : M} (h : x' ∈ (chart_at H x).source) :
   cont_mdiff_at I 𝓘(𝕜, E) n (ext_chart_at I x) x' :=
 begin
-  refine (cont_mdiff_at_iff' h (mem_chart_source _ _)).mpr _,
+  refine (cont_mdiff_at_iff_of_mem_source h (mem_chart_source _ _)).mpr _,
   rw [← ext_chart_at_source I] at h,
   refine ⟨ext_chart_at_continuous_at' _ _ h, _⟩,
   refine cont_diff_within_at_id.congr_of_eventually_eq _ _,

--- a/src/geometry/manifold/cont_mdiff.lean
+++ b/src/geometry/manifold/cont_mdiff.lean
@@ -130,7 +130,7 @@ lemma cont_diff_within_at_local_invariant_prop (n : with_top ℕ) :
     { assume y hy, simp only with mfld_simps at hy, simpa only [hy] with mfld_simps using hs hy.1 }
   end }
 
-lemma cont_diff_within_at_local_invariant_prop_mono (n : with_top ℕ)
+lemma cont_diff_within_at_prop_mono (n : with_top ℕ)
   ⦃s x t⦄ ⦃f : H → H'⦄ (hts : t ⊆ s) (h : cont_diff_within_at_prop I I' n f s x) :
   cont_diff_within_at_prop I I' n f t x :=
 begin
@@ -139,7 +139,7 @@ begin
   simp only [hy, hts _] with mfld_simps
 end
 
-lemma cont_diff_within_at_local_invariant_prop_id (x : H) :
+lemma cont_diff_within_at_prop_id (x : H) :
   cont_diff_within_at_prop I I ∞ id univ x :=
 begin
   simp [cont_diff_within_at_prop],
@@ -253,6 +253,30 @@ lemma cont_mdiff_within_at_iff :
 iff.rfl
 
 /-- One can reformulate smoothness within a set at a point as continuity within this set at this
+point, and smoothness in the corresponding extended chart. This form states smoothness of `f`
+written om sicj a way that the set is restrited to lie within the domain/codomain of the
+corresponding charts.
+Even though this expression is more complicated than the one in `cont_mdiff_within_at_iff`, it is
+a smaller set, but their germs at `ext_chart_at I x x` are equal. It is sometimes useful to rewrite
+using this in the goal.
+-/
+lemma cont_mdiff_within_at_iff' :
+  cont_mdiff_within_at I I' n f s x ↔ continuous_within_at f s x ∧
+    cont_diff_within_at 𝕜 n ((ext_chart_at I' (f x)) ∘ f ∘ (ext_chart_at I x).symm)
+    ((ext_chart_at I x).target ∩
+      (ext_chart_at I x).symm ⁻¹' (s ∩ f ⁻¹' (ext_chart_at I' (f x)).source))
+    (ext_chart_at I x x) :=
+begin
+  rw [cont_mdiff_within_at_iff, and.congr_right_iff],
+  set e := ext_chart_at I x, set e' := ext_chart_at I' (f x),
+  refine λ hc, cont_diff_within_at_congr_nhds _,
+  -- [⇑(e.symm) ⁻¹' s ∩ range ⇑I] ⇑e x' = 𝓝[e.target ∩ ⇑(e.symm) ⁻¹' (s ∩ f ⁻¹' (ext_chart_at I' y).source)] ⇑e x'
+  rw [← e.image_source_inter_eq', ← ext_chart_at_map_nhds_within_eq_image,
+      ← ext_chart_at_map_nhds_within, inter_comm, nhds_within_inter_of_mem],
+  exact hc (ext_chart_at_source_mem_nhds _ _)
+end
+
+/-- One can reformulate smoothness within a set at a point as continuity within this set at this
 point, and smoothness in the corresponding extended chart in the target. -/
 lemma cont_mdiff_within_at_iff_target :
   cont_mdiff_within_at I I' n f s x ↔ continuous_within_at f s x ∧
@@ -287,8 +311,8 @@ cont_mdiff_within_at_iff_target
 include Is I's
 
 /-- One can reformulate smoothness within a set at a point as continuity within this set at this
-point, and smoothness in the corresponding extended chart. -/
-lemma cont_mdiff_within_at_iff' {x' : M} {y : M'} (hx : x' ∈ (chart_at H x).source)
+point, and smoothness in any chart containing that point. -/
+lemma cont_mdiff_within_at_iff_of_mem_source {x' : M} {y : M'} (hx : x' ∈ (chart_at H x).source)
   (hy : f x' ∈ (chart_at H' y).source) :
   cont_mdiff_within_at I I' n f s x' ↔ continuous_within_at f s x' ∧
     cont_diff_within_at 𝕜 n (ext_chart_at I' y ∘ f ∘ (ext_chart_at I x).symm)
@@ -298,13 +322,31 @@ lemma cont_mdiff_within_at_iff' {x' : M} {y : M'} (hx : x' ∈ (chart_at H x).so
   (structure_groupoid.chart_mem_maximal_atlas _ x) hx
   (structure_groupoid.chart_mem_maximal_atlas _ y) hy
 
+lemma cont_mdiff_within_at_iff_of_mem_source' {x' : M} {y : M'} (hx : x' ∈ (chart_at H x).source)
+  (hy : f x' ∈ (chart_at H' y).source) :
+  cont_mdiff_within_at I I' n f s x' ↔ continuous_within_at f s x' ∧
+    cont_diff_within_at 𝕜 n ((ext_chart_at I' y) ∘ f ∘ (ext_chart_at I x).symm)
+    ((ext_chart_at I x).target ∩ (ext_chart_at I x).symm ⁻¹' (s ∩ f ⁻¹' (ext_chart_at I' y).source))
+    (ext_chart_at I x x') :=
+begin
+  refine (cont_mdiff_within_at_iff_of_mem_source hx hy).trans _,
+  rw [← ext_chart_at_source I] at hx,
+  rw [← ext_chart_at_source I'] at hy,
+  rw [and.congr_right_iff],
+  set e := ext_chart_at I x, set e' := ext_chart_at I' (f x),
+  refine λ hc, cont_diff_within_at_congr_nhds _,
+  rw [← e.image_source_inter_eq', ← ext_chart_at_map_nhds_within_eq_image' I x hx,
+      ← ext_chart_at_map_nhds_within' I x hx, inter_comm, nhds_within_inter_of_mem],
+  exact hc ((ext_chart_at_open_source _ _).mem_nhds hy)
+end
+
 lemma cont_mdiff_at_iff' {x' : M} {y : M'} (hx : x' ∈ (chart_at H x).source)
   (hy : f x' ∈ (chart_at H' y).source) :
   cont_mdiff_at I I' n f x' ↔ continuous_at f x' ∧
     cont_diff_within_at 𝕜 n (ext_chart_at I' y ∘ f ∘ (ext_chart_at I x).symm)
     (range I)
     (ext_chart_at I x x') :=
-(cont_mdiff_within_at_iff' hx hy).trans $
+(cont_mdiff_within_at_iff_of_mem_source hx hy).trans $
   by rw [continuous_within_at_univ, preimage_univ, univ_inter]
 
 omit I's
@@ -335,7 +377,7 @@ lemma cont_mdiff_on_iff :
       (ext_chart_at I x).symm ⁻¹' (s ∩ f ⁻¹' (ext_chart_at I' y).source)) :=
 begin
   split,
-  sorry { assume h,
+  { assume h,
     refine ⟨λ x hx, (h x hx).1, λ x y z hz, _⟩,
     simp only with mfld_simps at hz,
     let w := (ext_chart_at I x).symm z,
@@ -343,14 +385,15 @@ begin
     specialize h w this,
     have w1 : w ∈ (chart_at H x).source, by simp only [w, hz] with mfld_simps,
     have w2 : f w ∈ (chart_at H' y).source, by simp only [w, hz] with mfld_simps,
-    convert ((cont_mdiff_within_at_iff' w1 w2).mp h).2.mono _,
+    convert ((cont_mdiff_within_at_iff_of_mem_source w1 w2).mp h).2.mono _,
     { simp only [w, hz] with mfld_simps },
     { mfld_set_tac } },
   { rintros ⟨hcont, hdiff⟩ x hx,
-    refine ⟨hcont x hx, _⟩,
-    refine (hdiff x (f x) (ext_chart_at I x x) (by simp only [hx] with mfld_simps)).mono_of_mem _,
-    sorry
-    }
+    refine ((cont_diff_within_at_local_invariant_prop I I' n).lift_prop_within_at_iff $
+      hcont x hx).mpr _,
+    dsimp [cont_diff_within_at_prop],
+    convert hdiff x (f x) (ext_chart_at I x x) (by simp only [hx] with mfld_simps) using 1,
+    mfld_set_tac }
 end
 
 /-- One can reformulate smoothness on a set as continuity on this set, and smoothness in any
@@ -543,7 +586,7 @@ end
 lemma cont_mdiff_within_at.mono (hf : cont_mdiff_within_at I I' n f s x) (hts : t ⊆ s) :
   cont_mdiff_within_at I I' n f t x :=
 structure_groupoid.local_invariant_prop.lift_prop_within_at_mono
-  (cont_diff_within_at_local_invariant_prop_mono I I' n) hf hts
+  (cont_diff_within_at_prop_mono I I' n) hf hts
 
 lemma cont_mdiff_at.cont_mdiff_within_at (hf : cont_mdiff_at I I' n f x) :
   cont_mdiff_within_at I I' n f s x :=
@@ -611,8 +654,7 @@ begin
       { assume y hy, exact hy.2 },
       { assume y hy, exact hu ⟨hy.1.1, hy.2⟩ } },
     have h' : cont_mdiff_within_at I I' n f (s ∩ o) x := h.mono (inter_subset_left _ _),
-    simp only [cont_mdiff_within_at, lift_prop_within_at, cont_diff_within_at_prop]
-      at h',
+    simp only [cont_mdiff_within_at, lift_prop_within_at, cont_diff_within_at_prop] at h',
     -- let `u` be a good neighborhood in the chart where the function is smooth
     rcases h.2.cont_diff_on le_rfl with ⟨u, u_nhds, u_subset, hu⟩,
     -- pull it back to the manifold, and intersect with a suitable neighborhood of `x`, to get the
@@ -638,11 +680,7 @@ begin
       { simp only [mem_insert_iff, ho hy.2, h', h'o ⟨hy.2, h'⟩] with mfld_simps } },
     show cont_mdiff_on I I' n f v,
     { assume y hy,
-      apply
-        (((cont_diff_within_at_local_invariant_prop I I' n).lift_prop_within_at_indep_chart
-        (structure_groupoid.chart_mem_maximal_atlas _ x) (v_incl hy)
-        (structure_groupoid.chart_mem_maximal_atlas _ (f x)) (v_incl' y hy))).2,
-      split,
+      have : continuous_within_at f v y,
       { apply (((ext_chart_at_continuous_on_symm I' (f x) _ _).comp'
           (hu _ hy.2).continuous_within_at).comp' (ext_chart_at_continuous_on I x _ _)).congr_mono,
         { assume z hz,
@@ -653,6 +691,7 @@ begin
         { simp only [v_incl hy, v_incl' y hy] with mfld_simps },
         { simp only [v_incl hy, v_incl' y hy] with mfld_simps },
         { simp only [v_incl hy] with mfld_simps } },
+      refine (cont_mdiff_within_at_iff_of_mem_source' (v_incl hy) (v_incl' y hy)).mpr ⟨this, _⟩,
       { apply hu.mono,
         { assume z hz,
           simp only [v] with mfld_simps at hz,
@@ -846,14 +885,14 @@ lemma cont_mdiff_on_of_mem_maximal_atlas
   (h : e ∈ maximal_atlas I M) : cont_mdiff_on I I n e e.source :=
 cont_mdiff_on.of_le
   ((cont_diff_within_at_local_invariant_prop I I ∞).lift_prop_on_of_mem_maximal_atlas
-    (cont_diff_within_at_local_invariant_prop_id I) h) le_top
+    (cont_diff_within_at_prop_id I) h) le_top
 
 /-- The inverse of an atlas member is `C^n` for any `n`. -/
 lemma cont_mdiff_on_symm_of_mem_maximal_atlas
   (h : e ∈ maximal_atlas I M) : cont_mdiff_on I I n e.symm e.target :=
 cont_mdiff_on.of_le
   ((cont_diff_within_at_local_invariant_prop I I ∞).lift_prop_on_symm_of_mem_maximal_atlas
-    (cont_diff_within_at_local_invariant_prop_id I) h) le_top
+    (cont_diff_within_at_prop_id I) h) le_top
 
 lemma cont_mdiff_on_chart :
   cont_mdiff_on I I n (chart_at H x) (chart_at H x).source :=
@@ -872,7 +911,7 @@ section id
 
 lemma cont_mdiff_id : cont_mdiff I I n (id : M → M) :=
 cont_mdiff.of_le ((cont_diff_within_at_local_invariant_prop I I ∞).lift_prop_id
-  (cont_diff_within_at_local_invariant_prop_id I)) le_top
+  (cont_diff_within_at_prop_id I)) le_top
 
 lemma smooth_id : smooth I I (id : M → M) := cont_mdiff_id
 
@@ -1371,7 +1410,7 @@ lemma cont_mdiff_proj :
   cont_mdiff (I.prod 𝓘(𝕜, E')) I n Z.to_topological_vector_bundle_core.proj :=
 begin
   assume x,
-  rw [cont_mdiff_at, cont_mdiff_within_at_iff],
+  rw [cont_mdiff_at, cont_mdiff_within_at_iff'],
   refine ⟨Z.to_topological_vector_bundle_core.continuous_proj.continuous_within_at, _⟩,
   simp only [(∘), chart_at, chart] with mfld_simps,
   apply cont_diff_within_at_fst.congr,
@@ -1427,7 +1466,7 @@ lemma smooth_const_section (v : E')
     (show M → Z.to_topological_vector_bundle_core.total_space, from λ x, ⟨x, v⟩) :=
 begin
   assume x,
-  rw [cont_mdiff_at, cont_mdiff_within_at_iff],
+  rw [cont_mdiff_at, cont_mdiff_within_at_iff'],
   split,
   { apply continuous.continuous_within_at,
     apply topological_fiber_bundle_core.continuous_const_section,
@@ -1662,7 +1701,7 @@ section projections
 lemma cont_mdiff_within_at_fst {s : set (M × N)} {p : M × N} :
   cont_mdiff_within_at (I.prod J) I n prod.fst s p :=
 begin
-  rw cont_mdiff_within_at_iff,
+  rw cont_mdiff_within_at_iff',
   refine ⟨continuous_within_at_fst, _⟩,
   refine cont_diff_within_at_fst.congr (λ y hy, _) _,
   { simp only with mfld_simps at hy,
@@ -1701,7 +1740,7 @@ cont_mdiff_fst
 lemma cont_mdiff_within_at_snd {s : set (M × N)} {p : M × N} :
   cont_mdiff_within_at (I.prod J) J n prod.snd s p :=
 begin
-  rw cont_mdiff_within_at_iff,
+  rw cont_mdiff_within_at_iff',
   refine ⟨continuous_within_at_snd, _⟩,
   refine cont_diff_within_at_snd.congr (λ y hy, _) _,
   { simp only with mfld_simps at hy,

--- a/src/geometry/manifold/diffeomorph.lean
+++ b/src/geometry/manifold/diffeomorph.lean
@@ -398,7 +398,7 @@ def to_trans_diffeomorph (e : E ≃ₘ[𝕜] F) : M ≃ₘ⟮I, I.trans_diffeomo
 { to_equiv := equiv.refl M,
   cont_mdiff_to_fun := λ x,
     begin
-      refine cont_mdiff_within_at_iff.2 ⟨continuous_within_at_id, _⟩,
+      refine cont_mdiff_within_at_iff'.2 ⟨continuous_within_at_id, _⟩,
       refine e.cont_diff.cont_diff_within_at.congr' (λ y hy, _) _,
       { simp only [equiv.coe_refl, id, (∘), I.coe_ext_chart_at_trans_diffeomorph,
           (ext_chart_at I x).right_inv hy.1] },
@@ -407,7 +407,7 @@ def to_trans_diffeomorph (e : E ≃ₘ[𝕜] F) : M ≃ₘ⟮I, I.trans_diffeomo
     end,
   cont_mdiff_inv_fun := λ x,
     begin
-      refine cont_mdiff_within_at_iff.2 ⟨continuous_within_at_id, _⟩,
+      refine cont_mdiff_within_at_iff'.2 ⟨continuous_within_at_id, _⟩,
       refine e.symm.cont_diff.cont_diff_within_at.congr' (λ y hy, _) _,
       { simp only [mem_inter_eq, I.ext_chart_at_trans_diffeomorph_target] at hy,
         simp only [equiv.coe_refl, equiv.refl_symm, id, (∘),

--- a/src/geometry/manifold/local_invariant_properties.lean
+++ b/src/geometry/manifold/local_invariant_properties.lean
@@ -45,7 +45,7 @@ in the one for `lift_prop_within_at`.
 noncomputable theory
 open_locale classical manifold topological_space
 
-open set
+open set filter
 
 variables {H : Type*} {M : Type*} [topological_space H] [topological_space M] [charted_space H M]
 {H' : Type*} {M' : Type*} [topological_space H'] [topological_space M'] [charted_space H' M']
@@ -61,12 +61,14 @@ to charted spaces admitting these groupoids will inherit the good behavior. -/
 structure local_invariant_prop (P : (H → H') → (set H) → H → Prop) : Prop :=
 (is_local : ∀ {s x u} {f : H → H'}, is_open u → x ∈ u → (P f s x ↔ P f (s ∩ u) x))
 (right_invariance : ∀ {s x f} {e : local_homeomorph H H}, e ∈ G → x ∈ e.source → P f s x →
-                      P (f ∘ e.symm) (e.target ∩ e.symm ⁻¹' s) (e x))
-(congr : ∀ {s x} {f g : H → H'}, (∀ y ∈ s, f y = g y) → (f x = g x) → P f s x → P g s x)
-(left_invariance : ∀ {s x f} {e' : local_homeomorph H' H'}, e' ∈ G' → s ⊆ f ⁻¹' (e'.source) →
+                      P (f ∘ e.symm) (e.symm ⁻¹' s) (e x))
+(congr_of_forall : ∀ {s x} {f g : H → H'}, (∀ y ∈ s, f y = g y) → f x = g x → P f s x → P g s x)
+(left_invariance' : ∀ {s x f} {e' : local_homeomorph H' H'}, e' ∈ G' → s ⊆ f ⁻¹' e'.source →
                      f x ∈ e'.source → P f s x → P (e' ∘ f) s x)
 
 end structure_groupoid
+
+namespace charted_space
 
 /-- Given a property of germs of functions and sets in the model space, then one defines
 a corresponding property in a charted space, by requiring that it holds at the preferred chart at
@@ -74,31 +76,40 @@ this point. (When the property is local and invariant, it will in fact hold usin
 `lift_prop_within_at_indep_chart`). We require continuity in the lifted property, as otherwise one
 single chart might fail to capture the behavior of the function.
 -/
-def charted_space.lift_prop_within_at (P : (H → H') → set H → H → Prop)
+def lift_prop_within_at (P : (H → H') → set H → H → Prop)
   (f : M → M') (s : set M) (x : M) : Prop :=
 continuous_within_at f s x ∧
-P ((chart_at H' (f x)) ∘ f ∘ (chart_at H x).symm)
-  ((chart_at H x).target ∩ (chart_at H x).symm ⁻¹' (s ∩ f ⁻¹' (chart_at H' (f x)).source))
-  (chart_at H x x)
+P (chart_at H' (f x) ∘ f ∘ (chart_at H x).symm) ((chart_at H x).symm ⁻¹' s) (chart_at H x x)
 
 /-- Given a property of germs of functions and sets in the model space, then one defines
 a corresponding property of functions on sets in a charted space, by requiring that it holds
 around each point of the set, in the preferred charts. -/
-def charted_space.lift_prop_on (P : (H → H') → set H → H → Prop) (f : M → M') (s : set M) :=
-∀ x ∈ s, charted_space.lift_prop_within_at P f s x
+def lift_prop_on (P : (H → H') → set H → H → Prop) (f : M → M') (s : set M) :=
+∀ x ∈ s, lift_prop_within_at P f s x
 
 /-- Given a property of germs of functions and sets in the model space, then one defines
 a corresponding property of a function at a point in a charted space, by requiring that it holds
 in the preferred chart. -/
-def charted_space.lift_prop_at (P : (H → H') → set H → H → Prop) (f : M → M') (x : M) :=
-charted_space.lift_prop_within_at P f univ x
+def lift_prop_at (P : (H → H') → set H → H → Prop) (f : M → M') (x : M) :=
+lift_prop_within_at P f univ x
+
+lemma lift_prop_at_iff {P : (H → H') → set H → H → Prop} {f : M → M'} {x : M} :
+  lift_prop_at P f x ↔ continuous_at f x ∧
+  P (chart_at H' (f x) ∘ f ∘ (chart_at H x).symm) univ (chart_at H x x) :=
+by rw [lift_prop_at, lift_prop_within_at, continuous_within_at_univ, preimage_univ]
 
 /-- Given a property of germs of functions and sets in the model space, then one defines
 a corresponding property of a function in a charted space, by requiring that it holds
 in the preferred chart around every point. -/
-def charted_space.lift_prop (P : (H → H') → set H → H → Prop) (f : M → M') :=
-∀ x, charted_space.lift_prop_at P f x
+def lift_prop (P : (H → H') → set H → H → Prop) (f : M → M') :=
+∀ x, lift_prop_at P f x
 
+lemma lift_prop_iff {P : (H → H') → set H → H → Prop} {f : M → M'} :
+  lift_prop P f ↔ continuous f ∧
+  ∀ x, P (chart_at H' (f x) ∘ f ∘ (chart_at H x).symm) univ (chart_at H x x) :=
+by simp_rw [lift_prop, lift_prop_at_iff, forall_and_distrib, continuous_iff_continuous_at]
+
+end charted_space
 open charted_space
 
 namespace structure_groupoid
@@ -108,18 +119,107 @@ variables {G : structure_groupoid H} {G' : structure_groupoid H'}
 {P : (H → H') → set H → H → Prop} {g g' : M → M'} {s t : set M} {x : M}
 {Q : (H → H) → set H → H → Prop}
 
-lemma lift_prop_within_at_univ :
-  lift_prop_within_at P g univ x ↔ lift_prop_at P g x :=
+lemma lift_prop_within_at_univ : lift_prop_within_at P g univ x ↔ lift_prop_at P g x :=
 iff.rfl
 
-lemma lift_prop_on_univ :
-  lift_prop_on P g univ ↔ lift_prop P g :=
+lemma lift_prop_on_univ : lift_prop_on P g univ ↔ lift_prop P g :=
 by simp [lift_prop_on, lift_prop, lift_prop_at]
 
 namespace local_invariant_prop
 
+lemma _root_.mem_nhds_within_iff_eventually : t ∈ 𝓝[s] x ↔ ∀ᶠ y in 𝓝 x, y ∈ s → y ∈ t :=
+begin
+  rw [mem_nhds_within_iff_exists_mem_nhds_inter],
+  split,
+  { rintro ⟨u, hu, hut⟩, exact eventually_of_mem hu (λ x hxu hxs, hut ⟨hxu, hxs⟩) },
+  { refine λ h, ⟨_, h, λ y hy, hy.1 hy.2⟩ }
+end
+
+lemma _root_.mem_nhds_within_iff_eventually_eq : t ∈ 𝓝[s] x ↔ s =ᶠ[𝓝 x] (s ∩ t : set M) :=
+by simp_rw [mem_nhds_within_iff_eventually, eventually_eq_set, mem_inter_iff, iff_self_and]
+
+lemma _root_.local_homeomorph.eventually_nhds (e : local_homeomorph H H') {x : H} (p : H' → Prop)
+  (hx : x ∈ e.source) : (∀ᶠ y in 𝓝 (e x), p y) ↔ ∀ᶠ x in 𝓝 x, p (e x) :=
+begin
+  refine ⟨(e.continuous_at hx).eventually, _⟩,
+  intro h,
+  rw [← e.left_inv hx] at h,
+  filter_upwards [(e.symm.continuous_at $ e.maps_to hx).eventually h,
+    e.eventually_right_inverse' hx],
+  intros y hy heq,
+  rwa [heq] at hy
+end
+
+lemma _root_.local_homeomorph.eventually_nhds' (e : local_homeomorph H H') {x : H} (p : H → Prop)
+  (hx : x ∈ e.source) : (∀ᶠ y in 𝓝 (e x), p (e.symm y)) ↔ ∀ᶠ x in 𝓝 x, p x :=
+begin
+  rw [e.eventually_nhds _ hx],
+  refine eventually_congr ((e.eventually_left_inverse hx).mono $ λ y hy, _),
+  rw [hy]
+end
+
+lemma _root_.local_homeomorph.eventually_nhds_within (e : local_homeomorph H H') {x : H}
+  (p : H' → Prop) {s : set H}
+  (hx : x ∈ e.source) : (∀ᶠ y in 𝓝[e.symm ⁻¹' s] (e x), p y) ↔ ∀ᶠ x in 𝓝[s] x, p (e x) :=
+begin
+  refine iff.trans _ eventually_map,
+  rw [e.map_nhds_within_eq hx, e.image_source_inter_eq', e.nhds_within_target_inter (e.maps_to hx)]
+end
+
+lemma _root_.local_homeomorph.eventually_nhds_within' (e : local_homeomorph H H') {x : H}
+  (p : H → Prop) {s : set H}
+  (hx : x ∈ e.source) : (∀ᶠ y in 𝓝[e.symm ⁻¹' s] (e x), p (e.symm y)) ↔ ∀ᶠ x in 𝓝[s] x, p x :=
+begin
+  rw [e.eventually_nhds_within _ hx],
+  refine eventually_congr ((eventually_nhds_within_of_eventually_nhds $
+    e.eventually_left_inverse hx).mono $ λ y hy, _),
+  rw [hy]
+end
+
 variable (hG : G.local_invariant_prop G' P)
 include hG
+
+lemma congr_set {s t : set H} {x : H} {f : H → H'} (hu : s =ᶠ[𝓝 x] t) :
+  P f s x ↔ P f t x :=
+begin
+  obtain ⟨o, host, ho, hxo⟩ := mem_nhds_iff.mp hu.mem_iff,
+  simp_rw [subset_def, mem_set_of, ← and.congr_left_iff, ← mem_inter_iff, ← set.ext_iff] at host,
+  rw [hG.is_local ho hxo, host, ← hG.is_local ho hxo]
+end
+
+lemma is_local_nhds {s u : set H} {x : H} {f : H → H'} (hu : u ∈ 𝓝[s] x) (hx : x ∈ u) :
+  P f s x ↔ P f (s ∩ u) x :=
+hG.congr_set $ mem_nhds_within_iff_eventually_eq.mp hu
+
+lemma left_invariance {s : set H} {x : H} {f : H → H'} {e' : local_homeomorph H' H'}
+  (he' : e' ∈ G') (hfs : continuous_within_at f s x) (hxe' : f x ∈ e'.source) (hP : P f s x) :
+  P (e' ∘ f) s x :=
+begin
+  rw [hG.is_local_nhds (hfs.preimage_mem_nhds_within $ e'.open_source.mem_nhds hxe') hxe'] at hP ⊢,
+  exact hG.left_invariance' he' (inter_subset_right _ _) hxe' hP
+end
+
+lemma congr_nhds_within {s : set H} {x : H} {f g : H → H'} (h1 : f =ᶠ[𝓝[s] x] g) (h2 : f x = g x)
+  (hP : P f s x) : P g s x :=
+by { rw [hG.is_local_nhds h1 h2] at hP ⊢, exact hG.congr_of_forall (λ y hy, hy.2) h2 hP }
+
+lemma congr_nhds_within' {s : set H} {x : H} {f g : H → H'} (h1 : f =ᶠ[𝓝[s] x] g) (h2 : f x = g x)
+  (hP : P g s x) : P f s x :=
+hG.congr_nhds_within h1.symm h2.symm hP
+
+lemma congr {s : set H} {x : H} {f g : H → H'} (h : f =ᶠ[𝓝 x] g) (hP : P f s x) : P g s x :=
+hG.congr_nhds_within (mem_nhds_within_of_mem_nhds h) (mem_of_mem_nhds h : _) hP
+
+lemma congr' {s : set H} {x : H} {f g : H → H'} (h : f =ᶠ[𝓝 x] g) (hP : P g s x) : P f s x :=
+hG.congr h.symm hP
+
+-- lemma congr_nhds_within {s : set H} {x : H} {f g : H → H'} (h1 : f =ᶠ[𝓝[s] x] g) (h2 : f x = g x) :
+--   P f s x ↔ P g s x :=
+-- by { simp_rw [hG.is_local_nhds h1 h2],
+--   exact ⟨hG.congr' (λ y hy, hy.2) h2, hG.congr' (λ y hy, hy.2.symm) h2.symm⟩ }
+
+-- lemma congr {s : set H} {x : H} {f g : H → H'} (h : f =ᶠ[𝓝 x] g) : P f s x ↔ P g s x :=
+-- hG.congr_nhds_within (mem_nhds_within_of_mem_nhds h) (mem_of_mem_nhds h : _)
 
 /-- If a property of a germ of function `g` on a pointed set `(s, x)` is invariant under the
 structure groupoid (by composition in the source space and in the target space), then
@@ -133,85 +233,46 @@ lemma lift_prop_within_at_indep_chart_aux
   (hf : f ∈ G'.maximal_atlas M') (xf : g x ∈ f.source)
   (hf' : f' ∈ G'.maximal_atlas M') (xf' : g x ∈ f'.source)
   (hgs : continuous_within_at g s x)
-  (h : P (f ∘ g ∘ e.symm) (e.symm ⁻¹' (s ∩ g⁻¹' f.source)) (e x)) :
-  P (f' ∘ g ∘ e'.symm) (e'.symm ⁻¹' (s ∩ g⁻¹' f'.source)) (e' x) :=
+  (h : P (f ∘ g ∘ e.symm) (e.symm ⁻¹' s) (e x)) :
+  P (f' ∘ g ∘ e'.symm) (e'.symm ⁻¹' s) (e' x) :=
 begin
-  obtain ⟨o, o_open, xo, oe, oe', of, of'⟩ :
-    ∃ (o : set M), is_open o ∧ x ∈ o ∧ o ⊆ e.source ∧ o ⊆ e'.source ∧
-      o ∩ s ⊆ g ⁻¹' f.source ∧ o ∩ s ⊆  g⁻¹' f'.to_local_equiv.source,
-  { have : f.source ∩ f'.source ∈ 𝓝 (g x) :=
-      is_open.mem_nhds (is_open.inter f.open_source f'.open_source) ⟨xf, xf'⟩,
-    rcases mem_nhds_within.1 (hgs.preimage_mem_nhds_within this) with ⟨u, u_open, xu, hu⟩,
-    refine ⟨u ∩ e.source ∩ e'.source, _, ⟨⟨xu, xe⟩, xe'⟩, _, _, _, _⟩,
-    { exact is_open.inter (is_open.inter u_open e.open_source) e'.open_source },
-    { assume x hx, exact hx.1.2 },
-    { assume x hx, exact hx.2 },
-    { assume x hx, exact (hu ⟨hx.1.1.1, hx.2⟩).1 },
-    { assume x hx, exact (hu ⟨hx.1.1.1, hx.2⟩).2 } },
-  have A : P (f ∘ g ∘ e.symm)
-             (e.symm ⁻¹' (s ∩ g⁻¹' f.source) ∩ (e.target ∩ e.symm ⁻¹' o)) (e x),
-  { apply (hG.is_local _ _).1 h,
-    { exact e.continuous_on_symm.preimage_open_of_open e.open_target o_open },
-    { simp only [xe, xo] with mfld_simps} },
-  have B : P ((f.symm ≫ₕ f') ∘ (f ∘ g ∘ e.symm))
-             (e.symm ⁻¹' (s ∩ g⁻¹' f.source) ∩ (e.target ∩ e.symm ⁻¹' o)) (e x),
-  { refine hG.left_invariance (compatible_of_mem_maximal_atlas hf hf') (λ y hy, _)
-      (by simp only [xe, xf, xf'] with mfld_simps) A,
-    simp only with mfld_simps at hy,
-    have : e.symm y ∈ o ∩ s, by simp only [hy] with mfld_simps,
-    simpa only [hy] with mfld_simps using of' this },
-  have C : P (f' ∘ g ∘ e.symm)
-             (e.target ∩ e.symm ⁻¹' (s ∩ g⁻¹' f.source) ∩ (e.target ∩ e.symm ⁻¹' o)) (e x),
-  { rw [inter_assoc, inter_comm e.target],
-    refine (hG.is_local e.open_target $ e.to_local_equiv.source_subset_preimage_target (oe xo)).1 _,
-    refine hG.congr (λ y hy, _) (by simp only [xe, xf] with mfld_simps) B,
-    simp only [local_homeomorph.coe_trans, function.comp_app],
-    rw f.left_inv,
-    apply of,
-    simp only with mfld_simps at hy,
-    simp only [hy] with mfld_simps },
+  have hcont : continuous_within_at (f ∘ g ∘ e.symm) (e.symm ⁻¹' s) (e x),
+  { rw [← e.left_inv xe] at hgs xf,
+    refine (f.continuous_at $ by exact xf).comp_continuous_within_at _,
+    exact hgs.comp (e.symm.continuous_at $ e.maps_to xe).continuous_within_at subset.rfl },
+  have A : P ((f.symm ≫ₕ f') ∘ (f ∘ g ∘ e.symm)) (e.symm ⁻¹' s) (e x),
+  { refine hG.left_invariance (compatible_of_mem_maximal_atlas hf hf') hcont
+      (by simp only [xe, xf, xf'] with mfld_simps) h },
+  have B : P (f' ∘ g ∘ e.symm) (e.symm ⁻¹' s) (e x),
+  { refine hG.congr_nhds_within _ (by simp only [xe, xf] with mfld_simps) A,
+    simp_rw [local_homeomorph.coe_trans, eventually_eq],
+    have := (e.eventually_nhds_within' _ xe).mpr (hgs.eventually $ f.eventually_left_inverse xf),
+    exact this.mono (λ y, congr_arg f') },
   let w := e.symm ≫ₕ e',
-  let ow := w.target ∩ w.symm ⁻¹'
-    (e.target ∩ e.symm ⁻¹' (s ∩ g⁻¹' f.source) ∩ (e.target ∩ e.symm ⁻¹' o)),
+  let ow := w.symm ⁻¹' (e.symm ⁻¹' s),
   have wG : w ∈ G := compatible_of_mem_maximal_atlas he he',
-  have D : P ((f' ∘ g ∘ e.symm) ∘ w.symm) ow (w (e x)) :=
-    hG.right_invariance wG (by simp only [w, xe, xe'] with mfld_simps) C,
-  have E : P (f' ∘ g ∘ e'.symm) ow (w (e x)),
-  { refine hG.congr _ (by simp only [xe, xe'] with mfld_simps) D,
-    assume y hy,
-    simp only with mfld_simps,
-    rw e.left_inv,
-    simp only with mfld_simps at hy,
-    simp only [hy] with mfld_simps },
-  have : w (e x) = e' x, by simp only [w, xe] with mfld_simps,
-  rw this at E,
-  have : ow = (e'.target ∩ e'.symm ⁻¹' (s ∩ g⁻¹' f'.source))
-               ∩ (w.target ∩ (e'.target ∩ e'.symm ⁻¹' o)),
-  { ext y,
-    split,
-    { assume hy,
-      have : e.symm (e ((e'.symm) y)) = e'.symm y,
-        by { simp only with mfld_simps at hy, simp only [hy] with mfld_simps },
-      simp only [this] with mfld_simps at hy,
-      have : g (e'.symm y) ∈ f'.source, by { apply of', simp only [hy] with mfld_simps },
-      simp only [hy, this] with mfld_simps },
-    { assume hy,
-      simp only with mfld_simps at hy,
-      have : g (e'.symm y) ∈ f.source, by { apply of, simp only [hy] with mfld_simps },
-      simp only [this, hy] with mfld_simps } },
-  rw this at E,
-  apply (hG.is_local _ _).2 E,
-  { exact is_open.inter w.open_target
-      (e'.continuous_on_symm.preimage_open_of_open e'.open_target o_open) },
-  { simp only [xe', xe, xo] with mfld_simps },
+  have C : P ((f' ∘ g ∘ e.symm) ∘ w.symm) ow (w (e x)) :=
+    hG.right_invariance wG (by simp only [w, xe, xe'] with mfld_simps) B,
+  have : ∀ y ∈ e.source, w (e y) = e' y := λ y hy, by simp only [w, hy] with mfld_simps,
+  rw [this x xe] at C,
+  have D : P (f' ∘ g ∘ e'.symm) ow (e' x),
+  { refine hG.congr _ C,
+    refine ((e'.eventually_nhds' _ xe').mpr $ e.eventually_left_inverse xe).mono (λ y hy, _),
+    simp only [w] with mfld_simps,
+    rw [hy] },
+  refine (hG.congr_set _).2 D,
+  refine (eventually_of_mem _ $ λ y (hy : y ∈ e'.symm ⁻¹' e.source), _).set_eq,
+  { refine (e'.symm.continuous_at $ e'.maps_to xe').preimage_mem_nhds (e.open_source.mem_nhds _),
+    simp_rw [e'.left_inv xe', xe] },
+  simp_rw [ow, mem_preimage, w, local_homeomorph.coe_trans_symm, local_homeomorph.symm_symm,
+    function.comp_apply, e.left_inv hy]
 end
 
 lemma lift_prop_within_at_indep_chart [has_groupoid M G] [has_groupoid M' G']
   (he : e ∈ G.maximal_atlas M) (xe : x ∈ e.source)
   (hf : f ∈ G'.maximal_atlas M') (xf : g x ∈ f.source) :
   lift_prop_within_at P g s x ↔
-    continuous_within_at g s x ∧ P (f ∘ g ∘ e.symm)
-      (e.target ∩ e.symm ⁻¹' (s ∩ g⁻¹' f.source)) (e x) :=
+    continuous_within_at g s x ∧ P (f ∘ g ∘ e.symm) (e.symm ⁻¹' s) (e x) :=
 ⟨λ H, ⟨H.1,
   hG.lift_prop_within_at_indep_chart_aux (chart_mem_maximal_atlas _ _) (mem_chart_source _ _) he xe
   (chart_mem_maximal_atlas _ _) (mem_chart_source _ _) hf xf H.1 H.2⟩,
@@ -221,46 +282,21 @@ lemma lift_prop_within_at_indep_chart [has_groupoid M G] [has_groupoid M' G']
 
 lemma lift_prop_on_indep_chart [has_groupoid M G] [has_groupoid M' G']
   (he : e ∈ G.maximal_atlas M) (hf : f ∈ G'.maximal_atlas M') (h : lift_prop_on P g s) :
-  ∀ y ∈ e.target ∩ e.symm ⁻¹' (s ∩ g ⁻¹' f.source),
-  P (f ∘ g ∘ e.symm) (e.target ∩ e.symm ⁻¹' (s ∩ g ⁻¹' f.source)) y :=
+  ∀ y ∈ e.target ∩ e.symm ⁻¹'  (s ∩ g ⁻¹' f.source), P (f ∘ g ∘ e.symm) (e.symm ⁻¹' s) y :=
 begin
-  assume y hy,
-  simp only with mfld_simps at hy,
-  have : e.symm y ∈ s, by simp only [hy] with mfld_simps,
-  convert ((hG.lift_prop_within_at_indep_chart he _ hf _).1 (h _ this)).2,
-  repeat { simp only [hy] with mfld_simps },
+  intros y hy,
+  convert ((hG.lift_prop_within_at_indep_chart he (e.symm_maps_to hy.1) hf hy.2.2).1
+    (h _ hy.2.1)).2,
+  rw [e.right_inv hy.1],
 end
 
 lemma lift_prop_within_at_inter' (ht : t ∈ 𝓝[s] x) :
   lift_prop_within_at P g (s ∩ t) x ↔ lift_prop_within_at P g s x :=
 begin
-  by_cases hcont : ¬ (continuous_within_at g s x),
-  { have : ¬ (continuous_within_at g (s ∩ t) x), by rwa [continuous_within_at_inter' ht],
-    simp only [lift_prop_within_at, hcont, this, false_and] },
-  push_neg at hcont,
-  have A : continuous_within_at g (s ∩ t) x, by rwa [continuous_within_at_inter' ht],
-  obtain ⟨o, o_open, xo, oc, oc', ost⟩ :
-    ∃ (o : set M), is_open o ∧ x ∈ o ∧ o ⊆ (chart_at H x).source ∧
-      o ∩ s ⊆ g ⁻¹' (chart_at H' (g x)).source ∧ o ∩ s ⊆ t,
-  { rcases mem_nhds_within.1 ht with ⟨u, u_open, xu, ust⟩,
-    have : (chart_at H' (g x)).source ∈ 𝓝 (g x) :=
-      is_open.mem_nhds ((chart_at H' (g x))).open_source (mem_chart_source H' (g x)),
-    rcases mem_nhds_within.1 (hcont.preimage_mem_nhds_within this) with ⟨v, v_open, xv, hv⟩,
-    refine ⟨u ∩ v ∩ (chart_at H x).source, _, ⟨⟨xu, xv⟩, mem_chart_source _ _⟩, _, _, _⟩,
-    { exact is_open.inter (is_open.inter u_open v_open) (chart_at H x).open_source },
-    { assume y hy, exact hy.2 },
-    { assume y hy, exact hv ⟨hy.1.1.2, hy.2⟩ },
-    { assume y hy, exact ust ⟨hy.1.1.1, hy.2⟩ } },
-  simp only [lift_prop_within_at, A, hcont, true_and, preimage_inter],
-  have B : is_open ((chart_at H x).target ∩ (chart_at H x).symm⁻¹' o) :=
-    (chart_at H x).preimage_open_of_open_symm o_open,
-  have C : (chart_at H x) x ∈ (chart_at H x).target ∩ (chart_at H x).symm⁻¹' o,
-    by simp only [xo] with mfld_simps,
-  conv_lhs { rw hG.is_local B C },
-  conv_rhs { rw hG.is_local B C },
-  congr' 2,
-  have : ∀ y, y ∈ o ∩ s → y ∈ t := ost,
-  mfld_set_tac
+  rw [lift_prop_within_at, lift_prop_within_at, continuous_within_at_inter' ht, hG.congr_set],
+  simp_rw [eventually_eq_set, mem_preimage,
+    (chart_at H x).eventually_nhds' (λ x, x ∈ s ∩ t ↔ x ∈ s) (mem_chart_source H x)],
+  exact (mem_nhds_within_iff_eventually_eq.mp ht).symm.mem_iff
 end
 
 lemma lift_prop_within_at_inter (ht : t ∈ 𝓝 x) :
@@ -282,7 +318,7 @@ begin
 end
 
 lemma lift_prop_on_of_locally_lift_prop_on
-  (h : ∀x∈s, ∃u, is_open u ∧ x ∈ u ∧ lift_prop_on P g (s ∩ u)) :
+  (h : ∀ x ∈ s, ∃ u, is_open u ∧ x ∈ u ∧ lift_prop_on P g (s ∩ u)) :
   lift_prop_on P g s :=
 begin
   assume x hx,
@@ -292,8 +328,7 @@ begin
   exact is_open.mem_nhds u_open xu,
 end
 
-lemma lift_prop_of_locally_lift_prop_on
-  (h : ∀x, ∃u, is_open u ∧ x ∈ u ∧ lift_prop_on P g u) :
+lemma lift_prop_of_locally_lift_prop_on (h : ∀ x, ∃ u, is_open u ∧ x ∈ u ∧ lift_prop_on P g u) :
   lift_prop P g :=
 begin
   rw ← lift_prop_on_univ,
@@ -301,62 +336,41 @@ begin
   simp [h x],
 end
 
-lemma lift_prop_within_at_congr
-  (h : lift_prop_within_at P g s x) (h₁ : ∀ y ∈ s, g' y = g y) (hx : g' x = g x) :
-  lift_prop_within_at P g' s x :=
-begin
-  refine ⟨h.1.congr h₁ hx, _⟩,
-  have A : s ∩ g' ⁻¹' (chart_at H' (g' x)).source = s ∩ g ⁻¹' (chart_at H' (g' x)).source,
-  { ext y,
-    split,
-    { assume hy,
-      simp only with mfld_simps at hy,
-      simp only [hy, ← h₁ _ hy.1] with mfld_simps },
-    { assume hy,
-      simp only with mfld_simps at hy,
-      simp only [hy, h₁ _ hy.1] with mfld_simps } },
-  have := h.2,
-  rw [← hx, ← A] at this,
-  convert hG.congr _ _ this using 2,
-  { assume y hy,
-    simp only with mfld_simps at hy,
-    have : (chart_at H x).symm y ∈ s, by simp only [hy],
-    simp only [hy, h₁ _ this] with mfld_simps },
-  { simp only [hx] with mfld_simps }
-end
-
-lemma lift_prop_within_at_congr_iff (h₁ : ∀ y ∈ s, g' y = g y) (hx : g' x = g x) :
-  lift_prop_within_at P g' s x ↔ lift_prop_within_at P g s x :=
-⟨λ h, hG.lift_prop_within_at_congr h (λ y hy, (h₁ y hy).symm) hx.symm,
- λ h, hG.lift_prop_within_at_congr h h₁ hx⟩
-
 lemma lift_prop_within_at_congr_of_eventually_eq
   (h : lift_prop_within_at P g s x) (h₁ : g' =ᶠ[𝓝[s] x] g) (hx : g' x = g x) :
   lift_prop_within_at P g' s x :=
 begin
-  rcases h₁.exists_mem with ⟨t, t_nhd, ht⟩,
-  rw ← hG.lift_prop_within_at_inter' t_nhd at h ⊢,
-  exact hG.lift_prop_within_at_congr h (λ y hy, ht hy.2) hx
+  refine ⟨h.1.congr_of_eventually_eq h₁ hx, _⟩,
+  refine hG.congr_nhds_within' _ (by simp_rw [function.comp_apply,
+    (chart_at H x).left_inv (mem_chart_source H x), hx]) h.2,
+  simp_rw [eventually_eq, function.comp_app, (chart_at H x).eventually_nhds_within'
+    (λ y, chart_at H' (g' x) (g' y) = chart_at H' (g x) (g y))
+    (mem_chart_source H x)],
+  exact h₁.mono (λ y hy, by rw [hx, hy])
 end
 
-lemma lift_prop_within_at_congr_iff_of_eventually_eq
-  (h₁ : g' =ᶠ[𝓝[s] x] g) (hx : g' x = g x) :
+lemma lift_prop_within_at_congr_iff_of_eventually_eq (h₁ :  g' =ᶠ[𝓝[s] x] g) (hx : g' x = g x) :
   lift_prop_within_at P g' s x ↔ lift_prop_within_at P g s x :=
 ⟨λ h, hG.lift_prop_within_at_congr_of_eventually_eq h h₁.symm hx.symm,
  λ h, hG.lift_prop_within_at_congr_of_eventually_eq h h₁ hx⟩
 
-lemma lift_prop_at_congr_of_eventually_eq (h : lift_prop_at P g x) (h₁ : g' =ᶠ[𝓝 x] g) :
-  lift_prop_at P g' x :=
-begin
-  apply hG.lift_prop_within_at_congr_of_eventually_eq h _ h₁.eq_of_nhds,
-  convert h₁,
-  rw nhds_within_univ
-end
+lemma lift_prop_within_at_congr_iff
+  (h₁ : ∀ y ∈ s, g' y = g y) (hx : g' x = g x) :
+  lift_prop_within_at P g' s x ↔ lift_prop_within_at P g s x :=
+hG.lift_prop_within_at_congr_iff_of_eventually_eq (eventually_nhds_within_of_forall h₁) hx
+
+lemma lift_prop_within_at_congr
+  (h : lift_prop_within_at P g s x) (h₁ : ∀ y ∈ s, g' y = g y) (hx : g' x = g x) :
+  lift_prop_within_at P g' s x :=
+(hG.lift_prop_within_at_congr_iff h₁ hx).mpr h
 
 lemma lift_prop_at_congr_iff_of_eventually_eq
   (h₁ : g' =ᶠ[𝓝 x] g) : lift_prop_at P g' x ↔ lift_prop_at P g x :=
-⟨λ h, hG.lift_prop_at_congr_of_eventually_eq h h₁.symm,
- λ h, hG.lift_prop_at_congr_of_eventually_eq h h₁⟩
+hG.lift_prop_within_at_congr_iff_of_eventually_eq (by simp_rw [nhds_within_univ, h₁]) h₁.eq_of_nhds
+
+lemma lift_prop_at_congr_of_eventually_eq (h : lift_prop_at P g x) (h₁ : g' =ᶠ[𝓝 x] g) :
+  lift_prop_at P g' x :=
+(hG.lift_prop_at_congr_iff_of_eventually_eq h₁).mpr h
 
 lemma lift_prop_on_congr (h : lift_prop_on P g s) (h₁ : ∀ y ∈ s, g' y = g y) :
   lift_prop_on P g' s :=
@@ -404,15 +418,10 @@ lemma lift_prop_at_of_mem_maximal_atlas [has_groupoid M G]
   (hG : G.local_invariant_prop G Q) (hQ : ∀ y, Q id univ y)
   (he : e ∈ maximal_atlas M G) (hx : x ∈ e.source) : lift_prop_at Q e x :=
 begin
-  suffices h : Q (e ∘ e.symm) e.target (e x),
-  { rw [lift_prop_at, hG.lift_prop_within_at_indep_chart he hx G.id_mem_maximal_atlas (mem_univ _)],
-    refine ⟨(e.continuous_at hx).continuous_within_at, _⟩,
-    simpa only with mfld_simps },
-  have A : Q id e.target (e x),
-  { have : e x ∈ e.target, by simp only [hx] with mfld_simps,
-    simpa only with mfld_simps using (hG.is_local e.open_target this).1 (hQ (e x)) },
-  apply hG.congr _ _ A;
-  simp only [hx] with mfld_simps {contextual := tt}
+  simp_rw [lift_prop_at,
+    hG.lift_prop_within_at_indep_chart he hx G.id_mem_maximal_atlas (mem_univ _),
+    (e.continuous_at hx).continuous_within_at, true_and],
+  exact hG.congr' (e.eventually_right_inverse' hx) (hQ _)
 end
 
 lemma lift_prop_on_of_mem_maximal_atlas [has_groupoid M G]
@@ -422,26 +431,22 @@ begin
   assume x hx,
   apply hG.lift_prop_within_at_of_lift_prop_at_of_mem_nhds
     (hG.lift_prop_at_of_mem_maximal_atlas hQ he hx),
-  apply is_open.mem_nhds e.open_source hx,
+  exact is_open.mem_nhds e.open_source hx,
 end
 
 lemma lift_prop_at_symm_of_mem_maximal_atlas [has_groupoid M G] {x : H}
   (hG : G.local_invariant_prop G Q) (hQ : ∀ y, Q id univ y)
   (he : e ∈ maximal_atlas M G) (hx : x ∈ e.target) : lift_prop_at Q e.symm x :=
 begin
-  suffices h : Q (e ∘ e.symm) e.target x,
+  suffices h : Q (e ∘ e.symm) univ x,
   { have A : e.symm ⁻¹' e.source ∩ e.target = e.target,
       by mfld_set_tac,
     have : e.symm x ∈ e.source, by simp only [hx] with mfld_simps,
     rw [lift_prop_at,
       hG.lift_prop_within_at_indep_chart G.id_mem_maximal_atlas (mem_univ _) he this],
     refine ⟨(e.symm.continuous_at hx).continuous_within_at, _⟩,
-    simp only with mfld_simps,
-    rwa [hG.is_local e.open_target hx, A] },
-  have A : Q id e.target x,
-    by simpa only with mfld_simps using (hG.is_local e.open_target hx).1 (hQ x),
-  apply hG.congr _ _ A;
-  simp only [hx] with mfld_simps {contextual := tt}
+    simp only [h] with mfld_simps },
+  exact hG.congr' (e.eventually_right_inverse hx) (hQ x)
 end
 
 lemma lift_prop_on_symm_of_mem_maximal_atlas [has_groupoid M G]
@@ -451,7 +456,7 @@ begin
   assume x hx,
   apply hG.lift_prop_within_at_of_lift_prop_at_of_mem_nhds
     (hG.lift_prop_at_symm_of_mem_maximal_atlas hQ he hx),
-  apply is_open.mem_nhds e.open_target hx,
+  exact is_open.mem_nhds e.open_target hx,
 end
 
 lemma lift_prop_at_chart [has_groupoid M G]
@@ -476,18 +481,8 @@ hG.lift_prop_on_symm_of_mem_maximal_atlas hQ (chart_mem_maximal_atlas G x)
 lemma lift_prop_id (hG : G.local_invariant_prop G Q) (hQ : ∀ y, Q id univ y) :
   lift_prop Q (id : M → M) :=
 begin
-  assume x,
-  dsimp [lift_prop_at, lift_prop_within_at],
-  refine ⟨continuous_within_at_id, _⟩,
-  let t := ((chart_at H x).target ∩ (chart_at H x).symm ⁻¹' (chart_at H x).source),
-  suffices H : Q id t ((chart_at H x) x),
-  { simp only with mfld_simps,
-    refine hG.congr (λ y hy, _) (by simp) H,
-    simp only with mfld_simps at hy,
-    simp only [hy] with mfld_simps },
-  have : t = univ ∩ (chart_at H x).target, by mfld_set_tac,
-  rw this,
-  exact (hG.is_local (chart_at H x).open_target (by simp)).1 (hQ _)
+  simp_rw [lift_prop_iff, continuous_id, true_and],
+  exact λ x, hG.congr' ((chart_at H x).eventually_right_inverse $ mem_chart_target H x) (hQ _)
 end
 
 end local_invariant_prop
@@ -501,7 +496,17 @@ open local_homeomorph
 structure groupoid `G` for `H`, relative to a set `s` in `H`, if for all points `x` in the set, the
 function agrees with a `G`-structomorphism on `s` in a neighbourhood of `x`. -/
 def is_local_structomorph_within_at (f : H → H) (s : set H) (x : H) : Prop :=
-(x ∈ s) → ∃ (e : local_homeomorph H H), e ∈ G ∧ eq_on f e.to_fun (s ∩ e.source) ∧ x ∈ e.source
+x ∈ s → ∃ (e : local_homeomorph H H), e ∈ G ∧ eq_on f e.to_fun (s ∩ e.source) ∧ x ∈ e.source
+
+-- lemma is_local_structomorph_within_at_iff {f : H → H} {s : set H} {x : H} :
+--   is_local_structomorph_within_at G f s x ↔
+--   (x ∈ s → ∃ (e : local_homeomorph H H), e ∈ G ∧ eq_on f e.to_fun s ∧ x ∈ e.source) :=
+-- begin
+--   refine ⟨_, λ h hx, let ⟨e, h1, h2, h3⟩ := h hx in ⟨e, h1, h2.mono (inter_subset_left _ _), h3⟩⟩,
+--   intros h hx,
+--   obtain ⟨e, h1, h2, h3⟩ := h hx,
+--   sorry
+-- end
 
 /-- For a groupoid `G` which is `closed_under_restriction`, being a local structomorphism is a local
 invariant property. -/
@@ -524,22 +529,22 @@ lemma is_local_structomorph_within_at_local_invariant_prop [closed_under_restric
   end,
   right_invariance := begin
     intros s x f e' he'G he'x h hx,
-    have hxs : x ∈ s := by simpa only [e'.left_inv he'x] with mfld_simps using hx.2,
+    have hxs : x ∈ s := by simpa only [e'.left_inv he'x] with mfld_simps using hx,
     rcases h hxs with ⟨e, heG, hef, hex⟩,
     refine ⟨e'.symm.trans e, G.trans (G.symm he'G) heG, _, _⟩,
     { intros y hy,
       simp only with mfld_simps at hy,
-      simp only [hef ⟨hy.1.2, hy.2.2⟩] with mfld_simps },
+      simp only [hef ⟨hy.1, hy.2.2⟩] with mfld_simps },
     { simp only [hex, he'x] with mfld_simps }
   end,
-  congr := begin
+  congr_of_forall := begin
     intros s x f g hfgs hfg' h hx,
     rcases h hx with ⟨e, heG, hef, hex⟩,
     refine ⟨e, heG, _, hex⟩,
     intros y hy,
     rw [← hef hy, hfgs y hy.1]
   end,
-  left_invariance := begin
+  left_invariance' := begin
     intros s x f e' he'G he' hfx h hx,
     rcases h hx with ⟨e, heG, hef, hex⟩,
     refine ⟨e.trans e', G.trans heG he'G, _, _⟩,

--- a/src/geometry/manifold/local_invariant_properties.lean
+++ b/src/geometry/manifold/local_invariant_properties.lean
@@ -133,8 +133,8 @@ lemma lift_prop_within_at_indep_chart_aux
   (hf : f ∈ G'.maximal_atlas M') (xf : g x ∈ f.source)
   (hf' : f' ∈ G'.maximal_atlas M') (xf' : g x ∈ f'.source)
   (hgs : continuous_within_at g s x)
-  (h : P (f ∘ g ∘ e.symm) (e.target ∩ e.symm ⁻¹' (s ∩ g⁻¹' f.source)) (e x)) :
-  P (f' ∘ g ∘ e'.symm) (e'.target ∩ e'.symm ⁻¹' (s ∩ g⁻¹' f'.source)) (e' x) :=
+  (h : P (f ∘ g ∘ e.symm) (e.symm ⁻¹' (s ∩ g⁻¹' f.source)) (e x)) :
+  P (f' ∘ g ∘ e'.symm) (e'.symm ⁻¹' (s ∩ g⁻¹' f'.source)) (e' x) :=
 begin
   obtain ⟨o, o_open, xo, oe, oe', of, of'⟩ :
     ∃ (o : set M), is_open o ∧ x ∈ o ∧ o ⊆ e.source ∧ o ⊆ e'.source ∧
@@ -149,12 +149,12 @@ begin
     { assume x hx, exact (hu ⟨hx.1.1.1, hx.2⟩).1 },
     { assume x hx, exact (hu ⟨hx.1.1.1, hx.2⟩).2 } },
   have A : P (f ∘ g ∘ e.symm)
-             (e.target ∩ e.symm ⁻¹' (s ∩ g⁻¹' f.source) ∩ (e.target ∩ e.symm ⁻¹' o)) (e x),
+             (e.symm ⁻¹' (s ∩ g⁻¹' f.source) ∩ (e.target ∩ e.symm ⁻¹' o)) (e x),
   { apply (hG.is_local _ _).1 h,
     { exact e.continuous_on_symm.preimage_open_of_open e.open_target o_open },
     { simp only [xe, xo] with mfld_simps} },
   have B : P ((f.symm ≫ₕ f') ∘ (f ∘ g ∘ e.symm))
-             (e.target ∩ e.symm ⁻¹' (s ∩ g⁻¹' f.source) ∩ (e.target ∩ e.symm ⁻¹' o)) (e x),
+             (e.symm ⁻¹' (s ∩ g⁻¹' f.source) ∩ (e.target ∩ e.symm ⁻¹' o)) (e x),
   { refine hG.left_invariance (compatible_of_mem_maximal_atlas hf hf') (λ y hy, _)
       (by simp only [xe, xf, xf'] with mfld_simps) A,
     simp only with mfld_simps at hy,
@@ -162,7 +162,9 @@ begin
     simpa only [hy] with mfld_simps using of' this },
   have C : P (f' ∘ g ∘ e.symm)
              (e.target ∩ e.symm ⁻¹' (s ∩ g⁻¹' f.source) ∩ (e.target ∩ e.symm ⁻¹' o)) (e x),
-  { refine hG.congr (λ y hy, _) (by simp only [xe, xf] with mfld_simps) B,
+  { rw [inter_assoc, inter_comm e.target],
+    refine (hG.is_local e.open_target $ e.to_local_equiv.source_subset_preimage_target (oe xo)).1 _,
+    refine hG.congr (λ y hy, _) (by simp only [xe, xf] with mfld_simps) B,
     simp only [local_homeomorph.coe_trans, function.comp_app],
     rw f.left_inv,
     apply of,

--- a/src/geometry/manifold/local_invariant_properties.lean
+++ b/src/geometry/manifold/local_invariant_properties.lean
@@ -253,10 +253,10 @@ lemma lift_prop_within_at_indep_chart [has_groupoid M G] [has_groupoid M' G']
     hf xf (chart_mem_maximal_atlas _ _) (mem_chart_source _ _) H.1 H.2⟩⟩
 
 lemma lift_prop_on_indep_chart [has_groupoid M G] [has_groupoid M' G']
-  (he : e ∈ G.maximal_atlas M) (hf : f ∈ G'.maximal_atlas M') (h : lift_prop_on P g s) :
-  ∀ y ∈ e.target ∩ e.symm ⁻¹'  (s ∩ g ⁻¹' f.source), P (f ∘ g ∘ e.symm) (e.symm ⁻¹' s) y :=
+  (he : e ∈ G.maximal_atlas M) (hf : f ∈ G'.maximal_atlas M') (h : lift_prop_on P g s)
+  {y : H} (hy : y ∈ e.target ∩ e.symm ⁻¹'  (s ∩ g ⁻¹' f.source)) :
+  P (f ∘ g ∘ e.symm) (e.symm ⁻¹' s) y :=
 begin
-  intros y hy,
   convert ((hG.lift_prop_within_at_indep_chart he (e.symm_maps_to hy.1) hf hy.2.2).1
     (h _ hy.2.1)).2,
   rw [e.right_inv hy.1],

--- a/src/geometry/manifold/local_invariant_properties.lean
+++ b/src/geometry/manifold/local_invariant_properties.lean
@@ -93,8 +93,8 @@ begin
   exact hG.left_invariance' he' (inter_subset_right _ _) hxe' hP
 end
 
-lemma congr_iff_nhds_within {s : set H} {x : H} {f g : H → H'} (h1 : f =ᶠ[𝓝[s] x] g) (h2 : f x = g x) :
-  P f s x ↔ P g s x :=
+lemma congr_iff_nhds_within {s : set H} {x : H} {f g : H → H'} (h1 : f =ᶠ[𝓝[s] x] g)
+  (h2 : f x = g x) : P f s x ↔ P g s x :=
 by { simp_rw [hG.is_local_nhds h1 h2],
   exact ⟨hG.congr_of_forall (λ y hy, hy.2) h2, hG.congr_of_forall (λ y hy, hy.2.symm) h2.symm⟩ }
 
@@ -469,16 +469,6 @@ structure groupoid `G` for `H`, relative to a set `s` in `H`, if for all points 
 function agrees with a `G`-structomorphism on `s` in a neighbourhood of `x`. -/
 def is_local_structomorph_within_at (f : H → H) (s : set H) (x : H) : Prop :=
 x ∈ s → ∃ (e : local_homeomorph H H), e ∈ G ∧ eq_on f e.to_fun (s ∩ e.source) ∧ x ∈ e.source
-
--- lemma is_local_structomorph_within_at_iff {f : H → H} {s : set H} {x : H} :
---   is_local_structomorph_within_at G f s x ↔
---   (x ∈ s → ∃ (e : local_homeomorph H H), e ∈ G ∧ eq_on f e.to_fun s ∧ x ∈ e.source) :=
--- begin
---   refine ⟨_, λ h hx, let ⟨e, h1, h2, h3⟩ := h hx in ⟨e, h1, h2.mono (inter_subset_left _ _), h3⟩⟩,
---   intros h hx,
---   obtain ⟨e, h1, h2, h3⟩ := h hx,
---   sorry
--- end
 
 /-- For a groupoid `G` which is `closed_under_restriction`, being a local structomorphism is a local
 invariant property. -/

--- a/src/geometry/manifold/local_invariant_properties.lean
+++ b/src/geometry/manifold/local_invariant_properties.lean
@@ -81,7 +81,7 @@ begin
   rw [hG.is_local ho hxo, host, ← hG.is_local ho hxo]
 end
 
-lemma is_local_nhds {s u : set H} {x : H} {f : H → H'} (hu : u ∈ 𝓝[s] x) (hx : x ∈ u) :
+lemma is_local_nhds {s u : set H} {x : H} {f : H → H'} (hu : u ∈ 𝓝[s] x) :
   P f s x ↔ P f (s ∩ u) x :=
 hG.congr_set $ mem_nhds_within_iff_eventually_eq.mp hu
 
@@ -89,13 +89,13 @@ lemma left_invariance {s : set H} {x : H} {f : H → H'} {e' : local_homeomorph 
   (he' : e' ∈ G') (hfs : continuous_within_at f s x) (hxe' : f x ∈ e'.source) (hP : P f s x) :
   P (e' ∘ f) s x :=
 begin
-  rw [hG.is_local_nhds (hfs.preimage_mem_nhds_within $ e'.open_source.mem_nhds hxe') hxe'] at hP ⊢,
+  rw [hG.is_local_nhds (hfs.preimage_mem_nhds_within $ e'.open_source.mem_nhds hxe')] at hP ⊢,
   exact hG.left_invariance' he' (inter_subset_right _ _) hxe' hP
 end
 
 lemma congr_iff_nhds_within {s : set H} {x : H} {f g : H → H'} (h1 : f =ᶠ[𝓝[s] x] g)
   (h2 : f x = g x) : P f s x ↔ P g s x :=
-by { simp_rw [hG.is_local_nhds h1 h2],
+by { simp_rw [hG.is_local_nhds h1],
   exact ⟨hG.congr_of_forall (λ y hy, hy.2) h2, hG.congr_of_forall (λ y hy, hy.2.symm) h2.symm⟩ }
 
 lemma congr_nhds_within {s : set H} {x : H} {f g : H → H'} (h1 : f =ᶠ[𝓝[s] x] g) (h2 : f x = g x)

--- a/src/geometry/manifold/local_invariant_properties.lean
+++ b/src/geometry/manifold/local_invariant_properties.lean
@@ -176,6 +176,25 @@ begin
   rw [hy]
 end
 
+lemma _root_.local_homeomorph.preimage_eventually_eq_target_inter_preimage_inter
+  {e : local_homeomorph M H} {t : set M'}
+  {f : M → M'} (hf : continuous_within_at f s x) (hxe : x ∈ e.source) (ht : t ∈ 𝓝 (f x)) :
+  e.symm ⁻¹' s =ᶠ[𝓝 (e x)] (e.target ∩ e.symm ⁻¹' (s ∩ f ⁻¹' t) : set H) :=
+begin
+  rw [eventually_eq_set, e.eventually_nhds _ hxe],
+  filter_upwards [(e.open_source.mem_nhds hxe),
+    mem_nhds_within_iff_eventually.mp (hf.preimage_mem_nhds_within ht)],
+  intros y hy hyu,
+  simp_rw [mem_inter_iff, mem_preimage, mem_inter_iff, e.maps_to hy, true_and, iff_self_and,
+    e.left_inv hy, iff_true_intro hyu]
+end
+
+variables (H x)
+lemma _root_.chart_source_mem_nhds : (chart_at H x).source ∈ 𝓝 x :=
+(chart_at H x).open_source.mem_nhds $ mem_chart_source H x
+variables {H x}
+-- note: which is preferred? `𝓝[s] x = 𝓝[t] x ↔ s =ᶠ[𝓝 x] t`
+
 variable (hG : G.local_invariant_prop G' P)
 include hG
 
@@ -212,6 +231,19 @@ hG.congr_nhds_within (mem_nhds_within_of_mem_nhds h) (mem_of_mem_nhds h : _) hP
 
 lemma congr' {s : set H} {x : H} {f g : H → H'} (h : f =ᶠ[𝓝 x] g) (hP : P g s x) : P f s x :=
 hG.congr h.symm hP
+
+/-- `lift_prop_within_at P f s x` is equivalent to a definition where we restrict the set we are
+  considering to the domain of the charts at `x` and `f x`. -/
+lemma lift_prop_within_at_iff {f : M → M'} (hf : continuous_within_at f s x) :
+  lift_prop_within_at P f s x ↔
+  P ((chart_at H' (f x)) ∘ f ∘ (chart_at H x).symm)
+  ((chart_at H x).target ∩ (chart_at H x).symm ⁻¹' (s ∩ f ⁻¹' (chart_at H' (f x)).source))
+  (chart_at H x x) :=
+begin
+  rw [lift_prop_within_at, iff_true_intro hf, true_and, hG.congr_set],
+  exact local_homeomorph.preimage_eventually_eq_target_inter_preimage_inter hf
+    (mem_chart_source H x) (chart_source_mem_nhds H' (f x))
+end
 
 -- lemma congr_nhds_within {s : set H} {x : H} {f g : H → H'} (h1 : f =ᶠ[𝓝[s] x] g) (h2 : f x = g x) :
 --   P f s x ↔ P g s x :=

--- a/src/topology/continuous_on.lean
+++ b/src/topology/continuous_on.lean
@@ -94,6 +94,30 @@ begin
   exact (nhds a).sets_of_superset ((nhds a).inter_sets Hw h1) hw,
 end
 
+lemma mem_nhds_within_iff_eventually {s t : set α} {x : α} :
+  t ∈ 𝓝[s] x ↔ ∀ᶠ y in 𝓝 x, y ∈ s → y ∈ t :=
+begin
+  rw [mem_nhds_within_iff_exists_mem_nhds_inter],
+  split,
+  { rintro ⟨u, hu, hut⟩, exact eventually_of_mem hu (λ x hxu hxs, hut ⟨hxu, hxs⟩) },
+  { refine λ h, ⟨_, h, λ y hy, hy.1 hy.2⟩ }
+end
+
+lemma mem_nhds_within_iff_eventually_eq {s t : set α} {x : α} :
+  t ∈ 𝓝[s] x ↔ s =ᶠ[𝓝 x] (s ∩ t : set α) :=
+by simp_rw [mem_nhds_within_iff_eventually, eventually_eq_set, mem_inter_iff, iff_self_and]
+
+lemma nhds_within_eq_iff_eventually_eq {s t : set α} {x : α} : 𝓝[s] x = 𝓝[t] x ↔ s =ᶠ[𝓝 x] t :=
+begin
+  simp_rw [filter.ext_iff, mem_nhds_within_iff_eventually, eventually_eq_set],
+  split,
+  { intro h,
+    filter_upwards [(h t).mpr (eventually_of_forall $ λ x, id),
+      (h s).mp (eventually_of_forall $ λ x, id)],
+    exact λ x, iff.intro, },
+  { refine λ h u, eventually_congr (h.mono $ λ x h, _), rw [h] }
+end
+
 lemma preimage_nhds_within_coinduced' {π : α → β} {s : set β} {t : set α} {a : α}
   (h : a ∈ t) (ht : is_open t)
   (hs : s ∈ @nhds β (topological_space.coinduced (λ x : t, π x) subtype.topological_space) (π a)) :

--- a/src/topology/local_homeomorph.lean
+++ b/src/topology/local_homeomorph.lean
@@ -276,15 +276,7 @@ by rw [e.map_nhds_within_eq hx, e.image_source_inter_eq', e.target_inter_inv_pre
 
 lemma eventually_nhds (e : local_homeomorph α β) {x : α} (p : β → Prop)
   (hx : x ∈ e.source) : (∀ᶠ y in 𝓝 (e x), p y) ↔ ∀ᶠ x in 𝓝 x, p (e x) :=
-begin
-  refine ⟨(e.continuous_at hx).eventually, _⟩,
-  intro h,
-  rw [← e.left_inv hx] at h,
-  filter_upwards [(e.symm.continuous_at $ e.maps_to hx).eventually h,
-    e.eventually_right_inverse' hx],
-  intros y hy heq,
-  rwa [heq] at hy
-end
+iff.trans (by rw [e.map_nhds_eq hx]) eventually_map
 
 lemma eventually_nhds' (e : local_homeomorph α β) {x : α} (p : α → Prop)
   (hx : x ∈ e.source) : (∀ᶠ y in 𝓝 (e x), p (e.symm y)) ↔ ∀ᶠ x in 𝓝 x, p x :=
@@ -310,6 +302,9 @@ begin
   rw [hy]
 end
 
+/-- This lemma is useful in the manifold library in the case that `e` is a chart. It states that
+  locally around `e x` the set `e.symm ⁻¹' s` is the same as the set intersected with the target
+  of `e` and some other neighborhood of `f x` (which will be the source of a chart on `γ`).  -/
 lemma preimage_eventually_eq_target_inter_preimage_inter
   {e : local_homeomorph α β} {s : set α} {t : set γ} {x : α}
   {f : α → γ} (hf : continuous_within_at f s x) (hxe : x ∈ e.source) (ht : t ∈ 𝓝 (f x)) :

--- a/src/topology/local_homeomorph.lean
+++ b/src/topology/local_homeomorph.lean
@@ -237,7 +237,7 @@ lemma symm_target : e.symm.target = e.source := rfl
 
 /-- A local homeomorphism is continuous at any point of its source -/
 protected lemma continuous_at {x : α} (h : x ∈ e.source) : continuous_at e x :=
-(e.continuous_on x h).continuous_at (is_open.mem_nhds e.open_source h)
+(e.continuous_on x h).continuous_at (e.open_source.mem_nhds h)
 
 /-- A local homeomorphism inverse is continuous at any point of its target -/
 lemma continuous_at_symm {x : β} (h : x ∈ e.target) : continuous_at e.symm x :=
@@ -272,6 +272,56 @@ lemma map_nhds_within_preimage_eq (e : local_homeomorph α β) {x} (hx : x ∈ e
   map e (𝓝[e ⁻¹' s] x) = 𝓝[s] (e x) :=
 by rw [e.map_nhds_within_eq hx, e.image_source_inter_eq', e.target_inter_inv_preimage_preimage,
   e.nhds_within_target_inter (e.map_source hx)]
+
+
+lemma eventually_nhds (e : local_homeomorph α β) {x : α} (p : β → Prop)
+  (hx : x ∈ e.source) : (∀ᶠ y in 𝓝 (e x), p y) ↔ ∀ᶠ x in 𝓝 x, p (e x) :=
+begin
+  refine ⟨(e.continuous_at hx).eventually, _⟩,
+  intro h,
+  rw [← e.left_inv hx] at h,
+  filter_upwards [(e.symm.continuous_at $ e.maps_to hx).eventually h,
+    e.eventually_right_inverse' hx],
+  intros y hy heq,
+  rwa [heq] at hy
+end
+
+lemma eventually_nhds' (e : local_homeomorph α β) {x : α} (p : α → Prop)
+  (hx : x ∈ e.source) : (∀ᶠ y in 𝓝 (e x), p (e.symm y)) ↔ ∀ᶠ x in 𝓝 x, p x :=
+begin
+  rw [e.eventually_nhds _ hx],
+  refine eventually_congr ((e.eventually_left_inverse hx).mono $ λ y hy, _),
+  rw [hy]
+end
+
+lemma eventually_nhds_within (e : local_homeomorph α β) {x : α} (p : β → Prop) {s : set α}
+  (hx : x ∈ e.source) : (∀ᶠ y in 𝓝[e.symm ⁻¹' s] (e x), p y) ↔ ∀ᶠ x in 𝓝[s] x, p (e x) :=
+begin
+  refine iff.trans _ eventually_map,
+  rw [e.map_nhds_within_eq hx, e.image_source_inter_eq', e.nhds_within_target_inter (e.maps_to hx)]
+end
+
+lemma eventually_nhds_within' (e : local_homeomorph α β) {x : α} (p : α → Prop) {s : set α}
+  (hx : x ∈ e.source) : (∀ᶠ y in 𝓝[e.symm ⁻¹' s] (e x), p (e.symm y)) ↔ ∀ᶠ x in 𝓝[s] x, p x :=
+begin
+  rw [e.eventually_nhds_within _ hx],
+  refine eventually_congr ((eventually_nhds_within_of_eventually_nhds $
+    e.eventually_left_inverse hx).mono $ λ y hy, _),
+  rw [hy]
+end
+
+lemma preimage_eventually_eq_target_inter_preimage_inter
+  {e : local_homeomorph α β} {s : set α} {t : set γ} {x : α}
+  {f : α → γ} (hf : continuous_within_at f s x) (hxe : x ∈ e.source) (ht : t ∈ 𝓝 (f x)) :
+  e.symm ⁻¹' s =ᶠ[𝓝 (e x)] (e.target ∩ e.symm ⁻¹' (s ∩ f ⁻¹' t) : set β) :=
+begin
+  rw [eventually_eq_set, e.eventually_nhds _ hxe],
+  filter_upwards [(e.open_source.mem_nhds hxe),
+    mem_nhds_within_iff_eventually.mp (hf.preimage_mem_nhds_within ht)],
+  intros y hy hyu,
+  simp_rw [mem_inter_iff, mem_preimage, mem_inter_iff, e.maps_to hy, true_and, iff_self_and,
+    e.left_inv hy, iff_true_intro hyu]
+end
 
 lemma preimage_open_of_open {s : set β} (hs : is_open s) : is_open (e.source ∩ e ⁻¹' s) :=
 e.continuous_on.preimage_open_of_open e.open_source hs

--- a/src/topology/local_homeomorph.lean
+++ b/src/topology/local_homeomorph.lean
@@ -273,7 +273,6 @@ lemma map_nhds_within_preimage_eq (e : local_homeomorph α β) {x} (hx : x ∈ e
 by rw [e.map_nhds_within_eq hx, e.image_source_inter_eq', e.target_inter_inv_preimage_preimage,
   e.nhds_within_target_inter (e.map_source hx)]
 
-
 lemma eventually_nhds (e : local_homeomorph α β) {x : α} (p : β → Prop)
   (hx : x ∈ e.source) : (∀ᶠ y in 𝓝 (e x), p y) ↔ ∀ᶠ x in 𝓝 x, p (e x) :=
 iff.trans (by rw [e.map_nhds_eq hx]) eventually_map


### PR DESCRIPTION
* Simplify the sets in `local_invariant_prop` and `lift_prop_within_at`
* Simplify many proofs in `local_invariant_properties.lean`
* Reorder the intersection in `cont_diff_within_at_prop` to be more consistent with all lemmas in `smooth_manifold_with_corners.lean`
* New lemmas, such as `cont_mdiff_within_at_iff_of_mem_source` and properties of `local_invariant_prop`
* I expect that some lemmas in `cont_mdiff.lean` can be simplified using the new definitions, but I don't do that in this PR.
* Lemma renamings:
```
cont_mdiff_within_at_iff -> cont_mdiff_within_at_iff'
cont_mdiff_within_at_iff' -> cont_mdiff_within_at_iff_of_mem_source'
cont_mdiff_within_at_iff'' -> cont_mdiff_within_at_iff [or iff.rfl]
```

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
