### PR TITLE
[Merged by Bors] - chore(analysis/calculus/deriv): make the exponent explicit in pow lemmas

### DIFF
--- a/archive/100-theorems-list/9_area_of_a_circle.lean
+++ b/archive/100-theorems-list/9_area_of_a_circle.lean
@@ -93,7 +93,7 @@ begin
   { rintros x ⟨hx1, hx2⟩,
     convert ((has_deriv_at_const x ((r:ℝ)^2)).mul ((has_deriv_at_arcsin _ _).comp x
       ((has_deriv_at_const x (r:ℝ)⁻¹).mul (has_deriv_at_id' x)))).add
-        ((has_deriv_at_id' x).mul (((has_deriv_at_id' x).pow.const_sub ((r:ℝ)^2)).sqrt _)),
+        ((has_deriv_at_id' x).mul ((((has_deriv_at_id' x).pow 2).const_sub ((r:ℝ)^2)).sqrt _)),
     { have h : sqrt (1 - x ^ 2 / r ^ 2) * r = sqrt (r ^ 2 - x ^ 2),
       { rw [← sqrt_sq hle, ← sqrt_mul, sub_mul, sqrt_sq hle, mul_comm_div,
             div_self (pow_ne_zero 2 hlt.ne'), one_mul, mul_one],

--- a/src/analysis/calculus/deriv.lean
+++ b/src/analysis/calculus/deriv.lean
@@ -1896,7 +1896,7 @@ end polynomial
 section pow
 /-! ### Derivative of `x ↦ x^n` for `n : ℕ` -/
 variables {x : 𝕜} {s : set 𝕜} {c : 𝕜 → 𝕜} {c' : 𝕜}
-variable {n : ℕ }
+variable (n : ℕ)
 
 lemma has_strict_deriv_at_pow (n : ℕ) (x : 𝕜) :
   has_strict_deriv_at (λx, x^n) ((n : 𝕜) * x^(n-1)) x :=
@@ -1917,19 +1917,19 @@ lemma differentiable_at_pow : differentiable_at 𝕜 (λx, x^n) x :=
 (has_deriv_at_pow n x).differentiable_at
 
 lemma differentiable_within_at_pow : differentiable_within_at 𝕜 (λx, x^n) s x :=
-differentiable_at_pow.differentiable_within_at
+(differentiable_at_pow n).differentiable_within_at
 
 lemma differentiable_pow : differentiable 𝕜 (λx:𝕜, x^n) :=
-λx, differentiable_at_pow
+λ x, differentiable_at_pow n
 
 lemma differentiable_on_pow : differentiable_on 𝕜 (λx, x^n) s :=
-differentiable_pow.differentiable_on
+(differentiable_pow n).differentiable_on
 
-lemma deriv_pow : deriv (λx, x^n) x = (n : 𝕜) * x^(n-1) :=
+lemma deriv_pow : deriv (λ x, x^n) x = (n : 𝕜) * x^(n-1) :=
 (has_deriv_at_pow n x).deriv
 
-@[simp] lemma deriv_pow' : deriv (λx, x^n) = λ x, (n : 𝕜) * x^(n-1) :=
-funext $ λ x, deriv_pow
+@[simp] lemma deriv_pow' : deriv (λ x, x^n) = λ x, (n : 𝕜) * x^(n-1) :=
+funext $ λ x, deriv_pow n
 
 lemma deriv_within_pow (hxs : unique_diff_within_at 𝕜 s x) :
   deriv_within (λx, x^n) s x = (n : 𝕜) * x^(n-1) :=
@@ -1941,32 +1941,32 @@ lemma has_deriv_within_at.pow (hc : has_deriv_within_at c c' s x) :
 
 lemma has_deriv_at.pow (hc : has_deriv_at c c' x) :
   has_deriv_at (λ y, (c y)^n) ((n : 𝕜) * (c x)^(n-1) * c') x :=
-by { rw ← has_deriv_within_at_univ at *, exact hc.pow }
+by { rw ← has_deriv_within_at_univ at *, exact hc.pow n }
 
 lemma differentiable_within_at.pow (hc : differentiable_within_at 𝕜 c s x) :
   differentiable_within_at 𝕜 (λx, (c x)^n) s x :=
-hc.has_deriv_within_at.pow.differentiable_within_at
+(hc.has_deriv_within_at.pow n).differentiable_within_at
 
 @[simp] lemma differentiable_at.pow (hc : differentiable_at 𝕜 c x) :
   differentiable_at 𝕜 (λx, (c x)^n) x :=
-hc.has_deriv_at.pow.differentiable_at
+(hc.has_deriv_at.pow n).differentiable_at
 
 lemma differentiable_on.pow (hc : differentiable_on 𝕜 c s) :
   differentiable_on 𝕜 (λx, (c x)^n) s :=
-λx h, (hc x h).pow
+λx h, (hc x h).pow n
 
 @[simp] lemma differentiable.pow (hc : differentiable 𝕜 c) :
   differentiable 𝕜 (λx, (c x)^n) :=
-λx, (hc x).pow
+λx, (hc x).pow n
 
 lemma deriv_within_pow' (hc : differentiable_within_at 𝕜 c s x)
   (hxs : unique_diff_within_at 𝕜 s x) :
   deriv_within (λx, (c x)^n) s x = (n : 𝕜) * (c x)^(n-1) * (deriv_within c s x) :=
-hc.has_deriv_within_at.pow.deriv_within hxs
+(hc.has_deriv_within_at.pow n).deriv_within hxs
 
 @[simp] lemma deriv_pow'' (hc : differentiable_at 𝕜 c x) :
   deriv (λx, (c x)^n) x = (n : 𝕜) * (c x)^(n-1) * (deriv c x) :=
-hc.has_deriv_at.pow.deriv
+(hc.has_deriv_at.pow n).deriv
 
 end pow
 

--- a/src/analysis/complex/phragmen_lindelof.lean
+++ b/src/analysis/complex/phragmen_lindelof.lean
@@ -800,8 +800,8 @@ begin
       (norm_pos_iff.2 H) tendsto_const_nhds).eventually (eventually_gt_at_top C)).exists },
   intro n,
   -- This estimate follows from the Phragmen-Lindelöf principle in the right half-plane.
-  refine right_half_plane_of_tendsto_zero_on_real (differentiable_exp.pow.diff_cont_on_cl.smul hd)
-    _ _ (λ y, _) hz.le,
+  refine right_half_plane_of_tendsto_zero_on_real
+    ((differentiable_exp.pow n).diff_cont_on_cl.smul hd) _ _ (λ y, _) hz.le,
   { rcases hexp with ⟨c, hc, B, hO⟩,
     refine ⟨max c 1, max_lt hc one_lt_two, n + max B 0, is_O.of_norm_left _⟩,
     simp only [hg],

--- a/src/analysis/convex/specific_functions.lean
+++ b/src/analysis/convex/specific_functions.lean
@@ -42,7 +42,7 @@ lemma convex_on_exp : convex_on ℝ univ exp := strict_convex_on_exp.convex_on
 /-- `x^n`, `n : ℕ` is convex on the whole real line whenever `n` is even -/
 lemma even.convex_on_pow {n : ℕ} (hn : even n) : convex_on ℝ set.univ (λ x : ℝ, x^n) :=
 begin
-  apply convex_on_univ_of_deriv2_nonneg differentiable_pow,
+  apply convex_on_univ_of_deriv2_nonneg (differentiable_pow n),
   { simp only [deriv_pow', differentiable.mul, differentiable_const, differentiable_pow] },
   { intro x,
     obtain ⟨k, hk⟩ := (hn.tsub $ even_bit0 _).exists_two_nsmul _,
@@ -54,7 +54,7 @@ end
 lemma even.strict_convex_on_pow {n : ℕ} (hn : even n) (h : n ≠ 0) :
   strict_convex_on ℝ set.univ (λ x : ℝ, x^n) :=
 begin
-  apply strict_mono.strict_convex_on_univ_of_deriv differentiable_pow,
+  apply strict_mono.strict_convex_on_univ_of_deriv (differentiable_pow n),
   rw deriv_pow',
   replace h := nat.pos_of_ne_zero h,
   exact strict_mono.const_mul (odd.strict_mono_pow $ nat.even.sub_odd h hn $ nat.odd_iff.2 rfl)
@@ -65,7 +65,7 @@ end
 lemma convex_on_pow (n : ℕ) : convex_on ℝ (Ici 0) (λ x : ℝ, x^n) :=
 begin
   apply convex_on_of_deriv2_nonneg (convex_Ici _) (continuous_pow n).continuous_on
-    differentiable_on_pow,
+    (differentiable_on_pow n),
   { simp only [deriv_pow'], exact (@differentiable_on_pow ℝ _ _ _).const_mul (n : ℝ) },
   { intros x hx,
     rw [iter_deriv_pow, finset.prod_range_cast_nat_sub],
@@ -76,7 +76,7 @@ end
 lemma strict_convex_on_pow {n : ℕ} (hn : 2 ≤ n) : strict_convex_on ℝ (Ici 0) (λ x : ℝ, x^n) :=
 begin
   apply strict_mono_on.strict_convex_on_of_deriv (convex_Ici _) (continuous_on_pow _)
-    differentiable_on_pow,
+    (differentiable_on_pow n),
   rw [deriv_pow', interior_Ici],
   exact λ x (hx : 0 < x) y hy hxy, mul_lt_mul_of_pos_left (pow_lt_pow_of_lt_left hxy hx.le $
     nat.sub_pos_of_lt hn) (nat.cast_pos.2 $ zero_lt_two.trans_le hn),

--- a/src/analysis/special_functions/integrals.lean
+++ b/src/analysis/special_functions/integrals.lean
@@ -410,8 +410,8 @@ lemma integral_sin_pow_aux :
 begin
   let C := sin a ^ (n + 1) * cos a - sin b ^ (n + 1) * cos b,
   have h : ∀ α β γ : ℝ, α * (β * α * γ) = β * (α * α * γ) := λ α β γ, by ring,
-  have hu : ∀ x ∈ _, has_deriv_at (λ y, sin y ^ (n + 1 : ℕ)) ((n + 1 : ℕ) * cos x * sin x ^ n) x :=
-    λ x hx, by simpa only [mul_right_comm] using (has_deriv_at_sin x).pow,
+  have hu : ∀ x ∈ _, has_deriv_at (λ y, sin y ^ (n + 1)) ((n + 1 : ℕ) * cos x * sin x ^ n) x :=
+    λ x hx, by simpa only [mul_right_comm] using (has_deriv_at_sin x).pow (n+1),
   have hv : ∀ x ∈ [a, b], has_deriv_at (-cos) (sin x) x :=
     λ x hx, by simpa only [neg_neg] using (has_deriv_at_cos x).neg,
   have H := integral_mul_deriv_eq_deriv_mul hu hv _ _,
@@ -484,7 +484,7 @@ begin
   have h : ∀ α β γ : ℝ, α * (β * α * γ) = β * (α * α * γ) := λ α β γ, by ring,
   have hu : ∀ x ∈ _, has_deriv_at (λ y, cos y ^ (n + 1)) (-(n + 1 : ℕ) * sin x * cos x ^ n) x :=
     λ x hx, by simpa only [mul_right_comm, neg_mul, mul_neg]
-      using (has_deriv_at_cos x).pow,
+      using (has_deriv_at_cos x).pow (n+1),
   have hv : ∀ x ∈ [a, b], has_deriv_at sin (cos x) x := λ x hx, has_deriv_at_sin x,
   have H := integral_mul_deriv_eq_deriv_mul hu hv _ _,
   calc  ∫ x in a..b, cos x ^ (n + 2)


### PR DESCRIPTION
This is useful to build derivatives for explicit functions using dot notation.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
