### PR TITLE
[Merged by Bors] - feat(analysis/calculus/mean_value): remove assumption in strict_mono_on.strict_convex_on_of_deriv

### DIFF
--- a/src/analysis/calculus/mean_value.lean
+++ b/src/analysis/calculus/mean_value.lean
@@ -1043,9 +1043,7 @@ lemma strict_mono_on.exists_slope_lt_deriv_aux {x y : ℝ} {f : ℝ → ℝ}
   ∃ a ∈ Ioo x y, (f y - f x) / (y - x) < deriv f a :=
 begin
   have A : differentiable_on ℝ f (Ioo x y),
-  { assume w wmem,
-    apply differentiable_at.differentiable_within_at,
-    exact differentiable_at_of_deriv_ne_zero (h w wmem), },
+    from λ w wmem, (differentiable_at_of_deriv_ne_zero (h w wmem)).differentiable_within_at,
   obtain ⟨a, ⟨hxa, hay⟩, ha⟩ : ∃ a ∈ Ioo x y, deriv f a = (f y - f x) / (y - x),
     from exists_deriv_eq_slope f hxy hf A,
   rcases nonempty_Ioo.2 hay with ⟨b, ⟨hab, hby⟩⟩,
@@ -1095,9 +1093,7 @@ lemma strict_mono_on.exists_deriv_lt_slope_aux {x y : ℝ} {f : ℝ → ℝ}
   ∃ a ∈ Ioo x y, deriv f a < (f y - f x) / (y - x) :=
 begin
   have A : differentiable_on ℝ f (Ioo x y),
-  { assume w wmem,
-    apply differentiable_at.differentiable_within_at,
-    exact differentiable_at_of_deriv_ne_zero (h w wmem), },
+    from λ w wmem, (differentiable_at_of_deriv_ne_zero (h w wmem)).differentiable_within_at,
   obtain ⟨a, ⟨hxa, hay⟩, ha⟩ : ∃ a ∈ Ioo x y, deriv f a = (f y - f x) / (y - x),
     from exists_deriv_eq_slope f hxy hf A,
   rcases nonempty_Ioo.2 hxa with ⟨b, ⟨hxb, hba⟩⟩,
@@ -1160,7 +1156,7 @@ begin
   have hyzD' : Ioo y z ⊆ interior D,
     from subset_sUnion_of_mem ⟨is_open_Ioo, subset.trans Ioo_subset_Icc_self hyzD⟩,
   -- Then we get points `a` and `b` in each interval `[x, y]` and `[y, z]` where the derivatives
-  -- can be compared to the slopes between `x, y` and `, z` respectively.
+  -- can be compared to the slopes between `x, y` and `y, z` respectively.
   obtain ⟨a, ⟨hxa, hay⟩, ha⟩ : ∃ a ∈ Ioo x y, (f y - f x) / (y - x) < deriv f a,
     from strict_mono_on.exists_slope_lt_deriv (hf.mono hxyD) hxy (hf'.mono hxyD'),
   obtain ⟨b, ⟨hyb, hbz⟩, hb⟩ : ∃ b ∈ Ioo y z, deriv f b < (f z - f y) / (z - y),

--- a/src/analysis/calculus/mean_value.lean
+++ b/src/analysis/calculus/mean_value.lean
@@ -1037,7 +1037,7 @@ begin
   exact neg_convex_on_iff.mp (this.convex_on_of_deriv hD hf.neg hf'.neg),
 end
 
-lemma strict_mono_on.strict_convex_on_of_deriv_aux1 {x y : ℝ} {f : ℝ → ℝ}
+lemma strict_mono_on.exists_slope_lt_deriv_aux {x y : ℝ} {f : ℝ → ℝ}
   (hf : continuous_on f (Icc x y)) (hxy : x < y)
   (hf'_mono : strict_mono_on (deriv f) (Ioo x y)) (h : ∀ w ∈ Ioo x y, deriv f w ≠ 0) :
   ∃ a ∈ Ioo x y, (f y - f x) / (y - x) < deriv f a :=
@@ -1054,17 +1054,17 @@ begin
   exact hf'_mono ⟨hxa, hay⟩ ⟨hxa.trans hab, hby⟩ hab
 end
 
-lemma strict_mono_on.strict_convex_on_of_deriv_aux2 {x y : ℝ} {f : ℝ → ℝ}
+lemma strict_mono_on.exists_slope_lt_deriv {x y : ℝ} {f : ℝ → ℝ}
   (hf : continuous_on f (Icc x y)) (hxy : x < y)
   (hf'_mono : strict_mono_on (deriv f) (Ioo x y)) :
   ∃ a ∈ Ioo x y, (f y - f x) / (y - x) < deriv f a :=
 begin
   by_cases h : ∀ w ∈ Ioo x y, deriv f w ≠ 0,
-  { apply strict_mono_on.strict_convex_on_of_deriv_aux1 hf hxy hf'_mono h },
+  { apply strict_mono_on.exists_slope_lt_deriv_aux hf hxy hf'_mono h },
   { push_neg at h,
     rcases h with ⟨w, ⟨hxw, hwy⟩, hw⟩,
     obtain ⟨a, ⟨hxa, haw⟩, ha⟩ : ∃ (a : ℝ) (H : a ∈ Ioo x w), (f w - f x) / (w - x) < deriv f a,
-    { apply strict_mono_on.strict_convex_on_of_deriv_aux1 _ hxw _ _,
+    { apply strict_mono_on.exists_slope_lt_deriv_aux _ hxw _ _,
       { exact hf.mono (Icc_subset_Icc le_rfl hwy.le) },
       { exact hf'_mono.mono (Ioo_subset_Ioo le_rfl hwy.le) },
       { assume z hz,
@@ -1072,7 +1072,7 @@ begin
         apply ne_of_lt,
         exact hf'_mono ⟨hz.1, hz.2.trans hwy⟩ ⟨hxw, hwy⟩ hz.2 } },
     obtain ⟨b, ⟨hwb, hby⟩, hb⟩ : ∃ (b : ℝ) (H : b ∈ Ioo w y), (f y - f w) / (y - w) < deriv f b,
-    { apply strict_mono_on.strict_convex_on_of_deriv_aux1 _ hwy _ _,
+    { apply strict_mono_on.exists_slope_lt_deriv_aux _ hwy _ _,
       { refine hf.mono (Icc_subset_Icc hxw.le le_rfl), },
       { exact hf'_mono.mono (Ioo_subset_Ioo hxw.le le_rfl) },
       { assume z hz,
@@ -1089,7 +1089,7 @@ begin
     linarith }
 end
 
-lemma strict_mono_on.strict_convex_on_of_deriv_aux3 {x y : ℝ} {f : ℝ → ℝ}
+lemma strict_mono_on.exists_deriv_lt_slope_aux {x y : ℝ} {f : ℝ → ℝ}
   (hf : continuous_on f (Icc x y)) (hxy : x < y)
   (hf'_mono : strict_mono_on (deriv f) (Ioo x y)) (h : ∀ w ∈ Ioo x y, deriv f w ≠ 0) :
   ∃ a ∈ Ioo x y, deriv f a < (f y - f x) / (y - x) :=
@@ -1106,17 +1106,17 @@ begin
   exact hf'_mono ⟨hxb, hba.trans hay⟩ ⟨hxa, hay⟩ hba
 end
 
-lemma strict_mono_on.strict_convex_on_of_deriv_aux4 {x y : ℝ} {f : ℝ → ℝ}
+lemma strict_mono_on.exists_deriv_lt_slope {x y : ℝ} {f : ℝ → ℝ}
   (hf : continuous_on f (Icc x y)) (hxy : x < y)
   (hf'_mono : strict_mono_on (deriv f) (Ioo x y)) :
   ∃ a ∈ Ioo x y, deriv f a < (f y - f x) / (y - x) :=
 begin
   by_cases h : ∀ w ∈ Ioo x y, deriv f w ≠ 0,
-  { apply strict_mono_on.strict_convex_on_of_deriv_aux3 hf hxy hf'_mono h },
+  { apply strict_mono_on.exists_deriv_lt_slope_aux hf hxy hf'_mono h },
   { push_neg at h,
     rcases h with ⟨w, ⟨hxw, hwy⟩, hw⟩,
     obtain ⟨a, ⟨hxa, haw⟩, ha⟩ : ∃ (a : ℝ) (H : a ∈ Ioo x w), deriv f a < (f w - f x) / (w - x),
-    { apply strict_mono_on.strict_convex_on_of_deriv_aux3 _ hxw _ _,
+    { apply strict_mono_on.exists_deriv_lt_slope_aux _ hxw _ _,
       { exact hf.mono (Icc_subset_Icc le_rfl hwy.le) },
       { exact hf'_mono.mono (Ioo_subset_Ioo le_rfl hwy.le) },
       { assume z hz,
@@ -1124,7 +1124,7 @@ begin
         apply ne_of_lt,
         exact hf'_mono ⟨hz.1, hz.2.trans hwy⟩ ⟨hxw, hwy⟩ hz.2 } },
     obtain ⟨b, ⟨hwb, hby⟩, hb⟩ : ∃ (b : ℝ) (H : b ∈ Ioo w y), deriv f b < (f y - f w) / (y - w),
-    { apply strict_mono_on.strict_convex_on_of_deriv_aux3 _ hwy _ _,
+    { apply strict_mono_on.exists_deriv_lt_slope_aux _ hwy _ _,
       { refine hf.mono (Icc_subset_Icc hxw.le le_rfl), },
       { exact hf'_mono.mono (Ioo_subset_Ioo hxw.le le_rfl) },
       { assume z hz,
@@ -1162,9 +1162,9 @@ begin
   -- Then we get points `a` and `b` in each interval `[x, y]` and `[y, z]` where the derivatives
   -- can be compared to the slopes between `x, y` and `, z` respectively.
   obtain ⟨a, ⟨hxa, hay⟩, ha⟩ : ∃ a ∈ Ioo x y, (f y - f x) / (y - x) < deriv f a,
-    from strict_mono_on.strict_convex_on_of_deriv_aux2 (hf.mono hxyD) hxy (hf'.mono hxyD'),
+    from strict_mono_on.exists_slope_lt_deriv (hf.mono hxyD) hxy (hf'.mono hxyD'),
   obtain ⟨b, ⟨hyb, hbz⟩, hb⟩ : ∃ b ∈ Ioo y z, deriv f b < (f z - f y) / (z - y),
-    from strict_mono_on.strict_convex_on_of_deriv_aux4 (hf.mono hyzD) hyz (hf'.mono hyzD'),
+    from strict_mono_on.exists_deriv_lt_slope (hf.mono hyzD) hyz (hf'.mono hyzD'),
   apply ha.trans (lt_trans _ hb),
   exact hf' (hxyD' ⟨hxa, hay⟩) (hyzD' ⟨hyb, hbz⟩) (hay.trans hyb),
 end
@@ -1200,8 +1200,7 @@ theorem antitone.concave_on_univ_of_deriv {f : ℝ → ℝ} (hf : differentiable
 convex. Note that we don't require differentiability, since it is guaranteed at all but at most
 one point by the strict monotonicity of `f'`. -/
 lemma strict_mono.strict_convex_on_univ_of_deriv {f : ℝ → ℝ} (hf : continuous f)
-  (hf'_mono : strict_mono (deriv f)) :
-  strict_convex_on ℝ univ f :=
+  (hf'_mono : strict_mono (deriv f)) : strict_convex_on ℝ univ f :=
 (hf'_mono.strict_mono_on _).strict_convex_on_of_deriv convex_univ hf.continuous_on
 
 /-- If a function `f` is continuous and `f'` is strictly antitone on `ℝ` then `f` is strictly

--- a/src/analysis/calculus/mean_value.lean
+++ b/src/analysis/calculus/mean_value.lean
@@ -1037,11 +1037,116 @@ begin
   exact neg_convex_on_iff.mp (this.convex_on_of_deriv hD hf.neg hf'.neg),
 end
 
-/-- If a function `f` is continuous on a convex set `D ⊆ ℝ`, is differentiable on its interior,
-and `f'` is strictly monotone on the interior, then `f` is strictly convex on `D`. -/
+lemma strict_mono_on.strict_convex_on_of_deriv_aux1 {x y : ℝ} {f : ℝ → ℝ}
+  (hf : continuous_on f (Icc x y)) (hxy : x < y)
+  (hf'_mono : strict_mono_on (deriv f) (Ioo x y)) (h : ∀ w ∈ Ioo x y, deriv f w ≠ 0) :
+  ∃ a ∈ Ioo x y, (f y - f x) / (y - x) < deriv f a :=
+begin
+  have A : differentiable_on ℝ f (Ioo x y),
+  { assume w wmem,
+    apply differentiable_at.differentiable_within_at,
+    exact differentiable_at_of_deriv_ne_zero (h w wmem), },
+  obtain ⟨a, ⟨hxa, hay⟩, ha⟩ : ∃ a ∈ Ioo x y, deriv f a = (f y - f x) / (y - x),
+    from exists_deriv_eq_slope f hxy hf A,
+  rcases nonempty_Ioo.2 hay with ⟨b, ⟨hab, hby⟩⟩,
+  refine ⟨b, ⟨hxa.trans hab, hby⟩, _⟩,
+  rw ← ha,
+  exact hf'_mono ⟨hxa, hay⟩ ⟨hxa.trans hab, hby⟩ hab
+end
+
+lemma strict_mono_on.strict_convex_on_of_deriv_aux2 {x y : ℝ} {f : ℝ → ℝ}
+  (hf : continuous_on f (Icc x y)) (hxy : x < y)
+  (hf'_mono : strict_mono_on (deriv f) (Ioo x y)) :
+  ∃ a ∈ Ioo x y, (f y - f x) / (y - x) < deriv f a :=
+begin
+  by_cases h : ∀ w ∈ Ioo x y, deriv f w ≠ 0,
+  { apply strict_mono_on.strict_convex_on_of_deriv_aux1 hf hxy hf'_mono h },
+  { push_neg at h,
+    rcases h with ⟨w, ⟨hxw, hwy⟩, hw⟩,
+    obtain ⟨a, ⟨hxa, haw⟩, ha⟩ : ∃ (a : ℝ) (H : a ∈ Ioo x w), (f w - f x) / (w - x) < deriv f a,
+    { apply strict_mono_on.strict_convex_on_of_deriv_aux1 _ hxw _ _,
+      { exact hf.mono (Icc_subset_Icc le_rfl hwy.le) },
+      { exact hf'_mono.mono (Ioo_subset_Ioo le_rfl hwy.le) },
+      { assume z hz,
+        rw ← hw,
+        apply ne_of_lt,
+        exact hf'_mono ⟨hz.1, hz.2.trans hwy⟩ ⟨hxw, hwy⟩ hz.2 } },
+    obtain ⟨b, ⟨hwb, hby⟩, hb⟩ : ∃ (b : ℝ) (H : b ∈ Ioo w y), (f y - f w) / (y - w) < deriv f b,
+    { apply strict_mono_on.strict_convex_on_of_deriv_aux1 _ hwy _ _,
+      { refine hf.mono (Icc_subset_Icc hxw.le le_rfl), },
+      { exact hf'_mono.mono (Ioo_subset_Ioo hxw.le le_rfl) },
+      { assume z hz,
+        rw ← hw,
+        apply ne_of_gt,
+        exact hf'_mono ⟨hxw, hwy⟩ ⟨hxw.trans hz.1, hz.2⟩ hz.1, } },
+    refine ⟨b, ⟨hxw.trans hwb, hby⟩, _⟩,
+    simp only [div_lt_iff, hxy, hxw, hwy, sub_pos] at ⊢ ha hb,
+    have : deriv f a * (w - x) < deriv f b * (w - x),
+    { apply mul_lt_mul _ le_rfl (sub_pos.2 hxw) _,
+      { exact hf'_mono ⟨hxa, haw.trans hwy⟩ ⟨hxw.trans hwb, hby⟩ (haw.trans hwb) },
+      { rw ← hw,
+        exact (hf'_mono ⟨hxw, hwy⟩ ⟨hxw.trans hwb, hby⟩ hwb).le } },
+    linarith }
+end
+
+lemma strict_mono_on.strict_convex_on_of_deriv_aux3 {x y : ℝ} {f : ℝ → ℝ}
+  (hf : continuous_on f (Icc x y)) (hxy : x < y)
+  (hf'_mono : strict_mono_on (deriv f) (Ioo x y)) (h : ∀ w ∈ Ioo x y, deriv f w ≠ 0) :
+  ∃ a ∈ Ioo x y, deriv f a < (f y - f x) / (y - x) :=
+begin
+  have A : differentiable_on ℝ f (Ioo x y),
+  { assume w wmem,
+    apply differentiable_at.differentiable_within_at,
+    exact differentiable_at_of_deriv_ne_zero (h w wmem), },
+  obtain ⟨a, ⟨hxa, hay⟩, ha⟩ : ∃ a ∈ Ioo x y, deriv f a = (f y - f x) / (y - x),
+    from exists_deriv_eq_slope f hxy hf A,
+  rcases nonempty_Ioo.2 hxa with ⟨b, ⟨hxb, hba⟩⟩,
+  refine ⟨b, ⟨hxb, hba.trans hay⟩, _⟩,
+  rw ← ha,
+  exact hf'_mono ⟨hxb, hba.trans hay⟩ ⟨hxa, hay⟩ hba
+end
+
+lemma strict_mono_on.strict_convex_on_of_deriv_aux4 {x y : ℝ} {f : ℝ → ℝ}
+  (hf : continuous_on f (Icc x y)) (hxy : x < y)
+  (hf'_mono : strict_mono_on (deriv f) (Ioo x y)) :
+  ∃ a ∈ Ioo x y, deriv f a < (f y - f x) / (y - x) :=
+begin
+  by_cases h : ∀ w ∈ Ioo x y, deriv f w ≠ 0,
+  { apply strict_mono_on.strict_convex_on_of_deriv_aux3 hf hxy hf'_mono h },
+  { push_neg at h,
+    rcases h with ⟨w, ⟨hxw, hwy⟩, hw⟩,
+    obtain ⟨a, ⟨hxa, haw⟩, ha⟩ : ∃ (a : ℝ) (H : a ∈ Ioo x w), deriv f a < (f w - f x) / (w - x),
+    { apply strict_mono_on.strict_convex_on_of_deriv_aux3 _ hxw _ _,
+      { exact hf.mono (Icc_subset_Icc le_rfl hwy.le) },
+      { exact hf'_mono.mono (Ioo_subset_Ioo le_rfl hwy.le) },
+      { assume z hz,
+        rw ← hw,
+        apply ne_of_lt,
+        exact hf'_mono ⟨hz.1, hz.2.trans hwy⟩ ⟨hxw, hwy⟩ hz.2 } },
+    obtain ⟨b, ⟨hwb, hby⟩, hb⟩ : ∃ (b : ℝ) (H : b ∈ Ioo w y), deriv f b < (f y - f w) / (y - w),
+    { apply strict_mono_on.strict_convex_on_of_deriv_aux3 _ hwy _ _,
+      { refine hf.mono (Icc_subset_Icc hxw.le le_rfl), },
+      { exact hf'_mono.mono (Ioo_subset_Ioo hxw.le le_rfl) },
+      { assume z hz,
+        rw ← hw,
+        apply ne_of_gt,
+        exact hf'_mono ⟨hxw, hwy⟩ ⟨hxw.trans hz.1, hz.2⟩ hz.1, } },
+    refine ⟨a, ⟨hxa, haw.trans hwy⟩, _⟩,
+    simp only [lt_div_iff, hxy, hxw, hwy, sub_pos] at ⊢ ha hb,
+    have : deriv f a * (y - w) < deriv f b * (y - w),
+    { apply mul_lt_mul _ le_rfl (sub_pos.2 hwy) _,
+      { exact hf'_mono ⟨hxa, haw.trans hwy⟩ ⟨hxw.trans hwb, hby⟩ (haw.trans hwb) },
+      { rw ← hw,
+        exact (hf'_mono ⟨hxw, hwy⟩ ⟨hxw.trans hwb, hby⟩ hwb).le } },
+    linarith }
+end
+
+/-- If a function `f` is continuous on a convex set `D ⊆ ℝ`, and `f'` is strictly monotone on the
+interior, then `f` is strictly convex on `D`.
+Note that we don't require differentiability, since it is guaranteed at all but at most
+one point by the strict monotonicity of `f'`. -/
 lemma strict_mono_on.strict_convex_on_of_deriv {D : set ℝ} (hD : convex ℝ D) {f : ℝ → ℝ}
-  (hf : continuous_on f D) (hf' : differentiable_on ℝ f (interior D))
-  (hf'_mono : strict_mono_on (deriv f) (interior D)) :
+  (hf : continuous_on f D) (hf' : strict_mono_on (deriv f) (interior D)) :
   strict_convex_on ℝ D f :=
 strict_convex_on_of_slope_strict_mono_adjacent hD
 begin
@@ -1054,27 +1159,29 @@ begin
   have hyzD : Icc y z ⊆ D, from subset.trans (Icc_subset_Icc_left $ le_of_lt hxy) hxzD,
   have hyzD' : Ioo y z ⊆ interior D,
     from subset_sUnion_of_mem ⟨is_open_Ioo, subset.trans Ioo_subset_Icc_self hyzD⟩,
-  -- Then we apply MVT to both `[x, y]` and `[y, z]`
-  obtain ⟨a, ⟨hxa, hay⟩, ha⟩ : ∃ a ∈ Ioo x y, deriv f a = (f y - f x) / (y - x),
-    from exists_deriv_eq_slope f hxy (hf.mono hxyD) (hf'.mono hxyD'),
-  obtain ⟨b, ⟨hyb, hbz⟩, hb⟩ : ∃ b ∈ Ioo y z, deriv f b = (f z - f y) / (z - y),
-    from exists_deriv_eq_slope f hyz (hf.mono hyzD) (hf'.mono hyzD'),
-  rw [← ha, ← hb],
-  exact hf'_mono (hxyD' ⟨hxa, hay⟩) (hyzD' ⟨hyb, hbz⟩) (hay.trans hyb)
+  -- Then we get points `a` and `b` in each interval `[x, y]` and `[y, z]` where the derivatives
+  -- can be compared to the slopes between `x, y` and `, z` respectively.
+  obtain ⟨a, ⟨hxa, hay⟩, ha⟩ : ∃ a ∈ Ioo x y, (f y - f x) / (y - x) < deriv f a,
+    from strict_mono_on.strict_convex_on_of_deriv_aux2 (hf.mono hxyD) hxy (hf'.mono hxyD'),
+  obtain ⟨b, ⟨hyb, hbz⟩, hb⟩ : ∃ b ∈ Ioo y z, deriv f b < (f z - f y) / (z - y),
+    from strict_mono_on.strict_convex_on_of_deriv_aux4 (hf.mono hyzD) hyz (hf'.mono hyzD'),
+  apply ha.trans (lt_trans _ hb),
+  exact hf' (hxyD' ⟨hxa, hay⟩) (hyzD' ⟨hyb, hbz⟩) (hay.trans hyb),
 end
 
-/-- If a function `f` is continuous on a convex set `D ⊆ ℝ`, is differentiable on its interior,
-and `f'` is strictly antitone on the interior, then `f` is strictly concave on `D`. -/
+/-- If a function `f` is continuous on a convex set `D ⊆ ℝ` and `f'` is strictly antitone on the
+interior, then `f` is strictly concave on `D`.
+Note that we don't require differentiability, since it is guaranteed at all but at most
+one point by the strict antitonicity of `f'`. -/
 lemma strict_anti_on.strict_concave_on_of_deriv {D : set ℝ} (hD : convex ℝ D) {f : ℝ → ℝ}
-  (hf : continuous_on f D) (hf' : differentiable_on ℝ f (interior D))
-  (h_anti : strict_anti_on (deriv f) (interior D)) :
+  (hf : continuous_on f D) (h_anti : strict_anti_on (deriv f) (interior D)) :
   strict_concave_on ℝ D f :=
 begin
   have : strict_mono_on (deriv (-f)) (interior D),
   { intros x hx y hy hxy,
     convert neg_lt_neg (h_anti hx hy hxy);
     convert deriv.neg },
-  exact neg_strict_convex_on_iff.mp (this.strict_convex_on_of_deriv hD hf.neg hf'.neg),
+  exact neg_strict_convex_on_iff.mp (this.strict_convex_on_of_deriv hD hf.neg),
 end
 
 /-- If a function `f` is differentiable and `f'` is monotone on `ℝ` then `f` is convex. -/
@@ -1089,20 +1196,20 @@ theorem antitone.concave_on_univ_of_deriv {f : ℝ → ℝ} (hf : differentiable
 (hf'_anti.antitone_on _).concave_on_of_deriv convex_univ hf.continuous.continuous_on
   hf.differentiable_on
 
-/-- If a function `f` is differentiable and `f'` is strictly monotone on `ℝ` then `f` is strictly
-convex. -/
-lemma strict_mono.strict_convex_on_univ_of_deriv {f : ℝ → ℝ} (hf : differentiable ℝ f)
+/-- If a function `f` is continuous and `f'` is strictly monotone on `ℝ` then `f` is strictly
+convex. Note that we don't require differentiability, since it is guaranteed at all but at most
+one point by the strict monotonicity of `f'`. -/
+lemma strict_mono.strict_convex_on_univ_of_deriv {f : ℝ → ℝ} (hf : continuous f)
   (hf'_mono : strict_mono (deriv f)) :
   strict_convex_on ℝ univ f :=
-(hf'_mono.strict_mono_on _).strict_convex_on_of_deriv convex_univ hf.continuous.continuous_on
-  hf.differentiable_on
+(hf'_mono.strict_mono_on _).strict_convex_on_of_deriv convex_univ hf.continuous_on
 
-/-- If a function `f` is differentiable and `f'` is strictly antitone on `ℝ` then `f` is strictly
-concave. -/
-lemma strict_anti.strict_concave_on_univ_of_deriv {f : ℝ → ℝ} (hf : differentiable ℝ f)
+/-- If a function `f` is continuous and `f'` is strictly antitone on `ℝ` then `f` is strictly
+concave. Note that we don't require differentiability, since it is guaranteed at all but at most
+one point by the strict antitonicity of `f'`. -/
+lemma strict_anti.strict_concave_on_univ_of_deriv {f : ℝ → ℝ} (hf : continuous f)
   (hf'_anti : strict_anti (deriv f)) : strict_concave_on ℝ univ f :=
-(hf'_anti.strict_anti_on _).strict_concave_on_of_deriv convex_univ hf.continuous.continuous_on
-  hf.differentiable_on
+(hf'_anti.strict_anti_on _).strict_concave_on_of_deriv convex_univ hf.continuous_on
 
 /-- If a function `f` is continuous on a convex set `D ⊆ ℝ`, is twice differentiable on its
 interior, and `f''` is nonnegative on the interior, then `f` is convex on `D`. -/
@@ -1124,72 +1231,68 @@ theorem concave_on_of_deriv2_nonpos {D : set ℝ} (hD : convex ℝ D) {f : ℝ �
 (hD.interior.antitone_on_of_deriv_nonpos hf''.continuous_on (by rwa interior_interior)
   $ by rwa interior_interior).concave_on_of_deriv hD hf hf'
 
-/-- If a function `f` is continuous on a convex set `D ⊆ ℝ`, is twice differentiable on its
-interior, and `f''` is strictly positive on the interior, then `f` is strictly convex on `D`.
-Note that we don't require twice differentiability explicitly as it already implied by the second
-derivative being strictly positive. -/
+/-- If a function `f` is continuous on a convex set `D ⊆ ℝ` and `f''` is strictly positive on the
+interior, then `f` is strictly convex on `D`.
+Note that we don't require twice differentiability explicitly as it is already implied by the second
+derivative being strictly positive, except at at most one point. -/
 lemma strict_convex_on_of_deriv2_pos {D : set ℝ} (hD : convex ℝ D) {f : ℝ → ℝ}
-  (hf : continuous_on f D) (hf' : differentiable_on ℝ f (interior D))
-  (hf'' : ∀ x ∈ interior D, 0 < (deriv^[2] f) x) :
+  (hf : continuous_on f D) (hf'' : ∀ x ∈ interior D, 0 < (deriv^[2] f) x) :
   strict_convex_on ℝ D f :=
 (hD.interior.strict_mono_on_of_deriv_pos (λ z hz,
   (differentiable_at_of_deriv_ne_zero (hf'' z hz).ne').differentiable_within_at
-   .continuous_within_at) $ by rwa interior_interior).strict_convex_on_of_deriv hD hf hf'
+   .continuous_within_at) $ by rwa interior_interior).strict_convex_on_of_deriv hD hf
 
-/-- If a function `f` is continuous on a convex set `D ⊆ ℝ`, is twice differentiable on its
-interior, and `f''` is strictly negative on the interior, then `f` is strictly concave on `D`.
+/-- If a function `f` is continuous on a convex set `D ⊆ ℝ` and `f''` is strictly negative on the
+interior, then `f` is strictly concave on `D`.
 Note that we don't require twice differentiability explicitly as it already implied by the second
-derivative being strictly negative. -/
+derivative being strictly negative, except at at most one point. -/
 lemma strict_concave_on_of_deriv2_neg {D : set ℝ} (hD : convex ℝ D) {f : ℝ → ℝ}
-  (hf : continuous_on f D) (hf' : differentiable_on ℝ f (interior D))
-  (hf'' : ∀ x ∈ interior D, deriv^[2] f x < 0) :
+  (hf : continuous_on f D) (hf'' : ∀ x ∈ interior D, deriv^[2] f x < 0) :
   strict_concave_on ℝ D f :=
 (hD.interior.strict_anti_on_of_deriv_neg (λ z hz,
   (differentiable_at_of_deriv_ne_zero (hf'' z hz).ne).differentiable_within_at
-   .continuous_within_at) $ by rwa interior_interior).strict_concave_on_of_deriv hD hf hf'
+   .continuous_within_at) $ by rwa interior_interior).strict_concave_on_of_deriv hD hf
 
 /-- If a function `f` is twice differentiable on a open convex set `D ⊆ ℝ` and
 `f''` is nonnegative on `D`, then `f` is convex on `D`. -/
-theorem convex_on_open_of_deriv2_nonneg {D : set ℝ} (hD : convex ℝ D) (hD₂ : is_open D) {f : ℝ → ℝ}
+theorem convex_on_of_deriv2_nonneg' {D : set ℝ} (hD : convex ℝ D) {f : ℝ → ℝ}
   (hf' : differentiable_on ℝ f D) (hf'' : differentiable_on ℝ (deriv f) D)
   (hf''_nonneg : ∀ x ∈ D, 0 ≤ (deriv^[2] f) x) : convex_on ℝ D f :=
-convex_on_of_deriv2_nonneg hD hf'.continuous_on (by simpa [hD₂.interior_eq] using hf')
-  (by simpa [hD₂.interior_eq] using hf'') (by simpa [hD₂.interior_eq] using hf''_nonneg)
+convex_on_of_deriv2_nonneg hD hf'.continuous_on (hf'.mono interior_subset)
+  (hf''.mono interior_subset) (λ x hx, hf''_nonneg x (interior_subset hx))
 
 /-- If a function `f` is twice differentiable on an open convex set `D ⊆ ℝ` and
 `f''` is nonpositive on `D`, then `f` is concave on `D`. -/
-theorem concave_on_open_of_deriv2_nonpos {D : set ℝ} (hD : convex ℝ D) (hD₂ : is_open D) {f : ℝ → ℝ}
+theorem concave_on_of_deriv2_nonpos' {D : set ℝ} (hD : convex ℝ D) {f : ℝ → ℝ}
   (hf' : differentiable_on ℝ f D) (hf'' : differentiable_on ℝ (deriv f) D)
   (hf''_nonpos : ∀ x ∈ D, deriv^[2] f x ≤ 0) : concave_on ℝ D f :=
-concave_on_of_deriv2_nonpos hD hf'.continuous_on (by simpa [hD₂.interior_eq] using hf')
-  (by simpa [hD₂.interior_eq] using hf'') (by simpa [hD₂.interior_eq] using hf''_nonpos)
+concave_on_of_deriv2_nonpos hD hf'.continuous_on (hf'.mono interior_subset)
+  (hf''.mono interior_subset) (λ x hx, hf''_nonpos x (interior_subset hx))
 
-/-- If a function `f` is twice differentiable on a open convex set `D ⊆ ℝ` and
-`f''` is strictly positive on `D`, then `f` is strictly convex on `D`.
-Note that we don't require twice differentiability explicitly as it already implied by the second
-derivative being strictly positive. -/
-lemma strict_convex_on_open_of_deriv2_pos {D : set ℝ} (hD : convex ℝ D) (hD₂ : is_open D)
-  {f : ℝ → ℝ} (hf' : differentiable_on ℝ f D) (hf'' : ∀ x ∈ D, 0 < (deriv^[2] f) x) :
+/-- If a function `f` is continuous on a convex set `D ⊆ ℝ` and `f''` is strictly positive on `D`,
+then `f` is strictly convex on `D`.
+Note that we don't require twice differentiability explicitly as it is already implied by the second
+derivative being strictly positive, except at at most one point. -/
+lemma strict_convex_on_of_deriv2_pos' {D : set ℝ} (hD : convex ℝ D)
+  {f : ℝ → ℝ} (hf : continuous_on f D) (hf'' : ∀ x ∈ D, 0 < (deriv^[2] f) x) :
   strict_convex_on ℝ D f :=
-strict_convex_on_of_deriv2_pos hD hf'.continuous_on (by simpa [hD₂.interior_eq] using hf') $
-  by simpa [hD₂.interior_eq] using hf''
+strict_convex_on_of_deriv2_pos hD hf $ λ x hx, hf'' x (interior_subset hx)
 
-/-- If a function `f` is twice differentiable on an open convex set `D ⊆ ℝ` and
-`f''` is strictly negative on `D`, then `f` is strictly concave on `D`.
-Note that we don't require twice differentiability explicitly as it already implied by the second
-derivative being strictly negative. -/
-lemma strict_concave_on_open_of_deriv2_neg {D : set ℝ} (hD : convex ℝ D) (hD₂ : is_open D)
-  {f : ℝ → ℝ} (hf' : differentiable_on ℝ f D) (hf'' : ∀ x ∈ D, deriv^[2] f x < 0) :
+/-- If a function `f` is continuous on a convex set `D ⊆ ℝ` and `f''` is strictly negative on `D`,
+then `f` is strictly concave on `D`.
+Note that we don't require twice differentiability explicitly as it is already implied by the second
+derivative being strictly negative, except at at most one point. -/
+lemma strict_concave_on_of_deriv2_neg' {D : set ℝ} (hD : convex ℝ D)
+  {f : ℝ → ℝ} (hf : continuous_on f D) (hf'' : ∀ x ∈ D, deriv^[2] f x < 0) :
   strict_concave_on ℝ D f :=
-strict_concave_on_of_deriv2_neg hD hf'.continuous_on (by simpa [hD₂.interior_eq] using hf') $
-  by simpa [hD₂.interior_eq] using hf''
+strict_concave_on_of_deriv2_neg hD hf $ λ x hx, hf'' x (interior_subset hx)
 
 /-- If a function `f` is twice differentiable on `ℝ`, and `f''` is nonnegative on `ℝ`,
 then `f` is convex on `ℝ`. -/
 theorem convex_on_univ_of_deriv2_nonneg {f : ℝ → ℝ} (hf' : differentiable ℝ f)
   (hf'' : differentiable ℝ (deriv f)) (hf''_nonneg : ∀ x, 0 ≤ (deriv^[2] f) x) :
   convex_on ℝ univ f :=
-convex_on_open_of_deriv2_nonneg convex_univ is_open_univ hf'.differentiable_on
+convex_on_of_deriv2_nonneg' convex_univ hf'.differentiable_on
   hf''.differentiable_on (λ x _, hf''_nonneg x)
 
 /-- If a function `f` is twice differentiable on `ℝ`, and `f''` is nonpositive on `ℝ`,
@@ -1197,26 +1300,26 @@ then `f` is concave on `ℝ`. -/
 theorem concave_on_univ_of_deriv2_nonpos {f : ℝ → ℝ} (hf' : differentiable ℝ f)
   (hf'' : differentiable ℝ (deriv f)) (hf''_nonpos : ∀ x, deriv^[2] f x ≤ 0) :
   concave_on ℝ univ f :=
-concave_on_open_of_deriv2_nonpos convex_univ is_open_univ hf'.differentiable_on
+concave_on_of_deriv2_nonpos' convex_univ hf'.differentiable_on
   hf''.differentiable_on (λ x _, hf''_nonpos x)
 
-/-- If a function `f` is twice differentiable on `ℝ`, and `f''` is strictly positive on `ℝ`,
+/-- If a function `f` is continuous on `ℝ`, and `f''` is strictly positive on `ℝ`,
 then `f` is strictly convex on `ℝ`.
-Note that we don't require twice differentiability explicitly as it already implied by the second
-derivative being strictly positive. -/
-lemma strict_convex_on_univ_of_deriv2_pos {f : ℝ → ℝ} (hf' : differentiable ℝ f)
+Note that we don't require twice differentiability explicitly as it is already implied by the second
+derivative being strictly positive, except at at most one point.  -/
+lemma strict_convex_on_univ_of_deriv2_pos {f : ℝ → ℝ} (hf : continuous f)
   (hf'' : ∀ x, 0 < (deriv^[2] f) x) :
   strict_convex_on ℝ univ f :=
-strict_convex_on_open_of_deriv2_pos convex_univ is_open_univ hf'.differentiable_on $ λ x _, hf'' x
+strict_convex_on_of_deriv2_pos' convex_univ hf.continuous_on $ λ x _, hf'' x
 
-/-- If a function `f` is twice differentiable on `ℝ`, and `f''` is strictly negative on `ℝ`,
+/-- If a function `f` is continuous on `ℝ`, and `f''` is strictly negative on `ℝ`,
 then `f` is strictly concave on `ℝ`.
-Note that we don't require twice differentiability explicitly as it already implied by the second
-derivative being strictly negative. -/
-lemma strict_concave_on_univ_of_deriv2_neg {f : ℝ → ℝ} (hf' : differentiable ℝ f)
+Note that we don't require twice differentiability explicitly as it is already implied by the second
+derivative being strictly negative, except at at most one point.  -/
+lemma strict_concave_on_univ_of_deriv2_neg {f : ℝ → ℝ} (hf : continuous f)
   (hf'' : ∀ x, deriv^[2] f x < 0) :
   strict_concave_on ℝ univ f :=
-strict_concave_on_open_of_deriv2_neg convex_univ is_open_univ hf'.differentiable_on $ λ x _, hf'' x
+strict_concave_on_of_deriv2_neg' convex_univ hf.continuous_on $ λ x _, hf'' x
 
 /-! ### Functions `f : E → ℝ` -/
 

--- a/src/analysis/convex/function.lean
+++ b/src/analysis/convex/function.lean
@@ -316,9 +316,9 @@ lemma linear_order.concave_on_of_lt (hs : convex 𝕜 s)
 @linear_order.convex_on_of_lt _ _ βᵒᵈ _ _ _ _ _ _ s f hs hf
 
 /-- For a function on a convex set in a linearly ordered space (where the order and the algebraic
-structures aren't necessarily compatible), in order to prove that it is convex, it suffices to
-verify the inequality `f (a • x + b • y) ≤ a • f x + b • f y` for `x < y` and positive `a`, `b`. The
-main use case is `E = 𝕜` however one can apply it, e.g., to `𝕜^n` with lexicographic order. -/
+structures aren't necessarily compatible), in order to prove that it is strictly convex, it suffices
+to verify the inequality `f (a • x + b • y) < a • f x + b • f y` for `x < y` and positive `a`, `b`.
+The main use case is `E = 𝕜` however one can apply it, e.g., to `𝕜^n` with lexicographic order. -/
 lemma linear_order.strict_convex_on_of_lt (hs : convex 𝕜 s)
   (hf : ∀ ⦃x y : E⦄, x ∈ s → y ∈ s → x < y → ∀ ⦃a b : 𝕜⦄, 0 < a → 0 < b → a + b = 1 →
     f (a • x + b • y) < a • f x + b • f y) : strict_convex_on 𝕜 s f :=
@@ -330,9 +330,9 @@ begin
 end
 
 /-- For a function on a convex set in a linearly ordered space (where the order and the algebraic
-structures aren't necessarily compatible), in order to prove that it is concave it suffices to
-verify the inequality `a • f x + b • f y ≤ f (a • x + b • y)` for `x < y` and positive `a`, `b`. The
-main use case is `E = 𝕜` however one can apply it, e.g., to `𝕜^n` with lexicographic order. -/
+structures aren't necessarily compatible), in order to prove that it is strictly concave it suffices
+to verify the inequality `a • f x + b • f y < f (a • x + b • y)` for `x < y` and positive `a`, `b`.
+The main use case is `E = 𝕜` however one can apply it, e.g., to `𝕜^n` with lexicographic order. -/
 lemma linear_order.strict_concave_on_of_lt (hs : convex 𝕜 s)
   (hf : ∀ ⦃x y : E⦄, x ∈ s → y ∈ s → x < y → ∀ ⦃a b : 𝕜⦄, 0 < a → 0 < b → a + b = 1 →
      a • f x + b • f y < f (a • x + b • y)) : strict_concave_on 𝕜 s f :=

--- a/src/analysis/convex/specific_functions.lean
+++ b/src/analysis/convex/specific_functions.lean
@@ -34,7 +34,7 @@ open_locale big_operators
 
 /-- `exp` is strictly convex on the whole real line. -/
 lemma strict_convex_on_exp : strict_convex_on ℝ univ exp :=
-strict_convex_on_univ_of_deriv2_pos differentiable_exp (λ x, (iter_deriv_exp 2).symm ▸ exp_pos x)
+strict_convex_on_univ_of_deriv2_pos continuous_exp (λ x, (iter_deriv_exp 2).symm ▸ exp_pos x)
 
 /-- `exp` is convex on the whole real line. -/
 lemma convex_on_exp : convex_on ℝ univ exp := strict_convex_on_exp.convex_on
@@ -54,7 +54,7 @@ end
 lemma even.strict_convex_on_pow {n : ℕ} (hn : even n) (h : n ≠ 0) :
   strict_convex_on ℝ set.univ (λ x : ℝ, x^n) :=
 begin
-  apply strict_mono.strict_convex_on_univ_of_deriv (differentiable_pow n),
+  apply strict_mono.strict_convex_on_univ_of_deriv (continuous_pow n),
   rw deriv_pow',
   replace h := nat.pos_of_ne_zero h,
   exact strict_mono.const_mul (odd.strict_mono_pow $ nat.even.sub_odd h hn $ nat.odd_iff.2 rfl)
@@ -75,8 +75,7 @@ end
 /-- `x^n`, `n : ℕ` is strictly convex on `[0, +∞)` for all `n` greater than `2`. -/
 lemma strict_convex_on_pow {n : ℕ} (hn : 2 ≤ n) : strict_convex_on ℝ (Ici 0) (λ x : ℝ, x^n) :=
 begin
-  apply strict_mono_on.strict_convex_on_of_deriv (convex_Ici _) (continuous_on_pow _)
-    (differentiable_on_pow n),
+  apply strict_mono_on.strict_convex_on_of_deriv (convex_Ici _) (continuous_on_pow _),
   rw [deriv_pow', interior_Ici],
   exact λ x (hx : 0 < x) y hy hxy, mul_lt_mul_of_pos_left (pow_lt_pow_of_lt_left hxy hx.le $
     nat.sub_pos_of_lt hn) (nat.cast_pos.2 $ zero_lt_two.trans_le hn),
@@ -138,12 +137,8 @@ end
 lemma strict_convex_on_zpow {m : ℤ} (hm₀ : m ≠ 0) (hm₁ : m ≠ 1) :
   strict_convex_on ℝ (Ioi 0) (λ x : ℝ, x^m) :=
 begin
-  have : ∀ n : ℤ, differentiable_on ℝ (λ x, x ^ n) (Ioi (0 : ℝ)),
-    from λ n, differentiable_on_zpow _ _ (or.inl $ lt_irrefl _),
-  apply strict_convex_on_of_deriv2_pos (convex_Ioi 0),
-  { exact (this _).continuous_on },
-   all_goals { rw interior_Ioi },
-  { exact this _ },
+  apply strict_convex_on_of_deriv2_pos' (convex_Ioi 0),
+  { exact (continuous_on_zpow₀ m).mono (λ x hx, ne_of_gt hx) },
   intros x hx,
   rw iter_deriv_zpow,
   refine mul_pos _ (zpow_pos_of_pos hx _),
@@ -175,7 +170,6 @@ begin
   have A : deriv (λ (x : ℝ), x ^ p) = λ x, p * x^(p-1), by { ext x, simp [hp.le] },
   apply strict_convex_on_of_deriv2_pos (convex_Ici 0),
   { exact continuous_on_id.rpow_const (λ x _, or.inr (zero_le_one.trans hp.le)) },
-  { exact (differentiable_rpow_const hp.le).differentiable_on },
   rw interior_Ici,
   rintro x (hx : 0 < x),
   suffices : 0 < p * ((p - 1) * x ^ (p - 1 - 1)), by simpa [ne_of_gt hx, A],
@@ -186,8 +180,8 @@ lemma strict_concave_on_log_Ioi : strict_concave_on ℝ (Ioi 0) log :=
 begin
   have h₁ : Ioi 0 ⊆ ({0} : set ℝ)ᶜ,
   { exact λ x (hx : 0 < x) (hx' : x = 0), hx.ne' hx' },
-  refine strict_concave_on_open_of_deriv2_neg (convex_Ioi 0) is_open_Ioi
-    (differentiable_on_log.mono h₁) (λ x (hx : 0 < x), _),
+  refine strict_concave_on_of_deriv2_neg' (convex_Ioi 0)
+    (continuous_on_log.mono h₁) (λ x (hx : 0 < x), _),
   rw [function.iterate_succ, function.iterate_one],
   change (deriv (deriv log)) x < 0,
   rw [deriv_log', deriv_inv],
@@ -198,8 +192,8 @@ lemma strict_concave_on_log_Iio : strict_concave_on ℝ (Iio 0) log :=
 begin
   have h₁ : Iio 0 ⊆ ({0} : set ℝ)ᶜ,
   { exact λ x (hx : x < 0) (hx' : x = 0), hx.ne hx' },
-  refine strict_concave_on_open_of_deriv2_neg (convex_Iio 0) is_open_Iio
-    (differentiable_on_log.mono h₁) (λ x (hx : x < 0), _),
+  refine strict_concave_on_of_deriv2_neg' (convex_Iio 0)
+    (continuous_on_log.mono h₁) (λ x (hx : x < 0), _),
   rw [function.iterate_succ, function.iterate_one],
   change (deriv (deriv log)) x < 0,
   rw [deriv_log', deriv_inv],
@@ -241,11 +235,9 @@ end
 
 lemma strict_concave_on_sqrt_mul_log_Ioi : strict_concave_on ℝ (set.Ioi 1) (λ x, sqrt x * log x) :=
 begin
-  refine strict_concave_on_open_of_deriv2_neg (convex_Ioi 1) is_open_Ioi
-    (λ x hx, differentiable_within_at_of_deriv_within_ne_zero _) (λ x hx, _),
-  { rw [deriv_within_of_open is_open_Ioi hx, deriv_sqrt_mul_log x (zero_lt_one.trans hx)],
-    refine div_ne_zero _ (mul_ne_zero two_ne_zero (sqrt_ne_zero'.mpr (zero_lt_one.trans hx))),
-    linarith [log_pos hx] },
+  apply strict_concave_on_of_deriv2_neg' (convex_Ioi 1) _ (λ x hx, _),
+  { exact continuous_sqrt.continuous_on.mul
+      (continuous_on_log.mono (λ x hx, ne_of_gt (zero_lt_one.trans hx))) },
   { rw deriv2_sqrt_mul_log x (zero_lt_one.trans hx),
     exact div_neg_of_neg_of_pos (neg_neg_of_pos (log_pos hx))
       (mul_pos four_pos (pow_pos (sqrt_pos.mpr (zero_lt_one.trans hx)) 3)) },
@@ -257,16 +249,14 @@ open_locale real
 
 lemma strict_concave_on_sin_Icc : strict_concave_on ℝ (Icc 0 π) sin :=
 begin
-  apply strict_concave_on_of_deriv2_neg (convex_Icc _ _) continuous_on_sin
-    differentiable_sin.differentiable_on (λ x hx, _),
+  apply strict_concave_on_of_deriv2_neg (convex_Icc _ _) continuous_on_sin (λ x hx, _),
   rw interior_Icc at hx,
   simp [sin_pos_of_mem_Ioo hx],
 end
 
 lemma strict_concave_on_cos_Icc : strict_concave_on ℝ (Icc (-(π/2)) (π/2)) cos :=
 begin
-  apply strict_concave_on_of_deriv2_neg (convex_Icc _ _) continuous_on_cos
-    differentiable_cos.differentiable_on (λ x hx, _),
+  apply strict_concave_on_of_deriv2_neg (convex_Icc _ _) continuous_on_cos (λ x hx, _),
   rw interior_Icc at hx,
   simp [cos_pos_of_mem_Ioo hx],
 end


### PR DESCRIPTION
Currently, the lemma `strict_mono_on.strict_convex_on_of_deriv` states that, if a real function `f` is continuous on a convex set `D`, differentiable on its interior, and `deriv f` is strictly monotone on its interior, then `f` is convex on `D`. We remove the differentiability assumption: since `deriv f` is strictly monotone, there is at most one point of nondifferentiability (as `deriv f x = 0` when `f` is not differentiable), and the result is still true (although the proof is a little bit more complicated) in this case.

Of course, in essentially all applications the functions will be differentiable, but the lemma becomes easier to use as the user doesn't need to prove this differentiability.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
