### PR TITLE
[Merged by Bors] - chore(logic/is_empty): add lemmas for subtype, sigma, and psigma

### DIFF
--- a/src/logic/is_empty.lean
+++ b/src/logic/is_empty.lean
@@ -117,7 +117,7 @@ by simp only [← not_nonempty_iff, nonempty_sum, not_or_distrib]
 by simp only [← not_nonempty_iff, nonempty_psum, not_or_distrib]
 
 @[simp] lemma is_empty_subtype (p : α → Prop) : is_empty (subtype p) ↔ ∀ x, ¬p x :=
-⟨λ h i hi, h.elim' $ subtype.mk i hi, subtype.is_empty_of_false⟩
+by simp only [← not_nonempty_iff, nonempty_subtype, not_exists]
 
 lemma well_founded_of_empty {α} [is_empty α] (r : α → α → Prop) : well_founded r :=
 ⟨is_empty_elim⟩

--- a/src/logic/is_empty.lean
+++ b/src/logic/is_empty.lean
@@ -101,8 +101,22 @@ end is_empty
 @[simp] lemma not_is_empty_iff : ¬ is_empty α ↔ nonempty α :=
 not_iff_comm.mp not_nonempty_iff
 
+@[simp] lemma is_empty_Prop {p : Prop} : is_empty p ↔ ¬p :=
+by simp only [← not_nonempty_iff, nonempty_Prop]
+
 @[simp] lemma is_empty_pi {π : α → Sort*} : is_empty (Π a, π a) ↔ ∃ a, is_empty (π a) :=
 by simp only [← not_nonempty_iff, classical.nonempty_pi, not_forall]
+
+@[simp] lemma is_empty_sigma {α} {E : α → Type*} :
+  is_empty (sigma E) ↔ ∀ a, is_empty (E a) :=
+by simp only [← not_nonempty_iff, nonempty_sigma, not_exists]
+
+@[simp] lemma is_empty_psigma {α} {E : α → Type*} :
+  is_empty (psigma E) ↔ ∀ a, is_empty (E a) :=
+by simp only [← not_nonempty_iff, nonempty_psigma, not_exists]
+
+@[simp] lemma is_empty_subtype (p : α → Prop) : is_empty (subtype p) ↔ ∀ x, ¬p x :=
+by simp only [← not_nonempty_iff, nonempty_subtype, not_exists]
 
 @[simp] lemma is_empty_prod {α β : Type*} : is_empty (α × β) ↔ is_empty α ∨ is_empty β :=
 by simp only [← not_nonempty_iff, nonempty_prod, not_and_distrib]
@@ -116,16 +130,11 @@ by simp only [← not_nonempty_iff, nonempty_sum, not_or_distrib]
 @[simp] lemma is_empty_psum {α β} : is_empty (psum α β) ↔ is_empty α ∧ is_empty β :=
 by simp only [← not_nonempty_iff, nonempty_psum, not_or_distrib]
 
-@[simp] lemma is_empty_psigma {α} {E : α → Type*} :
-  is_empty (psigma E) ↔ ∀ a, is_empty (E a) :=
-by simp only [← not_nonempty_iff, nonempty_psigma, not_exists]
+@[simp] lemma is_empty_ulift {α} : is_empty (ulift α) ↔ is_empty α :=
+by simp only [← not_nonempty_iff, nonempty_ulift]
 
-@[simp] lemma is_empty_sigma {α} {E : α → Type*} :
-  is_empty (sigma E) ↔ ∀ a, is_empty (E a) :=
-by simp only [← not_nonempty_iff, nonempty_sigma, not_exists]
-
-@[simp] lemma is_empty_subtype (p : α → Prop) : is_empty (subtype p) ↔ ∀ x, ¬p x :=
-by simp only [← not_nonempty_iff, nonempty_subtype, not_exists]
+@[simp] lemma is_empty_plift {α} : is_empty (plift α) ↔ is_empty α :=
+by simp only [← not_nonempty_iff, nonempty_plift]
 
 lemma well_founded_of_empty {α} [is_empty α] (r : α → α → Prop) : well_founded r :=
 ⟨is_empty_elim⟩

--- a/src/logic/is_empty.lean
+++ b/src/logic/is_empty.lean
@@ -116,8 +116,11 @@ by simp only [← not_nonempty_iff, nonempty_sum, not_or_distrib]
 @[simp] lemma is_empty_psum {α β} : is_empty (psum α β) ↔ is_empty α ∧ is_empty β :=
 by simp only [← not_nonempty_iff, nonempty_psum, not_or_distrib]
 
+@[simp] lemma is_empty_subtype (p : α → Prop) : is_empty (subtype p) ↔ ∀ x, ¬p x :=
+⟨λ h i hi, h.elim' $ subtype.mk i hi, subtype.is_empty_of_false⟩
+
 lemma well_founded_of_empty {α} [is_empty α] (r : α → α → Prop) : well_founded r :=
-⟨is_empty_elim⟩ 
+⟨is_empty_elim⟩
 
 variables (α)
 

--- a/src/logic/is_empty.lean
+++ b/src/logic/is_empty.lean
@@ -116,6 +116,14 @@ by simp only [← not_nonempty_iff, nonempty_sum, not_or_distrib]
 @[simp] lemma is_empty_psum {α β} : is_empty (psum α β) ↔ is_empty α ∧ is_empty β :=
 by simp only [← not_nonempty_iff, nonempty_psum, not_or_distrib]
 
+@[simp] lemma is_empty_psigma {α} {E : α → Type*} :
+  is_empty (psigma E) ↔ ∀ a, is_empty (E a) :=
+by simp only [← not_nonempty_iff, nonempty_psigma, not_exists]
+
+@[simp] lemma is_empty_sigma {α} {E : α → Type*} :
+  is_empty (sigma E) ↔ ∀ a, is_empty (E a) :=
+by simp only [← not_nonempty_iff, nonempty_sigma, not_exists]
+
 @[simp] lemma is_empty_subtype (p : α → Prop) : is_empty (subtype p) ↔ ∀ x, ¬p x :=
 by simp only [← not_nonempty_iff, nonempty_subtype, not_exists]
 

--- a/src/logic/is_empty.lean
+++ b/src/logic/is_empty.lean
@@ -111,7 +111,7 @@ by simp only [← not_nonempty_iff, classical.nonempty_pi, not_forall]
   is_empty (sigma E) ↔ ∀ a, is_empty (E a) :=
 by simp only [← not_nonempty_iff, nonempty_sigma, not_exists]
 
-@[simp] lemma is_empty_psigma {α} {E : α → Type*} :
+@[simp] lemma is_empty_psigma {α} {E : α → Sort*} :
   is_empty (psigma E) ↔ ∀ a, is_empty (E a) :=
 by simp only [← not_nonempty_iff, nonempty_psigma, not_exists]
 

--- a/src/logic/nonempty.lean
+++ b/src/logic/nonempty.lean
@@ -38,6 +38,9 @@ lemma not_nonempty_iff_imp_false {α : Sort*} : ¬ nonempty α ↔ α → false 
 @[simp] lemma nonempty_sigma : nonempty (Σa:α, γ a) ↔ (∃a:α, nonempty (γ a)) :=
 iff.intro (assume ⟨⟨a, c⟩⟩, ⟨a, ⟨c⟩⟩) (assume ⟨a, ⟨c⟩⟩, ⟨⟨a, c⟩⟩)
 
+@[simp] lemma nonempty_psigma {α} {β : α → Sort*} : nonempty (psigma β) ↔ (∃a:α, nonempty (β a)) :=
+iff.intro (assume ⟨⟨a, c⟩⟩, ⟨a, ⟨c⟩⟩) (assume ⟨a, ⟨c⟩⟩, ⟨⟨a, c⟩⟩)
+
 @[simp] lemma nonempty_subtype {α} {p : α → Prop} : nonempty (subtype p) ↔ (∃a:α, p a) :=
 iff.intro (assume ⟨⟨a, h⟩⟩, ⟨a, h⟩) (assume ⟨a, h⟩, ⟨⟨a, h⟩⟩)
 
@@ -56,9 +59,6 @@ iff.intro
 iff.intro
   (assume ⟨h⟩, match h with psum.inl a := or.inl ⟨a⟩ | psum.inr b := or.inr ⟨b⟩ end)
   (assume h, match h with or.inl ⟨a⟩ := ⟨psum.inl a⟩ | or.inr ⟨b⟩ := ⟨psum.inr b⟩ end)
-
-@[simp] lemma nonempty_psigma {α} {β : α → Sort*} : nonempty (psigma β) ↔ (∃a:α, nonempty (β a)) :=
-iff.intro (assume ⟨⟨a, c⟩⟩, ⟨a, ⟨c⟩⟩) (assume ⟨a, ⟨c⟩⟩, ⟨⟨a, c⟩⟩)
 
 @[simp] lemma nonempty_empty : ¬ nonempty empty :=
 assume ⟨h⟩, h.elim


### PR DESCRIPTION
This reorders the nonempty lemmas to put `sigma` next to `psigma`. The resulting `is_empty` and `nonempty` lemmas are now in the same order.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
