### PR TITLE
[Merged by Bors] - feat(order/lattice, order/lattice_intervals): coe inf/sup lemmas

### DIFF
--- a/src/order/lattice.lean
+++ b/src/order/lattice.lean
@@ -980,9 +980,19 @@ protected def lattice [lattice α] {P : α → Prop}
   = x ⊔ y := rfl
 
 @[simp, norm_cast] lemma coe_inf [semilattice_inf α] {P : α → Prop}
-  (Psup : ∀⦃x y⦄, P x → P y → P (x ⊓ y)) (x y : subtype P) :
-(@has_inf.inf _ (@semilattice_inf.to_has_inf _ (subtype.semilattice_inf Psup)) x y : α)
+(Pinf : ∀⦃x y⦄, P x → P y → P (x ⊓ y)) (x y : subtype P) :
+(@has_inf.inf _ (@semilattice_inf.to_has_inf _ (subtype.semilattice_inf Pinf)) x y : α)
   = x ⊓ y := rfl
+
+@[simp] lemma subtype.mk_inf [semilattice_inf α] {P : α → Prop}
+(Pinf : ∀⦃x y⦄, P x → P y → P (x ⊓ y)) {x y : α} (hx : P x) (hy : P y) :
+(@has_inf.inf _ (@semilattice_inf.to_has_inf _ (subtype.semilattice_inf Pinf)) ⟨x,hx⟩ ⟨y,hy⟩) =
+  ⟨x ⊓ y, Pinf hx hy⟩ := rfl
+
+@[simp] lemma subtype.mk_sup [semilattice_sup α] {P : α → Prop}
+(Psup : ∀⦃x y⦄, P x → P y → P (x ⊔ y)) {x y : α} (hx : P x) (hy : P y) :
+(@has_sup.sup _ (@semilattice_sup.to_has_sup _ (subtype.semilattice_sup Psup)) ⟨x,hx⟩ ⟨y,hy⟩) =
+  ⟨x ⊔ y, Psup hx hy⟩ := rfl
 
 end subtype
 

--- a/src/order/lattice.lean
+++ b/src/order/lattice.lean
@@ -984,12 +984,12 @@ protected def lattice [lattice α] {P : α → Prop}
 (@has_inf.inf _ (@semilattice_inf.to_has_inf _ (subtype.semilattice_inf Pinf)) x y : α)
   = x ⊓ y := rfl
 
-@[simp] lemma subtype.mk_inf [semilattice_inf α] {P : α → Prop}
+@[simp] lemma mk_inf [semilattice_inf α] {P : α → Prop}
 (Pinf : ∀⦃x y⦄, P x → P y → P (x ⊓ y)) {x y : α} (hx : P x) (hy : P y) :
 (@has_inf.inf _ (@semilattice_inf.to_has_inf _ (subtype.semilattice_inf Pinf)) ⟨x,hx⟩ ⟨y,hy⟩) =
   ⟨x ⊓ y, Pinf hx hy⟩ := rfl
 
-@[simp] lemma subtype.mk_sup [semilattice_sup α] {P : α → Prop}
+@[simp] lemma mk_sup [semilattice_sup α] {P : α → Prop}
 (Psup : ∀⦃x y⦄, P x → P y → P (x ⊔ y)) {x y : α} (hx : P x) (hy : P y) :
 (@has_sup.sup _ (@semilattice_sup.to_has_sup _ (subtype.semilattice_sup Psup)) ⟨x,hx⟩ ⟨y,hy⟩) =
   ⟨x ⊔ y, Psup hx hy⟩ := rfl

--- a/src/order/lattice.lean
+++ b/src/order/lattice.lean
@@ -984,15 +984,15 @@ protected def lattice [lattice α] {P : α → Prop}
 (@has_inf.inf _ (@semilattice_inf.to_has_inf _ (subtype.semilattice_inf Pinf)) x y : α)
   = x ⊓ y := rfl
 
-@[simp] lemma mk_inf [semilattice_inf α] {P : α → Prop}
-(Pinf : ∀⦃x y⦄, P x → P y → P (x ⊓ y)) {x y : α} (hx : P x) (hy : P y) :
-(@has_inf.inf _ (@semilattice_inf.to_has_inf _ (subtype.semilattice_inf Pinf)) ⟨x,hx⟩ ⟨y,hy⟩) =
-  ⟨x ⊓ y, Pinf hx hy⟩ := rfl
-
 @[simp] lemma mk_sup [semilattice_sup α] {P : α → Prop}
 (Psup : ∀⦃x y⦄, P x → P y → P (x ⊔ y)) {x y : α} (hx : P x) (hy : P y) :
 (@has_sup.sup _ (@semilattice_sup.to_has_sup _ (subtype.semilattice_sup Psup)) ⟨x,hx⟩ ⟨y,hy⟩) =
   ⟨x ⊔ y, Psup hx hy⟩ := rfl
+
+@[simp] lemma mk_inf [semilattice_inf α] {P : α → Prop}
+(Pinf : ∀⦃x y⦄, P x → P y → P (x ⊓ y)) {x y : α} (hx : P x) (hy : P y) :
+(@has_inf.inf _ (@semilattice_inf.to_has_inf _ (subtype.semilattice_inf Pinf)) ⟨x,hx⟩ ⟨y,hy⟩) =
+  ⟨x ⊓ y, Pinf hx hy⟩ := rfl
 
 end subtype
 

--- a/src/order/lattice.lean
+++ b/src/order/lattice.lean
@@ -975,24 +975,22 @@ protected def lattice [lattice α] {P : α → Prop}
 { ..subtype.semilattice_inf Pinf, ..subtype.semilattice_sup Psup }
 
 @[simp, norm_cast] lemma coe_sup [semilattice_sup α] {P : α → Prop}
-(Psup : ∀⦃x y⦄, P x → P y → P (x ⊔ y)) (x y : subtype P) :
-(@has_sup.sup _ (@semilattice_sup.to_has_sup _ (subtype.semilattice_sup Psup)) x y : α)
-  = x ⊔ y := rfl
+  (Psup : ∀⦃x y⦄, P x → P y → P (x ⊔ y)) (x y : subtype P) :
+  (by {haveI := subtype.semilattice_sup Psup, exact (x ⊔ y : subtype P)} : α) = x ⊔ y := rfl
 
 @[simp, norm_cast] lemma coe_inf [semilattice_inf α] {P : α → Prop}
-(Pinf : ∀⦃x y⦄, P x → P y → P (x ⊓ y)) (x y : subtype P) :
-(@has_inf.inf _ (@semilattice_inf.to_has_inf _ (subtype.semilattice_inf Pinf)) x y : α)
-  = x ⊓ y := rfl
+  (Pinf : ∀⦃x y⦄, P x → P y → P (x ⊓ y)) (x y : subtype P) :
+  (by {haveI := subtype.semilattice_inf Pinf, exact (x ⊓ y : subtype P)} : α) = x ⊓ y := rfl
 
-@[simp] lemma mk_sup [semilattice_sup α] {P : α → Prop}
-(Psup : ∀⦃x y⦄, P x → P y → P (x ⊔ y)) {x y : α} (hx : P x) (hy : P y) :
-(@has_sup.sup _ (@semilattice_sup.to_has_sup _ (subtype.semilattice_sup Psup)) ⟨x,hx⟩ ⟨y,hy⟩) =
-  ⟨x ⊔ y, Psup hx hy⟩ := rfl
+@[simp] lemma mk_sup_mk [semilattice_sup α] {P : α → Prop} (Psup : ∀⦃x y⦄, P x → P y → P (x ⊔ y))
+  {x y : α} (hx : P x) (hy : P y) :
+  (by {haveI := subtype.semilattice_sup Psup, exact (⟨x, hx⟩ ⊔ ⟨y, hy⟩ : subtype P)}) =
+    ⟨x ⊔ y, Psup hx hy⟩ := rfl
 
-@[simp] lemma mk_inf [semilattice_inf α] {P : α → Prop}
-(Pinf : ∀⦃x y⦄, P x → P y → P (x ⊓ y)) {x y : α} (hx : P x) (hy : P y) :
-(@has_inf.inf _ (@semilattice_inf.to_has_inf _ (subtype.semilattice_inf Pinf)) ⟨x,hx⟩ ⟨y,hy⟩) =
-  ⟨x ⊓ y, Pinf hx hy⟩ := rfl
+@[simp] lemma mk_inf_mk [semilattice_inf α] {P : α → Prop} (Pinf : ∀⦃x y⦄, P x → P y → P (x ⊓ y))
+  {x y : α} (hx : P x) (hy : P y) :
+  (by {haveI := subtype.semilattice_inf Pinf, exact (⟨x, hx⟩ ⊓ ⟨y, hy⟩ : subtype P)}) =
+    ⟨x ⊓ y, Pinf hx hy⟩ := rfl
 
 end subtype
 

--- a/src/order/lattice.lean
+++ b/src/order/lattice.lean
@@ -974,6 +974,16 @@ protected def lattice [lattice α] {P : α → Prop}
   lattice {x : α // P x} :=
 { ..subtype.semilattice_inf Pinf, ..subtype.semilattice_sup Psup }
 
+@[simp, norm_cast] lemma coe_sup [semilattice_sup α] {P : α → Prop}
+(Psup : ∀⦃x y⦄, P x → P y → P (x ⊔ y)) (x y : subtype P) :
+(@has_sup.sup _ (@semilattice_sup.to_has_sup _ (subtype.semilattice_sup Psup)) x y : α)
+  = x ⊔ y := rfl
+
+@[simp, norm_cast] lemma coe_inf [semilattice_inf α] {P : α → Prop}
+  (Psup : ∀⦃x y⦄, P x → P y → P (x ⊓ y)) (x y : subtype P) :
+(@has_inf.inf _ (@semilattice_inf.to_has_inf _ (subtype.semilattice_inf Psup)) x y : α)
+  = x ⊓ y := rfl
+
 end subtype
 
 section lift

--- a/src/order/lattice_intervals.lean
+++ b/src/order/lattice_intervals.lean
@@ -40,8 +40,8 @@ subtype.semilattice_inf (λ x y hx hy, ⟨le_inf hx.1 hy.1, lt_of_le_of_lt inf_l
   order_bot (Ico a b) :=
 (is_least_Ico h).order_bot
 
-@[simp] lemma coe_inf [semilattice_inf α] {a b : α} (x y : Ico a b) :
-  (↑(x ⊓ y) : α) = (↑x ⊓ ↑y) := rfl
+@[simp, norm_cast] lemma coe_inf [semilattice_inf α] {a b : α} (x y : Ico a b) :
+  (↑(x ⊓ y) : α) = x ⊓ y := rfl
 
 end Ico
 
@@ -50,7 +50,8 @@ namespace Iio
 instance [semilattice_inf α] {a : α} : semilattice_inf (Iio a) :=
 subtype.semilattice_inf (λ x y hx hy, lt_of_le_of_lt inf_le_left hx)
 
-@[simp] lemma coe_inf [semilattice_inf α] {a : α} (x y : Iio a) : (↑(x ⊓ y) : α) = (↑x ⊓ ↑y) := rfl
+@[simp, norm_cast] lemma coe_inf [semilattice_inf α] {a : α} (x y : Iio a) :
+  (↑(x ⊓ y) : α) = x ⊓ y := rfl
 
 end Iio
 
@@ -64,8 +65,8 @@ subtype.semilattice_sup (λ x y hx hy, ⟨lt_of_lt_of_le hx.1 le_sup_left, sup_l
   order_top (Ioc a b) :=
 (is_greatest_Ioc h).order_top
 
-@[simp] lemma coe_sup [semilattice_sup α] {a b : α} (x y : Ioc a b) :
-  (↑(x ⊔ y) : α) = (↑x ⊔ ↑y) := rfl
+@[simp, norm_cast] lemma coe_sup [semilattice_sup α] {a b : α} (x y : Ioc a b) :
+  (↑(x ⊔ y) : α) = x ⊔ y := rfl
 
 end Ioc
 
@@ -74,7 +75,8 @@ namespace Ioi
 instance [semilattice_sup α] {a : α} : semilattice_sup (Ioi a) :=
 subtype.semilattice_sup (λ x y hx hy, lt_of_lt_of_le hx le_sup_left)
 
-@[simp] lemma coe_sup [semilattice_sup α] {a : α} (x y : Ioi a) : (↑(x ⊔ y) : α) = (↑x ⊔ ↑y) := rfl
+@[simp, norm_cast] lemma coe_sup [semilattice_sup α] {a : α} (x y : Ioi a) :
+  (↑(x ⊔ y) : α) = x ⊔ y := rfl
 
 end Ioi
 
@@ -106,9 +108,11 @@ instance [preorder α] [order_bot α] {a : α} : bounded_order (Iic a) :=
 { .. Iic.order_top,
   .. Iic.order_bot }
 
-@[simp] lemma coe_sup [semilattice_sup α] {a : α} (x y : Iic a) : (↑(x ⊔ y) : α) = (↑x ⊔ ↑y) := rfl
+@[simp, norm_cast] lemma coe_sup [semilattice_sup α] {a : α} (x y : Iic a) :
+  (↑(x ⊔ y) : α) = x ⊔ y := rfl
 
-@[simp] lemma coe_inf [semilattice_inf α] {a : α} (x y : Iic a) : (↑(x ⊓ y) : α) = (↑x ⊓ ↑y) := rfl
+@[simp, norm_cast] lemma coe_inf [semilattice_inf α] {a : α} (x y : Iic a) :
+  (↑(x ⊓ y) : α) = x ⊓ y := rfl
 
 end Iic
 
@@ -140,9 +144,11 @@ instance [preorder α] [order_top α] {a : α}: bounded_order (Ici a) :=
 { .. Ici.order_top,
   .. Ici.order_bot }
 
-@[simp] lemma coe_inf [semilattice_inf α] {a : α} (x y : Ici a) : (↑(x ⊓ y) : α) = (↑x ⊓ ↑y) := rfl
+@[simp, norm_cast] lemma coe_inf [semilattice_inf α] {a : α} (x y : Ici a) :
+  (↑(x ⊓ y) : α) = x ⊓ y := rfl
 
-@[simp] lemma coe_sup [semilattice_sup α] {a : α} (x y : Ici a) : (↑(x ⊔ y) : α) = (↑x ⊔ ↑y) := rfl
+@[simp, norm_cast] lemma coe_sup [semilattice_sup α] {a : α} (x y : Ici a) :
+  (↑(x ⊔ y) : α) = x ⊔ y := rfl
 
 end Ici
 
@@ -172,11 +178,11 @@ instance [lattice α] {a b : α} : lattice (Icc a b) :=
 { .. Icc.order_top h,
   .. Icc.order_bot h }
 
-@[simp] lemma coe_inf [semilattice_inf α] {a b : α} (x y : Icc a b) :
-  (↑(x ⊓ y) : α) = (↑x ⊓ ↑y) := rfl
+@[simp, norm_cast] lemma coe_inf [semilattice_inf α] {a b : α} (x y : Icc a b) :
+  (↑(x ⊓ y) : α) = x ⊓ y := rfl
 
-@[simp] lemma coe_sup [semilattice_sup α] {a b : α} (x y : Icc a b) :
-  (↑(x ⊔ y) : α) = (↑x ⊔ ↑y) := rfl
+@[simp, norm_cast] lemma coe_sup [semilattice_sup α] {a b : α} (x y : Icc a b) :
+  (↑(x ⊔ y) : α) = x ⊔ y := rfl
 
 end Icc
 

--- a/src/order/lattice_intervals.lean
+++ b/src/order/lattice_intervals.lean
@@ -32,14 +32,16 @@ namespace set
 
 namespace Ico
 
-variables {a b : α}
-
-instance [semilattice_inf α] : semilattice_inf (Ico a b) :=
+instance [semilattice_inf α] {a b : α} : semilattice_inf (Ico a b) :=
 subtype.semilattice_inf (λ x y hx hy, ⟨le_inf hx.1 hy.1, lt_of_le_of_lt inf_le_left hx.2⟩)
 
 /-- `Ico a b` has a bottom element whenever `a < b`. -/
-@[reducible] protected def order_bot [partial_order α] (h : a < b) : order_bot (Ico a b) :=
+@[reducible] protected def order_bot [partial_order α] {a b : α} (h : a < b) :
+  order_bot (Ico a b) :=
 (is_least_Ico h).order_bot
+
+@[simp] lemma coe_inf [semilattice_inf α] {a b : α} {x y : Ico a b} :
+  (↑(x ⊓ y) : α) = (↑x ⊓ ↑y) := rfl
 
 end Ico
 
@@ -48,89 +50,99 @@ namespace Iio
 instance [semilattice_inf α] {a : α} : semilattice_inf (Iio a) :=
 subtype.semilattice_inf (λ x y hx hy, lt_of_le_of_lt inf_le_left hx)
 
+@[simp] lemma coe_inf [semilattice_inf α] {a : α} {x y : Iio a} : (↑(x ⊓ y) : α) = (↑x ⊓ ↑y) := rfl
+
 end Iio
 
 namespace Ioc
 
-variables {a b : α}
-
-instance [semilattice_sup α] : semilattice_sup (Ioc a b) :=
+instance [semilattice_sup α] {a b : α} : semilattice_sup (Ioc a b) :=
 subtype.semilattice_sup (λ x y hx hy, ⟨lt_of_lt_of_le hx.1 le_sup_left, sup_le hx.2 hy.2⟩)
 
 /-- `Ioc a b` has a top element whenever `a < b`. -/
-@[reducible] protected def order_top [partial_order α] (h : a < b) : order_top (Ioc a b) :=
+@[reducible] protected def order_top [partial_order α] {a b : α} (h : a < b) :
+  order_top (Ioc a b) :=
 (is_greatest_Ioc h).order_top
+
+@[simp] lemma coe_sup [semilattice_sup α] {a b : α} {x y : Ioc a b} :
+  (↑(x ⊔ y) : α) = (↑x ⊔ ↑y) := rfl
 
 end Ioc
 
-namespace Iio
+namespace Ioi
 
 instance [semilattice_sup α] {a : α} : semilattice_sup (Ioi a) :=
 subtype.semilattice_sup (λ x y hx hy, lt_of_lt_of_le hx le_sup_left)
 
-end Iio
+@[simp] lemma coe_sup [semilattice_sup α] {a : α} {x y : Ioi a} : (↑(x ⊔ y) : α) = (↑x ⊔ ↑y) := rfl
+
+end Ioi
 
 namespace Iic
 
-variables {a : α}
-
-instance [semilattice_inf α] : semilattice_inf (Iic a) :=
+instance [semilattice_inf α] {a : α} : semilattice_inf (Iic a) :=
 subtype.semilattice_inf (λ x y hx hy, le_trans inf_le_left hx)
 
-instance [semilattice_sup α] : semilattice_sup (Iic a) :=
+instance [semilattice_sup α] {a : α} : semilattice_sup (Iic a) :=
 subtype.semilattice_sup (λ x y hx hy, sup_le hx hy)
 
-instance [lattice α] : lattice (Iic a) :=
+instance [lattice α] {a : α} : lattice (Iic a) :=
 { .. Iic.semilattice_inf,
   .. Iic.semilattice_sup }
 
-instance [preorder α] : order_top (Iic a) :=
+instance [preorder α] {a : α} : order_top (Iic a) :=
 { top := ⟨a, le_refl a⟩,
   le_top := λ x, x.prop }
 
 @[simp] lemma coe_top [preorder α] {a : α} : ↑(⊤ : Iic a) = a := rfl
 
-instance [preorder α] [order_bot α] : order_bot (Iic a) :=
+instance [preorder α] [order_bot α] {a : α} : order_bot (Iic a) :=
 { bot := ⟨⊥, bot_le⟩,
   bot_le := λ ⟨_,_⟩, subtype.mk_le_mk.2 bot_le }
 
 @[simp] lemma coe_bot [preorder α] [order_bot α] {a : α} : ↑(⊥ : Iic a) = (⊥ : α) := rfl
 
-instance [preorder α] [order_bot α] : bounded_order (Iic a) :=
+instance [preorder α] [order_bot α] {a : α} : bounded_order (Iic a) :=
 { .. Iic.order_top,
   .. Iic.order_bot }
+
+@[simp] lemma coe_sup [semilattice_sup α] {a : α} {x y : Iic a} : (↑(x ⊔ y) : α) = (↑x ⊔ ↑y) := rfl
+
+@[simp] lemma coe_inf [semilattice_inf α] {a : α} {x y : Iic a} : (↑(x ⊓ y) : α) = (↑x ⊓ ↑y) := rfl
 
 end Iic
 
 namespace Ici
 
-variables {a : α}
-
-instance [semilattice_inf α] : semilattice_inf (Ici a) :=
+instance [semilattice_inf α] {a : α}: semilattice_inf (Ici a) :=
 subtype.semilattice_inf (λ x y hx hy, le_inf hx hy)
 
-instance [semilattice_sup α] : semilattice_sup (Ici a) :=
+instance [semilattice_sup α] {a : α} : semilattice_sup (Ici a) :=
 subtype.semilattice_sup (λ x y hx hy, le_trans hx le_sup_left)
 
-instance [lattice α] : lattice (Ici a) :=
+instance [lattice α] {a : α} : lattice (Ici a) :=
 { .. Ici.semilattice_inf,
   .. Ici.semilattice_sup }
 
-instance [preorder α] : order_bot (Ici a) :=
+instance [preorder α] {a : α} : order_bot (Ici a) :=
 { bot := ⟨a, le_refl a⟩,
   bot_le := λ x, x.prop }
 
 @[simp] lemma coe_bot [preorder α] {a : α} : ↑(⊥ : Ici a) = a := rfl
 
-instance [preorder α] [order_top α] : order_top (Ici a) :=
+instance [preorder α] [order_top α] {a : α}: order_top (Ici a) :=
 { top := ⟨⊤, le_top⟩,
   le_top := λ ⟨_,_⟩, subtype.mk_le_mk.2 le_top }
 
 @[simp] lemma coe_top [preorder α] [order_top α] {a : α} : ↑(⊤ : Ici a) = (⊤ : α) := rfl
 
-instance [preorder α] [order_top α] : bounded_order (Ici a) :=
+instance [preorder α] [order_top α] {a : α}: bounded_order (Ici a) :=
 { .. Ici.order_top,
   .. Ici.order_bot }
+
+@[simp] lemma coe_inf [semilattice_inf α] {a : α} {x y : Ici a} : (↑(x ⊓ y) : α) = (↑x ⊓ ↑y) := rfl
+
+@[simp] lemma coe_sup [semilattice_sup α] {a : α} {x y : Ici a} : (↑(x ⊔ y) : α) = (↑x ⊔ ↑y) := rfl
 
 end Ici
 
@@ -159,6 +171,12 @@ instance [lattice α] {a b : α} : lattice (Icc a b) :=
   bounded_order (Icc a b) :=
 { .. Icc.order_top h,
   .. Icc.order_bot h }
+
+@[simp] lemma coe_inf [semilattice_inf α] {a b : α} (x y : Icc a b) :
+  (↑(x ⊓ y) : α) = (↑x ⊓ ↑y) := rfl
+
+@[simp] lemma coe_sup [semilattice_sup α] {a b : α} (x y : Icc a b) :
+  (↑(x ⊔ y) : α) = (↑x ⊔ ↑y) := rfl
 
 end Icc
 

--- a/src/order/lattice_intervals.lean
+++ b/src/order/lattice_intervals.lean
@@ -40,18 +40,12 @@ subtype.semilattice_inf (λ x y hx hy, ⟨le_inf hx.1 hy.1, lt_of_le_of_lt inf_l
   order_bot (Ico a b) :=
 (is_least_Ico h).order_bot
 
-@[simp, norm_cast] lemma coe_inf [semilattice_inf α] {a b : α} (x y : Ico a b) :
-  (↑(x ⊓ y) : α) = x ⊓ y := rfl
-
 end Ico
 
 namespace Iio
 
 instance [semilattice_inf α] {a : α} : semilattice_inf (Iio a) :=
 subtype.semilattice_inf (λ x y hx hy, lt_of_le_of_lt inf_le_left hx)
-
-@[simp, norm_cast] lemma coe_inf [semilattice_inf α] {a : α} (x y : Iio a) :
-  (↑(x ⊓ y) : α) = x ⊓ y := rfl
 
 end Iio
 
@@ -65,18 +59,12 @@ subtype.semilattice_sup (λ x y hx hy, ⟨lt_of_lt_of_le hx.1 le_sup_left, sup_l
   order_top (Ioc a b) :=
 (is_greatest_Ioc h).order_top
 
-@[simp, norm_cast] lemma coe_sup [semilattice_sup α] {a b : α} (x y : Ioc a b) :
-  (↑(x ⊔ y) : α) = x ⊔ y := rfl
-
 end Ioc
 
 namespace Ioi
 
 instance [semilattice_sup α] {a : α} : semilattice_sup (Ioi a) :=
 subtype.semilattice_sup (λ x y hx hy, lt_of_lt_of_le hx le_sup_left)
-
-@[simp, norm_cast] lemma coe_sup [semilattice_sup α] {a : α} (x y : Ioi a) :
-  (↑(x ⊔ y) : α) = x ⊔ y := rfl
 
 end Ioi
 
@@ -108,12 +96,6 @@ instance [preorder α] [order_bot α] {a : α} : bounded_order (Iic a) :=
 { .. Iic.order_top,
   .. Iic.order_bot }
 
-@[simp, norm_cast] lemma coe_sup [semilattice_sup α] {a : α} (x y : Iic a) :
-  (↑(x ⊔ y) : α) = x ⊔ y := rfl
-
-@[simp, norm_cast] lemma coe_inf [semilattice_inf α] {a : α} (x y : Iic a) :
-  (↑(x ⊓ y) : α) = x ⊓ y := rfl
-
 end Iic
 
 namespace Ici
@@ -144,12 +126,6 @@ instance [preorder α] [order_top α] {a : α}: bounded_order (Ici a) :=
 { .. Ici.order_top,
   .. Ici.order_bot }
 
-@[simp, norm_cast] lemma coe_inf [semilattice_inf α] {a : α} (x y : Ici a) :
-  (↑(x ⊓ y) : α) = x ⊓ y := rfl
-
-@[simp, norm_cast] lemma coe_sup [semilattice_sup α] {a : α} (x y : Ici a) :
-  (↑(x ⊔ y) : α) = x ⊔ y := rfl
-
 end Ici
 
 namespace Icc
@@ -177,12 +153,6 @@ instance [lattice α] {a b : α} : lattice (Icc a b) :=
   bounded_order (Icc a b) :=
 { .. Icc.order_top h,
   .. Icc.order_bot h }
-
-@[simp, norm_cast] lemma coe_inf [semilattice_inf α] {a b : α} (x y : Icc a b) :
-  (↑(x ⊓ y) : α) = x ⊓ y := rfl
-
-@[simp, norm_cast] lemma coe_sup [semilattice_sup α] {a b : α} (x y : Icc a b) :
-  (↑(x ⊔ y) : α) = x ⊔ y := rfl
 
 end Icc
 

--- a/src/order/lattice_intervals.lean
+++ b/src/order/lattice_intervals.lean
@@ -40,7 +40,7 @@ subtype.semilattice_inf (λ x y hx hy, ⟨le_inf hx.1 hy.1, lt_of_le_of_lt inf_l
   order_bot (Ico a b) :=
 (is_least_Ico h).order_bot
 
-@[simp] lemma coe_inf [semilattice_inf α] {a b : α} {x y : Ico a b} :
+@[simp] lemma coe_inf [semilattice_inf α] {a b : α} (x y : Ico a b) :
   (↑(x ⊓ y) : α) = (↑x ⊓ ↑y) := rfl
 
 end Ico
@@ -50,7 +50,7 @@ namespace Iio
 instance [semilattice_inf α] {a : α} : semilattice_inf (Iio a) :=
 subtype.semilattice_inf (λ x y hx hy, lt_of_le_of_lt inf_le_left hx)
 
-@[simp] lemma coe_inf [semilattice_inf α] {a : α} {x y : Iio a} : (↑(x ⊓ y) : α) = (↑x ⊓ ↑y) := rfl
+@[simp] lemma coe_inf [semilattice_inf α] {a : α} (x y : Iio a) : (↑(x ⊓ y) : α) = (↑x ⊓ ↑y) := rfl
 
 end Iio
 
@@ -64,7 +64,7 @@ subtype.semilattice_sup (λ x y hx hy, ⟨lt_of_lt_of_le hx.1 le_sup_left, sup_l
   order_top (Ioc a b) :=
 (is_greatest_Ioc h).order_top
 
-@[simp] lemma coe_sup [semilattice_sup α] {a b : α} {x y : Ioc a b} :
+@[simp] lemma coe_sup [semilattice_sup α] {a b : α} (x y : Ioc a b) :
   (↑(x ⊔ y) : α) = (↑x ⊔ ↑y) := rfl
 
 end Ioc
@@ -74,7 +74,7 @@ namespace Ioi
 instance [semilattice_sup α] {a : α} : semilattice_sup (Ioi a) :=
 subtype.semilattice_sup (λ x y hx hy, lt_of_lt_of_le hx le_sup_left)
 
-@[simp] lemma coe_sup [semilattice_sup α] {a : α} {x y : Ioi a} : (↑(x ⊔ y) : α) = (↑x ⊔ ↑y) := rfl
+@[simp] lemma coe_sup [semilattice_sup α] {a : α} (x y : Ioi a) : (↑(x ⊔ y) : α) = (↑x ⊔ ↑y) := rfl
 
 end Ioi
 
@@ -106,9 +106,9 @@ instance [preorder α] [order_bot α] {a : α} : bounded_order (Iic a) :=
 { .. Iic.order_top,
   .. Iic.order_bot }
 
-@[simp] lemma coe_sup [semilattice_sup α] {a : α} {x y : Iic a} : (↑(x ⊔ y) : α) = (↑x ⊔ ↑y) := rfl
+@[simp] lemma coe_sup [semilattice_sup α] {a : α} (x y : Iic a) : (↑(x ⊔ y) : α) = (↑x ⊔ ↑y) := rfl
 
-@[simp] lemma coe_inf [semilattice_inf α] {a : α} {x y : Iic a} : (↑(x ⊓ y) : α) = (↑x ⊓ ↑y) := rfl
+@[simp] lemma coe_inf [semilattice_inf α] {a : α} (x y : Iic a) : (↑(x ⊓ y) : α) = (↑x ⊓ ↑y) := rfl
 
 end Iic
 
@@ -140,9 +140,9 @@ instance [preorder α] [order_top α] {a : α}: bounded_order (Ici a) :=
 { .. Ici.order_top,
   .. Ici.order_bot }
 
-@[simp] lemma coe_inf [semilattice_inf α] {a : α} {x y : Ici a} : (↑(x ⊓ y) : α) = (↑x ⊓ ↑y) := rfl
+@[simp] lemma coe_inf [semilattice_inf α] {a : α} (x y : Ici a) : (↑(x ⊓ y) : α) = (↑x ⊓ ↑y) := rfl
 
-@[simp] lemma coe_sup [semilattice_sup α] {a : α} {x y : Ici a} : (↑(x ⊔ y) : α) = (↑x ⊔ ↑y) := rfl
+@[simp] lemma coe_sup [semilattice_sup α] {a : α} (x y : Ici a) : (↑(x ⊔ y) : α) = (↑x ⊔ ↑y) := rfl
 
 end Ici
 


### PR DESCRIPTION
This PR adds simp lemmas for coercions of inf/sup in order instances on intervals. We also change the order of some arguments in instances/lemmas, by removing `variables` commands, so that typeclass arguments precede others. 

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
