### PR TITLE
refactor(set_theory/ordinal/basic): redefine `min`, `well_ordering_rel`, and `ord`

### DIFF
--- a/src/data/quot.lean
+++ b/src/data/quot.lean
@@ -445,6 +445,11 @@ nonempty_of_exists q.exists_rep
 
 end trunc
 
+/-- A helper lemma for `quotient.lift_on' (f : α → β)`, where `β` is a partial order.  -/
+lemma eqv_imp_eq_of_eqv_imp_le {β} [partial_order β] {s : setoid α} {f : α → β}
+  (h : ∀ a b, a ≈ b → f a ≤ f b) : ∀ a b, a ≈ b → f a = f b :=
+λ a b hab, le_antisymm (h a b hab) (h b a $ setoid.symm hab)
+
 /-! ### `quotient` with implicit `setoid` -/
 
 namespace quotient

--- a/src/order/galois_connection.lean
+++ b/src/order/galois_connection.lean
@@ -720,7 +720,6 @@ lemma is_lub_of_l_image [preorder α] [preorder β] (gi : galois_coinsertion l u
   (hs : is_lub (l '' s) a) : is_lub s (u a) :=
 gi.dual.is_glb_of_u_image hs
 
-
 section lift
 
 variables [partial_order α]

--- a/src/set_theory/cardinal/ordinal.lean
+++ b/src/set_theory/cardinal/ordinal.lean
@@ -313,9 +313,8 @@ begin
   refine acc.rec_on (cardinal.lt_wf.apply c) (λ c _,
     quotient.induction_on c $ λ α IH ol, _) h,
   -- consider the minimal well-order `r` on `α` (a type with cardinality `c`).
-  rcases ord_eq α with ⟨r, wo, e⟩, resetI,
-  letI := linear_order_of_STO' r,
-  haveI : is_well_order α (<) := wo,
+  letI : linear_order α := linear_order_of_STO' well_ordering_rel,
+  haveI : is_well_order α (<) := well_ordering_rel.is_well_order,
   -- Define an order `s` on `α × α` by writing `(a, b) < (c, d)` if `max a b < max c d`, or
   -- the max are equal and `a < c`, or the max are equal and `a = c` and `b < d`.
   let g : α × α → α := λ p, max p.1 p.2,
@@ -329,10 +328,10 @@ begin
     `β × β` for some `β` of cardinality `< c`. By the inductive assumption, this set has the
     same cardinality as `β` (or it is finite if `β` is finite), so it is `< c`, which is a
     contradiction. -/
-  suffices : type s ≤ type r, {exact card_le_card this},
+  suffices : type s ≤ ord (#α), { exact card_le_card this },
   refine le_of_forall_lt (λ o h, _),
   rcases typein_surj s h with ⟨p, rfl⟩,
-  rw [← e, lt_ord],
+  rw [lt_ord],
   refine lt_of_le_of_lt
     (_ : _ ≤ card (succ (typein (<) (g p))) * card (succ (typein (<) (g p)))) _,
   { have : {q | s q p} ⊆ insert (g p) {x | x < g p} ×ˢ insert (g p) {x | x < g p},
@@ -340,17 +339,17 @@ begin
       simp only [s, embedding.coe_fn_mk, order.preimage, typein_lt_typein, prod.lex_def, typein_inj]
         at h,
       exact max_le_iff.1 (le_iff_lt_or_eq.2 $ h.imp_right and.left) },
-    suffices H : (insert (g p) {x | r x (g p)} : set α) ≃ ({x | r x (g p)} ⊕ punit),
+    suffices H : (insert (g p) {x | x < g p} : set α) ≃ ({x | x < g p} ⊕ punit),
     { exact ⟨(set.embedding_of_subset _ _ this).trans
         ((equiv.set.prod _ _).trans (H.prod_congr H)).to_embedding⟩ },
     refine (equiv.set.insert _).trans
       ((equiv.refl _).sum_congr punit_equiv_punit),
-    apply @irrefl _ r },
+    apply lt_irrefl },
   cases lt_or_le (card (succ (typein (<) (g p)))) ℵ₀ with qo qo,
   { exact (mul_lt_aleph_0 qo qo).trans_le ol },
   { suffices, {exact (IH _ this qo).trans_lt this},
     rw ← lt_ord, apply (ord_is_limit ol).2,
-    rw [mk_def, e], apply typein_lt_type }
+    apply typein_lt_type }
 end
 
 end using_ordinals


### PR DESCRIPTION
* redefine `ordinal.card` using `quotient.map`;
* redefine `ordinal.lift` to avoid pattern matching;
* define `ordinal.argmin`;
* redefine `ordinal.min I f` as `f (ordinal.argmin I f)`;
* redefine `well_ordering_rel` so that
  `ordinal.type (@well_ordering_rel α)` is definitionally equal to
  `cardinal.ord (#α)`;
* drop `ordinal.ord_eq_min` and `ordinal.ord_eq`;
* add `ordinal.type_well_ordering_rel`;
* add `cardinal.gc_ord_card`, `cardinal.gci_ord_card`,
  `cardinal.ord_mono`, `cardinal.ord_strict_mono`.

---
Motivated by and conflicts with #14708 
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
