### PR TITLE
[Merged by Bors] - feat(set_theory/ordinal/basic): basic lemmas on `ordinal.lift` 

### DIFF
--- a/src/order/rel_iso.lean
+++ b/src/order/rel_iso.lean
@@ -441,6 +441,14 @@ f.injective.eq_iff
 /-- Any equivalence lifts to a relation isomorphism between `s` and its preimage. -/
 protected def preimage (f : α ≃ β) (s : β → β → Prop) : f ⁻¹'o s ≃r s := ⟨f, λ a b, iff.rfl⟩
 
+instance is_well_order.preimage {α : Type u} (r : α → α → Prop) [is_well_order α r] (f : β ≃ α) :
+  is_well_order β (f ⁻¹'o r) :=
+@rel_embedding.is_well_order _ _ (f ⁻¹'o r) r (rel_iso.preimage f r) _
+
+instance is_well_order.ulift {α : Type u} (r : α → α → Prop) [is_well_order α r] :
+  is_well_order (ulift α) (ulift.down ⁻¹'o r) :=
+is_well_order.preimage r equiv.ulift
+
 /-- A surjective relation embedding is a relation isomorphism. -/
 @[simps apply]
 noncomputable def of_surjective (f : r ↪r s) (H : surjective f) : r ≃r s :=

--- a/src/set_theory/cardinal/cofinality.lean
+++ b/src/set_theory/cardinal/cofinality.lean
@@ -221,7 +221,6 @@ end
 begin
   refine induction_on o _,
   introsI α r _,
-  cases lift_type r with _ e, rw e,
   apply le_antisymm,
   { unfreezingI { refine le_cof_type.2 (λ S H, _) },
     have : (#(ulift.up ⁻¹' S)).lift ≤ #S,

--- a/src/set_theory/cardinal/cofinality.lean
+++ b/src/set_theory/cardinal/cofinality.lean
@@ -222,7 +222,7 @@ begin
   refine induction_on o _,
   introsI α r _,
   apply le_antisymm,
-  { unfreezingI { refine le_cof_type.2 (λ S H, _) },
+  { refine le_cof_type.2 (λ S H, _),
     have : (#(ulift.up ⁻¹' S)).lift ≤ #S,
     { rw [← cardinal.lift_umax, ← cardinal.lift_id' (#S)],
       exact mk_preimage_of_injective_lift ulift.up _ ulift.up_injective },

--- a/src/set_theory/ordinal/basic.lean
+++ b/src/set_theory/ordinal/basic.lean
@@ -804,20 +804,22 @@ quotient.sound ⟨⟨punit_equiv_punit, λ _ _, iff.rfl⟩⟩
 
 /-! ### Lifting ordinals to a higher universe -/
 
+instance {α : Type u} (r : α → α → Prop) [is_well_order α r] :
+  is_well_order (ulift.{v} α) (equiv.ulift.{v} ⁻¹'o r) :=
+@rel_embedding.is_well_order _ _ (@equiv.ulift.{v} α ⁻¹'o r) r
+  (rel_iso.preimage equiv.ulift.{v} r) _
+
 /-- The universe lift operation for ordinals, which embeds `ordinal.{u}` as
   a proper initial segment of `ordinal.{v}` for `v > u`. For the initial segment version,
   see `lift.initial_seg`. -/
 def lift (o : ordinal.{v}) : ordinal.{max v u} :=
-quotient.lift_on o (λ ⟨α, r, wo⟩,
-  @type _ _ (@rel_embedding.is_well_order _ _ (@equiv.ulift.{u} α ⁻¹'o r) r
-    (rel_iso.preimage equiv.ulift.{u} r) wo)) $
-λ ⟨α, r, _⟩ ⟨β, s, _⟩ ⟨f⟩,
-quot.sound ⟨(rel_iso.preimage equiv.ulift r).trans $
-  f.trans (rel_iso.preimage equiv.ulift s).symm⟩
+quotient.lift_on o (λ ⟨α, r, wo⟩, by exactI type (@equiv.ulift.{u} α ⁻¹'o r)) $
+  λ ⟨α, r, _⟩ ⟨β, s, _⟩ ⟨f⟩, quot.sound ⟨(rel_iso.preimage equiv.ulift r).trans $
+    f.trans (rel_iso.preimage equiv.ulift s).symm⟩
 
-theorem lift_type {α} (r : α → α → Prop) [is_well_order α r] :
-  ∃ wo', lift (type r) = @type _ (@equiv.ulift.{v} α ⁻¹'o r) wo' :=
-⟨_, rfl⟩
+@[simp] theorem type_lift (r : α → α → Prop) [is_well_order α r] :
+  type (@equiv.ulift.{v} α ⁻¹'o r) = lift.{v} (type r) :=
+rfl
 
 /-- `lift.{(max u v) u}` equals `lift.{v u}`. Using `set_option pp.universes true` will make it much
     easier to understand what's happening when using this lemma. -/

--- a/src/set_theory/ordinal/basic.lean
+++ b/src/set_theory/ordinal/basic.lean
@@ -890,8 +890,7 @@ by simp only [le_antisymm_iff, lift_le]
 @[simp] theorem lift_lt {a b : ordinal} : lift a < lift b ↔ a < b :=
 by simp only [lt_iff_le_not_le, lift_le]
 
-@[simp] theorem lift_zero : lift 0 = 0 :=
-quotient.sound ⟨(rel_iso.preimage equiv.ulift _).trans ⟨equiv_of_is_empty  _ _, λ a b, iff.rfl⟩⟩
+@[simp] theorem lift_zero : lift 0 = 0 := (rel_iso.rel_iso_of_is_empty _ _).ordinal_type_eq
 
 @[simp] theorem lift_one : lift 1 = 1 :=
 quotient.sound ⟨(rel_iso.preimage equiv.ulift _).trans ⟨punit_equiv_punit, λ a b, iff.rfl⟩⟩

--- a/src/set_theory/ordinal/basic.lean
+++ b/src/set_theory/ordinal/basic.lean
@@ -882,8 +882,7 @@ by haveI := @rel_embedding.is_well_order _ _ (@equiv.ulift.{max v w} α ⁻¹'o 
     (initial_seg.of_iso (rel_iso.preimage equiv.ulift s).symm)⟩⟩
 
 @[simp] theorem lift_le {a b : ordinal} : lift.{u v} a ≤ lift b ↔ a ≤ b :=
-induction_on a $ λ α r _, induction_on b $ λ β s _,
-by rw ← lift_umax; exactI lift_type_le
+induction_on a $ λ α r _, induction_on b $ λ β s _, by { rw ← lift_umax, exactI lift_type_le }
 
 @[simp] theorem lift_inj {a b : ordinal} : lift a = lift b ↔ a = b :=
 by simp only [le_antisymm_iff, lift_le]
@@ -892,12 +891,10 @@ by simp only [le_antisymm_iff, lift_le]
 by simp only [lt_iff_le_not_le, lift_le]
 
 @[simp] theorem lift_zero : lift 0 = 0 :=
-quotient.sound ⟨(rel_iso.preimage equiv.ulift _).trans
- ⟨equiv_of_is_empty  _ _, λ a b, iff.rfl⟩⟩
+quotient.sound ⟨(rel_iso.preimage equiv.ulift _).trans ⟨equiv_of_is_empty  _ _, λ a b, iff.rfl⟩⟩
 
 @[simp] theorem lift_one : lift 1 = 1 :=
-quotient.sound ⟨(rel_iso.preimage equiv.ulift _).trans
- ⟨punit_equiv_punit, λ a b, iff.rfl⟩⟩
+quotient.sound ⟨(rel_iso.preimage equiv.ulift _).trans ⟨punit_equiv_punit, λ a b, iff.rfl⟩⟩
 
 theorem one_eq_lift_type_unit : 1 = lift.{u} (@type unit empty_relation _) :=
 by rw [← one_eq_type_unit, lift_one]

--- a/src/set_theory/ordinal/basic.lean
+++ b/src/set_theory/ordinal/basic.lean
@@ -820,22 +820,15 @@ quotient.lift_on o (λ w, type $ ulift.down ⁻¹'o w.r) $
   type (ulift.down ⁻¹'o r) = lift.{v} (type r) :=
 rfl
 
-set_option pp.universes true
 theorem _root_.rel_iso.ordinal_lift_type_eq {α : Type u} {β : Type v}
   {r : α → α → Prop} {s : β → β → Prop} [is_well_order α r] [is_well_order β s] (f : r ≃r s) :
   lift.{v} (type r) = lift.{u} (type s) :=
-begin
-  change type (ulift.down.{v} ⁻¹'o r) = type (ulift.down.{u} ⁻¹'o s),
-  apply rel_iso.ordinal_type_eq,
-  apply (rel_iso.preimage equiv.ulift r).trans,
-  exact f.trans (rel_iso.preimage equiv.ulift s).symm
-end
+((rel_iso.preimage equiv.ulift r).trans $
+  f.trans (rel_iso.preimage equiv.ulift s).symm).ordinal_type_eq
 
-#exit
-
-@[simp] theorem type_preimage_lift {α : Type u} {β : Type v} (r : α → α → Prop) [is_well_order α r]
+@[simp] theorem type_lift_preimage {α : Type u} {β : Type v} (r : α → α → Prop) [is_well_order α r]
   (f : β ≃ α) : lift.{u} (type (f ⁻¹'o r)) = lift.{v} (type r) :=
-(rel_iso.preimage f r).ordinal_type_eq
+(rel_iso.preimage f r).ordinal_lift_type_eq
 
 /-- `lift.{(max u v) u}` equals `lift.{v u}`. Using `set_option pp.universes true` will make it much
     easier to understand what's happening when using this lemma. -/

--- a/src/set_theory/ordinal/basic.lean
+++ b/src/set_theory/ordinal/basic.lean
@@ -816,7 +816,7 @@ quotient.lift_on o (λ w, type $ ulift.down ⁻¹'o w.r) $
   λ ⟨α, r, _⟩ ⟨β, s, _⟩ ⟨f⟩, quot.sound ⟨(rel_iso.preimage equiv.ulift r).trans $
     f.trans (rel_iso.preimage equiv.ulift s).symm⟩
 
-@[simp] theorem type_lift (r : α → α → Prop) [is_well_order α r] :
+@[simp] theorem type_ulift (r : α → α → Prop) [is_well_order α r] :
   type (ulift.down ⁻¹'o r) = lift.{v} (type r) :=
 rfl
 


### PR DESCRIPTION
We add some missing instances for preimages, and missing theorems for `ordinal.lift`. We remove `ordinal.lift_type`, as it was just a worse way of stating `ordinal.type_ulift`.

We also tweak some spacing and golf a few theorems.

This conflicts with (and is inspired by) some of the changes of #15137.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
