### PR TITLE
[Merged by Bors] - feat(combinatorics/simple_graph/connectivity): simp confluence

### DIFF
--- a/src/combinatorics/simple_graph/connectivity.lean
+++ b/src/combinatorics/simple_graph/connectivity.lean
@@ -362,6 +362,15 @@ by induction p; simp [*]
   p.reverse.darts = (p.darts.map dart.symm).reverse :=
 by induction p; simp [*, sym2.eq_swap]
 
+/-- For `simp` confluence -/
+@[simp] lemma exists_mem_darts_and_symm_eq_iff {u v : V} (p : G.walk u v) (d : G.dart) :
+  (∃ (d' : G.dart), d' ∈ p.darts ∧ d'.symm = d) ↔ d.symm ∈ p.darts :=
+⟨by { rintro ⟨d', h, rfl⟩, rwa dart.symm_symm, }, λ h, ⟨d.symm, h, dart.symm_symm _⟩⟩
+
+lemma mem_darts_reverse {u v : V} {d : G.dart} {p : G.walk u v} :
+  d ∈ p.reverse.darts ↔ d.symm ∈ p.darts :=
+by simp
+
 lemma cons_map_snd_darts {u v : V} (p : G.walk u v) :
   u :: p.darts.map dart.snd = p.support :=
 by induction p; simp! [*]
@@ -408,16 +417,11 @@ lemma dart_fst_mem_support_of_mem_darts :
   { exact or.inr (dart_fst_mem_support_of_mem_darts _ hd), },
 end
 
-lemma dart_snd_mem_support_of_mem_darts :
-  Π {u v : V} (p : G.walk u v) {d : G.dart}, d ∈ p.darts → d.snd ∈ p.support
-| u v (cons h p') d hd := begin
-  simp only [support_cons, darts_cons, list.mem_cons_iff] at hd ⊢,
-  rcases hd with (rfl|hd),
-  { simp },
-  { exact or.inr (dart_snd_mem_support_of_mem_darts _ hd), },
-end
+lemma dart_snd_mem_support_of_mem_darts {u v : V} (p : G.walk u v) {d : G.dart} (h : d ∈ p.darts) :
+  d.snd ∈ p.support :=
+by simpa using p.reverse.dart_fst_mem_support_of_mem_darts (by simp [h] : d.symm ∈ p.reverse.darts)
 
-lemma mem_support_of_mem_edges {t u v w : V} (p : G.walk v w) (he : ⟦(t, u)⟧ ∈ p.edges) :
+lemma fst_mem_support_of_mem_edges {t u v w : V} (p : G.walk v w) (he : ⟦(t, u)⟧ ∈ p.edges) :
   t ∈ p.support :=
 begin
   obtain ⟨d, hd, he⟩ := list.mem_map.mp he,
@@ -426,6 +430,10 @@ begin
   { exact dart_fst_mem_support_of_mem_darts _ hd, },
   { exact dart_snd_mem_support_of_mem_darts _ hd, },
 end
+
+lemma snd_mem_support_of_mem_edges {t u v w : V} (p : G.walk v w) (he : ⟦(t, u)⟧ ∈ p.edges) :
+  u ∈ p.support :=
+by { rw sym2.eq_swap at he, exact p.fst_mem_support_of_mem_edges he }
 
 lemma darts_nodup_of_support_nodup {u v : V} {p : G.walk u v} (h : p.support.nodup) :
   p.darts.nodup :=
@@ -442,7 +450,7 @@ begin
   induction p,
   { simp, },
   { simp only [edges_cons, support_cons, list.nodup_cons] at h ⊢,
-    exact ⟨λ h', h.1 (mem_support_of_mem_edges p_p h'), p_ih h.2⟩, }
+    exact ⟨λ h', h.1 (fst_mem_support_of_mem_edges p_p h'), p_ih h.2⟩, }
 end
 
 /-! ### Trails, paths, circuits, cycles -/
@@ -541,6 +549,9 @@ begin
   rw reverse_append at h,
   apply h.of_append_left,
 end
+
+@[simp] lemma is_cycle.not_of_nil {u : V} : ¬ (nil : G.walk u u).is_cycle :=
+λ h, h.ne_nil rfl
 
 /-! ### Walk decompositions -/
 

--- a/src/combinatorics/simple_graph/connectivity.lean
+++ b/src/combinatorics/simple_graph/connectivity.lean
@@ -362,11 +362,6 @@ by induction p; simp [*]
   p.reverse.darts = (p.darts.map dart.symm).reverse :=
 by induction p; simp [*, sym2.eq_swap]
 
-/-- For `simp` confluence -/
-@[simp] lemma exists_mem_darts_and_symm_eq_iff {u v : V} (p : G.walk u v) (d : G.dart) :
-  (∃ (d' : G.dart), d' ∈ p.darts ∧ d'.symm = d) ↔ d.symm ∈ p.darts :=
-⟨by { rintro ⟨d', h, rfl⟩, rwa dart.symm_symm, }, λ h, ⟨d.symm, h, dart.symm_symm _⟩⟩
-
 lemma mem_darts_reverse {u v : V} {d : G.dart} {p : G.walk u v} :
   d ∈ p.reverse.darts ↔ d.symm ∈ p.darts :=
 by simp

--- a/src/data/list/basic.lean
+++ b/src/data/list/basic.lean
@@ -134,6 +134,15 @@ theorem mem_map_of_injective {f : α → β} (H : injective f) {a : α} {l : lis
   f a ∈ map f l ↔ a ∈ l :=
 ⟨λ m, let ⟨a', m', e⟩ := exists_of_mem_map m in H e ▸ m', mem_map_of_mem _⟩
 
+@[simp] lemma _root_.function.involutive.exists_mem_and_apply_eq_iff {f : α → α}
+  (hf : function.involutive f) (x : α) (l : list α) :
+  (∃ (y : α), y ∈ l ∧ f y = x) ↔ f x ∈ l :=
+⟨by { rintro ⟨y, h, rfl⟩, rwa hf y }, λ h, ⟨f x, h, hf _⟩⟩
+
+theorem mem_map_of_involutive {f : α → α} (hf : involutive f) {a : α} {l : list α} :
+  a ∈ map f l ↔ f a ∈ l :=
+by rw [mem_map, hf.exists_mem_and_apply_eq_iff]
+
 lemma forall_mem_map_iff {f : α → β} {l : list α} {P : β → Prop} :
   (∀ i ∈ l.map f, P i) ↔ ∀ j ∈ l, P (f j) :=
 begin


### PR DESCRIPTION
From branch `walks_and_trees`. Adds data/list/basic lemma to help simp prove `d ∈ p.reverse.darts ↔ d.symm ∈ p.darts`.



---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
