### PR TITLE
[Merged by Bors] - feat(topology/algebra/infinite_sum): Double sum is equal to a single value

### DIFF
--- a/src/topology/algebra/infinite_sum.lean
+++ b/src/topology/algebra/infinite_sum.lean
@@ -453,11 +453,12 @@ lemma tsum_eq_single {f : β → α} (b : β) (hf : ∀b' ≠ b, f b' = 0)  :
 (has_sum_single b hf).tsum_eq
 
 lemma tsum_tsum_eq_single (f : β → γ → α) (b : β) (c : γ)
-  (hf : ∀ (b' : β) (c' : γ), b ≠ b' ∨ c ≠ c' → f b' c' = 0) :
+  (hfb : ∀ (b' : β) (c' : γ), b' ≠ b → f b' c' = 0)
+  (hfc : ∀ (b' : β) (c' : γ), c' ≠ c → f b' c' = 0) :
   ∑' (b' : β) (c' : γ), f b' c' = f b c :=
 calc ∑' (b' : β) (c' : γ), f b' c' = ∑' (c' : γ), f b c' : tsum_eq_single b $ λ b' hb',
-  (tsum_eq_single c $ λ c' hc', hf b' c' (or.inl hb'.symm)).trans (hf b' c (or.inl hb'.symm))
-... = f b c : (tsum_eq_single c (λ c' hc', hf b c' (or.inr hc'.symm)))
+  (tsum_eq_single c $ λ c' hc', hfb b' c' hb').trans (hfb b' c hb')
+... = f b c : tsum_eq_single c (λ c' hc', hfc b c' hc')
 
 @[simp] lemma tsum_ite_eq (b : β) [decidable_pred (= b)] (a : α) :
   ∑' b', (if b' = b then a else 0) = a :=

--- a/src/topology/algebra/infinite_sum.lean
+++ b/src/topology/algebra/infinite_sum.lean
@@ -452,13 +452,11 @@ lemma tsum_eq_single {f : β → α} (b : β) (hf : ∀b' ≠ b, f b' = 0)  :
   ∑'b, f b = f b :=
 (has_sum_single b hf).tsum_eq
 
-lemma tsum_tsum_eq_single (f : β → γ → α) (b : β) (c : γ)
-  (hfb : ∀ (b' : β) (c' : γ), b' ≠ b → f b' c' = 0)
+lemma tsum_tsum_eq_single (f : β → γ → α) (b : β) (c : γ) (hfb : ∀ b' ≠ b, f b' c = 0)
   (hfc : ∀ (b' : β) (c' : γ), c' ≠ c → f b' c' = 0) :
-  ∑' (b' : β) (c' : γ), f b' c' = f b c :=
-calc ∑' (b' : β) (c' : γ), f b' c' = ∑' (c' : γ), f b c' : tsum_eq_single b $ λ b' hb',
-  (tsum_eq_single c $ λ c' hc', hfb b' c' hb').trans (hfb b' c hb')
-... = f b c : tsum_eq_single c (λ c' hc', hfc b c' hc')
+  ∑' b' c', f b' c' = f b c :=
+calc ∑' b' c', f b' c' = ∑' b', f b' c : tsum_congr $ λ b', tsum_eq_single _ (hfc b')
+... = f b c : tsum_eq_single _ hfb
 
 @[simp] lemma tsum_ite_eq (b : β) [decidable_pred (= b)] (a : α) :
   ∑' b', (if b' = b then a else 0) = a :=

--- a/src/topology/algebra/infinite_sum.lean
+++ b/src/topology/algebra/infinite_sum.lean
@@ -452,6 +452,13 @@ lemma tsum_eq_single {f : β → α} (b : β) (hf : ∀b' ≠ b, f b' = 0)  :
   ∑'b, f b = f b :=
 (has_sum_single b hf).tsum_eq
 
+lemma tsum_tsum_eq_single (f : β → γ → α) (b : β) (c : γ)
+  (hf : ∀ (b' : β) (c' : γ), b ≠ b' ∨ c ≠ c' → f b' c' = 0) :
+  ∑' (b' : β) (c' : γ), f b' c' = f b c :=
+calc ∑' (b' : β) (c' : γ), f b' c' = ∑' (c' : γ), f b c' : tsum_eq_single b $ λ b' hb',
+  (tsum_eq_single c $ λ c' hc', hf b' c' (or.inl hb'.symm)).trans (hf b' c (or.inl hb'.symm))
+... = f b c : (tsum_eq_single c (λ c' hc', hf b c' (or.inr hc'.symm)))
+
 @[simp] lemma tsum_ite_eq (b : β) [decidable_pred (= b)] (a : α) :
   ∑' b', (if b' = b then a else 0) = a :=
 (has_sum_ite_eq b a).tsum_eq


### PR DESCRIPTION
A generalized version of `tsum_eq_single` that works for a double indexed sum, when all but one summand is zero.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
