### PR TITLE
[Merged by Bors] - feat(data/finset/basic): Add `decidable_nonempty` for finsets.

### DIFF
--- a/src/algebra/big_operators/basic.lean
+++ b/src/algebra/big_operators/basic.lean
@@ -1186,7 +1186,7 @@ finset.strong_induction_on s
       if hx1 : f x = 1
       then ih' ▸ eq.symm (prod_subset hmem
         (λ y hy hy₁,
-          have y = x ∨ y = g x hx, by simp [hy] at hy₁; tauto,
+          have y = x ∨ y = g x hx, by simpa [hy, not_and_distrib, or_comm] using hy₁,
           this.elim (λ hy, hy.symm ▸ hx1)
             (λ hy, h x hx ▸ hy ▸ hx1.symm ▸ (one_mul _).symm)))
       else by rw [← insert_erase hx, prod_insert (not_mem_erase _ _),

--- a/src/data/bool/all_any.lean
+++ b/src/data/bool/all_any.lean
@@ -47,10 +47,4 @@ theorem any_iff_exists_prop : any l (λ a, p a) ↔ ∃ a ∈ l, p a := by simp 
 
 theorem any_of_mem {p : α → bool} (h₁ : a ∈ l) (h₂ : p a) : any l p := any_iff_exists.2 ⟨_, h₁, h₂⟩
 
-@[priority 500] instance decidable_forall_mem (l : list α) : decidable (∀ x ∈ l, p x) :=
-decidable_of_iff _ all_iff_forall_prop
-
-instance decidable_exists_mem (l : list α) : decidable (∃ x ∈ l, p x) :=
-decidable_of_iff _ any_iff_exists_prop
-
 end list

--- a/src/data/finset/basic.lean
+++ b/src/data/finset/basic.lean
@@ -166,12 +166,6 @@ theorem mem_def {a : α} {s : finset α} : a ∈ s ↔ a ∈ s.1 := iff.rfl
 instance decidable_mem [h : decidable_eq α] (a : α) (s : finset α) : decidable (a ∈ s) :=
 multiset.decidable_mem _ _
 
-instance decidable_forall_mem {P : α → Prop} [decidable_pred P] (s : finset α) :
-  decidable (∀ a ∈ s, P a) := s.val.decidable_forall_mem
-
-instance decidable_exists_mem {P : α → Prop} [decidable_pred P] (s : finset α) :
-  decidable (∃ a ∈ s, P a) := s.val.decidable_exists_mem
-
 /-! ### set coercion -/
 
 /-- Convert a finset to a set in the natural way. -/

--- a/src/data/finset/basic.lean
+++ b/src/data/finset/basic.lean
@@ -166,6 +166,12 @@ theorem mem_def {a : α} {s : finset α} : a ∈ s ↔ a ∈ s.1 := iff.rfl
 instance decidable_mem [h : decidable_eq α] (a : α) (s : finset α) : decidable (a ∈ s) :=
 multiset.decidable_mem _ _
 
+instance decidable_forall_mem {P : α → Prop} [decidable_pred P] (s : finset α) :
+  decidable (∀ a ∈ s, P a) := s.val.decidable_forall_mem
+
+instance decidable_exists_mem {P : α → Prop} [decidable_pred P] (s : finset α) :
+  decidable (∃ a ∈ s, P a) := s.val.decidable_exists_mem
+
 /-! ### set coercion -/
 
 /-- Convert a finset to a set in the natural way. -/

--- a/src/data/finset/basic.lean
+++ b/src/data/finset/basic.lean
@@ -327,7 +327,7 @@ in theorem assumptions instead of `∃ x, x ∈ s` or `s ≠ ∅` as it gives ac
 to the dot notation. -/
 protected def nonempty (s : finset α) : Prop := ∃ x : α, x ∈ s
 
-instance decidable_nonempty {s : finset α} : decidable (s.nonempty) :=
+instance decidable_nonempty {s : finset α} : decidable s.nonempty :=
 decidable_of_iff (∃ a ∈ s, true) $ by simp_rw [exists_prop, and_true, finset.nonempty]
 
 @[simp, norm_cast] lemma coe_nonempty {s : finset α} : (s : set α).nonempty ↔ s.nonempty := iff.rfl

--- a/src/data/finset/basic.lean
+++ b/src/data/finset/basic.lean
@@ -333,6 +333,9 @@ in theorem assumptions instead of `∃ x, x ∈ s` or `s ≠ ∅` as it gives ac
 to the dot notation. -/
 protected def nonempty (s : finset α) : Prop := ∃ x : α, x ∈ s
 
+instance decidable_nonempty {s : finset α} : decidable (s.nonempty) :=
+decidable_of_iff (∃ a ∈ s, true) $ by simp_rw [exists_prop, and_true, finset.nonempty]
+
 @[simp, norm_cast] lemma coe_nonempty {s : finset α} : (s : set α).nonempty ↔ s.nonempty := iff.rfl
 
 @[simp] lemma nonempty_coe_sort {s : finset α} : nonempty ↥s ↔ s.nonempty := nonempty_subtype

--- a/src/data/finset/card.lean
+++ b/src/data/finset/card.lean
@@ -57,6 +57,8 @@ alias card_pos ↔ _ nonempty.card_pos
 
 lemma card_ne_zero_of_mem (h : a ∈ s) : s.card ≠ 0 := (not_congr card_eq_zero).2 $ ne_empty_of_mem h
 
+instance decidable_nonempty : decidable (s.nonempty) := decidable_of_iff (0 < s.card) card_pos
+
 @[simp] lemma card_singleton (a : α) : card ({a} : finset α) = 1 := card_singleton _
 
 lemma card_singleton_inter [decidable_eq α] : ({a} ∩ s).card ≤ 1 :=

--- a/src/data/finset/card.lean
+++ b/src/data/finset/card.lean
@@ -57,8 +57,6 @@ alias card_pos ↔ _ nonempty.card_pos
 
 lemma card_ne_zero_of_mem (h : a ∈ s) : s.card ≠ 0 := (not_congr card_eq_zero).2 $ ne_empty_of_mem h
 
-instance decidable_nonempty : decidable (s.nonempty) := decidable_of_iff (0 < s.card) card_pos
-
 @[simp] lemma card_singleton (a : α) : card ({a} : finset α) = 1 := card_singleton _
 
 lemma card_singleton_inter [decidable_eq α] : ({a} ∩ s).card ≤ 1 :=

--- a/src/data/multiset/basic.lean
+++ b/src/data/multiset/basic.lean
@@ -1097,29 +1097,29 @@ variables {m : multiset α}
 
 /-- If `p` is a decidable predicate,
 so is the predicate that all elements of a multiset satisfy `p`. -/
-protected def decidable_forall_multiset {p : α → Prop} [hp : ∀a, decidable (p a)] :
-  decidable (∀a∈m, p a) :=
-quotient.rec_on_subsingleton m (λl, decidable_of_iff (∀a∈l, p a) $ by simp)
+protected def decidable_forall_multiset {p : α → Prop} [hp : ∀ a, decidable (p a)] :
+  decidable (∀ a ∈ m, p a) :=
+quotient.rec_on_subsingleton m (λl, decidable_of_iff (∀a ∈ l, p a) $ by simp)
 
-instance decidable_dforall_multiset {p : Πa∈m, Prop} [hp : ∀a (h : a ∈ m), decidable (p a h)] :
-  decidable (∀a (h : a ∈ m), p a h) :=
+instance decidable_dforall_multiset {p : Π a ∈ m, Prop} [hp : ∀ a (h : a ∈ m), decidable (p a h)] :
+  decidable (∀ a (h : a ∈ m), p a h) :=
 decidable_of_decidable_of_iff
   (@multiset.decidable_forall_multiset {a // a ∈ m} m.attach (λa, p a.1 a.2) _)
   (iff.intro (assume h a ha, h ⟨a, ha⟩ (mem_attach _ _)) (assume h ⟨a, ha⟩ _, h _ _))
 
 /-- decidable equality for functions whose domain is bounded by multisets -/
-instance decidable_eq_pi_multiset {β : α → Type*} [h : ∀a, decidable_eq (β a)] :
-  decidable_eq (Πa∈m, β a) :=
-assume f g, decidable_of_iff (∀a (h : a ∈ m), f a h = g a h) (by simp [function.funext_iff])
+instance decidable_eq_pi_multiset {β : α → Type*} [h : ∀ a, decidable_eq (β a)] :
+  decidable_eq (Π a ∈ m, β a) :=
+assume f g, decidable_of_iff (∀ a (h : a ∈ m), f a h = g a h) (by simp [function.funext_iff])
 
 /-- If `p` is a decidable predicate,
 so is the existence of an element in a multiset satisfying `p`. -/
-def decidable_exists_multiset {p : α → Prop} [decidable_pred p] :
+protected def decidable_exists_multiset {p : α → Prop} [decidable_pred p] :
   decidable (∃ x ∈ m, p x) :=
-quotient.rec_on_subsingleton m list.decidable_exists_mem
+quotient.rec_on_subsingleton m (λl, decidable_of_iff (∃ a ∈ l, p a) $ by simp)
 
-instance decidable_dexists_multiset {p : Πa∈m, Prop} [hp : ∀a (h : a ∈ m), decidable (p a h)] :
-  decidable (∃a (h : a ∈ m), p a h) :=
+instance decidable_dexists_multiset {p : Π a ∈ m, Prop} [hp : ∀ a (h : a ∈ m), decidable (p a h)] :
+  decidable (∃ a (h : a ∈ m), p a h) :=
 decidable_of_decidable_of_iff
   (@multiset.decidable_exists_multiset {a // a ∈ m} m.attach (λa, p a.1 a.2) _)
   (iff.intro (λ ⟨⟨a, ha₁⟩, _, ha₂⟩, ⟨a, ha₁, ha₂⟩)

--- a/src/data/multiset/basic.lean
+++ b/src/data/multiset/basic.lean
@@ -154,6 +154,14 @@ instance : has_mem α (multiset α) := ⟨mem⟩
 instance decidable_mem [decidable_eq α] (a : α) (s : multiset α) : decidable (a ∈ s) :=
 quot.rec_on_subsingleton s $ list.decidable_mem a
 
+instance decidable_forall_mem {P : α → Prop} [decidable_pred P] (m : multiset α) :
+  decidable (∀ a ∈ m, P a) :=
+quotient.rec_on_subsingleton m list.decidable_forall_mem
+
+instance decidable_exists_mem {P : α → Prop} [decidable_pred P] (m : multiset α) :
+  decidable (∃ a ∈ m, P a) :=
+quotient.rec_on_subsingleton m list.decidable_exists_mem
+
 @[simp] theorem mem_cons {a b : α} {s : multiset α} : a ∈ b ::ₘ s ↔ a = b ∨ a ∈ s :=
 quot.induction_on s $ λ l, iff.rfl
 

--- a/src/data/multiset/basic.lean
+++ b/src/data/multiset/basic.lean
@@ -154,14 +154,6 @@ instance : has_mem α (multiset α) := ⟨mem⟩
 instance decidable_mem [decidable_eq α] (a : α) (s : multiset α) : decidable (a ∈ s) :=
 quot.rec_on_subsingleton s $ list.decidable_mem a
 
-instance decidable_forall_mem {P : α → Prop} [decidable_pred P] (m : multiset α) :
-  decidable (∀ a ∈ m, P a) :=
-quotient.rec_on_subsingleton m list.decidable_forall_mem
-
-instance decidable_exists_mem {P : α → Prop} [decidable_pred P] (m : multiset α) :
-  decidable (∃ a ∈ m, P a) :=
-quotient.rec_on_subsingleton m list.decidable_exists_mem
-
 @[simp] theorem mem_cons {a b : α} {s : multiset α} : a ∈ b ::ₘ s ↔ a = b ∨ a ∈ s :=
 quot.induction_on s $ λ l, iff.rfl
 


### PR DESCRIPTION
Also remove some redundant decidable instances in multiset and list.

---
Note: as we have the nonempty predicate, we can define a decidable instance for it without worrying about diamond issues. This is always possible, even if there is no decidable equality on the underlying type.
