### PR TITLE
feat(order/compare): comparison in preorders

### DIFF
--- a/src/order/antisymmetrization.lean
+++ b/src/order/antisymmetrization.lean
@@ -3,6 +3,8 @@ Copyright (c) 2022 Yaël Dillies. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Yaël Dillies
 -/
+
+import order.basic_rels
 import order.hom.basic
 
 /-!
@@ -15,8 +17,6 @@ such that `a ≤ b` and `b ≤ a`.
 
 ## Main declarations
 
-* `antisymm_rel`: The antisymmetrization relation. `antisymm_rel r a b` means that `a` and `b` are
-  related both ways by `r`.
 * `antisymmetrization α r`: The quotient of `α` by `antisymm_rel r`. Even when `r` is just a
   preorder, `antisymmetrization α` is a partial order.
 -/
@@ -24,36 +24,6 @@ such that `a ≤ b` and `b ≤ a`.
 open function order_dual
 
 variables {α β : Type*}
-
-section relation
-variables (r : α → α → Prop)
-
-/-- The antisymmetrization relation. -/
-def antisymm_rel (a b : α) : Prop := r a b ∧ r b a
-
-lemma antisymm_rel_swap : antisymm_rel (swap r) = antisymm_rel r :=
-funext $ λ _, funext $ λ _, propext and.comm
-
-@[refl] lemma antisymm_rel_refl [is_refl α r] (a : α) : antisymm_rel r a a := ⟨refl _, refl _⟩
-
-variables {r}
-
-@[symm] lemma antisymm_rel.symm {a b : α} : antisymm_rel r a b → antisymm_rel r b a := and.symm
-
-@[trans] lemma antisymm_rel.trans [is_trans α r] {a b c : α} (hab : antisymm_rel r a b)
-  (hbc : antisymm_rel r b c) :
-  antisymm_rel r a c :=
-⟨trans hab.1 hbc.1, trans hbc.2 hab.2⟩
-
-instance antisymm_rel.decidable_rel [decidable_rel r] : decidable_rel (antisymm_rel r) :=
-λ _ _, and.decidable
-
-@[simp] lemma antisymm_rel_iff_eq [is_refl α r] [is_antisymm α r] {a b : α} :
-  antisymm_rel r a b ↔ a = b := antisymm_iff
-
-alias antisymm_rel_iff_eq ↔ antisymm_rel.eq _
-
-end relation
 
 section is_preorder
 variables (α) (r : α → α → Prop) [is_preorder α r]

--- a/src/order/basic_rels.lean
+++ b/src/order/basic_rels.lean
@@ -1,0 +1,81 @@
+/-
+Copyright (c) 2022 Yaël Dillies. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Yaël Dillies, Violeta Hernández Palacios
+-/
+
+import order.rel_classes
+
+/-!
+# Basic relations
+
+We define two basic relations from any other relation `r`: the antisymmetrization or
+indistinguishable relation `r a b ∧ r b a`, and the incomparable relation `¬ r a b ∧ ¬ r b a`.
+-/
+
+open function
+
+variables {α β : Type*} (r : α → α → Prop)
+
+/-! ### Antisymmetrization relation -/
+
+section antisymm
+
+/-- The antisymmetrization relation. -/
+def antisymm_rel (a b : α) : Prop := r a b ∧ r b a
+
+@[simp] lemma antisymm_rel_swap : antisymm_rel (swap r) = antisymm_rel r :=
+funext $ λ _, funext $ λ _, propext and.comm
+
+@[refl] lemma antisymm_rel_refl [is_refl α r] (a : α) : antisymm_rel r a a := ⟨refl _, refl _⟩
+
+instance [is_refl α r] : is_refl α (antisymm_rel r) := ⟨antisymm_rel_refl r⟩
+
+variables {r}
+
+@[symm] lemma antisymm_rel.symm {a b : α} : antisymm_rel r a b → antisymm_rel r b a := and.symm
+
+instance : is_symm α (antisymm_rel r) := ⟨λ a b, antisymm_rel.symm⟩
+
+@[trans] lemma antisymm_rel.trans [is_trans α r] {a b c : α} (hab : antisymm_rel r a b)
+  (hbc : antisymm_rel r b c) : antisymm_rel r a c :=
+⟨trans hab.1 hbc.1, trans hbc.2 hab.2⟩
+
+instance [is_trans α r] : is_trans α (antisymm_rel r) := ⟨λ a b c, antisymm_rel.trans⟩
+
+instance antisymm_rel.decidable_rel [decidable_rel r] : decidable_rel (antisymm_rel r) :=
+λ _ _, and.decidable
+
+@[simp] lemma antisymm_rel_iff_eq [is_refl α r] [is_antisymm α r] {a b : α} :
+  antisymm_rel r a b ↔ a = b := antisymm_iff
+
+alias antisymm_rel_iff_eq ↔ antisymm_rel.eq _
+
+end antisymm
+
+/-! ### Incomparable relation -/
+
+section incomp
+
+/-- The incomparability relation. -/
+def incomp_rel (a b : α) : Prop := ¬ r a b ∧ ¬ r b a
+
+@[simp] lemma incomp_rel_swap : incomp_rel (swap r) = incomp_rel r := antisymm_rel_swap _
+
+@[refl] lemma incomp_rel_refl [is_irrefl α r] (a : α) : incomp_rel r a a := ⟨irrefl _, irrefl _⟩
+
+instance [is_irrefl α r] : is_refl α (incomp_rel r) := ⟨incomp_rel_refl r⟩
+
+variables {r}
+
+@[symm] lemma incomp_rel.symm {a b : α} : incomp_rel r a b → incomp_rel r b a := and.symm
+
+instance : is_symm α (incomp_rel r) := ⟨λ a b, incomp_rel.symm⟩
+
+instance incomp_rel.decidable_rel [decidable_rel r] : decidable_rel (incomp_rel r) :=
+λ _ _, and.decidable
+
+@[simp] lemma not_incomp_rel [is_total α r] (a b : α) : ¬ incomp_rel r a b :=
+by { rw [incomp_rel, not_and_distrib, not_not, not_not], exact is_total.total a b }
+
+end incomp

--- a/src/order/basic_rels.lean
+++ b/src/order/basic_rels.lean
@@ -24,7 +24,7 @@ section antisymm
 /-- The antisymmetrization relation. -/
 def antisymm_rel (a b : α) : Prop := r a b ∧ r b a
 
-@[simp] lemma antisymm_rel_swap : antisymm_rel (swap r) = antisymm_rel r :=
+lemma antisymm_rel_swap : antisymm_rel (swap r) = antisymm_rel r :=
 funext $ λ _, funext $ λ _, propext and.comm
 
 @[refl] lemma antisymm_rel_refl [is_refl α r] (a : α) : antisymm_rel r a a := ⟨refl _, refl _⟩
@@ -60,7 +60,7 @@ section incomp
 /-- The incomparability relation. -/
 def incomp_rel (a b : α) : Prop := ¬ r a b ∧ ¬ r b a
 
-@[simp] lemma incomp_rel_swap : incomp_rel (swap r) = incomp_rel r := antisymm_rel_swap _
+lemma incomp_rel_swap : incomp_rel (swap r) = incomp_rel r := antisymm_rel_swap _
 
 @[refl] lemma incomp_rel_refl [is_irrefl α r] (a : α) : incomp_rel r a a := ⟨irrefl _, irrefl _⟩
 

--- a/src/order/basic_rels.lean
+++ b/src/order/basic_rels.lean
@@ -31,11 +31,15 @@ funext $ λ _, funext $ λ _, propext and.comm
 
 instance [is_refl α r] : is_refl α (antisymm_rel r) := ⟨antisymm_rel_refl r⟩
 
+lemma eq.antisymm_rel [is_refl α r] {a b : α} (h : a = b) : antisymm_rel r a b := by rw h
+
 variables {r}
 
 @[symm] lemma antisymm_rel.symm {a b : α} : antisymm_rel r a b → antisymm_rel r b a := and.symm
 
 instance : is_symm α (antisymm_rel r) := ⟨λ a b, antisymm_rel.symm⟩
+
+lemma antisymm_rel.comm {a b : α} : antisymm_rel r a b ↔ antisymm_rel r b a := comm
 
 @[trans] lemma antisymm_rel.trans [is_trans α r] {a b c : α} (hab : antisymm_rel r a b)
   (hbc : antisymm_rel r b c) : antisymm_rel r a c :=
@@ -50,6 +54,9 @@ instance antisymm_rel.decidable_rel [decidable_rel r] : decidable_rel (antisymm_
   antisymm_rel r a b ↔ a = b := antisymm_iff
 
 alias antisymm_rel_iff_eq ↔ antisymm_rel.eq _
+
+lemma le_iff_lt_or_antisymm_rel [preorder α] {a b : α} : a ≤ b ↔ a < b ∨ antisymm_rel (≤) a b :=
+by { rw [lt_iff_le_not_le, antisymm_rel], tauto! }
 
 end antisymm
 
@@ -71,6 +78,8 @@ variables {r}
 @[symm] lemma incomp_rel.symm {a b : α} : incomp_rel r a b → incomp_rel r b a := and.symm
 
 instance : is_symm α (incomp_rel r) := ⟨λ a b, incomp_rel.symm⟩
+
+lemma incomp_rel.comm {a b : α} : incomp_rel r a b ↔ incomp_rel r b a := comm
 
 instance incomp_rel.decidable_rel [decidable_rel r] : decidable_rel (incomp_rel r) :=
 λ _ _, and.decidable

--- a/src/order/basic_rels.lean
+++ b/src/order/basic_rels.lean
@@ -88,3 +88,9 @@ instance incomp_rel.decidable_rel [decidable_rel r] : decidable_rel (incomp_rel 
 by { rw [incomp_rel, not_and_distrib, not_not, not_not], exact is_total.total a b }
 
 end incomp
+
+/-- Two elements in a preorder compare as either less than, or equivalent (up to antisymmetry), or
+greater than, or are incomparable. In fact, exactly one of them holds: see `preordering.precmp`. -/
+lemma lt_or_antisymm_rel_or_gt_or_incomp_rel [preorder α] (a b : α) :
+  a < b ∨ antisymm_rel (≤) a b ∨ b < a ∨ incomp_rel (≤) a b :=
+by { rw [antisymm_rel, incomp_rel, lt_iff_le_not_le, lt_iff_le_not_le], tauto! }

--- a/src/order/compare.lean
+++ b/src/order/compare.lean
@@ -448,7 +448,7 @@ def to_preordering : ordering → preordering
 @[simp] lemma eq_to_preordering : eq.to_preordering = preordering.equiv := rfl
 @[simp] lemma gt_to_preordering : gt.to_preordering = preordering.gt := rfl
 
-@[simp] lemma precmp_to_cmp [linear_order α] (a b : α) : (cmp a b).to_preordering = precmp a b :=
+@[simp] lemma cmp_to_precmp [linear_order α] (a b : α) : (cmp a b).to_preordering = precmp a b :=
 begin
   rcases lt_trichotomy a b with h | h | h,
   { rw [h.cmp_eq_lt, h.precmp_eq_lt], refl },


### PR DESCRIPTION
We provide an extensive API for comparing values in preorders, analogous to the existing API on linear orders. We plan to eventually use this to golf many results on pre-games.

Obsoletes many of the changes in #14964.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
- [ ] depends on: #15168

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
