### PR TITLE
[Merged by Bors] - chore(topology/basic): use `finite` in `locally_finite_of_finite`

### DIFF
--- a/src/topology/basic.lean
+++ b/src/topology/basic.lean
@@ -1191,7 +1191,7 @@ lemma locally_finite.point_finite {f : β → set α} (hf : locally_finite f) (x
   {b | x ∈ f b}.finite :=
 let ⟨t, hxt, ht⟩ := hf x in ht.subset $ λ b hb, ⟨x, hb, mem_of_mem_nhds hxt⟩
 
-lemma locally_finite_of_fintype [fintype β] (f : β → set α) : locally_finite f :=
+lemma locally_finite_of_finite [finite β] (f : β → set α) : locally_finite f :=
 assume x, ⟨univ, univ_mem, to_finite _⟩
 
 lemma locally_finite.subset

--- a/src/topology/paracompact.lean
+++ b/src/topology/paracompact.lean
@@ -112,7 +112,7 @@ begin
   rcases compact_univ.elim_finite_subcover _ ho hu.ge with ⟨T, hT⟩,
   have := hT, simp only [subset_def, mem_Union] at this,
   choose i hiT hi using λ x, this x (mem_univ x),
-  refine ⟨(T : set ι), λ t, s t, λ t, ho _, _, locally_finite_of_fintype _, λ t, ⟨t, subset.rfl⟩⟩,
+  refine ⟨(T : set ι), λ t, s t, λ t, ho _, _, locally_finite_of_finite _, λ t, ⟨t, subset.rfl⟩⟩,
   simpa only [Union_coe_set, ← univ_subset_iff]
 end
 


### PR DESCRIPTION
Rename `locally_finite_of_fintype` to `locally_finite_of_finite`, use `[finite]` instead of `[fintype]`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
