### PR TITLE
[Merged by Bors] - feat(data/pnat/basic): `succ` as an order isomorphism between `ℕ` and `ℕ+`

### DIFF
--- a/src/data/pnat/basic.lean
+++ b/src/data/pnat/basic.lean
@@ -113,7 +113,7 @@ instance : add_right_cancel_semigroup ℕ+ :=
 coe_injective.add_right_cancel_semigroup coe (λ _ _, rfl)
 
 /-- The order isomorphism between ℕ and ℕ+ given by `succ`. -/
-def succ_order_iso : ℕ ≃o ℕ+ :=
+@[simps] def succ_order_iso : ℕ ≃o ℕ+ :=
 { to_fun := λ n, ⟨_, succ_pos n⟩,
   inv_fun := λ n, pred (n : ℕ),
   left_inv := pred_succ,

--- a/src/data/pnat/basic.lean
+++ b/src/data/pnat/basic.lean
@@ -112,6 +112,14 @@ coe_injective.add_left_cancel_semigroup coe (λ _ _, rfl)
 instance : add_right_cancel_semigroup ℕ+ :=
 coe_injective.add_right_cancel_semigroup coe (λ _ _, rfl)
 
+/-- The order isomorphism between ℕ and ℕ+ given by `succ`. -/
+def succ_order_iso : ℕ ≃o ℕ+ :=
+{ to_fun := λ n, ⟨_, succ_pos n⟩,
+  inv_fun := λ n, pred (n : ℕ),
+  left_inv := pred_succ,
+  right_inv := λ ⟨x, hx⟩, by simpa using succ_pred_eq_of_pos hx,
+  map_rel_iff' := @succ_le_succ_iff }
+
 @[priority 10]
 instance : covariant_class ℕ+ ℕ+ ((+)) (≤) :=
 ⟨by { rintro ⟨a, ha⟩ ⟨b, hb⟩ ⟨c, hc⟩, simp [←pnat.coe_le_coe] }⟩


### PR DESCRIPTION
Couldn't find this in the library. Asked on [Zulip](https://leanprover.zulipchat.com/#narrow/stream/217875-Is-there-code-for-X.3F/topic/order.20isomorphism.20between.20.E2.84.95.20and.20.E2.84.95.2B/near/288891689) in case anyone knew of this already.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
