### PR TITLE
[Merged by Bors] - feat(algebra/parity): more general odd.pos

### DIFF
--- a/archive/imo/imo1998_q2.lean
+++ b/archive/imo/imo1998_q2.lean
@@ -201,7 +201,7 @@ theorem imo1998_q2 [fintype J] [fintype C]
   (hk : ∀ (p : judge_pair J), p.distinct → (agreed_contestants r p).card ≤ k) :
   (b - 1) / (2 * b) ≤ k / a :=
 begin
-  rw clear_denominators ha (nat.pos_of_odd hb),
+  rw clear_denominators ha hb.odd,
   obtain ⟨z, hz⟩ := hb, rw hz at hJ, rw hz,
   have h := le_trans (A_card_lower_bound r hJ) (A_card_upper_bound r hk),
   rw [hC, hJ] at h,

--- a/archive/imo/imo1998_q2.lean
+++ b/archive/imo/imo1998_q2.lean
@@ -201,7 +201,7 @@ theorem imo1998_q2 [fintype J] [fintype C]
   (hk : ∀ (p : judge_pair J), p.distinct → (agreed_contestants r p).card ≤ k) :
   (b - 1) / (2 * b) ≤ k / a :=
 begin
-  rw clear_denominators ha hb.odd,
+  rw clear_denominators ha hb.pos,
   obtain ⟨z, hz⟩ := hb, rw hz at hJ, rw hz,
   have h := le_trans (A_card_lower_bound r hJ) (A_card_upper_bound r hk),
   rw [hC, hJ] at h,

--- a/src/algebra/parity.lean
+++ b/src/algebra/parity.lean
@@ -247,9 +247,9 @@ variables [canonically_ordered_comm_semiring α]
 
 -- TODO: this holds more generally in a `canonically_ordered_add_monoid` if we refactor `odd` to use
 -- either `2 • t` or `t + t` instead of `2 * t`.
-lemma odd.pos  [nontrivial α] : ∀ {n : α}, odd n → 0 < n
-| _ ⟨k, rfl⟩ :=
+lemma odd.pos [nontrivial α] {n : α} (hn : odd n) : 0 < n :=
 begin
+  obtain ⟨k, rfl⟩ := hn,
   rw [pos_iff_ne_zero, ne.def, add_eq_zero_iff, not_and'],
   exact λ h, (one_ne_zero h).elim
 end

--- a/src/algebra/parity.lean
+++ b/src/algebra/parity.lean
@@ -241,6 +241,21 @@ lemma odd.neg_one_pow (h : odd n) : (-1 : α) ^ n = -1 := by rw [h.neg_pow, one_
 
 end monoid
 
+section canonically_ordered_comm_semiring
+
+variables [canonically_ordered_comm_semiring α]
+
+-- TODO: this holds more generally in a `canonically_ordered_add_monoid` if we refactor `odd` to use
+-- either `2 • t` or `t + t` instead of `2 * t`.
+lemma odd.pos  [nontrivial α] : ∀ {n : α}, odd n → 0 < n
+| _ ⟨k, rfl⟩ :=
+begin
+  rw [pos_iff_ne_zero, ne.def, add_eq_zero_iff, not_and'],
+  exact λ h, (one_ne_zero h).elim
+end
+
+end canonically_ordered_comm_semiring
+
 section ring
 variables [ring α] {a b : α} {n : ℕ}
 

--- a/src/algebra/parity.lean
+++ b/src/algebra/parity.lean
@@ -245,7 +245,7 @@ section canonically_ordered_comm_semiring
 
 variables [canonically_ordered_comm_semiring α]
 
--- TODO: this holds more generally in a `canonically_ordered_add_monoid` if we refactor `odd` to use
+-- this holds more generally in a `canonically_ordered_add_monoid` if we refactor `odd` to use
 -- either `2 • t` or `t + t` instead of `2 * t`.
 lemma odd.pos [nontrivial α] {n : α} (hn : odd n) : 0 < n :=
 begin

--- a/src/data/nat/parity.lean
+++ b/src/data/nat/parity.lean
@@ -72,9 +72,6 @@ begin
               one_ne_zero, and_self] },
 end
 
-lemma pos_of_odd (h : odd n) : 0 < n :=
-by { obtain ⟨k, rfl⟩ := h, exact succ_pos' }
-
 @[simp] theorem two_dvd_ne_zero : ¬ 2 ∣ n ↔ n % 2 = 1 :=
 even_iff_two_dvd.symm.not.trans not_even_iff
 


### PR DESCRIPTION
The old version of this lemma (added in #13040) was only for ℕ and didn't allow dot notation. We remove this and add a version for `canonically_ordered_comm_semiring`s, and if the definition of `odd` changes, this will also work for `canononically_ordered_add_monoid`s.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
