### PR TITLE
[Merged by Bors] - chore(data/nat/squarefree): fix a tactic doc typo for norm num extension

### DIFF
--- a/src/data/nat/squarefree.lean
+++ b/src/data/nat/squarefree.lean
@@ -510,7 +510,7 @@ match match_numeral en with
 | _ := failed
 end
 
-/-- Evaluates the `prime` and `min_fac` functions. -/
+/-- Evaluates the `squarefree` predicate on naturals. -/
 @[norm_num] meta def eval_squarefree : expr → tactic (expr × expr)
 | `(squarefree (%%e : ℕ)) := do
   n ← e.to_nat,


### PR DESCRIPTION

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
