### PR TITLE
feat(representation_theory): add rep_hom homomorphism between representations

### DIFF
--- a/src/representation_theory/rep_equiv.lean
+++ b/src/representation_theory/rep_equiv.lean
@@ -1,0 +1,346 @@
+/-
+Copyright (c) 2022 Winston Yin. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Winston Yin
+-/
+import representation_theory.rep_hom
+
+/-!
+# Homomorphisms between representations
+
+This file defines equivalence between representations `rep_equiv`. We could define it as linear
+equivalence between modules that preserve the group action, or in the case of this file, as
+`rep_hom` that is also an `add_equiv`. Lemmas and definitions closely follow
+`algebra.module.equiv`.
+
+## Notations
+
+Since multiple different representations may be defined on the same vector space, the `rep_equiv`s
+are written to be from `ρ : representation k G V` to `ρ₂ : representation k G V₂`
+(denoted `ρ ≃ᵣ ρ₂`), rather than from `V` to `V₂`.
+
+## Tags
+
+representation, isomorphism
+-/
+
+open function
+open_locale big_operators
+
+section
+set_option old_structure_cmd true
+
+/-- A linear equivalence is an invertible linear map. -/
+@[nolint has_inhabited_instance]
+structure rep_equiv {k G V V₂ : Type*} [comm_semiring k] [monoid G]
+  [add_comm_monoid V] [module k V] [add_comm_monoid V₂] [module k V₂]
+  (ρ : representation k G V) (ρ₂ : representation k G V₂)
+  extends rep_hom ρ ρ₂, V ≃+ V₂
+end
+
+attribute [nolint doc_blame] rep_equiv.to_rep_hom
+attribute [nolint doc_blame] rep_equiv.to_add_equiv
+
+infixr ` ≃ᵣ `:25 := rep_equiv
+
+namespace rep_equiv
+
+section add_comm_monoid
+
+variables
+  {k G V V₂ : Type*} [comm_semiring k] [monoid G]
+  [add_comm_monoid V] [module k V] [add_comm_monoid V₂] [module k V₂]
+  {ρ : representation k G V} {ρ₂ : representation k G V₂}
+
+instance : has_coe (ρ ≃ᵣ ρ₂) (ρ →ᵣ ρ₂) := ⟨to_rep_hom⟩
+instance : has_coe_to_fun (ρ ≃ᵣ ρ₂) (λ _, V → V₂) := ⟨to_fun⟩
+
+@[simp] lemma coe_mk {to_fun inv_fun map_add map_smul map_smulG left_inv right_inv} :
+  ⇑(⟨to_fun, map_add, map_smul, map_smulG, inv_fun, left_inv, right_inv⟩ : ρ ≃ᵣ ρ₂) = to_fun :=
+rfl
+
+@[nolint doc_blame]
+def to_equiv : (ρ ≃ᵣ ρ₂) → V ≃ V₂ := λ f, f.to_add_equiv.to_equiv
+
+lemma to_equiv_injective : function.injective (to_equiv : (ρ ≃ᵣ ρ₂) → V ≃ V₂) :=
+λ ⟨_, _, _, _, _, _, _⟩ ⟨_, _, _, _, _, _, _⟩ h, rep_equiv.mk.inj_eq.mpr (equiv.mk.inj h)
+
+@[simp] lemma to_equiv_inj {e₁ e₂ : ρ ≃ᵣ ρ₂} : e₁.to_equiv = e₂.to_equiv ↔ e₁ = e₂ :=
+to_equiv_injective.eq_iff
+
+lemma to_rep_hom_injective :
+  injective (coe : (ρ ≃ᵣ ρ₂) → (ρ →ᵣ ρ₂)) :=
+λ e₁ e₂ H, to_equiv_injective $ equiv.ext $ rep_hom.congr_fun H
+
+@[simp, norm_cast] lemma to_rep_hom_inj {e₁ e₂ : ρ ≃ᵣ ρ₂} :
+  (e₁ : ρ →ᵣ ρ₂) = e₂ ↔ e₁ = e₂ :=
+to_rep_hom_injective.eq_iff
+
+instance : rep_hom_class (ρ ≃ᵣ ρ₂) ρ ρ₂ :=
+{ coe := rep_equiv.to_fun,
+  coe_injective' := λ f g h, to_rep_hom_injective (fun_like.coe_injective h),
+  map_add := map_add',
+  map_smulₛₗ := map_smul',
+  map_smulG := map_smulG' }
+
+lemma coe_injective :
+  @injective (ρ ≃ᵣ ρ₂) (V → V₂) coe_fn :=
+fun_like.coe_injective
+
+variables (e e' : ρ ≃ᵣ ρ₂)
+
+lemma to_rep_hom_eq_coe : e.to_rep_hom = (e : ρ →ᵣ ρ₂) := rfl
+
+@[simp, norm_cast] theorem coe_coe : ⇑(e : ρ →ᵣ ρ₂) = e := rfl
+
+@[simp] lemma coe_to_equiv : ⇑e.to_equiv = e := rfl
+
+@[simp] lemma coe_to_rep_hom : ⇑e.to_rep_hom = e := rfl
+
+@[simp] lemma to_fun_eq_coe : e.to_fun = e := rfl
+
+section
+
+variables {e e'}
+
+@[ext] lemma ext (h : ∀ x, e x = e' x) : e = e' := fun_like.ext _ _ h
+
+lemma ext_iff : e = e' ↔ ∀ x, e x = e' x := fun_like.ext_iff
+
+protected lemma congr_arg {x x'} : x = x' → e x = e x' := fun_like.congr_arg e
+
+protected lemma congr_fun (h : e = e') (x : V) : e x = e' x := fun_like.congr_fun h x
+
+end
+
+variables (ρ)
+
+/-- The identity map is a representation equivalence. -/
+@[refl]
+def refl : ρ ≃ᵣ ρ := { .. rep_hom.id, .. equiv.refl V }
+
+variables {ρ}
+
+@[simp] lemma refl_apply (x : V) : refl ρ x = x := rfl
+
+/-- Representation equivalences are symmetric. -/
+@[symm]
+def symm (e : ρ ≃ᵣ ρ₂) : ρ₂ ≃ᵣ ρ :=
+{ .. e.to_rep_hom.inverse e.inv_fun e.left_inv e.right_inv,
+  .. e.to_equiv.symm }
+
+/-- See Note [custom simps projection] -/
+def simps.symm_apply (e : ρ ≃ᵣ ρ₂) : V₂ → V := e.symm
+
+initialize_simps_projections rep_equiv (to_fun → apply, inv_fun → symm_apply)
+
+@[simp] lemma inv_fun_eq_symm : e.inv_fun = e.symm := rfl
+
+@[simp] lemma coe_to_equiv_symm : ⇑e.to_equiv.symm = e.symm := rfl
+
+variables
+  {V₃ : Type*} [add_comm_monoid V₃] [module k V₃] {ρ₃ : representation k G V₃}
+  (e₁₂ : ρ ≃ᵣ ρ₂) (e₂₃ : ρ₂ ≃ᵣ ρ₃)
+
+/-- Representation equivalences are transitive. -/
+@[trans]
+def trans : ρ ≃ᵣ ρ₃ :=
+{ .. e₂₃.to_rep_hom.comp e₁₂.to_rep_hom,
+  .. e₁₂.to_equiv.trans e₂₃.to_equiv }
+
+infixr ` ≪≫ᵣ `:80 := rep_equiv.trans
+
+variables {e₁₂ e₂₃}
+
+@[simp] lemma coe_to_add_equiv : ⇑(e.to_add_equiv) = e := rfl
+
+-- to_add_monoid_hom_commutes
+
+@[simp] theorem trans_apply (c : V) :
+  (e₁₂.trans e₂₃ : ρ ≃ᵣ ρ₃) c = e₂₃ (e₁₂ c) := rfl
+
+@[simp] theorem apply_symm_apply (c : V₂) : e (e.symm c) = c := e.right_inv c
+@[simp] theorem symm_apply_apply (b : V) : e.symm (e b) = b := e.left_inv b
+
+@[simp] lemma trans_symm : (e₁₂.trans e₂₃ : ρ ≃ᵣ ρ₃).symm = e₂₃.symm.trans e₁₂.symm :=
+rfl
+
+lemma symm_trans_apply
+  (c : V₃) : (e₁₂.trans e₂₃ : ρ ≃ᵣ ρ₃).symm c = e₁₂.symm (e₂₃.symm c) := rfl
+
+@[simp] lemma trans_refl : e.trans (refl ρ₂) = e := to_equiv_injective e.to_equiv.trans_refl
+@[simp] lemma refl_trans : (refl ρ).trans e = e := to_equiv_injective e.to_equiv.refl_trans
+
+lemma symm_apply_eq {x y} : e.symm x = y ↔ x = e y := e.to_equiv.symm_apply_eq
+
+lemma eq_symm_apply {x y} : y = e.symm x ↔ e y = x := e.to_equiv.eq_symm_apply
+
+lemma eq_comp_symm {α : Type*} (f : V₂ → α) (g : V → α) :
+  f = g ∘ e₁₂.symm ↔ f ∘ e₁₂ = g := e₁₂.to_equiv.eq_comp_symm f g
+
+lemma comp_symm_eq {α : Type*} (f : V₂ → α) (g : V → α) :
+  g ∘ e₁₂.symm = f ↔ g = f ∘ e₁₂ := e₁₂.to_equiv.comp_symm_eq f g
+
+lemma eq_symm_comp {α : Type*} (f : α → V) (g : α → V₂) :
+  f = e₁₂.symm ∘ g ↔ e₁₂ ∘ f = g := e₁₂.to_equiv.eq_symm_comp f g
+
+lemma symm_comp_eq {α : Type*} (f : α → V) (g : α → V₂) :
+  e₁₂.symm ∘ g = f ↔ g = e₁₂ ∘ f := e₁₂.to_equiv.symm_comp_eq f g
+
+lemma eq_comp_to_rep_hom_symm (f : ρ₂ →ᵣ ρ₃) (g : ρ →ᵣ ρ₃) :
+  f = g.comp e₁₂.symm.to_rep_hom ↔ f.comp e₁₂.to_rep_hom = g :=
+begin
+  split; intro H; ext,
+  { simp [H, e₁₂.to_equiv.eq_comp_symm f g] },
+  { simp [←H, ←e₁₂.to_equiv.eq_comp_symm f g] }
+end
+
+lemma comp_to_rep_hom_symm_eq (f : ρ₂ →ᵣ ρ₃) (g : ρ →ᵣ ρ₃) :
+  g.comp e₁₂.symm.to_rep_hom = f ↔ g = f.comp e₁₂.to_rep_hom :=
+begin
+  split; intro H; ext,
+  { simp [←H, ←e₁₂.to_equiv.comp_symm_eq f g] },
+  { simp [H, e₁₂.to_equiv.comp_symm_eq f g] }
+end
+
+lemma eq_to_rep_hom_symm_comp (f : ρ₃ →ᵣ ρ) (g : ρ₃ →ᵣ ρ₂) :
+  f = e₁₂.symm.to_rep_hom.comp g ↔ e₁₂.to_rep_hom.comp f = g :=
+begin
+  split; intro H; ext,
+  { simp [H, e₁₂.to_equiv.eq_symm_comp f g] },
+  { simp [←H, ←e₁₂.to_equiv.eq_symm_comp f g] }
+end
+
+lemma to_rep_hom_symm_comp_eq (f : ρ₃ →ᵣ ρ) (g : ρ₃ →ᵣ ρ₂) :
+  e₁₂.symm.to_rep_hom.comp g = f ↔ g = e₁₂.to_rep_hom.comp f :=
+begin
+  split; intro H; ext,
+  { simp [←H, ←e₁₂.to_equiv.symm_comp_eq f g] },
+  { simp [H, e₁₂.to_equiv.symm_comp_eq f g] }
+end
+
+@[simp] lemma refl_symm : (refl ρ).symm = rep_equiv.refl ρ := rfl
+
+@[simp] lemma self_trans_symm (f : ρ ≃ᵣ ρ₂) :
+  f.trans f.symm = rep_equiv.refl ρ :=
+by { ext x, simp }
+
+@[simp] lemma symm_trans_self (f : ρ ≃ᵣ ρ₂) :
+  f.symm.trans f = rep_equiv.refl ρ₂ :=
+by { ext x, simp }
+
+@[simp, norm_cast] lemma refl_to_rep_hom :
+  (rep_equiv.refl ρ : ρ →ᵣ ρ) = rep_hom.id :=
+rfl
+
+@[simp, norm_cast]
+lemma comp_coe (f : ρ ≃ᵣ ρ₂) (f' : ρ₂ ≃ᵣ ρ₃) :
+  (f' : ρ₂ →ᵣ ρ₃).comp (f : ρ →ᵣ ρ₂) = (f.trans f' : ρ ≃ᵣ ρ₃) := rfl
+
+@[simp] lemma mk_coe (h₁ h₂ h₃ f h₄ h₅) :
+  (rep_equiv.mk e h₁ h₂ h₃ f h₄ h₅ : ρ ≃ᵣ ρ₂) = e := ext $ λ _, rfl
+
+protected theorem map_add (a b : V) : e (a + b) = e a + e b := map_add e a b
+protected theorem map_zero : e 0 = 0 := map_zero e
+@[simp] protected theorem map_smulₛₗ (c : k) (x : V) : e (c • x) = c • e x := e.map_smul' c x
+@[simp] protected theorem map_smulG (g : G) (x : V) : e (ρ g x) = ρ₂ g (e x) := e.map_smulG' g x
+
+@[simp] lemma map_sum {ι : Type*} {s : finset ι} (u : ι → V) : e (∑ i in s, u i) = ∑ i in s, e (u i) :=
+e.to_rep_hom.map_sum
+
+@[simp] theorem map_eq_zero_iff {x : V} : e x = 0 ↔ x = 0 :=
+e.to_add_equiv.map_eq_zero_iff
+theorem map_ne_zero_iff {x : V} : e x ≠ 0 ↔ x ≠ 0 :=
+e.to_add_equiv.map_ne_zero_iff
+
+@[simp] theorem symm_symm (e : ρ ≃ᵣ ρ₂): e.symm.symm = e :=
+by { cases e, refl }
+
+lemma symm_bijective : function.bijective (symm : (ρ ≃ᵣ ρ₂) → (ρ₂ ≃ᵣ ρ)) :=
+equiv.bijective ⟨(symm : (ρ ≃ᵣ ρ₂) →
+  (ρ₂ ≃ᵣ ρ)), (symm : (ρ₂ ≃ᵣ ρ) → (ρ ≃ᵣ ρ₂)), symm_symm, symm_symm⟩
+
+@[simp] lemma mk_coe' (f h₁ h₂ h₃ h₄ h₅) : (rep_equiv.mk f h₁ h₂ h₃ ⇑e h₄ h₅ :
+  ρ₂ ≃ᵣ ρ) = e.symm :=
+symm_bijective.injective $ ext $ λ x, rfl
+
+@[simp] theorem symm_mk (f h₁ h₂ h₃ h₄ h₅) :
+  (⟨e, h₁, h₂, h₃, f, h₄, h₅⟩ : ρ ≃ᵣ ρ₂).symm =
+  { to_fun := f, inv_fun := e,
+    ..(⟨e, h₁, h₂, h₃, f, h₄, h₅⟩ : ρ ≃ᵣ ρ₂).symm } := rfl
+
+@[simp] lemma coe_symm_mk
+  {to_fun inv_fun map_add map_smul map_smulG left_inv right_inv} :
+  ⇑((⟨to_fun, map_add, map_smul, map_smulG, inv_fun, left_inv, right_inv⟩ : ρ ≃ᵣ ρ₂).symm) = inv_fun :=
+rfl
+
+protected lemma bijective : function.bijective e := e.to_equiv.bijective
+protected lemma injective : function.injective e := e.to_equiv.injective
+protected lemma surjective : function.surjective e := e.to_equiv.surjective
+
+protected lemma image_eq_preimage (s : set V) : e '' s = e.symm ⁻¹' s :=
+e.to_equiv.image_eq_preimage s
+
+protected lemma image_symm_eq_preimage (s : set V₂) : e.symm '' s = e ⁻¹' s :=
+e.to_equiv.symm.image_eq_preimage s
+
+section pointwise
+open_locale pointwise
+
+@[simp] lemma image_smul_set (e : ρ ≃ᵣ ρ₂) (c : k) (s : set V) :
+  e '' (c • s) = c • e '' s :=
+rep_hom.image_smul_set e.to_rep_hom c s
+
+@[simp] lemma preimage_smul_set (e : ρ ≃ᵣ ρ₂) (c : k) (s : set V₂) :
+  e ⁻¹' (c • s) = c • e ⁻¹' s :=
+by rw [← rep_equiv.image_symm_eq_preimage, ← rep_equiv.image_symm_eq_preimage,
+  image_smul_set]
+
+end pointwise
+
+-- restrict_scalars
+
+section automorphisms
+
+instance automorphism_group : group (ρ ≃ᵣ ρ) :=
+{ mul := λ f g, g.trans f,
+  one := rep_equiv.refl ρ,
+  inv := λ f, f.symm,
+  mul_assoc := λ f g h, rfl,
+  mul_one := λ f, ext $ λ x, rfl,
+  one_mul := λ f, ext $ λ x, rfl,
+  mul_left_inv := λ f, ext $ f.left_inv }
+
+/-- Restriction from representation automorphisms of `ρ` to representation endomorphisms of `ρ`,
+promoted to a monoid hom. -/
+@[simps]
+def automorphism_group.to_linear_map_monoid_hom : (ρ ≃ᵣ ρ) →* (ρ →ᵣ ρ) :=
+{ to_fun := coe,
+  map_one' := rfl,
+  map_mul' := λ _ _, rfl }
+
+-- apply_distrib_mul_action
+
+end automorphisms
+
+end add_comm_monoid
+
+end rep_equiv
+
+namespace representation
+
+-- comp_hom.to_linear_equiv
+
+end representation
+
+namespace distrib_mul_action
+
+--
+
+end distrib_mul_action
+
+namespace add_equiv
+
+--
+
+end add_equiv

--- a/src/representation_theory/rep_equiv.lean
+++ b/src/representation_theory/rep_equiv.lean
@@ -245,8 +245,8 @@ protected theorem map_zero : e 0 = 0 := map_zero e
 @[simp] protected theorem map_smulₛₗ (c : k) (x : V) : e (c • x) = c • e x := e.map_smul' c x
 @[simp] protected theorem map_smulG (g : G) (x : V) : e (ρ g x) = ρ₂ g (e x) := e.map_smulG' g x
 
-@[simp] lemma map_sum {ι : Type*} {s : finset ι} (u : ι → V) : e (∑ i in s, u i) = ∑ i in s, e (u i) :=
-e.to_rep_hom.map_sum
+@[simp] lemma map_sum {ι : Type*} {s : finset ι} (u : ι → V) :
+  e (∑ i in s, u i) = ∑ i in s, e (u i) := e.to_rep_hom.map_sum
 
 @[simp] theorem map_eq_zero_iff {x : V} : e x = 0 ↔ x = 0 :=
 e.to_add_equiv.map_eq_zero_iff
@@ -271,8 +271,8 @@ symm_bijective.injective $ ext $ λ x, rfl
 
 @[simp] lemma coe_symm_mk
   {to_fun inv_fun map_add map_smul map_smulG left_inv right_inv} :
-  ⇑((⟨to_fun, map_add, map_smul, map_smulG, inv_fun, left_inv, right_inv⟩ : ρ ≃ᵣ ρ₂).symm) = inv_fun :=
-rfl
+  ⇑((⟨to_fun, map_add, map_smul, map_smulG, inv_fun, left_inv, right_inv⟩ :
+  ρ ≃ᵣ ρ₂).symm) = inv_fun := rfl
 
 protected lemma bijective : function.bijective e := e.to_equiv.bijective
 protected lemma injective : function.injective e := e.to_equiv.injective

--- a/src/representation_theory/rep_equiv.lean
+++ b/src/representation_theory/rep_equiv.lean
@@ -55,8 +55,8 @@ variables
 instance : has_coe (ρ ≃ᵣ ρ₂) (ρ →ᵣ ρ₂) := ⟨to_rep_hom⟩
 instance : has_coe_to_fun (ρ ≃ᵣ ρ₂) (λ _, V → V₂) := ⟨to_fun⟩
 
-@[simp] lemma coe_mk {to_fun inv_fun map_add map_smul map_smulG left_inv right_inv} :
-  ⇑(⟨to_fun, map_add, map_smul, map_smulG, inv_fun, left_inv, right_inv⟩ : ρ ≃ᵣ ρ₂) = to_fun :=
+@[simp] lemma coe_mk {to_fun inv_fun map_add map_smul map_action left_inv right_inv} :
+  ⇑(⟨to_fun, map_add, map_smul, map_action, inv_fun, left_inv, right_inv⟩ : ρ ≃ᵣ ρ₂) = to_fun :=
 rfl
 
 @[nolint doc_blame]
@@ -81,7 +81,7 @@ instance : rep_hom_class (ρ ≃ᵣ ρ₂) ρ ρ₂ :=
   coe_injective' := λ f g h, to_rep_hom_injective (fun_like.coe_injective h),
   map_add := map_add',
   map_smulₛₗ := map_smul',
-  map_smulG := map_smulG' }
+  map_action := map_action' }
 
 lemma coe_injective :
   @injective (ρ ≃ᵣ ρ₂) (V → V₂) coe_fn :=
@@ -243,7 +243,7 @@ lemma comp_coe (f : ρ ≃ᵣ ρ₂) (f' : ρ₂ ≃ᵣ ρ₃) :
 protected theorem map_add (a b : V) : e (a + b) = e a + e b := map_add e a b
 protected theorem map_zero : e 0 = 0 := map_zero e
 @[simp] protected theorem map_smulₛₗ (c : k) (x : V) : e (c • x) = c • e x := e.map_smul' c x
-@[simp] protected theorem map_smulG (g : G) (x : V) : e (ρ g x) = ρ₂ g (e x) := e.map_smulG' g x
+@[simp] protected theorem map_action (g : G) (x : V) : e (ρ g x) = ρ₂ g (e x) := e.map_action' g x
 
 @[simp] lemma map_sum {ι : Type*} {s : finset ι} (u : ι → V) :
   e (∑ i in s, u i) = ∑ i in s, e (u i) := e.to_rep_hom.map_sum
@@ -270,8 +270,8 @@ symm_bijective.injective $ ext $ λ x, rfl
     ..(⟨e, h₁, h₂, h₃, f, h₄, h₅⟩ : ρ ≃ᵣ ρ₂).symm } := rfl
 
 @[simp] lemma coe_symm_mk
-  {to_fun inv_fun map_add map_smul map_smulG left_inv right_inv} :
-  ⇑((⟨to_fun, map_add, map_smul, map_smulG, inv_fun, left_inv, right_inv⟩ :
+  {to_fun inv_fun map_add map_smul map_action left_inv right_inv} :
+  ⇑((⟨to_fun, map_add, map_smul, map_action, inv_fun, left_inv, right_inv⟩ :
   ρ ≃ᵣ ρ₂).symm) = inv_fun := rfl
 
 protected lemma bijective : function.bijective e := e.to_equiv.bijective
@@ -326,21 +326,3 @@ end automorphisms
 end add_comm_monoid
 
 end rep_equiv
-
-namespace representation
-
--- comp_hom.to_linear_equiv
-
-end representation
-
-namespace distrib_mul_action
-
---
-
-end distrib_mul_action
-
-namespace add_equiv
-
---
-
-end add_equiv

--- a/src/representation_theory/rep_hom.lean
+++ b/src/representation_theory/rep_hom.lean
@@ -98,7 +98,8 @@ instance : has_coe_to_fun (ρ →ᵣ ρ₂) (λ _, V → V₂) := ⟨λ f, f⟩
 -- should there be coe to linear_map?
 @[simp] lemma to_fun_eq_coe {f : ρ →ᵣ ρ₂} : f.to_fun = (f : V → V₂) := rfl
 
-@[simp] lemma coe_eq_to_linear_map_coe {f : ρ →ᵣ ρ₂} : (f.to_linear_map : V → V₂) = (f : V → V₂) := rfl
+@[simp] lemma coe_eq_to_linear_map_coe {f : ρ →ᵣ ρ₂} :
+  (f.to_linear_map : V → V₂) = (f : V → V₂) := rfl
 
 @[ext] theorem ext {f g : ρ →ᵣ ρ₂} (h : ∀ x, f x = g x) : f = g := fun_like.ext f g h
 
@@ -125,7 +126,8 @@ lemma id_apply (x : V) :
 @[simp, norm_cast] lemma id_coe : ((rep_hom.id : ρ →ᵣ ρ) : V → V) = _root_.id := rfl
 
 section
-theorem rep_hom_is_rep_hom (f : ρ →ᵣ ρ₂) : is_rep_hom ρ ρ₂ f := ⟨f.map_add', f.map_smul', f.map_smulG'⟩
+theorem rep_hom_is_rep_hom (f : ρ →ᵣ ρ₂) : is_rep_hom ρ ρ₂ f :=
+⟨f.map_add', f.map_smul', f.map_smulG'⟩
 
 variables {f f' : ρ →ᵣ ρ₂}
 
@@ -540,7 +542,8 @@ instance _root_.representation.End.semiring : semiring ρ.End :=
   .. _root_.representation.End.monoid,
   .. rep_hom.add_comm_monoid }
 
-instance _root_.representation.End.ring [has_smul ℤ k] [is_scalar_tower ℤ k W₁] : ring (representation.End σ₁) :=
+instance _root_.representation.End.ring [has_smul ℤ k] [is_scalar_tower ℤ k W₁] :
+  ring (representation.End σ₁) :=
 { ..representation.End.semiring, ..rep_hom.add_comm_group }
 
 section

--- a/src/representation_theory/rep_hom.lean
+++ b/src/representation_theory/rep_hom.lean
@@ -63,3 +63,524 @@ class rep_hom_class (F : Type*) {k G V V₂ : out_param Type*} [comm_semiring k]
 attribute [nolint dangerous_instance] rep_hom_class.to_semilinear_map_class
 
 export rep_hom_class (map_smulG)
+
+namespace rep_hom_class
+
+variables
+  (F : Type*) {k G V V₂ : Type*} [comm_semiring k] [monoid G]
+  [add_comm_monoid V] [module k V] [add_comm_monoid V₂] [module k V₂]
+  {ρ : representation k G V} {ρ₂ : representation k G V₂}
+
+-- What instances of ..._class go here?
+
+end rep_hom_class
+
+namespace rep_hom
+
+section add_comm_monoid
+
+variables
+  {k G V V₂ : Type*} [comm_semiring k] [monoid G]
+  [add_comm_monoid V] [module k V] [add_comm_monoid V₂] [module k V₂]
+  {ρ : representation k G V} {ρ₂ : representation k G V₂}
+
+instance : rep_hom_class (ρ →ᵣ ρ₂) ρ ρ₂ :=
+{ coe := rep_hom.to_fun,
+  coe_injective' := λ f g h, by cases f; cases g; congr',
+  map_add := rep_hom.map_add',
+  map_smulₛₗ := rep_hom.map_smul',
+  map_smulG := rep_hom.map_smulG' }
+
+/-- Helper instance for when there's too many metavariables to apply `fun_like.has_coe_to_fun`
+directly.
+-/
+instance : has_coe_to_fun (ρ →ᵣ ρ₂) (λ _, V → V₂) := ⟨λ f, f⟩
+-- should there be coe to linear_map?
+@[simp] lemma to_fun_eq_coe {f : ρ →ᵣ ρ₂} : f.to_fun = (f : V → V₂) := rfl
+
+@[simp] lemma coe_eq_to_linear_map_coe {f : ρ →ᵣ ρ₂} : (f.to_linear_map : V → V₂) = (f : V → V₂) := rfl
+
+@[ext] theorem ext {f g : ρ →ᵣ ρ₂} (h : ∀ x, f x = g x) : f = g := fun_like.ext f g h
+
+/-- Copy of a `rep_hom` with a new `to_fun` equal to the old one. Useful to fix definitional
+equalities. -/
+protected def copy (f : ρ →ᵣ ρ₂) (f' : V → V₂) (h : f' = ⇑f) : ρ →ᵣ ρ₂ :=
+{ to_fun := f',
+  map_add' := h.symm ▸ f.map_add',
+  map_smul' := h.symm ▸ f.map_smul',
+  map_smulG' := h.symm ▸ f.map_smulG' }
+
+@[simp] lemma coe_mk (f : V → V₂) (h₁ h₂ h₃) :
+  ((rep_hom.mk f h₁ h₂ h₃ : ρ →ᵣ ρ₂) : V → V₂) = f := rfl
+
+/-- Identity map as a `rep_hom` -/
+def id : ρ →ᵣ ρ :=
+{ to_fun := id,
+  map_smulG' := by simp,
+  ..linear_map.id }
+
+lemma id_apply (x : V) :
+  @id k G V _ _ _ _ ρ x = x := rfl
+
+@[simp, norm_cast] lemma id_coe : ((rep_hom.id : ρ →ᵣ ρ) : V → V) = _root_.id := rfl
+
+section
+theorem rep_hom_is_rep_hom (f : ρ →ᵣ ρ₂) : is_rep_hom ρ ρ₂ f := ⟨f.map_add', f.map_smul', f.map_smulG'⟩
+
+variables {f f' : ρ →ᵣ ρ₂}
+
+theorem coe_injective : @injective (ρ →ᵣ ρ₂) (V → V₂) coe_fn :=
+fun_like.coe_injective
+
+protected lemma congr_arg {x x' : V} : x = x' → f x = f x' :=
+fun_like.congr_arg f
+
+protected lemma congr_fun (h : f = f') (x : V) : f x = f' x :=
+fun_like.congr_fun h x
+
+theorem ext_iff : f = f' ↔ ∀ x, f x = f' x :=
+fun_like.ext_iff
+
+@[simp] lemma mk_coe (f : ρ →ᵣ ρ₂) (h₁ h₂ h₃) :
+  (rep_hom.mk f h₁ h₂ h₃ : ρ →ᵣ ρ₂) = f := ext $ λ _, rfl
+
+variables (f f')
+
+protected lemma map_add (x y : V) : f (x + y) = f x + f y := map_add f x y
+protected lemma map_zero : f 0 = 0 := map_zero f
+protected lemma map_smul (c : k) (x : V) : f (c • x) = c • f x := map_smul f c x
+protected lemma map_smulG (g : G) (x : V) : f (ρ g x) = ρ₂ g (f x) := map_smulG f g x
+
+@[simp] lemma map_eq_zero_iff (h : function.injective f) {x : V} : f x = 0 ↔ x = 0 :=
+⟨λ w, by { apply h, simp [w], }, λ w, by { subst w, simp, }⟩
+
+section pointwise
+open_locale pointwise
+
+@[simp] lemma image_smul_set (c : k) (s : set V) :
+  f '' (c • s) = c • f '' s :=
+begin
+  apply set.subset.antisymm,
+  { rintros x ⟨y, ⟨z, zs, rfl⟩, rfl⟩,
+    exact ⟨f z, set.mem_image_of_mem _ zs, (f.map_smul _ _).symm ⟩ },
+  { rintros x ⟨y, ⟨z, hz, rfl⟩, rfl⟩,
+    exact (set.mem_image _ _ _).2 ⟨c • z, set.smul_mem_smul_set hz, f.map_smul _ _⟩ }
+end
+
+lemma preimage_smul_set {c : k} (hc : is_unit c) (s : set V₂) :
+  f ⁻¹' (c • s) = c • f ⁻¹' s :=
+begin
+  apply set.subset.antisymm,
+  { rintros x ⟨y, ys, hy⟩,
+    refine ⟨(hc.unit.inv : k) • x, _, _⟩,
+    { simp only [←hy, smul_smul, set.mem_preimage, units.inv_eq_coe_inv, map_smulₛₗ f, ← map_mul,
+        is_unit.coe_inv_mul, one_smul, map_one, ys, ring_hom.id_apply] },
+    { simp only [smul_smul, is_unit.mul_coe_inv, one_smul, units.inv_eq_coe_inv] } },
+  { rintros x ⟨y, hy, rfl⟩,
+    refine ⟨f y, hy, by simp only [ring_hom.id_apply, map_smulₛₗ f]⟩ }
+end
+
+end pointwise
+
+-- restrict scalars
+
+@[simp] lemma map_sum {ι} {t : finset ι} {g : ι → V} :
+  f (∑ i in t, g i) = (∑ i in t, f (g i)) :=
+f.to_linear_map.map_sum
+
+theorem to_linear_map_injective :
+  function.injective (to_linear_map : (ρ →ᵣ ρ₂) → (V →ₗ[k] V₂)) :=
+λ f g h, ext $ linear_map.congr_fun h
+
+-- ext_ring
+end
+
+section
+
+variables
+  {V₃ : Type*} [add_comm_monoid V₃] [module k V₃]
+  {ρ₃ : representation k G V₃} (f₂ : ρ₂ →ᵣ ρ₃) (f : ρ →ᵣ ρ₂)
+
+/-- Composition of two rep_hom's is a rep_hom -/
+def comp : ρ →ᵣ ρ₃ :=
+{ to_fun := f₂ ∘ f,
+  map_smulG' := λ g x, by rw [comp_app, comp_app, map_smulG, map_smulG],
+  ..linear_map.comp f₂.to_linear_map f.to_linear_map }
+
+infixr ` ∘ᵣ `:80 := rep_hom.comp
+
+lemma comp_apply (x : V) : f₂.comp f x = f₂ (f x) := rfl
+
+@[simp, norm_cast] lemma coe_comp : (f₂.comp f : V → V₃) = f₂ ∘ f := rfl
+
+@[simp] theorem comp_id : f.comp id = f :=
+rep_hom.ext $ λ x, rfl
+
+@[simp] theorem id_comp : id.comp f = f :=
+rep_hom.ext $ λ x, rfl
+
+variables {f₂ f} {f₂' : ρ₂ →ᵣ ρ₃} {f' : ρ →ᵣ ρ₂}
+
+theorem cancel_right (hg : function.surjective f) :
+  f₂.comp f = f₂'.comp f ↔ f₂ = f₂' :=
+⟨λ h, ext $ hg.forall.2 (ext_iff.1 h), λ h, h ▸ rfl⟩
+
+theorem cancel_left (hf : function.injective f₂) :
+  f₂.comp f = f₂.comp f' ↔ f = f' :=
+⟨λ h, ext $ λ x, hf $ by rw [← comp_apply, h, comp_apply], λ h, h ▸ rfl⟩
+
+end
+
+/-- If a function `f'` is a left and right inverse of a rep_hom `f`, then `f'` is a rep_hom
+itself. -/
+def inverse
+  (f : ρ →ᵣ ρ₂) (f' : V₂ → V) (h₁ : left_inverse f' f) (h₂ : right_inverse f' f) :
+  ρ₂ →ᵣ ρ := by dsimp [left_inverse, function.right_inverse] at h₁ h₂; exact
+{ to_fun := f',
+  map_smulG' := λ g x, by {rw [←h₁ (ρ g (f' x)), map_smulG], simp [h₂]},
+  ..linear_map.inverse f.to_linear_map f' h₁ h₂ }
+
+end add_comm_monoid
+
+section add_comm_group
+
+variables
+  {k G V V₂ : Type*} [comm_semiring k] [monoid G]
+  [add_comm_group V] [module k V] [add_comm_group V₂] [module k V₂]
+  {ρ : representation k G V} {ρ₂ : representation k G V₂}
+  (f : ρ →ᵣ ρ₂)
+
+protected lemma map_neg (x : V) : f (- x) = - f x := map_neg f x
+
+protected lemma map_sub (x y : V) : f (x - y) = f x - f y := map_sub f x y
+
+-- compatible_smul
+
+end add_comm_group
+
+end rep_hom
+
+-- module
+-- distrib_mul_action_hom
+
+namespace is_rep_hom
+
+section add_comm_monoid
+
+variables
+  {k G V V₂ : Type*} [comm_semiring k] [monoid G]
+  [add_comm_monoid V] [module k V] [add_comm_monoid V₂] [module k V₂]
+  {ρ : representation k G V} {ρ₂ : representation k G V₂}
+
+/-- Convert an `is_rep_hom` predicate to a `rep_hom` -/
+def mk' (f : V → V₂) (H : is_rep_hom ρ ρ₂ f) : ρ →ᵣ ρ₂ :=
+{ to_fun := f, map_add' := H.1, map_smul' := H.2, map_smulG' := H.3 }
+
+@[simp] theorem mk'_apply {f : V → V₂} (H : is_rep_hom ρ ρ₂ f) (x : V) :
+  mk' f H x = f x := rfl
+
+lemma is_rep_hom_smul (c : k) :
+  is_rep_hom ρ ρ (λ (z : V), c • z) :=
+begin
+  refine is_rep_hom.mk (smul_add c) _ _,
+  { intros _ _,
+    rw [←mul_smul, mul_comm, mul_smul] },
+  { intros _ _,
+    rw [linear_map.map_smulₛₗ, ring_hom.id_apply] }
+end
+
+lemma is_rep_hom_smulG_one :
+  is_rep_hom ρ ρ (λ (z : V), ρ 1 z) :=
+begin
+  refine is_rep_hom.mk _ _ _;
+  { intros _ _,
+    simp only [map_one, linear_map.one_apply] }
+end
+
+variables {f : V → V₂} (rh : is_rep_hom ρ ρ₂ f)
+
+lemma map_zero : f (0 : V) = (0 : V₂) := (rh.mk' f).map_zero
+
+end add_comm_monoid
+
+section add_comm_group
+
+variables
+  {k G V V₂ : Type*} [comm_semiring k] [monoid G]
+  [add_comm_group V] [module k V] [add_comm_group V₂] [module k V₂]
+  {ρ : representation k G V} {ρ₂ : representation k G V₂}
+  {f : V → V₂} (rh : is_rep_hom ρ ρ₂ f)
+
+lemma map_neg (x : V) : f (- x) = - f x := (rh.mk' f).map_neg x
+
+lemma map_sub (x y) : f (x - y) = f x - f y := (rh.mk' f).map_sub x y
+
+end add_comm_group
+
+end is_rep_hom
+
+/-- Endomorphisms respecting the representation structure, with associated ring structure
+`representation.End.semiring` and algebra structure `representation.End.algebra`. -/
+abbreviation representation.End {k G V : Type*}
+  [comm_semiring k] [monoid G] [add_comm_monoid V] [module k V]
+  (ρ : representation k G V) := ρ →ᵣ ρ
+
+-- various more general morphisms as rep_hom
+
+namespace rep_hom
+
+section has_smul
+
+variables
+  {k G V V₂ V₃ : Type*} [comm_semiring k] [monoid G]
+  [add_comm_monoid V] [module k V] [add_comm_monoid V₂] [module k V₂]
+  [add_comm_monoid V₃] [module k V₃]
+  {ρ : representation k G V} {ρ₂ : representation k G V₂} {ρ₃ : representation k G V₃}
+variables
+  {k' : Type*} [monoid k'] [distrib_mul_action k' V₂] [smul_comm_class k k' V₂]
+  [has_smul k' k] [is_scalar_tower k' k V₂]
+  {k'' : Type*} [monoid k''] [distrib_mul_action k'' V₂] [smul_comm_class k k'' V₂]
+  [has_smul k'' k] [is_scalar_tower k'' k V₂]
+
+-- The additional assumptions has_smul k' k and is_scalar_tower k' k V₂ are needed in order to
+-- pass scalar multiplication by an element of k' through the representation of an element of G as
+-- a k-linear map.
+instance : has_smul k' (ρ →ᵣ ρ₂) :=
+⟨λ a f, { to_fun := a • f,
+          map_add' := λ x y, by rw [pi.smul_apply,
+            f.map_add, smul_add, pi.smul_apply, pi.smul_apply],
+          map_smul' := λ c x, by rw [pi.smul_apply,
+            f.map_smul, ring_hom.id_apply, pi.smul_apply, ←smul_comm],
+          map_smulG' := λ g x, by rw [pi.smul_apply,
+            f.map_smulG, pi.smul_apply, linear_map.map_smul_of_tower] }⟩
+
+@[simp] lemma smul_apply (a : k) (f : ρ →ᵣ ρ₂) (x : V) : (a • f) x = a • f x := rfl
+
+lemma coe_smul (a : k) (f : ρ →ᵣ ρ₂) : ⇑(a • f) = a • f := rfl
+
+instance [smul_comm_class k'' k' V₂] : smul_comm_class k'' k' (ρ →ᵣ ρ₂) :=
+⟨λ a b f, ext $ λ x, smul_comm _ _ _⟩
+
+--
+
+end has_smul
+
+section arithmetic
+
+variables
+  {k G V V₂ V₃ : Type*} [comm_semiring k] [monoid G]
+  [add_comm_monoid V] [module k V] [add_comm_monoid V₂] [module k V₂]
+  [add_comm_monoid V₃] [module k V₃]
+  {ρ : representation k G V} {ρ₂ : representation k G V₂} {ρ₃ : representation k G V₃}
+variables
+  {W W₂ W₃ : Type*} [add_comm_group W] [module k W] [add_comm_group W₂] [module k W₂]
+  [add_comm_group W₃] [module k W₃]
+  {σ : representation k G W} {σ₂ : representation k G W₂} {σ₃ : representation k G W₃}
+
+/-- The constant 0 map is a rep_hom. -/
+instance : has_zero (ρ →ᵣ ρ₂) :=
+⟨{ to_fun := 0, map_add' := by simp, map_smul' := by simp, map_smulG' := by simp }⟩
+
+@[simp] lemma zero_apply (x : V) : (0 : ρ →ᵣ ρ₂) x = 0 := rfl
+
+@[simp] theorem comp_zero (f' : ρ₂ →ᵣ ρ₃) : (f'.comp (0 : ρ →ᵣ ρ₂) : ρ →ᵣ ρ₃) = 0 :=
+ext $ assume c, by rw [comp_apply, zero_apply, zero_apply, f'.map_zero]
+
+@[simp] theorem zero_comp (f : ρ →ᵣ ρ₂) : ((0 : ρ₂ →ᵣ ρ₃).comp f : ρ →ᵣ ρ₃) = 0 :=
+rfl
+
+instance : inhabited (ρ →ᵣ ρ₂) := ⟨0⟩
+
+@[simp] lemma default_def : (default : (ρ →ᵣ ρ₂)) = 0 := rfl
+
+/-- The sum of two rep_homs is a rep_hom. -/
+instance : has_add (ρ →ᵣ ρ₂) :=
+⟨λ f g, { to_fun := f + g,
+          map_add' := by simp [add_comm, add_left_comm],
+          map_smul' := by simp [smul_add],
+          map_smulG' := by simp [map_smulG] }⟩
+
+@[simp] lemma add_apply (f g : ρ →ᵣ ρ₂) (x : V) : (f + g) x = f x + g x := rfl
+
+lemma add_comp (f : ρ →ᵣ ρ₂) (g h : ρ₂ →ᵣ ρ₃) :
+  ((h + g).comp f : ρ →ᵣ ρ₃) = h.comp f + g.comp f := rfl
+
+lemma comp_add (f g : ρ →ᵣ ρ₂) (h : ρ₂ →ᵣ ρ₃) :
+  (h.comp (f + g) : ρ →ᵣ ρ₃) = h.comp f + h.comp g :=
+ext $ λ _, h.map_add _ _
+
+/-- The type of rep_homs is an additive monoid. -/
+instance : add_comm_monoid (ρ →ᵣ ρ₂) :=
+fun_like.coe_injective.add_comm_monoid _ rfl (λ _ _, rfl) (λ _ _, rfl)
+
+/-- The negation of a rep_hom is a rep_hom. -/
+instance : has_neg (ρ →ᵣ σ₂) :=
+⟨λ f, { to_fun := -f, map_add' := by simp [add_comm], map_smul' := by simp,
+      map_smulG' := by simp [map_smulG] }⟩
+
+@[simp] lemma neg_apply (f : ρ →ᵣ σ₂) (x : V) : (- f) x = - f x := rfl
+
+@[simp] lemma neg_comp (f : ρ →ᵣ ρ₂) (g : ρ₂ →ᵣ σ₃) : (- g).comp f = - g.comp f := rfl
+
+@[simp] lemma comp_neg (f : ρ →ᵣ σ₂) (g : σ₂ →ᵣ σ₃) : g.comp (- f) = - g.comp f :=
+ext $ λ _, g.map_neg _
+
+/-- The negation of a rep_hom is a rep_hom. -/
+instance : has_sub (ρ →ᵣ σ₂) :=
+⟨λ f g, { to_fun := f - g,
+          map_add' := λ x y, by simp only [pi.sub_apply, map_add, add_sub_add_comm],
+          map_smul' := λ r x, by simp [pi.sub_apply, map_smul, smul_sub],
+          map_smulG' := λ g x, by simp [pi.sub_apply, map_smulG] }⟩
+
+@[simp] lemma sub_apply (f g : ρ →ᵣ σ₂) (x : V) : (f - g) x = f x - g x := rfl
+
+lemma sub_comp (f : ρ →ᵣ ρ₂) (g h : ρ₂ →ᵣ σ₃) :
+  (g - h).comp f = g.comp f - h.comp f := rfl
+
+lemma comp_sub (f g : ρ →ᵣ σ₂) (h : σ₂ →ᵣ σ₃) :
+  h.comp (g - f) = h.comp g - h.comp f :=
+ext $ λ _, h.map_sub _ _
+
+/-- The type of linear maps is an additive group. -/
+-- the additional has_smul and is_scalar_tower assumptions are needed for rep_hom.has_smul
+instance [has_smul ℤ k] [is_scalar_tower ℤ k W₂] : add_comm_group (ρ →ᵣ σ₂) :=
+fun_like.coe_injective.add_comm_group _
+  rfl (λ _ _, rfl) (λ _, rfl) (λ _ _, rfl) (λ _ _, rfl)  (λ _ _, rfl)
+
+end arithmetic
+
+section actions
+
+variables
+  {k G V V₂ V₃ : Type*} [comm_semiring k] [monoid G]
+  [add_comm_monoid V] [module k V] [add_comm_monoid V₂] [module k V₂]
+  [add_comm_monoid V₃] [module k V₃]
+  {ρ : representation k G V} {ρ₂ : representation k G V₂} {ρ₃ : representation k G V₃}
+
+section has_smul
+
+variables
+  {k' : Type*} [monoid k'] [distrib_mul_action k' V₂] [smul_comm_class k k' V₂]
+  [has_smul k' k] [is_scalar_tower k' k V₂]
+  {k₃ : Type*} [monoid k₃] [distrib_mul_action k₃ V₃] [smul_comm_class k k₃ V₃]
+  [has_smul k₃ k] [is_scalar_tower k₃ k V₃]
+  {k'' : Type*} [monoid k''] [distrib_mul_action k'' V₂] [smul_comm_class k k'' V₂]
+  [has_smul k'' k] [is_scalar_tower k'' k V₂]
+
+instance : distrib_mul_action k' (ρ →ᵣ ρ₂) :=
+{ one_smul := λ f, ext $ λ _, one_smul _ _,
+  mul_smul := λ c c' f, ext $ λ _, mul_smul _ _ _,
+  smul_add := λ c f g, ext $ λ x, smul_add _ _ _,
+  smul_zero := λ c, ext $ λ x, smul_zero _ }
+
+theorem smul_comp (a : k₃) (g : ρ₂ →ᵣ ρ₃) (f : ρ →ᵣ ρ₂) :
+  (a • g).comp f = a • (g.comp f) := rfl
+
+theorem comp_smul [distrib_mul_action k' V₃] [smul_comm_class k k' V₃]
+  [is_scalar_tower k' k V₃] [linear_map.compatible_smul V₃ V₂ k' k]
+  (g : ρ₃ →ᵣ ρ₂) (a : k') (f : ρ →ᵣ ρ₃) : g.comp (a • f) = a • (g.comp f) :=
+ext $ λ x, g.to_linear_map.map_smul_of_tower _ _
+
+end has_smul
+
+section module
+
+variables
+  {k' : Type*} [semiring k'] [module k' V₂] [smul_comm_class k k' V₂]
+  [has_smul k' k] [is_scalar_tower k' k V₂]
+
+instance : module k' (ρ →ᵣ ρ₂) :=
+{ add_smul := λ a b f, ext $ λ x, add_smul _ _ _,
+  zero_smul := λ f, ext $ λ x, zero_smul _ _ }
+
+-- no_zero_smul_divisors
+
+end module
+
+end actions
+
+section as_monoid
+
+variables
+  {k G V W₁ : Type*} [comm_semiring k] [monoid G]
+  [add_comm_monoid V] [module k V] [add_comm_group W₁] [module k W₁]
+  {ρ : representation k G V} {σ₁ : representation k G W₁}
+
+instance : has_one ρ.End := ⟨rep_hom.id⟩
+instance : has_mul ρ.End := ⟨rep_hom.comp⟩
+
+lemma one_eq_id : (1 : ρ.End) = id := rfl
+lemma mul_eq_comp (f g : ρ.End) : f * g = f.comp g := rfl
+
+@[simp] lemma one_apply (x : V) : (1 : ρ.End) x = x := rfl
+@[simp] lemma mul_apply (f g : ρ.End) (x : V) : (f * g) x = f (g x) := rfl
+
+lemma monoid_hom_one_apply (x : V) : ρ (1 : G) x = (1 : ρ.End) x := by simp
+
+lemma coe_one : ⇑(1 : ρ.End) = _root_.id := rfl
+lemma coe_mul (f g : ρ.End) : ⇑(f * g) = f ∘ g := rfl
+
+instance _root_.representation.End.monoid : monoid ρ.End :=
+{ mul := (*),
+  one := (1 : ρ →ᵣ ρ),
+  mul_assoc := λ f g h, rep_hom.ext $ λ x, rfl,
+  mul_one := comp_id,
+  one_mul := id_comp }
+
+instance _root_.representation.End.semiring : semiring ρ.End :=
+{ mul := (*),
+  one := (1 : ρ →ᵣ ρ),
+  zero := 0,
+  add := (+),
+  mul_zero := comp_zero,
+  zero_mul := zero_comp,
+  left_distrib := λ f g h, comp_add _ _ _,
+  right_distrib := λ f g h, add_comp _ _ _,
+  .. add_monoid_with_one.unary,
+  .. _root_.representation.End.monoid,
+  .. rep_hom.add_comm_monoid }
+
+instance _root_.representation.End.ring [has_smul ℤ k] [is_scalar_tower ℤ k W₁] : ring (representation.End σ₁) :=
+{ ..representation.End.semiring, ..rep_hom.add_comm_group }
+
+section
+
+variables
+  {k' : Type*} [monoid k'] [distrib_mul_action k' V] [smul_comm_class k k' V]
+  [has_smul k' k] [is_scalar_tower k' k V]
+
+instance _root_.representation.End.is_scalar_tower :
+  is_scalar_tower k' ρ.End ρ.End := ⟨smul_comp⟩
+
+instance _root_.representation.End.smul_comm_class :
+  smul_comm_class k' ρ.End ρ.End :=
+⟨λ s _ _, (comp_smul _ s _).symm⟩
+
+instance _root_.representation.End.smul_comm_class' :
+  smul_comm_class ρ.End k' ρ.End :=
+smul_comm_class.symm _ _ _
+
+end
+
+/-- The tautological action by `ρ.End` (aka `ρ →ᵣ ρ`) on `V`. -/
+def End_representation : representation k ρ.End V :=
+{ to_fun := to_linear_map,
+  map_one' := by {ext, simp},
+  map_mul' := by {intros f g, ext, simp} }
+
+-- apply_smul_... (unlike module, representation is not a class)
+
+instance End_module : module ρ.End V :=
+{ smul := ($),
+  smul_zero := rep_hom.map_zero,
+  smul_add := rep_hom.map_add,
+  add_smul := rep_hom.add_apply,
+  zero_smul := (rep_hom.zero_apply : ∀ m, (0 : ρ →ᵣ ρ) m = 0),
+  one_smul := λ _, rfl,
+  mul_smul := λ _ _ _, rfl }
+
+end as_monoid
+
+end rep_hom
+
+-- distrib_mul_action

--- a/src/representation_theory/rep_hom.lean
+++ b/src/representation_theory/rep_hom.lean
@@ -1,0 +1,65 @@
+/-
+Copyright (c) 2022 Winston Yin. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Winston Yin
+-/
+import representation_theory.basic
+
+/-!
+# Homomorphisms between representations
+
+This file defines homomorphisms between representations `rep_hom` as linear maps that commute with
+the group action on the source and target spaces. Lemmas and definitions follow closely
+`algebra.module.linear_map`.
+
+## Notations
+
+Since multiple different representations may be defined on the same vector space, the `rep_hom`s are
+written to be from `ρ : representation k G V` to `ρ₂ : representation k G V₂` (denoted `ρ →ᵣ ρ₂`),
+rather than from `V` to `V₂`. This is denoted `ρ →ᵣ ρ₂`
+
+## Tags
+
+representation, homomorphism
+-/
+
+open function
+open_locale big_operators
+
+set_option old_structure_cmd true
+
+/-- A map from V to V₂ is a representation homomorphism if it is a linear map that commutes with
+G action (through representation ρ on V and ρ₂ on V₂) -/
+structure is_rep_hom
+  {k G V V₂: Type*} [comm_semiring k] [monoid G]
+  [add_comm_monoid V] [add_comm_monoid V₂] [module k V] [module k V₂]
+  (ρ : representation k G V) (ρ₂ : representation k G V₂)
+  (f : V → V₂) : Prop :=
+(map_add : ∀ x y, f (x + y) = f x + f y)
+(map_smul : ∀ (c : k) x, f (c • x) = c • f x)
+(map_smulG : ∀ (g : G) x, f (ρ g x) = ρ₂ g (f x))
+
+/-- Bundled homomorphism between representations -/
+structure rep_hom
+  {k G V V₂ : Type*} [comm_semiring k] [monoid G]
+  [add_comm_monoid V] [module k V] [add_comm_monoid V₂] [module k V₂]
+  (ρ : representation k G V) (ρ₂ : representation k G V₂) extends V →ₗ[k] V₂ :=
+(map_smulG' : ∀ (g : G) (x : V), to_fun (ρ g x) = ρ₂ g (to_fun x))
+
+/-- The `linear_map` underlying a `rep_hom`. -/
+add_decl_doc rep_hom.to_linear_map
+
+infixr ` →ᵣ `:25 := rep_hom
+
+/-- `rep_hom_class F ρ ρ₂` asserts `F` is a type of bundled representation homomorphisms `ρ → ρ₂`.
+A linear map `f` between `k`-modules `V` and `V₂` is a representation homomorphism if it commutes
+with the group action on `V` and `V₂`: `∀ g x, f (ρ g x) = ρ₂ g (f x)`. -/
+class rep_hom_class (F : Type*) {k G V V₂ : out_param Type*} [comm_semiring k] [monoid G]
+  [add_comm_monoid V] [module k V] [add_comm_monoid V₂] [module k V₂]
+  (ρ : representation k G V) (ρ₂ : representation k G V₂)
+  extends semilinear_map_class F (ring_hom.id k) V V₂ :=
+(map_smulG : ∀ (f : F) (g : G) (x : V), f (ρ g x) = ρ₂ g (f x))
+
+attribute [nolint dangerous_instance] rep_hom_class.to_semilinear_map_class
+
+export rep_hom_class (map_smulG)

--- a/src/representation_theory/rep_hom.lean
+++ b/src/representation_theory/rep_hom.lean
@@ -9,14 +9,14 @@ import representation_theory.basic
 # Homomorphisms between representations
 
 This file defines homomorphisms between representations `rep_hom` as linear maps that commute with
-the group action on the source and target spaces. Lemmas and definitions follow closely
+the group action on the source and target spaces. Lemmas and definitions closely follow
 `algebra.module.linear_map`.
 
 ## Notations
 
 Since multiple different representations may be defined on the same vector space, the `rep_hom`s are
 written to be from `ρ : representation k G V` to `ρ₂ : representation k G V₂` (denoted `ρ →ᵣ ρ₂`),
-rather than from `V` to `V₂`. This is denoted `ρ →ᵣ ρ₂`
+rather than from `V` to `V₂`.
 
 ## Tags
 


### PR DESCRIPTION
rep_hom.lean closely follows algebra.module.linear_map; rep_equiv.lean closely follows algebra.module.equiv

Co-authored-by: Winston Yin (winstonyin@berkeley.edu)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
