### PR TITLE
[Merged by Bors] - feat(linear_algebra/unitary_group): better constructor

### DIFF
--- a/src/linear_algebra/unitary_group.lean
+++ b/src/linear_algebra/unitary_group.lean
@@ -55,6 +55,13 @@ end
 variables {n : Type u} [decidable_eq n] [fintype n]
 variables {α : Type v} [comm_ring α] [star_ring α]
 
+@[simp] lemma mem_unitary_group_iff {A : matrix n n α} :
+  A ∈ matrix.unitary_group n α ↔ A * star A = 1 :=
+begin
+  refine ⟨and.right, λ hA, ⟨_, hA⟩⟩,
+  simpa only [matrix.mul_eq_mul, matrix.mul_eq_one_comm] using hA
+end
+
 namespace unitary_group
 
 instance coe_matrix : has_coe (unitary_group n α) (matrix n n α) := ⟨subtype.val⟩
@@ -144,13 +151,20 @@ end unitary_group
 
 section orthogonal_group
 
-variables (β : Type v) [comm_ring β]
+variables (n) (β : Type v) [comm_ring β]
 
 local attribute [instance] star_ring_of_comm
 /--
 `orthogonal_group n` is the group of `n` by `n` matrices where the transpose is the inverse.
 -/
 abbreviation orthogonal_group := unitary_group n β
+
+@[simp] lemma mem_orthogonal_group_iff {A : matrix n n β} :
+  A ∈ matrix.orthogonal_group n β ↔ A * star A = 1 :=
+begin
+  refine ⟨and.right, λ hA, ⟨_, hA⟩⟩,
+  simpa only [matrix.mul_eq_mul, matrix.mul_eq_one_comm] using hA
+end
 
 end orthogonal_group
 

--- a/src/linear_algebra/unitary_group.lean
+++ b/src/linear_algebra/unitary_group.lean
@@ -55,7 +55,7 @@ end
 variables {n : Type u} [decidable_eq n] [fintype n]
 variables {α : Type v} [comm_ring α] [star_ring α]
 
-@[simp] lemma mem_unitary_group_iff {A : matrix n n α} :
+lemma mem_unitary_group_iff {A : matrix n n α} :
   A ∈ matrix.unitary_group n α ↔ A * star A = 1 :=
 begin
   refine ⟨and.right, λ hA, ⟨_, hA⟩⟩,
@@ -159,7 +159,7 @@ local attribute [instance] star_ring_of_comm
 -/
 abbreviation orthogonal_group := unitary_group n β
 
-@[simp] lemma mem_orthogonal_group_iff {A : matrix n n β} :
+lemma mem_orthogonal_group_iff {A : matrix n n β} :
   A ∈ matrix.orthogonal_group n β ↔ A * star A = 1 :=
 begin
   refine ⟨and.right, λ hA, ⟨_, hA⟩⟩,


### PR DESCRIPTION
`A ∈ matrix.unitary_group n α` means by definition (for reasons of agreement with something more general) that `A * star A = 1` and `star A * A = 1`.  But either condition implies the other, so we provide a lemma to reduce to the first.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
