### PR TITLE
[Merged by Bors] - feat(data/finset/lattice): add three*2 lemmas about `finset.max/min`

### DIFF
--- a/src/data/finset/lattice.lean
+++ b/src/data/finset/lattice.lean
@@ -830,15 +830,13 @@ finset.induction_on s (λ _ H, by cases H)
       { exact mem_insert_of_mem (ih h) } }
   end)
 
-lemma coe_le_max_of_mem {a : α} {s : finset α} (as : a ∈ s) :
-  ↑a ≤ s.max :=
+lemma coe_le_max_of_mem {a : α} {s : finset α} (as : a ∈ s) : ↑a ≤ s.max :=
 le_sup_of_mem_set ⟨a, as, rfl⟩
 
 theorem le_max_of_mem {s : finset α} {a b : α} (h₁ : a ∈ s) (h₂ : s.max = b) : a ≤ b :=
 with_bot.coe_le_coe.mp $ (coe_le_max_of_mem h₁).trans h₂.le
 
-lemma max_mono {s t : finset α} (st : s ⊆ t) :
-  s.max ≤ t.max :=
+lemma max_mono {s t : finset α} (st : s ⊆ t) : s.max ≤ t.max :=
 sup_mono st
 
 lemma max_le {M : with_bot α} {s : finset α} (st : ∀ a : α, a ∈ s → (a : with_bot α) ≤ M) :

--- a/src/data/finset/lattice.lean
+++ b/src/data/finset/lattice.lean
@@ -831,7 +831,7 @@ finset.induction_on s (λ _ H, by cases H)
   end)
 
 lemma coe_le_max_of_mem {a : α} {s : finset α} (as : a ∈ s) : ↑a ≤ s.max :=
-le_sup_of_mem_set ⟨a, as, rfl⟩
+le_sup as
 
 theorem le_max_of_mem {s : finset α} {a b : α} (h₁ : a ∈ s) (h₂ : s.max = b) : a ≤ b :=
 with_bot.coe_le_coe.mp $ (coe_le_max_of_mem h₁).trans h₂.le

--- a/src/data/finset/lattice.lean
+++ b/src/data/finset/lattice.lean
@@ -820,6 +820,25 @@ theorem le_max_of_mem {s : finset α} {a b : α} (h₁ : a ∈ s) (h₂ : s.max 
 by rcases @le_sup (with_bot α) _ _ _ _ _ _ h₁ _ rfl with ⟨b', hb, ab⟩;
    cases h₂.symm.trans hb; assumption
 
+lemma mem_le_max {a : α} {s : finset α} (as : a ∈ s) :
+  ↑a ≤ s.max :=
+(le_fold_max _).mpr (or.inr ⟨a, as, rfl.le⟩)
+
+
+lemma max_mono {s t : finset α} (st : s ⊆ t) :
+  s.max ≤ t.max :=
+begin
+  by_cases s0 : s.nonempty,
+  { obtain ⟨a, as⟩ := nonempty.bex s0,
+    rcases max_of_mem as with ⟨w, sw⟩,
+    exact (le_fold_max _).mpr (or.inr ⟨w, st (mem_of_max sw), sw.le⟩) },
+  { simp [not_nonempty_iff_eq_empty.mp s0] },
+end
+
+lemma max_le (M : α) {s : finset α} (st : ∀ a : α, a ∈ s → a ≤ M) :
+  s.max ≤ M :=
+(fold_max_le _).mpr ⟨bot_le, λ x xs, with_bot.coe_le_coe.mpr (st x xs)⟩
+
 /-- Let `s` be a finset in a linear order. Then `s.min` is the minimum of `s` if `s` is not empty,
 and `⊤` otherwise. It belongs to `with_top α`. If you want to get an element of `α`, see
 `s.min'`. -/

--- a/src/data/finset/lattice.lean
+++ b/src/data/finset/lattice.lean
@@ -111,20 +111,6 @@ begin
   exact ⟨λ h c hc b hb, h b hb c hc, λ h b hb c hc, h c hc b hb⟩,
 end
 
-lemma le_sup_of_mem [decidable_eq α] {a : α} (as : a ∈ s.image f) :
-  a ≤ s.sup f :=
-begin
-  rcases mem_image.mp as with ⟨w, ws, rfl⟩,
-  exact le_sup ws,
-end
-
-lemma le_sup_of_mem_set {a : α} (as : a ∈ f '' s) :
-  a ≤ s.sup f :=
-begin
-  rcases as with ⟨b, bs, rfl⟩,
-  exact le_sup (mem_coe.mp bs),
-end
-
 @[simp] lemma sup_attach (s : finset β) (f : β → α) : s.attach.sup (λ x, f x) = s.sup f :=
 (s.attach.sup_map (function.embedding.subtype _) f).symm.trans $ congr_arg _ attach_map_val
 
@@ -841,7 +827,7 @@ sup_mono st
 
 lemma max_le {M : with_bot α} {s : finset α} (st : ∀ a : α, a ∈ s → (a : with_bot α) ≤ M) :
   s.max ≤ M :=
-(fold_max_le _).mpr ⟨bot_le, λ x xs, st x xs⟩
+sup_le st
 
 /-- Let `s` be a finset in a linear order. Then `s.min` is the minimum of `s` if `s` is not empty,
 and `⊤` otherwise. It belongs to `with_top α`. If you want to get an element of `α`, see

--- a/src/data/finset/lattice.lean
+++ b/src/data/finset/lattice.lean
@@ -110,7 +110,7 @@ begin
   simp_rw finset.sup_le_iff,
   exact ⟨λ h c hc b hb, h b hb c hc, λ h b hb c hc, h c hc b hb⟩,
 end
-#where
+
 lemma le_sup_of_mem [decidable_eq α] {a : α} (as : a ∈ s.image f) :
   a ≤ s.sup f :=
 begin

--- a/src/data/finset/lattice.lean
+++ b/src/data/finset/lattice.lean
@@ -860,9 +860,18 @@ theorem min_eq_top {s : finset α} : s.min = ⊤ ↔ s = ∅ :=
 
 theorem mem_of_min {s : finset α} : ∀ {a : α}, s.min = a → a ∈ s := @mem_of_max αᵒᵈ _ s
 
+lemma min_le_coe_of_mem {a : α} {s : finset α} (as : a ∈ s) : s.min ≤ a :=
+inf_le as
+
 theorem min_le_of_mem {s : finset α} {a b : α} (h₁ : b ∈ s) (h₂ : s.min = a) : a ≤ b :=
-by rcases @inf_le (with_top α) _ _ _ _ _ _ h₁ _ rfl with ⟨b', hb, ab⟩;
-   cases h₂.symm.trans hb; assumption
+with_top.coe_le_coe.mp $ h₂.ge.trans (min_le_coe_of_mem h₁)
+
+lemma min_mono {s t : finset α} (st : s ⊆ t) : t.min ≤ s.min :=
+inf_mono st
+
+lemma le_min {m : with_top α} {s : finset α} (st : ∀ a : α, a ∈ s → m ≤ a) :
+  m ≤ s.min :=
+le_inf st
 
 /-- Given a nonempty finset `s` in a linear order `α `, then `s.min' h` is its minimum, as an
 element of `α`, where `h` is a proof of nonemptiness. Without this assumption, use instead `s.min`,

--- a/src/data/finset/lattice.lean
+++ b/src/data/finset/lattice.lean
@@ -824,7 +824,6 @@ lemma mem_le_max {a : α} {s : finset α} (as : a ∈ s) :
   ↑a ≤ s.max :=
 (le_fold_max _).mpr (or.inr ⟨a, as, rfl.le⟩)
 
-
 lemma max_mono {s t : finset α} (st : s ⊆ t) :
   s.max ≤ t.max :=
 begin


### PR DESCRIPTION
The three lemmas are

* `mem_le_max: ↑a ≤ s.max`,
* `max_mono : s.max ≤ t.max`,
* `max_le : s.max ≤ M`,
and
* `min_le_coe_of_mem : s.min`,
* `min_mono : t.min ≤ s.min`,
* `le_min : m ≤ s.min`.

~~I feel that I did not get the hang of `finset.max`: probably a lot of golfing is possible, at least for `max_mono`!~~
Luckily, Eric looked at the PR and now the proofs have been shortened!

I also golfed `le_max_of_mem` and `min_le_of_mem`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
