### PR TITLE
[Merged by Bors] - refactor(data/finset/lattice): respell `finset.max/finset.min` using `sup/inf coe`

### DIFF
--- a/src/data/finset/lattice.lean
+++ b/src/data/finset/lattice.lean
@@ -779,8 +779,8 @@ variables [linear_order α]
 /-- Let `s` be a finset in a linear order. Then `s.max` is the maximum of `s` if `s` is not empty,
 and `⊥` otherwise. It belongs to `with_bot α`. If you want to get an element of `α`, see
 `s.max'`. -/
-protected def max : finset α → with_bot α :=
-fold max ⊥ coe
+protected def max (s : finset α) : with_bot α :=
+sup s coe
 
 theorem max_eq_sup_with_bot (s : finset α) :
   s.max = sup s coe := rfl
@@ -823,8 +823,8 @@ by rcases @le_sup (with_bot α) _ _ _ _ _ _ h₁ _ rfl with ⟨b', hb, ab⟩;
 /-- Let `s` be a finset in a linear order. Then `s.min` is the minimum of `s` if `s` is not empty,
 and `⊤` otherwise. It belongs to `with_top α`. If you want to get an element of `α`, see
 `s.min'`. -/
-protected def min : finset α → with_top α :=
-fold min ⊤ coe
+protected def min (s : finset α) : with_top α :=
+inf s coe
 
 theorem min_eq_inf_with_top (s : finset α) :
   s.min = inf s coe := rfl


### PR DESCRIPTION
This PR simply redefines
* `finset.max s` with the defeq `finset.sup s coe`,
* `finset.min s` with the defeq `finset.sup/inf s coe`.

This arose from PR #15212.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
