### PR TITLE
[Merged by Bors] - refactor(topology/algebra/order/basic): Add antitone versions of sup and inf lemmas for continuous monotone functions and move them to monotone/antitone namespaces.

### DIFF
--- a/src/dynamics/circle/rotation_number/translation_number.lean
+++ b/src/dynamics/circle/rotation_number/translation_number.lean
@@ -842,7 +842,7 @@ begin
   { refine csupr_mono (this y) (λ g, _),
     exact mono _ (mono _ hxy) },
   { simp only [map_add_one],
-    exact (map_csupr_of_continuous_at_of_monotone (continuous_at_id.add continuous_at_const)
+    exact (monotone.map_csupr_of_continuous_at (continuous_at_id.add continuous_at_const)
       (monotone_id.add_const (1 : ℝ)) (this x)).symm },
   { exact this x }
 end

--- a/src/order/complete_lattice.lean
+++ b/src/order/complete_lattice.lean
@@ -592,59 +592,6 @@ lemma antitone.le_map_Inf [complete_lattice β] {s : set α} {f : α → β} (hf
   (⨆ a ∈ s, f a) ≤ f (Inf s) :=
 hf.dual_left.le_map_Sup
 
-lemma monotone.Sup_image_le {R S : Type*} [complete_lattice R] [complete_linear_order S]
-  {f : R → S} (f_incr : monotone f) (A : set R) :
-  Sup (f '' A) ≤ f (Sup A) :=
-begin
-  refine Sup_le _,
-  intros x x_in_fA,
-  rcases (mem_image f A x).mp x_in_fA with ⟨z, ⟨z_in_A, fz_eq_x⟩⟩,
-  by_contra b_gt,
-  have key := (f_incr (le_Sup z_in_A)),
-  rw fz_eq_x at key,
-  exact (lt_self_iff_false x).mp (lt_of_le_of_lt key (not_le.mp b_gt)),
-end
-
-lemma monotone.le_Inf_image {R S : Type*} [complete_semilattice_Inf R] [complete_linear_order S]
-  {f : R → S} (f_incr : monotone f) (A : set R) :
-  f (Inf A) ≤ Inf (f '' A) :=
-begin
-  have := f_incr.dual,
-  refine le_Inf _,
-  intros x x_in_fA,
-  rcases (mem_image f A x).mp x_in_fA with ⟨z, ⟨z_in_A, fz_eq_x⟩⟩,
-  by_contra b_gt,
-  have key := (f_incr (Inf_le z_in_A)),
-  rw fz_eq_x at key,
-  exact (lt_self_iff_false x).mp (lt_of_lt_of_le (not_le.mp b_gt) key),
-end
-
-lemma antitone.Sup_image_le {R S : Type*} [complete_semilattice_Inf R] [complete_linear_order S]
-  {f : R → S} (f_decr : antitone f) (A : set R) :
-  Sup (f '' A) ≤ f (Inf A) :=
-begin
-  refine Sup_le _,
-  intros x x_in_fA,
-  rcases (mem_image f A x).mp x_in_fA with ⟨z, ⟨z_in_A, fz_eq_x⟩⟩,
-  by_contra b_gt,
-  have key := (f_decr (Inf_le z_in_A)),
-  rw fz_eq_x at key,
-  exact (lt_self_iff_false x).mp (lt_of_le_of_lt key (not_le.mp b_gt)),
-end
-
-lemma antitone.le_Inf_image {R S : Type*} [complete_semilattice_Sup R] [complete_linear_order S]
-  {f : R → S} (f_decr : antitone f) (A : set R) :
-  f (Sup A) ≤ Inf (f '' A) :=
-begin
-  refine le_Inf _,
-  intros x x_in_fA,
-  rcases (mem_image f A x).mp x_in_fA with ⟨z, ⟨z_in_A, fz_eq_x⟩⟩,
-  by_contra b_gt,
-  have key := (f_decr (le_Sup z_in_A)),
-  rw fz_eq_x at key,
-  exact (lt_self_iff_false x).mp (lt_of_lt_of_le (not_le.mp b_gt) key),
-end
-
 lemma order_iso.map_supr [complete_lattice β] (f : α ≃o β) (x : ι → α) :
   f (⨆ i, x i) = ⨆ i, f (x i) :=
 eq_of_forall_ge_iff $ f.surjective.forall.2 $ λ x,

--- a/src/order/complete_lattice.lean
+++ b/src/order/complete_lattice.lean
@@ -592,6 +592,59 @@ lemma antitone.le_map_Inf [complete_lattice β] {s : set α} {f : α → β} (hf
   (⨆ a ∈ s, f a) ≤ f (Inf s) :=
 hf.dual_left.le_map_Sup
 
+lemma monotone.Sup_image_le {R S : Type*} [complete_lattice R] [complete_linear_order S]
+  {f : R → S} (f_incr : monotone f) (A : set R) :
+  Sup (f '' A) ≤ f (Sup A) :=
+begin
+  refine Sup_le _,
+  intros x x_in_fA,
+  rcases (mem_image f A x).mp x_in_fA with ⟨z, ⟨z_in_A, fz_eq_x⟩⟩,
+  by_contra b_gt,
+  have key := (f_incr (le_Sup z_in_A)),
+  rw fz_eq_x at key,
+  exact (lt_self_iff_false x).mp (lt_of_le_of_lt key (not_le.mp b_gt)),
+end
+
+lemma monotone.le_Inf_image {R S : Type*} [complete_semilattice_Inf R] [complete_linear_order S]
+  {f : R → S} (f_incr : monotone f) (A : set R) :
+  f (Inf A) ≤ Inf (f '' A) :=
+begin
+  have := f_incr.dual,
+  refine le_Inf _,
+  intros x x_in_fA,
+  rcases (mem_image f A x).mp x_in_fA with ⟨z, ⟨z_in_A, fz_eq_x⟩⟩,
+  by_contra b_gt,
+  have key := (f_incr (Inf_le z_in_A)),
+  rw fz_eq_x at key,
+  exact (lt_self_iff_false x).mp (lt_of_lt_of_le (not_le.mp b_gt) key),
+end
+
+lemma antitone.Sup_image_le {R S : Type*} [complete_semilattice_Inf R] [complete_linear_order S]
+  {f : R → S} (f_decr : antitone f) (A : set R) :
+  Sup (f '' A) ≤ f (Inf A) :=
+begin
+  refine Sup_le _,
+  intros x x_in_fA,
+  rcases (mem_image f A x).mp x_in_fA with ⟨z, ⟨z_in_A, fz_eq_x⟩⟩,
+  by_contra b_gt,
+  have key := (f_decr (Inf_le z_in_A)),
+  rw fz_eq_x at key,
+  exact (lt_self_iff_false x).mp (lt_of_le_of_lt key (not_le.mp b_gt)),
+end
+
+lemma antitone.le_Inf_image {R S : Type*} [complete_semilattice_Sup R] [complete_linear_order S]
+  {f : R → S} (f_decr : antitone f) (A : set R) :
+  f (Sup A) ≤ Inf (f '' A) :=
+begin
+  refine le_Inf _,
+  intros x x_in_fA,
+  rcases (mem_image f A x).mp x_in_fA with ⟨z, ⟨z_in_A, fz_eq_x⟩⟩,
+  by_contra b_gt,
+  have key := (f_decr (le_Sup z_in_A)),
+  rw fz_eq_x at key,
+  exact (lt_self_iff_false x).mp (lt_of_lt_of_le (not_le.mp b_gt) key),
+end
+
 lemma order_iso.map_supr [complete_lattice β] (f : α ≃o β) (x : ι → α) :
   f (⨆ i, x i) = ⨆ i, f (x i) :=
 eq_of_forall_ge_iff $ f.surjective.forall.2 $ λ x,

--- a/src/order/liminf_limsup.lean
+++ b/src/order/liminf_limsup.lean
@@ -514,6 +514,18 @@ end complete_lattice
 
 section conditionally_complete_linear_order
 
+lemma frequently_lt_of_lt_Limsup {f : filter α} [conditionally_complete_linear_order α] {a : α}
+  (hf : f.is_cobounded (≤) . is_bounded_default) (h : a < f.Limsup) : ∃ᶠ n in f, a < n :=
+begin
+  contrapose! h,
+  simp only [not_frequently, not_lt] at h,
+  exact Limsup_le_of_le hf h,
+end
+
+lemma frequently_lt_of_Liminf_lt {f : filter α} [conditionally_complete_linear_order α] {a : α}
+  (hf : f.is_cobounded (≥) . is_bounded_default) (h : f.Liminf < a) : ∃ᶠ n in f, n < a :=
+@frequently_lt_of_lt_Limsup (order_dual α) f _ a hf h
+
 lemma eventually_lt_of_lt_liminf {f : filter α} [conditionally_complete_linear_order β]
   {u : α → β} {b : β} (h : b < liminf f u) (hu : f.is_bounded_under (≥) u . is_bounded_default) :
   ∀ᶠ a in f, b < u a :=

--- a/src/order/liminf_limsup.lean
+++ b/src/order/liminf_limsup.lean
@@ -465,6 +465,33 @@ theorem has_basis.liminf_eq_supr_infi {p : ι → Prop} {s : ι → set β} {f :
   (h : f.has_basis p s) : f.liminf u = ⨆ i (hi : p i), ⨅ a ∈ s i, u a :=
 @has_basis.limsup_eq_infi_supr αᵒᵈ _ _ _ _ _ _ _ h
 
+lemma limsup_eq_Inf_Sup {ι R : Type*} (f : filter ι) [complete_lattice R] (a : ι → R) :
+  f.limsup a = Inf ((λ I, Sup (a '' I)) '' f.sets) :=
+begin
+  refine le_antisymm _ _,
+  { rw limsup_eq,
+    apply Inf_le_Inf,
+    intros x hx,
+    rcases (mem_image _ f.sets x).mp hx with ⟨I, ⟨I_mem_f, hI⟩⟩,
+    filter_upwards [I_mem_f] with i hi,
+    rw ← hI,
+    exact le_Sup (mem_image_of_mem _ hi), },
+  { rw limsup_eq,
+    apply le_Inf_iff.mpr,
+    intros b hb,
+    simp only [mem_set_of_eq, filter.eventually] at hb,
+    apply Inf_le_of_le (mem_image_of_mem _ (filter.mem_sets.mpr hb)),
+    apply Sup_le,
+    intros x hx,
+    simp only [mem_image, mem_set_of_eq] at hx,
+    rcases hx with ⟨k, ak_le_b, ak_eq_x⟩,
+    rwa [ak_eq_x] at ak_le_b, },
+end
+
+lemma liminf_eq_Sup_Inf {ι R : Type*} (f : filter ι) [complete_lattice R] (a : ι → R) :
+  f.liminf a = Sup ((λ I, Inf (a '' I)) '' f.sets) :=
+@filter.limsup_eq_Inf_Sup ι (order_dual R) _ _ a
+
 @[simp] lemma liminf_nat_add (f : ℕ → α) (k : ℕ) :
   at_top.liminf (λ i, f (i + k)) = at_top.liminf f :=
 by { simp_rw liminf_eq_supr_infi_of_nat, exact supr_infi_ge_nat_add f k }

--- a/src/topology/algebra/order/basic.lean
+++ b/src/topology/algebra/order/basic.lean
@@ -2933,8 +2933,8 @@ monotone.map_cinfi_of_continuous_at
   (show continuous_at (order_dual.to_dual ∘ f) (⨅ i, g i), from Cf) Af H
 
 /-- A monotone map has a limit to the left of any point `x`, equal to `Sup (f '' (Iio x))`. -/
-lemma monotone.tendsto_nhds_within_Iio
-  {α β : Type*} [linear_order α] [topological_space α] [order_topology α]
+lemma monotone.tendsto_nhds_within_Iio {α β : Type*}
+  [linear_order α] [topological_space α] [order_topology α]
   [conditionally_complete_linear_order β] [topological_space β] [order_topology β]
   {f : α → β} (Mf : monotone f) (x : α) :
   tendsto f (𝓝[<] x) (𝓝 (Sup (f '' (Iio x)))) :=
@@ -2952,9 +2952,9 @@ begin
 end
 
 /-- A monotone map has a limit to the right of any point `x`, equal to `Inf (f '' (Ioi x))`. -/
-lemma monotone.tendsto_nhds_within_Ioi
-  {α : Type*} [linear_order α] [topological_space α] [order_topology α]
-  {β : Type*} [conditionally_complete_linear_order β] [topological_space β] [order_topology β]
+lemma monotone.tendsto_nhds_within_Ioi {α β : Type*}
+  [linear_order α] [topological_space α] [order_topology α]
+  [conditionally_complete_linear_order β] [topological_space β] [order_topology β]
   {f : α → β} (Mf : monotone f) (x : α) :
   tendsto f (𝓝[>] x) (𝓝 (Inf (f '' (Ioi x)))) :=
 @monotone.tendsto_nhds_within_Iio αᵒᵈ βᵒᵈ _ _ _ _ _ _ f Mf.dual x

--- a/src/topology/algebra/order/basic.lean
+++ b/src/topology/algebra/order/basic.lean
@@ -2883,11 +2883,42 @@ end
 
 lemma antitone.Sup_image_eq_apply_Inf {R S : Type*}
   [complete_linear_order R] [topological_space R] [order_topology R]
-  [complete_linear_order S] [topological_space S] [order_closed_topology S]
+  [complete_linear_order S] [topological_space S]
+  [order_topology S] -- was: [order_closed_topology S]
   {f : R → S} (f_decr : antitone f) (f_cont : continuous f)
   (A : set R) (hA : A.nonempty):
   Sup (f '' A) = f (Inf A) :=
-le_antisymm (f_decr.Sup_image_le A) (continuous_Inf_le_Sup_continuous f_cont A hA)
+begin
+  -- The working version proof was:
+  -- `le_antisymm (f_decr.Sup_image_le A) (continuous_Inf_le_Sup_continuous f_cont A hA)`
+
+  -- It indeed looks like the previously existing `antitone.le_map_Inf f_decr` would be
+  -- similar, but I fail to fill in the sorry with it. This is the reason I originally had to
+  -- introduce the new lemmas `antitone.Sup_image_le` etc.
+
+  -- (That the assumption in the existing lemma is somewhat more stringent is not an issue
+  -- for me, even the weaker result would be good enough to me, but I can't get it to work.)
+
+  apply le_antisymm _ (continuous_Inf_le_Sup_continuous f_cont A hA),
+
+  have similar_to_goal := @antitone.le_map_Inf R S _ _ A f f_decr, -- Why is this not enough?
+
+  convert similar_to_goal,
+
+  ext x,
+  split,
+  { intros hx,
+    rcases hx with ⟨r, ⟨r_in_A, fr_eq_x⟩⟩,
+    use r,
+    simp only [fr_eq_x, r_in_A, csupr_pos], },
+  { intros hx,
+    rcases hx with ⟨r, hr⟩,
+    use r,
+    split,
+    sorry, -- How to proceed?
+    sorry, -- How to proceed?
+    },
+end
 
 lemma antitone.Inf_image_eq_apply_Sup {R S : Type*}
   [complete_linear_order R] [topological_space R] [order_topology R]
@@ -2902,7 +2933,8 @@ end
 
 lemma monotone.Inf_image_eq_apply_Inf {R S : Type*}
   [complete_linear_order R] [topological_space R] [order_topology R]
-  [complete_linear_order S] [topological_space S] [order_closed_topology S]
+  [complete_linear_order S] [topological_space S]
+  [order_topology S] -- was: [order_closed_topology S]
   {f : R → S} (f_incr : monotone f) (f_cont : continuous f)
   (A : set R) (hA : A.nonempty):
   Inf (f '' A) = f (Inf A) :=
@@ -2910,7 +2942,8 @@ f_incr.dual_left.Inf_image_eq_apply_Sup f_cont A hA
 
 lemma monotone.Sup_image_eq_apply_Sup {R S : Type*}
   [complete_linear_order R] [topological_space R] [order_topology R]
-  [complete_linear_order S] [topological_space S] [order_closed_topology S]
+  [complete_linear_order S] [topological_space S]
+  [order_topology S] -- was: [order_closed_topology S]
   {f : R → S} (f_incr : monotone f) (f_cont : continuous f)
   (A : set R) (hA : A.nonempty):
   Sup (f '' A) = f (Sup A) :=

--- a/src/topology/algebra/order/basic.lean
+++ b/src/topology/algebra/order/basic.lean
@@ -2698,7 +2698,7 @@ end densely_ordered
 section complete_linear_order
 
 variables [complete_linear_order α] [topological_space α] [order_topology α]
-  [complete_linear_order β] [topological_space β] [order_topology β] [nonempty γ]
+  [complete_linear_order β] [topological_space β] [order_closed_topology β] [nonempty γ]
 
 lemma Sup_mem_closure {α : Type u} [topological_space α] [complete_linear_order α]
   [order_topology α] {s : set α} (hs : s.nonempty) :
@@ -2729,7 +2729,7 @@ lemma map_Sup_of_continuous_at_of_monotone' {f : α → β} {s : set α} (Cf : c
 ((is_lub_Sup _).is_lub_of_tendsto (λ x hx y hy xy, Mf xy) hs $
   Cf.mono_left inf_le_left).Sup_eq.symm
 
-/-- A monotone function `s` sending `bot` to `bot` and continuous at the supremum of a set sends
+/-- A monotone function `f` sending `bot` to `bot` and continuous at the supremum of a set sends
 this supremum to the supremum of the image of this set. -/
 lemma map_Sup_of_continuous_at_of_monotone {f : α → β} {s : set α} (Cf : continuous_at f (Sup s))
   (Mf : monotone f) (fbot : f ⊥ = ⊥) :
@@ -2761,7 +2761,7 @@ lemma map_Inf_of_continuous_at_of_monotone' {f : α → β} {s : set α} (Cf : c
   f (Inf s) = Inf (f '' s) :=
 @map_Sup_of_continuous_at_of_monotone' αᵒᵈ βᵒᵈ _ _ _ _ _ _ f s Cf Mf.dual hs
 
-/-- A monotone function `s` sending `top` to `top` and continuous at the infimum of a set sends
+/-- A monotone function `f` sending `top` to `top` and continuous at the infimum of a set sends
 this infimum to the infimum of the image of this set. -/
 lemma map_Inf_of_continuous_at_of_monotone {f : α → β} {s : set α} (Cf : continuous_at f (Inf s))
   (Mf : monotone f) (ftop : f ⊤ = ⊤) :
@@ -2781,6 +2781,76 @@ lemma map_infi_of_continuous_at_of_monotone {ι : Sort*} {f : α → β} {g : ι
   (Cf : continuous_at f (infi g)) (Mf : monotone f) (ftop : f ⊤ = ⊤) :
   f (infi g) = infi (f ∘ g) :=
 @map_supr_of_continuous_at_of_monotone αᵒᵈ βᵒᵈ _ _ _ _ _ _ ι f g Cf Mf.dual ftop
+
+
+
+
+
+
+
+/-- An antitone function continuous at the supremum of a nonempty set sends this supremum to
+the infimum of the image of this set. -/
+lemma map_Sup_of_continuous_at_of_antitone' {f : α → β} {s : set α} (Cf : continuous_at f (Sup s))
+  (Af : antitone f) (hs : s.nonempty) :
+  f (Sup s) = Inf (f '' s) :=
+map_Sup_of_continuous_at_of_monotone'
+  (show continuous_at (order_dual.to_dual ∘ f) (Sup s), from Cf) Af hs
+
+/-- An antitone function `f` sending `bot` to `top` and continuous at the supremum of a set sends
+this supremum to the infimum of the image of this set. -/
+lemma map_Sup_of_continuous_at_of_antitone {f : α → β} {s : set α} (Cf : continuous_at f (Sup s))
+  (Af : antitone f) (fbot : f ⊥ = ⊤) :
+  f (Sup s) = Inf (f '' s) :=
+map_Sup_of_continuous_at_of_monotone
+  (show continuous_at (order_dual.to_dual ∘ f) (Sup s), from Cf) Af fbot
+
+/-- An antitone function continuous at the indexed supremum over a nonempty `Sort` sends this
+indexed supremum to the indexed infimum of the composition. -/
+lemma map_supr_of_continuous_at_of_antitone' {ι : Sort*} [nonempty ι] {f : α → β} {g : ι → α}
+  (Cf : continuous_at f (supr g)) (Af : antitone f) :
+  f (⨆ i, g i) = ⨅ i, f (g i) :=
+map_supr_of_continuous_at_of_monotone'
+  (show continuous_at (order_dual.to_dual ∘ f) (supr g), from Cf) Af
+
+/-- An antitone function sending `bot` to `top` is continuous at the indexed supremum over
+a `Sort`, then it sends this indexed supremum to the indexed supremum of the composition. -/
+lemma map_supr_of_continuous_at_of_antitone {ι : Sort*} {f : α → β} {g : ι → α}
+  (Cf : continuous_at f (supr g)) (Af : antitone f) (fbot : f ⊥ = ⊤) :
+  f (⨆ i, g i) = ⨅ i, f (g i) :=
+map_supr_of_continuous_at_of_monotone
+  (show continuous_at (order_dual.to_dual ∘ f) (supr g), from Cf) Af fbot
+
+/-- An antitone function continuous at the infimum of a nonempty set sends this infimum to
+the supremum of the image of this set. -/
+lemma map_Inf_of_continuous_at_of_antitone' {f : α → β} {s : set α} (Cf : continuous_at f (Inf s))
+  (Af : antitone f) (hs : s.nonempty) :
+  f (Inf s) = Sup (f '' s) :=
+map_Inf_of_continuous_at_of_monotone'
+  (show continuous_at (order_dual.to_dual ∘ f) (Inf s), from Cf) Af hs
+
+/-- An antitone function `f` sending `top` to `bot` and continuous at the infimum of a set sends
+this infimum to the supremum of the image of this set. -/
+lemma map_Inf_of_continuous_at_of_antitone {f : α → β} {s : set α} (Cf : continuous_at f (Inf s))
+  (Af : antitone f) (ftop : f ⊤ = ⊥) :
+  f (Inf s) = Sup (f '' s) :=
+map_Inf_of_continuous_at_of_monotone
+  (show continuous_at (order_dual.to_dual ∘ f) (Inf s), from Cf) Af ftop
+
+/-- An antitone function continuous at the indexed infimum over a nonempty `Sort` sends this indexed
+infimum to the indexed supremum of the composition. -/
+lemma map_infi_of_continuous_at_of_antitone' {ι : Sort*} [nonempty ι] {f : α → β} {g : ι → α}
+  (Cf : continuous_at f (infi g)) (Af : antitone f) :
+  f (⨅ i, g i) = ⨆ i, f (g i) :=
+map_infi_of_continuous_at_of_monotone'
+  (show continuous_at (order_dual.to_dual ∘ f) (infi g), from Cf) Af
+
+/-- If an antitone function sending `top` to `bot` is continuous at the indexed infimum over
+a `Sort`, then it sends this indexed infimum to the indexed supremum of the composition. -/
+lemma map_infi_of_continuous_at_of_antitone {ι : Sort*} {f : α → β} {g : ι → α}
+  (Cf : continuous_at f (infi g)) (Af : antitone f) (ftop : f ⊤ = ⊥) :
+  f (infi g) = supr (f ∘ g) :=
+map_infi_of_continuous_at_of_monotone
+  (show continuous_at (order_dual.to_dual ∘ f) (infi g), from Cf) Af ftop
 
 end complete_linear_order
 
@@ -2863,90 +2933,3 @@ lemma monotone.tendsto_nhds_within_Ioi
 end conditionally_complete_linear_order
 
 end order_topology
-
-section monotone
-
-private lemma continuous_Inf_le_Sup_continuous {R S : Type*}
-  [complete_linear_order R] [topological_space R] [order_topology R]
-  [complete_linear_order S] [topological_space S] [order_closed_topology S]
-  {f : R → S} (f_cont : continuous f)
-  (A : set R) (hA : A.nonempty):
-  f (Inf A) ≤ Sup (f '' A) :=
-begin
-  refine le_Sup_iff.mpr _,
-  intros b hb,
-  have InfA_mem_clA : Inf A ∈ closure A, from Inf_mem_closure hA,
-  have aux := @continuous.continuous_on _ _ _ _ f (closure A) f_cont,
-  have key := (continuous_on.image_closure aux).trans (closure_mono (show f '' A ⊆ Iic b, from hb)),
-  simpa [closure_Iic] using key (mem_image_of_mem f InfA_mem_clA),
-end
-
-lemma antitone.Sup_image_eq_apply_Inf {R S : Type*}
-  [complete_linear_order R] [topological_space R] [order_topology R]
-  [complete_linear_order S] [topological_space S]
-  [order_topology S] -- was: [order_closed_topology S]
-  {f : R → S} (f_decr : antitone f) (f_cont : continuous f)
-  (A : set R) (hA : A.nonempty):
-  Sup (f '' A) = f (Inf A) :=
-begin
-  -- The working version proof was:
-  -- `le_antisymm (f_decr.Sup_image_le A) (continuous_Inf_le_Sup_continuous f_cont A hA)`
-
-  -- It indeed looks like the previously existing `antitone.le_map_Inf f_decr` would be
-  -- similar, but I fail to fill in the sorry with it. This is the reason I originally had to
-  -- introduce the new lemmas `antitone.Sup_image_le` etc.
-
-  -- (That the assumption in the existing lemma is somewhat more stringent is not an issue
-  -- for me, even the weaker result would be good enough to me, but I can't get it to work.)
-
-  apply le_antisymm _ (continuous_Inf_le_Sup_continuous f_cont A hA),
-
-  have similar_to_goal := @antitone.le_map_Inf R S _ _ A f f_decr, -- Why is this not enough?
-
-  convert similar_to_goal,
-
-  ext x,
-  split,
-  { intros hx,
-    rcases hx with ⟨r, ⟨r_in_A, fr_eq_x⟩⟩,
-    use r,
-    simp only [fr_eq_x, r_in_A, csupr_pos], },
-  { intros hx,
-    rcases hx with ⟨r, hr⟩,
-    use r,
-    split,
-    sorry, -- How to proceed?
-    sorry, -- How to proceed?
-    },
-end
-
-lemma antitone.Inf_image_eq_apply_Sup {R S : Type*}
-  [complete_linear_order R] [topological_space R] [order_topology R]
-  [complete_linear_order S] [topological_space S] [order_topology S]
-  {f : R → S} (f_decr : antitone f) (f_cont : continuous f)
-  (A : set R) (hA : A.nonempty):
-  Inf (f '' A) = f (Sup A) :=
-begin
-  have this : continuous (order_dual.to_dual ∘ f) := f_cont,
-  exact (map_Sup_of_continuous_at_of_monotone' this.continuous_at f_decr hA).symm,
-end
-
-lemma monotone.Inf_image_eq_apply_Inf {R S : Type*}
-  [complete_linear_order R] [topological_space R] [order_topology R]
-  [complete_linear_order S] [topological_space S]
-  [order_topology S] -- was: [order_closed_topology S]
-  {f : R → S} (f_incr : monotone f) (f_cont : continuous f)
-  (A : set R) (hA : A.nonempty):
-  Inf (f '' A) = f (Inf A) :=
-f_incr.dual_left.Inf_image_eq_apply_Sup f_cont A hA
-
-lemma monotone.Sup_image_eq_apply_Sup {R S : Type*}
-  [complete_linear_order R] [topological_space R] [order_topology R]
-  [complete_linear_order S] [topological_space S]
-  [order_topology S] -- was: [order_closed_topology S]
-  {f : R → S} (f_incr : monotone f) (f_cont : continuous f)
-  (A : set R) (hA : A.nonempty):
-  Sup (f '' A) = f (Sup A) :=
-f_incr.dual.Inf_image_eq_apply_Inf f_cont A hA
-
-end monotone

--- a/src/topology/algebra/order/basic.lean
+++ b/src/topology/algebra/order/basic.lean
@@ -2891,11 +2891,14 @@ le_antisymm (f_decr.Sup_image_le A) (continuous_Inf_le_Sup_continuous f_cont A h
 
 lemma antitone.Inf_image_eq_apply_Sup {R S : Type*}
   [complete_linear_order R] [topological_space R] [order_topology R]
-  [complete_linear_order S] [topological_space S] [order_closed_topology S]
+  [complete_linear_order S] [topological_space S] [order_topology S]
   {f : R → S} (f_decr : antitone f) (f_cont : continuous f)
   (A : set R) (hA : A.nonempty):
   Inf (f '' A) = f (Sup A) :=
-f_decr.dual.Sup_image_eq_apply_Inf f_cont A hA
+begin
+  have this : continuous (order_dual.to_dual ∘ f) := f_cont,
+  exact (map_Sup_of_continuous_at_of_monotone' this.continuous_at f_decr hA).symm,
+end
 
 lemma monotone.Inf_image_eq_apply_Inf {R S : Type*}
   [complete_linear_order R] [topological_space R] [order_topology R]

--- a/src/topology/algebra/order/basic.lean
+++ b/src/topology/algebra/order/basic.lean
@@ -2722,7 +2722,7 @@ lemma is_closed.Inf_mem {α : Type u} [topological_space α] [complete_linear_or
 
 /-- A monotone function continuous at the supremum of a nonempty set sends this supremum to
 the supremum of the image of this set. -/
-lemma map_Sup_of_continuous_at_of_monotone' {f : α → β} {s : set α} (Cf : continuous_at f (Sup s))
+lemma monotone.map_Sup_of_continuous_at' {f : α → β} {s : set α} (Cf : continuous_at f (Sup s))
   (Mf : monotone f) (hs : s.nonempty) :
   f (Sup s) = Sup (f '' s) :=
 --This is a particular case of the more general is_lub.is_lub_of_tendsto
@@ -2731,125 +2731,119 @@ lemma map_Sup_of_continuous_at_of_monotone' {f : α → β} {s : set α} (Cf : c
 
 /-- A monotone function `f` sending `bot` to `bot` and continuous at the supremum of a set sends
 this supremum to the supremum of the image of this set. -/
-lemma map_Sup_of_continuous_at_of_monotone {f : α → β} {s : set α} (Cf : continuous_at f (Sup s))
+lemma monotone.map_Sup_of_continuous_at {f : α → β} {s : set α} (Cf : continuous_at f (Sup s))
   (Mf : monotone f) (fbot : f ⊥ = ⊥) :
   f (Sup s) = Sup (f '' s) :=
 begin
   cases s.eq_empty_or_nonempty with h h,
   { simp [h, fbot] },
-  { exact map_Sup_of_continuous_at_of_monotone' Cf Mf h }
+  { exact monotone.map_Sup_of_continuous_at' Cf Mf h }
 end
 
 /-- A monotone function continuous at the indexed supremum over a nonempty `Sort` sends this indexed
 supremum to the indexed supremum of the composition. -/
-lemma map_supr_of_continuous_at_of_monotone' {ι : Sort*} [nonempty ι] {f : α → β} {g : ι → α}
+lemma monotone.map_supr_of_continuous_at' {ι : Sort*} [nonempty ι] {f : α → β} {g : ι → α}
   (Cf : continuous_at f (supr g)) (Mf : monotone f) :
   f (⨆ i, g i) = ⨆ i, f (g i) :=
-by rw [supr, map_Sup_of_continuous_at_of_monotone' Cf Mf (range_nonempty g), ← range_comp, supr]
+by rw [supr, monotone.map_Sup_of_continuous_at' Cf Mf (range_nonempty g), ← range_comp, supr]
 
 /-- If a monotone function sending `bot` to `bot` is continuous at the indexed supremum over
 a `Sort`, then it sends this indexed supremum to the indexed supremum of the composition. -/
-lemma map_supr_of_continuous_at_of_monotone {ι : Sort*} {f : α → β} {g : ι → α}
+lemma monotone.map_supr_of_continuous_at {ι : Sort*} {f : α → β} {g : ι → α}
   (Cf : continuous_at f (supr g)) (Mf : monotone f) (fbot : f ⊥ = ⊥) :
   f (⨆ i, g i) = ⨆ i, f (g i) :=
-by rw [supr, map_Sup_of_continuous_at_of_monotone Cf Mf fbot, ← range_comp, supr]
+by rw [supr, monotone.map_Sup_of_continuous_at Cf Mf fbot, ← range_comp, supr]
 
 /-- A monotone function continuous at the infimum of a nonempty set sends this infimum to
 the infimum of the image of this set. -/
-lemma map_Inf_of_continuous_at_of_monotone' {f : α → β} {s : set α} (Cf : continuous_at f (Inf s))
+lemma monotone.map_Inf_of_continuous_at' {f : α → β} {s : set α} (Cf : continuous_at f (Inf s))
   (Mf : monotone f) (hs : s.nonempty) :
   f (Inf s) = Inf (f '' s) :=
-@map_Sup_of_continuous_at_of_monotone' αᵒᵈ βᵒᵈ _ _ _ _ _ _ f s Cf Mf.dual hs
+@monotone.map_Sup_of_continuous_at' αᵒᵈ βᵒᵈ _ _ _ _ _ _ f s Cf Mf.dual hs
 
 /-- A monotone function `f` sending `top` to `top` and continuous at the infimum of a set sends
 this infimum to the infimum of the image of this set. -/
-lemma map_Inf_of_continuous_at_of_monotone {f : α → β} {s : set α} (Cf : continuous_at f (Inf s))
+lemma monotone.map_Inf_of_continuous_at {f : α → β} {s : set α} (Cf : continuous_at f (Inf s))
   (Mf : monotone f) (ftop : f ⊤ = ⊤) :
   f (Inf s) = Inf (f '' s) :=
-@map_Sup_of_continuous_at_of_monotone αᵒᵈ βᵒᵈ _ _ _ _ _ _ f s Cf Mf.dual ftop
+@monotone.map_Sup_of_continuous_at αᵒᵈ βᵒᵈ _ _ _ _ _ _ f s Cf Mf.dual ftop
 
 /-- A monotone function continuous at the indexed infimum over a nonempty `Sort` sends this indexed
 infimum to the indexed infimum of the composition. -/
-lemma map_infi_of_continuous_at_of_monotone' {ι : Sort*} [nonempty ι] {f : α → β} {g : ι → α}
+lemma monotone.map_infi_of_continuous_at' {ι : Sort*} [nonempty ι] {f : α → β} {g : ι → α}
   (Cf : continuous_at f (infi g)) (Mf : monotone f) :
   f (⨅ i, g i) = ⨅ i, f (g i) :=
-@map_supr_of_continuous_at_of_monotone' αᵒᵈ βᵒᵈ _ _ _ _ _ _ ι _ f g Cf Mf.dual
+@monotone.map_supr_of_continuous_at' αᵒᵈ βᵒᵈ _ _ _ _ _ _ ι _ f g Cf Mf.dual
 
 /-- If a monotone function sending `top` to `top` is continuous at the indexed infimum over
 a `Sort`, then it sends this indexed infimum to the indexed infimum of the composition. -/
-lemma map_infi_of_continuous_at_of_monotone {ι : Sort*} {f : α → β} {g : ι → α}
+lemma monotone.map_infi_of_continuous_at {ι : Sort*} {f : α → β} {g : ι → α}
   (Cf : continuous_at f (infi g)) (Mf : monotone f) (ftop : f ⊤ = ⊤) :
   f (infi g) = infi (f ∘ g) :=
-@map_supr_of_continuous_at_of_monotone αᵒᵈ βᵒᵈ _ _ _ _ _ _ ι f g Cf Mf.dual ftop
-
-
-
-
-
-
+@monotone.map_supr_of_continuous_at αᵒᵈ βᵒᵈ _ _ _ _ _ _ ι f g Cf Mf.dual ftop
 
 /-- An antitone function continuous at the supremum of a nonempty set sends this supremum to
 the infimum of the image of this set. -/
-lemma map_Sup_of_continuous_at_of_antitone' {f : α → β} {s : set α} (Cf : continuous_at f (Sup s))
+lemma antitone.map_Sup_of_continuous_at' {f : α → β} {s : set α} (Cf : continuous_at f (Sup s))
   (Af : antitone f) (hs : s.nonempty) :
   f (Sup s) = Inf (f '' s) :=
-map_Sup_of_continuous_at_of_monotone'
+monotone.map_Sup_of_continuous_at'
   (show continuous_at (order_dual.to_dual ∘ f) (Sup s), from Cf) Af hs
 
 /-- An antitone function `f` sending `bot` to `top` and continuous at the supremum of a set sends
 this supremum to the infimum of the image of this set. -/
-lemma map_Sup_of_continuous_at_of_antitone {f : α → β} {s : set α} (Cf : continuous_at f (Sup s))
+lemma antitone.map_Sup_of_continuous_at {f : α → β} {s : set α} (Cf : continuous_at f (Sup s))
   (Af : antitone f) (fbot : f ⊥ = ⊤) :
   f (Sup s) = Inf (f '' s) :=
-map_Sup_of_continuous_at_of_monotone
+monotone.map_Sup_of_continuous_at
   (show continuous_at (order_dual.to_dual ∘ f) (Sup s), from Cf) Af fbot
 
 /-- An antitone function continuous at the indexed supremum over a nonempty `Sort` sends this
 indexed supremum to the indexed infimum of the composition. -/
-lemma map_supr_of_continuous_at_of_antitone' {ι : Sort*} [nonempty ι] {f : α → β} {g : ι → α}
+lemma antitone.map_supr_of_continuous_at' {ι : Sort*} [nonempty ι] {f : α → β} {g : ι → α}
   (Cf : continuous_at f (supr g)) (Af : antitone f) :
   f (⨆ i, g i) = ⨅ i, f (g i) :=
-map_supr_of_continuous_at_of_monotone'
+monotone.map_supr_of_continuous_at'
   (show continuous_at (order_dual.to_dual ∘ f) (supr g), from Cf) Af
 
 /-- An antitone function sending `bot` to `top` is continuous at the indexed supremum over
 a `Sort`, then it sends this indexed supremum to the indexed supremum of the composition. -/
-lemma map_supr_of_continuous_at_of_antitone {ι : Sort*} {f : α → β} {g : ι → α}
+lemma antitone.map_supr_of_continuous_at {ι : Sort*} {f : α → β} {g : ι → α}
   (Cf : continuous_at f (supr g)) (Af : antitone f) (fbot : f ⊥ = ⊤) :
   f (⨆ i, g i) = ⨅ i, f (g i) :=
-map_supr_of_continuous_at_of_monotone
+monotone.map_supr_of_continuous_at
   (show continuous_at (order_dual.to_dual ∘ f) (supr g), from Cf) Af fbot
 
 /-- An antitone function continuous at the infimum of a nonempty set sends this infimum to
 the supremum of the image of this set. -/
-lemma map_Inf_of_continuous_at_of_antitone' {f : α → β} {s : set α} (Cf : continuous_at f (Inf s))
+lemma antitone.map_Inf_of_continuous_at' {f : α → β} {s : set α} (Cf : continuous_at f (Inf s))
   (Af : antitone f) (hs : s.nonempty) :
   f (Inf s) = Sup (f '' s) :=
-map_Inf_of_continuous_at_of_monotone'
+monotone.map_Inf_of_continuous_at'
   (show continuous_at (order_dual.to_dual ∘ f) (Inf s), from Cf) Af hs
 
 /-- An antitone function `f` sending `top` to `bot` and continuous at the infimum of a set sends
 this infimum to the supremum of the image of this set. -/
-lemma map_Inf_of_continuous_at_of_antitone {f : α → β} {s : set α} (Cf : continuous_at f (Inf s))
+lemma antitone.map_Inf_of_continuous_at {f : α → β} {s : set α} (Cf : continuous_at f (Inf s))
   (Af : antitone f) (ftop : f ⊤ = ⊥) :
   f (Inf s) = Sup (f '' s) :=
-map_Inf_of_continuous_at_of_monotone
+monotone.map_Inf_of_continuous_at
   (show continuous_at (order_dual.to_dual ∘ f) (Inf s), from Cf) Af ftop
 
 /-- An antitone function continuous at the indexed infimum over a nonempty `Sort` sends this indexed
 infimum to the indexed supremum of the composition. -/
-lemma map_infi_of_continuous_at_of_antitone' {ι : Sort*} [nonempty ι] {f : α → β} {g : ι → α}
+lemma antitone.map_infi_of_continuous_at' {ι : Sort*} [nonempty ι] {f : α → β} {g : ι → α}
   (Cf : continuous_at f (infi g)) (Af : antitone f) :
   f (⨅ i, g i) = ⨆ i, f (g i) :=
-map_infi_of_continuous_at_of_monotone'
+monotone.map_infi_of_continuous_at'
   (show continuous_at (order_dual.to_dual ∘ f) (infi g), from Cf) Af
 
 /-- If an antitone function sending `top` to `bot` is continuous at the indexed infimum over
 a `Sort`, then it sends this indexed infimum to the indexed supremum of the composition. -/
-lemma map_infi_of_continuous_at_of_antitone {ι : Sort*} {f : α → β} {g : ι → α}
+lemma antitone.map_infi_of_continuous_at {ι : Sort*} {f : α → β} {g : ι → α}
   (Cf : continuous_at f (infi g)) (Af : antitone f) (ftop : f ⊤ = ⊥) :
   f (infi g) = supr (f ∘ g) :=
-map_infi_of_continuous_at_of_monotone
+monotone.map_infi_of_continuous_at
   (show continuous_at (order_dual.to_dual ∘ f) (infi g), from Cf) Af ftop
 
 end complete_linear_order
@@ -2857,7 +2851,8 @@ end complete_linear_order
 section conditionally_complete_linear_order
 
 variables [conditionally_complete_linear_order α] [topological_space α] [order_topology α]
-  [conditionally_complete_linear_order β] [topological_space β] [order_topology β] [nonempty γ]
+  [conditionally_complete_linear_order β] [topological_space β] [order_closed_topology β]
+  [nonempty γ]
 
 lemma cSup_mem_closure {s : set α} (hs : s.nonempty) (B : bdd_above s) : Sup s ∈ closure s :=
 (is_lub_cSup hs B).mem_closure hs
@@ -2875,7 +2870,7 @@ lemma is_closed.cInf_mem {s : set α} (hc : is_closed s) (hs : s.nonempty) (B : 
 
 /-- If a monotone function is continuous at the supremum of a nonempty bounded above set `s`,
 then it sends this supremum to the supremum of the image of `s`. -/
-lemma map_cSup_of_continuous_at_of_monotone {f : α → β} {s : set α} (Cf : continuous_at f (Sup s))
+lemma monotone.map_cSup_of_continuous_at {f : α → β} {s : set α} (Cf : continuous_at f (Sup s))
   (Mf : monotone f) (ne : s.nonempty) (H : bdd_above s) :
   f (Sup s) = Sup (f '' s) :=
 begin
@@ -2886,28 +2881,61 @@ end
 
 /-- If a monotone function is continuous at the indexed supremum of a bounded function on
 a nonempty `Sort`, then it sends this supremum to the supremum of the composition. -/
-lemma map_csupr_of_continuous_at_of_monotone {f : α → β} {g : γ → α}
+lemma monotone.map_csupr_of_continuous_at {f : α → β} {g : γ → α}
   (Cf : continuous_at f (⨆ i, g i)) (Mf : monotone f) (H : bdd_above (range g)) :
   f (⨆ i, g i) = ⨆ i, f (g i) :=
-by rw [supr, map_cSup_of_continuous_at_of_monotone Cf Mf (range_nonempty _) H, ← range_comp, supr]
+by rw [supr, monotone.map_cSup_of_continuous_at Cf Mf (range_nonempty _) H, ← range_comp, supr]
 
 /-- If a monotone function is continuous at the infimum of a nonempty bounded below set `s`,
 then it sends this infimum to the infimum of the image of `s`. -/
-lemma map_cInf_of_continuous_at_of_monotone {f : α → β} {s : set α} (Cf : continuous_at f (Inf s))
+lemma monotone.map_cInf_of_continuous_at {f : α → β} {s : set α} (Cf : continuous_at f (Inf s))
   (Mf : monotone f) (ne : s.nonempty) (H : bdd_below s) :
   f (Inf s) = Inf (f '' s) :=
-@map_cSup_of_continuous_at_of_monotone αᵒᵈ βᵒᵈ _ _ _ _ _ _ f s Cf Mf.dual ne H
+@monotone.map_cSup_of_continuous_at αᵒᵈ βᵒᵈ _ _ _ _ _ _ f s Cf Mf.dual ne H
 
 /-- A continuous monotone function sends indexed infimum to indexed infimum in conditionally
 complete linear order, under a boundedness assumption. -/
-lemma map_cinfi_of_continuous_at_of_monotone {f : α → β} {g : γ → α}
+lemma monotone.map_cinfi_of_continuous_at {f : α → β} {g : γ → α}
   (Cf : continuous_at f (⨅ i, g i)) (Mf : monotone f) (H : bdd_below (range g)) :
   f (⨅ i, g i) = ⨅ i, f (g i) :=
-@map_csupr_of_continuous_at_of_monotone αᵒᵈ βᵒᵈ _ _ _ _ _ _ _ _ _ _ Cf Mf.dual H
+@monotone.map_csupr_of_continuous_at αᵒᵈ βᵒᵈ _ _ _ _ _ _ _ _ _ _ Cf Mf.dual H
+
+/-- If an antitone function is continuous at the supremum of a nonempty bounded above set `s`,
+then it sends this supremum to the infimum of the image of `s`. -/
+lemma antitone.map_cSup_of_continuous_at {f : α → β} {s : set α} (Cf : continuous_at f (Sup s))
+  (Af : antitone f) (ne : s.nonempty) (H : bdd_above s) :
+  f (Sup s) = Inf (f '' s) :=
+monotone.map_cSup_of_continuous_at
+  (show continuous_at (order_dual.to_dual ∘ f) (Sup s), from Cf) Af ne H
+
+/-- If an antitone function is continuous at the indexed supremum of a bounded function on
+a nonempty `Sort`, then it sends this supremum to the infimum of the composition. -/
+lemma antitone.map_csupr_of_continuous_at {f : α → β} {g : γ → α}
+  (Cf : continuous_at f (⨆ i, g i)) (Af : antitone f) (H : bdd_above (range g)) :
+  f (⨆ i, g i) = ⨅ i, f (g i) :=
+monotone.map_csupr_of_continuous_at
+  (show continuous_at (order_dual.to_dual ∘ f) (⨆ i, g i), from Cf) Af H
+
+/-- If an antitone function is continuous at the infimum of a nonempty bounded below set `s`,
+then it sends this infimum to the supremum of the image of `s`. -/
+lemma antitone.map_cInf_of_continuous_at {f : α → β} {s : set α} (Cf : continuous_at f (Inf s))
+  (Af : antitone f) (ne : s.nonempty) (H : bdd_below s) :
+  f (Inf s) = Sup (f '' s) :=
+monotone.map_cInf_of_continuous_at
+  (show continuous_at (order_dual.to_dual ∘ f) (Inf s), from Cf) Af ne H
+
+/-- A continuous antitone function sends indexed infimum to indexed supremum in conditionally
+complete linear order, under a boundedness assumption. -/
+lemma antitone.map_cinfi_of_continuous_at {f : α → β} {g : γ → α}
+  (Cf : continuous_at f (⨅ i, g i)) (Af : antitone f) (H : bdd_below (range g)) :
+  f (⨅ i, g i) = ⨆ i, f (g i) :=
+monotone.map_cinfi_of_continuous_at
+  (show continuous_at (order_dual.to_dual ∘ f) (⨅ i, g i), from Cf) Af H
 
 /-- A monotone map has a limit to the left of any point `x`, equal to `Sup (f '' (Iio x))`. -/
 lemma monotone.tendsto_nhds_within_Iio
-  {α : Type*} [linear_order α] [topological_space α] [order_topology α]
+  {α β : Type*} [linear_order α] [topological_space α] [order_topology α]
+  [conditionally_complete_linear_order β] [topological_space β] [order_topology β]
   {f : α → β} (Mf : monotone f) (x : α) :
   tendsto f (𝓝[<] x) (𝓝 (Sup (f '' (Iio x)))) :=
 begin
@@ -2926,9 +2954,10 @@ end
 /-- A monotone map has a limit to the right of any point `x`, equal to `Inf (f '' (Ioi x))`. -/
 lemma monotone.tendsto_nhds_within_Ioi
   {α : Type*} [linear_order α] [topological_space α] [order_topology α]
+  {β : Type*} [conditionally_complete_linear_order β] [topological_space β] [order_topology β]
   {f : α → β} (Mf : monotone f) (x : α) :
   tendsto f (𝓝[>] x) (𝓝 (Inf (f '' (Ioi x)))) :=
-@monotone.tendsto_nhds_within_Iio βᵒᵈ _ _ _ αᵒᵈ _ _ _ f Mf.dual x
+@monotone.tendsto_nhds_within_Iio αᵒᵈ βᵒᵈ _ _ _ _ _ _ f Mf.dual x
 
 end conditionally_complete_linear_order
 

--- a/src/topology/algebra/order/basic.lean
+++ b/src/topology/algebra/order/basic.lean
@@ -2863,3 +2863,54 @@ lemma monotone.tendsto_nhds_within_Ioi
 end conditionally_complete_linear_order
 
 end order_topology
+
+section monotone
+
+private lemma continuous_Inf_le_Sup_continuous {R S : Type*}
+  [complete_linear_order R] [topological_space R] [order_topology R]
+  [complete_linear_order S] [topological_space S] [order_closed_topology S]
+  {f : R → S} (f_cont : continuous f)
+  (A : set R) (hA : A.nonempty):
+  f (Inf A) ≤ Sup (f '' A) :=
+begin
+  refine le_Sup_iff.mpr _,
+  intros b hb,
+  have InfA_mem_clA : Inf A ∈ closure A, from Inf_mem_closure hA,
+  have aux := @continuous.continuous_on _ _ _ _ f (closure A) f_cont,
+  have key := (continuous_on.image_closure aux).trans (closure_mono (show f '' A ⊆ Iic b, from hb)),
+  simpa [closure_Iic] using key (mem_image_of_mem f InfA_mem_clA),
+end
+
+lemma antitone.Sup_image_eq_apply_Inf {R S : Type*}
+  [complete_linear_order R] [topological_space R] [order_topology R]
+  [complete_linear_order S] [topological_space S] [order_closed_topology S]
+  {f : R → S} (f_decr : antitone f) (f_cont : continuous f)
+  (A : set R) (hA : A.nonempty):
+  Sup (f '' A) = f (Inf A) :=
+le_antisymm (f_decr.Sup_image_le A) (continuous_Inf_le_Sup_continuous f_cont A hA)
+
+lemma antitone.Inf_image_eq_apply_Sup {R S : Type*}
+  [complete_linear_order R] [topological_space R] [order_topology R]
+  [complete_linear_order S] [topological_space S] [order_closed_topology S]
+  {f : R → S} (f_decr : antitone f) (f_cont : continuous f)
+  (A : set R) (hA : A.nonempty):
+  Inf (f '' A) = f (Sup A) :=
+f_decr.dual.Sup_image_eq_apply_Inf f_cont A hA
+
+lemma monotone.Inf_image_eq_apply_Inf {R S : Type*}
+  [complete_linear_order R] [topological_space R] [order_topology R]
+  [complete_linear_order S] [topological_space S] [order_closed_topology S]
+  {f : R → S} (f_incr : monotone f) (f_cont : continuous f)
+  (A : set R) (hA : A.nonempty):
+  Inf (f '' A) = f (Inf A) :=
+f_incr.dual_left.Inf_image_eq_apply_Sup f_cont A hA
+
+lemma monotone.Sup_image_eq_apply_Sup {R S : Type*}
+  [complete_linear_order R] [topological_space R] [order_topology R]
+  [complete_linear_order S] [topological_space S] [order_closed_topology S]
+  {f : R → S} (f_incr : monotone f) (f_cont : continuous f)
+  (A : set R) (hA : A.nonempty):
+  Sup (f '' A) = f (Sup A) :=
+f_incr.dual.Inf_image_eq_apply_Inf f_cont A hA
+
+end monotone

--- a/src/topology/algebra/order/basic.lean
+++ b/src/topology/algebra/order/basic.lean
@@ -2737,7 +2737,7 @@ lemma monotone.map_Sup_of_continuous_at {f : α → β} {s : set α} (Cf : conti
 begin
   cases s.eq_empty_or_nonempty with h h,
   { simp [h, fbot] },
-  { exact monotone.map_Sup_of_continuous_at' Cf Mf h }
+  { exact Mf.map_Sup_of_continuous_at' Cf h }
 end
 
 /-- A monotone function continuous at the indexed supremum over a nonempty `Sort` sends this indexed
@@ -2745,14 +2745,14 @@ supremum to the indexed supremum of the composition. -/
 lemma monotone.map_supr_of_continuous_at' {ι : Sort*} [nonempty ι] {f : α → β} {g : ι → α}
   (Cf : continuous_at f (supr g)) (Mf : monotone f) :
   f (⨆ i, g i) = ⨆ i, f (g i) :=
-by rw [supr, monotone.map_Sup_of_continuous_at' Cf Mf (range_nonempty g), ← range_comp, supr]
+by rw [supr, Mf.map_Sup_of_continuous_at' Cf (range_nonempty g), ← range_comp, supr]
 
 /-- If a monotone function sending `bot` to `bot` is continuous at the indexed supremum over
 a `Sort`, then it sends this indexed supremum to the indexed supremum of the composition. -/
 lemma monotone.map_supr_of_continuous_at {ι : Sort*} {f : α → β} {g : ι → α}
   (Cf : continuous_at f (supr g)) (Mf : monotone f) (fbot : f ⊥ = ⊥) :
   f (⨆ i, g i) = ⨆ i, f (g i) :=
-by rw [supr, monotone.map_Sup_of_continuous_at Cf Mf fbot, ← range_comp, supr]
+by rw [supr, Mf.map_Sup_of_continuous_at Cf fbot, ← range_comp, supr]
 
 /-- A monotone function continuous at the infimum of a nonempty set sends this infimum to
 the infimum of the image of this set. -/
@@ -2884,7 +2884,7 @@ a nonempty `Sort`, then it sends this supremum to the supremum of the compositio
 lemma monotone.map_csupr_of_continuous_at {f : α → β} {g : γ → α}
   (Cf : continuous_at f (⨆ i, g i)) (Mf : monotone f) (H : bdd_above (range g)) :
   f (⨆ i, g i) = ⨆ i, f (g i) :=
-by rw [supr, monotone.map_cSup_of_continuous_at Cf Mf (range_nonempty _) H, ← range_comp, supr]
+by rw [supr, Mf.map_cSup_of_continuous_at Cf (range_nonempty _) H, ← range_comp, supr]
 
 /-- If a monotone function is continuous at the infimum of a nonempty bounded below set `s`,
 then it sends this infimum to the infimum of the image of `s`. -/

--- a/src/topology/algebra/order/liminf_limsup.lean
+++ b/src/topology/algebra/order/liminf_limsup.lean
@@ -195,7 +195,7 @@ variables {ι R S : Type*} {F : filter ι} [ne_bot F]
 /-- A continuous antitone function between complete linear ordered spaces sends a `filter.limsup`
 to the `filter.liminf` of the images. -/
 lemma antitone.map_limsup_of_continuous
-  (a : ι → R) {f : R → S} (f_decr : antitone f) (f_cont : continuous f ) :
+  (a : ι → R) {f : R → S} (f_decr : antitone f) (f_cont : continuous f) :
   f (F.limsup a) = F.liminf (f ∘ a) :=
 begin
   rw [filter.limsup_eq_Inf_Sup, filter.liminf_eq_Sup_Inf] at *,

--- a/src/topology/algebra/order/liminf_limsup.lean
+++ b/src/topology/algebra/order/liminf_limsup.lean
@@ -240,6 +240,13 @@ begin
     exact lt_irrefl _ (B.trans_lt I) }
 end
 
+/-- A continuous antitone function between complete linear ordered spaces sends a `filter.limsup`
+to the `filter.liminf` of the images. -/
+lemma antitone.map_limsup_of_continuous_at
+  {f : R → S} (f_decr : antitone f) (a : ι → R) (f_cont : continuous_at f (F.limsup a)) :
+  f (F.limsup a) = F.liminf (f ∘ a) :=
+f_decr.map_Limsup_of_continuous_at f_cont
+
 /-- An antitone function between complete linear ordered spaces sends a `filter.Liminf`
 to the `filter.limsup` of the image if it is continuous at the `Liminf`. -/
 lemma antitone.map_Liminf_of_continuous_at {F : filter R} [ne_bot F]
@@ -248,6 +255,13 @@ lemma antitone.map_Liminf_of_continuous_at {F : filter R} [ne_bot F]
 @antitone.map_Limsup_of_continuous_at
   (order_dual R) (order_dual S) _ _ _ _ _ _ _ _ f f_decr.dual f_cont
 
+/-- A continuous antitone function between complete linear ordered spaces sends a `filter.liminf`
+to the `filter.limsup` of the images. -/
+lemma antitone.map_liminf_of_continuous_at
+  {f : R → S} (f_decr : antitone f) (a : ι → R) (f_cont : continuous_at f (F.liminf a)) :
+  f (F.liminf a) = F.limsup (f ∘ a) :=
+f_decr.map_Liminf_of_continuous_at f_cont
+
 /-- A monotone function between complete linear ordered spaces sends a `filter.Limsup`
 to the `filter.limsup` of the image if it is continuous at the `Limsup`. -/
 lemma monotone.map_Limsup_of_continuous_at {F : filter R} [ne_bot F]
@@ -255,11 +269,25 @@ lemma monotone.map_Limsup_of_continuous_at {F : filter R} [ne_bot F]
   f (F.Limsup) = F.limsup f :=
 @antitone.map_Limsup_of_continuous_at R (order_dual S) _ _ _ _ _ _ _ _ f f_incr f_cont
 
+/-- A continuous monotone function between complete linear ordered spaces sends a `filter.limsup`
+to the `filter.limsup` of the images. -/
+lemma monotone.map_limsup_of_continuous_at
+  {f : R → S} (f_incr : monotone f) (a : ι → R) (f_cont : continuous_at f (F.limsup a)) :
+  f (F.limsup a) = F.limsup (f ∘ a) :=
+f_incr.map_Limsup_of_continuous_at f_cont
+
 /-- A monotone function between complete linear ordered spaces sends a `filter.Liminf`
 to the `filter.liminf` of the image if it is continuous at the `Liminf`. -/
 lemma monotone.map_Liminf_of_continuous_at {F : filter R} [ne_bot F]
   {f : R → S} (f_incr : monotone f) (f_cont : continuous_at f (F.Liminf)) :
   f (F.Liminf) = F.liminf f :=
 @antitone.map_Liminf_of_continuous_at R (order_dual S) _ _ _ _ _ _ _ _ f f_incr f_cont
+
+/-- A continuous monotone function between complete linear ordered spaces sends a `filter.liminf`
+to the `filter.liminf` of the images. -/
+lemma monotone.map_liminf_of_continuous_at
+  {f : R → S} (f_incr : monotone f) (a : ι → R) (f_cont : continuous_at f (F.liminf a)) :
+  f (F.liminf a) = F.liminf (f ∘ a) :=
+f_incr.map_Liminf_of_continuous_at f_cont
 
 end monotone

--- a/src/topology/algebra/order/liminf_limsup.lean
+++ b/src/topology/algebra/order/liminf_limsup.lean
@@ -190,48 +190,76 @@ section monotone
 
 variables {ι R S : Type*} {F : filter ι} [ne_bot F]
   [complete_linear_order R] [topological_space R] [order_topology R]
-  [complete_linear_order S] [topological_space S] [order_closed_topology S]
+  [complete_linear_order S] [topological_space S] [order_topology S]
 
-/-- A continuous antitone function between complete linear ordered spaces sends a `filter.limsup`
-to the `filter.liminf` of the images. -/
-lemma antitone.map_limsup_of_continuous
-  (a : ι → R) {f : R → S} (f_decr : antitone f) (f_cont : continuous f ) :
-  f (F.limsup a) = F.liminf (f ∘ a) :=
+/-- An antitone function between complete linear ordered spaces sends a `filter.Limsup`
+to the `filter.liminf` of the image if it is continuous at the `Limsup`. -/
+lemma antitone.map_Limsup_of_continuous_at {F : filter R} [ne_bot F]
+  {f : R → S} (f_decr : antitone f) (f_cont : continuous_at f (F.Limsup)) :
+  f (F.Limsup) = F.liminf f :=
 begin
-  rw [filter.limsup_eq_Inf_Sup, filter.liminf_eq_Sup_Inf] at *,
-  rw (f_decr.map_Inf_of_continuous_at' f_cont.continuous_at _),
-  { apply congr_arg,
-    simp only [set.image_image, function.comp_app],
-    refine subset_antisymm _ _;
-    { intros i hi,
-      rw set.mem_image at *,
-      rcases hi with ⟨I, I_mem_F, hI⟩,
-      refine ⟨I, I_mem_F, _⟩,
-      rw [← hI, f_decr.map_Sup_of_continuous_at' f_cont.continuous_at _, set.image_image],
-      exact set.nonempty_image_iff.mpr (ne_bot.nonempty_of_mem ‹ne_bot F› I_mem_F), }, },
-  { refine set.nonempty_image_iff.mpr set.nonempty_of_nonempty_subtype, },
+  apply le_antisymm,
+  { have A : {a : R | ∀ᶠ (n : R) in F, n ≤ a}.nonempty, from ⟨⊤, by simp⟩,
+    rw [Limsup, (f_decr.map_Inf_of_continuous_at' f_cont A)],
+    apply le_of_forall_lt,
+    assume c hc,
+    simp only [liminf, Liminf, lt_Sup_iff, eventually_map, set.mem_set_of_eq, exists_prop,
+      set.mem_image, exists_exists_and_eq_and] at hc ⊢,
+    rcases hc with ⟨d, hd, h'd⟩,
+    refine ⟨f d, _, h'd⟩,
+    filter_upwards [hd] with x hx using f_decr hx },
+  { rcases eq_or_lt_of_le (bot_le : ⊥ ≤ F.Limsup) with h|Limsup_ne_bot,
+    { rw ← h,
+      apply liminf_le_of_frequently_le,
+      apply frequently_of_forall,
+      assume x,
+      exact f_decr bot_le },
+    by_cases h' : ∃ c, c < F.Limsup ∧ set.Ioo c F.Limsup = ∅,
+    { rcases h' with ⟨c, c_lt, hc⟩,
+      have B : ∃ᶠ n in F, F.Limsup ≤ n,
+      { apply (frequently_lt_of_lt_Limsup (by is_bounded_default) c_lt).mono,
+        assume x hx,
+        by_contra',
+        have : (set.Ioo c F.Limsup).nonempty := ⟨x, ⟨hx, this⟩⟩,
+        simpa [hc] },
+      apply liminf_le_of_frequently_le,
+      exact B.mono (λ x hx, f_decr hx) },
+    by_contra' H,
+    obtain ⟨l, l_lt, h'l⟩ : ∃ l < F.Limsup, set.Ioc l F.Limsup ⊆ {x : R | f x < F.liminf f},
+      from exists_Ioc_subset_of_mem_nhds ((tendsto_order.1 f_cont.tendsto).2 _ H)
+        ⟨⊥, Limsup_ne_bot⟩,
+    obtain ⟨m, l_m, m_lt⟩  : (set.Ioo l F.Limsup).nonempty,
+    { contrapose! h',
+      refine ⟨l, l_lt, by rwa set.not_nonempty_iff_eq_empty at h'⟩ },
+    have B : F.liminf f ≤ f m,
+    { apply liminf_le_of_frequently_le,
+      apply (frequently_lt_of_lt_Limsup (by is_bounded_default) m_lt).mono,
+      assume x hx,
+      exact f_decr hx.le },
+    have I : f m < F.liminf f := h'l ⟨l_m, m_lt.le⟩,
+    exact lt_irrefl _ (B.trans_lt I) }
 end
 
-/-- A continuous antitone function between complete linear ordered spaces sends a `filter.liminf`
-to the `filter.limsup` of the images. -/
-lemma antitone.map_liminf_of_continuous
-  (a : ι → R) {f : R → S} (f_decr : antitone f) (f_cont : continuous f) :
-  f (F.liminf a) = F.limsup (f ∘ a) :=
-@antitone.map_limsup_of_continuous ι (order_dual R) (order_dual S)
-  F _ _ _ _ _ _ _ a f f_decr.dual f_cont
+/-- An antitone function between complete linear ordered spaces sends a `filter.Liminf`
+to the `filter.limsup` of the image if it is continuous at the `Liminf`. -/
+lemma antitone.map_Liminf_of_continuous_at {F : filter R} [ne_bot F]
+  {f : R → S} (f_decr : antitone f) (f_cont : continuous_at f (F.Liminf)) :
+  f (F.Liminf) = F.limsup f :=
+@antitone.map_Limsup_of_continuous_at
+  (order_dual R) (order_dual S) _ _ _ _ _ _ _ _ f f_decr.dual f_cont
 
-/-- A continuous monotone function between complete linear ordered spaces sends a `filter.liminf`
-to the `filter.liminf` of the images. -/
-lemma monotone.map_liminf_of_continuous
-  (a : ι → R) {f : R → S} (f_incr : monotone f) (f_cont : continuous f) :
-  f (F.liminf a) = F.liminf (f ∘ a) :=
-@antitone.map_liminf_of_continuous ι R (order_dual S) F _ _ _ _ _ _ _ a f f_incr f_cont
+/-- A monotone function between complete linear ordered spaces sends a `filter.Limsup`
+to the `filter.limsup` of the image if it is continuous at the `Limsup`. -/
+lemma monotone.map_Limsup_of_continuous_at {F : filter R} [ne_bot F]
+  {f : R → S} (f_incr : monotone f) (f_cont : continuous_at f (F.Limsup)) :
+  f (F.Limsup) = F.limsup f :=
+@antitone.map_Limsup_of_continuous_at R (order_dual S) _ _ _ _ _ _ _ _ f f_incr f_cont
 
-/-- A continuous monotone function between complete linear ordered spaces sends a `filter.limsup`
-to the `filter.limsup` of the images. -/
-lemma monotone.map_limsup_of_continuous
-  (a : ι → R) {f : R → S} (f_incr : monotone f) (f_cont : continuous f) :
-  f (F.limsup a) = F.limsup (f ∘ a) :=
-@antitone.map_limsup_of_continuous ι R (order_dual S) F _ _ _ _ _ _ _ a f f_incr f_cont
+/-- A monotone function between complete linear ordered spaces sends a `filter.Liminf`
+to the `filter.liminf` of the image if it is continuous at the `Liminf`. -/
+lemma monotone.map_Liminf_of_continuous_at {F : filter R} [ne_bot F]
+  {f : R → S} (f_incr : monotone f) (f_cont : continuous_at f (F.Liminf)) :
+  f (F.Liminf) = F.liminf f :=
+@antitone.map_Liminf_of_continuous_at R (order_dual S) _ _ _ _ _ _ _ _ f f_incr f_cont
 
 end monotone

--- a/src/topology/algebra/order/liminf_limsup.lean
+++ b/src/topology/algebra/order/liminf_limsup.lean
@@ -219,49 +219,13 @@ lemma _root_.filter.liminf_eq_Sup_Inf
   F.liminf a = Sup ((λ I, Inf (a '' I)) '' F.sets) :=
 @filter.limsup_eq_Inf_Sup ι (order_dual R) _ _ a
 
-/- lemma limsup_eq_Inf_Sup
-  {ι R : Type*} [semilattice_sup ι] [nonempty ι] [complete_lattice R] (a : ι → R) :
-  at_top.limsup a = Inf ((λ i, Sup (a '' (Ici i))) '' univ) :=
-begin
-  refine le_antisymm _ _,
-  { rw limsup_eq,
-    apply Inf_le_Inf,
-    intros x hx,
-    simp only [image_univ, mem_range] at hx,
-    rcases hx with ⟨j, hj⟩,
-    filter_upwards [Ici_mem_at_top j],
-    intros i hij,
-    rw ← hj,
-    exact le_Sup (mem_image_of_mem _ hij), },
-  { rw limsup_eq,
-    apply le_Inf_iff.mpr,
-    intros b hb,
-    simp only [mem_set_of_eq, eventually_at_top] at hb,
-    rcases hb with ⟨j, hj⟩,
-    apply Inf_le_of_le (mem_image_of_mem _ (mem_univ j)),
-    apply Sup_le,
-    intros x hx,
-    simp at hx,
-    rcases hx with ⟨k, j_le_k, ak_eq_x⟩,
-    rw ← ak_eq_x,
-    exact hj k j_le_k, },
-end
-
-lemma liminf_eq_Sup_Inf
-  {ι R : Type*} [semilattice_sup ι] [nonempty ι] [complete_lattice R] (a : ι → R) :
-  at_top.liminf a = Sup ((λ i, Inf (a '' (Ici i))) '' univ) :=
-@limsup_eq_Inf_Sup ι (order_dual R) _ _ _ a
- -/
-
 lemma antitone.liminf_comp_eq_apply_limsup_of_continuous
   {ι R : Type*} {F : filter ι} [ne_bot F]
   [complete_linear_order R] [topological_space R] [order_topology R]
   (a : ι → R) {f : R → R} (f_decr : antitone f) (f_cont : continuous f) :
   F.liminf (f ∘ a) = f (F.limsup a) :=
 begin
-  rw filter.limsup_eq_Inf_Sup,
-  rw filter.liminf_eq_Sup_Inf,
-  rw ←f_decr.Sup_image_eq_apply_Inf f_cont,
+  rw [filter.limsup_eq_Inf_Sup, filter.liminf_eq_Sup_Inf, ←f_decr.Sup_image_eq_apply_Inf f_cont],
   { apply congr_arg,
     simp only [image_image, function.comp_app],
     refine subset_antisymm _ _;
@@ -272,24 +236,6 @@ begin
       rw [← hI, ← f_decr.Inf_image_eq_apply_Sup f_cont _ _, image_image],
       exact nonempty_image_iff.mpr (ne_bot.nonempty_of_mem ‹ne_bot F› I_mem_F), }, },
   { refine nonempty_image_iff.mpr nonempty_of_nonempty_subtype, },
-end
-
-lemma antitone.liminf_comp_eq_apply_limsup_of_continuous'
-  {ι R : Type*} [semilattice_sup ι] [nonempty ι]
-  [complete_linear_order R] [topological_space R] [order_topology R]
-  (a : ι → R) {f : R → R} (f_decr : antitone f) (f_cont : continuous f) :
-  at_top.liminf (f ∘ a) = f (at_top.limsup a) :=
-begin
-  --rw @limsup_eq_infi_supr R ι _ at_top a,
-  --rw @liminf_eq_supr_infi R ι _ at_top (f ∘ a),
-  rw [limsup_eq_Inf_Sup, liminf_eq_Sup_Inf,
-      ←f_decr.Sup_image_eq_apply_Inf f_cont _ (nonempty_image_iff.mpr (@univ_nonempty ι _))],
-  apply congr_arg,
-  simp_rw [image_image, function.comp_app, image_univ],
-  apply congr_arg,
-  funext n,
-  rw ← f_decr.Inf_image_eq_apply_Sup f_cont _ (nonempty_image_iff.mpr nonempty_Ici),
-  simp_rw image_image,
 end
 
 lemma antitone.limsup_comp_eq_apply_liminf_of_continuous

--- a/src/topology/algebra/order/liminf_limsup.lean
+++ b/src/topology/algebra/order/liminf_limsup.lean
@@ -190,10 +190,12 @@ section monotone
 
 open set
 
-lemma antitone.map_limsup_of_continuous
-  {ι R : Type*} {F : filter ι} [ne_bot F]
+variables {ι R S : Type*} {F : filter ι} [ne_bot F]
   [complete_linear_order R] [topological_space R] [order_topology R]
-  (a : ι → R) {f : R → R} (f_decr : antitone f) (f_cont : continuous f ) :
+  [complete_linear_order S] [topological_space S] [order_topology S]
+
+lemma antitone.map_limsup_of_continuous
+  (a : ι → R) {f : R → S} (f_decr : antitone f) (f_cont : continuous f ) :
   f (F.limsup a) = F.liminf (f ∘ a) :=
 begin
   rw [filter.limsup_eq_Inf_Sup, filter.liminf_eq_Sup_Inf] at *,
@@ -211,10 +213,19 @@ begin
 end
 
 lemma antitone.map_liminf_of_continuous
-  {ι R : Type*} {F : filter ι} [ne_bot F]
-  [complete_linear_order R] [topological_space R] [order_topology R]
-  (a : ι → R) {f : R → R} (f_decr : antitone f) (f_cont : continuous f) :
+  (a : ι → R) {f : R → S} (f_decr : antitone f) (f_cont : continuous f) :
   f (F.liminf a) = F.limsup (f ∘ a) :=
-@antitone.map_limsup_of_continuous ι (order_dual R) F _ _ _ _ a f f_decr.dual f_cont
+@antitone.map_limsup_of_continuous ι (order_dual R) (order_dual S)
+  F _ _ _ _ _ _ _ a f f_decr.dual f_cont
+
+lemma monotone.map_liminf_of_continuous
+  (a : ι → R) {f : R → S} (f_incr : monotone f) (f_cont : continuous f) :
+  f (F.liminf a) = F.liminf (f ∘ a) :=
+@antitone.map_liminf_of_continuous ι R (order_dual S) F _ _ _ _ _ _ _ a f f_incr f_cont
+
+lemma monotone.map_limsup_of_continuous
+  (a : ι → R) {f : R → S} (f_incr : monotone f) (f_cont : continuous f) :
+  f (F.limsup a) = F.limsup (f ∘ a) :=
+@antitone.map_limsup_of_continuous ι R (order_dual S) F _ _ _ _ _ _ _ a f f_incr f_cont
 
 end monotone

--- a/src/topology/algebra/order/liminf_limsup.lean
+++ b/src/topology/algebra/order/liminf_limsup.lean
@@ -190,7 +190,7 @@ section monotone
 
 variables {ι R S : Type*} {F : filter ι} [ne_bot F]
   [complete_linear_order R] [topological_space R] [order_topology R]
-  [complete_linear_order S] [topological_space S] [order_topology S]
+  [complete_linear_order S] [topological_space S] [order_closed_topology S]
 
 /-- A continuous antitone function between complete linear ordered spaces sends a `filter.limsup`
 to the `filter.liminf` of the images. -/

--- a/src/topology/algebra/order/liminf_limsup.lean
+++ b/src/topology/algebra/order/liminf_limsup.lean
@@ -190,35 +190,6 @@ section monotone
 
 open set
 
-lemma _root_.filter.limsup_eq_Inf_Sup
-  {ι R : Type*} (F : filter ι) [complete_lattice R] (a : ι → R) :
-  F.limsup a = Inf ((λ I, Sup (a '' I)) '' F.sets) :=
-begin
-  refine le_antisymm _ _,
-  { rw limsup_eq,
-    apply Inf_le_Inf,
-    intros x hx,
-    rcases (mem_image _ F.sets x).mp hx with ⟨I, ⟨I_mem_F, hI⟩⟩,
-    filter_upwards [I_mem_F] with i hi,
-    rw ← hI,
-    exact le_Sup (mem_image_of_mem _ hi), },
-  { rw limsup_eq,
-    apply le_Inf_iff.mpr,
-    intros b hb,
-    simp only [mem_set_of_eq, filter.eventually] at hb,
-    apply Inf_le_of_le (mem_image_of_mem _ (filter.mem_sets.mpr hb)),
-    apply Sup_le,
-    intros x hx,
-    simp only [mem_image, mem_set_of_eq] at hx,
-    rcases hx with ⟨k, ak_le_b, ak_eq_x⟩,
-    rwa [ak_eq_x] at ak_le_b, },
-end
-
-lemma _root_.filter.liminf_eq_Sup_Inf
-  {ι R : Type*} (F : filter ι) [complete_lattice R] (a : ι → R) :
-  F.liminf a = Sup ((λ I, Inf (a '' I)) '' F.sets) :=
-@filter.limsup_eq_Inf_Sup ι (order_dual R) _ _ a
-
 lemma antitone.liminf_comp_eq_apply_limsup_of_continuous
   {ι R : Type*} {F : filter ι} [ne_bot F]
   [complete_linear_order R] [topological_space R] [order_topology R]

--- a/src/topology/algebra/order/liminf_limsup.lean
+++ b/src/topology/algebra/order/liminf_limsup.lean
@@ -190,11 +190,11 @@ section monotone
 
 open set
 
-lemma antitone.liminf_comp_eq_apply_limsup_of_continuous
+lemma antitone.map_limsup_of_continuous
   {ι R : Type*} {F : filter ι} [ne_bot F]
   [complete_linear_order R] [topological_space R] [order_topology R]
   (a : ι → R) {f : R → R} (f_decr : antitone f) (f_cont : continuous f ) :
-  F.liminf (f ∘ a) = f (F.limsup a) :=
+  f (F.limsup a) = F.liminf (f ∘ a) :=
 begin
   rw [filter.limsup_eq_Inf_Sup, filter.liminf_eq_Sup_Inf] at *,
   rw (map_Inf_of_continuous_at_of_antitone' f_cont.continuous_at f_decr _),
@@ -210,12 +210,11 @@ begin
   { refine nonempty_image_iff.mpr nonempty_of_nonempty_subtype, },
 end
 
-lemma antitone.limsup_comp_eq_apply_liminf_of_continuous
+lemma antitone.map_liminf_of_continuous
   {ι R : Type*} {F : filter ι} [ne_bot F]
   [complete_linear_order R] [topological_space R] [order_topology R]
   (a : ι → R) {f : R → R} (f_decr : antitone f) (f_cont : continuous f) :
-  F.limsup (f ∘ a) = f (F.liminf a) :=
-@antitone.liminf_comp_eq_apply_limsup_of_continuous ι (order_dual R) F _ _ _ _
-  a f f_decr.dual f_cont
+  f (F.liminf a) = F.limsup (f ∘ a) :=
+@antitone.map_limsup_of_continuous ι (order_dual R) F _ _ _ _ a f f_decr.dual f_cont
 
 end monotone

--- a/src/topology/algebra/order/liminf_limsup.lean
+++ b/src/topology/algebra/order/liminf_limsup.lean
@@ -190,53 +190,6 @@ section monotone
 
 open set
 
-private lemma continuous_Inf_le_Sup_continuous {R S : Type*}
-  [complete_linear_order R] [topological_space R] [order_topology R]
-  [complete_linear_order S] [topological_space S] [order_closed_topology S]
-  {f : R → S} (f_cont : continuous f)
-  (A : set R) (hA : A.nonempty):
-  f (Inf A) ≤ Sup (f '' A) :=
-begin
-  refine le_Sup_iff.mpr _,
-  intros b hb,
-  have InfA_mem_clA : Inf A ∈ closure A, from Inf_mem_closure hA,
-  have aux := @continuous.continuous_on _ _ _ _ f (closure A) f_cont,
-  have key := (continuous_on.image_closure aux).trans (closure_mono (show f '' A ⊆ Iic b, from hb)),
-  simpa [closure_Iic] using key (mem_image_of_mem f InfA_mem_clA),
-end
-
-lemma antitone.Sup_image_eq_apply_Inf {R S : Type*}
-  [complete_linear_order R] [topological_space R] [order_topology R]
-  [complete_linear_order S] [topological_space S] [order_closed_topology S]
-  {f : R → S} (f_decr : antitone f) (f_cont : continuous f)
-  (A : set R) (hA : A.nonempty):
-  Sup (f '' A) = f (Inf A) :=
-le_antisymm (f_decr.Sup_image_le A) (continuous_Inf_le_Sup_continuous f_cont A hA)
-
-lemma antitone.Inf_image_eq_apply_Sup {R S : Type*}
-  [complete_linear_order R] [topological_space R] [order_topology R]
-  [complete_linear_order S] [topological_space S] [order_closed_topology S]
-  {f : R → S} (f_decr : antitone f) (f_cont : continuous f)
-  (A : set R) (hA : A.nonempty):
-  Inf (f '' A) = f (Sup A) :=
-f_decr.dual.Sup_image_eq_apply_Inf f_cont A hA
-
-lemma monotone.Inf_image_eq_apply_Inf {R S : Type*}
-  [complete_linear_order R] [topological_space R] [order_topology R]
-  [complete_linear_order S] [topological_space S] [order_closed_topology S]
-  {f : R → S} (f_incr : monotone f) (f_cont : continuous f)
-  (A : set R) (hA : A.nonempty):
-  Inf (f '' A) = f (Inf A) :=
-f_incr.dual_left.Inf_image_eq_apply_Sup f_cont A hA
-
-lemma Sup_mono_eq_mono_Sup {R S : Type*}
-  [complete_linear_order R] [topological_space R] [order_topology R]
-  [complete_linear_order S] [topological_space S] [order_closed_topology S]
-  {f : R → S} (f_incr : monotone f) (f_cont : continuous f)
-  (A : set R) (hA : A.nonempty):
-  Sup (f '' A) = f (Sup A) :=
-f_incr.dual.Inf_image_eq_apply_Inf f_cont A hA
-
 lemma limsup_eq_Inf_Sup
   {ι R : Type*} [semilattice_sup ι] [nonempty ι] [complete_lattice R] (a : ι → R) :
   at_top.limsup a = Inf ((λ i, Sup (a '' (Ici i))) '' univ) :=

--- a/src/topology/algebra/order/liminf_limsup.lean
+++ b/src/topology/algebra/order/liminf_limsup.lean
@@ -196,22 +196,14 @@ lemma _root_.filter.limsup_eq_Inf_Sup
 begin
   refine le_antisymm _ _,
   { rw limsup_eq,
-    apply Inf_le_Inf,
-    intros x hx,
+    refine Inf_le_Inf (λ x hx, _),
     rcases (mem_image _ F.sets x).mp hx with ⟨I, ⟨I_mem_F, hI⟩⟩,
     filter_upwards [I_mem_F] with i hi,
-    rw ← hI,
-    exact le_Sup (mem_image_of_mem _ hi), },
-  { rw limsup_eq,
-    apply le_Inf_iff.mpr,
-    intros b hb,
-    simp only [mem_set_of_eq, filter.eventually] at hb,
-    apply Inf_le_of_le (mem_image_of_mem _ (filter.mem_sets.mpr hb)),
-    apply Sup_le,
-    intros x hx,
-    simp only [mem_image, mem_set_of_eq] at hx,
-    rcases hx with ⟨k, ak_le_b, ak_eq_x⟩,
-    rwa [ak_eq_x] at ak_le_b, },
+    exact hI ▸ le_Sup (mem_image_of_mem _ hi), },
+  { refine le_Inf_iff.mpr (λ b hb, Inf_le_of_le (mem_image_of_mem _ $ filter.mem_sets.mpr hb)
+      $ Sup_le _),
+    rintros _ ⟨_, h, rfl⟩,
+    exact h, },
 end
 
 lemma _root_.filter.liminf_eq_Sup_Inf

--- a/src/topology/algebra/order/liminf_limsup.lean
+++ b/src/topology/algebra/order/liminf_limsup.lean
@@ -190,59 +190,6 @@ section monotone
 
 open set
 
-lemma monotone.Sup_image_le {R S : Type*} [complete_lattice R] [complete_linear_order S]
-  {f : R → S} (f_incr : monotone f) (A : set R) :
-  Sup (f '' A) ≤ f (Sup A) :=
-begin
-  refine Sup_le _,
-  intros x x_in_fA,
-  rcases (mem_image f A x).mp x_in_fA with ⟨z, ⟨z_in_A, fz_eq_x⟩⟩,
-  by_contra b_gt,
-  have key := (f_incr (le_Sup z_in_A)),
-  rw fz_eq_x at key,
-  exact (lt_self_iff_false x).mp (lt_of_le_of_lt key (not_le.mp b_gt)),
-end
-
-lemma monotone.le_Inf_image {R S : Type*} [complete_semilattice_Inf R] [complete_linear_order S]
-  {f : R → S} (f_incr : monotone f) (A : set R) :
-  f (Inf A) ≤ Inf (f '' A) :=
-begin
-  have := f_incr.dual,
-  refine le_Inf _,
-  intros x x_in_fA,
-  rcases (mem_image f A x).mp x_in_fA with ⟨z, ⟨z_in_A, fz_eq_x⟩⟩,
-  by_contra b_gt,
-  have key := (f_incr (Inf_le z_in_A)),
-  rw fz_eq_x at key,
-  exact (lt_self_iff_false x).mp (lt_of_lt_of_le (not_le.mp b_gt) key),
-end
-
-lemma antitone.Sup_image_le {R S : Type*} [complete_semilattice_Inf R] [complete_linear_order S]
-  {f : R → S} (f_decr : antitone f) (A : set R) :
-  Sup (f '' A) ≤ f (Inf A) :=
-begin
-  refine Sup_le _,
-  intros x x_in_fA,
-  rcases (mem_image f A x).mp x_in_fA with ⟨z, ⟨z_in_A, fz_eq_x⟩⟩,
-  by_contra b_gt,
-  have key := (f_decr (Inf_le z_in_A)),
-  rw fz_eq_x at key,
-  exact (lt_self_iff_false x).mp (lt_of_le_of_lt key (not_le.mp b_gt)),
-end
-
-lemma antitone.le_Inf_image {R S : Type*} [complete_semilattice_Sup R] [complete_linear_order S]
-  {f : R → S} (f_decr : antitone f) (A : set R) :
-  f (Sup A) ≤ Inf (f '' A) :=
-begin
-  refine le_Inf _,
-  intros x x_in_fA,
-  rcases (mem_image f A x).mp x_in_fA with ⟨z, ⟨z_in_A, fz_eq_x⟩⟩,
-  by_contra b_gt,
-  have key := (f_decr (le_Sup z_in_A)),
-  rw fz_eq_x at key,
-  exact (lt_self_iff_false x).mp (lt_of_lt_of_le (not_le.mp b_gt) key),
-end
-
 private lemma continuous_Inf_le_Sup_continuous {R S : Type*}
   [complete_linear_order R] [topological_space R] [order_topology R]
   [complete_linear_order S] [topological_space S] [order_closed_topology S]

--- a/src/topology/algebra/order/liminf_limsup.lean
+++ b/src/topology/algebra/order/liminf_limsup.lean
@@ -239,11 +239,11 @@ begin
 end
 
 lemma antitone.limsup_comp_eq_apply_liminf_of_continuous
-  {ι R : Type*} [semilattice_sup ι] [nonempty ι]
+  {ι R : Type*} {F : filter ι} [ne_bot F]
   [complete_linear_order R] [topological_space R] [order_topology R]
   (a : ι → R) {f : R → R} (f_decr : antitone f) (f_cont : continuous f) :
-  at_top.limsup (f ∘ a) = f (at_top.liminf a) :=
-@antitone.liminf_comp_eq_apply_limsup_of_continuous ι (order_dual R) _ _ _ _ _
+  F.limsup (f ∘ a) = f (F.liminf a) :=
+@antitone.liminf_comp_eq_apply_limsup_of_continuous ι (order_dual R) F _ _ _ _
   a f f_decr.dual f_cont
 
 end monotone

--- a/src/topology/algebra/order/liminf_limsup.lean
+++ b/src/topology/algebra/order/liminf_limsup.lean
@@ -197,7 +197,7 @@ lemma antitone.map_limsup_of_continuous
   f (F.limsup a) = F.liminf (f ∘ a) :=
 begin
   rw [filter.limsup_eq_Inf_Sup, filter.liminf_eq_Sup_Inf] at *,
-  rw (map_Inf_of_continuous_at_of_antitone' f_cont.continuous_at f_decr _),
+  rw (f_decr.map_Inf_of_continuous_at' f_cont.continuous_at _),
   { apply congr_arg,
     simp only [image_image, function.comp_app],
     refine subset_antisymm _ _;
@@ -205,7 +205,7 @@ begin
       rw mem_image at *,
       rcases hi with ⟨I, I_mem_F, hI⟩,
       refine ⟨I, I_mem_F, _⟩,
-      rw [← hI, map_Sup_of_continuous_at_of_antitone' f_cont.continuous_at f_decr _, image_image],
+      rw [← hI, f_decr.map_Sup_of_continuous_at' f_cont.continuous_at _, image_image],
       exact nonempty_image_iff.mpr (ne_bot.nonempty_of_mem ‹ne_bot F› I_mem_F), }, },
   { refine nonempty_image_iff.mpr nonempty_of_nonempty_subtype, },
 end

--- a/src/topology/algebra/order/liminf_limsup.lean
+++ b/src/topology/algebra/order/liminf_limsup.lean
@@ -237,10 +237,8 @@ lemma Sup_mono_eq_mono_Sup {R S : Type*}
   Sup (f '' A) = f (Sup A) :=
 f_incr.dual.Inf_image_eq_apply_Inf f_cont A hA
 
-lemma limsup_eq_Inf_Sup {ι R : Type*}
-  [semilattice_sup ι] [nonempty ι]
-  [complete_linear_order R] [topological_space R] [order_topology R]
-  (a : ι → R) :
+lemma limsup_eq_Inf_Sup
+  {ι R : Type*} [semilattice_sup ι] [nonempty ι] [complete_lattice R] (a : ι → R) :
   at_top.limsup a = Inf ((λ i, Sup (a '' (Ici i))) '' univ) :=
 begin
   refine le_antisymm _ _,
@@ -267,12 +265,10 @@ begin
     exact hj k j_le_k, },
 end
 
-lemma liminf_eq_Sup_Inf {ι R : Type*}
-  [semilattice_sup ι] [nonempty ι]
-  [complete_linear_order R] [topological_space R] [order_topology R]
-  (a : ι → R) :
+lemma liminf_eq_Sup_Inf
+  {ι R : Type*} [semilattice_sup ι] [nonempty ι] [complete_lattice R] (a : ι → R) :
   at_top.liminf a = Sup ((λ i, Inf (a '' (Ici i))) '' univ) :=
-@limsup_eq_Inf_Sup ι (order_dual R) _ _ _ _ _ a
+@limsup_eq_Inf_Sup ι (order_dual R) _ _ _ a
 
 lemma antitone.liminf_comp_eq_apply_limsup_of_continuous
   {ι R : Type*} [semilattice_sup ι] [nonempty ι]

--- a/src/topology/algebra/order/liminf_limsup.lean
+++ b/src/topology/algebra/order/liminf_limsup.lean
@@ -194,6 +194,8 @@ variables {ι R S : Type*} {F : filter ι} [ne_bot F]
   [complete_linear_order R] [topological_space R] [order_topology R]
   [complete_linear_order S] [topological_space S] [order_topology S]
 
+/-- A continuous antitone function between complete linear ordered spaces sends a `filter.limsup`
+to the `filter.liminf` of the images. -/
 lemma antitone.map_limsup_of_continuous
   (a : ι → R) {f : R → S} (f_decr : antitone f) (f_cont : continuous f ) :
   f (F.limsup a) = F.liminf (f ∘ a) :=
@@ -212,17 +214,23 @@ begin
   { refine nonempty_image_iff.mpr nonempty_of_nonempty_subtype, },
 end
 
+/-- A continuous antitone function between complete linear ordered spaces sends a `filter.liminf`
+to the `filter.limsup` of the images. -/
 lemma antitone.map_liminf_of_continuous
   (a : ι → R) {f : R → S} (f_decr : antitone f) (f_cont : continuous f) :
   f (F.liminf a) = F.limsup (f ∘ a) :=
 @antitone.map_limsup_of_continuous ι (order_dual R) (order_dual S)
   F _ _ _ _ _ _ _ a f f_decr.dual f_cont
 
+/-- A continuous monotone function between complete linear ordered spaces sends a `filter.liminf`
+to the `filter.liminf` of the images. -/
 lemma monotone.map_liminf_of_continuous
   (a : ι → R) {f : R → S} (f_incr : monotone f) (f_cont : continuous f) :
   f (F.liminf a) = F.liminf (f ∘ a) :=
 @antitone.map_liminf_of_continuous ι R (order_dual S) F _ _ _ _ _ _ _ a f f_incr f_cont
 
+/-- A continuous monotone function between complete linear ordered spaces sends a `filter.limsup`
+to the `filter.limsup` of the images. -/
 lemma monotone.map_limsup_of_continuous
   (a : ι → R) {f : R → S} (f_incr : monotone f) (f_cont : continuous f) :
   f (F.limsup a) = F.limsup (f ∘ a) :=

--- a/src/topology/algebra/order/liminf_limsup.lean
+++ b/src/topology/algebra/order/liminf_limsup.lean
@@ -185,3 +185,170 @@ end
 end conditionally_complete_linear_order
 
 end liminf_limsup
+
+section monotone
+
+open set
+
+lemma monotone.Sup_image_le {R S : Type*} [complete_lattice R] [complete_linear_order S]
+  {f : R → S} (f_incr : monotone f) (A : set R) :
+  Sup (f '' A) ≤ f (Sup A) :=
+begin
+  refine Sup_le _,
+  intros x x_in_fA,
+  rcases (mem_image f A x).mp x_in_fA with ⟨z, ⟨z_in_A, fz_eq_x⟩⟩,
+  by_contra b_gt,
+  have key := (f_incr (le_Sup z_in_A)),
+  rw fz_eq_x at key,
+  exact (lt_self_iff_false x).mp (lt_of_le_of_lt key (not_le.mp b_gt)),
+end
+
+lemma monotone.le_Inf_image {R S : Type*} [complete_semilattice_Inf R] [complete_linear_order S]
+  {f : R → S} (f_incr : monotone f) (A : set R) :
+  f (Inf A) ≤ Inf (f '' A) :=
+begin
+  have := f_incr.dual,
+  refine le_Inf _,
+  intros x x_in_fA,
+  rcases (mem_image f A x).mp x_in_fA with ⟨z, ⟨z_in_A, fz_eq_x⟩⟩,
+  by_contra b_gt,
+  have key := (f_incr (Inf_le z_in_A)),
+  rw fz_eq_x at key,
+  exact (lt_self_iff_false x).mp (lt_of_lt_of_le (not_le.mp b_gt) key),
+end
+
+lemma antitone.Sup_image_le {R S : Type*} [complete_semilattice_Inf R] [complete_linear_order S]
+  {f : R → S} (f_decr : antitone f) (A : set R) :
+  Sup (f '' A) ≤ f (Inf A) :=
+begin
+  refine Sup_le _,
+  intros x x_in_fA,
+  rcases (mem_image f A x).mp x_in_fA with ⟨z, ⟨z_in_A, fz_eq_x⟩⟩,
+  by_contra b_gt,
+  have key := (f_decr (Inf_le z_in_A)),
+  rw fz_eq_x at key,
+  exact (lt_self_iff_false x).mp (lt_of_le_of_lt key (not_le.mp b_gt)),
+end
+
+lemma antitone.le_Inf_image {R S : Type*} [complete_semilattice_Sup R] [complete_linear_order S]
+  {f : R → S} (f_decr : antitone f) (A : set R) :
+  f (Sup A) ≤ Inf (f '' A) :=
+begin
+  refine le_Inf _,
+  intros x x_in_fA,
+  rcases (mem_image f A x).mp x_in_fA with ⟨z, ⟨z_in_A, fz_eq_x⟩⟩,
+  by_contra b_gt,
+  have key := (f_decr (le_Sup z_in_A)),
+  rw fz_eq_x at key,
+  exact (lt_self_iff_false x).mp (lt_of_lt_of_le (not_le.mp b_gt) key),
+end
+
+private lemma continuous_Inf_le_Sup_continuous {R S : Type*}
+  [complete_linear_order R] [topological_space R] [order_topology R]
+  [complete_linear_order S] [topological_space S] [order_closed_topology S]
+  {f : R → S} (f_cont : continuous f)
+  (A : set R) (hA : A.nonempty):
+  f (Inf A) ≤ Sup (f '' A) :=
+begin
+  refine le_Sup_iff.mpr _,
+  intros b hb,
+  have InfA_mem_clA : Inf A ∈ closure A, from Inf_mem_closure hA,
+  have aux := @continuous.continuous_on _ _ _ _ f (closure A) f_cont,
+  have key := (continuous_on.image_closure aux).trans (closure_mono (show f '' A ⊆ Iic b, from hb)),
+  simpa [closure_Iic] using key (mem_image_of_mem f InfA_mem_clA),
+end
+
+lemma antitone.Sup_image_eq_apply_Inf {R S : Type*}
+  [complete_linear_order R] [topological_space R] [order_topology R]
+  [complete_linear_order S] [topological_space S] [order_closed_topology S]
+  {f : R → S} (f_decr : antitone f) (f_cont : continuous f)
+  (A : set R) (hA : A.nonempty):
+  Sup (f '' A) = f (Inf A) :=
+le_antisymm (f_decr.Sup_image_le A) (continuous_Inf_le_Sup_continuous f_cont A hA)
+
+lemma antitone.Inf_image_eq_apply_Sup {R S : Type*}
+  [complete_linear_order R] [topological_space R] [order_topology R]
+  [complete_linear_order S] [topological_space S] [order_closed_topology S]
+  {f : R → S} (f_decr : antitone f) (f_cont : continuous f)
+  (A : set R) (hA : A.nonempty):
+  Inf (f '' A) = f (Sup A) :=
+f_decr.dual.Sup_image_eq_apply_Inf f_cont A hA
+
+lemma monotone.Inf_image_eq_apply_Inf {R S : Type*}
+  [complete_linear_order R] [topological_space R] [order_topology R]
+  [complete_linear_order S] [topological_space S] [order_closed_topology S]
+  {f : R → S} (f_incr : monotone f) (f_cont : continuous f)
+  (A : set R) (hA : A.nonempty):
+  Inf (f '' A) = f (Inf A) :=
+f_incr.dual_left.Inf_image_eq_apply_Sup f_cont A hA
+
+lemma Sup_mono_eq_mono_Sup {R S : Type*}
+  [complete_linear_order R] [topological_space R] [order_topology R]
+  [complete_linear_order S] [topological_space S] [order_closed_topology S]
+  {f : R → S} (f_incr : monotone f) (f_cont : continuous f)
+  (A : set R) (hA : A.nonempty):
+  Sup (f '' A) = f (Sup A) :=
+f_incr.dual.Inf_image_eq_apply_Inf f_cont A hA
+
+lemma limsup_eq_Inf_Sup {ι R : Type*}
+  [semilattice_sup ι] [nonempty ι]
+  [complete_linear_order R] [topological_space R] [order_topology R]
+  (a : ι → R) :
+  at_top.limsup a = Inf ((λ i, Sup (a '' (Ici i))) '' univ) :=
+begin
+  refine le_antisymm _ _,
+  { rw limsup_eq,
+    apply Inf_le_Inf,
+    intros x hx,
+    simp only [image_univ, mem_range] at hx,
+    rcases hx with ⟨j, hj⟩,
+    filter_upwards [Ici_mem_at_top j],
+    intros i hij,
+    rw ← hj,
+    exact le_Sup (mem_image_of_mem _ hij), },
+  { rw limsup_eq,
+    apply le_Inf_iff.mpr,
+    intros b hb,
+    simp only [mem_set_of_eq, eventually_at_top] at hb,
+    rcases hb with ⟨j, hj⟩,
+    apply Inf_le_of_le (mem_image_of_mem _ (mem_univ j)),
+    apply Sup_le,
+    intros x hx,
+    simp at hx,
+    rcases hx with ⟨k, j_le_k, ak_eq_x⟩,
+    rw ← ak_eq_x,
+    exact hj k j_le_k, },
+end
+
+lemma liminf_eq_Sup_Inf {ι R : Type*}
+  [semilattice_sup ι] [nonempty ι]
+  [complete_linear_order R] [topological_space R] [order_topology R]
+  (a : ι → R) :
+  at_top.liminf a = Sup ((λ i, Inf (a '' (Ici i))) '' univ) :=
+@limsup_eq_Inf_Sup ι (order_dual R) _ _ _ _ _ a
+
+lemma antitone.liminf_comp_eq_apply_limsup_of_continuous
+  {ι R : Type*} [semilattice_sup ι] [nonempty ι]
+  [complete_linear_order R] [topological_space R] [order_topology R]
+  (a : ι → R) {f : R → R} (f_decr : antitone f) (f_cont : continuous f) :
+  at_top.liminf (f ∘ a) = f (at_top.limsup a) :=
+begin
+  rw [limsup_eq_Inf_Sup, liminf_eq_Sup_Inf,
+      ←f_decr.Sup_image_eq_apply_Inf f_cont _ (nonempty_image_iff.mpr (@univ_nonempty ι _))],
+  apply congr_arg,
+  simp_rw [image_image, function.comp_app, image_univ],
+  apply congr_arg,
+  funext n,
+  rw ← f_decr.Inf_image_eq_apply_Sup f_cont _ (nonempty_image_iff.mpr nonempty_Ici),
+  simp_rw image_image,
+end
+
+lemma antitone.limsup_comp_eq_apply_liminf_of_continuous
+  {ι R : Type*} [semilattice_sup ι] [nonempty ι]
+  [complete_linear_order R] [topological_space R] [order_topology R]
+  (a : ι → R) {f : R → R} (f_decr : antitone f) (f_cont : continuous f) :
+  at_top.limsup (f ∘ a) = f (at_top.liminf a) :=
+@antitone.liminf_comp_eq_apply_limsup_of_continuous ι (order_dual R) _ _ _ _ _
+  a f f_decr.dual f_cont
+
+end monotone

--- a/src/topology/algebra/order/liminf_limsup.lean
+++ b/src/topology/algebra/order/liminf_limsup.lean
@@ -193,10 +193,11 @@ open set
 lemma antitone.liminf_comp_eq_apply_limsup_of_continuous
   {ι R : Type*} {F : filter ι} [ne_bot F]
   [complete_linear_order R] [topological_space R] [order_topology R]
-  (a : ι → R) {f : R → R} (f_decr : antitone f) (f_cont : continuous f) :
+  (a : ι → R) {f : R → R} (f_decr : antitone f) (f_cont : continuous f ) :
   F.liminf (f ∘ a) = f (F.limsup a) :=
 begin
-  rw [filter.limsup_eq_Inf_Sup, filter.liminf_eq_Sup_Inf, ←f_decr.Sup_image_eq_apply_Inf f_cont],
+  rw [filter.limsup_eq_Inf_Sup, filter.liminf_eq_Sup_Inf] at *,
+  rw (map_Inf_of_continuous_at_of_antitone' f_cont.continuous_at f_decr _),
   { apply congr_arg,
     simp only [image_image, function.comp_app],
     refine subset_antisymm _ _;
@@ -204,7 +205,7 @@ begin
       rw mem_image at *,
       rcases hi with ⟨I, I_mem_F, hI⟩,
       refine ⟨I, I_mem_F, _⟩,
-      rw [← hI, ← f_decr.Inf_image_eq_apply_Sup f_cont _ _, image_image],
+      rw [← hI, map_Sup_of_continuous_at_of_antitone' f_cont.continuous_at f_decr _, image_image],
       exact nonempty_image_iff.mpr (ne_bot.nonempty_of_mem ‹ne_bot F› I_mem_F), }, },
   { refine nonempty_image_iff.mpr nonempty_of_nonempty_subtype, },
 end

--- a/src/topology/algebra/order/liminf_limsup.lean
+++ b/src/topology/algebra/order/liminf_limsup.lean
@@ -188,8 +188,6 @@ end liminf_limsup
 
 section monotone
 
-open set
-
 variables {ι R S : Type*} {F : filter ι} [ne_bot F]
   [complete_linear_order R] [topological_space R] [order_topology R]
   [complete_linear_order S] [topological_space S] [order_topology S]
@@ -203,15 +201,15 @@ begin
   rw [filter.limsup_eq_Inf_Sup, filter.liminf_eq_Sup_Inf] at *,
   rw (f_decr.map_Inf_of_continuous_at' f_cont.continuous_at _),
   { apply congr_arg,
-    simp only [image_image, function.comp_app],
+    simp only [set.image_image, function.comp_app],
     refine subset_antisymm _ _;
     { intros i hi,
-      rw mem_image at *,
+      rw set.mem_image at *,
       rcases hi with ⟨I, I_mem_F, hI⟩,
       refine ⟨I, I_mem_F, _⟩,
-      rw [← hI, f_decr.map_Sup_of_continuous_at' f_cont.continuous_at _, image_image],
-      exact nonempty_image_iff.mpr (ne_bot.nonempty_of_mem ‹ne_bot F› I_mem_F), }, },
-  { refine nonempty_image_iff.mpr nonempty_of_nonempty_subtype, },
+      rw [← hI, f_decr.map_Sup_of_continuous_at' f_cont.continuous_at _, set.image_image],
+      exact set.nonempty_image_iff.mpr (ne_bot.nonempty_of_mem ‹ne_bot F› I_mem_F), }, },
+  { refine set.nonempty_image_iff.mpr set.nonempty_of_nonempty_subtype, },
 end
 
 /-- A continuous antitone function between complete linear ordered spaces sends a `filter.liminf`

--- a/src/topology/instances/ennreal.lean
+++ b/src/topology/instances/ennreal.lean
@@ -449,8 +449,8 @@ begin
     casesI is_empty_or_nonempty ι,
     { rw [infi_of_empty, infi_of_empty, mul_top, if_neg],
       exact mt h0 (not_nonempty_iff.2 ‹_›) },
-    { exact (monotone.map_infi_of_continuous_at' (ennreal.continuous_at_const_mul H)
-        ennreal.mul_left_mono).symm } }
+    { exact (ennreal.mul_left_mono.map_infi_of_continuous_at'
+            (ennreal.continuous_at_const_mul H)).symm } }
 end
 
 lemma infi_mul_left {ι} [nonempty ι] {f : ι → ℝ≥0∞} {a : ℝ≥0∞}
@@ -581,7 +581,7 @@ begin
   by_cases hf : ∀ i, f i = 0,
   { obtain rfl : f = (λ _, 0), from funext hf,
     simp only [supr_zero_eq_zero, mul_zero] },
-  { refine monotone.map_supr_of_continuous_at _ (monotone_id.const_mul' _) (mul_zero a),
+  { refine (monotone_id.const_mul' _).map_supr_of_continuous_at _ (mul_zero a),
     refine ennreal.tendsto.const_mul tendsto_id (or.inl _),
     exact mt supr_eq_zero.1 hf }
 end

--- a/src/topology/instances/ennreal.lean
+++ b/src/topology/instances/ennreal.lean
@@ -449,7 +449,7 @@ begin
     casesI is_empty_or_nonempty ι,
     { rw [infi_of_empty, infi_of_empty, mul_top, if_neg],
       exact mt h0 (not_nonempty_iff.2 ‹_›) },
-    { exact (map_infi_of_continuous_at_of_monotone' (ennreal.continuous_at_const_mul H)
+    { exact (monotone.map_infi_of_continuous_at' (ennreal.continuous_at_const_mul H)
         ennreal.mul_left_mono).symm } }
 end
 
@@ -507,7 +507,7 @@ protected lemma tendsto_inv_nat_nhds_zero : tendsto (λ n : ℕ, (n : ℝ≥0∞
 ennreal.inv_top ▸ ennreal.tendsto_inv_iff.2 tendsto_nat_nhds_top
 
 lemma supr_add {ι : Sort*} {s : ι → ℝ≥0∞} [h : nonempty ι] : supr s + a = ⨆b, s b + a :=
-map_supr_of_continuous_at_of_monotone' (continuous_at_id.add continuous_at_const) $
+monotone.map_supr_of_continuous_at' (continuous_at_id.add continuous_at_const) $
   monotone_id.add monotone_const
 
 lemma bsupr_add' {ι : Sort*} {p : ι → Prop} (h : ∃ i, p i) {f : ι → ℝ≥0∞} :
@@ -581,7 +581,7 @@ begin
   by_cases hf : ∀ i, f i = 0,
   { obtain rfl : f = (λ _, 0), from funext hf,
     simp only [supr_zero_eq_zero, mul_zero] },
-  { refine map_supr_of_continuous_at_of_monotone _ (monotone_id.const_mul' _) (mul_zero a),
+  { refine monotone.map_supr_of_continuous_at _ (monotone_id.const_mul' _) (mul_zero a),
     refine ennreal.tendsto.const_mul tendsto_id (or.inl _),
     exact mt supr_eq_zero.1 hf }
 end

--- a/src/topology/metric_space/gluing.lean
+++ b/src/topology/metric_space/gluing.lean
@@ -106,7 +106,7 @@ private lemma glue_dist_triangle (Φ : Z → X) (Ψ : Z → Y) (ε : ℝ)
     have : (⨅ p, dist z (Φ p) + dist x (Ψ p)) ≤ (⨅ p, dist y (Φ p) + dist x (Ψ p)) + dist y z,
     { have : (⨅ p, dist y (Φ p) + dist x (Ψ p)) + dist y z =
             infi ((λt, t + dist y z) ∘ (λp, dist y (Φ p) + dist x (Ψ p))),
-      { refine map_cinfi_of_continuous_at_of_monotone (continuous_at_id.add continuous_at_const) _
+      { refine monotone.map_cinfi_of_continuous_at (continuous_at_id.add continuous_at_const) _
           (B _ _),
         intros x y hx, simpa },
       rw [this, comp],
@@ -124,7 +124,7 @@ private lemma glue_dist_triangle (Φ : Z → X) (Ψ : Z → Y) (ε : ℝ)
     have : (⨅ p, dist z (Φ p) + dist x (Ψ p)) ≤ dist x y + ⨅ p, dist z (Φ p) + dist y (Ψ p),
     { have : dist x y + (⨅ p, dist z (Φ p) + dist y (Ψ p)) =
             infi ((λt, dist x y + t) ∘ (λp, dist z (Φ p) + dist y (Ψ p))),
-      { refine map_cinfi_of_continuous_at_of_monotone (continuous_at_const.add continuous_at_id) _
+      { refine monotone.map_cinfi_of_continuous_at (continuous_at_const.add continuous_at_id) _
           (B _ _),
         intros x y hx, simpa },
       rw [this, comp],
@@ -142,7 +142,7 @@ private lemma glue_dist_triangle (Φ : Z → X) (Ψ : Z → Y) (ε : ℝ)
     have : (⨅ p, dist x (Φ p) + dist z (Ψ p)) ≤ dist x y + ⨅ p, dist y (Φ p) + dist z (Ψ p),
     { have : dist x y + (⨅ p, dist y (Φ p) + dist z (Ψ p)) =
             infi ((λt, dist x y + t) ∘ (λp, dist y (Φ p) + dist z (Ψ p))),
-      { refine map_cinfi_of_continuous_at_of_monotone (continuous_at_const.add continuous_at_id) _
+      { refine monotone.map_cinfi_of_continuous_at (continuous_at_const.add continuous_at_id) _
           (B _ _),
         intros x y hx, simpa },
       rw [this, comp],
@@ -160,7 +160,7 @@ private lemma glue_dist_triangle (Φ : Z → X) (Ψ : Z → Y) (ε : ℝ)
     have : (⨅ p, dist x (Φ p) + dist z (Ψ p)) ≤ (⨅ p, dist x (Φ p) + dist y (Ψ p)) + dist y z,
     { have : (⨅ p, dist x (Φ p) + dist y (Ψ p)) + dist y z =
             infi ((λt, t + dist y z) ∘ (λp, dist x (Φ p) + dist y (Ψ p))),
-      { refine map_cinfi_of_continuous_at_of_monotone (continuous_at_id.add continuous_at_const) _
+      { refine monotone.map_cinfi_of_continuous_at (continuous_at_id.add continuous_at_const) _
           (B _ _),
         intros x y hx, simpa },
       rw [this, comp],

--- a/src/topology/metric_space/gromov_hausdorff_realized.lean
+++ b/src/topology/metric_space/gromov_hausdorff_realized.lean
@@ -369,12 +369,12 @@ begin
   -- (here the addition of `dist f g`) preserve infimum and supremum
   have E1 : ∀ x, (⨅ y, g (inl x, inr y)) + dist f g = ⨅ y, g (inl x, inr y) + dist f g,
   { assume x,
-    refine map_cinfi_of_continuous_at_of_monotone (continuous_at_id.add continuous_at_const) _ _,
+    refine monotone.map_cinfi_of_continuous_at (continuous_at_id.add continuous_at_const) _ _,
     { assume x y hx, simpa },
     { show bdd_below (range (λ (y : Y), g (inl x, inr y))),
         from ⟨cg, forall_range_iff.2(λi, Hcg _)⟩ } },
   have E2 : (⨆ x, ⨅ y, g (inl x, inr y)) + dist f g = ⨆ x, (⨅ y, g (inl x, inr y)) + dist f g,
-  { refine map_csupr_of_continuous_at_of_monotone (continuous_at_id.add continuous_at_const) _ _,
+  { refine monotone.map_csupr_of_continuous_at (continuous_at_id.add continuous_at_const) _ _,
     { assume x y hx, simpa },
     { simpa using HD_bound_aux1 _ 0 } },
   -- deduce the result from the above two steps
@@ -398,12 +398,12 @@ begin
   -- (here the addition of `dist f g`) preserve infimum and supremum
   have E1 : ∀ y, (⨅ x, g (inl x, inr y)) + dist f g = ⨅ x, g (inl x, inr y) + dist f g,
   { assume y,
-    refine map_cinfi_of_continuous_at_of_monotone (continuous_at_id.add continuous_at_const) _ _,
+    refine monotone.map_cinfi_of_continuous_at (continuous_at_id.add continuous_at_const) _ _,
     { assume x y hx, simpa },
     { show bdd_below (range (λx:X, g (inl x, inr y))),
         from ⟨cg, forall_range_iff.2 (λi, Hcg _)⟩ } },
   have E2 : (⨆ y, ⨅ x, g (inl x, inr y)) + dist f g = ⨆ y, (⨅ x, g (inl x, inr y)) + dist f g,
-  { refine map_csupr_of_continuous_at_of_monotone (continuous_at_id.add continuous_at_const) _ _,
+  { refine monotone.map_csupr_of_continuous_at (continuous_at_id.add continuous_at_const) _ _,
     { assume x y hx, simpa },
     { simpa using HD_bound_aux2 _ 0 } },
   -- deduce the result from the above two steps


### PR DESCRIPTION
This PR adds antitone versions of lemmas about supremum and infimum under monotone functions and moves those lemmas to monotone/antitone namespaces. Simultaneously, the type class assumption on the codomain is weakened from `order_topology` to `order_closed_topology`.

Moreover, lemmas about limsup and liminf under monotone/antitone functions are added: `antitone.map_Limsup_of_continuous_at` etc.

---

There was a [question on Zulip](https://leanprover.zulipchat.com/#narrow/stream/217875-Is-there-code-for-X.3F/topic/limsup_antitone_continuous_eq_antitone_continuous_liminf/near/289002206) about the existence of similar lemmas.

I originally labeled this _feat(topology/algebra/order/liminf_limsup): Add lemmas about limsup and liminf under monotone/antitone functions_, but the review showed how to use rather more the existing lemmas, so I relabeled as _refactor(topology/algebra/order/basic)_.

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
