### PR TITLE
[Merged by Bors] - feat(data/polynomial/laurent): define `degree` and some API

### DIFF
--- a/src/data/polynomial/laurent.lean
+++ b/src/data/polynomial/laurent.lean
@@ -415,7 +415,7 @@ section exact_degrees
 
 open_locale classical
 
-lemma degree_C_mul_T (n : ℤ) (a : R) (a0 : a ≠ 0) : (C a * T n).degree = n :=
+@[simp] lemma degree_C_mul_T (n : ℤ) (a : R) (a0 : a ≠ 0) : (C a * T n).degree = n :=
 begin
   rw degree,
   convert finset.max_singleton,

--- a/src/data/polynomial/laurent.lean
+++ b/src/data/polynomial/laurent.lean
@@ -428,7 +428,7 @@ lemma degree_C_mul_T_ite (n : ℤ) (a : R) : (C a * T n).degree = ite (a = 0) �
 by split_ifs with h h;
   simp only [h, map_zero, zero_mul, degree_zero, degree_C_mul_T, ne.def, not_false_iff]
 
-lemma degree_T [nontrivial R] (n : ℤ) : (T n : R[T;T⁻¹]).degree = n :=
+@[simp] lemma degree_T [nontrivial R] (n : ℤ) : (T n : R[T;T⁻¹]).degree = n :=
 begin
   rw [← one_mul (T n), ← map_one C],
   exact degree_C_mul_T n 1 (one_ne_zero : (1 : R) ≠ 0),

--- a/src/data/polynomial/laurent.lean
+++ b/src/data/polynomial/laurent.lean
@@ -365,25 +365,27 @@ section support
 lemma support_C_mul_T (a : R) (n : ℤ) : (C a * T n).support ⊆ {n} :=
 by simpa only [← single_eq_C_mul_T] using support_single_subset
 
+lemma support_C_mul_T_ne_zero {a : R} (a0 : a ≠ 0) (n : ℤ) : (C a * T n).support = {n} :=
+begin
+  rw ← single_eq_C_mul_T,
+  exact support_single_ne_zero _ a0,
+end
+
 @[simp] lemma to_laurent_support (f : R[X]) :
   f.to_laurent.support = f.support.map nat.cast_embedding :=
 begin
-  rw (show (f.support.map nat.cast_embedding = f.support.image (coe : ℕ → ℤ)), by
-  { ext, simp only [finset.mem_map, nat.cast_embedding_apply, finset.mem_image] }),
   generalize' hd : f.support = s,
   revert f,
   refine finset.induction_on s _ _; clear s,
-  { simp only [polynomial.support_eq_empty, map_zero, finsupp.support_zero, finset.image_empty,
-      eq_self_iff_true, implies_true_iff] {contextual := tt} },
+  { simp only [polynomial.support_eq_empty, map_zero, finsupp.support_zero, eq_self_iff_true,
+      implies_true_iff, finset.map_empty] {contextual := tt} },
   { intros a s as hf f fs,
-    have : (erase a f).to_laurent.support = finset.image coe s := hf (f.erase a) (by simp only
+    have : (erase a f).to_laurent.support = s.map nat.cast_embedding := hf (f.erase a) (by simp only
       [fs, finset.erase_eq_of_not_mem as, polynomial.support_erase, finset.erase_insert_eq_erase]),
-    rw [← monomial_add_erase f a, finset.image_insert, ← this, map_add,
+    rw [← monomial_add_erase f a, finset.map_insert, ← this, map_add,
       polynomial.to_laurent_C_mul_T, support_add_eq, finset.insert_eq],
     { congr,
-      refine support_eq_singleton'.mpr ⟨f.coeff a, _, (single_eq_C_mul_T _ _).symm⟩,
-      refine polynomial.mem_support_iff.mp _,
-      simp only [fs, finset.mem_insert, eq_self_iff_true, true_or] },
+      exact support_C_mul_T_ne_zero (polynomial.mem_support_iff.mp (by simp [fs])) _ },
     { rw this,
       exact disjoint.mono_left (support_C_mul_T _ _) (by simpa) } }
 end

--- a/src/data/polynomial/laurent.lean
+++ b/src/data/polynomial/laurent.lean
@@ -371,7 +371,10 @@ begin
   exact support_single_ne_zero _ a0,
 end
 
-@[simp] lemma to_laurent_support (f : R[X]) :
+/--  The support of a polynomial `f` is a finset in `ℕ`.  The lemma `to_laurent_support f`
+shows that the support of `f.to_laurent` is the same finset, but viewed in `ℤ` under the natural
+inclusion `ℕ ↪ ℤ`. -/
+lemma to_laurent_support (f : R[X]) :
   f.to_laurent.support = f.support.map nat.cast_embedding :=
 begin
   generalize' hd : f.support = s,

--- a/src/data/polynomial/laurent.lean
+++ b/src/data/polynomial/laurent.lean
@@ -365,7 +365,7 @@ section support
 lemma support_C_mul_T (a : R) (n : ℤ) : (C a * T n).support ⊆ {n} :=
 by simpa only [← single_eq_C_mul_T] using support_single_subset
 
-lemma support_C_mul_T_ne_zero {a : R} (a0 : a ≠ 0) (n : ℤ) : (C a * T n).support = {n} :=
+lemma support_C_mul_T_of_ne_zero {a : R} (a0 : a ≠ 0) (n : ℤ) : (C a * T n).support = {n} :=
 begin
   rw ← single_eq_C_mul_T,
   exact support_single_ne_zero _ a0,

--- a/src/data/polynomial/laurent.lean
+++ b/src/data/polynomial/laurent.lean
@@ -385,7 +385,7 @@ begin
     rw [← monomial_add_erase f a, finset.map_insert, ← this, map_add,
       polynomial.to_laurent_C_mul_T, support_add_eq, finset.insert_eq],
     { congr,
-      exact support_C_mul_T_ne_zero (polynomial.mem_support_iff.mp (by simp [fs])) _ },
+      exact support_C_mul_T_of_ne_zero (polynomial.mem_support_iff.mp (by simp [fs])) _ },
     { rw this,
       exact disjoint.mono_left (support_C_mul_T _ _) (by simpa) } }
 end

--- a/src/data/polynomial/laurent.lean
+++ b/src/data/polynomial/laurent.lean
@@ -399,6 +399,16 @@ def degree (f : R[T;T⁻¹]) : with_bot ℤ := f.support.max
 
 @[simp] lemma degree_zero : degree (0 : R[T;T⁻¹]) = ⊥ := rfl
 
+@[simp] lemma degree_eq_bot_iff {f : R[T;T⁻¹]} : f.degree = ⊥ ↔ f = 0 :=
+begin
+  refine ⟨λ h, _, λ h, by rw [h, degree_zero]⟩,
+  rw [degree, finset.max_eq_sup_with_bot] at h,
+  ext n,
+  refine not_not.mp (λ f0, _),
+  simp_rw [finset.sup_eq_bot_iff, finsupp.mem_support_iff, ne.def, with_bot.coe_ne_bot] at h,
+  exact h n f0,
+end
+
 section exact_degrees
 
 open_locale classical

--- a/src/data/polynomial/laurent.lean
+++ b/src/data/polynomial/laurent.lean
@@ -366,7 +366,7 @@ lemma support_C_mul_T (a : R) (n : ℤ) : (C a * T n).support ⊆ {n} :=
 by simpa only [← single_eq_C_mul_T] using support_single_subset
 
 @[simp] lemma to_laurent_support (f : R[X]) :
-  f.to_laurent.support = f.support.map (nat.cast_embedding) :=
+  f.to_laurent.support = f.support.map nat.cast_embedding :=
 begin
   rw (show (f.support.map nat.cast_embedding = f.support.image (coe : ℕ → ℤ)), by
   { ext, simp only [finset.mem_map, nat.cast_embedding_apply, finset.mem_image] }),

--- a/src/data/polynomial/laurent.lean
+++ b/src/data/polynomial/laurent.lean
@@ -418,13 +418,15 @@ begin
   exact degree_C_mul_T n 1 (one_ne_zero : (1 : R) ≠ 0),
 end
 
-lemma degree_C (a : R) : (C a).degree = ite (a = 0) ⊥ 0 :=
+@[simp] lemma degree_C {a : R} (a0 : a ≠ 0) : (C a).degree = 0 :=
 begin
-  split_ifs with h h,
-  { simp only [h, map_zero, degree_zero] },
-  { rw [← mul_one (C a), ← T_zero],
-    exact degree_C_mul_T 0 a h }
+  rw [← mul_one (C a), ← T_zero],
+  exact degree_C_mul_T 0 a a0
 end
+
+lemma degree_C_ite (a : R) : (C a).degree = ite (a = 0) ⊥ 0 :=
+by split_ifs with h h;
+  simp only [h, map_zero, degree_zero, degree_C, ne.def, not_false_iff]
 
 end exact_degrees
 

--- a/src/data/polynomial/laurent.lean
+++ b/src/data/polynomial/laurent.lean
@@ -412,13 +412,17 @@ begin
     and_self],
 end
 
+lemma degree_C_mul_T_ite (n : ℤ) (a : R) : (C a * T n).degree = ite (a = 0) ⊥ n :=
+by split_ifs with h h;
+  simp only [h, map_zero, zero_mul, degree_zero, degree_C_mul_T, ne.def, not_false_iff]
+
 lemma degree_T [nontrivial R] (n : ℤ) : (T n : R[T;T⁻¹]).degree = n :=
 begin
   rw [← one_mul (T n), ← map_one C],
   exact degree_C_mul_T n 1 (one_ne_zero : (1 : R) ≠ 0),
 end
 
-@[simp] lemma degree_C {a : R} (a0 : a ≠ 0) : (C a).degree = 0 :=
+lemma degree_C {a : R} (a0 : a ≠ 0) : (C a).degree = 0 :=
 begin
   rw [← mul_one (C a), ← T_zero],
   exact degree_C_mul_T 0 a a0

--- a/src/data/polynomial/laurent.lean
+++ b/src/data/polynomial/laurent.lean
@@ -365,8 +365,11 @@ section support
 lemma support_C_mul_T (a : R) (n : ℤ) : (C a * T n).support ⊆ {n} :=
 by simpa only [← single_eq_C_mul_T] using support_single_subset
 
-@[simp] lemma to_laurent_support (f : R[X]) : f.to_laurent.support = f.support.image coe :=
+@[simp] lemma to_laurent_support (f : R[X]) :
+  f.to_laurent.support = f.support.map (nat.cast_embedding) :=
 begin
+  rw (show (f.support.map nat.cast_embedding = f.support.image (coe : ℕ → ℤ)), by
+  { ext, simp only [finset.mem_map, nat.cast_embedding_apply, finset.mem_image] }),
   generalize' hd : f.support = s,
   revert f,
   refine finset.induction_on s _ _; clear s,

--- a/src/data/polynomial/laurent.lean
+++ b/src/data/polynomial/laurent.lean
@@ -314,12 +314,9 @@ left_inverse_trunc_to_laurent.injective
   f.to_laurent = g.to_laurent ↔ f = g :=
 ⟨λ h, polynomial.to_laurent_injective h, congr_arg _⟩
 
-lemma _root_.polynomial.to_laurent_ne_zero (f : R[X])  (f0 : f ≠ 0) :
-  f.to_laurent ≠ 0 :=
-begin
-  refine (map_ne_zero_iff _ _).mpr f0,
-  exact polynomial.to_laurent_injective,
-end
+lemma _root_.polynomial.to_laurent_ne_zero {f : R[X]} :
+  f ≠ 0 ↔ f.to_laurent ≠ 0 :=
+(map_ne_zero_iff _ (by exact polynomial.to_laurent_injective)).symm
 
 lemma exists_T_pow (f : R[T;T⁻¹]) :
   ∃ (n : ℕ) (f' : R[X]), f'.to_laurent = f * T n :=


### PR DESCRIPTION
This PR introduces the `degree` for Laurent polynomials.  It takes values in `with_bot ℤ`and is defined as `f.support.max`.

It may make sense to define a "degree" on any `add_monoid_algebra` whose value group is `linear_ordered`, but I am only defining `degree` for Laurent polynomials.

The PR also proves some API lemmas about support and relationship between the degree of a Laurent polynomial and the degree with polynomials, seen as Laurent polynomials.

In future PRs I intend to define also `int_degree`, analogous to `nat_degree` of polynomials.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
