### PR TITLE
feat(data/finite/basic): redefine `nat.card` in terms of `fintype.card`

### DIFF
--- a/src/data/finite/basic.lean
+++ b/src/data/finite/basic.lean
@@ -126,6 +126,9 @@ not_finite_iff_infinite.not_right.symm
 
 lemma of_subsingleton {α : Sort*} [subsingleton α] : finite α := finite.of_equiv _ equiv.plift
 
+instance [infinite α] : is_empty (unique α) :=
+⟨λ h, by { haveI := @unique.fintype α h, exact not_finite α }⟩
+
 @[nolint instance_priority]
 instance finite.prop (p : Prop) : finite p := of_subsingleton
 

--- a/src/data/finite/card.lean
+++ b/src/data/finite/card.lean
@@ -3,8 +3,9 @@ Copyright (c) 2022 Kyle Miller. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Kyle Miller
 -/
+
 import data.finite.basic
-import set_theory.cardinal.finite
+import data.nat.enat
 
 /-!
 
@@ -30,6 +31,54 @@ noncomputable theory
 open_locale classical
 
 variables {α β γ : Type*}
+
+/-! ### Cardinality as an enat -/
+
+namespace enat
+
+/-- The cardinality of a type as an `enat`.-/
+def card (α : Type*) : enat :=
+if h : finite α then @fintype.card α (@fintype.of_finite α h) else ⊤
+
+@[simp] theorem card_eq_fintype_card (α : Type*) [fintype α] : enat.card α = fintype.card α :=
+begin
+  rw [card, dif_pos (finite.of_fintype' α), enat.coe_inj],
+  apply fintype.card_congr' rfl
+end
+
+@[simp] theorem card_eq_top (α : Type*) [h : infinite α] : enat.card α = ⊤ :=
+dif_neg $ not_finite_iff_infinite.2 h
+
+theorem card_eq_zero (α : Type*) [is_empty α] : card α = 0 := by simp
+theorem card_eq_one (α : Type*) [unique α] : card α = 1 := by simp
+theorem card_empty : card empty = 0 := by simp
+theorem card_pempty : card pempty = 0 := by simp
+theorem card_unit : card unit = 1 := by simp
+theorem card_punit : card punit = 1 := by simp
+theorem card_bool : card bool = 2 := by simp
+theorem card_fin (n : ℕ) : card (fin n) = n := by simp
+theorem card_nat : card ℕ = ⊤ := by simp
+theorem card_int : card ℤ = ⊤ := by simp
+theorem card_rat : card ℚ = ⊤ := by simp
+
+@[simp] theorem card_eq_zero_iff : card α = 0 ↔ is_empty α :=
+by casesI fintype_or_infinite α; simp
+
+@[simp] theorem card_eq_one_iff : card α = 1 ↔ nonempty (unique α) :=
+by { casesI fintype_or_infinite α; simp, apply_instance }
+
+@[simp] theorem card_sum (α β : Type*) : card (α ⊕ β) = card α + card β :=
+by casesI fintype_or_infinite α; casesI fintype_or_infinite β; simp
+
+end enat
+
+/-! ### Cardinality as a nat -/
+
+namespace nat
+
+def card (α : Type*) : ℕ := (enat.card α).to_nat 0
+
+end nat
 
 /-- There is (noncomputably) an equivalence between a finite type `α` and `fin (nat.card α)`. -/
 def finite.equiv_fin (α : Type*) [finite α] : α ≃ fin (nat.card α) :=

--- a/src/data/finite/card.lean
+++ b/src/data/finite/card.lean
@@ -5,7 +5,6 @@ Authors: Kyle Miller
 -/
 
 import data.finite.basic
-import data.nat.enat
 
 /-!
 
@@ -32,43 +31,46 @@ open_locale classical
 
 variables {α β γ : Type*}
 
-/-! ### Cardinality as an enat -/
+/-! ### Cardinality as a nat with top -/
 
-namespace enat
+namespace nat
 
-/-- The cardinality of a type as an `enat`.-/
-def card (α : Type*) : enat :=
+/-- The cardinality of a type as a `with_top ℕ`.-/
+def card_top (α : Type*) : with_top ℕ :=
 if h : finite α then @fintype.card α (@fintype.of_finite α h) else ⊤
 
-@[simp] theorem card_eq_fintype_card (α : Type*) [fintype α] : enat.card α = fintype.card α :=
+@[simp] theorem card_top_eq_fintype_card (α : Type*) [fintype α] : card_top α = fintype.card α :=
 begin
-  rw [card, dif_pos (finite.of_fintype' α), enat.coe_inj],
+  rw [card_top, dif_pos (finite.of_fintype' α), with_top.coe_eq_coe],
   apply fintype.card_congr' rfl
 end
 
-@[simp] theorem card_eq_top (α : Type*) [h : infinite α] : enat.card α = ⊤ :=
+@[simp] theorem card_top_eq_top (α : Type*) [h : infinite α] : card_top α = ⊤ :=
 dif_neg $ not_finite_iff_infinite.2 h
 
-theorem card_eq_zero (α : Type*) [is_empty α] : card α = 0 := by simp
-theorem card_eq_one (α : Type*) [unique α] : card α = 1 := by simp
-theorem card_empty : card empty = 0 := by simp
-theorem card_pempty : card pempty = 0 := by simp
-theorem card_unit : card unit = 1 := by simp
-theorem card_punit : card punit = 1 := by simp
-theorem card_bool : card bool = 2 := by simp
-theorem card_fin (n : ℕ) : card (fin n) = n := by simp
-theorem card_nat : card ℕ = ⊤ := by simp
-theorem card_int : card ℤ = ⊤ := by simp
-theorem card_rat : card ℚ = ⊤ := by simp
+theorem card_top_eq_zero (α : Type*) [is_empty α] : card_top α = 0 := by simp
+theorem card_top_eq_one (α : Type*) [unique α] : card_top α = 1 := by simp
+theorem card_top_empty : card_top empty = 0 := by simp
+theorem card_top_pempty : card_top pempty = 0 := by simp
+theorem card_top_unit : card_top unit = 1 := by simp
+theorem card_top_punit : card_top punit = 1 := by simp
+@[simp] theorem card_top_bool : card_top bool = 2 := card_top_eq_fintype_card bool
+theorem card_top_fin (n : ℕ) : card_top (fin n) = n := by simp
+theorem card_top_nat : card_top ℕ = ⊤ := by simp
+theorem card_top_int : card_top ℤ = ⊤ := by simp
+theorem card_top_rat : card_top ℚ = ⊤ := by simp
 
-@[simp] theorem card_eq_zero_iff : card α = 0 ↔ is_empty α :=
+@[simp] theorem card_top_eq_zero_iff : card_top α = 0 ↔ is_empty α :=
 by casesI fintype_or_infinite α; simp
 
-@[simp] theorem card_eq_one_iff : card α = 1 ↔ nonempty (unique α) :=
+@[simp] theorem card_top_eq_one_iff : card_top α = 1 ↔ nonempty (unique α) :=
 by { casesI fintype_or_infinite α; simp, apply_instance }
 
-@[simp] theorem card_sum (α β : Type*) : card (α ⊕ β) = card α + card β :=
-by casesI fintype_or_infinite α; casesI fintype_or_infinite β; simp
+@[simp] theorem card_top_sum (α β : Type*) : card_top (α ⊕ β) = card_top α + card_top β :=
+by { casesI fintype_or_infinite α; casesI fintype_or_infinite β; simp,
+rw with_top.coe_add,
+
+}
 
 end enat
 

--- a/src/data/finite/card.lean
+++ b/src/data/finite/card.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2022 Kyle Miller. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Kyle Miller
+Authors: Kyle Miller, Violeta Hernández Palacios
 -/
 
 import data.finite.basic

--- a/src/data/fintype/basic.lean
+++ b/src/data/fintype/basic.lean
@@ -1066,12 +1066,12 @@ by rw [←card_unit, card_eq]; exact
   λ ⟨x, hx⟩, ⟨⟨λ _, (), λ _, x, λ _, (hx _).trans (hx _).symm,
     λ _, subsingleton.elim _ _⟩⟩⟩
 
-lemma card_eq_zero_iff : card α = 0 ↔ is_empty α :=
+@[simp] lemma card_eq_zero_iff : card α = 0 ↔ is_empty α :=
 by rw [card, finset.card_eq_zero, univ_eq_empty_iff]
 
-lemma card_eq_zero [is_empty α] : card α = 0 := card_eq_zero_iff.2 ‹_›
+@[simp] lemma card_eq_zero [is_empty α] : card α = 0 := card_eq_zero_iff.2 ‹_›
 
-lemma card_eq_one_iff_nonempty_unique : card α = 1 ↔ nonempty (unique α) :=
+@[simp] lemma card_eq_one_iff_nonempty_unique : card α = 1 ↔ nonempty (unique α) :=
 ⟨λ h, let ⟨d, h⟩ := fintype.card_eq_one_iff.mp h in ⟨{ default := d, uniq := h}⟩,
  λ ⟨h⟩, by exactI fintype.card_unique⟩
 

--- a/src/data/nat/enat.lean
+++ b/src/data/nat/enat.lean
@@ -85,8 +85,6 @@ instance : add_monoid_with_one enat :=
 lemma some_eq_coe (n : ℕ) : some n = n := rfl
 
 @[simp] lemma coe_inj {x y : ℕ} : (x : enat) = y ↔ x = y := part.some_inj
-@[simp] lemma coe_eq_zero_iff {x : ℕ} : (x : enat) = 0 ↔ x = 0 := coe_inj
-@[simp] lemma coe_eq_one_iff {x : ℕ} : (x : enat) = 1 ↔ x = 1 := coe_inj
 
 @[simp] lemma dom_coe (x : ℕ) : (x : enat).dom := trivial
 
@@ -248,13 +246,6 @@ lemma top_eq_none : (⊤ : enat) = none := rfl
 ne.lt_top (λ h, absurd (congr_arg dom h) $ by simpa only [dom_coe] using true_ne_false)
 
 @[simp] lemma coe_ne_top (x : ℕ) : (x : enat) ≠ ⊤ := ne_of_lt (coe_lt_top x)
-@[simp] lemma top_ne_coe (x : ℕ) : (⊤ : enat) ≠ x := (coe_ne_top x).symm
-
-@[simp] lemma zero_ne_top : (0 : enat) ≠ ⊤ := coe_ne_top 0
-@[simp] lemma top_ne_zero : (⊤ : enat) ≠ 0 := top_ne_coe 0
-
-@[simp] lemma one_ne_top : (1 : enat) ≠ ⊤ := coe_ne_top 1
-@[simp] lemma top_ne_one : (⊤ : enat) ≠ 1 := top_ne_coe 1
 
 lemma not_is_max_coe (x : ℕ) : ¬ is_max (x : enat) :=
 not_is_max_of_lt (coe_lt_top x)

--- a/src/data/nat/enat.lean
+++ b/src/data/nat/enat.lean
@@ -85,6 +85,8 @@ instance : add_monoid_with_one enat :=
 lemma some_eq_coe (n : ℕ) : some n = n := rfl
 
 @[simp] lemma coe_inj {x y : ℕ} : (x : enat) = y ↔ x = y := part.some_inj
+@[simp] lemma coe_eq_zero_iff {x : ℕ} : (x : enat) = 0 ↔ x = 0 := coe_inj
+@[simp] lemma coe_eq_one_iff {x : ℕ} : (x : enat) = 1 ↔ x = 1 := coe_inj
 
 @[simp] lemma dom_coe (x : ℕ) : (x : enat).dom := trivial
 
@@ -246,6 +248,13 @@ lemma top_eq_none : (⊤ : enat) = none := rfl
 ne.lt_top (λ h, absurd (congr_arg dom h) $ by simpa only [dom_coe] using true_ne_false)
 
 @[simp] lemma coe_ne_top (x : ℕ) : (x : enat) ≠ ⊤ := ne_of_lt (coe_lt_top x)
+@[simp] lemma top_ne_coe (x : ℕ) : (⊤ : enat) ≠ x := (coe_ne_top x).symm
+
+@[simp] lemma zero_ne_top : (0 : enat) ≠ ⊤ := coe_ne_top 0
+@[simp] lemma top_ne_zero : (⊤ : enat) ≠ 0 := top_ne_coe 0
+
+@[simp] lemma one_ne_top : (1 : enat) ≠ ⊤ := coe_ne_top 1
+@[simp] lemma top_ne_one : (⊤ : enat) ≠ 1 := top_ne_coe 1
 
 lemma not_is_max_coe (x : ℕ) : ¬ is_max (x : enat) :=
 not_is_max_of_lt (coe_lt_top x)

--- a/src/measure_theory/probability_mass_function/constructions.lean
+++ b/src/measure_theory/probability_mass_function/constructions.lean
@@ -303,7 +303,7 @@ by simpa only [uniform_of_fintype, finset.mem_univ, if_true, uniform_of_finset_a
 
 @[simp] lemma support_uniform_of_fintype (α : Type*) [fintype α] [nonempty α] :
   (uniform_of_fintype α).support = ⊤ :=
-set.ext (λ x, by simpa [mem_support_iff] using fintype.card_ne_zero)
+set.ext (λ x, by simp [mem_support_iff])
 
 lemma mem_support_uniform_of_fintype (a : α) : a ∈ (uniform_of_fintype α).support := by simp
 


### PR DESCRIPTION
This removes the dependency on cardinals. The goal is to ultimately restate the theorems relating cardinals to `fintype.card` in terms of `nat.card`, thus removing computability concerns.

A lot of the theorems currently in the `finite` namespace would better belong in the `nat` namespace, but I've avoided moving them for now to minimize breakage.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
- [ ] depends on: #15233

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
