### PR TITLE
[Merged by Bors] - chore(set_theory/ordinal/cantor_normal_form): mark `CNF` as `pp_nodot`

### DIFF
--- a/src/set_theory/ordinal/cantor_normal_form.lean
+++ b/src/set_theory/ordinal/cantor_normal_form.lean
@@ -47,7 +47,7 @@ by rw [CNF_rec, dif_neg o0]
     base-`b` expansion of `o`.
 
     `CNF b (b ^ u₁ * v₁ + b ^ u₂ * v₂) = [(u₁, v₁), (u₂, v₂)]` -/
-def CNF (b o : ordinal) : list (ordinal × ordinal) :=
+@[pp_nodot] def CNF (b o : ordinal) : list (ordinal × ordinal) :=
 if b0 : b = 0 then [] else
 CNF_rec b0 [] (λ o o0 IH, (log b o, o / b ^ log b o) :: IH) o
 


### PR DESCRIPTION
`b.CNF o` doesn't make much sense, since `b` is the base argument rather than the main argument.
The existing lemmas all use the `CNF b o` spelling anyway.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
