### PR TITLE
refactor(order/antisymmetrization): antisymm_rel → indistinguishable

### DIFF
--- a/src/order/antisymmetrization.lean
+++ b/src/order/antisymmetrization.lean
@@ -53,7 +53,7 @@ lemma indistinguishable_rfl : indistinguishable a a := indistinguishable_refl _
 instance : is_refl α indistinguishable := ⟨indistinguishable_refl⟩
 instance : is_trans α indistinguishable := ⟨λ a b c h, h.trans⟩
 
-lemma indistinguishable.image (hf : monotone f) (h : indistinguishable a b) :
+lemma indistinguishable.image (h : indistinguishable a b) (hf : monotone f) :
   indistinguishable (f a) (f b) :=
 ⟨hf h.1, hf h.2⟩
 

--- a/src/order/antisymmetrization.lean
+++ b/src/order/antisymmetrization.lean
@@ -15,90 +15,92 @@ such that `a ≤ b` and `b ≤ a`.
 
 ## Main declarations
 
-* `antisymm_rel`: The antisymmetrization relation. `antisymm_rel r a b` means that `a` and `b` are
-  related both ways by `r`.
-* `antisymmetrization α r`: The quotient of `α` by `antisymm_rel r`. Even when `r` is just a
-  preorder, `antisymmetrization α` is a partial order.
+* `order.indistinguishable`: We say that `a` and `b` are order indistinguishable when `a ≤ b` and
+  `b ≤ a`.
+* `antisymmetrization α`: The quotient of `α` by `order.indistinguishable`. Even when `α` is just
+  a preorder, `antisymmetrization α` is a partial order.
 -/
 
 open function order_dual
 
 variables {α β : Type*}
 
+namespace order
 section relation
-variables (r : α → α → Prop)
 
-/-- The antisymmetrization relation. -/
-def antisymm_rel (a b : α) : Prop := r a b ∧ r b a
+/-- `order.indistinguishable a b` means that `a ≤ b` and `b ≤ a`. -/
+def indistinguishable [has_le α] (a b : α) : Prop := a ≤ b ∧ b ≤ a
 
-lemma antisymm_rel_swap : antisymm_rel (swap r) = antisymm_rel r :=
-funext $ λ _, funext $ λ _, propext and.comm
+@[refl] lemma indistinguishable_refl [preorder α] (a : α) : indistinguishable a a :=
+⟨refl _, refl _⟩
 
-@[refl] lemma antisymm_rel_refl [is_refl α r] (a : α) : antisymm_rel r a a := ⟨refl _, refl _⟩
+instance [preorder α] : is_refl α indistinguishable := ⟨indistinguishable_refl⟩
 
-variables {r}
+@[symm] lemma indistinguishable.symm [has_le α] {a b : α} :
+  indistinguishable a b → indistinguishable b a := and.symm
 
-@[symm] lemma antisymm_rel.symm {a b : α} : antisymm_rel r a b → antisymm_rel r b a := and.symm
+instance [has_le α] : is_symm α indistinguishable := ⟨λ a b h, h.symm⟩
 
-@[trans] lemma antisymm_rel.trans [is_trans α r] {a b c : α} (hab : antisymm_rel r a b)
-  (hbc : antisymm_rel r b c) :
-  antisymm_rel r a c :=
-⟨trans hab.1 hbc.1, trans hbc.2 hab.2⟩
+@[trans] lemma indistinguishable.trans [preorder α] {a b c : α}
+  (hab : indistinguishable a b) (hbc : indistinguishable b c) : indistinguishable a c :=
+⟨hab.1.trans hbc.1, hbc.2.trans hab.2⟩
 
-instance antisymm_rel.decidable_rel [decidable_rel r] : decidable_rel (antisymm_rel r) :=
+instance [preorder α] : is_trans α indistinguishable := ⟨λ a b c h, h.trans⟩
+
+instance [has_le α] [@decidable_rel α (≤)] : decidable_rel (@indistinguishable α _) :=
 λ _ _, and.decidable
 
-@[simp] lemma antisymm_rel_iff_eq [is_refl α r] [is_antisymm α r] {a b : α} :
-  antisymm_rel r a b ↔ a = b := antisymm_iff
+@[simp] lemma indistinguishable_iff_eq [partial_order α] {a b : α} :
+  indistinguishable a b ↔ a = b := antisymm_iff
 
-alias antisymm_rel_iff_eq ↔ antisymm_rel.eq _
+alias indistinguishable_iff_eq ↔ indistinguishable.eq _
 
 end relation
+end order
 
-section is_preorder
-variables (α) (r : α → α → Prop) [is_preorder α r]
+section preorder
+variables (α) [preorder α]
 
 /-- The antisymmetrization relation as an equivalence relation. -/
-@[simps] def antisymm_rel.setoid : setoid α :=
-⟨antisymm_rel r, antisymm_rel_refl _, λ _ _, antisymm_rel.symm, λ _ _ _, antisymm_rel.trans⟩
+@[simps] def order.indistinguishable.setoid : setoid α :=
+⟨@order.indistinguishable α _, order.indistinguishable_refl, λ _ _ h, h.symm, λ _ _ _ h, h.trans⟩
+
+open order
 
 /-- The partial order derived from a preorder by making pairwise comparable elements equal. This is
 the quotient by `λ a b, a ≤ b ∧ b ≤ a`. -/
-def antisymmetrization : Type* := quotient $ antisymm_rel.setoid α r
+def antisymmetrization : Type* := quotient $ order.indistinguishable.setoid α
 
 variables {α}
 
 /-- Turn an element into its antisymmetrization. -/
-def to_antisymmetrization : α → antisymmetrization α r := quotient.mk'
+def to_antisymmetrization : α → antisymmetrization α := quotient.mk'
 
 /-- Get a representative from the antisymmetrization. -/
-noncomputable def of_antisymmetrization : antisymmetrization α r → α := quotient.out'
+noncomputable def of_antisymmetrization : antisymmetrization α → α := quotient.out'
 
-instance [inhabited α] : inhabited (antisymmetrization α r) := quotient.inhabited _
+instance [inhabited α] : inhabited (antisymmetrization α) := quotient.inhabited _
 
 @[elab_as_eliminator]
-protected lemma antisymmetrization.ind {p : antisymmetrization α r → Prop} :
-  (∀ a, p $ to_antisymmetrization r a) → ∀ q, p q :=
+protected lemma antisymmetrization.ind {p : antisymmetrization α → Prop} :
+  (∀ a, p $ to_antisymmetrization a) → ∀ q, p q :=
 quot.ind
 
 @[elab_as_eliminator]
-protected lemma antisymmetrization.induction_on {p : antisymmetrization α r → Prop}
-  (a : antisymmetrization α r) (h : ∀ a, p $ to_antisymmetrization r a) : p a :=
+protected lemma antisymmetrization.induction_on {p : antisymmetrization α → Prop}
+  (a : antisymmetrization α) (h : ∀ a, p $ to_antisymmetrization a) : p a :=
 quotient.induction_on' a h
 
-@[simp] lemma to_antisymmetrization_of_antisymmetrization (a : antisymmetrization α r) :
-  to_antisymmetrization r (of_antisymmetrization r a) = a := quotient.out_eq' _
+@[simp] lemma to_antisymmetrization_of_antisymmetrization (a : antisymmetrization α) :
+  to_antisymmetrization (of_antisymmetrization a) = a := quotient.out_eq' _
 
-end is_preorder
+variables [preorder β] {a b : α}
 
-section preorder
-variables {α} [preorder α] [preorder β] {a b : α}
-
-lemma antisymm_rel.image {a b : α} (h : antisymm_rel (≤) a b) {f : α → β} (hf : monotone f) :
-  antisymm_rel (≤) (f a) (f b) :=
+lemma indistinguishable.image {a b : α} (h : indistinguishable a b) {f : α → β} (hf : monotone f) :
+  indistinguishable (f a) (f b) :=
 ⟨hf h.1, hf h.2⟩
 
-instance : partial_order (antisymmetrization α (≤)) :=
+instance : partial_order (antisymmetrization α) :=
 { le := λ a b, quotient.lift_on₂' a b (≤) $ λ (a₁ a₂ b₁ b₂ : α) h₁ h₂,
     propext ⟨λ h, h₁.2.trans $ h.trans h₂.1, λ h, h₁.1.trans $ h.trans h₂.2⟩,
   lt := λ a b, quotient.lift_on₂' a b (<) $ λ (a₁ a₂ b₁ b₂ : α) h₁ h₂,
@@ -109,67 +111,68 @@ instance : partial_order (antisymmetrization α (≤)) :=
   le_antisymm := λ a b, quotient.induction_on₂' a b $ λ a b hab hba, quotient.sound' ⟨hab, hba⟩ }
 
 instance [@decidable_rel α (≤)] [@decidable_rel α (<)] [is_total α (≤)] :
-  linear_order (antisymmetrization α (≤)) :=
+  linear_order (antisymmetrization α) :=
 { le_total := λ a b, quotient.induction_on₂' a b $ total_of (≤),
-  decidable_eq := @quotient.decidable_eq _ (antisymm_rel.setoid _ (≤)) antisymm_rel.decidable_rel,
+  decidable_eq := @quotient.decidable_eq _ (order.indistinguishable.setoid _)
+    indistinguishable.decidable_rel,
   decidable_le := λ _ _, quotient.lift_on₂'.decidable _ _ _ _,
   decidable_lt := λ _ _, quotient.lift_on₂'.decidable _ _ _ _,
   ..antisymmetrization.partial_order }
 
 @[simp] lemma to_antisymmetrization_le_to_antisymmetrization_iff :
-  to_antisymmetrization (≤) a ≤ to_antisymmetrization (≤) b ↔ a ≤ b := iff.rfl
+  to_antisymmetrization a ≤ to_antisymmetrization b ↔ a ≤ b := iff.rfl
 
 @[simp] lemma to_antisymmetrization_lt_to_antisymmetrization_iff :
-  to_antisymmetrization (≤) a < to_antisymmetrization (≤) b ↔ a < b := iff.rfl
+  to_antisymmetrization a < to_antisymmetrization b ↔ a < b := iff.rfl
 
-@[simp] lemma of_antisymmetrization_le_of_antisymmetrization_iff {a b : antisymmetrization α (≤)} :
-  of_antisymmetrization (≤) a ≤ of_antisymmetrization (≤) b ↔ a ≤ b :=
+@[simp] lemma of_antisymmetrization_le_of_antisymmetrization_iff {a b : antisymmetrization α} :
+  of_antisymmetrization a ≤ of_antisymmetrization b ↔ a ≤ b :=
 by convert to_antisymmetrization_le_to_antisymmetrization_iff.symm;
-  exact (to_antisymmetrization_of_antisymmetrization _ _).symm
+  exact (to_antisymmetrization_of_antisymmetrization _).symm
 
-@[simp] lemma of_antisymmetrization_lt_of_antisymmetrization_iff {a b : antisymmetrization α (≤)} :
-  of_antisymmetrization (≤) a < of_antisymmetrization (≤) b ↔ a < b :=
+@[simp] lemma of_antisymmetrization_lt_of_antisymmetrization_iff {a b : antisymmetrization α} :
+  of_antisymmetrization a < of_antisymmetrization b ↔ a < b :=
 by convert to_antisymmetrization_lt_to_antisymmetrization_iff.symm;
-  exact (to_antisymmetrization_of_antisymmetrization _ _).symm
+  exact (to_antisymmetrization_of_antisymmetrization _).symm
 
-@[mono] lemma to_antisymmetrization_mono : monotone (@to_antisymmetrization α (≤) _) := λ a b, id
+@[mono] lemma to_antisymmetrization_mono : monotone (@to_antisymmetrization α _) := λ a b, id
 
 /-- `to_antisymmetrization` as an order homomorphism. -/
-@[simps] def order_hom.to_antisymmetrization : α →o antisymmetrization α (≤) :=
-⟨to_antisymmetrization (≤), λ a b, id⟩
+@[simps] def order_hom.to_antisymmetrization : α →o antisymmetrization α :=
+⟨to_antisymmetrization, λ a b, id⟩
 
-private lemma lift_fun_antisymm_rel (f : α →o β) :
-  ((antisymm_rel.setoid α (≤)).r ⇒ (antisymm_rel.setoid β (≤)).r) f f :=
+private lemma lift_fun_indistinguishable (f : α →o β) :
+  ((indistinguishable.setoid α).r ⇒ (indistinguishable.setoid β).r) f f :=
 λ a b h, ⟨f.mono h.1, f.mono h.2⟩
 
 /-- Turns an order homomorphism from `α` to `β` into one from `antisymmetrization α` to
 `antisymmetrization β`. `antisymmetrization` is actually a functor. See `Preorder_to_PartialOrder`.
 -/
 protected def order_hom.antisymmetrization (f : α →o β) :
-  antisymmetrization α (≤) →o antisymmetrization β (≤) :=
-⟨quotient.map' f $ lift_fun_antisymm_rel f, λ a b, quotient.induction_on₂' a b $ f.mono⟩
+  antisymmetrization α →o antisymmetrization β :=
+⟨quotient.map' f $ lift_fun_indistinguishable f, λ a b, quotient.induction_on₂' a b $ f.mono⟩
 
 @[simp] lemma order_hom.coe_antisymmetrization (f : α →o β) :
-  ⇑f.antisymmetrization = quotient.map' f (lift_fun_antisymm_rel f) := rfl
+  ⇑f.antisymmetrization = quotient.map' f (lift_fun_indistinguishable f) := rfl
 
-@[simp] lemma order_hom.antisymmetrization_apply (f : α →o β) (a : antisymmetrization α (≤)) :
-  f.antisymmetrization a = quotient.map' f (lift_fun_antisymm_rel f) a := rfl
+@[simp] lemma order_hom.antisymmetrization_apply (f : α →o β) (a : antisymmetrization α) :
+  f.antisymmetrization a = quotient.map' f (lift_fun_indistinguishable f) a := rfl
 
 @[simp] lemma order_hom.antisymmetrization_apply_mk (f : α →o β) (a : α) :
-  f.antisymmetrization (to_antisymmetrization _ a) = (to_antisymmetrization _ (f a)) :=
-quotient.map'_mk' f (lift_fun_antisymm_rel f) _
+  f.antisymmetrization (to_antisymmetrization a) = (to_antisymmetrization (f a)) :=
+quotient.map'_mk' f (lift_fun_indistinguishable f) _
 
 variables (α)
 
 /-- `of_antisymmetrization` as an order embedding. -/
-@[simps] noncomputable def order_embedding.of_antisymmetrization : antisymmetrization α (≤) ↪o α :=
-{ to_fun := of_antisymmetrization _,
+@[simps] noncomputable def order_embedding.of_antisymmetrization : antisymmetrization α ↪o α :=
+{ to_fun := of_antisymmetrization,
   inj' := λ _ _, quotient.out_inj.1,
   map_rel_iff' := λ a b, of_antisymmetrization_le_of_antisymmetrization_iff }
 
 /-- `antisymmetrization` and `order_dual` commute. -/
 def order_iso.dual_antisymmetrization :
-  (antisymmetrization α (≤))ᵒᵈ ≃o antisymmetrization αᵒᵈ (≤) :=
+  (antisymmetrization α)ᵒᵈ ≃o antisymmetrization αᵒᵈ :=
 { to_fun := quotient.map' id $ λ _ _, and.symm,
   inv_fun := quotient.map' id $ λ _ _, and.symm,
   left_inv := λ a, quotient.induction_on' a $ λ a, by simp_rw [quotient.map'_mk', id],
@@ -177,11 +180,11 @@ def order_iso.dual_antisymmetrization :
   map_rel_iff' := λ a b, quotient.induction_on₂' a b $ λ a b, iff.rfl }
 
 @[simp] lemma order_iso.dual_antisymmetrization_apply (a : α) :
-  order_iso.dual_antisymmetrization _ (to_dual $ to_antisymmetrization _ a) =
-    to_antisymmetrization _ (to_dual a) := rfl
+  order_iso.dual_antisymmetrization _ (to_dual $ to_antisymmetrization a) =
+    to_antisymmetrization (to_dual a) := rfl
 
 @[simp] lemma order_iso.dual_antisymmetrization_symm_apply (a : α) :
-  (order_iso.dual_antisymmetrization _).symm (to_antisymmetrization _ $ to_dual a) =
-    to_dual (to_antisymmetrization _ a) := rfl
+  (order_iso.dual_antisymmetrization _).symm (to_antisymmetrization $ to_dual a) =
+    to_dual (to_antisymmetrization a) := rfl
 
 end preorder

--- a/src/order/antisymmetrization.lean
+++ b/src/order/antisymmetrization.lean
@@ -96,8 +96,8 @@ quotient.induction_on' a h
 
 variables [preorder β] {a b : α}
 
-lemma indistinguishable.image {a b : α} (h : indistinguishable a b) {f : α → β} (hf : monotone f) :
-  indistinguishable (f a) (f b) :=
+lemma order.indistinguishable.image {a b : α} (h : indistinguishable a b)
+  {f : α → β} (hf : monotone f) : indistinguishable (f a) (f b) :=
 ⟨hf h.1, hf h.2⟩
 
 instance : partial_order (antisymmetrization α) :=
@@ -113,7 +113,7 @@ instance : partial_order (antisymmetrization α) :=
 instance [@decidable_rel α (≤)] [@decidable_rel α (<)] [is_total α (≤)] :
   linear_order (antisymmetrization α) :=
 { le_total := λ a b, quotient.induction_on₂' a b $ total_of (≤),
-  decidable_eq := @quotient.decidable_eq _ (order.indistinguishable.setoid _)
+  decidable_eq := @quotient.decidable_eq _ (indistinguishable.setoid _)
     indistinguishable.decidable_rel,
   decidable_le := λ _ _, quotient.lift_on₂'.decidable _ _ _ _,
   decidable_lt := λ _ _, quotient.lift_on₂'.decidable _ _ _ _,

--- a/src/order/category/PartialOrder.lean
+++ b/src/order/category/PartialOrder.lean
@@ -77,8 +77,7 @@ def Preorder_to_PartialOrder_forget_adjunction :
 adjunction.mk_of_hom_equiv
   { hom_equiv := λ X Y, { to_fun := λ f,
       ⟨f ∘ to_antisymmetrization, f.mono.comp to_antisymmetrization_mono⟩,
-    inv_fun := λ f, ⟨λ a, quotient.lift_on' a f $ λ a b h,
-      (order.indistinguishable.image h f.mono).eq,
+    inv_fun := λ f, ⟨λ a, quotient.lift_on' a f $ λ a b h, (h.image f.mono).eq,
       λ a b, quotient.induction_on₂' a b $ λ a b h, f.mono h⟩,
     left_inv := λ f, order_hom.ext _ _ $ funext $ λ x, quotient.induction_on' x $ λ x, rfl,
     right_inv := λ f, order_hom.ext _ _ $ funext $ λ x, rfl },

--- a/src/order/category/PartialOrder.lean
+++ b/src/order/category/PartialOrder.lean
@@ -77,7 +77,8 @@ def Preorder_to_PartialOrder_forget_adjunction :
 adjunction.mk_of_hom_equiv
   { hom_equiv := λ X Y, { to_fun := λ f,
       ⟨f ∘ to_antisymmetrization, f.mono.comp to_antisymmetrization_mono⟩,
-    inv_fun := λ f, ⟨λ a, quotient.lift_on' a f $ λ a b h, (indistinguishable.image h f.mono).eq,
+    inv_fun := λ f, ⟨λ a, quotient.lift_on' a f $ λ a b h,
+      (order.indistinguishable.image h f.mono).eq,
       λ a b, quotient.induction_on₂' a b $ λ a b h, f.mono h⟩,
     left_inv := λ f, order_hom.ext _ _ $ funext $ λ x, quotient.induction_on' x $ λ x, rfl,
     right_inv := λ f, order_hom.ext _ _ $ funext $ λ x, rfl },

--- a/src/order/category/PartialOrder.lean
+++ b/src/order/category/PartialOrder.lean
@@ -63,7 +63,7 @@ lemma PartialOrder_dual_comp_forget_to_Preorder :
 
 /-- `antisymmetrization` as a functor. It is the free functor. -/
 def Preorder_to_PartialOrder : Preorder.{u} ⥤ PartialOrder :=
-{ obj := λ X, PartialOrder.of (antisymmetrization X (≤)),
+{ obj := λ X, PartialOrder.of (antisymmetrization X),
   map := λ X Y f, f.antisymmetrization,
   map_id' := λ X,
     by { ext, exact quotient.induction_on' x (λ x, quotient.map'_mk' _ (λ a b, id) _) },
@@ -76,9 +76,9 @@ def Preorder_to_PartialOrder_forget_adjunction :
   Preorder_to_PartialOrder.{u} ⊣ forget₂ PartialOrder Preorder :=
 adjunction.mk_of_hom_equiv
   { hom_equiv := λ X Y, { to_fun := λ f,
-      ⟨f ∘ to_antisymmetrization (≤), f.mono.comp to_antisymmetrization_mono⟩,
-    inv_fun := λ f, ⟨λ a, quotient.lift_on' a f $ λ a b h, (antisymm_rel.image h f.mono).eq, λ a b,
-      quotient.induction_on₂' a b $ λ a b h, f.mono h⟩,
+      ⟨f ∘ to_antisymmetrization, f.mono.comp to_antisymmetrization_mono⟩,
+    inv_fun := λ f, ⟨λ a, quotient.lift_on' a f $ λ a b h, (indistinguishable.image h f.mono).eq,
+      λ a b, quotient.induction_on₂' a b $ λ a b h, f.mono h⟩,
     left_inv := λ f, order_hom.ext _ _ $ funext $ λ x, quotient.induction_on' x $ λ x, rfl,
     right_inv := λ f, order_hom.ext _ _ $ funext $ λ x, rfl },
   hom_equiv_naturality_left_symm' := λ X Y Z f g,


### PR DESCRIPTION
We rename `antisymm_rel` to `order.indistinguishable`, and specialize its relation to `≤` (as this is really the only use case we currently have for this relation).

Co-authored-by: Yaël Dillies <@YaelDillies>

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
