### PR TITLE
refactor(set_theory/cardinal/basic): `enat.card` → `nat.card_top`

### DIFF
--- a/src/set_theory/cardinal/basic.lean
+++ b/src/set_theory/cardinal/basic.lean
@@ -1165,7 +1165,7 @@ end
 
 /-- This function sends finite cardinals to the corresponding natural, and infinite cardinals
   to `⊤`. -/
-def to_enat : cardinal →+ enat :=
+def to_nat_top : cardinal →+ with_top ℕ :=
 { to_fun := λ c, if c < ℵ₀ then c.to_nat else ⊤,
   map_zero' := by simp [if_pos (zero_lt_one.trans one_lt_aleph_0)],
   map_add' := λ x y, begin
@@ -1175,33 +1175,33 @@ def to_enat : cardinal →+ enat :=
       { obtain ⟨y0, rfl⟩ := lt_aleph_0.1 hy,
         simp only [add_lt_aleph_0 hx hy, hx, hy, to_nat_cast, if_true],
         rw [← nat.cast_add, to_nat_cast, nat.cast_add] },
-      { rw [if_neg hy, if_neg, enat.add_top],
+      { rw [if_neg hy, if_neg, with_top.add_top],
         contrapose! hy,
         apply le_add_self.trans_lt hy } },
-    { rw [if_neg hx, if_neg, enat.top_add],
+    { rw [if_neg hx, if_neg, with_top.top_add],
       contrapose! hx,
       apply le_self_add.trans_lt hx },
   end }
 
-lemma to_enat_apply_of_lt_aleph_0 {c : cardinal} (h : c < ℵ₀) : c.to_enat = c.to_nat :=
+lemma to_nat_top_apply_of_lt_aleph_0 {c : cardinal} (h : c < ℵ₀) : c.to_nat_top = c.to_nat :=
 if_pos h
 
-lemma to_enat_apply_of_aleph_0_le {c : cardinal} (h : ℵ₀ ≤ c) : c.to_enat = ⊤ :=
+lemma to_nat_top_apply_of_aleph_0_le {c : cardinal} (h : ℵ₀ ≤ c) : c.to_nat_top = ⊤ :=
 if_neg h.not_lt
 
-@[simp] lemma to_enat_cast (n : ℕ) : cardinal.to_enat n = n :=
-by rw [to_enat_apply_of_lt_aleph_0 (nat_lt_aleph_0 n), to_nat_cast]
+@[simp] lemma to_nat_top_cast (n : ℕ) : cardinal.to_nat_top n = n :=
+by rw [to_nat_top_apply_of_lt_aleph_0 (nat_lt_aleph_0 n), to_nat_cast]
 
-@[simp] lemma mk_to_enat_of_infinite [h : infinite α] : (#α).to_enat = ⊤ :=
-to_enat_apply_of_aleph_0_le (infinite_iff.1 h)
+@[simp] lemma mk_to_nat_top_of_infinite [h : infinite α] : (#α).to_nat_top = ⊤ :=
+to_nat_top_apply_of_aleph_0_le (infinite_iff.1 h)
 
-@[simp] theorem aleph_0_to_enat : to_enat ℵ₀ = ⊤ :=
-to_enat_apply_of_aleph_0_le le_rfl
+@[simp] theorem aleph_0_to_nat_top : to_nat_top ℵ₀ = ⊤ :=
+to_nat_top_apply_of_aleph_0_le le_rfl
 
-lemma to_enat_surjective : surjective to_enat :=
-λ x, enat.cases_on x ⟨ℵ₀, to_enat_apply_of_aleph_0_le le_rfl⟩ $ λ n, ⟨n, to_enat_cast n⟩
+lemma to_nat_top_surjective : surjective to_nat_top :=
+λ x, with_top.rec_top_coe ⟨ℵ₀, aleph_0_to_nat_top⟩ (λ n, ⟨n, to_nat_top_cast n⟩) x
 
-lemma mk_to_enat_eq_coe_card [fintype α] : (#α).to_enat = fintype.card α :=
+lemma mk_to_nat_top_eq_coe_card [fintype α] : (#α).to_nat_top = fintype.card α :=
 by simp
 
 lemma mk_int : #ℤ = ℵ₀ := mk_denumerable ℤ

--- a/src/set_theory/cardinal/continuum.lean
+++ b/src/set_theory/cardinal/continuum.lean
@@ -54,8 +54,8 @@ by { rw ←succ_aleph_0, exact order.succ_le_of_lt aleph_0_lt_continuum }
 @[simp] theorem continuum_to_nat : continuum.to_nat = 0 :=
 to_nat_apply_of_aleph_0_le aleph_0_le_continuum
 
-@[simp] theorem continuum_to_enat : continuum.to_enat = ⊤ :=
-to_enat_apply_of_aleph_0_le aleph_0_le_continuum
+@[simp] theorem continuum_to_nat_top : continuum.to_nat_top = ⊤ :=
+to_nat_top_apply_of_aleph_0_le aleph_0_le_continuum
 
 /-!
 ### Addition

--- a/src/set_theory/cardinal/finite.lean
+++ b/src/set_theory/cardinal/finite.lean
@@ -12,9 +12,8 @@ import set_theory.cardinal.basic
 
 * `nat.card α` is the cardinality of `α` as a natural number.
   If `α` is infinite, `nat.card α = 0`.
-* `enat.card α` is the cardinality of `α` as an extended natural number.
-  If `α` is infinite, `enat.card α = ⊤`.
-
+* `nat.card_top α` is the cardinality of `α` as an extended natural number (`with_top ℕ`).
+  If `α` is infinite, `nat.card_top α = ⊤`.
 -/
 
 open cardinal
@@ -77,18 +76,14 @@ card_congr equiv.ulift
 @[simp] lemma card_plift (α : Type*) : nat.card (plift α) = nat.card α :=
 card_congr equiv.plift
 
+/-- `nat.card_top α` is the cardinality of `α` as an extended natural number (`with_top ℕ`).
+  If `α` is infinite, `nat.card_top α = ⊤`. -/
+def card_top (α : Type*) : with_top ℕ := (mk α).to_nat_top
+
+@[simp] lemma card_top_eq_coe_fintype_card [fintype α] : card_top α = fintype.card α :=
+mk_to_nat_top_eq_coe_card
+
+@[simp] lemma card_top_eq_top_of_infinite [infinite α] : card_top α = ⊤ :=
+mk_to_nat_top_of_infinite
+
 end nat
-
-namespace enat
-
-/-- `enat.card α` is the cardinality of `α` as an extended natural number.
-  If `α` is infinite, `enat.card α = ⊤`. -/
-def card (α : Type*) : enat := (mk α).to_enat
-
-@[simp]
-lemma card_eq_coe_fintype_card [fintype α] : card α = fintype.card α := mk_to_enat_eq_coe_card
-
-@[simp]
-lemma card_eq_top_of_infinite [infinite α] : card α = ⊤ := mk_to_enat_of_infinite
-
-end enat

--- a/src/set_theory/cardinal/ordinal.lean
+++ b/src/set_theory/cardinal/ordinal.lean
@@ -222,8 +222,8 @@ aleph_0_pos.trans_le (aleph_0_le_aleph o)
 @[simp] theorem aleph_to_nat (o : ordinal) : (aleph o).to_nat = 0 :=
 to_nat_apply_of_aleph_0_le $ aleph_0_le_aleph o
 
-@[simp] theorem aleph_to_enat (o : ordinal) : (aleph o).to_enat = ⊤ :=
-to_enat_apply_of_aleph_0_le $ aleph_0_le_aleph o
+@[simp] theorem aleph_to_nat_top (o : ordinal) : (aleph o).to_nat_top = ⊤ :=
+to_nat_top_apply_of_aleph_0_le $ aleph_0_le_aleph o
 
 instance nonempty_out_aleph (o : ordinal) : nonempty (aleph o).ord.out.α :=
 begin


### PR DESCRIPTION
We transition away from `enat` and into `with_top ℕ`. The idea is that `enat` should be discouraged in noncomputable contexts.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
