### PR TITLE
chore(set_theory/zfc): fix def-eq abuse

### DIFF
--- a/src/set_theory/zfc.lean
+++ b/src/set_theory/zfc.lean
@@ -696,7 +696,7 @@ def mem_set (x : Set.{u}) (A : Class.{u}) : Prop := A x
 instance : has_coe Set Class := ⟨λ x, {y | y ∈ x}⟩
 
 /-- The universal class -/
-def univ : Class := set.univ
+def univ : Class := of_set set.univ
 
 /-- Assert that `A` is a ZFC set satisfying `p` -/
 def to_Set (p : Class.{u}) (A : Class.{u}) : Prop := ∃ x, ↑x = A ∧ mem_set x p
@@ -717,7 +717,7 @@ def Class_to_Cong (x : Class.{u}) : set Class.{u} := {y | y ∈ x}
 def powerset (x : Class) : Class := Cong_to_Class (set.powerset x)
 
 /-- The union of a class is the class of all members of ZFC sets in the class -/
-def Union (x : Class) : Class := set.sUnion (Class_to_Cong x)
+def Union (x : Class) : Class := of_set $ set.sUnion (Class_to_Cong x)
 notation `⋃` := Union
 
 theorem of_Set.inj {x y : Set.{u}} (h : (x : Class.{u}) = y) : x = y :=

--- a/src/set_theory/zfc.lean
+++ b/src/set_theory/zfc.lean
@@ -715,7 +715,7 @@ def Class_to_Cong (x : Class.{u}) : set Class.{u} := {y | y ∈ x}
 def powerset (x : Class) : Class := Cong_to_Class (set.powerset x)
 
 /-- The union of a class is the class of all members of ZFC sets in the class -/
-def Union (x : Class) : Class := of_set $ set.sUnion (Class_to_Cong x)
+def Union (x : Class) : Class := of_set $ set.sUnion $ Class_to_Cong x
 notation `⋃` := Union
 
 theorem of_Set.inj {x y : Set.{u}} (h : (x : Class.{u}) = y) : x = y :=

--- a/src/set_theory/zfc.lean
+++ b/src/set_theory/zfc.lean
@@ -688,8 +688,6 @@ def of_set : set Set ≃ Class := equiv.refl _
 /-- The preferred way to state that a set `x` belongs in a class `A`. -/
 def mem_set (x : Set.{u}) (A : Class.{u}) : Prop := A x
 
-@[simp] theorem apply_iff_mem_set {x : Set.{u}} {A : Class.{u}} : A x ↔ mem_set x A := iff.rfl
-
 @[simp] theorem mem_set_of_set {x : Set} {s : set Set} : mem_set x (of_set s) ↔ x ∈ s := iff.rfl
 
 /-- Coerce a ZFC set into a class -/

--- a/src/set_theory/zfc.lean
+++ b/src/set_theory/zfc.lean
@@ -776,7 +776,7 @@ mem_univ.2 $ or.elim (classical.em $ ∃ x, ∀ y, mem_set y p ↔ y = x)
 
 /-- Function value -/
 def fval (F A : Class.{u}) : Class.{u} :=
-iota $ of_set {y | to_Set (of_set {x | mem_set (Set.pair x y) F}) A}
+iota $ of_set {y | A ∈ of_set {x | mem_set (Set.pair x y) F}}
 
 infixl `′`:100 := fval
 
@@ -790,7 +790,7 @@ namespace Set
   {x y : Set.{u}} (h : y ∈ x) :
   (Set.map f x ′ y : Class.{u}) = f y :=
 Class.iota_val _ _ $ λ z, begin
-  simp only [Class.mem_hom_right, mem_map, exists_prop, Class.to_Set_of_Set, Class.mem_set_of_set,
+  simp only [Class.mem_hom_right, mem_map, exists_prop, Class.mem_hom_left, Class.mem_set_of_set,
     set.mem_set_of_eq],
   exact ⟨λ ⟨w, wz, pr⟩, let ⟨wy, fw⟩ := Set.pair_inj pr in by rw [←fw, wy],
     λ e, by { subst e, exact ⟨_, h, rfl⟩ }⟩


### PR DESCRIPTION
Throughout this part of the code, there was a lot of abuse of the definitional equalities between `set α` and `α → Prop`, and between `Class` and `set Set`. We introduce two definitions `of_set` and `mem_set` to hide away these casts, and use them throughout.

[Zulip discussion](https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/ZFC.20definable.20class/near/289116052)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
