### PR TITLE
[Merged by Bors] - golf(data/polynomial/degree/definitions): golf three proofs

### DIFF
--- a/src/data/polynomial/degree/definitions.lean
+++ b/src/data/polynomial/degree/definitions.lean
@@ -827,20 +827,20 @@ by rw [ne.def, ← degree_eq_bot];
   cases degree p; exact dec_trivial
 
 lemma degree_nonneg_iff_ne_zero : 0 ≤ degree p ↔ p ≠ 0 :=
-⟨λ h0p hp0, absurd h0p (by rw [hp0, degree_zero]; exact dec_trivial),
-  λ hp0, le_of_not_gt (λ h, by simp [gt, degree_eq_bot, *] at *)⟩
+by simp [degree_eq_bot.not, ← not_lt, ← not_iff]
 
 lemma nat_degree_eq_zero_iff_degree_le_zero : p.nat_degree = 0 ↔ p.degree ≤ 0 :=
 by rw [← nonpos_iff_eq_zero, nat_degree_le_iff_degree_le, with_bot.coe_zero]
 
 theorem degree_le_iff_coeff_zero (f : R[X]) (n : with_bot ℕ) :
   degree f ≤ n ↔ ∀ m : ℕ, n < m → coeff f m = 0 :=
-⟨λ (H : finset.sup (f.support) some ≤ n) m (Hm : n < (m : with_bot ℕ)), decidable.of_not_not $ λ H4,
-  have H1 : m ∉ f.support,
-    from λ H2, not_lt_of_ge ((finset.sup_le_iff.1 H) m H2 : ((m : with_bot ℕ) ≤ n)) Hm,
-  H1 $ mem_support_iff.2 H4,
-λ H, finset.sup_le $ λ b Hb, decidable.of_not_not $ λ Hn,
-  mem_support_iff.1 Hb $ H b $ lt_of_not_ge Hn⟩
+begin
+  refine ⟨λ h m mn, coeff_eq_zero_of_degree_lt (h.trans_lt mn), λ h, _⟩,
+  rcases n with _ | n,
+  { exact (degree_eq_bot.mpr (ext (λ (n : ℕ), h _ (with_bot.bot_lt_coe _)))).le },
+  refine finset.max_le (λ a ha, not_not.mp (λ ha0, not_not.mpr ha _)),
+  exact not_mem_support_iff.mpr (h _ (not_le.mp ha0))
+end
 
 theorem degree_lt_iff_coeff_zero (f : R[X]) (n : ℕ) :
   degree f < n ↔ ∀ m : ℕ, n ≤ m → coeff f m = 0 :=

--- a/src/data/polynomial/degree/definitions.lean
+++ b/src/data/polynomial/degree/definitions.lean
@@ -559,12 +559,11 @@ end
 lemma degree_update_le (p : R[X]) (n : ℕ) (a : R) :
   degree (p.update n a) ≤ max (degree p) n :=
 begin
-  simp only [degree, coeff_update_apply, le_max_iff, finset.sup_le_iff, mem_support_iff],
-  intros b hb,
-  split_ifs at hb with h,
-  { subst b,
-    exact or.inr le_rfl },
-  { exact or.inl (le_degree_of_ne_zero hb) }
+  rw [degree, support_update],
+  split_ifs,
+  { exact (finset.max_mono (erase_subset _ _)).trans (le_max_left _ _) },
+  { rw [sup_insert, max_comm],
+    exact rfl.le },
 end
 
 lemma degree_sum_le (s : finset ι) (f : ι → R[X]) :

--- a/src/data/polynomial/degree/definitions.lean
+++ b/src/data/polynomial/degree/definitions.lean
@@ -563,7 +563,7 @@ begin
   split_ifs,
   { exact (finset.max_mono (erase_subset _ _)).trans (le_max_left _ _) },
   { rw [sup_insert, max_comm],
-    exact rfl.le },
+    exact le_rfl },
 end
 
 lemma degree_sum_le (s : finset ι) (f : ι → R[X]) :
@@ -826,20 +826,14 @@ by rw [ne.def, ← degree_eq_bot];
   cases degree p; exact dec_trivial
 
 lemma degree_nonneg_iff_ne_zero : 0 ≤ degree p ↔ p ≠ 0 :=
-by simp [degree_eq_bot.not, ← not_lt, ← not_iff]
+by simp [degree_eq_bot, ← not_lt]
 
 lemma nat_degree_eq_zero_iff_degree_le_zero : p.nat_degree = 0 ↔ p.degree ≤ 0 :=
 by rw [← nonpos_iff_eq_zero, nat_degree_le_iff_degree_le, with_bot.coe_zero]
 
 theorem degree_le_iff_coeff_zero (f : R[X]) (n : with_bot ℕ) :
   degree f ≤ n ↔ ∀ m : ℕ, n < m → coeff f m = 0 :=
-begin
-  refine ⟨λ h m mn, coeff_eq_zero_of_degree_lt (h.trans_lt mn), λ h, _⟩,
-  rcases n with _ | n,
-  { exact (degree_eq_bot.mpr (ext (λ (n : ℕ), h _ (with_bot.bot_lt_coe _)))).le },
-  refine finset.max_le (λ a ha, not_not.mp (λ ha0, not_not.mpr ha _)),
-  exact not_mem_support_iff.mpr (h _ (not_le.mp ha0))
-end
+by simp only [degree, finset.sup_le_iff, mem_support_iff, ne.def, ← not_le, not_imp_comm]
 
 theorem degree_lt_iff_coeff_zero (f : R[X]) (n : ℕ) :
   degree f < n ↔ ∀ m : ℕ, n ≤ m → coeff f m = 0 :=


### PR DESCRIPTION
Lemmas `degree_update_le`, `degree_nonneg_iff_ne_zero` and `degree_le_iff_coeff_zero` have shorter proofs.

All three lemmas use the same axioms as they did before: 
```lean
propext
quot.sound
classical.choice
```

The golfing in `degree_le_iff_coeff_zero` is motivated by #15199, where the older version no longer compiles.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
