### PR TITLE
[Merged by Bors] - feat(group_theory/group_action/option): Scalar action on an option

### DIFF
--- a/src/group_theory/group_action/option.lean
+++ b/src/group_theory/group_action/option.lean
@@ -1,0 +1,53 @@
+/-
+Copyright (c) 2022 Yaël Dillies. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Yaël Dillies
+-/
+import group_theory.group_action.defs
+
+/-!
+# Sum instances for additive and multiplicative actions
+
+This file defines instances for additive and multiplicative actions on the binary `sum` type.
+
+## See also
+
+* `group_theory.group_action.pi`
+* `group_theory.group_action.prod`
+* `group_theory.group_action.sigma`
+-/
+
+variables {M N P α β γ : Type*}
+
+namespace option
+
+section has_smul
+variables [has_smul α β] [has_smul α γ] [has_smul β γ] (a : α) (b : β) (x : option β)
+
+@[to_additive option.has_vadd] instance : has_smul α (option β) := ⟨λ a, option.map $ (•) a⟩
+
+@[to_additive] lemma smul_def : a • x = x.map ((•) a) := rfl
+@[simp, to_additive] lemma smul_none : a • (none : option β) = none := rfl
+@[simp, to_additive] lemma smul_some : a • some b = some (a • b) := rfl
+
+instance [is_scalar_tower α β γ] : is_scalar_tower α β (option γ) :=
+⟨λ a b x, by { cases x, exacts [rfl, congr_arg some (smul_assoc _ _ _)] }⟩
+
+@[to_additive] instance {α β γ : Type*} [has_smul α γ] [has_smul β γ] [smul_comm_class α β γ] :
+  smul_comm_class α β (option γ) :=
+⟨λ a b x, by { cases x, exacts [rfl, congr_arg some (smul_comm _ _ _)] }⟩
+
+instance [has_smul αᵐᵒᵖ β] [is_central_scalar α β] : is_central_scalar α (option β) :=
+⟨λ a x, by { cases x, exacts [rfl, congr_arg some (op_smul_eq_smul _ _)] }⟩
+
+@[to_additive] instance [has_faithful_smul α β] : has_faithful_smul α (option β) :=
+⟨λ x y h, eq_of_smul_eq_smul $ λ b : β, by injection h (some b)⟩
+
+end has_smul
+
+instance [monoid α] [mul_action α β] : mul_action α (option β) :=
+{ smul := (•),
+  one_smul := λ b, by { cases b, exacts [rfl, congr_arg some (one_smul _ _)] },
+  mul_smul := λ a₁ a₂ b, by { cases b, exacts [rfl, congr_arg some (mul_smul _ _ _)] } }
+
+end option

--- a/src/group_theory/group_action/option.lean
+++ b/src/group_theory/group_action/option.lean
@@ -6,15 +6,17 @@ Authors: Yaël Dillies
 import group_theory.group_action.defs
 
 /-!
-# Sum instances for additive and multiplicative actions
+# Option instances for additive and multiplicative actions
 
-This file defines instances for additive and multiplicative actions on the binary `sum` type.
+This file defines instances for additive and multiplicative actions on `option` type. Scalar
+multiplication is defined by `a • some b = some (a • b)` and `a • none = none`.
 
 ## See also
 
 * `group_theory.group_action.pi`
 * `group_theory.group_action.prod`
 * `group_theory.group_action.sigma`
+* `group_theory.group_action.sum`
 -/
 
 variables {M N P α β γ : Type*}
@@ -35,7 +37,7 @@ instance [is_scalar_tower α β γ] : is_scalar_tower α β (option γ) :=
 
 @[to_additive] instance {α β γ : Type*} [has_smul α γ] [has_smul β γ] [smul_comm_class α β γ] :
   smul_comm_class α β (option γ) :=
-⟨λ a b x, by { cases x, exacts [rfl, congr_arg some (smul_comm _ _ _)] }⟩
+⟨λ a b, function.commute.option_map $ smul_comm _ _⟩
 
 instance [has_smul αᵐᵒᵖ β] [is_central_scalar α β] : is_central_scalar α (option β) :=
 ⟨λ a x, by { cases x, exacts [rfl, congr_arg some (op_smul_eq_smul _ _)] }⟩

--- a/src/group_theory/group_action/option.lean
+++ b/src/group_theory/group_action/option.lean
@@ -19,35 +19,35 @@ multiplication is defined by `a • some b = some (a • b)` and `a • none = n
 * `group_theory.group_action.sum`
 -/
 
-variables {M N P α β γ : Type*}
+variables {M N α : Type*}
 
 namespace option
 
 section has_smul
-variables [has_smul α β] [has_smul α γ] [has_smul β γ] (a : α) (b : β) (x : option β)
+variables [has_smul M α] [has_smul N α] (a : M) (b : α) (x : option α)
 
-@[to_additive option.has_vadd] instance : has_smul α (option β) := ⟨λ a, option.map $ (•) a⟩
+@[to_additive option.has_vadd] instance : has_smul M (option α) := ⟨λ a, option.map $ (•) a⟩
 
 @[to_additive] lemma smul_def : a • x = x.map ((•) a) := rfl
-@[simp, to_additive] lemma smul_none : a • (none : option β) = none := rfl
+@[simp, to_additive] lemma smul_none : a • (none : option α) = none := rfl
 @[simp, to_additive] lemma smul_some : a • some b = some (a • b) := rfl
 
-instance [is_scalar_tower α β γ] : is_scalar_tower α β (option γ) :=
+instance [has_smul M N] [is_scalar_tower M N α] : is_scalar_tower M N (option α) :=
 ⟨λ a b x, by { cases x, exacts [rfl, congr_arg some (smul_assoc _ _ _)] }⟩
 
-@[to_additive] instance {α β γ : Type*} [has_smul α γ] [has_smul β γ] [smul_comm_class α β γ] :
-  smul_comm_class α β (option γ) :=
+@[to_additive] instance {M N α : Type*} [has_smul M α] [has_smul N α] [smul_comm_class M N α] :
+  smul_comm_class M N (option α) :=
 ⟨λ a b, function.commute.option_map $ smul_comm _ _⟩
 
-instance [has_smul αᵐᵒᵖ β] [is_central_scalar α β] : is_central_scalar α (option β) :=
+instance [has_smul Mᵐᵒᵖ α] [is_central_scalar M α] : is_central_scalar M (option α) :=
 ⟨λ a x, by { cases x, exacts [rfl, congr_arg some (op_smul_eq_smul _ _)] }⟩
 
-@[to_additive] instance [has_faithful_smul α β] : has_faithful_smul α (option β) :=
-⟨λ x y h, eq_of_smul_eq_smul $ λ b : β, by injection h (some b)⟩
+@[to_additive] instance [has_faithful_smul M α] : has_faithful_smul M (option α) :=
+⟨λ x y h, eq_of_smul_eq_smul $ λ b : α, by injection h (some b)⟩
 
 end has_smul
 
-instance [monoid α] [mul_action α β] : mul_action α (option β) :=
+instance [monoid M] [mul_action M α] : mul_action M (option α) :=
 { smul := (•),
   one_smul := λ b, by { cases b, exacts [rfl, congr_arg some (one_smul _ _)] },
   mul_smul := λ a₁ a₂ b, by { cases b, exacts [rfl, congr_arg some (mul_smul _ _ _)] } }

--- a/src/group_theory/group_action/option.lean
+++ b/src/group_theory/group_action/option.lean
@@ -35,8 +35,7 @@ variables [has_smul M α] [has_smul N α] (a : M) (b : α) (x : option α)
 instance [has_smul M N] [is_scalar_tower M N α] : is_scalar_tower M N (option α) :=
 ⟨λ a b x, by { cases x, exacts [rfl, congr_arg some (smul_assoc _ _ _)] }⟩
 
-@[to_additive] instance {M N α : Type*} [has_smul M α] [has_smul N α] [smul_comm_class M N α] :
-  smul_comm_class M N (option α) :=
+@[to_additive] instance [smul_comm_class M N α] : smul_comm_class M N (option α) :=
 ⟨λ a b, function.commute.option_map $ smul_comm _ _⟩
 
 instance [has_smul Mᵐᵒᵖ α] [is_central_scalar M α] : is_central_scalar M (option α) :=

--- a/src/group_theory/group_action/pi.lean
+++ b/src/group_theory/group_action/pi.lean
@@ -13,6 +13,7 @@ This file defines instances for mul_action and related structures on Pi types.
 
 ## See also
 
+* `group_theory.group_action.option`
 * `group_theory.group_action.prod`
 * `group_theory.group_action.sigma`
 * `group_theory.group_action.sum`

--- a/src/group_theory/group_action/prod.lean
+++ b/src/group_theory/group_action/prod.lean
@@ -19,6 +19,7 @@ scalar multiplication as a homomorphism from `α × β` to `β`.
 
 ## See also
 
+* `group_theory.group_action.option`
 * `group_theory.group_action.pi`
 * `group_theory.group_action.sigma`
 * `group_theory.group_action.sum`

--- a/src/group_theory/group_action/sum.lean
+++ b/src/group_theory/group_action/sum.lean
@@ -12,6 +12,7 @@ This file defines instances for additive and multiplicative actions on the binar
 
 ## See also
 
+* `group_theory.group_action.option`
 * `group_theory.group_action.pi`
 * `group_theory.group_action.prod`
 * `group_theory.group_action.sigma`

--- a/src/logic/function/conjugate.lean
+++ b/src/logic/function/conjugate.lean
@@ -51,6 +51,11 @@ lemma inverses_right (h : semiconj f ga gb) (ha : right_inverse ga' ga)
   semiconj f ga' gb' :=
 λ x, by rw [← hb (f (ga' x)), ← h.eq, ha x]
 
+lemma option_map {f : α → β} {ga : α → α} {gb : β → β} (h : semiconj f ga gb) :
+  semiconj (option.map f) (option.map ga) (option.map gb)
+| none := rfl
+| (some a) := congr_arg some $ h _
+
 end semiconj
 
 /-- Two maps `f g : α → α` commute if `f (g x) = g (f x)` for all `x : α`.
@@ -77,6 +82,9 @@ lemma comp_left (h : commute f g) (h' : commute f' g) : commute (f ∘ f') g :=
 lemma id_right : commute f id := semiconj.id_right
 
 lemma id_left : commute id f := semiconj.id_left
+
+lemma option_map {f g : α → α} : commute f g → commute (option.map f) (option.map g) :=
+semiconj.option_map
 
 end commute
 


### PR DESCRIPTION
`has_scalar α β → has_scalar α (option β)` and similar.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

From Con(NF)

I actually use it on a type synonym of `with_bot` there, but it seems like a restricted enough use case that I can copy over the relevant instances by hand.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
