### PR TITLE
[Merged by Bors] - feat(data/finset/fold): add lemma `fold_max_add`

### DIFF
--- a/src/data/finset/fold.lean
+++ b/src/data/finset/fold.lean
@@ -230,6 +230,11 @@ end
 lemma lt_fold_max : c < s.fold max b f ↔ (c < b ∨ ∃ x∈s, c < f x) :=
 fold_op_rel_iff_or $ λ x y z, lt_max_iff
 
+lemma fold_max_add [has_add β] [covariant_class β β (function.swap (+)) (≤)]
+ (n : with_bot β) (s : finset α) :
+  finset.fold max ⊥ (λ (x : α), ↑(f x) + n) s = finset.fold max ⊥ (coe ∘ f) s + n :=
+by { classical, apply s.induction_on; simp [max_add_add_right] {contextual := tt} }
+
 end order
 
 end fold

--- a/src/data/finset/fold.lean
+++ b/src/data/finset/fold.lean
@@ -232,7 +232,7 @@ fold_op_rel_iff_or $ λ x y z, lt_max_iff
 
 lemma fold_max_add [has_add β] [covariant_class β β (function.swap (+)) (≤)]
  (n : with_bot β) (s : finset α) :
-  finset.fold max ⊥ (λ (x : α), ↑(f x) + n) s = finset.fold max ⊥ (coe ∘ f) s + n :=
+  s.fold max ⊥ (λ (x : α), ↑(f x) + n) = s.fold max ⊥ (coe ∘ f) + n :=
 by { classical, apply s.induction_on; simp [max_add_add_right] {contextual := tt} }
 
 end order


### PR DESCRIPTION
The lemma shows that adding inside or outside a "max-fold" amounts to the same.  It is the folded version of docs#max_add_add_right.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
