### PR TITLE
[Merged by Bors] - fix(category_theory/abelian/transfer): fix a potential timeout

### DIFF
--- a/src/category_theory/abelian/transfer.lean
+++ b/src/category_theory/abelian/transfer.lean
@@ -137,7 +137,6 @@ end
 local attribute [simp] cokernel_iso coimage_iso_image coimage_iso_image_aux
 
 -- The account of this proof in the Stacks project omits this calculation.
--- Happily it's little effort: our `[ext]` and `[simp]` lemmas only need a little guidance.
 lemma coimage_iso_image_hom {X Y : C} (f : X ⟶ Y) :
   (coimage_iso_image F G i adj f).hom = abelian.coimage_image_comparison f :=
 begin

--- a/src/category_theory/abelian/transfer.lean
+++ b/src/category_theory/abelian/transfer.lean
@@ -140,7 +140,15 @@ local attribute [simp] cokernel_iso coimage_iso_image coimage_iso_image_aux
 -- Happily it's little effort: our `[ext]` and `[simp]` lemmas only need a little guidance.
 lemma coimage_iso_image_hom {X Y : C} (f : X ⟶ Y) :
   (coimage_iso_image F G i adj f).hom = abelian.coimage_image_comparison f :=
-by { ext, simpa [-functor.map_comp, ←G.map_comp_assoc] using nat_iso.naturality_1 i f, }
+by { ext, simpa only [←G.map_comp_assoc, coimage_iso_image, nat_iso.inv_inv_app, cokernel_iso,
+  coimage_iso_image_aux, iso.trans_symm, iso.symm_symm_eq, iso.refl_trans, iso.trans_refl,
+  iso.trans_hom, iso.symm_hom, cokernel_comp_is_iso_inv, cokernel_epi_comp_inv, as_iso_hom,
+  functor.map_iso_hom, cokernel_epi_comp_hom, preserves_kernel.iso_hom, kernel_comp_mono_hom,
+  kernel_is_iso_comp_hom, cokernel_iso_of_eq_hom_comp_desc_assoc, cokernel.π_desc_assoc,
+  category.assoc, π_comp_cokernel_iso_of_eq_inv_assoc, π_comp_cokernel_comparison_assoc,
+  kernel.lift_ι, kernel.lift_ι_assoc, kernel_iso_of_eq_hom_comp_ι_assoc,
+  kernel_comparison_comp_ι_assoc,
+  abelian.coimage_image_factorisation] using nat_iso.naturality_1 i f, }
 
 end abelian_of_adjunction
 

--- a/src/category_theory/abelian/transfer.lean
+++ b/src/category_theory/abelian/transfer.lean
@@ -140,15 +140,18 @@ local attribute [simp] cokernel_iso coimage_iso_image coimage_iso_image_aux
 -- Happily it's little effort: our `[ext]` and `[simp]` lemmas only need a little guidance.
 lemma coimage_iso_image_hom {X Y : C} (f : X ⟶ Y) :
   (coimage_iso_image F G i adj f).hom = abelian.coimage_image_comparison f :=
-by { ext, simpa only [←G.map_comp_assoc, coimage_iso_image, nat_iso.inv_inv_app, cokernel_iso,
-  coimage_iso_image_aux, iso.trans_symm, iso.symm_symm_eq, iso.refl_trans, iso.trans_refl,
-  iso.trans_hom, iso.symm_hom, cokernel_comp_is_iso_inv, cokernel_epi_comp_inv, as_iso_hom,
-  functor.map_iso_hom, cokernel_epi_comp_hom, preserves_kernel.iso_hom, kernel_comp_mono_hom,
-  kernel_is_iso_comp_hom, cokernel_iso_of_eq_hom_comp_desc_assoc, cokernel.π_desc_assoc,
-  category.assoc, π_comp_cokernel_iso_of_eq_inv_assoc, π_comp_cokernel_comparison_assoc,
-  kernel.lift_ι, kernel.lift_ι_assoc, kernel_iso_of_eq_hom_comp_ι_assoc,
-  kernel_comparison_comp_ι_assoc,
-  abelian.coimage_image_factorisation] using nat_iso.naturality_1 i f, }
+begin
+  ext, 
+  simpa only [←G.map_comp_assoc, coimage_iso_image, nat_iso.inv_inv_app, cokernel_iso,
+    coimage_iso_image_aux, iso.trans_symm, iso.symm_symm_eq, iso.refl_trans, iso.trans_refl,
+    iso.trans_hom, iso.symm_hom, cokernel_comp_is_iso_inv, cokernel_epi_comp_inv, as_iso_hom,
+    functor.map_iso_hom, cokernel_epi_comp_hom, preserves_kernel.iso_hom, kernel_comp_mono_hom,
+    kernel_is_iso_comp_hom, cokernel_iso_of_eq_hom_comp_desc_assoc, cokernel.π_desc_assoc,
+    category.assoc, π_comp_cokernel_iso_of_eq_inv_assoc, π_comp_cokernel_comparison_assoc,
+    kernel.lift_ι, kernel.lift_ι_assoc, kernel_iso_of_eq_hom_comp_ι_assoc,
+    kernel_comparison_comp_ι_assoc,
+    abelian.coimage_image_factorisation] using nat_iso.naturality_1 i f
+end
 
 end abelian_of_adjunction
 

--- a/src/ring_theory/localization/basic.lean
+++ b/src/ring_theory/localization/basic.lean
@@ -793,13 +793,6 @@ instance : comm_semiring (localization M) :=
   right_distrib  := λ m n k, localization.induction_on₃ m n k (by tac),
   .. localization.comm_monoid_with_zero M }
 
-lemma mk_sum {ι : Type*} (f : ι → R) (s : finset ι) (b : M) :
-  mk (s.sum f) b = s.sum (λ i, mk (f i) b) :=
-by classical; exact finset.induction_on s (by simp only [finset.sum_empty, mk_zero]) begin
-  intros i s h ih,
-  rw [finset.sum_insert h, ←add_mk_self, ih, finset.sum_insert h],
-end
-
 instance {S : Type*} [monoid S] [distrib_mul_action S R] [is_scalar_tower S R R] :
   distrib_mul_action S (localization M) :=
 { smul_zero := λ s, by simp only [←localization.mk_zero 1, localization.smul_mk, smul_zero],

--- a/src/ring_theory/localization/basic.lean
+++ b/src/ring_theory/localization/basic.lean
@@ -793,6 +793,13 @@ instance : comm_semiring (localization M) :=
   right_distrib  := λ m n k, localization.induction_on₃ m n k (by tac),
   .. localization.comm_monoid_with_zero M }
 
+lemma mk_sum {ι : Type*} (f : ι → R) (s : finset ι) (b : M) :
+  mk (s.sum f) b = s.sum (λ i, mk (f i) b) :=
+by classical; exact finset.induction_on s (by simp only [finset.sum_empty, mk_zero]) begin
+  intros i s h ih,
+  rw [finset.sum_insert h, ←add_mk_self, ih, finset.sum_insert h],
+end
+
 instance {S : Type*} [monoid S] [distrib_mul_action S R] [is_scalar_tower S R R] :
   distrib_mul_action S (localization M) :=
 { smul_zero := λ s, by simp only [←localization.mk_zero 1, localization.smul_mk, smul_zero],


### PR DESCRIPTION
At `src/category_theory/abelian/transfer.lean` line 149, `abelian_of_adjunction.coimage_iso_image_hom` is on edge of being timed out by any additional simp lemmas, see #15232. This pr squeezed the `simpa` statement. 

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
