### PR TITLE
refactor(topology/inseparable): rename to `kolmogorov_quotient`

### DIFF
--- a/src/topology/inseparable.lean
+++ b/src/topology/inseparable.lean
@@ -19,7 +19,7 @@ In this file we define
 
 * `inseparable_setoid X`: same relation, as a `setoid`;
 
-* `separation_quotient X`: the quotient of `X` by its `inseparable_setoid`.
+* `kolmogorov_quotient X`: the quotient of `X` by its `inseparable_setoid`.
 
 We also prove various basic properties of the relation `inseparable`.
 
@@ -251,14 +251,14 @@ lemma is_open.not_inseparable (hs : is_open s) (hx : x ∈ s) (hy : y ∉ s) : �
 λ h, hy $ (h.mem_open_iff hs).1 hx
 
 /-!
-### Separation quotient
+### Kolmogorov (separation) quotient
 
 In this section we define the quotient of a topological space by the `inseparable` relation.
 -/
 
 variable (X)
 
-/-- A `setoid` version of `inseparable`, used to define the `separation_quotient`. -/
+/-- A `setoid` version of `inseparable`, used to define the `kolmogorov_quotient`. -/
 def inseparable_setoid : setoid X :=
 { r := (~),
   .. setoid.comap 𝓝 ⊥ }
@@ -266,32 +266,32 @@ def inseparable_setoid : setoid X :=
 /-- The quotient of a topological space by its `inseparable_setoid`. This quotient is guaranteed to
 be a T₀ space. -/
 @[derive topological_space]
-def separation_quotient := quotient (inseparable_setoid X)
+def kolmogorov_quotient := quotient (inseparable_setoid X)
 
 variable {X}
 
-namespace separation_quotient
+namespace kolmogorov_quotient
 
 /-- The natural map from a topological space to its separation quotient. -/
-def mk : X → separation_quotient X := quotient.mk'
+def mk : X → kolmogorov_quotient X := quotient.mk'
 
-lemma quotient_map_mk : quotient_map (mk : X → separation_quotient X) :=
+lemma quotient_map_mk : quotient_map (mk : X → kolmogorov_quotient X) :=
 quotient_map_quot_mk
 
-lemma continuous_mk : continuous (mk : X → separation_quotient X) :=
+lemma continuous_mk : continuous (mk : X → kolmogorov_quotient X) :=
 continuous_quot_mk
 
 @[simp] lemma mk_eq_mk : mk x = mk y ↔ x ~ y := quotient.eq'
 
-lemma surjective_mk : surjective (mk : X → separation_quotient X) :=
+lemma surjective_mk : surjective (mk : X → kolmogorov_quotient X) :=
 surjective_quot_mk _
 
-@[simp] lemma range_mk : range (mk : X → separation_quotient X) = univ :=
+@[simp] lemma range_mk : range (mk : X → kolmogorov_quotient X) = univ :=
 surjective_mk.range_eq
 
-instance [nonempty X] : nonempty (separation_quotient X) := nonempty.map mk ‹_›
-instance [inhabited X] : inhabited (separation_quotient X) := ⟨mk default⟩
-instance [subsingleton X] : subsingleton (separation_quotient X) := surjective_mk.subsingleton
+instance [nonempty X] : nonempty (kolmogorov_quotient X) := nonempty.map mk ‹_›
+instance [inhabited X] : inhabited (kolmogorov_quotient X) := ⟨mk default⟩
+instance [subsingleton X] : subsingleton (kolmogorov_quotient X) := surjective_mk.subsingleton
 
 lemma preimage_image_mk_open (hs : is_open s) : mk ⁻¹' (mk '' s) = s :=
 begin
@@ -300,7 +300,7 @@ begin
   exact ((mk_eq_mk.1 hxy).mem_open_iff hs).1 hys
 end
 
-lemma is_open_map_mk : is_open_map (mk : X → separation_quotient X) :=
+lemma is_open_map_mk : is_open_map (mk : X → kolmogorov_quotient X) :=
 λ s hs, quotient_map_mk.is_open_preimage.1 $ by rwa preimage_image_mk_open hs
 
 lemma preimage_image_mk_closed (hs : is_closed s) : mk ⁻¹' (mk '' s) = s :=
@@ -310,14 +310,14 @@ begin
   exact ((mk_eq_mk.1 hxy).mem_closed_iff hs).1 hys
 end
 
-lemma inducing_mk : inducing (mk : X → separation_quotient X) :=
+lemma inducing_mk : inducing (mk : X → kolmogorov_quotient X) :=
 ⟨le_antisymm (continuous_iff_le_induced.1 continuous_mk)
   (λ s hs, ⟨mk '' s, is_open_map_mk s hs, preimage_image_mk_open hs⟩)⟩
 
-lemma is_closed_map_mk : is_closed_map (mk : X → separation_quotient X) :=
+lemma is_closed_map_mk : is_closed_map (mk : X → kolmogorov_quotient X) :=
 inducing_mk.is_closed_map $ by { rw [range_mk], exact is_closed_univ }
 
 lemma map_mk_nhds : map mk (𝓝 x) = 𝓝 (mk x) :=
 by rw [inducing_mk.nhds_eq_comap, map_comap_of_surjective surjective_mk]
 
-end separation_quotient
+end kolmogorov_quotient

--- a/src/topology/separation.lean
+++ b/src/topology/separation.lean
@@ -195,9 +195,9 @@ def specialization_order (α : Type*) [topological_space α] [t0_space α] : par
 { .. specialization_preorder α,
   .. partial_order.lift (order_dual.to_dual ∘ 𝓝) nhds_injective }
 
-instance : t0_space (separation_quotient α) :=
+instance : t0_space (kolmogorov_quotient α) :=
 ⟨λ x' y', quotient.induction_on₂' x' y' $
-  λ x y h, separation_quotient.mk_eq_mk.2 $ separation_quotient.inducing_mk.inseparable_iff.1 h⟩
+  λ x y h, kolmogorov_quotient.mk_eq_mk.2 $ kolmogorov_quotient.inducing_mk.inseparable_iff.1 h⟩
 
 theorem minimal_nonempty_closed_subsingleton [t0_space α] {s : set α} (hs : is_closed s)
   (hmin : ∀ t ⊆ s, t.nonempty → is_closed t → t = s) :


### PR DESCRIPTION
This is the name used, e.g., in Wikipedia. They also use `indistinguishable` for `inseparable` but it's too ambiguous and `topologically_indistinguishable` is too long.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
