### PR TITLE
[Merged by Bors] - feat(data/nat/parity): `nat.bit1_div_bit0`

### DIFF
--- a/src/data/nat/parity.lean
+++ b/src/data/nat/parity.lean
@@ -201,6 +201,18 @@ by { convert nat.div_add_mod' n 2, rw odd_iff.mp h }
 lemma one_add_div_two_mul_two_of_odd (h : odd n) : 1 + n / 2 * 2 = n :=
 by { rw add_comm, convert nat.div_add_mod' n 2, rw odd_iff.mp h }
 
+@[simp] lemma bit0_div_two : bit0 n / 2 = n :=
+by rw [←nat.bit0_eq_bit0, bit0_eq_two_mul, two_mul_div_two_of_even (even_bit0 n)]
+
+@[simp] lemma bit1_div_two : bit1 n / 2 = n :=
+by rw [←nat.bit1_eq_bit1, bit1, bit0_eq_two_mul, nat.two_mul_div_two_add_one_of_odd (odd_bit1 n)]
+
+@[simp] lemma bit0_div_bit0 : bit0 n / bit0 m = n / m :=
+by rw [bit0_eq_two_mul m, ←nat.div_div_eq_div_mul, bit0_div_two]
+
+@[simp] lemma nat.bit1_div_bit0 : bit1 n / bit0 m = n / m :=
+by rw [bit0_eq_two_mul, ←nat.div_div_eq_div_mul, bit1_div_two]
+
 -- Here are examples of how `parity_simps` can be used with `nat`.
 
 example (m n : ℕ) (h : even m) : ¬ even (n + 3) ↔ even (m^2 + m + n) :=

--- a/src/data/nat/parity.lean
+++ b/src/data/nat/parity.lean
@@ -210,7 +210,7 @@ by rw [←nat.bit1_eq_bit1, bit1, bit0_eq_two_mul, nat.two_mul_div_two_add_one_o
 @[simp] lemma bit0_div_bit0 : bit0 n / bit0 m = n / m :=
 by rw [bit0_eq_two_mul m, ←nat.div_div_eq_div_mul, bit0_div_two]
 
-@[simp] lemma nat.bit1_div_bit0 : bit1 n / bit0 m = n / m :=
+@[simp] lemma bit1_div_bit0 : bit1 n / bit0 m = n / m :=
 by rw [bit0_eq_two_mul, ←nat.div_div_eq_div_mul, bit1_div_two]
 
 -- Here are examples of how `parity_simps` can be used with `nat`.

--- a/src/data/nat/parity.lean
+++ b/src/data/nat/parity.lean
@@ -201,10 +201,10 @@ by { convert nat.div_add_mod' n 2, rw odd_iff.mp h }
 lemma one_add_div_two_mul_two_of_odd (h : odd n) : 1 + n / 2 * 2 = n :=
 by { rw add_comm, convert nat.div_add_mod' n 2, rw odd_iff.mp h }
 
-@[simp] lemma bit0_div_two : bit0 n / 2 = n :=
+lemma bit0_div_two : bit0 n / 2 = n :=
 by rw [←nat.bit0_eq_bit0, bit0_eq_two_mul, two_mul_div_two_of_even (even_bit0 n)]
 
-@[simp] lemma bit1_div_two : bit1 n / 2 = n :=
+lemma bit1_div_two : bit1 n / 2 = n :=
 by rw [←nat.bit1_eq_bit1, bit1, bit0_eq_two_mul, nat.two_mul_div_two_add_one_of_odd (odd_bit1 n)]
 
 @[simp] lemma bit0_div_bit0 : bit0 n / bit0 m = n / m :=


### PR DESCRIPTION
This PR adds `nat.bit1_div_bit0` and related lemmas. This came up when working with the power series of sin.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
