### PR TITLE
[Merged by Bors] - chore(analysis/inner_product_space): split slow proof

### DIFF
--- a/src/analysis/inner_product_space/l2_space.lean
+++ b/src/analysis/inner_product_space/l2_space.lean
@@ -407,7 +407,7 @@ by rw [orthogonal_family.linear_isometry_equiv_symm_apply_single,
 
 @[simp] protected lemma coe_mk (hsp : (span 𝕜 (set.range v)).topological_closure = ⊤) :
   ⇑(hilbert_basis.mk hv hsp) = v :=
-funext (orthonormal.linear_isometry_equiv_symm_apply_single_one hv _)
+funext $ orthonormal.linear_isometry_equiv_symm_apply_single_one hv _
 
 /-- An orthonormal family of vectors whose span has trivial orthogonal complement is a Hilbert
 basis. -/

--- a/src/analysis/inner_product_space/l2_space.lean
+++ b/src/analysis/inner_product_space/l2_space.lean
@@ -400,15 +400,14 @@ begin
   simp [← linear_map.span_singleton_eq_range, ← submodule.span_Union],
 end
 
-lemma _root_.orthonormal.linear_isometry_equiv_symm_apply_single_one
-  (hsp : (span 𝕜 (set.range v)).topological_closure = ⊤) (h i) :
+lemma _root_.orthonormal.linear_isometry_equiv_symm_apply_single_one (h i) :
   (hv.orthogonal_family.linear_isometry_equiv h).symm (lp.single 2 i 1) = v i :=
 by rw [orthogonal_family.linear_isometry_equiv_symm_apply_single,
   linear_isometry.to_span_singleton_apply, one_smul]
 
 @[simp] protected lemma coe_mk (hsp : (span 𝕜 (set.range v)).topological_closure = ⊤) :
   ⇑(hilbert_basis.mk hv hsp) = v :=
-funext (hv.linear_isometry_equiv_symm_apply_single_one hsp _)
+funext (orthonormal.linear_isometry_equiv_symm_apply_single_one hv _)
 
 /-- An orthonormal family of vectors whose span has trivial orthogonal complement is a Hilbert
 basis. -/

--- a/src/analysis/inner_product_space/l2_space.lean
+++ b/src/analysis/inner_product_space/l2_space.lean
@@ -400,13 +400,15 @@ begin
   simp [← linear_map.span_singleton_eq_range, ← submodule.span_Union],
 end
 
+lemma _root_.orthonormal.linear_isometry_equiv_symm_apply_single_one
+  (hsp : (span 𝕜 (set.range v)).topological_closure = ⊤) (h i) :
+  (hv.orthogonal_family.linear_isometry_equiv h).symm (lp.single 2 i 1) = v i :=
+by rw [orthogonal_family.linear_isometry_equiv_symm_apply_single,
+  linear_isometry.to_span_singleton_apply, one_smul]
+
 @[simp] protected lemma coe_mk (hsp : (span 𝕜 (set.range v)).topological_closure = ⊤) :
   ⇑(hilbert_basis.mk hv hsp) = v :=
-begin
-  ext i,
-  show (hilbert_basis.mk hv hsp).repr.symm _ = v i,
-  simp [hilbert_basis.mk]
-end
+funext (hv.linear_isometry_equiv_symm_apply_single_one hsp _)
 
 /-- An orthonormal family of vectors whose span has trivial orthogonal complement is a Hilbert
 basis. -/


### PR DESCRIPTION
This proof times out in the kernel at about 90 000 out of 100 000 heartbeats, and #14894 pushed it over the edge of timing out (except #15251 upped the timeout limits so everything sitll builds at the moment). I don't know enough about the kernel to debug why it doesn't like this proof, but splitting it into a `rw` part and a part that uses defeq seems to fix the timeout (moving it back down to about 60 000 out of 100 000 heartbeats).

Zulip thread: https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/Timeout.20in.20the.20kernel/near/289294804

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
