### PR TITLE
feat(logic/hydra): induction on an unordered pair

### DIFF
--- a/src/logic/hydra.lean
+++ b/src/logic/hydra.lean
@@ -140,6 +140,14 @@ or.inr $ by rwa prod.swap_swap
 lemma game_add.swap_right {a b} (h : game_add r r a b) : game_add_swap r a b.swap :=
 or.inr $ by rwa game_add_swap_swap
 
+lemma game_add.swap_mk_left {a b c d} : game_add r r (a, b) (c, d) →
+  game_add_swap r (b, a) (c, d) :=
+@game_add.swap_left α r (a, b) (c, d)
+
+lemma game_add.swap_mk_right {a b c d} : game_add r r (a, b) (c, d) →
+  game_add_swap r (a, b) (d, c) :=
+@game_add.swap_right α r (a, b) (c, d)
+
 /-- `game_add` is a `subrelation` of `game_add_swap`. -/
 lemma game_add_swap_le_game_add : game_add r r ≤ game_add_swap r := λ a b, game_add.swap
 

--- a/src/logic/hydra.lean
+++ b/src/logic/hydra.lean
@@ -111,18 +111,33 @@ end
 lemma _root_.well_founded.game_add (hα : well_founded rα) (hβ : well_founded rβ) :
   well_founded (game_add rα rβ) := ⟨λ ⟨a,b⟩, (hα.apply a).game_add (hβ.apply b)⟩
 
+def game_add.fix {C : α → β → Sort*} (hα : well_founded rα) (hβ : well_founded rβ)
+  (IH : Π a₁ b₁, (Π a₂ b₂, game_add rα rβ (a₂, b₂) (a₁, b₁) → C a₂ b₂) → C a₁ b₁) (a : α) (b : β) :
+  C a b :=
+@well_founded.fix (α × β) (λ x, C x.1 x.2) _ (hα.game_add hβ)
+  (λ ⟨x₁, x₂⟩ IH', IH x₁ x₂ $ λ a' b', IH' ⟨a', b'⟩) ⟨a, b⟩
+
+lemma game_add.fix_eq {C : α → β → Sort*} (hα : well_founded rα) (hβ : well_founded rβ)
+  (IH : Π a₁ b₁, (Π a₂ b₂, game_add rα rβ (a₂, b₂) (a₁, b₁) → C a₂ b₂) → C a₁ b₁) (a : α) (b : β) :
+  game_add.fix hα hβ IH a b = IH a b (λ a' b' h, game_add.fix hα hβ IH a' b') :=
+by { rw [game_add.fix, well_founded.fix_eq], refl }
+
+lemma game_add.induction {C : α → β → Prop} : well_founded rα → well_founded rβ →
+  (∀ a₁ b₁, (∀ a₂ b₂, game_add rα rβ (a₂, b₂) (a₁, b₁) → C a₂ b₂) → C a₁ b₁) → ∀ a b, C a b :=
+game_add.fix
+
 /-- The relation `game_add r r a b ∨ game_add r r a.swap b`, which is well-founded when `r` is. -/
 def game_add_swap (r : α → α → Prop) (a b : α × α) : Prop :=
 game_add r r a b ∨ game_add r r a.swap b
 
 variable {r : α → α → Prop}
 
-theorem game_add.swap {a b} : game_add r r a b → game_add_swap r a b := or.inl
+lemma game_add.swap {a b} : game_add r r a b → game_add_swap r a b := or.inl
 
-theorem game_add.swap_left {a b} (h : game_add r r a b) : game_add_swap r a.swap b :=
+lemma game_add.swap_left {a b} (h : game_add r r a b) : game_add_swap r a.swap b :=
 or.inr $ by rwa prod.swap_swap
 
-theorem game_add.swap_right {a b} (h : game_add r r a b) : game_add_swap r a b.swap :=
+lemma game_add.swap_right {a b} (h : game_add r r a b) : game_add_swap r a b.swap :=
 or.inr $ by rwa game_add_swap_swap
 
 /-- `game_add` is a `subrelation` of `game_add_swap`. -/
@@ -144,6 +159,21 @@ lemma _root_.acc.game_add_swap {a b} (ha : acc r a) (hb : acc r b) : acc (game_a
 /-- The `game_add_swap` relation is well-founded. -/
 lemma _root_.well_founded.game_add_swap (h : well_founded r) :
   well_founded (game_add_swap r) := ⟨λ ⟨a, b⟩, (h.apply a).game_add_swap (h.apply b)⟩
+
+def game_add_swap.fix {C : α → α → Sort*} (hr : well_founded r)
+  (IH : Π a₁ b₁, (Π a₂ b₂, game_add_swap r (a₂, b₂) (a₁, b₁) → C a₂ b₂) → C a₁ b₁) (a b : α) :
+  C a b :=
+@well_founded.fix (α × α) (λ x, C x.1 x.2) _ hr.game_add_swap
+  (λ ⟨x₁, x₂⟩ IH', IH x₁ x₂ $ λ a' b', IH' ⟨a', b'⟩) ⟨a, b⟩
+
+lemma game_add_swap.fix_eq {C : α → α → Sort*} (hr : well_founded r)
+  (IH : Π a₁ b₁, (Π a₂ b₂, game_add_swap r (a₂, b₂) (a₁, b₁) → C a₂ b₂) → C a₁ b₁) (a b : α) :
+  game_add_swap.fix hr IH a b = IH a b (λ a' b' h, game_add_swap.fix hr IH a' b') :=
+by { rw [game_add_swap.fix, well_founded.fix_eq], refl }
+
+lemma game_add_swap.induction {C : α → α → Prop} : well_founded r →
+  (∀ a₁ b₁, (∀ a₂ b₂, game_add_swap r (a₂, b₂) (a₁, b₁) → C a₂ b₂) → C a₁ b₁) → ∀ a b, C a b :=
+game_add_swap.fix
 
 end aux_rels
 

--- a/src/logic/hydra.lean
+++ b/src/logic/hydra.lean
@@ -86,13 +86,10 @@ variables {rα rβ}
 
 @[simp] lemma game_add_swap_swap : ∀ (a b : α × β),
   game_add rβ rα a.swap b.swap ↔ game_add rα rβ a b :=
-begin
-  rintros ⟨a₁, b₁⟩ ⟨a₂, b₂⟩,
-  split,
-  all_goals
+λ ⟨a₁, b₁⟩ ⟨a₂, b₂⟩, begin
+  split;
   { rintro (⟨_, _, _, rb⟩ | ⟨_, _, _, ra⟩),
-    { exact game_add.snd rb },
-    { exact game_add.fst ra } }
+    exacts [game_add.snd rb, game_add.fst ra] }
 end
 
 /-- If `a` is accessible under `rα` and `b` is accessible under `rβ`, then `(a, b)` is

--- a/src/logic/hydra.lean
+++ b/src/logic/hydra.lean
@@ -111,6 +111,7 @@ end
 lemma _root_.well_founded.game_add (hα : well_founded rα) (hβ : well_founded rβ) :
   well_founded (game_add rα rβ) := ⟨λ ⟨a,b⟩, (hα.apply a).game_add (hβ.apply b)⟩
 
+/-- Recursion on the well-founded `game_add` relation. -/
 def game_add.fix {C : α → β → Sort*} (hα : well_founded rα) (hβ : well_founded rβ)
   (IH : Π a₁ b₁, (Π a₂ b₂, game_add rα rβ (a₂, b₂) (a₁, b₁) → C a₂ b₂) → C a₁ b₁) (a : α) (b : β) :
   C a b :=
@@ -122,6 +123,7 @@ lemma game_add.fix_eq {C : α → β → Sort*} (hα : well_founded rα) (hβ : 
   game_add.fix hα hβ IH a b = IH a b (λ a' b' h, game_add.fix hα hβ IH a' b') :=
 by { rw [game_add.fix, well_founded.fix_eq], refl }
 
+/-- Induction on the well-founded `game_add` relation. -/
 lemma game_add.induction {C : α → β → Prop} : well_founded rα → well_founded rβ →
   (∀ a₁ b₁, (∀ a₂ b₂, game_add rα rβ (a₂, b₂) (a₁, b₁) → C a₂ b₂) → C a₁ b₁) → ∀ a b, C a b :=
 game_add.fix
@@ -168,6 +170,7 @@ lemma _root_.acc.game_add_swap {a b} (ha : acc r a) (hb : acc r b) : acc (game_a
 lemma _root_.well_founded.game_add_swap (h : well_founded r) :
   well_founded (game_add_swap r) := ⟨λ ⟨a, b⟩, (h.apply a).game_add_swap (h.apply b)⟩
 
+/-- Recursion on the well-founded `game_add_swap` relation. -/
 def game_add_swap.fix {C : α → α → Sort*} (hr : well_founded r)
   (IH : Π a₁ b₁, (Π a₂ b₂, game_add_swap r (a₂, b₂) (a₁, b₁) → C a₂ b₂) → C a₁ b₁) (a b : α) :
   C a b :=
@@ -179,6 +182,7 @@ lemma game_add_swap.fix_eq {C : α → α → Sort*} (hr : well_founded r)
   game_add_swap.fix hr IH a b = IH a b (λ a' b' h, game_add_swap.fix hr IH a' b') :=
 by { rw [game_add_swap.fix, well_founded.fix_eq], refl }
 
+/-- Induction on the well-founded `game_add_swap` relation. -/
 lemma game_add_swap.induction {C : α → α → Prop} : well_founded r →
   (∀ a₁ b₁, (∀ a₂ b₂, game_add_swap r (a₂, b₂) (a₁, b₁) → C a₂ b₂) → C a₁ b₁) → ∀ a b, C a b :=
 game_add_swap.fix


### PR DESCRIPTION
We define the relation `game_add_swap r a b = game_add r r a b ∨ game_add r r a.swap b` and prove its well-foundedness. This formalizes induction on an unordered pair, where either entry decreases.

To facilitate using these relations, we also add custom induction/recursion lemmas for `game_add` and `game_add_swap`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
