### PR TITLE
chore(set_theory/game/pgame): golf `le` and `lf` basic API

### DIFF
--- a/src/logic/hydra.lean
+++ b/src/logic/hydra.lean
@@ -140,6 +140,14 @@ or.inr $ by rwa prod.swap_swap
 lemma game_add.swap_right {a b} (h : game_add r r a b) : game_add_swap r a b.swap :=
 or.inr $ by rwa game_add_swap_swap
 
+lemma game_add.swap_mk_left {a b c d} : game_add r r (a, b) (c, d) →
+  game_add_swap r (b, a) (c, d) :=
+@game_add.swap_left α r (a, b) (c, d)
+
+lemma game_add.swap_mk_right {a b c d} : game_add r r (a, b) (c, d) →
+  game_add_swap r (a, b) (d, c) :=
+@game_add.swap_right α r (a, b) (c, d)
+
 /-- `game_add` is a `subrelation` of `game_add_swap`. -/
 lemma game_add_swap_le_game_add : game_add r r ≤ game_add_swap r := λ a b, game_add.swap
 

--- a/src/logic/hydra.lean
+++ b/src/logic/hydra.lean
@@ -111,18 +111,33 @@ end
 lemma _root_.well_founded.game_add (hα : well_founded rα) (hβ : well_founded rβ) :
   well_founded (game_add rα rβ) := ⟨λ ⟨a,b⟩, (hα.apply a).game_add (hβ.apply b)⟩
 
+def game_add.fix {C : α → β → Sort*} (hα : well_founded rα) (hβ : well_founded rβ)
+  (IH : Π a₁ b₁, (Π a₂ b₂, game_add rα rβ (a₂, b₂) (a₁, b₁) → C a₂ b₂) → C a₁ b₁) (a : α) (b : β) :
+  C a b :=
+@well_founded.fix (α × β) (λ x, C x.1 x.2) _ (hα.game_add hβ)
+  (λ ⟨x₁, x₂⟩ IH', IH x₁ x₂ $ λ a' b', IH' ⟨a', b'⟩) ⟨a, b⟩
+
+lemma game_add.fix_eq {C : α → β → Sort*} (hα : well_founded rα) (hβ : well_founded rβ)
+  (IH : Π a₁ b₁, (Π a₂ b₂, game_add rα rβ (a₂, b₂) (a₁, b₁) → C a₂ b₂) → C a₁ b₁) (a : α) (b : β) :
+  game_add.fix hα hβ IH a b = IH a b (λ a' b' h, game_add.fix hα hβ IH a' b') :=
+by { rw [game_add.fix, well_founded.fix_eq], refl }
+
+lemma game_add.induction {C : α → β → Prop} : well_founded rα → well_founded rβ →
+  (∀ a₁ b₁, (∀ a₂ b₂, game_add rα rβ (a₂, b₂) (a₁, b₁) → C a₂ b₂) → C a₁ b₁) → ∀ a b, C a b :=
+game_add.fix
+
 /-- The relation `game_add r r a b ∨ game_add r r a.swap b`, which is well-founded when `r` is. -/
 def game_add_swap (r : α → α → Prop) (a b : α × α) : Prop :=
 game_add r r a b ∨ game_add r r a.swap b
 
 variable {r : α → α → Prop}
 
-theorem game_add.swap {a b} : game_add r r a b → game_add_swap r a b := or.inl
+lemma game_add.swap {a b} : game_add r r a b → game_add_swap r a b := or.inl
 
-theorem game_add.swap_left {a b} (h : game_add r r a b) : game_add_swap r a.swap b :=
+lemma game_add.swap_left {a b} (h : game_add r r a b) : game_add_swap r a.swap b :=
 or.inr $ by rwa prod.swap_swap
 
-theorem game_add.swap_right {a b} (h : game_add r r a b) : game_add_swap r a b.swap :=
+lemma game_add.swap_right {a b} (h : game_add r r a b) : game_add_swap r a b.swap :=
 or.inr $ by rwa game_add_swap_swap
 
 /-- `game_add` is a `subrelation` of `game_add_swap`. -/
@@ -144,6 +159,21 @@ lemma _root_.acc.game_add_swap {a b} (ha : acc r a) (hb : acc r b) : acc (game_a
 /-- The `game_add_swap` relation is well-founded. -/
 lemma _root_.well_founded.game_add_swap (h : well_founded r) :
   well_founded (game_add_swap r) := ⟨λ ⟨a, b⟩, (h.apply a).game_add_swap (h.apply b)⟩
+
+def game_add_swap.fix {C : α → α → Sort*} (hr : well_founded r)
+  (IH : Π a₁ b₁, (Π a₂ b₂, game_add_swap r (a₂, b₂) (a₁, b₁) → C a₂ b₂) → C a₁ b₁) (a b : α) :
+  C a b :=
+@well_founded.fix (α × α) (λ x, C x.1 x.2) _ hr.game_add_swap
+  (λ ⟨x₁, x₂⟩ IH', IH x₁ x₂ $ λ a' b', IH' ⟨a', b'⟩) ⟨a, b⟩
+
+lemma game_add_swap.fix_eq {C : α → α → Sort*} (hr : well_founded r)
+  (IH : Π a₁ b₁, (Π a₂ b₂, game_add_swap r (a₂, b₂) (a₁, b₁) → C a₂ b₂) → C a₁ b₁) (a b : α) :
+  game_add_swap.fix hr IH a b = IH a b (λ a' b' h, game_add_swap.fix hr IH a' b') :=
+by { rw [game_add_swap.fix, well_founded.fix_eq], refl }
+
+lemma game_add_swap.induction {C : α → α → Prop} : well_founded r →
+  (∀ a₁ b₁, (∀ a₂ b₂, game_add_swap r (a₂, b₂) (a₁, b₁) → C a₂ b₂) → C a₁ b₁) → ∀ a b, C a b :=
+game_add_swap.fix
 
 end aux_rels
 

--- a/src/logic/hydra.lean
+++ b/src/logic/hydra.lean
@@ -111,6 +111,7 @@ end
 lemma _root_.well_founded.game_add (hα : well_founded rα) (hβ : well_founded rβ) :
   well_founded (game_add rα rβ) := ⟨λ ⟨a,b⟩, (hα.apply a).game_add (hβ.apply b)⟩
 
+/-- Recursion on the well-founded `game_add` relation. -/
 def game_add.fix {C : α → β → Sort*} (hα : well_founded rα) (hβ : well_founded rβ)
   (IH : Π a₁ b₁, (Π a₂ b₂, game_add rα rβ (a₂, b₂) (a₁, b₁) → C a₂ b₂) → C a₁ b₁) (a : α) (b : β) :
   C a b :=
@@ -122,6 +123,7 @@ lemma game_add.fix_eq {C : α → β → Sort*} (hα : well_founded rα) (hβ : 
   game_add.fix hα hβ IH a b = IH a b (λ a' b' h, game_add.fix hα hβ IH a' b') :=
 by { rw [game_add.fix, well_founded.fix_eq], refl }
 
+/-- Induction on the well-founded `game_add` relation. -/
 lemma game_add.induction {C : α → β → Prop} : well_founded rα → well_founded rβ →
   (∀ a₁ b₁, (∀ a₂ b₂, game_add rα rβ (a₂, b₂) (a₁, b₁) → C a₂ b₂) → C a₁ b₁) → ∀ a b, C a b :=
 game_add.fix
@@ -168,6 +170,7 @@ lemma _root_.acc.game_add_swap {a b} (ha : acc r a) (hb : acc r b) : acc (game_a
 lemma _root_.well_founded.game_add_swap (h : well_founded r) :
   well_founded (game_add_swap r) := ⟨λ ⟨a, b⟩, (h.apply a).game_add_swap (h.apply b)⟩
 
+/-- Recursion on the well-founded `game_add_swap` relation. -/
 def game_add_swap.fix {C : α → α → Sort*} (hr : well_founded r)
   (IH : Π a₁ b₁, (Π a₂ b₂, game_add_swap r (a₂, b₂) (a₁, b₁) → C a₂ b₂) → C a₁ b₁) (a b : α) :
   C a b :=
@@ -179,6 +182,7 @@ lemma game_add_swap.fix_eq {C : α → α → Sort*} (hr : well_founded r)
   game_add_swap.fix hr IH a b = IH a b (λ a' b' h, game_add_swap.fix hr IH a' b') :=
 by { rw [game_add_swap.fix, well_founded.fix_eq], refl }
 
+/-- Induction on the well-founded `game_add_swap` relation. -/
 lemma game_add_swap.induction {C : α → α → Prop} : well_founded r →
   (∀ a₁ b₁, (∀ a₂ b₂, game_add_swap r (a₂, b₂) (a₁, b₁) → C a₂ b₂) → C a₁ b₁) → ∀ a b, C a b :=
 game_add_swap.fix

--- a/src/set_theory/game/pgame.lean
+++ b/src/set_theory/game/pgame.lean
@@ -273,33 +273,33 @@ localized "infix ` ⧏ `:50 := pgame.lf" in pgame
 @[simp] protected theorem not_le {x y : pgame} : ¬ x ≤ y ↔ y ⧏ x := iff.rfl
 @[simp] theorem not_lf {x y : pgame} : ¬ x ⧏ y ↔ y ≤ x := not_not
 theorem _root_.has_le.le.not_gf {x y : pgame} : x ≤ y → ¬ y ⧏ x := not_lf.2
-theorem lf.not_ge {x y : pgame} : x ⧏ y → ¬ y ≤ x := pgame.not_le.2
+theorem lf.not_ge {x y : pgame} : x ⧏ y → ¬ y ≤ x := id
+
+/-- Definition of `x ≤ y` on pre-games, in terms of `⧏` -/
+theorem le_iff_forall_lf {x y : pgame} :
+  x ≤ y ↔ (∀ i, x.move_left i ⧏ y) ∧ ∀ j, x ⧏ y.move_right j :=
+by { unfold has_le.le, rw game_add_swap.fix_eq, refl }
 
 /-- Definition of `x ≤ y` on pre-games built using the constructor. -/
 @[simp] theorem mk_le_mk {xl xr xL xR yl yr yL yR} :
   mk xl xr xL xR ≤ mk yl yr yL yR ↔
   (∀ i, xL i ⧏ mk yl yr yL yR) ∧ ∀ j, mk xl xr xL xR ⧏ yR j :=
-by { unfold has_le.le, rw game_add_swap.fix_eq, refl }
-
-/-- Definition of `x ≤ y` on pre-games, in terms of `⧏` -/
-theorem le_iff_forall_lf {x y : pgame} :
-  x ≤ y ↔ (∀ i, x.move_left i ⧏ y) ∧ ∀ j, x ⧏ y.move_right j :=
-by { cases x, cases y, exact mk_le_mk }
+le_iff_forall_lf
 
 theorem le_of_forall_lf {x y : pgame} (h₁ : ∀ i, x.move_left i ⧏ y) (h₂ : ∀ j, x ⧏ y.move_right j) :
   x ≤ y :=
 le_iff_forall_lf.2 ⟨h₁, h₂⟩
 
+/-- Definition of `x ⧏ y` on pre-games, in terms of `≤` -/
+theorem lf_iff_exists_le {x y : pgame} :
+  x ⧏ y ↔ (∃ i, x ≤ y.move_left i) ∨ ∃ j, x.move_right j ≤ y :=
+by { rw [lf, le_iff_forall_lf, not_and_distrib], simp }
+
 /-- Definition of `x ⧏ y` on pre-games built using the constructor. -/
 @[simp] theorem mk_lf_mk {xl xr xL xR yl yr yL yR} :
   mk xl xr xL xR ⧏ mk yl yr yL yR ↔
   (∃ i, mk xl xr xL xR ≤ yL i) ∨ ∃ j, xR j ≤ mk yl yr yL yR :=
-by { rw [lf, mk_le_mk, not_and_distrib], simp }
-
-/-- Definition of `x ⧏ y` on pre-games, in terms of `≤` -/
-theorem lf_iff_exists_le {x y : pgame} :
-  x ⧏ y ↔ (∃ i, x ≤ y.move_left i) ∨ ∃ j, x.move_right j ≤ y :=
-by { cases x, cases y, exact mk_lf_mk }
+lf_iff_exists_le
 
 theorem le_or_gf (x y : pgame) : x ≤ y ∨ y ⧏ x :=
 by { rw ←pgame.not_le, apply em }

--- a/src/set_theory/game/pgame.lean
+++ b/src/set_theory/game/pgame.lean
@@ -259,9 +259,9 @@ instance is_empty_one_right_moves : is_empty (right_moves 1) := pempty.is_empty
 /-- The less or equal relation on pre-games.
 
 If `0 ≤ x`, then Left can win `x` as the second player. -/
-instance : has_le pgame := ⟨game_add_swap.fix wf_is_option $ λ x y IH,
-  (∀ i, ¬ IH y (x.move_left i) (game_add.snd $ is_option.move_left i).swap_mk_right) ∧
-  (∀ j, ¬ IH (y.move_right j) x (game_add.fst $ is_option.move_right j).swap_mk_right)⟩
+instance : has_le pgame := ⟨game_add_swap.fix wf_is_option $ λ x y le,
+  (∀ i, ¬ le y (x.move_left i) (game_add.snd $ is_option.move_left i).swap_mk_right) ∧
+  (∀ j, ¬ le (y.move_right j) x (game_add.fst $ is_option.move_right j).swap_mk_right)⟩
 
 /-- The less or fuzzy relation on pre-games.
 


### PR DESCRIPTION
We redefine `≤` using a new fancy induction principle, thus sidestepping a lot of induction weirdness. We also make `x ⧏ y` def-eq to `¬ y ≤ x`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
- [x] depends on: #15286

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
