### PR TITLE
feat(order/bounded_order + algebra/order/{monoid + group}): some with_bot lemmas

### DIFF
--- a/src/algebra/order/group.lean
+++ b/src/algebra/order/group.lean
@@ -775,6 +775,22 @@ begin
   exact mul_lt_mul_of_lt_of_lt hab hcd
 end
 
+--  Sould this lemma move somewhere else?  Where?
+lemma with_bot.add_coe_neg_le_iff {α} [add_group α] [preorder α]
+  [covariant_class α α (function.swap (+)) (≤)]
+  (a : with_bot α) (b : α) (c : with_bot α) :
+  a + (-b : α) ≤ c ↔ a ≤ c + b :=
+begin
+  rcases a.eq_bot_or_coe with rfl | ⟨a, rfl⟩,
+  { simp },
+  { rcases c.eq_bot_or_coe with rfl | ⟨c, rfl⟩,
+    { simp only [with_bot.not_coe_le_bot, with_bot.bot_add, iff_false, ← with_bot.coe_add,
+        not_false_iff] },
+    { norm_cast,
+      rw [← sub_eq_add_neg, sub_le_iff_le_add] } }
+end
+
+
 end preorder
 
 end comm_group

--- a/src/algebra/order/group.lean
+++ b/src/algebra/order/group.lean
@@ -790,7 +790,6 @@ begin
       rw [← sub_eq_add_neg, sub_le_iff_le_add] } }
 end
 
-
 end preorder
 
 end comm_group

--- a/src/algebra/order/group.lean
+++ b/src/algebra/order/group.lean
@@ -781,9 +781,9 @@ lemma with_bot.add_coe_neg_le_iff {α} [add_group α] [preorder α]
   (a : with_bot α) (b : α) (c : with_bot α) :
   a + (-b : α) ≤ c ↔ a ≤ c + b :=
 begin
-  rcases a.eq_bot_or_coe with rfl | ⟨a, rfl⟩,
+  induction a using with_bot.rec_bot_coe,
   { simp },
-  { rcases c.eq_bot_or_coe with rfl | ⟨c, rfl⟩,
+  { induction c using with_bot.rec_bot_coe,
     { simp only [with_bot.not_coe_le_bot, with_bot.bot_add, iff_false, ← with_bot.coe_add,
         not_false_iff] },
     { norm_cast,

--- a/src/algebra/order/monoid.lean
+++ b/src/algebra/order/monoid.lean
@@ -1177,13 +1177,13 @@ lemma add_eq_coe : a + b = x ↔ ∃ (a' b' : α), ↑a' = a ∧ ↑b' = b ∧ a
 
 /-  It is not `to_additive` of `with_bot.map_mul_of_mul_hom`, since `with_bot` does not have
 a multiplication. -/
-lemma map_add_of_add_hom {β F} [has_add β] [add_hom_class F α β] (f : F)
+lemma map_add_of_add_hom {α β F} [has_add α] [has_add β] [add_hom_class F α β] (f : F)
   (a b : with_bot α) :
   (a + b).map f = a.map f + b.map f :=
 begin
-  rcases a.eq_bot_or_coe with rfl | ⟨a, rfl⟩,
-  { exact (b.map f).bot_add.symm },
-  { rcases b.eq_bot_or_coe with rfl | ⟨b, rfl⟩,
+  induction a using with_bot.rec_bot_coe,
+  { exact (bot_add _).symm },
+  { induction b using with_bot.rec_bot_coe,
     { exact (add_bot _).symm },
     { rw [map_coe, map_coe, ← coe_add (f a), ← map_add],
       refl } },
@@ -1192,7 +1192,7 @@ end
 lemma exists_eq_add {A} [add_comm_group A] (a : with_bot A) (b : A) :
   ∃ (a' : with_bot A), a = a' + b :=
 begin
-  rcases a.eq_bot_or_coe with rfl | ⟨a, rfl⟩,
+  induction a using with_bot.rec_bot_coe,
   { exact ⟨_, (bot_add _).symm⟩ },
   { exact ⟨(a - b : A), coe_eq_coe.mpr (sub_add_cancel a b).symm⟩ }
 end

--- a/src/algebra/order/monoid.lean
+++ b/src/algebra/order/monoid.lean
@@ -1175,6 +1175,28 @@ lemma add_eq_coe : a + b = x ↔ ∃ (a' b' : α), ↑a' = a ∧ ↑b' = b ∧ a
 @[simp] lemma add_coe_eq_bot_iff : a + y = ⊥ ↔ a = ⊥ := with_top.add_coe_eq_top_iff
 @[simp] lemma coe_add_eq_bot_iff : ↑x + b = ⊥ ↔ b = ⊥ := with_top.coe_add_eq_top_iff
 
+/-  It is not `to_additive` of `with_bot.map_mul_of_mul_hom`, since `with_bot` does not have
+a multiplication. -/
+lemma map_add_of_add_hom {β F} [has_add β] [add_hom_class F α β] (f : F)
+  (a b : with_bot α) :
+  (a + b).map f = a.map f + b.map f :=
+begin
+  rcases a.eq_bot_or_coe with rfl | ⟨a, rfl⟩,
+  { exact (b.map f).bot_add.symm },
+  { rcases b.eq_bot_or_coe with rfl | ⟨b, rfl⟩,
+    { exact (add_bot _).symm },
+    { rw [map_coe, map_coe, ← coe_add (f a), ← map_add],
+      refl } },
+end
+
+lemma exists_eq_add {A} [add_comm_group A] (a : with_bot A) (b : A) :
+  ∃ (a' : with_bot A), a = a' + b :=
+begin
+  rcases a.eq_bot_or_coe with rfl | ⟨a, rfl⟩,
+  { exact ⟨_, (bot_add _).symm⟩ },
+  { exact ⟨(a - b : A), coe_eq_coe.mpr (sub_add_cancel a b).symm⟩ }
+end
+
 variables [preorder α]
 
 instance covariant_class_add_le [covariant_class α α (+) (≤)] :

--- a/src/algebra/order/monoid.lean
+++ b/src/algebra/order/monoid.lean
@@ -1177,7 +1177,7 @@ lemma add_eq_coe : a + b = x ↔ ∃ (a' b' : α), ↑a' = a ∧ ↑b' = b ∧ a
 
 /-  It is not `to_additive` of `with_bot.map_mul_of_mul_hom`, since `with_bot` does not have
 a multiplication. -/
-lemma map_add_of_add_hom {α β F} [has_add α] [has_add β] [add_hom_class F α β] (f : F)
+protected lemma map_add {α β F} [has_add α] [has_add β] [add_hom_class F α β] (f : F)
   (a b : with_bot α) :
   (a + b).map f = a.map f + b.map f :=
 begin

--- a/src/order/bounded_order.lean
+++ b/src/order/bounded_order.lean
@@ -547,15 +547,6 @@ option.rec h₁ h₂
 @[simp] lemma rec_bot_coe_coe {C : with_bot α → Sort*} (d : C ⊥) (f : Π (a : α), C a)
   (x : α) : @rec_bot_coe _ C d f ↑x = f x := rfl
 
-/--  Similar to `eq_or_ne a ⊥`, except that it stays within `with_bot` and does not leak into
-`option`. -/
-lemma eq_bot_or_coe {α : Type*} : ∀ n : with_bot α, n = ⊥ ∨ ∃ m : α, n = m :=
-begin
-  refine with_bot.rec_bot_coe _ _,
-  { exact or.inl rfl },
-  { exact λ a, or.inr ⟨a, rfl⟩ }
-end
-
 /-- Specialization of `option.get_or_else` to values in `with_bot α` that respects API boundaries.
 -/
 def unbot' (d : α) (x : with_bot α) : α := rec_bot_coe d id x
@@ -679,10 +670,10 @@ lemma map_fn_le_iff {α β} [preorder α] [linear_order β] (f : α → β)
   (a b : with_bot α) (mono_iff : ∀ {a b}, f a ≤ f b ↔ a ≤ b) :
   a.map f ≤ b.map f ↔ a ≤ b :=
 begin
-  rcases a.eq_bot_or_coe with rfl | ⟨a, rfl⟩,
+  induction a using with_bot.rec_bot_coe,
   { simp },
-  { rcases b.eq_bot_or_coe with rfl | ⟨b, rfl⟩,
-    { simp [with_bot.not_coe_le_bot a], },
+  { induction b using with_bot.rec_bot_coe,
+    { simp [not_coe_le_bot a] },
     { simpa using mono_iff } }
 end
 

--- a/src/order/bounded_order.lean
+++ b/src/order/bounded_order.lean
@@ -547,6 +547,15 @@ option.rec h₁ h₂
 @[simp] lemma rec_bot_coe_coe {C : with_bot α → Sort*} (d : C ⊥) (f : Π (a : α), C a)
   (x : α) : @rec_bot_coe _ C d f ↑x = f x := rfl
 
+/--  Similar to `eq_or_ne a ⊥`, except that it stays within `with_bot` and does not leak into
+`option`. -/
+lemma eq_bot_or_coe {α : Type*} : ∀ n : with_bot α, n = ⊥ ∨ ∃ m : α, n = m :=
+begin
+  refine with_bot.rec_bot_coe _ _,
+  { exact or.inl rfl },
+  { exact λ a, or.inr ⟨a, rfl⟩ }
+end
+
 /-- Specialization of `option.get_or_else` to values in `with_bot α` that respects API boundaries.
 -/
 def unbot' (d : α) (x : with_bot α) : α := rec_bot_coe d id x
@@ -665,6 +674,17 @@ instance [partial_order α] : partial_order (with_bot α) :=
       rw le_antisymm h₁' h₂' }
   end,
   .. with_bot.preorder }
+
+lemma map_fn_le_iff {α β} [preorder α] [linear_order β] (f : α → β)
+  (a b : with_bot α) (mono_iff : ∀ {a b}, f a ≤ f b ↔ a ≤ b) :
+  a.map f ≤ b.map f ↔ a ≤ b :=
+begin
+  rcases a.eq_bot_or_coe with rfl | ⟨a, rfl⟩,
+  { simp },
+  { rcases b.eq_bot_or_coe with rfl | ⟨b, rfl⟩,
+    { simp [with_bot.not_coe_le_bot a], },
+    { simpa using mono_iff } }
+end
 
 lemma le_coe_get_or_else [preorder α] : ∀ (a : with_bot α) (b : α), a ≤ a.get_or_else b
 | (some a) b := le_refl a


### PR DESCRIPTION
This PR adds some lemmas involving `with_bot` and its interactions with `add, neg, add_hom, map`.

I use them to work with `with_bot ℤ` on Laurent polynomials.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
