### PR TITLE
[Merged by Bors] - feat(data/pfun): tooling to help reasoning about pfun domains

### DIFF
--- a/src/data/pfun.lean
+++ b/src/data/pfun.lean
@@ -68,7 +68,7 @@ def dom (f : α →. β) : set α := {a | (f a).dom}
 @[simp] lemma mem_dom (f : α →. β) (x : α) : x ∈ dom f ↔ ∃ y, y ∈ f x :=
 by simp [dom, part.dom_iff_mem]
 
-@[simp] def dom_mk (p : α → Prop) (f : Π a, p a → β) : pfun.dom (λ x, ⟨p x, f x⟩) = {x | p x} :=
+@[simp] lemma dom_mk (p : α → Prop) (f : Π a, p a → β) : pfun.dom (λ x, ⟨p x, f x⟩) = {x | p x} :=
 rfl
 
 theorem dom_eq (f : α →. β) : dom f = {x | ∃ y, y ∈ f x} :=

--- a/src/data/pfun.lean
+++ b/src/data/pfun.lean
@@ -322,7 +322,7 @@ rel.preimage_union _ s t
 lemma preimage_univ : f.preimage set.univ = f.dom :=
 by ext; simp [mem_preimage, mem_dom]
 
-lemma pfun.coe_preimage (s : set β) (f : α → β) : (f : α →. β).preimage s = f ⁻¹' s :=
+lemma coe_preimage (f : α → β) (s : set β) : (f : α →. β).preimage s = f ⁻¹' s :=
 by ext; simp
 
 /-- Core of a set `s : set β` with respect to a partial function `f : α →. β`. Set of all `a : α`

--- a/src/data/pfun.lean
+++ b/src/data/pfun.lean
@@ -68,6 +68,9 @@ def dom (f : α →. β) : set α := {a | (f a).dom}
 @[simp] lemma mem_dom (f : α →. β) (x : α) : x ∈ dom f ↔ ∃ y, y ∈ f x :=
 by simp [dom, part.dom_iff_mem]
 
+@[simp] def dom_mk (p : α → Prop) (f : Π a, p a → β) : pfun.dom (λ x, ⟨p x, f x⟩) = {x | p x} :=
+rfl
+
 theorem dom_eq (f : α →. β) : dom f = {x | ∃ y, y ∈ f x} :=
 set.ext (mem_dom f)
 
@@ -318,6 +321,9 @@ rel.preimage_union _ s t
 
 lemma preimage_univ : f.preimage set.univ = f.dom :=
 by ext; simp [mem_preimage, mem_dom]
+
+lemma pfun.coe_preimage (s : set β) (f : α → β) : (f : α →. β).preimage s = f ⁻¹' s :=
+by ext; simp
 
 /-- Core of a set `s : set β` with respect to a partial function `f : α →. β`. Set of all `a : α`
 such that `f a ∈ s`, if `f a` is defined. -/


### PR DESCRIPTION
Tooling to help reasoning about pfun domains. Helps solving problems such as:

```lean
-- Informal: Find the domain of the function $g(x) = \sqrt{x-2}$. Express your answer using intervals notation.
example :
  (pfun.sqrt.comp $ pfun.lift (λ x : ℝ, x - 2)).dom = set.Ici 2 :=
begin
  have h₀ : (pfun.sqrt).dom = set.Ici 0, { refl },
  simp only [pfun.lift_eq_coe, pfun.dom_comp],
  rw [h₀, pfun.coe_preimage],
  ext,
  simp only [set.preimage_sub_const_Ici, zero_add],
end
```

Co-authored-by: Eric Wieser <wieser.eric@gmail.com>

---
[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
