### PR TITLE
[Merged by Bors] - feat(tactic/linear_combination): allow linear_combination to leave goal open

### DIFF
--- a/src/tactic/linear_combination.lean
+++ b/src/tactic/linear_combination.lean
@@ -9,10 +9,9 @@ import tactic.ring
 /-!
 
 # linear_combination Tactic
-
 In this file, the `linear_combination` tactic is created.  This tactic, which
-works over `ring`s, attempts to prove the target by creating and applying a
-linear combination of a list of equalities.  This file also includes a
+works over `ring`s, attempts to simplify the target by creating a linear combination
+  of a list of equalities and subtracting it from the target.  This file also includes a
 definition for `linear_combination_config`.  A `linear_combination_config`
 object can be passed into the tactic, allowing the user to specify a
 normalization tactic.
@@ -24,8 +23,7 @@ given coefficients.  Then, it subtracts the right side of the weighted sum
 from the left side so that the right side equals 0, and it does the same with
 the target.  Afterwards, it sets the goal to be the equality between the
 lefthand side of the new goal and the lefthand side of the new weighted sum.
-Lastly, it uses a normalization tactic to see if the weighted sum is equal
-to the target.
+Lastly, calls a normalization tactic on this target.
 
 ## References
 
@@ -286,11 +284,11 @@ when config.normalize config.normalization_tactic
 
 
 /--
-This is a tactic that attempts to prove the target by creating and applying a
-  linear combination of a list of equalities.  (If the `normalize` field of the
+This is a tactic that attempts to simplify the target by creating a linear combination
+  of a list of equalities and subtracting it from the target.
+  (If the `normalize` field of the
   configuration is set to ff, then the tactic will simply set the user up to
-  prove their target using the linear combination instead of attempting to
-  finish the proof.)
+  prove their target using the linear combination instead of normalizing the subtraction.)
 
 Note: The left and right sides of all the equalities should have the same
   ring type, and the coefficients should also have this type.  There must be
@@ -347,13 +345,13 @@ section interactive_mode
 setup_tactic_parser
 
 /--
-`linear_combination` attempts to prove the target by creating and applying a
-  linear combination of a list of equalities.  The tactic will create a linear
+`linear_combination` attempts to simplify the target by creating a linear combination
+  of a list of equalities and subtracting it from the target.
+  The tactic will create a linear
   combination by adding the equalities together from left to right, so the order
   of the input hypotheses does matter.  If the `normalize` field of the
   configuration is set to false, then the tactic will simply set the user up to
-  prove their target using the linear combination instead of attempting to
-  finish the proof.
+  prove their target using the linear combination instead of normalizing the subtraction.
 
 Note: The left and right sides of all the equalities should have the same
   type, and the coefficients should also have this type.  There must be
@@ -371,7 +369,7 @@ Note: The left and right sides of all the equalities should have the same
       for normalization; by default, this value is the standard configuration
       for a linear_combination_config.  In the standard configuration,
       `normalize` is set to tt (meaning this tactic is set to use
-      normalization), and `normalization_tactic` is set to  `ring1`.
+      normalization), and `normalization_tactic` is set to  `ring_nf SOP`.
 
 Example Usage:
 ```
@@ -382,6 +380,13 @@ by linear_combination 1*h1 - 2*h2
 example (x y : ℤ) (h1 : x*y + 2*x = 1) (h2 : x = y) :
   x*y = -2*y + 1 :=
 by linear_combination h1 - 2*h2
+
+example (x y : ℤ) (h1 : x*y + 2*x = 1) (h2 : x = y) :
+  x*y = -2*y + 1 :=
+begin
+ linear_combination -2*h2,
+ /- Goal: x * y + x * 2 - 1 = 0 -/
+end
 
 example (x y z : ℝ) (ha : x + 2*y - z = 4) (hb : 2*x + y + z = -2)
     (hc : x + 2*y + z = 2) :

--- a/src/tactic/linear_combination.lean
+++ b/src/tactic/linear_combination.lean
@@ -251,13 +251,12 @@ do
 
 
 /--
-UPDATE
-This tactic changes the goal to be that the lefthand side of the target is
-  equal to the lefthand side of the given expression.  For example,
+This tactic changes the goal to be that the lefthand side of the target minus the
+  lefthand side of the given expression is equal to 0.  For example,
   if `hsum_on_left` is `5*x - 5*y = 0`, and the target is `-5*y + 5*x = 0`, this
-  tactic will change the target to be `-5*y + 5*x = 5*x - 5*y`.
+  tactic will change the target to be `-5*y + 5*x - (5*x - 5*y) = 0`.
 
-This tactic only should be used when the target's type an equality whose
+This tactic only should be used when the target's type is an equality whose
   right side is 0.
 
 * Input:

--- a/src/tactic/linear_combination.lean
+++ b/src/tactic/linear_combination.lean
@@ -11,7 +11,7 @@ import tactic.ring
 # linear_combination Tactic
 In this file, the `linear_combination` tactic is created.  This tactic, which
 works over `ring`s, attempts to simplify the target by creating a linear combination
-  of a list of equalities and subtracting it from the target.  This file also includes a
+of a list of equalities and subtracting it from the target.  This file also includes a
 definition for `linear_combination_config`.  A `linear_combination_config`
 object can be passed into the tactic, allowing the user to specify a
 normalization tactic.

--- a/src/tactic/linear_combination.lean
+++ b/src/tactic/linear_combination.lean
@@ -58,6 +58,8 @@ lemma replace_eq_expr {α} [h : has_zero α] {x y : α} (h1 : x = 0) (h2 : y = x
   y = 0 :=
 by rwa h2
 
+lemma eq_zero_of_sub_eq_zero {α} [add_group α] {x y : α} (h : y = 0) (h2 : x - y = 0) : x = 0 :=
+by rwa [h, sub_zero] at h2
 
 /-! ### Configuration -/
 
@@ -72,7 +74,7 @@ checking if the weighted sum is equivalent to the goal (when `normalize` is `tt`
 -/
 meta structure linear_combination_config : Type :=
 (normalize : bool := tt)
-(normalization_tactic : tactic unit := `[ring1])
+(normalization_tactic : tactic unit := `[ring_nf SOP])
 
 
 /-! ### Part 1: Multiplying Equations by Constants and Adding Them Together -/
@@ -249,6 +251,7 @@ do
 
 
 /--
+UPDATE
 This tactic changes the goal to be that the lefthand side of the target is
   equal to the lefthand side of the given expression.  For example,
   if `hsum_on_left` is `5*x - 5*y = 0`, and the target is `-5*y + 5*x = 0`, this
@@ -263,8 +266,8 @@ This tactic only should be used when the target's type an equality whose
 
 * Output: N/A
 -/
-meta def set_goal_to_hleft_eq_tleft (hsum_on_left : expr) : tactic unit :=
-do to_expr ``(replace_eq_expr %%hsum_on_left) >>= apply, skip
+meta def set_goal_to_hleft_sub_tleft (hsum_on_left : expr) : tactic unit :=
+do to_expr ``(eq_zero_of_sub_eq_zero %%hsum_on_left) >>= apply, skip
 
 /--
 This tactic attempts to prove the goal by normalizing the target if the
@@ -276,7 +279,7 @@ This tactic attempts to prove the goal by normalizing the target if the
 
 * Output: N/A
 -/
-meta def prove_equal_if_desired (config : linear_combination_config) :
+meta def normalize_if_desired (config : linear_combination_config) :
   tactic unit :=
 when config.normalize config.normalization_tactic
 
@@ -314,8 +317,8 @@ do
   hsum ← make_sum_of_hyps ext h_eqs coeffs,
   hsum_on_left ← move_to_left_side hsum,
   move_target_to_left_side,
-  set_goal_to_hleft_eq_tleft hsum_on_left,
-  prove_equal_if_desired config
+  set_goal_to_hleft_sub_tleft hsum_on_left,
+  normalize_if_desired config
 
 /-- `mk_mul [p₀, p₁, ..., pₙ]` produces the pexpr `p₀ * p₁ * ... * pₙ`. -/
 meta def mk_mul : list pexpr → pexpr

--- a/src/tactic/polyrith.lean
+++ b/src/tactic/polyrith.lean
@@ -451,7 +451,7 @@ The second half of `tactic.polyrith` processes the output from Sage into
 a call to `linear_combination`.
 -/
 meta def process_output (eq_names : list expr) (m : list expr) (R : expr) (sage_out : json) :
-  tactic format := do
+  tactic format := focus1 $ do
   some coeffs_as_poly ← convert_sage_output sage_out | fail!"internal error: No output available",
   coeffs_as_pexpr ← coeffs_as_poly.mmap (poly.to_pexpr m),
   let eq_names_pexpr := eq_names.map to_pexpr,
@@ -460,6 +460,9 @@ meta def process_output (eq_names : list expr) (m : list expr) (R : expr) (sage_
   let components := (eq_names.zip coeffs_as_expr).filter
     $ λ pr, bnot $ pr.2.is_app_of `has_zero.zero,
   expr_string ← components_to_lc_format components,
+  let lc_fmt : format := "linear_combination " ++ format.nest 2 (format.group expr_string),
+  done <|>
+    fail!"polyrith found the following certificate, but it failed to close the goal:\n{lc_fmt}",
   return $ "linear_combination " ++ format.nest 2 (format.group expr_string)
 
 /-- Tactic for the special case when no hypotheses are available. -/

--- a/test/linear_combination.lean
+++ b/test/linear_combination.lean
@@ -192,7 +192,7 @@ by linear_combination
 example {x y z w : ℤ} (h₁ : 3 * x = 4 + y) (h₂ : x + 2 * y = 1) : z + w = w + z :=
 begin
   linear_combination with {normalize := ff},
-  guard_target' z + w - (w + z) = 0 - 0,
+  guard_target' z + w - (w + z) - (0 - 0) = 0,
   simp [add_comm]
 end
 
@@ -201,58 +201,61 @@ by linear_combination with {normalization_tactic := `[simp [add_comm]]}
 
 /-! ### Cases that should fail -/
 
--- This should fail because there are no hypotheses given
-example (x y : ℤ) (h1 : x*y + 2*x = 1) (h2 : x = y) :
-  x*y = -2*y + 1 :=
-begin
-  success_if_fail {linear_combination},
-  linear_combination h1 - 2 * h2,
-end
+-- todo: update
 
--- This should fail because the second coefficient has a different type than
---   the equations it is being combined with.  This was a design choice for the
---   sake of simplicity, but the tactic could potentially be modified to allow
---   this behavior.
-example (x y : ℤ) (h1 : x*y + 2*x = 1) (h2 : x = y) :
-  x*y + 2*x = 1 :=
-begin
-  success_if_fail_with_msg {linear_combination h1 + (0 : ℝ) * h2}
-    "invalid type ascription, term has type
-  ℝ
-but is expected to have type
-  ℤ",
-  linear_combination h1
-end
+-- -- This should fail because there are no hypotheses given
+-- example (x y : ℤ) (h1 : x*y + 2*x = 1) (h2 : x = y) :
+--   x*y = -2*y + 1 :=
+-- begin
+--   linear_combination,
+--   -- success_if_fail {linear_combination},
+--   linear_combination h1 - 2 * h2,
+-- end
 
--- This should fail because the second coefficient has a different type than
---   the equations it is being combined with.  This was a design choice for the
---   sake of simplicity, but the tactic could potentially be modified to allow
---   this behavior.
-example (x y : ℤ) (h1 : x*y + 2*x = 1) (h2 : x = y) :
-  x*y + 2*x = 1 :=
-begin
-  success_if_fail {linear_combination h1 + (0 : ℕ)  * h2},
-  linear_combination h1
-end
+-- -- This should fail because the second coefficient has a different type than
+-- --   the equations it is being combined with.  This was a design choice for the
+-- --   sake of simplicity, but the tactic could potentially be modified to allow
+-- --   this behavior.
+-- example (x y : ℤ) (h1 : x*y + 2*x = 1) (h2 : x = y) :
+--   x*y + 2*x = 1 :=
+-- begin
+--   success_if_fail_with_msg {linear_combination h1 + (0 : ℝ) * h2}
+--     "invalid type ascription, term has type
+--   ℝ
+-- but is expected to have type
+--   ℤ",
+--   linear_combination h1
+-- end
 
--- This should fail because the coefficients are incorrect.  They should instead
---   be -2 and 3, respectively.
-example (x y : ℤ) (h1 : 3*x + 2*y = 10) (h2 : 2*x + 5*y = 3) :
-  11*y = -11 :=
-begin
-  success_if_fail {linear_combination 2*h1 - 3*h2},
-  linear_combination -2*h1 + 3*h2
-end
+-- -- This should fail because the second coefficient has a different type than
+-- --   the equations it is being combined with.  This was a design choice for the
+-- --   sake of simplicity, but the tactic could potentially be modified to allow
+-- --   this behavior.
+-- example (x y : ℤ) (h1 : x*y + 2*x = 1) (h2 : x = y) :
+--   x*y + 2*x = 1 :=
+-- begin
+--   success_if_fail {linear_combination h1 + (0 : ℕ)  * h2},
+--   linear_combination h1
+-- end
 
--- This fails because the linear_combination tactic requires the equations
---   and coefficients to use a type that fulfills the add_group condition,
---   and ℕ does not.
-example (a b : ℕ) (h1 : a = 3) :
-  a = 3 :=
-begin
-  success_if_fail {linear_combination h1},
-  exact h1
-end
+-- -- This should fail because the coefficients are incorrect.  They should instead
+-- --   be -2 and 3, respectively.
+-- example (x y : ℤ) (h1 : 3*x + 2*y = 10) (h2 : 2*x + 5*y = 3) :
+--   11*y = -11 :=
+-- begin
+--   success_if_fail {linear_combination 2*h1 - 3*h2},
+--   linear_combination -2*h1 + 3*h2
+-- end
+
+-- -- This fails because the linear_combination tactic requires the equations
+-- --   and coefficients to use a type that fulfills the add_group condition,
+-- --   and ℕ does not.
+-- example (a b : ℕ) (h1 : a = 3) :
+--   a = 3 :=
+-- begin
+--   success_if_fail {linear_combination h1},
+--   exact h1
+-- end
 
 example (a b : ℤ) (x y : ℝ) (hab : a = b) (hxy : x = y) : 2*x = 2*y :=
 begin

--- a/test/linear_combination.lean
+++ b/test/linear_combination.lean
@@ -199,63 +199,60 @@ end
 example {x y z w : ℤ} (h₁ : 3 * x = 4 + y) (h₂ : x + 2 * y = 1) : z + w = w + z :=
 by linear_combination with {normalization_tactic := `[simp [add_comm]]}
 
+/-! ### Cases where the goal is not closed -/
+
+example (x y : ℚ) (h1 : x + y = 3) (h2 : 3*x = 7) :
+  x*x*y + y*x*y + 6*x = 3*x*y + 14 :=
+begin
+  linear_combination x*y*h1 + h2,
+  guard_target' (x * 3 - 7 = 0),
+  linear_combination h2
+end
+
+example (a b c d : ℚ) (h1 : a = 4) (h2 : 3 = b) (h3 : c*3 = d) (h4 : -d = a) :
+  6 - 3*c + 3*a + 3*d = 2*b - d + 12 - 3*a :=
+begin
+  linear_combination 2*h2,
+  linear_combination -h3,
+  linear_combination 3*h1,
+  linear_combination -3*h4,
+end
+
+example (x y : ℤ) (h1 : x*y + 2*x = 1) (h2 : x = y) :
+  x*y = -2*y + 1 :=
+begin
+  linear_combination,
+  linear_combination h1 - 2 * h2,
+end
+
 /-! ### Cases that should fail -/
 
--- todo: update
 
--- -- This should fail because there are no hypotheses given
--- example (x y : ℤ) (h1 : x*y + 2*x = 1) (h2 : x = y) :
---   x*y = -2*y + 1 :=
--- begin
---   linear_combination,
---   -- success_if_fail {linear_combination},
---   linear_combination h1 - 2 * h2,
--- end
+-- This should fail because the second coefficient has a different type than
+--   the equations it is being combined with.  This was a design choice for the
+--   sake of simplicity, but the tactic could potentially be modified to allow
+--   this behavior.
+example (x y : ℤ) (h1 : x*y + 2*x = 1) (h2 : x = y) :
+  x*y + 2*x = 1 :=
+begin
+  success_if_fail_with_msg {linear_combination h1 + (0 : ℝ) * h2}
+    "invalid type ascription, term has type
+  ℝ
+but is expected to have type
+  ℤ",
+  linear_combination h1
+end
 
--- -- This should fail because the second coefficient has a different type than
--- --   the equations it is being combined with.  This was a design choice for the
--- --   sake of simplicity, but the tactic could potentially be modified to allow
--- --   this behavior.
--- example (x y : ℤ) (h1 : x*y + 2*x = 1) (h2 : x = y) :
---   x*y + 2*x = 1 :=
--- begin
---   success_if_fail_with_msg {linear_combination h1 + (0 : ℝ) * h2}
---     "invalid type ascription, term has type
---   ℝ
--- but is expected to have type
---   ℤ",
---   linear_combination h1
--- end
 
--- -- This should fail because the second coefficient has a different type than
--- --   the equations it is being combined with.  This was a design choice for the
--- --   sake of simplicity, but the tactic could potentially be modified to allow
--- --   this behavior.
--- example (x y : ℤ) (h1 : x*y + 2*x = 1) (h2 : x = y) :
---   x*y + 2*x = 1 :=
--- begin
---   success_if_fail {linear_combination h1 + (0 : ℕ)  * h2},
---   linear_combination h1
--- end
-
--- -- This should fail because the coefficients are incorrect.  They should instead
--- --   be -2 and 3, respectively.
--- example (x y : ℤ) (h1 : 3*x + 2*y = 10) (h2 : 2*x + 5*y = 3) :
---   11*y = -11 :=
--- begin
---   success_if_fail {linear_combination 2*h1 - 3*h2},
---   linear_combination -2*h1 + 3*h2
--- end
-
--- -- This fails because the linear_combination tactic requires the equations
--- --   and coefficients to use a type that fulfills the add_group condition,
--- --   and ℕ does not.
--- example (a b : ℕ) (h1 : a = 3) :
---   a = 3 :=
--- begin
---   success_if_fail {linear_combination h1},
---   exact h1
--- end
+-- This fails because the linear_combination tactic requires the equations
+--   and coefficients to use a type that fulfills the add_group condition,
+--   and ℕ does not.
+example (a b : ℕ) (h1 : a = 3) :
+  a = 3 :=
+begin
+  success_if_fail {linear_combination h1},
+  exact h1
+end
 
 example (a b : ℤ) (x y : ℝ) (hab : a = b) (hxy : x = y) : 2*x = 2*y :=
 begin


### PR DESCRIPTION
Previously, `linear_combination` was a finishing tactic: it would close the goal, or fail. 

This PR changes it to be more of a simplification tactic. The semantics are "subtract this linear combination from the goal and normalize." In the case where the linear combination *does* close the goal, this behavior is the same as before.

This is a very convenient way to see what's missing from your linear combination. I imagine that people will often look at the remaining expression and modify the combination until the goal is closed.

By request of @hrmacbeth the default normalizer is `ring SOP`.

cc @digama0 

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
