### PR TITLE
feat(field_theory/adjoin): If `E/F` is finite dimensional, then `E →ₐ[F] K` is finite

### DIFF
--- a/src/field_theory/adjoin.lean
+++ b/src/field_theory/adjoin.lean
@@ -591,7 +591,7 @@ end adjoin_integral_element
 
 section induction
 
-variables {F : Type*} [field F] {E : Type*} [field E] [algebra F E]
+variables {F E K : Type*} [field F] [field E] [field K] [algebra F E] [algebra F K]
 
 /-- An intermediate field `S` is finitely generated if there exists `t : finset E` such that
 `intermediate_field.adjoin F t = S`. -/
@@ -642,6 +642,20 @@ lemma induction_on_adjoin [fd : finite_dimensional F E] (P : intermediate_field 
 begin
   letI : is_noetherian F E := is_noetherian.iff_fg.2 infer_instance,
   exact induction_on_adjoin_fg P base ih K K.fg_of_noetherian
+end
+
+instance alg_hom.finite_of_finite_dimensional [finite_dimensional F E] : finite (E →ₐ[F] K) :=
+begin
+  suffices : finite ((⊤ : intermediate_field F E) →ₐ[F] K),
+  { exactI finite.of_equiv _ (intermediate_field.top_equiv.arrow_congr alg_equiv.refl) },
+  apply intermediate_field.induction_on_adjoin (λ L : intermediate_field F E, finite (L →ₐ[F] K)),
+  { haveI : subsingleton (F →ₐ[F] K) := alg_hom.subsingleton,
+    exact finite.of_equiv _ ((intermediate_field.bot_equiv F E).symm.arrow_congr alg_equiv.refl) },
+  { intros L x hL,
+    haveI := λ f : L →ₐ[F] K, @intermediate_field.fintype_of_alg_hom_adjoin_integral
+      L _ E _ _ x K _ f.to_ring_hom.to_algebra (algebra.is_integral_of_finite L E x),
+    exact finite.of_equiv _ (@alg_hom_equiv_sigma F L L⟮x⟯ K _ _ _ _ _ _ _ _
+      L⟮x⟯.is_scalar_tower).symm },
 end
 
 end induction


### PR DESCRIPTION
This PR adds an instance stating that if `E/F` is finite dimensional, then `E →ₐ[F] K` is finite. The proof is by induction on intermediate fields of `E/F`, adjoining one element at a time.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
