### PR TITLE
[Merged by Bors] - feat(measure_theory/measure/measure_space): generalize measure.comap

### DIFF
--- a/src/measure_theory/measure/measure_space.lean
+++ b/src/measure_theory/measure/measure_space.lean
@@ -1019,6 +1019,31 @@ lemma tendsto_ae_map {f : α → β} (hf : ae_measurable f μ) : tendsto f μ.ae
 
 omit m0
 
+/-- Pullback of a `measure` as a linear map. If `f` sends each measurable set to a measurable
+set, then for each measurable set `s` we have `comapₗ f μ s = μ (f '' s)`.
+
+If the linearity is not needed, please use `comap` instead, which works for a larger class of
+functions. -/
+def comapₗ [measurable_space α] (f : α → β) : measure β →ₗ[ℝ≥0∞] measure α :=
+if hf : injective f ∧ ∀ s, measurable_set s → measurable_set (f '' s) then
+  lift_linear (outer_measure.comap f) $ λ μ s hs t,
+  begin
+    simp only [coe_to_outer_measure, outer_measure.comap_apply, ← image_inter hf.1,
+      image_diff hf.1],
+    apply le_to_outer_measure_caratheodory,
+    exact hf.2 s hs
+  end
+else 0
+
+lemma comapₗ_apply {β} [measurable_space α] {mβ : measurable_space β}
+  (f : α → β) (hfi : injective f)
+  (hf : ∀ s, measurable_set s → measurable_set (f '' s)) (μ : measure β) (hs : measurable_set s) :
+  comapₗ f μ s = μ (f '' s) :=
+begin
+  rw [comapₗ, dif_pos, lift_linear_apply _ hs, outer_measure.comap_apply, coe_to_outer_measure],
+  exact ⟨hfi, hf⟩
+end
+
 /-- Pullback of a `measure`. If `f` sends each measurable set to a null-measurable set,
 then for each measurable set `s` we have `comap f μ s = μ (f '' s)`. -/
 def comap [measurable_space α] (f : α → β) (μ : measure β) : measure α :=
@@ -1044,6 +1069,12 @@ lemma comap_apply {β} [measurable_space α] {mβ : measurable_space β} (f : α
   (hf : ∀ s, measurable_set s → measurable_set (f '' s)) (μ : measure β) (hs : measurable_set s) :
   comap f μ s = μ (f '' s) :=
 comap_apply₀ f μ hfi (λ s hs, (hf s hs).null_measurable_set) hs.null_measurable_set
+
+lemma comapₗ_eq_comap {β} [measurable_space α] {mβ : measurable_space β} (f : α → β)
+  (hfi : injective f) (hf : ∀ s, measurable_set s → measurable_set (f '' s))
+  (μ : measure β) (hs : measurable_set s) :
+  comapₗ f μ s = comap f μ s :=
+(comapₗ_apply f hfi hf μ hs).trans (comap_apply f hfi hf μ hs).symm
 
 /-! ### Restricting a measure -/
 

--- a/src/measure_theory/measure/measure_space.lean
+++ b/src/measure_theory/measure/measure_space.lean
@@ -1019,76 +1019,31 @@ lemma tendsto_ae_map {f : α → β} (hf : ae_measurable f μ) : tendsto f μ.ae
 
 omit m0
 
-/-- Pullback of a `measure` as a linear map. If `f` sends each `measurable` set to a `measurable`
-set, then for each measurable set `s` we have `comap f μ s = μ (f '' s)`. -/
-def comapₗ [measurable_space α] (f : α → β) : measure β →ₗ[ℝ≥0∞] measure α :=
-if hf : injective f ∧ ∀ s, measurable_set s → measurable_set (f '' s) then
-  lift_linear (outer_measure.comap f) $ λ μ s hs t,
-  begin
-    simp only [coe_to_outer_measure, outer_measure.comap_apply, ← image_inter hf.1,
-      image_diff hf.1],
-    apply le_to_outer_measure_caratheodory,
-    exact hf.2 s hs
-  end
-else 0
-
-lemma comapₗ_apply {β} [measurable_space α] {mβ : measurable_space β}
-  (f : α → β) (hfi : injective f)
-  (hf : ∀ s, measurable_set s → measurable_set (f '' s)) (μ : measure β) (hs : measurable_set s) :
-  comapₗ f μ s = μ (f '' s) :=
-begin
-  rw [comapₗ, dif_pos, lift_linear_apply _ hs, outer_measure.comap_apply, coe_to_outer_measure],
-  exact ⟨hfi, hf⟩
-end
-
-lemma le_caratheodory_comap_to_outer_measure [mα : measurable_space α] (f : α → β) (μ : measure β)
-  (hfi : injective f) (hf : ∀ s, measurable_set s → null_measurable_set (f '' s) μ) :
-  mα ≤ (outer_measure.comap f μ.to_outer_measure).caratheodory :=
-begin
-  intros s hs t,
-  simp_rw [outer_measure.comap_apply, coe_to_outer_measure, ← image_inter hfi, image_diff hfi],
-  let fs' := to_measurable μ (f '' s),
-  have : μ (f '' t) = μ (f '' t ∩ fs') + μ (f '' t \ fs'),
-    from le_to_outer_measure_caratheodory _ _ (measurable_set_to_measurable _ _) _,
-  rw this,
-  congr' 1,
-  { refine measure_congr ((hf s hs).to_measurable_ae_eq.mono (λ x hx, _)),
-    rw eq_iff_iff at hx ⊢,
-    change x ∈ (f '' t ∩ fs') ↔ x ∈ (f '' t ∩ f '' s),
-    change x ∈ fs' ↔ x ∈ f '' s at hx,
-    simp_rw [set.mem_inter_iff, hx], },
-  { refine measure_congr ((hf s hs).to_measurable_ae_eq.mono (λ x hx, _)),
-    rw eq_iff_iff at hx ⊢,
-    change x ∈ (f '' t \ fs') ↔ x ∈ (f '' t \ f '' s),
-    change x ∈ fs' ↔ x ∈ f '' s at hx,
-    simp_rw [set.mem_diff, hx], },
-end
-
 /-- Pullback of a `measure`. If `f` sends each measurable set to a null-measurable set,
 then for each measurable set `s` we have `comap f μ s = μ (f '' s)`. -/
 def comap [measurable_space α] (f : α → β) (μ : measure β) : measure α :=
-if hf : injective f ∧ ∀ s, measurable_set s → null_measurable_set (f '' s) μ
-then (outer_measure.comap f μ.to_outer_measure).to_measure
-  (le_caratheodory_comap_to_outer_measure f μ hf.1 hf.2)
+if hf : injective f ∧ ∀ s, measurable_set s → null_measurable_set (f '' s) μ then
+  (outer_measure.comap f μ.to_outer_measure).to_measure $ λ s hs t,
+  begin
+    simp only [coe_to_outer_measure, outer_measure.comap_apply, ← image_inter hf.1,
+      image_diff hf.1],
+    exact (measure_inter_add_diff₀ _ (hf.2 s hs)).symm
+  end
 else 0
 
-lemma comap_apply₀ {β} [measurable_space α] {mβ : measurable_space β} (f : α → β) (μ : measure β)
-  (hfi : injective f) (hf : ∀ s, measurable_set s → null_measurable_set (f '' s) μ)
-  (hs : measurable_set s) :
-  comap f μ s = μ (f '' s) :=
-by { rw [comap, dif_pos], exacts [to_measure_apply _ _ hs, ⟨hfi, hf⟩], }
+lemma comap_apply₀ [measurable_space α] (f : α → β) (μ : measure β) (hfi : injective f)
+  (hf : ∀ s, measurable_set s → null_measurable_set (f '' s) μ)
+  (hs : null_measurable_set s (comap f μ)) :
+   comap f μ s = μ (f '' s) :=
+begin
+  rw [comap, dif_pos (and.intro hfi hf)] at hs ⊢,
+  rw [to_measure_apply₀ _ _ hs, outer_measure.comap_apply, coe_to_outer_measure]
+end
 
 lemma comap_apply {β} [measurable_space α] {mβ : measurable_space β} (f : α → β) (hfi : injective f)
   (hf : ∀ s, measurable_set s → measurable_set (f '' s)) (μ : measure β) (hs : measurable_set s) :
   comap f μ s = μ (f '' s) :=
-comap_apply₀ f μ hfi (λ s hs, (hf s hs).null_measurable_set) hs
-
-lemma comap_eq_comapₗ {β} [measurable_space α] {mβ : measurable_space β} (f : α → β)
-  (hfi : injective f) (hf : ∀ s, measurable_set s → measurable_set (f '' s))
-  (μ : measure β) (hs : measurable_set s) :
-  comap f μ s = comapₗ f μ s :=
-by { rw [comap_apply f hfi hf μ hs, comapₗ_apply f hfi hf μ hs], }
-
+comap_apply₀ f μ hfi (λ s hs, (hf s hs).null_measurable_set) hs.null_measurable_set
 
 /-! ### Restricting a measure -/
 


### PR DESCRIPTION
Generalize comap to functions verifying `injective f ∧ ∀ s, measurable_set s → null_measurable_set (f '' s) μ`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

The change makes the following sorry true, while it was only true for measurable sets before:
```lean
import measure_theory.measure.measure_space_def

variables {V : Type*} [measure_space V] {p : V → Prop} {s : set V}

instance subtype.measure_space : measure_space (subtype p) :=
{ volume := measure.comap subtype.val volume,
  ..subtype.measurable_space }

lemma subtype.volume_univ (hs : null_measurable_set s) : volume (univ : set s) = volume s := sorry
```
According to @YaelDillies , that result will be useful in #2819 .

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
