### PR TITLE
[Merged by Bors] - feat(data/list/basic): add `list.length_filter_le` and `list.length_filter_map_le`

### DIFF
--- a/src/data/list/basic.lean
+++ b/src/data/list/basic.lean
@@ -2917,6 +2917,14 @@ end
 @[simp] theorem filter_map_some (l : list α) : filter_map some l = l :=
 by rw filter_map_eq_map; apply map_id
 
+theorem map_filter_map_some_eq_filter_map_is_some (f : α → option β) (l : list α) :
+  (l.filter_map f).map some = (l.map f).filter (λ b, b.is_some) :=
+begin
+  induction l with x xs ih,
+  { simp },
+  { cases h : f x; rw [list.filter_map_cons, h]; simp [h, ih] },
+end
+
 @[simp] theorem mem_filter_map (f : α → option β) (l : list α) {b : β} :
   b ∈ filter_map f l ↔ ∃ a, a ∈ l ∧ f a = some b :=
 begin
@@ -2944,14 +2952,6 @@ theorem map_filter_map_of_inv (f : α → option β) (g : β → α)
   (H : ∀ x : α, (f x).map g = some x) (l : list α) :
   map g (filter_map f l) = l :=
 by simp only [map_filter_map, H, filter_map_some]
-
-theorem map_filter_map_some_eq_filter_map_is_some (f : α → option β) (l : list α) :
-  (l.filter_map f).map some = (l.map f).filter (λ b, b.is_some) :=
-begin
-  induction l with x xs ih,
-  { simp },
-  { cases h : f x; rw [list.filter_map_cons, h]; simp [h, ih] },
-end
 
 theorem length_filter_le (p : α → Prop) [decidable_pred p] (l : list α) :
   (l.filter p).length ≤ l.length :=

--- a/src/data/list/basic.lean
+++ b/src/data/list/basic.lean
@@ -2945,21 +2945,23 @@ theorem map_filter_map_of_inv (f : α → option β) (g : β → α)
   map g (filter_map f l) = l :=
 by simp only [map_filter_map, H, filter_map_some]
 
-theorem length_filter_map (f : α → option β) (l : list α) :
-  (filter_map f l).length ≤ l.length :=
+theorem map_filter_map_some_eq_filter_map_is_some (f : α → option β) (l : list α) :
+  (l.filter_map f).map some = (l.map f).filter (λ b, b.is_some) :=
 begin
-  induction l with hd tl ih,
-  { refl },
-  { rw length,
-    unfold filter_map,
-    cases f hd,
-    { change (filter_map f tl).length ≤ tl.length + 1,
-      apply le_trans ih,
-      apply nat.le_succ },
-    { change (val :: (filter_map f tl)).length ≤ tl.length + 1,
-      rw length,
-      apply add_le_add_right,
-      exact ih } }
+  induction l with x xs ih,
+  { simp },
+  { cases h : f x; rw [list.filter_map_cons, h]; simp [h, ih] },
+end
+
+theorem length_filter_le (p : α → Prop) [decidable_pred p] (l : list α) :
+  (l.filter p).length ≤ l.length :=
+list.length_le_of_sublist (list.filter_sublist _)
+
+theorem length_filter_map_le (f : α → option β) (l : list α) :
+  (list.filter_map f l).length ≤ l.length :=
+begin
+  rw [← list.length_map some, list.map_filter_map_some_eq_filter_map_is_some, ← list.length_map f],
+  apply list.length_filter_le,
 end
 
 theorem sublist.filter_map (f : α → option β) {l₁ l₂ : list α}

--- a/src/data/list/basic.lean
+++ b/src/data/list/basic.lean
@@ -2945,6 +2945,23 @@ theorem map_filter_map_of_inv (f : α → option β) (g : β → α)
   map g (filter_map f l) = l :=
 by simp only [map_filter_map, H, filter_map_some]
 
+theorem length_filter_map (f : α → option β) (l : list α) :
+  (filter_map f l).length ≤ l.length :=
+begin
+  induction l with hd tl ih,
+  { refl },
+  { rw length,
+    unfold filter_map,
+    cases f hd,
+    { change (filter_map f tl).length ≤ tl.length + 1,
+      apply le_trans ih,
+      apply nat.le_succ },
+    { change (val :: (filter_map f tl)).length ≤ tl.length + 1,
+      rw length,
+      apply add_le_add_right,
+      exact ih } }
+end
+
 theorem sublist.filter_map (f : α → option β) {l₁ l₂ : list α}
   (s : l₁ <+ l₂) : filter_map f l₁ <+ filter_map f l₂ :=
 by induction s with l₁ l₂ a s IH l₁ l₂ a s IH;


### PR DESCRIPTION
A `list` can't get longer when applying `list.filter` or `list.filter_map`.

Co-authored-by: Junyan Xu <junyanxu.math@gmail.com>
Co-authored-by: Kyle Miller <kmill31415@gmail.com>

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
