### PR TITLE
[Merged by Bors] - feat(ring_theory): the integral closure `C` of `A` is Noetherian over `A`

### DIFF
--- a/src/ring_theory/dedekind_domain/integral_closure.lean
+++ b/src/ring_theory/dedekind_domain/integral_closure.lean
@@ -163,7 +163,6 @@ lemma is_integral_closure.is_noetherian [is_integrally_closed A] [is_noetherian_
 begin
   haveI := classical.dec_eq L,
   obtain ⟨s, b, hb_int⟩ := finite_dimensional.exists_is_basis_integral A K L,
-  -- rw is_noetherian_ring_iff,
   let b' := (trace_form K L).dual_basis (trace_form_nondegenerate K L) b,
   letI := is_noetherian_span_of_finite A (set.finite_range b'),
   let f : C →ₗ[A] submodule.span A (set.range b') :=

--- a/src/ring_theory/dedekind_domain/integral_closure.lean
+++ b/src/ring_theory/dedekind_domain/integral_closure.lean
@@ -157,22 +157,29 @@ include L
 
 /- If `L` is a finite separable extension of `K = Frac(A)`, where `A` is
 integrally closed and Noetherian, the integral closure `C` of `A` in `L` is
-Noetherian. -/
-lemma is_integral_closure.is_noetherian_ring [is_integrally_closed A] [is_noetherian_ring A] :
-  is_noetherian_ring C :=
+Noetherian over `A`. -/
+lemma is_integral_closure.is_noetherian [is_integrally_closed A] [is_noetherian_ring A] :
+  is_noetherian A C :=
 begin
   haveI := classical.dec_eq L,
   obtain ⟨s, b, hb_int⟩ := finite_dimensional.exists_is_basis_integral A K L,
-  rw is_noetherian_ring_iff,
+  -- rw is_noetherian_ring_iff,
   let b' := (trace_form K L).dual_basis (trace_form_nondegenerate K L) b,
   letI := is_noetherian_span_of_finite A (set.finite_range b'),
   let f : C →ₗ[A] submodule.span A (set.range b') :=
     (submodule.of_le (is_integral_closure.range_le_span_dual_basis C b hb_int)).comp
     ((algebra.linear_map C L).restrict_scalars A).range_restrict,
-  refine is_noetherian_of_tower A (is_noetherian_of_ker_bot f _),
+  refine is_noetherian_of_ker_bot f _,
   rw [linear_map.ker_comp, submodule.ker_of_le, submodule.comap_bot, linear_map.ker_cod_restrict],
   exact linear_map.ker_eq_bot_of_injective (is_integral_closure.algebra_map_injective C A L)
 end
+
+/- If `L` is a finite separable extension of `K = Frac(A)`, where `A` is
+integrally closed and Noetherian, the integral closure `C` of `A` in `L` is
+Noetherian. -/
+lemma is_integral_closure.is_noetherian_ring [is_integrally_closed A] [is_noetherian_ring A] :
+  is_noetherian_ring C :=
+is_noetherian_ring_iff.mpr $ is_noetherian_of_tower A (is_integral_closure.is_noetherian A K L C)
 
 variables {A K}
 


### PR DESCRIPTION
where `A` is an integrally closed Noetherian domain and `C` is the closure in a finite separable extension `L` of `Frac(A)`

I was going to use this in https://github.com/leanprover-community/mathlib/pull/15315 but it turns out we don't assume separability there. Since it might still be useful elsewhere, I turned it into a new PR.

The proof was already in mathlib, as part of showing that the integral closure of a Dedekind domain is Noetherian, so I could just split off the part that dealt with Noetherianness.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

This is a redo of #15380, which I accidentally pushed to the wrong repository.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
