### PR TITLE
[Merged by Bors] - feat(data/vector/basic): make the recursor work with `induction _ using` syntax

### DIFF
--- a/src/data/vector/basic.lean
+++ b/src/data/vector/basic.lean
@@ -321,12 +321,13 @@ def mmap {m} [monad m] {α} {β : Type u} (f : α → m β) :
 /-- Define `C v` by induction on `v : vector α n`.
 
 This function has two arguments: `h_nil` handles the base case on `C nil`,
-and `h_cons` defines the inductive step using `∀ x : α, C w → C (x ::ᵥ w)`. -/
-@[elab_as_eliminator] def induction_on {C : Π {n : ℕ}, vector α n → Sort*}
-  (v : vector α n)
+and `h_cons` defines the inductive step using `∀ x : α, C w → C (x ::ᵥ w)`.
+
+This can be used as `induction v using vector.induction`. -/
+@[elab_as_eliminator] def induction {C : Π {n : ℕ}, vector α n → Sort*}
   (h_nil : C nil)
-  (h_cons : ∀ {n : ℕ} {x : α} {w : vector α n}, C w → C (x ::ᵥ w)) :
-    C v :=
+  (h_cons : ∀ {n : ℕ} {x : α} {w : vector α n}, C w → C (x ::ᵥ w))
+  {n : ℕ} (v : vector α n) : C v :=
 begin
   induction n with n ih generalizing v,
   { rcases v with ⟨_|⟨-,-⟩,-|-⟩,
@@ -336,6 +337,17 @@ begin
     apply @h_cons n _ ⟨v, (add_left_inj 1).mp v_property⟩,
     apply ih, }
 end
+
+-- check that the above works with `induction ... using`
+example (v : vector α n) : true := by induction v using vector.induction; trivial
+
+/-- A version of `vector.induction` that takes `v` first. -/
+@[elab_as_eliminator, reducible] def induction_on {C : Π {n : ℕ}, vector α n → Sort*}
+  (v : vector α n)
+  (h_nil : C nil)
+  (h_cons : ∀ {n : ℕ} {x : α} {w : vector α n}, C w → C (x ::ᵥ w)) :
+    C v :=
+induction h_nil @h_cons v
 
 variables {β γ : Type*}
 

--- a/src/data/vector/basic.lean
+++ b/src/data/vector/basic.lean
@@ -572,7 +572,7 @@ instance : is_lawful_traversable.{u} (flip vector n) :=
 
 meta instance reflect [reflected_univ.{u}] {α : Type u} [has_reflect α] [reflected _ α] {n : ℕ} :
   has_reflect (vector α n) :=
-λ v, @vector.induction_on n α (λ n, reflected _) v
+λ v, @vector.induction_on α (λ n, reflected _) n v
   ((by reflect_name : reflected _ @vector.nil.{u}).subst `(α))
   (λ n x xs ih, (by reflect_name : reflected _ @vector.cons.{u}).subst₄ `(α) `(n) `(x) ih)
 

--- a/src/data/vector/basic.lean
+++ b/src/data/vector/basic.lean
@@ -328,7 +328,7 @@ This can be used as `induction v using vector.induction_on`. -/
   {n : ℕ} (v : vector α n)
   (h_nil : C nil)
   (h_cons : ∀ {n : ℕ} {x : α} {w : vector α n}, C w → C (x ::ᵥ w)) :
-  C v :=
+    C v :=
 begin
   induction n with n ih generalizing v,
   { rcases v with ⟨_|⟨-,-⟩,-|-⟩,

--- a/src/data/vector/basic.lean
+++ b/src/data/vector/basic.lean
@@ -323,11 +323,12 @@ def mmap {m} [monad m] {α} {β : Type u} (f : α → m β) :
 This function has two arguments: `h_nil` handles the base case on `C nil`,
 and `h_cons` defines the inductive step using `∀ x : α, C w → C (x ::ᵥ w)`.
 
-This can be used as `induction v using vector.induction`. -/
-@[elab_as_eliminator] def induction {C : Π {n : ℕ}, vector α n → Sort*}
+This can be used as `induction v using vector.induction_on`. -/
+@[elab_as_eliminator] def induction_on {C : Π {n : ℕ}, vector α n → Sort*}
+  {n : ℕ} (v : vector α n)
   (h_nil : C nil)
-  (h_cons : ∀ {n : ℕ} {x : α} {w : vector α n}, C w → C (x ::ᵥ w))
-  {n : ℕ} (v : vector α n) : C v :=
+  (h_cons : ∀ {n : ℕ} {x : α} {w : vector α n}, C w → C (x ::ᵥ w)) :
+  C v :=
 begin
   induction n with n ih generalizing v,
   { rcases v with ⟨_|⟨-,-⟩,-|-⟩,
@@ -339,15 +340,7 @@ begin
 end
 
 -- check that the above works with `induction ... using`
-example (v : vector α n) : true := by induction v using vector.induction; trivial
-
-/-- A version of `vector.induction` that takes `v` first. -/
-@[elab_as_eliminator, reducible] def induction_on {C : Π {n : ℕ}, vector α n → Sort*}
-  (v : vector α n)
-  (h_nil : C nil)
-  (h_cons : ∀ {n : ℕ} {x : α} {w : vector α n}, C w → C (x ::ᵥ w)) :
-    C v :=
-induction h_nil @h_cons v
+example (v : vector α n) : true := by induction v using vector.induction_on; trivial
 
 variables {β γ : Type*}
 


### PR DESCRIPTION

The `induction` tactic is picky about the order of its arguments, especially when the motive is dependently-typed. Attempting to use `induction v using vector.induction_on` gives the error:

> invalid user defined recursor, type of the major premise 'v' does not contain the recursor index 'C'

which indicates that the argument order has confused Lean into thinking that the motive is an index.
The cause here was that the motive `C` was between the indices (`n`) and the major premise (`v`).

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
