### PR TITLE
[Merged by Bors] - feat(linear_algebra/projective_space/subspace): defines subspaces of a projective space

### DIFF
--- a/src/linear_algebra/projective_space/subspace.lean
+++ b/src/linear_algebra/projective_space/subspace.lean
@@ -30,6 +30,7 @@ and the subspaces of the projective space, which is given by taking the span of 
 projective space and the submodules of the underlying vector space.
 -/
 
+
 variables (K V : Type*) [field K] [add_comm_group V] [module K V]
 
 namespace projectivization

--- a/src/linear_algebra/projective_space/subspace.lean
+++ b/src/linear_algebra/projective_space/subspace.lean
@@ -22,20 +22,19 @@ also in the subset.
 ## Results
 
 - There is a Galois insertion between the subsets of points of a projective space
-and the subspaces of the projective space, which is given by taking the span of the set of points.
+  and the subspaces of the projective space, which is given by taking the span of the set of points.
 - The subspaces of a projective space form a complete lattice under inclusion.
 
 # Future Work
 - Show that there is a one-to-one order-preserving correspondence between subspaces of a
-projective space and the submodules of the underlying vector space.
+  projective space and the submodules of the underlying vector space.
 -/
-
 
 variables (K V : Type*) [field K] [add_comm_group V] [module K V]
 
 namespace projectivization
 
-/-- A subspace of projective space is a structure consisting of a set of points such that:
+/-- A subspace of a projective space is a structure consisting of a set of points such that:
 If two nonzero vectors determine points which are in the set, and the sum of the two vectors is
 nonzero, then the point determined by the sum is also in the set. -/
 @[ext] structure subspace :=
@@ -59,7 +58,7 @@ lemma mem_add (T : subspace K V) (v w : V) (hv : v ≠ 0) (hw : w ≠ 0) (hvw : 
   projectivization.mk K (v + w) (hvw) ∈ T :=
   T.mem_add' v w hv hw hvw
 
-/-- The span of a set of points in projective space is defined inductively to be the set of points
+/-- The span of a set of points in a projective space is defined inductively to be the set of points
 which contains the original set, and contains all points determined by the (nonzero) sum of two
 nonzero vectors, each of which determine points in the span. -/
 inductive span_carrier (S : set (ℙ K V)) : set (ℙ K V)
@@ -100,17 +99,6 @@ def gi : galois_insertion (span : set (ℙ K V) → subspace K V) coe :=
   le_l_u := λ S, subset_span _,
   choice_eq := λ _ _, rfl }
 
-/-- The ambient projective space is the top of the lattice of subspaces. -/
-instance has_top : has_top (subspace K V) :=
-⟨⟨⊤, λ _ _ _ _ _ _ _, trivial⟩⟩
-
-instance subspace_inhabited : inhabited (subspace K V) :=
-{ default := ⊤ }
-
-/-- The empty set is the bottom of the lattice of subspaces. -/
-instance has_bot : has_bot (subspace K V) :=
-⟨⟨⊥, λ v w hv hw hvw h, h.elim⟩⟩
-
 /-- The infimum of two subspaces exists. -/
 instance has_inf : has_inf (subspace K V) :=
 ⟨λ A B, ⟨A ⊓ B, λ v w hv hw hvw h1 h2,
@@ -125,37 +113,19 @@ end⟩⟩
 
 /-- The subspaces of a projective space form a complete lattice. -/
 instance : complete_lattice (subspace K V) :=
-{ sup := λ A B, Inf { E | A ≤ E ∧ B ≤ E },
-  le_sup_left := begin
-    rintros A B x hx E ⟨E, hE, rfl⟩,
-    exact hE.1 hx,
-  end,
-  le_sup_right := begin
-    rintros A B x hx E ⟨E, hE, rfl⟩,
-    exact hE.2 hx,
-  end,
-  sup_le := λ A B C h1 h2 x hx, hx C ⟨C, ⟨h1, h2⟩, rfl⟩,
-  inf_le_left := λ A B x hx, by exact hx.1,
+{ inf_le_left := λ A B x hx, by exact hx.1,
   inf_le_right := λ A B x hx, by exact hx.2,
   le_inf := λ A B C h1 h2 x hx, ⟨h1 hx, h2 hx⟩,
-  Sup := λ A, Inf { E | ∀ U ∈ A, U ≤ E },
-  le_Sup := begin
-    rintros S A hA x hx E ⟨E, hE, rfl⟩,
-    exact hE _ hA hx,
-  end,
-  Sup_le := λ S A hA x hx, hx A ⟨A, hA, rfl⟩,
-  Inf_le := λ S A hA x hx, by exact hx _ ⟨A, hA, rfl⟩,
-  le_Inf := begin
-    rintros S A hA x hx E ⟨E, hE, rfl⟩,
-    exact hA _ hE hx,
-  end,
-  le_top := λ E x hx, trivial,
-  bot_le := λ E x hx, hx.elim,
-  ..(infer_instance : has_Inf _),
   ..(infer_instance : has_inf _),
-  ..(infer_instance : has_top _),
-  ..(infer_instance : has_bot _),
-  ..set_like.partial_order }
+  ..complete_lattice_of_Inf (subspace K V)
+  begin
+    refine λ s, ⟨λ a ha x hx, (hx _ ⟨a, ha, rfl⟩), λ a ha x hx E, _⟩,
+    rintros ⟨E, hE, rfl⟩,
+    exact (ha hE hx)
+  end }
+
+instance subspace_inhabited : inhabited (subspace K V) :=
+{ default := ⊤ }
 
 end subspace
 

--- a/src/linear_algebra/projective_space/subspace.lean
+++ b/src/linear_algebra/projective_space/subspace.lean
@@ -1,0 +1,159 @@
+/-
+Copyright (c) 2022 Michael Blyth. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Michael Blyth
+-/
+
+import linear_algebra.projective_space.basic
+
+/-!
+# Subspaces of Projective Space
+
+In this file we define subspaces of a projective space, and show that the subspaces of a projective
+space form a complete lattice under inclusion.
+
+## Implementation Details
+
+A subspace of a projective space ℙ K V is defined to be a structure consisting of a subset of
+ℙ K V such that if two nonzero vectors in V determine points in ℙ K V which are in the subset, and
+the sum of the two vectors is nonzero, then the point determined by the sum of the two vectors is
+also in the subset.
+
+## Results
+
+- There is a Galois insertion between the subsets of points of a projective space
+and the subspaces of the projective space, which is given by taking the span of the set of points.
+- The subspaces of a projective space form a complete lattice under inclusion.
+
+# Future Work
+- Show that there is a one-to-one order-preserving correspondence between subspaces of a
+projective space and the submodules of the underlying vector space.
+-/
+
+variables (K V : Type*) [field K] [add_comm_group V] [module K V]
+
+namespace projectivization
+
+/-- A subspace of projective space is a structure consisting of a set of points such that if two
+nonzero vectors determine points which are in the set, and the sum of the two vectors is nonzero,
+then the point determined by the sum of the two vectors is also in the set. -/
+@[ext] structure subspace :=
+(carrier : set (ℙ K V))
+(mem_add' (v w : V) (hv : v ≠ 0) (hw : w ≠ 0) (hvw : v + w ≠ 0) :
+  mk K v hv ∈ carrier → mk K w hw ∈ carrier → mk K (v + w) (hvw) ∈ carrier)
+
+namespace subspace
+
+variables {K V}
+
+instance : set_like (subspace K V) (ℙ K V) :=
+{ coe := carrier,
+  coe_injective' := λ A B, by { cases A, cases B, simp } }
+
+@[simp]
+lemma mem_carrier_iff (A : subspace K V) (x : ℙ K V) : x ∈ A.carrier ↔ x ∈ A := iff.refl _
+
+lemma mem_add (T : subspace K V) (v w : V) (hv : v ≠ 0) (hw : w ≠ 0) (hvw : v + w ≠ 0) :
+  projectivization.mk K v hv ∈ T → projectivization.mk K w hw ∈ T →
+  projectivization.mk K (v + w) (hvw) ∈ T :=
+  T.mem_add' v w hv hw hvw
+
+
+/-- The span of a set of points in projective space is defined inductively to be the set of points
+which contains the original set, and contains all points determined by the (nonzero) sum of two
+nonzero vectors, each of which determine points in the span. -/
+inductive span_carrier (S : set (ℙ K V)) : set (ℙ K V)
+| of (x : ℙ K V) (hx : x ∈ S) : span_carrier x
+| mem_add (v w : V) (hv : v ≠ 0) (hw : w ≠ 0) (hvw : v + w ≠ 0) :
+    span_carrier (projectivization.mk K v hv) → span_carrier (projectivization.mk K w hw) →
+    span_carrier (projectivization.mk K (v + w) (hvw))
+
+/-- The span of a set of points in projective space is a subspace. -/
+def span (S : set (ℙ K V)) : subspace K V :=
+{ carrier := span_carrier S,
+  mem_add' := λ v w hv hw hvw,
+    span_carrier.mem_add v w hv hw hvw }
+
+/- The span of a set of points contains the set of points. -/
+lemma subset_span (S : set (ℙ K V)) : S ⊆ span S := λ x hx, span_carrier.of _ hx
+
+/-- The span of a subspace is the subspace. -/
+@[simp] lemma span_coe (W : subspace K V) : span ↑W = W :=
+begin
+  ext, refine ⟨λ hx, _, λ hx, _⟩,
+  { induction hx with a ha u w hu hw huw _ _ hum hwm,
+      { exact ha },
+      { exact mem_add W u w hu hw huw hum hwm } },
+  { exact subset_span W hx },
+end
+
+/-- The span of a set of points is a Galois insertion between sets of points of a projective space
+and subspaces of the projective space. -/
+def gi : galois_insertion (span : set (ℙ K V) → subspace K V) coe :=
+{ choice := λ S hS, span S,
+  gc := λ A B, ⟨λ h, le_trans (subset_span _) h, begin
+    intros h x hx,
+    induction hx,
+    { apply h, assumption },
+    { apply B.mem_add, assumption' }
+  end⟩,
+  le_l_u := λ S, subset_span _,
+  choice_eq := λ _ _, rfl }
+
+/-- The ambient projective space is the top of the lattice of subspaces. -/
+instance has_top : has_top (subspace K V) :=
+⟨⟨⊤, λ _ _ _ _ _ _ _, trivial⟩⟩
+
+/-- The empty set is the bottom of the lattice of subspaces. -/
+instance has_bot : has_bot (subspace K V) :=
+⟨⟨⊥, λ v w hv hw hvw h, h.elim⟩⟩
+
+/-- The infimum of two subspaces exists. -/
+instance has_inf : has_inf (subspace K V) :=
+⟨λ A B, ⟨A ⊓ B, λ v w hv hw hvw h1 h2,
+  ⟨A.mem_add _ _ hv hw _ h1.1 h2.1, B.mem_add _ _ hv hw _ h1.2 h2.2⟩⟩⟩
+
+/-- Infimums of arbitrary collections of subspaces exist. -/
+instance has_Inf : has_Inf (subspace K V) :=
+⟨λ A, ⟨Inf (coe '' A), λ v w hv hw hvw h1 h2 t, begin
+  rintro ⟨s, hs, rfl⟩,
+  exact s.mem_add v w hv hw _ (h1 s ⟨s, hs, rfl⟩) (h2 s ⟨s, hs, rfl⟩),
+end⟩⟩
+
+/-- The subspaces of a projective space form a complete lattice. -/
+instance : complete_lattice (subspace K V) :=
+{ sup := λ A B, Inf { E | A ≤ E ∧ B ≤ E },
+  le_sup_left := begin
+    rintros A B x hx E ⟨E,hE,rfl⟩,
+    exact hE.1 hx,
+  end,
+  le_sup_right := begin
+    rintros A B x hx E ⟨E,hE,rfl⟩,
+    exact hE.2 hx,
+  end,
+  sup_le := λ A B C h1 h2 x hx, hx C ⟨C,⟨h1,h2⟩, rfl⟩,
+  inf_le_left := λ A B x hx, by exact hx.1,
+  inf_le_right := λ A B x hx, by exact hx.2,
+  le_inf := λ A B C h1 h2 x hx, ⟨h1 hx, h2 hx⟩,
+  Sup := λ A, Inf { E | ∀ U ∈ A, U ≤ E },
+  le_Sup := begin
+    rintros S A hA x hx E ⟨E,hE,rfl⟩,
+    exact hE _ hA hx,
+  end,
+  Sup_le := λ S A hA x hx, hx A ⟨A, hA, rfl⟩,
+  Inf_le := λ S A hA x hx, by exact hx _ ⟨A, hA, rfl⟩,
+  le_Inf := begin
+    rintros S A hA x hx E ⟨E,hE,rfl⟩,
+    exact hA _ hE hx,
+  end,
+  le_top := λ E x hx, trivial,
+  bot_le := λ E x hx, hx.elim,
+  ..(infer_instance : has_Inf _),
+  ..(infer_instance : has_inf _),
+  ..(infer_instance : has_top _),
+  ..(infer_instance : has_bot _),
+  ..set_like.partial_order }
+
+end subspace
+
+end projectivization

--- a/src/linear_algebra/projective_space/subspace.lean
+++ b/src/linear_algebra/projective_space/subspace.lean
@@ -34,9 +34,9 @@ variables (K V : Type*) [field K] [add_comm_group V] [module K V]
 
 namespace projectivization
 
-/-- A subspace of projective space is a structure consisting of a set of points such that if two
-nonzero vectors determine points which are in the set, and the sum of the two vectors is nonzero,
-then the point determined by the sum of the two vectors is also in the set. -/
+/-- A subspace of projective space is a structure consisting of a set of points such that:
+If two nonzero vectors determine points which are in the set, and the sum of the two vectors is
+nonzero, then the point determined by the sum is also in the set. -/
 @[ext] structure subspace :=
 (carrier : set (ℙ K V))
 (mem_add' (v w : V) (hv : v ≠ 0) (hw : w ≠ 0) (hvw : v + w ≠ 0) :
@@ -58,7 +58,6 @@ lemma mem_add (T : subspace K V) (v w : V) (hv : v ≠ 0) (hw : w ≠ 0) (hvw : 
   projectivization.mk K (v + w) (hvw) ∈ T :=
   T.mem_add' v w hv hw hvw
 
-
 /-- The span of a set of points in projective space is defined inductively to be the set of points
 which contains the original set, and contains all points determined by the (nonzero) sum of two
 nonzero vectors, each of which determine points in the span. -/
@@ -74,7 +73,7 @@ def span (S : set (ℙ K V)) : subspace K V :=
   mem_add' := λ v w hv hw hvw,
     span_carrier.mem_add v w hv hw hvw }
 
-/- The span of a set of points contains the set of points. -/
+/-- The span of a set of points contains the set of points. -/
 lemma subset_span (S : set (ℙ K V)) : S ⊆ span S := λ x hx, span_carrier.of _ hx
 
 /-- The span of a subspace is the subspace. -/
@@ -104,6 +103,9 @@ def gi : galois_insertion (span : set (ℙ K V) → subspace K V) coe :=
 instance has_top : has_top (subspace K V) :=
 ⟨⟨⊤, λ _ _ _ _ _ _ _, trivial⟩⟩
 
+instance subspace_inhabited : inhabited (subspace K V) :=
+{ default := ⊤ }
+
 /-- The empty set is the bottom of the lattice of subspaces. -/
 instance has_bot : has_bot (subspace K V) :=
 ⟨⟨⊥, λ v w hv hw hvw h, h.elim⟩⟩
@@ -124,26 +126,26 @@ end⟩⟩
 instance : complete_lattice (subspace K V) :=
 { sup := λ A B, Inf { E | A ≤ E ∧ B ≤ E },
   le_sup_left := begin
-    rintros A B x hx E ⟨E,hE,rfl⟩,
+    rintros A B x hx E ⟨E, hE, rfl⟩,
     exact hE.1 hx,
   end,
   le_sup_right := begin
-    rintros A B x hx E ⟨E,hE,rfl⟩,
+    rintros A B x hx E ⟨E, hE, rfl⟩,
     exact hE.2 hx,
   end,
-  sup_le := λ A B C h1 h2 x hx, hx C ⟨C,⟨h1,h2⟩, rfl⟩,
+  sup_le := λ A B C h1 h2 x hx, hx C ⟨C, ⟨h1, h2⟩, rfl⟩,
   inf_le_left := λ A B x hx, by exact hx.1,
   inf_le_right := λ A B x hx, by exact hx.2,
   le_inf := λ A B C h1 h2 x hx, ⟨h1 hx, h2 hx⟩,
   Sup := λ A, Inf { E | ∀ U ∈ A, U ≤ E },
   le_Sup := begin
-    rintros S A hA x hx E ⟨E,hE,rfl⟩,
+    rintros S A hA x hx E ⟨E, hE, rfl⟩,
     exact hE _ hA hx,
   end,
   Sup_le := λ S A hA x hx, hx A ⟨A, hA, rfl⟩,
   Inf_le := λ S A hA x hx, by exact hx _ ⟨A, hA, rfl⟩,
   le_Inf := begin
-    rintros S A hA x hx E ⟨E,hE,rfl⟩,
+    rintros S A hA x hx E ⟨E, hE, rfl⟩,
     exact hA _ hE hx,
   end,
   le_top := λ E x hx, trivial,


### PR DESCRIPTION
This PR defines subspaces of a projective space, and shows that they form a complete lattice under inclusion. In an upcoming PR we show that there is an order-preserving bijection between the lattice of a subspaces of a projective space and the lattice of submodules of the underlying vector space.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
