### PR TITLE
[Merged by Bors] - feat(big_operators/basic): sum of count over finset.filter equals countp

### DIFF
--- a/src/algebra/big_operators/basic.lean
+++ b/src/algebra/big_operators/basic.lean
@@ -1014,39 +1014,7 @@ end
 
 lemma sum_filter_count_eq_countp [decidable_eq α] (p : α → Prop) [decidable_pred p] (l : list α) :
   ∑ x in l.to_finset.filter p, l.count x = l.countp p :=
-begin
-  induction l with a as h,
-  { simp },
-  { rw [list.to_finset_cons],
-    by_cases ha : a ∈ as.to_finset,
-    { rw [finset.insert_eq_of_mem ha, list.countp_cons],
-      calc ∑ x in as.to_finset.filter p, (a :: as).count x
-        = ∑ x in as.to_finset.filter p, (as.count x + ite (a = x) (ite (p a) 1 0) 0) :
-          begin
-            refine finset.sum_congr rfl (λ x hx, _),
-            split_ifs with hax hpa,
-            { simp [hax] },
-            { exact false.elim (hpa $ hax.symm ▸ (finset.mem_filter.1 hx).2) },
-            { simp [ne.symm hax] }
-          end
-        ... = list.countp p as + ite (p a) 1 0 : by simp_rw [finset.sum_add_distrib, h,
-          finset.sum_ite_eq, finset.mem_filter, ← ite_and, and_assoc, and_self, ha, true_and] },
-    { calc ∑ x in (insert a as.to_finset).filter p, (a :: as).count x
-        = (ite (p a) ((a :: as).count a) 0) + ∑ x in as.to_finset.filter p, (a :: as).count x :
-          begin
-            rw [finset.filter_insert],
-            split_ifs with hpa,
-            { exact finset.sum_insert (λ h, ha (finset.mem_filter.1 h).1) },
-            { exact (zero_add _).symm }
-          end
-        ... = (ite (p a) 1 0) + ∑ x in as.to_finset.filter p, as.count x : begin
-          congr' 1,
-          { simp [list.count_eq_zero_of_not_mem (ha ∘ list.mem_to_finset.2)] },
-          { refine finset.sum_congr rfl (λ x hx, _),
-            simp [(λ hxa, ha (hxa ▸ (finset.mem_filter.1 hx).1) : x ≠ a)] }
-        end
-        ... = (a :: as).countp p : by rw [h, list.countp_cons, add_comm] } }
-end
+by simp [finset.sum, sum_map_count_dedup_filter_eq_countp p l]
 
 open multiset
 

--- a/src/algebra/big_operators/basic.lean
+++ b/src/algebra/big_operators/basic.lean
@@ -1012,6 +1012,42 @@ begin
   rw [count_eq_zero_of_not_mem hx, pow_zero],
 end
 
+lemma sum_filter_count_eq_countp [decidable_eq α] (p : α → Prop) [decidable_pred p] (l : list α) :
+  ∑ x in l.to_finset.filter p, l.count x = l.countp p :=
+begin
+  induction l with a as h,
+  { simp },
+  { rw [list.to_finset_cons],
+    by_cases ha : a ∈ as.to_finset,
+    { rw [finset.insert_eq_of_mem ha, list.countp_cons],
+      calc ∑ x in as.to_finset.filter p, (a :: as).count x
+        = ∑ x in as.to_finset.filter p, (as.count x + ite (a = x) (ite (p a) 1 0) 0) :
+          begin
+            refine finset.sum_congr rfl (λ x hx, _),
+            split_ifs with hax hpa,
+            { simp [hax] },
+            { exact false.elim (hpa $ hax.symm ▸ (finset.mem_filter.1 hx).2) },
+            { simp [ne.symm hax] }
+          end
+        ... = list.countp p as + ite (p a) 1 0 : by simp_rw [finset.sum_add_distrib, h,
+          finset.sum_ite_eq, finset.mem_filter, ← ite_and, and_assoc, and_self, ha, true_and] },
+    { calc ∑ x in (insert a as.to_finset).filter p, (a :: as).count x
+        = (ite (p a) ((a :: as).count a) 0) + ∑ x in as.to_finset.filter p, (a :: as).count x :
+          begin
+            rw [finset.filter_insert],
+            split_ifs with hpa,
+            { exact finset.sum_insert (λ h, ha (finset.mem_filter.1 h).1) },
+            { exact (zero_add _).symm }
+          end
+        ... = (ite (p a) 1 0) + ∑ x in as.to_finset.filter p, as.count x : begin
+          congr' 1,
+          { simp [list.count_eq_zero_of_not_mem (ha ∘ list.mem_to_finset.2)] },
+          { refine finset.sum_congr rfl (λ x hx, _),
+            simp [(λ hxa, ha (hxa ▸ (finset.mem_filter.1 hx).1) : x ≠ a)] }
+        end
+        ... = (a :: as).countp p : by rw [h, list.countp_cons, add_comm] } }
+end
+
 open multiset
 
 @[to_additive] lemma prod_multiset_map_count [decidable_eq α] (s : multiset α)

--- a/src/algebra/big_operators/multiset.lean
+++ b/src/algebra/big_operators/multiset.lean
@@ -80,7 +80,7 @@ by simp [repeat, list.prod_repeat]
 
 @[to_additive]
 lemma prod_map_eq_pow_single [decidable_eq ι] (i : ι) (hf : ∀ i' ≠ i, i' ∈ m → f i' = 1) :
-  (m.map f).prod = (f i) ^ (m.count i) :=
+  (m.map f).prod = f i ^ m.count i :=
 begin
   induction m using quotient.induction_on with l,
   simp [list.prod_map_eq_pow_single i f hf],
@@ -338,8 +338,8 @@ lemma prod_eq_one_iff [canonically_ordered_monoid α] {m : multiset α} :
   m.prod = 1 ↔ ∀ x ∈ m, x = (1 : α) :=
 quotient.induction_on m $ λ l, by simpa using list.prod_eq_one_iff l
 
-/-- Slightly more general version of `prod_eq_one_iff` for a non-ordered `monoid` -/
-@[to_additive "Slightly more general version of `sum_eq_zero_iff` for a non-ordered `monoid`"]
+/-- Slightly more general version of `multiset.prod_eq_one_iff` for a non-ordered `monoid` -/
+@[to_additive "Slightly more general version of `multiset.sum_eq_zero_iff` for a non-ordered `add_monoid`"]
 lemma prod_eq_one [comm_monoid α] {m : multiset α} (h : ∀ x ∈ m, x = (1 : α)) : m.prod = 1 :=
 begin
   induction m using quotient.induction_on with l,

--- a/src/algebra/big_operators/multiset.lean
+++ b/src/algebra/big_operators/multiset.lean
@@ -339,7 +339,8 @@ lemma prod_eq_one_iff [canonically_ordered_monoid α] {m : multiset α} :
 quotient.induction_on m $ λ l, by simpa using list.prod_eq_one_iff l
 
 /-- Slightly more general version of `multiset.prod_eq_one_iff` for a non-ordered `monoid` -/
-@[to_additive "Slightly more general version of `multiset.sum_eq_zero_iff` for a non-ordered `add_monoid`"]
+@[to_additive "Slightly more general version of `multiset.sum_eq_zero_iff`
+  for a non-ordered `add_monoid`"]
 lemma prod_eq_one [comm_monoid α] {m : multiset α} (h : ∀ x ∈ m, x = (1 : α)) : m.prod = 1 :=
 begin
   induction m using quotient.induction_on with l,

--- a/src/algebra/big_operators/multiset.lean
+++ b/src/algebra/big_operators/multiset.lean
@@ -79,17 +79,16 @@ lemma prod_nsmul (m : multiset α) : ∀ (n : ℕ), (n • m).prod = m.prod ^ n
 by simp [repeat, list.prod_repeat]
 
 @[to_additive]
-lemma prod_map_eq_pow_single {M : Type*} [comm_monoid M] [decidable_eq α]
-  (a : α) (f : α → M) (hf : ∀ a' ≠ a, a' ∈ s → f a' = 1) :
-  (s.map f).prod = (f a) ^ (s.count a) :=
+lemma prod_map_eq_pow_single [decidable_eq ι] (i : ι) (hf : ∀ i' ≠ i, i' ∈ m → f i' = 1) :
+  (m.map f).prod = (f i) ^ (m.count i) :=
 begin
-  induction s using quotient.induction_on with l,
-  simp [list.prod_map_eq_pow_single a f hf],
+  induction m using quotient.induction_on with l,
+  simp [list.prod_map_eq_pow_single i f hf],
 end
 
 @[to_additive]
-lemma prod_eq_pow_single [decidable_eq α] [comm_monoid α]
-  (a : α) (h : ∀ a' ≠ a, a' ∈ s → a' = 1) : s.prod = a ^ (s.count a) :=
+lemma prod_eq_pow_single [decidable_eq α] (a : α) (h : ∀ a' ≠ a, a' ∈ s → a' = 1) :
+  s.prod = a ^ (s.count a) :=
 begin
   induction s using quotient.induction_on with l,
   simp [list.prod_eq_pow_single a h],
@@ -340,7 +339,7 @@ lemma prod_eq_one_iff [canonically_ordered_monoid α] {m : multiset α} :
 quotient.induction_on m $ λ l, by simpa using list.prod_eq_one_iff l
 
 /-- Slightly more general version of `prod_eq_one_iff` for a non-ordered `monoid` -/
-@[to_additive]
+@[to_additive "Slightly more general version of `sum_eq_zero_iff` for a non-ordered `monoid`"]
 lemma prod_eq_one [comm_monoid α] {m : multiset α} (h : ∀ x ∈ m, x = (1 : α)) : m.prod = 1 :=
 begin
   induction m using quotient.induction_on with l,

--- a/src/algebra/big_operators/multiset.lean
+++ b/src/algebra/big_operators/multiset.lean
@@ -79,7 +79,7 @@ lemma prod_nsmul (m : multiset α) : ∀ (n : ℕ), (n • m).prod = m.prod ^ n
 by simp [repeat, list.prod_repeat]
 
 @[to_additive]
-lemma prod_multiset_map_eq_pow_single {M : Type*} [comm_monoid M] [decidable_eq α]
+lemma prod_map_eq_pow_single {M : Type*} [comm_monoid M] [decidable_eq α]
   (a : α) (f : α → M) (hf : ∀ a' ≠ a, a' ∈ s → f a' = 1) :
   (s.map f).prod = (f a) ^ (s.count a) :=
 begin
@@ -88,7 +88,7 @@ begin
 end
 
 @[to_additive]
-lemma prod_multiset_eq_pow_single [decidable_eq α] [comm_monoid α]
+lemma prod_eq_pow_single [decidable_eq α] [comm_monoid α]
   (a : α) (h : ∀ a' ≠ a, a' ∈ s → a' = 1) : s.prod = a ^ (s.count a) :=
 begin
   induction s using quotient.induction_on with l,

--- a/src/algebra/big_operators/multiset.lean
+++ b/src/algebra/big_operators/multiset.lean
@@ -79,6 +79,23 @@ lemma prod_nsmul (m : multiset α) : ∀ (n : ℕ), (n • m).prod = m.prod ^ n
 by simp [repeat, list.prod_repeat]
 
 @[to_additive]
+lemma prod_multiset_map_eq_pow_single {M : Type*} [comm_monoid M] [decidable_eq α]
+  (a : α) (f : α → M) (hf : ∀ a' ≠ a, a' ∈ s → f a' = 1) :
+  (s.map f).prod = (f a) ^ (s.count a) :=
+begin
+  induction s using quotient.induction_on with l,
+  simp [list.prod_map_eq_pow_single a f hf],
+end
+
+@[to_additive]
+lemma prod_multiset_eq_pow_single [decidable_eq α] [comm_monoid α]
+  (a : α) (h : ∀ a' ≠ a, a' ∈ s → a' = 1) : s.prod = a ^ (s.count a) :=
+begin
+  induction s using quotient.induction_on with l,
+  simp [list.prod_eq_pow_single a h],
+end
+
+@[to_additive]
 lemma pow_count [decidable_eq α] (a : α) : a ^ s.count a = (s.filter (eq a)).prod :=
 by rw [filter_eq, prod_repeat]
 
@@ -321,6 +338,14 @@ end
 lemma prod_eq_one_iff [canonically_ordered_monoid α] {m : multiset α} :
   m.prod = 1 ↔ ∀ x ∈ m, x = (1 : α) :=
 quotient.induction_on m $ λ l, by simpa using list.prod_eq_one_iff l
+
+/-- Slightly more general version of `prod_eq_one_iff` for a non-ordered `monoid` -/
+@[to_additive]
+lemma prod_eq_one [comm_monoid α] {m : multiset α} (h : ∀ x ∈ m, x = (1 : α)) : m.prod = 1 :=
+begin
+  induction m using quotient.induction_on with l,
+  simp [list.prod_eq_one h],
+end
 
 @[to_additive]
 lemma le_prod_of_mem [canonically_ordered_monoid α] {m : multiset α} {a : α} (h : a ∈ m) :

--- a/src/data/list/big_operators.lean
+++ b/src/data/list/big_operators.lean
@@ -435,7 +435,7 @@ le_antisymm (hl₂ ▸ single_le_prod hl₁ _ hx) (hl₁ x hx)
   λ h, by rw [eq_repeat.2 ⟨rfl, h⟩, prod_repeat, one_pow]⟩
 
 /-- Slightly more general version of `prod_eq_one_iff` for a non-ordered `monoid` -/
-@[to_additive]
+@[to_additive "Slightly more general version of `sum_eq_zero_iff` for a non-ordered `monoid`"]
 lemma prod_eq_one [monoid M] {l : list M} (hl : ∀ (x ∈ l), x = (1 : M)) : l.prod = 1 :=
 trans (prod_eq_pow_card l 1 hl) (one_pow l.length)
 

--- a/src/data/list/big_operators.lean
+++ b/src/data/list/big_operators.lean
@@ -435,7 +435,8 @@ le_antisymm (hl₂ ▸ single_le_prod hl₁ _ hx) (hl₁ x hx)
   λ h, by rw [eq_repeat.2 ⟨rfl, h⟩, prod_repeat, one_pow]⟩
 
 /-- Slightly more general version of `list.prod_eq_one_iff` for a non-ordered `monoid` -/
-@[to_additive "Slightly more general version of `list.sum_eq_zero_iff` for a non-ordered `add_monoid`"]
+@[to_additive "Slightly more general version of `list.sum_eq_zero_iff`
+  for a non-ordered `add_monoid`"]
 lemma prod_eq_one [monoid M] {l : list M} (hl : ∀ (x ∈ l), x = (1 : M)) : l.prod = 1 :=
 trans (prod_eq_pow_card l 1 hl) (one_pow l.length)
 

--- a/src/data/list/big_operators.lean
+++ b/src/data/list/big_operators.lean
@@ -434,8 +434,8 @@ le_antisymm (hl₂ ▸ single_le_prod hl₁ _ hx) (hl₁ x hx)
 ⟨all_one_of_le_one_le_of_prod_eq_one (λ _ _, one_le _),
   λ h, by rw [eq_repeat.2 ⟨rfl, h⟩, prod_repeat, one_pow]⟩
 
-/-- Slightly more general version of `prod_eq_one_iff` for a non-ordered `monoid` -/
-@[to_additive "Slightly more general version of `sum_eq_zero_iff` for a non-ordered `monoid`"]
+/-- Slightly more general version of `list.prod_eq_one_iff` for a non-ordered `monoid` -/
+@[to_additive "Slightly more general version of `list.sum_eq_zero_iff` for a non-ordered `add_monoid`"]
 lemma prod_eq_one [monoid M] {l : list M} (hl : ∀ (x ∈ l), x = (1 : M)) : l.prod = 1 :=
 trans (prod_eq_pow_card l 1 hl) (one_pow l.length)
 

--- a/src/data/list/big_operators.lean
+++ b/src/data/list/big_operators.lean
@@ -62,11 +62,6 @@ lemma prod_eq_pow_card (l : list M) (m : M) (h : ∀ (x ∈ l), x = m) :
 by rw [← prod_repeat, ← list.eq_repeat.mpr ⟨rfl, h⟩]
 
 @[to_additive]
-lemma prod_eq_one {l : list M} (hl : ∀ (x ∈ l), x = (1 : M)) :
-  l.prod = 1 :=
-trans (prod_eq_pow_card l 1 hl) (one_pow l.length)
-
-@[to_additive]
 lemma prod_hom_rel (l : list ι) {r : M → N → Prop} {f : ι → M} {g : ι → N} (h₁ : r 1 1)
   (h₂ : ∀ ⦃i a b⦄, r a b → r (f i * a) (g i * b)) :
   r (l.map f).prod (l.map g).prod :=
@@ -438,6 +433,11 @@ le_antisymm (hl₂ ▸ single_le_prod hl₁ _ hx) (hl₁ x hx)
   l.prod = 1 ↔ ∀ x ∈ l, x = (1 : M) :=
 ⟨all_one_of_le_one_le_of_prod_eq_one (λ _ _, one_le _),
   λ h, by rw [eq_repeat.2 ⟨rfl, h⟩, prod_repeat, one_pow]⟩
+
+/-- Slightly more general version of `prod_eq_one_iff` for a non-ordered `monoid` -/
+@[to_additive]
+lemma prod_eq_one [monoid M] {l : list M} (hl : ∀ (x ∈ l), x = (1 : M)) : l.prod = 1 :=
+trans (prod_eq_pow_card l 1 hl) (one_pow l.length)
 
 /-- If all elements in a list are bounded below by `1`, then the length of the list is bounded
 by the sum of the elements. -/

--- a/src/data/list/big_operators.lean
+++ b/src/data/list/big_operators.lean
@@ -62,6 +62,11 @@ lemma prod_eq_pow_card (l : list M) (m : M) (h : ∀ (x ∈ l), x = m) :
 by rw [← prod_repeat, ← list.eq_repeat.mpr ⟨rfl, h⟩]
 
 @[to_additive]
+lemma prod_eq_one {l : list M} (hl : ∀ (x ∈ l), x = (1 : M)) :
+  l.prod = 1 :=
+trans (prod_eq_pow_card l 1 hl) (one_pow l.length)
+
+@[to_additive]
 lemma prod_hom_rel (l : list ι) {r : M → N → Prop} {f : ι → M} {g : ι → N} (h₁ : r 1 1)
   (h₂ : ∀ ⦃i a b⦄, r a b → r (f i * a) (g i * b)) :
   r (l.map f).prod (l.map g).prod :=

--- a/src/data/list/count.lean
+++ b/src/data/list/count.lean
@@ -208,7 +208,7 @@ begin
 end
 
 @[to_additive]
-lemma prod_map_eq_pow_single [decidable_eq α] [monoid β] {l : list α} (a : α) (f : α → β)
+lemma prod_map_eq_pow_single [monoid β] {l : list α} (a : α) (f : α → β)
   (hf : ∀ a' ≠ a, a' ∈ l → f a' = 1) : (l.map f).prod = (f a) ^ (l.count a) :=
 begin
   induction l with a' as h generalizing a,
@@ -221,7 +221,7 @@ begin
 end
 
 @[to_additive]
-lemma prod_eq_pow_single [decidable_eq α] [monoid α] {l : list α} (a : α)
+lemma prod_eq_pow_single [monoid α] {l : list α} (a : α)
   (h : ∀ a' ≠ a, a' ∈ l → a' = 1) : l.prod = a ^ (l.count a) :=
 trans (by rw [map_id'']) (prod_map_eq_pow_single a id h)
 

--- a/src/data/list/count.lean
+++ b/src/data/list/count.lean
@@ -208,18 +208,22 @@ begin
 end
 
 @[to_additive]
-lemma prod_map_eq_pow_single [monoid β] {l : list α} (a : α)
-  (f : α → β) (hf : ∀ a' ≠ a, a' ∈ l → f a' = 1) :
-  (l.map f).prod = (f a) ^ (l.count a) :=
+lemma prod_map_eq_pow_single [decidable_eq α] [monoid β] {l : list α} (a : α) (f : α → β)
+  (hf : ∀ a' ≠ a, a' ∈ l → f a' = 1) : (l.map f).prod = (f a) ^ (l.count a) :=
 begin
   induction l with a' as h generalizing a,
   { rw [map_nil, prod_nil, count_nil, pow_zero] },
   { specialize h a (λ a' ha' hfa', hf a' ha' (mem_cons_of_mem _ hfa')),
-    rw [map_cons, prod_cons, count_cons, h],
+    rw [list.map_cons, list.prod_cons, count_cons, h],
     split_ifs with ha',
     { rw [ha', pow_succ] },
-    { rw [hf a' (ne.symm ha') (mem_cons_self a' as), one_mul] } }
+    { rw [hf a' (ne.symm ha') (list.mem_cons_self a' as), one_mul] } }
 end
+
+@[to_additive]
+lemma prod_eq_pow_single [decidable_eq α] [monoid α] {l : list α} (a : α)
+  (h : ∀ a' ≠ a, a' ∈ l → a' = 1) : l.prod = a ^ (l.count a) :=
+trans (by rw [map_id'']) (prod_map_eq_pow_single a id h)
 
 end count
 

--- a/src/data/list/count.lean
+++ b/src/data/list/count.lean
@@ -208,7 +208,7 @@ begin
 end
 
 @[to_additive]
-lemma prod_map_eq_pow_single [decidable_eq α] [monoid β] {l : list α} (a : α)
+lemma prod_map_eq_pow_single [monoid β] {l : list α} (a : α)
   (f : α → β) (hf : ∀ a' ≠ a, a' ∈ l → f a' = 1) :
   (l.map f).prod = (f a) ^ (l.count a) :=
 begin

--- a/src/data/list/count.lean
+++ b/src/data/list/count.lean
@@ -207,6 +207,20 @@ begin
   { rw [count_cons', count_cons', count_erase_of_ne] }
 end
 
+@[to_additive]
+lemma prod_map_eq_pow_single [decidable_eq α] [monoid β] {l : list α} (a : α)
+  (f : α → β) (hf : ∀ a' ≠ a, a' ∈ l → f a' = 1) :
+  (l.map f).prod = (f a) ^ (l.count a) :=
+begin
+  induction l with a' as h generalizing a,
+  { rw [map_nil, prod_nil, count_nil, pow_zero] },
+  { specialize h a (λ a' ha' hfa', hf a' ha' (mem_cons_of_mem _ hfa')),
+    rw [map_cons, prod_cons, count_cons, h],
+    split_ifs with ha',
+    { rw [ha', pow_succ] },
+    { rw [hf a' (ne.symm ha') (mem_cons_self a' as), one_mul] } }
+end
+
 end count
 
 end list

--- a/src/data/list/dedup.lean
+++ b/src/data/list/dedup.lean
@@ -77,7 +77,7 @@ lemma repeat_dedup {x : α} : ∀ {k}, k ≠ 0 → (repeat x k).dedup = [x]
 | (n+2) _ := by rw [repeat_succ, dedup_cons_of_mem (mem_repeat.2 ⟨n.succ_ne_zero, rfl⟩),
     repeat_dedup n.succ_ne_zero]
 
-lemma count_dedup [decidable_eq α] (l : list α) (a : α) :
+lemma count_dedup (l : list α) (a : α) :
   l.dedup.count a = if a ∈ l then 1 else 0 :=
 begin
   refine trans (count_eq_of_nodup $ nodup_dedup l) _,
@@ -85,7 +85,7 @@ begin
 end
 
 /-- Summing the count of `x` over a list filtered by some `p` is just `countp` applied to `p` -/
-lemma sum_map_count_dedup_filter_eq_countp [decidable_eq α] (p : α → Prop) [decidable_pred p]
+lemma sum_map_count_dedup_filter_eq_countp (p : α → Prop) [decidable_pred p]
   (l : list α) : ((l.dedup.filter p).map $ λ x, l.count x).sum = l.countp p :=
 begin
   induction l with a as h,
@@ -107,7 +107,7 @@ begin
         exact ha'.2.symm } } },
 end
 
-lemma sum_map_count_dedup_eq_length [decidable_eq α] (l : list α) :
+lemma sum_map_count_dedup_eq_length (l : list α) :
   (l.dedup.map $ λ x, l.count x).sum = l.length :=
 calc (l.dedup.map $ λ x, l.count x).sum
   = ((l.dedup.filter $ λ x, true).map (λ x, l.count x)).sum :

--- a/src/data/list/dedup.lean
+++ b/src/data/list/dedup.lean
@@ -77,4 +77,34 @@ lemma repeat_dedup {x : α} : ∀ {k}, k ≠ 0 → (repeat x k).dedup = [x]
 | (n+2) _ := by rw [repeat_succ, dedup_cons_of_mem (mem_repeat.2 ⟨n.succ_ne_zero, rfl⟩),
     repeat_dedup n.succ_ne_zero]
 
+lemma count_dedup [decidable_eq α] (l : list α) (a : α) :
+  l.dedup.count a = if a ∈ l then 1 else 0 :=
+begin
+  refine trans (count_eq_of_nodup $ nodup_dedup l) _,
+  simp_rw [mem_dedup],
+end
+
+/-- Summing the count of `x` over a list filtered by some `p` is just `countp` applied to `p` -/
+lemma sum_map_count_dedup_filter_eq_countp [decidable_eq α] (p : α → Prop) [decidable_pred p]
+  (l : list α) : ((l.dedup.filter p).map (λ x, l.count x)).sum = l.countp p :=
+begin
+  induction l with a as h,
+  { simp },
+  { simp_rw [list.countp_cons, list.count_cons', list.sum_map_add],
+    congr' 1,
+    { refine trans _ h,
+      by_cases ha : a ∈ as,
+      { simp [dedup_cons_of_mem ha] },
+      { simp only [dedup_cons_of_not_mem ha, list.filter],
+        split_ifs with hp; simp [list.map_cons, list.sum_cons,
+          list.count_eq_zero.2 ha, zero_add] } },
+    { by_cases hp : p a,
+      { refine trans (sum_map_eq_nsmul_single a _ (λ _ h _, by simp [h])) _,
+        simp [hp, count_dedup] },
+      { refine trans (list.sum_eq_zero $ λ n hn, _) (by simp [hp]),
+        obtain ⟨a', ha'⟩ := list.mem_map.1 hn,
+        simp only [(λ h, hp (h ▸ (list.mem_filter.1 ha'.1).2) : a' ≠ a), if_false] at ha',
+        exact ha'.2.symm } } },
+end
+
 end list

--- a/src/data/list/dedup.lean
+++ b/src/data/list/dedup.lean
@@ -86,7 +86,7 @@ end
 
 /-- Summing the count of `x` over a list filtered by some `p` is just `countp` applied to `p` -/
 lemma sum_map_count_dedup_filter_eq_countp [decidable_eq α] (p : α → Prop) [decidable_pred p]
-  (l : list α) : ((l.dedup.filter p).map (λ x, l.count x)).sum = l.countp p :=
+  (l : list α) : ((l.dedup.filter p).map $ λ x, l.count x).sum = l.countp p :=
 begin
   induction l with a as h,
   { simp },
@@ -106,5 +106,13 @@ begin
         simp only [(λ h, hp (h ▸ (list.mem_filter.1 ha'.1).2) : a' ≠ a), if_false] at ha',
         exact ha'.2.symm } } },
 end
+
+lemma sum_map_count_dedup_eq_length [decidable_eq α] (l : list α) :
+  (l.dedup.map $ λ x, l.count x).sum = l.length :=
+calc (l.dedup.map $ λ x, l.count x).sum
+  = ((l.dedup.filter $ λ x, true).map (λ x, l.count x)).sum :
+    by { congr, exact symm (filter_true _) }
+  ... = l.countp (λ x, true) : sum_map_count_dedup_filter_eq_countp _ l
+  ... = l.length : (countp_eq_length _).2 (by simp)
 
 end list

--- a/src/data/list/dedup.lean
+++ b/src/data/list/dedup.lean
@@ -79,10 +79,7 @@ lemma repeat_dedup {x : α} : ∀ {k}, k ≠ 0 → (repeat x k).dedup = [x]
 
 lemma count_dedup (l : list α) (a : α) :
   l.dedup.count a = if a ∈ l then 1 else 0 :=
-begin
-  refine trans (count_eq_of_nodup $ nodup_dedup l) _,
-  simp_rw [mem_dedup],
-end
+by simp_rw [count_eq_of_nodup $ nodup_dedup l, mem_dedup]
 
 /-- Summing the count of `x` over a list filtered by some `p` is just `countp` applied to `p` -/
 lemma sum_map_count_dedup_filter_eq_countp (p : α → Prop) [decidable_pred p]
@@ -109,10 +106,6 @@ end
 
 lemma sum_map_count_dedup_eq_length (l : list α) :
   (l.dedup.map $ λ x, l.count x).sum = l.length :=
-calc (l.dedup.map $ λ x, l.count x).sum
-  = ((l.dedup.filter $ λ x, true).map (λ x, l.count x)).sum :
-    by { congr, exact symm (filter_true _) }
-  ... = l.countp (λ x, true) : sum_map_count_dedup_filter_eq_countp _ l
-  ... = l.length : (countp_eq_length _).2 (by simp)
+by simpa using sum_map_count_dedup_filter_eq_countp (λ _, true) l
 
 end list

--- a/src/data/list/nodup.lean
+++ b/src/data/list/nodup.lean
@@ -135,6 +135,14 @@ theorem nodup_repeat (a : α) : ∀ {n : ℕ}, nodup (repeat a n) ↔ n ≤ 1
   (d : nodup l) (h : a ∈ l) : count a l = 1 :=
 le_antisymm (nodup_iff_count_le_one.1 d a) (count_pos.2 h)
 
+lemma count_eq_of_nodup [decidable_eq α] {a : α} {l : list α}
+  (d : nodup l) : count a l = if a ∈ l then 1 else 0 :=
+begin
+  split_ifs with h,
+  { exact count_eq_one_of_mem d h },
+  { exact count_eq_zero_of_not_mem h },
+end
+
 lemma nodup.of_append_left : nodup (l₁ ++ l₂) → nodup l₁ :=
 nodup.sublist (sublist_append_left l₁ l₂)
 

--- a/src/data/multiset/nodup.lean
+++ b/src/data/multiset/nodup.lean
@@ -60,6 +60,14 @@ quot.induction_on s $ λ l, nodup_iff_count_le_one
   (d : nodup s) (h : a ∈ s) : count a s = 1 :=
 le_antisymm (nodup_iff_count_le_one.1 d a) (count_pos.2 h)
 
+lemma count_eq_of_nodup [decidable_eq α] {a : α} {s : multiset α}
+  (d : nodup s) : count a s = if a ∈ s then 1 else 0 :=
+begin
+  split_ifs with h,
+  { exact count_eq_one_of_mem d h },
+  { exact count_eq_zero_of_not_mem h },
+end
+
 lemma nodup_iff_pairwise {α} {s : multiset α} : nodup s ↔ pairwise (≠) s :=
 quotient.induction_on s $ λ l, (pairwise_coe_iff_pairwise (by exact λ a b, ne.symm)).symm
 


### PR DESCRIPTION
The sum of `l.count x` over `x` in `l.to_finset.filter p` is equal to `l.countp p`.
Also includes `prod_eq_one` instances for `list` and `multiset`

---
The proof is still pretty long, but I haven't found a way to golf it any more with all the case bashing involved

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
