### PR TITLE
[Merged by Bors] - fix(tactic/solve_by_elim): apply_assumption argument parsing

### DIFF
--- a/src/tactic/solve_by_elim.lean
+++ b/src/tactic/solve_by_elim.lean
@@ -273,13 +273,13 @@ Optional arguments:
   the next one will be attempted.
 -/
 meta def apply_assumption
-  (lemmas : option (list expr) := none)
+  (lemmas : parse pexpr_list?)
   (opt : apply_any_opt := {})
   (tac : tactic unit := skip) : tactic unit :=
 do
   lemmas ← match lemmas with
   | none := local_context
-  | some lemmas := return lemmas
+  | some lemmas := lemmas.mmap to_expr
   end,
   tactic.apply_any lemmas opt tac
 

--- a/test/solve_by_elim.lean
+++ b/test/solve_by_elim.lean
@@ -171,3 +171,7 @@ begin
   rintro ⟨n, hf | hg⟩,
   solve_by_elim* [or.inl, or.inr, Exists.intro] { max_depth := 20 },
 end
+
+-- Check that no list of arguments is needed when using a config object
+example (a : ℤ) (h : a = 2) : a = 2 :=
+by apply_assumption {use_exfalso := ff}


### PR DESCRIPTION
The optional list of expressions to `apply_assumption` should be parsed interactively. This fixes a bug where `none` would have to be provided before a config object.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
