### PR TITLE
feat(data/finsupp/basic): finitely supported function from list of input/output pairs

### DIFF
--- a/src/data/finsupp/basic.lean
+++ b/src/data/finsupp/basic.lean
@@ -841,8 +841,12 @@ begin
     { simp } }
 end
 
+/-- `of_list_pairs` is a left inverse of `to_list ∘ graph`. -/
+lemma left_inverse_of_list_pairs_graph : left_inverse of_list_pairs (to_list ∘ (@graph α M _)) :=
+of_list_pairs_graph
+
 lemma of_list_pairs_surjective : surjective (@of_list_pairs α M _) :=
-λ f, ⟨_, of_list_pairs_graph f⟩
+left_inverse_of_list_pairs_graph.surjective
 
 end of_list_pairs
 

--- a/src/data/finsupp/basic.lean
+++ b/src/data/finsupp/basic.lean
@@ -819,10 +819,10 @@ begin
   induction l with c l IH,
   { exact (list.not_mem_nil _ h).elim },
   { cases c with a' m',
-    simp only [function.update, of_list_pairs_cons, coe_update, eq_rec_constant, dite_eq_ite],
+    simp only [function.update, of_list_pairs_cons, coe_update],
     cases h,
     { rcases prod.mk.inj h with ⟨rfl, rfl⟩,
-      exact if_pos rfl },
+      exact dif_pos rfl },
     { split_ifs with ha ha,
       { subst ha,
         exact H _ (l.mem_cons_self _) },
@@ -833,16 +833,13 @@ end
 begin
   ext,
   by_cases h : f a = 0,
-  { rw h,
-    apply of_list_pairs_apply_zero_of_not_mem,
-    simpa using h },
-  { apply of_list_pairs_apply_eq_of_nodup,
-    { simpa using h },
-    { simp } }
+  { simp [of_list_pairs_apply_zero_of_not_mem, h] },
+  { apply of_list_pairs_apply_eq_of_nodup;
+    simp [h] }
 end
 
 /-- `of_list_pairs` is a left inverse of `to_list ∘ graph`. -/
-lemma left_inverse_of_list_pairs_graph : left_inverse of_list_pairs (to_list ∘ (@graph α M _)) :=
+lemma left_inverse_of_list_pairs_graph : left_inverse of_list_pairs (to_list ∘ @graph α M _) :=
 of_list_pairs_graph
 
 lemma of_list_pairs_surjective : surjective (@of_list_pairs α M _) :=

--- a/src/data/finsupp/basic.lean
+++ b/src/data/finsupp/basic.lean
@@ -821,13 +821,12 @@ begin
   { cases c with a' m',
     simp only [function.update, of_list_pairs_cons, coe_update, eq_rec_constant, dite_eq_ite],
     cases h,
-    { rw prod.mk.inj_iff at h,
-      simpa [h.1] using h.2.symm },
-    { rcases eq_or_ne a a' with rfl | ha,
-      { rw [eq_self_iff_true, if_true],
+    { rcases prod.mk.inj h with ⟨rfl, rfl⟩,
+      exact if_pos rfl },
+    { split_ifs with ha ha,
+      { subst ha,
         exact H _ (l.mem_cons_self _) },
-      { simp only [ha, if_false],
-        exact IH h (λ m'' hm, H _ (list.mem_cons_of_mem _ hm)) } } }
+      { exact (IH h (λ m'' hm, H _ (list.mem_cons_of_mem _ hm))) } } }
 end
 
 @[simp] lemma of_list_pairs_graph (f : α →₀ M) : of_list_pairs f.graph.to_list = f :=


### PR DESCRIPTION
We define `finsupp.of_list_pairs`, which builds a finitely supported function from the list of input and output pairs. Only the first output is considered in case of a repeated input.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
- [x] depends on: #15434

The planned use case for this new definition is to facilitate giving the [Cantor Normal Form](https://leanprover-community.github.io/mathlib_docs/set_theory/ordinal/cantor_normal_form.html#ordinal.CNF) of an ordinal as a finitely supported function.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
