### PR TITLE
[Merged by Bors] - chore(order/basic): remove two lemmas breaking API boundaries

### DIFF
--- a/src/algebra/order/monoid.lean
+++ b/src/algebra/order/monoid.lean
@@ -789,7 +789,7 @@ instance [ordered_comm_monoid α] : ordered_comm_monoid αᵒᵈ :=
 @[to_additive ordered_cancel_add_comm_monoid.to_contravariant_class]
 instance ordered_cancel_comm_monoid.to_contravariant_class [ordered_cancel_comm_monoid α] :
   contravariant_class αᵒᵈ αᵒᵈ has_mul.mul has_le.le :=
-{ elim := λ a b c bc, (ordered_cancel_comm_monoid.le_of_mul_le_mul_left a c b (dual_le.mp bc)) }
+{ elim := λ a b c, ordered_cancel_comm_monoid.le_of_mul_le_mul_left a c b }
 
 @[to_additive]
 instance [ordered_cancel_comm_monoid α] : ordered_cancel_comm_monoid αᵒᵈ :=

--- a/src/analysis/normed_space/lattice_ordered_group.lean
+++ b/src/analysis/normed_space/lattice_ordered_group.lean
@@ -85,18 +85,8 @@ normed lattice ordered group.
 -/
 @[priority 100] -- see Note [lower instance priority]
 instance : normed_lattice_add_comm_group αᵒᵈ :=
-{ add_le_add_left := begin
-    intros a b h₁ c,
-    rw ← order_dual.dual_le,
-    rw ← order_dual.dual_le at h₁,
-    exact add_le_add_left h₁ _,
-  end,
-  solid := begin
-    intros a b h₂,
-    apply dual_solid,
-    rw ← order_dual.dual_le at h₂,
-    exact h₂,
-  end, }
+{ add_le_add_left := λ a b, add_le_add_left,
+  solid := dual_solid }
 
 lemma norm_abs_eq_norm (a : α) : ∥|a|∥ = ∥a∥ :=
 (solid (abs_abs a).le).antisymm (solid (abs_abs a).symm.le)

--- a/src/field_theory/galois.lean
+++ b/src/field_theory/galois.lean
@@ -257,7 +257,7 @@ def intermediate_field_equiv_subgroup [finite_dimensional F E] [is_galois F E] :
   left_inv := λ K, fixed_field_fixing_subgroup K,
   right_inv := λ H, intermediate_field.fixing_subgroup_fixed_field H,
   map_rel_iff' := λ K L, by { rw [←fixed_field_fixing_subgroup L, intermediate_field.le_iff_le,
-                                  fixed_field_fixing_subgroup L, ←order_dual.dual_le], refl } }
+                                  fixed_field_fixing_subgroup L], refl } }
 
 /-- The Galois correspondence as a galois_insertion -/
 def galois_insertion_intermediate_field_subgroup [finite_dimensional F E] :

--- a/src/order/basic.lean
+++ b/src/order/basic.lean
@@ -410,15 +410,6 @@ instance (α : Type*) [has_le α] : has_le αᵒᵈ := ⟨λ x y : α, y ≤ x�
 instance (α : Type*) [has_lt α] : has_lt αᵒᵈ := ⟨λ x y : α, y < x⟩
 instance (α : Type*) [has_zero α] : has_zero αᵒᵈ := ⟨(0 : α)⟩
 
--- `dual_le` and `dual_lt` should not be simp lemmas:
--- they cause a loop since `α` and `αᵒᵈ` are definitionally equal
-
-lemma dual_le [has_le α] {a b : α} :
-  @has_le.le αᵒᵈ _ a b ↔ @has_le.le α _ b a := iff.rfl
-
-lemma dual_lt [has_lt α] {a b : α} :
-  @has_lt.lt αᵒᵈ _ a b ↔ @has_lt.lt α _ b a := iff.rfl
-
 instance (α : Type*) [preorder α] : preorder αᵒᵈ :=
 { le_refl          := le_refl,
   le_trans         := λ a b c hab hbc, hbc.trans hab,

--- a/src/order/modular_lattice.lean
+++ b/src/order/modular_lattice.lean
@@ -171,7 +171,7 @@ by rw [inf_comm, sup_comm, ← sup_inf_assoc_of_le y h, inf_comm, sup_comm]
 
 instance : is_modular_lattice αᵒᵈ :=
 ⟨λ x y z xz, le_of_eq (by { rw [inf_comm, sup_comm, eq_comm, inf_comm, sup_comm],
-  convert sup_inf_assoc_of_le (order_dual.of_dual y) (order_dual.dual_le.2 xz) })⟩
+  exact @sup_inf_assoc_of_le α _ _ _ y _ xz })⟩
 
 variables {x y z : α}
 


### PR DESCRIPTION
`order.dual_le` and `order.dual_lt` don't conform to API boundaries, as they abuse the def-eq between `αᵒᵈ` and `α` instead of using `to_dual` or `of_dual` to perform the cast. As such, we remove them.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
