### PR TITLE
[Merged by Bors] - doc(set_theory/game/nim): update module docs

### DIFF
--- a/src/set_theory/game/nim.lean
+++ b/src/set_theory/game/nim.lean
@@ -25,7 +25,7 @@ However, this definition does not work for us because it would make the type of 
 theorem, since that requires the type of `nim` to be `ordinal.{u} → pgame.{u}`. For this reason, we
 instead use `o.out.α` for the possible moves. You can use `to_left_moves_nim` and
 `to_right_moves_nim` to convert an ordinal less than `o` into a left or right move of `nim o`, and
-viceversa.
+vice versa.
 -/
 
 universes u

--- a/src/set_theory/game/nim.lean
+++ b/src/set_theory/game/nim.lean
@@ -19,18 +19,15 @@ where `n` and `m` are natural numbers, then `G + H` has the Grundy value `n xor 
 
 ## Implementation details
 
-The pen-and-paper definition of nim defines the possible moves of `nim o` to be `{o' | o' < o}`.
+The pen-and-paper definition of nim defines the possible moves of `nim o` to be `set.Iio o`.
 However, this definition does not work for us because it would make the type of nim
 `ordinal.{u} → pgame.{u + 1}`, which would make it impossible for us to state the Sprague-Grundy
 theorem, since that requires the type of `nim` to be `ordinal.{u} → pgame.{u}`. For this reason, we
-instead use `o.out.α` for the possible moves, which makes proofs significantly more messy and
-tedious, but avoids the universe bump.
-
-The lemma `nim_def` is somewhat prone to produce "motive is not type correct" errors. If you run
-into this problem, you may find the lemmas `exists_ordinal_move_left_eq` and `exists_move_left_eq`
-useful.
-
+instead use `o.out.α` for the possible moves. You can use `to_left_moves_nim` and
+`to_right_moves_nim` to convert an ordinal less than `o` into a left or right move of `nim o`, and
+viceversa.
 -/
+
 universes u
 
 /-- `ordinal.out'` has the sole purpose of making `nim` computable. It performs the same job as


### PR DESCRIPTION
We update the module docs to reflect that you should use `to_left_moves_nim` and `to_right_moves_nim` to interface with the nim API, instead of using the raw definition (which has the problems the old docs mentioned).

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
`exists_ordinal_move_left_eq` and `exists_move_left_eq` will be removed in a future PR - they're obsoleted by the equivalence `to_left_moves_nim`.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
