### PR TITLE
refactor(data/set_like/basic): make `set_like.partial_order` into a `def`

### DIFF
--- a/src/data/set/pointwise.lean
+++ b/src/data/set/pointwise.lean
@@ -1354,8 +1354,6 @@ begin
   exact s.mul_mem ha hb
 end
 
-lemma le_def {S T : set M} : closure S ≤ closure T ↔ ∀ ⦃x : M⦄, x ∈ closure S → x ∈ closure T := iff.rfl
-
 @[to_additive]
 lemma closure_mul_le (S T : set M) : closure (S * T) ≤ closure S ⊔ closure T :=
 Inf_le $ λ x ⟨s, t, hs, ht, hx⟩, hx ▸ (closure S ⊔ closure T).mul_mem

--- a/src/data/set/pointwise.lean
+++ b/src/data/set/pointwise.lean
@@ -1354,11 +1354,13 @@ begin
   exact s.mul_mem ha hb
 end
 
+lemma le_def {S T : set M} : closure S ≤ closure T ↔ ∀ ⦃x : M⦄, x ∈ closure S → x ∈ closure T := iff.rfl
+
 @[to_additive]
 lemma closure_mul_le (S T : set M) : closure (S * T) ≤ closure S ⊔ closure T :=
 Inf_le $ λ x ⟨s, t, hs, ht, hx⟩, hx ▸ (closure S ⊔ closure T).mul_mem
-    (set_like.le_def.mp le_sup_left $ subset_closure hs)
-    (set_like.le_def.mp le_sup_right $ subset_closure ht)
+  (let H : closure S ≤ closure S ⊔ closure T := le_sup_left in H $ subset_closure hs)
+  (let H : closure T ≤ closure S ⊔ closure T := le_sup_right in H $ subset_closure ht)
 
 @[to_additive]
 lemma sup_eq_closure (H K : submonoid M) : H ⊔ K = closure (H * K) :=

--- a/src/data/set_like/basic.lean
+++ b/src/data/set_like/basic.lean
@@ -135,29 +135,8 @@ theorem ext_iff : p = q ↔ (∀ x, x ∈ p ↔ x ∈ q) := coe_injective.eq_iff
 
 @[simp] protected lemma eta (x : p) (hx : (x : B) ∈ p) : (⟨x, hx⟩ : p) = x := subtype.eta x hx
 
--- `dangerous_instance` does not know that `B` is used only as an `out_param`
-@[nolint dangerous_instance, priority 100]
-instance : partial_order A :=
+protected def partial_order : partial_order A :=
 { le := λ H K, ∀ ⦃x⦄, x ∈ H → x ∈ K,
   .. partial_order.lift (coe : A → set B) coe_injective }
-
-lemma le_def {S T : A} : S ≤ T ↔ ∀ ⦃x : B⦄, x ∈ S → x ∈ T := iff.rfl
-
-@[simp, norm_cast]
-lemma coe_subset_coe {S T : A} : (S : set B) ⊆ T ↔ S ≤ T := iff.rfl
-
-@[mono] lemma coe_mono : monotone (coe : A → set B) := λ a b, coe_subset_coe.mpr
-
-@[simp, norm_cast]
-lemma coe_ssubset_coe {S T : A} : (S : set B) ⊂ T ↔ S < T := iff.rfl
-
-@[mono] lemma coe_strict_mono : strict_mono (coe : A → set B) := λ a b, coe_ssubset_coe.mpr
-
-lemma not_le_iff_exists : ¬(p ≤ q) ↔ ∃ x ∈ p, x ∉ q := set.not_subset
-
-lemma exists_of_lt : p < q → ∃ x ∈ q, x ∉ p := set.exists_of_ssubset
-
-lemma lt_iff_le_and_exists : p < q ↔ p ≤ q ∧ ∃ x ∈ q, x ∉ p :=
-by rw [lt_iff_le_not_le, not_le_iff_exists]
 
 end set_like

--- a/src/group_theory/submonoid/basic.lean
+++ b/src/group_theory/submonoid/basic.lean
@@ -132,6 +132,9 @@ instance : set_like (submonoid M) M :=
   coe_injective' := λ p q h, by cases p; cases q; congr' }
 
 @[to_additive]
+instance : partial_order (submonoid M) := set_like.partial_order
+
+@[to_additive]
 instance : submonoid_class (submonoid M) M :=
 { one_mem := submonoid.one_mem',
   mul_mem := submonoid.mul_mem' }
@@ -264,7 +267,7 @@ instance : complete_lattice (submonoid M) :=
   inf_le_right := λ a b x, and.right,
   .. complete_lattice_of_Inf (submonoid M) $ λ s,
     is_glb.of_image (λ S T,
-      show (S : set M) ≤ T ↔ S ≤ T, from set_like.coe_subset_coe) is_glb_binfi }
+      show (S : set M) ≤ T ↔ S ≤ T, from iff.rfl) is_glb_binfi }
 
 @[simp, to_additive]
 lemma subsingleton_iff : subsingleton (submonoid M) ↔ subsingleton M :=

--- a/src/group_theory/subsemigroup/basic.lean
+++ b/src/group_theory/subsemigroup/basic.lean
@@ -85,6 +85,9 @@ instance : set_like (subsemigroup M) M :=
 ⟨subsemigroup.carrier, λ p q h, by cases p; cases q; congr'⟩
 
 @[to_additive]
+instance : partial_order (subsemigroup M) := set_like.partial_order
+
+@[to_additive]
 instance : mul_mem_class (subsemigroup M) M :=
 { mul_mem := subsemigroup.mul_mem' }
 
@@ -208,7 +211,7 @@ instance : complete_lattice (subsemigroup M) :=
   inf_le_right := λ a b x, and.right,
   .. complete_lattice_of_Inf (subsemigroup M) $ λ s,
     is_glb.of_image (λ S T,
-      show (S : set M) ≤ T ↔ S ≤ T, from set_like.coe_subset_coe) is_glb_binfi }
+      show (S : set M) ≤ T ↔ S ≤ T, from iff.rfl) is_glb_binfi }
 
 @[simp, to_additive]
 lemma subsingleton_of_subsingleton [subsingleton (subsemigroup M)] : subsingleton M :=

--- a/src/order/closure.lean
+++ b/src/order/closure.lean
@@ -371,7 +371,7 @@ end complete_lattice
 
 /- Lemmas for `lower_adjoint (coe : α → set β)`, where `set_like α β` -/
 section coe_to_set
-variables [set_like α β] (l : lower_adjoint (coe : α → set β))
+variables [set_like α β] [preorder α] (l : lower_adjoint (coe : α → set β))
 
 lemma subset_closure (s : set β) : s ⊆ l s :=
 l.le_closure s
@@ -386,7 +386,8 @@ lemma mem_iff (s : set β) (x : β) : x ∈ l s ↔ ∀ S : α, s ⊆ S → x �
 by { simp_rw [←set_like.mem_coe, ←set.singleton_subset_iff, ←l.le_iff_subset],
   exact ⟨λ h S, h.trans, λ h, h _ le_rfl⟩ }
 
-lemma eq_of_le {s : set β} {S : α} (h₁ : s ⊆ S) (h₂ : S ≤ l s) : l s = S :=
+lemma eq_of_le {α} [set_like α β] [partial_order α] (l : lower_adjoint (coe : α → set β))
+  {s : set β} {S : α} (h₁ : s ⊆ S) (h₂ : S ≤ l s) : l s = S :=
 ((l.le_iff_subset _ _).2 h₁).antisymm h₂
 
 lemma closure_union_closure_subset (x y : α) :


### PR DESCRIPTION
This fixes the diamond in `upper_set`, where `upper_set.distrib_lattice` and `set_like.partial_order` give two opposite definitions for the order.

(I don't yet know if this approach will work smoothly, hence draft and awaiting CI).

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
