### PR TITLE
[Merged by Bors] - refactor(field_theory/*): Refactor `normal` to use `is_algebraic`

### DIFF
--- a/src/field_theory/fixed.lean
+++ b/src/field_theory/fixed.lean
@@ -227,7 +227,7 @@ minpoly.eq_of_irreducible_of_monic (minpoly.irreducible G F x)
   (minpoly.eval₂ G F x) (minpoly.monic G F x)
 
 instance normal : normal (fixed_points.subfield G F) F :=
-⟨λ x, is_integral G F x, λ x, (polynomial.splits_id_iff_splits _).1 $
+⟨λ x, (is_integral G F x).is_algebraic _, λ x, (polynomial.splits_id_iff_splits _).1 $
 by { rw [← minpoly_eq_minpoly, minpoly,
     coe_algebra_map, ← subfield.to_subring.subtype_eq_subtype,
     polynomial.map_to_subring _ (fixed_points.subfield G F).to_subring, prod_X_sub_smul],

--- a/src/field_theory/galois.lean
+++ b/src/field_theory/galois.lean
@@ -66,7 +66,7 @@ instance self : is_galois F F :=
 
 variables (F) {E}
 
-lemma integral [is_galois F E] (x : E) : is_integral F x := normal.is_integral' x
+lemma integral [is_galois F E] (x : E) : is_integral F x := to_normal.is_integral x
 
 lemma separable [is_galois F E] (x : E) : (minpoly F x).separable := is_separable.separable F x
 

--- a/src/field_theory/normal.lean
+++ b/src/field_theory/normal.lean
@@ -30,24 +30,25 @@ open polynomial is_scalar_tower
 
 variables (F K : Type*) [field F] [field K] [algebra F K]
 
---TODO(Commelin): refactor normal to extend `is_algebraic`??
-
 /-- Typeclass for normal field extension: `K` is a normal extension of `F` iff the minimal
 polynomial of every element `x` in `K` splits in `K`, i.e. every conjugate of `x` is in `K`. -/
 class normal : Prop :=
-(is_integral' (x : K) : is_integral F x)
+(is_algebraic' : algebra.is_algebraic F K)
 (splits' (x : K) : splits (algebra_map F K) (minpoly F x))
 
 variables {F K}
 
-theorem normal.is_integral (h : normal F K) (x : K) : is_integral F x := normal.is_integral' x
+theorem normal.is_algebraic (h : normal F K) (x : K) : is_algebraic F x := normal.is_algebraic' x
+
+theorem normal.is_integral (h : normal F K) (x : K) : is_integral F x :=
+is_algebraic_iff_is_integral.mp (h.is_algebraic x)
 
 theorem normal.splits (h : normal F K) (x : K) :
   splits (algebra_map F K) (minpoly F x) := normal.splits' x
 
 theorem normal_iff : normal F K ↔
   ∀ x : K, is_integral F x ∧ splits (algebra_map F K) (minpoly F x) :=
-⟨λ h x, ⟨h.is_integral x, h.splits x⟩, λ h, ⟨λ x, (h x).1, λ x, (h x).2⟩⟩
+⟨λ h x, ⟨h.is_integral x, h.splits x⟩, λ h, ⟨λ x, (h x).1.is_algebraic F, λ x, (h x).2⟩⟩
 
 theorem normal.out : normal F K →
   ∀ x : K, is_integral F x ∧ splits (algebra_map F K) (minpoly F x) := normal_iff.1
@@ -55,7 +56,7 @@ theorem normal.out : normal F K →
 variables (F K)
 
 instance normal_self : normal F F :=
-⟨λ x, is_integral_algebra_map, λ x, by { rw minpoly.eq_X_sub_C', exact splits_X_sub_C _ }⟩
+⟨λ x, is_integral_algebra_map.is_algebraic F, λ x, (minpoly.eq_X_sub_C' x).symm ▸ splits_X_sub_C _⟩
 
 variables {K}
 


### PR DESCRIPTION
This PR refactors `normal` to use `is_algebraic` rather than `is_integral`, as suggested by a TODO comment.

I think the motivation is that `is_algebraic` is the preferred language when discussing fields.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
