### PR TITLE
[Merged by Bors] - feat(field_theory/adjoin): The compositum of finitely many finite dimensional intermediate fields is finite dimensional, finset version

### DIFF
--- a/src/field_theory/adjoin.lean
+++ b/src/field_theory/adjoin.lean
@@ -851,7 +851,7 @@ begin
   rw [algebra.tensor_product.product_map_range, E1.range_val, E2.range_val, sup_to_subalgebra],
 end
 
-instance intermediate_field.finite_dimensional_supr_of_finite
+instance finite_dimensional_supr_of_finite
   {ι : Type*} {t : ι → intermediate_field K L} [h : finite ι] [Π i, finite_dimensional K (t i)] :
   finite_dimensional K (⨆ i, t i : intermediate_field K L) :=
 begin
@@ -862,10 +862,21 @@ begin
   { exact set.finite_univ },
   all_goals { dsimp only [P] },
   { rw supr_emptyset,
-    exact (intermediate_field.bot_equiv K L).symm.to_linear_equiv.finite_dimensional },
+    exact (bot_equiv K L).symm.to_linear_equiv.finite_dimensional },
   { intros _ s _ _ hs,
     rw supr_insert,
     exactI intermediate_field.finite_dimensional_sup _ _ },
+end
+
+instance finite_dimensional_supr_of_mem_finset {ι : Type*}
+  {f : ι → intermediate_field K L} {s : finset ι} [h : Π i ∈ s, finite_dimensional K (f i)] :
+  finite_dimensional K (⨆ i ∈ s, f i : intermediate_field K L) :=
+begin
+  haveI : Π i : {i // i ∈ s}, finite_dimensional K (f i) := λ i, h i i.2,
+  have : (⨆ i ∈ s, f i) = ⨆ i : {i // i ∈ s}, f i :=
+  le_antisymm (supr_le (λ i, supr_le (λ h, le_supr (λ i : {i // i ∈ s}, f i) ⟨i, h⟩)))
+    (supr_le (λ i, le_supr_of_le i (le_supr_of_le i.2 le_rfl))),
+  exact this.symm ▸ intermediate_field.finite_dimensional_supr_of_finite,
 end
 
 end supremum

--- a/src/field_theory/adjoin.lean
+++ b/src/field_theory/adjoin.lean
@@ -868,7 +868,7 @@ begin
     exactI intermediate_field.finite_dimensional_sup _ _ },
 end
 
-instance finite_dimensional_supr_of_mem_finset {ι : Type*}
+instance finite_dimensional_supr_of_finset {ι : Type*}
   {f : ι → intermediate_field K L} {s : finset ι} [h : Π i ∈ s, finite_dimensional K (f i)] :
   finite_dimensional K (⨆ i ∈ s, f i : intermediate_field K L) :=
 begin


### PR DESCRIPTION
This PR adds a finset version of `finite_dimensional_supr_of_finite`, since `⨆ i ∈ s` seems to be the best way to talk about finite compositums in practice.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
