### PR TITLE
[Merged by Bors] - feat(data/list/of_fn): lemmas to turn quantifiers over lists to quantifiers over tuples

### DIFF
--- a/src/data/fin/tuple/basic.lean
+++ b/src/data/fin/tuple/basic.lean
@@ -690,4 +690,15 @@ mem_find_iff.2 ⟨hi, λ j hj, le_of_eq $ h i j hi hj⟩
 
 end find
 
+/-- To show two sigma pairs of tuples agree, it to show the second elements are related via
+`fin.cast`. -/
+lemma sigma_eq_of_eq_comp_cast {α : Type*} :
+  ∀ {a b : Σ ii, fin ii → α} (h : a.fst = b.fst), a.snd = b.snd ∘ fin.cast h → a = b
+| ⟨ai, a⟩ ⟨bi, b⟩ hi h :=
+begin
+  dsimp only at hi,
+  subst hi,
+  simpa using h,
+end
+
 end fin

--- a/src/data/list/of_fn.lean
+++ b/src/data/list/of_fn.lean
@@ -159,7 +159,7 @@ by simp only [mem_of_fn, set.forall_range_iff]
   of_fn (λ i : fin n, c) = repeat c n :=
 nat.rec_on n (by simp) $ λ n ihn, by simp [ihn]
 
-/- Lists are equivalent to the sigma type of tuples of a given length. -/
+/-- Lists are equivalent to the sigma type of tuples of a given length. -/
 @[simps]
 def equiv_sigma_tuple : list α ≃ Σ n, fin n → α :=
 { to_fun := λ l, ⟨l.length, λ i, l.nth_le ↑i i.2⟩,

--- a/src/data/list/of_fn.lean
+++ b/src/data/list/of_fn.lean
@@ -157,4 +157,30 @@ by simp only [mem_of_fn, set.forall_range_iff]
   of_fn (λ i : fin n, c) = repeat c n :=
 nat.rec_on n (by simp) $ λ n ihn, by simp [ihn]
 
+/-- A recursor for lists that expands a list into a function mapping to its elements. -/
+def of_fn_rec (C : list α → Sort*) (h : ∀ n (f : fin n → α), C (list.of_fn f)) (l : list α) : C l :=
+l.of_fn_nth_le ▸ h l.length (λ i, l.nth_le ↑i i.2)
+
+lemma exists_iff_exists_tuple {P : list α → Prop} :
+  (∃ l : list α, P l) ↔ ∃ n (f : fin n → α), P (list.of_fn f) :=
+begin
+  split,
+  { rintros ⟨l, h⟩,
+    induction l using list.of_fn_rec,
+    exact ⟨_, _, h⟩ },
+  { rintros ⟨n, f, h⟩,
+    exact ⟨_, h⟩ },
+end
+
+lemma forall_iff_forall_tuple {P : list α → Prop} :
+  (∀ l : list α, P l) ↔ ∀ n (f : fin n → α), P (list.of_fn f) :=
+begin
+  split,
+  { intros h n f,
+    exact h _, },
+  { intros h l,
+    induction l using list.of_fn_rec,
+    exact h _ _ },
+end
+
 end list

--- a/src/data/list/of_fn.lean
+++ b/src/data/list/of_fn.lean
@@ -178,7 +178,7 @@ cast (congr_arg _ l.of_fn_nth_le) $ h l.length (λ i, l.nth_le ↑i i.2)
 @[simp]
 lemma of_fn_rec_of_fn {C : list α → Sort*} (h : Π n (f : fin n → α), C (list.of_fn f))
   {n : ℕ} (f : fin n → α) : @of_fn_rec _ C h (list.of_fn f) = h _ f :=
-equiv_sigma_tuple.cast_symm_apply_apply (λ s, h s.1 s.2) ⟨n, f⟩
+equiv_sigma_tuple.right_inverse_symm.cast_eq (λ s, h s.1 s.2) ⟨n, f⟩
 
 lemma exists_iff_exists_tuple {P : list α → Prop} :
   (∃ l : list α, P l) ↔ ∃ n (f : fin n → α), P (list.of_fn f) :=

--- a/src/data/list/of_fn.lean
+++ b/src/data/list/of_fn.lean
@@ -181,14 +181,12 @@ lemma of_fn_rec_of_fn {C : list α → Sort*} (h : Π n (f : fin n → α), C (l
 begin
   rw [of_fn_rec, cast_eq_iff_heq],
   have := length_of_fn f,
-  congr',
-  simp_rw [←fin.coe_cast this, nth_le_of_fn],
-  ext,
-  { rw this },
-  intros a b hab,
   congr,
-  rw [fin.cast_eq_cast, cast_eq_iff_heq],
-  exact hab,
+  { exact this },
+  { simp_rw [←fin.coe_cast this, nth_le_of_fn],
+    refine function.hfunext (congr_arg _ this) (λ a b hab, congr_arg_heq _ _),
+    rw [fin.cast_eq_cast, cast_eq_iff_heq],
+    exact hab }
 end
 
 lemma exists_iff_exists_tuple {P : list α → Prop} :

--- a/src/data/list/of_fn.lean
+++ b/src/data/list/of_fn.lean
@@ -168,9 +168,28 @@ def equiv_sigma_tuple : list α ≃ Σ n, fin n → α :=
   right_inv := λ ⟨n, f⟩, fin.sigma_eq_of_eq_comp_cast (length_of_fn _) $ funext $ λ i,
     nth_le_of_fn' f i.prop }
 
-/-- A recursor for lists that expands a list into a function mapping to its elements. -/
-def of_fn_rec (C : list α → Sort*) (h : Π n (f : fin n → α), C (list.of_fn f)) (l : list α) : C l :=
-l.of_fn_nth_le.rec $ h l.length (λ i, l.nth_le ↑i i.2)
+/-- A recursor for lists that expands a list into a function mapping to its elements.
+
+This can be used with `induction l using list.of_fn_rec`. -/
+@[elab_as_eliminator]
+def of_fn_rec {C : list α → Sort*} (h : Π n (f : fin n → α), C (list.of_fn f)) (l : list α) : C l :=
+cast (congr_arg _ l.of_fn_nth_le) $ h l.length (λ i, l.nth_le ↑i i.2)
+
+@[simp]
+lemma of_fn_rec_of_fn {C : list α → Sort*} (h : Π n (f : fin n → α), C (list.of_fn f))
+  {n : ℕ} (f : fin n → α) : @of_fn_rec _ C h (list.of_fn f) = h _ f :=
+begin
+  rw [of_fn_rec, cast_eq_iff_heq],
+  have := length_of_fn f,
+  congr',
+  simp_rw [←fin.coe_cast this, nth_le_of_fn],
+  ext,
+  { rw this },
+  intros a b hab,
+  congr,
+  rw [fin.cast_eq_cast, cast_eq_iff_heq],
+  exact hab,
+end
 
 lemma exists_iff_exists_tuple {P : list α → Prop} :
   (∃ l : list α, P l) ↔ ∃ n (f : fin n → α), P (list.of_fn f) :=

--- a/src/data/list/of_fn.lean
+++ b/src/data/list/of_fn.lean
@@ -178,16 +178,7 @@ cast (congr_arg _ l.of_fn_nth_le) $ h l.length (λ i, l.nth_le ↑i i.2)
 @[simp]
 lemma of_fn_rec_of_fn {C : list α → Sort*} (h : Π n (f : fin n → α), C (list.of_fn f))
   {n : ℕ} (f : fin n → α) : @of_fn_rec _ C h (list.of_fn f) = h _ f :=
-begin
-  rw [of_fn_rec, cast_eq_iff_heq],
-  have := length_of_fn f,
-  congr,
-  { exact this },
-  { simp_rw [←fin.coe_cast this, nth_le_of_fn],
-    refine function.hfunext (congr_arg _ this) (λ a b hab, congr_arg_heq _ _),
-    rw [fin.cast_eq_cast, cast_eq_iff_heq],
-    exact hab }
-end
+equiv_sigma_tuple.cast_symm_apply_apply (λ s, h s.1 s.2) ⟨n, f⟩
 
 lemma exists_iff_exists_tuple {P : list α → Prop} :
   (∃ l : list α, P l) ↔ ∃ n (f : fin n → α), P (list.of_fn f) :=

--- a/src/logic/equiv/basic.lean
+++ b/src/logic/equiv/basic.lean
@@ -243,26 +243,6 @@ ext $ λ x, by { substs h h2, refl }
 lemma cast_eq_iff_heq {α β} (h : α = β) {a : α} {b : β} : equiv.cast h a = b ↔ a == b :=
 by { subst h, simp }
 
-section eq_rec_lemmas
-
-lemma rec_symm_apply_apply {γ : α → Sort*} (e : α ≃ β) (f : Π b : β, γ (e.symm b)) (y : β) :
-  @eq.rec _ _ γ (f (e (e.symm y))) _ (e.symm_apply_apply (e.symm y)) = f y :=
-eq_of_heq $ (eq_rec_heq _ _).trans $ by rw [e.apply_symm_apply]
-
-lemma rec_apply_symm_apply {γ : β → Sort*} (e : α ≃ β) (f : Π a : α, γ (e a)) (y : α) :
-  @eq.rec _ _ γ (f (e.symm (e y))) _ (e.apply_symm_apply (e y)) = f y :=
-eq_of_heq $ (eq_rec_heq _ _).trans $ by rw [e.symm_apply_apply]
-
-lemma cast_symm_apply_apply {γ : α → Sort*} (e : α ≃ β) (f : Π b : β, γ (e.symm b)) (y : β) :
-  cast (congr_arg _ (e.symm_apply_apply (e.symm y))) (f (e (e.symm y))) = f y :=
-eq_of_heq $ (eq_rec_heq _ _).trans $ by rw [e.apply_symm_apply]
-
-lemma cast_apply_symm_apply {γ : β → Sort*} (e : α ≃ β) (f : Π a : α, γ (e a)) (y : α) :
-  cast (congr_arg _ (e.apply_symm_apply (e y))) (f (e.symm (e y))) = f y :=
-eq_of_heq $ (eq_rec_heq _ _).trans $ by rw [e.symm_apply_apply]
-
-end eq_rec_lemmas
-
 lemma symm_apply_eq {α β} (e : α ≃ β) {x y} : e.symm x = y ↔ x = e y :=
 ⟨λ H, by simp [H.symm], λ H, by simp [H]⟩
 

--- a/src/logic/equiv/basic.lean
+++ b/src/logic/equiv/basic.lean
@@ -243,6 +243,26 @@ ext $ λ x, by { substs h h2, refl }
 lemma cast_eq_iff_heq {α β} (h : α = β) {a : α} {b : β} : equiv.cast h a = b ↔ a == b :=
 by { subst h, simp }
 
+section eq_rec_lemmas
+
+lemma rec_symm_apply_apply {γ : α → Sort*} (e : α ≃ β) (f : Π b : β, γ (e.symm b)) (y : β) :
+  @eq.rec _ _ γ (f (e (e.symm y))) _ (e.symm_apply_apply (e.symm y)) = f y :=
+eq_of_heq $ (eq_rec_heq _ _).trans $ by rw [e.apply_symm_apply]
+
+lemma rec_apply_symm_apply {γ : β → Sort*} (e : α ≃ β) (f : Π a : α, γ (e a)) (y : α) :
+  @eq.rec _ _ γ (f (e.symm (e y))) _ (e.apply_symm_apply (e y)) = f y :=
+eq_of_heq $ (eq_rec_heq _ _).trans $ by rw [e.symm_apply_apply]
+
+lemma cast_symm_apply_apply {γ : α → Sort*} (e : α ≃ β) (f : Π b : β, γ (e.symm b)) (y : β) :
+  cast (congr_arg _ (e.symm_apply_apply (e.symm y))) (f (e (e.symm y))) = f y :=
+eq_of_heq $ (eq_rec_heq _ _).trans $ by rw [e.apply_symm_apply]
+
+lemma cast_apply_symm_apply {γ : β → Sort*} (e : α ≃ β) (f : Π a : α, γ (e a)) (y : α) :
+  cast (congr_arg _ (e.apply_symm_apply (e y))) (f (e.symm (e y))) = f y :=
+eq_of_heq $ (eq_rec_heq _ _).trans $ by rw [e.symm_apply_apply]
+
+end eq_rec_lemmas
+
 lemma symm_apply_eq {α β} (e : α ≃ β) {x y} : e.symm x = y ↔ x = e y :=
 ⟨λ H, by simp [H.symm], λ H, by simp [H]⟩
 

--- a/src/logic/function/basic.lean
+++ b/src/logic/function/basic.lean
@@ -774,6 +774,21 @@ lemma eq_rec_inj {α : Sort*} {a a' : α} (h : a = a') {C : α → Type*} (x y :
 lemma cast_inj {α β : Type*} (h : α = β) {x y : α} : cast h x = cast h y ↔ x = y :=
 (cast_bijective h).injective.eq_iff
 
+lemma function.left_inverse.eq_rec_eq {α β : Sort*} {γ : β → Sort v} {f : α → β} {g : β → α}
+  (h : function.left_inverse g f) (C : Π a : α, γ (f a)) (a : α) :
+  (congr_arg f (h a)).rec (C (g (f a))) = C a :=
+eq_of_heq $ (eq_rec_heq _ _).trans $ by rw h
+
+lemma function.left_inverse.eq_rec_on_eq {α β : Sort*} {γ : β → Sort v} {f : α → β} {g : β → α}
+  (h : function.left_inverse g f) (C : Π a : α, γ (f a)) (a : α) :
+  (congr_arg f (h a)).rec_on (C (g (f a))) = C a :=
+h.eq_rec_eq _ _
+
+lemma function.left_inverse.cast_eq {α β : Sort*} {γ : β → Sort v} {f : α → β} {g : β → α}
+  (h : function.left_inverse g f) (C : Π a : α, γ (f a)) (a : α) :
+  cast (congr_arg (λ a, γ (f a)) (h a)) (C (g (f a))) = C a :=
+eq_of_heq $ (eq_rec_heq _ _).trans $ by rw h
+
 /-- A set of functions "separates points"
 if for each pair of distinct points there is a function taking different values on them. -/
 def set.separates_points {α β : Type*} (A : set (α → β)) : Prop :=


### PR DESCRIPTION
In order to prove a property of the recursor, this adds some helper lemmas to `function.left_inverse`

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
