### PR TITLE
[Merged by Bors] - feat(set_theory/ordinal/arithmetic): more log lemmas

### DIFF
--- a/src/set_theory/ordinal/arithmetic.lean
+++ b/src/set_theory/ordinal/arithmetic.lean
@@ -2079,8 +2079,7 @@ if b1 : 1 < b then (right_le_opow _ b1).trans (opow_log_le_self b (ordinal.pos_i
 else by simp only [log_of_not_one_lt_left b1, ordinal.zero_le]
 
 @[simp] theorem log_one_right (b : ordinal) : log b 1 = 0 :=
-if hb : 1 < b then by rwa [←lt_one_iff_zero, ←lt_opow_iff_log_lt hb zero_lt_one, opow_one]
-else log_of_not_one_lt_left hb 1
+if hb : 1 < b then log_eq_zero hb else log_of_not_one_lt_left hb 1
 
 theorem mod_opow_log_lt_self {b o : ordinal} (b0 : b ≠ 0) (o0 : o ≠ 0) : o % b ^ log b o < o :=
 (mod_lt _ $ opow_ne_zero _ b0).trans_le (opow_log_le_self _ $ ordinal.pos_iff_ne_zero.2 o0)

--- a/src/set_theory/ordinal/arithmetic.lean
+++ b/src/set_theory/ordinal/arithmetic.lean
@@ -2082,12 +2082,8 @@ else by simp only [log_of_not_one_lt_left b1, ordinal.zero_le]
 if hb : 1 < b then by rwa [←lt_one_iff_zero, ←lt_opow_iff_log_lt hb zero_lt_one, opow_one]
 else log_of_not_one_lt_left hb 1
 
-theorem mod_opow_log_lt_self (b : ordinal) {o : ordinal} (ho : 0 < o) : o % b ^ log b o < o :=
-begin
-  rcases eq_or_ne b 0 with rfl | hb,
-  { simpa using ho },
-  exact (mod_lt _ $ opow_ne_zero _ hb).trans_le (opow_log_le_self _ $ ho)
-end
+theorem mod_opow_log_lt_self {b o : ordinal} (b0 : b ≠ 0) (o0 : o ≠ 0) : o % b ^ log b o < o :=
+(mod_lt _ $ opow_ne_zero _ b0).trans_le (opow_log_le_self _ $ ordinal.pos_iff_ne_zero.2 o0)
 
 theorem log_mod_opow_log_lt_log_self {b o : ordinal} (hb : 1 < b) (ho : 0 < o) (hbo : b ≤ o) :
   log b (o % b ^ log b o) < log b o :=

--- a/src/set_theory/ordinal/arithmetic.lean
+++ b/src/set_theory/ordinal/arithmetic.lean
@@ -773,8 +773,10 @@ theorem div_le {a b c : ordinal} (b0 : b ≠ 0) : a / b ≤ c ↔ a < b * succ c
 ⟨λ h, (lt_mul_succ_div a b0).trans_le (mul_le_mul_left' (succ_le_succ_iff.2 h) _),
  λ h, by rw div_def a b0; exact cInf_le' h⟩
 
-theorem lt_div {a b c : ordinal} (c0 : c ≠ 0) : a < b / c ↔ c * succ a ≤ b :=
-by rw [← not_le, div_le c0, not_lt]
+theorem lt_div {a b c : ordinal} (h : c ≠ 0) : a < b / c ↔ c * succ a ≤ b :=
+by rw [← not_le, div_le h, not_lt]
+
+theorem div_pos {b c : ordinal} (h : c ≠ 0) : 0 < b / c ↔ c ≤ b := by simp [lt_div h]
 
 theorem le_div {a b c : ordinal} (c0 : c ≠ 0) :
   a ≤ b / c ↔ c * a ≤ b :=
@@ -2050,6 +2052,20 @@ theorem opow_le_iff_le_log {b x c : ordinal} (b1 : 1 < b) (x0 : 0 < x) : b ^ c �
 theorem lt_opow_iff_log_lt {b x c : ordinal} (b1 : 1 < b) (x0 : 0 < x) : x < b ^ c ↔ log b x < c :=
 lt_iff_lt_of_le_iff_le (opow_le_iff_le_log b1 x0)
 
+theorem log_pos {b o : ordinal} (hb : 1 < b) (ho : 0 < o) (hbo : b ≤ o) : 0 < log b o :=
+by rwa [←succ_le_iff, succ_zero, ←opow_le_iff_le_log hb ho, opow_one]
+
+theorem log_eq_zero {b o : ordinal} (hbo : o < b) : log b o = 0 :=
+begin
+  rcases eq_zero_or_pos o with rfl | ho,
+  { exact log_zero_right b },
+  cases le_or_lt b 1 with hb hb,
+  { rcases le_one_iff.1 hb with rfl | rfl,
+    { exact log_zero_left o },
+    { exact log_one_left o } },
+  { rwa [←ordinal.le_zero, ←lt_succ_iff, succ_zero, ←lt_opow_iff_log_lt hb ho, opow_one] }
+end
+
 @[mono] theorem log_mono_right (b) {x y : ordinal} (xy : x ≤ y) : log b x ≤ log b y :=
 if x0 : x = 0 then by simp only [x0, log_zero_right, ordinal.zero_le] else
 have x0 : 0 < x, from ordinal.pos_iff_ne_zero.2 x0,
@@ -2066,8 +2082,25 @@ else by simp only [log_of_not_one_lt_left b1, ordinal.zero_le]
 if hb : 1 < b then by rwa [←lt_one_iff_zero, ←lt_opow_iff_log_lt hb zero_lt_one, opow_one]
 else log_of_not_one_lt_left hb 1
 
-theorem mod_opow_log_lt_self {b o : ordinal} (b0 : b ≠ 0) (o0 : o ≠ 0) : o % b ^ log b o < o :=
-(mod_lt _ $ opow_ne_zero _ b0).trans_le (opow_log_le_self _ $ ordinal.pos_iff_ne_zero.2 o0)
+theorem mod_opow_log_lt_self (b : ordinal) {o : ordinal} (ho : 0 < o) : o % b ^ log b o < o :=
+begin
+  rcases eq_or_ne b 0 with rfl | hb,
+  { simpa using ho },
+  exact (mod_lt _ $ opow_ne_zero _ hb).trans_le (opow_log_le_self _ $ ho)
+end
+
+theorem log_mod_opow_log_lt_log_self {b o : ordinal} (hb : 1 < b) (ho : 0 < o) (hbo : b ≤ o) :
+  log b (o % b ^ log b o) < log b o :=
+begin
+  cases eq_zero_or_pos (o % b ^ log b o),
+  { rw [h, log_zero_right],
+    apply log_pos hb ho hbo },
+  { rw [←succ_le_iff, succ_log_def hb h],
+    apply cInf_le',
+    apply mod_lt,
+    rw ←ordinal.pos_iff_ne_zero,
+    exact opow_pos _ (zero_lt_one.trans hb) }
+end
 
 lemma opow_mul_add_pos {b v : ordinal} (hb : 0 < b) (u) (hv : 0 < v) (w) : 0 < b ^ u * v + w :=
 (opow_pos u hb).trans_le ((le_mul_left _ hv).trans (le_add_right _ _))
@@ -2096,10 +2129,16 @@ begin
     exact (not_lt_of_le h) (opow_mul_add_lt_opow_succ hvb hw) }
 end
 
-@[simp] theorem log_opow {b : ordinal} (hb : 1 < b) (x : ordinal) : log b (b ^ x) = x :=
+theorem log_opow {b : ordinal} (hb : 1 < b) (x : ordinal) : log b (b ^ x) = x :=
 begin
   convert log_opow_mul_add hb zero_lt_one hb (opow_pos x (zero_lt_one.trans hb)),
   rw [add_zero, mul_one]
+end
+
+theorem div_opow_log_lt {b : ordinal} (o : ordinal) (hb : 1 < b) : o / b ^ log b o < b :=
+begin
+  rw [div_lt (opow_pos _ (zero_lt_one.trans hb)).ne', ←opow_succ],
+  exact lt_opow_succ_log_self hb o
 end
 
 theorem add_log_le_log_mul {x y : ordinal} (b : ordinal) (x0 : 0 < x) (y0 : 0 < y) :

--- a/src/set_theory/ordinal/cantor_normal_form.lean
+++ b/src/set_theory/ordinal/cantor_normal_form.lean
@@ -29,11 +29,11 @@ namespace ordinal
 
 /-- Inducts on the base `b` expansion of an ordinal. -/
 @[elab_as_eliminator] noncomputable def CNF_rec {b : ordinal} (b0 : b ≠ 0)
-  {C : ordinal → Sort*} (H0 : C 0) (H : ∀ o, o ≠ 0 → C (o % b ^ log b o) → C o) : ∀ o, C o
+  {C : ordinal → Sort*} (H0 : C 0) (H : ∀ o, 0 < o → C (o % b ^ log b o) → C o) : ∀ o, C o
 | o :=
   if o0 : o = 0 then by rwa o0 else
-  have _, from mod_opow_log_lt_self b0 o0,
-  H o o0 (CNF_rec (o % b ^ log b o))
+  have _, from mod_opow_log_lt_self b (ordinal.pos_iff_ne_zero.2 o0),
+  H o (ordinal.pos_iff_ne_zero.2 o0) (CNF_rec (o % b ^ log b o))
 using_well_founded {dec_tac := `[assumption]}
 
 @[simp] theorem CNF_rec_zero {b} (b0) {C H0 H} : @CNF_rec b b0 C H0 H 0 = H0 :=
@@ -41,7 +41,7 @@ by rw [CNF_rec, dif_pos rfl]; refl
 
 @[simp] theorem CNF_rec_ne_zero {b} (b0) {C H0 H o} (o0) :
   @CNF_rec b b0 C H0 H o = H o o0 (@CNF_rec b b0 C H0 H _) :=
-by rw [CNF_rec, dif_neg o0]
+by rw [CNF_rec, dif_neg o0.ne']
 
 /-- The Cantor normal form of an ordinal `o` is the list of coefficients and exponents in the
 base-`b` expansion of `o`.
@@ -60,11 +60,11 @@ dif_pos rfl
 if b0 : b = 0 then dif_pos b0 else (dif_neg b0).trans $ CNF_rec_zero _
 
 /-- Recursive definition for the Cantor normal form. -/
-theorem CNF_ne_zero {b o : ordinal} (b0 : b ≠ 0) (o0 : o ≠ 0) :
+theorem CNF_ne_zero {b o : ordinal} (b0 : b ≠ 0) (o0 : 0 < o) :
   CNF b o = (log b o, o / b ^ log b o) :: CNF b (o % b ^ log b o) :=
 by unfold CNF; rw [dif_neg b0, dif_neg b0, CNF_rec_ne_zero b0 o0]
 
-@[simp] theorem one_CNF {o : ordinal} (o0 : o ≠ 0) : CNF 1 o = [(0, o)] :=
+@[simp] theorem one_CNF {o : ordinal} (o0 : 0 < o) : CNF 1 o = [(0, o)] :=
 by rw [CNF_ne_zero ordinal.one_ne_zero o0, log_of_not_one_lt_left (irrefl _), opow_zero, mod_one,
        CNF_zero, div_one]
 
@@ -87,12 +87,12 @@ begin
     intros o o0 IH, cases IH with IH₁ IH₂,
     simp only [CNF_ne_zero b0 o0, list.forall_mem_cons, list.pairwise_cons, IH₂, and_true],
     refine ⟨⟨le_rfl, λ p m, _⟩, λ p m, _⟩,
-    { exact (IH₁ p m).trans (log_mono_right _ $ le_of_lt $ mod_opow_log_lt_self b0 o0) },
+    { exact (IH₁ p m).trans (log_mono_right _ $ le_of_lt $ mod_opow_log_lt_self b o0) },
     { refine (IH₁ p m).trans_lt ((lt_opow_iff_log_lt b1 _).1 _),
       { rw ordinal.pos_iff_ne_zero, intro e,
         rw e at m, simpa only [CNF_zero] using m },
       { exact mod_lt _ (opow_ne_zero _ b0) } } },
-  { by_cases o0 : o = 0,
+  { cases eq_zero_or_pos o with o0 o0,
     { simp only [o0, CNF_zero, list.pairwise.nil, and_true], exact λ _, false.elim },
     rw [← b1, one_CNF o0],
     simp only [list.mem_singleton, log_one_left, forall_eq, le_refl, true_and,
@@ -123,8 +123,7 @@ begin
   simp only [CNF_ne_zero b0 o0, list.mem_cons_iff, forall_eq_or_imp, iff_true_intro @IH, and_true],
   nth_rewrite 1 ←@succ_le_iff,
   rw [div_lt (opow_ne_zero _ b0), ←opow_succ, le_div (opow_ne_zero _ b0), succ_zero, mul_one],
-  refine ⟨lt_opow_succ_log_self b1 _, opow_log_le_self _ _⟩,
-  rwa ordinal.pos_iff_ne_zero
+  exact ⟨lt_opow_succ_log_self b1 _, opow_log_le_self _ o0⟩
 end
 
 /-- Every coefficient in the Cantor normal form `CNF b o` is less than `b`. -/

--- a/src/set_theory/ordinal/cantor_normal_form.lean
+++ b/src/set_theory/ordinal/cantor_normal_form.lean
@@ -29,11 +29,11 @@ namespace ordinal
 
 /-- Inducts on the base `b` expansion of an ordinal. -/
 @[elab_as_eliminator] noncomputable def CNF_rec {b : ordinal} (b0 : b ≠ 0)
-  {C : ordinal → Sort*} (H0 : C 0) (H : ∀ o, 0 < o → C (o % b ^ log b o) → C o) : ∀ o, C o
+  {C : ordinal → Sort*} (H0 : C 0) (H : ∀ o, o ≠ 0 → C (o % b ^ log b o) → C o) : ∀ o, C o
 | o :=
   if o0 : o = 0 then by rwa o0 else
-  have _, from mod_opow_log_lt_self b (ordinal.pos_iff_ne_zero.2 o0),
-  H o (ordinal.pos_iff_ne_zero.2 o0) (CNF_rec (o % b ^ log b o))
+  have _, from mod_opow_log_lt_self b0 o0,
+  H o o0 (CNF_rec (o % b ^ log b o))
 using_well_founded {dec_tac := `[assumption]}
 
 @[simp] theorem CNF_rec_zero {b} (b0) {C H0 H} : @CNF_rec b b0 C H0 H 0 = H0 :=
@@ -41,7 +41,7 @@ by rw [CNF_rec, dif_pos rfl]; refl
 
 @[simp] theorem CNF_rec_ne_zero {b} (b0) {C H0 H o} (o0) :
   @CNF_rec b b0 C H0 H o = H o o0 (@CNF_rec b b0 C H0 H _) :=
-by rw [CNF_rec, dif_neg o0.ne']
+by rw [CNF_rec, dif_neg o0]
 
 /-- The Cantor normal form of an ordinal `o` is the list of coefficients and exponents in the
 base-`b` expansion of `o`.
@@ -60,11 +60,11 @@ dif_pos rfl
 if b0 : b = 0 then dif_pos b0 else (dif_neg b0).trans $ CNF_rec_zero _
 
 /-- Recursive definition for the Cantor normal form. -/
-theorem CNF_ne_zero {b o : ordinal} (b0 : b ≠ 0) (o0 : 0 < o) :
+theorem CNF_ne_zero {b o : ordinal} (b0 : b ≠ 0) (o0 : o ≠ 0) :
   CNF b o = (log b o, o / b ^ log b o) :: CNF b (o % b ^ log b o) :=
 by unfold CNF; rw [dif_neg b0, dif_neg b0, CNF_rec_ne_zero b0 o0]
 
-@[simp] theorem one_CNF {o : ordinal} (o0 : 0 < o) : CNF 1 o = [(0, o)] :=
+@[simp] theorem one_CNF {o : ordinal} (o0 : o ≠ 0) : CNF 1 o = [(0, o)] :=
 by rw [CNF_ne_zero ordinal.one_ne_zero o0, log_of_not_one_lt_left (irrefl _), opow_zero, mod_one,
        CNF_zero, div_one]
 
@@ -87,12 +87,12 @@ begin
     intros o o0 IH, cases IH with IH₁ IH₂,
     simp only [CNF_ne_zero b0 o0, list.forall_mem_cons, list.pairwise_cons, IH₂, and_true],
     refine ⟨⟨le_rfl, λ p m, _⟩, λ p m, _⟩,
-    { exact (IH₁ p m).trans (log_mono_right _ $ le_of_lt $ mod_opow_log_lt_self b o0) },
+    { exact (IH₁ p m).trans (log_mono_right _ $ le_of_lt $ mod_opow_log_lt_self b0 o0) },
     { refine (IH₁ p m).trans_lt ((lt_opow_iff_log_lt b1 _).1 _),
       { rw ordinal.pos_iff_ne_zero, intro e,
         rw e at m, simpa only [CNF_zero] using m },
       { exact mod_lt _ (opow_ne_zero _ b0) } } },
-  { cases eq_zero_or_pos o with o0 o0,
+  { by_cases o0 : o = 0,
     { simp only [o0, CNF_zero, list.pairwise.nil, and_true], exact λ _, false.elim },
     rw [← b1, one_CNF o0],
     simp only [list.mem_singleton, log_one_left, forall_eq, le_refl, true_and,
@@ -123,7 +123,8 @@ begin
   simp only [CNF_ne_zero b0 o0, list.mem_cons_iff, forall_eq_or_imp, iff_true_intro @IH, and_true],
   nth_rewrite 1 ←@succ_le_iff,
   rw [div_lt (opow_ne_zero _ b0), ←opow_succ, le_div (opow_ne_zero _ b0), succ_zero, mul_one],
-  exact ⟨lt_opow_succ_log_self b1 _, opow_log_le_self _ o0⟩
+  refine ⟨lt_opow_succ_log_self b1 _, opow_log_le_self _ _⟩,
+  rwa ordinal.pos_iff_ne_zero
 end
 
 /-- Every coefficient in the Cantor normal form `CNF b o` is less than `b`. -/


### PR DESCRIPTION
We prove a bunch of lemmas on the ordinal logarithm that are relevant for Cantor normal forms.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
