### PR TITLE
feat(logic/basic): add simp lemma `not_imp_false_iff`

### DIFF
--- a/src/logic/basic.lean
+++ b/src/logic/basic.lean
@@ -370,6 +370,8 @@ is classically true but not constructively. -/
 
 theorem of_not_not : ¬¬a → a := by_contra
 
+@[simp] theorem not_imp_false_iff : ¬a → false ↔ a := not_not
+
 lemma not_ne_iff {α : Sort*} {a b : α} : ¬ a ≠ b ↔ a = b := not_not
 
 -- See Note [decidable namespace]

--- a/src/number_theory/legendre_symbol/quadratic_char.lean
+++ b/src/number_theory/legendre_symbol/quadratic_char.lean
@@ -271,9 +271,9 @@ begin
     norm_num,
     split,
     { intros h h',
-      have t := (of_not_not h).symm.trans h',
+      have t := h.symm.trans h',
       norm_num at t, },
-    exact λ h h', h' ((or_iff_left h).mp h₃), },
+    exact λ h, (or_iff_left h).mp h₃, },
 end
 
 end char

--- a/src/order/chain.lean
+++ b/src/order/chain.lean
@@ -181,7 +181,8 @@ begin
   case union : s hs ih
   { apply or.imp_left h.antisymm',
     apply classical.by_contradiction,
-    simp [not_or_distrib, sUnion_subset_iff, not_forall],
+    simp only [not_or_distrib, sUnion_subset_iff, not_forall, exists_prop, and_imp,
+               forall_exists_index],
     intros c₃ hc₃ h₁ h₂,
     obtain h | h := chain_closure_succ_total_aux hc₁ (hs c₃ hc₃) (λ c₄, ih _ hc₃),
     { exact h₁ (subset_succ_chain.trans h) },


### PR DESCRIPTION
This just adds `not_imp_false_iff {a : Prop} : ¬a → false ↔ a` as a `simp` lemma.
See the discussion [here](https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/.60not_not.60.20and.20.60simp.60/near/289878013).

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
