### PR TITLE
[Merged by Bors] - feat(geometry/euclidean/oriented_angle): `continuous_at_oangle`

### DIFF
--- a/src/geometry/euclidean/oriented_angle.lean
+++ b/src/geometry/euclidean/oriented_angle.lean
@@ -51,6 +51,15 @@ def oangle (x y : V) : real.angle :=
 complex.arg ((complex.isometry_of_orthonormal hb).symm y /
   (complex.isometry_of_orthonormal hb).symm x)
 
+/-- Oriented angles are continuous when the vectors involved are nonzero. -/
+lemma continuous_at_oangle {x : V × V} (hx1 : x.1 ≠ 0) (hx2 : x.2 ≠ 0) :
+  continuous_at (λ y : V × V, hb.oangle y.1 y.2) x :=
+(complex.continuous_at_arg_coe_angle (by simp [hx1, hx2])).comp $
+  continuous_at.div
+    ((complex.isometry_of_orthonormal hb).symm.continuous.comp continuous_snd).continuous_at
+    ((complex.isometry_of_orthonormal hb).symm.continuous.comp continuous_fst).continuous_at
+    (by simp [hx1])
+
 /-- If the first vector passed to `oangle` is 0, the result is 0. -/
 @[simp] lemma oangle_zero_left (x : V) : hb.oangle 0 x = 0 :=
 by simp [oangle]
@@ -795,6 +804,11 @@ local notation `ob` := o.fin_orthonormal_basis_orthonormal dec_trivial hd2.out
 See `inner_product_geometry.angle` for the corresponding unoriented angle definition. -/
 def oangle (x y : V) : real.angle :=
 (ob).oangle x y
+
+/-- Oriented angles are continuous when the vectors involved are nonzero. -/
+lemma continuous_at_oangle {x : V × V} (hx1 : x.1 ≠ 0) (hx2 : x.2 ≠ 0) :
+  continuous_at (λ y : V × V, o.oangle y.1 y.2) x :=
+(ob).continuous_at_oangle hx1 hx2
 
 /-- If the first vector passed to `oangle` is 0, the result is 0. -/
 @[simp] lemma oangle_zero_left (x : V) : o.oangle 0 x = 0 :=


### PR DESCRIPTION
Add lemmas that oriented angles are continuous, as a function of a
pair of vectors, except where one of the vectors is zero, analogous to
the lemmas previously added for unoriented angles.



---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
