### PR TITLE
[Merged by Bors] - refactor(algebra/punit_instances): Move order instances

### DIFF
--- a/src/algebra/punit_instances.lean
+++ b/src/algebra/punit_instances.lean
@@ -70,34 +70,6 @@ intros; exact subsingleton.elim _ _
 @[simp] lemma lcm_eq : lcm x y = star := rfl
 @[simp] lemma norm_unit_eq : norm_unit x = 1 := rfl
 
-instance : complete_boolean_algebra punit :=
-by refine
-{ le := λ _ _, true,
-  le_antisymm := λ _ _ _ _, subsingleton.elim _ _,
-  lt := λ _ _, false,
-  lt_iff_le_not_le := λ _ _, iff_of_false not_false (λ H, H.2 trivial),
-  top := star,
-  bot := star,
-  sup := λ _ _, star,
-  inf := λ _ _, star,
-  Sup := λ _, star,
-  Inf := λ _, star,
-  compl := λ _, star,
-  sdiff := λ _ _, star,
-  .. };
-intros; trivial <|> simp only [eq_iff_true_of_subsingleton]
-
-@[simp] lemma top_eq : (⊤ : punit) = star := rfl
-@[simp] lemma bot_eq : (⊥ : punit) = star := rfl
-@[simp] lemma sup_eq : x ⊔ y = star := rfl
-@[simp] lemma inf_eq : x ⊓ y = star := rfl
-@[simp] lemma Sup_eq : Sup s = star := rfl
-@[simp] lemma Inf_eq : Inf s = star := rfl
-@[simp] lemma compl_eq : xᶜ = star := rfl
-@[simp] lemma sdiff_eq : x \ y = star := rfl
-@[simp] protected lemma le : x ≤ y := trivial
-@[simp] lemma not_lt : ¬(x < y) := not_false
-
 instance : canonically_ordered_add_monoid punit :=
 by refine
 { exists_add_of_le := λ _ _ _, ⟨star, subsingleton.elim _ _⟩,

--- a/src/algebra/punit_instances.lean
+++ b/src/algebra/punit_instances.lean
@@ -79,11 +79,7 @@ intros; trivial
 instance : linear_ordered_cancel_add_comm_monoid punit :=
 { add_left_cancel := λ _ _ _ _, subsingleton.elim _ _,
   le_of_add_le_add_left := λ _ _ _ _, trivial,
-  le_total := λ _ _, or.inl trivial,
-  decidable_le := λ _ _, decidable.true,
-  decidable_eq := punit.decidable_eq,
-  decidable_lt := λ _ _, decidable.false,
-  .. punit.canonically_ordered_add_monoid }
+  .. punit.canonically_ordered_add_monoid, ..punit.linear_order }
 
 instance : has_smul R punit :=
 { smul := λ _ _, star }

--- a/src/order/basic.lean
+++ b/src/order/basic.lean
@@ -724,8 +724,8 @@ by refine_struct
     intros; trivial <|> simp only [eq_iff_true_of_subsingleton, not_true, and_false] <|>
       exact or.inl trivial
 
-@[simp] lemma max_eq : max a b = star := rfl
-@[simp] lemma min_eq : min a b = star := rfl
+lemma max_eq : max a b = star := rfl
+lemma min_eq : min a b = star := rfl
 @[simp] protected lemma le : a ≤ b := trivial
 @[simp] lemma not_lt : ¬ a < b := not_false
 

--- a/src/order/basic.lean
+++ b/src/order/basic.lean
@@ -709,6 +709,30 @@ or_iff_not_imp_left.2 $ λ h,
   ⟨λ a ha₁, le_of_not_gt $ λ ha₂, h ⟨a, ha₁, ha₂⟩,
     λ a ha₂, le_of_not_gt $ λ ha₁, h ⟨a, ha₁, ha₂⟩⟩
 
+namespace punit
+variables (a b : punit.{u+1})
+
+instance : linear_order punit :=
+by refine_struct
+{ le := λ _ _, true,
+  lt := λ _ _, false,
+  max := λ _ _, star,
+  min := λ _ _, star,
+  decidable_eq := punit.decidable_eq,
+  decidable_le := λ _ _, decidable.true,
+  decidable_lt := λ _ _, decidable.false };
+    intros; trivial <|> simp only [eq_iff_true_of_subsingleton, not_true, and_false] <|>
+      exact or.inl trivial
+
+@[simp] lemma max_eq : max a b = star := rfl
+@[simp] lemma min_eq : min a b = star := rfl
+@[simp] protected lemma le : a ≤ b := trivial
+@[simp] lemma not_lt : ¬ a < b := not_false
+
+instance : densely_ordered punit := ⟨λ _ _, false.elim⟩
+
+end punit
+
 variables {s : β → β → Prop} {t : γ → γ → Prop}
 
 /-! ### Linear order from a total partial order -/

--- a/src/order/boolean_algebra.lean
+++ b/src/order/boolean_algebra.lean
@@ -923,3 +923,29 @@ protected def function.injective.boolean_algebra [has_sup α] [has_inf α] [has_
   ..hf.generalized_boolean_algebra f map_sup map_inf map_bot map_sdiff }
 
 end lift
+
+namespace punit
+variables (a b : punit.{u+1})
+
+instance : boolean_algebra punit :=
+by refine_struct
+{ le := λ _ _, true,
+  lt := λ _ _, false,
+  top := star,
+  bot := star,
+  sup := λ _ _, star,
+  inf := λ _ _, star,
+  compl := λ _, star,
+  sdiff := λ _ _, star };
+    intros; trivial <|> simp only [eq_iff_true_of_subsingleton, not_true, and_false]
+
+@[simp] lemma top_eq : (⊤ : punit) = star := rfl
+@[simp] lemma bot_eq : (⊥ : punit) = star := rfl
+@[simp] lemma sup_eq : a ⊔ b = star := rfl
+@[simp] lemma inf_eq : a ⊓ b = star := rfl
+@[simp] lemma compl_eq : aᶜ = star := rfl
+@[simp] lemma sdiff_eq : a \ b = star := rfl
+@[simp] protected lemma le : a ≤ b := trivial
+@[simp] lemma not_lt : ¬ a < b := not_false
+
+end punit

--- a/src/order/boolean_algebra.lean
+++ b/src/order/boolean_algebra.lean
@@ -929,15 +929,13 @@ variables (a b : punit.{u+1})
 
 instance : boolean_algebra punit :=
 by refine_struct
-{ le := λ _ _, true,
-  lt := λ _ _, false,
-  top := star,
+{ top := star,
   bot := star,
   sup := λ _ _, star,
   inf := λ _ _, star,
   compl := λ _, star,
-  sdiff := λ _ _, star };
-    intros; trivial <|> simp only [eq_iff_true_of_subsingleton, not_true, and_false]
+  sdiff := λ _ _, star, ..punit.linear_order };
+    intros; trivial <|> exact subsingleton.elim _ _
 
 @[simp] lemma top_eq : (⊤ : punit) = star := rfl
 @[simp] lemma bot_eq : (⊥ : punit) = star := rfl
@@ -945,7 +943,5 @@ by refine_struct
 @[simp] lemma inf_eq : a ⊓ b = star := rfl
 @[simp] lemma compl_eq : aᶜ = star := rfl
 @[simp] lemma sdiff_eq : a \ b = star := rfl
-@[simp] protected lemma le : a ≤ b := trivial
-@[simp] lemma not_lt : ¬ a < b := not_false
 
 end punit

--- a/src/order/category/Preorder.lean
+++ b/src/order/category/Preorder.lean
@@ -3,11 +3,10 @@ Copyright (c) 2020 Johan Commelin. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Johan Commelin
 -/
-import category_theory.concrete_category.bundled_hom
-import algebra.punit_instances
-import order.hom.basic
 import category_theory.category.Cat
 import category_theory.category.preorder
+import category_theory.concrete_category.bundled_hom
+import order.hom.basic
 
 /-!
 # Category of preorders

--- a/src/order/complete_boolean_algebra.lean
+++ b/src/order/complete_boolean_algebra.lean
@@ -300,3 +300,18 @@ protected def function.injective.complete_boolean_algebra [has_sup α] [has_inf 
   ..hf.boolean_algebra f map_sup map_inf map_top map_bot map_compl map_sdiff }
 
 end lift
+
+namespace punit
+variables (s : set punit.{u+1}) (x y : punit.{u+1})
+
+instance : complete_boolean_algebra punit :=
+by refine_struct
+{ Sup := λ _, star,
+  Inf := λ _, star,
+  ..punit.boolean_algebra };
+    intros; trivial <|> simp only [eq_iff_true_of_subsingleton, not_true, and_false]
+
+@[simp] lemma Sup_eq : Sup s = star := rfl
+@[simp] lemma Inf_eq : Inf s = star := rfl
+
+end punit


### PR DESCRIPTION
The location of those instances means that order files need to pull out a bunch of algebra to use the (trivial) order structures on `punit`. This moves the `complete_boolean_algebra` instance to `order.complete_boolean_algebra` and splits off the `boolean_algebra` and `linear_order` instances.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
We could split further but this is precisely the amount of splitting required by #15370.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
