### PR TITLE
[Merged by Bors] - doc(set_theory/ordinal/cantor_normal_form): implementation notes

### DIFF
--- a/src/set_theory/ordinal/cantor_normal_form.lean
+++ b/src/set_theory/ordinal/cantor_normal_form.lean
@@ -11,7 +11,16 @@ import set_theory.ordinal.arithmetic
 
 The Cantor normal form of an ordinal is generally defined as its base `ω` expansion, with its
 non-zero exponents in decreasing order. Here, we more generally define a base `b` expansion
-`ordinal.CNF` in this manner, for any `b ≥ 2`.
+`ordinal.CNF` in this manner, which is well-behaved for any `b ≥ 2`.
+
+# Implementation notes
+
+We implement `ordinal.CNF` as an association list, where keys are exponents and values are
+coefficients. This is because this structure intrinsically reflects two key properties of the Cantor
+normal form:
+
+- It is ordered.
+- It has finitely many entries.
 
 # Todo
 


### PR DESCRIPTION
We write a short paragraph on why `CNF` is implemented as a list of pairs. 

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

I know that a proper association list in Lean would instead have the type `list (Σ x : ordinal, ordinal)`. A planned refactor will make `CNF` have this type.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
