### PR TITLE
[Merged by Bors] - fix(analysis/locally_convex): weaken assumptions for `totally_bounded.is_vonN_bounded`

### DIFF
--- a/src/analysis/locally_convex/balanced_core_hull.lean
+++ b/src/analysis/locally_convex/balanced_core_hull.lean
@@ -240,10 +240,9 @@ variables (𝕜 E)
 
 lemma nhds_basis_balanced : (𝓝 (0 : E)).has_basis
   (λ (s : set E), s ∈ 𝓝 (0 : E) ∧ balanced 𝕜 s) id :=
-(𝓝 0 : filter E).basis_sets.to_has_basis
-  (λ s hs, ⟨balanced_core 𝕜 s,
-    ⟨balanced_core_mem_nhds_zero hs, balanced_core_balanced s⟩, balanced_core_subset s⟩)
-  (λ s hs, ⟨s, hs.1, rfl.subset⟩)
+filter.has_basis_self.mpr
+  (λ s hs, ⟨balanced_core 𝕜 s, balanced_core_mem_nhds_zero hs,
+            balanced_core_balanced s, balanced_core_subset s⟩)
 
 lemma nhds_basis_closed_balanced [t3_space E] : (𝓝 (0 : E)).has_basis
   (λ (s : set E), s ∈ 𝓝 (0 : E) ∧ is_closed s ∧ balanced 𝕜 s) id :=

--- a/src/analysis/locally_convex/balanced_core_hull.lean
+++ b/src/analysis/locally_convex/balanced_core_hull.lean
@@ -238,6 +238,13 @@ end
 
 variables (𝕜 E)
 
+lemma nhds_basis_balanced : (𝓝 (0 : E)).has_basis
+  (λ (s : set E), s ∈ 𝓝 (0 : E) ∧ balanced 𝕜 s) id :=
+(𝓝 0 : filter E).basis_sets.to_has_basis
+  (λ s hs, ⟨balanced_core 𝕜 s,
+    ⟨balanced_core_mem_nhds_zero hs, balanced_core_balanced s⟩, balanced_core_subset s⟩)
+  (λ s hs, ⟨s, hs.1, rfl.subset⟩)
+
 lemma nhds_basis_closed_balanced [t3_space E] : (𝓝 (0 : E)).has_basis
   (λ (s : set E), s ∈ 𝓝 (0 : E) ∧ is_closed s ∧ balanced 𝕜 s) id :=
 begin

--- a/src/analysis/locally_convex/bounded.lean
+++ b/src/analysis/locally_convex/bounded.lean
@@ -162,9 +162,8 @@ end bornology
 
 section uniform_add_group
 
-variables [nondiscrete_normed_field 𝕜] [add_comm_group E] [module 𝕜 E]
+variables (𝕜) [nondiscrete_normed_field 𝕜] [add_comm_group E] [module 𝕜 E]
 variables [uniform_space E] [uniform_add_group E] [has_continuous_smul 𝕜 E]
-variables [t3_space E]
 
 lemma totally_bounded.is_vonN_bounded {s : set E} (hs : totally_bounded s) :
   bornology.is_vonN_bounded 𝕜 s :=
@@ -174,7 +173,7 @@ begin
   have h : filter.tendsto (λ (x : E × E), x.fst + x.snd) (𝓝 (0,0)) (𝓝 ((0 : E) + (0 : E))) :=
     tendsto_add,
   rw add_zero at h,
-  have h' := (nhds_basis_closed_balanced 𝕜 E).prod (nhds_basis_closed_balanced 𝕜 E),
+  have h' := (nhds_basis_balanced 𝕜 E).prod (nhds_basis_balanced 𝕜 E),
   simp_rw [←nhds_prod_eq, id.def] at h',
   rcases h.basis_left h' U hU with ⟨x, hx, h''⟩,
   rcases hs x.snd hx.2.1 with ⟨t, ht, hs⟩,
@@ -187,7 +186,7 @@ begin
     simpa only [hz] using h'' hz' },
   refine λ y hy, absorbs.mono_left _ hx_fstsnd,
   rw [←set.singleton_vadd, vadd_eq_add],
-  exact (absorbent_nhds_zero hx.1.1).absorbs.add hx.2.2.2.absorbs_self,
+  exact (absorbent_nhds_zero hx.1.1).absorbs.add hx.2.2.absorbs_self,
 end
 
 end uniform_add_group


### PR DESCRIPTION
The `t3_space` assumption was needed because of `nhds_basis_closed_balanced`, but closedness was never used, and removing the closedness condition allows us to drop the `t3_space` assumption

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
