### PR TITLE
[Merged by Bors] - chore(data/json): add a missing subtype parser for nullable types

### DIFF
--- a/src/data/json.lean
+++ b/src/data/json.lean
@@ -134,6 +134,9 @@ meta instance {α : Type} [json_serializable α] (p : α → Prop) [decidable_pr
     else
       exception (λ _, format!"condition does not hold") }
 
+meta instance {α : Type} [non_null_json_serializable α] (p : α → Prop) [decidable_pred p] :
+  non_null_json_serializable (subtype p) := {}
+
 /-- Note this only makes sense on types which do not themselves serialize to `null` -/
 meta instance {α} [non_null_json_serializable α] : json_serializable (option α) :=
 { to_json := option.elim json.null to_json,

--- a/test/json.lean
+++ b/test/json.lean
@@ -14,6 +14,20 @@ run_cmd do
   let j := json.of_int (-1),
   tactic.success_if_fail_with_msg (of_json ℕ j) "must be non-negative"
 
+run_cmd do
+  let j := json.of_int 1,
+  v ← of_json {x // x ≠ some 2} j,
+  guard (v = ⟨some 1, dec_trivial⟩),
+  v ← of_json (option {x // x ≠ 2}) j,
+  guard (v = some ⟨1, dec_trivial⟩)
+
+run_cmd do
+  let j := json.null,
+  v ← of_json {x // x ≠ some 2} j,
+  guard (v = ⟨none, dec_trivial⟩),
+  v ← of_json (option {x // x ≠ 2}) j,
+  guard (v = none)
+
 @[derive [decidable_eq, non_null_json_serializable]]
 structure my_type (yval : bool) :=
 (x : nat)


### PR DESCRIPTION
This instance is needed by `of_json (option (subtype p)) j`.
There is now a test for this.



---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
