### PR TITLE
[Merged by Bors] - chore(algebra/order/sub): Generalize lemmas

### DIFF
--- a/src/algebra/big_operators/multiset.lean
+++ b/src/algebra/big_operators/multiset.lean
@@ -154,7 +154,7 @@ quotient.induction_on s (λ l a h, by simpa using list.dvd_prod h) a
 
 lemma prod_dvd_prod_of_le (h : s ≤ t) : s.prod ∣ t.prod :=
 begin
-  obtain ⟨z, rfl⟩ := multiset.le_iff_exists_add.1 h,
+  obtain ⟨z, rfl⟩ := multiset.exists_add_of_le h,
   simp only [prod_add, dvd_mul_right],
 end
 

--- a/src/algebra/big_operators/multiset.lean
+++ b/src/algebra/big_operators/multiset.lean
@@ -153,10 +153,7 @@ lemma dvd_prod : a ∈ s → a ∣ s.prod :=
 quotient.induction_on s (λ l a h, by simpa using list.dvd_prod h) a
 
 lemma prod_dvd_prod_of_le (h : s ≤ t) : s.prod ∣ t.prod :=
-begin
-  obtain ⟨z, rfl⟩ := multiset.exists_add_of_le h,
-  simp only [prod_add, dvd_mul_right],
-end
+by { obtain ⟨z, rfl⟩ := exists_add_of_le h, simp only [prod_add, dvd_mul_right] }
 
 end comm_monoid
 

--- a/src/algebra/order/monoid_lemmas.lean
+++ b/src/algebra/order/monoid_lemmas.lean
@@ -1068,6 +1068,9 @@ lemma contravariant.mul_le_cancellable [has_mul α] [has_le α] [contravariant_c
   {a : α} : mul_le_cancellable a :=
 λ b c, le_of_mul_le_mul_left'
 
+@[to_additive] lemma mul_le_cancellable_one [monoid α] [has_le α] : mul_le_cancellable (1 : α) :=
+λ a b, by simpa only [one_mul] using id
+
 namespace mul_le_cancellable
 
 @[to_additive]

--- a/src/algebra/order/ring.lean
+++ b/src/algebra/order/ring.lean
@@ -1514,7 +1514,7 @@ instance to_no_zero_divisors : no_zero_divisors α :=
 instance to_covariant_mul_le : covariant_class α α (*) (≤) :=
 begin
   refine ⟨λ a b c h, _⟩,
-  rcases le_iff_exists_add.1 h with ⟨c, rfl⟩,
+  rcases exists_add_of_le h with ⟨c, rfl⟩,
   rw mul_add,
   apply self_le_add_right
 end

--- a/src/algebra/order/sub.lean
+++ b/src/algebra/order/sub.lean
@@ -94,7 +94,7 @@ end
 
 /-! ### Preorder -/
 
-section ordered_add_comm_monoid
+section ordered_add_comm_semigroup
 
 section preorder
 variables [preorder α]
@@ -163,6 +163,7 @@ tsub_le_iff_right.2 $ calc
   ... ≤ a - b + (c + (b - c)) : add_le_add_left le_add_tsub _
   ... = a - b + c + (b - c) : (add_assoc _ _ _).symm
 
+/-- See `tsub_add_tsub_comm` for the equality. -/
 lemma add_tsub_add_le_tsub_add_tsub : a + b - (c + d) ≤ a - c + (b - d) :=
 begin
   rw [add_comm c, tsub_le_iff_left, add_assoc, ←tsub_le_iff_left, ←tsub_le_iff_left],
@@ -287,6 +288,12 @@ begin
   simpa [hc] using h,
 end
 
+protected lemma lt_tsub_of_add_lt_right (hc : add_le_cancellable c) (h : a + c < b) : a < b - c :=
+(hc.le_tsub_of_add_le_right h.le).lt_of_ne $ by { rintro rfl, exact h.not_le le_tsub_add }
+
+protected lemma lt_tsub_of_add_lt_left (ha : add_le_cancellable a) (h : a + c < b) : c < b - a :=
+ha.lt_tsub_of_add_lt_right $ by rwa add_comm
+
 end add_le_cancellable
 
 /-! #### Lemmas where addition is order-reflecting. -/
@@ -317,6 +324,14 @@ contravariant.add_le_cancellable.lt_add_of_tsub_lt_left h
 lemma lt_add_of_tsub_lt_right (h : a - c < b) : a < b + c :=
 contravariant.add_le_cancellable.lt_add_of_tsub_lt_right h
 
+/-- This lemma (and some of its corollaries) also holds for `ennreal`, but this proof doesn't work
+for it. Maybe we should add this lemma as field to `has_ordered_sub`? -/
+lemma lt_tsub_of_add_lt_left : a + c < b → c < b - a :=
+contravariant.add_le_cancellable.lt_tsub_of_add_lt_left
+
+lemma lt_tsub_of_add_lt_right : a + c < b → a < b - c :=
+contravariant.add_le_cancellable.lt_tsub_of_add_lt_right
+
 end contra
 
 section both
@@ -334,7 +349,7 @@ by rw [add_comm a b, add_comm a c, add_tsub_add_eq_tsub_right]
 
 end both
 
-end ordered_add_comm_monoid
+end ordered_add_comm_semigroup
 
 /-! ### Lemmas in a linearly ordered monoid. -/
 section linear_order
@@ -355,8 +370,6 @@ lt_iff_lt_of_le_iff_le tsub_le_iff_left
 lemma lt_tsub_comm : a < b - c ↔ c < b - a :=
 lt_tsub_iff_left.trans lt_tsub_iff_right.symm
 
-
-
 section cov
 variable [covariant_class α α (+) (≤)]
 
@@ -368,26 +381,30 @@ end cov
 
 end linear_order
 
-/-! ### Lemmas in a canonically ordered monoid. -/
+@[to_additive] lemma mul_le_cancellable_one [monoid α] [has_le α] : mul_le_cancellable (1 : α) :=
+λ a b, by simpa only [one_mul] using id
 
-section canonically_ordered_add_monoid
-variables [canonically_ordered_add_monoid α] [has_sub α] [has_ordered_sub α] {a b c d : α}
+section ordered_add_comm_monoid
+variables [partial_order α] [add_comm_monoid α] [has_sub α] [has_ordered_sub α]
+
+@[simp] lemma tsub_zero (a : α) : a - 0 = a :=
+add_le_cancellable.tsub_eq_of_eq_add add_le_cancellable_zero (add_zero _).symm
+
+end ordered_add_comm_monoid
+
+section has_exists_add_of_le
+variables [add_comm_semigroup α] [partial_order α] [has_exists_add_of_le α]
+  [covariant_class α α (+) (≤)] [has_sub α] [has_ordered_sub α] {a b c d : α}
 
 @[simp] lemma add_tsub_cancel_of_le (h : a ≤ b) : a + (b - a) = b :=
 begin
   refine le_antisymm _ le_add_tsub,
-  obtain ⟨c, rfl⟩ := le_iff_exists_add.1 h,
+  obtain ⟨c, rfl⟩ := exists_add_of_le h,
   exact add_le_add_left add_tsub_le_left a,
 end
 
 lemma tsub_add_cancel_of_le (h : a ≤ b) : b - a + a = b :=
 by { rw [add_comm], exact add_tsub_cancel_of_le h }
-
-lemma add_tsub_cancel_iff_le : a + (b - a) = b ↔ a ≤ b :=
-⟨λ h, le_iff_exists_add.mpr ⟨b - a, h.symm⟩, add_tsub_cancel_of_le⟩
-
-lemma tsub_add_cancel_iff_le : b - a + a = b ↔ a ≤ b :=
-by { rw [add_comm], exact add_tsub_cancel_iff_le }
 
 lemma add_le_of_le_tsub_right_of_le (h : b ≤ c) (h2 : a ≤ c - b) : a + b ≤ c :=
 (add_le_add_right h2 b).trans_eq $ tsub_add_cancel_of_le h
@@ -401,63 +418,28 @@ by rw [tsub_le_iff_right, tsub_add_cancel_of_le h]
 lemma tsub_left_inj (h1 : c ≤ a) (h2 : c ≤ b) : a - c = b - c ↔ a = b :=
 by simp_rw [le_antisymm_iff, tsub_le_tsub_iff_right h1, tsub_le_tsub_iff_right h2]
 
+lemma tsub_inj_left (h₁ : a ≤ b) (h₂ : a ≤ c) : b - a = c - a → b = c := (tsub_left_inj h₁ h₂).1
+
 /-- See `lt_of_tsub_lt_tsub_right` for a stronger statement in a linear order. -/
 lemma lt_of_tsub_lt_tsub_right_of_le (h : c ≤ b) (h2 : a - c < b - c) : a < b :=
 by { refine ((tsub_le_tsub_iff_right h).mp h2.le).lt_of_ne _, rintro rfl, exact h2.false }
 
-@[simp] lemma tsub_eq_zero_iff_le : a - b = 0 ↔ a ≤ b :=
-by rw [← nonpos_iff_eq_zero, tsub_le_iff_left, add_zero]
-
-/-- One direction of `tsub_eq_zero_iff_le`, as a `@[simp]`-lemma. -/
-@[simp] lemma tsub_eq_zero_of_le (h : a ≤ b) : a - b = 0 :=
-tsub_eq_zero_iff_le.mpr h
-
-@[simp] lemma tsub_self (a : α) : a - a = 0 :=
-tsub_eq_zero_iff_le.mpr le_rfl
-
-@[simp] lemma tsub_le_self : a - b ≤ a :=
-tsub_le_iff_left.mpr $ le_add_left le_rfl
-
-@[simp] lemma tsub_zero (a : α) : a - 0 = a :=
-le_antisymm tsub_le_self $ le_add_tsub.trans_eq $ zero_add _
-
-@[simp] lemma zero_tsub (a : α) : 0 - a = 0 :=
-tsub_eq_zero_iff_le.mpr $ zero_le a
-
-lemma tsub_self_add (a b : α) : a - (a + b) = 0 :=
-by { rw [tsub_eq_zero_iff_le], apply self_le_add_right }
-
-lemma tsub_inj_left (h₁ : a ≤ b) (h₂ : a ≤ c) (h₃ : b - a = c - a) : b = c :=
-by rw [← tsub_add_cancel_of_le h₁, ← tsub_add_cancel_of_le h₂, h₃]
-
-lemma tsub_pos_iff_not_le : 0 < a - b ↔ ¬ a ≤ b :=
-by rw [pos_iff_ne_zero, ne.def, tsub_eq_zero_iff_le]
-
-lemma tsub_pos_of_lt (h : a < b) : 0 < b - a :=
-tsub_pos_iff_not_le.mpr h.not_le
-
-lemma tsub_add_tsub_cancel (hab : b ≤ a) (hbc : c ≤ b) : (a - b) + (b - c) = a - c :=
+lemma tsub_add_tsub_cancel (hab : b ≤ a) (hcb : c ≤ b) : (a - b) + (b - c) = a - c :=
 begin
   convert tsub_add_cancel_of_le (tsub_le_tsub_right hab c) using 2,
-  rw [tsub_tsub, add_tsub_cancel_of_le hbc],
+  rw [tsub_tsub, add_tsub_cancel_of_le hcb],
 end
 
 lemma tsub_tsub_tsub_cancel_right (h : c ≤ b) : (a - c) - (b - c) = a - b :=
 by rw [tsub_tsub, add_tsub_cancel_of_le h]
 
-lemma tsub_lt_of_lt (h : a < b) : a - c < b :=
-lt_of_le_of_lt tsub_le_self h
-
-/-! ### Lemmas that assume that an element is `add_le_cancellable`. -/
+/-! #### Lemmas that assume that an element is `add_le_cancellable`. -/
 
 namespace add_le_cancellable
+
 protected lemma eq_tsub_iff_add_eq_of_le (hc : add_le_cancellable c) (h : c ≤ b) :
   a = b - c ↔ a + c = b :=
-begin
-  split,
-  { rintro rfl, exact tsub_add_cancel_of_le h },
-  { rintro rfl, exact (hc.add_tsub_cancel_right).symm }
-end
+⟨by { rintro rfl, exact tsub_add_cancel_of_le h }, hc.eq_tsub_of_add_eq⟩
 
 protected lemma tsub_eq_iff_eq_add_of_le (hb : add_le_cancellable b) (h : b ≤ a) :
   a - b = c ↔ a = c + b :=
@@ -474,8 +456,7 @@ by rw [add_comm a, hb.add_tsub_assoc_of_le h, add_comm]
 
 protected lemma tsub_tsub_assoc (hbc : add_le_cancellable (b - c)) (h₁ : b ≤ a) (h₂ : c ≤ b) :
   a - (b - c) = a - b + c :=
-by rw [hbc.tsub_eq_iff_eq_add_of_le (tsub_le_self.trans h₁), add_assoc,
-  add_tsub_cancel_of_le h₂, tsub_add_cancel_of_le h₁]
+hbc.tsub_eq_of_eq_add $ by rw [add_assoc, add_tsub_cancel_of_le h₂, tsub_add_cancel_of_le h₁]
 
 protected lemma tsub_add_tsub_comm (hb : add_le_cancellable b) (hd : add_le_cancellable d)
   (hba : b ≤ a) (hdc : d ≤ c) : a - b + (c - d) = a + c - (b + d) :=
@@ -499,17 +480,6 @@ protected lemma tsub_lt_iff_right (hb : add_le_cancellable b) (hba : b ≤ a) :
   a - b < c ↔ a < c + b :=
 by { rw [add_comm], exact hb.tsub_lt_iff_left hba }
 
-protected lemma lt_tsub_of_add_lt_right (hc : add_le_cancellable c) (h : a + c < b) : a < b - c :=
-begin
-  apply lt_of_le_of_ne,
-  { rw [← add_tsub_cancel_of_le h.le, add_right_comm, add_assoc],
-    rw [hc.add_tsub_assoc_of_le], refine le_self_add, refine le_add_self },
-  { rintro rfl, apply h.not_le, exact le_tsub_add }
-end
-
-protected lemma lt_tsub_of_add_lt_left (ha : add_le_cancellable a) (h : a + c < b) : c < b - a :=
-by { apply ha.lt_tsub_of_add_lt_right, rwa add_comm }
-
 protected lemma tsub_lt_iff_tsub_lt (hb : add_le_cancellable b) (hc : add_le_cancellable c)
   (h₁ : b ≤ a) (h₂ : c ≤ a) : a - b < c ↔ a - c < b :=
 by rw [hb.tsub_lt_iff_left h₁, hc.tsub_lt_iff_right h₂]
@@ -521,12 +491,9 @@ by rw [ha.le_tsub_iff_left h₁, hc.le_tsub_iff_right h₂]
 protected lemma lt_tsub_iff_right_of_le (hc : add_le_cancellable c) (h : c ≤ b) :
   a < b - c ↔ a + c < b :=
 begin
-  refine ⟨_, hc.lt_tsub_of_add_lt_right⟩,
-  intro h2,
-  refine (add_le_of_le_tsub_right_of_le h h2.le).lt_of_ne _,
+  refine ⟨λ h', (add_le_of_le_tsub_right_of_le h h'.le).lt_of_ne _, hc.lt_tsub_of_add_lt_right⟩,
   rintro rfl,
-  apply h2.not_le,
-  rw [hc.add_tsub_cancel_right]
+  exact h'.ne' hc.add_tsub_cancel_right,
 end
 
 protected lemma lt_tsub_iff_left_of_le (hc : add_le_cancellable c) (h : c ≤ b) :
@@ -539,20 +506,6 @@ begin
   conv_lhs at h { rw [← tsub_add_cancel_of_le hca] },
   exact lt_of_add_lt_add_left (hb.lt_add_of_tsub_lt_right h),
 end
-
-protected lemma tsub_le_tsub_iff_left (ha : add_le_cancellable a) (hc : add_le_cancellable c)
-  (h : c ≤ a) : a - b ≤ a - c ↔ c ≤ b :=
-begin
-  refine ⟨_, λ h, tsub_le_tsub_left h a⟩,
-  rw [tsub_le_iff_left, ← hc.add_tsub_assoc_of_le h,
-    hc.le_tsub_iff_right (h.trans le_add_self), add_comm b],
-  apply ha,
-end
-
-protected lemma tsub_right_inj (ha : add_le_cancellable a) (hb : add_le_cancellable b)
-  (hc : add_le_cancellable c) (hba : b ≤ a) (hca : c ≤ a) : a - b = a - c ↔ b = c :=
-by simp_rw [le_antisymm_iff, ha.tsub_le_tsub_iff_left hb hba, ha.tsub_le_tsub_iff_left hc hca,
-  and_comm]
 
 protected lemma tsub_lt_tsub_right_of_le (hc : add_le_cancellable c) (h : c ≤ a) (h2 : a < b) :
   a - c < b - c :=
@@ -573,12 +526,11 @@ end
 
 @[simp] protected lemma add_tsub_tsub_cancel (hac : add_le_cancellable (a - c)) (h : c ≤ a) :
   (a + b) - (a - c) = b + c :=
-(hac.tsub_eq_iff_eq_add_of_le $ tsub_le_self.trans le_self_add).mpr $
-  by rw [add_assoc, add_tsub_cancel_of_le h, add_comm]
+hac.tsub_eq_of_eq_add $ by rw [add_assoc, add_tsub_cancel_of_le h, add_comm]
 
 protected lemma tsub_tsub_cancel_of_le (hba : add_le_cancellable (b - a)) (h : a ≤ b) :
   b - (b - a) = a :=
-by rw [hba.tsub_eq_iff_eq_add_of_le tsub_le_self, add_tsub_cancel_of_le h]
+hba.tsub_eq_of_eq_add (add_tsub_cancel_of_le h).symm
 
 end add_le_cancellable
 
@@ -617,15 +569,6 @@ contravariant.add_le_cancellable.tsub_lt_iff_left hbc
 lemma tsub_lt_iff_right (hbc : b ≤ a) : a - b < c ↔ a < c + b :=
 contravariant.add_le_cancellable.tsub_lt_iff_right hbc
 
-/-- This lemma (and some of its corollaries also holds for `ennreal`,
-  but this proof doesn't work for it.
-  Maybe we should add this lemma as field to `has_ordered_sub`? -/
-lemma lt_tsub_of_add_lt_right (h : a + c < b) : a < b - c :=
-contravariant.add_le_cancellable.lt_tsub_of_add_lt_right h
-
-lemma lt_tsub_of_add_lt_left (h : a + c < b) : c < b - a :=
-contravariant.add_le_cancellable.lt_tsub_of_add_lt_left h
-
 lemma tsub_lt_iff_tsub_lt (h₁ : b ≤ a) (h₂ : c ≤ a) : a - b < c ↔ a - c < b :=
 contravariant.add_le_cancellable.tsub_lt_iff_tsub_lt contravariant.add_le_cancellable h₁ h₂
 
@@ -644,13 +587,6 @@ contravariant.add_le_cancellable.lt_tsub_iff_left_of_le h
 lemma lt_of_tsub_lt_tsub_left_of_le  [contravariant_class α α (+) (<)]
   (hca : c ≤ a) (h : a - b < a - c) : c < b :=
 contravariant.add_le_cancellable.lt_of_tsub_lt_tsub_left_of_le hca h
-
-lemma tsub_le_tsub_iff_left (h : c ≤ a) : a - b ≤ a - c ↔ c ≤ b :=
-contravariant.add_le_cancellable.tsub_le_tsub_iff_left contravariant.add_le_cancellable h
-
-lemma tsub_right_inj (hba : b ≤ a) (hca : c ≤ a) : a - b = a - c ↔ b = c :=
-contravariant.add_le_cancellable.tsub_right_inj contravariant.add_le_cancellable
-  contravariant.add_le_cancellable hba hca
 
 lemma tsub_lt_tsub_right_of_le (h : c ≤ a) (h2 : a < b) : a - c < b - c :=
 contravariant.add_le_cancellable.tsub_lt_tsub_right_of_le h h2
@@ -672,6 +608,72 @@ lemma tsub_tsub_cancel_of_le (h : a ≤ b) : b - (b - a) = a :=
 contravariant.add_le_cancellable.tsub_tsub_cancel_of_le h
 
 end contra
+end has_exists_add_of_le
+
+/-! ### Lemmas in a canonically ordered monoid. -/
+
+section canonically_ordered_add_monoid
+variables [canonically_ordered_add_monoid α] [has_sub α] [has_ordered_sub α] {a b c d : α}
+
+lemma add_tsub_cancel_iff_le : a + (b - a) = b ↔ a ≤ b :=
+⟨λ h, le_iff_exists_add.mpr ⟨b - a, h.symm⟩, add_tsub_cancel_of_le⟩
+
+lemma tsub_add_cancel_iff_le : b - a + a = b ↔ a ≤ b :=
+by { rw [add_comm], exact add_tsub_cancel_iff_le }
+
+@[simp] lemma tsub_eq_zero_iff_le : a - b = 0 ↔ a ≤ b :=
+by rw [← nonpos_iff_eq_zero, tsub_le_iff_left, add_zero]
+
+alias tsub_eq_zero_iff_le ↔ _ tsub_eq_zero_of_le
+
+attribute [simp] tsub_eq_zero_of_le
+
+@[simp] lemma tsub_self (a : α) : a - a = 0 := tsub_eq_zero_of_le le_rfl
+
+@[simp] lemma tsub_le_self : a - b ≤ a := tsub_le_iff_left.mpr $ le_add_left le_rfl
+
+@[simp] lemma zero_tsub (a : α) : 0 - a = 0 := tsub_eq_zero_of_le $ zero_le a
+
+lemma tsub_self_add (a b : α) : a - (a + b) = 0 := tsub_eq_zero_of_le $ self_le_add_right _ _
+
+lemma tsub_pos_iff_not_le : 0 < a - b ↔ ¬ a ≤ b :=
+by rw [pos_iff_ne_zero, ne.def, tsub_eq_zero_iff_le]
+
+lemma tsub_pos_of_lt (h : a < b) : 0 < b - a := tsub_pos_iff_not_le.mpr h.not_le
+
+lemma tsub_lt_of_lt (h : a < b) : a - c < b := lt_of_le_of_lt tsub_le_self h
+
+namespace add_le_cancellable
+
+protected lemma tsub_le_tsub_iff_left (ha : add_le_cancellable a) (hc : add_le_cancellable c)
+  (h : c ≤ a) : a - b ≤ a - c ↔ c ≤ b :=
+begin
+  refine ⟨_, λ h, tsub_le_tsub_left h a⟩,
+  rw [tsub_le_iff_left, ← hc.add_tsub_assoc_of_le h, hc.le_tsub_iff_right (h.trans le_add_self),
+    add_comm b],
+  apply ha,
+end
+
+protected lemma tsub_right_inj (ha : add_le_cancellable a) (hb : add_le_cancellable b)
+  (hc : add_le_cancellable c) (hba : b ≤ a) (hca : c ≤ a) : a - b = a - c ↔ b = c :=
+by simp_rw [le_antisymm_iff, ha.tsub_le_tsub_iff_left hb hba, ha.tsub_le_tsub_iff_left hc hca,
+  and_comm]
+
+end add_le_cancellable
+
+/-! #### Lemmas where addition is order-reflecting. -/
+
+section contra
+variable [contravariant_class α α (+) (≤)]
+
+lemma tsub_le_tsub_iff_left (h : c ≤ a) : a - b ≤ a - c ↔ c ≤ b :=
+contravariant.add_le_cancellable.tsub_le_tsub_iff_left contravariant.add_le_cancellable h
+
+lemma tsub_right_inj (hba : b ≤ a) (hca : c ≤ a) : a - b = a - c ↔ b = c :=
+contravariant.add_le_cancellable.tsub_right_inj contravariant.add_le_cancellable
+  contravariant.add_le_cancellable hba hca
+
+end contra
 
 end canonically_ordered_add_monoid
 
@@ -686,7 +688,7 @@ by rw [tsub_pos_iff_not_le, not_le]
 lemma tsub_eq_tsub_min (a b : α) : a - b = a - min a b :=
 begin
   cases le_total a b with h h,
-  { rw [min_eq_left h, tsub_self, tsub_eq_zero_iff_le.mpr h] },
+  { rw [min_eq_left h, tsub_self, tsub_eq_zero_of_le h] },
   { rw [min_eq_right h] },
 end
 
@@ -747,7 +749,7 @@ end contra
 lemma tsub_add_eq_max : a - b + b = max a b :=
 begin
   cases le_total a b with h h,
-  { rw [max_eq_right h, tsub_eq_zero_iff_le.mpr h, zero_add] },
+  { rw [max_eq_right h, tsub_eq_zero_of_le h, zero_add] },
   { rw [max_eq_left h, tsub_add_cancel_of_le h] }
 end
 
@@ -757,7 +759,7 @@ by rw [add_comm, max_comm, tsub_add_eq_max]
 lemma tsub_min : a - min a b = a - b :=
 begin
   cases le_total a b with h h,
-  { rw [min_eq_left h, tsub_self, tsub_eq_zero_iff_le.mpr h] },
+  { rw [min_eq_left h, tsub_self, tsub_eq_zero_of_le h] },
   { rw [min_eq_right h] }
 end
 

--- a/src/algebra/order/sub.lean
+++ b/src/algebra/order/sub.lean
@@ -135,6 +135,10 @@ lemma tsub_le_tsub (hab : a ≤ b) (hcd : c ≤ d) : a - d ≤ b - c :=
 lemma add_tsub_le_assoc : a + b - c ≤ a + (b - c) :=
 by { rw [tsub_le_iff_left, add_left_comm], exact add_le_add_left le_add_tsub a }
 
+/-- See `tsub_add_eq_add_tsub` for the equality. -/
+lemma tsub_add_le_right_comm : a + b - c ≤ a - c + b :=
+by { rw [add_comm, add_comm _ b], exact add_tsub_le_assoc }
+
 lemma add_le_add_add_tsub : a + b ≤ (a + c) + (b - c) :=
 by { rw [add_assoc], exact add_le_add_left le_add_tsub a }
 
@@ -158,6 +162,22 @@ tsub_le_iff_right.2 $ calc
     a ≤ a - b + b : le_tsub_add
   ... ≤ a - b + (c + (b - c)) : add_le_add_left le_add_tsub _
   ... = a - b + c + (b - c) : (add_assoc _ _ _).symm
+
+lemma add_tsub_add_le_tsub_add_tsub : a + b - (c + d) ≤ a - c + (b - d) :=
+begin
+  rw [add_comm c, tsub_le_iff_left, add_assoc, ←tsub_le_iff_left, ←tsub_le_iff_left],
+  refine (tsub_le_tsub_right add_tsub_le_assoc c).trans _,
+  rw [add_comm a, add_comm (a - c)],
+  exact add_tsub_le_assoc,
+end
+
+/-- See `add_tsub_add_eq_tsub_left` for the equality. -/
+lemma add_tsub_add_le_tsub_left : a + b - (a + c) ≤ b - c :=
+by { rw [tsub_le_iff_left, add_assoc], exact add_le_add_left le_add_tsub _ }
+
+/-- See `add_tsub_add_eq_tsub_right` for the equality. -/
+lemma add_tsub_add_le_tsub_right : a + c - (b + c) ≤ a - b :=
+by { rw [tsub_le_iff_left, add_right_comm], exact add_le_add_right le_add_tsub c }
 
 end cov
 
@@ -221,33 +241,13 @@ begin
   { rw [tsub_le_iff_left, add_assoc, ← tsub_le_iff_left, ← tsub_le_iff_left] }
 end
 
-section cov
-variable [covariant_class α α (+) (≤)]
-
-lemma tsub_add_eq_tsub_tsub (a b c : α) : a - (b + c) = a - b - c :=
-begin
-  refine le_antisymm (tsub_le_iff_left.mpr _)
-    (tsub_le_iff_left.mpr $ tsub_le_iff_left.mpr _),
-  { rw [add_assoc], refine le_trans le_add_tsub (add_le_add_left le_add_tsub _) },
-  { rw [← add_assoc], apply le_add_tsub }
-end
+lemma tsub_add_eq_tsub_tsub (a b c : α) : a - (b + c) = a - b - c := (tsub_tsub _ _ _).symm
 
 lemma tsub_add_eq_tsub_tsub_swap (a b c : α) : a - (b + c) = a - c - b :=
 by { rw [add_comm], apply tsub_add_eq_tsub_tsub }
 
 lemma tsub_right_comm : a - b - c = a - c - b :=
 by simp_rw [← tsub_add_eq_tsub_tsub, add_comm]
-
-lemma add_tsub_add_le_tsub_add_tsub :
-  (a + b) - (c + d) ≤ (a - c) + (b - d) :=
-begin
-  rw [add_comm c, ← tsub_tsub],
-  refine (tsub_le_tsub_right add_tsub_le_assoc c).trans _,
-  rw [add_comm a, add_comm (a - c)],
-  exact add_tsub_le_assoc
-end
-
-end cov
 
 /-! ### Lemmas that assume that an element is `add_le_cancellable`. -/
 
@@ -324,12 +324,9 @@ variables [covariant_class α α (+) (≤)] [contravariant_class α α (+) (≤)
 
 lemma add_tsub_add_eq_tsub_right (a c b : α) : (a + c) - (b + c) = a - b :=
 begin
-  apply le_antisymm,
-  { rw [tsub_le_iff_left, add_right_comm], exact add_le_add_right le_add_tsub c },
-  { rw [tsub_le_iff_left, add_comm b],
-    apply le_of_add_le_add_right,
-    rw [add_assoc],
-    exact le_tsub_add }
+  refine add_tsub_add_le_tsub_right.antisymm (tsub_le_iff_right.2 $ le_of_add_le_add_right _), swap,
+  rw add_assoc,
+  exact le_tsub_add,
 end
 
 lemma add_tsub_add_eq_tsub_left (a b c : α) : (a + b) - (a + c) = b - c :=

--- a/src/algebra/order/sub.lean
+++ b/src/algebra/order/sub.lean
@@ -136,7 +136,7 @@ lemma add_tsub_le_assoc : a + b - c ≤ a + (b - c) :=
 by { rw [tsub_le_iff_left, add_left_comm], exact add_le_add_left le_add_tsub a }
 
 /-- See `tsub_add_eq_add_tsub` for the equality. -/
-lemma tsub_add_le_right_comm : a + b - c ≤ a - c + b :=
+lemma add_tsub_le_tsub_add : a + b - c ≤ a - c + b :=
 by { rw [add_comm, add_comm _ b], exact add_tsub_le_assoc }
 
 lemma add_le_add_add_tsub : a + b ≤ (a + c) + (b - c) :=

--- a/src/algebra/order/sub.lean
+++ b/src/algebra/order/sub.lean
@@ -381,9 +381,6 @@ end cov
 
 end linear_order
 
-@[to_additive] lemma mul_le_cancellable_one [monoid α] [has_le α] : mul_le_cancellable (1 : α) :=
-λ a b, by simpa only [one_mul] using id
-
 section ordered_add_comm_monoid
 variables [partial_order α] [add_comm_monoid α] [has_sub α] [has_ordered_sub α]
 

--- a/src/data/list/basic.lean
+++ b/src/data/list/basic.lean
@@ -1408,7 +1408,7 @@ lemma modify_nth_tail_modify_nth_tail_le
   (l.modify_nth_tail f n).modify_nth_tail g m =
     l.modify_nth_tail (λl, (f l).modify_nth_tail g (m - n)) n :=
 begin
-  rcases le_iff_exists_add.1 h with ⟨m, rfl⟩,
+  rcases exists_add_of_le h with ⟨m, rfl⟩,
   rw [add_tsub_cancel_left, add_comm, modify_nth_tail_modify_nth_tail]
 end
 

--- a/src/data/nat/fib.lean
+++ b/src/data/nat/fib.lean
@@ -77,7 +77,7 @@ by rw [fib_add_two, add_tsub_cancel_right]
 
 lemma fib_lt_fib_succ {n : ℕ} (hn : 2 ≤ n) : fib n < fib (n + 1) :=
 begin
-  rcases le_iff_exists_add.1 hn with ⟨n, rfl⟩,
+  rcases exists_add_of_le hn with ⟨n, rfl⟩,
   rw [← tsub_pos_iff_lt, add_comm 2, fib_add_two_sub_fib_add_one],
   apply fib_pos (succ_pos n),
 end

--- a/src/data/real/nnreal.lean
+++ b/src/data/real/nnreal.lean
@@ -357,7 +357,7 @@ ordered_comm_monoid.to_covariant_class_left ℝ≥0
 lemma le_of_forall_pos_le_add {a b : ℝ≥0} (h : ∀ε, 0 < ε → a ≤ b + ε) : a ≤ b :=
 le_of_forall_le_of_dense $ assume x hxb,
 begin
-  rcases le_iff_exists_add.1 (le_of_lt hxb) with ⟨ε, rfl⟩,
+  rcases exists_add_of_le (le_of_lt hxb) with ⟨ε, rfl⟩,
   exact h _ ((lt_add_iff_pos_right b).1 hxb)
 end
 

--- a/src/order/order_iso_nat.lean
+++ b/src/order/order_iso_nat.lean
@@ -148,7 +148,7 @@ theorem exists_increasing_or_nonincreasing_subseq (r : α → α → Prop) [is_t
 begin
   obtain ⟨g, hr | hnr⟩ := exists_increasing_or_nonincreasing_subseq' r f,
   { refine ⟨g, or.intro_left _ (λ m n mn, _)⟩,
-    obtain ⟨x, rfl⟩ := le_iff_exists_add.1 (nat.succ_le_iff.2 mn),
+    obtain ⟨x, rfl⟩ := exists_add_of_le (nat.succ_le_iff.2 mn),
     induction x with x ih,
     { apply hr },
     { apply is_trans.trans _ _ _ _ (hr _),

--- a/src/order/well_founded_set.lean
+++ b/src/order/well_founded_set.lean
@@ -663,7 +663,7 @@ begin
   by_cases hn : n < g 0,
   { apply hf1.2 m n mn,
     rwa [if_pos hn, if_pos (mn.trans hn)] at hmn },
-  { obtain ⟨n', rfl⟩ := le_iff_exists_add.1 (not_lt.1 hn),
+  { obtain ⟨n', rfl⟩ := exists_add_of_le (not_lt.1 hn),
     rw [if_neg hn, add_comm (g 0) n', add_tsub_cancel_right] at hmn,
     split_ifs at hmn with hm hm,
     { apply hf1.2 m (g n') (lt_of_lt_of_le hm (g.monotone n'.zero_le)),

--- a/src/ring_theory/polynomial/eisenstein.lean
+++ b/src/ring_theory/polynomial/eisenstein.lean
@@ -115,7 +115,7 @@ lemma exists_mem_adjoin_mul_eq_pow_nat_degree_le {x : S} (hx : aeval x f = 0)
   ∃ y ∈ adjoin R ({x} : set S), (algebra_map R S) p * y = x ^ i :=
 begin
   intros i hi,
-  obtain ⟨k, hk⟩ := le_iff_exists_add.1 hi,
+  obtain ⟨k, hk⟩ := exists_add_of_le hi,
   rw [hk, pow_add],
   obtain ⟨y, hy, H⟩ := exists_mem_adjoin_mul_eq_pow_nat_degree hx hmo hf,
   refine ⟨y * x ^ k, _, _⟩,
@@ -131,7 +131,7 @@ lemma pow_nat_degree_le_of_root_of_monic_mem {x : R} (hroot : is_root f x) (hmo 
   ∀ i, f.nat_degree ≤ i → x ^ i ∈ 𝓟 :=
 begin
   intros i hi,
-  obtain ⟨k, hk⟩ := le_iff_exists_add.1 hi,
+  obtain ⟨k, hk⟩ := exists_add_of_le hi,
   rw [hk, pow_add],
   suffices : x ^ f.nat_degree ∈ 𝓟,
   { exact mul_mem_right (x ^ k) 𝓟 this },
@@ -147,7 +147,7 @@ lemma pow_nat_degree_le_of_aeval_zero_of_monic_mem_map {x : S} (hx : aeval x f =
 begin
   suffices : x ^ (f.map (algebra_map R S)).nat_degree ∈ 𝓟.map (algebra_map R S),
   { intros i hi,
-    obtain ⟨k, hk⟩ := le_iff_exists_add.1 hi,
+    obtain ⟨k, hk⟩ := exists_add_of_le hi,
     rw [hk, pow_add],
     refine mul_mem_right _ _ this },
   rw [aeval_def, eval₂_eq_eval_map, ← is_root.def] at hx,


### PR DESCRIPTION
Generalize many lemmas from `canonically_ordered_add_monoid` to `has_exists_add_of_le`, and a few other generalizations.

### New lemmas
* `mul_le_cancellable_one`/`add_le_cancellable_zero`
* `tsub_add_le_right_comm`
* `add_tsub_add_le_tsub_left`
* `add_tsub_add_le_tsub_right`

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

I checked by hand that I didn't add any other lemma and that no lemma was lost.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
