### PR TITLE
[Merged by Bors] - feat(tactic/ext): don't remove attr

### DIFF
--- a/src/tactic/ext.lean
+++ b/src/tactic/ext.lean
@@ -296,10 +296,8 @@ meta def extensional_attribute : user_attribute unit (option name) :=
 { name := `ext,
   descr := "lemmas usable by `ext` tactic",
   parser := optional ident,
-  before_unset := some $ λ _ _, pure (),
   after_set := some $ λ n _ b, do
     add ← extensional_attribute.get_param n,
-    unset_attribute `ext n,
     e ← get_env,
     n ← if (e.structure_fields n).is_some
       then derive_struct_ext_lemma n


### PR DESCRIPTION
In #8785 the ext attribute was changed to try to remove itself after it is applied, unfortunately this is not possible however.
The command `unset_attribute` is not persistent, as seen in https://github.com/leanprover-community/lean/blob/bf12a6c9b74846b532a248617eae692d2c13f18b/src/library/tactic/user_attribute.cpp#L365.
This means that even though it appears that a declaration doesn't have the `ext` attribute when `#print`ed immediately after, the attribute reappears after the namespace is closed
This leads to weird discrepancies like the following: 
https://leanprover-community.github.io/mathlib_docs/topology/algebra/open_subgroup.html#open_subgroup.ext
where the `to_additive` version of the lemma doesn't have the `ext` attribute in doc-gen (as it is copied immediately, so before the end of the current scope), but the original does have the attribute, as it only temporarily didn't.

To resolve this we simply give up on removing the `ext` attribute.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
