### PR TITLE
[Merged by Bors] - refactor(logic/equiv/nat): remove `equiv.nat_prod_nat_equiv_nat`

### DIFF
--- a/src/data/countable/basic.lean
+++ b/src/data/countable/basic.lean
@@ -60,7 +60,7 @@ instance [countable α] [countable β] : countable (α × β) :=
 begin
   rcases exists_injective_nat α with ⟨f, hf⟩,
   rcases exists_injective_nat β with ⟨g, hg⟩,
-  exact (equiv.nat_prod_nat_equiv_nat.injective.comp $ hf.prod_map hg).countable
+  exact (nat.mkpair_equiv.injective.comp $ hf.prod_map hg).countable
 end
 
 instance [countable α] [Π a, countable (π a)] : countable (sigma π) :=

--- a/src/logic/equiv/nat.lean
+++ b/src/logic/equiv/nat.lean
@@ -20,16 +20,6 @@ namespace equiv
 variables {α : Type*}
 
 /--
-An equivalence between `ℕ × ℕ` and `ℕ`, using the `mkpair` and `unpair` functions in
-`data.nat.pairing`.
--/
-@[simp] def nat_prod_nat_equiv_nat : ℕ × ℕ ≃ ℕ :=
-⟨λ p, nat.mkpair p.1 p.2,
- nat.unpair,
- λ p, begin cases p, apply nat.unpair_mkpair end,
- nat.mkpair_unpair⟩
-
-/--
 An equivalence between `bool × ℕ` and `ℕ`, by mapping `(tt, x)` to `2 * x + 1` and `(ff, x)` to
 `2 * x`.
 -/
@@ -56,7 +46,7 @@ An equivalence between `α × α` and `α`, given that there is an equivalence b
 -/
 def prod_equiv_of_equiv_nat (e : α ≃ ℕ) : α × α ≃ α :=
 calc α × α ≃ ℕ × ℕ : prod_congr e e
-      ...  ≃ ℕ     : nat_prod_nat_equiv_nat
+      ...  ≃ ℕ     : mkpair_equiv
       ...  ≃ α     : e.symm
 
 /--

--- a/src/measure_theory/measure/outer_measure.lean
+++ b/src/measure_theory/measure/outer_measure.lean
@@ -533,12 +533,12 @@ let μ := λs, ⨅{f : ℕ → set α} (h : s ⊆ ⋃i, f i), ∑'i, m (f i) in
           (by simpa using (hε' i).ne'),
       simpa [μ, infi_lt_iff] },
     refine le_trans _ (ennreal.tsum_le_tsum $ λ i, le_of_lt (hf i).2),
-    rw [← ennreal.tsum_prod, ← equiv.nat_prod_nat_equiv_nat.symm.tsum_eq],
+    rw [← ennreal.tsum_prod, ← nat.mkpair_equiv.symm.tsum_eq],
     swap, {apply_instance},
     refine infi_le_of_le _ (infi_le _ _),
     exact Union_subset (λ i, subset.trans (hf i).1 $
       Union_subset $ λ j, subset.trans (by simp) $
-      subset_Union _ $ equiv.nat_prod_nat_equiv_nat (i, j)),
+      subset_Union _ $ nat.mkpair_equiv (i, j)),
   end }
 
 lemma of_function_apply (s : set α) :


### PR DESCRIPTION
This is a duplicate of `nat.mkpair_equiv`.

---
See [Zulip poll](https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/naming.20contest/near/290046428).

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
