### PR TITLE
refactor(data/nat/pairing): rename `mkpair_equiv` to `equiv.nat_prod_nat_equiv_nat`

### DIFF
--- a/src/data/nat/pairing.lean
+++ b/src/data/nat/pairing.lean
@@ -63,15 +63,15 @@ begin
     simp [unpair, ae, nat.not_lt_zero, add_assoc] }
 end
 
-/-- An equivalence between `ℕ × ℕ` and `ℕ`. -/
-@[simps { fully_applied := ff }] def mkpair_equiv : ℕ × ℕ ≃ ℕ :=
+/-- An equivalence between `ℕ × ℕ` and `ℕ`, using the `mkpair` and `unpair` functions. -/
+@[simps { fully_applied := ff }] def _root_.equiv.nat_prod_nat_equiv_nat : ℕ × ℕ ≃ ℕ :=
 ⟨uncurry mkpair, unpair, λ ⟨a, b⟩, unpair_mkpair a b, mkpair_unpair⟩
 
 lemma surjective_unpair : surjective unpair :=
-mkpair_equiv.symm.surjective
+equiv.nat_prod_nat_equiv_nat.symm.surjective
 
 @[simp] lemma mkpair_eq_mkpair {a b c d : ℕ} : mkpair a b = mkpair c d ↔ a = c ∧ b = d :=
-mkpair_equiv.injective.eq_iff.trans (@prod.ext_iff ℕ ℕ (a, b) (c, d))
+equiv.nat_prod_nat_equiv_nat.injective.eq_iff.trans (@prod.ext_iff ℕ ℕ (a, b) (c, d))
 
 theorem unpair_lt {n : ℕ} (n1 : 1 ≤ n) : (unpair n).1 < n :=
 let s := sqrt n in begin

--- a/src/logic/equiv/nat.lean
+++ b/src/logic/equiv/nat.lean
@@ -20,16 +20,6 @@ namespace equiv
 variables {α : Type*}
 
 /--
-An equivalence between `ℕ × ℕ` and `ℕ`, using the `mkpair` and `unpair` functions in
-`data.nat.pairing`.
--/
-@[simp] def nat_prod_nat_equiv_nat : ℕ × ℕ ≃ ℕ :=
-⟨λ p, nat.mkpair p.1 p.2,
- nat.unpair,
- λ p, begin cases p, apply nat.unpair_mkpair end,
- nat.mkpair_unpair⟩
-
-/--
 An equivalence between `bool × ℕ` and `ℕ`, by mapping `(tt, x)` to `2 * x + 1` and `(ff, x)` to
 `2 * x`.
 -/


### PR DESCRIPTION
Drop the duplicate definition of `equiv.nat_prod_nat_equiv_nat` from
`logic.equiv.nat`.

---

Conflicts with #15509, see [Zulip poll](https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/naming.20contest/near/290046428).
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
