### PR TITLE
[Merged by Bors] - feat(linear_algebra/symplectic_group): add definition of symplectic group

### DIFF
--- a/src/algebra/lie/classical.lean
+++ b/src/algebra/lie/classical.lean
@@ -119,13 +119,10 @@ end special_linear
 
 namespace symplectic
 
-/-- The matrix defining the canonical skew-symmetric bilinear form. -/
-def J : matrix (l ⊕ l) (l ⊕ l) R := matrix.from_blocks 0 (-1) 1 0
-
 /-- The symplectic Lie algebra: skew-adjoint matrices with respect to the canonical skew-symmetric
 bilinear form. -/
 def sp [fintype l] : lie_subalgebra R (matrix (l ⊕ l) (l ⊕ l) R) :=
-  skew_adjoint_matrices_lie_subalgebra (J l R)
+  skew_adjoint_matrices_lie_subalgebra (matrix.J l R)
 
 end symplectic
 

--- a/src/algebra/lie/classical.lean
+++ b/src/algebra/lie/classical.lean
@@ -9,6 +9,7 @@ import data.matrix.dmatrix
 import algebra.lie.abelian
 import linear_algebra.matrix.trace
 import algebra.lie.skew_adjoint
+import linear_algebra.symplectic_group
 
 /-!
 # Classical Lie algebras

--- a/src/data/matrix/block.lean
+++ b/src/data/matrix/block.lean
@@ -183,6 +183,13 @@ begin
   ext i j, rcases i; rcases j; simp [from_blocks],
 end
 
+lemma from_blocks_neg [has_neg R]
+  (A : matrix n l R) (B : matrix n m R) (C : matrix o l R) (D : matrix o m R) :
+  - (from_blocks A B C D) = from_blocks (-A) (-B) (-C) (-D) :=
+begin
+  ext i j, cases i; cases j; simp [from_blocks],
+end
+
 lemma from_blocks_add [has_add α]
   (A  : matrix n l α) (B  : matrix n m α) (C  : matrix o l α) (D  : matrix o m α)
   (A' : matrix n l α) (B' : matrix n m α) (C' : matrix o l α) (D' : matrix o m α) :

--- a/src/linear_algebra/symplectic_group.lean
+++ b/src/linear_algebra/symplectic_group.lean
@@ -226,11 +226,7 @@ end
 
 lemma inv_eq_symplectic_inv (A : matrix (l ⊕ l) (l ⊕ l) R) (hA : A ∈ symplectic_group l R) :
   A⁻¹ = - (J l R) ⬝ Aᵀ ⬝ (J l R) :=
-begin
-  have H := inv_left_mul_aux hA,
-  simp only [←matrix.neg_mul] at H,
-  exact inv_eq_left_inv H
-end
+inv_eq_left_inv (by simp only [matrix.neg_mul, inv_left_mul_aux hA])
 
 instance : group (symplectic_group l R) :=
 { mul_left_inv :=

--- a/src/linear_algebra/symplectic_group.lean
+++ b/src/linear_algebra/symplectic_group.lean
@@ -58,7 +58,7 @@ begin
   exact neg_neg 1,
 end
 
-lemma J_det_mul_J_det [rc : fact (ring_char R ≠ 2)] : (det (J l R)) * (det (J l R)) = 1 :=
+lemma J_det_mul_J_det : (det (J l R)) * (det (J l R)) = 1 :=
 begin
   rw [←det_mul, J_squared],
   rw [←one_smul R (-1 : matrix _ _ R)],
@@ -177,7 +177,7 @@ instance : has_inv (symplectic_group l R) :=
   mul_mem (mul_mem (neg_mem $ J_mem _ _) $ transpose_mem A.2) $ J_mem _ _⟩ }
 
 @[simp] lemma coe_inv (A : symplectic_group l R) :
-  (↑(A⁻¹) : matrix _ _ _) = - (J l R) ⬝ (A : matrix (l ⊕ l) (l ⊕ l) R)ᵀ ⬝ (J l R) := rfl
+  - (J l R) ⬝ (A : matrix (l ⊕ l) (l ⊕ l) R)ᵀ ⬝ (J l R) = (↑(A⁻¹) : matrix _ _ _) := rfl
 
 lemma inv_left_mul_aux (hA : A ∈ symplectic_group l R) :
   -(J l R ⬝ Aᵀ ⬝ J l R ⬝ A) = 1 :=
@@ -191,7 +191,7 @@ calc -(J l R ⬝ Aᵀ ⬝ J l R ⬝ A)
 lemma coe_inv' (A : symplectic_group l R) : (↑(A⁻¹) : matrix (l ⊕ l) (l ⊕ l) R) = A⁻¹ :=
 begin
   refine (coe_inv A).trans (inv_eq_left_inv _).symm,
-  simp only [matrix.neg_mul, inv_left_mul_aux, set_like.coe_mem],
+  simp only [matrix.neg_mul, inv_left_mul_aux, set_like.coe_mem, ← coe_inv],
 end
 
 lemma inv_eq_symplectic_inv (A : matrix (l ⊕ l) (l ⊕ l) R) (hA : A ∈ symplectic_group l R) :
@@ -202,7 +202,7 @@ instance : group (symplectic_group l R) :=
 { mul_left_inv := λ A,
   begin
     apply subtype.ext,
-    simp only [submonoid.coe_one, submonoid.coe_mul, matrix.neg_mul, coe_inv],
+    simp only [submonoid.coe_one, submonoid.coe_mul, matrix.neg_mul, ← coe_inv],
     change -(J l R ⬝ (↑A)ᵀ ⬝ J l R) ⬝ ↑A = 1,
     rw matrix.neg_mul,
     exact inv_left_mul_aux A.2,

--- a/src/linear_algebra/symplectic_group.lean
+++ b/src/linear_algebra/symplectic_group.lean
@@ -175,7 +175,7 @@ instance : has_inv (symplectic_group l R) :=
   mul_mem (mul_mem (neg_mem $ J_mem _ _) $ transpose_mem A.2) $ J_mem _ _⟩ }
 
 @[simp] lemma coe_inv (A : symplectic_group l R) :
-  -(J l R ⬝ (↑A)ᵀ ⬝ J l R) = (↑(A⁻¹) : matrix _ _ _) := by {iterate {rw [← matrix.neg_mul]}, refl}
+  (↑(A⁻¹) : matrix _ _ _) = - J l R ⬝ (↑A)ᵀ ⬝ J l R := rfl
 
 lemma inv_left_mul_aux (hA : A ∈ symplectic_group l R) :
   -(J l R ⬝ Aᵀ ⬝ J l R ⬝ A) = 1 :=
@@ -188,8 +188,8 @@ calc -(J l R ⬝ Aᵀ ⬝ J l R ⬝ A)
 
 lemma coe_inv' (A : symplectic_group l R) : (↑(A⁻¹) : matrix (l ⊕ l) (l ⊕ l) R) = A⁻¹ :=
 begin
-  refine (coe_inv A).symm.trans (inv_eq_left_inv _).symm,
-  simp only [matrix.neg_mul, inv_left_mul_aux, set_like.coe_mem, ← coe_inv],
+  refine (coe_inv A).trans (inv_eq_left_inv _).symm,
+  simp only [matrix.neg_mul, inv_left_mul_aux, set_like.coe_mem, coe_inv],
 end
 
 lemma inv_eq_symplectic_inv (A : matrix (l ⊕ l) (l ⊕ l) R) (hA : A ∈ symplectic_group l R) :
@@ -200,7 +200,7 @@ instance : group (symplectic_group l R) :=
 { mul_left_inv := λ A,
   begin
     apply subtype.ext,
-    simp only [submonoid.coe_one, submonoid.coe_mul, matrix.neg_mul, ← coe_inv],
+    simp only [submonoid.coe_one, submonoid.coe_mul, matrix.neg_mul, coe_inv],
     change -(J l R ⬝ (↑A)ᵀ ⬝ J l R) ⬝ ↑A = 1,
     rw matrix.neg_mul,
     exact inv_left_mul_aux A.2,

--- a/src/linear_algebra/symplectic_group.lean
+++ b/src/linear_algebra/symplectic_group.lean
@@ -108,8 +108,7 @@ variables (l) (R)
 
 lemma J_mem : (J l R) ∈ symplectic_group l R :=
 begin
-  rw mem_iff,
-  rw [J, from_blocks_multiply, from_blocks_transpose, from_blocks_multiply],
+  rw [mem_iff, J, from_blocks_multiply, from_blocks_transpose, from_blocks_multiply],
   simp,
 end
 
@@ -174,7 +173,7 @@ instance : has_inv (symplectic_group l R) :=
 { inv := λ A, ⟨- (J l R) ⬝ (A : matrix (l ⊕ l) (l ⊕ l) R)ᵀ ⬝ (J l R),
   mul_mem (mul_mem (neg_mem $ J_mem _ _) $ transpose_mem A.2) $ J_mem _ _⟩ }
 
-@[simp] lemma coe_inv (A : symplectic_group l R) :
+lemma coe_inv (A : symplectic_group l R) :
   (↑(A⁻¹) : matrix _ _ _) = - J l R ⬝ (↑A)ᵀ ⬝ J l R := rfl
 
 lemma inv_left_mul_aux (hA : A ∈ symplectic_group l R) :
@@ -189,7 +188,7 @@ calc -(J l R ⬝ Aᵀ ⬝ J l R ⬝ A)
 lemma coe_inv' (A : symplectic_group l R) : (↑(A⁻¹) : matrix (l ⊕ l) (l ⊕ l) R) = A⁻¹ :=
 begin
   refine (coe_inv A).trans (inv_eq_left_inv _).symm,
-  simp only [matrix.neg_mul, inv_left_mul_aux, set_like.coe_mem, coe_inv],
+  simp [inv_left_mul_aux, coe_inv],
 end
 
 lemma inv_eq_symplectic_inv (A : matrix (l ⊕ l) (l ⊕ l) R) (hA : A ∈ symplectic_group l R) :
@@ -201,8 +200,7 @@ instance : group (symplectic_group l R) :=
   begin
     apply subtype.ext,
     simp only [submonoid.coe_one, submonoid.coe_mul, matrix.neg_mul, coe_inv],
-    change -(J l R ⬝ (↑A)ᵀ ⬝ J l R) ⬝ ↑A = 1,
-    rw matrix.neg_mul,
+    rw [matrix.mul_eq_mul, matrix.neg_mul],
     exact inv_left_mul_aux A.2,
   end,
   .. symplectic_group.has_inv,

--- a/src/linear_algebra/symplectic_group.lean
+++ b/src/linear_algebra/symplectic_group.lean
@@ -68,7 +68,7 @@ begin
   exact even_add_self _
 end
 
-lemma is_unit_det_J [fact (ring_char R ≠ 2)] : is_unit (det (J l R)) :=
+lemma is_unit_det_J : is_unit (det (J l R)) :=
 is_unit_iff_exists_inv.mpr ⟨det (J l R), J_det_mul_J_det _ _⟩
 
 end J_matrix_lemmas
@@ -130,8 +130,6 @@ begin
   simp [h],
 end
 
-variables [fact (ring_char R ≠ 2)]
-
 lemma symplectic_det (hA : A ∈ symplectic_group l R) : is_unit $ det A :=
 begin
   rw is_unit_iff_exists_inv,
@@ -177,7 +175,7 @@ instance : has_inv (symplectic_group l R) :=
   mul_mem (mul_mem (neg_mem $ J_mem _ _) $ transpose_mem A.2) $ J_mem _ _⟩ }
 
 @[simp] lemma coe_inv (A : symplectic_group l R) :
-  - (J l R) ⬝ (A : matrix (l ⊕ l) (l ⊕ l) R)ᵀ ⬝ (J l R) = (↑(A⁻¹) : matrix _ _ _) := rfl
+  -(J l R ⬝ (↑A)ᵀ ⬝ J l R) = (↑(A⁻¹) : matrix _ _ _) := by {iterate {rw [← matrix.neg_mul]}, refl}
 
 lemma inv_left_mul_aux (hA : A ∈ symplectic_group l R) :
   -(J l R ⬝ Aᵀ ⬝ J l R ⬝ A) = 1 :=
@@ -190,7 +188,7 @@ calc -(J l R ⬝ Aᵀ ⬝ J l R ⬝ A)
 
 lemma coe_inv' (A : symplectic_group l R) : (↑(A⁻¹) : matrix (l ⊕ l) (l ⊕ l) R) = A⁻¹ :=
 begin
-  refine (coe_inv A).trans (inv_eq_left_inv _).symm,
+  refine (coe_inv A).symm.trans (inv_eq_left_inv _).symm,
   simp only [matrix.neg_mul, inv_left_mul_aux, set_like.coe_mem, ← coe_inv],
 end
 

--- a/src/linear_algebra/symplectic_group.lean
+++ b/src/linear_algebra/symplectic_group.lean
@@ -1,13 +1,9 @@
-import algebra.lie.classical
 import data.real.basic
-import linear_algebra.matrix.determinant
+import linear_algebra.matrix.nonsingular_inverse
 
 open_locale matrix
 
-variables {R l : Type*}
-
-open lie_algebra.symplectic
-
+variables {l R : Type*}
 
 section J_matrix_lemmas
 
@@ -34,7 +30,7 @@ begin
   norm_num,
 end
 
-variables [comm_ring R]
+variables (R) [comm_ring R]
 
 /-- The matrix defining the canonical skew-symmetric bilinear form. -/
 def J : matrix (l ⊕ l) (l ⊕ l) R := matrix.from_blocks 0 (-1) 1 0
@@ -95,8 +91,7 @@ end J_matrix_lemmas
 
 
 
-
-open lie_algebra.symplectic matrix
+open matrix
 
 variables (l) [decidable_eq l] [fintype l]
 
@@ -144,8 +139,9 @@ variables (A B : symplectic_group l)
 
 @[simp] lemma one_apply : ⇑(1 : symplectic_group l) = (1 : matrix (l ⊕ l) (l ⊕ l)  ℝ) := rfl
 
-lemma mul_mem {A B : matrix (l ⊕ l) (l ⊕ l) ℝ} (hA : A ∈ symplectic_group l) (hB : B ∈ symplectic_group l) :
-A ⬝ B ∈ symplectic_group l :=
+lemma mul_mem {A B : matrix (l ⊕ l) (l ⊕ l) ℝ}
+  (hA : A ∈ symplectic_group l) (hB : B ∈ symplectic_group l) :
+  A ⬝ B ∈ symplectic_group l :=
 submonoid.mul_mem _ hA hB
 
 end coe_lemmas
@@ -217,8 +213,10 @@ begin
   calc Aᵀ ⬝ J l ℝ ⬝ A
       = - Aᵀ ⬝ (J l ℝ)⁻¹ ⬝ A  : by {rw J_inv, simp}
   ... = - Aᵀ ⬝ (A ⬝ J l ℝ ⬝ Aᵀ)⁻¹ ⬝ A : by rw hA
-  ... = - (Aᵀ ⬝ (Aᵀ⁻¹ ⬝ (J l ℝ)⁻¹)) ⬝ A⁻¹ ⬝ A : by simp only [matrix.mul_inv_rev, matrix.mul_assoc, matrix.neg_mul]
-  ... = - (J l ℝ)⁻¹ : by rw [mul_nonsing_inv_cancel_left _ _ huAT, nonsing_inv_mul_cancel_right _ _ huA]
+  ... = - (Aᵀ ⬝ (Aᵀ⁻¹ ⬝ (J l ℝ)⁻¹)) ⬝ A⁻¹ ⬝ A : by simp only [matrix.mul_inv_rev,
+                                                              matrix.mul_assoc, matrix.neg_mul]
+  ... = - (J l ℝ)⁻¹ : by rw [mul_nonsing_inv_cancel_left _ _ huAT,
+                             nonsing_inv_mul_cancel_right _ _ huA]
   ... = (J l ℝ) : by simp [J_inv]
 end
 
@@ -239,7 +237,8 @@ instance : has_inv (symplectic_group l) := {
     mul_mem (mul_mem (neg_mem $ J_mem l) $ transpose_mem A.2) $ J_mem _⟩,
 }
 
-@[simp] lemma coe_inv (A : symplectic_group l): (↑(A⁻¹) : matrix _ _ _) = - (J l ℝ) ⬝ Aᵀ ⬝ (J l ℝ) := rfl
+@[simp] lemma coe_inv (A : symplectic_group l): (↑(A⁻¹) : matrix _ _ _) = - (J l ℝ) ⬝ Aᵀ ⬝ (J l ℝ)
+  := rfl
 
 @[simp] lemma inv_apply (A : symplectic_group l): ⇑(A⁻¹) = - (J l ℝ) ⬝ Aᵀ ⬝ (J l ℝ) := rfl
 

--- a/src/linear_algebra/symplectic_group.lean
+++ b/src/linear_algebra/symplectic_group.lean
@@ -1,5 +1,25 @@
+/-
+Copyright (c) 2022 Matej Penciak. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Matej Penciak, Moritz Doll, Fabien Clery
+-/
+
 import data.real.basic
 import linear_algebra.matrix.nonsingular_inverse
+
+/-!
+# The Symplectic Group
+
+## Main Definitions
+
+`J`
+`symplectic_group`
+
+## Implementation Notes
+
+## TODO
+* Fill in all this stuff
+-/
 
 open_locale matrix
 
@@ -9,7 +29,7 @@ section J_matrix_lemmas
 
 namespace matrix
 
-variables (l) [decidable_eq l] [fintype l]
+variables (l) [decidable_eq l]
 
 lemma neg_one : (-1 : matrix l l ℝ)  = (-1 : ℝ) • 1  := by simp only [neg_smul, one_smul]
 
@@ -43,6 +63,8 @@ begin
   simp [from_blocks],
 end
 
+variables [fintype l]
+
 lemma J_squared : (J l ℝ) ⬝ (J l ℝ) = -1 :=
 begin
   unfold J,
@@ -60,11 +82,10 @@ end
 
 lemma J_det : det (J l ℝ) = 1 ∨ det (J l ℝ) = - 1:=
 begin
-  have H : (det (J l ℝ)) * (det (J l ℝ)) = 1 := by {
-    rw [←det_mul, J_squared, neg_one, det_smul],
+  have H : (det (J l ℝ)) * (det (J l ℝ)) = 1 := by
+  { rw [←det_mul, J_squared, neg_one, det_smul],
     simp only [fintype.card_sum, det_one, mul_one],
-    rw minus_powers,
-  },
+    rw minus_powers },
   rw [←sq_eq_one_iff, pow_two],
   exact H,
 end
@@ -75,17 +96,11 @@ end matrix
 
 end J_matrix_lemmas
 
-
-
-
-
-
-
-
 open matrix
 
 variables (l) [decidable_eq l] [fintype l]
 
+/-- TODO: Fill in this docstring -/
 def symplectic_group : submonoid (matrix (l ⊕ l) (l ⊕ l)  ℝ) :=
 { carrier := { A | A ⬝ (J l ℝ) ⬝ Aᵀ = J l ℝ},
   mul_mem' :=
@@ -110,14 +125,6 @@ instance coe_matrix : has_coe (symplectic_group l) (matrix (l ⊕ l) (l ⊕ l)  
 instance coe_fun : has_coe_to_fun (symplectic_group l) (λ _, (l ⊕ l) → (l ⊕ l) → ℝ) :=
 { coe := λ A, A.val }
 
-
-
-
-
-
-
-
-
 section coe_lemmas
 
 variables (A B : symplectic_group l)
@@ -137,14 +144,6 @@ submonoid.mul_mem _ hA hB
 
 end coe_lemmas
 
-
-
-
-
-
-
-
-
 section symplectic_J
 
 variables (l)
@@ -157,6 +156,7 @@ begin
   simp,
 end
 
+/-- TODO: Fill in this doc string -/
 def sym_J : symplectic_group l := ⟨J l ℝ, J_mem l⟩
 
 variables {l}
@@ -166,13 +166,6 @@ variables {l}
 @[simp] lemma J_apply : ⇑(sym_J l) = J l ℝ := rfl
 
 end symplectic_J
-
-
-
-
-
-
-
 
 variables {A : matrix (l ⊕ l) (l ⊕ l) ℝ}
 
@@ -223,10 +216,9 @@ lemma transpose_mem_iff : Aᵀ ∈ symplectic_group l ↔ A ∈ symplectic_group
 lemma mem_iff' : A ∈ symplectic_group l ↔ Aᵀ ⬝ (J l ℝ) ⬝ A = J l ℝ :=
 by rw [←transpose_mem_iff, mem_iff, transpose_transpose]
 
-instance : has_inv (symplectic_group l) := {
-  inv := λ A, ⟨- (J l ℝ) ⬝ Aᵀ ⬝ (J l ℝ),
-    mul_mem (mul_mem (neg_mem $ J_mem l) $ transpose_mem A.2) $ J_mem _⟩,
-}
+instance : has_inv (symplectic_group l) :=
+{ inv := λ A, ⟨- (J l ℝ) ⬝ Aᵀ ⬝ (J l ℝ),
+  mul_mem (mul_mem (neg_mem $ J_mem l) $ transpose_mem A.2) $ J_mem _⟩ }
 
 @[simp] lemma coe_inv (A : symplectic_group l): (↑(A⁻¹) : matrix _ _ _) = - (J l ℝ) ⬝ Aᵀ ⬝ (J l ℝ)
   := rfl
@@ -242,8 +234,8 @@ calc -(J l ℝ ⬝ Aᵀ ⬝ J l ℝ ⬝ A)
 ... = (-1 : ℝ) • -1 : by rw J_squared
 ... = 1 : by simp only [neg_smul_neg, one_smul]
 
-instance : group (symplectic_group l) := {
-  mul_left_inv :=
+instance : group (symplectic_group l) :=
+{ mul_left_inv :=
   begin
     intro A,
     apply subtype.ext,
@@ -251,7 +243,6 @@ instance : group (symplectic_group l) := {
     exact inv_left_mul_aux A.2,
   end,
   .. symplectic_group.has_inv,
-  .. submonoid.to_monoid _
-}
+  .. submonoid.to_monoid _ }
 
 end symplectic_group

--- a/src/linear_algebra/symplectic_group.lean
+++ b/src/linear_algebra/symplectic_group.lean
@@ -4,7 +4,7 @@ import linear_algebra.matrix.determinant
 
 open_locale matrix
 
-variables {l : Type*}
+variables {R l : Type*}
 
 open lie_algebra.symplectic
 
@@ -33,6 +33,11 @@ begin
   exact even_add_self n,
   norm_num,
 end
+
+variables [comm_ring R]
+
+/-- The matrix defining the canonical skew-symmetric bilinear form. -/
+def J : matrix (l ⊕ l) (l ⊕ l) R := matrix.from_blocks 0 (-1) 1 0
 
 @[simp] lemma J_transpose : (J l ℝ)ᵀ = - (J l ℝ) :=
 begin

--- a/src/linear_algebra/symplectic_group.lean
+++ b/src/linear_algebra/symplectic_group.lean
@@ -218,6 +218,16 @@ calc -(J l R ⬝ Aᵀ ⬝ J l R ⬝ A)
 ... = (-1 : R) • -1 : by rw J_squared
 ... = 1 : by simp only [neg_smul_neg, one_smul]
 
+lemma coe_inv' (A : symplectic_group l R) : (↑(A⁻¹) : matrix (l ⊕ l) (l ⊕ l) R) = A⁻¹ :=
+begin
+  rw coe_inv,
+  apply eq.symm,
+  apply inv_eq_left_inv,
+  simp only [matrix.neg_mul],
+  apply inv_left_mul_aux,
+  simp only [set_like.coe_mem],
+end
+
 lemma inv_eq_symplectic_inv (A : matrix (l ⊕ l) (l ⊕ l) R) (hA : A ∈ symplectic_group l R) :
   A⁻¹ = - (J l R) ⬝ Aᵀ ⬝ (J l R) :=
 begin

--- a/src/linear_algebra/symplectic_group.lean
+++ b/src/linear_algebra/symplectic_group.lean
@@ -77,12 +77,6 @@ begin
   exact even_add_self _
 end
 
-lemma J_det [rc : fact (ring_char R ≠ 2)] : det (J l R) = 1 ∨ det (J l R) = - 1:=
-begin
-  rw [←sq_eq_one_iff, pow_two],
-  exact J_det_mul_J_det _ _,
-end
-
 lemma J_det_unit [fact (ring_char R ≠ 2)] : is_unit (det (J l R)) :=
 is_unit_iff_exists_inv.mpr ⟨det (J l R), J_det_mul_J_det _ _⟩
 

--- a/src/linear_algebra/symplectic_group.lean
+++ b/src/linear_algebra/symplectic_group.lean
@@ -95,7 +95,7 @@ end matrix
 
 end J_matrix_lemmas
 
-open matrix
+namespace matrix
 
 variables (l) (R) [decidable_eq l] [fintype l] [comm_ring R]
 
@@ -111,9 +111,13 @@ def symplectic_group : submonoid (matrix (l ⊕ l) (l ⊕ l)  R) :=
   end,
   one_mem' := by simp }
 
-variables {l} {R}
+end matrix
 
 namespace symplectic_group
+
+variables {l} {R} [decidable_eq l] [fintype l] [comm_ring R]
+
+open matrix
 
 lemma mem_iff {A : matrix (l ⊕ l) (l ⊕ l)  R} :
   A ∈ symplectic_group l R ↔ A ⬝ (J l R) ⬝ Aᵀ = J l R :=

--- a/src/linear_algebra/symplectic_group.lean
+++ b/src/linear_algebra/symplectic_group.lean
@@ -125,21 +125,14 @@ by simp [symplectic_group]
 
 instance coe_matrix : has_coe (symplectic_group l R) (matrix (l ⊕ l) (l ⊕ l)  R) := ⟨subtype.val⟩
 
-instance coe_fun : has_coe_to_fun (symplectic_group l R) (λ _, (l ⊕ l) → (l ⊕ l) → R) :=
-{ coe := λ A, A.val }
-
 section coe_lemmas
 
 variables (A B : symplectic_group l R)
 
-@[simp] lemma mul_val : ↑(A * B) = A ⬝ B := rfl
-
-@[simp] lemma mul_apply : ⇑(A * B) = (A ⬝ B) := rfl
+@[simp] lemma mul_val : ↑(A * B) = (A : matrix (l ⊕ l) (l ⊕ l) R) ⬝ (B : matrix (l ⊕ l) (l ⊕ l) R)
+:= rfl
 
 @[simp] lemma one_val : ↑(1 : symplectic_group l R) = (1 : matrix (l ⊕ l) (l ⊕ l)  R) := rfl
-
-@[simp] lemma one_apply : ⇑(1 : symplectic_group l R) = (1 : matrix (l ⊕ l) (l ⊕ l)  R) := rfl
-
 
 lemma mul_mem {A B : matrix (l ⊕ l) (l ⊕ l) R}
   (hA : A ∈ symplectic_group l R) (hB : B ∈ symplectic_group l R) :
@@ -160,14 +153,12 @@ begin
   simp,
 end
 
-/-- TODO: The canonical skew-symmetric matrix as an element in the symplectic group. -/
+/-- The canonical skew-symmetric matrix as an element in the symplectic group. -/
 def sym_J : symplectic_group l R := ⟨J l R, J_mem l R⟩
 
 variables {l} {R}
 
 @[simp] lemma coe_J : ↑(sym_J l R) = J l R := rfl
-
-@[simp] lemma J_apply : ⇑(sym_J l R) = J l R := rfl
 
 end symplectic_J
 
@@ -225,13 +216,11 @@ lemma mem_iff' : A ∈ symplectic_group l R ↔ Aᵀ ⬝ (J l R) ⬝ A = J l R :
 by rw [←transpose_mem_iff, mem_iff, transpose_transpose]
 
 instance : has_inv (symplectic_group l R) :=
-{ inv := λ A, ⟨- (J l R) ⬝ Aᵀ ⬝ (J l R),
+{ inv := λ A, ⟨- (J l R) ⬝ (A : matrix (l ⊕ l) (l ⊕ l) R)ᵀ ⬝ (J l R),
   mul_mem (mul_mem (neg_mem $ J_mem _ _) $ transpose_mem A.2) $ J_mem _ _⟩ }
 
 @[simp] lemma coe_inv (A : symplectic_group l R) :
-  (↑(A⁻¹) : matrix _ _ _) = - (J l R) ⬝ Aᵀ ⬝ (J l R) := rfl
-
-@[simp] lemma inv_apply (A : symplectic_group l R): ⇑(A⁻¹) = - (J l R) ⬝ Aᵀ ⬝ (J l R) := rfl
+  (↑(A⁻¹) : matrix _ _ _) = - (J l R) ⬝ (A : matrix (l ⊕ l) (l ⊕ l) R)ᵀ ⬝ (J l R) := rfl
 
 lemma inv_left_mul_aux {A : matrix (l ⊕ l) (l ⊕ l) R} (hA : A ∈ symplectic_group l R) :
   -(J l R ⬝ Aᵀ ⬝ J l R ⬝ A) = 1 :=
@@ -247,7 +236,7 @@ instance : group (symplectic_group l R) :=
   begin
     intro A,
     apply subtype.ext,
-    simp only [mul_val, inv_apply, matrix.neg_mul, one_val],
+    simp only [mul_val, one_val, matrix.neg_mul, coe_inv],
     exact inv_left_mul_aux A.2,
   end,
   .. symplectic_group.has_inv,

--- a/src/linear_algebra/symplectic_group.lean
+++ b/src/linear_algebra/symplectic_group.lean
@@ -10,14 +10,18 @@ import linear_algebra.matrix.nonsingular_inverse
 /-!
 # The Symplectic Group
 
+This file defines the symplectic group and proves elementary properties.
+
 ## Main Definitions
 
-`J`
-`symplectic_group`
+`matrix.J`: the canonical `2n × 2n` skew-symmetric matrix
+`symplectic_group`: the group of symplectic matrices
 
 ## Implementation Notes
 
 ## TODO
+* Every symplectic matrix has determinant 1
+* For `n = 1` the symplectic group coincides with the special linear group
 * Fill in all this stuff
 -/
 
@@ -33,9 +37,7 @@ variables (l) [decidable_eq l]
 
 lemma neg_one : (-1 : matrix l l ℝ)  = (-1 : ℝ) • 1  := by simp only [neg_smul, one_smul]
 
-lemma neg_one_transpose : (-1 : matrix l l ℝ)ᵀ = -1 := by rw [transpose_neg, transpose_one]
-
-lemma pm_one_unit {S : Type*} [ring S] {x : S} (h : x = 1 ∨ x = -1) : is_unit x :=
+lemma pm_one_unit [ring R] {x : R} (h : x = 1 ∨ x = -1) : is_unit x :=
 begin
   cases h,
   { simp only [h, is_unit_one] },
@@ -55,17 +57,17 @@ variables (R) [comm_ring R]
 /-- The matrix defining the canonical skew-symmetric bilinear form. -/
 def J : matrix (l ⊕ l) (l ⊕ l) R := matrix.from_blocks 0 (-1) 1 0
 
-@[simp] lemma J_transpose : (J l ℝ)ᵀ = - (J l ℝ) :=
+@[simp] lemma J_transpose : (J l R)ᵀ = - (J l R) :=
 begin
   unfold J,
-  rw [from_blocks_transpose, ←neg_one_smul ℝ (from_blocks _ _ _ _), from_blocks_smul,
-      matrix.transpose_zero, matrix.transpose_one,  neg_one_transpose],
+  rw [from_blocks_transpose, ←neg_one_smul R (from_blocks _ _ _ _), from_blocks_smul,
+      matrix.transpose_zero, matrix.transpose_one, transpose_neg],
   simp [from_blocks],
 end
 
 variables [fintype l]
 
-lemma J_squared : (J l ℝ) ⬝ (J l ℝ) = -1 :=
+lemma J_squared : (J l R) ⬝ (J l R) = -1 :=
 begin
   unfold J,
   rw from_blocks_multiply,
@@ -73,24 +75,30 @@ begin
   rw [← neg_zero, ← matrix.from_blocks_neg,← from_blocks_one],
 end
 
-lemma J_inv : (J l ℝ)⁻¹ = -(J l ℝ) :=
+lemma J_inv : (J l R)⁻¹ = -(J l R) :=
 begin
   refine matrix.inv_eq_right_inv _,
   rw [matrix.mul_neg, J_squared],
   exact neg_neg 1,
 end
 
-lemma J_det : det (J l ℝ) = 1 ∨ det (J l ℝ) = - 1:=
+variables [no_zero_divisors R]
+
+lemma J_det : det (J l R) = 1 ∨ det (J l R) = - 1:=
 begin
-  have H : (det (J l ℝ)) * (det (J l ℝ)) = 1 := by
-  { rw [←det_mul, J_squared, neg_one, det_smul],
+  have H : (det (J l R)) * (det (J l R)) = 1 := by
+  { rw [←det_mul, J_squared],
+    rw [←one_smul R (-1 : matrix _ _ R)],
+    rw [smul_neg, ←neg_smul, det_smul],
     simp only [fintype.card_sum, det_one, mul_one],
-    rw minus_powers },
+    rw neg_one_pow_eq_one_iff_even,
+    exact even_add_self _,
+    sorry,  },
   rw [←sq_eq_one_iff, pow_two],
   exact H,
 end
 
-lemma J_det_unit : is_unit (det (J l ℝ)) := pm_one_unit (J_det l)
+lemma J_det_unit : is_unit (det (J l R)) := pm_one_unit (J_det l R)
 
 end matrix
 
@@ -98,11 +106,11 @@ end J_matrix_lemmas
 
 open matrix
 
-variables (l) [decidable_eq l] [fintype l]
+variables (l) (R) [decidable_eq l] [fintype l] [comm_ring R]
 
-/-- TODO: Fill in this docstring -/
-def symplectic_group : submonoid (matrix (l ⊕ l) (l ⊕ l)  ℝ) :=
-{ carrier := { A | A ⬝ (J l ℝ) ⬝ Aᵀ = J l ℝ},
+/-- The group of symplectic matrices over a ring `R`. -/
+def symplectic_group : submonoid (matrix (l ⊕ l) (l ⊕ l)  R) :=
+{ carrier := { A | A ⬝ (J l R) ⬝ Aᵀ = J l R},
   mul_mem' :=
   begin
     intros a b ha hb,
@@ -116,30 +124,32 @@ variables {l}
 
 namespace symplectic_group
 
-lemma mem_iff {A : matrix (l ⊕ l) (l ⊕ l)  ℝ} :
-  A ∈ symplectic_group l ↔ A ⬝ (J l ℝ) ⬝ Aᵀ = J l ℝ :=
+lemma mem_iff {A : matrix (l ⊕ l) (l ⊕ l)  R} :
+  A ∈ symplectic_group l R ↔ A ⬝ (J l R) ⬝ Aᵀ = J l R :=
 by simp [symplectic_group]
 
-instance coe_matrix : has_coe (symplectic_group l) (matrix (l ⊕ l) (l ⊕ l)  ℝ) := ⟨subtype.val⟩
+instance coe_matrix : has_coe (symplectic_group l R) (matrix (l ⊕ l) (l ⊕ l)  R) := ⟨subtype.val⟩
 
-instance coe_fun : has_coe_to_fun (symplectic_group l) (λ _, (l ⊕ l) → (l ⊕ l) → ℝ) :=
+instance coe_fun : has_coe_to_fun (symplectic_group l R) (λ _, (l ⊕ l) → (l ⊕ l) → R) :=
 { coe := λ A, A.val }
 
 section coe_lemmas
 
-variables (A B : symplectic_group l)
+variables (A B : symplectic_group l R)
 
 @[simp] lemma mul_val : ↑(A * B) = A ⬝ B := rfl
 
 @[simp] lemma mul_apply : ⇑(A * B) = (A ⬝ B) := rfl
 
-@[simp] lemma one_val : ↑(1 : symplectic_group l) = (1 : matrix (l ⊕ l) (l ⊕ l)  ℝ) := rfl
+@[simp] lemma one_val : ↑(1 : symplectic_group l R) = (1 : matrix (l ⊕ l) (l ⊕ l)  R) := rfl
 
-@[simp] lemma one_apply : ⇑(1 : symplectic_group l) = (1 : matrix (l ⊕ l) (l ⊕ l)  ℝ) := rfl
+@[simp] lemma one_apply : ⇑(1 : symplectic_group l R) = (1 : matrix (l ⊕ l) (l ⊕ l)  R) := rfl
 
-lemma mul_mem {A B : matrix (l ⊕ l) (l ⊕ l) ℝ}
-  (hA : A ∈ symplectic_group l) (hB : B ∈ symplectic_group l) :
-  A ⬝ B ∈ symplectic_group l :=
+variables {R}
+
+lemma mul_mem {A B : matrix (l ⊕ l) (l ⊕ l) R}
+  (hA : A ∈ symplectic_group l R) (hB : B ∈ symplectic_group l R) :
+  A ⬝ B ∈ symplectic_group l R :=
 submonoid.mul_mem _ hA hB
 
 end coe_lemmas
@@ -148,7 +158,7 @@ section symplectic_J
 
 variables (l)
 
-lemma J_mem : (J l ℝ) ∈ symplectic_group l :=
+lemma J_mem : (J l R) ∈ symplectic_group l R :=
 begin
   rw mem_iff,
   unfold J,
@@ -157,26 +167,28 @@ begin
 end
 
 /-- TODO: Fill in this doc string -/
-def sym_J : symplectic_group l := ⟨J l ℝ, J_mem l⟩
+def sym_J : symplectic_group l R := ⟨J l R, J_mem l R⟩
 
 variables {l}
 
-@[simp] lemma coe_J : ↑(sym_J l) = J l ℝ := rfl
+@[simp] lemma coe_J : ↑(sym_J l R) = J l R := rfl
 
-@[simp] lemma J_apply : ⇑(sym_J l) = J l ℝ := rfl
+@[simp] lemma J_apply : ⇑(sym_J l R) = J l R := rfl
 
 end symplectic_J
 
-variables {A : matrix (l ⊕ l) (l ⊕ l) ℝ}
+variables [no_zero_divisors R]
+variables {R} {A : matrix (l ⊕ l) (l ⊕ l) R}
 
-lemma symplectic_det (hA : A ∈ symplectic_group l) : is_unit $ det A :=
+lemma symplectic_det (hA : A ∈ symplectic_group l R) : is_unit $ det A :=
 begin
   rw mem_iff at hA,
   apply_fun det at hA,
   simp only [det_mul, det_transpose] at hA,
-  have H := J_det l,
+  have H := J_det l R,
   cases H,
-  { rw [H, mul_one, ←sq, sq_eq_one_iff] at hA,
+  {
+    rw [H, mul_one, ←sq, sq_eq_one_iff] at hA,
     exact pm_one_unit hA },
   { rw H at hA,
   simp only [mul_neg, mul_one, neg_mul, neg_inj] at hA,
@@ -184,7 +196,7 @@ begin
   exact pm_one_unit hA },
 end
 
-lemma transpose_mem (hA : A ∈ symplectic_group l) : Aᵀ ∈ symplectic_group l :=
+lemma transpose_mem (hA : A ∈ symplectic_group l R) : Aᵀ ∈ symplectic_group l R :=
 begin
   rw mem_iff at ⊢ hA,
   rw transpose_transpose,
@@ -194,47 +206,47 @@ begin
     rw matrix.det_transpose,
     exact huA,
   end,
-  calc Aᵀ ⬝ J l ℝ ⬝ A
-      = - Aᵀ ⬝ (J l ℝ)⁻¹ ⬝ A  : by {rw J_inv, simp}
-  ... = - Aᵀ ⬝ (A ⬝ J l ℝ ⬝ Aᵀ)⁻¹ ⬝ A : by rw hA
-  ... = - (Aᵀ ⬝ (Aᵀ⁻¹ ⬝ (J l ℝ)⁻¹)) ⬝ A⁻¹ ⬝ A : by simp only [matrix.mul_inv_rev,
+  calc Aᵀ ⬝ J l R ⬝ A
+      = - Aᵀ ⬝ (J l R)⁻¹ ⬝ A  : by {rw J_inv, simp}
+  ... = - Aᵀ ⬝ (A ⬝ J l R ⬝ Aᵀ)⁻¹ ⬝ A : by rw hA
+  ... = - (Aᵀ ⬝ (Aᵀ⁻¹ ⬝ (J l R)⁻¹)) ⬝ A⁻¹ ⬝ A : by simp only [matrix.mul_inv_rev,
                                                               matrix.mul_assoc, matrix.neg_mul]
-  ... = - (J l ℝ)⁻¹ : by rw [mul_nonsing_inv_cancel_left _ _ huAT,
+  ... = - (J l R)⁻¹ : by rw [mul_nonsing_inv_cancel_left _ _ huAT,
                              nonsing_inv_mul_cancel_right _ _ huA]
-  ... = (J l ℝ) : by simp [J_inv]
+  ... = (J l R) : by simp [J_inv]
 end
 
-lemma neg_mem (h : A ∈ symplectic_group l) : -A ∈ symplectic_group l :=
+lemma neg_mem (h : A ∈ symplectic_group l R) : -A ∈ symplectic_group l R :=
 begin
   rw mem_iff at h ⊢,
   simp [h],
 end
 
-lemma transpose_mem_iff : Aᵀ ∈ symplectic_group l ↔ A ∈ symplectic_group l :=
+lemma transpose_mem_iff : Aᵀ ∈ symplectic_group l R ↔ A ∈ symplectic_group l R :=
 ⟨λ hA, by simpa using transpose_mem hA , transpose_mem⟩
 
-lemma mem_iff' : A ∈ symplectic_group l ↔ Aᵀ ⬝ (J l ℝ) ⬝ A = J l ℝ :=
+lemma mem_iff' : A ∈ symplectic_group l R ↔ Aᵀ ⬝ (J l R) ⬝ A = J l R :=
 by rw [←transpose_mem_iff, mem_iff, transpose_transpose]
 
-instance : has_inv (symplectic_group l) :=
-{ inv := λ A, ⟨- (J l ℝ) ⬝ Aᵀ ⬝ (J l ℝ),
-  mul_mem (mul_mem (neg_mem $ J_mem l) $ transpose_mem A.2) $ J_mem _⟩ }
+instance : has_inv (symplectic_group l R) :=
+{ inv := λ A, ⟨- (J l R) ⬝ Aᵀ ⬝ (J l R),
+  mul_mem (mul_mem (neg_mem $ J_mem l R) $ transpose_mem A.2) $ J_mem _ R⟩ }
 
-@[simp] lemma coe_inv (A : symplectic_group l): (↑(A⁻¹) : matrix _ _ _) = - (J l ℝ) ⬝ Aᵀ ⬝ (J l ℝ)
+@[simp] lemma coe_inv (A : symplectic_group l R): (↑(A⁻¹) : matrix _ _ _) = - (J l R) ⬝ Aᵀ ⬝ (J l R)
   := rfl
 
-@[simp] lemma inv_apply (A : symplectic_group l): ⇑(A⁻¹) = - (J l ℝ) ⬝ Aᵀ ⬝ (J l ℝ) := rfl
+@[simp] lemma inv_apply (A : symplectic_group l R): ⇑(A⁻¹) = - (J l R) ⬝ Aᵀ ⬝ (J l R) := rfl
 
-lemma inv_left_mul_aux {A : matrix (l ⊕ l) (l ⊕ l) ℝ} (hA : A ∈ symplectic_group l) :
-  -(J l ℝ ⬝ Aᵀ ⬝ J l ℝ ⬝ A) = 1 :=
-calc -(J l ℝ ⬝ Aᵀ ⬝ J l ℝ ⬝ A)
-    = - J l ℝ ⬝ (Aᵀ ⬝ J l ℝ ⬝ A) : by simp only [matrix.mul_assoc, matrix.neg_mul]
-... = - J l ℝ ⬝ J l ℝ : by {rw mem_iff' at hA, rw hA}
-... = (-1 : ℝ) • (J l ℝ ⬝ J l ℝ) : by simp only [matrix.neg_mul, neg_smul, one_smul]
-... = (-1 : ℝ) • -1 : by rw J_squared
+lemma inv_left_mul_aux {A : matrix (l ⊕ l) (l ⊕ l) R} (hA : A ∈ symplectic_group l R) :
+  -(J l R ⬝ Aᵀ ⬝ J l R ⬝ A) = 1 :=
+calc -(J l R ⬝ Aᵀ ⬝ J l R ⬝ A)
+    = - J l R ⬝ (Aᵀ ⬝ J l R ⬝ A) : by simp only [matrix.mul_assoc, matrix.neg_mul]
+... = - J l R ⬝ J l R : by {rw mem_iff' at hA, rw hA}
+... = (-1 : R) • (J l R ⬝ J l R) : by simp only [matrix.neg_mul, neg_smul, one_smul]
+... = (-1 : R) • -1 : by rw J_squared
 ... = 1 : by simp only [neg_smul_neg, one_smul]
 
-instance : group (symplectic_group l) :=
+instance : group (symplectic_group l R) :=
 { mul_left_inv :=
   begin
     intro A,

--- a/src/linear_algebra/symplectic_group.lean
+++ b/src/linear_algebra/symplectic_group.lean
@@ -18,9 +18,9 @@ lemma neg_one_transpose : (-1 : matrix l l ℝ)ᵀ = -1 := by rw [transpose_neg,
 lemma pm_one_unit {S : Type*} [ring S] {x : S} (h : x = 1 ∨ x = -1) : is_unit x :=
 begin
   cases h,
-  {simp only [h, is_unit_one],},
+  { simp only [h, is_unit_one] },
   { use -1,
-    simp only [h, units.coe_neg_one]}
+    simp only [h, units.coe_neg_one] }
 end
 
 lemma minus_powers (n : ℕ) : (-1 : ℝ)^(n + n) = 1 :=
@@ -65,17 +65,8 @@ begin
     simp only [fintype.card_sum, det_one, mul_one],
     rw minus_powers,
   },
-  have H2 : (det (J l ℝ))^2 = 1 := by {
-    unfold pow, -- MP: What to do with these?
-    unfold monoid.npow,
-    unfold ring.npow,
-    unfold comm_ring.npow,
-    unfold npow_rec,
-    rw mul_one,
-    exact H,
-  } ,
-  rw ←sq_eq_one_iff,
-  exact H2,
+  rw [←sq_eq_one_iff, pow_two],
+  exact H,
 end
 
 lemma J_det_unit : is_unit (det (J l ℝ)) := pm_one_unit (J_det l)

--- a/src/linear_algebra/symplectic_group.lean
+++ b/src/linear_algebra/symplectic_group.lean
@@ -65,7 +65,7 @@ begin
 end
 
 variables (R)
-variables [no_zero_divisors R] [nontrivial R]
+variables [nontrivial R]
 
 lemma J_det_mul_J_det [rc : fact (ring_char R ≠ 2)] : (det (J l R)) * (det (J l R)) = 1 :=
 begin

--- a/src/linear_algebra/symplectic_group.lean
+++ b/src/linear_algebra/symplectic_group.lean
@@ -20,22 +20,13 @@ This file defines the symplectic group and proves elementary properties.
 ## Implementation Notes
 
 ## TODO
-* Every symplectic matrix has determinant 1
-* For `n = 1` the symplectic group coincides with the special linear group
-* Fill in all this stuff
+* Every symplectic matrix has determinant 1.
+* For `n = 1` the symplectic group coincides with the special linear group.
 -/
 
 open_locale matrix
 
 variables {l R : Type*}
-
-section J_matrix_lemmas
-
-namespace matrix
-
-variables (l) [decidable_eq l]
-
-lemma neg_one : (-1 : matrix l l ℝ)  = (-1 : ℝ) • 1  := by simp only [neg_smul, one_smul]
 
 lemma pm_one_unit [ring R] {x : R} (h : x = 1 ∨ x = -1) : is_unit x :=
 begin
@@ -45,12 +36,11 @@ begin
     simp only [h, units.coe_neg_one] }
 end
 
-lemma minus_powers (n : ℕ) : (-1 : ℝ)^(n + n) = 1 :=
-begin
-  rw neg_one_pow_eq_one_iff_even,
-  exact even_add_self n,
-  norm_num,
-end
+section J_matrix_lemmas
+
+namespace matrix
+
+variables (l) [decidable_eq l]
 
 variables (R) [comm_ring R]
 
@@ -61,7 +51,7 @@ def J : matrix (l ⊕ l) (l ⊕ l) R := matrix.from_blocks 0 (-1) 1 0
 begin
   unfold J,
   rw [from_blocks_transpose, ←neg_one_smul R (from_blocks _ _ _ _), from_blocks_smul,
-      matrix.transpose_zero, matrix.transpose_one, transpose_neg],
+    matrix.transpose_zero, matrix.transpose_one, transpose_neg],
   simp [from_blocks],
 end
 
@@ -166,7 +156,7 @@ begin
   simp,
 end
 
-/-- TODO: Fill in this doc string -/
+/-- TODO: The canonical skew-symmetric matrix as an element in the symplectic group. -/
 def sym_J : symplectic_group l R := ⟨J l R, J_mem l R⟩
 
 variables {l} {R}
@@ -198,9 +188,9 @@ begin
   { rw [H, mul_one, ←sq, sq_eq_one_iff] at hA,
     exact pm_one_unit hA },
   { rw H at hA,
-  simp only [mul_neg, mul_one, neg_mul, neg_inj] at hA,
-  rw [←sq, sq_eq_one_iff] at hA,
-  exact pm_one_unit hA },
+    simp only [mul_neg, mul_one, neg_mul, neg_inj] at hA,
+    rw [←sq, sq_eq_one_iff] at hA,
+    exact pm_one_unit hA },
 end
 
 lemma transpose_mem (hA : A ∈ symplectic_group l R) :
@@ -223,7 +213,6 @@ begin
                              nonsing_inv_mul_cancel_right _ _ huA]
   ... = (J l R) : by simp [J_inv]
 end
-
 
 lemma transpose_mem_iff : Aᵀ ∈ symplectic_group l R ↔ A ∈ symplectic_group l R :=
 ⟨λ hA, by simpa using transpose_mem hA , transpose_mem⟩

--- a/src/linear_algebra/symplectic_group.lean
+++ b/src/linear_algebra/symplectic_group.lean
@@ -220,12 +220,8 @@ calc -(J l R ⬝ Aᵀ ⬝ J l R ⬝ A)
 
 lemma coe_inv' (A : symplectic_group l R) : (↑(A⁻¹) : matrix (l ⊕ l) (l ⊕ l) R) = A⁻¹ :=
 begin
-  rw coe_inv,
-  apply eq.symm,
-  apply inv_eq_left_inv,
-  simp only [matrix.neg_mul],
-  apply inv_left_mul_aux,
-  simp only [set_like.coe_mem],
+  refine (coe_inv A).trans (inv_eq_left_inv _).symm,
+  simp only [matrix.neg_mul, inv_left_mul_aux, set_like.coe_mem],
 end
 
 lemma inv_eq_symplectic_inv (A : matrix (l ⊕ l) (l ⊕ l) R) (hA : A ∈ symplectic_group l R) :

--- a/src/linear_algebra/symplectic_group.lean
+++ b/src/linear_algebra/symplectic_group.lean
@@ -28,14 +28,6 @@ open_locale matrix
 
 variables {l R : Type*}
 
-lemma pm_one_unit [ring R] {x : R} (h : x = 1 ∨ x = -1) : is_unit x :=
-begin
-  cases h,
-  { simp only [h, is_unit_one] },
-  { use -1,
-    simp only [h, units.coe_neg_one] }
-end
-
 section J_matrix_lemmas
 
 namespace matrix
@@ -178,17 +170,15 @@ variables [fact (ring_char R ≠ 2)]
 
 lemma symplectic_det (hA : A ∈ symplectic_group l R) : is_unit $ det A :=
 begin
+  rw is_unit_iff_exists_inv,
+  use A.det,
+  refine (J_det_unit l R).mul_left_cancel _,
+  rw [mul_one],
   rw mem_iff at hA,
   apply_fun det at hA,
   simp only [det_mul, det_transpose] at hA,
-  have H := J_det l R,
-  cases H,
-  { rw [H, mul_one, ←sq, sq_eq_one_iff] at hA,
-    exact pm_one_unit hA },
-  { rw H at hA,
-    simp only [mul_neg, mul_one, neg_mul, neg_inj] at hA,
-    rw [←sq, sq_eq_one_iff] at hA,
-    exact pm_one_unit hA },
+  rw [mul_comm A.det, mul_assoc] at hA,
+  exact hA,
 end
 
 lemma transpose_mem (hA : A ∈ symplectic_group l R) :

--- a/src/linear_algebra/symplectic_group.lean
+++ b/src/linear_algebra/symplectic_group.lean
@@ -159,7 +159,7 @@ begin
   simp [h],
 end
 
-variables [no_zero_divisors R] [nontrivial R]
+variables [nontrivial R]
 variables [fact (ring_char R ≠ 2)]
 
 lemma symplectic_det (hA : A ∈ symplectic_group l R) : is_unit $ det A :=

--- a/src/linear_algebra/symplectic_group.lean
+++ b/src/linear_algebra/symplectic_group.lean
@@ -218,6 +218,14 @@ calc -(J l R ⬝ Aᵀ ⬝ J l R ⬝ A)
 ... = (-1 : R) • -1 : by rw J_squared
 ... = 1 : by simp only [neg_smul_neg, one_smul]
 
+lemma inv_eq_symplectic_inv (A : matrix (l ⊕ l) (l ⊕ l) R) (hA : A ∈ symplectic_group l R) :
+  A⁻¹ = - (J l R) ⬝ Aᵀ ⬝ (J l R) :=
+begin
+  have H := inv_left_mul_aux hA,
+  simp only [←matrix.neg_mul] at H,
+  exact inv_eq_left_inv H
+end
+
 instance : group (symplectic_group l R) :=
 { mul_left_inv :=
   begin

--- a/src/linear_algebra/symplectic_group.lean
+++ b/src/linear_algebra/symplectic_group.lean
@@ -75,21 +75,24 @@ end
 variables (R)
 variables [no_zero_divisors R] [nontrivial R]
 
+lemma J_det_mul_J_det [rc : fact (ring_char R ≠ 2)] : (det (J l R)) * (det (J l R)) = 1 :=
+begin
+  rw [←det_mul, J_squared],
+  rw [←one_smul R (-1 : matrix _ _ R)],
+  rw [smul_neg, ←neg_smul, det_smul],
+  simp only [fintype.card_sum, det_one, mul_one],
+  rw neg_one_pow_eq_one_iff_even (ring.neg_one_ne_one_of_char_ne_two (fact.elim rc)),
+  exact even_add_self _
+end
+
 lemma J_det [rc : fact (ring_char R ≠ 2)] : det (J l R) = 1 ∨ det (J l R) = - 1:=
 begin
-  have H : (det (J l R)) * (det (J l R)) = 1 := by
-  { rw [←det_mul, J_squared],
-    rw [←one_smul R (-1 : matrix _ _ R)],
-    rw [smul_neg, ←neg_smul, det_smul],
-    simp only [fintype.card_sum, det_one, mul_one],
-    rw neg_one_pow_eq_one_iff_even (ring.neg_one_ne_one_of_char_ne_two (fact.elim rc)),
-    exact even_add_self _ },
   rw [←sq_eq_one_iff, pow_two],
-  exact H,
+  exact J_det_mul_J_det _ _,
 end
 
 lemma J_det_unit [fact (ring_char R ≠ 2)] : is_unit (det (J l R)) :=
-  pm_one_unit (J_det l R)
+is_unit_iff_exists_inv.mpr ⟨det (J l R), J_det_mul_J_det _ _⟩
 
 end matrix
 

--- a/src/linear_algebra/symplectic_group.lean
+++ b/src/linear_algebra/symplectic_group.lean
@@ -1,0 +1,262 @@
+import algebra.lie.classical
+import data.real.basic
+import linear_algebra.matrix.determinant
+
+open_locale matrix
+
+variables {l : Type*}
+
+open lie_algebra.symplectic
+
+
+section J_matrix_lemmas
+
+namespace matrix
+
+variables (l) [decidable_eq l] [fintype l]
+
+lemma neg_one : (-1 : matrix l l ℝ)  = (-1 : ℝ) • 1  := by simp only [neg_smul, one_smul]
+
+lemma neg_one_transpose : (-1 : matrix l l ℝ)ᵀ = -1 := by rw [transpose_neg, transpose_one]
+
+lemma pm_one_unit {S : Type*} [ring S] {x : S} (h : x = 1 ∨ x = -1) : is_unit x :=
+begin
+  cases h,
+  {simp only [h, is_unit_one],},
+  { use -1,
+    simp only [h, units.coe_neg_one]}
+end
+
+lemma minus_powers (n : ℕ) : (-1 : ℝ)^(n + n) = 1 :=
+begin
+  rw neg_one_pow_eq_one_iff_even,
+  exact even_add_self n,
+  norm_num,
+end
+
+@[simp] lemma J_transpose : (J l ℝ)ᵀ = - (J l ℝ) :=
+begin
+  unfold J,
+  rw [from_blocks_transpose, ←neg_one_smul ℝ (from_blocks _ _ _ _), from_blocks_smul,
+      matrix.transpose_zero, matrix.transpose_one,  neg_one_transpose],
+  simp [from_blocks],
+end
+
+lemma J_squared : (J l ℝ) ⬝ (J l ℝ) = -1 :=
+begin
+  unfold J,
+  rw from_blocks_multiply,
+  simp only [matrix.zero_mul, matrix.neg_mul, zero_add, neg_zero', matrix.one_mul, add_zero],
+  rw [← neg_zero, ← matrix.from_blocks_neg,← from_blocks_one],
+end
+
+lemma J_inv : (J l ℝ)⁻¹ = -(J l ℝ) :=
+begin
+  refine matrix.inv_eq_right_inv _,
+  rw [matrix.mul_neg, J_squared],
+  exact neg_neg 1,
+end
+
+lemma J_det : det (J l ℝ) = 1 ∨ det (J l ℝ) = - 1:=
+begin
+  have H : (det (J l ℝ)) * (det (J l ℝ)) = 1 := by {
+    rw [←det_mul, J_squared, neg_one, det_smul],
+    simp only [fintype.card_sum, det_one, mul_one],
+    rw minus_powers,
+  },
+  have H2 : (det (J l ℝ))^2 = 1 := by {
+    unfold pow, -- MP: What to do with these?
+    unfold monoid.npow,
+    unfold ring.npow,
+    unfold comm_ring.npow,
+    unfold npow_rec,
+    rw mul_one,
+    exact H,
+  } ,
+  rw ←sq_eq_one_iff,
+  exact H2,
+end
+
+lemma J_det_unit : is_unit (det (J l ℝ)) := pm_one_unit (J_det l)
+
+end matrix
+
+end J_matrix_lemmas
+
+
+
+
+
+
+
+
+
+open lie_algebra.symplectic matrix
+
+variables (l) [decidable_eq l] [fintype l]
+
+def symplectic_group : submonoid (matrix (l ⊕ l) (l ⊕ l)  ℝ) :=
+{ carrier := { A | A ⬝ (J l ℝ) ⬝ Aᵀ = J l ℝ},
+  mul_mem' :=
+  begin
+    intros a b ha hb,
+    simp only [mul_eq_mul, set.mem_set_of_eq, transpose_mul] at *,
+    rw [←matrix.mul_assoc, a.mul_assoc, a.mul_assoc, hb],
+    exact ha,
+  end,
+  one_mem' := by simp }
+
+variables {l}
+
+namespace symplectic_group
+
+lemma mem_iff {A : matrix (l ⊕ l) (l ⊕ l)  ℝ} :
+  A ∈ symplectic_group l ↔ A ⬝ (J l ℝ) ⬝ Aᵀ = J l ℝ :=
+by simp [symplectic_group]
+
+instance coe_matrix : has_coe (symplectic_group l) (matrix (l ⊕ l) (l ⊕ l)  ℝ) := ⟨subtype.val⟩
+
+instance coe_fun : has_coe_to_fun (symplectic_group l) (λ _, (l ⊕ l) → (l ⊕ l) → ℝ) :=
+{ coe := λ A, A.val }
+
+
+
+
+
+
+
+
+
+section coe_lemmas
+
+variables (A B : symplectic_group l)
+
+@[simp] lemma mul_val : ↑(A * B) = A ⬝ B := rfl
+
+@[simp] lemma mul_apply : ⇑(A * B) = (A ⬝ B) := rfl
+
+@[simp] lemma one_val : ↑(1 : symplectic_group l) = (1 : matrix (l ⊕ l) (l ⊕ l)  ℝ) := rfl
+
+@[simp] lemma one_apply : ⇑(1 : symplectic_group l) = (1 : matrix (l ⊕ l) (l ⊕ l)  ℝ) := rfl
+
+lemma mul_mem {A B : matrix (l ⊕ l) (l ⊕ l) ℝ} (hA : A ∈ symplectic_group l) (hB : B ∈ symplectic_group l) :
+A ⬝ B ∈ symplectic_group l :=
+submonoid.mul_mem _ hA hB
+
+end coe_lemmas
+
+
+
+
+
+
+
+
+
+section symplectic_J
+
+variables (l)
+
+lemma J_mem : (J l ℝ) ∈ symplectic_group l :=
+begin
+  rw mem_iff,
+  unfold J,
+  rw [from_blocks_multiply, from_blocks_transpose, from_blocks_multiply],
+  simp,
+end
+
+def sym_J : symplectic_group l := ⟨J l ℝ, J_mem l⟩
+
+variables {l}
+
+@[simp] lemma coe_J : ↑(sym_J l) = J l ℝ := rfl
+
+@[simp] lemma J_apply : ⇑(sym_J l) = J l ℝ := rfl
+
+end symplectic_J
+
+
+
+
+
+
+
+
+variables {A : matrix (l ⊕ l) (l ⊕ l) ℝ}
+
+lemma symplectic_det (hA : A ∈ symplectic_group l) : is_unit $ det A :=
+begin
+  rw mem_iff at hA,
+  apply_fun det at hA,
+  simp only [det_mul, det_transpose] at hA,
+  have H := J_det l,
+  cases H,
+  { rw [H, mul_one, ←sq, sq_eq_one_iff] at hA,
+    exact pm_one_unit hA },
+  { rw H at hA,
+  simp only [mul_neg, mul_one, neg_mul, neg_inj] at hA,
+  rw [←sq, sq_eq_one_iff] at hA,
+  exact pm_one_unit hA },
+end
+
+lemma transpose_mem (hA : A ∈ symplectic_group l) : Aᵀ ∈ symplectic_group l :=
+begin
+  rw mem_iff at ⊢ hA,
+  rw transpose_transpose,
+  have huA := symplectic_det hA,
+  have huAT : is_unit (Aᵀ).det :=
+  begin
+    rw matrix.det_transpose,
+    exact huA,
+  end,
+  calc Aᵀ ⬝ J l ℝ ⬝ A
+      = - Aᵀ ⬝ (J l ℝ)⁻¹ ⬝ A  : by {rw J_inv, simp}
+  ... = - Aᵀ ⬝ (A ⬝ J l ℝ ⬝ Aᵀ)⁻¹ ⬝ A : by rw hA
+  ... = - (Aᵀ ⬝ (Aᵀ⁻¹ ⬝ (J l ℝ)⁻¹)) ⬝ A⁻¹ ⬝ A : by simp only [matrix.mul_inv_rev, matrix.mul_assoc, matrix.neg_mul]
+  ... = - (J l ℝ)⁻¹ : by rw [mul_nonsing_inv_cancel_left _ _ huAT, nonsing_inv_mul_cancel_right _ _ huA]
+  ... = (J l ℝ) : by simp [J_inv]
+end
+
+lemma neg_mem (h : A ∈ symplectic_group l) : -A ∈ symplectic_group l :=
+begin
+  rw mem_iff at h ⊢,
+  simp [h],
+end
+
+lemma transpose_mem_iff : Aᵀ ∈ symplectic_group l ↔ A ∈ symplectic_group l :=
+⟨λ hA, by simpa using transpose_mem hA , transpose_mem⟩
+
+lemma mem_iff' : A ∈ symplectic_group l ↔ Aᵀ ⬝ (J l ℝ) ⬝ A = J l ℝ :=
+by rw [←transpose_mem_iff, mem_iff, transpose_transpose]
+
+instance : has_inv (symplectic_group l) := {
+  inv := λ A, ⟨- (J l ℝ) ⬝ Aᵀ ⬝ (J l ℝ),
+    mul_mem (mul_mem (neg_mem $ J_mem l) $ transpose_mem A.2) $ J_mem _⟩,
+}
+
+@[simp] lemma coe_inv (A : symplectic_group l): (↑(A⁻¹) : matrix _ _ _) = - (J l ℝ) ⬝ Aᵀ ⬝ (J l ℝ) := rfl
+
+@[simp] lemma inv_apply (A : symplectic_group l): ⇑(A⁻¹) = - (J l ℝ) ⬝ Aᵀ ⬝ (J l ℝ) := rfl
+
+lemma inv_left_mul_aux {A : matrix (l ⊕ l) (l ⊕ l) ℝ} (hA : A ∈ symplectic_group l) :
+  -(J l ℝ ⬝ Aᵀ ⬝ J l ℝ ⬝ A) = 1 :=
+calc -(J l ℝ ⬝ Aᵀ ⬝ J l ℝ ⬝ A)
+    = - J l ℝ ⬝ (Aᵀ ⬝ J l ℝ ⬝ A) : by simp only [matrix.mul_assoc, matrix.neg_mul]
+... = - J l ℝ ⬝ J l ℝ : by {rw mem_iff' at hA, rw hA}
+... = (-1 : ℝ) • (J l ℝ ⬝ J l ℝ) : by simp only [matrix.neg_mul, neg_smul, one_smul]
+... = (-1 : ℝ) • -1 : by rw J_squared
+... = 1 : by simp only [neg_smul_neg, one_smul]
+
+instance : group (symplectic_group l) := {
+  mul_left_inv :=
+  begin
+    intro A,
+    apply subtype.ext,
+    simp only [mul_val, inv_apply, matrix.neg_mul, one_val],
+    exact inv_left_mul_aux A.2,
+  end,
+  .. symplectic_group.has_inv,
+  .. submonoid.to_monoid _
+}
+
+end symplectic_group


### PR DESCRIPTION
This PR defines the symplectic group over arbitrary ring (with characteristic not 2)

It also moves the definition of the `symplectic.J` into the new `linear_algebra/symplectic_group` file, and adds a lemma `from_blocks_neg` to `data/matrix/block`. 

Co-authored-by: Moritz Doll <moritz.doll@googlemail.com>

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
