### PR TITLE
[Merged by Bors] - chore(set_theory/game/nim): reorder lemmas

### DIFF
--- a/src/set_theory/game/nim.lean
+++ b/src/set_theory/game/nim.lean
@@ -61,44 +61,6 @@ lemma nim_def (o : ordinal) : nim o = pgame.mk o.out.α o.out.α
   (λ o₂, nim (ordinal.typein (<) o₂)) :=
 by { rw nim, refl }
 
-instance : is_empty (nim 0).left_moves :=
-by { rw nim_def, exact ordinal.is_empty_out_zero }
-
-instance : is_empty (nim 0).right_moves :=
-by { rw nim_def, exact ordinal.is_empty_out_zero }
-
-noncomputable instance : unique (nim 1).left_moves :=
-by { rw nim_def, exact ordinal.unique_out_one }
-
-noncomputable instance : unique (nim 1).right_moves :=
-by { rw nim_def, exact ordinal.unique_out_one }
-
-/-- `nim 0` has exactly the same moves as `0`. -/
-def nim_zero_relabelling : nim 0 ≡r 0 := relabelling.is_empty _
-
-@[simp] theorem nim_zero_equiv : nim 0 ≈ 0 := equiv.is_empty _
-
-/-- `nim 1` has exactly the same moves as `star`. -/
-noncomputable def nim_one_relabelling : nim 1 ≡r star :=
-begin
-  rw nim_def,
-  refine ⟨_, _, λ i, _, λ j, _⟩,
-  any_goals { dsimp, apply equiv.equiv_of_unique },
-  all_goals { simp, exact nim_zero_relabelling }
-end
-
-@[simp] theorem nim_one_equiv : nim 1 ≈ star := nim_one_relabelling.equiv
-
-@[simp] lemma nim_birthday (o : ordinal) : (nim o).birthday = o :=
-begin
-  induction o using ordinal.induction with o IH,
-  rw [nim_def, birthday_def],
-  dsimp,
-  rw max_eq_right le_rfl,
-  convert lsub_typein o,
-  exact funext (λ i, IH _ (typein_lt_self i))
-end
-
 lemma left_moves_nim (o : ordinal) : (nim o).left_moves = o.out.α :=
 by { rw nim_def, refl }
 lemma right_moves_nim (o : ordinal) : (nim o).right_moves = o.out.α :=
@@ -140,6 +102,44 @@ by simp
 lemma move_right_nim {o : ordinal} (i) :
   (nim o).move_right (to_right_moves_nim i) = nim i :=
 by simp
+
+instance : is_empty (nim 0).left_moves :=
+by { rw nim_def, exact ordinal.is_empty_out_zero }
+
+instance : is_empty (nim 0).right_moves :=
+by { rw nim_def, exact ordinal.is_empty_out_zero }
+
+noncomputable instance : unique (nim 1).left_moves :=
+by { rw nim_def, exact ordinal.unique_out_one }
+
+noncomputable instance : unique (nim 1).right_moves :=
+by { rw nim_def, exact ordinal.unique_out_one }
+
+/-- `nim 0` has exactly the same moves as `0`. -/
+def nim_zero_relabelling : nim 0 ≡r 0 := relabelling.is_empty _
+
+@[simp] theorem nim_zero_equiv : nim 0 ≈ 0 := equiv.is_empty _
+
+/-- `nim 1` has exactly the same moves as `star`. -/
+noncomputable def nim_one_relabelling : nim 1 ≡r star :=
+begin
+  rw nim_def,
+  refine ⟨_, _, λ i, _, λ j, _⟩,
+  any_goals { dsimp, apply equiv.equiv_of_unique },
+  all_goals { simp, exact nim_zero_relabelling }
+end
+
+@[simp] theorem nim_one_equiv : nim 1 ≈ star := nim_one_relabelling.equiv
+
+@[simp] lemma nim_birthday (o : ordinal) : (nim o).birthday = o :=
+begin
+  induction o using ordinal.induction with o IH,
+  rw [nim_def, birthday_def],
+  dsimp,
+  rw max_eq_right le_rfl,
+  convert lsub_typein o,
+  exact funext (λ i, IH _ (typein_lt_self i))
+end
 
 @[simp] lemma neg_nim (o : ordinal) : -nim o = nim o :=
 begin


### PR DESCRIPTION
We move the most basic API for `nim` to the beginning of the file. This was causing trouble in another PR, where I wanted to prove basic properties of `nim 1` alongside those of `nim 0` but couldn't because of this missing API.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
