### PR TITLE
[Merged by Bors] - ci(.github/workflows/*): Make build step fail if lean returns nonzero value

### DIFF
--- a/.github/workflows/bors.yml
+++ b/.github/workflows/bors.yml
@@ -78,6 +78,7 @@ jobs:
       - name: leanpkg build
         id: build
         run: |
+          set -o pipefail
           leanpkg configure
           echo "::set-output name=started::true"
           lean --json -T150000 --make src | python3 scripts/detect_errors.py

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -86,6 +86,7 @@ jobs:
       - name: leanpkg build
         id: build
         run: |
+          set -o pipefail
           leanpkg configure
           echo "::set-output name=started::true"
           lean --json -T150000 --make src | python3 scripts/detect_errors.py

--- a/.github/workflows/build.yml.in
+++ b/.github/workflows/build.yml.in
@@ -64,6 +64,7 @@ jobs:
       - name: leanpkg build
         id: build
         run: |
+          set -o pipefail
           leanpkg configure
           echo "::set-output name=started::true"
           lean --json -T150000 --make src | python3 scripts/detect_errors.py

--- a/.github/workflows/build_fork.yml
+++ b/.github/workflows/build_fork.yml
@@ -84,6 +84,7 @@ jobs:
       - name: leanpkg build
         id: build
         run: |
+          set -o pipefail
           leanpkg configure
           echo "::set-output name=started::true"
           lean --json -T150000 --make src | python3 scripts/detect_errors.py


### PR DESCRIPTION
Currently, when building mathlib, if the second `lean --make src` returns a nonzero value, say due to an out-of-memory error, this value will be masked by the pipe, causing the build step to appear to succeed. The problem will then show up down the line, say in linting. This bit us in lean-liquid.

This change causes the build step to fail if the `lean --make` command fails.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
