### PR TITLE
[Merged by Bors] - refactor(data/dfinsupp/basic): Improve definitional equalities of coercions

### DIFF
--- a/src/algebra/direct_sum/basic.lean
+++ b/src/algebra/direct_sum/basic.lean
@@ -49,8 +49,7 @@ variables [Π i, add_comm_group (β i)]
 instance : add_comm_group (direct_sum ι β) := dfinsupp.add_comm_group
 
 variables {β}
-@[simp] lemma sub_apply (g₁ g₂ : ⨁ i, β i) (i : ι) : (g₁ - g₂) i = g₁ i - g₂ i :=
-dfinsupp.sub_apply _ _ _
+@[simp] lemma sub_apply (g₁ g₂ : ⨁ i, β i) (i : ι) : (g₁ - g₂) i = g₁ i - g₂ i := rfl
 
 end add_comm_group
 
@@ -59,8 +58,7 @@ variables [Π i, add_comm_monoid (β i)]
 @[simp] lemma zero_apply (i : ι) : (0 : ⨁ i, β i) i = 0 := rfl
 
 variables {β}
-@[simp] lemma add_apply (g₁ g₂ : ⨁ i, β i) (i : ι) : (g₁ + g₂) i = g₁ i + g₂ i :=
-dfinsupp.add_apply _ _ _
+@[simp] lemma add_apply (g₁ g₂ : ⨁ i, β i) (i : ι) : (g₁ + g₂) i = g₁ i + g₂ i := rfl
 
 variables (β)
 include dec_ι
@@ -223,10 +221,10 @@ variables {α : ι → Type u} {δ : Π i, α i → Type w} [Π i j, add_comm_mo
 noncomputable def sigma_curry : (⨁ (i : Σ i, _), δ i.1 i.2) →+ ⨁ i j, δ i j :=
 { to_fun := @dfinsupp.sigma_curry _ _ δ _,
   map_zero' := dfinsupp.sigma_curry_zero,
-  map_add' := λ f g, dfinsupp.sigma_curry_add f g }
+  map_add' := λ f g, @dfinsupp.sigma_curry_add _ _ δ _ f g }
 
 @[simp] lemma sigma_curry_apply (f : ⨁ (i : Σ i, _), δ i.1 i.2) (i : ι) (j : α i) :
-  sigma_curry f i j = f ⟨i, j⟩ := dfinsupp.sigma_curry_apply f i j
+  sigma_curry f i j = f ⟨i, j⟩ := @dfinsupp.sigma_curry_apply _ _ δ _ f i j
 
 /--The natural map between `⨁ i (j : α i), δ i j` and `Π₀ (i : Σ i, α i), δ i.1 i.2`, inverse of
 `curry`.-/

--- a/src/data/dfinsupp/basic.lean
+++ b/src/data/dfinsupp/basic.lean
@@ -128,11 +128,11 @@ instance [Π i, add_zero_class (β i)] : has_add (Π₀ i, β i) :=
 
 lemma add_apply [Π i, add_zero_class (β i)] (g₁ g₂ : Π₀ i, β i) (i : ι) :
   (g₁ + g₂) i = g₁ i + g₂ i :=
-zip_with_apply _ _ g₁ g₂ i
+rfl
 
 @[simp] lemma coe_add [Π i, add_zero_class (β i)] (g₁ g₂ : Π₀ i, β i) :
   ⇑(g₁ + g₂) = g₁ + g₂ :=
-funext $ add_apply g₁ g₂
+rfl
 
 instance [Π i, add_zero_class (β i)] : add_zero_class (Π₀ i, β i) :=
 fun_like.coe_injective.add_zero_class _ coe_zero coe_add
@@ -147,7 +147,7 @@ lemma nsmul_apply [Π i, add_monoid (β i)] (b : ℕ) (v : Π₀ i, β i) (i : �
 rfl
 
 @[simp] lemma coe_nsmul [Π i, add_monoid (β i)] (b : ℕ) (v : Π₀ i, β i) : ⇑(b • v) = b • v :=
-funext $ nsmul_apply b v
+rfl
 
 instance [Π i, add_monoid (β i)] : add_monoid (Π₀ i, β i) :=
 fun_like.coe_injective.add_monoid _ coe_zero coe_add (λ _ _, coe_nsmul _ _)
@@ -202,7 +202,7 @@ lemma zsmul_apply [Π i, add_group (β i)] (b : ℤ) (v : Π₀ i, β i) (i : ι
 rfl
 
 @[simp] lemma coe_zsmul [Π i, add_group (β i)] (b : ℤ) (v : Π₀ i, β i) : ⇑(b • v) = b • v :=
-funext $ zsmul_apply b v
+rfl
 
 instance [Π i, add_group (β i)] : add_group (Π₀ i, β i) :=
 fun_like.coe_injective.add_group _
@@ -226,7 +226,7 @@ rfl
 @[simp] lemma coe_smul [monoid γ] [Π i, add_monoid (β i)]
   [Π i, distrib_mul_action γ (β i)] (b : γ) (v : Π₀ i, β i) :
   ⇑(b • v) = b • v :=
-funext $ smul_apply b v
+rfl
 
 instance {δ : Type*} [monoid γ] [monoid δ]
   [Π i, add_monoid (β i)] [Π i, distrib_mul_action γ (β i)] [Π i, distrib_mul_action δ (β i)]
@@ -354,12 +354,12 @@ rfl
 @[simp] lemma subtype_domain_add [Π i, add_zero_class (β i)] {p : ι → Prop} [decidable_pred p]
   (v v' : Π₀ i, β i) :
   (v + v').subtype_domain p = v.subtype_domain p + v'.subtype_domain p :=
-ext $ λ i, rfl
+coe_fn_injective rfl
 
 @[simp] lemma subtype_domain_smul [monoid γ] [Π i, add_monoid (β i)]
   [Π i, distrib_mul_action γ (β i)] {p : ι → Prop} [decidable_pred p] (r : γ) (f : Π₀ i, β i) :
   (r • f).subtype_domain p = r • f.subtype_domain p :=
-ext $ λ i, rfl
+coe_fn_injective rfl
 
 variables (γ β)
 
@@ -384,12 +384,12 @@ variables {γ β}
 @[simp]
 lemma subtype_domain_neg [Π i, add_group (β i)] {p : ι → Prop} [decidable_pred p] {v : Π₀ i, β i} :
   (- v).subtype_domain p = - v.subtype_domain p :=
-ext $ λ i, rfl
+coe_fn_injective rfl
 
 @[simp] lemma subtype_domain_sub [Π i, add_group (β i)] {p : ι → Prop} [decidable_pred p]
   {v v' : Π₀ i, β i} :
   (v - v').subtype_domain p = v.subtype_domain p - v'.subtype_domain p :=
-ext $ λ i, rfl
+coe_fn_injective rfl
 
 end filter_and_subtype_domain
 
@@ -590,7 +590,7 @@ by rw [erase_single, if_neg h]
 
 section update
 
-variables (f : Π₀ i, β i) (i) (b : β i) [decidable (b = 0)]
+variables (f : Π₀ i, β i) (i) (b : β i)
 
 /-- Replace the value of a `Π₀ i, β i` at a given point `i : ι` by a given value `b : β i`.
 If `b = 0`, this amounts to removing `i` from the support.
@@ -599,27 +599,22 @@ Otherwise, `i` is added to it.
 This is the (dependent) finitely-supported version of `function.update`. -/
 def update : Π₀ i, β i :=
 ⟨function.update f i b, f.support'.map $ λ s,
-  ⟨if b = 0 then multiset.erase s i else i ::ₘ s,
-  begin
-    intro j,
+  ⟨i ::ₘ s, λ j, begin
     rcases eq_or_ne i j with rfl|hi,
-    { split_ifs with hb,
-      { simp [hb] },
-      { simp } },
+    { simp, },
     { obtain hj | (hj : f j = 0) := s.prop j,
-      { split_ifs;
-        simp [multiset.mem_erase_of_ne hi.symm, hj] },
-      { simp [function.update_noteq hi.symm, hj] } }
+      { exact or.inl (multiset.mem_cons_of_mem hj), },
+      { exact or.inr ((function.update_noteq hi.symm b _).trans hj) } }
   end⟩⟩
 
 variables (j : ι)
 
-@[simp] lemma coe_update : (f.update i b : Π (i : ι), β i) = function.update f i b :=
-rfl
-@[simp] lemma update_self [decidable (f i = 0)] : f.update i (f i) = f :=
+@[simp] lemma coe_update : (f.update i b : Π (i : ι), β i) = function.update f i b := rfl
+
+@[simp] lemma update_self : f.update i (f i) = f :=
 by { ext, simp }
 
-@[simp] lemma update_eq_erase [decidable ((0 : β i) = 0)] : f.update i 0 = f.erase i :=
+@[simp] lemma update_eq_erase : f.update i 0 = f.erase i :=
 begin
   ext j,
   rcases eq_or_ne i j with rfl|hi,
@@ -628,7 +623,7 @@ begin
 end
 
 lemma update_eq_single_add_erase {β : ι → Type*} [Π i, add_zero_class (β i)] (f : Π₀ i, β i) (i : ι)
-  (b : β i) [decidable (b = 0)] :
+  (b : β i) :
   f.update i b = single i b + f.erase i :=
 begin
   ext j,
@@ -638,7 +633,7 @@ begin
 end
 
 lemma update_eq_erase_add_single {β : ι → Type*} [Π i, add_zero_class (β i)] (f : Π₀ i, β i) (i : ι)
-  (b : β i) [decidable (b = 0)] :
+  (b : β i) :
   f.update i b = f.erase i + single i b :=
 begin
   ext j,
@@ -648,7 +643,7 @@ begin
 end
 
 lemma update_eq_sub_add_single {β : ι → Type*} [Π i, add_group (β i)] (f : Π₀ i, β i) (i : ι)
-  (b : β i) [decidable (b = 0)] :
+  (b : β i) :
   f.update i b = f - single i (f i) + single i b :=
 by rw [update_eq_erase_add_single f i b, erase_eq_sub_single f i]
 
@@ -945,7 +940,7 @@ by { ext j, by_cases h1 : j = i; by_cases h2 : f j ≠ 0; simp at h2; simp [h1, 
   (f.erase i).support = f.support.erase i :=
 by { ext j, by_cases h1 : j = i, simp [h1], by_cases h2 : f j ≠ 0; simp at h2; simp [h1, h2] }
 
-lemma support_update_ne_zero (f : Π₀ i, β i) (i : ι) {b : β i} [decidable (b = 0)] (h : b ≠ 0) :
+lemma support_update_ne_zero (f : Π₀ i, β i) (i : ι) {b : β i} (h : b ≠ 0) :
   support (f.update i b) = insert i f.support :=
 begin
   ext j,
@@ -1188,33 +1183,35 @@ end
 `curry`.-/
 noncomputable def sigma_uncurry [Π i j, has_zero (δ i j)] (f : Π₀ i j, δ i j) :
   Π₀ (i : Σ i, _), δ i.1 i.2 :=
-by { classical,
-  exact mk (f.support.bUnion $ λ i, (f i).support.image $ sigma.mk i) (λ ⟨⟨i, j⟩, _⟩, f i j) }
+{ to_fun := λ i, f i.1 i.2,
+  support' := f.support'.map $ λ s,
+    ⟨(multiset.bind ↑s $ λ i, ((f i).support.map ⟨sigma.mk i, sigma_mk_injective⟩).val), λ i, begin
+      simp_rw [multiset.mem_bind, map_val, multiset.mem_map, function.embedding.coe_fn_mk,
+        ←finset.mem_def, mem_support_to_fun],
+      obtain hi | (hi : f i.1 = 0) := s.prop i.1,
+      { by_cases hi' : f i.1 i.2 = 0,
+        { exact or.inr hi' },
+        { exact or.inl ⟨_, hi, i.2, hi', sigma.eta _⟩ } },
+      { right,
+        rw [hi, zero_apply] }
+    end⟩ }
 
 @[simp] lemma sigma_uncurry_apply [Π i j, has_zero (δ i j)] (f : Π₀ i j, δ i j) (i : ι) (j : α i) :
   sigma_uncurry f ⟨i, j⟩ = f i j :=
-begin
-  dunfold sigma_uncurry, by_cases h : f i j = 0,
-  { rw mk_apply, split_ifs, { refl }, { exact h.symm } },
-  { apply mk_of_mem, rw mem_bUnion, refine ⟨i, _, _⟩,
-    { rw mem_support_to_fun, intro H, rw ext_iff at H, exact h (H j) },
-    { apply mem_image_of_mem, rw mem_support_to_fun, exact h } }
-end
+rfl
 
 @[simp] lemma sigma_uncurry_zero [Π i j, has_zero (δ i j)] :
   sigma_uncurry (0 : Π₀ i j, δ i j) = 0 :=
-by { ext ⟨i, j⟩, rw sigma_uncurry_apply, refl }
+rfl
 
 @[simp] lemma sigma_uncurry_add [Π i j, add_zero_class (δ i j)] (f g : Π₀ i j, δ i j) :
   sigma_uncurry (f + g) = sigma_uncurry f + sigma_uncurry g :=
-by { ext ⟨i, j⟩, rw [add_apply, sigma_uncurry_apply,
-    sigma_uncurry_apply, sigma_uncurry_apply, @add_apply _ (λ i, Π₀ j, δ i j) _, add_apply] }
+coe_fn_injective rfl
 
 @[simp] lemma sigma_uncurry_smul [monoid γ] [Π i j, add_monoid (δ i j)]
   [Π i j, distrib_mul_action γ (δ i j)] (r : γ) (f : Π₀ i j, δ i j) :
   sigma_uncurry (r • f) = r • sigma_uncurry f :=
-by { ext ⟨i, j⟩, rw [smul_apply, sigma_uncurry_apply,
-    sigma_uncurry_apply, @smul_apply _ _ (λ i, Π₀ j, δ i j) _ _ _, smul_apply] }
+coe_fn_injective rfl
 
 @[simp] lemma sigma_uncurry_single [Π i j, has_zero (δ i j)] (i) (j : α i) (x : δ i j) :
   sigma_uncurry (single i (single j x : Π₀ (j : α i), δ i j)) = single ⟨i, j⟩ x:=

--- a/src/data/dfinsupp/basic.lean
+++ b/src/data/dfinsupp/basic.lean
@@ -61,7 +61,7 @@ instance : has_zero (Π₀ i, β i) := ⟨⟨0, trunc.mk $ ⟨∅, λ i, or.inr 
 instance : inhabited (Π₀ i, β i) := ⟨0⟩
 
 @[simp]
-lemma coe_mk (f : Π i, β i) (s) : ⇑(⟨f, s⟩ : Π₀ i, β i) = f := rfl
+lemma coe_mk' (f : Π i, β i) (s) : ⇑(⟨f, s⟩ : Π₀ i, β i) = f := rfl
 
 @[simp] lemma coe_zero : ⇑(0 : Π₀ i, β i) = 0 := rfl
 lemma zero_apply (i : ι) : (0 : Π₀ i, β i) i = 0 := rfl
@@ -850,7 +850,7 @@ begin
   cases f with f s,
   induction s using trunc.induction_on,
   dsimp only [support, trunc.lift_mk],
-  rw [finset.mem_filter, multiset.mem_to_finset, coe_mk],
+  rw [finset.mem_filter, multiset.mem_to_finset, coe_mk'],
   exact and_iff_right_of_imp (s.prop i).resolve_right
 end
 
@@ -1475,7 +1475,7 @@ def sum_add_hom [Π i, add_zero_class (β i)] [add_comm_monoid γ] (φ : Π i, �
   map_add' := begin
     rintros ⟨f, sf, hf⟩ ⟨g, sg, hg⟩,
     change ∑ i in _, _ = (∑ i in _, _) + (∑ i in _, _),
-    simp only [coe_add, coe_mk, subtype.coe_mk, pi.add_apply, map_add, finset.sum_add_distrib],
+    simp only [coe_add, coe_mk', subtype.coe_mk, pi.add_apply, map_add, finset.sum_add_distrib],
     congr' 1,
     { refine (finset.sum_subset _ _).symm,
       { intro i, simp only [multiset.mem_to_finset, multiset.mem_add], exact or.inl },
@@ -1509,7 +1509,7 @@ begin
   change ∑ i in _, _ = (∑ i in finset.filter _ _, _),
   rw [finset.sum_filter, finset.sum_congr rfl],
   intros i _,
-  dsimp only [coe_mk, subtype.coe_mk] at *,
+  dsimp only [coe_mk', subtype.coe_mk] at *,
   split_ifs,
   refl,
   rw [(not_not.mp h), add_monoid_hom.map_zero],

--- a/src/data/dfinsupp/basic.lean
+++ b/src/data/dfinsupp/basic.lean
@@ -20,34 +20,18 @@ universes u u₁ u₂ v v₁ v₂ v₃ w x y l
 
 open_locale big_operators
 
-variables (ι : Type u) {γ : Type w} (β : ι → Type v) {β₁ : ι → Type v₁} {β₂ : ι → Type v₂}
+variables {ι : Type u} {γ : Type w} {β : ι → Type v} {β₁ : ι → Type v₁} {β₂ : ι → Type v₂}
 
-namespace dfinsupp
 
-variable [Π i, has_zero (β i)]
+variable (β)
+/-- A dependent function `Π i, β i` with finite support.
 
-/-- An auxiliary structure used in the definition of of `dfinsupp`,
-the type used to make infinite direct sum of modules over a ring. -/
-structure pre : Type (max u v) :=
+Instead of storing the support directly, which would make `dfinsupp.has_add` require decidability
+of equality on `β i`, we store a multiset that is a superset of the true support. -/
+structure dfinsupp [Π i, has_zero (β i)] : Type (max u v) :=
+mk' ::
 (to_fun : Π i, β i)
-(pre_support : multiset ι)
-(zero : ∀ i, i ∈ pre_support ∨ to_fun i = 0)
-
-instance inhabited_pre : inhabited (pre ι β) :=
-⟨⟨λ i, 0, ∅, λ i, or.inr rfl⟩⟩
-
-instance : setoid (pre ι β) :=
-{ r := λ x y, ∀ i, x.to_fun i = y.to_fun i,
-  iseqv := ⟨λ f i, rfl, λ f g H i, (H i).symm,
-    λ f g h H1 H2 i, (H1 i).trans (H2 i)⟩ }
-
-end dfinsupp
-
-variable {ι}
-/-- A dependent function `Π i, β i` with finite support. -/
-@[reducible]
-def dfinsupp [Π i, has_zero (β i)] : Type* :=
-quotient (dfinsupp.pre.setoid ι β)
+(support' : trunc {s : multiset ι // ∀ i, i ∈ s ∨ to_fun i = 0})
 variable {β}
 
 notation `Π₀` binders `, ` r:(scoped f, dfinsupp f) := r
@@ -59,12 +43,13 @@ section basic
 variables [Π i, has_zero (β i)] [Π i, has_zero (β₁ i)] [Π i, has_zero (β₂ i)]
 
 instance fun_like : fun_like (Π₀ i, β i) ι β :=
-⟨λ f, quotient.lift_on f pre.to_fun $ λ _ _, funext,
-  λ f g H, quotient.induction_on₂ f g (λ _ _ H, quotient.sound H) (congr_fun H)⟩
+⟨λ f, f.to_fun, λ ⟨f₁, s₁⟩ ⟨f₂, s₁⟩ (h : f₁= f₂), by { subst h, congr'} ⟩
 
 /-- Helper instance for when there are too many metavariables to apply `fun_like.has_coe_to_fun`
 directly. -/
 instance : has_coe_to_fun (Π₀ i, β i) (λ _, Π i, β i) := fun_like.has_coe_to_fun
+
+@[simp] lemma to_fun_eq_coe (f : Π₀ i, β i) : f.to_fun = f := rfl
 
 @[ext] lemma ext {f g : Π₀ i, β i} (h : ∀ i, f i = g i) : f = g := fun_like.ext _ _ h
 /-- Deprecated. Use `fun_like.ext_iff` instead. -/
@@ -72,12 +57,11 @@ lemma ext_iff {f g : Π₀ i, β i} : f = g ↔ ∀ i, f i = g i := fun_like.ext
 /-- Deprecated. Use `fun_like.coe_injective` instead. -/
 lemma coe_fn_injective : @function.injective (Π₀ i, β i) (Π i, β i) coe_fn := fun_like.coe_injective
 
-instance : has_zero (Π₀ i, β i) := ⟨⟦⟨0, ∅, λ i, or.inr rfl⟩⟧⟩
+instance : has_zero (Π₀ i, β i) := ⟨⟨0, trunc.mk $ ⟨∅, λ i, or.inr rfl⟩⟩⟩
 instance : inhabited (Π₀ i, β i) := ⟨0⟩
 
 @[simp]
-lemma coe_pre_mk (f : Π i, β i) (s : multiset ι) (hf) :
-  ⇑(⟦⟨f, s, hf⟩⟧ : Π₀ i, β i) = f := rfl
+lemma coe_mk (f : Π i, β i) (s) : ⇑(⟨f, s⟩ : Π₀ i, β i) = f := rfl
 
 @[simp] lemma coe_zero : ⇑(0 : Π₀ i, β i) = 0 := rfl
 lemma zero_apply (i : ι) : (0 : Π₀ i, β i) i = 0 := rfl
@@ -93,19 +77,17 @@ bundled:
 * `dfinsupp.map_range.linear_map`
 * `dfinsupp.map_range.linear_equiv`
 -/
-def map_range (f : Π i, β₁ i → β₂ i) (hf : ∀ i, f i 0 = 0) : (Π₀ i, β₁ i) → Π₀ i, β₂ i :=
-quotient.map
-  (λ x, ⟨λ i, f i (x.1 i), x.2, λ i, (x.3 i).imp_right $ λ H, by rw [H, hf]⟩)
-  (λ x y H i, by simp only [H i])
+def map_range (f : Π i, β₁ i → β₂ i) (hf : ∀ i, f i 0 = 0) (x : Π₀ i, β₁ i) : Π₀ i, β₂ i :=
+⟨λ i, f i (x i), x.support'.map $ λ s, ⟨s, λ i, (s.2 i).imp_right $ λ h : x i = 0, h.symm ▸ hf i⟩⟩
 
 @[simp] lemma map_range_apply
   (f : Π i, β₁ i → β₂ i) (hf : ∀ i, f i 0 = 0) (g : Π₀ i, β₁ i) (i : ι) :
   map_range f hf g i = f i (g i) :=
-quotient.induction_on g $ λ x, rfl
+rfl
 
 @[simp] lemma map_range_id (h : ∀ i, id (0 : β₁ i) = 0 := λ i, rfl) (g : Π₀ (i : ι), β₁ i) :
   map_range (λ i, (id : β₁ i → β₁ i)) h g = g :=
-by { ext, simp only [map_range_apply, id.def] }
+by { ext, refl }
 
 lemma map_range_comp (f : Π i, β₁ i → β₂ i) (f₂ : Π i, β i → β₁ i)
   (hf : ∀ i, f i 0 = 0) (hf₂ : ∀ i, f₂ i 0 = 0) (h : ∀ i, (f i ∘ f₂ i) 0 = 0)
@@ -119,23 +101,23 @@ by { ext, simp only [map_range_apply, coe_zero, pi.zero_apply, hf] }
 
 /-- Let `f i` be a binary operation `β₁ i → β₂ i → β i` such that `f i 0 0 = 0`.
 Then `zip_with f hf` is a binary operation `Π₀ i, β₁ i → Π₀ i, β₂ i → Π₀ i, β i`. -/
-def zip_with (f : Π i, β₁ i → β₂ i → β i) (hf : ∀ i, f i 0 0 = 0) :
-  (Π₀ i, β₁ i) → (Π₀ i, β₂ i) → (Π₀ i, β i) :=
-begin
-  refine quotient.map₂
-    (λ x y, ⟨λ i, f i (x.1 i) (y.1 i), x.2 + y.2, λ i, _⟩) _,
-  { cases x.3 i with h1 h1,
-    { left, rw multiset.mem_add, left, exact h1 },
-    cases y.3 i with h2 h2,
-    { left, rw multiset.mem_add, right, exact h2 },
-    right, rw [h1, h2, hf] },
-  exact λ x₁ x₂ H1 y₁ y₂ H2 i, by simp only [H1 i, H2 i]
-end
+def zip_with (f : Π i, β₁ i → β₂ i → β i) (hf : ∀ i, f i 0 0 = 0)
+  (x : Π₀ i, β₁ i) (y : Π₀ i, β₂ i) : (Π₀ i, β i) :=
+⟨λ i, f i (x i) (y i), begin
+  refine x.support'.bind (λ xs, _),
+  refine y.support'.map (λ ys, _),
+  refine ⟨xs + ys, λ i, _⟩,
+  obtain h1 | (h1 : x i = 0) := xs.prop i,
+  { left, rw multiset.mem_add, left, exact h1 },
+  obtain h2 | (h2 : y i = 0) := ys.prop i,
+  { left, rw multiset.mem_add, right, exact h2 },
+  right, rw [h1, h2, hf]
+end⟩
 
 @[simp] lemma zip_with_apply
   (f : Π i, β₁ i → β₂ i → β i) (hf : ∀ i, f i 0 0 = 0) (g₁ : Π₀ i, β₁ i) (g₂ : Π₀ i, β₂ i) (i : ι) :
   zip_with f hf g₁ g₂ i = f i (g₁ i) (g₂ i) :=
-quotient.induction_on₂ g₁ g₂ $ λ _ _, rfl
+rfl
 
 end basic
 
@@ -162,7 +144,7 @@ instance has_nat_scalar [Π i, add_monoid (β i)] : has_smul ℕ (Π₀ i, β i)
 
 lemma nsmul_apply [Π i, add_monoid (β i)] (b : ℕ) (v : Π₀ i, β i) (i : ι) :
   (b • v) i = b • (v i) :=
-map_range_apply _ _ v i
+rfl
 
 @[simp] lemma coe_nsmul [Π i, add_monoid (β i)] (b : ℕ) (v : Π₀ i, β i) : ⇑(b • v) = b • v :=
 funext $ nsmul_apply b v
@@ -195,21 +177,21 @@ instance [Π i, add_group (β i)] : has_neg (Π₀ i, β i) :=
 ⟨λ f, f.map_range (λ _, has_neg.neg) (λ _, neg_zero)⟩
 
 lemma neg_apply [Π i, add_group (β i)] (g : Π₀ i, β i) (i : ι) : (- g) i = - g i :=
-map_range_apply _ _ g i
+rfl
 
 @[simp] lemma coe_neg [Π i, add_group (β i)] (g : Π₀ i, β i) : ⇑(- g) = - g :=
-funext $ neg_apply g
+rfl
 
 instance [Π i, add_group (β i)] : has_sub (Π₀ i, β i) :=
 ⟨zip_with (λ _, has_sub.sub) (λ _, sub_zero 0)⟩
 
 lemma sub_apply [Π i, add_group (β i)] (g₁ g₂ : Π₀ i, β i) (i : ι) :
   (g₁ - g₂) i = g₁ i - g₂ i :=
-zip_with_apply _ _ g₁ g₂ i
+rfl
 
 @[simp] lemma coe_sub [Π i, add_group (β i)] (g₁ g₂ : Π₀ i, β i) :
   ⇑(g₁ - g₂) = g₁ - g₂ :=
-funext $ sub_apply g₁ g₂
+rfl
 
 /-- Note the general `dfinsupp.has_smul` instance doesn't apply as `ℤ` is not distributive
 unless `β i`'s addition is commutative. -/
@@ -217,7 +199,7 @@ instance has_int_scalar [Π i, add_group (β i)] : has_smul ℤ (Π₀ i, β i) 
 ⟨λc v, v.map_range (λ _, (•) c) (λ _, zsmul_zero _)⟩
 
 lemma zsmul_apply [Π i, add_group (β i)] (b : ℤ) (v : Π₀ i, β i) (i : ι) : (b • v) i = b • (v i) :=
-map_range_apply _ _ v i
+rfl
 
 @[simp] lemma coe_zsmul [Π i, add_group (β i)] (b : ℤ) (v : Π₀ i, β i) : ⇑(b • v) = b • v :=
 funext $ zsmul_apply b v
@@ -239,7 +221,7 @@ instance [monoid γ] [Π i, add_monoid (β i)] [Π i, distrib_mul_action γ (β 
 lemma smul_apply [monoid γ] [Π i, add_monoid (β i)]
   [Π i, distrib_mul_action γ (β i)] (b : γ) (v : Π₀ i, β i) (i : ι) :
   (b • v) i = b • (v i) :=
-map_range_apply _ _ v i
+rfl
 
 @[simp] lemma coe_smul [monoid γ] [Π i, add_monoid (β i)]
   [Π i, distrib_mul_action γ (β i)] (b : γ) (v : Π₀ i, β i) :
@@ -282,15 +264,14 @@ end algebra
 section filter_and_subtype_domain
 
 /-- `filter p f` is the function which is `f i` if `p i` is true and 0 otherwise. -/
-def filter [Π i, has_zero (β i)] (p : ι → Prop) [decidable_pred p] : (Π₀ i, β i) → Π₀ i, β i :=
-quotient.map
-  (λ x, ⟨λ i, if p i then x.1 i else 0, x.2, λ i, (x.3 i).imp_right $ λ H, by rw [H, if_t_t]⟩)
-  (λ x y H i, by simp only [H i])
+def filter [Π i, has_zero (β i)] (p : ι → Prop) [decidable_pred p] (x : Π₀ i, β i) : Π₀ i, β i :=
+⟨λ i, if p i then x i else 0, x.support'.map
+  (λ xs, ⟨xs, λ i, (xs.prop i).imp_right $ λ H : x i = 0, by rw [H, if_t_t]⟩)⟩
 
 @[simp] lemma filter_apply [Π i, has_zero (β i)]
   (p : ι → Prop) [decidable_pred p] (i : ι) (f : Π₀ i, β i) :
   f.filter p i = if p i then f i else 0 :=
-quotient.induction_on f $ λ x, rfl
+rfl
 
 lemma filter_apply_pos [Π i, has_zero (β i)]
   {p : ι → Prop} [decidable_pred p] (f : Π₀ i, β i) {i : ι} (h : p i) :
@@ -354,13 +335,12 @@ variables {γ β}
 
 /-- `subtype_domain p f` is the restriction of the finitely supported function
   `f` to the subtype `p`. -/
-def subtype_domain [Π i, has_zero (β i)] (p : ι → Prop) [decidable_pred p] :
-  (Π₀ i, β i) → Π₀ i : subtype p, β i :=
-quotient.map
-  (λ x, ⟨λ i, x.1 (i : ι), (x.2.filter p).attach.map $ λ j, ⟨j, (multiset.mem_filter.1 j.2).2⟩,
-      λ i, (x.3 i).imp_left $ λ H, multiset.mem_map.2
-        ⟨⟨i, multiset.mem_filter.2 ⟨H, i.2⟩⟩, multiset.mem_attach _ _, subtype.eta _ _⟩⟩)
-  (λ x y H i, H i)
+def subtype_domain [Π i, has_zero (β i)] (p : ι → Prop) [decidable_pred p] (x : Π₀ i, β i) :
+  Π₀ i : subtype p, β i :=
+⟨λ i, x (i : ι), x.support'.map
+  (λ xs, ⟨(multiset.filter p xs).attach.map $ λ j, ⟨j, (multiset.mem_filter.1 j.2).2⟩,
+      λ i, (xs.prop i).imp_left $ λ H, multiset.mem_map.2
+        ⟨⟨i, multiset.mem_filter.2 ⟨H, i.2⟩⟩, multiset.mem_attach _ _, subtype.eta _ _⟩⟩)⟩
 
 @[simp] lemma subtype_domain_zero [Π i, has_zero (β i)] {p : ι → Prop} [decidable_pred p] :
   subtype_domain p (0 : Π₀ i, β i) = 0 :=
@@ -369,17 +349,17 @@ rfl
 @[simp] lemma subtype_domain_apply [Π i, has_zero (β i)] {p : ι → Prop} [decidable_pred p]
   {i : subtype p} {v : Π₀ i, β i} :
   (subtype_domain p v) i = v i :=
-quotient.induction_on v $ λ x, rfl
+rfl
 
 @[simp] lemma subtype_domain_add [Π i, add_zero_class (β i)] {p : ι → Prop} [decidable_pred p]
   (v v' : Π₀ i, β i) :
   (v + v').subtype_domain p = v.subtype_domain p + v'.subtype_domain p :=
-ext $ λ i, by simp only [add_apply, subtype_domain_apply]
+ext $ λ i, rfl
 
 @[simp] lemma subtype_domain_smul [monoid γ] [Π i, add_monoid (β i)]
   [Π i, distrib_mul_action γ (β i)] {p : ι → Prop} [decidable_pred p] (r : γ) (f : Π₀ i, β i) :
   (r • f).subtype_domain p = r • f.subtype_domain p :=
-quotient.induction_on f $ λ x, rfl
+ext $ λ i, rfl
 
 variables (γ β)
 
@@ -404,12 +384,12 @@ variables {γ β}
 @[simp]
 lemma subtype_domain_neg [Π i, add_group (β i)] {p : ι → Prop} [decidable_pred p] {v : Π₀ i, β i} :
   (- v).subtype_domain p = - v.subtype_domain p :=
-ext $ λ i, by simp only [neg_apply, subtype_domain_apply]
+ext $ λ i, rfl
 
 @[simp] lemma subtype_domain_sub [Π i, add_group (β i)] {p : ι → Prop} [decidable_pred p]
   {v v' : Π₀ i, β i} :
   (v - v').subtype_domain p = v.subtype_domain p - v'.subtype_domain p :=
-ext $ λ i, by simp only [sub_apply, subtype_domain_apply]
+ext $ λ i, rfl
 
 end filter_and_subtype_domain
 
@@ -424,16 +404,16 @@ omit dec
 lemma finite_support (f : Π₀ i, β i) : set.finite {i | f i ≠ 0} :=
 begin
   classical,
-  exact quotient.induction_on f (λ x, x.2.to_finset.finite_to_set.subset (λ i H,
-    multiset.mem_to_finset.2 ((x.3 i).resolve_right H)))
+  exact trunc.induction_on f.support' (λ xs, (multiset.to_finset ↑xs).finite_to_set.subset (λ i H,
+    multiset.mem_to_finset.2 ((xs.prop i).resolve_right H)))
 end
 include dec
 
 /-- Create an element of `Π₀ i, β i` from a finset `s` and a function `x`
 defined on this `finset`. -/
 def mk (s : finset ι) (x : Π i : (↑s : set ι), β (i : ι)) : Π₀ i, β i :=
-⟦⟨λ i, if H : i ∈ s then x ⟨i, H⟩ else 0, s.1,
-λ i, if H : i ∈ s then or.inl H else or.inr $ dif_neg H⟩⟧
+⟨λ i, if H : i ∈ s then x ⟨i, H⟩ else 0, trunc.mk ⟨s.1,
+  λ i, if H : i ∈ s then or.inl H else or.inr $ dif_neg H⟩⟩
 
 variables {s : finset ι} {x : Π i : (↑s : set ι), β i} {i : ι}
 
@@ -460,7 +440,7 @@ instance [is_empty ι] : unique (Π₀ i, β i) :=
   (All dependent functions on a finite type are finitely supported.) -/
 @[simps apply] def equiv_fun_on_fintype [fintype ι] : (Π₀ i, β i) ≃ (Π i, β i) :=
 { to_fun := coe_fn,
-  inv_fun := λ f, ⟦⟨f, finset.univ.1, λ i, or.inl $ finset.mem_univ_val _⟩⟧,
+  inv_fun := λ f, ⟨f, trunc.mk ⟨finset.univ.1, λ i, or.inl $ finset.mem_univ_val _⟩⟩,
   left_inv := λ x, coe_fn_injective rfl,
   right_inv := λ x, rfl }
 
@@ -472,32 +452,21 @@ include dec
 /-- The function `single i b : Π₀ i, β i` sends `i` to `b`
 and all other points to `0`. -/
 def single (i : ι) (b : β i) : Π₀ i, β i :=
-mk {i} $ λ j, eq.rec_on (finset.mem_singleton.1 j.prop).symm b
+⟨pi.single i b,
+  trunc.mk ⟨{i}, λ j, (decidable.eq_or_ne j i).imp (by simp) (λ h, pi.single_eq_of_ne h _)⟩⟩
+
+lemma single_eq_pi_single {i b} : ⇑(single i b : Π₀ i, β i) = pi.single i b :=
+rfl
 
 @[simp] lemma single_apply {i i' b} :
   (single i b : Π₀ i, β i) i' = (if h : i = i' then eq.rec_on h b else 0) :=
 begin
-  dsimp only [single],
-  by_cases h : i = i',
-  { have h1 : i' ∈ ({i} : finset ι) := finset.mem_singleton.2 h.symm,
-    simp only [mk_apply, dif_pos h, dif_pos h1], refl },
-  { have h1 : i' ∉ ({i} : finset ι) := finset.not_mem_singleton.2 (ne.symm h),
-    simp only [mk_apply, dif_neg h, dif_neg h1] }
-end
-
-lemma single_eq_pi_single {i b} : ⇑(single i b : Π₀ i, β i) = pi.single i b :=
-begin
-  ext i',
-  simp only [pi.single, function.update],
-  split_ifs,
-  { simp [h] },
-  { simp [ne.symm h] }
+  rw [single_eq_pi_single, pi.single, function.update],
+  simp [@eq_comm _ i i'],
 end
 
 @[simp] lemma single_zero (i) : (single i 0 : Π₀ i, β i) = 0 :=
-quotient.sound $ λ j, if H : j ∈ ({i} : finset _)
-then by dsimp only; rw [dif_pos H]; cases finset.mem_singleton.1 H; refl
-else dif_neg H
+fun_like.coe_injective $ pi.single_zero _
 
 @[simp] lemma single_eq_same {i b} : (single i b : Π₀ i, β i) i = b :=
 by simp only [single_apply, dif_pos rfl]
@@ -506,7 +475,7 @@ lemma single_eq_of_ne {i i' b} (h : i ≠ i') : (single i b : Π₀ i, β i) i' 
 by simp only [single_apply, dif_neg h]
 
 lemma single_injective {i} : function.injective (single i : β i → Π₀ i, β i) :=
-λ x y H, congr_fun (mk_injective _ H) ⟨i, by simp⟩
+λ x y H, pi.single_injective β i $ coe_fn_injective.eq_iff.mpr H
 
 /-- Like `finsupp.single_eq_single_iff`, but with a `heq` due to dependent types -/
 lemma single_eq_single_iff (i j : ι) (xi : β i) (xj : β j) :
@@ -570,15 +539,13 @@ by { ext, simp [dfinsupp.single_eq_pi_single], }
 by { ext i', simp only [← single_eq_pi_single, equiv_fun_on_fintype_symm_coe] }
 
 /-- Redefine `f i` to be `0`. -/
-def erase (i : ι) : (Π₀ i, β i) → Π₀ i, β i :=
-quotient.map
-  (λ x, ⟨λ j, if j = i then 0 else x.1 j, x.2,
-          λ j, (x.3 j).imp_right $ λ H, by simp only [H, if_t_t]⟩)
-  (λ x y H j, if h : j = i then by simp only [if_pos h] else by simp only [if_neg h, H j])
+def erase (i : ι) (x : Π₀ i, β i) : Π₀ i, β i :=
+⟨λ j, if j = i then 0 else x.1 j, x.support'.map $ λ xs,
+  ⟨xs, λ j, (xs.prop j).imp_right $ λ H, by simp only [H, if_t_t]⟩⟩
 
 @[simp] lemma erase_apply {i j : ι} {f : Π₀ i, β i} :
   (f.erase i) j = if j = i then 0 else f j :=
-quotient.induction_on f $ λ x, rfl
+rfl
 
 @[simp] lemma erase_same {i : ι} {f : Π₀ i, β i} : (f.erase i) i = 0 :=
 by simp
@@ -631,27 +598,24 @@ Otherwise, `i` is added to it.
 
 This is the (dependent) finitely-supported version of `function.update`. -/
 def update : Π₀ i, β i :=
-quotient.map (λ (x : pre _ _), ⟨function.update x.to_fun i b,
-  if b = 0 then x.pre_support.erase i else i ::ₘ x.pre_support,
+⟨function.update f i b, f.support'.map $ λ s,
+  ⟨if b = 0 then multiset.erase s i else i ::ₘ s,
   begin
     intro j,
     rcases eq_or_ne i j with rfl|hi,
     { split_ifs with hb,
       { simp [hb] },
       { simp } },
-    { cases x.zero j with hj hj,
+    { obtain hj | (hj : f j = 0) := s.prop j,
       { split_ifs;
         simp [multiset.mem_erase_of_ne hi.symm, hj] },
       { simp [function.update_noteq hi.symm, hj] } }
-  end⟩)
-  (λ x y h j,
-    show function.update x.to_fun i b j = function.update y.to_fun i b j,
-    by rw (funext h : x.to_fun = y.to_fun)) f
+  end⟩⟩
 
 variables (j : ι)
 
 @[simp] lemma coe_update : (f.update i b : Π (i : ι), β i) = function.update f i b :=
-quotient.induction_on f (λ _, rfl)
+rfl
 @[simp] lemma update_self [decidable (f i = 0)] : f.update i (f i) = f :=
 by { ext, simp }
 
@@ -751,25 +715,26 @@ protected theorem induction {p : (Π₀ i, β i) → Prop} (f : Π₀ i, β i)
   (h0 : p 0) (ha : ∀i b (f : Π₀ i, β i), f i = 0 → b ≠ 0 → p f → p (single i b + f)) :
   p f :=
 begin
-  refine quotient.induction_on f (λ x, _),
-  cases x with f s H, revert f H,
-  apply multiset.induction_on s,
-  { intros f H, convert h0, ext i, exact (H i).resolve_left id },
-  intros i s ih f H,
-  have H2 : p (erase i ⟦{to_fun := f, pre_support := i ::ₘ s, zero := H}⟧),
-  { dsimp only [erase, quotient.map_mk],
+  cases f with f s,
+  induction s using trunc.induction_on,
+  cases s with s H,
+  induction s using multiset.induction_on with i s ih generalizing f,
+  { have : f = 0 := funext (λ i, (H i).resolve_left id),
+    subst this,
+    exact h0 },
+  have H2 : p (erase i ⟨f, trunc.mk ⟨i ::ₘ s, H⟩⟩),
+  { dsimp only [erase, trunc.map, trunc.bind, trunc.lift_on, trunc.lift_mk, function.comp,
+      subtype.coe_mk],
     have H2 : ∀ j, j ∈ s ∨ ite (j = i) 0 (f j) = 0,
     { intro j, cases H j with H2 H2,
       { cases multiset.mem_cons.1 H2 with H3 H3,
         { right, exact if_pos H3 },
         { left, exact H3 } },
       right, split_ifs; [refl, exact H2] },
-    have H3 : (⟦{to_fun := λ (j : ι), ite (j = i) 0 (f j),
-         pre_support := i ::ₘ s, zero := _}⟧ : Π₀ i, β i)
-      = ⟦{to_fun := λ (j : ι), ite (j = i) 0 (f j), pre_support := s, zero := H2}⟧ :=
-      quotient.sound (λ i, rfl),
+    have H3 : (⟨λ (j : ι), ite (j = i) 0 (f j), trunc.mk ⟨i ::ₘ s, _⟩⟩ : Π₀ i, β i)
+      = ⟨λ (j : ι), ite (j = i) 0 (f j), trunc.mk ⟨s, H2⟩⟩ := ext (λ _, rfl),
     rw H3, apply ih },
-  have H3 : single i _ + _ = (⟦{to_fun := f, pre_support := i ::ₘ s, zero := H}⟧ : Π₀ i, β i) :=
+  have H3 : single i _ + _ = (⟨f, trunc.mk ⟨i ::ₘ s, H⟩⟩ : Π₀ i, β i) :=
     single_add_erase _ _,
   rw ← H3,
   change p (single i (f i) + _),
@@ -864,30 +829,34 @@ variables [Π i, has_zero (β i)] [Π i (x : β i), decidable (x ≠ 0)]
 
 /-- Set `{i | f x ≠ 0}` as a `finset`. -/
 def support (f : Π₀ i, β i) : finset ι :=
-quotient.lift_on f (λ x, x.2.to_finset.filter $ λ i, x.1 i ≠ 0) $
+f.support'.lift (λ xs, (multiset.to_finset ↑xs).filter $ λ i, f i ≠ 0) $
 begin
-  intros x y Hxy,
+  rintros ⟨sx, hx⟩ ⟨sy, hy⟩,
+  dsimp only [subtype.coe_mk, to_fun_eq_coe] at *,
   ext i, split,
   { intro H,
     rcases finset.mem_filter.1 H with ⟨h1, h2⟩,
-    rw Hxy i at h2,
-    exact finset.mem_filter.2 ⟨multiset.mem_to_finset.2 $ (y.3 i).resolve_right h2, h2⟩ },
+    exact finset.mem_filter.2 ⟨multiset.mem_to_finset.2 $ (hy i).resolve_right h2, h2⟩ },
   { intro H,
     rcases finset.mem_filter.1 H with ⟨h1, h2⟩,
-    rw ← Hxy i at h2,
-    exact finset.mem_filter.2 ⟨multiset.mem_to_finset.2 $ (x.3 i).resolve_right h2, h2⟩ },
+    exact finset.mem_filter.2 ⟨multiset.mem_to_finset.2 $ (hx i).resolve_right h2, h2⟩ },
 end
 
 @[simp] theorem support_mk_subset {s : finset ι} {x : Π i : (↑s : set ι), β i.1} :
   (mk s x).support ⊆ s :=
 λ i H, multiset.mem_to_finset.1 (finset.mem_filter.1 H).1
 
+@[simp] theorem support_mk'_subset {f : Π i, β i} {s : multiset ι} {h} :
+  (mk' f $ trunc.mk ⟨s, h⟩).support ⊆ s.to_finset :=
+λ i H, multiset.mem_to_finset.1 $ by simpa using (finset.mem_filter.1 H).1
+
 @[simp] theorem mem_support_to_fun (f : Π₀ i, β i) (i) : i ∈ f.support ↔ f i ≠ 0 :=
 begin
-  refine quotient.induction_on f (λ x, _),
-  dsimp only [support, quotient.lift_on_mk],
-  rw [finset.mem_filter, multiset.mem_to_finset],
-  exact and_iff_right_of_imp (x.3 i).resolve_right
+  cases f with f s,
+  induction s using trunc.induction_on,
+  dsimp only [support, trunc.lift_mk],
+  rw [finset.mem_filter, multiset.mem_to_finset, coe_mk],
+  exact and_iff_right_of_imp (s.prop i).resolve_right
 end
 
 theorem eq_mk_support (f : Π₀ i, β i) : f = mk f.support (λ i, f i) :=
@@ -924,7 +893,7 @@ begin
 end
 
 lemma support_single_subset {i : ι} {b : β i} : (single i b).support ⊆ {i} :=
-support_mk_subset
+support_mk'_subset
 
 section map_range_and_zip_with
 
@@ -1048,19 +1017,17 @@ open finset
 
 variables {κ : Type*}
 /--Reindexing (and possibly removing) terms of a dfinsupp.-/
-noncomputable def comap_domain [Π i, has_zero (β i)] (h : κ → ι) (hh : function.injective h) :
-  (Π₀ i, β i) → Π₀ k, β (h k) :=
-begin
-  refine quotient.lift (λ f, ⟦_⟧) (λ f f' h, _),
-  exact { to_fun := λ x, f.to_fun (h x),
-    pre_support := (f.pre_support.to_finset.preimage h (hh.inj_on _)).val,
-    zero := λ x, (f.zero (h x)).imp_left $ λ hx, mem_preimage.mpr $ multiset.mem_to_finset.mpr hx },
-  exact quot.sound (λ x, h _)
-end
+noncomputable def comap_domain [Π i, has_zero (β i)] (h : κ → ι) (hh : function.injective h)
+  (f : Π₀ i, β i) : Π₀ k, β (h k) :=
+{ to_fun := λ x, f (h x),
+  support' := f.support'.map $ λ s,
+    ⟨((multiset.to_finset ↑s).preimage h (hh.inj_on _)).val,
+    λ x, (s.prop (h x)).imp_left $ λ hx, mem_preimage.mpr $ multiset.mem_to_finset.mpr hx ⟩ }
+
 @[simp] lemma comap_domain_apply [Π i, has_zero (β i)] (h : κ → ι) (hh : function.injective h)
   (f : Π₀ i, β i) (k : κ) :
   comap_domain h hh f k = f (h k) :=
-by { rcases f, refl }
+rfl
 
 @[simp] lemma comap_domain_zero [Π i, has_zero (β i)] (h : κ → ι) (hh : function.injective h) :
   comap_domain h hh (0 : Π₀ i, β i) = 0 :=
@@ -1089,19 +1056,15 @@ end
 
 omit dec
 /--A computable version of comap_domain when an explicit left inverse is provided.-/
-def comap_domain'[Π i, has_zero (β i)] (h : κ → ι) {h' : ι → κ} (hh' : function.left_inverse h' h) :
-  (Π₀ i, β i) → (Π₀ k, β (h k)) :=
-begin
-  refine quotient.lift (λ f, ⟦_⟧) (λ f f' h, _),
-  exact { to_fun := λ x, f.to_fun (h x),
-    pre_support := f.pre_support.map h',
-    zero := λ x, (f.zero (h x)).imp_left $ λ hx, multiset.mem_map.mpr ⟨_, hx, hh' _⟩ },
-  exact quot.sound (λ x, h _),
-end
+def comap_domain' [Π i, has_zero (β i)] (h : κ → ι) {h' : ι → κ}
+  (hh' : function.left_inverse h' h) (f : Π₀ i, β i) : (Π₀ k, β (h k)) :=
+{ to_fun := λ x, f (h x),
+  support' := f.support'.map $ λ s, ⟨multiset.map h' s, λ x,
+    (s.prop (h x)).imp_left $ λ hx, multiset.mem_map.mpr ⟨_, hx, hh' _⟩⟩ }
 
 @[simp] lemma comap_domain'_apply [Π i, has_zero (β i)] (h : κ → ι) {h' : ι → κ}
   (hh' : function.left_inverse h' h) (f : Π₀ i, β i) (k : κ) : comap_domain' h hh' f k = f (h k) :=
-by { rcases f, refl }
+rfl
 
 @[simp] lemma comap_domain'_zero [Π i, has_zero (β i)] (h : κ → ι) {h' : ι → κ}
   (hh' : function.left_inverse h' h) :
@@ -1205,7 +1168,7 @@ begin
 end
 
 @[simp] lemma sigma_curry_single [Π i j, has_zero (δ i j)] (ij : Σ i, α i) (x : δ ij.1 ij.2) :
-  sigma_curry (single ij x) = single ij.1 (single ij.2 x : Π₀ j, δ ij.1 j) :=
+  @sigma_curry _ _ _ _ (single ij x) = single ij.1 (single ij.2 x : Π₀ j, δ ij.1 j) :=
 begin
   obtain ⟨i, j⟩ := ij,
   ext i' j',
@@ -1286,21 +1249,18 @@ variables {α : option ι → Type v}
 /-- Adds a term to a dfinsupp, making a dfinsupp indexed by an `option`.
 
 This is the dfinsupp version of `option.rec`. -/
-def extend_with [Π i, has_zero (α i)] (a : α none) : (Π₀ i, α (some i)) → Π₀ i, α i :=
-begin
-  refine quotient.lift (λ f, ⟦_⟧) (λ f f' h, _),
-  exact { to_fun := option.rec a f.to_fun,
-    pre_support := none ::ₘ (f.pre_support.map some),
-    zero := λ i, option.rec (or.inl $ multiset.mem_cons_self _ _)
-      (λ i, (f.zero i).imp_left $ λ h, multiset.mem_cons_of_mem $ multiset.mem_map_of_mem _ h) i },
-  { refine quot.sound (option.rec _ $ λ x, _), refl, exact h x },
-end
+def extend_with [Π i, has_zero (α i)] (a : α none) (f : Π₀ i, α (some i)) : Π₀ i, α i :=
+{ to_fun := option.rec a f,
+  support' := f.support'.map $ λ s, ⟨none ::ₘ multiset.map some s, λ i,
+    option.rec (or.inl $ multiset.mem_cons_self _ _)
+      (λ i, (s.prop i).imp_left $ λ h, multiset.mem_cons_of_mem $ multiset.mem_map_of_mem _ h) i⟩ }
+
 @[simp] lemma extend_with_none [Π i, has_zero (α i)] (f : Π₀ i, α (some i)) (a : α none) :
   f.extend_with a none = a :=
-by { rcases f, refl }
+rfl
 @[simp] lemma extend_with_some [Π i, has_zero (α i)] (f : Π₀ i, α (some i)) (a : α none) (i : ι) :
   f.extend_with a (some i) = f i :=
-by { rcases f, refl }
+rfl
 
 @[simp] lemma extend_with_single_zero [decidable_eq ι] [Π i, has_zero (α i)]
   (i : ι) (x : α (some i)) :
@@ -1335,9 +1295,10 @@ This is the dfinsupp version of `equiv.pi_option_equiv_prod`. -/
     { rw extend_with_none },
     { rw [extend_with_some, comap_domain_apply] }
   end,
-  right_inv := λ _, begin
+  right_inv := λ x, begin
+    dsimp only,
     ext,
-    { exact extend_with_none _ _ },
+    { exact extend_with_none x.snd _ },
     { rw [comap_domain_apply, extend_with_some] }
   end }
 
@@ -1498,43 +1459,44 @@ also an `add_monoid_hom`.
 def sum_add_hom [Π i, add_zero_class (β i)] [add_comm_monoid γ] (φ : Π i, β i →+ γ) :
   (Π₀ i, β i) →+ γ :=
 { to_fun := (λ f,
-    quotient.lift_on f (λ x, ∑ i in x.2.to_finset, φ i (x.1 i)) $ λ x y H,
+    f.support'.lift (λ s, ∑ i in multiset.to_finset ↑s, φ i (f i)) $
     begin
-      have H1 : x.2.to_finset ∩ y.2.to_finset ⊆ x.2.to_finset, from finset.inter_subset_left _ _,
-      have H2 : x.2.to_finset ∩ y.2.to_finset ⊆ y.2.to_finset, from finset.inter_subset_right _ _,
+      rintros ⟨sx, hx⟩ ⟨sy, hy⟩,
+      dsimp only [subtype.coe_mk, to_fun_eq_coe] at *,
+      have H1 : sx.to_finset ∩ sy.to_finset ⊆ sx.to_finset, from finset.inter_subset_left _ _,
+      have H2 : sx.to_finset ∩ sy.to_finset ⊆ sy.to_finset, from finset.inter_subset_right _ _,
       refine (finset.sum_subset H1 _).symm.trans
           ((finset.sum_congr rfl _).trans (finset.sum_subset H2 _)),
-      { intros i H1 H2, rw finset.mem_inter at H2, rw H i,
+      { intros i H1 H2, rw finset.mem_inter at H2,
         simp only [multiset.mem_to_finset] at H1 H2,
-        rw [(y.3 i).resolve_left (mt (and.intro H1) H2), add_monoid_hom.map_zero] },
-      { intros i H1, rw H i },
-      { intros i H1 H2, rw finset.mem_inter at H2, rw ← H i,
+        rw [(hy i).resolve_left (mt (and.intro H1) H2), add_monoid_hom.map_zero] },
+      { intros i H1, refl },
+      { intros i H1 H2, rw finset.mem_inter at H2,
         simp only [multiset.mem_to_finset] at H1 H2,
-        rw [(x.3 i).resolve_left (mt (λ H3, and.intro H3 H1) H2), add_monoid_hom.map_zero] }
+        rw [(hx i).resolve_left (mt (λ H3, and.intro H3 H1) H2), add_monoid_hom.map_zero] }
     end),
-  map_add' := assume f g,
-  begin
-    refine quotient.induction_on f (λ x, _),
-    refine quotient.induction_on g (λ y, _),
+  map_add' := begin
+    rintros ⟨f, sf, hf⟩ ⟨g, sg, hg⟩,
     change ∑ i in _, _ = (∑ i in _, _) + (∑ i in _, _),
-    simp only, conv { to_lhs, congr, skip, funext, rw add_monoid_hom.map_add },
-    simp only [finset.sum_add_distrib],
+    simp only [coe_add, coe_mk, subtype.coe_mk, pi.add_apply, map_add, finset.sum_add_distrib],
     congr' 1,
     { refine (finset.sum_subset _ _).symm,
       { intro i, simp only [multiset.mem_to_finset, multiset.mem_add], exact or.inl },
       { intros i H1 H2, simp only [multiset.mem_to_finset, multiset.mem_add] at H2,
-        rw [(x.3 i).resolve_left H2, add_monoid_hom.map_zero] } },
+        rw [(hf i).resolve_left H2, add_monoid_hom.map_zero] } },
     { refine (finset.sum_subset _ _).symm,
       { intro i, simp only [multiset.mem_to_finset, multiset.mem_add], exact or.inr },
       { intros i H1 H2, simp only [multiset.mem_to_finset, multiset.mem_add] at H2,
-        rw [(y.3 i).resolve_left H2, add_monoid_hom.map_zero] } }
+        rw [(hg i).resolve_left H2, add_monoid_hom.map_zero] } }
   end,
   map_zero' := rfl }
 
 @[simp] lemma sum_add_hom_single [Π i, add_zero_class (β i)] [add_comm_monoid γ]
   (φ : Π i, β i →+ γ) (i) (x : β i) : sum_add_hom φ (single i x) = φ i x :=
-(add_zero _).trans $ congr_arg (φ i) $ show (if H : i ∈ ({i} : finset _) then x else 0) = x,
-from dif_pos $ finset.mem_singleton_self i
+begin
+  dsimp [sum_add_hom, single, trunc.lift_mk],
+  rw [multiset.to_finset_singleton, finset.sum_singleton, pi.single_eq_same],
+end
 
 @[simp] lemma sum_add_hom_comp_single [Π i, add_zero_class (β i)] [add_comm_monoid γ]
   (f : Π i, β i →+ γ) (i : ι) :
@@ -1546,11 +1508,11 @@ lemma sum_add_hom_apply [Π i, add_zero_class (β i)] [Π i (x : β i), decidabl
   [add_comm_monoid γ] (φ : Π i, β i →+ γ) (f : Π₀ i, β i) :
   sum_add_hom φ f = f.sum (λ x, φ x) :=
 begin
-  refine quotient.induction_on f (λ x, _),
+  rcases f with ⟨f, s, hf⟩,
   change ∑ i in _, _ = (∑ i in finset.filter _ _, _),
   rw [finset.sum_filter, finset.sum_congr rfl],
   intros i _,
-  dsimp only,
+  dsimp only [coe_mk, subtype.coe_mk] at *,
   split_ifs,
   refl,
   rw [(not_not.mp h), add_monoid_hom.map_zero],
@@ -1631,9 +1593,9 @@ lemma sum_add_hom_comm {ι₁ ι₂ : Sort*} {β₁ : ι₁ → Type*} {β₂ : 
   sum_add_hom (λ i₂, sum_add_hom (λ i₁, h i₁ i₂) f₁) f₂ =
   sum_add_hom (λ i₁, sum_add_hom (λ i₂, (h i₁ i₂).flip) f₂) f₁ :=
 begin
-  refine quotient.induction_on₂ f₁ f₂ (λ x₁ x₂, _),
+  obtain ⟨⟨f₁, s₁, h₁⟩, ⟨f₂, s₂, h₂⟩⟩ := ⟨f₁, f₂⟩,
   simp only [sum_add_hom, add_monoid_hom.finset_sum_apply, quotient.lift_on_mk,
-    add_monoid_hom.coe_mk, add_monoid_hom.flip_apply],
+    add_monoid_hom.coe_mk, add_monoid_hom.flip_apply, trunc.lift],
   exact finset.sum_comm,
 end
 

--- a/src/data/dfinsupp/order.lean
+++ b/src/data/dfinsupp/order.lean
@@ -44,8 +44,8 @@ lemma le_def {f g : Π₀ i, α i} : f ≤ g ↔ ∀ i, f i ≤ g i := iff.rfl
 
 /-- The order on `dfinsupp`s over a partial order embeds into the order on functions -/
 def order_embedding_to_fun : (Π₀ i, α i) ↪o Π i, α i :=
-{ to_fun := λ f, f,
-  inj' := λ f g h, dfinsupp.ext $ λ i, by { dsimp at h, rw h },
+{ to_fun := coe_fn,
+  inj' := coe_fn_injective,
   map_rel_iff' := λ a b, (@le_def _ _ _ _ a b).symm }
 
 @[simp] lemma order_embedding_to_fun_apply {f : Π₀ i, α i} {i : ι} :

--- a/src/data/finsupp/to_dfinsupp.lean
+++ b/src/data/finsupp/to_dfinsupp.lean
@@ -65,7 +65,9 @@ section defs
 
 /-- Interpret a `finsupp` as a homogenous `dfinsupp`. -/
 def finsupp.to_dfinsupp [has_zero M] (f : ι →₀ M) : Π₀ i : ι, M :=
-⟦⟨f, f.support.1, λ i, (classical.em (f i = 0)).symm.imp_left (finsupp.mem_support_iff.mpr)⟩⟧
+{ to_fun := f,
+  support' := trunc.mk
+    ⟨f.support.1, λ i, (classical.em (f i = 0)).symm.imp_left (finsupp.mem_support_iff.mpr)⟩ }
 
 @[simp] lemma finsupp.to_dfinsupp_coe [has_zero M] (f : ι →₀ M) : ⇑f.to_dfinsupp = f := rfl
 
@@ -204,11 +206,11 @@ open finsupp
 
 /-- `finsupp.split` is an equivalence between `(Σ i, η i) →₀ N` and `Π₀ i, (η i →₀ N)`. -/
 def sigma_finsupp_equiv_dfinsupp [has_zero N] : ((Σ i, η i) →₀ N) ≃ (Π₀ i, (η i →₀ N)) :=
-{ to_fun := λ f, ⟦⟨split f, (split_support f : finset ι).val, λ i,
+{ to_fun := λ f, ⟨split f, trunc.mk ⟨(split_support f : finset ι).val, λ i,
     begin
-    rw [← finset.mem_def, mem_split_support_iff_nonzero],
-    exact (decidable.em _).symm
-    end⟩⟧,
+      rw [← finset.mem_def, mem_split_support_iff_nonzero],
+      exact (decidable.em _).symm
+    end⟩⟩,
   inv_fun := λ f,
   begin
     refine on_finset (finset.sigma f.support (λ j, (f j).support)) (λ ji, f ji.1 ji.2)


### PR DESCRIPTION
This means that `dfinsupp.coe_add` etc are true by definition, rather than requiring the application of `quotient.induction` first.
The key change is that the underlying function is no longer "hidden" under the quotient, as it does not need to be.

One motivation for this is to make the API more similar to that of `finsupp`.

This change eliminates `dfinsupp.pre`, instead using `{s : multiset ι // ∀ i, i ∈ s ∨ to_fun i = 0}` directly.
We no longer even need to create a `setoid` instance, since we can just use `trunc`.

While adjusting some proofs in `data/finsupp/interval` to use the new definition, this ended up eliminating some decidable arguments. I don't think that is a consequence of this redefinition, and is incidental cleanup that could have been performed separately.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
