### PR TITLE
feat(topology/{instances/ennreal,metric_space/hausdorff_distance)): technical lemmas

### DIFF
--- a/src/topology/instances/ennreal.lean
+++ b/src/topology/instances/ennreal.lean
@@ -136,6 +136,27 @@ def lt_top_homeomorph_nnreal : {a | a < ∞} ≃ₜ ℝ≥0 :=
 by refine (homeomorph.set_congr $ set.ext $ λ x, _).trans ne_top_homeomorph_nnreal;
   simp only [mem_set_of_eq, lt_top_iff_ne_top]
 
+/-- If `f : α → ℝ≥0∞` is a continuous function, then there exists a continuous function
+`g : α → ℝ≥0` that is equal to zero when `f x = 0` and is strictly between zero and `f x` when
+`f x ≠ 0`. -/
+lemma exists_continuous_pos_lt [topological_space α] {f : α → ℝ≥0∞} (hf : continuous f) :
+  ∃ g : C(α, ℝ≥0), (∀ x, f x = 0 → g x = 0) ∧ (∀ x, f x ≠ 0 → 0 < g x ∧ ↑(g x) < f x) :=
+begin
+  have h : ∀ {a : ℝ≥0∞}, min a 1 ≠ ∞, from λ a, (min_lt_iff.2 $ or.inr ennreal.one_lt_top).ne,
+  have h₀ : ∀ {a : ℝ≥0∞}, a ≠ 0 → min a 1 ≠ 0,
+    from λ a ha, (lt_min ha.bot_lt ennreal.zero_lt_one).ne',
+  refine ⟨⟨λ x, (min (f x) 1).to_nnreal / 2, _⟩, λ x, _, λ x, _⟩,
+  { refine (continuous_iff_continuous_at.2 $ λ x, (ennreal.tendsto_to_nnreal _).comp _).div_const,
+    exacts [h, (hf.min continuous_const).continuous_at] },
+  { intro hx,
+    simp only [hx, continuous_map.coe_mk, zero_min, ennreal.zero_to_nnreal, _root_.zero_div] },
+  { intro hx, split,
+    { exact (nnreal.half_pos $ ennreal.to_nnreal_pos (h₀ hx) h) },
+    { rw [continuous_map.coe_mk, ennreal.coe_div _root_.two_ne_zero, ennreal.coe_two,
+        ennreal.coe_to_nnreal h],
+      exact (ennreal.half_lt_self (h₀ hx) h).trans_le (min_le_left _ _) } }
+end
+
 lemma nhds_top : 𝓝 ∞ = ⨅ a ≠ ∞, 𝓟 (Ioi a) :=
 nhds_top_order.trans $ by simp [lt_top_iff_ne_top, Ioi]
 
@@ -317,6 +338,12 @@ protected lemma tendsto.mul {f : filter α} {ma : α → ℝ≥0∞} {mb : α �
   tendsto (λa, ma a * mb a) f (𝓝 (a * b)) :=
 show tendsto ((λp:ℝ≥0∞×ℝ≥0∞, p.1 * p.2) ∘ (λa, (ma a, mb a))) f (𝓝 (a * b)), from
 tendsto.comp (ennreal.tendsto_mul ha hb) (hma.prod_mk_nhds hmb)
+
+lemma _root_.continuous.ennreal_mul [topological_space α] {f g : α → ℝ≥0∞} (hf : continuous f)
+  (hg : continuous g) (h₁ : ∀ x, f x ≠ 0 ∨ g x ≠ ∞) (h₂ : ∀ x, g x ≠ 0 ∨ f x ≠ ∞) :
+  continuous (λ x, f x * g x) :=
+continuous_iff_continuous_at.2 $
+  λ x, ennreal.tendsto.mul hf.continuous_at (h₁ x) hg.continuous_at (h₂ x)
 
 protected lemma tendsto.const_mul {f : filter α} {m : α → ℝ≥0∞} {a b : ℝ≥0∞}
   (hm : tendsto m f (𝓝 b)) (hb : b ≠ 0 ∨ a ≠ ⊤) : tendsto (λb, a * m b) f (𝓝 (a * b)) :=

--- a/src/topology/metric_space/hausdorff_distance.lean
+++ b/src/topology/metric_space/hausdorff_distance.lean
@@ -185,6 +185,26 @@ begin
   exact mem_closure_iff_inf_edist_zero.2 H,
 end
 
+/-- Every open set `U` in a (pseudo)emetric space is the support of a continuous function
+`r : α → ℝ≥0` that is less than the infimum extended distance to `Uᶜ` at all points
+`x ∈ U`. -/
+lemma _root_.is_open.exists_continuous_pos_lt_inf_edist {U : set α} (hU : is_open U) :
+  ∃ r : C(α, ℝ≥0), support r = U ∧ ∀ x ∈ U, ↑(r x) < inf_edist x Uᶜ :=
+begin
+  rcases ennreal.exists_continuous_pos_lt (@continuous_inf_edist _ _ Uᶜ) with ⟨r, h₁, h₂⟩,
+  simp only [ne.def, ← mem_iff_inf_edist_zero_of_closed hU.is_closed_compl, mem_compl_iff,
+    not_not] at h₁ h₂,
+  exact ⟨r, ext (λ x, ⟨not_imp_comm.2 (h₁ x), λ hx, (h₂ x hx).1.ne'⟩), λ x hx, (h₂ x hx).2⟩,
+end
+
+/-- Every open set `U` in a (pseudo)emetric space is the support of a continuous function
+`r : α → ℝ≥0` such that `emetric.closed_ball x (r x) ⊆ U` whenever `x ∈ U`. -/
+lemma _root_.is_open.exists_continuous_pos_emetric_closed_ball_subset {U : set α} (hU : is_open U) :
+  ∃ r : C(α, ℝ≥0), support r = U ∧ ∀ x ∈ U, closed_ball x (r x) ⊆ U :=
+let ⟨r, hr, hlt⟩ := hU.exists_continuous_pos_lt_inf_edist
+in ⟨r, hr, λ x hx, disjoint_compl_right_iff_subset.1
+  (disjoint_closed_ball_of_lt_inf_edist $ hlt x hx)⟩
+
 end inf_edist --section
 
 /-! ### The Hausdorff distance as a function into `ℝ≥0∞`. -/


### PR DESCRIPTION
These lemmas were written as part of an unsuccessful attempt to prove
Lemma 3.6 from the sphere eversion project in a different way. I'm not
sure that we want them in `mathlib`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
