### PR TITLE
[Merged by Bors] - feat(data/nat/pairing): basic bounds on `mkpair`

### DIFF
--- a/src/data/nat/pairing.lean
+++ b/src/data/nat/pairing.lean
@@ -129,16 +129,13 @@ begin
     exact le_trans h₁ (nat.le_add_left _ _) }
 end
 
-theorem mkpair_lt_max_succ_sq (m n : ℕ) : mkpair m n < (max m n + 1) ^ 2 :=
+theorem mkpair_lt_max_add_one_sq (m n : ℕ) : mkpair m n < (max m n + 1) ^ 2 :=
 begin
-  rw mkpair,
-  split_ifs,
-  { rw [max_eq_right h.le, add_sq, add_assoc, sq, add_lt_add_iff_left, mul_one,
-      two_mul, add_assoc],
+  rw [mkpair, add_sq, mul_one, two_mul, sq, add_assoc, add_assoc],
+  cases lt_or_le m n,
+  { rw [if_pos h, max_eq_right h.le, add_lt_add_iff_left, add_assoc],
     exact h.trans_le (self_le_add_right n _) },
-  { rw not_lt at h,
-    rw [max_eq_left h, add_sq, add_assoc, add_assoc, sq, add_lt_add_iff_left, mul_one,
-      two_mul, add_assoc, add_lt_add_iff_left],
+  { rw [if_neg h.not_lt, max_eq_left h, add_lt_add_iff_left, add_assoc, add_lt_add_iff_left],
     exact lt_succ_of_le h }
 end
 
@@ -152,17 +149,11 @@ begin
 end
 
 theorem add_le_mkpair (m n : ℕ) : m + n ≤ mkpair m n :=
-begin
-  rw mkpair,
-  split_ifs,
-  { rw [add_comm, add_le_add_iff_right],
-    exact le_mul_self n },
-  { rw add_assoc,
-    apply self_le_add_left }
-end
+(max_sq_add_min_le_mkpair _ _).trans' $
+  by { rw [sq, ←min_add_max, add_comm, add_le_add_iff_right], exact le_mul_self _ }
 
 theorem unpair_add_le (n : ℕ) : (unpair n).1 + (unpair n).2 ≤ n :=
-by { rw [←mkpair_unpair n, unpair_mkpair], apply add_le_mkpair }
+(add_le_mkpair _ _).trans_eq (mkpair_unpair _)
 
 end nat
 open nat

--- a/src/data/nat/pairing.lean
+++ b/src/data/nat/pairing.lean
@@ -142,6 +142,16 @@ begin
     exact lt_succ_of_le h }
 end
 
+theorem max_sq_add_min_le_mkpair (m n : ℕ) : max m n ^ 2 + min m n ≤ mkpair m n :=
+begin
+  rw mkpair,
+  split_ifs,
+  { rw [max_eq_right h.le, min_eq_left h.le, sq] },
+  { rw not_lt at h,
+    rw [max_eq_left h, min_eq_right h, sq, add_assoc, add_le_add_iff_left],
+    apply h.trans (self_le_add_right m n) }
+end
+
 theorem add_le_mkpair (m n : ℕ) : m + n ≤ mkpair m n :=
 begin
   rw mkpair,

--- a/src/data/nat/pairing.lean
+++ b/src/data/nat/pairing.lean
@@ -129,6 +129,32 @@ begin
     exact le_trans h₁ (nat.le_add_left _ _) }
 end
 
+theorem mkpair_lt_max_succ_sq (m n : ℕ) : mkpair m n < (max m n + 1) ^ 2 :=
+begin
+  rw mkpair,
+  split_ifs,
+  { rw [max_eq_right h.le, add_sq, add_assoc, sq, add_lt_add_iff_left, mul_one,
+      two_mul, add_assoc],
+    exact h.trans_le (self_le_add_right n _) },
+  { rw not_lt at h,
+    rw [max_eq_left h, add_sq, add_assoc, add_assoc, sq, add_lt_add_iff_left, mul_one,
+      two_mul, add_assoc, add_lt_add_iff_left],
+    exact lt_succ_of_le h }
+end
+
+theorem add_le_mkpair (m n : ℕ) : m + n ≤ mkpair m n :=
+begin
+  rw mkpair,
+  split_ifs,
+  { rw [add_comm, add_le_add_iff_right],
+    exact le_mul_self n },
+  { rw add_assoc,
+    apply self_le_add_left }
+end
+
+theorem unpair_add_le (n : ℕ) : (unpair n).1 + (unpair n).2 ≤ n :=
+by { rw [←mkpair_unpair n, unpair_mkpair], apply add_le_mkpair }
+
 end nat
 open nat
 

--- a/src/data/nat/pairing.lean
+++ b/src/data/nat/pairing.lean
@@ -145,11 +145,10 @@ end
 theorem max_sq_add_min_le_mkpair (m n : ℕ) : max m n ^ 2 + min m n ≤ mkpair m n :=
 begin
   rw mkpair,
-  split_ifs,
-  { rw [max_eq_right h.le, min_eq_left h.le, sq] },
-  { rw not_lt at h,
-    rw [max_eq_left h, min_eq_right h, sq, add_assoc, add_le_add_iff_left],
-    apply h.trans (self_le_add_right m n) }
+  cases lt_or_le m n,
+  { rw [if_pos h, max_eq_right h.le, min_eq_left h.le, sq], },
+  { rw [if_neg h.not_lt, max_eq_left h, min_eq_right h, sq, add_assoc, add_le_add_iff_left],
+    exact le_add_self }
 end
 
 theorem add_le_mkpair (m n : ℕ) : m + n ≤ mkpair m n :=


### PR DESCRIPTION
Needed for #15505.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

The proofs could be simplified using `linarith`, but this seems to be too basic of a file for it to be used.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
