### PR TITLE
[Merged by Bors] - feat(set_theory/zfc/ordinal): more lemmas on transitive sets

### DIFF
--- a/src/set_theory/zfc/ordinal.lean
+++ b/src/set_theory/zfc/ordinal.lean
@@ -26,6 +26,10 @@ Further development can be found on the branch `von_neumann_v2`.
   `set_theory/ordinal/arithmetic.lean`.
 -/
 
+universe u
+
+variables {x y z : Set.{u}}
+
 namespace Set
 
 /-- A transitive set is one where every element is a subset. -/

--- a/src/set_theory/zfc/ordinal.lean
+++ b/src/set_theory/zfc/ordinal.lean
@@ -60,11 +60,11 @@ theorem is_transitive.sUnion' (H : ∀ y ∈ x, is_transitive y) : (⋃₀ x).is
   exact mem_sUnion_of_mem ((H w hw).mem_trans hz hw') hw
 end
 
-theorem is_transitive_iff_Union_subset : x.is_transitive ↔ ⋃₀ x ⊆ x :=
+theorem is_transitive_iff_sUnion_subset : x.is_transitive ↔ ⋃₀ x ⊆ x :=
 ⟨λ h y hy, by { rcases mem_sUnion.1 hy with ⟨z, hz, hz'⟩, exact h.mem_trans hz' hz },
   λ H y hy z hz, H $ mem_sUnion_of_mem hz hy⟩
 
-alias is_transitive_iff_Union_subset ↔ is_transitive.Union_subset _
+alias is_transitive_iff_sUnion_subset ↔ is_transitive.sUnion_subset _
 
 theorem is_transitive_iff_subset_powerset : x.is_transitive ↔ x ⊆ powerset x :=
 ⟨λ h y hy, mem_powerset.2 $ h.subset_of_mem hy, λ H y hy z hz, mem_powerset.1 (H hy) hz⟩

--- a/src/set_theory/zfc/ordinal.lean
+++ b/src/set_theory/zfc/ordinal.lean
@@ -31,27 +31,38 @@ namespace Set
 /-- A transitive set is one where every element is a subset. -/
 def is_transitive (x : Set) : Prop := ∀ y ∈ x, y ⊆ x
 
-theorem is_transitive.subset_of_mem {x y : Set} (h : x.is_transitive) : y ∈ x → y ⊆ x := h y
+@[simp] theorem empty_is_transitive : is_transitive ∅ := λ y hy, (mem_empty y hy).elim
 
-theorem is_transitive_iff_mem_trans {z : Set} :
-  z.is_transitive ↔ ∀ {x y : Set}, x ∈ y → y ∈ z → x ∈ z :=
+theorem is_transitive.subset_of_mem (h : x.is_transitive) : y ∈ x → y ⊆ x := h y
+
+theorem is_transitive_iff_mem_trans : z.is_transitive ↔ ∀ {x y : Set}, x ∈ y → y ∈ z → x ∈ z :=
 ⟨λ h x y hx hy, h.subset_of_mem hy hx, λ H x hx y hy, H hy hx⟩
 
 alias is_transitive_iff_mem_trans ↔ is_transitive.mem_trans _
 
-theorem is_transitive.sUnion {x : Set} (h : x.is_transitive) : (⋃₀ x).is_transitive :=
+protected theorem is_transitive.inter (hx : x.is_transitive) (hy : y.is_transitive) :
+  (x ∩ y).is_transitive :=
+λ z hz w hw, by { rw mem_inter at hz ⊢, exact ⟨hx.mem_trans hw hz.1, hy.mem_trans hw hz.2⟩ }
+
+protected theorem is_transitive.sUnion (h : x.is_transitive) : (⋃₀ x).is_transitive :=
 λ y hy z hz, begin
   rcases mem_sUnion.1 hy with ⟨w, hw, hw'⟩,
   exact mem_sUnion_of_mem hz (h.mem_trans hw' hw)
 end
 
-theorem is_transitive_iff_sUnion_subset {x : Set} : x.is_transitive ↔ ⋃₀ x ⊆ x :=
+theorem is_transitive.sUnion' (H : ∀ y ∈ x, is_transitive y) : (⋃₀ x).is_transitive :=
+λ y hy z hz, begin
+  rcases mem_sUnion.1 hy with ⟨w, hw, hw'⟩,
+  exact mem_sUnion_of_mem ((H w hw).mem_trans hz hw') hw
+end
+
+theorem is_transitive_iff_Union_subset : x.is_transitive ↔ ⋃₀ x ⊆ x :=
 ⟨λ h y hy, by { rcases mem_sUnion.1 hy with ⟨z, hz, hz'⟩, exact h.mem_trans hz' hz },
   λ H y hy z hz, H $ mem_sUnion_of_mem hz hy⟩
 
-alias is_transitive_iff_sUnion_subset ↔ is_transitive.sUnion_subset _
+alias is_transitive_iff_Union_subset ↔ is_transitive.Union_subset _
 
-theorem is_transitive_iff_subset_powerset {x : Set} : x.is_transitive ↔ x ⊆ powerset x :=
+theorem is_transitive_iff_subset_powerset : x.is_transitive ↔ x ⊆ powerset x :=
 ⟨λ h y hy, mem_powerset.2 $ h.subset_of_mem hy, λ H y hy z hz, mem_powerset.1 (H hy) hz⟩
 
 alias is_transitive_iff_subset_powerset ↔ is_transitive.subset_powerset _


### PR DESCRIPTION
We add `empty_is_transitive`, `is_transitive.inter`, and `is_transitive.sUnion'`. We also add a `variables` block.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
