### PR TITLE
[Merged by Bors] - feat(data/real/basic): add a repr showing an underlying cauchy sequence

### DIFF
--- a/src/data/real/basic.lean
+++ b/src/data/real/basic.lean
@@ -286,7 +286,11 @@ noncomputable instance decidable_lt (a b : ℝ) : decidable (a < b) := by apply_
 noncomputable instance decidable_le (a b : ℝ) : decidable (a ≤ b) := by apply_instance
 noncomputable instance decidable_eq (a b : ℝ) : decidable (a = b) := by apply_instance
 
-/-- Show the underlying cauchy series for real numbers. -/
+/-- Show an underlying cauchy sequence for real numbers.
+
+The representative chosen is the one passed in the VM to `quot.mk`, so two cauchy sequences
+converging to the same number may be printed differently.
+-/
 meta instance : has_repr ℝ :=
 { repr := λ r, "real.of_cauchy " ++ repr r.cauchy }
 

--- a/src/data/real/basic.lean
+++ b/src/data/real/basic.lean
@@ -286,7 +286,17 @@ noncomputable instance decidable_lt (a b : ℝ) : decidable (a < b) := by apply_
 noncomputable instance decidable_le (a b : ℝ) : decidable (a ≤ b) := by apply_instance
 noncomputable instance decidable_eq (a b : ℝ) : decidable (a = b) := by apply_instance
 
-open rat
+/-- Attempt to show the underlying cauchy series for real numbers. Note that this is not all that
+useful, since most real numbers can't be computed in the first place.
+
+For cauchy sequences which don't converge in 5 steps, we just use `sorry` as a repr along with a
+comment. -/
+meta instance : has_repr ℝ :=
+{ repr := λ r,
+  let N := 5, seq := r.cauchy.unquot in
+    option.get_or_else
+      ((list.range N).mfirst $ λ i, if seq i = seq i.succ then some (repr (seq i)) else none)
+      ("(⟨sorry /- " ++ (",".intercalate $ (list.range N).map $ repr ∘ seq) ++ ",... -/⟩ : ℝ)") }
 
 @[simp] theorem of_rat_eq_cast : ∀ x : ℚ, of_rat x = x :=
 of_rat.eq_rat_cast

--- a/src/data/real/basic.lean
+++ b/src/data/real/basic.lean
@@ -286,17 +286,9 @@ noncomputable instance decidable_lt (a b : ℝ) : decidable (a < b) := by apply_
 noncomputable instance decidable_le (a b : ℝ) : decidable (a ≤ b) := by apply_instance
 noncomputable instance decidable_eq (a b : ℝ) : decidable (a = b) := by apply_instance
 
-/-- Attempt to show the underlying cauchy series for real numbers. Note that this is not all that
-useful, since most real numbers can't be computed in the first place.
-
-For cauchy sequences which don't converge in 5 steps, we just use `sorry` as a repr along with a
-comment. -/
+/-- Show the underlying cauchy series for real numbers. -/
 meta instance : has_repr ℝ :=
-{ repr := λ r,
-  let N := 5, seq := r.cauchy.unquot in
-    option.get_or_else
-      ((list.range N).mfirst $ λ i, if seq i = seq i.succ then some (repr (seq i)) else none)
-      ("(⟨sorry /- " ++ (",".intercalate $ (list.range N).map $ repr ∘ seq) ++ ",... -/⟩ : ℝ)") }
+{ repr := λ r, "real.of_cauchy " ++ repr r.cauchy }
 
 @[simp] theorem of_rat_eq_cast : ∀ x : ℚ, of_rat x = x :=
 of_rat.eq_rat_cast

--- a/src/data/real/cau_seq_completion.lean
+++ b/src/data/real/cau_seq_completion.lean
@@ -175,8 +175,12 @@ congr_arg mk $ by split_ifs with h; [simp [const_lim_zero.1 h], refl]
 theorem of_rat_div (x y : β) : of_rat (x / y) = (of_rat x / of_rat y : Cauchy) :=
 by simp only [div_eq_inv_mul, of_rat_inv, of_rat_mul]
 
-/-- Show the first 10 items of a cauchy series -/
-meta instance [has_repr β]: has_repr Cauchy :=
+/-- Show the first 10 items of a representative of this equivalence class of cauchy sequences.
+
+The representative chosen is the one passed in the VM to `quot.mk`, so two cauchy sequences
+converging to the same number may be printed differently.
+-/
+meta instance [has_repr β] : has_repr Cauchy :=
 { repr := λ r,
   let N := 10, seq := r.unquot in
     "(sorry /- " ++ (", ".intercalate $ (list.range N).map $ repr ∘ seq) ++ ", ... -/)" }

--- a/src/data/real/cau_seq_completion.lean
+++ b/src/data/real/cau_seq_completion.lean
@@ -175,6 +175,12 @@ congr_arg mk $ by split_ifs with h; [simp [const_lim_zero.1 h], refl]
 theorem of_rat_div (x y : β) : of_rat (x / y) = (of_rat x / of_rat y : Cauchy) :=
 by simp only [div_eq_inv_mul, of_rat_inv, of_rat_mul]
 
+/-- Show the first 10 items of a cauchy series -/
+meta instance [has_repr β]: has_repr Cauchy :=
+{ repr := λ r,
+  let N := 10, seq := r.unquot in
+    "(sorry /- " ++ (", ".intercalate $ (list.range N).map $ repr ∘ seq) ++ ", ... -/)" }
+
 end
 end cau_seq.completion
 

--- a/test/real.lean
+++ b/test/real.lean
@@ -1,10 +1,10 @@
 import data.real.basic
 
-meta def test_repr (r : ℝ) (s : string) : tactic unit := guard (repr r = s)
+meta def test_repr (r : ℝ) (s : string) : tactic unit :=
+guard (repr r = s) <|> fail!"got {repr r}"
 
-run_cmd test_repr 0 "0"
-run_cmd test_repr 1 "1"
-run_cmd test_repr (37 : ℕ) "37"
-run_cmd test_repr (3.7 : ℚ) "37/10"
+run_cmd test_repr 0 "real.of_cauchy (sorry /- 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, ... -/)"
+run_cmd test_repr 1 "real.of_cauchy (sorry /- 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, ... -/)"
+run_cmd test_repr (37 : ℕ) "real.of_cauchy (sorry /- 37, 37, 37, 37, 37, 37, 37, 37, 37, 37, ... -/)"
 run_cmd test_repr ⟨cau_seq.completion.mk $ ⟨λ n, 2^(-n:ℤ), sorry⟩⟩
-                  "(⟨sorry /- 1,1/2,1/4,1/8,1/16,... -/⟩ : ℝ)"
+                  "real.of_cauchy (sorry /- 1, 1/2, 1/4, 1/8, 1/16, 1/32, 1/64, 1/128, 1/256, 1/512, ... -/)"

--- a/test/real.lean
+++ b/test/real.lean
@@ -6,5 +6,6 @@ guard (repr r = s) <|> fail!"got {repr r}"
 run_cmd test_repr 0 "real.of_cauchy (sorry /- 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, ... -/)"
 run_cmd test_repr 1 "real.of_cauchy (sorry /- 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, ... -/)"
 run_cmd test_repr (37 : ℕ) "real.of_cauchy (sorry /- 37, 37, 37, 37, 37, 37, 37, 37, 37, 37, ... -/)"
+run_cmd test_repr (2 + 3) "real.of_cauchy (sorry /- 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, ... -/)"
 run_cmd test_repr ⟨cau_seq.completion.mk $ ⟨λ n, 2^(-n:ℤ), sorry⟩⟩
                   "real.of_cauchy (sorry /- 1, 1/2, 1/4, 1/8, 1/16, 1/32, 1/64, 1/128, 1/256, 1/512, ... -/)"

--- a/test/real.lean
+++ b/test/real.lean
@@ -1,0 +1,10 @@
+import data.real.basic
+
+meta def test_repr (r : ℝ) (s : string) : tactic unit := guard (repr r = s)
+
+run_cmd test_repr 0 "0"
+run_cmd test_repr 1 "1"
+run_cmd test_repr (37 : ℕ) "37"
+run_cmd test_repr (3.7 : ℚ) "37/10"
+run_cmd test_repr ⟨cau_seq.completion.mk $ ⟨λ n, 2^(-n:ℤ), sorry⟩⟩
+                  "(⟨sorry /- 1,1/2,1/4,1/8,1/16,... -/⟩ : ℝ)"


### PR DESCRIPTION
This isn't all that useful, but it gives a slightly nicer experience for users who are surprised when `#eval (2 + 3 : real)` emits a gigantic pile of garbage.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
-->


[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
