### PR TITLE
[Merged by Bors] - feat(linear_algebra): lemmas on associatedness of determinants of linear maps

### DIFF
--- a/src/linear_algebra/determinant.lean
+++ b/src/linear_algebra/determinant.lean
@@ -409,6 +409,25 @@ have is_unit (linear_map.to_matrix (finite_dimensional.fin_basis 𝕜 M)
     by simp only [linear_map.det_to_matrix, is_unit_iff_ne_zero.2 hf],
 linear_equiv.of_is_unit_det this
 
+lemma linear_map.associated_det_of_eq_comp (e : M ≃ₗ[R] M) (f f' : M →ₗ[R] M)
+  (h : ∀ x, f x = f' (e x)) : associated f.det f'.det :=
+begin
+  suffices : associated (f'.comp e.to_linear_map).det f'.det,
+  { convert this using 2, ext x, exact h x },
+  rw [← mul_one f'.det, linear_map.det_comp],
+  exact associated.mul_left _ (associated_one_iff_is_unit.mpr e.is_unit_det')
+end
+
+lemma linear_map.associated_det_comp_equiv {N : Type*} [add_comm_group N] [module R N]
+  (f : N →ₗ[R] M) (e e' : M ≃ₗ[R] N) :
+  associated (f.comp e.to_linear_map).det (f.comp e'.to_linear_map).det :=
+begin
+  refine linear_map.associated_det_of_eq_comp (e.trans e'.symm) _ _ _,
+  intro x,
+  simp only [linear_map.comp_apply, linear_equiv.coe_to_linear_map, linear_equiv.trans_apply,
+             linear_equiv.apply_symm_apply],
+end
+
 /-- The determinant of a family of vectors with respect to some basis, as an alternating
 multilinear map. -/
 def basis.det : alternating_map R M R ι :=

--- a/src/linear_algebra/determinant.lean
+++ b/src/linear_algebra/determinant.lean
@@ -412,7 +412,7 @@ linear_equiv.of_is_unit_det this
 lemma linear_map.associated_det_of_eq_comp (e : M ≃ₗ[R] M) (f f' : M →ₗ[R] M)
   (h : ∀ x, f x = f' (e x)) : associated f.det f'.det :=
 begin
-  suffices : associated (f'.comp e.to_linear_map).det f'.det,
+  suffices : associated (f' ∘ₗ ↑e).det f'.det,
   { convert this using 2, ext x, exact h x },
   rw [← mul_one f'.det, linear_map.det_comp],
   exact associated.mul_left _ (associated_one_iff_is_unit.mpr e.is_unit_det')

--- a/src/linear_algebra/determinant.lean
+++ b/src/linear_algebra/determinant.lean
@@ -420,11 +420,11 @@ end
 
 lemma linear_map.associated_det_comp_equiv {N : Type*} [add_comm_group N] [module R N]
   (f : N →ₗ[R] M) (e e' : M ≃ₗ[R] N) :
-  associated (f.comp e.to_linear_map).det (f.comp e'.to_linear_map).det :=
+  associated (f ∘ₗ ↑e).det (f ∘ₗ ↑e').det :=
 begin
   refine linear_map.associated_det_of_eq_comp (e.trans e'.symm) _ _ _,
   intro x,
-  simp only [linear_map.comp_apply, linear_equiv.coe_to_linear_map, linear_equiv.trans_apply,
+  simp only [linear_map.comp_apply, linear_equiv.coe_coe, linear_equiv.trans_apply,
              linear_equiv.apply_symm_apply],
 end
 


### PR DESCRIPTION
`det f` equals `det f'` up to units if `f'` is `f` composed with a linear equiv.

First a homogeneous form where `f f' : M → M`, then a heterogeneous form where `f f' : M → N` and the equivs `e e' : N → M`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
