### PR TITLE
[Merged by Bors] - feat(linear_algebra/projective_space/subspace): adds lemmas about the span operation and supremums of collections of subspaces

### DIFF
--- a/src/linear_algebra/projective_space/subspace.lean
+++ b/src/linear_algebra/projective_space/subspace.lean
@@ -121,10 +121,10 @@ instance subspace_inhabited : inhabited (subspace K V) :=
 { default := ⊤ }
 
 /-- The span of the empty set is the bottom of the lattice of subspaces. -/
-lemma span_empty : span (∅ : set (ℙ K V)) = ⊥ := gi.gc.l_bot
+@[simp] lemma span_empty : span (∅ : set (ℙ K V)) = ⊥ := gi.gc.l_bot
 
 /-- The span of the entire projective space is the top of the lattice of subspaces. -/
-lemma span_univ : span (set.univ : set (ℙ K V)) = ⊤ :=
+@[simp] lemma span_univ : span (set.univ : set (ℙ K V)) = ⊤ :=
 by { rw [eq_top_iff, set_like.le_def], intros x hx, exact subset_span _ (set.mem_univ x) }
 
 /-- The span of a set of points is contained in a subspace if and only if the set of points is
@@ -165,7 +165,9 @@ by { simp_rw ← span_le_subspace_iff, exact ⟨λ hu W hW, hW hu, λ W, W (span
 subspaces which contain the set. -/
 lemma span_eq_Inf {S : set (ℙ K V)} : span S = Inf {W | S ⊆ W} :=
 begin
-  ext, simp_rw [mem_carrier_iff, mem_span x], refine ⟨λ hx, _, λ hx W hW, _⟩,
+  ext,
+  simp_rw [mem_carrier_iff, mem_span x],
+  refine ⟨λ hx, _, λ hx W hW, _⟩,
   { rintros W ⟨T, ⟨hT, rfl⟩⟩, exact (hx T hT) },
   { exact (@Inf_le _ _ {W : subspace K V | S ⊆ ↑W} W hW) x hx },
 end
@@ -174,12 +176,14 @@ end
 contained in the span of the set of points, then the span of the set of points is equal to
 the subspace. -/
 lemma span_eq_of_le {S : set (ℙ K V)} {W : subspace K V} (hS : S ⊆ W) (hW : W ≤ span S) :
-  span S = W := by { refine le_antisymm _ hW, rwa span_le_subspace_iff }
+  span S = W :=
+le_antisymm (span_le_subspace_iff.mpr hS) hW
 
-/-- If two sets of points in a projective space are such that each set is contained in the span of
-the other set, then the two sets have equal spans. -/
-lemma span_eq_span {S T : set (ℙ K V)} (hS : S ⊆ span T) (hT : T ⊆ span S) : span S = span T :=
-by { rw ← span_le_subspace_iff at hS hT, exact le_antisymm hS hT }
+/-- The spans of two sets of points in a projective space are equal if and only if each set of
+points is contained in the span of the other set. -/
+lemma span_eq_span_iff {S T : set (ℙ K V)} : span S = span T ↔ S ⊆ span T ∧ T ⊆ span S :=
+⟨λ h, ⟨h ▸ subset_span S, h.symm ▸ subset_span T⟩,
+  λ h, le_antisymm (span_le_subspace_iff.2 h.1) (span_le_subspace_iff.2 h.2)⟩
 
 end subspace
 

--- a/src/linear_algebra/projective_space/subspace.lean
+++ b/src/linear_algebra/projective_space/subspace.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Michael Blyth
 -/
 
-import linear_algebra.projective_space.basic
+import linear_algebra.projective_space.independence
 
 /-!
 # Subspaces of Projective Space
@@ -121,19 +121,15 @@ instance : complete_lattice (subspace K V) :=
 instance subspace_inhabited : inhabited (subspace K V) :=
 { default := ⊤ }
 
-/-- The span of a set of points is contained in a subspace iff the set of points is contained in the
-subspace. -/
+/-- The span of a set of points is contained in a subspace if and only if the set of points is
+contained in the subspace. -/
 lemma span_le_subspace_iff {S : set (ℙ K V)} {W : subspace K V} : span S ≤ W ↔ S ⊆ W :=
-by { exact gi.gc S W }
+gi.gc S W
 
 /-- If a set of points is a subset of another set of points, then its span will be contained in the
 span of that set. -/
 lemma span_mono {S T : set (ℙ K V)} (h : S ⊆ T) : span S ≤ span T :=
-begin
-  rintros s hs, induction hs with u hu v w _ _ _ _ _ hvt hwt,
-  { exact subset_span T (h hu) },
-  { exact mem_add (span T) v w _ _ _ hvt hwt },
-end
+galois_connection.monotone_l gi.gc h
 
 /-- The supremum of two subspaces is equal to the span of their union. -/
 lemma sup_eq_span_union (W S : subspace K V) : W ⊔ S = span (W ∪ S) :=

--- a/src/linear_algebra/projective_space/subspace.lean
+++ b/src/linear_algebra/projective_space/subspace.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Michael Blyth
 -/
 
-import linear_algebra.projective_space.independence
+import linear_algebra.projective_space.basic
 
 /-!
 # Subspaces of Projective Space

--- a/src/linear_algebra/projective_space/subspace.lean
+++ b/src/linear_algebra/projective_space/subspace.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Michael Blyth
 -/
 
-import linear_algebra.projective_space.basic
+import linear_algebra.projective_space.independence
 
 /-!
 # Subspaces of Projective Space
@@ -76,16 +76,6 @@ def span (S : set (ℙ K V)) : subspace K V :=
 /-- The span of a set of points contains the set of points. -/
 lemma subset_span (S : set (ℙ K V)) : S ⊆ span S := λ x hx, span_carrier.of _ hx
 
-/-- The span of a subspace is the subspace. -/
-@[simp] lemma span_coe (W : subspace K V) : span ↑W = W :=
-begin
-  ext, refine ⟨λ hx, _, λ hx, _⟩,
-  { induction hx with a ha u w hu hw huw _ _ hum hwm,
-      { exact ha },
-      { exact mem_add W u w hu hw huw hum hwm } },
-  { exact subset_span W hx },
-end
-
 /-- The span of a set of points is a Galois insertion between sets of points of a projective space
 and subspaces of the projective space. -/
 def gi : galois_insertion (span : set (ℙ K V) → subspace K V) coe :=
@@ -98,6 +88,10 @@ def gi : galois_insertion (span : set (ℙ K V) → subspace K V) coe :=
   end⟩,
   le_l_u := λ S, subset_span _,
   choice_eq := λ _ _, rfl }
+
+/-- The span of a subspace is the subspace. -/
+@[simp] lemma span_coe (W : subspace K V) : span ↑W = W :=
+by { exact galois_insertion.l_u_eq gi W }
 
 /-- The infimum of two subspaces exists. -/
 instance has_inf : has_inf (subspace K V) :=
@@ -126,6 +120,30 @@ instance : complete_lattice (subspace K V) :=
 
 instance subspace_inhabited : inhabited (subspace K V) :=
 { default := ⊤ }
+
+/-- The span of a set of points is contained in a subspace iff the set of points is contained in the
+subspace. -/
+lemma span_le_subspace_iff {S : set (ℙ K V)} {W : subspace K V} : span S ≤ W ↔ S ⊆ W :=
+by { exact gi.gc S W }
+
+/-- If a set of points is a subset of another set of points, then its span will be contained in the
+span of that set. -/
+lemma span_mono {S T : set (ℙ K V)} (h : S ⊆ T) : span S ≤ span T :=
+begin
+  rintros s hs, induction hs with u hu v w _ _ _ _ _ hvt hwt,
+  { exact subset_span T (h hu) },
+  { exact mem_add (span T) v w _ _ _ hvt hwt },
+end
+
+/-- The supremum of two subspaces is equal to the span of their union. -/
+lemma sup_eq_span_union (W S : subspace K V) : W ⊔ S = span (W ∪ S) :=
+by { exact (galois_insertion.l_sup_u (@gi K V _ _ _) W S).symm }
+
+/-- The supremum of a collection of subspaces is equal to the span of the union of the
+collection. -/
+lemma Sup_eq_span_union (S : set (subspace K V)) :
+  Sup S = span ⋃ (W : subspace K V) (hW : W ∈ S), W :=
+by { apply symm, rw (Sup_eq_supr), exact galois_insertion.l_bsupr_u (gi) _ }
 
 end subspace
 

--- a/src/linear_algebra/projective_space/subspace.lean
+++ b/src/linear_algebra/projective_space/subspace.lean
@@ -137,13 +137,13 @@ end
 
 /-- The supremum of two subspaces is equal to the span of their union. -/
 lemma sup_eq_span_union (W S : subspace K V) : W ⊔ S = span (W ∪ S) :=
-by { exact (galois_insertion.l_sup_u (@gi K V _ _ _) W S).symm }
+by { apply symm, exact (galois_insertion.l_sup_u gi W S) }
 
 /-- The supremum of a collection of subspaces is equal to the span of the union of the
 collection. -/
 lemma Sup_eq_span_union (S : set (subspace K V)) :
   Sup S = span ⋃ (W : subspace K V) (hW : W ∈ S), W :=
-by { apply symm, rw (Sup_eq_supr), exact galois_insertion.l_bsupr_u (gi) _ }
+by { apply symm, rw (Sup_eq_supr), exact galois_insertion.l_bsupr_u gi _ }
 
 end subspace
 


### PR DESCRIPTION
This PR adds lemmas relating the span operation to the order relations between subsets and subspaces, and adds lemmas about computing the supremum of a collection of subspaces using the span operation.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
