### PR TITLE
[Merged by Bors] - feat(algebraic_topology/dold_kan): construction of idempotent endomorphisms

### DIFF
--- a/src/algebraic_topology/dold_kan/faces.lean
+++ b/src/algebraic_topology/dold_kan/faces.lean
@@ -61,8 +61,8 @@ lemma of_comp {Y Z : C} {q n : ℕ} {φ : Y ⟶ X _[n+1]}
   higher_faces_vanish q (f ≫ φ) := λ j hj,
 by rw [assoc, v j hj, comp_zero]
 
-lemma comp_Hσ_eq {Y : C} {n a q : ℕ} (hnaq : n=a+q) {φ : Y ⟶ X _[n+1]}
-  (v : higher_faces_vanish q φ) : φ ≫ (Hσ q).f (n+1) =
+lemma comp_Hσ_eq {Y : C} {n a q : ℕ} {φ : Y ⟶ X _[n+1]}
+  (v : higher_faces_vanish q φ) (hnaq : n=a+q) : φ ≫ (Hσ q).f (n+1) =
   - φ ≫ X.δ ⟨a+1, nat.succ_lt_succ (nat.lt_succ_iff.mpr (nat.le.intro hnaq.symm))⟩ ≫
     X.σ ⟨a, nat.lt_succ_iff.mpr (nat.le.intro hnaq.symm)⟩ :=
 begin
@@ -134,8 +134,8 @@ begin
     ring_exp, },
 end
 
-lemma comp_Hσ_eq_zero {Y : C} {n q : ℕ} (hqn : n<q) {φ : Y ⟶ X _[n+1]}
-  (v : higher_faces_vanish q φ) : φ ≫ (Hσ q).f (n+1) = 0 :=
+lemma comp_Hσ_eq_zero {Y : C} {n q : ℕ} {φ : Y ⟶ X _[n+1]}
+  (v : higher_faces_vanish q φ) (hqn : n<q) : φ ≫ (Hσ q).f (n+1) = 0 :=
 begin
   simp only [Hσ, homotopy.null_homotopic_map'_f (c_mk (n+2) (n+1) rfl) (c_mk (n+1) n rfl)],
   rw [hσ'_eq_zero hqn (c_mk (n+1) n rfl), comp_zero, zero_add],
@@ -168,10 +168,10 @@ begin
   simp only [comp_add, add_comp, comp_id],
   -- when n < q, the result follows immediately from the assumption
   by_cases hqn : n<q,
-  { rw [comp_Hσ_eq_zero hqn v, zero_comp, add_zero, v j (by linarith)], },
+  { rw [v.comp_Hσ_eq_zero hqn, zero_comp, add_zero, v j (by linarith)], },
   -- we now assume that n≥q, and write n=a+q
   cases nat.le.dest (not_lt.mp hqn) with a ha,
-  rw [comp_Hσ_eq (show n=a+q, by linarith) v, neg_comp, add_neg_eq_zero, assoc, assoc],
+  rw [v.comp_Hσ_eq (show n=a+q, by linarith), neg_comp, add_neg_eq_zero, assoc, assoc],
   cases n with m hm,
   -- the boundary case n=0
   { simpa only [nat.eq_zero_of_add_eq_zero_left ha, fin.eq_zero j,

--- a/src/algebraic_topology/dold_kan/homotopies.lean
+++ b/src/algebraic_topology/dold_kan/homotopies.lean
@@ -11,7 +11,7 @@ import algebraic_topology.dold_kan.notations
 
 # Construction of homotopies for the Dold-Kan correspondence
 
-TODO (@joelriou) continue adding the various files references below
+TODO (@joelriou) continue adding the various files referenced below
 
 (The general strategy of proof of the Dold-Kan correspondence is explained
 in `equivalence.lean`.)

--- a/src/algebraic_topology/dold_kan/projections.lean
+++ b/src/algebraic_topology/dold_kan/projections.lean
@@ -6,7 +6,7 @@ Authors: Joël Riou
 
 import algebraic_topology.dold_kan.faces
 
-/-
+/-!
 
 # Construction of projections for the Dold-Kan correspondence
 

--- a/src/algebraic_topology/dold_kan/projections.lean
+++ b/src/algebraic_topology/dold_kan/projections.lean
@@ -1,0 +1,176 @@
+/-
+Copyright (c) 2022 Joël Riou. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Joël Riou
+-/
+
+import algebraic_topology.dold_kan.faces
+
+/-
+
+# Construction of projections for the Dold-Kan correspondence
+
+TODO (@joelriou) continue adding the various files referenced below
+
+In this file, we construct endomorphisms `P q : K[X] ⟶ K[X]` for all
+`q : ℕ`. We study how they behave with respect to face maps with the lemmas
+`higher_faces_vanish.of_P`, `higher_faces_vanish.comp_P_eq_self` and
+`comp_P_eq_self_iff`.
+
+Then, we show that they are projections (see `P_f_idem`
+and `P_idem`). They are natural transformations (see `nat_trans_P`
+and `P_f_naturality`) and are compatible with the application
+of additive functors (see `map_P`).
+
+By passing to the limit, these endomorphisms `P q` shall be used in `p_infty.lean`
+in order to define `P_infty : K[X] ⟶ K[X]`, see `equivalence.lean` for the general
+strategy of proof of the Dold-Kan equivalence.
+
+-/
+
+open category_theory
+open category_theory.category
+open category_theory.limits
+open category_theory.preadditive
+open category_theory.simplicial_object
+open opposite
+open_locale simplicial dold_kan
+
+noncomputable theory
+
+namespace algebraic_topology
+
+namespace dold_kan
+
+variables {C : Type*} [category C] [preadditive C]
+variables {X : simplicial_object C}
+
+/-- This is the inductive definition of the projections `P q : K[X] ⟶ K[X]`,
+with `P 0 := 𝟙 _` and `P (q+1) := P q ≫ (𝟙 _ + Hσ q)`. -/
+noncomputable def P : ℕ → (K[X] ⟶ K[X])
+| 0     := 𝟙 _
+| (q+1) := P q ≫ (𝟙 _ + Hσ q)
+
+/-- All the `P q` coincide with `𝟙 _` in degree 0. -/
+@[simp]
+lemma P_f_0_eq (q : ℕ) : ((P q).f 0 : X _[0] ⟶ X _[0]) = 𝟙 _ :=
+begin
+  induction q with q hq,
+  { refl, },
+  { unfold P,
+    simp only [homological_complex.add_f_apply, homological_complex.comp_f,
+      homological_complex.id_f, id_comp, hq, Hσ_eq_zero, add_zero], },
+end
+
+/-- Q q is the complement projection associated to P q -/
+def Q (q : ℕ) : K[X] ⟶ K[X] := 𝟙 _ - P q
+
+lemma P_add_Q (q : ℕ) : P q + Q q = 𝟙 K[X] := by { rw Q, abel, }
+
+lemma P_add_Q_f (q n : ℕ) : (P q).f n + (Q q).f n = 𝟙 (X _[n]) :=
+homological_complex.congr_hom (P_add_Q q) n
+
+@[simp]
+lemma Q_eq_zero : (Q 0 : K[X] ⟶ _) = 0 := sub_self _
+
+lemma Q_eq (q : ℕ) : (Q (q+1) : K[X] ⟶ _) = Q q - P q ≫ Hσ q :=
+by { unfold Q P, simp only [comp_add, comp_id], abel, }
+
+/-- All the `Q q` coincide with `0` in degree 0. -/
+@[simp]
+lemma Q_f_0_eq (q : ℕ) : ((Q q).f 0 : X _[0] ⟶ X _[0]) = 0 :=
+by simp only [homological_complex.sub_f_apply, homological_complex.id_f, Q, P_f_0_eq, sub_self]
+
+namespace higher_faces_vanish
+
+/-- This lemma expresses the vanishing of
+`(P q).f (n+1) ≫ X.δ k : X _[n+1] ⟶ X _[n]` when `k≠0` and `k≥n-q+2` -/
+lemma of_P : Π (q n : ℕ), higher_faces_vanish q (((P q).f (n+1) : X _[n+1] ⟶ X _[n+1]))
+| 0     := λ n j hj₁, by { exfalso, have hj₂ := fin.is_lt j, linarith, }
+| (q+1) := λ n, by { unfold P, exact (of_P q n).induction, }
+
+@[reassoc]
+lemma comp_P_eq_self {Y : C} {n q : ℕ} {φ : Y ⟶ X _[n+1]}
+  (v : higher_faces_vanish q φ) : φ ≫ (P q).f (n+1) = φ :=
+begin
+  induction q with q hq,
+  { unfold P,
+    apply comp_id, },
+  { unfold P,
+    simp only [comp_add, homological_complex.comp_f, homological_complex.add_f_apply,
+      comp_id, ← assoc, hq v.of_succ, add_right_eq_self],
+    by_cases hqn : n<q,
+    { exact v.of_succ.comp_Hσ_eq_zero hqn, },
+    { cases nat.le.dest (not_lt.mp hqn) with a ha,
+      have hnaq : n=a+q := by linarith,
+      simp only [v.of_succ.comp_Hσ_eq hnaq, neg_eq_zero, ← assoc],
+      have eq := v ⟨a, by linarith⟩
+        (by simp only [hnaq, fin.coe_mk, nat.succ_eq_add_one, add_assoc]),
+      simp only [fin.succ_mk] at eq,
+      simp only [eq, zero_comp], }, },
+end
+
+end higher_faces_vanish
+
+lemma comp_P_eq_self_iff {Y : C} {n q : ℕ} {φ : Y ⟶ X _[n+1]} :
+  φ ≫ (P q).f (n+1) = φ ↔ higher_faces_vanish q φ :=
+begin
+  split,
+  { intro hφ,
+    rw ← hφ,
+    apply higher_faces_vanish.of_comp,
+    apply higher_faces_vanish.of_P, },
+  { exact higher_faces_vanish.comp_P_eq_self, },
+end
+
+@[simp, reassoc]
+lemma P_f_idem (q n : ℕ) :
+  ((P q).f n : X _[n] ⟶ _) ≫ ((P q).f n) = (P q).f n :=
+begin
+  cases n,
+  { rw [P_f_0_eq q, comp_id], },
+  { exact (higher_faces_vanish.of_P q n).comp_P_eq_self, }
+end
+
+@[simp, reassoc]
+lemma P_idem (q : ℕ) : (P q : K[X] ⟶ K[X]) ≫ P q = P q :=
+by { ext n, exact P_f_idem q n, }
+
+/-- For each `q`, `P q` is a natural transformation. -/
+def nat_trans_P (q : ℕ) :
+  alternating_face_map_complex C ⟶ alternating_face_map_complex C :=
+{ app := λ X, P q,
+  naturality' := λ X Y f, begin
+    induction q with q hq,
+    { unfold P,
+      dsimp only [alternating_face_map_complex],
+      rw [id_comp, comp_id], },
+    { unfold P,
+      simp only [add_comp, comp_add, assoc, comp_id, hq],
+      congr' 1,
+      rw [← assoc, hq, assoc],
+      congr' 1,
+      exact (nat_trans_Hσ q).naturality' f, }
+  end }
+
+@[simp, reassoc]
+lemma P_f_naturality (q n : ℕ) {X Y : simplicial_object C} (f : X ⟶ Y) :
+  f.app (op [n]) ≫ (P q).f n = (P q).f n ≫ f.app (op [n]) :=
+homological_complex.congr_hom ((nat_trans_P q).naturality f) n
+
+lemma map_P {D : Type*} [category D] [preadditive D]
+  (G : C ⥤ D) [G.additive] (X : simplicial_object C) (q n : ℕ) :
+  ((P q : K[((whiskering C D).obj G).obj X] ⟶ _).f n) = G.map ((P q : K[X] ⟶ _).f n) :=
+begin
+  induction q with q hq,
+  { unfold P,
+    dsimp,
+    rw G.map_id, },
+  { unfold P,
+    simp only [comp_add, homological_complex.comp_f, homological_complex.add_f_apply,
+      comp_id, functor.map_add, functor.map_comp, hq, map_Hσ], }
+end
+
+end dold_kan
+
+end algebraic_topology

--- a/src/algebraic_topology/dold_kan/projections.lean
+++ b/src/algebraic_topology/dold_kan/projections.lean
@@ -42,8 +42,7 @@ namespace algebraic_topology
 
 namespace dold_kan
 
-variables {C : Type*} [category C] [preadditive C]
-variables {X : simplicial_object C}
+variables {C : Type*} [category C] [preadditive C] {X : simplicial_object C}
 
 /-- This is the inductive definition of the projections `P q : K[X] ⟶ K[X]`,
 with `P 0 := 𝟙 _` and `P (q+1) := P q ≫ (𝟙 _ + Hσ q)`. -/
@@ -62,7 +61,7 @@ begin
       homological_complex.id_f, id_comp, hq, Hσ_eq_zero, add_zero], },
 end
 
-/-- Q q is the complement projection associated to P q -/
+/-- `Q q` is the complement projection associated to `P q` -/
 def Q (q : ℕ) : K[X] ⟶ K[X] := 𝟙 _ - P q
 
 lemma P_add_Q (q : ℕ) : P q + Q q = 𝟙 K[X] := by { rw Q, abel, }

--- a/src/algebraic_topology/dold_kan/projections.lean
+++ b/src/algebraic_topology/dold_kan/projections.lean
@@ -160,12 +160,11 @@ homological_complex.congr_hom ((nat_trans_P q).naturality f) n
 
 lemma map_P {D : Type*} [category D] [preadditive D]
   (G : C ⥤ D) [G.additive] (X : simplicial_object C) (q n : ℕ) :
-  ((P q : K[((whiskering C D).obj G).obj X] ⟶ _).f n) = G.map ((P q : K[X] ⟶ _).f n) :=
+  G.map ((P q : K[X] ⟶ _).f n) = (P q : K[((whiskering C D).obj G).obj X] ⟶ _).f n :=
 begin
   induction q with q hq,
   { unfold P,
-    dsimp,
-    rw G.map_id, },
+    apply G.map_id, },
   { unfold P,
     simp only [comp_add, homological_complex.comp_f, homological_complex.add_f_apply,
       comp_id, functor.map_add, functor.map_comp, hq, map_Hσ], }


### PR DESCRIPTION
This PR introduces a sequence of idempotent endomorphisms of the alternating face map complex of a simplicial object in a preadditive category. In a future PR, by taking the "limit" of this sequence, we shall get the projection on the normalized subcomplex, parallel to the degenerate sucomplex.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
