### PR TITLE
[Merged by Bors] - fix(data/json): `rbmap string α` never serializes to `null`

### DIFF
--- a/src/data/json.lean
+++ b/src/data/json.lean
@@ -98,7 +98,7 @@ meta instance {α} [json_serializable α] : non_null_json_serializable (list α)
     json.array l ← success j | exception (λ _, format!"array expected, got {j.typename}"),
     l.mmap (of_json α) }
 
-meta instance {α} [json_serializable α] : json_serializable (rbmap string α) :=
+meta instance {α} [json_serializable α] : non_null_json_serializable (rbmap string α) :=
 { to_json := λ m, json.object (m.to_list.map $ λ x, (x.1, to_json x.2)),
   of_json := λ j, do
     json.object l ← success j | exception (λ _, format!"object expected, got {j.typename}"),


### PR DESCRIPTION
This change means that `option (rbmap string α)` can now serialize



---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
