### PR TITLE
[Merged by Bors] - chore(algebra/lie/direct_sum): remove `direct_sum.lie_algebra_is_internal`

### DIFF
--- a/src/algebra/lie/direct_sum.lean
+++ b/src/algebra/lie/direct_sum.lean
@@ -194,14 +194,6 @@ section ideals
 
 variables {L : Type w} [lie_ring L] [lie_algebra R L] (I : ι → lie_ideal R L)
 
-/-- Given a Lie algebra `L` and a family of ideals `I i ⊆ L`, informally this definition is the
-statement that `L = ⨁ i, I i`.
-
-More formally, the inclusions give a natural map from the (external) direct sum to the enclosing Lie
-algebra: `(⨁ i, I i) → L`, and this definition is the proposition that this map is bijective. -/
-def lie_algebra_is_internal [decidable_eq ι] : Prop :=
-function.bijective $ to_module R ι L $ λ i, ((I i).incl : I i →ₗ[R] L)
-
 /-- The fact that this instance is necessary seems to be a bug in typeclass inference. See
 [this Zulip thread](https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/
 Typeclass.20resolution.20under.20binders/near/245151099). -/

--- a/src/algebra/lie/direct_sum.lean
+++ b/src/algebra/lie/direct_sum.lean
@@ -11,7 +11,7 @@ import algebra.lie.basic
 /-!
 # Direct sums of Lie algebras and Lie modules
 
-Direct sums of Lie algebras and Lie modules carry natural algbebra and module structures.
+Direct sums of Lie algebras and Lie modules carry natural algebra and module structures.
 
 ## Tags
 


### PR DESCRIPTION
This meant the same thing as the unprefixed version, and wasn't used anywhere:
```lean
example [decidable_eq ι] : direct_sum.lie_algebra_is_internal I ↔ direct_sum.is_internal I := iff.rfl
```
I think it was added before `direct_sum.is_internal` generalized to arbitrary additive subobjects.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
