### PR TITLE
[Merged by Bors] - feat(data/sign): `left.sign_neg`, `right.sign_neg`

### DIFF
--- a/src/data/sign.lean
+++ b/src/data/sign.lean
@@ -205,7 +205,7 @@ end linear_ordered_ring
 
 section add_group
 
-variables [add_group α] [preorder α] [decidable_rel ((<) : α → α → Prop)] {a : α}
+variables [add_group α] [preorder α] [decidable_rel ((<) : α → α → Prop)]
 
 lemma left.sign_neg [covariant_class α α (+) (<)] (a : α) : sign (-a) = - sign a :=
 begin

--- a/src/data/sign.lean
+++ b/src/data/sign.lean
@@ -207,7 +207,7 @@ section add_group
 
 variables [add_group α] [preorder α] [decidable_rel ((<) : α → α → Prop)] {a : α}
 
-lemma left.sign_neg [covariant_class α α (+) (<)] : sign (-a) = - sign a :=
+lemma left.sign_neg [covariant_class α α (+) (<)] (a : α) : sign (-a) = - sign a :=
 begin
   simp_rw [sign_apply, left.neg_pos_iff, left.neg_neg_iff],
   split_ifs with h h',

--- a/src/data/sign.lean
+++ b/src/data/sign.lean
@@ -217,7 +217,7 @@ begin
   { simp }
 end
 
-lemma right.sign_neg [covariant_class α α (function.swap (+)) (<)] : sign (-a) = - sign a :=
+lemma right.sign_neg [covariant_class α α (function.swap (+)) (<)] (a : α) : sign (-a) = - sign a :=
 begin
   simp_rw [sign_apply, right.neg_pos_iff, right.neg_neg_iff],
   split_ifs with h h',

--- a/src/data/sign.lean
+++ b/src/data/sign.lean
@@ -202,3 +202,30 @@ def sign_hom : α →*₀ sign_type :=
                mul_neg_of_pos_of_neg, mul_pos] }
 
 end linear_ordered_ring
+
+section add_group
+
+variables [add_group α] [preorder α] [decidable_rel ((<) : α → α → Prop)] {a : α}
+
+lemma left.sign_neg_eq_neg_sign [covariant_class α α (+) (<)] : sign (-a) = - sign a :=
+begin
+  simp_rw [sign_apply, left.neg_pos_iff, left.neg_neg_iff],
+  split_ifs with h h',
+  { exact false.elim (lt_asymm h h') },
+  { simp },
+  { simp },
+  { simp }
+end
+
+lemma right.sign_neg_eq_neg_sign [covariant_class α α (function.swap (+)) (<)] :
+  sign (-a) = - sign a :=
+begin
+  simp_rw [sign_apply, right.neg_pos_iff, right.neg_neg_iff],
+  split_ifs with h h',
+  { exact false.elim (lt_asymm h h') },
+  { simp },
+  { simp },
+  { simp }
+end
+
+end add_group

--- a/src/data/sign.lean
+++ b/src/data/sign.lean
@@ -207,7 +207,7 @@ section add_group
 
 variables [add_group α] [preorder α] [decidable_rel ((<) : α → α → Prop)] {a : α}
 
-lemma left.sign_neg_eq_neg_sign [covariant_class α α (+) (<)] : sign (-a) = - sign a :=
+lemma left.sign_neg [covariant_class α α (+) (<)] : sign (-a) = - sign a :=
 begin
   simp_rw [sign_apply, left.neg_pos_iff, left.neg_neg_iff],
   split_ifs with h h',
@@ -217,8 +217,7 @@ begin
   { simp }
 end
 
-lemma right.sign_neg_eq_neg_sign [covariant_class α α (function.swap (+)) (<)] :
-  sign (-a) = - sign a :=
+lemma right.sign_neg [covariant_class α α (function.swap (+)) (<)] : sign (-a) = - sign a :=
 begin
   simp_rw [sign_apply, right.neg_pos_iff, right.neg_neg_iff],
   split_ifs with h h',


### PR DESCRIPTION
Add lemmas that the sign of `-a` is the negation of the sign of `a`,
for two kinds of ordered additive groups (corresponding to the type
classes on the `left` and `right` variants of the `neg_pos_iff` and
`neg_neg_iff` lemmas used).

---

I didn't do anything about inconsistent naming of lemmas between the
sign function in this file and other sign functions.  For both
`int.sign` and `real.sign` the equivalent lemma is `sign_neg`, but
here `sign_neg` gives the sign of a negative value, equivalent to
`real.sign_of_neg`.



---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
