### PR TITLE
[Merged by Bors] - feat(algebra/periodic): `fract_periodic`

### DIFF
--- a/src/algebra/periodic.lean
+++ b/src/algebra/periodic.lean
@@ -523,3 +523,7 @@ lemma antiperiodic.div [has_add α] [division_ring β]
 by simp [*, neg_div_neg_eq] at *
 
 end function
+
+lemma int.fract_periodic (α) [linear_ordered_ring α] [floor_ring α] :
+  function.periodic int.fract (1 : α) :=
+by exact_mod_cast λ a, int.fract_add_int a 1


### PR DESCRIPTION
Add the lemma that `int.fract` is periodic with period 1.  Note that
this goes in `algebra.periodic` alongside the definition of
`periodic`, rather than `algebra.order.floor` alongside the definition
of `fract`, because of import ordering (`algebra.periodic` ends up
importing `algebra.order.floor`).



---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
