### PR TITLE
[Merged by Bors] - feat(geometry/manifold/mfderiv): differentiability is a `local_invariant_prop`, and consequences

### DIFF
--- a/src/analysis/calculus/fderiv.lean
+++ b/src/analysis/calculus/fderiv.lean
@@ -496,6 +496,11 @@ begin
   exact ⟨f', hf'.mono st⟩
 end
 
+lemma differentiable_within_at.mono_of_mem (h : differentiable_within_at 𝕜 f s x) {t : set E}
+  (hst : s ∈ nhds_within x t) :
+  differentiable_within_at 𝕜 f t x :=
+(h.has_fderiv_within_at.mono_of_mem hst).differentiable_within_at
+
 lemma differentiable_within_at_univ :
   differentiable_within_at 𝕜 f univ x ↔ differentiable_at 𝕜 f x :=
 by simp only [differentiable_within_at, has_fderiv_within_at_univ, differentiable_at]

--- a/src/geometry/manifold/mfderiv.lean
+++ b/src/geometry/manifold/mfderiv.lean
@@ -3,6 +3,7 @@ Copyright (c) 2020 Sébastien Gouëzel. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Sébastien Gouëzel
 -/
+import geometry.manifold.local_invariant_properties
 import geometry.manifold.tangent_bundle
 
 /-!
@@ -118,6 +119,64 @@ variables {𝕜 : Type*} [nontrivially_normed_field 𝕜]
 {H' : Type*} [topological_space H'] (I' : model_with_corners 𝕜 E' H')
 {M' : Type*} [topological_space M'] [charted_space H' M']
 
+/-- Property in the model space of a model with corners of being differentiable within at set at a
+point, when read in the model vector space. This property will be lifted to manifolds to define
+differentiable functions between manifolds. -/
+def differentiable_within_at_prop (f : H → H') (s : set H) (x : H) : Prop :=
+differentiable_within_at 𝕜 (I' ∘ f ∘ (I.symm)) (⇑(I.symm) ⁻¹' s ∩ set.range I) (I x)
+
+/-- Being differentiable in the model space is a local property, invariant under smooth maps.
+Therefore, it will lift nicely to manifolds. -/
+lemma differentiable_within_at_local_invariant_prop :
+  (cont_diff_groupoid ⊤ I).local_invariant_prop (cont_diff_groupoid ⊤ I')
+    (differentiable_within_at_prop I I') :=
+{ is_local :=
+  begin
+    assume s x u f u_open xu,
+    have : I.symm ⁻¹' (s ∩ u) ∩ set.range I = (I.symm ⁻¹' s ∩ set.range I) ∩ I.symm ⁻¹' u,
+      by simp only [set.inter_right_comm, set.preimage_inter],
+    rw [differentiable_within_at_prop, differentiable_within_at_prop, this],
+    symmetry,
+    apply differentiable_within_at_inter,
+    have : u ∈ 𝓝 (I.symm (I x)),
+      by { rw [model_with_corners.left_inv], exact is_open.mem_nhds u_open xu },
+    apply continuous_at.preimage_mem_nhds I.continuous_symm.continuous_at this,
+  end,
+  right_invariance :=
+  begin
+    assume s x f e he hx h,
+    rw differentiable_within_at_prop at h ⊢,
+    have : I x = (I ∘ e.symm ∘ I.symm) (I (e x)), by simp only [hx] with mfld_simps,
+    rw this at h,
+    have : I (e x) ∈ (I.symm) ⁻¹' e.target ∩ set.range I, by simp only [hx] with mfld_simps,
+    have := ((mem_groupoid_of_pregroupoid.2 he).2.cont_diff_within_at this),
+    convert (h.comp' _ (this.differentiable_within_at le_top)).mono_of_mem _ using 1,
+    { ext y, simp only with mfld_simps },
+    refine mem_nhds_within.mpr ⟨I.symm ⁻¹' e.target, e.open_target.preimage I.continuous_symm,
+      by simp_rw [set.mem_preimage, I.left_inv, e.maps_to hx], _⟩,
+    mfld_set_tac
+  end,
+  congr_of_forall :=
+  begin
+    assume s x f g h hx hf,
+    apply hf.congr,
+    { assume y hy,
+      simp only with mfld_simps at hy,
+      simp only [h, hy] with mfld_simps },
+    { simp only [hx] with mfld_simps }
+  end,
+  left_invariance' :=
+  begin
+    assume s x f e' he' hs hx h,
+    rw differentiable_within_at_prop at h ⊢,
+    have A : (I' ∘ f ∘ I.symm) (I x) ∈ (I'.symm ⁻¹' e'.source ∩ set.range I'),
+      by simp only [hx] with mfld_simps,
+    have := ((mem_groupoid_of_pregroupoid.2 he').1.cont_diff_within_at A),
+    convert (this.differentiable_within_at le_top).comp _ h _,
+    { ext y, simp only with mfld_simps },
+    { assume y hy, simp only with mfld_simps at hy, simpa only [hy] with mfld_simps using hs hy.1 }
+  end }
+
 /-- Predicate ensuring that, at a point and within a set, a function can have at most one
 derivative. This is expressed using the preferred chart at the considered point. -/
 def unique_mdiff_within_at (s : set M) (x : M) :=
@@ -145,6 +204,11 @@ continuous_within_at f s x ∧
 differentiable_within_at 𝕜 (written_in_ext_chart_at I I' x f)
   ((ext_chart_at I x).symm ⁻¹' s ∩ range I) ((ext_chart_at I x) x)
 
+lemma mdifferentiable_within_at_iff_lift_prop_within_at (f : M → M') (s : set M) (x : M) :
+  mdifferentiable_within_at I I' f s x
+  ↔ lift_prop_within_at (differentiable_within_at_prop I I') f s x :=
+by refl
+
 /-- `mdifferentiable_at I I' f x` indicates that the function `f` between manifolds
 has a derivative at the point `x`.
 This is a generalization of `differentiable_at` to manifolds.
@@ -157,6 +221,15 @@ def mdifferentiable_at (f : M → M') (x : M) :=
 continuous_at f x ∧
 differentiable_within_at 𝕜 (written_in_ext_chart_at I I' x f) (range I)
   ((ext_chart_at I x) x)
+
+lemma mdifferentiable_at_iff_lift_prop_at (f : M → M') (x : M) :
+  mdifferentiable_at I I' f x
+  ↔ lift_prop_at (differentiable_within_at_prop I I') f x :=
+begin
+  congrm _ ∧ _,
+  { rw continuous_within_at_univ },
+  { simp [differentiable_within_at_prop, set.univ_inter] }
+end
 
 /-- `mdifferentiable_on I I' f s` indicates that the function `f` between manifolds
 has a derivative within `s` at all points of `s`.
@@ -344,6 +417,22 @@ begin
 end
 
 include Is I's
+
+/-- One can reformulate differentiability within a set at a point as continuity within this set at
+this point, and differentiability in any chart containing that point. -/
+lemma mdifferentiable_within_at_iff_of_mem_source
+  {x' : M} {y : M'}
+  (hx : x' ∈ (charted_space.chart_at H x).source)
+  (hy : f x' ∈ (charted_space.chart_at H' y).source) :
+  mdifferentiable_within_at I I' f s x'
+  ↔ continuous_within_at f s x'
+    ∧ differentiable_within_at 𝕜
+        ((ext_chart_at I' y) ∘ f ∘ ((ext_chart_at I x).symm))
+        (((ext_chart_at I x).symm) ⁻¹' s ∩ set.range I)
+        ((ext_chart_at I x) x') :=
+(differentiable_within_at_local_invariant_prop I I').lift_prop_within_at_indep_chart
+  (structure_groupoid.chart_mem_maximal_atlas _ x) hx
+  (structure_groupoid.chart_mem_maximal_atlas _ y) hy
 
 lemma mfderiv_within_zero_of_not_mdifferentiable_within_at
   (h : ¬ mdifferentiable_within_at I I' f s x) : mfderiv_within I I' f s x = 0 :=
@@ -537,6 +626,19 @@ lemma mfderiv_within_inter (ht : t ∈ 𝓝 x) (hs : unique_mdiff_within_at I s 
   mfderiv_within I I' f (s ∩ t) x = mfderiv_within I I' f s x :=
 by rw [mfderiv_within, mfderiv_within, ext_chart_preimage_inter_eq,
   mdifferentiable_within_at_inter ht, fderiv_within_inter (ext_chart_preimage_mem_nhds I x ht) hs]
+
+lemma mdifferentiable_at_iff_of_mem_source {x' : M} {y : M'}
+  (hx : x' ∈ (charted_space.chart_at H x).source)
+  (hy : f x' ∈ (charted_space.chart_at H' y).source) :
+  mdifferentiable_at I I' f x'
+  ↔ continuous_at f x'
+    ∧ differentiable_within_at 𝕜
+        ((ext_chart_at I' y) ∘ f ∘ ((ext_chart_at I x).symm))
+        (set.range I)
+        ((ext_chart_at I x) x') :=
+mdifferentiable_within_at_univ.symm.trans $
+  (mdifferentiable_within_at_iff_of_mem_source hx hy).trans $
+  by rw [continuous_within_at_univ, set.preimage_univ, set.univ_inter]
 
 omit Is I's
 


### PR DESCRIPTION
The boilerplate to make differentiability into a `local_invariant_prop` was missing.  I added this, stated the lemmas that the definition of differentiability on a manifold this gives is equivalent to the existing definition, and deduced as a consequence that differentiability is invariant under choice of chart.

Almost everything is copied nearly exactly, even up to docstrings, from the corresponding lemmas about `cont_(m)diff`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
