### PR TITLE
[Merged by Bors] - chore(analysis/inner_product_space): golf two proofs

### DIFF
--- a/src/analysis/inner_product_space/basic.lean
+++ b/src/analysis/inner_product_space/basic.lean
@@ -212,7 +212,7 @@ lemma inner_self_re_to_K {x : F} : (re ⟪x, x⟫ : 𝕜) = ⟪x, x⟫ :=
 by norm_num [ext_iff, inner_self_nonneg_im]
 
 lemma inner_abs_conj_sym {x y : F} : abs ⟪x, y⟫ = abs ⟪y, x⟫ :=
-  by rw [←inner_conj_sym, abs_conj]
+by rw [←inner_conj_sym, abs_conj]
 
 lemma inner_neg_left {x y : F} : ⟪-x, y⟫ = -⟪x, y⟫ :=
 by { rw [← neg_one_smul 𝕜 x, inner_smul_left], simp }
@@ -595,6 +595,18 @@ begin
   simp [inner_sub_sub_self, this],
   ring,
 end
+
+variable (𝕜)
+include 𝕜
+
+lemma ext_inner_left {x y : E} (h : ∀ v, ⟪v, x⟫ = ⟪v, y⟫) : x = y :=
+by rw [←sub_eq_zero, ←inner_self_eq_zero, inner_sub_right, sub_eq_zero, h (x - y)]
+
+lemma ext_inner_right {x y : E} (h : ∀ v, ⟪x, v⟫ = ⟪y, v⟫) : x = y :=
+by rw [←sub_eq_zero, ←inner_self_eq_zero, inner_sub_left, sub_eq_zero, h (x - y)]
+
+omit 𝕜
+variable {𝕜}
 
 /-- Parallelogram law -/
 lemma parallelogram_law {x y : E} :

--- a/src/analysis/inner_product_space/dual.lean
+++ b/src/analysis/inner_product_space/dual.lean
@@ -69,10 +69,10 @@ variable (𝕜)
 include 𝕜
 
 lemma ext_inner_left {x y : E} (h : ∀ v, ⟪v, x⟫ = ⟪v, y⟫) : x = y :=
-by { rw [←sub_eq_zero, ←inner_self_eq_zero, inner_sub_right, sub_eq_zero], exact h (x - y) }
+by rw [←sub_eq_zero, ←inner_self_eq_zero, inner_sub_right, sub_eq_zero, h (x - y)]
 
 lemma ext_inner_right {x y : E} (h : ∀ v, ⟪x, v⟫ = ⟪y, v⟫) : x = y :=
-by { rw [←sub_eq_zero, ←inner_self_eq_zero, inner_sub_left, sub_eq_zero], exact h (x - y) }
+by rw [←sub_eq_zero, ←inner_self_eq_zero, inner_sub_left, sub_eq_zero, h (x - y)]
 
 omit 𝕜
 variable {𝕜}

--- a/src/analysis/inner_product_space/dual.lean
+++ b/src/analysis/inner_product_space/dual.lean
@@ -67,22 +67,13 @@ show ∥(to_dual_map 𝕜 E).to_continuous_linear_map∥ = 1,
 
 variable (𝕜)
 include 𝕜
+
 lemma ext_inner_left {x y : E} (h : ∀ v, ⟪v, x⟫ = ⟪v, y⟫) : x = y :=
-begin
-  apply (to_dual_map 𝕜 E).map_eq_iff.mp,
-  ext v,
-  rw [to_dual_map_apply, to_dual_map_apply, ←inner_conj_sym],
-  nth_rewrite_rhs 0 [←inner_conj_sym],
-  exact congr_arg conj (h v)
-end
+by { rw [←sub_eq_zero, ←inner_self_eq_zero, inner_sub_right, sub_eq_zero], exact h (x - y) }
 
 lemma ext_inner_right {x y : E} (h : ∀ v, ⟪x, v⟫ = ⟪y, v⟫) : x = y :=
-begin
-  refine ext_inner_left 𝕜 (λ v, _),
-  rw [←inner_conj_sym],
-  nth_rewrite_rhs 0 [←inner_conj_sym],
-  exact congr_arg conj (h v)
-end
+by { rw [←sub_eq_zero, ←inner_self_eq_zero, inner_sub_left, sub_eq_zero], exact h (x - y) }
+
 omit 𝕜
 variable {𝕜}
 

--- a/src/analysis/inner_product_space/dual.lean
+++ b/src/analysis/inner_product_space/dual.lean
@@ -65,16 +65,6 @@ lemma innerSL_norm [nontrivial E] : ∥(innerSL : E →L⋆[𝕜] E →L[𝕜] �
 show ∥(to_dual_map 𝕜 E).to_continuous_linear_map∥ = 1,
   from linear_isometry.norm_to_continuous_linear_map _
 
-variable (𝕜)
-include 𝕜
-
-lemma ext_inner_left {x y : E} (h : ∀ v, ⟪v, x⟫ = ⟪v, y⟫) : x = y :=
-by rw [←sub_eq_zero, ←inner_self_eq_zero, inner_sub_right, sub_eq_zero, h (x - y)]
-
-lemma ext_inner_right {x y : E} (h : ∀ v, ⟪x, v⟫ = ⟪y, v⟫) : x = y :=
-by rw [←sub_eq_zero, ←inner_self_eq_zero, inner_sub_left, sub_eq_zero, h (x - y)]
-
-omit 𝕜
 variable {𝕜}
 
 lemma ext_inner_left_basis {ι : Type*} {x y : E} (b : basis ι 𝕜 E)


### PR DESCRIPTION
Golf two proofs and move the lemmas into `inner_product_space/basic` since they now only depend on elementary facts about inner product spaces.

---

This is a streamlined version of a proof suggested on [zulip](https://leanprover.zulipchat.com/#narrow/stream/217875-Is-there-code-for-X.3F/topic/inner.20product.20space.20eq).

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
