### PR TITLE
feat(data/list/basic): nth_eq_nth_of_nth_le_eq_nth_le

### DIFF
--- a/src/data/list/basic.lean
+++ b/src/data/list/basic.lean
@@ -1161,7 +1161,7 @@ theorem nth_eq_nth_of_nth_le_eq_nth_le {l₁ l₂ : list α}
   {n₁ n₂ : ℕ} {lt_len₁ : n₁ < l₁.length} {lt_len₂ : n₂ < l₂.length}
   (h : l₁.nth_le n₁ lt_len₁ = l₂.nth_le n₂ lt_len₂) :
   l₁.nth n₁ = l₂.nth n₂ :=
-by rw [list.nth_le_nth lt_len₁, list.nth_le_nth lt_len₂, h]
+by rw [nth_le_nth lt_len₁, nth_le_nth lt_len₂, h]
 
 theorem nth_eq_some {l : list α} {n a} : nth l n = some a ↔ ∃ h, nth_le l n h = a :=
 ⟨λ e,
@@ -1511,7 +1511,7 @@ by rw [← option.some_inj, ← nth_le_nth, nth_update_nth_eq, nth_le_nth]; simp
 @[simp] lemma nth_le_update_nth_of_ne {l : list α} {i j : ℕ} (h : i ≠ j) (a : α)
   (hj : j < (l.update_nth i a).length) :
   (l.update_nth i a).nth_le j hj = l.nth_le j (by simpa using hj) :=
-by rw [← option.some_inj, ← list.nth_le_nth, list.nth_update_nth_ne _ _ h, list.nth_le_nth]
+by rw [← option.some_inj, ← nth_le_nth, list.nth_update_nth_ne _ _ h, nth_le_nth]
 
 lemma mem_or_eq_of_mem_update_nth : ∀ {l : list α} {n : ℕ} {a b : α}
   (h : a ∈ l.update_nth n b), a ∈ l ∨ a = b

--- a/src/data/list/basic.lean
+++ b/src/data/list/basic.lean
@@ -1157,12 +1157,6 @@ theorem nth_len_le : ∀ {l : list α} {n}, length l ≤ n → nth l n = none
 | []       n     h := rfl
 | (a :: l) (n+1) h := nth_len_le (le_of_succ_le_succ h)
 
-theorem nth_eq_nth_of_nth_le_eq_nth_le {l₁ l₂ : list α}
-  {n₁ n₂ : ℕ} {lt_len₁ : n₁ < l₁.length} {lt_len₂ : n₂ < l₂.length}
-  (h : l₁.nth_le n₁ lt_len₁ = l₂.nth_le n₂ lt_len₂) :
-  l₁.nth n₁ = l₂.nth n₂ :=
-by rw [nth_le_nth lt_len₁, nth_le_nth lt_len₂, h]
-
 theorem nth_eq_some {l : list α} {n a} : nth l n = some a ↔ ∃ h, nth_le l n h = a :=
 ⟨λ e,
   have h : n < length l, from lt_of_not_ge $ λ hn,
@@ -1180,6 +1174,12 @@ begin
     rw [← nth_eq_some, h] at h₂, cases h₂ },
   { solve_by_elim [nth_len_le] },
 end
+
+theorem nth_eq_nth_of_nth_le_eq_nth_le {l₁ l₂ : list α}
+  {n₁ n₂ : ℕ} {lt_len₁ : n₁ < l₁.length} {lt_len₂ : n₂ < l₂.length}
+  (h : l₁.nth_le n₁ lt_len₁ = l₂.nth_le n₂ lt_len₂) :
+  l₁.nth n₁ = l₂.nth n₂ :=
+by rw [nth_le_nth lt_len₁, nth_le_nth lt_len₂, h]
 
 theorem nth_of_mem {a} {l : list α} (h : a ∈ l) : ∃ n, nth l n = some a :=
 let ⟨n, h, e⟩ := nth_le_of_mem h in ⟨n, by rw [nth_le_nth, e]⟩

--- a/src/data/list/basic.lean
+++ b/src/data/list/basic.lean
@@ -1157,6 +1157,12 @@ theorem nth_len_le : ∀ {l : list α} {n}, length l ≤ n → nth l n = none
 | []       n     h := rfl
 | (a :: l) (n+1) h := nth_len_le (le_of_succ_le_succ h)
 
+theorem nth_eq_nth_of_nth_le_eq_nth_le {l₁ l₂ : list α}
+  {n₁ n₂ : ℕ} {lt_len₁ : n₁ < l₁.length} {lt_len₂ : n₂ < l₂.length}
+  (h : l₁.nth_le n₁ lt_len₁ = l₂.nth_le n₂ lt_len₂) :
+  l₁.nth n₁ = l₂.nth n₂ :=
+by rw [list.nth_le_nth lt_len₁, list.nth_le_nth lt_len₂, h]
+
 theorem nth_eq_some {l : list α} {n a} : nth l n = some a ↔ ∃ h, nth_le l n h = a :=
 ⟨λ e,
   have h : n < length l, from lt_of_not_ge $ λ hn,


### PR DESCRIPTION
I often have `l₁.nth_le n _ = l₂.nth_le n _` among proved things. However, as a result of using the tactic `ext1` I need to show `l₁.nth n = l₂.nth n` which is the purpose of this lemma.

Co-authored-by: Junyan Xu [junyanxu.math@gmail.com](mailto:junyanxu.math@gmail.com)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
