### PR TITLE
[Merged by Bors] - feat(topology/subset_properties): `locally_compact_space` instance for `Π` types

### DIFF
--- a/src/topology/subset_properties.lean
+++ b/src/topology/subset_properties.lean
@@ -1018,6 +1018,21 @@ instance locally_compact_space.prod (α : Type*) (β : Type*) [topological_space
 have _ := λ x : α × β, (compact_basis_nhds x.1).prod_nhds' (compact_basis_nhds x.2),
 locally_compact_space_of_has_basis this $ λ x s ⟨⟨_, h₁⟩, _, h₂⟩, h₁.prod h₂
 
+instance locally_compact_space.pi {ι : Type*} {π : ι → Type*} [Π i, topological_space (π i)]
+  [∀ i, compact_space (π i)] [∀ i, locally_compact_space (π i)] :
+  locally_compact_space (Π i, π i) :=
+⟨λ t n hn, begin
+  rw [nhds_pi, filter.mem_pi] at hn,
+  obtain ⟨s, hs, n', hn', hsub⟩ := hn,
+  choose n'' hn'' hsub' hc using λ i, locally_compact_space.local_compact_nhds (t i) (n' i) (hn' i),
+  use s.pi n'', rw set_pi_mem_nhds_iff hs,
+  refine ⟨λ i _, hn'' i, subset_trans (λ _, _) hsub, _⟩,
+  { refine forall₂_imp (λ i _, _), apply hsub' },
+  { classical, rw ← set.univ_pi_ite, apply is_compact_univ_pi,
+    intro i, by_cases i ∈ s, { rw if_pos h, apply hc },
+    { rw if_neg h, exact compact_space.compact_univ } },
+end⟩
+
 /-- A reformulation of the definition of locally compact space: In a locally compact space,
   every open set containing `x` has a compact subset containing `x` in its interior. -/
 lemma exists_compact_subset [locally_compact_space α] {x : α} {U : set α}

--- a/src/topology/subset_properties.lean
+++ b/src/topology/subset_properties.lean
@@ -1022,6 +1022,8 @@ section pi
 
 variables [Π i, topological_space (π i)] [∀ i, locally_compact_space (π i)]
 
+/--In general it suffices that all but finitely many of the spaces are compact,
+  but that's not straightforward to state and use. -/
 instance locally_compact_space.pi_finite [finite ι] : locally_compact_space (Π i, π i) :=
 ⟨λ t n hn, begin
   rw [nhds_pi, filter.mem_pi] at hn,

--- a/src/topology/subset_properties.lean
+++ b/src/topology/subset_properties.lean
@@ -1018,7 +1018,7 @@ instance locally_compact_space.prod (α : Type*) (β : Type*) [topological_space
 have _ := λ x : α × β, (compact_basis_nhds x.1).prod_nhds' (compact_basis_nhds x.2),
 locally_compact_space_of_has_basis this $ λ x s ⟨⟨_, h₁⟩, _, h₂⟩, h₁.prod h₂
 
-section
+section pi
 
 variables [Π i, topological_space (π i)] [∀ i, locally_compact_space (π i)]
 
@@ -1032,6 +1032,7 @@ instance locally_compact_space.pi_finite [finite ι] : locally_compact_space (Π
   { exact λ i hi, hsub' i (h i trivial), },
 end⟩
 
+/-- For spaces that are not Hausdorff. -/
 instance locally_compact_space.pi [∀ i, compact_space (π i)] : locally_compact_space (Π i, π i) :=
 ⟨λ t n hn, begin
   rw [nhds_pi, filter.mem_pi] at hn,
@@ -1047,7 +1048,7 @@ instance locally_compact_space.pi [∀ i, compact_space (π i)] : locally_compac
     { rw if_neg h, exact compact_space.compact_univ, } },
 end⟩
 
-end
+end pi
 
 /-- A reformulation of the definition of locally compact space: In a locally compact space,
   every open set containing `x` has a compact subset containing `x` in its interior. -/

--- a/src/topology/subset_properties.lean
+++ b/src/topology/subset_properties.lean
@@ -1027,9 +1027,9 @@ instance locally_compact_space.pi_finite [finite ι] : locally_compact_space (Π
   rw [nhds_pi, filter.mem_pi] at hn,
   obtain ⟨s, hs, n', hn', hsub⟩ := hn,
   choose n'' hn'' hsub' hc using λ i, locally_compact_space.local_compact_nhds (t i) (n' i) (hn' i),
-  use (set.univ : set ι).pi n'', rw set_pi_mem_nhds_iff (@set.finite_univ ι _),
-  refine ⟨λ i _, hn'' i, subset_trans (λ _ h, _) hsub, is_compact_univ_pi hc⟩,
-  intros i _, exact hsub' i (h i trivial),
+  refine ⟨(set.univ : set ι).pi n'', _, subset_trans (λ _ h, _) hsub, is_compact_univ_pi hc⟩,
+  { exact (set_pi_mem_nhds_iff (@set.finite_univ ι _) _).mpr (λ i hi, hn'' i), },
+  { exact λ i hi, hsub' i (h i trivial), },
 end⟩
 
 instance locally_compact_space.pi [∀ i, compact_space (π i)] : locally_compact_space (Π i, π i) :=
@@ -1037,12 +1037,14 @@ instance locally_compact_space.pi [∀ i, compact_space (π i)] : locally_compac
   rw [nhds_pi, filter.mem_pi] at hn,
   obtain ⟨s, hs, n', hn', hsub⟩ := hn,
   choose n'' hn'' hsub' hc using λ i, locally_compact_space.local_compact_nhds (t i) (n' i) (hn' i),
-  use s.pi n'', rw set_pi_mem_nhds_iff hs,
-  refine ⟨λ i _, hn'' i, subset_trans (λ _, _) hsub, _⟩,
-  { refine forall₂_imp (λ i _, _), apply hsub' },
-  { classical, rw ← set.univ_pi_ite, apply is_compact_univ_pi,
-    intro i, by_cases i ∈ s, { rw if_pos h, apply hc },
-    { rw if_neg h, exact compact_space.compact_univ } },
+  refine ⟨s.pi n'', _, subset_trans (λ _, _) hsub, _⟩,
+  { exact (set_pi_mem_nhds_iff hs _).mpr (λ i _, hn'' i), },
+  { exact forall₂_imp (λ i hi hi', hsub' i hi'), },
+  { rw ← set.univ_pi_ite,
+    refine is_compact_univ_pi (λ i, _),
+    by_cases i ∈ s,
+    { rw if_pos h, exact hc i, },
+    { rw if_neg h, exact compact_space.compact_univ, } },
 end⟩
 
 end

--- a/src/topology/subset_properties.lean
+++ b/src/topology/subset_properties.lean
@@ -1018,9 +1018,21 @@ instance locally_compact_space.prod (α : Type*) (β : Type*) [topological_space
 have _ := λ x : α × β, (compact_basis_nhds x.1).prod_nhds' (compact_basis_nhds x.2),
 locally_compact_space_of_has_basis this $ λ x s ⟨⟨_, h₁⟩, _, h₂⟩, h₁.prod h₂
 
-instance locally_compact_space.pi {ι : Type*} {π : ι → Type*} [Π i, topological_space (π i)]
-  [∀ i, compact_space (π i)] [∀ i, locally_compact_space (π i)] :
-  locally_compact_space (Π i, π i) :=
+section
+
+variables [Π i, topological_space (π i)] [∀ i, locally_compact_space (π i)]
+
+instance locally_compact_space.pi_finite [finite ι] : locally_compact_space (Π i, π i) :=
+⟨λ t n hn, begin
+  rw [nhds_pi, filter.mem_pi] at hn,
+  obtain ⟨s, hs, n', hn', hsub⟩ := hn,
+  choose n'' hn'' hsub' hc using λ i, locally_compact_space.local_compact_nhds (t i) (n' i) (hn' i),
+  use (set.univ : set ι).pi n'', rw set_pi_mem_nhds_iff (@set.finite_univ ι _),
+  refine ⟨λ i _, hn'' i, subset_trans (λ _ h, _) hsub, is_compact_univ_pi hc⟩,
+  intros i _, exact hsub' i (h i trivial),
+end⟩
+
+instance locally_compact_space.pi [∀ i, compact_space (π i)] : locally_compact_space (Π i, π i) :=
 ⟨λ t n hn, begin
   rw [nhds_pi, filter.mem_pi] at hn,
   obtain ⟨s, hs, n', hn', hsub⟩ := hn,
@@ -1032,6 +1044,8 @@ instance locally_compact_space.pi {ι : Type*} {π : ι → Type*} [Π i, topolo
     intro i, by_cases i ∈ s, { rw if_pos h, apply hc },
     { rw if_neg h, exact compact_space.compact_univ } },
 end⟩
+
+end
 
 /-- A reformulation of the definition of locally compact space: In a locally compact space,
   every open set containing `x` has a compact subset containing `x` in its interior. -/


### PR DESCRIPTION
This PR adds 
- `locally_compact_space.pi` mirroring `locally_compact_space.prod` and
- `locally_compact_space.pi_finite` for finite products

Proof by: @alreadydone 

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
