### PR TITLE
[Merged by Bors] - feat(topology/continuous_function/basic): inverse equations for `homeomorph.to_continuous_map`

### DIFF
--- a/src/topology/continuous_function/basic.lean
+++ b/src/topology/continuous_function/basic.lean
@@ -287,30 +287,30 @@ end gluing
 end continuous_map
 
 namespace homeomorph
-variables {α β : Type*} [topological_space α] [topological_space β]
-variable (f : α ≃ₜ β)
+variables {α β γ : Type*} [topological_space α] [topological_space β] [topological_space γ]
+variables (f : α ≃ₜ β) (g : β ≃ₜ γ)
 
-/--
-The forward direction of a homeomorphism, as a bundled continuous map.
--/
+/-- The forward direction of a homeomorphism, as a bundled continuous map. -/
 @[simps]
 def to_continuous_map (e : α ≃ₜ β) : C(α, β) := ⟨e⟩
 
 /--`homeomorph.to_continuous_map` as a coercion. -/
 instance : has_coe (α ≃ₜ β) C(α, β) := ⟨homeomorph.to_continuous_map⟩
 
-/--
-Left inverse to a continuous map from a homeomorphism, mirroring `equiv.symm_comp_self`.
--/
+@[simp] lemma to_continuous_map_as_coe : f.to_continuous_map = f := rfl
+
+@[simp] lemma coe_refl : (homeomorph.refl α : C(α, α)) = continuous_map.id α := rfl
+
+@[simp] lemma coe_trans : (f.trans g : C(α, γ)) = (g : C(β, γ)).comp f := rfl
+
+/-- Left inverse to a continuous map from a homeomorphism, mirroring `equiv.symm_comp_self`. -/
 lemma symm_comp_to_continuous_map :
   (f.symm : C(β, α)).comp (f : C(α, β)) = continuous_map.id α :=
-by { ext, apply f.to_equiv.symm_apply_apply }
+by rw [← coe_trans, self_trans_symm, coe_refl]
 
-/--
-Right inverse to a continuous map from a homeomorphism, mirroring `equiv.self_comp_symm`.
--/
+/-- Right inverse to a continuous map from a homeomorphism, mirroring `equiv.self_comp_symm`. -/
 lemma to_continuous_map_comp_symm :
   (f : C(α, β)).comp (f.symm : C(β, α)) = continuous_map.id β :=
-by { ext, apply f.to_equiv.apply_symm_apply }
+by rw [← coe_trans, symm_trans_self, coe_refl]
 
 end homeomorph

--- a/src/topology/continuous_function/basic.lean
+++ b/src/topology/continuous_function/basic.lean
@@ -297,7 +297,7 @@ def to_continuous_map (e : α ≃ₜ β) : C(α, β) := ⟨e⟩
 /--`homeomorph.to_continuous_map` as a coercion. -/
 instance : has_coe (α ≃ₜ β) C(α, β) := ⟨homeomorph.to_continuous_map⟩
 
-@[simp] lemma to_continuous_map_as_coe : f.to_continuous_map = f := rfl
+lemma to_continuous_map_as_coe : f.to_continuous_map = f := rfl
 
 @[simp] lemma coe_refl : (homeomorph.refl α : C(α, α)) = continuous_map.id α := rfl
 

--- a/src/topology/continuous_function/basic.lean
+++ b/src/topology/continuous_function/basic.lean
@@ -296,6 +296,10 @@ The forward direction of a homeomorphism, as a bundled continuous map.
 @[simps]
 def homeomorph.to_continuous_map (e : α ≃ₜ β) : C(α, β) := ⟨e⟩
 
+/--`homeomorph.to_continuous_map` as a coercion. -/
+instance homeomorph.coe_to_continuous_map : has_coe (α ≃ₜ β) C(α, β) :=
+⟨homeomorph.to_continuous_map⟩
+
 /--
 Left inverse to a continuous map from a homemorphism, mirroring `equiv.symm_comp_self`.
 -/

--- a/src/topology/continuous_function/basic.lean
+++ b/src/topology/continuous_function/basic.lean
@@ -286,9 +286,28 @@ end gluing
 
 end continuous_map
 
+section
+variables {α β : Type*} [topological_space α] [topological_space β]
+variable (f : α ≃ₜ β)
+
 /--
 The forward direction of a homeomorphism, as a bundled continuous map.
 -/
 @[simps]
-def homeomorph.to_continuous_map {α β : Type*} [topological_space α] [topological_space β]
-  (e : α ≃ₜ β) : C(α, β) := ⟨e⟩
+def homeomorph.to_continuous_map (e : α ≃ₜ β) : C(α, β) := ⟨e⟩
+
+/--
+Left inverse to a continuous map from a homemorphism
+-/
+lemma homeomorph.symm_comp_to_continuous_map :
+  f.symm.to_continuous_map.comp f.to_continuous_map = continuous_map.id α :=
+by { ext, apply f.to_equiv.symm_apply_apply }
+
+/--
+Right inverse to a continuous map from a homemorphism
+-/
+lemma homeomorph.comp_symm_to_continuous_map :
+  f.to_continuous_map.comp f.symm.to_continuous_map = continuous_map.id β :=
+by { ext, apply f.to_equiv.apply_symm_apply }
+
+end

--- a/src/topology/continuous_function/basic.lean
+++ b/src/topology/continuous_function/basic.lean
@@ -286,7 +286,7 @@ end gluing
 
 end continuous_map
 
-section
+namespace homeomorph
 variables {α β : Type*} [topological_space α] [topological_space β]
 variable (f : α ≃ₜ β)
 
@@ -294,24 +294,23 @@ variable (f : α ≃ₜ β)
 The forward direction of a homeomorphism, as a bundled continuous map.
 -/
 @[simps]
-def homeomorph.to_continuous_map (e : α ≃ₜ β) : C(α, β) := ⟨e⟩
+def to_continuous_map (e : α ≃ₜ β) : C(α, β) := ⟨e⟩
 
 /--`homeomorph.to_continuous_map` as a coercion. -/
-instance homeomorph.coe_to_continuous_map : has_coe (α ≃ₜ β) C(α, β) :=
-⟨homeomorph.to_continuous_map⟩
+instance : has_coe (α ≃ₜ β) C(α, β) := ⟨homeomorph.to_continuous_map⟩
 
 /--
-Left inverse to a continuous map from a homemorphism, mirroring `equiv.symm_comp_self`.
+Left inverse to a continuous map from a homeomorphism, mirroring `equiv.symm_comp_self`.
 -/
-lemma homeomorph.symm_comp_self :
-  f.symm.to_continuous_map.comp f.to_continuous_map = continuous_map.id α :=
+lemma symm_comp_to_continuous_map :
+  (f.symm : C(β, α)).comp (f : C(α, β)) = continuous_map.id α :=
 by { ext, apply f.to_equiv.symm_apply_apply }
 
 /--
-Right inverse to a continuous map from a homemorphism, mirroring `equiv.self_comp_symm`.
+Right inverse to a continuous map from a homeomorphism, mirroring `equiv.self_comp_symm`.
 -/
-lemma homeomorph.self_comp_symm :
-  f.to_continuous_map.comp f.symm.to_continuous_map = continuous_map.id β :=
+lemma to_continuous_map_comp_symm :
+  (f : C(α, β)).comp (f.symm : C(β, α)) = continuous_map.id β :=
 by { ext, apply f.to_equiv.apply_symm_apply }
 
-end
+end homeomorph

--- a/src/topology/continuous_function/basic.lean
+++ b/src/topology/continuous_function/basic.lean
@@ -297,16 +297,16 @@ The forward direction of a homeomorphism, as a bundled continuous map.
 def homeomorph.to_continuous_map (e : α ≃ₜ β) : C(α, β) := ⟨e⟩
 
 /--
-Left inverse to a continuous map from a homemorphism
+Left inverse to a continuous map from a homemorphism, mirroring `equiv.symm_comp_self`.
 -/
-lemma homeomorph.symm_comp_to_continuous_map :
+lemma homeomorph.symm_comp_self :
   f.symm.to_continuous_map.comp f.to_continuous_map = continuous_map.id α :=
 by { ext, apply f.to_equiv.symm_apply_apply }
 
 /--
-Right inverse to a continuous map from a homemorphism
+Right inverse to a continuous map from a homemorphism, mirroring `equiv.self_comp_symm`.
 -/
-lemma homeomorph.comp_symm_to_continuous_map :
+lemma homeomorph.self_comp_symm :
   f.to_continuous_map.comp f.symm.to_continuous_map = continuous_map.id β :=
 by { ext, apply f.to_equiv.apply_symm_apply }
 

--- a/src/topology/continuous_function/basic.lean
+++ b/src/topology/continuous_function/basic.lean
@@ -304,12 +304,12 @@ instance : has_coe (α ≃ₜ β) C(α, β) := ⟨homeomorph.to_continuous_map�
 @[simp] lemma coe_trans : (f.trans g : C(α, γ)) = (g : C(β, γ)).comp f := rfl
 
 /-- Left inverse to a continuous map from a homeomorphism, mirroring `equiv.symm_comp_self`. -/
-lemma symm_comp_to_continuous_map :
+@[simp] lemma symm_comp_to_continuous_map :
   (f.symm : C(β, α)).comp (f : C(α, β)) = continuous_map.id α :=
 by rw [← coe_trans, self_trans_symm, coe_refl]
 
 /-- Right inverse to a continuous map from a homeomorphism, mirroring `equiv.self_comp_symm`. -/
-lemma to_continuous_map_comp_symm :
+@[simp] lemma to_continuous_map_comp_symm :
   (f : C(α, β)).comp (f.symm : C(β, α)) = continuous_map.id β :=
 by rw [← coe_trans, symm_trans_self, coe_refl]
 

--- a/src/topology/homeomorph.lean
+++ b/src/topology/homeomorph.lean
@@ -106,6 +106,12 @@ h.to_equiv.apply_symm_apply x
 @[simp] lemma symm_apply_apply (h : α ≃ₜ β) (x : α) : h.symm (h x) = x :=
 h.to_equiv.symm_apply_apply x
 
+@[simp] lemma self_trans_symm (h : α ≃ₜ β) : h.trans h.symm = homeomorph.refl α :=
+by { ext, apply symm_apply_apply }
+
+@[simp] lemma symm_trans_self (h : α ≃ₜ β) : h.symm.trans h = homeomorph.refl β :=
+by { ext, apply apply_symm_apply }
+
 protected lemma bijective (h : α ≃ₜ β) : function.bijective h := h.to_equiv.bijective
 protected lemma injective (h : α ≃ₜ β) : function.injective h := h.to_equiv.injective
 protected lemma surjective (h : α ≃ₜ β) : function.surjective h := h.to_equiv.surjective


### PR DESCRIPTION
This PR adds two lemmas stating the left and right inverse of an `homeomorph.to_continuous_map`:
-`homeomorph.symm_comp_to_continuous_map`, and
-`homeomorph.comp_symm_to_continuous_map`

Suggested by: @alreadydone 

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
