### PR TITLE
[Merged by Bors] - chore(field_theory/splitting_field): remove unneeded parameter

### DIFF
--- a/src/field_theory/splitting_field.lean
+++ b/src/field_theory/splitting_field.lean
@@ -480,23 +480,21 @@ theorem nat_degree_remove_factor' {f : K[X]} {n : ℕ} (hfn : f.nat_degree = n+1
 by rw [nat_degree_remove_factor, hfn, n.add_sub_cancel]
 
 /-- Auxiliary construction to a splitting field of a polynomial. Uses induction on the degree. -/
-def splitting_field_aux (n : ℕ) : Π {K : Type u} [field K], by exactI Π (f : K[X]),
-  f.nat_degree = n → Type u :=
-nat.rec_on n (λ K _ _ _, K) $ λ n ih K _ f hf, by exactI
-ih f.remove_factor (nat_degree_remove_factor' hf)
+def splitting_field_aux (n : ℕ) : Π {K : Type u} [field K], by exactI Π (f : K[X]), Type u :=
+nat.rec_on n (λ K _ _, K) $ λ n ih K _ f, by exactI
+ih f.remove_factor
 
 namespace splitting_field_aux
 
-theorem succ (n : ℕ) (f : K[X]) (hfn : f.nat_degree = n + 1) :
-  splitting_field_aux (n+1) f hfn =
-    splitting_field_aux n f.remove_factor (nat_degree_remove_factor' hfn) := rfl
+theorem succ (n : ℕ) (f : K[X]) :
+  splitting_field_aux (n+1) f = splitting_field_aux n f.remove_factor := rfl
 
 instance field (n : ℕ) : Π {K : Type u} [field K], by exactI
-  Π {f : K[X]} (hfn : f.nat_degree = n), field (splitting_field_aux n f hfn) :=
-nat.rec_on n (λ K _ _ _, ‹field K›) $ λ n ih K _ f hf, ih _
+  Π {f : K[X]}, field (splitting_field_aux n f) :=
+nat.rec_on n (λ K _ _, ‹field K›) $ λ n ih K _ f, ih
 
-instance inhabited {n : ℕ} {f : K[X]} (hfn : f.nat_degree = n) :
-  inhabited (splitting_field_aux n f hfn) := ⟨37⟩
+instance inhabited {n : ℕ} {f : K[X]} :
+  inhabited (splitting_field_aux n f) := ⟨37⟩
 
 /-
 Note that the recursive nature of this definition and `splitting_field_aux.field` creates
@@ -519,66 +517,66 @@ example (x : ℕ) {α} (a₀ aₙ : α) : (cases_twice a₀ aₙ x).1 = (cases_t
 We don't really care at this point because this is an implementation detail (which is why this is
 not a docstring), but we do in `splitting_field.algebra'` below. -/
 instance algebra (n : ℕ) : Π (R : Type*) {K : Type u} [comm_semiring R] [field K],
-  by exactI Π [algebra R K] {f : K[X]} (hfn : f.nat_degree = n),
-    algebra R (splitting_field_aux n f hfn) :=
-nat.rec_on n (λ R K _ _ _ _ _, by exactI ‹algebra R K›) $
-         λ n ih R K _ _ _ f hfn, by exactI ih R (nat_degree_remove_factor' hfn)
+  by exactI Π [algebra R K] {f : K[X]},
+    algebra R (splitting_field_aux n f) :=
+nat.rec_on n (λ R K _ _ _ _, by exactI ‹algebra R K›) $
+         λ n ih R K _ _ _ f, by exactI ih R
 
 instance is_scalar_tower (n : ℕ) : Π (R₁ R₂ : Type*) {K : Type u}
   [comm_semiring R₁] [comm_semiring R₂] [has_smul R₁ R₂] [field K],
   by exactI Π [algebra R₁ K] [algebra R₂ K],
-  by exactI Π [is_scalar_tower R₁ R₂ K] {f : K[X]} (hfn : f.nat_degree = n),
-    is_scalar_tower R₁ R₂ (splitting_field_aux n f hfn) :=
-nat.rec_on n (λ R₁ R₂ K _ _ _ _ _ _ _ _ _, by exactI ‹is_scalar_tower R₁ R₂ K›) $
-         λ n ih R₁ R₂ K _ _ _ _ _ _ _ f hfn, by exactI ih R₁ R₂ (nat_degree_remove_factor' hfn)
+  by exactI Π [is_scalar_tower R₁ R₂ K] {f : K[X]},
+    is_scalar_tower R₁ R₂ (splitting_field_aux n f) :=
+nat.rec_on n (λ R₁ R₂ K _ _ _ _ _ _ _ _, by exactI ‹is_scalar_tower R₁ R₂ K›) $
+         λ n ih R₁ R₂ K _ _ _ _ _ _ _ f, by exactI ih R₁ R₂
 
-instance algebra''' {n : ℕ} {f : K[X]} (hfn : f.nat_degree = n + 1) :
+instance algebra''' {n : ℕ} {f : K[X]} :
   algebra (adjoin_root f.factor)
-    (splitting_field_aux n f.remove_factor (nat_degree_remove_factor' hfn)) :=
-splitting_field_aux.algebra n _ _
+    (splitting_field_aux n f.remove_factor) :=
+splitting_field_aux.algebra n _
 
-instance algebra' {n : ℕ} {f : K[X]} (hfn : f.nat_degree = n + 1) :
-  algebra (adjoin_root f.factor) (splitting_field_aux n.succ f hfn) :=
-splitting_field_aux.algebra''' _
+instance algebra' {n : ℕ} {f : K[X]} :
+  algebra (adjoin_root f.factor) (splitting_field_aux n.succ f) :=
+splitting_field_aux.algebra'''
 
-instance algebra'' {n : ℕ} {f : K[X]} (hfn : f.nat_degree = n + 1) :
-  algebra K (splitting_field_aux n f.remove_factor (nat_degree_remove_factor' hfn)) :=
-splitting_field_aux.algebra n K _
+instance algebra'' {n : ℕ} {f : K[X]} :
+  algebra K (splitting_field_aux n f.remove_factor) :=
+splitting_field_aux.algebra n K
 
-instance scalar_tower' {n : ℕ} {f : K[X]} (hfn : f.nat_degree = n + 1) :
+instance scalar_tower' {n : ℕ} {f : K[X]} :
   is_scalar_tower K (adjoin_root f.factor)
-    (splitting_field_aux n f.remove_factor (nat_degree_remove_factor' hfn)) :=
+    (splitting_field_aux n f.remove_factor) :=
 begin
   -- finding this instance ourselves makes things faster
   haveI : is_scalar_tower K (adjoin_root f.factor) (adjoin_root f.factor) :=
     is_scalar_tower.right,
   exact
-    splitting_field_aux.is_scalar_tower n K (adjoin_root f.factor) (nat_degree_remove_factor' hfn),
+    splitting_field_aux.is_scalar_tower n K (adjoin_root f.factor),
 end
 
-instance scalar_tower {n : ℕ} {f : K[X]} (hfn : f.nat_degree = n + 1) :
-  is_scalar_tower K (adjoin_root f.factor) (splitting_field_aux _ f hfn) :=
-splitting_field_aux.scalar_tower' _
+instance scalar_tower {n : ℕ} {f : K[X]} :
+  is_scalar_tower K (adjoin_root f.factor) (splitting_field_aux (n + 1) f) :=
+splitting_field_aux.scalar_tower'
 
-theorem algebra_map_succ (n : ℕ) (f : K[X]) (hfn : f.nat_degree = n + 1) :
-  by exact algebra_map K (splitting_field_aux _ _ hfn) =
+theorem algebra_map_succ (n : ℕ) (f : K[X]) :
+  by exact algebra_map K (splitting_field_aux (n+1) f) =
     (algebra_map (adjoin_root f.factor)
-        (splitting_field_aux n f.remove_factor (nat_degree_remove_factor' hfn))).comp
+        (splitting_field_aux n f.remove_factor)).comp
       (adjoin_root.of f.factor) :=
 is_scalar_tower.algebra_map_eq _ _ _
 
 protected theorem splits (n : ℕ) : ∀ {K : Type u} [field K], by exactI
   ∀ (f : K[X]) (hfn : f.nat_degree = n),
-    splits (algebra_map K $ splitting_field_aux n f hfn) f :=
+    splits (algebra_map K $ splitting_field_aux n f) f :=
 nat.rec_on n (λ K _ _ hf, by exactI splits_of_degree_le_one _
   (le_trans degree_le_nat_degree $ hf.symm ▸ with_bot.coe_le_coe.2 zero_le_one)) $ λ n ih K _ f hf,
 by { resetI, rw [← splits_id_iff_splits, algebra_map_succ, ← map_map, splits_id_iff_splits,
     ← X_sub_C_mul_remove_factor f (λ h, by { rw h at hf, cases hf })],
-exact splits_mul _ (splits_X_sub_C _) (ih _ _) }
+exact splits_mul _ (splits_X_sub_C _) (ih _ (nat_degree_remove_factor' hf)) }
 
 theorem exists_lift (n : ℕ) : ∀ {K : Type u} [field K], by exactI
   ∀ (f : K[X]) (hfn : f.nat_degree = n) {L : Type*} [field L], by exactI
-    ∀ (j : K →+* L) (hf : splits j f), ∃ k : splitting_field_aux n f hfn →+* L,
+    ∀ (j : K →+* L) (hf : splits j f), ∃ k : splitting_field_aux n f →+* L,
       k.comp (algebra_map _ _) = j :=
 nat.rec_on n (λ K _ _ _ L _ j _, by exactI ⟨j, j.comp_id⟩) $ λ n ih K _ f hf L _ j hj, by exactI
 have hndf : f.nat_degree ≠ 0, by { intro h, rw h at hf, cases hf },
@@ -596,37 +594,37 @@ let ⟨k, hk⟩ := ih f.remove_factor (nat_degree_remove_factor' hf) (adjoin_roo
 
 theorem adjoin_roots (n : ℕ) : ∀ {K : Type u} [field K], by exactI
   ∀ (f : K[X]) (hfn : f.nat_degree = n),
-    algebra.adjoin K (↑(f.map $ algebra_map K $ splitting_field_aux n f hfn).roots.to_finset :
-      set (splitting_field_aux n f hfn)) = ⊤ :=
+    algebra.adjoin K (↑(f.map $ algebra_map K $ splitting_field_aux n f).roots.to_finset :
+      set (splitting_field_aux n f)) = ⊤ :=
 nat.rec_on n (λ K _ f hf, by exactI algebra.eq_top_iff.2 (λ x, subalgebra.range_le _ ⟨x, rfl⟩)) $
 λ n ih K _ f hfn, by exactI
 have hndf : f.nat_degree ≠ 0, by { intro h, rw h at hfn, cases hfn },
 have hfn0 : f ≠ 0, by { intro h, rw h at hndf, exact hndf rfl },
-have hmf0 : map (algebra_map K (splitting_field_aux n.succ f hfn)) f ≠ 0 := map_ne_zero hfn0,
+have hmf0 : map (algebra_map K (splitting_field_aux n.succ f)) f ≠ 0 := map_ne_zero hfn0,
 by { rw [algebra_map_succ, ← map_map, ← X_sub_C_mul_remove_factor _ hndf,
          polynomial.map_mul] at hmf0 ⊢,
 rw [roots_mul hmf0, polynomial.map_sub, map_X, map_C, roots_X_sub_C, multiset.to_finset_add,
     finset.coe_union, multiset.to_finset_singleton, finset.coe_singleton,
     algebra.adjoin_union_eq_adjoin_adjoin, ← set.image_singleton,
     algebra.adjoin_algebra_map K (adjoin_root f.factor)
-      (splitting_field_aux n f.remove_factor (nat_degree_remove_factor' hfn)),
+      (splitting_field_aux n f.remove_factor),
     adjoin_root.adjoin_root_eq_top, algebra.map_top,
     is_scalar_tower.adjoin_range_to_alg_hom K (adjoin_root f.factor)
-      (splitting_field_aux n f.remove_factor (nat_degree_remove_factor' hfn)),
-    ih, subalgebra.restrict_scalars_top] }
+      (splitting_field_aux n f.remove_factor),
+    ih _ (nat_degree_remove_factor' hfn), subalgebra.restrict_scalars_top] }
 
 end splitting_field_aux
 
 /-- A splitting field of a polynomial. -/
 def splitting_field (f : K[X]) :=
-splitting_field_aux _ f rfl
+splitting_field_aux f.nat_degree f
 
 namespace splitting_field
 
 variables (f : K[X])
 
 instance : field (splitting_field f) :=
-splitting_field_aux.field _ _
+splitting_field_aux.field _
 
 instance inhabited : inhabited (splitting_field f) := ⟨37⟩
 
@@ -653,25 +651,25 @@ since `K = ℕ` and `K = ℤ` are not possible due to the `field K` assumption. 
 library and not unique to this `algebra` instance.
 -/
 instance algebra' {R} [comm_semiring R] [algebra R K] : algebra R (splitting_field f) :=
-splitting_field_aux.algebra _ _ _
+splitting_field_aux.algebra _ _
 
 instance : algebra K (splitting_field f) :=
-splitting_field_aux.algebra _ _ _
+splitting_field_aux.algebra _ _
 
 protected theorem splits : splits (algebra_map K (splitting_field f)) f :=
-splitting_field_aux.splits _ _ _
+splitting_field_aux.splits _ _ rfl
 
 variables [algebra K L] (hb : splits (algebra_map K L) f)
 
 /-- Embeds the splitting field into any other field that splits the polynomial. -/
 def lift : splitting_field f →ₐ[K] L :=
-{ commutes' := λ r, by { have := classical.some_spec (splitting_field_aux.exists_lift _ _ _ _ hb),
+{ commutes' := λ r, by { have := classical.some_spec (splitting_field_aux.exists_lift _ _ rfl _ hb),
     exact ring_hom.ext_iff.1 this r },
   .. classical.some (splitting_field_aux.exists_lift _ _ _ _ hb) }
 
 theorem adjoin_roots : algebra.adjoin K
     (↑(f.map (algebra_map K $ splitting_field f)).roots.to_finset : set (splitting_field f)) = ⊤ :=
-splitting_field_aux.adjoin_roots _ _ _
+splitting_field_aux.adjoin_roots _ _ rfl
 
 theorem adjoin_root_set : algebra.adjoin K (f.root_set f.splitting_field) = ⊤ :=
 adjoin_roots f

--- a/src/field_theory/splitting_field.lean
+++ b/src/field_theory/splitting_field.lean
@@ -479,7 +479,12 @@ theorem nat_degree_remove_factor' {f : K[X]} {n : ℕ} (hfn : f.nat_degree = n+1
   f.remove_factor.nat_degree = n :=
 by rw [nat_degree_remove_factor, hfn, n.add_sub_cancel]
 
-/-- Auxiliary construction to a splitting field of a polynomial. Uses induction on the degree. -/
+/-- Auxiliary construction to a splitting field of a polynomial, which removes `n` (arbitrarily-chosen) factors.
+
+Uses recursion on the degree. For better definitional behaviour, structures including `splitting_field_aux`
+(such as instances) should be defined using this recursion in each field, rather than defining the whole
+tuple through recursion.
+-/
 def splitting_field_aux (n : ℕ) : Π {K : Type u} [field K], by exactI Π (f : K[X]), Type u :=
 nat.rec_on n (λ K _ _, K) $ λ n ih K _ f, by exactI
 ih f.remove_factor

--- a/src/field_theory/splitting_field.lean
+++ b/src/field_theory/splitting_field.lean
@@ -479,11 +479,13 @@ theorem nat_degree_remove_factor' {f : K[X]} {n : ℕ} (hfn : f.nat_degree = n+1
   f.remove_factor.nat_degree = n :=
 by rw [nat_degree_remove_factor, hfn, n.add_sub_cancel]
 
-/-- Auxiliary construction to a splitting field of a polynomial, which removes `n` (arbitrarily-chosen) factors.
+/-- Auxiliary construction to a splitting field of a polynomial, which removes
+`n` (arbitrarily-chosen) factors.
 
-Uses recursion on the degree. For better definitional behaviour, structures including `splitting_field_aux`
-(such as instances) should be defined using this recursion in each field, rather than defining the whole
-tuple through recursion.
+Uses recursion on the degree. For better definitional behaviour, structures
+including `splitting_field_aux` (such as instances) should be defined using
+this recursion in each field, rather than defining the whole tuple through
+recursion.
 -/
 def splitting_field_aux (n : ℕ) : Π {K : Type u} [field K], by exactI Π (f : K[X]), Type u :=
 nat.rec_on n (λ K _ _, K) $ λ n ih K _ f, by exactI


### PR DESCRIPTION
The definition of `splitting_field_aux` relied on a parameter `hfn : n = f.nat_degree` that was never actually used in the construction or its instances, only in the `splits` theorem. So we might as well delete it.

This PR prepares for a redefinition of all instances on `splitting_field_aux` to fix instance diamonds, see the `splitting_field-diamond` branch for progress.



---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
