### PR TITLE
[Merged by Bors] - feat(topology): composition of continuous functions is continuous w.r.t. the compact-open topologies

### DIFF
--- a/src/topology/compact_open.lean
+++ b/src/topology/compact_open.lean
@@ -103,33 +103,22 @@ lemma continuous_comp_left : continuous (λ g, g.comp f : C(β, γ) → C(α, γ
 continuous_generated_from $ assume m ⟨s, hs, u, hu, hm⟩,
   by { rw [hm, image_gen f hs hu], exact continuous_map.is_open_gen (hs.image f.2) hu }
 
-/--This is Prop. 9 of Chap. X, §3, №. 4 of Bourbaki's *Topologie Générale*-/
-lemma continuous_map.continuous_prod (α β γ : Type*) [topological_space α] [topological_space β]
+/-- Composition is a continuous map from `C(α, β) × C(β, γ)` to `C(α, γ)`, provided that `β` is
+  locally compact. This is Prop. 9 of Chap. X, §3, №. 4 of Bourbaki's *Topologie Générale*. -/
+lemma continuous_prod (α β γ : Type*) [topological_space α] [topological_space β]
   [locally_compact_space β] [topological_space γ] :
   continuous (λ x : C(α, β) × C(β, γ), x.2.comp x.1) :=
-begin
-  apply continuous_generated_from,
-  rintros M ⟨K, hK, U, hU, hM⟩,
-  apply is_open_iff_forall_mem_open.mpr,
+continuous_generated_from begin
+  rintros M ⟨K, hK, U, hU, rfl⟩,
+  conv { congr, rw [compact_open.gen, preimage_set_of_eq],
+    congr, funext, rw [coe_comp, image_comp, image_subset_iff] },
+  rw is_open_iff_forall_mem_open,
   rintros ⟨φ₀, ψ₀⟩ H,
-  simp only [set.mem_preimage, hM, compact_open.gen, set.image_subset_iff, coe_comp,
-    set.mem_set_of_eq, @set.preimage_comp _ _ _ φ₀ ψ₀ _, to_fun_eq_coe] at H,
-  obtain ⟨L, ⟨hL, hL_left, hL_right⟩⟩ := exists_compact_superset' (hK.image φ₀.2)
-    (hU.preimage ψ₀.2) (set.image_subset_iff.mpr H),
-  set V : (set C(α, β)) := { φ | φ '' K ⊆ interior L } with def_V,
-  have hV := continuous_map.is_open_gen hK is_open_interior,
-  set W : (set C(β, γ)) := {ψ | ψ '' L ⊆ U } with def_W,
-  have hW := continuous_map.is_open_gen hL hU,
-  use V ×ˢ W,
-  split,
-  { rintros ⟨φ, ψ⟩ ⟨hφ, hψ⟩,
-    simp only [set.mem_preimage, hM, compact_open.gen, set.image_subset_iff, coe_comp,
-    set.mem_set_of_eq],
-    rw [← set.image_subset_iff, set.image_comp],
-    exact (set.image_subset ψ $ set.subset.trans hφ interior_subset).trans hψ },
-  exact ⟨is_open.prod hV hW, set.mem_prod.mpr
-    ⟨by {simp only [set.mem_set_of_eq], exact hL_left},
-    by {simp only [set.mem_set_of_eq, set.image_subset_iff], exact hL_right}⟩⟩,
+  obtain ⟨L, hL, hKL, hLU⟩ := exists_compact_between (hK.image φ₀.2) (hU.preimage ψ₀.2) H,
+  use {φ : C(α, β) | φ '' K ⊆ interior L} ×ˢ {ψ : C(β, γ) | ψ '' L ⊆ U},
+  use λ ⟨φ, ψ⟩ ⟨hφ, hψ⟩, subset_trans hφ (interior_subset.trans $ image_subset_iff.mp hψ),
+  use (continuous_map.is_open_gen hK is_open_interior).prod (continuous_map.is_open_gen hL hU),
+  exact mem_prod.mpr ⟨hKL, image_subset_iff.mpr hLU⟩,
 end
 
 end functorial

--- a/src/topology/compact_open.lean
+++ b/src/topology/compact_open.lean
@@ -121,6 +121,10 @@ continuous_generated_from begin
   exact mem_prod.mpr ⟨hKL, image_subset_iff.mpr hLU⟩,
 end
 
+lemma yuri1 (α β γ : Type*) [topological_space α] [topological_space β]
+  [locally_compact_space β] [topological_space γ] [has_mul γ] [has_continuous_mul γ]:
+  continuous (λ x y : C(α, β) × C(β, γ), (x.2.comp x.1) * (y.2.comp y.1)) := sorry
+
 end functorial
 
 section ev

--- a/src/topology/compact_open.lean
+++ b/src/topology/compact_open.lean
@@ -103,6 +103,35 @@ lemma continuous_comp_left : continuous (λ g, g.comp f : C(β, γ) → C(α, γ
 continuous_generated_from $ assume m ⟨s, hs, u, hu, hm⟩,
   by { rw [hm, image_gen f hs hu], exact continuous_map.is_open_gen (hs.image f.2) hu }
 
+/--This is Prop. 9 of Chap. X, §3, №. 4 of Bourbaki's *Topologie Générale*-/
+lemma continuous_map.continuous_prod (α β γ : Type*) [topological_space α] [topological_space β]
+  [locally_compact_space β] [topological_space γ] :
+  continuous (λ x : C(α, β) × C(β, γ), x.2.comp x.1) :=
+begin
+  apply continuous_generated_from,
+  rintros M ⟨K, hK, U, hU, hM⟩,
+  apply is_open_iff_forall_mem_open.mpr,
+  rintros ⟨φ₀, ψ₀⟩ H,
+  simp only [set.mem_preimage, hM, compact_open.gen, set.image_subset_iff, coe_comp,
+    set.mem_set_of_eq, @set.preimage_comp _ _ _ φ₀ ψ₀ _, to_fun_eq_coe] at H,
+  obtain ⟨L, ⟨hL, hL_left, hL_right⟩⟩ := exists_compact_superset' (hK.image φ₀.2)
+    (hU.preimage ψ₀.2) (set.image_subset_iff.mpr H),
+  set V : (set C(α, β)) := { φ | φ '' K ⊆ interior L } with def_V,
+  have hV := continuous_map.is_open_gen hK is_open_interior,
+  set W : (set C(β, γ)) := {ψ | ψ '' L ⊆ U } with def_W,
+  have hW := continuous_map.is_open_gen hL hU,
+  use V ×ˢ W,
+  split,
+  { rintros ⟨φ, ψ⟩ ⟨hφ, hψ⟩,
+    simp only [set.mem_preimage, hM, compact_open.gen, set.image_subset_iff, coe_comp,
+    set.mem_set_of_eq],
+    rw [← set.image_subset_iff, set.image_comp],
+    exact (set.image_subset ψ $ set.subset.trans hφ interior_subset).trans hψ },
+  exact ⟨is_open.prod hV hW, set.mem_prod.mpr
+    ⟨by {simp only [set.mem_set_of_eq], exact hL_left},
+    by {simp only [set.mem_set_of_eq, set.image_subset_iff], exact hL_right}⟩⟩,
+end
+
 end functorial
 
 section ev

--- a/src/topology/compact_open.lean
+++ b/src/topology/compact_open.lean
@@ -121,10 +121,6 @@ continuous_generated_from begin
   exact mem_prod.mpr ⟨hKL, image_subset_iff.mpr hLU⟩,
 end
 
-lemma yuri1 (α β γ : Type*) [topological_space α] [topological_space β]
-  [locally_compact_space β] [topological_space γ] [has_mul γ] [has_continuous_mul γ]:
-  continuous (λ x y : C(α, β) × C(β, γ), (x.2.comp x.1) * (y.2.comp y.1)) := sorry
-
 end functorial
 
 section ev

--- a/src/topology/compact_open.lean
+++ b/src/topology/compact_open.lean
@@ -105,7 +105,7 @@ continuous_generated_from $ assume m ⟨s, hs, u, hu, hm⟩,
 
 /-- Composition is a continuous map from `C(α, β) × C(β, γ)` to `C(α, γ)`, provided that `β` is
   locally compact. This is Prop. 9 of Chap. X, §3, №. 4 of Bourbaki's *Topologie Générale*. -/
-lemma continuous_prod (α β γ : Type*) [topological_space α] [topological_space β]
+lemma continuous_comp' (α β γ : Type*) [topological_space α] [topological_space β]
   [locally_compact_space β] [topological_space γ] :
   continuous (λ x : C(α, β) × C(β, γ), x.2.comp x.1) :=
 continuous_generated_from begin
@@ -120,6 +120,13 @@ continuous_generated_from begin
   use (continuous_map.is_open_gen hK is_open_interior).prod (continuous_map.is_open_gen hL hU),
   exact mem_prod.mpr ⟨hKL, image_subset_iff.mpr hLU⟩,
 end
+
+lemma continuous.comp' {X α β γ : Type*} [topological_space X]
+  [topological_space α] [topological_space β]
+  [locally_compact_space β] [topological_space γ] {f : X → C(α, β)} {g : X → C(β, γ)}
+   (hf : continuous f) (hg : continuous g) :
+  continuous (λ x, (g x).comp (f x)) :=
+(continuous_comp' α β γ).comp (hf.prod_mk hg : continuous (λ x, (f x, g x)))
 
 end functorial
 

--- a/src/topology/compact_open.lean
+++ b/src/topology/compact_open.lean
@@ -105,8 +105,7 @@ continuous_generated_from $ assume m ⟨s, hs, u, hu, hm⟩,
 
 /-- Composition is a continuous map from `C(α, β) × C(β, γ)` to `C(α, γ)`, provided that `β` is
   locally compact. This is Prop. 9 of Chap. X, §3, №. 4 of Bourbaki's *Topologie Générale*. -/
-lemma continuous_comp' (α β γ : Type*) [topological_space α] [topological_space β]
-  [locally_compact_space β] [topological_space γ] :
+lemma continuous_comp' [locally_compact_space β] :
   continuous (λ x : C(α, β) × C(β, γ), x.2.comp x.1) :=
 continuous_generated_from begin
   rintros M ⟨K, hK, U, hU, rfl⟩,
@@ -121,12 +120,10 @@ continuous_generated_from begin
   exact mem_prod.mpr ⟨hKL, image_subset_iff.mpr hLU⟩,
 end
 
-lemma continuous.comp' {X α β γ : Type*} [topological_space X]
-  [topological_space α] [topological_space β]
-  [locally_compact_space β] [topological_space γ] {f : X → C(α, β)} {g : X → C(β, γ)}
-   (hf : continuous f) (hg : continuous g) :
+lemma continuous.comp' {X : Type*} [topological_space X] [locally_compact_space β]
+  {f : X → C(α, β)} {g : X → C(β, γ)} (hf : continuous f) (hg : continuous g) :
   continuous (λ x, (g x).comp (f x)) :=
-(continuous_comp' α β γ).comp (hf.prod_mk hg : continuous (λ x, (f x, g x)))
+continuous_comp'.comp (hf.prod_mk hg : continuous $ λ x, (f x, g x))
 
 end functorial
 

--- a/src/topology/separation.lean
+++ b/src/topology/separation.lean
@@ -1198,6 +1198,20 @@ begin
     compact_closure_of_subset_compact hK' interior_subset⟩,
 end
 
+/--
+In a locally compact T₂ space, given a compact set `K` inside an open set `U`, we can find a
+open set `V` between these sets with compact closure: `K ⊆ V` and the closure of `V` is inside `U`.
+-/
+lemma exists_open_between_and_is_compact_closure [locally_compact_space α] [t2_space α]
+  {K U : set α} (hK : is_compact K) (hU : is_open U) (hKU : K ⊆ U) :
+  ∃ V, is_open V ∧ K ⊆ V ∧ closure V ⊆ U ∧ is_compact (closure V) :=
+begin
+  rcases exists_compact_between hK hU hKU with ⟨V, hV, hKV, hVU⟩,
+  exact ⟨interior V, is_open_interior, hKV,
+    (closure_minimal interior_subset hV.is_closed).trans hVU,
+    compact_closure_of_subset_compact hV interior_subset⟩,
+end
+
 lemma is_preirreducible_iff_subsingleton [t2_space α] (S : set α) :
   is_preirreducible S ↔ S.subsingleton :=
 begin
@@ -1317,42 +1331,6 @@ begin
   use [U₁, mem_of_superset V₁_in h₁, V₁, V₁_in,
        U₂, mem_of_superset V₂_in h₂, V₂, V₂_in],
   tauto
-end
-
-/--
-In a locally compact T₃ space, given a compact set `K` inside an open set `U`, we can find a
-compact set `K'` between these sets: `K` is inside the interior of `K'` and `K' ⊆ U`.
--/
-lemma exists_compact_between [locally_compact_space α] [t3_space α]
-  {K U : set α} (hK : is_compact K) (hU : is_open U) (hKU : K ⊆ U) :
-  ∃ K', is_compact K' ∧ K ⊆ interior K' ∧ K' ⊆ U :=
-begin
-  choose C hxC hCU hC using λ x : K, nhds_is_closed (hU.mem_nhds $ hKU x.2),
-  choose L hL hxL using λ x : K, exists_compact_mem_nhds (x : α),
-  have : K ⊆ ⋃ x, interior (L x) ∩ interior (C x), from
-  λ x hx, mem_Union.mpr ⟨⟨x, hx⟩,
-    ⟨mem_interior_iff_mem_nhds.mpr (hxL _), mem_interior_iff_mem_nhds.mpr (hxC _)⟩⟩,
-  rcases hK.elim_finite_subcover _ _ this with ⟨t, ht⟩,
-  { refine ⟨⋃ x ∈ t, L x ∩ C x, t.compact_bUnion (λ x _, (hL x).inter_right (hC x)), λ x hx, _, _⟩,
-    { obtain ⟨y, hyt, hy : x ∈ interior (L y) ∩ interior (C y)⟩ := mem_Union₂.mp (ht hx),
-      rw [← interior_inter] at hy,
-      refine interior_mono (subset_bUnion_of_mem hyt) hy },
-    { simp_rw [Union_subset_iff], rintro x -, exact (inter_subset_right _ _).trans (hCU _) } },
-  { exact λ _, is_open_interior.inter is_open_interior }
-end
-
-/--
-In a locally compact regular space, given a compact set `K` inside an open set `U`, we can find a
-open set `V` between these sets with compact closure: `K ⊆ V` and the closure of `V` is inside `U`.
--/
-lemma exists_open_between_and_is_compact_closure [locally_compact_space α] [t3_space α]
-  {K U : set α} (hK : is_compact K) (hU : is_open U) (hKU : K ⊆ U) :
-  ∃ V, is_open V ∧ K ⊆ V ∧ closure V ⊆ U ∧ is_compact (closure V) :=
-begin
-  rcases exists_compact_between hK hU hKU with ⟨V, hV, hKV, hVU⟩,
-  refine ⟨interior V, is_open_interior, hKV,
-    (closure_minimal interior_subset hV.is_closed).trans hVU,
-    compact_closure_of_subset_compact hV interior_subset⟩,
 end
 
 end t3

--- a/src/topology/subset_properties.lean
+++ b/src/topology/subset_properties.lean
@@ -1078,6 +1078,28 @@ protected lemma is_open.locally_compact_space [locally_compact_space α] {s : se
   (hs : is_open s) : locally_compact_space s :=
 hs.open_embedding_subtype_coe.locally_compact_space
 
+/-- In a locally compact space, for every containement `K ⊆ U` of a compact set `K` in an open
+  set `U`, there is a compact neighborhood `L` such that `K ⊆ L ⊆ U`: equivalently, there is a
+  compact `L` such that `K ⊆ interior L` and `L ⊆ U`. -/
+lemma exists_compact_superset' [hα : locally_compact_space α] {K U : set α} (hK : is_compact K)
+  (hU : is_open U) (h_KU : K ⊆ U) : ∃ L, is_compact L ∧ K ⊆ interior L ∧ L ⊆ U :=
+begin
+  let ι : U → α := coe,
+  have hι : embedding ι, exact embedding_subtype_coe,
+  set K' := ι⁻¹' K with K'_def,
+  have h_KK' : K = ι '' (K') := by { simp only [subtype.image_preimage_coe,
+    inter_eq_self_of_subset_left h_KU]},
+  obtain ⟨L', h1_L', h2_L'⟩ := @exists_compact_superset U _ hU.locally_compact_space K'
+    (hι.is_compact_iff_is_compact_image.mpr $ by {simp only [← h_KK', hK]}),
+  use ι '' L',
+  exact
+    ⟨hι.is_compact_iff_is_compact_image.mp h1_L',
+    by {rwa [h_KK', image_subset_iff,
+      (hU.is_open_map_subtype_coe).preimage_interior_eq_interior_preimage hι.continuous,
+      function.injective.preimage_image hι.inj]} ,
+    by {simp only [image_subset_iff, subtype.coe_preimage_self, subset_univ]}⟩,
+end
+
 lemma ultrafilter.le_nhds_Lim [compact_space α] (F : ultrafilter α) :
   ↑F ≤ 𝓝 (@Lim _ _ (F : filter α).nonempty_of_ne_bot F) :=
 begin

--- a/src/topology/subset_properties.lean
+++ b/src/topology/subset_properties.lean
@@ -1033,19 +1033,24 @@ lemma exists_compact_mem_nhds [locally_compact_space α] (x : α) :
 let ⟨K, hKc, hx, H⟩ := exists_compact_subset is_open_univ (mem_univ x)
 in ⟨K, hKc, mem_interior_iff_mem_nhds.1 hx⟩
 
+/-- In a locally compact space, for every containement `K ⊆ U` of a compact set `K` in an open
+  set `U`, there is a compact neighborhood `L` such that `K ⊆ L ⊆ U`: equivalently, there is a
+  compact `L` such that `K ⊆ interior L` and `L ⊆ U`. -/
+lemma exists_compact_between [hα : locally_compact_space α] {K U : set α} (hK : is_compact K)
+  (hU : is_open U) (h_KU : K ⊆ U) : ∃ L, is_compact L ∧ K ⊆ interior L ∧ L ⊆ U :=
+begin
+  choose V hVc hxV hKV using λ x : K, exists_compact_subset hU (h_KU x.2),
+  have : K ⊆ ⋃ x, interior (V x), from λ x hx, mem_Union.2 ⟨⟨x, hx⟩, hxV _⟩,
+  rcases hK.elim_finite_subcover _ (λ x, @is_open_interior α _ (V x)) this with ⟨t, ht⟩,
+  refine ⟨_, t.compact_bUnion (λ x _, hVc x), λ x hx, _, set.Union₂_subset (λ i _, hKV i)⟩,
+  rcases mem_Union₂.1 (ht hx) with ⟨y, hyt, hy⟩,
+  exact interior_mono (subset_bUnion_of_mem hyt) hy,
+end
+
 /-- In a locally compact space, every compact set is contained in the interior of a compact set. -/
 lemma exists_compact_superset [locally_compact_space α] {K : set α} (hK : is_compact K) :
   ∃ K', is_compact K' ∧ K ⊆ interior K' :=
-begin
-  choose U hUc hxU using λ x : K, exists_compact_mem_nhds (x : α),
-  have : K ⊆ ⋃ x, interior (U x),
-    from λ x hx, mem_Union.2 ⟨⟨x, hx⟩, mem_interior_iff_mem_nhds.2 (hxU _)⟩,
-  rcases hK.elim_finite_subcover _ _ this with ⟨t, ht⟩,
-  { refine ⟨_, t.compact_bUnion (λ x _, hUc x), λ x hx, _⟩,
-    rcases mem_Union₂.1 (ht hx) with ⟨y, hyt, hy⟩,
-    exact interior_mono (subset_bUnion_of_mem hyt) hy },
-  { exact λ _, is_open_interior }
-end
+let ⟨L, hLc, hKL, _⟩ := exists_compact_between hK is_open_univ K.subset_univ in ⟨L, hLc, hKL⟩
 
 protected lemma closed_embedding.locally_compact_space [locally_compact_space β] {f : α → β}
   (hf : closed_embedding f) : locally_compact_space α :=
@@ -1077,28 +1082,6 @@ end
 protected lemma is_open.locally_compact_space [locally_compact_space α] {s : set α}
   (hs : is_open s) : locally_compact_space s :=
 hs.open_embedding_subtype_coe.locally_compact_space
-
-/-- In a locally compact space, for every containement `K ⊆ U` of a compact set `K` in an open
-  set `U`, there is a compact neighborhood `L` such that `K ⊆ L ⊆ U`: equivalently, there is a
-  compact `L` such that `K ⊆ interior L` and `L ⊆ U`. -/
-lemma exists_compact_superset' [hα : locally_compact_space α] {K U : set α} (hK : is_compact K)
-  (hU : is_open U) (h_KU : K ⊆ U) : ∃ L, is_compact L ∧ K ⊆ interior L ∧ L ⊆ U :=
-begin
-  let ι : U → α := coe,
-  have hι : embedding ι, exact embedding_subtype_coe,
-  set K' := ι⁻¹' K with K'_def,
-  have h_KK' : K = ι '' (K') := by { simp only [subtype.image_preimage_coe,
-    inter_eq_self_of_subset_left h_KU]},
-  obtain ⟨L', h1_L', h2_L'⟩ := @exists_compact_superset U _ hU.locally_compact_space K'
-    (hι.is_compact_iff_is_compact_image.mpr $ by {simp only [← h_KK', hK]}),
-  use ι '' L',
-  exact
-    ⟨hι.is_compact_iff_is_compact_image.mp h1_L',
-    by {rwa [h_KK', image_subset_iff,
-      (hU.is_open_map_subtype_coe).preimage_interior_eq_interior_preimage hι.continuous,
-      function.injective.preimage_image hι.inj]} ,
-    by {simp only [image_subset_iff, subtype.coe_preimage_self, subset_univ]}⟩,
-end
 
 lemma ultrafilter.le_nhds_Lim [compact_space α] (F : ultrafilter α) :
   ↑F ≤ 𝓝 (@Lim _ _ (F : filter α).nonempty_of_ne_bot F) :=


### PR DESCRIPTION
* Remove the `t2_space` assumption from `exists_compact_between` by generalizing the proof of `exists_compact_superset`, and move it from `topology/separation` to `topology/subset_properties`.
* Use it to prove `continuous_map.continuous_prod` in `topology/continuous_map` stating that for topological spaces `X,Y,Z` with `Y` locally compact, the composition induces a continuous map from `C(X,Y) x C(Y,Z)` to `C(X,Z)` where all function spaces are endowed with the compact-open topology. The (statement and the) proof is taken from Prop. 9 of Chap. X, §3, №. 4 of Bourbaki's *Topologie Générale*.
* Generalize `exists_open_between_and_is_compact_closure` from `t3_space` to `t2_space` using the generalized `exists_compact_between`.

This has been briefly discussed in [this Zulip discussion](https://leanprover.zulipchat.com/#narrow/stream/217875-Is-there-code-for-X.3F/topic/continuity.20of.20continuous.20composition)