### PR TITLE
[Merged by Bors] - feat(algebra/algebra/subalgebra/basic): Swap arguments of `map` and `comap`

### DIFF
--- a/src/algebra/algebra/subalgebra/basic.lean
+++ b/src/algebra/algebra/subalgebra/basic.lean
@@ -317,8 +317,8 @@ lemma map_injective {S₁ S₂ : subalgebra R A} (f : A →ₐ[R] B)
   (hf : function.injective f) (ih : S₁.map f = S₂.map f) : S₁ = S₂ :=
 ext $ set.ext_iff.1 $ set.image_injective.2 hf $ set.ext $ set_like.ext_iff.mp ih
 
-lemma map_injective' {S₁ S₂ : subalgebra R A} (f : A →ₐ[R] B)
-  (hf : function.injective f) : function.injective (λ S, map S f) :=
+lemma map_injective' (f : A →ₐ[R] B) (hf : function.injective f) :
+  function.injective (λ S, map S f) :=
 λ S₁ S₂, map_injective f hf
 
 @[simp] lemma map_id (S : subalgebra R A) : S.map (alg_hom.id R A) = S :=

--- a/src/algebra/algebra/subalgebra/basic.lean
+++ b/src/algebra/algebra/subalgebra/basic.lean
@@ -350,7 +350,7 @@ theorem map_le {S : subalgebra R A} {f : A →ₐ[R] B} {U : subalgebra R B} :
   map f S ≤ U ↔ S ≤ comap U f :=
 set.image_subset_iff
 
-lemma gc_map_comap (f : A →ₐ[R] B) : galois_connection (λ S, map f S) (λ S, comap S f) :=
+lemma gc_map_comap (f : A →ₐ[R] B) : galois_connection (map f) (λ S, comap S f) :=
 λ S U, map_le
 
 @[simp] lemma mem_comap (S : subalgebra R B) (f : A →ₐ[R] B) (x : A) :

--- a/src/algebra/algebra/subalgebra/basic.lean
+++ b/src/algebra/algebra/subalgebra/basic.lean
@@ -341,16 +341,16 @@ set_like.coe_injective rfl
 rfl
 
 /-- Preimage of a subalgebra under an algebra homomorphism. -/
-def comap (S : subalgebra R B) (f : A →ₐ[R] B) : subalgebra R A :=
+def comap (f : A →ₐ[R] B) (S : subalgebra R B) : subalgebra R A :=
 { algebra_map_mem' := λ r, show f (algebra_map R A r) ∈ S,
     from (f.commutes r).symm ▸ S.algebra_map_mem r,
   .. S.to_subsemiring.comap (f : A →+* B) }
 
 theorem map_le {S : subalgebra R A} {f : A →ₐ[R] B} {U : subalgebra R B} :
-  map f S ≤ U ↔ S ≤ comap U f :=
+  map f S ≤ U ↔ S ≤ comap f U :=
 set.image_subset_iff
 
-lemma gc_map_comap (f : A →ₐ[R] B) : galois_connection (map f) (λ S, comap S f) :=
+lemma gc_map_comap (f : A →ₐ[R] B) : galois_connection (map f) (comap f) :=
 λ S U, map_le
 
 @[simp] lemma mem_comap (S : subalgebra R B) (f : A →ₐ[R] B) (x : A) :
@@ -655,7 +655,7 @@ set_like.coe_injective set.image_univ
 set_like.coe_injective $
   by simp only [← set.range_comp, (∘), algebra.coe_bot, subalgebra.coe_map, f.commutes]
 
-@[simp] theorem comap_top (f : A →ₐ[R] B) : subalgebra.comap (⊤ : subalgebra R B) f = ⊤ :=
+@[simp] theorem comap_top (f : A →ₐ[R] B) : (⊤ : subalgebra R B).comap f = ⊤ :=
 eq_top_iff.2 $ λ x, mem_top
 
 /-- `alg_hom` to `⊤ : subalgebra R A`. -/

--- a/src/algebra/algebra/subalgebra/basic.lean
+++ b/src/algebra/algebra/subalgebra/basic.lean
@@ -317,6 +317,10 @@ lemma map_injective {S₁ S₂ : subalgebra R A} (f : A →ₐ[R] B)
   (hf : function.injective f) (ih : S₁.map f = S₂.map f) : S₁ = S₂ :=
 ext $ set.ext_iff.1 $ set.image_injective.2 hf $ set.ext $ set_like.ext_iff.mp ih
 
+lemma map_injective' {S₁ S₂ : subalgebra R A} (f : A →ₐ[R] B)
+  (hf : function.injective f) : function.injective (λ S, map S f) :=
+λ S₁ S₂, map_injective f hf
+
 @[simp] lemma map_id (S : subalgebra R A) : S.map (alg_hom.id R A) = S :=
 set_like.coe_injective $ set.image_id _
 

--- a/src/algebra/algebra/subalgebra/basic.lean
+++ b/src/algebra/algebra/subalgebra/basic.lean
@@ -305,7 +305,7 @@ def to_submodule_equiv (S : subalgebra R A) : S.to_submodule ≃ₗ[R] S :=
 linear_equiv.of_eq _ _ rfl
 
 /-- Transport a subalgebra via an algebra homomorphism. -/
-def map (S : subalgebra R A) (f : A →ₐ[R] B) : subalgebra R B :=
+def map (f : A →ₐ[R] B) (S : subalgebra R A) : subalgebra R B :=
 { algebra_map_mem' := λ r, f.commutes r ▸ set.mem_image_of_mem _ (S.algebra_map_mem r),
   .. S.to_subsemiring.map (f : A →+* B) }
 
@@ -313,13 +313,9 @@ lemma map_mono {S₁ S₂ : subalgebra R A} {f : A →ₐ[R] B} :
   S₁ ≤ S₂ → S₁.map f ≤ S₂.map f :=
 set.image_subset f
 
-lemma map_injective {S₁ S₂ : subalgebra R A} (f : A →ₐ[R] B)
-  (hf : function.injective f) (ih : S₁.map f = S₂.map f) : S₁ = S₂ :=
-ext $ set.ext_iff.1 $ set.image_injective.2 hf $ set.ext $ set_like.ext_iff.mp ih
-
-lemma map_injective' (f : A →ₐ[R] B) (hf : function.injective f) :
-  function.injective (λ S, map S f) :=
-λ S₁ S₂, map_injective f hf
+lemma map_injective {f : A →ₐ[R] B} (hf : function.injective f) :
+  function.injective (map f) :=
+λ S₁ S₂ ih, ext $ set.ext_iff.1 $ set.image_injective.2 hf $ set.ext $ set_like.ext_iff.mp ih
 
 @[simp] lemma map_id (S : subalgebra R A) : S.map (alg_hom.id R A) = S :=
 set_like.coe_injective $ set.image_id _
@@ -329,7 +325,7 @@ lemma map_map (S : subalgebra R A) (g : B →ₐ[R] C) (f : A →ₐ[R] B) :
 set_like.coe_injective $ set.image_image _ _ _
 
 lemma mem_map {S : subalgebra R A} {f : A →ₐ[R] B} {y : B} :
-  y ∈ map S f ↔ ∃ x ∈ S, f x = y :=
+  y ∈ map f S ↔ ∃ x ∈ S, f x = y :=
 subsemiring.mem_map
 
 lemma map_to_submodule {S : subalgebra R A} {f : A →ₐ[R] B} :
@@ -351,10 +347,10 @@ def comap (S : subalgebra R B) (f : A →ₐ[R] B) : subalgebra R A :=
   .. S.to_subsemiring.comap (f : A →+* B) }
 
 theorem map_le {S : subalgebra R A} {f : A →ₐ[R] B} {U : subalgebra R B} :
-  map S f ≤ U ↔ S ≤ comap U f :=
+  map f S ≤ U ↔ S ≤ comap U f :=
 set.image_subset_iff
 
-lemma gc_map_comap (f : A →ₐ[R] B) : galois_connection (λ S, map S f) (λ S, comap S f) :=
+lemma gc_map_comap (f : A →ₐ[R] B) : galois_connection (λ S, map f S) (λ S, comap S f) :=
 λ S U, map_le
 
 @[simp] lemma mem_comap (S : subalgebra R B) (f : A →ₐ[R] B) (x : A) :
@@ -652,10 +648,10 @@ algebra.eq_top_iff
 @[simp] theorem range_id : (alg_hom.id R A).range = ⊤ :=
 set_like.coe_injective set.range_id
 
-@[simp] theorem map_top (f : A →ₐ[R] B) : subalgebra.map (⊤ : subalgebra R A) f = f.range :=
+@[simp] theorem map_top (f : A →ₐ[R] B) : (⊤ : subalgebra R A).map f = f.range :=
 set_like.coe_injective set.image_univ
 
-@[simp] theorem map_bot (f : A →ₐ[R] B) : subalgebra.map (⊥ : subalgebra R A) f = ⊥ :=
+@[simp] theorem map_bot (f : A →ₐ[R] B) : (⊥ : subalgebra R A).map f = ⊥ :=
 set_like.coe_injective $
   by simp only [← set.range_comp, (∘), algebra.coe_bot, subalgebra.coe_map, f.commutes]
 

--- a/src/field_theory/intermediate_field.lean
+++ b/src/field_theory/intermediate_field.lean
@@ -268,7 +268,7 @@ variables {L' : Type*} [field L'] [algebra K L']
 
 /-- If `f : L →+* L'` fixes `K`, `S.map f` is the intermediate field between `L'` and `K`
 such that `x ∈ S ↔ f x ∈ S.map f`. -/
-def map (f : L →ₐ[K] L') : intermediate_field K L' :=
+def map (f : L →ₐ[K] L') (S : intermediate_field K L) : intermediate_field K L' :=
 { inv_mem' := by { rintros _ ⟨x, hx, rfl⟩, exact ⟨x⁻¹, S.inv_mem hx, f.map_inv x⟩ },
   neg_mem' := λ x hx, (S.to_subalgebra.map f).neg_mem hx,
   .. S.to_subalgebra.map f}
@@ -378,7 +378,7 @@ section tower
 
 /-- Lift an intermediate_field of an intermediate_field -/
 def lift {F : intermediate_field K L} (E : intermediate_field K F) : intermediate_field K L :=
-map E (val F)
+E.map (val F)
 
 instance has_lift {F : intermediate_field K L} :
   has_lift_t (intermediate_field K F) (intermediate_field K L) := ⟨lift⟩

--- a/src/ring_theory/adjoin/fg.lean
+++ b/src/ring_theory/adjoin/fg.lean
@@ -126,7 +126,7 @@ end
 
 lemma fg_of_fg_map (S : subalgebra R A) (f : A →ₐ[R] B) (hf : function.injective f)
   (hs : (S.map f).fg) : S.fg :=
-let ⟨s, hs⟩ := hs in ⟨s.preimage f $ λ _ _ _ _ h, hf h, map_injective f hf $
+let ⟨s, hs⟩ := hs in ⟨s.preimage f $ λ _ _ _ _ h, hf h, map_injective hf $
 by { rw [← algebra.adjoin_image, finset.coe_preimage, set.image_preimage_eq_of_subset, hs],
   rw [← alg_hom.coe_range, ← algebra.adjoin_le_iff, hs, ← algebra.map_top], exact map_mono le_top }⟩
 

--- a/src/ring_theory/algebra_tower.lean
+++ b/src/ring_theory/algebra_tower.lean
@@ -68,8 +68,7 @@ namespace algebra
 theorem adjoin_algebra_map (R : Type u) (S : Type v) (A : Type w)
   [comm_semiring R] [comm_semiring S] [semiring A] [algebra R S] [algebra S A] [algebra R A]
   [is_scalar_tower R S A] (s : set S) :
-  adjoin R (algebra_map S A '' s) =
-    subalgebra.map (adjoin R s) (is_scalar_tower.to_alg_hom R S A) :=
+  adjoin R (algebra_map S A '' s) = (adjoin R s).map (is_scalar_tower.to_alg_hom R S A) :=
 le_antisymm (adjoin_le $ set.image_subset_iff.2 $ λ y hy, ⟨y, subset_adjoin hy, rfl⟩)
   (subalgebra.map_le.2 $ adjoin_le $ λ y hy, subset_adjoin ⟨y, hy, rfl⟩)
 


### PR DESCRIPTION
As suggested by @eric-wieser, I swapped the arguments of `subalgebra.map` and `subalgebra.comap`. I also updated `subalgebra.map_injective` to use `function.injective` and to have `f` implicit. This is done to make the `subalgebra` API match the `subgroup`, `submodule`, etc... API.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
