### PR TITLE
[Merged by Bors] - fix(linear_algebra/prod): add missing `of_dual`s in lemma statements

### DIFF
--- a/src/linear_algebra/prod.lean
+++ b/src/linear_algebra/prod.lean
@@ -686,7 +686,7 @@ Give an injective map `f : M × N →ₗ[R] M` we can find a nested sequence of 
 all isomorphic to `M`.
 -/
 def tunnel (f : M × N →ₗ[R] M) (i : injective f) : ℕ →o (submodule R M)ᵒᵈ :=
-⟨λ n, (tunnel' f i n).1, monotone_nat_of_le_succ (λ n, begin
+⟨λ n, order_dual.to_dual (tunnel' f i n).1, monotone_nat_of_le_succ (λ n, begin
     dsimp [tunnel', tunnel_aux],
     rw [submodule.map_comp, submodule.map_comp],
     apply submodule.map_subtype_le,
@@ -705,7 +705,7 @@ def tailing_linear_equiv (f : M × N →ₗ[R] M) (i : injective f) (n : ℕ) : 
   (tunnel_aux_injective f i (tunnel' f i n))).symm.trans (submodule.snd_equiv R M N)
 
 lemma tailing_le_tunnel (f : M × N →ₗ[R] M) (i : injective f) (n : ℕ) :
-  tailing f i n ≤ tunnel f i n :=
+  tailing f i n ≤ (tunnel f i n).of_dual :=
 begin
   dsimp [tailing, tunnel_aux],
   rw [submodule.map_comp, submodule.map_comp],
@@ -713,7 +713,7 @@ begin
 end
 
 lemma tailing_disjoint_tunnel_succ (f : M × N →ₗ[R] M) (i : injective f) (n : ℕ) :
-  disjoint (tailing f i n) (tunnel f i (n+1)) :=
+  disjoint (tailing f i n) (tunnel f i (n+1)).of_dual :=
 begin
   rw disjoint_iff,
   dsimp [tailing, tunnel, tunnel'],
@@ -723,7 +723,7 @@ begin
 end
 
 lemma tailing_sup_tunnel_succ_le_tunnel (f : M × N →ₗ[R] M) (i : injective f) (n : ℕ) :
-  tailing f i n ⊔ tunnel f i (n+1) ≤ tunnel f i n :=
+  tailing f i n ⊔ (tunnel f i (n+1)).of_dual ≤ (tunnel f i n).of_dual :=
 begin
   dsimp [tailing, tunnel, tunnel', tunnel_aux],
   rw [←submodule.map_sup, sup_comm, submodule.fst_sup_snd, submodule.map_comp, submodule.map_comp],
@@ -743,7 +743,7 @@ by simp [tailings]
 by simp [tailings]
 
 lemma tailings_disjoint_tunnel (f : M × N →ₗ[R] M) (i : injective f) (n : ℕ) :
-  disjoint (tailings f i n) (tunnel f i (n+1)) :=
+  disjoint (tailings f i n) (tunnel f i (n+1)).of_dual :=
 begin
   induction n with n ih,
   { simp only [tailings_zero],


### PR DESCRIPTION
Without these the lemmas contain nonsense statements of the form `(x : α) ≤ (y : αᵒᵈ)`.



---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
