### PR TITLE
[Merged by Bors] - feat(combinatorics/simple_graph/connectivity): walk.copy function to relax dependent type issues

### DIFF
--- a/src/combinatorics/simple_graph/connectivity.lean
+++ b/src/combinatorics/simple_graph/connectivity.lean
@@ -104,8 +104,8 @@ occur within the "copy context." -/
 protected def copy {u v u' v'} (p : G.walk u v) (hu : u = u') (hv : v = v') : G.walk u' v' :=
 eq.rec (eq.rec p hv) hu
 
-@[simp] lemma copy_rfl_rfl {u v} (p : G.walk u v) (hu : u = u) (hv : v = v) :
-  p.copy hu hv = p := rfl
+@[simp] lemma copy_rfl_rfl {u v} (p : G.walk u v) :
+  p.copy rfl rfl = p := rfl
 
 @[simp] lemma copy_copy {u v u' v' u'' v''} (p : G.walk u v)
   (hu : u = u') (hv : v = v') (hu' : u' = u'') (hv' : v' = v'') :

--- a/src/combinatorics/simple_graph/connectivity.lean
+++ b/src/combinatorics/simple_graph/connectivity.lean
@@ -112,15 +112,15 @@ eq.rec (eq.rec p hv) hu
   (p.copy hu hv).copy hu' hv' = p.copy (hu.trans hu') (hv.trans hv') :=
 by { subst_vars, refl }
 
-@[simp] lemma walk.copy_nil {u u'} (hu : u = u') : (walk.nil : G.walk u u).copy hu hu = walk.nil :=
+@[simp] lemma copy_nil {u u'} (hu : u = u') : (walk.nil : G.walk u u).copy hu hu = walk.nil :=
 by { subst_vars, refl }
 
-lemma walk.copy_cons {u v w u' w'} (h : G.adj u v) (p : G.walk v w) (hu : u = u') (hw : w = w') :
+lemma copy_cons {u v w u' w'} (h : G.adj u v) (p : G.walk v w) (hu : u = u') (hw : w = w') :
   (walk.cons h p).copy hu hw = walk.cons (by rwa ← hu) (p.copy rfl hw) :=
 by { subst_vars, refl }
 
 @[simp]
-lemma walk.cons_copy {u v w v' w'} (h : G.adj u v) (p : G.walk v' w') (hv : v' = v) (hw : w' = w) :
+lemma cons_copy {u v w v' w'} (h : G.adj u v) (p : G.walk v' w') (hv : v' = v) (hw : w' = w) :
   walk.cons h (p.copy hv hw) = (walk.cons (by rwa hv) p).copy rfl hw :=
 by { subst_vars, refl }
 


### PR DESCRIPTION
Walks in a graph present a special challenge since the endpoints of a walk appear as type indices, leading to a constant struggle with dependent types and strict definitional equality. This commit introduces a `walk.copy` function to be able to change the definitions of a walk's endpoints. There are also many simp lemmas to push the copy function out of most expressions.

An example of a lemma that `copy` lets us express:
```lean
lemma map_eq_of_eq {f : G →g G'} (f' : G →g G') (h : f = f') :
  p.map f = (p.map f').copy (by rw h) (by rw h)
```

Thanks to @**Junyan Xu|224323** for the idea.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
