### PR TITLE
refactor(data/polynomial/*): redefine `polynomial` as a abbreviation

### DIFF
--- a/src/data/polynomial/algebra_map.lean
+++ b/src/data/polynomial/algebra_map.lean
@@ -27,31 +27,9 @@ variables [comm_semiring R] {p q r : R[X]}
 
 variables [semiring A] [algebra R A]
 
-/-- Note that this instance also provides `algebra R R[X]`. -/
-instance algebra_of_algebra : algebra R (polynomial A) :=
-{ smul_def' := λ r p, to_finsupp_injective $ begin
-    dsimp only [ring_hom.to_fun_eq_coe, ring_hom.comp_apply],
-    rw [to_finsupp_smul, to_finsupp_mul, to_finsupp_C],
-    exact algebra.smul_def' _ _,
-  end,
-  commutes' := λ r p, to_finsupp_injective $ begin
-    dsimp only [ring_hom.to_fun_eq_coe, ring_hom.comp_apply],
-    simp_rw [to_finsupp_mul, to_finsupp_C],
-    convert algebra.commutes' r p.to_finsupp,
-  end,
-  to_ring_hom := C.comp (algebra_map R A) }
-
 lemma algebra_map_apply (r : R) :
   algebra_map R (polynomial A) r = C (algebra_map R A r) :=
 rfl
-
-@[simp] lemma to_finsupp_algebra_map (r : R) :
-  (algebra_map R (polynomial A) r).to_finsupp = algebra_map R _ r :=
-show to_finsupp (C (algebra_map _ _ r)) = _, by { rw to_finsupp_C, refl }
-
-lemma of_finsupp_algebra_map (r : R) :
-  (⟨algebra_map R _ r⟩ : A[X]) = algebra_map R (polynomial A) r :=
-to_finsupp_injective (to_finsupp_algebra_map _).symm
 
 /--
 When we have `[comm_semiring R]`, the function `C` is the same as `algebra_map R R[X]`.
@@ -75,21 +53,6 @@ variables {R}
   (h₂ : f X = g X) : f = g :=
 alg_hom.coe_ring_hom_injective (polynomial.ring_hom_ext'
   (congr_arg alg_hom.to_ring_hom h₁) h₂)
-
-variable (R)
-
-/-- Algebra isomorphism between `polynomial R` and `add_monoid_algebra R ℕ`. This is just an
-implementation detail, but it can be useful to transfer results from `finsupp` to polynomials. -/
-@[simps]
-def to_finsupp_iso_alg : R[X] ≃ₐ[R] add_monoid_algebra R ℕ :=
-{ commutes' := λ r,
-  begin
-    dsimp,
-    exact to_finsupp_algebra_map _,
-  end,
-  ..to_finsupp_iso R }
-
-variable {R}
 
 instance [nontrivial A] : nontrivial (subalgebra R (polynomial A)) :=
 ⟨⟨⊥, ⊤, begin
@@ -122,7 +85,7 @@ begin
   conv_rhs { rw [←polynomial.sum_C_mul_X_eq p], },
   dsimp [eval₂, sum],
   simp only [f.map_sum, f.map_mul, f.map_pow, ring_hom.eq_int_cast, ring_hom.map_int_cast],
-  simp [polynomial.C_eq_algebra_map],
+  simp [polynomial.C_eq_algebra_map, - add_monoid_algebra.coe_algebra_map],
 end
 
 -- these used to be about `algebra_map ℤ R`, but now the simp-normal form is `int.cast_ring_hom R`.

--- a/src/data/polynomial/basic.lean
+++ b/src/data/polynomial/basic.lean
@@ -32,7 +32,7 @@ the polynomials. For instance,
 
 Polynomials are defined using `add_monoid_algebra R ℕ`, where `R` is a semiring.
 The variable `X` commutes with every polynomial `p`: lemma `X_mul` proves the identity
-`X * p = `p * X`.  The relationship to `add_monoid_algebra R ℕ` is through a structure
+`X * p` = `p * X`.  The relationship to `add_monoid_algebra R ℕ` is through a structure
 to make polynomials irreducible from the point of view of the kernel. Most operations
 are irreducible since Lean can not compute anyway with `add_monoid_algebra`. There are two
 exceptions that we make semireducible:
@@ -53,8 +53,7 @@ noncomputable theory
 
 Polynomials should be seen as (semi-)rings with the additional constructor `X`.
 The embedding from `R` is called `C`. -/
-structure polynomial (R : Type*) [semiring R] := of_finsupp ::
-(to_finsupp : add_monoid_algebra R ℕ)
+abbreviation polynomial (R : Type*) [semiring R] := add_monoid_algebra R ℕ
 
 localized "notation R`[X]`:9000 := polynomial R" in polynomial
 open finsupp add_monoid_algebra
@@ -67,213 +66,17 @@ variables {R : Type u} {a b : R} {m n : ℕ}
 section semiring
 variables [semiring R] {p q : R[X]}
 
-lemma forall_iff_forall_finsupp (P : R[X] → Prop) :
-  (∀ p, P p) ↔ ∀ (q : add_monoid_algebra R ℕ), P ⟨q⟩ :=
-⟨λ h q, h ⟨q⟩, λ h ⟨p⟩, h p⟩
-
-lemma exists_iff_exists_finsupp (P : R[X] → Prop) :
-  (∃ p, P p) ↔ ∃ (q : add_monoid_algebra R ℕ), P ⟨q⟩ :=
-⟨λ ⟨⟨p⟩, hp⟩, ⟨p, hp⟩, λ ⟨q, hq⟩, ⟨⟨q⟩, hq⟩ ⟩
-
-/-! ### Conversions to and from `add_monoid_algebra`
-
-Since `polynomial R` is not defeq to `add_monoid_algebra R ℕ`, but instead is a structure wrapping
-it, we have to copy across all the arithmetic operators manually, along with the lemmas about how
-they unfold around `polynomial.of_finsupp` and `polynomial.to_finsupp`.
--/
-section add_monoid_algebra
-
-/-- The function version of `monomial`. Use `monomial` instead of this one. -/
-@[irreducible] def monomial_fun (n : ℕ) (a : R) : R[X] := ⟨finsupp.single n a⟩
-@[irreducible] private def add : R[X] → R[X] → R[X]
-| ⟨a⟩ ⟨b⟩ := ⟨a + b⟩
-@[irreducible] private def neg {R : Type u} [ring R] : R[X] → R[X]
-| ⟨a⟩ := ⟨-a⟩
-@[irreducible] private def mul : R[X] → R[X] → R[X]
-| ⟨a⟩ ⟨b⟩ := ⟨a * b⟩
-
-instance : has_zero R[X] := ⟨⟨0⟩⟩
-instance : has_one R[X] := ⟨monomial_fun 0 (1 : R)⟩
-instance : has_add R[X] := ⟨add⟩
-instance {R : Type u} [ring R] : has_neg R[X] := ⟨neg⟩
-instance {R : Type u} [ring R] : has_sub R[X] := ⟨λ a b, a + -b⟩
-instance : has_mul R[X] := ⟨mul⟩
-instance {S : Type*} [monoid S] [distrib_mul_action S R] : has_smul S R[X] :=
-⟨λ r p, ⟨r • p.to_finsupp⟩⟩
-@[priority 1]  -- to avoid a bug in the `ring` tactic
-instance has_pow : has_pow R[X] ℕ := { pow := λ p n, npow_rec n p }
-
-@[simp] lemma of_finsupp_zero : (⟨0⟩ : R[X]) = 0 :=
-rfl
-
-@[simp] lemma of_finsupp_one : (⟨1⟩ : R[X]) = 1 :=
-begin
-  change (⟨1⟩ : R[X]) = monomial_fun 0 (1 : R),
-  rw [monomial_fun],
-  refl
-end
-
-@[simp] lemma of_finsupp_add {a b} : (⟨a + b⟩ : R[X]) = ⟨a⟩ + ⟨b⟩ := show _ = add _ _, by rw add
-@[simp] lemma of_finsupp_neg {R : Type u} [ring R] {a} : (⟨-a⟩ : R[X]) = -⟨a⟩ :=
-show _ = neg _, by rw neg
-@[simp] lemma of_finsupp_sub {R : Type u} [ring R] {a b} : (⟨a - b⟩ : R[X]) = ⟨a⟩ - ⟨b⟩ :=
-by { rw [sub_eq_add_neg, of_finsupp_add, of_finsupp_neg], refl }
-@[simp] lemma of_finsupp_mul (a b) : (⟨a * b⟩ : R[X]) = ⟨a⟩ * ⟨b⟩ := show _ = mul _ _, by rw mul
-@[simp] lemma of_finsupp_smul {S : Type*} [monoid S] [distrib_mul_action S R] (a : S) (b) :
-  (⟨a • b⟩ : R[X]) = (a • ⟨b⟩ : R[X]) := rfl
-@[simp] lemma of_finsupp_pow (a) (n : ℕ) : (⟨a ^ n⟩ : R[X]) = ⟨a⟩ ^ n :=
-begin
-  change _ = npow_rec n _,
-  induction n,
-  { simp [npow_rec], } ,
-  { simp [npow_rec, n_ih, pow_succ] }
-end
-
-
-@[simp] lemma to_finsupp_zero : (0 : R[X]).to_finsupp = 0 :=
-rfl
-
-@[simp] lemma to_finsupp_one : (1 : R[X]).to_finsupp = 1 :=
-begin
-  change to_finsupp (monomial_fun _ _) = _,
-  rw monomial_fun,
-  refl,
-end
-
-@[simp] lemma to_finsupp_add (a b : R[X]) : (a + b).to_finsupp = a.to_finsupp + b.to_finsupp :=
-by { cases a, cases b, rw ←of_finsupp_add }
-@[simp] lemma to_finsupp_neg {R : Type u} [ring R] (a : R[X]) : (-a).to_finsupp = -a.to_finsupp :=
-by { cases a, rw ←of_finsupp_neg }
-@[simp] lemma to_finsupp_sub {R : Type u} [ring R] (a b : R[X]) :
-  (a - b).to_finsupp = a.to_finsupp - b.to_finsupp :=
-by { rw [sub_eq_add_neg, ←to_finsupp_neg, ←to_finsupp_add], refl }
-@[simp] lemma to_finsupp_mul (a b : R[X]) : (a * b).to_finsupp = a.to_finsupp * b.to_finsupp :=
-by { cases a, cases b, rw ←of_finsupp_mul }
-@[simp] lemma to_finsupp_smul {S : Type*} [monoid S] [distrib_mul_action S R] (a : S) (b : R[X]) :
-  (a • b).to_finsupp = a • b.to_finsupp := rfl
-@[simp] lemma to_finsupp_pow (a : R[X]) (n : ℕ) : (a ^ n).to_finsupp = a.to_finsupp ^ n :=
-by { cases a, rw ←of_finsupp_pow }
-
 lemma _root_.is_smul_regular.polynomial {S : Type*} [monoid S] [distrib_mul_action S R] {a : S}
   (ha : is_smul_regular R a) : is_smul_regular R[X] a
-| ⟨x⟩ ⟨y⟩ h := congr_arg _ $ ha.finsupp (polynomial.of_finsupp.inj h)
-
-lemma to_finsupp_injective : function.injective (to_finsupp : R[X] → add_monoid_algebra _ _) :=
-λ ⟨x⟩ ⟨y⟩, congr_arg _
-
-@[simp] lemma to_finsupp_inj {a b : R[X]} : a.to_finsupp = b.to_finsupp ↔ a = b :=
-to_finsupp_injective.eq_iff
-
-@[simp] lemma to_finsupp_eq_zero {a : R[X]} : a.to_finsupp = 0 ↔ a = 0 :=
-by rw [←to_finsupp_zero, to_finsupp_inj]
-
-@[simp] lemma to_finsupp_eq_one {a : R[X]} : a.to_finsupp = 1 ↔ a = 1 :=
-by rw [←to_finsupp_one, to_finsupp_inj]
-
-/-- A more convenient spelling of `polynomial.of_finsupp.inj_eq` in terms of `iff`. -/
-lemma of_finsupp_inj {a b} : (⟨a⟩ : R[X]) = ⟨b⟩ ↔ a = b :=
-iff_of_eq of_finsupp.inj_eq
-
-@[simp] lemma of_finsupp_eq_zero {a} : (⟨a⟩ : R[X]) = 0 ↔ a = 0 :=
-by rw [←of_finsupp_zero, of_finsupp_inj]
-
-@[simp] lemma of_finsupp_eq_one {a} : (⟨a⟩ : R[X]) = 1 ↔ a = 1 :=
-by rw [←of_finsupp_one, of_finsupp_inj]
-
-instance : inhabited R[X] := ⟨0⟩
-
-instance : has_nat_cast R[X] := ⟨λ n, polynomial.of_finsupp n⟩
-
-instance : semiring R[X] :=
-function.injective.semiring to_finsupp to_finsupp_injective
-  to_finsupp_zero to_finsupp_one to_finsupp_add to_finsupp_mul
-  (λ _ _, to_finsupp_smul _ _) to_finsupp_pow (λ _, rfl)
-
-instance {S} [monoid S] [distrib_mul_action S R] : distrib_mul_action S R[X] :=
-function.injective.distrib_mul_action
-  ⟨to_finsupp, to_finsupp_zero, to_finsupp_add⟩ to_finsupp_injective to_finsupp_smul
-
-instance {S} [monoid S] [distrib_mul_action S R] [has_faithful_smul S R] :
-  has_faithful_smul S R[X] :=
-{ eq_of_smul_eq_smul := λ s₁ s₂ h, eq_of_smul_eq_smul $ λ a : ℕ →₀ R, congr_arg to_finsupp (h ⟨a⟩) }
-
-instance {S} [semiring S] [module S R] : module S R[X] :=
-function.injective.module _
-  ⟨to_finsupp, to_finsupp_zero, to_finsupp_add⟩ to_finsupp_injective to_finsupp_smul
-
-instance {S₁ S₂} [monoid S₁] [monoid S₂] [distrib_mul_action S₁ R] [distrib_mul_action S₂ R]
-  [smul_comm_class S₁ S₂ R] : smul_comm_class S₁ S₂ R[X] :=
-⟨by { rintros _ _ ⟨⟩, simp_rw [←of_finsupp_smul, smul_comm] }⟩
-
-instance {S₁ S₂} [has_smul S₁ S₂] [monoid S₁] [monoid S₂] [distrib_mul_action S₁ R]
-  [distrib_mul_action S₂ R] [is_scalar_tower S₁ S₂ R] : is_scalar_tower S₁ S₂ R[X] :=
-⟨by { rintros _ _ ⟨⟩, simp_rw [←of_finsupp_smul, smul_assoc] }⟩
-
-instance {S} [monoid S] [distrib_mul_action S R] [distrib_mul_action Sᵐᵒᵖ R]
-  [is_central_scalar S R] : is_central_scalar S R[X] :=
-⟨by { rintros _ ⟨⟩, simp_rw [←of_finsupp_smul, op_smul_eq_smul] }⟩
-
-instance [subsingleton R] : unique R[X] :=
-{ uniq := by { rintros ⟨x⟩, refine congr_arg of_finsupp _, simp },
-.. polynomial.inhabited }
-
-variable (R)
-
-/-- Ring isomorphism between `R[X]` and `add_monoid_algebra R ℕ`. This is just an
-implementation detail, but it can be useful to transfer results from `finsupp` to polynomials. -/
-@[simps apply symm_apply]
-def to_finsupp_iso : R[X] ≃+* add_monoid_algebra R ℕ :=
-{ to_fun := to_finsupp,
-  inv_fun := of_finsupp,
-  left_inv := λ ⟨p⟩, rfl,
-  right_inv := λ p, rfl,
-  map_mul' := to_finsupp_mul,
-  map_add' := to_finsupp_add }
-
-end add_monoid_algebra
-
-variable {R}
-
-lemma of_finsupp_sum {ι : Type*} (s : finset ι) (f : ι → add_monoid_algebra R ℕ) :
-  (⟨∑ i in s, f i⟩ : R[X]) = ∑ i in s, ⟨f i⟩ :=
-map_sum (to_finsupp_iso R).symm f s
-
-lemma to_finsupp_sum {ι : Type*} (s : finset ι) (f : ι → R[X]) :
-  (∑ i in s, f i : R[X]).to_finsupp = ∑ i in s, (f i).to_finsupp :=
-map_sum (to_finsupp_iso R) f s
-
-/--
-The set of all `n` such that `X^n` has a non-zero coefficient.
--/
-@[simp]
-def support : R[X] → finset ℕ
-| ⟨p⟩ := p.support
-
-@[simp] lemma support_of_finsupp (p) : support (⟨p⟩ : R[X]) = p.support :=
-by rw support
-
-@[simp] lemma support_zero : (0 : R[X]).support = ∅ :=
-rfl
-
-@[simp] lemma support_eq_empty : p.support = ∅ ↔ p = 0 :=
-by { rcases p, simp [support] }
-
-lemma card_support_eq_zero : p.support.card = 0 ↔ p = 0 :=
-by simp
+| x y h := ha.finsupp h
 
 /-- `monomial s a` is the monomial `a * X^s` -/
 def monomial (n : ℕ) : R →ₗ[R] R[X] :=
-{ to_fun := monomial_fun n,
-  map_add' := by simp [monomial_fun],
-  map_smul' := by simp [monomial_fun, ←of_finsupp_smul] }
+{ to_fun := single n,
+  map_add' := by simp,
+  map_smul' := by simp }
 
-@[simp] lemma to_finsupp_monomial (n : ℕ) (r : R) :
-  (monomial n r).to_finsupp = finsupp.single n r :=
-by simp [monomial, monomial_fun]
-
-@[simp] lemma of_finsupp_single (n : ℕ) (r : R) :
-  (⟨finsupp.single n r⟩ : R[X]) = monomial n r :=
-by simp [monomial, monomial_fun]
+lemma monomial_def (n : ℕ) (r : R) : monomial n r = single n r := rfl
 
 @[simp]
 lemma monomial_zero_right (n : ℕ) :
@@ -286,12 +89,11 @@ lemma monomial_zero_one : monomial 0 (1 : R) = 1 := rfl
 -- TODO: can't we just delete this one?
 lemma monomial_add (n : ℕ) (r s : R) :
   monomial n (r + s) = monomial n r + monomial n s :=
-(monomial n).map_add _ _
+map_add _ _ _
 
 lemma monomial_mul_monomial (n m : ℕ) (r s : R) :
   monomial n r * monomial m s = monomial (n + m) (r * s) :=
-to_finsupp_injective $
-  by simp only [to_finsupp_monomial, to_finsupp_mul, add_monoid_algebra.single_mul_single]
+by simp only [monomial_def, single_mul_single]
 
 @[simp]
 lemma monomial_pow (n : ℕ) (r : R) (k : ℕ) :
@@ -299,46 +101,32 @@ lemma monomial_pow (n : ℕ) (r : R) (k : ℕ) :
 begin
   induction k with k ih,
   { simp [pow_zero, monomial_zero_one], },
-  { simp [pow_succ, ih, monomial_mul_monomial, nat.succ_eq_add_one, mul_add, add_comm] },
+  { rw [pow_succ, ih, monomial_mul_monomial, nat.mul_succ, pow_succ, add_comm], },
 end
 
 lemma smul_monomial {S} [monoid S] [distrib_mul_action S R] (a : S) (n : ℕ) (b : R) :
   a • monomial n b = monomial n (a • b) :=
-to_finsupp_injective $ by simp
+smul_single a n b
 
 lemma monomial_injective (n : ℕ) :
   function.injective (monomial n : R → R[X]) :=
-begin
-  convert (to_finsupp_iso R).symm.injective.comp (single_injective n),
-  ext,
-  simp
-end
+single_injective n
 
 @[simp] lemma monomial_eq_zero_iff (t : R) (n : ℕ) :
   monomial n t = 0 ↔ t = 0 :=
 linear_map.map_eq_zero_iff _ (polynomial.monomial_injective n)
 
 lemma support_add : (p + q).support ⊆ p.support ∪ q.support :=
-begin
-  rcases p, rcases q,
-  simp only [←of_finsupp_add, support],
-  exact support_add
-end
+finsupp.support_add
 
 /--
 `C a` is the constant polynomial `a`.
 `C` is provided as a ring homomorphism.
 -/
 def C : R →+* R[X] :=
-{ map_one' := by simp [monomial_zero_one],
-  map_mul' := by simp [monomial_mul_monomial],
-  map_zero' := by simp,
-  .. monomial 0 }
+single_zero_ring_hom
 
 @[simp] lemma monomial_zero_left (a : R) : monomial 0 a = C a := rfl
-
-@[simp] lemma to_finsupp_C (a : R) : (C a).to_finsupp = single 0 a :=
-by rw [←monomial_zero_left, to_finsupp_monomial]
 
 lemma C_0 : C (0 : R) = 0 := by simp
 
@@ -356,7 +144,7 @@ smul_monomial _ _ r
 
 @[simp] lemma C_bit1 : C (bit1 a) = bit1 (C a) := by simp [bit1, C_bit0]
 
-lemma C_pow : C (a ^ n) = C a ^ n := C.map_pow a n
+lemma C_pow : C (a ^ n) = C a ^ n := map_pow _ _ _
 
 @[simp]
 lemma C_eq_nat_cast (n : ℕ) : C (n : R) = (n : R[X]) :=
@@ -383,10 +171,9 @@ end
 /-- `X` commutes with everything, even when the coefficients are noncommutative. -/
 lemma X_mul : X * p = p * X :=
 begin
-  rcases p,
-  simp only [X, ←of_finsupp_single, ←of_finsupp_mul, linear_map.coe_mk],
+  simp only [X, linear_map.coe_mk],
   ext,
-  simp [add_monoid_algebra.mul_apply, sum_single_index, add_comm],
+  simp [add_monoid_algebra.mul_apply, monomial_def, sum_single_index, add_comm],
 end
 
 lemma X_pow_mul {n : ℕ} : X^n * p = p * X^n :=
@@ -443,11 +230,13 @@ lemma X_pow_mul_monomial (k n : ℕ) (r : R) : X^k * monomial n r = monomial (n+
 by rw [X_pow_mul, monomial_mul_X_pow]
 
 /-- `coeff p n` (often denoted `p.coeff n`) is the coefficient of `X^n` in `p`. -/
-@[simp] def coeff : R[X] → ℕ → R
-| ⟨p⟩ := p
+def coeff : R[X] → ℕ → R
+| p := p
+
+lemma coeff_def : p.coeff = p := rfl
 
 lemma coeff_monomial : coeff (monomial n a) m = if n = m then a else 0 :=
-by { simp only [←of_finsupp_single, coeff, linear_map.coe_mk], rw finsupp.single_apply }
+finsupp.single_apply
 
 @[simp] lemma coeff_zero (n : ℕ) : coeff (0 : R[X]) n = 0 := rfl
 
@@ -467,7 +256,7 @@ lemma coeff_X_of_ne_one {n : ℕ} (hn : n ≠ 1) : coeff (X : R[X]) n = 0 :=
 by rw [coeff_X, if_neg hn.symm]
 
 @[simp] lemma mem_support_iff : n ∈ p.support ↔ p.coeff n ≠ 0 :=
-by { rcases p, simp }
+by simp [coeff_def]
 
 lemma not_mem_support_iff : n ∉ p.support ↔ p.coeff n = 0 :=
 by simp
@@ -499,7 +288,7 @@ calc C a = 0 ↔ C a = C 0 : by rw C_0
          ... ↔ a = 0 : C_inj
 
 theorem ext_iff {p q : R[X]} : p = q ↔ ∀ n, coeff p n = coeff q n :=
-by { rcases p, rcases q, simp [coeff, finsupp.ext_iff] }
+finsupp.ext_iff
 
 @[ext] lemma ext {p q : R[X]} : (∀ n, coeff p n = coeff q n) → p = q :=
 ext_iff.2
@@ -507,14 +296,7 @@ ext_iff.2
 /-- Monomials generate the additive monoid of polynomials. -/
 lemma add_submonoid_closure_set_of_eq_monomial :
   add_submonoid.closure {p : R[X] | ∃ n a, p = monomial n a} = ⊤ :=
-begin
-  apply top_unique,
-  rw [← add_submonoid.map_equiv_top (to_finsupp_iso R).symm.to_add_equiv,
-    ← finsupp.add_closure_set_of_eq_single, add_monoid_hom.map_mclosure],
-  refine add_submonoid.closure_mono (set.image_subset_iff.2 _),
-  rintro _ ⟨n, a, rfl⟩,
-  exact ⟨n, a, polynomial.of_finsupp_single _ _⟩,
-end
+finsupp.add_closure_set_of_eq_single
 
 lemma add_hom_ext {M : Type*} [add_monoid M] {f g : R[X] →+ M}
   (h : ∀ n a, f (monomial n a) = g (monomial n a)) :
@@ -539,10 +321,10 @@ by rw [←one_smul R p, ←h, zero_smul]
 section fewnomials
 
 lemma support_monomial (n) {a : R} (H : a ≠ 0) : (monomial n a).support = singleton n :=
-by rw [←of_finsupp_single, support, finsupp.support_single_ne_zero _ H]
+finsupp.support_single_ne_zero _ H
 
 lemma support_monomial' (n) (a : R) : (monomial n a).support ⊆ singleton n :=
-by { rw [←of_finsupp_single, support], exact finsupp.support_single_subset }
+finsupp.support_single_subset
 
 lemma support_C_mul_X_pow (n : ℕ) {c : R} (h : c ≠ 0) : (C c * X ^ n).support = singleton n :=
 by rw [←monomial_eq_C_mul_X, support_monomial n h]
@@ -599,13 +381,13 @@ begin
 end
 
 lemma monomial_left_inj {a : R} (ha : a ≠ 0) {i j : ℕ} : (monomial i a) = (monomial j a) ↔ i = j :=
-by simp_rw [←of_finsupp_single, finsupp.single_left_inj ha]
+finsupp.single_left_inj ha
 
 lemma binomial_eq_binomial {k l m n : ℕ} {u v : R} (hu : u ≠ 0) (hv : v ≠ 0) :
   C u * X ^ k + C v * X ^ l = C u * X ^ m + C v * X ^ n ↔
   (k = m ∧ l = n) ∨ (u = v ∧ k = n ∧ l = m) ∨ (u + v = 0 ∧ k = l ∧ m = n) :=
 begin
-  simp_rw [←monomial_eq_C_mul_X, ←to_finsupp_inj, to_finsupp_add, to_finsupp_monomial],
+  simp_rw [←monomial_eq_C_mul_X],
   exact finsupp.single_add_single_eq_single_add_single hu hv,
 end
 
@@ -630,13 +412,7 @@ end
 
 /-- Expressing the product of two polynomials as a double sum. -/
 lemma mul_eq_sum_sum :
-  p * q = ∑ i in p.support, q.sum (λ j a, (monomial (i + j)) (p.coeff i * a)) :=
-begin
-  apply to_finsupp_injective,
-  rcases p, rcases q,
-  simp [support, sum, coeff, to_finsupp_sum],
-  refl
-end
+  p * q = ∑ i in p.support, q.sum (λ j a, (monomial (i + j)) (p.coeff i * a)) := rfl
 
 @[simp] lemma sum_zero_index {S : Type*} [add_comm_monoid S] (f : ℕ → R → S) :
   (0 : R[X]).sum f = 0 :=
@@ -663,15 +439,11 @@ sum_monomial_index 1 1 f hf
 lemma sum_add_index {S : Type*} [add_comm_monoid S] (p q : R[X])
   (f : ℕ → R → S) (hf : ∀ i, f i 0 = 0) (h_add : ∀a b₁ b₂, f a (b₁ + b₂) = f a b₁ + f a b₂) :
   (p + q).sum f = p.sum f + q.sum f :=
-begin
-  rcases p, rcases q,
-  simp only [←of_finsupp_add, sum, support, coeff, pi.add_apply, coe_add],
-  exact finsupp.sum_add_index' hf h_add,
-end
+finsupp.sum_add_index' hf h_add
 
 lemma sum_add' {S : Type*} [add_comm_monoid S] (p : R[X]) (f g : ℕ → R → S) :
   p.sum (f + g) = p.sum f + p.sum g :=
-by simp [sum_def, finset.sum_add_distrib]
+finset.sum_add_distrib
 
 lemma sum_add {S : Type*} [add_comm_monoid S] (p : R[X]) (f g : ℕ → R → S) :
   p.sum (λ n x, f n x + g n x) = p.sum f + p.sum g :=
@@ -679,47 +451,27 @@ sum_add' _ _ _
 
 lemma sum_smul_index {S : Type*} [add_comm_monoid S] (p : R[X]) (b : R)
   (f : ℕ → R → S) (hf : ∀ i, f i 0 = 0) : (b • p).sum f = p.sum (λ n a, f n (b * a)) :=
-begin
-  rcases p,
-  simpa [sum, support, coeff] using finsupp.sum_smul_index hf,
-end
+finsupp.sum_smul_index hf
 
 /-- `erase p n` is the polynomial `p` in which the `X^n` term has been erased. -/
-@[irreducible] definition erase (n : ℕ) : R[X] → R[X]
-| ⟨p⟩ := ⟨p.erase n⟩
-
-@[simp] lemma to_finsupp_erase (p : R[X]) (n : ℕ) :
-  to_finsupp (p.erase n) = (p.to_finsupp).erase n :=
-by { rcases p, simp only [erase] }
-
-@[simp] lemma of_finsupp_erase (p : add_monoid_algebra R ℕ) (n : ℕ) :
-  (⟨p.erase n⟩ : R[X]) = (⟨p⟩ : R[X]).erase n :=
-by { rcases p, simp only [erase] }
+abbreviation erase : ℕ → R[X] → R[X] := finsupp.erase
 
 @[simp] lemma support_erase (p : R[X]) (n : ℕ) :
   support (p.erase n) = (support p).erase n :=
-by { rcases p, simp only [support, erase, support_erase] }
+support_erase
 
 lemma monomial_add_erase (p : R[X]) (n : ℕ) : monomial n (coeff p n) + p.erase n = p :=
-to_finsupp_injective $ begin
-  rcases p,
-  rw [to_finsupp_add, to_finsupp_monomial, to_finsupp_erase, coeff],
-  exact finsupp.single_add_erase _ _,
-end
+finsupp.single_add_erase _ _
 
 lemma coeff_erase (p : R[X]) (n i : ℕ) :
   (p.erase n).coeff i = if i = n then 0 else p.coeff i :=
-begin
-  rcases p,
-  simp only [erase, coeff],
-  convert rfl
-end
+by convert rfl
 
 @[simp] lemma erase_zero (n : ℕ) : (0 : R[X]).erase n = 0 :=
-to_finsupp_injective $ by simp
+by simp !
 
 @[simp] lemma erase_monomial {n : ℕ} {a : R} : erase n (monomial n a) = 0 :=
-to_finsupp_injective $ by simp
+by simp ! [monomial_def]
 
 @[simp] lemma erase_same (p : R[X]) (n : ℕ) : coeff (p.erase n) n = 0 :=
 by simp [coeff_erase]
@@ -733,17 +485,13 @@ section update
 /-- Replace the coefficient of a `p : polynomial p` at a given degree `n : ℕ`
 by a given value `a : R`. If `a = 0`, this is equal to `p.erase n`
 If `p.nat_degree < n` and `a ≠ 0`, this increases the degree to `n`.  -/
-def update (p : R[X]) (n : ℕ) (a : R) :
+abbreviation update (p : R[X]) (n : ℕ) (a : R) :
   R[X] :=
-polynomial.of_finsupp (p.to_finsupp.update n a)
+finsupp.update p n a
 
 lemma coeff_update (p : R[X]) (n : ℕ) (a : R) :
   (p.update n a).coeff = function.update p.coeff n a :=
-begin
-  ext,
-  cases p,
-  simp only [coeff, update, function.update_apply, coe_update],
-end
+by simp [coeff_def]
 
 lemma coeff_update_apply (p : R[X]) (n : ℕ) (a : R) (i : ℕ) :
   (p.update n a).coeff i = if (i = n) then a else p.coeff i :=
@@ -763,7 +511,7 @@ by { ext, rw [coeff_update_apply, coeff_erase] }
 
 lemma support_update (p : R[X]) (n : ℕ) (a : R) [decidable (a = 0)] :
   support (p.update n a) = if a = 0 then p.support.erase n else insert n p.support :=
-by { cases p, simp only [support, update, support_update], congr }
+by { simp only [support_update], congr }
 
 lemma support_update_zero (p : R[X]) (n : ℕ) :
   support (p.update n 0) = p.support.erase n :=
@@ -777,38 +525,21 @@ end update
 
 end semiring
 
-section comm_semiring
-variables [comm_semiring R]
-
-instance : comm_semiring R[X] :=
-function.injective.comm_semiring to_finsupp to_finsupp_injective
-  to_finsupp_zero to_finsupp_one to_finsupp_add to_finsupp_mul
-  (λ _ _, to_finsupp_smul _ _) to_finsupp_pow (λ _, rfl)
-
-end comm_semiring
-
 section ring
 variables [ring R]
 
-instance : has_int_cast R[X] := ⟨λ n, of_finsupp n⟩
-
-instance : ring R[X] :=
-function.injective.ring to_finsupp to_finsupp_injective
-  to_finsupp_zero to_finsupp_one to_finsupp_add to_finsupp_mul to_finsupp_neg to_finsupp_sub
-  (λ _ _, to_finsupp_smul _ _) (λ _ _, to_finsupp_smul _ _) to_finsupp_pow (λ _, rfl) (λ _, rfl)
-
 @[simp] lemma coeff_neg (p : R[X]) (n : ℕ) : coeff (-p) n = -coeff p n :=
-by { rcases p, rw [←of_finsupp_neg, coeff, coeff, finsupp.neg_apply] }
+finsupp.neg_apply _ _
 
 @[simp]
 lemma coeff_sub (p q : R[X]) (n : ℕ) : coeff (p - q) n = coeff p n - coeff q n :=
-by { rcases p, rcases q, rw [←of_finsupp_sub, coeff, coeff, coeff, finsupp.sub_apply] }
+finsupp.sub_apply _ _ _
 
 @[simp] lemma monomial_neg (n : ℕ) (a : R) : monomial n (-a) = -(monomial n a) :=
 by rw [eq_neg_iff_add_eq_zero, ←monomial_add, neg_add_self, monomial_zero_right]
 
 @[simp] lemma support_neg {p : R[X]} : (-p).support = p.support :=
-by { rcases p, rw [←of_finsupp_neg, support, support, finsupp.support_neg] }
+finsupp.support_neg _
 
 @[simp]
 lemma C_eq_int_cast (n : ℤ) : C (n : R) = n :=
@@ -816,21 +547,9 @@ lemma C_eq_int_cast (n : ℤ) : C (n : R) = n :=
 
 end ring
 
-instance [comm_ring R] : comm_ring R[X] :=
-function.injective.comm_ring to_finsupp to_finsupp_injective
-  to_finsupp_zero to_finsupp_one to_finsupp_add to_finsupp_mul to_finsupp_neg to_finsupp_sub
-  (λ _ _, to_finsupp_smul _ _) (λ _ _, to_finsupp_smul _ _) to_finsupp_pow (λ _, rfl) (λ _, rfl)
-
 section nonzero_semiring
 
 variables [semiring R] [nontrivial R]
-instance : nontrivial R[X] :=
-begin
-  have h : nontrivial (add_monoid_algebra R ℕ) := by apply_instance,
-  rcases h.exists_pair_ne with ⟨x, y, hxy⟩,
-  refine ⟨⟨⟨x⟩, ⟨y⟩, _⟩⟩,
-  simp [hxy],
-end
 
 lemma X_ne_zero : (X : R[X]) ≠ 0 :=
 mt (congr_arg (λ p, coeff p 1)) (by simp)
@@ -839,7 +558,7 @@ end nonzero_semiring
 
 @[simp] lemma nontrivial_iff [semiring R] : nontrivial R[X] ↔ nontrivial R :=
 ⟨λ h, let ⟨r, s, hrs⟩ := @exists_pair_ne _ h in nontrivial.of_polynomial_ne hrs,
-  λ h, @polynomial.nontrivial _ _ h⟩
+  by { introI h, apply_instance }⟩
 
 section repr
 variables [semiring R]

--- a/src/data/polynomial/coeff.lean
+++ b/src/data/polynomial/coeff.lean
@@ -34,11 +34,11 @@ coeff_monomial
 
 @[simp]
 lemma coeff_add (p q : R[X]) (n : ℕ) : coeff (p + q) n = coeff p n + coeff q n :=
-by { rcases p, rcases q, simp_rw [←of_finsupp_add, coeff], exact finsupp.add_apply _ _ _ }
+finsupp.add_apply _ _ _
 
 @[simp] lemma coeff_smul [monoid S] [distrib_mul_action S R] (r : S) (p : R[X]) (n : ℕ) :
   coeff (r • p) n = r • coeff p n :=
-by { rcases p, simp_rw [←of_finsupp_smul, coeff], exact finsupp.smul_apply _ _ _ }
+finsupp.smul_apply _ _ _
 
 lemma support_smul [monoid S] [distrib_mul_action S R] (r : S) (p : R[X]) :
   support (r • p) ⊆ support p :=
@@ -78,18 +78,14 @@ variable {R}
 
 lemma coeff_sum [semiring S] (n : ℕ) (f : ℕ → R → S[X]) :
   coeff (p.sum f) n = p.sum (λ a b, coeff (f a b) n) :=
-by { rcases p, simp [polynomial.sum, support, coeff] }
+by simp [polynomial.sum, support]
 
 /-- Decomposes the coefficient of the product `p * q` as a sum
 over `nat.antidiagonal`. A version which sums over `range (n + 1)` can be obtained
 by using `finset.nat.sum_antidiagonal_eq_sum_range_succ`. -/
 lemma coeff_mul (p q : R[X]) (n : ℕ) :
   coeff (p * q) n = ∑ x in nat.antidiagonal n, coeff p x.1 * coeff q x.2 :=
-begin
-  rcases p, rcases q,
-  simp_rw [←of_finsupp_mul, coeff],
-  exact add_monoid_algebra.mul_apply_antidiagonal p q n _ (λ x, nat.mem_antidiagonal)
-end
+add_monoid_algebra.mul_apply_antidiagonal p q n _ (λ x, nat.mem_antidiagonal)
 
 @[simp] lemma mul_coeff_zero (p q : R[X]) : coeff (p * q) 0 = coeff p 0 * coeff q 0 :=
 by simp [coeff_mul]
@@ -107,23 +103,16 @@ by { rw [← monomial_eq_C_mul_X, coeff_monomial], congr' 1, simp [eq_comm] }
 lemma coeff_C_mul_X (x : R) (n : ℕ) : coeff (C x * X : R[X]) n = if n = 1 then x else 0 :=
 by rw [← pow_one X, coeff_C_mul_X_pow]
 
-@[simp] lemma coeff_C_mul (p : R[X]) : coeff (C a * p) n = a * coeff p n :=
-begin
-  rcases p,
-  simp_rw [←monomial_zero_left, ←of_finsupp_single, ←of_finsupp_mul, coeff],
-  exact add_monoid_algebra.single_zero_mul_apply p a n
-end
+@[simp] lemma coeff_C_mul (p : R[X]) :
+  coeff (C a * p) n = a * coeff p n :=
+add_monoid_algebra.single_zero_mul_apply p a n
 
 lemma C_mul' (a : R) (f : R[X]) : C a * f = a • f :=
 by { ext, rw [coeff_C_mul, coeff_smul, smul_eq_mul] }
 
 @[simp] lemma coeff_mul_C (p : R[X]) (n : ℕ) (a : R) :
   coeff (p * C a) n = coeff p n * a :=
-begin
-  rcases p,
-  simp_rw [←monomial_zero_left, ←of_finsupp_single, ←of_finsupp_mul, coeff],
-  exact add_monoid_algebra.mul_single_zero_apply p a n
-end
+add_monoid_algebra.mul_single_zero_apply p a n
 
 lemma coeff_X_pow (k n : ℕ) :
   coeff (X^k : R[X]) n = if n = k then 1 else 0 :=

--- a/src/data/polynomial/degree/definitions.lean
+++ b/src/data/polynomial/degree/definitions.lean
@@ -272,7 +272,6 @@ lemma sum_over_range' [add_comm_monoid S] (p : R[X]) {f : ℕ → R → S} (h : 
   (n : ℕ) (w : p.nat_degree < n) :
   p.sum f = ∑ (a : ℕ) in range n, f a (coeff p a) :=
 begin
-  rcases p,
   have := supp_subset_range w,
   simp only [polynomial.sum, support, coeff, nat_degree, degree] at ⊢ this,
   exact finsupp.sum_of_support_subset _ this _ (λ n hn, h n)
@@ -550,7 +549,7 @@ le_antisymm (degree_add_le _ _) $
   end
 
 lemma degree_erase_le (p : R[X]) (n : ℕ) : degree (p.erase n) ≤ degree p :=
-by { rcases p, simp only [erase, degree, coeff, support], convert sup_mono (erase_subset _ _) }
+by convert sup_mono (erase_subset _ _)
 
 lemma degree_erase_lt (hp : p ≠ 0) : degree (p.erase (nat_degree p)) < degree p :=
 begin
@@ -582,7 +581,6 @@ calc degree (p * q) ≤ (p.support).sup (λi, degree (sum q (λj a, C (coeff p i
     begin
       simp only [monomial_eq_C_mul_X.symm],
       convert degree_sum_le _ _,
-      exact mul_eq_sum_sum
     end
   ... ≤ p.support.sup (λi, q.support.sup (λj, degree (C (coeff p i * coeff q j) * X ^ (i + j)))) :
     finset.sup_mono_fun (assume i hi,  degree_sum_le _ _)

--- a/src/data/polynomial/eval.lean
+++ b/src/data/polynomial/eval.lean
@@ -86,7 +86,7 @@ begin
   simp [mul_sum, mul_assoc],
 end
 
-@[simp] lemma eval₂_C_X : eval₂ C X p = p :=
+@[simp] lemma eval₂_C_X : p.eval₂ C X = p :=
 polynomial.induction_on' p (λ p q hp hq, by simp [hp, hq])
   (λ n x, by rw [eval₂_monomial, monomial_eq_smul_X, C_mul'])
 
@@ -127,16 +127,13 @@ lemma eval₂_finset_sum (s : finset ι) (g : ι → R[X]) (x : S) :
   (∑ i in s, g i).eval₂ f x = ∑ i in s, (g i).eval₂ f x :=
 map_sum (eval₂_add_monoid_hom f x) _ _
 
-lemma eval₂_of_finsupp {f : R →+* S} {x : S} {p : add_monoid_algebra R ℕ} :
-  eval₂ f x (⟨p⟩ : R[X]) = lift_nc ↑f (powers_hom S x) p :=
-by { simp only [eval₂_eq_sum, sum, to_finsupp_sum, support, coeff], refl }
+lemma eval₂_eq_lift_nc {f : R →+* S} {x : S} {p : add_monoid_algebra R ℕ} :
+  eval₂ f x (p : R[X]) = lift_nc ↑f (powers_hom S x) p := rfl
 
 lemma eval₂_mul_noncomm (hf : ∀ k, commute (f $ q.coeff k) x) :
   eval₂ f x (p * q) = eval₂ f x p * eval₂ f x q :=
 begin
-  rcases p, rcases q,
-  simp only [coeff] at hf,
-  simp only [←of_finsupp_mul, eval₂_of_finsupp],
+  simp only [eval₂_eq_lift_nc],
   exact lift_nc_mul _ _ p q (λ k n hn, (hf k).pow_right n)
 end
 
@@ -232,7 +229,7 @@ def eval₂_ring_hom (f : R →+* S) (x : S) : R[X] →+* S :=
 
 @[simp] lemma coe_eval₂_ring_hom (f : R →+* S) (x) : ⇑(eval₂_ring_hom f x) = eval₂ f x := rfl
 
-lemma eval₂_pow (n : ℕ) : (p ^ n).eval₂ f x = p.eval₂ f x ^ n := (eval₂_ring_hom _ _).map_pow _ _
+lemma eval₂_pow (n : ℕ) : (p ^ n).eval₂ f x = p.eval₂ f x ^ n := (eval₂_ring_hom f x).map_pow _ _
 
 lemma eval₂_dvd : p ∣ q → eval₂ f x p ∣ eval₂ f x q :=
 (eval₂_ring_hom f x).map_dvd

--- a/src/data/polynomial/laurent.lean
+++ b/src/data/polynomial/laurent.lean
@@ -85,21 +85,18 @@ local notation R`[T;T⁻¹]`:9000 := laurent_polynomial R
 /--  The ring homomorphism, taking a polynomial with coefficients in `R` to a Laurent polynomial
 with coefficients in `R`. -/
 def polynomial.to_laurent [semiring R] : R[X] →+* R[T;T⁻¹] :=
-(map_domain_ring_hom R int.of_nat_hom).comp (to_finsupp_iso R)
+map_domain_ring_hom R int.of_nat_hom
 
 /-- This is not a simp lemma, as it is usually preferable to use the lemmas about `C` and `X`
 instead. -/
 lemma polynomial.to_laurent_apply [semiring R] (p : R[X]) :
-  p.to_laurent = p.to_finsupp.map_domain coe := rfl
+  p.to_laurent = p.map_domain coe := rfl
 
 /--  The `R`-algebra map, taking a polynomial with coefficients in `R` to a Laurent polynomial
 with coefficients in `R`. -/
 def polynomial.to_laurent_alg [comm_semiring R] :
   R[X] →ₐ[R] R[T;T⁻¹] :=
-begin
-  refine alg_hom.comp _ (to_finsupp_iso_alg R).to_alg_hom,
-  exact (map_domain_alg_hom R R int.of_nat_hom),
-end
+map_domain_alg_hom R R int.of_nat_hom
 
 @[simp]
 lemma polynomial.to_laurent_alg_apply [comm_semiring R] (f : R[X]) :
@@ -168,8 +165,8 @@ by convert single_mul_single.symm; simp
 @[simp]
 lemma _root_.polynomial.to_laurent_C_mul_T (n : ℕ) (r : R) :
   ((polynomial.monomial n r).to_laurent : R[T;T⁻¹]) = C r * T n :=
-show map_domain coe (monomial n r).to_finsupp = (C r * T n : R[T;T⁻¹]),
-by rw [to_finsupp_monomial, map_domain_single, single_eq_C_mul_T]
+show map_domain coe (monomial n r) = (C r * T n : R[T;T⁻¹]),
+by rw [monomial_def, map_domain_single, single_eq_C_mul_T]
 
 @[simp]
 lemma _root_.polynomial.to_laurent_C (r : R) :
@@ -271,23 +268,18 @@ lemma T_mul (n : ℤ) (f : R[T;T⁻¹]) : T n * f = f * T n :=
 nonnegative degree coincide with the ones of `f`.  The terms of negative degree of `f` "vanish".
 `trunc` is a left-inverse to `polynomial.to_laurent`. -/
 def trunc : R[T;T⁻¹] →+ R[X] :=
-((to_finsupp_iso R).symm.to_add_monoid_hom).comp $
-  comap_domain.add_monoid_hom $ λ a b, int.of_nat.inj
+comap_domain.add_monoid_hom $ λ a b, int.of_nat.inj
 
 @[simp]
 lemma trunc_C_mul_T (n : ℤ) (r : R) : trunc (C r * T n) = ite (0 ≤ n) (monomial n.to_nat r) 0 :=
 begin
-  apply (to_finsupp_iso R).injective,
-  rw [← single_eq_C_mul_T, trunc, add_monoid_hom.coe_comp, function.comp_app,
-    comap_domain.add_monoid_hom_apply, to_finsupp_iso_apply],
+  rw [← single_eq_C_mul_T, trunc, comap_domain.add_monoid_hom_apply],
   by_cases n0 : 0 ≤ n,
   { lift n to ℕ using n0,
-    erw [comap_domain_single, to_finsupp_iso_symm_apply],
-    simp only [int.coe_nat_nonneg, int.to_nat_coe_nat, if_true, to_finsupp_iso_apply,
-      to_finsupp_monomial] },
+    erw [comap_domain_single],
+    simpa only [int.coe_nat_nonneg, int.to_nat_coe_nat, if_true] },
   { lift (- n) to ℕ using (neg_pos.mpr (not_le.mp n0)).le with m,
-    rw [to_finsupp_iso_apply, to_finsupp_inj, if_neg n0],
-    erw to_finsupp_iso_symm_apply,
+    rw [if_neg n0],
     ext a,
     have := ((not_le.mp n0).trans_le (int.coe_zero_le a)).ne',
     simp only [coeff, comap_domain_apply, int.of_nat_eq_coe, coeff_zero, single_apply_eq_zero, this,
@@ -380,10 +372,10 @@ begin
   generalize' hd : f.support = s,
   revert f,
   refine finset.induction_on s _ _; clear s,
-  { simp only [polynomial.support_eq_empty, map_zero, finsupp.support_zero, eq_self_iff_true,
+  { simp only [support_eq_empty, map_zero, finsupp.support_zero, eq_self_iff_true,
       implies_true_iff, finset.map_empty] {contextual := tt} },
   { intros a s as hf f fs,
-    have : (erase a f).to_laurent.support = s.map nat.cast_embedding := hf (f.erase a) (by simp only
+    have : (f.erase a).to_laurent.support = s.map nat.cast_embedding := hf (f.erase a) (by simp only
       [fs, finset.erase_eq_of_not_mem as, polynomial.support_erase, finset.erase_insert_eq_erase]),
     rw [← monomial_add_erase f a, finset.map_insert, ← this, map_add,
       polynomial.to_laurent_C_mul_T, support_add_eq, finset.insert_eq],

--- a/src/data/polynomial/monomial.lean
+++ b/src/data/polynomial/monomial.lean
@@ -22,10 +22,7 @@ variables [semiring R] {p q r : R[X]}
 
 lemma monomial_one_eq_iff [nontrivial R] {i j : ℕ} :
   (monomial i 1 : R[X]) = monomial j 1 ↔ i = j :=
-begin
-  simp_rw [←of_finsupp_single],
-  exact add_monoid_algebra.of_injective.eq_iff
-end
+add_monoid_algebra.of_injective.eq_iff
 
 instance [nontrivial R] : infinite R[X] :=
 infinite.of_injective (λ i, monomial i 1) $
@@ -55,21 +52,9 @@ end
 lemma ring_hom_ext {S} [semiring S] {f g : R[X] →+* S}
   (h₁ : ∀ a, f (C a) = g (C a)) (h₂ : f X = g X) : f = g :=
 begin
-  set f' := f.comp (to_finsupp_iso R).symm.to_ring_hom with hf',
-  set g' := g.comp (to_finsupp_iso R).symm.to_ring_hom with hg',
-  have A : f' = g',
-  { ext,
-    { simp [h₁, ring_equiv.to_ring_hom_eq_coe] },
-    { simpa [ring_equiv.to_ring_hom_eq_coe] using h₂, } },
-  have B : f = f'.comp (to_finsupp_iso R),
-    by { rw [hf', ring_hom.comp_assoc], ext x, simp only [ring_equiv.to_ring_hom_eq_coe,
-      ring_equiv.symm_apply_apply, function.comp_app, ring_hom.coe_comp,
-      ring_equiv.coe_to_ring_hom] },
-  have C : g = g'.comp (to_finsupp_iso R),
-    by { rw [hg', ring_hom.comp_assoc], ext x, simp only [ring_equiv.to_ring_hom_eq_coe,
-      ring_equiv.symm_apply_apply, function.comp_app, ring_hom.coe_comp,
-      ring_equiv.coe_to_ring_hom] },
-  rw [B, C, A]
+  ext,
+  { simp [h₁, ← monomial_def], },
+  { simpa using h₂, }
 end
 
 @[ext] lemma ring_hom_ext' {S} [semiring S] {f g : R[X] →+* S}


### PR DESCRIPTION
After this refactoring, we can generalize many of the lemmas to make them available for both `polynomial` and `laurent_polynomial`.



---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
