### PR TITLE
[Merged by Bors] - fix(algebra/monoid_algebra/basic): add `int_cast` to `monoid_algebra` instances

### DIFF
--- a/src/algebra/monoid_algebra/basic.lean
+++ b/src/algebra/monoid_algebra/basic.lean
@@ -243,12 +243,17 @@ instance [ring k] [semigroup G] : non_unital_ring (monoid_algebra k G) :=
 { .. monoid_algebra.add_comm_group,
   .. monoid_algebra.non_unital_semiring }
 
+-- note that whenever possible, we have to extend `non_assoc_ring` to get the `int_cast`.
+
 instance [ring k] [mul_one_class G] : non_assoc_ring (monoid_algebra k G) :=
-{ .. monoid_algebra.add_comm_group,
+{ int_cast                    := λ n, single 1 (algebra_map ℤ k n),
+  int_cast_of_nat             := λ n, by simpa,
+  int_cast_neg_succ_of_nat    := λ n, by simpa,
+  .. monoid_algebra.add_comm_group,
   .. monoid_algebra.non_assoc_semiring }
 
 instance [ring k] [monoid G] : ring (monoid_algebra k G) :=
-{ .. monoid_algebra.non_unital_non_assoc_ring,
+{ .. monoid_algebra.non_assoc_ring,
   .. monoid_algebra.semiring }
 
 instance [comm_ring k] [comm_semigroup G] : non_unital_comm_ring (monoid_algebra k G) :=
@@ -1091,11 +1096,16 @@ instance [ring k] [add_semigroup G] : non_unital_ring (add_monoid_algebra k G) :
   .. add_monoid_algebra.non_unital_semiring }
 
 instance [ring k] [add_zero_class G] : non_assoc_ring (add_monoid_algebra k G) :=
-{ .. add_monoid_algebra.add_comm_group,
+{ int_cast                    := λ n, single 0 (algebra_map ℤ k n),
+  int_cast_of_nat             := λ n, by simpa,
+  int_cast_neg_succ_of_nat    := λ n, by simpa,
+  .. add_monoid_algebra.add_comm_group,
   .. add_monoid_algebra.non_assoc_semiring }
 
+-- note that whenever possible, we have to extend `non_assoc_ring` to get the `int_cast`.
+
 instance [ring k] [add_monoid G] : ring (add_monoid_algebra k G) :=
-{ .. add_monoid_algebra.non_unital_non_assoc_ring,
+{ .. add_monoid_algebra.non_assoc_ring,
   .. add_monoid_algebra.semiring }
 
 instance [comm_ring k] [add_comm_semigroup G] : non_unital_comm_ring (add_monoid_algebra k G) :=

--- a/src/algebra/monoid_algebra/basic.lean
+++ b/src/algebra/monoid_algebra/basic.lean
@@ -244,7 +244,7 @@ instance [ring k] [semigroup G] : non_unital_ring (monoid_algebra k G) :=
   .. monoid_algebra.non_unital_semiring }
 
 instance [ring k] [mul_one_class G] : non_assoc_ring (monoid_algebra k G) :=
-{ int_cast                    := λ n, single 1 (algebra_map ℤ k n),
+{ int_cast                    := λ z, single 1 (z : k),
   int_cast_of_nat             := λ n, by simpa,
   int_cast_neg_succ_of_nat    := λ n, by simpa,
   .. monoid_algebra.add_comm_group,

--- a/src/algebra/monoid_algebra/basic.lean
+++ b/src/algebra/monoid_algebra/basic.lean
@@ -183,7 +183,7 @@ instance : non_assoc_semiring (monoid_algebra k G) :=
     single_zero, sum_zero, add_zero, mul_one, sum_single],
   ..monoid_algebra.non_unital_non_assoc_semiring }
 
-lemma nat_cast_def {n : ℕ} : (n : monoid_algebra k G) = single 1 n := rfl
+lemma nat_cast_def (n : ℕ) : (n : monoid_algebra k G) = single 1 n := rfl
 
 end mul_one_class
 
@@ -252,7 +252,7 @@ instance [ring k] [mul_one_class G] : non_assoc_ring (monoid_algebra k G) :=
   .. monoid_algebra.add_comm_group,
   .. monoid_algebra.non_assoc_semiring }
 
-lemma int_cast_def [ring k] [mul_one_class G] {z : ℤ} : (z : monoid_algebra k G) = single 1 z := rfl
+lemma int_cast_def [ring k] [mul_one_class G] (z : ℤ) : (z : monoid_algebra k G) = single 1 z := rfl
 
 instance [ring k] [monoid G] : ring (monoid_algebra k G) :=
 { .. monoid_algebra.non_assoc_ring,
@@ -1036,7 +1036,7 @@ instance : non_assoc_semiring (add_monoid_algebra k G) :=
     single_zero, sum_zero, add_zero, mul_one, sum_single],
   .. add_monoid_algebra.non_unital_non_assoc_semiring }
 
-lemma nat_cast_def {n : ℕ} : (n : add_monoid_algebra k G) = single 0 n := rfl
+lemma nat_cast_def (n : ℕ) : (n : add_monoid_algebra k G) = single 0 n := rfl
 
 end mul_one_class
 
@@ -1106,7 +1106,7 @@ instance [ring k] [add_zero_class G] : non_assoc_ring (add_monoid_algebra k G) :
   .. add_monoid_algebra.add_comm_group,
   .. add_monoid_algebra.non_assoc_semiring }
 
-lemma int_cast_def [ring k] [add_zero_class G] {z : ℤ} :
+lemma int_cast_def [ring k] [add_zero_class G] (z : ℤ) :
   (z : add_monoid_algebra k G) = single 0 z := rfl
 
 instance [ring k] [add_monoid G] : ring (add_monoid_algebra k G) :=

--- a/src/algebra/monoid_algebra/basic.lean
+++ b/src/algebra/monoid_algebra/basic.lean
@@ -1094,7 +1094,7 @@ instance [ring k] [add_semigroup G] : non_unital_ring (add_monoid_algebra k G) :
   .. add_monoid_algebra.non_unital_semiring }
 
 instance [ring k] [add_zero_class G] : non_assoc_ring (add_monoid_algebra k G) :=
-{ int_cast                    := λ n, single 0 (algebra_map ℤ k n),
+{ int_cast                    := λ z, single 1 (z : k),
   int_cast_of_nat             := λ n, by simpa,
   int_cast_neg_succ_of_nat    := λ n, by simpa,
   .. add_monoid_algebra.add_comm_group,

--- a/src/algebra/monoid_algebra/basic.lean
+++ b/src/algebra/monoid_algebra/basic.lean
@@ -183,6 +183,8 @@ instance : non_assoc_semiring (monoid_algebra k G) :=
     single_zero, sum_zero, add_zero, mul_one, sum_single],
   ..monoid_algebra.non_unital_non_assoc_semiring }
 
+lemma nat_cast_def {n : ℕ} : (n : monoid_algebra k G) = single 1 n := rfl
+
 end mul_one_class
 
 /-! #### Semiring structure -/
@@ -249,6 +251,8 @@ instance [ring k] [mul_one_class G] : non_assoc_ring (monoid_algebra k G) :=
   int_cast_neg_succ_of_nat    := λ n, by simpa,
   .. monoid_algebra.add_comm_group,
   .. monoid_algebra.non_assoc_semiring }
+
+lemma int_cast_def [ring k] [mul_one_class G] {z : ℤ} : (z : monoid_algebra k G) = single 1 z := rfl
 
 instance [ring k] [monoid G] : ring (monoid_algebra k G) :=
 { .. monoid_algebra.non_assoc_ring,
@@ -1032,6 +1036,8 @@ instance : non_assoc_semiring (add_monoid_algebra k G) :=
     single_zero, sum_zero, add_zero, mul_one, sum_single],
   .. add_monoid_algebra.non_unital_non_assoc_semiring }
 
+lemma nat_cast_def {n : ℕ} : (n : add_monoid_algebra k G) = single 0 n := rfl
+
 end mul_one_class
 
 /-! #### Semiring structure -/
@@ -1099,6 +1105,9 @@ instance [ring k] [add_zero_class G] : non_assoc_ring (add_monoid_algebra k G) :
   int_cast_neg_succ_of_nat    := λ n, by simpa,
   .. add_monoid_algebra.add_comm_group,
   .. add_monoid_algebra.non_assoc_semiring }
+
+lemma int_cast_def [ring k] [add_zero_class G] {z : ℤ} :
+  (z : add_monoid_algebra k G) = single 0 z := rfl
 
 instance [ring k] [add_monoid G] : ring (add_monoid_algebra k G) :=
 { .. add_monoid_algebra.non_assoc_ring,

--- a/src/algebra/monoid_algebra/basic.lean
+++ b/src/algebra/monoid_algebra/basic.lean
@@ -243,8 +243,6 @@ instance [ring k] [semigroup G] : non_unital_ring (monoid_algebra k G) :=
 { .. monoid_algebra.add_comm_group,
   .. monoid_algebra.non_unital_semiring }
 
--- note that whenever possible, we have to extend `non_assoc_ring` to get the `int_cast`.
-
 instance [ring k] [mul_one_class G] : non_assoc_ring (monoid_algebra k G) :=
 { int_cast                    := λ n, single 1 (algebra_map ℤ k n),
   int_cast_of_nat             := λ n, by simpa,
@@ -1101,8 +1099,6 @@ instance [ring k] [add_zero_class G] : non_assoc_ring (add_monoid_algebra k G) :
   int_cast_neg_succ_of_nat    := λ n, by simpa,
   .. add_monoid_algebra.add_comm_group,
   .. add_monoid_algebra.non_assoc_semiring }
-
--- note that whenever possible, we have to extend `non_assoc_ring` to get the `int_cast`.
 
 instance [ring k] [add_monoid G] : ring (add_monoid_algebra k G) :=
 { .. add_monoid_algebra.non_assoc_ring,

--- a/src/algebra/monoid_algebra/basic.lean
+++ b/src/algebra/monoid_algebra/basic.lean
@@ -1094,7 +1094,7 @@ instance [ring k] [add_semigroup G] : non_unital_ring (add_monoid_algebra k G) :
   .. add_monoid_algebra.non_unital_semiring }
 
 instance [ring k] [add_zero_class G] : non_assoc_ring (add_monoid_algebra k G) :=
-{ int_cast                    := λ z, single 1 (z : k),
+{ int_cast                    := λ z, single 0 (z : k),
   int_cast_of_nat             := λ n, by simpa,
   int_cast_neg_succ_of_nat    := λ n, by simpa,
   .. add_monoid_algebra.add_comm_group,

--- a/src/data/polynomial/basic.lean
+++ b/src/data/polynomial/basic.lean
@@ -228,12 +228,6 @@ lemma to_finsupp_sum {ι : Type*} (s : finset ι) (f : ι → R[X]) :
   (∑ i in s, f i : R[X]).to_finsupp = ∑ i in s, (f i).to_finsupp :=
 map_sum (to_finsupp_iso R) f s
 
-/-- `monomial s a` is the monomial `a * X^s` -/
-def monomial (n : ℕ) : R →ₗ[R] R[X] :=
-{ to_fun := λ t, ⟨finsupp.single n t⟩,
-  map_add' := by simp,
-  map_smul' := by simp [←of_finsupp_smul] }
-
 /--
 The set of all `n` such that `X^n` has a non-zero coefficient.
 -/

--- a/src/data/polynomial/basic.lean
+++ b/src/data/polynomial/basic.lean
@@ -83,8 +83,6 @@ they unfold around `polynomial.of_finsupp` and `polynomial.to_finsupp`.
 -/
 section add_monoid_algebra
 
-/-- The function version of `monomial`. Use `monomial` instead of this one. -/
-def monomial_fun (n : ℕ) (a : R) : R[X] := ⟨finsupp.single n a⟩
 @[irreducible] private def add : R[X] → R[X] → R[X]
 | ⟨a⟩ ⟨b⟩ := ⟨a + b⟩
 @[irreducible] private def neg {R : Type u} [ring R] : R[X] → R[X]
@@ -93,7 +91,7 @@ def monomial_fun (n : ℕ) (a : R) : R[X] := ⟨finsupp.single n a⟩
 | ⟨a⟩ ⟨b⟩ := ⟨a * b⟩
 
 instance : has_zero R[X] := ⟨⟨0⟩⟩
-instance : has_one R[X] := ⟨monomial_fun 0 (1 : R)⟩
+instance : has_one R[X] := ⟨⟨1⟩⟩
 instance : has_add R[X] := ⟨add⟩
 instance {R : Type u} [ring R] : has_neg R[X] := ⟨neg⟩
 instance {R : Type u} [ring R] : has_sub R[X] := ⟨λ a b, a + -b⟩
@@ -103,15 +101,8 @@ instance {S : Type*} [monoid S] [distrib_mul_action S R] : has_smul S R[X] :=
 @[priority 1]  -- to avoid a bug in the `ring` tactic
 instance has_pow : has_pow R[X] ℕ := { pow := λ p n, npow_rec n p }
 
-@[simp] lemma of_finsupp_zero : (⟨0⟩ : R[X]) = 0 :=
-rfl
-
-@[simp] lemma of_finsupp_one : (⟨1⟩ : R[X]) = 1 :=
-begin
-  change (⟨1⟩ : R[X]) = monomial_fun 0 (1 : R),
-  rw [monomial_fun],
-  refl
-end
+@[simp] lemma of_finsupp_zero : (⟨0⟩ : R[X]) = 0 := rfl
+@[simp] lemma of_finsupp_one : (⟨1⟩ : R[X]) = 1 := rfl
 
 @[simp] lemma of_finsupp_add {a b} : (⟨a + b⟩ : R[X]) = ⟨a⟩ + ⟨b⟩ := show _ = add _ _, by rw add
 @[simp] lemma of_finsupp_neg {R : Type u} [ring R] {a} : (⟨-a⟩ : R[X]) = -⟨a⟩ :=
@@ -133,12 +124,7 @@ end
 @[simp] lemma to_finsupp_zero : (0 : R[X]).to_finsupp = 0 :=
 rfl
 
-@[simp] lemma to_finsupp_one : (1 : R[X]).to_finsupp = 1 :=
-begin
-  change to_finsupp (monomial_fun _ _) = _,
-  rw monomial_fun,
-  refl,
-end
+@[simp] lemma to_finsupp_one : (1 : R[X]).to_finsupp = 1 := rfl
 
 @[simp] lemma to_finsupp_add (a b : R[X]) : (a + b).to_finsupp = a.to_finsupp + b.to_finsupp :=
 by { cases a, cases b, rw ←of_finsupp_add }
@@ -242,6 +228,12 @@ lemma to_finsupp_sum {ι : Type*} (s : finset ι) (f : ι → R[X]) :
   (∑ i in s, f i : R[X]).to_finsupp = ∑ i in s, (f i).to_finsupp :=
 map_sum (to_finsupp_iso R) f s
 
+/-- `monomial s a` is the monomial `a * X^s` -/
+def monomial (n : ℕ) : R →ₗ[R] R[X] :=
+{ to_fun := λ t, ⟨finsupp.single n t⟩,
+  map_add' := by simp,
+  map_smul' := by simp [←of_finsupp_smul] }
+
 /--
 The set of all `n` such that `X^n` has a non-zero coefficient.
 -/
@@ -261,19 +253,13 @@ by { rcases p, simp [support] }
 lemma card_support_eq_zero : p.support.card = 0 ↔ p = 0 :=
 by simp
 
-/-- `monomial s a` is the monomial `a * X^s` -/
-def monomial (n : ℕ) : R →ₗ[R] R[X] :=
-{ to_fun := monomial_fun n,
-  map_add' := by simp [monomial_fun],
-  map_smul' := by simp [monomial_fun, ←of_finsupp_smul] }
-
 @[simp] lemma to_finsupp_monomial (n : ℕ) (r : R) :
   (monomial n r).to_finsupp = finsupp.single n r :=
-by simp [monomial, monomial_fun]
+by simp [monomial]
 
 @[simp] lemma of_finsupp_single (n : ℕ) (r : R) :
   (⟨finsupp.single n r⟩ : R[X]) = monomial n r :=
-by simp [monomial, monomial_fun]
+by simp [monomial]
 
 @[simp]
 lemma monomial_zero_right (n : ℕ) :

--- a/src/data/polynomial/basic.lean
+++ b/src/data/polynomial/basic.lean
@@ -774,10 +774,12 @@ variables [ring R]
 
 instance : has_int_cast R[X] := ⟨λ n, of_finsupp n⟩
 
+local attribute [ext] non_assoc_ring
+
 instance : ring R[X] :=
-function.injective.ring to_finsupp to_finsupp_injective
-  to_finsupp_zero to_finsupp_one to_finsupp_add to_finsupp_mul to_finsupp_neg to_finsupp_sub
-  (λ _ _, to_finsupp_smul _ _) (λ _ _, to_finsupp_smul _ _) to_finsupp_pow (λ _, rfl) (λ _, rfl)
+to_finsupp_injective.ring to_finsupp to_finsupp_zero to_finsupp_one to_finsupp_add to_finsupp_mul
+  to_finsupp_neg to_finsupp_sub (λ _ _, to_finsupp_smul _ _) (λ _ _, to_finsupp_smul _ _)
+  to_finsupp_pow (λ _, rfl) (λ _, rfl)
 
 @[simp] lemma coeff_neg (p : R[X]) (n : ℕ) : coeff (-p) n = -coeff p n :=
 by { rcases p, rw [←of_finsupp_neg, coeff, coeff, finsupp.neg_apply] }

--- a/src/data/polynomial/basic.lean
+++ b/src/data/polynomial/basic.lean
@@ -775,9 +775,9 @@ variables [ring R]
 instance : has_int_cast R[X] := ⟨λ n, of_finsupp n⟩
 
 instance : ring R[X] :=
-to_finsupp_injective.ring to_finsupp to_finsupp_zero to_finsupp_one to_finsupp_add to_finsupp_mul
-  to_finsupp_neg to_finsupp_sub (λ _ _, to_finsupp_smul _ _) (λ _ _, to_finsupp_smul _ _)
-  to_finsupp_pow (λ _, rfl) (λ _, rfl)
+function.injective.ring to_finsupp to_finsupp_injective
+  to_finsupp_zero to_finsupp_one to_finsupp_add to_finsupp_mul to_finsupp_neg to_finsupp_sub
+  (λ _ _, to_finsupp_smul _ _) (λ _ _, to_finsupp_smul _ _) to_finsupp_pow (λ _, rfl) (λ _, rfl)
 
 @[simp] lemma coeff_neg (p : R[X]) (n : ℕ) : coeff (-p) n = -coeff p n :=
 by { rcases p, rw [←of_finsupp_neg, coeff, coeff, finsupp.neg_apply] }

--- a/src/data/polynomial/basic.lean
+++ b/src/data/polynomial/basic.lean
@@ -84,7 +84,7 @@ they unfold around `polynomial.of_finsupp` and `polynomial.to_finsupp`.
 section add_monoid_algebra
 
 /-- The function version of `monomial`. Use `monomial` instead of this one. -/
-@[irreducible] def monomial_fun (n : ℕ) (a : R) : R[X] := ⟨finsupp.single n a⟩
+def monomial_fun (n : ℕ) (a : R) : R[X] := ⟨finsupp.single n a⟩
 @[irreducible] private def add : R[X] → R[X] → R[X]
 | ⟨a⟩ ⟨b⟩ := ⟨a + b⟩
 @[irreducible] private def neg {R : Type u} [ring R] : R[X] → R[X]
@@ -308,11 +308,7 @@ to_finsupp_injective $ by simp
 
 lemma monomial_injective (n : ℕ) :
   function.injective (monomial n : R → R[X]) :=
-begin
-  convert (to_finsupp_iso R).symm.injective.comp (single_injective n),
-  ext,
-  simp
-end
+(to_finsupp_iso R).symm.injective.comp (single_injective n)
 
 @[simp] lemma monomial_eq_zero_iff (t : R) (n : ℕ) :
   monomial n t = 0 ↔ t = 0 :=

--- a/src/data/polynomial/basic.lean
+++ b/src/data/polynomial/basic.lean
@@ -774,8 +774,6 @@ variables [ring R]
 
 instance : has_int_cast R[X] := ⟨λ n, of_finsupp n⟩
 
-local attribute [ext] non_assoc_ring
-
 instance : ring R[X] :=
 to_finsupp_injective.ring to_finsupp to_finsupp_zero to_finsupp_one to_finsupp_add to_finsupp_mul
   to_finsupp_neg to_finsupp_sub (λ _ _, to_finsupp_smul _ _) (λ _ _, to_finsupp_smul _ _)

--- a/src/data/polynomial/expand.lean
+++ b/src/data/polynomial/expand.lean
@@ -240,7 +240,7 @@ variable {R}
 
 theorem of_irreducible_expand {p : ℕ} (hp : p ≠ 0) {f : R[X]}
   (hf : irreducible (expand R p f)) : irreducible f :=
-@@of_irreducible_map _ _ _ (is_local_ring_hom_expand R hp.bot_lt) hf
+let _ := is_local_ring_hom_expand R hp.bot_lt in by exactI of_irreducible_map ↑(expand R p) hf
 
 theorem of_irreducible_expand_pow {p : ℕ} (hp : p ≠ 0) {f : R[X]} {n : ℕ} :
   irreducible (expand R (p ^ n) f) → irreducible f :=

--- a/test/instance_diamonds.lean
+++ b/test/instance_diamonds.lean
@@ -170,8 +170,7 @@ example [comm_semiring R] [nontrivial R] :
   polynomial.has_smul_pi' _ _ _ = (polynomial.has_smul_pi _ _ : has_smul R[X] (R → R[X])) :=
 rfl
 
-/-- `polynomial.algebra_of_algebra` was previously blocked from being defeq with `algebra_nat`
-due to the irreduciblity of `polynomial.monomial_fun`. -/
+/-- `polynomial.algebra_of_algebra` is consistent with `algebra_nat`. -/
 example : (polynomial.algebra_of_algebra : algebra ℕ F[X]) = algebra_nat := rfl
 
 end polynomial

--- a/test/instance_diamonds.lean
+++ b/test/instance_diamonds.lean
@@ -171,7 +171,7 @@ example [comm_semiring R] [nontrivial R] :
 rfl
 
 /-- `polynomial.algebra_of_algebra` is consistent with `algebra_nat`. -/
-example [comm_semiring R] : (polynomial.algebra_of_algebra : algebra ℕ R[X]) = algebra_nat := rfl
+example [semiring R] : (polynomial.algebra_of_algebra : algebra ℕ R[X]) = algebra_nat := rfl
 
 /-- `polynomial.algebra_of_algebra` is consistent with `algebra_int`. -/
 example [ring R] : (polynomial.algebra_of_algebra : algebra ℤ R[X]) = algebra_int _ := rfl

--- a/test/instance_diamonds.lean
+++ b/test/instance_diamonds.lean
@@ -173,6 +173,9 @@ rfl
 /-- `polynomial.algebra_of_algebra` is consistent with `algebra_nat`. -/
 example [comm_semiring R] : (polynomial.algebra_of_algebra : algebra ℕ R[X]) = algebra_nat := rfl
 
+/-- `polynomial.algebra_of_algebra` is consistent with `algebra_int`. -/
+example [ring R] : (polynomial.algebra_of_algebra : algebra ℤ R[X]) = algebra_int _ := rfl
+
 end polynomial
 
 /-! ## `subtype` instances -/

--- a/test/instance_diamonds.lean
+++ b/test/instance_diamonds.lean
@@ -170,6 +170,10 @@ example [comm_semiring R] [nontrivial R] :
   polynomial.has_smul_pi' _ _ _ = (polynomial.has_smul_pi _ _ : has_smul R[X] (R → R[X])) :=
 rfl
 
+/-- `polynomial.algebra_of_algebra` was previously blocked from being defeq with `algebra_nat`
+due to the irreduciblity of `polynomial.monomial_fun`. -/
+example : (polynomial.algebra_of_algebra : algebra ℕ F[X]) = algebra_nat := rfl
+
 end polynomial
 
 /-! ## `subtype` instances -/

--- a/test/instance_diamonds.lean
+++ b/test/instance_diamonds.lean
@@ -171,7 +171,10 @@ example [comm_semiring R] [nontrivial R] :
 rfl
 
 /-- `polynomial.algebra_of_algebra` is consistent with `algebra_nat`. -/
-example : (polynomial.algebra_of_algebra : algebra ℕ F[X]) = algebra_nat := rfl
+example [semiring R] : (polynomial.algebra_of_algebra : algebra ℕ R[X]) = algebra_nat := rfl
+
+/-- `polynomial.algebra_of_algebra` is consistent with `algebra_int`. -/
+example [ring R] : (polynomial.algebra_of_algebra : algebra ℤ R[X]) = algebra_int _ := rfl
 
 end polynomial
 


### PR DESCRIPTION
Note that this reshuffles how some instances are created to ensure that they get the `int_cast` field.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

- [x] depends on: #15778

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
