### PR TITLE
[Merged by Bors] - fix(algebra/order/field_defs): move definitions to a separate file

### DIFF
--- a/src/algebra/order/field.lean
+++ b/src/algebra/order/field.lean
@@ -3,12 +3,7 @@ Copyright (c) 2014 Robert Lewis. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Robert Lewis, Leonardo de Moura, Mario Carneiro, Floris van Doorn
 -/
-import algebra.field.basic
-import algebra.group_power.lemmas
-import algebra.group_power.order
-import algebra.order.ring
-import order.bounds
-import tactic.monotonicity.basic
+import algebra.order.field_defs
 
 /-!
 # Linear ordered (semi)fields
@@ -27,18 +22,6 @@ A linear ordered (semi)field is a (semi)field equipped with a linear order such 
 set_option old_structure_cmd true
 
 variables {α β : Type*}
-
-/-- A linear ordered semifield is a field with a linear order respecting the operations. -/
-@[protect_proj] class linear_ordered_semifield (α : Type*)
-  extends linear_ordered_semiring α, semifield α
-
-/-- A linear ordered field is a field with a linear order respecting the operations. -/
-@[protect_proj] class linear_ordered_field (α : Type*) extends linear_ordered_comm_ring α, field α
-
-@[priority 100] -- See note [lower instance priority]
-instance linear_ordered_field.to_linear_ordered_semifield [linear_ordered_field α] :
-  linear_ordered_semifield α :=
-{ ..linear_ordered_ring.to_linear_ordered_semiring, ..‹linear_ordered_field α› }
 
 namespace function
 

--- a/src/algebra/order/field_defs.lean
+++ b/src/algebra/order/field_defs.lean
@@ -1,0 +1,45 @@
+/-
+Copyright (c) 2014 Robert Lewis. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Robert Lewis, Leonardo de Moura, Mario Carneiro, Floris van Doorn
+-/
+import algebra.field.basic
+import algebra.group_power.lemmas
+import algebra.group_power.order
+import algebra.order.ring
+import order.bounds
+import tactic.monotonicity.basic
+
+/-!
+# Linear ordered (semi)fields
+
+A linear ordered (semi)field is a (semi)field equipped with a linear order such that
+* addition respects the order: `a ≤ b → c + a ≤ c + b`;
+* multiplication of positives is positive: `0 < a → 0 < b → 0 < a * b`;
+* `0 < 1`.
+
+## Main Definitions
+
+* `linear_ordered_semifield`: Typeclass for linear order semifields.
+* `linear_ordered_field`: Typeclass for linear ordered fields.
+
+## Implementation details
+
+For olean caching reasons, this file is separate to the main file, algebra.order.field.
+The lemmata are instead located there.
+
+-/
+
+set_option old_structure_cmd true
+
+/-- A linear ordered semifield is a field with a linear order respecting the operations. -/
+@[protect_proj] class linear_ordered_semifield (α : Type*)
+  extends linear_ordered_semiring α, semifield α
+
+/-- A linear ordered field is a field with a linear order respecting the operations. -/
+@[protect_proj] class linear_ordered_field (α : Type*) extends linear_ordered_comm_ring α, field α
+
+@[priority 100] -- See note [lower instance priority]
+instance linear_ordered_field.to_linear_ordered_semifield {α} [linear_ordered_field α] :
+  linear_ordered_semifield α :=
+{ ..linear_ordered_ring.to_linear_ordered_semiring, ..‹linear_ordered_field α› }


### PR DESCRIPTION
Considering the "saving olean" bug, this will provide a stopgap to at least make compilation times be smaller.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
