### PR TITLE
[Merged by Bors] - chore(.github/workflows): increase olean generation timeout

### DIFF
--- a/.github/workflows/bors.yml
+++ b/.github/workflows/bors.yml
@@ -82,7 +82,7 @@ jobs:
           leanpkg configure
           echo "::set-output name=started::true"
           lean --json -T150000 --make src | python3 scripts/detect_errors.py
-          lean --json -T150000 --make src | python3 scripts/detect_errors.py
+          lean --json -T400000 --make src | python3 scripts/detect_errors.py
 
       - name: push release to azure
         if: always() && github.repository == 'leanprover-community/mathlib' && steps.build.outputs.started == 'true'

--- a/.github/workflows/bors.yml
+++ b/.github/workflows/bors.yml
@@ -82,7 +82,7 @@ jobs:
           leanpkg configure
           echo "::set-output name=started::true"
           lean --json -T150000 --make src | python3 scripts/detect_errors.py
-          lean --json -T400000 --make src | python3 scripts/detect_errors.py
+          lean --json --make src | python3 scripts/detect_errors.py
 
       - name: push release to azure
         if: always() && github.repository == 'leanprover-community/mathlib' && steps.build.outputs.started == 'true'

--- a/.github/workflows/bors.yml
+++ b/.github/workflows/bors.yml
@@ -82,7 +82,7 @@ jobs:
           leanpkg configure
           echo "::set-output name=started::true"
           lean --json -T150000 --make src | python3 scripts/detect_errors.py
-          lean --json --make src | python3 scripts/detect_errors.py
+          lean --json -T400000 --make src | python3 scripts/detect_errors.py
 
       - name: push release to azure
         if: always() && github.repository == 'leanprover-community/mathlib' && steps.build.outputs.started == 'true'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -90,7 +90,7 @@ jobs:
           leanpkg configure
           echo "::set-output name=started::true"
           lean --json -T150000 --make src | python3 scripts/detect_errors.py
-          lean --json -T400000 --make src | python3 scripts/detect_errors.py
+          lean --json --make src | python3 scripts/detect_errors.py
 
       - name: push release to azure
         if: always() && github.repository == 'leanprover-community/mathlib' && steps.build.outputs.started == 'true'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -90,7 +90,7 @@ jobs:
           leanpkg configure
           echo "::set-output name=started::true"
           lean --json -T150000 --make src | python3 scripts/detect_errors.py
-          lean --json -T150000 --make src | python3 scripts/detect_errors.py
+          lean --json -T400000 --make src | python3 scripts/detect_errors.py
 
       - name: push release to azure
         if: always() && github.repository == 'leanprover-community/mathlib' && steps.build.outputs.started == 'true'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -90,7 +90,7 @@ jobs:
           leanpkg configure
           echo "::set-output name=started::true"
           lean --json -T150000 --make src | python3 scripts/detect_errors.py
-          lean --json --make src | python3 scripts/detect_errors.py
+          lean --json -T400000 --make src | python3 scripts/detect_errors.py
 
       - name: push release to azure
         if: always() && github.repository == 'leanprover-community/mathlib' && steps.build.outputs.started == 'true'

--- a/.github/workflows/build.yml.in
+++ b/.github/workflows/build.yml.in
@@ -68,7 +68,7 @@ jobs:
           leanpkg configure
           echo "::set-output name=started::true"
           lean --json -T150000 --make src | python3 scripts/detect_errors.py
-          lean --json -T150000 --make src | python3 scripts/detect_errors.py
+          lean --json -T400000 --make src | python3 scripts/detect_errors.py
 
       - name: push release to azure
         if: always() && github.repository == 'leanprover-community/mathlib' && steps.build.outputs.started == 'true'

--- a/.github/workflows/build.yml.in
+++ b/.github/workflows/build.yml.in
@@ -68,7 +68,7 @@ jobs:
           leanpkg configure
           echo "::set-output name=started::true"
           lean --json -T150000 --make src | python3 scripts/detect_errors.py
-          lean --json --make src | python3 scripts/detect_errors.py
+          lean --json -T400000 --make src | python3 scripts/detect_errors.py
 
       - name: push release to azure
         if: always() && github.repository == 'leanprover-community/mathlib' && steps.build.outputs.started == 'true'

--- a/.github/workflows/build.yml.in
+++ b/.github/workflows/build.yml.in
@@ -68,7 +68,7 @@ jobs:
           leanpkg configure
           echo "::set-output name=started::true"
           lean --json -T150000 --make src | python3 scripts/detect_errors.py
-          lean --json -T400000 --make src | python3 scripts/detect_errors.py
+          lean --json --make src | python3 scripts/detect_errors.py
 
       - name: push release to azure
         if: always() && github.repository == 'leanprover-community/mathlib' && steps.build.outputs.started == 'true'

--- a/.github/workflows/build_fork.yml
+++ b/.github/workflows/build_fork.yml
@@ -88,7 +88,7 @@ jobs:
           leanpkg configure
           echo "::set-output name=started::true"
           lean --json -T150000 --make src | python3 scripts/detect_errors.py
-          lean --json -T490000 --make src | python3 scripts/detect_errors.py
+          lean --json --make src | python3 scripts/detect_errors.py
 
       - name: push release to azure
         if: always() && github.repository == 'leanprover-community/mathlib' && steps.build.outputs.started == 'true'

--- a/.github/workflows/build_fork.yml
+++ b/.github/workflows/build_fork.yml
@@ -88,7 +88,7 @@ jobs:
           leanpkg configure
           echo "::set-output name=started::true"
           lean --json -T150000 --make src | python3 scripts/detect_errors.py
-          lean --json --make src | python3 scripts/detect_errors.py
+          lean --json -T400000 --make src | python3 scripts/detect_errors.py
 
       - name: push release to azure
         if: always() && github.repository == 'leanprover-community/mathlib' && steps.build.outputs.started == 'true'

--- a/.github/workflows/build_fork.yml
+++ b/.github/workflows/build_fork.yml
@@ -88,7 +88,7 @@ jobs:
           leanpkg configure
           echo "::set-output name=started::true"
           lean --json -T150000 --make src | python3 scripts/detect_errors.py
-          lean --json -T150000 --make src | python3 scripts/detect_errors.py
+          lean --json -T490000 --make src | python3 scripts/detect_errors.py
 
       - name: push release to azure
         if: always() && github.repository == 'leanprover-community/mathlib' && steps.build.outputs.started == 'true'


### PR DESCRIPTION
We are currently experiencing timeouts when saving some oleans (leanprover-community/lean#749). Since Lean does not error out when deterministic timeouts happen during olean generation (leanprover-community/lean#750) and we already run Lean twice when compiling mathlib, Ben Toner suggested the following clever hack: Increase the timeout, but only on the second lean run. This effectively means anything that was reported as a timeout before is still reported as a timeout (by the first call), while olean generation gets more heartbeats.

Co-authored-by: Ben Toner <bentoner@bentoner.com>

---

Note: I have not verified that deterministic timeouts in the first Lean run stop CI, but this should be the case.

The motivation for this is https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/.22saving.20olean.22.3F

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
