### PR TITLE
feat(topology/algebra/infinite_sum): has_sum.shift_tsub

### DIFF
--- a/src/topology/algebra/infinite_sum.lean
+++ b/src/topology/algebra/infinite_sum.lean
@@ -837,6 +837,52 @@ begin
     { apply_instance } }
 end
 
+/-- If a sequence `ℕ → α` has a sum at `x : α`, then so does an extension of it,
+inserting a zero term at the beginning. -/
+lemma has_sum.shift_pred {f : ℕ → α} {x : α} (h : has_sum f x) :
+  has_sum (λ n, if n = 0 then 0 else f (n - 1)) x :=
+begin
+  rw has_sum at h ⊢,
+  rw tendsto_nhds at h ⊢,
+  simp only [filter.mem_at_top_sets, ge_iff_le, finset.le_eq_subset, set.mem_preimage] at h ⊢,
+  intros s hs hx,
+  obtain ⟨u, hu⟩ := h s hs hx,
+  refine ⟨u.image nat.succ, λ v hv, _⟩,
+  specialize hu ((v.erase 0).image nat.pred ) _,
+  { intros i hi,
+    rw finset.mem_image,
+    refine ⟨i.succ, _, nat.pred_succ _⟩,
+    simp only [finset.mem_erase, ne.def, nat.succ_ne_zero, not_false_iff, true_and],
+    refine hv _,
+    simpa using hi },
+  convert hu using 1,
+  refine finset.sum_bij_ne_zero (λ i _ _, i.pred) _ _ _ _,
+  { intros i hi hi',
+    simp only [finset.mem_image, finset.mem_erase, ne.def, exists_prop, ite_eq_left_iff,
+               not_forall] at hi' ⊢,
+    exact ⟨i, ⟨hi'.left, hi⟩, rfl⟩ },
+  { simp only [ne.def, ite_eq_left_iff, not_forall, exists_prop, and_imp],
+    intros,
+    exact nat.pred_inj (nat.pos_of_ne_zero ‹_›) (nat.pos_of_ne_zero ‹_›) ‹_› },
+  { simp only [finset.mem_image, finset.mem_erase, ne.def, exists_prop, ite_eq_left_iff, not_forall,
+               forall_exists_index, and_imp],
+    rintro b x hx hv rfl hf,
+    exact ⟨_, hv, ⟨hx, hf⟩, rfl⟩ },
+  { simp [nat.pred_eq_sub_one] { contextual := tt } }
+end
+
+/-- If a sequence `ℕ → α` has a sum at `x : α`, then so does an extension of it,
+inserting `k` zero terms at the beginning. -/
+lemma has_sum.shift_tsub {f : ℕ → α} {x : α} (h : has_sum f x) (k : ℕ) :
+  has_sum (λ n, if n < k then 0 else f (n - k)) x :=
+begin
+  induction k with k IH,
+  { simpa using h },
+  convert IH.shift_pred,
+  ext (_|_);
+  simp [nat.succ_lt_succ_iff]
+end
+
 /-- If `f₀, f₁, f₂, ...` and `g₀, g₁, g₂, ...` are both convergent then so is the `ℤ`-indexed
 sequence: `..., g₂, g₁, g₀, f₀, f₁, f₂, ...`. -/
 lemma has_sum.int_rec {b : α} {f g : ℕ → α} (hf : has_sum f a) (hg : has_sum g b) :

--- a/src/topology/algebra/infinite_sum.lean
+++ b/src/topology/algebra/infinite_sum.lean
@@ -839,7 +839,8 @@ end
 
 /-- If a sequence `ℕ → α` has a sum at `x : α`, then so does an extension of it,
 inserting a zero term at the beginning. -/
-lemma has_sum.shift_pred {f : ℕ → α} {x : α} (h : has_sum f x) :
+lemma has_sum.shift_pred {α : Type*} [add_comm_monoid α] [topological_space α]
+  {f : ℕ → α} {x : α} (h : has_sum f x) :
   has_sum (λ n, if n = 0 then 0 else f (n - 1)) x :=
 begin
   rw has_sum at h ⊢,
@@ -873,7 +874,8 @@ end
 
 /-- If a sequence `ℕ → α` has a sum at `x : α`, then so does an extension of it,
 inserting `k` zero terms at the beginning. -/
-lemma has_sum.shift_tsub {f : ℕ → α} {x : α} (h : has_sum f x) (k : ℕ) :
+lemma has_sum.shift_tsub {α : Type*} [add_comm_monoid α] [topological_space α]
+  {f : ℕ → α} {x : α} (h : has_sum f x) (k : ℕ) :
   has_sum (λ n, if n < k then 0 else f (n - k)) x :=
 begin
   induction k with k IH,

--- a/src/topology/algebra/infinite_sum.lean
+++ b/src/topology/algebra/infinite_sum.lean
@@ -885,6 +885,35 @@ begin
   simp [nat.succ_lt_succ_iff]
 end
 
+/-- If a sequence `ℕ → α` has a sum at `x : α`, then so does an extension of it,
+inserting `a : α` at the beginning. -/
+lemma has_sum.shift_pred_add {α : Type*} [add_comm_monoid α] [topological_space α]
+  [has_continuous_add α] {f : ℕ → α} {x : α} (h : has_sum f x) (y : α) :
+  has_sum (λ n, if n = 0 then y else f (n - 1)) (y + x) :=
+begin
+  set g : ℕ → α := pi.single 0 y with hg,
+  have hsplit : (λ (n : ℕ), ite (n = 0) y (f (n - 1))) = g + (λ (n : ℕ), ite (n = 0) 0 (f (n - 1))),
+  { ext (_|_);
+    simp [hg] },
+  rw hsplit,
+  suffices : has_sum g y,
+  { exact this.add h.shift_pred },
+  have : y = g 0 := by simp [hg],
+  rw this,
+  refine has_sum_single _ _,
+  simp [hg, pi.single_apply] { contextual := tt }
+end
+
+/-- If `f₀, f₁, f₂, ...` is convergent then so is the `ℕ`-indexed sequence: `y, f₀, f₁, f₂, ...`. -/
+lemma has_sum.nat_rec {α : Type*} [add_comm_monoid α] [topological_space α]
+  [has_continuous_add α] {f : ℕ → α} {x : α} (h : has_sum f x) (y : α) :
+  @has_sum α _ _ _ (@nat.rec (λ _, α) y (λ i _, f i) : ℕ → α) (y + x) :=
+begin
+  convert h.shift_pred_add y,
+  ext (_|_);
+  simp
+end
+
 /-- If `f₀, f₁, f₂, ...` and `g₀, g₁, g₂, ...` are both convergent then so is the `ℤ`-indexed
 sequence: `..., g₂, g₁, g₀, f₀, f₁, f₂, ...`. -/
 lemma has_sum.int_rec {b : α} {f g : ℕ → α} (hf : has_sum f a) (hg : has_sum g b) :


### PR DESCRIPTION
If a sequence `ℕ → α` has a sum at `x : α`, then so does an extension of it,
inserting `k` zero terms at the beginning.



---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
