### PR TITLE
Uniform limits of holomorphic functions

### DIFF
--- a/src/analysis/calculus/uniform_limits_deriv.lean
+++ b/src/analysis/calculus/uniform_limits_deriv.lean
@@ -1,0 +1,614 @@
+/-
+Copyright (c) 2022 Kevin H. Wilson. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kevin H. Wilson
+-/
+import analysis.calculus.mean_value
+import analysis.normed_space.is_R_or_C
+
+/-!
+# Swapping limits and derivatives via uniform convergence
+
+The purpose of this file is to prove that the derivative of the pointwise limit of a sequence of
+functions is the pointwise limit of the functions' derivatives when the derivatives converge
+_uniformly_. The formal statement appears as `has_fderiv_at_of_tendsto_locally_uniformly_at`.
+
+## Main statements
+
+* `uniform_cauchy_seq_on_filter_of_tendsto_uniformly_on_filter_fderiv`: If
+    1. `f : ℕ → E → G` is a sequence of functions which have derivatives
+       `f' : ℕ → (E → (E →L[𝕜] G))` on a neighborhood of `x`,
+    2.the `f` converge at `x`, and
+    3. the `f'` converge uniformly on a neighborhood of `x`,
+  then the `f` converge _uniformly_ on a neighborhood of `x`
+* `has_fderiv_at_of_tendsto_uniformly_on_filter` : Suppose (1), (2), and (3) above are true. Let
+  `g` (resp. `g'`) be the limiting function of the `f` (resp. `g'`). Then `g'` is the derivative of
+  `g` on a neighborhood of `x`
+* `has_fderiv_at_of_tendsto_uniformly_on`: An often-easier-to-use version of the above theorem when
+  all *all* the derivatives exist and functions converge on a common open set and the derivatives
+  converge uniformly there.
+
+Each of the above statements also has variations that support `deriv` instead of `fderiv`.
+
+## Implementation notes
+
+Our technique for proving the main result is the famous "`ε / 3` proof." In words, you can find it
+explained, for instance, at [this StackExchange post](https://math.stackexchange.com/questions/214218/uniform-convergence-of-derivatives-tao-14-2-7).
+The subtlety is that we want to prove that the difference quotients of the `g` converge to the `g'`.
+That is, we want to prove something like:
+
+```
+∀ ε > 0, ∃ δ > 0, ∀ y ∈ B_δ(x), |y - x|⁻¹ * |(g y - g x) - g' x (y - x)| < ε.
+```
+
+To do so, we will need to introduce a pair of quantifers
+
+```lean
+∀ ε > 0, ∃ N, ∀ n ≥ N, ∃ δ > 0, ∀ y ∈ B_δ(x), |y - x|⁻¹ * |(g y - g x) - g' x (y - x)| < ε.
+```
+
+So how do we write this in terms of filters? Well, the initial definition of the derivative is
+
+```lean
+tendsto (|y - x|⁻¹ * |(g y - g x) - g' x (y - x)|) (𝓝 x) (𝓝 0)
+```
+
+There are two ways we might introduce `n`. We could do:
+
+```lean
+∀ᶠ (n : ℕ) in at_top, tendsto (|y - x|⁻¹ * |(g y - g x) - g' x (y - x)|) (𝓝 x) (𝓝 0)
+```
+
+but this is equivalent to the quantifier order `∃ N, ∀ n ≥ N, ∀ ε > 0, ∃ δ > 0, ∀ y ∈ B_δ(x)`,
+which _implies_ our desired `∀ ∃ ∀ ∃ ∀` but is _not_ equivalent to it. On the other hand, we might
+try
+
+```lean
+tendsto (|y - x|⁻¹ * |(g y - g x) - g' x (y - x)|) (at_top ×ᶠ 𝓝 x) (𝓝 0)
+```
+
+but this is equivalent to the quantifer order `∀ ε > 0, ∃ N, ∃ δ > 0, ∀ n ≥ N, ∀ y ∈ B_δ(x)`, which
+again _implies_ our desired `∀ ∃ ∀ ∃ ∀` but is not equivalent to it.
+
+So to get the quantifier order we want, we need to introduce a new filter construction, which we
+call a "curried filter"
+
+```lean
+tendsto (|y - x|⁻¹ * |(g y - g x) - g' x (y - x)|) (at_top.curry (𝓝 x)) (𝓝 0)
+```
+
+Then the above implications are `filter.tendsto.curry` and
+`filter.tendsto.mono_left filter.curry_le_prod`. We will use both of these deductions as part of
+our proof.
+
+We note that if you loosen the assumptions of the main theorem then the proof becomes quite a bit
+easier. In particular, if you assume there is a common neighborhood `s` where all of the three
+assumptions of `has_fderiv_at_of_tendsto_uniformly_on_filter` hold and that the `f'` are
+continuous, then you can avoid the mean value theorem and much of the work around curried fitlers.
+
+## Tags
+
+uniform convergence, limits of derivatives
+-/
+
+section filter_curry
+
+variables {α β γ : Type*}
+
+/-- This filter is characterized by `filter.eventually_curry_iff`:
+`(∀ᶠ (x : α × β) in f.curry g, p x) ↔ ∀ᶠ (x : α) in f, ∀ᶠ (y : β) in g, p (x, y)`. Useful
+in adding quantifiers to the middle of `tendsto`s. See
+`has_fderiv_at_of_tendsto_uniformly_on_filter`. -/
+def filter.curry (f : filter α) (g : filter β) : filter (α × β) :=
+{ sets := { s | ∀ᶠ (a : α) in f, ∀ᶠ (b : β) in g, (a, b) ∈ s },
+  univ_sets := (by simp only [set.mem_set_of_eq, set.mem_univ, filter.eventually_true]),
+  sets_of_superset := begin
+    intros x y hx hxy,
+    simp only [set.mem_set_of_eq] at hx ⊢,
+    exact hx.mono (λ a ha, ha.mono(λ b hb, set.mem_of_subset_of_mem hxy hb)),
+  end,
+  inter_sets := begin
+    intros x y hx hy,
+    simp only [set.mem_set_of_eq, set.mem_inter_eq] at hx hy ⊢,
+    exact (hx.and hy).mono (λ a ha, (ha.1.and ha.2).mono (λ b hb, hb)),
+  end, }
+
+lemma filter.eventually_curry_iff {f : filter α} {g : filter β} {p : α × β → Prop} :
+  (∀ᶠ (x : α × β) in f.curry g, p x) ↔ ∀ᶠ (x : α) in f, ∀ᶠ (y : β) in g, p (x, y) :=
+begin
+  simp only [filter.curry],
+  rw filter.eventually_iff,
+  simp only [filter.mem_mk, set.mem_set_of_eq],
+end
+
+lemma filter.curry_le_prod {f : filter α} {g : filter β} :
+  f.curry g ≤ f.prod g :=
+begin
+  intros u hu,
+  rw ←filter.eventually_mem_set at hu ⊢,
+  rw filter.eventually_curry_iff,
+  exact hu.curry,
+end
+
+lemma filter.tendsto.curry {f : α → β → γ} {la : filter α} {lb : filter β} {lc : filter γ} :
+  (∀ᶠ a in la, filter.tendsto (λ b : β, f a b) lb lc) → filter.tendsto ↿f (la.curry lb) lc :=
+begin
+  intros h,
+  rw filter.tendsto_def,
+  simp only [filter.curry, filter.mem_mk, set.mem_set_of_eq, set.mem_preimage],
+  simp_rw filter.tendsto_def at h,
+  refine (λ s hs, h.mono (λ a ha, filter.eventually_iff.mpr _)),
+  simpa [function.has_uncurry.uncurry, set.preimage] using ha s hs,
+end
+
+end filter_curry
+
+open filter
+open_locale uniformity filter topological_space
+
+section limits_of_derivatives
+
+variables {ι : Type*} {l : filter ι} [ne_bot l]
+  {E : Type*} [normed_add_comm_group E] [normed_space ℝ E]
+  {𝕜 : Type*} [is_R_or_C 𝕜] [normed_space 𝕜 E]
+  {G : Type*} [normed_add_comm_group G] [normed_space 𝕜 G]
+  {f : ι → E → G} {g : E → G} {f' : ι → (E → (E →L[𝕜] G))} {g' : E → (E →L[𝕜] G)}
+  {x : E}
+
+/-- If a sequence of functions real or complex functions are eventually differentiable on a
+neighborhood of `x`, they converge pointwise _at_ `x`, and their derivatives
+converge uniformly in a neighborhood of `x`, then the functions form a uniform Cauchy sequence
+in a neighborhood of `x`. -/
+lemma uniform_cauchy_seq_on_filter_of_tendsto_uniformly_on_filter_fderiv
+  (hf : ∀ᶠ (n : ι × E) in (l ×ᶠ 𝓝 x), has_fderiv_at (f n.fst) (f' n.fst n.snd) n.snd)
+  (hfg : tendsto (λ n, f n x) l (𝓝 (g x)))
+  (hfg' : uniform_cauchy_seq_on_filter f' l (𝓝 x)) :
+  uniform_cauchy_seq_on_filter f l (𝓝 x) :=
+begin
+  rw normed_add_comm_group.uniform_cauchy_seq_on_filter_iff_tendsto_uniformly_on_filter_zero at hfg' ⊢,
+
+  suffices : tendsto_uniformly_on_filter
+    (λ (n : ι × ι) (z : E), f n.fst z - f n.snd z - (f n.fst x - f n.snd x)) 0 (l ×ᶠ l) (𝓝 x) ∧
+    tendsto_uniformly_on_filter (λ (n : ι × ι) (z : E), f n.fst x - f n.snd x) 0 (l ×ᶠ l) (𝓝 x),
+  { have := this.1.add this.2,
+    rw add_zero at this,
+    exact this.congr (by simp), },
+  split,
+  { -- This inequality follows from the mean value theorem. To apply it, we will need to shrink our
+    -- neighborhood to small enough ball
+    rw metric.tendsto_uniformly_on_filter_iff at hfg' ⊢,
+    intros ε hε,
+    have := (tendsto_swap4_prod.eventually (hf.prod_mk hf)).diag_of_prod_right,
+    obtain ⟨a, b, c, d, e⟩ := eventually_prod_iff.1 ((hfg' ε hε).and this),
+    obtain ⟨R, hR, hR'⟩ := metric.nhds_basis_ball.eventually_iff.mp d,
+    let r := min 1 R,
+    have hr : 0 < r, { simp [hR], },
+    have hr' : ∀ ⦃y : E⦄, y ∈ metric.ball x r → c y,
+    { exact (λ y hy, hR' (lt_of_lt_of_le (metric.mem_ball.mp hy) (min_le_right _ _))), },
+    have hxy : ∀ (y : E), y ∈ metric.ball x r → ∥y - x∥ < 1,
+    { intros y hy,
+      rw [metric.mem_ball, dist_eq_norm] at hy,
+      exact lt_of_lt_of_le hy (min_le_left _ _), },
+    have hxyε : ∀ (y : E), y ∈ metric.ball x r → ε * ∥y - x∥ < ε,
+    { intros y hy,
+      exact (mul_lt_iff_lt_one_right hε.lt).mpr (hxy y hy), },
+
+    -- With a small ball in hand, apply the mean value theorem
+    refine eventually_prod_iff.mpr ⟨_, b, (λ e : E, metric.ball x r e),
+      eventually_mem_set.mpr (metric.nhds_basis_ball.mem_of_mem hr), (λ n hn y hy, _)⟩,
+    simp only [pi.zero_apply, dist_zero_left] at e ⊢,
+    refine lt_of_le_of_lt _ (hxyε y hy),
+    exact convex.norm_image_sub_le_of_norm_has_fderiv_within_le
+      (λ y hy, ((e hn (hr' hy)).2.1.sub (e hn (hr' hy)).2.2).has_fderiv_within_at)
+      (λ y hy, (e hn (hr' hy)).1.le)
+      (convex_ball x r) (metric.mem_ball_self hr) hy, },
+  { -- This is just `hfg` run through `eventually_prod_iff`
+    refine metric.tendsto_uniformly_on_filter_iff.mpr (λ ε hε, _),
+    obtain ⟨t, ht, ht'⟩ := (metric.cauchy_iff.mp hfg.cauchy_map).2 ε hε,
+    exact eventually_prod_iff.mpr
+    ⟨ (λ (n : ι × ι), (f n.fst x ∈ t) ∧ (f n.snd x ∈ t)),
+      eventually_prod_iff.mpr ⟨_, ht, _, ht, (λ n hn n' hn', ⟨hn, hn'⟩)⟩,
+      (λ y, true),
+      (by simp),
+      (λ n hn y hy, by simpa [norm_sub_rev, dist_eq_norm] using ht' _ hn.1 _ hn.2)⟩, },
+end
+
+/-- A variant of the second fundamental theorem of calculus (FTC-2): If a sequence of functions
+real or complex functions are differentiable on a ball centered at `x`, they
+converge pointwise _at_ `x`, and their derivatives converge uniformly on the ball, then the
+functions form a uniform Cauchy sequence on the ball.
+
+NOTE: The fact that we work on a ball is typically all that is necessary to work with power series
+and Dirichlet series (our primary use case). However, this can be generalized by replacing the ball
+with any connected, bounded, open set and replacing uniform convergence with local uniform
+convergence.
+-/
+lemma uniform_cauchy_seq_on_ball_of_tendsto_uniformly_on_ball_fderiv
+  {r : ℝ} (hr : 0 < r)
+  (hf : ∀ n : ι, ∀ y : E, y ∈ metric.ball x r → has_fderiv_at (f n) (f' n y) y)
+  (hfg : tendsto (λ n, f n x) l (𝓝 (g x)))
+  (hfg' : uniform_cauchy_seq_on f' l (metric.ball x r)) :
+  uniform_cauchy_seq_on f l (metric.ball x r) :=
+begin
+  rw normed_add_comm_group.uniform_cauchy_seq_on_iff_tendsto_uniformly_on_zero at hfg' ⊢,
+
+  suffices : tendsto_uniformly_on
+    (λ (n : ι × ι) (z : E), f n.fst z - f n.snd z - (f n.fst x - f n.snd x)) 0 (l ×ᶠ l) (metric.ball x r) ∧
+    tendsto_uniformly_on (λ (n : ι × ι) (z : E), f n.fst x - f n.snd x) 0 (l ×ᶠ l) (metric.ball x r),
+  { have := this.1.add this.2,
+    rw add_zero at this,
+    refine this.congr _,
+    apply eventually_of_forall,
+    intros n z hz,
+    simp, },
+  split,
+  { -- This inequality follows from the mean value theorem
+    rw metric.tendsto_uniformly_on_iff at hfg' ⊢,
+    intros ε hε,
+    obtain ⟨q, hqpos, hq⟩ : ∃ q : ℝ, 0 < q ∧ q * r < ε,
+    { simp_rw mul_comm,
+      exact exists_pos_mul_lt hε.lt r, },
+    apply (hfg' q hqpos.gt).mono,
+    intros n hn y hy,
+    simp_rw [dist_eq_norm, pi.zero_apply, zero_sub, norm_neg] at hn ⊢,
+    have mvt := convex.norm_image_sub_le_of_norm_has_fderiv_within_le
+      (λ z hz, ((hf n.fst z hz).sub (hf n.snd z hz)).has_fderiv_within_at)
+      (λ z hz, (hn z hz).le) (convex_ball x r) (metric.mem_ball_self hr) hy,
+    refine lt_of_le_of_lt mvt _,
+    have : q * ∥y - x∥ < q * r,
+    { exact mul_lt_mul' rfl.le (by simpa only [dist_eq_norm] using metric.mem_ball.mp hy)
+        (norm_nonneg _) hqpos, },
+    exact this.trans hq, },
+  { -- This is just `hfg` run through `eventually_prod_iff`
+    refine metric.tendsto_uniformly_on_iff.mpr (λ ε hε, _),
+    obtain ⟨t, ht, ht'⟩ := (metric.cauchy_iff.mp hfg.cauchy_map).2 ε hε,
+    rw eventually_prod_iff,
+    refine ⟨(λ n, f n x ∈ t), ht, (λ n, f n x ∈ t), ht, _⟩,
+    intros n hn n' hn' z hz,
+    rw [dist_eq_norm, pi.zero_apply, zero_sub, norm_neg, ←dist_eq_norm],
+    exact (ht' _ hn _ hn'), },
+end
+
+/-- If `f_n → g` pointwise and the derivatives `(f_n)' → h` _uniformly_ converge, then
+in fact for a fixed `y`, the difference quotients `∥z - y∥⁻¹ • (f_n z - f_n y)` converge
+_uniformly_ to `∥z - y∥⁻¹ • (g z - g y)` -/
+lemma difference_quotients_converge_uniformly
+  (hf : ∀ᶠ (n : ι × E) in (l ×ᶠ 𝓝 x), has_fderiv_at (f n.fst) (f' n.fst n.snd) n.snd)
+  (hfg : ∀ᶠ (y : E) in 𝓝 x, tendsto (λ n, f n y) l (𝓝 (g y)))
+  (hfg' : tendsto_uniformly_on_filter f' g' l (𝓝 x)) :
+  tendsto_uniformly_on_filter
+    (λ n : ι, λ y : E, (∥y - x∥⁻¹ : 𝕜) • (f n y - f n x))
+    (λ y : E, (∥y - x∥⁻¹ : 𝕜) • (g y - g x))
+    l (𝓝 x) :=
+begin
+  refine uniform_cauchy_seq_on_filter.tendsto_uniformly_on_filter_of_tendsto _
+    ((hfg.and (eventually_const.mpr hfg.self_of_nhds)).mono (λ y hy, (hy.1.sub hy.2).const_smul _)),
+  rw normed_add_comm_group.uniform_cauchy_seq_on_filter_iff_tendsto_uniformly_on_filter_zero,
+  rw metric.tendsto_uniformly_on_filter_iff,
+
+  have hfg'' := hfg'.uniform_cauchy_seq_on_filter,
+  rw normed_add_comm_group.uniform_cauchy_seq_on_filter_iff_tendsto_uniformly_on_filter_zero at hfg'',
+  rw metric.tendsto_uniformly_on_filter_iff at hfg'',
+  intros ε hε,
+  obtain ⟨q, hqpos, hqε⟩ := exists_pos_rat_lt hε,
+  specialize hfg'' (q : ℝ) (by simp [hqpos]),
+
+  have := (tendsto_swap4_prod.eventually (hf.prod_mk hf)).diag_of_prod_right,
+  obtain ⟨a, b, c, d, e⟩ := eventually_prod_iff.1 (hfg''.and this),
+  obtain ⟨r, hr, hr'⟩ := metric.nhds_basis_ball.eventually_iff.mp d,
+
+  rw eventually_prod_iff,
+  refine ⟨_, b, (λ e : E, metric.ball x r e),
+    eventually_mem_set.mpr (metric.nhds_basis_ball.mem_of_mem hr), (λ n hn y hy, _)⟩,
+  simp only [pi.zero_apply, dist_zero_left],
+  rw [← smul_sub, norm_smul, norm_inv, is_R_or_C.norm_coe_norm],
+  refine lt_of_le_of_lt _ hqε,
+  by_cases hyz' : x = y, { simp [hyz', hqpos.le], },
+  have hyz : 0 < ∥y - x∥,
+  {rw norm_pos_iff, intros hy', exact hyz' (eq_of_sub_eq_zero hy').symm, },
+  rw [inv_mul_le_iff hyz, mul_comm],
+  have : ∀ a b c d : G, a - b - (c - d) = a - c - (b - d),
+  { intros a b c d,
+    rw [←sub_add, ←sub_add, sub_sub, sub_sub],
+    conv { congr, congr, congr, skip, rw add_comm, }, },
+  rw this,
+  simp only [pi.zero_apply, dist_zero_left] at e,
+  refine convex.norm_image_sub_le_of_norm_has_fderiv_within_le
+    (λ y hy, ((e hn (hr' hy)).2.1.sub (e hn (hr' hy)).2.2).has_fderiv_within_at)
+    (λ y hy, (e hn (hr' hy)).1.le)
+    (convex_ball x r) (metric.mem_ball_self hr) hy,
+end
+
+/-- `(d/dx) lim_{n → ∞} f n x = lim_{n → ∞} f' n x` when the `f' n` converge
+_uniformly_ to their limit at `x`.
+
+In words the assumptions mean the following:
+  * `hf`: There is a neighborhood of `x` such that for all sufficiently large `n`, `f' n` is the
+    derivative of `f n` **and** for all sufficiently large `N`, there is a neighborhood of `x`
+    such that for all `n ≥ N`, `f' n` is the derivative of `f n`
+  * `hfg`: The `f n` converge pointwise to `g` on a neighborhood of `x`
+  * `hfg'`: The `f'` converge "uniformly at" `x` to `g'`. This does not mean that the `f' n` even
+    converge away from `x`! --/
+lemma has_fderiv_at_of_tendsto_uniformly_on_filter
+  (hf : ∀ᶠ (n : ι × E) in (l ×ᶠ 𝓝 x), has_fderiv_at (f n.fst) (f' n.fst n.snd) n.snd)
+  (hfg : ∀ᶠ y in 𝓝 x, tendsto (λ n, f n y) l (𝓝 (g y)))
+  (hfg' : tendsto_uniformly_on_filter f' g' l (𝓝 x)) :
+  has_fderiv_at g (g' x) x :=
+begin
+  -- The proof strategy follows several steps:
+  --   1. The quantifiers in the definition of the derivative are
+  --      `∀ ε > 0, ∃δ > 0, ∀y ∈ B_δ(x)`. We will introduce a quantifier in the middle:
+  --      `∀ ε > 0, ∃N, ∀n ≥ N, ∃δ > 0, ∀y ∈ B_δ(x)` which will allow us to introduce the `f(') n`
+  --   2. The order of the quantifiers `hfg` are opposite to what we need. We will be able to swap
+  --      the quantifiers using the uniform convergence assumption
+  rw has_fderiv_at_iff_tendsto,
+
+  -- Introduce extra quantifier via curried filters
+  suffices : tendsto
+    (λ (y : ι × E), ∥y.snd - x∥⁻¹ * ∥g y.snd - g x - (g' x) (y.snd - x)∥) (l.curry (𝓝 x)) (𝓝 0),
+  { rw metric.tendsto_nhds at this ⊢,
+    intros ε hε,
+    specialize this ε hε,
+    rw eventually_curry_iff at this,
+    simp only at this,
+    exact (eventually_const.mp this).mono (by simp only [imp_self, forall_const]), },
+
+  -- With the new quantifier in hand, we can perform the famous `ε/3` proof. Specifically,
+  -- we will break up the limit (the difference functions minus the derivative go to 0) into 3:
+  --   * The difference functions of the `f n` converge *uniformly* to the difference functions
+  --     of the `g n`
+  --   * The `f' n` are the derivatives of the `f n`
+  --   * The `f' n` converge to `g'` at `x`
+  conv
+  { congr, funext,
+    rw [←norm_norm, ←norm_inv,←@is_R_or_C.norm_of_real 𝕜 _ _,
+      is_R_or_C.of_real_inv, ←norm_smul], },
+  rw ←tendsto_zero_iff_norm_tendsto_zero,
+  have : (λ a : ι × E, (∥a.snd - x∥⁻¹ : 𝕜) • (g a.snd - g x - (g' x) (a.snd - x))) =
+    (λ a : ι × E, (∥a.snd - x∥⁻¹ : 𝕜) • (g a.snd - g x - (f a.fst a.snd - f a.fst x))) +
+    (λ a : ι × E, (∥a.snd - x∥⁻¹ : 𝕜) • ((f a.fst a.snd - f a.fst x) -
+      ((f' a.fst x) a.snd - (f' a.fst x) x))) +
+    (λ a : ι × E, (∥a.snd - x∥⁻¹ : 𝕜) • ((f' a.fst x - g' x) (a.snd - x))),
+  { ext, simp only [pi.add_apply], rw [←smul_add, ←smul_add], congr,
+  simp only [map_sub, sub_add_sub_cancel, continuous_linear_map.coe_sub', pi.sub_apply], },
+  simp_rw this,
+  have : 𝓝 (0 : G) = 𝓝 (0 + 0 + 0), simp only [add_zero],
+  rw this,
+  refine tendsto.add (tendsto.add _ _) _,
+  simp only,
+  { have := difference_quotients_converge_uniformly hf hfg hfg',
+    rw metric.tendsto_uniformly_on_filter_iff at this,
+    rw metric.tendsto_nhds,
+    intros ε hε,
+    apply ((this ε hε).filter_mono curry_le_prod).mono,
+    intros n hn,
+    rw dist_eq_norm at hn ⊢,
+    rw ← smul_sub at hn,
+    rwa sub_zero, },
+  { -- (Almost) the definition of the derivatives
+    rw metric.tendsto_nhds,
+    intros ε hε,
+    rw eventually_curry_iff,
+    refine hf.curry.mono (λ n hn, _),
+    have := hn.self_of_nhds,
+    rw [has_fderiv_at_iff_tendsto, metric.tendsto_nhds] at this,
+    refine (this ε hε).mono (λ y hy, _),
+    rw dist_eq_norm at hy ⊢,
+    simp only [sub_zero, map_sub, norm_mul, norm_inv, norm_norm] at hy ⊢,
+    rw [norm_smul, norm_inv, is_R_or_C.norm_coe_norm],
+    exact hy, },
+  { -- hfg' after specializing to `x` and applying the definition of the operator norm
+    refine tendsto.mono_left _ curry_le_prod,
+    have h1: tendsto (λ n : ι × E, g' n.snd - f' n.fst n.snd) (l ×ᶠ 𝓝 x) (𝓝 0),
+    { rw metric.tendsto_uniformly_on_filter_iff at hfg',
+      exact metric.tendsto_nhds.mpr (λ ε hε, by simpa using hfg' ε hε), },
+    have h2: tendsto (λ n : ι, g' x - f' n x) l (𝓝 0),
+    { rw metric.tendsto_nhds at h1 ⊢,
+      exact (λ ε hε, (h1 ε hε).curry.mono (λ n hn, hn.self_of_nhds)), },
+    have := (tendsto_fst.comp (h2.prod_map tendsto_id)),
+    refine squeeze_zero_norm _ (tendsto_zero_iff_norm_tendsto_zero.mp this),
+    intros n,
+    simp_rw [norm_smul, norm_inv, is_R_or_C.norm_coe_norm],
+    by_cases hx : x = n.snd, { simp [hx], },
+    have hnx : 0 < ∥n.snd - x∥,
+    { rw norm_pos_iff, intros hx', exact hx (eq_of_sub_eq_zero hx').symm, },
+    rw [inv_mul_le_iff hnx, mul_comm],
+    simp only [function.comp_app, prod_map],
+    rw norm_sub_rev,
+    exact (f' n.fst x - g' x).le_op_norm (n.snd - x), },
+end
+
+/-- `(d/dx) lim_{n → ∞} f n x = lim_{n → ∞} f' n x` when the `f' n` converge
+_uniformly_ to their limit on an open set containing `x`. -/
+lemma has_fderiv_at_of_tendsto_uniformly_on
+  {s : set E} (hs : is_open s)
+  (hf : ∀ (n : ι), ∀ (x : E), x ∈ s → has_fderiv_at (f n) (f' n x) x)
+  (hfg : ∀ (x : E), x ∈ s → tendsto (λ n, f n x) l (𝓝 (g x)))
+  (hfg' : tendsto_uniformly_on f' g' l s) :
+  ∀ (x : E), x ∈ s → has_fderiv_at g (g' x) x :=
+begin
+  intros x hx,
+  have hf : ∀ᶠ (n : ι × E) in (l ×ᶠ 𝓝 x), has_fderiv_at (f n.fst) (f' n.fst n.snd) n.snd,
+  { exact eventually_prod_iff.mpr ⟨(λ y, true), (by simp), (λ y, y ∈ s),
+      eventually_mem_set.mpr (mem_nhds_iff.mpr ⟨s, rfl.subset, hs, hx⟩),
+      (λ n hn y hy, hf n y hy)⟩, },
+
+  have hfg : ∀ᶠ y in 𝓝 x, tendsto (λ n, f n y) l (𝓝 (g y)),
+  { exact eventually_iff.mpr (mem_nhds_iff.mpr ⟨s, set.subset_def.mpr hfg, hs, hx⟩), },
+
+  have hfg' := hfg'.tendsto_uniformly_on_filter.mono_right (calc
+    𝓝 x = 𝓝[s] x : ((hs.nhds_within_eq hx).symm)
+    ... ≤ 𝓟 s : (by simp only [nhds_within, inf_le_right])),
+
+  exact has_fderiv_at_of_tendsto_uniformly_on_filter hf hfg hfg',
+end
+
+/-- `(d/dx) lim_{n → ∞} f n x = lim_{n → ∞} f' n x` when the `f' n` converge
+_uniformly_ to their limit. -/
+lemma has_fderiv_at_of_tendsto_uniformly
+  (hf : ∀ (n : ι), ∀ (x : E), has_fderiv_at (f n) (f' n x) x)
+  (hfg : ∀ (x : E), tendsto (λ n, f n x) l (𝓝 (g x)))
+  (hfg' : tendsto_uniformly f' g' l) :
+  ∀ (x : E), has_fderiv_at g (g' x) x :=
+begin
+  intros x,
+  have hf : ∀ (n : ι), ∀ (x : E), x ∈ set.univ → has_fderiv_at (f n) (f' n x) x, { simp [hf], },
+  have hfg : ∀ (x : E), x ∈ set.univ → tendsto (λ n, f n x) l (𝓝 (g x)), { simp [hfg], },
+  have hfg' : tendsto_uniformly_on f' g' l set.univ, { rwa tendsto_uniformly_on_univ, },
+  refine has_fderiv_at_of_tendsto_uniformly_on is_open_univ hf hfg hfg' x (set.mem_univ x),
+end
+
+end limits_of_derivatives
+
+section deriv
+
+/-! ### `deriv` versions of above theorems -/
+
+variables {ι : Type*} {l : filter ι} [ne_bot l]
+  {𝕜 : Type*} [is_R_or_C 𝕜]
+  {G : Type*} [normed_add_comm_group G] [normed_space 𝕜 G]
+  {f : ι → 𝕜 → G} {g : 𝕜 → G} {f' : ι → 𝕜 → G} {g' : 𝕜 → G}
+  {x : 𝕜}
+
+lemma uniform_cauchy_seq_on_filter_of_tendsto_uniformly_on_filter_deriv
+  (hf : ∀ᶠ (n : ι × 𝕜) in (l ×ᶠ 𝓝 x), has_deriv_at (f n.fst) (f' n.fst n.snd) n.snd)
+  (hfg : tendsto (λ n, f n x) l (𝓝 (g x)))
+  (hfg' : uniform_cauchy_seq_on_filter f' l (𝓝 x)) :
+  uniform_cauchy_seq_on_filter f l (𝓝 x) :=
+begin
+  -- The first part of the proof rewrites `hf` and the goal to be functions so that Lean
+  -- can recognize them when we apply
+  -- `uniform_cauchy_seq_on_filter_of_tendsto_uniformly_on_filter_fderiv`
+  let F' : ι → 𝕜 → (𝕜 →L[𝕜] G) := (λ n, λ z, (1 : 𝕜 →L[𝕜] 𝕜).smul_right (f' n z)),
+  simp_rw has_deriv_at_iff_has_fderiv_at at hf,
+  have : ∀ n : ι, ∀ z : 𝕜, (1 : 𝕜 →L[𝕜] 𝕜).smul_right (f' n z) = F' n z, simp,
+  simp_rw this at hf,
+
+  -- Now we need to rewrite hfg' in terms of continuous_linear_maps. The tricky part is that
+  -- operator norms are written in terms of `≤` whereas metrics are written in terms of `<`. So we
+  -- need to shrink `ε` utilizing the arhcimedian property of `ℝ`
+  have hfg' : uniform_cauchy_seq_on_filter F' l (𝓝 x),
+  { rw [normed_add_comm_group.uniform_cauchy_seq_on_filter_iff_tendsto_uniformly_on_filter_zero,
+      metric.tendsto_uniformly_on_filter_iff] at hfg' ⊢,
+    intros ε hε,
+    obtain ⟨q, hq, hq'⟩ := exists_rat_btwn hε.lt,
+    apply (hfg' q hq).mono,
+    intros n hn,
+    refine lt_of_le_of_lt _ hq',
+    simp only [F', dist_eq_norm, pi.zero_apply, zero_sub, norm_neg] at hn ⊢,
+    refine continuous_linear_map.op_norm_le_bound _ hq.le _,
+    intros z,
+    simp only [continuous_linear_map.coe_sub', pi.sub_apply, continuous_linear_map.smul_right_apply,
+      continuous_linear_map.one_apply],
+    rw [←smul_sub, norm_smul, mul_comm],
+    exact mul_le_mul hn.le rfl.le (norm_nonneg _) hq.le, },
+  exact uniform_cauchy_seq_on_filter_of_tendsto_uniformly_on_filter_fderiv hf hfg hfg',
+end
+
+lemma uniform_cauchy_seq_on_ball_of_tendsto_uniformly_on_ball_deriv
+  {r : ℝ} (hr : 0 < r)
+  (hf : ∀ n : ι, ∀ y : 𝕜, y ∈ metric.ball x r → has_deriv_at (f n) (f' n y) y)
+  (hfg : tendsto (λ n, f n x) l (𝓝 (g x)))
+  (hfg' : uniform_cauchy_seq_on f' l (metric.ball x r)) :
+  uniform_cauchy_seq_on f l (metric.ball x r) :=
+begin
+  -- The first part of the proof rewrites `hf` and the goal to be functions so that Lean
+  -- can recognize them when we apply
+  -- `uniform_cauchy_seq_on_filter_of_tendsto_uniformly_on_filter_fderiv`
+  let F' : ι → 𝕜 → (𝕜 →L[𝕜] G) := (λ n, λ z, (1 : 𝕜 →L[𝕜] 𝕜).smul_right (f' n z)),
+  simp_rw has_deriv_at_iff_has_fderiv_at at hf,
+  have : ∀ n : ι, ∀ z : 𝕜, (1 : 𝕜 →L[𝕜] 𝕜).smul_right (f' n z) = F' n z, simp,
+  simp_rw this at hf,
+
+  -- Now we need to rewrite hfg' in terms of continuous_linear_maps. The tricky part is that
+  -- operator norms are written in terms of `≤` whereas metrics are written in terms of `<`. So we
+  -- need to shrink `ε` utilizing the arhcimedian property of `ℝ`
+  have hfg' : uniform_cauchy_seq_on F' l (metric.ball x r),
+  { rw [normed_add_comm_group.uniform_cauchy_seq_on_iff_tendsto_uniformly_on_zero,
+      metric.tendsto_uniformly_on_iff] at hfg' ⊢,
+    intros ε hε,
+    obtain ⟨q, hq, hq'⟩ := exists_rat_btwn hε.lt,
+    apply (hfg' q hq).mono,
+    intros n hn y hy,
+    refine lt_of_le_of_lt _ hq',
+    simp only [F', dist_eq_norm, pi.zero_apply, zero_sub, norm_neg] at hn ⊢,
+    refine continuous_linear_map.op_norm_le_bound _ hq.le _,
+    intros z,
+    simp only [continuous_linear_map.coe_sub', pi.sub_apply, continuous_linear_map.smul_right_apply,
+      continuous_linear_map.one_apply],
+    rw [←smul_sub, norm_smul, mul_comm],
+    exact mul_le_mul (hn y hy).le rfl.le (norm_nonneg _) hq.le, },
+  exact uniform_cauchy_seq_on_ball_of_tendsto_uniformly_on_ball_fderiv hr hf hfg hfg',
+end
+
+lemma has_deriv_at_of_tendsto_uniformly_on_filter
+  (hf : ∀ᶠ (n : ι × 𝕜) in (l ×ᶠ 𝓝 x), has_deriv_at (f n.fst) (f' n.fst n.snd) n.snd)
+  (hfg : ∀ᶠ y in 𝓝 x, tendsto (λ n, f n y) l (𝓝 (g y)))
+  (hfg' : tendsto_uniformly_on_filter f' g' l (𝓝 x)) :
+  has_deriv_at g (g' x) x :=
+begin
+  -- The first part of the proof rewrites `hf` and the goal to be functions so that Lean
+  -- can recognize them when we apply `has_fderiv_at_of_tendsto_uniformly_on_filter`
+  let F' : ι → 𝕜 → (𝕜 →L[𝕜] G) := (λ n, λ z, (1 : 𝕜 →L[𝕜] 𝕜).smul_right (f' n z)),
+  let G' : 𝕜 → (𝕜 →L[𝕜] G) := (λ z, (1 : 𝕜 →L[𝕜] 𝕜).smul_right (g' z)),
+
+  simp_rw has_deriv_at_iff_has_fderiv_at at hf ⊢,
+  have : ∀ z : 𝕜, (1 : 𝕜 →L[𝕜] 𝕜).smul_right (g' z) = G' z, simp,
+  rw this,
+  have : ∀ n : ι, ∀ z : 𝕜, (1 : 𝕜 →L[𝕜] 𝕜).smul_right (f' n z) = F' n z, simp,
+  simp_rw this at hf,
+
+  -- Now we need to rewrite hfg' in terms of continuous_linear_maps. The tricky part is that
+  -- operator norms are written in terms of `≤` whereas metrics are written in terms of `<`. So we
+  -- need to shrink `ε` utilizing the arhcimedian property of `ℝ`
+  have hfg' : tendsto_uniformly_on_filter F' G' l (𝓝 x),
+  { rw metric.tendsto_uniformly_on_filter_iff at hfg' ⊢,
+    intros ε hε,
+    obtain ⟨q, hq, hq'⟩ := exists_rat_btwn hε.lt,
+    apply (hfg' q hq).mono,
+    intros n hn,
+    refine lt_of_le_of_lt _ hq',
+    simp only [F', G', dist_eq_norm] at hn ⊢,
+    refine continuous_linear_map.op_norm_le_bound _ hq.le _,
+    intros z,
+    simp only [continuous_linear_map.coe_sub', pi.sub_apply, continuous_linear_map.smul_right_apply,
+      continuous_linear_map.one_apply],
+    rw [←smul_sub, norm_smul, mul_comm],
+    exact mul_le_mul hn.le rfl.le (norm_nonneg _) hq.le, },
+  exact has_fderiv_at_of_tendsto_uniformly_on_filter hf hfg hfg',
+end
+
+lemma has_deriv_at_of_tendsto_uniformly_on
+  {s : set 𝕜} (hs : is_open s)
+  (hf : ∀ (n : ι), ∀ (x : 𝕜), x ∈ s → has_deriv_at (f n) (f' n x) x)
+  (hfg : ∀ (x : 𝕜), x ∈ s → tendsto (λ n, f n x) l (𝓝 (g x)))
+  (hfg' : tendsto_uniformly_on f' g' l s) :
+  ∀ (x : 𝕜), x ∈ s → has_deriv_at g (g' x) x :=
+begin
+  intros x hx,
+  have hsx : s ∈ 𝓝 x, { exact mem_nhds_iff.mpr ⟨s, rfl.subset, hs, hx⟩, },
+  rw tendsto_uniformly_on_iff_tendsto_uniformly_on_filter at hfg',
+  have hfg' := hfg'.mono_right (le_principal_iff.mpr hsx),
+  have hfg : ∀ᶠ y in 𝓝 x, tendsto (λ n, f n y) l (𝓝 (g y)),
+  { exact eventually_iff_exists_mem.mpr ⟨s, hsx, hfg⟩, },
+  have hf : ∀ᶠ (n : ι × 𝕜) in (l ×ᶠ 𝓝 x), has_deriv_at (f n.fst) (f' n.fst n.snd) n.snd,
+  { rw eventually_prod_iff,
+    refine ⟨(λ y, true), by simp, (λ y, y ∈ s), _, (λ n hn y hy, hf n y hy)⟩,
+    exact eventually_mem_set.mpr hsx, },
+  exact has_deriv_at_of_tendsto_uniformly_on_filter hf hfg hfg',
+end
+
+lemma has_deriv_at_of_tendsto_uniformly
+  (hf : ∀ (n : ι), ∀ (x : 𝕜), has_deriv_at (f n) (f' n x) x)
+  (hfg : ∀ (x : 𝕜), tendsto (λ n, f n x) l (𝓝 (g x)))
+  (hfg' : tendsto_uniformly f' g' l) :
+  ∀ (x : 𝕜), has_deriv_at g (g' x) x :=
+begin
+  intros x,
+  have hf : ∀ (n : ι), ∀ (x : 𝕜), x ∈ set.univ → has_deriv_at (f n) (f' n x) x, { simp [hf], },
+  have hfg : ∀ (x : 𝕜), x ∈ set.univ → tendsto (λ n, f n x) l (𝓝 (g x)), { simp [hfg], },
+  have hfg' : tendsto_uniformly_on f' g' l set.univ, { rwa tendsto_uniformly_on_univ, },
+  exact has_deriv_at_of_tendsto_uniformly_on is_open_univ hf hfg hfg' x (set.mem_univ x),
+end
+
+end deriv

--- a/src/analysis/calculus/uniform_limits_holomorphic.lean
+++ b/src/analysis/calculus/uniform_limits_holomorphic.lean
@@ -1,0 +1,457 @@
+/-
+Copyright (c) 2022 Kevin H. Wilson. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kevin H. Wilson
+-/
+-- import analysis.analytic.basic
+-- import analysis.complex.cauchy_integral
+-- import ring_theory.power_series.basic
+-- import linear_algebra.multilinear.basic
+-- import analysis.normed.field.basic
+import analysis.calculus.fderiv_analytic
+-- import analysis.calculus.uniform_limits_deriv
+
+/-!
+# Uniform limits of holomorphic functions are holomorphic
+
+The purpose of this file is to prove that a uniform limit of holomorphic functions is holomorphic,
+a critical component of many theories, notably that of Dirichlet series.
+
+## Main statements
+
+* `analytic_at_of_tendsto_uniformly_on_filter` : If `f : ℕ → ℂ → ℂ` is a sequence functions which
+  are analytic at `x` and they converge _uniformly_ to `g : ℂ → ℂ` on `𝓝 x`, then `f` is also
+  analytic at `x`
+
+## Implementation notes
+
+The steps to our proof are:
+  * Develop a language which lets us translate between the vast complexity of formal multilinear
+    series that form the foundation of analyticity in mathlib, and more prosaic sums when we're in
+    one dimension
+  * Given an analytic function `f : 𝕜 → 𝕜` on _any_ nontrivially normed field, define an
+    antiderivative `F : 𝕜 → 𝕜`
+  * Now when `𝕜` is either `ℝ` or `ℂ`, use the mean value theorem to show that given a sequence of
+    analytic functions `f : ℕ → 𝕜 → 𝕜`, the sequence of antiderivatives `F : ℕ → 𝕜 → 𝕜` form a
+    uniform Cauchy sequence and thus converge to some function `G`
+  * Apply `has_fderiv_at_of_tendsto_uniformly_on` to show that `G' = g` and so, when
+    `𝕜 = ℂ`, we have that `G` is analytic (`differentiable_on.analytic_on`) and thus so is `g`
+    (`analytic_on.fderiv`)
+
+## Tags
+
+uniform convergence, holomorphic functions
+-/
+
+open_locale big_operators
+
+variables {ι 𝕜 E F : Type*} [fintype ι] [decidable_eq ι]
+
+section general
+
+lemma foo₁ [comm_semiring 𝕜] [add_comm_monoid E] [module 𝕜 E] (f : multilinear_map 𝕜 (λ i : ι, 𝕜) E)
+  (x : ι → 𝕜) : f x = (∏ i, x i) • (f 1) :=
+begin
+  rw ← multilinear_map.map_smul_univ,
+  exact congr_arg f (funext $ λ i, by simp)
+end
+
+lemma foo₂ [comm_semiring 𝕜] (f : multilinear_map 𝕜 (λ i : ι, 𝕜) 𝕜)
+  (x : ι → 𝕜) : f x = (f 1) * (∏ i, x i) :=
+by rw [foo₁, smul_eq_mul, mul_comm]
+
+lemma bar₁ [comm_semiring 𝕜] [add_comm_monoid E] [module 𝕜 E]
+  [topological_space 𝕜] [topological_space E]
+  (f : continuous_multilinear_map 𝕜 (λ i : ι, 𝕜) E)
+  (x : ι → 𝕜) : f x = (∏ i, x i) • (f 1) :=
+foo₁ f.to_multilinear_map x
+
+lemma bar₂ [comm_semiring 𝕜] [topological_space 𝕜]
+  (f : continuous_multilinear_map 𝕜 (λ i : ι, 𝕜) 𝕜)
+  (x : ι → 𝕜) : f x = (f 1) * (∏ i, x i) :=
+foo₂ f.to_multilinear_map x
+
+lemma sum₁ [comm_ring 𝕜] [add_comm_group E] [module 𝕜 E]
+  [topological_space 𝕜] [topological_add_group 𝕜] [has_continuous_const_smul 𝕜 𝕜]
+  [topological_space E] [topological_add_group E] [has_continuous_const_smul 𝕜 E]
+  (φ : formal_multilinear_series 𝕜 𝕜 E) (x : 𝕜) :
+  φ.sum x = ∑' (n : ℕ), x^n • (φ n 1) :=
+begin
+  rw formal_multilinear_series.sum,
+  congr,
+  ext n,
+  rw [bar₁, fin.prod_const]
+end
+
+lemma sum₂ [comm_ring 𝕜]
+  [topological_space 𝕜] [topological_add_group 𝕜] [has_continuous_const_smul 𝕜 𝕜]
+  (φ : formal_multilinear_series 𝕜 𝕜 𝕜) (x : 𝕜) :
+  φ.sum x = ∑' (n : ℕ), (φ n 1) * x^n :=
+begin
+  rw formal_multilinear_series.sum,
+  congr,
+  ext n,
+  rw [bar₂, fin.prod_const]
+end
+
+lemma partial_sum₁ [comm_ring 𝕜] [add_comm_group E] [module 𝕜 E]
+  [topological_space 𝕜] [topological_add_group 𝕜] [has_continuous_const_smul 𝕜 𝕜]
+  [topological_space E] [topological_add_group E] [has_continuous_const_smul 𝕜 E]
+  (φ : formal_multilinear_series 𝕜 𝕜 E) (x : 𝕜) (n : ℕ) :
+  φ.partial_sum n x = ∑ k in finset.range n, x^k • (φ k 1) :=
+begin
+  rw formal_multilinear_series.partial_sum,
+  congr,
+  ext n,
+  rw [bar₁, fin.prod_const],
+end
+
+lemma partial_sum₂ [comm_ring 𝕜]
+  [topological_space 𝕜] [topological_add_group 𝕜] [has_continuous_const_smul 𝕜 𝕜]
+  (φ : formal_multilinear_series 𝕜 𝕜 𝕜) (x : 𝕜) (n : ℕ) :
+  φ.partial_sum n x = ∑ k in finset.range n, (φ k 1) * x^k :=
+begin
+  rw formal_multilinear_series.partial_sum,
+  congr,
+  ext n,
+  rw [bar₂, fin.prod_const],
+end
+
+lemma partial_sum₃ [comm_ring 𝕜]
+  [topological_space 𝕜] [topological_add_group 𝕜] [has_continuous_const_smul 𝕜 𝕜]
+  (φ : formal_multilinear_series 𝕜 𝕜 𝕜) (n : ℕ) :
+  φ.partial_sum n = (λ x, ∑ k in finset.range n, (φ k 1) * x^k) :=
+begin
+  ext,
+  rw formal_multilinear_series.partial_sum,
+  congr,
+  ext n,
+  rw [bar₂, fin.prod_const],
+end
+
+end general
+
+section normed_field
+variables [normed_field 𝕜] [normed_add_comm_group E] [normed_space 𝕜 E]
+
+def formal_multilinear_series.antideriv (φ : formal_multilinear_series 𝕜 𝕜 E) : formal_multilinear_series 𝕜 𝕜 E
+| 0 := 0
+| (n + 1) := ((n + 1) : 𝕜)⁻¹ • (continuous_multilinear_map.mk_pi_algebra_fin 𝕜 (n + 1) 𝕜).smul_right (φ n 1)
+
+end normed_field
+
+section nontrivially_normed_field
+-- TODO: Why doesn't `nontrivially_normed_field` get imported?
+variables [nontrivially_normed_field 𝕜] [normed_add_comm_group E] [normed_space 𝕜 E]
+  {φ : formal_multilinear_series 𝕜 𝕜 E}
+
+lemma antideriv_radius_mono {r : nnreal}
+  -- φ.radius ≤ φ.antideriv.radius :=
+  (hr : ↑r < φ.radius) : ↑r ≤ φ.antideriv.radius :=
+begin
+  -- suffices : ∀ (r : nnreal), ↑r < φ.radius → ↑r ≤ φ.antideriv.radius,
+  -- {
+  --   intros r hr,
+  --   by_contradiction h,
+  --   push_neg at h,
+  --   obtain ⟨r, hr, hr'⟩ := ennreal.lt_iff_exists_nnreal_btwn.mp (this r hr),
+  --   -- exact not_lt_of_le rfl.le (lt_of_lt_of_le hr (antideriv_radius_mono hr')),
+  -- },
+  -- intros r hr,
+  obtain ⟨C, hC, hm⟩ := φ.norm_mul_pow_le_of_lt_radius hr,
+  refine formal_multilinear_series.le_radius_of_bound _ (C * r) _,
+  intros n,
+  induction n with n hn,
+  simp only [formal_multilinear_series.antideriv, norm_zero, zero_mul],
+  refine mul_nonneg hC.lt.le nnreal.zero_le_coe,
+
+  have : n.succ = n + 1, refl,
+  rw this,
+  dunfold formal_multilinear_series.antideriv,
+  rw norm_smul,
+  have : ∥(continuous_multilinear_map.mk_pi_algebra_fin 𝕜 (n + 1) 𝕜).smul_right ((φ n) 1)∥ = ∥(continuous_multilinear_map.mk_pi_algebra_fin 𝕜 (n + 1) 𝕜)∥ * ∥((φ n) 1)∥, {
+    rw continuous_multilinear_map.norm_def,
+    simp,
+    simp [has_norm.norm],
+    ext,
+
+  },
+  simp only [continuous_multilinear_map.norm_mk_pi_algebra_fin, mul_one],
+  rw [pow_add (r : ℝ) n 1, ←mul_assoc, pow_one],
+  refine mul_le_mul _ rfl.le nnreal.zero_le_coe hC.lt.le,
+  rw [norm_mul, mul_assoc],
+  have : C = 1 * C, simp,
+  rw this,
+  have : ∥φ n 1∥ ≤ ∥φ n∥,
+  { convert continuous_multilinear_map.unit_le_op_norm _ 1 _,
+    { refl },
+    { have : (1 : fin n → ℂ) = (λ i, 1), { ext, refl, refl, },
+      rw this,
+      simp only [has_norm.norm, nnnorm_one],
+      norm_cast,
+      rw finset.sup_le_iff,
+      intros b hb,
+      exact rfl.le, } },
+  refine mul_le_mul _
+    ((mul_le_mul this rfl.le (by simp only [pow_nonneg, nnreal.zero_le_coe]) (norm_nonneg _)).trans (hm n))
+    (mul_nonneg (norm_nonneg _) (by simp only [pow_nonneg, nnreal.zero_le_coe]))
+    zero_le_one,
+
+  rw norm_inv,
+  have : (n : ℂ) + 1 = (((n + 1) : ℝ) : ℂ), norm_cast,
+  rw this,
+  norm_cast,
+  rw inv_le _ _,
+  rw real.norm_of_nonneg _,
+  simp only [inv_one, nat.cast_add, nat.cast_one, le_add_iff_nonneg_left, nat.cast_nonneg],
+  norm_cast,
+  simp only [zero_le'],
+
+  simp only [nat.cast_add, nat.cast_one, real.norm_eq_abs, abs_pos, ne.def],
+  norm_cast,
+  simp only [nat.succ_ne_zero, not_false_iff],
+
+  simp only [zero_lt_one],
+end
+
+-- The proof is by approximation below coupled with the above lemma
+lemma antideriv_radius_mono':
+  φ.radius ≤ (pad φ).radius :=
+begin
+  by_contradiction h,
+  push_neg at h,
+  obtain ⟨r, hr, hr'⟩ := ennreal.lt_iff_exists_nnreal_btwn.mp h,
+  exact not_lt_of_le rfl.le (lt_of_lt_of_le hr (antideriv_radius_mono hr')),
+end
+
+lemma blahblah {y : ℂ} {n : ℕ} :
+  has_deriv_at (λ z : ℂ, (pad φ) (n + 1) (λ i : fin (n + 1), z)) (φ n (λ i : fin n, y)) y :=
+begin
+  rw bar₂,
+  conv {
+    congr, funext, rw bar₂, rw fin.prod_const,
+  },
+  rw fin.prod_const,
+  have : pad φ (n + 1) 1 = ((n + 1) : ℂ)⁻¹ * (φ n 1), {
+    simp only [pad],
+    rw continuous_multilinear_map.smul_apply,
+    simp only [continuous_multilinear_map.mk_pi_algebra_fin_apply, list.of_fn_succ, pi.one_apply, list.of_fn_const, list.prod_cons,
+  list.prod_repeat, one_pow, mul_one, algebra.id.smul_eq_mul],
+  },
+  rw this,
+  -- Now need to pull out the const with has_deriv_at_const
+  sorry,
+end
+
+lemma blahblah2 {y : ℂ} {n : ℕ} :
+  has_deriv_at ((pad φ).partial_sum n.succ) (φ.partial_sum n y) y :=
+begin
+  rw partial_sum₂,
+  rw partial_sum₃,
+  induction n with n hn,
+  simp only [finset.range_one, finset.sum_singleton, pow_zero, mul_one, finset.range_zero, finset.sum_empty, pad, continuous_multilinear_map.zero_apply],
+  exact has_deriv_at_const y 0,
+  rw finset.sum_range_succ,
+  conv {
+    congr, funext, rw finset.sum_range_succ,
+  },
+  refine has_deriv_at.add hn _,
+  dunfold pad,
+  simp only [continuous_multilinear_map.smul_apply, continuous_multilinear_map.mk_pi_algebra_fin_apply, list.of_fn_succ, pi.one_apply, list.of_fn_const, list.prod_cons, list.prod_repeat, one_pow, mul_one, algebra.id.smul_eq_mul],
+  have : n.succ = n + 1, simp,
+  rw this,
+  have : (φ n (λ i : fin n, y)) = ((φ n) 1 * y ^ n), { rw bar₂, rw fin.prod_const, },
+  rw ← this,
+  refine blahblah.congr_of_eventually_eq _,
+  apply filter.eventually_of_forall,
+  intros z,
+  simp only [pad, list.repeat_succ, mul_eq_mul_left_iff, mul_eq_zero, inv_eq_zero, continuous_multilinear_map.smul_apply, continuous_multilinear_map.mk_pi_algebra_fin_apply, list.of_fn_succ, pi.one_apply, list.of_fn_const, list.prod_cons, list.prod_repeat, one_pow, mul_one, algebra.id.smul_eq_mul],
+  left,
+  rw ←pow_one z,
+  rw pow_add,
+  rw mul_comm,
+  simp,
+end
+
+lemma blahblah3 {y : ℂ} (hφ : 0 < φ.radius) (hy' : y ∈ emetric.ball (0 : ℂ) φ.radius):
+  has_deriv_at (pad φ).sum (φ.sum y) y :=
+begin
+  -- For technical reasons involving uniform convergence, we need to shrink our radius
+  obtain ⟨r, hr, hr'⟩ : ∃ (r : nnreal), nndist y 0 < r ∧ ↑r < φ.radius,
+  { suffices : ∃ (r : nnreal), ((nndist y 0) : ennreal) < r ∧ ↑r < φ.radius,
+    { obtain ⟨r, hr, hr'⟩ := this,
+      refine ⟨r, (by simpa using hr), hr'⟩, },
+    exact ennreal.lt_iff_exists_nnreal_btwn.mp hy', },
+
+  have h1 : is_open (metric.ball (0 : ℂ) r), exact metric.is_open_ball,
+  have h2 : ∀ n : ℕ, ∀ z : ℂ, z ∈ metric.ball (0 : ℂ) r → has_deriv_at ((pad φ).partial_sum n.succ) (φ.partial_sum n z) z, {
+    intros n z hz,
+    exact blahblah2,
+  },
+  have foo : filter.tendsto (λ n : ℕ, n.succ) filter.at_top filter.at_top, {
+    rw filter.tendsto_at_top_at_top_iff_of_monotone,
+    intros b,
+    use b,
+    exact nat.le_succ b,
+    intros m n hmn,
+    exact nat.succ_le_succ hmn,
+  },
+  have h3 : ∀ z : ℂ, z ∈ metric.ball (0 : ℂ) r → filter.tendsto (λ n : ℕ, (pad φ).partial_sum n.succ z) filter.at_top (nhds ((pad φ).sum z)), {
+    intros z hz,
+    suffices : filter.tendsto (λ (n : ℕ), (pad φ).partial_sum n z) filter.at_top (nhds ((pad φ).sum z)), {
+      exact this.comp foo,
+    },
+    have : 0 < (pad φ).radius, exact lt_of_lt_of_le hφ antideriv_radius_mono',
+    have hh2 : ↑r < (pad φ).radius, exact lt_of_lt_of_le hr' antideriv_radius_mono',
+    simpa using (((pad φ).has_fpower_series_on_ball this).tendsto_uniformly_on hh2).tendsto_at hz,
+  },
+  have h4 : tendsto_uniformly_on (λ (n : ℕ) (z : ℂ), φ.partial_sum n z) φ.sum filter.at_top (metric.ball 0 r), {
+    simpa using (φ.has_fpower_series_on_ball hφ).tendsto_uniformly_on hr',
+  },
+  exact has_deriv_at_of_tendsto_uniformly_on h1 h2 h3 h4 y hr,
+end
+
+end nontrivially_normed_field
+
+section is_R_or_C
+
+open filter
+open_locale filter topological_space
+
+variables
+  {f : ℕ → ℂ → ℂ}
+  {g : ℂ → ℂ}
+  {p : formal_multilinear_series ℂ ℂ ℂ}
+  {x : ℂ}
+  {r : ennreal}
+
+noncomputable def antideriv_func
+  (h : has_fpower_series_on_ball g p x r) : ℂ → ℂ :=
+λ z, (pad p).sum (z - x)
+
+lemma antideriv_func_has_fpower_series_on_ball
+  (h : has_fpower_series_on_ball g p x r) :
+  has_fpower_series_on_ball (antideriv_func h) (pad p) x r :=
+begin
+  have : x = 0 + x, simp,
+  conv {congr, skip, skip, rw this,},
+  dunfold antideriv_func,
+  apply has_fpower_series_on_ball.comp_sub,
+  refine has_fpower_series_on_ball.mono _ h.r_pos (h.r_le.trans antideriv_radius_mono'),
+  refine (pad p).has_fpower_series_on_ball _,
+  calc 0 < r : h.r_pos
+    ... ≤ p.radius : h.r_le
+    ... ≤ (pad p).radius : antideriv_radius_mono',
+end
+
+lemma antideriv_func_has_deriv_at
+  (h : has_fpower_series_on_ball g p x r) {y : ℂ} (hy : y ∈ emetric.ball x r) :
+  has_deriv_at (antideriv_func h) (g y) y :=
+begin
+  let recenter : ℂ → ℂ := (λ z, z - x),
+  have : (antideriv_func h) = (pad p).sum ∘ recenter,
+  {
+    funext,
+    simp [antideriv_func, pad, recenter],
+  },
+  rw this,
+  have : y - x ∈ emetric.ball (0 : ℂ) p.radius, sorry,
+  have := blahblah3 (lt_of_lt_of_le h.r_pos h.r_le) this,
+  have ugh : y - x = recenter y, simp [recenter],
+  conv at this {congr, skip, skip, rw ugh, },
+  have bah : has_deriv_at recenter 1 y, sorry,
+  have aa := has_deriv_at.comp y this bah,
+  have bb : g y = p.sum (y - x), sorry,
+  rw ←bb at aa,
+  simp at aa,
+  exact aa,
+end
+
+/-- If a sequence of holomorphic functions converges uniformly on a ball around `x`, then the limit
+is also holomorphic at `x` -/
+theorem main_theorem
+  {f : ℕ → ℂ → ℂ}
+  {g : ℂ → ℂ}
+  {x : ℂ}
+  {s : set ℂ}
+  (hs : s ∈ 𝓝 x)
+  (hf : ∀ (n : ℕ), analytic_on ℂ (f n) s)
+  (hfg : tendsto_uniformly_on f g at_top s) :
+  analytic_at ℂ g x :=
+begin
+  obtain ⟨_r, h_r, h_r'⟩ := metric.nhds_basis_closed_ball.mem_iff.mp hs,
+  let r : nnreal := _r.to_nnreal,
+  have hr : 0 < r, exact real.to_nnreal_pos.mpr h_r,
+  have : max _r 0 = _r, {
+    exact max_eq_left_of_lt h_r,
+  },
+  have hr' : metric.closed_ball x r ⊆ s, {simp [this, h_r'], },
+
+  have hf' : ∀ n : ℕ, differentiable_on ℂ (f n) (metric.closed_ball x r), {
+    intros n y hy,
+    exact (hf n y (set.mem_of_mem_of_subset hy hr')).differentiable_at.differentiable_within_at,
+  },
+
+  have hf'' : ∀ n : ℕ, has_fpower_series_on_ball (f n) (cauchy_power_series (f n) x r) x r, {
+    intros n,
+    exact (hf' n).has_fpower_series_on_ball hr,
+  },
+
+  let F : ℕ → ℂ → ℂ := (λ n : ℕ, antideriv_func (hf'' n)),
+  let G : ℂ → ℂ := (λ z : ℂ, lim at_top (λ n : ℕ, F n z)),
+
+  have hF : ∀ (n : ℕ), ∀ (y : ℂ), y ∈ metric.ball x r → has_deriv_at (F n) (f n y) y,
+  { intros n y hy,
+    have : y ∈ emetric.ball x r,
+    { rw [emetric.mem_ball, edist_nndist],
+      rw [metric.mem_ball, dist_nndist] at hy,
+      norm_cast at hy ⊢,
+      exact hy, },
+    exact antideriv_func_has_deriv_at (hf'' n) this, },
+  have foo : tendsto (λ n, F n x) at_top (𝓝 (G x)),
+  { apply tendsto_nhds_lim,
+    use 0,
+    have : ∀ n, F n x = 0,
+    { intros n,
+      have := (antideriv_func_has_fpower_series_on_ball (hf'' n)).coeff_zero,
+      simp [pad] at this,
+      exact this.symm, },
+    simp_rw this,
+    exact tendsto_const_nhds, },
+  have hfgg := hfg.mono (metric.ball_subset_closed_ball.trans hr'),
+  have hFG : ∀ (y : ℂ), y ∈ metric.ball x r → tendsto (λ n : ℕ, F n y) at_top (𝓝 (G y)),
+  {
+    intros y hy,
+    have := uniform_cauchy_seq_on_ball_of_tendsto_uniformly_on_ball_deriv hr hF foo hfgg.uniform_cauchy_seq_on,
+    have : cauchy_seq (λ n : ℕ, F n y), {
+      rw metric.cauchy_seq_iff,
+      intros ε hε,
+      rw metric.uniform_cauchy_seq_on_iff at this,
+      obtain ⟨N, hN⟩ := this ε hε,
+      use N,
+      intros m hm n hn,
+      exact hN m hm n hn y hy,
+    },
+    simpa using this.tendsto_lim,
+  },
+  have : is_open (metric.ball x r), exact metric.is_open_ball,
+  have foo := has_deriv_at_of_tendsto_uniformly_on this hF hFG (hfg.mono (metric.ball_subset_closed_ball.trans hr')),
+  have : analytic_on ℂ G (metric.ball x r), {
+    intros y hy,
+    have : metric.ball x r ∈ 𝓝 y,
+    { exact mem_nhds_iff.mpr ⟨metric.ball x r, rfl.subset, metric.is_open_ball, hy⟩, },
+    refine differentiable_on.analytic_at _ this,
+    intros z hz,
+    exact (foo z hz).differentiable_at.differentiable_within_at,
+  },
+  obtain ⟨p, ⟨R, hR⟩⟩ := (this.deriv x (metric.mem_ball_self hr)),
+  obtain ⟨R', hlR', hrR'⟩ := ennreal.lt_iff_exists_nnreal_btwn.mp hR.r_pos,
+  use [p, min R' r],
+  have hR' := hR.mono hlR' hrR'.le,
+  refine (hR'.mono (by simp [lt_min, hR'.r_pos, hr]) (min_le_left R' r)).congr _,
+  intros y hy,
+  simp at hy,
+  exact (foo y hy.2).deriv,
+end
+
+end is_R_or_C

--- a/src/analysis/calculus/uniform_limits_holomorphic.lean
+++ b/src/analysis/calculus/uniform_limits_holomorphic.lean
@@ -3,8 +3,10 @@ Copyright (c) 2022 Kevin H. Wilson. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Kevin H. Wilson
 -/
+import analysis.complex.cauchy_integral
 import analysis.calculus.fderiv_analytic
--- import analysis.calculus.uniform_limits_deriv
+import analysis.calculus.uniform_limits_deriv
+import topology.uniform_space.complete_separated
 
 /-!
 # Uniform limits of holomorphic functions are holomorphic
@@ -12,11 +14,23 @@ import analysis.calculus.fderiv_analytic
 The purpose of this file is to prove that a uniform limit of holomorphic functions is holomorphic,
 a critical component of many theories, notably that of Dirichlet series.
 
+## Definitions
+
+* `formal_multilinear_series.antideriv` : The formal antiderivative of a power series with a one
+  dimensional domain
+* `has_fpower_series_on_ball.antideriv` : The formal antiderivative of an analytic function on a
+  ball
+
 ## Main statements
 
-* `analytic_at_of_tendsto_uniformly_on_filter` : If `f : ℕ → ℂ → ℂ` is a sequence functions which
-  are analytic at `x` and they converge _uniformly_ to `g : ℂ → ℂ` on `𝓝 x`, then `f` is also
-  analytic at `x`
+* `has_fpower_series_on_ball.antideriv_has_deriv_at` : Morera's Theorem. A function on `ℝ` or `ℂ`
+  that is analytic on a ball admits an antiderivative on that ball.
+* `complex.analytic_at_of_tendsto_uniformly_on` : If `f : ℕ → ℂ → ℂ` is a sequence functions which
+  are analytic on a shared neighborhood of `x` and they converge _uniformly_ to `g : ℂ → ℂ` on that
+  neighborhood, then `f` is also analytic at `x`.
+* `complex.analytic_on_of_tendsto_uniformly_on` : Same as above, but if the shared neighborhood `s`
+  is _open_, then in fact `f` is analytic on all of `s`.
+
 
 ## Implementation notes
 
@@ -35,10 +49,11 @@ The steps to our proof are:
 
 ## Tags
 
-uniform convergence, holomorphic functions
+uniform convergence, holomorphic functions, morera's theorem
 -/
 
-open_locale big_operators
+open filter nat
+open_locale big_operators topological_space uniformity
 
 variables {ι 𝕜 E F : Type*} [fintype ι] [decidable_eq ι]
 
@@ -64,43 +79,11 @@ begin
   exact congr_arg f (funext $ λ i, by simp)
 end
 
-lemma foo₂ [comm_semiring 𝕜] (f : multilinear_map 𝕜 (λ i : ι, 𝕜) 𝕜)
-  (x : ι → 𝕜) : f x = (f 1) * (∏ i, x i) :=
-by rw [foo₁, smul_eq_mul, mul_comm]
-
 lemma bar₁ [comm_semiring 𝕜] [add_comm_monoid E] [module 𝕜 E]
   [topological_space 𝕜] [topological_space E]
   (f : continuous_multilinear_map 𝕜 (λ i : ι, 𝕜) E)
   (x : ι → 𝕜) : f x = (∏ i, x i) • (f 1) :=
 foo₁ f.to_multilinear_map x
-
-lemma bar₂ [comm_semiring 𝕜] [topological_space 𝕜]
-  (f : continuous_multilinear_map 𝕜 (λ i : ι, 𝕜) 𝕜)
-  (x : ι → 𝕜) : f x = (f 1) * (∏ i, x i) :=
-foo₂ f.to_multilinear_map x
-
-lemma sum₁ [comm_ring 𝕜] [add_comm_group E] [module 𝕜 E]
-  [topological_space 𝕜] [topological_add_group 𝕜] [has_continuous_const_smul 𝕜 𝕜]
-  [topological_space E] [topological_add_group E] [has_continuous_const_smul 𝕜 E]
-  (φ : formal_multilinear_series 𝕜 𝕜 E) (x : 𝕜) :
-  φ.sum x = ∑' (n : ℕ), x^n • (φ n 1) :=
-begin
-  rw formal_multilinear_series.sum,
-  congr,
-  ext n,
-  rw [bar₁, fin.prod_const]
-end
-
-lemma sum₂ [comm_ring 𝕜]
-  [topological_space 𝕜] [topological_add_group 𝕜] [has_continuous_const_smul 𝕜 𝕜]
-  (φ : formal_multilinear_series 𝕜 𝕜 𝕜) (x : 𝕜) :
-  φ.sum x = ∑' (n : ℕ), (φ n 1) * x^n :=
-begin
-  rw formal_multilinear_series.sum,
-  congr,
-  ext n,
-  rw [bar₂, fin.prod_const]
-end
 
 lemma partial_sum₁ [comm_ring 𝕜] [add_comm_group E] [module 𝕜 E]
   [topological_space 𝕜] [topological_add_group 𝕜] [has_continuous_const_smul 𝕜 𝕜]
@@ -114,27 +97,14 @@ begin
   rw [bar₁, fin.prod_const],
 end
 
-lemma partial_sum₂ [comm_ring 𝕜]
+lemma partial_sum5 [comm_ring 𝕜] [add_comm_group E] [module 𝕜 E]
   [topological_space 𝕜] [topological_add_group 𝕜] [has_continuous_const_smul 𝕜 𝕜]
-  (φ : formal_multilinear_series 𝕜 𝕜 𝕜) (x : 𝕜) (n : ℕ) :
-  φ.partial_sum n x = ∑ k in finset.range n, (φ k 1) * x^k :=
-begin
-  rw formal_multilinear_series.partial_sum,
-  congr,
-  ext n,
-  rw [bar₂, fin.prod_const],
-end
-
-lemma partial_sum₃ [comm_ring 𝕜]
-  [topological_space 𝕜] [topological_add_group 𝕜] [has_continuous_const_smul 𝕜 𝕜]
-  (φ : formal_multilinear_series 𝕜 𝕜 𝕜) (n : ℕ) :
-  φ.partial_sum n = (λ x, ∑ k in finset.range n, (φ k 1) * x^k) :=
+  [topological_space E] [topological_add_group E] [has_continuous_const_smul 𝕜 E]
+  (φ : formal_multilinear_series 𝕜 𝕜 E) (n : ℕ) :
+  φ.partial_sum n = (λ x : 𝕜, ∑ k in finset.range n, x^k • (φ k 1)) :=
 begin
   ext,
-  rw formal_multilinear_series.partial_sum,
-  congr,
-  ext n,
-  rw [bar₂, fin.prod_const],
+  exact partial_sum₁ φ x n,
 end
 
 end general
@@ -145,9 +115,11 @@ variables [normed_field 𝕜] [normed_add_comm_group E] [normed_space 𝕜 E]
 /-- The formal antiderivative of a multilinear power series with a one-dimensional domain. Note
 that while we have defined this for any `normed_field`, it really only makes sense when that
 field is characterisitic 0. -/
-def formal_multilinear_series.antideriv (φ : formal_multilinear_series 𝕜 𝕜 E) : formal_multilinear_series 𝕜 𝕜 E
+def formal_multilinear_series.antideriv (φ : formal_multilinear_series 𝕜 𝕜 E) :
+  formal_multilinear_series 𝕜 𝕜 E
 | 0 := 0
-| (n + 1) := ((n + 1) : 𝕜)⁻¹ • (continuous_multilinear_map.mk_pi_algebra_fin 𝕜 (n + 1) 𝕜).smul_right (φ n 1)
+| (n + 1) := ((n + 1) : 𝕜)⁻¹ •
+  (continuous_multilinear_map.mk_pi_algebra_fin 𝕜 (n + 1) 𝕜).smul_right (φ n 1)
 
 end normed_field
 
@@ -184,7 +156,7 @@ end nontrivially_normed_field
 section is_R_or_C
 
 variables [is_R_or_C 𝕜] [normed_add_comm_group E] [normed_space 𝕜 E]
-  {φ : formal_multilinear_series 𝕜 𝕜 E}
+  (φ : formal_multilinear_series 𝕜 𝕜 E)
 
 lemma formal_multilinear_series.antideriv_radius_mono_aux {r : nnreal}
   (hr : ↑r < φ.radius) : ↑r ≤ φ.antideriv.radius :=
@@ -193,284 +165,280 @@ begin
   refine formal_multilinear_series.le_radius_of_bound _ (C * r) _,
   intros n,
   induction n with n hn,
-  simp only [formal_multilinear_series.antideriv, norm_zero, zero_mul],
-  refine mul_nonneg hC.lt.le nnreal.zero_le_coe,
+  { simp only [formal_multilinear_series.antideriv, norm_zero, zero_mul],
+    exact mul_nonneg hC.lt.le nnreal.zero_le_coe, },
 
   have : n.succ = n + 1, refl,
   rw this,
   dunfold formal_multilinear_series.antideriv,
-  rw norm_smul,
-  rw continuous_multilinear_map.norm_smul_right,
-  simp only [norm_inv, continuous_multilinear_map.norm_mk_pi_algebra_fin, one_mul],
+  rw [norm_smul, continuous_multilinear_map.norm_smul_right, norm_inv,
+    continuous_multilinear_map.norm_mk_pi_algebra_fin, one_mul, pow_add (r : ℝ) n 1,
+    ← mul_assoc, pow_one, ← continuous_multilinear_map.norm_one_dim],
 
-  rw [pow_add (r : ℝ) n 1, ←mul_assoc, pow_one],
   refine mul_le_mul _ rfl.le nnreal.zero_le_coe hC.lt.le,
-  rw [mul_assoc],
   have : C = 1 * C, simp,
-  rw this,
-  rw ← continuous_multilinear_map.norm_one_dim,
-  have : ∥φ n 1∥ ≤ ∥φ n∥,
-  { convert continuous_multilinear_map.unit_le_op_norm _ 1 _,
-    { have : (1 : fin n → 𝕜) = (λ i, 1), { ext, refl, },
-      rw this,
-      simp only [has_norm.norm, nnnorm_one],
-      norm_cast,
-      rw finset.sup_le_iff,
-      intros b hb,
-      exact rfl.le, } },
-  refine mul_le_mul _
-    ((mul_le_mul this rfl.le (by simp only [pow_nonneg, nnreal.zero_le_coe]) (norm_nonneg _)).trans (hm n))
-    (mul_nonneg (norm_nonneg _) (by simp only [pow_nonneg, nnreal.zero_le_coe]))
-    zero_le_one,
+  rw [this, mul_assoc],
+  refine mul_le_mul _ (hm n)
+    (mul_nonneg (norm_nonneg _) (by simp only [pow_nonneg, nnreal.zero_le_coe])) zero_le_one,
 
   norm_cast,
-  rw inv_le _ zero_lt_one,
-  rw [inv_one, is_R_or_C.norm_eq_abs, is_R_or_C.abs_cast_nat],
-  norm_cast,
-  simp,
-
   rw [is_R_or_C.norm_eq_abs, is_R_or_C.abs_cast_nat],
-  norm_cast,
-  linarith,
+  rw inv_le _ zero_lt_one,
+  { simp, },
+  { norm_cast, simp, },
+  { apply_instance, },
 end
 
-lemma formal_multilinear_series.antideriv_radius_mono:
+lemma formal_multilinear_series.antideriv_radius_mono :
   φ.radius ≤ φ.antideriv.radius :=
 begin
   by_contradiction h,
   push_neg at h,
   obtain ⟨r, hr, hr'⟩ := ennreal.lt_iff_exists_nnreal_btwn.mp h,
-  exact not_lt_of_le rfl.le (lt_of_lt_of_le hr (formal_multilinear_series.antideriv_radius_mono_aux hr')),
+  exact not_lt_of_le rfl.le
+    (lt_of_lt_of_le hr (φ.antideriv_radius_mono_aux hr')),
 end
 
-lemma blahblah {y : ℂ} {n : ℕ} :
-  has_deriv_at (λ z : ℂ, (pad φ) (n + 1) (λ i : fin (n + 1), z)) (φ n (λ i : fin n, y)) y :=
+lemma formal_multilinear_series.antideriv_has_deriv_at_parial_sum {y : 𝕜} {n : ℕ} :
+  has_deriv_at (φ.antideriv.partial_sum n.succ) (φ.partial_sum n y) y :=
 begin
-  rw bar₂,
-  conv {
-    congr, funext, rw bar₂, rw fin.prod_const,
-  },
-  rw fin.prod_const,
-  have : pad φ (n + 1) 1 = ((n + 1) : ℂ)⁻¹ * (φ n 1), {
-    simp only [pad],
-    rw continuous_multilinear_map.smul_apply,
-    simp only [continuous_multilinear_map.mk_pi_algebra_fin_apply, list.of_fn_succ, pi.one_apply, list.of_fn_const, list.prod_cons,
-  list.prod_repeat, one_pow, mul_one, algebra.id.smul_eq_mul],
-  },
-  rw this,
-  -- Now need to pull out the const with has_deriv_at_const
-  sorry,
-end
-
-lemma blahblah2 {y : ℂ} {n : ℕ} :
-  has_deriv_at ((pad φ).partial_sum n.succ) (φ.partial_sum n y) y :=
-begin
-  rw partial_sum₂,
-  rw partial_sum₃,
+  -- Proof is by induction and the fact that d/dx (x^n) = n x^(n - 1)
+  rw partial_sum₁,
+  rw partial_sum5,
   induction n with n hn,
-  simp only [finset.range_one, finset.sum_singleton, pow_zero, mul_one, finset.range_zero, finset.sum_empty, pad, continuous_multilinear_map.zero_apply],
-  exact has_deriv_at_const y 0,
+  { -- base case is trivial as it's an empty sum
+    simp only [finset.range_one, finset.sum_singleton, pow_zero, one_smul,
+    finset.range_zero, finset.sum_empty],
+    exact has_deriv_at_const y _, },
+
+  -- Inductive case's main difficulty is cancelling (n + 1)⁻¹ through a bunch of casts
   rw finset.sum_range_succ,
-  conv {
-    congr, funext, rw finset.sum_range_succ,
-  },
+  conv { congr, funext, rw finset.sum_range_succ, },
   refine has_deriv_at.add hn _,
-  dunfold pad,
-  simp only [continuous_multilinear_map.smul_apply, continuous_multilinear_map.mk_pi_algebra_fin_apply, list.of_fn_succ, pi.one_apply, list.of_fn_const, list.prod_cons, list.prod_repeat, one_pow, mul_one, algebra.id.smul_eq_mul],
-  have : n.succ = n + 1, simp,
-  rw this,
-  have : (φ n (λ i : fin n, y)) = ((φ n) 1 * y ^ n), { rw bar₂, rw fin.prod_const, },
-  rw ← this,
-  refine blahblah.congr_of_eventually_eq _,
-  apply filter.eventually_of_forall,
-  intros z,
-  simp only [pad, list.repeat_succ, mul_eq_mul_left_iff, mul_eq_zero, inv_eq_zero, continuous_multilinear_map.smul_apply, continuous_multilinear_map.mk_pi_algebra_fin_apply, list.of_fn_succ, pi.one_apply, list.of_fn_const, list.prod_cons, list.prod_repeat, one_pow, mul_one, algebra.id.smul_eq_mul],
-  left,
-  rw ←pow_one z,
-  rw pow_add,
-  rw mul_comm,
-  simp,
+  simp only [formal_multilinear_series.antideriv, continuous_multilinear_map.smul_apply,
+    continuous_multilinear_map.smul_right_apply, continuous_multilinear_map.mk_pi_algebra_fin_apply,
+    list.of_fn_succ, pi.one_apply, list.of_fn_const, list.prod_cons, list.prod_repeat, one_pow,
+    mul_one, one_smul],
+  conv { congr, funext, rw ← smul_assoc, },
+  refine has_deriv_at.smul_const _ (φ n 1),
+  have aa := (has_deriv_at_pow (n + 1) y).const_mul ((n : 𝕜) + 1)⁻¹,
+  simp only [cast_add, cast_one, add_succ_sub_one, add_zero] at aa,
+  have : (((n : 𝕜) + 1)⁻¹ * (((n : 𝕜) + 1) * y ^ n)) = y ^ n,
+  { rw ←mul_assoc,
+    conv { congr, skip, rw ← one_mul (y ^ n), },
+    congr,
+    rw inv_mul_cancel,
+    norm_cast,
+    simp, },
+  rw this at aa,
+  apply aa.congr_of_eventually_eq,
+  simp only [eventually_eq, algebra.id.smul_eq_mul, mul_eq_mul_left_iff, inv_eq_zero],
+  exact eventually_of_forall (λ y, by rw mul_comm),
 end
 
-lemma blahblah3 {y : ℂ} (hφ : 0 < φ.radius) (hy' : y ∈ emetric.ball (0 : ℂ) φ.radius):
-  has_deriv_at (pad φ).sum (φ.sum y) y :=
+lemma formal_multilinear_series.antideriv_has_deriv_at_sum [complete_space E] {y : 𝕜}
+  (hφ : 0 < φ.radius) (hy' : y ∈ emetric.ball (0 : 𝕜) φ.radius) :
+  has_deriv_at φ.antideriv.sum (φ.sum y) y :=
 begin
   -- For technical reasons involving uniform convergence, we need to shrink our radius
   obtain ⟨r, hr, hr'⟩ : ∃ (r : nnreal), nndist y 0 < r ∧ ↑r < φ.radius,
   { suffices : ∃ (r : nnreal), ((nndist y 0) : ennreal) < r ∧ ↑r < φ.radius,
     { obtain ⟨r, hr, hr'⟩ := this,
       refine ⟨r, (by simpa using hr), hr'⟩, },
+    rw [emetric.mem_ball, edist_nndist] at hy',
     exact ennreal.lt_iff_exists_nnreal_btwn.mp hy', },
 
-  have h1 : is_open (metric.ball (0 : ℂ) r), exact metric.is_open_ball,
-  have h2 : ∀ n : ℕ, ∀ z : ℂ, z ∈ metric.ball (0 : ℂ) r → has_deriv_at ((pad φ).partial_sum n.succ) (φ.partial_sum n z) z, {
-    intros n z hz,
-    exact blahblah2,
-  },
-  have foo : filter.tendsto (λ n : ℕ, n.succ) filter.at_top filter.at_top, {
-    rw filter.tendsto_at_top_at_top_iff_of_monotone,
-    intros b,
-    use b,
-    exact nat.le_succ b,
-    intros m n hmn,
-    exact nat.succ_le_succ hmn,
-  },
-  have h3 : ∀ z : ℂ, z ∈ metric.ball (0 : ℂ) r → filter.tendsto (λ n : ℕ, (pad φ).partial_sum n.succ z) filter.at_top (nhds ((pad φ).sum z)), {
-    intros z hz,
-    suffices : filter.tendsto (λ (n : ℕ), (pad φ).partial_sum n z) filter.at_top (nhds ((pad φ).sum z)), {
-      exact this.comp foo,
-    },
-    have : 0 < (pad φ).radius, exact lt_of_lt_of_le hφ antideriv_radius_mono',
-    have hh2 : ↑r < (pad φ).radius, exact lt_of_lt_of_le hr' antideriv_radius_mono',
-    simpa using (((pad φ).has_fpower_series_on_ball this).tendsto_uniformly_on hh2).tendsto_at hz,
-  },
-  have h4 : tendsto_uniformly_on (λ (n : ℕ) (z : ℂ), φ.partial_sum n z) φ.sum filter.at_top (metric.ball 0 r), {
-    simpa using (φ.has_fpower_series_on_ball hφ).tendsto_uniformly_on hr',
-  },
-  exact has_deriv_at_of_tendsto_uniformly_on h1 h2 h3 h4 y hr,
+  -- Ultimately, we'll use the fact that you can swap limits and derivatives when
+  -- the derivatives converge uniformly
+  have h3 : ∀ z : 𝕜, z ∈ metric.ball (0 : 𝕜) r →
+    tendsto (λ n : ℕ, φ.antideriv.partial_sum n.succ z) at_top (𝓝 (φ.antideriv.sum z)),
+    { intros z hz,
+      suffices ha : tendsto (λ (n : ℕ), φ.antideriv.partial_sum n z) at_top
+        (𝓝 (φ.antideriv.sum z)),
+      { exact ha.comp
+        (tendsto_at_top_at_top_of_monotone (λ b c, succ_le_succ) (λ b, ⟨b, le_succ b⟩)), },
+      have h1 := lt_of_lt_of_le hφ φ.antideriv_radius_mono,
+      have h2 := lt_of_lt_of_le hr' φ.antideriv_radius_mono,
+      have h3 := ((φ.antideriv.has_fpower_series_on_ball h1).tendsto_uniformly_on h2).tendsto_at hz,
+      simpa using h3, },
+
+  refine has_deriv_at_of_tendsto_uniformly_on metric.is_open_ball _ h3
+    (by simpa using (φ.has_fpower_series_on_ball hφ).tendsto_uniformly_on hr') y hr,
+  { intros n z hz, exact φ.antideriv_has_deriv_at_parial_sum, },
 end
 
-end nontrivially_normed_field
+end is_R_or_C
 
-section is_R_or_C
+section is_R_or_C_fpower_series
+variables [is_R_or_C 𝕜] [normed_add_comm_group E] [normed_space 𝕜 E] [complete_space E]
+  {f : 𝕜 → E} {φ : formal_multilinear_series 𝕜 𝕜 E} {x : 𝕜} {r : ennreal}
 
-open filter
-open_locale filter topological_space
+/-- The antiderivative of an analytic funciton -/
+noncomputable def has_fpower_series_on_ball.antideriv
+  (h : has_fpower_series_on_ball f φ x r) : 𝕜 → E :=
+λ z, φ.antideriv.sum (z - x)
 
-variables
-  {f : ℕ → ℂ → ℂ}
-  {g : ℂ → ℂ}
-  {p : formal_multilinear_series ℂ ℂ ℂ}
-  {x : ℂ}
-  {r : ennreal}
-
-noncomputable def antideriv_func
-  (h : has_fpower_series_on_ball g p x r) : ℂ → ℂ :=
-λ z, (pad p).sum (z - x)
-
-lemma antideriv_func_has_fpower_series_on_ball
-  (h : has_fpower_series_on_ball g p x r) :
-  has_fpower_series_on_ball (antideriv_func h) (pad p) x r :=
+lemma has_fpower_series_on_ball.antideriv_has_fpower_series_on_ball
+  (h : has_fpower_series_on_ball f φ x r) :
+  has_fpower_series_on_ball h.antideriv φ.antideriv x r :=
 begin
   have : x = 0 + x, simp,
   conv {congr, skip, skip, rw this,},
-  dunfold antideriv_func,
+  dunfold has_fpower_series_on_ball.antideriv,
   apply has_fpower_series_on_ball.comp_sub,
-  refine has_fpower_series_on_ball.mono _ h.r_pos (h.r_le.trans antideriv_radius_mono'),
-  refine (pad p).has_fpower_series_on_ball _,
+  refine has_fpower_series_on_ball.mono _ h.r_pos (h.r_le.trans φ.antideriv_radius_mono),
+  refine φ.antideriv.has_fpower_series_on_ball _,
   calc 0 < r : h.r_pos
-    ... ≤ p.radius : h.r_le
-    ... ≤ (pad p).radius : antideriv_radius_mono',
+    ... ≤ φ.radius : h.r_le
+    ... ≤ φ.antideriv.radius : φ.antideriv_radius_mono,
 end
 
-lemma antideriv_func_has_deriv_at
-  (h : has_fpower_series_on_ball g p x r) {y : ℂ} (hy : y ∈ emetric.ball x r) :
-  has_deriv_at (antideriv_func h) (g y) y :=
+/-- **Morera's Theorem**: An analytic function over `ℝ` or `ℂ` admits an antiderivative -/
+lemma has_fpower_series_on_ball.antideriv_has_deriv_at
+  (h : has_fpower_series_on_ball f φ x r) {y : 𝕜} (hy : y ∈ emetric.ball x r) :
+  has_deriv_at h.antideriv (f y) y :=
 begin
-  let recenter : ℂ → ℂ := (λ z, z - x),
-  have : (antideriv_func h) = (pad p).sum ∘ recenter,
-  {
-    funext,
-    simp [antideriv_func, pad, recenter],
-  },
+  let recenter : 𝕜 → 𝕜 := (λ z, z - x),
+  have : h.antideriv = φ.antideriv.sum ∘ recenter,
+  { funext,
+    simp [has_fpower_series_on_ball.antideriv, formal_multilinear_series.antideriv, recenter], },
   rw this,
-  have : y - x ∈ emetric.ball (0 : ℂ) p.radius, sorry,
-  have := blahblah3 (lt_of_lt_of_le h.r_pos h.r_le) this,
-  have ugh : y - x = recenter y, simp [recenter],
-  conv at this {congr, skip, skip, rw ugh, },
-  have bah : has_deriv_at recenter 1 y, sorry,
-  have aa := has_deriv_at.comp y this bah,
-  have bb : g y = p.sum (y - x), sorry,
+  have hyr : y - x ∈ emetric.ball (0 : 𝕜) r,
+  { rw [emetric.mem_ball, edist_dist, dist_eq_norm] at hy ⊢,
+    rw sub_zero,
+    exact hy, },
+  have hyφ : y - x ∈ emetric.ball (0 : 𝕜) φ.radius,
+  { exact set.mem_of_mem_of_subset hyr (emetric.ball_subset_ball h.r_le), },
+  have := φ.antideriv_has_deriv_at_sum (lt_of_lt_of_le h.r_pos h.r_le) hyφ,
+  have aa := has_deriv_at.scomp y this ((has_deriv_at_id y).sub_const x),
+  have bb : f y = φ.sum (y - x), { simpa using h.sum hyr, },
   rw ←bb at aa,
-  simp at aa,
-  exact aa,
+  simpa using aa,
 end
 
-/-- If a sequence of holomorphic functions converges uniformly on a ball around `x`, then the limit
-is also holomorphic at `x` -/
-theorem main_theorem
-  {f : ℕ → ℂ → ℂ}
-  {g : ℂ → ℂ}
-  {x : ℂ}
-  {s : set ℂ}
-  (hs : s ∈ 𝓝 x)
-  (hf : ∀ (n : ℕ), analytic_on ℂ (f n) s)
-  (hfg : tendsto_uniformly_on f g at_top s) :
-  analytic_at ℂ g x :=
+/-- **Morera's Theorem**: An analytic function over `ℝ` or `ℂ` admits an antiderivative -/
+lemma has_fpower_series_at.antideriv_has_deriv_at
+  (h : has_fpower_series_at f φ x) :
+  has_deriv_at (classical.some_spec h).antideriv (f x) x :=
 begin
+  refine has_fpower_series_on_ball.antideriv_has_deriv_at _ _,
+  rw [emetric.mem_ball, edist_self],
+  exact (classical.some_spec h).r_pos,
+end
+
+end is_R_or_C_fpower_series
+
+section complex
+variables {η : Type*} {l : filter η} [ne_bot l]
+  [normed_add_comm_group E] [normed_space ℂ E] [complete_space E]
+  {f : η → ℂ → E} {g : ℂ → E} {φ : formal_multilinear_series ℂ ℂ E} {x : ℂ}
+  {r : ennreal} {s : set ℂ}
+
+/-- If a sequence of holomorphic functions converges uniformly on a neighborhhod of `x`, then the
+limit is also holomorphic at `x`. -/
+theorem complex.analytic_at_of_tendsto_uniformly_on (hs : s ∈ 𝓝 x)
+  (hf : ∀ (n : η), analytic_on ℂ (f n) s)
+  (hfg : tendsto_uniformly_on f g l s) : analytic_at ℂ g x :=
+begin
+  -- Proof strategy: We will use the fact that the complex derivative of a complex function is
+  -- analytic. To do so, we first construct antiderivatives of `f n` and `g` by shrinking to a
+  -- small ball around `x` and applying the above machinery
   obtain ⟨_r, h_r, h_r'⟩ := metric.nhds_basis_closed_ball.mem_iff.mp hs,
   let r : nnreal := _r.to_nnreal,
   have hr : 0 < r, exact real.to_nnreal_pos.mpr h_r,
-  have : max _r 0 = _r, {
-    exact max_eq_left_of_lt h_r,
-  },
+  have : max _r 0 = _r, { exact max_eq_left_of_lt h_r, },
   have hr' : metric.closed_ball x r ⊆ s, {simp [this, h_r'], },
 
-  have hf' : ∀ n : ℕ, differentiable_on ℂ (f n) (metric.closed_ball x r), {
-    intros n y hy,
-    exact (hf n y (set.mem_of_mem_of_subset hy hr')).differentiable_at.differentiable_within_at,
-  },
+  -- Our first use of `ℂ` instead of `ℝ`: An analytic function has a power series which converges on
+  -- the largest ball on which the function is differentiable. We use this to get a _common_ radius
+  -- of convergence.
+  have hfp : ∀ n, has_fpower_series_on_ball (f n) (cauchy_power_series (f n) x r) x r,
+  { intros n,
+    refine differentiable_on.has_fpower_series_on_ball _ hr,
+    intros y hy,
+    exact (hf n y (set.mem_of_mem_of_subset hy hr')).differentiable_at.differentiable_within_at, },
 
-  have hf'' : ∀ n : ℕ, has_fpower_series_on_ball (f n) (cauchy_power_series (f n) x r) x r, {
-    intros n,
-    exact (hf' n).has_fpower_series_on_ball hr,
-  },
+  -- Construct the antiderivatives
+  let F : η → ℂ → E := (λ n, (hfp n).antideriv),
+  let G : ℂ → E := (λ z, lim l (λ n, F n z)),
 
-  let F : ℕ → ℂ → ℂ := (λ n : ℕ, antideriv_func (hf'' n)),
-  let G : ℂ → ℂ := (λ z : ℂ, lim at_top (λ n : ℕ, F n z)),
-
-  have hF : ∀ (n : ℕ), ∀ (y : ℂ), y ∈ metric.ball x r → has_deriv_at (F n) (f n y) y,
+  -- Show that the `F` converge (necessarily to `G`) via
+  -- `uniform_cauchy_seq_on_ball_of_tendsto_uniformly_on_ball_deriv`
+  have hF : ∀ n y, y ∈ metric.ball x r → has_deriv_at (F n) (f n y) y,
   { intros n y hy,
     have : y ∈ emetric.ball x r,
     { rw [emetric.mem_ball, edist_nndist],
       rw [metric.mem_ball, dist_nndist] at hy,
       norm_cast at hy ⊢,
       exact hy, },
-    exact antideriv_func_has_deriv_at (hf'' n) this, },
-  have foo : tendsto (λ n, F n x) at_top (𝓝 (G x)),
-  { apply tendsto_nhds_lim,
-    use 0,
+    exact (hfp n).antideriv_has_deriv_at this, },
+  have hFG : tendsto (λ n, F n x) l (𝓝 (G x)),
+  { refine tendsto_nhds_lim ⟨0, _⟩,
     have : ∀ n, F n x = 0,
     { intros n,
-      have := (antideriv_func_has_fpower_series_on_ball (hf'' n)).coeff_zero,
-      simp [pad] at this,
+      have := (hfp n).antideriv_has_fpower_series_on_ball.coeff_zero,
+      simp only [formal_multilinear_series.antideriv, real.coe_to_nnreal',
+        continuous_multilinear_map.zero_apply, fin.forall_fin_zero_pi] at this,
       exact this.symm, },
     simp_rw this,
     exact tendsto_const_nhds, },
-  have hfgg := hfg.mono (metric.ball_subset_closed_ball.trans hr'),
-  have hFG : ∀ (y : ℂ), y ∈ metric.ball x r → tendsto (λ n : ℕ, F n y) at_top (𝓝 (G y)),
-  {
-    intros y hy,
-    have := uniform_cauchy_seq_on_ball_of_tendsto_uniformly_on_ball_deriv hr hF foo hfgg.uniform_cauchy_seq_on,
-    have : cauchy_seq (λ n : ℕ, F n y), {
-      rw metric.cauchy_seq_iff,
+  have hFG' := hfg.mono (metric.ball_subset_closed_ball.trans hr'),
+  have hFG : ∀ y, y ∈ metric.ball x r → tendsto (λ n, F n y) l (𝓝 (G y)),
+  { intros y hy,
+    have := uniform_cauchy_seq_on_ball_of_tendsto_uniformly_on_ball_deriv hr hF hFG
+      hFG'.uniform_cauchy_seq_on,
+    have : cauchy (map (λ n, F n y) l),
+    { rw metric.cauchy_iff,
+      split,
+      { exact filter.map_ne_bot, },
       intros ε hε,
-      rw metric.uniform_cauchy_seq_on_iff at this,
-      obtain ⟨N, hN⟩ := this ε hε,
-      use N,
-      intros m hm n hn,
-      exact hN m hm n hn y hy,
-    },
-    simpa using this.tendsto_lim,
-  },
+      obtain ⟨N, hN, hNm⟩ := (metric.uniform_cauchy_seq_on_iff'.mp this) ε hε,
+      refine ⟨_, image_mem_map hN, λ m hm n hn, _⟩,
+      obtain ⟨m', hm'⟩ := hm,
+      obtain ⟨n', hn'⟩ := hn,
+      simp only at hm' hn',
+      rw [←hm'.2, ←hn'.2],
+      exact hNm m' hm'.1 n' hn'.1 y hy, },
+    rw cauchy_map_iff_exists_tendsto at this,
+    simpa using tendsto_nhds_lim this, },
+
+  -- Since the `F` converge to `G`, we can use `has_deriv_at_of_tendsto_uniformly_on` to show that
+  -- the derivative of `G` is `g` at `x`
   have : is_open (metric.ball x r), exact metric.is_open_ball,
-  have foo := has_deriv_at_of_tendsto_uniformly_on this hF hFG (hfg.mono (metric.ball_subset_closed_ball.trans hr')),
-  have : analytic_on ℂ G (metric.ball x r), {
-    intros y hy,
+  have hfin := has_deriv_at_of_tendsto_uniformly_on this hF hFG
+    (hfg.mono (metric.ball_subset_closed_ball.trans hr')),
+
+  -- Our second use of `ℂ`: differentiability implies analyticity
+  have : analytic_on ℂ G (metric.ball x r),
+  { intros y hy,
     have : metric.ball x r ∈ 𝓝 y,
     { exact mem_nhds_iff.mpr ⟨metric.ball x r, rfl.subset, metric.is_open_ball, hy⟩, },
     refine differentiable_on.analytic_at _ this,
     intros z hz,
-    exact (foo z hz).differentiable_at.differentiable_within_at,
-  },
+    exact (hfin z hz).differentiable_at.differentiable_within_at, },
+
+  -- Analyticity implies the derivative is analytic
   obtain ⟨p, ⟨R, hR⟩⟩ := (this.deriv x (metric.mem_ball_self hr)),
+
+  -- The `congr` for replacing `deriv G` with `g` requires us to show that `deriv G` and
+  -- `g` match on a small ball around `x`. So shrink radii further so we can apply `hfin`
   obtain ⟨R', hlR', hrR'⟩ := ennreal.lt_iff_exists_nnreal_btwn.mp hR.r_pos,
   use [p, min R' r],
   have hR' := hR.mono hlR' hrR'.le,
   refine (hR'.mono (by simp [lt_min, hR'.r_pos, hr]) (min_le_left R' r)).congr _,
+
+  -- Finally, apply `hfin` on this small ball
   intros y hy,
-  simp at hy,
-  exact (foo y hy.2).deriv,
+  simp only [emetric.mem_ball, lt_min_iff, edist_lt_coe] at hy,
+  exact (hfin y hy.2).deriv,
 end
 
-end is_R_or_C
+/-- If a sequence of holomorphic functions converges uniformly on a domain, then the
+limit is also holomorphic on the domain -/
+theorem complex.analytic_on_of_tendsto_uniformly_on (hs : is_open s)
+  (hf : ∀ (n : η), analytic_on ℂ (f n) s)
+  (hfg : tendsto_uniformly_on f g l s) : analytic_on ℂ g s :=
+λ x hx, complex.analytic_at_of_tendsto_uniformly_on
+  (mem_nhds_iff.mpr ⟨s, rfl.subset, hs, hx⟩) hf hfg
+
+end complex

--- a/src/analysis/normed/group/basic.lean
+++ b/src/analysis/normed/group/basic.lean
@@ -469,6 +469,50 @@ begin
   simp [dist_eq_norm]
 end
 
+lemma normed_add_comm_group.tendsto_uniformly_on_zero {f : ι → E → G} {s : set E} {l : filter ι} :
+  tendsto_uniformly_on f 0 l s ↔ ∀ ε > 0, ∀ᶠ (N : ι) in l, ∀ x : E, x ∈ s → ∥f N x∥ < ε :=
+begin
+  rw metric.tendsto_uniformly_on_iff,
+  split,
+  { exact (λ h ε hε, (h ε hε).mono (λ i hi x hx, by simpa using (hi x hx))), },
+  { exact (λ h ε hε, (h ε hε).mono (λ i hi x hx, by simpa using (hi x hx))), },
+end
+
+lemma normed_add_comm_group.uniform_cauchy_seq_on_filter_iff_tendsto_uniformly_on_filter_zero
+  {f : ι → E → G} {l : filter ι} {l' : filter E} :
+  uniform_cauchy_seq_on_filter f l l' ↔
+  tendsto_uniformly_on_filter (λ n : ι × ι, λ z : E, f n.fst z - f n.snd z) 0 (l.prod l) l' :=
+begin
+  split,
+  { intros hf u hu,
+    obtain ⟨ε, hε, H⟩ := uniformity_basis_dist.mem_uniformity_iff.mp hu,
+    have : {p : G × G | dist p.fst p.snd < ε} ∈ (𝓤 G),
+    { rw uniformity_basis_dist.mem_uniformity_iff,
+      exact ⟨ε, hε, by simp [H]⟩, },
+    refine (hf {p : G × G | dist p.fst p.snd < ε} this).mono (λ x hx,
+      H 0 (f x.fst.fst x.snd - f x.fst.snd x.snd) _),
+    simpa [dist_eq_norm, norm_sub_rev] using hx, },
+
+  { intros hf u hu,
+    obtain ⟨ε, hε, H⟩ := uniformity_basis_dist.mem_uniformity_iff.mp hu,
+    have : {p : G × G | dist p.fst p.snd < ε} ∈ (𝓤 G),
+    { rw uniformity_basis_dist.mem_uniformity_iff,
+      exact ⟨ε, hε, by simp [H]⟩, },
+    refine (hf {p : G × G | dist p.fst p.snd < ε} this).mono (λ x hx,
+      H (f x.fst.fst x.snd) (f x.fst.snd x.snd) _),
+    simpa [dist_eq_norm, norm_sub_rev] using hx, },
+end
+
+lemma normed_add_comm_group.uniform_cauchy_seq_on_iff_tendsto_uniformly_on_zero
+  {f : ι → E → G} {s : set E} {l : filter ι} :
+  uniform_cauchy_seq_on f l s ↔
+  tendsto_uniformly_on (λ n : ι × ι, λ z : E, f n.fst z - f n.snd z) 0 (l.prod l) s :=
+begin
+  rw tendsto_uniformly_on_iff_tendsto_uniformly_on_filter,
+  rw uniform_cauchy_seq_on_iff_uniform_cauchy_seq_on_filter,
+  exact normed_add_comm_group.uniform_cauchy_seq_on_filter_iff_tendsto_uniformly_on_filter_zero,
+end
+
 open finset
 
 /-- A homomorphism `f` of seminormed groups is Lipschitz, if there exists a constant `C` such that

--- a/src/topology/algebra/uniform_group.lean
+++ b/src/topology/algebra/uniform_group.lean
@@ -322,7 +322,19 @@ uniform_continuous_inv.comp_cauchy_seq h
   by simp [← preimage_smul_inv, preimage]
 
 section uniform_convergence
-variables {ι : Type*} {l : filter ι} {f f' : ι → β → α} {g g' : β → α} {s : set β}
+variables {ι : Type*} {l : filter ι} {l' : filter β} {f f' : ι → β → α} {g g' : β → α} {s : set β}
+
+@[to_additive] lemma tendsto_uniformly_on_filter.mul (hf : tendsto_uniformly_on_filter f g l l')
+  (hf' : tendsto_uniformly_on_filter f' g' l l') :
+  tendsto_uniformly_on_filter (f * f') (g * g') l l' :=
+λ u hu, ((uniform_continuous_mul.comp_tendsto_uniformly_on_filter
+  (hf.prod hf')) u hu).diag_of_prod_left
+
+@[to_additive] lemma tendsto_uniformly_on_filter.div (hf : tendsto_uniformly_on_filter f g l l')
+  (hf' : tendsto_uniformly_on_filter f' g' l l') :
+  tendsto_uniformly_on_filter (f / f') (g / g') l l' :=
+λ u hu, ((uniform_continuous_div.comp_tendsto_uniformly_on_filter
+  (hf.prod hf')) u hu).diag_of_prod_left
 
 @[to_additive] lemma tendsto_uniformly_on.mul (hf : tendsto_uniformly_on f g l s)
   (hf' : tendsto_uniformly_on f' g' l s) : tendsto_uniformly_on (f * f') (g * g') l s :=
@@ -331,6 +343,14 @@ variables {ι : Type*} {l : filter ι} {f f' : ι → β → α} {g g' : β → 
 @[to_additive] lemma tendsto_uniformly_on.div (hf : tendsto_uniformly_on f g l s)
   (hf' : tendsto_uniformly_on f' g' l s) : tendsto_uniformly_on (f / f') (g / g') l s :=
 λ u hu, ((uniform_continuous_div.comp_tendsto_uniformly_on (hf.prod hf')) u hu).diag_of_prod
+
+@[to_additive] lemma tendsto_uniformly.mul (hf : tendsto_uniformly f g l)
+  (hf' : tendsto_uniformly f' g' l) : tendsto_uniformly (f * f') (g * g') l :=
+λ u hu, ((uniform_continuous_mul.comp_tendsto_uniformly (hf.prod hf')) u hu).diag_of_prod
+
+@[to_additive] lemma tendsto_uniformly.div (hf : tendsto_uniformly f g l)
+  (hf' : tendsto_uniformly f' g' l) : tendsto_uniformly (f / f') (g / g') l :=
+λ u hu, ((uniform_continuous_div.comp_tendsto_uniformly (hf.prod hf')) u hu).diag_of_prod
 
 @[to_additive] lemma uniform_cauchy_seq_on.mul (hf : uniform_cauchy_seq_on f l s)
   (hf' : uniform_cauchy_seq_on f' l s) : uniform_cauchy_seq_on (f * f') l s :=

--- a/src/topology/metric_space/basic.lean
+++ b/src/topology/metric_space/basic.lean
@@ -1319,19 +1319,6 @@ end
 end real
 
 section cauchy_seq
-variables [nonempty β] [semilattice_sup β]
-
-/-- In a pseudometric space, Cauchy sequences are characterized by the fact that, eventually,
-the distance between its elements is arbitrarily small -/
-@[nolint ge_or_gt] -- see Note [nolint_ge]
-theorem metric.cauchy_seq_iff {u : β → α} :
-  cauchy_seq u ↔ ∀ε>0, ∃N, ∀m n≥N, dist (u m) (u n) < ε :=
-uniformity_basis_dist.cauchy_seq_iff
-
-/-- A variation around the pseudometric characterization of Cauchy sequences -/
-theorem metric.cauchy_seq_iff' {u : β → α} :
-  cauchy_seq u ↔ ∀ε>0, ∃N, ∀n≥N, dist (u n) (u N) < ε :=
-uniformity_basis_dist.cauchy_seq_iff'
 
 /-- In a pseudometric space, unifom Cauchy sequences are characterized by the fact that, eventually,
 the distance between all its elements is uniformly, arbitrarily small -/
@@ -1356,6 +1343,8 @@ begin
     exact eventually_prod_iff.mpr ⟨(λ z, z ∈ N), hN, (λ z, z ∈ N), hN,
       (λ n hn m hm x hx, hab (hNm n hn m hm x hx))⟩, },
 end
+
+variables [nonempty β] [semilattice_sup β]
 
 /-- In a pseudometric space, unifom Cauchy sequences are characterized by the fact that, eventually,
 the distance between all its elements is uniformly, arbitrarily small. Version for `at_top` -/
@@ -1384,6 +1373,18 @@ begin
     rcases hb with ⟨hbl, hbr⟩,
     exact hab (hN b.fst hbl.ge b.snd hbr.ge x hx), },
 end
+
+/-- In a pseudometric space, Cauchy sequences are characterized by the fact that, eventually,
+the distance between its elements is arbitrarily small -/
+@[nolint ge_or_gt] -- see Note [nolint_ge]
+theorem metric.cauchy_seq_iff {u : β → α} :
+  cauchy_seq u ↔ ∀ε>0, ∃N, ∀m n≥N, dist (u m) (u n) < ε :=
+uniformity_basis_dist.cauchy_seq_iff
+
+/-- A variation around the pseudometric characterization of Cauchy sequences -/
+theorem metric.cauchy_seq_iff' {u : β → α} :
+  cauchy_seq u ↔ ∀ε>0, ∃N, ∀n≥N, dist (u n) (u N) < ε :=
+uniformity_basis_dist.cauchy_seq_iff'
 
 /-- If the distance between `s n` and `s m`, `n ≤ m` is bounded above by `b n`
 and `b` converges to zero, then `s` is a Cauchy sequence.  -/

--- a/src/topology/metric_space/basic.lean
+++ b/src/topology/metric_space/basic.lean
@@ -1335,6 +1335,30 @@ uniformity_basis_dist.cauchy_seq_iff'
 
 /-- In a pseudometric space, unifom Cauchy sequences are characterized by the fact that, eventually,
 the distance between all its elements is uniformly, arbitrarily small -/
+theorem metric.uniform_cauchy_seq_on_iff' {p : filter β} {γ : Type*}
+  {F : β → γ → α} {s : set γ} :
+  uniform_cauchy_seq_on F p s ↔
+    ∀ ε : ℝ, ε > 0 → ∃ t ∈ p, ∀ m, m ∈ t → ∀ n, n ∈ t → ∀ x, x ∈ s →  dist (F m x) (F n x) < ε :=
+begin
+  split,
+  { intros h ε hε,
+    let u := { a : α × α | dist a.fst a.snd < ε },
+    have hu : u ∈ 𝓤 α := metric.mem_uniformity_dist.mpr ⟨ε, hε, (λ a b, by simp)⟩,
+    obtain ⟨pa, hpa, pb, hpb, hpapb⟩ := eventually_prod_iff.mp (h u hu),
+    let t := {a : β | pa a ∧ pb a},
+    refine ⟨t, hpa.and hpb, λ m hm n hn x hx, _⟩,
+    have hpam := (set.mem_set_of.mp hm).1,
+    have hpan := (set.mem_set_of.mp hn).2,
+    simpa [u] using (hpapb hpam hpan x hx), },
+  { intros h u hu,
+    rcases (metric.mem_uniformity_dist.mp hu) with ⟨ε, hε, hab⟩,
+    rcases h ε hε with ⟨N, hN, hNm⟩,
+    exact eventually_prod_iff.mpr ⟨(λ z, z ∈ N), hN, (λ z, z ∈ N), hN,
+      (λ n hn m hm x hx, hab (hNm n hn m hm x hx))⟩, },
+end
+
+/-- In a pseudometric space, unifom Cauchy sequences are characterized by the fact that, eventually,
+the distance between all its elements is uniformly, arbitrarily small. Version for `at_top` -/
 @[nolint ge_or_gt] -- see Note [nolint_ge]
 theorem metric.uniform_cauchy_seq_on_iff {γ : Type*}
   {F : β → γ → α} {s : set γ} :

--- a/src/topology/metric_space/basic.lean
+++ b/src/topology/metric_space/basic.lean
@@ -800,6 +800,17 @@ begin
   exact hs _ (dist_mem_uniformity ε_pos),
 end
 
+/-- Expressing uniform convergence using `dist` -/
+lemma tendsto_uniformly_on_filter_iff {ι : Type*}
+  {F : ι → β → α} {f : β → α} {p : filter ι} {p' : filter β} :
+  tendsto_uniformly_on_filter F f p p' ↔
+  ∀ ε > 0, ∀ᶠ (n : ι × β) in (p ×ᶠ p'), dist (f n.snd) (F n.fst n.snd) < ε :=
+begin
+  refine ⟨λ H ε hε, H _ (dist_mem_uniformity hε), λ H u hu, _⟩,
+  rcases mem_uniformity_dist.1 hu with ⟨ε, εpos, hε⟩,
+  refine (H ε εpos).mono (λ n hn, hε hn),
+end
+
 /-- Expressing locally uniform convergence on a set using `dist`. -/
 lemma tendsto_locally_uniformly_on_iff {ι : Type*} [topological_space β]
   {F : ι → β → α} {f : β → α} {p : filter ι} {s : set β} :

--- a/src/topology/uniform_space/uniform_convergence.lean
+++ b/src/topology/uniform_space/uniform_convergence.lean
@@ -41,6 +41,13 @@ convergence what a Cauchy sequence is to the usual notion of convergence.
 
 ## Implementation notes
 
+We derive most of our initial results from an auxiliary definition `tendsto_uniformly_on_filter`.
+This definition in and of itself can sometimes be useful, e.g., when studying the local behavior
+of the `Fₙ` near a point, which would typically look like `tendsto_uniformly_on_filter F f p (𝓝 x)`.
+Still, while this may be the "correct" definition (see
+`tendsto_uniformly_on_iff_tendtso_uniformly_on_filter`), it is somewhat unwieldy to work with in
+practice. Thus, we provide the more traditional definition in `tendsto_uniformly_on`.
+
 Most results hold under weaker assumptions of locally uniform approximation. In a first section,
 we prove the results under these weaker assumptions. Then, we derive the results on uniform
 convergence from them.
@@ -55,9 +62,77 @@ open_locale topological_space classical uniformity filter
 
 open set filter
 
+section generic
+
+variables {α β γ ι : Type*} {p : filter ι} {p' : filter α}
+
+lemma filter.eventually_swap_iff {f : (ι × α) → Prop} : (∀ᶠ (x : ι × α) in (p.prod p'), f x) ↔
+  ∀ᶠ (y : α × ι) in (p'.prod p), f y.swap :=
+begin
+  rw [eventually_prod_iff, eventually_prod_iff],
+  split,
+  { intros h,
+    obtain ⟨pa, hpa, pb, hpb, hpapb⟩ := h,
+    exact ⟨pb, hpb, pa, hpa, λ x hx y hy, hpapb hy hx⟩, },
+  { intros h,
+    obtain ⟨pa, hpa, pb, hpb, hpapb⟩ := h,
+    exact ⟨pb, hpb, pa, hpa, λ x hx y hy, hpapb hy hx⟩, },
+end
+
+lemma eventually_prod_principal_iff {f : ι × α → Prop} {s : set α} :
+  (∀ᶠ (x : ι × α) in (p.prod (𝓟 s)), f x) ↔ ∀ᶠ (n : ι) in p, ∀ (y : α), y ∈ s → f (n, y) :=
+begin
+  rw [eventually_prod_iff, eventually_iff_exists_mem],
+  split,
+  { rintros ⟨pa, hpa, pb, hpb, hpapb⟩,
+    exact ⟨_, hpa, (λ n hn y hy, hpapb hn ((eventually_principal.mp hpb) y hy))⟩, },
+  { rintros ⟨t, ht, htmem⟩,
+    exact ⟨_, ht, _, by simp, htmem⟩, },
+end
+
+lemma filter.prod_le_of_le_of_le {p₁ p₂ : filter ι} {q₁ q₂ : filter α} (hp : p₁ ≤ p₂)
+  (hq : q₁ ≤ q₂) :  p₁ ×ᶠ q₁ ≤ p₂ ×ᶠ q₂ :=
+begin
+  intros s hs,
+  rw mem_prod_iff at hs ⊢,
+  obtain ⟨t₁, ht₁, t₂, ht₂, ht⟩ := hs,
+  exact ⟨t₁, hp ht₁, t₂, hq ht₂, ht⟩,
+end
+
+lemma filter.prod_le_of_left_le (p' : filter α) {p'' : filter ι} (hp : p ≤ p'') :
+  p ×ᶠ p' ≤ p'' ×ᶠ p' :=
+filter.prod_le_of_le_of_le hp rfl.le
+
+lemma filter.prod_le_of_right_le (p : filter ι) {p'' : filter α} (hp : p' ≤ p'') :
+  p ×ᶠ p' ≤ p ×ᶠ p'' :=
+filter.prod_le_of_le_of_le rfl.le hp
+
+lemma filter.eventually.diag_of_prod_left {f : filter α} {g : filter γ}
+  {p : (α × α) × γ → Prop} :
+  (∀ᶠ x in (f ×ᶠ f ×ᶠ g), p x) →
+  (∀ᶠ (x : α × γ) in (f ×ᶠ g), p ((x.1, x.1), x.2)) :=
+begin
+  intros h,
+  obtain ⟨t, ht, s, hs, hst⟩ := eventually_prod_iff.1 h,
+  refine (ht.diag_of_prod.prod_mk hs).mono (λ x hx, by simp only [hst hx.1 hx.2, prod.mk.eta]),
+end
+
+lemma filter.eventually.diag_of_prod_right {f : filter α} {g : filter γ}
+  {p : α × γ × γ → Prop} :
+  (∀ᶠ x in (f ×ᶠ (g ×ᶠ g)), p x) →
+  (∀ᶠ (x : α × γ) in (f ×ᶠ g), p (x.1, x.2, x.2)) :=
+begin
+  intros h,
+  obtain ⟨t, ht, s, hs, hst⟩ := eventually_prod_iff.1 h,
+  refine (ht.prod_mk hs.diag_of_prod).mono (λ x hx, by simp only [hst hx.1 hx.2, prod.mk.eta]),
+end
+
+end generic
+
 universes u v w
 variables {α β γ ι : Type*} [uniform_space β]
-variables {F : ι → α → β} {f : α → β} {s s' : set α} {x : α} {p : filter ι} {g : ι → α}
+variables {F : ι → α → β} {f : α → β} {s s' : set α} {x : α} {p : filter ι} {p' : filter α}
+  {g : ι → α}
 
 /-!
 ### Different notions of uniform convergence
@@ -65,11 +140,40 @@ variables {F : ι → α → β} {f : α → β} {s s' : set α} {x : α} {p : f
 We define uniform convergence and locally uniform convergence, on a set or in the whole space.
 -/
 
+/-- A sequence of functions `Fₙ` converges uniformly on a filter `p'` to a limiting function `f`
+with respect to the filter `p` if, for any entourage of the diagonal `u`, one has
+`p ×ᶠ p'`-eventually `(f x, Fₙ x) ∈ u`. -/
+def tendsto_uniformly_on_filter (F : ι → α → β) (f : α → β) (p : filter ι) (p' : filter α) :=
+∀ u ∈ 𝓤 β, ∀ᶠ (n : ι × α) in (p ×ᶠ p'), (f n.snd, F n.fst n.snd) ∈ u
+
+/--
+A sequence of functions `Fₙ` converges uniformly on a filter `p'` to a limiting function `f` w.r.t.
+filter `p` iff the function `(n, x) ↦ (f x, Fₙ x)` converges along `p ×ᶠ p'` to the uniformity.
+In other words: one knows nothing about the behavior of `x` in this limit besides it being in `p'`.
+-/
+lemma tendsto_uniformly_on_filter_iff_tendsto :
+  tendsto_uniformly_on_filter F f p p' ↔
+  tendsto (λ q : ι × α, (f q.2, F q.1 q.2)) (p ×ᶠ p') (𝓤 β) :=
+forall₂_congr $ λ u u_in, by simp [mem_map, filter.eventually, mem_prod_iff, preimage]
+
 /-- A sequence of functions `Fₙ` converges uniformly on a set `s` to a limiting function `f` with
 respect to the filter `p` if, for any entourage of the diagonal `u`, one has `p`-eventually
 `(f x, Fₙ x) ∈ u` for all `x ∈ s`. -/
 def tendsto_uniformly_on (F : ι → α → β) (f : α → β) (p : filter ι) (s : set α) :=
-∀ u ∈ 𝓤 β, ∀ᶠ n in p, ∀ x ∈ s, (f x, F n x) ∈ u
+∀ u ∈ 𝓤 β, ∀ᶠ n in p, ∀ (x : α), x ∈ s → (f x, F n x) ∈ u
+
+lemma tendsto_uniformly_on_iff_tendsto_uniformly_on_filter :
+  tendsto_uniformly_on F f p s ↔ tendsto_uniformly_on_filter F f p (𝓟 s) :=
+begin
+  simp only [tendsto_uniformly_on, tendsto_uniformly_on_filter],
+  apply forall₂_congr,
+  simp_rw [eventually_prod_principal_iff],
+  simp,
+end
+
+lemma tendsto_uniformly_on.tendsto_uniformly_on_filter
+  (h : tendsto_uniformly_on F f p s) : tendsto_uniformly_on_filter F f p (𝓟 s) :=
+by rwa ← tendsto_uniformly_on_iff_tendsto_uniformly_on_filter
 
 /--
 A sequence of functions `Fₙ` converges uniformly on a set `s` to a limiting function `f` w.r.t.
@@ -78,17 +182,35 @@ In other words: one knows nothing about the behavior of `x` in this limit beside
 -/
 lemma tendsto_uniformly_on_iff_tendsto {F : ι → α → β} {f : α → β} {p : filter ι} {s : set α} :
   tendsto_uniformly_on F f p s ↔ tendsto (λ q : ι × α, (f q.2, F q.1 q.2)) (p ×ᶠ 𝓟 s) (𝓤 β) :=
-forall₂_congr $ λ u u_in, by simp [mem_map, filter.eventually, mem_prod_principal]
+by simp [tendsto_uniformly_on_iff_tendsto_uniformly_on_filter,
+  tendsto_uniformly_on_filter_iff_tendsto]
 
 /-- A sequence of functions `Fₙ` converges uniformly to a limiting function `f` with respect to a
 filter `p` if, for any entourage of the diagonal `u`, one has `p`-eventually
 `(f x, Fₙ x) ∈ u` for all `x`. -/
 def tendsto_uniformly (F : ι → α → β) (f : α → β) (p : filter ι) :=
-∀ u ∈ 𝓤 β, ∀ᶠ n in p, ∀ x, (f x, F n x) ∈ u
+∀ u ∈ 𝓤 β, ∀ᶠ n in p, ∀ (x : α), (f x, F n x) ∈ u
+
+lemma tendsto_uniformly_iff_tendsto_uniformly_on_filter :
+  tendsto_uniformly F f p ↔ tendsto_uniformly_on_filter F f p ⊤ :=
+begin
+  simp only [tendsto_uniformly, tendsto_uniformly_on_filter],
+  apply forall₂_congr,
+  simp_rw [← principal_univ, eventually_prod_principal_iff],
+  simp,
+end
+
+lemma tendsto_uniformly.tendsto_uniformly_on_filter
+  (h : tendsto_uniformly F f p) : tendsto_uniformly_on_filter F f p ⊤ :=
+by rwa ← tendsto_uniformly_iff_tendsto_uniformly_on_filter
 
 lemma tendsto_uniformly_on_iff_tendsto_uniformly_comp_coe :
   tendsto_uniformly_on F f p s ↔ tendsto_uniformly (λ i (x : s), F i x) (f ∘ coe) p :=
-forall₂_congr $ λ V hV, by simp
+begin
+  apply forall₂_congr,
+  intros u hu,
+  simp,
+end
 
 /--
 A sequence of functions `Fₙ` converges uniformly to a limiting function `f` w.r.t.
@@ -97,43 +219,107 @@ In other words: one knows nothing about the behavior of `x` in this limit.
 -/
 lemma tendsto_uniformly_iff_tendsto {F : ι → α → β} {f : α → β} {p : filter ι} :
   tendsto_uniformly F f p ↔ tendsto (λ q : ι × α, (f q.2, F q.1 q.2)) (p ×ᶠ ⊤) (𝓤 β) :=
-forall₂_congr $ λ u u_in, by simp [mem_map, filter.eventually, mem_prod_top]
+by simp [tendsto_uniformly_iff_tendsto_uniformly_on_filter, tendsto_uniformly_on_filter_iff_tendsto]
+
+/-- Uniform converence implies pointwise convergence. -/
+lemma tendsto_uniformly_on_filter.tendsto_at (h : tendsto_uniformly_on_filter F f p p')
+  (hx : 𝓟 {x} ≤ p') : tendsto (λ n, F n x) p $ 𝓝 (f x) :=
+begin
+  refine uniform.tendsto_nhds_right.mpr (λ u hu, mem_map.mpr _),
+  filter_upwards [(h u hu).curry],
+  intros i h,
+  simpa using (h.filter_mono hx),
+end
+
+/-- Uniform converence implies pointwise convergence. -/
+lemma tendsto_uniformly_on.tendsto_at (h : tendsto_uniformly_on F f p s) {x : α} (hx : x ∈ s) :
+  tendsto (λ n, F n x) p $ 𝓝 (f x) :=
+h.tendsto_uniformly_on_filter.tendsto_at
+  (le_principal_iff.mpr $ mem_principal.mpr $ singleton_subset_iff.mpr $ hx)
 
 /-- Uniform converence implies pointwise convergence. -/
 lemma tendsto_uniformly.tendsto_at (h : tendsto_uniformly F f p) (x : α) :
   tendsto (λ n, F n x) p $ 𝓝 (f x) :=
-uniform.tendsto_nhds_right.mpr $ λ u hu, mem_map.mpr $ by { filter_upwards [h u hu], tauto, }
+h.tendsto_uniformly_on_filter.tendsto_at le_top
 
 lemma tendsto_uniformly_on_univ :
   tendsto_uniformly_on F f p univ ↔ tendsto_uniformly F f p :=
 by simp [tendsto_uniformly_on, tendsto_uniformly]
 
+lemma tendsto_uniformly_on_filter.mono_left {p'' : filter ι}
+  (h : tendsto_uniformly_on_filter F f p p') (hp : p'' ≤ p) :
+  tendsto_uniformly_on_filter F f p'' p' :=
+λ u hu, (h u hu).filter_mono (p'.prod_le_of_left_le hp)
+
+lemma tendsto_uniformly_on_filter.mono_right {p'' : filter α}
+  (h : tendsto_uniformly_on_filter F f p p') (hp : p'' ≤ p') :
+  tendsto_uniformly_on_filter F f p p'' :=
+λ u hu, (h u hu).filter_mono (p.prod_le_of_right_le hp)
+
 lemma tendsto_uniformly_on.mono {s' : set α}
   (h : tendsto_uniformly_on F f p s) (h' : s' ⊆ s) : tendsto_uniformly_on F f p s' :=
-λ u hu, (h u hu).mono (λ n hn x hx, hn x (h' hx))
+tendsto_uniformly_on_iff_tendsto_uniformly_on_filter.mpr
+  (h.tendsto_uniformly_on_filter.mono_right (le_principal_iff.mpr $ mem_principal.mpr h'))
+
+lemma tendsto_uniformly_on_filter.congr {F' : ι → α → β}
+  (hf : tendsto_uniformly_on_filter F f p p')
+  (hff' : ∀ᶠ (n : ι × α) in (p ×ᶠ p'), F n.fst n.snd = F' n.fst n.snd) :
+  tendsto_uniformly_on_filter F' f p p' :=
+begin
+  refine (λ u hu, ((hf u hu).and hff').mono (λ n h, _)),
+  rw ← h.right,
+  exact h.left,
+end
 
 lemma tendsto_uniformly_on.congr {F' : ι → α → β}
   (hf : tendsto_uniformly_on F f p s) (hff' : ∀ᶠ n in p, set.eq_on (F n) (F' n) s) :
   tendsto_uniformly_on F' f p s :=
 begin
-  refine (λ u hu, ((hf u hu).and hff').mono (λ n h x hx, _)),
-  rw ← h.right hx,
-  exact h.left x hx,
+  rw tendsto_uniformly_on_iff_tendsto_uniformly_on_filter at hf ⊢,
+  refine hf.congr _,
+  rw eventually_iff at hff' ⊢,
+  simp only [set.eq_on] at hff',
+  simp only [mem_prod_principal, hff', mem_set_of_eq],
 end
 
 protected lemma tendsto_uniformly.tendsto_uniformly_on
   (h : tendsto_uniformly F f p) : tendsto_uniformly_on F f p s :=
 (tendsto_uniformly_on_univ.2 h).mono (subset_univ s)
 
+/-- Composing on the right by a function preserves uniform convergence on a filter -/
+lemma tendsto_uniformly_on_filter.comp (h : tendsto_uniformly_on_filter F f p p') (g : γ → α) :
+  tendsto_uniformly_on_filter (λ n, F n ∘ g) (f ∘ g) p (p'.comap g) :=
+begin
+  intros u hu,
+  obtain ⟨pa, hpa, pb, hpb, hpapb⟩ := eventually_prod_iff.mp (h u hu),
+  rw eventually_prod_iff,
+  simp_rw eventually_comap,
+  exact ⟨pa, hpa, pb ∘ g, ⟨hpb.mono (λ x hx y hy, by simp only [hx, hy, function.comp_app]),
+    λ x hx y hy, hpapb hx hy⟩⟩,
+end
+
 /-- Composing on the right by a function preserves uniform convergence on a set -/
 lemma tendsto_uniformly_on.comp (h : tendsto_uniformly_on F f p s) (g : γ → α) :
   tendsto_uniformly_on (λ n, F n ∘ g) (f ∘ g) p (g ⁻¹' s) :=
-λ u hu, (h u hu).mono (λ i hi, λ a, hi (g a))
+begin
+  rw tendsto_uniformly_on_iff_tendsto_uniformly_on_filter at h ⊢,
+  simpa [tendsto_uniformly_on, comap_principal] using (tendsto_uniformly_on_filter.comp h g),
+end
 
 /-- Composing on the right by a function preserves uniform convergence -/
 lemma tendsto_uniformly.comp (h : tendsto_uniformly F f p) (g : γ → α) :
   tendsto_uniformly (λ n, F n ∘ g) (f ∘ g) p :=
-λ u hu, (h u hu).mono (λ i hi, λ a, hi (g a))
+begin
+  rw tendsto_uniformly_iff_tendsto_uniformly_on_filter at h ⊢,
+  simpa [principal_univ, comap_principal] using (h.comp g),
+end
+
+/-- Composing on the left by a uniformly continuous function preserves
+  uniform convergence on a filter -/
+lemma uniform_continuous.comp_tendsto_uniformly_on_filter [uniform_space γ] {g : β → γ}
+  (hg : uniform_continuous g) (h : tendsto_uniformly_on_filter F f p p') :
+  tendsto_uniformly_on_filter (λ i, g ∘ (F i)) (g ∘ f) p p' :=
+λ u hu, h _ (hg hu)
 
 /-- Composing on the left by a uniformly continuous function preserves
   uniform convergence on a set -/
@@ -148,17 +334,32 @@ lemma uniform_continuous.comp_tendsto_uniformly [uniform_space γ] {g : β → �
   tendsto_uniformly (λ i, g ∘ (F i)) (g ∘ f) p :=
 λ u hu, h _ (hg hu)
 
+lemma tendsto_uniformly_on_filter.prod_map {ι' α' β' : Type*} [uniform_space β']
+  {F' : ι' → α' → β'} {f' : α' → β'} {q : filter ι'} {q' : filter α'}
+  (h : tendsto_uniformly_on_filter F f p p') (h' : tendsto_uniformly_on_filter F' f' q q') :
+  tendsto_uniformly_on_filter (λ (i : ι × ι'), prod.map (F i.1) (F' i.2))
+    (prod.map f f') (p.prod q) (p'.prod q') :=
+begin
+  intros u hu,
+  rw [uniformity_prod_eq_prod, mem_map, mem_prod_iff] at hu,
+  obtain ⟨v, hv, w, hw, hvw⟩ := hu,
+  apply (tendsto_swap4_prod.eventually ((h v hv).prod_mk (h' w hw))).mono,
+  simp only [prod_map, and_imp, prod.forall],
+  intros n n' x hxv hxw,
+  have hout : ((f x.fst, F n x.fst), (f' x.snd, F' n' x.snd)) ∈
+    {x : (β × β) × β' × β' | ((x.fst.fst, x.snd.fst), x.fst.snd, x.snd.snd) ∈ u},
+  { exact mem_of_mem_of_subset (set.mem_prod.mpr ⟨hxv, hxw⟩) hvw, },
+  exact hout,
+end
+
 lemma tendsto_uniformly_on.prod_map {ι' α' β' : Type*} [uniform_space β']
   {F' : ι' → α' → β'} {f' : α' → β'} {p' : filter ι'} {s' : set α'}
   (h : tendsto_uniformly_on F f p s) (h' : tendsto_uniformly_on F' f' p' s') :
   tendsto_uniformly_on (λ (i : ι × ι'), prod.map (F i.1) (F' i.2))
     (prod.map f f') (p.prod p') (s ×ˢ s') :=
 begin
-  intros u hu,
-  rw [uniformity_prod_eq_prod, mem_map, mem_prod_iff] at hu,
-  obtain ⟨v, hv, w, hw, hvw⟩ := hu,
-  exact mem_prod_iff.mpr ⟨_, h v hv, _, h' w hw,
-    λ i hi a ha, hvw (show (_, _) ∈ v ×ˢ w, from ⟨hi.1 a.1 ha.1, hi.2 a.2 ha.2⟩)⟩,
+  rw tendsto_uniformly_on_iff_tendsto_uniformly_on_filter at h h' ⊢,
+  simpa only [prod_principal_principal] using (h.prod_map h'),
 end
 
 lemma tendsto_uniformly.prod_map {ι' α' β' : Type*} [uniform_space β'] {F' : ι' → α' → β'}
@@ -168,6 +369,13 @@ begin
   rw [←tendsto_uniformly_on_univ, ←univ_prod_univ] at *,
   exact h.prod_map h',
 end
+
+lemma tendsto_uniformly_on_filter.prod {ι' β' : Type*} [uniform_space β']
+  {F' : ι' → α → β'} {f' : α → β'} {q : filter ι'}
+  (h : tendsto_uniformly_on_filter F f p p') (h' : tendsto_uniformly_on_filter F' f' q p') :
+  tendsto_uniformly_on_filter (λ (i : ι × ι') a, (F i.1 a, F' i.2 a)) 
+    (λ a, (f a, f' a)) (p.prod q) p' :=
+λ u hu, ((h.prod_map h') u hu).diag_of_prod_right
 
 lemma tendsto_uniformly_on.prod {ι' β' : Type*} [uniform_space β'] {F' : ι' → α → β'} {f' : α → β'}
   {p' : filter ι'} (h : tendsto_uniformly_on F f p s) (h' : tendsto_uniformly_on F' f' p' s) :
@@ -179,20 +387,30 @@ lemma tendsto_uniformly.prod {ι' β' : Type*} [uniform_space β'] {F' : ι' →
   tendsto_uniformly (λ (i : ι × ι') a, (F i.1 a, F' i.2 a)) (λ a, (f a, f' a)) (p.prod p') :=
 (h.prod_map h').comp (λ a, (a, a))
 
+/-- Uniform convergence on a filter `p'` to a constant function is equivalent to convergence in
+`p ×ᶠ p'`. -/
+lemma tendsto_prod_filter_iff {c : β} :
+  tendsto ↿F (p ×ᶠ p') (𝓝 c) ↔ tendsto_uniformly_on_filter F (λ _, c) p p' :=
+begin
+  simp_rw [tendsto, nhds_eq_comap_uniformity, map_le_iff_le_comap.symm, map_map, le_def, mem_map],
+  exact forall₂_congr (λ u hu, by simpa [eventually_iff]),
+end
+
 /-- Uniform convergence on a set `s` to a constant function is equivalent to convergence in
 `p ×ᶠ 𝓟 s`. -/
 lemma tendsto_prod_principal_iff {c : β} :
   tendsto ↿F (p ×ᶠ 𝓟 s) (𝓝 c) ↔ tendsto_uniformly_on F (λ _, c) p s :=
 begin
-  unfold tendsto,
-  simp_rw [nhds_eq_comap_uniformity, map_le_iff_le_comap.symm, map_map, le_def, mem_map,
-    mem_prod_principal],
-  simpa,
+  rw tendsto_uniformly_on_iff_tendsto_uniformly_on_filter,
+  exact tendsto_prod_filter_iff,
 end
 
 /-- Uniform convergence to a constant function is equivalent to convergence in `p ×ᶠ ⊤`. -/
 lemma tendsto_prod_top_iff {c : β} : tendsto ↿F (p ×ᶠ ⊤) (𝓝 c) ↔ tendsto_uniformly F (λ _, c) p :=
-by rw [←principal_univ, ←tendsto_uniformly_on_univ, ←tendsto_prod_principal_iff]
+begin
+  rw tendsto_uniformly_iff_tendsto_uniformly_on_filter,
+  exact tendsto_prod_filter_iff,
+end
 
 /-- Uniform convergence on the empty set is vacuously true -/
 lemma tendsto_uniformly_on_empty :
@@ -202,16 +420,30 @@ lemma tendsto_uniformly_on_empty :
 /-- Uniform convergence on a singleton is equivalent to regular convergence -/
 lemma tendsto_uniformly_on_singleton_iff_tendsto :
   tendsto_uniformly_on F f p {x} ↔ tendsto (λ n : ι, F n x) p (𝓝 (f x)) :=
-by simp_rw [uniform.tendsto_nhds_right, tendsto_uniformly_on, mem_singleton_iff, forall_eq,
-  tendsto_def, preimage, filter.eventually]
+begin
+  simp_rw [tendsto_uniformly_on_iff_tendsto, uniform.tendsto_nhds_right, tendsto_def],
+  exact forall₂_congr (λ u hu, by simp [mem_prod_principal, preimage]),
+end
+
+/-- If a sequence `g` converges to some `b`, then the sequence of constant functions
+`λ n, λ a, g n` converges to the constant function `λ a, b` on any set `s` -/
+lemma filter.tendsto.tendsto_uniformly_on_filter_const
+  {g : ι → β} {b : β} (hg : tendsto g p (𝓝 b)) (p' : filter α) :
+  tendsto_uniformly_on_filter (λ n : ι, λ a : α, g n) (λ a : α, b) p p' :=
+begin
+  rw tendsto_uniformly_on_filter_iff_tendsto,
+  rw uniform.tendsto_nhds_right at hg,
+  exact (hg.comp (tendsto_fst.comp ((@tendsto_id ι p).prod_map (@tendsto_id α p')))).congr
+    (λ x, by simp),
+end
 
 /-- If a sequence `g` converges to some `b`, then the sequence of constant functions
 `λ n, λ a, g n` converges to the constant function `λ a, b` on any set `s` -/
 lemma filter.tendsto.tendsto_uniformly_on_const
   {g : ι → β} {b : β} (hg : tendsto g p (𝓝 b)) (s : set α) :
   tendsto_uniformly_on (λ n : ι, λ a : α, g n) (λ a : α, b) p s :=
-λ u hu, hg.eventually
-  (eventually_of_mem (mem_nhds_left b hu) (λ x hx y hy, hx) : ∀ᶠ x in 𝓝 b, ∀ y ∈ s, (b, x) ∈ u)
+tendsto_uniformly_on_iff_tendsto_uniformly_on_filter.mpr
+  (hg.tendsto_uniformly_on_filter_const (𝓟 s))
 
 lemma uniform_continuous_on.tendsto_uniformly [uniform_space α] [uniform_space γ]
   {x : α} {U : set α} (hU : U ∈ 𝓝 x)
@@ -239,29 +471,55 @@ uniform_continuous_on.tendsto_uniformly univ_mem $
 
 /-- A sequence is uniformly Cauchy if eventually all of its pairwise differences are
 uniformly bounded -/
+def uniform_cauchy_seq_on_filter
+  (F : ι → α → β) (p : filter ι) (p' : filter α) : Prop :=
+  ∀ u : set (β × β), u ∈ 𝓤 β → ∀ᶠ (m : (ι × ι) × α) in ((p ×ᶠ p) ×ᶠ p'),
+    (F m.fst.fst m.snd, F m.fst.snd m.snd) ∈ u
+
+/-- A sequence is uniformly Cauchy if eventually all of its pairwise differences are
+uniformly bounded -/
 def uniform_cauchy_seq_on
   (F : ι → α → β) (p : filter ι) (s : set α) : Prop :=
-  ∀ u : set (β × β), u ∈ 𝓤 β → ∀ᶠ (m : ι × ι) in (p ×ᶠ p),
-    ∀ (x : α), x ∈ s → (F m.fst x, F m.snd x) ∈ u
+  ∀ u : set (β × β), u ∈ 𝓤 β → ∀ᶠ (m : ι × ι) in (p ×ᶠ p), ∀ (x : α), x ∈ s →
+    (F m.fst x, F m.snd x) ∈ u
+
+lemma uniform_cauchy_seq_on_iff_uniform_cauchy_seq_on_filter :
+  uniform_cauchy_seq_on F p s ↔ uniform_cauchy_seq_on_filter F p (𝓟 s) :=
+begin
+  simp only [uniform_cauchy_seq_on, uniform_cauchy_seq_on_filter],
+  refine forall₂_congr (λ u hu, _),
+  rw eventually_prod_principal_iff,
+end
+
+lemma uniform_cauchy_seq_on.uniform_cauchy_seq_on_filter (hF : uniform_cauchy_seq_on F p s) :
+  uniform_cauchy_seq_on_filter F p (𝓟 s) :=
+by rwa ←uniform_cauchy_seq_on_iff_uniform_cauchy_seq_on_filter
+
+/-- A sequence that converges uniformly is also uniformly Cauchy -/
+lemma tendsto_uniformly_on_filter.uniform_cauchy_seq_on_filter
+  (hF : tendsto_uniformly_on_filter F f p p') :
+  uniform_cauchy_seq_on_filter F p p' :=
+begin
+  intros u hu,
+  rcases comp_symm_of_uniformity hu with ⟨t, ht, htsymm, htmem⟩,
+  have := tendsto_swap4_prod.eventually ((hF t ht).prod_mk (hF t ht)),
+  apply this.diag_of_prod_right.mono,
+  simp only [and_imp, prod.forall],
+  intros n1 n2 x hl hr,
+  exact set.mem_of_mem_of_subset (prod_mk_mem_comp_rel (htsymm hl) hr) htmem,
+end
 
 /-- A sequence that converges uniformly is also uniformly Cauchy -/
 lemma tendsto_uniformly_on.uniform_cauchy_seq_on (hF : tendsto_uniformly_on F f p s) :
   uniform_cauchy_seq_on F p s :=
-begin
-  intros u hu,
-  rcases comp_symm_of_uniformity hu with ⟨t, ht, htsymm, htmem⟩,
-  apply ((hF t ht).prod_mk (hF t ht)).mono,
-  intros n h x hx,
-  cases h with hl hr,
-  specialize hl x hx,
-  specialize hr x hx,
-  exact set.mem_of_mem_of_subset (prod_mk_mem_comp_rel (htsymm hl) hr) htmem,
-end
+uniform_cauchy_seq_on_iff_uniform_cauchy_seq_on_filter.mpr
+  hF.tendsto_uniformly_on_filter.uniform_cauchy_seq_on_filter
 
 /-- A uniformly Cauchy sequence converges uniformly to its limit -/
-lemma uniform_cauchy_seq_on.tendsto_uniformly_on_of_tendsto [ne_bot p]
-  (hF : uniform_cauchy_seq_on F p s) (hF' : ∀ x : α, x ∈ s → tendsto (λ n, F n x) p (nhds (f x))) :
-  tendsto_uniformly_on F f p s :=
+lemma uniform_cauchy_seq_on_filter.tendsto_uniformly_on_filter_of_tendsto [ne_bot p]
+  (hF : uniform_cauchy_seq_on_filter F p p')
+  (hF' : ∀ᶠ (x : α) in p', tendsto (λ n, F n x) p (𝓝 (f x))) :
+  tendsto_uniformly_on_filter F f p p' :=
 begin
   -- Proof idea: |f_n(x) - f(x)| ≤ |f_n(x) - f_m(x)| + |f_m(x) - f(x)|. We choose `n`
   -- so that |f_n(x) - f_m(x)| is uniformly small across `s` whenever `m ≥ n`. Then for
@@ -269,30 +527,79 @@ begin
   intros u hu,
   rcases comp_symm_of_uniformity hu with ⟨t, ht, htsymm, htmem⟩,
 
-  -- Choose n
-  apply (hF t ht).curry.mono,
+  -- We will choose n, x, and m simultaneously. n and x come from hF. m comes from hF'
+  -- But we need to promote hF' to the full product filter to use it
+  have hmc : ∀ᶠ (x : (ι × ι) × α) in p ×ᶠ p ×ᶠ p', tendsto (λ (n : ι), F n x.snd) p (𝓝 (f x.snd)),
+  { rw eventually_prod_iff,
+    refine ⟨(λ x, true), by simp, _, hF', by simp⟩, },
 
-  -- Work with a specific x
-  intros n hn x hx,
+  -- To apply filter operations we'll need to do some order manipulation
+  rw filter.eventually_swap_iff,
+  have := tendsto_prod_assoc.eventually (tendsto_prod_swap.eventually ((hF t ht).and hmc)),
+  apply this.curry.mono,
+  simp only [equiv.prod_assoc_apply, eventually_and, eventually_const, prod.snd_swap,
+    prod.fst_swap, and_imp, prod.forall],
+
+  -- Complete the proof
+  intros x n hx hm',
   refine set.mem_of_mem_of_subset (mem_comp_rel.mpr _) htmem,
+  rw uniform.tendsto_nhds_right at hm',
+  have := hx.and (hm' ht),
+  obtain ⟨m, hm⟩ := this.exists,
+  exact ⟨F m x, ⟨hm.2, htsymm hm.1⟩⟩,
+end
 
-  -- Choose m
-  specialize hF' x hx,
-  rw uniform.tendsto_nhds_right at hF',
-  rcases (hn.and (hF'.eventually (eventually_mem_set.mpr ht))).exists with ⟨m, hm, hm'⟩,
+/-- A uniformly Cauchy sequence converges uniformly to its limit -/
+lemma uniform_cauchy_seq_on.tendsto_uniformly_on_of_tendsto [ne_bot p]
+  (hF : uniform_cauchy_seq_on F p s) (hF' : ∀ x : α, x ∈ s → tendsto (λ n, F n x) p (𝓝 (f x))) :
+  tendsto_uniformly_on F f p s :=
+tendsto_uniformly_on_iff_tendsto_uniformly_on_filter.mpr
+  (hF.uniform_cauchy_seq_on_filter.tendsto_uniformly_on_filter_of_tendsto hF')
 
-  -- Finish the proof
-  exact ⟨F m x, ⟨hm', htsymm (hm x hx)⟩⟩,
+lemma uniform_cauchy_seq_on_filter.mono_left {p'' : filter ι}
+  (hf : uniform_cauchy_seq_on_filter F p p') (hp : p'' ≤ p) :
+  uniform_cauchy_seq_on_filter F p'' p' :=
+begin
+  intros u hu,
+  have := (hf u hu).filter_mono (p'.prod_le_of_left_le (filter.prod_le_of_le_of_le hp hp)),
+  exact this.mono (by simp),
+end
+
+lemma uniform_cauchy_seq_on_filter.mono_right {p'' : filter α}
+  (hf : uniform_cauchy_seq_on_filter F p p') (hp : p'' ≤ p') :
+  uniform_cauchy_seq_on_filter F p p'' :=
+begin
+  intros u hu,
+  have := (hf u hu).filter_mono ((p ×ᶠ p).prod_le_of_right_le hp),
+  exact this.mono (by simp),
 end
 
 lemma uniform_cauchy_seq_on.mono {s' : set α} (hf : uniform_cauchy_seq_on F p s) (hss' : s' ⊆ s) :
   uniform_cauchy_seq_on F p s' :=
-λ u hu, (hf u hu).mono (λ x hx y hy, hx y (hss' hy))
+begin
+  rw uniform_cauchy_seq_on_iff_uniform_cauchy_seq_on_filter at hf ⊢,
+  exact hf.mono_right (le_principal_iff.mpr $mem_principal.mpr hss'),
+end
+
+/-- Composing on the right by a function preserves uniform Cauchy sequences -/
+lemma uniform_cauchy_seq_on_filter.comp {γ : Type*} (hf : uniform_cauchy_seq_on_filter F p p')
+  (g : γ → α) :
+  uniform_cauchy_seq_on_filter (λ n, F n ∘ g) p (p'.comap g) :=
+begin
+  intros u hu,
+  obtain ⟨pa, hpa, pb, hpb, hpapb⟩ := eventually_prod_iff.mp (hf u hu),
+  rw eventually_prod_iff,
+  refine ⟨pa, hpa, pb ∘ g, _, λ x hx y hy, hpapb hx hy⟩,
+  exact eventually_comap.mpr (hpb.mono (λ x hx y hy, by simp only [hx, hy, function.comp_app])),
+end
 
 /-- Composing on the right by a function preserves uniform Cauchy sequences -/
 lemma uniform_cauchy_seq_on.comp {γ : Type*} (hf : uniform_cauchy_seq_on F p s) (g : γ → α) :
   uniform_cauchy_seq_on (λ n, F n ∘ g) p (g ⁻¹' s) :=
-λ u hu, (hf u hu).mono (λ x hx y hy, hx (g y) hy)
+begin
+  rw uniform_cauchy_seq_on_iff_uniform_cauchy_seq_on_filter at hf ⊢,
+  simpa only [uniform_cauchy_seq_on, comap_principal] using (hf.comp g),
+end
 
 /-- Composing on the left by a uniformly continuous function preserves
 uniform Cauchy sequences -/
@@ -429,11 +736,11 @@ end
 
 protected lemma tendsto_uniformly_on.tendsto_locally_uniformly_on
   (h : tendsto_uniformly_on F f p s) : tendsto_locally_uniformly_on F f p s :=
-λ u hu x hx, ⟨s, self_mem_nhds_within, h u hu⟩
+λ u hu x hx,⟨s, self_mem_nhds_within, by simpa using (h u hu)⟩
 
 protected lemma tendsto_uniformly.tendsto_locally_uniformly
   (h : tendsto_uniformly F f p) : tendsto_locally_uniformly F f p :=
-λ u hu x, ⟨univ, univ_mem, by simpa using h u hu⟩
+λ u hu x, ⟨univ, univ_mem, by simpa using (h u hu)⟩
 
 lemma tendsto_locally_uniformly_on.mono (h : tendsto_locally_uniformly_on F f p s) (h' : s' ⊆ s) :
   tendsto_locally_uniformly_on F f p s' :=
@@ -460,6 +767,7 @@ begin
   obtain ⟨t, ht⟩ := compact_univ.elim_nhds_subcover' (λ k hk, U k) (λ k hk, (hU k).1),
   replace hU := λ (x : t), (hU x).2,
   rw ← eventually_all at hU,
+  -- rw [← principal_univ, eventually_prod_principal_iff],
   refine hU.mono (λ i hi x, _),
   specialize ht (mem_univ x),
   simp only [exists_prop, mem_Union, set_coe.exists, exists_and_distrib_right,subtype.coe_mk] at ht,
@@ -654,7 +962,8 @@ tends to `f x` if `f` is continuous at `x` within `s`. -/
 lemma tendsto_uniformly_on.tendsto_comp (h : tendsto_uniformly_on F f p s)
   (hf : continuous_within_at f s x) (hg : tendsto g p (𝓝[s] x)) :
   tendsto (λ n, F n (g n)) p (𝓝 (f x)) :=
-tendsto_comp_of_locally_uniform_limit_within hf hg (λ u hu, ⟨s, self_mem_nhds_within, h u hu⟩)
+tendsto_comp_of_locally_uniform_limit_within hf hg (λ u hu,
+  ⟨s, self_mem_nhds_within, h u hu⟩)
 
 /-- If `Fₙ` tends locally uniformly to `f`, and `gₙ` tends to `x`, then `Fₙ gₙ` tends to `f x`. -/
 lemma tendsto_locally_uniformly.tendsto_comp (h : tendsto_locally_uniformly F f p)


### PR DESCRIPTION
**WORK IN PROGRESS**

(N.B. The only real new code here is in `uniform_limits_holomorphic`. Everything else is in dependent commits.)
    
This commit proves that uniform limits of holomorphic functions are holomorphic. The proof strategy is the usual one: prove Morera's Theorem (holomorphic functions have antiderivatives), show that they have a limit, the derivative of the limit is the limit of the derivatives, and finally that derivatives of complex analytic functions are complex analytic.
    
Note that there are several TODOs remaining on this commit:
  - [x] Finalize some `sorry`s still lying around
  - [x] Generalize various typeclasses
  - [ ] Migrate some of the lemmas currently called `foo` and `bar` to better homes involving formal_multilinear_series
  - [x] Docs
    
But it's at a place where I figured I could at least create a WIP PR.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

- [x] depends on: #14090 (You can swap limits and derivatives when the derivatives converge uniformly)

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
