### PR TITLE
[Merged by Bors] - feat(analysis/convex/cone): lemmas about `inner_dual_cone` of unions

### DIFF
--- a/src/analysis/convex/cone.lean
+++ b/src/analysis/convex/cone.lean
@@ -630,6 +630,10 @@ lemma inner_dual_cone_le_inner_dual_cone (h : t ⊆ s) :
 lemma pointed_inner_dual_cone : s.inner_dual_cone.pointed :=
 λ x hx, by rw inner_zero_right
 
+lemma inner_dual_cone_singleton (x : H) :
+  ({x} : set H).inner_dual_cone = (convex_cone.positive_cone ℝ ℝ).comap (innerₛₗ x) :=
+convex_cone.ext $ λ i, forall_eq
+
 lemma inner_dual_cone_union (s t : set H) :
   (s ∪ t).inner_dual_cone = s.inner_dual_cone ⊓ t.inner_dual_cone :=
 le_antisymm
@@ -646,7 +650,7 @@ begin
   exact hx _ _ hj,
 end
 
-lemma inner_dual_cone_sUnion {ι : Sort*} (S : set (set H)) :
+lemma inner_dual_cone_sUnion (S : set (set H)) :
   (⋃₀ S).inner_dual_cone = Inf (set.inner_dual_cone '' S) :=
 by simp_rw [Inf_image, sUnion_eq_bUnion, inner_dual_cone_Union]
 

--- a/src/analysis/convex/cone.lean
+++ b/src/analysis/convex/cone.lean
@@ -630,17 +630,29 @@ lemma inner_dual_cone_le_inner_dual_cone (h : t ⊆ s) :
 lemma pointed_inner_dual_cone : s.inner_dual_cone.pointed :=
 λ x hx, by rw inner_zero_right
 
+lemma inner_dual_cone_union (s t : set H) :
+  (s ∪ t).inner_dual_cone = s.inner_dual_cone ⊓ t.inner_dual_cone :=
+le_antisymm
+  (le_inf (λ x hx y hy, hx _ $ or.inl hy) (λ x hx y hy, hx _ $ or.inr hy))
+  (λ x hx y, or.rec (hx.1 _) (hx.2 _))
+
+lemma inner_dual_cone_Union {ι : Sort*} (f : ι → set H) :
+  (⋃ i, f i).inner_dual_cone = ⨅ i, (f i).inner_dual_cone :=
+begin
+  refine le_antisymm (le_infi $ λ i x hx y hy, hx _ $ mem_Union_of_mem _ hy) _,
+  intros x hx y hy,
+  rw [convex_cone.mem_coe, convex_cone.mem_infi] at hx,
+  obtain ⟨j, hj⟩ := mem_Union.mp hy,
+  exact hx _ _ hj,
+end
+
+lemma inner_dual_cone_sUnion {ι : Sort*} (S : set (set H)) :
+  (⋃₀ S).inner_dual_cone = Inf (set.inner_dual_cone '' S) :=
+by simp_rw [Inf_image, sUnion_eq_bUnion, inner_dual_cone_Union]
+
 /-- The dual cone of `s` equals the intersection of dual cones of the points in `s`. -/
 lemma inner_dual_cone_eq_Inter_inner_dual_cone_singleton :
   (s.inner_dual_cone : set H) = ⋂ i : s, (({i} : set H).inner_dual_cone : set H) :=
-begin
-  simp_rw [set.Inter_coe_set, subtype.coe_mk],
-  refine set.ext (λ x, iff.intro (λ hx, _) _),
-  { refine set.mem_Inter.2 (λ i, set.mem_Inter.2 (λ hi _, _)),
-    rintro ⟨ ⟩,
-    exact hx i hi },
-  { simp only [set.mem_Inter, convex_cone.mem_coe, mem_inner_dual_cone,
-      set.mem_singleton_iff, forall_eq, imp_self] }
-end
+by rw [←convex_cone.coe_infi, ←inner_dual_cone_Union, Union_of_singleton_coe]
 
 end dual

--- a/src/analysis/convex/cone.lean
+++ b/src/analysis/convex/cone.lean
@@ -640,6 +640,10 @@ le_antisymm
   (le_inf (λ x hx y hy, hx _ $ or.inl hy) (λ x hx y hy, hx _ $ or.inr hy))
   (λ x hx y, or.rec (hx.1 _) (hx.2 _))
 
+lemma inner_dual_cone_insert (x : H) (s : set H) :
+  (insert x s).inner_dual_cone = set.inner_dual_cone {x} ⊓ s.inner_dual_cone :=
+by rw [insert_eq, inner_dual_cone_union]
+
 lemma inner_dual_cone_Union {ι : Sort*} (f : ι → set H) :
   (⋃ i, f i).inner_dual_cone = ⨅ i, (f i).inner_dual_cone :=
 begin

--- a/src/analysis/convex/cone.lean
+++ b/src/analysis/convex/cone.lean
@@ -639,7 +639,7 @@ lemma inner_dual_cone_Union {ι : Sort*} (f : ι → set H) :
 begin
   refine le_antisymm (le_infi $ λ i x hx y hy, hx _ $ mem_Union_of_mem _ hy) _,
   intros x hx y hy,
-  rw [set_like.mem_coe, convex_cone.mem_infi] at hx,
+  rw [convex_cone.mem_infi] at hx,
   obtain ⟨j, hj⟩ := mem_Union.mp hy,
   exact hx _ _ hj,
 end

--- a/src/analysis/convex/cone.lean
+++ b/src/analysis/convex/cone.lean
@@ -620,6 +620,8 @@ lemma inner_dual_cone_le_inner_dual_cone (h : t ⊆ s) :
 lemma pointed_inner_dual_cone : s.inner_dual_cone.pointed :=
 λ x hx, by rw inner_zero_right
 
+/-- The inner dual cone of a singleton is given by the preimage of the positive cone under the
+linear map `λ y, ⟪x, y⟫`. -/
 lemma inner_dual_cone_singleton (x : H) :
   ({x} : set H).inner_dual_cone = (convex_cone.positive_cone ℝ ℝ).comap (innerₛₗ x) :=
 convex_cone.ext $ λ i, forall_eq


### PR DESCRIPTION
This discards the proof in #15639 and replaces it with a more general strategy and some auxiliary lemmas.

This includes an `insert` lemma for consistency with `submodule.span_insert`, even though it follows trivially from the union lemma.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
