### PR TITLE
[Merged by Bors] - feat(algebra/hom/group_instances): add missing `int_cast` and `nat_cast` lemmas to `add_monoid.End` and `module.End`

### DIFF
--- a/src/algebra/hom/group_instances.lean
+++ b/src/algebra/hom/group_instances.lean
@@ -69,9 +69,23 @@ instance [add_comm_monoid M] : semiring (add_monoid.End M) :=
   .. add_monoid.End.monoid M,
   .. add_monoid_hom.add_comm_monoid }
 
+/-- See also `add_monoid.End.nat_cast_def`. -/
+@[simp] lemma add_monoid.End.nat_cast_apply [add_comm_monoid M] (n : ℕ) (m : M):
+  (↑n : add_monoid.End M) m = n • m := rfl
+
+instance [add_comm_group M] : add_comm_group (add_monoid.End M) :=
+add_monoid_hom.add_comm_group
+
 instance [add_comm_group M] : ring (add_monoid.End M) :=
-{ .. add_monoid.End.semiring,
+{ int_cast := λ z, z • 1,
+  int_cast_of_nat := of_nat_zsmul _,
+  int_cast_neg_succ_of_nat  := zsmul_neg_succ_of_nat _,
+  .. add_monoid.End.semiring,
   .. add_monoid_hom.add_comm_group }
+
+/-- See also `add_monoid.End.int_cast_def`. -/
+@[simp] lemma add_monoid.End.int_cast_apply [add_comm_group M] (z : ℤ) (m : M):
+  (↑z : add_monoid.End M) m = z • m := rfl
 
 /-!
 ### Morphisms of morphisms

--- a/src/algebra/hom/group_instances.lean
+++ b/src/algebra/hom/group_instances.lean
@@ -70,7 +70,7 @@ instance [add_comm_monoid M] : semiring (add_monoid.End M) :=
   .. add_monoid_hom.add_comm_monoid }
 
 /-- See also `add_monoid.End.nat_cast_def`. -/
-@[simp] lemma add_monoid.End.nat_cast_apply [add_comm_monoid M] (n : ℕ) (m : M):
+@[simp] lemma add_monoid.End.nat_cast_apply [add_comm_monoid M] (n : ℕ) (m : M) :
   (↑n : add_monoid.End M) m = n • m := rfl
 
 instance [add_comm_group M] : add_comm_group (add_monoid.End M) :=

--- a/src/algebra/hom/group_instances.lean
+++ b/src/algebra/hom/group_instances.lean
@@ -84,7 +84,7 @@ instance [add_comm_group M] : ring (add_monoid.End M) :=
   .. add_monoid_hom.add_comm_group }
 
 /-- See also `add_monoid.End.int_cast_def`. -/
-@[simp] lemma add_monoid.End.int_cast_apply [add_comm_group M] (z : ℤ) (m : M):
+@[simp] lemma add_monoid.End.int_cast_apply [add_comm_group M] (z : ℤ) (m : M) :
   (↑z : add_monoid.End M) m = z • m := rfl
 
 /-!

--- a/src/algebra/module/basic.lean
+++ b/src/algebra/module/basic.lean
@@ -200,7 +200,7 @@ instance add_comm_group.int_module : module ℤ M :=
   zero_smul := zero_zsmul,
   add_smul := λ r s x, add_zsmul x r s }
 
-lemma add_monoid.End.int_cast_def [add_comm_group M] (n : ℤ) :
+lemma add_monoid.End.int_cast_def [add_comm_group M] (z : ℤ) :
   (↑z : add_monoid.End M) = distrib_mul_action.to_add_monoid_End ℤ M z := rfl
 
 /-- A structure containing most informations as in a module, except the fields `zero_smul`

--- a/src/algebra/module/basic.lean
+++ b/src/algebra/module/basic.lean
@@ -71,6 +71,9 @@ instance add_comm_monoid.nat_module : module ℕ M :=
   zero_smul := zero_nsmul,
   add_smul := λ r s x, add_nsmul x r s }
 
+lemma add_monoid.End.nat_cast_def [add_comm_monoid M] (n : ℕ) :
+  (↑n : add_monoid.End M) = distrib_mul_action.to_add_monoid_End ℕ M n := rfl
+
 theorem add_smul : (r + s) • x = r • x + s • x := module.add_smul r s x
 
 lemma convex.combo_self {a b : R} (h : a + b = 1) (x : M) : a • x + b • x = x :=
@@ -196,6 +199,9 @@ instance add_comm_group.int_module : module ℤ M :=
   smul_zero := zsmul_zero,
   zero_smul := zero_zsmul,
   add_smul := λ r s x, add_zsmul x r s }
+
+lemma add_monoid.End.int_cast_def [add_comm_group M] (n : ℤ) :
+  (↑z : add_monoid.End M) = distrib_mul_action.to_add_monoid_End ℤ M z := rfl
 
 /-- A structure containing most informations as in a module, except the fields `zero_smul`
 and `smul_zero`. As these fields can be deduced from the other ones when `M` is an `add_comm_group`,

--- a/src/algebra/module/basic.lean
+++ b/src/algebra/module/basic.lean
@@ -71,7 +71,7 @@ instance add_comm_monoid.nat_module : module ℕ M :=
   zero_smul := zero_nsmul,
   add_smul := λ r s x, add_nsmul x r s }
 
-lemma add_monoid.End.nat_cast_def [add_comm_monoid M] (n : ℕ) :
+lemma add_monoid.End.nat_cast_def (n : ℕ) :
   (↑n : add_monoid.End M) = distrib_mul_action.to_add_monoid_End ℕ M n := rfl
 
 theorem add_smul : (r + s) • x = r • x + s • x := module.add_smul r s x
@@ -200,7 +200,7 @@ instance add_comm_group.int_module : module ℤ M :=
   zero_smul := zero_zsmul,
   add_smul := λ r s x, add_zsmul x r s }
 
-lemma add_monoid.End.int_cast_def [add_comm_group M] (z : ℤ) :
+lemma add_monoid.End.int_cast_def (z : ℤ) :
   (↑z : add_monoid.End M) = distrib_mul_action.to_add_monoid_End ℤ M z := rfl
 
 /-- A structure containing most informations as in a module, except the fields `zero_smul`

--- a/src/algebra/module/linear_map.lean
+++ b/src/algebra/module/linear_map.lean
@@ -811,12 +811,26 @@ instance _root_.module.End.semiring : semiring (module.End R M) :=
   zero_mul := zero_comp,
   left_distrib := λ f g h, comp_add _ _ _,
   right_distrib := λ f g h, add_comp _ _ _,
+  nat_cast := λ n, n • 1,
+  nat_cast_zero := add_monoid.nsmul_zero' _,
+  nat_cast_succ := λ n, (add_monoid.nsmul_succ' n 1).trans (add_comm _ _),
   .. add_monoid_with_one.unary,
   .. _root_.module.End.monoid,
   .. linear_map.add_comm_monoid }
 
+/-- See also `module.End.nat_cast_def`. -/
+@[simp] lemma _root_.module.End.nat_cast_apply (n : ℕ) (m : M) :
+  (↑n : module.End R M) m = n • m := rfl
+
 instance _root_.module.End.ring : ring (module.End R N₁) :=
-{ ..module.End.semiring, ..linear_map.add_comm_group }
+{ int_cast := λ z, z • 1,
+  int_cast_of_nat := of_nat_zsmul _,
+  int_cast_neg_succ_of_nat := zsmul_neg_succ_of_nat _,
+  ..module.End.semiring, ..linear_map.add_comm_group }
+
+/-- See also `module.End.int_cast_def`. -/
+@[simp] lemma _root_.module.End.int_cast_apply (z : ℤ) (m : N₁) :
+  (↑z : module.End R N₁) m = z • m := rfl
 
 section
 variables [monoid S] [distrib_mul_action S M] [smul_comm_class R S M]
@@ -929,5 +943,11 @@ def module_End_self_op : R ≃+* module.End Rᵐᵒᵖ R :=
   left_inv := mul_one,
   right_inv := λ f, linear_map.ext_ring_op $ mul_one _,
   ..module.to_module_End _ _ }
+
+lemma End.nat_cast_def (n : ℕ) [add_comm_monoid N₁] [module R N₁] :
+  (↑n : module.End R N₁) = module.to_module_End R N₁ n := rfl
+
+lemma End.int_cast_def (z : ℤ) [add_comm_group N₁] [module R N₁] :
+  (↑z : module.End R N₁) = module.to_module_End R N₁ z := rfl
 
 end module


### PR DESCRIPTION
We already had provided the `nat_cast` field for `add_monoid.End`, this just copies the same pattern to the three other fields, and adds the 8 missing `rfl` lemmas.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
