### PR TITLE
feat(data/fintype/order): strong induction on fintypes

### DIFF
--- a/src/data/fintype/order.lean
+++ b/src/data/fintype/order.lean
@@ -171,3 +171,10 @@ begin
   obtain ⟨b, rfl⟩ := ha,
   exact hM b,
 end
+
+/-! ### Induction -/
+
+lemma fintype.strong_induction [fintype α] [preorder α] {p : α → Prop}
+(H : ∀ k, ((∀ i < k, p i) → p k)) (a : α) :
+  p a :=
+@well_founded_lt.induction _ _ ⟨fintype.preorder.well_founded_lt⟩ _ _ H


### PR DESCRIPTION
This PR uses the induction lemma from #15399 to provide a strong induction lemma relative to a preorder on a fintype. Possibly this will become redundant with the widespread adoption of the `well_founded_lt` typeclass, but it is easy and useful for now. (One corollary is that it provides a way to use induction on `fin n` without casting to and from successor types). 

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
