### PR TITLE
[Merged by Bors] - feat(group_theory/group_action/defs): `vadd_assoc_class`

### DIFF
--- a/src/algebra/group/to_additive.lean
+++ b/src/algebra/group/to_additive.lean
@@ -219,6 +219,8 @@ meta def tr : bool → list string → list string
 | is_comm ("npow" :: s)               := add_comm_prefix is_comm "nsmul"     :: tr ff s
 | is_comm ("zpow" :: s)               := add_comm_prefix is_comm "zsmul"     :: tr ff s
 | is_comm ("is" :: "square" :: s)     := add_comm_prefix is_comm "even"      :: tr ff s
+| is_comm ("is" :: "scalar" :: "tower" :: s) :=
+   add_comm_prefix is_comm "vadd_assoc_class"   :: tr ff s
 | is_comm ("is" :: "regular" :: s)    := add_comm_prefix is_comm "is_add_regular"   :: tr ff s
 | is_comm ("is" :: "left" :: "regular" :: s)  :=
   add_comm_prefix is_comm "is_add_left_regular"  :: tr ff s

--- a/src/data/finset/pointwise.lean
+++ b/src/data/finset/pointwise.lean
@@ -810,23 +810,20 @@ instance smul_comm_class [has_smul α γ] [has_smul β γ] [smul_comm_class α �
   smul_comm_class (finset α) (finset β) (finset γ) :=
 ⟨λ s t u, coe_injective $ by simp_rw [coe_smul, smul_comm]⟩
 
-@[to_additive]
-instance is_scalar_tower [has_smul α β] [has_smul α γ] [has_smul β γ]
-  [is_scalar_tower α β γ] :
+@[to_additive vadd_assoc_class]
+instance is_scalar_tower [has_smul α β] [has_smul α γ] [has_smul β γ] [is_scalar_tower α β γ] :
   is_scalar_tower α β (finset γ) :=
 ⟨λ a b s, by simp only [←image_smul, image_image, smul_assoc]⟩
 
 variables [decidable_eq β]
 
-@[to_additive]
-instance is_scalar_tower' [has_smul α β] [has_smul α γ] [has_smul β γ]
-  [is_scalar_tower α β γ] :
+@[to_additive vadd_assoc_class']
+instance is_scalar_tower' [has_smul α β] [has_smul α γ] [has_smul β γ] [is_scalar_tower α β γ] :
   is_scalar_tower α (finset β) (finset γ) :=
 ⟨λ a s t, coe_injective $ by simp only [coe_smul_finset, coe_smul, smul_assoc]⟩
 
-@[to_additive]
-instance is_scalar_tower'' [has_smul α β] [has_smul α γ] [has_smul β γ]
-  [is_scalar_tower α β γ] :
+@[to_additive vadd_assoc_class'']
+instance is_scalar_tower'' [has_smul α β] [has_smul α γ] [has_smul β γ] [is_scalar_tower α β γ] :
   is_scalar_tower (finset α) (finset β) (finset γ) :=
 ⟨λ a s t, coe_injective $ by simp only [coe_smul_finset, coe_smul, smul_assoc]⟩
 

--- a/src/data/finset/pointwise.lean
+++ b/src/data/finset/pointwise.lean
@@ -810,6 +810,7 @@ instance smul_comm_class [has_smul α γ] [has_smul β γ] [smul_comm_class α �
   smul_comm_class (finset α) (finset β) (finset γ) :=
 ⟨λ s t u, coe_injective $ by simp_rw [coe_smul, smul_comm]⟩
 
+@[to_additive]
 instance is_scalar_tower [has_smul α β] [has_smul α γ] [has_smul β γ]
   [is_scalar_tower α β γ] :
   is_scalar_tower α β (finset γ) :=
@@ -817,11 +818,13 @@ instance is_scalar_tower [has_smul α β] [has_smul α γ] [has_smul β γ]
 
 variables [decidable_eq β]
 
+@[to_additive]
 instance is_scalar_tower' [has_smul α β] [has_smul α γ] [has_smul β γ]
   [is_scalar_tower α β γ] :
   is_scalar_tower α (finset β) (finset γ) :=
 ⟨λ a s t, coe_injective $ by simp only [coe_smul_finset, coe_smul, smul_assoc]⟩
 
+@[to_additive]
 instance is_scalar_tower'' [has_smul α β] [has_smul α γ] [has_smul β γ]
   [is_scalar_tower α β γ] :
   is_scalar_tower (finset α) (finset β) (finset γ) :=

--- a/src/data/finset/pointwise.lean
+++ b/src/data/finset/pointwise.lean
@@ -810,19 +810,19 @@ instance smul_comm_class [has_smul α γ] [has_smul β γ] [smul_comm_class α �
   smul_comm_class (finset α) (finset β) (finset γ) :=
 ⟨λ s t u, coe_injective $ by simp_rw [coe_smul, smul_comm]⟩
 
-@[to_additive vadd_assoc_class]
+@[to_additive]
 instance is_scalar_tower [has_smul α β] [has_smul α γ] [has_smul β γ] [is_scalar_tower α β γ] :
   is_scalar_tower α β (finset γ) :=
 ⟨λ a b s, by simp only [←image_smul, image_image, smul_assoc]⟩
 
 variables [decidable_eq β]
 
-@[to_additive vadd_assoc_class']
+@[to_additive]
 instance is_scalar_tower' [has_smul α β] [has_smul α γ] [has_smul β γ] [is_scalar_tower α β γ] :
   is_scalar_tower α (finset β) (finset γ) :=
 ⟨λ a s t, coe_injective $ by simp only [coe_smul_finset, coe_smul, smul_assoc]⟩
 
-@[to_additive vadd_assoc_class'']
+@[to_additive]
 instance is_scalar_tower'' [has_smul α β] [has_smul α γ] [has_smul β γ] [is_scalar_tower α β γ] :
   is_scalar_tower (finset α) (finset β) (finset γ) :=
 ⟨λ a s t, coe_injective $ by simp only [coe_smul_finset, coe_smul, smul_assoc]⟩

--- a/src/data/set/pointwise.lean
+++ b/src/data/set/pointwise.lean
@@ -1016,21 +1016,18 @@ instance smul_comm_class [has_smul α γ] [has_smul β γ] [smul_comm_class α �
   smul_comm_class (set α) (set β) (set γ) :=
 ⟨λ _ _ _, image2_left_comm smul_comm⟩
 
-@[to_additive vadd_assoc_class]
-instance is_scalar_tower [has_smul α β] [has_smul α γ] [has_smul β γ]
-  [is_scalar_tower α β γ] :
+@[to_additive]
+instance is_scalar_tower [has_smul α β] [has_smul α γ] [has_smul β γ] [is_scalar_tower α β γ] :
   is_scalar_tower α β (set γ) :=
 { smul_assoc := λ a b T, by simp only [←image_smul, image_image, smul_assoc] }
 
-@[to_additive vadd_assoc_class']
-instance is_scalar_tower' [has_smul α β] [has_smul α γ] [has_smul β γ]
-  [is_scalar_tower α β γ] :
+@[to_additive']
+instance is_scalar_tower' [has_smul α β] [has_smul α γ] [has_smul β γ] [is_scalar_tower α β γ] :
   is_scalar_tower α (set β) (set γ) :=
 ⟨λ _ _ _, image2_image_left_comm $ smul_assoc _⟩
 
-@[to_additive vadd_assoc_class'']
-instance is_scalar_tower'' [has_smul α β] [has_smul α γ] [has_smul β γ]
-  [is_scalar_tower α β γ] :
+@[to_additive'']
+instance is_scalar_tower'' [has_smul α β] [has_smul α γ] [has_smul β γ] [is_scalar_tower α β γ] :
   is_scalar_tower (set α) (set β) (set γ) :=
 { smul_assoc := λ T T' T'', image2_assoc smul_assoc }
 

--- a/src/data/set/pointwise.lean
+++ b/src/data/set/pointwise.lean
@@ -1016,16 +1016,19 @@ instance smul_comm_class [has_smul α γ] [has_smul β γ] [smul_comm_class α �
   smul_comm_class (set α) (set β) (set γ) :=
 ⟨λ _ _ _, image2_left_comm smul_comm⟩
 
+@[to_additive]
 instance is_scalar_tower [has_smul α β] [has_smul α γ] [has_smul β γ]
   [is_scalar_tower α β γ] :
   is_scalar_tower α β (set γ) :=
 { smul_assoc := λ a b T, by simp only [←image_smul, image_image, smul_assoc] }
 
+@[to_additive]
 instance is_scalar_tower' [has_smul α β] [has_smul α γ] [has_smul β γ]
   [is_scalar_tower α β γ] :
   is_scalar_tower α (set β) (set γ) :=
 ⟨λ _ _ _, image2_image_left_comm $ smul_assoc _⟩
 
+@[to_additive]
 instance is_scalar_tower'' [has_smul α β] [has_smul α γ] [has_smul β γ]
   [is_scalar_tower α β γ] :
   is_scalar_tower (set α) (set β) (set γ) :=
@@ -1368,6 +1371,7 @@ le_antisymm
     (λ k hk, subset_closure ⟨1, k, H.one_mem, hk, one_mul k⟩))
   (by conv_rhs { rw [← closure_eq H, ← closure_eq K] }; apply closure_mul_le)
 
+@[to_additive]
 lemma pow_smul_mem_closure_smul {N : Type*} [comm_monoid N] [mul_action M N]
   [is_scalar_tower M N N] (r : M) (s : set N) {x : N} (hx : x ∈ closure s) :
   ∃ n : ℕ, r ^ n • x ∈ closure (r • s) :=

--- a/src/data/set/pointwise.lean
+++ b/src/data/set/pointwise.lean
@@ -1016,19 +1016,19 @@ instance smul_comm_class [has_smul α γ] [has_smul β γ] [smul_comm_class α �
   smul_comm_class (set α) (set β) (set γ) :=
 ⟨λ _ _ _, image2_left_comm smul_comm⟩
 
-@[to_additive]
+@[to_additive vadd_assoc_class]
 instance is_scalar_tower [has_smul α β] [has_smul α γ] [has_smul β γ]
   [is_scalar_tower α β γ] :
   is_scalar_tower α β (set γ) :=
 { smul_assoc := λ a b T, by simp only [←image_smul, image_image, smul_assoc] }
 
-@[to_additive]
+@[to_additive vadd_assoc_class']
 instance is_scalar_tower' [has_smul α β] [has_smul α γ] [has_smul β γ]
   [is_scalar_tower α β γ] :
   is_scalar_tower α (set β) (set γ) :=
 ⟨λ _ _ _, image2_image_left_comm $ smul_assoc _⟩
 
-@[to_additive]
+@[to_additive vadd_assoc_class'']
 instance is_scalar_tower'' [has_smul α β] [has_smul α γ] [has_smul β γ]
   [is_scalar_tower α β γ] :
   is_scalar_tower (set α) (set β) (set γ) :=

--- a/src/data/set/pointwise.lean
+++ b/src/data/set/pointwise.lean
@@ -1021,12 +1021,12 @@ instance is_scalar_tower [has_smul α β] [has_smul α γ] [has_smul β γ] [is_
   is_scalar_tower α β (set γ) :=
 { smul_assoc := λ a b T, by simp only [←image_smul, image_image, smul_assoc] }
 
-@[to_additive']
+@[to_additive]
 instance is_scalar_tower' [has_smul α β] [has_smul α γ] [has_smul β γ] [is_scalar_tower α β γ] :
   is_scalar_tower α (set β) (set γ) :=
 ⟨λ _ _ _, image2_image_left_comm $ smul_assoc _⟩
 
-@[to_additive'']
+@[to_additive]
 instance is_scalar_tower'' [has_smul α β] [has_smul α γ] [has_smul β γ] [is_scalar_tower α β γ] :
   is_scalar_tower (set α) (set β) (set γ) :=
 { smul_assoc := λ T T' T'', image2_assoc smul_assoc }

--- a/src/group_theory/group_action/defs.lean
+++ b/src/group_theory/group_action/defs.lean
@@ -188,17 +188,24 @@ add_decl_doc vadd_comm_class.symm
   smul_comm_class M M α :=
 ⟨λ a a' b, by rw [← mul_smul, mul_comm, mul_smul]⟩
 
+/-- An instance of `vadd_assoc_class M N α` states that the additive action of `M` on `α` is
+determined by the additive actions of `M` on `N` and `N` on `α`. -/
+class vadd_assoc_class (M N α : Type*) [has_vadd M N] [has_vadd N α] [has_vadd M α] : Prop :=
+(vadd_assoc : ∀ (x : M) (y : N) (z : α), (x +ᵥ y) +ᵥ z = x +ᵥ (y +ᵥ z))
+
 /-- An instance of `is_scalar_tower M N α` states that the multiplicative
 action of `M` on `α` is determined by the multiplicative actions of `M` on `N`
 and `N` on `α`. -/
+@[to_additive vadd_assoc_class]
 class is_scalar_tower (M N α : Type*) [has_smul M N] [has_smul N α] [has_smul M α] : Prop :=
 (smul_assoc : ∀ (x : M) (y : N) (z : α), (x • y) • z = x • (y • z))
 
-@[simp] lemma smul_assoc {M N} [has_smul M N] [has_smul N α] [has_smul M α]
+@[simp, to_additive] lemma smul_assoc {M N} [has_smul M N] [has_smul N α] [has_smul M α]
   [is_scalar_tower M N α] (x : M) (y : N) (z : α) :
   (x • y) • z = x • y • z :=
 is_scalar_tower.smul_assoc x y z
 
+@[to_additive]
 instance semigroup.is_scalar_tower [semigroup α] : is_scalar_tower α α α := ⟨mul_assoc⟩
 
 /-- A typeclass indicating that the right (aka `mul_opposite`) and left actions by `M` on `α` are
@@ -268,9 +275,13 @@ tower of scalar actions `N → α → β`.
 This cannot be an instance because it can cause infinite loops whenever the `has_smul` arguments
 are still metavariables.
 -/
-@[priority 100]
-lemma comp.is_scalar_tower [has_smul M β] [has_smul α β] [is_scalar_tower M α β]
-  (g : N → M) :
+@[priority 100, to_additive "Given a tower of additive actions `M → α → β`, if we use
+`has_smul.comp` to pull back both of `M`'s actions by a map `g : N → M`, then we obtain a new tower
+of scalar actions `N → α → β`.
+
+This cannot be an instance because it can cause infinite loops whenever the `has_smul` arguments
+are still metavariables."]
+lemma comp.is_scalar_tower [has_smul M β] [has_smul α β] [is_scalar_tower M α β] (g : N → M) :
   (by haveI := comp α g; haveI := comp β g; exact is_scalar_tower N α β) :=
 by exact {smul_assoc := λ n, @smul_assoc _ _ _ _ _ _ _ (g n) }
 
@@ -305,10 +316,12 @@ lemma mul_smul_comm [has_mul β] [has_smul α β] [smul_comm_class α β β] (s 
 
 /-- Note that the `is_scalar_tower α β β` typeclass argument is usually satisfied by `algebra α β`.
 -/
+@[to_additive, nolint to_additive_doc]
 lemma smul_mul_assoc [has_mul β] [has_smul α β] [is_scalar_tower α β β] (r : α) (x y : β)  :
   (r • x) * y = r • (x * y) :=
 smul_assoc r x y
 
+@[to_additive]
 lemma smul_smul_smul_comm [has_smul α β] [has_smul α γ] [has_smul β δ] [has_smul α δ]
   [has_smul γ δ] [is_scalar_tower α β δ] [is_scalar_tower α γ δ] [smul_comm_class β γ δ]
   (a : α) (b : β) (c : γ) (d : δ) : (a • b) • (c • d) = (a • c) • b • d :=
@@ -316,11 +329,13 @@ by { rw [smul_assoc, smul_assoc, smul_comm b], apply_instance }
 
 variables [has_smul M α]
 
+@[to_additive]
 lemma commute.smul_right [has_mul α] [smul_comm_class M α α] [is_scalar_tower M α α]
   {a b : α} (h : commute a b) (r : M) :
   commute a (r • b) :=
 (mul_smul_comm _ _ _).trans ((congr_arg _ h).trans $ (smul_mul_assoc _ _ _).symm)
 
+@[to_additive]
 lemma commute.smul_left [has_mul α] [smul_comm_class M α α] [is_scalar_tower M α α]
   {a b : α} (h : commute a b) (r : M) :
   commute (r • a) b :=
@@ -411,13 +426,14 @@ instance monoid.to_mul_action : mul_action M M :=
 This is promoted to an `add_torsor` by `add_group_is_add_torsor`. -/
 add_decl_doc add_monoid.to_add_action
 
-instance is_scalar_tower.left : is_scalar_tower M M α :=
+@[to_additive] instance is_scalar_tower.left : is_scalar_tower M M α :=
 ⟨λ x y z, mul_smul x y z⟩
 
 variables {M}
 
 /-- Note that the `is_scalar_tower M α α` and `smul_comm_class M α α` typeclass arguments are
 usually satisfied by `algebra M α`. -/
+@[to_additive, nolint to_additive_doc]
 lemma smul_mul_smul [has_mul α] (r s : M) (x y : α)
   [is_scalar_tower M α α] [smul_comm_class M α α] :
   (r • x) * (s • y) = (r * s) • (x * y) :=
@@ -465,13 +481,13 @@ end
 
 section compatible_scalar
 
-@[simp] lemma smul_one_smul {M} (N) [monoid N] [has_smul M N] [mul_action N α] [has_smul M α]
-  [is_scalar_tower M N α] (x : M) (y : α) :
+@[simp, to_additive] lemma smul_one_smul {M} (N) [monoid N] [has_smul M N] [mul_action N α]
+  [has_smul M α] [is_scalar_tower M N α] (x : M) (y : α) :
   (x • (1 : N)) • y = x • y :=
 by rw [smul_assoc, one_smul]
 
-@[simp] lemma smul_one_mul {M N} [mul_one_class N] [has_smul M N] [is_scalar_tower M N N] (x : M)
-  (y : N) : (x • 1) * y = x • y :=
+@[simp, to_additive] lemma smul_one_mul {M N} [mul_one_class N] [has_smul M N]
+  [is_scalar_tower M N N] (x : M) (y : N) : (x • 1) * y = x • y :=
 by rw [smul_mul_assoc, one_mul]
 
 @[simp, to_additive] lemma mul_smul_one
@@ -479,6 +495,7 @@ by rw [smul_mul_assoc, one_mul]
   y * (x • 1) = x • y :=
 by rw [← smul_eq_mul, ← smul_comm, smul_eq_mul, mul_one]
 
+@[to_additive]
 lemma is_scalar_tower.of_smul_one_mul {M N} [monoid N] [has_smul M N]
   (h : ∀ (x : M) (y : N), (x • (1 : N)) * y = x • y) :
   is_scalar_tower M N N :=

--- a/src/group_theory/group_action/defs.lean
+++ b/src/group_theory/group_action/defs.lean
@@ -69,7 +69,8 @@ lemma smul_left_injective' [has_smul M α] [has_faithful_smul M α] :
 λ m₁ m₂ h, has_faithful_smul.eq_of_smul_eq_smul (congr_fun h)
 
 /-- See also `monoid.to_mul_action` and `mul_zero_class.to_smul_with_zero`. -/
-@[priority 910, to_additive] -- see Note [lower instance priority]
+@[priority 910, -- see Note [lower instance priority]
+to_additive "See also `add_monoid.to_add_action`"]
 instance has_mul.to_has_smul (α : Type*) [has_mul α] : has_smul α α := ⟨(*)⟩
 
 @[simp, to_additive] lemma smul_eq_mul (α : Type*) [has_mul α] {a a' : α} : a • a' = a * a' := rfl
@@ -136,7 +137,8 @@ is_pretransitive.exists_smul_eq x y
 @[to_additive] lemma surjective_smul (x : α) : surjective (λ c : M, c • x) := exists_smul_eq M x
 
 /-- The regular action of a group on itself is transitive. -/
-@[to_additive] instance regular.is_pretransitive [group G] : is_pretransitive G G :=
+@[to_additive "The regular action of a group on itself is transitive."]
+instance regular.is_pretransitive [group G] : is_pretransitive G G :=
 ⟨λ x y, ⟨y * x⁻¹, inv_mul_cancel_right _ _⟩⟩
 
 end mul_action
@@ -309,7 +311,7 @@ section
 
 /-- Note that the `smul_comm_class α β β` typeclass argument is usually satisfied by `algebra α β`.
 -/
-@[to_additive]
+@[to_additive, nolint to_additive_doc]
 lemma mul_smul_comm [has_mul β] [has_smul α β] [smul_comm_class α β β] (s : α) (x y : β) :
   x * (s • y) = s • (x * y) :=
 (smul_comm s x y).symm
@@ -364,11 +366,11 @@ variable (M)
 @[simp, to_additive] theorem one_smul (b : α) : (1 : M) • b = b := mul_action.one_smul _
 
 /-- `has_smul` version of `one_mul_eq_id` -/
-@[to_additive]
+@[to_additive "`has_vadd` version of `zero_add_eq_id`"]
 lemma one_smul_eq_id : ((•) (1 : M) : α → α) = id := funext $ one_smul _
 
 /-- `has_smul` version of `comp_mul_left` -/
-@[to_additive]
+@[to_additive "`has_vadd` version of `comp_add_left`"]
 lemma comp_smul_left (a₁ a₂ : M) : (•) a₁ ∘ (•) a₂ = ((•) (a₁ * a₂) : α → α) :=
 funext $ λ _, (mul_smul _ _ _).symm
 

--- a/src/group_theory/group_action/defs.lean
+++ b/src/group_theory/group_action/defs.lean
@@ -795,3 +795,4 @@ See note [reducible non-instances]. -/
 @[reducible]
 def add_action.of_End_hom [add_monoid M] (f : M →+ additive (function.End α)) : add_action M α :=
 add_action.comp_hom α f
+#lint

--- a/src/group_theory/group_action/defs.lean
+++ b/src/group_theory/group_action/defs.lean
@@ -198,7 +198,7 @@ class vadd_assoc_class (M N α : Type*) [has_vadd M N] [has_vadd N α] [has_vadd
 /-- An instance of `is_scalar_tower M N α` states that the multiplicative
 action of `M` on `α` is determined by the multiplicative actions of `M` on `N`
 and `N` on `α`. -/
-@[to_additive vadd_assoc_class]
+@[to_additive]
 class is_scalar_tower (M N α : Type*) [has_smul M N] [has_smul N α] [has_smul M α] : Prop :=
 (smul_assoc : ∀ (x : M) (y : N) (z : α), (x • y) • z = x • (y • z))
 

--- a/src/group_theory/group_action/defs.lean
+++ b/src/group_theory/group_action/defs.lean
@@ -797,4 +797,3 @@ See note [reducible non-instances]. -/
 @[reducible]
 def add_action.of_End_hom [add_monoid M] (f : M →+ additive (function.End α)) : add_action M α :=
 add_action.comp_hom α f
-#lint

--- a/src/order/filter/pointwise.lean
+++ b/src/order/filter/pointwise.lean
@@ -636,21 +636,18 @@ instance smul_comm_class [has_smul α γ] [has_smul β γ] [smul_comm_class α �
   smul_comm_class (filter α) (filter β) (filter γ) :=
 ⟨λ f g h, map₂_left_comm smul_comm⟩
 
-@[to_additive]
-instance is_scalar_tower [has_smul α β] [has_smul α γ] [has_smul β γ]
-  [is_scalar_tower α β γ] :
+@[to_additive vadd_assoc_class]
+instance is_scalar_tower [has_smul α β] [has_smul α γ] [has_smul β γ] [is_scalar_tower α β γ] :
   is_scalar_tower α β (filter γ) :=
 ⟨λ a b f, by simp only [←map_smul, map_map, smul_assoc]⟩
 
-@[to_additive]
-instance is_scalar_tower' [has_smul α β] [has_smul α γ] [has_smul β γ]
-  [is_scalar_tower α β γ] :
+@[to_additive vadd_assoc_class']
+instance is_scalar_tower' [has_smul α β] [has_smul α γ] [has_smul β γ] [is_scalar_tower α β γ] :
   is_scalar_tower α (filter β) (filter γ) :=
 ⟨λ a f g, by { refine (map_map₂_distrib_left $ λ _ _, _).symm, exact (smul_assoc a _ _).symm }⟩
 
-@[to_additive]
-instance is_scalar_tower'' [has_smul α β] [has_smul α γ] [has_smul β γ]
-  [is_scalar_tower α β γ] :
+@[to_additive vadd_assoc_class'']
+instance is_scalar_tower'' [has_smul α β] [has_smul α γ] [has_smul β γ] [is_scalar_tower α β γ] :
   is_scalar_tower (filter α) (filter β) (filter γ) :=
 ⟨λ f g h, map₂_assoc smul_assoc⟩
 

--- a/src/order/filter/pointwise.lean
+++ b/src/order/filter/pointwise.lean
@@ -636,17 +636,17 @@ instance smul_comm_class [has_smul α γ] [has_smul β γ] [smul_comm_class α �
   smul_comm_class (filter α) (filter β) (filter γ) :=
 ⟨λ f g h, map₂_left_comm smul_comm⟩
 
-@[to_additive vadd_assoc_class]
+@[to_additive]
 instance is_scalar_tower [has_smul α β] [has_smul α γ] [has_smul β γ] [is_scalar_tower α β γ] :
   is_scalar_tower α β (filter γ) :=
 ⟨λ a b f, by simp only [←map_smul, map_map, smul_assoc]⟩
 
-@[to_additive vadd_assoc_class']
+@[to_additive']
 instance is_scalar_tower' [has_smul α β] [has_smul α γ] [has_smul β γ] [is_scalar_tower α β γ] :
   is_scalar_tower α (filter β) (filter γ) :=
 ⟨λ a f g, by { refine (map_map₂_distrib_left $ λ _ _, _).symm, exact (smul_assoc a _ _).symm }⟩
 
-@[to_additive vadd_assoc_class'']
+@[to_additive'']
 instance is_scalar_tower'' [has_smul α β] [has_smul α γ] [has_smul β γ] [is_scalar_tower α β γ] :
   is_scalar_tower (filter α) (filter β) (filter γ) :=
 ⟨λ f g h, map₂_assoc smul_assoc⟩

--- a/src/order/filter/pointwise.lean
+++ b/src/order/filter/pointwise.lean
@@ -636,16 +636,19 @@ instance smul_comm_class [has_smul α γ] [has_smul β γ] [smul_comm_class α �
   smul_comm_class (filter α) (filter β) (filter γ) :=
 ⟨λ f g h, map₂_left_comm smul_comm⟩
 
+@[to_additive]
 instance is_scalar_tower [has_smul α β] [has_smul α γ] [has_smul β γ]
   [is_scalar_tower α β γ] :
   is_scalar_tower α β (filter γ) :=
 ⟨λ a b f, by simp only [←map_smul, map_map, smul_assoc]⟩
 
+@[to_additive]
 instance is_scalar_tower' [has_smul α β] [has_smul α γ] [has_smul β γ]
   [is_scalar_tower α β γ] :
   is_scalar_tower α (filter β) (filter γ) :=
 ⟨λ a f g, by { refine (map_map₂_distrib_left $ λ _ _, _).symm, exact (smul_assoc a _ _).symm }⟩
 
+@[to_additive]
 instance is_scalar_tower'' [has_smul α β] [has_smul α γ] [has_smul β γ]
   [is_scalar_tower α β γ] :
   is_scalar_tower (filter α) (filter β) (filter γ) :=

--- a/src/order/filter/pointwise.lean
+++ b/src/order/filter/pointwise.lean
@@ -641,12 +641,12 @@ instance is_scalar_tower [has_smul α β] [has_smul α γ] [has_smul β γ] [is_
   is_scalar_tower α β (filter γ) :=
 ⟨λ a b f, by simp only [←map_smul, map_map, smul_assoc]⟩
 
-@[to_additive']
+@[to_additive]
 instance is_scalar_tower' [has_smul α β] [has_smul α γ] [has_smul β γ] [is_scalar_tower α β γ] :
   is_scalar_tower α (filter β) (filter γ) :=
 ⟨λ a f g, by { refine (map_map₂_distrib_left $ λ _ _, _).symm, exact (smul_assoc a _ _).symm }⟩
 
-@[to_additive'']
+@[to_additive]
 instance is_scalar_tower'' [has_smul α β] [has_smul α γ] [has_smul β γ] [is_scalar_tower α β γ] :
   is_scalar_tower (filter α) (filter β) (filter γ) :=
 ⟨λ f g h, map₂_assoc smul_assoc⟩


### PR DESCRIPTION
Additivize `is_scalar_tower` into a new class `vadd_assoc_class`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
I need this to additivize properly results about `mul_action.stabilizer` that are themselves needed for Kneser's theorem (whose statement is usually given using additive notation, so I really can't do without this).

`vadd_assoc_class` as a name doesn't really go with `is_scalar_tower` (what would? `is_add_scalar_assoc_class`?) but it does match `smul_comm_class` and `vadd_comm_class`. I already suggested renaming `is_scalar_tower` to `smul_assoc_class` on Zulip, and it would make even more sense after this PR.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
