### PR TITLE
[Merged by Bors] - chore(data/seq/*): trivial spacing fixes

### DIFF
--- a/src/data/seq/computation.lean
+++ b/src/data/seq/computation.lean
@@ -22,21 +22,21 @@ coinductive computation (α : Type u) : Type u
   An element of `computation α` is an infinite sequence of `option α` such
   that if `f n = some a` for some `n` then it is constantly `some a` after that. -/
 def computation (α : Type u) : Type u :=
-{ f : stream (option α) // ∀ {n a}, f n = some a → f (n+1) = some a }
+{f : stream (option α) // ∀ {n a}, f n = some a → f (n + 1) = some a}
 
 namespace computation
 variables {α : Type u} {β : Type v} {γ : Type w}
 
 -- constructors
 /-- `return a` is the computation that immediately terminates with result `a`. -/
-def return (a : α) : computation α := ⟨stream.const (some a), λn a', id⟩
+def return (a : α) : computation α := ⟨stream.const (some a), λ n a', id⟩
 
 instance : has_coe_t α (computation α) := ⟨return⟩ -- note [use has_coe_t]
 
 /-- `think c` is the computation that delays for one "tick" and then performs
   computation `c`. -/
 def think (c : computation α) : computation α :=
-⟨none :: c.1, λn a h, by {cases n with n, contradiction, exact c.2 h}⟩
+⟨none :: c.1, λ n a h, by {cases n with n, contradiction, exact c.2 h}⟩
 
 /-- `thinkN c n` is the computation that delays for `n` ticks and then performs
   computation `c`. -/
@@ -57,7 +57,7 @@ def tail (c : computation α) : computation α :=
 
 /-- `empty α` is the computation that never returns, an infinite sequence of
   `think`s. -/
-def empty (α) : computation α := ⟨stream.const none, λn a', id⟩
+def empty (α) : computation α := ⟨stream.const none, λ n a', id⟩
 
 instance : inhabited (computation α) := ⟨empty _⟩
 
@@ -147,7 +147,7 @@ def corec.F (f : β → α ⊕ β) : α ⊕ β → option α × (α ⊕ β)
   `corec f b = think (corec f b')`. -/
 def corec (f : β → α ⊕ β) (b : β) : computation α :=
 begin
-  refine ⟨stream.corec' (corec.F f) (sum.inr b), λn a' h, _⟩,
+  refine ⟨stream.corec' (corec.F f) (sum.inr b), λ n a' h, _⟩,
   rw stream.corec'_eq,
   change stream.corec' (corec.F f) (corec.F f (sum.inr b)).2 n = some a',
   revert h, generalize : sum.inr b = o, revert o,
@@ -203,12 +203,12 @@ section bisim
   theorem eq_of_bisim (bisim : is_bisimulation R) {s₁ s₂} (r : s₁ ~ s₂) : s₁ = s₂ :=
   begin
     apply subtype.eq,
-    apply stream.eq_of_bisim (λx y, ∃ s s' : computation α, s.1 = x ∧ s'.1 = y ∧ R s s'),
+    apply stream.eq_of_bisim (λ x y, ∃ s s' : computation α, s.1 = x ∧ s'.1 = y ∧ R s s'),
     dsimp [stream.is_bisimulation],
     intros t₁ t₂ e,
     exact match t₁, t₂, e with ._, ._, ⟨s, s', rfl, rfl, r⟩ :=
       suffices head s = head s' ∧ R (tail s) (tail s'), from
-      and.imp id (λr, ⟨tail s, tail s',
+      and.imp id (λ r, ⟨tail s, tail s',
         by cases s; refl, by cases s'; refl, r⟩) this,
       begin
         have := bisim r, revert r this,
@@ -467,8 +467,8 @@ mem_rec_on (get_mem s) (h1 _) h2
 
 /-- Map a function on the result of a computation. -/
 def map (f : α → β) : computation α → computation β
-| ⟨s, al⟩ := ⟨s.map (λo, option.cases_on o none (some ∘ f)),
-λn b, begin
+| ⟨s, al⟩ := ⟨s.map (λ o, option.cases_on o none (some ∘ f)),
+λ n b, begin
   dsimp [stream.map, stream.nth],
   induction e : s n with a; intro h,
   { contradiction }, { rw [al e, ←h] }
@@ -511,7 +511,7 @@ by apply s.cases_on; intro; simp
 @[simp] theorem map_id : ∀ (s : computation α), map id s = s
 | ⟨f, al⟩ := begin
   apply subtype.eq; simp [map, function.comp],
-  have e : (@option.rec α (λ_, option α) none some) = id,
+  have e : (@option.rec α (λ _, option α) none some) = id,
   { ext ⟨⟩; refl },
   simp [e, stream.map_id]
 end
@@ -528,7 +528,7 @@ end
 @[simp] theorem ret_bind (a) (f : α → computation β) :
   bind (return a) f = f a :=
 begin
-  apply eq_of_bisim (λc₁ c₂,
+  apply eq_of_bisim (λ c₁ c₂,
          c₁ = bind (return a) f ∧ c₂ = f a ∨
          c₁ = corec (bind.F f) (sum.inr c₂)),
   { intros c₁ c₂ h,
@@ -550,7 +550,7 @@ destruct_eq_think $ by simp [bind, bind.F]
 
 @[simp] theorem bind_ret (f : α → β) (s) : bind s (return ∘ f) = map f s :=
 begin
-  apply eq_of_bisim (λc₁ c₂, c₁ = c₂ ∨
+  apply eq_of_bisim (λ c₁ c₂, c₁ = c₂ ∨
          ∃ s, c₁ = bind s (return ∘ f) ∧ c₂ = map f s),
   { intros c₁ c₂ h,
     exact match c₁, c₂, h with
@@ -568,7 +568,7 @@ by rw bind_ret; change (λ x : α, x) with @id α; rw map_id
 @[simp] theorem bind_assoc (s : computation α) (f : α → computation β) (g : β → computation γ) :
   bind (bind s f) g = bind s (λ (x : α), bind (f x) g) :=
 begin
-  apply eq_of_bisim (λc₁ c₂, c₁ = c₂ ∨
+  apply eq_of_bisim (λ c₁ c₂, c₁ = c₂ ∨
          ∃ s, c₁ = bind (bind s f) g ∧ c₂ = bind s (λ (x : α), bind (f x) g)),
   { intros c₁ c₂ h,
     exact match c₁, c₂, h with
@@ -678,7 +678,7 @@ theorem terminates_map_iff (f : α → β) (s : computation α) :
   the first one that gives a result. -/
 def orelse (c₁ c₂ : computation α) : computation α :=
 @computation.corec α (computation α × computation α)
-  (λ⟨c₁, c₂⟩, match destruct c₁ with
+  (λ ⟨c₁, c₂⟩, match destruct c₁ with
   | sum.inl a := sum.inl a
   | sum.inr c₁' := match destruct c₂ with
     | sum.inl a := sum.inl a
@@ -703,7 +703,7 @@ destruct_eq_think $ by unfold has_orelse.orelse; simp [orelse]
 
 @[simp] theorem empty_orelse (c) : (empty α <|> c) = c :=
 begin
-  apply eq_of_bisim (λc₁ c₂, (empty α <|> c₂) = c₁) _ rfl,
+  apply eq_of_bisim (λ c₁ c₂, (empty α <|> c₂) = c₁) _ rfl,
   intros s' s h, rw ←h,
   apply cases_on s; intros s; rw think_empty; simp,
   rw ←think_empty,
@@ -711,7 +711,7 @@ end
 
 @[simp] theorem orelse_empty (c : computation α) : (c <|> empty α) = c :=
 begin
-  apply eq_of_bisim (λc₁ c₂, (c₂ <|> empty α) = c₁) _ rfl,
+  apply eq_of_bisim (λ c₁ c₂, (c₂ <|> empty α) = c₁) _ rfl,
   intros s' s h, rw ←h,
   apply cases_on s; intros s; rw think_empty; simp,
   rw←think_empty,
@@ -723,20 +723,20 @@ def equiv (c₁ c₂ : computation α) : Prop := ∀ a, a ∈ c₁ ↔ a ∈ c�
 
 infix ` ~ `:50 := equiv
 
-@[refl] theorem equiv.refl (s : computation α) : s ~ s := λ_, iff.rfl
+@[refl] theorem equiv.refl (s : computation α) : s ~ s := λ _, iff.rfl
 
 @[symm] theorem equiv.symm {s t : computation α} : s ~ t → t ~ s :=
-λh a, (h a).symm
+λ h a, (h a).symm
 
 @[trans] theorem equiv.trans {s t u : computation α} : s ~ t → t ~ u → s ~ u :=
-λh1 h2 a, (h1 a).trans (h2 a)
+λ h1 h2 a, (h1 a).trans (h2 a)
 
 theorem equiv.equivalence : equivalence (@equiv α) :=
 ⟨@equiv.refl _, @equiv.symm _, @equiv.trans _⟩
 
 theorem equiv_of_mem {s t : computation α} {a} (h1 : a ∈ s) (h2 : a ∈ t) : s ~ t :=
-λa', ⟨λma, by rw mem_unique ma h1; exact h2,
-      λma, by rw mem_unique ma h2; exact h1⟩
+λ a', ⟨λ ma, by rw mem_unique ma h1; exact h2,
+      λ ma, by rw mem_unique ma h2; exact h1⟩
 
 theorem terminates_congr {c₁ c₂ : computation α}
   (h : c₁ ~ c₂) : terminates c₁ ↔ terminates c₂ :=
@@ -744,7 +744,7 @@ by simp only [terminates_iff, exists_congr h]
 
 theorem promises_congr {c₁ c₂ : computation α}
   (h : c₁ ~ c₂) (a) : c₁ ~> a ↔ c₂ ~> a :=
-forall_congr (λa', imp_congr (h a') iff.rfl)
+forall_congr (λ a', imp_congr (h a') iff.rfl)
 
 theorem get_equiv {c₁ c₂ : computation α} (h : c₁ ~ c₂)
   [terminates c₁] [terminates c₂] : get c₁ = get c₂ :=
@@ -758,9 +758,9 @@ theorem thinkN_equiv (s : computation α) (n) : thinkN s n ~ s :=
 
 theorem bind_congr {s1 s2 : computation α} {f1 f2 : α → computation β}
   (h1 : s1 ~ s2) (h2 : ∀ a, f1 a ~ f2 a) : bind s1 f1 ~ bind s2 f2 :=
-λ b, ⟨λh, let ⟨a, ha, hb⟩ := exists_of_mem_bind h in
+λ b, ⟨λ h, let ⟨a, ha, hb⟩ := exists_of_mem_bind h in
         mem_bind ((h1 a).1 ha) ((h2 a b).1 hb),
-      λh, let ⟨a, ha, hb⟩ := exists_of_mem_bind h in
+      λ h, let ⟨a, ha, hb⟩ := exists_of_mem_bind h in
         mem_bind ((h1 a).2 ha) ((h2 a b).2 hb)⟩
 
 theorem equiv_ret_of_mem {s : computation α} {a} (h : a ∈ s) : s ~ return a :=
@@ -779,10 +779,10 @@ theorem lift_rel.swap (R : α → β → Prop) (ca : computation α) (cb : compu
 and_comm _ _
 
 theorem lift_eq_iff_equiv (c₁ c₂ : computation α) : lift_rel (=) c₁ c₂ ↔ c₁ ~ c₂ :=
-⟨λ⟨h1, h2⟩ a,
+⟨λ ⟨h1, h2⟩ a,
   ⟨λ a1, let ⟨b, b2, ab⟩ := h1 a1 in by rwa ab,
    λ a2, let ⟨b, b1, ab⟩ := h2 a2 in by rwa ←ab⟩,
-λe, ⟨λ a a1, ⟨a, (e _).1 a1, rfl⟩, λ a a2, ⟨a, (e _).2 a2, rfl⟩⟩⟩
+λ e, ⟨λ a a1, ⟨a, (e _).1 a1, rfl⟩, λ a a2, ⟨a, (e _).2 a2, rfl⟩⟩⟩
 
 theorem lift_rel.refl (R : α → α → Prop) (H : reflexive R) : reflexive (lift_rel R) :=
 λ s, ⟨λ a as, ⟨a, as, H a⟩, λ b bs, ⟨b, bs, H b⟩⟩
@@ -831,9 +831,9 @@ H.right h
 
 theorem lift_rel_def {R : α → β → Prop} {ca cb} : lift_rel R ca cb ↔
   (terminates ca ↔ terminates cb) ∧ ∀ {a b}, a ∈ ca → b ∈ cb → R a b :=
-⟨λh, ⟨terminates_of_lift_rel h, λ a b ma mb,
+⟨λ h, ⟨terminates_of_lift_rel h, λ a b ma mb,
   let ⟨b', mb', ab⟩ := h.left ma in by rwa mem_unique mb mb'⟩,
-λ⟨l, r⟩,
+λ ⟨l, r⟩,
  ⟨λ a ma, let ⟨⟨b, mb⟩⟩ := l.1 ⟨⟨_, ma⟩⟩ in ⟨b, mb, r ma mb⟩,
   λ b mb, let ⟨⟨a, ma⟩⟩ := l.2 ⟨⟨_, mb⟩⟩ in ⟨a, ma, r ma mb⟩⟩⟩
 
@@ -858,8 +858,8 @@ let ⟨l1, r1⟩ := h1 in
 
 @[simp] theorem lift_rel_return_left (R : α → β → Prop) (a : α) (cb : computation β) :
   lift_rel R (return a) cb ↔ ∃ {b}, b ∈ cb ∧ R a b :=
-⟨λ⟨l, r⟩, l (ret_mem _),
- λ⟨b, mb, ab⟩,
+⟨λ ⟨l, r⟩, l (ret_mem _),
+ λ ⟨b, mb, ab⟩,
   ⟨λ a' ma', by rw eq_of_ret_mem ma'; exact ⟨b, mb, ab⟩,
    λ b' mb', ⟨_, ret_mem _, by rw mem_unique mb' mb; exact ab⟩⟩⟩
 
@@ -870,13 +870,13 @@ by rw [lift_rel.swap, lift_rel_return_left]
 @[simp] theorem lift_rel_return (R : α → β → Prop) (a : α) (b : β) :
   lift_rel R (return a) (return b) ↔ R a b :=
 by rw [lift_rel_return_left]; exact
-⟨λ⟨b', mb', ab'⟩, by rwa eq_of_ret_mem mb' at ab',
- λab, ⟨_, ret_mem _, ab⟩⟩
+⟨λ ⟨b', mb', ab'⟩, by rwa eq_of_ret_mem mb' at ab',
+ λ ab, ⟨_, ret_mem _, ab⟩⟩
 
 @[simp] theorem lift_rel_think_left (R : α → β → Prop) (ca : computation α) (cb : computation β) :
   lift_rel R (think ca) cb ↔ lift_rel R ca cb :=
-and_congr (forall_congr $ λb, imp_congr ⟨of_think_mem, think_mem⟩ iff.rfl)
- (forall_congr $ λb, imp_congr iff.rfl $
+and_congr (forall_congr $ λ b, imp_congr ⟨of_think_mem, think_mem⟩ iff.rfl)
+ (forall_congr $ λ b, imp_congr iff.rfl $
     exists_congr $ λ b, and_congr ⟨of_think_mem, think_mem⟩ iff.rfl)
 
 @[simp] theorem lift_rel_think_right (R : α → β → Prop) (ca : computation α) (cb : computation β) :

--- a/src/data/seq/parallel.lean
+++ b/src/data/seq/parallel.lean
@@ -18,7 +18,7 @@ open wseq
 variables {α : Type u} {β : Type v}
 
 def parallel.aux2 : list (computation α) → α ⊕ list (computation α) :=
-list.foldr (λc o, match o with
+list.foldr (λ c o, match o with
 | sum.inl a  := sum.inl a
 | sum.inr ls := rmap (λ c', c' :: ls) (destruct c)
 end) (sum.inr [])
@@ -204,7 +204,7 @@ def parallel_rec {S : wseq (computation α)} (C : α → Sort v)
   (H : ∀ s ∈ S, ∀ a ∈ s, C a) {a} (h : a ∈ parallel S) : C a :=
 begin
   let T : wseq (computation (α × computation α)) :=
-    S.map (λc, c.map (λ a, (a, c))),
+    S.map (λ c, c.map (λ a, (a, c))),
   have : S = T.map (map (λ c, c.1)),
   { rw [←wseq.map_comp], refine (wseq.map_id _).symm.trans (congr_arg (λ f, wseq.map f S) _),
     funext c, dsimp [id, function.comp], rw [←map_comp], exact (map_id _).symm },
@@ -243,11 +243,11 @@ theorem parallel_congr_lem {S T : wseq (computation α)} {a}
 theorem parallel_congr_left {S T : wseq (computation α)} {a}
   (h1 : ∀ s ∈ S, s ~> a) (H : S.lift_rel equiv T) : parallel S ~ parallel T :=
 let h2 := (parallel_congr_lem H).1 h1 in
-λ a', ⟨λh, by have aa := parallel_promises h1 h; rw ←aa; rw ←aa at h; exact
+λ a', ⟨λ h, by have aa := parallel_promises h1 h; rw ←aa; rw ←aa at h; exact
   let ⟨s, sS, as⟩ := exists_of_mem_parallel h,
       ⟨t, tT, st⟩ := wseq.exists_of_lift_rel_left H sS,
       aT := (st _).1 as in mem_parallel h2 tT aT,
-λh, by have aa := parallel_promises h2 h; rw ←aa; rw ←aa at h; exact
+λ h, by have aa := parallel_promises h2 h; rw ←aa; rw ←aa at h; exact
   let ⟨s, sS, as⟩ := exists_of_mem_parallel h,
       ⟨t, tT, st⟩ := wseq.exists_of_lift_rel_right H sS,
       aT := (st _).2 as in mem_parallel h1 tT aT⟩

--- a/src/data/seq/wseq.lean
+++ b/src/data/seq/wseq.lean
@@ -60,7 +60,7 @@ def think : wseq α → wseq α := seq.cons none
 /-- Destruct a weak sequence, to (eventually possibly) produce either
   `none` for `nil` or `some (a, s)` if an element is produced. -/
 def destruct : wseq α → computation (option (α × wseq α)) :=
-computation.corec (λs, match seq.destruct s with
+computation.corec (λ s, match seq.destruct s with
   | none              := sum.inl none
   | some (none, s')   := sum.inr s'
   | some (some a, s') := sum.inl (some (a, s'))
@@ -85,7 +85,7 @@ computation.map ((<$>) prod.fst) (destruct s)
 /-- Encode a computation yielding a weak sequence into additional
   `think` constructors in a weak sequence -/
 def flatten : computation (wseq α) → wseq α :=
-seq.corec (λc, match computation.destruct c with
+seq.corec (λ c, match computation.destruct c with
   | sum.inl s := seq.omap return (seq.destruct s)
   | sum.inr c' := some (none, c')
   end)
@@ -94,7 +94,7 @@ seq.corec (λc, match computation.destruct c with
   wrapper, unlike `head`, because `flatten` allows us to hide this
   in the construction of the weak sequence itself. -/
 def tail (s : wseq α) : wseq α :=
-flatten $ (λo, option.rec_on o nil prod.snd) <$> destruct s
+flatten $ (λ o, option.rec_on o nil prod.snd) <$> destruct s
 
 /-- drop the first `n` elements from `s`. -/
 def drop (s : wseq α) : ℕ → wseq α
@@ -107,7 +107,7 @@ def nth (s : wseq α) (n : ℕ) : computation (option α) := head (drop s n)
 
 /-- Convert `s` to a list (if it is finite and completes in finite time). -/
 def to_list (s : wseq α) : computation (list α) :=
-@computation.corec (list α) (list α × wseq α) (λ⟨l, s⟩,
+@computation.corec (list α) (list α × wseq α) (λ ⟨l, s⟩,
   match seq.destruct s with
   | none              := sum.inl l.reverse
   | some (none, s')   := sum.inr (l, s')
@@ -116,7 +116,7 @@ def to_list (s : wseq α) : computation (list α) :=
 
 /-- Get the length of `s` (if it is finite and completes in finite time). -/
 def length (s : wseq α) : computation ℕ :=
-@computation.corec ℕ (ℕ × wseq α) (λ⟨n, s⟩,
+@computation.corec ℕ (ℕ × wseq α) (λ ⟨n, s⟩,
   match seq.destruct s with
   | none              := sum.inl n
   | some (none, s')   := sum.inr (n, s')
@@ -148,7 +148,7 @@ instance head_terminates (s : wseq α) [productive s] :
 
 /-- Replace the `n`th element of `s` with `a`. -/
 def update_nth (s : wseq α) (n : ℕ) (a : α) : wseq α :=
-@seq.corec (option α) (ℕ × wseq α) (λ⟨n, s⟩,
+@seq.corec (option α) (ℕ × wseq α) (λ ⟨n, s⟩,
   match seq.destruct s, n with
   | none,               n     := none
   | some (none, s'),    n     := some (none, n, s')
@@ -159,7 +159,7 @@ def update_nth (s : wseq α) (n : ℕ) (a : α) : wseq α :=
 
 /-- Remove the `n`th element of `s`. -/
 def remove_nth (s : wseq α) (n : ℕ) : wseq α :=
-@seq.corec (option α) (ℕ × wseq α) (λ⟨n, s⟩,
+@seq.corec (option α) (ℕ × wseq α) (λ ⟨n, s⟩,
   match seq.destruct s, n with
   | none,               n     := none
   | some (none, s'),    n     := some (none, n, s')
@@ -170,7 +170,7 @@ def remove_nth (s : wseq α) (n : ℕ) : wseq α :=
 
 /-- Map the elements of `s` over `f`, removing any values that yield `none`. -/
 def filter_map (f : α → option β) : wseq α → wseq β :=
-seq.corec (λs, match seq.destruct s with
+seq.corec (λ s, match seq.destruct s with
   | none              := none
   | some (none, s')   := some (none, s')
   | some (some a, s') := some (f a, s')
@@ -178,7 +178,7 @@ seq.corec (λs, match seq.destruct s with
 
 /-- Select the elements of `s` that satisfy `p`. -/
 def filter (p : α → Prop) [decidable_pred p] : wseq α → wseq α :=
-filter_map (λa, if p a then some a else none)
+filter_map (λ a, if p a then some a else none)
 
 -- example of infinite list manipulations
 /-- Get the first element of `s` satisfying `p`. -/
@@ -187,7 +187,7 @@ head $ filter p s
 
 /-- Zip a function over two weak sequences -/
 def zip_with (f : α → β → γ) (s1 : wseq α) (s2 : wseq β) : wseq γ :=
-@seq.corec (option γ) (wseq α × wseq β) (λ⟨s1, s2⟩,
+@seq.corec (option γ) (wseq α × wseq β) (λ ⟨s1, s2⟩,
   match seq.destruct s1, seq.destruct s2 with
   | some (none, s1'),    some (none, s2')    := some (none, s1', s2')
   | some (some a1, s1'), some (none, s2')    := some (none, s1, s2')
@@ -217,7 +217,7 @@ def indexes_of [decidable_eq α] (a : α) : wseq α → wseq ℕ := find_indexes
 /-- `union s1 s2` is a weak sequence which interleaves `s1` and `s2` in
   some order (nondeterministically). -/
 def union (s1 s2 : wseq α) : wseq α :=
-@seq.corec (option α) (wseq α × wseq α) (λ⟨s1, s2⟩,
+@seq.corec (option α) (wseq α × wseq α) (λ ⟨s1, s2⟩,
   match seq.destruct s1, seq.destruct s2 with
   | none,                none                := none
   | some (a1, s1'),      none                := some (a1, s1', nil)
@@ -241,7 +241,7 @@ end
 
 /-- Get the first `n` elements of a weak sequence -/
 def take (s : wseq α) (n : ℕ) : wseq α :=
-@seq.corec (option α) (ℕ × wseq α) (λ⟨n, s⟩,
+@seq.corec (option α) (ℕ × wseq α) (λ ⟨n, s⟩,
   match n, seq.destruct s with
   | 0,   _                 := none
   | m+1, none              := none
@@ -252,7 +252,7 @@ def take (s : wseq α) (n : ℕ) : wseq α :=
 /-- Split the sequence at position `n` into a finite initial segment
   and the weak sequence tail -/
 def split_at (s : wseq α) (n : ℕ) : computation (list α × wseq α) :=
-@computation.corec (list α × wseq α) (ℕ × list α × wseq α) (λ⟨n, l, s⟩,
+@computation.corec (list α × wseq α) (ℕ × list α × wseq α) (λ ⟨n, l, s⟩,
   match n, seq.destruct s with
   | 0,   _                 := sum.inl (l.reverse, s)
   | m+1, none              := sum.inl (l.reverse, s)
@@ -262,7 +262,7 @@ def split_at (s : wseq α) (n : ℕ) : computation (list α × wseq α) :=
 
 /-- Returns `tt` if any element of `s` satisfies `p` -/
 def any (s : wseq α) (p : α → bool) : computation bool :=
-computation.corec (λs : wseq α,
+computation.corec (λ s : wseq α,
   match seq.destruct s with
   | none              := sum.inl ff
   | some (none, s')   := sum.inr s'
@@ -271,7 +271,7 @@ computation.corec (λs : wseq α,
 
 /-- Returns `tt` if every element of `s` satisfies `p` -/
 def all (s : wseq α) (p : α → bool) : computation bool :=
-computation.corec (λs : wseq α,
+computation.corec (λ s : wseq α,
   match seq.destruct s with
   | none              := sum.inl tt
   | some (none, s')   := sum.inr s'
@@ -282,7 +282,7 @@ computation.corec (λs : wseq α,
   of partial results. (There is no `scanr` because this would require
   working from the end of the sequence, which may not exist.) -/
 def scanl (f : α → β → α) (a : α) (s : wseq β) : wseq α :=
-cons a $ @seq.corec (option α) (α × wseq β) (λ⟨a, s⟩,
+cons a $ @seq.corec (option α) (α × wseq β) (λ ⟨a, s⟩,
   match seq.destruct s with
   | none              := none
   | some (none, s')   := some (none, a, s')
@@ -314,7 +314,7 @@ def map (f : α → β) : wseq α → wseq β := seq.map (option.map f)
 /-- Flatten a sequence of weak sequences. (Note that this allows
   empty sequences, unlike `seq.join`.) -/
 def join (S : wseq (wseq α)) : wseq α :=
-seq.join ((λo : option (wseq α), match o with
+seq.join ((λ o : option (wseq α), match o with
   | none := seq1.ret none
   | some s := (none, s)
   end) <$> S)
@@ -483,7 +483,7 @@ seq.destruct_cons _ _
 
 @[simp] theorem flatten_ret (s : wseq α) : flatten (return s) = s :=
 begin
-  refine seq.eq_of_bisim (λs1 s2, flatten (return s2) = s1) _ rfl,
+  refine seq.eq_of_bisim (λ s1 s2, flatten (return s2) = s1) _ rfl,
   intros s' s h, rw ←h, simp [flatten],
   cases seq.destruct s, { simp },
   { cases val with o s', simp }
@@ -495,12 +495,12 @@ seq.destruct_eq_cons $ by simp [flatten, think]
 @[simp]
 theorem destruct_flatten (c : computation (wseq α)) : destruct (flatten c) = c >>= destruct :=
 begin
-  refine computation.eq_of_bisim (λc1 c2, c1 = c2 ∨
+  refine computation.eq_of_bisim (λ c1 c2, c1 = c2 ∨
     ∃ c, c1 = destruct (flatten c) ∧ c2 = computation.bind c destruct) _ (or.inr ⟨c, rfl, rfl⟩),
   intros c1 c2 h, exact match c1, c2, h with
   | _, _, (or.inl $ eq.refl c) := by cases c.destruct; simp
   | _, _, (or.inr ⟨c, rfl, rfl⟩) := begin
-    apply c.cases_on (λa, _) (λc', _); repeat {simp},
+    apply c.cases_on (λ a, _) (λ c', _); repeat {simp},
     { cases (destruct a).destruct; simp },
     { exact or.inr ⟨c', rfl, rfl⟩ }
   end end
@@ -630,7 +630,7 @@ instance productive_dropn (s : wseq α) [productive s] (n) : productive (drop s 
 /-- Given a productive weak sequence, we can collapse all the `think`s to
   produce a sequence. -/
 def to_seq (s : wseq α) [productive s] : seq α :=
-⟨λ n, (nth s n).get, λn h,
+⟨λ n, (nth s n).get, λ n h,
 begin
   cases e : computation.get (nth s (n + 1)), {assumption},
   have := mem_of_get_eq _ e,
@@ -685,7 +685,7 @@ begin
     unfold cons has_mem.mem wseq.mem seq.mem seq.cons, simp,
     have h_a_eq_a' : a = a' ↔ some (some a) = some (some a'), {simp},
     rw [h_a_eq_a'],
-    refine ⟨stream.eq_or_mem_of_mem_cons, λo, _⟩,
+    refine ⟨stream.eq_or_mem_of_mem_cons, λ o, _⟩,
     { cases o with e m,
       { rw e, apply stream.mem_cons },
       { exact stream.mem_cons_of_mem _ m } } },
@@ -704,7 +704,7 @@ theorem mem_cons (s : wseq α) (a) : a ∈ cons a s :=
 theorem mem_of_mem_tail {s : wseq α} {a} : a ∈ tail s → a ∈ s :=
 begin
   intro h, have := h, cases h with n e, revert s, simp [stream.nth],
-  induction n with n IH; intro s; apply s.cases_on _ (λx s, _) (λ s, _);
+  induction n with n IH; intro s; apply s.cases_on _ (λ x s, _) (λ s, _);
     repeat{simp}; intros m e; injections,
   { exact or.inr m },
   { exact or.inr m },
@@ -877,7 +877,7 @@ by simp only [productive_iff]; exact
   forall_congr (λ n, terminates_congr $ nth_congr h _)
 
 theorem equiv.ext {s t : wseq α} (h : ∀ n, nth s n ~ nth t n) : s ~ t :=
-⟨λ s t, ∀ n, nth s n ~ nth t n, h, λs t h, begin
+⟨λ s t, ∀ n, nth s n ~ nth t n, h, λ s t h, begin
   refine lift_rel_def.2 ⟨_, _⟩,
   { rw [←head_terminates_iff, ←head_terminates_iff],
     exact terminates_congr (h 0) },
@@ -1194,7 +1194,7 @@ theorem lift_rel_join (R : α → β → Prop) {S : wseq (wseq α)} {T : wseq (w
   s1 = append s (join S) ∧ s2 = append t (join T) ∧
   lift_rel R s t ∧ lift_rel (lift_rel R) S T,
   ⟨nil, nil, S, T, by simp, by simp, by simp, h⟩,
-λs1 s2 ⟨s, t, S, T, h1, h2, st, ST⟩, begin
+λ s1 s2 ⟨s, t, S, T, h1, h2, st, ST⟩, begin
   clear _fun_match _x,
   rw [h1, h2], rw [destruct_append, destruct_append],
   apply computation.lift_rel_bind _ _ (lift_rel_destruct st),
@@ -1277,7 +1277,7 @@ end
 
 @[simp] theorem bind_ret (f : α → β) (s) : bind s (ret ∘ f) ~ map f s :=
 begin
-  dsimp [bind], change (λx, ret (f x)) with (ret ∘ f),
+  dsimp [bind], change (λ x, ret (f x)) with (ret ∘ f),
   rw [map_comp], apply join_map_ret
 end
 
@@ -1287,7 +1287,7 @@ end
 @[simp] theorem map_join (f : α → β) (S) :
   map f (join S) = join (map (map f) S) :=
 begin
-  apply seq.eq_of_bisim (λs1 s2,
+  apply seq.eq_of_bisim (λ s1 s2,
     ∃ s S, s1 = append s (map f (join S)) ∧
       s2 = append s (join (map (map f) S))),
   { intros s1 s2 h,


### PR DESCRIPTION
We do `λx` → `λ x` and a single instance of `{ x }` → `{x}`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
