### PR TITLE
[Merged by Bors] - feat(data/real/ennreal): add instance linear_ordered_comm_monoid_with_zero ℝ≥0∞

### DIFF
--- a/src/data/real/ennreal.lean
+++ b/src/data/real/ennreal.lean
@@ -94,6 +94,12 @@ canonically_ordered_comm_semiring.to_covariant_mul_le
 instance covariant_class_add_le : covariant_class ℝ≥0∞ ℝ≥0∞ (+) (≤) :=
 ordered_add_comm_monoid.to_covariant_class_left ℝ≥0∞
 
+noncomputable instance : linear_ordered_comm_monoid_with_zero ℝ≥0∞ :=
+{ mul_le_mul_left := λ a b, mul_le_mul_left',
+  zero_le_one := zero_le 1,
+  .. ennreal.linear_ordered_add_comm_monoid_with_top,
+  .. (show comm_semiring ℝ≥0∞, from infer_instance) }
+
 instance : inhabited ℝ≥0∞ := ⟨0⟩
 
 instance : has_coe ℝ≥0 ℝ≥0∞ := ⟨ option.some ⟩
@@ -221,7 +227,6 @@ protected lemma zero_lt_one : 0 < (1 : ℝ≥0∞) :=
 
 @[simp] lemma one_lt_two : (1 : ℝ≥0∞) < 2 :=
 coe_one ▸ coe_two ▸ by exact_mod_cast (@one_lt_two ℕ _ _)
-lemma one_le_two : (1 : ℝ≥0∞) ≤ 2 := one_lt_two.le
 @[simp] lemma zero_lt_two : (0:ℝ≥0∞) < 2 := lt_trans ennreal.zero_lt_one one_lt_two
 lemma two_ne_zero : (2:ℝ≥0∞) ≠ 0 := (ne_of_lt zero_lt_two).symm
 lemma two_ne_top : (2:ℝ≥0∞) ≠ ∞ := coe_two ▸ coe_ne_top
@@ -230,8 +235,7 @@ lemma two_ne_top : (2:ℝ≥0∞) ≠ ∞ := coe_two ▸ coe_ne_top
 instance _root_.fact_one_le_one_ennreal : fact ((1 : ℝ≥0∞) ≤ 1) := ⟨le_rfl⟩
 
 /-- `(1 : ℝ≥0∞) ≤ 2`, recorded as a `fact` for use with `Lp` spaces. -/
-instance _root_.fact_one_le_two_ennreal : fact ((1 : ℝ≥0∞) ≤ 2) :=
-⟨ennreal.coe_le_coe.2 (show (1 : ℝ≥0) ≤ 2, by norm_num)⟩
+instance _root_.fact_one_le_two_ennreal : fact ((1 : ℝ≥0∞) ≤ 2) := ⟨one_le_two⟩
 
 /-- `(1 : ℝ≥0∞) ≤ ∞`, recorded as a `fact` for use with `Lp` spaces. -/
 instance _root_.fact_one_le_top_ennreal : fact ((1 : ℝ≥0∞) ≤ ∞) := ⟨le_top⟩

--- a/src/probability/variance.lean
+++ b/src/probability/variance.lean
@@ -82,7 +82,7 @@ begin
   { apply hX.integrable_sq.add,
     convert integrable_const (𝔼[X] ^ 2),
     apply_instance },
-  { exact ((hX.integrable ennreal.one_le_two).const_mul 2).mul_const' _ },
+  { exact ((hX.integrable one_le_two).const_mul 2).mul_const' _ },
   simp only [integral_mul_right, pi.pow_apply, pi.mul_apply, pi.bit0_apply, pi.one_apply,
     integral_const (integral ℙ X ^ 2), integral_mul_left (2 : ℝ), one_mul,
     variance, pi.pow_apply, measure_univ, ennreal.one_to_real, algebra.id.smul_eq_mul],
@@ -149,19 +149,19 @@ Var[X + Y] = 𝔼[λ a, (X a)^2 + (Y a)^2 + 2 * X a * Y a] - 𝔼[X+Y]^2 :
 begin
   simp only [pi.add_apply, pi.pow_apply, pi.mul_apply, mul_assoc],
   rw [integral_add, integral_add, integral_add, integral_mul_left],
-  { exact hX.integrable ennreal.one_le_two },
-  { exact hY.integrable ennreal.one_le_two },
+  { exact hX.integrable one_le_two },
+  { exact hY.integrable one_le_two },
   { exact hX.integrable_sq },
   { exact hY.integrable_sq },
   { exact hX.integrable_sq.add hY.integrable_sq },
   { apply integrable.const_mul,
-    exact h.integrable_mul (hX.integrable ennreal.one_le_two) (hY.integrable ennreal.one_le_two) }
+    exact h.integrable_mul (hX.integrable one_le_two) (hY.integrable one_le_two) }
 end
 ... = (𝔼[X^2] + 𝔼[Y^2] + 2 * (𝔼[X] * 𝔼[Y])) - (𝔼[X] + 𝔼[Y])^2 :
 begin
   congr,
   exact h.integral_mul_of_integrable
-    (hX.integrable ennreal.one_le_two) (hY.integrable ennreal.one_le_two),
+    (hX.integrable one_le_two) (hY.integrable one_le_two),
 end
 ... = Var[X] + Var[Y] :
   by { simp only [variance_def', hX, hY, pi.pow_apply], ring }
@@ -182,9 +182,9 @@ begin
     - (𝔼[X k] + 𝔼[∑ i in s, X i]) ^ 2 :
   begin
     rw [integral_add', integral_add', integral_add'],
-    { exact mem_ℒp.integrable ennreal.one_le_two (hs _ (mem_insert_self _ _)) },
+    { exact mem_ℒp.integrable one_le_two (hs _ (mem_insert_self _ _)) },
     { apply integrable_finset_sum' _ (λ i hi, _),
-      exact mem_ℒp.integrable ennreal.one_le_two (hs _ (mem_insert_of_mem hi)) },
+      exact mem_ℒp.integrable one_le_two (hs _ (mem_insert_of_mem hi)) },
     { exact mem_ℒp.integrable_sq (hs _ (mem_insert_self _ _)) },
     { apply mem_ℒp.integrable_sq,
       exact mem_ℒp_finset_sum' _ (λ i hi, (hs _ (mem_insert_of_mem hi))) },
@@ -197,8 +197,8 @@ begin
       simp only [mul_sum, sum_apply, pi.mul_apply],
       apply integrable_finset_sum _ (λ i hi, _),
       apply indep_fun.integrable_mul _
-        (mem_ℒp.integrable ennreal.one_le_two (hs _ (mem_insert_self _ _)))
-        (mem_ℒp.integrable ennreal.one_le_two (hs _ (mem_insert_of_mem hi))),
+        (mem_ℒp.integrable one_le_two (hs _ (mem_insert_self _ _)))
+        (mem_ℒp.integrable one_le_two (hs _ (mem_insert_of_mem hi))),
       apply h (mem_insert_self _ _) (mem_insert_of_mem hi),
       exact (λ hki, ks (hki.symm ▸ hi)) }
   end
@@ -216,19 +216,19 @@ begin
     rw integral_finset_sum s (λ i hi, _), swap,
     { apply integrable.const_mul _ 2,
       apply indep_fun.integrable_mul _
-        (mem_ℒp.integrable ennreal.one_le_two (hs _ (mem_insert_self _ _)))
-        (mem_ℒp.integrable ennreal.one_le_two (hs _ (mem_insert_of_mem hi))),
+        (mem_ℒp.integrable one_le_two (hs _ (mem_insert_self _ _)))
+        (mem_ℒp.integrable one_le_two (hs _ (mem_insert_of_mem hi))),
       apply h (mem_insert_self _ _) (mem_insert_of_mem hi),
       exact (λ hki, ks (hki.symm ▸ hi)) },
     rw [integral_finset_sum s
-      (λ i hi, (mem_ℒp.integrable ennreal.one_le_two (hs _ (mem_insert_of_mem hi)))),
+      (λ i hi, (mem_ℒp.integrable one_le_two (hs _ (mem_insert_of_mem hi)))),
       mul_sum, mul_sum, ← sum_sub_distrib],
     apply finset.sum_eq_zero (λ i hi, _),
     rw [integral_mul_left, indep_fun.integral_mul_of_integrable', sub_self],
     { apply h (mem_insert_self _ _) (mem_insert_of_mem hi),
       exact (λ hki, ks (hki.symm ▸ hi)) },
-    { exact mem_ℒp.integrable ennreal.one_le_two (hs _ (mem_insert_self _ _)) },
-    { exact mem_ℒp.integrable ennreal.one_le_two (hs _ (mem_insert_of_mem hi)) }
+    { exact mem_ℒp.integrable one_le_two (hs _ (mem_insert_self _ _)) },
+    { exact mem_ℒp.integrable one_le_two (hs _ (mem_insert_of_mem hi)) }
   end
   ... = Var[X k] + ∑ i in s, Var[X i] :
     by rw IH (λ i hi, hs i (mem_insert_of_mem hi))


### PR DESCRIPTION
Adding this instance also yields an instance of `zero_le_one_class` via type class inference, which gives access to `one_le_two`, so we remove `ennreal.one_le_two` in favor of `one_le_two`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
