### PR TITLE
[Merged by Bors] - feat(order/complete_lattice): add `equiv.supr_congr` and `equiv.supr_comp` lemmas

### DIFF
--- a/src/order/complete_lattice.lean
+++ b/src/order/complete_lattice.lean
@@ -416,6 +416,10 @@ protected lemma function.surjective.supr_congr {g : ι' → α} (h : ι → ι')
   (h2 : ∀ x, g (h x) = f x) : (⨆ x, f x) = ⨆ y, g y :=
 by { convert h1.supr_comp g, exact (funext h2).symm }
 
+protected lemma equiv.supr_congr {g : ι' → α} (e : ι ≃ ι') (h : ∀ x, g (e x) = f x) :
+  (⨆ x, f x) = ⨆ y, g y :=
+e.surjective.supr_congr _ h
+
 @[congr] lemma supr_congr_Prop {p q : Prop} {f₁ : p → α} {f₂ : q → α} (pq : p ↔ q)
   (f : ∀ x, f₁ (pq.mpr x) = f₂ x) : supr f₁ = supr f₂ :=
 by { obtain rfl := propext pq, congr' with x, apply f }
@@ -440,9 +444,13 @@ lemma function.surjective.infi_comp {f : ι → ι'} (hf : surjective f) (g : ι
   (⨅ x, g (f x)) = ⨅ y, g y :=
 @function.surjective.supr_comp αᵒᵈ _ _  _ f hf g
 
-lemma function.surjective.infi_congr {g : ι' → α} (h : ι → ι') (h1 : surjective h)
+protected lemma function.surjective.infi_congr {g : ι' → α} (h : ι → ι') (h1 : surjective h)
   (h2 : ∀ x, g (h x) = f x) : (⨅ x, f x) = ⨅ y, g y :=
 @function.surjective.supr_congr αᵒᵈ _ _ _ _ _ h h1 h2
+
+protected lemma equiv.infi_congr {g : ι' → α} (e : ι ≃ ι') (h : ∀ x, g (e x) = f x) :
+  (⨅ x, f x) = ⨅ y, g y :=
+@equiv.supr_congr αᵒᵈ _ _ _ _ _ e h
 
 @[congr]lemma infi_congr_Prop {p q : Prop} {f₁ : p → α} {f₂ : q → α}
   (pq : p ↔ q) (f : ∀ x, f₁ (pq.mpr x) = f₂ x) : infi f₁ = infi f₂ :=

--- a/src/order/complete_lattice.lean
+++ b/src/order/complete_lattice.lean
@@ -412,6 +412,10 @@ lemma function.surjective.supr_comp {f : ι → ι'} (hf : surjective f) (g : ι
   (⨆ x, g (f x)) = ⨆ y, g y :=
 by simp only [supr, hf.range_comp]
 
+lemma equiv.supr_comp {g : ι' → α} (e : ι ≃ ι') :
+  (⨆ x, g (e x)) = ⨆ y, g y :=
+e.surjective.supr_comp _
+
 protected lemma function.surjective.supr_congr {g : ι' → α} (h : ι → ι') (h1 : surjective h)
   (h2 : ∀ x, g (h x) = f x) : (⨆ x, f x) = ⨆ y, g y :=
 by { convert h1.supr_comp g, exact (funext h2).symm }
@@ -443,6 +447,10 @@ lemma infi_congr (h : ∀ i, f i = g i) : (⨅ i, f i) = ⨅ i, g i := congr_arg
 lemma function.surjective.infi_comp {f : ι → ι'} (hf : surjective f) (g : ι' → α) :
   (⨅ x, g (f x)) = ⨅ y, g y :=
 @function.surjective.supr_comp αᵒᵈ _ _  _ f hf g
+
+lemma equiv.infi_comp {g : ι' → α} (e : ι ≃ ι') :
+  (⨅ x, g (e x)) = ⨅ y, g y :=
+@equiv.supr_comp αᵒᵈ _ _ _ _ e
 
 protected lemma function.surjective.infi_congr {g : ι' → α} (h : ι → ι') (h1 : surjective h)
   (h2 : ∀ x, g (h x) = f x) : (⨅ x, f x) = ⨅ y, g y :=

--- a/src/order/conditionally_complete_lattice.lean
+++ b/src/order/conditionally_complete_lattice.lean
@@ -482,23 +482,6 @@ lemma cinfi_set_le {f : β → α} {s : set β}
   (H : bdd_below (f '' s)) {c : β} (hc : c ∈ s) : (⨅ i : s, f i) ≤ f c :=
 @le_csupr_set αᵒᵈ _ _ _ _ H _ hc
 
-lemma equiv.csupr {ι ι' : Type*} (e : ι ≃ ι') {f : ι → α} (hf : bdd_above (range f)) {g : ι' → α}
-  (hfg : ∀ i, f i = g (e i)) : (⨆ i, f i) = ⨆ i, g i :=
-begin
-  casesI is_empty_or_nonempty ι,
-  { haveI : is_empty ι' := (equiv.is_empty_congr e).mp h, simp only [supr, range_eq_empty] },
-  { haveI : nonempty ι' := (equiv.nonempty_congr e).mp h,
-    have hg : bdd_above (range g),
-    { obtain ⟨M, hM⟩ := hf, use M, rintros - ⟨i, rfl⟩, refine hM ⟨(e.symm i), _⟩,
-      simpa only [equiv.apply_symm_apply] using hfg (e.symm i), },
-    refine le_antisymm (csupr_le (λ i, (hfg i).symm ▸ le_csupr hg (e i))) (csupr_le (λ i, _)),
-    simpa only [equiv.apply_symm_apply, hfg (e.symm i)] using le_csupr hf (e.symm i) },
-end
-
-lemma equiv.cinfi {ι ι' : Type*} (e : ι ≃ ι') {f : ι → α} (hf : bdd_below (range f)) {g : ι' → α}
-  (hfg : ∀ i, f i = g (e i)) : (⨅ i, f i) = ⨅ i, g i :=
-@equiv.csupr αᵒᵈ _ _ _ e _ hf _ hfg
-
 @[simp] theorem csupr_const [hι : nonempty ι] {a : α} : (⨆ b : ι, a) = a :=
 by rw [supr, range_const, cSup_singleton]
 

--- a/src/order/conditionally_complete_lattice.lean
+++ b/src/order/conditionally_complete_lattice.lean
@@ -482,6 +482,23 @@ lemma cinfi_set_le {f : β → α} {s : set β}
   (H : bdd_below (f '' s)) {c : β} (hc : c ∈ s) : (⨅ i : s, f i) ≤ f c :=
 @le_csupr_set αᵒᵈ _ _ _ _ H _ hc
 
+lemma equiv.csupr {ι ι' : Type*} (e : ι ≃ ι') {f : ι → α} (hf : bdd_above (range f)) {g : ι' → α}
+  (hfg : ∀ i, f i = g (e i)) : (⨆ i, f i) = ⨆ i, g i :=
+begin
+  casesI is_empty_or_nonempty ι,
+  { haveI : is_empty ι' := (equiv.is_empty_congr e).mp h, simp only [supr, range_eq_empty] },
+  { haveI : nonempty ι' := (equiv.nonempty_congr e).mp h,
+    have hg : bdd_above (range g),
+    { obtain ⟨M, hM⟩ := hf, use M, rintros - ⟨i, rfl⟩, refine hM ⟨(e.symm i), _⟩,
+      simpa only [equiv.apply_symm_apply] using hfg (e.symm i), },
+    refine le_antisymm (csupr_le (λ i, (hfg i).symm ▸ le_csupr hg (e i))) (csupr_le (λ i, _)),
+    simpa only [equiv.apply_symm_apply, hfg (e.symm i)] using le_csupr hf (e.symm i) },
+end
+
+lemma equiv.cinfi {ι ι' : Type*} (e : ι ≃ ι') {f : ι → α} (hf : bdd_below (range f)) {g : ι' → α}
+  (hfg : ∀ i, f i = g (e i)) : (⨅ i, f i) = ⨅ i, g i :=
+@equiv.csupr αᵒᵈ _ _ _ e _ hf _ hfg
+
 @[simp] theorem csupr_const [hι : nonempty ι] {a : α} : (⨆ b : ι, a) = a :=
 by rw [supr, range_const, cSup_singleton]
 


### PR DESCRIPTION
Adds these lemmas as easy consequences of the `function.surjective` versions in order to aid in discovery.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
