### PR TITLE
[Merged by Bors] - feat(category_theory/epi_mono): preserves/reflects properties for epi/split_epi

### DIFF
--- a/src/category_theory/epi_mono.lean
+++ b/src/category_theory/epi_mono.lean
@@ -38,6 +38,7 @@ such that `f ≫ retraction f = 𝟙 X`.
 
 Every split monomorphism is a monomorphism.
 -/
+@[ext]
 class split_mono {X Y : C} (f : X ⟶ Y) :=
 (retraction : Y ⟶ X)
 (id' : f ≫ retraction = 𝟙 X . obviously)
@@ -49,6 +50,7 @@ such that `section_ f ≫ f = 𝟙 Y`.
 
 Every split epimorphism is an epimorphism.
 -/
+@[ext]
 class split_epi {X Y : C} (f : X ⟶ Y) :=
 (section_ : Y ⟶ X)
 (id' : section_ ≫ f = 𝟙 Y . obviously)

--- a/src/category_theory/functor/epi_mono.lean
+++ b/src/category_theory/functor/epi_mono.lean
@@ -167,4 +167,62 @@ instance reflects_epimorphisms_of_faithful (F : C ⥤ D) [faithful F] : reflects
 { reflects := λ X Y f hf, ⟨λ Z g h hgh, by exactI F.map_injective ((cancel_epi (F.map f)).1
     (by rw [← F.map_comp, hgh, F.map_comp]))⟩ }
 
+section
+
+variables (F : C ⥤ D) {X Y : C} (f : X ⟶ Y)
+
+/-- Split epimorphisms are preserved by the application of any functor. -/
+@[simps]
+def map_split_epi (s : split_epi f) : split_epi (F.map f) :=
+⟨F.map s.section_, by { rw [← F.map_comp, ← F.map_id], congr' 1, apply split_epi.id, }⟩
+
+/-- Split monomorphisms are preserved by the application of any functor. -/
+@[simps]
+def map_split_mono (s : split_mono f) : split_mono (F.map f) :=
+⟨F.map s.retraction, by { rw [← F.map_comp, ← F.map_id], congr' 1, apply split_mono.id, }⟩
+
+/-- If `F` is a fully faithful functor, split epimorphisms are preserved and reflected by `F`. -/
+def split_epi_equiv [full F] [faithful F] : split_epi f ≃ split_epi (F.map f) :=
+{ to_fun := F.map_split_epi f,
+  inv_fun := λ s, begin
+    refine ⟨F.preimage s.section_, _⟩,
+    apply F.map_injective,
+    simp only [map_comp, image_preimage, map_id],
+    apply split_epi.id,
+  end,
+  left_inv := by tidy,
+  right_inv := by tidy, }
+
+/-- If `F` is a fully faithful functor, split monomorphisms are preserved and reflected by `F`. -/
+def split_mono_equiv [full F] [faithful F] : split_mono f ≃ split_mono (F.map f) :=
+{ to_fun := F.map_split_mono f,
+  inv_fun := λ s, begin
+    refine ⟨F.preimage s.retraction, _⟩,
+    apply F.map_injective,
+    simp only [map_comp, image_preimage, map_id],
+    apply split_mono.id,
+  end,
+  left_inv := by tidy,
+  right_inv := by tidy, }
+
+lemma epi_iff_epi_map [hF₁ : preserves_epimorphisms F] [hF₂ : reflects_epimorphisms F] :
+  epi f ↔ epi (F.map f) :=
+begin
+  split,
+  { introI h,
+    exact F.map_epi f, },
+  { exact F.epi_of_epi_map, },
+end
+
+lemma mono_iff_mono_map [hF₁ : preserves_monomorphisms F] [hF₂ : reflects_monomorphisms F] :
+  mono f ↔ mono (F.map f) :=
+begin
+  split,
+  { introI h,
+    exact F.map_mono f, },
+  { exact F.mono_of_mono_map, },
+end
+
+end
+
 end category_theory.functor

--- a/src/category_theory/functor/epi_mono.lean
+++ b/src/category_theory/functor/epi_mono.lean
@@ -216,7 +216,7 @@ begin
 end
 
 @[simp]
-lemma mono_iff_mono_map [hF₁ : preserves_monomorphisms F] [hF₂ : reflects_monomorphisms F] :
+lemma mono_map_iff_mono [hF₁ : preserves_monomorphisms F] [hF₂ : reflects_monomorphisms F] :
   mono (F.map f) ↔ mono f :=
 begin
   split,

--- a/src/category_theory/functor/epi_mono.lean
+++ b/src/category_theory/functor/epi_mono.lean
@@ -205,22 +205,24 @@ def split_mono_equiv [full F] [faithful F] : split_mono f ≃ split_mono (F.map 
   left_inv := by tidy,
   right_inv := by tidy, }
 
+@[simp]
 lemma epi_iff_epi_map [hF₁ : preserves_epimorphisms F] [hF₂ : reflects_epimorphisms F] :
-  epi f ↔ epi (F.map f) :=
+  epi (F.map f) ↔ epi f :=
 begin
   split,
+  { exact F.epi_of_epi_map, },
   { introI h,
     exact F.map_epi f, },
-  { exact F.epi_of_epi_map, },
 end
 
+@[simp]
 lemma mono_iff_mono_map [hF₁ : preserves_monomorphisms F] [hF₂ : reflects_monomorphisms F] :
-  mono f ↔ mono (F.map f) :=
+  mono (F.map f) ↔ mono f :=
 begin
   split,
+  { exact F.mono_of_mono_map, },
   { introI h,
     exact F.map_mono f, },
-  { exact F.mono_of_mono_map, },
 end
 
 end

--- a/src/category_theory/functor/epi_mono.lean
+++ b/src/category_theory/functor/epi_mono.lean
@@ -206,7 +206,7 @@ def split_mono_equiv [full F] [faithful F] : split_mono f ≃ split_mono (F.map 
   right_inv := by tidy, }
 
 @[simp]
-lemma epi_iff_epi_map [hF₁ : preserves_epimorphisms F] [hF₂ : reflects_epimorphisms F] :
+lemma epi_map_iff_epi [hF₁ : preserves_epimorphisms F] [hF₂ : reflects_epimorphisms F] :
   epi (F.map f) ↔ epi f :=
 begin
   split,


### PR DESCRIPTION
This PR shows that split epi/mono are preserved by any functor, and reflected by fully faithful functors. Moreover, `iff` lemmas are obtained for functors which both preserve and reflect epimorphisms (resp. monomorphisms).

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
