### PR TITLE
[Merged by Bors] - feat(group_theory/group_action/conj_act): smul_comm_class instances

### DIFF
--- a/src/group_theory/group_action/conj_act.lean
+++ b/src/group_theory/group_action/conj_act.lean
@@ -30,7 +30,7 @@ is that some theorems about the group actions will not apply when since this
 
 -/
 
-variables (M G G₀ R K : Type*)
+variables (α M G G₀ R K : Type*)
 
 /-- A type alias for a group `G`. `conj_act G` acts on `G` by conjugation -/
 def conj_act : Type* := G
@@ -62,6 +62,9 @@ def to_conj_act : G ≃* conj_act G := of_conj_act.symm
 /-- A recursor for `conj_act`, for use as `induction x using conj_act.rec` when `x : conj_act G`. -/
 protected def rec {C : conj_act G → Sort*} (h : Π g, C (to_conj_act g)) : Π g, C g := h
 
+@[simp] lemma «forall» (p : conj_act G → Prop) :
+  (∀ (x : conj_act G), p x) ↔ ∀ x : G, p (to_conj_act x) := iff.rfl
+
 @[simp] lemma of_mul_symm_eq : (@of_conj_act G _).symm = to_conj_act := rfl
 @[simp] lemma to_mul_symm_eq : (@to_conj_act G _).symm = of_conj_act := rfl
 @[simp] lemma to_conj_act_of_conj_act (x : conj_act G) : to_conj_act (of_conj_act x) = x := rfl
@@ -79,9 +82,6 @@ instance : has_smul (conj_act G) G :=
 { smul := λ g h, of_conj_act g * h * (of_conj_act g)⁻¹ }
 
 lemma smul_def (g : conj_act G) (h : G) : g • h = of_conj_act g * h * (of_conj_act g)⁻¹ := rfl
-
-@[simp] lemma «forall» (p : conj_act G → Prop) :
-  (∀ (x : conj_act G), p x) ↔ ∀ x : G, p (to_conj_act x) := iff.rfl
 
 end div_inv_monoid
 
@@ -102,6 +102,14 @@ instance units_mul_distrib_mul_action : mul_distrib_mul_action (conj_act Mˣ) M 
   mul_smul := by simp [units_smul_def, mul_assoc, mul_inv_rev],
   smul_mul := by simp [units_smul_def, mul_assoc],
   smul_one := by simp [units_smul_def], }
+
+instance units_smul_comm_class [has_smul α M] [smul_comm_class α M M] [is_scalar_tower α M M] :
+  smul_comm_class α (conj_act Mˣ) M :=
+{ smul_comm := λ a um m, by rw [units_smul_def, units_smul_def, mul_smul_comm, smul_mul_assoc] }
+
+instance units_smul_comm_class' [has_smul α M] [smul_comm_class M α M] [is_scalar_tower α M M] :
+  smul_comm_class (conj_act Mˣ) α M :=
+by { haveI : smul_comm_class α M M := smul_comm_class.symm _ _ _, exact smul_comm_class.symm _ _ _ }
 
 end monoid
 
@@ -129,6 +137,14 @@ instance mul_action₀ : mul_action (conj_act G₀) G₀ :=
   one_smul := by simp [smul_def],
   mul_smul := by simp [smul_def, mul_assoc, mul_inv_rev] }
 
+instance smul_comm_class₀ [has_smul α G₀] [smul_comm_class α G₀ G₀] [is_scalar_tower α G₀ G₀] :
+  smul_comm_class α (conj_act G₀) G₀ :=
+{ smul_comm := λ a ug g, by rw [smul_def, smul_def, mul_smul_comm, smul_mul_assoc] }
+
+instance smul_comm_class₀' [has_smul α G₀] [smul_comm_class G₀ α G₀] [is_scalar_tower α G₀ G₀] :
+  smul_comm_class (conj_act G₀) α G₀ :=
+by { haveI := smul_comm_class.symm G₀ α G₀, exact smul_comm_class.symm _ _ _ }
+
 end group_with_zero
 
 section division_ring
@@ -150,6 +166,14 @@ instance : mul_distrib_mul_action (conj_act G) G :=
   smul_one := by simp [smul_def],
   one_smul := by simp [smul_def],
   mul_smul := by simp [smul_def, mul_assoc] }
+
+instance smul_comm_class [has_smul α G] [smul_comm_class α G G] [is_scalar_tower α G G] :
+  smul_comm_class α (conj_act G) G :=
+{ smul_comm := λ a ug g, by rw [smul_def, smul_def, mul_smul_comm, smul_mul_assoc] }
+
+instance smul_comm_class' [has_smul α G] [smul_comm_class G α G] [is_scalar_tower α G G] :
+  smul_comm_class (conj_act G) α G :=
+by { haveI := smul_comm_class.symm G α G, exact smul_comm_class.symm _ _ _ }
 
 lemma smul_eq_mul_aut_conj (g : conj_act G) (h : G) : g • h = mul_aut.conj (of_conj_act g) h := rfl
 


### PR DESCRIPTION
Notably these instances give us access to conjugation as a linear map, enabling the pointwise scalar multiplication on submodules.

I also moved the `forall` lemma to be next to the `rec` definition it is similar to.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
