### PR TITLE
[Merged by Bors] - chore(data/multiset/basic): rename theorems, mark as `simp`

### DIFF
--- a/src/algebra/big_operators/multiset.lean
+++ b/src/algebra/big_operators/multiset.lean
@@ -66,7 +66,7 @@ by rw [← m.coe_to_list, coe_erase, coe_map, coe_map, coe_prod, coe_prod,
 
 @[simp, to_additive]
 lemma prod_singleton (a : α) : prod {a} = a :=
-by simp only [mul_one, prod_cons, singleton_eq_cons, eq_self_iff_true, prod_zero]
+by simp only [mul_one, prod_cons, ←cons_zero, eq_self_iff_true, prod_zero]
 
 @[to_additive]
 lemma prod_pair (a b : α) : ({a, b} : multiset α).prod = a * b :=
@@ -389,7 +389,7 @@ le_prod_nonempty_of_submultiplicative_on_pred f (λ i, true) (by simp [h_mul]) (
   hs_nonempty (by simp)
 
 @[simp] lemma sum_map_singleton (s : multiset α) : (s.map (λ a, ({a} : multiset α))).sum = s :=
-multiset.induction_on s (by simp) (by simp [singleton_eq_cons])
+multiset.induction_on s (by simp) (by simp)
 
 lemma abs_sum_le_sum_abs [linear_ordered_add_comm_group α] {s : multiset α} :
   abs s.sum ≤ (s.map abs).sum :=

--- a/src/data/finset/basic.lean
+++ b/src/data/finset/basic.lean
@@ -1855,7 +1855,7 @@ by simpa [←to_finset_eq hl, ←to_finset_eq hl'] using h
 finset.eq_of_veq dedup_cons
 
 @[simp] lemma to_finset_singleton (a : α) : to_finset ({a} : multiset α) = {a} :=
-by rw [singleton_eq_cons, to_finset_cons, to_finset_zero, is_lawful_singleton.insert_emptyc_eq]
+by rw [←cons_zero, to_finset_cons, to_finset_zero, is_lawful_singleton.insert_emptyc_eq]
 
 @[simp] lemma to_finset_add (s t : multiset α) : to_finset (s + t) = to_finset s ∪ to_finset t :=
 finset.ext $ by simp

--- a/src/data/finset/noncomm_prod.lean
+++ b/src/data/finset/noncomm_prod.lean
@@ -262,7 +262,7 @@ by simp [noncomm_prod, insert_val_of_not_mem ha, multiset.noncomm_prod_cons']
 @[simp, to_additive] lemma noncomm_prod_singleton (a : α) (f : α → β) :
   noncomm_prod ({a} : finset α) f
     (λ x hx y hy, by rw [mem_singleton.mp hx, mem_singleton.mp hy]) = f a :=
-by simp [noncomm_prod, multiset.singleton_eq_cons]
+by simp [noncomm_prod, ←multiset.cons_zero]
 
 @[to_additive]
 lemma noncomm_prod_map (s : finset α) (f : α → β)

--- a/src/data/fintype/basic.lean
+++ b/src/data/fintype/basic.lean
@@ -876,7 +876,7 @@ instance : fintype punit := fintype.of_subsingleton punit.star
 
 @[simp] theorem fintype.card_punit : fintype.card punit = 1 := rfl
 
-instance : fintype bool := ⟨⟨tt ::ₘ ff ::ₘ 0, by simp⟩, λ x, by cases x; simp⟩
+instance : fintype bool := ⟨⟨{tt, ff}, by simp⟩, λ x, by cases x; simp⟩
 
 @[simp] theorem fintype.univ_bool : @univ bool _ = {tt, ff} := rfl
 
@@ -1283,8 +1283,7 @@ instance plift.fintype_Prop (p : Prop) [decidable p] : fintype (plift p) :=
 ⟨if h : p then {⟨h⟩} else ∅, λ ⟨h⟩, by simp [h]⟩
 
 instance Prop.fintype : fintype Prop :=
-⟨⟨true ::ₘ false ::ₘ 0, by simp [true_ne_false]⟩,
- classical.cases (by simp) (by simp)⟩
+⟨⟨{true, false}, by simp [true_ne_false]⟩, classical.cases (by simp) (by simp)⟩
 
 @[simp] lemma fintype.card_Prop : fintype.card Prop = 2 := rfl
 

--- a/src/data/list/nodup.lean
+++ b/src/data/list/nodup.lean
@@ -42,7 +42,7 @@ lemma rel_nodup {r : α → β → Prop} (hr : relator.bi_unique r) : (forall₂
 
 protected lemma nodup.cons (ha : a ∉ l) (hl : nodup l) : nodup (a :: l) := nodup_cons.2 ⟨ha, hl⟩
 
-lemma nodup_singleton (a : α) : nodup [a] := pairwise_singleton _ _
+@[simp] lemma nodup_singleton (a : α) : nodup [a] := pairwise_singleton _ _
 
 lemma nodup.of_cons (h : nodup (a :: l)) : nodup l := (nodup_cons.1 h).2
 lemma nodup.not_mem (h : (a :: l).nodup) : a ∉ l := (nodup_cons.1 h).1

--- a/src/data/list/nodup.lean
+++ b/src/data/list/nodup.lean
@@ -42,7 +42,7 @@ lemma rel_nodup {r : α → β → Prop} (hr : relator.bi_unique r) : (forall₂
 
 protected lemma nodup.cons (ha : a ∉ l) (hl : nodup l) : nodup (a :: l) := nodup_cons.2 ⟨ha, hl⟩
 
-@[simp] lemma nodup_singleton (a : α) : nodup [a] := pairwise_singleton _ _
+lemma nodup_singleton (a : α) : nodup [a] := pairwise_singleton _ _
 
 lemma nodup.of_cons (h : nodup (a :: l)) : nodup l := (nodup_cons.1 h).2
 lemma nodup.not_mem (h : (a :: l).nodup) : a ∉ l := (nodup_cons.1 h).1

--- a/src/data/multiset/basic.lean
+++ b/src/data/multiset/basic.lean
@@ -365,7 +365,7 @@ by simp only [←cons_zero, mem_cons, iff_self, or_false, not_mem_zero]
 theorem mem_singleton_self (a : α) : a ∈ ({a} : multiset α) :=
 by { rw ←cons_zero, exact mem_cons_self _ _ }
 
-theorem singleton_inj {a b : α} : ({a} : multiset α) = {b} ↔ a = b :=
+@[simp] theorem singleton_inj {a b : α} : ({a} : multiset α) = {b} ↔ a = b :=
 by { simp_rw [←cons_zero], exact cons_inj_left _ }
 
 @[simp] theorem singleton_ne_zero (a : α) : ({a} : multiset α) ≠ 0 :=
@@ -374,6 +374,9 @@ ne_of_gt (lt_cons_self _ _)
 @[simp] theorem singleton_le {a : α} {s : multiset α} : {a} ≤ s ↔ a ∈ s :=
 ⟨λ h, mem_of_le h (mem_singleton_self _),
  λ h, let ⟨t, e⟩ := exists_cons_of_mem h in e.symm ▸ cons_le_cons _ (zero_le _)⟩
+
+@[simp] lemma singleton_eq_cons_iff {a b : α} (m : multiset α) : {a} = b ::ₘ m ↔ a = b ∧ m = 0 :=
+by { rw [←cons_zero, cons_eq_cons], simp [eq_comm] }
 
 theorem pair_comm (x y : α) : ({x, y} : multiset α) = {y, x} := cons_swap x y 0
 

--- a/src/data/multiset/basic.lean
+++ b/src/data/multiset/basic.lean
@@ -53,7 +53,7 @@ instance : has_zero (multiset α)   := ⟨multiset.zero⟩
 instance : has_emptyc (multiset α) := ⟨0⟩
 instance inhabited_multiset : inhabited (multiset α)  := ⟨0⟩
 
-@[simp] theorem coe_nil_eq_zero : (@nil α : multiset α) = 0 := rfl
+@[simp] theorem coe_nil : (@nil α : multiset α) = 0 := rfl
 @[simp] theorem empty_eq_zero : (∅ : multiset α) = 0 := rfl
 
 @[simp] theorem coe_eq_zero (l : list α) : (l : multiset α) = 0 ↔ l = [] :=
@@ -359,16 +359,16 @@ instance : has_singleton α (multiset α) := ⟨λ a, a ::ₘ 0⟩
 
 instance : is_lawful_singleton α (multiset α) := ⟨λ a, rfl⟩
 
-theorem singleton_eq_cons (a : α) : singleton a = a ::ₘ 0 := rfl
+@[simp] theorem cons_zero (a : α) : a ::ₘ 0 = {a} := rfl
 
 @[simp] theorem mem_singleton {a b : α} : b ∈ ({a} : multiset α) ↔ b = a :=
-by simp only [singleton_eq_cons, mem_cons, iff_self, or_false, not_mem_zero]
+by simp only [←cons_zero, mem_cons, iff_self, or_false, not_mem_zero]
 
 theorem mem_singleton_self (a : α) : a ∈ ({a} : multiset α) :=
-by { rw singleton_eq_cons, exact mem_cons_self _ _ }
+by { rw ←cons_zero, exact mem_cons_self _ _ }
 
 theorem singleton_inj {a b : α} : ({a} : multiset α) = {b} ↔ a = b :=
-by { simp_rw [singleton_eq_cons], exact cons_inj_left _ }
+by { simp_rw [←cons_zero], exact cons_inj_left _ }
 
 @[simp] theorem singleton_ne_zero (a : α) : ({a} : multiset α) ≠ 0 :=
 ne_of_gt (lt_cons_self _ _)
@@ -392,7 +392,7 @@ instance : has_add (multiset α) := ⟨multiset.add⟩
 
 @[simp] theorem coe_add (s t : list α) : (s + t : multiset α) = (s ++ t : list α) := rfl
 
-theorem singleton_add (a : α) (s : multiset α) : {a} + s = a ::ₘ s := rfl
+@[simp] theorem singleton_add (a : α) (s : multiset α) : {a} + s = a ::ₘ s := rfl
 
 private theorem add_le_add_iff_left' {s t u : multiset α} : s + t ≤ s + u ↔ t ≤ u :=
 quotient.induction_on₃ s t u $ λ l₁ l₂ l₃, subperm_append_left _
@@ -494,7 +494,7 @@ by rw [card.map_nsmul s n, nat.nsmul_eq_mul]
 quot.induction_on s $ λ l, rfl
 
 @[simp] theorem card_singleton (a : α) : card ({a} : multiset α) = 1 :=
-by simp only [singleton_eq_cons, card_zero, eq_self_iff_true, zero_add, card_cons]
+by simp only [←cons_zero, card_zero, eq_self_iff_true, zero_add, card_cons]
 
 lemma card_pair (a b : α) : ({a, b} : multiset α).card = 2 :=
 by rw [insert_eq_cons, card_cons, card_singleton]
@@ -602,7 +602,7 @@ def repeat (a : α) (n : ℕ) : multiset α := repeat a n
 @[simp] lemma repeat_succ (a : α) (n) : repeat a (n+1) = a ::ₘ repeat a n := by simp [repeat]
 
 @[simp] lemma repeat_one (a : α) : repeat a 1 = {a} :=
-by simp only [repeat_succ, singleton_eq_cons, eq_self_iff_true, repeat_zero, cons_inj_right]
+by simp only [repeat_succ, ←cons_zero, eq_self_iff_true, repeat_zero, cons_inj_right]
 
 @[simp] lemma card_repeat : ∀ (a : α) n, card (repeat a n) = n := length_repeat
 
@@ -1687,10 +1687,10 @@ theorem count_cons (a b : α) (s : multiset α) :
 countp_cons _ _ _
 
 @[simp] theorem count_singleton_self (a : α) : count a ({a} : multiset α) = 1 :=
-by simp only [count_cons_self, singleton_eq_cons, eq_self_iff_true, count_zero]
+by simp only [count_cons_self, ←cons_zero, eq_self_iff_true, count_zero]
 
 theorem count_singleton (a b : α) : count a ({b} : multiset α) = if a = b then 1 else 0 :=
-by simp only [count_cons, singleton_eq_cons, count_zero, zero_add]
+by simp only [count_cons, ←cons_zero, count_zero, zero_add]
 
 @[simp] theorem count_add (a : α) : ∀ s t, count a (s + t) = count a s + count a t :=
 countp_add _

--- a/src/data/multiset/basic.lean
+++ b/src/data/multiset/basic.lean
@@ -353,11 +353,14 @@ end
 end
 
 /-! ### Singleton -/
+
 instance : has_singleton α (multiset α) := ⟨λ a, a ::ₘ 0⟩
 
 instance : is_lawful_singleton α (multiset α) := ⟨λ a, rfl⟩
 
 @[simp] theorem cons_zero (a : α) : a ::ₘ 0 = {a} := rfl
+
+@[simp] theorem coe_singleton (a : α) : ([a] : multiset α) = {a} := rfl
 
 @[simp] theorem mem_singleton {a b : α} : b ∈ ({a} : multiset α) ↔ b = a :=
 by simp only [←cons_zero, mem_cons, iff_self, or_false, not_mem_zero]

--- a/src/data/multiset/basic.lean
+++ b/src/data/multiset/basic.lean
@@ -232,7 +232,7 @@ by simp only [←cons_zero, mem_cons, iff_self, or_false, not_mem_zero]
 theorem mem_singleton_self (a : α) : a ∈ ({a} : multiset α) :=
 by { rw ←cons_zero, exact mem_cons_self _ _ }
 
-theorem singleton_inj {a b : α} : ({a} : multiset α) = {b} ↔ a = b :=
+@[simp] theorem singleton_inj {a b : α} : ({a} : multiset α) = {b} ↔ a = b :=
 by { simp_rw [←cons_zero], exact cons_inj_left _ }
 
 @[simp] lemma singleton_eq_cons_iff {a b : α} (m : multiset α) : {a} = b ::ₘ m ↔ a = b ∧ m = 0 :=

--- a/src/data/multiset/basic.lean
+++ b/src/data/multiset/basic.lean
@@ -77,8 +77,6 @@ instance : has_insert α (multiset α) := ⟨cons⟩
 @[simp] theorem cons_coe (a : α) (l : list α) :
   (a ::ₘ l : multiset α) = (a::l : list α) := rfl
 
-theorem singleton_coe (a : α) : (a ::ₘ 0 : multiset α) = ([a] : list α) := rfl
-
 @[simp] theorem cons_inj_left {a b : α} (s : multiset α) :
   a ::ₘ s = b ::ₘ s ↔ a = b :=
 ⟨quot.induction_on s $ λ l e,

--- a/src/data/multiset/basic.lean
+++ b/src/data/multiset/basic.lean
@@ -1690,7 +1690,7 @@ theorem count_cons (a b : α) (s : multiset α) :
   count a (b ::ₘ s) = count a s + (if a = b then 1 else 0) :=
 countp_cons _ _ _
 
-@[simp] theorem count_singleton_self (a : α) : count a ({a} : multiset α) = 1 :=
+theorem count_singleton_self (a : α) : count a ({a} : multiset α) = 1 :=
 count_eq_one_of_mem (nodup_singleton a) $ mem_singleton_self a
 
 theorem count_singleton (a b : α) : count a ({b} : multiset α) = if a = b then 1 else 0 :=

--- a/src/data/multiset/basic.lean
+++ b/src/data/multiset/basic.lean
@@ -1691,7 +1691,7 @@ theorem count_cons (a b : α) (s : multiset α) :
 countp_cons _ _ _
 
 @[simp] theorem count_singleton_self (a : α) : count a ({a} : multiset α) = 1 :=
-by simp only [count_cons_self, ←cons_zero, eq_self_iff_true, count_zero]
+count_eq_one_of_mem (nodup_singleton a) $ mem_singleton_self a
 
 theorem count_singleton (a b : α) : count a ({b} : multiset α) = if a = b then 1 else 0 :=
 by simp only [count_cons, ←cons_zero, count_zero, zero_add]

--- a/src/data/multiset/nodup.lean
+++ b/src/data/multiset/nodup.lean
@@ -32,7 +32,7 @@ quot.induction_on s $ λ l, nodup_cons
 
 lemma nodup.cons (m : a ∉ s) (n : nodup s) : nodup (a ::ₘ s) := nodup_cons.2 ⟨m, n⟩
 
-theorem nodup_singleton : ∀ a : α, nodup ({a} : multiset α) := nodup_singleton
+@[simp] theorem nodup_singleton : ∀ a : α, nodup ({a} : multiset α) := nodup_singleton
 
 lemma nodup.of_cons (h : nodup (a ::ₘ s)) : nodup s := (nodup_cons.1 h).2
 

--- a/src/data/polynomial/ring_division.lean
+++ b/src/data/polynomial/ring_division.lean
@@ -427,7 +427,7 @@ begin
   rw [count_roots, root_multiplicity_X_sub_C],
   split_ifs with h,
   { rw [h, count_singleton_self] },
-  { rw [singleton_eq_cons, count_cons_of_ne h, count_zero] }
+  { rw [←cons_zero, count_cons_of_ne h, count_zero] }
 end
 
 @[simp] lemma roots_C (x : R) : (C x).roots = 0 :=

--- a/src/data/sym/sym2.lean
+++ b/src/data/sym/sym2.lean
@@ -376,7 +376,7 @@ private def from_vector : vector α 2 → α × α
 
 private lemma perm_card_two_iff {a₁ b₁ a₂ b₂ : α} :
   [a₁, b₁].perm [a₂, b₂] ↔ a₁ = a₂ ∧ b₁ = b₂ ∨ a₁ = b₂ ∧ b₁ = a₂ :=
-{ mp  := by { simp [← multiset.coe_eq_coe, ← multiset.cons_coe, multiset.cons_eq_cons]; tidy },
+{ mp  := by { simp [← multiset.coe_eq_coe, ← multiset.cons_coe, multiset.cons_eq_cons], tidy },
   mpr := by { intro h, cases h; rw [h.1, h.2], apply list.perm.swap', refl } }
 
 /--

--- a/src/group_theory/perm/cycle/concrete.lean
+++ b/src/group_theory/perm/cycle/concrete.lean
@@ -105,7 +105,7 @@ begin
   rw cycle_type_eq [l.attach.form_perm],
   { simp only [map, function.comp_app],
     rw [support_form_perm_of_nodup _ hl, card_to_finset, dedup_eq_self.mpr hl],
-    { simpa },
+    { simp },
     { intros x h,
       simpa [h, nat.succ_le_succ_iff] using hn } },
   { simp },

--- a/src/group_theory/perm/cycle/type.lean
+++ b/src/group_theory/perm/cycle/type.lean
@@ -179,8 +179,8 @@ cycle_induction_on
 lemma lcm_cycle_type (σ : perm α) : σ.cycle_type.lcm = order_of σ :=
 cycle_induction_on (λ τ : perm α, τ.cycle_type.lcm = order_of τ) σ
   (by rw [cycle_type_one, lcm_zero, order_of_one])
-  (λ σ hσ, by rw [hσ.cycle_type, ←singleton_coe, cons_zero, lcm_singleton,
-    order_of_is_cycle hσ, normalize_eq])
+  (λ σ hσ, by rw [hσ.cycle_type, coe_singleton, lcm_singleton, order_of_is_cycle hσ,
+    normalize_eq])
   (λ σ τ hστ hc hσ hτ, by rw [hστ.cycle_type, lcm_add, lcm_eq_nat_lcm, hστ.order_of, hσ, hτ])
 
 lemma dvd_of_mem_cycle_type {σ : perm α} {n : ℕ} (h : n ∈ σ.cycle_type) : n ∣ order_of σ :=
@@ -331,8 +331,7 @@ lemma cycle_type_of_card_le_mem_cycle_type_add_two {n : ℕ} {g : perm α}
 begin
   obtain ⟨c, g', rfl, hd, hc, rfl⟩ := mem_cycle_type_iff.1 hng,
   by_cases g'1 : g' = 1,
-  { rw [hd.cycle_type, hc.cycle_type, ←multiset.cons_zero, multiset.singleton_coe,
-      g'1, cycle_type_one, add_zero] },
+  { rw [hd.cycle_type, hc.cycle_type, coe_singleton, g'1, cycle_type_one, add_zero] },
   contrapose! hn2,
   apply le_trans _ (c * g').support.card_le_univ,
   rw [hd.card_support_mul],

--- a/src/group_theory/perm/cycle/type.lean
+++ b/src/group_theory/perm/cycle/type.lean
@@ -179,7 +179,7 @@ cycle_induction_on
 lemma lcm_cycle_type (σ : perm α) : σ.cycle_type.lcm = order_of σ :=
 cycle_induction_on (λ τ : perm α, τ.cycle_type.lcm = order_of τ) σ
   (by rw [cycle_type_one, lcm_zero, order_of_one])
-  (λ σ hσ, by rw [hσ.cycle_type, ←singleton_coe, ←singleton_eq_cons, lcm_singleton,
+  (λ σ hσ, by rw [hσ.cycle_type, ←singleton_coe, cons_zero, lcm_singleton,
     order_of_is_cycle hσ, normalize_eq])
   (λ σ τ hστ hc hσ hτ, by rw [hστ.cycle_type, lcm_add, lcm_eq_nat_lcm, hστ.order_of, hσ, hτ])
 
@@ -331,7 +331,7 @@ lemma cycle_type_of_card_le_mem_cycle_type_add_two {n : ℕ} {g : perm α}
 begin
   obtain ⟨c, g', rfl, hd, hc, rfl⟩ := mem_cycle_type_iff.1 hng,
   by_cases g'1 : g' = 1,
-  { rw [hd.cycle_type, hc.cycle_type, multiset.singleton_eq_cons, multiset.singleton_coe,
+  { rw [hd.cycle_type, hc.cycle_type, ←multiset.cons_zero, multiset.singleton_coe,
       g'1, cycle_type_one, add_zero] },
   contrapose! hn2,
   apply le_trans _ (c * g').support.card_le_univ,
@@ -581,8 +581,8 @@ begin
     exact (ne_of_lt zero_lt_three h).elim },
   obtain ⟨n, hn⟩ := exists_mem_of_ne_zero h0,
   by_cases h1 : σ.cycle_type.erase n = 0,
-  { rw [←sum_cycle_type, ←cons_erase hn, h1, ←singleton_eq_cons, multiset.sum_singleton] at h,
-    rw [is_three_cycle, ←cons_erase hn, h1, h, singleton_eq_cons] },
+  { rw [←sum_cycle_type, ←cons_erase hn, h1, cons_zero, multiset.sum_singleton] at h,
+    rw [is_three_cycle, ←cons_erase hn, h1, h, ←cons_zero] },
   obtain ⟨m, hm⟩ := exists_mem_of_ne_zero h1,
   rw [←sum_cycle_type, ←cons_erase hn, ←cons_erase hm, multiset.sum_cons, multiset.sum_cons] at h,
   -- TODO: linarith [...] should solve this directly

--- a/src/ring_theory/ideal/operations.lean
+++ b/src/ring_theory/ideal/operations.lean
@@ -718,7 +718,7 @@ begin
   obtain ⟨t, rfl⟩ : ∃ t, s = b ::ₘ t,
   from ⟨s.erase b, (multiset.cons_erase hb).symm⟩,
   refine t.induction_on _ _,
-  { simp only [exists_prop, ←multiset.singleton_eq_cons, multiset.prod_singleton,
+  { simp only [exists_prop, multiset.cons_zero, multiset.prod_singleton,
       multiset.mem_singleton, exists_eq_left, imp_self] },
   intros a s ih h,
   rw [multiset.cons_swap, multiset.prod_cons, hp.mul_le] at h,


### PR DESCRIPTION
This PR does the following:
- rename `coe_nil_eq_zero` to `coe_nil`.
- rename `singleton_eq_cons` to `cons_zero`, flip direction, mark `simp` (we prefer `{a}` over `a ::ₘ 0`).
- add lemmas `coe_singleton` and `singleton_eq_cons_iff`.
- ditch `singleton_coe` in favor of `cons_zero` and `coe_singleton`.
- mark `singleton_add`, `singleton_inj`, `nodup_singleton` as `simp`.
- unmark `count_singleton_self` as `simp`, since it can now be solved automatically via `count_eq_one_of_mem`.
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

- [x] depends on: #15882 

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
