### PR TITLE
[Merged by Bors] - chore(order/basic): move `Prop.partial_order` to `order/basic`

### DIFF
--- a/src/order/basic.lean
+++ b/src/order/basic.lean
@@ -770,6 +770,22 @@ instance : densely_ordered punit := ⟨λ _ _, false.elim⟩
 
 end punit
 
+section prop
+
+instance Prop.has_le : has_le Prop := ⟨λ a b, a → b⟩
+
+@[simp] lemma le_Prop_eq : ((≤) : Prop → Prop → Prop) = (→) := rfl
+
+lemma subrelation_iff_le {r s : α → α → Prop} : subrelation r s ↔ r ≤ s := iff.rfl
+
+instance Prop.partial_order : partial_order Prop :=
+{ le_refl      := λ _, id,
+  le_trans     := λ a b c f g, g ∘ f,
+  le_antisymm  := λ a b Hab Hba, propext ⟨Hab, Hba⟩,
+  ..Prop.has_le }
+
+end prop
+
 variables {s : β → β → Prop} {t : γ → γ → Prop}
 
 /-! ### Linear order from a total partial order -/

--- a/src/order/basic.lean
+++ b/src/order/basic.lean
@@ -772,6 +772,7 @@ end punit
 
 section prop
 
+/-- Propositions form a complete boolean algebra, where the `≤` relation is given by implication. -/
 instance Prop.has_le : has_le Prop := ⟨(→)⟩
 
 @[simp] lemma le_Prop_eq : ((≤) : Prop → Prop → Prop) = (→) := rfl

--- a/src/order/basic.lean
+++ b/src/order/basic.lean
@@ -772,7 +772,7 @@ end punit
 
 section prop
 
-instance Prop.has_le : has_le Prop := ⟨λ a b, a → b⟩
+instance Prop.has_le : has_le Prop := ⟨(→)⟩
 
 @[simp] lemma le_Prop_eq : ((≤) : Prop → Prop → Prop) = (→) := rfl
 

--- a/src/order/bounded_order.lean
+++ b/src/order/bounded_order.lean
@@ -344,13 +344,6 @@ begin
   { exact h'.symm }
 end
 
-/-- Propositions form a bounded order. -/
-instance Prop.bounded_order : bounded_order Prop :=
-{ top          := true,
-  le_top       := λ a Ha, true.intro,
-  bot          := false,
-  bot_le       := @false.elim }
-
 /-- Propositions form a distributive lattice. -/
 instance Prop.distrib_lattice : distrib_lattice Prop :=
 { sup          := or,
@@ -366,9 +359,15 @@ instance Prop.distrib_lattice : distrib_lattice Prop :=
     λ Ha, ⟨H.1.resolve_left Ha, H.2.resolve_left Ha⟩,
   ..Prop.partial_order }
 
+/-- Propositions form a bounded order. -/
+instance Prop.bounded_order : bounded_order Prop :=
+{ top          := true,
+  le_top       := λ a Ha, true.intro,
+  bot          := false,
+  bot_le       := @false.elim }
+
 instance Prop.le_is_total : is_total Prop (≤) :=
 ⟨λ p q, by { change (p → q) ∨ (q → p), tauto! }⟩
-
 
 @[simp] lemma sup_Prop_eq : (⊔) = (∨) := rfl
 @[simp] lemma inf_Prop_eq : (⊓) = (∧) := rfl

--- a/src/order/bounded_order.lean
+++ b/src/order/bounded_order.lean
@@ -344,14 +344,16 @@ begin
   { exact h'.symm }
 end
 
+/-- Propositions form a bounded order. -/
+instance Prop.bounded_order : bounded_order Prop :=
+{ top          := true,
+  le_top       := λ a Ha, true.intro,
+  bot          := false,
+  bot_le       := @false.elim }
+
 /-- Propositions form a distributive lattice. -/
 instance Prop.distrib_lattice : distrib_lattice Prop :=
-{ le           := λ a b, a → b,
-  le_refl      := λ _, id,
-  le_trans     := λ a b c f g, g ∘ f,
-  le_antisymm  := λ a b Hab Hba, propext ⟨Hab, Hba⟩,
-
-  sup          := or,
+{ sup          := or,
   le_sup_left  := @or.inl,
   le_sup_right := @or.inr,
   sup_le       := λ a b c, or.rec,
@@ -361,24 +363,13 @@ instance Prop.distrib_lattice : distrib_lattice Prop :=
   inf_le_right := @and.right,
   le_inf       := λ a b c Hab Hac Ha, and.intro (Hab Ha) (Hac Ha),
   le_sup_inf   := λ a b c H, or_iff_not_imp_left.2 $
-    λ Ha, ⟨H.1.resolve_left Ha, H.2.resolve_left Ha⟩ }
-
-/-- Propositions form a bounded order. -/
-instance Prop.bounded_order : bounded_order Prop :=
-{ top          := true,
-  le_top       := λ a Ha, true.intro,
-  bot          := false,
-  bot_le       := @false.elim }
+    λ Ha, ⟨H.1.resolve_left Ha, H.2.resolve_left Ha⟩,
+  ..Prop.partial_order }
 
 instance Prop.le_is_total : is_total Prop (≤) :=
 ⟨λ p q, by { change (p → q) ∨ (q → p), tauto! }⟩
 
-noncomputable instance Prop.linear_order : linear_order Prop :=
-by classical; exact lattice.to_linear_order Prop
 
-lemma subrelation_iff_le {r s : α → α → Prop} : subrelation r s ↔ r ≤ s := iff.rfl
-
-@[simp] lemma le_Prop_eq : ((≤) : Prop → Prop → Prop) = (→) := rfl
 @[simp] lemma sup_Prop_eq : (⊔) = (∨) := rfl
 @[simp] lemma inf_Prop_eq : (⊓) = (∧) := rfl
 

--- a/src/order/bounded_order.lean
+++ b/src/order/bounded_order.lean
@@ -369,6 +369,9 @@ instance Prop.bounded_order : bounded_order Prop :=
 instance Prop.le_is_total : is_total Prop (≤) :=
 ⟨λ p q, by { change (p → q) ∨ (q → p), tauto! }⟩
 
+noncomputable instance Prop.linear_order : linear_order Prop :=
+by classical; exact lattice.to_linear_order Prop
+
 @[simp] lemma sup_Prop_eq : (⊔) = (∨) := rfl
 @[simp] lemma inf_Prop_eq : (⊓) = (∧) := rfl
 


### PR DESCRIPTION
This ensures, among other things, that `r ≤ s` is almost always available as notation for subrelations.

We don't move `Prop.linear_order` since doing so means we need to manually prove `or = max_default` and `and = min_default`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
