### PR TITLE
[Merged by Bors] - feat(data/sym/sym2): `sym2.lift₂`

### DIFF
--- a/src/data/sym/sym2.lean
+++ b/src/data/sym/sym2.lean
@@ -98,7 +98,7 @@ protected lemma induction_on {f : sym2 α → Prop} (i : sym2 α) (hf : ∀ x y,
 i.ind hf
 
 @[elab_as_eliminator]
-protected lemma induction_on₂ {f : sym2 α → sym2 α → Prop} (i j : sym2 α)
+protected lemma induction_on₂ {f : sym2 α → sym2 β → Prop} (i : sym2 α) (j : sym2 β)
   (hf : ∀ x₁ x₂ y₁ y₂, f ⟦(x₁, x₂)⟧ ⟦(y₁, y₂)⟧) : f i j :=
 quotient.induction_on₂ i j $ by { rintros ⟨a₁, a₂⟩ ⟨b₁, b₂⟩, exact hf _ _ _ _ }
 
@@ -148,16 +148,16 @@ lemma coe_lift_symm_apply (F : sym2 α → β) (a₁ a₂ : α) :
   (lift.symm F : α → α → β) a₁ a₂ = F ⟦(a₁, a₂)⟧ := rfl
 
 /-- A two-argument version of `sym2.lift`. -/
-def lift₂ : {f : α → α → α → α → β // ∀ a₁ a₂ a₃ a₄,
-  f a₁ a₂ a₃ a₄ = f a₂ a₁ a₃ a₄ ∧ f a₁ a₂ a₃ a₄ = f a₁ a₂ a₄ a₃} ≃ (sym2 α → sym2 α → β) :=
-{ to_fun := λ f, quotient.lift₂ (λ a b : α × α, f.1 a.1 a.2 b.1 b.2) begin
+def lift₂ : {f : α → α → β → β → γ // ∀ a₁ a₂ b₁ b₂,
+  f a₁ a₂ b₁ b₂ = f a₂ a₁ b₁ b₂ ∧ f a₁ a₂ b₁ b₂ = f a₁ a₂ b₂ b₁} ≃ (sym2 α → sym2 β → γ) :=
+{ to_fun := λ f, quotient.lift₂ (λ (a : α × α) (b : β × β), f.1 a.1 a.2 b.1 b.2) begin
     rintro _ _ _ _ ⟨⟩ ⟨⟩,
     exacts [rfl, (f.2 _ _ _ _).2, (f.2 _ _ _ _).1, (f.2 _ _ _ _).1.trans (f.2 _ _ _ _).2]
   end,
   inv_fun := λ F, ⟨λ x₁ x₂ y₁ y₂, F ⟦(x₁, x₂)⟧ ⟦(y₁, y₂)⟧, λ a₁ a₂ b₁ b₂,
     by { split, exacts [congr_arg2 F eq_swap rfl, congr_arg2 F rfl eq_swap] }⟩,
   left_inv := λ f, subtype.ext rfl,
-  right_inv := λ F, funext₂' $ λ x y, sym2.induction_on₂ x y $ λ _ _ _ _, rfl }
+  right_inv := λ F, funext₂ $ λ x y, sym2.induction_on₂ x y $ λ _ _ _ _, rfl }
 
 @[simp]
 lemma lift₂_mk (f : {f : α → α → α → α → β // ∀ a₁ a₂ a₃ a₄,

--- a/src/data/sym/sym2.lean
+++ b/src/data/sym/sym2.lean
@@ -160,13 +160,13 @@ def lift₂ : {f : α → α → β → β → γ // ∀ a₁ a₂ b₁ b₂,
   right_inv := λ F, funext₂ $ λ x y, sym2.induction_on₂ x y $ λ _ _ _ _, rfl }
 
 @[simp]
-lemma lift₂_mk (f : {f : α → α → α → α → β // ∀ a₁ a₂ a₃ a₄,
-  f a₁ a₂ a₃ a₄ = f a₂ a₁ a₃ a₄ ∧ f a₁ a₂ a₃ a₄ = f a₁ a₂ a₄ a₃}) (a₁ a₂ a₃ a₄ : α) :
-  lift₂ f ⟦(a₁, a₂)⟧ ⟦(a₃, a₄)⟧ = (f : α → α → α → α → β) a₁ a₂ a₃ a₄ := rfl
+lemma lift₂_mk (f : {f : α → α → β → β → γ // ∀ a₁ a₂ b₁ b₂,
+  f a₁ a₂ b₁ b₂ = f a₂ a₁ b₁ b₂ ∧ f a₁ a₂ b₁ b₂ = f a₁ a₂ b₂ b₁}) (a₁ a₂ : α) (b₁ b₂ : β) :
+  lift₂ f ⟦(a₁, a₂)⟧ ⟦(b₁, b₂)⟧ = (f : α → α → β → β → γ) a₁ a₂ b₁ b₂ := rfl
 
 @[simp]
-lemma coe_lift₂_symm_apply (F : sym2 α → sym2 α → β) (a₁ a₂ a₃ a₄ : α) :
-  (lift₂.symm F : α → α → α → α → β) a₁ a₂ a₃ a₄ = F ⟦(a₁, a₂)⟧ ⟦(a₃, a₄)⟧ := rfl
+lemma coe_lift₂_symm_apply (F : sym2 α → sym2 β → γ) (a₁ a₂ : α) (b₁ b₂ : β) :
+  (lift₂.symm F : α → α → β → β → γ) a₁ a₂ b₁ b₂ = F ⟦(a₁, a₂)⟧ ⟦(b₁, b₂)⟧ := rfl
 
 /--
 The functor `sym2` is functorial, and this function constructs the induced maps.

--- a/src/data/sym/sym2.lean
+++ b/src/data/sym/sym2.lean
@@ -99,7 +99,7 @@ i.ind hf
 
 @[elab_as_eliminator]
 protected lemma induction_on₂ {f : sym2 α → sym2 β → Prop} (i : sym2 α) (j : sym2 β)
-  (hf : ∀ x₁ x₂ y₁ y₂, f ⟦(x₁, x₂)⟧ ⟦(y₁, y₂)⟧) : f i j :=
+  (hf : ∀ a₁ a₂ b₁ b₂, f ⟦(a₁, a₂)⟧ ⟦(b₁, b₂)⟧) : f i j :=
 quotient.induction_on₂ i j $ by { rintros ⟨a₁, a₂⟩ ⟨b₁, b₂⟩, exact hf _ _ _ _ }
 
 protected lemma «exists» {α : Sort*} {f : sym2 α → Prop} :
@@ -154,10 +154,10 @@ def lift₂ : {f : α → α → β → β → γ // ∀ a₁ a₂ b₁ b₂,
     rintro _ _ _ _ ⟨⟩ ⟨⟩,
     exacts [rfl, (f.2 _ _ _ _).2, (f.2 _ _ _ _).1, (f.2 _ _ _ _).1.trans (f.2 _ _ _ _).2]
   end,
-  inv_fun := λ F, ⟨λ x₁ x₂ y₁ y₂, F ⟦(x₁, x₂)⟧ ⟦(y₁, y₂)⟧, λ a₁ a₂ b₁ b₂,
+  inv_fun := λ F, ⟨λ a₁ a₂ b₁ b₂, F ⟦(a₁, a₂)⟧ ⟦(b₁, b₂)⟧, λ a₁ a₂ b₁ b₂,
     by { split, exacts [congr_arg2 F eq_swap rfl, congr_arg2 F rfl eq_swap] }⟩,
   left_inv := λ f, subtype.ext rfl,
-  right_inv := λ F, funext₂ $ λ x y, sym2.induction_on₂ x y $ λ _ _ _ _, rfl }
+  right_inv := λ F, funext₂ $ λ a b, sym2.induction_on₂ a b $ λ _ _ _ _, rfl }
 
 @[simp]
 lemma lift₂_mk (f : {f : α → α → β → β → γ // ∀ a₁ a₂ b₁ b₂,

--- a/src/data/sym/sym2.lean
+++ b/src/data/sym/sym2.lean
@@ -149,7 +149,7 @@ lemma coe_lift_symm_apply (F : sym2 α → β) (a₁ a₂ : α) :
 
 /-- A two-argument version of `sym2.lift`. -/
 def lift₂ : {f : α → α → α → α → β // ∀ a₁ a₂ a₃ a₄,
-  (f a₁ a₂ a₃ a₄ = f a₂ a₁ a₃ a₄ ∧ f a₁ a₂ a₃ a₄ = f a₁ a₂ a₄ a₃)} ≃ (sym2 α → sym2 α → β) :=
+  f a₁ a₂ a₃ a₄ = f a₂ a₁ a₃ a₄ ∧ f a₁ a₂ a₃ a₄ = f a₁ a₂ a₄ a₃} ≃ (sym2 α → sym2 α → β) :=
 { to_fun := λ f, quotient.lift₂ (λ a b : α × α, f.1 a.1 a.2 b.1 b.2) begin
     rintro _ _ _ _ ⟨⟩ ⟨⟩,
     exacts [rfl, (f.2 _ _ _ _).2, (f.2 _ _ _ _).1, (f.2 _ _ _ _).1.trans (f.2 _ _ _ _).2]
@@ -161,7 +161,7 @@ def lift₂ : {f : α → α → α → α → β // ∀ a₁ a₂ a₃ a₄,
 
 @[simp]
 lemma lift₂_mk (f : {f : α → α → α → α → β // ∀ a₁ a₂ a₃ a₄,
-  (f a₁ a₂ a₃ a₄ = f a₂ a₁ a₃ a₄ ∧ f a₁ a₂ a₃ a₄ = f a₁ a₂ a₄ a₃)}) (a₁ a₂ a₃ a₄ : α) :
+  f a₁ a₂ a₃ a₄ = f a₂ a₁ a₃ a₄ ∧ f a₁ a₂ a₃ a₄ = f a₁ a₂ a₄ a₃}) (a₁ a₂ a₃ a₄ : α) :
   lift₂ f ⟦(a₁, a₂)⟧ ⟦(a₃, a₄)⟧ = (f : α → α → α → α → β) a₁ a₂ a₃ a₄ := rfl
 
 @[simp]

--- a/src/data/sym/sym2.lean
+++ b/src/data/sym/sym2.lean
@@ -94,8 +94,13 @@ protected lemma ind {f : sym2 α → Prop} (h : ∀ x y, f ⟦(x, y)⟧) : ∀ i
 quotient.ind $ prod.rec $ by exact h
 
 @[elab_as_eliminator]
-protected lemma induction_on {f : sym2 α → Prop} (i : sym2 α) (hf : ∀ x y, f ⟦(x,y)⟧) : f i :=
+protected lemma induction_on {f : sym2 α → Prop} (i : sym2 α) (hf : ∀ x y, f ⟦(x, y)⟧) : f i :=
 i.ind hf
+
+@[elab_as_eliminator]
+protected lemma induction_on₂ {f : sym2 α → sym2 α → Prop} (i j : sym2 α)
+  (hf : ∀ x₁ x₂ y₁ y₂, f ⟦(x₁, x₂)⟧ ⟦(y₁, y₂)⟧) : f i j :=
+quotient.induction_on₂ i j $ by { rintros ⟨a₁, a₂⟩ ⟨b₁, b₂⟩, exact hf _ _ _ _ }
 
 protected lemma «exists» {α : Sort*} {f : sym2 α → Prop} :
   (∃ (x : sym2 α), f x) ↔ ∃ x y, f ⟦(x, y)⟧ :=
@@ -141,6 +146,21 @@ lemma lift_mk (f : {f : α → α → β // ∀ a₁ a₂, f a₁ a₂ = f a₂ 
 @[simp]
 lemma coe_lift_symm_apply (F : sym2 α → β) (a₁ a₂ : α) :
   (lift.symm F : α → α → β) a₁ a₂ = F ⟦(a₁, a₂)⟧ := rfl
+
+/-- A two-argument version of `sym2.lift`. -/
+def lift₂ : {f : α → α → α → α → β // ∀ a₁ a₂ a₃ a₄,
+  (f a₁ a₂ a₃ a₄ = f a₂ a₁ a₃ a₄ ∧ f a₁ a₂ a₃ a₄ = f a₁ a₂ a₄ a₃)} ≃ (sym2 α → sym2 α → β) :=
+{ to_fun := λ f, quotient.lift₂ (λ a b : α × α, f.1 a.1 a.2 b.1 b.2) begin
+    rintro _ _ _ _ ⟨⟩ ⟨⟩,
+    exacts [rfl, (f.2 _ _ _ _).2, (f.2 _ _ _ _).1, (f.2 _ _ _ _).1.trans (f.2 _ _ _ _).2]
+  end,
+  inv_fun := λ F, ⟨λ x₁ x₂ y₁ y₂, F ⟦(x₁, x₂)⟧ ⟦(y₁, y₂)⟧, λ a₁ a₂ b₁ b₂,
+    by { split, exacts [congr_arg2 F eq_swap rfl, congr_arg2 F rfl eq_swap] }⟩,
+  left_inv := λ f, subtype.ext rfl,
+  right_inv := λ F, begin
+    dsimp,
+    apply funext₂' (λ x y, _),
+  end }
 
 /--
 The functor `sym2` is functorial, and this function constructs the induced maps.

--- a/src/data/sym/sym2.lean
+++ b/src/data/sym/sym2.lean
@@ -157,10 +157,16 @@ def lift₂ : {f : α → α → α → α → β // ∀ a₁ a₂ a₃ a₄,
   inv_fun := λ F, ⟨λ x₁ x₂ y₁ y₂, F ⟦(x₁, x₂)⟧ ⟦(y₁, y₂)⟧, λ a₁ a₂ b₁ b₂,
     by { split, exacts [congr_arg2 F eq_swap rfl, congr_arg2 F rfl eq_swap] }⟩,
   left_inv := λ f, subtype.ext rfl,
-  right_inv := λ F, begin
-    dsimp,
-    apply funext₂' (λ x y, _),
-  end }
+  right_inv := λ F, funext₂' $ λ x y, sym2.induction_on₂ x y $ λ _ _ _ _, rfl }
+
+@[simp]
+lemma lift₂_mk (f : {f : α → α → α → α → β // ∀ a₁ a₂ a₃ a₄,
+  (f a₁ a₂ a₃ a₄ = f a₂ a₁ a₃ a₄ ∧ f a₁ a₂ a₃ a₄ = f a₁ a₂ a₄ a₃)}) (a₁ a₂ a₃ a₄ : α) :
+  lift₂ f ⟦(a₁, a₂)⟧ ⟦(a₃, a₄)⟧ = (f : α → α → α → α → β) a₁ a₂ a₃ a₄ := rfl
+
+@[simp]
+lemma coe_lift₂_symm_apply (F : sym2 α → sym2 α → β) (a₁ a₂ a₃ a₄ : α) :
+  (lift₂.symm F : α → α → α → α → β) a₁ a₂ a₃ a₄ = F ⟦(a₁, a₂)⟧ ⟦(a₃, a₄)⟧ := rfl
 
 /--
 The functor `sym2` is functorial, and this function constructs the induced maps.

--- a/src/logic/basic.lean
+++ b/src/logic/basic.lean
@@ -917,7 +917,7 @@ congr_fun₂ (congr_fun h _) _ _
 lemma funext₂ {f g : Π a b, γ a b} (h : ∀ a b, f a b = g a b) : f = g :=
 funext $ λ _, funext $ h _
 
-lemma funext₃ {f g : Π a b, γ a b → Prop} (h : ∀ a b c, f a b c = g a b c) : f = g :=
+lemma funext₃ {f g : Π a b c, δ a b c} (h : ∀ a b c, f a b c = g a b c) : f = g :=
 funext $ λ _, funext₂ $ h _
 
 end equality

--- a/src/logic/basic.lean
+++ b/src/logic/basic.lean
@@ -917,6 +917,9 @@ congr_fun₂ (congr_fun h _) _ _
 lemma funext₂ {f g : Π a, β a → Prop} (h : ∀ a b, f a b = g a b) : f = g :=
 funext $ λ _, funext $ h _
 
+lemma funext₂' {f g : Π a b, γ a b} (h : ∀ a b, f a b = g a b) : f = g :=
+funext $ λ _, funext $ h _
+
 lemma funext₃ {f g : Π a b, γ a b → Prop} (h : ∀ a b c, f a b c = g a b c) : f = g :=
 funext $ λ _, funext₂ $ h _
 

--- a/src/logic/basic.lean
+++ b/src/logic/basic.lean
@@ -914,10 +914,7 @@ lemma congr_fun₃ {f g : Π a b c, δ a b c} (h : f = g) (a : α) (b : β a) (c
   f a b c = g a b c :=
 congr_fun₂ (congr_fun h _) _ _
 
-lemma funext₂ {f g : Π a, β a → Prop} (h : ∀ a b, f a b = g a b) : f = g :=
-funext $ λ _, funext $ h _
-
-lemma funext₂' {f g : Π a b, γ a b} (h : ∀ a b, f a b = g a b) : f = g :=
+lemma funext₂ {f g : Π a b, γ a b} (h : ∀ a b, f a b = g a b) : f = g :=
 funext $ λ _, funext $ h _
 
 lemma funext₃ {f g : Π a b, γ a b → Prop} (h : ∀ a b c, f a b c = g a b c) : f = g :=


### PR DESCRIPTION
We add `sym2.lift₂`, a two-argument version of `sym2.lift`. Its intended purpose is for defining the relation on unordered pairs relating pairs where exactly one entry decreases.

We also generalize the types for the existing `funext₂` and `funext₃`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

See #15885 for further context

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
