### PR TITLE
[Merged by Bors] - doc(linear_algebra/clifford_algebra/basic): docstring clarification

### DIFF
--- a/src/linear_algebra/clifford_algebra/basic.lean
+++ b/src/linear_algebra/clifford_algebra/basic.lean
@@ -16,12 +16,12 @@ a quadratic_form `Q`.
 
 ## Notation
 
-The Clifford algebra of the `R`-module `M` equipped with a quadratic_form `Q` is denoted as
-`clifford_algebra Q`.
+The Clifford algebra of the `R`-module `M` equipped with a quadratic_form `Q` is
+an `R`-algebra denoted `clifford_algebra Q`.
 
 Given a linear morphism `f : M → A` from a module `M` to another `R`-algebra `A`, such that
 `cond : ∀ m, f m * f m = algebra_map _ _ (Q m)`, there is a (unique) lift of `f` to an `R`-algebra
-morphism, which is denoted `clifford_algebra.lift Q f cond`.
+morphism from `clifford_algebra Q` to `A`, which is denoted `clifford_algebra.lift Q f cond`.
 
 The canonical linear map `M → clifford_algebra Q` is denoted `clifford_algebra.ι Q`.
 


### PR DESCRIPTION

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)

An Imperial student is discussing formalising spin groups with Eric and I wanted to help with some technicality, but I learnt about Clifford algebras 20 years ago and have forgotten all I knew. I'm now re-learning the theory not through Wikipedia but via mathlib docstrings. I think it's amazing that we have got to this point! What's even better is that unlike Wikipedia, where if you don't understand things you have to find another resource, with mathlib if you don't understand the docstring you can just go and read the code and then clarify the docstring.Thanks so much to Rob for recognising the importance of good module docstrings many years ago now.
