### PR TITLE
[Merged by Bors] - chore(analysis/calculus/cont_diff): rename and add @[simp] to `iterated_fderiv_within_zero_fun`

### DIFF
--- a/src/analysis/calculus/cont_diff.lean
+++ b/src/analysis/calculus/cont_diff.lean
@@ -1568,7 +1568,7 @@ end
 
 /-! ### Constants -/
 
-lemma iterated_fderiv_zero_fun {n : ℕ} :
+@[simp] lemma iterated_fderiv_zero_fun {n : ℕ} :
   iterated_fderiv 𝕜 n (λ x : E, (0 : F)) = 0 :=
 begin
   induction n with n IH,
@@ -1579,10 +1579,6 @@ begin
     rw fderiv_const,
     refl }
 end
-
-@[simp] lemma iterated_fderiv_zero_fun_apply {n : ℕ} {x : E} :
-  iterated_fderiv 𝕜 n (0 : E → F) x = 0 :=
-(congr_fun iterated_fderiv_zero_fun x).trans (pi.zero_apply _)
 
 lemma cont_diff_zero_fun :
   cont_diff 𝕜 n (λ x : E, (0 : F)) :=

--- a/src/analysis/calculus/cont_diff.lean
+++ b/src/analysis/calculus/cont_diff.lean
@@ -1568,7 +1568,7 @@ end
 
 /-! ### Constants -/
 
-lemma iterated_fderiv_within_zero_fun {n : ℕ} :
+lemma iterated_fderiv_zero_fun {n : ℕ} :
   iterated_fderiv 𝕜 n (λ x : E, (0 : F)) = 0 :=
 begin
   induction n with n IH,
@@ -1580,11 +1580,15 @@ begin
     refl }
 end
 
+@[simp] lemma iterated_fderiv_zero_fun_apply {n : ℕ} {x : E} :
+  iterated_fderiv 𝕜 n (0 : E → F) x = 0 :=
+(congr_fun iterated_fderiv_zero_fun x).trans (pi.zero_apply _)
+
 lemma cont_diff_zero_fun :
   cont_diff 𝕜 n (λ x : E, (0 : F)) :=
 begin
   apply cont_diff_of_differentiable_iterated_fderiv (λm hm, _),
-  rw iterated_fderiv_within_zero_fun,
+  rw iterated_fderiv_zero_fun,
   apply differentiable_const (0 : (E [×m]→L[𝕜] F))
 end
 


### PR DESCRIPTION
Rename the lemma `iterated_fderiv_within_zero_fun` to `iterated_fderiv_zero_fun` because it is not stated with `iterated_fderiv_within` and add the `simp` attribute.

---

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
