### PR TITLE
[Merged by Bors] - feat(analysis/normed_space/multilinear): constant scalar multiplication is continuous

### DIFF
--- a/src/analysis/normed_space/multilinear.lean
+++ b/src/analysis/normed_space/multilinear.lean
@@ -961,9 +961,6 @@ section smul
 variables {R : Type*} [semiring R] [module R G] [smul_comm_class 𝕜 R G]
   [has_continuous_const_smul R G]
 
-lemma smul_continuous_multilinear_map {c : R} (m : continuous_multilinear_map 𝕜 E G) :
-  (c • continuous_linear_map.id 𝕜 G).comp_continuous_multilinear_map m = c • m := rfl
-
 instance : has_continuous_const_smul R (continuous_multilinear_map 𝕜 E G) :=
 ⟨λ c, (continuous_linear_map.comp_continuous_multilinear_mapL 𝕜 _ G G
   (c • continuous_linear_map.id 𝕜 G)).2⟩

--- a/src/analysis/normed_space/multilinear.lean
+++ b/src/analysis/normed_space/multilinear.lean
@@ -958,19 +958,17 @@ end continuous_multilinear_map
 
 section smul
 
-variables [semiring R] [module R F] [smul_comm_class 𝕜 R F] [has_continuous_const_smul R F]
+variables {R : Type*} [semiring R] [module R G] [smul_comm_class 𝕜 R G]
+  [has_continuous_const_smul R G]
 
 lemma smul_continuous_multilinear_map {k : ℕ} {c : R}
-  (m : continuous_multilinear_map 𝕜 (λ (i : fin k), E) F):
-  (c • continuous_linear_map.id 𝕜 F).comp_continuous_multilinear_map m = c • m :=
+  (m : continuous_multilinear_map 𝕜 E G):
+  (c • continuous_linear_map.id 𝕜 G).comp_continuous_multilinear_map m = c • m :=
 by { ext x, simp }
 
-instance {k : ℕ}: has_continuous_const_smul R (continuous_multilinear_map 𝕜 (λ (i : fin k), E) F) :=
-⟨λ c, begin
-  simp_rw ←smul_continuous_multilinear_map,
-  refine (continuous_linear_map.comp_continuous_multilinear_mapL 𝕜 _ F F
-    (c • continuous_linear_map.id 𝕜 F)).2,
-end⟩
+instance {k : ℕ}: has_continuous_const_smul R (continuous_multilinear_map 𝕜 E G) :=
+⟨λ c, (continuous_linear_map.comp_continuous_multilinear_mapL 𝕜 _ G G
+  (c • continuous_linear_map.id 𝕜 G)).2⟩
 
 end smul
 

--- a/src/analysis/normed_space/multilinear.lean
+++ b/src/analysis/normed_space/multilinear.lean
@@ -956,6 +956,24 @@ linear_map.mk_continuous_norm_le _ (prod_nonneg $ λ i _, norm_nonneg _) _
 
 end continuous_multilinear_map
 
+section smul
+
+variables [semiring R] [module R F] [smul_comm_class 𝕜 R F] [has_continuous_const_smul R F]
+
+lemma smul_continuous_multilinear_map {k : ℕ} {c : R}
+  (m : continuous_multilinear_map 𝕜 (λ (i : fin k), E) F):
+  (c • continuous_linear_map.id 𝕜 F).comp_continuous_multilinear_map m = c • m :=
+by { ext x, simp }
+
+instance {k : ℕ}: has_continuous_const_smul R (continuous_multilinear_map 𝕜 (λ (i : fin k), E) F) :=
+⟨λ c, begin
+  simp_rw ←smul_continuous_multilinear_map,
+  refine (continuous_linear_map.comp_continuous_multilinear_mapL 𝕜 _ F F
+    (c • continuous_linear_map.id 𝕜 F)).2,
+end⟩
+
+end smul
+
 section currying
 /-!
 ### Currying

--- a/src/analysis/normed_space/multilinear.lean
+++ b/src/analysis/normed_space/multilinear.lean
@@ -961,12 +961,10 @@ section smul
 variables {R : Type*} [semiring R] [module R G] [smul_comm_class 𝕜 R G]
   [has_continuous_const_smul R G]
 
-lemma smul_continuous_multilinear_map {k : ℕ} {c : R}
-  (m : continuous_multilinear_map 𝕜 E G):
-  (c • continuous_linear_map.id 𝕜 G).comp_continuous_multilinear_map m = c • m :=
-by { ext x, simp }
+lemma smul_continuous_multilinear_map {c : R} (m : continuous_multilinear_map 𝕜 E G) :
+  (c • continuous_linear_map.id 𝕜 G).comp_continuous_multilinear_map m = c • m := rfl
 
-instance {k : ℕ}: has_continuous_const_smul R (continuous_multilinear_map 𝕜 E G) :=
+instance : has_continuous_const_smul R (continuous_multilinear_map 𝕜 E G) :=
 ⟨λ c, (continuous_linear_map.comp_continuous_multilinear_mapL 𝕜 _ G G
   (c • continuous_linear_map.id 𝕜 G)).2⟩
 


### PR DESCRIPTION
This PR adds an instance for continuous multilinear maps that gives continuous scalar multiplication.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
