### PR TITLE
[Merged by Bors] - feat(linear_algebra/matrix): Add matrix properties for sesquilinear forms

### DIFF
--- a/src/algebra/hom/ring.lean
+++ b/src/algebra/hom/ring.lean
@@ -391,6 +391,14 @@ protected lemma map_bit0 (f : α →+* β) : ∀ a, f (bit0 a) = bit0 (f a) := m
 /-- Ring homomorphisms preserve `bit1`. -/
 protected lemma map_bit1 (f : α →+* β) : ∀ a, f (bit1 a) = bit1 (f a) := map_bit1 f
 
+@[simp] lemma apply_ite_zero_one (f : α →+* β) (p : Prop) [decidable p] :
+  f (ite p 0 1) = ite p 0 1 :=
+by { split_ifs; simp [h] }
+
+@[simp] lemma apply_ite_one_zero (f : α →+* β) (p : Prop) [decidable p] :
+  f (ite p 1 0) = ite p 1 0 :=
+by { split_ifs; simp [h] }
+
 /-- `f : α →+* β` has a trivial codomain iff `f 1 = 0`. -/
 lemma codomain_trivial_iff_map_one_eq_zero : (0 : β) = 1 ↔ f 1 = 0 := by rw [map_one, eq_comm]
 

--- a/src/algebra/hom/ring.lean
+++ b/src/algebra/hom/ring.lean
@@ -391,11 +391,11 @@ protected lemma map_bit0 (f : α →+* β) : ∀ a, f (bit0 a) = bit0 (f a) := m
 /-- Ring homomorphisms preserve `bit1`. -/
 protected lemma map_bit1 (f : α →+* β) : ∀ a, f (bit1 a) = bit1 (f a) := map_bit1 f
 
-@[simp] lemma apply_ite_zero_one (f : α →+* β) (p : Prop) [decidable p] :
+@[simp] lemma map_ite_zero_one {F : Type*} [ring_hom_class F α β] (f : F) (p : Prop) [decidable p] :
   f (ite p 0 1) = ite p 0 1 :=
 by { split_ifs; simp [h] }
 
-@[simp] lemma apply_ite_one_zero (f : α →+* β) (p : Prop) [decidable p] :
+@[simp] lemma map_ite_one_zero {F : Type*} [ring_hom_class F α β] (f : F) (p : Prop) [decidable p] :
   f (ite p 1 0) = ite p 1 0 :=
 by { split_ifs; simp [h] }
 

--- a/src/algebra/lie/skew_adjoint.lean
+++ b/src/algebra/lie/skew_adjoint.lean
@@ -119,7 +119,7 @@ begin
     A ∈ skew_adjoint_matrices_submodule (Pᵀ ⬝ J ⬝ P),
   { simp only [lie_subalgebra.mem_coe, submodule.mem_map_equiv, lie_subalgebra.mem_map_submodule,
       coe_coe], exact this, },
-  simp [matrix.is_skew_adjoint, J.is_adjoint_pair_equiv _ _ P (is_unit_of_invertible P)],
+  simp [matrix.is_skew_adjoint, J.is_adjoint_pair_equiv' _ _ P (is_unit_of_invertible P)],
 end
 
 lemma skew_adjoint_matrices_lie_subalgebra_equiv_apply

--- a/src/linear_algebra/bilinear_map.lean
+++ b/src/linear_algebra/bilinear_map.lean
@@ -268,6 +268,10 @@ def compl₁₂ (f : Mₗ →ₗ[R] Nₗ →ₗ[R] Pₗ) (g : Qₗ →ₗ[R] M�
 @[simp] theorem compl₁₂_apply (f : Mₗ →ₗ[R] Nₗ →ₗ[R] Pₗ) (g : Qₗ →ₗ[R] Mₗ) (g' : Qₗ' →ₗ[R] Nₗ)
   (x : Qₗ) (y : Qₗ') : f.compl₁₂ g g' x y = f (g x) (g' y) := rfl
 
+@[simp] theorem compl₁₂_id_id (f : Mₗ →ₗ[R] Nₗ →ₗ[R] Pₗ) :
+  f.compl₁₂ (linear_map.id) (linear_map.id) = f :=
+by { ext, simp_rw [compl₁₂_apply, id_coe, id.def] }
+
 lemma compl₁₂_inj {f₁ f₂ : Mₗ →ₗ[R] Nₗ →ₗ[R] Pₗ} {g : Qₗ →ₗ[R] Mₗ} {g' : Qₗ' →ₗ[R] Nₗ}
   (hₗ : function.surjective g) (hᵣ : function.surjective g') :
   f₁.compl₁₂ g g' = f₂.compl₁₂ g g' ↔ f₁ = f₂ :=

--- a/src/linear_algebra/bilinear_map.lean
+++ b/src/linear_algebra/bilinear_map.lean
@@ -256,6 +256,9 @@ include σ₄₃
   f.compl₂ g m q = f m (g q) := rfl
 omit σ₄₃
 
+@[simp] theorem compl₂_id : f.compl₂ linear_map.id = f :=
+by { ext, rw [compl₂_apply, id_coe, id.def] }
+
 /-- Composing linear maps `Q → M` and `Q' → N` with a bilinear map `M → N → P` to
 form a bilinear map `Q → Q' → P`. -/
 def compl₁₂ (f : Mₗ →ₗ[R] Nₗ →ₗ[R] Pₗ) (g : Qₗ →ₗ[R] Mₗ) (g' : Qₗ' →ₗ[R] Nₗ) :

--- a/src/linear_algebra/bilinear_map.lean
+++ b/src/linear_algebra/bilinear_map.lean
@@ -301,12 +301,15 @@ end comm_semiring
 section comm_ring
 
 variables {R R₂ S S₂ M N P : Type*}
+variables {Mₗ Nₗ Pₗ : Type*}
 variables [comm_ring R] [comm_ring S] [comm_ring R₂] [comm_ring S₂]
 variables [add_comm_group M] [add_comm_group N] [add_comm_group P]
+variables [add_comm_group Mₗ] [add_comm_group Nₗ] [add_comm_group Pₗ]
 variables [module R M] [module S N] [module R₂ P] [module S₂ P]
+variables [module R Mₗ] [module R Nₗ] [module R Pₗ]
 variables [smul_comm_class S₂ R₂ P]
 variables {ρ₁₂ : R →+* R₂} {σ₁₂ : S →+* S₂}
-variables (b₁ : basis ι₁ R M) (b₂ : basis ι₂ S N)
+variables (b₁ : basis ι₁ R M) (b₂ : basis ι₂ S N) (b₁' : basis ι₁ R Mₗ) (b₂' : basis ι₂ R Nₗ)
 
 lemma lsmul_injective [no_zero_smul_divisors R M] {x : R} (hx : x ≠ 0) :
   function.injective (lsmul R M x) :=
@@ -322,8 +325,10 @@ lemma ext_basis {B B' : M →ₛₗ[ρ₁₂] N →ₛₗ[σ₁₂] P}
   (h : ∀ i j, B (b₁ i) (b₂ j) = B' (b₁ i) (b₂ j)) : B = B' :=
 b₁.ext $ λ i, b₂.ext $ λ j, h i j
 
-/-- Write out `B x y` as a sum over `B (b i) (b j)` if `b` is a basis. -/
-lemma sum_repr_mul_repr_mul {B : M →ₛₗ[ρ₁₂] N →ₛₗ[σ₁₂] P} (x y) :
+/-- Write out `B x y` as a sum over `B (b i) (b j)` if `b` is a basis.
+
+Version for semi-bilinear maps.-/
+lemma sum_repr_mul_repr_mulₛₗ {B : M →ₛₗ[ρ₁₂] N →ₛₗ[σ₁₂] P} (x y) :
   (b₁.repr x).sum (λ i xi, (b₂.repr y).sum (λ j yj, (ρ₁₂ xi) • (σ₁₂ yj) • B (b₁ i) (b₂ j))) =
   B x y :=
 begin
@@ -332,6 +337,17 @@ begin
     linear_map.map_smulₛₗ₂, linear_map.map_smulₛₗ],
 end
 
+/-- Write out `B x y` as a sum over `B (b i) (b j)` if `b` is a basis.
+
+Version for bilinear maps.-/
+lemma sum_repr_mul_repr_mul {B : Mₗ →ₗ[R] Nₗ →ₗ[R] Pₗ} (x y) :
+  (b₁'.repr x).sum (λ i xi, (b₂'.repr y).sum (λ j yj, xi • yj • B (b₁' i) (b₂' j))) =
+  B x y :=
+begin
+  conv_rhs { rw [← b₁'.total_repr x, ← b₂'.total_repr y] },
+  simp_rw [finsupp.total_apply, finsupp.sum, map_sum₂, map_sum,
+    linear_map.map_smul₂, linear_map.map_smul],
+end
 
 end comm_ring
 

--- a/src/linear_algebra/bilinear_map.lean
+++ b/src/linear_algebra/bilinear_map.lean
@@ -306,21 +306,16 @@ section comm_ring
 variables {R R₂ S S₂ M N P : Type*}
 variables {Mₗ Nₗ Pₗ : Type*}
 variables [comm_ring R] [comm_ring S] [comm_ring R₂] [comm_ring S₂]
-variables [add_comm_group M] [add_comm_group N] [add_comm_group P]
-variables [add_comm_group Mₗ] [add_comm_group Nₗ] [add_comm_group Pₗ]
+
+section add_comm_monoid
+
+variables [add_comm_monoid M] [add_comm_monoid N] [add_comm_monoid P]
+variables [add_comm_monoid Mₗ] [add_comm_monoid Nₗ] [add_comm_monoid Pₗ]
 variables [module R M] [module S N] [module R₂ P] [module S₂ P]
 variables [module R Mₗ] [module R Nₗ] [module R Pₗ]
 variables [smul_comm_class S₂ R₂ P]
 variables {ρ₁₂ : R →+* R₂} {σ₁₂ : S →+* S₂}
 variables (b₁ : basis ι₁ R M) (b₂ : basis ι₂ S N) (b₁' : basis ι₁ R Mₗ) (b₂' : basis ι₂ R Nₗ)
-
-lemma lsmul_injective [no_zero_smul_divisors R M] {x : R} (hx : x ≠ 0) :
-  function.injective (lsmul R M x) :=
-smul_right_injective _ hx
-
-lemma ker_lsmul [no_zero_smul_divisors R M] {a : R} (ha : a ≠ 0) :
-  (linear_map.lsmul R M a).ker = ⊥ :=
-linear_map.ker_eq_bot_of_injective (linear_map.lsmul_injective ha)
 
 
 /-- Two bilinear maps are equal when they are equal on all basis vectors. -/
@@ -351,6 +346,23 @@ begin
   simp_rw [finsupp.total_apply, finsupp.sum, map_sum₂, map_sum,
     linear_map.map_smul₂, linear_map.map_smul],
 end
+
+end add_comm_monoid
+
+section add_comm_group
+
+variables [add_comm_group M] [add_comm_group N] [add_comm_group P]
+variables [module R M] [module S N] [module R₂ P] [module S₂ P]
+
+lemma lsmul_injective [no_zero_smul_divisors R M] {x : R} (hx : x ≠ 0) :
+  function.injective (lsmul R M x) :=
+smul_right_injective _ hx
+
+lemma ker_lsmul [no_zero_smul_divisors R M] {a : R} (ha : a ≠ 0) :
+  (linear_map.lsmul R M a).ker = ⊥ :=
+linear_map.ker_eq_bot_of_injective (linear_map.lsmul_injective ha)
+
+end add_comm_group
 
 end comm_ring
 

--- a/src/linear_algebra/bilinear_map.lean
+++ b/src/linear_algebra/bilinear_map.lean
@@ -329,7 +329,7 @@ b₁.ext $ λ i, b₂.ext $ λ j, h i j
 
 /-- Write out `B x y` as a sum over `B (b i) (b j)` if `b` is a basis.
 
-Version for semi-bilinear maps.-/
+Version for semi-bilinear maps, see `sum_repr_mul_repr_mul` for the bilinear version. -/
 lemma sum_repr_mul_repr_mulₛₗ {B : M →ₛₗ[ρ₁₂] N →ₛₗ[σ₁₂] P} (x y) :
   (b₁.repr x).sum (λ i xi, (b₂.repr y).sum (λ j yj, (ρ₁₂ xi) • (σ₁₂ yj) • B (b₁ i) (b₂ j))) =
   B x y :=
@@ -341,7 +341,7 @@ end
 
 /-- Write out `B x y` as a sum over `B (b i) (b j)` if `b` is a basis.
 
-Version for bilinear maps.-/
+Version for bilinear maps, see `sum_repr_mul_repr_mulₛₗ` for the semi-bilinear version. -/
 lemma sum_repr_mul_repr_mul {B : Mₗ →ₗ[R] Nₗ →ₗ[R] Pₗ} (x y) :
   (b₁'.repr x).sum (λ i xi, (b₂'.repr y).sum (λ j yj, xi • yj • B (b₁' i) (b₂' j))) =
   B x y :=

--- a/src/linear_algebra/finsupp_vector_space.lean
+++ b/src/linear_algebra/finsupp_vector_space.lean
@@ -210,7 +210,7 @@ variables {R M n : Type*}
 variables [decidable_eq n] [fintype n]
 variables [semiring R] [add_comm_monoid M] [module R M]
 
-lemma finset_sum_single_ite (a : R) (i : n) :
+lemma _root_.finset.sum_single_ite (a : R) (i : n) :
   finset.univ.sum (λ (x : n), finsupp.single x (ite (i = x) a 0)) = finsupp.single i a :=
 begin
   rw finset.sum_congr_set {i} (λ (x : n), finsupp.single x (ite (i = x) a 0))
@@ -235,7 +235,7 @@ begin
   apply_fun b.repr,
   simp only [equiv_fun_symm_apply, std_basis_apply', linear_equiv.map_sum,
     linear_equiv.map_smulₛₗ, ring_hom.id_apply, repr_self, finsupp.smul_single', boole_mul],
-  exact finset_sum_single_ite 1 i,
+  exact finset.sum_single_ite 1 i,
 end
 
 end basis

--- a/src/linear_algebra/finsupp_vector_space.lean
+++ b/src/linear_algebra/finsupp_vector_space.lean
@@ -210,12 +210,32 @@ variables {R M n : Type*}
 variables [decidable_eq n] [fintype n]
 variables [semiring R] [add_comm_monoid M] [module R M]
 
+lemma test (a : R) (i : n) :
+  finset.univ.sum (λ (x : n), finsupp.single x (ite (i = x) a 0)) = finsupp.single i a :=
+begin
+  rw finset.sum_congr_set {i} (λ (x : n), finsupp.single x (ite (i = x) a 0))
+    (λ _, finsupp.single i a),
+  { simp },
+  { intros x hx,
+    rw set.mem_singleton_iff at hx,
+    simp [hx] },
+  intros x hx,
+  have hx' : ¬i = x :=
+  begin
+    refine ne_comm.mp _,
+    rwa mem_singleton_iff at hx,
+  end,
+  simp [hx'],
+end
+
 @[simp] lemma equiv_fun_symm_std_basis (b : basis n R M) (i : n) :
   b.equiv_fun.symm (linear_map.std_basis R (λ _, R) i 1) = b i :=
 begin
+  have := equiv_like.injective b.repr,
   apply_fun b.repr,
-  { simp },
-  exact equiv_like.injective b.repr,
+  simp only [equiv_fun_symm_apply, std_basis_apply', linear_equiv.map_sum,
+    linear_equiv.map_smulₛₗ, ring_hom.id_apply, repr_self, finsupp.smul_single', boole_mul],
+  exact test 1 i,
 end
 
 end basis

--- a/src/linear_algebra/finsupp_vector_space.lean
+++ b/src/linear_algebra/finsupp_vector_space.lean
@@ -203,3 +203,19 @@ begin
 end
 
 end module
+
+namespace basis
+
+variables {R M n : Type*}
+variables [decidable_eq n] [fintype n]
+variables [semiring R] [add_comm_monoid M] [module R M]
+
+@[simp] lemma equiv_fun_symm_std_basis (b : basis n R M) (i : n) :
+  b.equiv_fun.symm (linear_map.std_basis R (λ _, R) i 1) = b i :=
+begin
+  apply_fun b.repr,
+  { simp },
+  exact equiv_like.injective b.repr,
+end
+
+end basis

--- a/src/linear_algebra/finsupp_vector_space.lean
+++ b/src/linear_algebra/finsupp_vector_space.lean
@@ -210,7 +210,7 @@ variables {R M n : Type*}
 variables [decidable_eq n] [fintype n]
 variables [semiring R] [add_comm_monoid M] [module R M]
 
-lemma test (a : R) (i : n) :
+lemma finset_sum_single_ite (a : R) (i : n) :
   finset.univ.sum (λ (x : n), finsupp.single x (ite (i = x) a 0)) = finsupp.single i a :=
 begin
   rw finset.sum_congr_set {i} (λ (x : n), finsupp.single x (ite (i = x) a 0))
@@ -235,7 +235,7 @@ begin
   apply_fun b.repr,
   simp only [equiv_fun_symm_apply, std_basis_apply', linear_equiv.map_sum,
     linear_equiv.map_smulₛₗ, ring_hom.id_apply, repr_self, finsupp.smul_single', boole_mul],
-  exact test 1 i,
+  exact finset_sum_single_ite 1 i,
 end
 
 end basis

--- a/src/linear_algebra/matrix/bilinear_form.lean
+++ b/src/linear_algebra/matrix/bilinear_form.lean
@@ -9,6 +9,7 @@ import linear_algebra.matrix.nondegenerate
 import linear_algebra.matrix.nonsingular_inverse
 import linear_algebra.matrix.to_linear_equiv
 import linear_algebra.bilinear_form
+import linear_algebra.matrix.sesquilinear_form
 
 /-!
 # Bilinear form
@@ -361,18 +362,6 @@ variables {n : Type*} [fintype n]
 variables (b : basis n R₃ M₃)
 variables (J J₃ A A' : matrix n n R₃)
 
-/-- The condition for the square matrices `A`, `A'` to be an adjoint pair with respect to the square
-matrices `J`, `J₃`. -/
-def matrix.is_adjoint_pair := Aᵀ ⬝ J₃ = J ⬝ A'
-
-/-- The condition for a square matrix `A` to be self-adjoint with respect to the square matrix
-`J`. -/
-def matrix.is_self_adjoint := matrix.is_adjoint_pair J J A A
-
-/-- The condition for a square matrix `A` to be skew-adjoint with respect to the square matrix
-`J`. -/
-def matrix.is_skew_adjoint := matrix.is_adjoint_pair J J A (-A)
-
 @[simp] lemma is_adjoint_pair_to_bilin' [decidable_eq n] :
   bilin_form.is_adjoint_pair (matrix.to_bilin' J) (matrix.to_bilin' J₃)
       (matrix.to_lin' A) (matrix.to_lin' A') ↔
@@ -409,7 +398,7 @@ begin
   refl,
 end
 
-lemma matrix.is_adjoint_pair_equiv [decidable_eq n] (P : matrix n n R₃) (h : is_unit P) :
+lemma matrix.is_adjoint_pair_equiv' [decidable_eq n] (P : matrix n n R₃) (h : is_unit P) :
   (Pᵀ ⬝ J ⬝ P).is_adjoint_pair (Pᵀ ⬝ J ⬝ P) A A' ↔
     J.is_adjoint_pair J (P ⬝ A ⬝ P⁻¹) (P ⬝ A' ⬝ P⁻¹) :=
 have h' : is_unit P.det := P.is_unit_iff_is_unit_det.mp h,
@@ -432,12 +421,12 @@ variables [decidable_eq n]
 
 /-- The submodule of pair-self-adjoint matrices with respect to bilinear forms corresponding to
 given matrices `J`, `J₂`. -/
-def pair_self_adjoint_matrices_submodule : submodule R₃ (matrix n n R₃) :=
+def pair_self_adjoint_matrices_submodule' : submodule R₃ (matrix n n R₃) :=
 (bilin_form.is_pair_self_adjoint_submodule (matrix.to_bilin' J) (matrix.to_bilin' J₃)).map
   ((linear_map.to_matrix' : ((n → R₃) →ₗ[R₃] (n → R₃)) ≃ₗ[R₃] matrix n n R₃) :
   ((n → R₃) →ₗ[R₃] (n → R₃)) →ₗ[R₃] matrix n n R₃)
 
-@[simp] lemma mem_pair_self_adjoint_matrices_submodule :
+@[simp] lemma mem_pair_self_adjoint_matrices_submodule' :
   A ∈ (pair_self_adjoint_matrices_submodule J J₃) ↔ matrix.is_adjoint_pair J J₃ A A :=
 begin
   simp only [pair_self_adjoint_matrices_submodule, linear_equiv.coe_coe,
@@ -453,19 +442,19 @@ end
 
 /-- The submodule of self-adjoint matrices with respect to the bilinear form corresponding to
 the matrix `J`. -/
-def self_adjoint_matrices_submodule : submodule R₃ (matrix n n R₃) :=
+def self_adjoint_matrices_submodule' : submodule R₃ (matrix n n R₃) :=
   pair_self_adjoint_matrices_submodule J J
 
-@[simp] lemma mem_self_adjoint_matrices_submodule :
+@[simp] lemma mem_self_adjoint_matrices_submodule' :
   A ∈ self_adjoint_matrices_submodule J ↔ J.is_self_adjoint A :=
 by { erw mem_pair_self_adjoint_matrices_submodule, refl, }
 
 /-- The submodule of skew-adjoint matrices with respect to the bilinear form corresponding to
 the matrix `J`. -/
-def skew_adjoint_matrices_submodule : submodule R₃ (matrix n n R₃) :=
+def skew_adjoint_matrices_submodule' : submodule R₃ (matrix n n R₃) :=
   pair_self_adjoint_matrices_submodule (-J) J
 
-@[simp] lemma mem_skew_adjoint_matrices_submodule :
+@[simp] lemma mem_skew_adjoint_matrices_submodule' :
   A ∈ skew_adjoint_matrices_submodule J ↔ J.is_skew_adjoint A :=
 begin
   erw mem_pair_self_adjoint_matrices_submodule,

--- a/src/linear_algebra/matrix/bilinear_form.lean
+++ b/src/linear_algebra/matrix/bilinear_form.lean
@@ -245,18 +245,6 @@ noncomputable def bilin_form.to_matrix : bilin_form R₂ M₂ ≃ₗ[R₂] matri
 noncomputable def matrix.to_bilin : matrix n n R₂ ≃ₗ[R₂] bilin_form R₂ M₂ :=
 (bilin_form.to_matrix b).symm
 
-@[simp] lemma basis.equiv_fun_symm_std_basis (i : n) :
-  b.equiv_fun.symm (std_basis R₂ (λ _, R₂) i 1) = b i :=
-begin
-  rw [b.equiv_fun_symm_apply, finset.sum_eq_single i],
-  { rw [std_basis_same, one_smul] },
-  { rintros j - hj,
-    rw [std_basis_ne _ _ _ _ hj, zero_smul] },
-  { intro,
-    have := mem_univ i,
-    contradiction }
-end
-
 @[simp] lemma bilin_form.to_matrix_apply (B : bilin_form R₂ M₂) (i j : n) :
   bilin_form.to_matrix b B i j = B (b i) (b j) :=
 by rw [bilin_form.to_matrix, linear_equiv.trans_apply, bilin_form.to_matrix'_apply, congr_apply,

--- a/src/linear_algebra/matrix/bilinear_form.lean
+++ b/src/linear_algebra/matrix/bilinear_form.lean
@@ -429,40 +429,24 @@ def pair_self_adjoint_matrices_submodule' : submodule R₃ (matrix n n R₃) :=
 lemma mem_pair_self_adjoint_matrices_submodule' :
   A ∈ (pair_self_adjoint_matrices_submodule J J₃) ↔ matrix.is_adjoint_pair J J₃ A A :=
 by simp only [mem_pair_self_adjoint_matrices_submodule]
-/-begin
-  simp only [pair_self_adjoint_matrices_submodule, linear_equiv.coe_coe,
-    linear_map.to_matrix'_apply, submodule.mem_map, bilin_form.mem_is_pair_self_adjoint_submodule],
-  split,
-  { rintros ⟨f, hf, hA⟩,
-    have hf' : f = A.to_lin' := by rw [←hA, matrix.to_lin'_to_matrix'], rw hf' at hf,
-    rw ← is_adjoint_pair_to_bilin',
-    exact hf, },
-  { intros h, refine ⟨A.to_lin', _, linear_map.to_matrix'_to_lin' _⟩,
-    exact (is_adjoint_pair_to_bilin' _ _ _ _).mpr h, },
-end-/
 
 /-- The submodule of self-adjoint matrices with respect to the bilinear form corresponding to
 the matrix `J`. -/
 def self_adjoint_matrices_submodule' : submodule R₃ (matrix n n R₃) :=
   pair_self_adjoint_matrices_submodule J J
 
-@[simp] lemma mem_self_adjoint_matrices_submodule' :
+lemma mem_self_adjoint_matrices_submodule' :
   A ∈ self_adjoint_matrices_submodule J ↔ J.is_self_adjoint A :=
 by simp only [mem_self_adjoint_matrices_submodule]
---{ erw mem_pair_self_adjoint_matrices_submodule, refl, }
 
 /-- The submodule of skew-adjoint matrices with respect to the bilinear form corresponding to
 the matrix `J`. -/
 def skew_adjoint_matrices_submodule' : submodule R₃ (matrix n n R₃) :=
   pair_self_adjoint_matrices_submodule (-J) J
 
-@[simp] lemma mem_skew_adjoint_matrices_submodule' :
+lemma mem_skew_adjoint_matrices_submodule' :
   A ∈ skew_adjoint_matrices_submodule J ↔ J.is_skew_adjoint A :=
-by simp only [mem_self_adjoint_matrices_submodule]
-/-begin
-  erw mem_pair_self_adjoint_matrices_submodule,
-  simp [matrix.is_skew_adjoint, matrix.is_adjoint_pair],
-end-/
+by simp only [mem_skew_adjoint_matrices_submodule]
 
 end matrix_adjoints
 

--- a/src/linear_algebra/matrix/bilinear_form.lean
+++ b/src/linear_algebra/matrix/bilinear_form.lean
@@ -426,9 +426,10 @@ def pair_self_adjoint_matrices_submodule' : submodule R₃ (matrix n n R₃) :=
   ((linear_map.to_matrix' : ((n → R₃) →ₗ[R₃] (n → R₃)) ≃ₗ[R₃] matrix n n R₃) :
   ((n → R₃) →ₗ[R₃] (n → R₃)) →ₗ[R₃] matrix n n R₃)
 
-@[simp] lemma mem_pair_self_adjoint_matrices_submodule' :
+lemma mem_pair_self_adjoint_matrices_submodule' :
   A ∈ (pair_self_adjoint_matrices_submodule J J₃) ↔ matrix.is_adjoint_pair J J₃ A A :=
-begin
+by simp only [mem_pair_self_adjoint_matrices_submodule]
+/-begin
   simp only [pair_self_adjoint_matrices_submodule, linear_equiv.coe_coe,
     linear_map.to_matrix'_apply, submodule.mem_map, bilin_form.mem_is_pair_self_adjoint_submodule],
   split,
@@ -438,7 +439,7 @@ begin
     exact hf, },
   { intros h, refine ⟨A.to_lin', _, linear_map.to_matrix'_to_lin' _⟩,
     exact (is_adjoint_pair_to_bilin' _ _ _ _).mpr h, },
-end
+end-/
 
 /-- The submodule of self-adjoint matrices with respect to the bilinear form corresponding to
 the matrix `J`. -/
@@ -447,7 +448,8 @@ def self_adjoint_matrices_submodule' : submodule R₃ (matrix n n R₃) :=
 
 @[simp] lemma mem_self_adjoint_matrices_submodule' :
   A ∈ self_adjoint_matrices_submodule J ↔ J.is_self_adjoint A :=
-by { erw mem_pair_self_adjoint_matrices_submodule, refl, }
+by simp only [mem_self_adjoint_matrices_submodule]
+--{ erw mem_pair_self_adjoint_matrices_submodule, refl, }
 
 /-- The submodule of skew-adjoint matrices with respect to the bilinear form corresponding to
 the matrix `J`. -/
@@ -456,10 +458,11 @@ def skew_adjoint_matrices_submodule' : submodule R₃ (matrix n n R₃) :=
 
 @[simp] lemma mem_skew_adjoint_matrices_submodule' :
   A ∈ skew_adjoint_matrices_submodule J ↔ J.is_skew_adjoint A :=
-begin
+by simp only [mem_self_adjoint_matrices_submodule]
+/-begin
   erw mem_pair_self_adjoint_matrices_submodule,
   simp [matrix.is_skew_adjoint, matrix.is_adjoint_pair],
-end
+end-/
 
 end matrix_adjoints
 

--- a/src/linear_algebra/matrix/sesquilinear_form.lean
+++ b/src/linear_algebra/matrix/sesquilinear_form.lean
@@ -33,7 +33,7 @@ sesquilinear_form, matrix, basis
 
 -/
 
-variables {R R₁ R₂ M M₁ M₂ M₁' M₂' n m n' m' : Type*}
+variables {R R₁ R₂ M M₁ M₂ M₁' M₂' n m n' m' ι : Type*}
 
 open_locale big_operators
 open finset linear_map matrix
@@ -561,3 +561,82 @@ begin
 end
 
 end matrix_adjoints
+
+namespace linear_map
+
+/-! ### Nondegenerate bilinear forms-/
+
+section det
+
+open matrix
+
+variables [comm_ring R₁] [add_comm_monoid M₁] [module R₁ M₁]
+variables [decidable_eq ι] [fintype ι]
+
+lemma _root_.matrix.nondegenerate_to_bilin'_iff_nondegenerate_to_bilin {M : matrix ι ι R₁}
+  (b : basis ι R₁ M₁) : M.to_linear_map₂'.nondegenerate ↔
+  (matrix.to_linear_map₂ b b M).nondegenerate := sorry
+--(nondegenerate_congr_iff b.equiv_fun.symm).symm
+
+variables (B : M₁ →ₗ[R₁] M₁ →ₗ[R₁] R₁)
+variables [is_domain R₁]
+
+-- Lemmas transferring nondegeneracy between a matrix and its associated bilinear form
+
+theorem _root_.matrix.nondegenerate.to_bilin' {M : matrix ι ι R₁} (h : M.nondegenerate) :
+  M.to_linear_map₂'.nondegenerate :=
+λ x hx, h.eq_zero_of_ortho $ λ y, by simpa only [to_bilin'_apply'] using hx y
+
+/-
+@[simp] lemma _root_.matrix.nondegenerate_to_bilin'_iff {M : matrix ι ι R₃} :
+  M.to_bilin'.nondegenerate ↔ M.nondegenerate :=
+⟨λ h v hv, h v $ λ w, (M.to_bilin'_apply' _ _).trans $ hv w, matrix.nondegenerate.to_bilin'⟩
+
+theorem _root_.matrix.nondegenerate.to_bilin {M : matrix ι ι R₃} (h : M.nondegenerate)
+  (b : basis ι R₃ M₃) : (to_bilin b M).nondegenerate :=
+(matrix.nondegenerate_to_bilin'_iff_nondegenerate_to_bilin b).mp h.to_bilin'
+
+@[simp] lemma _root_.matrix.nondegenerate_to_bilin_iff {M : matrix ι ι R₃} (b : basis ι R₃ M₃) :
+  (to_bilin b M).nondegenerate ↔ M.nondegenerate :=
+by rw [←matrix.nondegenerate_to_bilin'_iff_nondegenerate_to_bilin,
+       matrix.nondegenerate_to_bilin'_iff]
+
+-- Lemmas transferring nondegeneracy between a bilinear form and its associated matrix
+
+@[simp] theorem nondegenerate_to_matrix'_iff {B : bilin_form R₃ (ι → R₃)} :
+  B.to_matrix'.nondegenerate ↔ B.nondegenerate :=
+matrix.nondegenerate_to_bilin'_iff.symm.trans $ (matrix.to_bilin'_to_matrix' B).symm ▸ iff.rfl
+
+theorem nondegenerate.to_matrix' {B : bilin_form R₃ (ι → R₃)} (h : B.nondegenerate) :
+  B.to_matrix'.nondegenerate :=
+nondegenerate_to_matrix'_iff.mpr h
+
+@[simp] theorem nondegenerate_to_matrix_iff {B : bilin_form R₃ M₃} (b : basis ι R₃ M₃) :
+  (to_matrix b B).nondegenerate ↔ B.nondegenerate :=
+(matrix.nondegenerate_to_bilin_iff b).symm.trans $ (matrix.to_bilin_to_matrix b B).symm ▸ iff.rfl
+
+theorem nondegenerate.to_matrix {B : bilin_form R₃ M₃} (h : B.nondegenerate)
+  (b : basis ι R₃ M₃) : (to_matrix b B).nondegenerate :=
+(nondegenerate_to_matrix_iff b).mpr h
+
+-- Some shorthands for combining the above with `matrix.nondegenerate_of_det_ne_zero`
+
+lemma nondegenerate_to_bilin'_iff_det_ne_zero {M : matrix ι ι A} :
+  M.to_bilin'.nondegenerate ↔ M.det ≠ 0 :=
+by rw [matrix.nondegenerate_to_bilin'_iff, matrix.nondegenerate_iff_det_ne_zero]
+
+theorem nondegenerate_to_bilin'_of_det_ne_zero' (M : matrix ι ι A) (h : M.det ≠ 0) :
+  M.to_bilin'.nondegenerate :=
+nondegenerate_to_bilin'_iff_det_ne_zero.mpr h
+
+lemma nondegenerate_iff_det_ne_zero {B : bilin_form A M₃}
+  (b : basis ι A M₃) : B.nondegenerate ↔ (to_matrix b B).det ≠ 0 :=
+by rw [←matrix.nondegenerate_iff_det_ne_zero, nondegenerate_to_matrix_iff]
+
+theorem nondegenerate_of_det_ne_zero (b : basis ι A M₃) (h : (to_matrix b B₃).det ≠ 0) :
+  B₃.nondegenerate :=
+(nondegenerate_iff_det_ne_zero b).mpr h
+-/
+end det
+
+end linear_map

--- a/src/linear_algebra/matrix/sesquilinear_form.lean
+++ b/src/linear_algebra/matrix/sesquilinear_form.lean
@@ -32,17 +32,13 @@ sesquilinear_form, matrix, basis
 
 -/
 
-variables {R R₁ R₂ M N n m o ι : Type*}
-
-section matrix
+variables {R R₁ R₂ M₁ M₂ n m o ι : Type*}
 
 open_locale big_operators
 open finset linear_map matrix
 open_locale matrix
 
-variables [fintype ι]
-
-section comm_semiring
+section aux_to_linear_map
 
 variables [comm_semiring R] [comm_semiring R₁] [comm_semiring R₂]
 variables [fintype n] [fintype m]
@@ -60,6 +56,19 @@ mk₂'ₛₗ σ₁ σ₂ (λ (v : n → R₁) (w : m → R₂), ∑ i j, σ₁ (
 
 variables [decidable_eq n] [decidable_eq m]
 
+@[simp] lemma std_basis_apply' (i i' : n) : (std_basis R₁ (λ (_x : n), R₁) i) 1 i' =
+  ite (i = i') 1 0  :=
+begin
+  rw [linear_map.std_basis_apply, function.update_apply, pi.zero_apply],
+  congr' 1, rw [eq_iff_iff, eq_comm],
+end
+
+@[simp] lemma ring_hom_ite_zero_one (p : Prop) [decidable p] : σ₁ (ite p 0 1) = ite p 0 1 :=
+by { split_ifs; simp [h] }
+
+@[simp] lemma ring_hom_ite_one_zero (p : Prop) [decidable p] : σ₁ (ite p 1 0) = ite p 1 0 :=
+by { split_ifs; simp [h] }
+
 lemma matrix.to_linear_map₂'_aux_std_basis (f : matrix n m R) (i : n) (j : m) :
   f.to_linear_map₂'_aux σ₁ σ₂ (std_basis R₁ (λ _, R₁) i 1) (std_basis R₂ (λ _, R₂) j 1) = f i j :=
 begin
@@ -69,26 +78,82 @@ begin
     simp_rw [mul_assoc, ←finset.mul_sum],
     simp only [boole_mul, finset.sum_ite_eq, finset.mem_univ, if_true, mul_comm (f _ _)],
   end,
-  have h₁ : ∀ i', ite (i = i') 1 0 = σ₁ ((std_basis R₁ (λ (_x : n), R₁) i) 1 i') :=
-  begin
-    sorry,
-  end,
-  have h₂ : ∀ j', ite (j = j') 1 0 = σ₂ ((std_basis R₂ (λ (_x : m), R₂) j) 1 j') :=
-  begin
-    sorry,
-  end,
   rw ←this,
-  exact finset.sum_congr rfl (λ _ _, finset.sum_congr rfl (λ _ _, by rw [h₁, h₂])),
+  exact finset.sum_congr rfl (λ _ _, finset.sum_congr rfl (λ _ _, by simp)),
 end
 
-section add_comm_monoid
+end aux_to_linear_map
 
-variables [add_comm_monoid M] [module R M]
+section aux_to_matrix
 
+section comm_semiring
 
+variables [comm_semiring R] [comm_semiring R₁] [comm_semiring R₂]
+variables [add_comm_monoid M₁] [module R₁ M₁] [add_comm_monoid M₂] [module R₂ M₂]
 
-end add_comm_monoid
+variables {σ₁ : R₁ →+* R} {σ₂ : R₂ →+* R}
+
+/-- The linear map from sesquilinear forms to `matrix n m R` given an `n`-indexed basis for `M₁`
+and an `m`-indexed basis for `M₂`.
+
+This is an auxiliary definition for the equivalence `matrix.to_linear_mapₛₗ₂'`. -/
+def linear_map.to_matrix₂_aux (b₁ : n → M₁) (b₂ : m → M₂) :
+  (M₁ →ₛₗ[σ₁] M₂ →ₛₗ[σ₂] R) →ₗ[R] matrix n m R :=
+{ to_fun := λ f, of $ λ i j, f (b₁ i) (b₂ j),
+  map_add' := λ f g, rfl,
+  map_smul' := λ f g, rfl }
+
+@[simp] lemma linear_map.to_matrix₂_aux_apply (f : M₁ →ₛₗ[σ₁] M₂ →ₛₗ[σ₂] R)
+  (b₁ : n → M₁) (b₂ : m → M₂) (i : n) (j : m) :
+  linear_map.to_matrix₂_aux b₁ b₂ f i j = f (b₁ i) (b₂ j) := rfl
 
 end comm_semiring
 
-end matrix
+section comm_ring
+
+variables [comm_ring R] [comm_ring R₁] [comm_ring R₂]
+variables [add_comm_monoid M₁] [module R₁ M₁] [add_comm_monoid M₂] [module R₂ M₂]
+variables [fintype n] [fintype m]
+variables [decidable_eq n] [decidable_eq m]
+
+variables {σ₁ : R₁ →+* R} {σ₂ : R₂ →+* R}
+
+lemma linear_map.to_linear_map₂'_aux_to_matrix₂_aux (f : (n → R₁) →ₛₗ[σ₁] (m → R₂) →ₛₗ[σ₂] R) :
+  matrix.to_linear_map₂'_aux σ₁ σ₂ (linear_map.to_matrix₂_aux
+    (λ i, std_basis R₁ (λ _, R₁) i 1) (λ j, std_basis R₂ (λ _, R₂) j 1) f) = f :=
+begin
+  refine ext_basis (pi.basis_fun R₁ n) (pi.basis_fun R₂ m) (λ i j, _),
+  simp_rw [pi.basis_fun_apply, matrix.to_linear_map₂'_aux_std_basis,
+    linear_map.to_matrix₂_aux_apply],
+end
+
+lemma matrix.to_matrix₂_aux_to_linear_map₂'_aux (f : matrix n m R) :
+  linear_map.to_matrix₂_aux (λ i, std_basis R₁ (λ _, R₁) i 1) (λ j, std_basis R₂ (λ _, R₂) j 1)
+    (f.to_linear_map₂'_aux σ₁ σ₂) = f :=
+by { ext i j, simp_rw [linear_map.to_matrix₂_aux_apply, matrix.to_linear_map₂'_aux_std_basis] }
+
+end comm_ring
+
+end aux_to_matrix
+
+section to_matrix'
+
+section comm_ring
+
+variables [comm_ring R] [comm_ring R₁] [comm_ring R₂]
+variables [add_comm_monoid M₁] [module R₁ M₁] [add_comm_monoid M₂] [module R₂ M₂]
+variables [fintype n] [fintype m]
+variables [decidable_eq n] [decidable_eq m]
+
+variables {σ₁ : R₁ →+* R} {σ₂ : R₂ →+* R}
+
+/-- The linear equivalence between bilinear forms on `n → R` and `n × n` matrices -/
+def linear_map.to_matrix₂' : ((n → R₁) →ₛₗ[σ₁] (m → R₂) →ₛₗ[σ₂] R) ≃ₗ[R] matrix n m R :=
+{ inv_fun := matrix.to_linear_map₂'_aux σ₁ σ₂,
+  left_inv := linear_map.to_linear_map₂'_aux_to_matrix₂_aux,
+  right_inv := matrix.to_matrix₂_aux_to_linear_map₂'_aux,
+  ..linear_map.to_matrix₂_aux (λ i, std_basis R₁ (λ _, R₁) i 1) (λ j, std_basis R₂ (λ _, R₂) j 1) }
+
+end comm_ring
+
+end to_matrix'

--- a/src/linear_algebra/matrix/sesquilinear_form.lean
+++ b/src/linear_algebra/matrix/sesquilinear_form.lean
@@ -1,0 +1,94 @@
+/-
+Copyright (c) 2020 Anne Baanen. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Anne Baanen, Kexing Ying, Moritz Doll
+-/
+
+import linear_algebra.matrix.basis
+import linear_algebra.matrix.nondegenerate
+import linear_algebra.matrix.nonsingular_inverse
+import linear_algebra.matrix.to_linear_equiv
+
+/-!
+# Sesquilinear form
+
+This file defines the conversion between sesquilinear forms and matrices.
+
+## Main definitions
+
+ * `matrix.to_linear_map₂` given a basis define a bilinear form
+ * `matrix.to_linear_map₂'` define the bilinear form on `n → R`
+ * `linear_map.to_matrix₂`: calculate the matrix coefficients of a bilinear form
+ * `linear_map.to_matrix₂'`: calculate the matrix coefficients of a bilinear form on `n → R`
+
+## Todos
+
+At the moment this is quite a literal port from `matrix.bilinear_form`. Everything should be
+generalized to fully semibilinear forms.
+
+## Tags
+
+sesquilinear_form, matrix, basis
+
+-/
+
+variables {R R₁ R₂ M N n m o ι : Type*}
+
+section matrix
+
+open_locale big_operators
+open finset linear_map matrix
+open_locale matrix
+
+variables [fintype ι]
+
+section comm_semiring
+
+variables [comm_semiring R] [comm_semiring R₁] [comm_semiring R₂]
+variables [fintype n] [fintype m]
+
+variables (σ₁ : R₁ →+* R) (σ₂ : R₂ →+* R)
+
+def matrix.to_linear_map₂'_aux  (f : matrix n m R) :
+  (n → R₁) →ₛₗ[σ₁] (m → R₂) →ₛₗ[σ₂] R :=
+mk₂'ₛₗ σ₁ σ₂ (λ (v : n → R₁) (w : m → R₂), ∑ i j, σ₁ (v i) * f i j * σ₂ (w j))
+  (λ _ _ _, by simp only [pi.add_apply, map_add, add_mul, sum_add_distrib] )
+  (λ _ _ _, by simp only [pi.smul_apply, smul_eq_mul, ring_hom.map_mul, mul_assoc, mul_sum] )
+  (λ _ _ _, by simp only [pi.add_apply, map_add, mul_add, sum_add_distrib] )
+  (λ _ _ _, by
+    simp only [pi.smul_apply, smul_eq_mul, ring_hom.map_mul, mul_assoc, mul_left_comm, mul_sum] )
+
+variables [decidable_eq n] [decidable_eq m]
+
+lemma matrix.to_linear_map₂'_aux_std_basis (f : matrix n m R) (i : n) (j : m) :
+  f.to_linear_map₂'_aux σ₁ σ₂ (std_basis R₁ (λ _, R₁) i 1) (std_basis R₂ (λ _, R₂) j 1) = f i j :=
+begin
+  rw [matrix.to_linear_map₂'_aux, mk₂'ₛₗ_apply],
+  have : (∑ i' j', (if i = i' then 1 else 0) * f i' j' * (if j = j' then 1 else 0)) = f i j :=
+  begin
+    simp_rw [mul_assoc, ←finset.mul_sum],
+    simp only [boole_mul, finset.sum_ite_eq, finset.mem_univ, if_true, mul_comm (f _ _)],
+  end,
+  have h₁ : ∀ i', ite (i = i') 1 0 = σ₁ ((std_basis R₁ (λ (_x : n), R₁) i) 1 i') :=
+  begin
+    sorry,
+  end,
+  have h₂ : ∀ j', ite (j = j') 1 0 = σ₂ ((std_basis R₂ (λ (_x : m), R₂) j) 1 j') :=
+  begin
+    sorry,
+  end,
+  rw ←this,
+  exact finset.sum_congr rfl (λ _ _, finset.sum_congr rfl (λ _ _, by rw [h₁, h₂])),
+end
+
+section add_comm_monoid
+
+variables [add_comm_monoid M] [module R M]
+
+
+
+end add_comm_monoid
+
+end comm_semiring
+
+end matrix

--- a/src/linear_algebra/matrix/sesquilinear_form.lean
+++ b/src/linear_algebra/matrix/sesquilinear_form.lean
@@ -216,6 +216,10 @@ linear_map.to_matrixₛₗ₂'.symm_symm
   linear_map.to_matrixₛₗ₂' (matrix.to_linear_mapₛₗ₂' σ₁ σ₂ M) = M :=
 linear_map.to_matrixₛₗ₂'.apply_symm_apply M
 
+@[simp] lemma linear_map.to_matrix'_to_linear_map₂' (M : matrix n m R) :
+  linear_map.to_matrix₂' (matrix.to_linear_map₂' M) = M :=
+linear_map.to_matrixₛₗ₂'.apply_symm_apply M
+
 @[simp] lemma linear_map.to_matrixₛₗ₂'_apply (B : (n → R₁) →ₛₗ[σ₁] (m → R₂) →ₛₗ[σ₂] R) (i : n)
   (j : m): linear_map.to_matrixₛₗ₂' B i j =
     B (std_basis R₁ (λ _, R₁) i 1) (std_basis R₂ (λ _, R₂) j 1) :=
@@ -228,7 +232,7 @@ rfl
 
 variables [fintype n'] [fintype m']
 variables [decidable_eq n'] [decidable_eq m']
-/-
+
 @[simp] lemma linear_map.to_matrix₂'_comp (B : (n → R) →ₗ[R] (m → R) →ₗ[R] R)
   (l : (n' → R) →ₗ[R] (n → R)) (r : (m' → R) →ₗ[R] (m → R)) :
   (B.compl₁₂ l r).to_matrix₂' = l.to_matrix'ᵀ ⬝ B.to_matrix₂' ⬝ r.to_matrix' :=
@@ -237,7 +241,8 @@ begin
   simp only [linear_map.to_matrix₂'_apply, linear_map.compl₁₂_apply, transpose_apply,
     matrix.mul_apply, linear_map.to_matrix', linear_equiv.coe_mk, sum_mul],
   rw sum_comm,
-  conv_lhs { rw ← linear_map.sum_repr_mul_repr_mul (pi.basis_fun R n) (l _) (r _) },
+  conv_lhs { rw ←linear_map.sum_repr_mul_repr_mul (pi.basis_fun R n) (pi.basis_fun R m)
+    (l _) (r _) },
   rw finsupp.sum_fintype,
   { apply sum_congr rfl,
     rintros i' -,
@@ -250,31 +255,29 @@ begin
   { intros, simp only [zero_smul, finsupp.sum_zero] }
 end
 
-lemma linear_map.to_matrix'_comp_left (B : bilin_form R₂ (n → R₂))
-  (f : (n → R₂) →ₗ[R₂] (n → R₂)) : (B.comp_left f).to_matrix' = f.to_matrix'ᵀ ⬝ B.to_matrix' :=
-by simp only [bilin_form.comp_left, bilin_form.to_matrix'_comp, to_matrix'_id, matrix.mul_one]
+lemma linear_map.to_matrix₂'_comp_left (B : (n → R) →ₗ[R] (m → R) →ₗ[R] R)
+  (f : (n' → R) →ₗ[R] (n → R)) : (B.comp f).to_matrix₂' = f.to_matrix'ᵀ ⬝ B.to_matrix₂' :=
+by { rw [←linear_map.compl₂_id (B.comp f), ←linear_map.compl₁₂], simp }
 
-lemma linear_map.to_matrix'_comp_right (B : bilin_form R₂ (n → R₂))
-  (f : (n → R₂) →ₗ[R₂] (n → R₂)) : (B.comp_right f).to_matrix' = B.to_matrix' ⬝ f.to_matrix' :=
-by simp only [bilin_form.comp_right, bilin_form.to_matrix'_comp, to_matrix'_id,
-              transpose_one, matrix.one_mul]
+lemma linear_map.to_matrix₂'_comp_right (B : (n → R) →ₗ[R] (m → R) →ₗ[R] R)
+  (f : (m' → R) →ₗ[R] (m → R)) : (B.compl₂ f).to_matrix₂' = B.to_matrix₂' ⬝ f.to_matrix' :=
+by { rw [←linear_map.comp_id B, ←linear_map.compl₁₂], simp }
 
-lemma linear_map.mul_to_matrix'_mul (B : bilin_form R₂ (n → R₂))
-  (M : matrix o n R₂) (N : matrix n o R₂) :
-  M ⬝ B.to_matrix' ⬝ N = (B.comp Mᵀ.to_lin' N.to_lin').to_matrix' :=
-by simp only [B.to_matrix'_comp, transpose_transpose, to_matrix'_to_lin']
+lemma linear_map.mul_to_matrix₂'_mul (B : (n → R) →ₗ[R] (m → R) →ₗ[R] R)
+  (M : matrix n' n R) (N : matrix m m' R) :
+  M ⬝ B.to_matrix₂' ⬝ N = (B.compl₁₂ Mᵀ.to_lin' N.to_lin').to_matrix₂' :=
+by simp
 
-lemma linear_map.mul_to_matrix' (B : bilin_form R₂ (n → R₂)) (M : matrix n n R₂) :
-  M ⬝ B.to_matrix' = (B.comp_left Mᵀ.to_lin').to_matrix' :=
-by simp only [B.to_matrix'_comp_left, transpose_transpose, to_matrix'_to_lin']
+lemma linear_map.mul_to_matrix' (B : (n → R) →ₗ[R] (m → R) →ₗ[R] R) (M : matrix n' n R) :
+  M ⬝ B.to_matrix₂' = (B.comp Mᵀ.to_lin').to_matrix₂' :=
+by simp only [B.to_matrix₂'_comp_left, transpose_transpose, to_matrix'_to_lin']
 
-lemma linear_map.to_matrix'_mul (B : bilin_form R₂ (n → R₂)) (M : matrix n n R₂) :
-  B.to_matrix' ⬝ M = (B.comp_right M.to_lin').to_matrix' :=
-by simp only [B.to_matrix'_comp_right, to_matrix'_to_lin']
+lemma linear_map.to_matrix₂'_mul (B : (n → R) →ₗ[R] (m → R) →ₗ[R] R) (M : matrix m m' R) :
+  B.to_matrix₂' ⬝ M = (B.compl₂ M.to_lin').to_matrix₂' :=
+by simp only [B.to_matrix₂'_comp_right, to_matrix'_to_lin']
 
-lemma matrix.to_bilin'_comp (M : matrix n n R₂) (P Q : matrix n o R₂) :
-  M.to_bilin'.comp P.to_lin' Q.to_lin' = (Pᵀ ⬝ M ⬝ Q).to_bilin' :=
-linear_map.to_matrix'.injective
-  (by simp only [bilin_form.to_matrix'_comp, bilin_form.to_matrix'_to_bilin', to_matrix'_to_lin'])
--/
+lemma matrix.to_bilin'_comp (M : matrix n m R) (P : matrix n n' R) (Q : matrix m m' R) :
+  M.to_linear_map₂'.compl₁₂ P.to_lin' Q.to_lin' = (Pᵀ ⬝ M ⬝ Q).to_linear_map₂' :=
+linear_map.to_matrix₂'.injective (by simp)
+
 end to_matrix'

--- a/src/linear_algebra/matrix/sesquilinear_form.lean
+++ b/src/linear_algebra/matrix/sesquilinear_form.lean
@@ -304,7 +304,8 @@ variables (b₁ : basis n R M₁) (b₂ : basis m R M₂)
 /-- `linear_map.to_matrix₂ b₁ b₂` is the equivalence between `R`-bilinear forms on `M` and
 `n`-by-`n` matrices with entries in `R`, if `b` is an `R`-basis for `M`. -/
 noncomputable def linear_map.to_matrix₂ : (M₁ →ₗ[R] M₂ →ₗ[R] R) ≃ₗ[R] matrix n m R :=
-(b₁.equiv_fun.arrow_congr (b₂.equiv_fun.arrow_congr (linear_equiv.refl R R))).trans linear_map.to_matrix₂'
+(b₁.equiv_fun.arrow_congr (b₂.equiv_fun.arrow_congr (linear_equiv.refl R R))).trans
+  linear_map.to_matrix₂'
 
 /-- `bilin_form.to_matrix b` is the equivalence between `R`-bilinear forms on `M` and
 `n`-by-`n` matrices with entries in `R`, if `b` is an `R`-basis for `M`. -/

--- a/src/linear_algebra/matrix/sesquilinear_form.lean
+++ b/src/linear_algebra/matrix/sesquilinear_form.lean
@@ -325,52 +325,55 @@ begin
   simp [matrix.to_linear_map₂'_apply],
 end
 
-/-
--- Not a `simp` lemma since `bilin_form.to_matrix` needs an extra argument
-lemma bilinear_form.to_matrix_aux_eq (B : bilin_form R₂ M₂) :
-  bilin_form.to_matrix_aux b B = bilin_form.to_matrix b B :=
-ext (λ i j, by rw [bilin_form.to_matrix_apply, bilin_form.to_matrix_aux_apply])
+-- Not a `simp` lemma since `linear_map.to_matrix₂` needs an extra argument
+lemma linear_map.to_matrix₂_aux_eq (B : M₁ →ₗ[R] M₂ →ₗ[R] R) :
+  linear_map.to_matrix₂_aux b₁ b₂ B = linear_map.to_matrix₂ b₁ b₂ B :=
+ext (λ i j, by rw [linear_map.to_matrix₂_apply, linear_map.to_matrix₂_aux_apply])
 
-@[simp] lemma bilin_form.to_matrix_symm :
-  (bilin_form.to_matrix b).symm = matrix.to_bilin b :=
+@[simp] lemma linear_map.to_matrix₂_symm :
+  (linear_map.to_matrix₂ b₁ b₂).symm = matrix.to_linear_map₂ b₁ b₂ :=
 rfl
 
-@[simp] lemma matrix.to_bilin_symm :
-  (matrix.to_bilin b).symm = bilin_form.to_matrix b :=
-(bilin_form.to_matrix b).symm_symm
+@[simp] lemma matrix.to_linear_map₂_symm :
+  (matrix.to_linear_map₂ b₁ b₂).symm = linear_map.to_matrix₂ b₁ b₂ :=
+(linear_map.to_matrix₂ b₁ b₂).symm_symm
 
-lemma matrix.to_bilin_basis_fun :
-  matrix.to_bilin (pi.basis_fun R₂ n) = matrix.to_bilin' :=
-by { ext M, simp only [matrix.to_bilin_apply, matrix.to_bilin'_apply, pi.basis_fun_repr] }
+lemma matrix.to_linear_map₂_basis_fun :
+  matrix.to_linear_map₂ (pi.basis_fun R n) (pi.basis_fun R m) = matrix.to_linear_map₂' :=
+by { ext M, simp only [matrix.to_linear_map₂_apply, matrix.to_linear_map₂'_apply, pi.basis_fun_repr,
+  coe_comp, function.comp_app]}
 
-lemma bilin_form.to_matrix_basis_fun :
-  bilin_form.to_matrix (pi.basis_fun R₂ n) = bilin_form.to_matrix' :=
-by { ext B, rw [bilin_form.to_matrix_apply, bilin_form.to_matrix'_apply,
+lemma linear_map.to_matrix₂_basis_fun :
+  linear_map.to_matrix₂ (pi.basis_fun R n) (pi.basis_fun R m) = linear_map.to_matrix₂' :=
+by { ext B, rw [linear_map.to_matrix₂_apply, linear_map.to_matrix₂'_apply,
                 pi.basis_fun_apply, pi.basis_fun_apply] }
 
-@[simp] lemma matrix.to_bilin_to_matrix (B : bilin_form R₂ M₂) :
-  matrix.to_bilin b (bilin_form.to_matrix b B) = B :=
-(matrix.to_bilin b).apply_symm_apply B
+@[simp] lemma matrix.to_linear_map₂_to_matrix₂ (B : M₁ →ₗ[R] M₂ →ₗ[R] R) :
+  matrix.to_linear_map₂ b₁ b₂ (linear_map.to_matrix₂ b₁ b₂ B) = B :=
+(matrix.to_linear_map₂ b₁ b₂).apply_symm_apply B
 
-@[simp] lemma bilin_form.to_matrix_to_bilin (M : matrix n n R₂) :
-  bilin_form.to_matrix b (matrix.to_bilin b M) = M :=
-(bilin_form.to_matrix b).apply_symm_apply M
+@[simp] lemma linear_map.to_matrix₂_to_linear_map₂ (M : matrix n m R) :
+  linear_map.to_matrix₂ b₁ b₂ (matrix.to_linear_map₂ b₁ b₂ M) = M :=
+(linear_map.to_matrix₂ b₁ b₂).apply_symm_apply M
 
-variables {M₂' : Type*} [add_comm_monoid M₂'] [module R₂ M₂']
-variables (c : basis o R₂ M₂')
-variables [decidable_eq o]
+variables [add_comm_monoid M₁'] [module R M₁']
+variables [add_comm_monoid M₂'] [module R M₂']
+variables (b₁' : basis n' R M₁')
+variables (b₂' : basis m' R M₂')
+variables [fintype n'] [fintype m']
+variables [decidable_eq n'] [decidable_eq m']
 
--- Cannot be a `simp` lemma because `b` must be inferred.
-lemma bilin_form.to_matrix_comp
-  (B : bilin_form R₂ M₂) (l r : M₂' →ₗ[R₂] M₂) :
-  bilin_form.to_matrix c (B.comp l r) =
-    (to_matrix c b l)ᵀ ⬝ bilin_form.to_matrix b B ⬝ to_matrix c b r :=
+-- Cannot be a `simp` lemma because `b₁` and `b₂` must be inferred.
+lemma linear_map.to_matrix₂_comp
+  (B : M₁ →ₗ[R] M₂ →ₗ[R] R) (l : M₁' →ₗ[R] M₁) (r : M₂' →ₗ[R] M₂) :
+  linear_map.to_matrix₂ b₁' b₂' (B.compl₁₂ l r) =
+    (to_matrix b₁' b₁ l)ᵀ ⬝ linear_map.to_matrix₂ b₁ b₂ B ⬝ to_matrix b₂' b₂ r :=
 begin
   ext i j,
-  simp only [bilin_form.to_matrix_apply, bilin_form.comp_apply, transpose_apply, matrix.mul_apply,
-    linear_map.to_matrix', linear_equiv.coe_mk, sum_mul],
+  simp only [linear_map.to_matrix₂_apply, compl₁₂_apply, transpose_apply, matrix.mul_apply,
+    linear_map.to_matrix_apply, linear_equiv.coe_mk, sum_mul],
   rw sum_comm,
-  conv_lhs { rw ← bilin_form.sum_repr_mul_repr_mul b },
+  conv_lhs { rw ←linear_map.sum_repr_mul_repr_mul b₁ b₂ },
   rw finsupp.sum_fintype,
   { apply sum_congr rfl,
     rintros i' -,
@@ -383,21 +386,31 @@ begin
   { intros, simp only [zero_smul, finsupp.sum_zero] }
 end
 
-lemma bilin_form.to_matrix_comp_left (B : bilin_form R₂ M₂) (f : M₂ →ₗ[R₂] M₂) :
-  bilin_form.to_matrix b (B.comp_left f) = (to_matrix b b f)ᵀ ⬝ bilin_form.to_matrix b B :=
-by simp only [comp_left, bilin_form.to_matrix_comp b b, to_matrix_id, matrix.mul_one]
+lemma linear_map.to_matrix₂_comp_left (B : M₁ →ₗ[R] M₂ →ₗ[R] R) (f : M₁' →ₗ[R] M₁) :
+  linear_map.to_matrix₂ b₁' b₂ (B.comp f) = (to_matrix b₁' b₁ f)ᵀ ⬝ linear_map.to_matrix₂ b₁ b₂ B :=
+begin
+  rw [←linear_map.compl₂_id (B.comp f), ←linear_map.compl₁₂, linear_map.to_matrix₂_comp b₁ b₂],
+  simp,
+end
 
-lemma bilin_form.to_matrix_comp_right (B : bilin_form R₂ M₂) (f : M₂ →ₗ[R₂] M₂) :
-  bilin_form.to_matrix b (B.comp_right f) = bilin_form.to_matrix b B ⬝ (to_matrix b b f) :=
-by simp only [bilin_form.comp_right, bilin_form.to_matrix_comp b b, to_matrix_id,
-              transpose_one, matrix.one_mul]
+lemma linear_map.to_matrix₂_comp_right (B : M₁ →ₗ[R] M₂ →ₗ[R] R) (f : M₂' →ₗ[R] M₂) :
+  linear_map.to_matrix₂ b₁ b₂' (B.compl₂ f) = linear_map.to_matrix₂ b₁ b₂ B ⬝ (to_matrix b₂' b₂ f) :=
+by { rw [←linear_map.comp_id B, ←linear_map.compl₁₂, linear_map.to_matrix₂_comp b₁ b₂], simp }
 
 @[simp]
-lemma bilin_form.to_matrix_mul_basis_to_matrix (c : basis o R₂ M₂) (B : bilin_form R₂ M₂) :
-  (b.to_matrix c)ᵀ ⬝ bilin_form.to_matrix b B ⬝ b.to_matrix c = bilin_form.to_matrix c B :=
-by rw [← linear_map.to_matrix_id_eq_basis_to_matrix, ← bilin_form.to_matrix_comp,
-       bilin_form.comp_id_id]
+lemma bilin_form.to_matrix_mul_basis_to_matrix (c₁ : basis n' R M₁) (c₂ : basis m' R M₂)
+  (B : M₁ →ₗ[R] M₂ →ₗ[R] R) : (b₁.to_matrix c₁)ᵀ ⬝ linear_map.to_matrix₂ b₁ b₂ B ⬝ b₂.to_matrix c₂ =
+  linear_map.to_matrix₂ c₁ c₂ B :=
+begin
+  rw ←linear_map.to_matrix_id_eq_basis_to_matrix,
+  rw ←linear_map.to_matrix_id_eq_basis_to_matrix,
+  rw ←linear_map.to_matrix₂_comp,
+  rw linear_map.compl₁₂_id_id,
+end
+--by rw [← linear_map.to_matrix_id_eq_basis_to_matrix, ←linear_map.to_matrix₂_comp,
+--       bilin_form.comp_id_id]
 
+/-
 lemma bilin_form.mul_to_matrix_mul (B : bilin_form R₂ M₂)
   (M : matrix o n R₂) (N : matrix n o R₂) :
   M ⬝ bilin_form.to_matrix b B ⬝ N =

--- a/src/linear_algebra/matrix/sesquilinear_form.lean
+++ b/src/linear_algebra/matrix/sesquilinear_form.lean
@@ -232,7 +232,7 @@ rfl
 variables [fintype n'] [fintype m']
 variables [decidable_eq n'] [decidable_eq m']
 
-@[simp] lemma linear_map.to_matrix₂'_comp (B : (n → R) →ₗ[R] (m → R) →ₗ[R] R)
+@[simp] lemma linear_map.to_matrix₂'_compl₁₂ (B : (n → R) →ₗ[R] (m → R) →ₗ[R] R)
   (l : (n' → R) →ₗ[R] (n → R)) (r : (m' → R) →ₗ[R] (m → R)) :
   (B.compl₁₂ l r).to_matrix₂' = l.to_matrix'ᵀ ⬝ B.to_matrix₂' ⬝ r.to_matrix' :=
 begin
@@ -254,11 +254,11 @@ begin
   { intros, simp only [zero_smul, finsupp.sum_zero] }
 end
 
-lemma linear_map.to_matrix₂'_comp_left (B : (n → R) →ₗ[R] (m → R) →ₗ[R] R)
+lemma linear_map.to_matrix₂'_comp (B : (n → R) →ₗ[R] (m → R) →ₗ[R] R)
   (f : (n' → R) →ₗ[R] (n → R)) : (B.comp f).to_matrix₂' = f.to_matrix'ᵀ ⬝ B.to_matrix₂' :=
 by { rw [←linear_map.compl₂_id (B.comp f), ←linear_map.compl₁₂], simp }
 
-lemma linear_map.to_matrix₂'_comp_right (B : (n → R) →ₗ[R] (m → R) →ₗ[R] R)
+lemma linear_map.to_matrix₂'_compl₂ (B : (n → R) →ₗ[R] (m → R) →ₗ[R] R)
   (f : (m' → R) →ₗ[R] (m → R)) : (B.compl₂ f).to_matrix₂' = B.to_matrix₂' ⬝ f.to_matrix' :=
 by { rw [←linear_map.comp_id B, ←linear_map.compl₁₂], simp }
 
@@ -269,11 +269,11 @@ by simp
 
 lemma linear_map.mul_to_matrix' (B : (n → R) →ₗ[R] (m → R) →ₗ[R] R) (M : matrix n' n R) :
   M ⬝ B.to_matrix₂' = (B.comp Mᵀ.to_lin').to_matrix₂' :=
-by simp only [B.to_matrix₂'_comp_left, transpose_transpose, to_matrix'_to_lin']
+by simp only [B.to_matrix₂'_comp, transpose_transpose, to_matrix'_to_lin']
 
 lemma linear_map.to_matrix₂'_mul (B : (n → R) →ₗ[R] (m → R) →ₗ[R] R) (M : matrix m m' R) :
   B.to_matrix₂' ⬝ M = (B.compl₂ M.to_lin').to_matrix₂' :=
-by simp only [B.to_matrix₂'_comp_right, to_matrix'_to_lin']
+by simp only [B.to_matrix₂'_compl₂, to_matrix'_to_lin']
 
 lemma matrix.to_linear_map₂'_comp (M : matrix n m R) (P : matrix n n' R) (Q : matrix m m' R) :
   M.to_linear_map₂'.compl₁₂ P.to_lin' Q.to_lin' = (Pᵀ ⬝ M ⬝ Q).to_linear_map₂' :=
@@ -364,7 +364,7 @@ variables [fintype n'] [fintype m']
 variables [decidable_eq n'] [decidable_eq m']
 
 -- Cannot be a `simp` lemma because `b₁` and `b₂` must be inferred.
-lemma linear_map.to_matrix₂_comp
+lemma linear_map.to_matrix₂_compl₁₂
   (B : M₁ →ₗ[R] M₂ →ₗ[R] R) (l : M₁' →ₗ[R] M₁) (r : M₂' →ₗ[R] M₂) :
   linear_map.to_matrix₂ b₁' b₂' (B.compl₁₂ l r) =
     (to_matrix b₁' b₁ l)ᵀ ⬝ linear_map.to_matrix₂ b₁ b₂ B ⬝ to_matrix b₂' b₂ r :=
@@ -386,50 +386,47 @@ begin
   { intros, simp only [zero_smul, finsupp.sum_zero] }
 end
 
-lemma linear_map.to_matrix₂_comp_left (B : M₁ →ₗ[R] M₂ →ₗ[R] R) (f : M₁' →ₗ[R] M₁) :
+lemma linear_map.to_matrix₂_comp (B : M₁ →ₗ[R] M₂ →ₗ[R] R) (f : M₁' →ₗ[R] M₁) :
   linear_map.to_matrix₂ b₁' b₂ (B.comp f) = (to_matrix b₁' b₁ f)ᵀ ⬝ linear_map.to_matrix₂ b₁ b₂ B :=
 begin
-  rw [←linear_map.compl₂_id (B.comp f), ←linear_map.compl₁₂, linear_map.to_matrix₂_comp b₁ b₂],
+  rw [←linear_map.compl₂_id (B.comp f), ←linear_map.compl₁₂, linear_map.to_matrix₂_compl₁₂ b₁ b₂],
   simp,
 end
 
-lemma linear_map.to_matrix₂_comp_right (B : M₁ →ₗ[R] M₂ →ₗ[R] R) (f : M₂' →ₗ[R] M₂) :
+lemma linear_map.to_matrix₂_compl₂ (B : M₁ →ₗ[R] M₂ →ₗ[R] R) (f : M₂' →ₗ[R] M₂) :
   linear_map.to_matrix₂ b₁ b₂' (B.compl₂ f) = linear_map.to_matrix₂ b₁ b₂ B ⬝ (to_matrix b₂' b₂ f) :=
-by { rw [←linear_map.comp_id B, ←linear_map.compl₁₂, linear_map.to_matrix₂_comp b₁ b₂], simp }
+by { rw [←linear_map.comp_id B, ←linear_map.compl₁₂, linear_map.to_matrix₂_compl₁₂ b₁ b₂], simp }
 
 @[simp]
 lemma bilin_form.to_matrix_mul_basis_to_matrix (c₁ : basis n' R M₁) (c₂ : basis m' R M₂)
   (B : M₁ →ₗ[R] M₂ →ₗ[R] R) : (b₁.to_matrix c₁)ᵀ ⬝ linear_map.to_matrix₂ b₁ b₂ B ⬝ b₂.to_matrix c₂ =
   linear_map.to_matrix₂ c₁ c₂ B :=
 begin
-  rw ←linear_map.to_matrix_id_eq_basis_to_matrix,
-  rw ←linear_map.to_matrix_id_eq_basis_to_matrix,
-  rw ←linear_map.to_matrix₂_comp,
-  rw linear_map.compl₁₂_id_id,
+  simp_rw ←linear_map.to_matrix_id_eq_basis_to_matrix,
+  rw [←linear_map.to_matrix₂_compl₁₂, linear_map.compl₁₂_id_id],
 end
---by rw [← linear_map.to_matrix_id_eq_basis_to_matrix, ←linear_map.to_matrix₂_comp,
---       bilin_form.comp_id_id]
 
-/-
-lemma bilin_form.mul_to_matrix_mul (B : bilin_form R₂ M₂)
-  (M : matrix o n R₂) (N : matrix n o R₂) :
-  M ⬝ bilin_form.to_matrix b B ⬝ N =
-    bilin_form.to_matrix c (B.comp (to_lin c b Mᵀ) (to_lin c b N)) :=
-by simp only [B.to_matrix_comp b c, to_matrix_to_lin, transpose_transpose]
+lemma bilin_form.mul_to_matrix_mul (B : M₁ →ₗ[R] M₂ →ₗ[R] R)
+  (M : matrix n' n R) (N : matrix m m' R) :
+  M ⬝ linear_map.to_matrix₂ b₁ b₂ B ⬝ N =
+    linear_map.to_matrix₂ b₁' b₂' (B.compl₁₂ (to_lin b₁' b₁ Mᵀ) (to_lin b₂' b₂ N)) :=
+by simp_rw [linear_map.to_matrix₂_compl₁₂ b₁ b₂, to_matrix_to_lin, transpose_transpose]
 
-lemma bilin_form.mul_to_matrix (B : bilin_form R₂ M₂) (M : matrix n n R₂) :
-  M ⬝ bilin_form.to_matrix b B =
-    bilin_form.to_matrix b (B.comp_left (to_lin b b Mᵀ)) :=
-by rw [B.to_matrix_comp_left b, to_matrix_to_lin, transpose_transpose]
+lemma bilin_form.mul_to_matrix (B : M₁ →ₗ[R] M₂ →ₗ[R] R) (M : matrix n' n R) :
+  M ⬝ linear_map.to_matrix₂ b₁ b₂ B =
+    linear_map.to_matrix₂ b₁' b₂ (B.comp (to_lin b₁' b₁ Mᵀ)) :=
+by rw [linear_map.to_matrix₂_comp b₁, to_matrix_to_lin, transpose_transpose]
 
-lemma bilin_form.to_matrix_mul (B : bilin_form R₂ M₂) (M : matrix n n R₂) :
-  bilin_form.to_matrix b B ⬝ M =
-    bilin_form.to_matrix b (B.comp_right (to_lin b b M)) :=
-by rw [B.to_matrix_comp_right b, to_matrix_to_lin]
+lemma bilin_form.to_matrix_mul (B : M₁ →ₗ[R] M₂ →ₗ[R] R) (M : matrix m m' R) :
+  linear_map.to_matrix₂ b₁ b₂ B ⬝ M =
+    linear_map.to_matrix₂ b₁ b₂' (B.compl₂ (to_lin b₂' b₂ M)) :=
+by rw [linear_map.to_matrix₂_compl₂ b₁, to_matrix_to_lin]
 
-lemma matrix.to_bilin_comp (M : matrix n n R₂) (P Q : matrix n o R₂) :
-  (matrix.to_bilin b M).comp (to_lin c b P) (to_lin c b Q) = matrix.to_bilin c (Pᵀ ⬝ M ⬝ Q) :=
-(bilin_form.to_matrix c).injective
-  (by simp only [bilin_form.to_matrix_comp b c, bilin_form.to_matrix_to_bilin, to_matrix_to_lin])
--/
+lemma matrix.to_bilin_comp (M : matrix n m R) (P : matrix n n' R) (Q : matrix m m' R) :
+  (matrix.to_linear_map₂ b₁ b₂ M).compl₁₂ (to_lin b₁' b₁ P) (to_lin b₂' b₂ Q) =
+  matrix.to_linear_map₂ b₁' b₂' (Pᵀ ⬝ M ⬝ Q) :=
+(linear_map.to_matrix₂ b₁' b₂').injective
+  (by simp only [linear_map.to_matrix₂_compl₁₂ b₁ b₂, linear_map.to_matrix₂_to_linear_map₂,
+    to_matrix_to_lin])
+
 end to_matrix

--- a/src/linear_algebra/matrix/sesquilinear_form.lean
+++ b/src/linear_algebra/matrix/sesquilinear_form.lean
@@ -167,7 +167,7 @@ linear_map.to_matrixₛₗ₂'.symm
 
 /-- The linear equivalence between `n × n` matrices and bilinear forms on `n → R` -/
 def matrix.to_linear_map₂' : matrix n m R ≃ₗ[R] ((n → R) →ₗ[R] (m → R) →ₗ[R] R) :=
-linear_map.to_matrixₛₗ₂'.symm
+linear_map.to_matrix₂'.symm
 
 lemma matrix.to_linear_mapₛₗ₂'_aux_eq (M : matrix n m R) :
   matrix.to_linear_map₂'_aux σ₁ σ₂ M = matrix.to_linear_mapₛₗ₂' σ₁ σ₂ M := rfl
@@ -303,34 +303,29 @@ noncomputable def linear_map.to_matrix₂ : (M₁ →ₗ[R] M₂ →ₗ[R] R) �
 
 /-- `bilin_form.to_matrix b` is the equivalence between `R`-bilinear forms on `M` and
 `n`-by-`n` matrices with entries in `R`, if `b` is an `R`-basis for `M`. -/
-noncomputable def matrix.to_bilin : matrix n m R ≃ₗ[R] (M₁ →ₗ[R] M₂ →ₗ[R] R) :=
+noncomputable def matrix.to_linear_map₂ : matrix n m R ≃ₗ[R] (M₁ →ₗ[R] M₂ →ₗ[R] R) :=
 (linear_map.to_matrix₂ b₁ b₂).symm
 
-/-@[simp] lemma basis.equiv_fun_symm_std_basis (i : n) :
-  b.equiv_fun.symm (std_basis R₂ (λ _, R₂) i 1) = b i :=
-begin
-  rw [b.equiv_fun_symm_apply, finset.sum_eq_single i],
-  { rw [std_basis_same, one_smul] },
-  { rintros j - hj,
-    rw [std_basis_ne _ _ _ _ hj, zero_smul] },
-  { intro,
-    have := mem_univ i,
-    contradiction }
-end-/
+@[simp] lemma linear_equiv_one_apply (x : M₁): (1 : M₁ ≃ₗ[R] M₁) x = x := rfl
 
-@[simp] lemma bilin_form.to_matrix_apply (B : bilin_form R₂ M₂) (i j : n) :
-  bilin_form.to_matrix b B i j = B (b i) (b j) :=
-by rw [bilin_form.to_matrix, linear_equiv.trans_apply, bilin_form.to_matrix'_apply, congr_apply,
-       b.equiv_fun_symm_std_basis, b.equiv_fun_symm_std_basis]
-/-
-@[simp] lemma matrix.to_bilin_apply (M : matrix n n R₂) (x y : M₂) :
-  matrix.to_bilin b M x y = ∑ i j, b.repr x i * M i j * b.repr y j :=
+@[simp] lemma linear_equiv_one_symm : (1 : M₁ ≃ₗ[R] M₁).symm = (1 : M₁ ≃ₗ[R] M₁) := rfl
+
+-- We make this and not `linear_map.to_matrix₂` a `simp` lemma to avoid timeouts
+@[simp] lemma linear_map.to_matrix₂_apply (B : M₁ →ₗ[R] M₂ →ₗ[R] R) (i : n) (j : m) :
+  linear_map.to_matrix₂ b₁ b₂ B i j = B (b₁ i) (b₂ j) :=
+by simp only [linear_map.to_matrix₂, linear_equiv.trans_apply, linear_map.to_matrix₂'_apply,
+  linear_equiv.trans_apply, linear_map.to_matrix₂'_apply, linear_equiv.arrow_congr_apply,
+  basis.equiv_fun_symm_std_basis, linear_equiv_one_apply]
+
+@[simp] lemma matrix.to_linear_map₂_apply (M : matrix n m R) (x : M₁) (y : M₂) :
+  matrix.to_linear_map₂ b₁ b₂ M x y = ∑ i j, b₁.repr x i * M i j * b₂.repr y j :=
 begin
-  rw [matrix.to_bilin, bilin_form.to_matrix, linear_equiv.symm_trans_apply, ← matrix.to_bilin'],
-  simp only [congr_symm, congr_apply, linear_equiv.symm_symm, matrix.to_bilin'_apply,
-    basis.equiv_fun_apply]
+  rw [matrix.to_linear_map₂, linear_map.to_matrix₂, linear_equiv.symm_trans_apply,
+    ←matrix.to_linear_map₂'],
+  simp [matrix.to_linear_map₂'_apply],
 end
 
+/-
 -- Not a `simp` lemma since `bilin_form.to_matrix` needs an extra argument
 lemma bilinear_form.to_matrix_aux_eq (B : bilin_form R₂ M₂) :
   bilin_form.to_matrix_aux b B = bilin_form.to_matrix b B :=
@@ -423,6 +418,5 @@ lemma matrix.to_bilin_comp (M : matrix n n R₂) (P Q : matrix n o R₂) :
   (matrix.to_bilin b M).comp (to_lin c b P) (to_lin c b Q) = matrix.to_bilin c (Pᵀ ⬝ M ⬝ Q) :=
 (bilin_form.to_matrix c).injective
   (by simp only [bilin_form.to_matrix_comp b c, bilin_form.to_matrix_to_bilin, to_matrix_to_lin])
-
-end to_matrix
 -/
+end to_matrix

--- a/src/linear_algebra/matrix/sesquilinear_form.lean
+++ b/src/linear_algebra/matrix/sesquilinear_form.lean
@@ -300,23 +300,19 @@ variables (b₁ : basis n R M₁) (b₂ : basis m R M₂)
 /-- `linear_map.to_matrix₂ b₁ b₂` is the equivalence between `R`-bilinear forms on `M` and
 `n`-by-`n` matrices with entries in `R`, if `b` is an `R`-basis for `M`. -/
 noncomputable def linear_map.to_matrix₂ : (M₁ →ₗ[R] M₂ →ₗ[R] R) ≃ₗ[R] matrix n m R :=
-(b₁.equiv_fun.arrow_congr (b₂.equiv_fun.arrow_congr (1 : R ≃ₗ[R] R))).trans linear_map.to_matrix₂'
+(b₁.equiv_fun.arrow_congr (b₂.equiv_fun.arrow_congr (linear_equiv.refl R R))).trans linear_map.to_matrix₂'
 
 /-- `bilin_form.to_matrix b` is the equivalence between `R`-bilinear forms on `M` and
 `n`-by-`n` matrices with entries in `R`, if `b` is an `R`-basis for `M`. -/
 noncomputable def matrix.to_linear_map₂ : matrix n m R ≃ₗ[R] (M₁ →ₗ[R] M₂ →ₗ[R] R) :=
 (linear_map.to_matrix₂ b₁ b₂).symm
 
-@[simp] lemma linear_equiv_one_apply (x : M₁): (1 : M₁ ≃ₗ[R] M₁) x = x := rfl
-
-@[simp] lemma linear_equiv_one_symm : (1 : M₁ ≃ₗ[R] M₁).symm = (1 : M₁ ≃ₗ[R] M₁) := rfl
-
 -- We make this and not `linear_map.to_matrix₂` a `simp` lemma to avoid timeouts
 @[simp] lemma linear_map.to_matrix₂_apply (B : M₁ →ₗ[R] M₂ →ₗ[R] R) (i : n) (j : m) :
   linear_map.to_matrix₂ b₁ b₂ B i j = B (b₁ i) (b₂ j) :=
 by simp only [linear_map.to_matrix₂, linear_equiv.trans_apply, linear_map.to_matrix₂'_apply,
   linear_equiv.trans_apply, linear_map.to_matrix₂'_apply, linear_equiv.arrow_congr_apply,
-  basis.equiv_fun_symm_std_basis, linear_equiv_one_apply]
+  basis.equiv_fun_symm_std_basis, linear_equiv.refl_apply]
 
 @[simp] lemma matrix.to_linear_map₂_apply (M : matrix n m R) (x : M₁) (y : M₂) :
   matrix.to_linear_map₂ b₁ b₂ M x y = ∑ i j, b₁.repr x i * M i j * b₂.repr y j :=
@@ -573,25 +569,26 @@ open matrix
 variables [comm_ring R₁] [add_comm_monoid M₁] [module R₁ M₁]
 variables [decidable_eq ι] [fintype ι]
 
-lemma _root_.matrix.nondegenerate_to_bilin'_iff_nondegenerate_to_bilin {M : matrix ι ι R₁}
-  (b : basis ι R₁ M₁) : M.to_linear_map₂'.nondegenerate ↔
-  (matrix.to_linear_map₂ b b M).nondegenerate := sorry
---(nondegenerate_congr_iff b.equiv_fun.symm).symm
+lemma _root_.matrix.separating_left_to_linear_map₂'_iff_separating_left_to_linear_map₂
+  {M : matrix ι ι R₁} (b : basis ι R₁ M₁) : M.to_linear_map₂'.separating_left ↔
+  (matrix.to_linear_map₂ b b M).separating_left :=
+(separating_left_congr_iff b.equiv_fun.symm b.equiv_fun.symm).symm
 
 variables (B : M₁ →ₗ[R₁] M₁ →ₗ[R₁] R₁)
 variables [is_domain R₁]
 
 -- Lemmas transferring nondegeneracy between a matrix and its associated bilinear form
 
-theorem _root_.matrix.nondegenerate.to_bilin' {M : matrix ι ι R₁} (h : M.nondegenerate) :
-  M.to_linear_map₂'.nondegenerate :=
-λ x hx, h.eq_zero_of_ortho $ λ y, by simpa only [to_bilin'_apply'] using hx y
+theorem _root_.matrix.nondegenerate.to_linear_map₂' {M : matrix ι ι R₁} (h : M.nondegenerate) :
+  M.to_linear_map₂'.separating_left :=
+λ x hx, h.eq_zero_of_ortho $ λ y, by simpa only [to_linear_map₂'_apply'] using hx y
+
+@[simp] lemma _root_.matrix.nondegenerate_to_linear_map₂'_iff {M : matrix ι ι R₁} :
+  M.to_linear_map₂'.separating_left ↔ M.nondegenerate :=
+⟨λ h v hv, h v $ λ w, (M.to_linear_map₂'_apply' _ _).trans $ hv w,
+  matrix.nondegenerate.to_linear_map₂'⟩
 
 /-
-@[simp] lemma _root_.matrix.nondegenerate_to_bilin'_iff {M : matrix ι ι R₃} :
-  M.to_bilin'.nondegenerate ↔ M.nondegenerate :=
-⟨λ h v hv, h v $ λ w, (M.to_bilin'_apply' _ _).trans $ hv w, matrix.nondegenerate.to_bilin'⟩
-
 theorem _root_.matrix.nondegenerate.to_bilin {M : matrix ι ι R₃} (h : M.nondegenerate)
   (b : basis ι R₃ M₃) : (to_bilin b M).nondegenerate :=
 (matrix.nondegenerate_to_bilin'_iff_nondegenerate_to_bilin b).mp h.to_bilin'

--- a/src/linear_algebra/matrix/sesquilinear_form.lean
+++ b/src/linear_algebra/matrix/sesquilinear_form.lean
@@ -481,7 +481,7 @@ begin
   refl,
 end
 
-@[simp] lemma is_adjoint_pair_to_bilin :
+@[simp] lemma is_adjoint_pair_to_linear_map₂ :
   is_adjoint_pair (matrix.to_linear_map₂ b₁ b₁ J) (matrix.to_linear_map₂ b₂ b₂ J')
       (matrix.to_lin b₁ b₂ A) (matrix.to_lin b₂ b₁ A') ↔
     matrix.is_adjoint_pair J J' A A' :=
@@ -608,8 +608,8 @@ by rw [←matrix.separating_left_to_linear_map₂'_iff_separating_left_to_linear
 matrix.separating_left_to_linear_map₂'_iff.symm.trans $
   (matrix.to_linear_map₂'_to_matrix' B).symm ▸ iff.rfl
 
-theorem separating_left.to_matrix₂' {B : (ι → R₁) →ₗ[R₁] (ι → R₁) →ₗ[R₁] R₁} (h : B.separating_left) :
-  B.to_matrix₂'.nondegenerate :=
+theorem separating_left.to_matrix₂' {B : (ι → R₁) →ₗ[R₁] (ι → R₁) →ₗ[R₁] R₁}
+  (h : B.separating_left) : B.to_matrix₂'.nondegenerate :=
 nondegenerate_to_matrix₂'_iff.mpr h
 
 @[simp] theorem nondegenerate_to_matrix_iff {B : M₁ →ₗ[R₁] M₁ →ₗ[R₁] R₁}

--- a/src/linear_algebra/matrix/sesquilinear_form.lean
+++ b/src/linear_algebra/matrix/sesquilinear_form.lean
@@ -138,7 +138,7 @@ end aux_to_matrix
 
 section to_matrix'
 
-/-! ### `to_matrix'` section
+/-! ### Bilinear forms over `n → R`
 
 This section deals with the conversion between matrices and sesquilinear forms on `n → R₂`.
 -/
@@ -283,7 +283,7 @@ end to_matrix'
 
 section to_matrix
 
-/-! ### `to_matrix` section
+/-! ### Bilinear forms over arbitrary vector spaces
 
 This section deals with the conversion between matrices and bilinear forms on
 a module with a fixed basis.
@@ -394,11 +394,12 @@ begin
 end
 
 lemma linear_map.to_matrix₂_compl₂ (B : M₁ →ₗ[R] M₂ →ₗ[R] R) (f : M₂' →ₗ[R] M₂) :
-  linear_map.to_matrix₂ b₁ b₂' (B.compl₂ f) = linear_map.to_matrix₂ b₁ b₂ B ⬝ (to_matrix b₂' b₂ f) :=
+  linear_map.to_matrix₂ b₁ b₂' (B.compl₂ f) =
+  linear_map.to_matrix₂ b₁ b₂ B ⬝ (to_matrix b₂' b₂ f) :=
 by { rw [←linear_map.comp_id B, ←linear_map.compl₁₂, linear_map.to_matrix₂_compl₁₂ b₁ b₂], simp }
 
 @[simp]
-lemma bilin_form.to_matrix_mul_basis_to_matrix (c₁ : basis n' R M₁) (c₂ : basis m' R M₂)
+lemma linear_map.to_matrix₂_mul_basis_to_matrix (c₁ : basis n' R M₁) (c₂ : basis m' R M₂)
   (B : M₁ →ₗ[R] M₂ →ₗ[R] R) : (b₁.to_matrix c₁)ᵀ ⬝ linear_map.to_matrix₂ b₁ b₂ B ⬝ b₂.to_matrix c₂ =
   linear_map.to_matrix₂ c₁ c₂ B :=
 begin
@@ -406,23 +407,23 @@ begin
   rw [←linear_map.to_matrix₂_compl₁₂, linear_map.compl₁₂_id_id],
 end
 
-lemma bilin_form.mul_to_matrix_mul (B : M₁ →ₗ[R] M₂ →ₗ[R] R)
+lemma linear_map.mul_to_matrix₂_mul (B : M₁ →ₗ[R] M₂ →ₗ[R] R)
   (M : matrix n' n R) (N : matrix m m' R) :
   M ⬝ linear_map.to_matrix₂ b₁ b₂ B ⬝ N =
     linear_map.to_matrix₂ b₁' b₂' (B.compl₁₂ (to_lin b₁' b₁ Mᵀ) (to_lin b₂' b₂ N)) :=
 by simp_rw [linear_map.to_matrix₂_compl₁₂ b₁ b₂, to_matrix_to_lin, transpose_transpose]
 
-lemma bilin_form.mul_to_matrix (B : M₁ →ₗ[R] M₂ →ₗ[R] R) (M : matrix n' n R) :
+lemma linear_map.mul_to_matrix₂ (B : M₁ →ₗ[R] M₂ →ₗ[R] R) (M : matrix n' n R) :
   M ⬝ linear_map.to_matrix₂ b₁ b₂ B =
     linear_map.to_matrix₂ b₁' b₂ (B.comp (to_lin b₁' b₁ Mᵀ)) :=
 by rw [linear_map.to_matrix₂_comp b₁, to_matrix_to_lin, transpose_transpose]
 
-lemma bilin_form.to_matrix_mul (B : M₁ →ₗ[R] M₂ →ₗ[R] R) (M : matrix m m' R) :
+lemma linear_map.to_matrix₂_mul (B : M₁ →ₗ[R] M₂ →ₗ[R] R) (M : matrix m m' R) :
   linear_map.to_matrix₂ b₁ b₂ B ⬝ M =
     linear_map.to_matrix₂ b₁ b₂' (B.compl₂ (to_lin b₂' b₂ M)) :=
 by rw [linear_map.to_matrix₂_compl₂ b₁, to_matrix_to_lin]
 
-lemma matrix.to_bilin_comp (M : matrix n m R) (P : matrix n n' R) (Q : matrix m m' R) :
+lemma matrix.to_linear_map₂_compl₁₂ (M : matrix n m R) (P : matrix n n' R) (Q : matrix m m' R) :
   (matrix.to_linear_map₂ b₁ b₂ M).compl₁₂ (to_lin b₁' b₁ P) (to_lin b₂' b₂ Q) =
   matrix.to_linear_map₂ b₁' b₂' (Pᵀ ⬝ M ⬝ Q) :=
 (linear_map.to_matrix₂ b₁' b₂').injective

--- a/src/linear_algebra/matrix/sesquilinear_form.lean
+++ b/src/linear_algebra/matrix/sesquilinear_form.lean
@@ -212,6 +212,10 @@ linear_map.to_matrixₛₗ₂'.symm_symm
   matrix.to_linear_mapₛₗ₂' σ₁ σ₂ (linear_map.to_matrixₛₗ₂' B) = B :=
 (matrix.to_linear_mapₛₗ₂' σ₁ σ₂).apply_symm_apply B
 
+@[simp] lemma matrix.to_linear_map₂'_to_matrix' (B : (n → R) →ₗ[R] (m → R) →ₗ[R] R) :
+  matrix.to_linear_map₂' (linear_map.to_matrix₂' B) = B :=
+matrix.to_linear_map₂'.apply_symm_apply B
+
 @[simp] lemma linear_map.to_matrix'_to_linear_mapₛₗ₂' (M : matrix n m R) :
   linear_map.to_matrixₛₗ₂' (matrix.to_linear_mapₛₗ₂' σ₁ σ₂ M) = M :=
 linear_map.to_matrixₛₗ₂'.apply_symm_apply M
@@ -575,7 +579,6 @@ lemma _root_.matrix.separating_left_to_linear_map₂'_iff_separating_left_to_lin
 (separating_left_congr_iff b.equiv_fun.symm b.equiv_fun.symm).symm
 
 variables (B : M₁ →ₗ[R₁] M₁ →ₗ[R₁] R₁)
-variables [is_domain R₁]
 
 -- Lemmas transferring nondegeneracy between a matrix and its associated bilinear form
 
@@ -583,57 +586,61 @@ theorem _root_.matrix.nondegenerate.to_linear_map₂' {M : matrix ι ι R₁} (h
   M.to_linear_map₂'.separating_left :=
 λ x hx, h.eq_zero_of_ortho $ λ y, by simpa only [to_linear_map₂'_apply'] using hx y
 
-@[simp] lemma _root_.matrix.nondegenerate_to_linear_map₂'_iff {M : matrix ι ι R₁} :
+@[simp] lemma _root_.matrix.separating_left_to_linear_map₂'_iff {M : matrix ι ι R₁} :
   M.to_linear_map₂'.separating_left ↔ M.nondegenerate :=
 ⟨λ h v hv, h v $ λ w, (M.to_linear_map₂'_apply' _ _).trans $ hv w,
   matrix.nondegenerate.to_linear_map₂'⟩
 
-/-
-theorem _root_.matrix.nondegenerate.to_bilin {M : matrix ι ι R₃} (h : M.nondegenerate)
-  (b : basis ι R₃ M₃) : (to_bilin b M).nondegenerate :=
-(matrix.nondegenerate_to_bilin'_iff_nondegenerate_to_bilin b).mp h.to_bilin'
+theorem _root_.matrix.nondegenerate.to_linear_map₂ {M : matrix ι ι R₁} (h : M.nondegenerate)
+  (b : basis ι R₁ M₁) : (to_linear_map₂ b b M).separating_left :=
+(matrix.separating_left_to_linear_map₂'_iff_separating_left_to_linear_map₂ b).mp h.to_linear_map₂'
 
-@[simp] lemma _root_.matrix.nondegenerate_to_bilin_iff {M : matrix ι ι R₃} (b : basis ι R₃ M₃) :
-  (to_bilin b M).nondegenerate ↔ M.nondegenerate :=
-by rw [←matrix.nondegenerate_to_bilin'_iff_nondegenerate_to_bilin,
-       matrix.nondegenerate_to_bilin'_iff]
+@[simp] lemma _root_.matrix.separating_left_to_linear_map₂_iff {M : matrix ι ι R₁}
+  (b : basis ι R₁ M₁) : (to_linear_map₂ b b M).separating_left ↔ M.nondegenerate :=
+by rw [←matrix.separating_left_to_linear_map₂'_iff_separating_left_to_linear_map₂,
+       matrix.separating_left_to_linear_map₂'_iff]
 
 -- Lemmas transferring nondegeneracy between a bilinear form and its associated matrix
 
-@[simp] theorem nondegenerate_to_matrix'_iff {B : bilin_form R₃ (ι → R₃)} :
-  B.to_matrix'.nondegenerate ↔ B.nondegenerate :=
-matrix.nondegenerate_to_bilin'_iff.symm.trans $ (matrix.to_bilin'_to_matrix' B).symm ▸ iff.rfl
+@[simp] theorem nondegenerate_to_matrix₂'_iff {B : (ι → R₁) →ₗ[R₁] (ι → R₁) →ₗ[R₁] R₁} :
+  B.to_matrix₂'.nondegenerate ↔ B.separating_left :=
+matrix.separating_left_to_linear_map₂'_iff.symm.trans $
+  (matrix.to_linear_map₂'_to_matrix' B).symm ▸ iff.rfl
 
-theorem nondegenerate.to_matrix' {B : bilin_form R₃ (ι → R₃)} (h : B.nondegenerate) :
-  B.to_matrix'.nondegenerate :=
-nondegenerate_to_matrix'_iff.mpr h
+theorem separating_left.to_matrix₂' {B : (ι → R₁) →ₗ[R₁] (ι → R₁) →ₗ[R₁] R₁} (h : B.separating_left) :
+  B.to_matrix₂'.nondegenerate :=
+nondegenerate_to_matrix₂'_iff.mpr h
 
-@[simp] theorem nondegenerate_to_matrix_iff {B : bilin_form R₃ M₃} (b : basis ι R₃ M₃) :
-  (to_matrix b B).nondegenerate ↔ B.nondegenerate :=
-(matrix.nondegenerate_to_bilin_iff b).symm.trans $ (matrix.to_bilin_to_matrix b B).symm ▸ iff.rfl
+@[simp] theorem nondegenerate_to_matrix_iff {B : M₁ →ₗ[R₁] M₁ →ₗ[R₁] R₁}
+  (b : basis ι R₁ M₁) : (to_matrix₂ b b B).nondegenerate ↔ B.separating_left :=
+(matrix.separating_left_to_linear_map₂_iff b).symm.trans $
+  (matrix.to_linear_map₂_to_matrix₂ b b B).symm ▸ iff.rfl
 
-theorem nondegenerate.to_matrix {B : bilin_form R₃ M₃} (h : B.nondegenerate)
-  (b : basis ι R₃ M₃) : (to_matrix b B).nondegenerate :=
+theorem separating_left.to_matrix₂ {B : M₁ →ₗ[R₁] M₁ →ₗ[R₁] R₁} (h : B.separating_left)
+  (b : basis ι R₁ M₁) : (to_matrix₂ b b B).nondegenerate :=
 (nondegenerate_to_matrix_iff b).mpr h
 
 -- Some shorthands for combining the above with `matrix.nondegenerate_of_det_ne_zero`
 
-lemma nondegenerate_to_bilin'_iff_det_ne_zero {M : matrix ι ι A} :
-  M.to_bilin'.nondegenerate ↔ M.det ≠ 0 :=
-by rw [matrix.nondegenerate_to_bilin'_iff, matrix.nondegenerate_iff_det_ne_zero]
+variables [is_domain R₁]
 
-theorem nondegenerate_to_bilin'_of_det_ne_zero' (M : matrix ι ι A) (h : M.det ≠ 0) :
-  M.to_bilin'.nondegenerate :=
-nondegenerate_to_bilin'_iff_det_ne_zero.mpr h
+lemma separating_left_to_linear_map₂'_iff_det_ne_zero {M : matrix ι ι R₁} :
+  M.to_linear_map₂'.separating_left ↔ M.det ≠ 0 :=
+by rw [matrix.separating_left_to_linear_map₂'_iff, matrix.nondegenerate_iff_det_ne_zero]
 
-lemma nondegenerate_iff_det_ne_zero {B : bilin_form A M₃}
-  (b : basis ι A M₃) : B.nondegenerate ↔ (to_matrix b B).det ≠ 0 :=
+theorem separating_left_to_linear_map₂'_of_det_ne_zero' (M : matrix ι ι R₁) (h : M.det ≠ 0) :
+  M.to_linear_map₂'.separating_left :=
+separating_left_to_linear_map₂'_iff_det_ne_zero.mpr h
+
+lemma separating_left_iff_det_ne_zero {B : M₁ →ₗ[R₁] M₁ →ₗ[R₁] R₁}
+  (b : basis ι R₁ M₁) : B.separating_left ↔ (to_matrix₂ b b B).det ≠ 0 :=
 by rw [←matrix.nondegenerate_iff_det_ne_zero, nondegenerate_to_matrix_iff]
 
-theorem nondegenerate_of_det_ne_zero (b : basis ι A M₃) (h : (to_matrix b B₃).det ≠ 0) :
-  B₃.nondegenerate :=
-(nondegenerate_iff_det_ne_zero b).mpr h
--/
+theorem separating_left_of_det_ne_zero {B : M₁ →ₗ[R₁] M₁ →ₗ[R₁] R₁} (b : basis ι R₁ M₁)
+  (h : (to_matrix₂ b b B).det ≠ 0) :
+  B.separating_left :=
+(separating_left_iff_det_ne_zero b).mpr h
+
 end det
 
 end linear_map

--- a/src/linear_algebra/matrix/sesquilinear_form.lean
+++ b/src/linear_algebra/matrix/sesquilinear_form.lean
@@ -144,7 +144,7 @@ variables {σ₁ : R₁ →+* R} {σ₂ : R₂ →+* R}
 
 /-- The linear equivalence between sesquilinear forms and `n × m` matrices -/
 def linear_map.to_matrixₛₗ₂' : ((n → R₁) →ₛₗ[σ₁] (m → R₂) →ₛₗ[σ₂] R) ≃ₗ[R] matrix n m R :=
-{ to_fun := linear_map.to_matrix₂_aux (λ i, std_basis R₁ (λ _, R₁) i 1) (λ j, std_basis R₂ (λ _, R₂) j 1),
+{ to_fun := linear_map.to_matrix₂_aux _ _,
   inv_fun := matrix.to_linear_map₂'_aux σ₁ σ₂,
   left_inv := linear_map.to_linear_map₂'_aux_to_matrix₂_aux,
   right_inv := matrix.to_matrix₂_aux_to_linear_map₂'_aux,

--- a/src/linear_algebra/matrix/sesquilinear_form.lean
+++ b/src/linear_algebra/matrix/sesquilinear_form.lean
@@ -4,12 +4,12 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Anne Baanen, Kexing Ying, Moritz Doll
 -/
 
+import linear_algebra.finsupp_vector_space
 import linear_algebra.matrix.basis
 import linear_algebra.matrix.nondegenerate
 import linear_algebra.matrix.nonsingular_inverse
 import linear_algebra.matrix.to_linear_equiv
 import linear_algebra.sesquilinear_form
-import linear_algebra.finsupp_vector_space
 
 /-!
 # Sesquilinear form
@@ -144,7 +144,8 @@ variables {σ₁ : R₁ →+* R} {σ₂ : R₂ →+* R}
 
 /-- The linear equivalence between sesquilinear forms and `n × m` matrices -/
 def linear_map.to_matrixₛₗ₂' : ((n → R₁) →ₛₗ[σ₁] (m → R₂) →ₛₗ[σ₂] R) ≃ₗ[R] matrix n m R :=
-{ inv_fun := matrix.to_linear_map₂'_aux σ₁ σ₂,
+{ to_fun := linear_map.to_matrix₂_aux (λ i, std_basis R₁ (λ _, R₁) i 1) (λ j, std_basis R₂ (λ _, R₂) j 1),
+  inv_fun := matrix.to_linear_map₂'_aux σ₁ σ₂,
   left_inv := linear_map.to_linear_map₂'_aux_to_matrix₂_aux,
   right_inv := matrix.to_matrix₂_aux_to_linear_map₂'_aux,
   ..linear_map.to_matrix₂_aux (λ i, std_basis R₁ (λ _, R₁) i 1) (λ j, std_basis R₂ (λ _, R₂) j 1) }

--- a/src/linear_algebra/matrix/sesquilinear_form.lean
+++ b/src/linear_algebra/matrix/sesquilinear_form.lean
@@ -61,12 +61,6 @@ mk₂'ₛₗ σ₁ σ₂ (λ (v : n → R₁) (w : m → R₂), ∑ i j, σ₁ (
 
 variables [decidable_eq n] [decidable_eq m]
 
-@[simp] lemma ring_hom_ite_zero_one (p : Prop) [decidable p] : σ₁ (ite p 0 1) = ite p 0 1 :=
-by { split_ifs; simp [h] }
-
-@[simp] lemma ring_hom_ite_one_zero (p : Prop) [decidable p] : σ₁ (ite p 1 0) = ite p 1 0 :=
-by { split_ifs; simp [h] }
-
 lemma matrix.to_linear_map₂'_aux_std_basis (f : matrix n m R) (i : n) (j : m) :
   f.to_linear_map₂'_aux σ₁ σ₂ (std_basis R₁ (λ _, R₁) i 1) (std_basis R₂ (λ _, R₂) j 1) = f i j :=
 begin

--- a/src/linear_algebra/matrix/sesquilinear_form.lean
+++ b/src/linear_algebra/matrix/sesquilinear_form.lean
@@ -9,6 +9,7 @@ import linear_algebra.matrix.nondegenerate
 import linear_algebra.matrix.nonsingular_inverse
 import linear_algebra.matrix.to_linear_equiv
 import linear_algebra.sesquilinear_form
+import linear_algebra.finsupp_vector_space
 
 /-!
 # Sesquilinear form

--- a/src/linear_algebra/matrix/sesquilinear_form.lean
+++ b/src/linear_algebra/matrix/sesquilinear_form.lean
@@ -138,7 +138,7 @@ section to_matrix'
 
 /-! ### Bilinear forms over `n → R`
 
-This section deals with the conversion between matrices and sesquilinear forms on `n → R₂`.
+This section deals with the conversion between matrices and sesquilinear forms on `n → R`.
 -/
 
 variables [comm_ring R] [comm_ring R₁] [comm_ring R₂]
@@ -147,13 +147,14 @@ variables [decidable_eq n] [decidable_eq m]
 
 variables {σ₁ : R₁ →+* R} {σ₂ : R₂ →+* R}
 
-/-- The linear equivalence between sesquilinear forms on `n → R` and `n × n` matrices -/
+/-- The linear equivalence between sesquilinear forms and `n × m` matrices -/
 def linear_map.to_matrixₛₗ₂' : ((n → R₁) →ₛₗ[σ₁] (m → R₂) →ₛₗ[σ₂] R) ≃ₗ[R] matrix n m R :=
 { inv_fun := matrix.to_linear_map₂'_aux σ₁ σ₂,
   left_inv := linear_map.to_linear_map₂'_aux_to_matrix₂_aux,
   right_inv := matrix.to_matrix₂_aux_to_linear_map₂'_aux,
   ..linear_map.to_matrix₂_aux (λ i, std_basis R₁ (λ _, R₁) i 1) (λ j, std_basis R₂ (λ _, R₂) j 1) }
 
+/-- The linear equivalence between bilinear forms and `n × m` matrices -/
 def linear_map.to_matrix₂' : ((n → R) →ₗ[R] (m → R) →ₗ[R] R) ≃ₗ[R] matrix n m R :=
 linear_map.to_matrixₛₗ₂'
 

--- a/src/linear_algebra/matrix/sesquilinear_form.lean
+++ b/src/linear_algebra/matrix/sesquilinear_form.lean
@@ -46,6 +46,10 @@ variables [fintype n] [fintype m]
 
 variables (σ₁ : R₁ →+* R) (σ₂ : R₂ →+* R)
 
+
+/-- The map from `matrix n n R` to bilinear forms on `n → R`.
+
+This is an auxiliary definition for the equivalence `matrix.to_linear_map₂'`. -/
 def matrix.to_linear_map₂'_aux  (f : matrix n m R) :
   (n → R₁) →ₛₗ[σ₁] (m → R₂) →ₛₗ[σ₂] R :=
 mk₂'ₛₗ σ₁ σ₂ (λ (v : n → R₁) (w : m → R₂), ∑ i j, σ₁ (v i) * f i j * σ₂ (w j))
@@ -56,13 +60,6 @@ mk₂'ₛₗ σ₁ σ₂ (λ (v : n → R₁) (w : m → R₂), ∑ i j, σ₁ (
     simp only [pi.smul_apply, smul_eq_mul, ring_hom.map_mul, mul_assoc, mul_left_comm, mul_sum] )
 
 variables [decidable_eq n] [decidable_eq m]
-
-@[simp] lemma std_basis_apply' (i i' : n) : (std_basis R₁ (λ (_x : n), R₁) i) 1 i' =
-  ite (i = i') 1 0  :=
-begin
-  rw [linear_map.std_basis_apply, function.update_apply, pi.zero_apply],
-  congr' 1, rw [eq_iff_iff, eq_comm],
-end
 
 @[simp] lemma ring_hom_ite_zero_one (p : Prop) [decidable p] : σ₁ (ite p 0 1) = ite p 0 1 :=
 by { split_ifs; simp [h] }

--- a/src/linear_algebra/sesquilinear_form.lean
+++ b/src/linear_algebra/sesquilinear_form.lean
@@ -37,7 +37,7 @@ Sesquilinear form,
 
 open_locale big_operators
 
-variables {R R₁ R₂ R₃ M M₁ M₂ K K₁ K₂ V V₁ V₂ n: Type*}
+variables {R R₁ R₂ R₃ M M₁ M₂ Mₗ₁ Mₗ₁' Mₗ₂ Mₗ₂' K K₁ K₂ V V₁ V₂ n : Type*}
 
 namespace linear_map
 
@@ -548,6 +548,46 @@ the only element that is left-orthogonal to every other element is `0`; i.e.,
 for every nonzero `x` in `M₁`, there exists `y` in `M₂` with `B x y ≠ 0`.-/
 def separating_left (B : M₁ →ₛₗ[I₁] M₂ →ₛₗ[I₂] R) : Prop :=
 ∀ x : M₁, (∀ y : M₂, B x y = 0) → x = 0
+
+variables (M₁ M₂ I₁ I₂)
+
+/-- In a non-trivial module, zero is not non-degenerate. -/
+lemma not_separating_left_zero [nontrivial M₁] : ¬(0 : M₁ →ₛₗ[I₁] M₂ →ₛₗ[I₂] R).separating_left :=
+let ⟨m, hm⟩ := exists_ne (0 : M₁) in λ h, hm (h m $ λ n, rfl)
+
+variables {M₁ M₂ I₁ I₂}
+
+lemma separating_left.ne_zero [nontrivial M₁] {B : M₁ →ₛₗ[I₁] M₂ →ₛₗ[I₂] R}
+  (h : B.separating_left) : B ≠ 0 :=
+λ h0, not_separating_left_zero M₁ M₂ I₁ I₂ $ h0 ▸ h
+
+section linear
+
+variables [add_comm_monoid Mₗ₁] [add_comm_monoid Mₗ₂] [add_comm_monoid Mₗ₁'] [add_comm_monoid Mₗ₂']
+variables [module R Mₗ₁] [module R Mₗ₂] [module R Mₗ₁'] [module R Mₗ₂']
+variables {B : Mₗ₁ →ₗ[R] Mₗ₂ →ₗ[R] R} (e₁ : Mₗ₁ ≃ₗ[R] Mₗ₁') (e₂ : Mₗ₂ ≃ₗ[R] Mₗ₂')
+
+lemma separating_left.congr (h : B.separating_left) :
+  (e₁.arrow_congr (e₂.arrow_congr (linear_equiv.refl R R)) B).separating_left :=
+begin
+  intros x hx,
+  rw ←e₁.symm.map_eq_zero_iff,
+  refine h (e₁.symm x) (λ y, _),
+  specialize hx (e₂ y),
+  simp only [linear_equiv.arrow_congr_apply, linear_equiv.symm_apply_apply,
+    linear_equiv.map_eq_zero_iff] at hx,
+  exact hx,
+end
+
+@[simp] lemma separating_left_congr_iff :
+  (e₁.arrow_congr (e₂.arrow_congr (linear_equiv.refl R R)) B).separating_left ↔ B.separating_left :=
+⟨λ h, begin
+  convert h.congr e₁.symm e₂.symm,
+  ext x y,
+  simp,
+end, separating_left.congr e₁ e₂⟩
+
+end linear
 
 /-- A bilinear form is called right-separating if
 the only element that is right-orthogonal to every other element is `0`; i.e.,

--- a/src/linear_algebra/std_basis.lean
+++ b/src/linear_algebra/std_basis.lean
@@ -38,7 +38,7 @@ open_locale big_operators
 
 namespace linear_map
 
-variables (R : Type*) {ι : Type*} [semiring R] (φ : ι → Type*)
+variables (R : Type*) {ι M n : Type*} [semiring R] (φ : ι → Type*)
   [Π i, add_comm_monoid (φ i)] [Π i, module R (φ i)] [decidable_eq ι]
 
 /-- The standard basis of the product of `φ`. -/
@@ -142,6 +142,22 @@ end
 lemma std_basis_eq_single {a : R} :
   (λ (i : ι), (std_basis R (λ _ : ι, R) i) a) = λ (i : ι), (finsupp.single i a) :=
 funext $ λ i, (finsupp.single_eq_pi_single i a).symm
+
+variables [decidable_eq n] [fintype n]
+variables [add_comm_monoid M] [module R M]
+variables {b : basis n R M}
+
+@[simp] lemma basis.equiv_fun_symm_std_basis (i : n) :
+  b.equiv_fun.symm (std_basis R (λ _, R) i 1) = b i :=
+begin
+  rw [b.equiv_fun_symm_apply, finset.sum_eq_single i],
+  { rw [std_basis_same, one_smul] },
+  { rintros j - hj,
+    rw [std_basis_ne _ _ _ _ hj, zero_smul] },
+  { intro,
+    have := finset.mem_univ i,
+    contradiction  }
+end
 
 end linear_map
 

--- a/src/linear_algebra/std_basis.lean
+++ b/src/linear_algebra/std_basis.lean
@@ -38,7 +38,7 @@ open_locale big_operators
 
 namespace linear_map
 
-variables (R : Type*) {ι M n : Type*} [semiring R] (φ : ι → Type*)
+variables (R : Type*) {ι : Type*} [semiring R] (φ : ι → Type*)
   [Π i, add_comm_monoid (φ i)] [Π i, module R (φ i)] [decidable_eq ι]
 
 /-- The standard basis of the product of `φ`. -/
@@ -143,23 +143,27 @@ lemma std_basis_eq_single {a : R} :
   (λ (i : ι), (std_basis R (λ _ : ι, R) i) a) = λ (i : ι), (finsupp.single i a) :=
 funext $ λ i, (finsupp.single_eq_pi_single i a).symm
 
-variables [decidable_eq n] [fintype n]
-variables [add_comm_monoid M] [module R M]
-variables {b : basis n R M}
+end linear_map
 
-@[simp] lemma basis.equiv_fun_symm_std_basis (i : n) :
-  b.equiv_fun.symm (std_basis R (λ _, R) i 1) = b i :=
+namespace basis
+
+variables {R M n : Type*}
+variables [decidable_eq n] [fintype n]
+variables [semiring R] [add_comm_monoid M] [module R M]
+
+@[simp] lemma equiv_fun_symm_std_basis (b : basis n R M) (i : n) :
+  b.equiv_fun.symm (linear_map.std_basis R (λ _, R) i 1) = b i :=
 begin
   rw [b.equiv_fun_symm_apply, finset.sum_eq_single i],
-  { rw [std_basis_same, one_smul] },
+  { rw [linear_map.std_basis_same, one_smul] },
   { rintros j - hj,
-    rw [std_basis_ne _ _ _ _ hj, zero_smul] },
+    rw [linear_map.std_basis_ne _ _ _ _ hj, zero_smul] },
   { intro,
     have := finset.mem_univ i,
-    contradiction  }
+    contradiction }
 end
 
-end linear_map
+end basis
 
 namespace pi
 open linear_map

--- a/src/linear_algebra/std_basis.lean
+++ b/src/linear_algebra/std_basis.lean
@@ -47,6 +47,13 @@ def std_basis : Π (i : ι), φ i →ₗ[R] (Πi, φ i) := single
 lemma std_basis_apply (i : ι) (b : φ i) : std_basis R φ i b = update 0 i b :=
 rfl
 
+@[simp] lemma std_basis_apply' (i i' : ι) : (std_basis R (λ (_x : ι), R) i) 1 i' =
+  ite (i = i') 1 0  :=
+begin
+  rw [linear_map.std_basis_apply, function.update_apply, pi.zero_apply],
+  congr' 1, rw [eq_iff_iff, eq_comm],
+end
+
 lemma coe_std_basis (i : ι) : ⇑(std_basis R φ i) = pi.single i :=
 rfl
 

--- a/src/linear_algebra/std_basis.lean
+++ b/src/linear_algebra/std_basis.lean
@@ -152,26 +152,6 @@ funext $ λ i, (finsupp.single_eq_pi_single i a).symm
 
 end linear_map
 
-namespace basis
-
-variables {R M n : Type*}
-variables [decidable_eq n] [fintype n]
-variables [semiring R] [add_comm_monoid M] [module R M]
-
-@[simp] lemma equiv_fun_symm_std_basis (b : basis n R M) (i : n) :
-  b.equiv_fun.symm (linear_map.std_basis R (λ _, R) i 1) = b i :=
-begin
-  rw [b.equiv_fun_symm_apply, finset.sum_eq_single i],
-  { rw [linear_map.std_basis_same, one_smul] },
-  { rintros j - hj,
-    rw [linear_map.std_basis_ne _ _ _ _ hj, zero_smul] },
-  { intro,
-    have := finset.mem_univ i,
-    contradiction }
-end
-
-end basis
-
 namespace pi
 open linear_map
 open set


### PR DESCRIPTION
The main goal of this PR is to move `linear_algebra/matrix/bilinear_form` to the curried bilinear map form. Since this file as quite few dependencies we copy it to a new file `linear_algebra/matrix/sesquilinear_form` and then move all the dependencies.

The structure is taken literally from `linear_algebra/matrix/bilinear_form` with generalizations and easier proofs where possible. The new lemmas are named exactly as the old ones with the following changes:
- the namespace changed from `bilin_form` to `linear_map`
- `bilin` is changed to `linear_map₂`. In case there is the necessity for separate bilinear and semi-bilinear lemmas we use `linear_map₂` and `linear_mapₛₗ₂`
- If `bilin` is not in the name of a lemma, `matrix` is changed to `matrix₂` to avoid nameclashes with lemmas for linear maps `M →ₛₗ[ρ₁₂] N`

Moreover, the following changes were necessary:

`linear_algebra/bilinear_map`:
- Weakened some typeclass assumptions
- Added bilinear version of `sum_repr_mul_repr_mul` and moved sesquilinear version to `sum_repr_mul_repr_mulₛₗ`

`linear_algebra/matrix/bilinear_form`:
- Moved `basis.equiv_fun_symm_std_basis` to `linear_algebra/std_basis`
- `adjoint_pair` section: Removed a few definitions (they are now in `linear_algebra/matrix/sesquilinear_form`) and added a prime to the names of lemmas that have the same name as the version in `linear_algebra/matrix/sesquilinear_form`

`linear_algebra/sesquilinear_form`:
- Added a few missing lemmas about left-separating bilinear forms (note that `separating_left` was previously known as `nondegenerate`)

`linear_algebra/std_basis`:
- Lemma `std_basis_apply'` for calculating the application of `i' : ι` to `(std_basis R (λ (_x : ι), R) i)`

`algebra/hom/ring/`:
- Lemmas for calculating a ring homomorphism applied to `ite 0 1` and `ite 1 0`

The last two additions are needed to get a reasonable proof for `matrix.to_linear_map₂'_aux_std_basis`.

---

There are some bikeshedding questions about docstrings: Should the map ` M →ₛₗ[ρ₁₂] N →ₛₗ[σ₁₂] R` be called "semi-bilinear" or "sesquilinear" or something completely different?
I have very slight naming inconsistency in that I add a subscript `₂` after `matrix` in some lemmas if there is no reference to bilinear maps in some sense, i.e., there is `linear_map.mul_to_matrix₂_mul` (l. 412), but `linear_map.to_matrix'_to_linear_map₂'`(l.223).
I thought about using the subscript everywhere but I find these subscripts annoying to type.

Please let me know if you want any further explanation of the naming schemes, I find them completely obvious but I spend too much time on this PR..

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
