### PR TITLE
[Merged by Bors] - chore(tactic/doc_commands): simpler tactic_doc / library_note encoding

### DIFF
--- a/src/meta/expr.lean
+++ b/src/meta/expr.lean
@@ -120,12 +120,6 @@ meta def head : name → string
 meta def is_private (n : name) : bool :=
 n.head = "_private"
 
-/-- Get the last component of a name, and convert it to a string. -/
-meta def last : name → string
-| (mk_string s _)  := s
-| (mk_numeral n _) := repr n
-| anonymous        := "[anonymous]"
-
 /-- Returns the number of characters used to print all the string components of a name,
   including periods between name segments. Ignores numerical parts of a name. -/
 meta def length : name → ℕ

--- a/src/tactic/doc_commands.lean
+++ b/src/tactic/doc_commands.lean
@@ -32,10 +32,11 @@ information.
 def string.hash (s : string) : ℕ :=
 s.fold 1 (λ h c, (33*h + c.val) % unsigned_sz)
 
-/-- `mk_hashed_name nspace id` hashes the string `id` to a value `i` and returns the name
-`nspace._i` -/
-meta def string.mk_hashed_name (nspace : name) (id : string) : name :=
-nspace <.> ("_" ++ to_string id.hash)
+/-- Get the last component of a name, and convert it to a string. -/
+meta def name.last : name → string
+| (name.mk_string s _)  := s
+| (name.mk_numeral n _) := repr n
+| anonymous             := "[anonymous]"
 
 open tactic
 
@@ -84,8 +85,9 @@ mk_definition decl_name (reflect type).collect_univ_params (reflect type) (refle
 `add_library_note note_name note` adds a declaration of type `string × string` and tags it with
 the `library_note` attribute. -/
 meta def tactic.add_library_note (note_name note : string) : tactic unit :=
-do let decl_name := note_name.mk_hashed_name `library_note,
-   add_decl $ mk_reflected_definition decl_name (note_name, note),
+do let decl_name := `library_note <.> note_name,
+   add_decl $ mk_reflected_definition decl_name (),
+   add_doc_string decl_name note,
    library_note_attr.set decl_name () tt none
 
 open tactic
@@ -110,7 +112,7 @@ add_library_note note_name doc_string
 Returns a list of pairs `(note_id, note_content)` -/
 meta def tactic.get_library_notes : tactic (list (string × string)) :=
 attribute.get_instances `library_note >>=
-  list.mmap (λ dcl, mk_const dcl >>= eval_expr (string × string))
+  list.mmap (λ dcl, prod.mk dcl.last <$> doc_string dcl)
 
 /-! ### The `add_tactic_doc_entry` command -/
 
@@ -135,42 +137,20 @@ structure tactic_doc_entry :=
 (category : doc_category)
 (decl_names : list _root_.name)
 (tags : list string := [])
-(description : string := "")
 (inherit_description_from : option _root_.name := none)
 
 /-- Turns a `tactic_doc_entry` into a JSON representation. -/
-meta def tactic_doc_entry.to_json (d : tactic_doc_entry) : json :=
+meta def tactic_doc_entry.to_json (d : tactic_doc_entry) (desc : string) : json :=
 json.object [
   ("name", d.name),
   ("category", d.category.to_string),
   ("decl_names", d.decl_names.map (json.of_string ∘ to_string)),
   ("tags", d.tags.map json.of_string),
-  ("description", d.description)
+  ("description", desc)
 ]
 
-meta instance : has_to_string tactic_doc_entry :=
-⟨json.unparse ∘ tactic_doc_entry.to_json⟩
-
-/-- `update_description_from tde inh_id` replaces the `description` field of `tde` with the
-    doc string of the declaration named `inh_id`. -/
-meta def tactic_doc_entry.update_description_from (tde : tactic_doc_entry) (inh_id : name) :
-  tactic tactic_doc_entry :=
-do ds ← doc_string inh_id <|> fail (to_string inh_id ++ " has no doc string"),
-   return { description := ds .. tde }
-
-/--
-`update_description tde` replaces the `description` field of `tde` with:
-
-* the doc string of `tde.inherit_description_from`, if this field has a value
-* the doc string of the entry in `tde.decl_names`, if this field has length 1
-
-If neither of these conditions are met, it returns `tde`. -/
-meta def tactic_doc_entry.update_description (tde : tactic_doc_entry) : tactic tactic_doc_entry :=
-match tde.inherit_description_from, tde.decl_names with
-| some inh_id, _ := tde.update_description_from inh_id
-| none, [inh_id] := tde.update_description_from inh_id
-| none, _ := return tde
-end
+meta instance tactic_doc_entry.has_to_string : has_to_string (tactic_doc_entry × string) :=
+⟨λ ⟨doc, desc⟩, json.unparse (doc.to_json desc)⟩
 
 /-- A user attribute `tactic_doc` for tagging decls of type `tactic_doc_entry`
 for use in doc output -/
@@ -180,26 +160,31 @@ for use in doc output -/
   parser := failed }
 
 /-- Collects everything in the environment tagged with the attribute `tactic_doc`. -/
-meta def tactic.get_tactic_doc_entries : tactic (list tactic_doc_entry) :=
+meta def tactic.get_tactic_doc_entries : tactic (list (tactic_doc_entry × string)) :=
 attribute.get_instances `tactic_doc >>=
-  list.mmap (λ dcl, mk_const dcl >>= eval_expr tactic_doc_entry)
+  list.mmap (λ dcl, prod.mk <$> (mk_const dcl >>= eval_expr tactic_doc_entry) <*> doc_string dcl)
 
 /-- `add_tactic_doc tde` adds a declaration to the environment
 with `tde` as its body and tags it with the `tactic_doc`
 attribute. If `tde.decl_names` has exactly one entry `` `decl`` and
 if `tde.description` is the empty string, `add_tactic_doc` uses the doc
 string of `decl` as the description. -/
-meta def tactic.add_tactic_doc (tde : tactic_doc_entry) : tactic unit :=
-do when (tde.description = "" ∧ tde.inherit_description_from.is_none ∧ tde.decl_names.length ≠ 1) $
-     fail "A tactic doc entry must either:
+meta def tactic.add_tactic_doc (tde : tactic_doc_entry) (doc : option string) : tactic unit :=
+do desc ← doc <|> (do
+    inh_id ← match tde.inherit_description_from, tde.decl_names with
+    | some inh_id, _ := pure inh_id
+    | none, [inh_id] := pure inh_id
+    | none, _ := fail "A tactic doc entry must either:
  1. have a description written as a doc-string for the `add_tactic_doc` invocation, or
  2. have a single declaration in the `decl_names` field, to inherit a description from, or
  3. explicitly indicate the declaration to inherit the description from using
-    `inherit_description_from`.",
-   tde ← if tde.description = "" then tde.update_description else return tde,
-   let decl_name := (tde.name ++ tde.category.to_string).mk_hashed_name `tactic_doc,
-   add_decl $ mk_definition decl_name [] `(tactic_doc_entry) (reflect tde),
-   tactic_doc_entry_attr.set decl_name () tt none
+    `inherit_description_from`."
+    end,
+    doc_string inh_id <|> fail (to_string inh_id ++ " has no doc string")),
+  let decl_name := `tactic_doc <.> tde.category.to_string <.> tde.name,
+  add_decl $ mk_definition decl_name [] `(tactic_doc_entry) (reflect tde),
+  add_doc_string decl_name desc,
+  tactic_doc_entry_attr.set decl_name () tt none
 
 /--
 A command used to add documentation for a tactic, command, hole command, or attribute.
@@ -246,11 +231,7 @@ messages.
   (_ : parse $ tk "add_tactic_doc") : parser unit := do
 pe ← parser.pexpr,
 e ← eval_pexpr tactic_doc_entry pe,
-let e : tactic_doc_entry := match mi.doc_string with
-  | some desc := { description := desc, ..e }
-  | none := e
-  end,
-tactic.add_tactic_doc e .
+tactic.add_tactic_doc e mi.doc_string .
 
 /--
 At various places in mathlib, we leave implementation notes that are referenced from many other

--- a/src/tactic/lint/default.lean
+++ b/src/tactic/lint/default.lean
@@ -19,13 +19,8 @@ attribute.
 
 open tactic
 
-add_tactic_doc
-{ name                     := "linting commands",
-  category                 := doc_category.cmd,
-  decl_names               := [`lint_cmd, `lint_mathlib_cmd, `lint_all_cmd, `list_linters],
-  tags                     := ["linting"],
-  description              :=
-"User commands to spot common mistakes in the code
+/--
+User commands to spot common mistakes in the code
 
 * `#lint`: check all declarations in the current file
 * `#lint_mathlib`: check all declarations in mathlib (so excluding core or other projects,
@@ -93,7 +88,13 @@ or `lint only my_new_check`.
 If you add the attribute `@[linter]` to `linter.my_new_check` it will run by default.
 
 Adding the attribute `@[nolint doc_blame unused_arguments]` to a declaration
-omits it from only the specified linter checks." }
+omits it from only the specified linter checks.
+-/
+add_tactic_doc
+{ name                     := "linting commands",
+  category                 := doc_category.cmd,
+  decl_names               := [`lint_cmd, `lint_mathlib_cmd, `lint_all_cmd, `list_linters],
+  tags                     := ["linting"] }
 
 /-- The default linters used in mathlib CI. -/
 meta def mathlib_linters : list name := by do


### PR DESCRIPTION
This does some encoding optimizations on the documentation commands:

* Long strings inside `expr` is a source of stack overflows in lean external checkers because the translation uses a chain of `string.cons` applications, so we should avoid putting doc strings in exprs.
* There is no need to hash names for either `library_note` or `tactic_doc`, because they already come with a unique name.

Concretely:
* Instead of encoding `/-- doc -/ library_note "my note"` as
  ```lean
  @[library_note] def library_note._1234 := ("my note", "doc")
  ```
  we encode it as
  ```lean
  /-- doc -/
  @[library_note] def library_note.«my note» := ()
  ```
  so we don't have to do any string -> expr encoding.
* Similarly, the `description` field is removed from `tactic_doc_entry` and its data is moved to the doc string.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
