### PR TITLE
[Merged by Bors] - chore(data/sign): simplify definition of multiplication

### DIFF
--- a/src/data/sign.lean
+++ b/src/data/sign.lean
@@ -37,9 +37,7 @@ end⟩
 
 /-- The multiplication on `sign_type`. -/
 def mul : sign_type → sign_type → sign_type
-| neg neg  := pos
-| neg zero := zero
-| neg pos  := neg
+| neg h    := -h
 | zero _   := zero
 | pos h    := h
 

--- a/src/data/sign.lean
+++ b/src/data/sign.lean
@@ -37,9 +37,9 @@ end⟩
 
 /-- The multiplication on `sign_type`. -/
 def mul : sign_type → sign_type → sign_type
-| neg h    := -h
-| zero _   := zero
-| pos h    := h
+| neg h  := -h
+| zero _ := zero
+| pos h  := h
 
 instance : has_mul sign_type := ⟨mul⟩
 

--- a/src/data/sign.lean
+++ b/src/data/sign.lean
@@ -35,13 +35,12 @@ end⟩
 @[simp] lemma neg_eq_neg_one : neg = -1 := rfl
 @[simp] lemma pos_eq_one     : pos = 1  := rfl
 
-/-- The multiplication on `sign_type`. -/
-def mul : sign_type → sign_type → sign_type
-| neg h  := -h
-| zero _ := zero
-| pos h  := h
-
-instance : has_mul sign_type := ⟨mul⟩
+instance : has_mul sign_type :=
+⟨λ x y, match x with
+| neg  := -y
+| zero := zero
+| pos  := y
+end⟩
 
 /-- The less-than relation on signs. -/
 inductive le : sign_type → sign_type → Prop
@@ -226,3 +225,6 @@ begin
 end
 
 end add_group
+
+theorem int.not_acc (a : ℤ) : ¬ acc (<) a :=
+λ h, acc.rec_on h (λ x _ h, h _ (sub_one_lt x))

--- a/src/data/sign.lean
+++ b/src/data/sign.lean
@@ -225,6 +225,3 @@ begin
 end
 
 end add_group
-
-theorem int.not_acc (a : ℤ) : ¬ acc (<) a :=
-λ h, acc.rec_on h (λ x _ h, h _ (sub_one_lt x))


### PR DESCRIPTION
Removing cases from the match results in better definitional equalities, and is also shorter.

This also eliminates the separate `mul` definition for consistency with how the `has_neg` instance has the definition inlined.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
