### PR TITLE
[Merged by Bors] - chore(probability/*): change to probability notation in the probability folder

### DIFF
--- a/src/probability/cond_count.lean
+++ b/src/probability/cond_count.lean
@@ -40,31 +40,31 @@ open measure_theory measurable_space
 
 namespace probability_theory
 
-variables {α : Type*} [measurable_space α]
+variables {Ω : Type*} [measurable_space Ω]
 
 /-- Given a set `s`, `cond_count s` is the counting measure conditioned on `s`. In particular,
 `cond_count s t` is the proportion of `s` that is contained in `t`.
 
 This is a probability measure when `s` is finite and nonempty and is given by
 `probability_theory.cond_count_is_probability_measure`. -/
-def cond_count (s : set α) : measure α := measure.count[|s]
+def cond_count (s : set Ω) : measure Ω := measure.count[|s]
 
-@[simp] lemma cond_count_empty_meas : (cond_count ∅ : measure α) = 0 :=
+@[simp] lemma cond_count_empty_meas : (cond_count ∅ : measure Ω) = 0 :=
 by simp [cond_count]
 
-lemma cond_count_empty {s : set α} : cond_count s ∅ = 0 :=
+lemma cond_count_empty {s : set Ω} : cond_count s ∅ = 0 :=
 by simp
 
-lemma finite_of_cond_count_ne_zero {s t : set α} (h : cond_count s t ≠ 0) :
+lemma finite_of_cond_count_ne_zero {s t : set Ω} (h : cond_count s t ≠ 0) :
   s.finite :=
 begin
   by_contra hs',
   simpa [cond_count, cond, measure.count_apply_infinite hs'] using h,
 end
 
-variables [measurable_singleton_class α]
+variables [measurable_singleton_class Ω]
 
-lemma cond_count_is_probability_measure {s : set α} (hs : s.finite) (hs' : s.nonempty) :
+lemma cond_count_is_probability_measure {s : set Ω} (hs : s.finite) (hs' : s.nonempty) :
   is_probability_measure (cond_count s) :=
 { measure_univ :=
   begin
@@ -73,17 +73,17 @@ lemma cond_count_is_probability_measure {s : set α} (hs : s.finite) (hs' : s.no
     { exact (measure.count_apply_lt_top.2 hs).ne }
   end }
 
-lemma cond_count_singleton (a : α) (t : set α) [decidable (a ∈ t)] :
-  cond_count {a} t = if a ∈ t then 1 else 0 :=
+lemma cond_count_singleton (ω : Ω) (t : set Ω) [decidable (ω ∈ t)] :
+  cond_count {ω} t = if ω ∈ t then 1 else 0 :=
 begin
-  rw [cond_count, cond_apply _ (measurable_set_singleton a), measure.count_singleton,
+  rw [cond_count, cond_apply _ (measurable_set_singleton ω), measure.count_singleton,
     ennreal.inv_one, one_mul],
   split_ifs,
-  { rw [(by simpa : ({a} : set α) ∩ t = {a}), measure.count_singleton] },
-  { rw [(by simpa : ({a} : set α) ∩ t = ∅), measure.count_empty] },
+  { rw [(by simpa : ({ω} : set Ω) ∩ t = {ω}), measure.count_singleton] },
+  { rw [(by simpa : ({ω} : set Ω) ∩ t = ∅), measure.count_empty] },
 end
 
-variables {s t u : set α}
+variables {s t u : set Ω}
 
 lemma cond_count_inter_self (hs : s.finite):
   cond_count s (s ∩ t) = cond_count s t :=
@@ -159,7 +159,7 @@ begin
   exacts [htu.mono inf_le_right inf_le_right, (hs.inter_of_left _).measurable_set],
 end
 
-lemma cond_count_compl (t : set α) (hs : s.finite) (hs' : s.nonempty) :
+lemma cond_count_compl (t : set Ω) (hs : s.finite) (hs' : s.nonempty) :
   cond_count s t + cond_count s tᶜ = 1 :=
 begin
   rw [← cond_count_union hs disjoint_compl_right, set.union_compl_self,
@@ -190,7 +190,7 @@ begin
 end
 
 /-- A version of the law of total probability for counting probabilites. -/
-lemma cond_count_add_compl_eq (u t : set α) (hs : s.finite) :
+lemma cond_count_add_compl_eq (u t : set Ω) (hs : s.finite) :
   cond_count (s ∩ u) t * cond_count s u + cond_count (s ∩ uᶜ) t * cond_count s uᶜ =
   cond_count s t :=
 begin

--- a/src/probability/conditional_expectation.lean
+++ b/src/probability/conditional_expectation.lean
@@ -27,8 +27,8 @@ namespace measure_theory
 
 open probability_theory
 
-variables {α E : Type*} [normed_add_comm_group E] [normed_space ℝ E] [complete_space E]
-  {m₁ m₂ m : measurable_space α} {μ : measure α} {f : α → E}
+variables {Ω E : Type*} [normed_add_comm_group E] [normed_space ℝ E] [complete_space E]
+  {m₁ m₂ m : measurable_space Ω} {μ : measure Ω} {f : Ω → E}
 
 /-- If `m₁, m₂` are independent σ-algebras and `f` is `m₁`-measurable, then `𝔼[f | m₂] = 𝔼[f]`
 almost everywhere. -/

--- a/src/probability/conditional_probability.lean
+++ b/src/probability/conditional_probability.lean
@@ -10,13 +10,13 @@ import probability.independence
 
 This file defines conditional probability and includes basic results relating to it.
 
-Given some measure `μ` defined on a measure space on some type `α` and some `s : set α`,
+Given some measure `μ` defined on a measure space on some type `Ω` and some `s : set Ω`,
 we define the measure of `μ` conditioned on `s` as the restricted measure scaled by
 the inverse of the measure of `s`: `cond μ s = (μ s)⁻¹ • μ.restrict s`. The scaling
 ensures that this is a probability measure (when `μ` is a finite measure).
 
 From this definition, we derive the "axiomatic" definition of conditional probability
-based on application: for any `s t : set α`, we have `μ[t|s] = (μ s)⁻¹ * μ (s ∩ t)`.
+based on application: for any `s t : set Ω`, we have `μ[t|s] = (μ s)⁻¹ * μ (s ∩ t)`.
 
 ## Main Statements
 
@@ -59,7 +59,7 @@ open_locale ennreal
 
 open measure_theory measurable_space
 
-variables {α : Type*} {m : measurable_space α} (μ : measure α) {s t : set α}
+variables {Ω : Type*} {m : measurable_space Ω} (μ : measure Ω) {s t : set Ω}
 
 namespace probability_theory
 
@@ -68,7 +68,7 @@ section definitions
 /-- The conditional probability measure of measure `μ` on set `s` is `μ` restricted to `s`
 and scaled by the inverse of `μ s` (to make it a probability measure):
 `(μ s)⁻¹ • μ.restrict s`. -/
-def cond (s : set α) : measure α :=
+def cond (s : set Ω) : measure Ω :=
   (μ s)⁻¹ • μ.restrict s
 
 end definitions
@@ -93,11 +93,11 @@ by simp [cond]
 by simp [cond, measure_univ, measure.restrict_univ]
 
 /-- The axiomatic definition of conditional probability derived from a measure-theoretic one. -/
-lemma cond_apply (hms : measurable_set s) (t : set α) :
+lemma cond_apply (hms : measurable_set s) (t : set Ω) :
   μ[t|s] = (μ s)⁻¹ * μ (s ∩ t) :=
 by { rw [cond, measure.smul_apply, measure.restrict_apply' hms, set.inter_comm], refl }
 
-lemma cond_inter_self (hms : measurable_set s) (t : set α) :
+lemma cond_inter_self (hms : measurable_set s) (t : set Ω) :
   μ[s ∩ t|s] = μ[t|s] :=
 by rw [cond_apply _ hms, ← set.inter_assoc, set.inter_self, ← cond_apply _ hms]
 
@@ -138,13 +138,13 @@ lemma cond_cond_eq_cond_inter [is_finite_measure μ]
 cond_cond_eq_cond_inter' μ hms hmt (measure_ne_top μ s) hci
 
 lemma cond_mul_eq_inter'
-  (hms : measurable_set s) (hcs : μ s ≠ 0) (hcs' : μ s ≠ ∞) (t : set α) :
+  (hms : measurable_set s) (hcs : μ s ≠ 0) (hcs' : μ s ≠ ∞) (t : set Ω) :
   μ[t|s] * μ s = μ (s ∩ t) :=
 by rw [cond_apply μ hms t, mul_comm, ←mul_assoc,
   ennreal.mul_inv_cancel hcs hcs', one_mul]
 
 lemma cond_mul_eq_inter [is_finite_measure μ]
-  (hms : measurable_set s) (hcs : μ s ≠ 0) (t : set α) :
+  (hms : measurable_set s) (hcs : μ s ≠ 0) (t : set Ω) :
   μ[t|s] * μ s = μ (s ∩ t) :=
 cond_mul_eq_inter' μ hms hcs (measure_ne_top _ s) t
 

--- a/src/probability/density.lean
+++ b/src/probability/density.lean
@@ -21,8 +21,8 @@ random variables with this distribution.
 
 ## Main definitions
 
-* `measure_theory.has_pdf` : A random variable `X : α → E` is said to `has_pdf` with
-  respect to the measure `ℙ` on `α` and `μ` on `E` if there exists a measurable function `f`
+* `measure_theory.has_pdf` : A random variable `X : Ω → E` is said to `has_pdf` with
+  respect to the measure `ℙ` on `Ω` and `μ` on `E` if there exists a measurable function `f`
   such that the push-forward measure of `ℙ` along `X` equals `μ.with_density f`.
 * `measure_theory.pdf` : If `X` is a random variable that `has_pdf X ℙ μ`, then `pdf X`
   is the measurable function `f` such that the push-forward measure of `ℙ` along `X` equals
@@ -33,7 +33,7 @@ random variables with this distribution.
 ## Main results
 
 * `measure_theory.pdf.integral_fun_mul_eq_integral` : Law of the unconscious statistician,
-  i.e. if a random variable `X : α → E` has pdf `f`, then `𝔼(g(X)) = ∫ x, g x * f x dx` for
+  i.e. if a random variable `X : Ω → E` has pdf `f`, then `𝔼(g(X)) = ∫ x, g x * f x dx` for
   all measurable `g : E → ℝ`.
 * `measure_theory.pdf.integral_mul_eq_integral` : A real-valued random variable `X` with
   pdf `f` has expectation `∫ x, x * f x dx`.
@@ -55,32 +55,32 @@ namespace measure_theory
 
 open topological_space measure_theory.measure
 
-variables {α E : Type*} [measurable_space E]
+variables {Ω E : Type*} [measurable_space E]
 
-/-- A random variable `X : α → E` is said to `has_pdf` with respect to the measure `ℙ` on `α` and
+/-- A random variable `X : Ω → E` is said to `has_pdf` with respect to the measure `ℙ` on `Ω` and
 `μ` on `E` if there exists a measurable function `f` such that the push-forward measure of `ℙ`
 along `X` equals `μ.with_density f`. -/
-class has_pdf {m : measurable_space α} (X : α → E)
-  (ℙ : measure α) (μ : measure E . volume_tac) : Prop :=
+class has_pdf {m : measurable_space Ω} (X : Ω → E)
+  (ℙ : measure Ω) (μ : measure E . volume_tac) : Prop :=
 (pdf' : measurable X ∧ ∃ (f : E → ℝ≥0∞), measurable f ∧ map X ℙ = μ.with_density f)
 
 @[measurability]
-lemma has_pdf.measurable {m : measurable_space α}
-  (X : α → E) (ℙ : measure α) (μ : measure E . volume_tac) [hX : has_pdf X ℙ μ] :
+lemma has_pdf.measurable {m : measurable_space Ω}
+  (X : Ω → E) (ℙ : measure Ω) (μ : measure E . volume_tac) [hX : has_pdf X ℙ μ] :
   measurable X :=
 hX.pdf'.1
 
 /-- If `X` is a random variable that `has_pdf X ℙ μ`, then `pdf X` is the measurable function `f`
 such that the push-forward measure of `ℙ` along `X` equals `μ.with_density f`. -/
-def pdf {m : measurable_space α} (X : α → E) (ℙ : measure α) (μ : measure E . volume_tac) :=
+def pdf {m : measurable_space Ω} (X : Ω → E) (ℙ : measure Ω) (μ : measure E . volume_tac) :=
 if hX : has_pdf X ℙ μ then classical.some hX.pdf'.2 else 0
 
-lemma pdf_undef {m : measurable_space α} {ℙ : measure α} {μ : measure E} {X : α → E}
+lemma pdf_undef {m : measurable_space Ω} {ℙ : measure Ω} {μ : measure E} {X : Ω → E}
   (h : ¬ has_pdf X ℙ μ) :
   pdf X ℙ μ = 0 :=
 by simp only [pdf, dif_neg h]
 
-lemma has_pdf_of_pdf_ne_zero {m : measurable_space α} {ℙ : measure α} {μ : measure E} {X : α → E}
+lemma has_pdf_of_pdf_ne_zero {m : measurable_space Ω} {ℙ : measure Ω} {μ : measure E} {X : Ω → E}
   (h : pdf X ℙ μ ≠ 0) : has_pdf X ℙ μ :=
 begin
   by_contra hpdf,
@@ -88,19 +88,19 @@ begin
   exact hpdf (false.rec (has_pdf X ℙ μ) (h rfl))
 end
 
-lemma pdf_eq_zero_of_not_measurable {m : measurable_space α}
-  {ℙ : measure α} {μ : measure E} {X : α → E} (hX : ¬ measurable X) :
+lemma pdf_eq_zero_of_not_measurable {m : measurable_space Ω}
+  {ℙ : measure Ω} {μ : measure E} {X : Ω → E} (hX : ¬ measurable X) :
   pdf X ℙ μ = 0 :=
 pdf_undef (λ hpdf, hX hpdf.pdf'.1)
 
-lemma measurable_of_pdf_ne_zero {m : measurable_space α}
-  {ℙ : measure α} {μ : measure E} (X : α → E) (h : pdf X ℙ μ ≠ 0) :
+lemma measurable_of_pdf_ne_zero {m : measurable_space Ω}
+  {ℙ : measure Ω} {μ : measure E} (X : Ω → E) (h : pdf X ℙ μ ≠ 0) :
   measurable X :=
 by { by_contra hX, exact h (pdf_eq_zero_of_not_measurable hX) }
 
 @[measurability]
-lemma measurable_pdf {m : measurable_space α}
-  (X : α → E) (ℙ : measure α) (μ : measure E . volume_tac) :
+lemma measurable_pdf {m : measurable_space Ω}
+  (X : Ω → E) (ℙ : measure Ω) (μ : measure E . volume_tac) :
   measurable (pdf X ℙ μ) :=
 begin
   by_cases hX : has_pdf X ℙ μ,
@@ -110,32 +110,32 @@ begin
     exact measurable_zero }
 end
 
-lemma map_eq_with_density_pdf {m : measurable_space α}
-  (X : α → E) (ℙ : measure α) (μ : measure E . volume_tac) [hX : has_pdf X ℙ μ] :
+lemma map_eq_with_density_pdf {m : measurable_space Ω}
+  (X : Ω → E) (ℙ : measure Ω) (μ : measure E . volume_tac) [hX : has_pdf X ℙ μ] :
   measure.map X ℙ = μ.with_density (pdf X ℙ μ) :=
 begin
   rw [pdf, dif_pos hX],
   exact (classical.some_spec hX.pdf'.2).2
 end
 
-lemma map_eq_set_lintegral_pdf {m : measurable_space α}
-  (X : α → E) (ℙ : measure α) (μ : measure E . volume_tac) [hX : has_pdf X ℙ μ]
+lemma map_eq_set_lintegral_pdf {m : measurable_space Ω}
+  (X : Ω → E) (ℙ : measure Ω) (μ : measure E . volume_tac) [hX : has_pdf X ℙ μ]
   {s : set E} (hs : measurable_set s) :
   measure.map X ℙ s = ∫⁻ x in s, pdf X ℙ μ x ∂μ :=
 by rw [← with_density_apply _ hs, map_eq_with_density_pdf X ℙ μ]
 
 namespace pdf
 
-variables {m : measurable_space α} {ℙ : measure α} {μ : measure E}
+variables {m : measurable_space Ω} {ℙ : measure Ω} {μ : measure E}
 
-lemma lintegral_eq_measure_univ {X : α → E} [has_pdf X ℙ μ] :
+lemma lintegral_eq_measure_univ {X : Ω → E} [has_pdf X ℙ μ] :
   ∫⁻ x, pdf X ℙ μ x ∂μ = ℙ set.univ :=
 begin
   rw [← set_lintegral_univ, ← map_eq_set_lintegral_pdf X ℙ μ measurable_set.univ,
       measure.map_apply (has_pdf.measurable X ℙ μ) measurable_set.univ, set.preimage_univ],
 end
 
-lemma ae_lt_top [is_finite_measure ℙ] {μ : measure E} {X : α → E} :
+lemma ae_lt_top [is_finite_measure ℙ] {μ : measure E} {X : Ω → E} :
   ∀ᵐ x ∂μ, pdf X ℙ μ x < ∞ :=
 begin
   by_cases hpdf : has_pdf X ℙ μ,
@@ -147,11 +147,11 @@ begin
     exact filter.eventually_of_forall (λ x, with_top.zero_lt_top) }
 end
 
-lemma of_real_to_real_ae_eq [is_finite_measure ℙ] {X : α → E} :
+lemma of_real_to_real_ae_eq [is_finite_measure ℙ] {X : Ω → E} :
   (λ x, ennreal.of_real (pdf X ℙ μ x).to_real) =ᵐ[μ] pdf X ℙ μ :=
 of_real_to_real_ae_eq ae_lt_top
 
-lemma integrable_iff_integrable_mul_pdf [is_finite_measure ℙ] {X : α → E} [has_pdf X ℙ μ]
+lemma integrable_iff_integrable_mul_pdf [is_finite_measure ℙ] {X : Ω → E} [has_pdf X ℙ μ]
   {f : E → ℝ} (hf : measurable f) :
   integrable (λ x, f (X x)) ℙ ↔ integrable (λ x, f x * (pdf X ℙ μ x).to_real) μ :=
 begin
@@ -165,7 +165,7 @@ end
 function `f`, `f ∘ X` is a random variable with expectation `∫ x, f x * pdf X ∂μ`
 where `μ` is a measure on the codomain of `X`. -/
 lemma integral_fun_mul_eq_integral [is_finite_measure ℙ]
-  {X : α → E} [has_pdf X ℙ μ] {f : E → ℝ} (hf : measurable f) :
+  {X : Ω → E} [has_pdf X ℙ μ] {f : E → ℝ} (hf : measurable f) :
   ∫ x, f x * (pdf X ℙ μ x).to_real ∂μ = ∫ x, f (X x) ∂ℙ :=
 begin
   by_cases hpdf : integrable (λ x, f x * (pdf X ℙ μ x).to_real) μ,
@@ -206,21 +206,21 @@ begin
     all_goals { apply_instance } }
 end
 
-lemma map_absolutely_continuous {X : α → E} [has_pdf X ℙ μ] : map X ℙ ≪ μ :=
+lemma map_absolutely_continuous {X : Ω → E} [has_pdf X ℙ μ] : map X ℙ ≪ μ :=
 by { rw map_eq_with_density_pdf X ℙ μ, exact with_density_absolutely_continuous _ _, }
 
 /-- A random variable that `has_pdf` is quasi-measure preserving. -/
-lemma to_quasi_measure_preserving {X : α → E} [has_pdf X ℙ μ] : quasi_measure_preserving X ℙ μ :=
+lemma to_quasi_measure_preserving {X : Ω → E} [has_pdf X ℙ μ] : quasi_measure_preserving X ℙ μ :=
 { measurable := has_pdf.measurable X ℙ μ,
   absolutely_continuous := map_absolutely_continuous, }
 
-lemma have_lebesgue_decomposition_of_has_pdf {X : α → E} [hX' : has_pdf X ℙ μ] :
+lemma have_lebesgue_decomposition_of_has_pdf {X : Ω → E} [hX' : has_pdf X ℙ μ] :
   (map X ℙ).have_lebesgue_decomposition μ :=
 ⟨⟨⟨0, pdf X ℙ μ⟩,
   by simp only [zero_add, measurable_pdf X ℙ μ, true_and, mutually_singular.zero_left,
     map_eq_with_density_pdf X ℙ μ] ⟩⟩
 
-lemma has_pdf_iff {X : α → E} :
+lemma has_pdf_iff {X : Ω → E} :
   has_pdf X ℙ μ ↔ measurable X ∧ (map X ℙ).have_lebesgue_decomposition μ ∧ map X ℙ ≪ μ :=
 begin
   split,
@@ -232,7 +232,7 @@ begin
     rwa with_density_rn_deriv_eq }
 end
 
-lemma has_pdf_iff_of_measurable {X : α → E} (hX : measurable X) :
+lemma has_pdf_iff_of_measurable {X : Ω → E} (hX : measurable X) :
   has_pdf X ℙ μ ↔ (map X ℙ).have_lebesgue_decomposition μ ∧ map X ℙ ≪ μ :=
 by { rw has_pdf_iff, simp only [hX, true_and], }
 
@@ -245,7 +245,7 @@ map also `has_pdf` if `(map g (map X ℙ)).have_lebesgue_decomposition μ`.
 
 `quasi_measure_preserving_has_pdf'` is more useful in the case we are working with a
 probability measure and a real-valued random variable. -/
-lemma quasi_measure_preserving_has_pdf {X : α → E} [has_pdf X ℙ μ]
+lemma quasi_measure_preserving_has_pdf {X : Ω → E} [has_pdf X ℙ μ]
   {g : E → F} (hg : quasi_measure_preserving g μ ν)
   (hmap : (map g (map X ℙ)).have_lebesgue_decomposition ν) :
   has_pdf (g ∘ X) ℙ ν :=
@@ -261,7 +261,7 @@ begin
 end
 
 lemma quasi_measure_preserving_has_pdf' [is_finite_measure ℙ] [sigma_finite ν]
-  {X : α → E} [has_pdf X ℙ μ] {g : E → F} (hg : quasi_measure_preserving g μ ν) :
+  {X : Ω → E} [has_pdf X ℙ μ] {g : E → F} (hg : quasi_measure_preserving g μ ν) :
   has_pdf (g ∘ X) ℙ ν :=
 quasi_measure_preserving_has_pdf hg infer_instance
 
@@ -269,7 +269,7 @@ end
 
 section real
 
-variables [is_finite_measure ℙ] {X : α → ℝ}
+variables [is_finite_measure ℙ] {X : Ω → ℝ}
 
 /-- A real-valued random variable `X` `has_pdf X ℙ λ` (where `λ` is the Lebesgue measure) if and
 only if the push-forward measure of `ℙ` along `X` is absolutely continuous with respect to `λ`. -/
@@ -318,13 +318,13 @@ section
 
 /-- A random variable `X` has uniform distribution if it has a probability density function `f`
 with support `s` such that `f = (μ s)⁻¹ 1ₛ` a.e. where `1ₛ` is the indicator function for `s`. -/
-def is_uniform {m : measurable_space α} (X : α → E) (support : set E)
-  (ℙ : measure α) (μ : measure E . volume_tac) :=
+def is_uniform {m : measurable_space Ω} (X : Ω → E) (support : set E)
+  (ℙ : measure Ω) (μ : measure E . volume_tac) :=
 pdf X ℙ μ =ᵐ[μ] support.indicator ((μ support)⁻¹ • 1)
 
 namespace is_uniform
 
-lemma has_pdf {m : measurable_space α} {X : α → E} {ℙ : measure α} {μ : measure E}
+lemma has_pdf {m : measurable_space Ω} {X : Ω → E} {ℙ : measure Ω} {μ : measure E}
   {s : set E} (hns : μ s ≠ 0) (hnt : μ s ≠ ∞) (hu : is_uniform X s ℙ μ) :
   has_pdf X ℙ μ :=
 has_pdf_of_pdf_ne_zero
@@ -341,13 +341,13 @@ begin
   exact set.indicator_ae_eq_zero hu.symm,
 end
 
-lemma pdf_to_real_ae_eq {m : measurable_space α}
-  {X : α → E} {ℙ : measure α} {μ : measure E} {s : set E} (hX : is_uniform X s ℙ μ) :
+lemma pdf_to_real_ae_eq {m : measurable_space Ω}
+  {X : Ω → E} {ℙ : measure Ω} {μ : measure E} {s : set E} (hX : is_uniform X s ℙ μ) :
   (λ x, (pdf X ℙ μ x).to_real) =ᵐ[μ]
   (λ x, (s.indicator ((μ s)⁻¹ • (1 : E → ℝ≥0∞)) x).to_real) :=
 filter.eventually_eq.fun_comp hX ennreal.to_real
 
-lemma measure_preimage {m : measurable_space α} {X : α → E} {ℙ : measure α} {μ : measure E}
+lemma measure_preimage {m : measurable_space Ω} {X : Ω → E} {ℙ : measure Ω} {μ : measure E}
   {s : set E} (hns : μ s ≠ 0) (hnt : μ s ≠ ∞) (hms : measurable_set s)
   (hu : is_uniform X s ℙ μ)
   {A : set E} (hA : measurable_set A) :
@@ -361,7 +361,7 @@ begin
   rw ennreal.div_eq_inv_mul,
 end
 
-lemma is_probability_measure {m : measurable_space α} {X : α → E} {ℙ : measure α} {μ : measure E}
+lemma is_probability_measure {m : measurable_space Ω} {X : Ω → E} {ℙ : measure Ω} {μ : measure E}
   {s : set E} (hns : μ s ≠ 0) (hnt : μ s ≠ ∞) (hms : measurable_set s)
   (hu : is_uniform X s ℙ μ) :
   is_probability_measure ℙ :=
@@ -371,7 +371,7 @@ lemma is_probability_measure {m : measurable_space α} {X : α → E} {ℙ : mea
     ennreal.div_self hns hnt],
 end⟩
 
-variables {X : α → ℝ} {s : set ℝ} (hms : measurable_set s) (hns : volume s ≠ 0)
+variables {X : Ω → ℝ} {s : set ℝ} (hms : measurable_set s) (hns : volume s ≠ 0)
 
 include hms hns
 

--- a/src/probability/hitting_time.lean
+++ b/src/probability/hitting_time.lean
@@ -37,24 +37,24 @@ open_locale classical measure_theory nnreal ennreal topological_space big_operat
 
 namespace measure_theory
 
-variables {α β ι : Type*} {m : measurable_space α}
+variables {Ω β ι : Type*} {m : measurable_space Ω}
 
 /-- Hitting time: given a stochastic process `u` and a set `s`, `hitting u s n m` is the first time
 `u` is in `s` after time `n` and before time `m` (if `u` does not hit `s` after time `n` and
 before `m` then the hitting time is simply `m`).
 
 The hitting time is a stopping time if the process is adapted and discrete. -/
-noncomputable def hitting [preorder ι] [has_Inf ι] (u : ι → α → β) (s : set β) (n m : ι) : α → ι :=
+noncomputable def hitting [preorder ι] [has_Inf ι] (u : ι → Ω → β) (s : set β) (n m : ι) : Ω → ι :=
 λ x, if ∃ j ∈ set.Icc n m, u j x ∈ s then Inf (set.Icc n m ∩ {i : ι | u i x ∈ s}) else m
 
 section inequalities
 
-variables [conditionally_complete_linear_order ι] {u : ι → α → β} {s : set β} {n i : ι} {x : α}
+variables [conditionally_complete_linear_order ι] {u : ι → Ω → β} {s : set β} {n i : ι} {ω : Ω}
 
-lemma hitting_of_lt {m : ι} (h : m < n) : hitting u s n m x = m :=
+lemma hitting_of_lt {m : ι} (h : m < n) : hitting u s n m ω = m :=
 begin
   simp_rw [hitting],
-  have h_not : ¬∃ (j : ι) (H : j ∈ set.Icc n m), u j x ∈ s,
+  have h_not : ¬ ∃ (j : ι) (H : j ∈ set.Icc n m), u j ω ∈ s,
   { push_neg,
     intro j,
     rw set.Icc_eq_empty_of_lt h,
@@ -62,7 +62,7 @@ begin
   simp only [h_not, if_false],
 end
 
-lemma hitting_le {m : ι} (x : α) : hitting u s n m x ≤ m :=
+lemma hitting_le {m : ι} (ω : Ω) : hitting u s n m ω ≤ m :=
 begin
   cases le_or_lt n m with h_le h_lt,
   { simp only [hitting],
@@ -73,7 +73,7 @@ begin
   { rw hitting_of_lt h_lt, },
 end
 
-lemma le_hitting {m : ι} (hnm : n ≤ m) (x : α) : n ≤ hitting u s n m x :=
+lemma le_hitting {m : ι} (hnm : n ≤ m) (ω : Ω) : n ≤ hitting u s n m ω :=
 begin
   simp only [hitting],
   split_ifs,
@@ -85,23 +85,23 @@ begin
   { exact hnm },
 end
 
-lemma le_hitting_of_exists {m : ι} (h_exists : ∃ j ∈ set.Icc n m, u j x ∈ s) :
-  n ≤ hitting u s n m x :=
+lemma le_hitting_of_exists {m : ι} (h_exists : ∃ j ∈ set.Icc n m, u j ω ∈ s) :
+  n ≤ hitting u s n m ω :=
 begin
-  refine le_hitting _ x,
+  refine le_hitting _ ω,
   by_contra,
   rw set.Icc_eq_empty_of_lt (not_le.mp h) at h_exists,
   simpa using h_exists,
 end
 
-lemma hitting_mem_Icc {m : ι} (hnm : n ≤ m) (x : α) : hitting u s n m x ∈ set.Icc n m :=
-⟨le_hitting hnm x, hitting_le x⟩
+lemma hitting_mem_Icc {m : ι} (hnm : n ≤ m) (ω : Ω) : hitting u s n m ω ∈ set.Icc n m :=
+⟨le_hitting hnm ω, hitting_le ω⟩
 
-lemma hitting_mem_set [is_well_order ι (<)] {m : ι} (h_exists : ∃ j ∈ set.Icc n m, u j x ∈ s) :
-  u (hitting u s n m x) x ∈ s :=
+lemma hitting_mem_set [is_well_order ι (<)] {m : ι} (h_exists : ∃ j ∈ set.Icc n m, u j ω ∈ s) :
+  u (hitting u s n m ω) ω ∈ s :=
 begin
   simp_rw [hitting, if_pos h_exists],
-  have h_nonempty : (set.Icc n m ∩ {i : ι | u i x ∈ s}).nonempty,
+  have h_nonempty : (set.Icc n m ∩ {i : ι | u i ω ∈ s}).nonempty,
   { obtain ⟨k, hk₁, hk₂⟩ := h_exists,
     exact ⟨k, set.mem_inter hk₁ hk₂⟩, },
   have h_mem := Inf_mem h_nonempty,
@@ -109,34 +109,34 @@ begin
   exact h_mem.2,
 end
 
-lemma hitting_le_of_mem {m : ι} (hin : n ≤ i) (him : i ≤ m) (his : u i x ∈ s) :
-  hitting u s n m x ≤ i :=
+lemma hitting_le_of_mem {m : ι} (hin : n ≤ i) (him : i ≤ m) (his : u i ω ∈ s) :
+  hitting u s n m ω ≤ i :=
 begin
-  have h_exists : ∃ k ∈ set.Icc n m, u k x ∈ s := ⟨i, ⟨hin, him⟩, his⟩,
+  have h_exists : ∃ k ∈ set.Icc n m, u k ω ∈ s := ⟨i, ⟨hin, him⟩, his⟩,
   simp_rw [hitting, if_pos h_exists],
   exact cInf_le (bdd_below.inter_of_left bdd_below_Icc) (set.mem_inter ⟨hin, him⟩ his),
 end
 
 lemma hitting_le_iff_of_exists [is_well_order ι (<)] {m : ι}
-  (h_exists : ∃ j ∈ set.Icc n m, u j x ∈ s) :
-  hitting u s n m x ≤ i ↔ ∃ j ∈ set.Icc n i, u j x ∈ s :=
+  (h_exists : ∃ j ∈ set.Icc n m, u j ω ∈ s) :
+  hitting u s n m ω ≤ i ↔ ∃ j ∈ set.Icc n i, u j ω ∈ s :=
 begin
   split; intro h',
-  { exact ⟨hitting u s n m x, ⟨le_hitting_of_exists h_exists, h'⟩, hitting_mem_set h_exists⟩, },
-  { have h'' : ∃ k ∈ set.Icc n (min m i), u k x ∈ s,
+  { exact ⟨hitting u s n m ω, ⟨le_hitting_of_exists h_exists, h'⟩, hitting_mem_set h_exists⟩, },
+  { have h'' : ∃ k ∈ set.Icc n (min m i), u k ω ∈ s,
     { obtain ⟨k₁, hk₁_mem, hk₁_s⟩ := h_exists,
       obtain ⟨k₂, hk₂_mem, hk₂_s⟩ := h',
       refine ⟨min k₁ k₂, ⟨le_min hk₁_mem.1 hk₂_mem.1, min_le_min hk₁_mem.2 hk₂_mem.2⟩, _⟩,
-      exact min_rec' (λ j, u j x ∈ s) hk₁_s hk₂_s, },
+      exact min_rec' (λ j, u j ω ∈ s) hk₁_s hk₂_s, },
     obtain ⟨k, hk₁, hk₂⟩ := h'',
     refine le_trans _ (hk₁.2.trans (min_le_right _ _)),
     exact hitting_le_of_mem hk₁.1 (hk₁.2.trans (min_le_left _ _)) hk₂, },
 end
 
 lemma hitting_le_iff_of_lt [is_well_order ι (<)] {m : ι} (i : ι) (hi : i < m) :
-  hitting u s n m x ≤ i ↔ ∃ j ∈ set.Icc n i, u j x ∈ s :=
+  hitting u s n m ω ≤ i ↔ ∃ j ∈ set.Icc n i, u j ω ∈ s :=
 begin
-  by_cases h_exists : ∃ j ∈ set.Icc n m, u j x ∈ s,
+  by_cases h_exists : ∃ j ∈ set.Icc n m, u j ω ∈ s,
   { rw hitting_le_iff_of_exists h_exists, },
   { simp_rw [hitting, if_neg h_exists],
     push_neg at h_exists,
@@ -145,22 +145,22 @@ begin
 end
 
 lemma hitting_lt_iff [is_well_order ι (<)] {m : ι} (i : ι) (hi : i ≤ m) :
-  hitting u s n m x < i ↔ ∃ j ∈ set.Ico n i, u j x ∈ s :=
+  hitting u s n m ω < i ↔ ∃ j ∈ set.Ico n i, u j ω ∈ s :=
 begin
   split; intro h',
-  { have h : ∃ j ∈ set.Icc n m, u j x ∈ s,
+  { have h : ∃ j ∈ set.Icc n m, u j ω ∈ s,
     { by_contra,
       simp_rw [hitting, if_neg h, ← not_le] at h',
       exact h' hi, },
-    exact ⟨hitting u s n m x, ⟨le_hitting_of_exists h, h'⟩, hitting_mem_set h⟩, },
+    exact ⟨hitting u s n m ω, ⟨le_hitting_of_exists h, h'⟩, hitting_mem_set h⟩, },
   { obtain ⟨k, hk₁, hk₂⟩ := h',
     refine lt_of_le_of_lt _ hk₁.2,
     exact hitting_le_of_mem hk₁.1 (hk₁.2.le.trans hi) hk₂, },
 end
 
 lemma hitting_eq_hitting_of_exists
-  {m₁ m₂ : ι} (h : m₁ ≤ m₂) (h' : ∃ j ∈ set.Icc n m₁, u j x ∈ s) :
-  hitting u s n m₁ x = hitting u s n m₂ x :=
+  {m₁ m₂ : ι} (h : m₁ ≤ m₂) (h' : ∃ j ∈ set.Icc n m₁, u j ω ∈ s) :
+  hitting u s n m₁ ω = hitting u s n m₂ ω :=
 begin
   simp only [hitting, if_pos h'],
   obtain ⟨j, hj₁, hj₂⟩ := h',
@@ -181,15 +181,15 @@ end inequalities
 lemma hitting_is_stopping_time
   [conditionally_complete_linear_order ι] [is_well_order ι (<)] [encodable ι]
   [topological_space β] [pseudo_metrizable_space β] [measurable_space β] [borel_space β]
-  {f : filtration ι m} {u : ι → α → β} {s : set β} {n n' : ι}
+  {f : filtration ι m} {u : ι → Ω → β} {s : set β} {n n' : ι}
   (hu : adapted f u) (hs : measurable_set s) :
   is_stopping_time f (hitting u s n n') :=
 begin
   intro i,
   cases le_or_lt n' i with hi hi,
-  { have h_le : ∀ x, hitting u s n n' x ≤ i := λ x, (hitting_le x).trans hi,
+  { have h_le : ∀ ω, hitting u s n n' ω ≤ i := λ x, (hitting_le x).trans hi,
     simp [h_le], },
-  { have h_set_eq_Union : {x | hitting u s n n' x ≤ i} = ⋃ j ∈ set.Icc n i, u j ⁻¹' s,
+  { have h_set_eq_Union : {ω | hitting u s n n' ω ≤ i} = ⋃ j ∈ set.Icc n i, u j ⁻¹' s,
     { ext x,
       rw [set.mem_set_of_eq, hitting_le_iff_of_lt _ hi],
       simp only [set.mem_Icc, exists_prop, set.mem_Union, set.mem_preimage], },
@@ -199,12 +199,12 @@ begin
 end
 
 lemma stopped_value_hitting_mem [conditionally_complete_linear_order ι] [is_well_order ι (<)]
-  {u : ι → α → β} {s : set β} {n m : ι} {x : α} (h : ∃ j ∈ set.Icc n m, u j x ∈ s) :
-  stopped_value u (hitting u s n m) x ∈ s :=
+  {u : ι → Ω → β} {s : set β} {n m : ι} {ω : Ω} (h : ∃ j ∈ set.Icc n m, u j ω ∈ s) :
+  stopped_value u (hitting u s n m) ω ∈ s :=
 begin
   simp only [stopped_value, hitting, if_pos h],
   obtain ⟨j, hj₁, hj₂⟩ := h,
-  have : Inf (set.Icc n m ∩ {i | u i x ∈ s}) ∈ set.Icc n m ∩ {i | u i x ∈ s} :=
+  have : Inf (set.Icc n m ∩ {i | u i ω ∈ s}) ∈ set.Icc n m ∩ {i | u i ω ∈ s} :=
     Inf_mem (set.nonempty_of_mem ⟨hj₁, hj₂⟩),
   exact this.2,
 end
@@ -215,7 +215,7 @@ lemma is_stopping_time_hitting_is_stopping_time
   [conditionally_complete_linear_order ι] [is_well_order ι (<)] [encodable ι]
   [topological_space ι] [order_topology ι] [first_countable_topology ι]
   [topological_space β] [pseudo_metrizable_space β] [measurable_space β] [borel_space β]
-  {f : filtration ι m} {u : ι → α → β} {τ : α → ι} (hτ : is_stopping_time f τ)
+  {f : filtration ι m} {u : ι → Ω → β} {τ : Ω → ι} (hτ : is_stopping_time f τ)
   {N : ι} (hτbdd : ∀ x, τ x ≤ N) {s : set β} (hs : measurable_set s) (hf : adapted f u) :
   is_stopping_time f (λ x, hitting u s (τ x) N x) :=
 begin
@@ -238,9 +238,9 @@ end
 
 section complete_lattice
 
-variables [complete_lattice ι] {u : ι → α → β} {s : set β} {f : filtration ι m}
+variables [complete_lattice ι] {u : ι → Ω → β} {s : set β} {f : filtration ι m}
 
-lemma hitting_eq_Inf (x : α) : hitting u s ⊥ ⊤ x = Inf {i : ι | u i x ∈ s} :=
+lemma hitting_eq_Inf (ω : Ω) : hitting u s ⊥ ⊤ ω = Inf {i : ι | u i ω ∈ s} :=
 begin
   simp only [hitting, set.mem_Icc, bot_le, le_top, and_self, exists_true_left, set.Icc_bot,
     set.Iic_top, set.univ_inter, ite_eq_left_iff, not_exists],
@@ -255,15 +255,15 @@ end complete_lattice
 section conditionally_complete_linear_order_bot
 
 variables [conditionally_complete_linear_order_bot ι] [is_well_order ι (<)]
-variables {u : ι → α → β} {s : set β} {f : filtration ℕ m}
+variables {u : ι → Ω → β} {s : set β} {f : filtration ℕ m}
 
-lemma hitting_bot_le_iff {i n : ι} {x : α} (hx : ∃ j, j ≤ n ∧ u j x ∈ s) :
-  hitting u s ⊥ n x ≤ i ↔ ∃ j ≤ i, u j x ∈ s :=
+lemma hitting_bot_le_iff {i n : ι} {ω : Ω} (hx : ∃ j, j ≤ n ∧ u j ω ∈ s) :
+  hitting u s ⊥ n ω ≤ i ↔ ∃ j ≤ i, u j ω ∈ s :=
 begin
   cases lt_or_le i n with hi hi,
   { rw hitting_le_iff_of_lt _ hi,
     simp, },
-  { simp only [(hitting_le x).trans hi, true_iff],
+  { simp only [(hitting_le ω).trans hi, true_iff],
     obtain ⟨j, hj₁, hj₂⟩ := hx,
     exact ⟨j, hj₁.trans hi, hj₂⟩, },
 end

--- a/src/probability/independence.lean
+++ b/src/probability/independence.lean
@@ -9,12 +9,12 @@ import measure_theory.constructions.pi
 /-!
 # Independence of sets of sets and measure spaces (σ-algebras)
 
-* A family of sets of sets `π : ι → set (set α)` is independent with respect to a measure `μ` if for
+* A family of sets of sets `π : ι → set (set Ω)` is independent with respect to a measure `μ` if for
   any finite set of indices `s = {i_1, ..., i_n}`, for any sets `f i_1 ∈ π i_1, ..., f i_n ∈ π i_n`,
   `μ (⋂ i in s, f i) = ∏ i in s, μ (f i) `. It will be used for families of π-systems.
 * A family of measurable space structures (i.e. of σ-algebras) is independent with respect to a
   measure `μ` (typically defined on a finer σ-algebra) if the family of sets of measurable sets they
-  define is independent. I.e., `m : ι → measurable_space α` is independent with respect to a
+  define is independent. I.e., `m : ι → measurable_space Ω` is independent with respect to a
   measure `μ` if for any finite set of indices `s = {i_1, ..., i_n}`, for any sets
   `f i_1 ∈ m i_1, ..., f i_n ∈ m i_n`, then `μ (⋂ i in s, f i) = ∏ i in s, μ (f i)`.
 * Independence of sets (or events in probabilistic parlance) is defined as independence of the
@@ -33,12 +33,12 @@ measurable space structures they generate are independent.
 ## Implementation notes
 
 We provide one main definition of independence:
-* `Indep_sets`: independence of a family of sets of sets `pi : ι → set (set α)`.
+* `Indep_sets`: independence of a family of sets of sets `pi : ι → set (set Ω)`.
 Three other independence notions are defined using `Indep_sets`:
-* `Indep`: independence of a family of measurable space structures `m : ι → measurable_space α`,
-* `Indep_set`: independence of a family of sets `s : ι → set α`,
+* `Indep`: independence of a family of measurable space structures `m : ι → measurable_space Ω`,
+* `Indep_set`: independence of a family of sets `s : ι → set Ω`,
 * `Indep_fun`: independence of a family of functions. For measurable spaces
-  `m : Π (i : ι), measurable_space (β i)`, we consider functions `f : Π (i : ι), α → β i`.
+  `m : Π (i : ι), measurable_space (β i)`, we consider functions `f : Π (i : ι), Ω → β i`.
 
 Additionally, we provide four corresponding statements for two measurable space structures (resp.
 sets of sets, sets, functions) instead of a family. These properties are denoted by the same names
@@ -51,10 +51,10 @@ TODO: prove that equivalence.
 
 Most of the definitions and lemma in this file list all variables instead of using the `variables`
 keyword at the beginning of a section, for example
-`lemma indep.symm {α} {m₁ m₂ : measurable_space α} [measurable_space α] {μ : measure α} ...` .
+`lemma indep.symm {Ω} {m₁ m₂ : measurable_space Ω} [measurable_space Ω] {μ : measure Ω} ...` .
 This is intentional, to be able to control the order of the `measurable_space` variables. Indeed
 when defining `μ` in the example above, the measurable space used is the last one defined, here
-`[measurable_space α]`, and not `m₁` or `m₂`.
+`[measurable_space Ω]`, and not `m₁` or `m₂`.
 
 ## References
 
@@ -69,95 +69,95 @@ namespace probability_theory
 
 section definitions
 
-/-- A family of sets of sets `π : ι → set (set α)` is independent with respect to a measure `μ` if
+/-- A family of sets of sets `π : ι → set (set Ω)` is independent with respect to a measure `μ` if
 for any finite set of indices `s = {i_1, ..., i_n}`, for any sets
 `f i_1 ∈ π i_1, ..., f i_n ∈ π i_n`, then `μ (⋂ i in s, f i) = ∏ i in s, μ (f i) `.
 It will be used for families of pi_systems. -/
-def Indep_sets {α ι} [measurable_space α] (π : ι → set (set α)) (μ : measure α . volume_tac) :
+def Indep_sets {Ω ι} [measurable_space Ω] (π : ι → set (set Ω)) (μ : measure Ω . volume_tac) :
   Prop :=
-∀ (s : finset ι) {f : ι → set α} (H : ∀ i, i ∈ s → f i ∈ π i), μ (⋂ i ∈ s, f i) = ∏ i in s, μ (f i)
+∀ (s : finset ι) {f : ι → set Ω} (H : ∀ i, i ∈ s → f i ∈ π i), μ (⋂ i ∈ s, f i) = ∏ i in s, μ (f i)
 
 /-- Two sets of sets `s₁, s₂` are independent with respect to a measure `μ` if for any sets
 `t₁ ∈ p₁, t₂ ∈ s₂`, then `μ (t₁ ∩ t₂) = μ (t₁) * μ (t₂)` -/
-def indep_sets {α} [measurable_space α] (s1 s2 : set (set α)) (μ : measure α . volume_tac) : Prop :=
-∀ t1 t2 : set α, t1 ∈ s1 → t2 ∈ s2 → μ (t1 ∩ t2) = μ t1 * μ t2
+def indep_sets {Ω} [measurable_space Ω] (s1 s2 : set (set Ω)) (μ : measure Ω . volume_tac) : Prop :=
+∀ t1 t2 : set Ω, t1 ∈ s1 → t2 ∈ s2 → μ (t1 ∩ t2) = μ t1 * μ t2
 
 /-- A family of measurable space structures (i.e. of σ-algebras) is independent with respect to a
 measure `μ` (typically defined on a finer σ-algebra) if the family of sets of measurable sets they
-define is independent. `m : ι → measurable_space α` is independent with respect to measure `μ` if
+define is independent. `m : ι → measurable_space Ω` is independent with respect to measure `μ` if
 for any finite set of indices `s = {i_1, ..., i_n}`, for any sets
 `f i_1 ∈ m i_1, ..., f i_n ∈ m i_n`, then `μ (⋂ i in s, f i) = ∏ i in s, μ (f i) `. -/
-def Indep {α ι} (m : ι → measurable_space α) [measurable_space α] (μ : measure α . volume_tac) :
+def Indep {Ω ι} (m : ι → measurable_space Ω) [measurable_space Ω] (μ : measure Ω . volume_tac) :
   Prop :=
 Indep_sets (λ x, {s | measurable_set[m x] s}) μ
 
 /-- Two measurable space structures (or σ-algebras) `m₁, m₂` are independent with respect to a
 measure `μ` (defined on a third σ-algebra) if for any sets `t₁ ∈ m₁, t₂ ∈ m₂`,
 `μ (t₁ ∩ t₂) = μ (t₁) * μ (t₂)` -/
-def indep {α} (m₁ m₂ : measurable_space α) [measurable_space α] (μ : measure α . volume_tac) :
+def indep {Ω} (m₁ m₂ : measurable_space Ω) [measurable_space Ω] (μ : measure Ω . volume_tac) :
   Prop :=
 indep_sets {s | measurable_set[m₁] s} {s | measurable_set[m₂] s} μ
 
 /-- A family of sets is independent if the family of measurable space structures they generate is
 independent. For a set `s`, the generated measurable space has measurable sets `∅, s, sᶜ, univ`. -/
-def Indep_set {α ι} [measurable_space α] (s : ι → set α) (μ : measure α . volume_tac) : Prop :=
+def Indep_set {Ω ι} [measurable_space Ω] (s : ι → set Ω) (μ : measure Ω . volume_tac) : Prop :=
 Indep (λ i, generate_from {s i}) μ
 
 /-- Two sets are independent if the two measurable space structures they generate are independent.
 For a set `s`, the generated measurable space structure has measurable sets `∅, s, sᶜ, univ`. -/
-def indep_set {α} [measurable_space α] (s t : set α) (μ : measure α . volume_tac) : Prop :=
+def indep_set {Ω} [measurable_space Ω] (s t : set Ω) (μ : measure Ω . volume_tac) : Prop :=
 indep (generate_from {s}) (generate_from {t}) μ
 
-/-- A family of functions defined on the same space `α` and taking values in possibly different
+/-- A family of functions defined on the same space `Ω` and taking values in possibly different
 spaces, each with a measurable space structure, is independent if the family of measurable space
-structures they generate on `α` is independent. For a function `g` with codomain having measurable
+structures they generate on `Ω` is independent. For a function `g` with codomain having measurable
 space structure `m`, the generated measurable space structure is `measurable_space.comap g m`. -/
-def Indep_fun {α ι} [measurable_space α] {β : ι → Type*} (m : Π (x : ι), measurable_space (β x))
-  (f : Π (x : ι), α → β x) (μ : measure α . volume_tac) : Prop :=
+def Indep_fun {Ω ι} [measurable_space Ω] {β : ι → Type*} (m : Π (x : ι), measurable_space (β x))
+  (f : Π (x : ι), Ω → β x) (μ : measure Ω . volume_tac) : Prop :=
 Indep (λ x, measurable_space.comap (f x) (m x)) μ
 
 /-- Two functions are independent if the two measurable space structures they generate are
 independent. For a function `f` with codomain having measurable space structure `m`, the generated
 measurable space structure is `measurable_space.comap f m`. -/
-def indep_fun {α β γ} [measurable_space α] [mβ : measurable_space β] [mγ : measurable_space γ]
-  (f : α → β) (g : α → γ) (μ : measure α . volume_tac) : Prop :=
+def indep_fun {Ω β γ} [measurable_space Ω] [mβ : measurable_space β] [mγ : measurable_space γ]
+  (f : Ω → β) (g : Ω → γ) (μ : measure Ω . volume_tac) : Prop :=
 indep (measurable_space.comap f mβ) (measurable_space.comap g mγ) μ
 
 end definitions
 
 section indep
 
-lemma indep_sets.symm {α} {s₁ s₂ : set (set α)} [measurable_space α] {μ : measure α}
+lemma indep_sets.symm {Ω} {s₁ s₂ : set (set Ω)} [measurable_space Ω] {μ : measure Ω}
   (h : indep_sets s₁ s₂ μ) :
   indep_sets s₂ s₁ μ :=
 by { intros t1 t2 ht1 ht2, rw [set.inter_comm, mul_comm], exact h t2 t1 ht2 ht1, }
 
-lemma indep.symm {α} {m₁ m₂ : measurable_space α} [measurable_space α] {μ : measure α}
+lemma indep.symm {Ω} {m₁ m₂ : measurable_space Ω} [measurable_space Ω] {μ : measure Ω}
   (h : indep m₁ m₂ μ) :
   indep m₂ m₁ μ :=
 indep_sets.symm h
 
-lemma indep_sets_of_indep_sets_of_le_left {α} {s₁ s₂ s₃: set (set α)} [measurable_space α]
-  {μ : measure α} (h_indep : indep_sets s₁ s₂ μ) (h31 : s₃ ⊆ s₁) :
+lemma indep_sets_of_indep_sets_of_le_left {Ω} {s₁ s₂ s₃: set (set Ω)} [measurable_space Ω]
+  {μ : measure Ω} (h_indep : indep_sets s₁ s₂ μ) (h31 : s₃ ⊆ s₁) :
   indep_sets s₃ s₂ μ :=
 λ t1 t2 ht1 ht2, h_indep t1 t2 (set.mem_of_subset_of_mem h31 ht1) ht2
 
-lemma indep_sets_of_indep_sets_of_le_right {α} {s₁ s₂ s₃: set (set α)} [measurable_space α]
-  {μ : measure α} (h_indep : indep_sets s₁ s₂ μ) (h32 : s₃ ⊆ s₂) :
+lemma indep_sets_of_indep_sets_of_le_right {Ω} {s₁ s₂ s₃: set (set Ω)} [measurable_space Ω]
+  {μ : measure Ω} (h_indep : indep_sets s₁ s₂ μ) (h32 : s₃ ⊆ s₂) :
   indep_sets s₁ s₃ μ :=
 λ t1 t2 ht1 ht2, h_indep t1 t2 ht1 (set.mem_of_subset_of_mem h32 ht2)
 
-lemma indep_of_indep_of_le_left {α} {m₁ m₂ m₃: measurable_space α} [measurable_space α]
-  {μ : measure α} (h_indep : indep m₁ m₂ μ) (h31 : m₃ ≤ m₁) :
+lemma indep_of_indep_of_le_left {Ω} {m₁ m₂ m₃: measurable_space Ω} [measurable_space Ω]
+  {μ : measure Ω} (h_indep : indep m₁ m₂ μ) (h31 : m₃ ≤ m₁) :
   indep m₃ m₂ μ :=
 λ t1 t2 ht1 ht2, h_indep t1 t2 (h31 _ ht1) ht2
 
-lemma indep_of_indep_of_le_right {α} {m₁ m₂ m₃: measurable_space α} [measurable_space α]
-  {μ : measure α} (h_indep : indep m₁ m₂ μ) (h32 : m₃ ≤ m₂) :
+lemma indep_of_indep_of_le_right {Ω} {m₁ m₂ m₃: measurable_space Ω} [measurable_space Ω]
+  {μ : measure Ω} (h_indep : indep m₁ m₂ μ) (h32 : m₃ ≤ m₂) :
   indep m₁ m₃ μ :=
 λ t1 t2 ht1 ht2, h_indep t1 t2 ht1 (h32 _ ht2)
 
-lemma indep_sets.union {α} [measurable_space α] {s₁ s₂ s' : set (set α)} {μ : measure α}
+lemma indep_sets.union {Ω} [measurable_space Ω] {s₁ s₂ s' : set (set Ω)} {μ : measure Ω}
   (h₁ : indep_sets s₁ s' μ) (h₂ : indep_sets s₂ s' μ) :
   indep_sets (s₁ ∪ s₂) s' μ :=
 begin
@@ -167,15 +167,15 @@ begin
   { exact h₂ t1 t2 ht1₂ ht2, },
 end
 
-@[simp] lemma indep_sets.union_iff {α} [measurable_space α] {s₁ s₂ s' : set (set α)}
-  {μ : measure α} :
+@[simp] lemma indep_sets.union_iff {Ω} [measurable_space Ω] {s₁ s₂ s' : set (set Ω)}
+  {μ : measure Ω} :
   indep_sets (s₁ ∪ s₂) s' μ ↔ indep_sets s₁ s' μ ∧ indep_sets s₂ s' μ :=
 ⟨λ h, ⟨indep_sets_of_indep_sets_of_le_left h (set.subset_union_left s₁ s₂),
     indep_sets_of_indep_sets_of_le_left h (set.subset_union_right s₁ s₂)⟩,
   λ h, indep_sets.union h.left h.right⟩
 
-lemma indep_sets.Union {α ι} [measurable_space α] {s : ι → set (set α)} {s' : set (set α)}
-  {μ : measure α} (hyp : ∀ n, indep_sets (s n) s' μ) :
+lemma indep_sets.Union {Ω ι} [measurable_space Ω] {s : ι → set (set Ω)} {s' : set (set Ω)}
+  {μ : measure Ω} (hyp : ∀ n, indep_sets (s n) s' μ) :
   indep_sets (⋃ n, s n) s' μ :=
 begin
   intros t1 t2 ht1 ht2,
@@ -184,17 +184,17 @@ begin
   exact hyp n t1 t2 ht1 ht2,
 end
 
-lemma indep_sets.inter {α} [measurable_space α] {s₁ s' : set (set α)} (s₂ : set (set α))
-  {μ : measure α} (h₁ : indep_sets s₁ s' μ) :
+lemma indep_sets.inter {Ω} [measurable_space Ω] {s₁ s' : set (set Ω)} (s₂ : set (set Ω))
+  {μ : measure Ω} (h₁ : indep_sets s₁ s' μ) :
   indep_sets (s₁ ∩ s₂) s' μ :=
 λ t1 t2 ht1 ht2, h₁ t1 t2 ((set.mem_inter_iff _ _ _).mp ht1).left ht2
 
-lemma indep_sets.Inter {α ι} [measurable_space α] {s : ι → set (set α)} {s' : set (set α)}
-  {μ : measure α} (h : ∃ n, indep_sets (s n) s' μ) :
+lemma indep_sets.Inter {Ω ι} [measurable_space Ω] {s : ι → set (set Ω)} {s' : set (set Ω)}
+  {μ : measure Ω} (h : ∃ n, indep_sets (s n) s' μ) :
   indep_sets (⋂ n, s n) s' μ :=
 by {intros t1 t2 ht1 ht2, cases h with n h, exact h t1 t2 (set.mem_Inter.mp ht1 n) ht2 }
 
-lemma indep_sets_singleton_iff {α} [measurable_space α] {s t : set α} {μ : measure α} :
+lemma indep_sets_singleton_iff {Ω} [measurable_space Ω] {s t : set Ω} {μ : measure Ω} :
   indep_sets {s} {t} μ ↔ μ (s ∩ t) = μ s * μ t :=
 ⟨λ h, h s t rfl rfl,
   λ h s1 t1 hs1 ht1, by rwa [set.mem_singleton_iff.mp hs1, set.mem_singleton_iff.mp ht1]⟩
@@ -204,7 +204,7 @@ end indep
 /-! ### Deducing `indep` from `Indep` -/
 section from_Indep_to_indep
 
-lemma Indep_sets.indep_sets {α ι} {s : ι → set (set α)} [measurable_space α] {μ : measure α}
+lemma Indep_sets.indep_sets {Ω ι} {s : ι → set (set Ω)} [measurable_space Ω] {μ : measure Ω}
   (h_indep : Indep_sets s μ) {i j : ι} (hij : i ≠ j) :
   indep_sets (s i) (s j) μ :=
 begin
@@ -229,7 +229,7 @@ begin
   rw [←h_inter, ←h_prod, h_indep {i, j} hf_m],
 end
 
-lemma Indep.indep {α ι} {m : ι → measurable_space α} [measurable_space α] {μ : measure α}
+lemma Indep.indep {Ω ι} {m : ι → measurable_space Ω} [measurable_space Ω] {μ : measure Ω}
   (h_indep : Indep m μ) {i j : ι} (hij : i ≠ j) :
   indep (m i) (m j) μ :=
 begin
@@ -237,8 +237,8 @@ begin
   exact Indep_sets.indep_sets h_indep hij,
 end
 
-lemma Indep_fun.indep_fun {α ι : Type*} {m₀ : measurable_space α} {μ : measure α} {β : ι → Type*}
-  {m : Π x, measurable_space (β x)} {f : Π i, α → β i} (hf_Indep : Indep_fun m f μ)
+lemma Indep_fun.indep_fun {Ω ι : Type*} {m₀ : measurable_space Ω} {μ : measure Ω} {β : ι → Type*}
+  {m : Π x, measurable_space (β x)} {f : Π i, Ω → β i} (hf_Indep : Indep_fun m f μ)
   {i j : ι} (hij : i ≠ j) :
   indep_fun (f i) (f j) μ :=
 hf_Indep.indep hij
@@ -254,14 +254,14 @@ Independence of measurable spaces is equivalent to independence of generating π
 section from_measurable_spaces_to_sets_of_sets
 /-! ### Independence of measurable space structures implies independence of generating π-systems -/
 
-lemma Indep.Indep_sets {α ι} [measurable_space α] {μ : measure α} {m : ι → measurable_space α}
-  {s : ι → set (set α)} (hms : ∀ n, m n = generate_from (s n))
+lemma Indep.Indep_sets {Ω ι} [measurable_space Ω] {μ : measure Ω} {m : ι → measurable_space Ω}
+  {s : ι → set (set Ω)} (hms : ∀ n, m n = generate_from (s n))
   (h_indep : Indep m μ) :
   Indep_sets s μ :=
 λ S f hfs, h_indep S $ λ x hxS,
   ((hms x).symm ▸ measurable_set_generate_from (hfs x hxS) : measurable_set[m x] (f x))
 
-lemma indep.indep_sets {α} [measurable_space α] {μ : measure α} {s1 s2 : set (set α)}
+lemma indep.indep_sets {Ω} [measurable_space Ω] {μ : measure Ω} {s1 s2 : set (set Ω)}
   (h_indep : indep (generate_from s1) (generate_from s2) μ) :
   indep_sets s1 s2 μ :=
 λ t1 t2 ht1 ht2, h_indep t1 t2 (measurable_set_generate_from ht1) (measurable_set_generate_from ht2)
@@ -271,18 +271,18 @@ end from_measurable_spaces_to_sets_of_sets
 section from_pi_systems_to_measurable_spaces
 /-! ### Independence of generating π-systems implies independence of measurable space structures -/
 
-private lemma indep_sets.indep_aux {α} {m2 : measurable_space α}
-  {m : measurable_space α} {μ : measure α} [is_probability_measure μ] {p1 p2 : set (set α)}
+private lemma indep_sets.indep_aux {Ω} {m2 : measurable_space Ω}
+  {m : measurable_space Ω} {μ : measure Ω} [is_probability_measure μ] {p1 p2 : set (set Ω)}
   (h2 : m2 ≤ m) (hp2 : is_pi_system p2) (hpm2 : m2 = generate_from p2)
-  (hyp : indep_sets p1 p2 μ) {t1 t2 : set α} (ht1 : t1 ∈ p1) (ht2m : measurable_set[m2] t2) :
+  (hyp : indep_sets p1 p2 μ) {t1 t2 : set Ω} (ht1 : t1 ∈ p1) (ht2m : measurable_set[m2] t2) :
   μ (t1 ∩ t2) = μ t1 * μ t2 :=
 begin
   let μ_inter := μ.restrict t1,
   let ν := (μ t1) • μ,
   have h_univ : μ_inter set.univ = ν set.univ,
   by rw [measure.restrict_apply_univ, measure.smul_apply, smul_eq_mul, measure_univ, mul_one],
-  haveI : is_finite_measure μ_inter := @restrict.is_finite_measure α _ t1 μ ⟨measure_lt_top μ t1⟩,
-  rw [set.inter_comm, ←@measure.restrict_apply α _ μ t1 t2 (h2 t2 ht2m)],
+  haveI : is_finite_measure μ_inter := @restrict.is_finite_measure Ω _ t1 μ ⟨measure_lt_top μ t1⟩,
+  rw [set.inter_comm, ←@measure.restrict_apply Ω _ μ t1 t2 (h2 t2 ht2m)],
   refine ext_on_measurable_space_of_generate_finite m p2 (λ t ht, _) h2 hpm2 hp2 h_univ ht2m,
   have ht2 : measurable_set[m] t,
   { refine h2 _ _,
@@ -292,8 +292,8 @@ begin
   exact hyp t1 t ht1 ht,
 end
 
-lemma indep_sets.indep {α} {m1 m2 : measurable_space α} {m : measurable_space α}
-  {μ : measure α} [is_probability_measure μ] {p1 p2 : set (set α)} (h1 : m1 ≤ m) (h2 : m2 ≤ m)
+lemma indep_sets.indep {Ω} {m1 m2 : measurable_space Ω} {m : measurable_space Ω}
+  {μ : measure Ω} [is_probability_measure μ] {p1 p2 : set (set Ω)} (h1 : m1 ≤ m) (h2 : m2 ≤ m)
   (hp1 : is_pi_system p1) (hp2 : is_pi_system p2) (hpm1 : m1 = generate_from p1)
   (hpm2 : m2 = generate_from p2) (hyp : indep_sets p1 p2 μ) :
   indep m1 m2 μ :=
@@ -303,8 +303,8 @@ begin
   let ν := (μ t2) • μ,
   have h_univ : μ_inter set.univ = ν set.univ,
   by rw [measure.restrict_apply_univ, measure.smul_apply, smul_eq_mul, measure_univ, mul_one],
-  haveI : is_finite_measure μ_inter := @restrict.is_finite_measure α _ t2 μ ⟨measure_lt_top μ t2⟩,
-  rw [mul_comm, ←@measure.restrict_apply α _ μ t2 t1 (h1 t1 ht1)],
+  haveI : is_finite_measure μ_inter := @restrict.is_finite_measure Ω _ t2 μ ⟨measure_lt_top μ t2⟩,
+  rw [mul_comm, ←@measure.restrict_apply Ω _ μ t2 t1 (h1 t1 ht1)],
   refine ext_on_measurable_space_of_generate_finite m p1 (λ t ht, _) h1 hpm1 hp1 h_univ ht1,
   have ht1 : measurable_set[m] t,
   { refine h1 _ _,
@@ -314,9 +314,9 @@ begin
   exact indep_sets.indep_aux h2 hp2 hpm2 hyp ht ht2,
 end
 
-variables {α ι : Type*} {m0 : measurable_space α} {μ : measure α}
+variables {Ω ι : Type*} {m0 : measurable_space Ω} {μ : measure Ω}
 
-lemma Indep_sets.pi_Union_Inter_singleton {π : ι → set (set α)} {a : ι} {S : finset ι}
+lemma Indep_sets.pi_Union_Inter_singleton {π : ι → set (set Ω)} {a : ι} {S : finset ι}
   (hp_ind : Indep_sets π μ) (haS : a ∉ S) :
   indep_sets (pi_Union_Inter π {S}) (π a) μ :=
 begin
@@ -351,8 +351,8 @@ begin
 end
 
 /-- Auxiliary lemma for `Indep_sets.Indep`. -/
-theorem Indep_sets.Indep_aux [is_probability_measure μ] (m : ι → measurable_space α)
-  (h_le : ∀ i, m i ≤ m0) (π : ι → set (set α)) (h_pi : ∀ n, is_pi_system (π n))
+theorem Indep_sets.Indep_aux [is_probability_measure μ] (m : ι → measurable_space Ω)
+  (h_le : ∀ i, m i ≤ m0) (π : ι → set (set Ω)) (h_pi : ∀ n, is_pi_system (π n))
   (hp_univ : ∀ i, set.univ ∈ π i) (h_generate : ∀ i, m i = generate_from (π i))
   (h_ind : Indep_sets π μ) :
   Indep m μ :=
@@ -379,8 +379,8 @@ begin
 end
 
 /-- The measurable space structures generated by independent pi-systems are independent. -/
-theorem Indep_sets.Indep [is_probability_measure μ] (m : ι → measurable_space α)
-  (h_le : ∀ i, m i ≤ m0) (π : ι → set (set α)) (h_pi : ∀ n, is_pi_system (π n))
+theorem Indep_sets.Indep [is_probability_measure μ] (m : ι → measurable_space Ω)
+  (h_le : ∀ i, m i ≤ m0) (π : ι → set (set Ω)) (h_pi : ∀ n, is_pi_system (π n))
   (h_generate : ∀ i, m i = generate_from (π i)) (h_ind : Indep_sets π μ) :
   Indep m μ :=
 begin
@@ -437,10 +437,10 @@ We prove the following equivalences on `indep_set`, for measurable sets `s, t`.
 * `indep_set s t μ ↔ indep_sets {s} {t} μ`.
 -/
 
-variables {α : Type*} [measurable_space α] {s t : set α} (S T : set (set α))
+variables {Ω : Type*} [measurable_space Ω] {s t : set Ω} (S T : set (set Ω))
 
 lemma indep_set_iff_indep_sets_singleton (hs_meas : measurable_set s) (ht_meas : measurable_set t)
-  (μ : measure α . volume_tac) [is_probability_measure μ] :
+  (μ : measure Ω . volume_tac) [is_probability_measure μ] :
   indep_set s t μ ↔ indep_sets {s} {t} μ :=
 ⟨indep.indep_sets, λ h, indep_sets.indep
   (generate_from_le (λ u hu, by rwa set.mem_singleton_iff.mp hu))
@@ -448,12 +448,12 @@ lemma indep_set_iff_indep_sets_singleton (hs_meas : measurable_set s) (ht_meas :
   (is_pi_system.singleton t) rfl rfl h⟩
 
 lemma indep_set_iff_measure_inter_eq_mul (hs_meas : measurable_set s) (ht_meas : measurable_set t)
-  (μ : measure α . volume_tac) [is_probability_measure μ] :
+  (μ : measure Ω . volume_tac) [is_probability_measure μ] :
   indep_set s t μ ↔ μ (s ∩ t) = μ s * μ t :=
 (indep_set_iff_indep_sets_singleton hs_meas ht_meas μ).trans indep_sets_singleton_iff
 
 lemma indep_sets.indep_set_of_mem (hs : s ∈ S) (ht : t ∈ T) (hs_meas : measurable_set s)
-  (ht_meas : measurable_set t) (μ : measure α . volume_tac) [is_probability_measure μ]
+  (ht_meas : measurable_set t) (μ : measure Ω . volume_tac) [is_probability_measure μ]
   (h_indep : indep_sets S T μ) :
   indep_set s t μ :=
 (indep_set_iff_measure_inter_eq_mul hs_meas ht_meas μ).mpr (h_indep s t hs ht)
@@ -466,7 +466,7 @@ section indep_fun
 
 -/
 
-variables {α β β' γ γ' : Type*} {mα : measurable_space α} {μ : measure α} {f : α → β} {g : α → β'}
+variables {Ω β β' γ γ' : Type*} {mΩ : measurable_space Ω} {μ : measure Ω} {f : Ω → β} {g : Ω → β'}
 
 lemma indep_fun_iff_measure_inter_preimage_eq_mul
   {mβ : measurable_space β} {mβ' : measurable_space β'} :
@@ -480,30 +480,30 @@ begin
 end
 
 lemma Indep_fun_iff_measure_inter_preimage_eq_mul {ι : Type*} {β : ι → Type*}
-  (m : Π x, measurable_space (β x)) (f : Π i, α → β i) :
+  (m : Π x, measurable_space (β x)) (f : Π i, Ω → β i) :
   Indep_fun m f μ
     ↔ ∀ (S : finset ι) {sets : Π i : ι, set (β i)} (H : ∀ i, i ∈ S → measurable_set[m i] (sets i)),
       μ (⋂ i ∈ S, (f i) ⁻¹' (sets i)) = ∏ i in S, μ ((f i) ⁻¹' (sets i)) :=
 begin
   refine ⟨λ h S sets h_meas, h _ (λ i hi_mem, ⟨sets i, h_meas i hi_mem, rfl⟩), _⟩,
-  intros h S setsα h_meas,
+  intros h S setsΩ h_meas,
   let setsβ : (Π i : ι, set (β i)) := λ i,
     dite (i ∈ S) (λ hi_mem, (h_meas i hi_mem).some) (λ _, set.univ),
   have h_measβ : ∀ i ∈ S, measurable_set[m i] (setsβ i),
   { intros i hi_mem,
     simp_rw [setsβ, dif_pos hi_mem],
     exact (h_meas i hi_mem).some_spec.1, },
-  have h_preim : ∀ i ∈ S, setsα i = (f i) ⁻¹' (setsβ i),
+  have h_preim : ∀ i ∈ S, setsΩ i = (f i) ⁻¹' (setsβ i),
   { intros i hi_mem,
     simp_rw [setsβ, dif_pos hi_mem],
     exact (h_meas i hi_mem).some_spec.2.symm, },
-  have h_left_eq : μ (⋂ i ∈ S, setsα i) = μ (⋂ i ∈ S, (f i) ⁻¹' (setsβ i)),
+  have h_left_eq : μ (⋂ i ∈ S, setsΩ i) = μ (⋂ i ∈ S, (f i) ⁻¹' (setsβ i)),
   { congr' with i x,
     simp only [set.mem_Inter],
     split; intros h hi_mem; specialize h hi_mem,
     { rwa h_preim i hi_mem at h, },
     { rwa h_preim i hi_mem, }, },
-  have h_right_eq : (∏ i in S, μ (setsα i)) = ∏ i in S, μ ((f i) ⁻¹' (setsβ i)),
+  have h_right_eq : (∏ i in S, μ (setsΩ i)) = ∏ i in S, μ ((f i) ⁻¹' (setsβ i)),
   { refine finset.prod_congr rfl (λ i hi_mem, _),
     rw h_preim i hi_mem, },
   rw [h_left_eq, h_right_eq],
@@ -520,7 +520,7 @@ begin
   { rwa ← indep_set_iff_measure_inter_eq_mul (hf hs) (hg ht) μ, },
 end
 
-lemma indep_fun.ae_eq {mβ : measurable_space β} {f g f' g' : α → β}
+lemma indep_fun.ae_eq {mβ : measurable_space β} {f g f' g' : Ω → β}
   (hfg : indep_fun f g μ) (hf : f =ᵐ[μ] f') (hg : g =ᵐ[μ] g') :
   indep_fun f' g' μ :=
 begin
@@ -547,14 +547,14 @@ two disjoint finite index sets, then the tuple formed by `f i` for `i ∈ S` is 
 tuple `(f i)_i` for `i ∈ T`. -/
 lemma Indep_fun.indep_fun_finset [is_probability_measure μ]
   {ι : Type*} {β : ι → Type*} {m : Π i, measurable_space (β i)}
-  {f : Π i, α → β i} (S T : finset ι) (hST : disjoint S T) (hf_Indep : Indep_fun m f μ)
+  {f : Π i, Ω → β i} (S T : finset ι) (hST : disjoint S T) (hf_Indep : Indep_fun m f μ)
   (hf_meas : ∀ i, measurable (f i)) :
   indep_fun (λ a (i : S), f i a) (λ a (i : T), f i a) μ :=
 begin
   -- We introduce π-systems, build from the π-system of boxes which generates `measurable_space.pi`.
   let πSβ := (set.pi (set.univ : set S) ''
     (set.pi (set.univ : set S) (λ i, {s : set (β i) | measurable_set[m i] s}))),
-  let πS := {s : set α | ∃ t ∈ πSβ, (λ a (i : S), f i a) ⁻¹' t = s},
+  let πS := {s : set Ω | ∃ t ∈ πSβ, (λ a (i : S), f i a) ⁻¹' t = s},
   have hπS_pi : is_pi_system πS := is_pi_system_pi.comap (λ a i, f i a),
   have hπS_gen : measurable_space.pi.comap (λ a (i : S), f i a) = generate_from πS,
   { rw [generate_from_pi.symm, comap_generate_from],
@@ -563,7 +563,7 @@ begin
     { exact finset.fintype_coe_sort S, }, },
   let πTβ := (set.pi (set.univ : set T) ''
     (set.pi (set.univ : set T) (λ i, {s : set (β i) | measurable_set[m i] s}))),
-  let πT := {s : set α | ∃ t ∈ πTβ, (λ a (i : T), f i a) ⁻¹' t = s},
+  let πT := {s : set Ω | ∃ t ∈ πTβ, (λ a (i : T), f i a) ⁻¹' t = s},
   have hπT_pi : is_pi_system πT := is_pi_system_pi.comap (λ a i, f i a),
   have hπT_gen : measurable_space.pi.comap (λ a (i : T), f i a) = generate_from πT,
   { rw [generate_from_pi.symm, comap_generate_from],
@@ -590,14 +590,14 @@ begin
   { intros i hi, rw h_sets_s'_eq hi, exact hs1 _, },
   have h_meas_t' : ∀ i ∈ T, measurable_set (sets_t' i),
   { intros i hi, simp_rw [sets_t', dif_pos hi], exact ht1 _, },
-  have h_eq_inter_S : (λ (a : α) (i : ↥S), f ↑i a) ⁻¹' set.pi set.univ sets_s
+  have h_eq_inter_S : (λ (ω : Ω) (i : ↥S), f ↑i ω) ⁻¹' set.pi set.univ sets_s
     = ⋂ i ∈ S, (f i) ⁻¹' (sets_s' i),
   { ext1 x,
     simp only [set.mem_preimage, set.mem_univ_pi, set.mem_Inter],
     split; intro h,
     { intros i hi, rw [h_sets_s'_eq hi], exact h ⟨i, hi⟩, },
     { rintros ⟨i, hi⟩, specialize h i hi, rw [h_sets_s'_eq hi] at h, exact h, }, },
-  have h_eq_inter_T : (λ (a : α) (i : ↥T), f ↑i a) ⁻¹' set.pi set.univ sets_t
+  have h_eq_inter_T : (λ (ω : Ω) (i : ↥T), f ↑i ω) ⁻¹' set.pi set.univ sets_t
     = ⋂ i ∈ T, (f i) ⁻¹' (sets_t' i),
   { ext1 x,
     simp only [set.mem_preimage, set.mem_univ_pi, set.mem_Inter],
@@ -632,7 +632,7 @@ end
 
 lemma Indep_fun.indep_fun_prod [is_probability_measure μ]
   {ι : Type*} {β : ι → Type*} {m : Π i, measurable_space (β i)}
-  {f : Π i, α → β i} (hf_Indep : Indep_fun m f μ) (hf_meas : ∀ i, measurable (f i))
+  {f : Π i, Ω → β i} (hf_Indep : Indep_fun m f μ) (hf_meas : ∀ i, measurable (f i))
   (i j k : ι) (hik : i ≠ k) (hjk : j ≠ k) :
   indep_fun (λ a, (f i a, f j a)) (f k) μ :=
 begin
@@ -667,7 +667,7 @@ end
 @[to_additive]
 lemma Indep_fun.mul [is_probability_measure μ]
   {ι : Type*} {β : Type*} {m : measurable_space β} [has_mul β] [has_measurable_mul₂ β]
-  {f : ι → α → β} (hf_Indep : Indep_fun (λ _, m) f μ) (hf_meas : ∀ i, measurable (f i))
+  {f : ι → Ω → β} (hf_Indep : Indep_fun (λ _, m) f μ) (hf_meas : ∀ i, measurable (f i))
   (i j k : ι) (hik : i ≠ k) (hjk : j ≠ k) :
   indep_fun (f i * f j) (f k) μ :=
 begin
@@ -679,7 +679,7 @@ end
 @[to_additive]
 lemma Indep_fun.indep_fun_finset_prod_of_not_mem [is_probability_measure μ]
   {ι : Type*} {β : Type*} {m : measurable_space β} [comm_monoid β] [has_measurable_mul₂ β]
-  {f : ι → α → β} (hf_Indep : Indep_fun (λ _, m) f μ) (hf_meas : ∀ i, measurable (f i))
+  {f : ι → Ω → β} (hf_Indep : Indep_fun (λ _, m) f μ) (hf_meas : ∀ i, measurable (f i))
   {s : finset ι} {i : ι} (hi : i ∉ s) :
   indep_fun (∏ j in s, f j) (f i) μ :=
 begin
@@ -704,7 +704,7 @@ end
 @[to_additive]
 lemma Indep_fun.indep_fun_prod_range_succ [is_probability_measure μ]
   {β : Type*} {m : measurable_space β} [comm_monoid β] [has_measurable_mul₂ β]
-  {f : ℕ → α → β} (hf_Indep : Indep_fun (λ _, m) f μ) (hf_meas : ∀ i, measurable (f i))
+  {f : ℕ → Ω → β} (hf_Indep : Indep_fun (λ _, m) f μ) (hf_meas : ∀ i, measurable (f i))
   (n : ℕ) :
   indep_fun (∏ j in finset.range n, f j) (f n) μ :=
 hf_Indep.indep_fun_finset_prod_of_not_mem hf_meas finset.not_mem_range_self

--- a/src/probability/integration.lean
+++ b/src/probability/integration.lean
@@ -20,8 +20,8 @@ will always pick the later typeclass in this situation, and does not care whethe
 `[]`, `{}`, or `()`. All of these use the `measurable_space` `M2` to define `μ`:
 
 ```lean
-example {M1 : measurable_space α} [M2 : measurable_space α] {μ : measure α} : sorry := sorry
-example [M1 : measurable_space α] {M2 : measurable_space α} {μ : measure α} : sorry := sorry
+example {M1 : measurable_space Ω} [M2 : measurable_space Ω] {μ : measure Ω} : sorry := sorry
+example [M1 : measurable_space Ω] {M2 : measurable_space Ω} {μ : measure Ω} : sorry := sorry
 ```
 
 -/
@@ -30,17 +30,17 @@ noncomputable theory
 open set measure_theory
 open_locale ennreal measure_theory
 
-variables {α : Type*} {mα : measurable_space α} {μ : measure α} {f g : α → ℝ≥0∞} {X Y : α → ℝ}
+variables {Ω : Type*} {mΩ : measurable_space Ω} {μ : measure Ω} {f g : Ω → ℝ≥0∞} {X Y : Ω → ℝ}
 
 namespace probability_theory
 
 /-- If a random variable `f` in `ℝ≥0∞` is independent of an event `T`, then if you restrict the
   random variable to `T`, then `E[f * indicator T c 0]=E[f] * E[indicator T c 0]`. It is useful for
   `lintegral_mul_eq_lintegral_mul_lintegral_of_independent_measurable_space`. -/
-lemma lintegral_mul_indicator_eq_lintegral_mul_lintegral_indicator {Mf mα : measurable_space α}
-  {μ : measure α} (hMf : Mf ≤ mα) (c : ℝ≥0∞) {T : set α} (h_meas_T : measurable_set T)
+lemma lintegral_mul_indicator_eq_lintegral_mul_lintegral_indicator {Mf mΩ : measurable_space Ω}
+  {μ : measure Ω} (hMf : Mf ≤ mΩ) (c : ℝ≥0∞) {T : set Ω} (h_meas_T : measurable_set T)
   (h_ind : indep_sets {s | measurable_set[Mf] s} {T} μ) (h_meas_f : measurable[Mf] f) :
-  ∫⁻ a, f a * T.indicator (λ _, c) a ∂μ = ∫⁻ a, f a ∂μ * ∫⁻ a, T.indicator (λ _, c) a ∂μ :=
+  ∫⁻ ω, f ω * T.indicator (λ _, c) ω ∂μ = ∫⁻ ω, f ω ∂μ * ∫⁻ ω, T.indicator (λ _, c) ω ∂μ :=
 begin
   revert f,
   have h_mul_indicator : ∀ g, measurable g → measurable (λ a, g a * T.indicator (λ x, c) a),
@@ -77,10 +77,10 @@ end
    independence. See `lintegral_mul_eq_lintegral_mul_lintegral_of_independent_fn` for
    a more common variant of the product of independent variables. -/
 lemma lintegral_mul_eq_lintegral_mul_lintegral_of_independent_measurable_space
-  {Mf Mg mα : measurable_space α} {μ : measure α}
-  (hMf : Mf ≤ mα) (hMg : Mg ≤ mα) (h_ind : indep Mf Mg μ)
+  {Mf Mg mΩ : measurable_space Ω} {μ : measure Ω}
+  (hMf : Mf ≤ mΩ) (hMg : Mg ≤ mΩ) (h_ind : indep Mf Mg μ)
   (h_meas_f : measurable[Mf] f) (h_meas_g : measurable[Mg] g) :
-  ∫⁻ a, f a * g a ∂μ = ∫⁻ a, f a ∂μ * ∫⁻ a, g a ∂μ :=
+  ∫⁻ ω, f ω * g ω ∂μ = ∫⁻ ω, f ω ∂μ * ∫⁻ ω, g ω ∂μ :=
 begin
   revert g,
   have h_measM_f : measurable f, from h_meas_f.mono hMf le_rfl,
@@ -108,7 +108,7 @@ end
    then `E[f * g] = E[f] * E[g]`. -/
 lemma lintegral_mul_eq_lintegral_mul_lintegral_of_indep_fun
   (h_meas_f : measurable f) (h_meas_g : measurable g) (h_indep_fun : indep_fun f g μ) :
-  ∫⁻ a, (f * g) a ∂μ = ∫⁻ a, f a ∂μ * ∫⁻ a, g a ∂μ :=
+  ∫⁻ ω, (f * g) ω ∂μ = ∫⁻ ω, f ω ∂μ * ∫⁻ ω, g ω ∂μ :=
 lintegral_mul_eq_lintegral_mul_lintegral_of_independent_measurable_space
   (measurable_iff_comap_le.1 h_meas_f) (measurable_iff_comap_le.1 h_meas_g) h_indep_fun
   (measurable.of_comap_le le_rfl) (measurable.of_comap_le le_rfl)
@@ -118,7 +118,7 @@ lintegral_mul_eq_lintegral_mul_lintegral_of_independent_measurable_space
    `lintegral_mul_eq_lintegral_mul_lintegral_of_indep_fun`). -/
 lemma lintegral_mul_eq_lintegral_mul_lintegral_of_indep_fun'
   (h_meas_f : ae_measurable f μ) (h_meas_g : ae_measurable g μ) (h_indep_fun : indep_fun f g μ) :
-  ∫⁻ a, (f * g) a ∂μ = ∫⁻ a, f a ∂μ * ∫⁻ a, g a ∂μ :=
+  ∫⁻ ω, (f * g) ω ∂μ = ∫⁻ ω, f ω ∂μ * ∫⁻ ω, g ω ∂μ :=
 begin
   have fg_ae : f * g =ᵐ[μ] (h_meas_f.mk _) * (h_meas_g.mk _),
     from h_meas_f.ae_eq_mk.mul h_meas_g.ae_eq_mk,
@@ -130,13 +130,13 @@ begin
 end
 
 /-- The product of two independent, integrable, real_valued random variables is integrable. -/
-lemma indep_fun.integrable_mul {β : Type*} [measurable_space β] {X Y : α → β}
+lemma indep_fun.integrable_mul {β : Type*} [measurable_space β] {X Y : Ω → β}
   [normed_division_ring β] [borel_space β]
   (hXY : indep_fun X Y μ) (hX : integrable X μ) (hY : integrable Y μ) :
   integrable (X * Y) μ :=
 begin
-  let nX : α → ennreal := λ a, ∥X a∥₊,
-  let nY : α → ennreal := λ a, ∥Y a∥₊,
+  let nX : Ω → ennreal := λ a, ∥X a∥₊,
+  let nY : Ω → ennreal := λ a, ∥Y a∥₊,
 
   have hXY' : indep_fun (λ a, ∥X a∥₊) (λ a, ∥Y a∥₊) μ :=
     hXY.comp measurable_nnnorm measurable_nnnorm,
@@ -244,7 +244,7 @@ hXY.integral_mul_of_integrable hX hY
   satisfying appropriate integrability conditions. -/
 theorem indep_fun_iff_integral_comp_mul [is_finite_measure μ]
   {β β' : Type*} {mβ : measurable_space β} {mβ' : measurable_space β'}
-  {f : α → β} {g : α → β'} {hfm : measurable f} {hgm : measurable g} :
+  {f : Ω → β} {g : Ω → β'} {hfm : measurable f} {hgm : measurable g} :
   indep_fun f g μ ↔
   ∀ {φ : β → ℝ} {ψ : β' → ℝ},
     measurable φ → measurable ψ → integrable (φ ∘ f) μ → integrable (ψ ∘ g) μ →

--- a/src/probability/martingale.lean
+++ b/src/probability/martingale.lean
@@ -9,11 +9,11 @@ import probability.hitting_time
 /-!
 # Martingales
 
-A family of functions `f : ι → α → E` is a martingale with respect to a filtration `ℱ` if every
+A family of functions `f : ι → Ω → E` is a martingale with respect to a filtration `ℱ` if every
 `f i` is integrable, `f` is adapted with respect to `ℱ` and for all `i ≤ j`,
-`μ[f j | ℱ i] =ᵐ[μ] f i`. On the other hand, `f : ι → α → E` is said to be a supermartingale
+`μ[f j | ℱ i] =ᵐ[μ] f i`. On the other hand, `f : ι → Ω → E` is said to be a supermartingale
 with respect to the filtration `ℱ` if `f i` is integrable, `f` is adapted with resepct to `ℱ`
-and for all `i ≤ j`, `μ[f j | ℱ i] ≤ᵐ[μ] f i`. Finally, `f : ι → α → E` is said to be a
+and for all `i ≤ j`, `μ[f j | ℱ i] ≤ᵐ[μ] f i`. Finally, `f : ι → Ω → E` is said to be a
 submartingale with respect to the filtration `ℱ` if `f i` is integrable, `f` is adapted with
 resepct to `ℱ` and for all `i ≤ j`, `f i ≤ᵐ[μ] μ[f j | ℱ i]`.
 
@@ -40,35 +40,35 @@ open_locale nnreal ennreal measure_theory probability_theory big_operators
 
 namespace measure_theory
 
-variables {α E ι : Type*} [preorder ι]
-  {m0 : measurable_space α} {μ : measure α}
+variables {Ω E ι : Type*} [preorder ι]
+  {m0 : measurable_space Ω} {μ : measure Ω}
   [normed_add_comm_group E] [normed_space ℝ E] [complete_space E]
-  {f g : ι → α → E} {ℱ : filtration ι m0}
+  {f g : ι → Ω → E} {ℱ : filtration ι m0}
 
-/-- A family of functions `f : ι → α → E` is a martingale with respect to a filtration `ℱ` if `f`
+/-- A family of functions `f : ι → Ω → E` is a martingale with respect to a filtration `ℱ` if `f`
 is adapted with respect to `ℱ` and for all `i ≤ j`, `μ[f j | ℱ i] =ᵐ[μ] f i`. -/
-def martingale (f : ι → α → E) (ℱ : filtration ι m0) (μ : measure α) : Prop :=
+def martingale (f : ι → Ω → E) (ℱ : filtration ι m0) (μ : measure Ω) : Prop :=
 adapted ℱ f ∧ ∀ i j, i ≤ j → μ[f j | ℱ i] =ᵐ[μ] f i
 
-/-- A family of integrable functions `f : ι → α → E` is a supermartingale with respect to a
+/-- A family of integrable functions `f : ι → Ω → E` is a supermartingale with respect to a
 filtration `ℱ` if `f` is adapted with respect to `ℱ` and for all `i ≤ j`,
 `μ[f j | ℱ.le i] ≤ᵐ[μ] f i`. -/
-def supermartingale [has_le E] (f : ι → α → E) (ℱ : filtration ι m0) (μ : measure α) : Prop :=
+def supermartingale [has_le E] (f : ι → Ω → E) (ℱ : filtration ι m0) (μ : measure Ω) : Prop :=
 adapted ℱ f ∧ (∀ i j, i ≤ j → μ[f j | ℱ i] ≤ᵐ[μ] f i) ∧ ∀ i, integrable (f i) μ
 
-/-- A family of integrable functions `f : ι → α → E` is a submartingale with respect to a
+/-- A family of integrable functions `f : ι → Ω → E` is a submartingale with respect to a
 filtration `ℱ` if `f` is adapted with respect to `ℱ` and for all `i ≤ j`,
 `f i ≤ᵐ[μ] μ[f j | ℱ.le i]`. -/
-def submartingale [has_le E] (f : ι → α → E) (ℱ : filtration ι m0) (μ : measure α) : Prop :=
+def submartingale [has_le E] (f : ι → Ω → E) (ℱ : filtration ι m0) (μ : measure Ω) : Prop :=
 adapted ℱ f ∧ (∀ i j, i ≤ j → f i ≤ᵐ[μ] μ[f j | ℱ i]) ∧ ∀ i, integrable (f i) μ
 
-lemma martingale_const (ℱ : filtration ι m0) (μ : measure α) [is_finite_measure μ] (x : E) :
+lemma martingale_const (ℱ : filtration ι m0) (μ : measure Ω) [is_finite_measure μ] (x : E) :
   martingale (λ _ _, x) ℱ μ :=
 ⟨adapted_const ℱ _, λ i j hij, by rw condexp_const (ℱ.le _)⟩
 
 variables (E)
-lemma martingale_zero (ℱ : filtration ι m0) (μ : measure α) :
-  martingale (0 : ι → α → E) ℱ μ :=
+lemma martingale_zero (ℱ : filtration ι m0) (μ : measure Ω) :
+  martingale (0 : ι → Ω → E) ℱ μ :=
 ⟨adapted_zero E ℱ, λ i j hij, by { rw [pi.zero_apply, condexp_zero], simp, }⟩
 variables {E}
 
@@ -90,7 +90,7 @@ lemma integrable (hf : martingale f ℱ μ) (i : ι) : integrable (f i) μ :=
 integrable_condexp.congr (hf.condexp_ae_eq (le_refl i))
 
 lemma set_integral_eq [sigma_finite_filtration μ ℱ] (hf : martingale f ℱ μ) {i j : ι} (hij : i ≤ j)
-  {s : set α} (hs : measurable_set[ℱ i] s) :
+  {s : set Ω} (hs : measurable_set[ℱ i] s) :
   ∫ x in s, f i x ∂μ = ∫ x in s, f j x ∂μ :=
 begin
   rw ← @set_integral_condexp _ _ _ _ _ (ℱ i) m0 _ _ _ (ℱ.le i) _ (hf.integrable j) hs,
@@ -131,7 +131,7 @@ lemma martingale_iff [partial_order E] : martingale f ℱ μ ↔
 ⟨λ hf, ⟨hf.supermartingale, hf.submartingale⟩,
  λ ⟨hf₁, hf₂⟩, ⟨hf₁.1, λ i j hij, (hf₁.2.1 i j hij).antisymm (hf₂.2.1 i j hij)⟩⟩
 
-lemma martingale_condexp (f : α → E) (ℱ : filtration ι m0) (μ : measure α)
+lemma martingale_condexp (f : Ω → E) (ℱ : filtration ι m0) (μ : measure Ω)
   [sigma_finite_filtration μ ℱ] :
   martingale (λ i, μ[f | ℱ i]) ℱ μ :=
 ⟨λ i, strongly_measurable_condexp, λ i j hij, condexp_condexp_of_le (ℱ.mono hij) (ℱ.le j)⟩
@@ -153,8 +153,8 @@ lemma condexp_ae_le [has_le E] (hf : supermartingale f ℱ μ) {i j : ι} (hij :
   μ[f j | ℱ i] ≤ᵐ[μ] f i :=
 hf.2.1 i j hij
 
-lemma set_integral_le [sigma_finite_filtration μ ℱ] {f : ι → α → ℝ} (hf : supermartingale f ℱ μ)
-  {i j : ι} (hij : i ≤ j) {s : set α} (hs : measurable_set[ℱ i] s) :
+lemma set_integral_le [sigma_finite_filtration μ ℱ] {f : ι → Ω → ℝ} (hf : supermartingale f ℱ μ)
+  {i j : ι} (hij : i ≤ j) {s : set Ω} (hs : measurable_set[ℱ i] s) :
   ∫ x in s, f j x ∂μ ≤ ∫ x in s, f i x ∂μ :=
 begin
   rw ← set_integral_condexp (ℱ.le i) (hf.integrable j) hs,
@@ -227,8 +227,8 @@ begin
 end
 
 /-- The converse of this lemma is `measure_theory.submartingale_of_set_integral_le`. -/
-lemma set_integral_le [sigma_finite_filtration μ ℱ] {f : ι → α → ℝ} (hf : submartingale f ℱ μ)
-  {i j : ι} (hij : i ≤ j) {s : set α} (hs : measurable_set[ℱ i] s) :
+lemma set_integral_le [sigma_finite_filtration μ ℱ] {f : ι → Ω → ℝ} (hf : submartingale f ℱ μ)
+  {i j : ι} (hij : i ≤ j) {s : set Ω} (hs : measurable_set[ℱ i] s) :
   ∫ x in s, f i x ∂μ ≤ ∫ x in s, f j x ∂μ :=
 begin
   rw [← neg_le_neg_iff, ← integral_neg, ← integral_neg],
@@ -243,7 +243,7 @@ lemma sub_martingale [preorder E] [covariant_class E E (+) (≤)]
   (hf : submartingale f ℱ μ) (hg : martingale g ℱ μ) : submartingale (f - g) ℱ μ :=
 hf.sub_supermartingale hg.supermartingale
 
-protected lemma sup {f g : ι → α → ℝ} (hf : submartingale f ℱ μ) (hg : submartingale g ℱ μ) :
+protected lemma sup {f g : ι → Ω → ℝ} (hf : submartingale f ℱ μ) (hg : submartingale g ℱ μ) :
   submartingale (f ⊔ g) ℱ μ :=
 begin
   refine ⟨λ i, @strongly_measurable.sup _ _ _ _ (ℱ i) _ _ _ (hf.adapted i) (hg.adapted i),
@@ -257,7 +257,7 @@ begin
       (eventually_of_forall (λ x, le_max_right _ _))) }
 end
 
-protected lemma pos {f : ι → α → ℝ} (hf : submartingale f ℱ μ) :
+protected lemma pos {f : ι → Ω → ℝ} (hf : submartingale f ℱ μ) :
   submartingale (f⁺) ℱ μ :=
 hf.sup (martingale_zero _ _ _).submartingale
 
@@ -266,8 +266,8 @@ end submartingale
 section submartingale
 
 lemma submartingale_of_set_integral_le [is_finite_measure μ]
-  {f : ι → α → ℝ} (hadp : adapted ℱ f) (hint : ∀ i, integrable (f i) μ)
-  (hf : ∀ i j : ι, i ≤ j → ∀ s : set α, measurable_set[ℱ i] s →
+  {f : ι → Ω → ℝ} (hadp : adapted ℱ f) (hint : ∀ i, integrable (f i) μ)
+  (hf : ∀ i j : ι, i ≤ j → ∀ s : set Ω, measurable_set[ℱ i] s →
     ∫ x in s, f i x ∂μ ≤ ∫ x in s, f j x ∂μ) :
   submartingale f ℱ μ :=
 begin
@@ -287,7 +287,7 @@ begin
 end
 
 lemma submartingale_of_condexp_sub_nonneg [is_finite_measure μ]
-  {f : ι → α → ℝ} (hadp : adapted ℱ f) (hint : ∀ i, integrable (f i) μ)
+  {f : ι → Ω → ℝ} (hadp : adapted ℱ f) (hint : ∀ i, integrable (f i) μ)
   (hf : ∀ i j, i ≤ j → 0 ≤ᵐ[μ] μ[f j - f i | ℱ i]) :
   submartingale f ℱ μ :=
 begin
@@ -298,7 +298,7 @@ begin
 end
 
 lemma submartingale.condexp_sub_nonneg
-  {f : ι → α → ℝ} (hf : submartingale f ℱ μ) {i j : ι} (hij : i ≤ j) :
+  {f : ι → Ω → ℝ} (hf : submartingale f ℱ μ) {i j : ι} (hij : i ≤ j) :
   0 ≤ᵐ[μ] μ[f j - f i | ℱ i] :=
 begin
   by_cases h : sigma_finite (μ.trim (ℱ.le i)),
@@ -310,7 +310,7 @@ begin
   { exact h }
 end
 
-lemma submartingale_iff_condexp_sub_nonneg [is_finite_measure μ] {f : ι → α → ℝ} :
+lemma submartingale_iff_condexp_sub_nonneg [is_finite_measure μ] {f : ι → Ω → ℝ} :
   submartingale f ℱ μ ↔ adapted ℱ f ∧ (∀ i, integrable (f i) μ) ∧ ∀ i j, i ≤ j →
   0 ≤ᵐ[μ] μ[f j - f i | ℱ i] :=
 ⟨λ h, ⟨h.adapted, h.integrable, λ i j, h.condexp_sub_nonneg⟩,
@@ -333,7 +333,7 @@ section
 variables {F : Type*} [normed_lattice_add_comm_group F]
   [normed_space ℝ F] [complete_space F] [ordered_smul ℝ F]
 
-lemma smul_nonneg {f : ι → α → F}
+lemma smul_nonneg {f : ι → Ω → F}
   {c : ℝ} (hc : 0 ≤ c) (hf : supermartingale f ℱ μ) :
   supermartingale (c • f) ℱ μ :=
 begin
@@ -344,7 +344,7 @@ begin
   exact smul_le_smul_of_nonneg hle hc,
 end
 
-lemma smul_nonpos {f : ι → α → F}
+lemma smul_nonpos {f : ι → Ω → F}
   {c : ℝ} (hc : c ≤ 0) (hf : supermartingale f ℱ μ) :
   submartingale (c • f) ℱ μ :=
 begin
@@ -363,7 +363,7 @@ section
 variables {F : Type*} [normed_lattice_add_comm_group F]
   [normed_space ℝ F] [complete_space F] [ordered_smul ℝ F]
 
-lemma smul_nonneg {f : ι → α → F}
+lemma smul_nonneg {f : ι → Ω → F}
   {c : ℝ} (hc : 0 ≤ c) (hf : submartingale f ℱ μ) :
   submartingale (c • f) ℱ μ :=
 begin
@@ -371,7 +371,7 @@ begin
   exact supermartingale.neg (hf.neg.smul_nonneg hc),
 end
 
-lemma smul_nonpos {f : ι → α → F}
+lemma smul_nonpos {f : ι → Ω → F}
   {c : ℝ} (hc : c ≤ 0) (hf : submartingale f ℱ μ) :
   supermartingale (c • f) ℱ μ :=
 begin
@@ -388,8 +388,8 @@ section nat
 variables {𝒢 : filtration ℕ m0}
 
 lemma submartingale_of_set_integral_le_succ [is_finite_measure μ]
-  {f : ℕ → α → ℝ} (hadp : adapted 𝒢 f) (hint : ∀ i, integrable (f i) μ)
-  (hf : ∀ i, ∀ s : set α, measurable_set[𝒢 i] s → ∫ x in s, f i x ∂μ ≤ ∫ x in s, f (i + 1) x ∂μ) :
+  {f : ℕ → Ω → ℝ} (hadp : adapted 𝒢 f) (hint : ∀ i, integrable (f i) μ)
+  (hf : ∀ i, ∀ s : set Ω, measurable_set[𝒢 i] s → ∫ x in s, f i x ∂μ ≤ ∫ x in s, f (i + 1) x ∂μ) :
   submartingale f 𝒢 μ :=
 begin
   refine submartingale_of_set_integral_le hadp hint (λ i j hij s hs, _),
@@ -399,8 +399,8 @@ begin
 end
 
 lemma supermartingale_of_set_integral_succ_le [is_finite_measure μ]
-  {f : ℕ → α → ℝ} (hadp : adapted 𝒢 f) (hint : ∀ i, integrable (f i) μ)
-  (hf : ∀ i, ∀ s : set α, measurable_set[𝒢 i] s → ∫ x in s, f (i + 1) x ∂μ ≤ ∫ x in s, f i x ∂μ) :
+  {f : ℕ → Ω → ℝ} (hadp : adapted 𝒢 f) (hint : ∀ i, integrable (f i) μ)
+  (hf : ∀ i, ∀ s : set Ω, measurable_set[𝒢 i] s → ∫ x in s, f (i + 1) x ∂μ ≤ ∫ x in s, f i x ∂μ) :
   supermartingale f 𝒢 μ :=
 begin
   rw ← neg_neg f,
@@ -409,15 +409,15 @@ begin
 end
 
 lemma martingale_of_set_integral_eq_succ [is_finite_measure μ]
-  {f : ℕ → α → ℝ} (hadp : adapted 𝒢 f) (hint : ∀ i, integrable (f i) μ)
-  (hf : ∀ i, ∀ s : set α, measurable_set[𝒢 i] s → ∫ x in s, f i x ∂μ = ∫ x in s, f (i + 1) x ∂μ) :
+  {f : ℕ → Ω → ℝ} (hadp : adapted 𝒢 f) (hint : ∀ i, integrable (f i) μ)
+  (hf : ∀ i, ∀ s : set Ω, measurable_set[𝒢 i] s → ∫ x in s, f i x ∂μ = ∫ x in s, f (i + 1) x ∂μ) :
   martingale f 𝒢 μ :=
 martingale_iff.2
   ⟨supermartingale_of_set_integral_succ_le hadp hint $ λ i s hs, (hf i s hs).ge,
    submartingale_of_set_integral_le_succ hadp hint $ λ i s hs, (hf i s hs).le⟩
 
 lemma submartingale_nat [is_finite_measure μ]
-  {f : ℕ → α → ℝ} (hadp : adapted 𝒢 f) (hint : ∀ i, integrable (f i) μ)
+  {f : ℕ → Ω → ℝ} (hadp : adapted 𝒢 f) (hint : ∀ i, integrable (f i) μ)
   (hf : ∀ i, f i ≤ᵐ[μ] μ[f (i + 1) | 𝒢 i]) :
   submartingale f 𝒢 μ :=
 begin
@@ -429,7 +429,7 @@ begin
 end
 
 lemma supermartingale_nat [is_finite_measure μ]
-  {f : ℕ → α → ℝ} (hadp : adapted 𝒢 f) (hint : ∀ i, integrable (f i) μ)
+  {f : ℕ → Ω → ℝ} (hadp : adapted 𝒢 f) (hint : ∀ i, integrable (f i) μ)
   (hf : ∀ i, μ[f (i + 1) | 𝒢 i] ≤ᵐ[μ] f i) :
   supermartingale f 𝒢 μ :=
 begin
@@ -440,14 +440,14 @@ begin
 end
 
 lemma martingale_nat [is_finite_measure μ]
-  {f : ℕ → α → ℝ} (hadp : adapted 𝒢 f) (hint : ∀ i, integrable (f i) μ)
+  {f : ℕ → Ω → ℝ} (hadp : adapted 𝒢 f) (hint : ∀ i, integrable (f i) μ)
   (hf : ∀ i, f i =ᵐ[μ] μ[f (i + 1) | 𝒢 i]) :
   martingale f 𝒢 μ :=
 martingale_iff.2 ⟨supermartingale_nat hadp hint $ λ i, (hf i).symm.le,
   submartingale_nat hadp hint $ λ i, (hf i).le⟩
 
 lemma submartingale_of_condexp_sub_nonneg_nat [is_finite_measure μ]
-  {f : ℕ → α → ℝ} (hadp : adapted 𝒢 f) (hint : ∀ i, integrable (f i) μ)
+  {f : ℕ → Ω → ℝ} (hadp : adapted 𝒢 f) (hint : ∀ i, integrable (f i) μ)
   (hf : ∀ i, 0 ≤ᵐ[μ] μ[f (i + 1) - f i | 𝒢 i]) :
   submartingale f 𝒢 μ :=
 begin
@@ -458,7 +458,7 @@ begin
 end
 
 lemma supermartingale_of_condexp_sub_nonneg_nat [is_finite_measure μ]
-  {f : ℕ → α → ℝ} (hadp : adapted 𝒢 f) (hint : ∀ i, integrable (f i) μ)
+  {f : ℕ → Ω → ℝ} (hadp : adapted 𝒢 f) (hint : ∀ i, integrable (f i) μ)
   (hf : ∀ i, 0 ≤ᵐ[μ] μ[f i - f (i + 1) | 𝒢 i]) :
   supermartingale f 𝒢 μ :=
 begin
@@ -468,7 +468,7 @@ begin
 end
 
 lemma martingale_of_condexp_sub_eq_zero_nat [is_finite_measure μ]
-  {f : ℕ → α → ℝ} (hadp : adapted 𝒢 f) (hint : ∀ i, integrable (f i) μ)
+  {f : ℕ → Ω → ℝ} (hadp : adapted 𝒢 f) (hint : ∀ i, integrable (f i) μ)
   (hf : ∀ i, μ[f (i + 1) - f i | 𝒢 i] =ᵐ[μ] 0) :
   martingale f 𝒢 μ :=
 begin
@@ -482,7 +482,7 @@ end
 
 namespace submartingale
 
-lemma integrable_stopped_value [has_le E] {f : ℕ → α → E} (hf : submartingale f 𝒢 μ) {τ : α → ℕ}
+lemma integrable_stopped_value [has_le E] {f : ℕ → Ω → E} (hf : submartingale f 𝒢 μ) {τ : Ω → ℕ}
   (hτ : is_stopping_time 𝒢 τ) {N : ℕ} (hbdd : ∀ x, τ x ≤ N) :
   integrable (stopped_value f τ) μ :=
 integrable_stopped_value hτ hf.integrable hbdd
@@ -494,14 +494,14 @@ integrable_stopped_value hτ hf.integrable hbdd
 expectation of `stopped_value f τ` is less than or equal to the expectation of `stopped_value f π`.
 This is the forward direction of the optional stopping theorem. -/
 lemma expected_stopped_value_mono [sigma_finite_filtration μ 𝒢]
-  {f : ℕ → α → ℝ} (hf : submartingale f 𝒢 μ) {τ π : α → ℕ}
+  {f : ℕ → Ω → ℝ} (hf : submartingale f 𝒢 μ) {τ π : Ω → ℕ}
   (hτ : is_stopping_time 𝒢 τ) (hπ : is_stopping_time 𝒢 π) (hle : τ ≤ π)
   {N : ℕ} (hbdd : ∀ x, π x ≤ N) :
   μ[stopped_value f τ] ≤ μ[stopped_value f π] :=
 begin
   rw [← sub_nonneg, ← integral_sub', stopped_value_sub_eq_sum' hle hbdd],
   { simp only [finset.sum_apply],
-    have : ∀ i, measurable_set[𝒢 i] {x : α | τ x ≤ i ∧ i < π x},
+    have : ∀ i, measurable_set[𝒢 i] {ω : Ω | τ ω ≤ i ∧ i < π ω},
     { intro i,
       refine (hτ i).inter _,
       convert (hπ i).compl,
@@ -526,8 +526,8 @@ end submartingale
 is a submartingale if for all bounded stopping times `τ` and `π` such that `τ ≤ π`, the
 stopped value of `f` at `τ` has expectation smaller than its stopped value at `π`. -/
 lemma submartingale_of_expected_stopped_value_mono [is_finite_measure μ]
-  {f : ℕ → α → ℝ} (hadp : adapted 𝒢 f) (hint : ∀ i, integrable (f i) μ)
-  (hf : ∀ τ π : α → ℕ, is_stopping_time 𝒢 τ → is_stopping_time 𝒢 π → τ ≤ π → (∃ N, ∀ x, π x ≤ N) →
+  {f : ℕ → Ω → ℝ} (hadp : adapted 𝒢 f) (hint : ∀ i, integrable (f i) μ)
+  (hf : ∀ τ π : Ω → ℕ, is_stopping_time 𝒢 τ → is_stopping_time 𝒢 π → τ ≤ π → (∃ N, ∀ x, π x ≤ N) →
     μ[stopped_value f τ] ≤ μ[stopped_value f π]) :
   submartingale f 𝒢 μ :=
 begin
@@ -546,9 +546,9 @@ end
 is a submartingale if and only if for all bounded stopping times `τ` and `π` such that `τ ≤ π`, the
 stopped value of `f` at `τ` has expectation smaller than its stopped value at `π`. -/
 lemma submartingale_iff_expected_stopped_value_mono [is_finite_measure μ]
-  {f : ℕ → α → ℝ} (hadp : adapted 𝒢 f) (hint : ∀ i, integrable (f i) μ) :
+  {f : ℕ → Ω → ℝ} (hadp : adapted 𝒢 f) (hint : ∀ i, integrable (f i) μ) :
   submartingale f 𝒢 μ ↔
-  ∀ τ π : α → ℕ, is_stopping_time 𝒢 τ → is_stopping_time 𝒢 π → τ ≤ π → (∃ N, ∀ x, π x ≤ N) →
+  ∀ τ π : Ω → ℕ, is_stopping_time 𝒢 τ → is_stopping_time 𝒢 π → τ ≤ π → (∃ N, ∀ x, π x ≤ N) →
     μ[stopped_value f τ] ≤ μ[stopped_value f π] :=
 ⟨λ hf _ _ hτ hπ hle ⟨N, hN⟩, hf.expected_stopped_value_mono hτ hπ hle hN,
  submartingale_of_expected_stopped_value_mono hadp hint⟩
@@ -558,7 +558,7 @@ section maximal
 open finset
 
 lemma smul_le_stopped_value_hitting [is_finite_measure μ]
-  {f : ℕ → α → ℝ} (hsub : submartingale f 𝒢 μ) {ε : ℝ≥0} (n : ℕ) :
+  {f : ℕ → Ω → ℝ} (hsub : submartingale f 𝒢 μ) {ε : ℝ≥0} (n : ℕ) :
   ε • μ {x | (ε : ℝ) ≤ (range (n + 1)).sup' nonempty_range_succ (λ k, f k x)} ≤
   ennreal.of_real (∫ x in {x | (ε : ℝ) ≤ (range (n + 1)).sup' nonempty_range_succ (λ k, f k x)},
     stopped_value f (hitting f {y : ℝ | ↑ε ≤ y} 0 n) x ∂μ) :=
@@ -589,7 +589,7 @@ we have `ε • μ {ε ≤ f* n} ≤ ∫ x in {ε ≤ f* n}, f n` where `f* n x 
 In some literature, the Doob's maximal inequality refers to what we call Doob's Lp inequality
 (which is a corollary of this lemma and will be proved in an upcomming PR). -/
 lemma maximal_ineq [is_finite_measure μ]
-  {f : ℕ → α → ℝ} (hsub : submartingale f 𝒢 μ) (hnonneg : 0 ≤ f) {ε : ℝ≥0} (n : ℕ) :
+  {f : ℕ → Ω → ℝ} (hsub : submartingale f 𝒢 μ) (hnonneg : 0 ≤ f) {ε : ℝ≥0} (n : ℕ) :
   ε • μ {x | (ε : ℝ) ≤ (range (n + 1)).sup' nonempty_range_succ (λ k, f k x)} ≤
   ennreal.of_real (∫ x in {x | (ε : ℝ) ≤ (range (n + 1)).sup' nonempty_range_succ (λ k, f k x)},
     f n x ∂μ) :=
@@ -597,31 +597,31 @@ begin
   suffices : ε • μ {x | (ε : ℝ) ≤ (range (n + 1)).sup' nonempty_range_succ (λ k, f k x)} +
     ennreal.of_real (∫ x in {x | ((range (n + 1)).sup' nonempty_range_succ (λ k, f k x)) < ε},
       f n x ∂μ) ≤ ennreal.of_real (μ[f n]),
-  { have hadd : ennreal.of_real (∫ (x : α), f n x ∂μ) =
-      ennreal.of_real (∫ (x : α) in
-        {x : α | ↑ε ≤ ((range (n + 1)).sup' nonempty_range_succ (λ k, f k x))}, f n x ∂μ) +
-      ennreal.of_real (∫ (x : α) in
-        {x : α | ((range (n + 1)).sup' nonempty_range_succ (λ k, f k x)) < ↑ε}, f n x ∂μ),
+  { have hadd : ennreal.of_real (∫ ω, f n ω ∂μ) =
+      ennreal.of_real (∫ ω in
+        {ω | ↑ε ≤ ((range (n + 1)).sup' nonempty_range_succ (λ k, f k ω))}, f n ω ∂μ) +
+      ennreal.of_real (∫ ω in
+        {ω | ((range (n + 1)).sup' nonempty_range_succ (λ k, f k ω)) < ↑ε}, f n ω ∂μ),
     { rw [← ennreal.of_real_add, ← integral_union],
       { conv_lhs { rw ← integral_univ },
         convert rfl,
-        ext x,
+        ext ω,
         change (ε : ℝ) ≤ _ ∨ _ < (ε : ℝ) ↔ _,
         simp only [le_or_lt, true_iff] },
-      { rintro x ⟨hx₁ : _ ≤ _, hx₂ : _ < _⟩,
-        exact (not_le.2 hx₂) hx₁ },
+      { rintro ω ⟨hω₁ : _ ≤ _, hω₂ : _ < _⟩,
+        exact (not_le.2 hω₂) hω₁ },
       { exact (measurable_set_lt (finset.measurable_range_sup''
           (λ n _, (hsub.strongly_measurable n).measurable.le (𝒢.le n))) measurable_const) },
       exacts [(hsub.integrable _).integrable_on, (hsub.integrable _).integrable_on,
         integral_nonneg (hnonneg _), integral_nonneg (hnonneg _)] },
     rwa [hadd, ennreal.add_le_add_iff_right ennreal.of_real_ne_top] at this },
-  calc ε • μ {x | (ε : ℝ) ≤ (range (n + 1)).sup' nonempty_range_succ (λ k, f k x)}
-    + ennreal.of_real (∫ x in {x | ((range (n + 1)).sup' nonempty_range_succ (λ k, f k x)) < ε},
-        f n x ∂μ)
-    ≤ ennreal.of_real (∫ x in {x | (ε : ℝ) ≤ (range (n + 1)).sup' nonempty_range_succ (λ k, f k x)},
-        stopped_value f (hitting f {y : ℝ | ↑ε ≤ y} 0 n) x ∂μ)
-    + ennreal.of_real (∫ x in {x | ((range (n + 1)).sup' nonempty_range_succ (λ k, f k x)) < ε},
-        stopped_value f (hitting f {y : ℝ | ↑ε ≤ y} 0 n) x ∂μ) :
+  calc ε • μ {ω | (ε : ℝ) ≤ (range (n + 1)).sup' nonempty_range_succ (λ k, f k ω)}
+    + ennreal.of_real (∫ ω in {ω | ((range (n + 1)).sup' nonempty_range_succ (λ k, f k ω)) < ε},
+        f n ω ∂μ)
+    ≤ ennreal.of_real (∫ ω in {ω | (ε : ℝ) ≤ (range (n + 1)).sup' nonempty_range_succ (λ k, f k ω)},
+        stopped_value f (hitting f {y : ℝ | ↑ε ≤ y} 0 n) ω ∂μ)
+    + ennreal.of_real (∫ ω in {ω | ((range (n + 1)).sup' nonempty_range_succ (λ k, f k ω)) < ε},
+        stopped_value f (hitting f {y : ℝ | ↑ε ≤ y} 0 n) ω ∂μ) :
     begin
       refine add_le_add (smul_le_stopped_value_hitting hsub _)
         (ennreal.of_real_le_of_real (set_integral_mono_on (hsub.integrable n).integrable_on
@@ -629,26 +629,26 @@ begin
           (hitting_is_stopping_time hsub.adapted measurable_set_Ici) hsub.integrable hitting_le))
         (measurable_set_lt (finset.measurable_range_sup''
           (λ n _, (hsub.strongly_measurable n).measurable.le (𝒢.le n))) measurable_const) _)),
-      intros x hx,
-      rw set.mem_set_of_eq at hx,
-      have : hitting f {y : ℝ | ↑ε ≤ y} 0 n x = n,
+      intros ω hω,
+      rw set.mem_set_of_eq at hω,
+      have : hitting f {y : ℝ | ↑ε ≤ y} 0 n ω = n,
       { simp only [hitting, set.mem_set_of_eq, exists_prop, pi.coe_nat, nat.cast_id,
           ite_eq_right_iff, forall_exists_index, and_imp],
         intros m hm hεm,
-        exact false.elim ((not_le.2 hx)
+        exact false.elim ((not_le.2 hω)
           ((le_sup'_iff _).2 ⟨m, mem_range.2 (nat.lt_succ_of_le hm.2), hεm⟩)) },
       simp_rw [stopped_value, this],
     end
-    ... = ennreal.of_real (∫ x, stopped_value f (hitting f {y : ℝ | ↑ε ≤ y} 0 n) x ∂μ) :
+    ... = ennreal.of_real (∫ ω, stopped_value f (hitting f {y : ℝ | ↑ε ≤ y} 0 n) ω ∂μ) :
     begin
       rw [← ennreal.of_real_add, ← integral_union],
       { conv_rhs { rw ← integral_univ },
         convert rfl,
-        ext x,
+        ext ω,
         change _ ↔ (ε : ℝ) ≤ _ ∨ _ < (ε : ℝ),
         simp only [le_or_lt, iff_true] },
-      { rintro x ⟨hx₁ : _ ≤ _, hx₂ : _ < _⟩,
-        exact (not_le.2 hx₂) hx₁ },
+      { rintro ω ⟨hω₁ : _ ≤ _, hω₂ : _ < _⟩,
+        exact (not_le.2 hω₂) hω₁ },
       { exact (measurable_set_lt (finset.measurable_range_sup''
           (λ n _, (hsub.strongly_measurable n).measurable.le (𝒢.le n))) measurable_const) },
       { exact (integrable.integrable_on (integrable_stopped_value
@@ -663,24 +663,24 @@ begin
       rw ← stopped_value_const f n,
       exact hsub.expected_stopped_value_mono
         (hitting_is_stopping_time hsub.adapted measurable_set_Ici)
-        (is_stopping_time_const _ _) (λ x, hitting_le x) (λ x, le_rfl : ∀ x, n ≤ n),
+        (is_stopping_time_const _ _) (λ ω, hitting_le ω) (λ ω, le_rfl : ∀ ω, n ≤ n),
     end
 end
 
 end maximal
 
-lemma submartingale.sum_mul_sub [is_finite_measure μ] {R : ℝ} {ξ f : ℕ → α → ℝ}
+lemma submartingale.sum_mul_sub [is_finite_measure μ] {R : ℝ} {ξ f : ℕ → Ω → ℝ}
   (hf : submartingale f 𝒢 μ) (hξ : adapted 𝒢 ξ)
-  (hbdd : ∀ n x, ξ n x ≤ R) (hnonneg : ∀ n x, 0 ≤ ξ n x) :
-  submartingale (λ n : ℕ, ∑ k in finset.range n, ξ k * (f (k + 1) - f k)) 𝒢 μ :=
+  (hbdd : ∀ n ω, ξ n ω ≤ R) (hnonneg : ∀ n ω, 0 ≤ ξ n ω) :
+  submartingale (λ n, ∑ k in finset.range n, ξ k * (f (k + 1) - f k)) 𝒢 μ :=
 begin
-  have hξbdd : ∀ i, ∃ (C : ℝ), ∀ (x : α), |ξ i x| ≤ C :=
-    λ i, ⟨R, λ x, (abs_of_nonneg (hnonneg i x)).trans_le (hbdd i x)⟩,
+  have hξbdd : ∀ i, ∃ C, ∀ ω, |ξ i ω| ≤ C :=
+    λ i, ⟨R, λ ω, (abs_of_nonneg (hnonneg i ω)).trans_le (hbdd i ω)⟩,
   have hint : ∀ m, integrable (∑ k in finset.range m, ξ k * (f (k + 1) - f k)) μ :=
     λ m, integrable_finset_sum' _
       (λ i hi, integrable.bdd_mul ((hf.integrable _).sub (hf.integrable _))
       hξ.strongly_measurable.ae_strongly_measurable (hξbdd _)),
-  have hadp : adapted 𝒢 (λ (n : ℕ), ∑ (k : ℕ) in finset.range n, ξ k * (f (k + 1) - f k)),
+  have hadp : adapted 𝒢 (λ n, ∑ k in finset.range n, ξ k * (f (k + 1) - f k)),
   { intro m,
     refine finset.strongly_measurable_sum' _ (λ i hi, _),
     rw finset.mem_range at hi,
@@ -700,10 +700,10 @@ end
 /-- Given a discrete submartingale `f` and a predictable process `ξ` (i.e. `ξ (n + 1)` is adapted)
 the process defined by `λ n, ∑ k in finset.range n, ξ (k + 1) * (f (k + 1) - f k)` is also a
 submartingale. -/
-lemma submartingale.sum_mul_sub' [is_finite_measure μ] {R : ℝ} {ξ f : ℕ → α → ℝ}
+lemma submartingale.sum_mul_sub' [is_finite_measure μ] {R : ℝ} {ξ f : ℕ → Ω → ℝ}
   (hf : submartingale f 𝒢 μ) (hξ : adapted 𝒢 (λ n, ξ (n + 1)))
-  (hbdd : ∀ n x, ξ n x ≤ R) (hnonneg : ∀ n x, 0 ≤ ξ n x) :
-  submartingale (λ n : ℕ, ∑ k in finset.range n, ξ (k + 1) * (f (k + 1) - f k)) 𝒢 μ :=
+  (hbdd : ∀ n ω, ξ n ω ≤ R) (hnonneg : ∀ n ω, 0 ≤ ξ n ω) :
+  submartingale (λ n, ∑ k in finset.range n, ξ (k + 1) * (f (k + 1) - f k)) 𝒢 μ :=
 hf.sum_mul_sub hξ (λ n, hbdd _) (λ n, hnonneg _)
 
 end nat

--- a/src/probability/stopping.lean
+++ b/src/probability/stopping.lean
@@ -20,8 +20,8 @@ at a specific time and is the first step in formalizing stochastic processes.
   filtration `f` if at each point in time `i`, `u i` is `f i`-strongly measurable
 * `measure_theory.prog_measurable`: a sequence of functions `u` is said to be progressively
   measurable with respect to a filtration `f` if at each point in time `i`, `u` restricted to
-  `set.Iic i × α` is strongly measurable with respect to the product `measurable_space` structure
-  where the σ-algebra used for `α` is `f i`.
+  `set.Iic i × Ω` is strongly measurable with respect to the product `measurable_space` structure
+  where the σ-algebra used for `Ω` is `f i`.
 * `measure_theory.filtration.natural`: the natural filtration with respect to a sequence of
   measurable functions is the smallest filtration to which it is adapted to
 * `measure_theory.is_stopping_time`: a stopping time with respect to some filtration `f` is a
@@ -50,16 +50,16 @@ namespace measure_theory
 
 /-! ### Filtrations -/
 
-/-- A `filtration` on measurable space `α` with σ-algebra `m` is a monotone
+/-- A `filtration` on measurable space `Ω` with σ-algebra `m` is a monotone
 sequence of sub-σ-algebras of `m`. -/
-structure filtration {α : Type*} (ι : Type*) [preorder ι] (m : measurable_space α) :=
-(seq   : ι → measurable_space α)
+structure filtration {Ω : Type*} (ι : Type*) [preorder ι] (m : measurable_space Ω) :=
+(seq   : ι → measurable_space Ω)
 (mono' : monotone seq)
 (le'   : ∀ i : ι, seq i ≤ m)
 
-variables {α β ι : Type*} {m : measurable_space α}
+variables {Ω β ι : Type*} {m : measurable_space Ω}
 
-instance [preorder ι] : has_coe_to_fun (filtration ι m) (λ _, ι → measurable_space α) :=
+instance [preorder ι] : has_coe_to_fun (filtration ι m) (λ _, ι → measurable_space Ω) :=
 ⟨λ f, f.seq⟩
 
 namespace filtration
@@ -69,17 +69,17 @@ protected lemma mono {i j : ι} (f : filtration ι m) (hij : i ≤ j) : f i ≤ 
 
 protected lemma le (f : filtration ι m) (i : ι) : f i ≤ m := f.le' i
 
-@[ext] protected lemma ext {f g : filtration ι m} (h : (f : ι → measurable_space α) = g) : f = g :=
+@[ext] protected lemma ext {f g : filtration ι m} (h : (f : ι → measurable_space Ω) = g) : f = g :=
 by { cases f, cases g, simp only, exact h, }
 
 variable (ι)
 /-- The constant filtration which is equal to `m` for all `i : ι`. -/
-def const (m' : measurable_space α) (hm' : m' ≤ m) : filtration ι m :=
+def const (m' : measurable_space Ω) (hm' : m' ≤ m) : filtration ι m :=
 ⟨λ _, m', monotone_const, λ _, hm'⟩
 variable {ι}
 
 @[simp]
-lemma const_apply {m' : measurable_space α} {hm' : m' ≤ m} (i : ι) : const ι m' hm' i = m' := rfl
+lemma const_apply {m' : measurable_space Ω} {hm' : m' ≤ m} (i : ι) : const ι m' hm' i = m' := rfl
 
 instance : inhabited (filtration ι m) := ⟨const ι m le_rfl⟩
 
@@ -198,22 +198,22 @@ instance : complete_lattice (filtration ι m) :=
 
 end filtration
 
-lemma measurable_set_of_filtration [preorder ι] {f : filtration ι m} {s : set α} {i : ι}
+lemma measurable_set_of_filtration [preorder ι] {f : filtration ι m} {s : set Ω} {i : ι}
   (hs : measurable_set[f i] s) : measurable_set[m] s :=
 f.le i s hs
 
 /-- A measure is σ-finite with respect to filtration if it is σ-finite with respect
 to all the sub-σ-algebra of the filtration. -/
-class sigma_finite_filtration [preorder ι] (μ : measure α) (f : filtration ι m) : Prop :=
+class sigma_finite_filtration [preorder ι] (μ : measure Ω) (f : filtration ι m) : Prop :=
 (sigma_finite : ∀ i : ι, sigma_finite (μ.trim (f.le i)))
 
-instance sigma_finite_of_sigma_finite_filtration [preorder ι] (μ : measure α) (f : filtration ι m)
+instance sigma_finite_of_sigma_finite_filtration [preorder ι] (μ : measure Ω) (f : filtration ι m)
   [hf : sigma_finite_filtration μ f] (i : ι) :
   sigma_finite (μ.trim (f.le i)) :=
 by apply hf.sigma_finite -- can't exact here
 
 @[priority 100]
-instance is_finite_measure.sigma_finite_filtration [preorder ι] (μ : measure α) (f : filtration ι m)
+instance is_finite_measure.sigma_finite_filtration [preorder ι] (μ : measure Ω) (f : filtration ι m)
   [is_finite_measure μ] :
   sigma_finite_filtration μ f :=
 ⟨λ n, by apply_instance⟩
@@ -221,19 +221,19 @@ instance is_finite_measure.sigma_finite_filtration [preorder ι] (μ : measure �
 /-- Given a integrable function `g`, the conditional expectations of `g` with respect to a
 filtration is uniformly integrable. -/
 lemma integrable.uniform_integrable_condexp_filtration
-  [preorder ι] {μ : measure α} [is_finite_measure μ] {f : filtration ι m}
-  {g : α → ℝ} (hg : integrable g μ) :
+  [preorder ι] {μ : measure Ω} [is_finite_measure μ] {f : filtration ι m}
+  {g : Ω → ℝ} (hg : integrable g μ) :
   uniform_integrable (λ i, μ[g | f i]) 1 μ :=
 hg.uniform_integrable_condexp f.le
 
 section adapted_process
 
 variables [topological_space β] [preorder ι]
-  {u v : ι → α → β} {f : filtration ι m}
+  {u v : ι → Ω → β} {f : filtration ι m}
 
 /-- A sequence of functions `u` is adapted to a filtration `f` if for all `i`,
 `u i` is `f i`-measurable. -/
-def adapted (f : filtration ι m) (u : ι → α → β) : Prop :=
+def adapted (f : filtration ι m) (u : ι → Ω → β) : Prop :=
 ∀ i : ι, strongly_measurable[f i] (u i)
 
 namespace adapted
@@ -265,21 +265,21 @@ lemma adapted_const (f : filtration ι m) (x : β) : adapted f (λ _ _, x) :=
 λ i, strongly_measurable_const
 
 variable (β)
-lemma adapted_zero [has_zero β] (f : filtration ι m) : adapted f (0 : ι → α → β) :=
-λ i, @strongly_measurable_zero α β (f i) _ _
+lemma adapted_zero [has_zero β] (f : filtration ι m) : adapted f (0 : ι → Ω → β) :=
+λ i, @strongly_measurable_zero Ω β (f i) _ _
 variable {β}
 
 /-- Progressively measurable process. A sequence of functions `u` is said to be progressively
 measurable with respect to a filtration `f` if at each point in time `i`, `u` restricted to
-`set.Iic i × α` is measurable with respect to the product `measurable_space` structure where the
-σ-algebra used for `α` is `f i`.
+`set.Iic i × Ω` is measurable with respect to the product `measurable_space` structure where the
+σ-algebra used for `Ω` is `f i`.
 The usual definition uses the interval `[0,i]`, which we replace by `set.Iic i`. We recover the
 usual definition for index types `ℝ≥0` or `ℕ`. -/
-def prog_measurable [measurable_space ι] (f : filtration ι m) (u : ι → α → β) : Prop :=
-∀ i, strongly_measurable[subtype.measurable_space.prod (f i)] (λ p : set.Iic i × α, u p.1 p.2)
+def prog_measurable [measurable_space ι] (f : filtration ι m) (u : ι → Ω → β) : Prop :=
+∀ i, strongly_measurable[subtype.measurable_space.prod (f i)] (λ p : set.Iic i × Ω, u p.1 p.2)
 
 lemma prog_measurable_const [measurable_space ι] (f : filtration ι m) (b : β) :
-  prog_measurable f ((λ _ _, b) : ι → α → β) :=
+  prog_measurable f ((λ _ _, b) : ι → Ω → β) :=
 λ i, @strongly_measurable_const _ _ (subtype.measurable_space.prod (f i)) _ _
 
 namespace prog_measurable
@@ -289,19 +289,19 @@ variables [measurable_space ι]
 protected lemma adapted (h : prog_measurable f u) : adapted f u :=
 begin
   intro i,
-  have : u i = (λ p : set.Iic i × α, u p.1 p.2) ∘ (λ x, (⟨i, set.mem_Iic.mpr le_rfl⟩, x)) := rfl,
+  have : u i = (λ p : set.Iic i × Ω, u p.1 p.2) ∘ (λ x, (⟨i, set.mem_Iic.mpr le_rfl⟩, x)) := rfl,
   rw this,
   exact (h i).comp_measurable measurable_prod_mk_left,
 end
 
-protected lemma comp {t : ι → α → ι} [topological_space ι] [borel_space ι] [metrizable_space ι]
+protected lemma comp {t : ι → Ω → ι} [topological_space ι] [borel_space ι] [metrizable_space ι]
   (h : prog_measurable f u) (ht : prog_measurable f t)
-  (ht_le : ∀ i x, t i x ≤ i) :
-  prog_measurable f (λ i x, u (t i x) x) :=
+  (ht_le : ∀ i ω, t i ω ≤ i) :
+  prog_measurable f (λ i ω, u (t i ω) ω) :=
 begin
   intro i,
-  have : (λ p : ↥(set.Iic i) × α, u (t (p.fst : ι) p.snd) p.snd)
-    = (λ p : ↥(set.Iic i) × α, u (p.fst : ι) p.snd) ∘ (λ p : ↥(set.Iic i) × α,
+  have : (λ p : ↥(set.Iic i) × Ω, u (t (p.fst : ι) p.snd) p.snd)
+    = (λ p : ↥(set.Iic i) × Ω, u (p.fst : ι) p.snd) ∘ (λ p : ↥(set.Iic i) × Ω,
       (⟨t (p.fst : ι) p.snd, set.mem_Iic.mpr ((ht_le _ _).trans p.fst.prop)⟩, p.snd)) := rfl,
   rw this,
   exact (h i).comp_measurable ((ht i).measurable.subtype_mk.prod_mk measurable_snd),
@@ -311,27 +311,27 @@ section arithmetic
 
 @[to_additive] protected lemma mul [has_mul β] [has_continuous_mul β]
   (hu : prog_measurable f u) (hv : prog_measurable f v) :
-  prog_measurable f (λ i x, u i x * v i x) :=
+  prog_measurable f (λ i ω, u i ω * v i ω) :=
 λ i, (hu i).mul (hv i)
 
 @[to_additive] protected lemma finset_prod' {γ} [comm_monoid β] [has_continuous_mul β]
-  {U : γ → ι → α → β} {s : finset γ} (h : ∀ c ∈ s, prog_measurable f (U c)) :
+  {U : γ → ι → Ω → β} {s : finset γ} (h : ∀ c ∈ s, prog_measurable f (U c)) :
   prog_measurable f (∏ c in s, U c) :=
 finset.prod_induction U (prog_measurable f) (λ _ _, prog_measurable.mul)
   (prog_measurable_const _ 1) h
 
 @[to_additive] protected lemma finset_prod {γ} [comm_monoid β] [has_continuous_mul β]
-  {U : γ → ι → α → β} {s : finset γ} (h : ∀ c ∈ s, prog_measurable f (U c)) :
+  {U : γ → ι → Ω → β} {s : finset γ} (h : ∀ c ∈ s, prog_measurable f (U c)) :
   prog_measurable f (λ i a, ∏ c in s, U c i a) :=
 by { convert prog_measurable.finset_prod' h, ext i a, simp only [finset.prod_apply], }
 
 @[to_additive] protected lemma inv [group β] [topological_group β] (hu : prog_measurable f u) :
-  prog_measurable f (λ i x, (u i x)⁻¹) :=
+  prog_measurable f (λ i ω, (u i ω)⁻¹) :=
 λ i, (hu i).inv
 
 @[to_additive] protected lemma div [group β] [topological_group β]
   (hu : prog_measurable f u) (hv : prog_measurable f v) :
-  prog_measurable f (λ i x, u i x / v i x) :=
+  prog_measurable f (λ i ω, u i ω / v i ω) :=
 λ i, (hu i).div (hv i)
 
 end arithmetic
@@ -339,12 +339,12 @@ end arithmetic
 end prog_measurable
 
 lemma prog_measurable_of_tendsto' {γ} [measurable_space ι] [metrizable_space β]
-  (fltr : filter γ) [fltr.ne_bot] [fltr.is_countably_generated] {U : γ → ι → α → β}
+  (fltr : filter γ) [fltr.ne_bot] [fltr.is_countably_generated] {U : γ → ι → Ω → β}
   (h : ∀ l, prog_measurable f (U l)) (h_tendsto : tendsto U fltr (𝓝 u)) :
   prog_measurable f u :=
 begin
   assume i,
-  apply @strongly_measurable_of_tendsto (set.Iic i × α) β γ (measurable_space.prod _ (f i))
+  apply @strongly_measurable_of_tendsto (set.Iic i × Ω) β γ (measurable_space.prod _ (f i))
    _ _ fltr _ _ _ _ (λ l, h l i),
   rw tendsto_pi_nhds at h_tendsto ⊢,
   intro x,
@@ -354,7 +354,7 @@ begin
 end
 
 lemma prog_measurable_of_tendsto [measurable_space ι] [metrizable_space β]
-  {U : ℕ → ι → α → β}
+  {U : ℕ → ι → Ω → β}
   (h : ∀ l, prog_measurable f (U l)) (h_tendsto : tendsto U at_top (𝓝 u)) :
   prog_measurable f u :=
 prog_measurable_of_tendsto' at_top h h_tendsto
@@ -364,10 +364,10 @@ prog_measurable_of_tendsto' at_top h h_tendsto
 theorem adapted.prog_measurable_of_continuous
   [topological_space ι] [metrizable_space ι] [measurable_space ι]
   [second_countable_topology ι] [opens_measurable_space ι] [metrizable_space β]
-  (h : adapted f u) (hu_cont : ∀ x, continuous (λ i, u i x)) :
+  (h : adapted f u) (hu_cont : ∀ ω, continuous (λ i, u i ω)) :
   prog_measurable f u :=
 λ i, @strongly_measurable_uncurry_of_continuous_of_strongly_measurable _ _ (set.Iic i) _ _ _ _ _ _ _
-  (f i) _ (λ x, (hu_cont x).comp continuous_induced_dom) (λ j, (h j).mono (f.mono j.prop))
+  (f i) _ (λ ω, (hu_cont ω).comp continuous_induced_dom) (λ j, (h j).mono (f.mono j.prop))
 
 end adapted_process
 
@@ -380,7 +380,7 @@ include mβ
 /-- Given a sequence of functions, the natural filtration is the smallest sequence
 of σ-algebras such that that sequence of functions is measurable with respect to
 the filtration. -/
-def natural (u : ι → α → β) (hum : ∀ i, strongly_measurable (u i)) : filtration ι m :=
+def natural (u : ι → Ω → β) (hum : ∀ i, strongly_measurable (u i)) : filtration ι m :=
 { seq   := λ i, ⨆ j ≤ i, measurable_space.comap (u j) mβ,
   mono' := λ i j hij, bsupr_mono $ λ k, ge_trans hij,
   le'   := λ i,
@@ -390,7 +390,7 @@ def natural (u : ι → α → β) (hum : ∀ i, strongly_measurable (u i)) : fi
     exact (hum j).measurable ht,
   end }
 
-lemma adapted_natural {u : ι → α → β} (hum : ∀ i, strongly_measurable[m] (u i)) :
+lemma adapted_natural {u : ι → Ω → β} (hum : ∀ i, strongly_measurable[m] (u i)) :
   adapted (natural u hum) u :=
 begin
   assume i,
@@ -409,8 +409,8 @@ with respect to `f i`.
 
 Intuitively, the stopping time `τ` describes some stopping rule such that at time
 `i`, we may determine it with the information we have at time `i`. -/
-def is_stopping_time [preorder ι] (f : filtration ι m) (τ : α → ι) :=
-∀ i : ι, measurable_set[f i] $ {x | τ x ≤ i}
+def is_stopping_time [preorder ι] (f : filtration ι m) (τ : Ω → ι) :=
+∀ i : ι, measurable_set[f i] $ {ω | τ ω ≤ i}
 
 lemma is_stopping_time_const [preorder ι] (f : filtration ι m) (i : ι) :
   is_stopping_time f (λ x, i) :=
@@ -419,23 +419,23 @@ lemma is_stopping_time_const [preorder ι] (f : filtration ι m) (i : ι) :
 section measurable_set
 
 section preorder
-variables [preorder ι] {f : filtration ι m} {τ : α → ι}
+variables [preorder ι] {f : filtration ι m} {τ : Ω → ι}
 
 protected lemma is_stopping_time.measurable_set_le (hτ : is_stopping_time f τ) (i : ι) :
-  measurable_set[f i] {x | τ x ≤ i} :=
+  measurable_set[f i] {ω | τ ω ≤ i} :=
 hτ i
 
 lemma is_stopping_time.measurable_set_lt_of_pred [pred_order ι]
   (hτ : is_stopping_time f τ) (i : ι) :
-  measurable_set[f i] {x | τ x < i} :=
+  measurable_set[f i] {ω | τ ω < i} :=
 begin
   by_cases hi_min : is_min i,
-  { suffices : {x : α | τ x < i} = ∅, by { rw this, exact @measurable_set.empty _ (f i), },
-    ext1 x,
+  { suffices : {ω : Ω | τ ω < i} = ∅, by { rw this, exact @measurable_set.empty _ (f i), },
+    ext1 ω,
     simp only [set.mem_set_of_eq, set.mem_empty_eq, iff_false],
     rw is_min_iff_forall_not_lt at hi_min,
-    exact hi_min (τ x), },
-  have : {x : α | τ x < i} = τ ⁻¹' (set.Iio i) := rfl,
+    exact hi_min (τ ω), },
+  have : {ω : Ω | τ ω < i} = τ ⁻¹' (set.Iio i) := rfl,
   rw [this, ←Iic_pred_of_not_is_min hi_min],
   exact f.mono (pred_le i) _ (hτ.measurable_set_le $ pred i),
 end
@@ -446,13 +446,13 @@ section countable_stopping_time
 
 namespace is_stopping_time
 
-variables [partial_order ι] {τ : α → ι} {f : filtration ι m}
+variables [partial_order ι] {τ : Ω → ι} {f : filtration ι m}
 
 protected lemma measurable_set_eq_of_countable
   (hτ : is_stopping_time f τ) (h_countable : (set.range τ).countable) (i : ι) :
-  measurable_set[f i] {a | τ a = i} :=
+  measurable_set[f i] {ω | τ ω = i} :=
 begin
-  have : {a | τ a = i} = {a | τ a ≤ i} \ (⋃ (j ∈ set.range τ) (hj : j < i), {a | τ a ≤ j}),
+  have : {ω | τ ω = i} = {ω | τ ω ≤ i} \ (⋃ (j ∈ set.range τ) (hj : j < i), {ω | τ ω ≤ j}),
   { ext1 a,
     simp only [set.mem_set_of_eq, set.mem_range, set.Union_exists, set.Union_Union_eq',
       set.mem_diff, set.mem_Union, exists_prop, not_exists, not_and, not_le],
@@ -474,36 +474,36 @@ begin
 end
 
 protected lemma measurable_set_eq_of_encodable [encodable ι] (hτ : is_stopping_time f τ) (i : ι) :
-  measurable_set[f i] {a | τ a = i} :=
+  measurable_set[f i] {ω | τ ω = i} :=
 hτ.measurable_set_eq_of_countable (set.to_countable _) i
 
 protected lemma measurable_set_lt_of_countable
   (hτ : is_stopping_time f τ) (h_countable : (set.range τ).countable) (i : ι) :
-  measurable_set[f i] {a | τ a < i} :=
+  measurable_set[f i] {ω | τ ω < i} :=
 begin
-  have : {a | τ a < i} = {a | τ a ≤ i} \ {a | τ a = i},
-  { ext1 x, simp [lt_iff_le_and_ne], },
+  have : {ω | τ ω < i} = {ω | τ ω ≤ i} \ {ω | τ ω = i},
+  { ext1 ω, simp [lt_iff_le_and_ne], },
   rw this,
   exact (hτ.measurable_set_le i).diff (hτ.measurable_set_eq_of_countable h_countable i),
 end
 
 protected lemma measurable_set_lt_of_encodable [encodable ι] (hτ : is_stopping_time f τ) (i : ι) :
-  measurable_set[f i] {a | τ a < i} :=
+  measurable_set[f i] {ω | τ ω < i} :=
 hτ.measurable_set_lt_of_countable (set.to_countable _) i
 
-protected lemma measurable_set_ge_of_countable {ι} [linear_order ι] {τ : α → ι} {f : filtration ι m}
+protected lemma measurable_set_ge_of_countable {ι} [linear_order ι] {τ : Ω → ι} {f : filtration ι m}
   (hτ : is_stopping_time f τ) (h_countable : (set.range τ).countable) (i : ι) :
-  measurable_set[f i] {a | i ≤ τ a} :=
+  measurable_set[f i] {ω | i ≤ τ ω} :=
 begin
-  have : {x | i ≤ τ x} = {x | τ x < i}ᶜ,
-  { ext1 x, simp only [set.mem_set_of_eq, set.mem_compl_eq, not_lt], },
+  have : {ω | i ≤ τ ω} = {ω | τ ω < i}ᶜ,
+  { ext1 ω, simp only [set.mem_set_of_eq, set.mem_compl_eq, not_lt], },
   rw this,
   exact (hτ.measurable_set_lt_of_countable h_countable i).compl,
 end
 
-protected lemma measurable_set_ge_of_encodable {ι} [linear_order ι] {τ : α → ι} {f : filtration ι m}
+protected lemma measurable_set_ge_of_encodable {ι} [linear_order ι] {τ : Ω → ι} {f : filtration ι m}
   [encodable ι] (hτ : is_stopping_time f τ) (i : ι) :
-  measurable_set[f i] {a | i ≤ τ a} :=
+  measurable_set[f i] {ω | i ≤ τ ω} :=
 hτ.measurable_set_ge_of_countable (set.to_countable _) i
 
 end is_stopping_time
@@ -511,13 +511,13 @@ end is_stopping_time
 end countable_stopping_time
 
 section linear_order
-variables [linear_order ι] {f : filtration ι m} {τ : α → ι}
+variables [linear_order ι] {f : filtration ι m} {τ : Ω → ι}
 
 lemma is_stopping_time.measurable_set_gt (hτ : is_stopping_time f τ) (i : ι) :
-  measurable_set[f i] {x | i < τ x} :=
+  measurable_set[f i] {ω | i < τ ω} :=
 begin
-  have : {x | i < τ x} = {x | τ x ≤ i}ᶜ,
-  { ext1 x, simp only [set.mem_set_of_eq, set.mem_compl_eq, not_le], },
+  have : {ω | i < τ ω} = {ω | τ ω ≤ i}ᶜ,
+  { ext1 ω, simp only [set.mem_set_of_eq, set.mem_compl_eq, not_le], },
   rw this,
   exact (hτ.measurable_set_le i).compl,
 end
@@ -529,17 +529,17 @@ variables [topological_space ι] [order_topology ι] [first_countable_topology �
 /-- Auxiliary lemma for `is_stopping_time.measurable_set_lt`. -/
 lemma is_stopping_time.measurable_set_lt_of_is_lub
   (hτ : is_stopping_time f τ) (i : ι) (h_lub : is_lub (set.Iio i) i) :
-  measurable_set[f i] {x | τ x < i} :=
+  measurable_set[f i] {ω | τ ω < i} :=
 begin
   by_cases hi_min : is_min i,
-  { suffices : {x : α | τ x < i} = ∅, by { rw this, exact @measurable_set.empty _ (f i), },
-    ext1 x,
+  { suffices : {ω | τ ω < i} = ∅, by { rw this, exact @measurable_set.empty _ (f i), },
+    ext1 ω,
     simp only [set.mem_set_of_eq, set.mem_empty_eq, iff_false],
-    exact is_min_iff_forall_not_lt.mp hi_min (τ x), },
+    exact is_min_iff_forall_not_lt.mp hi_min (τ ω), },
   obtain ⟨seq, -, -, h_tendsto, h_bound⟩ : ∃ seq : ℕ → ι,
       monotone seq ∧ (∀ j, seq j ≤ i) ∧ tendsto seq at_top (𝓝 i) ∧ (∀ j, seq j < i),
     from h_lub.exists_seq_monotone_tendsto (not_is_min_iff.mp hi_min),
-  have h_Ioi_eq_Union : set.Iio i = ⋃ j, { k | k ≤ seq j},
+  have h_Ioi_eq_Union : set.Iio i = ⋃ j, {k | k ≤ seq j},
   { ext1 k,
     simp only [set.mem_Iio, set.mem_Union, set.mem_set_of_eq],
     refine ⟨λ hk_lt_i, _, λ h_exists_k_le_seq, _⟩,
@@ -550,8 +550,8 @@ begin
       exact ⟨a, ha a le_rfl⟩, },
     { obtain ⟨j, hk_seq_j⟩ := h_exists_k_le_seq,
       exact hk_seq_j.trans_lt (h_bound j), }, },
-  have h_lt_eq_preimage : {x : α | τ x < i} = τ ⁻¹' (set.Iio i),
-  { ext1 x, simp only [set.mem_set_of_eq, set.mem_preimage, set.mem_Iio], },
+  have h_lt_eq_preimage : {ω | τ ω < i} = τ ⁻¹' (set.Iio i),
+  { ext1 ω, simp only [set.mem_set_of_eq, set.mem_preimage, set.mem_Iio], },
   rw [h_lt_eq_preimage, h_Ioi_eq_Union],
   simp only [set.preimage_Union, set.preimage_set_of_eq],
   exact measurable_set.Union
@@ -559,41 +559,41 @@ begin
 end
 
 lemma is_stopping_time.measurable_set_lt (hτ : is_stopping_time f τ) (i : ι) :
-  measurable_set[f i] {x | τ x < i} :=
+  measurable_set[f i] {ω | τ ω < i} :=
 begin
   obtain ⟨i', hi'_lub⟩ : ∃ i', is_lub (set.Iio i) i', from exists_lub_Iio i,
   cases lub_Iio_eq_self_or_Iio_eq_Iic i hi'_lub with hi'_eq_i h_Iio_eq_Iic,
   { rw ← hi'_eq_i at hi'_lub ⊢,
     exact hτ.measurable_set_lt_of_is_lub i' hi'_lub, },
-  { have h_lt_eq_preimage : {x : α | τ x < i} = τ ⁻¹' (set.Iio i) := rfl,
+  { have h_lt_eq_preimage : {ω : Ω | τ ω < i} = τ ⁻¹' (set.Iio i) := rfl,
     rw [h_lt_eq_preimage, h_Iio_eq_Iic],
     exact f.mono (lub_Iio_le i hi'_lub) _ (hτ.measurable_set_le i'), },
 end
 
 lemma is_stopping_time.measurable_set_ge (hτ : is_stopping_time f τ) (i : ι) :
-  measurable_set[f i] {x | i ≤ τ x} :=
+  measurable_set[f i] {ω | i ≤ τ ω} :=
 begin
-  have : {x | i ≤ τ x} = {x | τ x < i}ᶜ,
-  { ext1 x, simp only [set.mem_set_of_eq, set.mem_compl_eq, not_lt], },
+  have : {ω | i ≤ τ ω} = {ω | τ ω < i}ᶜ,
+  { ext1 ω, simp only [set.mem_set_of_eq, set.mem_compl_eq, not_lt], },
   rw this,
   exact (hτ.measurable_set_lt i).compl,
 end
 
 lemma is_stopping_time.measurable_set_eq (hτ : is_stopping_time f τ) (i : ι) :
-  measurable_set[f i] {x | τ x = i} :=
+  measurable_set[f i] {ω | τ ω = i} :=
 begin
-  have : {x | τ x = i} = {x | τ x ≤ i} ∩ {x | τ x ≥ i},
-  { ext1 x, simp only [set.mem_set_of_eq, ge_iff_le, set.mem_inter_eq, le_antisymm_iff], },
+  have : {ω | τ ω = i} = {ω | τ ω ≤ i} ∩ {ω | τ ω ≥ i},
+  { ext1 ω, simp only [set.mem_set_of_eq, ge_iff_le, set.mem_inter_eq, le_antisymm_iff], },
   rw this,
   exact (hτ.measurable_set_le i).inter (hτ.measurable_set_ge i),
 end
 
 lemma is_stopping_time.measurable_set_eq_le (hτ : is_stopping_time f τ) {i j : ι} (hle : i ≤ j) :
-  measurable_set[f j] {x | τ x = i} :=
+  measurable_set[f j] {ω | τ ω = i} :=
 f.mono hle _ $ hτ.measurable_set_eq i
 
 lemma is_stopping_time.measurable_set_lt_le (hτ : is_stopping_time f τ) {i j : ι} (hle : i ≤ j) :
-  measurable_set[f j] {x | τ x < i} :=
+  measurable_set[f j] {ω | τ ω < i} :=
 f.mono hle _ $ hτ.measurable_set_lt i
 
 end topological_space
@@ -603,11 +603,11 @@ end linear_order
 section encodable
 
 lemma is_stopping_time_of_measurable_set_eq [preorder ι] [encodable ι]
-  {f : filtration ι m} {τ : α → ι} (hτ : ∀ i, measurable_set[f i] {x | τ x = i}) :
+  {f : filtration ι m} {τ : Ω → ι} (hτ : ∀ i, measurable_set[f i] {ω | τ ω = i}) :
   is_stopping_time f τ :=
 begin
   intro i,
-  rw show {x | τ x ≤ i} = ⋃ k ≤ i, {x | τ x = k}, by { ext, simp },
+  rw show {ω | τ ω ≤ i} = ⋃ k ≤ i, {ω | τ ω = k}, by { ext, simp },
   refine measurable_set.bUnion (set.to_countable _) (λ k hk, _),
   exact f.mono hk _ (hτ k),
 end
@@ -618,38 +618,38 @@ end measurable_set
 
 namespace is_stopping_time
 
-protected lemma max [linear_order ι] {f : filtration ι m} {τ π : α → ι}
+protected lemma max [linear_order ι] {f : filtration ι m} {τ π : Ω → ι}
   (hτ : is_stopping_time f τ) (hπ : is_stopping_time f π) :
-  is_stopping_time f (λ x, max (τ x) (π x)) :=
+  is_stopping_time f (λ ω, max (τ ω) (π ω)) :=
 begin
   intro i,
   simp_rw [max_le_iff, set.set_of_and],
   exact (hτ i).inter (hπ i),
 end
 
-protected lemma max_const [linear_order ι] {f : filtration ι m} {τ : α → ι}
+protected lemma max_const [linear_order ι] {f : filtration ι m} {τ : Ω → ι}
   (hτ : is_stopping_time f τ) (i : ι) :
-  is_stopping_time f (λ x, max (τ x) i) :=
+  is_stopping_time f (λ ω, max (τ ω) i) :=
 hτ.max (is_stopping_time_const f i)
 
-protected lemma min [linear_order ι] {f : filtration ι m} {τ π : α → ι}
+protected lemma min [linear_order ι] {f : filtration ι m} {τ π : Ω → ι}
   (hτ : is_stopping_time f τ) (hπ : is_stopping_time f π) :
-  is_stopping_time f (λ x, min (τ x) (π x)) :=
+  is_stopping_time f (λ ω, min (τ ω) (π ω)) :=
 begin
   intro i,
   simp_rw [min_le_iff, set.set_of_or],
   exact (hτ i).union (hπ i),
 end
 
-protected lemma min_const [linear_order ι] {f : filtration ι m} {τ : α → ι}
+protected lemma min_const [linear_order ι] {f : filtration ι m} {τ : Ω → ι}
   (hτ : is_stopping_time f τ) (i : ι) :
-  is_stopping_time f (λ x, min (τ x) i) :=
+  is_stopping_time f (λ ω, min (τ ω) i) :=
 hτ.min (is_stopping_time_const f i)
 
 lemma add_const [add_group ι] [preorder ι] [covariant_class ι ι (function.swap (+)) (≤)]
   [covariant_class ι ι (+) (≤)]
-  {f : filtration ι m} {τ : α → ι} (hτ : is_stopping_time f τ) {i : ι} (hi : 0 ≤ i) :
-  is_stopping_time f (λ x, τ x + i) :=
+  {f : filtration ι m} {τ : Ω → ι} (hτ : is_stopping_time f τ) {i : ι} (hi : 0 ≤ i) :
+  is_stopping_time f (λ ω, τ ω + i) :=
 begin
   intro j,
   simp_rw [← le_sub_iff_add_le],
@@ -657,8 +657,8 @@ begin
 end
 
 lemma add_const_nat
-  {f : filtration ℕ m} {τ : α → ℕ} (hτ : is_stopping_time f τ) {i : ℕ} :
-  is_stopping_time f (λ x, τ x + i) :=
+  {f : filtration ℕ m} {τ : Ω → ℕ} (hτ : is_stopping_time f τ) {i : ℕ} :
+  is_stopping_time f (λ ω, τ ω + i) :=
 begin
   refine is_stopping_time_of_measurable_set_eq (λ j, _),
   by_cases hij : i ≤ j,
@@ -666,40 +666,40 @@ begin
     exact f.mono (j.sub_le i) _ (hτ.measurable_set_eq (j - i)) },
   { rw not_le at hij,
     convert measurable_set.empty,
-    ext x,
+    ext ω,
     simp only [set.mem_empty_eq, iff_false],
-    rintro (hx : τ x + i = j),
+    rintro (hx : τ ω + i = j),
     linarith },
 end
 
 -- generalize to certain encodable type?
 lemma add
-  {f : filtration ℕ m} {τ π : α → ℕ} (hτ : is_stopping_time f τ) (hπ : is_stopping_time f π) :
+  {f : filtration ℕ m} {τ π : Ω → ℕ} (hτ : is_stopping_time f τ) (hπ : is_stopping_time f π) :
   is_stopping_time f (τ + π) :=
 begin
   intro i,
-  rw (_ : {x | (τ + π) x ≤ i} = ⋃ k ≤ i, {x | π x = k} ∩ {x | τ x + k ≤ i}),
+  rw (_ : {ω | (τ + π) ω ≤ i} = ⋃ k ≤ i, {ω | π ω = k} ∩ {ω | τ ω + k ≤ i}),
   { exact measurable_set.Union (λ k, measurable_set.Union_Prop
       (λ hk, (hπ.measurable_set_eq_le hk).inter (hτ.add_const_nat i))) },
-  ext,
+  ext ω,
   simp only [pi.add_apply, set.mem_set_of_eq, set.mem_Union, set.mem_inter_eq, exists_prop],
-  refine ⟨λ h, ⟨π x, by linarith, rfl, h⟩, _⟩,
+  refine ⟨λ h, ⟨π ω, by linarith, rfl, h⟩, _⟩,
   rintro ⟨j, hj, rfl, h⟩,
   assumption
 end
 
 section preorder
 
-variables [preorder ι] {f : filtration ι m} {τ π : α → ι}
+variables [preorder ι] {f : filtration ι m} {τ π : Ω → ι}
 
 /-- The associated σ-algebra with a stopping time. -/
-protected def measurable_space (hτ : is_stopping_time f τ) : measurable_space α :=
-{ measurable_set' := λ s, ∀ i : ι, measurable_set[f i] (s ∩ {x | τ x ≤ i}),
+protected def measurable_space (hτ : is_stopping_time f τ) : measurable_space Ω :=
+{ measurable_set' := λ s, ∀ i : ι, measurable_set[f i] (s ∩ {ω | τ ω ≤ i}),
   measurable_set_empty :=
-    λ i, (set.empty_inter {x | τ x ≤ i}).symm ▸ @measurable_set.empty _ (f i),
+    λ i, (set.empty_inter {ω | τ ω ≤ i}).symm ▸ @measurable_set.empty _ (f i),
   measurable_set_compl := λ s hs i,
     begin
-      rw (_ : sᶜ ∩ {x | τ x ≤ i} = (sᶜ ∪ {x | τ x ≤ i}ᶜ) ∩ {x | τ x ≤ i}),
+      rw (_ : sᶜ ∩ {ω | τ ω ≤ i} = (sᶜ ∪ {ω | τ ω ≤ i}ᶜ) ∩ {ω | τ ω ≤ i}),
       { refine measurable_set.inter _ _,
         { rw ← set.compl_inter,
           exact (hs i).compl },
@@ -714,9 +714,9 @@ protected def measurable_space (hτ : is_stopping_time f τ) : measurable_space 
       exact measurable_set.Union (hs i),
     end }
 
-protected lemma measurable_set (hτ : is_stopping_time f τ) (s : set α) :
+protected lemma measurable_set (hτ : is_stopping_time f τ) (s : set Ω) :
   measurable_set[hτ.measurable_space] s ↔
-  ∀ i : ι, measurable_set[f i] (s ∩ {x | τ x ≤ i}) :=
+  ∀ i : ι, measurable_set[f i] (s ∩ {ω | τ ω ≤ i}) :=
 iff.rfl
 
 lemma measurable_space_mono
@@ -724,7 +724,7 @@ lemma measurable_space_mono
   hτ.measurable_space ≤ hπ.measurable_space :=
 begin
   intros s hs i,
-  rw (_ : s ∩ {x | π x ≤ i} = s ∩ {x | τ x ≤ i} ∩ {x | π x ≤ i}),
+  rw (_ : s ∩ {ω | π ω ≤ i} = s ∩ {ω | τ ω ≤ i} ∩ {ω | π ω ≤ i}),
   { exact (hs i).inter (hπ i) },
   { ext,
     simp only [set.mem_inter_eq, iff_self_and, and.congr_left_iff, set.mem_set_of_eq],
@@ -736,11 +736,11 @@ lemma measurable_space_le_of_encodable [encodable ι] (hτ : is_stopping_time f 
   hτ.measurable_space ≤ m :=
 begin
   intros s hs,
-  change ∀ i, measurable_set[f i] (s ∩ {x | τ x ≤ i}) at hs,
-  rw (_ : s = ⋃ i, s ∩ {x | τ x ≤ i}),
+  change ∀ i, measurable_set[f i] (s ∩ {ω | τ ω ≤ i}) at hs,
+  rw (_ : s = ⋃ i, s ∩ {ω | τ ω ≤ i}),
   { exact measurable_set.Union (λ i, f.le i _ (hs i)) },
-  { ext x, split; rw set.mem_Union,
-    { exact λ hx, ⟨τ x, hx, le_rfl⟩ },
+  { ext ω, split; rw set.mem_Union,
+    { exact λ hx, ⟨τ ω, hx, le_rfl⟩ },
     { rintro ⟨_, hx, _⟩,
       exact hx } }
 end
@@ -750,37 +750,37 @@ lemma measurable_space_le' [is_countably_generated (at_top : filter ι)] [(at_to
   hτ.measurable_space ≤ m :=
 begin
   intros s hs,
-  change ∀ i, measurable_set[f i] (s ∩ {x | τ x ≤ i}) at hs,
+  change ∀ i, measurable_set[f i] (s ∩ {ω | τ ω ≤ i}) at hs,
   obtain ⟨seq : ℕ → ι, h_seq_tendsto⟩ := at_top.exists_seq_tendsto,
-  rw (_ : s = ⋃ n, s ∩ {x | τ x ≤ seq n}),
+  rw (_ : s = ⋃ n, s ∩ {ω | τ ω ≤ seq n}),
   { exact measurable_set.Union (λ i, f.le (seq i) _ (hs (seq i))), },
-  { ext x, split; rw set.mem_Union,
+  { ext ω, split; rw set.mem_Union,
     { intros hx,
-      suffices : ∃ i, τ x ≤ seq i, from ⟨this.some, hx, this.some_spec⟩,
+      suffices : ∃ i, τ ω ≤ seq i, from ⟨this.some, hx, this.some_spec⟩,
       rw tendsto_at_top at h_seq_tendsto,
-      exact (h_seq_tendsto (τ x)).exists, },
+      exact (h_seq_tendsto (τ ω)).exists, },
     { rintro ⟨_, hx, _⟩,
       exact hx }, },
   all_goals { apply_instance, },
 end
 
-lemma measurable_space_le {ι} [semilattice_sup ι] {f : filtration ι m} {τ : α → ι}
+lemma measurable_space_le {ι} [semilattice_sup ι] {f : filtration ι m} {τ : Ω → ι}
   [is_countably_generated (at_top : filter ι)] (hτ : is_stopping_time f τ) :
   hτ.measurable_space ≤ m :=
 begin
   casesI is_empty_or_nonempty ι,
-  { haveI : is_empty α := ⟨λ x, is_empty.false (τ x)⟩,
+  { haveI : is_empty Ω := ⟨λ ω, is_empty.false (τ ω)⟩,
     intros s hsτ,
     suffices hs : s = ∅, by { rw hs, exact measurable_set.empty, },
-    haveI : unique (set α) := set.unique_empty,
+    haveI : unique (set Ω) := set.unique_empty,
     rw [unique.eq_default s, unique.eq_default ∅], },
   exact measurable_space_le' hτ,
 end
 
-example {f : filtration ℕ m} {τ : α → ℕ} (hτ : is_stopping_time f τ) : hτ.measurable_space ≤ m :=
+example {f : filtration ℕ m} {τ : Ω → ℕ} (hτ : is_stopping_time f τ) : hτ.measurable_space ≤ m :=
 hτ.measurable_space_le
 
-example {f : filtration ℝ m} {τ : α → ℝ} (hτ : is_stopping_time f τ) : hτ.measurable_space ≤ m :=
+example {f : filtration ℝ m} {τ : Ω → ℝ} (hτ : is_stopping_time f τ) : hτ.measurable_space ≤ m :=
 hτ.measurable_space_le
 
 @[simp] lemma measurable_space_const (f : filtration ι m) (i : ι) :
@@ -799,13 +799,13 @@ begin
     { simp only [hij, set.set_of_false, set.inter_empty, measurable_set.empty], }, },
 end
 
-lemma measurable_set_inter_eq_iff (hτ : is_stopping_time f τ) (s : set α) (i : ι) :
-  measurable_set[hτ.measurable_space] (s ∩ {x | τ x = i})
-    ↔ measurable_set[f i] (s ∩ {x | τ x = i}) :=
+lemma measurable_set_inter_eq_iff (hτ : is_stopping_time f τ) (s : set Ω) (i : ι) :
+  measurable_set[hτ.measurable_space] (s ∩ {ω | τ ω = i})
+    ↔ measurable_set[f i] (s ∩ {ω | τ ω = i}) :=
 begin
-  have : ∀ j, ({x : α | τ x = i} ∩ {x : α | τ x ≤ j}) = {x : α | τ x = i} ∩ {x | i ≤ j},
+  have : ∀ j, ({ω : Ω | τ ω = i} ∩ {ω : Ω | τ ω ≤ j}) = {ω : Ω | τ ω = i} ∩ {ω | i ≤ j},
   { intro j,
-    ext1 x,
+    ext1 ω,
     simp only [set.mem_inter_eq, set.mem_set_of_eq, and.congr_right_iff],
     intro hxi,
     rw hxi, },
@@ -820,11 +820,11 @@ begin
     { simp [hij], }, },
 end
 
-lemma measurable_space_le_of_le_const (hτ : is_stopping_time f τ) {i : ι} (hτ_le : ∀ x, τ x ≤ i) :
+lemma measurable_space_le_of_le_const (hτ : is_stopping_time f τ) {i : ι} (hτ_le : ∀ ω, τ ω ≤ i) :
   hτ.measurable_space ≤ f i :=
 (measurable_space_mono hτ _ hτ_le).trans (measurable_space_const _ _).le
 
-lemma le_measurable_space_of_const_le (hτ : is_stopping_time f τ) {i : ι} (hτ_le : ∀ x, i ≤ τ x) :
+lemma le_measurable_space_of_const_le (hτ : is_stopping_time f τ) {i : ι} (hτ_le : ∀ ω, i ≤ τ ω) :
   f i ≤ hτ.measurable_space :=
 (measurable_space_const _ _).symm.le.trans (measurable_space_mono _ hτ hτ_le)
 
@@ -832,7 +832,7 @@ end preorder
 
 instance sigma_finite_stopping_time {ι} [semilattice_sup ι] [order_bot ι]
   [(filter.at_top : filter ι).is_countably_generated]
-  {μ : measure α} {f : filtration ι m} {τ : α → ι}
+  {μ : measure Ω} {f : filtration ι m} {τ : Ω → ι}
   [sigma_finite_filtration μ f] (hτ : is_stopping_time f τ) :
   sigma_finite (μ.trim hτ.measurable_space_le) :=
 begin
@@ -844,22 +844,22 @@ end
 
 section linear_order
 
-variables [linear_order ι] {f : filtration ι m} {τ π : α → ι}
+variables [linear_order ι] {f : filtration ι m} {τ π : Ω → ι}
 
 protected lemma measurable_set_le' (hτ : is_stopping_time f τ) (i : ι) :
-  measurable_set[hτ.measurable_space] {x | τ x ≤ i} :=
+  measurable_set[hτ.measurable_space] {ω | τ ω ≤ i} :=
 begin
   intro j,
-  have : {x : α | τ x ≤ i} ∩ {x : α | τ x ≤ j} = {x : α | τ x ≤ min i j},
-  { ext1 x, simp only [set.mem_inter_eq, set.mem_set_of_eq, le_min_iff], },
+  have : {ω : Ω | τ ω ≤ i} ∩ {ω : Ω | τ ω ≤ j} = {ω : Ω | τ ω ≤ min i j},
+  { ext1 ω, simp only [set.mem_inter_eq, set.mem_set_of_eq, le_min_iff], },
   rw this,
   exact f.mono (min_le_right i j) _ (hτ _),
 end
 
 protected lemma measurable_set_gt' (hτ : is_stopping_time f τ) (i : ι) :
-  measurable_set[hτ.measurable_space] {x | i < τ x} :=
+  measurable_set[hτ.measurable_space] {ω | i < τ ω} :=
 begin
-  have : {x : α | i < τ x} = {x : α | τ x ≤ i}ᶜ, by { ext1 x, simp, },
+  have : {ω : Ω | i < τ ω} = {ω : Ω | τ ω ≤ i}ᶜ, by { ext1 ω, simp, },
   rw this,
   exact (hτ.measurable_set_le' i).compl,
 end
@@ -867,19 +867,19 @@ end
 protected lemma measurable_set_eq' [topological_space ι] [order_topology ι]
   [first_countable_topology ι]
   (hτ : is_stopping_time f τ) (i : ι) :
-  measurable_set[hτ.measurable_space] {x | τ x = i} :=
+  measurable_set[hτ.measurable_space] {ω | τ ω = i} :=
 begin
-  rw [← set.univ_inter {x | τ x = i}, measurable_set_inter_eq_iff, set.univ_inter],
+  rw [← set.univ_inter {ω | τ ω = i}, measurable_set_inter_eq_iff, set.univ_inter],
   exact hτ.measurable_set_eq i,
 end
 
 protected lemma measurable_set_ge' [topological_space ι] [order_topology ι]
   [first_countable_topology ι]
   (hτ : is_stopping_time f τ) (i : ι) :
-  measurable_set[hτ.measurable_space] {x | i ≤ τ x} :=
+  measurable_set[hτ.measurable_space] {ω | i ≤ τ ω} :=
 begin
-  have : {x | i ≤ τ x} = {x | τ x = i} ∪ {x | i < τ x},
-  { ext1 x,
+  have : {ω | i ≤ τ ω} = {ω | τ ω = i} ∪ {ω | i < τ ω},
+  { ext1 ω,
     simp only [le_iff_lt_or_eq, set.mem_set_of_eq, set.mem_union_eq],
     rw [@eq_comm _ i, or_comm], },
   rw this,
@@ -889,10 +889,10 @@ end
 protected lemma measurable_set_lt' [topological_space ι] [order_topology ι]
   [first_countable_topology ι]
   (hτ : is_stopping_time f τ) (i : ι) :
-  measurable_set[hτ.measurable_space] {x | τ x < i} :=
+  measurable_set[hτ.measurable_space] {ω | τ ω < i} :=
 begin
-  have : {x | τ x < i} = {x | τ x ≤ i} \ {x | τ x = i},
-  { ext1 x,
+  have : {ω | τ ω < i} = {ω | τ ω ≤ i} \ {ω | τ ω = i},
+  { ext1 ω,
     simp only [lt_iff_le_and_ne, set.mem_set_of_eq, set.mem_diff], },
   rw this,
   exact (hτ.measurable_set_le' i).diff (hτ.measurable_set_eq' i),
@@ -902,22 +902,22 @@ section countable
 
 protected lemma measurable_set_eq_of_countable'
   (hτ : is_stopping_time f τ) (h_countable : (set.range τ).countable) (i : ι) :
-  measurable_set[hτ.measurable_space] {x | τ x = i} :=
+  measurable_set[hτ.measurable_space] {ω | τ ω = i} :=
 begin
-  rw [← set.univ_inter {x | τ x = i}, measurable_set_inter_eq_iff, set.univ_inter],
+  rw [← set.univ_inter {ω | τ ω = i}, measurable_set_inter_eq_iff, set.univ_inter],
   exact hτ.measurable_set_eq_of_countable h_countable i,
 end
 
 protected lemma measurable_set_eq_of_encodable' [encodable ι] (hτ : is_stopping_time f τ) (i : ι) :
-  measurable_set[hτ.measurable_space] {a | τ a = i} :=
+  measurable_set[hτ.measurable_space] {ω | τ ω = i} :=
 hτ.measurable_set_eq_of_countable' (set.to_countable _) i
 
 protected lemma measurable_set_ge_of_countable'
   (hτ : is_stopping_time f τ) (h_countable : (set.range τ).countable) (i : ι) :
-  measurable_set[hτ.measurable_space] {x | i ≤ τ x} :=
+  measurable_set[hτ.measurable_space] {ω | i ≤ τ ω} :=
 begin
-  have : {x | i ≤ τ x} = {x | τ x = i} ∪ {x | i < τ x},
-  { ext1 x,
+  have : {ω | i ≤ τ ω} = {ω | τ ω = i} ∪ {ω | i < τ ω},
+  { ext1 ω,
     simp only [le_iff_lt_or_eq, set.mem_set_of_eq, set.mem_union_eq],
     rw [@eq_comm _ i, or_comm], },
   rw this,
@@ -925,22 +925,22 @@ begin
 end
 
 protected lemma measurable_set_ge_of_encodable' [encodable ι] (hτ : is_stopping_time f τ) (i : ι) :
-  measurable_set[hτ.measurable_space] {a | i ≤ τ a} :=
+  measurable_set[hτ.measurable_space] {ω | i ≤ τ ω} :=
 hτ.measurable_set_ge_of_countable' (set.to_countable _) i
 
 protected lemma measurable_set_lt_of_countable'
   (hτ : is_stopping_time f τ) (h_countable : (set.range τ).countable) (i : ι) :
-  measurable_set[hτ.measurable_space] {x | τ x < i} :=
+  measurable_set[hτ.measurable_space] {ω | τ ω < i} :=
 begin
-  have : {x | τ x < i} = {x | τ x ≤ i} \ {x | τ x = i},
-  { ext1 x,
+  have : {ω | τ ω < i} = {ω | τ ω ≤ i} \ {ω | τ ω = i},
+  { ext1 ω,
     simp only [lt_iff_le_and_ne, set.mem_set_of_eq, set.mem_diff], },
   rw this,
   exact (hτ.measurable_set_le' i).diff (hτ.measurable_set_eq_of_countable' h_countable i),
 end
 
 protected lemma measurable_set_lt_of_encodable' [encodable ι] (hτ : is_stopping_time f τ) (i : ι) :
-  measurable_set[hτ.measurable_space] {a | τ a < i} :=
+  measurable_set[hτ.measurable_space] {ω | τ ω < i} :=
 hτ.measurable_set_lt_of_countable' (set.to_countable _) i
 
 protected lemma measurable_space_le_of_countable (hτ : is_stopping_time f τ)
@@ -948,12 +948,12 @@ protected lemma measurable_space_le_of_countable (hτ : is_stopping_time f τ)
   hτ.measurable_space ≤ m :=
 begin
   intros s hs,
-  change ∀ i, measurable_set[f i] (s ∩ {x | τ x ≤ i}) at hs,
-  rw (_ : s = ⋃ (i ∈ set.range τ), s ∩ {x | τ x ≤ i}),
+  change ∀ i, measurable_set[f i] (s ∩ {ω | τ ω ≤ i}) at hs,
+  rw (_ : s = ⋃ (i ∈ set.range τ), s ∩ {ω | τ ω ≤ i}),
   { exact measurable_set.bUnion h_countable (λ i _, f.le i _ (hs i)), },
-  { ext x,
+  { ext ω,
     split; rw set.mem_Union,
-    { exact λ hx, ⟨τ x, by simpa using hx⟩,},
+    { exact λ hx, ⟨τ ω, by simpa using hx⟩,},
     { rintro ⟨i, hx⟩,
       simp only [set.mem_range, set.Union_exists, set.mem_Union, set.mem_inter_eq,
         set.mem_set_of_eq, exists_prop, exists_and_distrib_right] at hx,
@@ -966,11 +966,11 @@ protected lemma measurable [topological_space ι] [measurable_space ι]
   [borel_space ι] [order_topology ι] [second_countable_topology ι]
   (hτ : is_stopping_time f τ) :
   measurable[hτ.measurable_space] τ :=
-@measurable_of_Iic ι α _ _ _ hτ.measurable_space _ _ _ _ (λ i, hτ.measurable_set_le' i)
+@measurable_of_Iic ι Ω _ _ _ hτ.measurable_space _ _ _ _ (λ i, hτ.measurable_set_le' i)
 
 protected lemma measurable_of_le [topological_space ι] [measurable_space ι]
   [borel_space ι] [order_topology ι] [second_countable_topology ι]
-  (hτ : is_stopping_time f τ) {i : ι} (hτ_le : ∀ x, τ x ≤ i) :
+  (hτ : is_stopping_time f τ) {i : ι} (hτ_le : ∀ ω, τ ω ≤ i) :
   measurable[f i] τ :=
 hτ.measurable.mono (measurable_space_le_of_le_const _ hτ_le) le_rfl
 
@@ -984,13 +984,13 @@ begin
     change measurable_set[hτ.measurable_space] s ∧ measurable_set[hπ.measurable_space] s
       → measurable_set[(hτ.min hπ).measurable_space] s,
     simp_rw is_stopping_time.measurable_set,
-    have : ∀ i, {x | min (τ x) (π x) ≤ i} = {x | τ x ≤ i} ∪ {x | π x ≤ i},
-    { intro i, ext1 x, simp, },
+    have : ∀ i, {ω | min (τ ω) (π ω) ≤ i} = {ω | τ ω ≤ i} ∪ {ω | π ω ≤ i},
+    { intro i, ext1 ω, simp, },
     simp_rw [this, set.inter_union_distrib_left],
     exact λ h i, (h.left i).union (h.right i), },
 end
 
-lemma measurable_set_min_iff (hτ : is_stopping_time f τ) (hπ : is_stopping_time f π) (s : set α) :
+lemma measurable_set_min_iff (hτ : is_stopping_time f τ) (hπ : is_stopping_time f π) (s : set Ω) :
   measurable_set[(hτ.min hπ).measurable_space] s
     ↔ measurable_set[hτ.measurable_space] s ∧ measurable_set[hπ.measurable_space] s :=
 by { rw measurable_space_min, refl, }
@@ -999,7 +999,7 @@ lemma measurable_space_min_const (hτ : is_stopping_time f τ) {i : ι} :
   (hτ.min_const i).measurable_space = hτ.measurable_space ⊓ f i :=
 by rw [hτ.measurable_space_min (is_stopping_time_const _ i), measurable_space_const]
 
-lemma measurable_set_min_const_iff (hτ : is_stopping_time f τ) (s : set α)
+lemma measurable_set_min_const_iff (hτ : is_stopping_time f τ) (s : set Ω)
   {i : ι} :
   measurable_set[(hτ.min_const i).measurable_space] s
     ↔ measurable_set[hτ.measurable_space] s ∧ measurable_set[f i] s :=
@@ -1007,18 +1007,18 @@ by rw [measurable_space_min_const, measurable_space.measurable_set_inf]
 
 lemma measurable_set_inter_le [topological_space ι] [second_countable_topology ι] [order_topology ι]
   [measurable_space ι] [borel_space ι]
-  (hτ : is_stopping_time f τ) (hπ : is_stopping_time f π) (s : set α)
+  (hτ : is_stopping_time f τ) (hπ : is_stopping_time f π) (s : set Ω)
   (hs : measurable_set[hτ.measurable_space] s) :
-  measurable_set[(hτ.min hπ).measurable_space] (s ∩ {x | τ x ≤ π x}) :=
+  measurable_set[(hτ.min hπ).measurable_space] (s ∩ {ω | τ ω ≤ π ω}) :=
 begin
   simp_rw is_stopping_time.measurable_set at ⊢ hs,
   intro i,
-  have : (s ∩ {x | τ x ≤ π x} ∩ {x | min (τ x) (π x) ≤ i})
-    = (s ∩ {x | τ x ≤ i}) ∩ {x | min (τ x) (π x) ≤ i} ∩ {x | min (τ x) i ≤ min (min (τ x) (π x)) i},
-  { ext1 x,
+  have : (s ∩ {ω | τ ω ≤ π ω} ∩ {ω | min (τ ω) (π ω) ≤ i})
+    = (s ∩ {ω | τ ω ≤ i}) ∩ {ω | min (τ ω) (π ω) ≤ i} ∩ {ω | min (τ ω) i ≤ min (min (τ ω) (π ω)) i},
+  { ext1 ω,
     simp only [min_le_iff, set.mem_inter_eq, set.mem_set_of_eq, le_min_iff, le_refl, true_and,
       and_true, true_or, or_true],
-    by_cases hτi : τ x ≤ i,
+    by_cases hτi : τ ω ≤ i,
     { simp only [hτi, true_or, and_true, and.congr_right_iff],
       intro hx,
       split; intro h,
@@ -1040,12 +1040,12 @@ end
 lemma measurable_set_inter_le_iff [topological_space ι]
   [second_countable_topology ι] [order_topology ι] [measurable_space ι] [borel_space ι]
   (hτ : is_stopping_time f τ) (hπ : is_stopping_time f π)
-  (s : set α) :
-  measurable_set[hτ.measurable_space] (s ∩ {x | τ x ≤ π x})
-    ↔ measurable_set[(hτ.min hπ).measurable_space] (s ∩ {x | τ x ≤ π x}) :=
+  (s : set Ω) :
+  measurable_set[hτ.measurable_space] (s ∩ {ω | τ ω ≤ π ω})
+    ↔ measurable_set[(hτ.min hπ).measurable_space] (s ∩ {ω | τ ω ≤ π ω}) :=
 begin
   split; intro h,
-  { have : s ∩ {x | τ x ≤ π x} = s ∩ {x | τ x ≤ π x} ∩ {x | τ x ≤ π x},
+  { have : s ∩ {ω | τ ω ≤ π ω} = s ∩ {ω | τ ω ≤ π ω} ∩ {ω | τ ω ≤ π ω},
       by rw [set.inter_assoc, set.inter_self],
     rw this,
     exact measurable_set_inter_le _ _ _ h, },
@@ -1056,17 +1056,17 @@ end
 lemma measurable_set_le_stopping_time [topological_space ι]
   [second_countable_topology ι] [order_topology ι] [measurable_space ι] [borel_space ι]
   (hτ : is_stopping_time f τ) (hπ : is_stopping_time f π) :
-  measurable_set[hτ.measurable_space] {x | τ x ≤ π x} :=
+  measurable_set[hτ.measurable_space] {ω | τ ω ≤ π ω} :=
 begin
   rw hτ.measurable_set,
   intro j,
-  have : {x | τ x ≤ π x} ∩ {x | τ x ≤ j} = {x | min (τ x) j ≤ min (π x) j} ∩ {x | τ x ≤ j},
-  { ext1 x,
+  have : {ω | τ ω ≤ π ω} ∩ {ω | τ ω ≤ j} = {ω | min (τ ω) j ≤ min (π ω) j} ∩ {ω | τ ω ≤ j},
+  { ext1 ω,
     simp only [set.mem_inter_eq, set.mem_set_of_eq, min_le_iff, le_min_iff, le_refl, and_true,
       and.congr_left_iff],
     intro h,
     simp only [h, or_self, and_true],
-    by_cases hj : j ≤ π x,
+    by_cases hj : j ≤ π ω,
     { simp only [hj, h.trans hj, or_self], },
     { simp only [hj, or_false], }, },
   rw this,
@@ -1079,11 +1079,11 @@ end
 lemma measurable_set_stopping_time_le [topological_space ι]
   [second_countable_topology ι] [order_topology ι] [measurable_space ι] [borel_space ι]
   (hτ : is_stopping_time f τ) (hπ : is_stopping_time f π) :
-  measurable_set[hπ.measurable_space] {x | τ x ≤ π x} :=
+  measurable_set[hπ.measurable_space] {ω | τ ω ≤ π ω} :=
 begin
-  suffices : measurable_set[(hτ.min hπ).measurable_space] {x : α | τ x ≤ π x},
+  suffices : measurable_set[(hτ.min hπ).measurable_space] {ω : Ω | τ ω ≤ π ω},
     by { rw measurable_set_min_iff hτ hπ at this, exact this.2, },
-  rw [← set.univ_inter {x : α | τ x ≤ π x}, ← hτ.measurable_set_inter_le_iff hπ, set.univ_inter],
+  rw [← set.univ_inter {ω : Ω | τ ω ≤ π ω}, ← hτ.measurable_set_inter_le_iff hπ, set.univ_inter],
   exact measurable_set_le_stopping_time hτ hπ,
 end
 
@@ -1091,13 +1091,13 @@ lemma measurable_set_eq_stopping_time [add_group ι]
   [topological_space ι] [measurable_space ι] [borel_space ι] [order_topology ι]
   [measurable_singleton_class ι] [second_countable_topology ι] [has_measurable_sub₂ ι]
   (hτ : is_stopping_time f τ) (hπ : is_stopping_time f π) :
-  measurable_set[hτ.measurable_space] {x | τ x = π x} :=
+  measurable_set[hτ.measurable_space] {ω | τ ω = π ω} :=
 begin
   rw hτ.measurable_set,
   intro j,
-  have : {x | τ x = π x} ∩ {x | τ x ≤ j}
-    = {x | min (τ x) j = min (π x) j} ∩ {x | τ x ≤ j} ∩ {x | π x ≤ j},
-  { ext1 x,
+  have : {ω | τ ω = π ω} ∩ {ω | τ ω ≤ j}
+    = {ω | min (τ ω) j = min (π ω) j} ∩ {ω | τ ω ≤ j} ∩ {ω | π ω ≤ j},
+  { ext1 ω,
     simp only [set.mem_inter_eq, set.mem_set_of_eq],
     refine ⟨λ h, ⟨⟨_, h.2⟩, _⟩, λ h, ⟨_, h.1.2⟩⟩,
     { rw h.1, },
@@ -1117,13 +1117,13 @@ lemma measurable_set_eq_stopping_time_of_encodable [encodable ι]
   [topological_space ι] [measurable_space ι] [borel_space ι] [order_topology ι]
   [measurable_singleton_class ι] [second_countable_topology ι]
   (hτ : is_stopping_time f τ) (hπ : is_stopping_time f π) :
-  measurable_set[hτ.measurable_space] {x | τ x = π x} :=
+  measurable_set[hτ.measurable_space] {ω | τ ω = π ω} :=
 begin
   rw hτ.measurable_set,
   intro j,
-  have : {x | τ x = π x} ∩ {x | τ x ≤ j}
-    = {x | min (τ x) j = min (π x) j} ∩ {x | τ x ≤ j} ∩ {x | π x ≤ j},
-  { ext1 x,
+  have : {ω | τ ω = π ω} ∩ {ω | τ ω ≤ j}
+    = {ω | min (τ ω) j = min (π ω) j} ∩ {ω | τ ω ≤ j} ∩ {ω | π ω ≤ j},
+  { ext1 ω,
     simp only [set.mem_inter_eq, set.mem_set_of_eq],
     refine ⟨λ h, ⟨⟨_, h.2⟩, _⟩, λ h, ⟨_, h.1.2⟩⟩,
     { rw h.1, },
@@ -1147,29 +1147,29 @@ section linear_order
 
 /-! ## Stopped value and stopped process -/
 
-/-- Given a map `u : ι → α → E`, its stopped value with respect to the stopping
-time `τ` is the map `x ↦ u (τ x) x`. -/
-def stopped_value (u : ι → α → β) (τ : α → ι) : α → β :=
-λ x, u (τ x) x
+/-- Given a map `u : ι → Ω → E`, its stopped value with respect to the stopping
+time `τ` is the map `x ↦ u (τ ω) x`. -/
+def stopped_value (u : ι → Ω → β) (τ : Ω → ι) : Ω → β :=
+λ ω, u (τ ω) ω
 
-lemma stopped_value_const (u : ι → α → β) (i : ι) : stopped_value u (λ x, i) = u i :=
+lemma stopped_value_const (u : ι → Ω → β) (i : ι) : stopped_value u (λ ω, i) = u i :=
 rfl
 
 variable [linear_order ι]
 
-/-- Given a map `u : ι → α → E`, the stopped process with respect to `τ` is `u i x` if
-`i ≤ τ x`, and `u (τ x) x` otherwise.
+/-- Given a map `u : ι → Ω → E`, the stopped process with respect to `τ` is `u i x` if
+`i ≤ τ ω`, and `u (τ ω) x` otherwise.
 
 Intuitively, the stopped process stops evolving once the stopping time has occured. -/
-def stopped_process (u : ι → α → β) (τ : α → ι) : ι → α → β :=
-λ i x, u (min i (τ x)) x
+def stopped_process (u : ι → Ω → β) (τ : Ω → ι) : ι → Ω → β :=
+λ i ω, u (min i (τ ω)) ω
 
-lemma stopped_process_eq_of_le {u : ι → α → β} {τ : α → ι}
-  {i : ι} {x : α} (h : i ≤ τ x) : stopped_process u τ i x = u i x :=
+lemma stopped_process_eq_of_le {u : ι → Ω → β} {τ : Ω → ι}
+  {i : ι} {ω : Ω} (h : i ≤ τ ω) : stopped_process u τ i ω = u i ω :=
 by simp [stopped_process, min_eq_left h]
 
-lemma stopped_process_eq_of_ge {u : ι → α → β} {τ : α → ι}
-  {i : ι} {x : α} (h : τ x ≤ i) : stopped_process u τ i x = u (τ x) x :=
+lemma stopped_process_eq_of_ge {u : ι → Ω → β} {τ : Ω → ι}
+  {i : ι} {ω : Ω} (h : τ ω ≤ i) : stopped_process u τ i ω = u (τ ω) ω :=
 by simp [stopped_process, min_eq_right h]
 
 section prog_measurable
@@ -1177,42 +1177,42 @@ section prog_measurable
 variables [measurable_space ι] [topological_space ι] [order_topology ι]
   [second_countable_topology ι] [borel_space ι]
   [topological_space β]
-  {u : ι → α → β} {τ : α → ι} {f : filtration ι m}
+  {u : ι → Ω → β} {τ : Ω → ι} {f : filtration ι m}
 
 lemma prog_measurable_min_stopping_time [metrizable_space ι] (hτ : is_stopping_time f τ) :
-  prog_measurable f (λ i x, min i (τ x)) :=
+  prog_measurable f (λ i ω, min i (τ ω)) :=
 begin
   intro i,
-  let m_prod : measurable_space (set.Iic i × α) := measurable_space.prod _ (f i),
-  let m_set : ∀ t : set (set.Iic i × α), measurable_space t :=
-    λ _, @subtype.measurable_space (set.Iic i × α) _ m_prod,
-  let s := {p : set.Iic i × α | τ p.2 ≤ i},
-  have hs : measurable_set[m_prod] s, from @measurable_snd (set.Iic i) α _ (f i) _ (hτ i),
-  have h_meas_fst : ∀ t : set (set.Iic i × α),
-      measurable[m_set t] (λ x : t, ((x : set.Iic i × α).fst : ι)),
-    from λ t, (@measurable_subtype_coe (set.Iic i × α) m_prod _).fst.subtype_coe,
+  let m_prod : measurable_space (set.Iic i × Ω) := measurable_space.prod _ (f i),
+  let m_set : ∀ t : set (set.Iic i × Ω), measurable_space t :=
+    λ _, @subtype.measurable_space (set.Iic i × Ω) _ m_prod,
+  let s := {p : set.Iic i × Ω | τ p.2 ≤ i},
+  have hs : measurable_set[m_prod] s, from @measurable_snd (set.Iic i) Ω _ (f i) _ (hτ i),
+  have h_meas_fst : ∀ t : set (set.Iic i × Ω),
+      measurable[m_set t] (λ x : t, ((x : set.Iic i × Ω).fst : ι)),
+    from λ t, (@measurable_subtype_coe (set.Iic i × Ω) m_prod _).fst.subtype_coe,
   apply measurable.strongly_measurable,
   refine measurable_of_restrict_of_restrict_compl hs _ _,
   { refine @measurable.min _ _ _ _ _ (m_set s) _ _ _ _ _ (h_meas_fst s) _,
     refine @measurable_of_Iic ι s _ _ _ (m_set s) _ _ _ _ (λ j, _),
-    have h_set_eq : (λ x : s, τ (x : set.Iic i × α).snd) ⁻¹' set.Iic j
-      = (λ x : s, (x : set.Iic i × α).snd) ⁻¹' {x | τ x ≤ min i j},
-    { ext1 x,
+    have h_set_eq : (λ x : s, τ (x : set.Iic i × Ω).snd) ⁻¹' set.Iic j
+      = (λ x : s, (x : set.Iic i × Ω).snd) ⁻¹' {ω | τ ω ≤ min i j},
+    { ext1 ω,
       simp only [set.mem_preimage, set.mem_Iic, iff_and_self, le_min_iff, set.mem_set_of_eq],
-      exact λ _, x.prop, },
+      exact λ _, ω.prop, },
     rw h_set_eq,
-    suffices h_meas : @measurable _ _ (m_set s) (f i) (λ x : s, (x : set.Iic i × α).snd),
+    suffices h_meas : @measurable _ _ (m_set s) (f i) (λ x : s, (x : set.Iic i × Ω).snd),
       from h_meas (f.mono (min_le_left _ _) _ (hτ.measurable_set_le (min i j))),
     exact measurable_snd.comp (@measurable_subtype_coe _ m_prod _), },
-  { suffices h_min_eq_left : (λ x : sᶜ, min ↑((x : set.Iic i × α).fst) (τ (x : set.Iic i × α).snd))
-      = λ x : sᶜ, ↑((x : set.Iic i × α).fst),
+  { suffices h_min_eq_left : (λ x : sᶜ, min ↑((x : set.Iic i × Ω).fst) (τ (x : set.Iic i × Ω).snd))
+      = λ x : sᶜ, ↑((x : set.Iic i × Ω).fst),
     { rw [set.restrict, h_min_eq_left],
       exact h_meas_fst _, },
-    ext1 x,
+    ext1 ω,
     rw min_eq_left,
-    have hx_fst_le : ↑(x : set.Iic i × α).fst ≤ i, from (x : set.Iic i × α).fst.prop,
+    have hx_fst_le : ↑(ω : set.Iic i × Ω).fst ≤ i, from (ω : set.Iic i × Ω).fst.prop,
     refine hx_fst_le.trans (le_of_lt _),
-    convert x.prop,
+    convert ω.prop,
     simp only [not_le, set.mem_compl_eq, set.mem_set_of_eq], },
 end
 
@@ -1232,11 +1232,11 @@ lemma prog_measurable.strongly_measurable_stopped_process [metrizable_space ι]
 (hu.adapted_stopped_process hτ i).mono (f.le _)
 
 lemma strongly_measurable_stopped_value_of_le
-  (h : prog_measurable f u) (hτ : is_stopping_time f τ) {n : ι} (hτ_le : ∀ x, τ x ≤ n) :
+  (h : prog_measurable f u) (hτ : is_stopping_time f τ) {n : ι} (hτ_le : ∀ ω, τ ω ≤ n) :
   strongly_measurable[f n] (stopped_value u τ) :=
 begin
-  have : stopped_value u τ = (λ (p : set.Iic n × α), u ↑(p.fst) p.snd) ∘ (λ x, (⟨τ x, hτ_le x⟩, x)),
-  { ext1 x, simp only [stopped_value, function.comp_app, subtype.coe_mk], },
+  have : stopped_value u τ = (λ (p : set.Iic n × Ω), u ↑(p.fst) p.snd) ∘ (λ ω, (⟨τ ω, hτ_le ω⟩, ω)),
+  { ext1 ω, simp only [stopped_value, function.comp_app, subtype.coe_mk], },
   rw this,
   refine strongly_measurable.comp_measurable (h n) _,
   exact (hτ.measurable_of_le hτ_le).subtype_mk.prod_mk measurable_id,
@@ -1246,14 +1246,14 @@ lemma measurable_stopped_value [metrizable_space β] [measurable_space β] [bore
   (hf_prog : prog_measurable f u) (hτ : is_stopping_time f τ) :
   measurable[hτ.measurable_space] (stopped_value u τ) :=
 begin
-  have h_str_meas : ∀ i, strongly_measurable[f i] (stopped_value u (λ x, min (τ x) i)),
+  have h_str_meas : ∀ i, strongly_measurable[f i] (stopped_value u (λ ω, min (τ ω) i)),
     from λ i, strongly_measurable_stopped_value_of_le hf_prog (hτ.min_const i)
       (λ _, min_le_right _ _),
   intros t ht i,
-  suffices : stopped_value u τ ⁻¹' t ∩ {x : α | τ x ≤ i}
-      = stopped_value u (λ x, min (τ x) i) ⁻¹' t ∩ {x : α | τ x ≤ i},
+  suffices : stopped_value u τ ⁻¹' t ∩ {ω : Ω | τ ω ≤ i}
+      = stopped_value u (λ ω, min (τ ω) i) ⁻¹' t ∩ {ω : Ω | τ ω ≤ i},
     by { rw this, exact ((h_str_meas i).measurable ht).inter (hτ.measurable_set_le i), },
-  ext1 x,
+  ext1 ω,
   simp only [stopped_value, set.mem_inter_eq, set.mem_preimage, set.mem_set_of_eq,
     and.congr_left_iff],
   intro h,
@@ -1269,24 +1269,24 @@ section nat
 
 open filtration
 
-variables {f : filtration ℕ m} {u : ℕ → α → β} {τ π : α → ℕ}
+variables {f : filtration ℕ m} {u : ℕ → Ω → β} {τ π : Ω → ℕ}
 
 lemma stopped_value_sub_eq_sum [add_comm_group β] (hle : τ ≤ π) :
   stopped_value u π - stopped_value u τ =
-  λ x, (∑ i in finset.Ico (τ x) (π x), (u (i + 1) - u i)) x :=
+  λ ω, (∑ i in finset.Ico (τ ω) (π ω), (u (i + 1) - u i)) ω :=
 begin
-  ext x,
-  rw [finset.sum_Ico_eq_sub _ (hle x), finset.sum_range_sub, finset.sum_range_sub],
+  ext ω,
+  rw [finset.sum_Ico_eq_sub _ (hle ω), finset.sum_range_sub, finset.sum_range_sub],
   simp [stopped_value],
 end
 
-lemma stopped_value_sub_eq_sum' [add_comm_group β] (hle : τ ≤ π) {N : ℕ} (hbdd : ∀ x, π x ≤ N) :
+lemma stopped_value_sub_eq_sum' [add_comm_group β] (hle : τ ≤ π) {N : ℕ} (hbdd : ∀ ω, π ω ≤ N) :
   stopped_value u π - stopped_value u τ =
-  λ x, (∑ i in finset.range (N + 1),
-    set.indicator {x | τ x ≤ i ∧ i < π x} (u (i + 1) - u i)) x :=
+  λ ω, (∑ i in finset.range (N + 1),
+    set.indicator {ω | τ ω ≤ i ∧ i < π ω} (u (i + 1) - u i)) ω :=
 begin
   rw stopped_value_sub_eq_sum hle,
-  ext x,
+  ext ω,
   simp only [finset.sum_apply, finset.sum_indicator_eq_sum_filter],
   refine finset.sum_congr _ (λ _ _, rfl),
   ext i,
@@ -1305,8 +1305,8 @@ lemma adapted.prog_measurable_of_nat [topological_space β] [has_continuous_add 
   (h : adapted f u) : prog_measurable f u :=
 begin
   intro i,
-  have : (λ p : ↥(set.Iic i) × α, u ↑(p.fst) p.snd)
-    = λ p : ↥(set.Iic i) × α, ∑ j in finset.range (i + 1), if ↑p.fst = j then u j p.snd else 0,
+  have : (λ p : ↥(set.Iic i) × Ω, u ↑(p.fst) p.snd)
+    = λ p : ↥(set.Iic i) × Ω, ∑ j in finset.range (i + 1), if ↑p.fst = j then u j p.snd else 0,
   { ext1 p,
     rw finset.sum_ite_eq,
     have hp_mem : (p.fst : ℕ) ∈ finset.range (i + 1) := finset.mem_range_succ_iff.mpr p.fst.prop,
@@ -1314,7 +1314,7 @@ begin
   rw this,
   refine finset.strongly_measurable_sum _ (λ j hj, strongly_measurable.ite _ _ _),
   { suffices h_meas : measurable[measurable_space.prod _ (f i)]
-        (λ a : ↥(set.Iic i) × α, (a.fst : ℕ)),
+        (λ a : ↥(set.Iic i) × Ω, (a.fst : ℕ)),
       from h_meas (measurable_set_singleton j),
     exact measurable_fst.subtype_coe, },
   { have h_le : j ≤ i, from finset.mem_range_succ_iff.mp hj,
@@ -1335,9 +1335,9 @@ lemma adapted.strongly_measurable_stopped_process_of_nat [topological_space β]
   strongly_measurable (stopped_process u τ n) :=
 hu.prog_measurable_of_nat.strongly_measurable_stopped_process hτ n
 
-lemma stopped_value_eq {N : ℕ} (hbdd : ∀ x, τ x ≤ N) :
+lemma stopped_value_eq {N : ℕ} (hbdd : ∀ ω, τ ω ≤ N) :
   stopped_value u τ =
-  λ x, (∑ i in finset.range (N + 1), set.indicator {x | τ x = i} (u i)) x :=
+  λ x, (∑ i in finset.range (N + 1), set.indicator {ω | τ ω = i} (u i)) x :=
 begin
   ext y,
   rw [stopped_value, finset.sum_apply, finset.sum_eq_single (τ y)],
@@ -1352,17 +1352,17 @@ end
 lemma stopped_process_eq (n : ℕ) :
   stopped_process u τ n =
   set.indicator {a | n ≤ τ a} (u n) +
-    ∑ i in finset.range n, set.indicator {a | τ a = i} (u i) :=
+    ∑ i in finset.range n, set.indicator {ω | τ ω = i} (u i) :=
 begin
-  ext x,
+  ext ω,
   rw [pi.add_apply, finset.sum_apply],
-  cases le_or_lt n (τ x),
+  cases le_or_lt n (τ ω),
   { rw [stopped_process_eq_of_le h, set.indicator_of_mem, finset.sum_eq_zero, add_zero],
     { intros m hm,
       rw finset.mem_range at hm,
       exact set.indicator_of_not_mem ((lt_of_lt_of_le hm h).ne.symm) _ },
     { exact h } },
-  { rw [stopped_process_eq_of_ge (le_of_lt h), finset.sum_eq_single_of_mem (τ x)],
+  { rw [stopped_process_eq_of_ge (le_of_lt h), finset.sum_eq_single_of_mem (τ ω)],
     { rw [set.indicator_of_not_mem, zero_add, set.indicator_of_mem],
       { exact rfl }, -- refl does not work
       { exact not_le.2 h } },
@@ -1376,18 +1376,18 @@ end add_comm_monoid
 
 section normed_add_comm_group
 
-variables [normed_add_comm_group β] {p : ℝ≥0∞} {μ : measure α}
+variables [normed_add_comm_group β] {p : ℝ≥0∞} {μ : measure Ω}
 
 lemma mem_ℒp_stopped_process (hτ : is_stopping_time f τ) (hu : ∀ n, mem_ℒp (u n) p μ) (n : ℕ) :
   mem_ℒp (stopped_process u τ n) p μ :=
 begin
   rw stopped_process_eq,
   refine mem_ℒp.add _ _,
-  { exact mem_ℒp.indicator (f.le n {a : α | n ≤ τ a} (hτ.measurable_set_ge n)) (hu n) },
-  { suffices : mem_ℒp (λ x, ∑ (i : ℕ) in finset.range n, {a : α | τ a = i}.indicator (u i) x) p μ,
-    { convert this, ext1 x, simp only [finset.sum_apply] },
+  { exact mem_ℒp.indicator (f.le n {a : Ω | n ≤ τ a} (hτ.measurable_set_ge n)) (hu n) },
+  { suffices : mem_ℒp (λ ω, ∑ (i : ℕ) in finset.range n, {a : Ω | τ a = i}.indicator (u i) ω) p μ,
+    { convert this, ext1 ω, simp only [finset.sum_apply] },
     refine mem_ℒp_finset_sum _ (λ i hi, mem_ℒp.indicator _ (hu i)),
-    exact f.le i {a : α | τ a = i} (hτ.measurable_set_eq i) },
+    exact f.le i {a : Ω | τ a = i} (hτ.measurable_set_eq i) },
 end
 
 lemma integrable_stopped_process (hτ : is_stopping_time f τ)
@@ -1396,19 +1396,19 @@ lemma integrable_stopped_process (hτ : is_stopping_time f τ)
 by { simp_rw ← mem_ℒp_one_iff_integrable at hu ⊢, exact mem_ℒp_stopped_process hτ hu n, }
 
 lemma mem_ℒp_stopped_value (hτ : is_stopping_time f τ)
-  (hu : ∀ n, mem_ℒp (u n) p μ) {N : ℕ} (hbdd : ∀ x, τ x ≤ N) :
+  (hu : ∀ n, mem_ℒp (u n) p μ) {N : ℕ} (hbdd : ∀ ω, τ ω ≤ N) :
   mem_ℒp (stopped_value u τ) p μ :=
 begin
   rw stopped_value_eq hbdd,
   suffices : mem_ℒp (λ x, ∑ (i : ℕ) in finset.range (N + 1),
-    {a : α | τ a = i}.indicator (u i) x) p μ,
-  { convert this, ext1 x, simp only [finset.sum_apply] },
+    {a : Ω | τ a = i}.indicator (u i) x) p μ,
+  { convert this, ext1 ω, simp only [finset.sum_apply] },
   refine mem_ℒp_finset_sum _ (λ i hi, mem_ℒp.indicator _ (hu i)),
-  exact f.le i {a : α | τ a = i} (hτ.measurable_set_eq i)
+  exact f.le i {a : Ω | τ a = i} (hτ.measurable_set_eq i)
 end
 
 lemma integrable_stopped_value (hτ : is_stopping_time f τ)
-  (hu : ∀ n, integrable (u n) μ) {N : ℕ} (hbdd : ∀ x, τ x ≤ N) :
+  (hu : ∀ n, integrable (u n) μ) {N : ℕ} (hbdd : ∀ ω, τ ω ≤ N) :
   integrable (stopped_value u τ) μ :=
 by { simp_rw ← mem_ℒp_one_iff_integrable at hu ⊢, exact mem_ℒp_stopped_value hτ hu hbdd, }
 
@@ -1418,28 +1418,28 @@ end nat
 
 section piecewise_const
 
-variables [preorder ι] {𝒢 : filtration ι m} {τ η : α → ι} {i j : ι} {s : set α}
+variables [preorder ι] {𝒢 : filtration ι m} {τ η : Ω → ι} {i j : ι} {s : set Ω}
   [decidable_pred (∈ s)]
 
 /-- Given stopping times `τ` and `η` which are bounded below, `set.piecewise s τ η` is also
 a stopping time with respect to the same filtration. -/
 lemma is_stopping_time.piecewise_of_le (hτ_st : is_stopping_time 𝒢 τ)
-  (hη_st : is_stopping_time 𝒢 η) (hτ : ∀ x, i ≤ τ x) (hη : ∀ x, i ≤ η x)
+  (hη_st : is_stopping_time 𝒢 η) (hτ : ∀ ω, i ≤ τ ω) (hη : ∀ x, i ≤ η x)
   (hs : measurable_set[𝒢 i] s) :
   is_stopping_time 𝒢 (s.piecewise τ η) :=
 begin
   intro n,
   have : {x | s.piecewise τ η x ≤ n}
-    = (s ∩ {x | τ x ≤ n}) ∪ (sᶜ ∩ {x | η x ≤ n}),
-  { ext1 x,
+    = (s ∩ {ω | τ ω ≤ n}) ∪ (sᶜ ∩ {x | η x ≤ n}),
+  { ext1 ω,
     simp only [set.piecewise, set.mem_inter_eq, set.mem_set_of_eq, and.congr_right_iff],
-    by_cases hx : x ∈ s; simp [hx], },
+    by_cases hx : ω ∈ s; simp [hx], },
   rw this,
   by_cases hin : i ≤ n,
   { have hs_n : measurable_set[𝒢 n] s, from 𝒢.mono hin _ hs,
     exact (hs_n.inter (hτ_st n)).union (hs_n.compl.inter (hη_st n)), },
-  { have hτn : ∀ x, ¬ τ x ≤ n := λ x hτn, hin ((hτ x).trans hτn),
-    have hηn : ∀ x, ¬ η x ≤ n := λ x hηn, hin ((hη x).trans hηn),
+  { have hτn : ∀ ω, ¬ τ ω ≤ n := λ ω hτn, hin ((hτ ω).trans hτn),
+    have hηn : ∀ ω, ¬ η ω ≤ n := λ ω hηn, hin ((hη ω).trans hηn),
     simp [hτn, hηn], },
 end
 
@@ -1448,13 +1448,13 @@ lemma is_stopping_time_piecewise_const (hij : i ≤ j) (hs : measurable_set[𝒢
 (is_stopping_time_const 𝒢 i).piecewise_of_le (is_stopping_time_const 𝒢 j)
   (λ x, le_rfl) (λ _, hij) hs
 
-lemma stopped_value_piecewise_const {ι' : Type*} {i j : ι'} {f : ι' → α → ℝ} :
+lemma stopped_value_piecewise_const {ι' : Type*} {i j : ι'} {f : ι' → Ω → ℝ} :
   stopped_value f (s.piecewise (λ _, i) (λ _, j)) = s.piecewise (f i) (f j) :=
-by { ext x, rw stopped_value, by_cases hx : x ∈ s; simp [hx] }
+by { ext ω, rw stopped_value, by_cases hx : ω ∈ s; simp [hx] }
 
-lemma stopped_value_piecewise_const' {ι' : Type*} {i j : ι'} {f : ι' → α → ℝ} :
+lemma stopped_value_piecewise_const' {ι' : Type*} {i j : ι'} {f : ι' → Ω → ℝ} :
   stopped_value f (s.piecewise (λ _, i) (λ _, j)) = s.indicator (f i) + sᶜ.indicator (f j) :=
-by { ext x, rw stopped_value, by_cases hx : x ∈ s; simp [hx] }
+by { ext ω, rw stopped_value, by_cases hx : ω ∈ s; simp [hx] }
 
 end piecewise_const
 

--- a/src/probability/variance.lean
+++ b/src/probability/variance.lean
@@ -33,7 +33,7 @@ namespace probability_theory
 /-- The variance of a random variable is `𝔼[X^2] - 𝔼[X]^2` or, equivalently, `𝔼[(X - 𝔼[X])^2]`. We
 use the latter as the definition, to ensure better behavior even in garbage situations. -/
 def variance {Ω : Type*} {m : measurable_space Ω} (f : Ω → ℝ) (μ : measure Ω) : ℝ :=
-μ[(f - (λ x, μ[f])) ^ 2]
+μ[(f - (λ ω, μ[f])) ^ 2]
 
 @[simp] lemma variance_zero {Ω : Type*} {m : measurable_space Ω} (μ : measure Ω) :
   variance 0 μ = 0 :=
@@ -41,12 +41,12 @@ by simp [variance]
 
 lemma variance_nonneg {Ω : Type*} {m : measurable_space Ω} (f : Ω → ℝ) (μ : measure Ω) :
   0 ≤ variance f μ :=
-integral_nonneg (λ x, sq_nonneg _)
+integral_nonneg (λ ω, sq_nonneg _)
 
 lemma variance_mul {Ω : Type*} {m : measurable_space Ω} (c : ℝ) (f : Ω → ℝ) (μ : measure Ω) :
-  variance (λ x, c * f x) μ = c^2 * variance f μ :=
+  variance (λ ω, c * f ω) μ = c^2 * variance f μ :=
 calc
-variance (λ x, c * f x) μ
+variance (λ ω, c * f ω) μ
     = ∫ x, (c * f x - ∫ y, c * f y ∂μ) ^ 2 ∂μ : rfl
 ... = ∫ x, (c * (f x - ∫ y, f y ∂μ)) ^ 2 ∂μ :
   by { congr' 1 with x, simp_rw [integral_mul_left, mul_sub] }
@@ -100,9 +100,9 @@ begin
   { rw [variance, integral_undef],
     { exact integral_nonneg (λ a, sq_nonneg _) },
     { assume h,
-      have A : mem_ℒp (X - λ (x : Ω), 𝔼[X]) 2 ℙ := (mem_ℒp_two_iff_integrable_sq
+      have A : mem_ℒp (X - λ (ω : Ω), 𝔼[X]) 2 ℙ := (mem_ℒp_two_iff_integrable_sq
         (h_int.ae_strongly_measurable.sub ae_strongly_measurable_const)).2 h,
-      have B : mem_ℒp (λ (x : Ω), 𝔼[X]) 2 ℙ := mem_ℒp_const _,
+      have B : mem_ℒp (λ (ω : Ω), 𝔼[X]) 2 ℙ := mem_ℒp_const _,
       apply hX,
       convert A.add B,
       simp } }


### PR DESCRIPTION

This PR makes two notational changes in the probability folder: `α` changed to `Ω` and `x` of type `α` to `ω`.

---

I have not changed the measure to `ℙ` since in `probability/notation`, `ℙ` denotes the volume measure of a measure space and in many cases we are not working over a measure space as we have many different sigma-algebras.

Also, I've not changed the notation for random variables. I have seen a lot of different notations for random variables in literature so I don't think there is a standard notation (In mathlib I've seen `X, ξ, f, u` so pretty messy also). 

[Discussion on Zulip](https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/notation.20in.20probability.20theory)

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
