### PR TITLE
[Merged by Bors] - feat(category_theory/preadditive/injective): Adjoint functors preserves injective objects

### DIFF
--- a/src/category_theory/preadditive/injective.lean
+++ b/src/category_theory/preadditive/injective.lean
@@ -21,7 +21,7 @@ open category_theory
 open category_theory.limits
 open opposite
 
-universes v₁ v₂ u₁ u₂
+universes v v₁ v₂ u₁ u₂
 
 namespace category_theory
 variables {C : Type u₁} [category.{v₁} C]
@@ -84,7 +84,7 @@ lemma iso_iff {P Q : C} (i : P ≅ Q) : injective P ↔ injective Q :=
 ⟨of_iso i, of_iso i.symm⟩
 
 /-- The axiom of choice says that every nonempty type is an injective object in `Type`. -/
-instance (X : Type u) [nonempty X] : injective X :=
+instance (X : Type u₁) [nonempty X] : injective X :=
 { factors := λ Y Z g f mono,
   ⟨λ z, by classical; exact
     if h : z ∈ set.range f
@@ -98,7 +98,7 @@ instance (X : Type u) [nonempty X] : injective X :=
     { exact false.elim (h ⟨y, rfl⟩) },
   end⟩ }
 
-instance Type.enough_injectives : enough_injectives (Type u) :=
+instance Type.enough_injectives : enough_injectives (Type u₁) :=
 { presentation := λ X, nonempty.intro
   { J := with_bot X,
     injective := infer_instance,
@@ -177,16 +177,14 @@ end
 section adjunction
 open category_theory.functor
 
- universes v₁ v₂ u₁ u₂
+variables {D : Type u₂} [category.{v₂} D]
+variables {L : C ⥤ D} {R : D ⥤ C} [preserves_monomorphisms L]
 
- variables {D : Type u₂} [category.{v₂} D]
- variables {L : C ⥤ D} {R : D ⥤ C} [preserves_monomorphisms L]
+lemma injective_of_adjoint (adj : L ⊣ R) {J : D} [injective J] : injective $ R.obj J :=
+⟨λ A A' g f im, by exactI ⟨adj.hom_equiv _ _ (factor_thru ((adj.hom_equiv A J).symm g) (L.map f)),
+ (adj.hom_equiv _ _).symm.injective (by simp)⟩⟩
 
- lemma injective_of_adjoint (adj : L ⊣ R) {J : 𝓑} [injective J] : injective $ R.obj J :=
- ⟨λ A A' g f im, by exactI ⟨adj.hom_equiv _ _ (factor_thru ((adj.hom_equiv A J).symm g) (L.map f)),
-  (adj.hom_equiv _ _).symm.injective (by simp)⟩⟩
-
- end adjunction
+end adjunction
 
 section enough_injectives
 variable [enough_injectives C]

--- a/src/category_theory/preadditive/injective.lean
+++ b/src/category_theory/preadditive/injective.lean
@@ -175,24 +175,17 @@ begin
 end
 
 section adjunction
-
- open category_theory.functor
+open category_theory.functor
 
  universes v₁ v₂ u₁ u₂
 
- variables {𝓐 : Type u₁} {𝓑 : Type u₂} [category.{v₁ u₁} 𝓐] [category.{v₂ u₂} 𝓑]
+ variables {𝓐 : Type u₁} {𝓑 : Type u₂} [category.{v₁} 𝓐] [category.{v₂} 𝓑]
  variables {L : 𝓐 ⥤ 𝓑} {R : 𝓑 ⥤ 𝓐} (adj : L ⊣ R) [preserves_monomorphisms L]
 
  include adj
  lemma injective_of_adjoint {J : 𝓑} [injective J] : injective $ R.obj J :=
- { factors := λ A A' g f im,
-   begin
-     resetI,
-     haveI : mono (L.map f) := functor.map_mono L _,
-     refine ⟨adj.hom_equiv _ _ (factor_thru ((adj.hom_equiv A J).symm g) (L.map f)), _⟩,
-     apply_fun (adj.hom_equiv _ _).symm using equiv.injective,
-     simp,
-   end }
+ ⟨λ A A' g f im, by exactI ⟨adj.hom_equiv _ _ (factor_thru ((adj.hom_equiv A J).symm g) (L.map f)),
+  (adj.hom_equiv _ _).symm.injective (by simp)⟩⟩
 
  end adjunction
 

--- a/src/category_theory/preadditive/injective.lean
+++ b/src/category_theory/preadditive/injective.lean
@@ -184,7 +184,7 @@ section adjunction
  variables {L : 𝓐 ⥤ 𝓑} {R : 𝓑 ⥤ 𝓐} (adj : L ⊣ R) [preserves_monomorphisms L]
 
  include adj
- def injective_of_adjoint {J : 𝓑} [injective J] : injective $ R.obj J :=
+ lemma injective_of_adjoint {J : 𝓑} [injective J] : injective $ R.obj J :=
  { factors := λ A A' g f im,
    begin
      resetI,

--- a/src/category_theory/preadditive/injective.lean
+++ b/src/category_theory/preadditive/injective.lean
@@ -180,7 +180,7 @@ open category_theory.functor
 variables {D : Type u₂} [category.{v₂} D]
 variables {L : C ⥤ D} {R : D ⥤ C} [preserves_monomorphisms L]
 
-lemma injective_of_adjoint (adj : L ⊣ R) {J : D} [injective J] : injective $ R.obj J :=
+lemma injective_of_adjoint (adj : L ⊣ R) (J : D) [injective J] : injective $ R.obj J :=
 ⟨λ A A' g f im, by exactI ⟨adj.hom_equiv _ _ (factor_thru ((adj.hom_equiv A J).symm g) (L.map f)),
  (adj.hom_equiv _ _).symm.injective (by simp)⟩⟩
 

--- a/src/category_theory/preadditive/injective.lean
+++ b/src/category_theory/preadditive/injective.lean
@@ -174,6 +174,28 @@ begin
   exact functor.preserves_epimorphisms.iso_iff (coyoneda.obj_op_op _)
 end
 
+section adjunction
+
+ open category_theory.functor
+
+ universes v₁ v₂ u₁ u₂
+
+ variables {𝓐 : Type u₁} {𝓑 : Type u₂} [category.{v₁ u₁} 𝓐] [category.{v₂ u₂} 𝓑]
+ variables {L : 𝓐 ⥤ 𝓑} {R : 𝓑 ⥤ 𝓐} (adj : L ⊣ R) [preserves_monomorphisms L]
+
+ include adj
+ def injective_of_adjoint {J : 𝓑} [injective J] : injective $ R.obj J :=
+ { factors := λ A A' g f im,
+   begin
+     resetI,
+     haveI : mono (L.map f) := functor.map_mono L _,
+     refine ⟨adj.hom_equiv _ _ (factor_thru ((adj.hom_equiv A J).symm g) (L.map f)), _⟩,
+     apply_fun (adj.hom_equiv _ _).symm using equiv.injective,
+     simp,
+   end }
+
+ end adjunction
+
 section enough_injectives
 variable [enough_injectives C]
 

--- a/src/category_theory/preadditive/injective.lean
+++ b/src/category_theory/preadditive/injective.lean
@@ -21,10 +21,10 @@ open category_theory
 open category_theory.limits
 open opposite
 
-universes v u
+universes v₁ v₂ u₁ u₂
 
 namespace category_theory
-variables {C : Type u} [category.{v} C]
+variables {C : Type u₁} [category.{v₁} C]
 
 /--
 An object `J` is injective iff every morphism into `J` can be obtained by extending a monomorphism.
@@ -179,11 +179,10 @@ open category_theory.functor
 
  universes v₁ v₂ u₁ u₂
 
- variables {𝓐 : Type u₁} {𝓑 : Type u₂} [category.{v₁} 𝓐] [category.{v₂} 𝓑]
- variables {L : 𝓐 ⥤ 𝓑} {R : 𝓑 ⥤ 𝓐} (adj : L ⊣ R) [preserves_monomorphisms L]
+ variables {D : Type u₂} [category.{v₂} D]
+ variables {L : C ⥤ D} {R : D ⥤ C} [preserves_monomorphisms L]
 
- include adj
- lemma injective_of_adjoint {J : 𝓑} [injective J] : injective $ R.obj J :=
+ lemma injective_of_adjoint (adj : L ⊣ R) {J : 𝓑} [injective J] : injective $ R.obj J :=
  ⟨λ A A' g f im, by exactI ⟨adj.hom_equiv _ _ (factor_thru ((adj.hom_equiv A J).symm g) (L.map f)),
   (adj.hom_equiv _ _).symm.injective (by simp)⟩⟩
 


### PR DESCRIPTION
For a pair of adjoint functors, if the left adjoint preserves monomorphism, then the right adjoint preserves injective object

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
