### PR TITLE
[Merged by Bors] - feat(topology/metric_space): Add first countability instances

### DIFF
--- a/src/topology/algebra/uniform_group.lean
+++ b/src/topology/algebra/uniform_group.lean
@@ -208,7 +208,7 @@ variables {α}
 
 @[to_additive] theorem uniform_group.uniformity_countably_generated
   [(𝓝 (1 : α)).is_countably_generated] :
-  (uniformity α).is_countably_generated :=
+  (𝓤 α).is_countably_generated :=
 by { rw uniformity_eq_comap_nhds_one, exact filter.comap.is_countably_generated _ _ }
 
 open mul_opposite

--- a/src/topology/algebra/uniform_group.lean
+++ b/src/topology/algebra/uniform_group.lean
@@ -206,7 +206,7 @@ by { rw [← comap_swap_uniformity, uniformity_eq_comap_nhds_one, comap_comap, (
 
 variables {α}
 
-@[to_additive] instance uniform_group.uniformity_countably_generated
+@[to_additive] theorem uniform_group.uniformity_countably_generated
   [(𝓝 (1 : α)).is_countably_generated] :
   (uniformity α).is_countably_generated :=
 by { rw uniformity_eq_comap_nhds_one, exact filter.comap.is_countably_generated _ _ }

--- a/src/topology/algebra/uniform_group.lean
+++ b/src/topology/algebra/uniform_group.lean
@@ -204,6 +204,13 @@ end
   𝓤 α = comap (λx:α×α, x.1 / x.2) (𝓝 (1:α)) :=
 by { rw [← comap_swap_uniformity, uniformity_eq_comap_nhds_one, comap_comap, (∘)], refl }
 
+variables {α}
+
+@[to_additive] instance uniform_group.uniformity_countably_generated
+  [(𝓝 (1 : α)).is_countably_generated] :
+  (uniformity α).is_countably_generated :=
+by { rw uniformity_eq_comap_nhds_one, exact filter.comap.is_countably_generated _ _ }
+
 open mul_opposite
 
 @[to_additive]

--- a/src/topology/metric_space/basic.lean
+++ b/src/topology/metric_space/basic.lean
@@ -1000,6 +1000,7 @@ lemma _root_.dense_range.exists_dist_lt {β : Type*} {f : β → α} (hf : dense
 exists_range_iff.1 (hf.exists_dist_lt x hε)
 
 /-- Every pseudo-metric space is first countable. -/
+@[priority 100]
 instance pseudo_metric_space.first_countable_topology {α : Type*}
   [pseudo_metric_space α] : topological_space.first_countable_topology α :=
 ⟨λ x, filter.has_countable_basis.is_countably_generated

--- a/src/topology/metric_space/basic.lean
+++ b/src/topology/metric_space/basic.lean
@@ -999,13 +999,6 @@ lemma _root_.dense_range.exists_dist_lt {β : Type*} {f : β → α} (hf : dense
   ∃ y, dist x (f y) < ε :=
 exists_range_iff.1 (hf.exists_dist_lt x hε)
 
-/-- Every pseudo-metric space is first countable. -/
-@[priority 100]
-instance pseudo_metric_space.first_countable_topology {α : Type*}
-  [pseudo_metric_space α] : topological_space.first_countable_topology α :=
-⟨λ x, filter.has_countable_basis.is_countably_generated
-  (⟨metric.nhds_basis_ball_inv_nat_pos, {n : ℕ | 0 < n}.to_countable⟩)⟩
-
 end metric
 
 open metric

--- a/src/topology/metric_space/basic.lean
+++ b/src/topology/metric_space/basic.lean
@@ -999,6 +999,12 @@ lemma _root_.dense_range.exists_dist_lt {β : Type*} {f : β → α} (hf : dense
   ∃ y, dist x (f y) < ε :=
 exists_range_iff.1 (hf.exists_dist_lt x hε)
 
+/-- Every pseudo-metric space is first countable. -/
+instance pseudo_metric_space.first_countable_topology {α : Type*}
+  [pseudo_metric_space α] : topological_space.first_countable_topology α :=
+⟨λ x, filter.has_countable_basis.is_countably_generated
+  (⟨metric.nhds_basis_ball_inv_nat_pos, {n : ℕ | 0 < n}.to_countable⟩)⟩
+
 end metric
 
 open metric

--- a/src/topology/metric_space/closeds.lean
+++ b/src/topology/metric_space/closeds.lean
@@ -299,6 +299,8 @@ instance nonempty_compacts.compact_space [compact_space α] : compact_space (non
   exact nonempty_compacts.is_closed_in_closeds.is_compact
 end⟩
 
+--set_option trace.class_instances true
+
 /-- In a second countable space, the type of nonempty compact subsets is second countable -/
 instance nonempty_compacts.second_countable_topology [second_countable_topology α] :
   second_countable_topology (nonempty_compacts α) :=
@@ -377,7 +379,7 @@ begin
       -- we have proved that `d` is a good approximation of `t` as requested
       exact ⟨d, ‹d ∈ v›, Dtc⟩ },
   end,
-  apply uniform_space.second_countable_of_separable,
+  exact uniform_space.second_countable_of_separable (nonempty_compacts α),
 end
 
 end --section

--- a/src/topology/metric_space/closeds.lean
+++ b/src/topology/metric_space/closeds.lean
@@ -299,8 +299,6 @@ instance nonempty_compacts.compact_space [compact_space α] : compact_space (non
   exact nonempty_compacts.is_closed_in_closeds.is_compact
 end⟩
 
---set_option trace.class_instances true
-
 /-- In a second countable space, the type of nonempty compact subsets is second countable -/
 instance nonempty_compacts.second_countable_topology [second_countable_topology α] :
   second_countable_topology (nonempty_compacts α) :=

--- a/src/topology/metric_space/metrizable.lean
+++ b/src/topology/metric_space/metrizable.lean
@@ -64,7 +64,7 @@ end
 
 /-- Every pseudo-metrizable space is first countable. -/
 instance pseudo_metrizable_space.first_countable_topology [h : pseudo_metrizable_space X] :
-  topological_space.first_countable_topology E :=
+  topological_space.first_countable_topology X :=
 by unfreezingI { rcases h with ⟨_, hm⟩, rw ←hm, apply_instance }
 
 instance pseudo_metrizable_space.subtype [pseudo_metrizable_space X]

--- a/src/topology/metric_space/metrizable.lean
+++ b/src/topology/metric_space/metrizable.lean
@@ -62,6 +62,11 @@ begin
   exact ⟨⟨hf.comap_pseudo_metric_space, rfl⟩⟩
 end
 
+/-- Every pseudo-metrizable space is first countable. -/
+instance pseudo_metrizable_space.first_countable_topology [h : pseudo_metrizable_space X] :
+  topological_space.first_countable_topology E :=
+by unfreezingI { rcases h with ⟨_, hm⟩, rw ←hm, apply_instance }
+
 instance pseudo_metrizable_space.subtype [pseudo_metrizable_space X]
   (s : set X) : pseudo_metrizable_space s :=
 inducing_coe.pseudo_metrizable_space

--- a/src/topology/metric_space/metrizable.lean
+++ b/src/topology/metric_space/metrizable.lean
@@ -5,6 +5,7 @@ Authors: Yury Kudryashov
 -/
 import topology.urysohns_lemma
 import topology.continuous_function.bounded
+import topology.uniform_space.cauchy
 
 /-!
 # Metrizability of a T₃ topological space with second countable topology
@@ -64,9 +65,13 @@ end
 
 /-- Every pseudo-metrizable space is first countable. -/
 @[priority 100]
-instance pseudo_metrizable_space.first_countable_topology [h : pseudo_metrizable_space X] :
-  topological_space.first_countable_topology X :=
-by unfreezingI { rcases h with ⟨_, hm⟩, rw ←hm, apply_instance }
+instance pseudo_metrizable_space.first_countable_topology [h : pseudo_metrizable_space E] :
+  topological_space.first_countable_topology E :=
+begin
+  unfreezingI { rcases h with ⟨_, hm⟩, rw ←hm },
+  exact @uniform_space.first_countable_topology E pseudo_metric_space.to_uniform_space
+    emetric.uniformity.filter.is_countably_generated,
+end
 
 instance pseudo_metrizable_space.subtype [pseudo_metrizable_space X]
   (s : set X) : pseudo_metrizable_space s :=

--- a/src/topology/metric_space/metrizable.lean
+++ b/src/topology/metric_space/metrizable.lean
@@ -65,11 +65,11 @@ end
 
 /-- Every pseudo-metrizable space is first countable. -/
 @[priority 100]
-instance pseudo_metrizable_space.first_countable_topology [h : pseudo_metrizable_space E] :
-  topological_space.first_countable_topology E :=
+instance pseudo_metrizable_space.first_countable_topology [h : pseudo_metrizable_space X] :
+  topological_space.first_countable_topology X :=
 begin
   unfreezingI { rcases h with ⟨_, hm⟩, rw ←hm },
-  exact @uniform_space.first_countable_topology E pseudo_metric_space.to_uniform_space
+  exact @uniform_space.first_countable_topology X pseudo_metric_space.to_uniform_space
     emetric.uniformity.filter.is_countably_generated,
 end
 

--- a/src/topology/metric_space/metrizable.lean
+++ b/src/topology/metric_space/metrizable.lean
@@ -63,6 +63,7 @@ begin
 end
 
 /-- Every pseudo-metrizable space is first countable. -/
+@[priority 100]
 instance pseudo_metrizable_space.first_countable_topology [h : pseudo_metrizable_space X] :
   topological_space.first_countable_topology X :=
 by unfreezingI { rcases h with ⟨_, hm⟩, rw ←hm, apply_instance }


### PR DESCRIPTION
This PR proves the following two facts:
- pseudo-metric/metrizable spaces are first countable
- uniform groups that have a countably generated neighborhood at the origin have a countably generated uniformity

The instance for uniform groups allows for an easy way to prove that a topological group is metrizable, since the neighborhood filter is a more common object than the uniformity.

In total this PR gives the proof that a topological group is metrizable iff it the neighborhood filter at the origin is countably generated.

---

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
