### PR TITLE
[Merged by Bors] - refactor(data/fintype/basic): drop 2 noncomputable instances

### DIFF
--- a/src/algebra/big_operators/basic.lean
+++ b/src/algebra/big_operators/basic.lean
@@ -1543,13 +1543,7 @@ end prod_eq_zero
 lemma prod_unique_nonempty {α β : Type*} [comm_monoid β] [unique α]
   (s : finset α) (f : α → β) (h : s.nonempty) :
   (∏ x in s, f x) = f default :=
-begin
-  obtain ⟨a, ha⟩ := h,
-  have : s = {a},
-  { ext b,
-    simpa [subsingleton.elim a b] using ha },
-  rw [this, finset.prod_singleton, subsingleton.elim a default]
-end
+by rw [h.eq_singleton_default, finset.prod_singleton]
 
 end finset
 
@@ -1600,8 +1594,8 @@ by rw [univ_unique, prod_singleton]
   (∏ x : α, f x) = 1 :=
 by rw [eq_empty_of_is_empty (univ : finset α), finset.prod_empty]
 
-@[to_additive]
-lemma prod_subsingleton {α β : Type*} [comm_monoid β] [subsingleton α] (f : α → β) (a : α) :
+@[to_additive] lemma prod_subsingleton {α β : Type*} [comm_monoid β] [subsingleton α] [fintype α]
+  (f : α → β) (a : α) :
   (∏ x : α, f x) = f a :=
 begin
   haveI : unique α := unique_of_subsingleton a,

--- a/src/data/finite/basic.lean
+++ b/src/data/finite/basic.lean
@@ -64,11 +64,6 @@ not_finite_iff_infinite.mp h
 lemma not_infinite_iff_finite {α : Type*} : ¬ infinite α ↔ finite α :=
 not_finite_iff_infinite.not_right.symm
 
-lemma of_subsingleton {α : Sort*} [subsingleton α] : finite α := finite.of_equiv _ equiv.plift
-
-@[nolint instance_priority]
-instance finite.prop (p : Prop) : finite p := of_subsingleton
-
 namespace finite
 
 lemma exists_max [finite α] [nonempty α] [linear_order β] (f : α → β) :
@@ -80,7 +75,16 @@ lemma exists_min [finite α] [nonempty α] [linear_order β] (f : α → β) :
 by { haveI := fintype.of_finite α, exact fintype.exists_min f }
 
 @[priority 100] -- see Note [lower instance priority]
-instance of_is_empty {α : Sort*} [is_empty α] : finite α := finite.of_equiv _ equiv.plift
+instance of_subsingleton {α : Sort*} [subsingleton α] : finite α :=
+begin
+  casesI is_empty_or_nonempty α,
+  { exact finite.of_equiv _ (equiv.equiv_empty α).symm },
+  { casesI (unique_iff_subsingleton_and_nonempty α).mpr ⟨‹_›, ‹_›⟩,
+    exact finite.of_equiv unit (equiv.equiv_punit α).symm }
+end
+
+@[nolint instance_priority] -- Higher priority for `Prop`s
+instance prop (p : Prop) : finite p := finite.of_subsingleton
 
 instance [finite α] [finite β] : finite (α × β) :=
 by { haveI := fintype.of_finite α, haveI := fintype.of_finite β, apply_instance }

--- a/src/data/finite/basic.lean
+++ b/src/data/finite/basic.lean
@@ -76,12 +76,7 @@ by { haveI := fintype.of_finite α, exact fintype.exists_min f }
 
 @[priority 100] -- see Note [lower instance priority]
 instance of_subsingleton {α : Sort*} [subsingleton α] : finite α :=
-begin
-  casesI is_empty_or_nonempty α,
-  { exact finite.of_equiv _ (equiv.equiv_empty α).symm },
-  { casesI (unique_iff_subsingleton_and_nonempty α).mpr ⟨‹_›, ‹_›⟩,
-    exact finite.of_equiv unit (equiv.equiv_punit α).symm }
-end
+of_injective (function.const α ()) $ function.injective_of_subsingleton _
 
 @[nolint instance_priority] -- Higher priority for `Prop`s
 instance prop (p : Prop) : finite p := finite.of_subsingleton

--- a/src/data/finset/basic.lean
+++ b/src/data/finset/basic.lean
@@ -468,8 +468,11 @@ begin
     rw ← h_uniq hne.some hne.some_spec, exact hne.some_spec }
 end
 
-lemma nonempty.eq_singleton_default [unique α] {s : finset α} (hs : s.nonempty) : s = {default} :=
-eq_singleton_iff_nonempty_unique_mem.mpr ⟨hs, λ x hx, subsingleton.elim _ _⟩
+lemma nonempty_iff_eq_singleton_default [unique α] {s : finset α} :
+  s.nonempty ↔ s = {default} :=
+by simp [eq_singleton_iff_nonempty_unique_mem]
+
+alias nonempty_iff_eq_singleton_default ↔ nonempty.eq_singleton_default _
 
 lemma singleton_iff_unique_mem (s : finset α) : (∃ a, s = {a}) ↔ ∃! a, a ∈ s :=
 by simp only [eq_singleton_iff_unique_mem, exists_unique]

--- a/src/data/finset/basic.lean
+++ b/src/data/finset/basic.lean
@@ -468,6 +468,9 @@ begin
     rw ← h_uniq hne.some hne.some_spec, exact hne.some_spec }
 end
 
+lemma nonempty.eq_singleton_default [unique α] {s : finset α} (hs : s.nonempty) : s = {default} :=
+eq_singleton_iff_nonempty_unique_mem.mpr ⟨hs, λ x hx, subsingleton.elim _ _⟩
+
 lemma singleton_iff_unique_mem (s : finset α) : (∃ a, s = {a}) ↔ ∃! a, a ∈ s :=
 by simp only [eq_singleton_iff_unique_mem, exists_unique]
 

--- a/src/data/fintype/basic.lean
+++ b/src/data/fintype/basic.lean
@@ -619,17 +619,6 @@ arbitrary `fintype` instances, use `finset.univ_eq_empty`. -/
 arbitrary `fintype` instances, use `fintype.card_eq_zero_iff`. -/
 @[simp] theorem card_of_is_empty [is_empty α] : fintype.card α = 0 := rfl
 
-open_locale classical
-variables (α)
-
-/-- Any subsingleton type is (noncomputably) a fintype (with zero or one term). -/
-@[priority 5] -- see Note [lower instance priority]
-noncomputable instance of_subsingleton' [subsingleton α] : fintype α :=
-if h : nonempty α then
-  of_subsingleton (nonempty.some h)
-else
-  @fintype.of_is_empty _ $ not_nonempty_iff.mp h
-
 end fintype
 
 namespace set
@@ -1488,11 +1477,8 @@ fintype.of_surjective quotient.mk (λ x, quotient.induction_on x (λ x, ⟨x, rf
 instance finset.fintype [fintype α] : fintype (finset α) :=
 ⟨univ.powerset, λ x, finset.mem_powerset.2 (finset.subset_univ _)⟩
 
--- irreducible due to this conversation on Zulip:
--- https://leanprover.zulipchat.com/#narrow/stream/113488-general/
--- topic/.60simp.60.20ignoring.20lemmas.3F/near/241824115
-@[irreducible] instance function.embedding.fintype {α β} [fintype α] [fintype β]
-  [decidable_eq α] [decidable_eq β] : fintype (α ↪ β) :=
+instance function.embedding.fintype {α β} [fintype α] [fintype β] [decidable_eq α]
+  [decidable_eq β] : fintype (α ↪ β) :=
 fintype.of_equiv _ (equiv.subtype_injective_equiv_embedding α β)
 
 instance [decidable_eq α] [fintype α] {n : ℕ} : fintype (sym.sym' α n) :=
@@ -2104,17 +2090,9 @@ begin
   intros x y, contrapose, apply hf,
 end
 
--- irreducible due to this conversation on Zulip:
--- https://leanprover.zulipchat.com/#narrow/stream/113488-general/
--- topic/.60simp.60.20ignoring.20lemmas.3F/near/241824115
-
-@[irreducible]
 instance function.embedding.is_empty {α β} [infinite α] [fintype β] : is_empty (α ↪ β) :=
-  ⟨λ f, let ⟨x, y, ne, feq⟩ := fintype.exists_ne_map_eq_of_infinite f in ne $ f.injective feq⟩
+⟨λ f, let ⟨x, y, ne, feq⟩ := fintype.exists_ne_map_eq_of_infinite f in ne $ f.injective feq⟩
 
-@[priority 100]
-noncomputable instance function.embedding.fintype' {α β : Type*} [fintype β] : fintype (α ↪ β) :=
-by casesI fintype_or_infinite α; apply_instance
 /--
 The strong pigeonhole principle for infinitely many pigeons in
 finitely many pigeonholes.  If there are infinitely many pigeons in

--- a/src/ring_theory/noetherian.lean
+++ b/src/ring_theory/noetherian.lean
@@ -774,17 +774,15 @@ lemma is_noetherian_ring_iff_ideal_fg (R : Type*) [semiring R] :
 is_noetherian_ring_iff.trans is_noetherian_def
 
 @[priority 80] -- see Note [lower instance priority]
-instance is_noetherian_of_fintype (R M) [fintype M] [semiring R] [add_comm_monoid M] [module R M] :
+instance is_noetherian_of_finite (R M) [finite M] [semiring R] [add_comm_monoid M] [module R M] :
   is_noetherian R M :=
-by letI := classical.dec; exact
-⟨assume s, ⟨to_finset s, by rw [set.coe_to_finset, submodule.span_eq]⟩⟩
+⟨λ s, ⟨(s : set M).to_finite.to_finset, by rw [set.finite.coe_to_finset, submodule.span_eq]⟩⟩
 
 /-- Modules over the trivial ring are Noetherian. -/
 @[priority 100] -- see Note [lower instance priority]
 instance is_noetherian_of_subsingleton (R M) [subsingleton R] [semiring R] [add_comm_monoid M]
   [module R M] : is_noetherian R M :=
-by haveI := module.subsingleton R M;
-   exact is_noetherian_of_fintype R M
+by { haveI := module.subsingleton R M, exact is_noetherian_of_finite R M }
 
 @[priority 100] -- see Note [lower instance priority]
 instance ring.is_noetherian_of_subsingleton {R} [semiring R] [subsingleton R] :

--- a/src/set_theory/cardinal/finite.lean
+++ b/src/set_theory/cardinal/finite.lean
@@ -55,8 +55,8 @@ end
 
 lemma card_of_subsingleton (a : α) [subsingleton α] : nat.card α = 1 :=
 begin
-  rw [card_eq_fintype_card],
-  convert fintype.card_of_subsingleton a,
+  letI := fintype.of_subsingleton a,
+  rw [card_eq_fintype_card, fintype.card_of_subsingleton a]
 end
 
 @[simp] lemma card_unique [unique α] : nat.card α = 1 :=


### PR DESCRIPTION
Drop `fintype.of_subsingleton'` and `function.embedding.fintype'`. First, we should use `finite` instances instead of noncomputable `fintype` instances. Second, these instances created diamonds with non-primed versions.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
