### PR TITLE
[Merged by Bors] - chore(data/polynomial/degree/definitions): make an argument explicit

### DIFF
--- a/src/data/polynomial/degree/definitions.lean
+++ b/src/data/polynomial/degree/definitions.lean
@@ -648,7 +648,7 @@ lemma monic.ne_zero_of_ne (h : (0:R) ≠ 1) {p : R[X]} (hp : p.monic) :
   p ≠ 0 :=
 by { nontriviality R, exact hp.ne_zero }
 
-lemma monic_of_nat_degree_le_of_coeff_eq_one (pn : p.nat_degree ≤ n) (p1 : p.coeff n = 1) :
+lemma monic_of_nat_degree_le_of_coeff_eq_one (n : ℕ) (pn : p.nat_degree ≤ n) (p1 : p.coeff n = 1) :
   monic p :=
 begin
   nontriviality,
@@ -656,9 +656,9 @@ begin
   exact ne_of_eq_of_ne p1 one_ne_zero,
 end
 
-lemma monic_of_degree_le_of_coeff_eq_one (pn : p.degree ≤ n) (p1 : p.coeff n = 1) :
+lemma monic_of_degree_le_of_coeff_eq_one (n : ℕ) (pn : p.degree ≤ n) (p1 : p.coeff n = 1) :
   monic p :=
-monic_of_nat_degree_le_of_coeff_eq_one (nat_degree_le_of_degree_le pn) p1
+monic_of_nat_degree_le_of_coeff_eq_one n (nat_degree_le_of_degree_le pn) p1
 
 lemma monic.ne_zero_of_polynomial_ne {r} (hp : monic p) (hne : q ≠ r) : p ≠ 0 :=
 by { haveI := nontrivial.of_polynomial_ne hne, exact hp.ne_zero }


### PR DESCRIPTION
The argument `n : ℕ` cannot be deduced from the goal and it is useful to be able to provide it.

This argument changed from explicit to implicit when I prepared #15818.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
