### PR TITLE
[Merged by Bors] - feat(algebra/order/sub): add `canonically_ordered_add_monoid.to_add_cancel_comm_monoid`

### DIFF
--- a/src/algebra/order/sub.lean
+++ b/src/algebra/order/sub.lean
@@ -214,21 +214,6 @@ contravariant.add_le_cancellable.le_tsub_of_add_le_left h
 lemma le_tsub_of_add_le_right (h : a + b ≤ c) : a ≤ c - b :=
 contravariant.add_le_cancellable.le_tsub_of_add_le_right h
 
-variables (α)
-
-/-- A `canonically_ordered_add_monoid` with ordered subtraction and order-reflecting addition is
-cancellative. This is not an instance at it would form a typeclass loop.
-
-See note [reducible non-instances]. -/
-@[reducible]
-def canonically_ordered_add_monoid.to_add_cancel_comm_monoid : add_cancel_comm_monoid α :=
-{ add_left_cancel := λ a b c h, begin
-    have := congr_arg (λ x, x - a) h,
-    dsimp at this,
-    rwa [add_tsub_cancel_left, add_tsub_cancel_left] at this,
-  end,
-  ..(by apply_instance : add_comm_monoid α) }
-
 end contra
 
 end add_comm_semigroup
@@ -684,6 +669,21 @@ contravariant.add_le_cancellable.tsub_le_tsub_iff_left contravariant.add_le_canc
 lemma tsub_right_inj (hba : b ≤ a) (hca : c ≤ a) : a - b = a - c ↔ b = c :=
 contravariant.add_le_cancellable.tsub_right_inj contravariant.add_le_cancellable
   contravariant.add_le_cancellable hba hca
+
+variables (α)
+
+/-- A `canonically_ordered_add_monoid` with ordered subtraction and order-reflecting addition is
+cancellative. This is not an instance at it would form a typeclass loop.
+
+See note [reducible non-instances]. -/
+@[reducible]
+def canonically_ordered_add_monoid.to_add_cancel_comm_monoid : add_cancel_comm_monoid α :=
+{ add_left_cancel := λ a b c h, begin
+    have := congr_arg (λ x, x - a) h,
+    dsimp at this,
+    rwa [add_tsub_cancel_left, add_tsub_cancel_left] at this,
+  end,
+  ..(by apply_instance : add_comm_monoid α) }
 
 end contra
 

--- a/src/algebra/order/sub.lean
+++ b/src/algebra/order/sub.lean
@@ -678,11 +678,7 @@ cancellative. This is not an instance at it would form a typeclass loop.
 See note [reducible non-instances]. -/
 @[reducible]
 def canonically_ordered_add_monoid.to_add_cancel_comm_monoid : add_cancel_comm_monoid α :=
-{ add_left_cancel := λ a b c h, begin
-    have := congr_arg (λ x, x - a) h,
-    dsimp at this,
-    rwa [add_tsub_cancel_left, add_tsub_cancel_left] at this,
-  end,
+{ add_left_cancel := λ a b c h, by simpa only [add_tsub_cancel_left] using congr_arg (λ x, x - a) h,
   ..(by apply_instance : add_comm_monoid α) }
 
 end contra

--- a/src/algebra/order/sub.lean
+++ b/src/algebra/order/sub.lean
@@ -214,6 +214,21 @@ contravariant.add_le_cancellable.le_tsub_of_add_le_left h
 lemma le_tsub_of_add_le_right (h : a + b ≤ c) : a ≤ c - b :=
 contravariant.add_le_cancellable.le_tsub_of_add_le_right h
 
+variables (α)
+
+/-- A `canonically_ordered_add_monoid` with ordered subtraction and order-reflecting addition is
+cancellative. This is not an instance at it would form a typeclass loop.
+
+See note [reducible non-instances]. -/
+@[reducible]
+def canonically_ordered_add_monoid.to_add_cancel_comm_monoid : add_cancel_comm_monoid α :=
+{ add_left_cancel := λ a b c h, begin
+    have := congr_arg (λ x, x - a) h,
+    dsimp at this,
+    rwa [add_tsub_cancel_left, add_tsub_cancel_left] at this,
+  end,
+  ..(by apply_instance : add_comm_monoid α) }
+
 end contra
 
 end add_comm_semigroup


### PR DESCRIPTION
We don't have a typeclass for cancellative ordered additive monoids (such as `nat` or finsupps with nat as their codomain).
This definition is enough to create the instance mid-proof if needed, so is better than nothing.

We already have similar definitions such as `no_zero_divisors.to_cancel_comm_monoid` for rings.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

Split from #15905

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
