### PR TITLE
[Merged by Bors] - chore(linear_algebra/free_module/basic): tidy up

### DIFF
--- a/src/linear_algebra/finsupp_vector_space.lean
+++ b/src/linear_algebra/finsupp_vector_space.lean
@@ -57,6 +57,12 @@ begin
       apply range_comp_subset_range } }
 end
 
+end ring
+
+section semiring
+variables {R : Type*} {M : Type*} {ι : Type*}
+variables [semiring R] [add_comm_monoid M] [module R M]
+
 open linear_map submodule
 
 /-- The basis on `ι →₀ M` with basis vectors `λ ⟨i, x⟩, single i (b i x)`. -/
@@ -116,7 +122,7 @@ basis.of_repr (linear_equiv.refl _ _)
   (finsupp.basis_single_one : ι → (ι →₀ R)) = λ i, finsupp.single i 1 :=
 funext $ λ i, basis.apply_eq_iff.mpr rfl
 
-end ring
+end semiring
 
 section dim
 variables {K : Type u} {V : Type v} {ι : Type v}

--- a/src/linear_algebra/free_module/basic.lean
+++ b/src/linear_algebra/free_module/basic.lean
@@ -91,15 +91,6 @@ noncomputable def constr {S : Type z} [semiring S] [module S N] [smul_comm_class
 instance no_zero_smul_divisors [no_zero_divisors R] : no_zero_smul_divisors R M :=
 let ⟨⟨_, b⟩⟩ := exists_basis R M in b.no_zero_smul_divisors
 
-/-- The product of finitely many free modules is free. -/
-instance pi {ι : Type*} [fintype ι] {M : ι → Type*} [Π (i : ι), add_comm_group (M i)]
-  [Π (i : ι), module R (M i)] [Π (i : ι), module.free R (M i)] : module.free R (Π i, M i) :=
-of_basis $ pi.basis $ λ i, choose_basis R (M i)
-
-/-- The module of finite matrices is free. -/
-instance matrix {m n : Type*} [fintype m] [fintype n] : module.free R (matrix m n R) :=
-of_basis $ matrix.std_basis R m n
-
 variables {R M N}
 
 lemma of_equiv (e : M ≃ₗ[R] N) : module.free R N :=
@@ -113,16 +104,24 @@ of_equiv e
 
 variables (R M N)
 
-instance {ι : Type v} : module.free R (ι →₀ R) :=
-of_basis (basis.of_repr (linear_equiv.refl _ _))
-
-instance {ι : Type v} [fintype ι] : module.free R (ι → R) :=
-of_equiv (basis.of_repr $ linear_equiv.refl _ _).equiv_fun
+/-- The module structure provided by `semiring.to_module` is free. -/
+instance self : module.free R R := of_basis (basis.singleton unit R)
 
 instance prod [module.free R N] : module.free R (M × N) :=
 of_basis $ (choose_basis R M).prod (choose_basis R N)
 
-instance self : module.free R R := of_basis $ basis.singleton unit R
+/-- The product of finitely many free modules is free. -/
+instance pi {ι : Type*} [fintype ι] {M : ι → Type*} [Π (i : ι), add_comm_monoid (M i)]
+  [Π (i : ι), module R (M i)] [Π (i : ι), module.free R (M i)] : module.free R (Π i, M i) :=
+of_basis $ pi.basis $ λ i, choose_basis R (M i)
+
+/-- The module of finite matrices is free. -/
+instance matrix {m n : Type*} [fintype m] [fintype n] [module.free R M] :
+  module.free R (matrix m n M) :=
+module.free.pi R
+
+instance finsupp {ι : Type v} : module.free R (ι →₀ R) :=
+of_basis (basis.of_repr (linear_equiv.refl _ _))
 
 @[priority 100]
 instance of_subsingleton [subsingleton N] : module.free R N :=
@@ -148,7 +147,7 @@ variables [comm_ring R] [add_comm_group M] [module R M] [module.free R M]
 variables [add_comm_group N] [module R N] [module.free R N]
 
 instance tensor : module.free R (M ⊗[R] N) :=
-of_equiv' (of_equiv' (finsupp.free R) (finsupp_tensor_finsupp' R _ _).symm)
+of_equiv' (of_equiv' (free.finsupp R) (finsupp_tensor_finsupp' R _ _).symm)
   (tensor_product.congr (choose_basis R M).repr (choose_basis R N).repr).symm
 
 end comm_ring

--- a/src/linear_algebra/free_module/basic.lean
+++ b/src/linear_algebra/free_module/basic.lean
@@ -7,6 +7,7 @@ Authors: Riccardo Brasca
 import linear_algebra.direct_sum.finsupp
 import logic.small
 import linear_algebra.std_basis
+import linear_algebra.finsupp_vector_space
 
 /-!
 
@@ -25,7 +26,7 @@ Use `finsupp.total_id_surjective` to prove that any module is the quotient of a 
 
 universes u v w z
 
-variables (R : Type u) (M : Type v) (N : Type z)
+variables {ι : Type*} (R : Type u) (M : Type v) (N : Type z)
 
 open_locale tensor_product direct_sum big_operators
 
@@ -111,17 +112,20 @@ instance prod [module.free R N] : module.free R (M × N) :=
 of_basis $ (choose_basis R M).prod (choose_basis R N)
 
 /-- The product of finitely many free modules is free. -/
-instance pi {ι : Type*} [fintype ι] {M : ι → Type*} [Π (i : ι), add_comm_monoid (M i)]
+instance pi (M : ι → Type*) [finite ι] [Π (i : ι), add_comm_monoid (M i)]
   [Π (i : ι), module R (M i)] [Π (i : ι), module.free R (M i)] : module.free R (Π i, M i) :=
-of_basis $ pi.basis $ λ i, choose_basis R (M i)
+let ⟨_⟩ := nonempty_fintype ι in by exactI (of_basis $ pi.basis $ λ i, choose_basis R (M i))
 
 /-- The module of finite matrices is free. -/
-instance matrix {m n : Type*} [fintype m] [fintype n] [module.free R M] :
-  module.free R (matrix m n M) :=
-module.free.pi R
+instance matrix {m n : Type*} [finite m] [finite n] : module.free R (matrix m n M) :=
+module.free.pi R _
 
-instance finsupp {ι : Type v} : module.free R (ι →₀ R) :=
-of_basis (basis.of_repr (linear_equiv.refl _ _))
+variables (ι)
+
+instance finsupp : module.free R (ι →₀ M) :=
+of_basis (finsupp.basis $ λ i, choose_basis R M)
+
+variables {ι}
 
 @[priority 100]
 instance of_subsingleton [subsingleton N] : module.free R N :=
@@ -147,7 +151,7 @@ variables [comm_ring R] [add_comm_group M] [module R M] [module.free R M]
 variables [add_comm_group N] [module R N] [module.free R N]
 
 instance tensor : module.free R (M ⊗[R] N) :=
-of_equiv' (of_equiv' (free.finsupp R) (finsupp_tensor_finsupp' R _ _).symm)
+of_equiv' (of_equiv' (free.finsupp _ R _) (finsupp_tensor_finsupp' R _ _).symm)
   (tensor_product.congr (choose_basis R M).repr (choose_basis R N).repr).symm
 
 end comm_ring

--- a/src/linear_algebra/free_module/basic.lean
+++ b/src/linear_algebra/free_module/basic.lean
@@ -122,6 +122,10 @@ module.free.pi R _
 
 variables (ι)
 
+/-- The product of finitely many free modules is free (non-dependent version to help with typeclass
+search). -/
+instance function [finite ι] : module.free R (ι → M) := free.pi _ _
+
 instance finsupp : module.free R (ι →₀ M) :=
 of_basis (finsupp.basis $ λ i, choose_basis R M)
 

--- a/src/linear_algebra/free_module/strong_rank_condition.lean
+++ b/src/linear_algebra/free_module/strong_rank_condition.lean
@@ -43,9 +43,10 @@ begin
   { rwa strong_rank_condition_iff_succ R },
   intros n f, by_contradiction hf,
 
-  -- Lean is unable to find this instance without help, either via this `letI`, or via a duplicate
-  -- instance with unecessarily strong typeclasses on `R` and `M`.
+  -- Lean is unable to find these instances without help, either via this `letI`, or via duplicate
+  -- instances with unecessarily strong typeclasses on `R` and `M`.
   letI : module.finite R (fin n.succ → R) := module.finite.pi,
+  letI : module.free R (fin n.succ → R) := module.free.pi _ _,
 
   let g : (fin (n + 1) → R) →ₗ[R] fin (n + 1) → R :=
     (extend_by_zero.linear_map R cast_succ).comp f,


### PR DESCRIPTION
This generalizes a few free instances to not assume the same ring appears twice, notably `module.free R (ι →₀ R)` to `module.free R (ι →₀ M)` and `module.free R (matrix m n R)` to `module.free R (matrix m n M)`.

This renames `module.free.pi.free`, a special case of `module.free.pi`, to `module.free.function`.
It also renames `module.free.finsupp.free` to `module.free.finsupp`.

In order to make this change we relax the typeclasses in `finsupp.basis` from rings to semirings.
We make the same relaxation on `module.free.pi`, which results in us running into the same typeclass search bug that already occurs for `module.finite`.

Finally, at the request of the new linter this changes `fintype` assumptions to `finite`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
