### PR TITLE
feat(tactic/interactive_expr): Color instances in the infoview

### DIFF
--- a/src/tactic/interactive_expr.lean
+++ b/src/tactic/interactive_expr.lean
@@ -376,7 +376,7 @@ meta def tactic_view_goal {γ} (local_c : tc local_collection γ) (target_c : tc
   tc filter_type γ :=
 tc.stateless $ λ ft, do
   is ← tactic.frozen_local_instances,
-  let frozen : bool := (is ≠ option.none),
+  let frozen : bool := is ≠ none,
   let is' : list expr := option.cases_on is [] id,
   g@(expr.mvar u_n pp_n y) ← main_goal,
   t ← get_tag g,
@@ -393,8 +393,8 @@ tc.stateless $ λ ft, do
   let lcs := group_local_collection lcs,
   lchs ← lcs.mmap (λ lc, do
     lh ← local_c lc,
+    cls ← is_class lc.type,
     ns ← lc.locals.mmap (λ n, do -- extract into function?
-      cls ← is_class lc.type,
       let var_color : attr γ := if ¬ cls
         then attr.style [("color", "#cc7a00")]  -- "goal-hyp"
         else if frozen

--- a/src/tactic/interactive_expr.lean
+++ b/src/tactic/interactive_expr.lean
@@ -392,7 +392,7 @@ tc.stateless $ λ ft, do
   lchs ← lcs.mmap (λ lc, do
     lh ← local_c lc,
     cls ← is_class lc.type,
-    ns ← lc.locals.mmap (λ n, do -- extract into function?
+    let ns := lc.locals.map (λ n,
       let var_color : attr γ := if ¬ cls
         then attr.style [("color", "#cc7a00")]  -- "goal-hyp"
         else match is with
@@ -400,8 +400,7 @@ tc.stateless $ λ ft, do
                         then attr.style [("color", "#2aa198")]  -- "goal-hyp-inst"
                         else attr.style [("font-style", "italic")] -- "goal-hyp-noninst"
         | none := attr.style [("color", "#dc322f")] -- "goal-hyp-unfrozen"
-        end,
-        pure $ h "span" [cn "goal-hyp b pr2", var_color] [html.of_name $ expr.local_pp_name n]),
+        end in h "span" [cn "goal-hyp b pr2", var_color] [html.of_name $ expr.local_pp_name n]),
     pure $ h "li" [key lc.key] (ns ++ [": ", h "span" [cn "goal-hyp-type", key "type"] [lh]])),
   t_comp ← target_c g,
   pure $ h "ul" [key g.hash, className "list pl0 font-code"] $ case_tag ++ lchs ++ [

--- a/src/tactic/interactive_expr.lean
+++ b/src/tactic/interactive_expr.lean
@@ -376,8 +376,6 @@ meta def tactic_view_goal {γ} (local_c : tc local_collection γ) (target_c : tc
   tc filter_type γ :=
 tc.stateless $ λ ft, do
   is ← tactic.frozen_local_instances,
-  let frozen : bool := is ≠ none,
-  let is' : list expr := option.cases_on is [] id,
   g@(expr.mvar u_n pp_n y) ← main_goal,
   t ← get_tag g,
   let case_tag : list (html γ) :=
@@ -397,11 +395,12 @@ tc.stateless $ λ ft, do
     ns ← lc.locals.mmap (λ n, do -- extract into function?
       let var_color : attr γ := if ¬ cls
         then attr.style [("color", "#cc7a00")]  -- "goal-hyp"
-        else if frozen
-          then if n ∈ is'
-            then attr.style [("color", "#2aa198")]  -- "goal-hyp-inst"
-            else attr.style [("font-style", "italic")] -- "goal-hyp-noninst"
-        else attr.style [("color", "#dc322f")], -- "goal-hyp-unfrozen"
+        else match is with
+        | some is' := if n ∈ is'
+                        then attr.style [("color", "#2aa198")]  -- "goal-hyp-inst"
+                        else attr.style [("font-style", "italic")] -- "goal-hyp-noninst"
+        | none := attr.style [("color", "#dc322f")] -- "goal-hyp-unfrozen"
+        end,
         pure $ h "span" [cn "goal-hyp b pr2", var_color] [html.of_name $ expr.local_pp_name n]),
     pure $ h "li" [key lc.key] (ns ++ [": ", h "span" [cn "goal-hyp-type", key "type"] [lh]])),
   t_comp ← target_c g,

--- a/src/tactic/interactive_expr.lean
+++ b/src/tactic/interactive_expr.lean
@@ -392,7 +392,7 @@ tc.stateless $ λ ft, do
   lchs ← lcs.mmap (λ lc, do
     lh ← local_c lc,
     cls ← is_class lc.type,
-    let ns := lc.locals.map (λ n,
+    let ns : list (html γ) := lc.locals.map $ λ n,
       let var_color : attr γ := if ¬ cls
         then attr.style [("color", "#cc7a00")]  -- "goal-hyp"
         else match is with
@@ -400,7 +400,7 @@ tc.stateless $ λ ft, do
                         then attr.style [("color", "#2aa198")]  -- "goal-hyp-inst"
                         else attr.style [("font-style", "italic")] -- "goal-hyp-noninst"
         | none := attr.style [("color", "#dc322f")] -- "goal-hyp-unfrozen"
-        end in h "span" [cn "goal-hyp b pr2", var_color] [html.of_name $ expr.local_pp_name n]),
+        end in h "span" [cn "goal-hyp b pr2", var_color] [html.of_name $ expr.local_pp_name n],
     pure $ h "li" [key lc.key] (ns ++ [": ", h "span" [cn "goal-hyp-type", key "type"] [lh]])),
   t_comp ← target_c g,
   pure $ h "ul" [key g.hash, className "list pl0 font-code"] $ case_tag ++ lchs ++ [

--- a/src/tactic/interactive_expr.lean
+++ b/src/tactic/interactive_expr.lean
@@ -393,14 +393,14 @@ tc.stateless $ λ ft, do
     lh ← local_c lc,
     cls ← is_class lc.type,
     let ns : list (html γ) := lc.locals.map $ λ n,
-      let var_color : attr γ := if ¬ cls
-        then attr.style [("color", "#cc7a00")]  -- "goal-hyp"
+      let var_style : string := if ¬ cls
+        then "goal-hyp"
         else match is with
         | some is' := if n ∈ is'
-                        then attr.style [("color", "#2aa198")]  -- "goal-hyp-inst"
-                        else attr.style [("font-style", "italic")] -- "goal-hyp-noninst"
-        | none := attr.style [("color", "#dc322f")] -- "goal-hyp-unfrozen"
-        end in h "span" [cn "goal-hyp b pr2", var_color] [html.of_name $ expr.local_pp_name n],
+                        then "goal-hyp-inst"
+                        else "goal-hyp-noninst"
+        | none := "goal-hyp-unfrozen"
+        end in h "span" [cn "goal-hyp b pr2", cn var_style] [html.of_name $ expr.local_pp_name n],
     pure $ h "li" [key lc.key] (ns ++ [": ", h "span" [cn "goal-hyp-type", key "type"] [lh]])),
   t_comp ← target_c g,
   pure $ h "ul" [key g.hash, className "list pl0 font-code"] $ case_tag ++ lchs ++ [

--- a/src/tactic/interactive_expr.lean
+++ b/src/tactic/interactive_expr.lean
@@ -400,7 +400,7 @@ tc.stateless $ λ ft, do
                         then "goal-hyp-inst"
                         else "goal-hyp-noninst"
         | none := "goal-hyp-unfrozen"
-        end in h "span" [cn "goal-hyp b pr2", cn var_style] [html.of_name $ expr.local_pp_name n],
+        end in h "span" [cn $ var_style ++ " b pr2"] [html.of_name $ expr.local_pp_name n],
     pure $ h "li" [key lc.key] (ns ++ [": ", h "span" [cn "goal-hyp-type", key "type"] [lh]])),
   t_comp ← target_c g,
   pure $ h "ul" [key g.hash, className "list pl0 font-code"] $ case_tag ++ lchs ++ [


### PR DESCRIPTION
Change the behavior of the infoview to visually distinguish:
* frozen instances
* typeclass assumptions that are not instances
* unfrozen typeclass assumptions
* non typeclass assumptions

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

The style is very much up for debate! See [Zulip](https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/Instance.20cache.20in.20the.20infoview). Once we have decided on the style, I will open a preliminary PR to `vscode-lean` adding the new attributes to [the CSS](https://github.com/leanprover/vscode-lean/blob/master/infoview/index.css).

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
