### PR TITLE
[Merged by Bors] - refactor(algebra/periodic): weaken another `antiperiodic` typeclass assumption

### DIFF
--- a/src/algebra/periodic.lean
+++ b/src/algebra/periodic.lean
@@ -456,7 +456,8 @@ lemma antiperiodic.add_const [add_comm_semigroup α] [has_neg β] (h : antiperio
   antiperiodic (λ x, f (x + a)) c :=
 λ x, by simpa [add_assoc x c a, add_comm c, ←add_assoc x a c] using h (x + a)
 
-lemma antiperiodic.const_sub [add_comm_group α] [add_group β] (h : antiperiodic f c) (a : α) :
+lemma antiperiodic.const_sub [add_comm_group α] [has_involutive_neg β] (h : antiperiodic f c)
+  (a : α) :
   antiperiodic (λ x, f (a - x)) c :=
 begin
   rw [←neg_neg c],


### PR DESCRIPTION
Followup to #15941 and #15782, weakening the typeclass assumption on
the codomain of the antiperiodic function in `antiperiodic.const_sub`
(added by #15782) in the same way as done for other lemmas in #15941.



---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
