### PR TITLE
[Merged by Bors] - chore(*/..eq): add is_refl instances

### DIFF
--- a/src/data/int/modeq.lean
+++ b/src/data/int/modeq.lean
@@ -36,6 +36,8 @@ namespace modeq
 
 protected theorem rfl : a ≡ a [ZMOD n] := modeq.refl _
 
+instance : is_refl _ (modeq n) := ⟨modeq.refl⟩
+
 @[symm] protected theorem symm : a ≡ b [ZMOD n] → b ≡ a [ZMOD n] := eq.symm
 
 @[trans] protected theorem trans : a ≡ b [ZMOD n] → b ≡ c [ZMOD n] → a ≡ c [ZMOD n] := eq.trans

--- a/src/data/nat/modeq.lean
+++ b/src/data/nat/modeq.lean
@@ -39,6 +39,8 @@ namespace modeq
 
 protected theorem rfl : a ≡ a [MOD n] := modeq.refl _
 
+instance : is_refl _ (modeq n) := ⟨modeq.refl⟩
+
 @[symm] protected theorem symm : a ≡ b [MOD n] → b ≡ a [MOD n] := eq.symm
 
 @[trans] protected theorem trans : a ≡ b [MOD n] → b ≡ c [MOD n] → a ≡ c [MOD n] := eq.trans

--- a/src/linear_algebra/smodeq.lean
+++ b/src/linear_algebra/smodeq.lean
@@ -44,7 +44,11 @@ by rw [smodeq.def, submodule.quotient.eq, mem_bot, sub_eq_zero]
 @[mono] theorem mono (HU : U₁ ≤ U₂) (hxy : x ≡ y [SMOD U₁]) : x ≡ y [SMOD U₂] :=
 (submodule.quotient.eq U₂).2 $ HU $ (submodule.quotient.eq U₁).1 hxy
 
-@[refl] theorem refl : x ≡ x [SMOD U] := eq.refl _
+@[refl] protected theorem refl (x : M) : x ≡ x [SMOD U] := @rfl _ _
+
+protected theorem rfl : x ≡ x [SMOD U] := smodeq.refl _
+
+instance : is_refl _ (smodeq U) := ⟨smodeq.refl⟩
 
 @[symm] theorem symm (hxy : x ≡ y [SMOD U]) : y ≡ x [SMOD U] := hxy.symm
 

--- a/src/ring_theory/henselian.lean
+++ b/src/ring_theory/henselian.lean
@@ -250,7 +250,7 @@ instance is_adic_complete.henselian_ring
       specialize ha 1,
       rw [hc, pow_one, ← ideal.one_eq_top, ideal.smul_eq_mul, mul_one, sub_eq_add_neg] at ha,
       rw [← smodeq.sub_mem, ← add_zero a₀],
-      refine ha.symm.trans (smodeq.refl.add _),
+      refine ha.symm.trans (smodeq.rfl.add _),
       rw [smodeq.zero, ideal.neg_mem_iff],
       exact ideal.mul_mem_right _ _ h₁, }
   end }


### PR DESCRIPTION
This allows the use of docs#of_eq, an extremely underused utility method. Also fixes `smodeq` to match the `rfl/refl` conventions. 

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
