### PR TITLE
[Merged by Bors] - feat(topology/connected): make `connected_component_in` more usable, develop API

### DIFF
--- a/src/topology/connected.lean
+++ b/src/topology/connected.lean
@@ -597,14 +597,10 @@ theorem connected_component_in_subset (F : set α) (x : α) :
   connected_component_in F x ⊆ F :=
 by { rw [connected_component_in], split_ifs; simp }
 
-theorem connected_component_in_univ (x : α) :
-  connected_component_in univ x = connected_component x :=
-by { rw [connected_component_in], split_ifs; simp }
-
 theorem is_preconnected_connected_component {x : α} : is_preconnected (connected_component x) :=
 is_preconnected_sUnion x _ (λ _, and.right) (λ _, and.left)
 
-lemma is_preconnected_connected_comp_in {x : α} {F : set α} :
+lemma is_preconnected_connected_component_in {x : α} {F : set α} :
   is_preconnected (connected_component_in F x) :=
 begin
   rw [connected_component_in], split_ifs,
@@ -618,8 +614,8 @@ theorem is_connected_connected_component {x : α} : is_connected (connected_comp
 
 lemma is_connected_connected_component_in_iff {x : α} {F : set α} :
   is_connected (connected_component_in F x) ↔ x ∈ F :=
-by simp_rw [← connected_component_in_nonempty_iff, is_connected, is_preconnected_connected_comp_in,
-  and_true]
+by simp_rw [← connected_component_in_nonempty_iff, is_connected,
+  is_preconnected_connected_component_in, and_true]
 
 theorem is_preconnected.subset_connected_component {x : α} {s : set α}
   (H1 : is_preconnected s) (H2 : x ∈ s) : s ⊆ connected_component x :=
@@ -642,6 +638,10 @@ theorem is_connected.subset_connected_component {x : α} {s : set α}
   (H1 : is_connected s) (H2 : x ∈ s) : s ⊆ connected_component x :=
 H1.2.subset_connected_component H2
 
+lemma is_preconnected.connected_component_in {x : α} {F : set α} (h : is_preconnected F)
+  (hx : x ∈ F) : connected_component_in F x = F :=
+(connected_component_in_subset F x).antisymm (h.subset_connected_component_in hx subset_rfl)
+
 theorem connected_component_eq {x y : α} (h : y ∈ connected_component x) :
   connected_component x = connected_component y :=
 eq_of_subset_of_subset
@@ -649,6 +649,23 @@ eq_of_subset_of_subset
   (is_connected_connected_component.subset_connected_component
     (set.mem_of_mem_of_subset mem_connected_component
       (is_connected_connected_component.subset_connected_component h)))
+
+lemma connected_component_in_eq {x y : α} {F : set α} (h : y ∈ connected_component_in F x) :
+  connected_component_in F x = connected_component_in F y :=
+begin
+  have hx : x ∈ F := connected_component_in_nonempty_iff.mp ⟨y, h⟩,
+  simp_rw [connected_component_in, dif_pos hx] at h ⊢,
+  obtain ⟨⟨y, hy⟩, h2y, rfl⟩ := h,
+  simp_rw [subtype.coe_mk, dif_pos hy, connected_component_eq h2y]
+end
+
+theorem connected_component_in_univ (x : α) :
+  connected_component_in univ x = connected_component x :=
+subset_antisymm
+  (is_preconnected_connected_component_in.subset_connected_component $
+    mem_connected_component_in trivial)
+  (is_preconnected_connected_component.subset_connected_component_in mem_connected_component $
+    subset_univ _)
 
 lemma connected_component_disjoint {x y : α} (h : connected_component x ≠ connected_component y) :
   disjoint (connected_component x) (connected_component y) :=


### PR DESCRIPTION
From the [Sphere Eversion Project](https://github.com/leanprover-community/sphere-eversion/blob/333231d77aa028bb164abc695ac8a4abce4af0c2/src/to_mathlib/topology/misc.lean#L516)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
