### PR TITLE
[Merged by Bors] - feat(topology/connected): definition and basic properties about locally connected spaces

### DIFF
--- a/src/topology/algebra/module/locally_convex.lean
+++ b/src/topology/algebra/module/locally_convex.lean
@@ -92,8 +92,8 @@ lemma locally_convex_space_iff_exists_convex_subset_zero :
 (locally_convex_space_iff_zero 𝕜 E).trans has_basis_self
 
 -- see Note [lower instance priority]
-@[priority 100] instance locally_convex_space.to_locally_connected_space [module ℝ E] [has_continuous_smul ℝ E]
-  [locally_convex_space ℝ E] :
+@[priority 100] instance locally_convex_space.to_locally_connected_space [module ℝ E]
+  [has_continuous_smul ℝ E] [locally_convex_space ℝ E] :
   locally_connected_space E :=
 locally_connected_space_of_connected_bases _ _
   (λ x, @locally_convex_space.convex_basis ℝ _ _ _ _ _ _ x)

--- a/src/topology/algebra/module/locally_convex.lean
+++ b/src/topology/algebra/module/locally_convex.lean
@@ -91,7 +91,8 @@ lemma locally_convex_space_iff_exists_convex_subset_zero :
   ∀ U ∈ (𝓝 0 : filter E), ∃ S ∈ (𝓝 0 : filter E), convex 𝕜 S ∧ S ⊆ U :=
 (locally_convex_space_iff_zero 𝕜 E).trans has_basis_self
 
-instance locally_convex_space.to_locally_connected_space [module ℝ E] [has_continuous_smul ℝ E]
+-- see Note [lower instance priority]
+@[priority 100] instance locally_convex_space.to_locally_connected_space [module ℝ E] [has_continuous_smul ℝ E]
   [locally_convex_space ℝ E] :
   locally_connected_space E :=
 locally_connected_space_of_connected_bases _ _

--- a/src/topology/algebra/module/locally_convex.lean
+++ b/src/topology/algebra/module/locally_convex.lean
@@ -91,6 +91,17 @@ lemma locally_convex_space_iff_exists_convex_subset_zero :
   ∀ U ∈ (𝓝 0 : filter E), ∃ S ∈ (𝓝 0 : filter E), convex 𝕜 S ∧ S ⊆ U :=
 (locally_convex_space_iff_zero 𝕜 E).trans has_basis_self
 
+instance locally_convex_space.to_locally_connected_space [module ℝ E] [has_continuous_smul ℝ E]
+  [locally_convex_space ℝ E] :
+  locally_connected_space E :=
+begin
+  rw locally_connected_space_iff_connected_subsets,
+  intros x U hUx,
+  rcases (locally_convex_space_iff_exists_convex_subset ℝ E).mp infer_instance _ _ hUx with
+    ⟨V, hVx, hV, hVU⟩,
+  exact ⟨V, hVx, hV.is_preconnected, hVU⟩
+end
+
 end module
 
 section lattice_ops

--- a/src/topology/algebra/module/locally_convex.lean
+++ b/src/topology/algebra/module/locally_convex.lean
@@ -43,7 +43,7 @@ class locally_convex_space (𝕜 E : Type*) [ordered_semiring 𝕜] [add_comm_mo
 variables (𝕜 E : Type*) [ordered_semiring 𝕜] [add_comm_monoid E] [module 𝕜 E] [topological_space E]
 
 lemma locally_convex_space_iff :
-  locally_convex_space 𝕜 E ↔
+  locally_convex_space 𝕜 E ↔S
   ∀ x : E, (𝓝 x).has_basis (λ (s : set E), s ∈ 𝓝 x ∧ convex 𝕜 s) id :=
 ⟨@locally_convex_space.convex_basis _ _ _ _ _ _, locally_convex_space.mk⟩
 

--- a/src/topology/algebra/module/locally_convex.lean
+++ b/src/topology/algebra/module/locally_convex.lean
@@ -43,7 +43,7 @@ class locally_convex_space (𝕜 E : Type*) [ordered_semiring 𝕜] [add_comm_mo
 variables (𝕜 E : Type*) [ordered_semiring 𝕜] [add_comm_monoid E] [module 𝕜 E] [topological_space E]
 
 lemma locally_convex_space_iff :
-  locally_convex_space 𝕜 E ↔S
+  locally_convex_space 𝕜 E ↔
   ∀ x : E, (𝓝 x).has_basis (λ (s : set E), s ∈ 𝓝 x ∧ convex 𝕜 s) id :=
 ⟨@locally_convex_space.convex_basis _ _ _ _ _ _, locally_convex_space.mk⟩
 
@@ -94,13 +94,9 @@ lemma locally_convex_space_iff_exists_convex_subset_zero :
 instance locally_convex_space.to_locally_connected_space [module ℝ E] [has_continuous_smul ℝ E]
   [locally_convex_space ℝ E] :
   locally_connected_space E :=
-begin
-  rw locally_connected_space_iff_connected_subsets,
-  intros x U hUx,
-  rcases (locally_convex_space_iff_exists_convex_subset ℝ E).mp infer_instance _ _ hUx with
-    ⟨V, hVx, hV, hVU⟩,
-  exact ⟨V, hVx, hV.is_preconnected, hVU⟩
-end
+locally_connected_space_of_connected_bases _ _
+  (λ x, @locally_convex_space.convex_basis ℝ _ _ _ _ _ _ x)
+  (λ x s hs, hs.2.is_preconnected)
 
 end module
 

--- a/src/topology/connected.lean
+++ b/src/topology/connected.lean
@@ -1191,24 +1191,24 @@ begin
 end
 
 lemma locally_connected_space_iff_connected_subsets :
-  locally_connected_space α ↔ ∀ (x : α) (U ∈ 𝓝 x), ∃ V ∈ 𝓝 x, is_connected V ∧ V ⊆ U :=
+  locally_connected_space α ↔ ∀ (x : α) (U ∈ 𝓝 x), ∃ V ∈ 𝓝 x, is_preconnected V ∧ V ⊆ U :=
 begin
   split,
   { rw locally_connected_space_iff_open_connected_subsets,
     intros h x U hxU,
     rcases h x U hxU with ⟨V, hVU, hV₁, hxV, hV₂⟩,
-    exact ⟨V, hV₁.mem_nhds hxV, hV₂, hVU⟩ },
+    exact ⟨V, hV₁.mem_nhds hxV, hV₂.is_preconnected, hVU⟩ },
   { rw locally_connected_space_iff_connected_component_in_open,
     refine λ h U hU x hxU, is_open_iff_mem_nhds.mpr (λ y hy, _),
     rw connected_component_in_eq hy,
     rcases h y U (hU.mem_nhds $ (connected_component_in_subset _ _) hy) with ⟨V, hVy, hV, hVU⟩,
     exact filter.mem_of_superset hVy
-      (hV.is_preconnected.subset_connected_component_in (mem_of_mem_nhds hVy) hVU) }
+      (hV.subset_connected_component_in (mem_of_mem_nhds hVy) hVU) }
 end
 
 lemma locally_connected_space_iff_connected_basis :
   locally_connected_space α ↔
-  ∀ x, (𝓝 x).has_basis (λ s : set α, s ∈ 𝓝 x ∧ is_connected s) id :=
+  ∀ x, (𝓝 x).has_basis (λ s : set α, s ∈ 𝓝 x ∧ is_preconnected s) id :=
 begin
   rw locally_connected_space_iff_connected_subsets,
   congrm ∀ x, (_ : Prop),

--- a/src/topology/connected.lean
+++ b/src/topology/connected.lean
@@ -1126,8 +1126,10 @@ end preconnected
 
 section locally_connected_space
 
-/-- A locally connected space is a space where every neighborhood filter has a basis of *open*
-connected sets. -/
+/-- A topological space is **locally connected** if each neighborhood filter admits a basis
+of connected *open* sets. Note that it is equivalent to each point having a basis of connected
+(non necessarily open) sets but in a non-trivial way, so we choose this definition and prove the
+equivalence later in `locally_connected_space_iff_connected_basis`. -/
 class locally_connected_space (α : Type*) [topological_space α] : Prop :=
 (open_connected_basis : ∀ x, (𝓝 x).has_basis (λ s : set α, is_open s ∧ x ∈ s ∧ is_connected s) id)
 
@@ -1217,6 +1219,18 @@ begin
   rw locally_connected_space_iff_connected_subsets,
   congrm ∀ x, (_ : Prop),
   exact filter.has_basis_self.symm
+end
+
+lemma locally_connected_space_of_connected_bases {ι : Type*} (b : α → ι → set α) (p : α → ι → Prop)
+  (hbasis : ∀ x, (𝓝 x).has_basis (p x) (b x))
+  (hconnected : ∀ x i, p x i → is_preconnected (b x i)) :
+  locally_connected_space α :=
+begin
+  rw locally_connected_space_iff_connected_basis,
+  exact λ x, (hbasis x).to_has_basis
+    (λ i hi, ⟨b x i, ⟨(hbasis x).mem_of_mem hi, hconnected x i hi⟩, subset_rfl⟩)
+    (λ s hs, ⟨(hbasis x).index s hs.1,
+      ⟨(hbasis x).property_index hs.1, (hbasis x).set_index_subset hs.1⟩⟩)
 end
 
 end locally_connected_space

--- a/src/topology/connected.lean
+++ b/src/topology/connected.lean
@@ -1175,6 +1175,10 @@ begin
   exact is_open_univ.connected_component_in
 end
 
+lemma is_clopen_connected_component [locally_connected_space α] {x : α} :
+  is_clopen (connected_component x) :=
+⟨is_open_connected_component, is_closed_connected_component⟩
+
 lemma locally_connected_space_iff_connected_component_in_open :
   locally_connected_space α ↔ ∀ F : set α, is_open F → ∀ x ∈ F,
   is_open (connected_component_in F x) :=

--- a/src/topology/locally_constant/basic.lean
+++ b/src/topology/locally_constant/basic.lean
@@ -185,6 +185,16 @@ begin
   apply h,
 end
 
+lemma of_constant_on_preconnected_clopens [locally_connected_space X] {f : X → Y}
+  (h : ∀ U : set X, is_preconnected U → is_clopen U → ∀ x ∈ U, ∀ y ∈ U, f x = f y) :
+  is_locally_constant f :=
+begin
+  rw iff_exists_open,
+  exact λ x, ⟨connected_component x, is_open_connected_component, mem_connected_component,
+    λ y hy, (h (connected_component x) is_preconnected_connected_component
+    is_clopen_connected_component x mem_connected_component y hy).symm⟩,
+end
+
 end is_locally_constant
 
 /-- A (bundled) locally constant function from a topological space `X` to a type `Y`. -/

--- a/src/topology/locally_constant/basic.lean
+++ b/src/topology/locally_constant/basic.lean
@@ -185,15 +185,19 @@ begin
   apply h,
 end
 
-lemma of_constant_on_preconnected_clopens [locally_connected_space X] {f : X → Y}
-  (h : ∀ U : set X, is_preconnected U → is_clopen U → ∀ x ∈ U, ∀ y ∈ U, f x = f y) :
+lemma of_constant_on_connected_components [locally_connected_space X] {f : X → Y}
+  (h : ∀ x, ∀ y ∈ connected_component x, f y = f x) :
   is_locally_constant f :=
 begin
   rw iff_exists_open,
-  exact λ x, ⟨connected_component x, is_open_connected_component, mem_connected_component,
-    λ y hy, (h (connected_component x) is_preconnected_connected_component
-    is_clopen_connected_component x mem_connected_component y hy).symm⟩,
+  exact λ x, ⟨connected_component x, is_open_connected_component, mem_connected_component, h x⟩,
 end
+
+lemma of_constant_on_preconnected_clopens [locally_connected_space X] {f : X → Y}
+  (h : ∀ U : set X, is_preconnected U → is_clopen U → ∀ x ∈ U, ∀ y ∈ U, f y = f x) :
+  is_locally_constant f :=
+of_constant_on_connected_components (λ x, h (connected_component x)
+  is_preconnected_connected_component is_clopen_connected_component x mem_connected_component)
 
 end is_locally_constant
 


### PR DESCRIPTION
This was introduced in the [Sphere Eversion Project](https://github.com/leanprover-community/sphere-eversion/blob/333231d77aa028bb164abc695ac8a4abce4af0c2/src/to_mathlib/topology/misc.lean#L444); I added a clean API, proved the equivalence with "weak local connectedness" (where we don't require the bases to be made of open sets), generalized [local connectedness of normed spaces](https://github.com/leanprover-community/sphere-eversion/blob/333231d77aa028bb164abc695ac8a4abce4af0c2/src/to_mathlib/topology/misc.lean#L504) to local connectedness of locally convex spaces, and proved the lemmas @hrmacbeth asked for on [Zulip](https://leanprover.zulipchat.com/#narrow/stream/116395-maths/topic/Missing.20facts.20about.20.60locally_constant.60/near/290704266).

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

- [x] depends on: #15964 

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
