### PR TITLE
[Merged by Bors] - feat(analysis/special_functions/trigonometric/angle): signs of angles

### DIFF
--- a/src/analysis/special_functions/trigonometric/angle.lean
+++ b/src/analysis/special_functions/trigonometric/angle.lean
@@ -282,7 +282,7 @@ by rw [sign, sin_zero, sign_zero]
 @[simp] lemma sign_coe_pi : (π : angle).sign = 0 :=
 by rw [sign, sin_coe_pi, _root_.sign_zero]
 
-@[simp] lemma sign_neg (θ : angle) : (-θ).sign = -(θ.sign) :=
+@[simp] lemma sign_neg (θ : angle) : (-θ).sign = - θ.sign :=
 by simp_rw [sign, sin_neg, left.sign_neg]
 
 lemma sign_antiperiodic : function.antiperiodic sign (π : angle) :=

--- a/src/analysis/special_functions/trigonometric/angle.lean
+++ b/src/analysis/special_functions/trigonometric/angle.lean
@@ -274,10 +274,10 @@ cos_antiperiodic.sub_eq θ
 /-- The sign of a `real.angle` is `0` if the angle is `0` or `π`, `1` if the angle is strictly
 between `0` and `π` and `-1` is the angle is strictly between `-π` and `0`. It is defined as the
 sign of the sine of the angle. -/
-def sign (θ : angle) : sign_type := _root_.sign (sin θ)
+def sign (θ : angle) : sign_type := sign (sin θ)
 
 @[simp] lemma sign_zero : (0 : angle).sign = 0 :=
-by rw [sign, sin_zero, _root_.sign_zero]
+by rw [sign, sin_zero, sign_zero]
 
 @[simp] lemma sign_coe_pi : (π : angle).sign = 0 :=
 by rw [sign, sin_coe_pi, _root_.sign_zero]
@@ -304,7 +304,7 @@ sign_antiperiodic.sub_eq θ
 by simp [sign_antiperiodic.sub_eq']
 
 lemma sign_eq_zero_iff {θ : angle} : θ.sign = 0 ↔ θ = 0 ∨ θ = π :=
-by rw [sign, _root_.sign_eq_zero_iff, sin_eq_zero_iff]
+by rw [sign, sign_eq_zero_iff, sin_eq_zero_iff]
 
 end angle
 

--- a/src/analysis/special_functions/trigonometric/angle.lean
+++ b/src/analysis/special_functions/trigonometric/angle.lean
@@ -286,10 +286,7 @@ by rw [sign, sin_coe_pi, _root_.sign_zero]
 by simp_rw [sign, sin_neg, left.sign_neg]
 
 lemma sign_antiperiodic : function.antiperiodic sign (π : angle) :=
-begin
-  intro θ,
-  rw [sign, sign, sin_add_pi, left.sign_neg]
-end
+λ θ, by rw [sign, sign, sin_add_pi, left.sign_neg]
 
 @[simp] lemma sign_add_pi (θ : angle) : (θ + π).sign = -θ.sign :=
 sign_antiperiodic θ

--- a/src/analysis/special_functions/trigonometric/angle.lean
+++ b/src/analysis/special_functions/trigonometric/angle.lean
@@ -5,6 +5,7 @@ Authors: Calle Sönne
 -/
 import analysis.special_functions.trigonometric.basic
 import algebra.char_zero.quotient
+import data.sign
 
 /-!
 # The type of angles
@@ -269,6 +270,41 @@ cos_antiperiodic θ
 
 @[simp] lemma cos_sub_pi (θ : angle) : cos (θ - π) = -cos θ :=
 cos_antiperiodic.sub_eq θ
+
+/-- The sign of a `real.angle` is `0` if the angle is `0` or `π`, `1` if the angle is strictly
+between `0` and `π` and `-1` is the angle is strictly between `-π` and `0`. It is defined as the
+sign of the sine of the angle. -/
+def sign (θ : angle) : sign_type := _root_.sign (sin θ)
+
+@[simp] lemma sign_zero : (0 : angle).sign = 0 :=
+by rw [sign, sin_zero, _root_.sign_zero]
+
+@[simp] lemma sign_coe_pi : (π : angle).sign = 0 :=
+by rw [sign, sin_coe_pi, _root_.sign_zero]
+
+@[simp] lemma sign_neg (θ : angle) : (-θ).sign = -(θ.sign) :=
+by simp_rw [sign, sin_neg, left.sign_neg]
+
+lemma sign_antiperiodic : function.antiperiodic sign (π : angle) :=
+begin
+  intro θ,
+  rw [sign, sign, sin_add_pi, left.sign_neg]
+end
+
+@[simp] lemma sign_add_pi (θ : angle) : (θ + π).sign = -θ.sign :=
+sign_antiperiodic θ
+
+@[simp] lemma sign_pi_add (θ : angle) : ((π : angle) + θ).sign = -θ.sign :=
+by rw [add_comm, sign_add_pi]
+
+@[simp] lemma sign_sub_pi (θ : angle) : (θ - π).sign = -θ.sign :=
+sign_antiperiodic.sub_eq θ
+
+@[simp] lemma sign_pi_sub (θ : angle) : ((π : angle) - θ).sign = θ.sign :=
+by simp [sign_antiperiodic.sub_eq']
+
+lemma sign_eq_zero_iff {θ : angle} : θ.sign = 0 ↔ θ = 0 ∨ θ = π :=
+by rw [sign, _root_.sign_eq_zero_iff, sin_eq_zero_iff]
 
 end angle
 

--- a/src/linear_algebra/quadratic_form/real.lean
+++ b/src/linear_algebra/quadratic_form/real.lean
@@ -55,7 +55,7 @@ begin
   erw [hsum],
   simp only [u, function.comp, smul_eq_mul],
   split_ifs,
-  { simp only [h, zero_smul, zero_mul, sign_zero] },
+  { simp only [h, zero_smul, zero_mul, real.sign_zero] },
   have hwu : w j = u j,
   { simp only [u, dif_neg h, units.coe_mk0] },
   simp only [hwu, units.coe_mk0],


### PR DESCRIPTION
Add a definition of `real.angle.sign` and some associated basic
lemmas.  This is intended for use in relating oriented and unoriented
angles in Euclidean geometry (if the signs of two oriented angles
between nonzero vectors are equal, then those angles are equal if and
only if the corresponding unoriented angles are equal, and lots of
lemmas can be stated of the form "these two angles have the same sign"
or "these two angles have opposite signs").

---

More lemmas will follow; the ones in this PR are just the ones that
don't depend on anything else not yet in mathlib.



---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
