### PR TITLE
[Merged by Bors] - chore(topology/algebra/uniform_mul_action): the action of a ring on itself is uniformly continuous

### DIFF
--- a/src/analysis/specific_limits/normed.lean
+++ b/src/analysis/specific_limits/normed.lean
@@ -561,7 +561,7 @@ begin
   apply (cauchy_seq_range_of_norm_bounded _ _ (_ : ∀ n, _ ≤ b * |f(n+1) - f(n)|)).neg,
   { exact normed_uniform_group },
   { simp_rw [abs_of_nonneg (sub_nonneg_of_le (hfa (nat.le_succ _))), ← mul_sum],
-    apply real.uniform_continuous_mul_const.comp_cauchy_seq,
+    apply real.uniform_continuous_const_mul.comp_cauchy_seq,
     simp_rw [sum_range_sub, sub_eq_add_neg],
     exact (tendsto.cauchy_seq hf0).add_const },
   { intro n,

--- a/src/topology/algebra/uniform_mul_action.lean
+++ b/src/topology/algebra/uniform_mul_action.lean
@@ -47,6 +47,25 @@ instance add_group.has_uniform_continuous_const_smul_int [add_group X] [uniform_
   has_uniform_continuous_const_smul ℤ X :=
 ⟨uniform_continuous_const_zsmul⟩
 
+/-- A `distrib_mul_action` that is continuous on a uniform group is uniformly continuous.
+This can't be an instance due to it forming a loop with
+`has_uniform_continuous_const_smul.to_has_continuous_const_smul` -/
+lemma has_uniform_continuous_const_smul_of_continuous_const_smul [monoid R] [add_comm_group M]
+  [distrib_mul_action R M] [uniform_space M] [uniform_add_group M] [has_continuous_const_smul R M] :
+  has_uniform_continuous_const_smul R M :=
+⟨λ r, uniform_continuous_of_continuous_at_zero (distrib_mul_action.to_add_monoid_hom M r)
+  (continuous.continuous_at (continuous_const_smul r))⟩
+
+/-- The action of `semiring.to_module` is uniformly continuous. -/
+instance ring.has_uniform_continuous_const_smul [ring R] [uniform_space R]
+  [uniform_add_group R] [has_continuous_mul R] : has_uniform_continuous_const_smul R R :=
+has_uniform_continuous_const_smul_of_continuous_const_smul _ _
+
+/-- The action of `semiring.to_opposite_module` is uniformly continuous. -/
+instance ring.has_uniform_continuous_const_op_smul [ring R] [uniform_space R]
+  [uniform_add_group R] [has_continuous_mul R] : has_uniform_continuous_const_smul Rᵐᵒᵖ R :=
+has_uniform_continuous_const_smul_of_continuous_const_smul _ _
+
 section has_smul
 
 variable [has_smul M X]

--- a/src/topology/instances/real.lean
+++ b/src/topology/instances/real.lean
@@ -5,6 +5,7 @@ Authors: Johannes Hölzl, Mario Carneiro
 -/
 import topology.metric_space.basic
 import topology.algebra.uniform_group
+import topology.algebra.uniform_mul_action
 import topology.algebra.ring
 import topology.algebra.star
 import ring_theory.subring.basic
@@ -101,14 +102,8 @@ lemma real.continuous.inv [topological_space α] {f : α → ℝ} (h : ∀a, f a
 show continuous ((has_inv.inv ∘ @subtype.val ℝ (λr, r ≠ 0)) ∘ λa, ⟨f a, h a⟩),
   from real.continuous_inv.comp (continuous_subtype_mk _ hf)
 
-lemma real.uniform_continuous_mul_const {x : ℝ} : uniform_continuous ((*) x) :=
-metric.uniform_continuous_iff.2 $ λ ε ε0, begin
-  cases exists_gt (|x|) with y xy,
-  have y0 := lt_of_le_of_lt (abs_nonneg _) xy,
-  refine ⟨_, div_pos ε0 y0, λ a b h, _⟩,
-  rw [real.dist_eq, ← mul_sub, abs_mul, ← mul_div_cancel' ε (ne_of_gt y0)],
-  exact mul_lt_mul' (le_of_lt xy) h (abs_nonneg _) y0
-end
+lemma real.uniform_continuous_const_mul {x : ℝ} : uniform_continuous ((*) x) :=
+uniform_continuous_const_smul x
 
 lemma real.uniform_continuous_mul (s : set (ℝ × ℝ))
   {r₁ r₂ : ℝ} (H : ∀ x ∈ s, |(x : ℝ × ℝ).1| < r₁ ∧ |x.2| < r₂) :


### PR DESCRIPTION
This proof can be used to golf the misnamed `real.uniform_continuous_mul_const` which is now called `real.uniform_continuous_const_mul`.

Co-authored-by: Maria Ines de Frutos Fernandez <mariaines.dff@gmail.com>



---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

In the long run a nicer way to handle this might be to split out a `has_uniform_continuous_mul` from `uniform_continuous_group`, which would be more consistent with `has_continuous_mul`.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
