### PR TITLE
[Merged by Bors] - chore(order/conditionally_complete_lattice): `with_top.coe_infi` and `with_top.coe_supr`

### DIFF
--- a/src/order/conditionally_complete_lattice.lean
+++ b/src/order/conditionally_complete_lattice.lean
@@ -64,6 +64,21 @@ theorem with_top.cinfi_empty {α : Type*} [is_empty ι] [has_Inf α] (f : ι →
   (⨅ i, f i) = ⊤ :=
 by rw [infi, range_eq_empty, with_top.cInf_empty]
 
+lemma with_top.coe_Inf' [has_Inf α] {s : set α} (hs : s.nonempty) :
+  ↑(Inf s) = (Inf (coe '' s) : with_top α) :=
+begin
+  obtain ⟨x, hx⟩ := hs,
+  change _ = ite _ _ _,
+  split_ifs,
+  { cases h (mem_image_of_mem _ hx) },
+  { rw preimage_image_eq,
+    exact option.some_injective _ },
+end
+
+@[norm_cast] lemma with_top.coe_infi [nonempty ι] [has_Inf α] (f : ι → α) :
+  ↑(⨅ i, f i) = (⨅ i, f i : with_top α) :=
+by rw [infi, infi, with_top.coe_Inf' (range_nonempty f), range_comp]
+
 @[simp]
 theorem with_bot.cSup_empty {α : Type*} [has_Sup α] : Sup (∅ : set (with_bot α)) = ⊥ :=
 if_pos $ set.empty_subset _
@@ -72,6 +87,14 @@ if_pos $ set.empty_subset _
 theorem with_bot.csupr_empty {α : Type*} [is_empty ι] [has_Sup α] (f : ι → with_bot α) :
   (⨆ i, f i) = ⊥ :=
 by rw [supr, range_eq_empty, with_bot.cSup_empty]
+
+lemma with_bot.coe_Sup' [has_Sup α] {s : set α} (hs : s.nonempty) :
+  ↑(Sup s) = (Sup (coe '' s) : with_bot α) :=
+@with_top.coe_Inf' (αᵒᵈ) _ _ hs
+
+@[norm_cast] lemma with_bot.coe_supr [nonempty ι] [has_Sup α] (f : ι → α) :
+  ↑(⨆ i, f i) = (⨆ i, f i : with_bot α) :=
+@with_top.coe_infi (αᵒᵈ) _ _ _ _
 
 end -- section
 
@@ -855,25 +878,10 @@ begin
   simp_rw [mem_range, supr_exists, @supr_comm _ α, supr_supr_eq_right],
 end
 
+/-- A version of `with-top.coe_Inf'` with a more convenient but less general statement. -/
 @[norm_cast] lemma coe_Inf {s : set α} (hs : s.nonempty) :
   ↑(Inf s) = (⨅ a ∈ s, ↑a : with_top α) :=
-begin
-  obtain ⟨x, hx⟩ := hs,
-  have : (⨅ a ∈ s, ↑a : with_top α) ≤ x := infi₂_le_of_le x hx le_rfl,
-  rcases le_coe_iff.1 this with ⟨r, r_eq, hr⟩,
-  refine le_antisymm
-    (le_infi₂ $ λ a ha, coe_le_coe.2 $ cInf_le (order_bot.bdd_below s) ha) _,
-  { rw r_eq,
-    apply coe_le_coe.2 (le_cInf ⟨x, hx⟩ (λ a has, coe_le_coe.1 _)),
-    rw ←r_eq,
-    exact infi₂_le_of_le a has le_rfl }
-end
-
-@[norm_cast] lemma coe_infi [nonempty ι] (f : ι → α) : ↑(⨅ i, f i) = (⨅ i, f i : with_top α) :=
-begin
-  rw [infi, coe_Inf (range_nonempty f)],
-  simp_rw [mem_range, infi_exists, @infi_comm _ α, infi_infi_eq_right],
-end
+by rw [coe_Inf' hs, Inf_image]
 
 end with_top
 

--- a/src/order/conditionally_complete_lattice.lean
+++ b/src/order/conditionally_complete_lattice.lean
@@ -60,8 +60,18 @@ theorem with_top.cInf_empty {α : Type*} [has_Inf α] : Inf (∅ : set (with_top
 if_pos $ set.empty_subset _
 
 @[simp]
+theorem with_top.cinfi_empty {α : Type*} [is_empty ι] [has_Inf α] (f : ι → with_top α) :
+  (⨅ i, f i) = ⊤ :=
+by rw [infi, range_eq_empty, with_top.cInf_empty]
+
+@[simp]
 theorem with_bot.cSup_empty {α : Type*} [has_Sup α] : Sup (∅ : set (with_bot α)) = ⊥ :=
 if_pos $ set.empty_subset _
+
+@[simp]
+theorem with_bot.csupr_empty {α : Type*} [is_empty ι] [has_Sup α] (f : ι → with_bot α) :
+  (⨆ i, f i) = ⊥ :=
+by rw [supr, range_eq_empty, with_bot.cSup_empty]
 
 end -- section
 

--- a/src/order/conditionally_complete_lattice.lean
+++ b/src/order/conditionally_complete_lattice.lean
@@ -837,6 +837,13 @@ begin
   { exact supr₂_le (λ a ha, coe_le_coe.2 $ le_cSup hb ha) }
 end
 
+lemma coe_supr {ι : Sort*} (f : ι → α) (h : bdd_above (set.range f)) :
+  ↑(⨆ i, f i) = (⨆ i, f i : with_top α) :=
+begin
+  rw [supr, coe_Sup h],
+  simp_rw [mem_range, supr_exists, @supr_comm _ α, supr_supr_eq_right],
+end
+
 lemma coe_Inf {s : set α} (hs : s.nonempty) : (↑(Inf s) : with_top α) = ⨅ a ∈ s, ↑a :=
 begin
   obtain ⟨x, hx⟩ := hs,
@@ -848,6 +855,12 @@ begin
     apply coe_le_coe.2 (le_cInf ⟨x, hx⟩ (λ a has, coe_le_coe.1 _)),
     rw ←r_eq,
     exact infi₂_le_of_le a has le_rfl }
+end
+
+lemma coe_infi {ι : Sort*} [nonempty ι] (f : ι → α) : ↑(⨅ i, f i) = (⨅ i, f i : with_top α) :=
+begin
+  rw [infi, coe_Inf (range_nonempty f)],
+  simp_rw [mem_range, infi_exists, @infi_comm _ α, infi_infi_eq_right],
 end
 
 end with_top

--- a/src/order/conditionally_complete_lattice.lean
+++ b/src/order/conditionally_complete_lattice.lean
@@ -883,12 +883,12 @@ noncomputable instance : complete_linear_order (with_top α) :=
   Inf := Inf, le_Inf := λ s, (is_glb_Inf s).2, Inf_le := λ s, (is_glb_Inf s).1,
   .. with_top.linear_order, ..with_top.lattice, ..with_top.order_top, ..with_top.order_bot }
 
-/-- A version of `with-top.coe_Sup'` with a more convenient but less general statement. -/
+/-- A version of `with_top.coe_Sup'` with a more convenient but less general statement. -/
 @[norm_cast] lemma coe_Sup {s : set α} (hb : bdd_above s) :
   ↑(Sup s) = (⨆ a ∈ s, ↑a : with_top α) :=
 by rw [coe_Sup' hb, Sup_image]
 
-/-- A version of `with-top.coe_Inf'` with a more convenient but less general statement. -/
+/-- A version of `with_top.coe_Inf'` with a more convenient but less general statement. -/
 @[norm_cast] lemma coe_Inf {s : set α} (hs : s.nonempty) :
   ↑(Inf s) = (⨅ a ∈ s, ↑a : with_top α) :=
 by rw [coe_Inf' hs, Inf_image]

--- a/src/order/conditionally_complete_lattice.lean
+++ b/src/order/conditionally_complete_lattice.lean
@@ -79,6 +79,20 @@ end
   ↑(⨅ i, f i) = (⨅ i, f i : with_top α) :=
 by rw [infi, infi, with_top.coe_Inf' (range_nonempty f), range_comp]
 
+theorem with_top.coe_Sup' [preorder α] [has_Sup α] {s : set α} (hs : bdd_above s) :
+  ↑(Sup s) = (Sup (coe '' s) : with_top α) :=
+begin
+  change _ = ite _ _ _,
+  rw [if_neg, preimage_image_eq, if_pos hs],
+  { exact option.some_injective _ },
+  { rintro ⟨x, h, ⟨⟩⟩ },
+end
+
+@[norm_cast] lemma with_top.coe_supr [preorder α] [has_Sup α] (f : ι → α)
+  (h : bdd_above (set.range f)) :
+  ↑(⨆ i, f i) = (⨆ i, f i : with_top α) :=
+by rw [supr, supr, with_top.coe_Sup' h, range_comp]
+
 @[simp]
 theorem with_bot.cSup_empty {α : Type*} [has_Sup α] : Sup (∅ : set (with_bot α)) = ⊥ :=
 if_pos $ set.empty_subset _
@@ -86,15 +100,24 @@ if_pos $ set.empty_subset _
 @[simp]
 theorem with_bot.csupr_empty {α : Type*} [is_empty ι] [has_Sup α] (f : ι → with_bot α) :
   (⨆ i, f i) = ⊥ :=
-by rw [supr, range_eq_empty, with_bot.cSup_empty]
+@with_top.cinfi_empty _ αᵒᵈ _ _ _
 
-lemma with_bot.coe_Sup' [has_Sup α] {s : set α} (hs : s.nonempty) :
+@[norm_cast] lemma with_bot.coe_Sup' [has_Sup α] {s : set α} (hs : s.nonempty) :
   ↑(Sup s) = (Sup (coe '' s) : with_bot α) :=
-@with_top.coe_Inf' (αᵒᵈ) _ _ hs
+@with_top.coe_Inf' αᵒᵈ _ _ hs
 
 @[norm_cast] lemma with_bot.coe_supr [nonempty ι] [has_Sup α] (f : ι → α) :
   ↑(⨆ i, f i) = (⨆ i, f i : with_bot α) :=
-@with_top.coe_infi (αᵒᵈ) _ _ _ _
+@with_top.coe_infi αᵒᵈ _ _ _ _
+
+@[norm_cast] theorem with_bot.coe_Inf' [preorder α] [has_Inf α] {s : set α} (hs : bdd_below s) :
+  ↑(Inf s) = (Inf (coe '' s) : with_bot α) :=
+@with_top.coe_Sup' αᵒᵈ _ _ _ hs
+
+@[norm_cast] lemma with_bot.coe_infi [preorder α] [has_Inf α] (f : ι → α)
+  (h : bdd_below (set.range f)) :
+  ↑(⨅ i, f i) = (⨅ i, f i : with_bot α) :=
+@with_top.coe_supr αᵒᵈ _ _ _ _ h
 
 end -- section
 
@@ -860,23 +883,10 @@ noncomputable instance : complete_linear_order (with_top α) :=
   Inf := Inf, le_Inf := λ s, (is_glb_Inf s).2, Inf_le := λ s, (is_glb_Inf s).1,
   .. with_top.linear_order, ..with_top.lattice, ..with_top.order_top, ..with_top.order_bot }
 
+/-- A version of `with-top.coe_Sup'` with a more convenient but less general statement. -/
 @[norm_cast] lemma coe_Sup {s : set α} (hb : bdd_above s) :
   ↑(Sup s) = (⨆ a ∈ s, ↑a : with_top α) :=
-begin
-  cases s.eq_empty_or_nonempty with hs hs,
-  { rw [hs, cSup_empty], simp only [set.mem_empty_eq, supr_bot, supr_false], refl },
-  apply le_antisymm,
-  { refine (coe_le_iff.2 $ λ b hb, cSup_le hs $ λ a has, coe_le_coe.1 $ hb ▸ _),
-    exact le_supr₂_of_le a has le_rfl },
-  { exact supr₂_le (λ a ha, coe_le_coe.2 $ le_cSup hb ha) }
-end
-
-@[norm_cast] lemma coe_supr (f : ι → α) (h : bdd_above (set.range f)) :
-  ↑(⨆ i, f i) = (⨆ i, f i : with_top α) :=
-begin
-  rw [supr, coe_Sup h],
-  simp_rw [mem_range, supr_exists, @supr_comm _ α, supr_supr_eq_right],
-end
+by rw [coe_Sup' hb, Sup_image]
 
 /-- A version of `with-top.coe_Inf'` with a more convenient but less general statement. -/
 @[norm_cast] lemma coe_Inf {s : set α} (hs : s.nonempty) :

--- a/src/order/conditionally_complete_lattice.lean
+++ b/src/order/conditionally_complete_lattice.lean
@@ -837,7 +837,8 @@ noncomputable instance : complete_linear_order (with_top α) :=
   Inf := Inf, le_Inf := λ s, (is_glb_Inf s).2, Inf_le := λ s, (is_glb_Inf s).1,
   .. with_top.linear_order, ..with_top.lattice, ..with_top.order_top, ..with_top.order_bot }
 
-lemma coe_Sup {s : set α} (hb : bdd_above s) : (↑(Sup s) : with_top α) = ⨆ a ∈ s, ↑a :=
+@[norm_cast] lemma coe_Sup {s : set α} (hb : bdd_above s) :
+  ↑(Sup s) = (⨆ a ∈ s, ↑a : with_top α) :=
 begin
   cases s.eq_empty_or_nonempty with hs hs,
   { rw [hs, cSup_empty], simp only [set.mem_empty_eq, supr_bot, supr_false], refl },
@@ -847,14 +848,15 @@ begin
   { exact supr₂_le (λ a ha, coe_le_coe.2 $ le_cSup hb ha) }
 end
 
-lemma coe_supr {ι : Sort*} (f : ι → α) (h : bdd_above (set.range f)) :
+@[norm_cast] lemma coe_supr (f : ι → α) (h : bdd_above (set.range f)) :
   ↑(⨆ i, f i) = (⨆ i, f i : with_top α) :=
 begin
   rw [supr, coe_Sup h],
   simp_rw [mem_range, supr_exists, @supr_comm _ α, supr_supr_eq_right],
 end
 
-lemma coe_Inf {s : set α} (hs : s.nonempty) : (↑(Inf s) : with_top α) = ⨅ a ∈ s, ↑a :=
+@[norm_cast] lemma coe_Inf {s : set α} (hs : s.nonempty) :
+  ↑(Inf s) = (⨅ a ∈ s, ↑a : with_top α) :=
 begin
   obtain ⟨x, hx⟩ := hs,
   have : (⨅ a ∈ s, ↑a : with_top α) ≤ x := infi₂_le_of_le x hx le_rfl,
@@ -867,7 +869,7 @@ begin
     exact infi₂_le_of_le a has le_rfl }
 end
 
-lemma coe_infi {ι : Sort*} [nonempty ι] (f : ι → α) : ↑(⨅ i, f i) = (⨅ i, f i : with_top α) :=
+@[norm_cast] lemma coe_infi [nonempty ι] (f : ι → α) : ↑(⨅ i, f i) = (⨅ i, f i : with_top α) :=
 begin
   rw [infi, coe_Inf (range_nonempty f)],
   simp_rw [mem_range, infi_exists, @infi_comm _ α, infi_infi_eq_right],


### PR DESCRIPTION
This adds `infi` and `supr` versions of the existing `Inf` and `Sup` lemmas, and adds some more general primed lemmas that work when much weaker assumptions are available on `α`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
