### PR TITLE
[Merged by Bors] - feat(analysis/normed_space/basic): change `homeomorph_unit_ball` to make it obviously smooth

### DIFF
--- a/src/analysis/inner_product_space/calculus.lean
+++ b/src/analysis/inner_product_space/calculus.lean
@@ -334,11 +334,40 @@ end
 
 end pi_like
 
-lemma cont_diff_homeomorph_unit_ball {n : with_top ℕ} {E : Type*} [inner_product_space ℝ E] :
-  cont_diff ℝ n ((coe : metric.ball (0 : E) 1 → E) ∘ homeomorph_unit_ball) :=
+section diffeomorph_unit_ball
+
+open metric (hiding mem_nhds_iff)
+
+variables {n : with_top ℕ} {E : Type*} [inner_product_space ℝ E]
+
+lemma cont_diff_homeomorph_unit_ball :
+  cont_diff ℝ n $ λ (x : E), (homeomorph_unit_ball x : E) :=
 begin
   suffices : cont_diff ℝ n (λ x, (1 + ∥x∥^2).sqrt⁻¹), { exact this.smul cont_diff_id, },
   have h : ∀ (x : E), 0 < 1 + ∥x∥ ^ 2 := λ x, by linarith [sq_nonneg (∥x∥)],
   refine cont_diff.inv _ (λ x, real.sqrt_ne_zero'.mpr (h x)),
   exact (cont_diff_const.add cont_diff_norm_sq).sqrt (λ x, (h x).ne.symm),
 end
+
+lemma cont_diff_homeomorph_unit_ball_symm
+  {f : E → E} (h : ∀ y (hy : y ∈ ball (0 : E) 1), f y = homeomorph_unit_ball.symm ⟨y, hy⟩) :
+  cont_diff_on ℝ n f $ ball 0 1 :=
+begin
+  intros y hy,
+  apply cont_diff_at.cont_diff_within_at,
+  have hf : f =ᶠ[𝓝 y] λ y, (1 - ∥(y : E)∥^2).sqrt⁻¹ • (y : E),
+  { rw eventually_eq_iff_exists_mem,
+    refine ⟨ball (0 : E) 1, mem_nhds_iff.mpr ⟨ball (0 : E) 1, set.subset.refl _, is_open_ball, hy⟩,
+      λ z hz, _⟩,
+    rw h z hz,
+    refl, },
+  refine cont_diff_at.congr_of_eventually_eq _ hf,
+  suffices : cont_diff_at ℝ n (λy, (1 - ∥(y : E)∥^2).sqrt⁻¹) y, { exact this.smul cont_diff_at_id },
+  have h : 0 < 1 - ∥(y : E)∥^2, by rwa [mem_ball_zero_iff, ← _root_.abs_one, ← abs_norm_eq_norm,
+    ← sq_lt_sq, one_pow, ← sub_pos] at hy,
+  refine cont_diff_at.inv _ (real.sqrt_ne_zero'.mpr h),
+  refine cont_diff_at.comp _ (cont_diff_at_sqrt h.ne.symm) _,
+  exact cont_diff_at_const.sub cont_diff_norm_sq.cont_diff_at,
+end
+
+end diffeomorph_unit_ball

--- a/src/analysis/inner_product_space/calculus.lean
+++ b/src/analysis/inner_product_space/calculus.lean
@@ -349,7 +349,7 @@ begin
   exact (cont_diff_const.add cont_diff_norm_sq).sqrt (λ x, (h x).ne.symm),
 end
 
-lemma cont_diff_homeomorph_unit_ball_symm
+lemma cont_diff_on_homeomorph_unit_ball_symm
   {f : E → E} (h : ∀ y (hy : y ∈ ball (0 : E) 1), f y = homeomorph_unit_ball.symm ⟨y, hy⟩) :
   cont_diff_on ℝ n f $ ball 0 1 :=
 begin

--- a/src/analysis/inner_product_space/calculus.lean
+++ b/src/analysis/inner_product_space/calculus.lean
@@ -333,3 +333,12 @@ begin
 end
 
 end pi_like
+
+lemma cont_diff_homeomorph_unit_ball {n : with_top ℕ} {E : Type*} [inner_product_space ℝ E] :
+  cont_diff ℝ n ((coe : metric.ball (0 : E) 1 → E) ∘ homeomorph_unit_ball) :=
+begin
+  suffices : cont_diff ℝ n (λ x, (1 + ∥x∥^2).sqrt⁻¹), { exact this.smul cont_diff_id, },
+  have h : ∀ (x : E), 0 < 1 + ∥x∥ ^ 2 := λ x, by linarith [sq_nonneg (∥x∥)],
+  refine cont_diff.inv _ (λ x, real.sqrt_ne_zero'.mpr (h x)),
+  exact (cont_diff_const.add cont_diff_norm_sq).sqrt (λ x, (h x).ne.symm),
+end

--- a/src/analysis/inner_product_space/calculus.lean
+++ b/src/analysis/inner_product_space/calculus.lean
@@ -344,7 +344,7 @@ lemma cont_diff_homeomorph_unit_ball :
   cont_diff ℝ n $ λ (x : E), (homeomorph_unit_ball x : E) :=
 begin
   suffices : cont_diff ℝ n (λ x, (1 + ∥x∥^2).sqrt⁻¹), { exact this.smul cont_diff_id, },
-  have h : ∀ (x : E), 0 < 1 + ∥x∥ ^ 2 := λ x, by linarith [sq_nonneg (∥x∥)],
+  have h : ∀ (x : E), 0 < 1 + ∥x∥ ^ 2 := λ x, by positivity,
   refine cont_diff.inv _ (λ x, real.sqrt_ne_zero'.mpr (h x)),
   exact (cont_diff_const.add cont_diff_norm_sq).sqrt (λ x, (h x).ne.symm),
 end

--- a/src/analysis/normed_space/basic.lean
+++ b/src/analysis/normed_space/basic.lean
@@ -170,7 +170,7 @@ smoothness properties that hold when `E` is an inner-product space. -/
 def homeomorph_unit_ball [normed_space ℝ E] :
   E ≃ₜ ball (0 : E) 1 :=
 { to_fun := λ x, ⟨(1 + ∥x∥^2).sqrt⁻¹ • x, begin
-    have : 0 < 1 + ∥x∥ ^ 2 := by linarith [sq_nonneg (∥x∥)],
+    have : 0 < 1 + ∥x∥ ^ 2, by positivity,
     rw [mem_ball_zero_iff, norm_smul, real.norm_eq_abs, abs_inv, ← div_eq_inv_mul,
       div_lt_one (abs_pos.mpr $ real.sqrt_ne_zero'.mpr this), ← abs_norm_eq_norm x, ← sq_lt_sq,
       abs_norm_eq_norm, real.sq_sqrt this.le],
@@ -179,7 +179,7 @@ def homeomorph_unit_ball [normed_space ℝ E] :
   inv_fun := λ y, (1 - ∥(y : E)∥^2).sqrt⁻¹ • (y : E),
   left_inv := λ x,
   begin
-    have : 0 < 1 + ∥x∥ ^ 2 := by linarith [sq_nonneg (∥x∥)],
+    have : 0 < 1 + ∥x∥ ^ 2, by positivity,
     field_simp [norm_smul, smul_smul, this.ne', real.sq_sqrt this.le, ← real.sqrt_div this.le],
   end,
   right_inv := λ y,
@@ -191,8 +191,7 @@ def homeomorph_unit_ball [normed_space ℝ E] :
   continuous_to_fun := continuous_subtype_mk _ $
   begin
     suffices : continuous (λ x, (1 + ∥x∥^2).sqrt⁻¹), { exact this.smul continuous_id, },
-    have h : ∀ (x : E), 0 < 1 + ∥x∥ ^ 2 := λ x, by linarith [sq_nonneg (∥x∥)],
-    refine continuous.inv₀ _ (λ x, real.sqrt_ne_zero'.mpr (h x)),
+    refine continuous.inv₀ _ (λ x, real.sqrt_ne_zero'.mpr (by positivity)),
     continuity,
   end,
   continuous_inv_fun :=

--- a/src/analysis/normed_space/basic.lean
+++ b/src/analysis/normed_space/basic.lean
@@ -162,7 +162,10 @@ by rw [frontier, closure_closed_ball, interior_closed_ball x hr,
 This homeomorphism sends `x : E` to `(1 + ∥x∥²)^(- ½) • x`.
 
 In many cases the actual implementation is not important, so we don't mark the projection lemmas
-`homeomorph_unit_ball_apply_coe` and `homeomorph_unit_ball_symm_apply` as `@[simp]`. -/
+`homeomorph_unit_ball_apply_coe` and `homeomorph_unit_ball_symm_apply` as `@[simp]`.
+
+See also `cont_diff_homeomorph_unit_ball` and `cont_diff_on_homeomorph_unit_ball_symm` for
+smoothness properties that hold when `E` is an inner-product space. -/
 @[simps { attrs := [] }]
 def homeomorph_unit_ball [normed_space ℝ E] :
   E ≃ₜ ball (0 : E) 1 :=


### PR DESCRIPTION
Formalized as part of the Sphere Eversion project.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
