### PR TITLE
[Merged by Bors] - refactor(topology/constructions): review `quotient` API

### DIFF
--- a/src/analysis/special_functions/trigonometric/angle.lean
+++ b/src/analysis/special_functions/trigonometric/angle.lean
@@ -177,7 +177,7 @@ def sin (θ : angle) : ℝ := sin_periodic.lift θ
 rfl
 
 @[continuity] lemma continuous_sin : continuous sin :=
-continuous_quotient_lift_on' _ real.continuous_sin
+real.continuous_sin.quotient_lift_on' _
 
 /-- The cosine of a `real.angle`. -/
 def cos (θ : angle) : ℝ := cos_periodic.lift θ
@@ -186,7 +186,7 @@ def cos (θ : angle) : ℝ := cos_periodic.lift θ
 rfl
 
 @[continuity] lemma continuous_cos : continuous cos :=
-continuous_quotient_lift_on' _ real.continuous_cos
+real.continuous_cos.quotient_lift_on' _
 
 lemma cos_eq_real_cos_iff_eq_or_eq_neg {θ : angle} {ψ : ℝ} : cos θ = real.cos ψ ↔ θ = ψ ∨ θ = -ψ :=
 begin

--- a/src/topology/algebra/group.lean
+++ b/src/topology/algebra/group.lean
@@ -1146,8 +1146,8 @@ instance quotient_group.has_continuous_const_smul : has_continuous_const_smul G 
 @[to_additive]
 lemma quotient_group.continuous_smul₁ (x : G ⧸ Γ) : continuous (λ g : G, g • x) :=
 begin
-  rcases quotient_group.mk_surjective x with ⟨g₀, rfl⟩,
-  exact continuous_quotient_mk.comp (continuous_mul_right g₀)
+  induction x using quotient_group.induction_on,
+  exact continuous_quotient_mk.comp (continuous_mul_right x)
 end
 
 @[to_additive]

--- a/src/topology/algebra/group.lean
+++ b/src/topology/algebra/group.lean
@@ -746,11 +746,7 @@ instance topological_group_quotient [N.normal] : topological_group (G ⧸ N) :=
       { exact (surjective_quot_mk _).prod_map (surjective_quot_mk _) } },
     exact (quotient_map.continuous_iff quot).2 cont,
   end,
-  continuous_inv := begin
-    have : continuous ((coe : G → G ⧸ N) ∘ (λ (a : G), a⁻¹)) :=
-      continuous_quot_mk.comp continuous_inv,
-    convert continuous_quotient_lift _ this,
-  end }
+  continuous_inv := by convert (@continuous_inv G _ _ _).quotient_map' _ }
 
 end quotient_topological_group
 
@@ -1144,19 +1140,14 @@ variables [group G] [topological_space G] [topological_group G] {Γ : subgroup G
 
 @[to_additive]
 instance quotient_group.has_continuous_const_smul : has_continuous_const_smul G (G ⧸ Γ) :=
-{ continuous_const_smul := λ g₀, begin
-    apply continuous_coinduced_dom.2,
-    change continuous (λ g : G, quotient_group.mk (g₀ * g)),
-    exact continuous_coinduced_rng.comp (continuous_mul_left g₀),
-  end }
+{ continuous_const_smul := λ g,
+    by convert ((@continuous_const _ _ _ _ g).mul continuous_id).quotient_map' _ }
 
 @[to_additive]
 lemma quotient_group.continuous_smul₁ (x : G ⧸ Γ) : continuous (λ g : G, g • x) :=
 begin
-  obtain ⟨g₀, rfl⟩ : ∃ g₀, quotient_group.mk g₀ = x,
-  { exact @quotient.exists_rep _ (quotient_group.left_rel Γ) x },
-  change continuous (λ g, quotient_group.mk (g * g₀)),
-  exact continuous_coinduced_rng.comp (continuous_mul_right g₀)
+  rcases quotient_group.mk_surjective x with ⟨g₀, rfl⟩,
+  exact continuous_quotient_mk.comp (continuous_mul_right g₀)
 end
 
 @[to_additive]

--- a/src/topology/algebra/monoid.lean
+++ b/src/topology/algebra/monoid.lean
@@ -250,8 +250,12 @@ variables [topological_space M] [monoid M] [has_continuous_mul M]
 @[to_additive]
 lemma submonoid.top_closure_mul_self_subset (s : submonoid M) :
   (closure (s : set M)) * closure (s : set M) ⊆ closure (s : set M) :=
-image2_subset_iff.2 $ λ x hx y hy, map_mem_closure₂ continuous_mul hx hy $
-  λ a ha b hb, s.mul_mem ha hb
+calc
+(closure (s : set M)) * closure (s : set M)
+    = (λ p : M × M, p.1 * p.2) '' (closure ((s : set M) ×ˢ (s : set M))) : by simp [closure_prod_eq]
+... ⊆ closure ((λ p : M × M, p.1 * p.2) '' ((s : set M) ×ˢ (s : set M))) :
+  image_closure_subset_closure_image continuous_mul
+... = closure s : by simp [s.coe_mul_self_eq]
 
 @[to_additive]
 lemma submonoid.top_closure_mul_self_eq (s : submonoid M) :

--- a/src/topology/algebra/monoid.lean
+++ b/src/topology/algebra/monoid.lean
@@ -250,12 +250,8 @@ variables [topological_space M] [monoid M] [has_continuous_mul M]
 @[to_additive]
 lemma submonoid.top_closure_mul_self_subset (s : submonoid M) :
   (closure (s : set M)) * closure (s : set M) ⊆ closure (s : set M) :=
-calc
-(closure (s : set M)) * closure (s : set M)
-    = (λ p : M × M, p.1 * p.2) '' (closure ((s : set M) ×ˢ (s : set M))) : by simp [closure_prod_eq]
-... ⊆ closure ((λ p : M × M, p.1 * p.2) '' ((s : set M) ×ˢ (s : set M))) :
-  image_closure_subset_closure_image continuous_mul
-... = closure s : by simp [s.coe_mul_self_eq]
+image2_subset_iff.2 $ λ x hx y hy, map_mem_closure₂ continuous_mul hx hy $
+  λ a ha b hb, s.mul_mem ha hb
 
 @[to_additive]
 lemma submonoid.top_closure_mul_self_eq (s : submonoid M) :

--- a/src/topology/connected.lean
+++ b/src/topology/connected.lean
@@ -1280,7 +1280,7 @@ def continuous.connected_components_lift (h : continuous f) :
 
 @[continuity] lemma continuous.connected_components_lift_continuous (h : continuous f) :
   continuous h.connected_components_lift :=
-continuous_quotient_lift_on' h.image_eq_of_connected_component_eq h
+h.quotient_lift_on' h.image_eq_of_connected_component_eq
 
 @[simp] lemma continuous.connected_components_lift_apply_coe (h : continuous f) (x : α) :
   h.connected_components_lift x = f x := rfl

--- a/src/topology/constructions.lean
+++ b/src/topology/constructions.lean
@@ -934,7 +934,7 @@ lemma continuous.quotient_lift {f : α → β} (h : continuous f) (hs : ∀ a b,
   continuous (quotient.lift f hs : quotient s → β) :=
 continuous_coinduced_dom.2 h
 
-lemma continuous.quotient_lift_on' {f : α → β} (h : continuous f) (hs : ∀ a b, a ≈ b → f a = f b) :
+lemma continuous.quotient_lift_on' {f : α → β} (h : continuous f) (hs : ∀ a b, s.r a b → f a = f b) :
   continuous (λ x, quotient.lift_on' x f hs : quotient s → β) :=
 h.quotient_lift hs
 

--- a/src/topology/constructions.lean
+++ b/src/topology/constructions.lean
@@ -934,7 +934,8 @@ lemma continuous.quotient_lift {f : α → β} (h : continuous f) (hs : ∀ a b,
   continuous (quotient.lift f hs : quotient s → β) :=
 continuous_coinduced_dom.2 h
 
-lemma continuous.quotient_lift_on' {f : α → β} (h : continuous f) (hs : ∀ a b, s.r a b → f a = f b) :
+lemma continuous.quotient_lift_on' {f : α → β} (h : continuous f)
+  (hs : ∀ a b, @setoid.r _ s a b → f a = f b) :
   continuous (λ x, quotient.lift_on' x f hs : quotient s → β) :=
 h.quotient_lift hs
 

--- a/src/topology/constructions.lean
+++ b/src/topology/constructions.lean
@@ -930,13 +930,17 @@ quotient_map_quot_mk
 lemma continuous_quotient_mk : continuous (@quotient.mk α s) :=
 continuous_coinduced_rng
 
-lemma continuous_quotient_lift {f : α → β} (hs : ∀ a b, a ≈ b → f a = f b)
-  (h : continuous f) : continuous (quotient.lift f hs : quotient s → β) :=
+lemma continuous.quotient_lift {f : α → β} (h : continuous f) (hs : ∀ a b, a ≈ b → f a = f b) :
+  continuous (quotient.lift f hs : quotient s → β) :=
 continuous_coinduced_dom.2 h
 
-lemma continuous_quotient_lift_on' {f : α → β} (hs : ∀ a b, a ≈ b → f a = f b)
-  (h : continuous f) : continuous (λ x, quotient.lift_on' x f hs : quotient s → β) :=
-continuous_coinduced_dom.2 h
+lemma continuous.quotient_lift_on' {f : α → β} (h : continuous f) (hs : ∀ a b, a ≈ b → f a = f b) :
+  continuous (λ x, quotient.lift_on' x f hs : quotient s → β) :=
+h.quotient_lift hs
+
+lemma continuous.quotient_map' {t : setoid β} {f : α → β} (hf : continuous f)
+  (H : (s.r ⇒ t.r) f f) : continuous (quotient.map' f H) :=
+(continuous_quotient_mk.comp hf).quotient_lift _
 
 end quotient
 


### PR DESCRIPTION
* rename `continuous_quotient_lift` to `continuous.quotient_lift`;
* rename `continuous_quotient_lift_on'` to `continuous.quotient_lift_on'`;
* add `continuous.quotient_map'` and use it to golf some proofs.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
