### PR TITLE
[Merged by Bors] - chore(ring_theory/*): make ACC/DCC on rings be defeq to module versions

### DIFF
--- a/src/ring_theory/artinian.lean
+++ b/src/ring_theory/artinian.lean
@@ -321,19 +321,13 @@ end comm_ring
 
 Strictly speaking, this should be called `is_left_artinian_ring` but we omit the `left_` for
 convenience in the commutative case. For a right Artinian ring, use `is_artinian Rᵐᵒᵖ R`. -/
-class is_artinian_ring (R) [ring R] extends is_artinian R R : Prop
-
--- TODO: Can we define `is_artinian_ring` in a different way so this isn't needed?
-@[priority 100]
-instance is_artinian_ring_of_finite (R) [ring R] [finite R] : is_artinian_ring R := ⟨⟩
+@[reducible] def is_artinian_ring (R) [ring R] := is_artinian R R
 
 theorem is_artinian_ring_iff {R} [ring R] : is_artinian_ring R ↔ is_artinian R R :=
-⟨λ h, h.1, @is_artinian_ring.mk _ _⟩
+iff.rfl
 
 theorem ring.is_artinian_of_zero_eq_one {R} [ring R] (h01 : (0 : R) = 1) : is_artinian_ring R :=
-by haveI := subsingleton_of_zero_eq_one h01;
-   haveI := fintype.of_subsingleton (0:R); split;
-  apply_instance
+have _ := subsingleton_of_zero_eq_one h01, by exactI infer_instance
 
 theorem is_artinian_of_submodule_of_artinian (R M) [ring R] [add_comm_group M] [module R M]
   (N : submodule R M) (h : is_artinian R M) : is_artinian R N :=
@@ -359,7 +353,6 @@ let ⟨s, hs⟩ := hN in
 begin
   haveI := classical.dec_eq M,
   haveI := classical.dec_eq R,
-  letI : is_artinian R R := by apply_instance,
   have : ∀ x ∈ s, x ∈ N, from λ x hx, hs ▸ submodule.subset_span hx,
   refine @@is_artinian_of_surjective ((↑s : set M) → R) _ _ _ (pi.module _ _ _)
     _ _ _ is_artinian_pi,

--- a/src/ring_theory/noetherian.lean
+++ b/src/ring_theory/noetherian.lean
@@ -763,10 +763,10 @@ end
 A (semi)ring is Noetherian if it is Noetherian as a module over itself,
 i.e. all its ideals are finitely generated.
 -/
-class is_noetherian_ring (R) [semiring R] extends is_noetherian R R : Prop
+@[reducible] def is_noetherian_ring (R) [semiring R] := is_noetherian R R
 
 theorem is_noetherian_ring_iff {R} [semiring R] : is_noetherian_ring R ↔ is_noetherian R R :=
-⟨λ h, h.1, @is_noetherian_ring.mk _ _⟩
+iff.rfl
 
 /-- A ring is Noetherian if and only if all its ideals are finitely-generated. -/
 lemma is_noetherian_ring_iff_ideal_fg (R : Type*) [semiring R] :
@@ -783,11 +783,6 @@ instance is_noetherian_of_finite (R M) [finite M] [semiring R] [add_comm_monoid 
 instance is_noetherian_of_subsingleton (R M) [subsingleton R] [semiring R] [add_comm_monoid M]
   [module R M] : is_noetherian R M :=
 by { haveI := module.subsingleton R M, exact is_noetherian_of_finite R M }
-
-@[priority 100] -- see Note [lower instance priority]
-instance ring.is_noetherian_of_subsingleton {R} [semiring R] [subsingleton R] :
-  is_noetherian_ring R :=
-⟨⟩
 
 theorem is_noetherian_of_submodule_of_noetherian (R M) [semiring R] [add_comm_monoid M] [module R M]
   (N : submodule R M) (h : is_noetherian R M) : is_noetherian R N :=


### PR DESCRIPTION
This makes `is_noetherian_ring R` defeq to `is_noetherian R R`, and similar for `is_artinian_ring`. This was discussed on https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/.40.5Breducible.5D.20defs.20of.20classes.20on.20the.20leadup.20to.20Lean4.2E.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
