### PR TITLE
[Merged by Bors] - feat(algebraic/dold_kan): construction of the functors N₁ and N₂

### DIFF
--- a/src/algebraic_topology/dold_kan/functor_n.lean
+++ b/src/algebraic_topology/dold_kan/functor_n.lean
@@ -6,7 +6,7 @@ Authors: Joël Riou
 
 import algebraic_topology.dold_kan.p_infty
 
-/-
+/-!
 
 # Construction of functors N for the Dold-Kan correspondence
 

--- a/src/algebraic_topology/dold_kan/functor_n.lean
+++ b/src/algebraic_topology/dold_kan/functor_n.lean
@@ -12,9 +12,10 @@ import algebraic_topology.dold_kan.p_infty
 
 TODO (@joelriou) continue adding the various files referenced below
 
-In this file, we construct the functors `N₁ : simplicial_object C ⥤ karoubi (chain_complex C ℕ)`
+In this file, we construct functors `N₁ : simplicial_object C ⥤ karoubi (chain_complex C ℕ)`
 and `N₂ : karoubi (simplicial_object C) ⥤ karoubi (chain_complex C ℕ)`
-for any preadditive category `C`.
+for any preadditive category `C`. (The indices of these functors are the number of occurrences
+of `karoubi` at the source or the target.)
 
 In the case `C` is additive, the functor `N₂` shall be the functor of the equivalence
 `category_theory.preadditive.dold_kan.equivalence` defined in `equivalence_additive.lean`.

--- a/src/algebraic_topology/dold_kan/functor_n.lean
+++ b/src/algebraic_topology/dold_kan/functor_n.lean
@@ -1,0 +1,66 @@
+/-
+Copyright (c) 2022 Joël Riou. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Joël Riou
+-/
+
+import algebraic_topology.dold_kan.p_infty
+
+/-
+
+# Construction of functors N for the Dold-Kan correspondence
+
+TODO (@joelriou) continue adding the various files referenced below
+
+In this file, we construct the functors `N₁ : simplicial_object C ⥤ karoubi (chain_complex C ℕ)`
+and `N₂ : karoubi (simplicial_object C) ⥤ karoubi (chain_complex C ℕ)`
+for any preadditive category `C`.
+
+In the case `C` is additive, the functor `N₂` shall be the functor of the equivalence
+`category_theory.preadditive.dold_kan.equivalence` defined in `equivalence_additive.lean`.
+
+In the case the category `C` is pseudoabelian, the composition of `N₁` with the inverse of the
+equivalence `chain_complex C ℕ ⥤ karoubi (chain_complex C ℕ)` will be the functor
+`category_theory.idempotents.dold_kan.N` of the equivalence of categories
+`category_theory.idempotents.dold_kan.equivalence : simplicial_object C ≌ chain_complex C ℕ`
+defined in `equivalence_pseudoabelian.lean`.
+
+When the category `C` is abelian, a relation between `N₁` and the
+normalized Moore complex functor shall be obtained in `normalized.lean`.
+
+(See `equivalence.lean` for the general strategy of proof.)
+
+-/
+
+open category_theory
+open category_theory.category
+open category_theory.idempotents
+
+noncomputable theory
+
+namespace algebraic_topology
+
+namespace dold_kan
+
+variables {C : Type*} [category C] [preadditive C]
+
+/-- The functor `simplicial_object C ⥤ karoubi (chain_complex C ℕ)` which maps
+`X` to the formal direct factor of `K[X]` defined by `P_infty`. -/
+@[simps]
+def N₁ : simplicial_object C ⥤ karoubi (chain_complex C ℕ) :=
+{ obj := λ X,
+  { X := alternating_face_map_complex.obj X,
+    p := P_infty,
+    idem := P_infty_idem, },
+  map := λ X Y f,
+  { f := P_infty ≫ alternating_face_map_complex.map f,
+    comm := by tidy, }, }
+
+/-- The extension of `N₁` to the Karoubi envelope of `simplicial_object C`. -/
+@[simps]
+def N₂ : karoubi (simplicial_object C) ⥤ karoubi (chain_complex C ℕ) :=
+(functor_extension₁ _ _).obj N₁
+
+end dold_kan
+
+end algebraic_topology


### PR DESCRIPTION
This PR constructs two functors, including `N₂ : karoubi (simplicial_object C) ⥤ karoubi (chain_complex C ℕ)` which shall be an equivalence of categories for any preadditive category `C`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
