### PR TITLE
[Merged by Bors] - feat(linear_algebra/span, matrix, finite_dimensional): new lemmas

### DIFF
--- a/src/linear_algebra/finite_dimensional.lean
+++ b/src/linear_algebra/finite_dimensional.lean
@@ -1314,6 +1314,10 @@ lemma finrank_span_finset_le_card (s : finset V)  :
 calc (s : set V).finrank K ≤ (s : set V).to_finset.card : finrank_span_le_card s
                                 ... = s.card : by simp
 
+lemma finrank_range_le_card {ι : Type*} [fintype ι] {b : ι → V} :
+  (set.range b).finrank K ≤ fintype.card ι :=
+(finrank_span_le_card _).trans $ by { rw set.to_finset_range, exact finset.card_image_le }
+
 lemma finrank_span_eq_card {ι : Type*} [fintype ι] {b : ι → V}
   (hb : linear_independent K b) :
   finrank K (span K (set.range b)) = fintype.card ι :=
@@ -1449,6 +1453,10 @@ begin
     have hi : f.ker = ⊥ := ker_subtype _,
     convert (linear_independent_of_top_le_span_of_card_eq_finrank hs hc).map' _ hi }
 end
+
+lemma linear_independent_iff_card_le_finrank_span {ι : Type*} [fintype ι] {b : ι → V} :
+  linear_independent K b ↔ fintype.card ι ≤ (set.range b).finrank K :=
+by rw [linear_independent_iff_card_eq_finrank_span, finrank_range_le_card.le_iff_eq]
 
 /-- A family of `finrank K V` vectors forms a basis if they span the whole space. -/
 noncomputable def basis_of_top_le_span_of_card_eq_finrank {ι : Type*} [fintype ι] (b : ι → V)

--- a/src/linear_algebra/matrix/to_lin.lean
+++ b/src/linear_algebra/matrix/to_lin.lean
@@ -268,6 +268,11 @@ lemma matrix.ker_to_lin'_eq_bot_iff {M : matrix n n R} :
   M.to_lin'.ker = ⊥ ↔ ∀ v, M.mul_vec v = 0 → v = 0 :=
 by simp only [submodule.eq_bot_iff, linear_map.mem_ker, matrix.to_lin'_apply]
 
+lemma matrix.range_to_lin' (M : matrix m n R) : M.to_lin'.range = span R (range Mᵀ) :=
+by simp_rw [range_eq_map, ←supr_range_std_basis, map_supr, range_eq_map, ←ideal.span_singleton_one,
+  ideal.span, submodule.map_span, image_image, image_singleton, matrix.to_lin'_apply,
+  M.mul_vec_std_basis_apply, supr_span, range_eq_Union]
+
 /-- If `M` and `M'` are each other's inverse matrices, they provide an equivalence between `m → A`
 and `n → A` corresponding to `M.mul_vec` and `M'.mul_vec`. -/
 @[simps]

--- a/src/linear_algebra/span.lean
+++ b/src/linear_algebra/span.lean
@@ -505,11 +505,12 @@ lemma not_mem_span_of_apply_not_mem_span_image
    x ∉ submodule.span R s :=
 h.imp (apply_mem_span_image_of_mem_span f)
 
-lemma supr_eq_span {ι : Sort*} (p : ι → submodule R M) :
-  (⨆ (i : ι), p i) = submodule.span R (⋃ (i : ι), ↑(p i)) :=
-le_antisymm
-  (supr_le $ assume i, subset.trans (assume m hm, set.mem_Union.mpr ⟨i, hm⟩) subset_span)
-  (span_le.mpr $ Union_subset_iff.mpr $ assume i m hm, mem_supr_of_mem i hm)
+lemma supr_span {ι : Sort*} (p : ι → set M) : (⨆ i, span R (p i)) = span R (⋃ i, p i) :=
+le_antisymm (supr_le $ λ i, span_mono $ subset_Union _ i) $
+  span_le.mpr $ Union_subset $ λ i m hm, mem_supr_of_mem i $ subset_span hm
+
+lemma supr_eq_span {ι : Sort*} (p : ι → submodule R M) : (⨆ i, p i) = span R (⋃ i, ↑(p i)) :=
+by simp_rw [← supr_span, span_eq]
 
 lemma supr_to_add_submonoid {ι : Sort*} (p : ι → submodule R M) :
   (⨆ i, p i).to_add_submonoid = ⨆ i, (p i).to_add_submonoid :=


### PR DESCRIPTION
+ Introduce `submodule.supr_span` and deduce `submodule.supr_eq_span` from it.

+ Use supr_span to prove that the range of `matrix.to_lin' M` is spanned by column vectors of `M`.

+ Show the rank of a finite set in a vector space is at most the cardinality of the indexing type (`finrank_range_le_card`), so in order to show the set is linearly independent, it suffices to prove the reverse inequality (`linear_independent_iff_card_le_finrank_span`).

Spinoff of [Zulip question](https://leanprover.zulipchat.com/#narrow/stream/217875-Is-there-code-for-X.3F/topic/more.20linear.20algebra/near/292630550)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
