### PR TITLE
[Merged by Bors] - feat(number_theory/legendre_symbol/add_character): change `coe_to_fun` for `add_char` so it includes `of_add`

### DIFF
--- a/src/number_theory/legendre_symbol/add_character.lean
+++ b/src/number_theory/legendre_symbol/add_character.lean
@@ -100,15 +100,14 @@ lemma inv_apply (ψ : add_char R R') (x : R) : ψ⁻¹ x = ψ (-x) := rfl
 @[simp]
 lemma map_zero_one (ψ : add_char R R') : ψ 0 = 1 :=
 begin
-  rw [coe_to_fun_apply, show of_add (0 : R) = 1, from rfl, ψ.map_one'],
+  rw [coe_to_fun_apply, of_add_zero, ψ.map_one'],
 end
 
 /-- An additive character maps sums to products. -/
 @[simp]
 lemma map_add_mul (ψ : add_char R R') (x y : R) : ψ (x + y) = ψ x * ψ y :=
 begin
-  rw [coe_to_fun_apply, coe_to_fun_apply, coe_to_fun_apply,
-      show of_add (x + y) = of_add x * of_add y, from rfl, ψ.map_mul'],
+  rw [coe_to_fun_apply, coe_to_fun_apply, coe_to_fun_apply, of_add_add, ψ.map_mul'],
 end
 
 /-- An additive character maps multiples by natural numbers to powers. -/
@@ -126,8 +125,7 @@ lemma map_zsmul_zpow {R' : Type v} [comm_group R'] (ψ : add_char R R') (n : ℤ
   ψ (n • x) = (ψ x) ^ n :=
 begin
   cases n,
-  { have : int.of_nat n • x = n • x := of_nat_zsmul x n,
-    rw [of_nat_zsmul, zpow_of_nat],
+  { rw [of_nat_zsmul, zpow_of_nat],
     exact map_nsmul_pow ψ n x, },
   { have h_inv : ψ⁻¹ x = (ψ x)⁻¹,
     { rw [eq_inv_iff_mul_eq_one, inv_apply, ← map_add_mul, neg_add_eq_sub, sub_self,

--- a/src/number_theory/legendre_symbol/add_character.lean
+++ b/src/number_theory/legendre_symbol/add_character.lean
@@ -65,43 +65,27 @@ def add_char : Type (max u v) := (multiplicative R) →* R'
 
 end add_char_def
 
+namespace add_char
+
 section coe_to_fun
 
 variables {R : Type u} [add_monoid R] {R' : Type v} [comm_monoid R']
 
 /-- Interpret an additive character as a monoid homomorphism. -/
-def add_char.to_monoid_hom : (add_char R R') → (multiplicative R →* R') := id
+def to_monoid_hom : (add_char R R') → (multiplicative R →* R') := id
 
 open multiplicative
 
 /-- Define coercion to a function so that it includes the move from `R` to `multiplicative R`.
 After we have proved the API lemmas below, we don't need to worry about writing `of_add a`
 when we want to apply an additive character. -/
-instance add_char.has_coe_to_fun : has_coe_to_fun (add_char R R') (λ x, R → R') :=
+instance has_coe_to_fun : has_coe_to_fun (add_char R R') (λ x, R → R') :=
 { coe := λ ψ x, ψ.to_monoid_hom (of_add x) }
 
 lemma coe_to_fun_apply (ψ : add_char R R') (a : R) : ψ a = ψ.to_monoid_hom (of_add a) := rfl
 
-instance add_char.monoid_hom_class : monoid_hom_class (add_char R R') (multiplicative R) R' :=
+instance monoid_hom_class : monoid_hom_class (add_char R R') (multiplicative R) R' :=
 monoid_hom.monoid_hom_class
-
-end coe_to_fun
-
-section group_structure
-
-namespace add_char
-
-open multiplicative
-
-variables {R : Type u} [add_comm_group R] {R' : Type v} [comm_monoid R']
-
-/-- An additive character on a commutative additive group has an inverse.
-
-Note that this is a different inverse to the one provided by `monoid_hom.has_inv`,
-as it acts on the domain instead of the codomain. -/
-instance has_inv : has_inv (add_char R R') := ⟨λ ψ, ψ.comp inv_monoid_hom⟩
-
-lemma inv_apply (ψ : add_char R R') (x : R) : ψ⁻¹ x = ψ (-x) := rfl
 
 /-- An additive character maps `0` to `1`. -/
 @[simp]
@@ -118,6 +102,22 @@ by rw [coe_to_fun_apply, coe_to_fun_apply _ x, coe_to_fun_apply _ y, of_add_add,
 lemma map_nsmul_pow (ψ : add_char R R') (n : ℕ) (x : R) : ψ (n • x) = (ψ x) ^ n :=
 by rw [coe_to_fun_apply, coe_to_fun_apply _ x, of_add_nsmul, map_pow]
 
+end coe_to_fun
+
+section group_structure
+
+open multiplicative
+
+variables {R : Type u} [add_comm_group R] {R' : Type v} [comm_monoid R']
+
+/-- An additive character on a commutative additive group has an inverse.
+
+Note that this is a different inverse to the one provided by `monoid_hom.has_inv`,
+as it acts on the domain instead of the codomain. -/
+instance has_inv : has_inv (add_char R R') := ⟨λ ψ, ψ.comp inv_monoid_hom⟩
+
+lemma inv_apply (ψ : add_char R R') (x : R) : ψ⁻¹ x = ψ (-x) := rfl
+
 /-- An additive character maps multiples by integers to powers. -/
 @[simp]
 lemma map_zsmul_zpow {R' : Type v} [comm_group R'] (ψ : add_char R R') (n : ℤ) (x : R) :
@@ -132,13 +132,9 @@ instance comm_group : comm_group (add_char R R') :=
                      add_left_neg, map_zero_one], },
   ..monoid_hom.comm_monoid }
 
-end add_char
-
 end group_structure
 
 section additive
-
-namespace add_char
 
 -- The domain and target of our additive characters. Now we restrict to rings on both sides.
 variables {R : Type u} [comm_ring R] {R' : Type v} [comm_ring R']
@@ -415,6 +411,6 @@ begin
     exact sum_eq_zero_of_is_nontrivial (hψ b h), },
 end
 
-end add_char
-
 end additive
+
+end add_char

--- a/src/number_theory/legendre_symbol/add_character.lean
+++ b/src/number_theory/legendre_symbol/add_character.lean
@@ -261,10 +261,7 @@ lemma zmod_char_apply {n : ℕ+} {ζ : C} (hζ : ζ ^ ↑n = 1) (a : zmod n) :
   zmod_char n hζ a = ζ ^ a.val := rfl
 
 lemma zmod_char_apply' {n : ℕ+} {ζ : C} (hζ : ζ ^ ↑n = 1) (a : ℕ) : zmod_char n hζ a = ζ ^ a :=
-begin
-  nth_rewrite 1 ← nat.div_add_mod a n,
-  rw [zmod_char_apply, zmod.val_nat_cast a, pow_add, pow_mul, hζ, one_pow, one_mul],
-end
+by rw [pow_eq_pow_mod a hζ, zmod_char_apply, zmod.val_nat_cast a]
 
 end zmod_char_def
 


### PR DESCRIPTION
The purpose of this PR is to carry out the solution mentioned [here](https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/map.20from.20mult.20gp.20to.20add.20gp/near/292623869) to the unpleasantness that one has to explicitly invoke `of_add` and `to_add` when working with homomorphisms from additive to multiplicative monoids (in the form `multiplicative M → M'`). The idea is to implement the coercion to a function `M → M'` so that it inserts the `to_add` conversion automatically.

This is done here for additive characters (which also simplifies the treatment of Gauss sums in `number_theory/legendre_symbol/gauss_sum`).

We also change many `nat` arguments in `add_character.lean` to `pnat`, to help the with the refactor of cyclotomic fields. See the discussion [here](https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/.60pnat.60.20vs.20.60.5Bfact.20.280.20.3C.20n.29.5D.60/near/293293368).


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
