### PR TITLE
[Merged by Bors] - chore(combinatorics/*): Fix lint

### DIFF
--- a/src/combinatorics/additive/salem_spencer.lean
+++ b/src/combinatorics/additive/salem_spencer.lean
@@ -57,7 +57,7 @@ is a set such that the average of any two distinct elements is not in the set."]
 def mul_salem_spencer : Prop := ∀ ⦃a b c⦄, a ∈ s → b ∈ s → c ∈ s → a * b = c * c → a = b
 
 /-- Whether a given finset is Salem-Spencer is decidable. -/
-@[to_additive]
+@[to_additive "Whether a given finset is Salem-Spencer is decidable."]
 instance {α : Type*} [decidable_eq α] [monoid α] {s : finset α} :
   decidable (mul_salem_spencer (s : set α)) :=
 decidable_of_iff (∀ a ∈ s, ∀ b ∈ s, ∀ c ∈ s, a * b = c * c → a = b)

--- a/src/combinatorics/hales_jewett.lean
+++ b/src/combinatorics/hales_jewett.lean
@@ -172,7 +172,7 @@ by simp_rw [line.apply, line.diagonal, option.get_or_else_none]
 /-- The Hales-Jewett theorem. This version has a restriction on universe levels which is necessary
 for the proof. See `exists_mono_in_high_dimension` for a fully universe-polymorphic version. -/
 private theorem exists_mono_in_high_dimension' :
-  ∀ (α : Type u) [fintype α] (κ : Type (max v u)) [fintype κ],
+  ∀ (α : Type u) [fintype α] (κ : Type (max v u)) [finite κ],
   ∃ (ι : Type) (_ : fintype ι), ∀ C : (ι → α) → κ, ∃ l : line α ι, l.is_mono C :=
 -- The proof proceeds by induction on `α`.
 fintype.induction_empty_option
@@ -188,6 +188,7 @@ begin -- This deals with the degenerate case where `α` is empty.
 end
 begin -- Now we have to show that the theorem holds for `option α` if it holds for `α`.
   introsI α _ ihα κ _,
+  casesI nonempty_fintype κ,
 -- Later we'll need `α` to be nonempty. So we first deal with the trivial case where `α` is empty.
 -- Then `option α` has only one element, so any line is monochromatic.
   by_cases h : nonempty α,
@@ -267,7 +268,7 @@ end
 
 /-- The Hales-Jewett theorem: for any finite types `α` and `κ`, there exists a finite type `ι` such
 that whenever the hypercube `ι → α` is `κ`-colored, there is a monochromatic combinatorial line. -/
-theorem exists_mono_in_high_dimension (α : Type u) [fintype α] (κ : Type v) [fintype κ] :
+theorem exists_mono_in_high_dimension (α : Type u) [fintype α] (κ : Type v) [finite κ] :
   ∃ (ι : Type) [fintype ι], ∀ C : (ι → α) → κ, ∃ l : line α ι, l.is_mono C :=
 let ⟨ι, ιfin, hι⟩ := exists_mono_in_high_dimension' α (ulift κ)
 in ⟨ι, ιfin, λ C, let ⟨l, c, hc⟩ := hι (ulift.up ∘ C) in ⟨l, c.down, λ x, by rw ←hc⟩ ⟩
@@ -276,8 +277,8 @@ end line
 
 /-- A generalization of Van der Waerden's theorem: if `M` is a finitely colored commutative
 monoid, and `S` is a finite subset, then there exists a monochromatic homothetic copy of `S`. -/
-theorem exists_mono_homothetic_copy
-  {M κ} [add_comm_monoid M] (S : finset M) [fintype κ] (C : M → κ) :
+theorem exists_mono_homothetic_copy {M κ : Type*} [add_comm_monoid M] (S : finset M) [finite κ]
+  (C : M → κ) :
   ∃ (a > 0) (b : M) (c : κ), ∀ s ∈ S, C (a • s + b) = c :=
 begin
   obtain ⟨ι, _inst, hι⟩ := line.exists_mono_in_high_dimension S κ,

--- a/src/combinatorics/hall/finite.lean
+++ b/src/combinatorics/hall/finite.lean
@@ -11,9 +11,9 @@ import data.set.finite
 
 This module proves the basic form of Hall's theorem.
 In constrast to the theorem described in `combinatorics.hall.basic`, this
-version requires that the indexed family `t : ι → finset α` have `ι` be a `fintype`.
+version requires that the indexed family `t : ι → finset α` have `ι` be finite.
 The `combinatorics.hall.basic` module applies a compactness argument to this version
-to remove the `fintype` constraint on `ι`.
+to remove the `finite` constraint on `ι`.
 
 The modules are split like this since the generalized statement
 depends on the topology and category theory libraries, but the finite
@@ -38,7 +38,10 @@ universes u v
 
 namespace hall_marriage_theorem
 
-variables {ι : Type u} {α : Type v} [fintype ι] {t : ι → finset α} [decidable_eq α]
+variables {ι : Type u} {α : Type v} [decidable_eq α] {t : ι → finset α}
+
+section fintype
+variables [fintype ι]
 
 lemma hall_cond_of_erase {x : ι} (a : α)
   (ha : ∀ (s : finset ι), s.nonempty → s ≠ univ → s.card < (s.bUnion t).card)
@@ -211,6 +214,11 @@ begin
     { exact sdiff_subset _ _ (hsf'' ⟨x, h⟩) } }
 end
 
+
+end fintype
+
+variables [finite ι]
+
 /--
 Here we combine the two inductive steps into a full strong induction proof,
 completing the proof the harder direction of **Hall's Marriage Theorem**.
@@ -219,6 +227,7 @@ theorem hall_hard_inductive
   (ht : ∀ (s : finset ι), s.card ≤ (s.bUnion t).card) :
   ∃ (f : ι → α), function.injective f ∧ ∀ x, f x ∈ t x :=
 begin
+  casesI nonempty_fintype ι,
   unfreezingI
   { induction hn : fintype.card ι using nat.strong_induction_on with n ih generalizing ι },
   rcases n with _|_,
@@ -229,7 +238,7 @@ begin
                     (∀ (s' : finset ι'), s'.card ≤ (s'.bUnion t').card) →
                     ∃ (f : ι' → α), function.injective f ∧ ∀ x, f x ∈ t' x,
     { introsI ι' _ _ hι' ht',
-      exact ih _ (nat.lt_succ_of_le hι') ht' rfl, },
+      exact ih _ (nat.lt_succ_of_le hι') ht' _ rfl },
     by_cases h : ∀ (s : finset ι), s.nonempty → s ≠ univ → s.card < (s.bUnion t).card,
     { exact hall_hard_inductive_step_A hn ht ih' h, },
     { push_neg at h,
@@ -241,15 +250,15 @@ end hall_marriage_theorem
 
 /--
 This is the version of **Hall's Marriage Theorem** in terms of indexed
-families of finite sets `t : ι → finset α` with `ι` a `fintype`.
+families of finite sets `t : ι → finset α` with `ι` finite.
 It states that there is a set of distinct representatives if and only
 if every union of `k` of the sets has at least `k` elements.
 
 See `finset.all_card_le_bUnion_card_iff_exists_injective` for a version
-where the `fintype ι` constraint is removed.
+where the `finite ι` constraint is removed.
 -/
 theorem finset.all_card_le_bUnion_card_iff_exists_injective'
-  {ι α : Type*} [fintype ι] [decidable_eq α] (t : ι → finset α) :
+  {ι α : Type*} [finite ι] [decidable_eq α] (t : ι → finset α) :
   (∀ (s : finset ι), s.card ≤ (s.bUnion t).card) ↔
     (∃ (f : ι → α), function.injective f ∧ ∀ x, f x ∈ t x) :=
 begin

--- a/src/combinatorics/hindman.lean
+++ b/src/combinatorics/hindman.lean
@@ -91,7 +91,8 @@ inductive FP {M} [semigroup M] : stream M → set M
 
 /-- If `m` and `m'` are finite products in `M`, then so is `m * m'`, provided that `m'` is obtained
 from a subsequence of `M` starting sufficiently late. -/
-@[to_additive]
+@[to_additive "If `m` and `m'` are finite products in `M`, then so is `m + m'`, provided that `m'`
+is obtained from a subsequence of `M` starting sufficiently late."]
 lemma FP.mul {M} [semigroup M] {a : stream M} {m : M} (hm : m ∈ FP a) :
   ∃ n, ∀ m' ∈ FP (a.drop n), m * m' ∈ FP a :=
 begin
@@ -165,7 +166,8 @@ end
 
 /-- The strong form of **Hindman's theorem**: in any finite cover of an FP-set, one the parts
 contains an FP-set. -/
-@[to_additive FS_partition_regular]
+@[to_additive FS_partition_regular "he strong form of **Hindman's theorem**: in any finite cover of
+an FP-set, one the parts contains an FP-set."]
 lemma FP_partition_regular {M} [semigroup M] (a : stream M) (s : set (set M)) (sfin : s.finite)
   (scov : FP a ⊆ ⋃₀ s) : ∃ (c ∈ s) (b : stream M), FP b ⊆ c :=
 let ⟨U, idem, aU⟩ := exists_idempotent_ultrafilter_le_FP a in
@@ -174,7 +176,8 @@ let ⟨c, cs, hc⟩ := (ultrafilter.finite_sUnion_mem_iff sfin).mp (mem_of_super
 
 /-- The weak form of **Hindman's theorem**: in any finite cover of a nonempty semigroup, one of the
 parts contains an FP-set. -/
-@[to_additive exists_FS_of_finite_cover]
+@[to_additive exists_FS_of_finite_cover "The weak form of **Hindman's theorem**: in any finite cover
+of a nonempty semigroup, one of the parts contains an FP-set."]
 lemma exists_FP_of_finite_cover {M} [semigroup M] [nonempty M] (s : set (set M))
   (sfin : s.finite) (scov : ⊤ ⊆ ⋃₀ s) : ∃ (c ∈ s) (a : stream M), FP a ⊆ c :=
 let ⟨U, hU⟩ := exists_idempotent_of_compact_t2_of_continuous_mul_left

--- a/src/combinatorics/hindman.lean
+++ b/src/combinatorics/hindman.lean
@@ -91,7 +91,7 @@ inductive FP {M} [semigroup M] : stream M → set M
 
 /-- If `m` and `m'` are finite products in `M`, then so is `m * m'`, provided that `m'` is obtained
 from a subsequence of `M` starting sufficiently late. -/
-@[to_additive "If `m` and `m'` are finite products in `M`, then so is `m + m'`, provided that `m'`
+@[to_additive "If `m` and `m'` are finite sums in `M`, then so is `m + m'`, provided that `m'`
 is obtained from a subsequence of `M` starting sufficiently late."]
 lemma FP.mul {M} [semigroup M] {a : stream M} {m : M} (hm : m ∈ FP a) :
   ∃ n, ∀ m' ∈ FP (a.drop n), m * m' ∈ FP a :=
@@ -166,8 +166,8 @@ end
 
 /-- The strong form of **Hindman's theorem**: in any finite cover of an FP-set, one the parts
 contains an FP-set. -/
-@[to_additive FS_partition_regular "he strong form of **Hindman's theorem**: in any finite cover of
-an FP-set, one the parts contains an FP-set."]
+@[to_additive FS_partition_regular "The strong form of **Hindman's theorem**: in any finite cover of
+an FS-set, one the parts contains an FS-set."]
 lemma FP_partition_regular {M} [semigroup M] (a : stream M) (s : set (set M)) (sfin : s.finite)
   (scov : FP a ⊆ ⋃₀ s) : ∃ (c ∈ s) (b : stream M), FP b ⊆ c :=
 let ⟨U, idem, aU⟩ := exists_idempotent_ultrafilter_le_FP a in
@@ -177,7 +177,7 @@ let ⟨c, cs, hc⟩ := (ultrafilter.finite_sUnion_mem_iff sfin).mp (mem_of_super
 /-- The weak form of **Hindman's theorem**: in any finite cover of a nonempty semigroup, one of the
 parts contains an FP-set. -/
 @[to_additive exists_FS_of_finite_cover "The weak form of **Hindman's theorem**: in any finite cover
-of a nonempty semigroup, one of the parts contains an FP-set."]
+of a nonempty additive semigroup, one of the parts contains an FS-set."]
 lemma exists_FP_of_finite_cover {M} [semigroup M] [nonempty M] (s : set (set M))
   (sfin : s.finite) (scov : ⊤ ⊆ ⋃₀ s) : ∃ (c ∈ s) (a : stream M), FP a ⊆ c :=
 let ⟨U, hU⟩ := exists_idempotent_of_compact_t2_of_continuous_mul_left

--- a/src/combinatorics/simple_graph/coloring.lean
+++ b/src/combinatorics/simple_graph/coloring.lean
@@ -99,8 +99,8 @@ setoid.is_partition_classes (setoid.ker C)
 lemma coloring.mem_color_classes {v : V} : C.color_class (C v) ∈ C.color_classes :=
 ⟨v, rfl⟩
 
-lemma coloring.color_classes_finite_of_fintype [fintype α] : C.color_classes.finite :=
-by { rw set.finite_def, apply setoid.nonempty_fintype_classes_ker, }
+lemma coloring.color_classes_finite [finite α] : C.color_classes.finite :=
+set.finite_coe_iff.1 $ setoid.finite_classes_ker _
 
 lemma coloring.card_color_classes_le [fintype α] [fintype C.color_classes] :
   fintype.card C.color_classes ≤ fintype.card α :=
@@ -255,9 +255,9 @@ begin
   exact colorable_set_nonempty_of_colorable hc,
 end
 
-lemma colorable_chromatic_number_of_fintype (G : simple_graph V) [fintype V] :
+lemma colorable_chromatic_number_of_fintype (G : simple_graph V) [finite V] :
   G.colorable G.chromatic_number :=
-colorable_chromatic_number G.colorable_of_fintype
+by { casesI nonempty_fintype V, exact colorable_chromatic_number G.colorable_of_fintype }
 
 lemma chromatic_number_le_one_of_subsingleton (G : simple_graph V) [subsingleton V] :
   G.chromatic_number ≤ 1 :=
@@ -279,7 +279,7 @@ begin
   apply colorable_of_is_empty,
 end
 
-lemma is_empty_of_chromatic_number_eq_zero (G : simple_graph V) [fintype V]
+lemma is_empty_of_chromatic_number_eq_zero (G : simple_graph V) [finite V]
   (h : G.chromatic_number = 0) : is_empty V :=
 begin
   have h' := G.colorable_chromatic_number_of_fintype,
@@ -436,11 +436,12 @@ begin
   simp,
 end
 
--- TODO eliminate `fintype V` constraint once chromatic numbers are refactored.
+-- TODO eliminate `finite V` constraint once chromatic numbers are refactored.
 -- This is just to ensure the chromatic number exists.
-lemma is_clique.card_le_chromatic_number [fintype V] {s : finset V} (h : G.is_clique s) :
+lemma is_clique.card_le_chromatic_number [finite V] {s : finset V} (h : G.is_clique s) :
   s.card ≤ G.chromatic_number :=
-h.card_le_of_colorable G.colorable_chromatic_number_of_fintype
+by { casesI nonempty_fintype V,
+  exact h.card_le_of_colorable G.colorable_chromatic_number_of_fintype }
 
 protected
 lemma colorable.clique_free {n m : ℕ} (hc : G.colorable n) (hm : n < m) : G.clique_free m :=
@@ -451,9 +452,9 @@ begin
   exact nat.lt_le_antisymm hm (h.card_le_of_colorable hc),
 end
 
--- TODO eliminate `fintype V` constraint once chromatic numbers are refactored.
+-- TODO eliminate `finite V` constraint once chromatic numbers are refactored.
 -- This is just to ensure the chromatic number exists.
-lemma clique_free_of_chromatic_number_lt [fintype V] {n : ℕ} (hc : G.chromatic_number < n) :
+lemma clique_free_of_chromatic_number_lt [finite V] {n : ℕ} (hc : G.chromatic_number < n) :
   G.clique_free n :=
 G.colorable_chromatic_number_of_fintype.clique_free hc
 

--- a/src/combinatorics/simple_graph/partition.lean
+++ b/src/combinatorics/simple_graph/partition.lean
@@ -129,9 +129,9 @@ begin
     rw set.finite.card_to_finset at h,
     apply P.to_colorable.mono h, },
   { rintro ⟨C⟩,
-    refine ⟨C.to_partition, C.color_classes_finite_of_fintype, le_trans _ (fintype.card_fin n).le⟩,
+    refine ⟨C.to_partition, C.color_classes_finite, le_trans _ (fintype.card_fin n).le⟩,
     generalize_proofs h,
-    haveI : fintype C.color_classes := C.color_classes_finite_of_fintype.fintype,
+    haveI : fintype C.color_classes := C.color_classes_finite.fintype,
     rw h.card_to_finset,
     exact C.card_color_classes_le },
 end

--- a/src/data/setoid/partition.lean
+++ b/src/data/setoid/partition.lean
@@ -67,9 +67,8 @@ lemma classes_ker_subset_fiber_set {β : Type*} (f : α → β) :
   (setoid.ker f).classes ⊆ set.range (λ y, {x | f x = y}) :=
 by { rintro s ⟨x, rfl⟩, rw set.mem_range, exact ⟨f x, rfl⟩ }
 
-lemma nonempty_fintype_classes_ker {α β : Type*} [fintype β] (f : α → β) :
-  nonempty (fintype (setoid.ker f).classes) :=
-by { classical, exact ⟨set.fintype_subset _ (classes_ker_subset_fiber_set f)⟩ }
+lemma finite_classes_ker {α β : Type*} [finite β] (f : α → β) : finite (setoid.ker f).classes :=
+by { classical, exact finite.set.subset _ (classes_ker_subset_fiber_set f) }
 
 lemma card_classes_ker_le {α β : Type*} [fintype β]
   (f : α → β) [fintype (setoid.ker f).classes] :


### PR DESCRIPTION
Fix the linting errors coming from `fintype_finite`, `to_additive_doc` and `doc_blame`. Pull out a `[projective_plane P L]` assumption to a `variables` declaration in `combinatorics.configuration`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
