### PR TITLE
[Merged by Bors] - chore(ring_theory/chain_of_divisors): make some variables that can be infered implicit

### DIFF
--- a/src/ring_theory/adjoin_root.lean
+++ b/src/ring_theory/adjoin_root.lean
@@ -534,8 +534,7 @@ lemma quot_map_of_equiv_quot_map_C_map_span_mk_symm_mk (x : adjoin_root f) :
   (quot_map_of_equiv_quot_map_C_map_span_mk I f).symm
   (ideal.quotient.mk ((I.map (C : R →+* R[X])).map (span {f})^.quotient.mk) x) =
     ideal.quotient.mk (I.map (of f)) x :=
-by rw [quot_map_of_equiv_quot_map_C_map_span_mk, ideal.quot_equiv_of_eq_symm,
-    ideal.quot_equiv_of_eq_mk ]
+by rw [quot_map_of_equiv_quot_map_C_map_span_mk, ideal.quot_equiv_of_eq_symm, quot_equiv_of_eq_mk]
 
 /-- The natural isomorphism `R[α]/((I[x] ⊔ (f)) / (f)) ≅ (R[x]/I[x])/((f) ⊔ I[x] / I[x])`
   for `α` a root of `f : polynomial R` and `I : ideal R`-/

--- a/src/ring_theory/adjoin_root.lean
+++ b/src/ring_theory/adjoin_root.lean
@@ -572,7 +572,7 @@ lemma polynomial.quot_quot_equiv_comm_mk (p : R[X]) :
   (polynomial.quot_quot_equiv_comm I f) (ideal.quotient.mk  _ (p.map I^.quotient.mk)) =
   (ideal.quotient.mk _ (ideal.quotient.mk _ p)) :=
 by simp only [polynomial.quot_quot_equiv_comm, quotient_equiv_mk,
-  polynomial_quotient_equiv_quotient_polynomial_map_mk ]
+  polynomial_quotient_equiv_quotient_polynomial_map_mk]
 
 @[simp]
 lemma polynomial.quot_quot_equiv_comm_symm_mk_mk (p : R[X]) :

--- a/src/ring_theory/chain_of_divisors.lean
+++ b/src/ring_theory/chain_of_divisors.lean
@@ -336,7 +336,7 @@ variables [unique (Mˣ)] [unique (Nˣ)]
   bijection between the factors of `m` and the factors of `n` that preserves `∣`. -/
 @[simps]
 def mk_factor_order_iso_of_factor_dvd_equiv
-  {m : M} {n : N} (d : {l : M // l ∣ m} ≃ {l : N // l ∣ n})
+  {m : M} {n : N} {d : {l : M // l ∣ m} ≃ {l : N // l ∣ n}}
   (hd : ∀ l l', ((d l) : N) ∣ (d l') ↔ (l : M) ∣ (l' : M)) :
    set.Iic (associates.mk m) ≃o set.Iic (associates.mk n) :=
 { to_fun := λ l, ⟨associates.mk (d ⟨associates_equiv_of_unique_units ↑l,
@@ -361,7 +361,7 @@ variables [unique_factorization_monoid M] [unique_factorization_monoid N]
 
 lemma mem_normalized_factors_factor_dvd_iso_of_mem_normalized_factors [decidable_eq N] {m p : M}
   {n : N} (hm : m ≠ 0) (hn : n ≠ 0) (hp : p ∈ normalized_factors m)
-  (d : {l : M // l ∣ m} ≃ {l : N // l ∣ n})
+  {d : {l : M // l ∣ m} ≃ {l : N // l ∣ n}}
   (hd : ∀ l l', ((d l) : N) ∣ (d l') ↔ (l : M) ∣ (l' : M)) :
     ↑(d ⟨p, dvd_of_mem_normalized_factors hp⟩) ∈ normalized_factors n :=
 begin
@@ -376,7 +376,7 @@ begin
     (associates_equiv_of_unique_units.symm p), by simp only [dvd_of_mem_normalized_factors hp,
       associates_equiv_of_unique_units_apply, out_mk, normalize_eq,
       associates_equiv_of_unique_units_symm_apply] ⟩)
-    = ↑(mk_factor_order_iso_of_factor_dvd_equiv d hd ⟨( associates_equiv_of_unique_units.symm p),
+    = ↑(mk_factor_order_iso_of_factor_dvd_equiv hd ⟨( associates_equiv_of_unique_units.symm p),
       by simp only [associates_equiv_of_unique_units_symm_apply] ;
         exact mk_dvd_mk.mpr (dvd_of_mem_normalized_factors hp) ⟩),
   { rw mk_factor_order_iso_of_factor_dvd_equiv_apply_coe,
@@ -392,11 +392,12 @@ end
 
 variables [decidable_rel ((∣) : M → M → Prop)] [decidable_rel ((∣) : N → N → Prop)]
 
-lemma multiplicity_eq_multiplicity_factor_dvd_iso_of_mem_normalized_factor {m p : M} {n : N}
+lemma multiplicity_factor_dvd_iso_eq_multiplicity_of_mem_normalized_factor {m p : M} {n : N}
   (hm : m ≠ 0) (hn : n ≠ 0) (hp : p ∈ normalized_factors m)
-  (d : {l : M // l ∣ m} ≃ {l : N // l ∣ n}) (hd : ∀ l l', ((d l) : N) ∣ (d l') ↔ (l : M) ∣ l') :
-    multiplicity p m = multiplicity ((d ⟨p, dvd_of_mem_normalized_factors hp⟩) : N) n :=
+  {d : {l : M // l ∣ m} ≃ {l : N // l ∣ n}} (hd : ∀ l l', ((d l) : N) ∣ (d l') ↔ (l : M) ∣ l') :
+    multiplicity ((d ⟨p, dvd_of_mem_normalized_factors hp⟩) : N) n = multiplicity p m :=
 begin
+  apply eq.symm,
   suffices : multiplicity (associates.mk p) (associates.mk m) = multiplicity (associates.mk
     ↑(d ⟨associates_equiv_of_unique_units (associates_equiv_of_unique_units.symm p),
       by simp [dvd_of_mem_normalized_factors hp]⟩))
@@ -407,14 +408,14 @@ begin
     (associates_equiv_of_unique_units.symm p), by simp only [dvd_of_mem_normalized_factors hp,
       associates_equiv_of_unique_units_symm_apply, associates_equiv_of_unique_units_apply,
       out_mk, normalize_eq] ⟩)
-      = ↑(mk_factor_order_iso_of_factor_dvd_equiv d hd ⟨(associates_equiv_of_unique_units.symm p),
+      = ↑(mk_factor_order_iso_of_factor_dvd_equiv hd ⟨(associates_equiv_of_unique_units.symm p),
         by rw [associates_equiv_of_unique_units_symm_apply] ;
           exact mk_le_mk_of_dvd (dvd_of_mem_normalized_factors hp) ⟩),
   { rw mk_factor_order_iso_of_factor_dvd_equiv_apply_coe, refl },
   rw this,
   letI := classical.dec_eq (associates M),
   refine multiplicity_prime_eq_multiplicity_image_by_factor_order_iso (mk_ne_zero.mpr hn) _
-    (mk_factor_order_iso_of_factor_dvd_equiv d hd),
+    (mk_factor_order_iso_of_factor_dvd_equiv hd),
   obtain ⟨q, hq, hq'⟩ := exists_mem_normalized_factors_of_dvd (mk_ne_zero.mpr hm)
     ((prime_mk p).mpr (prime_of_normalized_factor p hp)).irreducible
       (mk_le_mk_of_dvd (dvd_of_mem_normalized_factors hp)),


### PR DESCRIPTION
A few variables could be made implicit in some of the lemmas in `ring_theory/chain_of_divisors`. I also made a (very) minor stylistic change to a proof from one of my previous PRs in `ring_theory/adjoin_root` 

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
