### PR TITLE
[Merged by Bors] - chore(algebra/algebra/unitization): update `comm_semiring` instance for `unitization`

### DIFF
--- a/src/algebra/algebra/unitization.lean
+++ b/src/algebra/algebra/unitization.lean
@@ -345,9 +345,8 @@ instance [comm_monoid R] [non_unital_semiring A] [distrib_mul_action R A] [is_sc
       abel },
   ..unitization.mul_one_class }
 
--- This should work for `non_unital_comm_semiring`s, but we don't seem to have those
-instance [comm_monoid R] [comm_semiring A] [distrib_mul_action R A] [is_scalar_tower R A A]
-  [smul_comm_class R A A] : comm_monoid (unitization R A) :=
+instance [comm_monoid R] [non_unital_comm_semiring A] [distrib_mul_action R A]
+  [is_scalar_tower R A A] [smul_comm_class R A A] : comm_monoid (unitization R A) :=
 { mul_comm := λ x₁ x₂, ext (mul_comm x₁.1 x₂.1) $
     show x₁.1 • x₂.2 + x₂.1 • x₁.2 + x₁.2 * x₂.2 = x₂.1 • x₁.2 + x₁.1 • x₂.2 + x₂.2 * x₁.2,
     by rw [add_comm (x₁.1 • x₂.2), mul_comm],
@@ -358,8 +357,7 @@ instance [comm_semiring R] [non_unital_semiring A] [module R A] [is_scalar_tower
 { ..unitization.monoid,
   ..unitization.non_assoc_semiring }
 
--- This should work for `non_unital_comm_semiring`s, but we don't seem to have those
-instance [comm_semiring R] [comm_semiring A] [module R A] [is_scalar_tower R A A]
+instance [comm_semiring R] [non_unital_comm_semiring A] [module R A] [is_scalar_tower R A A]
   [smul_comm_class R A A] : comm_semiring (unitization R A) :=
 { ..unitization.comm_monoid,
   ..unitization.non_assoc_semiring }


### PR DESCRIPTION
The `comm_monoid` and `comm_semiring` instances for `unitization` had type class restrictions that were too strong because `non_unital_comm_semiring` didn't exist at the time `unitization` was created. This drops those restrictions.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
