### PR TITLE
[Merged by Bors] - feat(algebra/order/complete.field): add real.ring_hom_eq_id

### DIFF
--- a/src/algebra/order/complete_field.lean
+++ b/src/algebra/order/complete_field.lean
@@ -322,7 +322,7 @@ instance real.ring_hom.unique : unique (ℝ →+* ℝ) :=
   uniq :=
   begin
     intro f,
-    have f_mon : monotone f,
+    have fmon : monotone f,
     { intros a b hab,
       have : f b - f a ≥ 0,
       { calc
@@ -332,7 +332,7 @@ instance real.ring_hom.unique : unique (ℝ →+* ℝ) :=
             ...     ≥ 0                         : sq_nonneg _, },
       linarith, },
     haveI : subsingleton (ℝ →+*o ℝ):= order_ring_hom.subsingleton,
-    exact congr_arg order_ring_hom.to_ring_hom (subsingleton.elim ⟨f, f_mon⟩ ⟨_, monotone_id⟩),
+    exact congr_arg order_ring_hom.to_ring_hom (subsingleton.elim ⟨f, fmon⟩ ⟨default, monotone_id⟩),
   end }
 
 end real

--- a/src/algebra/order/complete_field.lean
+++ b/src/algebra/order/complete_field.lean
@@ -315,23 +315,20 @@ end linear_ordered_field
 
 section real
 
-/-- Any ring homomorphism `ℝ → ℝ` is an ordered ring isomorphism and thus there are no
+/-- Any ring homomorphism `ℝ → ℝ` is an ordered ring isomorphism, and thus there are no
 nontrivial ring homorphism `ℝ → ℝ`. -/
 lemma real.ring_hom_eq_id (f : ℝ →+* ℝ) : f = ring_hom.id ℝ :=
 begin
-  have f_smon : strict_mono f,
+  have f_mon : monotone f,
   { intros a b hab,
-    let e := real.sqrt (b - a),
-    have fenz : f e ≠ 0 :=
-      by rwa [map_ne_zero_iff _ (ring_hom.injective f), real.sqrt_ne_zero', sub_pos],
-    have : f b - f a > 0,
+    have : f b - f a ≥ 0,
     { calc
-        f b - f a = f (b - a)   : (ring_hom.map_sub _ _ _).symm
-          ...     = f (e^2)     : by rw (real.sq_sqrt (le_of_lt $ sub_pos.mpr hab))
-          ...     = (f e)^2     : ring_hom.map_pow _ _ _
-          ...     > 0           : (sq_pos_iff (f e)).mpr fenz, },
+        f b - f a = f (b - a)                 : (ring_hom.map_sub _ _ _).symm
+          ...     = f (real.sqrt (b - a)^2)   : by rw sq_sqrt (sub_nonneg.mpr hab)
+          ...     = (f (real.sqrt (b - a)))^2 : ring_hom.map_pow _ _ _
+          ...     ≥ 0                         : sq_nonneg _, },
     linarith, },
-  let φ : ℝ →+*o ℝ := { to_ring_hom := f, monotone' := strict_mono.monotone f_smon, },
+  let φ : ℝ →+*o ℝ := { to_ring_hom := f, monotone' := f_mon },
   let ι : ℝ →+*o ℝ := { to_ring_hom := ring_hom.id ℝ, monotone' := monotone_id, },
   haveI : subsingleton (ℝ →+*o ℝ):= order_ring_hom.subsingleton,
   exact congr_arg (λ f : ℝ →+*o ℝ, f.to_ring_hom) (subsingleton.elim φ ι),

--- a/src/algebra/order/complete_field.lean
+++ b/src/algebra/order/complete_field.lean
@@ -312,3 +312,35 @@ instance : unique (β ≃+*o γ) := unique_of_subsingleton $ induced_order_ring_
 
 end induced_map
 end linear_ordered_field
+
+section real
+
+/-- Any ring homomorphism `ℝ → ℝ` is an ordered ring isomorphism and thus there are no
+nontrivial ring homorphism `ℝ → ℝ`. -/
+lemma real.ring_hom_eq_id (f : ℝ →+* ℝ) : f = ring_hom.id ℝ :=
+begin
+  have f_smon : strict_mono f,
+  { intros a b hab,
+    let e := real.sqrt (b - a),
+    have fenz : f e ≠ 0,
+    { have f_inj : function.injective f := ring_hom.injective f,
+      rw map_ne_zero_iff _ f_inj,
+      rw real.sqrt_ne_zero',
+      linarith, },
+    have : f b - f a > 0,
+    { calc
+        f b - f a = f (b - a)   : (ring_hom.map_sub _ _ _).symm
+          ...     = f (e^2)     : by rw (real.sq_sqrt (le_of_lt $ sub_pos.mpr hab))
+          ...     = (f e)^2     : ring_hom.map_pow _ _ _
+          ...     > 0           : (sq_pos_iff (f e)).mpr fenz,
+    },
+    linarith, },
+    let φ : ℝ →+*o ℝ := { to_ring_hom := f, monotone' := strict_mono.monotone f_smon, },
+    let ι : ℝ →+*o ℝ := { to_ring_hom := ring_hom.id ℝ, monotone' := monotone_id, },
+    haveI : subsingleton (ℝ →+*o ℝ):= order_ring_hom.subsingleton,
+    exact congr_arg (λ f : ℝ →+*o ℝ, f.to_ring_hom) (subsingleton.elim φ ι),
+end
+
+end real
+
+#lint

--- a/src/algebra/order/complete_field.lean
+++ b/src/algebra/order/complete_field.lean
@@ -315,22 +315,24 @@ end linear_ordered_field
 
 section real
 
-/-- Any ring homomorphism `ℝ → ℝ` is an ordered ring isomorphism, and thus there are no
-nontrivial ring homorphism `ℝ → ℝ`. -/
+variables {R S : Type*} [linear_ordered_field R] [linear_ordered_field S]
+
+lemma ring_hom_monotone (hR : ∀ r : R, r ≥ 0 → ∃ s : R, s^2 = r) (f : R →+* S) : monotone f :=
+begin
+  intros a b hab,
+  apply le_of_sub_nonneg,
+  obtain ⟨s, hs⟩ := hR (b - a) (sub_nonneg.mpr hab),
+  calc
+    f b - f a = f (b - a) : (ring_hom.map_sub _ _ _).symm
+          ... = f(s^2)    : by rw ←hs
+          ... = f(s)^2    : ring_hom.map_pow _ _ _
+          ... ≥ 0         : sq_nonneg _
+end
+
+/-- There exists no nontrivial ring homomorphism `ℝ →+* ℝ`. -/
 instance real.ring_hom.unique : unique (ℝ →+* ℝ) :=
 { default := ring_hom.id ℝ,
-  uniq :=
-  begin
-    intro f,
-    have fmon : monotone f,
-    { intros a b hab,
-      apply le_of_sub_nonneg,
-      calc
-        f b - f a = f (b - a)                 : (ring_hom.map_sub _ _ _).symm
-          ...     = f (real.sqrt (b - a)^2)   : by rw sq_sqrt (sub_nonneg.mpr hab)
-          ...     = (f (real.sqrt (b - a)))^2 : ring_hom.map_pow _ _ _
-          ...     ≥ 0                         : sq_nonneg _, },
-    exact congr_arg order_ring_hom.to_ring_hom (subsingleton.elim ⟨f, fmon⟩ default),
-  end }
+  uniq := λ f, congr_arg order_ring_hom.to_ring_hom
+    (subsingleton.elim ⟨f, ring_hom_monotone (λ r hr, ⟨real.sqrt r, sq_sqrt hr⟩) f⟩ default), }
 
 end real

--- a/src/algebra/order/complete_field.lean
+++ b/src/algebra/order/complete_field.lean
@@ -324,13 +324,12 @@ instance real.ring_hom.unique : unique (ℝ →+* ℝ) :=
     intro f,
     have fmon : monotone f,
     { intros a b hab,
-      have : f b - f a ≥ 0,
-      { calc
-          f b - f a = f (b - a)                 : (ring_hom.map_sub _ _ _).symm
-            ...     = f (real.sqrt (b - a)^2)   : by rw sq_sqrt (sub_nonneg.mpr hab)
-            ...     = (f (real.sqrt (b - a)))^2 : ring_hom.map_pow _ _ _
-            ...     ≥ 0                         : sq_nonneg _, },
-      linarith, },
+      apply le_of_sub_nonneg,
+      calc
+        f b - f a = f (b - a)                 : (ring_hom.map_sub _ _ _).symm
+          ...     = f (real.sqrt (b - a)^2)   : by rw sq_sqrt (sub_nonneg.mpr hab)
+          ...     = (f (real.sqrt (b - a)))^2 : ring_hom.map_pow _ _ _
+          ...     ≥ 0                         : sq_nonneg _, },
     exact congr_arg order_ring_hom.to_ring_hom (subsingleton.elim ⟨f, fmon⟩ default),
   end }
 

--- a/src/algebra/order/complete_field.lean
+++ b/src/algebra/order/complete_field.lean
@@ -332,9 +332,7 @@ instance real.ring_hom.unique : unique (ℝ →+* ℝ) :=
             ...     ≥ 0                         : sq_nonneg _, },
       linarith, },
     haveI : subsingleton (ℝ →+*o ℝ):= order_ring_hom.subsingleton,
-    exact congr_arg order_ring_hom.to_ring_hom
-      (subsingleton.elim ⟨f, f_mon⟩ ⟨ring_hom.id ℝ, monotone_id⟩),
-  end,
-}
+    exact congr_arg order_ring_hom.to_ring_hom (subsingleton.elim ⟨f, f_mon⟩ ⟨_, monotone_id⟩),
+  end }
 
 end real

--- a/src/algebra/order/complete_field.lean
+++ b/src/algebra/order/complete_field.lean
@@ -317,7 +317,7 @@ section real
 
 variables {R S : Type*} [linear_ordered_field R] [linear_ordered_field S]
 
-lemma ring_hom_monotone (hR : ∀ r : R, r ≥ 0 → ∃ s : R, s^2 = r) (f : R →+* S) : monotone f :=
+lemma ring_hom_monotone (hR : ∀ r : R, 0 ≤ r → ∃ s : R, s^2 = r) (f : R →+* S) : monotone f :=
 begin
   intros a b hab,
   apply le_of_sub_nonneg,

--- a/src/algebra/order/complete_field.lean
+++ b/src/algebra/order/complete_field.lean
@@ -329,13 +329,12 @@ begin
         f b - f a = f (b - a)   : (ring_hom.map_sub _ _ _).symm
           ...     = f (e^2)     : by rw (real.sq_sqrt (le_of_lt $ sub_pos.mpr hab))
           ...     = (f e)^2     : ring_hom.map_pow _ _ _
-          ...     > 0           : (sq_pos_iff (f e)).mpr fenz,
-    },
+          ...     > 0           : (sq_pos_iff (f e)).mpr fenz, },
     linarith, },
-    let φ : ℝ →+*o ℝ := { to_ring_hom := f, monotone' := strict_mono.monotone f_smon, },
-    let ι : ℝ →+*o ℝ := { to_ring_hom := ring_hom.id ℝ, monotone' := monotone_id, },
-    haveI : subsingleton (ℝ →+*o ℝ):= order_ring_hom.subsingleton,
-    exact congr_arg (λ f : ℝ →+*o ℝ, f.to_ring_hom) (subsingleton.elim φ ι),
+  let φ : ℝ →+*o ℝ := { to_ring_hom := f, monotone' := strict_mono.monotone f_smon, },
+  let ι : ℝ →+*o ℝ := { to_ring_hom := ring_hom.id ℝ, monotone' := monotone_id, },
+  haveI : subsingleton (ℝ →+*o ℝ):= order_ring_hom.subsingleton,
+  exact congr_arg (λ f : ℝ →+*o ℝ, f.to_ring_hom) (subsingleton.elim φ ι),
 end
 
 end real

--- a/src/algebra/order/complete_field.lean
+++ b/src/algebra/order/complete_field.lean
@@ -331,7 +331,6 @@ instance real.ring_hom.unique : unique (ℝ →+* ℝ) :=
             ...     = (f (real.sqrt (b - a)))^2 : ring_hom.map_pow _ _ _
             ...     ≥ 0                         : sq_nonneg _, },
       linarith, },
-    haveI : subsingleton (ℝ →+*o ℝ):= order_ring_hom.subsingleton,
     exact congr_arg order_ring_hom.to_ring_hom (subsingleton.elim ⟨f, fmon⟩ default),
   end }
 

--- a/src/algebra/order/complete_field.lean
+++ b/src/algebra/order/complete_field.lean
@@ -328,10 +328,9 @@ begin
           ...     = (f (real.sqrt (b - a)))^2 : ring_hom.map_pow _ _ _
           ...     ≥ 0                         : sq_nonneg _, },
     linarith, },
-  let φ : ℝ →+*o ℝ := { to_ring_hom := f, monotone' := f_mon },
-  let ι : ℝ →+*o ℝ := { to_ring_hom := ring_hom.id ℝ, monotone' := monotone_id, },
   haveI : subsingleton (ℝ →+*o ℝ):= order_ring_hom.subsingleton,
-  exact congr_arg (λ f : ℝ →+*o ℝ, f.to_ring_hom) (subsingleton.elim φ ι),
+  exact congr_arg order_ring_hom.to_ring_hom
+    (subsingleton.elim ⟨f, f_mon⟩ ⟨ring_hom.id ℝ, monotone_id⟩),
 end
 
 end real

--- a/src/algebra/order/complete_field.lean
+++ b/src/algebra/order/complete_field.lean
@@ -317,20 +317,24 @@ section real
 
 /-- Any ring homomorphism `ℝ → ℝ` is an ordered ring isomorphism, and thus there are no
 nontrivial ring homorphism `ℝ → ℝ`. -/
-lemma real.ring_hom_eq_id (f : ℝ →+* ℝ) : f = ring_hom.id ℝ :=
-begin
-  have f_mon : monotone f,
-  { intros a b hab,
-    have : f b - f a ≥ 0,
-    { calc
-        f b - f a = f (b - a)                 : (ring_hom.map_sub _ _ _).symm
-          ...     = f (real.sqrt (b - a)^2)   : by rw sq_sqrt (sub_nonneg.mpr hab)
-          ...     = (f (real.sqrt (b - a)))^2 : ring_hom.map_pow _ _ _
-          ...     ≥ 0                         : sq_nonneg _, },
-    linarith, },
-  haveI : subsingleton (ℝ →+*o ℝ):= order_ring_hom.subsingleton,
-  exact congr_arg order_ring_hom.to_ring_hom
-    (subsingleton.elim ⟨f, f_mon⟩ ⟨ring_hom.id ℝ, monotone_id⟩),
-end
+instance real.ring_hom.unique : unique (ℝ →+* ℝ) :=
+{ default := ring_hom.id ℝ,
+  uniq :=
+  begin
+    intro f,
+    have f_mon : monotone f,
+    { intros a b hab,
+      have : f b - f a ≥ 0,
+      { calc
+          f b - f a = f (b - a)                 : (ring_hom.map_sub _ _ _).symm
+            ...     = f (real.sqrt (b - a)^2)   : by rw sq_sqrt (sub_nonneg.mpr hab)
+            ...     = (f (real.sqrt (b - a)))^2 : ring_hom.map_pow _ _ _
+            ...     ≥ 0                         : sq_nonneg _, },
+      linarith, },
+    haveI : subsingleton (ℝ →+*o ℝ):= order_ring_hom.subsingleton,
+    exact congr_arg order_ring_hom.to_ring_hom
+      (subsingleton.elim ⟨f, f_mon⟩ ⟨ring_hom.id ℝ, monotone_id⟩),
+  end,
+}
 
 end real

--- a/src/algebra/order/complete_field.lean
+++ b/src/algebra/order/complete_field.lean
@@ -322,11 +322,8 @@ begin
   have f_smon : strict_mono f,
   { intros a b hab,
     let e := real.sqrt (b - a),
-    have fenz : f e ≠ 0,
-    { have f_inj : function.injective f := ring_hom.injective f,
-      rw map_ne_zero_iff _ f_inj,
-      rw real.sqrt_ne_zero',
-      linarith, },
+    have fenz : f e ≠ 0 :=
+      by rwa [map_ne_zero_iff _ (ring_hom.injective f), real.sqrt_ne_zero', sub_pos],
     have : f b - f a > 0,
     { calc
         f b - f a = f (b - a)   : (ring_hom.map_sub _ _ _).symm
@@ -342,5 +339,3 @@ begin
 end
 
 end real
-
-#lint

--- a/src/algebra/order/complete_field.lean
+++ b/src/algebra/order/complete_field.lean
@@ -332,7 +332,7 @@ instance real.ring_hom.unique : unique (ℝ →+* ℝ) :=
             ...     ≥ 0                         : sq_nonneg _, },
       linarith, },
     haveI : subsingleton (ℝ →+*o ℝ):= order_ring_hom.subsingleton,
-    exact congr_arg order_ring_hom.to_ring_hom (subsingleton.elim ⟨f, fmon⟩ ⟨default, monotone_id⟩),
+    exact congr_arg order_ring_hom.to_ring_hom (subsingleton.elim ⟨f, fmon⟩ default),
   end }
 
 end real


### PR DESCRIPTION
Proves that there are no nontrivial ring homomorphism from ℝ to ℝ. 

This is motivated by a remark of K. Buzzard (see https://leanprover.zulipchat.com/#narrow/stream/217875-Is-there-code-for-X.3F/topic/Continuous.20complex.20ring.20hom/near/293264751). 

It looks like it should be a direct consequence of the results of ```algebra/order/complete.field``` but I was not able to see how to do it more directly. 

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
