### PR TITLE
fix(topology/algebra/module/locally_convex): minimize imports

### DIFF
--- a/src/topology/algebra/module/locally_convex.lean
+++ b/src/topology/algebra/module/locally_convex.lean
@@ -3,7 +3,8 @@ Copyright (c) 2022 Anatole Dedecker. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Anatole Dedecker
 -/
-import analysis.convex.topology
+import analysis.convex.basic
+import topology.algebra.module.basic
 /-!
 # Locally convex topological modules
 


### PR DESCRIPTION
This was causing problems for defining the strong operator topology because this file currently transitively imports `analysis/normed_space/operator_norm`

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
