### PR TITLE
[Merged by Bors] - feat(analysis/convex/topology): minimize import

### DIFF
--- a/src/analysis/convex/strict_convex_space.lean
+++ b/src/analysis/convex/strict_convex_space.lean
@@ -7,6 +7,7 @@ import analysis.convex.strict
 import analysis.convex.topology
 import analysis.normed_space.ordered
 import analysis.normed_space.pointwise
+import analysis.normed_space.affine_isometry
 
 /-!
 # Strictly convex spaces

--- a/src/analysis/convex/topology.lean
+++ b/src/analysis/convex/topology.lean
@@ -5,7 +5,7 @@ Authors: Alexander Bentkamp, Yury Kudryashov
 -/
 import analysis.convex.jensen
 import analysis.normed.group.pointwise
-import analysis.normed_space.finite_dimension
+import topology.algebra.module.finite_dimension
 import analysis.normed_space.ray
 import topology.path_connected
 import topology.algebra.affine


### PR DESCRIPTION
Importing `analysis/normed_space/finite_dimension` was problematic for defining the strong operator topology because this needs quite a few facts about convexity but it has to be defined before `continuous_linear_map.has_op_norm`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
