### PR TITLE
[Merged by Bors] - feat(analysis/special_functions/trigonometric/angle): more on angles equal or not equal to 0 or π

### DIFF
--- a/src/analysis/special_functions/trigonometric/angle.lean
+++ b/src/analysis/special_functions/trigonometric/angle.lean
@@ -105,8 +105,26 @@ by simp_rw [←coe_nat_zsmul, int.coe_nat_bit0, int.coe_nat_one, two_zsmul_eq_if
 lemma two_nsmul_eq_zero_iff {θ : angle} : (2 : ℕ) • θ = 0 ↔ (θ = 0 ∨ θ = π) :=
 by convert two_nsmul_eq_iff; simp
 
+lemma two_nsmul_ne_zero_iff {θ : angle} : (2 : ℕ) • θ ≠ 0 ↔ θ ≠ 0 ∧ θ ≠ π :=
+by rw [←not_or_distrib, ←two_nsmul_eq_zero_iff]
+
 lemma two_zsmul_eq_zero_iff {θ : angle} : (2 : ℤ) • θ = 0 ↔ (θ = 0 ∨ θ = π) :=
 by simp_rw [two_zsmul, ←two_nsmul, two_nsmul_eq_zero_iff]
+
+lemma two_zsmul_ne_zero_iff {θ : angle} : (2 : ℤ) • θ ≠ 0 ↔ θ ≠ 0 ∧ θ ≠ π :=
+by rw [←not_or_distrib, ←two_zsmul_eq_zero_iff]
+
+lemma eq_neg_self_iff {θ : angle} : θ = -θ ↔ θ = 0 ∨ θ = π :=
+by rw [←add_eq_zero_iff_eq_neg, ←two_nsmul, two_nsmul_eq_zero_iff]
+
+lemma ne_neg_self_iff {θ : angle} : θ ≠ -θ ↔ θ ≠ 0 ∧ θ ≠ π :=
+by rw [←not_or_distrib, ←eq_neg_self_iff.not]
+
+lemma neg_eq_self_iff {θ : angle} : -θ = θ ↔ θ = 0 ∨ θ = π :=
+by rw [eq_comm, eq_neg_self_iff]
+
+lemma neg_ne_self_iff {θ : angle} : -θ ≠ θ ↔ θ ≠ 0 ∧ θ ≠ π :=
+by rw [←not_or_distrib, ←neg_eq_self_iff.not]
 
 theorem cos_eq_iff_coe_eq_or_eq_neg {θ ψ : ℝ} :
   cos θ = cos ψ ↔ (θ : angle) = ψ ∨ (θ : angle) = -ψ :=
@@ -227,6 +245,9 @@ begin
   simp
 end
 
+lemma sin_ne_zero_iff {θ : angle} : sin θ ≠ 0 ↔ θ ≠ 0 ∧ θ ≠ π :=
+by rw [←not_or_distrib, ←sin_eq_zero_iff]
+
 @[simp] lemma sin_neg (θ : angle) : sin (-θ) = -sin θ :=
 begin
   induction θ using real.angle.induction_on,
@@ -302,6 +323,9 @@ by simp [sign_antiperiodic.sub_eq']
 
 lemma sign_eq_zero_iff {θ : angle} : θ.sign = 0 ↔ θ = 0 ∨ θ = π :=
 by rw [sign, sign_eq_zero_iff, sin_eq_zero_iff]
+
+lemma sign_ne_zero_iff {θ : angle} : θ.sign ≠ 0 ↔ θ ≠ 0 ∧ θ ≠ π :=
+by rw [←not_or_distrib, ←sign_eq_zero_iff]
 
 end angle
 


### PR DESCRIPTION
We have various lemmas giving conditions for an angle to equal 0 or π.
Add some more such lemmas, plus negated versions of existing lemmas
giving conditions for angles not to equal 0 or π.



---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
