### PR TITLE
[Merged by Bors] - feat(data/sign): `sign_one`, `sign_mul`, `sign_pow`

### DIFF
--- a/src/data/sign.lean
+++ b/src/data/sign.lean
@@ -255,6 +255,15 @@ end
 
 end linear_order
 
+section ordered_semiring
+
+variables [ordered_semiring α] [decidable_rel ((<) : α → α → Prop)] [nontrivial α]
+
+@[simp] lemma sign_one : sign (1 : α) = 1 :=
+sign_pos zero_lt_one
+
+end ordered_semiring
+
 section linear_ordered_ring
 
 variables [linear_ordered_ring α] {a b : α}
@@ -262,6 +271,14 @@ variables [linear_ordered_ring α] {a b : α}
 /- I'm not sure why this is necessary, see https://leanprover.zulipchat.com/#narrow/stream/
 113488-general/topic/type.20class.20inference.20issues/near/276937942 -/
 local attribute [instance] linear_ordered_ring.decidable_lt
+
+lemma sign_mul (x y : α) : sign (x * y) = sign x * sign y :=
+begin
+  rcases lt_trichotomy x 0 with hx | hx | hx; rcases lt_trichotomy y 0 with hy | hy | hy;
+    simp only [sign_zero, mul_zero, zero_mul, sign_pos, sign_neg, hx, hy, mul_one, neg_one_mul,
+               neg_neg, one_mul, mul_pos_of_neg_of_neg, mul_neg_of_neg_of_pos, neg_zero',
+               mul_neg_of_pos_of_neg, mul_pos]
+end
 
 /-- `sign` as a `monoid_with_zero_hom` for a nontrivial ordered semiring. Note that linearity
 is required; consider ℂ with the order `z ≤ w` iff they have the same imaginary part and
@@ -271,14 +288,13 @@ def sign_hom : α →*₀ sign_type :=
 { to_fun := sign,
   map_zero' := sign_zero,
   map_one' := sign_pos zero_lt_one,
-  map_mul' := λ x y, by
-    rcases lt_trichotomy x 0 with hx | hx | hx; rcases lt_trichotomy y 0 with hy | hy | hy;
-    simp only [sign_zero, mul_zero, zero_mul, sign_pos, sign_neg, hx, hy, mul_one, neg_one_mul,
-               neg_neg, one_mul, mul_pos_of_neg_of_neg, mul_neg_of_neg_of_pos, neg_zero',
-               mul_neg_of_pos_of_neg, mul_pos] }
+  map_mul' := sign_mul }
 
-lemma sign_mul (a b : α) : sign (a * b) = sign a * sign b :=
-sign_hom.map_mul a b
+lemma sign_pow (x : α) (n : ℕ) : sign (x ^ n) = (sign x) ^ n :=
+begin
+  change sign_hom (x ^ n) = (sign_hom x) ^ n,
+  exact map_pow _ _ _
+end
 
 end linear_ordered_ring
 

--- a/src/data/sign.lean
+++ b/src/data/sign.lean
@@ -287,7 +287,7 @@ is required; consider ℂ with the order `z ≤ w` iff they have the same imagin
 def sign_hom : α →*₀ sign_type :=
 { to_fun := sign,
   map_zero' := sign_zero,
-  map_one' := sign_pos zero_lt_one,
+  map_one' := sign_one,
   map_mul' := sign_mul }
 
 lemma sign_pow (x : α) (n : ℕ) : sign (x ^ n) = (sign x) ^ n :=

--- a/src/data/sign.lean
+++ b/src/data/sign.lean
@@ -277,6 +277,9 @@ def sign_hom : α →*₀ sign_type :=
                neg_neg, one_mul, mul_pos_of_neg_of_neg, mul_neg_of_neg_of_pos, neg_zero',
                mul_neg_of_pos_of_neg, mul_pos] }
 
+lemma sign_mul (a b : α) : sign (a * b) = sign a * sign b :=
+sign_hom.map_mul a b
+
 end linear_ordered_ring
 
 section add_group


### PR DESCRIPTION
Add a lemma about the sign of the product of two numbers (in the
`linear_ordered_ring` case, extracted from the existing `sign_hom` in
that case). Also add `sign_one` and `sign_pow`.



---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
