### PR TITLE
chore(data.matrix): rename `minor` to `matrix.on`

### DIFF
--- a/scripts/nolints.txt
+++ b/scripts/nolints.txt
@@ -384,7 +384,7 @@ apply_nolint list.traverse doc_blame
 apply_nolint list.perm.prod_eq' to_additive_doc
 
 -- data/matrix/basic.lean
-apply_nolint matrix.mul_one_on fintype_finite
+apply_nolint matrix.mul_on_one fintype_finite
 apply_nolint matrix.one_on_mul fintype_finite
 
 -- data/matrix/basis.lean

--- a/scripts/nolints.txt
+++ b/scripts/nolints.txt
@@ -384,8 +384,8 @@ apply_nolint list.traverse doc_blame
 apply_nolint list.perm.prod_eq' to_additive_doc
 
 -- data/matrix/basic.lean
-apply_nolint matrix.mul_minor_one fintype_finite
-apply_nolint matrix.one_minor_mul fintype_finite
+apply_nolint matrix.mul_one_on fintype_finite
+apply_nolint matrix.one_on_mul fintype_finite
 
 -- data/matrix/basis.lean
 apply_nolint matrix.induction_on fintype_finite

--- a/src/algebra/lie/classical.lean
+++ b/src/algebra/lie/classical.lean
@@ -331,7 +331,7 @@ begin
   rcases i with ⟨⟨i₁ | i₂⟩ | i₃⟩;
   rcases j with ⟨⟨j₁ | j₂⟩ | j₃⟩;
   simp only [indefinite_diagonal, matrix.diagonal, equiv.sum_assoc_apply_inl_inl,
-    matrix.reindex_lie_equiv_apply, matrix.minor_apply, equiv.symm_symm, matrix.reindex_apply,
+    matrix.reindex_lie_equiv_apply, matrix.on_apply, equiv.symm_symm, matrix.reindex_apply,
     sum.elim_inl, if_true, eq_self_iff_true, matrix.one_apply_eq, matrix.from_blocks_apply₁₁,
     dmatrix.zero_apply, equiv.sum_assoc_apply_inl_inr, if_false, matrix.from_blocks_apply₁₂,
     matrix.from_blocks_apply₂₁, matrix.from_blocks_apply₂₂, equiv.sum_assoc_apply_inr,

--- a/src/algebra/lie/matrix.lean
+++ b/src/algebra/lie/matrix.lean
@@ -73,7 +73,7 @@ types, `matrix.reindex`, is an equivalence of Lie algebras. -/
 def matrix.reindex_lie_equiv : matrix n n R ≃ₗ⁅R⁆ matrix m m R :=
 { to_fun := matrix.reindex e e,
   map_lie' := λ M N, by simp only [lie_ring.of_associative_ring_bracket, matrix.reindex_apply,
-    matrix.minor_mul_equiv, matrix.mul_eq_mul, matrix.minor_sub, pi.sub_apply],
+    matrix.on_mul_equiv, matrix.mul_eq_mul, matrix.on_sub, pi.sub_apply],
   ..(matrix.reindex_linear_equiv R R e e) }
 
 @[simp] lemma matrix.reindex_lie_equiv_apply (M : matrix n n R) :

--- a/src/data/matrix/basic.lean
+++ b/src/data/matrix/basic.lean
@@ -1647,7 +1647,6 @@ lemma star_mul [fintype n] [non_unital_semiring α] [star_ring α] (M N : matrix
   star (M ⬝ N) = star N ⬝ star M := conj_transpose_mul _ _
 
 end star
-end matrix
 
 /-- Given maps `(r_reindex : l → m)` and  `(c_reindex : o → n)` reindexing the rows and columns of
 a matrix `M : matrix m n α`, the matrix `M.on r_reindex c_reindex : matrix l o α` is defined
@@ -1656,10 +1655,8 @@ by `(M.on r_reindex c_reindex) i j = M (r_reindex i) (c_reindex j)` for `(i,j) :
 We call this function `matrix.on` because it resembles `function.on_fun M f` (written `M on f`
 using notation). Note that the total number of row and columns does not have to be preserved.
 If `r_reindex` and `c_reindex` are injective, then the resulting matrix is a submatrix. -/
-protected def matrix.on (A : matrix m n α) (r_reindex : l → m) (c_reindex : o → n) : matrix l o α :=
+protected def «on» (A : matrix m n α) (r_reindex : l → m) (c_reindex : o → n) : matrix l o α :=
 matrix.of $ λ i j, A (r_reindex i) (c_reindex j)
-
-namespace matrix
 
 @[simp] lemma on_apply (A : matrix m n α) (r_reindex : l → m) (c_reindex : o → n) (i j) :
   A.on r_reindex c_reindex i j = A (r_reindex i) (c_reindex j) := rfl

--- a/src/data/matrix/basic.lean
+++ b/src/data/matrix/basic.lean
@@ -1647,148 +1647,151 @@ lemma star_mul [fintype n] [non_unital_semiring α] [star_ring α] (M N : matrix
   star (M ⬝ N) = star N ⬝ star M := conj_transpose_mul _ _
 
 end star
+end matrix
 
 /-- Given maps `(r_reindex : l → m)` and  `(c_reindex : o → n)` reindexing the rows and columns of
-a matrix `M : matrix m n α`, the matrix `M.minor r_reindex c_reindex : matrix l o α` is defined
-by `(M.minor r_reindex c_reindex) i j = M (r_reindex i) (c_reindex j)` for `(i,j) : l × o`.
+a matrix `M : matrix m n α`, the matrix `M.on r_reindex c_reindex : matrix l o α` is defined
+by `(M.on r_reindex c_reindex) i j = M (r_reindex i) (c_reindex j)` for `(i,j) : l × o`.
 Note that the total number of row and columns does not have to be preserved. -/
-def minor (A : matrix m n α) (r_reindex : l → m) (c_reindex : o → n) : matrix l o α :=
-of $ λ i j, A (r_reindex i) (c_reindex j)
+protected def matrix.on (A : matrix m n α) (r_reindex : l → m) (c_reindex : o → n) : matrix l o α :=
+matrix.of $ λ i j, A (r_reindex i) (c_reindex j)
 
-@[simp] lemma minor_apply (A : matrix m n α) (r_reindex : l → m) (c_reindex : o → n) (i j) :
-  A.minor r_reindex c_reindex i j = A (r_reindex i) (c_reindex j) := rfl
+namespace matrix
 
-@[simp] lemma minor_id_id (A : matrix m n α) :
-  A.minor id id = A :=
+@[simp] lemma on_apply (A : matrix m n α) (r_reindex : l → m) (c_reindex : o → n) (i j) :
+  A.on r_reindex c_reindex i j = A (r_reindex i) (c_reindex j) := rfl
+
+@[simp] lemma on_id_id (A : matrix m n α) :
+  A.on id id = A :=
 ext $ λ _ _, rfl
 
-@[simp] lemma minor_minor {l₂ o₂ : Type*} (A : matrix m n α)
+@[simp] lemma on_on {l₂ o₂ : Type*} (A : matrix m n α)
   (r₁ : l → m) (c₁ : o → n) (r₂ : l₂ → l) (c₂ : o₂ → o) :
-  (A.minor r₁ c₁).minor r₂ c₂ = A.minor (r₁ ∘ r₂) (c₁ ∘ c₂) :=
+  (A.on r₁ c₁).on r₂ c₂ = A.on (r₁ ∘ r₂) (c₁ ∘ c₂) :=
 ext $ λ _ _, rfl
 
-@[simp] lemma transpose_minor (A : matrix m n α) (r_reindex : l → m) (c_reindex : o → n) :
-  (A.minor r_reindex c_reindex)ᵀ = Aᵀ.minor c_reindex r_reindex :=
+@[simp] lemma transpose_on (A : matrix m n α) (r_reindex : l → m) (c_reindex : o → n) :
+  (A.on r_reindex c_reindex)ᵀ = Aᵀ.on c_reindex r_reindex :=
 ext $ λ _ _, rfl
 
-@[simp] lemma conj_transpose_minor
+@[simp] lemma conj_transpose_on
   [has_star α] (A : matrix m n α) (r_reindex : l → m) (c_reindex : o → n) :
-  (A.minor r_reindex c_reindex)ᴴ = Aᴴ.minor c_reindex r_reindex :=
+  (A.on r_reindex c_reindex)ᴴ = Aᴴ.on c_reindex r_reindex :=
 ext $ λ _ _, rfl
 
-lemma minor_add [has_add α] (A B : matrix m n α) :
-  ((A + B).minor : (l → m) → (o → n) → matrix l o α) = A.minor + B.minor := rfl
+lemma add_on [has_add α] (A B : matrix m n α) :
+  ((A + B).on : (l → m) → (o → n) → matrix l o α) = A.on + B.on := rfl
 
-lemma minor_neg [has_neg α] (A : matrix m n α) :
-  ((-A).minor : (l → m) → (o → n) → matrix l o α) = -A.minor := rfl
+lemma neg_on [has_neg α] (A : matrix m n α) :
+  ((-A).on : (l → m) → (o → n) → matrix l o α) = -A.on := rfl
 
-lemma minor_sub [has_sub α] (A B : matrix m n α) :
-  ((A - B).minor : (l → m) → (o → n) → matrix l o α) = A.minor - B.minor := rfl
+lemma sub_on [has_sub α] (A B : matrix m n α) :
+  ((A - B).on : (l → m) → (o → n) → matrix l o α) = A.on - B.on := rfl
 
-@[simp] lemma minor_zero [has_zero α] :
-  ((0 : matrix m n α).minor : (l → m) → (o → n) → matrix l o α) = 0 := rfl
+@[simp] lemma zero_on [has_zero α] :
+  ((0 : matrix m n α).on : (l → m) → (o → n) → matrix l o α) = 0 := rfl
 
-lemma minor_smul {R : Type*} [has_smul R α] (r : R) (A : matrix m n α) :
-  ((r • A : matrix m n α).minor : (l → m) → (o → n) → matrix l o α) = r • A.minor := rfl
+lemma smul_on {R : Type*} [has_smul R α] (r : R) (A : matrix m n α) :
+  ((r • A : matrix m n α).on : (l → m) → (o → n) → matrix l o α) = r • A.on := rfl
 
-lemma minor_map (f : α → β) (e₁ : l → m) (e₂ : o → n) (A : matrix m n α) :
-  (A.map f).minor e₁ e₂ = (A.minor e₁ e₂).map f := rfl
+lemma map_on (f : α → β) (e₁ : l → m) (e₂ : o → n) (A : matrix m n α) :
+  (A.map f).on e₁ e₂ = (A.on e₁ e₂).map f := rfl
 
 /-- Given a `(m × m)` diagonal matrix defined by a map `d : m → α`, if the reindexing map `e` is
   injective, then the resulting matrix is again diagonal. -/
-lemma minor_diagonal [has_zero α] [decidable_eq m] [decidable_eq l] (d : m → α) (e : l → m)
+lemma diagonal_on [has_zero α] [decidable_eq m] [decidable_eq l] (d : m → α) (e : l → m)
   (he : function.injective e) :
-  (diagonal d).minor e e = diagonal (d ∘ e) :=
+  (diagonal d).on e e = diagonal (d ∘ e) :=
 ext $ λ i j, begin
-  rw minor_apply,
+  rw on_apply,
   by_cases h : i = j,
   { rw [h, diagonal_apply_eq, diagonal_apply_eq], },
   { rw [diagonal_apply_ne _ h, diagonal_apply_ne _ (he.ne h)], },
 end
 
-lemma minor_one [has_zero α] [has_one α] [decidable_eq m] [decidable_eq l] (e : l → m)
+lemma one_on [has_zero α] [has_one α] [decidable_eq m] [decidable_eq l] (e : l → m)
   (he : function.injective e) :
-  (1 : matrix m m α).minor e e = 1 :=
-minor_diagonal _ e he
+  (1 : matrix m m α).on e e = 1 :=
+diagonal_on _ e he
 
-lemma minor_mul [fintype n] [fintype o] [has_mul α] [add_comm_monoid α] {p q : Type*}
+lemma mul_on [fintype n] [fintype o] [has_mul α] [add_comm_monoid α] {p q : Type*}
   (M : matrix m n α) (N : matrix n p α)
   (e₁ : l → m) (e₂ : o → n) (e₃ : q → p) (he₂ : function.bijective e₂) :
-  (M ⬝ N).minor e₁ e₃ = (M.minor e₁ e₂) ⬝ (N.minor e₂ e₃) :=
+  (M ⬝ N).on e₁ e₃ = (M.on e₁ e₂) ⬝ (N.on e₂ e₃) :=
 ext $ λ _ _, (he₂.sum_comp _).symm
 
-lemma diag_minor (A : matrix m m α) (e : l → m) : diag (A.minor e e) = A.diag ∘ e := rfl
+lemma diag_on (A : matrix m m α) (e : l → m) : diag (A.on e e) = A.diag ∘ e := rfl
 
-/-! `simp` lemmas for `matrix.minor`s interaction with `matrix.diagonal`, `1`, and `matrix.mul` for
+/-! `simp` lemmas for `matrix.on`s interaction with `matrix.diagonal`, `1`, and `matrix.mul` for
 when the mappings are bundled. -/
 
 @[simp]
-lemma minor_diagonal_embedding [has_zero α] [decidable_eq m] [decidable_eq l] (d : m → α)
+lemma diagonal_on_embedding [has_zero α] [decidable_eq m] [decidable_eq l] (d : m → α)
   (e : l ↪ m) :
-  (diagonal d).minor e e = diagonal (d ∘ e) :=
-minor_diagonal d e e.injective
+  (diagonal d).on e e = diagonal (d ∘ e) :=
+diagonal_on d e e.injective
 
 @[simp]
-lemma minor_diagonal_equiv [has_zero α] [decidable_eq m] [decidable_eq l] (d : m → α)
+lemma diagonal_on_equiv [has_zero α] [decidable_eq m] [decidable_eq l] (d : m → α)
   (e : l ≃ m) :
-  (diagonal d).minor e e = diagonal (d ∘ e) :=
-minor_diagonal d e e.injective
+  (diagonal d).on e e = diagonal (d ∘ e) :=
+diagonal_on d e e.injective
 
 @[simp]
-lemma minor_one_embedding [has_zero α] [has_one α] [decidable_eq m] [decidable_eq l] (e : l ↪ m) :
-  (1 : matrix m m α).minor e e = 1 :=
-minor_one e e.injective
+lemma one_on_embedding [has_zero α] [has_one α] [decidable_eq m] [decidable_eq l] (e : l ↪ m) :
+  (1 : matrix m m α).on e e = 1 :=
+one_on e e.injective
 
 @[simp]
-lemma minor_one_equiv [has_zero α] [has_one α] [decidable_eq m] [decidable_eq l] (e : l ≃ m) :
-  (1 : matrix m m α).minor e e = 1 :=
-minor_one e e.injective
+lemma one_on_equiv [has_zero α] [has_one α] [decidable_eq m] [decidable_eq l] (e : l ≃ m) :
+  (1 : matrix m m α).on e e = 1 :=
+one_on e e.injective
 
 @[simp]
-lemma minor_mul_equiv [fintype n] [fintype o] [add_comm_monoid α] [has_mul α] {p q : Type*}
+lemma mul_on_equiv [fintype n] [fintype o] [add_comm_monoid α] [has_mul α] {p q : Type*}
   (M : matrix m n α) (N : matrix n p α) (e₁ : l → m) (e₂ : o ≃ n) (e₃ : q → p)  :
-  (M.minor e₁ e₂) ⬝ (N.minor e₂ e₃) = (M ⬝ N).minor e₁ e₃ :=
-(minor_mul M N e₁ e₂ e₃ e₂.bijective).symm
+  (M.on e₁ e₂) ⬝ (N.on e₂ e₃) = (M ⬝ N).on e₁ e₃ :=
+(mul_on M N e₁ e₂ e₃ e₂.bijective).symm
 
-lemma mul_minor_one [fintype n] [fintype o] [non_assoc_semiring α] [decidable_eq o] (e₁ : n ≃ o)
+lemma mul_one_on [fintype n] [fintype o] [non_assoc_semiring α] [decidable_eq o] (e₁ : n ≃ o)
   (e₂ : l → o) (M : matrix m n α) :
-  M ⬝ (1 : matrix o o α).minor e₁ e₂ = minor M id (e₁.symm ∘ e₂) :=
+  M ⬝ (1 : matrix o o α).on e₁ e₂ = M.on id (e₁.symm ∘ e₂) :=
 begin
-  let A := M.minor id e₁.symm,
-  have : M = A.minor id e₁,
-  { simp only [minor_minor, function.comp.right_id, minor_id_id, equiv.symm_comp_self], },
-  rw [this, minor_mul_equiv],
-  simp only [matrix.mul_one, minor_minor, function.comp.right_id, minor_id_id,
+  let A := M.on id e₁.symm,
+  have : M = A.on id e₁,
+  { simp only [on_on, function.comp.right_id, on_id_id, equiv.symm_comp_self], },
+  rw [this, mul_on_equiv],
+  simp only [matrix.mul_one, on_on, function.comp.right_id, on_id_id,
     equiv.symm_comp_self],
 end
 
-lemma one_minor_mul [fintype m] [fintype o] [non_assoc_semiring α] [decidable_eq o] (e₁ : l → o)
+lemma one_on_mul [fintype m] [fintype o] [non_assoc_semiring α] [decidable_eq o] (e₁ : l → o)
   (e₂ : m ≃ o) (M : matrix m n α) :
-  ((1 : matrix o o α).minor e₁ e₂).mul M = minor M (e₂.symm ∘ e₁) id :=
+  ((1 : matrix o o α).on e₁ e₂).mul M = M.on (e₂.symm ∘ e₁) id :=
 begin
-  let A := M.minor e₂.symm id,
-  have : M = A.minor e₂ id,
-  { simp only [minor_minor, function.comp.right_id, minor_id_id, equiv.symm_comp_self], },
-  rw [this, minor_mul_equiv],
-  simp only [matrix.one_mul, minor_minor, function.comp.right_id, minor_id_id,
+  let A := M.on e₂.symm id,
+  have : M = A.on e₂ id,
+  { simp only [on_on, function.comp.right_id, on_id_id, equiv.symm_comp_self], },
+  rw [this, mul_on_equiv],
+  simp only [matrix.one_mul, on_on, function.comp.right_id, on_id_id,
     equiv.symm_comp_self],
 end
 
 /-- The natural map that reindexes a matrix's rows and columns with equivalent types is an
 equivalence. -/
 def reindex (eₘ : m ≃ l) (eₙ : n ≃ o) : matrix m n α ≃ matrix l o α :=
-{ to_fun    := λ M, M.minor eₘ.symm eₙ.symm,
-  inv_fun   := λ M, M.minor eₘ eₙ,
+{ to_fun    := λ M, M.on eₘ.symm eₙ.symm,
+  inv_fun   := λ M, M.on eₘ eₙ,
   left_inv  := λ M, by simp,
   right_inv := λ M, by simp, }
 
 @[simp] lemma reindex_apply (eₘ : m ≃ l) (eₙ : n ≃ o) (M : matrix m n α) :
-  reindex eₘ eₙ M = M.minor eₘ.symm eₙ.symm :=
+  reindex eₘ eₙ M = M.on eₘ.symm eₙ.symm :=
 rfl
 
 @[simp] lemma reindex_refl_refl (A : matrix m n α) :
   reindex (equiv.refl _) (equiv.refl _) A = A :=
-A.minor_id_id
+A.on_id_id
 
 @[simp] lemma reindex_symm (eₘ : m ≃ l) (eₙ : n ≃ o) :
   (reindex eₘ eₙ).symm = (reindex eₘ.symm eₙ.symm : matrix l o α ≃ _) :=
@@ -1797,7 +1800,7 @@ rfl
 @[simp] lemma reindex_trans {l₂ o₂ : Type*} (eₘ : m ≃ l) (eₙ : n ≃ o)
   (eₘ₂ : l ≃ l₂) (eₙ₂ : o ≃ o₂) : (reindex eₘ eₙ).trans (reindex eₘ₂ eₙ₂) =
     (reindex (eₘ.trans eₘ₂) (eₙ.trans eₙ₂) : matrix m n α ≃ _) :=
-equiv.ext $ λ A, (A.minor_minor eₘ.symm eₙ.symm eₘ₂.symm eₙ₂.symm : _)
+equiv.ext $ λ A, (A.on_on eₘ.symm eₙ.symm eₘ₂.symm eₙ₂.symm : _)
 
 lemma transpose_reindex (eₘ : m ≃ l) (eₙ : n ≃ o) (M : matrix m n α) :
   (reindex eₘ eₙ M)ᵀ = (reindex eₙ eₘ Mᵀ) :=
@@ -1808,30 +1811,30 @@ lemma conj_transpose_reindex [has_star α] (eₘ : m ≃ l) (eₙ : n ≃ o) (M 
 rfl
 
 @[simp]
-lemma minor_mul_transpose_minor [fintype m] [fintype n] [add_comm_monoid α] [has_mul α]
+lemma on_mul_transpose_on [fintype m] [fintype n] [add_comm_monoid α] [has_mul α]
   (e : m ≃ n) (M : matrix m n α) :
-  (M.minor id e) ⬝ (Mᵀ).minor e id = M ⬝ Mᵀ :=
-by rw [minor_mul_equiv, minor_id_id]
+  (M.on id e) ⬝ (Mᵀ).on e id = M ⬝ Mᵀ :=
+by rw [mul_on_equiv, on_id_id]
 
 /-- The left `n × l` part of a `n × (l+r)` matrix. -/
 @[reducible]
 def sub_left {m l r : nat} (A : matrix (fin m) (fin (l + r)) α) : matrix (fin m) (fin l) α :=
-minor A id (fin.cast_add r)
+A.on id (fin.cast_add r)
 
 /-- The right `n × r` part of a `n × (l+r)` matrix. -/
 @[reducible]
 def sub_right {m l r : nat} (A : matrix (fin m) (fin (l + r)) α) : matrix (fin m) (fin r) α :=
-minor A id (fin.nat_add l)
+A.on id (fin.nat_add l)
 
 /-- The top `u × n` part of a `(u+d) × n` matrix. -/
 @[reducible]
 def sub_up {d u n : nat} (A : matrix (fin (u + d)) (fin n) α) : matrix (fin u) (fin n) α :=
-minor A (fin.cast_add d) id
+A.on (fin.cast_add d) id
 
 /-- The bottom `d × n` part of a `(u+d) × n` matrix. -/
 @[reducible]
 def sub_down {d u n : nat} (A : matrix (fin (u + d)) (fin n) α) : matrix (fin d) (fin n) α :=
-minor A (fin.nat_add u) id
+A.on (fin.nat_add u) id
 
 /-- The top-right `u × r` part of a `(u+d) × (l+r)` matrix. -/
 @[reducible]
@@ -1943,7 +1946,7 @@ end
 
 @[simp] lemma update_column_subsingleton [subsingleton n] (A : matrix m n R)
   (i : n) (b : m → R) :
-  A.update_column i b = (col b).minor id (function.const n ()) :=
+  A.update_column i b = (col b).on id (function.const n ()) :=
 begin
   ext x y,
   simp [update_column_apply, subsingleton.elim i y]
@@ -1951,7 +1954,7 @@ end
 
 @[simp] lemma update_row_subsingleton [subsingleton m] (A : matrix m n R)
   (i : m) (b : n → R)  :
-  A.update_row i b = (row b).minor (function.const m ()) id :=
+  A.update_row i b = (row b).on (function.const m ()) id :=
 begin
   ext x y,
   simp [update_column_apply, subsingleton.elim i x]

--- a/src/data/matrix/basic.lean
+++ b/src/data/matrix/basic.lean
@@ -1756,7 +1756,7 @@ lemma on_mul_equiv [fintype n] [fintype o] [add_comm_monoid α] [has_mul α] {p 
   (M.on e₁ e₂) ⬝ (N.on e₂ e₃) = (M ⬝ N).on e₁ e₃ :=
 (on_mul M N e₁ e₂ e₃ e₂.bijective).symm
 
-lemma on_mul_one [fintype n] [fintype o] [non_assoc_semiring α] [decidable_eq o] (e₁ : n ≃ o)
+lemma mul_on_one [fintype n] [fintype o] [non_assoc_semiring α] [decidable_eq o] (e₁ : n ≃ o)
   (e₂ : l → o) (M : matrix m n α) :
   M ⬝ (1 : matrix o o α).on e₁ e₂ = M.on id (e₁.symm ∘ e₂) :=
 begin

--- a/src/data/matrix/basic.lean
+++ b/src/data/matrix/basic.lean
@@ -1652,7 +1652,10 @@ end matrix
 /-- Given maps `(r_reindex : l → m)` and  `(c_reindex : o → n)` reindexing the rows and columns of
 a matrix `M : matrix m n α`, the matrix `M.on r_reindex c_reindex : matrix l o α` is defined
 by `(M.on r_reindex c_reindex) i j = M (r_reindex i) (c_reindex j)` for `(i,j) : l × o`.
-Note that the total number of row and columns does not have to be preserved. -/
+
+We call this function `matrix.on` because it resembles `function.on_fun M f` (written `M on f`
+using notation). Note that the total number of row and columns does not have to be preserved.
+If `r_reindex` and `c_reindex` are injective, then the resulting matrix is a submatrix. -/
 protected def matrix.on (A : matrix m n α) (r_reindex : l → m) (c_reindex : o → n) : matrix l o α :=
 matrix.of $ λ i j, A (r_reindex i) (c_reindex j)
 

--- a/src/data/matrix/basic.lean
+++ b/src/data/matrix/basic.lean
@@ -1679,27 +1679,27 @@ ext $ λ _ _, rfl
   (A.on r_reindex c_reindex)ᴴ = Aᴴ.on c_reindex r_reindex :=
 ext $ λ _ _, rfl
 
-lemma add_on [has_add α] (A B : matrix m n α) :
+lemma on_add [has_add α] (A B : matrix m n α) :
   ((A + B).on : (l → m) → (o → n) → matrix l o α) = A.on + B.on := rfl
 
-lemma neg_on [has_neg α] (A : matrix m n α) :
+lemma on_neg [has_neg α] (A : matrix m n α) :
   ((-A).on : (l → m) → (o → n) → matrix l o α) = -A.on := rfl
 
-lemma sub_on [has_sub α] (A B : matrix m n α) :
+lemma on_sub [has_sub α] (A B : matrix m n α) :
   ((A - B).on : (l → m) → (o → n) → matrix l o α) = A.on - B.on := rfl
 
-@[simp] lemma zero_on [has_zero α] :
+@[simp] lemma on_zero [has_zero α] :
   ((0 : matrix m n α).on : (l → m) → (o → n) → matrix l o α) = 0 := rfl
 
-lemma smul_on {R : Type*} [has_smul R α] (r : R) (A : matrix m n α) :
+lemma on_smul {R : Type*} [has_smul R α] (r : R) (A : matrix m n α) :
   ((r • A : matrix m n α).on : (l → m) → (o → n) → matrix l o α) = r • A.on := rfl
 
-lemma map_on (f : α → β) (e₁ : l → m) (e₂ : o → n) (A : matrix m n α) :
+lemma on_map (f : α → β) (e₁ : l → m) (e₂ : o → n) (A : matrix m n α) :
   (A.map f).on e₁ e₂ = (A.on e₁ e₂).map f := rfl
 
 /-- Given a `(m × m)` diagonal matrix defined by a map `d : m → α`, if the reindexing map `e` is
   injective, then the resulting matrix is again diagonal. -/
-lemma diagonal_on [has_zero α] [decidable_eq m] [decidable_eq l] (d : m → α) (e : l → m)
+lemma on_diagonal [has_zero α] [decidable_eq m] [decidable_eq l] (d : m → α) (e : l → m)
   (he : function.injective e) :
   (diagonal d).on e e = diagonal (d ∘ e) :=
 ext $ λ i j, begin
@@ -1709,12 +1709,12 @@ ext $ λ i j, begin
   { rw [diagonal_apply_ne _ h, diagonal_apply_ne _ (he.ne h)], },
 end
 
-lemma one_on [has_zero α] [has_one α] [decidable_eq m] [decidable_eq l] (e : l → m)
+lemma on_one [has_zero α] [has_one α] [decidable_eq m] [decidable_eq l] (e : l → m)
   (he : function.injective e) :
   (1 : matrix m m α).on e e = 1 :=
-diagonal_on _ e he
+on_diagonal _ e he
 
-lemma mul_on [fintype n] [fintype o] [has_mul α] [add_comm_monoid α] {p q : Type*}
+lemma on_mul [fintype n] [fintype o] [has_mul α] [add_comm_monoid α] {p q : Type*}
   (M : matrix m n α) (N : matrix n p α)
   (e₁ : l → m) (e₂ : o → n) (e₃ : q → p) (he₂ : function.bijective e₂) :
   (M ⬝ N).on e₁ e₃ = (M.on e₁ e₂) ⬝ (N.on e₂ e₃) :=
@@ -1726,41 +1726,41 @@ lemma diag_on (A : matrix m m α) (e : l → m) : diag (A.on e e) = A.diag ∘ e
 when the mappings are bundled. -/
 
 @[simp]
-lemma diagonal_on_embedding [has_zero α] [decidable_eq m] [decidable_eq l] (d : m → α)
+lemma on_diagonal_embedding [has_zero α] [decidable_eq m] [decidable_eq l] (d : m → α)
   (e : l ↪ m) :
   (diagonal d).on e e = diagonal (d ∘ e) :=
-diagonal_on d e e.injective
+on_diagonal d e e.injective
 
 @[simp]
-lemma diagonal_on_equiv [has_zero α] [decidable_eq m] [decidable_eq l] (d : m → α)
+lemma on_diagonal_equiv [has_zero α] [decidable_eq m] [decidable_eq l] (d : m → α)
   (e : l ≃ m) :
   (diagonal d).on e e = diagonal (d ∘ e) :=
-diagonal_on d e e.injective
+on_diagonal d e e.injective
 
 @[simp]
-lemma one_on_embedding [has_zero α] [has_one α] [decidable_eq m] [decidable_eq l] (e : l ↪ m) :
+lemma on_one_embedding [has_zero α] [has_one α] [decidable_eq m] [decidable_eq l] (e : l ↪ m) :
   (1 : matrix m m α).on e e = 1 :=
-one_on e e.injective
+on_one e e.injective
 
 @[simp]
-lemma one_on_equiv [has_zero α] [has_one α] [decidable_eq m] [decidable_eq l] (e : l ≃ m) :
+lemma on_one_equiv [has_zero α] [has_one α] [decidable_eq m] [decidable_eq l] (e : l ≃ m) :
   (1 : matrix m m α).on e e = 1 :=
-one_on e e.injective
+on_one e e.injective
 
 @[simp]
-lemma mul_on_equiv [fintype n] [fintype o] [add_comm_monoid α] [has_mul α] {p q : Type*}
+lemma on_mul_equiv [fintype n] [fintype o] [add_comm_monoid α] [has_mul α] {p q : Type*}
   (M : matrix m n α) (N : matrix n p α) (e₁ : l → m) (e₂ : o ≃ n) (e₃ : q → p)  :
   (M.on e₁ e₂) ⬝ (N.on e₂ e₃) = (M ⬝ N).on e₁ e₃ :=
-(mul_on M N e₁ e₂ e₃ e₂.bijective).symm
+(on_mul M N e₁ e₂ e₃ e₂.bijective).symm
 
-lemma mul_one_on [fintype n] [fintype o] [non_assoc_semiring α] [decidable_eq o] (e₁ : n ≃ o)
+lemma on_mul_one [fintype n] [fintype o] [non_assoc_semiring α] [decidable_eq o] (e₁ : n ≃ o)
   (e₂ : l → o) (M : matrix m n α) :
   M ⬝ (1 : matrix o o α).on e₁ e₂ = M.on id (e₁.symm ∘ e₂) :=
 begin
   let A := M.on id e₁.symm,
   have : M = A.on id e₁,
   { simp only [on_on, function.comp.right_id, on_id_id, equiv.symm_comp_self], },
-  rw [this, mul_on_equiv],
+  rw [this, on_mul_equiv],
   simp only [matrix.mul_one, on_on, function.comp.right_id, on_id_id,
     equiv.symm_comp_self],
 end
@@ -1772,7 +1772,7 @@ begin
   let A := M.on e₂.symm id,
   have : M = A.on e₂ id,
   { simp only [on_on, function.comp.right_id, on_id_id, equiv.symm_comp_self], },
-  rw [this, mul_on_equiv],
+  rw [this, on_mul_equiv],
   simp only [matrix.one_mul, on_on, function.comp.right_id, on_id_id,
     equiv.symm_comp_self],
 end
@@ -1814,7 +1814,7 @@ rfl
 lemma on_mul_transpose_on [fintype m] [fintype n] [add_comm_monoid α] [has_mul α]
   (e : m ≃ n) (M : matrix m n α) :
   (M.on id e) ⬝ (Mᵀ).on e id = M ⬝ Mᵀ :=
-by rw [mul_on_equiv, on_id_id]
+by rw [on_mul_equiv, on_id_id]
 
 /-- The left `n × l` part of a `n × (l+r)` matrix. -/
 @[reducible]

--- a/src/data/matrix/block.lean
+++ b/src/data/matrix/block.lean
@@ -125,19 +125,19 @@ begin
   simp only [conj_transpose, from_blocks_transpose, from_blocks_map]
 end
 
-@[simp] lemma from_blocks_minor_sum_swap_left
+@[simp] lemma from_blocks_on_sum_swap_left
   (A : matrix n l α) (B : matrix n m α) (C : matrix o l α) (D : matrix o m α) (f : p → l ⊕ m) :
-  (from_blocks A B C D).minor sum.swap f = (from_blocks C D A B).minor id f :=
+  (from_blocks A B C D).on sum.swap f = (from_blocks C D A B).on id f :=
 by { ext i j, cases i; dsimp; cases f j; refl }
 
-@[simp] lemma from_blocks_minor_sum_swap_right
+@[simp] lemma from_blocks_on_sum_swap_right
   (A : matrix n l α) (B : matrix n m α) (C : matrix o l α) (D : matrix o m α) (f : p → n ⊕ o) :
-  (from_blocks A B C D).minor f sum.swap = (from_blocks B A D C).minor f id :=
+  (from_blocks A B C D).on f sum.swap = (from_blocks B A D C).on f id :=
 by { ext i j, cases j; dsimp; cases f i; refl }
 
-lemma from_blocks_minor_sum_swap_sum_swap {l m n o α : Type*}
+lemma from_blocks_on_sum_swap_sum_swap {l m n o α : Type*}
   (A : matrix n l α) (B : matrix n m α) (C : matrix o l α) (D : matrix o m α) :
-  (from_blocks A B C D).minor sum.swap sum.swap = from_blocks D C B A :=
+  (from_blocks A B C D).on sum.swap sum.swap = from_blocks D C B A :=
 by simp
 
 /-- A 2x2 block matrix is block diagonal if the blocks outside of the diagonal vanish -/
@@ -147,7 +147,7 @@ to_blocks₁₂ A = 0 ∧ to_blocks₂₁ A = 0
 /-- Let `p` pick out certain rows and `q` pick out certain columns of a matrix `M`. Then
   `to_block M p q` is the corresponding block matrix. -/
 def to_block (M : matrix m n α) (p : m → Prop) (q : n → Prop) :
-  matrix {a // p a} {a // q a} α := M.minor coe coe
+  matrix {a // p a} {a // q a} α := M.on coe coe
 
 @[simp] lemma to_block_apply (M : matrix m n α) (p : m → Prop) (q : n → Prop)
   (i : {a // p a}) (j : {a // q a}) : to_block M p q i j = M ↑i ↑j := rfl
@@ -155,7 +155,7 @@ def to_block (M : matrix m n α) (p : m → Prop) (q : n → Prop) :
 /-- Let `b` map rows and columns of a square matrix `M` to blocks. Then
   `to_square_block M b k` is the block `k` matrix. -/
 def to_square_block (M : matrix m m α) {n : nat} (b : m → fin n) (k : fin n) :
-  matrix {a // b a = k} {a // b a = k} α := M.minor coe coe
+  matrix {a // b a = k} {a // b a = k} α := M.on coe coe
 
 @[simp] lemma to_square_block_def (M : matrix m m α) {n : nat} (b : m → fin n) (k : fin n) :
   to_square_block M b k = λ i j, M ↑i ↑j := rfl
@@ -163,7 +163,7 @@ def to_square_block (M : matrix m m α) {n : nat} (b : m → fin n) (k : fin n) 
 /-- Alternate version with `b : m → nat`. Let `b` map rows and columns of a square matrix `M` to
   blocks. Then `to_square_block' M b k` is the block `k` matrix. -/
 def to_square_block' (M : matrix m m α) (b : m → nat) (k : nat) :
-  matrix {a // b a = k} {a // b a = k} α := M.minor coe coe
+  matrix {a // b a = k} {a // b a = k} α := M.on coe coe
 
 @[simp] lemma to_square_block_def' (M : matrix m m α) (b : m → nat) (k : nat) :
   to_square_block' M b k = λ i j, M ↑i ↑j := rfl
@@ -171,7 +171,7 @@ def to_square_block' (M : matrix m m α) (b : m → nat) (k : nat) :
 /-- Let `p` pick out certain rows and columns of a square matrix `M`. Then
   `to_square_block_prop M p` is the corresponding block matrix. -/
 def to_square_block_prop (M : matrix m m α) (p : m → Prop) :
-  matrix {a // p a} {a // p a} α := M.minor coe coe
+  matrix {a // p a} {a // p a} α := M.on coe coe
 
 @[simp] lemma to_square_block_prop_def (M : matrix m m α) (p : m → Prop) :
   to_square_block_prop M p = λ i j, M ↑i ↑j := rfl
@@ -460,8 +460,8 @@ lemma block_diagonal'_eq_block_diagonal (M : o → matrix m n α) {k k'} (i j) :
   block_diagonal M (i, k) (j, k') = block_diagonal' M ⟨k, i⟩ ⟨k', j⟩ :=
 rfl
 
-lemma block_diagonal'_minor_eq_block_diagonal (M : o → matrix m n α) :
-  (block_diagonal' M).minor (prod.to_sigma ∘ prod.swap) (prod.to_sigma ∘ prod.swap) =
+lemma block_diagonal'_on_eq_block_diagonal (M : o → matrix m n α) :
+  (block_diagonal' M).on (prod.to_sigma ∘ prod.swap) (prod.to_sigma ∘ prod.swap) =
     block_diagonal M :=
 matrix.ext $ λ ⟨k, i⟩ ⟨k', j⟩, rfl
 

--- a/src/data/matrix/notation.lean
+++ b/src/data/matrix/notation.lean
@@ -301,17 +301,17 @@ by { ext i, refine fin.cases _ _ i; simp }
 
 end smul
 
-section minor
+section on
 
-@[simp] lemma minor_empty (A : matrix m' n' α) (row : fin 0 → m') (col : o' → n') :
-  minor A row col = ![] :=
+@[simp] lemma on_empty (A : matrix m' n' α) (row : fin 0 → m') (col : o' → n') :
+  A.on row col = ![] :=
 empty_eq _
 
-@[simp] lemma minor_cons_row (A : matrix m' n' α) (i : m') (row : fin m → m') (col : o' → n') :
-  minor A (vec_cons i row) col = vec_cons (λ j, A i (col j)) (minor A row col) :=
-by { ext i j, refine fin.cases _ _ i; simp [minor] }
+@[simp] lemma on_cons_row (A : matrix m' n' α) (i : m') (row : fin m → m') (col : o' → n') :
+  A.on (vec_cons i row) col = vec_cons (λ j, A i (col j)) (A.on row col) :=
+by { ext i j, refine fin.cases _ _ i; simp [matrix.on] }
 
-end minor
+end on
 
 section vec2_and_vec3
 

--- a/src/data/matrix/notation.lean
+++ b/src/data/matrix/notation.lean
@@ -301,7 +301,7 @@ by { ext i, refine fin.cases _ _ i; simp }
 
 end smul
 
-section on
+section matrix_on
 
 @[simp] lemma on_empty (A : matrix m' n' α) (row : fin 0 → m') (col : o' → n') :
   A.on row col = ![] :=
@@ -311,7 +311,7 @@ empty_eq _
   A.on (vec_cons i row) col = vec_cons (λ j, A i (col j)) (A.on row col) :=
 by { ext i j, refine fin.cases _ _ i; simp [matrix.on] }
 
-end on
+end matrix_on
 
 section vec2_and_vec3
 

--- a/src/linear_algebra/determinant.lean
+++ b/src/linear_algebra/determinant.lean
@@ -89,8 +89,8 @@ begin
   -- Although `m` and `n` are different a priori, we will show they have the same cardinality.
   -- This turns the problem into one for square matrices, which is easy.
   let e := index_equiv_of_inv hMM' hM'M,
-  rw [← det_on_equiv_self e, ← mul_on_equiv _ _ _ (equiv.refl n) _, det_comm,
-    mul_on_equiv, equiv.coe_refl, on_id_id]
+  rw [← det_on_equiv_self e, ← on_mul_equiv _ _ _ (equiv.refl n) _, det_comm,
+    on_mul_equiv, equiv.coe_refl, on_id_id]
 end
 
 /-- If `M'` is a two-sided inverse for `M` (indexed differently), `det (M ⬝ N ⬝ M') = det N`.

--- a/src/linear_algebra/determinant.lean
+++ b/src/linear_algebra/determinant.lean
@@ -89,8 +89,8 @@ begin
   -- Although `m` and `n` are different a priori, we will show they have the same cardinality.
   -- This turns the problem into one for square matrices, which is easy.
   let e := index_equiv_of_inv hMM' hM'M,
-  rw [← det_minor_equiv_self e, ← minor_mul_equiv _ _ _ (equiv.refl n) _, det_comm,
-    minor_mul_equiv, equiv.coe_refl, minor_id_id]
+  rw [← det_on_equiv_self e, ← mul_on_equiv _ _ _ (equiv.refl n) _, det_comm,
+    mul_on_equiv, equiv.coe_refl, on_id_id]
 end
 
 /-- If `M'` is a two-sided inverse for `M` (indexed differently), `det (M ⬝ N ⬝ M') = det N`.

--- a/src/linear_algebra/matrix/adjugate.lean
+++ b/src/linear_algebra/matrix/adjugate.lean
@@ -21,10 +21,10 @@ which sends a matrix `A` and vector `b` to the vector consisting of the
 determinant of replacing the `i`th column of `A` with `b` at index `i`
 (written as `(A.update_column i b).det`).
 Using Cramer's rule, we can compute for each matrix `A` the matrix `adjugate A`.
-The entries of the adjugate are the determinants of each minor of `A`.
-Instead of defining a minor to be `A` with row `i` and column `j` deleted, we
-replace the `i`th row of `A` with the `j`th basis vector; this has the same
-determinant as the minor but more importantly equals Cramer's rule applied
+The entries of the adjugate are the minors of `A`.
+Instead of defining a minor by deleting row `i` and column `j` of `A`, we
+replace the `i`th row of `A` with the `j`th basis vector; the resulting matrix
+has the same determinant but more importantly equals Cramer's rule applied
 to `A` and the `j`th basis vector, simplifying the subsequent proofs.
 We prove the adjugate behaves like `det A • A⁻¹`.
 

--- a/src/linear_algebra/matrix/basis.lean
+++ b/src/linear_algebra/matrix/basis.lean
@@ -214,7 +214,7 @@ lemma basis.to_matrix_reindex' [decidable_eq ι] [decidable_eq ι']
   (b : basis ι R M) (v : ι' → M) (e : ι ≃ ι') :
   (b.reindex e).to_matrix v = matrix.reindex_alg_equiv _ e (b.to_matrix (v ∘ e)) :=
 by { ext, simp only [basis.to_matrix_apply, basis.reindex_repr, matrix.reindex_alg_equiv_apply,
-        matrix.reindex_apply, matrix.minor_apply, function.comp_app, e.apply_symm_apply] }
+        matrix.reindex_apply, matrix.on_apply, function.comp_app, e.apply_symm_apply] }
 
 end fintype
 
@@ -237,8 +237,8 @@ by rw [basis.to_matrix_mul_to_matrix, basis.to_matrix_self]
 @[simp]
 lemma basis.to_matrix_reindex
   (b : basis ι R M) (v : ι' → M) (e : ι ≃ ι') :
-  (b.reindex e).to_matrix v = (b.to_matrix v).minor e.symm id :=
-by { ext, simp only [basis.to_matrix_apply, basis.reindex_repr, matrix.minor_apply, id.def] }
+  (b.reindex e).to_matrix v = (b.to_matrix v).on e.symm id :=
+by { ext, simp only [basis.to_matrix_apply, basis.reindex_repr, matrix.on_apply, id.def] }
 
 @[simp]
 lemma basis.to_matrix_map (b : basis ι R M) (f : M ≃ₗ[R] N) (v : ι → N) :

--- a/src/linear_algebra/matrix/block.lean
+++ b/src/linear_algebra/matrix/block.lean
@@ -51,7 +51,7 @@ begin
   simp only [matrix.reindex_apply, to_block_apply, equiv.symm_symm,
     equiv.sum_compl_apply_inr, equiv.sum_compl_apply_inl,
     from_blocks_apply₁₁, from_blocks_apply₁₂, from_blocks_apply₂₁, from_blocks_apply₂₂,
-    matrix.minor_apply],
+    matrix.on_apply],
 end
 
 lemma det_to_square_block (M : matrix m m R) {n : nat} (b : m → fin n) (k : fin n) :

--- a/src/linear_algebra/matrix/determinant.lean
+++ b/src/linear_algebra/matrix/determinant.lean
@@ -214,8 +214,8 @@ lemma det_permute (σ : perm n) (M : matrix n n R) : matrix.det (λ i, M (σ i))
 
 /-- Permuting rows and columns with the same equivalence has no effect. -/
 @[simp]
-lemma det_minor_equiv_self (e : n ≃ m) (A : matrix m m R) :
-  det (A.minor e e) = det A :=
+lemma det_on_equiv_self (e : n ≃ m) (A : matrix m m R) :
+  det (A.on e e) = det A :=
 begin
   rw [det_apply', det_apply'],
   apply fintype.sum_equiv (equiv.perm_congr e),
@@ -224,16 +224,16 @@ begin
   congr' 1,
   apply fintype.prod_equiv e,
   intro i,
-  rw [equiv.perm_congr_apply, equiv.symm_apply_apply, minor_apply],
+  rw [equiv.perm_congr_apply, equiv.symm_apply_apply, on_apply],
 end
 
 /-- Reindexing both indices along the same equivalence preserves the determinant.
 
-For the `simp` version of this lemma, see `det_minor_equiv_self`; this one is unsuitable because
+For the `simp` version of this lemma, see `det_on_equiv_self`; this one is unsuitable because
 `matrix.reindex_apply` unfolds `reindex` first.
 -/
 lemma det_reindex_self (e : m ≃ n) (A : matrix m m R) : det (reindex e e A) = det A :=
-det_minor_equiv_self e.symm A
+det_on_equiv_self e.symm A
 
 /-- The determinant of a permutation matrix equals its sign. -/
 @[simp] lemma det_permutation (σ : perm n) :
@@ -642,10 +642,10 @@ by rw [←det_transpose, from_blocks_transpose, transpose_zero, det_from_blocks_
 /-- Laplacian expansion of the determinant of an `n+1 × n+1` matrix along column 0. -/
 lemma det_succ_column_zero {n : ℕ} (A : matrix (fin n.succ) (fin n.succ) R) :
   det A = ∑ i : fin n.succ, (-1) ^ (i : ℕ) * A i 0 *
-    det (A.minor i.succ_above fin.succ) :=
+    det (A.on i.succ_above fin.succ) :=
 begin
   rw [matrix.det_apply, finset.univ_perm_fin_succ, ← finset.univ_product_univ],
-  simp only [finset.sum_map, equiv.to_embedding_apply, finset.sum_product, matrix.minor],
+  simp only [finset.sum_map, equiv.to_embedding_apply, finset.sum_product, matrix.on],
   refine finset.sum_congr rfl (λ i _, fin.cases _ (λ i, _) i),
   { simp only [fin.prod_univ_succ, matrix.det_apply, finset.mul_sum,
         equiv.perm.decompose_fin_symm_apply_zero, fin.coe_zero, one_mul,
@@ -676,16 +676,16 @@ end
 /-- Laplacian expansion of the determinant of an `n+1 × n+1` matrix along row 0. -/
 lemma det_succ_row_zero {n : ℕ} (A : matrix (fin n.succ) (fin n.succ) R) :
   det A = ∑ j : fin n.succ, (-1) ^ (j : ℕ) * A 0 j *
-    det (A.minor fin.succ j.succ_above) :=
+    det (A.on fin.succ j.succ_above) :=
 by { rw [← det_transpose A, det_succ_column_zero],
      refine finset.sum_congr rfl (λ i _, _),
      rw [← det_transpose],
-     simp only [transpose_apply, transpose_minor, transpose_transpose] }
+     simp only [transpose_apply, transpose_on, transpose_transpose] }
 
 /-- Laplacian expansion of the determinant of an `n+1 × n+1` matrix along row `i`. -/
 lemma det_succ_row {n : ℕ} (A : matrix (fin n.succ) (fin n.succ) R) (i : fin n.succ) :
   det A = ∑ j : fin n.succ, (-1) ^ (i + j : ℕ) * A i j *
-    det (A.minor i.succ_above j.succ_above) :=
+    det (A.on i.succ_above j.succ_above) :=
 begin
   simp_rw [pow_add, mul_assoc, ← mul_sum],
   have : det A = (-1 : R) ^ (i : ℕ) * (i.cycle_range⁻¹).sign * det A,
@@ -697,7 +697,7 @@ begin
   congr,
   rw [← det_permute, det_succ_row_zero],
   refine finset.sum_congr rfl (λ j _, _),
-  rw [mul_assoc, matrix.minor, matrix.minor],
+  rw [mul_assoc, matrix.on, matrix.on],
   congr,
   { rw [equiv.perm.inv_def, fin.cycle_range_symm_zero] },
   { ext i' j',
@@ -707,10 +707,10 @@ end
 /-- Laplacian expansion of the determinant of an `n+1 × n+1` matrix along column `j`. -/
 lemma det_succ_column {n : ℕ} (A : matrix (fin n.succ) (fin n.succ) R) (j : fin n.succ) :
   det A = ∑ i : fin n.succ, (-1) ^ (i + j : ℕ) * A i j *
-    det (A.minor i.succ_above j.succ_above) :=
+    det (A.on i.succ_above j.succ_above) :=
 by { rw [← det_transpose, det_succ_row _ j],
      refine finset.sum_congr rfl (λ i _, _),
-     rw [add_comm, ← det_transpose, transpose_apply, transpose_minor, transpose_transpose] }
+     rw [add_comm, ← det_transpose, transpose_apply, transpose_on, transpose_transpose] }
 
 
 /-- Determinant of 0x0 matrix -/

--- a/src/linear_algebra/matrix/hermitian.lean
+++ b/src/linear_algebra/matrix/hermitian.lean
@@ -84,9 +84,9 @@ h.transpose.map _ $ λ _, rfl
   (A + B).is_hermitian :=
 (conj_transpose_add _ _).trans (hA.symm ▸ hB.symm ▸ rfl)
 
-@[simp] lemma is_hermitian.minor {A : matrix n n α} (h : A.is_hermitian) (f : m → n) :
-  (A.minor f f).is_hermitian :=
-(conj_transpose_minor _ _ _).trans (h.symm ▸ rfl)
+@[simp] lemma is_hermitian.on {A : matrix n n α} (h : A.is_hermitian) (f : m → n) :
+  (A.on f f).is_hermitian :=
+(conj_transpose_on _ _ _).trans (h.symm ▸ rfl)
 
 /-- The real diagonal matrix `diagonal v` is hermitian. -/
 @[simp] lemma is_hermitian_diagonal [decidable_eq n] (v : n → ℝ) :

--- a/src/linear_algebra/matrix/is_diag.lean
+++ b/src/linear_algebra/matrix/is_diag.lean
@@ -110,9 +110,9 @@ ha.transpose.map (star_zero _)
   Aᴴ.is_diag ↔ A.is_diag :=
 ⟨ λ ha, by {convert ha.conj_transpose, simp}, is_diag.conj_transpose ⟩
 
-lemma is_diag.minor [has_zero α]
+lemma is_diag.on [has_zero α]
   {A : matrix n n α} (ha : A.is_diag) {f : m → n} (hf : injective f) :
-  (A.minor f f).is_diag :=
+  (A.on f f).is_diag :=
 λ i j h, ha (hf.ne h)
 
 /-- `(A ⊗ B).is_diag` if both `A` and `B` are diagonal. -/

--- a/src/linear_algebra/matrix/nonsingular_inverse.lean
+++ b/src/linear_algebra/matrix/nonsingular_inverse.lean
@@ -536,10 +536,10 @@ of the Schur complement. -/
 lemma det_from_blocks₂₂ (A : matrix m m α) (B : matrix m n α) (C : matrix n m α) (D : matrix n n α)
   [invertible D] : (matrix.from_blocks A B C D).det = det D * det (A - B ⬝ (⅟D) ⬝ C) :=
 begin
-  have : from_blocks A B C D = (from_blocks D C B A).minor (sum_comm _ _) (sum_comm _ _),
+  have : from_blocks A B C D = (from_blocks D C B A).on (sum_comm _ _) (sum_comm _ _),
   { ext i j,
     cases i; cases j; refl },
-  rw [this, det_minor_equiv_self, det_from_blocks₁₁],
+  rw [this, det_on_equiv_self, det_from_blocks₁₁],
 end
 
 @[simp] lemma det_from_blocks_one₂₂ (A : matrix m m α) (B : matrix m n α) (C : matrix n m α) :

--- a/src/linear_algebra/matrix/reindex.lean
+++ b/src/linear_algebra/matrix/reindex.lean
@@ -77,7 +77,7 @@ on_on _ _ _ _ _
 
 lemma reindex_linear_equiv_one [decidable_eq m] [decidable_eq m'] [has_one A]
   (e : m ≃ m') : (reindex_linear_equiv R A e e (1 : matrix m m A)) = 1 :=
-one_on_equiv e.symm
+on_one_equiv e.symm
 
 end add_comm_monoid
 
@@ -88,12 +88,12 @@ lemma reindex_linear_equiv_mul [fintype n] [fintype n']
   (eₘ : m ≃ m') (eₙ : n ≃ n') (eₒ : o ≃ o') (M : matrix m n A) (N : matrix n o A) :
   reindex_linear_equiv R A eₘ eₙ M ⬝ reindex_linear_equiv R A eₙ eₒ N =
     reindex_linear_equiv R A eₘ eₒ (M ⬝ N) :=
-mul_on_equiv M N _ _ _
+on_mul_equiv M N _ _ _
 
 lemma mul_reindex_linear_equiv_one [fintype n] [fintype o] [decidable_eq o] (e₁ : o ≃ n)
   (e₂ : o ≃ n') (M : matrix m n A) : M.mul (reindex_linear_equiv R A e₁ e₂ 1) =
     reindex_linear_equiv R A (equiv.refl m) (e₁.symm.trans e₂) M :=
-mul_one_on _ _ _
+mul_on_one _ _ _
 
 end semiring
 
@@ -108,7 +108,7 @@ a matrix's rows and columns with equivalent types, `matrix.reindex`, is an equiv
 def reindex_alg_equiv (e : m ≃ n) : matrix m m R ≃ₐ[R] matrix n n R :=
 { to_fun    := reindex e e,
   map_mul'  := λ a b, (reindex_linear_equiv_mul R R e e e a b).symm,
-  commutes' := λ r, by simp [algebra_map, algebra.to_ring_hom, smul_on],
+  commutes' := λ r, by simp [algebra_map, algebra.to_ring_hom, on_smul],
   ..(reindex_linear_equiv R R e e) }
 
 @[simp] lemma reindex_alg_equiv_apply (e : m ≃ n) (M : matrix m m R) :

--- a/src/linear_algebra/matrix/reindex.lean
+++ b/src/linear_algebra/matrix/reindex.lean
@@ -73,11 +73,11 @@ lemma reindex_linear_equiv_comp_apply (e₁ : m ≃ m') (e₂ : n ≃ n') (e₁'
   (e₂' : n' ≃ n'') (M : matrix m n A) :
   (reindex_linear_equiv R A e₁' e₂') (reindex_linear_equiv R A e₁ e₂ M) =
     reindex_linear_equiv R A (e₁.trans e₁') (e₂.trans e₂') M :=
-minor_minor _ _ _ _ _
+on_on _ _ _ _ _
 
 lemma reindex_linear_equiv_one [decidable_eq m] [decidable_eq m'] [has_one A]
   (e : m ≃ m') : (reindex_linear_equiv R A e e (1 : matrix m m A)) = 1 :=
-minor_one_equiv e.symm
+one_on_equiv e.symm
 
 end add_comm_monoid
 
@@ -88,12 +88,12 @@ lemma reindex_linear_equiv_mul [fintype n] [fintype n']
   (eₘ : m ≃ m') (eₙ : n ≃ n') (eₒ : o ≃ o') (M : matrix m n A) (N : matrix n o A) :
   reindex_linear_equiv R A eₘ eₙ M ⬝ reindex_linear_equiv R A eₙ eₒ N =
     reindex_linear_equiv R A eₘ eₒ (M ⬝ N) :=
-minor_mul_equiv M N _ _ _
+mul_on_equiv M N _ _ _
 
 lemma mul_reindex_linear_equiv_one [fintype n] [fintype o] [decidable_eq o] (e₁ : o ≃ n)
   (e₂ : o ≃ n') (M : matrix m n A) : M.mul (reindex_linear_equiv R A e₁ e₂ 1) =
     reindex_linear_equiv R A (equiv.refl m) (e₁.symm.trans e₂) M :=
-mul_minor_one _ _ _
+mul_one_on _ _ _
 
 end semiring
 
@@ -108,7 +108,7 @@ a matrix's rows and columns with equivalent types, `matrix.reindex`, is an equiv
 def reindex_alg_equiv (e : m ≃ n) : matrix m m R ≃ₐ[R] matrix n n R :=
 { to_fun    := reindex e e,
   map_mul'  := λ a b, (reindex_linear_equiv_mul R R e e e a b).symm,
-  commutes' := λ r, by simp [algebra_map, algebra.to_ring_hom, minor_smul],
+  commutes' := λ r, by simp [algebra_map, algebra.to_ring_hom, smul_on],
   ..(reindex_linear_equiv R R e e) }
 
 @[simp] lemma reindex_alg_equiv_apply (e : m ≃ n) (M : matrix m m R) :
@@ -130,7 +130,7 @@ end algebra
 
 /-- Reindexing both indices along the same equivalence preserves the determinant.
 
-For the `simp` version of this lemma, see `det_minor_equiv_self`.
+For the `simp` version of this lemma, see `det_on_equiv_self`.
 -/
 lemma det_reindex_linear_equiv_self [comm_ring R] [fintype m] [decidable_eq m]
   [fintype n] [decidable_eq n] (e : m ≃ n) (M : matrix m m R) :
@@ -139,7 +139,7 @@ det_reindex_self e M
 
 /-- Reindexing both indices along the same equivalence preserves the determinant.
 
-For the `simp` version of this lemma, see `det_minor_equiv_self`.
+For the `simp` version of this lemma, see `det_on_equiv_self`.
 -/
 lemma det_reindex_alg_equiv [comm_ring R] [fintype m] [decidable_eq m] [fintype n] [decidable_eq n]
   (e : m ≃ n) (A : matrix m m R) :

--- a/src/linear_algebra/matrix/symmetric.lean
+++ b/src/linear_algebra/matrix/symmetric.lean
@@ -94,9 +94,9 @@ h.transpose.map _
   (k • A).is_symm :=
 (transpose_smul _ _).trans (congr_arg _ h)
 
-@[simp] lemma is_symm.minor {A : matrix n n α} (h : A.is_symm) (f : m → n) :
-  (A.minor f f).is_symm :=
-(transpose_minor _ _ _).trans (h.symm ▸ rfl)
+@[simp] lemma is_symm.on {A : matrix n n α} (h : A.is_symm) (f : m → n) :
+  (A.on f f).is_symm :=
+(transpose_on _ _ _).trans (h.symm ▸ rfl)
 
 /-- The diagonal matrix `diagonal v` is symmetric. -/
 @[simp] lemma is_symm_diagonal [decidable_eq n] [has_zero α] (v : n → α) :

--- a/src/linear_algebra/matrix/transvection.lean
+++ b/src/linear_algebra/matrix/transvection.lean
@@ -269,7 +269,7 @@ begin
   cases t,
   ext a b,
   simp only [reindex_equiv, transvection, mul_boole, algebra.id.smul_eq_mul, to_matrix_mk,
-    minor_apply, reindex_apply, dmatrix.add_apply, pi.smul_apply, reindex_alg_equiv_apply],
+    on_apply, reindex_apply, dmatrix.add_apply, pi.smul_apply, reindex_alg_equiv_apply],
   by_cases ha : e t_i = a; by_cases hb : e t_j = b; by_cases hab : a = b;
   simp [ha, hb, hab, ← e.apply_eq_iff_eq_symm_apply, std_basis_matrix]
 end
@@ -585,12 +585,12 @@ begin
   rcases H with ⟨L₀, L₀', D₀, h₀⟩,
   refine ⟨L₀.map (reindex_equiv e.symm), L₀'.map (reindex_equiv e.symm), D₀ ∘ e, _⟩,
   have : M = reindex_alg_equiv 𝕜 e.symm (reindex_alg_equiv 𝕜 e M),
-    by simp only [equiv.symm_symm, minor_minor, reindex_apply, minor_id_id, equiv.symm_comp_self,
+    by simp only [equiv.symm_symm, on_on, reindex_apply, on_id_id, equiv.symm_comp_self,
       reindex_alg_equiv_apply],
   rw this,
   simp only [to_matrix_reindex_equiv_prod, list.map_map, reindex_alg_equiv_apply],
   simp only [← reindex_alg_equiv_apply, ← reindex_alg_equiv_mul, h₀],
-  simp only [equiv.symm_symm, reindex_apply, minor_diagonal_equiv, reindex_alg_equiv_apply],
+  simp only [equiv.symm_symm, reindex_apply, diagonal_on_equiv, reindex_alg_equiv_apply],
 end
 
 /-- Any matrix can be reduced to diagonal form by elementary operations. Formulated here on `Type 0`

--- a/src/linear_algebra/matrix/transvection.lean
+++ b/src/linear_algebra/matrix/transvection.lean
@@ -590,7 +590,7 @@ begin
   rw this,
   simp only [to_matrix_reindex_equiv_prod, list.map_map, reindex_alg_equiv_apply],
   simp only [← reindex_alg_equiv_apply, ← reindex_alg_equiv_mul, h₀],
-  simp only [equiv.symm_symm, reindex_apply, diagonal_on_equiv, reindex_alg_equiv_apply],
+  simp only [equiv.symm_symm, reindex_apply, on_diagonal_equiv, reindex_alg_equiv_apply],
 end
 
 /-- Any matrix can be reduced to diagonal form by elementary operations. Formulated here on `Type 0`

--- a/src/linear_algebra/vandermonde.lean
+++ b/src/linear_algebra/vandermonde.lean
@@ -84,7 +84,7 @@ begin
                (v 0 ^ (j.succ : ℕ))
                (λ (i : fin n), v (fin.succ i) ^ (j.succ : ℕ) - v 0 ^ (j.succ : ℕ))
                (fin.succ_above 0 i)) :
-    by simp_rw [det_succ_column_zero, fin.sum_univ_succ, of_apply, matrix.cons_val_zero, minor,
+    by simp_rw [det_succ_column_zero, fin.sum_univ_succ, of_apply, matrix.cons_val_zero, matrix.on,
                 of_apply, matrix.cons_val_succ,
                 fin.coe_zero, pow_zero, one_mul, sub_self, mul_zero, zero_mul,
                 finset.sum_const_zero, add_zero]

--- a/src/ring_theory/trace.lean
+++ b/src/ring_theory/trace.lean
@@ -491,7 +491,7 @@ lemma trace_matrix_eq_embeddings_matrix_reindex_mul_trans [fintype κ]
   (e : κ ≃ (L →ₐ[K] E)) : (trace_matrix K b).map (algebra_map K E) =
   (embeddings_matrix_reindex K E b e) ⬝ (embeddings_matrix_reindex K E b e)ᵀ :=
 by rw [trace_matrix_eq_embeddings_matrix_mul_trans, embeddings_matrix_reindex, reindex_apply,
-  transpose_minor, ← minor_mul_transpose_minor, ← equiv.coe_refl, equiv.refl_symm]
+  transpose_on, ← on_mul_transpose_on, ← equiv.coe_refl, equiv.refl_symm]
 
 end field
 

--- a/src/topology/instances/matrix.lean
+++ b/src/topology/instances/matrix.lean
@@ -150,15 +150,15 @@ lemma continuous.matrix_vec_mul [non_unital_non_assoc_semiring R] [has_continuou
 continuous_pi $ λ i, hA.matrix_dot_product $ continuous_pi $ λ j, hB.matrix_elem _ _
 
 @[continuity]
-lemma continuous.matrix_minor {A : X → matrix l n R} (hA : continuous A) (e₁ : m → l) (e₂ : p → n) :
-  continuous (λ x, (A x).minor e₁ e₂) :=
+lemma continuous.matrix_on {A : X → matrix l n R} (hA : continuous A) (e₁ : m → l) (e₂ : p → n) :
+  continuous (λ x, (A x).on e₁ e₂) :=
 continuous_matrix $ λ i j, hA.matrix_elem _ _
 
 @[continuity]
 lemma continuous.matrix_reindex {A : X → matrix l n R}
   (hA : continuous A) (e₁ : l ≃ m) (e₂ : n ≃ p) :
   continuous (λ x, reindex e₁ e₂ (A x)) :=
-hA.matrix_minor _ _
+hA.matrix_on _ _
 
 @[continuity]
 lemma continuous.matrix_diag {A : X → matrix n n R} (hA : continuous A) :

--- a/test/matrix.lean
+++ b/test/matrix.lean
@@ -59,7 +59,7 @@ example {a b c d x y : α} :
   mul_vec !![a, b; c, d] ![x, y] = ![a * x + b * y, c * x + d * y] :=
 by simp
 
-example {a b c d : α} : minor !![a, b; c, d] ![1, 0] ![0] = !![c; a] :=
+example {a b c d : α} : matrix.on !![a, b; c, d] ![1, 0] ![0] = !![c; a] :=
 by { ext, simp }
 
 example {a b c : α} : ![a, b, c] 0 = a := by simp
@@ -96,7 +96,7 @@ begin
   simp [matrix.det_succ_row_zero, fin.sum_univ_succ],
   /-
   Try this: simp only [det_succ_row_zero, fin.sum_univ_succ, neg_mul, mul_one,
-  fin.default_eq_zero, fin.coe_zero, one_mul, cons_val_one, fin.coe_succ, univ_unique, minor_apply,
+  fin.default_eq_zero, fin.coe_zero, one_mul, cons_val_one, fin.coe_succ, univ_unique, on_apply,
   pow_one, fin.zero_succ_above, fin.succ_succ_above_zero,  finset.sum_singleton, cons_val_zero,
   cons_val_succ, det_fin_zero, pow_zero]
   -/
@@ -111,7 +111,7 @@ begin
   /-
   Try this: simp only [det_succ_row_zero, fin.sum_univ_succ, neg_mul, cons_append,
   mul_one, fin.default_eq_zero, fin.coe_zero, cons_vec_bit0_eq_alt0, one_mul, cons_val_one,
-  cons_vec_alt0, fin.succ_succ_above_one, fin.coe_succ, univ_unique, minor_apply, pow_one,
+  cons_vec_alt0, fin.succ_succ_above_one, fin.coe_succ, univ_unique, on_apply, pow_one,
   fin.zero_succ_above, fin.succ_zero_eq_one, fin.succ_succ_above_zero, nat.neg_one_sq,
   finset.sum_singleton, cons_val_zero, cons_val_succ, det_fin_zero, head_cons, pow_zero]
    -/


### PR DESCRIPTION
As discussed on Zulip: https://leanprover.zulipchat.com/#narrow/stream/116395-maths/topic/matrix.2Eminor.20wrong.20terminology.3F

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
