### PR TITLE
[Merged by Bors] - feat(analysis/normed/group/basic): construct a normed group from a seminormed group satisfying `∥x∥ = 0 → x = 0`

### DIFF
--- a/src/analysis/normed/group/basic.lean
+++ b/src/analysis/normed/group/basic.lean
@@ -1073,6 +1073,12 @@ end seminormed_add_comm_group
 
 section normed_add_comm_group
 
+def normed_add_comm_group.of_separation [h₁ : seminormed_add_comm_group E]
+  (h₂ : ∀ x : E, ∥x∥ = 0 → x = 0) : normed_add_comm_group E :=
+{ to_metric_space :=
+  { eq_of_dist_eq_zero := λ x y hxy, by rw h₁.dist_eq at hxy; rw ← sub_eq_zero; exact h₂ _ hxy },
+  ..h₁ }
+
 /-- Construct a normed group from a translation invariant distance -/
 def normed_add_comm_group.of_add_dist [has_norm E] [add_comm_group E] [metric_space E]
   (H1 : ∀ x : E, ∥x∥ = dist x 0)

--- a/src/analysis/normed/group/basic.lean
+++ b/src/analysis/normed/group/basic.lean
@@ -1073,6 +1073,10 @@ end seminormed_add_comm_group
 
 section normed_add_comm_group
 
+/-- Construct a `normed_add_comm_group` from a `seminormed_add_comm_group` satisfying
+`∀ x, ∥x∥ = 0 → x = 0`. This avoids having to go back to the `(pseudo_)metric_space` level
+when declaring a `normed_add_comm_group` instance as a special case of a more general
+`seminormed_add_comm_group` instance. -/
 def normed_add_comm_group.of_separation [h₁ : seminormed_add_comm_group E]
   (h₂ : ∀ x : E, ∥x∥ = 0 → x = 0) : normed_add_comm_group E :=
 { to_metric_space :=


### PR DESCRIPTION
This makes it more convenient to have a `normed_add_comm_group` instance as a special case of a general `seminormed_add_comm_group` without having to go back to the (pseudo) metric space level.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
