### PR TITLE
[Merged by Bors] - feat(algebraic_topology/dold_kan): the normalized Moore complex is a direct factor of the alternating face map complex

### DIFF
--- a/src/algebraic_topology/Moore_complex.lean
+++ b/src/algebraic_topology/Moore_complex.lean
@@ -157,4 +157,11 @@ def normalized_Moore_complex : simplicial_object C ⥤ chain_complex C ℕ :=
   map_id' := λ X, by { ext n, cases n; { dsimp, simp, }, },
   map_comp' := λ X Y Z f g, by { ext n, cases n; simp, }, }
 
+variable {C}
+
+@[simp]
+lemma normalized_Moore_complex_obj_d (X : simplicial_object C) (n : ℕ) :
+  ((normalized_Moore_complex C).obj X).d (n+1) n = normalized_Moore_complex.obj_d X n :=
+by apply chain_complex.of_d
+
 end algebraic_topology

--- a/src/algebraic_topology/dold_kan/normalized.lean
+++ b/src/algebraic_topology/dold_kan/normalized.lean
@@ -1,0 +1,141 @@
+/-
+Copyright (c) 2022 Joël Riou. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Joël Riou
+-/
+
+import algebraic_topology.dold_kan.functor_n
+
+/-!
+
+# Comparison with the normalized Moore complex functor
+
+TODO (@joelriou) continue adding the various files referenced below
+
+In this file, we show that when the category `A` is abelian,
+there is an isomorphism `N₁_iso_to_karoubi_normalized A` between
+the functor `N₁ : simplicial_object A ⥤ karoubi (chain_complex A ℕ)`
+defined in `functor_n.lean` and the composition of
+`normalized_Moore_complex A` with the inclusion
+`chain_complex A ℕ ⥤ karoubi (chain_complex A ℕ)`.
+
+This isomorphism shall be used in `equivalence.lean` in order to obtain
+the Dold-Kan equivalence
+`category_theory.abelian.dold_kan.equivalence : simplicial_object A ≌ chain_complex A ℕ`
+with a functor (definitionally) equal to `normalized_Moore_complex A`.
+
+-/
+
+open category_theory category_theory.category category_theory.limits
+  category_theory.subobject category_theory.idempotents
+open_locale dold_kan
+
+noncomputable theory
+
+namespace algebraic_topology
+
+namespace dold_kan
+
+universe v
+
+variables {A : Type*} [category A] [abelian A] {X : simplicial_object A}
+
+lemma higher_faces_vanish.on_Moore_complex (n : ℕ) :
+  higher_faces_vanish (n+1) ((inclusion_of_Moore_complex_map X).f (n+1)) := λ j hj,
+begin
+  dsimp [inclusion_of_Moore_complex_map],
+  rw [← factor_thru_arrow _ _ (finset_inf_arrow_factors finset.univ
+    _ j (by simp only [finset.mem_univ])), assoc, kernel_subobject_arrow_comp, comp_zero],
+end
+
+lemma P_infty_factors_thru_Moore_complex_degreewise (n : ℕ) :
+  subobject.factors (normalized_Moore_complex.obj_X X n) (P_infty.f n) :=
+begin
+  cases n,
+  { apply top_factors, },
+  { rw [P_infty_f, normalized_Moore_complex.obj_X, finset_inf_factors],
+    intros i hi,
+    apply kernel_subobject_factors,
+    exact (higher_faces_vanish.of_P (n+1) n) i (le_add_self), }
+end
+
+/-- P_infty factors through the normalized_Moore_complex -/
+@[simps]
+def P_infty_into_Moore_subcomplex (X : simplicial_object A) : K[X] ⟶ N[X] :=
+chain_complex.of_hom _ _ _ _ _ _
+  (λ n, factor_thru _ _ (P_infty_factors_thru_Moore_complex_degreewise n))
+  (λ n, begin
+    rw [← cancel_mono (normalized_Moore_complex.obj_X X n).arrow, assoc, assoc,
+      factor_thru_arrow, ← inclusion_of_Moore_complex_map_f,
+      ← normalized_Moore_complex_obj_d, ← (inclusion_of_Moore_complex_map X).comm' (n+1) n rfl,
+      inclusion_of_Moore_complex_map_f, factor_thru_arrow_assoc,
+      ← alternating_face_map_complex_obj_d],
+    exact P_infty.comm' (n+1) n rfl,
+  end)
+
+@[simp, reassoc]
+lemma P_infty_into_Moore_subcomplex_comp_inclusion (X : simplicial_object A) :
+  P_infty_into_Moore_subcomplex X ≫ inclusion_of_Moore_complex_map X = P_infty := by tidy
+
+@[simp, reassoc]
+lemma P_infty_into_Moore_subcomplex_naturality {X Y : simplicial_object A} (f : X ⟶ Y) :
+  alternating_face_map_complex.map f ≫ P_infty_into_Moore_subcomplex Y =
+    P_infty_into_Moore_subcomplex X ≫ normalized_Moore_complex.map f := by tidy
+
+@[simp, reassoc]
+lemma P_infty_comp_P_infty_into_Moore_subcomplex (X : simplicial_object A) :
+  P_infty ≫ P_infty_into_Moore_subcomplex X = P_infty_into_Moore_subcomplex X := by tidy
+
+@[simp, reassoc]
+lemma inclusion_of_Moore_complex_map_comp_P_infty (X : simplicial_object A) :
+  inclusion_of_Moore_complex_map X ≫ P_infty = inclusion_of_Moore_complex_map X :=
+begin
+  ext n,
+  cases n,
+  { dsimp, simp only [comp_id], },
+  { exact (higher_faces_vanish.on_Moore_complex n).comp_P_eq_self, },
+end
+
+instance : mono (inclusion_of_Moore_complex_map X) :=
+⟨λ Y f₁ f₂ hf, by { ext n, exact homological_complex.congr_hom hf n, }⟩
+
+/-- `inclusion_of_Moore_complex_map X` is a split mono. -/
+def split_mono_inclusion_of_Moore_complex (X : simplicial_object A) :
+  split_mono (inclusion_of_Moore_complex_map X) :=
+{ retraction := P_infty_into_Moore_subcomplex X,
+  id' := by simp only [← cancel_mono (inclusion_of_Moore_complex_map X), assoc, id_comp,
+    P_infty_into_Moore_subcomplex_comp_inclusion, inclusion_of_Moore_complex_map_comp_P_infty], }
+
+variable (A)
+
+/-- When the category `A` is abelian,
+the functor `N₁ : simplicial_object A ⥤ karoubi (chain_complex A ℕ)` defined
+using `P_infty` identifies to the composition of the normalized Moore complex functor
+and the inclusion in the Karoubi envelope. -/
+def N₁_iso_to_karoubi_normalized :
+  N₁ ≅ (normalized_Moore_complex A ⋙ to_karoubi _) :=
+{ hom :=
+  { app := λ X,
+    { f := P_infty_into_Moore_subcomplex X,
+      comm := by tidy, }, },
+  inv :=
+  { app := λ X,
+    { f := inclusion_of_Moore_complex_map X,
+      comm := by tidy, }, },
+  hom_inv_id' := begin
+    ext X : 3,
+    simp only [P_infty_into_Moore_subcomplex_comp_inclusion, nat_trans.comp_app,
+      karoubi.comp, N₁_obj_p, nat_trans.id_app, karoubi.id_eq],
+  end,
+  inv_hom_id' := begin
+    ext X : 3,
+    simp only [← cancel_mono (inclusion_of_Moore_complex_map X),
+      nat_trans.comp_app, karoubi.comp, assoc, P_infty_into_Moore_subcomplex_comp_inclusion,
+      inclusion_of_Moore_complex_map_comp_P_infty, nat_trans.id_app, karoubi.id_eq],
+    dsimp only [functor.comp_obj, to_karoubi],
+    rw id_comp,
+  end }
+
+end dold_kan
+
+end algebraic_topology

--- a/src/algebraic_topology/dold_kan/normalized.lean
+++ b/src/algebraic_topology/dold_kan/normalized.lean
@@ -100,7 +100,7 @@ instance : mono (inclusion_of_Moore_complex_map X) :=
 ⟨λ Y f₁ f₂ hf, by { ext n, exact homological_complex.congr_hom hf n, }⟩
 
 /-- `inclusion_of_Moore_complex_map X` is a split mono. -/
-def split_mono_inclusion_of_Moore_complex (X : simplicial_object A) :
+def split_mono_inclusion_of_Moore_complex_map (X : simplicial_object A) :
   split_mono (inclusion_of_Moore_complex_map X) :=
 { retraction := P_infty_into_Moore_subcomplex X,
   id' := by simp only [← cancel_mono (inclusion_of_Moore_complex_map X), assoc, id_comp,

--- a/src/algebraic_topology/dold_kan/normalized.lean
+++ b/src/algebraic_topology/dold_kan/normalized.lean
@@ -40,7 +40,7 @@ universe v
 
 variables {A : Type*} [category A] [abelian A] {X : simplicial_object A}
 
-lemma higher_faces_vanish.on_Moore_complex (n : ℕ) :
+lemma higher_faces_vanish.inclusion_of_Moore_complex_map (n : ℕ) :
   higher_faces_vanish (n+1) ((inclusion_of_Moore_complex_map X).f (n+1)) := λ j hj,
 begin
   dsimp [inclusion_of_Moore_complex_map],

--- a/src/algebraic_topology/dold_kan/normalized.lean
+++ b/src/algebraic_topology/dold_kan/normalized.lean
@@ -48,7 +48,7 @@ begin
     _ j (by simp only [finset.mem_univ])), assoc, kernel_subobject_arrow_comp, comp_zero],
 end
 
-lemma P_infty_factors_thru_Moore_complex_degreewise (n : ℕ) :
+lemma factors_normalized_Moore_complex_P_infty (n : ℕ) :
   subobject.factors (normalized_Moore_complex.obj_X X n) (P_infty.f n) :=
 begin
   cases n,

--- a/src/algebraic_topology/dold_kan/normalized.lean
+++ b/src/algebraic_topology/dold_kan/normalized.lean
@@ -13,7 +13,7 @@ import algebraic_topology.dold_kan.functor_n
 TODO (@joelriou) continue adding the various files referenced below
 
 In this file, we show that when the category `A` is abelian,
-there is an isomorphism `N₁_iso_to_karoubi_normalized A` between
+there is an isomorphism `N₁_iso_normalized_Moore_complex_comp_to_karoubi` between
 the functor `N₁ : simplicial_object A ⥤ karoubi (chain_complex A ℕ)`
 defined in `functor_n.lean` and the composition of
 `normalized_Moore_complex A` with the inclusion
@@ -59,11 +59,11 @@ begin
     exact (higher_faces_vanish.of_P (n+1) n) i (le_add_self), }
 end
 
-/-- P_infty factors through the normalized_Moore_complex -/
+/-- P_infty factors through the normalized Moore complex -/
 @[simps]
 def P_infty_to_normalized_Moore_complex (X : simplicial_object A) : K[X] ⟶ N[X] :=
 chain_complex.of_hom _ _ _ _ _ _
-  (λ n, factor_thru _ _ (P_infty_factors_thru_Moore_complex_degreewise n))
+  (λ n, factor_thru _ _ (factors_normalized_Moore_complex_P_infty n))
   (λ n, begin
     rw [← cancel_mono (normalized_Moore_complex.obj_X X n).arrow, assoc, assoc,
       factor_thru_arrow, ← inclusion_of_Moore_complex_map_f,
@@ -74,17 +74,19 @@ chain_complex.of_hom _ _ _ _ _ _
   end)
 
 @[simp, reassoc]
-lemma P_infty_into_Moore_subcomplex_comp_inclusion (X : simplicial_object A) :
-  P_infty_into_Moore_subcomplex X ≫ inclusion_of_Moore_complex_map X = P_infty := by tidy
+lemma P_infty_to_normalized_Moore_complex_comp_inclusion_of_Moore_complex_map
+  (X : simplicial_object A) :
+  P_infty_to_normalized_Moore_complex X ≫ inclusion_of_Moore_complex_map X = P_infty := by tidy
 
 @[simp, reassoc]
-lemma P_infty_into_Moore_subcomplex_naturality {X Y : simplicial_object A} (f : X ⟶ Y) :
-  alternating_face_map_complex.map f ≫ P_infty_into_Moore_subcomplex Y =
-    P_infty_into_Moore_subcomplex X ≫ normalized_Moore_complex.map f := by tidy
+lemma P_infty_to_normalized_Moore_complex_naturality {X Y : simplicial_object A} (f : X ⟶ Y) :
+  alternating_face_map_complex.map f ≫ P_infty_to_normalized_Moore_complex Y =
+    P_infty_to_normalized_Moore_complex X ≫ normalized_Moore_complex.map f := by tidy
 
 @[simp, reassoc]
-lemma P_infty_comp_P_infty_into_Moore_subcomplex (X : simplicial_object A) :
-  P_infty ≫ P_infty_into_Moore_subcomplex X = P_infty_into_Moore_subcomplex X := by tidy
+lemma P_infty_comp_P_infty_to_normalized_Moore_complex (X : simplicial_object A) :
+  P_infty ≫ P_infty_to_normalized_Moore_complex X = P_infty_to_normalized_Moore_complex X :=
+by tidy
 
 @[simp, reassoc]
 lemma inclusion_of_Moore_complex_map_comp_P_infty (X : simplicial_object A) :
@@ -93,7 +95,7 @@ begin
   ext n,
   cases n,
   { dsimp, simp only [comp_id], },
-  { exact (higher_faces_vanish.on_Moore_complex n).comp_P_eq_self, },
+  { exact (higher_faces_vanish.inclusion_of_Moore_complex_map n).comp_P_eq_self, },
 end
 
 instance : mono (inclusion_of_Moore_complex_map X) :=
@@ -102,9 +104,10 @@ instance : mono (inclusion_of_Moore_complex_map X) :=
 /-- `inclusion_of_Moore_complex_map X` is a split mono. -/
 def split_mono_inclusion_of_Moore_complex_map (X : simplicial_object A) :
   split_mono (inclusion_of_Moore_complex_map X) :=
-{ retraction := P_infty_into_Moore_subcomplex X,
+{ retraction := P_infty_to_normalized_Moore_complex X,
   id' := by simp only [← cancel_mono (inclusion_of_Moore_complex_map X), assoc, id_comp,
-    P_infty_into_Moore_subcomplex_comp_inclusion, inclusion_of_Moore_complex_map_comp_P_infty], }
+    P_infty_to_normalized_Moore_complex_comp_inclusion_of_Moore_complex_map,
+    inclusion_of_Moore_complex_map_comp_P_infty], }
 
 variable (A)
 
@@ -116,7 +119,7 @@ def N₁_iso_normalized_Moore_complex_comp_to_karoubi :
   N₁ ≅ (normalized_Moore_complex A ⋙ to_karoubi _) :=
 { hom :=
   { app := λ X,
-    { f := P_infty_into_Moore_subcomplex X,
+    { f := P_infty_to_normalized_Moore_complex X,
       comm := by tidy, }, },
   inv :=
   { app := λ X,
@@ -124,14 +127,15 @@ def N₁_iso_normalized_Moore_complex_comp_to_karoubi :
       comm := by tidy, }, },
   hom_inv_id' := begin
     ext X : 3,
-    simp only [P_infty_into_Moore_subcomplex_comp_inclusion, nat_trans.comp_app,
-      karoubi.comp, N₁_obj_p, nat_trans.id_app, karoubi.id_eq],
+    simp only [P_infty_to_normalized_Moore_complex_comp_inclusion_of_Moore_complex_map,
+      nat_trans.comp_app, karoubi.comp, N₁_obj_p, nat_trans.id_app, karoubi.id_eq],
   end,
   inv_hom_id' := begin
     ext X : 3,
     simp only [← cancel_mono (inclusion_of_Moore_complex_map X),
-      nat_trans.comp_app, karoubi.comp, assoc, P_infty_into_Moore_subcomplex_comp_inclusion,
-      inclusion_of_Moore_complex_map_comp_P_infty, nat_trans.id_app, karoubi.id_eq],
+      nat_trans.comp_app, karoubi.comp, assoc, nat_trans.id_app, karoubi.id_eq,
+      P_infty_to_normalized_Moore_complex_comp_inclusion_of_Moore_complex_map,
+      inclusion_of_Moore_complex_map_comp_P_infty],
     dsimp only [functor.comp_obj, to_karoubi],
     rw id_comp,
   end }

--- a/src/algebraic_topology/dold_kan/normalized.lean
+++ b/src/algebraic_topology/dold_kan/normalized.lean
@@ -112,7 +112,7 @@ variable (A)
 the functor `N₁ : simplicial_object A ⥤ karoubi (chain_complex A ℕ)` defined
 using `P_infty` identifies to the composition of the normalized Moore complex functor
 and the inclusion in the Karoubi envelope. -/
-def N₁_iso_to_karoubi_normalized :
+def N₁_iso_normalized_Moore_complex_comp_to_karoubi :
   N₁ ≅ (normalized_Moore_complex A ⋙ to_karoubi _) :=
 { hom :=
   { app := λ X,

--- a/src/algebraic_topology/dold_kan/normalized.lean
+++ b/src/algebraic_topology/dold_kan/normalized.lean
@@ -61,7 +61,7 @@ end
 
 /-- P_infty factors through the normalized_Moore_complex -/
 @[simps]
-def P_infty_into_Moore_subcomplex (X : simplicial_object A) : K[X] ⟶ N[X] :=
+def P_infty_to_normalized_Moore_complex (X : simplicial_object A) : K[X] ⟶ N[X] :=
 chain_complex.of_hom _ _ _ _ _ _
   (λ n, factor_thru _ _ (P_infty_factors_thru_Moore_complex_degreewise n))
   (λ n, begin

--- a/src/algebraic_topology/dold_kan/p_infty.lean
+++ b/src/algebraic_topology/dold_kan/p_infty.lean
@@ -61,6 +61,9 @@ def P_infty : K[X] ⟶ K[X] := chain_complex.of_hom _ _ _ _ _ _
   (λ n, by simpa only [← P_is_eventually_constant (show n ≤ n, by refl),
     alternating_face_map_complex.obj_d_eq] using (P (n+1)).comm (n+1) n)
 
+@[simp]
+lemma P_infty_f_0 : (P_infty.f 0 : X _[0] ⟶ X _[0]) = 𝟙 _ := rfl
+
 lemma P_infty_f (n : ℕ) : (P_infty.f n : X _[n] ⟶  X _[n] ) = (P n).f n := rfl
 
 @[simp, reassoc]


### PR DESCRIPTION
In this PR, we show that when the category `A` is abelian, there is an isomorphism `N₁_iso_to_karoubi_normalized A` between
the functor `N₁ : simplicial_object A ⥤ karoubi (chain_complex A ℕ)` defined in `functor_n.lean` and the composition of `normalized_Moore_complex A` with the inclusion `chain_complex A ℕ ⥤ karoubi (chain_complex A ℕ)`.
(In particular, the normalized Moore complex is a direct factor of the alternating face map complex.)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
