### PR TITLE
[Merged by Bors] - feat(number_theory/padics/padic_norm): add int_eq_one_iff

### DIFF
--- a/src/number_theory/padics/padic_norm.lean
+++ b/src/number_theory/padics/padic_norm.lean
@@ -308,8 +308,63 @@ begin
       linarith, } },
 end
 
+lemma int_lt_one_iff (m : ℤ) : padic_norm p m < 1 ↔ (p : ℤ) ∣ m :=
+begin
+  rw [← not_iff_not, ← int_eq_one_iff, eq_iff_le_not_lt],
+  simp only [padic_norm.of_int, true_and],
+end
+
+lemma of_nat (m : ℕ) : padic_norm p m ≤ 1 :=
+padic_norm.of_int p (m : ℤ)
+
 /-- The `p`-adic norm of a natural `m` is one iff `p` doesn't divide `m`. -/
 lemma nat_eq_one_iff (m : ℕ) : padic_norm p m = 1 ↔ ¬ p ∣ m :=
-by simp [← int.coe_nat_dvd, ← int_eq_one_iff]
+by simp only [←int.coe_nat_dvd, ←int_eq_one_iff, int.cast_coe_nat]
 
+lemma nat_lt_one_iff (m : ℕ) : padic_norm p m < 1 ↔ p ∣ m :=
+by simp only [←int.coe_nat_dvd, ←int_lt_one_iff, int.cast_coe_nat]
+
+open_locale big_operators
+
+lemma sum_lt {t : ℚ} {n : ℕ} {F : ℕ → ℚ}
+  (hF : ∀ i, i < n → padic_norm p (F i) < t) (hn : 0 < n) :
+  padic_norm p (∑ i in finset.range n, F i) < t :=
+begin
+  induction n with d hd, {cases hn, },
+  cases d, {simp [hF], },
+  rw finset.sum_range_succ,
+  refine lt_of_le_of_lt (padic_norm.nonarchimedean p) _,
+  refine max_lt (hd (λ i hi, hF _ (hi.trans (nat.lt_succ_self _))) d.zero_lt_succ) _,
+  exact hF _ (nat.lt_succ_self _),
+end
+
+lemma sum_le {t : ℚ} {n : ℕ} {F : ℕ → ℚ}
+  (hF : ∀ i, i < n → padic_norm p (F i) ≤ t) (hn : 0 < n) :
+  padic_norm p (∑ i in finset.range n, F i) ≤ t :=
+begin
+  induction n with d hd, {cases hn, },
+  cases d, {simp [hF], },
+  rw finset.sum_range_succ,
+  refine (padic_norm.nonarchimedean p).trans _,
+  refine max_le (hd (λ i hi, hF _ (hi.trans (nat.lt_succ_self _))) d.zero_lt_succ) _,
+  exact hF _ (nat.lt_succ_self _),
+end
+
+lemma sum_lt' {t : ℚ} {n : ℕ} {F : ℕ → ℚ}
+  (hF : ∀ i, i < n → padic_norm p (F i) < t) (ht : 0 < t) :
+  padic_norm p (∑ i in finset.range n, F i) < t :=
+begin
+  obtain rfl | hn := @eq_zero_or_pos ℕ _ n,
+  { simp [ht], },
+  { exact sum_lt hF hn, },
+end
+
+lemma sum_le' {t : ℚ} {n : ℕ} {F : ℕ → ℚ}
+  (hF : ∀ i, i < n → padic_norm p (F i) ≤ t) (ht : 0 ≤ t) :
+  padic_norm p (∑ i in finset.range n, F i) ≤ t :=
+begin
+  obtain rfl | hn := @eq_zero_or_pos ℕ _ n,
+  { simp [ht], },
+  { exact sum_le hF hn, },
+end
 end padic_norm

--- a/src/number_theory/padics/padic_norm.lean
+++ b/src/number_theory/padics/padic_norm.lean
@@ -46,7 +46,6 @@ if q = 0 then 0 else (↑p : ℚ) ^ (-(padic_val_rat p q))
 
 namespace padic_norm
 
-section padic_norm
 open padic_val_rat
 variables (p : ℕ)
 
@@ -286,5 +285,31 @@ begin
     { exact_mod_cast hp.1.one_lt } }
 end
 
-end padic_norm
+/-- The `p`-adic norm of an integer `m` is one iff `p` doesn't divide `m`. -/
+lemma int_eq_one_iff (m : ℤ) : padic_norm p m = 1 ↔ ¬ (p : ℤ) ∣ m :=
+begin
+  nth_rewrite 1 ← pow_one p,
+  simp only [dvd_iff_norm_le, int.cast_coe_nat, nat.cast_one, zpow_neg, zpow_one, not_le],
+  split,
+  { intro h,
+    rw [h, inv_lt_one_iff_of_pos];
+    norm_cast,
+    { exact nat.prime.one_lt (fact.out _), },
+    { exact nat.prime.pos (fact.out _), }, },
+  { simp only [padic_norm],
+    split_ifs,
+    { rw [inv_lt_zero, ← nat.cast_zero, nat.cast_lt],
+      intro h, exact (nat.not_lt_zero p h).elim, },
+    { have : 1 < (p : ℚ) := by norm_cast; exact (nat.prime.one_lt (fact.out _ : nat.prime p)),
+      rw [← zpow_neg_one, zpow_lt_iff_lt this],
+      have : 0 ≤ padic_val_rat p m, simp only [of_int, nat.cast_nonneg],
+      intro h,
+      rw [← zpow_zero (p : ℚ), zpow_inj];
+      linarith, } },
+end
+
+/-- The `p`-adic norm of a natural `m` is one iff `p` doesn't divide `m`. -/
+lemma nat_eq_one_iff (m : ℕ) : padic_norm p m = 1 ↔ ¬ p ∣ m :=
+by simp [← int.coe_nat_dvd, ← int_eq_one_iff]
+
 end padic_norm

--- a/src/number_theory/padics/padic_norm.lean
+++ b/src/number_theory/padics/padic_norm.lean
@@ -326,45 +326,54 @@ by simp only [←int.coe_nat_dvd, ←int_lt_one_iff, int.cast_coe_nat]
 
 open_locale big_operators
 
-lemma sum_lt {t : ℚ} {n : ℕ} {F : ℕ → ℚ}
-  (hF : ∀ i, i < n → padic_norm p (F i) < t) (hn : 0 < n) :
-  padic_norm p (∑ i in finset.range n, F i) < t :=
+lemma sum_lt {α : Type*} {F : α → ℚ} {t : ℚ} {s : finset α} :
+  s.nonempty → (∀ i ∈ s, padic_norm p (F i) < t) →
+  padic_norm p (∑ i in s, F i) < t :=
 begin
-  induction n with d hd, {cases hn, },
-  cases d, {simp [hF], },
-  rw finset.sum_range_succ,
-  refine lt_of_le_of_lt (padic_norm.nonarchimedean p) _,
-  refine max_lt (hd (λ i hi, hF _ (hi.trans (nat.lt_succ_self _))) d.zero_lt_succ) _,
-  exact hF _ (nat.lt_succ_self _),
+  classical,
+  refine s.induction_on (by { rintro ⟨-, ⟨⟩⟩, }) _,
+  rintro a S haS IH - ht,
+  by_cases hs : S.nonempty,
+  { rw finset.sum_insert haS,
+    exact lt_of_le_of_lt (padic_norm.nonarchimedean p) (max_lt
+      (ht a (finset.mem_insert_self a S))
+      (IH hs (λ b hb, ht b (finset.mem_insert_of_mem hb)))),
+  },
+  { simp * at *, },
 end
 
-lemma sum_le {t : ℚ} {n : ℕ} {F : ℕ → ℚ}
-  (hF : ∀ i, i < n → padic_norm p (F i) ≤ t) (hn : 0 < n) :
-  padic_norm p (∑ i in finset.range n, F i) ≤ t :=
+lemma sum_le {α : Type*} {F : α → ℚ} {t : ℚ} {s : finset α} :
+  s.nonempty → (∀ i ∈ s, padic_norm p (F i) ≤ t) →
+  padic_norm p (∑ i in s, F i) ≤ t :=
 begin
-  induction n with d hd, {cases hn, },
-  cases d, {simp [hF], },
-  rw finset.sum_range_succ,
-  refine (padic_norm.nonarchimedean p).trans _,
-  refine max_le (hd (λ i hi, hF _ (hi.trans (nat.lt_succ_self _))) d.zero_lt_succ) _,
-  exact hF _ (nat.lt_succ_self _),
+  classical,
+  refine s.induction_on (by { rintro ⟨-, ⟨⟩⟩, }) _,
+  rintro a S haS IH - ht,
+  by_cases hs : S.nonempty,
+  { rw finset.sum_insert haS,
+    exact (padic_norm.nonarchimedean p).trans (max_le
+      (ht a (finset.mem_insert_self a S))
+      (IH hs (λ b hb, ht b (finset.mem_insert_of_mem hb)))),
+  },
+  { simp * at *, },
 end
 
-lemma sum_lt' {t : ℚ} {n : ℕ} {F : ℕ → ℚ}
-  (hF : ∀ i, i < n → padic_norm p (F i) < t) (ht : 0 < t) :
-  padic_norm p (∑ i in finset.range n, F i) < t :=
+lemma sum_lt' {α : Type*} {F : α → ℚ} {t : ℚ} {s : finset α}
+  (hF : ∀ i ∈ s, padic_norm p (F i) < t) (ht : 0 < t) :
+  padic_norm p (∑ i in s, F i) < t :=
 begin
-  obtain rfl | hn := @eq_zero_or_pos ℕ _ n,
+  obtain rfl | hs := finset.eq_empty_or_nonempty s,
   { simp [ht], },
-  { exact sum_lt hF hn, },
+  { exact sum_lt hs hF, },
 end
 
-lemma sum_le' {t : ℚ} {n : ℕ} {F : ℕ → ℚ}
-  (hF : ∀ i, i < n → padic_norm p (F i) ≤ t) (ht : 0 ≤ t) :
-  padic_norm p (∑ i in finset.range n, F i) ≤ t :=
+lemma sum_le' {α : Type*} {F : α → ℚ} {t : ℚ} {s : finset α}
+  (hF : ∀ i ∈ s, padic_norm p (F i) ≤ t) (ht : 0 ≤ t) :
+  padic_norm p (∑ i in s, F i) ≤ t :=
 begin
-  obtain rfl | hn := @eq_zero_or_pos ℕ _ n,
+  obtain rfl | hs := finset.eq_empty_or_nonempty s,
   { simp [ht], },
-  { exact sum_le hF hn, },
+  { exact sum_le hs hF, },
 end
+
 end padic_norm

--- a/src/number_theory/padics/padic_norm.lean
+++ b/src/number_theory/padics/padic_norm.lean
@@ -337,8 +337,7 @@ begin
   { rw finset.sum_insert haS,
     exact lt_of_le_of_lt (padic_norm.nonarchimedean p) (max_lt
       (ht a (finset.mem_insert_self a S))
-      (IH hs (λ b hb, ht b (finset.mem_insert_of_mem hb)))),
-  },
+      (IH hs (λ b hb, ht b (finset.mem_insert_of_mem hb)))), },
   { simp * at *, },
 end
 
@@ -353,8 +352,7 @@ begin
   { rw finset.sum_insert haS,
     exact (padic_norm.nonarchimedean p).trans (max_le
       (ht a (finset.mem_insert_self a S))
-      (IH hs (λ b hb, ht b (finset.mem_insert_of_mem hb)))),
-  },
+      (IH hs (λ b hb, ht b (finset.mem_insert_of_mem hb)))), },
   { simp * at *, },
 end
 


### PR DESCRIPTION
Add the proof that the p-adic norm of an integer is 1 iff the integer is not a multiple of p and related API for `padic_norm`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.
Add proof that an integer has p-adic norm 1 iff it's not a multiple of p.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)

I also deleted a `padic_norm` section which encompassed the entire file (presumably the result of someone breaking down a large file into smaller pieces).