### PR TITLE
[Merged by Bors] - feat(field_theory/normal): A compositum of normal extensions is normal

### DIFF
--- a/src/field_theory/adjoin.lean
+++ b/src/field_theory/adjoin.lean
@@ -402,9 +402,9 @@ is_splitting_field_iff.mpr ⟨splits_of_splits hp (λ x hx, subset_adjoin F (p.r
 
 open_locale big_operators
 
-lemma splitting_field_supr {ι : Type*} {t : ι → intermediate_field F E}
-  {p : ι → F[X]} {s : finset ι} (h0 : ∏ i in s, p i ≠ 0)
-  (h : ∀ i ∈ s, (p i).is_splitting_field F (t i)) :
+/-- A compositum of splitting fields is a splitting field -/
+lemma is_splitting_field_supr {ι : Type*} {t : ι → intermediate_field F E} {p : ι → F[X]}
+  {s : finset ι} (h0 : ∏ i in s, p i ≠ 0) (h : ∀ i ∈ s, (p i).is_splitting_field F (t i)) :
   (∏ i in s, p i).is_splitting_field F (⨆ i ∈ s, t i : intermediate_field F E) :=
 begin
   let K : intermediate_field F E := ⨆ i ∈ s, t i,

--- a/src/field_theory/adjoin.lean
+++ b/src/field_theory/adjoin.lean
@@ -492,7 +492,7 @@ begin
   refine exists_finset_of_mem_supr (set_like.le_def.mp (supr_le (λ i x hx, set_like.le_def.mp
     (le_supr_of_le ⟨i, x, hx⟩ le_rfl) (subset_adjoin F _ _))) hx),
   rw [intermediate_field.minpoly_eq, subtype.coe_mk, polynomial.mem_root_set, minpoly.aeval],
-  refine minpoly.ne_zero (is_integral_iff.mp (is_algebraic_iff_is_integral.mp (h i ⟨x, hx⟩))),
+  exact minpoly.ne_zero (is_integral_iff.mp (is_algebraic_iff_is_integral.mp (h i ⟨x, hx⟩)))
 end
 
 end adjoin_simple

--- a/src/field_theory/adjoin.lean
+++ b/src/field_theory/adjoin.lean
@@ -386,7 +386,7 @@ begin
   rwa is_algebraic_iff_is_integral,
 end
 
-lemma is_splitting_field_iff {p : polynomial F} {K : intermediate_field F E} :
+lemma is_splitting_field_iff {p : F[X]} {K : intermediate_field F E} :
   p.is_splitting_field F K ↔ p.splits (algebra_map F K) ∧ K = adjoin F (p.root_set E) :=
 begin
   suffices : _ → ((algebra.adjoin F (p.root_set K) = ⊤ ↔ K = adjoin F (p.root_set E))),
@@ -396,9 +396,25 @@ begin
   exact λ hp, (adjoin_root_set_eq_range hp K.val).symm.trans eq_comm,
 end
 
-lemma adjoin_root_set_is_splitting_field {p : polynomial F} (hp : p.splits (algebra_map F E)) :
+lemma adjoin_root_set_is_splitting_field {p : F[X]} (hp : p.splits (algebra_map F E)) :
   p.is_splitting_field F (adjoin F (p.root_set E)) :=
 is_splitting_field_iff.mpr ⟨splits_of_splits hp (λ x hx, subset_adjoin F (p.root_set E) hx), rfl⟩
+
+open_locale big_operators
+
+lemma splitting_field_supr {ι : Type*} {t : ι → intermediate_field F E}
+  {p : ι → F[X]} {s : finset ι} (h0 : ∏ i in s, p i ≠ 0)
+  (h : ∀ i ∈ s, (p i).is_splitting_field F (t i)) :
+  (∏ i in s, p i).is_splitting_field F (⨆ i ∈ s, t i : intermediate_field F E) :=
+begin
+  let K : intermediate_field F E := ⨆ i ∈ s, t i,
+  have hK : ∀ i ∈ s, t i ≤ K := λ i hi, le_supr_of_le i (le_supr (λ _, t i) hi),
+  simp only [is_splitting_field_iff] at h ⊢,
+  refine ⟨splits_prod (algebra_map F K) (λ i hi, polynomial.splits_comp_of_splits
+    (algebra_map F (t i)) (inclusion (hK i hi)).to_ring_hom (h i hi).1), _⟩,
+  simp only [root_set_prod p s h0, ←set.supr_eq_Union, (@gc F _ E _ _).l_supr₂],
+  exact supr_congr (λ i, supr_congr (λ hi, (h i hi).2)),
+end
 
 open set complete_lattice
 
@@ -468,6 +484,16 @@ lemma exists_finset_of_mem_supr' {ι : Type*} {f : ι → intermediate_field F E
   {x : E} (hx : x ∈ ⨆ i, f i) : ∃ s : finset (Σ i, f i), x ∈ ⨆ i ∈ s, F⟮(i.2 : E)⟯ :=
 exists_finset_of_mem_supr (set_like.le_def.mp (supr_le
   (λ i x h, set_like.le_def.mp (le_supr_of_le ⟨i, x, h⟩ le_rfl) (mem_adjoin_simple_self F x))) hx)
+
+lemma exists_finset_of_mem_supr'' {ι : Type*} {f : ι → intermediate_field F E}
+  (h : ∀ i, algebra.is_algebraic F (f i)) {x : E} (hx : x ∈ ⨆ i, f i) :
+  ∃ s : finset (Σ i, f i), x ∈ ⨆ i ∈ s, adjoin F ((minpoly F (i.2 : _)).root_set E) :=
+begin
+  refine exists_finset_of_mem_supr (set_like.le_def.mp (supr_le (λ i x hx, set_like.le_def.mp
+    (le_supr_of_le ⟨i, x, hx⟩ le_rfl) (subset_adjoin F _ _))) hx),
+  rw [intermediate_field.minpoly_eq, subtype.coe_mk, polynomial.mem_root_set, minpoly.aeval],
+  refine minpoly.ne_zero (is_integral_iff.mp (is_algebraic_iff_is_integral.mp (h i ⟨x, hx⟩))),
+end
 
 end adjoin_simple
 end adjoin_def
@@ -959,6 +985,7 @@ begin
   exact this.symm ▸ intermediate_field.finite_dimensional_supr_of_finite,
 end
 
+/-- A compositum of algebraic extensions is algebraic -/
 lemma is_algebraic_supr {ι : Type*} {f : ι → intermediate_field K L}
   (h : ∀ i, algebra.is_algebraic K (f i)) :
   algebra.is_algebraic K (⨆ i, f i : intermediate_field K L) :=

--- a/src/field_theory/normal.lean
+++ b/src/field_theory/normal.lean
@@ -207,7 +207,7 @@ begin
   let E : intermediate_field F K := ⨆ i ∈ s, adjoin F ((minpoly F (i.2 : _)).root_set K),
   have hF : normal F E,
   { apply normal.of_is_splitting_field (∏ i in s, minpoly F i.2),
-    refine splitting_field_supr _ (λ i hi, adjoin_root_set_is_splitting_field _),
+    refine is_splitting_field_supr _ (λ i hi, adjoin_root_set_is_splitting_field _),
     { exact finset.prod_ne_zero_iff.mpr (λ i hi, minpoly.ne_zero ((h i.1).is_integral i.2)) },
     { exact polynomial.splits_comp_of_splits _ (algebra_map (t i.1) K) ((h i.1).splits i.2) } },
   have hE : E ≤ ⨆ i, t i,

--- a/src/field_theory/normal.lean
+++ b/src/field_theory/normal.lean
@@ -196,6 +196,31 @@ instance (p : F[X]) : normal F p.splitting_field := normal.of_is_splitting_field
 
 end normal_tower
 
+namespace intermediate_field
+
+/-- A compositum of normal extensions is normal -/
+instance normal_supr {ι : Type*} (t : ι → intermediate_field F K) [h : ∀ i, normal F (t i)] :
+  normal F (⨆ i, t i : intermediate_field F K) :=
+begin
+  refine ⟨is_algebraic_supr (λ i, (h i).1), λ x, _⟩,
+  obtain ⟨s, hx⟩ := exists_finset_of_mem_supr'' (λ i, (h i).1) x.2,
+  let E : intermediate_field F K := ⨆ i ∈ s, adjoin F ((minpoly F (i.2 : _)).root_set K),
+  have hF : normal F E,
+  { apply normal.of_is_splitting_field (∏ i in s, minpoly F i.2),
+    refine splitting_field_supr _ (λ i hi, adjoin_root_set_is_splitting_field _),
+    { exact finset.prod_ne_zero_iff.mpr (λ i hi, minpoly.ne_zero ((h i.1).is_integral i.2)) },
+    { exact polynomial.splits_comp_of_splits _ (algebra_map (t i.1) K) ((h i.1).splits i.2) } },
+  have hE : E ≤ ⨆ i, t i,
+  { refine supr_le (λ i, supr_le (λ hi, le_supr_of_le i.1 _)),
+    rw [adjoin_le_iff, ←image_root_set ((h i.1).splits i.2) (t i.1).val],
+    exact λ _ ⟨a, _, h⟩, h ▸ a.2 },
+  have := hF.splits ⟨x, hx⟩,
+  rw [minpoly_eq, subtype.coe_mk, ←minpoly_eq] at this,
+  exact polynomial.splits_comp_of_splits _ (inclusion hE).to_ring_hom this,
+end
+
+end intermediate_field
+
 variables {F} {K} {K₁ K₂ K₃:Type*} [field K₁] [field K₂] [field K₃]
  [algebra F K₁] [algebra F K₂] [algebra F K₃]
  (ϕ : K₁ →ₐ[F] K₂) (χ : K₁ ≃ₐ[F] K₂) (ψ : K₂ →ₐ[F] K₃) (ω : K₂ ≃ₐ[F] K₃)


### PR DESCRIPTION
This PR proves that a compositum of normal extensions is normal.

The proof uses a technical lemma `exists_finset_of_mem_supr''` to reduce to the case of a finite compositum of finite normal extensions (i.e., a finite compositum of splitting fields), which is proved in `is_splitting_field_supr`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
