### PR TITLE
[Merged by Bors] - feat(linear_algebra/clifford_algebra/basic): invertibility of vectors

### DIFF
--- a/src/linear_algebra/clifford_algebra/basic.lean
+++ b/src/linear_algebra/clifford_algebra/basic.lean
@@ -293,6 +293,30 @@ by { ext x, exact alg_hom.congr_fun (map_id Q₁) x }
 
 end map
 
+variables (Q)
+
+/-- If the quadratic form of a vector is invertible, then so is that vector. -/
+def invertible_ι_of_invertible (m : M) [invertible (Q m)] : invertible (ι Q m) :=
+{ inv_of := ι Q (⅟(Q m) • m),
+  inv_of_mul_self := by rw [map_smul, smul_mul_assoc, ι_sq_scalar, algebra.smul_def, ←map_mul,
+    inv_of_mul_self, map_one],
+  mul_inv_of_self := by rw [map_smul, mul_smul_comm, ι_sq_scalar, algebra.smul_def, ←map_mul,
+    inv_of_mul_self, map_one] }
+
+/-- For a vector with invertible quadratic form, $v^{-1} = \frac{v}{Q(v)}$ -/
+lemma inv_of_ι (m : M) [invertible (Q m)] [invertible (ι Q m)] : ⅟(ι Q m) = ι Q (⅟(Q m) • m) :=
+begin
+  letI := invertible_ι_of_invertible Q m,
+  convert (rfl : ⅟(ι Q m) = _),
+end
+
+lemma is_unit_ι_of_is_unit (m : M) (h : is_unit (Q m)) : is_unit (ι Q m) :=
+begin
+  casesI h.nonempty_invertible,
+  letI := invertible_ι_of_invertible Q m,
+  exactI is_unit_of_invertible (ι Q m),
+end
+
 end clifford_algebra
 
 namespace tensor_algebra

--- a/src/linear_algebra/clifford_algebra/basic.lean
+++ b/src/linear_algebra/clifford_algebra/basic.lean
@@ -310,7 +310,7 @@ begin
   convert (rfl : ⅟(ι Q m) = _),
 end
 
-lemma is_unit_ι_of_is_unit (m : M) (h : is_unit (Q m)) : is_unit (ι Q m) :=
+lemma is_unit_ι_of_is_unit {m : M} (h : is_unit (Q m)) : is_unit (ι Q m) :=
 begin
   casesI h.nonempty_invertible,
   letI := invertible_ι_of_invertible Q m,


### PR DESCRIPTION
I believe the reverse direction of `is_unit_ι_of_is_unit` is true, but it requires that `Q` is divisible by two and #11468.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
