### PR TITLE
[Merged by Bors] - feat(field_theory/intermediate_field): Add `alg_hom.field_range`

### DIFF
--- a/src/field_theory/adjoin.lean
+++ b/src/field_theory/adjoin.lean
@@ -189,6 +189,14 @@ by { ext, rw [mem_restrict_scalars, mem_bot], exact set.ext_iff.mp subtype.range
   (⊤ : intermediate_field F E).restrict_scalars K = ⊤ :=
 rfl
 
+lemma _root_.alg_hom.field_range_eq_map {K : Type*} [field K] [algebra F K] (f : E →ₐ[F] K) :
+  f.field_range = intermediate_field.map f ⊤ :=
+set_like.ext' set.image_univ.symm
+
+lemma _root_.alg_hom.map_field_range {K L : Type*} [field K] [field L] [algebra F K] [algebra F L]
+  (f : E →ₐ[F] K) (g : K →ₐ[F] L) : f.field_range.map g = (g.comp f).field_range :=
+set_like.ext' (set.range_comp g f).symm
+
 end lattice
 
 section adjoin_def

--- a/src/field_theory/intermediate_field.lean
+++ b/src/field_theory/intermediate_field.lean
@@ -320,6 +320,7 @@ namespace alg_hom
 variables (f : L →ₐ[K] L')
 
 /-- The range of an algebra homomorphism, as an intermediate field. -/
+@[simps to_subalgebra]
 def field_range : intermediate_field K L' :=
 { .. f.range,
   .. (f : L →+* L').field_range }

--- a/src/field_theory/intermediate_field.lean
+++ b/src/field_theory/intermediate_field.lean
@@ -322,7 +322,7 @@ variables (f : L →ₐ[K] L')
 /-- The range of an algebra homomorphism, as an intermediate field. -/
 def field_range : intermediate_field K L' :=
 { .. f.range,
-  .. f.to_ring_hom.field_range }
+  .. (f : L →+* L').field_range }
 
 @[simp] lemma coe_field_range : ↑f.field_range = set.range f := rfl
 

--- a/src/field_theory/intermediate_field.lean
+++ b/src/field_theory/intermediate_field.lean
@@ -327,6 +327,9 @@ def field_range : intermediate_field K L' :=
 
 @[simp] lemma coe_field_range : ↑f.field_range = set.range f := rfl
 
+@[simp] lemma field_range_to_subfield :
+  f.field_range.to_subfield = (f : L →+* L').field_range := rfl
+
 variables {f}
 
 @[simp] lemma mem_field_range {y : L'} : y ∈ f.field_range ↔ ∃ x, f x = y := iff.rfl

--- a/src/field_theory/intermediate_field.lean
+++ b/src/field_theory/intermediate_field.lean
@@ -39,7 +39,7 @@ intermediate field, field extension
 open finite_dimensional polynomial
 open_locale big_operators polynomial
 
-variables (K L : Type*) [field K] [field L] [algebra K L]
+variables (K L L' : Type*) [field K] [field L] [field L'] [algebra K L] [algebra K L']
 
 /-- `S : intermediate_field K L` is a subset of `L` such that there is a field
 tower `L / S / K`. -/
@@ -50,7 +50,7 @@ structure intermediate_field extends subalgebra K L :=
 /-- Reinterpret an `intermediate_field` as a `subalgebra`. -/
 add_decl_doc intermediate_field.to_subalgebra
 
-variables {K L} (S : intermediate_field K L)
+variables {K L L'} (S : intermediate_field K L)
 
 namespace intermediate_field
 
@@ -283,8 +283,6 @@ is_scalar_tower.subalgebra' _ _ _ S.to_subalgebra
 instance is_scalar_tower_mid' : is_scalar_tower K S L :=
 S.is_scalar_tower_mid
 
-variables {L' : Type*} [field L'] [algebra K L']
-
 /-- If `f : L →+* L'` fixes `K`, `S.map f` is the intermediate field between `L'` and `K`
 such that `x ∈ S ↔ f x ∈ S.map f`. -/
 def map (f : L →ₐ[K] L') (S : intermediate_field K L) : intermediate_field K L' :=
@@ -314,6 +312,27 @@ e.subalgebra_map E.to_subalgebra
 
 @[simp] lemma intermediate_field_map_symm_apply_coe (e : L ≃ₐ[K] L') (E : intermediate_field K L)
   (a : E.map e.to_alg_hom) : ↑((intermediate_field_map e E).symm a) = e.symm a := rfl
+
+end intermediate_field
+
+namespace alg_hom
+
+variables (f : L →ₐ[K] L')
+
+/-- The range of an algebra homomorphism, as an intermediate field. -/
+def field_range : intermediate_field K L' :=
+{ .. f.range,
+  .. f.to_ring_hom.field_range }
+
+@[simp] lemma coe_field_range : ↑f.field_range = set.range f := rfl
+
+variables {f}
+
+@[simp] lemma mem_field_range {y : L'} : y ∈ f.field_range ↔ ∃ x, f x = y := iff.rfl
+
+end alg_hom
+
+namespace intermediate_field
 
 /-- The embedding from an intermediate field of `L / K` to `L`. -/
 def val : S →ₐ[K] L :=


### PR DESCRIPTION
This PR adds `alg_hom.field_range` (which produces an `intermediate_field` rather than a `subalgebra`) and copies over the API from `ring_hom.field_range` (which produces a `subfield` rather than a `subring`).

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
