### PR TITLE
[Merged by Bors] - chore(analysis/calculus/cont_diff): Add two missing cont_diff_on lemmas

### DIFF
--- a/src/analysis/calculus/cont_diff.lean
+++ b/src/analysis/calculus/cont_diff.lean
@@ -654,10 +654,10 @@ lemma cont_diff_on.of_le (h : cont_diff_on 𝕜 n f s) (hmn : m ≤ n) :
   cont_diff_on 𝕜 m f s :=
 λ x hx, (h x hx).of_le hmn
 
-lemma cont_diff_on.of_succ (h : cont_diff_on 𝕜 (n + 1) f s) : cont_diff_on 𝕜 n f s :=
+lemma cont_diff_on.of_succ {n : ℕ} (h : cont_diff_on 𝕜 (n + 1) f s) : cont_diff_on 𝕜 n f s :=
 h.of_le $ with_top.coe_le_coe.mpr le_self_add
 
-lemma cont_diff_on.one_of_succ (h : cont_diff_on 𝕜 (n + 1) f s) : cont_diff_on 𝕜 1 f s :=
+lemma cont_diff_on.one_of_succ {n : ℕ} (h : cont_diff_on 𝕜 (n + 1) f s) : cont_diff_on 𝕜 1 f s :=
 h.of_le $ with_top.coe_le_coe.mpr le_add_self
 
 lemma cont_diff_on_iff_forall_nat_le :

--- a/src/analysis/calculus/cont_diff.lean
+++ b/src/analysis/calculus/cont_diff.lean
@@ -654,6 +654,12 @@ lemma cont_diff_on.of_le (h : cont_diff_on 𝕜 n f s) (hmn : m ≤ n) :
   cont_diff_on 𝕜 m f s :=
 λ x hx, (h x hx).of_le hmn
 
+lemma cont_diff_on.of_succ (h : cont_diff_on 𝕜 (n + 1) f s) : cont_diff_on 𝕜 n f s :=
+h.of_le $ with_top.coe_le_coe.mpr le_self_add
+
+lemma cont_diff_on.one_of_succ (h : cont_diff_on 𝕜 (n + 1) f s) : cont_diff_on 𝕜 1 f s :=
+h.of_le $ with_top.coe_le_coe.mpr le_add_self
+
 lemma cont_diff_on_iff_forall_nat_le :
   cont_diff_on 𝕜 n f s ↔ ∀ m : ℕ, ↑m ≤ n → cont_diff_on 𝕜 m f s :=
 ⟨λ H m hm, H.of_le hm, λ H x hx m hm, H m hm x hx m le_rfl⟩


### PR DESCRIPTION
Adds two lemmas that are immediate consequences of `cont_diff_on.of_le`. Names and proofs are taken verbatim from the corresponding `cont_diff` lemmas.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
