### PR TITLE
[Merged by Bors] - refactor(field_theory/*): Move and golf `alg_hom.fintype`

### DIFF
--- a/src/field_theory/fixed.lean
+++ b/src/field_theory/fixed.lean
@@ -276,56 +276,6 @@ lemma cardinal_mk_alg_hom (K : Type u) (V : Type v) (W : Type w)
   cardinal.mk (V →ₐ[K] W) ≤ finrank W (V →ₗ[K] W) :=
 cardinal_mk_le_finrank_of_linear_independent $ linear_independent_to_linear_map K V W
 
-section alg_hom_fintype
-
-/-- A technical finiteness result. -/
-noncomputable def fintype.subtype_prod {E : Type*} {X : set E} (hX : X.finite) {L : Type*}
-  (F : E → multiset L) : fintype (Π x : X, {l : L // l ∈ F x}) :=
-by { classical, letI : fintype X := set.finite.fintype hX, exact pi.fintype}
-
-variables (E K : Type*) [field E] [field K] [algebra F E] [algebra F K] [finite_dimensional F E]
-
-/-- Function from Hom_K(E,L) to pi type Π (x : basis), roots of min poly of x -/
--- Marked as `noncomputable!` since this definition takes multiple seconds to compile,
--- and isn't very computable in practice (since neither `finrank` nor `fin_basis` are).
-noncomputable! def roots_of_min_poly_pi_type (φ : E →ₐ[F] K)
-  (x : set.range (finite_dimensional.fin_basis F E : _ → E)) :
-  {l : K // l ∈ (((minpoly F x.1).map (algebra_map F K)).roots : multiset K)} :=
-⟨φ x, begin
-  rw [polynomial.mem_roots_map (minpoly.ne_zero_of_finite_field_extension F x.val),
-    ← polynomial.alg_hom_eval₂_algebra_map, ← φ.map_zero],
-  exact congr_arg φ (minpoly.aeval F (x : E)),
-end⟩
-
-lemma aux_inj_roots_of_min_poly : function.injective (roots_of_min_poly_pi_type F E K) :=
-begin
-  intros f g h,
-  suffices : (f : E →ₗ[F] K) = g,
-  { rw linear_map.ext_iff at this,
-    ext x, exact this x },
-  rw function.funext_iff at h,
-  apply linear_map.ext_on (finite_dimensional.fin_basis F E).span_eq,
-  rintro e he,
-  have := (h ⟨e, he⟩),
-  apply_fun subtype.val at this,
-  exact this,
-end
-
-/-- Given field extensions `E/F` and `K/F`, with `E/F` finite, there are finitely many `F`-algebra
-  homomorphisms `E →ₐ[K] K`. -/
-noncomputable instance alg_hom.fintype : fintype (E →ₐ[F] K) :=
-let n := finite_dimensional.finrank F E in
-begin
-  let B : basis (fin n) F E := finite_dimensional.fin_basis F E,
-  let X := set.range (B : fin n → E),
-  have hX : X.finite := set.finite_range ⇑B,
-  refine @fintype.of_injective _ _
-    (fintype.subtype_prod hX (λ e, ((minpoly F e).map (algebra_map F K)).roots)) _
-    (aux_inj_roots_of_min_poly F E K),
-end
-
-end alg_hom_fintype
-
 noncomputable instance alg_equiv.fintype (K : Type u) (V : Type v)
   [field K] [field V] [algebra K V] [finite_dimensional K V] :
   fintype (V ≃ₐ[K] V) :=

--- a/src/field_theory/minpoly.lean
+++ b/src/field_theory/minpoly.lean
@@ -387,6 +387,43 @@ lemma sub_algebra_map {B : Type*} [comm_ring B] [algebra A B] {x : B}
   minpoly A (x - (algebra_map A B a)) = (minpoly A x).comp (X + C a) :=
 by simpa [sub_eq_add_neg] using add_algebra_map hx (-a)
 
+section alg_hom_fintype
+
+/-- A technical finiteness result. -/
+noncomputable def fintype.subtype_prod {E : Type*} {X : set E} (hX : X.finite) {L : Type*}
+  (F : E → multiset L) : fintype (Π x : X, {l : L // l ∈ F x}) :=
+let hX := finite.fintype hX in by exactI pi.fintype
+
+variables (F E K : Type*) [field F] [ring E] [comm_ring K] [is_domain K]
+  [algebra F E] [algebra F K] [finite_dimensional F E]
+
+/-- Function from Hom_K(E,L) to pi type Π (x : basis), roots of min poly of x -/
+-- Marked as `noncomputable!` since this definition takes multiple seconds to compile,
+-- and isn't very computable in practice (since neither `finrank` nor `fin_basis` are).
+noncomputable! def roots_of_min_poly_pi_type (φ : E →ₐ[F] K)
+  (x : range (finite_dimensional.fin_basis F E : _ → E)) :
+  {l : K // l ∈ (((minpoly F x.1).map (algebra_map F K)).roots : multiset K)} :=
+⟨φ x, by rw [mem_roots_map (minpoly.ne_zero_of_finite_field_extension F x.val),
+  subtype.val_eq_coe, ←aeval_def, aeval_alg_hom_apply, minpoly.aeval, map_zero]⟩
+
+lemma aux_inj_roots_of_min_poly : injective (roots_of_min_poly_pi_type F E K) :=
+begin
+  intros f g h,
+  suffices : (f : E →ₗ[F] K) = g,
+  { rwa fun_like.ext'_iff at this ⊢ },
+  rw funext_iff at h,
+  exact linear_map.ext_on (finite_dimensional.fin_basis F E).span_eq
+    (λ e he, subtype.ext_iff.mp (h ⟨e, he⟩)),
+end
+
+/-- Given field extensions `E/F` and `K/F`, with `E/F` finite, there are finitely many `F`-algebra
+  homomorphisms `E →ₐ[K] K`. -/
+noncomputable instance alg_hom.fintype : fintype (E →ₐ[F] K) :=
+@fintype.of_injective _ _ (fintype.subtype_prod (finite_range (finite_dimensional.fin_basis F E))
+  (λ e, ((minpoly F e).map (algebra_map F K)).roots)) _ (aux_inj_roots_of_min_poly F E K)
+
+end alg_hom_fintype
+
 section gcd_domain
 
 variables {R S : Type*} (K L : Type*) [comm_ring R] [is_domain R] [normalized_gcd_monoid R]


### PR DESCRIPTION
This PR moves `alg_hom.fintype` to `minpoly.lean` so that it can be used later (e.g., in `normal.lean`).

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
