### PR TITLE
[Merged by Bors] - feat(group_theory/coset): Right cosets are orbits

### DIFF
--- a/src/group_theory/coset.lean
+++ b/src/group_theory/coset.lean
@@ -170,6 +170,16 @@ set.ext $ by simp [mem_left_coset_iff, mul_mem_cancel_left (s.inv_mem ha)]
 lemma right_coset_mem_right_coset {a : α} (ha : a ∈ s) : (s : set α) *r a = s :=
 set.ext $ assume b, by simp [mem_right_coset_iff, mul_mem_cancel_right (s.inv_mem ha)]
 
+@[to_additive] lemma orbit_subgroup_eq_right_coset (a : α) : mul_action.orbit s a = s *r a :=
+set.ext (λ b, ⟨λ ⟨c, d⟩, ⟨c, c.2, d⟩, λ ⟨c, d, e⟩, ⟨⟨c, d⟩, e⟩⟩)
+
+@[to_additive] lemma orbit_subgroup_eq_self_of_mem {a : α} (ha : a ∈ s) :
+  mul_action.orbit s a = s :=
+(orbit_subgroup_eq_right_coset s a).trans (right_coset_mem_right_coset s ha)
+
+@[to_additive] lemma orbit_subgroup_one_eq_self : mul_action.orbit s (1 : α) = s :=
+orbit_subgroup_eq_self_of_mem s s.one_mem
+
 @[to_additive eq_add_cosets_of_normal]
 theorem eq_cosets_of_normal (N : s.normal) (g : α) : g *l s = s *r g :=
 set.ext $ assume a, by simp [mem_left_coset_iff, mem_right_coset_iff]; rw [N.mem_comm_iff]

--- a/src/group_theory/group_action/basic.lean
+++ b/src/group_theory/group_action/basic.lean
@@ -71,6 +71,15 @@ set.range_subset_iff.2 $ λ a', mul_smul a' a b ▸ mem_orbit _ _
   ↑(a • b') = a • (b' : β) :=
 rfl
 
+lemma orbit_subgroup_eq_self_of_mem {G : Type*} [group G] {H : subgroup G} {g : G} (h : g ∈ H) :
+  mul_action.orbit H g = H :=
+set.ext (λ x, ⟨λ ⟨y, z⟩, (congr_arg (∈ H) z).mp (H.mul_mem y.2 h),
+  λ y, ⟨⟨x, y⟩ * ⟨g, h⟩⁻¹, inv_mul_cancel_right x g⟩⟩)
+
+@[simp] lemma orbit_subgroup_one_eq_self {G : Type*} [group G] (H : subgroup G) :
+  mul_action.orbit H (1 : G) = H :=
+orbit_subgroup_eq_self_of_mem H.one_mem
+
 variables (α) (β)
 
 /-- The set of elements fixed under the whole action. -/

--- a/src/group_theory/group_action/basic.lean
+++ b/src/group_theory/group_action/basic.lean
@@ -71,15 +71,6 @@ set.range_subset_iff.2 $ λ a', mul_smul a' a b ▸ mem_orbit _ _
   ↑(a • b') = a • (b' : β) :=
 rfl
 
-lemma orbit_subgroup_eq_self_of_mem {G : Type*} [group G] {H : subgroup G} {g : G} (h : g ∈ H) :
-  mul_action.orbit H g = H :=
-set.ext (λ x, ⟨λ ⟨y, z⟩, (congr_arg (∈ H) z).mp (H.mul_mem y.2 h),
-  λ y, ⟨⟨x, y⟩ * ⟨g, h⟩⁻¹, inv_mul_cancel_right x g⟩⟩)
-
-@[simp] lemma orbit_subgroup_one_eq_self {G : Type*} [group G] (H : subgroup G) :
-  mul_action.orbit H (1 : G) = H :=
-orbit_subgroup_eq_self_of_mem H.one_mem
-
 variables (α) (β)
 
 /-- The set of elements fixed under the whole action. -/


### PR DESCRIPTION
This PR adds a few lemma about the orbit of the action of a subgroup of a group on the group.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
