### PR TITLE
[Merged by Bors] - feat(combinatorics/young_diagram): add transposes, rows and columns of Young diagrams

### DIFF
--- a/src/combinatorics/young_diagram.lean
+++ b/src/combinatorics/young_diagram.lean
@@ -66,6 +66,8 @@ instance : set_like young_diagram (ℕ × ℕ) :=
 @[simp] lemma mem_cells {μ : young_diagram} (c : ℕ × ℕ) :
   c ∈ μ.cells ↔ c ∈ μ := iff.rfl
 
+instance decidable_mem (μ : young_diagram) : decidable_pred (∈ μ) := λ _, μ.cells.decidable_mem _
+
 /-- In "English notation", a Young diagram is drawn so that (i1, j1) ≤ (i2, j2)
     means (i1, j1) is weakly up-and-left of (i2, j2). -/
 lemma up_left_mem (μ : young_diagram) {i1 i2 j1 j2 : ℕ}
@@ -176,7 +178,7 @@ def row (μ : young_diagram) (i : ℕ) : finset (ℕ × ℕ) := μ.cells.filter 
 lemma mem_row_iff {μ : young_diagram} {i : ℕ} {c : ℕ × ℕ} : c ∈ μ.row i ↔ c ∈ μ ∧ c.fst = i :=
 by simp [row]
 
-protected lemma exists_not_mem_row (μ : young_diagram) (i : ℕ) : ∃ j, (i, j) ∉ μ.cells :=
+protected lemma exists_not_mem_row (μ : young_diagram) (i : ℕ) : ∃ j, (i, j) ∉ μ :=
 begin
   obtain ⟨j, hj⟩ := infinite.exists_not_mem_finset
     ((μ.cells).preimage (prod.mk i) (λ _ _ _ _ h, by {cases h, refl})),

--- a/src/combinatorics/young_diagram.lean
+++ b/src/combinatorics/young_diagram.lean
@@ -153,6 +153,7 @@ protected lemma le_of_transpose_le {μ ν : young_diagram} (h_le : μ.transpose 
 ⟨ young_diagram.le_of_transpose_le,
   by { convert @young_diagram.le_of_transpose_le μ.transpose ν.transpose, simp } ⟩
 
+/-- Transposing Young diagrams is an `order_iso`. -/
 def transpose_order_iso : young_diagram ≃o young_diagram :=
 ⟨⟨transpose, transpose, λ _, by simp, λ _, by simp⟩, by simp⟩
 
@@ -182,6 +183,7 @@ begin
   rw finset.mem_preimage at hj, exact ⟨j, hj⟩,
 end
 
+/-- Length of a row of a Young diagram --/
 def row_len (μ : young_diagram) (i : ℕ) : ℕ := nat.find $ μ.exists_not_mem_row i
 
 lemma mem_iff_lt_row_len {μ : young_diagram} {i j : ℕ} : (i, j) ∈ μ ↔ j < μ.row_len i :=
@@ -205,7 +207,9 @@ by { by_contra' h_lt, rw ← lt_self_iff_false (μ.row_len i1),
 end rows
 
 section columns
-/-- This section has an identical API to the rows section. --/
+/-- Columns and column lengths of Young diagrams.
+
+This section has an identical API to the rows section. --/
 
 def col (μ : young_diagram) (j : ℕ) := μ.cells.filter (λ c, c.snd = j)
 
@@ -217,6 +221,7 @@ by { obtain ⟨i, hi⟩ := infinite.exists_not_mem_finset
        ((μ.cells).preimage (λ i, prod.mk i j) (λ _ _ _ _ h, by {cases h, refl})),
      rw finset.mem_preimage at hi, exact ⟨i, hi⟩ }
 
+/-- Length of a column of a Young diagram --/
 def col_len (μ : young_diagram) (j : ℕ) : ℕ := nat.find $ μ.exists_not_mem_col j
 
 lemma mem_iff_lt_col_len {μ : young_diagram} {i j : ℕ} : (i, j) ∈ μ ↔ i < μ.col_len j :=

--- a/src/combinatorics/young_diagram.lean
+++ b/src/combinatorics/young_diagram.lean
@@ -171,7 +171,7 @@ This section defines `μ.row` and `μ.row_len`, with the following API:
 Note: #3 is not convenient for defining `μ.row_len`; instead, `μ.row_len` is defined
 as the smallest `j` such that `(i, j) ∉ μ`. --/
 
-def row (μ : young_diagram) (i : ℕ) := μ.cells.filter (λ c, c.fst = i)
+def row (μ : young_diagram) (i : ℕ) : finset (ℕ × ℕ) := μ.cells.filter (λ c, c.fst = i)
 
 lemma mem_row_iff {μ : young_diagram} {i : ℕ} {c : ℕ × ℕ} : c ∈ μ.row i ↔ c ∈ μ ∧ c.fst = i :=
 by simp [row]
@@ -211,7 +211,7 @@ section columns
 
 This section has an identical API to the rows section. --/
 
-def col (μ : young_diagram) (j : ℕ) := μ.cells.filter (λ c, c.snd = j)
+def col (μ : young_diagram) (j : ℕ) : finset (ℕ × ℕ) := μ.cells.filter (λ c, c.snd = j)
 
 lemma mem_col_iff {μ : young_diagram} {j : ℕ} {c : ℕ × ℕ} : c ∈ μ.col j ↔ c ∈ μ ∧ c.snd = j :=
 by simp [col]

--- a/src/combinatorics/young_diagram.lean
+++ b/src/combinatorics/young_diagram.lean
@@ -143,20 +143,29 @@ def transpose (μ : young_diagram) : young_diagram :=
 @[simp] lemma mem_transpose {μ : young_diagram} {c : ℕ × ℕ} : c ∈ μ.transpose ↔ c.swap ∈ μ :=
 by { change c ∈ μ.cells.map _ ↔ _, rw finset.mem_map_equiv, refl, }
 
-@[simp] lemma transpose_eq_iff {μ ν : young_diagram} : μ.transpose = ν ↔ μ = ν.transpose :=
-by { split; { rintro rfl, ext, simp } }
-
 @[simp] lemma transpose_transpose (μ : young_diagram) : μ.transpose.transpose = μ :=
-by rw transpose_eq_iff
+by { ext, simp }
+
+lemma transpose_eq_iff_eq_transpose {μ ν : young_diagram} :
+  μ.transpose = ν ↔ μ = ν.transpose :=
+by { split; { rintro rfl, simp } }
+
+@[simp] lemma transpose_eq_iff {μ ν : young_diagram} :
+  μ.transpose = ν.transpose ↔ μ = ν :=
+by { rw transpose_eq_iff_eq_transpose, simp }
 
 -- This is effectively both directions of the iff statement below.
 protected lemma le_of_transpose_le {μ ν : young_diagram} (h_le : μ.transpose ≤ ν) :
   μ ≤ ν.transpose :=
 λ c hc, by { simp only [mem_transpose], apply h_le, simpa }
 
-@[simp] lemma transpose_le_iff {μ ν : young_diagram} : μ.transpose ≤ ν ↔ μ ≤ ν.transpose :=
-⟨ young_diagram.le_of_transpose_le,
-  by { convert @young_diagram.le_of_transpose_le μ.transpose ν.transpose, simp } ⟩
+@[simp] lemma transpose_le_iff {μ ν : young_diagram} : μ.transpose ≤ ν.transpose ↔ μ ≤ ν :=
+⟨ λ h, by { convert young_diagram.le_of_transpose_le h, simp },
+  λ h, by { convert @young_diagram.le_of_transpose_le _ _ _, simpa } ⟩
+
+@[mono]
+protected lemma transpose_mono {μ ν : young_diagram} (h_le : μ ≤ ν) : μ.transpose ≤ ν.transpose :=
+by simp [h_le]
 
 /-- Transposing Young diagrams is an `order_iso`. -/
 def transpose_order_iso : young_diagram ≃o young_diagram :=

--- a/src/combinatorics/young_diagram.lean
+++ b/src/combinatorics/young_diagram.lean
@@ -66,7 +66,8 @@ instance : set_like young_diagram (ℕ × ℕ) :=
 @[simp] lemma mem_cells {μ : young_diagram} (c : ℕ × ℕ) :
   c ∈ μ.cells ↔ c ∈ μ := iff.rfl
 
-instance decidable_mem (μ : young_diagram) : decidable_pred (∈ μ) := λ _, μ.cells.decidable_mem _
+instance decidable_mem (μ : young_diagram) : decidable_pred (∈ μ) :=
+show decidable_pred (∈ μ.cells), by apply_instance
 
 /-- In "English notation", a Young diagram is drawn so that (i1, j1) ≤ (i2, j2)
     means (i1, j1) is weakly up-and-left of (i2, j2). -/
@@ -129,8 +130,8 @@ end distrib_lattice
 @[reducible] protected def card (μ : young_diagram) : ℕ := μ.cells.card
 
 section transpose
-/-- The `transpose` of a Young diagram is obtained by swapping i's with j's. --/
 
+/-- The `transpose` of a Young diagram is obtained by swapping i's with j's. -/
 def transpose (μ : young_diagram) : young_diagram :=
 { cells :=  (equiv.prod_comm _ _).finset_congr μ.cells,
   is_lower_set := λ _ _ h, begin
@@ -154,7 +155,7 @@ by { split; { rintro rfl, simp } }
   μ.transpose = ν.transpose ↔ μ = ν :=
 by { rw transpose_eq_iff_eq_transpose, simp }
 
--- This is effectively both directions of the iff statement below.
+-- This is effectively both directions of `transpose_le_iff` below.
 protected lemma le_of_transpose_le {μ ν : young_diagram} (h_le : μ.transpose ≤ ν) :
   μ ≤ ν.transpose :=
 λ c hc, by { simp only [mem_transpose], apply h_le, simpa }
@@ -165,10 +166,10 @@ protected lemma le_of_transpose_le {μ ν : young_diagram} (h_le : μ.transpose 
 
 @[mono]
 protected lemma transpose_mono {μ ν : young_diagram} (h_le : μ ≤ ν) : μ.transpose ≤ ν.transpose :=
-by simp [h_le]
+transpose_le_iff.mpr h_le
 
 /-- Transposing Young diagrams is an `order_iso`. -/
-def transpose_order_iso : young_diagram ≃o young_diagram :=
+@[simps] def transpose_order_iso : young_diagram ≃o young_diagram :=
 ⟨⟨transpose, transpose, λ _, by simp, λ _, by simp⟩, by simp⟩
 
 end transpose
@@ -206,7 +207,7 @@ lemma mem_iff_lt_row_len {μ : young_diagram} {i j : ℕ} : (i, j) ∈ μ ↔ j 
 by { rw [row_len, nat.lt_find_iff], push_neg,
      exact ⟨λ h _ hmj, μ.up_left_mem (by refl) hmj h, λ h, h _ (by refl)⟩ }
 
-lemma row_eq_prod {μ : young_diagram} {i : ℕ} : μ.row i = {i} ×ˢ (finset.range (μ.row_len i)) :=
+lemma row_eq_prod {μ : young_diagram} {i : ℕ} : μ.row i = {i} ×ˢ finset.range (μ.row_len i) :=
 by { ext ⟨a, b⟩,
      simp only [finset.mem_product, finset.mem_singleton, finset.mem_range,
                 mem_row_iff, mem_iff_lt_row_len, and_comm, and.congr_right_iff],
@@ -264,10 +265,10 @@ by { by_contra' h_lt, rw ← lt_self_iff_false (μ.col_len j1),
      rw ← mem_iff_lt_col_len at h_lt ⊢,
      exact μ.up_left_mem (by refl) hj h_lt }
 
-@[simp] lemma transpose_col_len (μ : young_diagram) (j : ℕ) : μ.transpose.col_len j = μ.row_len j :=
+@[simp] lemma col_len_transpose (μ : young_diagram) (j : ℕ) : μ.transpose.col_len j = μ.row_len j :=
 by simp [row_len, col_len]
 
-@[simp] lemma transpose_row_len (μ : young_diagram) (i : ℕ) : μ.transpose.row_len i = μ.col_len i :=
+@[simp] lemma row_len_transpose (μ : young_diagram) (i : ℕ) : μ.transpose.row_len i = μ.col_len i :=
 by simp [row_len, col_len]
 
 end columns

--- a/src/combinatorics/young_diagram.lean
+++ b/src/combinatorics/young_diagram.lean
@@ -143,7 +143,7 @@ by { change c ∈ μ.cells.map _ ↔ _, rw finset.mem_map_equiv, refl, }
 @[simp] lemma transpose_eq_iff {μ ν : young_diagram} : μ.transpose = ν ↔ μ = ν.transpose :=
 by { split; { rintro rfl, ext, simp } }
 
-@[simp] lemma transpose_transpose {μ : young_diagram} : μ.transpose.transpose = μ :=
+@[simp] lemma transpose_transpose (μ : young_diagram) : μ.transpose.transpose = μ :=
 by rw transpose_eq_iff
 
 -- This is effectively both directions of the iff statement below.
@@ -243,6 +243,12 @@ lemma col_len_decr (μ : young_diagram) (j1 j2 : ℕ) (hj : j1 ≤ j2) : μ.col_
 by { by_contra' h_lt, rw ← lt_self_iff_false (μ.col_len j1),
      rw ← mem_iff_lt_col_len at h_lt ⊢,
      exact μ.up_left_mem (by refl) hj h_lt }
+
+@[simp] lemma transpose_col_len (μ : young_diagram) (j : ℕ) : μ.transpose.col_len j = μ.row_len j :=
+by simp [row_len, col_len]
+
+@[simp] lemma transpose_row_len (μ : young_diagram) (i : ℕ) : μ.transpose.row_len i = μ.col_len i :=
+by simp [row_len, col_len]
 
 end columns
 


### PR DESCRIPTION
Add transposes, rows (and row lengths), columns (and column lengths) of Young diagrams.

---

There are two things I'm not sure about in this PR:
~~1. The definition of `exists_not_mem_row` has to use `(i, j) ∉ μ.cells` instead of `(i, j) ∉ μ`. See line 179.~~
2. Is there a way to automatically deduce each proof in the columns section by replacing `μ` by `μ.transpose`? 
Comments or ideas welcome.

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
