### PR TITLE
[Merged by Bors] - feat(*): generalize to and add distrib_smul instances

### DIFF
--- a/src/algebra/monoid_algebra/basic.lean
+++ b/src/algebra/monoid_algebra/basic.lean
@@ -268,9 +268,13 @@ instance [comm_ring k] [comm_monoid G] : comm_ring (monoid_algebra k G) :=
 
 variables {S : Type*}
 
-instance [monoid R] [semiring k] [distrib_mul_action R k] :
-  has_smul R (monoid_algebra k G) :=
-finsupp.has_smul
+instance [semiring k] [smul_zero_class R k] :
+  smul_zero_class R (monoid_algebra k G) :=
+finsupp.smul_zero_class
+
+instance [semiring k] [distrib_smul R k] :
+  distrib_smul R (monoid_algebra k G) :=
+finsupp.distrib_smul _ _
 
 instance [monoid R] [semiring k] [distrib_mul_action R k] :
   distrib_mul_action R (monoid_algebra k G) :=
@@ -451,7 +455,7 @@ end misc_theorems
 /-! #### Non-unital, non-associative algebra structure -/
 section non_unital_non_assoc_algebra
 
-variables (k) [monoid R] [semiring k] [distrib_mul_action R k] [has_mul G]
+variables (k) [semiring k] [distrib_smul R k] [has_mul G]
 
 instance is_scalar_tower_self [is_scalar_tower R k k] :
   is_scalar_tower R (monoid_algebra k G) (monoid_algebra k G) :=
@@ -999,9 +1003,9 @@ end mul_one_class
 /-! #### Semiring structure -/
 section semiring
 
-instance {R : Type*} [monoid R] [semiring k] [distrib_mul_action R k] :
-  has_smul R (add_monoid_algebra k G) :=
-finsupp.has_smul
+instance {R : Type*} [semiring k] [smul_zero_class R k] :
+  smul_zero_class R (add_monoid_algebra k G) :=
+finsupp.smul_zero_class
 
 variables [semiring k] [add_monoid G]
 
@@ -1298,22 +1302,22 @@ variables {k G}
 
 section non_unital_non_assoc_algebra
 
-variables (k) [monoid R] [semiring k] [distrib_mul_action R k] [has_add G]
+variables (k) [semiring k] [distrib_smul R k] [has_add G]
 
 instance is_scalar_tower_self [is_scalar_tower R k k] :
   is_scalar_tower R (add_monoid_algebra k G) (add_monoid_algebra k G) :=
-@monoid_algebra.is_scalar_tower_self k (multiplicative G) R _ _ _ _ _
+@monoid_algebra.is_scalar_tower_self k (multiplicative G) R _ _ _ _
 
 /-- Note that if `k` is a `comm_semiring` then we have `smul_comm_class k k k` and so we can take
 `R = k` in the below. In other words, if the coefficients are commutative amongst themselves, they
 also commute with the algebra multiplication. -/
 instance smul_comm_class_self [smul_comm_class R k k] :
   smul_comm_class R (add_monoid_algebra k G) (add_monoid_algebra k G) :=
-@monoid_algebra.smul_comm_class_self k (multiplicative G) R _ _ _ _ _
+@monoid_algebra.smul_comm_class_self k (multiplicative G) R _ _ _ _
 
 instance smul_comm_class_symm_self [smul_comm_class k R k] :
   smul_comm_class (add_monoid_algebra k G) R (add_monoid_algebra k G) :=
-@monoid_algebra.smul_comm_class_symm_self k (multiplicative G) R _ _ _ _ _
+@monoid_algebra.smul_comm_class_symm_self k (multiplicative G) R _ _ _ _
 
 variables {A : Type u₃} [non_unital_non_assoc_semiring A]
 

--- a/src/data/finsupp/basic.lean
+++ b/src/data/finsupp/basic.lean
@@ -1296,36 +1296,42 @@ end
 end
 
 section
-instance [monoid R] [add_monoid M] [distrib_mul_action R M] : has_smul R (α →₀ M) :=
-⟨λa v, v.map_range ((•) a) (smul_zero _)⟩
+
+instance [has_zero M] [smul_zero_class R M] : smul_zero_class R (α →₀ M) :=
+{ smul := λ a v, v.map_range ((•) a) (smul_zero _),
+  smul_zero := λ a, by { ext, apply smul_zero } }
 
 /-!
 Throughout this section, some `monoid` and `semiring` arguments are specified with `{}` instead of
 `[]`. See note [implicit instance arguments].
 -/
 
-@[simp] lemma coe_smul {_ : monoid R} [add_monoid M] [distrib_mul_action R M]
+@[simp] lemma coe_smul [add_monoid M] [distrib_smul R M]
   (b : R) (v : α →₀ M) : ⇑(b • v) = b • v := rfl
-lemma smul_apply {_ : monoid R} [add_monoid M] [distrib_mul_action R M]
+lemma smul_apply [add_monoid M] [distrib_smul R M]
   (b : R) (v : α →₀ M) (a : α) : (b • v) a = b • (v a) := rfl
 
-lemma _root_.is_smul_regular.finsupp {_ : monoid R} [add_monoid M] [distrib_mul_action R M] {k : R}
+lemma _root_.is_smul_regular.finsupp [add_monoid M] [distrib_smul R M] {k : R}
   (hk : is_smul_regular M k) : is_smul_regular (α →₀ M) k :=
 λ _ _ h, ext $ λ i, hk (congr_fun h i)
 
-instance [monoid R] [nonempty α] [add_monoid M] [distrib_mul_action R M] [has_faithful_smul R M] :
+instance [monoid R] [nonempty α] [add_monoid M] [distrib_smul R M] [has_faithful_smul R M] :
   has_faithful_smul R (α →₀ M) :=
 { eq_of_smul_eq_smul := λ r₁ r₂ h, let ⟨a⟩ := ‹nonempty α› in eq_of_smul_eq_smul $ λ m : M,
     by simpa using congr_fun (h (single a m)) a }
 
 variables (α M)
 
-instance [monoid R] [add_monoid M] [distrib_mul_action R M] : distrib_mul_action R (α →₀ M) :=
+instance [add_zero_class M] [distrib_smul R M] : distrib_smul R (α →₀ M) :=
 { smul      := (•),
   smul_add  := λ a x y, ext $ λ _, smul_add _ _ _,
+  smul_zero := λ x, ext $ λ _, smul_zero _ }
+
+instance [monoid R] [add_monoid M] [distrib_mul_action R M] : distrib_mul_action R (α →₀ M) :=
+{ smul      := (•),
   one_smul  := λ x, ext $ λ _, one_smul _ _,
   mul_smul  := λ r s x, ext $ λ _, mul_smul _ _ _,
-  smul_zero := λ x, ext $ λ _, smul_zero _ }
+  ..finsupp.distrib_smul _ _ }
 
 instance [monoid R] [monoid S] [add_monoid M] [distrib_mul_action R M] [distrib_mul_action S M]
   [has_smul R S] [is_scalar_tower R S M] :
@@ -1416,14 +1422,14 @@ lemma sum_smul_index [semiring R] [add_comm_monoid M] {g : α →₀ R} {b : R} 
   (h0 : ∀i, h i 0 = 0) : (b • g).sum h = g.sum (λi a, h i (b * a)) :=
 finsupp.sum_map_range_index h0
 
-lemma sum_smul_index' [monoid R] [add_monoid M] [distrib_mul_action R M] [add_comm_monoid N]
+lemma sum_smul_index' [add_monoid M] [distrib_smul R M] [add_comm_monoid N]
   {g : α →₀ M} {b : R} {h : α → M → N} (h0 : ∀i, h i 0 = 0) :
   (b • g).sum h = g.sum (λi c, h i (b • c)) :=
 finsupp.sum_map_range_index h0
 
 /-- A version of `finsupp.sum_smul_index'` for bundled additive maps. -/
 lemma sum_smul_index_add_monoid_hom
-  [monoid R] [add_monoid M] [add_comm_monoid N] [distrib_mul_action R M]
+  [add_monoid M] [add_comm_monoid N] [distrib_smul R M]
   {g : α →₀ M} {b : R} {h : α → M →+ N} :
   (b • g).sum (λ a, h a) = g.sum (λ i c, h i (b • c)) :=
 sum_map_range_index (λ i, (h i).map_zero)

--- a/src/data/finsupp/basic.lean
+++ b/src/data/finsupp/basic.lean
@@ -1315,7 +1315,7 @@ lemma _root_.is_smul_regular.finsupp [add_monoid M] [distrib_smul R M] {k : R}
   (hk : is_smul_regular M k) : is_smul_regular (α →₀ M) k :=
 λ _ _ h, ext $ λ i, hk (congr_fun h i)
 
-instance [monoid R] [nonempty α] [add_monoid M] [distrib_smul R M] [has_faithful_smul R M] :
+instance [nonempty α] [add_monoid M] [distrib_smul R M] [has_faithful_smul R M] :
   has_faithful_smul R (α →₀ M) :=
 { eq_of_smul_eq_smul := λ r₁ r₂ h, let ⟨a⟩ := ‹nonempty α› in eq_of_smul_eq_smul $ λ m : M,
     by simpa using congr_fun (h (single a m)) a }

--- a/src/data/polynomial/basic.lean
+++ b/src/data/polynomial/basic.lean
@@ -97,8 +97,9 @@ instance : has_add R[X] := ⟨add⟩
 instance {R : Type u} [ring R] : has_neg R[X] := ⟨neg⟩
 instance {R : Type u} [ring R] : has_sub R[X] := ⟨λ a b, a + -b⟩
 instance : has_mul R[X] := ⟨mul⟩
-instance {S : Type*} [monoid S] [distrib_mul_action S R] : has_smul S R[X] :=
-⟨λ r p, ⟨r • p.to_finsupp⟩⟩
+instance {S : Type*} [smul_zero_class S R] : smul_zero_class S R[X] :=
+{ smul := λ r p, ⟨r • p.to_finsupp⟩,
+  smul_zero := λ a, congr_arg of_finsupp (smul_zero a) }
 @[priority 1]  -- to avoid a bug in the `ring` tactic
 instance has_pow : has_pow R[X] ℕ := { pow := λ p n, npow_rec n p }
 
@@ -111,7 +112,7 @@ show _ = neg _, by rw neg
 @[simp] lemma of_finsupp_sub {R : Type u} [ring R] {a b} : (⟨a - b⟩ : R[X]) = ⟨a⟩ - ⟨b⟩ :=
 by { rw [sub_eq_add_neg, of_finsupp_add, of_finsupp_neg], refl }
 @[simp] lemma of_finsupp_mul (a b) : (⟨a * b⟩ : R[X]) = ⟨a⟩ * ⟨b⟩ := show _ = mul _ _, by rw mul
-@[simp] lemma of_finsupp_smul {S : Type*} [monoid S] [distrib_mul_action S R] (a : S) (b) :
+@[simp] lemma of_finsupp_smul {S : Type*} [smul_zero_class S R] (a : S) (b) :
   (⟨a • b⟩ : R[X]) = (a • ⟨b⟩ : R[X]) := rfl
 @[simp] lemma of_finsupp_pow (a) (n : ℕ) : (⟨a ^ n⟩ : R[X]) = ⟨a⟩ ^ n :=
 begin
@@ -136,7 +137,7 @@ by { cases a, rw ←of_finsupp_neg }
 by { rw [sub_eq_add_neg, ←to_finsupp_neg, ←to_finsupp_add], refl }
 @[simp] lemma to_finsupp_mul (a b : R[X]) : (a * b).to_finsupp = a.to_finsupp * b.to_finsupp :=
 by { cases a, cases b, rw ←of_finsupp_mul }
-@[simp] lemma to_finsupp_smul {S : Type*} [monoid S] [distrib_mul_action S R] (a : S) (b : R[X]) :
+@[simp] lemma to_finsupp_smul {S : Type*} [smul_zero_class S R] (a : S) (b : R[X]) :
   (a • b).to_finsupp = a • b.to_finsupp := rfl
 @[simp] lemma to_finsupp_pow (a : R[X]) (n : ℕ) : (a ^ n).to_finsupp = a.to_finsupp ^ n :=
 by { cases a, rw ←of_finsupp_pow }
@@ -195,6 +196,11 @@ instance {S₁ S₂} [monoid S₁] [monoid S₂] [distrib_mul_action S₁ R] [di
 instance {S₁ S₂} [has_smul S₁ S₂] [monoid S₁] [monoid S₂] [distrib_mul_action S₁ R]
   [distrib_mul_action S₂ R] [is_scalar_tower S₁ S₂ R] : is_scalar_tower S₁ S₂ R[X] :=
 ⟨by { rintros _ _ ⟨⟩, simp_rw [←of_finsupp_smul, smul_assoc] }⟩
+
+instance is_scalar_tower_right {α K : Type*} [semiring K] [distrib_smul α K]
+  [is_scalar_tower α K K] : is_scalar_tower α K[X] K[X] :=
+⟨by rintros _ ⟨⟩ ⟨⟩;
+  simp_rw [smul_eq_mul, ← of_finsupp_smul, ← of_finsupp_mul, ← of_finsupp_smul, smul_mul_assoc]⟩
 
 instance {S} [monoid S] [distrib_mul_action S R] [distrib_mul_action Sᵐᵒᵖ R]
   [is_central_scalar S R] : is_central_scalar S R[X] :=

--- a/src/data/rat/cast.lean
+++ b/src/data/rat/cast.lean
@@ -350,3 +350,22 @@ by rw [cast_def, div_eq_mul_inv, unop_mul, unop_inv, unop_nat_cast, unop_int_cas
     (commute.cast_int_right _ r.num).eq, cast_def, div_eq_mul_inv]
 
 end mul_opposite
+
+section smul
+
+namespace rat
+
+variables {K : Type*} [division_ring K]
+
+@[priority 100]
+instance distrib_smul  : distrib_smul ℚ K :=
+{ smul := (•),
+  smul_zero := λ a, by rw [smul_def, mul_zero],
+  smul_add := λ a x y, by simp only [smul_def, mul_add, cast_add] }
+
+instance is_scalar_tower_right : is_scalar_tower ℚ K K :=
+⟨λ a x y, by simp only [smul_def, smul_eq_mul, mul_assoc]⟩
+
+end rat
+
+end smul

--- a/src/field_theory/ratfunc.lean
+++ b/src/field_theory/ratfunc.lean
@@ -140,7 +140,9 @@ of `∀ {p q a : K[X]} (hq : q ≠ 0) (ha : a ≠ 0), f (a * p) (a * q) = f p q)
   (H : ∀ {p q p' q'} (hq : q ∈ K[X]⁰) (hq' : q' ∈ K[X]⁰), p * q' = p' * q →
     f p q = f p' q') :
   P :=
-localization.lift_on (to_fraction_ring x) (λ p q, f p q) (λ p p' q q' h, H q.2 q'.2
+localization.lift_on
+  (by exact to_fraction_ring x) -- Fix timeout by manipulating elaboration order
+  (λ p q, f p q) (λ p p' q q' h, H q.2 q'.2
   (let ⟨⟨c, hc⟩, mul_eq⟩ := (localization.r_iff_exists).mp h in
     mul_cancel_right_coe_non_zero_divisor.mp mul_eq))
 
@@ -148,7 +150,7 @@ lemma lift_on_of_fraction_ring_mk {P : Sort v} (n : K[X]) (d : K[X]⁰)
   (f : ∀ (p q : K[X]), P)
   (H : ∀ {p q p' q'} (hq : q ∈ K[X]⁰) (hq' : q' ∈ K[X]⁰), p * q' = p' * q →
     f p q = f p' q') :
-  ratfunc.lift_on (of_fraction_ring (localization.mk n d)) f @H = f n d :=
+  ratfunc.lift_on (by exact of_fraction_ring (localization.mk n d)) f @H = f n d :=
 begin
   unfold ratfunc.lift_on,
   exact localization.lift_on_mk _ _ _ _

--- a/src/group_theory/group_action/big_operators.lean
+++ b/src/group_theory/group_action/big_operators.lean
@@ -19,11 +19,11 @@ variables {α β γ : Type*}
 open_locale big_operators
 
 section
-variables [monoid α] [add_monoid β] [distrib_mul_action α β]
+variables [add_monoid β] [distrib_smul α β]
 
 lemma list.smul_sum {r : α} {l : list β} :
   r • l.sum = (l.map ((•) r)).sum :=
-(distrib_mul_action.to_add_monoid_hom β r).map_list_sum l
+(distrib_smul.to_add_monoid_hom β r).map_list_sum l
 
 end
 
@@ -37,15 +37,15 @@ lemma list.smul_prod {r : α} {l : list β} :
 end
 
 section
-variables [monoid α] [add_comm_monoid β] [distrib_mul_action α β]
+variables [add_comm_monoid β] [distrib_smul α β]
 
 lemma multiset.smul_sum {r : α} {s : multiset β} :
   r • s.sum = (s.map ((•) r)).sum :=
-(distrib_mul_action.to_add_monoid_hom β r).map_multiset_sum s
+(distrib_smul.to_add_monoid_hom β r).map_multiset_sum s
 
 lemma finset.smul_sum {r : α} {f : γ → β} {s : finset γ} :
   r • ∑ x in s, f x = ∑ x in s, r • f x :=
-(distrib_mul_action.to_add_monoid_hom β r).map_sum f s
+(distrib_smul.to_add_monoid_hom β r).map_sum f s
 
 end
 

--- a/src/group_theory/group_action/defs.lean
+++ b/src/group_theory/group_action/defs.lean
@@ -494,8 +494,58 @@ end compatible_scalar
 class smul_zero_class (M A : Type*) [has_zero A] extends has_smul M A :=
 (smul_zero : ∀ (a : M), a • (0 : A) = 0)
 
-@[simp] theorem smul_zero [has_zero A] [smul_zero_class M A] (a : M) : a • (0 : A) = 0 :=
+section smul_zero
+
+variables [has_zero A] [smul_zero_class M A]
+
+@[simp] theorem smul_zero (a : M) : a • (0 : A) = 0 :=
 smul_zero_class.smul_zero _
+
+/-- Pullback a zero-preserving scalar multiplication along an injective zero-preserving map.
+See note [reducible non-instances]. -/
+@[reducible]
+protected def function.injective.smul_zero_class [has_zero B] [has_smul M B] (f : zero_hom B A)
+  (hf : injective f) (smul : ∀ (c : M) x, f (c • x) = c • f x) :
+  smul_zero_class M B :=
+{ smul := (•),
+  smul_zero := λ c, hf $ by simp only [smul, map_zero, smul_zero] }
+
+/-- Pushforward a zero-preserving scalar multiplication along a zero-preserving map.
+See note [reducible non-instances]. -/
+@[reducible]
+protected def zero_hom.smul_zero_class [has_zero B] [has_smul M B] (f : zero_hom A B)
+  (smul : ∀ (c : M) x, f (c • x) = c • f x) :
+  smul_zero_class M B :=
+{ smul := (•),
+  smul_zero := λ c, by simp only [← map_zero f, ← smul, smul_zero] }
+
+/-- Push forward the multiplication of `R` on `M` along a compatible surjective map `f : R → S`.
+
+See also `function.surjective.distrib_mul_action_left`.
+-/
+@[reducible]
+def function.surjective.smul_zero_class_left {R S M : Type*} [has_zero M] [smul_zero_class R M]
+  [has_smul S M] (f : R → S) (hf : function.surjective f) (hsmul : ∀ c (x : M), f c • x = c • x) :
+  smul_zero_class S M :=
+{ smul := (•),
+  smul_zero := hf.forall.mpr $ λ c, by rw [hsmul, smul_zero] }
+
+variable (A)
+
+/-- Compose a `smul_zero_class` with a function, with scalar multiplication `f r' • m`.
+See note [reducible non-instances]. -/
+@[reducible] def smul_zero_class.comp_fun (f : N → M) :
+  smul_zero_class N A :=
+{ smul := has_smul.comp.smul f,
+  smul_zero := λ x, smul_zero (f x) }
+
+/-- Each element of the scalars defines a zero-preserving map. -/
+@[simps]
+def smul_zero_class.to_zero_hom (x : M) : zero_hom A A :=
+{ to_fun := (•) x,
+  map_zero' := smul_zero x }
+
+end smul_zero
 
 /-- Typeclass for scalar multiplication that preserves `0` and `+` on the right.
 
@@ -505,9 +555,67 @@ This is exactly `distrib_mul_action` without the `mul_action` part.
   extends smul_zero_class M A :=
 (smul_add : ∀ (a : M) (x y : A), a • (x + y) = a • x + a • y)
 
-theorem smul_add [add_zero_class A] [distrib_smul M A] (a : M) (b₁ b₂ : A) :
+section distrib_smul
+
+variables [add_zero_class A] [distrib_smul M A]
+
+theorem smul_add (a : M) (b₁ b₂ : A) :
   a • (b₁ + b₂) = a • b₁ + a • b₂ :=
 distrib_smul.smul_add _ _ _
+
+/-- Pullback a distributive scalar multiplication along an injective additive monoid
+homomorphism.
+See note [reducible non-instances]. -/
+@[reducible]
+protected def function.injective.distrib_smul [add_zero_class B] [has_smul M B] (f : B →+ A)
+  (hf : injective f) (smul : ∀ (c : M) x, f (c • x) = c • f x) :
+  distrib_smul M B :=
+{ smul := (•),
+  smul_add := λ c x y, hf $ by simp only [smul, map_add, smul_add],
+  .. hf.smul_zero_class f.to_zero_hom smul }
+
+/-- Pushforward a distributive scalar multiplication along a surjective additive monoid
+homomorphism.
+See note [reducible non-instances]. -/
+@[reducible]
+protected def function.surjective.distrib_smul [add_zero_class B] [has_smul M B] (f : A →+ B)
+  (hf : surjective f) (smul : ∀ (c : M) x, f (c • x) = c • f x) :
+  distrib_smul M B :=
+{ smul := (•),
+  smul_add := λ c x y, by { rcases hf x with ⟨x, rfl⟩, rcases hf y with ⟨y, rfl⟩,
+    simp only [smul_add, ← smul, ← map_add] },
+  .. f.to_zero_hom.smul_zero_class smul }
+
+/-- Push forward the multiplication of `R` on `M` along a compatible surjective map `f : R → S`.
+
+See also `function.surjective.distrib_mul_action_left`.
+-/
+@[reducible]
+def function.surjective.distrib_smul_left {R S M : Type*} [add_zero_class M] [distrib_smul R M]
+  [has_smul S M] (f : R → S) (hf : function.surjective f) (hsmul : ∀ c (x : M), f c • x = c • x) :
+  distrib_smul S M :=
+{ smul := (•),
+  smul_add := hf.forall.mpr $ λ c x y, by simp only [hsmul, smul_add],
+  .. hf.smul_zero_class_left f hsmul }
+
+variable (A)
+
+/-- Compose a `distrib_smul` with a function, with scalar multiplication `f r' • m`.
+See note [reducible non-instances]. -/
+@[reducible] def distrib_smul.comp_fun (f : N → M) :
+  distrib_smul N A :=
+{ smul := has_smul.comp.smul f,
+  smul_add := λ x, smul_add (f x),
+  .. smul_zero_class.comp_fun A f }
+
+/-- Each element of the scalars defines a additive monoid homomorphism. -/
+@[simps]
+def distrib_smul.to_add_monoid_hom (x : M) : A →+ A :=
+{ to_fun := (•) x,
+  map_add' := smul_add x,
+  .. smul_zero_class.to_zero_hom A x }
+
+end distrib_smul
 
 /-- Typeclass for multiplicative actions on additive structures. This generalizes group modules. -/
 @[ext] class distrib_mul_action (M A : Type*) [monoid M] [add_monoid A]
@@ -537,8 +645,7 @@ protected def function.injective.distrib_mul_action [add_monoid B] [has_smul M B
   (hf : injective f) (smul : ∀ (c : M) x, f (c • x) = c • f x) :
   distrib_mul_action M B :=
 { smul := (•),
-  smul_add := λ c x y, hf $ by simp only [smul, f.map_add, smul_add],
-  smul_zero := λ c, hf $ by simp only [smul, f.map_zero, smul_zero],
+  .. hf.distrib_smul f smul,
   .. hf.mul_action f smul }
 
 /-- Pushforward a distributive multiplicative action along a surjective additive monoid
@@ -549,9 +656,7 @@ protected def function.surjective.distrib_mul_action [add_monoid B] [has_smul M 
   (hf : surjective f) (smul : ∀ (c : M) x, f (c • x) = c • f x) :
   distrib_mul_action M B :=
 { smul := (•),
-  smul_add := λ c x y, by { rcases hf x with ⟨x, rfl⟩, rcases hf y with ⟨y, rfl⟩,
-    simp only [smul_add, ← smul, ← f.map_add] },
-  smul_zero := λ c, by simp only [← f.map_zero, ← smul, smul_zero],
+  .. hf.distrib_smul f smul,
   .. hf.mul_action f smul }
 
 /-- Push forward the action of `R` on `M` along a compatible surjective map `f : R →* S`.
@@ -564,8 +669,7 @@ def function.surjective.distrib_mul_action_left {R S M : Type*} [monoid R] [add_
   (f : R →* S) (hf : function.surjective f) (hsmul : ∀ c (x : M), f c • x = c • x) :
   distrib_mul_action S M :=
 { smul := (•),
-  smul_zero := hf.forall.mpr $ λ c, by rw [hsmul, smul_zero],
-  smul_add := hf.forall.mpr $ λ c x y, by simp only [hsmul, smul_add],
+  .. hf.distrib_smul_left f hsmul,
   .. hf.mul_action_left f hsmul }
 
 variable (A)
@@ -575,16 +679,13 @@ See note [reducible non-instances]. -/
 @[reducible] def distrib_mul_action.comp_hom [monoid N] (f : N →* M) :
   distrib_mul_action N A :=
 { smul := has_smul.comp.smul f,
-  smul_zero := λ x, smul_zero (f x),
-  smul_add := λ x, smul_add (f x),
+  .. distrib_smul.comp_fun A f,
   .. mul_action.comp_hom A f }
 
 /-- Each element of the monoid defines a additive monoid homomorphism. -/
 @[simps]
 def distrib_mul_action.to_add_monoid_hom (x : M) : A →+ A :=
-{ to_fun := (•) x,
-  map_zero' := smul_zero x,
-  map_add' := smul_add x }
+distrib_smul.to_add_monoid_hom A x
 
 variables (M)
 

--- a/src/linear_algebra/basic.lean
+++ b/src/linear_algebra/basic.lean
@@ -69,7 +69,7 @@ variables {V : Type*} {V₂ : Type*}
 namespace finsupp
 
 lemma smul_sum {α : Type*} {β : Type*} {R : Type*} {M : Type*}
-  [has_zero β] [monoid R] [add_comm_monoid M] [distrib_mul_action R M]
+  [has_zero β] [add_comm_monoid M] [distrib_smul R M]
   {v : α →₀ β} {c : R} {h : α → β → M} :
   c • (v.sum h) = v.sum (λa b, c • h a b) :=
 finset.smul_sum

--- a/src/linear_algebra/quotient.lean
+++ b/src/linear_algebra/quotient.lean
@@ -109,7 +109,7 @@ function.surjective.mul_action mk (surjective_quot_mk _) P^.quotient.mk_smul
 instance mul_action (P : submodule R M) : mul_action R (M ⧸ P) :=
 quotient.mul_action' P
 
-instance smul_zero_class' [monoid S] [has_smul S R] [smul_zero_class S M]
+instance smul_zero_class' [has_smul S R] [smul_zero_class S M]
   [is_scalar_tower S R M]
   (P : submodule R M) : smul_zero_class S (M ⧸ P) :=
 zero_hom.smul_zero_class ⟨mk, mk_zero _⟩ P^.quotient.mk_smul

--- a/src/linear_algebra/quotient.lean
+++ b/src/linear_algebra/quotient.lean
@@ -109,6 +109,23 @@ function.surjective.mul_action mk (surjective_quot_mk _) P^.quotient.mk_smul
 instance mul_action (P : submodule R M) : mul_action R (M ⧸ P) :=
 quotient.mul_action' P
 
+instance smul_zero_class' [monoid S] [has_smul S R] [smul_zero_class S M]
+  [is_scalar_tower S R M]
+  (P : submodule R M) : smul_zero_class S (M ⧸ P) :=
+zero_hom.smul_zero_class ⟨mk, mk_zero _⟩ P^.quotient.mk_smul
+
+instance smul_zero_class (P : submodule R M) : smul_zero_class R (M ⧸ P) :=
+quotient.smul_zero_class' P
+
+instance distrib_smul' [has_smul S R] [distrib_smul S M]
+  [is_scalar_tower S R M]
+  (P : submodule R M) : distrib_smul S (M ⧸ P) :=
+function.surjective.distrib_smul
+  ⟨mk, rfl, λ _ _, rfl⟩ (surjective_quot_mk _) P^.quotient.mk_smul
+
+instance distrib_smul (P : submodule R M) : distrib_smul R (M ⧸ P) :=
+quotient.distrib_smul' P
+
 instance distrib_mul_action' [monoid S] [has_smul S R] [distrib_mul_action S M]
   [is_scalar_tower S R M]
   (P : submodule R M) : distrib_mul_action S (M ⧸ P) :=

--- a/src/representation_theory/maschke.lean
+++ b/src/representation_theory/maschke.lean
@@ -104,8 +104,10 @@ In fact, the sum over `g : G` of the conjugate of `π` by `g` is a `k[G]`-linear
 def sum_of_conjugates_equivariant : W →ₗ[monoid_algebra k G] V :=
 monoid_algebra.equivariant_of_linear_of_comm (π.sum_of_conjugates G) (λ g v,
 begin
-  dsimp [sum_of_conjugates],
-  simp only [linear_map.sum_apply, finset.smul_sum],
+  simp only [sum_of_conjugates, linear_map.sum_apply,
+    -- We have a `module (monoid_algebra k G)` instance but are working with `finsupp`s,
+    -- so help the elaborator unfold everything correctly.
+    @finset.smul_sum (monoid_algebra k G)],
   dsimp [conjugate],
   conv_lhs
   { rw [←finset.univ_map_embedding (mul_right_embedding g⁻¹)],

--- a/test/instance_diamonds.lean
+++ b/test/instance_diamonds.lean
@@ -150,9 +150,9 @@ end multiplicative
 section finsupp
 open finsupp
 
-/-- `finsupp.comap_has_smul` can form a non-equal diamond with `finsupp.has_smul` -/
+/-- `finsupp.comap_has_smul` can form a non-equal diamond with `finsupp.smul_zero_class` -/
 example {k : Type*} [semiring k] [nontrivial k] :
-  (finsupp.comap_has_smul : has_smul k (k →₀ k)) ≠ finsupp.has_smul :=
+  (finsupp.comap_has_smul : has_smul k (k →₀ k)) ≠ finsupp.smul_zero_class.to_has_smul :=
 begin
   obtain ⟨u : k, hu⟩ := exists_ne (1 : k),
   intro h,
@@ -164,10 +164,10 @@ begin
   exact one_ne_zero h,
 end
 
-/-- `finsupp.comap_has_smul` can form a non-equal diamond with `finsupp.has_smul` even when
+/-- `finsupp.comap_has_smul` can form a non-equal diamond with `finsupp.smul_zero_class` even when
 the domain is a group. -/
 example {k : Type*} [semiring k] [nontrivial kˣ] :
-  (finsupp.comap_has_smul : has_smul kˣ (kˣ →₀ k)) ≠ finsupp.has_smul :=
+  (finsupp.comap_has_smul : has_smul kˣ (kˣ →₀ k)) ≠ finsupp.smul_zero_class.to_has_smul :=
 begin
   obtain ⟨u : kˣ, hu⟩ := exists_ne (1 : kˣ),
   haveI : nontrivial k := ⟨⟨u, 1, units.ext.ne hu⟩⟩,


### PR DESCRIPTION
This PR builds on #16123 by adding `distrib_smul` (and `smul_zero_class`) instances for:
 * `finsupp`
 * `add_monoid_algebra`
 * `polynomial`
 * submodule quotients
 * scalar multiplication by `ℚ`

It also generalizes some results by weakening `distrib_mul_action` to `distrib_smul`. The choice of instances and generalizations is based on which are necessary to solve instance diamonds in `splitting_field`, so I probably missed a lot of additional changes. Since I'm not so interested in generalizing everything at the moment, I'd rather leave missing instances to follow-up PRs.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

 - [x] depends on: #16123

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
