### PR TITLE
feat(algebra/euclidean_domain): use `is_well_founded` in definition of `euclidean_domain`

### DIFF
--- a/src/ring_theory/principal_ideal_domain.lean
+++ b/src/ring_theory/principal_ideal_domain.lean
@@ -158,7 +158,7 @@ instance euclidean_domain.to_principal_ideal_domain : is_principal_ideal_ring R 
 { principal := λ S, by exactI
     ⟨if h : {x : R | x ∈ S ∧ x ≠ 0}.nonempty
     then
-    have wf : well_founded (euclidean_domain.r : R → R → Prop) := euclidean_domain.r_well_founded,
+    let wf := @is_well_founded.wf R euclidean_domain.r _ in
     have hmin : well_founded.min wf {x : R | x ∈ S ∧ x ≠ 0} h ∈ S ∧
         well_founded.min wf {x : R | x ∈ S ∧ x ≠ 0} h ≠ 0,
       from well_founded.min_mem wf {x : R | x ∈ S ∧ x ≠ 0} h,


### PR DESCRIPTION
We rename the `r_well_founded` field to `r_is_well_founded` and change its type to `is_well_founded R r`. This allows us to sometimes use typeclass inference to deduce the argument, such as in `int.euclidean_domain`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
