### PR TITLE
[Merged by Bors] - feat(algebra/order/complete_field): generalize ring_hom_monotone

### DIFF
--- a/src/algebra/order/complete_field.lean
+++ b/src/algebra/order/complete_field.lean
@@ -313,7 +313,7 @@ end linear_ordered_field
 
 section real
 
-variables {R S : Type*} [linear_ordered_field R] [linear_ordered_field S]
+variables {R S : Type*} [ordered_ring R] [ordered_ring S]
 
 lemma ring_hom_monotone (hR : ∀ r : R, 0 ≤ r → ∃ s : R, s^2 = r) (f : R →+* S) : monotone f :=
 begin

--- a/src/algebra/order/complete_field.lean
+++ b/src/algebra/order/complete_field.lean
@@ -313,7 +313,7 @@ end linear_ordered_field
 
 section real
 
-variables {R S : Type*} [ordered_ring R] [ordered_ring S]
+variables {R S : Type*} [ordered_ring R] [linear_ordered_ring S]
 
 lemma ring_hom_monotone (hR : ∀ r : R, 0 ≤ r → ∃ s : R, s^2 = r) (f : R →+* S) : monotone f :=
 begin


### PR DESCRIPTION
@alreadydone noticed that in the proof of ```ring_hom_monotone``` can be generalized to rings. 

Co-authored-by: Junyan Xu <junyanxumath@gmail.com>

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
