### PR TITLE
[Merged by Bors] - refactor(algebra/lie): replace local instance with type synonym

### DIFF
--- a/src/algebra/lie/free.lean
+++ b/src/algebra/lie/free.lean
@@ -165,10 +165,8 @@ def of : X → free_lie_algebra R X := λ x, quot.mk _ (lib.of R x)
 
 variables {L : Type w} [lie_ring L] [lie_algebra R L]
 
-local attribute [instance] lie_ring.to_non_unital_non_assoc_semiring
-
 /-- An auxiliary definition used to construct the equivalence `lift` below. -/
-def lift_aux (f : X → L) := lib.lift R f
+def lift_aux (f : X → commutator_ring L) := lib.lift R f
 
 lemma lift_aux_map_smul (f : X → L) (t : R) (a : lib R X) :
   lift_aux R f (t • a) = t • lift_aux R f a :=
@@ -201,7 +199,7 @@ begin
 end
 
 /-- The quotient map as a `non_unital_alg_hom`. -/
-def mk : lib R X →ₙₐ[R] free_lie_algebra R X :=
+def mk : lib R X →ₙₐ[R] commutator_ring (free_lie_algebra R X) :=
 { to_fun    := quot.mk (rel R X),
   map_smul' := λ t a, rfl,
   map_zero' := rfl,

--- a/src/algebra/lie/non_unital_non_assoc_algebra.lean
+++ b/src/algebra/lie/non_unital_non_assoc_algebra.lean
@@ -55,10 +55,10 @@ show non_unital_non_assoc_semiring L, from
 
 namespace lie_algebra
 
-instance [nonempty L] : nonempty (commutator_ring L) :=
+instance (L : Type v) [nonempty L] : nonempty (commutator_ring L) :=
 ‹nonempty L›
 
-instance [inhabited L] : inhabited (commutator_ring L) :=
+instance (L : Type v) [inhabited L] : inhabited (commutator_ring L) :=
 ‹inhabited L›
 
 instance : lie_ring (commutator_ring L) :=

--- a/src/algebra/lie/non_unital_non_assoc_algebra.lean
+++ b/src/algebra/lie/non_unital_non_assoc_algebra.lean
@@ -27,12 +27,6 @@ algebra and we provide some basic definitions for doing so here.
     `has_bracket` (denoted `⁅, ⁆`) into a `has_mul` (denoted `*`).
   * `lie_hom.to_non_unital_alg_hom`
 
-## Implementation notes
-
-Previously the structure was added by a non-instance `lie_ring.to_non_unital_non_assoc_semiring`,
-which could be made an instance locally. This caused instance diamonds since all rings are
-also Lie rings, so we'd get two incompatible multiplications on each ring.
-
 ## Tags
 
 lie algebra, non-unital, non-associative

--- a/src/algebra/lie/non_unital_non_assoc_algebra.lean
+++ b/src/algebra/lie/non_unital_non_assoc_algebra.lean
@@ -23,8 +23,15 @@ algebra and we provide some basic definitions for doing so here.
 
 ## Main definitions
 
-  * `lie_ring.to_non_unital_non_assoc_semiring`
+  * `commutator_ring` turns a Lie ring into a `non_unital_non_assoc_semiring` by turning its
+    `has_bracket` (denoted `⁅, ⁆`) into a `has_mul` (denoted `*`).
   * `lie_hom.to_non_unital_alg_hom`
+
+## Implementation notes
+
+Previously the structure was added by a non-instance `lie_ring.to_non_unital_non_assoc_semiring`,
+which could be made an instance locally. This caused instance diamonds since all rings are
+also Lie rings, so we'd get two incompatible multiplications on each ring.
 
 ## Tags
 
@@ -35,9 +42,16 @@ universes u v w
 
 variables (R : Type u) (L : Type v) [comm_ring R] [lie_ring L] [lie_algebra R L]
 
+/-- Type synonym for turning a `lie_ring` into a `non_unital_non_assoc_semiring`.
+
+A `lie_ring` can be regarded as a `non_unital_non_assoc_semiring` by turning its
+`has_bracket` (denoted `⁅, ⁆`) into a `has_mul` (denoted `*`). -/
+def commutator_ring (L : Type v) : Type v := L
+
 /-- A `lie_ring` can be regarded as a `non_unital_non_assoc_semiring` by turning its
 `has_bracket` (denoted `⁅, ⁆`) into a `has_mul` (denoted `*`). -/
-def lie_ring.to_non_unital_non_assoc_semiring : non_unital_non_assoc_semiring L :=
+instance : non_unital_non_assoc_semiring (commutator_ring L) :=
+show non_unital_non_assoc_semiring L, from
 { mul           := has_bracket.bracket,
   left_distrib  := lie_add,
   right_distrib := add_lie,
@@ -45,17 +59,28 @@ def lie_ring.to_non_unital_non_assoc_semiring : non_unital_non_assoc_semiring L 
   mul_zero      := lie_zero,
   .. (infer_instance : add_comm_monoid L) }
 
-local attribute [instance] lie_ring.to_non_unital_non_assoc_semiring
-
 namespace lie_algebra
+
+instance [nonempty L] : nonempty (commutator_ring L) :=
+‹nonempty L›
+
+instance [inhabited L] : inhabited (commutator_ring L) :=
+‹inhabited L›
+
+instance : lie_ring (commutator_ring L) :=
+show lie_ring L, by apply_instance
+
+instance : lie_algebra R (commutator_ring L) :=
+show lie_algebra R L, by apply_instance
 
 /-- Regarding the `lie_ring` of a `lie_algebra` as a `non_unital_non_assoc_semiring`, we can
 reinterpret the `smul_lie` law as an `is_scalar_tower`. -/
-instance is_scalar_tower : is_scalar_tower R L L := ⟨smul_lie⟩
+instance is_scalar_tower : is_scalar_tower R (commutator_ring L) (commutator_ring L) := ⟨smul_lie⟩
 
 /-- Regarding the `lie_ring` of a `lie_algebra` as a `non_unital_non_assoc_semiring`, we can
 reinterpret the `lie_smul` law as an `smul_comm_class`. -/
-instance smul_comm_class : smul_comm_class R L L := ⟨λ t x y, (lie_smul t x y).symm⟩
+instance smul_comm_class : smul_comm_class R (commutator_ring L) (commutator_ring L) :=
+⟨λ t x y, (lie_smul t x y).symm⟩
 
 end lie_algebra
 
@@ -66,14 +91,14 @@ variables {R L} {L₂ : Type w} [lie_ring L₂] [lie_algebra R L₂]
 /-- Regarding the `lie_ring` of a `lie_algebra` as a `non_unital_non_assoc_semiring`, we can
 regard a `lie_hom` as a `non_unital_alg_hom`. -/
 @[simps]
-def to_non_unital_alg_hom (f : L →ₗ⁅R⁆ L₂) : L →ₙₐ[R] L₂ :=
+def to_non_unital_alg_hom (f : L →ₗ⁅R⁆ L₂) : commutator_ring L →ₙₐ[R] commutator_ring L₂ :=
 { to_fun := f,
   map_zero' := f.map_zero,
   map_mul'  := f.map_lie,
   ..f }
 
 lemma to_non_unital_alg_hom_injective :
-  function.injective (to_non_unital_alg_hom : _ → (L →ₙₐ[R] L₂)) :=
+  function.injective (to_non_unital_alg_hom : _ → (commutator_ring L →ₙₐ[R] commutator_ring L₂)) :=
 λ f g h, ext $ non_unital_alg_hom.congr_fun h
 
 end lie_hom


### PR DESCRIPTION
A Lie ring can be viewed as a `non_unital_non_assoc_semiring` by using its bracket operator as the multiplication. Defining this as an instance causes diamonds because all rings are also Lie rings, so there are two incompatible multiplications on the same type.

Instead of the previous approach, of making this a `def` and only locally enabling the instance being careful not to cause diamonds, we use a type synonym that is guaranteed to have only one multiplication operator.

Someone who knows more about Lie theory should definitely check that the changes make mathematical sense.

Zulip thread: https://leanprover.zulipchat.com/#narrow/stream/116395-maths/topic/.60lie_ring.2Eto_non_unital_non_assoc_semiring.60



---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
