### PR TITLE
[Merged by Bors] - fix(control/random): typo

### DIFF
--- a/src/control/random.lean
+++ b/src/control/random.lean
@@ -130,7 +130,7 @@ namespace io
 private def accum_char (w : ℕ) (c : char) : ℕ :=
 c.to_nat + 256 * w
 
-/-- create and a seed a random number generator -/
+/-- create and seed a random number generator -/
 def mk_generator : io std_gen := do
 seed ← io.rand 0 shift_31_left,
 return $ mk_std_gen seed


### PR DESCRIPTION
Fix a small typo in the `random.lean` doc comment of `mk_generator` definition.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
