### PR TITLE
refactor(*): make `equiv_like` extend `fun_like`

### DIFF
--- a/src/algebra/algebra/basic.lean
+++ b/src/algebra/algebra/basic.lean
@@ -851,7 +851,7 @@ variables (e : A₁ ≃ₐ[R] A₂)
 instance : alg_equiv_class (A₁ ≃ₐ[R] A₂) R A₁ A₂ :=
 { coe := to_fun,
   inv := inv_fun,
-  coe_injective' := λ f g h₁ h₂, by { cases f, cases g, congr' },
+  coe_inv_injective' := λ f g h₁ h₂, by { cases f, cases g, congr' },
   map_add := map_add',
   map_mul := map_mul',
   commutes := commutes',

--- a/src/algebra/hom/equiv.lean
+++ b/src/algebra/hom/equiv.lean
@@ -100,10 +100,9 @@ instance [has_mul M] [has_mul N] [h : mul_equiv_class F M N] : mul_hom_class F M
   to_additive]
 instance [mul_one_class M] [mul_one_class N] [mul_equiv_class F M N] :
   monoid_hom_class F M N :=
-{ coe := (coe : F → M → N),
-  map_one := λ e,
+{ map_one := λ e,
   calc e 1 = e 1 * 1 : (mul_one _).symm
-       ... = e 1 * e (inv e (1 : N) : M) : congr_arg _ (right_inv e 1).symm
+       ... = e 1 * e (inv e (1 : N) : M) : congr_arg _ $ eq.symm (right_inv e 1)
        ... = e (inv e (1 : N)) : by rw [← map_mul, one_mul]
        ... = 1 : right_inv e 1,
   .. mul_equiv_class.mul_hom_class F }
@@ -142,7 +141,7 @@ instance [has_mul M] [has_mul N] : has_coe_to_fun (M ≃* N) (λ _, M → N) := 
 @[to_additive]
 instance [has_mul M] [has_mul N] : mul_equiv_class (M ≃* N) M N :=
 { coe := to_fun, inv := inv_fun, left_inv := left_inv, right_inv := right_inv,
-  coe_injective' := λ f g h₁ h₂, by { cases f, cases g, congr' },
+  coe_inv_injective' := λ f g h₁ h₂, by { cases f, cases g, congr' },
   map_mul := map_mul' }
 
 variables [has_mul M] [has_mul N] [has_mul P] [has_mul Q]

--- a/src/algebra/hom/equiv.lean
+++ b/src/algebra/hom/equiv.lean
@@ -102,7 +102,7 @@ instance [mul_one_class M] [mul_one_class N] [mul_equiv_class F M N] :
   monoid_hom_class F M N :=
 { map_one := λ e,
   calc e 1 = e 1 * 1 : (mul_one _).symm
-       ... = e 1 * e (inv e (1 : N) : M) : congr_arg _ $ eq.symm (right_inv e 1)
+       ... = e 1 * e (inv e (1 : N) : M) : congr_arg _ (right_inv e 1).symm
        ... = e (inv e (1 : N)) : by rw [← map_mul, one_mul]
        ... = 1 : right_inv e 1,
   .. mul_equiv_class.mul_hom_class F }

--- a/src/algebra/hom/equiv.lean
+++ b/src/algebra/hom/equiv.lean
@@ -94,9 +94,7 @@ variables (F)
 @[priority 100, -- See note [lower instance priority]
   to_additive]
 instance [has_mul M] [has_mul N] [h : mul_equiv_class F M N] : mul_hom_class F M N :=
-{ coe := (coe : F → M → N),
-  coe_injective' := @fun_like.coe_injective F _ _ _,
-  .. h }
+{ .. h }
 
 @[priority 100, -- See note [lower instance priority]
   to_additive]

--- a/src/algebra/hom/equiv.lean
+++ b/src/algebra/hom/equiv.lean
@@ -94,13 +94,15 @@ variables (F)
 @[priority 100, -- See note [lower instance priority]
   to_additive]
 instance [has_mul M] [has_mul N] [h : mul_equiv_class F M N] : mul_hom_class F M N :=
-{ .. h }
+{ coe := (coe : F → M → N),
+  .. h }
 
 @[priority 100, -- See note [lower instance priority]
   to_additive]
 instance [mul_one_class M] [mul_one_class N] [mul_equiv_class F M N] :
   monoid_hom_class F M N :=
-{ map_one := λ e,
+{ coe := (coe : F → M → N),
+  map_one := λ e,
   calc e 1 = e 1 * 1 : (mul_one _).symm
        ... = e 1 * e (inv e (1 : N) : M) : congr_arg _ (right_inv e 1).symm
        ... = e (inv e (1 : N)) : by rw [← map_mul, one_mul]

--- a/src/algebra/module/equiv.lean
+++ b/src/algebra/module/equiv.lean
@@ -96,9 +96,7 @@ variables [module R M] [module S M₂] {σ : R →+* S} {σ' : S →+* R}
 @[priority 100, nolint dangerous_instance]
 instance [ring_hom_inv_pair σ σ'] [ring_hom_inv_pair σ' σ] [s : semilinear_equiv_class F σ M M₂] :
   semilinear_map_class F σ M M₂ :=
-{ coe := (coe : F → M → M₂),
-  coe_injective' := @fun_like.coe_injective F _ _ _,
-  ..s }
+{ ..s }
 
 end semilinear_equiv_class
 
@@ -146,7 +144,7 @@ to_linear_map_injective.eq_iff
 instance : semilinear_equiv_class (M ≃ₛₗ[σ] M₂) σ M M₂ :=
 { coe := linear_equiv.to_fun,
   inv := linear_equiv.inv_fun,
-  coe_injective' := λ f g h₁ h₂, by { cases f, cases g, congr' },
+  coe_inv_injective' := λ f g h₁ h₂, by { cases f, cases g, congr' },
   left_inv := linear_equiv.left_inv,
   right_inv := linear_equiv.right_inv,
   map_add := map_add',

--- a/src/algebra/module/equiv.lean
+++ b/src/algebra/module/equiv.lean
@@ -96,7 +96,8 @@ variables [module R M] [module S M₂] {σ : R →+* S} {σ' : S →+* R}
 @[priority 100, nolint dangerous_instance]
 instance [ring_hom_inv_pair σ σ'] [ring_hom_inv_pair σ' σ] [s : semilinear_equiv_class F σ M M₂] :
   semilinear_map_class F σ M M₂ :=
-{ ..s }
+{ coe := (coe : F → M → M₂),
+  ..s }
 
 end semilinear_equiv_class
 

--- a/src/algebra/order/hom/ring.lean
+++ b/src/algebra/order/hom/ring.lean
@@ -220,7 +220,7 @@ def to_order_iso (f : α ≃+*o β) : α ≃o β := ⟨f.to_ring_equiv.to_equiv,
 instance : order_ring_iso_class (α ≃+*o β) α β :=
 { coe := λ f, f.to_fun,
   inv := λ f, f.inv_fun,
-  coe_inv_injective' := λ f g h₁ h₂, by { obtain ⟨⟨_, _⟩, _⟩ := f, obtain ⟨⟨_, _⟩, _⟩ := g, congr'},
+  coe_inv_injective' := λ f g _ _, by { obtain ⟨⟨_, _⟩, _⟩ := f, obtain ⟨⟨_, _⟩, _⟩ := g, congr' },
   map_add := λ f, f.map_add',
   map_mul := λ f, f.map_mul',
   map_le_map_iff := λ f, f.map_le_map_iff',

--- a/src/algebra/order/hom/ring.lean
+++ b/src/algebra/order/hom/ring.lean
@@ -220,7 +220,7 @@ def to_order_iso (f : α ≃+*o β) : α ≃o β := ⟨f.to_ring_equiv.to_equiv,
 instance : order_ring_iso_class (α ≃+*o β) α β :=
 { coe := λ f, f.to_fun,
   inv := λ f, f.inv_fun,
-  coe_injective' := λ f g h₁ h₂, by { obtain ⟨⟨_, _⟩, _⟩ := f, obtain ⟨⟨_, _⟩, _⟩ := g, congr' },
+  coe_inv_injective' := λ f g h₁ h₂, by { obtain ⟨⟨_, _⟩, _⟩ := f, obtain ⟨⟨_, _⟩, _⟩ := g, congr'},
   map_add := λ f, f.map_add',
   map_mul := λ f, f.map_mul',
   map_le_map_iff := λ f, f.map_le_map_iff',

--- a/src/algebra/ring/equiv.lean
+++ b/src/algebra/ring/equiv.lean
@@ -71,16 +71,13 @@ namespace ring_equiv_class
 instance to_add_equiv_class (F R S : Type*)
   [has_mul R] [has_add R] [has_mul S] [has_add S] [h : ring_equiv_class F R S] :
   add_equiv_class F R S :=
-{ coe := coe_fn,
-  .. h }
+{ .. h }
 
 @[priority 100] -- See note [lower instance priority]
 instance to_ring_hom_class (F R S : Type*)
   [non_assoc_semiring R] [non_assoc_semiring S] [h : ring_equiv_class F R S] :
   ring_hom_class F R S :=
-{ coe := coe_fn,
-  coe_injective' := fun_like.coe_injective,
-  map_zero := map_zero,
+{ map_zero := map_zero,
   map_one := map_one,
   .. h }
 
@@ -88,9 +85,7 @@ instance to_ring_hom_class (F R S : Type*)
 instance to_non_unital_ring_hom_class (F R S : Type*)
   [non_unital_non_assoc_semiring R] [non_unital_non_assoc_semiring S] [h : ring_equiv_class F R S] :
   non_unital_ring_hom_class F R S :=
-{ coe := coe_fn,
-  coe_injective' := fun_like.coe_injective,
-  map_zero := map_zero,
+{ map_zero := map_zero,
   .. h }
 
 end ring_equiv_class
@@ -109,7 +104,7 @@ variables [has_mul R] [has_add R] [has_mul S] [has_add S] [has_mul S'] [has_add 
 instance : ring_equiv_class (R ≃+* S) R S :=
 { coe := to_fun,
   inv := inv_fun,
-  coe_injective' := λ e f h₁ h₂, by { cases e, cases f, congr' },
+  coe_inv_injective' := λ e f h₁ h₂, by { cases e, cases f, congr' },
   map_add := map_add',
   map_mul := map_mul',
   left_inv := ring_equiv.left_inv,

--- a/src/algebra/ring/equiv.lean
+++ b/src/algebra/ring/equiv.lean
@@ -71,13 +71,15 @@ namespace ring_equiv_class
 instance to_add_equiv_class (F R S : Type*)
   [has_mul R] [has_add R] [has_mul S] [has_add S] [h : ring_equiv_class F R S] :
   add_equiv_class F R S :=
-{ .. h }
+{ coe := coe_fn,
+  .. h }
 
 @[priority 100] -- See note [lower instance priority]
 instance to_ring_hom_class (F R S : Type*)
   [non_assoc_semiring R] [non_assoc_semiring S] [h : ring_equiv_class F R S] :
   ring_hom_class F R S :=
-{ map_zero := map_zero,
+{ coe := coe_fn,
+  map_zero := map_zero,
   map_one := map_one,
   .. h }
 
@@ -85,7 +87,8 @@ instance to_ring_hom_class (F R S : Type*)
 instance to_non_unital_ring_hom_class (F R S : Type*)
   [non_unital_non_assoc_semiring R] [non_unital_non_assoc_semiring S] [h : ring_equiv_class F R S] :
   non_unital_ring_hom_class F R S :=
-{ map_zero := map_zero,
+{ coe := coe_fn,
+  map_zero := map_zero,
   .. h }
 
 end ring_equiv_class

--- a/src/analysis/normed_space/linear_isometry.lean
+++ b/src/analysis/normed_space/linear_isometry.lean
@@ -379,9 +379,7 @@ include σ₂₁
 -- `σ₂₁` becomes a metavariable, but it's OK since it's an outparam
 @[priority 100, nolint dangerous_instance]
 instance [s : semilinear_isometry_equiv_class 𝓕 σ₁₂ E E₂] : semilinear_isometry_class 𝓕 σ₁₂ E E₂ :=
-{ coe := (coe : 𝓕 → E → E₂),
-  coe_injective' := @fun_like.coe_injective 𝓕 _ _ _,
-  ..s }
+{ ..s }
 omit σ₂₁
 
 end semilinear_isometry_equiv_class

--- a/src/analysis/normed_space/linear_isometry.lean
+++ b/src/analysis/normed_space/linear_isometry.lean
@@ -379,7 +379,8 @@ include σ₂₁
 -- `σ₂₁` becomes a metavariable, but it's OK since it's an outparam
 @[priority 100, nolint dangerous_instance]
 instance [s : semilinear_isometry_equiv_class 𝓕 σ₁₂ E E₂] : semilinear_isometry_class 𝓕 σ₁₂ E E₂ :=
-{ ..s }
+{ coe := (coe : 𝓕 → E → E₂),
+  ..s }
 omit σ₂₁
 
 end semilinear_isometry_equiv_class

--- a/src/analysis/normed_space/linear_isometry.lean
+++ b/src/analysis/normed_space/linear_isometry.lean
@@ -401,7 +401,7 @@ to_linear_equiv_injective.eq_iff
 instance : semilinear_isometry_equiv_class (E ≃ₛₗᵢ[σ₁₂] E₂) σ₁₂ E E₂ :=
 { coe := λ e, e.to_fun,
   inv := λ e, e.inv_fun,
-  coe_injective' := λ f g h₁ h₂,
+  coe_inv_injective' := λ f g h₁ h₂,
     by { cases f with f' _, cases g with g' _, cases f', cases g', congr', },
   left_inv := λ e, e.left_inv,
   right_inv := λ e, e.right_inv,

--- a/src/data/fun_like/equiv.lean
+++ b/src/data/fun_like/equiv.lean
@@ -5,6 +5,7 @@ Authors: Anne Baanen
 -/
 
 import data.fun_like.embedding
+import tactic.congr
 
 /-!
 # Typeclass for a type `F` with an injective map to `A ≃ B`
@@ -118,6 +119,8 @@ instead of linearly increasing the work per `my_iso`-related declaration.
 
 -/
 
+set_option old_structure_cmd true
+
 /-- The class `equiv_like E α β` expresses that terms of type `E` have an
 injective coercion to bijections between `α` and `β`.
 
@@ -138,13 +141,13 @@ variables {E F α β γ : Sort*} [iE : equiv_like E α β] [iF : equiv_like F β
 include iE
 
 lemma inv_injective : function.injective (equiv_like.inv : E → (β → α)) :=
-λ e g h, fun_like.coe_injective' $ function.left_inverse.eq_right_inverse (right_inv e)
+λ e g h, coe_injective' $ function.left_inverse.eq_right_inverse (right_inv e)
   (h.symm ▸ left_inv g : function.right_inverse g (inv e))
 
 @[priority 100]
 instance to_embedding_like : embedding_like E α β :=
-{ coe := fun_like.coe,
-  coe_injective' := fun_like.coe_injective',
+{ coe := coe,
+  coe_injective' := coe_injective',
   injective' := λ e, function.left_inverse.injective (left_inv e) }
 
 protected lemma injective (e : E) : function.injective e := embedding_like.injective e

--- a/src/data/fun_like/equiv.lean
+++ b/src/data/fun_like/equiv.lean
@@ -116,6 +116,14 @@ This means anything set up for `my_iso`s will automatically work for `cool_iso_c
 and defining `cool_iso_class` only takes a constant amount of effort,
 instead of linearly increasing the work per `my_iso`-related declaration.
 
+If you already have a definition of homomorphisms (e.g. `my_hom_class`), you
+could also try defining the corresponding isomorphism by extending both
+`my_hom_class` and `equiv_like`. Make sure however that this does not create
+extra work in this particular instance: it's often easier to show a bijective
+map is an isomorphism, compared to showing a map is a homomorphism.  Compare the
+class of group homomorphisms `monoid_hom_class` which needs a proof of `map_mul`
+and `map_one`, and the class of group isomorphisms `mul_hom_class` which only
+needs `map_mul`. Thus, `mul_hom_class` does not extend `monoid_hom_class`.
 -/
 
 set_option old_structure_cmd true

--- a/src/data/fun_like/equiv.lean
+++ b/src/data/fun_like/equiv.lean
@@ -129,7 +129,7 @@ such as `zero_equiv_class`, `mul_equiv_class`, `monoid_equiv_class`, ....
 class equiv_like (E : Sort*) (α β : out_param Sort*) extends fun_like E α (λ _, β) :=
 (inv : E → β → α)
 -- the `show` below fixes elaboration problems when using these fields stemming from the fact
--- that in this case, `fun_like.coe : E → Π (_ : α), β`, not `E → α → β`.
+-- that in this case, `fun_like.coe : E → Π (a : α), (λ _, β) a`, not `E → α → β`.
 (left_inv  : ∀ e, function.left_inverse (inv e) (show α → β, from coe e))
 (right_inv : ∀ e, function.right_inverse (inv e) (show α → β, from coe e))
 (coe_inv_injective' : ∀ e g, coe e = coe g → inv e = inv g → e = g)

--- a/src/data/fun_like/equiv.lean
+++ b/src/data/fun_like/equiv.lean
@@ -5,7 +5,6 @@ Authors: Anne Baanen
 -/
 
 import data.fun_like.embedding
-import tactic.congr
 
 /-!
 # Typeclass for a type `F` with an injective map to `A ≃ B`

--- a/src/logic/equiv/basic.lean
+++ b/src/logic/equiv/basic.lean
@@ -88,7 +88,7 @@ namespace equiv
 
 instance : equiv_like (α ≃ β) α β :=
 { coe := to_fun, inv := inv_fun, left_inv := left_inv, right_inv := right_inv,
-  coe_injective' := λ e₁ e₂ h₁ h₂, by { cases e₁, cases e₂, congr' } }
+  coe_inv_injective' := λ e₁ e₂ h₁ h₂, by { cases e₁, cases e₂, congr' } }
 
 instance : has_coe_to_fun (α ≃ β) (λ _, α → β) := ⟨to_fun⟩
 

--- a/src/model_theory/basic.lean
+++ b/src/model_theory/basic.lean
@@ -558,7 +558,7 @@ instance : equiv_like (M ≃[L] N) M N :=
   inv := λ f, f.inv_fun,
   left_inv := λ f, f.left_inv,
   right_inv := λ f, f.right_inv,
-  coe_injective' := λ f g h₁ h₂, begin
+  coe_inv_injective' := λ f g h₁ h₂, begin
     cases f,
     cases g,
     simp only,

--- a/src/order/hom/basic.lean
+++ b/src/order/hom/basic.lean
@@ -498,7 +498,7 @@ instance : order_iso_class (α ≃o β) α β :=
   inv := λ f, f.inv_fun,
   left_inv := λ f, f.left_inv,
   right_inv := λ f, f.right_inv,
-  coe_inv_injective' := λ f g h₁ h₂, by { obtain ⟨⟨_, _⟩, _⟩ := f, obtain ⟨⟨_, _⟩, _⟩ := g, congr'},
+  coe_inv_injective' := λ f g _ _, by { obtain ⟨⟨_, _⟩, _⟩ := f, obtain ⟨⟨_, _⟩, _⟩ := g, congr' },
   map_le_map_iff := λ f, f.map_rel_iff' }
 
 @[simp] lemma to_fun_eq_coe {f : α ≃o β} : f.to_fun = f := rfl

--- a/src/order/hom/basic.lean
+++ b/src/order/hom/basic.lean
@@ -498,7 +498,7 @@ instance : order_iso_class (α ≃o β) α β :=
   inv := λ f, f.inv_fun,
   left_inv := λ f, f.left_inv,
   right_inv := λ f, f.right_inv,
-  coe_injective' := λ f g h₁ h₂, by { obtain ⟨⟨_, _⟩, _⟩ := f, obtain ⟨⟨_, _⟩, _⟩ := g, congr' },
+  coe_inv_injective' := λ f g h₁ h₂, by { obtain ⟨⟨_, _⟩, _⟩ := f, obtain ⟨⟨_, _⟩, _⟩ := g, congr'},
   map_le_map_iff := λ f, f.map_rel_iff' }
 
 @[simp] lemma to_fun_eq_coe {f : α ≃o β} : f.to_fun = f := rfl

--- a/src/topology/algebra/module/basic.lean
+++ b/src/topology/algebra/module/basic.lean
@@ -341,9 +341,7 @@ include σ'
 @[priority 100, nolint dangerous_instance]
 instance [s: continuous_semilinear_equiv_class F σ M M₂] :
   continuous_semilinear_map_class F σ M M₂ :=
-{ coe := (coe : F → M → M₂),
-  coe_injective' := @fun_like.coe_injective F _ _ _,
-  ..s }
+{ ..s }
 omit σ'
 
 end continuous_semilinear_equiv_class
@@ -1414,7 +1412,7 @@ instance : has_coe (M₁ ≃SL[σ₁₂] M₂) (M₁ →SL[σ₁₂] M₂) := �
 instance : continuous_semilinear_equiv_class (M₁ ≃SL[σ₁₂] M₂) σ₁₂ M₁ M₂ :=
 { coe := λ f, f,
   inv := λ f, f.inv_fun,
-  coe_injective' := λ f g h₁ h₂, by { cases f with f' _, cases g with g' _,  cases f', cases g',
+  coe_inv_injective' := λ f g h₁ h₂, by { cases f with f' _, cases g with g' _,  cases f', cases g',
                                       congr' },
   left_inv := λ f, f.left_inv,
   right_inv := λ f, f.right_inv,

--- a/src/topology/algebra/module/basic.lean
+++ b/src/topology/algebra/module/basic.lean
@@ -341,7 +341,8 @@ include σ'
 @[priority 100, nolint dangerous_instance]
 instance [s: continuous_semilinear_equiv_class F σ M M₂] :
   continuous_semilinear_map_class F σ M M₂ :=
-{ ..s }
+{ coe := (coe : F → M → M₂),
+  ..s }
 omit σ'
 
 end continuous_semilinear_equiv_class


### PR DESCRIPTION
This changes `equiv_like` so that it actually extends `fun_like` instead of only having it as an instance. We do this by renaming the current `coe_injective'` field to `coe_inv_injective'` so that it doesn't conflict with the one from `fun_like`. We then use it to autofill the `fun_like.coe_injective'` field. In this way, it is no more difficult to create instances of `equiv_like` than before, one only uses the `coe_inv_injective'` field instead of the `coe_injective'` field.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
