### PR TITLE
[Merged by Bors] - feat(tactic/positivity): Handle division of integers

### DIFF
--- a/src/tactic/positivity.lean
+++ b/src/tactic/positivity.lean
@@ -300,8 +300,6 @@ div_nonneg ha hb.le
 private lemma int_div_self_pos {a : ℤ} (ha : 0 < a) : 0 < a / a :=
 by { rw int.div_self ha.ne', exact zero_lt_one }
 
-private lemma int_div_nonneg {a b : ℤ} (ha : 0 ≤ a) (hb : 0 ≤ b) : 0 ≤ a / b := int.div_nonneg ha hb
-
 private lemma int_div_nonneg_of_pos_of_nonneg {a b : ℤ} (ha : 0 < a) (hb : 0 ≤ b) : 0 ≤ a / b :=
 int.div_nonneg ha.le hb
 
@@ -321,14 +319,15 @@ meta def positivity_div : expr → tactic strictness
   typ ← infer_type a,
   match typ, strictness_a, strictness_b with
   | `(ℤ), positive pa, positive pb :=
-      if a = b -- Only attempts to prove `0 < a / a`, otherwise falls back to `0 ≤ a / b`
-      then positive <$> mk_app ``int_div_self_pos [pa]
-      else nonnegative <$> mk_app ``int_div_nonneg_of_pos_of_pos [pa, pb]
+      if a = b then -- Only attempts to prove `0 < a / a`, otherwise falls back to `0 ≤ a / b`
+        positive <$> mk_app ``int_div_self_pos [pa]
+      else
+       nonnegative <$> mk_app ``int_div_nonneg_of_pos_of_pos [pa, pb]
   | `(ℤ), positive pa, nonnegative pb :=
     nonnegative <$> mk_app ``int_div_nonneg_of_pos_of_nonneg [pa, pb]
   | `(ℤ), nonnegative pa, positive pb :=
     nonnegative <$> mk_app ``int_div_nonneg_of_nonneg_of_pos [pa, pb]
-  | `(ℤ), nonnegative pa, nonnegative pb := nonnegative <$> mk_app ``int_div_nonneg [pa, pb]
+  | `(ℤ), nonnegative pa, nonnegative pb := nonnegative <$> mk_app ``int.div_nonneg [pa, pb]
   | _, positive pa, positive pb := positive <$> mk_app ``div_pos [pa, pb]
   | _, positive pa, nonnegative pb := nonnegative <$> mk_app ``div_nonneg_of_pos_of_nonneg [pa, pb]
   | _, nonnegative pa, positive pb := nonnegative <$> mk_app ``div_nonneg_of_nonneg_of_pos [pa, pb]

--- a/src/tactic/positivity.lean
+++ b/src/tactic/positivity.lean
@@ -313,25 +313,29 @@ int.div_nonneg ha.le hb.le
 are nonnegative, and strictly positive if both numerator and denominator are. -/
 @[positivity]
 meta def positivity_div : expr → tactic strictness
-| `(%%a / %%b) := do
+| `(@has_div.div int _ %%a %%b) := do
   strictness_a ← core a,
   strictness_b ← core b,
-  typ ← infer_type a,
-  match typ, strictness_a, strictness_b with
-  | `(ℤ), positive pa, positive pb :=
+  match strictness_a, strictness_b with
+  | positive pa, positive pb :=
       if a = b then -- Only attempts to prove `0 < a / a`, otherwise falls back to `0 ≤ a / b`
         positive <$> mk_app ``int_div_self_pos [pa]
       else
        nonnegative <$> mk_app ``int_div_nonneg_of_pos_of_pos [pa, pb]
-  | `(ℤ), positive pa, nonnegative pb :=
+  | positive pa, nonnegative pb :=
     nonnegative <$> mk_app ``int_div_nonneg_of_pos_of_nonneg [pa, pb]
-  | `(ℤ), nonnegative pa, positive pb :=
+  | nonnegative pa, positive pb :=
     nonnegative <$> mk_app ``int_div_nonneg_of_nonneg_of_pos [pa, pb]
-  | `(ℤ), nonnegative pa, nonnegative pb := nonnegative <$> mk_app ``int.div_nonneg [pa, pb]
-  | _, positive pa, positive pb := positive <$> mk_app ``div_pos [pa, pb]
-  | _, positive pa, nonnegative pb := nonnegative <$> mk_app ``div_nonneg_of_pos_of_nonneg [pa, pb]
-  | _, nonnegative pa, positive pb := nonnegative <$> mk_app ``div_nonneg_of_nonneg_of_pos [pa, pb]
-  | _, nonnegative pa, nonnegative pb := nonnegative <$> mk_app ``div_nonneg [pa, pb]
+  | nonnegative pa, nonnegative pb := nonnegative <$> mk_app ``int.div_nonneg [pa, pb]
+  end
+| `(%%a / %%b) := do
+  strictness_a ← core a,
+  strictness_b ← core b,
+  match strictness_a, strictness_b with
+  | positive pa, positive pb := positive <$> mk_app ``div_pos [pa, pb]
+  | positive pa, nonnegative pb := nonnegative <$> mk_app ``div_nonneg_of_pos_of_nonneg [pa, pb]
+  | nonnegative pa, positive pb := nonnegative <$> mk_app ``div_nonneg_of_nonneg_of_pos [pa, pb]
+  | nonnegative pa, nonnegative pb := nonnegative <$> mk_app ``div_nonneg [pa, pb]
   end
 | _ := failed
 

--- a/test/positivity.lean
+++ b/test/positivity.lean
@@ -45,9 +45,9 @@ example {a : ℤ} (ha : 3 < a) : 0 < a + a := by positivity
 
 example {a b : ℚ} (ha : 3 < a) (hb : 4 ≤ b) : 0 < 3 + a * b / 7 + b + 7 + 14 := by positivity
 
--- TODO: this fails because `div_nonneg` doesn't apply directly to `ℤ` -- it requires a linearly
--- ordered field
--- example {a b : ℤ} (ha : 3 < a) (hb : 4 ≤ b) : 0 < 3 + a * b / 7 + b + 7 + 14 := by positivity
+example {a b : ℤ} (ha : 3 < a) (hb : 4 ≤ b) : 0 < 3 + a * b / 7 + b + 7 + 14 := by positivity
+
+example {a : ℤ} (ha : 0 < a) : 0 < a / a := by positivity
 
 example {a : ℕ} : 0 < a ^ 0 := by positivity
 


### PR DESCRIPTION
Extend `positivity_div` to handle division of integers.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
