### PR TITLE
[Merged by Bors] - fix(topology/continuous_function/basic): use `old_structure_cmd` to define `continuous_map_class` 

### DIFF
--- a/src/data/fun_like/basic.lean
+++ b/src/data/fun_like/basic.lean
@@ -95,7 +95,7 @@ class cooler_hom_class (F : Type*) (A B : out_param $ Type*) [cool_class A] [coo
   extends my_hom_class F A B :=
 (map_cool : ∀ (f : F), f cool_class.cool = cool_class.cool)
 
-set_option old_structure_cmd false
+end
 
 @[simp] lemma map_cool {F A B : Type*} [cool_class A] [cool_class B] [cooler_hom_class F A B]
   (f : F) : f cool_class.cool = cool_class.cool :=

--- a/src/data/fun_like/basic.lean
+++ b/src/data/fun_like/basic.lean
@@ -88,6 +88,7 @@ structure cooler_hom (A B : Type*) [cool_class A] [cool_class B]
   extends my_hom A B :=
 (map_cool' : to_fun cool_class.cool = cool_class.cool)
 
+section
 set_option old_structure_cmd true
 
 class cooler_hom_class (F : Type*) (A B : out_param $ Type*) [cool_class A] [cool_class B]

--- a/src/data/fun_like/basic.lean
+++ b/src/data/fun_like/basic.lean
@@ -57,6 +57,7 @@ the axioms of your new type of morphisms.
 Continuing the example above:
 
 ```
+section
 set_option old_structure_cmd true
 
 /-- `my_hom_class F A B` states that `F` is a type of `my_class.op`-preserving morphisms.
@@ -65,8 +66,7 @@ class my_hom_class (F : Type*) (A B : out_param $ Type*) [my_class A] [my_class 
   extends fun_like F A (λ _, B) :=
 (map_op : ∀ (f : F) (x y : A), f (my_class.op x y) = my_class.op (f x) (f y))
 
-set_option old_structure_cmd false
-
+end
 @[simp] lemma map_op {F A B : Type*} [my_class A] [my_class B] [my_hom_class F A B]
   (f : F) (x y : A) : f (my_class.op x y) = my_class.op (f x) (f y) :=
 my_hom_class.map_op

--- a/src/data/fun_like/basic.lean
+++ b/src/data/fun_like/basic.lean
@@ -57,11 +57,15 @@ the axioms of your new type of morphisms.
 Continuing the example above:
 
 ```
+set_option old_structure_cmd true
+
 /-- `my_hom_class F A B` states that `F` is a type of `my_class.op`-preserving morphisms.
 You should extend this class when you extend `my_hom`. -/
 class my_hom_class (F : Type*) (A B : out_param $ Type*) [my_class A] [my_class B]
   extends fun_like F A (λ _, B) :=
 (map_op : ∀ (f : F) (x y : A), f (my_class.op x y) = my_class.op (f x) (f y))
+
+set_option old_structure_cmd false
 
 @[simp] lemma map_op {F A B : Type*} [my_class A] [my_class B] [my_hom_class F A B]
   (f : F) (x y : A) : f (my_class.op x y) = my_class.op (f x) (f y) :=
@@ -84,9 +88,13 @@ structure cooler_hom (A B : Type*) [cool_class A] [cool_class B]
   extends my_hom A B :=
 (map_cool' : to_fun cool_class.cool = cool_class.cool)
 
+set_option old_structure_cmd true
+
 class cooler_hom_class (F : Type*) (A B : out_param $ Type*) [cool_class A] [cool_class B]
   extends my_hom_class F A B :=
 (map_cool : ∀ (f : F), f cool_class.cool = cool_class.cool)
+
+set_option old_structure_cmd false
 
 @[simp] lemma map_cool {F A B : Type*} [cool_class A] [cool_class B] [cooler_hom_class F A B]
   (f : F) : f cool_class.cool = cool_class.cool :=

--- a/src/data/fun_like/equiv.lean
+++ b/src/data/fun_like/equiv.lean
@@ -91,6 +91,7 @@ structure cooler_iso (A B : Type*) [cool_class A] [cool_class B]
   extends my_iso A B :=
 (map_cool' : to_fun cool_class.cool = cool_class.cool)
 
+section
 set_option old_structure_cmd true
 
 class cooler_iso_class (F : Type*) (A B : out_param $ Type*) [cool_class A] [cool_class B]

--- a/src/data/fun_like/equiv.lean
+++ b/src/data/fun_like/equiv.lean
@@ -61,10 +61,14 @@ the axioms of your new type of isomorphisms.
 Continuing the example above:
 
 ```
+set_option old_structure_cmd true
+
 /-- `my_iso_class F A B` states that `F` is a type of `my_class.op`-preserving morphisms.
 You should extend this class when you extend `my_iso`. -/
 class my_iso_class (F : Type*) (A B : out_param $ Type*) [my_class A] [my_class B]
   extends equiv_like F A (λ _, B), my_hom_class F A B.
+
+set_option old_structure_cmd false
 
 -- You can replace `my_iso.equiv_like` with the below instance:
 instance : my_iso_class (my_iso A B) A B :=
@@ -86,9 +90,13 @@ structure cooler_iso (A B : Type*) [cool_class A] [cool_class B]
   extends my_iso A B :=
 (map_cool' : to_fun cool_class.cool = cool_class.cool)
 
+set_option old_structure_cmd true
+
 class cooler_iso_class (F : Type*) (A B : out_param $ Type*) [cool_class A] [cool_class B]
   extends my_iso_class F A B :=
 (map_cool : ∀ (f : F), f cool_class.cool = cool_class.cool)
+
+set_option old_structure_cmd false
 
 @[simp] lemma map_cool {F A B : Type*} [cool_class A] [cool_class B] [cooler_iso_class F A B]
   (f : F) : f cool_class.cool = cool_class.cool :=

--- a/src/data/fun_like/equiv.lean
+++ b/src/data/fun_like/equiv.lean
@@ -69,7 +69,7 @@ You should extend this class when you extend `my_iso`. -/
 class my_iso_class (F : Type*) (A B : out_param $ Type*) [my_class A] [my_class B]
   extends equiv_like F A (λ _, B), my_hom_class F A B.
 
-set_option old_structure_cmd false
+end
 
 -- You can replace `my_iso.equiv_like` with the below instance:
 instance : my_iso_class (my_iso A B) A B :=

--- a/src/data/fun_like/equiv.lean
+++ b/src/data/fun_like/equiv.lean
@@ -98,7 +98,7 @@ class cooler_iso_class (F : Type*) (A B : out_param $ Type*) [cool_class A] [coo
   extends my_iso_class F A B :=
 (map_cool : ∀ (f : F), f cool_class.cool = cool_class.cool)
 
-set_option old_structure_cmd false
+end
 
 @[simp] lemma map_cool {F A B : Type*} [cool_class A] [cool_class B] [cooler_iso_class F A B]
   (f : F) : f cool_class.cool = cool_class.cool :=

--- a/src/data/fun_like/equiv.lean
+++ b/src/data/fun_like/equiv.lean
@@ -61,6 +61,7 @@ the axioms of your new type of isomorphisms.
 Continuing the example above:
 
 ```
+section
 set_option old_structure_cmd true
 
 /-- `my_iso_class F A B` states that `F` is a type of `my_class.op`-preserving morphisms.

--- a/src/topology/continuous_function/basic.lean
+++ b/src/topology/continuous_function/basic.lean
@@ -41,7 +41,7 @@ class continuous_map_class (F : Type*) (α β : out_param $ Type*) [topological_
   extends fun_like F α (λ _, β) :=
 (map_continuous (f : F) : continuous f)
 
-set_option old_structure_cmd false
+end
 
 export continuous_map_class (map_continuous)
 

--- a/src/topology/continuous_function/basic.lean
+++ b/src/topology/continuous_function/basic.lean
@@ -31,6 +31,7 @@ structure continuous_map (α β : Type*) [topological_space α] [topological_spa
 
 notation `C(` α `, ` β `)` := continuous_map α β
 
+set_option old_structure_cmd true
 /-- `continuous_map_class F α β` states that `F` is a type of continuous maps.
 
 You should extend this class when you extend `continuous_map`. -/
@@ -38,6 +39,8 @@ class continuous_map_class (F : Type*) (α β : out_param $ Type*) [topological_
   [topological_space β]
   extends fun_like F α (λ _, β) :=
 (map_continuous (f : F) : continuous f)
+
+set_option old_structure_cmd false
 
 export continuous_map_class (map_continuous)
 

--- a/src/topology/continuous_function/basic.lean
+++ b/src/topology/continuous_function/basic.lean
@@ -31,6 +31,7 @@ structure continuous_map (α β : Type*) [topological_space α] [topological_spa
 
 notation `C(` α `, ` β `)` := continuous_map α β
 
+section
 set_option old_structure_cmd true
 /-- `continuous_map_class F α β` states that `F` is a type of continuous maps.
 

--- a/src/topology/spectral/hom.lean
+++ b/src/topology/spectral/hom.lean
@@ -72,7 +72,8 @@ attribute [simp] map_spectral
 instance spectral_map_class.to_continuous_map_class [topological_space α] [topological_space β]
   [spectral_map_class F α β] :
   continuous_map_class F α β :=
-⟨λ f, (map_spectral f).continuous⟩
+{ map_continuous := λ f, (map_spectral f).continuous,
+  ..‹spectral_map_class F α β› }
 
 instance [topological_space α] [topological_space β] [spectral_map_class F α β] :
   has_coe_t F (spectral_map α β) :=


### PR DESCRIPTION
We fix `continuous_map_class` to use `old_structure_cmd`, and also fix the documentation of `fun_like` and `equiv_like` to specify that this should be done systematically for new morphism type classes. Without this, we get a `to_fun_like` field in the newly created class which then creates diamonds.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
