### PR TITLE
[Merged by Bors] - feat(probability/integration): remove integrability assumption in indep_fun.integral_mul

### DIFF
--- a/src/probability/independence.lean
+++ b/src/probability/independence.lean
@@ -520,6 +520,10 @@ begin
   { rwa ← indep_set_iff_measure_inter_eq_mul (hf hs) (hg ht) μ, },
 end
 
+lemma indep_fun.symm {mβ : measurable_space β} {f g : Ω → β} (hfg : indep_fun f g μ) :
+  indep_fun g f μ :=
+hfg.symm
+
 lemma indep_fun.ae_eq {mβ : measurable_space β} {f g f' g' : Ω → β}
   (hfg : indep_fun f g μ) (hf : f =ᵐ[μ] f') (hg : g =ᵐ[μ] g') :
   indep_fun f' g' μ :=

--- a/src/probability/integration.lean
+++ b/src/probability/integration.lean
@@ -129,6 +129,11 @@ begin
   exact h_indep_fun.ae_eq h_meas_f.ae_eq_mk h_meas_g.ae_eq_mk
 end
 
+lemma lintegral_mul_eq_lintegral_mul_lintegral_of_indep_fun''
+  (h_meas_f : ae_measurable f μ) (h_meas_g : ae_measurable g μ) (h_indep_fun : indep_fun f g μ) :
+  ∫⁻ ω, f ω * g ω ∂μ = ∫⁻ ω, f ω ∂μ * ∫⁻ ω, g ω ∂μ :=
+lintegral_mul_eq_lintegral_mul_lintegral_of_indep_fun' h_meas_f h_meas_g h_indep_fun
+
 /-- The product of two independent, integrable, real_valued random variables is integrable. -/
 lemma indep_fun.integrable_mul {β : Type*} [measurable_space β] {X Y : Ω → β}
   [normed_division_ring β] [borel_space β]
@@ -152,6 +157,56 @@ begin
   refine ⟨hX.1.mul hY.1, _⟩,
   simp_rw [has_finite_integral, pi.mul_apply, nnnorm_mul, ennreal.coe_mul, hmul],
   exact ennreal.mul_lt_top_iff.mpr (or.inl ⟨hX.2, hY.2⟩)
+end
+
+/-- If product of two independent, integrable, real_valued random variables is integrable and the
+second one is not almost everywhere zero, then the first one is integrable. -/
+lemma indep_fun.integrable_left_of_integrable_mul {β : Type*} [measurable_space β] {X Y : Ω → β}
+  [normed_division_ring β] [borel_space β]
+  (hXY : indep_fun X Y μ) (h'XY : integrable (X * Y) μ)
+  (hX : ae_strongly_measurable X μ) (hY : ae_strongly_measurable Y μ) (h'Y : ¬(Y =ᵐ[μ] 0)) :
+  integrable X μ :=
+begin
+  refine ⟨hX, _⟩,
+  have I : ∫⁻ x, ∥Y x∥₊ ∂μ ≠ 0,
+  { assume H,
+    have I : (λ (a : Ω), ↑∥Y a∥₊) =ᵐ[μ] 0 := (lintegral_eq_zero_iff' hY.ennnorm).1 H,
+    apply h'Y,
+    filter_upwards [I] with x hx,
+    simpa using hx },
+  apply lt_top_iff_ne_top.2 (λ H, _),
+  have J : indep_fun (λ (a : Ω), ↑∥X a∥₊) (λ (a : Ω), ↑∥Y a∥₊) μ,
+  { have M : measurable (λ (x : β), (∥x∥₊ : ℝ≥0∞)) := measurable_nnnorm.coe_nnreal_ennreal,
+    apply indep_fun.comp hXY M M },
+  have A : ∫⁻ x, ∥X x * Y x∥₊ ∂μ < ∞ := h'XY.2,
+  simp only [nnnorm_mul, ennreal.coe_mul] at A,
+  rw [lintegral_mul_eq_lintegral_mul_lintegral_of_indep_fun'' hX.ennnorm hY.ennnorm J, H] at A,
+  simpa [ennreal.top_mul, I] using A,
+end
+
+/-- If product of two independent, integrable, real_valued random variables is integrable and the
+first one is not almost everywhere zero, then the second one is integrable. -/
+lemma indep_fun.integrable_right_of_integrable_mul {β : Type*} [measurable_space β] {X Y : Ω → β}
+  [normed_division_ring β] [borel_space β]
+  (hXY : indep_fun X Y μ) (h'XY : integrable (X * Y) μ)
+  (hX : ae_strongly_measurable X μ) (hY : ae_strongly_measurable Y μ) (h'X : ¬(X =ᵐ[μ] 0)) :
+  integrable Y μ :=
+begin
+  refine ⟨hY, _⟩,
+  have I : ∫⁻ x, ∥X x∥₊ ∂μ ≠ 0,
+  { assume H,
+    have I : (λ (a : Ω), ↑∥X a∥₊) =ᵐ[μ] 0 := (lintegral_eq_zero_iff' hX.ennnorm).1 H,
+    apply h'X,
+    filter_upwards [I] with x hx,
+    simpa using hx },
+  apply lt_top_iff_ne_top.2 (λ H, _),
+  have J : indep_fun (λ (a : Ω), ↑∥X a∥₊) (λ (a : Ω), ↑∥Y a∥₊) μ,
+  { have M : measurable (λ (x : β), (∥x∥₊ : ℝ≥0∞)) := measurable_nnnorm.coe_nnreal_ennreal,
+    apply indep_fun.comp hXY M M },
+  have A : ∫⁻ x, ∥X x * Y x∥₊ ∂μ < ∞ := h'XY.2,
+  simp only [nnnorm_mul, ennreal.coe_mul] at A,
+  rw [lintegral_mul_eq_lintegral_mul_lintegral_of_indep_fun'' hX.ennnorm hY.ennnorm J, H] at A,
+  simpa [ennreal.top_mul, I] using A,
 end
 
 /-- The (Bochner) integral of the product of two independent, nonnegative random
@@ -234,10 +289,40 @@ begin
   ring
 end
 
-theorem indep_fun.integral_mul_of_integrable' (hXY : indep_fun X Y μ)
-  (hX : integrable X μ) (hY : integrable Y μ) :
+theorem indep_fun.integral_mul (hXY : indep_fun X Y μ)
+  (hX : ae_measurable X μ) (hY : ae_measurable Y μ) :
+  integral μ (X * Y) = integral μ X * integral μ Y :=
+begin
+  by_cases h'X : X =ᵐ[μ] 0,
+  { have h' : X * Y =ᵐ[μ] 0,
+    { filter_upwards [h'X] with x hx,
+      simp [hx] },
+    simp only [integral_congr_ae h'X, integral_congr_ae h', pi.zero_apply, integral_const,
+      algebra.id.smul_eq_mul, mul_zero, zero_mul] },
+  by_cases h'Y : Y =ᵐ[μ] 0,
+  { have h' : X * Y =ᵐ[μ] 0,
+    { filter_upwards [h'Y] with x hx,
+      simp [hx] },
+    simp only [integral_congr_ae h'Y, integral_congr_ae h', pi.zero_apply, integral_const,
+      algebra.id.smul_eq_mul, mul_zero, zero_mul] },
+  by_cases h : integrable (X * Y) μ,
+  { have HX : integrable X μ := hXY.integrable_left_of_integrable_mul
+      h hX.ae_strongly_measurable hY.ae_strongly_measurable h'Y,
+    have HY : integrable Y μ := hXY.integrable_right_of_integrable_mul
+      h hX.ae_strongly_measurable hY.ae_strongly_measurable h'X,
+    exact hXY.integral_mul_of_integrable HX HY },
+  { have I : ¬(integrable X μ ∧ integrable Y μ),
+    { rintros ⟨HX, HY⟩,
+      exact h (hXY.integrable_mul HX HY) },
+    rw not_and_distrib at I,
+    cases I;
+    simp [integral_undef, I, h] }
+end
+
+theorem indep_fun.integral_mul' (hXY : indep_fun X Y μ)
+  (hX : ae_measurable X μ) (hY : ae_measurable Y μ) :
   integral μ (λ x, X x * Y x) = integral μ X * integral μ Y :=
-hXY.integral_mul_of_integrable hX hY
+hXY.integral_mul hX hY
 
 /-- Independence of functions `f` and `g` into arbitrary types is characterized by the relation
   `E[(φ ∘ f) * (ψ ∘ g)] = E[φ ∘ f] * E[ψ ∘ g]` for all measurable `φ` and `ψ` with values in `ℝ`

--- a/src/probability/integration.lean
+++ b/src/probability/integration.lean
@@ -159,8 +159,8 @@ begin
   exact ennreal.mul_lt_top_iff.mpr (or.inl ⟨hX.2, hY.2⟩)
 end
 
-/-- If product of two independent, integrable, real_valued random variables is integrable and the
-second one is not almost everywhere zero, then the first one is integrable. -/
+/-- If the product of two independent real_valued random variables is integrable and
+the second one is not almost everywhere zero, then the first one is integrable. -/
 lemma indep_fun.integrable_left_of_integrable_mul {β : Type*} [measurable_space β] {X Y : Ω → β}
   [normed_division_ring β] [borel_space β]
   (hXY : indep_fun X Y μ) (h'XY : integrable (X * Y) μ)
@@ -168,23 +168,23 @@ lemma indep_fun.integrable_left_of_integrable_mul {β : Type*} [measurable_space
   integrable X μ :=
 begin
   refine ⟨hX, _⟩,
-  have I : ∫⁻ x, ∥Y x∥₊ ∂μ ≠ 0,
+  have I : ∫⁻ ω, ∥Y ω∥₊ ∂μ ≠ 0,
   { assume H,
-    have I : (λ (a : Ω), ↑∥Y a∥₊) =ᵐ[μ] 0 := (lintegral_eq_zero_iff' hY.ennnorm).1 H,
+    have I : (λ ω, ↑∥Y ω∥₊) =ᵐ[μ] 0 := (lintegral_eq_zero_iff' hY.ennnorm).1 H,
     apply h'Y,
-    filter_upwards [I] with x hx,
-    simpa using hx },
+    filter_upwards [I] with ω hω,
+    simpa using hω },
   apply lt_top_iff_ne_top.2 (λ H, _),
-  have J : indep_fun (λ (a : Ω), ↑∥X a∥₊) (λ (a : Ω), ↑∥Y a∥₊) μ,
+  have J : indep_fun (λ ω, ↑∥X ω∥₊) (λ ω, ↑∥Y ω∥₊) μ,
   { have M : measurable (λ (x : β), (∥x∥₊ : ℝ≥0∞)) := measurable_nnnorm.coe_nnreal_ennreal,
     apply indep_fun.comp hXY M M },
-  have A : ∫⁻ x, ∥X x * Y x∥₊ ∂μ < ∞ := h'XY.2,
+  have A : ∫⁻ ω, ∥X ω * Y ω∥₊ ∂μ < ∞ := h'XY.2,
   simp only [nnnorm_mul, ennreal.coe_mul] at A,
   rw [lintegral_mul_eq_lintegral_mul_lintegral_of_indep_fun'' hX.ennnorm hY.ennnorm J, H] at A,
   simpa [ennreal.top_mul, I] using A,
 end
 
-/-- If product of two independent, integrable, real_valued random variables is integrable and the
+/-- If the product of two independent real_valued random variables is integrable and the
 first one is not almost everywhere zero, then the second one is integrable. -/
 lemma indep_fun.integrable_right_of_integrable_mul {β : Type*} [measurable_space β] {X Y : Ω → β}
   [normed_division_ring β] [borel_space β]
@@ -193,17 +193,17 @@ lemma indep_fun.integrable_right_of_integrable_mul {β : Type*} [measurable_spac
   integrable Y μ :=
 begin
   refine ⟨hY, _⟩,
-  have I : ∫⁻ x, ∥X x∥₊ ∂μ ≠ 0,
+  have I : ∫⁻ ω, ∥X ω∥₊ ∂μ ≠ 0,
   { assume H,
-    have I : (λ (a : Ω), ↑∥X a∥₊) =ᵐ[μ] 0 := (lintegral_eq_zero_iff' hX.ennnorm).1 H,
+    have I : (λ ω, ↑∥X ω∥₊) =ᵐ[μ] 0 := (lintegral_eq_zero_iff' hX.ennnorm).1 H,
     apply h'X,
-    filter_upwards [I] with x hx,
-    simpa using hx },
+    filter_upwards [I] with ω hω,
+    simpa using hω },
   apply lt_top_iff_ne_top.2 (λ H, _),
-  have J : indep_fun (λ (a : Ω), ↑∥X a∥₊) (λ (a : Ω), ↑∥Y a∥₊) μ,
+  have J : indep_fun (λ ω, ↑∥X ω∥₊) (λ ω, ↑∥Y ω∥₊) μ,
   { have M : measurable (λ (x : β), (∥x∥₊ : ℝ≥0∞)) := measurable_nnnorm.coe_nnreal_ennreal,
     apply indep_fun.comp hXY M M },
-  have A : ∫⁻ x, ∥X x * Y x∥₊ ∂μ < ∞ := h'XY.2,
+  have A : ∫⁻ ω, ∥X ω * Y ω∥₊ ∂μ < ∞ := h'XY.2,
   simp only [nnnorm_mul, ennreal.coe_mul] at A,
   rw [lintegral_mul_eq_lintegral_mul_lintegral_of_indep_fun'' hX.ennnorm hY.ennnorm J, H] at A,
   simpa [ennreal.top_mul, I] using A,
@@ -289,27 +289,27 @@ begin
   ring
 end
 
+/-- The (Bochner) integral of the product of two independent random
+  variables is the product of their integrals. -/
 theorem indep_fun.integral_mul (hXY : indep_fun X Y μ)
-  (hX : ae_measurable X μ) (hY : ae_measurable Y μ) :
+  (hX : ae_strongly_measurable X μ) (hY : ae_strongly_measurable Y μ) :
   integral μ (X * Y) = integral μ X * integral μ Y :=
 begin
   by_cases h'X : X =ᵐ[μ] 0,
   { have h' : X * Y =ᵐ[μ] 0,
-    { filter_upwards [h'X] with x hx,
-      simp [hx] },
+    { filter_upwards [h'X] with ω hω,
+      simp [hω] },
     simp only [integral_congr_ae h'X, integral_congr_ae h', pi.zero_apply, integral_const,
       algebra.id.smul_eq_mul, mul_zero, zero_mul] },
   by_cases h'Y : Y =ᵐ[μ] 0,
   { have h' : X * Y =ᵐ[μ] 0,
-    { filter_upwards [h'Y] with x hx,
-      simp [hx] },
+    { filter_upwards [h'Y] with ω hω,
+      simp [hω] },
     simp only [integral_congr_ae h'Y, integral_congr_ae h', pi.zero_apply, integral_const,
       algebra.id.smul_eq_mul, mul_zero, zero_mul] },
   by_cases h : integrable (X * Y) μ,
-  { have HX : integrable X μ := hXY.integrable_left_of_integrable_mul
-      h hX.ae_strongly_measurable hY.ae_strongly_measurable h'Y,
-    have HY : integrable Y μ := hXY.integrable_right_of_integrable_mul
-      h hX.ae_strongly_measurable hY.ae_strongly_measurable h'X,
+  { have HX : integrable X μ := hXY.integrable_left_of_integrable_mul h hX hY h'Y,
+    have HY : integrable Y μ := hXY.integrable_right_of_integrable_mul h hX hY h'X,
     exact hXY.integral_mul_of_integrable HX HY },
   { have I : ¬(integrable X μ ∧ integrable Y μ),
     { rintros ⟨HX, HY⟩,
@@ -320,8 +320,8 @@ begin
 end
 
 theorem indep_fun.integral_mul' (hXY : indep_fun X Y μ)
-  (hX : ae_measurable X μ) (hY : ae_measurable Y μ) :
-  integral μ (λ x, X x * Y x) = integral μ X * integral μ Y :=
+  (hX : ae_strongly_measurable X μ) (hY : ae_strongly_measurable Y μ) :
+  integral μ (λ ω, X ω * Y ω) = integral μ X * integral μ Y :=
 hXY.integral_mul hX hY
 
 /-- Independence of functions `f` and `g` into arbitrary types is characterized by the relation

--- a/src/probability/moments.lean
+++ b/src/probability/moments.lean
@@ -192,12 +192,25 @@ begin
 end
 
 lemma indep_fun.mgf_add {X Y : Ω → ℝ} (h_indep : indep_fun X Y μ)
-  (h_int_X : integrable (λ ω, exp (t * X ω)) μ)
-  (h_int_Y : integrable (λ ω, exp (t * Y ω)) μ) :
+  (hX : ae_strongly_measurable (λ ω, exp (t * X ω)) μ)
+  (hY : ae_strongly_measurable (λ ω, exp (t * Y ω)) μ) :
   mgf (X + Y) μ t = mgf X μ t * mgf Y μ t :=
 begin
   simp_rw [mgf, pi.add_apply, mul_add, exp_add],
-  exact (h_indep.exp_mul t t).integral_mul_of_integrable' h_int_X h_int_Y,
+  exact (h_indep.exp_mul t t).integral_mul hX hY,
+end
+
+lemma indep_fun.mgf_add' {X Y : Ω → ℝ} (h_indep : indep_fun X Y μ)
+  (hX : ae_strongly_measurable X μ)
+  (hY : ae_strongly_measurable Y μ) :
+  mgf (X + Y) μ t = mgf X μ t * mgf Y μ t :=
+begin
+  have A : continuous (λ (x : ℝ), exp (t * x)), by continuity,
+  have h'X : ae_strongly_measurable (λ ω, exp (t * X ω)) μ :=
+    A.ae_strongly_measurable.comp_ae_measurable hX.ae_measurable,
+  have h'Y : ae_strongly_measurable (λ ω, exp (t * Y ω)) μ :=
+    A.ae_strongly_measurable.comp_ae_measurable hY.ae_measurable,
+  exact h_indep.mgf_add h'X h'Y
 end
 
 lemma indep_fun.cgf_add {X Y : Ω → ℝ} (h_indep : indep_fun X Y μ)
@@ -207,8 +220,32 @@ lemma indep_fun.cgf_add {X Y : Ω → ℝ} (h_indep : indep_fun X Y μ)
 begin
   by_cases hμ : μ = 0,
   { simp [hμ], },
-  simp only [cgf, h_indep.mgf_add h_int_X h_int_Y],
+  simp only [cgf, h_indep.mgf_add h_int_X.ae_strongly_measurable h_int_Y.ae_strongly_measurable],
   exact log_mul (mgf_pos' hμ h_int_X).ne' (mgf_pos' hμ h_int_Y).ne',
+end
+
+lemma ae_strongly_measurable_exp_mul_add {X Y : Ω → ℝ}
+  (h_int_X : ae_strongly_measurable (λ ω, exp (t * X ω)) μ)
+  (h_int_Y : ae_strongly_measurable (λ ω, exp (t * Y ω)) μ) :
+  ae_strongly_measurable (λ ω, exp (t * (X + Y) ω)) μ :=
+begin
+  simp_rw [pi.add_apply, mul_add, exp_add],
+  exact ae_strongly_measurable.mul h_int_X h_int_Y,
+end
+
+lemma ae_strongly_measurable_exp_mul_sum {X : ι → Ω → ℝ} {s : finset ι}
+  (h_int : ∀ i ∈ s, ae_strongly_measurable (λ ω, exp (t * X i ω)) μ) :
+  ae_strongly_measurable (λ ω, exp (t * (∑ i in s, X i) ω)) μ :=
+begin
+  classical,
+  induction s using finset.induction_on with i s hi_notin_s h_rec h_int,
+  { simp only [pi.zero_apply, sum_apply, sum_empty, mul_zero, exp_zero],
+    exact ae_strongly_measurable_const, },
+  { have : ∀ (i : ι), i ∈ s → ae_strongly_measurable (λ (ω : Ω), exp (t * X i ω)) μ,
+      from λ i hi, h_int i (mem_insert_of_mem hi),
+    specialize h_rec this,
+    rw sum_insert hi_notin_s,
+    apply ae_strongly_measurable_exp_mul_add (h_int i (mem_insert_self _ _)) h_rec }
 end
 
 lemma indep_fun.integrable_exp_mul_add {X Y : Ω → ℝ} (h_indep : indep_fun X Y μ)
@@ -239,18 +276,18 @@ end
 
 lemma Indep_fun.mgf_sum [is_probability_measure μ]
   {X : ι → Ω → ℝ} (h_indep : Indep_fun (λ i, infer_instance) X μ) (h_meas : ∀ i, measurable (X i))
-  {s : finset ι} (h_int : ∀ i ∈ s, integrable (λ ω, exp (t * X i ω)) μ) :
+  {s : finset ι} :
   mgf (∑ i in s, X i) μ t = ∏ i in s, mgf (X i) μ t :=
 begin
   classical,
   induction s using finset.induction_on with i s hi_notin_s h_rec h_int,
   { simp only [sum_empty, mgf_zero_fun, measure_univ, ennreal.one_to_real, prod_empty], },
-  { have h_int' : ∀ (i : ι), i ∈ s → integrable (λ (ω : Ω), exp (t * X i ω)) μ,
-      from λ i hi, h_int i (mem_insert_of_mem hi),
+  { have h_int' : ∀ (i : ι), ae_strongly_measurable (λ (ω : Ω), exp (t * X i ω)) μ,
+      from λ i, ((h_meas i).const_mul t).exp.ae_strongly_measurable,
     rw [sum_insert hi_notin_s, indep_fun.mgf_add
-        (h_indep.indep_fun_finset_sum_of_not_mem h_meas hi_notin_s).symm
-        (h_int i (mem_insert_self _ _)) (h_indep.integrable_exp_mul_sum h_meas h_int'),
-      h_rec h_int', prod_insert hi_notin_s], },
+          (h_indep.indep_fun_finset_sum_of_not_mem h_meas hi_notin_s).symm (h_int' i)
+          (ae_strongly_measurable_exp_mul_sum (λ i hi, h_int' i)),
+        h_rec, prod_insert hi_notin_s] }
 end
 
 lemma Indep_fun.cgf_sum [is_probability_measure μ]
@@ -260,7 +297,7 @@ lemma Indep_fun.cgf_sum [is_probability_measure μ]
 begin
   simp_rw cgf,
   rw ← log_prod _ _ (λ j hj, _),
-  { rw h_indep.mgf_sum h_meas h_int, },
+  { rw h_indep.mgf_sum h_meas },
   { exact (mgf_pos (h_int j hj)).ne', },
 end
 

--- a/src/probability/moments.lean
+++ b/src/probability/moments.lean
@@ -201,8 +201,7 @@ begin
 end
 
 lemma indep_fun.mgf_add' {X Y : Ω → ℝ} (h_indep : indep_fun X Y μ)
-  (hX : ae_strongly_measurable X μ)
-  (hY : ae_strongly_measurable Y μ) :
+  (hX : ae_strongly_measurable X μ) (hY : ae_strongly_measurable Y μ) :
   mgf (X + Y) μ t = mgf X μ t * mgf Y μ t :=
 begin
   have A : continuous (λ (x : ℝ), exp (t * x)), by continuity,
@@ -276,7 +275,7 @@ end
 
 lemma Indep_fun.mgf_sum [is_probability_measure μ]
   {X : ι → Ω → ℝ} (h_indep : Indep_fun (λ i, infer_instance) X μ) (h_meas : ∀ i, measurable (X i))
-  {s : finset ι} :
+  (s : finset ι) :
   mgf (∑ i in s, X i) μ t = ∏ i in s, mgf (X i) μ t :=
 begin
   classical,

--- a/src/probability/variance.lean
+++ b/src/probability/variance.lean
@@ -224,11 +224,11 @@ begin
       (λ i hi, (mem_ℒp.integrable one_le_two (hs _ (mem_insert_of_mem hi)))),
       mul_sum, mul_sum, ← sum_sub_distrib],
     apply finset.sum_eq_zero (λ i hi, _),
-    rw [integral_mul_left, indep_fun.integral_mul_of_integrable', sub_self],
+    rw [integral_mul_left, indep_fun.integral_mul', sub_self],
     { apply h (mem_insert_self _ _) (mem_insert_of_mem hi),
       exact (λ hki, ks (hki.symm ▸ hi)) },
-    { exact mem_ℒp.integrable one_le_two (hs _ (mem_insert_self _ _)) },
-    { exact mem_ℒp.integrable one_le_two (hs _ (mem_insert_of_mem hi)) }
+    { exact mem_ℒp.ae_strongly_measurable (hs _ (mem_insert_self _ _)) },
+    { exact mem_ℒp.ae_strongly_measurable (hs _ (mem_insert_of_mem hi)) }
   end
   ... = Var[X k] + ∑ i in s, Var[X i] :
     by rw IH (λ i hi, hs i (mem_insert_of_mem hi))


### PR DESCRIPTION
The integral of a product of independent random variables is the product of the integrals. This is already in mathlib when the random variables are integrable, but it also holds when they are not integrable (as both sides are then zero). In this PR, we remove the integrability assumption from this statement (and weaken accordingly further results that depended on this one).

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
