### PR TITLE
[Merged by Bors] - feat(data/nat/{choose/multinomial,factorial/big_operations}): add multinomial coefficient definition with basic lemma's

### DIFF
--- a/src/data/nat/choose/multinomial.lean
+++ b/src/data/nat/choose/multinomial.lean
@@ -70,14 +70,14 @@ begin
   rw nat.mul_div_assoc _ (prod_factorial_dvd_factorial_sum _ _),
 end
 
-lemma multinomial_insert [decidable_eq α] (h : a ∉ s) {n : ℕ} :
+lemma multinomial_insert [decidable_eq α] (h : a ∉ s) :
   multinomial (insert a s) f = (f a + s.sum f).choose (f a) * multinomial s f :=
 begin
   rw choose_eq_factorial_div_factorial (le.intro rfl),
   simp only [multinomial, nat.add_sub_cancel_left, finset.sum_insert h, finset.prod_insert h,
-    h₁, function.comp_app],
-  rw [div_mul_div_comm (n.factorial_mul_factorial_dvd_factorial_add (s.sum f))
-    prod_factorial_dvd_factorial_sum _ _, mul_comm n! (s.sum f)!, mul_assoc,
+    function.comp_app],
+  rw [div_mul_div_comm ((f a).factorial_mul_factorial_dvd_factorial_add (s.sum f))
+    (prod_factorial_dvd_factorial_sum _ _), mul_comm (f a)! (s.sum f)!, mul_assoc,
     mul_comm _ (s.sum f)!, nat.mul_div_mul _ _ (factorial_pos _)],
 end
 
@@ -97,7 +97,7 @@ by simpa [finset.sum_pair hab, finset.prod_pair hab] using multinomial_spec {a, 
 
 @[simp] lemma binomial_one [decidable_eq α] (h : a ≠ b) (h₁ : f a = 1) :
   multinomial {a, b} f = (f b).succ :=
-by simp [multinomial_one {b} f (finset.not_mem_singleton.mpr h) h₁]
+by simp [multinomial_insert_one {b} f (finset.not_mem_singleton.mpr h) h₁]
 
 lemma binomial_succ_succ [decidable_eq α] (h : a ≠ b) :
   multinomial {a, b} (function.update (function.update f a (f a).succ) b (f b).succ) =

--- a/src/data/nat/choose/multinomial.lean
+++ b/src/data/nat/choose/multinomial.lean
@@ -7,6 +7,7 @@ Authors: Kyle Miller, Pim Otte
 import algebra.big_operators.fin
 import algebra.big_operators.order
 import data.nat.choose.basic
+import data.nat.factorial.big_operators
 import data.fin.vec_notation
 
 import tactic.linarith
@@ -35,19 +36,6 @@ from `s`, where `c ∈ s` appears with multiplicity `f c`.
 Defined as `(∑ i in s, f i)! / ∏ i in s, (f i)!`.
 -/
 def multinomial : ℕ := (∑ i in s, f i)! / ∏ i in s, (f i)!
-
-lemma prod_factorial_dvd_factorial_sum : (∏ i in s, (f i)!) ∣ (∑ i in s, f i)! :=
-begin
-  classical,
-  induction s using finset.induction with a' s' has ih,
-  { simp only [finset.sum_empty, finset.prod_empty, factorial], },
-  { simp only [finset.prod_insert has, finset.sum_insert has],
-    refine dvd_trans (mul_dvd_mul_left ((f a')!) ih) _,
-    apply nat.factorial_mul_factorial_dvd_factorial_add, },
-end
-
-lemma prod_factorial_pos : 0 < ∏ i in s, (f i)! :=
-finset.prod_pos (λ i _, factorial_pos (f i))
 
 lemma multinomial_pos : 0 < multinomial s f := nat.div_pos
   (le_of_dvd (factorial_pos _) (prod_factorial_dvd_factorial_sum s f)) (prod_factorial_pos s f)

--- a/src/data/nat/choose/multinomial.lean
+++ b/src/data/nat/choose/multinomial.lean
@@ -4,10 +4,13 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Pim Otte
 Heavily inspired by code from Kyle Miller and Kevin Buzzard
 -/
-import data.nat.choose.basic
-import data.list.perm
-import data.finset.basic
 import algebra.big_operators.basic
+import algebra.big_operators.fin
+import data.nat.choose.basic
+import data.finset.basic
+import data.list.perm
+import data.fin.vec_notation
+
 import tactic.linarith
 
 /-!
@@ -148,6 +151,21 @@ begin
     function.update_same, function.update_noteq (ne_comm.mp h)],
   convert succ_mul_choose_eq (f a + f b) (f a),
   exact succ_add (f a) (f b),
+end
+
+/-! ### Simple cases -/
+
+lemma multinomial_univ_two  (a b: ℕ) : multinomial finset.univ (![a, b]) = (a + b)! / (a! * b!) :=
+begin
+    unfold multinomial,
+    simp [fin.sum_univ_two, fin.prod_univ_two],
+end
+
+lemma multinomial_univ_three  (a b c: ℕ) : multinomial finset.univ (![a, b, c]) =
+  (a + b + c)! / (a! * b! * c!) :=
+begin
+    unfold multinomial,
+    simp [fin.sum_univ_three, fin.prod_univ_three],
 end
 
 end nat

--- a/src/data/nat/choose/multinomial.lean
+++ b/src/data/nat/choose/multinomial.lean
@@ -38,13 +38,11 @@ lemma prod_factorial_dvd_factorial_sum {α} (s : finset α) (f : α → ℕ) :
 begin
   classical,
   induction s using finset.induction with α' s' has ih,
-  { simp only [finset.sum_empty, finset.prod_empty, factorial],
-  },
+  { simp only [finset.sum_empty, finset.prod_empty, factorial], },
   { simp [finset.prod_insert has, finset.sum_insert has],
     refine dvd_trans (mul_dvd_mul_left ((f α')!) ih) _,
     convert factorial_mul_factorial_dvd_factorial (le.intro rfl),
-    rw nat.add_sub_cancel_left,
-  },
+    rw nat.add_sub_cancel_left, },
 end
 
 lemma mul_factorial_dvd_factorial_add (a b : ℕ) : a! * b! ∣ (a + b)! :=

--- a/src/data/nat/choose/multinomial.lean
+++ b/src/data/nat/choose/multinomial.lean
@@ -74,7 +74,7 @@ begin
   rw nat.mul_div_assoc _ (prod_factorial_dvd_factorial_sum _ _),
 end
 
-lemma multinomial_add_n [decidable_eq α] (h : a ∉ s) {n : ℕ} (h₁: f a = n) :
+lemma multinomial_add_n [decidable_eq α] (h : a ∉ s) {n : ℕ} (h₁ : f a = n) :
   multinomial (insert a s) f = (n + s.sum f).choose n * multinomial s f :=
 begin
   rw choose_eq_factorial_div_factorial (le.intro rfl),

--- a/src/data/nat/choose/multinomial.lean
+++ b/src/data/nat/choose/multinomial.lean
@@ -1,0 +1,153 @@
+/-
+Copyright (c) 2022 Pim Otte. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Pim Otte
+Heavily inspired by code from Kyle Miller and Kevin Buzzard
+-/
+import data.nat.choose.basic
+import data.list.perm
+import tactic
+
+/-!
+# Multinomial
+
+This file defines the multinomial coefficient and several small lemma's for manipulating it.
+
+## Main declarations
+
+- `nat.multinomial`: the multinomial coefficient
+
+-/
+
+open_locale nat
+
+namespace nat
+
+/-- The multinomial coefficient. Gives the number of strings consisting of symbols
+from `s`, where `c ∈ s` appears with multiplicity `f c`.
+
+Defined as `(s.sum f)! / s.prod (factorial ∘ f)`
+-/
+def multinomial {α} (s : finset α) (f : α → ℕ) : ℕ := (s.sum f)! / s.prod (factorial ∘ f)
+
+
+lemma prod_factorial_dvd_factorial_sum {α} (s : finset α) (f : α → ℕ) :
+  s.prod (factorial ∘ f) ∣ (s.sum f)! :=
+begin
+  classical,
+  induction s using finset.induction with α' s' has ih,
+  { simp only [finset.sum_empty, finset.prod_empty, factorial],
+  },
+  { simp [finset.prod_insert has, finset.sum_insert has],
+    refine dvd_trans (mul_dvd_mul_left ((f α')!) ih) _,
+    convert factorial_mul_factorial_dvd_factorial (le.intro rfl),
+    rw nat.add_sub_cancel_left,
+  },
+end
+
+lemma mul_factorial_dvd_factorial_add (a b : ℕ) : a! * b! ∣ (a + b)! :=
+begin
+  convert @factorial_mul_factorial_dvd_factorial (a + b) a (le.intro rfl),
+  rw nat.add_sub_cancel_left,
+end
+
+lemma prod_factorial_pos {α} (s : finset α) (f : α → ℕ) :
+  0 < s.prod (factorial ∘ f) :=
+begin
+  classical,
+  induction s using finset.induction with α' s' has ih,
+  { simp only [succ_pos', finset.prod_empty], },
+  { rw finset.prod_insert has,
+    exact nat.mul_pos (nat.factorial_pos (f α')) ih, },
+end
+
+lemma multinomial_pos {α} (s : finset α) (f : α → ℕ): 0 < multinomial s f :=
+nat.div_pos (le_of_dvd (factorial_pos _) (prod_factorial_dvd_factorial_sum s f))
+  (prod_factorial_pos s f)
+
+lemma multinomial_spec {α} (s : finset α) (f : α → ℕ):
+  s.prod (factorial ∘ f) * multinomial s f = (s.sum f)! :=
+begin
+  exact nat.mul_div_cancel' (prod_factorial_dvd_factorial_sum s f),
+end
+
+
+@[simp] lemma multinomial_nil {α} (f: α → ℕ): multinomial ∅ f = 1 := rfl
+
+@[simp] lemma multinomial_singleton {α} (f: α → ℕ) (a : α): multinomial {a} f = 1 :=
+by simp [multinomial, nat.div_self (factorial_pos (f a))]
+
+@[simp] lemma multinomial_one {α} [decidable_eq α]
+  (s : finset α) (f : α → ℕ) (a : α) (h: a ∉ s) (h₁: f a = 1):
+  multinomial (insert a s) f = (s.sum f).succ * multinomial s f :=
+begin
+  simp only [multinomial, one_mul, factorial],
+  rw [finset.sum_insert h, finset.prod_insert h, h₁, add_comm, ←succ_eq_add_one, factorial_succ],
+  simp only [factorial_one, one_mul, function.comp_app, factorial],
+  rw nat.mul_div_assoc _ (prod_factorial_dvd_factorial_sum _ _),
+end
+
+lemma multinomial_add_n {α} [decidable_eq α]
+  (s : finset α) (f : α → ℕ) (a : α) (h: a ∉ s) {n : ℕ} (h₁: f a = n) :
+  multinomial (insert a s) f = (n + (s.sum f)).choose n * multinomial s f :=
+begin
+  rw choose_eq_factorial_div_factorial (le.intro rfl),
+  simp [multinomial, nat.add_sub_cancel_left, finset.sum_insert h, finset.prod_insert h, h₁],
+  rw div_mul_div_comm (mul_factorial_dvd_factorial_add n (s.sum f))
+    (prod_factorial_dvd_factorial_sum _ _),
+  rw mul_comm n! (s.sum f)!,
+  rw mul_assoc,
+  rw mul_comm _ (s.sum f)!,
+  rw nat.mul_div_mul _ _ (factorial_pos (s.sum f)),
+end
+
+/-! ### Connection to binomial coefficients -/
+
+lemma binomial_eq {α} [decidable_eq α] (f: α → ℕ) (a b: α) (h: a ≠ b) :
+  multinomial {a, b} f = (f a + f b)! / ((f a)! * (f b)!) :=
+  by simp [multinomial, finset.sum_pair h, finset.prod_pair h]
+
+
+lemma binomial_eq_choose {α} [decidable_eq α] (f: α → ℕ) (a b: α) (h: a ≠ b) :
+  multinomial {a, b} f = (f a + f b).choose (f a) :=
+begin
+  have fact : f a ≤ f a + f b, by linarith,
+  simp [binomial_eq _ _ _ h, choose_eq_factorial_div_factorial fact],
+end
+
+lemma binomial_spec {α} [decidable_eq α] (f: α → ℕ) (a b: α) (hab: a ≠ b) :
+  (f a)! * (f b)! * multinomial {a, b} f  = (f a + f b)! :=
+begin
+  have h := multinomial_spec {a, b} f ,
+  simpa [finset.sum_pair hab, finset.prod_pair hab] using h,
+end
+
+@[simp] lemma binomial_one {α} [decidable_eq α] (f: α → ℕ) (a b: α) (h: a ≠ b) (h₁: f a = 1) :
+  multinomial {a, b} f = (f b).succ :=
+begin
+  rw multinomial_one {b} f a (finset.not_mem_singleton.mpr h) h₁,
+  simp,
+end
+
+lemma binomial_succ_succ {α} [decidable_eq α] (f: α → ℕ) (a b: α) (h: a ≠ b) :
+  multinomial {a, b} (function.update (function.update f a (f a).succ) b (f b).succ) =
+  multinomial {a, b} (function.update f a (f a).succ)
+  + multinomial {a, b} (function.update f b (f b).succ) :=
+begin
+  simp only [binomial_eq_choose, function.update_apply, function.update_noteq,
+    succ_add, add_succ, choose_succ_succ, h, ne.def, not_false_iff, function.update_same],
+  rw if_neg (ne_comm.mp h),
+  ring,
+end
+
+lemma succ_mul_binomial {α} [decidable_eq α] (f: α → ℕ) (a b: α) (h: a ≠ b) :
+  (f a + f b).succ * multinomial {a, b} f =
+  (f a).succ * multinomial {a, b} (function.update f a (f a).succ) :=
+begin
+  rw [binomial_eq_choose _ _ _ h, binomial_eq_choose _ _ _ h, mul_comm (f a).succ,
+    function.update_same, function.update_noteq (ne_comm.mp h)],
+  convert succ_mul_choose_eq (f a + f b) (f a),
+  exact succ_add (f a) (f b),
+end
+
+end nat

--- a/src/data/nat/choose/multinomial.lean
+++ b/src/data/nat/choose/multinomial.lean
@@ -33,31 +33,27 @@ variables {a b : α}
 /-- The multinomial coefficient. Gives the number of strings consisting of symbols
 from `s`, where `c ∈ s` appears with multiplicity `f c`.
 
-Defined as `(∑ i in s, f i)! / ∏ i in s, (factorial ∘ f) i`
+Defined as `(∑ i in s, f i)! / ∏ i in s, (f i)!`
 -/
-def multinomial : ℕ := (∑ i in s, f i)! / ∏ i in s, (factorial ∘ f) i
+def multinomial : ℕ := (∑ i in s, f i)! / ∏ i in s, (f i)!
 
-lemma prod_factorial_dvd_factorial_sum : s.prod (factorial ∘ f) ∣ (s.sum f)! :=
+lemma prod_factorial_dvd_factorial_sum : (∏ i in s, (f i)!) ∣ (∑ i in s, f i)! :=
 begin
   classical,
-  induction s using finset.induction with α' s' has ih,
+  induction s using finset.induction with a' s' has ih,
   { simp only [finset.sum_empty, finset.prod_empty, factorial], },
   { simp only [finset.prod_insert has, finset.sum_insert has],
-    refine dvd_trans (mul_dvd_mul_left ((f α')!) ih) _,
+    refine dvd_trans (mul_dvd_mul_left ((f a')!) ih) _,
     apply nat.factorial_mul_factorial_dvd_factorial_add, },
 end
 
-lemma prod_factorial_pos : 0 < s.prod (factorial ∘ f) :=
-begin
-  apply finset.prod_pos,
-  intros i hi,
-  exact factorial_pos (f i),
-end
+lemma prod_factorial_pos : 0 < ∏ i in s, (f i)! :=
+finset.prod_pos (λ i _, factorial_pos (f i))
 
-lemma multinomial_pos : 0 < multinomial s f := nat.div_pos (le_of_dvd (factorial_pos _)
-  (prod_factorial_dvd_factorial_sum s f)) (prod_factorial_pos s f)
+lemma multinomial_pos : 0 < multinomial s f := nat.div_pos
+  (le_of_dvd (factorial_pos _) (prod_factorial_dvd_factorial_sum s f)) (prod_factorial_pos s f)
 
-lemma multinomial_spec : s.prod (factorial ∘ f) * multinomial s f = (s.sum f)! :=
+lemma multinomial_spec : (∏ i in s, (f i)!) * multinomial s f = (∑ i in s, f i)! :=
 nat.mul_div_cancel' (prod_factorial_dvd_factorial_sum s f)
 
 @[simp] lemma multinomial_nil : multinomial ∅ f = 1 := rfl
@@ -65,7 +61,7 @@ nat.mul_div_cancel' (prod_factorial_dvd_factorial_sum s f)
 @[simp] lemma multinomial_singleton : multinomial {a} f = 1 :=
 by simp [multinomial, nat.div_self (factorial_pos (f a))]
 
-@[simp] lemma multinomial_one [decidable_eq α] (h : a ∉ s) (h₁ : f a = 1):
+@[simp] lemma multinomial_insert_one [decidable_eq α] (h : a ∉ s) (h₁ : f a = 1) :
   multinomial (insert a s) f = (s.sum f).succ * multinomial s f :=
 begin
   simp only [multinomial, one_mul, factorial],
@@ -74,14 +70,14 @@ begin
   rw nat.mul_div_assoc _ (prod_factorial_dvd_factorial_sum _ _),
 end
 
-lemma multinomial_add_n [decidable_eq α] (h : a ∉ s) {n : ℕ} (h₁ : f a = n) :
-  multinomial (insert a s) f = (n + s.sum f).choose n * multinomial s f :=
+lemma multinomial_insert [decidable_eq α] (h : a ∉ s) {n : ℕ} :
+  multinomial (insert a s) f = (f a + s.sum f).choose (f a) * multinomial s f :=
 begin
   rw choose_eq_factorial_div_factorial (le.intro rfl),
   simp only [multinomial, nat.add_sub_cancel_left, finset.sum_insert h, finset.prod_insert h,
     h₁, function.comp_app],
-  rw [div_mul_div_comm (nat.factorial_mul_factorial_dvd_factorial_add n (s.sum f))
-    (prod_factorial_dvd_factorial_sum _ _), mul_comm n! (s.sum f)!, mul_assoc,
+  rw [div_mul_div_comm (n.factorial_mul_factorial_dvd_factorial_add (s.sum f))
+    prod_factorial_dvd_factorial_sum _ _, mul_comm n! (s.sum f)!, mul_assoc,
     mul_comm _ (s.sum f)!, nat.mul_div_mul _ _ (factorial_pos _)],
 end
 
@@ -110,11 +106,12 @@ lemma binomial_succ_succ [decidable_eq α] (h : a ≠ b) :
 begin
   simp only [binomial_eq_choose, function.update_apply, function.update_noteq,
     succ_add, add_succ, choose_succ_succ, h, ne.def, not_false_iff, function.update_same],
-  rw if_neg (ne_comm.mp h),
+  rw if_neg h.symm,
   ring,
 end
 
-lemma succ_mul_binomial [decidable_eq α] (h : a ≠ b) : (f a + f b).succ * multinomial {a, b} f =
+lemma succ_mul_binomial [decidable_eq α] (h : a ≠ b) :
+  (f a + f b).succ * multinomial {a, b} f =
   (f a).succ * multinomial {a, b} (function.update f a (f a).succ) :=
 begin
   rw [binomial_eq_choose _ h, binomial_eq_choose _ h, mul_comm (f a).succ,

--- a/src/data/nat/choose/multinomial.lean
+++ b/src/data/nat/choose/multinomial.lean
@@ -82,7 +82,7 @@ begin
     h₁, function.comp_app],
   rw [div_mul_div_comm (nat.factorial_mul_factorial_dvd_factorial_add n (s.sum f))
     (prod_factorial_dvd_factorial_sum _ _), mul_comm n! (s.sum f)!, mul_assoc,
-    mul_comm _ (s.sum f)!, nat.mul_div_mul _ _ (factorial_pos (s.sum f))],
+    mul_comm _ (s.sum f)!, nat.mul_div_mul _ _ (factorial_pos _)],
 end
 
 /-! ### Connection to binomial coefficients -/

--- a/src/data/nat/choose/multinomial.lean
+++ b/src/data/nat/choose/multinomial.lean
@@ -6,7 +6,9 @@ Heavily inspired by code from Kyle Miller and Kevin Buzzard
 -/
 import data.nat.choose.basic
 import data.list.perm
-import tactic
+import data.finset.basic
+import algebra.big_operators.basic
+import tactic.linarith
 
 /-!
 # Multinomial

--- a/src/data/nat/choose/multinomial.lean
+++ b/src/data/nat/choose/multinomial.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2022 Pim Otte. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Pim Otte
+Authors: Kyle Miller, Pim Otte
 -/
 
 import algebra.big_operators.fin
@@ -22,8 +22,7 @@ This file defines the multinomial coefficient and several small lemma's for mani
 
 -/
 
-open_locale nat
-open_locale big_operators
+open_locale big_operators nat
 
 namespace nat
 
@@ -33,7 +32,7 @@ variables {a b : α}
 /-- The multinomial coefficient. Gives the number of strings consisting of symbols
 from `s`, where `c ∈ s` appears with multiplicity `f c`.
 
-Defined as `(∑ i in s, f i)! / ∏ i in s, (f i)!`
+Defined as `(∑ i in s, f i)! / ∏ i in s, (f i)!`.
 -/
 def multinomial : ℕ := (∑ i in s, f i)! / ∏ i in s, (f i)!
 

--- a/src/data/nat/factorial/big_operators.lean
+++ b/src/data/nat/factorial/big_operators.lean
@@ -9,7 +9,10 @@ import algebra.big_operators.order
 /-!
 # Factorial with big operators
 
-This file contains some lemma's on factorials in combination with big operators
+This file contains some lemmas on factorials in combination with big operators.
+
+While in terms of semantics they could be in the `basic.lean` file, importing 
+`algebra.big_operators.basic` leads to a cyclic import.
 
 -/
 

--- a/src/data/nat/factorial/big_operators.lean
+++ b/src/data/nat/factorial/big_operators.lean
@@ -1,0 +1,35 @@
+/-
+Copyright (c) 2022 Pim Otte. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Kyle Miller, Pim Otte
+-/
+import data.nat.factorial.basic
+import algebra.big_operators.order
+
+/-!
+# Factorial with big operators
+
+This file contains some lemma's on factorials in combination with big operators
+
+-/
+
+open_locale nat big_operators
+
+namespace nat
+
+variables {α : Type*} (s : finset α) (f : α → ℕ)
+
+lemma prod_factorial_pos : 0 < ∏ i in s, (f i)! :=
+finset.prod_pos (λ i _, factorial_pos (f i))
+
+lemma prod_factorial_dvd_factorial_sum : (∏ i in s, (f i)!) ∣ (∑ i in s, f i)! :=
+begin
+  classical,
+  induction s using finset.induction with a' s' has ih,
+  { simp only [finset.sum_empty, finset.prod_empty, factorial], },
+  { simp only [finset.prod_insert has, finset.sum_insert has],
+    refine dvd_trans (mul_dvd_mul_left ((f a')!) ih) _,
+    apply nat.factorial_mul_factorial_dvd_factorial_add, },
+end
+
+end nat


### PR DESCRIPTION
Chose a definition based on finset and a function for multiplicity. This allows the definition to be used in various context, including in a multiset context, where multiset.count yields the function describing multiplicity. Supporting lemma's concerning factorials are introduced in a new file, since importing big_operators in the main factorial file yields a circular import.

Co-authored-by: Kyle Miller <kmill31415@gmail.com>

---

I based a lot of this on [an old branch by Kyle Miller and Kevin Buzzard](https://github.com/leanprover-community/mathlib/tree/binomial/), however, I had some trouble when updating mathlib from there, so I took the liberty of making a new branch. It looks like bors squashes anyway, so I hope that won't be a problem?

I did not port all the lemma's over since I couldn't make some of them work. I'm looking to follow this up later with a proof of the multinomial theorem, possibly with some more lemma's that support that.

[Relevant thread on Zulip with discussion on the API](https://leanprover.zulipchat.com/#narrow/stream/113489-new-members/topic/Multinomial.20coefficients.20definition) 

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
