### PR TITLE
[Merged by Bors] - feat(number_theory/legendre_symbol/quadratic_reciprocity): switch to Gauss sum proof, clean-up

### DIFF
--- a/archive/imo/imo2008_q3.lean
+++ b/archive/imo/imo2008_q3.lean
@@ -33,7 +33,7 @@ lemma p_lemma (p : ℕ) (hpp : nat.prime p) (hp_mod_4_eq_1 : p ≡ 1 [MOD 4]) (h
 begin
   haveI := fact.mk hpp,
   have hp_mod_4_ne_3 : p % 4 ≠ 3, { linarith [(show p % 4 = 1, by exact hp_mod_4_eq_1)] },
-  obtain ⟨y, hy⟩ := (zmod.exists_sq_eq_neg_one_iff p).mpr hp_mod_4_ne_3,
+  obtain ⟨y, hy⟩ := zmod.exists_sq_eq_neg_one_iff.mpr hp_mod_4_ne_3,
 
   let m := zmod.val_min_abs y,
   let n := int.nat_abs m,

--- a/src/number_theory/legendre_symbol/gauss_eisenstein_lemmas.lean
+++ b/src/number_theory/legendre_symbol/gauss_eisenstein_lemmas.lean
@@ -162,7 +162,7 @@ begin
   have : (legendre_sym p a : zmod p) = (((-1)^((Ico 1 (p / 2).succ).filter
     (λ x : ℕ, p / 2 < (a * x : zmod p).val)).card : ℤ) : zmod p) :=
     by { rw [legendre_sym_eq_pow, legendre_symbol.gauss_lemma_aux p ha0]; simp },
-  cases legendre_sym_eq_one_or_neg_one p a ha0;
+  cases legendre_sym_eq_one_or_neg_one p ha0;
   cases neg_one_pow_eq_or ℤ ((Ico 1 (p / 2).succ).filter
     (λ x : ℕ, p / 2 < (a * x : zmod p).val)).card;
   simp [*, ne_neg_self p one_ne_zero, (ne_neg_self p one_ne_zero).symm] at *

--- a/src/number_theory/legendre_symbol/quadratic_char.lean
+++ b/src/number_theory/legendre_symbol/quadratic_char.lean
@@ -67,7 +67,7 @@ begin
 end
 
 @[simp]
-lemma quadratic_char_zero : quadratic_char_fun F 0 = 0 :=
+lemma quadratic_char_zero' : quadratic_char_fun F 0 = 0 :=
 by simp only [quadratic_char_fun, eq_self_iff_true, if_true, id.def]
 
 @[simp]
@@ -96,10 +96,10 @@ lemma quadratic_char_mul (a b : F) :
   quadratic_char_fun F (a * b) = quadratic_char_fun F a * quadratic_char_fun F b :=
 begin
   by_cases ha : a = 0,
-  { rw [ha, zero_mul, quadratic_char_zero, zero_mul], },
+  { rw [ha, zero_mul, quadratic_char_zero', zero_mul], },
   -- now `a ≠ 0`
   by_cases hb : b = 0,
-  { rw [hb, mul_zero, quadratic_char_zero, mul_zero], },
+  { rw [hb, mul_zero, quadratic_char_zero', mul_zero], },
   -- now `a ≠ 0` and `b ≠ 0`
   have hab := mul_ne_zero ha hb,
   by_cases hF : ring_char F = 2,
@@ -128,13 +128,17 @@ variables (F)
 { to_fun := quadratic_char_fun F,
   map_one' := quadratic_char_one,
   map_mul' := quadratic_char_mul,
-  map_nonunit' := λ a ha, by { rw of_not_not (mt ne.is_unit ha), exact quadratic_char_zero, } }
+  map_nonunit' := λ a ha, by { rw of_not_not (mt ne.is_unit ha), exact quadratic_char_zero', } }
 
 variables {F}
 
 /-- The value of the quadratic character on `a` is zero iff `a = 0`. -/
 lemma quadratic_char_eq_zero_iff {a : F} : quadratic_char F a = 0 ↔ a = 0 :=
 quadratic_char_eq_zero_iff'
+
+@[simp]
+lemma quadratic_char_zero : quadratic_char F 0 = 0 :=
+by simp only [quadratic_char_apply, quadratic_char_zero']
 
 /-- For nonzero `a : F`, `quadratic_char F a = 1 ↔ is_square a`. -/
 lemma quadratic_char_one_iff_is_square {a : F} (ha : a ≠ 0) :

--- a/src/number_theory/legendre_symbol/quadratic_char.lean
+++ b/src/number_theory/legendre_symbol/quadratic_char.lean
@@ -67,7 +67,7 @@ begin
 end
 
 @[simp]
-lemma quadratic_char_zero' : quadratic_char_fun F 0 = 0 :=
+lemma quadratic_char_fun_zero : quadratic_char_fun F 0 = 0 :=
 by simp only [quadratic_char_fun, eq_self_iff_true, if_true, id.def]
 
 @[simp]
@@ -96,10 +96,10 @@ lemma quadratic_char_mul (a b : F) :
   quadratic_char_fun F (a * b) = quadratic_char_fun F a * quadratic_char_fun F b :=
 begin
   by_cases ha : a = 0,
-  { rw [ha, zero_mul, quadratic_char_zero', zero_mul], },
+  { rw [ha, zero_mul, quadratic_char_fun_zero, zero_mul], },
   -- now `a ≠ 0`
   by_cases hb : b = 0,
-  { rw [hb, mul_zero, quadratic_char_zero', mul_zero], },
+  { rw [hb, mul_zero, quadratic_char_fun_zero, mul_zero], },
   -- now `a ≠ 0` and `b ≠ 0`
   have hab := mul_ne_zero ha hb,
   by_cases hF : ring_char F = 2,
@@ -128,7 +128,7 @@ variables (F)
 { to_fun := quadratic_char_fun F,
   map_one' := quadratic_char_one,
   map_mul' := quadratic_char_mul,
-  map_nonunit' := λ a ha, by { rw of_not_not (mt ne.is_unit ha), exact quadratic_char_zero', } }
+  map_nonunit' := λ a ha, by { rw of_not_not (mt ne.is_unit ha), exact quadratic_char_fun_zero, } }
 
 variables {F}
 
@@ -138,7 +138,7 @@ quadratic_char_eq_zero_iff'
 
 @[simp]
 lemma quadratic_char_zero : quadratic_char F 0 = 0 :=
-by simp only [quadratic_char_apply, quadratic_char_zero']
+by simp only [quadratic_char_apply, quadratic_char_fun_zero]
 
 /-- For nonzero `a : F`, `quadratic_char F a = 1 ↔ is_square a`. -/
 lemma quadratic_char_one_iff_is_square {a : F} (ha : a ≠ 0) :

--- a/src/number_theory/legendre_symbol/quadratic_char.lean
+++ b/src/number_theory/legendre_symbol/quadratic_char.lean
@@ -31,7 +31,7 @@ It takes the value zero at zero; for non-zero argument `a : α`, it is `1`
 if `a` is a square, otherwise it is `-1`.
 
 This only deserves the name "character" when it is multiplicative,
-e.g., when `α` is a finite field. See `quadratic_char_mul`.
+e.g., when `α` is a finite field. See `quadratic_char_fun_mul`.
 
 We will later define `quadratic_char` to be a multiplicative character
 of type `mul_char F ℤ`, when the domain is a finite field `F`.
@@ -57,7 +57,7 @@ open mul_char
 variables {F : Type*} [field F] [fintype F] [decidable_eq F]
 
 /-- Some basic API lemmas -/
-lemma quadratic_char_eq_zero_iff' {a : F} : quadratic_char_fun F a = 0 ↔ a = 0 :=
+lemma quadratic_char_fun_eq_zero_iff {a : F} : quadratic_char_fun F a = 0 ↔ a = 0 :=
 begin
   simp only [quadratic_char_fun],
   by_cases ha : a = 0,
@@ -71,11 +71,11 @@ lemma quadratic_char_fun_zero : quadratic_char_fun F 0 = 0 :=
 by simp only [quadratic_char_fun, eq_self_iff_true, if_true, id.def]
 
 @[simp]
-lemma quadratic_char_one : quadratic_char_fun F 1 = 1 :=
+lemma quadratic_char_fun_one : quadratic_char_fun F 1 = 1 :=
 by simp only [quadratic_char_fun, one_ne_zero, is_square_one, if_true, if_false, id.def]
 
 /-- If `ring_char F = 2`, then `quadratic_char_fun F` takes the value `1` on nonzero elements. -/
-lemma quadratic_char_eq_one_of_char_two' (hF : ring_char F = 2) {a : F} (ha : a ≠ 0) :
+lemma quadratic_char_fun_eq_one_of_char_two (hF : ring_char F = 2) {a : F} (ha : a ≠ 0) :
   quadratic_char_fun F a = 1 :=
 begin
   simp only [quadratic_char_fun, ha, if_false, ite_eq_left_iff],
@@ -84,7 +84,7 @@ end
 
 /-- If `ring_char F` is odd, then `quadratic_char_fun F a` can be computed in
 terms of `a ^ (fintype.card F / 2)`. -/
-lemma quadratic_char_eq_pow_of_char_ne_two' (hF : ring_char F ≠ 2) {a : F} (ha : a ≠ 0) :
+lemma quadratic_char_fun_eq_pow_of_char_ne_two (hF : ring_char F ≠ 2) {a : F} (ha : a ≠ 0) :
   quadratic_char_fun F a = if a ^ (fintype.card F / 2) = 1 then 1 else -1 :=
 begin
   simp only [quadratic_char_fun, ha, if_false],
@@ -92,7 +92,7 @@ begin
 end
 
 /-- The quadratic character is multiplicative. -/
-lemma quadratic_char_mul (a b : F) :
+lemma quadratic_char_fun_mul (a b : F) :
   quadratic_char_fun F (a * b) = quadratic_char_fun F a * quadratic_char_fun F b :=
 begin
   by_cases ha : a = 0,
@@ -104,14 +104,14 @@ begin
   have hab := mul_ne_zero ha hb,
   by_cases hF : ring_char F = 2,
   { -- case `ring_char F = 2`
-    rw [quadratic_char_eq_one_of_char_two' hF ha,
-        quadratic_char_eq_one_of_char_two' hF hb,
-        quadratic_char_eq_one_of_char_two' hF hab,
+    rw [quadratic_char_fun_eq_one_of_char_two hF ha,
+        quadratic_char_fun_eq_one_of_char_two hF hb,
+        quadratic_char_fun_eq_one_of_char_two hF hab,
         mul_one], },
   { -- case of odd characteristic
-    rw [quadratic_char_eq_pow_of_char_ne_two' hF ha,
-        quadratic_char_eq_pow_of_char_ne_two' hF hb,
-        quadratic_char_eq_pow_of_char_ne_two' hF hab,
+    rw [quadratic_char_fun_eq_pow_of_char_ne_two hF ha,
+        quadratic_char_fun_eq_pow_of_char_ne_two hF hb,
+        quadratic_char_fun_eq_pow_of_char_ne_two hF hab,
         mul_pow],
     cases finite_field.pow_dichotomy hF hb with hb' hb',
     { simp only [hb', mul_one, eq_self_iff_true, if_true], },
@@ -126,15 +126,15 @@ variables (F)
 /-- The quadratic character as a multiplicative character. -/
 @[simps] def quadratic_char : mul_char F ℤ :=
 { to_fun := quadratic_char_fun F,
-  map_one' := quadratic_char_one,
-  map_mul' := quadratic_char_mul,
+  map_one' := quadratic_char_fun_one,
+  map_mul' := quadratic_char_fun_mul,
   map_nonunit' := λ a ha, by { rw of_not_not (mt ne.is_unit ha), exact quadratic_char_fun_zero, } }
 
 variables {F}
 
 /-- The value of the quadratic character on `a` is zero iff `a = 0`. -/
 lemma quadratic_char_eq_zero_iff {a : F} : quadratic_char F a = 0 ↔ a = 0 :=
-quadratic_char_eq_zero_iff'
+quadratic_char_fun_eq_zero_iff
 
 @[simp]
 lemma quadratic_char_zero : quadratic_char F 0 = 0 :=
@@ -185,15 +185,15 @@ lemma quadratic_char_exists_neg_one (hF : ring_char F ≠ 2) : ∃ a, quadratic_
 /-- If `ring_char F = 2`, then `quadratic_char F` takes the value `1` on nonzero elements. -/
 lemma quadratic_char_eq_one_of_char_two (hF : ring_char F = 2) {a : F} (ha : a ≠ 0) :
   quadratic_char F a = 1 :=
-quadratic_char_eq_one_of_char_two' hF ha
+quadratic_char_fun_eq_one_of_char_two hF ha
 
 /-- If `ring_char F` is odd, then `quadratic_char F a` can be computed in
 terms of `a ^ (fintype.card F / 2)`. -/
 lemma quadratic_char_eq_pow_of_char_ne_two (hF : ring_char F ≠ 2) {a : F} (ha : a ≠ 0) :
   quadratic_char F a = if a ^ (fintype.card F / 2) = 1 then 1 else -1 :=
-quadratic_char_eq_pow_of_char_ne_two' hF ha
+quadratic_char_fun_eq_pow_of_char_ne_two hF ha
 
-lemma quadratic_char_eq_pow_of_char_ne_two'' (hF : ring_char F ≠ 2) (a : F) :
+lemma quadratic_char_eq_pow_of_char_ne_two' (hF : ring_char F ≠ 2) (a : F) :
   (quadratic_char F a : F) = a ^ (fintype.card F / 2) :=
 begin
   by_cases ha : a = 0,
@@ -322,7 +322,7 @@ end
 lemma quadratic_char_two [decidable_eq F] (hF : ring_char F ≠ 2) :
   quadratic_char F 2 = χ₈ (fintype.card F) :=
 is_quadratic.eq_of_eq_coe (quadratic_char_is_quadratic F) is_quadratic_χ₈ hF
-  ((quadratic_char_eq_pow_of_char_ne_two'' hF 2).trans (finite_field.two_pow_card hF))
+  ((quadratic_char_eq_pow_of_char_ne_two' hF 2).trans (finite_field.two_pow_card hF))
 
 /-- `2` is a square in `F` iff `#F` is not congruent to `3` or `5` mod `8`. -/
 lemma finite_field.is_square_two_iff :
@@ -398,7 +398,7 @@ begin
     exact ring.neg_one_ne_one_of_char_ne_two hF', },
   have hχ₂ : χ.is_quadratic := is_quadratic.comp (quadratic_char_is_quadratic F) _,
   have h := char.card_pow_card hχ₁ hχ₂ h hF',
-  rw [← quadratic_char_eq_pow_of_char_ne_two'' hF'] at h,
+  rw [← quadratic_char_eq_pow_of_char_ne_two' hF'] at h,
   exact (is_quadratic.eq_of_eq_coe (quadratic_char_is_quadratic F')
              (quadratic_char_is_quadratic F) hF' h).symm,
 end

--- a/src/number_theory/legendre_symbol/quadratic_reciprocity.lean
+++ b/src/number_theory/legendre_symbol/quadratic_reciprocity.lean
@@ -208,8 +208,7 @@ quadratic_char_card_sqrts (ne_of_eq_of_ne (ring_char_zmod_n p) hp) a
 /-- `legendre_sym p (-1)` is given by `χ₄ p`. -/
 lemma legendre_sym_neg_one (hp : p ≠ 2) : legendre_sym p (-1) = χ₄ p :=
 begin
-  have h : ring_char (zmod p) ≠ 2 := by { rw ring_char_zmod_n, exact hp, },
-  have h₁ := quadratic_char_neg_one h,
+  have h₁ := quadratic_char_neg_one (ne_of_eq_of_ne (ring_char_zmod_n p) hp),
   rw card p at h₁,
   exact_mod_cast h₁,
 end

--- a/src/number_theory/legendre_symbol/quadratic_reciprocity.lean
+++ b/src/number_theory/legendre_symbol/quadratic_reciprocity.lean
@@ -203,10 +203,7 @@ quadratic_char_neg_one_iff_not_is_square
 /-- The number of square roots of `a` modulo `p` is determined by the Legendre symbol. -/
 lemma legendre_sym_card_sqrts (hp : p ≠ 2) (a : ℤ) :
   ↑{x : zmod p | x^2 = a}.to_finset.card = legendre_sym p a + 1 :=
-begin
-  have h : ring_char (zmod p) ≠ 2 := by { rw ring_char_zmod_n, exact hp, },
-  exact quadratic_char_card_sqrts h a,
-end
+quadratic_char_card_sqrts (ne_of_eq_of_ne (ring_char_zmod_n p) hp) a
 
 /-- `legendre_sym p (-1)` is given by `χ₄ p`. -/
 lemma legendre_sym_neg_one (hp : p ≠ 2) : legendre_sym p (-1) = χ₄ p :=

--- a/src/number_theory/legendre_symbol/quadratic_reciprocity.lean
+++ b/src/number_theory/legendre_symbol/quadratic_reciprocity.lean
@@ -226,13 +226,18 @@ begin
 end
 
 /-- **Quadratic reciprocity theorem** -/
-theorem quadratic_reciprocity (hp1 : p ≠ 2) (hq1 : q ≠ 2) (hpq : p ≠ q) :
+theorem quadratic_reciprocity (hp : p ≠ 2) (hq : q ≠ 2) (hpq : p ≠ q) :
   legendre_sym q p * legendre_sym p q = (-1) ^ ((p / 2) * (q / 2)) :=
-have hpq0 : (p : zmod q) ≠ 0, from prime_ne_zero q p hpq.symm,
-have hqp0 : (q : zmod p) ≠ 0, from prime_ne_zero p q hpq,
-by rw [eisenstein_lemma q hq1 (nat.prime.mod_two_eq_one_iff_ne_two.mpr hp1) hpq0,
-       eisenstein_lemma p hp1 (nat.prime.mod_two_eq_one_iff_ne_two.mpr hq1) hqp0,
-  ← pow_add, legendre_symbol.sum_mul_div_add_sum_mul_div_eq_mul q p hpq0, mul_comm]
+begin
+  have h := quadratic_char_odd_prime (ne_of_eq_of_ne (ring_char_zmod_n p) hp) hq
+              (ne_of_eq_of_ne (ring_char_zmod_n p) hpq),
+  rw [card p] at h,
+  have nc : ∀ (n r : ℕ), ((n : ℤ) : zmod r) = n := by {intros n r, norm_cast},
+  rw [legendre_sym, legendre_sym, nc, nc, h, map_mul, mul_rotate', ← pow_two,
+      quadratic_char_sq_one, mul_one],
+  have := nat.odd_mod_four_iff.mp ((nat.prime.eq_two_or_odd (fact.out p.prime)).resolve_left hp),
+  sorry
+end
 
 lemma legendre_sym_two (hp : p ≠ 2) : legendre_sym p 2 = χ₈ p :=
 begin

--- a/src/number_theory/legendre_symbol/quadratic_reciprocity.lean
+++ b/src/number_theory/legendre_symbol/quadratic_reciprocity.lean
@@ -166,11 +166,7 @@ quadratic_char_sq_one ha
 /-- The Legendre symbol of `a^2` at `p` is 1 if `p ∤ a`. -/
 theorem legendre_sym_sq_one'  (p : ℕ) [fact p.prime] (a : ℤ) (ha : (a : zmod p) ≠ 0) :
   legendre_sym p (a ^ 2) = 1 :=
-begin
-  rw [legendre_sym],
-  push_cast,
-  exact quadratic_char_sq_one' ha,
-end
+by exact_mod_cast quadratic_char_sq_one' ha
 
 /-- The Legendre symbol depends only on `a` mod `p`. -/
 theorem legendre_sym_mod (p : ℕ) [fact p.prime] (a : ℤ) :

--- a/src/number_theory/legendre_symbol/quadratic_reciprocity.lean
+++ b/src/number_theory/legendre_symbol/quadratic_reciprocity.lean
@@ -234,55 +234,21 @@ by rw [eisenstein_lemma q hq1 (nat.prime.mod_two_eq_one_iff_ne_two.mpr hp1) hpq0
        eisenstein_lemma p hp1 (nat.prime.mod_two_eq_one_iff_ne_two.mpr hq1) hqp0,
   ← pow_add, legendre_symbol.sum_mul_div_add_sum_mul_div_eq_mul q p hpq0, mul_comm]
 
-lemma legendre_sym_two (hp2 : p ≠ 2) : legendre_sym p 2 = (-1) ^ (p / 4 + p / 2) :=
+lemma legendre_sym_two (hp : p ≠ 2) : legendre_sym p 2 = χ₈ p :=
 begin
-  have hp1 := nat.prime.mod_two_eq_one_iff_ne_two.mpr hp2,
-  have hp22 : p / 2 / 2 = _ := legendre_symbol.div_eq_filter_card (show 0 < 2, from dec_trivial)
-    (nat.div_le_self (p / 2) 2),
-  have hcard : (Ico 1 (p / 2).succ).card = p / 2, by simp,
-  have hx2 : ∀ x ∈ Ico 1 (p / 2).succ, (2 * x : zmod p).val = 2 * x,
-    from λ x hx, have h2xp : 2 * x < p,
-        from calc 2 * x ≤ 2 * (p / 2) : mul_le_mul_of_nonneg_left
-          (le_of_lt_succ $ (mem_Ico.mp hx).2) dec_trivial
-        ... < _ : by conv_rhs {rw [← div_add_mod p 2, hp1]}; exact lt_succ_self _,
-      by rw [← nat.cast_two, ← nat.cast_mul, val_cast_of_lt h2xp],
-  have hdisj : disjoint
-      ((Ico 1 (p / 2).succ).filter (λ x, p / 2 < ((2 : ℕ) * x : zmod p).val))
-      ((Ico 1 (p / 2).succ).filter (λ x, x * 2 ≤ p / 2)),
-    from disjoint_filter.2 (λ x hx, by { rw [nat.cast_two, hx2 x hx, mul_comm], simp }),
-  have hunion :
-      ((Ico 1 (p / 2).succ).filter (λ x, p / 2 < ((2 : ℕ) * x : zmod p).val)) ∪
-      ((Ico 1 (p / 2).succ).filter (λ x, x * 2 ≤ p / 2)) =
-      Ico 1 (p / 2).succ,
-    begin
-      rw [filter_union_right],
-      conv_rhs {rw [← @filter_true _ (Ico 1 (p / 2).succ)]},
-      exact filter_congr (λ x hx,
-        by rw [nat.cast_two, hx2 x hx, mul_comm, iff_true_intro (lt_or_le _ _)])
-    end,
-  have hp2' := prime_ne_zero p 2 hp2,
-  rw (by norm_cast : ((2 : ℕ) : zmod p) = (2 : ℤ)) at *,
-  erw [gauss_lemma p hp2 hp2',
-      neg_one_pow_eq_pow_mod_two, @neg_one_pow_eq_pow_mod_two _ _ (p / 4 + p / 2)],
-  refine congr_arg2 _ rfl ((eq_iff_modeq_nat 2).1 _),
-  rw [show 4 = 2 * 2, from rfl, ← nat.div_div_eq_div_mul, hp22, nat.cast_add,
-      ← sub_eq_iff_eq_add', sub_eq_add_neg, neg_eq_self_mod_two,
-      ← nat.cast_add, ← card_disjoint_union hdisj, hunion, hcard]
+  have h := quadratic_char_two (ne_of_eq_of_ne (ring_char_zmod_n p) hp),
+  rw [card p] at h,
+  rw [legendre_sym],
+  exact_mod_cast h,
 end
 
-lemma exists_sq_eq_two_iff (hp1 : p ≠ 2) :
-  is_square (2 : zmod p) ↔ p % 8 = 1 ∨ p % 8 = 7 :=
+lemma exists_sq_eq_two_iff (hp : p ≠ 2) : is_square (2 : zmod p) ↔ p % 8 = 1 ∨ p % 8 = 7 :=
 begin
-  have hp2 : ((2 : ℤ) : zmod p) ≠ 0, by exact_mod_cast prime_ne_zero p 2 hp1,
-  have hpm4 : p % 4 = p % 8 % 4, from (nat.mod_mul_left_mod p 2 4).symm,
-  have hpm2 : p % 2 = p % 8 % 2, from (nat.mod_mul_left_mod p 4 2).symm,
-  rw [show (2 : zmod p) = (2 : ℤ), by simp, ← legendre_sym_eq_one_iff p hp2],
-  erw [legendre_sym_two p hp1, neg_one_pow_eq_one_iff_even (show (-1 : ℤ) ≠ 1, from dec_trivial),
-    even_add, even_div, even_div],
-  have := nat.mod_lt p (show 0 < 8, from dec_trivial),
-  have hp := nat.prime.mod_two_eq_one_iff_ne_two.mpr hp1,
-  revert this hp,
-  erw [hpm4, hpm2],
+  rw [finite_field.is_square_two_iff, card p],
+  have h₁ := nat.prime.mod_two_eq_one_iff_ne_two.mpr hp,
+  rw [← nat.mod_mod_of_dvd p (by norm_num : 2 ∣ 8)] at h₁,
+  have h₂ := mod_lt p (by norm_num : 0 < 8),
+  revert h₂ h₁,
   generalize hm : p % 8 = m, unfreezingI {clear_dependent p},
   dec_trivial!,
 end

--- a/src/number_theory/legendre_symbol/quadratic_reciprocity.lean
+++ b/src/number_theory/legendre_symbol/quadratic_reciprocity.lean
@@ -66,10 +66,7 @@ lemma exists_sq_eq_neg_one_iff : is_square (-1 : zmod p) ↔ p % 4 ≠ 3 :=
 by rw [finite_field.is_square_neg_one_iff, card p]
 
 lemma mod_four_ne_three_of_sq_eq_neg_one {y : zmod p} (hy : y ^ 2 = -1) : p % 4 ≠ 3 :=
-begin
-  rw pow_two at hy,
-  exact (exists_sq_eq_neg_one_iff p).1 ⟨y, hy.symm⟩
-end
+(exists_sq_eq_neg_one_iff p).1 ⟨y, hy.symm.trans (pow_two y)⟩
 
 lemma mod_four_ne_three_of_sq_eq_neg_sq' {x y : zmod p} (hy : y ≠ 0) (hxy : x ^ 2 = - y ^ 2) :
   p % 4 ≠ 3 :=

--- a/src/number_theory/legendre_symbol/quadratic_reciprocity.lean
+++ b/src/number_theory/legendre_symbol/quadratic_reciprocity.lean
@@ -63,11 +63,7 @@ begin
 end
 
 lemma exists_sq_eq_neg_one_iff : is_square (-1 : zmod p) ↔ p % 4 ≠ 3 :=
-begin
-  have h := @finite_field.is_square_neg_one_iff (zmod p) _ _,
-  rw card p at h,
-  exact h,
-end
+by rw [finite_field.is_square_neg_one_iff, card p]
 
 lemma mod_four_ne_three_of_sq_eq_neg_one {y : zmod p} (hy : y ^ 2 = -1) : p % 4 ≠ 3 :=
 begin

--- a/src/number_theory/legendre_symbol/quadratic_reciprocity.lean
+++ b/src/number_theory/legendre_symbol/quadratic_reciprocity.lean
@@ -108,20 +108,18 @@ def legendre_sym (p : ℕ) [fact p.prime] (a : ℤ) : ℤ := quadratic_char (zmo
 lemma legendre_sym_eq_pow (p : ℕ) (a : ℤ) [hp : fact p.prime] :
   (legendre_sym p a : zmod p) = (a ^ (p / 2)) :=
 begin
-  rw legendre_sym,
-  by_cases ha : (a : zmod p) = 0,
-  { simp only [ha, zero_pow (nat.div_pos (hp.1.two_le) (succ_pos 1)), mul_char.map_zero,
-               int.cast_zero], },
-  by_cases hp₁ : p = 2,
-  { substI p,
-    generalize : (a : (zmod 2)) = b, revert b, dec_trivial, },
-  { have h₁ := quadratic_char_eq_pow_of_char_ne_two (by rwa ring_char_zmod_n p) ha,
-    rw card p at h₁,
-    rw h₁,
-    have h₂ := ring.neg_one_ne_one_of_char_ne_two (by rwa ring_char_zmod_n p),
-    cases pow_div_two_eq_neg_one_or_one p ha with h h,
-    { rw [if_pos h, h, int.cast_one], },
-    { rw [h, if_neg h₂, int.cast_neg, int.cast_one], } }
+  cases eq_or_ne (ring_char (zmod p)) 2 with hc hc,
+  { by_cases ha : (a : zmod p) = 0,
+    { rw [legendre_sym, ha, quadratic_char_zero,
+          zero_pow (nat.div_pos (hp.1.two_le) (succ_pos 1))],
+      norm_cast, },
+    { have := (ring_char_zmod_n p).symm.trans hc, -- p = 2
+      substI p,
+      rw [legendre_sym, quadratic_char_eq_one_of_char_two hc ha],
+      revert ha,
+      generalize : (a : (zmod 2)) = b, revert b, dec_trivial } },
+  { convert quadratic_char_eq_pow_of_char_ne_two'' hc (a : zmod p),
+    { exact (card p).symm }, },
 end
 
 /-- If `p ∤ a`, then `legendre_sym p a` is `1` or `-1`. -/

--- a/src/number_theory/legendre_symbol/quadratic_reciprocity.lean
+++ b/src/number_theory/legendre_symbol/quadratic_reciprocity.lean
@@ -119,7 +119,7 @@ begin
       revert ha,
       generalize : (a : (zmod 2)) = b, revert b, dec_trivial } },
   { convert quadratic_char_eq_pow_of_char_ne_two'' hc (a : zmod p),
-    { exact (card p).symm }, },
+    exact (card p).symm },
 end
 
 /-- If `p ∤ a`, then `legendre_sym p a` is `1` or `-1`. -/

--- a/src/number_theory/legendre_symbol/quadratic_reciprocity.lean
+++ b/src/number_theory/legendre_symbol/quadratic_reciprocity.lean
@@ -222,6 +222,25 @@ begin
   dec_trivial!,
 end
 
+lemma legendre_sym_neg_two (hp : p ≠ 2) : legendre_sym p (-2) = χ₈' p :=
+begin
+  have h := quadratic_char_neg_two (ne_of_eq_of_ne (ring_char_zmod_n p) hp),
+  rw [card p] at h,
+  rw [legendre_sym],
+  exact_mod_cast h,
+end
+
+lemma exists_sq_eq_neg_two_iff (hp : p ≠ 2) : is_square (-2 : zmod p) ↔ p % 8 = 1 ∨ p % 8 = 3 :=
+begin
+  rw [finite_field.is_square_neg_two_iff, card p],
+  have h₁ := nat.prime.mod_two_eq_one_iff_ne_two.mpr hp,
+  rw [← nat.mod_mod_of_dvd p (by norm_num : 2 ∣ 8)] at h₁,
+  have h₂ := mod_lt p (by norm_num : 0 < 8),
+  revert h₂ h₁,
+  generalize hm : p % 8 = m, unfreezingI {clear_dependent p},
+  dec_trivial!,
+end
+
 /-- **Quadratic reciprocity theorem** -/
 theorem quadratic_reciprocity (hp : p ≠ 2) (hq : q ≠ 2) (hpq : p ≠ q) :
   legendre_sym q p * legendre_sym p q = (-1) ^ ((p / 2) * (q / 2)) :=

--- a/src/number_theory/legendre_symbol/quadratic_reciprocity.lean
+++ b/src/number_theory/legendre_symbol/quadratic_reciprocity.lean
@@ -39,11 +39,13 @@ properties of quadratic Gauss sums as provided by `number_theory.legendre_symbol
 quadratic residue, quadratic nonresidue, Legendre symbol, quadratic reciprocity
 -/
 
-open finset nat char
+open nat
 
 namespace zmod
 
-variables (p q : ℕ) [fact p.prime] [fact q.prime]
+section euler
+
+variables (p : ℕ) [fact p.prime]
 
 /-- Euler's Criterion: A unit `x` of `zmod p` is a square if and only if `x ^ (p / 2) = 1`. -/
 lemma euler_criterion_units (x : (zmod p)ˣ) :
@@ -82,9 +84,16 @@ begin
   exact pow_card_sub_one_eq_one ha
 end
 
+end euler
+
+section legendre
+
 /-!
 ### Definition of the Legendre symbol and basic properties
 -/
+
+variables (p : ℕ) [hpp : fact p.prime]
+include hpp
 
 /-- The Legendre symbol of `a : ℤ` and a prime `p`, `legendre_sym p a`,
 is an integer defined as
@@ -96,16 +105,15 @@ is an integer defined as
 Note the order of the arguments! The advantage of the order chosen here is
 that `legendre_sym p` is a multiplicative function `ℤ → ℤ`.
 -/
-def legendre_sym (p : ℕ) [fact p.prime] (a : ℤ) : ℤ := quadratic_char (zmod p) a
+def legendre_sym (a : ℤ) : ℤ := quadratic_char (zmod p) a
 
 /-- We have the congruence `legendre_sym p a ≡ a ^ (p / 2) mod p`. -/
-lemma legendre_sym_eq_pow (p : ℕ) (a : ℤ) [hp : fact p.prime] :
-  (legendre_sym p a : zmod p) = (a ^ (p / 2)) :=
+lemma legendre_sym_eq_pow (a : ℤ) : (legendre_sym p a : zmod p) = (a ^ (p / 2)) :=
 begin
   cases eq_or_ne (ring_char (zmod p)) 2 with hc hc,
   { by_cases ha : (a : zmod p) = 0,
     { rw [legendre_sym, ha, quadratic_char_zero,
-          zero_pow (nat.div_pos (hp.1.two_le) (succ_pos 1))],
+          zero_pow (nat.div_pos (hpp.1.two_le) (succ_pos 1))],
       norm_cast, },
     { have := (ring_char_zmod_n p).symm.trans hc, -- p = 2
       substI p,
@@ -117,7 +125,7 @@ begin
 end
 
 /-- If `p ∤ a`, then `legendre_sym p a` is `1` or `-1`. -/
-lemma legendre_sym_eq_one_or_neg_one (p : ℕ) [fact p.prime] (a : ℤ) (ha : (a : zmod p) ≠ 0) :
+lemma legendre_sym_eq_one_or_neg_one (a : ℤ) (ha : (a : zmod p) ≠ 0) :
   legendre_sym p a = 1 ∨ legendre_sym p a = -1 :=
 quadratic_char_dichotomy ha
 
@@ -126,19 +134,17 @@ lemma legendre_sym_eq_neg_one_iff_not_one {a : ℤ} (ha : (a : zmod p) ≠ 0) :
 quadratic_char_eq_neg_one_iff_not_one ha
 
 /-- The Legendre symbol of `p` and `a` is zero iff `p ∣ a`. -/
-lemma legendre_sym_eq_zero_iff (p : ℕ) [fact p.prime] (a : ℤ) :
-  legendre_sym p a = 0 ↔ (a : zmod p) = 0 :=
+lemma legendre_sym_eq_zero_iff (a : ℤ) : legendre_sym p a = 0 ↔ (a : zmod p) = 0 :=
 quadratic_char_eq_zero_iff
 
-@[simp] lemma legendre_sym_zero (p : ℕ) [fact p.prime] : legendre_sym p 0 = 0 :=
+@[simp] lemma legendre_sym_zero : legendre_sym p 0 = 0 :=
 by rw [legendre_sym, int.cast_zero, mul_char.map_zero]
 
-@[simp] lemma legendre_sym_one (p : ℕ) [fact p.prime] : legendre_sym p 1 = 1 :=
+@[simp] lemma legendre_sym_one : legendre_sym p 1 = 1 :=
 by rw [legendre_sym, int.cast_one, mul_char.map_one]
 
 /-- The Legendre symbol is multiplicative in `a` for `p` fixed. -/
-lemma legendre_sym_mul (p : ℕ) [fact p.prime] (a b : ℤ) :
-  legendre_sym p (a * b) = legendre_sym p a * legendre_sym p b :=
+lemma legendre_sym_mul (a b : ℤ) : legendre_sym p (a * b) = legendre_sym p a * legendre_sym p b :=
 begin
   rw [legendre_sym, legendre_sym, legendre_sym],
   push_cast,
@@ -146,25 +152,22 @@ begin
 end
 
 /-- The Legendre symbol is a homomorphism of monoids with zero. -/
-@[simps] def legendre_sym_hom (p : ℕ) [fact p.prime] : ℤ →*₀ ℤ :=
+@[simps] def legendre_sym_hom : ℤ →*₀ ℤ :=
 { to_fun := legendre_sym p,
   map_zero' := legendre_sym_zero p,
   map_one' := legendre_sym_one p,
   map_mul' := legendre_sym_mul p }
 
 /-- The square of the symbol is 1 if `p ∤ a`. -/
-theorem legendre_sym_sq_one (p : ℕ) [fact p.prime] (a : ℤ) (ha : (a : zmod p) ≠ 0) :
-  (legendre_sym p a)^2 = 1 :=
+theorem legendre_sym_sq_one (a : ℤ) (ha : (a : zmod p) ≠ 0) : (legendre_sym p a)^2 = 1 :=
 quadratic_char_sq_one ha
 
 /-- The Legendre symbol of `a^2` at `p` is 1 if `p ∤ a`. -/
-theorem legendre_sym_sq_one' (p : ℕ) [fact p.prime] (a : ℤ) (ha : (a : zmod p) ≠ 0) :
-  legendre_sym p (a ^ 2) = 1 :=
+theorem legendre_sym_sq_one' (a : ℤ) (ha : (a : zmod p) ≠ 0) : legendre_sym p (a ^ 2) = 1 :=
 by exact_mod_cast quadratic_char_sq_one' ha
 
 /-- The Legendre symbol depends only on `a` mod `p`. -/
-theorem legendre_sym_mod (p : ℕ) [fact p.prime] (a : ℤ) :
-  legendre_sym p a = legendre_sym p (a % p) :=
+theorem legendre_sym_mod (a : ℤ) : legendre_sym p a = legendre_sym p (a % p) :=
 by simp only [legendre_sym, int_cast_mod]
 
 /-- When `p ∤ a`, then `legendre_sym p a = 1` iff `a` is a square mod `p`. -/
@@ -190,9 +193,16 @@ lemma legendre_sym_card_sqrts (hp : p ≠ 2) (a : ℤ) :
   ↑{x : zmod p | x^2 = a}.to_finset.card = legendre_sym p a + 1 :=
 quadratic_char_card_sqrts (ne_of_eq_of_ne (ring_char_zmod_n p) hp) a
 
+end legendre
+
+section values
+
 /-!
 ### The value of the Legendre symbol at `-1`
 -/
+
+variables (p : ℕ) [hpp : fact p.prime]
+include hpp
 
 /-- `legendre_sym p (-1)` is given by `χ₄ p`. -/
 lemma legendre_sym_neg_one (hp : p ≠ 2) : legendre_sym p (-1) = χ₄ p :=
@@ -271,21 +281,28 @@ begin
   dec_trivial!,
 end
 
+end values
+
+section reciprocity
+
 /-!
 ### The Law of Quadratic Reciprocity
 -/
+
+variables (p q : ℕ) [hpp : fact p.prime] [hqp : fact q.prime]
+include hpp hqp
 
 /-- The Law of Quadratic Reciprocity: if `p` and `q` are distinct odd primes, then
 `(q / p) * (p / q) = (-1)^((p-1)(q-1)/4)`. -/
 theorem quadratic_reciprocity (hp : p ≠ 2) (hq : q ≠ 2) (hpq : p ≠ q) :
   legendre_sym q p * legendre_sym p q = (-1) ^ ((p / 2) * (q / 2)) :=
 begin
-  have hp₁ := (nat.prime.eq_two_or_odd (fact.out p.prime)).resolve_left hp,
-  have hq₁ := (nat.prime.eq_two_or_odd (fact.out q.prime)).resolve_left hq,
+  have hp₁ := (nat.prime.eq_two_or_odd hpp.1).resolve_left hp,
+  have hq₁ := (nat.prime.eq_two_or_odd hqp.1).resolve_left hq,
   have hq₂ := ne_of_eq_of_ne (ring_char_zmod_n q) hq,
   have hpq₁ : (p : zmod q) ≠ 0 :=
   (mt (nat_coe_zmod_eq_zero_iff_dvd p q).mp
-        $ mt (nat.prime_dvd_prime_iff_eq (fact.out q.prime) (fact.out p.prime)).mp hpq.symm),
+        $ mt (nat.prime_dvd_prime_iff_eq hqp.1 hpp.1).mp hpq.symm),
   have h := quadratic_char_odd_prime (ne_of_eq_of_ne (ring_char_zmod_n p) hp) hq
               (ne_of_eq_of_ne (ring_char_zmod_n p) hpq),
   rw [card p] at h,
@@ -354,5 +371,7 @@ lemma exists_sq_eq_prime_iff_of_mod_four_eq_three (hp3 : p % 4 = 3) (hq3 : q % 4
   is_square (q : zmod p) ↔ ¬ is_square (p : zmod q) :=
 by rw [← legendre_sym_eq_one_iff' p (prime_ne_zero p q hpq), ← legendre_sym_eq_neg_one_iff' q,
        quadratic_reciprocity_three_mod_four p q hp3 hq3, neg_inj]
+
+end reciprocity
 
 end zmod

--- a/src/number_theory/legendre_symbol/quadratic_reciprocity.lean
+++ b/src/number_theory/legendre_symbol/quadratic_reciprocity.lean
@@ -33,6 +33,10 @@ We also prove the supplementary laws that give conditions for when `-1` or `2`
 The proofs use results for quadratic characters on arbitrary finite fields
 from `number_theory.legendre_symbol.quadratic_char`, which in turn are based on
 properties of quadratic Gauss sums as provided by `number_theory.legendre_symbol.gauss_sum`.
+
+## Tags
+
+quadratic residue, quadratic nonresidue, Legendre symbol, quadratic reciprocity
 -/
 
 open finset nat char

--- a/src/number_theory/legendre_symbol/quadratic_reciprocity.lean
+++ b/src/number_theory/legendre_symbol/quadratic_reciprocity.lean
@@ -203,7 +203,24 @@ begin
   exact_mod_cast h₁,
 end
 
-open_locale big_operators
+lemma legendre_sym_two (hp : p ≠ 2) : legendre_sym p 2 = χ₈ p :=
+begin
+  have h := quadratic_char_two (ne_of_eq_of_ne (ring_char_zmod_n p) hp),
+  rw [card p] at h,
+  rw [legendre_sym],
+  exact_mod_cast h,
+end
+
+lemma exists_sq_eq_two_iff (hp : p ≠ 2) : is_square (2 : zmod p) ↔ p % 8 = 1 ∨ p % 8 = 7 :=
+begin
+  rw [finite_field.is_square_two_iff, card p],
+  have h₁ := nat.prime.mod_two_eq_one_iff_ne_two.mpr hp,
+  rw [← nat.mod_mod_of_dvd p (by norm_num : 2 ∣ 8)] at h₁,
+  have h₂ := mod_lt p (by norm_num : 0 < 8),
+  revert h₂ h₁,
+  generalize hm : p % 8 = m, unfreezingI {clear_dependent p},
+  dec_trivial!,
+end
 
 /-- **Quadratic reciprocity theorem** -/
 theorem quadratic_reciprocity (hp : p ≠ 2) (hq : q ≠ 2) (hpq : p ≠ q) :
@@ -256,25 +273,6 @@ begin
   have hq' := nat.prime.mod_two_eq_one_iff_ne_two.mp (nat.odd_of_mod_four_eq_three hq),
   rw [quadratic_reciprocity' p q hp' hq', pow_mul, neg_one_pow_three_mod_four_div_two hp,
       neg_one_pow_three_mod_four_div_two hq, neg_one_mul],
-end
-
-lemma legendre_sym_two (hp : p ≠ 2) : legendre_sym p 2 = χ₈ p :=
-begin
-  have h := quadratic_char_two (ne_of_eq_of_ne (ring_char_zmod_n p) hp),
-  rw [card p] at h,
-  rw [legendre_sym],
-  exact_mod_cast h,
-end
-
-lemma exists_sq_eq_two_iff (hp : p ≠ 2) : is_square (2 : zmod p) ↔ p % 8 = 1 ∨ p % 8 = 7 :=
-begin
-  rw [finite_field.is_square_two_iff, card p],
-  have h₁ := nat.prime.mod_two_eq_one_iff_ne_two.mpr hp,
-  rw [← nat.mod_mod_of_dvd p (by norm_num : 2 ∣ 8)] at h₁,
-  have h₂ := mod_lt p (by norm_num : 0 < 8),
-  revert h₂ h₁,
-  generalize hm : p % 8 = m, unfreezingI {clear_dependent p},
-  dec_trivial!,
 end
 
 lemma exists_sq_eq_prime_iff_of_mod_four_eq_one (hp1 : p % 4 = 1) (hq1 : q ≠ 2) :

--- a/src/number_theory/legendre_symbol/quadratic_reciprocity.lean
+++ b/src/number_theory/legendre_symbol/quadratic_reciprocity.lean
@@ -108,7 +108,7 @@ that `legendre_sym p` is a multiplicative function `ℤ → ℤ`.
 def legendre_sym (a : ℤ) : ℤ := quadratic_char (zmod p) a
 
 /-- We have the congruence `legendre_sym p a ≡ a ^ (p / 2) mod p`. -/
-lemma legendre_sym_eq_pow (a : ℤ) : (legendre_sym p a : zmod p) = (a ^ (p / 2)) :=
+lemma legendre_sym_eq_pow (a : ℤ) : (legendre_sym p a : zmod p) = a ^ (p / 2) :=
 begin
   cases eq_or_ne (ring_char (zmod p)) 2 with hc hc,
   { by_cases ha : (a : zmod p) = 0,
@@ -308,7 +308,7 @@ begin
   have h := quadratic_char_odd_prime (ne_of_eq_of_ne (ring_char_zmod_n p) hp) hq
               (ne_of_eq_of_ne (ring_char_zmod_n p) hpq),
   rw [card p] at h,
-  have nc : ∀ (n r : ℕ), ((n : ℤ) : zmod r) = n := by {intros n r, norm_cast},
+  have nc : ∀ (n r : ℕ), ((n : ℤ) : zmod r) = n := λ n r, by norm_cast,
   have nc' : (((-1) ^ (p / 2) : ℤ) : zmod q) = (-1) ^ (p / 2) := by norm_cast,
   rw [legendre_sym, legendre_sym, nc, nc, h, map_mul, mul_rotate', mul_comm (p / 2), ← pow_two,
       quadratic_char_sq_one hpq₁, mul_one, pow_mul, χ₄_eq_neg_one_pow hp₁, nc', map_pow,
@@ -322,15 +322,10 @@ theorem quadratic_reciprocity' (hp : p ≠ 2) (hq : q ≠ 2) :
 begin
   cases eq_or_ne p q with h h,
   { unfreezingI {subst p},
-    have t : legendre_sym q q = 0 := by
-    { have : ((q : ℤ) : zmod q) = 0 := by exact_mod_cast nat_cast_self q,
-      exact (legendre_sym_eq_zero_iff q q).mpr this, },
-    rw [t, mul_zero], },
-  { have qr := quadratic_reciprocity hp hq h,
-    apply_fun (* legendre_sym p q) at qr,
-    simp only at qr,
+    rw [(legendre_sym_eq_zero_iff q q).mpr (by exact_mod_cast nat_cast_self q), mul_zero] },
+  { have qr := congr_arg (* legendre_sym p q) (quadratic_reciprocity hp hq h),
     have : ((q : ℤ) : zmod p) ≠ 0 := by exact_mod_cast prime_ne_zero p q h,
-    rwa [mul_assoc, ← pow_two, legendre_sym_sq_one p this, mul_one] at qr, }
+    simpa only [mul_assoc, ← pow_two, legendre_sym_sq_one p this, mul_one] using qr }
 end
 
 /-- The Law of Quadratic Reciprocity: if `p` and `q` are odd primes and `p % 4 = 1`,
@@ -338,9 +333,8 @@ then `(q / p) = (p / q)`. -/
 theorem quadratic_reciprocity_one_mod_four (hp : p % 4 = 1) (hq : q ≠ 2) :
   legendre_sym q p = legendre_sym p q :=
 begin
-  have hp' := prime.mod_two_eq_one_iff_ne_two.mp (odd_of_mod_four_eq_one hp),
-  rw [quadratic_reciprocity' hp' hq, pow_mul, neg_one_pow_div_two_of_one_mod_four hp,
-      one_pow, one_mul],
+  rw [quadratic_reciprocity' (prime.mod_two_eq_one_iff_ne_two.mp (odd_of_mod_four_eq_one hp)) hq,
+      pow_mul, neg_one_pow_div_two_of_one_mod_four hp, one_pow, one_mul],
 end
 
 /-- The Law of Quadratic Reciprocity: if `p` and `q` are primes that are both congruent

--- a/src/number_theory/legendre_symbol/quadratic_reciprocity.lean
+++ b/src/number_theory/legendre_symbol/quadratic_reciprocity.lean
@@ -339,7 +339,7 @@ theorem quadratic_reciprocity_one_mod_four (hp : p % 4 = 1) (hq : q ≠ 2) :
   legendre_sym q p = legendre_sym p q :=
 begin
   have hp' := nat.prime.mod_two_eq_one_iff_ne_two.mp (nat.odd_of_mod_four_eq_one hp),
-  rw [quadratic_reciprocity' hp' hq, pow_mul, neg_one_pow_one_mod_four_div_two hp,
+  rw [quadratic_reciprocity' hp' hq, pow_mul, neg_one_pow_div_two_of_one_mod_four hp,
       one_pow, one_mul],
 end
 
@@ -350,8 +350,8 @@ theorem quadratic_reciprocity_three_mod_four (hp : p % 4 = 3) (hq : q % 4 = 3):
 begin
   have hp' := nat.prime.mod_two_eq_one_iff_ne_two.mp (nat.odd_of_mod_four_eq_three hp),
   have hq' := nat.prime.mod_two_eq_one_iff_ne_two.mp (nat.odd_of_mod_four_eq_three hq),
-  rw [quadratic_reciprocity' hp' hq', pow_mul, neg_one_pow_three_mod_four_div_two hp,
-      neg_one_pow_three_mod_four_div_two hq, neg_one_mul],
+  rw [quadratic_reciprocity' hp' hq', pow_mul, neg_one_pow_div_two_of_three_mod_four hp,
+      neg_one_pow_div_two_of_three_mod_four hq, neg_one_mul],
 end
 
 /-- If `p` and `q` are odd primes and `p % 4 = 1`, then `q` is a square mod `p` iff

--- a/src/number_theory/legendre_symbol/quadratic_reciprocity.lean
+++ b/src/number_theory/legendre_symbol/quadratic_reciprocity.lean
@@ -119,13 +119,13 @@ begin
       substI p,
       rw [legendre_sym, quadratic_char_eq_one_of_char_two hc ha],
       revert ha,
-      generalize : (a : (zmod 2)) = b, revert b, dec_trivial } },
+      generalize : (a : zmod 2) = b, revert b, dec_trivial } },
   { convert quadratic_char_eq_pow_of_char_ne_two'' hc (a : zmod p),
     exact (card p).symm },
 end
 
 /-- If `p ∤ a`, then `legendre_sym p a` is `1` or `-1`. -/
-lemma legendre_sym_eq_one_or_neg_one (a : ℤ) (ha : (a : zmod p) ≠ 0) :
+lemma legendre_sym_eq_one_or_neg_one {a : ℤ} (ha : (a : zmod p) ≠ 0) :
   legendre_sym p a = 1 ∨ legendre_sym p a = -1 :=
 quadratic_char_dichotomy ha
 
@@ -159,11 +159,11 @@ end
   map_mul' := legendre_sym_mul p }
 
 /-- The square of the symbol is 1 if `p ∤ a`. -/
-theorem legendre_sym_sq_one (a : ℤ) (ha : (a : zmod p) ≠ 0) : (legendre_sym p a)^2 = 1 :=
+theorem legendre_sym_sq_one {a : ℤ} (ha : (a : zmod p) ≠ 0) : (legendre_sym p a) ^ 2 = 1 :=
 quadratic_char_sq_one ha
 
 /-- The Legendre symbol of `a^2` at `p` is 1 if `p ∤ a`. -/
-theorem legendre_sym_sq_one' (a : ℤ) (ha : (a : zmod p) ≠ 0) : legendre_sym p (a ^ 2) = 1 :=
+theorem legendre_sym_sq_one' {a : ℤ} (ha : (a : zmod p) ≠ 0) : legendre_sym p (a ^ 2) = 1 :=
 by exact_mod_cast quadratic_char_sq_one' ha
 
 /-- The Legendre symbol depends only on `a` mod `p`. -/
@@ -179,7 +179,7 @@ lemma legendre_sym_eq_one_iff' {a : ℕ} (ha0 : (a : zmod p) ≠ 0) :
   legendre_sym p a = 1 ↔ is_square (a : zmod p) :=
 by {rw legendre_sym_eq_one_iff, norm_cast, exact_mod_cast ha0}
 
-/-- `legendre_sym p a = -1` iff`a` is a nonsquare mod `p`. -/
+/-- `legendre_sym p a = -1` iff `a` is a nonsquare mod `p`. -/
 lemma legendre_sym_eq_neg_one_iff {a : ℤ} :
   legendre_sym p a = -1 ↔ ¬ is_square (a : zmod p) :=
 quadratic_char_neg_one_iff_not_is_square
@@ -201,8 +201,7 @@ section values
 ### The value of the Legendre symbol at `-1`
 -/
 
-variables (p : ℕ) [hpp : fact p.prime]
-include hpp
+variables {p : ℕ} [fact p.prime]
 
 /-- `legendre_sym p (-1)` is given by `χ₄ p`. -/
 lemma legendre_sym_neg_one (hp : p ≠ 2) : legendre_sym p (-1) = χ₄ p :=
@@ -217,7 +216,7 @@ lemma exists_sq_eq_neg_one_iff : is_square (-1 : zmod p) ↔ p % 4 ≠ 3 :=
 by rw [finite_field.is_square_neg_one_iff, card p]
 
 lemma mod_four_ne_three_of_sq_eq_neg_one {y : zmod p} (hy : y ^ 2 = -1) : p % 4 ≠ 3 :=
-(exists_sq_eq_neg_one_iff p).1 ⟨y, hy.symm.trans (pow_two y)⟩
+exists_sq_eq_neg_one_iff.1 ⟨y, hy.symm.trans (pow_two y)⟩
 
 /-- If two nonzero squares are negatives of each other in `zmod p`, then `p % 4 ≠ 3`. -/
 lemma mod_four_ne_three_of_sq_eq_neg_sq' {x y : zmod p} (hy : y ≠ 0) (hxy : x ^ 2 = - y ^ 2) :
@@ -232,15 +231,18 @@ lemma mod_four_ne_three_of_sq_eq_neg_sq {x y : zmod p} (hx : x ≠ 0) (hxy : x ^
 begin
   apply_fun (λ x, -x) at hxy,
   rw neg_neg at hxy,
-  exact mod_four_ne_three_of_sq_eq_neg_sq' p hx hxy.symm
+  exact mod_four_ne_three_of_sq_eq_neg_sq' hx hxy.symm
 end
 
 /-!
 ### The value of the Legendre symbol at `2` and `-2`
 -/
 
+variables (hp : p ≠ 2)
+include hp
+
 /-- `legendre_sym p 2` is given by `χ₈ p`. -/
-lemma legendre_sym_two (hp : p ≠ 2) : legendre_sym p 2 = χ₈ p :=
+lemma legendre_sym_two : legendre_sym p 2 = χ₈ p :=
 begin
   have h := quadratic_char_two (ne_of_eq_of_ne (ring_char_zmod_n p) hp),
   rw [card p] at h,
@@ -249,7 +251,7 @@ begin
 end
 
 /-- `2` is a square modulo an odd prime `p` iff `p` is congruent to `1` or `7` mod `8`. -/
-lemma exists_sq_eq_two_iff (hp : p ≠ 2) : is_square (2 : zmod p) ↔ p % 8 = 1 ∨ p % 8 = 7 :=
+lemma exists_sq_eq_two_iff : is_square (2 : zmod p) ↔ p % 8 = 1 ∨ p % 8 = 7 :=
 begin
   rw [finite_field.is_square_two_iff, card p],
   have h₁ := nat.prime.mod_two_eq_one_iff_ne_two.mpr hp,
@@ -261,7 +263,7 @@ begin
 end
 
 /-- `legendre_sym p (-2)` is given by `χ₈' p`. -/
-lemma legendre_sym_neg_two (hp : p ≠ 2) : legendre_sym p (-2) = χ₈' p :=
+lemma legendre_sym_neg_two : legendre_sym p (-2) = χ₈' p :=
 begin
   have h := quadratic_char_neg_two (ne_of_eq_of_ne (ring_char_zmod_n p) hp),
   rw [card p] at h,
@@ -270,7 +272,7 @@ begin
 end
 
 /-- `-2` is a square modulo an odd prime `p` iff `p` is congruent to `1` or `3` mod `8`. -/
-lemma exists_sq_eq_neg_two_iff (hp : p ≠ 2) : is_square (-2 : zmod p) ↔ p % 8 = 1 ∨ p % 8 = 3 :=
+lemma exists_sq_eq_neg_two_iff : is_square (-2 : zmod p) ↔ p % 8 = 1 ∨ p % 8 = 3 :=
 begin
   rw [finite_field.is_square_neg_two_iff, card p],
   have h₁ := nat.prime.mod_two_eq_one_iff_ne_two.mpr hp,
@@ -289,7 +291,7 @@ section reciprocity
 ### The Law of Quadratic Reciprocity
 -/
 
-variables (p q : ℕ) [hpp : fact p.prime] [hqp : fact q.prime]
+variables {p q : ℕ} [hpp : fact p.prime] [hqp : fact q.prime]
 include hpp hqp
 
 /-- The Law of Quadratic Reciprocity: if `p` and `q` are distinct odd primes, then
@@ -324,11 +326,11 @@ begin
     { have : ((q : ℤ) : zmod q) = 0 := by exact_mod_cast nat_cast_self q,
       exact (legendre_sym_eq_zero_iff q q).mpr this, },
     rw [t, mul_zero], },
-  { have qr := quadratic_reciprocity p q hp hq h,
+  { have qr := quadratic_reciprocity hp hq h,
     apply_fun (* legendre_sym p q) at qr,
     simp only at qr,
     have : ((q : ℤ) : zmod p) ≠ 0 := by exact_mod_cast prime_ne_zero p q h,
-    rwa [mul_assoc, ← pow_two, legendre_sym_sq_one p q this, mul_one] at qr, }
+    rwa [mul_assoc, ← pow_two, legendre_sym_sq_one p this, mul_one] at qr, }
 end
 
 /-- The Law of Quadratic Reciprocity: if `p` and `q` are odd primes and `p % 4 = 1`,
@@ -337,7 +339,7 @@ theorem quadratic_reciprocity_one_mod_four (hp : p % 4 = 1) (hq : q ≠ 2) :
   legendre_sym q p = legendre_sym p q :=
 begin
   have hp' := nat.prime.mod_two_eq_one_iff_ne_two.mp (nat.odd_of_mod_four_eq_one hp),
-  rw [quadratic_reciprocity' p q hp' hq, pow_mul, neg_one_pow_one_mod_four_div_two hp,
+  rw [quadratic_reciprocity' hp' hq, pow_mul, neg_one_pow_one_mod_four_div_two hp,
       one_pow, one_mul],
 end
 
@@ -348,7 +350,7 @@ theorem quadratic_reciprocity_three_mod_four (hp : p % 4 = 3) (hq : q % 4 = 3):
 begin
   have hp' := nat.prime.mod_two_eq_one_iff_ne_two.mp (nat.odd_of_mod_four_eq_three hp),
   have hq' := nat.prime.mod_two_eq_one_iff_ne_two.mp (nat.odd_of_mod_four_eq_three hq),
-  rw [quadratic_reciprocity' p q hp' hq', pow_mul, neg_one_pow_three_mod_four_div_two hp,
+  rw [quadratic_reciprocity' hp' hq', pow_mul, neg_one_pow_three_mod_four_div_two hp,
       neg_one_pow_three_mod_four_div_two hq, neg_one_mul],
 end
 
@@ -361,7 +363,7 @@ begin
   { unfreezingI {subst p} },
   { rw [← legendre_sym_eq_one_iff' p (prime_ne_zero p q h),
         ← legendre_sym_eq_one_iff' q (prime_ne_zero q p h.symm),
-        quadratic_reciprocity_one_mod_four p q hp1 hq1], }
+        quadratic_reciprocity_one_mod_four hp1 hq1], }
 end
 
 /-- If `p` and `q` are distinct primes that are both congruent to `3` mod `4`, then `q` is
@@ -370,7 +372,7 @@ lemma exists_sq_eq_prime_iff_of_mod_four_eq_three (hp3 : p % 4 = 3) (hq3 : q % 4
   (hpq : p ≠ q) :
   is_square (q : zmod p) ↔ ¬ is_square (p : zmod q) :=
 by rw [← legendre_sym_eq_one_iff' p (prime_ne_zero p q hpq), ← legendre_sym_eq_neg_one_iff' q,
-       quadratic_reciprocity_three_mod_four p q hp3 hq3, neg_inj]
+       quadratic_reciprocity_three_mod_four hp3 hq3, neg_inj]
 
 end reciprocity
 

--- a/src/number_theory/legendre_symbol/quadratic_reciprocity.lean
+++ b/src/number_theory/legendre_symbol/quadratic_reciprocity.lean
@@ -78,7 +78,7 @@ end
 lemma pow_div_two_eq_neg_one_or_one {a : zmod p} (ha : a ≠ 0) :
   a ^ (p / 2) = 1 ∨ a ^ (p / 2) = -1 :=
 begin
-  cases nat.prime.eq_two_or_odd (fact.out p.prime) with hp2 hp_odd,
+  cases prime.eq_two_or_odd (fact.out p.prime) with hp2 hp_odd,
   { substI p, revert a ha, dec_trivial },
   rw [← mul_self_eq_one_iff, ← pow_add, ← two_mul, two_mul_odd_div_two hp_odd],
   exact pow_card_sub_one_eq_one ha
@@ -120,7 +120,7 @@ begin
       rw [legendre_sym, quadratic_char_eq_one_of_char_two hc ha],
       revert ha,
       generalize : (a : zmod 2) = b, revert b, dec_trivial } },
-  { convert quadratic_char_eq_pow_of_char_ne_two'' hc (a : zmod p),
+  { convert quadratic_char_eq_pow_of_char_ne_two' hc (a : zmod p),
     exact (card p).symm },
 end
 
@@ -148,7 +148,7 @@ lemma legendre_sym_mul (a b : ℤ) : legendre_sym p (a * b) = legendre_sym p a *
 begin
   rw [legendre_sym, legendre_sym, legendre_sym],
   push_cast,
-  exact quadratic_char_mul (a : zmod p) b,
+  exact quadratic_char_fun_mul (a : zmod p) b,
 end
 
 /-- The Legendre symbol is a homomorphism of monoids with zero. -/
@@ -254,8 +254,8 @@ end
 lemma exists_sq_eq_two_iff : is_square (2 : zmod p) ↔ p % 8 = 1 ∨ p % 8 = 7 :=
 begin
   rw [finite_field.is_square_two_iff, card p],
-  have h₁ := nat.prime.mod_two_eq_one_iff_ne_two.mpr hp,
-  rw [← nat.mod_mod_of_dvd p (by norm_num : 2 ∣ 8)] at h₁,
+  have h₁ := prime.mod_two_eq_one_iff_ne_two.mpr hp,
+  rw [← mod_mod_of_dvd p (by norm_num : 2 ∣ 8)] at h₁,
   have h₂ := mod_lt p (by norm_num : 0 < 8),
   revert h₂ h₁,
   generalize hm : p % 8 = m, unfreezingI {clear_dependent p},
@@ -275,8 +275,8 @@ end
 lemma exists_sq_eq_neg_two_iff : is_square (-2 : zmod p) ↔ p % 8 = 1 ∨ p % 8 = 3 :=
 begin
   rw [finite_field.is_square_neg_two_iff, card p],
-  have h₁ := nat.prime.mod_two_eq_one_iff_ne_two.mpr hp,
-  rw [← nat.mod_mod_of_dvd p (by norm_num : 2 ∣ 8)] at h₁,
+  have h₁ := prime.mod_two_eq_one_iff_ne_two.mpr hp,
+  rw [← mod_mod_of_dvd p (by norm_num : 2 ∣ 8)] at h₁,
   have h₂ := mod_lt p (by norm_num : 0 < 8),
   revert h₂ h₁,
   generalize hm : p % 8 = m, unfreezingI {clear_dependent p},
@@ -299,12 +299,12 @@ include hpp hqp
 theorem quadratic_reciprocity (hp : p ≠ 2) (hq : q ≠ 2) (hpq : p ≠ q) :
   legendre_sym q p * legendre_sym p q = (-1) ^ ((p / 2) * (q / 2)) :=
 begin
-  have hp₁ := (nat.prime.eq_two_or_odd hpp.1).resolve_left hp,
-  have hq₁ := (nat.prime.eq_two_or_odd hqp.1).resolve_left hq,
+  have hp₁ := (prime.eq_two_or_odd hpp.1).resolve_left hp,
+  have hq₁ := (prime.eq_two_or_odd hqp.1).resolve_left hq,
   have hq₂ := ne_of_eq_of_ne (ring_char_zmod_n q) hq,
   have hpq₁ : (p : zmod q) ≠ 0 :=
   (mt (nat_coe_zmod_eq_zero_iff_dvd p q).mp
-        $ mt (nat.prime_dvd_prime_iff_eq hqp.1 hpp.1).mp hpq.symm),
+        $ mt (prime_dvd_prime_iff_eq hqp.1 hpp.1).mp hpq.symm),
   have h := quadratic_char_odd_prime (ne_of_eq_of_ne (ring_char_zmod_n p) hp) hq
               (ne_of_eq_of_ne (ring_char_zmod_n p) hpq),
   rw [card p] at h,
@@ -338,7 +338,7 @@ then `(q / p) = (p / q)`. -/
 theorem quadratic_reciprocity_one_mod_four (hp : p % 4 = 1) (hq : q ≠ 2) :
   legendre_sym q p = legendre_sym p q :=
 begin
-  have hp' := nat.prime.mod_two_eq_one_iff_ne_two.mp (nat.odd_of_mod_four_eq_one hp),
+  have hp' := prime.mod_two_eq_one_iff_ne_two.mp (odd_of_mod_four_eq_one hp),
   rw [quadratic_reciprocity' hp' hq, pow_mul, neg_one_pow_div_two_of_one_mod_four hp,
       one_pow, one_mul],
 end
@@ -348,8 +348,8 @@ to `3` mod `4`, then `(q / p) = -(p / q)`. -/
 theorem quadratic_reciprocity_three_mod_four (hp : p % 4 = 3) (hq : q % 4 = 3):
   legendre_sym q p = -legendre_sym p q :=
 begin
-  have hp' := nat.prime.mod_two_eq_one_iff_ne_two.mp (nat.odd_of_mod_four_eq_three hp),
-  have hq' := nat.prime.mod_two_eq_one_iff_ne_two.mp (nat.odd_of_mod_four_eq_three hq),
+  have hp' := prime.mod_two_eq_one_iff_ne_two.mp (odd_of_mod_four_eq_three hp),
+  have hq' := prime.mod_two_eq_one_iff_ne_two.mp (odd_of_mod_four_eq_three hq),
   rw [quadratic_reciprocity' hp' hq', pow_mul, neg_one_pow_div_two_of_three_mod_four hp,
       neg_one_pow_div_two_of_three_mod_four hq, neg_one_mul],
 end

--- a/src/number_theory/legendre_symbol/quadratic_reciprocity.lean
+++ b/src/number_theory/legendre_symbol/quadratic_reciprocity.lean
@@ -92,8 +92,7 @@ section legendre
 ### Definition of the Legendre symbol and basic properties
 -/
 
-variables (p : ℕ) [hpp : fact p.prime]
-include hpp
+variables (p : ℕ) [fact p.prime]
 
 /-- The Legendre symbol of `a : ℤ` and a prime `p`, `legendre_sym p a`,
 is an integer defined as
@@ -113,7 +112,7 @@ begin
   cases eq_or_ne (ring_char (zmod p)) 2 with hc hc,
   { by_cases ha : (a : zmod p) = 0,
     { rw [legendre_sym, ha, quadratic_char_zero,
-          zero_pow (nat.div_pos (hpp.1.two_le) (succ_pos 1))],
+          zero_pow (nat.div_pos ((fact.out p.prime).two_le) (succ_pos 1))],
       norm_cast, },
     { have := (ring_char_zmod_n p).symm.trans hc, -- p = 2
       substI p,

--- a/src/number_theory/legendre_symbol/quadratic_reciprocity.lean
+++ b/src/number_theory/legendre_symbol/quadratic_reciprocity.lean
@@ -225,13 +225,38 @@ begin
       quadratic_char_neg_one hq₂, card q, χ₄_eq_neg_one_pow hq₁],
 end
 
+theorem quadratic_reciprocity' (hp : p ≠ 2) (hq : q ≠ 2) :
+  legendre_sym q p = (-1) ^ ((p / 2) * (q / 2)) * legendre_sym p q :=
+begin
+  cases eq_or_ne p q with h h,
+  { unfreezingI {subst p},
+    have t : legendre_sym q q = 0 := by
+    { have : ((q : ℤ) : zmod q) = 0 := by exact_mod_cast nat_cast_self q,
+      exact (legendre_sym_eq_zero_iff q q).mpr this, },
+    rw [t, mul_zero], },
+  { have qr := quadratic_reciprocity p q hp hq h,
+    apply_fun (* legendre_sym p q) at qr,
+    simp only at qr,
+    have : ((q : ℤ) : zmod p) ≠ 0 := by exact_mod_cast prime_ne_zero p q h,
+    rwa [mul_assoc, ← pow_two, legendre_sym_sq_one p q this, mul_one] at qr, }
+end
+
 theorem quadratic_reciprocity_one_mod_four (hp : p % 4 = 1) (hq : q ≠ 2) :
   legendre_sym q p = legendre_sym p q :=
-sorry
+begin
+  have hp' := nat.prime.mod_two_eq_one_iff_ne_two.mp (nat.odd_of_mod_four_eq_one hp),
+  rw [quadratic_reciprocity' p q hp' hq, pow_mul, neg_one_pow_one_mod_four_div_two hp,
+      one_pow, one_mul],
+end
 
 theorem quadratic_reciprocity_three_mod_four (hp : p % 4 = 3) (hq : q % 4 = 3):
   legendre_sym q p = -legendre_sym p q :=
-sorry
+begin
+  have hp' := nat.prime.mod_two_eq_one_iff_ne_two.mp (nat.odd_of_mod_four_eq_three hp),
+  have hq' := nat.prime.mod_two_eq_one_iff_ne_two.mp (nat.odd_of_mod_four_eq_three hq),
+  rw [quadratic_reciprocity' p q hp' hq', pow_mul, neg_one_pow_three_mod_four_div_two hp,
+      neg_one_pow_three_mod_four_div_two hq, neg_one_mul],
+end
 
 lemma legendre_sym_two (hp : p ≠ 2) : legendre_sym p 2 = χ₈ p :=
 begin

--- a/src/number_theory/legendre_symbol/quadratic_reciprocity.lean
+++ b/src/number_theory/legendre_symbol/quadratic_reciprocity.lean
@@ -48,8 +48,7 @@ section euler
 variables (p : ℕ) [fact p.prime]
 
 /-- Euler's Criterion: A unit `x` of `zmod p` is a square if and only if `x ^ (p / 2) = 1`. -/
-lemma euler_criterion_units (x : (zmod p)ˣ) :
-  (∃ y : (zmod p)ˣ, y ^ 2 = x) ↔ x ^ (p / 2) = 1 :=
+lemma euler_criterion_units (x : (zmod p)ˣ) : (∃ y : (zmod p)ˣ, y ^ 2 = x) ↔ x ^ (p / 2) = 1 :=
 begin
   by_cases hc : p = 2,
   { substI hc,
@@ -63,8 +62,7 @@ begin
 end
 
 /-- Euler's Criterion: a nonzero `a : zmod p` is a square if and only if `x ^ (p / 2) = 1`. -/
-lemma euler_criterion {a : zmod p} (ha : a ≠ 0) :
-  is_square (a : zmod p) ↔ a ^ (p / 2) = 1 :=
+lemma euler_criterion {a : zmod p} (ha : a ≠ 0) : is_square (a : zmod p) ↔ a ^ (p / 2) = 1 :=
 begin
   apply (iff_congr _ (by simp [units.ext_iff])).mp (euler_criterion_units p (units.mk0 a ha)),
   simp only [units.ext_iff, sq, units.coe_mk0, units.coe_mul],
@@ -98,7 +96,7 @@ variables (p : ℕ) [fact p.prime]
 is an integer defined as
 
 * `0` if `a` is `0` modulo `p`;
-* `1` if `a` is a square modulo `p`
+* `1` if `a` is a nonzero square modulo `p`
 * `-1` otherwise.
 
 Note the order of the arguments! The advantage of the order chosen here is
@@ -112,7 +110,7 @@ begin
   cases eq_or_ne (ring_char (zmod p)) 2 with hc hc,
   { by_cases ha : (a : zmod p) = 0,
     { rw [legendre_sym, ha, quadratic_char_zero,
-          zero_pow (nat.div_pos ((fact.out p.prime).two_le) (succ_pos 1))],
+          zero_pow (nat.div_pos (fact.out p.prime).two_le (succ_pos 1))],
       norm_cast, },
     { have := (ring_char_zmod_n p).symm.trans hc, -- p = 2
       substI p,
@@ -144,11 +142,7 @@ by rw [legendre_sym, int.cast_one, mul_char.map_one]
 
 /-- The Legendre symbol is multiplicative in `a` for `p` fixed. -/
 lemma legendre_sym_mul (a b : ℤ) : legendre_sym p (a * b) = legendre_sym p a * legendre_sym p b :=
-begin
-  rw [legendre_sym, legendre_sym, legendre_sym],
-  push_cast,
-  exact quadratic_char_fun_mul (a : zmod p) b,
-end
+by simp only [legendre_sym, int.cast_mul, map_mul]
 
 /-- The Legendre symbol is a homomorphism of monoids with zero. -/
 @[simps] def legendre_sym_hom : ℤ →*₀ ℤ :=
@@ -179,18 +173,16 @@ lemma legendre_sym_eq_one_iff' {a : ℕ} (ha0 : (a : zmod p) ≠ 0) :
 by {rw legendre_sym_eq_one_iff, norm_cast, exact_mod_cast ha0}
 
 /-- `legendre_sym p a = -1` iff `a` is a nonsquare mod `p`. -/
-lemma legendre_sym_eq_neg_one_iff {a : ℤ} :
-  legendre_sym p a = -1 ↔ ¬ is_square (a : zmod p) :=
+lemma legendre_sym_eq_neg_one_iff {a : ℤ} : legendre_sym p a = -1 ↔ ¬ is_square (a : zmod p) :=
 quadratic_char_neg_one_iff_not_is_square
 
-lemma legendre_sym_eq_neg_one_iff' {a : ℕ} :
-  legendre_sym p a = -1 ↔ ¬ is_square (a : zmod p) :=
+lemma legendre_sym_eq_neg_one_iff' {a : ℕ} : legendre_sym p a = -1 ↔ ¬ is_square (a : zmod p) :=
 by {rw legendre_sym_eq_neg_one_iff, norm_cast}
 
 /-- The number of square roots of `a` modulo `p` is determined by the Legendre symbol. -/
 lemma legendre_sym_card_sqrts (hp : p ≠ 2) (a : ℤ) :
   ↑{x : zmod p | x^2 = a}.to_finset.card = legendre_sym p a + 1 :=
-quadratic_char_card_sqrts (ne_of_eq_of_ne (ring_char_zmod_n p) hp) a
+quadratic_char_card_sqrts ((ring_char_zmod_n p).substr hp) a
 
 end legendre
 
@@ -204,18 +196,15 @@ variables {p : ℕ} [fact p.prime]
 
 /-- `legendre_sym p (-1)` is given by `χ₄ p`. -/
 lemma legendre_sym_neg_one (hp : p ≠ 2) : legendre_sym p (-1) = χ₄ p :=
-begin
-  have h₁ := quadratic_char_neg_one (ne_of_eq_of_ne (ring_char_zmod_n p) hp),
-  rw card p at h₁,
-  exact_mod_cast h₁,
-end
+by simp only [legendre_sym, card p, quadratic_char_neg_one ((ring_char_zmod_n p).substr hp),
+              int.cast_neg, int.cast_one]
 
 /-- `-1` is a square in `zmod p` iff `p` is not congruent to `3` mod `4`. -/
 lemma exists_sq_eq_neg_one_iff : is_square (-1 : zmod p) ↔ p % 4 ≠ 3 :=
 by rw [finite_field.is_square_neg_one_iff, card p]
 
 lemma mod_four_ne_three_of_sq_eq_neg_one {y : zmod p} (hy : y ^ 2 = -1) : p % 4 ≠ 3 :=
-exists_sq_eq_neg_one_iff.1 ⟨y, hy.symm.trans (pow_two y)⟩
+exists_sq_eq_neg_one_iff.1 ⟨y, hy ▸ pow_two y⟩
 
 /-- If two nonzero squares are negatives of each other in `zmod p`, then `p % 4 ≠ 3`. -/
 lemma mod_four_ne_three_of_sq_eq_neg_sq' {x y : zmod p} (hy : y ≠ 0) (hxy : x ^ 2 = - y ^ 2) :
@@ -227,11 +216,7 @@ end
 
 lemma mod_four_ne_three_of_sq_eq_neg_sq {x y : zmod p} (hx : x ≠ 0) (hxy : x ^ 2 = - y ^ 2) :
   p % 4 ≠ 3 :=
-begin
-  apply_fun (λ x, -x) at hxy,
-  rw neg_neg at hxy,
-  exact mod_four_ne_three_of_sq_eq_neg_sq' hx hxy.symm
-end
+mod_four_ne_three_of_sq_eq_neg_sq' hx (eq_neg_iff_eq_neg.1 hxy)
 
 /-!
 ### The value of the Legendre symbol at `2` and `-2`
@@ -242,12 +227,8 @@ include hp
 
 /-- `legendre_sym p 2` is given by `χ₈ p`. -/
 lemma legendre_sym_two : legendre_sym p 2 = χ₈ p :=
-begin
-  have h := quadratic_char_two (ne_of_eq_of_ne (ring_char_zmod_n p) hp),
-  rw [card p] at h,
-  rw [legendre_sym],
-  exact_mod_cast h,
-end
+by simp only [legendre_sym, card p, quadratic_char_two ((ring_char_zmod_n p).substr hp),
+              int.cast_bit0, int.cast_one]
 
 /-- `2` is a square modulo an odd prime `p` iff `p` is congruent to `1` or `7` mod `8`. -/
 lemma exists_sq_eq_two_iff : is_square (2 : zmod p) ↔ p % 8 = 1 ∨ p % 8 = 7 :=
@@ -263,12 +244,8 @@ end
 
 /-- `legendre_sym p (-2)` is given by `χ₈' p`. -/
 lemma legendre_sym_neg_two : legendre_sym p (-2) = χ₈' p :=
-begin
-  have h := quadratic_char_neg_two (ne_of_eq_of_ne (ring_char_zmod_n p) hp),
-  rw [card p] at h,
-  rw [legendre_sym],
-  exact_mod_cast h,
-end
+by simp only [legendre_sym, card p, quadratic_char_neg_two ((ring_char_zmod_n p).substr hp),
+              int.cast_bit0, int.cast_one, int.cast_neg]
 
 /-- `-2` is a square modulo an odd prime `p` iff `p` is congruent to `1` or `3` mod `8`. -/
 lemma exists_sq_eq_neg_two_iff : is_square (-2 : zmod p) ↔ p % 8 = 1 ∨ p % 8 = 3 :=
@@ -290,28 +267,24 @@ section reciprocity
 ### The Law of Quadratic Reciprocity
 -/
 
-variables {p q : ℕ} [hpp : fact p.prime] [hqp : fact q.prime]
-include hpp hqp
+variables {p q : ℕ} [fact p.prime] [fact q.prime]
 
 /-- The Law of Quadratic Reciprocity: if `p` and `q` are distinct odd primes, then
 `(q / p) * (p / q) = (-1)^((p-1)(q-1)/4)`. -/
 theorem quadratic_reciprocity (hp : p ≠ 2) (hq : q ≠ 2) (hpq : p ≠ q) :
   legendre_sym q p * legendre_sym p q = (-1) ^ ((p / 2) * (q / 2)) :=
 begin
-  have hp₁ := (prime.eq_two_or_odd hpp.1).resolve_left hp,
-  have hq₁ := (prime.eq_two_or_odd hqp.1).resolve_left hq,
-  have hq₂ := ne_of_eq_of_ne (ring_char_zmod_n q) hq,
-  have hpq₁ : (p : zmod q) ≠ 0 :=
-  (mt (nat_coe_zmod_eq_zero_iff_dvd p q).mp
-        $ mt (prime_dvd_prime_iff_eq hqp.1 hpp.1).mp hpq.symm),
-  have h := quadratic_char_odd_prime (ne_of_eq_of_ne (ring_char_zmod_n p) hp) hq
-              (ne_of_eq_of_ne (ring_char_zmod_n p) hpq),
+  have hp₁ := (prime.eq_two_or_odd $ fact.out p.prime).resolve_left hp,
+  have hq₁ := (prime.eq_two_or_odd $ fact.out q.prime).resolve_left hq,
+  have hq₂ := (ring_char_zmod_n q).substr hq,
+  have h := quadratic_char_odd_prime ((ring_char_zmod_n p).substr hp) hq
+              ((ring_char_zmod_n p).substr hpq),
   rw [card p] at h,
   have nc : ∀ (n r : ℕ), ((n : ℤ) : zmod r) = n := λ n r, by norm_cast,
   have nc' : (((-1) ^ (p / 2) : ℤ) : zmod q) = (-1) ^ (p / 2) := by norm_cast,
   rw [legendre_sym, legendre_sym, nc, nc, h, map_mul, mul_rotate', mul_comm (p / 2), ← pow_two,
-      quadratic_char_sq_one hpq₁, mul_one, pow_mul, χ₄_eq_neg_one_pow hp₁, nc', map_pow,
-      quadratic_char_neg_one hq₂, card q, χ₄_eq_neg_one_pow hq₁],
+      quadratic_char_sq_one (prime_ne_zero q p hpq.symm), mul_one, pow_mul, χ₄_eq_neg_one_pow hp₁,
+      nc', map_pow, quadratic_char_neg_one hq₂, card q, χ₄_eq_neg_one_pow hq₁],
 end
 
 /-- The Law of Quadratic Reciprocity: if `p` and `q` are odd primes, then
@@ -320,7 +293,7 @@ theorem quadratic_reciprocity' (hp : p ≠ 2) (hq : q ≠ 2) :
   legendre_sym q p = (-1) ^ ((p / 2) * (q / 2)) * legendre_sym p q :=
 begin
   cases eq_or_ne p q with h h,
-  { unfreezingI {subst p},
+  { substI p,
     rw [(legendre_sym_eq_zero_iff q q).mpr (by exact_mod_cast nat_cast_self q), mul_zero] },
   { have qr := congr_arg (* legendre_sym p q) (quadratic_reciprocity hp hq h),
     have : ((q : ℤ) : zmod p) ≠ 0 := by exact_mod_cast prime_ne_zero p q h,
@@ -331,20 +304,16 @@ end
 then `(q / p) = (p / q)`. -/
 theorem quadratic_reciprocity_one_mod_four (hp : p % 4 = 1) (hq : q ≠ 2) :
   legendre_sym q p = legendre_sym p q :=
-begin
-  rw [quadratic_reciprocity' (prime.mod_two_eq_one_iff_ne_two.mp (odd_of_mod_four_eq_one hp)) hq,
-      pow_mul, neg_one_pow_div_two_of_one_mod_four hp, one_pow, one_mul],
-end
+by rw [quadratic_reciprocity' (prime.mod_two_eq_one_iff_ne_two.mp (odd_of_mod_four_eq_one hp)) hq,
+       pow_mul, neg_one_pow_div_two_of_one_mod_four hp, one_pow, one_mul]
 
 /-- The Law of Quadratic Reciprocity: if `p` and `q` are primes that are both congruent
 to `3` mod `4`, then `(q / p) = -(p / q)`. -/
 theorem quadratic_reciprocity_three_mod_four (hp : p % 4 = 3) (hq : q % 4 = 3):
   legendre_sym q p = -legendre_sym p q :=
-begin
-  have hp' := prime.mod_two_eq_one_iff_ne_two.mp (odd_of_mod_four_eq_three hp),
-  have hq' := prime.mod_two_eq_one_iff_ne_two.mp (odd_of_mod_four_eq_three hq),
-  rw [quadratic_reciprocity' hp' hq', pow_mul, neg_one_pow_div_two_of_three_mod_four hp,
-      neg_one_pow_div_two_of_three_mod_four hq, neg_one_mul],
+let nop := @neg_one_pow_div_two_of_three_mod_four in begin
+  rw [quadratic_reciprocity', pow_mul, nop hp, nop hq, neg_one_mul];
+  rwa [← prime.mod_two_eq_one_iff_ne_two, odd_of_mod_four_eq_three],
 end
 
 /-- If `p` and `q` are odd primes and `p % 4 = 1`, then `q` is a square mod `p` iff
@@ -353,7 +322,7 @@ lemma exists_sq_eq_prime_iff_of_mod_four_eq_one (hp1 : p % 4 = 1) (hq1 : q ≠ 2
   is_square (q : zmod p) ↔ is_square (p : zmod q) :=
 begin
   cases eq_or_ne p q with h h,
-  { unfreezingI {subst p} },
+  { substI p },
   { rw [← legendre_sym_eq_one_iff' p (prime_ne_zero p q h),
         ← legendre_sym_eq_one_iff' q (prime_ne_zero q p h.symm),
         quadratic_reciprocity_one_mod_four hp1 hq1], }

--- a/src/number_theory/legendre_symbol/zmod_char.lean
+++ b/src/number_theory/legendre_symbol/zmod_char.lean
@@ -70,18 +70,12 @@ end
 /-- If `n % 4 = 1`, then `(-1)^(n/2) = 1`. -/
 lemma _root_.neg_one_pow_div_two_of_one_mod_four {n : ℕ} (hn : n % 4 = 1) :
   (-1 : ℤ) ^ (n / 2) = 1 :=
-begin
-  rw [← χ₄_eq_neg_one_pow (nat.odd_of_mod_four_eq_one hn), ← zmod.nat_cast_mod, hn],
-  refl,
-end
+by { rw [← χ₄_eq_neg_one_pow (nat.odd_of_mod_four_eq_one hn), ← nat_cast_mod, hn], refl }
 
 /-- If `n % 4 = 3`, then `(-1)^(n/2) = -1`. -/
 lemma _root_.neg_one_pow_div_two_of_three_mod_four {n : ℕ} (hn : n % 4 = 3) :
   (-1 : ℤ) ^ (n / 2) = -1 :=
-begin
-  rw [← χ₄_eq_neg_one_pow (nat.odd_of_mod_four_eq_three hn), ← zmod.nat_cast_mod, hn],
-  refl,
-end
+by { rw [← χ₄_eq_neg_one_pow (nat.odd_of_mod_four_eq_three hn), ← nat_cast_mod, hn], refl }
 
 /-- Define the first primitive quadratic character on `zmod 8`, `χ₈`.
 It corresponds to the extension `ℚ(√2)/ℚ`. -/

--- a/src/number_theory/legendre_symbol/zmod_char.lean
+++ b/src/number_theory/legendre_symbol/zmod_char.lean
@@ -67,6 +67,21 @@ begin
     ((nat.mod_mod_of_dvd n (by norm_num : 2 ∣ 4)).trans hn),
 end
 
+/-- If `n % 4 = 1`, then `(-1)^(n/2) = 1`. -/
+lemma _root_.neg_one_pow_one_mod_four_div_two {n : ℕ} (hn : n % 4 = 1) : (-1 : ℤ) ^ (n / 2) = 1 :=
+begin
+  rw [← χ₄_eq_neg_one_pow (nat.odd_of_mod_four_eq_one hn), ← zmod.nat_cast_mod, hn],
+  refl,
+end
+
+/-- If `n % 4 = 3`, then `(-1)^(n/2) = -1`. -/
+lemma _root_.neg_one_pow_three_mod_four_div_two {n : ℕ} (hn : n % 4 = 3) :
+  (-1 : ℤ) ^ (n / 2) = -1 :=
+begin
+  rw [← χ₄_eq_neg_one_pow (nat.odd_of_mod_four_eq_three hn), ← zmod.nat_cast_mod, hn],
+  refl,
+end
+
 /-- Define the first primitive quadratic character on `zmod 8`, `χ₈`.
 It corresponds to the extension `ℚ(√2)/ℚ`. -/
 @[simps] def χ₈ : mul_char (zmod 8) ℤ :=

--- a/src/number_theory/legendre_symbol/zmod_char.lean
+++ b/src/number_theory/legendre_symbol/zmod_char.lean
@@ -68,14 +68,15 @@ begin
 end
 
 /-- If `n % 4 = 1`, then `(-1)^(n/2) = 1`. -/
-lemma _root_.neg_one_pow_one_mod_four_div_two {n : ℕ} (hn : n % 4 = 1) : (-1 : ℤ) ^ (n / 2) = 1 :=
+lemma _root_.neg_one_pow_div_two_of_one_mod_four {n : ℕ} (hn : n % 4 = 1) :
+  (-1 : ℤ) ^ (n / 2) = 1 :=
 begin
   rw [← χ₄_eq_neg_one_pow (nat.odd_of_mod_four_eq_one hn), ← zmod.nat_cast_mod, hn],
   refl,
 end
 
 /-- If `n % 4 = 3`, then `(-1)^(n/2) = -1`. -/
-lemma _root_.neg_one_pow_three_mod_four_div_two {n : ℕ} (hn : n % 4 = 3) :
+lemma _root_.neg_one_pow_div_two_of_three_mod_four {n : ℕ} (hn : n % 4 = 3) :
   (-1 : ℤ) ^ (n / 2) = -1 :=
 begin
   rw [← χ₄_eq_neg_one_pow (nat.odd_of_mod_four_eq_three hn), ← zmod.nat_cast_mod, hn],

--- a/src/number_theory/zsqrtd/gaussian_int.lean
+++ b/src/number_theory/zsqrtd/gaussian_int.lean
@@ -205,7 +205,7 @@ hp.1.eq_two_or_odd.elim
         revert this hp3 hp1,
         generalize : p % 4 = m, dec_trivial!,
       end,
-    let ⟨k, hk⟩ := (zmod.exists_sq_eq_neg_one_iff p).2 $
+    let ⟨k, hk⟩ := zmod.exists_sq_eq_neg_one_iff.2 $
       by rw hp41; exact dec_trivial in
     begin
       obtain ⟨k, k_lt_p, rfl⟩ : ∃ (k' : ℕ) (h : k' < p), (k' : zmod p) = k,


### PR DESCRIPTION
This PR is (for now) the final step in the quest to change the proof of Quadratic Reciprocity from using the Gauss and Eisenstein lemmas to using the results for quadratic characters of general finite fields obtained from properties of the quadratic Gauss sum. In addition, there is some clean-up of the file and some further results (e.g., on the quadratic character of `-2` and some versions of the law of quadratic reciprocity that are probably easier to use), and the documentation has been extended.

The Gauss and Eisenstein lemmas have been moved to `number_theory/legendre_symbol/gauss_eisenstein_lemmas` (where the auxiliary results needed for them have already been residing).

I have opened a [topic](https://leanprover.zulipchat.com/#narrow/stream/144837-PR-reviews/topic/.2316171.20renovate.20quadratic.20reciprocity/near/294460241) on this under "PR reviews".


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
