### PR TITLE
[Merged by Bors] - feat(category_theory/strong_epi): various results about strong_epi

### DIFF
--- a/src/category_theory/arrow.lean
+++ b/src/category_theory/arrow.lean
@@ -106,6 +106,21 @@ abbreviation iso_mk' {W X Y Z : T} (f : W ⟶ X) (g : Y ⟶ Z)
   (e₁ : W ≅ Y) (e₂ : X ≅ Z) (h : e₁.hom ≫ g = f ≫ e₂.hom) : arrow.mk f ≅ arrow.mk g :=
 arrow.iso_mk e₁ e₂ h
 
+lemma hom.congr_left {f g : arrow T} {φ₁ φ₂ : f ⟶ g} (h : φ₁ = φ₂) :
+  φ₁.left = φ₂.left := by rw h
+lemma hom.congr_right {f g : arrow T} {φ₁ φ₂ : f ⟶ g} (h : φ₁ = φ₂) :
+  φ₁.right = φ₂.right := by rw h
+
+lemma iso_w {f g : arrow T} (e : f ≅ g) : g.hom = e.inv.left ≫ f.hom ≫ e.hom.right :=
+begin
+  have eq := arrow.hom.congr_right e.inv_hom_id,
+  dsimp at eq,
+  erw [w_assoc, eq, category.comp_id],
+end
+
+lemma iso_w' {W X Y Z : T} {f : W ⟶ X} {g : Y ⟶ Z} (e : arrow.mk f ≅ arrow.mk g) :
+  g = e.inv.left ≫ f ≫ e.hom.right := iso_w e
+
 section
 
 variables {f g : arrow T} (sq : f ⟶ g)
@@ -215,5 +230,12 @@ def map_arrow (F : C ⥤ D) : arrow C ⥤ arrow D :=
     w' := by { have w := f.w, simp only [id_map] at w, dsimp, simp only [←F.map_comp, w], } } }
 
 end functor
+
+/-- The images of `f : arrow C` by two isomorphic functors `F : C ⥤ D` are
+isomorphic arrows in `D`. -/
+def arrow.iso_of_nat_iso {C D : Type*} [category C] [category D]
+  {F G : C ⥤ D} (e : F ≅ G) (f : arrow C) :
+  F.map_arrow.obj f ≅ G.map_arrow.obj f :=
+arrow.iso_mk (e.app f.left) (e.app f.right) (by simp)
 
 end category_theory

--- a/src/category_theory/concrete_category/basic.lean
+++ b/src/category_theory/concrete_category/basic.lean
@@ -134,6 +134,10 @@ lemma concrete_category.epi_of_surjective {X Y : C} (f : X ⟶ Y) (s : function.
   epi f :=
 (forget C).epi_of_epi_map ((epi_iff_surjective f).2 s)
 
+lemma concrete_category.bijective_of_is_iso {X Y : C} (f : X ⟶ Y) [is_iso f] :
+  function.bijective ((forget C).map f) :=
+by { rw ← is_iso_iff_bijective, apply_instance, }
+
 @[simp] lemma concrete_category.has_coe_to_fun_Type {X Y : Type u} (f : X ⟶ Y) :
   coe_fn f = f :=
 rfl

--- a/src/category_theory/functor/epi_mono.lean
+++ b/src/category_theory/functor/epi_mono.lean
@@ -237,7 +237,6 @@ end
 
 end category_theory.functor
 
-
 namespace category_theory.adjunction
 
 variables {C D : Type*} [category C] [category D] {F : C ⥤ D} {F' : D ⥤ C} {A B : C}
@@ -247,7 +246,8 @@ lemma strong_epi_map_of_strong_epi (adj : F ⊣ F') (f : A ⟶ B)
   strong_epi (F.map f) :=
 ⟨infer_instance, λ X Y Z, by { introI, rw adj.has_lifting_property_iff, apply_instance, }⟩
 
-instance [is_equivalence F] (f : A ⟶ B) [h : strong_epi f] : strong_epi (F.map f) :=
+instance strong_epi_map_of_is_equivalence [is_equivalence F] (f : A ⟶ B) [h : strong_epi f] :
+  strong_epi (F.map f) :=
 F.as_equivalence.to_adjunction.strong_epi_map_of_strong_epi f
 
 end category_theory.adjunction

--- a/src/category_theory/functor/epi_mono.lean
+++ b/src/category_theory/functor/epi_mono.lean
@@ -256,17 +256,18 @@ namespace category_theory.functor
 
 variables {C D : Type*} [category C] [category D] {F : C ⥤ D} {A B : C} (f : A ⟶ B)
 
-lemma strong_epi_iff_strong_epi_map_of_is_equivalence [is_equivalence F] :
-  strong_epi f ↔ strong_epi (F.map f) :=
+@[simp]
+lemma strong_epi_map_iff_strong_epi_of_is_equivalence [is_equivalence F] :
+  strong_epi (F.map f) ↔ strong_epi f  :=
 begin
   split,
-  { introI,
-    apply_instance, },
   { introI,
     have e : arrow.mk f ≅ arrow.mk (F.inv.map (F.map f)) :=
       arrow.iso_of_nat_iso F.as_equivalence.unit_iso (arrow.mk f),
     rw strong_epi.iff_of_arrow_iso e,
-    apply_instance, }
+    apply_instance, },
+  { introI,
+    apply_instance, },
 end
 
 end category_theory.functor

--- a/src/category_theory/functor/epi_mono.lean
+++ b/src/category_theory/functor/epi_mono.lean
@@ -4,6 +4,8 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Markus Himmel
 -/
 import category_theory.epi_mono
+import category_theory.limits.shapes.strong_epi
+import category_theory.lifting_properties.adjunction
 
 /-!
 # Preservation and reflection of monomorphisms and epimorphisms
@@ -183,6 +185,14 @@ def split_epi_equiv [full F] [faithful F] : split_epi f ≃ split_epi (F.map f) 
   left_inv := by tidy,
   right_inv := by tidy, }
 
+@[simp]
+lemma is_split_epi_iff [full F] [faithful F] : is_split_epi (F.map f) ↔ is_split_epi f :=
+begin
+  split,
+  { intro h, exact is_split_epi.mk' ((split_epi_equiv F f).inv_fun h.exists_split_epi.some), },
+  { intro h, exact is_split_epi.mk' ((split_epi_equiv F f).to_fun h.exists_split_epi.some), },
+end
+
 /-- If `F` is a fully faithful functor, split monomorphisms are preserved and reflected by `F`. -/
 def split_mono_equiv [full F] [faithful F] : split_mono f ≃ split_mono (F.map f) :=
 { to_fun := λ f, f.map F,
@@ -194,6 +204,14 @@ def split_mono_equiv [full F] [faithful F] : split_mono f ≃ split_mono (F.map 
   end,
   left_inv := by tidy,
   right_inv := by tidy, }
+
+@[simp]
+lemma is_split_mono_iff [full F] [faithful F] : is_split_mono (F.map f) ↔ is_split_mono f :=
+begin
+  split,
+  { intro h, exact is_split_mono.mk' ((split_mono_equiv F f).inv_fun h.exists_split_mono.some), },
+  { intro h, exact is_split_mono.mk' ((split_mono_equiv F f).to_fun h.exists_split_mono.some), },
+end
 
 @[simp]
 lemma epi_map_iff_epi [hF₁ : preserves_epimorphisms F] [hF₂ : reflects_epimorphisms F] :
@@ -215,6 +233,40 @@ begin
     exact F.map_mono f, },
 end
 
+end
+
+end category_theory.functor
+
+
+namespace category_theory.adjunction
+
+variables {C D : Type*} [category C] [category D] {F : C ⥤ D} {F' : D ⥤ C} {A B : C}
+
+lemma strong_epi_map_of_strong_epi (adj : F ⊣ F') (f : A ⟶ B)
+  [h₁ : F'.preserves_monomorphisms] [h₂ : F.preserves_epimorphisms] [strong_epi f] :
+  strong_epi (F.map f) :=
+⟨infer_instance, λ X Y Z, by { introI, rw adj.has_lifting_property_iff, apply_instance, }⟩
+
+instance [is_equivalence F] (f : A ⟶ B) [h : strong_epi f] : strong_epi (F.map f) :=
+F.as_equivalence.to_adjunction.strong_epi_map_of_strong_epi f
+
+end category_theory.adjunction
+
+namespace category_theory.functor
+
+variables {C D : Type*} [category C] [category D] {F : C ⥤ D} {A B : C} (f : A ⟶ B)
+
+lemma strong_epi_iff_strong_epi_map_of_is_equivalence [is_equivalence F] :
+  strong_epi f ↔ strong_epi (F.map f) :=
+begin
+  split,
+  { introI,
+    apply_instance, },
+  { introI,
+    have e : arrow.mk f ≅ arrow.mk (F.inv.map (F.map f)) :=
+      arrow.iso_of_nat_iso F.as_equivalence.unit_iso (arrow.mk f),
+    rw strong_epi.iff_of_arrow_iso e,
+    apply_instance, }
 end
 
 end category_theory.functor

--- a/src/category_theory/lifting_properties/basic.lean
+++ b/src/category_theory/lifting_properties/basic.lean
@@ -104,6 +104,44 @@ instance of_comp_right [has_lifting_property i p] [has_lifting_property i p'] :
       fac_right' := by simp only [comm_sq.fac_right_assoc, comm_sq.fac_right], },
 end⟩
 
+lemma of_arrow_iso_left {A B A' B' X Y : C} {i : A ⟶ B} {i' : A' ⟶ B'}
+  (e : arrow.mk i ≅ arrow.mk i') (p : X ⟶ Y)
+  [hip : has_lifting_property i p] : has_lifting_property i' p :=
+begin
+  have eq : i' = (arrow.left_func.map_iso e).inv ≫ i ≫ (arrow.right_func.map_iso e).hom,
+  { simp only [functor.map_iso_inv, arrow.left_func_map, functor.map_iso_hom,
+      arrow.right_func_map, arrow.w_mk_right_assoc, arrow.mk_hom],
+    have eq' := arrow.hom.congr_right e.inv_hom_id,
+    dsimp at eq' ⊢,
+    rw [eq', category.comp_id], },
+  rw eq,
+  apply_instance,
+end
+
+lemma of_arrow_iso_right {A B X Y X' Y' : C} (i : A ⟶ B) {p : X ⟶ Y} {p' : X' ⟶ Y'}
+  (e : arrow.mk p ≅ arrow.mk p')
+  [hip : has_lifting_property i p] : has_lifting_property i p' :=
+begin
+  have eq : p' = (arrow.left_func.map_iso e).inv ≫ p ≫ (arrow.right_func.map_iso e).hom,
+  { simp only [functor.map_iso_inv, arrow.left_func_map, functor.map_iso_hom,
+      arrow.right_func_map, arrow.w_mk_right_assoc, arrow.mk_hom],
+    have eq' := arrow.hom.congr_right e.inv_hom_id,
+    dsimp at eq' ⊢,
+    rw [eq', category.comp_id], },
+  rw eq,
+  apply_instance,
+end
+
+lemma iff_of_arrow_iso_left {A B A' B' X Y : C} {i : A ⟶ B} {i' : A' ⟶ B'}
+  (e : arrow.mk i ≅ arrow.mk i') (p : X ⟶ Y) :
+  has_lifting_property i p ↔ has_lifting_property i' p :=
+by { split; introI, exacts [of_arrow_iso_left e p, of_arrow_iso_left e.symm p], }
+
+lemma iff_of_arrow_iso_right {A B X Y X' Y' : C} (i : A ⟶ B) {p : X ⟶ Y} {p' : X' ⟶ Y'}
+  (e : arrow.mk p ≅ arrow.mk p') :
+  has_lifting_property i p ↔ has_lifting_property i p' :=
+by { split; introI, exacts [of_arrow_iso_right i e, of_arrow_iso_right i e.symm], }
+
 end has_lifting_property
 
 end category_theory

--- a/src/category_theory/lifting_properties/basic.lean
+++ b/src/category_theory/lifting_properties/basic.lean
@@ -107,30 +107,12 @@ end⟩
 lemma of_arrow_iso_left {A B A' B' X Y : C} {i : A ⟶ B} {i' : A' ⟶ B'}
   (e : arrow.mk i ≅ arrow.mk i') (p : X ⟶ Y)
   [hip : has_lifting_property i p] : has_lifting_property i' p :=
-begin
-  have eq : i' = (arrow.left_func.map_iso e).inv ≫ i ≫ (arrow.right_func.map_iso e).hom,
-  { simp only [functor.map_iso_inv, arrow.left_func_map, functor.map_iso_hom,
-      arrow.right_func_map, arrow.w_mk_right_assoc, arrow.mk_hom],
-    have eq' := arrow.hom.congr_right e.inv_hom_id,
-    dsimp at eq' ⊢,
-    rw [eq', category.comp_id], },
-  rw eq,
-  apply_instance,
-end
+by { rw arrow.iso_w' e, apply_instance, }
 
 lemma of_arrow_iso_right {A B X Y X' Y' : C} (i : A ⟶ B) {p : X ⟶ Y} {p' : X' ⟶ Y'}
   (e : arrow.mk p ≅ arrow.mk p')
   [hip : has_lifting_property i p] : has_lifting_property i p' :=
-begin
-  have eq : p' = (arrow.left_func.map_iso e).inv ≫ p ≫ (arrow.right_func.map_iso e).hom,
-  { simp only [functor.map_iso_inv, arrow.left_func_map, functor.map_iso_hom,
-      arrow.right_func_map, arrow.w_mk_right_assoc, arrow.mk_hom],
-    have eq' := arrow.hom.congr_right e.inv_hom_id,
-    dsimp at eq' ⊢,
-    rw [eq', category.comp_id], },
-  rw eq,
-  apply_instance,
-end
+by { rw arrow.iso_w' e, apply_instance, }
 
 lemma iff_of_arrow_iso_left {A B A' B' X Y : C} {i : A ⟶ B} {i' : A' ⟶ B'}
   (e : arrow.mk i ≅ arrow.mk i') (p : X ⟶ Y) :

--- a/src/category_theory/limits/shapes/strong_epi.lean
+++ b/src/category_theory/limits/shapes/strong_epi.lean
@@ -174,25 +174,6 @@ strong_epi_category.strong_epi_of_epi _
 lemma strong_mono_of_mono [strong_mono_category C] (f : P ⟶ Q) [mono f] : strong_mono f :=
 strong_mono_category.strong_mono_of_mono _
 
-lemma strong_epi_of_is_split_epi (f : P ⟶ Q) [is_split_epi f] : strong_epi f :=
-strong_epi.mk' begin
-  introsI X Y z hz u v sq,
-  exact comm_sq.has_lift.mk'
-  { l := section_ f ≫ u,
-    fac_left' := by simp only [← cancel_mono z, sq.w, category.assoc, is_split_epi.id_assoc],
-    fac_right' := by simp only [sq.w, category.assoc, is_split_epi.id_assoc], }
-end
-
-lemma strong_mono_of_is_split_mono (f : P ⟶ Q) [is_split_mono f] : strong_mono f :=
-strong_mono.mk' begin
-  introsI X Y z hz u v sq,
-  exact comm_sq.has_lift.mk'
-  { l := v ≫ retraction f,
-    fac_left' := by simp only [← sq.w_assoc, is_split_mono.id, category.comp_id],
-    fac_right' := by simp [← cancel_epi z, category.assoc, ← sq.w_assoc, sq.w,
-      is_split_mono.id_assoc], }
-end
-
 section
 local attribute [instance] strong_epi_of_epi
 

--- a/src/category_theory/limits/shapes/strong_epi.lean
+++ b/src/category_theory/limits/shapes/strong_epi.lean
@@ -119,6 +119,32 @@ lemma strong_mono_of_strong_mono [strong_mono (f ≫ g)] : strong_mono f :=
 { mono := by apply_instance,
   rlp := λ X Y z hz, has_lifting_property.of_right_iso _ _, }
 
+lemma strong_epi.of_arrow_iso {A B A' B' : C} {f : A ⟶ B} {g : A' ⟶ B'}
+  (e : arrow.mk f ≅ arrow.mk g) [h : strong_epi f] : strong_epi g :=
+{ epi := begin
+    rw arrow.iso_w' e,
+    haveI := epi_comp f e.hom.right,
+    apply epi_comp,
+  end,
+  llp := λ X Y z, by { introI, apply has_lifting_property.of_arrow_iso_left e z, }, }
+
+lemma strong_mono.of_arrow_iso {A B A' B' : C} {f : A ⟶ B} {g : A' ⟶ B'}
+  (e : arrow.mk f ≅ arrow.mk g) [h : strong_mono f] : strong_mono g :=
+{ mono := begin
+    rw arrow.iso_w' e,
+    haveI := mono_comp f e.hom.right,
+    apply mono_comp,
+  end,
+  rlp := λ X Y z, by { introI, apply has_lifting_property.of_arrow_iso_right z e, }, }
+
+lemma strong_epi.iff_of_arrow_iso {A B A' B' : C} {f : A ⟶ B} {g : A' ⟶ B'}
+  (e : arrow.mk f ≅ arrow.mk g) : strong_epi f ↔ strong_epi g :=
+by { split; introI, exacts [strong_epi.of_arrow_iso e, strong_epi.of_arrow_iso e.symm], }
+
+lemma strong_mono.iff_of_arrow_iso {A B A' B' : C} {f : A ⟶ B} {g : A' ⟶ B'}
+  (e : arrow.mk f ≅ arrow.mk g) : strong_mono f ↔ strong_mono g :=
+by { split; introI, exacts [strong_mono.of_arrow_iso e, strong_mono.of_arrow_iso e.symm], }
+
 end
 
 /-- A strong epimorphism that is a monomorphism is an isomorphism. -/
@@ -147,6 +173,25 @@ strong_epi_category.strong_epi_of_epi _
 
 lemma strong_mono_of_mono [strong_mono_category C] (f : P ⟶ Q) [mono f] : strong_mono f :=
 strong_mono_category.strong_mono_of_mono _
+
+lemma strong_epi_of_is_split_epi (f : P ⟶ Q) [is_split_epi f] : strong_epi f :=
+strong_epi.mk' begin
+  introsI X Y z hz u v sq,
+  exact comm_sq.has_lift.mk'
+  { l := section_ f ≫ u,
+    fac_left' := by simp only [← cancel_mono z, sq.w, category.assoc, is_split_epi.id_assoc],
+    fac_right' := by simp only [sq.w, category.assoc, is_split_epi.id_assoc], }
+end
+
+lemma strong_mono_of_is_split_mono (f : P ⟶ Q) [is_split_mono f] : strong_mono f :=
+strong_mono.mk' begin
+  introsI X Y z hz u v sq,
+  exact comm_sq.has_lift.mk'
+  { l := v ≫ retraction f,
+    fac_left' := by simp only [← sq.w_assoc, is_split_mono.id, category.comp_id],
+    fac_right' := by simp [← cancel_epi z, category.assoc, ← sq.w_assoc, sq.w,
+      is_split_mono.id_assoc], }
+end
 
 section
 local attribute [instance] strong_epi_of_epi


### PR DESCRIPTION
In order to prepare for the proof of the existence of strong epi mono factorisations in `simplex_category` (which shall be used for the Dold-Kan correspondence), various results are obtained, mostly about strong epimorphisms (and strong monomorphisms). If two arrows are isomorphic, then one is a strong epi iff the other is. An equivalence of categories preserves and reflects strong epimorphisms.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
