### PR TITLE
[Merged by Bors] - feat(data/nat/factorization/basic): lemmas about `n.factorization p = 0`

### DIFF
--- a/src/data/nat/factorization/basic.lean
+++ b/src/data/nat/factorization/basic.lean
@@ -140,13 +140,13 @@ lemma prime.factorization_pos_of_dvd {n p : ℕ} (hp : p.prime) (hn : n ≠ 0) (
 by rwa [←factors_count_eq, count_pos, mem_factors_iff_dvd hn hp]
 
 /-- The only numbers with empty prime factorization are `0` and `1` -/
-lemma factorization_eq_zero_iff (n : ℕ) : n.factorization = 0 ↔ n = 0 ∨ n = 1 :=
+lemma factorization_eq_zero_iff_le_one (n : ℕ) : n.factorization = 0 ↔ n = 0 ∨ n = 1 :=
 begin
   rw factorization_eq_factors_multiset n,
   simp [factorization, add_equiv.map_eq_zero_iff, multiset.coe_eq_zero],
 end
 
-lemma factorization_eq_zero_iff' (n p : ℕ) :
+lemma factorization_eq_zero_iff (n p : ℕ) :
   n.factorization p = 0 ↔ ¬p.prime ∨ ¬p ∣ n ∨ n = 0 :=
 begin
   rw [←not_mem_support_iff, support_factorization, mem_to_finset],
@@ -157,7 +157,7 @@ end
 
 lemma factorization_eq_zero_of_not_dvd {n p : ℕ} (h : ¬ p ∣ n) : n.factorization p = 0 :=
 begin
-  rw factorization_eq_zero_iff', simp [h],
+  rw factorization_eq_zero_iff, simp [h],
 end
 
 lemma factorization_eq_zero_of_remainder {p r : ℕ} (i : ℕ) (hr : ¬ p ∣ r) :
@@ -173,8 +173,8 @@ begin
   refine ⟨factorization_eq_zero_of_remainder i, λ h, _⟩,
   rcases eq_or_ne i 0 with rfl | hi0, {
     simp only [mul_zero, zero_add] at h,
-    simpa [pp, hr0] using (factorization_eq_zero_iff' _ _).1 h },
-  rw factorization_eq_zero_iff' at h,
+    simpa [pp, hr0] using (factorization_eq_zero_iff _ _).1 h },
+  rw factorization_eq_zero_iff at h,
   simp only [pp, hr0, not_true, _root_.add_eq_zero_iff, and_false, or_false, false_or] at h,
   contrapose! h,
   rwa ←nat.dvd_add_iff_right ((dvd.intro i rfl)),
@@ -459,7 +459,7 @@ begin
   by_cases pp : p.prime, swap, { simp [pp] },
   ext q,
   rcases eq_or_ne q p with rfl | hqp,
-  { simp only [finsupp.erase_same, factorization_eq_zero_iff', not_dvd_ord_compl pp hn],
+  { simp only [finsupp.erase_same, factorization_eq_zero_iff, not_dvd_ord_compl pp hn],
     simp },
   { rw [finsupp.erase_ne hqp, factorization_div (ord_proj_dvd n p)],
     simp [pp.factorization, hqp.symm] },
@@ -474,7 +474,7 @@ begin
   rw [←(factorization_le_iff_dvd hd0 (ord_compl_pos p hn0).ne'), factorization_ord_compl],
   intro q,
   rcases eq_or_ne q p with rfl | hqp,
-  { simp [factorization_eq_zero_iff', hpd] },
+  { simp [factorization_eq_zero_iff, hpd] },
   { simp [hqp, (factorization_le_iff_dvd hd0 hn0).2 hdn q] },
 end
 

--- a/src/data/nat/factorization/basic.lean
+++ b/src/data/nat/factorization/basic.lean
@@ -231,7 +231,7 @@ begin
   refl,
 end
 
-/-- The only prime factor of prime `p` is `p` itself, with multiplicity `1` -/
+/-- The multiplicity of prime `p` in `p` is `1` -/
 @[simp] lemma prime.factorization_self {p : ℕ} (hp : prime p) : p.factorization p = 1 :=
 by simp [hp]
 
@@ -245,7 +245,10 @@ lemma eq_pow_of_factorization_eq_single {n p k : ℕ} (hn : n ≠ 0)
   (h : n.factorization = finsupp.single p k) : n = p ^ k :=
 by { rw [←nat.factorization_prod_pow_eq_self hn, h], simp }
 
-
+/-- The only prime factor of prime `p` is `p` itself. -/
+lemma prime.eq_of_factorization_pos {p q : ℕ} (hp : prime p) (h : p.factorization q ≠ 0) :
+  p = q :=
+by simpa [hp.factorization, single_apply] using h
 
 /-! ### Equivalence between `ℕ+` and `ℕ →₀ ℕ` with support in the primes. -/
 

--- a/src/data/nat/factorization/basic.lean
+++ b/src/data/nat/factorization/basic.lean
@@ -175,9 +175,7 @@ begin
   simp [factorization, add_equiv.map_eq_zero_iff, multiset.coe_eq_zero],
 end
 
-
--- TODO: Fill in this docstring
-/-! ##  -/
+/-! ## Lemmas about factorizations of products and powers -/
 
 /-- For nonzero `a` and `b`, the power of `p` in `a * b` is the sum of the powers in `a` and `b` -/
 @[simp] lemma factorization_mul {a b : ℕ} (ha : a ≠ 0) (hb : b ≠ 0) :
@@ -213,8 +211,6 @@ begin
     simp [prod_insert hxT, sum_insert hxT, ←IH, factorization_mul (hS x hxS) hT] }
 end
 
-/-! ##  -/
-
 /-- For any `p`, the power of `p` in `n^k` is `k` times the power in `n` -/
 @[simp] lemma factorization_pow (n k : ℕ) :
   factorization (n^k) = k • n.factorization :=
@@ -223,6 +219,8 @@ begin
   rcases eq_or_ne n 0 with rfl | hn, { simp },
   rw [pow_succ, factorization_mul hn (pow_ne_zero _ hn), ih, succ_eq_one_add, add_smul, one_smul],
 end
+
+/-! ## Lemmas about factorizations of primes and prime powers -/
 
 /-- The only prime factor of prime `p` is `p` itself, with multiplicity `1` -/
 @[simp] lemma prime.factorization {p : ℕ} (hp : prime p) :

--- a/src/data/nat/factorization/basic.lean
+++ b/src/data/nat/factorization/basic.lean
@@ -155,6 +155,32 @@ begin
   { simp [hn, nat.mem_factors, not_and_distrib] },
 end
 
+lemma factorization_eq_zero_of_not_dvd {n p : ℕ} (h : ¬ p ∣ n) : n.factorization p = 0 :=
+begin
+  rw factorization_eq_zero_iff', simp [h],
+end
+
+lemma factorization_eq_zero_of_remainder {p r : ℕ} (i : ℕ) (hr : ¬ p ∣ r) :
+  (p * i + r).factorization p = 0 :=
+begin
+  apply factorization_eq_zero_of_not_dvd,
+  rwa ←nat.dvd_add_iff_right ((dvd.intro i rfl)),
+end
+
+lemma factorization_eq_zero_iff_remainder {p r : ℕ} (i : ℕ) (pp : p.prime) (hr0 : r ≠ 0) :
+  (¬ p ∣ r) ↔ (p * i + r).factorization p = 0 :=
+begin
+  refine ⟨factorization_eq_zero_of_remainder i, λ h, _⟩,
+  rcases eq_or_ne i 0 with rfl | hi0, {
+    simp only [mul_zero, zero_add] at h,
+    simpa [pp, hr0] using (factorization_eq_zero_iff' _ _).1 h },
+  rw factorization_eq_zero_iff' at h,
+  simp only [pp, hr0, not_true, _root_.add_eq_zero_iff, and_false, or_false, false_or] at h,
+  contrapose! h,
+  rwa ←nat.dvd_add_iff_right ((dvd.intro i rfl)),
+end
+
+
 /-- For nonzero `a` and `b`, the power of `p` in `a * b` is the sum of the powers in `a` and `b` -/
 @[simp] lemma factorization_mul {a b : ℕ} (ha : a ≠ 0) (hb : b ≠ 0) :
   (a * b).factorization = a.factorization + b.factorization :=

--- a/src/data/nat/factorization/basic.lean
+++ b/src/data/nat/factorization/basic.lean
@@ -119,6 +119,17 @@ prime.pos (prime_of_mem_factorization hp)
 lemma le_of_mem_factorization {n p : ℕ} (h : p ∈ n.factorization.support) : p ≤ n :=
 le_of_mem_factors (factor_iff_mem_factorization.mp h)
 
+/-! ## Lemmas characterising when `n.factorization p = 0` -/
+
+lemma factorization_eq_zero_iff (n p : ℕ) :
+  n.factorization p = 0 ↔ ¬p.prime ∨ ¬p ∣ n ∨ n = 0 :=
+begin
+  rw [←not_mem_support_iff, support_factorization, mem_to_finset],
+  rcases eq_or_ne n 0 with rfl | hn,
+  { simp },
+  { simp [hn, nat.mem_factors, not_and_distrib] },
+end
+
 @[simp]
 lemma factorization_eq_zero_of_non_prime (n : ℕ) {p : ℕ} (hp : ¬p.prime) : n.factorization p = 0 :=
 not_mem_support_iff.1 (mt prime_of_mem_factorization hp)
@@ -139,21 +150,6 @@ lemma prime.factorization_pos_of_dvd {n p : ℕ} (hp : p.prime) (hn : n ≠ 0) (
   0 < n.factorization p :=
 by rwa [←factors_count_eq, count_pos, mem_factors_iff_dvd hn hp]
 
-/-- The only numbers with empty prime factorization are `0` and `1` -/
-lemma factorization_eq_zero_iff_le_one (n : ℕ) : n.factorization = 0 ↔ n = 0 ∨ n = 1 :=
-begin
-  rw factorization_eq_factors_multiset n,
-  simp [factorization, add_equiv.map_eq_zero_iff, multiset.coe_eq_zero],
-end
-
-lemma factorization_eq_zero_iff (n p : ℕ) :
-  n.factorization p = 0 ↔ ¬p.prime ∨ ¬p ∣ n ∨ n = 0 :=
-begin
-  rw [←not_mem_support_iff, support_factorization, mem_to_finset],
-  rcases eq_or_ne n 0 with rfl | hn,
-  { simp },
-  { simp [hn, nat.mem_factors, not_and_distrib] },
-end
 
 lemma factorization_eq_zero_of_not_dvd {n p : ℕ} (h : ¬ p ∣ n) : n.factorization p = 0 :=
 begin
@@ -179,6 +175,17 @@ begin
   contrapose! h,
   rwa ←nat.dvd_add_iff_right ((dvd.intro i rfl)),
 end
+
+/-- The only numbers with empty prime factorization are `0` and `1` -/
+lemma factorization_eq_zero_iff_le_one (n : ℕ) : n.factorization = 0 ↔ n = 0 ∨ n = 1 :=
+begin
+  rw factorization_eq_factors_multiset n,
+  simp [factorization, add_equiv.map_eq_zero_iff, multiset.coe_eq_zero],
+end
+
+
+-- TODO: Fill in this docstring
+/-! ##  -/
 
 
 /-- For nonzero `a` and `b`, the power of `p` in `a * b` is the sum of the powers in `a` and `b` -/

--- a/src/data/nat/factorization/basic.lean
+++ b/src/data/nat/factorization/basic.lean
@@ -169,7 +169,7 @@ begin
 end
 
 /-- The only numbers with empty prime factorization are `0` and `1` -/
-lemma factorization_eq_zero_iff_le_one (n : ℕ) : n.factorization = 0 ↔ n = 0 ∨ n = 1 :=
+lemma factorization_eq_zero_iff' (n : ℕ) : n.factorization = 0 ↔ n = 0 ∨ n = 1 :=
 begin
   rw factorization_eq_factors_multiset n,
   simp [factorization, add_equiv.map_eq_zero_iff, multiset.coe_eq_zero],

--- a/src/data/nat/factorization/basic.lean
+++ b/src/data/nat/factorization/basic.lean
@@ -132,7 +132,10 @@ end
 
 @[simp]
 lemma factorization_eq_zero_of_non_prime (n : ℕ) {p : ℕ} (hp : ¬p.prime) : n.factorization p = 0 :=
-not_mem_support_iff.1 (mt prime_of_mem_factorization hp)
+by simp [factorization_eq_zero_iff, hp]
+
+lemma factorization_eq_zero_of_not_dvd {n p : ℕ} (h : ¬ p ∣ n) : n.factorization p = 0 :=
+by simp [factorization_eq_zero_iff, h]
 
 lemma factorization_eq_zero_of_lt {n p : ℕ} (h : n < p) : n.factorization p = 0 :=
 finsupp.not_mem_support_iff.mp (mt le_of_mem_factorization (not_le_of_lt h))
@@ -149,12 +152,6 @@ dvd_of_mem_factors (factor_iff_mem_factorization.1 (mem_support_iff.2 hn))
 lemma prime.factorization_pos_of_dvd {n p : ℕ} (hp : p.prime) (hn : n ≠ 0) (h : p ∣ n) :
   0 < n.factorization p :=
 by rwa [←factors_count_eq, count_pos, mem_factors_iff_dvd hn hp]
-
-
-lemma factorization_eq_zero_of_not_dvd {n p : ℕ} (h : ¬ p ∣ n) : n.factorization p = 0 :=
-begin
-  rw factorization_eq_zero_iff, simp [h],
-end
 
 lemma factorization_eq_zero_of_remainder {p r : ℕ} (i : ℕ) (hr : ¬ p ∣ r) :
   (p * i + r).factorization p = 0 :=

--- a/src/data/nat/factorization/basic.lean
+++ b/src/data/nat/factorization/basic.lean
@@ -155,22 +155,17 @@ by rwa [←factors_count_eq, count_pos, mem_factors_iff_dvd hn hp]
 
 lemma factorization_eq_zero_of_remainder {p r : ℕ} (i : ℕ) (hr : ¬ p ∣ r) :
   (p * i + r).factorization p = 0 :=
-begin
-  apply factorization_eq_zero_of_not_dvd,
-  rwa ←nat.dvd_add_iff_right ((dvd.intro i rfl)),
-end
+by { apply factorization_eq_zero_of_not_dvd, rwa ←nat.dvd_add_iff_right (dvd.intro i rfl) }
 
 lemma factorization_eq_zero_iff_remainder {p r : ℕ} (i : ℕ) (pp : p.prime) (hr0 : r ≠ 0) :
   (¬ p ∣ r) ↔ (p * i + r).factorization p = 0 :=
 begin
   refine ⟨factorization_eq_zero_of_remainder i, λ h, _⟩,
-  rcases eq_or_ne i 0 with rfl | hi0, {
-    simp only [mul_zero, zero_add] at h,
-    simpa [pp, hr0] using (factorization_eq_zero_iff _ _).1 h },
   rw factorization_eq_zero_iff at h,
-  simp only [pp, hr0, not_true, _root_.add_eq_zero_iff, and_false, or_false, false_or] at h,
   contrapose! h,
-  rwa ←nat.dvd_add_iff_right ((dvd.intro i rfl)),
+  refine ⟨pp, _, _⟩,
+  { rwa ←nat.dvd_add_iff_right ((dvd.intro i rfl)) },
+  { contrapose! hr0, exact (_root_.add_eq_zero_iff.mp hr0).2 },
 end
 
 /-- The only numbers with empty prime factorization are `0` and `1` -/


### PR DESCRIPTION
Adds some lemmas characterising conditions when `n.factorization p = 0`.

This PR also rearranges the order of some lemmas to better group them together (and adds some section docstrings).
Also swaps the names `factorization_eq_zero_iff` and `factorization_eq_zero_iff'`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
