### PR TITLE
[Merged by Bors] - chore(algebra/order/absolute_value): superficial tidying

### DIFF
--- a/src/algebra/order/absolute_value.lean
+++ b/src/algebra/order/absolute_value.lean
@@ -35,6 +35,8 @@ initialize_simps_projections absolute_value (to_mul_hom_to_fun → apply)
 
 section ordered_semiring
 
+section semiring
+
 variables {R S : Type*} [semiring R] [ordered_semiring S] (abv : absolute_value R S)
 
 instance mul_hom_class : mul_hom_class (absolute_value R S) R S :=
@@ -59,45 +61,40 @@ lt_of_le_of_ne (abv.nonneg x) (ne.symm $ mt abv.eq_zero.mp hx)
 
 protected theorem ne_zero {x : R} (hx : x ≠ 0) : abv x ≠ 0 := (abv.pos hx).ne'
 
+theorem map_one_of_is_regular (h : is_left_regular (abv 1)) : abv 1 = 1 :=
+h $ by simp [←abv.map_mul]
+
 @[simp] protected theorem map_zero : abv 0 = 0 := abv.eq_zero.2 rfl
+
+end semiring
+
+section ring
+
+variables {R S : Type*} [ring R] [ordered_semiring S] (abv : absolute_value R S)
+
+protected lemma sub_le (a b c : R) : abv (a - c) ≤ abv (a - b) + abv (b - c) :=
+by simpa [sub_eq_add_neg, add_assoc] using abv.add_le (a - b) (b - c)
+
+@[simp] lemma map_sub_eq_zero_iff (a b : R) : abv (a - b) = 0 ↔ a = b :=
+abv.eq_zero.trans sub_eq_zero
+
+end ring
 
 end ordered_semiring
 
 section ordered_ring
 
-variables {R S : Type*} [ring R] [ordered_ring S] (abv : absolute_value R S)
+section semiring
 
-protected lemma sub_le (a b c : R) : abv (a - c) ≤ abv (a - b) + abv (b - c) :=
-by simpa [sub_eq_add_neg, add_assoc] using abv.add_le (a - b) (b - c)
+section is_domain
 
-protected lemma le_sub (a b : R) : abv a - abv b ≤ abv (a - b) :=
-sub_le_iff_le_add.2 $ by simpa using abv.add_le (a - b) b
-
-@[simp] lemma map_sub_eq_zero_iff (a b : R) : abv (a - b) = 0 ↔ a = b :=
-abv.eq_zero.trans sub_eq_zero
-
-end ordered_ring
-
-section linear_ordered_ring
-
-variables {R S : Type*} [semiring R] [linear_ordered_ring S] (abv : absolute_value R S)
-
-/-- `absolute_value.abs` is `abs` as a bundled `absolute_value`. -/
-@[simps]
-protected def abs : absolute_value S S :=
-{ to_fun := abs,
-  nonneg' := abs_nonneg,
-  eq_zero' := λ _, abs_eq_zero,
-  add_le' := abs_add,
-  map_mul' := abs_mul }
-
-instance : inhabited (absolute_value S S) := ⟨absolute_value.abs⟩
-
-variables [nontrivial R]
+-- all of these are true for `no_zero_divisors S`; but it doesn't work smoothly with the
+-- `is_domain`/`cancel_monoid_with_zero` API
+variables {R S : Type*} [semiring R] [ordered_ring S] (abv : absolute_value R S)
+variables [is_domain S] [nontrivial R]
 
 @[simp] protected theorem map_one : abv 1 = 1 :=
-(mul_right_inj' $ abv.ne_zero one_ne_zero).1 $
-by rw [← abv.map_mul, mul_one, mul_one]
+abv.map_one_of_is_regular ((is_regular_of_ne_zero $ abv.ne_zero one_ne_zero).left)
 
 instance : monoid_with_zero_hom_class (absolute_value R S) R S :=
 { map_zero := λ f, f.map_zero,
@@ -117,13 +114,25 @@ def to_monoid_hom : R →* S := abv
 @[simp] protected lemma map_pow (a : R) (n : ℕ) : abv (a ^ n) = abv a ^ n :=
 abv.to_monoid_hom.map_pow a n
 
-end linear_ordered_ring
+end is_domain
 
-section linear_ordered_comm_ring
+end semiring
 
 section ring
 
-variables {R S : Type*} [ring R] [linear_ordered_comm_ring S] (abv : absolute_value R S)
+variables {R S : Type*} [ring R] [ordered_ring S] (abv : absolute_value R S)
+
+protected lemma le_sub (a b : R) : abv a - abv b ≤ abv (a - b) :=
+sub_le_iff_le_add.2 $ by simpa using abv.add_le (a - b) b
+
+end ring
+
+end ordered_ring
+
+section ordered_comm_ring
+
+variables {R S : Type*} [ring R] [ordered_comm_ring S] (abv : absolute_value R S)
+variables [no_zero_divisors S]
 
 @[simp] protected theorem map_neg (a : R) : abv (-a) = abv a :=
 begin
@@ -136,17 +145,36 @@ end
 protected theorem map_sub (a b : R) : abv (a - b) = abv (b - a) :=
 by rw [← neg_sub, abv.map_neg]
 
+end ordered_comm_ring
+
+section linear_ordered_ring
+
+variables {R S : Type*} [semiring R] [linear_ordered_ring S] (abv : absolute_value R S)
+
+/-- `absolute_value.abs` is `abs` as a bundled `absolute_value`. -/
+@[simps]
+protected def abs : absolute_value S S :=
+{ to_fun := abs,
+  nonneg' := abs_nonneg,
+  eq_zero' := λ _, abs_eq_zero,
+  add_le' := abs_add,
+  map_mul' := abs_mul }
+
+instance : inhabited (absolute_value S S) := ⟨absolute_value.abs⟩
+
+end linear_ordered_ring
+
+section linear_ordered_comm_ring
+
+variables {R S : Type*} [ring R] [linear_ordered_comm_ring S] (abv : absolute_value R S)
+
 lemma abs_abv_sub_le_abv_sub (a b : R) :
   abs (abv a - abv b) ≤ abv (a - b) :=
 abs_sub_le_iff.2 ⟨abv.le_sub _ _, by rw abv.map_sub; apply abv.le_sub⟩
 
-end ring
-
 end linear_ordered_comm_ring
 
 end absolute_value
-
-section is_absolute_value
 
 /-- A function `f` is an absolute value if it is nonnegative, zero only at 0, additive, and
 multiplicative.
@@ -168,7 +196,7 @@ variables {S : Type*} [ordered_semiring S]
 variables {R : Type*} [semiring R] (abv : R → S) [is_absolute_value abv]
 
 /-- A bundled absolute value is an absolute value. -/
-instance absolute_value.is_absolute_value
+instance _root_.absolute_value.is_absolute_value
   (abv : absolute_value R S) : is_absolute_value abv :=
 { abv_nonneg := abv.nonneg,
   abv_eq_zero := λ _, abv.eq_zero,
@@ -184,85 +212,118 @@ def to_absolute_value : absolute_value R S :=
   nonneg' := abv_nonneg abv,
   map_mul' := abv_mul abv }
 
-theorem abv_zero : abv 0 = 0 := (abv_eq_zero abv).2 rfl
+theorem abv_zero : abv 0 = 0 := (to_absolute_value abv).map_zero
 
-theorem abv_pos {a : R} : 0 < abv a ↔ a ≠ 0 :=
-by rw [lt_iff_le_and_ne, ne, eq_comm]; simp [abv_eq_zero abv, abv_nonneg abv]
-
+theorem abv_pos {a : R} : 0 < abv a ↔ a ≠ 0 := (to_absolute_value abv).pos_iff
 
 end ordered_semiring
 
 section linear_ordered_ring
 
 variables {S : Type*} [linear_ordered_ring S]
-variables {R : Type*} [semiring R] (abv : R → S) [is_absolute_value abv]
 
-instance abs_is_absolute_value {S} [linear_ordered_ring S] :
-  is_absolute_value (abs : S → S) :=
-{ abv_nonneg  := abs_nonneg,
-  abv_eq_zero := λ _, abs_eq_zero,
-  abv_add     := abs_add,
-  abv_mul     := abs_mul }
+instance abs_is_absolute_value : is_absolute_value (abs : S → S) :=
+  absolute_value.abs.is_absolute_value
 
 end linear_ordered_ring
 
-section linear_ordered_comm_ring
+section ordered_ring
 
-variables {S : Type*} [linear_ordered_comm_ring S]
+variables {S : Type*} [ordered_ring S]
 
 section semiring
+
 variables {R : Type*} [semiring R] (abv : R → S) [is_absolute_value abv]
 
-theorem abv_one [nontrivial R] : abv 1 = 1 :=
-(mul_right_inj' $ mt (abv_eq_zero abv).1 one_ne_zero).1 $
-by rw [← abv_mul abv, mul_one, mul_one]
+variables [is_domain S]
+
+theorem abv_one [nontrivial R] : abv 1 = 1 := (to_absolute_value abv).map_one
 
 /-- `abv` as a `monoid_with_zero_hom`. -/
-def abv_hom [nontrivial R] : R →*₀ S := ⟨abv, abv_zero abv, abv_one abv, abv_mul abv⟩
+def abv_hom [nontrivial R] : R →*₀ S := (to_absolute_value abv).to_monoid_with_zero_hom
 
 lemma abv_pow [nontrivial R] (abv : R → S) [is_absolute_value abv]
   (a : R) (n : ℕ) : abv (a ^ n) = abv a ^ n :=
-(abv_hom abv).to_monoid_hom.map_pow a n
+(to_absolute_value abv).map_pow a n
 
 end semiring
 
-end linear_ordered_comm_ring
-
-section linear_ordered_field
-variables {S : Type*} [linear_ordered_field S]
-
 section ring
+
 variables {R : Type*} [ring R] (abv : R → S) [is_absolute_value abv]
-
-theorem abv_neg (a : R) : abv (-a) = abv a :=
-by rw [← mul_self_inj_of_nonneg (abv_nonneg abv _) (abv_nonneg abv _),
-← abv_mul abv, ← abv_mul abv]; simp
-
-theorem abv_sub (a b : R) : abv (a - b) = abv (b - a) :=
-by rw [← neg_sub, abv_neg abv]
 
 lemma abv_sub_le (a b c : R) : abv (a - c) ≤ abv (a - b) + abv (b - c) :=
 by simpa [sub_eq_add_neg, add_assoc] using abv_add abv (a - b) (b - c)
 
 lemma sub_abv_le_abv_sub (a b : R) : abv a - abv b ≤ abv (a - b) :=
-sub_le_iff_le_add.2 $ by simpa using abv_add abv (a - b) b
+(to_absolute_value abv).le_sub a b
+
+end ring
+
+end ordered_ring
+
+section ordered_comm_ring
+
+variables {S : Type*} [ordered_comm_ring S]
+
+section ring
+
+variables {R : Type*} [ring R] (abv : R → S) [is_absolute_value abv]
+
+variables [no_zero_divisors S]
+
+theorem abv_neg (a : R) : abv (-a) = abv a :=
+(to_absolute_value abv).map_neg a
+
+theorem abv_sub (a b : R) : abv (a - b) = abv (b - a) :=
+(to_absolute_value abv).map_sub a b
+
+end ring
+
+end ordered_comm_ring
+
+section linear_ordered_comm_ring
+
+variables {S : Type*} [linear_ordered_comm_ring S]
+
+section ring
+
+variables {R : Type*} [ring R] (abv : R → S) [is_absolute_value abv]
 
 lemma abs_abv_sub_le_abv_sub (a b : R) :
   abs (abv a - abv b) ≤ abv (a - b) :=
-abs_sub_le_iff.2 ⟨sub_abv_le_abv_sub abv _ _,
-  by rw abv_sub abv; apply sub_abv_le_abv_sub abv⟩
+(to_absolute_value abv).abs_abv_sub_le_abv_sub a b
+
 end ring
 
-section field
-variables {R : Type*} [division_ring R] (abv : R → S) [is_absolute_value abv]
+end linear_ordered_comm_ring
 
-theorem abv_inv (a : R) : abv a⁻¹ = (abv a)⁻¹ := map_inv₀ (abv_hom abv) a
-theorem abv_div (a b : R) : abv (a / b) = abv a / abv b := map_div₀ (abv_hom abv) a b
+section linear_ordered_field
 
-end field
+variables {S : Type*} [linear_ordered_semifield S]
+
+section semiring
+
+variables {R : Type*} [semiring R] [nontrivial R] (abv : R → S) [is_absolute_value abv]
+
+lemma abv_one' : abv 1 = 1 :=
+(to_absolute_value abv).map_one_of_is_regular
+  $ (is_regular_of_ne_zero $ (to_absolute_value abv).ne_zero one_ne_zero).left
+
+/-- An absolute value as a monoid with zero homomorphism, assuming the target is a semifield. -/
+def abv_hom' : R →*₀ S := ⟨abv, abv_zero abv, abv_one' abv, abv_mul abv⟩
+
+end semiring
+
+section division_semiring
+
+variables {R : Type*} [division_semiring R] (abv : R → S) [is_absolute_value abv]
+
+theorem abv_inv (a : R) : abv a⁻¹ = (abv a)⁻¹ := map_inv₀ (abv_hom' abv) a
+theorem abv_div (a b : R) : abv (a / b) = abv a / abv b := map_div₀ (abv_hom' abv) a b
+
+end division_semiring
 
 end linear_ordered_field
-
-end is_absolute_value
 
 end is_absolute_value

--- a/src/algebra/order/absolute_value.lean
+++ b/src/algebra/order/absolute_value.lean
@@ -306,7 +306,6 @@ section semiring
 
 variables {R : Type*} [semiring R] [nontrivial R] (abv : R → S) [is_absolute_value abv]
 
-@[simp]
 lemma abv_one' : abv 1 = 1 :=
 (to_absolute_value abv).map_one_of_is_regular
   $ (is_regular_of_ne_zero $ (to_absolute_value abv).ne_zero one_ne_zero).left

--- a/src/algebra/order/absolute_value.lean
+++ b/src/algebra/order/absolute_value.lean
@@ -306,6 +306,7 @@ section semiring
 
 variables {R : Type*} [semiring R] [nontrivial R] (abv : R → S) [is_absolute_value abv]
 
+@[simp]
 lemma abv_one' : abv 1 = 1 :=
 (to_absolute_value abv).map_one_of_is_regular
   $ (is_regular_of_ne_zero $ (to_absolute_value abv).ne_zero one_ne_zero).left


### PR DESCRIPTION
This weakens the requirements of many lemmas in this file, preparing for further changes. `is_absolute_value` is unbundled, which is an approach that is currently not favoured in mathlib.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
