### PR TITLE
[Merged by Bors] - feat(algebra/star/self_adjoint): add `star_mul_self`, `mul_star_self` and `star_hom_apply`

### DIFF
--- a/src/algebra/star/self_adjoint.lean
+++ b/src/algebra/star/self_adjoint.lean
@@ -58,6 +58,17 @@ lemma star_eq [has_star R] {x : R} (hx : is_self_adjoint x) : star x = x := hx
 
 lemma _root_.is_self_adjoint_iff [has_star R] {x : R} : is_self_adjoint x ↔ star x = x := iff.rfl
 
+lemma star_mul_self [semigroup R] [star_semigroup R] (x : R) : is_self_adjoint (star x * x) :=
+by simp only [is_self_adjoint, star_mul, star_star]
+
+lemma mul_star_self [semigroup R] [star_semigroup R] (x : R) : is_self_adjoint (x * star x) :=
+by simpa only [star_star] using star_mul_self (star x)
+
+/-- Functions in a `star_hom_class` preserve self-adjoint elements. -/
+lemma star_hom_apply {F R S : Type*} [has_star R] [has_star S] [star_hom_class F R S]
+  {x : R} (hx : is_self_adjoint x) (f : F) : is_self_adjoint (f x) :=
+show star (f x) = f x, from map_star f x ▸ congr_arg f hx
+
 section add_group
 variables [add_group R] [star_add_monoid R]
 

--- a/src/algebra/star/self_adjoint.lean
+++ b/src/algebra/star/self_adjoint.lean
@@ -58,9 +58,11 @@ lemma star_eq [has_star R] {x : R} (hx : is_self_adjoint x) : star x = x := hx
 
 lemma _root_.is_self_adjoint_iff [has_star R] {x : R} : is_self_adjoint x ↔ star x = x := iff.rfl
 
+@[simp]
 lemma star_mul_self [semigroup R] [star_semigroup R] (x : R) : is_self_adjoint (star x * x) :=
 by simp only [is_self_adjoint, star_mul, star_star]
 
+@[simp]
 lemma mul_star_self [semigroup R] [star_semigroup R] (x : R) : is_self_adjoint (x * star x) :=
 by simpa only [star_star] using star_mul_self (star x)
 


### PR DESCRIPTION
add some basic missing lemmas in the `is_self_adjoint` namespace: that `star x * x`, `x * (star x)` are selfadjoint, and members of a `star_hom_class` preserve self-adjoint elements.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
