### PR TITLE
[Merged by Bors] - refactor(category_theory/morphism_property): stable_under_base_change

### DIFF
--- a/src/algebraic_geometry/morphisms/basic.lean
+++ b/src/algebraic_geometry/morphisms/basic.lean
@@ -413,9 +413,10 @@ end
 
 lemma is_local.stable_under_base_change
   {P : affine_target_morphism_property} (hP : P.is_local) (hP' : P.stable_under_base_change) :
-  (target_affine_locally P).stable_under_base_change  :=
+  (target_affine_locally P).stable_under_base_change :=
+morphism_property.stable_under_base_change.mk (target_affine_locally_respects_iso hP.respects_iso)
 begin
-  introv X H,
+  intros X Y S f g H,
   rw (hP.target_affine_locally_is_local.open_cover_tfae (pullback.fst : pullback f g ⟶ X)).out 0 1,
   use S.affine_cover.pullback_cover f,
   intro i,

--- a/src/category_theory/limits/shapes/comm_sq.lean
+++ b/src/category_theory/limits/shapes/comm_sq.lean
@@ -213,6 +213,13 @@ lemma of_iso_pullback (h : comm_sq fst snd f g) [has_pullback f g] (i : P ≅ pu
 of_is_limit' h (limits.is_limit.of_iso_limit (limit.is_limit _)
   (@pullback_cone.ext _ _ _ _ _ _ _ (pullback_cone.mk _ _ _) _ i w₁.symm w₂.symm).symm)
 
+lemma of_horiz_is_iso [is_iso fst] [is_iso g] (sq : comm_sq fst snd f g) :
+  is_pullback fst snd f g := of_is_limit' sq
+begin
+  refine pullback_cone.is_limit.mk _ (λ s, s.fst ≫ inv fst) (by tidy) (λ s, _) (by tidy),
+  simp only [← cancel_mono g, category.assoc, ← sq.w, is_iso.inv_hom_id_assoc, s.condition],
+end
+
 end is_pullback
 
 namespace is_pushout
@@ -374,6 +381,9 @@ lemma unop {P X Y Z : Cᵒᵖ} {fst : P ⟶ X} {snd : P ⟶ Y} {f : X ⟶ Z} {g 
 is_pushout.of_is_colimit (is_colimit.of_iso_colimit
   (limits.pullback_cone.is_limit_equiv_is_colimit_unop h.flip.cone h.flip.is_limit)
   h.to_comm_sq.flip.cone_unop)
+
+lemma of_vert_is_iso [is_iso snd] [is_iso f] (sq : comm_sq fst snd f g) :
+  is_pullback fst snd f g := is_pullback.flip (of_horiz_is_iso sq.flip)
 
 end is_pullback
 


### PR DESCRIPTION
This PR redefines `morphism_property.stable_under_base_change P`. This condition now states that for all pullback squares (`is_pullback`), the left map satisfies the property if the right map does. Then, it is automatic that the property `P` respects isos. A constructor is provided to take as an input the assumption that `P` respects isos and the previous condition that if a map `g` satisfies `P`, then `pullback.fst : pullback f g → _` satisfies it `P`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
