### PR TITLE
[Merged by Bors] - feat(analysis/special_functions/trigonometric/angle): continuity and signs

### DIFF
--- a/src/analysis/special_functions/trigonometric/angle.lean
+++ b/src/analysis/special_functions/trigonometric/angle.lean
@@ -6,7 +6,7 @@ Authors: Calle Sönne
 import analysis.special_functions.trigonometric.basic
 import algebra.char_zero.quotient
 import algebra.order.to_interval_mod
-import data.sign
+import topology.instances.sign
 
 /-!
 # The type of angles
@@ -520,6 +520,23 @@ end
 lemma eq_iff_abs_to_real_eq_of_sign_eq {θ ψ : angle} (h : θ.sign = ψ.sign) :
   θ = ψ ↔ |θ.to_real| = |ψ.to_real| :=
 by simpa [h] using @eq_iff_sign_eq_and_abs_to_real_eq θ ψ
+
+lemma continuous_at_sign {θ : angle} (h0 : θ ≠ 0) (hpi : θ ≠ π) : continuous_at sign θ :=
+(continuous_at_sign_of_ne_zero (sin_ne_zero_iff.2 ⟨h0, hpi⟩)).comp continuous_sin.continuous_at
+
+/-- Suppose a function to angles is continuous on a connected set and never takes the values `0`
+or `π` on that set. Then the values of the function on that set all have the same sign. -/
+lemma sign_eq_of_continuous_on {α : Type*} [topological_space α] {f : α → angle} {s : set α}
+  {x y : α} (hc : is_connected s) (hf : continuous_on f s) (hs : ∀ z ∈ s, f z ≠ 0 ∧ f z ≠ π)
+  (hx : x ∈ s) (hy : y ∈ s) : (f y).sign = (f x).sign :=
+begin
+  have hf' : continuous_on (sign ∘ f) s,
+  { refine (continuous_at.continuous_on (λ θ hθ, _)).comp hf (set.maps_to_image f s),
+    obtain ⟨z, hz, rfl⟩ := hθ,
+    exact continuous_at_sign (hs _ hz).1 (hs _ hz).2 },
+  exact (hc.image _ hf').is_preconnected.subsingleton
+    (set.mem_image_of_mem _ hy) (set.mem_image_of_mem _ hx)
+end
 
 end angle
 

--- a/src/analysis/special_functions/trigonometric/angle.lean
+++ b/src/analysis/special_functions/trigonometric/angle.lean
@@ -524,19 +524,22 @@ by simpa [h] using @eq_iff_sign_eq_and_abs_to_real_eq θ ψ
 lemma continuous_at_sign {θ : angle} (h0 : θ ≠ 0) (hpi : θ ≠ π) : continuous_at sign θ :=
 (continuous_at_sign_of_ne_zero (sin_ne_zero_iff.2 ⟨h0, hpi⟩)).comp continuous_sin.continuous_at
 
+lemma _root_.continuous_on.angle_sign_comp {α : Type*} [topological_space α] {f : α → angle}
+  {s : set α} (hf : continuous_on f s) (hs : ∀ z ∈ s, f z ≠ 0 ∧ f z ≠ π) :
+  continuous_on (sign ∘ f) s :=
+begin
+  refine (continuous_at.continuous_on (λ θ hθ, _)).comp hf (set.maps_to_image f s),
+  obtain ⟨z, hz, rfl⟩ := hθ,
+  exact continuous_at_sign (hs _ hz).1 (hs _ hz).2
+end
+
 /-- Suppose a function to angles is continuous on a connected set and never takes the values `0`
 or `π` on that set. Then the values of the function on that set all have the same sign. -/
 lemma sign_eq_of_continuous_on {α : Type*} [topological_space α] {f : α → angle} {s : set α}
   {x y : α} (hc : is_connected s) (hf : continuous_on f s) (hs : ∀ z ∈ s, f z ≠ 0 ∧ f z ≠ π)
   (hx : x ∈ s) (hy : y ∈ s) : (f y).sign = (f x).sign :=
-begin
-  have hf' : continuous_on (sign ∘ f) s,
-  { refine (continuous_at.continuous_on (λ θ hθ, _)).comp hf (set.maps_to_image f s),
-    obtain ⟨z, hz, rfl⟩ := hθ,
-    exact continuous_at_sign (hs _ hz).1 (hs _ hz).2 },
-  exact (hc.image _ hf').is_preconnected.subsingleton
-    (set.mem_image_of_mem _ hy) (set.mem_image_of_mem _ hx)
-end
+(hc.image _ (hf.angle_sign_comp hs)).is_preconnected.subsingleton
+  (set.mem_image_of_mem _ hy) (set.mem_image_of_mem _ hx)
 
 end angle
 


### PR DESCRIPTION
Add the lemmas that `real.angle.sign` is continuous away from 0 and π,
and thus that any function to angles that is continuous on a connected
set and does not take the value 0 or π on that set produces angles
with constant sign on that set (this is a general principle for use in
proving results about when two oriented angles in a geometrical
configuration must have the same sign).



---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
