### PR TITLE
[Merged by Bors] - chore(analysis/normed_space/star/*): migrate use of `a ∈ self_adjoint A` to `is_self_adjoint a`

### DIFF
--- a/src/algebra/star/self_adjoint.lean
+++ b/src/algebra/star/self_adjoint.lean
@@ -259,9 +259,9 @@ instance : has_pow (self_adjoint R) ℤ :=
 
 @[simp, norm_cast] lemma coe_zpow (x : self_adjoint R) (z : ℤ) : ↑(x ^ z) = (x : R) ^ z := rfl
 
-lemma rat_cast_mem : ∀ (x : ℚ), (x : R) ∈ self_adjoint R
+lemma rat_cast_mem : ∀ (x : ℚ), is_self_adjoint (x : R)
 | ⟨a, b, h1, h2⟩ :=
-  by rw [mem_iff, rat.cast_mk', star_mul', star_inv', star_nat_cast, star_int_cast]
+  by rw [is_self_adjoint, rat.cast_mk', star_mul', star_inv', star_nat_cast, star_int_cast]
 
 instance : has_rat_cast (self_adjoint R) :=
 ⟨λ n, ⟨n, rat_cast_mem n⟩⟩

--- a/src/analysis/normed_space/star/basic.lean
+++ b/src/analysis/normed_space/star/basic.lean
@@ -162,8 +162,8 @@ norm_mul_coe_unitary A ⟨U, hU⟩
 end unital
 end cstar_ring
 
-lemma nnnorm_pow_two_pow_of_self_adjoint [normed_ring E] [star_ring E] [cstar_ring E]
-  {x : E} (hx : x ∈ self_adjoint E) (n : ℕ) : ∥x ^ 2 ^ n∥₊ = ∥x∥₊ ^ (2 ^ n) :=
+lemma is_self_adjoint.nnnorm_pow_two_pow_of_self_adjoint [normed_ring E] [star_ring E] [cstar_ring E]
+  {x : E} (hx : is_self_adjoint x) (n : ℕ) : ∥x ^ 2 ^ n∥₊ = ∥x∥₊ ^ (2 ^ n) :=
 begin
   induction n with k hk,
   { simp only [pow_zero, pow_one] },
@@ -174,7 +174,7 @@ end
 
 lemma self_adjoint.nnnorm_pow_two_pow [normed_ring E] [star_ring E] [cstar_ring E]
   (x : self_adjoint E) (n : ℕ) : ∥x ^ 2 ^ n∥₊ = ∥x∥₊ ^ (2 ^ n) :=
-nnnorm_pow_two_pow_of_self_adjoint x.property _
+x.prop.nnnorm_pow_two_pow_of_self_adjoint _
 
 section starₗᵢ
 

--- a/src/analysis/normed_space/star/basic.lean
+++ b/src/analysis/normed_space/star/basic.lean
@@ -162,7 +162,7 @@ norm_mul_coe_unitary A ⟨U, hU⟩
 end unital
 end cstar_ring
 
-lemma is_self_adjoint.nnnorm_pow_two_pow_of_self_adjoint [normed_ring E] [star_ring E]
+lemma is_self_adjoint.nnnorm_pow_two_pow [normed_ring E] [star_ring E]
   [cstar_ring E] {x : E} (hx : is_self_adjoint x) (n : ℕ) : ∥x ^ 2 ^ n∥₊ = ∥x∥₊ ^ (2 ^ n) :=
 begin
   induction n with k hk,
@@ -174,7 +174,7 @@ end
 
 lemma self_adjoint.nnnorm_pow_two_pow [normed_ring E] [star_ring E] [cstar_ring E]
   (x : self_adjoint E) (n : ℕ) : ∥x ^ 2 ^ n∥₊ = ∥x∥₊ ^ (2 ^ n) :=
-x.prop.nnnorm_pow_two_pow_of_self_adjoint _
+x.prop.nnnorm_pow_two_pow _
 
 section starₗᵢ
 

--- a/src/analysis/normed_space/star/basic.lean
+++ b/src/analysis/normed_space/star/basic.lean
@@ -162,8 +162,8 @@ norm_mul_coe_unitary A ⟨U, hU⟩
 end unital
 end cstar_ring
 
-lemma is_self_adjoint.nnnorm_pow_two_pow_of_self_adjoint [normed_ring E] [star_ring E] [cstar_ring E]
-  {x : E} (hx : is_self_adjoint x) (n : ℕ) : ∥x ^ 2 ^ n∥₊ = ∥x∥₊ ^ (2 ^ n) :=
+lemma is_self_adjoint.nnnorm_pow_two_pow_of_self_adjoint [normed_ring E] [star_ring E]
+  [cstar_ring E] {x : E} (hx : is_self_adjoint x) (n : ℕ) : ∥x ^ 2 ^ n∥₊ = ∥x∥₊ ^ (2 ^ n) :=
 begin
   induction n with k hk,
   { simp only [pow_zero, pow_one] },

--- a/src/analysis/normed_space/star/exponential.lean
+++ b/src/analysis/normed_space/star/exponential.lean
@@ -28,7 +28,7 @@ variables {A : Type*}
 
 open complex
 
-lemma self_adjoint.exp_i_smul_unitary {a : A} (ha : a ∈ self_adjoint A) :
+lemma is_self_adjoint.exp_i_smul_unitary {a : A} (ha : is_self_adjoint a) :
   exp ℂ (I • a) ∈ unitary A :=
 begin
   rw [unitary.mem_iff, star_exp],
@@ -42,7 +42,7 @@ end
 over ℂ. -/
 @[simps]
 noncomputable def self_adjoint.exp_unitary (a : self_adjoint A) : unitary A :=
-⟨exp ℂ (I • a), self_adjoint.exp_i_smul_unitary (a.property)⟩
+⟨exp ℂ (I • a), a.prop.exp_i_smul_unitary⟩
 
 open self_adjoint
 

--- a/src/analysis/normed_space/star/spectrum.lean
+++ b/src/analysis/normed_space/star/spectrum.lean
@@ -99,11 +99,11 @@ end
 /-- Any element of the spectrum of a selfadjoint is real. -/
 theorem self_adjoint.mem_spectrum_eq_re [star_module ℂ A] [nontrivial A]
   (a : self_adjoint A) {z : ℂ} (hz : z ∈ spectrum ℂ (a : A)) : z = z.re :=
-a.property.mem_spectrum_eq_re hz
+a.prop.mem_spectrum_eq_re hz
 
 /-- The spectrum of a selfadjoint is real -/
 theorem is_self_adjoint.coe_re_map_spectrum [star_module ℂ A] [nontrivial A] {a : A}
-  (ha : a ∈ self_adjoint A) : spectrum ℂ a = (coe ∘ re '' (spectrum ℂ a) : set ℂ) :=
+  (ha : is_self_adjoint a) : spectrum ℂ a = (coe ∘ re '' (spectrum ℂ a) : set ℂ) :=
 le_antisymm (λ z hz, ⟨z, hz, (ha.mem_spectrum_eq_re hz).symm⟩) (λ z, by
   { rintros ⟨z, hz, rfl⟩,
     simpa only [(ha.mem_spectrum_eq_re hz).symm, function.comp_app] using hz })

--- a/src/analysis/normed_space/star/spectrum.lean
+++ b/src/analysis/normed_space/star/spectrum.lean
@@ -51,26 +51,24 @@ variables {A : Type*}
 
 local notation `↑ₐ` := algebra_map ℂ A
 
-lemma spectral_radius_eq_nnnorm_of_self_adjoint [norm_one_class A] {a : A}
-  (ha : a ∈ self_adjoint A) :
+lemma is_self_adjoint.spectral_radius_eq_nnnorm [norm_one_class A] {a : A}
+  (ha : is_self_adjoint a) :
   spectral_radius ℂ a = ∥a∥₊ :=
 begin
   have hconst : tendsto (λ n : ℕ, (∥a∥₊ : ℝ≥0∞)) at_top _ := tendsto_const_nhds,
   refine tendsto_nhds_unique _ hconst,
   convert (spectrum.pow_nnnorm_pow_one_div_tendsto_nhds_spectral_radius (a : A)).comp
-      (nat.tendsto_pow_at_top_at_top_of_one_lt (by linarith : 1 < 2)),
+      (nat.tendsto_pow_at_top_at_top_of_one_lt one_lt_two),
   refine funext (λ n, _),
   rw [function.comp_app, nnnorm_pow_two_pow_of_self_adjoint ha, ennreal.coe_pow, ←rpow_nat_cast,
     ←rpow_mul],
   simp,
 end
 
-lemma spectral_radius_eq_nnnorm_of_star_normal [norm_one_class A] (a : A) [is_star_normal a] :
+lemma is_star_normal.spectral_radius_eq_nnnorm [norm_one_class A] (a : A) [is_star_normal a] :
   spectral_radius ℂ a = ∥a∥₊ :=
 begin
   refine (ennreal.pow_strict_mono two_ne_zero).injective _,
-  have ha : a⋆ * a ∈ self_adjoint A,
-    from self_adjoint.mem_iff.mpr (by simpa only [star_star] using (star_mul a⋆ a)),
   have heq : (λ n : ℕ, ((∥(a⋆ * a) ^ n∥₊ ^ (1 / n : ℝ)) : ℝ≥0∞))
     = (λ x, x ^ 2) ∘ (λ n : ℕ, ((∥a ^ n∥₊ ^ (1 / n : ℝ)) : ℝ≥0∞)),
   { funext,
@@ -80,12 +78,13 @@ begin
     (spectrum.pow_nnnorm_pow_one_div_tendsto_nhds_spectral_radius a),
   rw ←heq at h₂,
   convert tendsto_nhds_unique h₂ (pow_nnnorm_pow_one_div_tendsto_nhds_spectral_radius (a⋆ * a)),
-  rw [spectral_radius_eq_nnnorm_of_self_adjoint ha, sq, nnnorm_star_mul_self, coe_mul],
+  rw [(is_self_adjoint.star_mul_self a).spectral_radius_eq_nnnorm, sq, nnnorm_star_mul_self,
+    coe_mul],
 end
 
 /-- Any element of the spectrum of a selfadjoint is real. -/
-theorem self_adjoint.mem_spectrum_eq_re [star_module ℂ A] [nontrivial A] {a : A}
-  (ha : a ∈ self_adjoint A) {z : ℂ} (hz : z ∈ spectrum ℂ a) : z = z.re :=
+theorem is_self_adjoint.mem_spectrum_eq_re [star_module ℂ A] [nontrivial A] {a : A}
+  (ha : is_self_adjoint a) {z : ℂ} (hz : z ∈ spectrum ℂ a) : z = z.re :=
 begin
   let Iu := units.mk0 I I_ne_zero,
   have : exp ℂ (I • z) ∈ spectrum ℂ (exp ℂ (I • a)),
@@ -98,20 +97,20 @@ begin
 end
 
 /-- Any element of the spectrum of a selfadjoint is real. -/
-theorem self_adjoint.mem_spectrum_eq_re' [star_module ℂ A] [nontrivial A]
+theorem self_adjoint.mem_spectrum_eq_re [star_module ℂ A] [nontrivial A]
   (a : self_adjoint A) {z : ℂ} (hz : z ∈ spectrum ℂ (a : A)) : z = z.re :=
-self_adjoint.mem_spectrum_eq_re a.property hz
+a.property.mem_spectrum_eq_re hz
 
 /-- The spectrum of a selfadjoint is real -/
-theorem self_adjoint.coe_re_map_spectrum [star_module ℂ A] [nontrivial A] {a : A}
+theorem is_self_adjoint.coe_re_map_spectrum [star_module ℂ A] [nontrivial A] {a : A}
   (ha : a ∈ self_adjoint A) : spectrum ℂ a = (coe ∘ re '' (spectrum ℂ a) : set ℂ) :=
-le_antisymm (λ z hz, ⟨z, hz, (self_adjoint.mem_spectrum_eq_re ha hz).symm⟩) (λ z, by
+le_antisymm (λ z hz, ⟨z, hz, (ha.mem_spectrum_eq_re hz).symm⟩) (λ z, by
   { rintros ⟨z, hz, rfl⟩,
-    simpa only [(self_adjoint.mem_spectrum_eq_re ha hz).symm, function.comp_app] using hz })
+    simpa only [(ha.mem_spectrum_eq_re hz).symm, function.comp_app] using hz })
 
 /-- The spectrum of a selfadjoint is real -/
-theorem self_adjoint.coe_re_map_spectrum' [star_module ℂ A] [nontrivial A] (a : self_adjoint A) :
+theorem self_adjoint.coe_re_map_spectrum [star_module ℂ A] [nontrivial A] (a : self_adjoint A) :
   spectrum ℂ (a : A) = (coe ∘ re '' (spectrum ℂ (a : A)) : set ℂ) :=
-self_adjoint.coe_re_map_spectrum a.property
+a.property.coe_re_map_spectrum
 
 end complex_scalars

--- a/src/analysis/normed_space/star/spectrum.lean
+++ b/src/analysis/normed_space/star/spectrum.lean
@@ -60,7 +60,7 @@ begin
   convert (spectrum.pow_nnnorm_pow_one_div_tendsto_nhds_spectral_radius (a : A)).comp
       (nat.tendsto_pow_at_top_at_top_of_one_lt one_lt_two),
   refine funext (λ n, _),
-  rw [function.comp_app, nnnorm_pow_two_pow_of_self_adjoint ha, ennreal.coe_pow, ←rpow_nat_cast,
+  rw [function.comp_app, ha.nnnorm_pow_two_pow, ennreal.coe_pow, ←rpow_nat_cast,
     ←rpow_mul],
   simp,
 end
@@ -93,7 +93,7 @@ begin
   exact complex.ext (of_real_re _)
     (by simpa only [←complex.exp_eq_exp_ℂ, mem_sphere_zero_iff_norm, norm_eq_abs, abs_exp,
       real.exp_eq_one_iff, smul_eq_mul, I_mul, neg_eq_zero]
-      using spectrum.subset_circle_of_unitary (self_adjoint.exp_i_smul_unitary ha) this),
+      using spectrum.subset_circle_of_unitary ha.exp_i_smul_unitary this),
 end
 
 /-- Any element of the spectrum of a selfadjoint is real. -/


### PR DESCRIPTION
After #15326, this PR migrates existing uses of `a ∈ self_adjoint A` to `is_self_adjoint a` so as to standardize. We also move several results into the `is_self_adjoint` namespace in order to take advantage of dot notation.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
