### PR TITLE
feat(probability_mass_function/uniform): Uniform probability distribution on a list

### DIFF
--- a/src/probability/probability_mass_function/uniform.lean
+++ b/src/probability/probability_mass_function/uniform.lean
@@ -186,6 +186,8 @@ end of_multiset
 
 section of_list
 
+/-- Given a non-empty list `l` construct the `pmf` which sends `a` to the fraction of
+  elements in `l` that are `a`. -/
 def of_list (l : list α) (h : ¬ l.empty) : pmf α :=
 pmf.of_multiset (quotient.mk l) (mt ((list.empty_iff_eq_nil).2 ∘ (multiset.coe_eq_zero l).1) h)
 
@@ -202,7 +204,7 @@ trans (pmf.support_of_multiset _) (set.ext $ λ x, by simp only [multiset.quot_m
 lemma mem_support_of_list_iff (a : α) : a ∈ (of_list l h).support ↔ a ∈ l :=
 by rw [support_of_list, set.mem_set_of_eq]
 
-@[simp] lemma of_list_apply_eq_zero_iff_not_mem (a : α) : of_list l h a = 0 ↔ a ∉ l :=
+lemma of_list_apply_eq_zero_iff_not_mem (a : α) : of_list l h a = 0 ↔ a ∉ l :=
 by rw [pmf.apply_eq_zero_iff _ a, mem_support_of_list_iff]
 
 lemma of_list_apply_eq_one_iff (a : α) : of_list l h a = 1 ↔ ∀ a' ∈ l, a' = a :=

--- a/src/probability/probability_mass_function/uniform.lean
+++ b/src/probability/probability_mass_function/uniform.lean
@@ -245,7 +245,7 @@ begin
 end
 
 @[simp] lemma to_measure_of_list_apply (t : set α) [measurable_space α] (ht : measurable_set t) :
-  (of_list l h).to_measure t = l.countp t / l.length :=
+  (of_list l h).to_measure t = l.countp (∈ t) / l.length :=
 (to_measure_apply_eq_to_outer_measure_apply _ t ht).trans
   (to_outer_measure_of_list_apply l h t)
 


### PR DESCRIPTION
Defines `pmf.of_list` for the distribution corresponding to drawing uniformly from the elements of a non-empty list.
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
