### PR TITLE
[Merged by Bors] - feat(tactic/tauto): add support for `¬_ ≠ _`

### DIFF
--- a/src/tactic/tauto.lean
+++ b/src/tactic/tauto.lean
@@ -28,6 +28,7 @@ do hs ← local_context,
          | `(¬ (_ ∧ _))  := replace h.local_pp_name ``(decidable.not_and_distrib'.mp %%h) <|>
                             replace h.local_pp_name ``(decidable.not_and_distrib.mp %%h)
          | `(¬ (_ ∨ _))  := replace h.local_pp_name ``(not_or_distrib.mp %%h)
+         | `(¬ _ ≠ _)      := replace h.local_pp_name ``(decidable.of_not_not %%h)
          | `(¬ ¬ _)      := replace h.local_pp_name ``(decidable.of_not_not %%h)
          | `(¬ (_ → (_ : Prop))) := replace h.local_pp_name ``(decidable.not_imp.mp %%h)
          | `(¬ (_ ↔ _)) := replace h.local_pp_name ``(decidable.not_iff.mp %%h)

--- a/src/tactic/tauto.lean
+++ b/src/tactic/tauto.lean
@@ -22,14 +22,14 @@ do hs ← local_context,
       do h ← get_local h.local_pp_name,
          e ← infer_type h,
          match e with
-         | `(¬ _ = _) := replace h.local_pp_name ``(mt iff.to_eq %%h)
-         | `(_ ≠ _)   := replace h.local_pp_name ``(mt iff.to_eq %%h)
-         | `(_ = _)   := replace h.local_pp_name ``(eq.to_iff %%h)
-         | `(¬ (_ ∧ _))  := replace h.local_pp_name ``(decidable.not_and_distrib'.mp %%h) <|>
-                            replace h.local_pp_name ``(decidable.not_and_distrib.mp %%h)
-         | `(¬ (_ ∨ _))  := replace h.local_pp_name ``(not_or_distrib.mp %%h)
-         | `(¬ _ ≠ _)      := replace h.local_pp_name ``(decidable.of_not_not %%h)
-         | `(¬ ¬ _)      := replace h.local_pp_name ``(decidable.of_not_not %%h)
+         | `(¬ _ = _)   := replace h.local_pp_name ``(mt iff.to_eq %%h)
+         | `(_ ≠ _)     := replace h.local_pp_name ``(mt iff.to_eq %%h)
+         | `(_ = _)     := replace h.local_pp_name ``(eq.to_iff %%h)
+         | `(¬ (_ ∧ _)) := replace h.local_pp_name ``(decidable.not_and_distrib'.mp %%h) <|>
+                           replace h.local_pp_name ``(decidable.not_and_distrib.mp %%h)
+         | `(¬ (_ ∨ _)) := replace h.local_pp_name ``(not_or_distrib.mp %%h)
+         | `(¬ _ ≠ _)   := replace h.local_pp_name ``(decidable.of_not_not %%h)
+         | `(¬ ¬ _)     := replace h.local_pp_name ``(decidable.of_not_not %%h)
          | `(¬ (_ → (_ : Prop))) := replace h.local_pp_name ``(decidable.not_imp.mp %%h)
          | `(¬ (_ ↔ _)) := replace h.local_pp_name ``(decidable.not_iff.mp %%h)
          | `(_ ↔ _) := replace h.local_pp_name ``(decidable.iff_iff_and_or_not_and_not.mp %%h) <|>

--- a/test/tauto.lean
+++ b/test/tauto.lean
@@ -100,3 +100,11 @@ begin
 end
 
 end closer
+
+/-  Zulip discussion:
+https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/tauto!.20fails.20on.20ne
+-/
+example {x y : ℕ} (h : ¬x ≠ y) : x = y :=
+begin
+  tauto!,
+end


### PR DESCRIPTION
This is an attempt to fix [this issue](https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/tauto!.20fails.20on.20ne).


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
