### PR TITLE
[Merged by Bors] - feat(data/real/ennreal): Add `to_real_{min, sup, inf}`

### DIFF
--- a/src/data/real/ennreal.lean
+++ b/src/data/real/ennreal.lean
@@ -1555,7 +1555,7 @@ lemma to_real_min {a b : ℝ≥0∞} (hr : a ≠ ∞) (hp : b ≠ ∞) :
   (λ h, by simp only [h, (ennreal.to_real_le_to_real hr hp).2 h, min_eq_left])
   (λ h, by simp only [h, (ennreal.to_real_le_to_real hp hr).2 h, min_eq_right])
 
-lemma to_real_sup {a b : ℝ≥0∞} (hr : a ≠ ∞)
+lemma to_real_sup {a b : ℝ≥0∞}
   : a ≠ ∞ → b ≠ ∞ → (a ⊔ b).to_real = a.to_real ⊔ b.to_real := to_real_max
 
 lemma to_real_inf {a b : ℝ≥0∞}

--- a/src/data/real/ennreal.lean
+++ b/src/data/real/ennreal.lean
@@ -1549,6 +1549,18 @@ lemma to_real_max (hr : a ≠ ∞) (hp : b ≠ ∞) :
   (λ h, by simp only [h, (ennreal.to_real_le_to_real hr hp).2 h, max_eq_right])
   (λ h, by simp only [h, (ennreal.to_real_le_to_real hp hr).2 h, max_eq_left])
 
+lemma to_real_min {a b : ℝ≥0∞} (hr : a ≠ ∞) (hp : b ≠ ∞) :
+  ennreal.to_real (min a b) = min (ennreal.to_real a) (ennreal.to_real b) :=
+(le_total a b).elim
+  (λ h, by simp only [h, (ennreal.to_real_le_to_real hr hp).2 h, min_eq_left])
+  (λ h, by simp only [h, (ennreal.to_real_le_to_real hp hr).2 h, min_eq_right])
+
+lemma to_real_sup {a b : ℝ≥0∞} (hr : a ≠ ∞)
+  : a ≠ ∞ → b ≠ ∞ → (a ⊔ b).to_real = a.to_real ⊔ b.to_real := to_real_max
+
+lemma to_real_inf {a b : ℝ≥0∞}
+  : a ≠ ∞ → b ≠ ∞ → (a ⊓ b).to_real = a.to_real ⊓ b.to_real := to_real_min
+
 lemma to_nnreal_pos_iff : 0 < a.to_nnreal ↔ (0 < a ∧ a < ∞) :=
 by { induction a using with_top.rec_top_coe; simp }
 


### PR DESCRIPTION
This adds `to_real_min` to match `to_real_max`, and adds `inf` and `sup` spellings of these lemmas.
