### PR TITLE
feat(data/set/fintype): `set.nontrivial` and `set.subsingleton` connection to `finset.off_diag`

### DIFF
--- a/src/data/finset/prod.lean
+++ b/src/data/finset/prod.lean
@@ -160,13 +160,11 @@ by { simp only [diag, mem_filter, mem_product], split; intros h;
 by { simp only [off_diag, mem_filter, mem_product], split; intros h;
      simp only [h, ne.def, not_false_iff, and_self] }
 
-@[simp] lemma off_diag_nonempty_iff [decidable_eq α] {s : finset α} :
-  (s : set α).nontrivial ↔ s.off_diag.nonempty :=
+@[simp] lemma off_diag_nonempty_iff {s : finset α} : (s : set α).nontrivial ↔ s.off_diag.nonempty :=
 by simp_rw [set.nontrivial, finset.nonempty, mem_off_diag, mem_coe,
             prod.exists, exists_and_distrib_left, exists_prop]
 
-@[simp] lemma off_diag_empty_iff [decidable_eq α] {s : finset α} :
-  (s : set α).subsingleton ↔ s.off_diag = ∅ :=
+@[simp] lemma off_diag_empty_iff {s : finset α} : (s : set α).subsingleton ↔ s.off_diag = ∅ :=
 by rw [← not_iff_not, set.not_subsingleton_iff, off_diag_nonempty_iff, nonempty_iff_ne_empty]
 
 @[simp] lemma diag_card : (diag s).card = s.card :=

--- a/src/data/finset/prod.lean
+++ b/src/data/finset/prod.lean
@@ -160,6 +160,15 @@ by { simp only [diag, mem_filter, mem_product], split; intros h;
 by { simp only [off_diag, mem_filter, mem_product], split; intros h;
      simp only [h, ne.def, not_false_iff, and_self] }
 
+@[simp] lemma off_diag_nonempty_iff [decidable_eq α] {s : finset α} :
+  (s : set α).nontrivial ↔ s.off_diag.nonempty :=
+by simp_rw [set.nontrivial, finset.nonempty, mem_off_diag, mem_coe,
+            prod.exists, exists_and_distrib_left, exists_prop]
+
+@[simp] lemma off_diag_empty_iff [decidable_eq α] {s : finset α} :
+  (s : set α).subsingleton ↔ s.off_diag = ∅ :=
+by rw [← not_iff_not, set.not_subsingleton_iff, off_diag_nonempty_iff, nonempty_iff_ne_empty]
+
 @[simp] lemma diag_card : (diag s).card = s.card :=
 begin
   suffices : diag s = s.image (λ a, (a, a)),

--- a/src/data/fintype/basic.lean
+++ b/src/data/fintype/basic.lean
@@ -1289,11 +1289,38 @@ instance Prop.fintype : fintype Prop :=
 instance subtype.fintype (p : α → Prop) [decidable_pred p] [fintype α] : fintype {x // p x} :=
 fintype.subtype (univ.filter p) (by simp)
 
-@[simp] lemma set.to_finset_eq_empty_iff {s : set α} [fintype s] : s.to_finset = ∅ ↔ s = ∅ :=
-by simp only [ext_iff, set.ext_iff, set.mem_to_finset, not_mem_empty, set.mem_empty_eq]
+namespace set
+variables {s : set α} [fintype s]
 
-@[simp] lemma set.to_finset_empty : (∅ : set α).to_finset = ∅ :=
-set.to_finset_eq_empty_iff.mpr rfl
+@[simp] lemma to_finset_eq_empty_iff : s.to_finset = ∅ ↔ s = ∅ :=
+by simp only [finset.ext_iff, ext_iff, mem_to_finset, finset.not_mem_empty, mem_empty_eq]
+
+@[simp] lemma to_finset_empty : (∅ : set α).to_finset = ∅ := to_finset_eq_empty_iff.mpr rfl
+
+@[simp] lemma to_finset_nonempty_iff  : s.to_finset.nonempty ↔ s.nonempty :=
+by rw [← not_iff_not, finset.not_nonempty_iff_eq_empty,
+       to_finset_eq_empty_iff, not_nonempty_iff_eq_empty]
+
+lemma nonempty.to_finset_nonempty (hs : s.nonempty) :
+  s.to_finset.nonempty := to_finset_nonempty_iff.mpr hs
+
+@[simp] lemma nontrivial_iff_to_finset_off_diag_nonempty [decidable_eq α]
+  : s.to_finset.off_diag.nonempty ↔ s.nontrivial :=
+by simp_rw [set.nontrivial, finset.nonempty, finset.mem_off_diag, mem_to_finset,
+            prod.exists, exists_and_distrib_left, exists_prop]
+
+lemma nontrivial.to_finset_off_diag_nonempty [decidable_eq α] (hs : s.nontrivial) :
+  s.to_finset.off_diag.nonempty := nontrivial_iff_to_finset_off_diag_nonempty.mpr hs
+
+@[simp] lemma subsingleton_iff_to_finset_off_diag_empty [decidable_eq α]
+  : s.to_finset.off_diag = ∅ ↔ s.subsingleton :=
+by rw [← not_iff_not, ← ne.def, ← nonempty_iff_ne_empty,
+       nontrivial_iff_to_finset_off_diag_nonempty, not_subsingleton_iff]
+
+lemma subsingleton.to_finset_off_diag_empty [decidable_eq α] (hs : s.subsingleton) :
+  s.to_finset.off_diag = ∅ := subsingleton_iff_to_finset_off_diag_empty.mpr hs
+
+end set
 
 /-- A set on a fintype, when coerced to a type, is a fintype. -/
 def set_fintype [fintype α] (s : set α) [decidable_pred (∈ s)] : fintype s :=

--- a/src/data/set/finite.lean
+++ b/src/data/set/finite.lean
@@ -129,16 +129,24 @@ section finite_to_finset
 @[simp] theorem finite.mem_to_finset {s : set α} (h : s.finite) {a : α} : a ∈ h.to_finset ↔ a ∈ s :=
 @mem_to_finset _ _ h.fintype _
 
-@[simp] theorem finite.nonempty_to_finset {s : set α} (h : s.finite) :
-  h.to_finset.nonempty ↔ s.nonempty :=
-by rw [← finset.coe_nonempty, finite.coe_to_finset]
-
 @[simp] lemma finite.coe_sort_to_finset {s : set α} (h : s.finite) :
   (h.to_finset : Type*) = s :=
 by rw [← finset.coe_sort_coe _, h.coe_to_finset]
 
+@[simp] theorem finite.nonempty_to_finset {s : set α} (h : s.finite) :
+  h.to_finset.nonempty ↔ s.nonempty :=
+by rw [← finset.coe_nonempty, finite.coe_to_finset]
+
 @[simp] lemma finite_empty_to_finset (h : (∅ : set α).finite) : h.to_finset = ∅ :=
 by rw [← finset.coe_inj, h.coe_to_finset, finset.coe_empty]
+
+@[simp] lemma finite.nontrivial_iff_to_finset_off_diag_nonempty [decidable_eq α] {s : set α}
+  (hs : s.finite) : hs.to_finset.off_diag.nonempty ↔ s.nontrivial :=
+by { letI := hs.fintype, exact nontrivial_iff_to_finset_off_diag_nonempty }
+
+@[simp] lemma finite.subsingleton_iff_to_finset_off_diag_empty [decidable_eq α] {s : set α}
+  (hs : s.finite) : hs.to_finset.off_diag = ∅ ↔ s.subsingleton :=
+by { letI := hs.fintype, exact subsingleton_iff_to_finset_off_diag_empty }
 
 @[simp] lemma finite.to_finset_inj {s t : set α} {hs : s.finite} {ht : t.finite} :
   hs.to_finset = ht.to_finset ↔ s = t :=


### PR DESCRIPTION
There is a natural correspondence between `s.nontrivial` and `s.subsingleton` and the emptiness or otherwise of `s.off_diag` for finite sets/finsets/sets with a fintype. This PR adds the relevant lemmas to support this.

---

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
