### PR TITLE
[Merged by Bors] - feat(data/finsupp/ne_locus): add a not-member lemma

### DIFF
--- a/src/data/finsupp/ne_locus.lean
+++ b/src/data/finsupp/ne_locus.lean
@@ -36,6 +36,9 @@ def ne_locus (f g : α →₀ N) : finset α :=
 by simpa only [ne_locus, finset.mem_filter, finset.mem_union, mem_support_iff,
     and_iff_right_iff_imp] using ne.ne_or_ne _
 
+lemma not_mem_ne_locus {f g : α →₀ N} {a : α} : a ∉ f.ne_locus g ↔ f a = g a :=
+mem_ne_locus.not.trans not_ne_iff
+
 @[simp] lemma coe_ne_locus : ↑(f.ne_locus g) = {x | f x ≠ g x} :=
 by { ext, exact mem_ne_locus }
 


### PR DESCRIPTION
This PR adds a convenience lemma characterizing non-membership in the `ne_locus`.

`simp` proves this lemma, but given the position of the negations in `mem_ne_locus`, this form is also convenient.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
