### PR TITLE
[Merged by Bors] - feat(algebra/gcd_monoid): `simp` lemmas for `associated (normalize x) y`

### DIFF
--- a/src/algebra/associated.lean
+++ b/src/algebra/associated.lean
@@ -292,6 +292,9 @@ instance [monoid α] : is_refl α associated := ⟨associated.refl⟩
 | x _ ⟨u, rfl⟩ := ⟨u⁻¹, by rw [mul_assoc, units.mul_inv, mul_one]⟩
 instance [monoid α] : is_symm α associated := ⟨λ a b, associated.symm⟩
 
+protected theorem comm [monoid α] {x y : α} : x ~ᵤ y ↔ y ~ᵤ x :=
+⟨associated.symm, associated.symm⟩
+
 @[trans] protected theorem trans [monoid α] : ∀{x y z : α}, x ~ᵤ y → y ~ᵤ z → x ~ᵤ z
 | x _ _ ⟨u, rfl⟩ ⟨v, rfl⟩ := ⟨u * v, by rw [units.coe_mul, mul_assoc]⟩
 instance [monoid α] : is_trans α associated := ⟨λ a b c, associated.trans⟩
@@ -341,6 +344,45 @@ lemma associated_mul_unit_right {β : Type*} [monoid β] (a u : β) (hu : is_uni
 lemma associated_unit_mul_right {β : Type*} [comm_monoid β] (a u : β) (hu : is_unit u) :
   associated a (u * a) :=
 (associated_unit_mul_left a u hu).symm
+
+lemma associated_mul_is_unit_left_iff {β : Type*} [monoid β] {a u b : β} (hu : is_unit u) :
+  associated (a * u) b ↔ associated a b :=
+⟨trans (associated_mul_unit_right _ _ hu), trans (associated_mul_unit_left _ _ hu)⟩
+
+lemma associated_is_unit_mul_left_iff {β : Type*} [comm_monoid β] {u a b : β} (hu : is_unit u) :
+  associated (u * a) b ↔ associated a b :=
+begin
+  rw mul_comm,
+  exact associated_mul_is_unit_left_iff hu
+end
+
+lemma associated_mul_is_unit_right_iff {β : Type*} [monoid β] {a b u : β} (hu : is_unit u) :
+  associated a (b * u) ↔ associated a b :=
+associated.comm.trans $ (associated_mul_is_unit_left_iff hu).trans associated.comm
+
+lemma associated_is_unit_mul_right_iff {β : Type*} [comm_monoid β] {a u b : β} (hu : is_unit u) :
+  associated a (u * b) ↔ associated a b :=
+associated.comm.trans $ (associated_is_unit_mul_left_iff hu).trans associated.comm
+
+@[simp]
+lemma associated_mul_unit_left_iff {β : Type*} [monoid β] {a b : β} {u : units β} :
+  associated (a * u) b ↔ associated a b :=
+associated_mul_is_unit_left_iff u.is_unit
+
+@[simp]
+lemma associated_unit_mul_left_iff {β : Type*} [comm_monoid β] {a b : β} {u : units β} :
+  associated (↑u * a) b ↔ associated a b :=
+associated_is_unit_mul_left_iff u.is_unit
+
+@[simp]
+lemma associated_mul_unit_right_iff {β : Type*} [monoid β] {a b : β} {u : units β} :
+  associated a (b * u) ↔ associated a b :=
+associated_mul_is_unit_right_iff u.is_unit
+
+@[simp]
+lemma associated_unit_mul_right_iff {β : Type*} [comm_monoid β] {a b : β} {u : units β} :
+  associated a (↑u * b) ↔ associated a b :=
+associated_is_unit_mul_right_iff u.is_unit
 
 lemma associated.mul_mul [comm_monoid α] {a₁ a₂ b₁ b₂ : α} :
   a₁ ~ᵤ b₁ → a₂ ~ᵤ b₂ → (a₁ * a₂) ~ᵤ (b₁ * b₂)

--- a/src/algebra/gcd_monoid/basic.lean
+++ b/src/algebra/gcd_monoid/basic.lean
@@ -101,6 +101,14 @@ theorem associated_normalize (x : α) : associated x (normalize x) :=
 theorem normalize_associated (x : α) : associated (normalize x) x :=
 (associated_normalize _).symm
 
+@[simp] lemma associated_normalize_iff {x y : α} :
+  associated x (normalize y) ↔ associated x y :=
+⟨λ h, h.trans (normalize_associated y), λ h, h.trans (associated_normalize y)⟩
+
+@[simp] lemma normalize_associated_iff {x y : α} :
+  associated (normalize x) y ↔ associated x y :=
+⟨λ h, (associated_normalize _).trans h, λ h, (normalize_associated _).trans h⟩
+
 lemma associates.mk_normalize (x : α) : associates.mk (normalize x) = associates.mk x :=
 associates.mk_eq_mk_iff_associated.2 (normalize_associated _)
 

--- a/src/algebra/gcd_monoid/basic.lean
+++ b/src/algebra/gcd_monoid/basic.lean
@@ -101,11 +101,11 @@ theorem associated_normalize (x : α) : associated x (normalize x) :=
 theorem normalize_associated (x : α) : associated (normalize x) x :=
 (associated_normalize _).symm
 
-@[simp] lemma associated_normalize_iff {x y : α} :
+lemma associated_normalize_iff {x y : α} :
   associated x (normalize y) ↔ associated x y :=
 ⟨λ h, h.trans (normalize_associated y), λ h, h.trans (associated_normalize y)⟩
 
-@[simp] lemma normalize_associated_iff {x y : α} :
+lemma normalize_associated_iff {x y : α} :
   associated (normalize x) y ↔ associated x y :=
 ⟨λ h, (associated_normalize _).trans h, λ h, (normalize_associated _).trans h⟩
 


### PR DESCRIPTION
The lemmas in `gcd_monoid` package `associated_normalize` and `normalize_associated` into a form suitable for `simp`. Useful e.g. for working with `normalized_factors`. The lemmas in `associated` are the `simp`-normal forms of the `normalize` lemmas, since `normalize x` is not itself in `simp`-normal form.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
