### PR TITLE
[Merged by Bors] - refactor(group_theory/finiteness): Make `group.rank` noncomputable

### DIFF
--- a/src/group_theory/finiteness.lean
+++ b/src/group_theory/finiteness.lean
@@ -282,19 +282,16 @@ variables (G)
 
 /-- The minimum number of generators of a group. -/
 @[to_additive "The minimum number of generators of an additive group"]
-def group.rank [h : group.fg G]
-  [decidable_pred (λ n, ∃ (S : finset G), S.card = n ∧ subgroup.closure (S : set G) = ⊤)] :=
-nat.find (group.fg_iff'.mp h)
+noncomputable def group.rank [h : group.fg G] :=
+@nat.find _ (classical.dec_pred _) (group.fg_iff'.mp h)
 
-@[to_additive] lemma group.rank_spec [h : group.fg G]
-  [decidable_pred (λ n, ∃ (S : finset G), S.card = n ∧ subgroup.closure (S : set G) = ⊤)] :
+@[to_additive] lemma group.rank_spec [h : group.fg G] :
   ∃ S : finset G, S.card = group.rank G ∧ subgroup.closure (S : set G) = ⊤ :=
-nat.find_spec (group.fg_iff'.mp h)
+@nat.find_spec _ (classical.dec_pred _) (group.fg_iff'.mp h)
 
-@[to_additive] lemma group.rank_le [group.fg G]
-  [decidable_pred (λ n, ∃ (S : finset G), S.card = n ∧ subgroup.closure (S : set G) = ⊤)]
+@[to_additive] lemma group.rank_le [h : group.fg G]
   {S : finset G} (hS : subgroup.closure (S : set G) = ⊤) : group.rank G ≤ S.card :=
-nat.find_le ⟨S, rfl, hS⟩
+@nat.find_le _ _ (classical.dec_pred _) (group.fg_iff'.mp h) ⟨S, rfl, hS⟩
 
 end group
 

--- a/src/group_theory/schreier.lean
+++ b/src/group_theory/schreier.lean
@@ -133,9 +133,7 @@ begin
   exact ⟨⟨T, hT⟩⟩,
 end
 
-lemma rank_le_index_mul_rank [hG : group.fg G] {H : subgroup G} (hH : H.index ≠ 0)
-  [decidable_pred (λ n, ∃ (S : finset G), S.card = n ∧ subgroup.closure (S : set G) = ⊤)]
-  [decidable_pred (λ n, ∃ (S : finset H), S.card = n ∧ subgroup.closure (S : set H) = ⊤)] :
+lemma rank_le_index_mul_rank [hG : group.fg G] {H : subgroup G} (hH : H.index ≠ 0) :
   @group.rank H _ (fg_of_index_ne_zero hH) _ ≤ H.index * group.rank G :=
 begin
   haveI := fg_of_index_ne_zero hH,

--- a/src/group_theory/schreier.lean
+++ b/src/group_theory/schreier.lean
@@ -134,7 +134,7 @@ begin
 end
 
 lemma rank_le_index_mul_rank [hG : group.fg G] {H : subgroup G} (hH : H.index ≠ 0) :
-  @group.rank H _ (fg_of_index_ne_zero hH) _ ≤ H.index * group.rank G :=
+  @group.rank H _ (fg_of_index_ne_zero hH) ≤ H.index * group.rank G :=
 begin
   haveI := fg_of_index_ne_zero hH,
   obtain ⟨S, hS₀, hS⟩ := group.rank_spec G,


### PR DESCRIPTION
I've been working on some more API for `group.rank`, and the decidability hypothesis was making lemma statements really clunky. If you wanted to say `group.rank G ≤ group.rank G'`, then the decidability hypotheses would add two lines to the statement of the lemma.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
