### PR TITLE
[Merged by Bors] - chore(order/bounded_order): Rename `is_complemented` to `complemented_lattice`

### DIFF
--- a/src/linear_algebra/basis.lean
+++ b/src/linear_algebra/basis.lean
@@ -1307,7 +1307,7 @@ lemma submodule.exists_is_compl (p : submodule K V) : ∃ q : submodule K V, is_
 let ⟨f, hf⟩ := p.subtype.exists_left_inverse_of_injective p.ker_subtype in
 ⟨f.ker, linear_map.is_compl_of_proj $ linear_map.ext_iff.1 hf⟩
 
-instance module.submodule.is_complemented : is_complemented (submodule K V) :=
+instance module.submodule.complemented_lattice : complemented_lattice (submodule K V) :=
 ⟨submodule.exists_is_compl⟩
 
 lemma linear_map.exists_right_inverse_of_surjective (f : V →ₗ[K] V')

--- a/src/order/atoms.lean
+++ b/src/order/atoms.lean
@@ -638,7 +638,8 @@ end is_compl
 
 variables [complemented_lattice α]
 
-lemma is_coatomic_of_is_atomic_of_complemented_lattice_of_is_modular [is_atomic α] : is_coatomic α :=
+lemma is_coatomic_of_is_atomic_of_complemented_lattice_of_is_modular [is_atomic α] :
+  is_coatomic α :=
 ⟨λ x, begin
   rcases exists_is_compl x with ⟨y, xy⟩,
   apply (eq_bot_or_exists_atom_le y).imp _ _,
@@ -651,7 +652,8 @@ lemma is_coatomic_of_is_atomic_of_complemented_lattice_of_is_modular [is_atomic 
     apply ha.Iic }
 end⟩
 
-lemma is_atomic_of_is_coatomic_of_complemented_lattice_of_is_modular [is_coatomic α] : is_atomic α :=
+lemma is_atomic_of_is_coatomic_of_complemented_lattice_of_is_modular [is_coatomic α] :
+  is_atomic α :=
 is_coatomic_dual_iff_is_atomic.1 is_coatomic_of_is_atomic_of_complemented_lattice_of_is_modular
 
 theorem is_atomic_iff_is_coatomic : is_atomic α ↔ is_coatomic α :=

--- a/src/order/atoms.lean
+++ b/src/order/atoms.lean
@@ -636,9 +636,9 @@ lemma is_coatom_iff_is_atom : is_coatom a ↔ is_atom b := hc.symm.is_atom_iff_i
 
 end is_compl
 
-variables [is_complemented α]
+variables [complemented_lattice α]
 
-lemma is_coatomic_of_is_atomic_of_is_complemented_of_is_modular [is_atomic α] : is_coatomic α :=
+lemma is_coatomic_of_is_atomic_of_complemented_lattice_of_is_modular [is_atomic α] : is_coatomic α :=
 ⟨λ x, begin
   rcases exists_is_compl x with ⟨y, xy⟩,
   apply (eq_bot_or_exists_atom_le y).imp _ _,
@@ -651,12 +651,12 @@ lemma is_coatomic_of_is_atomic_of_is_complemented_of_is_modular [is_atomic α] :
     apply ha.Iic }
 end⟩
 
-lemma is_atomic_of_is_coatomic_of_is_complemented_of_is_modular [is_coatomic α] : is_atomic α :=
-is_coatomic_dual_iff_is_atomic.1 is_coatomic_of_is_atomic_of_is_complemented_of_is_modular
+lemma is_atomic_of_is_coatomic_of_complemented_lattice_of_is_modular [is_coatomic α] : is_atomic α :=
+is_coatomic_dual_iff_is_atomic.1 is_coatomic_of_is_atomic_of_complemented_lattice_of_is_modular
 
 theorem is_atomic_iff_is_coatomic : is_atomic α ↔ is_coatomic α :=
-⟨λ h, @is_coatomic_of_is_atomic_of_is_complemented_of_is_modular _ _ _ _ _ h,
-  λ h, @is_atomic_of_is_coatomic_of_is_complemented_of_is_modular _ _ _ _ _ h⟩
+⟨λ h, @is_coatomic_of_is_atomic_of_complemented_lattice_of_is_modular _ _ _ _ _ h,
+  λ h, @is_atomic_of_is_coatomic_of_complemented_lattice_of_is_modular _ _ _ _ _ h⟩
 
 end is_modular_lattice
 

--- a/src/order/boolean_algebra.lean
+++ b/src/order/boolean_algebra.lean
@@ -559,7 +559,8 @@ lemma himp_eq : x ⇨ y = y ⊔ xᶜ := boolean_algebra.himp_eq x y
 @[simp] lemma top_sdiff : ⊤ \ x = xᶜ := by rw [sdiff_eq, top_inf_eq]
 
 @[priority 100]
-instance boolean_algebra.to_complemented_lattice : complemented_lattice α := ⟨λ x, ⟨xᶜ, is_compl_compl⟩⟩
+instance boolean_algebra.to_complemented_lattice : complemented_lattice α :=
+⟨λ x, ⟨xᶜ, is_compl_compl⟩⟩
 
 @[priority 100] -- see Note [lower instance priority]
 instance boolean_algebra.to_generalized_boolean_algebra : generalized_boolean_algebra α :=

--- a/src/order/boolean_algebra.lean
+++ b/src/order/boolean_algebra.lean
@@ -559,7 +559,7 @@ lemma himp_eq : x ⇨ y = y ⊔ xᶜ := boolean_algebra.himp_eq x y
 @[simp] lemma top_sdiff : ⊤ \ x = xᶜ := by rw [sdiff_eq, top_inf_eq]
 
 @[priority 100]
-instance boolean_algebra.to_is_complemented : is_complemented α := ⟨λ x, ⟨xᶜ, is_compl_compl⟩⟩
+instance boolean_algebra.to_complemented_lattice : complemented_lattice α := ⟨λ x, ⟨xᶜ, is_compl_compl⟩⟩
 
 @[priority 100] -- see Note [lower instance priority]
 instance boolean_algebra.to_generalized_boolean_algebra : generalized_boolean_algebra α :=

--- a/src/order/bounded_order.lean
+++ b/src/order/bounded_order.lean
@@ -24,7 +24,7 @@ instances for `Prop` and `fun`.
 * `with_<top/bot> α`: Equips `option α` with the order on `α` plus `none` as the top/bottom element.
 * `is_compl x y`: In a bounded lattice, predicate for "`x` is a complement of `y`". Note that in a
   non distributive lattice, an element can have several complements.
-* `is_complemented α`: Typeclass stating that any element of a lattice has a complement.
+* `complemented_lattice α`: Typeclass stating that any element of a lattice has a complement.
 
 ## Common lattices
 
@@ -1724,18 +1724,18 @@ end
 
 /-- A complemented bounded lattice is one where every element has a (not necessarily unique)
 complement. -/
-class is_complemented (α) [lattice α] [bounded_order α] : Prop :=
+class complemented_lattice (α) [lattice α] [bounded_order α] : Prop :=
 (exists_is_compl : ∀ (a : α), ∃ (b : α), is_compl a b)
 
-export is_complemented (exists_is_compl)
+export complemented_lattice (exists_is_compl)
 
-namespace is_complemented
-variables [lattice α] [bounded_order α] [is_complemented α]
+namespace complemented_lattice
+variables [lattice α] [bounded_order α] [complemented_lattice α]
 
-instance : is_complemented αᵒᵈ :=
+instance : complemented_lattice αᵒᵈ :=
 ⟨λ a, let ⟨b, hb⟩ := exists_is_compl (show α, from a) in ⟨b, hb.dual⟩⟩
 
-end is_complemented
+end complemented_lattice
 
 end is_compl
 

--- a/src/order/compactly_generated.lean
+++ b/src/order/compactly_generated.lean
@@ -475,7 +475,8 @@ instance is_atomistic_of_complemented_lattice [complemented_lattice α] : is_ato
 end, λ _, and.left⟩⟩
 
 /-- See Theorem 6.6, Călugăreanu -/
-theorem complemented_lattice_of_Sup_atoms_eq_top (h : Sup {a : α | is_atom a} = ⊤) : complemented_lattice α :=
+theorem complemented_lattice_of_Sup_atoms_eq_top (h : Sup {a : α | is_atom a} = ⊤) :
+  complemented_lattice α :=
 ⟨λ b, begin
   obtain ⟨s, ⟨s_ind, b_inf_Sup_s, s_atoms⟩, s_max⟩ := zorn_subset
     {s : set α | complete_lattice.set_independent s ∧ b ⊓ Sup s = ⊥ ∧ ∀ a ∈ s, is_atom a} _,

--- a/src/order/compactly_generated.lean
+++ b/src/order/compactly_generated.lean
@@ -437,7 +437,7 @@ section
 variables [is_modular_lattice α] [is_compactly_generated α]
 
 @[priority 100]
-instance is_atomic_of_is_complemented [is_complemented α] : is_atomic α :=
+instance is_atomic_of_complemented_lattice [complemented_lattice α] : is_atomic α :=
 ⟨λ b, begin
   by_cases h : {c : α | complete_lattice.is_compact_element c ∧ c ≤ b} ⊆ {⊥},
   { left,
@@ -459,7 +459,7 @@ end⟩
 
 /-- See Lemma 5.1, Călugăreanu -/
 @[priority 100]
-instance is_atomistic_of_is_complemented [is_complemented α] : is_atomistic α :=
+instance is_atomistic_of_complemented_lattice [complemented_lattice α] : is_atomistic α :=
 ⟨λ b, ⟨{a | is_atom a ∧ a ≤ b}, begin
   symmetry,
   have hle : Sup {a : α | is_atom a ∧ a ≤ b} ≤ b := (Sup_le $ λ _, and.right),
@@ -475,7 +475,7 @@ instance is_atomistic_of_is_complemented [is_complemented α] : is_atomistic α 
 end, λ _, and.left⟩⟩
 
 /-- See Theorem 6.6, Călugăreanu -/
-theorem is_complemented_of_Sup_atoms_eq_top (h : Sup {a : α | is_atom a} = ⊤) : is_complemented α :=
+theorem complemented_lattice_of_Sup_atoms_eq_top (h : Sup {a : α | is_atom a} = ⊤) : complemented_lattice α :=
 ⟨λ b, begin
   obtain ⟨s, ⟨s_ind, b_inf_Sup_s, s_atoms⟩, s_max⟩ := zorn_subset
     {s : set α | complete_lattice.set_independent s ∧ b ⊓ Sup s = ⊥ ∧ ∀ a ∈ s, is_atom a} _,
@@ -525,14 +525,14 @@ theorem is_complemented_of_Sup_atoms_eq_top (h : Sup {a : α | is_atom a} = ⊤)
 end⟩
 
 /-- See Theorem 6.6, Călugăreanu -/
-theorem is_complemented_of_is_atomistic [is_atomistic α] : is_complemented α :=
-is_complemented_of_Sup_atoms_eq_top Sup_atoms_eq_top
+theorem complemented_lattice_of_is_atomistic [is_atomistic α] : complemented_lattice α :=
+complemented_lattice_of_Sup_atoms_eq_top Sup_atoms_eq_top
 
-theorem is_complemented_iff_is_atomistic : is_complemented α ↔ is_atomistic α :=
+theorem complemented_lattice_iff_is_atomistic : complemented_lattice α ↔ is_atomistic α :=
 begin
   split; introsI,
-  { exact is_atomistic_of_is_complemented },
-  { exact is_complemented_of_is_atomistic }
+  { exact is_atomistic_of_complemented_lattice },
+  { exact complemented_lattice_of_is_atomistic }
 end
 
 end

--- a/src/order/hom/basic.lean
+++ b/src/order/hom/basic.lean
@@ -925,17 +925,17 @@ theorem order_iso.is_compl_iff {x y : α} :
   is_compl x y ↔ is_compl (f x) (f y) :=
 ⟨f.is_compl, λ h, f.symm_apply_apply x ▸ f.symm_apply_apply y ▸ f.symm.is_compl h⟩
 
-lemma order_iso.is_complemented
-  [is_complemented α] : is_complemented β :=
+lemma order_iso.complemented_lattice
+  [complemented_lattice α] : complemented_lattice β :=
 ⟨λ x, begin
   obtain ⟨y, hy⟩ := exists_is_compl (f.symm x),
   rw ← f.symm_apply_apply y at hy,
   refine ⟨f y, f.symm.is_compl_iff.2 hy⟩,
 end⟩
 
-theorem order_iso.is_complemented_iff :
-  is_complemented α ↔ is_complemented β :=
-⟨by { introI, exact f.is_complemented }, by { introI, exact f.symm.is_complemented }⟩
+theorem order_iso.complemented_lattice_iff :
+  complemented_lattice α ↔ complemented_lattice β :=
+⟨by { introI, exact f.complemented_lattice }, by { introI, exact f.symm.complemented_lattice }⟩
 
 end bounded_order
 end lattice_isos

--- a/src/order/modular_lattice.lean
+++ b/src/order/modular_lattice.lean
@@ -310,10 +310,10 @@ instance is_modular_lattice_Iic : is_modular_lattice (set.Iic a) :=
 instance is_modular_lattice_Ici : is_modular_lattice (set.Ici a) :=
 ⟨λ x y z xz, (sup_inf_le_assoc_of_le (y : α) xz : (↑x ⊔ ↑y) ⊓ ↑z ≤ ↑x ⊔ ↑y ⊓ ↑z)⟩
 
-section is_complemented
-variables [bounded_order α] [is_complemented α]
+section complemented_lattice
+variables [bounded_order α] [complemented_lattice α]
 
-instance is_complemented_Iic : is_complemented (set.Iic a) :=
+instance complemented_lattice_Iic : complemented_lattice (set.Iic a) :=
 ⟨λ ⟨x, hx⟩, let ⟨y, hy⟩ := exists_is_compl x in
   ⟨⟨y ⊓ a, set.mem_Iic.2 inf_le_right⟩, begin
     split,
@@ -324,7 +324,7 @@ instance is_complemented_Iic : is_complemented (set.Iic a) :=
       rw [← sup_inf_assoc_of_le _ (set.mem_Iic.1 hx), top_le_iff.1 hy.2, top_inf_eq] }
   end⟩⟩
 
-instance is_complemented_Ici : is_complemented (set.Ici a) :=
+instance complemented_lattice_Ici : complemented_lattice (set.Ici a) :=
 ⟨λ ⟨x, hx⟩, let ⟨y, hy⟩ := exists_is_compl x in
   ⟨⟨y ⊔ a, set.mem_Ici.2 le_sup_right⟩, begin
     split,
@@ -335,6 +335,6 @@ instance is_complemented_Ici : is_complemented (set.Ici a) :=
       exact le_trans hy.2 le_sup_left }
   end⟩⟩
 
-end is_complemented
+end complemented_lattice
 
 end is_modular_lattice

--- a/src/representation_theory/maschke.lean
+++ b/src/representation_theory/maschke.lean
@@ -184,7 +184,7 @@ let ⟨f, hf⟩ := monoid_algebra.exists_left_inverse_of_injective p.subtype p.k
 ⟨f.ker, linear_map.is_compl_of_proj $ linear_map.ext_iff.1 hf⟩
 
 /-- This also implies an instance `is_semisimple_module (monoid_algebra k G) V`. -/
-instance is_complemented : is_complemented (submodule (monoid_algebra k G) V) :=
+instance complemented_lattice : complemented_lattice (submodule (monoid_algebra k G) V) :=
 ⟨exists_is_compl⟩
 
 end submodule

--- a/src/ring_theory/simple_module.lean
+++ b/src/ring_theory/simple_module.lean
@@ -34,7 +34,7 @@ abbreviation is_simple_module := (is_simple_order (submodule R M))
 
 /-- A module is semisimple when every submodule has a complement, or equivalently, the module
   is a direct sum of simple modules. -/
-abbreviation is_semisimple_module := (is_complemented (submodule R M))
+abbreviation is_semisimple_module := (complemented_lattice (submodule R M))
 
 -- Making this an instance causes the linter to complain of "dangerous instances"
 theorem is_simple_module.nontrivial [is_simple_module R M] : nontrivial M :=
@@ -67,7 +67,7 @@ end is_simple_module
 theorem is_semisimple_of_Sup_simples_eq_top
   (h : Sup {m : submodule R M | is_simple_module R m} = ⊤) :
   is_semisimple_module R M :=
-is_complemented_of_Sup_atoms_eq_top (by simp_rw [← h, is_simple_module_iff_is_atom])
+complemented_lattice_of_Sup_atoms_eq_top (by simp_rw [← h, is_simple_module_iff_is_atom])
 
 namespace is_semisimple_module
 
@@ -82,7 +82,7 @@ end
 instance is_semisimple_submodule {m : submodule R M} : is_semisimple_module R m :=
 begin
   have f : submodule R m ≃o set.Iic m := submodule.map_subtype.rel_iso m,
-  exact f.is_complemented_iff.2 is_modular_lattice.is_complemented_Iic,
+  exact f.complemented_lattice_iff.2 is_modular_lattice.complemented_lattice_Iic,
 end
 
 end is_semisimple_module


### PR DESCRIPTION
This is to make space for the predicate `is_complemented : α → Prop := ∃ b, is_compl a b`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
