### PR TITLE
[Merged by Bors] - chore(category_theory): fix name of mono_app_of_mono

### DIFF
--- a/src/category_theory/adjunction/evaluation.lean
+++ b/src/category_theory/adjunction/evaluation.lean
@@ -75,14 +75,14 @@ instance evaluation_is_right_adjoint (c : C) :
   is_right_adjoint ((evaluation _ D).obj c) :=
 ⟨_, evaluation_adjunction_right _ _⟩
 
-lemma nat_trans.mono_iff_app_mono {F G : C ⥤ D} (η : F ⟶ G) :
+lemma nat_trans.mono_iff_mono_app {F G : C ⥤ D} (η : F ⟶ G) :
   mono η ↔ (∀ c, mono (η.app c)) :=
 begin
   split,
   { introsI h c,
     exact (infer_instance : mono (((evaluation _ _).obj c).map η)) },
   { introsI _,
-    apply nat_trans.mono_app_of_mono }
+    apply nat_trans.mono_of_mono_app }
 end
 
 end
@@ -140,14 +140,14 @@ instance evaluation_is_left_adjoint (c : C) :
   is_left_adjoint ((evaluation _ D).obj c) :=
 ⟨_, evaluation_adjunction_left _ _⟩
 
-lemma nat_trans.epi_iff_app_epi {F G : C ⥤ D} (η : F ⟶ G) :
+lemma nat_trans.epi_iff_epi_app {F G : C ⥤ D} (η : F ⟶ G) :
   epi η ↔ (∀ c, epi (η.app c)) :=
 begin
   split,
   { introsI h c,
     exact (infer_instance : epi (((evaluation _ _).obj c).map η)) },
   { introsI,
-    apply nat_trans.epi_app_of_epi }
+    apply nat_trans.epi_of_epi_app }
 end
 
 end

--- a/src/category_theory/functor/category.lean
+++ b/src/category_theory/functor/category.lean
@@ -67,11 +67,11 @@ lemma naturality_app {F G : C ⥤ (D ⥤ E)} (T : F ⟶ G) (Z : D) {X Y : C} (f 
 congr_fun (congr_arg app (T.naturality f)) Z
 
 /-- A natural transformation is a monomorphism if each component is. -/
-lemma mono_app_of_mono (α : F ⟶ G) [∀ (X : C), mono (α.app X)] : mono α :=
+lemma mono_of_mono_app (α : F ⟶ G) [∀ (X : C), mono (α.app X)] : mono α :=
 ⟨λ H g h eq, by { ext X, rw [←cancel_mono (α.app X), ←comp_app, eq, comp_app] }⟩
 
 /-- A natural transformation is an epimorphism if each component is. -/
-lemma epi_app_of_epi (α : F ⟶ G) [∀ (X : C), epi (α.app X)] : epi α :=
+lemma epi_of_epi_app (α : F ⟶ G) [∀ (X : C), epi (α.app X)] : epi α :=
 ⟨λ H g h eq, by { ext X, rw [←cancel_epi (α.app X), ←comp_app, eq, comp_app] }⟩
 
 /-- `hcomp α β` is the horizontal composition of natural transformations. -/

--- a/src/category_theory/sites/subsheaf.lean
+++ b/src/category_theory/sites/subsheaf.lean
@@ -324,7 +324,7 @@ begin
   rw is_iso_iff_bijective,
   split,
   { intros x y e,
-    have := (nat_trans.mono_iff_app_mono _ _).mp hf X,
+    have := (nat_trans.mono_iff_mono_app _ _).mp hf X,
     rw mono_iff_injective at this,
     exact this (congr_arg subtype.val e : _) },
   { rintro ⟨_, ⟨x, rfl⟩⟩, exact ⟨x, rfl⟩ }


### PR DESCRIPTION
This PR fixes the names of a few lemmas like `mono_app_of_mono`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
