### PR TITLE
[Merged by Bors] - feat(analysis/convex/body): define bodies and implement module instance

### DIFF
--- a/src/analysis/convex/body.lean
+++ b/src/analysis/convex/body.lean
@@ -84,24 +84,37 @@ instance : add_comm_monoid (convex_body V) :=
 { add_comm := λ K L, by { ext, simp only [coe_add, add_comm] },
   .. convex_body.add_monoid }
 
-instance : has_smul ℝ≥0 (convex_body V) :=
+noncomputable example : has_smul ℝ V := infer_instance
+example : topological_space V := infer_instance
+example : has_continuous_const_smul ℝ≥0 V := @nnreal.has_continuous_const_smul V _ _ _
+
+instance : has_smul ℝ (convex_body V) :=
 { smul := λ c K, ⟨c • (K : set V), K.convex.smul _, K.is_compact.smul _, K.nonempty.smul_set⟩ }
 
 @[simp]
-lemma coe_smul (c : ℝ≥0) (K : convex_body V) : (↑(c • K) : set V) = c • (K : set V) := rfl
+lemma coe_smul (c : ℝ) (K : convex_body V) : (↑(c • K) : set V) = c • (K : set V) := rfl
 
-instance : distrib_mul_action ℝ≥0 (convex_body V) :=
+-- @[simp]
+-- lemma coe_smul' (c: ℝ≥0) (K : convex_body V) : (↑(c • K) : set V) = c • (K : set V) := sorry
+
+instance : distrib_mul_action ℝ (convex_body V) :=
 { to_has_smul := convex_body.has_smul,
   one_smul := λ K, by { ext, simp only [coe_smul, one_smul] },
   mul_smul := λ c d K, by { ext, simp only [coe_smul, mul_smul] },
   smul_add := λ c K L, by { ext, simp only [coe_smul, coe_add, smul_add] },
   smul_zero := λ c, by { ext, simp only [coe_smul, coe_zero, smul_zero] } }
 
+instance has_smul' : has_smul ℝ≥0 (convex_body V) :=
+nnreal.distrib_mul_action.to_has_smul
+
+@[simp]
+lemma coe_smul' (c : ℝ) (K : convex_body V) : (↑(c • K) : set V) = c • (K : set V) := rfl
+
 /--
 The convex bodies in a fixed space $V$ form a module over the nonnegative reals.
 -/
 instance : module ℝ≥0 (convex_body V) :=
-{ to_distrib_mul_action := convex_body.distrib_mul_action,
+{ to_distrib_mul_action := infer_instance,
   add_smul := λ c d K,
   begin
     ext1,

--- a/src/analysis/convex/body.lean
+++ b/src/analysis/convex/body.lean
@@ -31,16 +31,13 @@ convex, convex body
 open_locale pointwise
 open_locale nnreal
 
-variables {V : Type}
-[seminormed_add_comm_group V]
-[normed_space ℝ V]
+variables (V : Type*) [seminormed_add_comm_group V] [normed_space ℝ V]
 
 /--
 Let `V` be a normed space. A subset of `V` is a convex body if and only if
 it is convex, compact, and nonempty.
 -/
-structure convex_body
-  (V : Type) [seminormed_add_comm_group V] [normed_space ℝ V] :=
+structure convex_body :=
 (carrier : set V)
 (convex' : convex ℝ carrier)
 (is_compact' : is_compact carrier)
@@ -93,13 +90,10 @@ instance : has_smul ℝ≥0 (convex_body V) :=
 @[simp]
 lemma coe_smul (c : ℝ≥0) (K : convex_body V) : (↑(c • K) : set V) = c • (K : set V) := rfl
 
-instance : mul_action ℝ≥0 (convex_body V) :=
+instance : distrib_mul_action ℝ≥0 (convex_body V) :=
 { to_has_smul := convex_body.has_smul,
   one_smul := λ K, by { ext, simp only [coe_smul, one_smul] },
-  mul_smul := λ c d K, by { ext, simp only [coe_smul, mul_smul] } }
-
-instance : distrib_mul_action ℝ≥0 (convex_body V) :=
-{ to_mul_action := convex_body.mul_action,
+  mul_smul := λ c d K, by { ext, simp only [coe_smul, mul_smul] },
   smul_add := λ c K L, by { ext, simp only [coe_smul, coe_add, smul_add] },
   smul_zero := λ c, by { ext, simp only [coe_smul, coe_zero, smul_zero] } }
 

--- a/src/analysis/convex/body.lean
+++ b/src/analysis/convex/body.lean
@@ -90,18 +90,12 @@ instance : has_smul ℝ (convex_body V) :=
 @[simp]
 lemma coe_smul (c : ℝ) (K : convex_body V) : (↑(c • K) : set V) = c • (K : set V) := rfl
 
--- @[simp]
--- lemma coe_smul' (c: ℝ≥0) (K : convex_body V) : (↑(c • K) : set V) = c • (K : set V) := sorry
-
 instance : distrib_mul_action ℝ (convex_body V) :=
 { to_has_smul := convex_body.has_smul,
   one_smul := λ K, by { ext, simp only [coe_smul, one_smul] },
   mul_smul := λ c d K, by { ext, simp only [coe_smul, mul_smul] },
   smul_add := λ c K L, by { ext, simp only [coe_smul, coe_add, smul_add] },
   smul_zero := λ c, by { ext, simp only [coe_smul, coe_zero, smul_zero] } }
-
-instance has_smul' : has_smul ℝ≥0 (convex_body V) :=
-nnreal.distrib_mul_action.to_has_smul
 
 @[simp]
 lemma coe_smul' (c : ℝ≥0) (K : convex_body V) : (↑(c • K) : set V) = c • (K : set V) := rfl
@@ -110,8 +104,7 @@ lemma coe_smul' (c : ℝ≥0) (K : convex_body V) : (↑(c • K) : set V) = c �
 The convex bodies in a fixed space $V$ form a module over the nonnegative reals.
 -/
 instance : module ℝ≥0 (convex_body V) :=
-{ to_distrib_mul_action := infer_instance,
-  add_smul := λ c d K,
+{ add_smul := λ c d K,
   begin
     ext1,
     simp only [coe_smul, coe_add],

--- a/src/analysis/convex/body.lean
+++ b/src/analysis/convex/body.lean
@@ -84,10 +84,6 @@ instance : add_comm_monoid (convex_body V) :=
 { add_comm := λ K L, by { ext, simp only [coe_add, add_comm] },
   .. convex_body.add_monoid }
 
-noncomputable example : has_smul ℝ V := infer_instance
-example : topological_space V := infer_instance
-example : has_continuous_const_smul ℝ≥0 V := @nnreal.has_continuous_const_smul V _ _ _
-
 instance : has_smul ℝ (convex_body V) :=
 { smul := λ c K, ⟨c • (K : set V), K.convex.smul _, K.is_compact.smul _, K.nonempty.smul_set⟩ }
 

--- a/src/analysis/convex/body.lean
+++ b/src/analysis/convex/body.lean
@@ -108,7 +108,7 @@ instance has_smul' : has_smul ℝ≥0 (convex_body V) :=
 nnreal.distrib_mul_action.to_has_smul
 
 @[simp]
-lemma coe_smul' (c : ℝ) (K : convex_body V) : (↑(c • K) : set V) = c • (K : set V) := rfl
+lemma coe_smul' (c : ℝ≥0) (K : convex_body V) : (↑(c • K) : set V) = c • (K : set V) := rfl
 
 /--
 The convex bodies in a fixed space $V$ form a module over the nonnegative reals.

--- a/src/analysis/convex/body.lean
+++ b/src/analysis/convex/body.lean
@@ -110,24 +110,9 @@ instance : module ℝ≥0 (convex_body V) :=
 { to_distrib_mul_action := convex_body.distrib_mul_action,
   add_smul := λ c d K,
   begin
-    ext,
+    ext1,
     simp only [coe_smul, coe_add],
-    split,
-    { rintro ⟨x, xK, rfl⟩,
-      exact ⟨c • x, d • x, ⟨x, xK, rfl⟩, ⟨x, xK, rfl⟩, by rw [add_smul]⟩ },
-    { rintro ⟨-, -, ⟨x₁, x₁K, rfl⟩, ⟨x₂, x₂K, rfl⟩, rfl⟩,
-      by_cases h : c + d = 0,
-      { rw [add_eq_zero_iff] at h,
-        simp only [h.1, h.2, zero_smul, zero_add],
-        exact ⟨x₁, x₁K, by rw [zero_smul]⟩ },
-      { rw [←ne.def, ←pos_iff_ne_zero,
-            ←nnreal.coe_lt_coe, nnreal.coe_add] at h,
-        refine ⟨((↑c : ℝ) / (c + d)) • x₁ + ((↑d : ℝ) / (c + d)) • x₂, _, _⟩,
-        { refine K.convex x₁K x₂K _ _ _,
-          any_goals { apply_rules [div_nonneg, add_nonneg, nnreal.coe_nonneg] },
-          rw [←add_div, div_self (ne_of_gt h)] },
-        { simp only [nnreal.smul_def, nonneg.coe_add, smul_add, smul_smul,
-          mul_div_cancel' _ (ne_of_gt h)] } } }
+    exact convex.add_smul K.convex (nnreal.coe_nonneg _) (nnreal.coe_nonneg _),
   end,
   zero_smul := λ K, by { ext1, exact set.zero_smul_set K.nonempty } }
 

--- a/src/analysis/convex/body.lean
+++ b/src/analysis/convex/body.lean
@@ -88,7 +88,7 @@ instance : add_comm_monoid (convex_body V) :=
   .. convex_body.add_monoid }
 
 instance : has_smul ℝ≥0 (convex_body V) :=
-{ smul := λ c K, ⟨c • (K : set V), K.convex.smul _, K.is_compact.smul _, K.nonempty.smul_set⟩}
+{ smul := λ c K, ⟨c • (K : set V), K.convex.smul _, K.is_compact.smul _, K.nonempty.smul_set⟩ }
 
 @[simp]
 lemma coe_smul (c : ℝ≥0) (K : convex_body V) : (↑(c • K) : set V) = c • (K : set V) := rfl

--- a/src/analysis/convex/body.lean
+++ b/src/analysis/convex/body.lean
@@ -1,0 +1,134 @@
+/-
+Copyright (c) 2022 Paul A. Reichert. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Paul A. Reichert
+-/
+import analysis.convex.basic
+import analysis.normed_space.basic
+import data.real.nnreal
+import data.set.pointwise
+import topology.subset_properties
+
+/-!
+# convex bodies
+
+This file contains the definition of the type `convex_body V`
+consisting of
+convex, compact, nonempty subsets of a real normed space `V`.
+
+`convex_body V` is a module over the nonnegative reals (`nnreal`).
+
+TODOs:
+- endow it with the Hausdorff metric
+- define positive convex bodies, requiring the interior to be nonempty
+- introduce support sets
+
+## Tags
+
+convex, convex body
+-/
+
+open_locale pointwise
+open_locale nnreal
+
+variables {V : Type}
+[seminormed_add_comm_group V]
+[normed_space ℝ V]
+
+/--
+Let `V` be a normed space. A subset of `V` is a convex body if and only if
+it is convex, compact, and nonempty.
+-/
+structure convex_body
+  (V : Type) [seminormed_add_comm_group V] [normed_space ℝ V] :=
+(carrier : set V)
+(convex' : convex ℝ carrier)
+(is_compact' : is_compact carrier)
+(nonempty' : carrier.nonempty)
+
+namespace convex_body
+
+variables {V}
+
+instance : set_like (convex_body V) V :=
+{ coe := convex_body.carrier,
+  coe_injective' := λ K L h, by { cases K, cases L, congr' } }
+
+lemma convex (K : convex_body V) : convex ℝ (K : set V) := K.convex'
+lemma is_compact (K : convex_body V) : is_compact (K : set V) := K.is_compact'
+lemma nonempty (K : convex_body V) : (K : set V).nonempty := K.nonempty'
+
+@[ext]
+protected lemma ext {K L : convex_body V} (h : (K : set V) = L) : K = L := set_like.ext' h
+
+@[simp]
+lemma coe_mk (s : set V) (h₁ h₂ h₃) : (mk s h₁ h₂ h₃ : set V) = s := rfl
+
+instance : add_monoid (convex_body V) :=
+-- we cannot write K + L to avoid reducibility issues with the set.has_add instance
+{ add := λ K L, ⟨set.image2 (+) K L,
+                 K.convex.add L.convex,
+                 K.is_compact.add L.is_compact,
+                 K.nonempty.add L.nonempty⟩,
+  add_assoc := λ K L M, by { ext, simp only [coe_mk, set.image2_add, add_assoc] },
+  zero := ⟨0, convex_singleton 0, is_compact_singleton, set.singleton_nonempty 0⟩,
+  zero_add := λ K, by { ext, simp only [coe_mk, set.image2_add, zero_add] },
+  add_zero := λ K, by { ext, simp only [coe_mk, set.image2_add, add_zero] } }
+
+@[simp]
+lemma coe_add (K L : convex_body V) : (↑(K + L) : set V) = (K : set V) + L := rfl
+
+@[simp]
+lemma coe_zero : (↑(0 : convex_body V) : set V) = 0 := rfl
+
+instance : inhabited (convex_body V) := ⟨0⟩
+
+instance : add_comm_monoid (convex_body V) :=
+{ add_comm := λ K L, by { ext, simp only [coe_add, add_comm] },
+  .. convex_body.add_monoid }
+
+instance : has_smul ℝ≥0 (convex_body V) :=
+{ smul := λ c K, ⟨c • (K : set V), K.convex.smul _, K.is_compact.smul _, K.nonempty.smul_set⟩}
+
+@[simp]
+lemma coe_smul (c : ℝ≥0) (K : convex_body V) : (↑(c • K) : set V) = c • (K : set V) := rfl
+
+instance : mul_action ℝ≥0 (convex_body V) :=
+{ to_has_smul := convex_body.has_smul,
+  one_smul := λ K, by { ext, simp only [coe_smul, one_smul] },
+  mul_smul := λ c d K, by { ext, simp only [coe_smul, mul_smul] } }
+
+instance : distrib_mul_action ℝ≥0 (convex_body V) :=
+{ to_mul_action := convex_body.mul_action,
+  smul_add := λ c K L, by { ext, simp only [coe_smul, coe_add, smul_add] },
+  smul_zero := λ c, by { ext, simp only [coe_smul, coe_zero, smul_zero] } }
+
+/--
+The convex bodies in a fixed space $V$ form a module over the nonnegative reals.
+-/
+instance : module ℝ≥0 (convex_body V) :=
+{ to_distrib_mul_action := convex_body.distrib_mul_action,
+  add_smul := λ c d K,
+  begin
+    ext,
+    simp only [coe_smul, coe_add],
+    split,
+    { rintro ⟨x, xK, rfl⟩,
+      exact ⟨c • x, d • x, ⟨x, xK, rfl⟩, ⟨x, xK, rfl⟩, by rw [add_smul]⟩ },
+    { rintro ⟨-, -, ⟨x₁, x₁K, rfl⟩, ⟨x₂, x₂K, rfl⟩, rfl⟩,
+      by_cases h : c + d = 0,
+      { rw [add_eq_zero_iff] at h,
+        simp only [h.1, h.2, zero_smul, zero_add],
+        exact ⟨x₁, x₁K, by rw [zero_smul]⟩ },
+      { rw [←ne.def, ←pos_iff_ne_zero,
+            ←nnreal.coe_lt_coe, nnreal.coe_add] at h,
+        refine ⟨((↑c : ℝ) / (c + d)) • x₁ + ((↑d : ℝ) / (c + d)) • x₂, _, _⟩,
+        { refine K.convex x₁K x₂K _ _ _,
+          any_goals { apply_rules [div_nonneg, add_nonneg, nnreal.coe_nonneg] },
+          rw [←add_div, div_self (ne_of_gt h)] },
+        { simp only [nnreal.smul_def, nonneg.coe_add, smul_add, smul_smul,
+          mul_div_cancel' _ (ne_of_gt h)] } } }
+  end,
+  zero_smul := λ K, by { ext1, exact set.zero_smul_set K.nonempty } }
+
+end convex_body

--- a/src/topology/algebra/const_mul_action.lean
+++ b/src/topology/algebra/const_mul_action.lean
@@ -119,7 +119,6 @@ lemma is_compact.smul {α β: Type} [has_smul α β] [topological_space β]
   [has_continuous_const_smul α β] (a : α) {s : set β}
   (hs : is_compact s) : is_compact (a • s) := hs.image (continuous_id'.const_smul a)
 
--- or move it to another place?
 instance nnreal.has_continuous_const_smul
   {α : Type} [mul_action ℝ α] [topological_space α]
   [has_continuous_const_smul ℝ α] : has_continuous_const_smul nnreal α :=

--- a/src/topology/algebra/const_mul_action.lean
+++ b/src/topology/algebra/const_mul_action.lean
@@ -115,12 +115,12 @@ instance {ι : Type*} {γ : ι → Type*} [∀ i, topological_space (γ i)] [Π 
   [∀ i, has_continuous_const_smul M (γ i)] : has_continuous_const_smul M (Π i, γ i) :=
 ⟨λ _, continuous_pi $ λ i, (continuous_apply i).const_smul _⟩
 
-lemma is_compact.smul {α β: Type} [has_smul α β] [topological_space β]
+lemma is_compact.smul {α β} [has_smul α β] [topological_space β]
   [has_continuous_const_smul α β] (a : α) {s : set β}
   (hs : is_compact s) : is_compact (a • s) := hs.image (continuous_id'.const_smul a)
 
 instance nnreal.has_continuous_const_smul
-  {α : Type} [mul_action ℝ α] [topological_space α]
+  {α} [mul_action ℝ α] [topological_space α]
   [has_continuous_const_smul ℝ α] : has_continuous_const_smul nnreal α :=
 { continuous_const_smul := λ c,
   begin

--- a/src/topology/algebra/const_mul_action.lean
+++ b/src/topology/algebra/const_mul_action.lean
@@ -3,6 +3,7 @@ Copyright (c) 2021 Alex Kontorovich, Heather Macbeth. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Alex Kontorovich, Heather Macbeth
 -/
+import data.real.nnreal
 import topology.algebra.constructions
 import topology.homeomorph
 import group_theory.group_action.basic
@@ -113,6 +114,20 @@ instance [has_smul M β] [has_continuous_const_smul M β] :
 instance {ι : Type*} {γ : ι → Type*} [∀ i, topological_space (γ i)] [Π i, has_smul M (γ i)]
   [∀ i, has_continuous_const_smul M (γ i)] : has_continuous_const_smul M (Π i, γ i) :=
 ⟨λ _, continuous_pi $ λ i, (continuous_apply i).const_smul _⟩
+
+lemma is_compact.smul {α β: Type} [has_smul α β] [topological_space β]
+  [has_continuous_const_smul α β] (a : α) {s : set β}
+  (hs : is_compact s) : is_compact (a • s) := hs.image (continuous_id'.const_smul a)
+
+-- or move it to another place?
+instance nnreal.has_continuous_const_smul
+  {α : Type} [mul_action ℝ α] [topological_space α]
+  [has_continuous_const_smul ℝ α] : has_continuous_const_smul nnreal α :=
+{ continuous_const_smul := λ c,
+  begin
+    convert continuous_id'.const_smul (↑c : ℝ),
+    apply_instance
+  end }
 
 end has_smul
 

--- a/src/topology/algebra/const_mul_action.lean
+++ b/src/topology/algebra/const_mul_action.lean
@@ -119,15 +119,6 @@ lemma is_compact.smul {α β} [has_smul α β] [topological_space β]
   [has_continuous_const_smul α β] (a : α) {s : set β}
   (hs : is_compact s) : is_compact (a • s) := hs.image (continuous_id'.const_smul a)
 
-instance nnreal.has_continuous_const_smul
-  {α} [mul_action ℝ α] [topological_space α]
-  [has_continuous_const_smul ℝ α] : has_continuous_const_smul nnreal α :=
-{ continuous_const_smul := λ c,
-  begin
-    convert continuous_id'.const_smul (↑c : ℝ),
-    apply_instance
-  end }
-
 end has_smul
 
 section monoid


### PR DESCRIPTION
Defines the type `convex_body V` and endows it with a
module structure over the nonnegative reals.

This commit also introduces `set_like` and `inhabited` instances.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
