### PR TITLE
feat(data/{nat.choose.multinomial, sym}): add multinomial theorem

### DIFF
--- a/src/data/nat/choose/multinomial.lean
+++ b/src/data/nat/choose/multinomial.lean
@@ -70,14 +70,14 @@ begin
   rw nat.mul_div_assoc _ (prod_factorial_dvd_factorial_sum _ _),
 end
 
-lemma multinomial_insert [decidable_eq α] (h : a ∉ s) {n : ℕ} :
+lemma multinomial_insert [decidable_eq α] (h : a ∉ s) :
   multinomial (insert a s) f = (f a + s.sum f).choose (f a) * multinomial s f :=
 begin
   rw choose_eq_factorial_div_factorial (le.intro rfl),
   simp only [multinomial, nat.add_sub_cancel_left, finset.sum_insert h, finset.prod_insert h,
-    h₁, function.comp_app],
-  rw [div_mul_div_comm (n.factorial_mul_factorial_dvd_factorial_add (s.sum f))
-    prod_factorial_dvd_factorial_sum _ _, mul_comm n! (s.sum f)!, mul_assoc,
+    function.comp_app],
+  rw [div_mul_div_comm ((f a).factorial_mul_factorial_dvd_factorial_add (s.sum f))
+    (prod_factorial_dvd_factorial_sum _ _), mul_comm (f a)! (s.sum f)!, mul_assoc,
     mul_comm _ (s.sum f)!, nat.mul_div_mul _ _ (factorial_pos _)],
 end
 
@@ -97,7 +97,7 @@ by simpa [finset.sum_pair hab, finset.prod_pair hab] using multinomial_spec {a, 
 
 @[simp] lemma binomial_one [decidable_eq α] (h : a ≠ b) (h₁ : f a = 1) :
   multinomial {a, b} f = (f b).succ :=
-by simp [multinomial_one {b} f (finset.not_mem_singleton.mpr h) h₁]
+by simp [multinomial_insert_one {b} f (finset.not_mem_singleton.mpr h) h₁]
 
 lemma binomial_succ_succ [decidable_eq α] (h : a ≠ b) :
   multinomial {a, b} (function.update (function.update f a (f a).succ) b (f b).succ) =

--- a/src/data/nat/choose/multinomial.lean
+++ b/src/data/nat/choose/multinomial.lean
@@ -4,10 +4,13 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Pim Otte
 Heavily inspired by code from Kyle Miller and Kevin Buzzard
 -/
-import data.nat.choose.basic
-import data.list.perm
-import data.finset.basic
 import algebra.big_operators.basic
+import algebra.big_operators.fin
+import data.nat.choose.basic
+import data.finset.basic
+import data.list.perm
+import data.fin.vec_notation
+
 import tactic.linarith
 
 /-!
@@ -148,6 +151,21 @@ begin
     function.update_same, function.update_noteq (ne_comm.mp h)],
   convert succ_mul_choose_eq (f a + f b) (f a),
   exact succ_add (f a) (f b),
+end
+
+/-! ### Simple cases -/
+
+lemma multinomial_univ_two  (a b: ℕ) : multinomial finset.univ (![a, b]) = (a + b)! / (a! * b!) :=
+begin
+    unfold multinomial,
+    simp [fin.sum_univ_two, fin.prod_univ_two],
+end
+
+lemma multinomial_univ_three  (a b c: ℕ) : multinomial finset.univ (![a, b, c]) =
+  (a + b + c)! / (a! * b! * c!) :=
+begin
+    unfold multinomial,
+    simp [fin.sum_univ_three, fin.prod_univ_three],
 end
 
 end nat

--- a/src/data/nat/choose/multinomial.lean
+++ b/src/data/nat/choose/multinomial.lean
@@ -38,13 +38,11 @@ lemma prod_factorial_dvd_factorial_sum {α} (s : finset α) (f : α → ℕ) :
 begin
   classical,
   induction s using finset.induction with α' s' has ih,
-  { simp only [finset.sum_empty, finset.prod_empty, factorial],
-  },
+  { simp only [finset.sum_empty, finset.prod_empty, factorial], },
   { simp [finset.prod_insert has, finset.sum_insert has],
     refine dvd_trans (mul_dvd_mul_left ((f α')!) ih) _,
     convert factorial_mul_factorial_dvd_factorial (le.intro rfl),
-    rw nat.add_sub_cancel_left,
-  },
+    rw nat.add_sub_cancel_left, },
 end
 
 lemma mul_factorial_dvd_factorial_add (a b : ℕ) : a! * b! ∣ (a + b)! :=

--- a/src/data/nat/choose/multinomial.lean
+++ b/src/data/nat/choose/multinomial.lean
@@ -22,6 +22,10 @@ This file defines the multinomial coefficient and several small lemma's for mani
 
 - `nat.multinomial`: the multinomial coefficient
 
+## Main results
+
+- `nat.multinomial_theorem`: The expansion of `(s.sum x) ^ n` using multinomial coefficients
+
 -/
 
 open_locale nat
@@ -192,7 +196,12 @@ namespace nat
 
 variables {α : Type*} (s : finset α)
 
-def multinomial_theorem [decidable_eq α] {R : Type*} [comm_semiring R] (x : α → R) :
+/--
+  The multinomial theorem
+
+  Proof is by induction on the number of summands.
+-/
+theorem multinomial_theorem [decidable_eq α] {R : Type*} [comm_semiring R] (x : α → R) :
   ∀ n, (s.sum x) ^ n = ∑ k in s.sym n, k.val.multinomial * (k.val.map x).prod :=
 begin
   induction s using finset.induction with a s ha ih,

--- a/src/data/nat/choose/multinomial.lean
+++ b/src/data/nat/choose/multinomial.lean
@@ -74,7 +74,7 @@ begin
   rw nat.mul_div_assoc _ (prod_factorial_dvd_factorial_sum _ _),
 end
 
-lemma multinomial_add_n [decidable_eq α] (h : a ∉ s) {n : ℕ} (h₁: f a = n) :
+lemma multinomial_add_n [decidable_eq α] (h : a ∉ s) {n : ℕ} (h₁ : f a = n) :
   multinomial (insert a s) f = (n + s.sum f).choose n * multinomial s f :=
 begin
   rw choose_eq_factorial_div_factorial (le.intro rfl),

--- a/src/data/nat/choose/multinomial.lean
+++ b/src/data/nat/choose/multinomial.lean
@@ -6,8 +6,10 @@ Authors: Pim Otte
 
 import algebra.big_operators.fin
 import algebra.big_operators.order
-import data.nat.choose.basic
+import data.nat.choose.sum
 import data.fin.vec_notation
+import data.finset.sym
+import data.finsupp.multiset
 
 import tactic.linarith
 
@@ -27,8 +29,7 @@ open_locale big_operators
 
 namespace nat
 
-variables {α : Type*} (s : finset α) (f : α → ℕ)
-variables {a b : α}
+variables {α : Type*} (s : finset α) (f : α → ℕ) {a b : α} (n : ℕ )
 
 /-- The multinomial coefficient. Gives the number of strings consisting of symbols
 from `s`, where `c ∈ s` appears with multiplicity `f c`.
@@ -81,6 +82,14 @@ begin
     mul_comm _ (s.sum f)!, nat.mul_div_mul _ _ (factorial_pos _)],
 end
 
+lemma multinomial_congr {f g : α → ℕ} (h : ∀ a ∈ s, f a = g a) :
+  multinomial s f = multinomial s g :=
+begin
+  simp only [multinomial], congr' 1,
+  { rw finset.sum_congr rfl h },
+  { exact finset.prod_congr rfl (λ a ha, by rw h a ha) },
+end
+
 /-! ### Connection to binomial coefficients -/
 
 lemma binomial_eq [decidable_eq α] (h : a ≠ b) :
@@ -128,5 +137,102 @@ by simp [multinomial, fin.sum_univ_two, fin.prod_univ_two]
 lemma multinomial_univ_three (a b c : ℕ) : multinomial finset.univ ![a, b, c] =
   (a + b + c)! / (a! * b! * c!) :=
 by simp [multinomial, fin.sum_univ_three, fin.prod_univ_three]
+
+end nat
+
+/-! ### Alternative definitions -/
+
+namespace finsupp
+
+variables {α : Type*}
+
+def multinomial (f : α →₀ ℕ) : ℕ := (f.sum $ λ _, id)! / f.prod (λ _ n, n!)
+
+lemma multinomial_eq (f : α →₀ ℕ) : f.multinomial = nat.multinomial f.support f := rfl
+
+lemma multinomial_update (a : α) (f : α →₀ ℕ) :
+  f.multinomial = (f.sum $ λ _, id).choose (f a) * (f.update a 0).multinomial :=
+begin
+  simp only [multinomial_eq],
+  classical,
+  by_cases a ∈ f.support,
+  { rw [← finset.insert_erase h, nat.multinomial_insert _ f (finset.not_mem_erase a _),
+      finset.add_sum_erase _ f h, support_update_zero], congr' 1,
+    exact nat.multinomial_congr _ (λ _ h, (function.update_noteq (finset.mem_erase.1 h).1 0 f).symm) },
+  rw not_mem_support_iff at h,
+  rw [h, nat.choose_zero_right, one_mul, ← h, update_self],
+end
+
+end finsupp
+
+namespace multiset
+
+variables {α : Type*}
+
+noncomputable def multinomial (m : multiset α) : ℕ := m.to_finsupp.multinomial
+
+lemma multinomial_filter_ne [decidable_eq α] (a : α) (m : multiset α) :
+  m.multinomial = m.card.choose (m.count a) * (m.filter ((≠) a)).multinomial :=
+begin
+  dsimp only [multinomial],
+  convert finsupp.multinomial_update a _,
+  { rw [← finsupp.card_to_multiset, m.to_finsupp_to_multiset] },
+  { ext1 a', rw [to_finsupp_apply, count_filter, finsupp.coe_update],
+    split_ifs,
+    { rw [function.update_noteq h.symm, to_finsupp_apply] },
+    { rw [not_ne_iff.1 h, function.update_same] } },
+end
+
+end multiset
+
+namespace nat
+
+/-! ### Multinomial theorem -/
+
+variables {α : Type*} (s : finset α)
+
+def multinomial_theorem [decidable_eq α] {R : Type*} [comm_semiring R] (x : α → R) :
+  ∀ n, (s.sum x) ^ n = ∑ k in s.sym n, k.val.multinomial * (k.val.map x).prod :=
+begin
+  induction s using finset.induction with a s ha ih,
+  { rw finset.sum_empty,
+    rintro (_ | n),
+    { rw [pow_zero, finset.sum_unique_nonempty],
+      { convert (one_mul _).symm, apply nat.cast_one },
+      { apply finset.univ_nonempty } },
+    { rw [pow_succ, zero_mul, finset.sym_empty, finset.sum_empty] } },
+  intro n,
+  rw [finset.sum_insert ha, add_pow, finset.sum_range],
+  simp_rw [ih, finset.mul_sum, finset.sum_mul, finset.sum_sigma'],
+  refine (finset.sum_bij (λ m _, sym.filter_ne a m)
+    (λ m hm, _) (λ m hm, _) (λ m₁ m₂ h₁ h₂ he, _) (λ m hm, _)).symm,
+  { rw finset.mem_sigma,
+    rw finset.mem_sym_iff at hm ⊢,
+    dsimp only [sym.filter_ne, sym.mem_mk],
+    refine ⟨finset.mem_univ _, λ a', _⟩,
+    rw multiset.mem_filter,
+    exact λ h, finset.mem_of_mem_insert_of_ne (hm a' h.1) h.2.symm },
+  { rw [m.1.multinomial_filter_ne a],
+    dsimp only [sym.filter_ne, fin.coe_mk],
+    conv in (m.1.map _) { rw [← m.1.filter_add_not ((=) a), multiset.map_add] },
+    rw [multiset.prod_add, m.1.filter_eq, multiset.map_repeat, multiset.prod_repeat, m.2],
+    rw [nat.cast_mul, mul_assoc, mul_comm],
+    congr' 1, apply mul_left_comm },
+  { replace he := sigma.subtype_ext_iff.1 he,
+    dsimp only [sym.filter_ne, subtype.coe_mk] at he,
+    simp only [fin.mk.inj_iff] at he,
+    ext a', obtain rfl | h := eq_or_ne a a', { exact he.1 },
+    erw [← multiset.count_filter_of_pos h, he.2, multiset.count_filter_of_pos h], refl },
+  { rw [finset.mem_sigma, finset.mem_sym_iff] at hm,
+    refine ⟨sym.fill a m, finset.mem_sym_iff.2 (λ a' h', finset.mem_insert.2 _), _⟩,
+    { rw [sym.fill, sym.mem_mk, multiset.mem_add] at h',
+      exact h'.imp (λ h, multiset.mem_singleton.1 (multiset.mem_of_mem_nsmul h)) (λ h, hm.2 a' h) },
+    apply sym.sigma_ext, ext1 a',
+    dsimp only [sym.filter_ne, sym.fill],
+    rw [multiset.count_filter], split_ifs,
+    { rw [multiset.count_add, multiset.count_nsmul, multiset.count_singleton, if_neg h.symm],
+      rw [mul_zero, zero_add], refl },
+    { exact multiset.count_eq_zero.2 (λ h', ha $ (not_ne_iff.1 h).symm ▸ hm.2 a' h') } },
+end
 
 end nat

--- a/src/data/nat/choose/multinomial.lean
+++ b/src/data/nat/choose/multinomial.lean
@@ -1,0 +1,153 @@
+/-
+Copyright (c) 2022 Pim Otte. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Pim Otte
+Heavily inspired by code from Kyle Miller and Kevin Buzzard
+-/
+import data.nat.choose.basic
+import data.list.perm
+import tactic
+
+/-!
+# Multinomial
+
+This file defines the multinomial coefficient and several small lemma's for manipulating it.
+
+## Main declarations
+
+- `nat.multinomial`: the multinomial coefficient
+
+-/
+
+open_locale nat
+
+namespace nat
+
+/-- The multinomial coefficient. Gives the number of strings consisting of symbols
+from `s`, where `c ∈ s` appears with multiplicity `f c`.
+
+Defined as `(s.sum f)! / s.prod (factorial ∘ f)`
+-/
+def multinomial {α} (s : finset α) (f : α → ℕ) : ℕ := (s.sum f)! / s.prod (factorial ∘ f)
+
+
+lemma prod_factorial_dvd_factorial_sum {α} (s : finset α) (f : α → ℕ) :
+  s.prod (factorial ∘ f) ∣ (s.sum f)! :=
+begin
+  classical,
+  induction s using finset.induction with α' s' has ih,
+  { simp only [finset.sum_empty, finset.prod_empty, factorial],
+  },
+  { simp [finset.prod_insert has, finset.sum_insert has],
+    refine dvd_trans (mul_dvd_mul_left ((f α')!) ih) _,
+    convert factorial_mul_factorial_dvd_factorial (le.intro rfl),
+    rw nat.add_sub_cancel_left,
+  },
+end
+
+lemma mul_factorial_dvd_factorial_add (a b : ℕ) : a! * b! ∣ (a + b)! :=
+begin
+  convert @factorial_mul_factorial_dvd_factorial (a + b) a (le.intro rfl),
+  rw nat.add_sub_cancel_left,
+end
+
+lemma prod_factorial_pos {α} (s : finset α) (f : α → ℕ) :
+  0 < s.prod (factorial ∘ f) :=
+begin
+  classical,
+  induction s using finset.induction with α' s' has ih,
+  { simp only [succ_pos', finset.prod_empty], },
+  { rw finset.prod_insert has,
+    exact nat.mul_pos (nat.factorial_pos (f α')) ih, },
+end
+
+lemma multinomial_pos {α} (s : finset α) (f : α → ℕ): 0 < multinomial s f :=
+nat.div_pos (le_of_dvd (factorial_pos _) (prod_factorial_dvd_factorial_sum s f))
+  (prod_factorial_pos s f)
+
+lemma multinomial_spec {α} (s : finset α) (f : α → ℕ):
+  s.prod (factorial ∘ f) * multinomial s f = (s.sum f)! :=
+begin
+  exact nat.mul_div_cancel' (prod_factorial_dvd_factorial_sum s f),
+end
+
+
+@[simp] lemma multinomial_nil {α} (f: α → ℕ): multinomial ∅ f = 1 := rfl
+
+@[simp] lemma multinomial_singleton {α} (f: α → ℕ) (a : α): multinomial {a} f = 1 :=
+by simp [multinomial, nat.div_self (factorial_pos (f a))]
+
+@[simp] lemma multinomial_one {α} [decidable_eq α]
+  (s : finset α) (f : α → ℕ) (a : α) (h: a ∉ s) (h₁: f a = 1):
+  multinomial (insert a s) f = (s.sum f).succ * multinomial s f :=
+begin
+  simp only [multinomial, one_mul, factorial],
+  rw [finset.sum_insert h, finset.prod_insert h, h₁, add_comm, ←succ_eq_add_one, factorial_succ],
+  simp only [factorial_one, one_mul, function.comp_app, factorial],
+  rw nat.mul_div_assoc _ (prod_factorial_dvd_factorial_sum _ _),
+end
+
+lemma multinomial_add_n {α} [decidable_eq α]
+  (s : finset α) (f : α → ℕ) (a : α) (h: a ∉ s) {n : ℕ} (h₁: f a = n) :
+  multinomial (insert a s) f = (n + (s.sum f)).choose n * multinomial s f :=
+begin
+  rw choose_eq_factorial_div_factorial (le.intro rfl),
+  simp [multinomial, nat.add_sub_cancel_left, finset.sum_insert h, finset.prod_insert h, h₁],
+  rw div_mul_div_comm (mul_factorial_dvd_factorial_add n (s.sum f))
+    (prod_factorial_dvd_factorial_sum _ _),
+  rw mul_comm n! (s.sum f)!,
+  rw mul_assoc,
+  rw mul_comm _ (s.sum f)!,
+  rw nat.mul_div_mul _ _ (factorial_pos (s.sum f)),
+end
+
+/-! ### Connection to binomial coefficients -/
+
+lemma binomial_eq {α} [decidable_eq α] (f: α → ℕ) (a b: α) (h: a ≠ b) :
+  multinomial {a, b} f = (f a + f b)! / ((f a)! * (f b)!) :=
+  by simp [multinomial, finset.sum_pair h, finset.prod_pair h]
+
+
+lemma binomial_eq_choose {α} [decidable_eq α] (f: α → ℕ) (a b: α) (h: a ≠ b) :
+  multinomial {a, b} f = (f a + f b).choose (f a) :=
+begin
+  have fact : f a ≤ f a + f b, by linarith,
+  simp [binomial_eq _ _ _ h, choose_eq_factorial_div_factorial fact],
+end
+
+lemma binomial_spec {α} [decidable_eq α] (f: α → ℕ) (a b: α) (hab: a ≠ b) :
+  (f a)! * (f b)! * multinomial {a, b} f  = (f a + f b)! :=
+begin
+  have h := multinomial_spec {a, b} f ,
+  simpa [finset.sum_pair hab, finset.prod_pair hab] using h,
+end
+
+@[simp] lemma binomial_one {α} [decidable_eq α] (f: α → ℕ) (a b: α) (h: a ≠ b) (h₁: f a = 1) :
+  multinomial {a, b} f = (f b).succ :=
+begin
+  rw multinomial_one {b} f a (finset.not_mem_singleton.mpr h) h₁,
+  simp,
+end
+
+lemma binomial_succ_succ {α} [decidable_eq α] (f: α → ℕ) (a b: α) (h: a ≠ b) :
+  multinomial {a, b} (function.update (function.update f a (f a).succ) b (f b).succ) =
+  multinomial {a, b} (function.update f a (f a).succ)
+  + multinomial {a, b} (function.update f b (f b).succ) :=
+begin
+  simp only [binomial_eq_choose, function.update_apply, function.update_noteq,
+    succ_add, add_succ, choose_succ_succ, h, ne.def, not_false_iff, function.update_same],
+  rw if_neg (ne_comm.mp h),
+  ring,
+end
+
+lemma succ_mul_binomial {α} [decidable_eq α] (f: α → ℕ) (a b: α) (h: a ≠ b) :
+  (f a + f b).succ * multinomial {a, b} f =
+  (f a).succ * multinomial {a, b} (function.update f a (f a).succ) :=
+begin
+  rw [binomial_eq_choose _ _ _ h, binomial_eq_choose _ _ _ h, mul_comm (f a).succ,
+    function.update_same, function.update_noteq (ne_comm.mp h)],
+  convert succ_mul_choose_eq (f a + f b) (f a),
+  exact succ_add (f a) (f b),
+end
+
+end nat

--- a/src/data/nat/choose/multinomial.lean
+++ b/src/data/nat/choose/multinomial.lean
@@ -33,31 +33,27 @@ variables {a b : α}
 /-- The multinomial coefficient. Gives the number of strings consisting of symbols
 from `s`, where `c ∈ s` appears with multiplicity `f c`.
 
-Defined as `(∑ i in s, f i)! / ∏ i in s, (factorial ∘ f) i`
+Defined as `(∑ i in s, f i)! / ∏ i in s, (f i)!`
 -/
-def multinomial : ℕ := (∑ i in s, f i)! / ∏ i in s, (factorial ∘ f) i
+def multinomial : ℕ := (∑ i in s, f i)! / ∏ i in s, (f i)!
 
-lemma prod_factorial_dvd_factorial_sum : s.prod (factorial ∘ f) ∣ (s.sum f)! :=
+lemma prod_factorial_dvd_factorial_sum : (∏ i in s, (f i)!) ∣ (∑ i in s, f i)! :=
 begin
   classical,
-  induction s using finset.induction with α' s' has ih,
+  induction s using finset.induction with a' s' has ih,
   { simp only [finset.sum_empty, finset.prod_empty, factorial], },
   { simp only [finset.prod_insert has, finset.sum_insert has],
-    refine dvd_trans (mul_dvd_mul_left ((f α')!) ih) _,
+    refine dvd_trans (mul_dvd_mul_left ((f a')!) ih) _,
     apply nat.factorial_mul_factorial_dvd_factorial_add, },
 end
 
-lemma prod_factorial_pos : 0 < s.prod (factorial ∘ f) :=
-begin
-  apply finset.prod_pos,
-  intros i hi,
-  exact factorial_pos (f i),
-end
+lemma prod_factorial_pos : 0 < ∏ i in s, (f i)! :=
+finset.prod_pos (λ i _, factorial_pos (f i))
 
-lemma multinomial_pos : 0 < multinomial s f := nat.div_pos (le_of_dvd (factorial_pos _)
-  (prod_factorial_dvd_factorial_sum s f)) (prod_factorial_pos s f)
+lemma multinomial_pos : 0 < multinomial s f := nat.div_pos
+  (le_of_dvd (factorial_pos _) (prod_factorial_dvd_factorial_sum s f)) (prod_factorial_pos s f)
 
-lemma multinomial_spec : s.prod (factorial ∘ f) * multinomial s f = (s.sum f)! :=
+lemma multinomial_spec : (∏ i in s, (f i)!) * multinomial s f = (∑ i in s, f i)! :=
 nat.mul_div_cancel' (prod_factorial_dvd_factorial_sum s f)
 
 @[simp] lemma multinomial_nil : multinomial ∅ f = 1 := rfl
@@ -65,7 +61,7 @@ nat.mul_div_cancel' (prod_factorial_dvd_factorial_sum s f)
 @[simp] lemma multinomial_singleton : multinomial {a} f = 1 :=
 by simp [multinomial, nat.div_self (factorial_pos (f a))]
 
-@[simp] lemma multinomial_one [decidable_eq α] (h : a ∉ s) (h₁ : f a = 1):
+@[simp] lemma multinomial_insert_one [decidable_eq α] (h : a ∉ s) (h₁ : f a = 1) :
   multinomial (insert a s) f = (s.sum f).succ * multinomial s f :=
 begin
   simp only [multinomial, one_mul, factorial],
@@ -74,14 +70,14 @@ begin
   rw nat.mul_div_assoc _ (prod_factorial_dvd_factorial_sum _ _),
 end
 
-lemma multinomial_add_n [decidable_eq α] (h : a ∉ s) {n : ℕ} (h₁ : f a = n) :
-  multinomial (insert a s) f = (n + s.sum f).choose n * multinomial s f :=
+lemma multinomial_insert [decidable_eq α] (h : a ∉ s) {n : ℕ} :
+  multinomial (insert a s) f = (f a + s.sum f).choose (f a) * multinomial s f :=
 begin
   rw choose_eq_factorial_div_factorial (le.intro rfl),
   simp only [multinomial, nat.add_sub_cancel_left, finset.sum_insert h, finset.prod_insert h,
     h₁, function.comp_app],
-  rw [div_mul_div_comm (nat.factorial_mul_factorial_dvd_factorial_add n (s.sum f))
-    (prod_factorial_dvd_factorial_sum _ _), mul_comm n! (s.sum f)!, mul_assoc,
+  rw [div_mul_div_comm (n.factorial_mul_factorial_dvd_factorial_add (s.sum f))
+    prod_factorial_dvd_factorial_sum _ _, mul_comm n! (s.sum f)!, mul_assoc,
     mul_comm _ (s.sum f)!, nat.mul_div_mul _ _ (factorial_pos _)],
 end
 
@@ -110,11 +106,12 @@ lemma binomial_succ_succ [decidable_eq α] (h : a ≠ b) :
 begin
   simp only [binomial_eq_choose, function.update_apply, function.update_noteq,
     succ_add, add_succ, choose_succ_succ, h, ne.def, not_false_iff, function.update_same],
-  rw if_neg (ne_comm.mp h),
+  rw if_neg h.symm,
   ring,
 end
 
-lemma succ_mul_binomial [decidable_eq α] (h : a ≠ b) : (f a + f b).succ * multinomial {a, b} f =
+lemma succ_mul_binomial [decidable_eq α] (h : a ≠ b) :
+  (f a + f b).succ * multinomial {a, b} f =
   (f a).succ * multinomial {a, b} (function.update f a (f a).succ) :=
 begin
   rw [binomial_eq_choose _ h, binomial_eq_choose _ h, mul_comm (f a).succ,

--- a/src/data/nat/choose/multinomial.lean
+++ b/src/data/nat/choose/multinomial.lean
@@ -158,7 +158,8 @@ begin
   by_cases a ∈ f.support,
   { rw [← finset.insert_erase h, nat.multinomial_insert _ f (finset.not_mem_erase a _),
       finset.add_sum_erase _ f h, support_update_zero], congr' 1,
-    exact nat.multinomial_congr _ (λ _ h, (function.update_noteq (finset.mem_erase.1 h).1 0 f).symm) },
+    exact nat.multinomial_congr _ (λ _ h, (function.update_noteq
+      (finset.mem_erase.1 h).1 0 f).symm) },
   rw not_mem_support_iff at h,
   rw [h, nat.choose_zero_right, one_mul, ← h, update_self],
 end

--- a/src/data/nat/choose/multinomial.lean
+++ b/src/data/nat/choose/multinomial.lean
@@ -82,7 +82,7 @@ begin
     h₁, function.comp_app],
   rw [div_mul_div_comm (nat.factorial_mul_factorial_dvd_factorial_add n (s.sum f))
     (prod_factorial_dvd_factorial_sum _ _), mul_comm n! (s.sum f)!, mul_assoc,
-    mul_comm _ (s.sum f)!, nat.mul_div_mul _ _ (factorial_pos (s.sum f))],
+    mul_comm _ (s.sum f)!, nat.mul_div_mul _ _ (factorial_pos _)],
 end
 
 /-! ### Connection to binomial coefficients -/

--- a/src/data/nat/choose/multinomial.lean
+++ b/src/data/nat/choose/multinomial.lean
@@ -6,7 +6,9 @@ Heavily inspired by code from Kyle Miller and Kevin Buzzard
 -/
 import data.nat.choose.basic
 import data.list.perm
-import tactic
+import data.finset.basic
+import algebra.big_operators.basic
+import tactic.linarith
 
 /-!
 # Multinomial

--- a/src/data/sym/basic.lean
+++ b/src/data/sym/basic.lean
@@ -312,6 +312,30 @@ multiset.mem_attach _ _
   :=
 coe_injective $ multiset.attach_cons _ _
 
+/-- fill (n+1) elements of sym α (n - i) with copies of a to obtain an element of sym α n  -/
+def fill (a : α) (m : Σ i : fin (n + 1), sym α (n - i)) : sym α n :=
+sym.mk (m.1.1 • {a} + m.2) begin
+  erw [multiset.card_add, m.2.2, multiset.card_nsmul, multiset.card_singleton, mul_one],
+  exact nat.add_sub_of_le (nat.lt_succ_iff.1 m.1.2),
+end
+
+def filter_ne [decidable_eq α] (a : α) {n : ℕ}
+  (m : sym α n) : Σ i : fin (n + 1), sym α (n - i) :=
+⟨⟨m.1.count a, (multiset.count_le_card _ _).trans_lt $ by rw [m.2, nat.lt_succ_iff]⟩,
+  sym.mk (m.1.filter ((≠) a)) $ eq_tsub_of_add_eq begin
+    conv_rhs { rw [← m.2, multiset.card_eq_countp_add_countp ((=) a), add_comm] },
+    rw multiset.countp_eq_card_filter, refl,
+  end⟩
+
+lemma sigma_ext (m₁ m₂ : Σ i : fin (n + 1), sym α (n - i))
+  (h : m₁.2.1 = m₂.2.1) : m₁ = m₂ :=
+sigma.subtype_ext (fin.ext $ begin
+  have h₁ := nat.sub_sub_self (nat.lt_succ_iff.1 m₁.1.2),
+  have h₂ := nat.sub_sub_self (nat.lt_succ_iff.1 m₂.1.2),
+  dsimp only [fin.val_eq_coe] at h₁ h₂,
+  rw [← h₁, ← h₂, ← m₁.2.2, ← m₂.2.2, h],
+end) h
+
 end sym
 
 section equiv


### PR DESCRIPTION
Proof by induction on the number of summands. finset.sym is used to sum over. It means we have access to the finset tooling to rewrite it, and it's one of the more direct ways of expressing it.

Co-authored-by: Junyan Xu <junyanxu.math@gmail.com>

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

- [ ] depends on: #16170 [multinomial defintions and basic lemma's]

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
