### PR TITLE
refactor(model_theory/syntax): use alias for fields of is_expansion_on

### DIFF
--- a/src/model_theory/language_map.lean
+++ b/src/model_theory/language_map.lean
@@ -174,22 +174,14 @@ protected structure injective : Prop :=
 /-- A language homomorphism is an expansion on a structure if it commutes with the interpretation of
 all symbols on that structure. -/
 class is_expansion_on (M : Type*) [L.Structure M] [L'.Structure M] : Prop :=
-(map_on_function : ∀ {n} (f : L.functions n) (x : fin n → M),
+(map_on_function [] : ∀ {n} (f : L.functions n) (x : fin n → M),
   fun_map (ϕ.on_function f) x = fun_map f x)
-(map_on_relation : ∀ {n} (R : L.relations n) (x : fin n → M),
+(map_on_relation [] : ∀ {n} (R : L.relations n) (x : fin n → M),
   rel_map (ϕ.on_relation R) x = rel_map R x)
 
-@[simp] lemma map_on_function {M : Type*}
-  [L.Structure M] [L'.Structure M] [ϕ.is_expansion_on M]
-  {n} (f : L.functions n) (x : fin n → M) :
-  fun_map (ϕ.on_function f) x = fun_map f x :=
-is_expansion_on.map_on_function f x
-
-@[simp] lemma map_on_relation {M : Type*}
-  [L.Structure M] [L'.Structure M] [ϕ.is_expansion_on M]
-  {n} (R : L.relations n) (x : fin n → M) :
-  rel_map (ϕ.on_relation R) x = rel_map R x :=
-is_expansion_on.map_on_relation R x
+alias is_expansion_on.map_on_function ← map_on_function
+alias is_expansion_on.map_on_relation ← map_on_relation
+attribute [simp] map_on_function map_on_relation
 
 instance id_is_expansion_on (M : Type*) [L.Structure M] : is_expansion_on (Lhom.id L) M :=
 ⟨λ _ _ _, rfl, λ _ _ _, rfl⟩


### PR DESCRIPTION

---

@awainverse you can do this with `alias` (relevant PR: #14018). Note that I had to use `[]` in the fields to make `\varphi` explicit.
