### PR TITLE
[Merged by Bors] - feat(tactic/qify) : `qify` tactic

### DIFF
--- a/src/tactic/qify.lean
+++ b/src/tactic/qify.lean
@@ -39,7 +39,8 @@ namespace qify
 The `qify` attribute is used by the `qify` tactic. It applies to lemmas that shift propositions
 from `nat` or `int` to `rat`.
 
-`qify` lemmas should have the form `∀ a₁ ... aₙ : ℕ, Pq (a₁ : ℚ) ... (aₙ : ℚ) ↔ Pn a₁ ... aₙ`.
+`qify` lemmas should have the form `∀ a₁ ... aₙ : ℕ, Pq (a₁ : ℚ) ... (aₙ : ℚ) ↔ Pn a₁ ... aₙ` or
+ `∀ a₁ ... aₙ : ℤ, Pq (a₁ : ℚ) ... (aₙ : ℚ) ↔ Pz a₁ ... aₙ`.
 For example, `rat.coe_nat_le_coe_nat_iff : ∀ (m n : ℕ), ↑m ≤ ↑n ↔ m ≤ n` is a `qify` lemma.
 -/
 @[user_attribute]

--- a/src/tactic/qify.lean
+++ b/src/tactic/qify.lean
@@ -146,22 +146,6 @@ replace_at (tactic.qify sl) locs l.include_goal >>= guardb
 
 end
 
-section tests
-
-example (a b c : ℕ) (h : a - b = c) (hab : b ≤ a) : a = c + b :=
-begin
-  qify [hab] at h ⊢, -- `zify` does the same thing here.
-  exact (sub_eq_iff_eq_add).1 h,
-end
-
-example (a b c : ℤ) (h : a / b = c) (hab : b ∣ a) (hb : b ≠ 0) : a = c * b :=
-begin
-  qify [hab] at h hb ⊢,
-  exact (div_eq_iff hb).1 h,
-end
-
-end tests
-
 add_tactic_doc
 { name := "qify",
   category := doc_category.attr,

--- a/src/tactic/qify.lean
+++ b/src/tactic/qify.lean
@@ -146,6 +146,22 @@ replace_at (tactic.qify sl) locs l.include_goal >>= guardb
 
 end
 
+section tests
+
+example (a b c : ℕ) (h : a - b = c) (hab : b ≤ a) : a = c + b :=
+begin
+  qify [hab] at h ⊢, -- `zify` does the same thing here.
+  exact (sub_eq_iff_eq_add).1 h,
+end
+
+example (a b c : ℤ) (h : a / b = c) (hab : b ∣ a) (hb : b ≠ 0) : a = c * b :=
+begin
+  qify [hab] at h hb ⊢,
+  exact (div_eq_iff hb).1 h,
+end
+
+end tests
+
 add_tactic_doc
 { name := "qify",
   category := doc_category.attr,

--- a/src/tactic/qify.lean
+++ b/src/tactic/qify.lean
@@ -10,7 +10,7 @@ import data.rat.cast
 /-!
 # A tactic to shift `ℕ` goals to `ℚ`
 
-Note that this file is followed by `zify`.
+Note that this file is following from `zify`.
 
 Division in `ℕ` is not always working fine (e.g. (5 : ℕ) / 2 = 2), so it's easier to work in `ℚ`,
 where division and subtraction are well behaved. `qify` can be used to cast goals and hypotheses

--- a/src/tactic/qify.lean
+++ b/src/tactic/qify.lean
@@ -12,10 +12,10 @@ import data.rat.cast
 
 Note that this file is followed by `zify`.
 
-Division in `ℕ` is not always working fine (e.g. (5 : ℕ) / 2 = 2), so that it's easier to work
-in `ℚ`, where division and subtraction is well behaved. `qify` can be used to cast goals and
-hypotheses about natural numbers to rational numbers. It makes use of `push_cast`, part of the
-`norm_cast` family, to simplify these goals.
+Division in `ℕ` is not always working fine (e.g. (5 : ℕ) / 2 = 2), so it's easier to work in `ℚ`,
+where division and subtraction are well behaved. `qify` can be used to cast goals and hypotheses
+about natural numbers to rational numbers. It makes use of `push_cast`, part of the `norm_cast`
+family, to simplify these goals.
 
 ## Implementation notes
 

--- a/src/tactic/qify.lean
+++ b/src/tactic/qify.lean
@@ -74,8 +74,8 @@ do sl ← qify_attr.get_cache,
 end qify
 
 /--
-`qify extra_lems e` is used to shift propositions in `e` from `ℕ` to `ℤ`.
-This is often useful since `ℤ` has well-behaved subtraction.
+`qify extra_lems e` is used to shift propositions in `e` from `ℕ` to `ℚ`.
+This is often useful since `ℚ` has well-behaved division and subtraction.
 
 The list of extra lemmas is used in the `push_cast` step.
 

--- a/src/tactic/qify.lean
+++ b/src/tactic/qify.lean
@@ -12,10 +12,10 @@ import data.rat.cast
 
 Note that this file is followed by `zify`.
 
-Division in `ℕ` is not always working fine (e.g. (5 : ℕ) / 2 = 2), so that it's easier to work in `ℚ`,
-where division and subtraction is well behaved. `qify` can be used to cast goals and hypotheses
-about natural numbers to rational numbers. It makes use of `push_cast`, part of the `norm_cast` family,
-to simplify these goals.
+Division in `ℕ` is not always working fine (e.g. (5 : ℕ) / 2 = 2), so that it's easier to work
+in `ℚ`, where division and subtraction is well behaved. `qify` can be used to cast goals and
+hypotheses about natural numbers to rational numbers. It makes use of `push_cast`, part of the
+`norm_cast` family, to simplify these goals.
 
 ## Implementation notes
 

--- a/src/tactic/qify.lean
+++ b/src/tactic/qify.lean
@@ -1,0 +1,154 @@
+/-
+Copyright (c) 2022 Jiale Miao. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Jiale Miao
+-/
+
+import tactic.norm_cast
+import data.rat.cast
+
+/-!
+# A tactic to shift `ℕ` goals to `ℚ`
+
+Note that this file is followed by `zify`.
+
+Division in `ℕ` is not always working fine (e.g. (5 : ℕ) / 2 = 2), so that it's easier to work in `ℚ`,
+where division and subtraction is well behaved. `qify` can be used to cast goals and hypotheses
+about natural numbers to rational numbers. It makes use of `push_cast`, part of the `norm_cast` family,
+to simplify these goals.
+
+## Implementation notes
+
+`qify` is extensible, using the attribute `@[qify]` to label lemmas used for moving propositions
+from `ℕ` to `ℚ`.
+`qify` lemmas should have the form `∀ a₁ ... aₙ : ℕ, Pq (a₁ : ℚ) ... (aₙ : ℚ) ↔ Pn a₁ ... aₙ`.
+For example, `rat.coe_nat_le_coe_nat_iff : ∀ (m n : ℕ), ↑m ≤ ↑n ↔ m ≤ n` is a `qify` lemma.
+
+`qify` is very nearly just `simp only with qify push_cast`. There are a few minor differences:
+* `qify` lemmas are used in the opposite order of the standard simp form.
+  E.g. we will rewrite with `rat.coe_nat_le_coe_nat_iff` from right to left.
+* `qify` should fail if no `qify` lemma applies (i.e. it was unable to shift any proposition to ℚ).
+  However, once this succeeds, it does not necessarily need to rewrite with any `push_cast` rules.
+-/
+
+open tactic
+
+namespace qify
+
+/--
+The `qify` attribute is used by the `qify` tactic. It applies to lemmas that shift propositions
+between `nat` and `rat`.
+
+`qify` lemmas should have the form `∀ a₁ ... aₙ : ℕ, Pq (a₁ : ℚ) ... (aₙ : ℚ) ↔ Pn a₁ ... aₙ`.
+For example, `rat.coe_nat_le_coe_nat_iff : ∀ (m n : ℕ), ↑m ≤ ↑n ↔ m ≤ n` is a `qify` lemma.
+-/
+@[user_attribute]
+meta def qify_attr : user_attribute simp_lemmas unit :=
+{ name := `qify,
+  descr := "Used to tag lemmas for use in the `qify` tactic",
+  cache_cfg :=
+    { mk_cache :=
+        λ ns, mmap (λ n, do c ← mk_const n, return (c, tt)) ns >>= simp_lemmas.mk.append_with_symm,
+      dependencies := [] } }
+
+/--
+Given an expression `e`, `lift_to_q e` looks for subterms of `e` that are propositions "about"
+natural numbers and change them to propositions about rational numbers.
+
+Returns an expression `e'` and a proof that `e = e'`.
+
+Includes `ge_iff_le` and `gt_iff_lt` in the simp set. These can't be tagged with `qify` as we
+want to use them in the "forward", not "backward", direction.
+-/
+meta def lift_to_q (e : expr) : tactic (expr × expr) :=
+do sl ← qify_attr.get_cache,
+   sl ← sl.add_simp `ge_iff_le, sl ← sl.add_simp `gt_iff_lt,
+   (e', prf, _) ← simplify sl [] e,
+   return (e', prf)
+
+@[qify] lemma rat.coe_nat_le_coe_nat_iff (a b : ℕ) : (a : ℚ) ≤ b ↔ a ≤ b := by simp
+@[qify] lemma rat.coe_nat_lt_coe_nat_iff (a b : ℕ) : (a : ℚ) < b ↔ a < b := by simp
+@[qify] lemma rat.coe_nat_eq_coe_nat_iff (a b : ℕ) : (a : ℚ) = b ↔ a = b := by simp
+@[qify] lemma rat.coe_nat_ne_coe_nat_iff (a b : ℕ) : (a : ℚ) ≠ b ↔ a ≠ b := by simp
+
+end qify
+
+/--
+`qify extra_lems e` is used to shift propositions in `e` from `ℕ` to `ℤ`.
+This is often useful since `ℤ` has well-behaved subtraction.
+
+The list of extra lemmas is used in the `push_cast` step.
+
+Returns an expression `e'` and a proof that `e = e'`.-/
+meta def tactic.qify (extra_lems : list simp_arg_type) : expr → tactic (expr × expr) := λ q,
+do (q1, p1) ← qify.lift_to_q q <|> fail "failed to find an applicable qify lemma",
+   (q2, p2) ← norm_cast.derive_push_cast extra_lems q1,
+   prod.mk q2 <$> mk_eq_trans p1 p2
+
+/--
+A variant of `tactic.qify` that takes `h`, a proof of a proposition about natural numbers,
+and returns a proof of the qified version of that propositon.
+-/
+meta def tactic.qify_proof (extra_lems : list simp_arg_type) (h : expr) : tactic expr :=
+do (_, pf) ← infer_type h >>= tactic.qify extra_lems,
+   mk_eq_mp pf h
+
+section
+
+setup_tactic_parser
+
+/--
+The `qify` tactic is used to shift propositions from `ℕ` to `ℚ`.
+This is often useful since `ℚ` has well-behaved division and subtraction.
+
+```lean
+example (a b c x y z : ℕ) (h : ¬ x*y*z < 0) : c < a + 3*b :=
+begin
+  qify,
+  qify at h,
+  /-
+  h : ¬↑x * ↑y * ↑z < 0
+  ⊢ ↑c < ↑a + 3 * ↑b
+  -/
+end
+```
+
+`qify` can be given extra lemmas to use in simplification. This is especially useful in the
+presence of nat subtraction and division: passing `≤` or `∣` arguments will allow `push_cast`
+to do more work.
+```
+example (a b c : ℕ) (h : a - b < c) (hab : b ≤ a) : false :=
+begin
+  qify [hab] at h,
+  /- h : ↑a - ↑b < ↑c -/
+end
+```
+
+```
+example (a b c : ℕ) (h : a / b = c) (hab : b ∣ a) : false :=
+begin
+  qify [hab] at h,
+  /- h : ↑a / ↑b = ↑c -/
+end
+```
+
+`qify` makes use of the `@[qify]` attribute to move propositions,
+and the `push_cast` tactic to simplify the `ℚ`-valued expressions.
+-/
+meta def tactic.interactive.qify (sl : parse simp_arg_list) (l : parse location) : tactic unit :=
+do locs ← l.get_locals,
+replace_at (tactic.qify sl) locs l.include_goal >>= guardb
+
+end
+
+add_tactic_doc
+{ name := "qify",
+  category := doc_category.attr,
+  decl_names := [`qify.qify_attr],
+  tags := ["coercions", "transport"] }
+
+add_tactic_doc
+{ name := "qify",
+  category := doc_category.tactic,
+  decl_names := [`tactic.interactive.qify],
+  tags := ["coercions", "transport"] }

--- a/test/qify.lean
+++ b/test/qify.lean
@@ -1,0 +1,13 @@
+import tactic.qify
+
+example (a b c : ℕ) (h : a - b = c) (hab : b ≤ a) : a = c + b :=
+begin
+  qify [hab] at h ⊢, -- `zify` does the same thing here.
+  exact sub_eq_iff_eq_add.1 h,
+end
+
+example (a b c : ℤ) (h : a / b = c) (hab : b ∣ a) (hb : b ≠ 0) : a = c * b :=
+begin
+  qify [hab] at h hb ⊢,
+  exact (div_eq_iff hb).1 h,
+end

--- a/test/qify.lean
+++ b/test/qify.lean
@@ -1,5 +1,15 @@
 import tactic.qify
 
+example (a b : ℕ) : (a : ℚ) ≤ b ↔ a ≤ b := by qify ; refl
+example (a b : ℕ) : (a : ℚ) < b ↔ a < b := by qify ; refl
+example (a b : ℕ) : (a : ℚ) = b ↔ a = b := by qify ; refl
+example (a b : ℕ) : (a : ℚ) ≠ b ↔ a ≠ b := by qify ; refl
+
+@[qify] lemma rat.coe_int_le_coe_int_iff (a b : ℤ) : (a : ℚ) ≤ b ↔ a ≤ b := by simp
+@[qify] lemma rat.coe_int_lt_coe_int_iff (a b : ℤ) : (a : ℚ) < b ↔ a < b := by simp
+@[qify] lemma rat.coe_int_eq_coe_int_iff (a b : ℤ) : (a : ℚ) = b ↔ a = b := by simp
+@[qify] lemma rat.coe_int_ne_coe_int_iff (a b : ℤ) : (a : ℚ) ≠ b ↔ a ≠ b := by simp
+
 example (a b c : ℕ) (h : a - b = c) (hab : b ≤ a) : a = c + b :=
 begin
   qify [hab] at h ⊢, -- `zify` does the same thing here.

--- a/test/qify.lean
+++ b/test/qify.lean
@@ -5,10 +5,10 @@ example (a b : ℕ) : (a : ℚ) < b ↔ a < b := by qify ; refl
 example (a b : ℕ) : (a : ℚ) = b ↔ a = b := by qify ; refl
 example (a b : ℕ) : (a : ℚ) ≠ b ↔ a ≠ b := by qify ; refl
 
-@[qify] lemma rat.coe_int_le_coe_int_iff (a b : ℤ) : (a : ℚ) ≤ b ↔ a ≤ b := by simp
-@[qify] lemma rat.coe_int_lt_coe_int_iff (a b : ℤ) : (a : ℚ) < b ↔ a < b := by simp
-@[qify] lemma rat.coe_int_eq_coe_int_iff (a b : ℤ) : (a : ℚ) = b ↔ a = b := by simp
-@[qify] lemma rat.coe_int_ne_coe_int_iff (a b : ℤ) : (a : ℚ) ≠ b ↔ a ≠ b := by simp
+example (a b : ℤ) : (a : ℚ) ≤ b ↔ a ≤ b := by qify ; refl
+example (a b : ℤ) : (a : ℚ) < b ↔ a < b := by qify ; refl
+example (a b : ℤ) : (a : ℚ) = b ↔ a = b := by qify ; refl
+example (a b : ℤ) : (a : ℚ) ≠ b ↔ a ≠ b := by qify ; refl
 
 example (a b c : ℕ) (h : a - b = c) (hab : b ≤ a) : a = c + b :=
 begin


### PR DESCRIPTION
This file mainly introduces `qify` which casts goals or hypotheses about natural numbers or integers to the ones about rational numbers.

Note that this file is following from `zify`.

This is motivated by thinking about division in natural numbers or integers. Division in natural numbers or integers is not always working fine (e.g. (5 : ℕ) / 2 = 2), so it's easier to work in `ℚ`, where division and subtraction are well behaved.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
