### PR TITLE
[Merged by Bors] - refactor(linear_algebra/affine_space/finite_dimensional): change three lemmas to instances

### DIFF
--- a/src/linear_algebra/affine_space/finite_dimensional.lean
+++ b/src/linear_algebra/affine_space/finite_dimensional.lean
@@ -266,7 +266,7 @@ begin
 end
 
 /-- The `vector_span` of adding a point to a finite-dimensional subspace is finite-dimensional. -/
-lemma finite_dimensional_vector_span_insert (s : affine_subspace k P)
+instance finite_dimensional_vector_span_insert (s : affine_subspace k P)
   [finite_dimensional k s.direction] (p : P) :
   finite_dimensional k (vector_span k (insert p (s : set P))) :=
 begin
@@ -282,7 +282,7 @@ end
 
 /-- The direction of the affine span of adding a point to a finite-dimensional subspace is
 finite-dimensional. -/
-lemma finite_dimensional_direction_affine_span_insert (s : affine_subspace k P)
+instance finite_dimensional_direction_affine_span_insert (s : affine_subspace k P)
   [finite_dimensional k s.direction] (p : P) :
   finite_dimensional k (affine_span k (insert p (s : set P))).direction :=
 (direction_affine_span k (insert p (s : set P))).symm ▸ finite_dimensional_vector_span_insert s p
@@ -291,7 +291,7 @@ variables (k)
 
 /-- The `vector_span` of adding a point to a set with a finite-dimensional `vector_span` is
 finite-dimensional. -/
-lemma finite_dimensional_vector_span_insert_set (s : set P)
+instance finite_dimensional_vector_span_insert_set (s : set P)
   [finite_dimensional k (vector_span k s)] (p : P) :
   finite_dimensional k (vector_span k (insert p s)) :=
 begin


### PR DESCRIPTION
I realised after the PR with these lemmas was approved that they are
actually suitable to be instances (don't depend on any hypotheses that
typeclass inference can't deduce), and making them such sometimes
allows removing explicit `haveI` uses because typeclass inference can
then find them automatically.



---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
