### PR TITLE
[Merged by Bors] - feat(analysis/normed/group/add_torsor): `normed_add_torsor` instance for `affine_subspace`

### DIFF
--- a/src/analysis/normed/group/add_torsor.lean
+++ b/src/analysis/normed/group/add_torsor.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Joseph Myers, Yury Kudryashov
 -/
 import analysis.normed.group.basic
+import linear_algebra.affine_space.affine_subspace
 import linear_algebra.affine_space.midpoint
 
 /-!
@@ -36,6 +37,13 @@ variables {α V P W Q : Type*} [seminormed_add_comm_group V] [pseudo_metric_spac
 @[priority 100]
 instance seminormed_add_comm_group.to_normed_add_torsor : normed_add_torsor V V :=
 { dist_eq_norm' := dist_eq_norm }
+
+/-- A nonempty affine subspace of a `normed_add_torsor` is itself a `normed_add_torsor`. -/
+@[nolint fails_quickly] -- Because of the add_torsor.nonempty instance.
+instance affine_subspace.to_normed_add_torsor {R : Type*} [ring R] [module R V]
+  (s : affine_subspace R P) [nonempty s] : normed_add_torsor s.direction s :=
+{ dist_eq_norm' := λ x y, normed_add_torsor.dist_eq_norm' ↑x ↑y,
+  ..affine_subspace.to_add_torsor s }
 
 include V
 


### PR DESCRIPTION
Add an instance that a nonempty affine subspace of a
`normed_add_torsor` is itself a `normed_add_torsor` (building on the
existing instance that says such a subspace of an `add_torsor` is
itself an `add_torsor`).

Note that this instance uses `@[nolint fails_quickly]`, because of a
typeclass loop with the `add_torsor.nonempty` instance.  I don't know
the right way to avoid that typeclass loop, but I don't think it's
meaningfully a new issue, since exactly the same nolint appears in
`nolints.txt` for `affine_subspace.to_add_torsor`.



---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
