### PR TITLE
[Merged by Bors] - feat(order/max): equivalence of no_top_order and no_max_order for linear orders

### DIFF
--- a/src/order/max.lean
+++ b/src/order/max.lean
@@ -79,6 +79,22 @@ instance no_min_order.to_no_bot_order (α : Type*) [preorder α] [no_min_order �
 instance no_max_order.to_no_top_order (α : Type*) [preorder α] [no_max_order α] : no_top_order α :=
 ⟨λ a, (exists_gt a).imp $ λ _, not_le_of_lt⟩
 
+lemma no_bot_order.to_no_min_order (α : Type*) [linear_order α] [no_bot_order α] : no_min_order α :=
+{ exists_lt := by { convert λ a : α, exists_not_ge a, simp_rw not_le, } }
+
+lemma no_top_order.to_no_max_order (α : Type*) [linear_order α] [no_top_order α] : no_max_order α :=
+{ exists_gt := by { convert λ a : α, exists_not_le a, simp_rw not_le, } }
+
+lemma no_bot_order_iff_no_min_order (α : Type*) [linear_order α] :
+  no_bot_order α ↔ no_min_order α :=
+⟨λ h, by { haveI := h, exact no_bot_order.to_no_min_order α },
+  λ h, by { haveI := h, exact no_min_order.to_no_bot_order α }⟩
+
+lemma no_top_order_iff_no_max_order (α : Type*) [linear_order α] :
+  no_top_order α ↔ no_max_order α :=
+⟨λ h, by { haveI := h, exact no_top_order.to_no_max_order α },
+  λ h, by { haveI := h, exact no_max_order.to_no_top_order α }⟩
+
 theorem no_min_order.not_acc [has_lt α] [no_min_order α] (a : α) : ¬ acc (<) a :=
 λ h, acc.rec_on h $ λ x _, (exists_lt x).rec_on
 


### PR DESCRIPTION

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

@YaelDillies I requested your review because I am surprised I did not find those results in the library, and you know that corner of mathlib better than anyone: are they already there?

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
