### PR TITLE
[Merged by Bors] - feat(analysis/ODE/picard_lindelof): Add corollaries to ODE solution existence theorem

### DIFF
--- a/docs/undergrad.yaml
+++ b/docs/undergrad.yaml
@@ -463,7 +463,7 @@ Multivariable calculus:
     inverse function theorem: 'has_strict_deriv_at.to_local_inverse'
     implicit function theorem: 'implicit_function_data.implicit_function'
   Differential equations:
-    Cauchy-Lipschitz Theorem: 'exists_forall_deriv_within_Icc_eq_of_lipschitz_of_continuous'
+    Cauchy-Lipschitz Theorem: 'exists_forall_deriv_within_Icc_eq_of_is_picard_lindelof'
     maximal solutions: ''
     Grönwall lemma: 'norm_le_gronwall_bound_of_norm_deriv_right_le'
     exit theorem of a compact subspace: ''

--- a/src/analysis/ODE/picard_lindelof.lean
+++ b/src/analysis/ODE/picard_lindelof.lean
@@ -57,7 +57,7 @@ structure picard_lindelof (E : Type*) [normed_add_comm_group E] [normed_space �
 /-- `Prop` structure holding the hypotheses of the Picard-Lindelöf theorem.
 
 The similarly named `picard_lindelof` structure is part of the internal API for convenience, so as
-not to constantly invoke choice. -/
+not to constantly invoke choice, but is not intended for public use. -/
 structure is_picard_lindelof
   {E : Type*} [normed_add_comm_group E] (v : ℝ → E → E) (t_min t₀ t_max : ℝ) (x₀ : E)
   (L : ℝ≥0) (R C : ℝ) : Prop :=
@@ -373,8 +373,7 @@ begin
     { exact zero_lt_one },
     { exact div_pos (half_pos hr) (lt_of_le_of_ne hC' (ne.symm h)) } },
   refine ⟨ε, hε0, L, r / 2, C, _⟩,
-  exact {
-    ht₀ := by {rw ←real.closed_ball_eq_Icc, exact mem_closed_ball_self hε0.le},
+  exact { ht₀ := by {rw ←real.closed_ball_eq_Icc, exact mem_closed_ball_self hε0.le},
     hR := (half_pos hr).le,
     lipschitz := λ t ht, hlip.mono (subset_inter_iff.mp
       (subset_trans (closed_ball_subset_ball (half_lt_self hr)) hball)).2,
@@ -385,8 +384,7 @@ begin
       split_ifs,
       { rwa ← h at hr' },
       { exact (mul_div_cancel' (r / 2) h).le }
-    end
-  }
+    end }
 end
 
 /-- A time-independent, locally continuously differentiable ODE admits a solution in some open

--- a/src/analysis/ODE/picard_lindelof.lean
+++ b/src/analysis/ODE/picard_lindelof.lean
@@ -406,6 +406,8 @@ begin
     (Icc_mem_nhds ht.1 ht.2)⟩,
 end
 
+/-- Refinement of `exists_forall_deriv_at_ball_eq_of_cont_diff_on_nhds` where the solution maps to
+within the specified neighbourhood `s` on which `v` is continuously differentiable. -/
 theorem ODE_solution_exists.at_ball_of_cont_diff_on_nhds_mem_set
   {s : set E} (hv : cont_diff_on ℝ 1 v s) (hs : s ∈ 𝓝 x₀) :
   ∃ (ε : ℝ) (hε : 0 < ε) (f : ℝ → E), f t₀ = x₀ ∧

--- a/src/analysis/ODE/picard_lindelof.lean
+++ b/src/analysis/ODE/picard_lindelof.lean
@@ -352,7 +352,7 @@ variables [proper_space E] {v : E → E} (t₀ : ℝ) (x₀ : E)
 
 /-- A time-independent, locally continuously differentiable ODE satisfies the hypotheses of the
   Picard-Lindelöf theorem. -/
-lemma is_picard_lindelof_of_time_indep_cont_diff_on_nhds
+lemma exists_is_picard_lindelof_const_of_cont_diff_on_nhds
   {s : set E} (hv : cont_diff_on ℝ 1 v s) (hs : s ∈ 𝓝 x₀) :
   ∃ (ε > (0 : ℝ)) L R C, is_picard_lindelof (λ t, v) (t₀ - ε) t₀ (t₀ + ε) x₀ L R C :=
 begin
@@ -392,12 +392,12 @@ end
 
 /-- A time-independent, locally continuously differentiable ODE admits a solution in some open
 interval. -/
-theorem exists_forall_deriv_at_ball_eq_of_cont_diff_on_nhds
+theorem exists_forall_deriv_at_Ioo_eq_of_cont_diff_on_nhds
   {s : set E} (hv : cont_diff_on ℝ 1 v s) (hs : s ∈ 𝓝 x₀) :
   ∃ (ε > (0 : ℝ)) (f : ℝ → E), f t₀ = x₀ ∧
     ∀ t ∈ Ioo (t₀ - ε) (t₀ + ε), f t ∈ s ∧ has_deriv_at f (v (f t)) t :=
 begin
-  obtain ⟨ε, hε, L, R, C, hpl⟩ := is_picard_lindelof_of_time_indep_cont_diff_on_nhds t₀ x₀ hv hs,
+  obtain ⟨ε, hε, L, R, C, hpl⟩ := exists_is_picard_lindelof_const_of_cont_diff_on_nhds t₀ x₀ hv hs,
   obtain ⟨f, hf1, hf2⟩ := exists_forall_deriv_within_Icc_eq_of_is_picard_lindelof x₀ hpl,
   have hf2' : ∀ t ∈ Ioo (t₀ - ε) (t₀ + ε), has_deriv_at f (v (f t)) t :=
     λ t ht, (hf2 t (Ioo_subset_Icc_self ht)).has_deriv_at (Icc_mem_nhds ht.1 ht.2),
@@ -419,8 +419,8 @@ begin
 end
 
 /-- A time-independent, continuously differentiable ODE admits a solution in some open interval. -/
-theorem exists_forall_deriv_at_ball_eq_of_cont_diff
+theorem exists_forall_deriv_at_Ioo_eq_of_cont_diff
   (hv : cont_diff ℝ 1 v) : ∃ (ε > (0 : ℝ)) (f : ℝ → E), f t₀ = x₀ ∧
     ∀ t ∈ Ioo (t₀ - ε) (t₀ + ε), has_deriv_at f (v (f t)) t :=
-let ⟨ε, hε, f, hf1, hf2⟩ := exists_forall_deriv_at_ball_eq_of_cont_diff_on_nhds t₀ x₀ hv.cont_diff_on
+let ⟨ε, hε, f, hf1, hf2⟩ := exists_forall_deriv_at_Ioo_eq_of_cont_diff_on_nhds t₀ x₀ hv.cont_diff_on
   (is_open.mem_nhds is_open_univ (mem_univ _)) in ⟨ε, hε, f, hf1, λ t ht, (hf2 t ht).2⟩

--- a/src/analysis/ODE/picard_lindelof.lean
+++ b/src/analysis/ODE/picard_lindelof.lean
@@ -356,14 +356,14 @@ variables [proper_space E] {v : E → E} (t₀ : ℝ) (x₀ : E)
 /-- A time-independent, locally continuously differentiable ODE satisfies the hypotheses of the
   Picard-Lindelöf theorem. -/
 lemma is_picard_lindelof_of_time_indep_cont_diff_on_nhds
-  {s : set E} (hv : cont_diff_on ℝ 1 v s) (hs : s ∈ nhds x₀) :
-  ∃ (ε : ℝ) (hε : 0 < ε) (L R C), is_picard_lindelof (λ t, v) (t₀ - ε) t₀ (t₀ + ε) x₀ L R C :=
+  {s : set E} (hv : cont_diff_on ℝ 1 v s) (hs : s ∈ 𝓝 x₀) :
+  ∃ (ε > (0 : ℝ)) (L R C), is_picard_lindelof (λ t, v) (t₀ - ε) t₀ (t₀ + ε) x₀ L R C :=
 begin
   -- extract Lipschitz constant
   obtain ⟨L, s', hs', hlip⟩ := cont_diff_at.exists_lipschitz_on_with
     ((hv.cont_diff_within_at (mem_of_mem_nhds hs)).cont_diff_at hs),
   -- radius of closed ball in which v is bounded
-  obtain ⟨r, hr : 0 < r, hball⟩ := metric.mem_nhds_iff.mp (inter_sets (nhds x₀) hs hs'),
+  obtain ⟨r, hr : 0 < r, hball⟩ := metric.mem_nhds_iff.mp (inter_sets (𝓝 x₀) hs hs'),
   have hr' := (half_pos hr).le,
   obtain ⟨C, hC⟩ := (is_compact_closed_ball x₀ (r / 2)).bdd_above_image -- uses proper_space E
     (hv.continuous_on.norm.mono (subset_inter_iff.mp
@@ -396,26 +396,19 @@ end
 /-- A time-independent, locally continuously differentiable ODE admits a solution in some open
 interval. -/
 theorem exists_forall_deriv_at_ball_eq_of_cont_diff_on_nhds
-  {s : set E} (hv : cont_diff_on ℝ 1 v s) (hs : s ∈ nhds x₀) :
+  {s : set E} (hv : cont_diff_on ℝ 1 v s) (hs : s ∈ 𝓝 x₀) :
   ∃ (ε : ℝ) (hε : 0 < ε) (f : ℝ → E), f t₀ = x₀ ∧
-    ∀ t ∈ ball t₀ ε, has_deriv_at f (v (f t)) t :=
+    ∀ t ∈ Ioo (t₀ - ε) (t₀ + ε), has_deriv_at f (v (f t)) t :=
 begin
   obtain ⟨ε, hε, L, R, C, hpl⟩ := is_picard_lindelof_of_time_indep_cont_diff_on_nhds t₀ x₀ hv hs,
   obtain ⟨f, hf1, hf2⟩ := exists_forall_deriv_within_Icc_eq_of_is_picard_lindelof x₀ hpl,
-  refine ⟨ε, hε, f, hf1, _⟩,
-  intros t ht,
-  refine (hf2 t _).has_deriv_at _,
-  { rw ←real.closed_ball_eq_Icc,
-    exact mem_of_mem_of_subset ht ball_subset_closed_ball },
-  { rw _root_.mem_nhds_iff,
-    use ball t₀ ε,
-    rw ←real.closed_ball_eq_Icc,
-    exact ⟨ball_subset_closed_ball, is_open_ball, ht⟩ }
+  exact ⟨ε, hε, f, hf1, λ t ht, (hf2 t (Ioo_subset_Icc_self ht)).has_deriv_at
+    (Icc_mem_nhds ht.1 ht.2)⟩,
 end
 
 /-- A time-independent, continuously differentiable ODE admits a solution in some open interval. -/
 theorem exists_forall_deriv_at_ball_eq_of_cont_diff
   (hv : cont_diff ℝ 1 v) : ∃ (ε : ℝ) (hε : 0 < ε) (f : ℝ → E), f t₀ = x₀ ∧
-    ∀ t ∈ ball t₀ ε, has_deriv_at f (v (f t)) t :=
+    ∀ t ∈ Ioo (t₀ - ε) (t₀ + ε), has_deriv_at f (v (f t)) t :=
 exists_forall_deriv_at_ball_eq_of_cont_diff_on_nhds t₀ x₀ hv.cont_diff_on
   (is_open.mem_nhds is_open_univ (mem_univ _))

--- a/src/analysis/ODE/picard_lindelof.lean
+++ b/src/analysis/ODE/picard_lindelof.lean
@@ -35,9 +35,14 @@ noncomputable theory
 
 variables {E : Type*} [normed_add_comm_group E] [normed_space ℝ E]
 
-/-- This structure holds arguments of the Picard-Lipschitz (Cauchy-Lipschitz) theorem. Unless you
-want to use one of the auxiliary lemmas, use
-`exists_forall_deriv_within_Icc_eq_of_lipschitz_of_continuous` instead of using this structure. -/
+/-- This structure holds arguments of the Picard-Lipschitz (Cauchy-Lipschitz) theorem. It is part of
+the internal API for convenience, so as not to constantly invoke choice. Unless you want to use one
+of the auxiliary lemmas, use `exists_forall_deriv_within_Icc_eq_of_lipschitz_of_continuous` instead
+of using this structure.
+
+The similarly named `is_picard_lindelof` is a bundled `Prop` holding the long hypotheses of the
+Picard-Lindelöf theorem as named arguments. It is used as part of the public API.
+-/
 structure picard_lindelof (E : Type*) [normed_add_comm_group E] [normed_space ℝ E] :=
 (to_fun : ℝ → E → E)
 (t_min t_max : ℝ)
@@ -49,7 +54,10 @@ structure picard_lindelof (E : Type*) [normed_add_comm_group E] [normed_space �
 (norm_le' : ∀ (t ∈ Icc t_min t_max) (x ∈ closed_ball x₀ R), ∥to_fun t x∥ ≤ C)
 (C_mul_le_R : (C : ℝ) * max (t_max - t₀) (t₀ - t_min) ≤ R)
 
-/-- Predicate for the hypotheses of the Picard-Lindelöf theorem -/
+/-- `Prop` structure holding the hypotheses of the Picard-Lindelöf theorem.
+
+The similarly named `picard_lindelof` structure is part of the internal API for convenience, so as
+not to constantly invoke choice. -/
 structure is_picard_lindelof
   {E : Type*} [normed_add_comm_group E] (v : ℝ → E → E) (t_min t₀ t_max : ℝ) (x₀ : E)
   (L : ℝ≥0) (R C : ℝ) : Prop :=
@@ -306,7 +314,8 @@ let ⟨N, K, hK⟩ := exists_contracting_iterate v in ⟨_, hK.is_fixed_pt_fixed
 
 end
 
-/-- Picard-Lindelöf (Cauchy-Lipschitz) theorem. -/
+/-- Picard-Lindelöf (Cauchy-Lipschitz) theorem. Use
+`exists_forall_deriv_within_Icc_eq_of_is_picard_lindelof` instead for the public API. -/
 lemma exists_solution :
   ∃ f : ℝ → E, f v.t₀ = v.x₀ ∧ ∀ t ∈ Icc v.t_min v.t_max,
     has_deriv_within_at f (v t (f t)) (Icc v.t_min v.t_max) t :=
@@ -322,7 +331,7 @@ end
 end picard_lindelof
 
 /-- Picard-Lindelöf (Cauchy-Lipschitz) theorem. -/
-lemma exists_forall_deriv_within_Icc_eq_of_lipschitz_of_continuous
+theorem exists_forall_deriv_within_Icc_eq_of_is_picard_lindelof
   [complete_space E]
   {v : ℝ → E → E} {t_min t₀ t_max : ℝ} (x₀ : E) {C R : ℝ} {L : ℝ≥0}
   (hpl : is_picard_lindelof v t_min t₀ t_max x₀ L R C) :
@@ -337,11 +346,12 @@ begin
       hpl.lipschitz, hpl.cont, hpl.norm_le, hpl.C_mul_le_R⟩
 end
 
+variables [proper_space E] {v : E → E} (t₀ : ℝ) (x₀ : E)
+
 /-- A time-independent, locally continuously differentiable ODE satisfies the hypotheses of the
   Picard-Lindelöf theorem. -/
-lemma time_indep_cont_diff_on_nhds_is_picard_lindelof
-  [proper_space E] (v : E → E) (x₀ : E) (s : set E) (hs : s ∈ nhds x₀)
-  (hv : cont_diff_on ℝ 1 v s) (t₀ : ℝ) :
+lemma is_picard_lindelof_of_time_indep_cont_diff_on_nhds
+  {s : set E} (hv : cont_diff_on ℝ 1 v s) (hs : s ∈ nhds x₀) :
   ∃ (ε : ℝ) (hε : 0 < ε) (L R C), is_picard_lindelof (λ t, v) (t₀ - ε) t₀ (t₀ + ε) x₀ L R C :=
 begin
   -- extract Lipschitz constant
@@ -382,14 +392,13 @@ end
 
 /-- A time-independent, locally continuously differentiable ODE admits a solution in some open
 interval. -/
-theorem ODE_solution_exists.at_ball_of_cont_diff_on_nhds
-  [proper_space E] (v : E → E) (x₀ : E) (s : set E) (hs : s ∈ nhds x₀)
-  (hv : cont_diff_on ℝ 1 v s) (t₀ : ℝ) :
+theorem exists_forall_deriv_at_ball_eq_of_cont_diff_on_nhds
+  {s : set E} (hv : cont_diff_on ℝ 1 v s) (hs : s ∈ nhds x₀) :
   ∃ (ε : ℝ) (hε : 0 < ε) (f : ℝ → E), f t₀ = x₀ ∧
     ∀ t ∈ metric.ball t₀ ε, has_deriv_at f (v (f t)) t :=
 begin
-  obtain ⟨ε, hε, L, R, C, hpl⟩ := time_indep_cont_diff_on_nhds_is_picard_lindelof v x₀ s hs hv t₀,
-  obtain ⟨f, hf1, hf2⟩ := exists_forall_deriv_within_Icc_eq_of_lipschitz_of_continuous x₀ hpl,
+  obtain ⟨ε, hε, L, R, C, hpl⟩ := is_picard_lindelof_of_time_indep_cont_diff_on_nhds t₀ x₀ hv hs,
+  obtain ⟨f, hf1, hf2⟩ := exists_forall_deriv_within_Icc_eq_of_is_picard_lindelof x₀ hpl,
   refine ⟨ε, hε, f, hf1, _⟩,
   intros t ht,
   refine (hf2 t _).has_deriv_at _,
@@ -402,9 +411,8 @@ begin
 end
 
 /-- A time-independent, continuously differentiable ODE admits a solution in some open interval. -/
-theorem ODE_solution_exists.at_ball_of_cont_diff
-  [proper_space E] (v : E → E) (hv : cont_diff ℝ 1 v) (t₀ : ℝ) (x₀ : E) :
-  ∃ (ε : ℝ) (hε : 0 < ε) (f : ℝ → E), f t₀ = x₀ ∧
+theorem exists_forall_deriv_at_ball_eq_of_cont_diff
+  (hv : cont_diff ℝ 1 v) : ∃ (ε : ℝ) (hε : 0 < ε) (f : ℝ → E), f t₀ = x₀ ∧
     ∀ t ∈ metric.ball t₀ ε, has_deriv_at f (v (f t)) t :=
-ODE_solution_exists.at_ball_of_cont_diff_on_nhds v x₀ univ
-  (is_open.mem_nhds is_open_univ (mem_univ _)) hv.cont_diff_on t₀
+exists_forall_deriv_at_ball_eq_of_cont_diff_on_nhds t₀ x₀ hv.cont_diff_on
+  (is_open.mem_nhds is_open_univ (mem_univ _))

--- a/src/analysis/ODE/picard_lindelof.lean
+++ b/src/analysis/ODE/picard_lindelof.lean
@@ -331,6 +331,10 @@ end
 
 end picard_lindelof
 
+lemma is_picard_lindelof.norm_le₀ {v : ℝ → E → E} {t_min t₀ t_max : ℝ} {x₀ : E} {C R : ℝ} {L : ℝ≥0}
+  (hpl : is_picard_lindelof v t_min t₀ t_max x₀ L R C) : ∥v t₀ x₀∥ ≤ C :=
+hpl.norm_le t₀ hpl.ht₀ x₀ $ mem_closed_ball_self hpl.hR
+
 /-- Picard-Lindelöf (Cauchy-Lipschitz) theorem. -/
 theorem exists_forall_deriv_within_Icc_eq_of_is_picard_lindelof
   [complete_space E] {v : ℝ → E → E} {t_min t₀ t_max : ℝ} (x₀ : E) {C R : ℝ} {L : ℝ≥0}
@@ -338,17 +342,10 @@ theorem exists_forall_deriv_within_Icc_eq_of_is_picard_lindelof
   ∃ f : ℝ → E, f t₀ = x₀ ∧ ∀ t ∈ Icc t_min t_max,
     has_deriv_within_at f (v t (f t)) (Icc t_min t_max) t :=
 begin
-  lift C to ℝ≥0 using ((norm_nonneg _).trans $ hpl.norm_le t₀ hpl.ht₀ x₀
-    (mem_closed_ball_self hpl.hR)),
+  lift C to ℝ≥0 using (norm_nonneg _).trans hpl.norm_le₀,
   lift t₀ to Icc t_min t_max using hpl.ht₀,
   exact picard_lindelof.exists_solution
-    ⟨v, t_min, t_max, t₀, x₀, C, ⟨R, hpl.hR⟩, L,
-      { ht₀ := t₀.property,
-        hR := hpl.hR,
-        lipschitz := hpl.lipschitz,
-        cont := hpl.cont,
-        norm_le := hpl.norm_le,
-        C_mul_le_R := hpl.C_mul_le_R }⟩
+    ⟨v, t_min, t_max, t₀, x₀, C, ⟨R, hpl.hR⟩, L, { ht₀ := t₀.property, ..hpl }⟩
 end
 
 variables [proper_space E] {v : E → E} (t₀ : ℝ) (x₀ : E)
@@ -357,7 +354,7 @@ variables [proper_space E] {v : E → E} (t₀ : ℝ) (x₀ : E)
   Picard-Lindelöf theorem. -/
 lemma is_picard_lindelof_of_time_indep_cont_diff_on_nhds
   {s : set E} (hv : cont_diff_on ℝ 1 v s) (hs : s ∈ 𝓝 x₀) :
-  ∃ (ε > (0 : ℝ)) (L R C), is_picard_lindelof (λ t, v) (t₀ - ε) t₀ (t₀ + ε) x₀ L R C :=
+  ∃ (ε > (0 : ℝ)) L R C, is_picard_lindelof (λ t, v) (t₀ - ε) t₀ (t₀ + ε) x₀ L R C :=
 begin
   -- extract Lipschitz constant
   obtain ⟨L, s', hs', hlip⟩ := cont_diff_at.exists_lipschitz_on_with
@@ -398,33 +395,22 @@ interval. -/
 theorem exists_forall_deriv_at_ball_eq_of_cont_diff_on_nhds
   {s : set E} (hv : cont_diff_on ℝ 1 v s) (hs : s ∈ 𝓝 x₀) :
   ∃ (ε > (0 : ℝ)) (f : ℝ → E), f t₀ = x₀ ∧
-    ∀ t ∈ Ioo (t₀ - ε) (t₀ + ε), has_deriv_at f (v (f t)) t :=
+    ∀ t ∈ Ioo (t₀ - ε) (t₀ + ε), f t ∈ s ∧ has_deriv_at f (v (f t)) t :=
 begin
   obtain ⟨ε, hε, L, R, C, hpl⟩ := is_picard_lindelof_of_time_indep_cont_diff_on_nhds t₀ x₀ hv hs,
   obtain ⟨f, hf1, hf2⟩ := exists_forall_deriv_within_Icc_eq_of_is_picard_lindelof x₀ hpl,
-  exact ⟨ε, hε, f, hf1, λ t ht, (hf2 t (Ioo_subset_Icc_self ht)).has_deriv_at
-    (Icc_mem_nhds ht.1 ht.2)⟩,
-end
-
-/-- Refinement of `exists_forall_deriv_at_ball_eq_of_cont_diff_on_nhds` where the solution maps to
-within the specified neighbourhood `s` on which `v` is continuously differentiable. -/
-theorem ODE_solution_exists.at_ball_of_cont_diff_on_nhds_mem_set
-  {s : set E} (hv : cont_diff_on ℝ 1 v s) (hs : s ∈ 𝓝 x₀) :
-  ∃ (ε > (0 : ℝ)) (f : ℝ → E), f t₀ = x₀ ∧
-    ∀ t ∈ Ioo (t₀ - ε) (t₀ + ε), f t ∈ s ∧ has_deriv_at f (v (f t)) t :=
-begin
-  obtain ⟨ε, hε, f, hf1, hf2⟩ := exists_forall_deriv_at_ball_eq_of_cont_diff_on_nhds t₀ x₀ hv hs,
+  have hf2' : ∀ t ∈ Ioo (t₀ - ε) (t₀ + ε), has_deriv_at f (v (f t)) t :=
+    λ t ht, (hf2 t (Ioo_subset_Icc_self ht)).has_deriv_at (Icc_mem_nhds ht.1 ht.2),
   have h : (f ⁻¹' s) ∈ 𝓝 t₀,
-  { apply continuous_at.preimage_mem_nhds
-    (hf2 t₀ (mem_Ioo.mpr ⟨sub_lt_self _ hε, lt_add_of_pos_right _ hε⟩)).continuous_at,
+  { have := (hf2' t₀ (mem_Ioo.mpr ⟨sub_lt_self _ hε, lt_add_of_pos_right _ hε⟩)),
+    apply continuous_at.preimage_mem_nhds this.continuous_at,
     rw hf1,
     exact hs },
   rw metric.mem_nhds_iff at h,
   obtain ⟨r, hr1, hr2⟩ := h,
   refine ⟨min r ε, lt_min hr1 hε, f, hf1, λ t ht,
-    ⟨_, hf2 t (mem_of_mem_of_subset ht (Ioo_subset_Ioo
-      (sub_le_sub_left (min_le_right _ _) _)
-      (add_le_add_left (min_le_right _ _) _)))⟩⟩,
+    ⟨_, hf2' t (mem_of_mem_of_subset ht (Ioo_subset_Ioo
+      (sub_le_sub_left (min_le_right _ _) _) (add_le_add_left (min_le_right _ _) _)))⟩⟩,
   rw ←set.mem_preimage,
   apply set.mem_of_mem_of_subset _ hr2,
   apply set.mem_of_mem_of_subset ht,
@@ -436,5 +422,5 @@ end
 theorem exists_forall_deriv_at_ball_eq_of_cont_diff
   (hv : cont_diff ℝ 1 v) : ∃ (ε > (0 : ℝ)) (f : ℝ → E), f t₀ = x₀ ∧
     ∀ t ∈ Ioo (t₀ - ε) (t₀ + ε), has_deriv_at f (v (f t)) t :=
-exists_forall_deriv_at_ball_eq_of_cont_diff_on_nhds t₀ x₀ hv.cont_diff_on
-  (is_open.mem_nhds is_open_univ (mem_univ _))
+let ⟨ε, hε, f, hf1, hf2⟩ := exists_forall_deriv_at_ball_eq_of_cont_diff_on_nhds t₀ x₀ hv.cont_diff_on
+  (is_open.mem_nhds is_open_univ (mem_univ _)) in ⟨ε, hε, f, hf1, λ t ht, (hf2 t ht).2⟩

--- a/src/analysis/ODE/picard_lindelof.lean
+++ b/src/analysis/ODE/picard_lindelof.lean
@@ -385,23 +385,22 @@ lemma time_indep_cont_diff_on_nhds_is_picard_lindelof
   (hv : cont_diff_on ℝ 1 v s) (t₀ : ℝ) :
   ∃ (ε : ℝ) (hε : 0 < ε), is_picard_lindelof (λ t, v) (t₀ - ε) t₀ (t₀ + ε) x₀ :=
 begin
-  have h1 := (hv.cont_diff_within_at (mem_of_mem_nhds hs)).cont_diff_at hs,
-  obtain ⟨L, s', hs', hlip⟩ := cont_diff_at.exists_lipschitz_on_with h1,
-  have h2 := lipschitz_on_with.mono hlip (set.inter_subset_right s s'),
-  have h3 := inter_sets (nhds x₀) hs hs',
-  obtain ⟨r, hr : 0 < r, hball⟩ := metric.mem_nhds_iff.mp h3,
+  -- extract Lipschitz constant
+  obtain ⟨L, s', hs', hlip⟩ := cont_diff_at.exists_lipschitz_on_with
+    ((hv.cont_diff_within_at (mem_of_mem_nhds hs)).cont_diff_at hs),
+  -- radius of closed ball in which v is bounded
+  obtain ⟨r, hr : 0 < r, hball⟩ := metric.mem_nhds_iff.mp (inter_sets (nhds x₀) hs hs'),
   have hr' := (half_pos hr).le,
-  have h4 := (is_compact_closed_ball x₀ (r / 2)).bdd_above_image
-    (hv.continuous_on.norm.mono
-      (subset_inter_iff.mp
+  obtain ⟨C, hC⟩ := (is_compact_closed_ball x₀ (r / 2)).bdd_above_image -- uses proper_space E
+    (hv.continuous_on.norm.mono (subset_inter_iff.mp
         ((closed_ball_subset_ball (half_lt_self hr)).trans hball)).left),
-  obtain ⟨C, hC⟩ := h4,
   have hC' : 0 ≤ C,
   { apply (norm_nonneg (v x₀)).trans,
     apply hC,
     exact ⟨x₀, ⟨mem_closed_ball_self hr', rfl⟩⟩ },
   refine ⟨if C = 0 then 1 else (r / 2 / C), _, L, r / 2, C, (half_pos hr).le,
-    λ t ht, hlip.mono (set.subset_inter_iff.mp (subset_trans (metric.closed_ball_subset_ball (half_lt_self hr)) hball)).2,
+    λ t ht, hlip.mono (set.subset_inter_iff.mp
+      (subset_trans (metric.closed_ball_subset_ball (half_lt_self hr)) hball)).2,
     λ x hx, continuous_on_const, λ t ht x hx, hC ⟨x, hx, rfl⟩, _⟩,
   { split_ifs,
     { exact zero_lt_one },

--- a/src/analysis/ODE/picard_lindelof.lean
+++ b/src/analysis/ODE/picard_lindelof.lean
@@ -321,25 +321,6 @@ end
 
 end picard_lindelof
 
--- /-- Picard-Lindelöf (Cauchy-Lipschitz) theorem. -/
--- lemma exists_forall_deriv_within_Icc_eq_of_lipschitz_of_continuous
---   [complete_space E]
---   {v : ℝ → E → E} {t_min t₀ t_max : ℝ} (ht₀ : t₀ ∈ Icc t_min t_max)
---   (x₀ : E) {C R : ℝ} (hR : 0 ≤ R) {L : ℝ≥0}
---   (Hlip : ∀ t ∈ Icc t_min t_max, lipschitz_on_with L (v t) (closed_ball x₀ R))
---   (Hcont : ∀ x ∈ closed_ball x₀ R, continuous_on (λ t, v t x) (Icc t_min t_max))
---   (Hnorm : ∀ (t ∈ Icc t_min t_max) (x ∈ closed_ball x₀ R), ∥v t x∥ ≤ C)
---   (Hmul_le : C * max (t_max - t₀) (t₀ - t_min) ≤ R) :
---   ∃ f : ℝ → E, f t₀ = x₀ ∧ ∀ t ∈ Icc t_min t_max,
---     has_deriv_within_at f (v t (f t)) (Icc t_min t_max) t :=
--- begin
---   lift C to ℝ≥0 using ((norm_nonneg _).trans $ Hnorm t₀ ht₀ x₀ (mem_closed_ball_self hR)),
---   lift R to ℝ≥0 using hR,
---   lift t₀ to Icc t_min t_max using ht₀,
---   exact picard_lindelof.exists_solution
---     ⟨v, t_min, t_max, t₀, x₀, C, R, L, Hlip, Hcont, Hnorm, Hmul_le⟩
--- end
-
 /-- Picard-Lindelöf (Cauchy-Lipschitz) theorem. -/
 lemma exists_forall_deriv_within_Icc_eq_of_lipschitz_of_continuous
   [complete_space E]
@@ -355,55 +336,6 @@ begin
     ⟨v, t_min, t_max, t₀, x₀, C, ⟨R, hpl.hR⟩, L,
       hpl.lipschitz, hpl.cont, hpl.norm_le, hpl.C_mul_le_R⟩
 end
-
--- /-- Predicate for the hypotheses of the Picard-Lindelöf theorem -/
--- @[reducible] def is_picard_lindelof
---   {E : Type*} [normed_add_comm_group E] (v : ℝ → E → E) (t_min t₀ t_max : ℝ) (x₀ : E) : Prop :=
--- ∃ (L : ℝ≥0) (R C : ℝ) (hR : 0 ≤ R),
--- (∀ (t : ℝ), t ∈ set.Icc t_min t_max → lipschitz_on_with L (v t) (metric.closed_ball x₀ R)) ∧
--- (∀ (x : E), x ∈ metric.closed_ball x₀ R → continuous_on (λ (t : ℝ), v t x) (set.Icc t_min t_max)) ∧
--- (∀ (t : ℝ), t ∈ set.Icc t_min t_max → ∀ (x : E), x ∈ metric.closed_ball x₀ R → ∥v t x∥ ≤ C) ∧
--- (C * linear_order.max (t_max - t₀) (t₀ - t_min) ≤ R)
-
--- /-- Picard-Lindelöf theorem where the hypothesis is a predicate -/
--- lemma ODE_solution_exists
---   [complete_space E] (v : ℝ → E → E) (t_min t₀ t_max : ℝ) (ht₀ : t₀ ∈ set.Icc t_min t_max) (x₀ : E)
---   (hpl : ∃ L R C, is_picard_lindelof v t_min t₀ t_max x₀ L R C) :
---   ∃ (f : ℝ → E), f t₀ = x₀ ∧ ∀ (t : ℝ), t ∈ set.Icc t_min t_max →
---     has_deriv_within_at f (v t (f t)) (set.Icc t_min t_max) t :=
--- let ⟨L, R, C, h1, h2, h3, h4⟩ := hpl in
---   exists_forall_deriv_within_Icc_eq_of_lipschitz_of_continuous ht₀ x₀ hR h1 h2 h3 h4
-
--- /-- Solution exists on a subset of a closed interval. -/
--- lemma ODE_solution_exists.within_at_set
---   [complete_space E] (v : ℝ → E → E) (t_min t₀ t_max : ℝ) (ht₀ : t₀ ∈ set.Icc t_min t_max) (x₀ : E)
---   {s : set ℝ} (hs : s ⊆ set.Icc t_min t_max)
---   (hpl : is_picard_lindelof v t_min t₀ t_max x₀) :
---   ∃ (f : ℝ → E), f t₀ = x₀ ∧ ∀ (t : ℝ), t ∈ s → has_deriv_within_at f (v t (f t)) s t :=
--- let ⟨f, h2, h3⟩ := ODE_solution_exists v t_min t₀ t_max ht₀ x₀ hpl in
---   ⟨f, h2, λ t ht, (h3 t (set.mem_of_subset_of_mem hs ht)).mono hs⟩
-
--- /-- Solution exists on an open subset of some closed interval. -/
--- lemma ODE_solution_exists.at_open_set
---   [complete_space E] (v : ℝ → E → E) (t_min t₀ t_max : ℝ) (ht₀ : t₀ ∈ set.Icc t_min t_max) (x₀ : E)
---   {s : set ℝ} (hs₁ : s ⊆ set.Icc t_min t_max) (hs₂ : is_open s)
---   (hpl : is_picard_lindelof v t_min t₀ t_max x₀) :
---   ∃ (f : ℝ → E), f t₀ = x₀ ∧ ∀ (t : ℝ), t ∈ s → has_deriv_at f (v t (f t)) t :=
--- let ⟨f, h1, h2⟩ := ODE_solution_exists.within_at_set v t_min t₀ t_max ht₀ x₀ hs₁ hpl in
---   ⟨f, h1, λ t ht, (h2 t ht).has_deriv_at (hs₂.mem_nhds_iff.mpr ht)⟩
-
--- /-- Solution exists on an open interval. -/
--- lemma ODE_solution_exists.at_ball
---   [complete_space E] (v : ℝ → E → E) (t₀ ε : ℝ) (hε : 0 < ε) (x₀ : E)
---   (hpl : is_picard_lindelof v (t₀ - ε) t₀ (t₀ + ε) x₀) :
---   ∃ (f : ℝ → E), f t₀ = x₀ ∧ ∀ (t : ℝ), t ∈ metric.ball t₀ ε → has_deriv_at f (v t (f t)) t :=
--- begin
---   refine ODE_solution_exists.at_open_set v (t₀ - ε) t₀ (t₀ + ε) _ x₀ _ metric.is_open_ball hpl,
---   { rw ←real.closed_ball_eq_Icc,
---     exact metric.mem_closed_ball_self hε.le },
---   { rw real.ball_eq_Ioo,
---     exact set.Ioo_subset_Icc_self }
--- end
 
 /-- A time-independent, locally continuously differentiable ODE satisfies the hypotheses of the
   Picard-Lindelöf theorem. -/
@@ -447,13 +379,6 @@ begin
     end
   }
 end
-
--- /-- A time-independent, continuously differentiable ODE satisfies the hypotheses of the
---   Picard-Lindelöf theorem. -/
--- lemma time_indep_cont_diff_is_picard_lindelof
---   [proper_space E] (v : E → E) (hv : cont_diff ℝ 1 v) (t₀ : ℝ) (x₀ : E) :
---   ∃ (ε : ℝ) (hε : 0 < ε), is_picard_lindelof (λ t, v) (t₀ - ε) t₀ (t₀ + ε) x₀ :=
--- time_indep_cont_diff_on_nhds_is_picard_lindelof v x₀ set.univ univ_mem hv.cont_diff_on t₀
 
 /-- A time-independent, locally continuously differentiable ODE admits a solution in some open
 interval. -/

--- a/src/analysis/ODE/picard_lindelof.lean
+++ b/src/analysis/ODE/picard_lindelof.lean
@@ -336,7 +336,8 @@ end
 
 end picard_lindelof
 
-lemma is_picard_lindelof.norm_le₀ {v : ℝ → E → E} {t_min t₀ t_max : ℝ} {x₀ : E} {C R : ℝ} {L : ℝ≥0}
+lemma is_picard_lindelof.norm_le₀ {E : Type*} [normed_add_comm_group E]
+  {v : ℝ → E → E} {t_min t₀ t_max : ℝ} {x₀ : E} {C R : ℝ} {L : ℝ≥0}
   (hpl : is_picard_lindelof v t_min t₀ t_max x₀ L R C) : ∥v t₀ x₀∥ ≤ C :=
 hpl.norm_le t₀ hpl.ht₀ x₀ $ mem_closed_ball_self hpl.hR
 

--- a/src/analysis/ODE/picard_lindelof.lean
+++ b/src/analysis/ODE/picard_lindelof.lean
@@ -397,7 +397,7 @@ end
 interval. -/
 theorem exists_forall_deriv_at_ball_eq_of_cont_diff_on_nhds
   {s : set E} (hv : cont_diff_on ℝ 1 v s) (hs : s ∈ 𝓝 x₀) :
-  ∃ (ε : ℝ) (hε : 0 < ε) (f : ℝ → E), f t₀ = x₀ ∧
+  ∃ (ε > (0 : ℝ)) (f : ℝ → E), f t₀ = x₀ ∧
     ∀ t ∈ Ioo (t₀ - ε) (t₀ + ε), has_deriv_at f (v (f t)) t :=
 begin
   obtain ⟨ε, hε, L, R, C, hpl⟩ := is_picard_lindelof_of_time_indep_cont_diff_on_nhds t₀ x₀ hv hs,
@@ -408,7 +408,7 @@ end
 
 /-- A time-independent, continuously differentiable ODE admits a solution in some open interval. -/
 theorem exists_forall_deriv_at_ball_eq_of_cont_diff
-  (hv : cont_diff ℝ 1 v) : ∃ (ε : ℝ) (hε : 0 < ε) (f : ℝ → E), f t₀ = x₀ ∧
+  (hv : cont_diff ℝ 1 v) : ∃ (ε > (0 : ℝ)) (f : ℝ → E), f t₀ = x₀ ∧
     ∀ t ∈ Ioo (t₀ - ε) (t₀ + ε), has_deriv_at f (v (f t)) t :=
 exists_forall_deriv_at_ball_eq_of_cont_diff_on_nhds t₀ x₀ hv.cont_diff_on
   (is_open.mem_nhds is_open_univ (mem_univ _))

--- a/src/analysis/ODE/picard_lindelof.lean
+++ b/src/analysis/ODE/picard_lindelof.lean
@@ -406,6 +406,30 @@ begin
     (Icc_mem_nhds ht.1 ht.2)⟩,
 end
 
+theorem ODE_solution_exists.at_ball_of_cont_diff_on_nhds_mem_set
+  {s : set E} (hv : cont_diff_on ℝ 1 v s) (hs : s ∈ 𝓝 x₀) :
+  ∃ (ε : ℝ) (hε : 0 < ε) (f : ℝ → E), f t₀ = x₀ ∧
+    ∀ t ∈ Ioo (t₀ - ε) (t₀ + ε), f t ∈ s ∧ has_deriv_at f (v (f t)) t :=
+begin
+  obtain ⟨ε, hε, f, hf1, hf2⟩ := exists_forall_deriv_at_ball_eq_of_cont_diff_on_nhds t₀ x₀ hv hs,
+  have h : (f ⁻¹' s) ∈ 𝓝 t₀,
+  { apply continuous_at.preimage_mem_nhds
+    (hf2 t₀ (mem_Ioo.mpr ⟨sub_lt_self _ hε, lt_add_of_pos_right _ hε⟩)).continuous_at,
+    rw hf1,
+    exact hs },
+  rw metric.mem_nhds_iff at h,
+  obtain ⟨r, hr1, hr2⟩ := h,
+  refine ⟨min r ε, lt_min hr1 hε, f, hf1, λ t ht,
+    ⟨_, hf2 t (mem_of_mem_of_subset ht (Ioo_subset_Ioo
+      (sub_le_sub_left (min_le_right _ _) _)
+      (add_le_add_left (min_le_right _ _) _)))⟩⟩,
+  rw ←set.mem_preimage,
+  apply set.mem_of_mem_of_subset _ hr2,
+  apply set.mem_of_mem_of_subset ht,
+  rw ←real.ball_eq_Ioo,
+  exact (metric.ball_subset_ball (min_le_left _ _))
+end
+
 /-- A time-independent, continuously differentiable ODE admits a solution in some open interval. -/
 theorem exists_forall_deriv_at_ball_eq_of_cont_diff
   (hv : cont_diff ℝ 1 v) : ∃ (ε > (0 : ℝ)) (f : ℝ → E), f t₀ = x₀ ∧

--- a/src/analysis/ODE/picard_lindelof.lean
+++ b/src/analysis/ODE/picard_lindelof.lean
@@ -410,7 +410,7 @@ end
 within the specified neighbourhood `s` on which `v` is continuously differentiable. -/
 theorem ODE_solution_exists.at_ball_of_cont_diff_on_nhds_mem_set
   {s : set E} (hv : cont_diff_on ℝ 1 v s) (hs : s ∈ 𝓝 x₀) :
-  ∃ (ε : ℝ) (hε : 0 < ε) (f : ℝ → E), f t₀ = x₀ ∧
+  ∃ (ε > (0 : ℝ)) (f : ℝ → E), f t₀ = x₀ ∧
     ∀ t ∈ Ioo (t₀ - ε) (t₀ + ε), f t ∈ s ∧ has_deriv_at f (v (f t)) t :=
 begin
   obtain ⟨ε, hε, f, hf1, hf2⟩ := exists_forall_deriv_at_ball_eq_of_cont_diff_on_nhds t₀ x₀ hv hs,

--- a/src/analysis/ODE/picard_lindelof.lean
+++ b/src/analysis/ODE/picard_lindelof.lean
@@ -11,13 +11,18 @@ import topology.metric_space.contracting
 
 In this file we prove that an ordinary differential equation $\dot x=v(t, x)$ such that $v$ is
 Lipschitz continuous in $x$ and continuous in $t$ has a local solution, see
-`exists_forall_deriv_within_Icc_eq_of_lipschitz_of_continuous`.
+`exists_forall_deriv_within_Icc_eq_of_is_picard_lindelof`.
+
+As a corollary, we prove that a time-independent locally continuously differentiable ODE has a
+local solution.
 
 ## Implementation notes
 
 In order to split the proof into small lemmas, we introduce a structure `picard_lindelof` that holds
 all assumptions of the main theorem. This structure and lemmas in the `picard_lindelof` namespace
-should be treated as private implementation details.
+should be treated as private implementation details. This is not to be confused with the `Prop`-
+valued structure `is_picard_lindelof`, which holds the long hypotheses of the Picard-Lindelöf
+theorem for actual use as part of the public API.
 
 We only prove existence of a solution in this file. For uniqueness see `ODE_solution_unique` and
 related theorems in `analysis.ODE.gronwall`.

--- a/src/analysis/ODE/picard_lindelof.lean
+++ b/src/analysis/ODE/picard_lindelof.lean
@@ -49,6 +49,17 @@ structure picard_lindelof (E : Type*) [normed_add_comm_group E] [normed_space �
 (norm_le' : ∀ (t ∈ Icc t_min t_max) (x ∈ closed_ball x₀ R), ∥to_fun t x∥ ≤ C)
 (C_mul_le_R : (C : ℝ) * max (t_max - t₀) (t₀ - t_min) ≤ R)
 
+/-- Predicate for the hypotheses of the Picard-Lindelöf theorem -/
+structure is_picard_lindelof
+  {E : Type*} [normed_add_comm_group E] (v : ℝ → E → E) (t_min t₀ t_max : ℝ) (x₀ : E)
+  (L : ℝ≥0) (R C : ℝ) : Prop :=
+(ht₀ : t₀ ∈ Icc t_min t_max)
+(hR : 0 ≤ R)
+(lipschitz : ∀ t ∈ set.Icc t_min t_max, lipschitz_on_with L (v t) (metric.closed_ball x₀ R))
+(cont : ∀ x ∈ metric.closed_ball x₀ R, continuous_on (λ (t : ℝ), v t x) (set.Icc t_min t_max))
+(norm_le : ∀ (t ∈ set.Icc t_min t_max) (x ∈ metric.closed_ball x₀ R), ∥v t x∥ ≤ C)
+(C_mul_le_R : (C : ℝ) * linear_order.max (t_max - t₀) (t₀ - t_min) ≤ R)
+
 namespace picard_lindelof
 
 variables (v : picard_lindelof E)
@@ -310,80 +321,96 @@ end
 
 end picard_lindelof
 
+-- /-- Picard-Lindelöf (Cauchy-Lipschitz) theorem. -/
+-- lemma exists_forall_deriv_within_Icc_eq_of_lipschitz_of_continuous
+--   [complete_space E]
+--   {v : ℝ → E → E} {t_min t₀ t_max : ℝ} (ht₀ : t₀ ∈ Icc t_min t_max)
+--   (x₀ : E) {C R : ℝ} (hR : 0 ≤ R) {L : ℝ≥0}
+--   (Hlip : ∀ t ∈ Icc t_min t_max, lipschitz_on_with L (v t) (closed_ball x₀ R))
+--   (Hcont : ∀ x ∈ closed_ball x₀ R, continuous_on (λ t, v t x) (Icc t_min t_max))
+--   (Hnorm : ∀ (t ∈ Icc t_min t_max) (x ∈ closed_ball x₀ R), ∥v t x∥ ≤ C)
+--   (Hmul_le : C * max (t_max - t₀) (t₀ - t_min) ≤ R) :
+--   ∃ f : ℝ → E, f t₀ = x₀ ∧ ∀ t ∈ Icc t_min t_max,
+--     has_deriv_within_at f (v t (f t)) (Icc t_min t_max) t :=
+-- begin
+--   lift C to ℝ≥0 using ((norm_nonneg _).trans $ Hnorm t₀ ht₀ x₀ (mem_closed_ball_self hR)),
+--   lift R to ℝ≥0 using hR,
+--   lift t₀ to Icc t_min t_max using ht₀,
+--   exact picard_lindelof.exists_solution
+--     ⟨v, t_min, t_max, t₀, x₀, C, R, L, Hlip, Hcont, Hnorm, Hmul_le⟩
+-- end
+
 /-- Picard-Lindelöf (Cauchy-Lipschitz) theorem. -/
 lemma exists_forall_deriv_within_Icc_eq_of_lipschitz_of_continuous
   [complete_space E]
-  {v : ℝ → E → E} {t_min t₀ t_max : ℝ} (ht₀ : t₀ ∈ Icc t_min t_max)
-  (x₀ : E) {C R : ℝ} (hR : 0 ≤ R) {L : ℝ≥0}
-  (Hlip : ∀ t ∈ Icc t_min t_max, lipschitz_on_with L (v t) (closed_ball x₀ R))
-  (Hcont : ∀ x ∈ closed_ball x₀ R, continuous_on (λ t, v t x) (Icc t_min t_max))
-  (Hnorm : ∀ (t ∈ Icc t_min t_max) (x ∈ closed_ball x₀ R), ∥v t x∥ ≤ C)
-  (Hmul_le : C * max (t_max - t₀) (t₀ - t_min) ≤ R) :
+  {v : ℝ → E → E} {t_min t₀ t_max : ℝ} (x₀ : E) {C R : ℝ} {L : ℝ≥0}
+  (hpl : is_picard_lindelof v t_min t₀ t_max x₀ L R C) :
   ∃ f : ℝ → E, f t₀ = x₀ ∧ ∀ t ∈ Icc t_min t_max,
     has_deriv_within_at f (v t (f t)) (Icc t_min t_max) t :=
 begin
-  lift C to ℝ≥0 using ((norm_nonneg _).trans $ Hnorm t₀ ht₀ x₀ (mem_closed_ball_self hR)),
-  lift R to ℝ≥0 using hR,
-  lift t₀ to Icc t_min t_max using ht₀,
+  lift C to ℝ≥0 using ((norm_nonneg _).trans $ hpl.norm_le t₀ hpl.ht₀ x₀
+    (mem_closed_ball_self hpl.hR)),
+  lift t₀ to Icc t_min t_max using hpl.ht₀,
   exact picard_lindelof.exists_solution
-    ⟨v, t_min, t_max, t₀, x₀, C, R, L, Hlip, Hcont, Hnorm, Hmul_le⟩
+    ⟨v, t_min, t_max, t₀, x₀, C, ⟨R, hpl.hR⟩, L,
+      hpl.lipschitz, hpl.cont, hpl.norm_le, hpl.C_mul_le_R⟩
 end
 
-/-- Predicate for the hypotheses of the Picard-Lindelöf theorem -/
-@[reducible] def is_picard_lindelof
-  {E : Type*} [normed_add_comm_group E] (v : ℝ → E → E) (t_min t₀ t_max : ℝ) (x₀ : E) : Prop :=
-∃ (L : ℝ≥0) (R C : ℝ) (hR : 0 ≤ R),
-(∀ (t : ℝ), t ∈ set.Icc t_min t_max → lipschitz_on_with L (v t) (metric.closed_ball x₀ R)) ∧
-(∀ (x : E), x ∈ metric.closed_ball x₀ R → continuous_on (λ (t : ℝ), v t x) (set.Icc t_min t_max)) ∧
-(∀ (t : ℝ), t ∈ set.Icc t_min t_max → ∀ (x : E), x ∈ metric.closed_ball x₀ R → ∥v t x∥ ≤ C) ∧
-(C * linear_order.max (t_max - t₀) (t₀ - t_min) ≤ R)
+-- /-- Predicate for the hypotheses of the Picard-Lindelöf theorem -/
+-- @[reducible] def is_picard_lindelof
+--   {E : Type*} [normed_add_comm_group E] (v : ℝ → E → E) (t_min t₀ t_max : ℝ) (x₀ : E) : Prop :=
+-- ∃ (L : ℝ≥0) (R C : ℝ) (hR : 0 ≤ R),
+-- (∀ (t : ℝ), t ∈ set.Icc t_min t_max → lipschitz_on_with L (v t) (metric.closed_ball x₀ R)) ∧
+-- (∀ (x : E), x ∈ metric.closed_ball x₀ R → continuous_on (λ (t : ℝ), v t x) (set.Icc t_min t_max)) ∧
+-- (∀ (t : ℝ), t ∈ set.Icc t_min t_max → ∀ (x : E), x ∈ metric.closed_ball x₀ R → ∥v t x∥ ≤ C) ∧
+-- (C * linear_order.max (t_max - t₀) (t₀ - t_min) ≤ R)
 
-/-- Picard-Lindelöf theorem where the hypothesis is a predicate -/
-lemma ODE_solution_exists
-  [complete_space E] (v : ℝ → E → E) (t_min t₀ t_max : ℝ) (ht₀ : t₀ ∈ set.Icc t_min t_max) (x₀ : E)
-  (hpl : is_picard_lindelof v t_min t₀ t_max x₀) :
-  ∃ (f : ℝ → E), f t₀ = x₀ ∧ ∀ (t : ℝ), t ∈ set.Icc t_min t_max →
-    has_deriv_within_at f (v t (f t)) (set.Icc t_min t_max) t :=
-let ⟨L, R, C, hR, h1, h2, h3, h4⟩ := hpl in
-  exists_forall_deriv_within_Icc_eq_of_lipschitz_of_continuous ht₀ x₀ hR h1 h2 h3 h4
+-- /-- Picard-Lindelöf theorem where the hypothesis is a predicate -/
+-- lemma ODE_solution_exists
+--   [complete_space E] (v : ℝ → E → E) (t_min t₀ t_max : ℝ) (ht₀ : t₀ ∈ set.Icc t_min t_max) (x₀ : E)
+--   (hpl : ∃ L R C, is_picard_lindelof v t_min t₀ t_max x₀ L R C) :
+--   ∃ (f : ℝ → E), f t₀ = x₀ ∧ ∀ (t : ℝ), t ∈ set.Icc t_min t_max →
+--     has_deriv_within_at f (v t (f t)) (set.Icc t_min t_max) t :=
+-- let ⟨L, R, C, h1, h2, h3, h4⟩ := hpl in
+--   exists_forall_deriv_within_Icc_eq_of_lipschitz_of_continuous ht₀ x₀ hR h1 h2 h3 h4
 
-/-- Solution exists on a subset of a closed interval. -/
-lemma ODE_solution_exists.within_at_set
-  [complete_space E] (v : ℝ → E → E) (t_min t₀ t_max : ℝ) (ht₀ : t₀ ∈ set.Icc t_min t_max) (x₀ : E)
-  {s : set ℝ} (hs : s ⊆ set.Icc t_min t_max)
-  (hpl : is_picard_lindelof v t_min t₀ t_max x₀) :
-  ∃ (f : ℝ → E), f t₀ = x₀ ∧ ∀ (t : ℝ), t ∈ s → has_deriv_within_at f (v t (f t)) s t :=
-let ⟨f, h2, h3⟩ := ODE_solution_exists v t_min t₀ t_max ht₀ x₀ hpl in
-  ⟨f, h2, λ t ht, (h3 t (set.mem_of_subset_of_mem hs ht)).mono hs⟩
+-- /-- Solution exists on a subset of a closed interval. -/
+-- lemma ODE_solution_exists.within_at_set
+--   [complete_space E] (v : ℝ → E → E) (t_min t₀ t_max : ℝ) (ht₀ : t₀ ∈ set.Icc t_min t_max) (x₀ : E)
+--   {s : set ℝ} (hs : s ⊆ set.Icc t_min t_max)
+--   (hpl : is_picard_lindelof v t_min t₀ t_max x₀) :
+--   ∃ (f : ℝ → E), f t₀ = x₀ ∧ ∀ (t : ℝ), t ∈ s → has_deriv_within_at f (v t (f t)) s t :=
+-- let ⟨f, h2, h3⟩ := ODE_solution_exists v t_min t₀ t_max ht₀ x₀ hpl in
+--   ⟨f, h2, λ t ht, (h3 t (set.mem_of_subset_of_mem hs ht)).mono hs⟩
 
-/-- Solution exists on an open subset of some closed interval. -/
-lemma ODE_solution_exists.at_open_set
-  [complete_space E] (v : ℝ → E → E) (t_min t₀ t_max : ℝ) (ht₀ : t₀ ∈ set.Icc t_min t_max) (x₀ : E)
-  {s : set ℝ} (hs₁ : s ⊆ set.Icc t_min t_max) (hs₂ : is_open s)
-  (hpl : is_picard_lindelof v t_min t₀ t_max x₀) :
-  ∃ (f : ℝ → E), f t₀ = x₀ ∧ ∀ (t : ℝ), t ∈ s → has_deriv_at f (v t (f t)) t :=
-let ⟨f, h1, h2⟩ := ODE_solution_exists.within_at_set v t_min t₀ t_max ht₀ x₀ hs₁ hpl in
-  ⟨f, h1, λ t ht, (h2 t ht).has_deriv_at (hs₂.mem_nhds_iff.mpr ht)⟩
+-- /-- Solution exists on an open subset of some closed interval. -/
+-- lemma ODE_solution_exists.at_open_set
+--   [complete_space E] (v : ℝ → E → E) (t_min t₀ t_max : ℝ) (ht₀ : t₀ ∈ set.Icc t_min t_max) (x₀ : E)
+--   {s : set ℝ} (hs₁ : s ⊆ set.Icc t_min t_max) (hs₂ : is_open s)
+--   (hpl : is_picard_lindelof v t_min t₀ t_max x₀) :
+--   ∃ (f : ℝ → E), f t₀ = x₀ ∧ ∀ (t : ℝ), t ∈ s → has_deriv_at f (v t (f t)) t :=
+-- let ⟨f, h1, h2⟩ := ODE_solution_exists.within_at_set v t_min t₀ t_max ht₀ x₀ hs₁ hpl in
+--   ⟨f, h1, λ t ht, (h2 t ht).has_deriv_at (hs₂.mem_nhds_iff.mpr ht)⟩
 
-/-- Solution exists on an open interval. -/
-lemma ODE_solution_exists.at_ball
-  [complete_space E] (v : ℝ → E → E) (t₀ ε : ℝ) (hε : 0 < ε) (x₀ : E)
-  (hpl : is_picard_lindelof v (t₀ - ε) t₀ (t₀ + ε) x₀) :
-  ∃ (f : ℝ → E), f t₀ = x₀ ∧ ∀ (t : ℝ), t ∈ metric.ball t₀ ε → has_deriv_at f (v t (f t)) t :=
-begin
-  refine ODE_solution_exists.at_open_set v (t₀ - ε) t₀ (t₀ + ε) _ x₀ _ metric.is_open_ball hpl,
-  { rw ←real.closed_ball_eq_Icc,
-    exact metric.mem_closed_ball_self hε.le },
-  { rw real.ball_eq_Ioo,
-    exact set.Ioo_subset_Icc_self }
-end
+-- /-- Solution exists on an open interval. -/
+-- lemma ODE_solution_exists.at_ball
+--   [complete_space E] (v : ℝ → E → E) (t₀ ε : ℝ) (hε : 0 < ε) (x₀ : E)
+--   (hpl : is_picard_lindelof v (t₀ - ε) t₀ (t₀ + ε) x₀) :
+--   ∃ (f : ℝ → E), f t₀ = x₀ ∧ ∀ (t : ℝ), t ∈ metric.ball t₀ ε → has_deriv_at f (v t (f t)) t :=
+-- begin
+--   refine ODE_solution_exists.at_open_set v (t₀ - ε) t₀ (t₀ + ε) _ x₀ _ metric.is_open_ball hpl,
+--   { rw ←real.closed_ball_eq_Icc,
+--     exact metric.mem_closed_ball_self hε.le },
+--   { rw real.ball_eq_Ioo,
+--     exact set.Ioo_subset_Icc_self }
+-- end
 
 /-- A time-independent, locally continuously differentiable ODE satisfies the hypotheses of the
   Picard-Lindelöf theorem. -/
 lemma time_indep_cont_diff_on_nhds_is_picard_lindelof
   [proper_space E] (v : E → E) (x₀ : E) (s : set E) (hs : s ∈ nhds x₀)
   (hv : cont_diff_on ℝ 1 v s) (t₀ : ℝ) :
-  ∃ (ε : ℝ) (hε : 0 < ε), is_picard_lindelof (λ t, v) (t₀ - ε) t₀ (t₀ + ε) x₀ :=
+  ∃ (ε : ℝ) (hε : 0 < ε) (L R C), is_picard_lindelof (λ t, v) (t₀ - ε) t₀ (t₀ + ε) x₀ L R C :=
 begin
   -- extract Lipschitz constant
   obtain ⟨L, s', hs', hlip⟩ := cont_diff_at.exists_lipschitz_on_with
@@ -398,25 +425,35 @@ begin
   { apply (norm_nonneg (v x₀)).trans,
     apply hC,
     exact ⟨x₀, ⟨mem_closed_ball_self hr', rfl⟩⟩ },
-  refine ⟨if C = 0 then 1 else (r / 2 / C), _, L, r / 2, C, (half_pos hr).le,
-    λ t ht, hlip.mono (set.subset_inter_iff.mp
-      (subset_trans (metric.closed_ball_subset_ball (half_lt_self hr)) hball)).2,
-    λ x hx, continuous_on_const, λ t ht x hx, hC ⟨x, hx, rfl⟩, _⟩,
-  { split_ifs,
+  set ε := if C = 0 then 1 else (r / 2 / C) with hε,
+  have hε0 : 0 < ε,
+  { rw hε,
+    split_ifs,
     { exact zero_lt_one },
     { exact div_pos (half_pos hr) (lt_of_le_of_ne hC' (ne.symm h)) } },
-  { rw [add_sub_cancel', sub_sub_cancel, max_self, mul_ite, mul_one],
-    split_ifs,
-    { rwa ← h at hr' },
-    { exact (mul_div_cancel' (r / 2) h).le } }
+  refine ⟨ε, hε0, L, r / 2, C, _⟩,
+  exact {
+    ht₀ := by {rw ←real.closed_ball_eq_Icc, exact mem_closed_ball_self hε0.le},
+    hR := (half_pos hr).le,
+    lipschitz := λ t ht, hlip.mono (set.subset_inter_iff.mp
+      (subset_trans (metric.closed_ball_subset_ball (half_lt_self hr)) hball)).2,
+    cont := λ x hx, continuous_on_const,
+    norm_le := λ t ht x hx, hC ⟨x, hx, rfl⟩,
+    C_mul_le_R := begin
+      rw [add_sub_cancel', sub_sub_cancel, max_self, mul_ite, mul_one],
+      split_ifs,
+      { rwa ← h at hr' },
+      { exact (mul_div_cancel' (r / 2) h).le }
+    end
+  }
 end
 
-/-- A time-independent, continuously differentiable ODE satisfies the hypotheses of the
-  Picard-Lindelöf theorem. -/
-lemma time_indep_cont_diff_is_picard_lindelof
-  [proper_space E] (v : E → E) (hv : cont_diff ℝ 1 v) (t₀ : ℝ) (x₀ : E) :
-  ∃ (ε : ℝ) (hε : 0 < ε), is_picard_lindelof (λ t, v) (t₀ - ε) t₀ (t₀ + ε) x₀ :=
-time_indep_cont_diff_on_nhds_is_picard_lindelof v x₀ set.univ univ_mem hv.cont_diff_on t₀
+-- /-- A time-independent, continuously differentiable ODE satisfies the hypotheses of the
+--   Picard-Lindelöf theorem. -/
+-- lemma time_indep_cont_diff_is_picard_lindelof
+--   [proper_space E] (v : E → E) (hv : cont_diff ℝ 1 v) (t₀ : ℝ) (x₀ : E) :
+--   ∃ (ε : ℝ) (hε : 0 < ε), is_picard_lindelof (λ t, v) (t₀ - ε) t₀ (t₀ + ε) x₀ :=
+-- time_indep_cont_diff_on_nhds_is_picard_lindelof v x₀ set.univ univ_mem hv.cont_diff_on t₀
 
 /-- A time-independent, locally continuously differentiable ODE admits a solution in some open
 interval. -/
@@ -425,13 +462,24 @@ theorem ODE_solution_exists.at_ball_of_cont_diff_on_nhds
   (hv : cont_diff_on ℝ 1 v s) (t₀ : ℝ) :
   ∃ (ε : ℝ) (hε : 0 < ε) (f : ℝ → E), f t₀ = x₀ ∧
     ∀ t ∈ metric.ball t₀ ε, has_deriv_at f (v (f t)) t :=
-let ⟨ε, hε, hpl⟩ := time_indep_cont_diff_on_nhds_is_picard_lindelof v x₀ s hs hv t₀ in
-   ⟨ε, hε, ODE_solution_exists.at_ball (λ t, v) t₀ ε hε x₀ hpl⟩
+begin
+  obtain ⟨ε, hε, L, R, C, hpl⟩ := time_indep_cont_diff_on_nhds_is_picard_lindelof v x₀ s hs hv t₀,
+  obtain ⟨f, hf1, hf2⟩ := exists_forall_deriv_within_Icc_eq_of_lipschitz_of_continuous x₀ hpl,
+  refine ⟨ε, hε, f, hf1, _⟩,
+  intros t ht,
+  refine (hf2 t _).has_deriv_at _,
+  { rw ←real.closed_ball_eq_Icc,
+    exact mem_of_mem_of_subset ht ball_subset_closed_ball },
+  { rw _root_.mem_nhds_iff,
+    use ball t₀ ε,
+    rw ←real.closed_ball_eq_Icc,
+    exact ⟨ball_subset_closed_ball, is_open_ball, ht⟩ }
+end
 
 /-- A time-independent, continuously differentiable ODE admits a solution in some open interval. -/
 theorem ODE_solution_exists.at_ball_of_cont_diff
   [proper_space E] (v : E → E) (hv : cont_diff ℝ 1 v) (t₀ : ℝ) (x₀ : E) :
   ∃ (ε : ℝ) (hε : 0 < ε) (f : ℝ → E), f t₀ = x₀ ∧
     ∀ t ∈ metric.ball t₀ ε, has_deriv_at f (v (f t)) t :=
-let ⟨ε, hε, hpl⟩ := time_indep_cont_diff_is_picard_lindelof v hv t₀ x₀ in
-   ⟨ε, hε, ODE_solution_exists.at_ball (λ t, v) t₀ ε hε x₀ hpl⟩
+ODE_solution_exists.at_ball_of_cont_diff_on_nhds v x₀ univ
+  (is_open.mem_nhds is_open_univ (mem_univ _)) hv.cont_diff_on t₀

--- a/src/analysis/ODE/picard_lindelof.lean
+++ b/src/analysis/ODE/picard_lindelof.lean
@@ -63,9 +63,9 @@ structure is_picard_lindelof
   (L : ℝ≥0) (R C : ℝ) : Prop :=
 (ht₀ : t₀ ∈ Icc t_min t_max)
 (hR : 0 ≤ R)
-(lipschitz : ∀ t ∈ set.Icc t_min t_max, lipschitz_on_with L (v t) (metric.closed_ball x₀ R))
-(cont : ∀ x ∈ metric.closed_ball x₀ R, continuous_on (λ (t : ℝ), v t x) (set.Icc t_min t_max))
-(norm_le : ∀ (t ∈ set.Icc t_min t_max) (x ∈ metric.closed_ball x₀ R), ∥v t x∥ ≤ C)
+(lipschitz : ∀ t ∈ Icc t_min t_max, lipschitz_on_with L (v t) (closed_ball x₀ R))
+(cont : ∀ x ∈ closed_ball x₀ R, continuous_on (λ (t : ℝ), v t x) (Icc t_min t_max))
+(norm_le : ∀ (t ∈ Icc t_min t_max) (x ∈ closed_ball x₀ R), ∥v t x∥ ≤ C)
 (C_mul_le_R : (C : ℝ) * linear_order.max (t_max - t₀) (t₀ - t_min) ≤ R)
 
 namespace picard_lindelof
@@ -332,8 +332,7 @@ end picard_lindelof
 
 /-- Picard-Lindelöf (Cauchy-Lipschitz) theorem. -/
 theorem exists_forall_deriv_within_Icc_eq_of_is_picard_lindelof
-  [complete_space E]
-  {v : ℝ → E → E} {t_min t₀ t_max : ℝ} (x₀ : E) {C R : ℝ} {L : ℝ≥0}
+  [complete_space E] {v : ℝ → E → E} {t_min t₀ t_max : ℝ} (x₀ : E) {C R : ℝ} {L : ℝ≥0}
   (hpl : is_picard_lindelof v t_min t₀ t_max x₀ L R C) :
   ∃ f : ℝ → E, f t₀ = x₀ ∧ ∀ t ∈ Icc t_min t_max,
     has_deriv_within_at f (v t (f t)) (Icc t_min t_max) t :=
@@ -377,8 +376,8 @@ begin
   exact {
     ht₀ := by {rw ←real.closed_ball_eq_Icc, exact mem_closed_ball_self hε0.le},
     hR := (half_pos hr).le,
-    lipschitz := λ t ht, hlip.mono (set.subset_inter_iff.mp
-      (subset_trans (metric.closed_ball_subset_ball (half_lt_self hr)) hball)).2,
+    lipschitz := λ t ht, hlip.mono (subset_inter_iff.mp
+      (subset_trans (closed_ball_subset_ball (half_lt_self hr)) hball)).2,
     cont := λ x hx, continuous_on_const,
     norm_le := λ t ht x hx, hC ⟨x, hx, rfl⟩,
     C_mul_le_R := begin
@@ -395,7 +394,7 @@ interval. -/
 theorem exists_forall_deriv_at_ball_eq_of_cont_diff_on_nhds
   {s : set E} (hv : cont_diff_on ℝ 1 v s) (hs : s ∈ nhds x₀) :
   ∃ (ε : ℝ) (hε : 0 < ε) (f : ℝ → E), f t₀ = x₀ ∧
-    ∀ t ∈ metric.ball t₀ ε, has_deriv_at f (v (f t)) t :=
+    ∀ t ∈ ball t₀ ε, has_deriv_at f (v (f t)) t :=
 begin
   obtain ⟨ε, hε, L, R, C, hpl⟩ := is_picard_lindelof_of_time_indep_cont_diff_on_nhds t₀ x₀ hv hs,
   obtain ⟨f, hf1, hf2⟩ := exists_forall_deriv_within_Icc_eq_of_is_picard_lindelof x₀ hpl,
@@ -413,6 +412,6 @@ end
 /-- A time-independent, continuously differentiable ODE admits a solution in some open interval. -/
 theorem exists_forall_deriv_at_ball_eq_of_cont_diff
   (hv : cont_diff ℝ 1 v) : ∃ (ε : ℝ) (hε : 0 < ε) (f : ℝ → E), f t₀ = x₀ ∧
-    ∀ t ∈ metric.ball t₀ ε, has_deriv_at f (v (f t)) t :=
+    ∀ t ∈ ball t₀ ε, has_deriv_at f (v (f t)) t :=
 exists_forall_deriv_at_ball_eq_of_cont_diff_on_nhds t₀ x₀ hv.cont_diff_on
   (is_open.mem_nhds is_open_univ (mem_univ _))

--- a/src/analysis/ODE/picard_lindelof.lean
+++ b/src/analysis/ODE/picard_lindelof.lean
@@ -332,7 +332,7 @@ end
 /-- Predicate for the hypotheses of the Picard-Lindelöf theorem -/
 @[reducible] def is_picard_lindelof
   {E : Type*} [normed_add_comm_group E] (v : ℝ → E → E) (t_min t₀ t_max : ℝ) (x₀ : E) : Prop :=
-∃ (L : nnreal) (R C : ℝ) (hR : 0 ≤ R),
+∃ (L : ℝ≥0) (R C : ℝ) (hR : 0 ≤ R),
 (∀ (t : ℝ), t ∈ set.Icc t_min t_max → lipschitz_on_with L (v t) (metric.closed_ball x₀ R)) ∧
 (∀ (x : E), x ∈ metric.closed_ball x₀ R → continuous_on (λ (t : ℝ), v t x) (set.Icc t_min t_max)) ∧
 (∀ (t : ℝ), t ∈ set.Icc t_min t_max → ∀ (x : E), x ∈ metric.closed_ball x₀ R → ∥v t x∥ ≤ C) ∧

--- a/src/analysis/ODE/picard_lindelof.lean
+++ b/src/analysis/ODE/picard_lindelof.lean
@@ -468,5 +468,5 @@ theorem ODE_solution_exists.at_ball_of_cont_diff
     ∀ t ∈ metric.ball t₀ ε, has_deriv_at f (v (f t)) t :=
 begin
   obtain ⟨ε, hε, hpl⟩ := time_indep_cont_diff_is_picard_lindelof v hv t₀ x₀,
-  refine ⟨ε, hε, ODE_solution_exists.at_ball (λ t, v) t₀ ε hε x₀ hpl⟩
+  exact ⟨ε, hε, ODE_solution_exists.at_ball (λ t, v) t₀ ε hε x₀ hpl⟩
 end

--- a/src/analysis/ODE/picard_lindelof.lean
+++ b/src/analysis/ODE/picard_lindelof.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2021 Yury G. Kudryashov. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Yury G. Kudryashov
+Authors: Yury G. Kudryashov, Winston Yin
 -/
 import analysis.special_functions.integrals
 import topology.metric_space.contracting

--- a/src/analysis/ODE/picard_lindelof.lean
+++ b/src/analysis/ODE/picard_lindelof.lean
@@ -331,7 +331,7 @@ end
 
 /-- Predicate for the hypotheses of the Picard-Lindelöf theorem -/
 @[reducible] def is_picard_lindelof
-  [complete_space E] (v : ℝ → E → E) (t_min t₀ t_max : ℝ) (x₀ : E) : Prop :=
+  {E : Type*} [normed_add_comm_group E] (v : ℝ → E → E) (t_min t₀ t_max : ℝ) (x₀ : E) : Prop :=
 ∃ (L : nnreal) (R C : ℝ) (hR : 0 ≤ R),
 (∀ (t : ℝ), t ∈ set.Icc t_min t_max → lipschitz_on_with L (v t) (metric.closed_ball x₀ R)) ∧
 (∀ (x : E), x ∈ metric.closed_ball x₀ R → continuous_on (λ (t : ℝ), v t x) (set.Icc t_min t_max)) ∧
@@ -425,26 +425,21 @@ begin
   cases hbbd with C hC,
   set ε := if C = 0 then 1 else (r / 2 / C) with hε,
   use ε,
-  have hε' : ε > 0,
+  have hε' : 0 < ε,
   { rw hε,
     split_ifs,
     { exact zero_lt_one },
-    rw gt,
     rw lt_div_iff,
-    { rw lt_div_iff zero_lt_two,
-      rw zero_mul,
-      rw zero_mul,
+    { rw [lt_div_iff zero_lt_two, zero_mul, zero_mul],
       exact hr,
       apply_instance },
     { have : ∥v x₀∥ ≤ C,
       { apply hC,
         rw set.mem_image,
         use x₀,
-        rw metric.mem_closed_ball,
-        rw dist_self,
+        rw [metric.mem_closed_ball, dist_self],
         refine ⟨_, rfl⟩,
-        rw le_div_iff zero_lt_two,
-        rw zero_mul,
+        rw [le_div_iff zero_lt_two, zero_mul],
         exact le_of_lt hr,
         apply_instance },
       apply lt_of_le_of_ne _ (ne.symm h),
@@ -456,11 +451,9 @@ begin
     apply le_of_lt,
     exact hε' },
   -- show is_picard_lindelof
-  use L,
-  use r / 2,
-  use C,
-  refine ⟨_, _, _, _, _⟩,
-  { linarith },
+  refine ⟨L, r / 2, C, _, _, _, _, _⟩,
+  { apply le_of_lt,
+    exact half_pos hr },
   { intros t ht,
     exact hlip' },
   { intros x hx,
@@ -475,10 +468,7 @@ begin
     exact hx },
   { rw [add_tsub_cancel_left, sub_sub_cancel, max_self, hε],
     split_ifs,
-    { rw h,
-      rw zero_mul,
-      rw le_div_iff zero_lt_two,
-      rw zero_mul,
+    { rw [h, zero_mul, le_div_iff zero_lt_two, zero_mul],
       exact le_of_lt hr,
       apply_instance },
     rw mul_div_cancel' _ h }
@@ -487,7 +477,7 @@ end
 /-- A time-independent, continuously differentiable ODE admits a solution in some open interval. -/
 theorem ODE_solution_exists.at_ball_of_cont_diff
   [proper_space E] (v : E → E) (hv : cont_diff ℝ 1 v) (t₀ : ℝ) (x₀ : E) :
-  ∃ (ε : ℝ) (hε : ε > 0) (f : ℝ → E), f t₀ = x₀ ∧
+  ∃ (ε : ℝ) (hε : 0 < ε) (f : ℝ → E), f t₀ = x₀ ∧
     ∀ t ∈ metric.ball t₀ ε, has_deriv_at f (v (f t)) t :=
 begin
   have h := time_indep_cont_diff_is_picard_lindelof v hv t₀ x₀,


### PR DESCRIPTION
We add some corollaries to the existence theorem of solutions to autonomous ODEs (Picard-Lindelöf / Cauchy-Lipschitz theorem).

* `is_picard_lindelof`: Predicate for the very long hypotheses of the Picard-Lindelöf theorem.
  * When applying `exists_forall_deriv_within_Icc_eq_of_lipschitz_of_continuous` directly to unite with a goal, Lean introduces a long list of goals with many meta-variables. The predicate makes the proof of these hypotheses more manageable.
  * Certain variables in the hypotheses, such as the Lipschitz constant, are often obtained from other facts non-constructively, so it is less convenient to directly use them to satisfy hypotheses (needing `Exists.some`). We avoid this problem by stating these non-`Prop` hypotheses under `∃`.
* Solution `f` exists on any subset `s` of some closed interval, where the derivative of `f` is defined by the value of `f` within `s` only.
* Solution `f` exists on any open subset `s` of some closed interval.
* There exists `ε > 0` such that a solution `f` exists on `(t₀ - ε, t₀ + ε)`.
* As a simple example, we show that time-independent, locally continuously differentiable ODEs satisfy `is_picard_lindelof` and hence a solution exists within some open interval.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
