### PR TITLE
chore(data/rat/defs): Shortcut instance for `ring ℚ`

### DIFF
--- a/src/data/rat/defs.lean
+++ b/src/data/rat/defs.lean
@@ -490,9 +490,8 @@ instance : is_domain ℚ :=
   .. (infer_instance : no_zero_divisors ℚ) }
 
 /- Extra instances to short-circuit type class resolution -/
--- TODO(Mario): this instance slows down data.real.basic
 instance : nontrivial ℚ         := by apply_instance
---instance : ring ℚ             := by apply_instance
+instance : ring ℚ               := by apply_instance
 instance : comm_semiring ℚ      := by apply_instance
 instance : semiring ℚ           := by apply_instance
 instance : add_comm_group ℚ     := by apply_instance


### PR DESCRIPTION
Uncomment the `ring ℚ` instance. This is needed to avoid computability poisoning as importing `analysis.normed.field.basic` currently makes Lean infer the ring operations on `ℚ` from `rat.normed_field`, which is noncomputable.

Mario commented this instance in e53c2bbb95c0eb9d3e612536d97a1eafb521e8a9, claiming performance reasons, but I could not witness any sensible difference.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->
An option to respect Mario's comment and fix the noncomputability poisoning would be to declare the instance *later* than `data.real.basic`, but that would be a confusing design.

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
