### PR TITLE
[Merged by Bors] - feat(group_theory/exponent): `card G ∣ exponent G ^ rank G`

### DIFF
--- a/src/group_theory/exponent.lean
+++ b/src/group_theory/exponent.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Julian Kuelshammer
 -/
 import data.zmod.quotient
+import group_theory.noncomm_pi_coprod
 import group_theory.order_of_element
 import algebra.gcd_monoid.finset
 import algebra.punit_instances
@@ -327,18 +328,10 @@ begin
   obtain ⟨S, hS1, hS2⟩ := group.rank_spec G,
   rw [←hS1, ←fintype.card_coe, ←finset.card_univ, ←finset.prod_const],
   let f : (Π g : S, zpowers (g : G)) →* G :=
-  { to_fun := λ a, ∏ g : S, a g,
-    map_one' := finset.prod_const_one,
-    map_mul' := λ a b, finset.prod_mul_distrib },
+  noncomm_pi_coprod (λ s t h x y hx hy, mul_comm x y),
   have hf : function.surjective f,
   { rw [←monoid_hom.range_top_iff_surjective, eq_top_iff, ←hS2, closure_le],
-    intros g₀ hg₀,
-    refine ⟨λ g, if ↑g = g₀ then ⟨g, mem_zpowers g⟩ else 1, _⟩,
-    simp only [f, monoid_hom.coe_mk],
-    refine (finset.prod_eq_single_of_mem (⟨g₀, hg₀⟩ : S) (finset.mem_univ ⟨g₀, hg₀⟩)
-      (λ g _ hg, _)).trans (congr_arg coe (if_pos rfl)),
-    rw [ne, subtype.ext_iff, subtype.coe_mk] at hg,
-    rw [if_neg hg, coe_one] },
+    exact λ g hg, ⟨pi.mul_single ⟨g, hg⟩ ⟨g, mem_zpowers g⟩, noncomm_pi_coprod_mul_single _ _⟩ },
   replace hf := nat_card_dvd_of_surjective f hf,
   rw nat.card_pi at hf,
   refine hf.trans (finset.prod_dvd_prod_of_dvd _ _ (λ g hg, _)),

--- a/src/group_theory/exponent.lean
+++ b/src/group_theory/exponent.lean
@@ -322,7 +322,7 @@ open_locale big_operators
 
 variables (G) [comm_group G] [group.fg G]
 
-lemma card_dvd_exponent_pow_rank : nat.card G ∣ monoid.exponent G ^ group.rank G :=
+@[to_additive] lemma card_dvd_exponent_pow_rank : nat.card G ∣ monoid.exponent G ^ group.rank G :=
 begin
   obtain ⟨S, hS1, hS2⟩ := group.rank_spec G,
   rw [←hS1, ←fintype.card_coe, ←finset.card_univ, ←finset.prod_const],
@@ -346,7 +346,7 @@ begin
   exact monoid.order_dvd_exponent (g : G),
 end
 
-lemma card_dvd_exponent_pow_rank' {n : ℕ} (hG : ∀ g : G, g ^ n = 1) :
+@[to_additive] lemma card_dvd_exponent_pow_rank' {n : ℕ} (hG : ∀ g : G, g ^ n = 1) :
   nat.card G ∣ n ^ group.rank G :=
 (card_dvd_exponent_pow_rank G).trans
     (pow_dvd_pow_of_dvd (monoid.exponent_dvd_of_forall_pow_eq_one G n hG) (group.rank G))

--- a/src/group_theory/exponent.lean
+++ b/src/group_theory/exponent.lean
@@ -324,7 +324,6 @@ variables (G) [comm_group G] [group.fg G]
 
 lemma card_dvd_exponent_pow_rank : nat.card G ∣ monoid.exponent G ^ group.rank G :=
 begin
-  classical,
   obtain ⟨S, hS1, hS2⟩ := group.rank_spec G,
   rw [←hS1, ←fintype.card_coe, ←finset.card_univ, ←finset.prod_const],
   let f : (Π g : S, zpowers (g : G)) →* G :=

--- a/src/group_theory/exponent.lean
+++ b/src/group_theory/exponent.lean
@@ -322,9 +322,7 @@ open_locale big_operators
 
 variables (G) [comm_group G] [group.fg G]
 
-lemma card_dvd_exponent_pow_rank
-  [decidable_pred (λ n, ∃ (S : finset G), S.card = n ∧ closure (S : set G) = ⊤)] :
-  nat.card G ∣ monoid.exponent G ^ group.rank G :=
+lemma card_dvd_exponent_pow_rank : nat.card G ∣ monoid.exponent G ^ group.rank G :=
 begin
   classical,
   obtain ⟨S, hS1, hS2⟩ := group.rank_spec G,
@@ -349,8 +347,7 @@ begin
   exact monoid.order_dvd_exponent (g : G),
 end
 
-lemma card_dvd_exponent_pow_rank' {n : ℕ} (hG : ∀ g : G, g ^ n = 1)
-  [decidable_pred (λ n, ∃ (S : finset G), S.card = n ∧ closure (S : set G) = ⊤)] :
+lemma card_dvd_exponent_pow_rank' {n : ℕ} (hG : ∀ g : G, g ^ n = 1) :
   nat.card G ∣ n ^ group.rank G :=
 (card_dvd_exponent_pow_rank G).trans
     (pow_dvd_pow_of_dvd (monoid.exponent_dvd_of_forall_pow_eq_one G n hG) (group.rank G))

--- a/src/group_theory/exponent.lean
+++ b/src/group_theory/exponent.lean
@@ -327,8 +327,7 @@ variables (G) [comm_group G] [group.fg G]
 begin
   obtain ⟨S, hS1, hS2⟩ := group.rank_spec G,
   rw [←hS1, ←fintype.card_coe, ←finset.card_univ, ←finset.prod_const],
-  let f : (Π g : S, zpowers (g : G)) →* G :=
-  noncomm_pi_coprod (λ s t h x y hx hy, mul_comm x y),
+  let f : (Π g : S, zpowers (g : G)) →* G := noncomm_pi_coprod (λ s t h x y hx hy, mul_comm x y),
   have hf : function.surjective f,
   { rw [←monoid_hom.range_top_iff_surjective, eq_top_iff, ←hS2, closure_le],
     exact λ g hg, ⟨pi.mul_single ⟨g, hg⟩ ⟨g, mem_zpowers g⟩, noncomm_pi_coprod_mul_single _ _⟩ },


### PR DESCRIPTION
This PR adds a lemma stating that `nat.card G ∣ monoid.exponent G ^ group.rank G`.

---

DONE: Once #16256 is merged, the `decidable_pred` assumptions can be removed from the statements.

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
