### PR TITLE
[Merged by Bors] - feat(order/filter/at_top_bot): add lemmas about convergence of `λ x, r * f x` to `±∞`

### DIFF
--- a/src/algebra/group_power/order.lean
+++ b/src/algebra/group_power/order.lean
@@ -251,8 +251,8 @@ monotone_nat_of_le_succ $ λ n,
 theorem pow_le_pow (ha : 1 ≤ a) (h : n ≤ m) : a ^ n ≤ a ^ m :=
 pow_mono ha h
 
-theorem le_self_pow (ha : 1 ≤ a) (h : 1 ≤ m) : a ≤ a ^ m :=
-eq.trans_le (pow_one a).symm (pow_le_pow ha h)
+theorem le_self_pow (ha : 1 ≤ a) (h : m ≠ 0) : a ≤ a ^ m :=
+(pow_one a).symm.trans_le (pow_le_pow ha $ pos_iff_ne_zero.mpr h)
 
 lemma strict_mono_pow (h : 1 < a) : strict_mono (λ n : ℕ, a ^ n) :=
 have 0 < a := zero_le_one.trans_lt h,

--- a/src/algebra/order/ring.lean
+++ b/src/algebra/order/ring.lean
@@ -163,6 +163,10 @@ alias zero_lt_two ← two_pos
 alias zero_lt_three ← three_pos
 alias zero_lt_four ← four_pos
 
+@[priority 100] -- see Note [lower instance priority]
+instance ordered_semiring.to_no_max_order : no_max_order α :=
+⟨assume a, ⟨a + 1, lt_add_of_pos_right _ one_pos⟩⟩
+
 end nontrivial
 
 -- See Note [decidable namespace]
@@ -725,11 +729,6 @@ le_of_not_gt (λ ha, absurd h (mul_neg_of_pos_of_neg ha hb).not_le)
 
 lemma nonpos_of_mul_nonneg_right (h : 0 ≤ a * b) (ha : a < 0) : b ≤ 0 :=
 le_of_not_gt (λ hb, absurd h (mul_neg_of_neg_of_pos ha hb).not_le)
-
-@[priority 100] -- see Note [lower instance priority]
-instance linear_ordered_semiring.to_no_max_order {α : Type*} [linear_ordered_semiring α] :
-  no_max_order α :=
-⟨assume a, ⟨a + 1, lt_add_of_pos_right _ zero_lt_one⟩⟩
 
 /-- Pullback a `linear_ordered_semiring` under an injective map.
 See note [reducible non-instances]. -/

--- a/src/data/nat/factorization/basic.lean
+++ b/src/data/nat/factorization/basic.lean
@@ -671,7 +671,7 @@ begin
   by_cases ha1 : a = 1,
   { rw [ha1, mul_one],
     exact hp p n hp' hn },
-  refine h (p^n) a ((hp'.one_lt).trans_le (le_self_pow (prime.one_lt hp').le (succ_le_iff.mpr hn)))
+  refine h (p^n) a ((hp'.one_lt).trans_le (le_self_pow (prime.one_lt hp').le hn.ne'))
     _ _ (hp _ _ hp' hn) hPa,
   { contrapose! hpa,
     simp [lt_one_iff.1 (lt_of_le_of_ne hpa ha1)] },

--- a/src/order/filter/at_top_bot.lean
+++ b/src/order/filter/at_top_bot.lean
@@ -682,6 +682,8 @@ lemma tendsto_neg_at_top_at_bot : tendsto (has_neg.neg : β → β) at_top at_bo
 lemma tendsto_neg_at_bot_at_top : tendsto (has_neg.neg : β → β) at_bot at_top :=
 @tendsto_neg_at_top_at_bot βᵒᵈ _
 
+variable {l}
+
 @[simp] lemma tendsto_neg_at_top_iff : tendsto (λ x, -f x) l at_top ↔ tendsto f l at_bot :=
 (order_iso.neg β).tendsto_at_bot_iff
 
@@ -711,11 +713,7 @@ tendsto_id.at_top_mul_at_top tendsto_id
 /-- The monomial function `x^n` tends to `+∞` at `+∞` for any positive natural `n`.
 A version for positive real powers exists as `tendsto_rpow_at_top`. -/
 lemma tendsto_pow_at_top {n : ℕ} (hn : n ≠ 0) : tendsto (λ x : α, x ^ n) at_top at_top :=
-begin
-  rw [← pos_iff_ne_zero, ← nat.succ_le_iff] at hn,
-  refine tendsto_at_top_mono' _ ((eventually_ge_at_top 1).mono $ λ x hx, _) tendsto_id,
-  simpa only [pow_one] using pow_le_pow hx hn
-end
+tendsto_at_top_mono' _ ((eventually_ge_at_top 1).mono $ λ x hx, le_self_pow hx hn) tendsto_id
 
 end ordered_semiring
 
@@ -782,29 +780,111 @@ lemma tendsto.at_top_of_mul_const {c : α} (hc : 0 < c) (hf : tendsto (λ x, f x
   tendsto f l at_top :=
 tendsto_at_top.2 $ λ b, (tendsto_at_top.1 hf (b * c)).mono $ λ x hx, le_of_mul_le_mul_right hx hc
 
+@[simp] lemma tendsto_pow_at_top_iff {n : ℕ} : tendsto (λ x : α, x ^ n) at_top at_top ↔ n ≠ 0 :=
+⟨λ h hn, by simpa only [hn, pow_zero, not_tendsto_const_at_top] using h, tendsto_pow_at_top⟩
+
 end linear_ordered_semiring
 
 lemma nonneg_of_eventually_pow_nonneg [linear_ordered_ring α] {a : α}
   (h : ∀ᶠ n in at_top, 0 ≤ a ^ (n : ℕ)) : 0 ≤ a :=
 let ⟨n, hn⟩ := (tendsto_bit1_at_top.eventually h).exists in pow_bit1_nonneg_iff.1 hn
 
+lemma not_tendsto_pow_at_top_at_bot [linear_ordered_ring α] :
+  ∀ {n : ℕ}, ¬tendsto (λ x : α, x ^ n) at_top at_bot
+| 0 := by simp [not_tendsto_const_at_bot]
+| (n + 1) := (tendsto_pow_at_top n.succ_ne_zero).not_tendsto disjoint_at_top_at_bot
+
 section linear_ordered_field
 
 variables [linear_ordered_field α] {l : filter β} {f : β → α} {r : α}
+
+/-!
+### Multiplication by constant: iff lemmas
+-/
+
+/-- If `r` is a positive constant, then `λ x, r * f x` tends to infinity along a filter if and only
+if `f` tends to infinity along the same filter. -/
+lemma tendsto_const_mul_at_top_of_pos (hr : 0 < r) :
+  tendsto (λ x, r * f x) l at_top ↔ tendsto f l at_top :=
+⟨λ h, h.at_top_of_const_mul hr,
+  λ h, tendsto.at_top_of_const_mul (inv_pos.2 hr) $ by simpa only [inv_mul_cancel_left₀ hr.ne']⟩
+
+/-- If `r` is a positive constant, then `λ x, f x * r` tends to infinity along a filter if and only
+if `f` tends to infinity along the same filter. -/
+lemma tendsto_mul_const_at_top_of_pos (hr : 0 < r) :
+  tendsto (λ x, f x * r) l at_top ↔ tendsto f l at_top :=
+by simpa only [mul_comm] using tendsto_const_mul_at_top_of_pos hr
+
+/-- If `r` is a positive constant, then `λ x, r * f x` tends to negative infinity along a filter if
+and only if `f` tends to negative infinity along the same filter. -/
+lemma tendsto_const_mul_at_bot_of_pos (hr : 0 < r) :
+  tendsto (λ x, r * f x) l at_bot ↔ tendsto f l at_bot :=
+by simpa only [← mul_neg, ← tendsto_neg_at_top_iff] using tendsto_const_mul_at_top_of_pos hr
+
+/-- If `r` is a positive constant, then `λ x, f x * r` tends to negative infinity along a filter if
+and only if `f` tends to negative infinity along the same filter. -/
+lemma tendsto_mul_const_at_bot_of_pos (hr : 0 < r) :
+  tendsto (λ x, f x * r) l at_bot ↔ tendsto f l at_bot :=
+by simpa only [mul_comm] using tendsto_const_mul_at_bot_of_pos hr
+
+/-- If `r` is a negative constant, then `λ x, r * f x` tends to infinity along a filter if and only
+if `f` tends to negative infinity along the same filter. -/
+lemma tendsto_const_mul_at_top_of_neg (hr : r < 0) :
+  tendsto (λ x, r * f x) l at_top ↔ tendsto f l at_bot :=
+by simpa only [neg_mul, tendsto_neg_at_bot_iff] using tendsto_const_mul_at_bot_of_pos (neg_pos.2 hr)
+
+/-- If `r` is a negative constant, then `λ x, f x * r` tends to infinity along a filter if and only
+if `f` tends to negative infinity along the same filter. -/
+lemma tendsto_mul_const_at_top_of_neg (hr : r < 0) :
+  tendsto (λ x, f x * r) l at_top ↔ tendsto f l at_bot :=
+by simpa only [mul_comm] using tendsto_const_mul_at_top_of_neg hr
+
+/-- If `r` is a negative constant, then `λ x, r * f x` tends to negative infinity along a filter if
+and only if `f` tends to infinity along the same filter. -/
+lemma tendsto_const_mul_at_bot_of_neg (hr : r < 0) :
+  tendsto (λ x, r * f x) l at_bot ↔ tendsto f l at_top :=
+by simpa only [neg_mul, tendsto_neg_at_top_iff] using tendsto_const_mul_at_top_of_pos (neg_pos.2 hr)
+
+/-- If `r` is a negative constant, then `λ x, f x * r` tends to negative infinity along a filter if
+and only if `f` tends to infinity along the same filter. -/
+lemma tendsto_mul_const_at_bot_of_neg (hr : r < 0) :
+  tendsto (λ x, f x * r) l at_bot ↔ tendsto f l at_top :=
+by simpa only [mul_comm] using tendsto_const_mul_at_bot_of_neg hr
+
+lemma tendsto_const_mul_at_top_iff [ne_bot l] :
+  tendsto (λ x, r * f x) l at_top ↔ 0 < r ∧ tendsto f l at_top ∨ r < 0 ∧ tendsto f l at_bot :=
+begin
+  rcases lt_trichotomy r 0 with hr|rfl|hr,
+  { simp [hr, hr.not_lt, tendsto_const_mul_at_top_of_neg] },
+  { simp [not_tendsto_const_at_top] },
+  { simp [hr, hr.not_lt, tendsto_const_mul_at_top_of_pos] }
+end
+
+lemma tendsto_mul_const_at_top_iff [ne_bot l] :
+  tendsto (λ x, f x * r) l at_top ↔ 0 < r ∧ tendsto f l at_top ∨ r < 0 ∧ tendsto f l at_bot :=
+by simp only [mul_comm _ r, tendsto_const_mul_at_top_iff]
+
+lemma tendsto_const_mul_at_bot_iff [ne_bot l] :
+  tendsto (λ x, r * f x) l at_bot ↔ 0 < r ∧ tendsto f l at_bot ∨ r < 0 ∧ tendsto f l at_top :=
+by simp only [← tendsto_neg_at_top_iff, ← mul_neg, tendsto_const_mul_at_top_iff, neg_neg]
+
+lemma tendsto_mul_const_at_bot_iff [ne_bot l] :
+  tendsto (λ x, f x * r) l at_bot ↔ 0 < r ∧ tendsto f l at_bot ∨ r < 0 ∧ tendsto f l at_top :=
+by simp only [mul_comm _ r, tendsto_const_mul_at_bot_iff]
 
 /-- If a function tends to infinity along a filter, then this function multiplied by a positive
 constant (on the left) also tends to infinity. For a version working in `ℕ` or `ℤ`, use
 `filter.tendsto.const_mul_at_top'` instead. -/
 lemma tendsto.const_mul_at_top (hr : 0 < r) (hf : tendsto f l at_top) :
   tendsto (λx, r * f x) l at_top :=
-tendsto.at_top_of_const_mul (inv_pos.2 hr) $ by simpa only [inv_mul_cancel_left₀ hr.ne']
+(tendsto_const_mul_at_top_of_pos hr).2 hf
 
 /-- If a function tends to infinity along a filter, then this function multiplied by a positive
 constant (on the right) also tends to infinity. For a version working in `ℕ` or `ℤ`, use
 `filter.tendsto.at_top_mul_const'` instead. -/
 lemma tendsto.at_top_mul_const (hr : 0 < r) (hf : tendsto f l at_top) :
   tendsto (λx, f x * r) l at_top :=
-by simpa only [mul_comm] using hf.const_mul_at_top hr
+(tendsto_mul_const_at_top_of_pos hr).2 hf
 
 /-- If a function tends to infinity along a filter, then this function divided by a positive
 constant also tends to infinity. -/
@@ -816,27 +896,25 @@ by simpa only [div_eq_mul_inv] using hf.at_top_mul_const (inv_pos.2 hr)
 constant (on the left) tends to negative infinity. -/
 lemma tendsto.neg_const_mul_at_top (hr : r < 0) (hf : tendsto f l at_top) :
   tendsto (λ x, r * f x) l at_bot :=
-by simpa only [(∘), neg_mul_eq_neg_mul, neg_neg]
-  using tendsto_neg_at_top_at_bot.comp (hf.const_mul_at_top (neg_pos.2 hr))
+(tendsto_const_mul_at_bot_of_neg hr).2 hf
 
 /-- If a function tends to infinity along a filter, then this function multiplied by a negative
 constant (on the right) tends to negative infinity. -/
 lemma tendsto.at_top_mul_neg_const (hr : r < 0) (hf : tendsto f l at_top) :
   tendsto (λ x, f x * r) l at_bot :=
-by simpa only [mul_comm] using hf.neg_const_mul_at_top hr
+(tendsto_mul_const_at_bot_of_neg hr).2 hf
 
 /-- If a function tends to negative infinity along a filter, then this function multiplied by
 a positive constant (on the left) also tends to negative infinity. -/
 lemma tendsto.const_mul_at_bot (hr : 0 < r) (hf : tendsto f l at_bot) :
   tendsto (λx, r * f x) l at_bot :=
-by simpa only [(∘), neg_mul_eq_mul_neg, neg_neg]
-  using tendsto_neg_at_top_at_bot.comp ((tendsto_neg_at_bot_at_top.comp hf).const_mul_at_top hr)
+(tendsto_const_mul_at_bot_of_pos hr).2 hf
 
 /-- If a function tends to negative infinity along a filter, then this function multiplied by
 a positive constant (on the right) also tends to negative infinity. -/
 lemma tendsto.at_bot_mul_const (hr : 0 < r) (hf : tendsto f l at_bot) :
   tendsto (λx, f x * r) l at_bot :=
-by simpa only [mul_comm] using hf.const_mul_at_bot hr
+(tendsto_mul_const_at_bot_of_pos hr).2 hf
 
 /-- If a function tends to negative infinity along a filter, then this function divided by
 a positive constant also tends to negative infinity. -/
@@ -848,14 +926,61 @@ by simpa only [div_eq_mul_inv] using hf.at_bot_mul_const (inv_pos.2 hr)
 a negative constant (on the left) tends to positive infinity. -/
 lemma tendsto.neg_const_mul_at_bot (hr : r < 0) (hf : tendsto f l at_bot) :
   tendsto (λ x, r * f x) l at_top :=
-by simpa only [(∘), neg_mul_eq_neg_mul, neg_neg]
-  using tendsto_neg_at_bot_at_top.comp (hf.const_mul_at_bot (neg_pos.2 hr))
+(tendsto_const_mul_at_top_of_neg hr).2 hf
 
 /-- If a function tends to negative infinity along a filter, then this function multiplied by
 a negative constant (on the right) tends to positive infinity. -/
 lemma tendsto.at_bot_mul_neg_const (hr : r < 0) (hf : tendsto f l at_bot) :
   tendsto (λ x, f x * r) l at_top :=
-by simpa only [mul_comm] using hf.neg_const_mul_at_bot hr
+(tendsto_mul_const_at_top_of_neg hr).2 hf
+
+/-- If `f` tends to infinity along a nontrivial filter `l`, then `λ x, r * f x` tends to infinity
+if and only if `0 < r. `-/
+lemma tendsto_const_mul_at_top_iff_pos [ne_bot l] (h : tendsto f l at_top) :
+  tendsto (λ x, r * f x) l at_top ↔ 0 < r :=
+by simp [tendsto_const_mul_at_top_iff, h, h.not_tendsto disjoint_at_top_at_bot]
+
+/-- If `f` tends to infinity along a nontrivial filter `l`, then `λ x, f x * r` tends to infinity
+if and only if `0 < r. `-/
+lemma tendsto_mul_const_at_top_iff_pos [ne_bot l] (h : tendsto f l at_top) :
+  tendsto (λ x, f x * r) l at_top ↔ 0 < r :=
+by simp only [mul_comm _ r, tendsto_const_mul_at_top_iff_pos h]
+
+/-- If `f` tends to negative infinity along a nontrivial filter `l`, then `λ x, r * f x` tends to
+infinity if and only if `r < 0. `-/
+lemma tendsto_const_mul_at_top_iff_neg [ne_bot l] (h : tendsto f l at_bot) :
+  tendsto (λ x, r * f x) l at_top ↔ r < 0 :=
+by simp [tendsto_const_mul_at_top_iff, h, h.not_tendsto disjoint_at_bot_at_top]
+
+/-- If `f` tends to negative infinity along a nontrivial filter `l`, then `λ x, f x * r` tends to
+infinity if and only if `r < 0. `-/
+lemma tendsto_mul_const_at_top_iff_neg [ne_bot l] (h : tendsto f l at_bot) :
+  tendsto (λ x, f x * r) l at_top ↔ r < 0 :=
+by simp only [mul_comm _ r, tendsto_const_mul_at_top_iff_neg h]
+
+/-- If `f` tends to negative infinity along a nontrivial filter `l`, then `λ x, r * f x` tends to
+negative infinity if and only if `0 < r. `-/
+lemma tendsto_const_mul_at_bot_iff_pos [ne_bot l] (h : tendsto f l at_bot) :
+  tendsto (λ x, r * f x) l at_bot ↔ 0 < r :=
+by simp [tendsto_const_mul_at_bot_iff, h, h.not_tendsto disjoint_at_bot_at_top]
+
+/-- If `f` tends to negative infinity along a nontrivial filter `l`, then `λ x, f x * r` tends to
+negative infinity if and only if `0 < r. `-/
+lemma tendsto_mul_const_at_bot_iff_pos [ne_bot l] (h : tendsto f l at_bot) :
+  tendsto (λ x, f x * r) l at_bot ↔ 0 < r :=
+by simp only [mul_comm _ r, tendsto_const_mul_at_bot_iff_pos h]
+
+/-- If `f` tends to infinity along a nontrivial filter `l`, then `λ x, r * f x` tends to negative
+infinity if and only if `r < 0. `-/
+lemma tendsto_const_mul_at_bot_iff_neg [ne_bot l] (h : tendsto f l at_top) :
+  tendsto (λ x, r * f x) l at_bot ↔ r < 0 :=
+by simp [tendsto_const_mul_at_bot_iff, h, h.not_tendsto disjoint_at_top_at_bot]
+
+/-- If `f` tends to infinity along a nontrivial filter `l`, then `λ x, f x * r` tends to negative
+infinity if and only if `r < 0. `-/
+lemma tendsto_mul_const_at_bot_iff_neg [ne_bot l] (h : tendsto f l at_top) :
+  tendsto (λ x, f x * r) l at_bot ↔ r < 0 :=
+by simp only [mul_comm _ r, tendsto_const_mul_at_bot_iff_neg h]
 
 lemma tendsto_const_mul_pow_at_top {c : α} {n : ℕ}
   (hn : n ≠ 0) (hc : 0 < c) : tendsto (λ x, c * x^n) at_top at_top :=
@@ -863,13 +988,7 @@ tendsto.const_mul_at_top hc (tendsto_pow_at_top hn)
 
 lemma tendsto_const_mul_pow_at_top_iff {c : α} {n : ℕ} :
   tendsto (λ x, c * x^n) at_top at_top ↔ n ≠ 0 ∧ 0 < c :=
-begin
-  refine ⟨λ h, ⟨_, _⟩, λ h, tendsto_const_mul_pow_at_top h.1 h.2⟩,
-  { rintro rfl,
-    simpa only [pow_zero, not_tendsto_const_at_top] using h },
-  { rcases ((h.eventually_gt_at_top 0).and (eventually_ge_at_top 0)).exists with ⟨k, hck, hk⟩,
-    exact pos_of_mul_pos_left hck (pow_nonneg hk _) },
-end
+by simp [tendsto_const_mul_at_top_iff, not_tendsto_pow_at_top_at_bot, and.comm]
 
 lemma tendsto_neg_const_mul_pow_at_top {c : α} {n : ℕ}
   (hn : n ≠ 0) (hc : c < 0) : tendsto (λ x, c * x^n) at_top at_bot :=

--- a/src/order/filter/at_top_bot.lean
+++ b/src/order/filter/at_top_bot.lean
@@ -851,6 +851,8 @@ lemma tendsto_mul_const_at_bot_of_neg (hr : r < 0) :
   tendsto (λ x, f x * r) l at_bot ↔ tendsto f l at_top :=
 by simpa only [mul_comm] using tendsto_const_mul_at_bot_of_neg hr
 
+/-- The function `λ x, r * f x` tends to infinity along a nontrivial filter if and only if `r > 0`
+and `f` tends to infinity or `r < 0` and `f` tends to negative infinity. -/
 lemma tendsto_const_mul_at_top_iff [ne_bot l] :
   tendsto (λ x, r * f x) l at_top ↔ 0 < r ∧ tendsto f l at_top ∨ r < 0 ∧ tendsto f l at_bot :=
 begin
@@ -860,17 +862,71 @@ begin
   { simp [hr, hr.not_lt, tendsto_const_mul_at_top_of_pos] }
 end
 
+/-- The function `λ x, f x * r` tends to infinity along a nontrivial filter if and only if `r > 0`
+and `f` tends to infinity or `r < 0` and `f` tends to negative infinity. -/
 lemma tendsto_mul_const_at_top_iff [ne_bot l] :
   tendsto (λ x, f x * r) l at_top ↔ 0 < r ∧ tendsto f l at_top ∨ r < 0 ∧ tendsto f l at_bot :=
 by simp only [mul_comm _ r, tendsto_const_mul_at_top_iff]
 
+/-- The function `λ x, r * f x` tends to negative infinity along a nontrivial filter if and only if
+`r > 0` and `f` tends to negative infinity or `r < 0` and `f` tends to infinity. -/
 lemma tendsto_const_mul_at_bot_iff [ne_bot l] :
   tendsto (λ x, r * f x) l at_bot ↔ 0 < r ∧ tendsto f l at_bot ∨ r < 0 ∧ tendsto f l at_top :=
 by simp only [← tendsto_neg_at_top_iff, ← mul_neg, tendsto_const_mul_at_top_iff, neg_neg]
 
+/-- The function `λ x, f x * r` tends to negative infinity along a nontrivial filter if and only if
+`r > 0` and `f` tends to negative infinity or `r < 0` and `f` tends to infinity. -/
 lemma tendsto_mul_const_at_bot_iff [ne_bot l] :
   tendsto (λ x, f x * r) l at_bot ↔ 0 < r ∧ tendsto f l at_bot ∨ r < 0 ∧ tendsto f l at_top :=
 by simp only [mul_comm _ r, tendsto_const_mul_at_bot_iff]
+
+/-- If `f` tends to infinity along a nontrivial filter `l`, then `λ x, r * f x` tends to infinity
+if and only if `0 < r. `-/
+lemma tendsto_const_mul_at_top_iff_pos [ne_bot l] (h : tendsto f l at_top) :
+  tendsto (λ x, r * f x) l at_top ↔ 0 < r :=
+by simp [tendsto_const_mul_at_top_iff, h, h.not_tendsto disjoint_at_top_at_bot]
+
+/-- If `f` tends to infinity along a nontrivial filter `l`, then `λ x, f x * r` tends to infinity
+if and only if `0 < r. `-/
+lemma tendsto_mul_const_at_top_iff_pos [ne_bot l] (h : tendsto f l at_top) :
+  tendsto (λ x, f x * r) l at_top ↔ 0 < r :=
+by simp only [mul_comm _ r, tendsto_const_mul_at_top_iff_pos h]
+
+/-- If `f` tends to negative infinity along a nontrivial filter `l`, then `λ x, r * f x` tends to
+infinity if and only if `r < 0. `-/
+lemma tendsto_const_mul_at_top_iff_neg [ne_bot l] (h : tendsto f l at_bot) :
+  tendsto (λ x, r * f x) l at_top ↔ r < 0 :=
+by simp [tendsto_const_mul_at_top_iff, h, h.not_tendsto disjoint_at_bot_at_top]
+
+/-- If `f` tends to negative infinity along a nontrivial filter `l`, then `λ x, f x * r` tends to
+infinity if and only if `r < 0. `-/
+lemma tendsto_mul_const_at_top_iff_neg [ne_bot l] (h : tendsto f l at_bot) :
+  tendsto (λ x, f x * r) l at_top ↔ r < 0 :=
+by simp only [mul_comm _ r, tendsto_const_mul_at_top_iff_neg h]
+
+/-- If `f` tends to negative infinity along a nontrivial filter `l`, then `λ x, r * f x` tends to
+negative infinity if and only if `0 < r. `-/
+lemma tendsto_const_mul_at_bot_iff_pos [ne_bot l] (h : tendsto f l at_bot) :
+  tendsto (λ x, r * f x) l at_bot ↔ 0 < r :=
+by simp [tendsto_const_mul_at_bot_iff, h, h.not_tendsto disjoint_at_bot_at_top]
+
+/-- If `f` tends to negative infinity along a nontrivial filter `l`, then `λ x, f x * r` tends to
+negative infinity if and only if `0 < r. `-/
+lemma tendsto_mul_const_at_bot_iff_pos [ne_bot l] (h : tendsto f l at_bot) :
+  tendsto (λ x, f x * r) l at_bot ↔ 0 < r :=
+by simp only [mul_comm _ r, tendsto_const_mul_at_bot_iff_pos h]
+
+/-- If `f` tends to infinity along a nontrivial filter `l`, then `λ x, r * f x` tends to negative
+infinity if and only if `r < 0. `-/
+lemma tendsto_const_mul_at_bot_iff_neg [ne_bot l] (h : tendsto f l at_top) :
+  tendsto (λ x, r * f x) l at_bot ↔ r < 0 :=
+by simp [tendsto_const_mul_at_bot_iff, h, h.not_tendsto disjoint_at_top_at_bot]
+
+/-- If `f` tends to infinity along a nontrivial filter `l`, then `λ x, f x * r` tends to negative
+infinity if and only if `r < 0. `-/
+lemma tendsto_mul_const_at_bot_iff_neg [ne_bot l] (h : tendsto f l at_top) :
+  tendsto (λ x, f x * r) l at_bot ↔ r < 0 :=
+by simp only [mul_comm _ r, tendsto_const_mul_at_bot_iff_neg h]
 
 /-- If a function tends to infinity along a filter, then this function multiplied by a positive
 constant (on the left) also tends to infinity. For a version working in `ℕ` or `ℤ`, use
@@ -933,54 +989,6 @@ a negative constant (on the right) tends to positive infinity. -/
 lemma tendsto.at_bot_mul_neg_const (hr : r < 0) (hf : tendsto f l at_bot) :
   tendsto (λ x, f x * r) l at_top :=
 (tendsto_mul_const_at_top_of_neg hr).2 hf
-
-/-- If `f` tends to infinity along a nontrivial filter `l`, then `λ x, r * f x` tends to infinity
-if and only if `0 < r. `-/
-lemma tendsto_const_mul_at_top_iff_pos [ne_bot l] (h : tendsto f l at_top) :
-  tendsto (λ x, r * f x) l at_top ↔ 0 < r :=
-by simp [tendsto_const_mul_at_top_iff, h, h.not_tendsto disjoint_at_top_at_bot]
-
-/-- If `f` tends to infinity along a nontrivial filter `l`, then `λ x, f x * r` tends to infinity
-if and only if `0 < r. `-/
-lemma tendsto_mul_const_at_top_iff_pos [ne_bot l] (h : tendsto f l at_top) :
-  tendsto (λ x, f x * r) l at_top ↔ 0 < r :=
-by simp only [mul_comm _ r, tendsto_const_mul_at_top_iff_pos h]
-
-/-- If `f` tends to negative infinity along a nontrivial filter `l`, then `λ x, r * f x` tends to
-infinity if and only if `r < 0. `-/
-lemma tendsto_const_mul_at_top_iff_neg [ne_bot l] (h : tendsto f l at_bot) :
-  tendsto (λ x, r * f x) l at_top ↔ r < 0 :=
-by simp [tendsto_const_mul_at_top_iff, h, h.not_tendsto disjoint_at_bot_at_top]
-
-/-- If `f` tends to negative infinity along a nontrivial filter `l`, then `λ x, f x * r` tends to
-infinity if and only if `r < 0. `-/
-lemma tendsto_mul_const_at_top_iff_neg [ne_bot l] (h : tendsto f l at_bot) :
-  tendsto (λ x, f x * r) l at_top ↔ r < 0 :=
-by simp only [mul_comm _ r, tendsto_const_mul_at_top_iff_neg h]
-
-/-- If `f` tends to negative infinity along a nontrivial filter `l`, then `λ x, r * f x` tends to
-negative infinity if and only if `0 < r. `-/
-lemma tendsto_const_mul_at_bot_iff_pos [ne_bot l] (h : tendsto f l at_bot) :
-  tendsto (λ x, r * f x) l at_bot ↔ 0 < r :=
-by simp [tendsto_const_mul_at_bot_iff, h, h.not_tendsto disjoint_at_bot_at_top]
-
-/-- If `f` tends to negative infinity along a nontrivial filter `l`, then `λ x, f x * r` tends to
-negative infinity if and only if `0 < r. `-/
-lemma tendsto_mul_const_at_bot_iff_pos [ne_bot l] (h : tendsto f l at_bot) :
-  tendsto (λ x, f x * r) l at_bot ↔ 0 < r :=
-by simp only [mul_comm _ r, tendsto_const_mul_at_bot_iff_pos h]
-
-/-- If `f` tends to infinity along a nontrivial filter `l`, then `λ x, r * f x` tends to negative
-infinity if and only if `r < 0. `-/
-lemma tendsto_const_mul_at_bot_iff_neg [ne_bot l] (h : tendsto f l at_top) :
-  tendsto (λ x, r * f x) l at_bot ↔ r < 0 :=
-by simp [tendsto_const_mul_at_bot_iff, h, h.not_tendsto disjoint_at_top_at_bot]
-
-/-- If `f` tends to infinity along a nontrivial filter `l`, then `λ x, f x * r` tends to negative
-infinity if and only if `r < 0. `-/
-lemma tendsto_mul_const_at_bot_iff_neg [ne_bot l] (h : tendsto f l at_top) :
-  tendsto (λ x, f x * r) l at_bot ↔ r < 0 :=
-by simp only [mul_comm _ r, tendsto_const_mul_at_bot_iff_neg h]
 
 lemma tendsto_const_mul_pow_at_top {c : α} {n : ℕ}
   (hn : n ≠ 0) (hc : 0 < c) : tendsto (λ x, c * x^n) at_top at_top :=


### PR DESCRIPTION
Other API changes:

* assume `m ≠ 0` instead of `1 ≤ m` in `le_self_pow`;
* generalize `linear_ordered_semiring.to_no_max_order` to `ordered_semiring.to_no_max_order`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
