### PR TITLE
[Merged by Bors] - fix(analysis/inner_product_space,geometry/euclidean): two deterministic timeout fixes

### DIFF
--- a/src/analysis/inner_product_space/l2_space.lean
+++ b/src/analysis/inner_product_space/l2_space.lean
@@ -501,7 +501,7 @@ by rw [is_hilbert_sum.linear_isometry_equiv_symm_apply_single,
 
 @[simp] protected lemma coe_mk (hsp : ⊤ ≤ (span 𝕜 (set.range v)).topological_closure) :
   ⇑(hilbert_basis.mk hv hsp) = v :=
-funext $ orthonormal.linear_isometry_equiv_symm_apply_single_one hv _
+by apply (funext $ orthonormal.linear_isometry_equiv_symm_apply_single_one hv hsp)
 
 /-- An orthonormal family of vectors whose span has trivial orthogonal complement is a Hilbert
 basis. -/

--- a/src/geometry/euclidean/oriented_angle.lean
+++ b/src/geometry/euclidean/oriented_angle.lean
@@ -879,7 +879,7 @@ begin
            star_ring_end_apply, star_trivial],
   rw [finset.sum_insert (dec_trivial : (0 : fin 2) ∉ ({1} : finset (fin 2))),
       finset.sum_singleton],
-  field_simp [norm_ne_zero_iff.2 hx, norm_ne_zero_iff.2 hy],
+  field_simp only [norm_ne_zero_iff.2 hx, norm_ne_zero_iff.2 hy, ne.def, not_false_iff],
   ring
 end
 


### PR DESCRIPTION
CI seems to be having some issues after #16356, which I can't reproduce with `-T100000` locally but can with `-T90000`. This PR speeds up `analysis/inner_product_space/l2_space.lean:hilbert_basis.coe_mk` (which was already investigated before in #15271) and `geometry/euclidean/oriented_angle.lean:inner_eq_norm_mul_norm_mul_cos_oangle`.

---

Related staging failures:
https://github.com/leanprover-community/mathlib/runs/8172030515?check_suite_focus=true
https://github.com/leanprover-community/mathlib/runs/8171565369?check_suite_focus=true

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
