### PR TITLE
[Merged by Bors] - fix(algebra/category/Module): speedup

### DIFF
--- a/src/algebra/category/Module/change_of_rings.lean
+++ b/src/algebra/category/Module/change_of_rings.lean
@@ -110,7 +110,7 @@ Extension of scalars is a functor where an `R`-module `M` is sent to `S ⊗ M` a
 `l : M1 ⟶ M2` is sent to `s ⊗ m ↦ s ⊗ l m`
 -/
 def map' {M1 M2 : Module.{v} R} (l : M1 ⟶ M2) : (obj' f M1) ⟶ (obj' f M2) :=
-@linear_map.base_change R S M1 M2 _ _ ((algebra_map S _).comp f).to_algebra _ _ _ _ l
+by apply (@linear_map.base_change R S M1 M2 _ _ ((algebra_map S _).comp f).to_algebra _ _ _ _ l)
 
 lemma map'_id {M : Module.{v} R} : map' f (𝟙 M) = 𝟙 _ :=
 linear_map.ext $ λ (x : obj' f M),

--- a/src/algebra/category/Module/change_of_rings.lean
+++ b/src/algebra/category/Module/change_of_rings.lean
@@ -110,6 +110,7 @@ Extension of scalars is a functor where an `R`-module `M` is sent to `S ⊗ M` a
 `l : M1 ⟶ M2` is sent to `s ⊗ m ↦ s ⊗ l m`
 -/
 def map' {M1 M2 : Module.{v} R} (l : M1 ⟶ M2) : (obj' f M1) ⟶ (obj' f M2) :=
+-- The "by apply" part makes this require 75% fewer heartbeats to process (#16371).
 by apply (@linear_map.base_change R S M1 M2 _ _ ((algebra_map S _).comp f).to_algebra _ _ _ _ l)
 
 lemma map'_id {M : Module.{v} R} : map' f (𝟙 M) = 𝟙 _ :=


### PR DESCRIPTION
This change makes `map'` go from using 95,000+ heartbeats (that is, `lean --make -T95000` fails locally) to using less than 25,000. With `set_option pp.all true`, the output of `#print map'` is the same before and after this change, but note that this is a `def` so perhaps using the `apply` tactic is not appropriate.

---

This is affecting a couple of open PRs (#16281 and #16355).

<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
