### PR TITLE
[Merged by Bors] - feat(linear_algebra/ray): `same_ray_map_iff` for injective linear maps

### DIFF
--- a/src/linear_algebra/ray.lean
+++ b/src/linear_algebra/ray.lean
@@ -128,7 +128,7 @@ h.imp (λ hx, by rw [hx, map_zero]) $ or.imp (λ hy, by rw [hy, map_zero]) $
 
 /-- The images of two vectors under an injective linear map are on the same ray if and only if the
 original vectors are on the same ray. -/
-lemma _root_.function.injective.same_ray_map_iff {f : M →ₗ[R] N}
+lemma _root_.function.injective.same_ray_map_iff {F : Type*} [linear_map_class F R M N] {f : F}
   (hf : function.injective f) : same_ray R (f x) (f y) ↔ same_ray R x y :=
 by simp only [same_ray, map_zero, ← hf.eq_iff, map_smul]
 

--- a/src/linear_algebra/ray.lean
+++ b/src/linear_algebra/ray.lean
@@ -134,8 +134,8 @@ by simp only [same_ray, map_zero, ← hf.eq_iff, map_smul]
 
 /-- The images of two vectors under a linear equivalence are on the same ray if and only if the
 original vectors are on the same ray. -/
-@[simp] lemma _root_.same_ray_map_iff (e : M ≃ₗ[R] N) : same_ray R (e x) (e y) ↔ same_ray R x y :=
-(show function.injective e.to_linear_map, from e.injective).same_ray_map_iff
+@[simp] lemma _root_.same_ray_map_iff {F : Type*} [linear_equiv_class F R M N] (e : F) : same_ray R (e x) (e y) ↔ same_ray R x y :=
+function.injective.same_ray_map_iff (equiv_like.injective e)
 
 /-- If two vectors are on the same ray then both scaled by the same action are also on the same
 ray. -/

--- a/src/linear_algebra/ray.lean
+++ b/src/linear_algebra/ray.lean
@@ -126,10 +126,23 @@ lemma map (f : M →ₗ[R] N) (h : same_ray R x y) : same_ray R (f x) (f y) :=
 h.imp (λ hx, by rw [hx, map_zero]) $ or.imp (λ hy, by rw [hy, map_zero]) $
   λ ⟨r₁, r₂, hr₁, hr₂, h⟩, ⟨r₁, r₂, hr₁, hr₂, by rw [←f.map_smul, ←f.map_smul, h]⟩
 
+/-- The images of two vectors under an injective linear map are on the same ray if and only if the
+original vectors are on the same ray. -/
+lemma _root_.function.injective.same_ray_map_iff {f : M →ₗ[R] N}
+  (hf : function.injective f) : same_ray R (f x) (f y) ↔ same_ray R x y :=
+begin
+  refine ⟨λ h, _, λ h, h.map f⟩,
+  rcases h with h | h | ⟨r₁, r₂, hr₁, hr₂, h⟩,
+  { exact or.inl ((f.map_eq_zero_iff hf).1 h) },
+  { exact or.inr (or.inl ((f.map_eq_zero_iff hf).1 h)) },
+  { simp_rw [←map_smul, hf.eq_iff] at h,
+    exact or.inr (or.inr ⟨r₁, r₂, hr₁, hr₂, h⟩) }
+end
+
 /-- The images of two vectors under a linear equivalence are on the same ray if and only if the
 original vectors are on the same ray. -/
 @[simp] lemma _root_.same_ray_map_iff (e : M ≃ₗ[R] N) : same_ray R (e x) (e y) ↔ same_ray R x y :=
-⟨λ h, by simpa using same_ray.map e.symm.to_linear_map h, same_ray.map e.to_linear_map⟩
+(show function.injective e.to_linear_map, from e.injective).same_ray_map_iff
 
 /-- If two vectors are on the same ray then both scaled by the same action are also on the same
 ray. -/

--- a/src/linear_algebra/ray.lean
+++ b/src/linear_algebra/ray.lean
@@ -134,8 +134,7 @@ by simp only [same_ray, map_zero, ← hf.eq_iff, map_smul]
 
 /-- The images of two vectors under a linear equivalence are on the same ray if and only if the
 original vectors are on the same ray. -/
-@[simp] lemma _root_.same_ray_map_iff {F : Type*} [linear_equiv_class F R M N] (e : F) :
-  same_ray R (e x) (e y) ↔ same_ray R x y :=
+@[simp] lemma _root_.same_ray_map_iff (e : M ≃ₗ[R] N) : same_ray R (e x) (e y) ↔ same_ray R x y :=
 function.injective.same_ray_map_iff (equiv_like.injective e)
 
 /-- If two vectors are on the same ray then both scaled by the same action are also on the same

--- a/src/linear_algebra/ray.lean
+++ b/src/linear_algebra/ray.lean
@@ -130,14 +130,7 @@ h.imp (λ hx, by rw [hx, map_zero]) $ or.imp (λ hy, by rw [hy, map_zero]) $
 original vectors are on the same ray. -/
 lemma _root_.function.injective.same_ray_map_iff {f : M →ₗ[R] N}
   (hf : function.injective f) : same_ray R (f x) (f y) ↔ same_ray R x y :=
-begin
-  refine ⟨λ h, _, λ h, h.map f⟩,
-  rcases h with h | h | ⟨r₁, r₂, hr₁, hr₂, h⟩,
-  { exact or.inl ((f.map_eq_zero_iff hf).1 h) },
-  { exact or.inr (or.inl ((f.map_eq_zero_iff hf).1 h)) },
-  { simp_rw [←map_smul, hf.eq_iff] at h,
-    exact or.inr (or.inr ⟨r₁, r₂, hr₁, hr₂, h⟩) }
-end
+by simp only [same_ray, map_zero, ← hf.eq_iff, map_smul]
 
 /-- The images of two vectors under a linear equivalence are on the same ray if and only if the
 original vectors are on the same ray. -/

--- a/src/linear_algebra/ray.lean
+++ b/src/linear_algebra/ray.lean
@@ -134,7 +134,8 @@ by simp only [same_ray, map_zero, ← hf.eq_iff, map_smul]
 
 /-- The images of two vectors under a linear equivalence are on the same ray if and only if the
 original vectors are on the same ray. -/
-@[simp] lemma _root_.same_ray_map_iff {F : Type*} [linear_equiv_class F R M N] (e : F) : same_ray R (e x) (e y) ↔ same_ray R x y :=
+@[simp] lemma _root_.same_ray_map_iff {F : Type*} [linear_equiv_class F R M N] (e : F) :
+  same_ray R (e x) (e y) ↔ same_ray R x y :=
 function.injective.same_ray_map_iff (equiv_like.injective e)
 
 /-- If two vectors are on the same ray then both scaled by the same action are also on the same


### PR DESCRIPTION
Add a stronger version of `same_ray_map_iff`, for any injective linear
map rather than just a linear equivalence.



---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
