### PR TITLE
[Merged by Bors] - chore(category_theory/sites/compatible_plus): speed up ι_plus_comp_iso_hom

### DIFF
--- a/src/category_theory/sites/compatible_plus.lean
+++ b/src/category_theory/sites/compatible_plus.lean
@@ -116,11 +116,17 @@ lemma ι_plus_comp_iso_hom (X) (W) : F.map (colimit.ι _ W) ≫ (J.plus_comp_iso
   (J.diagram_comp_iso F P X.unop).hom.app W ≫ colimit.ι _ W :=
 begin
   delta diagram_comp_iso plus_comp_iso,
-  dsimp [is_colimit.cocone_point_unique_up_to_iso],
-  simp only [← category.assoc],
+  simp only [is_colimit.desc_cocone_morphism_hom, is_colimit.unique_up_to_iso_hom,
+    cocones.forget_map, iso.trans_hom, nat_iso.of_components_hom_app, functor.map_iso_hom,
+    ← category.assoc],
   erw (is_colimit_of_preserves F (colimit.is_colimit (J.diagram P (unop X)))).fac,
-  dsimp,
-  simp,
+  simp only [category.assoc, has_limit.iso_of_nat_iso_hom_π, iso.symm_hom,
+    cover.multicospan_comp_hom_inv_left, eq_to_hom_refl, category.comp_id,
+    limit.cone_point_unique_up_to_iso_hom_comp, functor.map_cone_π_app,
+    multiequalizer.multifork_π_app_left, multiequalizer.lift_ι, functor.map_comp, eq_self_iff_true,
+    category.assoc, iso.trans_hom, iso.cancel_iso_hom_left, nat_iso.of_components_hom_app,
+    colimit.cocone_ι, category.assoc, has_colimit.iso_of_nat_iso_ι_hom],
+
 end
 
 @[simp, reassoc]


### PR DESCRIPTION
This failed when experimenting with `-T90000`; just squeezing the `simp`s seems to help a fair bit.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
