### PR TITLE
[Merged by Bors] - feat(data/nat/parity): add lemmas nat.bit{0|1}_mod_bit0

### DIFF
--- a/src/data/nat/basic.lean
+++ b/src/data/nat/basic.lean
@@ -1626,9 +1626,9 @@ by { convert bit1_lt_bit0_iff, refl, }
 | ff := bit0_le_bit1_iff
 | tt := bit1_le_bit1
 
-@[simp] lemma bit0_mod_two : bit0 n % 2 = 0 := by { rw nat.mod_two_of_bodd, simp }
+lemma bit0_mod_two : bit0 n % 2 = 0 := by { rw nat.mod_two_of_bodd, simp }
 
-@[simp] lemma bit1_mod_two : bit1 n % 2 = 1 := by { rw nat.mod_two_of_bodd, simp }
+lemma bit1_mod_two : bit1 n % 2 = 1 := by { rw nat.mod_two_of_bodd, simp }
 
 lemma pos_of_bit0_pos {n : ℕ} (h : 0 < bit0 n) : 0 < n :=
 by { cases n, cases h, apply succ_pos, }

--- a/src/data/nat/parity.lean
+++ b/src/data/nat/parity.lean
@@ -210,6 +210,21 @@ by rw [bit0_eq_two_mul m, ←nat.div_div_eq_div_mul, bit0_div_two]
 @[simp] lemma bit1_div_bit0 : bit1 n / bit0 m = n / m :=
 by rw [bit0_eq_two_mul, ←nat.div_div_eq_div_mul, bit1_div_two]
 
+@[simp] lemma bit0_mod_bit0 : bit0 n % bit0 m = bit0 (n % m) :=
+by rw [bit0_eq_two_mul n, bit0_eq_two_mul m, bit0_eq_two_mul (n % m), nat.mul_mod_mul_left]
+
+@[simp] lemma bit1_mod_bit0 : bit1 n % bit0 m = bit1 (n % m) :=
+begin
+  have h₁ := congr_arg (λ x, 2 * x + 1) (nat.div_add_mod n m),
+  dsimp only at h₁,
+  rw [mul_add, ← mul_assoc, add_assoc, ← bit0_eq_two_mul m, ← bit0_eq_two_mul n,
+      ← bit0_eq_two_mul (n % m), ← succ_eq_add_one, ← nat.bit1_eq_succ_bit0,
+      ← succ_eq_add_one, ← nat.bit1_eq_succ_bit0] at h₁,
+  have h₂ := nat.div_add_mod (bit1 n) (bit0 m),
+  rw [bit1_div_bit0] at h₂,
+  exact add_left_cancel (h₂.trans h₁.symm),
+end
+
 -- Here are examples of how `parity_simps` can be used with `nat`.
 
 example (m n : ℕ) (h : even m) : ¬ even (n + 3) ↔ even (m^2 + m + n) :=

--- a/src/data/nat/parity.lean
+++ b/src/data/nat/parity.lean
@@ -215,11 +215,9 @@ by rw [bit0_eq_two_mul n, bit0_eq_two_mul m, bit0_eq_two_mul (n % m), nat.mul_mo
 
 @[simp] lemma bit1_mod_bit0 : bit1 n % bit0 m = bit1 (n % m) :=
 begin
-  have h₁ := congr_arg (λ x, 2 * x + 1) (nat.div_add_mod n m),
-  dsimp only at h₁,
-  rw [mul_add, ← mul_assoc, add_assoc, ← bit0_eq_two_mul m, ← bit0_eq_two_mul n,
-      ← bit0_eq_two_mul (n % m), ← succ_eq_add_one, ← nat.bit1_eq_succ_bit0,
-      ← succ_eq_add_one, ← nat.bit1_eq_succ_bit0] at h₁,
+  have h₁ := congr_arg bit1 (nat.div_add_mod n m),
+  -- `∀ m n : ℕ, bit0 m * n = bit0 (m * n)` seems to be missing...
+  rw [bit1_add, bit0_eq_two_mul, ← mul_assoc, ← bit0_eq_two_mul] at h₁,
   have h₂ := nat.div_add_mod (bit1 n) (bit0 m),
   rw [bit1_div_bit0] at h₂,
   exact add_left_cancel (h₂.trans h₁.symm),


### PR DESCRIPTION
This PR adds a pair of lemmas that complement [nat.bit0_div_bit0](https://leanprover-community.github.io/mathlib_docs/data/nat/parity.html#nat.bit0_div_bit0) and [nat.bit1_div_bit0](https://leanprover-community.github.io/mathlib_docs/data/nat/parity.html#nat.bit1_div_bit0), namely
```lean
@[simp] lemma bit0_mod_bit0 : bit0 n % bit0 m = bit0 (n % m) := ...
@[simp] lemma bit1_mod_bit0 : bit1 n % bit0 m = bit1 (n % m) := ...
```
They will be helpful in an upcoming PR that introduces a `norm_num` extension for computing Jacobi symbols.

[Zulip thread](https://leanprover.zulipchat.com/#narrow/stream/217875-Is-there-code-for-X.3F/topic/bit0.2Fbit1.20and.20mod/near/297228893)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
