### PR TITLE
[Merged by Bors] - feat(linear_algebra/{basic, affine_space/restrict}): better support for restriction of affine and linear maps

### DIFF
--- a/src/algebra/lie/of_associative.lean
+++ b/src/algebra/lie/of_associative.lean
@@ -220,13 +220,13 @@ end
 
 variables (N x)
 
-lemma to_endomorphism_comp_subtype_mem (m : M) (hm : m ∈ N) :
-  (to_endomorphism R L M x).comp (N : submodule R M).subtype ⟨m, hm⟩ ∈ N :=
+lemma to_endomorphism_comp_subtype_mem (m : M) (hm : m ∈ (N : submodule R M)) :
+  (to_endomorphism R L M x).comp (N : submodule R M).subtype ⟨m, hm⟩ ∈ (N : submodule R M) :=
 by simpa using N.lie_mem hm
 
 @[simp] lemma to_endomorphism_restrict_eq_to_endomorphism
   (h := N.to_endomorphism_comp_subtype_mem x) :
-  ((to_endomorphism R L M x).restrict h : (N : submodule R M) →ₗ[R] N) = to_endomorphism R L N x :=
+  (to_endomorphism R L M x).restrict h = to_endomorphism R L N x :=
 by { ext, simp [linear_map.restrict_apply], }
 
 end lie_submodule

--- a/src/linear_algebra/affine_space/restrict.lean
+++ b/src/linear_algebra/affine_space/restrict.lean
@@ -68,10 +68,9 @@ lemma affine_map.restrict.linear
   [nonempty E] [nonempty F]
   (hEF : E.map φ ≤ F) :
   (φ.restrict hEF).linear = φ.linear.restrict
-    (by {
-      change E.direction ≤ F.direction.comap φ.linear,
-      rw [←submodule.map_le_iff_le_comap, ←affine_subspace.map_direction],
-      exact affine_subspace.direction_le hEF }) := rfl
+    (by { change E.direction ≤ F.direction.comap φ.linear,
+          rw [←submodule.map_le_iff_le_comap, ←affine_subspace.map_direction],
+          exact affine_subspace.direction_le hEF }) := rfl
 
 lemma affine_map.restrict.injective
   {φ : P₁ →ᵃ[k] P₂}

--- a/src/linear_algebra/affine_space/restrict.lean
+++ b/src/linear_algebra/affine_space/restrict.lean
@@ -23,7 +23,7 @@ This file defines restrictions of affine maps.
 * The restriction in surjective if the codomain is the image of the domain.
 -/
 
-variables {k V₁ P₁ V₂ P₂ : Type} [ring k]
+variables {k V₁ P₁ V₂ P₂ : Type*} [ring k]
   [add_comm_group V₁] [add_comm_group V₂]
   [module k V₁] [module k V₂]
   [add_torsor V₁ P₁] [add_torsor V₂ P₂]

--- a/src/linear_algebra/affine_space/restrict.lean
+++ b/src/linear_algebra/affine_space/restrict.lean
@@ -1,4 +1,27 @@
+/-
+Copyright (c) 2022 Paul Reichert. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Paul Reichert
+-/
 import linear_algebra.affine_space.affine_subspace
+
+/-!
+# Affine map restrictions
+
+This file defines restrictions of affine maps.
+
+## Main definitions
+
+* The domain and codomain of an affine map can be restricted using
+  `affine_map.restrict`.
+
+## Main theorems
+
+* The associated linear map of the restriction is the restriction of the
+  linear map associated to the original affine map.
+* The restriction is injective if the original map is injective.
+* The restriction in surjective if the codomain is the image of the domain.
+-/
 
 variables {k V₁ P₁ V₂ P₂ : Type} [ring k]
   [add_comm_group V₁] [add_comm_group V₂]
@@ -66,12 +89,4 @@ begin
   rw [affine_subspace.mem_map] at hx,
   obtain ⟨y, hy, rfl⟩ := hx,
   exact ⟨⟨y, hy⟩, rfl⟩,
-end
-
-lemma affine_map.bijective_iff_linear_bijective
-  (φ : P₁ →ᵃ[k] P₂) :
-function.bijective φ ↔ function.bijective φ.linear :=
-begin
-  simp only [function.bijective,
-    φ.injective_iff_linear_injective, φ.surjective_iff_linear_surjective],
 end

--- a/src/linear_algebra/affine_space/restrict.lean
+++ b/src/linear_algebra/affine_space/restrict.lean
@@ -83,11 +83,12 @@ begin
 end
 
 lemma affine_map.restrict.surjective
-  (φ : P₁ →ᵃ[k] P₂) {E : affine_subspace k P₁} [nonempty E] :
-  function.surjective (affine_map.restrict φ (le_refl (E.map φ))) :=
+  (φ : P₁ →ᵃ[k] P₂) {E : affine_subspace k P₁} {F : affine_subspace k P₂}
+  [nonempty E] [nonempty F] (h : E.map φ = F) :
+  function.surjective (affine_map.restrict φ (le_of_eq h)) :=
 begin
-  rintro ⟨x, hx : x ∈ E.map φ⟩,
-  rw [affine_subspace.mem_map] at hx,
+  rintro ⟨x, hx : x ∈ F⟩,
+  rw [←h, affine_subspace.mem_map] at hx,
   obtain ⟨y, hy, rfl⟩ := hx,
   exact ⟨⟨y, hy⟩, rfl⟩,
 end

--- a/src/linear_algebra/affine_space/restrict.lean
+++ b/src/linear_algebra/affine_space/restrict.lean
@@ -39,6 +39,7 @@ begin
 end
 
 local attribute [instance, nolint fails_quickly] affine_subspace.nonempty_map
+local attribute [instance, nolint fails_quickly] affine_subspace.to_add_torsor
 
 /-- Restrict domain and codomain of an affine map to the given submodules. -/
 def affine_map.restrict

--- a/src/linear_algebra/affine_space/restrict.lean
+++ b/src/linear_algebra/affine_space/restrict.lean
@@ -63,14 +63,19 @@ lemma affine_map.restrict.coe_apply
   (hEF : E.map φ ≤ F) (x : E) :
   ↑(φ.restrict hEF x) = φ x := rfl
 
+lemma affine_map.restrict.linear_aux
+  {φ : P₁ →ᵃ[k] P₂} {E : affine_subspace k P₁} {F : affine_subspace k P₂}
+  (hEF : E.map φ ≤ F) : E.direction ≤ F.direction.comap φ.linear :=
+begin
+  rw [←submodule.map_le_iff_le_comap, ←affine_subspace.map_direction],
+  exact affine_subspace.direction_le hEF,
+end
+
 lemma affine_map.restrict.linear
   (φ : P₁ →ᵃ[k] P₂) {E : affine_subspace k P₁} {F : affine_subspace k P₂}
   [nonempty E] [nonempty F]
   (hEF : E.map φ ≤ F) :
-  (φ.restrict hEF).linear = φ.linear.restrict
-    (by { change E.direction ≤ F.direction.comap φ.linear,
-          rw [←submodule.map_le_iff_le_comap, ←affine_subspace.map_direction],
-          exact affine_subspace.direction_le hEF }) := rfl
+  (φ.restrict hEF).linear = φ.linear.restrict (affine_map.restrict.linear_aux hEF) := rfl
 
 lemma affine_map.restrict.injective
   {φ : P₁ →ᵃ[k] P₂}

--- a/src/linear_algebra/affine_space/restrict.lean
+++ b/src/linear_algebra/affine_space/restrict.lean
@@ -41,7 +41,7 @@ end
 local attribute [instance, nolint fails_quickly] affine_subspace.nonempty_map
 local attribute [instance, nolint fails_quickly] affine_subspace.to_add_torsor
 
-/-- Restrict domain and codomain of an affine map to the given submodules. -/
+/-- Restrict domain and codomain of an affine map to the given subspaces. -/
 def affine_map.restrict
   (φ : P₁ →ᵃ[k] P₂) {E : affine_subspace k P₁} {F : affine_subspace k P₂}
   [nonempty E] [nonempty F]

--- a/src/linear_algebra/affine_space/restrict.lean
+++ b/src/linear_algebra/affine_space/restrict.lean
@@ -49,8 +49,8 @@ def affine_map.restrict
 begin
   refine ⟨_, _, _⟩,
   { exact λ x, ⟨φ x, hEF $ affine_subspace.mem_map.mpr ⟨x, x.property, rfl⟩⟩ },
-  { refine φ.linear.restrict' _,
-    rw [←affine_subspace.map_direction],
+  { refine φ.linear.restrict (_ : E.direction ≤ F.direction.comap φ.linear),
+    rw [←submodule.map_le_iff_le_comap, ←affine_subspace.map_direction],
     exact affine_subspace.direction_le hEF },
   { intros p v,
     simp only [subtype.ext_iff, subtype.coe_mk, affine_subspace.coe_vadd],
@@ -67,8 +67,11 @@ lemma affine_map.restrict.linear
   (φ : P₁ →ᵃ[k] P₂) {E : affine_subspace k P₁} {F : affine_subspace k P₂}
   [nonempty E] [nonempty F]
   (hEF : E.map φ ≤ F) :
-  (φ.restrict hEF).linear = φ.linear.restrict'
-    (by { rw [←affine_subspace.map_direction], exact affine_subspace.direction_le hEF }) := rfl
+  (φ.restrict hEF).linear = φ.linear.restrict
+    (by {
+      change E.direction ≤ F.direction.comap φ.linear,
+      rw [←submodule.map_le_iff_le_comap, ←affine_subspace.map_direction],
+      exact affine_subspace.direction_le hEF }) := rfl
 
 lemma affine_map.restrict.injective
   {φ : P₁ →ᵃ[k] P₂}

--- a/src/linear_algebra/affine_space/restrict.lean
+++ b/src/linear_algebra/affine_space/restrict.lean
@@ -1,0 +1,77 @@
+import linear_algebra.affine_space.affine_subspace
+
+variables {k V₁ P₁ V₂ P₂ : Type} [ring k]
+  [add_comm_group V₁] [add_comm_group V₂]
+  [module k V₁] [module k V₂]
+  [add_torsor V₁ P₁] [add_torsor V₂ P₂]
+
+include V₁ V₂
+
+/- not an instance because it loops with `nonempty` -/
+lemma affine_subspace.nonempty_map {E : affine_subspace k P₁} [Ene : nonempty E]
+  {φ : P₁ →ᵃ[k] P₂} : nonempty (E.map φ) :=
+begin
+  obtain ⟨x, hx⟩ := id Ene,
+  refine ⟨⟨φ x, affine_subspace.mem_map.mpr ⟨x, hx, rfl⟩⟩⟩,
+end
+
+local attribute [instance, nolint fails_quickly] affine_subspace.nonempty_map
+
+/-- Restrict domain and codomain of an affine map to the given submodules. -/
+def affine_map.restrict
+  (φ : P₁ →ᵃ[k] P₂) {E : affine_subspace k P₁} {F : affine_subspace k P₂}
+  [nonempty E] [nonempty F]
+  (hEF : E.map φ ≤ F) : E →ᵃ[k] F :=
+begin
+  refine ⟨_, _, _⟩,
+  { exact λ x, ⟨φ x, hEF $ affine_subspace.mem_map.mpr ⟨x, x.property, rfl⟩⟩ },
+  { refine φ.linear.restrict' _,
+    rw [←affine_subspace.map_direction],
+    exact affine_subspace.direction_le hEF },
+  { intros p v,
+    simp only [subtype.ext_iff, subtype.coe_mk, affine_subspace.coe_vadd],
+    apply affine_map.map_vadd },
+end
+
+lemma affine_map.restrict.coe_apply
+  (φ : P₁ →ᵃ[k] P₂) {E : affine_subspace k P₁} {F : affine_subspace k P₂}
+  [nonempty E] [nonempty F]
+  (hEF : E.map φ ≤ F) (x : E) :
+↑(φ.restrict hEF x) = φ x := rfl
+
+lemma affine_map.restrict.linear
+  (φ : P₁ →ᵃ[k] P₂) {E : affine_subspace k P₁} {F : affine_subspace k P₂}
+  [nonempty E] [nonempty F]
+  (hEF : E.map φ ≤ F) :
+(φ.restrict hEF).linear = φ.linear.restrict'
+  (by { rw [←affine_subspace.map_direction], exact affine_subspace.direction_le hEF }) := rfl
+
+lemma affine_map.restrict.injective
+  {φ : P₁ →ᵃ[k] P₂}
+  (hφ : function.injective φ) {E : affine_subspace k P₁} {F : affine_subspace k P₂}
+  [nonempty E] [nonempty F]
+  (hEF : E.map φ ≤ F) :
+function.injective (affine_map.restrict φ hEF) :=
+begin
+  intros x y h,
+  simp only [subtype.ext_iff, subtype.coe_mk, affine_map.restrict.coe_apply] at h ⊢,
+  exact hφ h,
+end
+
+lemma affine_map.restrict.surjective
+  (φ : P₁ →ᵃ[k] P₂) {E : affine_subspace k P₁} [nonempty E] :
+function.surjective (affine_map.restrict φ (le_refl (E.map φ))) :=
+begin
+  rintro ⟨x, hx : x ∈ E.map φ⟩,
+  rw [affine_subspace.mem_map] at hx,
+  obtain ⟨y, hy, rfl⟩ := hx,
+  exact ⟨⟨y, hy⟩, rfl⟩,
+end
+
+lemma affine_map.bijective_iff_linear_bijective
+  (φ : P₁ →ᵃ[k] P₂) :
+function.bijective φ ↔ function.bijective φ.linear :=
+begin
+  simp only [function.bijective,
+    φ.injective_iff_linear_injective, φ.surjective_iff_linear_surjective],
+end

--- a/src/linear_algebra/affine_space/restrict.lean
+++ b/src/linear_algebra/affine_space/restrict.lean
@@ -60,21 +60,21 @@ lemma affine_map.restrict.coe_apply
   (φ : P₁ →ᵃ[k] P₂) {E : affine_subspace k P₁} {F : affine_subspace k P₂}
   [nonempty E] [nonempty F]
   (hEF : E.map φ ≤ F) (x : E) :
-↑(φ.restrict hEF x) = φ x := rfl
+  ↑(φ.restrict hEF x) = φ x := rfl
 
 lemma affine_map.restrict.linear
   (φ : P₁ →ᵃ[k] P₂) {E : affine_subspace k P₁} {F : affine_subspace k P₂}
   [nonempty E] [nonempty F]
   (hEF : E.map φ ≤ F) :
-(φ.restrict hEF).linear = φ.linear.restrict'
-  (by { rw [←affine_subspace.map_direction], exact affine_subspace.direction_le hEF }) := rfl
+  (φ.restrict hEF).linear = φ.linear.restrict'
+    (by { rw [←affine_subspace.map_direction], exact affine_subspace.direction_le hEF }) := rfl
 
 lemma affine_map.restrict.injective
   {φ : P₁ →ᵃ[k] P₂}
   (hφ : function.injective φ) {E : affine_subspace k P₁} {F : affine_subspace k P₂}
   [nonempty E] [nonempty F]
   (hEF : E.map φ ≤ F) :
-function.injective (affine_map.restrict φ hEF) :=
+  function.injective (affine_map.restrict φ hEF) :=
 begin
   intros x y h,
   simp only [subtype.ext_iff, subtype.coe_mk, affine_map.restrict.coe_apply] at h ⊢,
@@ -83,7 +83,7 @@ end
 
 lemma affine_map.restrict.surjective
   (φ : P₁ →ᵃ[k] P₂) {E : affine_subspace k P₁} [nonempty E] :
-function.surjective (affine_map.restrict φ (le_refl (E.map φ))) :=
+  function.surjective (affine_map.restrict φ (le_refl (E.map φ))) :=
 begin
   rintro ⟨x, hx : x ∈ E.map φ⟩,
   rw [affine_subspace.mem_map] at hx,

--- a/src/linear_algebra/basic.lean
+++ b/src/linear_algebra/basic.lean
@@ -917,7 +917,10 @@ section restrict
 
 variables [add_comm_monoid M₁] [module R M₁]
 
-/-- Restrict domain and codomain of a linear map. -/
+/--
+Alternative version of `restrict` to restrict domain and codomain
+of a linear map.
+-/
 @[simps] def restrict' (f : M →ₗ[R] M₁)
   {p : submodule R M} {q : submodule R M₁} (hf : p.map f ≤ q) :
   p →ₗ[R] q :=

--- a/src/linear_algebra/basic.lean
+++ b/src/linear_algebra/basic.lean
@@ -184,7 +184,7 @@ ext $ assume b, rfl
   p.subtype.comp (cod_restrict p f h) = f :=
 ext $ assume b, rfl
 
-/-- Restrict domain and codomain of an endomorphism. -/
+/-- Restrict domain and codomain of a linear map. -/
 def restrict (f : M →ₗ[R] M₁) {p : submodule R M} {q : submodule R M₁} (hf : ∀ x ∈ p, f x ∈ q) :
   p →ₗ[R] q :=
 (f.dom_restrict p).cod_restrict q $ set_like.forall.2 hf
@@ -627,6 +627,12 @@ end
 lemma range_map_nonempty (N : submodule R M) :
   (set.range (λ ϕ, submodule.map ϕ N : (M →ₛₗ[σ₁₂] M₂) → submodule R₂ M₂)).nonempty :=
 ⟨_, set.mem_range.mpr ⟨0, rfl⟩⟩
+
+/-- Restrict domain and codomain of a linear map. -/
+@[simps] def restrict' [add_comm_monoid M₁] [module R M₁] (f : M →ₗ[R] M₁)
+  {p : submodule R M} {q : submodule R M₁} (hf : p.map f ≤ q) :
+  p →ₗ[R] q :=
+f.restrict (λ x hx, hf ⟨x, hx, rfl⟩)
 
 end
 

--- a/src/linear_algebra/basic.lean
+++ b/src/linear_algebra/basic.lean
@@ -628,12 +628,6 @@ lemma range_map_nonempty (N : submodule R M) :
   (set.range (λ ϕ, submodule.map ϕ N : (M →ₛₗ[σ₁₂] M₂) → submodule R₂ M₂)).nonempty :=
 ⟨_, set.mem_range.mpr ⟨0, rfl⟩⟩
 
-/-- Restrict domain and codomain of a linear map. -/
-@[simps] def restrict' [add_comm_monoid M₁] [module R M₁] (f : M →ₗ[R] M₁)
-  {p : submodule R M} {q : submodule R M₁} (hf : p.map f ≤ q) :
-  p →ₗ[R] q :=
-f.restrict (λ x hx, hf ⟨x, hx, rfl⟩)
-
 end
 
 variables {F : Type*} [sc : semilinear_map_class F σ₁₂ M M₂]
@@ -918,6 +912,18 @@ variables [ring_hom_comp_triple σ₁₂ σ₂₃ σ₁₃]
 variables [module R M] [module R₂ M₂] [module R₃ M₃]
 include R
 open submodule
+
+section restrict
+
+variables [add_comm_monoid M₁] [module R M₁]
+
+/-- Restrict domain and codomain of a linear map. -/
+@[simps] def restrict' (f : M →ₗ[R] M₁)
+  {p : submodule R M} {q : submodule R M₁} (hf : p.map f ≤ q) :
+  p →ₗ[R] q :=
+f.restrict (λ x hx, hf ⟨x, hx, rfl⟩)
+
+end restrict
 
 section finsupp
 variables {γ : Type*} [has_zero γ]

--- a/src/linear_algebra/basic.lean
+++ b/src/linear_algebra/basic.lean
@@ -185,23 +185,28 @@ ext $ assume b, rfl
 ext $ assume b, rfl
 
 /-- Restrict domain and codomain of an endomorphism. -/
-def restrict (f : M →ₗ[R] M) {p : submodule R M} (hf : ∀ x ∈ p, f x ∈ p) : p →ₗ[R] p :=
-(f.dom_restrict p).cod_restrict p $ set_like.forall.2 hf
+def restrict (f : M →ₗ[R] M₁) {p : submodule R M} {q : submodule R M₁} (hf : ∀ x ∈ p, f x ∈ q) :
+  p →ₗ[R] q :=
+(f.dom_restrict p).cod_restrict q $ set_like.forall.2 hf
+
+@[simp] lemma restrict_coe_apply (f : M →ₗ[R] M₁) {p : submodule R M} {q : submodule R M₁}
+  (hf : ∀ x ∈ p, f x ∈ q) (x : p) : ↑(f.restrict hf x) = f x := rfl
 
 lemma restrict_apply
-  {f : M →ₗ[R] M} {p : submodule R M} (hf : ∀ x ∈ p, f x ∈ p) (x : p) :
+  {f : M →ₗ[R] M₁} {p : submodule R M} {q : submodule R M₁} (hf : ∀ x ∈ p, f x ∈ q) (x : p) :
   f.restrict hf x = ⟨f x, hf x.1 x.2⟩ := rfl
 
-lemma subtype_comp_restrict {f : M →ₗ[R] M} {p : submodule R M} (hf : ∀ x ∈ p, f x ∈ p) :
-  p.subtype.comp (f.restrict hf) = f.dom_restrict p := rfl
+lemma subtype_comp_restrict {f : M →ₗ[R] M₁} {p : submodule R M} {q : submodule R M₁}
+  (hf : ∀ x ∈ p, f x ∈ q) :
+  q.subtype.comp (f.restrict hf) = f.dom_restrict p := rfl
 
 lemma restrict_eq_cod_restrict_dom_restrict
-  {f : M →ₗ[R] M} {p : submodule R M} (hf : ∀ x ∈ p, f x ∈ p) :
-  f.restrict hf = (f.dom_restrict p).cod_restrict p (λ x, hf x.1 x.2) := rfl
+  {f : M →ₗ[R] M₁} {p : submodule R M} {q : submodule R M₁} (hf : ∀ x ∈ p, f x ∈ q) :
+  f.restrict hf = (f.dom_restrict p).cod_restrict q (λ x, hf x.1 x.2) := rfl
 
 lemma restrict_eq_dom_restrict_cod_restrict
-  {f : M →ₗ[R] M} {p : submodule R M} (hf : ∀ x, f x ∈ p) :
-  f.restrict (λ x _, hf x) = (f.cod_restrict p hf).dom_restrict p := rfl
+  {f : M →ₗ[R] M₁} {p : submodule R M} {q : submodule R M₁} (hf : ∀ x, f x ∈ q) :
+  f.restrict (λ x _, hf x) = (f.cod_restrict q hf).dom_restrict p := rfl
 
 instance unique_of_left [subsingleton M] : unique (M →ₛₗ[σ₁₂] M₂) :=
 { uniq := λ f, ext $ λ x, by rw [subsingleton.elim x 0, map_zero, map_zero],
@@ -1118,7 +1123,9 @@ lemma range_cod_restrict {τ₂₁ : R₂ →+* R} [ring_hom_surjective τ₂₁
   range (cod_restrict p f hf) = comap p.subtype f.range :=
 by simpa only [range_eq_map] using map_cod_restrict _ _ _ _
 
-lemma ker_restrict {p : submodule R M} {f : M →ₗ[R] M} (hf : ∀ x : M, x ∈ p → f x ∈ p) :
+lemma ker_restrict [add_comm_monoid M₁] [module R M₁]
+  {p : submodule R M} {q : submodule R M₁} {f : M →ₗ[R] M₁}
+  (hf : ∀ x : M, x ∈ p → f x ∈ q) :
   ker (f.restrict hf) = (f.dom_restrict p).ker :=
 by rw [restrict_eq_cod_restrict_dom_restrict, ker_cod_restrict]
 

--- a/src/linear_algebra/basic.lean
+++ b/src/linear_algebra/basic.lean
@@ -913,21 +913,6 @@ variables [module R M] [module R₂ M₂] [module R₃ M₃]
 include R
 open submodule
 
-section restrict
-
-variables [add_comm_monoid M₁] [module R M₁]
-
-/--
-Alternative version of `restrict` to restrict domain and codomain
-of a linear map.
--/
-@[simps] def restrict' (f : M →ₗ[R] M₁)
-  {p : submodule R M} {q : submodule R M₁} (hf : p.map f ≤ q) :
-  p →ₗ[R] q :=
-f.restrict (λ x hx, hf ⟨x, hx, rfl⟩)
-
-end restrict
-
 section finsupp
 variables {γ : Type*} [has_zero γ]
 


### PR DESCRIPTION
- Generalizes `linear_map.restrict` to allow independent but simultaneous restriction of domain and codomain in a backwards compatible way (except for one type inference failure in `algebra.lie.of_associative` that had to be fixed manually).
- Adds `linear_map.restrict'` as an alternative to `linear_map.restrict` that takes a proof that the image of the new domain must be contained in the new codomain.
- Introduces `affine_map.restrict` for restriction of affine maps in a new file called `linear_algebra/affine_space/restrict.lean` and lemmata about injectivity, surjectivity and the coercion of a restricted map.
Design choice: A new file `restrict.lean` was created because `affine_subspace.lean` is already very long and `affine_map.lean` does not know about affine maps.
---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
