### PR TITLE
feat({tactic + test}/remove_subs): new tactic for splitting nat-subtractions

### DIFF
--- a/src/tactic/remove_subs.lean
+++ b/src/tactic/remove_subs.lean
@@ -9,12 +9,15 @@ import tactic.linarith
 # `remove_subs` -- a tactic for splitting `ℕ`-subtractions
 
 Subtraction between natural numbers is defined to be `0` when it should yield a negative number.
-The tactic `remove_subs` tries to remedy this by doing a case-split on each `ℕ`-subtractions,
+The tactic `remove_subs` tries to remedy this by doing a case-split on each `ℕ`-subtraction,
 depending on whether the subtraction is truncated to `0` or coincides with the usual notion of
 subtraction.
 
 See the tactic-doc for more details.
 -/
+
+namespace tactic
+namespace remove_subs
 
 lemma nat.le_cases (a b : ℕ) : a - b = 0 ∨ ∃ c, a = b + c :=
 begin
@@ -25,11 +28,9 @@ begin
     exact ⟨_, rfl⟩ },
 end
 
-namespace tactic
-
 /--  Given a list `l` of pairs of expressions, `local_constants_last l` reorders the list `l`
 so that all pairs `(a,b) ∈ l` with `a` a local constant appear last.  This is used in `get_sub`
-so that the replacement of the `ℕ`-subtractions begins with the subtractions where an old term
+so that the replacement of the `ℕ`-subtractions begins with subtractions where an old term
 can be substituted, rather than simply rewritten. -/
 meta def local_constants_last (l : list (expr × expr)) : list (expr × expr) :=
 let (csts, not_csts) := l.partition (λ e : expr × expr, e.1.is_local_constant) in not_csts ++ csts
@@ -81,7 +82,10 @@ swap,
     fail"could not rewrite: something went wrong",
 swap
 
+end remove_subs
+
 namespace interactive
+open remove_subs
 setup_tactic_parser
 
 /--  The tactic `remove_subs` looks for `ℕ`-subtractions in the goal and it recursively replaces

--- a/src/tactic/remove_subs.lean
+++ b/src/tactic/remove_subs.lean
@@ -28,10 +28,11 @@ end
 namespace tactic
 
 /--  `get_sub e` extracts a list of pairs `(a, b)` from the expression `e`, where `a - b` is a
-subexpression of `e`. -/
+subexpression of `e`.  While doing this, it also assumes that `e` was the target and rewrites the
+target to reduce the number of nat-subtractions, using the identity `a - b - c = a - (b + c)`. -/
 meta def get_sub : expr → tactic (list (expr × expr))
 | `(%%a - %%b - %%c) := do bc ← to_expr ``(%%b + %%c),
-                           to_expr ``(nat.sub_sub) >>= rewrite_target,
+                           to_expr ``(nat.sub_sub %%a %%b %%c) >>= rewrite_target,
                            [ga, gb, gc] ← [a, b, c].mmap get_sub,
                            return ((a, bc) :: (ga ++ gb ++ gc))
 | `(%%a - %%b)       := do [ga, gb] ← [a, b].mmap get_sub,

--- a/src/tactic/remove_subs.lean
+++ b/src/tactic/remove_subs.lean
@@ -8,12 +8,12 @@ import tactic.linarith
 /-!
 # `remove_subs` -- a tactic for splitting nat-subtractions
 
-The tactic `remove_subs` looks for nat-subtractions in the goal and it recursively replaces
-any subexpression of the form `a - b` by two branches: one where `a ≤ b` and `a - b` is replaced
-by `0` and one where `b < a` and it tries to replace `a` by `b + c`, for some `c : ℕ`.
+Subtraction between natural numbers is defined to be `0` when it should yield a negative number.
+The tactic `remove_subs` tries to remedy this by doing a case-split on each nat-subtractions,
+depending on whether the subtraction is truncated to `0` or coincides with the usual notion of
+subtraction.
 
-If `remove_subs` is called with the optional flag `!`, then, after the case splits, the tactic
-also tries `linarith` on all remaining goals.
+See the tactic-doc for more details.
 -/
 
 lemma nat.le_cases (a b : ℕ) : a - b = 0 ∨ ∃ c, a = b + c :=
@@ -65,11 +65,12 @@ swap
 namespace interactive
 setup_tactic_parser
 
-/--  Iterate replacing a subtraction with two cases, depending on whether the subtraction is
-truncated to `0` or it is an "actual" subtraction.
+/--  The tactic `remove_subs` looks for nat-subtractions in the goal and it recursively replaces
+any subexpression of the form `a - b` by two branches: one where `a ≤ b` and `a - b` is replaced
+by `0` and one where `b < a` and it tries to replace `a` by `b + c`, for some `c : ℕ`.
 
-If an optional `!` is passed, then, once the case splits in `remove_subs` are done,
-the tactic also tries `linarith` on all remaining goals. -/
+If `remove_subs` is called with the optional flag `!`, then, after the case splits, the tactic
+also tries `linarith` on all remaining goals. -/
 meta def remove_subs (la : parse (tk "!" )?) : tactic unit := focus1 $ do
 repeat (do
   some (a, b) ← list.last' <$> (target >>= get_sub),
@@ -79,3 +80,8 @@ ite la.is_some (any_goals' $ try $ `[ linarith ]) skip
 end interactive
 
 end tactic
+add_tactic_doc
+{ name       := "remove_subs",
+  category   := doc_category.tactic,
+  decl_names := [`tactic.interactive.remove_subs],
+  tags       := ["arithmetic", "case bashing", "finishing"] }

--- a/src/tactic/remove_subs.lean
+++ b/src/tactic/remove_subs.lean
@@ -58,9 +58,9 @@ meta def get_sub : expr → tactic (list (expr × expr))
 
 /--  `remove_one_sub a b` assumes that the expression `a - b` occurs in the target.
 It splits two cases:
-*  `a ≤ b`, in which case it replaces `a - b` with `0` and introduces the inequality `a ≤ b` into
+*  if `a ≤ b`, then it replaces `a - b` with `0` and introduces the inequality `a ≤ b` into
    the local context;
-*  writes `a = b + c`, for some `c` and tries to substitute this equality.
+*  otherwise, it writes `a = b + c`, for some `c` and tries to substitute this equality.
 -/
 meta def remove_one_sub (a b : expr) : tactic unit := do
 -- introduce names with the following meanings:
@@ -90,7 +90,7 @@ setup_tactic_parser
 
 /--  The tactic `remove_subs` looks for `ℕ`-subtractions in the goal and it recursively replaces
 any subexpression of the form `a - b` by two branches: one where `a ≤ b` and `a - b` is replaced
-by `0` and one where `b < a` and it tries to replace `a` by `b + c`, for some `c : ℕ`.
+by `0` and one where `∃ c : ℕ, a = b + c` and it tries to replace `a` by `b + c`.
 
 `remove_subs` fails if there are no `ℕ`-subtractions.
 

--- a/src/tactic/remove_subs.lean
+++ b/src/tactic/remove_subs.lean
@@ -1,0 +1,81 @@
+/-
+Copyright (c) 2022 Damiano Testa. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Damiano Testa
+-/
+import tactic.linarith
+
+/-!
+# `remove_subs` -- a tactic for splitting nat-subtractions
+
+The tactic `remove_subs` looks for nat-subtractions in the goal and it recursively replaces
+any subexpression of the form `a - b` by two branches: one where `a ≤ b` and `a - b` is replaced
+by `0` and one where `b < a` and it tries to replace `a` by `b + c`, for some `c : ℕ`.
+
+If `remove_subs` is called with the optional flag `!`, then, after the case splits, the tactic
+also tries `linarith` on all remaining goals.
+-/
+
+lemma nat.le_cases (a b : ℕ) : a - b = 0 ∨ ∃ c, a = b + c :=
+begin
+  by_cases ab : a ≤ b,
+  { exact or.inl (tsub_eq_zero_of_le ab) },
+  { refine or.inr _,
+    rcases nat.exists_eq_add_of_le ((not_le.mp ab).le) with ⟨c, rfl⟩,
+    exact ⟨_, rfl⟩ },
+end
+
+namespace tactic
+
+/--  `get_sub e` extracts a list of pairs `(a, b)` from the expression `e`, where `a - b` is a
+subexpression of `e`. -/
+meta def get_sub : expr → tactic (list (expr × expr))
+| `(%%a - %%b) := do [ga, gb] ← [a, b].mmap get_sub,
+                    return ((a, b) :: (ga ++ gb))
+| (expr.app f a) := do [gf, ga] ← [f, a].mmap get_sub,
+                    return (gf ++ ga)
+| _ := pure []
+
+/--  `remove_one_sub a b` assumes that the expression `a - b` occurs in the target.
+It splits two cases:
+*  `a ≤ b`, in which case it replaces `a - b` with `0`, introduces the inequality `a ≤ b` into
+   the local context and tries `simp`;
+*  writes `a = b + c`, for some `c`, tries to substitute this equality and tries `simp`.
+-/
+meta def remove_one_sub (a b : expr) : tactic unit := do
+-- introduce names with the following meanings:
+-- `eq0 : a - b = 0`, `exis : ∃ c, a = b + c`, `var = c`, `ide : a = b + c`
+[eq0, exis, var, ide] ← ["h", "k", "x", "hx"].mmap (λ y, get_unused_name y),
+-- either `a ≤ b` or `a = b + c`
+cases `(nat.le_cases %%a %%b) [eq0, exis],
+-- on the branch where `a ≤ b`...
+  prf0 ← get_local eq0,
+  rewrite_target prf0,
+  to_expr ``(nat.sub_eq_zero_iff_le) >>= λ x, rewrite_hyp x prf0,
+swap,
+-- on the branch where `b < a`...
+  get_local exis >>= λ x, cases x [var, ide],
+  -- either substitute or rewrite
+  get_local ide >>= (λ x, subst x <|> rewrite_target x),
+  vare ← get_local var,
+  to_expr ``(nat.add_sub_cancel_left %%b %%vare) >>= rewrite_target <|>
+    fail"could not rewrite: something went wrong",
+swap
+
+namespace interactive
+setup_tactic_parser
+
+/--  Iterate replacing a subtraction with two cases, depending on whether the subtraction is
+truncated to `0` or it is an "actual" subtraction.
+
+If an optional `!` is passed, then, once the case splits in `remove_subs` are done,
+the tactic also tries `linarith` on all remaining goals. -/
+meta def remove_subs (la : parse (tk "!" )?) : tactic unit := focus1 $ do
+repeat (do
+  some (a, b) ← list.last' <$> (target >>= get_sub),
+  remove_one_sub a b ),
+ite la.is_some (any_goals' $ try $ `[ linarith ]) skip
+
+end interactive
+
+end tactic

--- a/src/tactic/remove_subs.lean
+++ b/src/tactic/remove_subs.lean
@@ -14,6 +14,9 @@ depending on whether the subtraction is truncated to `0` or coincides with the u
 subtraction.
 
 See the tactic-doc for more details.
+
+##  Todo
+*  allow `remove_subs` to work `at` some hypotheses?
 -/
 
 namespace tactic

--- a/test/remove_subs.lean
+++ b/test/remove_subs.lean
@@ -1,0 +1,8 @@
+import tactic.remove_subs
+
+example {i l : ℕ} (i1 : 1 ≤ i) (il : i + 1 ≤ l) :
+  i - 1 + (l - i - 1 + 1) + 1 = l :=
+by remove_subs!
+
+example (n m : ℕ) : nat.pred n - m = nat.pred (n - m) :=
+show n - 1 - m = n - m - 1, by remove_subs!

--- a/test/remove_subs.lean
+++ b/test/remove_subs.lean
@@ -7,5 +7,31 @@ by remove_subs!
 example (n m : ℕ) : nat.pred n - m = nat.pred (n - m) :=
 show n - 1 - m = n - m - 1, by remove_subs!
 
+--1.36s
 example (n m : ℕ) : nat.pred n - m = nat.pred (n - m) :=
 by remove_subs!
+
+--3.05s
+example {a b c d e f g : ℕ} : a - b - c - d - e - f - g = a - f - g - e - c - d - b :=
+by remove_subs!
+
+example {a b c : ℕ} : a + b + c = a + b + c :=
+begin
+  success_if_fail_with_msg {remove_subs} "no ℕ-subtraction found",
+  refl
+end
+
+example {a b c : ℕ} : (a : ℤ) - b = a - b :=
+begin
+  success_if_fail_with_msg {remove_subs} "no ℕ-subtraction found",
+  refl
+end
+
+example {R} [ring R] {a b c d : ℕ} : (a : R) - b = a - b ∨ a - b = c - d :=
+by remove_subs; exact or.inl rfl
+
+example {R} [ring R] {a b c d : ℕ} : ite (a - b = a - b) ((a : R) - b = a - b) (a - b = c - d) :=
+by remove_subs; rw if_pos rfl
+
+example (a b : ℕ) : min a b + (a - b) = a :=
+by remove_subs; simp; assumption

--- a/test/remove_subs.lean
+++ b/test/remove_subs.lean
@@ -7,11 +7,9 @@ by remove_subs!
 example (n m : ℕ) : nat.pred n - m = nat.pred (n - m) :=
 show n - 1 - m = n - m - 1, by remove_subs!
 
---1.36s
 example (n m : ℕ) : nat.pred n - m = nat.pred (n - m) :=
 by remove_subs!
 
---3.05s
 example {a b c d e f g : ℕ} : a - b - c - d - e - f - g = a - f - g - e - c - d - b :=
 by remove_subs!
 
@@ -27,7 +25,7 @@ begin
   refl
 end
 
-example {R} [ring R] {a b c d : ℕ} : (a : R) - b = a - b ∨ a - b = c - d :=
+example {R} [ring R] {a b c d : ℕ} : (a : R) - b = a - b ∨ a - b = c - d ∨ (a : ℤ) - b = c - d :=
 by remove_subs; exact or.inl rfl
 
 example {R} [ring R] {a b c d : ℕ} : ite (a - b = a - b) ((a : R) - b = a - b) (a - b = c - d) :=

--- a/test/remove_subs.lean
+++ b/test/remove_subs.lean
@@ -6,3 +6,6 @@ by remove_subs!
 
 example (n m : ℕ) : nat.pred n - m = nat.pred (n - m) :=
 show n - 1 - m = n - m - 1, by remove_subs!
+
+example (n m : ℕ) : nat.pred n - m = nat.pred (n - m) :=
+by remove_subs!


### PR DESCRIPTION
More complete tactic at #16443.

A simple-minded tactic that splits nat-subtractions in a goal into the two obvious cases and continues until all nat-subtractions have been removed.

[Zulip](https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/Automatic.20proof.20for.20nat-sub)

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
