### PR TITLE
[Merged by Bors] - feat(group_theory/commutator): Add `commutator_element_self`

### DIFF
--- a/src/group_theory/commutator.lean
+++ b/src/group_theory/commutator.lean
@@ -40,6 +40,9 @@ variables (g₁ g₂ g₃ g)
 @[simp] lemma commutator_element_one_left : ⁅(1 : G), g⁆ = 1 :=
 (commute.one_left g).commutator_eq
 
+@[simp] lemma commutator_element_self : ⁅g, g⁆ = 1 :=
+(commute.refl g).commutator_eq
+
 @[simp] lemma commutator_element_inv : ⁅g₁, g₂⁆⁻¹ = ⁅g₂, g₁⁆ :=
 by simp_rw [commutator_element_def, mul_inv_rev, inv_inv, mul_assoc]
 


### PR DESCRIPTION
This PR adds `commutator_element_self`, similar to `commutator_element_one_left` and `commutator_element_one_right`.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
