### PR TITLE
[Merged by Bors] - feat(data/complex/module): define `real_part` and `imaginary_part`

### DIFF
--- a/src/data/complex/module.lean
+++ b/src/data/complex/module.lean
@@ -316,7 +316,7 @@ variables {A : Type*} [add_comm_group A] [module ℂ A] [star_add_monoid A] [sta
 @[simps] def skew_adjoint.neg_I_smul : skew_adjoint A →ₗ[ℝ] self_adjoint A :=
 { to_fun := λ a, ⟨-I • a, by simp only [self_adjoint.mem_iff, neg_smul, star_neg, star_smul,
     star_def, conj_I, skew_adjoint.star_coe_eq, neg_smul_neg]⟩,
-  map_add' := λ a b, by { ext, simp only [add_subgroup.coe_add, smul_add, add_mem_class.mk_add_mk] },
+  map_add' := λ a b, by { ext, simp only [add_subgroup.coe_add, smul_add, add_mem_class.mk_add_mk]},
   map_smul' := λ a b, by { ext, simp only [neg_smul, skew_adjoint.coe_smul, add_subgroup.coe_mk,
     ring_hom.id_apply, self_adjoint.coe_smul, smul_neg, neg_inj], rw smul_comm, } }
 

--- a/src/data/complex/module.lean
+++ b/src/data/complex/module.lean
@@ -7,6 +7,7 @@ import algebra.order.smul
 import data.complex.basic
 import data.fin.vec_notation
 import field_theory.tower
+import algebra.char_p.invertible
 
 /-!
 # Complex number as a vector space over `ℝ`
@@ -31,6 +32,13 @@ part, the embedding of `ℝ` in `ℂ`, and the complex conjugate):
 It also provides a universal property of the complex numbers `complex.lift`, which constructs a
 `ℂ →ₐ[ℝ] A` into any `ℝ`-algebra `A` given a square root of `-1`.
 
+In addition, this file provides a decomposition into `real_part` and `imaginary_part` for any
+element of a `star_module` over `ℂ`.
+
+## Notation
+
+* `ℜ` and `ℑ` for the `real_part` and `imaginary_part`, respectively, in the locale
+  `complex_star_module`.
 -/
 
 namespace complex
@@ -298,5 +306,72 @@ lemma lift_aux_neg_I : lift_aux (-I) ((neg_mul_neg _ _).trans I_mul_I) = conj_ae
 alg_hom_ext $ (lift_aux_apply_I _ _).trans conj_I.symm
 
 end lift
+
+section real_imaginary_part
+
+variables {A : Type*} [add_comm_group A] [module ℂ A] [star_add_monoid A] [star_module ℂ A]
+
+/-- Create a `self_adjoint` element from a `skew_adjoint` element by multiplying by the scalar
+`-complex.I`. -/
+@[simps] def skew_adjoint.neg_I_smul : skew_adjoint A →ₗ[ℝ] self_adjoint A :=
+{ to_fun := λ a, ⟨-I • a, by simp only [self_adjoint.mem_iff, neg_smul, star_neg, star_smul,
+    star_def, conj_I, skew_adjoint.star_coe_eq, neg_smul_neg]⟩,
+  map_add' := λ a b, by { ext, simp only [add_subgroup.coe_add, smul_add, add_mem_class.mk_add_mk] },
+  map_smul' := λ a b, by { ext, simp only [neg_smul, skew_adjoint.coe_smul, add_subgroup.coe_mk,
+    ring_hom.id_apply, self_adjoint.coe_smul, smul_neg, neg_inj], rw smul_comm, } }
+
+lemma skew_adjoint.I_smul_neg_I (a : skew_adjoint A) :
+  I • (skew_adjoint.neg_I_smul a : A) = a :=
+by simp only [smul_smul, skew_adjoint.neg_I_smul_apply_coe, neg_smul, smul_neg, I_mul_I, one_smul,
+  neg_neg]
+
+/-- The real part `ℜ a` of an element `a` of a star module over `ℂ`, as a linear map. This is just
+`self_adjoint_part ℝ`, but we provide it as a separate definition in order to link it with lemmas
+concerning the `imaginary_part`, which doesn't exist in star modules over other rings. -/
+noncomputable def real_part : A →ₗ[ℝ] self_adjoint A := self_adjoint_part ℝ
+
+/-- The imaginary part `ℑ a` of an element `a` of a star module over `ℂ`, as a linear map into the
+self adjoint elements. In a general star module, we have a decomposition into the `self_adjoint`
+and `skew_adjoint` parts, but in a star module over `ℂ` we have
+`real_part_add_I_smul_imaginary_part`, which allows us to decompose into a linear combination of
+`self_adjoint`s. -/
+noncomputable
+def imaginary_part : A →ₗ[ℝ] self_adjoint A := skew_adjoint.neg_I_smul.comp (skew_adjoint_part ℝ)
+
+localized "notation `ℜ` := real_part" in complex_star_module
+localized "notation `ℑ` := imaginary_part" in complex_star_module
+
+@[simp] lemma real_part_apply_coe (a : A) :
+  (ℜ a : A) = (2 : ℝ)⁻¹ • (a + star a) :=
+by { unfold real_part, simp only [self_adjoint_part_apply_coe, inv_of_eq_inv]}
+
+@[simp] lemma imaginary_part_apply_coe (a : A) :
+  (ℑ a : A) = -I • (2 : ℝ)⁻¹ • (a - star a) :=
+begin
+  unfold imaginary_part,
+  simp only [linear_map.coe_comp, skew_adjoint.neg_I_smul_apply_coe, skew_adjoint_part_apply_coe,
+    inv_of_eq_inv],
+end
+
+/-- The standard decomposition of `ℜ a + complex.I • ℑ a = a` of an element of a star module over
+`ℂ` into a linear combination of self adjoint elements. -/
+lemma real_part_add_I_smul_imaginary_part (a : A) : (ℜ a + I • ℑ a : A) = a :=
+by simpa only [smul_smul, real_part_apply_coe, imaginary_part_apply_coe, neg_smul, I_mul_I,
+  one_smul, neg_sub, add_add_sub_cancel, smul_sub, smul_add, neg_sub_neg, inv_of_eq_inv]
+  using inv_of_two_smul_add_inv_of_two_smul ℝ a
+
+@[simp] lemma real_part_I_smul (a : A) : ℜ (I • a) = - ℑ a :=
+by { ext, simp [smul_comm I, smul_sub, sub_eq_add_neg, add_comm] }
+
+@[simp] lemma imaginary_part_I_smul (a : A) : ℑ (I • a) = ℜ a :=
+by { ext, simp [smul_comm I, smul_smul I] }
+
+lemma real_part_smul (z : ℂ) (a : A) : ℜ (z • a) = z.re • ℜ a - z.im • ℑ a :=
+by { nth_rewrite 0 ←re_add_im z, simp [-re_add_im, add_smul, ←smul_smul, sub_eq_add_neg] }
+
+lemma imaginary_part_smul (z : ℂ) (a : A) : ℑ (z • a) = z.re • ℑ a + z.im • ℜ a :=
+by { nth_rewrite 0 ←re_add_im z, simp [-re_add_im, add_smul, ←smul_smul] }
+
+end real_imaginary_part
 
 end complex

--- a/src/data/complex/module.lean
+++ b/src/data/complex/module.lean
@@ -307,7 +307,11 @@ alg_hom_ext $ (lift_aux_apply_I _ _).trans conj_I.symm
 
 end lift
 
+end complex
+
 section real_imaginary_part
+
+open complex
 
 variables {A : Type*} [add_comm_group A] [module ℂ A] [star_add_monoid A] [star_module ℂ A]
 
@@ -373,5 +377,3 @@ lemma imaginary_part_smul (z : ℂ) (a : A) : ℑ (z • a) = z.re • ℑ a + z
 by { nth_rewrite 0 ←re_add_im z, simp [-re_add_im, add_smul, ←smul_smul] }
 
 end real_imaginary_part
-
-end complex


### PR DESCRIPTION
In a generic `star_module` one always has a decomposition of any element into a `self_adjoint_part` and a `skew_self_adjoint` part, but in a star module over `ℂ` we can instead decompose any element into a `real_part` and an `imaginary_part`, both of which are self-adjoint. Here we define these as `ℝ`-linear maps from the star module into the type of its self-adjoint elements and describe the basic relationships between these maps. The decomposition into real and imaginary parts is often useful for reducing arguments about elements of a star module over `ℂ` to the case when the element is self-adjoint.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
