### PR TITLE
[Merged by Bors] - refactor(algebra/order/monoid_lemma_zero_lt): Use `{x : α // 0 ≤ α}`

### DIFF
--- a/src/algebra/order/monoid_lemmas_zero_lt.lean
+++ b/src/algebra/order/monoid_lemmas_zero_lt.lean
@@ -13,8 +13,6 @@ Let `α` be a type with `<` and `0`.  We use the type `{x : α // 0 < x}` of pos
 to prove results about monotonicity of multiplication.  We also introduce the local notation `α>0`
 for the subtype `{x : α // 0 < x}`:
 
-*  the notation `α>0` to stands for `{x : α // 0 < x}`.
-
 If the type `α` also has a multiplication, then we combine this with (`contravariant_`)
 `covariant_class`es to assume that multiplication by positive elements is (strictly) monotone on a
 `mul_zero_class`, `monoid_with_zero`,...
@@ -41,118 +39,100 @@ More specifically, we use extensively the following typeclasses:
 * * `contravariant_class α>0 α (λ x y, y * x) (<)`, abbreviated `mul_pos_reflect_lt α`,
     expressing that multiplication by positive elements on the right is strictly reverse monotone.
 
-##  Formalization comments
+## Notation
 
-We use `α>0 = {x : α // 0 < x}` with a strict inequality since in most cases what happens with `0`
-is clear.  This creates a few bumps in the first couple of proofs, where we have to split cases on
-whether an element is `0` or not, but goes smoothly after that.  A further advantage is that we
-only introduce notation for the positive elements and we do not need also the non-negative ones.
-
-Some lemmas for `partial_order` also have a variant for `preorder`, where the `preorder` version has
-stronger hypotheses.  In this case we put the `preorder` lemma in the `preorder` namespace.
+The following is local notation in this file:
+* `α≥0`: `{x : α // 0 ≤ x}`
+* `α>0`: `{x : α // 0 < x}`
 -/
 
-/- I am changing the file `algebra/order/monoid_lemmas` incrementally, with the idea of
-reproducing almost all of the proofs in `algebra/order/ring` with weaker assumptions. -/
+variable (α : Type*)
 
-universe u
-variable {α : Type u}
-
-/-  Notation for positive elements
+/- Notations for nonnegative and positive elements
 https://
 leanprover.zulipchat.com/#narrow/stream/113488-general/topic/notation.20for.20positive.20elements
 -/
+local notation `α≥0` := {x : α // 0 ≤ x}
 local notation `α>0` := {x : α // 0 < x}
 
-namespace zero_lt
+section abbreviations
+variables [has_mul α] [has_zero α] [preorder α]
 
-section abbreviations_strict_mono
-variables (X : Type u) [has_mul X] [has_zero X] [has_lt X]
+/-- `pos_mul_mono α` is an abbreviation for `covariant_class α≥0 α (λ x y, x * y) (≤)`,
+expressing that multiplication by nonnegative elements on the left is monotone. -/
+abbreviation pos_mul_mono : Prop := covariant_class α≥0 α (λ x y, x * y) (≤)
 
-/--  `zero_lt.pos_mul_strict_mono α` is an abbreviation for
-`covariant_class α>0 α (λ x y, x * y) (<)`,
+/-- `mul_pos_mono α` is an abbreviation for `covariant_class α≥0 α (λ x y, y * x) (≤)`,
+expressing that multiplication by nonnegative elements on the right is monotone. -/
+abbreviation mul_pos_mono : Prop := covariant_class α≥0 α (λ x y, y * x) (≤)
+
+/-- `pos_mul_strict_mono α` is an abbreviation for `covariant_class α>0 α (λ x y, x * y) (<)`,
 expressing that multiplication by positive elements on the left is strictly monotone. -/
-abbreviation pos_mul_strict_mono : Prop :=
-covariant_class {x : X // 0 < x} X (λ x y, x * y) (<)
+abbreviation pos_mul_strict_mono : Prop := covariant_class α>0 α (λ x y, x * y) (<)
 
-/--  `zero_lt.mul_pos_strict_mono α` is an abbreviation for
-`covariant_class α>0 α (λ x y, y * x) (<)`,
+/-- `mul_pos_strict_mono α` is an abbreviation for `covariant_class α>0 α (λ x y, y * x) (<)`,
 expressing that multiplication by positive elements on the right is strictly monotone. -/
-abbreviation mul_pos_strict_mono : Prop :=
-covariant_class {x : X // 0 < x} X (λ x y, y * x) (<)
+abbreviation mul_pos_strict_mono : Prop := covariant_class α>0 α (λ x y, y * x) (<)
 
-/--  `zero_lt.pos_mul_reflect_lt α` is an abbreviation for
-`contravariant_class α>0 α (λ x y, x * y) (<)`,
-expressing that multiplication by positive elements on the left is strictly reverse monotone. -/
-abbreviation pos_mul_reflect_lt : Prop :=
-contravariant_class {x : X // 0 < x} X (λ x y, x * y) (<)
+/-- `pos_mul_reflect_lt α` is an abbreviation for `contravariant_class α≥0 α (λ x y, x * y) (<)`,
+expressing that multiplication by nonnegative elements on the left is strictly reverse monotone. -/
+abbreviation pos_mul_reflect_lt : Prop := contravariant_class α≥0 α (λ x y, x * y) (<)
 
-/--  `zero_lt.mul_pos_reflect_lt α` is an abbreviation for
-`contravariant_class α>0 α (λ x y, y * x) (<)`,
-expressing that multiplication by positive elements on the right is strictly reverse monotone. -/
-abbreviation mul_pos_reflect_lt : Prop :=
-contravariant_class {x : X // 0 < x} X (λ x y, y * x) (<)
+/-- `mul_pos_reflect_lt α` is an abbreviation for `contravariant_class α≥0 α (λ x y, y * x) (<)`,
+expressing that multiplication by nonnegative elements on the right is strictly reverse monotone. -/
+abbreviation mul_pos_reflect_lt : Prop := contravariant_class α≥0 α (λ x y, y * x) (<)
 
-end abbreviations_strict_mono
-
-section abbreviations_mono
-variables (X : Type*) [has_mul X] [has_zero X] [has_lt X] [has_le X]
-
-/--  `zero_lt.pos_mul_mono α` is an abbreviation for
-`covariant_class α>0 α (λ x y, x * y) (≤)`,
-expressing that multiplication by positive elements on the left is monotone. -/
-abbreviation pos_mul_mono : Prop :=
-covariant_class {x : X // 0 < x} X (λ x y, x * y) (≤)
-
-/--  `zero_lt.mul_pos_mono α` is an abbreviation for
-`covariant_class α>0 α (λ x y, y * x) (≤)`,
-expressing that multiplication by positive elements on the right is monotone. -/
-abbreviation mul_pos_mono : Prop :=
-covariant_class {x : X // 0 < x} X (λ x y, y * x) (≤)
-
-/--  `zero_lt.pos_mul_mono_rev α` is an abbreviation for
-`contravariant_class α>0 α (λ x y, x * y) (≤)`,
+/-- `pos_mul_mono_rev α` is an abbreviation for `contravariant_class α>0 α (λ x y, x * y) (≤)`,
 expressing that multiplication by positive elements on the left is reverse monotone. -/
-abbreviation pos_mul_mono_rev : Prop :=
-contravariant_class {x : X // 0 < x} X (λ x y, x * y) (≤)
+abbreviation pos_mul_mono_rev : Prop := contravariant_class α>0 α (λ x y, x * y) (≤)
 
-/--  `zero_lt.mul_pos_mono_rev α` is an abbreviation for
-`contravariant_class α>0 α (λ x y, y * x) (≤)`,
+/-- `mul_pos_mono_rev α` is an abbreviation for `contravariant_class α>0 α (λ x y, y * x) (≤)`,
 expressing that multiplication by positive elements on the right is reverse monotone. -/
-abbreviation mul_pos_mono_rev : Prop :=
-contravariant_class {x : X // 0 < x} X (λ x y, y * x) (≤)
+abbreviation mul_pos_mono_rev : Prop := contravariant_class α>0 α (λ x y, y * x) (≤)
 
-end abbreviations_mono
+end abbreviations
 
-variables {a b c d : α}
+variables {α} {a b c d : α}
 
 section has_mul_zero
 variables [has_mul α] [has_zero α]
 
-section has_lt
-variables [has_lt α]
+section preorder
+variables [preorder α]
 
-lemma mul_lt_mul_left' [pos_mul_strict_mono α]
-  (bc : b < c) (a0 : 0 < a) :
-  a * b < a * c :=
-@covariant_class.elim α>0 α (λ x y, x * y) (<) _ ⟨a, a0⟩ _ _ bc
+instance pos_mul_mono.to_covariant_class_pos_mul_le [pos_mul_mono α] :
+  covariant_class α>0 α (λ x y, x * y) (≤) :=
+⟨λ a b c bc, @covariant_class.elim α≥0 α (λ x y, x * y) (≤) _ ⟨_, a.2.le⟩ _ _ bc⟩
 
-lemma mul_lt_mul_right' [mul_pos_strict_mono α]
-  (bc : b < c) (a0 : 0 < a) :
-  b * a < c * a :=
-@covariant_class.elim α>0 α (λ x y, y * x) (<) _ ⟨a, a0⟩ _ _ bc
+instance mul_pos_mono.to_covariant_class_pos_mul_le [mul_pos_mono α] :
+  covariant_class α>0 α (λ x y, y * x) (≤) :=
+⟨λ a b c bc, @covariant_class.elim α≥0 α (λ x y, y * x) (≤) _ ⟨_, a.2.le⟩ _ _ bc⟩
 
--- proven with `a0 : 0 ≤ a` as `lt_of_mul_lt_mul_left`
-lemma lt_of_mul_lt_mul_left' [pos_mul_reflect_lt α]
-  (bc : a * b < a * c) (a0 : 0 < a) :
-  b < c :=
-@contravariant_class.elim α>0 α (λ x y, x * y) (<) _ ⟨a, a0⟩ _ _ bc
+instance pos_mul_reflect_lt.to_contravariant_class_pos_mul_lt [pos_mul_reflect_lt α] :
+  contravariant_class α>0 α (λ x y, x * y) (<) :=
+⟨λ a b c bc, @contravariant_class.elim α≥0 α (λ x y, x * y) (<) _ ⟨_, a.2.le⟩ _ _ bc⟩
 
--- proven with `a0 : 0 ≤ a` as `lt_of_mul_lt_mul_right`
-lemma lt_of_mul_lt_mul_right' [mul_pos_reflect_lt α]
-  (bc : b * a < c * a) (a0 : 0 < a) :
-  b < c :=
-@contravariant_class.elim α>0 α (λ x y, y * x) (<) _ ⟨a, a0⟩ _ _ bc
+instance mul_pos_reflect_lt.to_contravariant_class_pos_mul_lt [mul_pos_reflect_lt α] :
+  contravariant_class α>0 α (λ x y, y * x) (<) :=
+⟨λ a b c bc, @contravariant_class.elim α≥0 α (λ x y, y * x) (<) _ ⟨_, a.2.le⟩ _ _ bc⟩
+
+lemma mul_le_mul_of_nonneg_left [pos_mul_mono α] (h : b ≤ c) (ha : 0 ≤ a) : a * b ≤ a * c :=
+@covariant_class.elim α≥0 α (λ x y, x * y) (≤) _ ⟨a, ha⟩ _ _ h
+
+lemma mul_le_mul_of_nonneg_right [mul_pos_mono α] (h : b ≤ c) (ha : 0 ≤ a) : b * a ≤ c * a :=
+@covariant_class.elim α≥0 α (λ x y, y * x) (≤) _ ⟨a, ha⟩ _ _ h
+
+lemma mul_lt_mul_of_pos_left [pos_mul_strict_mono α] (bc : b < c) (ha : 0 < a) : a * b < a * c :=
+@covariant_class.elim α>0 α (λ x y, x * y) (<) _ ⟨a, ha⟩ _ _ bc
+
+lemma mul_lt_mul_of_pos_right [mul_pos_strict_mono α] (bc : b < c) (ha : 0 < a) : b * a < c * a :=
+@covariant_class.elim α>0 α (λ x y, y * x) (<) _ ⟨a, ha⟩ _ _ bc
+
+lemma lt_of_mul_lt_mul_left [pos_mul_reflect_lt α] (h : a * b < a * c) (ha : 0 ≤ a) : b < c :=
+@contravariant_class.elim α≥0 α (λ x y, x * y) (<) _ ⟨a, ha⟩ _ _ h
+
+lemma lt_of_mul_lt_mul_right [mul_pos_reflect_lt α] (h : b * a < c * a) (ha : 0 ≤ a) : b < c :=
+@contravariant_class.elim α≥0 α (λ x y, y * x) (<) _ ⟨a, ha⟩ _ _ h
 
 @[simp]
 lemma mul_lt_mul_left [pos_mul_strict_mono α] [pos_mul_reflect_lt α]
@@ -166,193 +146,113 @@ lemma mul_lt_mul_right [mul_pos_strict_mono α] [mul_pos_reflect_lt α]
   b * a < c * a ↔ b < c :=
 @rel_iff_cov α>0 α (λ x y, y * x) (<) _ _ ⟨a, a0⟩ _ _
 
-end has_lt
-
-section has_lt_le
-variables [has_lt α] [has_le α]
-
--- proven with `a0 : 0 ≤ a` as `mul_le_mul_left`
-lemma mul_le_mul_left_of_le_of_pos [pos_mul_mono α]
-  (bc : b ≤ c) (a0 : 0 < a) :
-  a * b ≤ a * c :=
-@covariant_class.elim α>0 α (λ x y, x * y) (≤) _ ⟨a, a0⟩ _ _ bc
-
--- proven with `a0 : 0 ≤ a` as `mul_le_mul_right`
-lemma mul_le_mul_right_of_le_of_pos [mul_pos_mono α]
-  (bc : b ≤ c) (a0 : 0 < a) :
-  b * a ≤ c * a :=
-@covariant_class.elim α>0 α (λ x y, y * x) (≤) _ ⟨a, a0⟩ _ _ bc
-
-lemma le_of_mul_le_mul_left' [pos_mul_mono_rev α]
+lemma le_of_mul_le_mul_of_pos_left [pos_mul_mono_rev α]
   (bc : a * b ≤ a * c) (a0 : 0 < a) :
   b ≤ c :=
 @contravariant_class.elim α>0 α (λ x y, x * y) (≤) _ ⟨a, a0⟩ _ _ bc
 
-lemma le_of_mul_le_mul_right' [mul_pos_mono_rev α]
+lemma le_of_mul_le_mul_of_pos_right [mul_pos_mono_rev α]
   (bc : b * a ≤ c * a) (a0 : 0 < a) :
   b ≤ c :=
 @contravariant_class.elim α>0 α (λ x y, y * x) (≤) _ ⟨a, a0⟩ _ _ bc
 
-@[simp]
-lemma mul_le_mul_left [pos_mul_mono α] [pos_mul_mono_rev α]
-  (a0 : 0 < a) :
+alias le_of_mul_le_mul_of_pos_left ← le_of_mul_le_mul_left
+alias le_of_mul_le_mul_of_pos_right ← le_of_mul_le_mul_right
+
+@[simp] lemma mul_le_mul_left [pos_mul_mono α] [pos_mul_mono_rev α] (ha : 0 < a) :
   a * b ≤ a * c ↔ b ≤ c :=
-@rel_iff_cov α>0 α (λ x y, x * y) (≤) _ _ ⟨a, a0⟩ _ _
+@rel_iff_cov α>0 α (λ x y, x * y) (≤) _ _ ⟨a, ha⟩ _ _
 
-@[simp]
-lemma mul_le_mul_right [mul_pos_mono α] [mul_pos_mono_rev α]
-  (a0 : 0 < a) :
+@[simp] lemma mul_le_mul_right [mul_pos_mono α] [mul_pos_mono_rev α] (ha : 0 < a) :
   b * a ≤ c * a ↔ b ≤ c :=
-@rel_iff_cov α>0 α (λ x y, y * x) (≤) _ _ ⟨a, a0⟩ _ _
+@rel_iff_cov α>0 α (λ x y, y * x) (≤) _ _ ⟨a, ha⟩ _ _
 
-end has_lt_le
+lemma mul_lt_mul_of_pos_of_nonneg [pos_mul_strict_mono α] [mul_pos_mono α]
+  (h₁ : a ≤ b) (h₂ : c < d) (a0 : 0 < a) (d0 : 0 ≤ d) : a * c < b * d :=
+(mul_lt_mul_of_pos_left h₂ a0).trans_le (mul_le_mul_of_nonneg_right h₁ d0)
 
-section preorder
-variables [preorder α]
+lemma mul_lt_mul_of_le_of_le' [pos_mul_strict_mono α] [mul_pos_mono α]
+  (h₁ : a ≤ b) (h₂ : c < d) (b0 : 0 < b) (c0 : 0 ≤ c) : a * c < b * d :=
+(mul_le_mul_of_nonneg_right h₁ c0).trans_lt (mul_lt_mul_of_pos_left h₂ b0)
 
--- proven with `a0 : 0 ≤ a` `d0 : 0 ≤ d` as `mul_le_mul_of_le_of_le`
-lemma preorder.mul_le_mul_of_le_of_le [pos_mul_mono α] [mul_pos_mono α]
-  (h₁ : a ≤ b) (h₂ : c ≤ d) (a0 : 0 < a) (d0 : 0 < d) : a * c ≤ b * d :=
-(mul_le_mul_left_of_le_of_pos h₂ a0).trans (mul_le_mul_right_of_le_of_pos h₁ d0)
+lemma mul_lt_mul_of_nonneg_of_pos [pos_mul_mono α] [mul_pos_strict_mono α]
+  (h₁ : a < b) (h₂ : c ≤ d) (a0 : 0 ≤ a) (d0 : 0 < d) : a * c < b * d :=
+(mul_le_mul_of_nonneg_left h₂ a0).trans_lt (mul_lt_mul_of_pos_right h₁ d0)
 
--- proven with `b0 : 0 ≤ b` `c0 : 0 ≤ c` as `mul_le_mul_of_le_of_le'`
-lemma preorder.mul_le_mul_of_le_of_le' [pos_mul_mono α] [mul_pos_mono α]
-  (h₁ : a ≤ b) (h₂ : c ≤ d) (b0 : 0 < b) (c0 : 0 < c) : a * c ≤ b * d :=
-(mul_le_mul_right_of_le_of_pos h₁ c0).trans (mul_le_mul_left_of_le_of_pos h₂ b0)
+lemma mul_lt_mul_of_le_of_lt' [pos_mul_mono α] [mul_pos_strict_mono α]
+  (h₁ : a < b) (h₂ : c ≤ d) (b0 : 0 ≤ b) (c0 : 0 < c) : a * c < b * d :=
+(mul_lt_mul_of_pos_right h₁ c0).trans_le (mul_le_mul_of_nonneg_left h₂ b0)
 
-lemma mul_lt_mul_of_le_of_lt [pos_mul_strict_mono α] [mul_pos_mono α]
-  (h₁ : a ≤ b) (h₂ : c < d) (a0 : 0 < a) (d0 : 0 < d) : a * c < b * d :=
-(mul_lt_mul_left' h₂ a0).trans_le (mul_le_mul_right_of_le_of_pos h₁ d0)
-
-lemma mul_lt_mul_of_le_of_lt' [pos_mul_strict_mono α] [mul_pos_mono α]
-  (h₁ : a ≤ b) (h₂ : c < d) (b0 : 0 < b) (c0 : 0 < c) : a * c < b * d :=
-(mul_le_mul_right_of_le_of_pos h₁ c0).trans_lt (mul_lt_mul_left' h₂ b0)
-
-lemma mul_lt_mul_of_lt_of_le [pos_mul_mono α] [mul_pos_strict_mono α]
-  (h₁ : a < b) (h₂ : c ≤ d) (a0 : 0 < a) (d0 : 0 < d) : a * c < b * d :=
-(mul_le_mul_left_of_le_of_pos h₂ a0).trans_lt (mul_lt_mul_right' h₁ d0)
-
-lemma mul_lt_mul_of_lt_of_le' [pos_mul_mono α] [mul_pos_strict_mono α]
-  (h₁ : a < b) (h₂ : c ≤ d) (b0 : 0 < b) (c0 : 0 < c) : a * c < b * d :=
-(mul_lt_mul_right' h₁ c0).trans_le (mul_le_mul_left_of_le_of_pos h₂ b0)
-
-lemma mul_lt_mul_of_lt_of_lt [pos_mul_strict_mono α] [mul_pos_strict_mono α]
+lemma mul_lt_mul_of_pos_of_pos [pos_mul_strict_mono α] [mul_pos_strict_mono α]
   (h₁ : a < b) (h₂ : c < d) (a0 : 0 < a) (d0 : 0 < d) : a * c < b * d :=
-(mul_lt_mul_left' h₂ a0).trans (mul_lt_mul_right' h₁ d0)
+(mul_lt_mul_of_pos_left h₂ a0).trans (mul_lt_mul_of_pos_right h₁ d0)
 
 lemma mul_lt_mul_of_lt_of_lt' [pos_mul_strict_mono α] [mul_pos_strict_mono α]
   (h₁ : a < b) (h₂ : c < d) (b0 : 0 < b) (c0 : 0 < c) : a * c < b * d :=
-(mul_lt_mul_right' h₁ c0).trans (mul_lt_mul_left' h₂ b0)
+(mul_lt_mul_of_pos_right h₁ c0).trans (mul_lt_mul_of_pos_left h₂ b0)
 
--- proven with `a0 : 0 ≤ a` as `mul_le_of_mul_le_left`
-lemma preorder.mul_le_of_mul_le_left [pos_mul_mono α]
-  (h : a * b ≤ c) (hle : d ≤ b) (a0 : 0 < a) :
-  a * d ≤ c :=
-(mul_le_mul_left_of_le_of_pos hle a0).trans h
-
-lemma mul_lt_of_mul_lt_left [pos_mul_mono α]
-  (h : a * b < c) (hle : d ≤ b) (a0 : 0 < a) :
+lemma mul_lt_of_mul_lt_of_nonneg_left [pos_mul_mono α] (h : a * b < c) (hdb : d ≤ b) (ha : 0 ≤ a) :
   a * d < c :=
-(mul_le_mul_left_of_le_of_pos hle a0).trans_lt h
+(mul_le_mul_of_nonneg_left hdb ha).trans_lt h
 
--- proven with `b0 : 0 ≤ b` as `le_mul_of_le_mul_left`
-lemma preorder.le_mul_of_le_mul_left [pos_mul_mono α]
-  (h : a ≤ b * c) (hle : c ≤ d) (b0 : 0 < b) :
-  a ≤ b * d :=
-h.trans (mul_le_mul_left_of_le_of_pos hle b0)
-
-lemma lt_mul_of_lt_mul_left [pos_mul_mono α]
-  (h : a < b * c) (hle : c ≤ d) (b0 : 0 < b) :
+lemma lt_mul_of_lt_mul_of_nonneg_left [pos_mul_mono α] (h : a < b * c) (hcd : c ≤ d) (hb : 0 ≤ b) :
   a < b * d :=
-h.trans_le (mul_le_mul_left_of_le_of_pos hle b0)
+h.trans_le $ mul_le_mul_of_nonneg_left hcd hb
 
--- proven with `b0 : 0 ≤ b` as `mul_le_of_mul_le_right`
-lemma preorder.mul_le_of_mul_le_right [mul_pos_mono α]
-  (h : a * b ≤ c) (hle : d ≤ a) (b0 : 0 < b) :
-  d * b ≤ c :=
-(mul_le_mul_right_of_le_of_pos hle b0).trans h
-
-lemma mul_lt_of_mul_lt_right [mul_pos_mono α]
-  (h : a * b < c) (hle : d ≤ a) (b0 : 0 < b) :
+lemma mul_lt_of_mul_lt_of_nonneg_right [mul_pos_mono α] (h : a * b < c) (hda : d ≤ a) (hb : 0 ≤ b) :
   d * b < c :=
-(mul_le_mul_right_of_le_of_pos hle b0).trans_lt h
+(mul_le_mul_of_nonneg_right hda hb).trans_lt h
 
--- proven with `c0 : 0 ≤ c` as `le_mul_of_le_mul_right`
-lemma preorder.le_mul_of_le_mul_right [mul_pos_mono α]
-  (h : a ≤ b * c) (hle : b ≤ d) (c0 : 0 < c) :
-  a ≤ d * c :=
-h.trans (mul_le_mul_right_of_le_of_pos hle c0)
-
-lemma lt_mul_of_lt_mul_right [mul_pos_mono α]
-  (h : a < b * c) (hle : b ≤ d) (c0 : 0 < c) :
+lemma lt_mul_of_lt_mul_of_nonneg_right [mul_pos_mono α] (h : a < b * c) (hbd : b ≤ d) (hc : 0 ≤ c) :
   a < d * c :=
-h.trans_le (mul_le_mul_right_of_le_of_pos hle c0)
+h.trans_le $ mul_le_mul_of_nonneg_right hbd hc
 
 end preorder
-
-section partial_order
-variables [partial_order α]
-
-@[priority 100] -- see Note [lower instance priority]
-instance pos_mul_strict_mono.to_pos_mul_mono [pos_mul_strict_mono α] : pos_mul_mono α :=
-⟨λ x a b h, h.eq_or_lt.elim (λ h', h' ▸ le_rfl) (λ h', (mul_lt_mul_left' h' x.prop).le)⟩
-
-@[priority 100] -- see Note [lower instance priority]
-instance mul_pos_strict_mono.to_mul_pos_mono [mul_pos_strict_mono α] : mul_pos_mono α :=
-⟨λ x a b h, h.eq_or_lt.elim (λ h', h' ▸ le_rfl) (λ h', (mul_lt_mul_right' h' x.prop).le)⟩
-
-@[priority 100] -- see Note [lower instance priority]
-instance pos_mul_mono_rev.to_pos_mul_reflect_lt [pos_mul_mono_rev α] : pos_mul_reflect_lt α :=
-⟨λ x a b h, lt_of_le_of_ne (le_of_mul_le_mul_left' h.le x.prop) (λ h', by simpa [h'] using h)⟩
-
-@[priority 100] -- see Note [lower instance priority]
-instance mul_pos_mono_rev.to_mul_pos_reflect_lt [mul_pos_mono_rev α] : mul_pos_reflect_lt α :=
-⟨λ x a b h, lt_of_le_of_ne (le_of_mul_le_mul_right' h.le x.prop) (λ h', by simpa [h'] using h)⟩
-
-end partial_order
 
 section linear_order
 variables [linear_order α]
 
 @[priority 100] -- see Note [lower instance priority]
 instance pos_mul_strict_mono.to_pos_mul_mono_rev [pos_mul_strict_mono α] : pos_mul_mono_rev α :=
-⟨λ x a b h, le_of_not_lt $ λ h', h.not_lt (mul_lt_mul_left' h' x.prop)⟩
+⟨λ x a b h, le_of_not_lt $ λ h', h.not_lt $ mul_lt_mul_of_pos_left h' x.prop⟩
 
 @[priority 100] -- see Note [lower instance priority]
 instance mul_pos_strict_mono.to_mul_pos_mono_rev [mul_pos_strict_mono α] : mul_pos_mono_rev α :=
-⟨λ x a b h, le_of_not_lt $ λ h', h.not_lt (mul_lt_mul_right' h' x.prop)⟩
+⟨λ x a b h, le_of_not_lt $ λ h', h.not_lt $ mul_lt_mul_of_pos_right h' x.prop⟩
 
 lemma pos_mul_mono_rev.to_pos_mul_strict_mono [pos_mul_mono_rev α] : pos_mul_strict_mono α :=
-⟨λ x a b h, lt_of_not_le $ λ h', h.not_le (le_of_mul_le_mul_left' h' x.prop)⟩
+⟨λ x a b h, lt_of_not_le $ λ h', h.not_le $ le_of_mul_le_mul_of_pos_left h' x.prop⟩
 
 lemma mul_pos_mono_rev.to_mul_pos_strict_mono [mul_pos_mono_rev α] : mul_pos_strict_mono α :=
-⟨λ x a b h, lt_of_not_le $ λ h', h.not_le (le_of_mul_le_mul_right' h' x.prop)⟩
+⟨λ x a b h, lt_of_not_le $ λ h', h.not_le $ le_of_mul_le_mul_of_pos_right h' x.prop⟩
 
 lemma pos_mul_strict_mono_iff_pos_mul_mono_rev : pos_mul_strict_mono α ↔ pos_mul_mono_rev α :=
-⟨@zero_lt.pos_mul_strict_mono.to_pos_mul_mono_rev _ _ _ _,
-         @pos_mul_mono_rev.to_pos_mul_strict_mono _ _ _ _⟩
+⟨@pos_mul_strict_mono.to_pos_mul_mono_rev _ _ _ _, @pos_mul_mono_rev.to_pos_mul_strict_mono _ _ _ _⟩
 
 lemma mul_pos_strict_mono_iff_mul_pos_mono_rev : mul_pos_strict_mono α ↔ mul_pos_mono_rev α :=
-⟨@zero_lt.mul_pos_strict_mono.to_mul_pos_mono_rev _ _ _ _,
-         @mul_pos_mono_rev.to_mul_pos_strict_mono _ _ _ _⟩
+⟨@mul_pos_strict_mono.to_mul_pos_mono_rev _ _ _ _, @mul_pos_mono_rev.to_mul_pos_strict_mono _ _ _ _⟩
 
-lemma pos_mul_reflect_lt.to_pos_mul_mono [pos_mul_reflect_lt α] : pos_mul_mono α :=
-⟨λ x a b h, le_of_not_lt $ λ h', h.not_lt (lt_of_mul_lt_mul_left' h' x.prop)⟩
+lemma pos_mul_reflect_lt.to_pos_mul_mono {α : Type*} [mul_zero_class α] [linear_order α]
+  [pos_mul_reflect_lt α] : pos_mul_mono α :=
+⟨λ x a b h, le_of_not_lt $ λ h', h.not_lt $ lt_of_mul_lt_mul_left h' x.prop⟩
 
-lemma mul_pos_reflect_lt.to_mul_pos_mono [mul_pos_reflect_lt α] : mul_pos_mono α :=
-⟨λ x a b h, le_of_not_lt $ λ h', h.not_lt (lt_of_mul_lt_mul_right' h' x.prop)⟩
+lemma mul_pos_reflect_lt.to_mul_pos_mono {α : Type*} [mul_zero_class α] [linear_order α]
+  [mul_pos_reflect_lt α] : mul_pos_mono α :=
+⟨λ x a b h, le_of_not_lt $ λ h', h.not_lt $ lt_of_mul_lt_mul_right h' x.prop⟩
 
 lemma pos_mul_mono.to_pos_mul_reflect_lt [pos_mul_mono α] : pos_mul_reflect_lt α :=
-⟨λ x a b h, lt_of_not_le $ λ h', h.not_le (mul_le_mul_left_of_le_of_pos h' x.prop)⟩
+⟨λ x a b h, lt_of_not_le $ λ h', h.not_le $ mul_le_mul_of_nonneg_left h' x.prop⟩
 
 lemma mul_pos_mono.to_mul_pos_reflect_lt [mul_pos_mono α] : mul_pos_reflect_lt α :=
-⟨λ x a b h, lt_of_not_le $ λ h', h.not_le (mul_le_mul_right_of_le_of_pos h' x.prop)⟩
+⟨λ x a b h, lt_of_not_le $ λ h', h.not_le $ mul_le_mul_of_nonneg_right h' x.prop⟩
 
-lemma pos_mul_mono_iff_pos_mul_reflect_lt : pos_mul_mono α ↔ pos_mul_reflect_lt α :=
-⟨@pos_mul_mono.to_pos_mul_reflect_lt _ _ _ _, @pos_mul_reflect_lt.to_pos_mul_mono _ _ _ _⟩
+lemma pos_mul_mono_iff_pos_mul_reflect_lt {α : Type*} [mul_zero_class α] [linear_order α] :
+  pos_mul_mono α ↔ pos_mul_reflect_lt α :=
+⟨@pos_mul_mono.to_pos_mul_reflect_lt _ _ _ _, @pos_mul_reflect_lt.to_pos_mul_mono _ _ _⟩
 
-lemma mul_pos_mono_iff_mul_pos_reflect_lt : mul_pos_mono α ↔ mul_pos_reflect_lt α :=
-⟨@mul_pos_mono.to_mul_pos_reflect_lt _ _ _ _, @mul_pos_reflect_lt.to_mul_pos_mono _ _ _ _⟩
+lemma mul_pos_mono_iff_mul_pos_reflect_lt {α : Type*} [mul_zero_class α] [linear_order α] :
+  mul_pos_mono α ↔ mul_pos_reflect_lt α :=
+⟨@mul_pos_mono.to_mul_pos_reflect_lt _ _ _ _, @mul_pos_reflect_lt.to_mul_pos_mono _ _ _⟩
 
 end linear_order
 
@@ -365,108 +265,49 @@ section preorder
 variables [preorder α]
 
 /-- Assumes left covariance. -/
-lemma left.mul_pos [pos_mul_strict_mono α]
-  (ha : 0 < a) (hb : 0 < b) :
-  0 < a * b :=
-have h : a * 0 < a * b, from mul_lt_mul_left' hb ha,
-by rwa [mul_zero] at h
+lemma left.mul_pos [pos_mul_strict_mono α] (ha : 0 < a) (hb : 0 < b) : 0 < a * b :=
+by simpa only [mul_zero] using mul_lt_mul_of_pos_left hb ha
 
 alias left.mul_pos ← _root_.mul_pos
 
-lemma mul_neg_of_pos_of_neg [pos_mul_strict_mono α]
-  (ha : 0 < a) (hb : b < 0) :
-  a * b < 0 :=
-have h : a * b < a * 0, from mul_lt_mul_left' hb ha,
-by rwa [mul_zero] at h
+lemma mul_neg_of_pos_of_neg [pos_mul_strict_mono α] (ha : 0 < a) (hb : b < 0) : a * b < 0 :=
+by simpa only [mul_zero] using mul_lt_mul_of_pos_left hb ha
 
 @[simp] lemma zero_lt_mul_left [pos_mul_strict_mono α] [pos_mul_reflect_lt α] (h : 0 < c) :
   0 < c * b ↔ 0 < b :=
 by { convert mul_lt_mul_left h, simp }
 
 /-- Assumes right covariance. -/
-lemma right.mul_pos [mul_pos_strict_mono α]
-  (ha : 0 < a) (hb : 0 < b) :
-  0 < a * b :=
-have h : 0 * b < a * b, from mul_lt_mul_right' ha hb,
-by rwa [zero_mul] at h
+lemma right.mul_pos [mul_pos_strict_mono α] (ha : 0 < a) (hb : 0 < b) : 0 < a * b :=
+by simpa only [zero_mul] using mul_lt_mul_of_pos_right ha hb
 
-lemma mul_neg_of_neg_of_pos [mul_pos_strict_mono α]
-  (ha : a < 0) (hb : 0 < b) :
-  a * b < 0 :=
-have h : a * b < 0 * b, from mul_lt_mul_right' ha hb,
-by rwa [zero_mul] at h
+lemma mul_neg_of_neg_of_pos [mul_pos_strict_mono α] (ha : a < 0) (hb : 0 < b) : a * b < 0 :=
+by simpa only [zero_mul] using mul_lt_mul_of_pos_right ha hb
 
 @[simp] lemma zero_lt_mul_right [mul_pos_strict_mono α] [mul_pos_reflect_lt α] (h : 0 < c) :
   0 < b * c ↔ 0 < b :=
 by { convert mul_lt_mul_right h, simp }
 
-end preorder
-
-section partial_order
-variables [partial_order α]
-
-lemma mul_le_mul_of_nonneg_left [pos_mul_mono α]
-  (bc : b ≤ c) (a0 : 0 ≤ a) :
-  a * b ≤ a * c :=
-a0.lt_or_eq.elim (mul_le_mul_left_of_le_of_pos bc) (λ h, by simp only [← h, zero_mul])
-
-lemma mul_le_mul_of_nonneg_right [mul_pos_mono α]
-  (bc : b ≤ c) (a0 : 0 ≤ a) :
-  b * a ≤ c * a :=
-a0.lt_or_eq.elim (mul_le_mul_right_of_le_of_pos bc) (λ h, by simp only [← h, mul_zero])
-
 /-- Assumes left covariance. -/
-lemma left.mul_nonneg [pos_mul_mono α]
-  (ha : 0 ≤ a) (hb : 0 ≤ b) :
-  0 ≤ a * b :=
-have h : a * 0 ≤ a * b, from mul_le_mul_of_nonneg_left hb ha,
-by rwa [mul_zero] at h
+lemma left.mul_nonneg [pos_mul_mono α] (ha : 0 ≤ a) (hb : 0 ≤ b) : 0 ≤ a * b :=
+by simpa only [mul_zero] using mul_le_mul_of_nonneg_left hb ha
 
 alias left.mul_nonneg ← mul_nonneg
 
-lemma mul_nonpos_of_nonneg_of_nonpos [pos_mul_mono α]
-  (ha : 0 ≤ a) (hb : b ≤ 0) :
-  a * b ≤ 0 :=
-have h : a * b ≤ a * 0, from mul_le_mul_of_nonneg_left hb ha,
-by rwa [mul_zero] at h
+lemma mul_nonpos_of_nonneg_of_nonpos [pos_mul_mono α] (ha : 0 ≤ a) (hb : b ≤ 0) : a * b ≤ 0 :=
+by simpa only [mul_zero] using mul_le_mul_of_nonneg_left hb ha
 
 /-- Assumes right covariance. -/
-lemma right.mul_nonneg [mul_pos_mono α]
-  (ha : 0 ≤ a) (hb : 0 ≤ b) :
-  0 ≤ a * b :=
-have h : 0 * b ≤ a * b, from mul_le_mul_of_nonneg_right ha hb,
-by rwa [zero_mul] at h
+lemma right.mul_nonneg [mul_pos_mono α] (ha : 0 ≤ a) (hb : 0 ≤ b) : 0 ≤ a * b :=
+by simpa only [zero_mul] using mul_le_mul_of_nonneg_right ha hb
 
-lemma mul_nonpos_of_nonpos_of_nonneg [mul_pos_mono α]
-  (ha : a ≤ 0) (hb : 0 ≤ b) :
-  a * b ≤ 0 :=
-have h : a * b ≤ 0 * b, from mul_le_mul_of_nonneg_right ha hb,
-by rwa [zero_mul] at h
+lemma mul_nonpos_of_nonpos_of_nonneg [mul_pos_mono α] (ha : a ≤ 0) (hb : 0 ≤ b) : a * b ≤ 0 :=
+by simpa only [zero_mul] using mul_le_mul_of_nonneg_right ha hb
 
-lemma lt_of_mul_lt_mul_left [pos_mul_reflect_lt α]
-  (bc : a * b < a * c) (a0 : 0 ≤ a) :
-  b < c :=
-begin
-  by_cases a₀ : a = 0,
-  { exact (lt_irrefl (0 : α) (by simpa only [a₀, zero_mul] using bc)).elim },
-  { exact lt_of_mul_lt_mul_left' bc ((ne.symm a₀).le_iff_lt.mp a0) }
-end
-
-lemma pos_of_mul_pos_right [pos_mul_reflect_lt α] (h : 0 < a * b) (ha : 0 ≤ a) :
-  0 < b :=
+lemma pos_of_mul_pos_right [pos_mul_reflect_lt α] (h : 0 < a * b) (ha : 0 ≤ a) : 0 < b :=
 lt_of_mul_lt_mul_left ((mul_zero a).symm ▸ h : a * 0 < a * b) ha
 
-lemma lt_of_mul_lt_mul_right [mul_pos_reflect_lt α]
-  (ab : a * c < b * c) (c0 : 0 ≤ c) :
-  a < b :=
-begin
-  by_cases c₀ : c = 0,
-  { exact (lt_irrefl (0 : α) (by simpa only [c₀, mul_zero] using ab)).elim },
-  { exact lt_of_mul_lt_mul_right' ab ((ne.symm c₀).le_iff_lt.mp c0) }
-end
-
-lemma pos_of_mul_pos_left [mul_pos_reflect_lt α] (h : 0 < a * b) (hb : 0 ≤ b) :
-  0 < a :=
+lemma pos_of_mul_pos_left [mul_pos_reflect_lt α] (h : 0 < a * b) (hb : 0 ≤ b) : 0 < a :=
 lt_of_mul_lt_mul_right ((zero_mul b).symm ▸ h : 0 * b < a * b) hb
 
 lemma pos_iff_pos_of_mul_pos [pos_mul_reflect_lt α] [mul_pos_reflect_lt α] (hab : 0 < a * b) :
@@ -481,37 +322,84 @@ lemma mul_le_mul [pos_mul_mono α] [mul_pos_mono α]
   (h₁ : a ≤ b) (h₂ : c ≤ d) (c0 : 0 ≤ c) (b0 : 0 ≤ b) : a * c ≤ b * d :=
 (mul_le_mul_of_nonneg_right h₁ c0).trans $ mul_le_mul_of_nonneg_left h₂ b0
 
-lemma mul_le_of_mul_le_left [pos_mul_mono α]
-  (h : a * b ≤ c) (hle : d ≤ b) (a0 : 0 ≤ a) :
+lemma mul_le_of_mul_le_of_nonneg_left [pos_mul_mono α] (h : a * b ≤ c) (hle : d ≤ b) (a0 : 0 ≤ a) :
   a * d ≤ c :=
 (mul_le_mul_of_nonneg_left hle a0).trans h
 
-lemma le_mul_of_le_mul_left [pos_mul_mono α]
-  (h : a ≤ b * c) (hle : c ≤ d) (b0 : 0 ≤ b) :
+lemma le_mul_of_le_mul_of_nonneg_left [pos_mul_mono α] (h : a ≤ b * c) (hle : c ≤ d) (b0 : 0 ≤ b) :
   a ≤ b * d :=
 h.trans (mul_le_mul_of_nonneg_left hle b0)
 
-lemma mul_le_of_mul_le_right [mul_pos_mono α]
-  (h : a * b ≤ c) (hle : d ≤ a) (b0 : 0 ≤ b) :
+lemma mul_le_of_mul_le_of_nonneg_right [mul_pos_mono α] (h : a * b ≤ c) (hle : d ≤ a) (b0 : 0 ≤ b) :
   d * b ≤ c :=
 (mul_le_mul_of_nonneg_right hle b0).trans h
 
-lemma le_mul_of_le_mul_right [mul_pos_mono α]
-  (h : a ≤ b * c) (hle : b ≤ d) (c0 : 0 ≤ c) :
+lemma le_mul_of_le_mul_of_nonneg_right [mul_pos_mono α] (h : a ≤ b * c) (hle : b ≤ d) (c0 : 0 ≤ c) :
   a ≤ d * c :=
 h.trans (mul_le_mul_of_nonneg_right hle c0)
 
-lemma mul_left_cancel_iff_of_pos [pos_mul_mono_rev α]
-  (a0 : 0 < a) :
-  a * b = a * c ↔ b = c :=
-⟨λ h, (le_of_mul_le_mul_left' h.le a0).antisymm (le_of_mul_le_mul_left' h.ge a0), congr_arg _⟩
+end preorder
 
-lemma mul_right_cancel_iff_of_pos [mul_pos_mono_rev α]
-  (b0 : 0 < b) :
-  a * b = c * b ↔ a = c :=
-⟨λ h, (le_of_mul_le_mul_right' h.le b0).antisymm (le_of_mul_le_mul_right' h.ge b0), congr_arg _⟩
+section partial_order
+variables [partial_order α]
 
-lemma mul_eq_mul_iff_eq_and_eq [pos_mul_strict_mono α] [mul_pos_strict_mono α]
+lemma pos_mul_mono_iff_covariant_pos : pos_mul_mono α ↔ covariant_class α>0 α (λ x y, x * y) (≤) :=
+⟨@pos_mul_mono.to_covariant_class_pos_mul_le _ _ _ _, λ h, ⟨λ a b c h, begin
+    obtain ha | ha := a.prop.eq_or_gt,
+    { simp only [ha, zero_mul] },
+    { exactI @covariant_class.elim α>0 α (λ x y, x * y) (≤) _ ⟨_, ha⟩ _ _ h }
+  end⟩⟩
+
+lemma mul_pos_mono_iff_covariant_pos : mul_pos_mono α ↔ covariant_class α>0 α (λ x y, y * x) (≤) :=
+⟨@mul_pos_mono.to_covariant_class_pos_mul_le _ _ _ _, λ h, ⟨λ a b c h, begin
+    obtain ha | ha := a.prop.eq_or_gt,
+    { simp only [ha, mul_zero] },
+    { exactI @covariant_class.elim α>0 α (λ x y, y * x) (≤) _ ⟨_, ha⟩ _ _ h }
+  end⟩⟩
+
+lemma pos_mul_reflect_lt_iff_contravariant_pos :
+  pos_mul_reflect_lt α ↔ contravariant_class α>0 α (λ x y, x * y) (<) :=
+⟨@pos_mul_reflect_lt.to_contravariant_class_pos_mul_lt _ _ _ _, λ h, ⟨λ a b c h, begin
+    obtain ha | ha := a.prop.eq_or_gt,
+    { simpa [ha] using h },
+    { exactI (@contravariant_class.elim α>0 α (λ x y, x * y) (<) _ ⟨_, ha⟩ _ _ h) }
+  end⟩⟩
+
+lemma mul_pos_reflect_lt_iff_contravariant_pos :
+  mul_pos_reflect_lt α ↔ contravariant_class α>0 α (λ x y, y * x) (<) :=
+⟨@mul_pos_reflect_lt.to_contravariant_class_pos_mul_lt _ _ _ _, λ h, ⟨λ a b c h, begin
+    obtain ha | ha := a.prop.eq_or_gt,
+    { simpa [ha] using h },
+    { exactI (@contravariant_class.elim α>0 α (λ x y, y * x) (<) _ ⟨_, ha⟩ _ _ h) }
+  end⟩⟩
+
+@[priority 100] -- see Note [lower instance priority]
+instance pos_mul_strict_mono.to_pos_mul_mono [pos_mul_strict_mono α] : pos_mul_mono α :=
+pos_mul_mono_iff_covariant_pos.2 $ ⟨λ a, strict_mono.monotone $ @covariant_class.elim _ _ _ _ _ _⟩
+
+@[priority 100] -- see Note [lower instance priority]
+instance mul_pos_strict_mono.to_mul_pos_mono [mul_pos_strict_mono α] : mul_pos_mono α :=
+mul_pos_mono_iff_covariant_pos.2 $ ⟨λ a, strict_mono.monotone $ @covariant_class.elim _ _ _ _ _ _⟩
+
+@[priority 100] -- see Note [lower instance priority]
+instance pos_mul_mono_rev.to_pos_mul_reflect_lt [pos_mul_mono_rev α] : pos_mul_reflect_lt α :=
+pos_mul_reflect_lt_iff_contravariant_pos.2
+  ⟨λ a b c h, (le_of_mul_le_mul_of_pos_left h.le a.2).lt_of_ne $ by { rintro rfl, simpa using h }⟩
+
+@[priority 100] -- see Note [lower instance priority]
+instance mul_pos_mono_rev.to_mul_pos_reflect_lt [mul_pos_mono_rev α] : mul_pos_reflect_lt α :=
+mul_pos_reflect_lt_iff_contravariant_pos.2
+  ⟨λ a b c h, (le_of_mul_le_mul_of_pos_right h.le a.2).lt_of_ne $ by { rintro rfl, simpa using h }⟩
+
+lemma mul_left_cancel_iff_of_pos [pos_mul_mono_rev α] (a0 : 0 < a) : a * b = a * c ↔ b = c :=
+⟨λ h, (le_of_mul_le_mul_of_pos_left h.le a0).antisymm $ le_of_mul_le_mul_of_pos_left h.ge a0,
+  congr_arg _⟩
+
+lemma mul_right_cancel_iff_of_pos [mul_pos_mono_rev α] (b0 : 0 < b) : a * b = c * b ↔ a = c :=
+⟨λ h, (le_of_mul_le_mul_of_pos_right h.le b0).antisymm $ le_of_mul_le_mul_of_pos_right h.ge b0,
+  congr_arg _⟩
+
+lemma mul_eq_mul_iff_eq_and_eq_of_pos [pos_mul_strict_mono α] [mul_pos_strict_mono α]
   [pos_mul_mono_rev α] [mul_pos_mono_rev α]
   (hac : a ≤ b) (hbd : c ≤ d) (a0 : 0 < a) (d0 : 0 < d) :
   a * c = b * d ↔ a = b ∧ c = d :=
@@ -521,10 +409,10 @@ begin
   { exact ⟨rfl, (mul_left_cancel_iff_of_pos a0).mp h⟩ },
   rcases eq_or_lt_of_le hbd with rfl | hbd,
   { exact ⟨(mul_right_cancel_iff_of_pos d0).mp h, rfl⟩ },
-  exact ((mul_lt_mul_of_lt_of_lt hac hbd a0 d0).ne h).elim,
+  exact ((mul_lt_mul_of_pos_of_pos hac hbd a0 d0).ne h).elim,
 end
 
-lemma mul_eq_mul_iff_eq_and_eq' [pos_mul_strict_mono α] [mul_pos_strict_mono α]
+lemma mul_eq_mul_iff_eq_and_eq_of_pos' [pos_mul_strict_mono α] [mul_pos_strict_mono α]
   [pos_mul_mono_rev α] [mul_pos_mono_rev α]
   (hac : a ≤ b) (hbd : c ≤ d) (b0 : 0 < b) (c0 : 0 < c) :
   a * c = b * d ↔ a = b ∧ c = d :=
@@ -659,588 +547,263 @@ lemma mul_lt_iff_lt_one_left
   a * b < b ↔ a < 1 :=
 iff.trans (by rw [one_mul]) (mul_lt_mul_right b0)
 
+/-! Lemmas of the form `1 ≤ b → a ≤ a * b`. -/
+
+lemma mul_le_of_le_one_left [mul_pos_mono α] (hb : 0 ≤ b) (h : a ≤ 1) : a * b ≤ b :=
+by simpa only [one_mul] using mul_le_mul_of_nonneg_right h hb
+
+lemma le_mul_of_one_le_left [mul_pos_mono α] (hb : 0 ≤ b) (h : 1 ≤ a) : b ≤ a * b :=
+by simpa only [one_mul] using mul_le_mul_of_nonneg_right h hb
+
+lemma mul_le_of_le_one_right [pos_mul_mono α] (ha : 0 ≤ a) (h : b ≤ 1) : a * b ≤ a :=
+by simpa only [mul_one] using mul_le_mul_of_nonneg_left h ha
+
+lemma le_mul_of_one_le_right [pos_mul_mono α] (ha : 0 ≤ a) (h : 1 ≤ b) : a ≤ a * b :=
+by simpa only [mul_one] using mul_le_mul_of_nonneg_left h ha
+
+lemma mul_lt_of_lt_one_left [mul_pos_strict_mono α] (hb : 0 < b) (h : a < 1) : a * b < b :=
+by simpa only [one_mul] using mul_lt_mul_of_pos_right h hb
+
+lemma lt_mul_of_one_lt_left [mul_pos_strict_mono α] (hb : 0 < b) (h : 1 < a) : b < a * b :=
+by simpa only [one_mul] using mul_lt_mul_of_pos_right h hb
+
+lemma mul_lt_of_lt_one_right [pos_mul_strict_mono α] (ha : 0 < a) (h : b < 1) : a * b < a :=
+by simpa only [mul_one] using mul_lt_mul_of_pos_left h ha
+
+lemma lt_mul_of_one_lt_right [pos_mul_strict_mono α] (ha : 0 < a) (h : 1 < b) : a < a * b :=
+by simpa only [mul_one] using mul_lt_mul_of_pos_left h ha
+
 /-! Lemmas of the form `b ≤ c → a ≤ 1 → b * a ≤ c`. -/
+/- Yaël: What's the point of these lemmas? They just chain an existing lemma with an assumption in
+all possible ways, thereby artificially inflating the API and making the truly relevant lemmas hard
+to find -/
 
--- proven with `b0 : 0 ≤ b` as `mul_le_of_le_of_le_one`
-lemma preorder.mul_le_of_le_of_le_one [pos_mul_mono α]
-  (bc : b ≤ c) (ha : a ≤ 1) (b0 : 0 < b) : b * a ≤ c :=
-calc  b * a ≤ b * 1 : mul_le_mul_left_of_le_of_pos ha b0
-        ... = b     : mul_one b
-        ... ≤ c     : bc
+lemma mul_le_of_le_of_le_one_of_nonneg [pos_mul_mono α] (h : b ≤ c) (ha : a ≤ 1) (hb : 0 ≤ b) :
+  b * a ≤ c :=
+(mul_le_of_le_one_right hb ha).trans h
 
-lemma mul_lt_of_le_of_lt_one [pos_mul_strict_mono α]
-  (bc : b ≤ c) (ha : a < 1) (b0 : 0 < b) : b * a < c :=
-calc  b * a < b * 1 : mul_lt_mul_left' ha b0
-        ... = b     : mul_one b
-        ... ≤ c     : bc
+lemma mul_lt_of_le_of_lt_one_of_pos [pos_mul_strict_mono α] (bc : b ≤ c) (ha : a < 1) (b0 : 0 < b) :
+  b * a < c :=
+(mul_lt_of_lt_one_right b0 ha).trans_le bc
 
-lemma mul_lt_of_lt_of_le_one [pos_mul_mono α]
-  (bc : b < c) (ha : a ≤ 1) (b0 : 0 < b) : b * a < c :=
-calc  b * a ≤ b * 1 : mul_le_mul_left_of_le_of_pos ha b0
-        ... = b     : mul_one b
-        ... < c     : bc
-
-lemma mul_lt_of_lt_of_lt_one [pos_mul_strict_mono α]
-  (bc : b < c) (ha : a < 1) (b0 : 0 < b) : b * a < c :=
-calc  b * a < b * 1 : mul_lt_mul_left' ha b0
-        ... = b     : mul_one b
-        ... < c     : bc
-
--- proven with `a0 : 0 ≤ a` as `left.mul_le_one_of_le_of_le`
-/-- Assumes left covariance. -/
-lemma preorder.left.mul_le_one_of_le_of_le' [pos_mul_mono α]
-  (ha : a ≤ 1) (hb : b ≤ 1) (a0 : 0 < a) : a * b ≤ 1 :=
-preorder.mul_le_of_le_of_le_one ha hb a0
+lemma mul_lt_of_lt_of_le_one_of_nonneg [pos_mul_mono α] (h : b < c) (ha : a ≤ 1) (hb : 0 ≤ b) :
+  b * a < c :=
+(mul_le_of_le_one_right hb ha).trans_lt h
 
 /-- Assumes left covariance. -/
-lemma left.mul_lt_one_of_le_of_lt [pos_mul_strict_mono α]
+lemma left.mul_le_one_of_le_of_le [pos_mul_mono α] (ha : a ≤ 1) (hb : b ≤ 1) (a0 : 0 ≤ a) :
+  a * b ≤ 1 :=
+mul_le_of_le_of_le_one_of_nonneg ha hb a0
+
+/-- Assumes left covariance. -/
+lemma left.mul_lt_of_le_of_lt_one_of_pos [pos_mul_strict_mono α]
   (ha : a ≤ 1) (hb : b < 1) (a0 : 0 < a) : a * b < 1 :=
-mul_lt_of_le_of_lt_one ha hb a0
+mul_lt_of_le_of_lt_one_of_pos ha hb a0
 
 /-- Assumes left covariance. -/
-lemma left.mul_lt_one_of_lt_of_le [pos_mul_mono α]
-  (ha : a < 1) (hb : b ≤ 1) (a0 : 0 < a) : a * b < 1 :=
-mul_lt_of_lt_of_le_one ha hb a0
+lemma left.mul_lt_of_lt_of_le_one_of_nonneg [pos_mul_mono α]
+  (ha : a < 1) (hb : b ≤ 1) (a0 : 0 ≤ a) : a * b < 1 :=
+mul_lt_of_lt_of_le_one_of_nonneg ha hb a0
 
-/-- Assumes left covariance. -/
-lemma left.mul_lt_one_of_lt_of_lt [pos_mul_strict_mono α]
-  (ha : a < 1) (hb : b < 1) (a0 : 0 < a) : a * b < 1 :=
-mul_lt_of_lt_of_lt_one ha hb a0
+lemma mul_le_of_le_of_le_one' [pos_mul_mono α] [mul_pos_mono α]
+  (bc : b ≤ c) (ha : a ≤ 1) (a0 : 0 ≤ a) (c0 : 0 ≤ c) : b * a ≤ c :=
+(mul_le_mul_of_nonneg_right bc a0).trans $ mul_le_of_le_one_right c0 ha
 
--- proven with `a0 : 0 ≤ a` and `c0 : 0 ≤ c` as `mul_le_of_le_of_le_one'`
-lemma preorder.mul_le_of_le_of_le_one' [pos_mul_mono α] [mul_pos_mono α]
-  (bc : b ≤ c) (ha : a ≤ 1) (a0 : 0 < a) (c0 : 0 < c) : b * a ≤ c :=
-calc  b * a ≤ c * a : mul_le_mul_right_of_le_of_pos bc a0
-        ... ≤ c * 1 : mul_le_mul_left_of_le_of_pos ha c0
-        ... = c     : mul_one c
+lemma mul_lt_of_lt_of_le_one' [pos_mul_mono α] [mul_pos_strict_mono α]
+  (bc : b < c) (ha : a ≤ 1) (a0 : 0 < a) (c0 : 0 ≤ c) : b * a < c :=
+(mul_lt_mul_of_pos_right bc a0).trans_le $ mul_le_of_le_one_right c0 ha
 
--- proven with `c0 : 0 ≤ c` as `mul_lt_of_lt_of_le_one'`
-lemma preorder.mul_lt_of_lt_of_le_one' [pos_mul_mono α] [mul_pos_strict_mono α]
-  (bc : b < c) (ha : a ≤ 1) (a0 : 0 < a) (c0 : 0 < c) : b * a < c :=
-calc  b * a < c * a : mul_lt_mul_right' bc a0
-        ... ≤ c * 1 : mul_le_mul_left_of_le_of_pos ha c0
-        ... = c     : mul_one c
+lemma mul_lt_of_le_of_lt_one' [pos_mul_strict_mono α] [mul_pos_mono α]
+  (bc : b ≤ c) (ha : a < 1) (a0 : 0 ≤ a) (c0 : 0 < c) : b * a < c :=
+(mul_le_mul_of_nonneg_right bc a0).trans_lt $ mul_lt_of_lt_one_right c0 ha
 
--- proven with `a0 : 0 ≤ a` as `mul_lt_of_le_of_lt_one'`
-lemma preorder.mul_lt_of_le_of_lt_one' [pos_mul_strict_mono α] [mul_pos_mono α]
-  (bc : b ≤ c) (ha : a < 1) (a0 : 0 < a) (c0 : 0 < c) : b * a < c :=
-calc  b * a ≤ c * a : mul_le_mul_right_of_le_of_pos bc a0
-        ... < c * 1 : mul_lt_mul_left' ha c0
-        ... = c     : mul_one c
-
-lemma mul_lt_of_lt_of_lt_one' [pos_mul_strict_mono α] [mul_pos_strict_mono α]
-  (bc : b < c) (ha : a < 1) (a0 : 0 < a) (c0 : 0 < c) : b * a < c :=
-calc  b * a < c * a : mul_lt_mul_right' bc a0
-        ... < c * 1 : mul_lt_mul_left' ha c0
-        ... = c     : mul_one c
+lemma mul_lt_of_lt_of_lt_one_of_pos [pos_mul_mono α] [mul_pos_strict_mono α]
+  (bc : b < c) (ha : a ≤ 1) (a0 : 0 < a) (c0 : 0 ≤ c) : b * a < c :=
+(mul_lt_mul_of_pos_right bc a0).trans_le $ mul_le_of_le_one_right c0 ha
 
 /-! Lemmas of the form `b ≤ c → 1 ≤ a → b ≤ c * a`. -/
 
--- proven with `c0 : 0 ≤ c` as `le_mul_of_le_of_one_le`
-lemma preorder.le_mul_of_le_of_one_le [pos_mul_mono α]
-  (bc : b ≤ c) (ha : 1 ≤ a) (c0 : 0 < c) : b ≤ c * a :=
-calc  b ≤ c     : bc
-    ... = c * 1 : (mul_one c).symm
-    ... ≤ c * a : mul_le_mul_left_of_le_of_pos ha c0
+lemma le_mul_of_le_of_one_le_of_nonneg [pos_mul_mono α] (h : b ≤ c) (ha : 1 ≤ a) (hc : 0 ≤ c) :
+  b ≤ c * a :=
+h.trans $ le_mul_of_one_le_right hc ha
 
-lemma lt_mul_of_le_of_one_lt [pos_mul_strict_mono α]
-  (bc : b ≤ c) (ha : 1 < a) (c0 : 0 < c) : b < c * a :=
-calc  b ≤ c     : bc
-    ... = c * 1 : (mul_one c).symm
-    ... < c * a : mul_lt_mul_left' ha c0
+lemma lt_mul_of_le_of_one_lt_of_pos [pos_mul_strict_mono α] (bc : b ≤ c) (ha : 1 < a) (c0 : 0 < c) :
+  b < c * a :=
+bc.trans_lt $ lt_mul_of_one_lt_right c0 ha
 
-lemma lt_mul_of_lt_of_one_le [pos_mul_mono α]
-  (bc : b < c) (ha : 1 ≤ a) (c0 : 0 < c) : b < c * a :=
-calc  b < c     : bc
-    ... = c * 1 : (mul_one c).symm
-    ... ≤ c * a : mul_le_mul_left_of_le_of_pos ha c0
-
-lemma lt_mul_of_lt_of_one_lt [pos_mul_strict_mono α]
-  (bc : b < c) (ha : 1 < a) (c0 : 0 < c) : b < c * a :=
-calc  b < c     : bc
-    ... = c * 1 : (mul_one _).symm
-    ... < c * a : mul_lt_mul_left' ha c0
-
--- proven with `a0 : 0 ≤ a` as `left.one_le_mul_of_le_of_le`
-/-- Assumes left covariance. -/
-lemma preorder.left.one_le_mul_of_le_of_le [pos_mul_mono α]
-  (ha : 1 ≤ a) (hb : 1 ≤ b) (a0 : 0 < a) : 1 ≤ a * b :=
-preorder.le_mul_of_le_of_one_le ha hb a0
+lemma lt_mul_of_lt_of_one_le_of_nonneg [pos_mul_mono α] (h : b < c) (ha : 1 ≤ a) (hc : 0 ≤ c) :
+  b < c * a :=
+h.trans_le $ le_mul_of_one_le_right hc ha
 
 /-- Assumes left covariance. -/
-lemma left.one_lt_mul_of_le_of_lt [pos_mul_strict_mono α]
+lemma left.one_le_mul_of_le_of_le [pos_mul_mono α] (ha : 1 ≤ a) (hb : 1 ≤ b) (a0 : 0 ≤ a) :
+  1 ≤ a * b :=
+le_mul_of_le_of_one_le_of_nonneg ha hb a0
+
+/-- Assumes left covariance. -/
+lemma left.one_lt_mul_of_le_of_lt_of_pos [pos_mul_strict_mono α]
   (ha : 1 ≤ a) (hb : 1 < b) (a0 : 0 < a) : 1 < a * b :=
-lt_mul_of_le_of_one_lt ha hb a0
+lt_mul_of_le_of_one_lt_of_pos ha hb a0
 
 /-- Assumes left covariance. -/
-lemma left.one_lt_mul_of_lt_of_le [pos_mul_mono α]
-  (ha : 1 < a) (hb : 1 ≤ b) (a0 : 0 < a) : 1 < a * b :=
-lt_mul_of_lt_of_one_le ha hb a0
+lemma left.lt_mul_of_lt_of_one_le_of_nonneg [pos_mul_mono α]
+  (ha : 1 < a) (hb : 1 ≤ b) (a0 : 0 ≤ a) : 1 < a * b :=
+lt_mul_of_lt_of_one_le_of_nonneg ha hb a0
 
-/-- Assumes left covariance. -/
-lemma left.one_lt_mul_of_lt_of_lt [pos_mul_strict_mono α]
-  (ha : 1 < a) (hb : 1 < b) (a0 : 0 < a) : 1 < a * b :=
-lt_mul_of_lt_of_one_lt ha hb a0
+lemma le_mul_of_le_of_one_le' [pos_mul_mono α] [mul_pos_mono α]
+  (bc : b ≤ c) (ha : 1 ≤ a) (a0 : 0 ≤ a) (b0 : 0 ≤ b) : b ≤ c * a :=
+(le_mul_of_one_le_right b0 ha).trans $ mul_le_mul_of_nonneg_right bc a0
 
--- proven with `a0 : 0 ≤ a` and `b0 : 0 ≤ b` as `le_mul_of_le_of_one_le'`
-lemma preorder.le_mul_of_le_of_one_le' [pos_mul_mono α] [mul_pos_mono α]
-  (bc : b ≤ c) (ha : 1 ≤ a) (a0 : 0 < a) (b0 : 0 < b) : b ≤ c * a :=
-calc  b = b * 1 : (mul_one b).symm
-    ... ≤ b * a : mul_le_mul_left_of_le_of_pos ha b0
-    ... ≤ c * a : mul_le_mul_right_of_le_of_pos bc a0
+lemma lt_mul_of_le_of_one_lt' [pos_mul_strict_mono α] [mul_pos_mono α]
+  (bc : b ≤ c) (ha : 1 < a) (a0 : 0 ≤ a) (b0 : 0 < b) : b < c * a :=
+(lt_mul_of_one_lt_right b0 ha).trans_le $ mul_le_mul_of_nonneg_right bc a0
 
--- proven with `a0 : 0 ≤ a` as `lt_mul_of_le_of_one_lt'`
-lemma preorder.lt_mul_of_le_of_one_lt' [pos_mul_strict_mono α] [mul_pos_mono α]
-  (bc : b ≤ c) (ha : 1 < a) (a0 : 0 < a) (b0 : 0 < b) : b < c * a :=
-calc  b = b * 1 : (mul_one b).symm
-    ... < b * a : mul_lt_mul_left' ha b0
-    ... ≤ c * a : mul_le_mul_right_of_le_of_pos bc a0
+lemma lt_mul_of_lt_of_one_le' [pos_mul_mono α] [mul_pos_strict_mono α]
+  (bc : b < c) (ha : 1 ≤ a) (a0 : 0 < a) (b0 : 0 ≤ b) : b < c * a :=
+(le_mul_of_one_le_right b0 ha).trans_lt $ mul_lt_mul_of_pos_right bc a0
 
--- proven with `b0 : 0 ≤ b` as `lt_mul_of_lt_of_one_le'`
-lemma preorder.lt_mul_of_lt_of_one_le' [pos_mul_mono α] [mul_pos_strict_mono α]
-  (bc : b < c) (ha : 1 ≤ a) (a0 : 0 < a) (b0 : 0 < b) : b < c * a :=
-calc  b = b * 1 : (mul_one b).symm
-    ... ≤ b * a : mul_le_mul_left_of_le_of_pos ha b0
-    ... < c * a : mul_lt_mul_right' bc a0
-
-lemma lt_mul_of_lt_of_one_lt' [pos_mul_strict_mono α] [mul_pos_strict_mono α]
+lemma lt_mul_of_lt_of_one_lt_of_pos [pos_mul_strict_mono α] [mul_pos_strict_mono α]
   (bc : b < c) (ha : 1 < a) (a0 : 0 < a) (b0 : 0 < b) : b < c * a :=
-calc  b = b * 1 : (mul_one b).symm
-    ... < b * a : mul_lt_mul_left' ha b0
-    ... < c * a : mul_lt_mul_right' bc a0
+(lt_mul_of_one_lt_right b0 ha).trans $ mul_lt_mul_of_pos_right bc a0
 
 /-! Lemmas of the form `a ≤ 1 → b ≤ c → a * b ≤ c`. -/
 
--- proven with `b0 : 0 ≤ b` as `mul_le_of_le_one_of_le`
-lemma preorder.mul_le_of_le_one_of_le [mul_pos_mono α]
-  (ha : a ≤ 1) (bc : b ≤ c) (b0 : 0 < b) : a * b ≤ c :=
-calc  a * b ≤ 1 * b : mul_le_mul_right_of_le_of_pos ha b0
-        ... = b     : one_mul b
-        ... ≤ c     : bc
+lemma mul_le_of_le_one_of_le_of_nonneg [mul_pos_mono α] (ha : a ≤ 1) (h : b ≤ c) (hb : 0 ≤ b) :
+  a * b ≤ c :=
+(mul_le_of_le_one_left hb ha).trans h
 
-lemma mul_lt_of_lt_one_of_le [mul_pos_strict_mono α]
-  (ha : a < 1) (bc : b ≤ c) (b0 : 0 < b) : a * b < c :=
-calc  a * b < 1 * b : mul_lt_mul_right' ha b0
-        ... = b     : one_mul b
-        ... ≤ c     : bc
+lemma mul_lt_of_lt_one_of_le_of_pos [mul_pos_strict_mono α] (ha : a < 1) (h : b ≤ c) (hb : 0 < b) :
+  a * b < c :=
+(mul_lt_of_lt_one_left hb ha).trans_le h
 
-lemma mul_lt_of_le_one_of_lt [mul_pos_mono α]
-  (ha : a ≤ 1) (hb : b < c) (b0 : 0 < b) : a * b < c :=
-calc  a * b ≤ 1 * b : mul_le_mul_right_of_le_of_pos ha b0
-        ... = b     : one_mul b
-        ... < c     : hb
-
-lemma mul_lt_of_lt_one_of_lt [mul_pos_strict_mono α]
-  (ha : a < 1) (bc : b < c) (b0 : 0 < b) : a * b < c :=
-calc  a * b < 1 * b : mul_lt_mul_right' ha b0
-        ... = b     : one_mul b
-        ... < c     : bc
-
--- proven with `b0 : 0 ≤ b` as `right.mul_le_one_of_le_of_le`
-/-- Assumes right covariance. -/
-lemma preorder.right.mul_le_one_of_le_of_le [mul_pos_mono α]
-  (ha : a ≤ 1) (hb : b ≤ 1) (b0 : 0 < b) : a * b ≤ 1 :=
-preorder.mul_le_of_le_one_of_le ha hb b0
+lemma mul_lt_of_le_one_of_lt_of_nonneg [mul_pos_mono α] (ha : a ≤ 1) (h : b < c) (hb : 0 ≤ b) :
+  a * b < c :=
+(mul_le_of_le_one_left hb ha).trans_lt h
 
 /-- Assumes right covariance. -/
-lemma right.mul_lt_one_of_lt_of_le [mul_pos_strict_mono α]
+lemma right.mul_lt_one_of_lt_of_le_of_pos [mul_pos_strict_mono α]
   (ha : a < 1) (hb : b ≤ 1) (b0 : 0 < b) : a * b < 1 :=
-mul_lt_of_lt_one_of_le ha hb b0
+mul_lt_of_lt_one_of_le_of_pos ha hb b0
 
 /-- Assumes right covariance. -/
-lemma right.mul_lt_one_of_le_of_lt [mul_pos_mono α]
-  (ha : a ≤ 1) (hb : b < 1) (b0 : 0 < b) : a * b < 1 :=
-mul_lt_of_le_one_of_lt ha hb b0
+lemma right.mul_lt_one_of_le_of_lt_of_nonneg [mul_pos_mono α]
+  (ha : a ≤ 1) (hb : b < 1) (b0 : 0 ≤ b) : a * b < 1 :=
+mul_lt_of_le_one_of_lt_of_nonneg ha hb b0
 
-/-- Assumes right covariance. -/
-lemma right.mul_lt_one_of_lt_of_lt [mul_pos_strict_mono α]
-  (ha : a < 1) (hb : b < 1) (b0 : 0 < b) : a * b < 1 :=
-mul_lt_of_lt_one_of_lt ha hb b0
-
--- proven with `a0 : 0 ≤ a` and `c0 : 0 ≤ c` as `mul_le_of_le_one_of_le'`
-lemma preorder.mul_le_of_le_one_of_le' [pos_mul_mono α] [mul_pos_mono α]
-  (ha : a ≤ 1) (bc : b ≤ c) (a0 : 0 < a) (c0 : 0 < c) : a * b ≤ c :=
-calc  a * b ≤ a * c : mul_le_mul_left_of_le_of_pos bc a0
-        ... ≤ 1 * c : mul_le_mul_right_of_le_of_pos ha c0
-        ... = c     : one_mul c
-
--- proven with `a0 : 0 ≤ a` as `mul_lt_of_lt_one_of_le'`
-lemma preorder.mul_lt_of_lt_one_of_le' [pos_mul_mono α] [mul_pos_strict_mono α]
-  (ha : a < 1) (bc : b ≤ c) (a0 : 0 < a) (c0 : 0 < c) : a * b < c :=
-calc  a * b ≤ a * c : mul_le_mul_left_of_le_of_pos bc a0
-        ... < 1 * c : mul_lt_mul_right' ha c0
-        ... = c     : one_mul c
-
--- proven with `c0 : 0 ≤ c` as `mul_lt_of_le_one_of_lt'`
-lemma preorder.mul_lt_of_le_one_of_lt' [pos_mul_strict_mono α] [mul_pos_mono α]
-  (ha : a ≤ 1) (bc : b < c) (a0 : 0 < a) (c0 : 0 < c) : a * b < c :=
-calc  a * b < a * c : mul_lt_mul_left' bc a0
-        ... ≤ 1 * c : mul_le_mul_right_of_le_of_pos ha c0
-        ... = c     : one_mul c
-
-lemma mul_lt_of_lt_one_of_lt' [pos_mul_strict_mono α] [mul_pos_strict_mono α]
+lemma mul_lt_of_lt_one_of_lt_of_pos [pos_mul_strict_mono α] [mul_pos_strict_mono α]
   (ha : a < 1) (bc : b < c) (a0 : 0 < a) (c0 : 0 < c) : a * b < c :=
-calc  a * b < a * c : mul_lt_mul_left' bc a0
-        ... < 1 * c : mul_lt_mul_right' ha c0
-        ... = c     : one_mul c
+(mul_lt_mul_of_pos_left bc a0).trans $ mul_lt_of_lt_one_left c0 ha
+
+/-- Assumes right covariance. -/
+lemma right.mul_le_one_of_le_of_le [mul_pos_mono α]
+  (ha : a ≤ 1) (hb : b ≤ 1) (b0 : 0 ≤ b) : a * b ≤ 1 :=
+mul_le_of_le_one_of_le_of_nonneg ha hb b0
+
+lemma mul_le_of_le_one_of_le' [pos_mul_mono α] [mul_pos_mono α]
+  (ha : a ≤ 1) (bc : b ≤ c) (a0 : 0 ≤ a) (c0 : 0 ≤ c) : a * b ≤ c :=
+(mul_le_mul_of_nonneg_left bc a0).trans $ mul_le_of_le_one_left c0 ha
+
+lemma mul_lt_of_lt_one_of_le' [pos_mul_mono α] [mul_pos_strict_mono α]
+  (ha : a < 1) (bc : b ≤ c) (a0 : 0 ≤ a) (c0 : 0 < c) : a * b < c :=
+(mul_le_mul_of_nonneg_left bc a0).trans_lt $ mul_lt_of_lt_one_left c0 ha
+
+lemma mul_lt_of_le_one_of_lt' [pos_mul_strict_mono α] [mul_pos_mono α]
+  (ha : a ≤ 1) (bc : b < c) (a0 : 0 < a) (c0 : 0 ≤ c) : a * b < c :=
+(mul_lt_mul_of_pos_left bc a0).trans_le $ mul_le_of_le_one_left c0 ha
 
 /-! Lemmas of the form `1 ≤ a → b ≤ c → b ≤ a * c`. -/
 
--- proven with `c0 : 0 ≤ c` as `le_mul_of_one_le_of_le`
-lemma preorder.le_mul_of_one_le_of_le [mul_pos_mono α]
-  (ha : 1 ≤ a) (bc : b ≤ c) (c0 : 0 < c) : b ≤ a * c :=
-calc  b ≤ c     : bc
-    ... = 1 * c : (one_mul c).symm
-    ... ≤ a * c : mul_le_mul_right_of_le_of_pos ha c0
+lemma lt_mul_of_one_lt_of_le_of_pos [mul_pos_strict_mono α] (ha : 1 < a) (h : b ≤ c) (hc : 0 < c) :
+  b < a * c :=
+h.trans_lt $ lt_mul_of_one_lt_left hc ha
 
-lemma lt_mul_of_one_lt_of_le [mul_pos_strict_mono α]
-  (ha : 1 < a) (bc : b ≤ c) (c0 : 0 < c) : b < a * c :=
-calc  b ≤ c     : bc
-    ... = 1 * c : (one_mul c).symm
-    ... < a * c : mul_lt_mul_right' ha c0
+lemma lt_mul_of_one_le_of_lt_of_nonneg [mul_pos_mono α] (ha : 1 ≤ a) (h : b < c) (hc : 0 ≤ c) :
+  b < a * c :=
+h.trans_le $ le_mul_of_one_le_left hc ha
 
-lemma lt_mul_of_one_le_of_lt [mul_pos_mono α]
-  (ha : 1 ≤ a) (bc : b < c) (c0 : 0 < c) : b < a * c :=
-calc  b < c     : bc
-    ... = 1 * c : (one_mul c).symm
-    ... ≤ a * c : mul_le_mul_right_of_le_of_pos ha c0
-
-lemma lt_mul_of_one_lt_of_lt [mul_pos_strict_mono α]
-  (ha : 1 < a) (bc : b < c) (c0 : 0 < c) : b < a * c :=
-calc  b < c     : bc
-    ... = 1 * c : (one_mul c).symm
-    ... < a * c : mul_lt_mul_right' ha c0
-
--- proven with `b0 : 0 ≤ b` as `right.one_le_mul_of_le_of_le`
-/-- Assumes right covariance. -/
-lemma preorder.right.one_le_mul_of_le_of_le [mul_pos_mono α]
-  (ha : 1 ≤ a) (hb : 1 ≤ b) (b0 : 0 < b) : 1 ≤ a * b :=
-preorder.le_mul_of_one_le_of_le ha hb b0
+lemma lt_mul_of_one_lt_of_lt_of_pos [mul_pos_strict_mono α] (ha : 1 < a) (h : b < c) (hc : 0 < c) :
+  b < a * c :=
+h.trans $ lt_mul_of_one_lt_left hc ha
 
 /-- Assumes right covariance. -/
-lemma right.one_lt_mul_of_lt_of_le [mul_pos_strict_mono α]
+lemma right.one_lt_mul_of_lt_of_le_of_pos [mul_pos_strict_mono α]
   (ha : 1 < a) (hb : 1 ≤ b) (b0 : 0 < b) : 1 < a * b :=
-lt_mul_of_one_lt_of_le ha hb b0
+lt_mul_of_one_lt_of_le_of_pos ha hb b0
 
 /-- Assumes right covariance. -/
-lemma right.one_lt_mul_of_le_of_lt [mul_pos_mono α]
-  (ha : 1 ≤ a) (hb : 1 < b) (b0 : 0 < b) : 1 < a * b :=
-lt_mul_of_one_le_of_lt ha hb b0
+lemma right.one_lt_mul_of_le_of_lt_of_nonneg [mul_pos_mono α]
+  (ha : 1 ≤ a) (hb : 1 < b) (b0 : 0 ≤ b) : 1 < a * b :=
+lt_mul_of_one_le_of_lt_of_nonneg ha hb b0
 
 /-- Assumes right covariance. -/
 lemma right.one_lt_mul_of_lt_of_lt [mul_pos_strict_mono α]
   (ha : 1 < a) (hb : 1 < b) (b0 : 0 < b) : 1 < a * b :=
-lt_mul_of_one_lt_of_lt ha hb b0
+lt_mul_of_one_lt_of_lt_of_pos ha hb b0
 
--- proven with `a0 : 0 ≤ a` and `b0 : 0 ≤ b` as `le_mul_of_one_le_of_le'`
-lemma preorder.le_mul_of_one_le_of_le' [pos_mul_mono α] [mul_pos_mono α]
-  (ha : 1 ≤ a) (bc : b ≤ c) (a0 : 0 < a) (b0 : 0 < b) : b ≤ a * c :=
-calc  b = 1 * b : (one_mul b).symm
-    ... ≤ a * b : mul_le_mul_right_of_le_of_pos ha b0
-    ... ≤ a * c : mul_le_mul_left_of_le_of_pos bc a0
+lemma lt_mul_of_one_lt_of_lt_of_nonneg [mul_pos_mono α] (ha : 1 ≤ a) (h : b < c) (hc : 0 ≤ c) :
+  b < a * c :=
+h.trans_le $ le_mul_of_one_le_left hc ha
 
--- proven with `a0 : 0 ≤ a` as `lt_mul_of_one_lt_of_le'`
-lemma preorder.lt_mul_of_one_lt_of_le' [pos_mul_mono α] [mul_pos_strict_mono α]
-  (ha : 1 < a) (bc : b ≤ c) (a0 : 0 < a) (b0 : 0 < b) : b < a * c :=
-calc  b = 1 * b : (one_mul b).symm
-    ... < a * b : mul_lt_mul_right' ha b0
-    ... ≤ a * c : mul_le_mul_left_of_le_of_pos bc a0
-
--- proven with `b0 : 0 ≤ b` as `lt_mul_of_one_le_of_lt'`
-lemma preorder.lt_mul_of_one_le_of_lt' [pos_mul_strict_mono α] [mul_pos_mono α]
-  (ha : 1 ≤ a) (bc : b < c) (a0 : 0 < a) (b0 : 0 < b) : b < a * c :=
-calc  b = 1 * b : (one_mul b).symm
-    ... ≤ a * b : mul_le_mul_right_of_le_of_pos ha b0
-    ... < a * c : mul_lt_mul_left' bc a0
-
-lemma lt_mul_of_one_lt_of_lt' [pos_mul_strict_mono α] [mul_pos_strict_mono α]
-  (ha : 1 < a) (bc : b < c) (a0 : 0 < a) (b0 : 0 < b) : b < a * c :=
-calc  b = 1 * b : (one_mul b).symm
-    ... < a * b : mul_lt_mul_right' ha b0
-    ... < a * c : mul_lt_mul_left' bc a0
-
--- proven with `a0 : 0 ≤ a` as `mul_le_of_le_one_right`
-lemma preorder.mul_le_of_le_one_right [pos_mul_mono α] (h : b ≤ 1) (a0 : 0 < a) :
-  a * b ≤ a :=
-preorder.mul_le_of_le_of_le_one le_rfl h a0
-
--- proven with `a0 : 0 ≤ a` as `le_mul_of_one_le_right`
-lemma preorder.le_mul_of_one_le_right [pos_mul_mono α] (h : 1 ≤ b) (a0 : 0 < a) :
-  a ≤ a * b :=
-preorder.le_mul_of_le_of_one_le le_rfl h a0
-
--- proven with `b0 : 0 ≤ b` as `mul_le_of_le_one_left`
-lemma preorder.mul_le_of_le_one_left [mul_pos_mono α] (h : a ≤ 1) (b0 : 0 < b) :
-  a * b ≤ b :=
-preorder.mul_le_of_le_one_of_le h le_rfl b0
-
--- proven with `b0 : 0 ≤ b` as `le_mul_of_one_le_left`
-lemma preorder.le_mul_of_one_le_left [mul_pos_mono α] (h : 1 ≤ a) (b0 : 0 < b) :
-  b ≤ a * b :=
-preorder.le_mul_of_one_le_of_le h le_rfl b0
-
-lemma mul_lt_of_lt_one_right [pos_mul_strict_mono α] (a0 : 0 < a) (h : b < 1) :
-  a * b < a :=
-mul_lt_of_le_of_lt_one le_rfl h a0
-
-lemma lt_mul_of_one_lt_right [pos_mul_strict_mono α] (a0 : 0 < a) (h : 1 < b) :
-  a < a * b :=
-lt_mul_of_le_of_one_lt le_rfl h a0
-
-lemma mul_lt_of_lt_one_left [mul_pos_strict_mono α] (b0 : 0 < b) (h : a < 1) :
-  a * b < b :=
-mul_lt_of_lt_one_of_le h le_rfl b0
-
-lemma lt_mul_of_one_lt_left [mul_pos_strict_mono α] (b0 : 0 < b) (h : 1 < a) :
-  b < a * b :=
-lt_mul_of_one_lt_of_le h le_rfl b0
-
--- proven with `a0 : 0 ≤ a` as `le_of_mul_le_of_one_le_left`
-lemma preorder.le_of_mul_le_of_one_le_left [pos_mul_mono α]
-  (h : a * b ≤ c) (hle : 1 ≤ b) (a0 : 0 < a) :
-  a ≤ c :=
-(preorder.le_mul_of_one_le_right hle a0).trans h
-
-lemma lt_of_mul_lt_of_one_le_left [pos_mul_mono α]
-  (h : a * b < c) (hle : 1 ≤ b) (a0 : 0 < a) :
+lemma lt_of_mul_lt_of_one_le_of_nonneg_left [pos_mul_mono α] (h : a * b < c) (hle : 1 ≤ b)
+  (ha : 0 ≤ a) :
   a < c :=
-(preorder.le_mul_of_one_le_right hle a0).trans_lt h
+(le_mul_of_one_le_right ha hle).trans_lt h
 
--- proven with `b0 : 0 ≤ b` as `le_of_le_mul_of_le_one_left`
-lemma preorder.le_of_le_mul_of_le_one_left [pos_mul_mono α]
-  (h : a ≤ b * c) (hle : c ≤ 1) (b0 : 0 < b) :
-  a ≤ b :=
-h.trans (preorder.mul_le_of_le_one_right hle b0)
-
-lemma lt_of_lt_mul_of_le_one_left [pos_mul_mono α]
-  (h : a < b * c) (hle : c ≤ 1) (b0 : 0 < b) :
+lemma lt_of_lt_mul_of_le_one_of_nonneg_left [pos_mul_mono α] (h : a < b * c) (hc : c ≤ 1)
+  (hb : 0 ≤ b) :
   a < b :=
-h.trans_le (preorder.mul_le_of_le_one_right hle b0)
+h.trans_le $ mul_le_of_le_one_right hb hc
 
--- proven with `b0 : 0 ≤ b` as `le_of_mul_le_of_one_le_right`
-lemma preorder.le_of_mul_le_of_one_le_right [mul_pos_mono α]
-  (h : a * b ≤ c) (hle : 1 ≤ a) (b0 : 0 < b) :
-  b ≤ c :=
-(preorder.le_mul_of_one_le_left hle b0).trans h
-
-lemma lt_of_mul_lt_of_one_le_right [mul_pos_mono α]
-  (h : a * b < c) (hle : 1 ≤ a) (b0 : 0 < b) :
-  b < c :=
-(preorder.le_mul_of_one_le_left hle b0).trans_lt h
-
--- proven with `c0 : 0 ≤ b` as `le_of_le_mul_of_le_one_right`
-lemma preorder.le_of_le_mul_of_le_one_right [mul_pos_mono α]
-  (h : a ≤ b * c) (hle : b ≤ 1) (c0 : 0 < c) :
-  a ≤ c :=
-h.trans (preorder.mul_le_of_le_one_left hle c0)
-
-lemma lt_of_lt_mul_of_le_one_right [mul_pos_mono α]
-  (h : a < b * c) (hle : b ≤ 1) (c0 : 0 < c) :
+lemma lt_of_lt_mul_of_le_one_of_nonneg_right [mul_pos_mono α] (h : a < b * c) (hb : b ≤ 1)
+  (hc : 0 ≤ c) :
   a < c :=
-h.trans_le (preorder.mul_le_of_le_one_left hle c0)
+h.trans_le $ mul_le_of_le_one_left hc hb
+
+lemma le_mul_of_one_le_of_le_of_nonneg [mul_pos_mono α] (ha : 1 ≤ a) (bc : b ≤ c) (c0 : 0 ≤ c) :
+  b ≤ a * c :=
+bc.trans $ le_mul_of_one_le_left c0 ha
+
+/-- Assumes right covariance. -/
+lemma right.one_le_mul_of_le_of_le [mul_pos_mono α] (ha : 1 ≤ a) (hb : 1 ≤ b) (b0 : 0 ≤ b) :
+  1 ≤ a * b :=
+le_mul_of_one_le_of_le_of_nonneg ha hb b0
+
+lemma le_of_mul_le_of_one_le_of_nonneg_left [pos_mul_mono α] (h : a * b ≤ c) (hb : 1 ≤ b)
+  (ha : 0 ≤ a) :
+  a ≤ c :=
+(le_mul_of_one_le_right ha hb).trans h
+
+lemma le_of_le_mul_of_le_one_of_nonneg_left [pos_mul_mono α] (h : a ≤ b * c) (hc : c ≤ 1)
+  (hb : 0 ≤ b) :
+  a ≤ b :=
+h.trans $ mul_le_of_le_one_right hb hc
+
+lemma le_of_mul_le_of_one_le_nonneg_right [mul_pos_mono α] (h : a * b ≤ c) (ha : 1 ≤ a)
+  (hb : 0 ≤ b) :
+  b ≤ c :=
+(le_mul_of_one_le_left hb ha).trans h
+
+lemma le_of_le_mul_of_le_one_of_nonneg_right [mul_pos_mono α] (h : a ≤ b * c) (hb : b ≤ 1)
+  (hc : 0 ≤ c) :
+  a ≤ c :=
+h.trans $ mul_le_of_le_one_left hc hb
 
 end preorder
 
 section linear_order
 variables [linear_order α]
 
+-- Yaël: What's the point of this lemma? If we have `0 * 0 = 0`, then we can just take `b = 0`.
 -- proven with `a0 : 0 ≤ a` as `exists_square_le`
-lemma exists_square_le' [pos_mul_strict_mono α]
-  (a0 : 0 < a) : ∃ (b : α), b * b ≤ a :=
+lemma exists_square_le' [pos_mul_strict_mono α] (a0 : 0 < a) : ∃ (b : α), b * b ≤ a :=
 begin
-  by_cases h : a < 1,
-  { use a,
-    have : a*a < a*1,
-    exact mul_lt_mul_left' h a0,
-    rw mul_one at this,
-    exact le_of_lt this },
-  { use 1,
-    push_neg at h,
-    rwa mul_one }
+  obtain ha | ha := lt_or_le a 1,
+  { exact ⟨a, (mul_lt_of_lt_one_right a0 ha).le⟩ },
+  { exact ⟨1, by rwa mul_one⟩ }
 end
 
 end linear_order
-
 end mul_one_class
-
-section mul_zero_one_class
-variables [mul_zero_one_class α]
-
-section partial_order
-variables [partial_order α]
-
-/-! Lemmas of the form `b ≤ c → a ≤ 1 → b * a ≤ c`. -/
-
-lemma mul_le_of_le_of_le_one [pos_mul_mono α]
-  (bc : b ≤ c) (ha : a ≤ 1) (b0 : 0 ≤ b) : b * a ≤ c :=
-b0.lt_or_eq.elim (preorder.mul_le_of_le_of_le_one bc ha)
-  (λ h, by rw [← h, zero_mul]; exact b0.trans bc)
-
-/-- Assumes left covariance. -/
-lemma left.mul_le_one_of_le_of_le [pos_mul_mono α]
-  (ha : a ≤ 1) (hb : b ≤ 1) (a0 : 0 ≤ a) : a * b ≤ 1 :=
-mul_le_of_le_of_le_one ha hb a0
-
-lemma mul_nonneg_le_one_le [pos_mul_mono α] [mul_pos_mono α]
-  (c0 : 0 ≤ c) (bc : b ≤ c) (a0 : 0 ≤ a) (ha : a ≤ 1) : b * a ≤ c :=
-calc  b * a ≤ c * a : mul_le_mul_of_nonneg_right bc a0
-        ... ≤ c * 1 : mul_le_mul_of_nonneg_left ha c0
-        ... = c     : mul_one c
-
-lemma mul_lt_of_lt_of_le_one' [pos_mul_mono α] [mul_pos_strict_mono α]
-  (bc : b < c) (ha : a ≤ 1) (a0 : 0 < a) (c0 : 0 ≤ c) : b * a < c :=
-calc  b * a < c * a : mul_lt_mul_right' bc a0
-        ... ≤ c * 1 : mul_le_mul_of_nonneg_left ha c0
-        ... = c     : mul_one c
-
-lemma mul_lt_of_le_of_lt_one' [pos_mul_strict_mono α] [mul_pos_mono α]
-  (bc : b ≤ c) (ha : a < 1) (a0 : 0 ≤ a) (c0 : 0 < c) : b * a < c :=
-calc  b * a ≤ c * a : mul_le_mul_of_nonneg_right bc a0
-        ... < c * 1 : mul_lt_mul_left' ha c0
-        ... = c     : mul_one c
-
-/-! Lemmas of the form `b ≤ c → 1 ≤ a → b ≤ c * a`. -/
-
-lemma le_mul_of_le_of_one_le [pos_mul_mono α]
-  (bc : b ≤ c) (ha : 1 ≤ a) (c0 : 0 ≤ c) : b ≤ c * a :=
-c0.lt_or_eq.elim (preorder.le_mul_of_le_of_one_le bc ha)
-  (λ h, by rw [← h, zero_mul] at *; exact bc)
-
-/-- Assumes left covariance. -/
-lemma left.one_le_mul_of_le_of_le [pos_mul_mono α]
-  (ha : 1 ≤ a) (hb : 1 ≤ b) (a0 : 0 ≤ a) : 1 ≤ a * b :=
-le_mul_of_le_of_one_le ha hb a0
-
-lemma le_mul_of_le_of_one_le' [pos_mul_mono α] [mul_pos_mono α]
-  (bc : b ≤ c) (ha : 1 ≤ a) (a0 : 0 ≤ a) (b0 : 0 ≤ b) : b ≤ c * a :=
-calc  b = b * 1 : (mul_one b).symm
-    ... ≤ b * a : mul_le_mul_of_nonneg_left ha b0
-    ... ≤ c * a : mul_le_mul_of_nonneg_right bc a0
-
-lemma lt_mul_of_le_of_one_lt' [pos_mul_strict_mono α] [mul_pos_mono α]
-  (bc : b ≤ c) (ha : 1 < a) (a0 : 0 ≤ a) (b0 : 0 < b) : b < c * a :=
-calc  b = b * 1 : (mul_one b).symm
-    ... < b * a : mul_lt_mul_left' ha b0
-    ... ≤ c * a : mul_le_mul_of_nonneg_right bc a0
-
-lemma lt_mul_of_lt_of_one_le' [pos_mul_mono α] [mul_pos_strict_mono α]
-  (bc : b < c) (ha : 1 ≤ a) (a0 : 0 < a) (b0 : 0 ≤ b) : b < c * a :=
-calc  b = b * 1 : (mul_one b).symm
-    ... ≤ b * a : mul_le_mul_of_nonneg_left ha b0
-    ... < c * a : mul_lt_mul_right' bc a0
-
-/-! Lemmas of the form `a ≤ 1 → b ≤ c → a * b ≤ c`. -/
-
-lemma mul_le_of_le_one_of_le [mul_pos_mono α]
-  (ha : a ≤ 1) (bc : b ≤ c) (b0 : 0 ≤ b) : a * b ≤ c :=
-b0.lt_or_eq.elim (preorder.mul_le_of_le_one_of_le ha bc)
-  (λ h, by rw [← h, mul_zero] at *; exact bc)
-
-/-- Assumes right covariance. -/
-lemma right.mul_le_one_of_le_of_le [mul_pos_mono α]
-  (ha : a ≤ 1) (hb : b ≤ 1) (b0 : 0 < b) : a * b ≤ 1 :=
-preorder.mul_le_of_le_one_of_le ha hb b0
-
-lemma mul_le_of_le_one_of_le' [pos_mul_mono α] [mul_pos_mono α]
-  (ha : a ≤ 1) (bc : b ≤ c) (a0 : 0 ≤ a) (c0 : 0 ≤ c) : a * b ≤ c :=
-calc  a * b ≤ a * c : mul_le_mul_of_nonneg_left bc a0
-        ... ≤ 1 * c : mul_le_mul_of_nonneg_right ha c0
-        ... = c     : one_mul c
-
-lemma mul_lt_of_lt_one_of_le' [pos_mul_mono α] [mul_pos_strict_mono α]
-  (ha : a < 1) (bc : b ≤ c) (a0 : 0 ≤ a) (c0 : 0 < c) : a * b < c :=
-calc  a * b ≤ a * c : mul_le_mul_of_nonneg_left bc a0
-        ... < 1 * c : mul_lt_mul_right' ha c0
-        ... = c     : one_mul c
-
-lemma mul_lt_of_le_one_of_lt' [pos_mul_strict_mono α] [mul_pos_mono α]
-  (ha : a ≤ 1) (bc : b < c) (a0 : 0 < a) (c0 : 0 ≤ c) : a * b < c :=
-calc  a * b < a * c : mul_lt_mul_left' bc a0
-        ... ≤ 1 * c : mul_le_mul_of_nonneg_right ha c0
-        ... = c     : one_mul c
-
-/-! Lemmas of the form `1 ≤ a → b ≤ c → b ≤ a * c`. -/
-
-lemma le_mul_of_one_le_of_le [mul_pos_mono α]
-  (ha : 1 ≤ a) (bc : b ≤ c) (c0 : 0 ≤ c) : b ≤ a * c :=
-c0.lt_or_eq.elim (preorder.le_mul_of_one_le_of_le ha bc)
-  (λ h, by rw [← h, mul_zero] at *; exact bc)
-
-/-- Assumes right covariance. -/
-lemma right.one_le_mul_of_le_of_le [mul_pos_mono α]
-  (ha : 1 ≤ a) (hb : 1 ≤ b) (b0 : 0 ≤ b) : 1 ≤ a * b :=
-le_mul_of_one_le_of_le ha hb b0
-
-lemma le_mul_of_one_le_of_le' [pos_mul_mono α] [mul_pos_mono α]
-  (ha : 1 ≤ a) (bc : b ≤ c) (a0 : 0 ≤ a) (b0 : 0 ≤ b) : b ≤ a * c :=
-calc  b = 1 * b : (one_mul b).symm
-    ... ≤ a * b : mul_le_mul_of_nonneg_right ha b0
-    ... ≤ a * c : mul_le_mul_of_nonneg_left bc a0
-
-lemma lt_mul_of_one_lt_of_le' [pos_mul_mono α] [mul_pos_strict_mono α]
-  (ha : 1 < a) (bc : b ≤ c) (a0 : 0 ≤ a) (b0 : 0 < b) : b < a * c :=
-calc  b = 1 * b : (one_mul b).symm
-    ... < a * b : mul_lt_mul_right' ha b0
-    ... ≤ a * c : mul_le_mul_of_nonneg_left bc a0
-
-lemma lt_mul_of_one_le_of_lt' [pos_mul_strict_mono α] [mul_pos_mono α]
-  (ha : 1 ≤ a) (bc : b < c) (a0 : 0 < a) (b0 : 0 ≤ b) : b < a * c :=
-calc  b = 1 * b : (one_mul b).symm
-    ... ≤ a * b : mul_le_mul_of_nonneg_right ha b0
-    ... < a * c : mul_lt_mul_left' bc a0
-
-lemma mul_le_of_le_one_right [pos_mul_mono α] (a0 : 0 ≤ a) (h : b ≤ 1) :
-  a * b ≤ a :=
-mul_le_of_le_of_le_one le_rfl h a0
-
-lemma le_mul_of_one_le_right [pos_mul_mono α] (a0 : 0 ≤ a) (h : 1 ≤ b) :
-  a ≤ a * b :=
-le_mul_of_le_of_one_le le_rfl h a0
-
-lemma mul_le_of_le_one_left [mul_pos_mono α] (b0 : 0 ≤ b) (h : a ≤ 1) :
-  a * b ≤ b :=
-mul_le_of_le_one_of_le h le_rfl b0
-
-lemma le_mul_of_one_le_left [mul_pos_mono α] (b0 : 0 ≤ b) (h : 1 ≤ a) :
-  b ≤ a * b :=
-le_mul_of_one_le_of_le h le_rfl b0
-
-lemma le_of_mul_le_of_one_le_of_nonneg_left [pos_mul_mono α]
-  (h : a * b ≤ c) (hle : 1 ≤ b) (a0 : 0 ≤ a) :
-  a ≤ c :=
-a0.lt_or_eq.elim (preorder.le_of_mul_le_of_one_le_left h hle)
-  (λ ha, by simpa only [← ha, zero_mul] using h)
-
-lemma le_of_le_mul_of_le_one_of_nonneg_left [pos_mul_mono α]
-  (h : a ≤ b * c) (hle : c ≤ 1) (b0 : 0 ≤ b) :
-  a ≤ b :=
-b0.lt_or_eq.elim (preorder.le_of_le_mul_of_le_one_left h hle)
-  (λ hb, by simpa only [← hb, zero_mul] using h)
-
-lemma le_of_mul_le_of_one_le_nonneg_right [mul_pos_mono α]
-  (h : a * b ≤ c) (hle : 1 ≤ a) (b0 : 0 ≤ b) :
-  b ≤ c :=
-b0.lt_or_eq.elim (preorder.le_of_mul_le_of_one_le_right h hle)
-  (λ ha, by simpa only [← ha, mul_zero] using h)
-
-lemma le_of_le_mul_of_le_one_right [mul_pos_mono α]
-  (h : a ≤ b * c) (hle : b ≤ 1) (c0 : 0 ≤ c) :
-  a ≤ c :=
-c0.lt_or_eq.elim (preorder.le_of_le_mul_of_le_one_right h hle)
-  (λ ha, by simpa only [← ha, mul_zero] using h)
-
-end partial_order
-
-section linear_order
-variables [linear_order α]
-
-lemma exists_square_le [pos_mul_strict_mono α]
-  (a0 : 0 ≤ a) : ∃ (b : α), b * b ≤ a :=
-a0.lt_or_eq.elim exists_square_le' (λ h, by rw [← h]; exact ⟨0, by simp⟩)
-
-end linear_order
-
-end mul_zero_one_class
 
 section cancel_monoid_with_zero
 
@@ -1250,41 +813,37 @@ section partial_order
 variables [partial_order α]
 
 lemma pos_mul_mono.to_pos_mul_strict_mono [pos_mul_mono α] : pos_mul_strict_mono α :=
-⟨λ x a b h, (mul_le_mul_left_of_le_of_pos h.le x.2).lt_of_ne (h.ne ∘ mul_left_cancel₀ x.2.ne')⟩
+⟨λ x a b h, (mul_le_mul_of_nonneg_left h.le x.2.le).lt_of_ne (h.ne ∘ mul_left_cancel₀ x.2.ne')⟩
 
 lemma pos_mul_mono_iff_pos_mul_strict_mono : pos_mul_mono α ↔ pos_mul_strict_mono α :=
-⟨@pos_mul_mono.to_pos_mul_strict_mono α _ _, @zero_lt.pos_mul_strict_mono.to_pos_mul_mono α _ _ _⟩
+⟨@pos_mul_mono.to_pos_mul_strict_mono α _ _, @pos_mul_strict_mono.to_pos_mul_mono α _ _⟩
 
 lemma mul_pos_mono.to_mul_pos_strict_mono [mul_pos_mono α] : mul_pos_strict_mono α :=
-⟨λ x a b h, (mul_le_mul_right_of_le_of_pos h.le x.2).lt_of_ne (h.ne ∘ mul_right_cancel₀ x.2.ne')⟩
+⟨λ x a b h, (mul_le_mul_of_nonneg_right h.le x.2.le).lt_of_ne (h.ne ∘ mul_right_cancel₀ x.2.ne')⟩
 
 lemma mul_pos_mono_iff_mul_pos_strict_mono : mul_pos_mono α ↔ mul_pos_strict_mono α :=
-⟨@mul_pos_mono.to_mul_pos_strict_mono α _ _, @zero_lt.mul_pos_strict_mono.to_mul_pos_mono α _ _ _⟩
+⟨@mul_pos_mono.to_mul_pos_strict_mono α _ _, @mul_pos_strict_mono.to_mul_pos_mono α _ _⟩
 
 lemma pos_mul_reflect_lt.to_pos_mul_mono_rev [pos_mul_reflect_lt α] : pos_mul_mono_rev α :=
 ⟨λ x a b h, h.eq_or_lt.elim (le_of_eq ∘ mul_left_cancel₀ x.2.ne.symm)
-                            (λ h', (lt_of_mul_lt_mul_left' h' x.2).le)⟩
+                            (λ h', (lt_of_mul_lt_mul_left h' x.2.le).le)⟩
 
 lemma pos_mul_mono_rev_iff_pos_mul_reflect_lt : pos_mul_mono_rev α ↔ pos_mul_reflect_lt α :=
-⟨@zero_lt.pos_mul_mono_rev.to_pos_mul_reflect_lt α _ _ _,
- @pos_mul_reflect_lt.to_pos_mul_mono_rev α _ _⟩
+⟨@pos_mul_mono_rev.to_pos_mul_reflect_lt α _ _, @pos_mul_reflect_lt.to_pos_mul_mono_rev α _ _⟩
 
 lemma mul_pos_reflect_lt.to_mul_pos_mono_rev [mul_pos_reflect_lt α] : mul_pos_mono_rev α :=
 ⟨λ x a b h, h.eq_or_lt.elim (le_of_eq ∘ mul_right_cancel₀ x.2.ne.symm)
-                            (λ h', (lt_of_mul_lt_mul_right' h' x.2).le)⟩
+                            (λ h', (lt_of_mul_lt_mul_right h' x.2.le).le)⟩
 
 lemma mul_pos_mono_rev_iff_mul_pos_reflect_lt : mul_pos_mono_rev α ↔ mul_pos_reflect_lt α :=
-⟨@zero_lt.mul_pos_mono_rev.to_mul_pos_reflect_lt α _ _ _,
- @mul_pos_reflect_lt.to_mul_pos_mono_rev α _ _⟩
+⟨@mul_pos_mono_rev.to_mul_pos_reflect_lt α _ _, @mul_pos_reflect_lt.to_mul_pos_mono_rev α _ _⟩
 
 end partial_order
 
 end cancel_monoid_with_zero
 
 section comm_semigroup_has_zero
-variables [comm_semigroup α] [has_zero α]
-
-variables [has_lt α]
+variables [comm_semigroup α] [has_zero α] [preorder α]
 
 lemma pos_mul_strict_mono_iff_mul_pos_strict_mono :
   pos_mul_strict_mono α ↔ mul_pos_strict_mono α :=
@@ -1293,8 +852,6 @@ by simp ! only [mul_comm]
 lemma pos_mul_reflect_lt_iff_mul_pos_reflect_lt :
   pos_mul_reflect_lt α ↔ mul_pos_reflect_lt α :=
 by simp ! only [mul_comm]
-
-variables [has_le α]
 
 lemma pos_mul_mono_iff_mul_pos_mono :
   pos_mul_mono α ↔ mul_pos_mono α :=
@@ -1305,7 +862,3 @@ lemma pos_mul_mono_rev_iff_mul_pos_mono_rev :
 by simp ! only [mul_comm]
 
 end comm_semigroup_has_zero
-
-end zero_lt
-
-export zero_lt

--- a/src/algebra/order/ring.lean
+++ b/src/algebra/order/ring.lean
@@ -113,23 +113,17 @@ class ordered_semiring (α : Type u) extends semiring α, ordered_cancel_add_com
 section ordered_semiring
 variables [ordered_semiring α] {a b c d : α}
 
-lemma mul_lt_mul_of_pos_left (h₁ : a < b) (h₂ : 0 < c) : c * a < c * b :=
-ordered_semiring.mul_lt_mul_of_pos_left a b c h₁ h₂
+@[priority 200] -- see Note [lower instance priority]
+instance ordered_semiring.pos_mul_strict_mono : pos_mul_strict_mono α :=
+⟨λ x a b h, ordered_semiring.mul_lt_mul_of_pos_left _ _ _ h x.prop⟩
 
-lemma mul_lt_mul_of_pos_right (h₁ : a < b) (h₂ : 0 < c) : a * c < b * c :=
-ordered_semiring.mul_lt_mul_of_pos_right a b c h₁ h₂
+@[priority 200] -- see Note [lower instance priority]
+instance ordered_semiring.mul_pos_strict_mono : mul_pos_strict_mono α :=
+⟨λ x a b h, ordered_semiring.mul_lt_mul_of_pos_right _ _ _ h x.prop⟩
 
 @[priority 100] -- see Note [lower instance priority]
 instance ordered_semiring.zero_le_one_class : zero_le_one_class α :=
 { ..‹ordered_semiring α› }
-
-@[priority 200] -- see Note [lower instance priority]
-instance ordered_semiring.pos_mul_strict_mono : zero_lt.pos_mul_strict_mono α :=
-⟨λ x a b h, mul_lt_mul_of_pos_left h x.prop⟩
-
-@[priority 200] -- see Note [lower instance priority]
-instance ordered_semiring.mul_pos_strict_mono : zero_lt.mul_pos_strict_mono α :=
-⟨λ x a b h, mul_lt_mul_of_pos_right h x.prop⟩
 
 section nontrivial
 
@@ -623,12 +617,6 @@ local attribute [instance] linear_ordered_semiring.decidable_le
 -- with only a `linear_ordered_semiring` typeclass argument.
 lemma zero_lt_one' : 0 < (1 : α) := zero_lt_one
 
-lemma le_of_mul_le_mul_left (h : c * a ≤ c * b) (hc : 0 < c) : a ≤ b :=
-(strict_mono_mul_left_of_pos hc).le_iff_le.1 h
-
-lemma le_of_mul_le_mul_right (h : a * c ≤ b * c) (hc : 0 < c) : a ≤ b :=
-(strict_mono_mul_right_of_pos hc).le_iff_le.1 h
-
 lemma nonneg_and_nonneg_or_nonpos_and_nonpos_of_mul_nnonneg (hab : 0 ≤ a * b) :
     (0 ≤ a ∧ 0 ≤ b) ∨ (a ≤ 0 ∧ b ≤ 0) :=
 begin
@@ -1024,14 +1012,7 @@ local attribute [instance] linear_ordered_ring.decidable_le linear_ordered_ring.
 
 @[priority 100] -- see Note [lower instance priority]
 instance linear_ordered_ring.to_linear_ordered_semiring : linear_ordered_semiring α :=
-{ mul_zero                   := mul_zero,
-  zero_mul                   := zero_mul,
-  add_left_cancel            := @add_left_cancel α _,
-  le_of_add_le_add_left      := @le_of_add_le_add_left α _ _ _,
-  mul_lt_mul_of_pos_left     := @mul_lt_mul_of_pos_left α _,
-  mul_lt_mul_of_pos_right    := @mul_lt_mul_of_pos_right α _,
-  le_total                   := linear_ordered_ring.le_total,
-  ..‹linear_ordered_ring α› }
+{ ..‹linear_ordered_ring α›, ..ordered_ring.to_ordered_semiring }
 
 @[priority 100] -- see Note [lower instance priority]
 instance linear_ordered_ring.is_domain : is_domain α :=
@@ -1420,13 +1401,11 @@ begin
 end
 
 @[priority 200] -- see Note [lower instance priority]
-instance canonically_ordered_comm_semiring.pos_mul_mono :
-  zero_lt.pos_mul_mono α :=
+instance canonically_ordered_comm_semiring.to_pos_mul_mono : pos_mul_mono α :=
 ⟨λ x a b h, by { obtain ⟨d, rfl⟩ := exists_add_of_le h, simp_rw [left_distrib, le_self_add], }⟩
 
 @[priority 200] -- see Note [lower instance priority]
-instance canonically_ordered_comm_semiring.mul_pos_mono :
-  zero_lt.mul_pos_mono α :=
+instance canonically_ordered_comm_semiring.to_mul_pos_mono : mul_pos_mono α :=
 ⟨λ x a b h, by { obtain ⟨d, rfl⟩ := exists_add_of_le h, simp_rw [right_distrib, le_self_add], }⟩
 
 /-- A version of `zero_lt_one : 0 < 1` for a `canonically_ordered_comm_semiring`. -/
@@ -1716,20 +1695,17 @@ with_top.comm_monoid_with_zero
 instance [canonically_ordered_comm_semiring α] [nontrivial α] : comm_semiring (with_bot α) :=
 with_top.comm_semiring
 
-instance [canonically_ordered_comm_semiring α] [nontrivial α] :
-  zero_lt.pos_mul_mono (with_bot α) :=
-⟨ begin
+instance [canonically_ordered_comm_semiring α] [nontrivial α] : pos_mul_mono (with_bot α) :=
+pos_mul_mono_iff_covariant_pos.2 ⟨begin
     rintros ⟨x, x0⟩ a b h, simp only [subtype.coe_mk],
-    induction x using with_bot.rec_bot_coe,
-    { have := bot_lt_coe (0 : α), rw [coe_zero] at this, exact absurd x0.le this.not_le, },
-    { induction a using with_bot.rec_bot_coe, { simp_rw [mul_bot x0.ne.symm, bot_le], },
-      induction b using with_bot.rec_bot_coe, { exact absurd h (bot_lt_coe a).not_le, },
-      { simp only [← coe_mul, coe_le_coe] at *,
-        exact mul_le_mul_left' h x, }, },
+    lift x to α using x0.ne_bot,
+    induction a using with_bot.rec_bot_coe, { simp_rw [mul_bot x0.ne.symm, bot_le] },
+    induction b using with_bot.rec_bot_coe, { exact absurd h (bot_lt_coe a).not_le },
+    simp only [← coe_mul, coe_le_coe] at *,
+    exact mul_le_mul_left' h x,
   end ⟩
 
-instance [canonically_ordered_comm_semiring α] [nontrivial α] :
-  zero_lt.mul_pos_mono (with_bot α) :=
-zero_lt.pos_mul_mono_iff_mul_pos_mono.mp zero_lt.pos_mul_mono
+instance [canonically_ordered_comm_semiring α] [nontrivial α] : mul_pos_mono (with_bot α) :=
+pos_mul_mono_iff_mul_pos_mono.mp infer_instance
 
 end with_bot

--- a/src/analysis/normed_space/basic.lean
+++ b/src/analysis/normed_space/basic.lean
@@ -173,7 +173,7 @@ begin
     obtain ⟨k, rfl⟩ := add_subgroup.mem_zmultiples_iff.mp hx,
     rw [mem_preimage, mem_ball_zero_iff, add_subgroup.coe_mk, mem_singleton_iff,
       subtype.ext_iff, add_subgroup.coe_mk, add_subgroup.coe_zero, norm_zsmul ℚ k e,
-      int.norm_cast_rat, int.norm_eq_abs, ← int.cast_abs, zero_lt.mul_lt_iff_lt_one_left
+      int.norm_cast_rat, int.norm_eq_abs, ← int.cast_abs, mul_lt_iff_lt_one_left
       (norm_pos_iff.mpr he), ← @int.cast_one ℝ _, int.cast_lt, int.abs_lt_one_iff, smul_eq_zero,
       or_iff_left he], },
 end

--- a/src/analysis/special_functions/bernstein.lean
+++ b/src/analysis/special_functions/bernstein.lean
@@ -299,11 +299,7 @@ begin
         ... = (2 * ∥f∥) * δ^(-2 : ℤ) * x * (1-x) / n
                                   : by { rw variance npos, ring, }
         ... ≤ (2 * ∥f∥) * δ^(-2 : ℤ) / n
-                                  : (div_le_div_right npos).mpr
-                                    begin
-                                      apply mul_nonneg_le_one_le w₂,
-                                      apply mul_nonneg_le_one_le w₂ le_rfl,
-                                      all_goals { unit_interval, },
-                                    end
+                                  : (div_le_div_right npos).mpr $
+              by refine mul_le_of_le_of_le_one' (mul_le_of_le_one_right w₂ _) _ _ w₂; unit_interval
         ... < ε/2 : nh, }
 end

--- a/src/measure_theory/integral/set_to_l1.lean
+++ b/src/measure_theory/integral/set_to_l1.lean
@@ -599,15 +599,9 @@ lemma norm_set_to_simple_func_le_sum_mul_norm (T : set α → F →L[ℝ] F') {C
   ∥f.set_to_simple_func T∥ ≤ C * ∑ x in f.range, (μ (f ⁻¹' {x})).to_real * ∥x∥ :=
 calc ∥f.set_to_simple_func T∥
     ≤ ∑ x in f.range, ∥T (f ⁻¹' {x})∥ * ∥x∥ : norm_set_to_simple_func_le_sum_op_norm T f
-... ≤ ∑ x in f.range, C * (μ (f ⁻¹' {x})).to_real * ∥x∥ :
-  begin
-    refine finset.sum_le_sum (λ b hb, _),
-    by_cases hb : ∥b∥ = 0,
-    { rw hb, simp, },
-    refine (zero_lt.mul_le_mul_right _).mpr _, swap, -- remove swap or inline the second subcase
-    { exact hT_norm _ (simple_func.measurable_set_fiber _ _), },
-    { exact lt_of_le_of_ne (norm_nonneg _) (ne.symm hb), },
-  end
+... ≤ ∑ x in f.range, C * (μ (f ⁻¹' {x})).to_real * ∥x∥
+    : sum_le_sum $ λ b hb, mul_le_mul_of_nonneg_right
+        (hT_norm _ $ simple_func.measurable_set_fiber _ _) $ norm_nonneg _
 ... ≤ C * ∑ x in f.range, (μ (f ⁻¹' {x})).to_real * ∥x∥ : by simp_rw [mul_sum, ← mul_assoc]
 
 lemma norm_set_to_simple_func_le_sum_mul_norm_of_integrable (T : set α → E →L[ℝ] F') {C : ℝ}
@@ -619,13 +613,10 @@ calc ∥f.set_to_simple_func T∥
 ... ≤ ∑ x in f.range, C * (μ (f ⁻¹' {x})).to_real * ∥x∥ :
   begin
     refine finset.sum_le_sum (λ b hb, _),
-    by_cases hb : ∥b∥ = 0,
-    { rw hb, simp, },
-    refine (zero_lt.mul_le_mul_right _).mpr _, swap, -- remove swap or inline the second subcase
-    { refine hT_norm _ (simple_func.measurable_set_fiber _ _)
-        (simple_func.measure_preimage_lt_top_of_integrable _ hf _),
-      rwa norm_eq_zero at hb, },
-    { exact lt_of_le_of_ne (norm_nonneg _) (ne.symm hb), },
+    obtain rfl | hb := eq_or_ne b 0,
+    { simp },
+    exact mul_le_mul_of_nonneg_right (hT_norm _ (simple_func.measurable_set_fiber _ _) $
+      simple_func.measure_preimage_lt_top_of_integrable _ hf hb) (norm_nonneg _),
   end
 ... ≤ C * ∑ x in f.range, (μ (f ⁻¹' {x})).to_real * ∥x∥ : by simp_rw [mul_sum, ← mul_assoc]
 


### PR DESCRIPTION
`pos_mul_mono`/`mul_pos_mono` and `pos_mul_reflect_lt`/`mul_pos_reflect_lt` were stated as covariance/contravariance of `{x : α // 0 < α}` over `α` even though the extension to `{x : α // 0 ≤ α}` also holds.

This meant that many lemmas were relying on antisymmetry only to treat the cases `a = 0` and `0 < a` separately, which made them need `partial_order` and depend on `classical.choice`. This prevented #16172 from actually removing the `decidable` lemma in `algebra.order.ring` after #16189 got merged.

Further, #16189 did not actually get rid of the temporary `zero_lt` namespace, so name conflicts that arise were not fixed.

Finally, `le_mul_of_one_le_left` and its seven friends were reproved inline about five time each.

Hence in this PR we
* restate `pos_mul_mono`, `mul_pos_mono`, `pos_mul_reflect_lt`, `mul_pos_reflect_lt` using `{x : α // 0 ≤ α}`
* provide the (classical) equivalence with the previous definitions in a `partial_order`.
* generalise lemmas from `partial_order` to `preorder`.
* delete all lemmas in the `preorder` namespace as they are now fully generalized. This in essence reverts (parts of) #12961, #13296 and #13299.
* replace most of the various `has_le`/`has_lt` assumptions by a blank `preorder` one, hence simplifying the file sectioning
* remove the `zero_lt` namespace.
* rename lemmas to fix name conflicts.
* delete a few lemmas that were left in `algebra.order.ring`.
* golf proofs involving `le_mul_of_one_le_left` and its seven friends. This is why the PR has a -450 lines diff.

---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message 
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
